### PR TITLE
debug: allow filter/search on debug values

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/baseDebugView.ts
+++ b/src/vs/workbench/contrib/debug/browser/baseDebugView.ts
@@ -9,19 +9,21 @@ import { ActionBar } from '../../../../base/browser/ui/actionbar/actionbar.js';
 import { HighlightedLabel, IHighlight } from '../../../../base/browser/ui/highlightedlabel/highlightedLabel.js';
 import { getDefaultHoverDelegate } from '../../../../base/browser/ui/hover/hoverDelegateFactory.js';
 import { IInputValidationOptions, InputBox } from '../../../../base/browser/ui/inputbox/inputBox.js';
+import { IKeyboardNavigationLabelProvider } from '../../../../base/browser/ui/list/list.js';
 import { IAsyncDataSource, ITreeNode, ITreeRenderer } from '../../../../base/browser/ui/tree/tree.js';
 import { Codicon } from '../../../../base/common/codicons.js';
 import { FuzzyScore, createMatches } from '../../../../base/common/filters.js';
 import { createSingleCallFunction } from '../../../../base/common/functional.js';
 import { KeyCode } from '../../../../base/common/keyCodes.js';
 import { DisposableStore, IDisposable, dispose, toDisposable } from '../../../../base/common/lifecycle.js';
+import { removeAnsiEscapeCodes } from '../../../../base/common/strings.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
 import { localize } from '../../../../nls.js';
 import { ICommandService } from '../../../../platform/commands/common/commands.js';
 import { IContextViewService } from '../../../../platform/contextview/browser/contextView.js';
 import { IHoverService } from '../../../../platform/hover/browser/hover.js';
 import { defaultInputBoxStyles } from '../../../../platform/theme/browser/defaultStyles.js';
-import { IDebugService, IExpression } from '../common/debug.js';
+import { IDebugService, IExpression, IScope } from '../common/debug.js';
 import { Variable } from '../common/debugModel.js';
 import { IDebugVisualizerService } from '../common/debugVisualizers.js';
 import { LinkDetector } from './linkDetector.js';
@@ -77,6 +79,32 @@ export interface IExpressionTemplateData {
 	lazyButton: HTMLElement;
 	currentElement: IExpression | undefined;
 }
+
+/** Splits highlights based on matching of the {@link expressionAndScopeLabelProvider} */
+export const splitExpressionOrScopeHighlights = (e: IExpression | IScope, highlights: IHighlight[]) => {
+	const nameEndsAt = e.name.length;
+	const labelBeginsAt = e.name.length + 2;
+	const name: IHighlight[] = [];
+	const value: IHighlight[] = [];
+	for (const hl of highlights) {
+		if (hl.start < nameEndsAt) {
+			name.push({ start: hl.start, end: Math.min(hl.end, nameEndsAt) });
+		}
+		if (hl.end > labelBeginsAt) {
+			value.push({ start: Math.max(hl.start - labelBeginsAt, 0), end: hl.end - labelBeginsAt });
+		}
+	}
+
+	return { name, value };
+};
+
+/** Keyboard label provider for expression and scope tree elements. */
+export const expressionAndScopeLabelProvider: IKeyboardNavigationLabelProvider<IExpression | IScope> = {
+	getKeyboardNavigationLabel(e) {
+		const stripAnsi = e.getSession()?.rememberedCapabilities?.supportsANSIStyling;
+		return `${e.name}: ${stripAnsi ? removeAnsiEscapeCodes(e.value) : e.value}`;
+	},
+};
 
 export abstract class AbstractExpressionDataSource<Input, Element extends IExpression> implements IAsyncDataSource<Input, Element> {
 	constructor(

--- a/src/vs/workbench/contrib/debug/browser/debugANSIHandling.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugANSIHandling.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { IHighlight } from '../../../../base/browser/ui/highlightedlabel/highlightedLabel.js';
 import { Color, RGBA } from '../../../../base/common/color.js';
 import { isDefined } from '../../../../base/common/types.js';
 import { editorHoverBackground, listActiveSelectionBackground, listFocusBackground, listInactiveFocusBackground, listInactiveSelectionBackground } from '../../../../platform/theme/common/colorRegistry.js';
@@ -16,7 +17,7 @@ import { ILinkDetector } from './linkDetector.js';
  * @param text The content to stylize.
  * @returns An {@link HTMLSpanElement} that contains the potentially stylized text.
  */
-export function handleANSIOutput(text: string, linkDetector: ILinkDetector, workspaceFolder: IWorkspaceFolder | undefined): HTMLSpanElement {
+export function handleANSIOutput(text: string, linkDetector: ILinkDetector, workspaceFolder: IWorkspaceFolder | undefined, highlights: IHighlight[] | undefined): HTMLSpanElement {
 
 	const root: HTMLSpanElement = document.createElement('span');
 	const textLength: number = text.length;
@@ -27,6 +28,7 @@ export function handleANSIOutput(text: string, linkDetector: ILinkDetector, work
 	let customUnderlineColor: RGBA | string | undefined;
 	let colorsInverted: boolean = false;
 	let currentPos: number = 0;
+	let unprintedChars = 0;
 	let buffer: string = '';
 
 	while (currentPos < textLength) {
@@ -58,8 +60,10 @@ export function handleANSIOutput(text: string, linkDetector: ILinkDetector, work
 
 			if (sequenceFound) {
 
+				unprintedChars += 2 + ansiSequence.length;
+
 				// Flush buffer with previous styles.
-				appendStylizedStringToContainer(root, buffer, styleNames, linkDetector, workspaceFolder, customFgColor, customBgColor, customUnderlineColor);
+				appendStylizedStringToContainer(root, buffer, styleNames, linkDetector, workspaceFolder, customFgColor, customBgColor, customUnderlineColor, highlights, currentPos - buffer.length - unprintedChars);
 
 				buffer = '';
 
@@ -105,7 +109,7 @@ export function handleANSIOutput(text: string, linkDetector: ILinkDetector, work
 
 	// Flush remaining text buffer if not empty.
 	if (buffer) {
-		appendStylizedStringToContainer(root, buffer, styleNames, linkDetector, workspaceFolder, customFgColor, customBgColor, customUnderlineColor);
+		appendStylizedStringToContainer(root, buffer, styleNames, linkDetector, workspaceFolder, customFgColor, customBgColor, customUnderlineColor, highlights, currentPos - buffer.length);
 	}
 
 	return root;
@@ -395,6 +399,8 @@ export function handleANSIOutput(text: string, linkDetector: ILinkDetector, work
  * @param customTextColor If provided, will apply custom color with inline style.
  * @param customBackgroundColor If provided, will apply custom backgroundColor with inline style.
  * @param customUnderlineColor If provided, will apply custom textDecorationColor with inline style.
+ * @param highlights The ranges to highlight.
+ * @param offset The starting index of the stringContent in the original text.
  */
 export function appendStylizedStringToContainer(
 	root: HTMLElement,
@@ -402,15 +408,24 @@ export function appendStylizedStringToContainer(
 	cssClasses: string[],
 	linkDetector: ILinkDetector,
 	workspaceFolder: IWorkspaceFolder | undefined,
-	customTextColor?: RGBA | string,
-	customBackgroundColor?: RGBA | string,
-	customUnderlineColor?: RGBA | string,
+	customTextColor: RGBA | string | undefined,
+	customBackgroundColor: RGBA | string | undefined,
+	customUnderlineColor: RGBA | string | undefined,
+	highlights: IHighlight[] | undefined,
+	offset: number,
 ): void {
 	if (!root || !stringContent) {
 		return;
 	}
 
-	const container = linkDetector.linkify(stringContent, true, workspaceFolder);
+	const container = linkDetector.linkify(
+		stringContent,
+		true,
+		workspaceFolder,
+		undefined,
+		undefined,
+		highlights?.map(h => ({ start: h.start - offset, end: h.end - offset, extraClasses: h.extraClasses })),
+	);
 
 	container.className = cssClasses.join(' ');
 	if (customTextColor) {

--- a/src/vs/workbench/contrib/debug/browser/linkDetector.ts
+++ b/src/vs/workbench/contrib/debug/browser/linkDetector.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { getWindow } from '../../../../base/browser/dom.js';
+import { getWindow, isHTMLElement, reset } from '../../../../base/browser/dom.js';
 import { StandardKeyboardEvent } from '../../../../base/browser/keyboardEvent.js';
 import { getDefaultHoverDelegate } from '../../../../base/browser/ui/hover/hoverDelegateFactory.js';
 import { KeyCode } from '../../../../base/common/keyCodes.js';
@@ -23,6 +23,8 @@ import { IDebugSession } from '../common/debug.js';
 import { IEditorService } from '../../../services/editor/common/editorService.js';
 import { IWorkbenchEnvironmentService } from '../../../services/environment/common/environmentService.js';
 import { IPathService } from '../../../services/path/common/pathService.js';
+import { IHighlight } from '../../../../base/browser/ui/highlightedlabel/highlightedLabel.js';
+import { Iterable } from '../../../../base/common/iterator.js';
 
 const CONTROL_CODES = '\\u0000-\\u0020\\u007f-\\u009f';
 const WEB_LINK_REGEX = new RegExp('(?:[a-zA-Z][a-zA-Z0-9+.-]{2,}:\\/\\/|data:|www\\.)[^\\s' + CONTROL_CODES + '"]{2,}[^\\s' + CONTROL_CODES + '"\')}\\],:;.!?]', 'ug');
@@ -42,6 +44,7 @@ type LinkPart = {
 	kind: LinkKind;
 	value: string;
 	captures: string[];
+	index: number;
 };
 
 export const enum DebugLinkHoverBehavior {
@@ -61,7 +64,7 @@ export type DebugLinkHoverBehaviorTypeData = { type: DebugLinkHoverBehavior.None
 	| { type: DebugLinkHoverBehavior.Rich; store: DisposableStore };
 
 export interface ILinkDetector {
-	linkify(text: string, splitLines?: boolean, workspaceFolder?: IWorkspaceFolder, includeFulltext?: boolean, hoverBehavior?: DebugLinkHoverBehaviorTypeData): HTMLElement;
+	linkify(text: string, splitLines?: boolean, workspaceFolder?: IWorkspaceFolder, includeFulltext?: boolean, hoverBehavior?: DebugLinkHoverBehaviorTypeData, highlights?: IHighlight[]): HTMLElement;
 	linkifyLocation(text: string, locationReference: number, session: IDebugSession, hoverBehavior?: DebugLinkHoverBehaviorTypeData): HTMLElement;
 }
 
@@ -88,11 +91,11 @@ export class LinkDetector implements ILinkDetector {
 	 * If a `hoverBehavior` is passed, hovers may be added using the workbench hover service.
 	 * This should be preferred for new code where hovers are desirable.
 	 */
-	linkify(text: string, splitLines?: boolean, workspaceFolder?: IWorkspaceFolder, includeFulltext?: boolean, hoverBehavior?: DebugLinkHoverBehaviorTypeData): HTMLElement {
-		return this._linkify(text, splitLines, workspaceFolder, includeFulltext, hoverBehavior);
+	linkify(text: string, splitLines?: boolean, workspaceFolder?: IWorkspaceFolder, includeFulltext?: boolean, hoverBehavior?: DebugLinkHoverBehaviorTypeData, highlights?: IHighlight[]): HTMLElement {
+		return this._linkify(text, splitLines, workspaceFolder, includeFulltext, hoverBehavior, highlights);
 	}
 
-	private _linkify(text: string, splitLines?: boolean, workspaceFolder?: IWorkspaceFolder, includeFulltext?: boolean, hoverBehavior?: DebugLinkHoverBehaviorTypeData, defaultRef?: { locationReference: number; session: IDebugSession }): HTMLElement {
+	private _linkify(text: string, splitLines?: boolean, workspaceFolder?: IWorkspaceFolder, includeFulltext?: boolean, hoverBehavior?: DebugLinkHoverBehaviorTypeData, highlights?: IHighlight[], defaultRef?: { locationReference: number; session: IDebugSession }): HTMLElement {
 		if (splitLines) {
 			const lines = text.split('\n');
 			for (let i = 0; i < lines.length - 1; i++) {
@@ -102,7 +105,7 @@ export class LinkDetector implements ILinkDetector {
 				// Remove the last element ('') that split added.
 				lines.pop();
 			}
-			const elements = lines.map(line => this._linkify(line, false, workspaceFolder, includeFulltext, hoverBehavior, defaultRef));
+			const elements = lines.map(line => this._linkify(line, false, workspaceFolder, includeFulltext, hoverBehavior, highlights, defaultRef));
 			if (elements.length === 1) {
 				// Do not wrap single line with extra span.
 				return elements[0];
@@ -115,26 +118,75 @@ export class LinkDetector implements ILinkDetector {
 		const container = document.createElement('span');
 		for (const part of this.detectLinks(text)) {
 			try {
+				let node: Node;
 				switch (part.kind) {
 					case 'text':
-						container.appendChild(defaultRef ? this.linkifyLocation(part.value, defaultRef.locationReference, defaultRef.session, hoverBehavior) : document.createTextNode(part.value));
+						node = defaultRef ? this.linkifyLocation(part.value, defaultRef.locationReference, defaultRef.session, hoverBehavior) : document.createTextNode(part.value);
 						break;
 					case 'web':
-						container.appendChild(this.createWebLink(includeFulltext ? text : undefined, part.value, hoverBehavior));
+						node = this.createWebLink(includeFulltext ? text : undefined, part.value, hoverBehavior);
 						break;
 					case 'path': {
 						const path = part.captures[0];
 						const lineNumber = part.captures[1] ? Number(part.captures[1]) : 0;
 						const columnNumber = part.captures[2] ? Number(part.captures[2]) : 0;
-						container.appendChild(this.createPathLink(includeFulltext ? text : undefined, part.value, path, lineNumber, columnNumber, workspaceFolder, hoverBehavior));
+						node = this.createPathLink(includeFulltext ? text : undefined, part.value, path, lineNumber, columnNumber, workspaceFolder, hoverBehavior);
 						break;
 					}
+					default:
+						node = document.createTextNode(part.value);
 				}
+
+				container.append(...this.applyHighlights(node, part.index, part.value.length, highlights));
 			} catch (e) {
 				container.appendChild(document.createTextNode(part.value));
 			}
 		}
 		return container;
+	}
+
+	private applyHighlights(node: Node, startIndex: number, length: number, highlights: IHighlight[] | undefined): Iterable<Node | string> {
+		const children: (Node | string)[] = [];
+		let currentIndex = startIndex;
+		const endIndex = startIndex + length;
+
+		for (const highlight of highlights || []) {
+			if (highlight.end <= currentIndex || highlight.start >= endIndex) {
+				continue;
+			}
+
+			if (highlight.start > currentIndex) {
+				children.push(node.textContent!.substring(currentIndex - startIndex, highlight.start - startIndex));
+				currentIndex = highlight.start;
+			}
+
+			const highlightEnd = Math.min(highlight.end, endIndex);
+			const highlightedText = node.textContent!.substring(currentIndex - startIndex, highlightEnd - startIndex);
+			const highlightSpan = document.createElement('span');
+			highlightSpan.classList.add('highlight');
+			if (highlight.extraClasses) {
+				highlightSpan.classList.add(...highlight.extraClasses);
+			}
+			highlightSpan.textContent = highlightedText;
+			children.push(highlightSpan);
+			currentIndex = highlightEnd;
+		}
+
+		if (currentIndex === startIndex) {
+			return Iterable.single(node); // no changes made
+		}
+
+		if (currentIndex < endIndex) {
+			children.push(node.textContent!.substring(currentIndex - startIndex));
+		}
+
+		// reuse the element if it's a link
+		if (isHTMLElement(node)) {
+			reset(node, ...children);
+			return Iterable.single(node);
+		}
+
+		return children;
 	}
 
 	/**
@@ -161,8 +213,8 @@ export class LinkDetector implements ILinkDetector {
 	 */
 	makeReferencedLinkDetector(locationReference: number, session: IDebugSession): ILinkDetector {
 		return {
-			linkify: (text, splitLines, workspaceFolder, includeFulltext, hoverBehavior) =>
-				this._linkify(text, splitLines, workspaceFolder, includeFulltext, hoverBehavior, { locationReference, session }),
+			linkify: (text, splitLines, workspaceFolder, includeFulltext, hoverBehavior, highlights) =>
+				this._linkify(text, splitLines, workspaceFolder, includeFulltext, hoverBehavior, highlights, { locationReference, session }),
 			linkifyLocation: this.linkifyLocation.bind(this),
 		};
 	}
@@ -295,16 +347,16 @@ export class LinkDetector implements ILinkDetector {
 
 	private detectLinks(text: string): LinkPart[] {
 		if (text.length > MAX_LENGTH) {
-			return [{ kind: 'text', value: text, captures: [] }];
+			return [{ kind: 'text', value: text, captures: [], index: 0 }];
 		}
 
 		const regexes: RegExp[] = [WEB_LINK_REGEX, PATH_LINK_REGEX];
 		const kinds: LinkKind[] = ['web', 'path'];
 		const result: LinkPart[] = [];
 
-		const splitOne = (text: string, regexIndex: number) => {
+		const splitOne = (text: string, regexIndex: number, baseIndex: number) => {
 			if (regexIndex >= regexes.length) {
-				result.push({ value: text, kind: 'text', captures: [] });
+				result.push({ value: text, kind: 'text', captures: [], index: baseIndex });
 				return;
 			}
 			const regex = regexes[regexIndex];
@@ -314,23 +366,24 @@ export class LinkDetector implements ILinkDetector {
 			while ((match = regex.exec(text)) !== null) {
 				const stringBeforeMatch = text.substring(currentIndex, match.index);
 				if (stringBeforeMatch) {
-					splitOne(stringBeforeMatch, regexIndex + 1);
+					splitOne(stringBeforeMatch, regexIndex + 1, baseIndex + currentIndex);
 				}
 				const value = match[0];
 				result.push({
 					value: value,
 					kind: kinds[regexIndex],
-					captures: match.slice(1)
+					captures: match.slice(1),
+					index: baseIndex + match.index
 				});
 				currentIndex = match.index + value.length;
 			}
 			const stringAfterMatches = text.substring(currentIndex);
 			if (stringAfterMatches) {
-				splitOne(stringAfterMatches, regexIndex + 1);
+				splitOne(stringAfterMatches, regexIndex + 1, baseIndex + currentIndex);
 			}
 		};
 
-		splitOne(text, 0);
+		splitOne(text, 0, 0);
 		return result;
 	}
 }

--- a/src/vs/workbench/contrib/debug/browser/media/debugViewlet.css
+++ b/src/vs/workbench/contrib/debug/browser/media/debugViewlet.css
@@ -274,6 +274,12 @@
 	font-family: var(--monaco-monospace-font);
 	font-weight: normal;
 }
+.debug-view-content .monaco-tl-contents .highlight {
+	color: unset !important;
+	background-color: var(--vscode-list-filterMatchBackground);
+	outline: 1px dotted var(--vscode-list-filterMatchBorder);
+	outline-offset: -1px;
+}
 
 /* Breakpoints */
 

--- a/src/vs/workbench/contrib/debug/browser/variablesView.ts
+++ b/src/vs/workbench/contrib/debug/browser/variablesView.ts
@@ -46,7 +46,7 @@ import { CONTEXT_BREAK_WHEN_VALUE_CHANGES_SUPPORTED, CONTEXT_BREAK_WHEN_VALUE_IS
 import { getContextForVariable } from '../common/debugContext.js';
 import { ErrorScope, Expression, Scope, StackFrame, Variable, VisualizedExpression, getUriForDebugMemory } from '../common/debugModel.js';
 import { DebugVisualizer, IDebugVisualizerService } from '../common/debugVisualizers.js';
-import { AbstractExpressionDataSource, AbstractExpressionsRenderer, IExpressionTemplateData, IInputBoxOptions, renderViewTree } from './baseDebugView.js';
+import { AbstractExpressionDataSource, AbstractExpressionsRenderer, expressionAndScopeLabelProvider, IExpressionTemplateData, IInputBoxOptions, renderViewTree } from './baseDebugView.js';
 import { ADD_TO_WATCH_ID, ADD_TO_WATCH_LABEL, COPY_EVALUATE_PATH_ID, COPY_EVALUATE_PATH_LABEL, COPY_VALUE_ID, COPY_VALUE_LABEL } from './debugCommands.js';
 import { DebugExpressionRenderer } from './debugExpressionRenderer.js';
 
@@ -138,7 +138,7 @@ export class VariablesView extends ViewPane implements IDebugViewWithVariables {
 			this.instantiationService.createInstance(VariablesDataSource), {
 			accessibilityProvider: new VariablesAccessibilityProvider(),
 			identityProvider: { getId: (element: IExpression | IScope) => element.getId() },
-			keyboardNavigationLabelProvider: { getKeyboardNavigationLabel: (e: IExpression | IScope) => e.name },
+			keyboardNavigationLabelProvider: expressionAndScopeLabelProvider,
 			overrideStyles: this.getLocationBasedColors().listOverrideStyles
 		});
 

--- a/src/vs/workbench/contrib/debug/browser/watchExpressionsView.ts
+++ b/src/vs/workbench/contrib/debug/browser/watchExpressionsView.ts
@@ -31,7 +31,7 @@ import { IViewletViewOptions } from '../../../browser/parts/views/viewsViewlet.j
 import { IViewDescriptorService } from '../../../common/views.js';
 import { CONTEXT_CAN_VIEW_MEMORY, CONTEXT_VARIABLE_IS_READONLY, CONTEXT_WATCH_EXPRESSIONS_EXIST, CONTEXT_WATCH_EXPRESSIONS_FOCUSED, CONTEXT_WATCH_ITEM_TYPE, IDebugConfiguration, IDebugService, IDebugViewWithVariables, IExpression, WATCH_VIEW_ID } from '../common/debug.js';
 import { Expression, Variable, VisualizedExpression } from '../common/debugModel.js';
-import { AbstractExpressionDataSource, AbstractExpressionsRenderer, IExpressionTemplateData, IInputBoxOptions, renderViewTree } from './baseDebugView.js';
+import { AbstractExpressionDataSource, AbstractExpressionsRenderer, expressionAndScopeLabelProvider, IExpressionTemplateData, IInputBoxOptions, renderViewTree } from './baseDebugView.js';
 import { DebugExpressionRenderer } from './debugExpressionRenderer.js';
 import { watchExpressionsAdd, watchExpressionsRemoveAll } from './debugIcons.js';
 import { VariablesRenderer, VisualizedVariableRenderer } from './variablesView.js';
@@ -109,7 +109,7 @@ export class WatchExpressionsView extends ViewPane implements IDebugViewWithVari
 						return undefined;
 					}
 
-					return e.name;
+					return expressionAndScopeLabelProvider.getKeyboardNavigationLabel(e);
 				}
 			},
 			dnd: new WatchExpressionsDragAndDrop(this.debugService),

--- a/src/vs/workbench/contrib/debug/test/browser/debugANSIHandling.test.ts
+++ b/src/vs/workbench/contrib/debug/test/browser/debugANSIHandling.test.ts
@@ -51,8 +51,8 @@ suite('Debug - ANSI Handling', () => {
 
 		assert.strictEqual(0, root.children.length);
 
-		appendStylizedStringToContainer(root, 'content1', ['class1', 'class2'], linkDetector, session.root);
-		appendStylizedStringToContainer(root, 'content2', ['class2', 'class3'], linkDetector, session.root);
+		appendStylizedStringToContainer(root, 'content1', ['class1', 'class2'], linkDetector, session.root, undefined, undefined, undefined, undefined, 0);
+		appendStylizedStringToContainer(root, 'content2', ['class2', 'class3'], linkDetector, session.root, undefined, undefined, undefined, undefined, 0);
 
 		assert.strictEqual(2, root.children.length);
 
@@ -82,7 +82,7 @@ suite('Debug - ANSI Handling', () => {
 	 * @returns An {@link HTMLSpanElement} that contains the stylized text.
 	 */
 	function getSequenceOutput(sequence: string): HTMLSpanElement {
-		const root: HTMLSpanElement = handleANSIOutput(sequence, linkDetector, session.root);
+		const root: HTMLSpanElement = handleANSIOutput(sequence, linkDetector, session.root, []);
 		assert.strictEqual(1, root.children.length);
 		const child: Node = root.lastChild!;
 		if (isHTMLSpanElement(child)) {
@@ -395,7 +395,7 @@ suite('Debug - ANSI Handling', () => {
 		if (elementsExpected === undefined) {
 			elementsExpected = assertions.length;
 		}
-		const root: HTMLSpanElement = handleANSIOutput(sequence, linkDetector, session.root);
+		const root: HTMLSpanElement = handleANSIOutput(sequence, linkDetector, session.root, []);
 		assert.strictEqual(elementsExpected, root.children.length);
 		for (let i = 0; i < elementsExpected; i++) {
 			const child: Node = root.children[i];

--- a/src/vs/workbench/contrib/debug/test/browser/linkDetector.test.ts
+++ b/src/vs/workbench/contrib/debug/test/browser/linkDetector.test.ts
@@ -197,7 +197,7 @@ suite('Debug - Link Detector', () => {
 	test('highlightOverlappingLinkStart', () => {
 		const input = isWindows ? 'C:\\foo\\bar.js:12:34' : '/Users/foo/bar.js:12:34';
 		const highlights: IHighlight[] = [{ start: 0, end: 10 }];
-		const expectedOutput = isWindows ? '<span><a tabindex="0"><span class="highlight">C:\\foo\\bar</span>.js:12:34</a></span>' : '<span><a tabindex="0"><span class="highlight">/Users/foo/</span>bar.js:12:34</a></span>';
+		const expectedOutput = isWindows ? '<span><a tabindex="0"><span class="highlight">C:\\foo\\bar</span>.js:12:34</a></span>' : '<span><a tabindex="0"><span class="highlight">/Users/foo</span>/bar.js:12:34</a></span>';
 		const output = linkDetector.linkify(input, false, undefined, false, undefined, highlights);
 
 		assert.strictEqual(1, output.children.length);
@@ -210,7 +210,7 @@ suite('Debug - Link Detector', () => {
 	test('highlightOverlappingLinkEnd', () => {
 		const input = isWindows ? 'C:\\foo\\bar.js:12:34' : '/Users/foo/bar.js:12:34';
 		const highlights: IHighlight[] = [{ start: 10, end: 20 }];
-		const expectedOutput = isWindows ? '<span><a tabindex="0">C:\\foo\\bar<span class="highlight">.js:12:34</span></a></span>' : '<span><a tabindex="0">/Users/foo/<span class="highlight">bar.js:12:34</span></a></span>';
+		const expectedOutput = isWindows ? '<span><a tabindex="0">C:\\foo\\bar<span class="highlight">.js:12:34</span></a></span>' : '<span><a tabindex="0">/Users/foo<span class="highlight">/bar.js:12</span>:34</a></span>';
 		const output = linkDetector.linkify(input, false, undefined, false, undefined, highlights);
 
 		assert.strictEqual(1, output.children.length);

--- a/src/vs/workbench/contrib/debug/test/browser/linkDetector.test.ts
+++ b/src/vs/workbench/contrib/debug/test/browser/linkDetector.test.ts
@@ -13,6 +13,7 @@ import { ITunnelService } from '../../../../../platform/tunnel/common/tunnel.js'
 import { WorkspaceFolder } from '../../../../../platform/workspace/common/workspace.js';
 import { LinkDetector } from '../../browser/linkDetector.js';
 import { workbenchInstantiationService } from '../../../../test/browser/workbenchTestServices.js';
+import { IHighlight } from '../../../../../base/browser/ui/highlightedlabel/highlightedLabel.js';
 
 suite('Debug - Link Detector', () => {
 
@@ -167,5 +168,68 @@ suite('Debug - Link Detector', () => {
 		assert(expectedOutput.test(output.outerHTML));
 		assertElementIsLink(output.children[1].children[0]);
 		assert.strictEqual(isWindows ? 'C:/foo/bar.js:12:34' : '/Users/foo/bar.js:12:34', output.children[1].children[0].textContent);
+	});
+
+	test('highlightNoLinks', () => {
+		const input = 'I am a string';
+		const highlights: IHighlight[] = [{ start: 2, end: 5 }];
+		const expectedOutput = '<span>I <span class="highlight">am </span>a string</span>';
+		const output = linkDetector.linkify(input, false, undefined, false, undefined, highlights);
+
+		assert.strictEqual(1, output.children.length);
+		assert.strictEqual('SPAN', output.tagName);
+		assert.strictEqual(expectedOutput, output.outerHTML);
+	});
+
+	test('highlightWithLink', () => {
+		const input = isWindows ? 'C:\\foo\\bar.js:12:34' : '/Users/foo/bar.js:12:34';
+		const highlights: IHighlight[] = [{ start: 0, end: 5 }];
+		const expectedOutput = isWindows ? '<span><a tabindex="0"><span class="highlight">C:\\fo</span>o\\bar.js:12:34</a></span>' : '<span><a tabindex="0"><span class="highlight">/User</span>s/foo/bar.js:12:34</a></span>';
+		const output = linkDetector.linkify(input, false, undefined, false, undefined, highlights);
+
+		assert.strictEqual(1, output.children.length);
+		assert.strictEqual('SPAN', output.tagName);
+		assert.strictEqual('A', output.firstElementChild!.tagName);
+		assert.strictEqual(expectedOutput, output.outerHTML);
+		assertElementIsLink(output.firstElementChild!);
+	});
+
+	test('highlightOverlappingLinkStart', () => {
+		const input = isWindows ? 'C:\\foo\\bar.js:12:34' : '/Users/foo/bar.js:12:34';
+		const highlights: IHighlight[] = [{ start: 0, end: 10 }];
+		const expectedOutput = isWindows ? '<span><a tabindex="0"><span class="highlight">C:\\foo\\bar</span>.js:12:34</a></span>' : '<span><a tabindex="0"><span class="highlight">/Users/foo/</span>bar.js:12:34</a></span>';
+		const output = linkDetector.linkify(input, false, undefined, false, undefined, highlights);
+
+		assert.strictEqual(1, output.children.length);
+		assert.strictEqual('SPAN', output.tagName);
+		assert.strictEqual('A', output.firstElementChild!.tagName);
+		assert.strictEqual(expectedOutput, output.outerHTML);
+		assertElementIsLink(output.firstElementChild!);
+	});
+
+	test('highlightOverlappingLinkEnd', () => {
+		const input = isWindows ? 'C:\\foo\\bar.js:12:34' : '/Users/foo/bar.js:12:34';
+		const highlights: IHighlight[] = [{ start: 10, end: 20 }];
+		const expectedOutput = isWindows ? '<span><a tabindex="0">C:\\foo\\bar<span class="highlight">.js:12:34</span></a></span>' : '<span><a tabindex="0">/Users/foo/<span class="highlight">bar.js:12:34</span></a></span>';
+		const output = linkDetector.linkify(input, false, undefined, false, undefined, highlights);
+
+		assert.strictEqual(1, output.children.length);
+		assert.strictEqual('SPAN', output.tagName);
+		assert.strictEqual('A', output.firstElementChild!.tagName);
+		assert.strictEqual(expectedOutput, output.outerHTML);
+		assertElementIsLink(output.firstElementChild!);
+	});
+
+	test('highlightOverlappingLinkStartAndEnd', () => {
+		const input = isWindows ? 'C:\\foo\\bar.js:12:34' : '/Users/foo/bar.js:12:34';
+		const highlights: IHighlight[] = [{ start: 5, end: 15 }];
+		const expectedOutput = isWindows ? '<span><a tabindex="0">C:\\fo<span class="highlight">o\\bar.js:1</span>2:34</a></span>' : '<span><a tabindex="0">/User<span class="highlight">s/foo/bar.</span>js:12:34</a></span>';
+		const output = linkDetector.linkify(input, false, undefined, false, undefined, highlights);
+
+		assert.strictEqual(1, output.children.length);
+		assert.strictEqual('SPAN', output.tagName);
+		assert.strictEqual('A', output.firstElementChild!.tagName);
+		assert.strictEqual(expectedOutput, output.outerHTML);
+		assertElementIsLink(output.firstElementChild!);
 	});
 });


### PR DESCRIPTION
I think this is something that never worked, or at least not for a long
while. Implementing match highlighting in values in the era of
linkification and ANSI support was a little more complex, but this works
well now.

![](https://memes.peet.io/img/24-12-b1f699dc-f20c-4c93-a5ce-f768473fff62.png)

Fixes #230945

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
