### PR TITLE
reverse cancellation and sequencer

### DIFF
--- a/extensions/microsoft-authentication/src/node/cachedPublicClientApplication.ts
+++ b/extensions/microsoft-authentication/src/node/cachedPublicClientApplication.ts
@@ -133,11 +133,11 @@ export class CachedPublicClientApplication implements ICachedPublicClientApplica
 				cancellable: true,
 				title: l10n.t('Signing in to Microsoft...')
 			},
-			(_process, token) => raceCancellationAndTimeoutError(
-				this._sequencer.queue(() => this._pca.acquireTokenInteractive(request)),
+			(_process, token) => this._sequencer.queue(() => raceCancellationAndTimeoutError(
+				this._pca.acquireTokenInteractive(request),
 				token,
 				1000 * 60 * 5
-			)
+			))
 		);
 		// this._setupRefresh(result);
 		if (this._isBrokerAvailable) {


### PR DESCRIPTION
When we cancel, then the promise should be cancelled. If we don't do this, we hang on the first interaction request until we timeout.

Fixes the 2nd point in https://github.com/microsoft/vscode/issues/236825#issuecomment-2563882150

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
