### PR TITLE
Update README with cloning instructions

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -28,7 +28,9 @@ If you already have VS Code and Docker installed, you can click the badge above 
 
 5. Type `https://github.com/microsoft/vscode` (or a branch or PR URL) in the input box and press <kbd>Enter</kbd>.
 
-6. After the container is running:
+6. Alternatively, you can clone the repository using the command `gh repo clone microsoft/vscode`.
+
+7. After the container is running:
     1. If you have the `DISPLAY` or `WAYLAND_DISPLAY` environment variables set locally (or in WSL on Windows), desktop apps in the container will be shown in local windows.
     2. If these are not set, open a web browser and go to [http://localhost:6080](http://localhost:6080), or use a [VNC Viewer][def] to connect to `localhost:5901` and enter `vscode` as the password. Anything you start in VS Code, or the integrated terminal, will appear here.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Visual Studio Code - Open Source ("Code - OSS")
 
 [![Feature Requests](https://img.shields.io/github/issues/microsoft/vscode/feature-request.svg)](https://github.com/microsoft/vscode/issues?q=is%3Aopen+is%3Aissue+label%3Afeature-request+sort%3Areactions-%2B1-desc)
-[![Bugs](https://img.shields.io/github/issues/microsoft/vscode/bug.svg)](https://github.com/microsoft/vscode/issues?utf8=✓&q=is%3Aissue+is%3Aopen+label%3Abug)
+[![Bugs](https://img.shields.io/github/issues/microsoft/vscode/bug.svg)](https://github.com/microsoft/vscode/issues?utf8=✓&q=is%3Aissue+is%3Aopen+is%3Aissue+label%3Abug)
 [![Gitter](https://img.shields.io/badge/chat-on%20gitter-yellow.svg)](https://gitter.im/Microsoft/vscode)
 
 ## The Repository

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ This repository includes a Visual Studio Code Dev Containers / GitHub Codespaces
 
 * For [Dev Containers](https://aka.ms/vscode-remote/download/containers), use the **Dev Containers: Clone Repository in Container Volume...** command which creates a Docker volume for better disk I/O on macOS and Windows.
   * If you already have VS Code and Docker installed, you can also click [here](https://vscode.dev/redirect?url=vscode://ms-vscode-remote.remote-containers/cloneInVolume?url=https://github.com/microsoft/vscode) to get started. This will cause VS Code to automatically install the Dev Containers extension if needed, clone the source code into a container volume, and spin up a dev container for use.
+  * Alternatively, you can clone the repository using the command `gh repo clone microsoft/vscode`.
 
 * For Codespaces, install the [GitHub Codespaces](https://marketplace.visualstudio.com/items?itemName=GitHub.codespaces) extension in VS Code, and use the **Codespaces: Create New Codespace** command.
 


### PR DESCRIPTION
Add instructions for cloning the repository using `gh repo clone microsoft/vscode`.

* **README.md**
  - Add a new instruction for cloning the repository using `gh repo clone microsoft/vscode` in the "Quick start - local" section.

* **.devcontainer/README.md**
  - Add a new instruction for cloning the repository using `gh repo clone microsoft/vscode` in the "Quick start - local" section.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/microsoft/vscode/pull/237094?shareId=6fea598c-d908-4818-b5ed-d3c51f5a4061).