### PR TITLE
Fix typo in `clipboardUtils.ts`

### DIFF
--- a/src/vs/editor/browser/controller/editContext/clipboardUtils.ts
+++ b/src/vs/editor/browser/controller/editContext/clipboardUtils.ts
@@ -36,7 +36,7 @@ export function getDataToCopy(viewModel: IViewModel, modelSelections: Range[], e
 
 /**
  * Every time we write to the clipboard, we record a bit of extra metadata here.
- * Every time we read from the cipboard, if the text matches our last written text,
+ * Every time we read from the clipboard, if the text matches our last written text,
  * we can fetch the previous metadata.
  */
 export class InMemoryClipboardMetadataManager {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

There was typo in `InMemoryClipboardMetadataManager`, so I fixed it. 
