### PR TITLE
Refactor: convert d.ts files to regular ts files

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/xterm-private.ts
+++ b/src/vs/workbench/contrib/terminal/browser/xterm-private.ts
@@ -3,13 +3,14 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { IBufferCell } from '@xterm/xterm';
+import type { IBufferCell } from '@xterm/xterm';
 
 export type XtermAttributes = Omit<IBufferCell, 'getWidth' | 'getChars' | 'getCode'> & { clone?(): XtermAttributes };
 
 export interface IXtermCore {
 	viewport?: {
 		readonly scrollBarWidth: number;
+		// eslint-disable-next-line @typescript-eslint/naming-convention
 		_innerRefresh(): void;
 	};
 
@@ -23,9 +24,9 @@ export interface IXtermCore {
 				cell: {
 					width: number;
 					height: number;
-				}
-			}
-		},
+				};
+			};
+		};
 		_renderer: {
 			value?: unknown;
 		};

--- a/src/vs/workbench/contrib/webview/browser/webviewMessages.ts
+++ b/src/vs/workbench/contrib/webview/browser/webviewMessages.ts
@@ -3,8 +3,8 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import type { IMouseWheelEvent } from 'vs/base/browser/mouseEvent';
-import type { WebviewStyles } from 'vs/workbench/contrib/webview/browser/webview';
+import type { IMouseWheelEvent } from '../../../../base/browser/mouseEvent.js';
+import type { WebviewStyles } from './webview.js';
 
 type KeyEvent = {
 	key: string;
@@ -15,11 +15,11 @@ type KeyEvent = {
 	ctrlKey: boolean;
 	metaKey: boolean;
 	repeat: boolean;
-}
+};
 
 type WebViewDragEvent = {
 	shiftKey: boolean;
-}
+};
 
 export type FromWebviewMessage = {
 	'onmessage': { message: any; transfer?: ArrayBuffer[] };
@@ -40,7 +40,7 @@ export type FromWebviewMessage = {
 	'did-keyup': KeyEvent;
 	'did-context-menu': { clientX: number; clientY: number; context: { [key: string]: unknown } };
 	'drag-start': void;
-	'drag': WebViewDragEvent
+	'drag': WebViewDragEvent;
 };
 
 interface UpdateContentEvent {


### PR DESCRIPTION
I don't think there is any reason for those files to be d.ts files instead of regular ts files (even though they only contain types)

It prevents the conventions rules from being applied (relative imports, ends with `.js`, trainling semi-colon...)

Also the naming-convention eslint rule (I have to disabled?)

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
