### PR TITLE
ci: fix broken monaco editor action

### DIFF
--- a/.github/workflows/monaco-editor.yml
+++ b/.github/workflows/monaco-editor.yml
@@ -45,11 +45,11 @@ jobs:
           path: ${{ steps.npmCacheDirPath.outputs.dir }}
           key: ${{ runner.os }}-npmCacheDir-${{ steps.nodeModulesCacheKey.outputs.value }}
           restore-keys: ${{ runner.os }}-npmCacheDir-
-      - name: Install libkrb5-dev
+      - name: Install system dependencies
         if: ${{ steps.cacheNodeModules.outputs.cache-hit != 'true' }}
         run: |
           sudo apt update
-          sudo apt install -y libkrb5-dev
+          sudo apt install -y libxkbfile-dev pkg-config libkrb5-dev libxss1
       - name: Execute npm
         if: ${{ steps.cacheNodeModules.outputs.cache-hit != 'true' }}
         env:


### PR DESCRIPTION
Refs https://github.com/microsoft/vscode/actions/runs/12633748739/job/35200011280

Runners have been updated to Ubuntu 24.04 from 22.04 which misses some system dependencies that are required for building our native modules.