### PR TITLE
Git - Revert "Git - escape shell-sensitive characters (#236849)"

### DIFF
--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -349,15 +349,10 @@ function getGitErrorCode(stderr: string): string | undefined {
 	return undefined;
 }
 
+// https://github.com/microsoft/vscode/issues/89373
+// https://github.com/git-for-windows/git/issues/2478
 function sanitizePath(path: string): string {
-	return path
-		// Drive letter
-		// https://github.com/microsoft/vscode/issues/89373
-		// https://github.com/git-for-windows/git/issues/2478
-		.replace(/^([a-z]):\\/i, (_, letter) => `${letter.toUpperCase()}:\\`)
-		// Shell-sensitive characters
-		// https://github.com/microsoft/vscode/issues/133566
-		.replace(/(["'\\\$!><#()\[\]*&^| ;{}?`])/g, '\\$1');
+	return path.replace(/^([a-z]):\\/i, (_, letter) => `${letter.toUpperCase()}:\\`);
 }
 
 const COMMIT_FORMAT = '%H%n%aN%n%aE%n%at%n%ct%n%P%n%D%n%B';


### PR DESCRIPTION
This reverts commit fca210cd103a496f25c23786b861a67f4d1ee16b.

Fixes [#237331](https://github.com/microsoft/vscode/issues/237331)

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
