### PR TITLE
Make `Terminal: Focus Terminal` use the default location when creating a new terminal

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminalActions.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalActions.ts
@@ -490,7 +490,7 @@ export function registerTerminalActions() {
 		},
 		precondition: sharedWhenClause.terminalAvailable,
 		run: async (c) => {
-			const instance = c.service.activeInstance || await c.service.createTerminal({ location: TerminalLocation.Panel });
+			const instance = c.service.activeInstance || await c.service.createTerminal();
 			if (!instance) {
 				return;
 			}


### PR DESCRIPTION
It won't make sense to merge this until someone on vscode team chooses if it makes sense or not. If it makes sense, then it solves #237189.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
`resolveLocation()` in `createTerminal()` ( https://github.com/Abrifq/vscode/blob/ddaf80dba856f95daa22da658a1a0f16978e8012/src/vs/workbench/contrib/terminal/browser/terminalService.ts#L948-L1019 ) already resolves to `defaultLocation` when `options.location` is not present, so just removing the parameter is enough to make it follow the defaults.