### PR TITLE
watcher - drop expensive `realcase` use for non recursive watching

### DIFF
--- a/src/vs/platform/files/node/watcher/parcel/parcelWatcher.ts
+++ b/src/vs/platform/files/node/watcher/parcel/parcelWatcher.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import * as parcelWatcher from '@parcel/watcher';
+import parcelWatcher from '@parcel/watcher';
 import { statSync, unlinkSync } from 'fs';
 import { tmpdir, homedir } from 'os';
 import { URI } from '../../../../../base/common/uri.js';


### PR DESCRIPTION
In testing with many thousand individual files, this operation is very expensive.

Refs: https://github.com/microsoft/vscode/issues/237351

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
