### PR TITLE
Retry executeCommand integration test on failure

### DIFF
--- a/extensions/vscode-api-tests/src/singlefolder-tests/terminal.shellIntegration.test.ts
+++ b/extensions/vscode-api-tests/src/singlefolder-tests/terminal.shellIntegration.test.ts
@@ -212,7 +212,12 @@ import { assertNoRpc } from '../utils';
 		await closeTerminalAsync(terminal);
 	});
 
-	test('executeCommand(executable, args)', async () => {
+	test('executeCommand(executable, args)', async function () {
+		// HACK: This test has flaked before where the `value` was `e`, not `echo hello`. After an
+		// investigation it's not clear how this happened, so in order to keep some of the value
+		// that the test adds, it will retry after a failure.
+		this.retries(3);
+
 		const { terminal, shellIntegration } = await createTerminalAndWaitForShellIntegration();
 		const { execution, endEvent } = executeCommandAsync(shellIntegration, 'echo', ['hello']);
 		const executionSync = await execution;


### PR DESCRIPTION
It's unclear how this happened and seems like a very rare flake.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
