### PR TITLE
Require `export` on all vscode public api types

### DIFF
--- a/.eslint-plugin-local/vscode-dts-use-export.ts
+++ b/.eslint-plugin-local/vscode-dts-use-export.ts
@@ -1,0 +1,32 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { TSESTree } from '@typescript-eslint/utils';
+import * as eslint from 'eslint';
+
+export = new class VscodeDtsUseExport implements eslint.Rule.RuleModule {
+
+	readonly meta: eslint.Rule.RuleMetaData = {
+		messages: {
+			useExport: `Public api types must use 'export'`,
+		},
+		schema: false,
+	};
+
+	create(context: eslint.Rule.RuleContext): eslint.Rule.RuleListener {
+		return {
+			['TSModuleDeclaration :matches(TSInterfaceDeclaration, ClassDeclaration, VariableDeclaration, TSEnumDeclaration, TSTypeAliasDeclaration)']: (node: any) => {
+				const parent = (<TSESTree.Node>node).parent;
+				if (parent && parent.type !== TSESTree.AST_NODE_TYPES.ExportNamedDeclaration) {
+					context.report({
+						node,
+						messageId: 'useExport'
+					});
+				}
+			}
+		};
+	}
+};
+

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -267,6 +267,7 @@ export default tseslint.config(
 			'local/vscode-dts-string-type-literals': 'warn',
 			'local/vscode-dts-interface-naming': 'warn',
 			'local/vscode-dts-cancellation': 'warn',
+			'local/vscode-dts-use-export': 'warn',
 			'local/vscode-dts-use-thenable': 'warn',
 			'local/vscode-dts-region-comments': 'warn',
 			'local/vscode-dts-vscode-in-comments': 'warn',

--- a/src/vscode-dts/vscode.d.ts
+++ b/src/vscode-dts/vscode.d.ts
@@ -6076,7 +6076,7 @@ declare module 'vscode' {
 	/**
 	 * Identifies a {@linkcode DocumentDropEdit} or {@linkcode DocumentPasteEdit}
 	 */
-	class DocumentDropOrPasteEditKind {
+	export class DocumentDropOrPasteEditKind {
 		static readonly Empty: DocumentDropOrPasteEditKind;
 
 		/**
@@ -6272,7 +6272,7 @@ declare module 'vscode' {
 	/**
 	 * Provider invoked when the user copies or pastes in a {@linkcode TextDocument}.
 	 */
-	interface DocumentPasteEditProvider<T extends DocumentPasteEdit = DocumentPasteEdit> {
+	export interface DocumentPasteEditProvider<T extends DocumentPasteEdit = DocumentPasteEdit> {
 
 		/**
 		 * Optional method invoked after the user copies from a {@link TextEditor text editor}.
@@ -6329,7 +6329,7 @@ declare module 'vscode' {
 	/**
 	 * An edit the applies a paste operation.
 	 */
-	class DocumentPasteEdit {
+	export class DocumentPasteEdit {
 
 		/**
 		 * Human readable label that describes the edit.
@@ -6373,7 +6373,7 @@ declare module 'vscode' {
 	/**
 	 * Provides additional metadata about how a {@linkcode DocumentPasteEditProvider} works.
 	 */
-	interface DocumentPasteProviderMetadata {
+	export interface DocumentPasteProviderMetadata {
 		/**
 		 * List of {@link DocumentDropOrPasteEditKind kinds} that the provider may return in {@linkcode DocumentPasteEditProvider.provideDocumentPasteEdits provideDocumentPasteEdits}.
 		 *
@@ -7924,7 +7924,7 @@ declare module 'vscode' {
 	/**
 	 * The confidence of a {@link TerminalShellExecutionCommandLine} value.
 	 */
-	enum TerminalShellExecutionCommandLineConfidence {
+	export enum TerminalShellExecutionCommandLineConfidence {
 		/**
 		 * The command line value confidence is low. This means that the value was read from the
 		 * terminal buffer using markers reported by the shell integration script. Additionally one
@@ -9167,7 +9167,7 @@ declare module 'vscode' {
 	 *
 	 * This interface is not intended to be implemented.
 	 */
-	interface TaskStartEvent {
+	export interface TaskStartEvent {
 		/**
 		 * The task item representing the task that got started.
 		 */
@@ -9179,7 +9179,7 @@ declare module 'vscode' {
 	 *
 	 * This interface is not intended to be implemented.
 	 */
-	interface TaskEndEvent {
+	export interface TaskEndEvent {
 		/**
 		 * The task item representing the task that finished.
 		 */
@@ -9971,7 +9971,7 @@ declare module 'vscode' {
 	/**
 	 * A panel that contains a webview.
 	 */
-	interface WebviewPanel {
+	export interface WebviewPanel {
 		/**
 		 * Identifies the type of the webview panel, such as `'markdown.preview'`.
 		 */
@@ -10101,7 +10101,7 @@ declare module 'vscode' {
 	 *
 	 * @param T Type of the webview's state.
 	 */
-	interface WebviewPanelSerializer<T = unknown> {
+	export interface WebviewPanelSerializer<T = unknown> {
 		/**
 		 * Restore a webview panel from its serialized `state`.
 		 *
@@ -10192,7 +10192,7 @@ declare module 'vscode' {
 	 *
 	 * @param T Type of the webview's state.
 	 */
-	interface WebviewViewResolveContext<T = unknown> {
+	export interface WebviewViewResolveContext<T = unknown> {
 		/**
 		 * Persisted state from the webview content.
 		 *
@@ -10282,7 +10282,7 @@ declare module 'vscode' {
 	 * Custom documents are only used within a given `CustomEditorProvider`. The lifecycle of a `CustomDocument` is
 	 * managed by the editor. When no more references remain to a `CustomDocument`, it is disposed of.
 	 */
-	interface CustomDocument {
+	export interface CustomDocument {
 		/**
 		 * The associated uri for this document.
 		 */
@@ -10302,7 +10302,7 @@ declare module 'vscode' {
 	 *
 	 * @see {@linkcode CustomEditorProvider.onDidChangeCustomDocument}.
 	 */
-	interface CustomDocumentEditEvent<T extends CustomDocument = CustomDocument> {
+	export interface CustomDocumentEditEvent<T extends CustomDocument = CustomDocument> {
 
 		/**
 		 * The document that the edit is for.
@@ -10341,7 +10341,7 @@ declare module 'vscode' {
 	 *
 	 * @see {@linkcode CustomEditorProvider.onDidChangeCustomDocument}.
 	 */
-	interface CustomDocumentContentChangeEvent<T extends CustomDocument = CustomDocument> {
+	export interface CustomDocumentContentChangeEvent<T extends CustomDocument = CustomDocument> {
 		/**
 		 * The document that the change is for.
 		 */
@@ -10351,7 +10351,7 @@ declare module 'vscode' {
 	/**
 	 * A backup for an {@linkcode CustomDocument}.
 	 */
-	interface CustomDocumentBackup {
+	export interface CustomDocumentBackup {
 		/**
 		 * Unique identifier for the backup.
 		 *
@@ -10371,7 +10371,7 @@ declare module 'vscode' {
 	/**
 	 * Additional information used to implement {@linkcode CustomDocumentBackup}.
 	 */
-	interface CustomDocumentBackupContext {
+	export interface CustomDocumentBackupContext {
 		/**
 		 * Suggested file location to write the new backup.
 		 *
@@ -10387,7 +10387,7 @@ declare module 'vscode' {
 	/**
 	 * Additional information about the opening custom document.
 	 */
-	interface CustomDocumentOpenContext {
+	export interface CustomDocumentOpenContext {
 		/**
 		 * The id of the backup to restore the document from or `undefined` if there is no backup.
 		 *
@@ -12462,7 +12462,7 @@ declare module 'vscode' {
 	/**
 	 * Defines the interface of a terminal pty, enabling extensions to control a terminal.
 	 */
-	interface Pseudoterminal {
+	export interface Pseudoterminal {
 		/**
 		 * An event that when fired will write data to the terminal. Unlike
 		 * {@link Terminal.sendText} which sends text to the underlying child

--- a/src/vscode-dts/vscode.proposed.aiRelatedInformation.d.ts
+++ b/src/vscode-dts/vscode.proposed.aiRelatedInformation.d.ts
@@ -14,7 +14,7 @@ declare module 'vscode' {
 		SettingInformation = 4
 	}
 
-	interface RelatedInformationBaseResult {
+	export interface RelatedInformationBaseResult {
 		type: RelatedInformationType;
 		weight: number;
 	}

--- a/src/vscode-dts/vscode.proposed.externalUriOpener.d.ts
+++ b/src/vscode-dts/vscode.proposed.externalUriOpener.d.ts
@@ -96,7 +96,7 @@ declare module 'vscode' {
 	/**
 	 * Additional information about the uri being opened.
 	 */
-	interface OpenExternalUriContext {
+	export interface OpenExternalUriContext {
 		/**
 		 * The uri that triggered the open.
 		 *
@@ -109,7 +109,7 @@ declare module 'vscode' {
 	/**
 	 * Additional metadata about a registered `ExternalUriOpener`.
 	 */
-	interface ExternalUriOpenerMetadata {
+	export interface ExternalUriOpenerMetadata {
 
 		/**
 		 * List of uri schemes the opener is triggered for.
@@ -142,7 +142,7 @@ declare module 'vscode' {
 		export function registerExternalUriOpener(id: string, opener: ExternalUriOpener, metadata: ExternalUriOpenerMetadata): Disposable;
 	}
 
-	interface OpenExternalOptions {
+	export interface OpenExternalOptions {
 		/**
 		 * Allows using openers contributed by extensions through  `registerExternalUriOpener`
 		 * when opening the resource.

--- a/src/vscode-dts/vscode.proposed.notebookVariableProvider.d.ts
+++ b/src/vscode-dts/vscode.proposed.notebookVariableProvider.d.ts
@@ -14,20 +14,20 @@ declare module 'vscode' {
 		Indexed = 2
 	}
 
-	interface VariablesResult {
+	export interface VariablesResult {
 		variable: Variable;
 		hasNamedChildren: boolean;
 		indexedChildrenCount: number;
 	}
 
-	interface NotebookVariableProvider {
+	export interface NotebookVariableProvider {
 		onDidChangeVariables: Event<NotebookDocument>;
 
 		/** When parent is undefined, this is requesting global Variables. When a variable is passed, it's requesting child props of that Variable. */
 		provideVariables(notebook: NotebookDocument, parent: Variable | undefined, kind: NotebookVariablesRequestKind, start: number, token: CancellationToken): AsyncIterable<VariablesResult>;
 	}
 
-	interface Variable {
+	export interface Variable {
 		/** The variable's name. */
 		name: string;
 

--- a/src/vscode-dts/vscode.proposed.quickDiffProvider.d.ts
+++ b/src/vscode-dts/vscode.proposed.quickDiffProvider.d.ts
@@ -11,7 +11,7 @@ declare module 'vscode' {
 		export function registerQuickDiffProvider(selector: DocumentSelector, quickDiffProvider: QuickDiffProvider, label: string, rootUri?: Uri): Disposable;
 	}
 
-	interface QuickDiffProvider {
+	export interface QuickDiffProvider {
 		label?: string;
 		readonly visible?: boolean;
 	}

--- a/src/vscode-dts/vscode.proposed.resolvers.d.ts
+++ b/src/vscode-dts/vscode.proposed.resolvers.d.ts
@@ -74,7 +74,7 @@ declare module 'vscode' {
 		export const appCommit: string | undefined;
 	}
 
-	interface TunnelOptions {
+	export interface TunnelOptions {
 		remoteAddress: { port: number; host: string };
 		// The desired local port. If this port can't be used, then another will be chosen.
 		localAddressPort?: number;
@@ -87,7 +87,7 @@ declare module 'vscode' {
 		protocol?: string;
 	}
 
-	interface TunnelDescription {
+	export interface TunnelDescription {
 		remoteAddress: { port: number; host: string };
 		//The complete local address(ex. localhost:1234)
 		localAddress: { port: number; host: string } | string;
@@ -100,7 +100,7 @@ declare module 'vscode' {
 		protocol?: string;
 	}
 
-	interface Tunnel extends TunnelDescription {
+	export interface Tunnel extends TunnelDescription {
 		// Implementers of Tunnel should fire onDidDispose when dispose is called.
 		onDidDispose: Event<void>;
 		dispose(): void | Thenable<void>;

--- a/src/vscode-dts/vscode.proposed.terminalQuickFixProvider.d.ts
+++ b/src/vscode-dts/vscode.proposed.terminalQuickFixProvider.d.ts
@@ -59,7 +59,7 @@ declare module 'vscode' {
 	/**
 	 * A matcher that runs on a sub-section of a terminal command's output
 	 */
-	interface TerminalOutputMatcher {
+	export interface TerminalOutputMatcher {
 		/**
 		 * A string or regex to match against the unwrapped line. If this is a regex with the multiline
 		 * flag, it will scan an amount of lines equal to `\n` instances in the regex + 1.
@@ -80,7 +80,7 @@ declare module 'vscode' {
 		length: number;
 	}
 
-	enum TerminalOutputAnchor {
+	export enum TerminalOutputAnchor {
 		Top = 0,
 		Bottom = 1
 	}


### PR DESCRIPTION
Adds new eslint rule which requires `export` be used for public api types

The `export` is not actually needed, but our existing typing files largely use it. This makes use of `export` consistent

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
