### PR TITLE
Add missing experimental tab to conptydll setting

### DIFF
--- a/src/vs/workbench/contrib/terminal/common/terminalConfiguration.ts
+++ b/src/vs/workbench/contrib/terminal/common/terminalConfiguration.ts
@@ -483,6 +483,7 @@ const terminalConfiguration: IConfigurationNode = {
 		[TerminalSettingId.ExperimentalWindowsUseConptyDll]: {
 			markdownDescription: localize('terminal.integrated.experimentalWindowsUseConptyDll', "Whether to use the experimental conpty.dll (v1.20.240626001) shipped with VS Code, instead of the one bundled with Windows."),
 			type: 'boolean',
+			tags: ['experimental'],
 			default: false
 		},
 		[TerminalSettingId.SplitCwd]: {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/d23ff0a0-129c-4a3a-b301-add37f61b5db)
