### PR TITLE
Add requestUuid for inline edits

### DIFF
--- a/src/vs/editor/common/languages.ts
+++ b/src/vs/editor/common/languages.ts
@@ -2407,6 +2407,12 @@ export interface IInlineEdit {
 
 export interface IInlineEditContext {
 	triggerKind: InlineEditTriggerKind;
+
+	/**
+	 * @experimental
+	 * @internal
+	 */
+	requestUuid?: string;
 }
 
 export enum InlineEditTriggerKind {

--- a/src/vs/editor/contrib/inlineCompletions/browser/model/inlineEditsAdapter.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/model/inlineEditsAdapter.ts
@@ -58,6 +58,7 @@ export class InlineEditsAdapter extends Disposable {
 					const inlineEdits = await Promise.all(allInlineEditProvider.map(async provider => {
 						const result = await provider.provideInlineEdit(model, {
 							triggerKind: InlineEditTriggerKind.Automatic,
+							requestUuid: context.requestUuid
 						}, token);
 						if (!result) { return undefined; }
 						return { result, provider };

--- a/src/vs/workbench/api/common/extHostLanguageFeatures.ts
+++ b/src/vs/workbench/api/common/extHostLanguageFeatures.ts
@@ -1526,7 +1526,8 @@ class InlineEditAdapter {
 	async provideInlineEdits(uri: URI, context: languages.IInlineEditContext, token: CancellationToken): Promise<extHostProtocol.IdentifiableInlineEdit | undefined> {
 		const doc = this._documents.getDocument(uri);
 		const result = await this._provider.provideInlineEdit(doc, {
-			triggerKind: this.languageTriggerKindToVSCodeTriggerKind[context.triggerKind]
+			triggerKind: this.languageTriggerKindToVSCodeTriggerKind[context.triggerKind],
+			requestUuid: context.requestUuid,
 		}, token);
 
 		if (!result) {

--- a/src/vscode-dts/vscode.proposed.inlineEdit.d.ts
+++ b/src/vscode-dts/vscode.proposed.inlineEdit.d.ts
@@ -52,6 +52,8 @@ declare module 'vscode' {
 		 * Describes how the inline edit was triggered.
 		 */
 		triggerKind: InlineEditTriggerKind;
+
+		requestUuid?: string;
 	}
 
 	export enum InlineEditTriggerKind {


### PR DESCRIPTION
Introduce a `requestUuid` property to the inline edit context.