### PR TITLE
Redo is a no-op after undo of file creation (fix #236984)

### DIFF
--- a/src/vs/workbench/contrib/bulkEdit/browser/bulkFileEdits.ts
+++ b/src/vs/workbench/contrib/bulkEdit/browser/bulkFileEdits.ts
@@ -255,15 +255,16 @@ class DeleteOperation implements IFileOperation {
 
 			// read file contents for undo operation. when a file is too large it won't be restored
 			let fileContent: IFileContent | undefined;
-			if (!edit.undoesCreate && !edit.options.folder && !(typeof edit.options.maxSize === 'number' && fileStat.size > edit.options.maxSize)) {
+			const isSizeLimitExceeded = typeof edit.options.maxSize === 'number' && fileStat.size > edit.options.maxSize;
+			if (!edit.undoesCreate && !edit.options.folder && !isSizeLimitExceeded) {
 				try {
 					fileContent = await this._fileService.readFile(edit.oldUri);
 				} catch (err) {
 					this._logService.error(err);
 				}
 			}
-			if (fileContent !== undefined) {
-				undoes.push(new CreateEdit(edit.oldUri, edit.options, fileContent.value));
+			if (!fileContent || !isSizeLimitExceeded) {
+				undoes.push(new CreateEdit(edit.oldUri, edit.options, fileContent?.value));
 			}
 		}
 


### PR DESCRIPTION
Fixes a regression introduced by the change from https://github.com/microsoft/vscode/pull/144890.