### PR TITLE
Highlight accepted inline edits temporarily

### DIFF
--- a/build/lib/stylelint/vscode-known-variables.json
+++ b/build/lib/stylelint/vscode-known-variables.json
@@ -370,6 +370,7 @@
 		"--vscode-inlineEdit-originalBackground",
 		"--vscode-inlineEdit-originalChangedLineBackground",
 		"--vscode-inlineEdit-originalChangedTextBackground",
+		"--vscode-inlineEdit-acceptedBackground",
 		"--vscode-input-background",
 		"--vscode-input-border",
 		"--vscode-input-foreground",

--- a/src/vs/editor/contrib/inlineCompletions/browser/utils.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/utils.ts
@@ -53,11 +53,15 @@ export function substringPos(text: string, pos: Position): string {
 	return text.substring(offset);
 }
 
-export function getEndPositionsAfterApplying(edits: readonly SingleTextEdit[]): Position[] {
+export function getModifiedRangesAfterApplying(edits: readonly SingleTextEdit[]): Range[] {
 	const sortPerm = Permutation.createSortPermutation(edits, compareBy(e => e.range, Range.compareRangesUsingStarts));
 	const edit = new TextEdit(sortPerm.apply(edits));
 	const sortedNewRanges = edit.getNewRanges();
-	const newRanges = sortPerm.inverse().apply(sortedNewRanges);
+	return sortPerm.inverse().apply(sortedNewRanges);
+}
+
+export function getEndPositionsAfterApplying(edits: readonly SingleTextEdit[]): Position[] {
+	const newRanges = getModifiedRangesAfterApplying(edits);
 	return newRanges.map(range => range.getEndPosition());
 }
 

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/sideBySideDiff.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/sideBySideDiff.ts
@@ -13,7 +13,7 @@ import { MenuId, MenuItemAction } from '../../../../../../platform/actions/commo
 import { ICommandService } from '../../../../../../platform/commands/common/commands.js';
 import { IInstantiationService } from '../../../../../../platform/instantiation/common/instantiation.js';
 import { diffInserted, diffRemoved } from '../../../../../../platform/theme/common/colorRegistry.js';
-import { darken, lighten, registerColor } from '../../../../../../platform/theme/common/colorUtils.js';
+import { darken, lighten, registerColor, transparent } from '../../../../../../platform/theme/common/colorUtils.js';
 import { IThemeService } from '../../../../../../platform/theme/common/themeService.js';
 import { ICodeEditor } from '../../../../../browser/editorBrowser.js';
 import { observableCodeEditor } from '../../../../../browser/observableCodeEditor.js';
@@ -94,6 +94,18 @@ export const modifiedBorder = registerColor(
 		hcLight: editorLineHighlightBorder
 	},
 	localize('inlineEdit.modifiedBorder', 'Border color for the modified text in inline edits.')
+);
+
+export const acceptedDecorationBackgroundColor = registerColor(
+	'inlineEdit.acceptedBackground',
+	{
+		light: transparent(modifiedChangedTextOverlayColor, 0.5),
+		dark: transparent(modifiedChangedTextOverlayColor, 0.5),
+		hcDark: modifiedChangedTextOverlayColor,
+		hcLight: modifiedChangedTextOverlayColor
+	},
+	localize('inlineEdit.acceptedBackground', 'Background color for the accepted text after appying an inline edit.'),
+	true
 );
 
 export class InlineEditsSideBySideDiff extends Disposable {

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/view.css
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/view.css
@@ -184,3 +184,7 @@
 		outline-offset: -1px;
 	}
 }
+
+.monaco-editor .inlineCompletionAccepted {
+	background-color: var(--vscode-inlineEdit-acceptedBackground);
+}


### PR DESCRIPTION
Introduce a visual indication for accepted inline edits by adding a background color and applying decorations that persist temporarily after acceptance. 