### PR TITLE
edits - better fix #236984

### DIFF
--- a/src/vs/workbench/contrib/bulkEdit/browser/bulkFileEdits.ts
+++ b/src/vs/workbench/contrib/bulkEdit/browser/bulkFileEdits.ts
@@ -255,15 +255,18 @@ class DeleteOperation implements IFileOperation {
 
 			// read file contents for undo operation. when a file is too large it won't be restored
 			let fileContent: IFileContent | undefined;
-			const isSizeLimitExceeded = typeof edit.options.maxSize === 'number' && fileStat.size > edit.options.maxSize;
-			if (!edit.undoesCreate && !edit.options.folder && !isSizeLimitExceeded) {
-				try {
-					fileContent = await this._fileService.readFile(edit.oldUri);
-				} catch (err) {
-					this._logService.error(err);
+			let fileContentExceedsMaxSize = false;
+			if (!edit.undoesCreate && !edit.options.folder) {
+				fileContentExceedsMaxSize = typeof edit.options.maxSize === 'number' && fileStat.size > edit.options.maxSize;
+				if (!fileContentExceedsMaxSize) {
+					try {
+						fileContent = await this._fileService.readFile(edit.oldUri);
+					} catch (err) {
+						this._logService.error(err);
+					}
 				}
 			}
-			if (!fileContent || !isSizeLimitExceeded) {
+			if (!fileContentExceedsMaxSize) {
 				undoes.push(new CreateEdit(edit.oldUri, edit.options, fileContent?.value));
 			}
 		}


### PR DESCRIPTION
Restore the semantics of how it used to be in before the change in https://github.com/microsoft/vscode/pull/144890

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
