### PR TITLE
Fix Shell Integration's Suggestions in PowerShell Strict Mode

### DIFF
--- a/src/vs/workbench/contrib/terminal/common/scripts/shellIntegration.ps1
+++ b/src/vs/workbench/contrib/terminal/common/scripts/shellIntegration.ps1
@@ -397,7 +397,9 @@ function Send-Completions {
 		if ($null -eq $completions -or $null -eq $completions.CompletionMatches) {
 			$result += ";0;$($completionPrefix.Length);$($completionPrefix.Length);[]"
 		} else {
-			$result += ";$($completions.ReplacementIndex);$($completions.ReplacementLength + $prefixCursorDelta);$($cursorIndex - $prefixCursorDelta);"
+			$replacementIndex = if ([bool]$completions.PSObject.Properties['ReplacementIndex']) { $completions.ReplacementIndex } else { '' }
+			$replacementLength = if ([bool]$completions.PSObject.Properties['ReplacementLength']) { $completions.ReplacementLength } else { '' }
+			$result += ";$replacementIndex;$($replacementLength + $prefixCursorDelta);$($cursorIndex - $prefixCursorDelta);"
 			$json = [System.Collections.ArrayList]@($completions.CompletionMatches)
 			# Relative directory completions
 			if ($completions.CompletionMatches.Count -gt 0 -and $completions.CompletionMatches.Where({ $_.ResultType -eq 3 -or $_.ResultType -eq 4 })) {
@@ -466,7 +468,9 @@ function Send-Completions {
 			([System.Management.Automation.CompletionCompleters]::CompleteVariable(''))
 		)
 		if ($null -ne $completions) {
-			$result += ";$($completions.ReplacementIndex);$($completions.ReplacementLength + $prefixCursorDelta);$($cursorIndex - $prefixCursorDelta);"
+  			$replacementIndex = if ([bool]$completions.PSObject.Properties['ReplacementIndex']) { $completions.ReplacementIndex } else { '' }
+  			$replacementLength = if ([bool]$completions.PSObject.Properties['ReplacementLength']) { $completions.ReplacementLength } else { '' }
+			$result += ";$replacementIndex;$($replacementLength + $prefixCursorDelta);$($cursorIndex - $prefixCursorDelta);"
 			$mappedCommands = Compress-Completions($completions)
 			$result += $mappedCommands | ConvertTo-Json -Compress
 		} else {
@@ -482,7 +486,7 @@ function Send-Completions {
 
 function Compress-Completions($completions) {
 	$completions | ForEach-Object {
-		if ($_.CustomIcon) {
+		if ([bool]$_.PSObject.Properties['CustomIcon'] -and $_.CustomIcon) {
 			,@($_.CompletionText, $_.ResultType, $_.ToolTip, $_.CustomIcon)
 		}
 		elseif ($_.CompletionText -eq $_.ToolTip) {


### PR DESCRIPTION
This fixes #237726.

As described in the issue, the Shell Integration's Suggestions' PowerShell script loaded by VS Code is not compatible with PowerShell's [Strict Mode](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/set-strictmode). The strict mode makes PowerShell validate additional stuff and bail if not valid. For instance, instead of returning nothing, it throws an exception when attempting to access a non-existent property or variable.
This was the case here, so I added a strict-mode-safe check based on [this Stack Overflow answer](https://stackoverflow.com/a/65784665). This should be the fastest solution for the issue as per [this Stack Overflow answer](https://stackoverflow.com/a/70492574).

Steps to Reproduce:

1. Make sure `terminal.integrated.shellIntegration.enabled` and `terminal.integrated.suggest.enabled` are enabled
2. Open integrated terminal on a suggestion-supported PowerShell profile
3. Run `Set-StrictMode -Version 'Latest'` to activate the PowerShell Strict Mode
4. Start typing in the terminal and you should see VS Code-provided suggestions and no errors

I don't know if there are any related tests that I should update with this..?