### PR TITLE
Asymmetry in Memento API's JSON encoding/decoding (fix #209479)

### DIFF
--- a/src/vs/workbench/api/common/extHostMemento.ts
+++ b/src/vs/workbench/api/common/extHostMemento.ts
@@ -76,7 +76,15 @@ export class ExtensionMemento implements vscode.Memento {
 	}
 
 	update(key: string, value: any): Promise<void> {
-		this._value![key] = value;
+		if (value !== null && typeof value === 'object') {
+			// Prevent the value from being as-is for until we have
+			// received the change event from the main side by emulating
+			// the treatment of values via JSON parsing and stringifying.
+			// (https://github.com/microsoft/vscode/issues/209479)
+			this._value![key] = JSON.parse(JSON.stringify(value));
+		} else {
+			this._value![key] = value;
+		}
 
 		const record = this._deferredPromises.get(key);
 		if (record !== undefined) {


### PR DESCRIPTION
In my testing, we have 1 place to decide how to convert data between extension host and window:

https://github.com/microsoft/vscode/blob/1464a395ee5d59e95b8ee88c4d3d87718e21af0b/src/vs/workbench/services/extensions/common/rpcProtocol.ts#L734-L746

Since `VSBuffer` and `SerializableObjectWithBuffers` are types that extensions cannot use, we seem to always fallback to `JSON.stringify` and `JSON.parse`.

However, there is also a `replacer` in use for transforming URIs:

https://github.com/microsoft/vscode/blob/1464a395ee5d59e95b8ee88c4d3d87718e21af0b/src/vs/workbench/services/extensions/common/rpcProtocol.ts#L85-L95

But my understanding is that this replacer would still be in use and not be broken by this change, given we preserve the necessary `"$mid":1` when using `JSON.parse(JSON.stringify(...))`