### PR TITLE
add a setting to determine which terminal suggest providers are activated

### DIFF
--- a/src/vs/workbench/contrib/terminal/terminalContribExports.ts
+++ b/src/vs/workbench/contrib/terminal/terminalContribExports.ts
@@ -32,6 +32,7 @@ export const enum TerminalContribCommandId {
 export const enum TerminalContribSettingId {
 	SuggestEnabled = TerminalSuggestSettingId.Enabled,
 	StickyScrollEnabled = TerminalStickyScrollSettingId.Enabled,
+	SuggestProviders = TerminalSuggestSettingId.Providers
 }
 
 // Export configuration schemes from terminalContrib - this is an exception to the eslint rule since

--- a/src/vs/workbench/contrib/terminal/terminalContribExports.ts
+++ b/src/vs/workbench/contrib/terminal/terminalContribExports.ts
@@ -32,7 +32,6 @@ export const enum TerminalContribCommandId {
 export const enum TerminalContribSettingId {
 	SuggestEnabled = TerminalSuggestSettingId.Enabled,
 	StickyScrollEnabled = TerminalStickyScrollSettingId.Enabled,
-	SuggestProviders = TerminalSuggestSettingId.Providers
 }
 
 // Export configuration schemes from terminalContrib - this is an exception to the eslint rule since

--- a/src/vs/workbench/contrib/terminalContrib/suggest/browser/pwshCompletionProviderAddon.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/browser/pwshCompletionProviderAddon.ts
@@ -56,7 +56,7 @@ export class PwshCompletionProviderAddon extends Disposable implements ITerminal
 	id: string = PwshCompletionProviderAddon.ID;
 	triggerCharacters?: string[] | undefined;
 	isBuiltin?: boolean = true;
-	static readonly ID = 'terminal.pwshCompletionProvider';
+	static readonly ID = 'pwsh-shell-integration';
 	static cachedPwshCommands: Set<ITerminalCompletion>;
 	readonly shellTypes = [GeneralShellType.PowerShell];
 	private _codeCompletionsRequested: boolean = false;
@@ -348,7 +348,7 @@ function rawCompletionToITerminalCompletion(rawCompletion: PwshCompletion, repla
 
 	return {
 		label,
-		provider: 'pwsh-script',
+		provider: PwshCompletionProviderAddon.ID,
 		icon,
 		detail,
 		isFile: rawCompletion.ResultType === 3,

--- a/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminal.suggest.contribution.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminal.suggest.contribution.ts
@@ -112,7 +112,7 @@ class TerminalSuggestContribution extends DisposableStore implements ITerminalCo
 			this._ctx.instance.focus();
 			this._ctx.instance.sendText(text, false);
 		}));
-		this.add(this._terminalCompletionService.registerTerminalCompletionProvider('builtinPwsh', 'pwsh', pwshCompletionProviderAddon));
+		this.add(this._terminalCompletionService.registerTerminalCompletionProvider('builtinPwsh', pwshCompletionProviderAddon.id, pwshCompletionProviderAddon));
 		// If completions are requested, pause and queue input events until completions are
 		// received. This fixing some problems in PowerShell, particularly enter not executing
 		// when typing quickly and some characters being printed twice. On Windows this isn't
@@ -178,6 +178,11 @@ class TerminalSuggestContribution extends DisposableStore implements ITerminalCo
 			return;
 		}
 		addon.shellType = this._ctx.instance.shellType;
+		if (!this._ctx.instance.xterm?.raw) {
+			return;
+		}
+		// Relies on shell type being set
+		this._loadPwshCompletionAddon(this._ctx.instance.xterm.raw);
 	}
 }
 

--- a/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalCompletionService.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalCompletionService.ts
@@ -149,6 +149,7 @@ export class TerminalCompletionService extends Disposable implements ITerminalCo
 
 		if (!extensionCompletionsEnabled || skipExtensionCompletions) {
 			providers = providers.filter(p => p.isBuiltin);
+			return this._collectCompletions(providers, shellType, promptValue, cursorPosition, token);
 		}
 
 		const providerConfig: { [key: string]: boolean } = this._configurationService.getValue(TerminalSuggestSettingId.Providers);
@@ -156,6 +157,7 @@ export class TerminalCompletionService extends Disposable implements ITerminalCo
 			const providerId = p.id;
 			return providerId && providerId in providerConfig && providerConfig[providerId];
 		});
+
 		if (!providers.length) {
 			return;
 		}

--- a/src/vs/workbench/contrib/terminalContrib/suggest/common/terminalSuggestConfiguration.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/common/terminalSuggestConfiguration.ts
@@ -15,6 +15,7 @@ export const enum TerminalSuggestSettingId {
 	RunOnEnter = 'terminal.integrated.suggest.runOnEnter',
 	BuiltinCompletions = 'terminal.integrated.suggest.builtinCompletions',
 	EnableExtensionCompletions = 'terminal.integrated.suggest.enableExtensionCompletions',
+	Providers = 'terminal.integrated.suggest.providers',
 }
 
 export const terminalSuggestConfigSection = 'terminal.integrated.suggest';
@@ -37,6 +38,17 @@ export const terminalSuggestConfiguration: IStringDictionary<IConfigurationPrope
 		markdownDescription: localize('suggest.enabled', "Enables experimental terminal Intellisense suggestions for supported shells ({0}) when {1} is set to {2}.\n\nIf shell integration is installed manually, {3} needs to be set to {4} before calling the shell integration script. \n\nFor extension provided completions, {5} will also need to be set.", 'PowerShell v7+, zsh, bash, fish', `\`#${TerminalSettingId.ShellIntegrationEnabled}#\``, '`true`', '`VSCODE_SUGGEST`', '`1`', `\`#${TerminalSuggestSettingId.EnableExtensionCompletions}#\``),
 		type: 'boolean',
 		default: false,
+		tags: ['experimental'],
+	},
+	[TerminalSuggestSettingId.Providers]: {
+		restricted: true,
+		markdownDescription: localize('suggest.providers', "Controls which shell providers are enabled for terminal suggestions."),
+		type: 'object',
+		properties: {},
+		default: {
+			'terminal-suggest': false,
+			'pwsh-shell-integration': false,
+		},
 		tags: ['experimental'],
 	},
 	[TerminalSuggestSettingId.QuickSuggestions]: {

--- a/src/vs/workbench/contrib/terminalContrib/suggest/common/terminalSuggestConfiguration.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/common/terminalSuggestConfiguration.ts
@@ -29,6 +29,10 @@ export interface ITerminalSuggestConfiguration {
 		'pwshCode': boolean;
 		'pwshGit': boolean;
 	};
+	providers: {
+		'terminal-suggest': boolean;
+		'pwsh-shell-integration': boolean;
+	};
 	enableExtensionCompletions: boolean;
 }
 

--- a/src/vs/workbench/contrib/terminalContrib/suggest/common/terminalSuggestConfiguration.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/common/terminalSuggestConfiguration.ts
@@ -46,7 +46,7 @@ export const terminalSuggestConfiguration: IStringDictionary<IConfigurationPrope
 		type: 'object',
 		properties: {},
 		default: {
-			'terminal-suggest': false,
+			'terminal-suggest': true,
 			'pwsh-shell-integration': false,
 		},
 		tags: ['experimental'],

--- a/src/vs/workbench/contrib/terminalContrib/suggest/common/terminalSuggestConfiguration.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/common/terminalSuggestConfiguration.ts
@@ -97,7 +97,7 @@ export const terminalSuggestConfiguration: IStringDictionary<IConfigurationPrope
 	},
 	[TerminalSuggestSettingId.EnableExtensionCompletions]: {
 		restricted: true,
-		markdownDescription: localize('suggest.enableExtensionCompletions', "Controls whether extension completions are enabled."),
+		markdownDescription: localize('suggest.enableExtensionCompletions', "Controls whether extension completions are enabled. Also be aware of the {0}-setting which controls which providers are enabled.", `\`#${TerminalSuggestSettingId.Providers}#\``),
 		type: 'boolean',
 		default: false,
 		tags: ['experimental'],

--- a/src/vs/workbench/contrib/terminalContrib/suggest/common/terminalSuggestConfiguration.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/common/terminalSuggestConfiguration.ts
@@ -42,7 +42,7 @@ export const terminalSuggestConfiguration: IStringDictionary<IConfigurationPrope
 	},
 	[TerminalSuggestSettingId.Providers]: {
 		restricted: true,
-		markdownDescription: localize('suggest.providers', "Controls which shell providers are enabled for terminal suggestions."),
+		markdownDescription: localize('suggest.providers', "Controls which providers are enabled for terminal suggestions.  Also be aware of the {0}-setting which controls if extensions are able to provide suggestions.", `\`#${TerminalSuggestSettingId.EnableExtensionCompletions}#\``),
 		type: 'object',
 		properties: {},
 		default: {

--- a/src/vs/workbench/contrib/terminalContrib/suggest/test/browser/terminalSuggestAddon.integrationTest.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/test/browser/terminalSuggestAddon.integrationTest.ts
@@ -110,6 +110,10 @@ suite('Terminal Contrib Suggest Recordings', () => {
 						pwshCode: true,
 						pwshGit: true
 					},
+					providers: {
+						'terminal-suggest': true,
+						'pwsh-shell-integration': true,
+					},
 					enableExtensionCompletions: false
 				} satisfies ITerminalSuggestConfiguration
 			}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
fix #233442

Also gets builtin pwsh completions back to working - before, the addon wasn't getting loaded because shell type was undefined here 

https://github.com/microsoft/vscode/blob/61940a2ec97830fc2079ef97a4f4f955ec6100fa/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminal.suggest.contribution.ts#L94-L100

So now we also call that here

https://github.com/microsoft/vscode/blob/61940a2ec97830fc2079ef97a4f4f955ec6100fa/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminal.suggest.contribution.ts#L175-L186