### PR TITLE
fix: add key match score, revert contiguous search

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
@@ -1679,7 +1679,7 @@ export class SettingsEditor2 extends EditorPane {
 		for (const g of this.defaultSettingsEditorModel.settingsGroups.slice(1)) {
 			for (const sect of g.sections) {
 				for (const setting of sect.settings) {
-					fullResult.filterMatches.push({ setting, matches: [], matchType: SettingMatchType.None, score: 0 });
+					fullResult.filterMatches.push({ setting, matches: [], matchType: SettingMatchType.None, keyMatchSize: 0, score: 0 });
 				}
 			}
 		}

--- a/src/vs/workbench/contrib/preferences/browser/settingsTreeModels.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsTreeModels.ts
@@ -959,6 +959,10 @@ export class SearchResultModel extends SettingsTreeModel {
 				// Sort by match type if the match types are not the same.
 				// The priority of the match type is given by the SettingMatchType enum.
 				return b.matchType - a.matchType;
+			} else if (a.matchType === SettingMatchType.KeyMatch) {
+				// The match types are the same and are KeyMatch.
+				// Sort by the number of words matched in the key.
+				return b.keyMatchSize - a.keyMatchSize;
 			} else if (a.matchType === SettingMatchType.RemoteMatch) {
 				// The match types are the same and are RemoteMatch.
 				// Sort by score.

--- a/src/vs/workbench/services/preferences/common/preferences.ts
+++ b/src/vs/workbench/services/preferences/common/preferences.ts
@@ -138,13 +138,15 @@ export enum SettingMatchType {
 	LanguageTagSettingMatch = 1 << 0,
 	RemoteMatch = 1 << 1,
 	DescriptionOrValueMatch = 1 << 2,
-	KeyMatch = 1 << 3
+	KeyMatch = 1 << 3,
+	KeyIdMatch = 1 << 4,
 }
 
 export interface ISettingMatch {
 	setting: ISetting;
 	matches: IRange[] | null;
 	matchType: SettingMatchType;
+	keyMatchSize: number;
 	score: number;
 }
 
@@ -184,7 +186,7 @@ export interface IPreferencesEditorModel<T> {
 }
 
 export type IGroupFilter = (group: ISettingsGroup) => boolean | null;
-export type ISettingMatcher = (setting: ISetting, group: ISettingsGroup) => { matches: IRange[]; matchType: SettingMatchType; score: number } | null;
+export type ISettingMatcher = (setting: ISetting, group: ISettingsGroup) => { matches: IRange[]; matchType: SettingMatchType; keyMatchSize: number; score: number } | null;
 
 export interface ISettingsEditorModel extends IPreferencesEditorModel<ISetting> {
 	readonly onDidChangeGroups: Event<void>;

--- a/src/vs/workbench/services/preferences/common/preferencesModels.ts
+++ b/src/vs/workbench/services/preferences/common/preferencesModels.ts
@@ -71,6 +71,7 @@ abstract class AbstractSettingsModel extends EditorModel {
 							setting,
 							matches: settingMatchResult && settingMatchResult.matches,
 							matchType: settingMatchResult?.matchType ?? SettingMatchType.None,
+							keyMatchSize: settingMatchResult?.keyMatchSize ?? 0,
 							score: settingMatchResult?.score ?? 0
 						});
 					}
@@ -899,6 +900,7 @@ export class DefaultSettingsEditorModel extends AbstractSettingsModel implements
 					setting: filteredMatch.setting,
 					score: filteredMatch.score,
 					matchType: filteredMatch.matchType,
+					keyMatchSize: filteredMatch.keyMatchSize,
 					matches: filteredMatch.matches && filteredMatch.matches.map(match => {
 						return new Range(
 							match.startLineNumber - filteredMatch.setting.range.startLineNumber,


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Fixes https://github.com/microsoft/vscode/issues/203838
Fixes https://github.com/microsoft/vscode/issues/226039

The main issue was that we restricted the key matching algorithm to match contiguous strings only. Reverting the match back to non-contiguous searching matches more cases again. One side effect is there are now many more results with certain queries such as "editor formonpast", but I also added a new field that should prioritize better matches and help move them to the top of all the noise.

CC @jrieken. 