### PR TITLE
fix: workbench search use correct findMatch colors (fix #237909)

### DIFF
--- a/src/vs/workbench/contrib/search/browser/searchTreeModel/fileMatch.ts
+++ b/src/vs/workbench/contrib/search/browser/searchTreeModel/fileMatch.ts
@@ -30,6 +30,7 @@ export class FileMatchImpl extends Disposable implements ISearchTreeFileMatch {
 		stickiness: TrackedRangeStickiness.NeverGrowsWhenTypingAtEdges,
 		zIndex: 13,
 		className: 'currentFindMatch',
+		inlineClassName: 'currentFindMatchInline',
 		overviewRuler: {
 			color: themeColorFromId(overviewRulerFindMatchForeground),
 			position: OverviewRulerLane.Center
@@ -44,6 +45,7 @@ export class FileMatchImpl extends Disposable implements ISearchTreeFileMatch {
 		description: 'search-find-match',
 		stickiness: TrackedRangeStickiness.NeverGrowsWhenTypingAtEdges,
 		className: 'findMatch',
+		inlineClassName: 'findMatchInline',
 		overviewRuler: {
 			color: themeColorFromId(overviewRulerFindMatchForeground),
 			position: OverviewRulerLane.Center


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

## Motivation
Fixes: #237909

With this user configuration, find match text color are improperly rendered when using Workbench Search (not the widget search):
```json
    "workbench.colorCustomizations": {
        "editor.findMatchHighlightForeground": "#000000",
        "editor.findMatchHighlightBackground": "#ffffb4",
        "editor.findMatchForeground": "#000000",
        "editor.findMatchBackground": "#ff4cde"
    },
````

### Before fix:
![image](https://github.com/user-attachments/assets/428efe3c-3547-43fd-9ff6-2b8a22bb0b21)

### After fix:
![image](https://github.com/user-attachments/assets/a15c23af-c2ca-44e6-9bfc-7e2c448b1cce)

## Code changes
Add the `inlineClassName` field to the Workbench Search ModelDecorationOptions to properly render the `editor.findMatchForeground` and `editor.findMatchHighlightForeground` colors.

This field is copied directly from the ModelDecorationOptions in `src/vs/editor/contrib/find/browser/findDecorations.ts`, as the widget search properly renders the foreground colors.
https://github.com/microsoft/vscode/blob/37066ba9a9ead9175d059b35124942cde3a4ca82/src/vs/editor/contrib/find/browser/findDecorations.ts#L286-L318
