### PR TITLE
Fix: Ensure walkthrough button focus outline is not truncated

### DIFF
--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/media/gettingStarted.css
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/media/gettingStarted.css
@@ -666,6 +666,11 @@
 	outline-offset: -1px;
 }
 
+.monaco-workbench .part.editor > .content .gettingStartedContainer button:focus-visible .category-progress {
+	bottom: 1px;
+	width: 99%;
+}
+
 .monaco-workbench .part.editor > .content .gettingStartedContainer .prev-button.button-link {
 	position: absolute;
 	left: 40px;


### PR DESCRIPTION
## Resolves
This pull request resolves issue #188711.

## Description
The outline that appears when the walkthrough button is focused had an `outline-offset` of `-1`, causing it to appear inside the element. As a result, the progress bar at the bottom of the button blocked the outline, making it invisible in some cases. [https://github.com/microsoft/vscode/blob/35b2db3ed14f4949a53de4ab972b8714d7321f7f/src/vs/workbench/contrib/welcomeGettingStarted/browser/media/gettingStarted.css#L673-L676](https://github.com/microsoft/vscode/blob/35b2db3ed14f4949a53de4ab972b8714d7321f7f/src/vs/workbench/contrib/welcomeGettingStarted/browser/media/gettingStarted.css#L673-L676)

To fix this, I slightly reduced the width of the progress bar and shifted it up by 1px, but only when the button is focused on. This ensures that the focus outline remains visible without being obscured by the progress bar.

![dark_mode_large_walkthrough_button_issue_resolved](https://github.com/user-attachments/assets/005e76c5-54a7-425e-8eef-912642aae2d1)
![light_mode_small_walkthrough_button_issue_resolved](https://github.com/user-attachments/assets/fdba31fc-1a40-4755-a057-11f76c8b72f2)
