### PR TITLE
Disable pointer events for NES control to allow word selection

### DIFF
--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/wordReplacementView.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/wordReplacementView.ts
@@ -120,6 +120,7 @@ export class WordReplacementView extends Disposable {
 						borderRadius: '4px',
 						boxSizing: 'border-box',
 						background: 'var(--vscode-inlineEdit-originalChangedTextBackground)',
+						pointerEvents: 'none',
 					}
 				}, []),
 				n.div({
@@ -131,6 +132,7 @@ export class WordReplacementView extends Disposable {
 						border: '1px solid var(--vscode-editorHoverWidget-border)',
 						//background: 'rgba(122, 122, 122, 0.12)', looks better
 						background: 'var(--vscode-inlineEdit-wordReplacementView-background)',
+						pointerEvents: 'none',
 					}
 				}, []),
 


### PR DESCRIPTION
Prevent the NES control from interfering with double-click selection of words by disabling pointer events. 

Fixes microsoft/vscode-copilot#11649