### PR TITLE
Fix tooltip for close button in dialog box

### DIFF
--- a/src/vs/base/browser/ui/dialog/dialog.css
+++ b/src/vs/base/browser/ui/dialog/dialog.css
@@ -153,3 +153,8 @@
 	margin: 4px 5px; /* allows button focus outline to be visible */
 	outline-offset: 2px !important;
 }
+
+/** Tooltip: Ensure tooltip is displayed above the dialog */
+.monaco-dialog-box .tooltip {
+	z-index: 2700;
+}

--- a/src/vs/base/browser/ui/dialog/dialog.ts
+++ b/src/vs/base/browser/ui/dialog/dialog.ts
@@ -434,6 +434,10 @@ export class Dialog extends Disposable {
 				}));
 
 				actionBar.push(action, { icon: true, label: false });
+
+				// Add tooltip to close button
+				const closeButton = actionBar.viewItems[0].element;
+				closeButton.title = nls.localize('dialogClose', "Close Dialog");
 			}
 
 			this.applyStyles();


### PR DESCRIPTION
Fixes #237947

Fix tooltip visibility for close button in dialog box.

* Add CSS rule in `src/vs/base/browser/ui/dialog/dialog.css` to set `z-index` of tooltip higher than dialog box.
* Update `src/vs/base/browser/ui/dialog/dialog.ts` to add tooltip to close button.

