### PR TITLE
 fix Issue #237947: Tooltip for Close Button in Dialog Box is Obscure…

### DIFF
--- a/src/vs/editor/browser/services/hoverService/hoverService.ts
+++ b/src/vs/editor/browser/services/hoverService/hoverService.ts
@@ -477,8 +477,9 @@ function getHoverOptionsIdentity(options: IHoverOptions | undefined): IHoverOpti
 
 class HoverContextViewDelegate implements IDelegate {
 
-	// Render over all other context views
-	public readonly layer = 1;
+	// Render over all other context views and dialogs
+	// Set the layer to 26 to fix the issue https://github.com/microsoft/vscode/issues/237947
+	public readonly layer = 26;
 
 	get anchorPosition() {
 		return this._hover.anchor;


### PR DESCRIPTION
This PR fixes Issue #237947: Tooltip for Close Button in Dialog Box is Obscured by the Dialog Itself

## Overview

In `dialog.css`, the z-index of the dialog modal box is set to 2600:

```css
/** Dialog: Modal Block */
.monaco-dialog-modal-block {
	position: fixed;
	height: 100%;
	width: 100%;
	left:0;
	top:0;
	z-index: 2600;
	display: flex;
	justify-content: center;
	align-items: center;
}
```

The tooltip is implemented by the contextView, and its z-index is dynamically assigned by JavaScript rather than being statically defined in CSS:

```typescript
//src\vs\base\browser\ui\contextview\contextview.ts
this.view.style.zIndex = `${2575 + (delegate.layer ?? 0)}`;
```

For tooltips (i.e., hover), its layer is specified by `HoverContextViewDelegate` as 1, so this JavaScript code above calculates its z-index as 2576, which is lower than the z-index of the dialog mentioned earlier, causing it to be obscured.

## Changes

Modified the `HoverContextViewDelegate` class in `src\vs\base\browser\ui\contextview\contextview.ts` to change its layer to 26.

## Testing

I have used my own TypeScript project to test out this feature.

Before this fix:
<img width="146" alt="Snipaste_2025-01-14_22-04-30" src="https://github.com/user-attachments/assets/580f0ea9-41b0-48ed-b0ff-fb1c43017075" />


After this fix:
<img width="145" alt="Snipaste_2025-01-14_22-10-27" src="https://github.com/user-attachments/assets/80d6cb77-cdb0-4176-9b7e-5022400a6905" />

