### PR TITLE
Fix codicon sizing in rendered chat markdown

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/media/chat.css
@@ -200,6 +200,10 @@
 	margin-bottom: 8px;
 }
 
+.interactive-item-container .value .rendered-markdown .codicon {
+	font-size: inherit;
+}
+
 .interactive-item-container .value .rendered-markdown blockquote {
 	margin: 0px;
 	padding: 0px 16px 0 10px;


### PR DESCRIPTION
The codicon is currently rendered at a fixed size instead of adapting the the actual text size

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
