### PR TITLE
Include checking for `github-enterprise`

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatSetup.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSetup.ts
@@ -69,7 +69,7 @@ const defaultChat = {
 	skusDocumentationUrl: product.defaultChatAgent?.skusDocumentationUrl ?? '',
 	publicCodeMatchesUrl: product.defaultChatAgent?.publicCodeMatchesUrl ?? '',
 	upgradePlanUrl: product.defaultChatAgent?.upgradePlanUrl ?? '',
-	providerId: product.defaultChatAgent?.providerId ?? '',
+	providerIds: [product.defaultChatAgent?.providerId ?? '', 'github-enterprise'],
 	providerName: product.defaultChatAgent?.providerName ?? '',
 	providerScopes: product.defaultChatAgent?.providerScopes ?? [[]],
 	entitlementUrl: product.defaultChatAgent?.entitlementUrl ?? '',
@@ -379,19 +379,19 @@ class ChatSetupRequests extends Disposable {
 		this._register(this.authenticationService.onDidChangeDeclaredProviders(() => this.resolve()));
 
 		this._register(this.authenticationService.onDidChangeSessions(e => {
-			if (e.providerId === defaultChat.providerId) {
+			if (defaultChat.providerIds.includes(e.providerId)) {
 				this.resolve();
 			}
 		}));
 
 		this._register(this.authenticationService.onDidRegisterAuthenticationProvider(e => {
-			if (e.id === defaultChat.providerId) {
+			if (defaultChat.providerIds.includes(e.id)) {
 				this.resolve();
 			}
 		}));
 
 		this._register(this.authenticationService.onDidUnregisterAuthenticationProvider(e => {
-			if (e.id === defaultChat.providerId) {
+			if (defaultChat.providerIds.includes(e.id)) {
 				this.resolve();
 			}
 		}));
@@ -438,9 +438,15 @@ class ChatSetupRequests extends Disposable {
 	}
 
 	private async findMatchingProviderSession(token: CancellationToken): Promise<AuthenticationSession | undefined> {
-		const sessions = await this.authenticationService.getSessions(defaultChat.providerId);
-		if (token.isCancellationRequested) {
-			return undefined;
+		let sessions: ReadonlyArray<AuthenticationSession> = [];
+		for (const providerId of defaultChat.providerIds) {
+			if (token.isCancellationRequested) {
+				return undefined;
+			}
+			sessions = await this.authenticationService.getSessions(providerId);
+			if (sessions.length) {
+				break;
+			}
 		}
 
 		for (const session of sessions) {
@@ -787,7 +793,7 @@ class ChatSetupController extends Disposable {
 			}
 
 			if (!session) {
-				session = (await this.authenticationService.getSessions(defaultChat.providerId)).at(0);
+				session = (await this.authenticationService.getSessions(defaultChat.providerIds[0])).at(0);
 				if (!session) {
 					return; // unexpected
 				}
@@ -817,7 +823,7 @@ class ChatSetupController extends Disposable {
 		try {
 			showCopilotView(this.viewsService, this.layoutService);
 
-			session = await this.authenticationService.createSession(defaultChat.providerId, defaultChat.providerScopes[0]);
+			session = await this.authenticationService.createSession(defaultChat.providerIds[0], defaultChat.providerScopes[0]);
 			entitlement = await this.requests.forceResolveEntitlement(session);
 		} catch (error) {
 			// noop


### PR DESCRIPTION
So that we hide the setup view for GHE.com users after they install Copilot & sign in.

Note: this behavior still isn't great if they haven't yet installed Copilot, but to keep this candidate small, we're just focused on fixing the case for when they have Copilot installed already.

cc @bpasero 

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
