### PR TITLE
Support nb cell Inline Values after cell execution

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/contrib/notebookVariables/notebookInlineVariables.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/notebookVariables/notebookInlineVariables.ts
@@ -1,0 +1,367 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { CancellationToken } from '../../../../../../base/common/cancellation.js';
+import { onUnexpectedExternalError } from '../../../../../../base/common/errors.js';
+import { Disposable, IDisposable } from '../../../../../../base/common/lifecycle.js';
+import { ResourceMap } from '../../../../../../base/common/map.js';
+import { format, noBreakWhitespace } from '../../../../../../base/common/strings.js';
+import { Constants } from '../../../../../../base/common/uint.js';
+import { Range } from '../../../../../../editor/common/core/range.js';
+import { InlineValueContext, InlineValueExpression, InlineValueText, InlineValueVariableLookup } from '../../../../../../editor/common/languages.js';
+import { IModelDeltaDecoration, InjectedTextCursorStops } from '../../../../../../editor/common/model.js';
+import { ILanguageFeaturesService } from '../../../../../../editor/common/services/languageFeatures.js';
+import { localize } from '../../../../../../nls.js';
+import { registerAction2 } from '../../../../../../platform/actions/common/actions.js';
+import { IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
+import { ServicesAccessor } from '../../../../../../platform/instantiation/common/instantiation.js';
+import { IDebugService } from '../../../../debug/common/debug.js';
+import { Expression } from '../../../../debug/common/debugModel.js';
+import { NotebookSetting } from '../../../common/notebookCommon.js';
+import { ICellExecutionStateChangedEvent, INotebookExecutionStateService } from '../../../common/notebookExecutionStateService.js';
+import { INotebookKernelMatchResult, INotebookKernelService, VariablesResult } from '../../../common/notebookKernelService.js';
+import { INotebookActionContext, NotebookAction } from '../../controller/coreActions.js';
+import { ICellViewModel, INotebookEditor, INotebookEditorContribution } from '../../notebookBrowser.js';
+import { registerNotebookContribution } from '../../notebookEditorExtensions.js';
+
+// value from debug, may need to keep an eye on and shorter to account for cells having a narrower viewport width
+const MAX_INLINE_DECORATOR_LENGTH = 150; // Max string length of each inline decorator. If exceeded ... is added
+
+const variableRegex = new RegExp(
+	'(?:[a-zA-Z_][a-zA-Z0-9_]*\\.)*' + //match any number of variable names separated by '.'
+	'[a-zA-Z_][a-zA-Z0-9_]*', //math variable name
+	'g',
+);
+
+class InlineSegment {
+	constructor(public column: number, public text: string) {
+	}
+}
+
+export class NotebookInlineVariablesController extends Disposable implements INotebookEditorContribution {
+
+	static readonly id: string = 'notebook.inlineVariablesController';
+
+	private cellDecorationIds = new Map<ICellViewModel, string[]>();
+	private cellContentListeners = new ResourceMap<IDisposable>();
+
+	constructor(
+		private readonly notebookEditor: INotebookEditor,
+		@INotebookKernelService private readonly notebookKernelService: INotebookKernelService,
+		@INotebookExecutionStateService private readonly notebookExecutionStateService: INotebookExecutionStateService,
+		@ILanguageFeaturesService private readonly languageFeaturesService: ILanguageFeaturesService,
+		@IConfigurationService private readonly configurationService: IConfigurationService,
+		@IDebugService private readonly debugService: IDebugService,
+	) {
+		super();
+
+		this._register(this.notebookExecutionStateService.onDidChangeExecution(async e => {
+			if (!this.configurationService.getValue<boolean>(NotebookSetting.notebookInlineVariables)) {
+				return;
+			}
+
+			if (this.isCellExecutionStateChangedEvent(e)) {
+				await this.updateInlineVariables(e);
+			}
+		}));
+
+		// !not necessary, only clearing on cell content changes that have deco's
+		// this._register(this.notebookEditor.onDidChangeModel(e => {
+		// 	if (e) {
+		// 		this.notebookTextModel = e;
+		// 		this.clearNotebookInlineDecorations();
+
+		// 	} else {
+		// 		this.notebookTextModel = undefined;
+		// 		this.cellContentListener.clear();
+		// 	}
+		// }));
+	}
+
+	private async updateInlineVariables(event: ICellExecutionStateChangedEvent): Promise<void> {
+		if (this.debugService.state !== 0) { // debug session is a state other than inactive, so clear and defer to whatever it's handling
+			this._clearNotebookInlineDecorations();
+			return;
+		}
+
+		if (this.notebookEditor.textModel?.uri !== event.notebook) {
+			return;
+		}
+
+		if (event.changed) { // undefined -> execution was completed, so return on all else
+			return;
+		}
+
+		const cell = this.notebookEditor.getCellByHandle(event.cellHandle);
+		if (!cell || cell.language !== 'python') { // TODO: support more than just python
+			return;
+		}
+		const model = cell.textModel;
+		if (!model) {
+			return;
+		}
+
+		this.clearCellInlineDecorations(cell);
+		const inlineDecorations: IModelDeltaDecoration[] = [];
+
+
+		// might need to be a new provider registry, since we will have these that don't necessarily provide at the right timing
+		if (this.languageFeaturesService.inlineValuesProvider.has(model)) {
+			// use extension based provider, borrowed from https://github.com/microsoft/vscode/blob/main/src/vs/workbench/contrib/debug/browser/debugEditorContribution.ts#L679
+			const lastLine = model.getLineCount();
+			const lastColumn = model.getLineMaxColumn(lastLine);
+			const ctx: InlineValueContext = {
+				frameId: 0, // ignored, we won't have a stack from since not in a debug session
+				stoppedLocation: new Range(lastLine, lastColumn, lastLine, lastColumn) // executing cell by cell, so "stopped" location would just be the end of document
+			};
+
+			const providers = this.languageFeaturesService.inlineValuesProvider.ordered(model).reverse();
+			const lineDecorations = new Map<number, InlineSegment[]>();
+
+			const fullCellRange = new Range(1, 1, lastLine, lastColumn);
+
+			const promises = providers.flatMap(provider => Promise.resolve(provider.provideInlineValues(model, fullCellRange, ctx, CancellationToken.None)).then(async (result) => {
+				if (result) {
+
+					let kernel: INotebookKernelMatchResult;
+					const kernelVars: VariablesResult[] = [];
+					if (result.some(iv => iv.type === 'variable')) { // if anyone will need a lookup, get vars now to avoid needing to do it multiple times
+						if (!this.notebookEditor.textModel) {
+							return; // should not happen, a cell will be executed
+						}
+						kernel = this.notebookKernelService.getMatchingKernel(this.notebookEditor.textModel);
+						const variables = kernel?.selected?.provideVariables(event.notebook, undefined, 'named', 0, CancellationToken.None);
+						if (!variables) {
+							return;
+						}
+						for await (const v of variables) {
+							kernelVars.push(v);
+						}
+					}
+
+					for (const iv of result) {
+						let text: string | undefined = undefined;
+						switch (iv.type) {
+							case 'text':
+								text = (iv as InlineValueText).text;
+								break;
+							case 'variable': {
+								const name = (iv as InlineValueVariableLookup).variableName;
+								if (!name) {
+									continue; // skip to next var, no valid name to lookup with
+								}
+								const value = kernelVars.find(v => v.name === name)?.value;
+								if (!value) {
+									continue;
+								}
+								text = format('{0} = {1}', name, value);
+							}
+							case 'expression': {
+								let expr = (iv as InlineValueExpression).expression;
+								if (!expr) {
+									const lineContent = model.getLineContent(iv.range.startLineNumber);
+									expr = lineContent.substring(iv.range.startColumn - 1, iv.range.endColumn - 1);
+								}
+								if (expr) {
+									const expression = new Expression(expr);
+									await expression.evaluate(undefined, undefined, 'watch', true);
+									if (expression.available) {
+										text = format('{0} = {1}', expr, expression.value);
+									}
+								}
+								break;
+							}
+						}
+
+						if (text) {
+							const line = iv.range.startLineNumber;
+							let lineSegments = lineDecorations.get(line);
+							if (!lineSegments) {
+								lineSegments = [];
+								lineDecorations.set(line, lineSegments);
+							}
+							if (!lineSegments.some(iv => iv.text === text)) { // de-dupe
+								lineSegments.push(new InlineSegment(iv.range.startColumn, text));
+							}
+						}
+					}
+				}
+			}, err => {
+				onUnexpectedExternalError(err);
+			}));
+
+			await Promise.all(promises);
+
+			// sort line segments and concatenate them into a decoration
+			lineDecorations.forEach((segments, line) => {
+				if (segments.length > 0) {
+					segments = segments.sort((a, b) => a.column - b.column);
+					const text = segments.map(s => s.text).join(', ');
+					inlineDecorations.push(...this.createNotebookInlineValueDecoration(line, text));
+
+				}
+			});
+
+
+		} else { // generic regex matching approach
+			const kernel = this.notebookKernelService.getMatchingKernel(this.notebookEditor.textModel);
+			const variables = kernel?.selected?.provideVariables(event.notebook, undefined, 'named', 0, CancellationToken.None);
+			if (!variables) {
+				return;
+			}
+
+			const vars: VariablesResult[] = [];
+			for await (const v of variables) {
+				vars.push(v);
+			}
+			const varNames: string[] = vars.map(v => v.name);
+
+			const document = cell.textModel;
+			if (!document) {
+				return;
+			}
+
+			for (let i = 1; i <= document.getLineCount(); i++) {
+				const line = document.getLineContent(i);
+
+				if (line.trimStart().startsWith('#')) {
+					continue;
+				}
+				for (let match = variableRegex.exec(line); match; match = variableRegex.exec(line)) {
+					const name = match[0];
+					if (varNames.includes(name)) {
+						const inlineVal = name + ' = ' + vars.find(v => v.name === name)?.value;
+						inlineDecorations.push(...this.createNotebookInlineValueDecoration(i, inlineVal));
+					}
+				}
+			}
+		}
+
+		if (inlineDecorations.length > 0) {
+			this.updateCellInlineDecorations(cell, inlineDecorations);
+			this.initCellContentListener(cell);
+		}
+	}
+
+	private updateCellInlineDecorations(cell: ICellViewModel, decorations: IModelDeltaDecoration[]) {
+		const oldDecorations = this.cellDecorationIds.get(cell) ?? [];
+		this.cellDecorationIds.set(cell, cell.deltaModelDecorations(
+			oldDecorations,
+			decorations
+		));
+	}
+
+	private initCellContentListener(cell: ICellViewModel) {
+		const cellModel = cell.textModel;
+		if (!cellModel) {
+			return; // should not happen
+		}
+
+		this.cellContentListeners.set(cell.uri, cellModel.onDidChangeContent(() => {
+			this.clearCellInlineDecorations(cell);
+		}));
+	}
+
+	private clearCellInlineDecorations(cell: ICellViewModel) {
+		const cellDecorations = this.cellDecorationIds.get(cell) ?? [];
+		if (cellDecorations) {
+			cell.deltaModelDecorations(cellDecorations, []);
+			this.cellDecorationIds.delete(cell);
+		}
+
+		const listener = this.cellContentListeners.get(cell.uri);
+		if (listener) {
+			listener.dispose();
+			this.cellContentListeners.delete(cell.uri);
+		}
+	}
+
+	private _clearNotebookInlineDecorations() {
+		this.cellDecorationIds.forEach((_, cell) => {
+			this.clearCellInlineDecorations(cell);
+		});
+	}
+
+	public clearNotebookInlineDecorations() {
+		this._clearNotebookInlineDecorations();
+	}
+
+	private isCellExecutionStateChangedEvent(e: any): e is ICellExecutionStateChangedEvent {
+		return 'cellHandle' in e;
+	}
+
+	// taken from /src/vs/workbench/contrib/debug/browser/debugEditorContribution.ts
+	private createNotebookInlineValueDecoration(lineNumber: number, contentText: string, column = Constants.MAX_SAFE_SMALL_INTEGER): IModelDeltaDecoration[] {
+		// If decoratorText is too long, trim and add ellipses. This could happen for minified files with everything on a single line
+		if (contentText.length > MAX_INLINE_DECORATOR_LENGTH) {
+			contentText = contentText.substring(0, MAX_INLINE_DECORATOR_LENGTH) + '...';
+		}
+
+		return [
+			{
+				range: {
+					startLineNumber: lineNumber,
+					endLineNumber: lineNumber,
+					startColumn: column,
+					endColumn: column
+				},
+				options: {
+					description: 'nb-inline-value-decoration-spacer',
+					after: {
+						content: noBreakWhitespace,
+						cursorStops: InjectedTextCursorStops.None
+					},
+					showIfCollapsed: true,
+				}
+			},
+			{
+				range: {
+					startLineNumber: lineNumber,
+					endLineNumber: lineNumber,
+					startColumn: column,
+					endColumn: column
+				},
+				options: {
+					description: 'nb-inline-value-decoration',
+					after: {
+						content: this.replaceWsWithNoBreakWs(contentText),
+						inlineClassName: 'nb-inline-value',
+						inlineClassNameAffectsLetterSpacing: true,
+						cursorStops: InjectedTextCursorStops.None
+					},
+					showIfCollapsed: true,
+				}
+			},
+		];
+	}
+
+	private replaceWsWithNoBreakWs(str: string): string {
+		return str.replace(/[ \t]/g, noBreakWhitespace);
+	}
+
+	override dispose(): void {
+		super.dispose();
+	}
+}
+
+
+registerNotebookContribution(NotebookInlineVariablesController.id, NotebookInlineVariablesController);
+
+registerAction2(class ClearNotebookInlineValues extends NotebookAction {
+	constructor() {
+		super({
+			id: 'notebook.clearAllInlineValues',
+			title: localize('clearAllInlineValues', 'Clear All Inline Values'),
+		});
+	}
+
+	override runWithContext(accessor: ServicesAccessor, context: INotebookActionContext): Promise<void> {
+		const editor = context.notebookEditor;
+		const controller = editor.getContribution<NotebookInlineVariablesController>(NotebookInlineVariablesController.id);
+		controller.clearNotebookInlineDecorations();
+		return Promise.resolve();
+	}
+
+});

--- a/src/vs/workbench/contrib/notebook/browser/contrib/notebookVariables/notebookInlineVariables.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/notebookVariables/notebookInlineVariables.ts
@@ -66,18 +66,6 @@ export class NotebookInlineVariablesController extends Disposable implements INo
 				await this.updateInlineVariables(e);
 			}
 		}));
-
-		// !not necessary, only clearing on cell content changes that have deco's
-		// this._register(this.notebookEditor.onDidChangeModel(e => {
-		// 	if (e) {
-		// 		this.notebookTextModel = e;
-		// 		this.clearNotebookInlineDecorations();
-
-		// 	} else {
-		// 		this.notebookTextModel = undefined;
-		// 		this.cellContentListener.clear();
-		// 	}
-		// }));
 	}
 
 	private async updateInlineVariables(event: ICellExecutionStateChangedEvent): Promise<void> {
@@ -343,6 +331,7 @@ export class NotebookInlineVariablesController extends Disposable implements INo
 
 	override dispose(): void {
 		super.dispose();
+		this._clearNotebookInlineDecorations();
 	}
 }
 

--- a/src/vs/workbench/contrib/notebook/browser/controller/editActions.ts
+++ b/src/vs/workbench/contrib/notebook/browser/controller/editActions.ts
@@ -40,6 +40,7 @@ import { INotebookKernelService } from '../../common/notebookKernelService.js';
 import { ICellRange } from '../../common/notebookRange.js';
 import { IEditorService } from '../../../../services/editor/common/editorService.js';
 import { ILanguageDetectionService } from '../../../../services/languageDetection/common/languageDetectionWorkerService.js';
+import { NotebookInlineVariablesController } from '../contrib/notebookVariables/notebookInlineVariables.js';
 
 const CLEAR_ALL_CELLS_OUTPUTS_COMMAND_ID = 'notebook.clearAllCellsOutputs';
 const EDIT_CELL_COMMAND_ID = 'notebook.cell.edit';
@@ -338,6 +339,9 @@ registerAction2(class ClearAllCellOutputsAction extends NotebookAction {
 		if (clearExecutionMetadataEdits.length) {
 			context.notebookEditor.textModel.applyEdits(clearExecutionMetadataEdits, true, undefined, () => undefined, undefined, computeUndoRedo);
 		}
+
+		const controller = editor.getContribution<NotebookInlineVariablesController>(NotebookInlineVariablesController.id);
+		controller.clearNotebookInlineDecorations();
 	}
 });
 

--- a/src/vs/workbench/contrib/notebook/browser/media/notebook.css
+++ b/src/vs/workbench/contrib/notebook/browser/media/notebook.css
@@ -449,6 +449,13 @@
 	background-color: var(--vscode-notebook-symbolHighlightBackground) !important;
 }
 
+/** Cell execution inline vars */
+.nb-inline-value {
+	background-color: var(--vscode-editorInlayHint-background);
+	color: var(--vscode-editorInlayHint-foreground) !important;
+	font-size: 90%;
+}
+
 /** Notebook Textual Selection Highlight */
 .nb-selection-highlight {
 	background-color: var(--vscode-editor-selectionBackground);

--- a/src/vs/workbench/contrib/notebook/browser/notebook.contribution.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebook.contribution.ts
@@ -1236,8 +1236,8 @@ configurationRegistry.registerConfiguration({
 			type: 'boolean',
 			default: false
 		},
-		[NotebookSetting.notebookInlineVariables]: {
-			markdownDescription: nls.localize('notebook.inlineVariables.description', "Enable the showing of inline variables within notebook code cells after cell execution. Values will remain until the cell is edited, re-executed, or explicitly cleared via the Clear All Outputs toolbar button or the `Notebook: Clear Inline Values` command. "),
+		[NotebookSetting.notebookInlineValues]: {
+			markdownDescription: nls.localize('notebook.inlineValues.description', "Enable the showing of inline values within notebook code cells after cell execution. Values will remain until the cell is edited, re-executed, or explicitly cleared via the Clear All Outputs toolbar button or the `Notebook: Clear Inline Values` command. "),
 			type: 'boolean',
 			default: false
 		},

--- a/src/vs/workbench/contrib/notebook/browser/notebook.contribution.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebook.contribution.ts
@@ -100,6 +100,7 @@ import './contrib/kernelDetection/notebookKernelDetection.js';
 import './contrib/cellDiagnostics/cellDiagnostics.js';
 import './contrib/multicursor/notebookMulticursor.js';
 import './contrib/multicursor/notebookSelectionHighlight.js';
+import './contrib/notebookVariables/notebookInlineVariables.js';
 
 // Diff Editor Contribution
 import './diff/notebookDiffActions.js';
@@ -1232,6 +1233,11 @@ configurationRegistry.registerConfiguration({
 		},
 		[NotebookSetting.notebookVariablesView]: {
 			markdownDescription: nls.localize('notebook.VariablesView.description', "Enable the experimental notebook variables view within the debug panel."),
+			type: 'boolean',
+			default: false
+		},
+		[NotebookSetting.notebookInlineVariables]: {
+			markdownDescription: nls.localize('notebook.inlineVariables.description', "Enable the showing of inline variables within notebook code cells after cell execution. Values will remain until the cell is edited, re-executed, or explicitly cleared with the `Notebook: Clear Inline Values` command. "),
 			type: 'boolean',
 			default: false
 		},

--- a/src/vs/workbench/contrib/notebook/browser/notebook.contribution.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebook.contribution.ts
@@ -1237,7 +1237,7 @@ configurationRegistry.registerConfiguration({
 			default: false
 		},
 		[NotebookSetting.notebookInlineVariables]: {
-			markdownDescription: nls.localize('notebook.inlineVariables.description', "Enable the showing of inline variables within notebook code cells after cell execution. Values will remain until the cell is edited, re-executed, or explicitly cleared with the `Notebook: Clear Inline Values` command. "),
+			markdownDescription: nls.localize('notebook.inlineVariables.description', "Enable the showing of inline variables within notebook code cells after cell execution. Values will remain until the cell is edited, re-executed, or explicitly cleared via the Clear All Outputs toolbar button or the `Notebook: Clear Inline Values` command. "),
 			type: 'boolean',
 			default: false
 		},

--- a/src/vs/workbench/contrib/notebook/common/notebookCommon.ts
+++ b/src/vs/workbench/contrib/notebook/common/notebookCommon.ts
@@ -1029,7 +1029,7 @@ export const NotebookSetting = {
 	cellChat: 'notebook.experimental.cellChat',
 	cellGenerate: 'notebook.experimental.generate',
 	notebookVariablesView: 'notebook.variablesView',
-	notebookInlineVariables: 'notebook.inlineVariables',
+	notebookInlineValues: 'notebook.inlineValues',
 	InteractiveWindowPromptToSave: 'interactiveWindow.promptToSaveOnClose',
 	cellFailureDiagnostics: 'notebook.cellFailureDiagnostics',
 	outputBackupSizeLimit: 'notebook.backup.sizeLimit',

--- a/src/vs/workbench/contrib/notebook/common/notebookCommon.ts
+++ b/src/vs/workbench/contrib/notebook/common/notebookCommon.ts
@@ -1029,6 +1029,7 @@ export const NotebookSetting = {
 	cellChat: 'notebook.experimental.cellChat',
 	cellGenerate: 'notebook.experimental.generate',
 	notebookVariablesView: 'notebook.variablesView',
+	notebookInlineVariables: 'notebook.inlineVariables',
 	InteractiveWindowPromptToSave: 'interactiveWindow.promptToSaveOnClose',
 	cellFailureDiagnostics: 'notebook.cellFailureDiagnostics',
 	outputBackupSizeLimit: 'notebook.backup.sizeLimit',


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Fixes: #237263

Adds support for inline vars after cell execution in notebooks. Extensions can use the `InlineValuesProvider` class to contribute providers that will give more intelligent results.
