### PR TITLE
chat: prototype of choices API for response stream

### DIFF
--- a/src/vs/workbench/api/common/extHost.api.impl.ts
+++ b/src/vs/workbench/api/common/extHost.api.impl.ts
@@ -1774,6 +1774,7 @@ export function createApiFactoryAndRegisterActors(accessor: ServicesAccessor): I
 			ChatResponseWarningPart: extHostTypes.ChatResponseWarningPart,
 			ChatResponseTextEditPart: extHostTypes.ChatResponseTextEditPart,
 			ChatResponseMarkdownWithVulnerabilitiesPart: extHostTypes.ChatResponseMarkdownWithVulnerabilitiesPart,
+			ChatResponseChoicesPart: extHostTypes.ChatResponseChoicesPart,
 			ChatResponseCommandButtonPart: extHostTypes.ChatResponseCommandButtonPart,
 			ChatResponseDetectedParticipantPart: extHostTypes.ChatResponseDetectedParticipantPart,
 			ChatResponseConfirmationPart: extHostTypes.ChatResponseConfirmationPart,

--- a/src/vs/workbench/api/common/extHostChatAgents2.ts
+++ b/src/vs/workbench/api/common/extHostChatAgents2.ts
@@ -242,6 +242,17 @@ class ChatAgentResponseStream {
 					_report(dto);
 					return this;
 				},
+				choices(titleOrOpts: string | vscode.ChatChoicesOptions, ...items: (string | vscode.ChatResponseChoice)[]) {
+					throwIfDone(this.choices);
+					checkProposedApiEnabled(that._extension, 'chatParticipantAdditions');
+
+					const part = typeof titleOrOpts === 'string'
+						? new extHostTypes.ChatResponseChoicesPart(titleOrOpts, items[0] as string, items.slice(1))
+						: new extHostTypes.ChatResponseChoicesPart(titleOrOpts.title, titleOrOpts.message, items, titleOrOpts.disableAfterUse);
+
+					const dto = typeConvert.ChatResponseChoicesPart.from(part);
+					_report(dto);
+				},
 				push(part) {
 					throwIfDone(this.push);
 
@@ -253,7 +264,8 @@ class ChatAgentResponseStream {
 						part instanceof extHostTypes.ChatResponseConfirmationPart ||
 						part instanceof extHostTypes.ChatResponseCodeCitationPart ||
 						part instanceof extHostTypes.ChatResponseMovePart ||
-						part instanceof extHostTypes.ChatResponseProgressPart2
+						part instanceof extHostTypes.ChatResponseProgressPart2 ||
+						part instanceof extHostTypes.ChatResponseChoicesPart
 					) {
 						checkProposedApiEnabled(that._extension, 'chatParticipantAdditions');
 					}

--- a/src/vs/workbench/api/common/extHostTypeConverters.ts
+++ b/src/vs/workbench/api/common/extHostTypeConverters.ts
@@ -38,7 +38,7 @@ import { DEFAULT_EDITOR_ASSOCIATION, SaveReason } from '../../common/editor.js';
 import { IViewBadge } from '../../common/views.js';
 import { ChatAgentLocation, IChatAgentRequest, IChatAgentResult } from '../../contrib/chat/common/chatAgents.js';
 import { IChatRequestVariableEntry } from '../../contrib/chat/common/chatModel.js';
-import { IChatAgentDetection, IChatAgentMarkdownContentWithVulnerability, IChatCodeCitation, IChatCommandButton, IChatConfirmation, IChatContentInlineReference, IChatContentReference, IChatFollowup, IChatMarkdownContent, IChatMoveMessage, IChatProgressMessage, IChatResponseCodeblockUriPart, IChatTaskDto, IChatTaskResult, IChatTextEdit, IChatTreeData, IChatUserActionEvent, IChatWarningMessage } from '../../contrib/chat/common/chatService.js';
+import { IChatAgentDetection, IChatAgentMarkdownContentWithVulnerability, IChatChoices, IChatCodeCitation, IChatCommandButton, IChatConfirmation, IChatContentInlineReference, IChatContentReference, IChatFollowup, IChatMarkdownContent, IChatMoveMessage, IChatProgressMessage, IChatResponseCodeblockUriPart, IChatTaskDto, IChatTaskResult, IChatTextEdit, IChatTreeData, IChatUserActionEvent, IChatWarningMessage } from '../../contrib/chat/common/chatService.js';
 import { IToolData, IToolResult } from '../../contrib/chat/common/languageModelToolsService.js';
 import * as chatProvider from '../../contrib/chat/common/languageModels.js';
 import { DebugTreeItemCollapsibleState, IDebugVisualizationTreeItem } from '../../contrib/debug/common/debug.js';
@@ -2519,6 +2519,18 @@ export namespace ChatResponseConfirmationPart {
 	}
 }
 
+export namespace ChatResponseChoicesPart {
+	export function from(part: vscode.ChatResponseChoicesPart): Dto<IChatChoices> {
+		return {
+			kind: 'choices',
+			title: part.title,
+			message: part.message,
+			disableAfterUse: part.disableAfterUse,
+			items: part.items,
+		};
+	}
+}
+
 export namespace ChatResponseFilesPart {
 	export function from(part: vscode.ChatResponseFileTreePart): IChatTreeData {
 		const { value, baseUri } = part;
@@ -2735,7 +2747,7 @@ export namespace ChatResponseCodeCitationPart {
 
 export namespace ChatResponsePart {
 
-	export function from(part: vscode.ChatResponsePart | vscode.ChatResponseTextEditPart | vscode.ChatResponseMarkdownWithVulnerabilitiesPart | vscode.ChatResponseDetectedParticipantPart | vscode.ChatResponseWarningPart | vscode.ChatResponseConfirmationPart | vscode.ChatResponseReferencePart2 | vscode.ChatResponseMovePart, commandsConverter: CommandsConverter, commandDisposables: DisposableStore): extHostProtocol.IChatProgressDto {
+	export function from(part: vscode.ChatResponsePart | vscode.ChatResponseTextEditPart | vscode.ChatResponseMarkdownWithVulnerabilitiesPart | vscode.ChatResponseDetectedParticipantPart | vscode.ChatResponseWarningPart | vscode.ChatResponseConfirmationPart | vscode.ChatResponseReferencePart2 | vscode.ChatResponseMovePart | vscode.ChatResponseChoicesPart, commandsConverter: CommandsConverter, commandDisposables: DisposableStore): extHostProtocol.IChatProgressDto {
 		if (part instanceof types.ChatResponseMarkdownPart) {
 			return ChatResponseMarkdownPart.from(part);
 		} else if (part instanceof types.ChatResponseAnchorPart) {
@@ -2764,6 +2776,8 @@ export namespace ChatResponsePart {
 			return ChatResponseCodeCitationPart.from(part);
 		} else if (part instanceof types.ChatResponseMovePart) {
 			return ChatResponseMovePart.from(part);
+		} else if (part instanceof types.ChatResponseChoicesPart) {
+			return ChatResponseChoicesPart.from(part);
 		}
 
 		return {
@@ -2813,6 +2827,7 @@ export namespace ChatAgentRequest {
 			location: ChatLocation.to(request.location),
 			acceptedConfirmationData: request.acceptedConfirmationData,
 			rejectedConfirmationData: request.rejectedConfirmationData,
+			choiceData: request.choiceData,
 			location2,
 			toolInvocationToken: Object.freeze({ sessionId: request.sessionId }) as never,
 			model

--- a/src/vs/workbench/api/common/extHostTypes.ts
+++ b/src/vs/workbench/api/common/extHostTypes.ts
@@ -4508,6 +4508,15 @@ export class ChatResponseDetectedParticipantPart {
 	}
 }
 
+export class ChatResponseChoicesPart {
+	constructor(
+		public title: string,
+		public message: string,
+		public items: (string | vscode.ChatResponseChoice)[],
+		public disableAfterUse = false,
+	) { }
+}
+
 export class ChatResponseConfirmationPart {
 	title: string;
 	message: string;

--- a/src/vs/workbench/contrib/chat/browser/actions/chatTitleActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatTitleActions.ts
@@ -489,7 +489,7 @@ export function registerChatTitleActions() {
 			await chatService.sendRequest(editingSession.chatSessionId, '', {
 				agentId: editAgent.id,
 				acceptedConfirmationData: [{ _type: 'toEditTransfer', transferedTurnResults: sourceRequests.map(v => v.response?.result) }], // TODO@jrieken HACKY
-				confirmation: typeof this.desc.title === 'string' ? this.desc.title : this.desc.title.value
+				madeChoice: { title: typeof this.desc.title === 'string' ? this.desc.title : this.desc.title.value },
 			});
 		}
 

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/chatChoicesWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/chatChoicesWidget.ts
@@ -13,15 +13,15 @@ import { MarkdownRenderer } from '../../../../../editor/browser/widget/markdownR
 import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
 import { defaultButtonStyles } from '../../../../../platform/theme/browser/defaultStyles.js';
 
-export interface IChatConfirmationButton {
+export interface IChatConfirmationButton<T> {
 	label: string;
 	isSecondary?: boolean;
-	data: any;
+	data: T;
 }
 
-export class ChatConfirmationWidget extends Disposable {
-	private _onDidClick = this._register(new Emitter<IChatConfirmationButton>());
-	get onDidClick(): Event<IChatConfirmationButton> { return this._onDidClick.event; }
+export class ChatChoicesWidget<T> extends Disposable {
+	private _onDidClick = this._register(new Emitter<IChatConfirmationButton<T>>());
+	get onDidClick(): Event<IChatConfirmationButton<T>> { return this._onDidClick.event; }
 
 	private _domNode: HTMLElement;
 	get domNode(): HTMLElement {
@@ -35,7 +35,7 @@ export class ChatConfirmationWidget extends Disposable {
 	constructor(
 		title: string,
 		message: string | IMarkdownString,
-		buttons: IChatConfirmationButton[],
+		buttons: IChatConfirmationButton<T>[],
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
 	) {
 		super();

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/chatToolInvocationPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/chatToolInvocationPart.ts
@@ -14,7 +14,7 @@ import { IInstantiationService } from '../../../../../platform/instantiation/com
 import { IChatProgressMessage, IChatToolInvocation, IChatToolInvocationSerialized } from '../../common/chatService.js';
 import { IChatRendererContent } from '../../common/chatViewModel.js';
 import { ChatTreeItem } from '../chat.js';
-import { ChatConfirmationWidget } from './chatConfirmationWidget.js';
+import { ChatChoicesWidget } from './chatChoicesWidget.js';
 import { IChatContentPart, IChatContentPartRenderContext } from './chatContentParts.js';
 import { ChatProgressContentPart } from './chatProgressContentPart.js';
 
@@ -78,7 +78,7 @@ class ChatToolInvocationSubPart extends Disposable {
 			const title = toolInvocation.confirmationMessages.title;
 			const message = toolInvocation.confirmationMessages.message;
 			const confirmWidget = this._register(instantiationService.createInstance(
-				ChatConfirmationWidget,
+				ChatChoicesWidget<any>,
 				title,
 				message,
 				[{ label: localize('continue', "Continue"), data: true }, { label: localize('cancel', "Cancel"), data: false, isSecondary: true }]));

--- a/src/vs/workbench/contrib/chat/browser/chatListFilter.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatListFilter.ts
@@ -1,0 +1,32 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { ITreeFilter, TreeFilterResult } from '../../../../base/browser/ui/tree/tree.js';
+import { FuzzyScore } from '../../../../base/common/filters.js';
+import { isRequestVM, isResponseVM } from '../common/chatViewModel.js';
+import { ChatTreeItem } from './chat.js';
+
+export interface IChatWidgetFilterDelegate {
+	getPrevElement(element: ChatTreeItem): ChatTreeItem | null;
+}
+
+export class ChatWidgetFilter implements ITreeFilter<ChatTreeItem, FuzzyScore> {
+	constructor(
+		private readonly delegate: IChatWidgetFilterDelegate,
+		private readonly inherited: undefined | ((item: ChatTreeItem) => boolean),
+	) { }
+
+	filter(element: ChatTreeItem): TreeFilterResult<FuzzyScore> {
+		if (isRequestVM(element)) {
+			const isChoiceFromResponseId = element.madeChoice?.responseId;
+			const previous = this.delegate.getPrevElement(element);
+			if (isResponseVM(previous) && previous.id === isChoiceFromResponseId) {
+				return false;
+			}
+		}
+
+		return this.inherited?.(element) ?? true;
+	}
+}

--- a/src/vs/workbench/contrib/chat/common/chatAgents.ts
+++ b/src/vs/workbench/contrib/chat/common/chatAgents.ts
@@ -162,6 +162,7 @@ export interface IChatAgentRequest {
 	locationData?: IChatLocationData;
 	acceptedConfirmationData?: any[];
 	rejectedConfirmationData?: any[];
+	choiceData?: (string | { title: string })[];
 	userSelectedModelId?: string;
 }
 

--- a/src/vs/workbench/contrib/chat/common/chatService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService.ts
@@ -16,7 +16,7 @@ import { FileType } from '../../../../platform/files/common/files.js';
 import { createDecorator } from '../../../../platform/instantiation/common/instantiation.js';
 import { IWorkspaceSymbol } from '../../search/common/search.js';
 import { ChatAgentLocation, IChatAgentCommand, IChatAgentData, IChatAgentResult } from './chatAgents.js';
-import { ChatModel, IChatModel, IChatRequestModel, IChatRequestVariableData, IChatRequestVariableEntry, IChatResponseModel, IExportableChatData, ISerializableChatData } from './chatModel.js';
+import { ChatModel, IChatModel, IChatRequestModel, IChatRequestVariableData, IChatRequestVariableEntry, IChatResponseModel, IExportableChatData, IMadeChoice, ISerializableChatData } from './chatModel.js';
 import { IParsedChatRequest } from './chatParserTypes.js';
 import { IChatParserContext } from './chatRequestParser.js';
 import { IChatRequestVariableValue } from './chatVariables.js';
@@ -196,6 +196,15 @@ export interface IChatConfirmation {
 	kind: 'confirmation';
 }
 
+export interface IChatChoices {
+	kind: 'choices';
+	title: string;
+	message: string;
+	disableAfterUse: boolean;
+	items: (string | { title: string })[];
+	isUsed?: boolean;
+}
+
 export interface IChatToolInvocation {
 	/** Presence of this property says that confirmation is required */
 	confirmationMessages?: IToolConfirmationMessages;
@@ -238,7 +247,8 @@ export type IChatProgress =
 	| IChatResponseCodeblockUriPart
 	| IChatConfirmation
 	| IChatToolInvocation
-	| IChatToolInvocationSerialized;
+	| IChatToolInvocationSerialized
+	| IChatChoices;
 
 export interface IChatFollowup {
 	kind: 'reply';
@@ -420,6 +430,7 @@ export interface IChatSendRequestOptions {
 	noCommandDetection?: boolean;
 	acceptedConfirmationData?: any[];
 	rejectedConfirmationData?: any[];
+	choiceData?: (string | { title: string })[];
 	attachedContext?: IChatRequestVariableEntry[];
 	workingSet?: URI[];
 
@@ -428,9 +439,9 @@ export interface IChatSendRequestOptions {
 	slashCommand?: string;
 
 	/**
-	 * The label of the confirmation action that was selected.
+	 * Information about the confirmation or choice that was selected.
 	 */
-	confirmation?: string;
+	madeChoice?: IMadeChoice;
 
 	/**
 	 * Flag to indicate whether a prompt instructions attachment is present.

--- a/src/vs/workbench/contrib/chat/common/chatServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/chatServiceImpl.ts
@@ -629,7 +629,7 @@ export class ChatService extends Disposable implements IChatService {
 				if (agentPart || (defaultAgent && !commandPart)) {
 					const prepareChatAgentRequest = async (agent: IChatAgentData, command?: IChatAgentCommand, enableCommandDetection?: boolean, chatRequest?: ChatRequestModel, isParticipantDetected?: boolean): Promise<IChatAgentRequest> => {
 						const initVariableData: IChatRequestVariableData = { variables: [] };
-						request = chatRequest ?? model.addRequest(parsedRequest, initVariableData, attempt, agent, command, options?.confirmation, options?.locationData, options?.attachedContext, options?.workingSet);
+						request = chatRequest ?? model.addRequest(parsedRequest, initVariableData, attempt, agent, command, options?.madeChoice, options?.locationData, options?.attachedContext, options?.workingSet);
 
 						let variableData: IChatRequestVariableData;
 						let message: string;
@@ -664,7 +664,8 @@ export class ChatService extends Disposable implements IChatService {
 							locationData: request.locationData,
 							acceptedConfirmationData: options?.acceptedConfirmationData,
 							rejectedConfirmationData: options?.rejectedConfirmationData,
-							userSelectedModelId: options?.userSelectedModelId
+							userSelectedModelId: options?.userSelectedModelId,
+							choiceData: options?.choiceData,
 						} satisfies IChatAgentRequest;
 					};
 

--- a/src/vs/workbench/contrib/chat/common/chatViewModel.ts
+++ b/src/vs/workbench/contrib/chat/common/chatViewModel.ts
@@ -13,7 +13,7 @@ import { IInstantiationService } from '../../../../platform/instantiation/common
 import { ILogService } from '../../../../platform/log/common/log.js';
 import { annotateVulnerabilitiesInText } from './annotations.js';
 import { getFullyQualifiedId, IChatAgentCommand, IChatAgentData, IChatAgentNameService, IChatAgentResult } from './chatAgents.js';
-import { ChatModelInitState, IChatModel, IChatProgressRenderableResponseContent, IChatRequestModel, IChatRequestVariableEntry, IChatResponseModel, IChatTextEditGroup, IResponse } from './chatModel.js';
+import { ChatModelInitState, IChatModel, IChatProgressRenderableResponseContent, IChatRequestModel, IChatRequestVariableEntry, IChatResponseModel, IChatTextEditGroup, IMadeChoice, IResponse } from './chatModel.js';
 import { IParsedChatRequest } from './chatParserTypes.js';
 import { ChatAgentVoteDirection, ChatAgentVoteDownReason, IChatCodeCitation, IChatContentReference, IChatFollowup, IChatProgressMessage, IChatResponseErrorDetails, IChatTask, IChatUsedContext } from './chatService.js';
 import { countWords } from './chatWordCounter.js';
@@ -73,7 +73,7 @@ export interface IChatRequestViewModel {
 	currentRenderedHeight: number | undefined;
 	readonly contentReferences?: ReadonlyArray<IChatContentReference>;
 	readonly workingSet?: ReadonlyArray<URI>;
-	readonly confirmation?: string;
+	readonly madeChoice?: IMadeChoice;
 	readonly shouldBeRemovedOnSend: boolean;
 	readonly isComplete: boolean;
 	readonly isCompleteAddedRequest: boolean;
@@ -182,6 +182,7 @@ export interface IChatResponseViewModel {
 	readonly contentUpdateTimings?: IChatLiveUpdateData;
 	readonly shouldBeRemovedOnSend: boolean;
 	readonly isCompleteAddedRequest: boolean;
+	readonly isChoiceAfterResponse?: string;
 	renderData?: IChatResponseRenderData;
 	currentRenderedHeight: number | undefined;
 	setVote(vote: ChatAgentVoteDirection): void;
@@ -371,8 +372,8 @@ export class ChatRequestViewModel implements IChatRequestViewModel {
 		return this._model.workingSet;
 	}
 
-	get confirmation() {
-		return this._model.confirmation;
+	get madeChoice() {
+		return this._model.madeChoice;
 	}
 
 	get isComplete() {
@@ -490,6 +491,10 @@ export class ChatResponseViewModel extends Disposable implements IChatResponseVi
 
 	get isCompleteAddedRequest() {
 		return this._model.isCompleteAddedRequest;
+	}
+
+	get isChoiceAfterResponse() {
+		return this._model.isChoiceAfterResponse;
 	}
 
 	get replyFollowups() {


### PR DESCRIPTION
This is an API similar to buttons in notifications and is a bit more flexible than the current confirmation API. It could supplant confirmation, but I left confirmation as-is for the moment. Marking this PR initially as a draft pending some discussion about awaitable choices


https://github.com/user-attachments/assets/442989c7-7974-4fe8-b070-a042a6aa63e7





<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
