### PR TITLE
Prevent NES flickering when switching tab actions

### DIFF
--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/view.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/view.ts
@@ -81,7 +81,12 @@ export class InlineEditsView extends Disposable {
 		)!;
 
 		this._previewTextModel.setLanguage(this._editor.getModel()!.getLanguageId());
-		this._previewTextModel.setValue(newText);
+
+		const previousNewText = this._previewTextModel.getValue();
+		if (previousNewText !== newText) {
+			// Only update the model if the text has changed to avoid flickering
+			this._previewTextModel.setValue(newText);
+		}
 
 		return {
 			state,


### PR DESCRIPTION
Update the inline edits model to only set the new value if it differs from the previous value, addressing flickering issues

Fixes microsoft/vscode-copilot#11743