### PR TITLE
Expose source as getter in inline completions

### DIFF
--- a/src/vs/editor/contrib/inlineCompletions/browser/controller/inlineCompletionsController.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/controller/inlineCompletionsController.ts
@@ -292,7 +292,7 @@ export class InlineCompletionsController extends Disposable {
 		this._register(contextKeySvcObs.bind(InlineCompletionContextKeys.suppressSuggestions, reader => {
 			const model = this.model.read(reader);
 			const state = model?.inlineCompletionState.read(reader);
-			return state?.primaryGhostText && state?.inlineCompletion ? state.inlineCompletion.inlineCompletion.source.inlineCompletions.suppressSuggestions : undefined;
+			return state?.primaryGhostText && state?.inlineCompletion ? state.inlineCompletion.source.inlineCompletions.suppressSuggestions : undefined;
 		}));
 		this._register(contextKeySvcObs.bind(InlineCompletionContextKeys.inlineSuggestionVisible, reader => {
 			const model = this.model.read(reader);

--- a/src/vs/editor/contrib/inlineCompletions/browser/model/inlineCompletionsSource.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/model/inlineCompletionsSource.ts
@@ -323,7 +323,7 @@ export class InlineCompletionWithUpdatedRange {
 	]);
 
 	public get forwardStable() {
-		return this.inlineCompletion.source.inlineCompletions.enableForwardStability ?? false;
+		return this.source.inlineCompletions.enableForwardStability ?? false;
 	}
 
 	private readonly _updatedRange = derivedOpts<Range | null>({ owner: this, equalsFn: Range.equalsRange }, reader => {
@@ -341,6 +341,9 @@ export class InlineCompletionWithUpdatedRange {
 	 */
 	public _inlineEdit: ISettableObservable<OffsetEdit | null>;
 	public get inlineEdit() { return this._inlineEdit.get(); }
+
+	public get source() { return this.inlineCompletion.source; }
+	public get sourceInlineCompletion() { return this.inlineCompletion.sourceInlineCompletion; }
 
 	private readonly _creationTime: number = Date.now();
 

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/gutterIndicatorView.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/gutterIndicatorView.ts
@@ -190,7 +190,7 @@ export class InlineEditsGutterIndicator extends Disposable {
 		const displayName = derived(this, reader => {
 			const state = this._model.read(reader)?.inlineEditState;
 			const item = state?.read(reader);
-			const completionSource = item?.inlineCompletion?.inlineCompletion.source;
+			const completionSource = item?.inlineCompletion?.source;
 			// TODO: expose the provider (typed) and expose the provider the edit belongs totyping and get correct edit
 			const displayName = (completionSource?.inlineCompletions as any).edits[0]?.provider?.displayName ?? localize('inlineEdit', "Inline Edit");
 			return displayName;
@@ -207,7 +207,7 @@ export class InlineEditsGutterIndicator extends Disposable {
 				}
 				h?.dispose();
 			},
-			this._model.map((m, r) => m?.state.read(r)?.inlineCompletion?.inlineCompletion.source.inlineCompletions.commands),
+			this._model.map((m, r) => m?.state.read(r)?.inlineCompletion?.source.inlineCompletions.commands),
 		).toDisposableLiveElement());
 
 		const focusTracker = disposableStore.add(trackFocus(content.element));


### PR DESCRIPTION
Refactor inline completion code to expose the source as a getter, simplifying access to related properties and improving code readability.