### PR TITLE
Fix toggling wrapping sometimes losing track of DOM nodes

### DIFF
--- a/src/vs/editor/browser/view/viewLayer.ts
+++ b/src/vs/editor/browser/view/viewLayer.ts
@@ -277,9 +277,20 @@ export class VisibleLinesCollection<T extends IVisibleLine> {
 		return false;
 	}
 
-	public onFlushed(e: viewEvents.ViewFlushedEvent): boolean {
+	public onFlushed(e: viewEvents.ViewFlushedEvent, flushDom?: boolean): boolean {
+		// No need to clear the dom node because a full .innerHTML will occur in
+		// ViewLayerRenderer._render, however the the fallbakc mechanism in the
+		// GPU renderer may cause this to be necessary as the .innerHTML call
+		// may not happen depending on the new state, leaving stale DOM nodes
+		// around.
+		if (flushDom) {
+			const start = this._linesCollection.getStartLineNumber();
+			const end = this._linesCollection.getEndLineNumber();
+			for (let i = start; i <= end; i++) {
+				this._linesCollection.getLine(i).getDomNode()?.remove();
+			}
+		}
 		this._linesCollection.flush();
-		// No need to clear the dom node because a full .innerHTML will occur in ViewLayerRenderer._render
 		return true;
 	}
 

--- a/src/vs/editor/browser/viewParts/viewLines/viewLines.ts
+++ b/src/vs/editor/browser/viewParts/viewLines/viewLines.ts
@@ -254,7 +254,7 @@ export class ViewLines extends ViewPart implements IViewLines {
 		return true;
 	}
 	public override onFlushed(e: viewEvents.ViewFlushedEvent): boolean {
-		const shouldRender = this._visibleLines.onFlushed(e);
+		const shouldRender = this._visibleLines.onFlushed(e, this._viewLineOptions.useGpu);
 		this._maxLineWidth = 0;
 		return shouldRender;
 	}


### PR DESCRIPTION
On flush, the DOM renderer expects the following render to have lines and as such defers clearing the innerHTML of the line collection in order to save a little time. Since this GPU renderer may not actually render lines however, this ends up having the possibility to lose track of rendered DOM lines and they would stick around until the next flush where it actually does clear the parent out.

This was mostly reproducible when toggling wrapping in markdown files, but it was somewhat difficult I believe depending on how many lines would pass canRender or not which changes at various stages of view events being fired.

Since this is a relatively risky and unnecessary change to apply when GPU acceleration is off, it will only change behavior when useGpu is true.

Fixes #237527

cc @hediet 