### PR TITLE
check if windows file is executable

### DIFF
--- a/extensions/terminal-suggest/src/helpers/executable.ts
+++ b/extensions/terminal-suggest/src/helpers/executable.ts
@@ -24,35 +24,16 @@ const windowsExecutableExtensions: string[] = [
 	'.bat',   // Batch file
 	'.cmd',   // Command script
 	'.com',   // Command file
-	'.cpl',   // Control Panel extension
-	'.msc',   // Microsoft Management Console file
-	'.scr',   // Screensaver file
+
+	'.msi',   // Windows Installer package
+
 	'.ps1',   // PowerShell script
+
 	'.vbs',   // VBScript file
 	'.js',    // JScript file
-	'.wsf',   // Windows Script File
-	'.msi',   // Windows Installer package
-	'.msp',   // Windows Installer patch
-	'.pif',   // Program Information File
-	'.gadget',// Windows Gadget
-	'.hta',   // HTML Application
 	'.jar',   // Java Archive (requires Java runtime)
 	'.py',    // Python script (requires Python interpreter)
 	'.rb',    // Ruby script (requires Ruby interpreter)
 	'.pl',    // Perl script (requires Perl interpreter)
 	'.sh',    // Shell script (via WSL or third-party tools)
-	'.ksh',   // KornShell script (via WSL or compatible shells)
-	'.inf',   // Setup Information File
-	'.scf',   // Shell Command File
-	'.lnk',   // Shortcut file
-	'.url',   // Internet shortcut
-	'.vb',    // VBScript file
-	'.vbe',   // VBScript Encoded Script file
-	'.wsh',   // Windows Script Host settings file
-	'.msh',   // Microsoft Shell script
-	'.msh1',  // Monad Shell script
-	'.msh2',  // Monad Shell script
-	'.mshxml',// Monad Shell XML script
-	'.msh1xml',// Monad Shell XML script
-	'.msh2xml' // Monad Shell XML script
 ];

--- a/extensions/terminal-suggest/src/helpers/executable.ts
+++ b/extensions/terminal-suggest/src/helpers/executable.ts
@@ -1,0 +1,58 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { osIsWindows } from './os';
+import * as fs from 'fs/promises';
+
+export async function isExecutable(filePath: string): Promise<boolean> {
+	if (osIsWindows()) {
+		return windowsExecutableExtensions.find(ext => filePath.endsWith(ext)) !== undefined;
+	}
+	try {
+		const stats = await fs.stat(filePath);
+		// On macOS/Linux, check if the executable bit is set
+		return (stats.mode & 0o100) !== 0;
+	} catch (error) {
+		// If the file does not exist or cannot be accessed, it's not executable
+		return false;
+	}
+}
+const windowsExecutableExtensions: string[] = [
+	'.exe',   // Executable file
+	'.bat',   // Batch file
+	'.cmd',   // Command script
+	'.com',   // Command file
+	'.cpl',   // Control Panel extension
+	'.msc',   // Microsoft Management Console file
+	'.scr',   // Screensaver file
+	'.ps1',   // PowerShell script
+	'.vbs',   // VBScript file
+	'.js',    // JScript file
+	'.wsf',   // Windows Script File
+	'.msi',   // Windows Installer package
+	'.msp',   // Windows Installer patch
+	'.pif',   // Program Information File
+	'.gadget',// Windows Gadget
+	'.hta',   // HTML Application
+	'.jar',   // Java Archive (requires Java runtime)
+	'.py',    // Python script (requires Python interpreter)
+	'.rb',    // Ruby script (requires Ruby interpreter)
+	'.pl',    // Perl script (requires Perl interpreter)
+	'.sh',    // Shell script (via WSL or third-party tools)
+	'.ksh',   // KornShell script (via WSL or compatible shells)
+	'.inf',   // Setup Information File
+	'.scf',   // Shell Command File
+	'.lnk',   // Shortcut file
+	'.url',   // Internet shortcut
+	'.vb',    // VBScript file
+	'.vbe',   // VBScript Encoded Script file
+	'.wsh',   // Windows Script Host settings file
+	'.msh',   // Microsoft Shell script
+	'.msh1',  // Monad Shell script
+	'.msh2',  // Monad Shell script
+	'.mshxml',// Monad Shell XML script
+	'.msh1xml',// Monad Shell XML script
+	'.msh2xml' // Monad Shell XML script
+];

--- a/extensions/terminal-suggest/src/helpers/os.ts
+++ b/extensions/terminal-suggest/src/helpers/os.ts
@@ -1,0 +1,10 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as os from 'os';
+
+export function osIsWindows(): boolean {
+	return os.platform() === 'win32';
+}

--- a/extensions/terminal-suggest/src/terminalSuggestMain.ts
+++ b/extensions/terminal-suggest/src/terminalSuggestMain.ts
@@ -3,7 +3,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 import * as vscode from 'vscode';
-import * as os from 'os';
 import * as fs from 'fs/promises';
 import * as path from 'path';
 import { ExecOptionsWithStringEncoding, execSync } from 'child_process';
@@ -11,7 +10,10 @@ import { upstreamSpecs } from './constants';
 import codeCompletionSpec from './completions/code';
 import cdSpec from './completions/cd';
 import codeInsidersCompletionSpec from './completions/code-insiders';
+import { osIsWindows } from './helpers/os';
+import { isExecutable } from './helpers/executable';
 
+const isWindows = osIsWindows();
 let cachedAvailableCommandsPath: string | undefined;
 let cachedAvailableCommands: Set<string> | undefined;
 const cachedBuiltinCommands: Map<string, string[] | undefined> = new Map();
@@ -101,7 +103,7 @@ export async function activate(context: vscode.ExtensionContext) {
 			const result = await getCompletionItemsFromSpecs(availableSpecs, terminalContext, commands, prefix, terminal.shellIntegration?.cwd, token);
 			if (result.cwd && (result.filesRequested || result.foldersRequested)) {
 				// const cwd = resolveCwdFromPrefix(prefix, terminal.shellIntegration?.cwd) ?? terminal.shellIntegration?.cwd;
-				return new vscode.TerminalCompletionList(result.items, { filesRequested: result.filesRequested, foldersRequested: result.foldersRequested, cwd: result.cwd, pathSeparator: osIsWindows() ? '\\' : '/' });
+				return new vscode.TerminalCompletionList(result.items, { filesRequested: result.filesRequested, foldersRequested: result.foldersRequested, cwd: result.cwd, pathSeparator: isWindows ? '\\' : '/' });
 			}
 			return result.items;
 		}
@@ -123,7 +125,7 @@ export async function resolveCwdFromPrefix(prefix: string, currentCwd?: vscode.U
 		// Get the nearest folder path from the prefix. This ignores everything after the `/` as
 		// they are what triggers changes in the directory.
 		let lastSlashIndex: number;
-		if (osIsWindows()) {
+		if (isWindows) {
 			// TODO: This support is very basic, ideally the slashes supported would depend upon the
 			//       shell type. For example git bash under Windows does not allow using \ as a path
 			//       separator.
@@ -179,28 +181,10 @@ function createCompletionItem(cursorPosition: number, prefix: string, label: str
 	};
 }
 
-async function isExecutable(filePath: string): Promise<boolean> {
-	// Windows doesn't have the concept of an executable bit and running any
-	// file is possible. We considered using $PATHEXT here but since it's mostly
-	// there for legacy reasons and it would be easier and more intuitive to add
-	// a setting if needed instead.
-	if (osIsWindows()) {
-		return true;
-	}
-	try {
-		const stats = await fs.stat(filePath);
-		// On macOS/Linux, check if the executable bit is set
-		return (stats.mode & 0o100) !== 0;
-	} catch (error) {
-		// If the file does not exist or cannot be accessed, it's not executable
-		return false;
-	}
-}
-
 async function getCommandsInPath(env: { [key: string]: string | undefined } = process.env): Promise<Set<string> | undefined> {
 	// Get PATH value
 	let pathValue: string | undefined;
-	if (osIsWindows()) {
+	if (isWindows) {
 		const caseSensitivePathKey = Object.keys(env).find(key => key.toLowerCase() === 'path');
 		if (caseSensitivePathKey) {
 			pathValue = env[caseSensitivePathKey];
@@ -218,7 +202,6 @@ async function getCommandsInPath(env: { [key: string]: string | undefined } = pr
 	}
 
 	// Extract executables from PATH
-	const isWindows = osIsWindows();
 	const paths = pathValue.split(isWindows ? ';' : ':');
 	const pathSeparator = isWindows ? '\\' : '/';
 	const executables = new Set<string>();
@@ -484,9 +467,7 @@ function getCompletionItemsFromArgs(args: Fig.SingleOrArray<Fig.Arg> | undefined
 	return { items, filesRequested, foldersRequested };
 }
 
-function osIsWindows(): boolean {
-	return os.platform() === 'win32';
-}
+
 
 function getFirstCommand(commandLine: string): string | undefined {
 	const wordsOnLine = commandLine.split(' ');

--- a/src/vs/workbench/services/suggest/browser/simpleCompletionModel.ts
+++ b/src/vs/workbench/services/suggest/browser/simpleCompletionModel.ts
@@ -234,6 +234,8 @@ const fileExtScores = new Map<string, number>(isWindows ? [
 	['exe', 0.08],
 	['bat', 0.07],
 	['cmd', 0.07],
+	['msi', 0.06],
+	['com', 0.06],
 	// Non-Windows
 	['sh', -0.05],
 	['bash', -0.05],


### PR DESCRIPTION
fix #237596

Also pulls some code out into helper files, so we don't keep growing the main extension file.