### PR TITLE
Use Electron fetch or Node fetch for github-authentication to support proxies

### DIFF
--- a/extensions/github-authentication/src/flows.ts
+++ b/extensions/github-authentication/src/flows.ts
@@ -105,8 +105,6 @@ async function exchangeCodeForToken(
 		headers: {
 			Accept: 'application/json',
 			'Content-Type': 'application/x-www-form-urlencoded',
-			'Content-Length': body.toString()
-
 		},
 		body: body.toString()
 	});

--- a/extensions/github-authentication/src/node/fetch.ts
+++ b/extensions/github-authentication/src/node/fetch.ts
@@ -2,6 +2,11 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import fetch from 'node-fetch';
 
-export const fetching = fetch;
+let _fetch: typeof fetch;
+try {
+	_fetch = require('electron').net.fetch;
+} catch {
+	_fetch = fetch;
+}
+export const fetching = _fetch;


### PR DESCRIPTION
Essentially a mirror of the changes in https://github.com/microsoft/vscode/pull/229202 for the microsoft-authentication extension.

Fixes https://github.com/microsoft/vscode/issues/207867