### PR TITLE
consolidate workbench feature logs under window

### DIFF
--- a/src/vs/workbench/contrib/editSessions/common/editSessionsLogService.ts
+++ b/src/vs/workbench/contrib/editSessions/common/editSessionsLogService.ts
@@ -7,6 +7,7 @@ import { joinPath } from '../../../../base/common/resources.js';
 import { localize } from '../../../../nls.js';
 import { IEnvironmentService } from '../../../../platform/environment/common/environment.js';
 import { AbstractLogger, ILogger, ILoggerService } from '../../../../platform/log/common/log.js';
+import { windowLogGroup } from '../../../services/log/common/logConstants.js';
 import { IEditSessionsLogService, editSessionsLogId } from './editSessions.js';
 
 export class EditSessionsLogService extends AbstractLogger implements IEditSessionsLogService {
@@ -19,7 +20,7 @@ export class EditSessionsLogService extends AbstractLogger implements IEditSessi
 		@IEnvironmentService environmentService: IEnvironmentService
 	) {
 		super();
-		this.logger = this._register(loggerService.createLogger(joinPath(environmentService.logsHome, `${editSessionsLogId}.log`), { id: editSessionsLogId, name: localize('cloudChangesLog', "Cloud Changes") }));
+		this.logger = this._register(loggerService.createLogger(joinPath(environmentService.logsHome, `${editSessionsLogId}.log`), { id: editSessionsLogId, name: localize('cloudChangesLog', "Cloud Changes"), group: windowLogGroup }));
 	}
 
 	trace(message: string, ...args: any[]): void {

--- a/src/vs/workbench/contrib/notebook/browser/services/notebookLoggingServiceImpl.ts
+++ b/src/vs/workbench/contrib/notebook/browser/services/notebookLoggingServiceImpl.ts
@@ -7,6 +7,7 @@ import * as nls from '../../../../../nls.js';
 import { Disposable } from '../../../../../base/common/lifecycle.js';
 import { INotebookLoggingService } from '../../common/notebookLoggingService.js';
 import { ILogger, ILoggerService } from '../../../../../platform/log/common/log.js';
+import { windowLogGroup } from '../../../../services/log/common/logConstants.js';
 
 const logChannelId = 'notebook.rendering';
 
@@ -20,7 +21,7 @@ export class NotebookLoggingService extends Disposable implements INotebookLoggi
 		@ILoggerService loggerService: ILoggerService,
 	) {
 		super();
-		this._logger = this._register(loggerService.createLogger(logChannelId, { name: nls.localize('renderChannelName', "Notebook") }));
+		this._logger = this._register(loggerService.createLogger(logChannelId, { name: nls.localize('renderChannelName', "Notebook"), group: windowLogGroup }));
 	}
 
 	debug(category: string, output: string): void {

--- a/src/vs/workbench/services/views/browser/viewDescriptorService.ts
+++ b/src/vs/workbench/services/views/browser/viewDescriptorService.ts
@@ -23,6 +23,7 @@ import { IStringDictionary } from '../../../../base/common/collections.js';
 import { ILogger, ILoggerService } from '../../../../platform/log/common/log.js';
 import { Lazy } from '../../../../base/common/lazy.js';
 import { IViewsService } from '../common/viewsService.js';
+import { windowLogGroup } from '../../log/common/logConstants.js';
 
 interface IViewsCustomizations {
 	viewContainerLocations: IStringDictionary<ViewContainerLocation>;
@@ -79,7 +80,7 @@ export class ViewDescriptorService extends Disposable implements IViewDescriptor
 	) {
 		super();
 
-		this.logger = new Lazy(() => loggerService.createLogger(VIEWS_LOG_ID, { name: VIEWS_LOG_NAME, hidden: true }));
+		this.logger = new Lazy(() => loggerService.createLogger(VIEWS_LOG_ID, { name: VIEWS_LOG_NAME, group: windowLogGroup }));
 
 		this.activeViewContextKeys = new Map<string, IContextKey<boolean>>();
 		this.movableViewContextKeys = new Map<string, IContextKey<boolean>>();

--- a/src/vs/workbench/services/views/common/viewContainerModel.ts
+++ b/src/vs/workbench/services/views/common/viewContainerModel.ts
@@ -9,7 +9,7 @@ import { IStorageService, StorageScope, StorageTarget } from '../../../../platfo
 import { Registry } from '../../../../platform/registry/common/platform.js';
 import { Disposable } from '../../../../base/common/lifecycle.js';
 import { Event, Emitter } from '../../../../base/common/event.js';
-import { IInstantiationService, ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
+import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { URI } from '../../../../base/common/uri.js';
 import { coalesce, move } from '../../../../base/common/arrays.js';
 import { isUndefined, isUndefinedOrNull } from '../../../../base/common/types.js';
@@ -17,29 +17,9 @@ import { isEqual } from '../../../../base/common/resources.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
 import { IStringDictionary } from '../../../../base/common/collections.js';
 import { ILogger, ILoggerService } from '../../../../platform/log/common/log.js';
-import { Action2, registerAction2 } from '../../../../platform/actions/common/actions.js';
-import { Categories } from '../../../../platform/action/common/actionCommonCategories.js';
-import { IOutputService } from '../../output/common/output.js';
 import { CounterSet } from '../../../../base/common/map.js';
-import { localize2 } from '../../../../nls.js';
 import { Lazy } from '../../../../base/common/lazy.js';
-
-registerAction2(class extends Action2 {
-	constructor() {
-		super({
-			id: '_workbench.output.showViewsLog',
-			title: localize2('showViewsLog', "Show Views Log"),
-			category: Categories.Developer,
-			f1: true
-		});
-	}
-	async run(servicesAccessor: ServicesAccessor): Promise<void> {
-		const loggerService = servicesAccessor.get(ILoggerService);
-		const outputService = servicesAccessor.get(IOutputService);
-		loggerService.setVisibility(VIEWS_LOG_ID, true);
-		outputService.showChannel(VIEWS_LOG_ID);
-	}
-});
+import { windowLogGroup } from '../../log/common/logConstants.js';
 
 export function getViewsStateStorageId(viewContainerStorageId: string): string { return `${viewContainerStorageId}.hidden`; }
 
@@ -84,7 +64,7 @@ class ViewDescriptorsState extends Disposable {
 	) {
 		super();
 
-		this.logger = new Lazy(() => loggerService.createLogger(VIEWS_LOG_ID, { name: VIEWS_LOG_NAME, hidden: true }));
+		this.logger = new Lazy(() => loggerService.createLogger(VIEWS_LOG_ID, { name: VIEWS_LOG_NAME, group: windowLogGroup }));
 
 		this.globalViewsStateStorageId = getViewsStateStorageId(viewContainerStorageId);
 		this.workspaceViewsStateStorageId = viewContainerStorageId;
@@ -354,7 +334,7 @@ export class ViewContainerModel extends Disposable implements IViewContainerMode
 	) {
 		super();
 
-		this.logger = new Lazy(() => loggerService.createLogger(VIEWS_LOG_ID, { name: VIEWS_LOG_NAME, hidden: true }));
+		this.logger = new Lazy(() => loggerService.createLogger(VIEWS_LOG_ID, { name: VIEWS_LOG_NAME, group: windowLogGroup }));
 
 		this._register(Event.filter(contextKeyService.onDidChangeContext, e => e.affectsSome(this.contextKeys))(() => this.onDidChangeContext()));
 		this.viewDescriptorsState = this._register(instantiationService.createInstance(ViewDescriptorsState, viewContainer.storageId || `${viewContainer.id}.state`, typeof viewContainer.title === 'string' ? viewContainer.title : viewContainer.title.original));


### PR DESCRIPTION
At present output view dropdown is filled with too many logs to maintain. With the introduction of compound logs, I would like to group logs per process. This will make the output view dropdown more manageable and easier to navigate. As part of this, I have moved Notebook and Cloud Changes logs under Window log as below: 

<img width="1138" alt="image" src="https://github.com/user-attachments/assets/00cae76c-58a3-479b-a2ec-68f7bda6d409" />

Above is the Window log composed of categories shown in the filter dropdown. You can filter categories and view the logs you want.
