### PR TITLE
prevent `.zlogin` and `.zprofile` from running more than once

### DIFF
--- a/src/vs/workbench/contrib/terminal/common/scripts/shellIntegration-login.zsh
+++ b/src/vs/workbench/contrib/terminal/common/scripts/shellIntegration-login.zsh
@@ -3,6 +3,12 @@
 #   Licensed under the MIT License. See License.txt in the project root for license information.
 # ---------------------------------------------------------------------------------------------
 
+# Prevent recursive sourcing
+if [[ -n "$VSCODE_LOGIN_INITIALIZED" ]]; then
+	return
+fi
+export VSCODE_LOGIN_INITIALIZED=1
+
 ZDOTDIR=$USER_ZDOTDIR
 if [[ $options[norcs] = off && -o "login" &&  -f $ZDOTDIR/.zlogin ]]; then
 	. $ZDOTDIR/.zlogin

--- a/src/vs/workbench/contrib/terminal/common/scripts/shellIntegration-profile.zsh
+++ b/src/vs/workbench/contrib/terminal/common/scripts/shellIntegration-profile.zsh
@@ -2,6 +2,13 @@
 #   Copyright (c) Microsoft Corporation. All rights reserved.
 #   Licensed under the MIT License. See License.txt in the project root for license information.
 # ---------------------------------------------------------------------------------------------
+
+# Prevent recursive sourcing
+if [[ -n "$VSCODE_PROFILE_INITIALIZED" ]]; then
+	return
+fi
+export VSCODE_PROFILE_INITIALIZED=1
+
 if [[ $options[norcs] = off && -o "login" ]]; then
 	if [[ -f $USER_ZDOTDIR/.zprofile ]]; then
 		VSCODE_ZDOTDIR=$ZDOTDIR


### PR DESCRIPTION
Not sure why these would be getting called more than once, but we've seen a few reports, so think adding these checks will fix it. 

Fix #238296