### PR TITLE
enforce foreground color for codicon in notebook list

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/media/notebook.css
+++ b/src/vs/workbench/contrib/notebook/browser/media/notebook.css
@@ -335,7 +335,7 @@
 }
 
 .monaco-workbench .notebookOverlay .monaco-list:focus-within .monaco-list-row .codicon:not(.suggest-icon) {
-	color: inherit;
+	color: var(--vscode-icon-foreground);
 }
 
 .monaco-workbench .notebookOverlay > .cell-list-container .notebook-overview-ruler-container {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

To fix

<img width="265" alt="image" src="https://github.com/user-attachments/assets/c86bc099-e48a-4745-b59c-340900ad9ac0" />
