### PR TITLE
Add `source-map-support` for stack trace formatting in `extensionHost` debugging

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
     "native-watchdog": "^1.4.1",
     "node-pty": "^1.1.0-beta22",
     "open": "^8.4.2",
+    "source-map-support": "^0.3.2",
     "tas-client-umd": "0.2.0",
     "v8-inspect-profiler": "^0.1.1",
     "vscode-oniguruma": "1.7.0",


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
Fixes https://github.com/microsoft/vscode/issues/145473

This pull request enables source map support for `extensionHost` debugging.

To test it, you would build a VSCode extension with source map enabled, along with `console.trace()`, uncaught exceptions or `tslog`, and see if the source is correctly resolved instead of somewhere in `${workspaceFolder}/dist/**`.