### PR TITLE
Remove paths from tsconfig.base.json

### DIFF
--- a/src/bootstrap-window.ts
+++ b/src/bootstrap-window.ts
@@ -5,9 +5,9 @@
 
 (function () {
 
-	type ISandboxConfiguration = import('vs/base/parts/sandbox/common/sandboxTypes.js').ISandboxConfiguration;
-	type ILoadResult<M, T extends ISandboxConfiguration> = import('vs/platform/window/electron-sandbox/window.js').ILoadResult<M, T>;
-	type ILoadOptions<T extends ISandboxConfiguration> = import('vs/platform/window/electron-sandbox/window.js').ILoadOptions<T>;
+	type ISandboxConfiguration = import('./vs/base/parts/sandbox/common/sandboxTypes.js').ISandboxConfiguration;
+	type ILoadResult<M, T extends ISandboxConfiguration> = import('./vs/platform/window/electron-sandbox/window.js').ILoadResult<M, T>;
+	type ILoadOptions<T extends ISandboxConfiguration> = import('./vs/platform/window/electron-sandbox/window.js').ILoadOptions<T>;
 	type IMainWindowSandboxGlobals = import('./vs/base/parts/sandbox/electron-sandbox/globals.js').IMainWindowSandboxGlobals;
 
 	const preloadGlobals: IMainWindowSandboxGlobals = (window as any).vscode; // defined by preload.ts

--- a/src/tsconfig.base.json
+++ b/src/tsconfig.base.json
@@ -12,12 +12,6 @@
 		"exactOptionalPropertyTypes": false,
 		"useUnknownInCatchVariables": false,
 		"forceConsistentCasingInFileNames": true,
-		"baseUrl": ".",
-		"paths": {
-			"vs/*": [
-				"./vs/*"
-			]
-		},
 		"target": "es2022",
 		"useDefineForClassFields": false,
 		"lib": [

--- a/src/vs/base/parts/sandbox/electron-sandbox/preload.ts
+++ b/src/vs/base/parts/sandbox/electron-sandbox/preload.ts
@@ -9,7 +9,7 @@
 
 	const { ipcRenderer, webFrame, contextBridge, webUtils } = require('electron');
 
-	type ISandboxConfiguration = import('vs/base/parts/sandbox/common/sandboxTypes.js').ISandboxConfiguration;
+	type ISandboxConfiguration = import('../common/sandboxTypes.js').ISandboxConfiguration;
 
 	//#region Utilities
 

--- a/src/vs/code/electron-sandbox/processExplorer/processExplorer.ts
+++ b/src/vs/code/electron-sandbox/processExplorer/processExplorer.ts
@@ -7,9 +7,9 @@
 
 (async function () {
 
-	type IBootstrapWindow = import('vs/platform/window/electron-sandbox/window.js').IBootstrapWindow;
-	type IProcessExplorerMain = import('vs/code/electron-sandbox/processExplorer/processExplorerMain.js').IProcessExplorerMain;
-	type ProcessExplorerWindowConfiguration = import('vs/platform/process/common/process.js').ProcessExplorerWindowConfiguration;
+	type IBootstrapWindow = import('../../../platform/window/electron-sandbox/window.js').IBootstrapWindow;
+	type IProcessExplorerMain = import('./processExplorerMain.js').IProcessExplorerMain;
+	type ProcessExplorerWindowConfiguration = import('../../../platform/process/common/process.js').ProcessExplorerWindowConfiguration;
 
 	const bootstrapWindow: IBootstrapWindow = (window as any).MonacoBootstrapWindow; // defined by bootstrap-window.ts
 

--- a/src/vs/code/electron-sandbox/workbench/workbench.ts
+++ b/src/vs/code/electron-sandbox/workbench/workbench.ts
@@ -10,10 +10,10 @@
 	// Add a perf entry right from the top
 	performance.mark('code/didStartRenderer');
 
-	type INativeWindowConfiguration = import('vs/platform/window/common/window.ts').INativeWindowConfiguration;
-	type IBootstrapWindow = import('vs/platform/window/electron-sandbox/window.js').IBootstrapWindow;
-	type IMainWindowSandboxGlobals = import('vs/base/parts/sandbox/electron-sandbox/globals.js').IMainWindowSandboxGlobals;
-	type IDesktopMain = import('vs/workbench/electron-sandbox/desktop.main.js').IDesktopMain;
+	type INativeWindowConfiguration = import('../../../platform/window/common/window.ts').INativeWindowConfiguration;
+	type IBootstrapWindow = import('../../../platform/window/electron-sandbox/window.js').IBootstrapWindow;
+	type IMainWindowSandboxGlobals = import('../../../base/parts/sandbox/electron-sandbox/globals.js').IMainWindowSandboxGlobals;
+	type IDesktopMain = import('../../../workbench/electron-sandbox/desktop.main.js').IDesktopMain;
 
 	const bootstrapWindow: IBootstrapWindow = (window as any).MonacoBootstrapWindow; 	// defined by bootstrap-window.ts
 	const preloadGlobals: IMainWindowSandboxGlobals = (window as any).vscode; 			// defined by preload.ts


### PR DESCRIPTION
After #236640, these paths are only used in a handful of import types. They can be removed, along with `baseUrl`.