### PR TITLE
Support extension specific default language

### DIFF
--- a/src/vs/platform/extensions/common/extensions.ts
+++ b/src/vs/platform/extensions/common/extensions.ts
@@ -266,6 +266,15 @@ export const EXTENSION_CATEGORIES = [
 	'Other',
 ];
 
+export interface ManifestL10nConfiguration {
+
+	/** The relative path to folder for l10n bundle files */
+	location: string;
+
+	/** Optional tag for default language of un-translated strings. */
+	defaultLocale?: string;
+}
+
 export interface IRelaxedExtensionManifest {
 	name: string;
 	displayName?: string;
@@ -278,7 +287,7 @@ export interface IRelaxedExtensionManifest {
 	preview?: boolean;
 	// For now this only supports pointing to l10n bundle files
 	// but it will be used for package.l10n.json files in the future
-	l10n?: string;
+	l10n?: string | ManifestL10nConfiguration;
 	icon?: string;
 	categories?: string[];
 	keywords?: string[];


### PR DESCRIPTION
Provide a mechanism for extension to specify it's own default language.
Allow extension owner to choose the language of untranslated string when using the builtin l10n API.

For motivation of this PR, please refer to #168127.

## Proposed Solution

We check the default language specified by extension maintainer from `package.json`.
And assume being `en` if not specified, for backward compatibility reason.

### Library Logic

When default-lang of extension match current VSCode language, we will not load any additional
string bundle. If default-lang is not matched, we will try loading `bundle.l10n.<locale>.json`
bundle file for current VSCode language.

The rest logic remain untouched, e.g. how we bypass translation if there is no corresponding bundle.

### Manifest Format in package.json

As proposed by TylerLeonhardt. In addition to original usage

```json
{
    "l10n": "./l10n"
}
```

Now we support the format like

```json
{
    "l10n": {
        "location": "./l10n",
        "defaultLocale": "en"
    }
}
```

as a way to specify default-lang for extensions by their maintainers.

## How to Verify

Is's not so easy to verify the if logic is correct, since that all related logic are coupled with
a. vscode current language b. file system state of particular extension.

### Prepare Extension

Write a extension that

1. `vscode.l10n.t` to translate a string.
2. specify l10n.defaultLocale other than `en`
3. provide a translated string bundle in English: `bundle.l10n.en.json`

Package the extension for following steps.

(I prepare a sample extension at https://github.com/wdhongtw/try-plugin, where the default-lang is `ja` Japanese.)

### Verify VSCode Logic

Now we need to launch a VSCode instance for three setup.

A. VSCode language match extension default-lang.
Try load the extension and verify the original string in `vscode.l10n.t` function call is used.

B. VSCode language does not match extension default-lang and be in any language that the extension
do provide translated string bundle.
Try load the extension and verify the translated string in `bundle.l10n.<locale>.json` is used.

C. VSCode language does not match extension default-lang and be in any language that extension
does not provide translated string bundle.
Try load the extension and verify the original string in `vscode.l10n.t` function call is used.

(To change the language of VSCode quickly, we can patch `defaultNLSConfiguration` in `src\vs\base\node\nls.ts`)