### PR TITLE
set word wrap on correct element

### DIFF
--- a/extensions/notebook-renderers/src/index.ts
+++ b/extensions/notebook-renderers/src/index.ts
@@ -404,9 +404,9 @@ function renderText(outputInfo: OutputItem, outputElement: HTMLElement, ctx: IRi
 	const outputOptions = { linesLimit: ctx.settings.lineLimit, scrollable: outputScrolling, trustHtml: false, linkifyFilePaths: ctx.settings.linkifyFilePaths };
 	const content = createOutputContent(outputInfo.id, text, outputOptions);
 	content.classList.add('output-plaintext');
-	outputElement.classList.toggle('word-wrap', ctx.settings.outputWordWrap);
+	content.classList.toggle('word-wrap', ctx.settings.outputWordWrap);
 	disposableStore.push(ctx.onDidChangeSettings(e => {
-		outputElement.classList.toggle('word-wrap', e.outputWordWrap);
+		content.classList.toggle('word-wrap', e.outputWordWrap);
 	}));
 
 	content.classList.toggle('scrollable', outputScrolling);

--- a/extensions/notebook-renderers/src/test/notebookRenderer.test.ts
+++ b/extensions/notebook-renderers/src/test/notebookRenderer.test.ts
@@ -152,8 +152,12 @@ suite('Notebook builtin output renderer', () => {
 			const inserted = outputElement.firstChild as HTMLElement;
 			assert.ok(inserted, `nothing appended to output element: ${outputElement.innerHTML}`);
 			assert.ok(outputElement.classList.contains('remove-padding'), `Padding should be removed for scrollable outputs ${outputElement.classList}`);
-			assert.ok(outputElement.classList.contains('word-wrap') && inserted.classList.contains('scrollable'),
-				`output content classList should contain word-wrap and scrollable ${inserted.classList}`);
+			if (mimeType === 'text/plain') {
+				assert.ok(inserted.classList.contains('word-wrap'), `Word wrap should be enabled for text/plain ${outputElement.classList}`);
+			} else {
+				assert.ok(outputElement.classList.contains('word-wrap') && inserted.classList.contains('scrollable'),
+					`output content classList should contain word-wrap and scrollable ${inserted.classList}`);
+			}
 			assert.ok(inserted.innerHTML.indexOf('>content</') > -1, `Content was not added to output element: ${outputElement.innerHTML}`);
 		});
 


### PR DESCRIPTION
fix https://github.com/microsoft/vscode-jupyter/issues/15759

the word-wrap class was set on a container element for plain-text, so it wasn't properly overriding the white-space css property