### PR TITLE
Skip image resize for small images

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/imageUtils.ts
+++ b/src/vs/workbench/contrib/chat/browser/imageUtils.ts
@@ -27,6 +27,9 @@ export async function resizeImage(data: Uint8Array): Promise<Uint8Array> {
 				const scaleFactor = 2048 / Math.max(width, height);
 				width = Math.round(width * scaleFactor);
 				height = Math.round(height * scaleFactor);
+			} else {
+				resolve(data);
+				return;
 			}
 
 			const scaleFactor = 768 / Math.min(width, height);


### PR DESCRIPTION
If the image is under 2048 we can just return the original data. This takes the paste controller part of pasting a smallish image from 100ms to 2ms 

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
