### PR TITLE
notifications - adjust positioning

### DIFF
--- a/src/vs/workbench/browser/parts/notifications/media/notificationsCenter.css
+++ b/src/vs/workbench/browser/parts/notifications/media/notificationsCenter.css
@@ -6,15 +6,15 @@
 .monaco-workbench > .notifications-center {
 	position: absolute;
 	z-index: 1000;
-	right: 8px;
-	bottom: 31px;
+	right: 11px; /* attempt to position at same location as a toast */
+	bottom: 33px; /* 22px status bar height + 11px (attempt to position at same location as a toast) */
 	display: none;
 	overflow: hidden;
 	border-radius: 4px;
 }
 
 .monaco-workbench.nostatusbar > .notifications-center {
-	bottom: 8px;
+	bottom: 11px; /* attempt to position at same location as a toast */
 }
 
 .monaco-workbench > .notifications-center.visible {

--- a/src/vs/workbench/browser/parts/notifications/media/notificationsToasts.css
+++ b/src/vs/workbench/browser/parts/notifications/media/notificationsToasts.css
@@ -7,7 +7,7 @@
 	position: absolute;
 	z-index: 1000;
 	right: 3px;
-	bottom: 26px;
+	bottom: 25px; /* 22px status bar height + 3px */
 	display: none;
 	overflow: hidden;
 }


### PR DESCRIPTION
When the center opens, it should show notifications exactly where the toast was

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
