### PR TITLE
Fix inline completion reuse

### DIFF
--- a/src/vs/editor/contrib/inlineCompletions/browser/model/inlineCompletionsSource.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/model/inlineCompletionsSource.ts
@@ -153,7 +153,8 @@ export class InlineCompletionsSource extends Disposable {
 			}
 
 			// Reuse Inline Edit if possible
-			if (activeInlineCompletion && activeInlineCompletion.isInlineEdit && activeInlineCompletion.canBeReused(this._textModel, position)) {
+			const newInlineEdit = updatedCompletions.completions.find(c => c.sourceInlineCompletion.isInlineEdit);
+			if (activeInlineCompletion && activeInlineCompletion.isInlineEdit && (activeInlineCompletion.canBeReused(this._textModel, position) || newInlineEdit?.hash() === activeInlineCompletion.inlineCompletion.hash())) {
 				updatedCompletions.dispose();
 				return false;
 			}

--- a/src/vs/editor/contrib/inlineCompletions/browser/model/inlineCompletionsSource.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/model/inlineCompletionsSource.ts
@@ -153,8 +153,7 @@ export class InlineCompletionsSource extends Disposable {
 			}
 
 			// Reuse Inline Edit if possible
-			const newInlineEdit = updatedCompletions.completions.find(c => c.sourceInlineCompletion.isInlineEdit);
-			if (activeInlineCompletion && activeInlineCompletion.isInlineEdit && (activeInlineCompletion.canBeReused(this._textModel, position) || newInlineEdit?.hash() === activeInlineCompletion.inlineCompletion.hash())) {
+			if (activeInlineCompletion && activeInlineCompletion.isInlineEdit && (activeInlineCompletion.canBeReused(this._textModel, position) || updatedCompletions.has(activeInlineCompletion.inlineCompletion) /* Inline Edit wins over completions if it's already been shown*/)) {
 				updatedCompletions.dispose();
 				return false;
 			}


### PR DESCRIPTION
Reuse active inline edit widget if incoming one is identical

Fixes microsoft/vscode-copilot#12094