### PR TITLE
feat: comprehensive key match scoring system

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/preferencesSearch.ts
+++ b/src/vs/workbench/contrib/preferences/browser/preferencesSearch.ts
@@ -139,7 +139,7 @@ export class LocalSearchProvider implements ISearchProvider {
 export class SettingMatches {
 	readonly matches: IRange[];
 	/** Whether to use the new key matching search algorithm that calculates more weights for each result */
-	useNewKeyMatchingSearch = false;
+	useNewKeyMatchingSearch: boolean = false;
 	matchType: SettingMatchType = SettingMatchType.None;
 	/**
 	 * A match score for key matches to allow comparing key matches against each other.

--- a/src/vs/workbench/contrib/preferences/browser/preferencesSearch.ts
+++ b/src/vs/workbench/contrib/preferences/browser/preferencesSearch.ts
@@ -138,6 +138,8 @@ export class LocalSearchProvider implements ISearchProvider {
 
 export class SettingMatches {
 	readonly matches: IRange[];
+	/** Whether to use the new key matching search algorithm that calculates more weights for each result */
+	useNewKeyMatchingSearch = false;
 	matchType: SettingMatchType = SettingMatchType.None;
 	/**
 	 * A match score for key matches to allow comparing key matches against each other.
@@ -153,6 +155,7 @@ export class SettingMatches {
 		valuesMatcher: (filter: string, setting: ISetting) => IRange[],
 		@IConfigurationService private readonly configurationService: IConfigurationService
 	) {
+		this.useNewKeyMatchingSearch = this.configurationService.getValue('workbench.settings.useWeightedKeySearch') === true;
 		this.matches = distinct(this._findMatchesInSetting(searchString, setting), (match) => `${match.startLineNumber}_${match.startColumn}_${match.endLineNumber}_${match.endColumn}_`);
 	}
 
@@ -182,30 +185,43 @@ export class SettingMatches {
 		const queryWords = new Set<string>(searchString.split(' '));
 		for (const word of queryWords) {
 			// Check if the key contains the word.
-			const keyMatches = matchesWords(word, settingKeyAsWords, true);
+			// Force contiguous matching iff we're using the new algorithm.
+			const keyMatches = matchesWords(word, settingKeyAsWords, this.useNewKeyMatchingSearch);
 			if (keyMatches?.length) {
 				keyMatchingWords.set(word, keyMatches.map(match => this.toKeyRange(setting, match)));
 			}
 		}
-		if (keyMatchingWords.size === queryWords.size) {
-			// All words in the query matched with something in the setting key.
-			this.matchType |= SettingMatchType.KeyMatch;
-			// Score based on how many words matched out of the entire key, penalizing longer setting names.
-			this.keyMatchScore = (keyMatchingWords.size / settingKeyAsWordsCount) + (1 / setting.key.length);
-		}
-		const keyMatches = matchesSubString(searchString, settingKeyAsWords);
-		if (keyMatches?.length) {
-			// Handles cases such as "editor formonpast" with missing letters.
-			keyMatchingWords.set(searchString, keyMatches.map(match => this.toKeyRange(setting, match)));
-			this.matchType |= SettingMatchType.KeyMatch;
-			this.keyMatchScore = keyMatchingWords.size;
+		if (this.useNewKeyMatchingSearch) {
+			if (keyMatchingWords.size === queryWords.size) {
+				// All words in the query matched with something in the setting key.
+				this.matchType |= SettingMatchType.KeyMatch;
+				// Score based on how many words matched out of the entire key, penalizing longer setting names.
+				this.keyMatchScore = (keyMatchingWords.size / settingKeyAsWordsCount) + (1 / setting.key.length);
+			}
+			const keyMatches = matchesSubString(searchString, settingKeyAsWords);
+			if (keyMatches?.length) {
+				// Handles cases such as "editor formonpast" with missing letters.
+				keyMatchingWords.set(searchString, keyMatches.map(match => this.toKeyRange(setting, match)));
+				this.matchType |= SettingMatchType.KeyMatch;
+				this.keyMatchScore = keyMatchingWords.size;
+			}
+		} else {
+			// Fall back to the old algorithm.
+			if (keyMatchingWords.size) {
+				this.matchType |= SettingMatchType.KeyMatch;
+				this.keyMatchScore = keyMatchingWords.size;
+			}
 		}
 		const keyIdMatches = matchesContiguousSubString(searchString, setting.key);
 		if (keyIdMatches?.length) {
 			// Handles cases such as "editor.formatonpaste" where the user tries searching for the ID.
 			keyMatchingWords.set(setting.key, keyIdMatches.map(match => this.toKeyRange(setting, match)));
-			this.matchType |= SettingMatchType.KeyMatch;
-			this.keyMatchScore = Math.max(this.keyMatchScore, searchString.length / setting.key.length);
+			if (this.useNewKeyMatchingSearch) {
+				this.matchType |= SettingMatchType.KeyMatch;
+				this.keyMatchScore = Math.max(this.keyMatchScore, searchString.length / setting.key.length);
+			} else {
+				this.matchType |= SettingMatchType.KeyIdMatch;
+			}
 		}
 
 		// Check if the match was for a language tag group setting such as [markdown].
@@ -217,15 +233,15 @@ export class SettingMatches {
 			return [...keyRanges];
 		}
 
-		// Exit early if the key already matched
-		if (this.matchType & SettingMatchType.KeyMatch) {
+		// New algorithm only: exit early if the key already matched.
+		if (this.useNewKeyMatchingSearch && (this.matchType & SettingMatchType.KeyMatch)) {
 			const keyRanges = keyMatchingWords.size ?
 				Array.from(keyMatchingWords.values()).flat() : [];
 			return [...keyRanges];
 		}
 
 		// Description search
-		if (this.searchDescription) {
+		if (this.searchDescription && this.matchType !== SettingMatchType.None) {
 			for (const word of queryWords) {
 				// Search the description lines.
 				for (let lineIndex = 0; lineIndex < setting.description.length; lineIndex++) {

--- a/src/vs/workbench/contrib/preferences/browser/preferencesSearch.ts
+++ b/src/vs/workbench/contrib/preferences/browser/preferencesSearch.ts
@@ -181,7 +181,6 @@ export class SettingMatches {
 
 		// Key search
 		const settingKeyAsWords: string = this._keyToLabel(setting.key);
-		const settingKeyAsWordsCount = settingKeyAsWords.split(' ').length;
 		const queryWords = new Set<string>(searchString.split(' '));
 		for (const word of queryWords) {
 			// Check if the key contains the word.
@@ -196,6 +195,7 @@ export class SettingMatches {
 				// All words in the query matched with something in the setting key.
 				this.matchType |= SettingMatchType.KeyMatch;
 				// Score based on how many words matched out of the entire key, penalizing longer setting names.
+				const settingKeyAsWordsCount = settingKeyAsWords.split(' ').length;
 				this.keyMatchScore = (keyMatchingWords.size / settingKeyAsWordsCount) + (1 / setting.key.length);
 			}
 			const keyMatches = matchesSubString(searchString, settingKeyAsWords);

--- a/src/vs/workbench/contrib/preferences/common/preferencesContribution.ts
+++ b/src/vs/workbench/contrib/preferences/common/preferencesContribution.ts
@@ -126,5 +126,11 @@ registry.registerConfiguration({
 			'default': 'filter',
 			'scope': ConfigurationScope.WINDOW
 		},
+		'workbench.settings.useWeightedKeySearch': {
+			'type': 'boolean',
+			'default': true,
+			'description': nls.localize('useWeightedKeySearch', "Controls whether to use a new weight calculation algorithm to order certain search results in the Settings editor. The only search results that will be affected are those where the search query has been determined to match the setting key, and the weights will be calculated in a way that places settings with more matched words and shorter names to the top of the search results."),
+			'scope': ConfigurationScope.WINDOW
+		}
 	}
 });

--- a/src/vs/workbench/contrib/preferences/common/preferencesContribution.ts
+++ b/src/vs/workbench/contrib/preferences/common/preferencesContribution.ts
@@ -128,9 +128,10 @@ registry.registerConfiguration({
 		},
 		'workbench.settings.useWeightedKeySearch': {
 			'type': 'boolean',
-			'default': true,
+			'default': false,
 			'description': nls.localize('useWeightedKeySearch', "Controls whether to use a new weight calculation algorithm to order certain search results in the Settings editor. The only search results that will be affected are those where the search query has been determined to match the setting key, and the weights will be calculated in a way that places settings with more matched words and shorter names to the top of the search results."),
-			'scope': ConfigurationScope.WINDOW
+			'scope': ConfigurationScope.WINDOW,
+			'tags': ['preview']
 		}
 	}
 });


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
Ref #226039

This PR adds a new scoring system for key matches in the Settings editor that prioritizes search results with more matching words and search results with shorter setting keys. It also adds another non-contiguous search to catch cases where the words don't exactly match.

As a result, "fomonpast" yields "editor.formatOnPaste" and "editor tab size" yields "editor.tabSize" as the first result.

On the current Stable and the current Insiders, "editor tab size" does not show "editor.tabSize" as the first result, and "fomonpast" does not yield "editor.formatOnPaste", so I believe this PR adds a significant improvement to the search experience in the Settings editor.

CC @sbatten