### PR TITLE
adjust terminal suggest font, line height when they change

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalSuggestAddon.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalSuggestAddon.ts
@@ -401,6 +401,9 @@ export class SuggestAddon extends Disposable implements ITerminalAddon, ISuggest
 		const fontInfo: ISimpleSuggestWidgetFontInfo = {
 			fontFamily: font.fontFamily,
 			fontSize: font.fontSize,
+			// In the editor's world, lineHeight is the pixels between the baselines of two lines of text
+			// In the terminal's world, lineHeight is the multiplier of the font size
+			// 1.5 is needed so that it's taller than a 16px icon
 			lineHeight: Math.ceil(c.lineHeight * font.fontSize * 1.5),
 			fontWeight: c.fontWeight.toString(),
 			letterSpacing: font.letterSpacing

--- a/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalSuggestAddon.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalSuggestAddon.ts
@@ -401,7 +401,7 @@ export class SuggestAddon extends Disposable implements ITerminalAddon, ISuggest
 		const fontInfo: ISimpleSuggestWidgetFontInfo = {
 			fontFamily: font.fontFamily,
 			fontSize: font.fontSize,
-			lineHeight: Math.ceil(c.fontSize * c.lineHeight * 1.5),
+			lineHeight: c.lineHeight,
 			fontWeight: c.fontWeight.toString(),
 			letterSpacing: font.letterSpacing
 		};

--- a/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalSuggestAddon.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalSuggestAddon.ts
@@ -401,7 +401,7 @@ export class SuggestAddon extends Disposable implements ITerminalAddon, ISuggest
 		const fontInfo: ISimpleSuggestWidgetFontInfo = {
 			fontFamily: font.fontFamily,
 			fontSize: font.fontSize,
-			lineHeight: c.lineHeight,
+			lineHeight: Math.ceil(c.lineHeight * font.fontSize * 1.5),
 			fontWeight: c.fontWeight.toString(),
 			letterSpacing: font.letterSpacing
 		};

--- a/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalSuggestAddon.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalSuggestAddon.ts
@@ -401,7 +401,7 @@ export class SuggestAddon extends Disposable implements ITerminalAddon, ISuggest
 		const fontInfo: ISimpleSuggestWidgetFontInfo = {
 			fontFamily: font.fontFamily,
 			fontSize: font.fontSize,
-			lineHeight: Math.ceil(1.5 * font.fontSize),
+			lineHeight: Math.ceil(c.fontSize * c.lineHeight * 1.5),
 			fontWeight: c.fontWeight.toString(),
 			letterSpacing: font.letterSpacing
 		};

--- a/src/vs/workbench/services/suggest/browser/simpleSuggestWidget.ts
+++ b/src/vs/workbench/services/suggest/browser/simpleSuggestWidget.ts
@@ -389,7 +389,6 @@ export class SimpleSuggestWidget extends Disposable {
 		// this._currentSuggestionDetails?.cancel();
 		// this._currentSuggestionDetails = undefined;
 
-
 		if (isFrozen && this._state !== State.Empty && this._state !== State.Hidden) {
 			this._setState(State.Frozen);
 			return;

--- a/src/vs/workbench/services/suggest/browser/simpleSuggestWidget.ts
+++ b/src/vs/workbench/services/suggest/browser/simpleSuggestWidget.ts
@@ -770,7 +770,7 @@ export class SimpleSuggestWidget extends Disposable {
 
 	private _getLayoutInfo() {
 		const fontInfo = this._getFontInfo();
-		const itemHeight = clamp(fontInfo.fontSize * fontInfo.lineHeight, 8, 1000);
+		const itemHeight = clamp(fontInfo.lineHeight, 8, 1000);
 		const statusBarHeight = !this._options.statusBarMenuId || !this._options.showStatusBarSettingId || !this._configurationService.getValue(this._options.showStatusBarSettingId) || this._state === State.Empty || this._state === State.Loading ? 0 : itemHeight;
 		const borderWidth = this._details.widget.borderWidth;
 		const borderHeight = 2 * borderWidth;

--- a/src/vs/workbench/services/suggest/browser/simpleSuggestWidget.ts
+++ b/src/vs/workbench/services/suggest/browser/simpleSuggestWidget.ts
@@ -23,6 +23,7 @@ import { IConfigurationService } from '../../../../platform/configuration/common
 import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
 import { canExpandCompletionItem, SimpleSuggestDetailsOverlay, SimpleSuggestDetailsWidget } from './simpleSuggestWidgetDetails.js';
 import { IContextKey, IContextKeyService, RawContextKey } from '../../../../platform/contextkey/common/contextkey.js';
+import { TerminalSettingId } from '../../../../platform/terminal/common/terminal.js';
 
 const $ = dom.$;
 
@@ -246,6 +247,10 @@ export class SimpleSuggestWidget extends Disposable {
 			if (e.affectsConfiguration('editor.suggest.showIcons')) {
 				applyIconStyle();
 			}
+			if (this._completionModel && e.affectsConfiguration(TerminalSettingId.FontSize) || e.affectsConfiguration(TerminalSettingId.LineHeight) || e.affectsConfiguration(TerminalSettingId.FontFamily)) {
+				this._layout(undefined);
+				this._list.splice(0, this._list.length, this._completionModel!.items);
+			}
 			if (_options.statusBarMenuId && _options.showStatusBarSettingId && e.affectsConfiguration(_options.showStatusBarSettingId)) {
 				const showStatusBar: boolean = _configurationService.getValue(_options.showStatusBarSettingId);
 				if (showStatusBar && !this._status) {
@@ -383,6 +388,7 @@ export class SimpleSuggestWidget extends Disposable {
 
 		// this._currentSuggestionDetails?.cancel();
 		// this._currentSuggestionDetails = undefined;
+
 
 		if (isFrozen && this._state !== State.Empty && this._state !== State.Hidden) {
 			this._setState(State.Frozen);
@@ -764,7 +770,7 @@ export class SimpleSuggestWidget extends Disposable {
 
 	private _getLayoutInfo() {
 		const fontInfo = this._getFontInfo();
-		const itemHeight = clamp(Math.ceil(fontInfo.lineHeight), 8, 1000);
+		const itemHeight = clamp(fontInfo.lineHeight, 8, 1000);
 		const statusBarHeight = !this._options.statusBarMenuId || !this._options.showStatusBarSettingId || !this._configurationService.getValue(this._options.showStatusBarSettingId) || this._state === State.Empty || this._state === State.Loading ? 0 : itemHeight;
 		const borderWidth = 1; //this._details.widget.borderWidth;
 		const borderHeight = 2 * borderWidth;

--- a/src/vs/workbench/services/suggest/browser/simpleSuggestWidget.ts
+++ b/src/vs/workbench/services/suggest/browser/simpleSuggestWidget.ts
@@ -180,7 +180,7 @@ export class SimpleSuggestWidget extends Disposable {
 		const applyIconStyle = () => this.element.domNode.classList.toggle('no-icons', !_configurationService.getValue('editor.suggest.showIcons'));
 		applyIconStyle();
 
-		const renderer = new SimpleSuggestWidgetItemRenderer(_getFontInfo);
+		const renderer = new SimpleSuggestWidgetItemRenderer(_getFontInfo, this._configurationService);
 		this._register(renderer);
 		this._listElement = dom.append(this.element.domNode, $('.tree'));
 		this._list = this._register(new List('SuggestWidget', this._listElement, {
@@ -770,9 +770,9 @@ export class SimpleSuggestWidget extends Disposable {
 
 	private _getLayoutInfo() {
 		const fontInfo = this._getFontInfo();
-		const itemHeight = clamp(fontInfo.lineHeight, 8, 1000);
+		const itemHeight = clamp(fontInfo.fontSize * fontInfo.lineHeight, 8, 1000);
 		const statusBarHeight = !this._options.statusBarMenuId || !this._options.showStatusBarSettingId || !this._configurationService.getValue(this._options.showStatusBarSettingId) || this._state === State.Empty || this._state === State.Loading ? 0 : itemHeight;
-		const borderWidth = 1; //this._details.widget.borderWidth;
+		const borderWidth = this._details.widget.borderWidth;
 		const borderHeight = 2 * borderWidth;
 
 		return {

--- a/src/vs/workbench/services/suggest/browser/simpleSuggestWidgetDetails.ts
+++ b/src/vs/workbench/services/suggest/browser/simpleSuggestWidgetDetails.ts
@@ -87,7 +87,7 @@ export class SimpleSuggestDetailsWidget {
 		const lineHeight = fontInfo.lineHeight;
 		const fontWeight = fontInfo.fontWeight;
 		const fontSizePx = `${fontSize}px`;
-		const lineHeightPx = `${lineHeight * fontSize}px`;
+		const lineHeightPx = `${lineHeight}px`;
 
 		this.domNode.style.fontSize = fontSizePx;
 		this.domNode.style.lineHeight = lineHeightPx;

--- a/src/vs/workbench/services/suggest/browser/simpleSuggestWidgetDetails.ts
+++ b/src/vs/workbench/services/suggest/browser/simpleSuggestWidgetDetails.ts
@@ -87,10 +87,10 @@ export class SimpleSuggestDetailsWidget {
 		const lineHeight = fontInfo.lineHeight;
 		const fontWeight = fontInfo.fontWeight;
 		const fontSizePx = `${fontSize}px`;
-		const lineHeightPx = `${lineHeight}px`;
+		const lineHeightPx = `${lineHeight * fontSize}px`;
 
 		this.domNode.style.fontSize = fontSizePx;
-		this.domNode.style.lineHeight = `${lineHeight / fontSize}`;
+		this.domNode.style.lineHeight = lineHeightPx;
 		this.domNode.style.fontWeight = fontWeight;
 		// this.domNode.style.fontFeatureSettings = fontInfo.fontFeatureSettings;
 		this._type.style.fontFamily = fontFamily;

--- a/src/vs/workbench/services/suggest/browser/simpleSuggestWidgetDetails.ts
+++ b/src/vs/workbench/services/suggest/browser/simpleSuggestWidgetDetails.ts
@@ -90,7 +90,7 @@ export class SimpleSuggestDetailsWidget {
 		const lineHeightPx = `${lineHeight}px`;
 
 		this.domNode.style.fontSize = fontSizePx;
-		this.domNode.style.lineHeight = lineHeightPx;
+		this.domNode.style.lineHeight = `${lineHeight / fontSize}`;
 		this.domNode.style.fontWeight = fontWeight;
 		// this.domNode.style.fontFeatureSettings = fontInfo.fontFeatureSettings;
 		this._type.style.fontFamily = fontFamily;

--- a/src/vs/workbench/services/suggest/browser/simpleSuggestWidgetRenderer.ts
+++ b/src/vs/workbench/services/suggest/browser/simpleSuggestWidgetRenderer.ts
@@ -99,7 +99,7 @@ export class SimpleSuggestWidgetItemRenderer implements IListRenderer<SimpleComp
 			const fontFeatureSettings = '';
 			const { fontFamily, fontSize, lineHeight, fontWeight, letterSpacing } = this._getFontInfo();
 			const fontSizePx = `${fontSize}px`;
-			const lineHeightPx = `${lineHeight * fontSize}px`;
+			const lineHeightPx = `${lineHeight}px`;
 			const letterSpacingPx = `${letterSpacing}px`;
 
 			root.style.fontSize = fontSizePx;

--- a/src/vs/workbench/services/suggest/browser/simpleSuggestWidgetRenderer.ts
+++ b/src/vs/workbench/services/suggest/browser/simpleSuggestWidgetRenderer.ts
@@ -12,6 +12,8 @@ import { Emitter, Event } from '../../../../base/common/event.js';
 import { createMatches } from '../../../../base/common/filters.js';
 import { DisposableStore } from '../../../../base/common/lifecycle.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
+import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
+import { TerminalSettingId } from '../../../../platform/terminal/common/terminal.js';
 
 export function getAriaId(index: number): string {
 	return `simple-suggest-aria-id-${index}`;
@@ -55,13 +57,16 @@ export class SimpleSuggestWidgetItemRenderer implements IListRenderer<SimpleComp
 	private readonly _onDidToggleDetails = new Emitter<void>();
 	readonly onDidToggleDetails: Event<void> = this._onDidToggleDetails.event;
 
+	private readonly _disposables = new DisposableStore();
+
 	readonly templateId = 'suggestion';
 
-	constructor(private readonly _getFontInfo: () => ISimpleSuggestWidgetFontInfo) {
+	constructor(private readonly _getFontInfo: () => ISimpleSuggestWidgetFontInfo, @IConfigurationService private readonly _configurationService: IConfigurationService) {
 	}
 
 	dispose(): void {
 		this._onDidToggleDetails.dispose();
+		this._disposables.dispose();
 	}
 
 	renderTemplate(container: HTMLElement): ISimpleSuggestionTemplateData {
@@ -94,7 +99,7 @@ export class SimpleSuggestWidgetItemRenderer implements IListRenderer<SimpleComp
 			const fontFeatureSettings = '';
 			const { fontFamily, fontSize, lineHeight, fontWeight, letterSpacing } = this._getFontInfo();
 			const fontSizePx = `${fontSize}px`;
-			const lineHeightPx = `${lineHeight}px`;
+			const lineHeightPx = `${lineHeight * fontSize}px`;
 			const letterSpacingPx = `${letterSpacing}px`;
 
 			root.style.fontSize = fontSizePx;
@@ -111,11 +116,11 @@ export class SimpleSuggestWidgetItemRenderer implements IListRenderer<SimpleComp
 
 		configureFont();
 
-		// data.disposables.add(this._editor.onDidChangeConfiguration(e => {
-		// 	if (e.hasChanged(EditorOption.fontInfo) || e.hasChanged(EditorOption.suggestFontSize) || e.hasChanged(EditorOption.suggestLineHeight)) {
-		// 		configureFont();
-		// 	}
-		// }));
+		this._disposables.add(this._configurationService.onDidChangeConfiguration(e => {
+			if (e.affectsConfiguration(TerminalSettingId.FontSize) || e.affectsConfiguration(TerminalSettingId.FontFamily) || e.affectsConfiguration(TerminalSettingId.FontWeight) || e.affectsConfiguration(TerminalSettingId.LineHeight)) {
+				configureFont();
+			}
+		}));
 
 		return { root, left, right, icon, colorspan, iconLabel, iconContainer, parametersLabel, qualifierLabel, detailsLabel, disposables };
 	}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
fix #238599

The crux of the issue was our version of line height vs the editor's. Ours has units of font size, while the editor's is in pixels.

The explanation for this line:

https://github.com/microsoft/vscode/blob/4765f5c9f608c32b013e60a4bce5d4f8e31a5ee9/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalSuggestAddon.ts#L404

Codicons have a min size of 16px, so if this is less than that, they'll get cutoff. Our default terminal value for font, 12px, and line height, 1px, mean that the icon will be cutoff by default without the use of a multiplier like 1.5.

You can also see this happens for the editor with a small font size. By default, the editor uses `18px`, which is 1.5* our default value. 
![Screenshot 2025-01-23 at 4 50 51 PM](https://github.com/user-attachments/assets/831a9716-5555-4c9a-a3d1-1ec73306b0f6)
