### PR TITLE
chat: invoke save participants only when accepting changes

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/tools/tools.ts
+++ b/src/vs/workbench/contrib/chat/browser/tools/tools.ts
@@ -12,6 +12,7 @@ import { localize } from '../../../../../nls.js';
 import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
 import { IWorkspaceContextService } from '../../../../../platform/workspace/common/workspace.js';
 import { IWorkbenchContribution } from '../../../../common/contributions.js';
+import { SaveReason } from '../../../../common/editor.js';
 import { ITextFileService } from '../../../../services/textfile/common/textfiles.js';
 import { ICodeMapperService } from '../../common/chatCodeMapperService.js';
 import { IChatEditingService } from '../../common/chatEditingService.js';
@@ -171,7 +172,10 @@ class EditTool implements IToolImpl {
 			dispose.dispose();
 		});
 
-		await this.textFileService.save(uri);
+		await this.textFileService.save(uri, {
+			reason: SaveReason.AUTO,
+			skipSaveParticipants: true,
+		});
 
 		return {
 			content: [{ kind: 'text', value: 'The file was edited successfully' }]


### PR DESCRIPTION
- Don't trigger save participants in edits from the edit file tool. Fixes the bad undo stack we discussed this morning.
- When modifications are accepted, if the file is not dirty, then trigger save participants. This lets you still get nice formatting.



https://github.com/user-attachments/assets/82c3818f-c3fc-4314-b8e0-6c9049a5e64a

