### PR TITLE
enable typescript commands when only config files are open

### DIFF
--- a/extensions/typescript-language-features/src/lazyClientHost.ts
+++ b/extensions/typescript-language-features/src/lazyClientHost.ts
@@ -15,7 +15,7 @@ import { ActiveJsTsEditorTracker } from './ui/activeJsTsEditorTracker';
 import ManagedFileContextManager from './ui/managedFileContext';
 import { ServiceConfigurationProvider } from './configuration/configuration';
 import * as fileSchemes from './configuration/fileSchemes';
-import { standardLanguageDescriptions } from './configuration/languageDescription';
+import { standardLanguageDescriptions, isJsConfigOrTsConfigFileName } from './configuration/languageDescription';
 import { Lazy, lazy } from './utils/lazy';
 import { Logger } from './logging/logger';
 import { PluginManager } from './tsServer/plugins';
@@ -97,6 +97,10 @@ function isSupportedDocument(
 	supportedLanguage: readonly string[],
 	document: vscode.TextDocument
 ): boolean {
+	//Activate for JS/TS config files
+	if (isJsConfigOrTsConfigFileName(document.fileName)) {
+		return true;
+	}
 	return supportedLanguage.indexOf(document.languageId) >= 0
 		&& !fileSchemes.disabledSchemes.has(document.uri.scheme);
 }

--- a/extensions/typescript-language-features/src/lazyClientHost.ts
+++ b/extensions/typescript-language-features/src/lazyClientHost.ts
@@ -97,10 +97,6 @@ function isSupportedDocument(
 	supportedLanguage: readonly string[],
 	document: vscode.TextDocument
 ): boolean {
-	//Activate for JS/TS config files
-	if (isJsConfigOrTsConfigFileName(document.fileName)) {
-		return true;
-	}
-	return supportedLanguage.indexOf(document.languageId) >= 0
+	return (supportedLanguage.indexOf(document.languageId) >= 0 || isJsConfigOrTsConfigFileName(document.fileName))
 		&& !fileSchemes.disabledSchemes.has(document.uri.scheme);
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
this solves  #237358.

see my previous PR here #238500 (reopening with clean commit history) @mjbvz I found the source of the issue, the ManagedFileContextManager was not being instantiated if only config files had been opened, this should address the root cause, all typescript commands should be available to config files now.