### PR TITLE
# Allow inline completion supression via configuration

### DIFF
--- a/src/vs/editor/contrib/suggest/browser/suggestModel.ts
+++ b/src/vs/editor/contrib/suggest/browser/suggestModel.ts
@@ -110,11 +110,12 @@ function canShowQuickSuggest(editor: ICodeEditor, contextKeyService: IContextKey
 		// Allow if there is no inline suggestion.
 		return true;
 	}
+	const suppressSuggestionConfig = !editor.getOption(EditorOption.inlineSuggest).suppressSuggestions;
 	const suppressSuggestions = contextKeyService.getContextKeyValue<boolean | undefined>(InlineCompletionContextKeys.suppressSuggestions.key);
 	if (suppressSuggestions !== undefined) {
-		return !suppressSuggestions;
+		return !suppressSuggestions || suppressSuggestionConfig;
 	}
-	return !editor.getOption(EditorOption.inlineSuggest).suppressSuggestions;
+	return suppressSuggestionConfig;
 }
 
 function canShowSuggestOnTriggerCharacters(editor: ICodeEditor, contextKeyService: IContextKeyService, configurationService: IConfigurationService): boolean {
@@ -122,11 +123,12 @@ function canShowSuggestOnTriggerCharacters(editor: ICodeEditor, contextKeyServic
 		// Allow if there is no inline suggestion.
 		return true;
 	}
+	const suppressSuggestionConfig = !editor.getOption(EditorOption.inlineSuggest).suppressSuggestions;
 	const suppressSuggestions = contextKeyService.getContextKeyValue<boolean | undefined>(InlineCompletionContextKeys.suppressSuggestions.key);
 	if (suppressSuggestions !== undefined) {
-		return !suppressSuggestions;
+		return !suppressSuggestions || suppressSuggestionConfig;
 	}
-	return !editor.getOption(EditorOption.inlineSuggest).suppressSuggestions;
+	return suppressSuggestionConfig;
 }
 
 export class SuggestModel implements IDisposable {

--- a/src/vs/editor/contrib/suggest/browser/suggestModel.ts
+++ b/src/vs/editor/contrib/suggest/browser/suggestModel.ts
@@ -112,8 +112,8 @@ function canShowQuickSuggest(editor: ICodeEditor, contextKeyService: IContextKey
 	}
 	const suppressSuggestionConfig = !editor.getOption(EditorOption.inlineSuggest).suppressSuggestions;
 	const suppressSuggestions = contextKeyService.getContextKeyValue<boolean | undefined>(InlineCompletionContextKeys.suppressSuggestions.key);
-	if (suppressSuggestions !== undefined) {
-		return !suppressSuggestions || suppressSuggestionConfig;
+	if (suppressSuggestionConfig && suppressSuggestions !== undefined) {
+		return !suppressSuggestions;
 	}
 	return suppressSuggestionConfig;
 }
@@ -125,8 +125,8 @@ function canShowSuggestOnTriggerCharacters(editor: ICodeEditor, contextKeyServic
 	}
 	const suppressSuggestionConfig = !editor.getOption(EditorOption.inlineSuggest).suppressSuggestions;
 	const suppressSuggestions = contextKeyService.getContextKeyValue<boolean | undefined>(InlineCompletionContextKeys.suppressSuggestions.key);
-	if (suppressSuggestions !== undefined) {
-		return !suppressSuggestions || suppressSuggestionConfig;
+	if (suppressSuggestionConfig && suppressSuggestions !== undefined) {
+		return !suppressSuggestions;
 	}
 	return suppressSuggestionConfig;
 }


### PR DESCRIPTION
# Problem statement

Currently all inline completions would fail this check due to the suppressSuggest being set to false on the extHostLanguageFeatures.ts . The check that sets this value inside the inlineCompletionContextKeys.ts always sets the value once a completion is visible, meaning it is always false.


## Proposal
Can we instead allow the setting value to be used as a additional check? So that users wanting to disable this behavior can choose to do so.