### PR TITLE
Properly trim prefixes in inline edits

### DIFF
--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -4250,7 +4250,7 @@ class InlineEditorSuggest extends BaseEditorOption<EditorOption.inlineSuggest, I
 					useMixedLinesDiff: 'forStableInsertions',
 					useInterleavedLinesDiff: 'never',
 					useGutterIndicator: true,
-					useCodeOverlay: 'whenPossible',
+					useCodeOverlay: 'moveCodeWhenPossible',
 				},
 			},
 		};

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/utils.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/utils.ts
@@ -14,6 +14,7 @@ import { OS } from '../../../../../../base/common/platform.js';
 import { getIndentationLength, splitLines } from '../../../../../../base/common/strings.js';
 import { URI } from '../../../../../../base/common/uri.js';
 import { MenuEntryActionViewItem } from '../../../../../../platform/actions/browser/menuEntryActionViewItem.js';
+import { ICodeEditor } from '../../../../../browser/editorBrowser.js';
 import { ObservableCodeEditor } from '../../../../../browser/observableCodeEditor.js';
 import { Point } from '../../../../../browser/point.js';
 import { Rect } from '../../../../../browser/rect.js';
@@ -24,6 +25,7 @@ import { Position } from '../../../../../common/core/position.js';
 import { Range } from '../../../../../common/core/range.js';
 import { SingleTextEdit, TextEdit } from '../../../../../common/core/textEdit.js';
 import { RangeMapping } from '../../../../../common/diff/rangeMapping.js';
+import { indentOfLine } from '../../../../../common/model/textModel.js';
 
 export function maxContentWidthInRange(editor: ObservableCodeEditor, range: LineRange, reader: IReader | undefined): number {
 	editor.layoutInfo.read(reader);
@@ -64,6 +66,22 @@ export function getOffsetForPos(editor: ObservableCodeEditor, pos: Position, rea
 	const lineContentWidth = editor.editor.getOffsetForColumn(pos.lineNumber, pos.column);
 
 	return lineContentWidth;
+}
+
+export function getPrefixTrim(diffRanges: Range[], originalLinesRange: LineRange, modifiedLines: string[], editor: ICodeEditor): { prefixTrim: number; prefixLeftOffset: number } {
+	const textModel = editor.getModel();
+	if (!textModel) {
+		return { prefixTrim: 0, prefixLeftOffset: 0 };
+	}
+
+	const replacementStart = diffRanges.map(r => r.isSingleLine() ? r.startColumn - 1 : 0);
+	const originalIndents = originalLinesRange.mapToLineArray(line => indentOfLine(textModel.getLineContent(line)));
+	const modifiedIndents = modifiedLines.map(line => indentOfLine(line));
+	const prefixTrim = Math.min(...replacementStart, ...originalIndents, ...modifiedIndents);
+
+	const prefixLeftOffset = editor.getOffsetForColumn(originalLinesRange.startLineNumber, prefixTrim + 1);
+
+	return { prefixTrim, prefixLeftOffset };
 }
 
 export class StatusBarViewItem extends MenuEntryActionViewItem {

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/wordReplacementView.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/wordReplacementView.ts
@@ -18,7 +18,7 @@ import { SingleTextEdit } from '../../../../../common/core/textEdit.js';
 import { ILanguageService } from '../../../../../common/languages/language.js';
 import { LineTokens } from '../../../../../common/tokens/lineTokens.js';
 import { TokenArray } from '../../../../../common/tokens/tokenArray.js';
-import { mapOutFalsy, n, rectToProps } from './utils.js';
+import { getPrefixTrim, mapOutFalsy, n, rectToProps } from './utils.js';
 import { localize } from '../../../../../../nls.js';
 import { IInlineEditsView } from './sideBySideDiff.js';
 import { Range } from '../../../../../common/core/range.js';
@@ -274,35 +274,13 @@ export class LineReplacementView extends Disposable implements IInlineEditsView 
 		stickiness: TrackedRangeStickiness.NeverGrowsWhenTypingAtEdges
 	};
 
-	private readonly maxPrefixTrim = derived(this, reader => {
-		const maxPrefixTrim = Math.max(...this._replacements.flatMap(r => [r.originalRange, r.modifiedRange]).map(r => r.isSingleLine() ? r.startColumn - 1 : 0));
-		if (maxPrefixTrim === 0) {
-			return 0;
-		}
-
-		const textModel = this._editor.editor.getModel()!;
-
-		const getLineTrimColLength = (line: string) => {
-			let i = 0;
-			while (i < line.length && line[i] === ' ') { i++; }
-			return i;
-		};
-
-		// TODO: make sure this works for tabs
-		return Math.min(
-			maxPrefixTrim,
-			...this._originalRange.mapToLineArray(line => getLineTrimColLength(textModel.getLineContent(line))),
-			...this._modifiedLines.map(line => getLineTrimColLength(line))
-		);
-	});
+	private readonly _maxPrefixTrim = getPrefixTrim(this._replacements.flatMap(r => [r.originalRange, r.modifiedRange]), this._originalRange, this._modifiedLines, this._editor.editor);
 
 	private readonly _modifiedLineElements = derived(reader => {
-
-		const maxPrefixTrim = this.maxPrefixTrim.read(reader);
-
 		const lines = [];
 		let requiredWidth = 0;
 
+		const maxPrefixTrim = this._maxPrefixTrim.prefixTrim;
 		const modifiedBubbles = rangesToBubbleRanges(this._replacements.map(r => r.modifiedRange)).map(r => new Range(r.startLineNumber, r.startColumn - maxPrefixTrim, r.endLineNumber, r.endColumn - maxPrefixTrim));
 
 		const textModel = this._editor.model.get()!;
@@ -351,12 +329,12 @@ export class LineReplacementView extends Disposable implements IInlineEditsView 
 		const PADDING = 4;
 
 		const editorModel = this._editor.editor.getModel()!;
-		const maxPrefixTrim = this.maxPrefixTrim.read(reader);
+		const { prefixTrim, prefixLeftOffset } = this._maxPrefixTrim;
 
-		// TODO, correctly count tabs
+		// TODO: correctly count tabs
 		const originalLineContents: string[] = [];
 		this._originalRange.forEach(line => originalLineContents.push(editorModel.getLineContent(line)));
-		const maxOriginalLineLength = Math.max(...originalLineContents.map(l => l.length)) - maxPrefixTrim;
+		const maxOriginalLineLength = Math.max(...originalLineContents.map(l => l.length)) - prefixTrim;
 		const maxLineWidth = Math.max(maxOriginalLineLength * w, requiredWidth);
 
 		const startLineNumber = this._originalRange.startLineNumber;
@@ -369,11 +347,9 @@ export class LineReplacementView extends Disposable implements IInlineEditsView 
 			return undefined;
 		}
 
-		const prefixTrimOffset = maxPrefixTrim * w;
-
 		// Box Widget positioning
 		const originalLinesOverlay = Rect.fromLeftTopWidthHeight(
-			editorLeftOffset + prefixTrimOffset,
+			editorLeftOffset + prefixLeftOffset,
 			topOfOriginalLines,
 			maxLineWidth,
 			bottomOfOriginalLines - topOfOriginalLines + PADDING
@@ -407,7 +383,7 @@ export class LineReplacementView extends Disposable implements IInlineEditsView 
 			lowerBackground,
 			lowerText,
 			padding: PADDING,
-			minContentWidthRequired: prefixTrimOffset + maxLineWidth + PADDING * 2,
+			minContentWidthRequired: maxLineWidth + PADDING * 2,
 		};
 	});
 


### PR DESCRIPTION
Implement a function to calculate prefix trimming for inline edits, enhancing the handling of original and modified lines. Remove obsolete code related to prefix trimming.