### PR TITLE
Git - use git command to retrieve push and fetch URLs when possible

### DIFF
--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -2642,18 +2642,22 @@ export class Repository {
 		const remotes: MutableRemote[] = [];
 
 		try {
-			// Attempt to parse the config file
-			remotes.push(...await this.getRemotesFS());
+			// Attempt to call git to get the remotes
+			remotes.push(...await this.getRemotesGit());
 
 			if (remotes.length === 0) {
-				this.logger.info('[Git][getRemotes] No remotes found in the git config file');
+				this.logger.info('[Git][getRemotes] No remotes returned from git');
 			}
 		}
 		catch (err) {
 			this.logger.warn(`[Git][getRemotes] Error: ${err.message}`);
 
-			// Fallback to using git to get the remotes
-			remotes.push(...await this.getRemotesGit());
+			// Fallback to parsing the config file
+			remotes.push(...await this.getRemotesFS());
+
+			if (remotes.length === 0) {
+				this.logger.info('[Git][getRemotes] No remotes found in the git config file');
+			}
 		}
 
 		for (const remote of remotes) {

--- a/extensions/git/src/test/smoke.test.ts
+++ b/extensions/git/src/test/smoke.test.ts
@@ -174,4 +174,16 @@ suite('git smoke test', function () {
 		assert.strictEqual(repository.state.workingTreeChanges.length, 0);
 		assert.strictEqual(repository.state.indexChanges.length, 0);
 	});
+
+	test('remotes are correctly resolved', async function () {
+		cp.execSync('git remote add origin alias', { cwd });
+		cp.execSync('git config url.https://example.com/.insteadOf alias', { cwd });
+
+		await repository.status();
+
+		assert.strictEqual(repository.state.remotes.length, 1);
+		assert.strictEqual(repository.state.remotes[0].name, 'origin');
+		assert.strictEqual(repository.state.remotes[0].fetchUrl, 'https://example.com/');
+		assert.strictEqual(repository.state.remotes[0].pushUrl, 'https://example.com/');
+	});
 });


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Currently, the git extension API does not respect `url.<base>.insteadOf` configured in the global `.gitconfig` in most cases.
This behavior is problematic for some users of the vscode-pull-request-github extension.

This pull request fixes the behavior by using the `git` command to retrieve remote information when possible.

fixes: #174941