### PR TITLE
Fix whitespace insertion rendered as deletion bug

### DIFF
--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/view.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/view.ts
@@ -235,7 +235,7 @@ export class InlineEditsView extends Disposable {
 			return 'ghostText';
 		}
 
-		if (inner.every(m => newText.getValueOfRange(m.modifiedRange).trim() === '')) {
+		if (inner.every(m => newText.getValueOfRange(m.modifiedRange).trim() === '' && edit.originalText.getValueOfRange(m.originalRange).trim() !== '')) {
 			return 'deletion';
 		}
 


### PR DESCRIPTION
Address a bug where whitespace insertions were incorrectly identified as deletions in the inline edits view.