### PR TITLE
tools: allow followup message with implicit cancel on tool confirmation

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/actions/chatExecuteActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatExecuteActions.ts
@@ -432,7 +432,10 @@ export class CancelAction extends Action2 {
 			icon: Codicon.stopCircle,
 			menu: {
 				id: MenuId.ChatExecute,
-				when: ContextKeyExpr.or(ChatContextKeys.requestInProgress, ContextKeyExpr.and(ChatContextKeys.location.isEqualTo(ChatAgentLocation.EditingSession), applyingChatEditsContextKey)),
+				when: ContextKeyExpr.or(
+					ChatContextKeys.requestInProgress,
+					ContextKeyExpr.and(ChatContextKeys.location.isEqualTo(ChatAgentLocation.EditingSession), applyingChatEditsContextKey)
+				),
 				order: 4,
 				group: 'navigation',
 			},

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/chatToolInvocationPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/chatToolInvocationPart.ts
@@ -91,7 +91,9 @@ class ChatToolInvocationSubPart extends Disposable {
 				toolInvocation.confirmed.complete(button.data);
 			}));
 			this._onDidChangeHeight.input = confirmWidget.onDidChangeHeight;
-			toolInvocation.confirmed.p.then(() => this._onNeedsRerender.fire());
+			toolInvocation.confirmed.p.then(() => {
+				this._onNeedsRerender.fire();
+			});
 		} else {
 			const content = typeof toolInvocation.invocationMessage === 'string' ?
 				new MarkdownString().appendText(toolInvocation.invocationMessage + '…') :

--- a/src/vs/workbench/contrib/chat/browser/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatWidget.ts
@@ -1098,6 +1098,8 @@ export class ChatWidget extends Disposable implements IChatWidget {
 				currentEditingSession?.remove(WorkingSetEntryRemovalReason.User, ...unconfirmedSuggestions);
 			}
 
+			this.chatService.cancelCurrentRequestForSession(this.viewModel.sessionId);
+
 			const result = await this.chatService.sendRequest(this.viewModel.sessionId, input, {
 				userSelectedModelId: this.inputPart.currentLanguageModel,
 				location: this.location,


### PR DESCRIPTION
- Make 'requestInProgress' false while waiting for a tool confirmation
- Cancel pending requests when sending a new request via the chat input

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
