### PR TITLE
set `top` on resize so widget is positioned correctly

### DIFF
--- a/src/vs/workbench/services/suggest/browser/simpleSuggestWidget.ts
+++ b/src/vs/workbench/services/suggest/browser/simpleSuggestWidget.ts
@@ -760,7 +760,9 @@ export class SimpleSuggestWidget extends Disposable {
 
 		this._listElement.style.width = `${width}px`;
 		this.element.layout(height, width);
-
+		if (this._cursorPosition) {
+			this.element.domNode.style.top = `${this._cursorPosition.top - height}px`;
+		}
 		this._positionDetails();
 	}
 


### PR DESCRIPTION
fix #235080

https://github.com/user-attachments/assets/c4aa4ae2-fe0b-403c-a0c5-90b2954b0f40

