### PR TITLE
Use `shellIntegration.env` for  `~` and `~/` completions

### DIFF
--- a/extensions/terminal-suggest/src/terminalSuggestMain.ts
+++ b/extensions/terminal-suggest/src/terminalSuggestMain.ts
@@ -141,6 +141,7 @@ export async function activate(context: vscode.ExtensionContext) {
 				const homeDirCompletion = result.items.find(i => i.label === '~');
 				if (homeDirCompletion && terminal.shellIntegration.env.HOME) {
 					homeDirCompletion.documentation = getFriendlyFilePath(vscode.Uri.file(terminal.shellIntegration.env.HOME), pathSeparator);
+					homeDirCompletion.kind = vscode.TerminalCompletionItemKind.Folder;
 				}
 			}
 

--- a/extensions/terminal-suggest/src/terminalSuggestMain.ts
+++ b/extensions/terminal-suggest/src/terminalSuggestMain.ts
@@ -135,8 +135,15 @@ export async function activate(context: vscode.ExtensionContext) {
 			const commands = [...commandsInPath.completionResources, ...builtinCommands];
 
 			const prefix = getPrefix(terminalContext.commandLine, terminalContext.cursorPosition);
-
+			const pathSeparator = isWindows ? '\\' : '/';
 			const result = await getCompletionItemsFromSpecs(availableSpecs, terminalContext, commands, prefix, terminal.shellIntegration?.cwd, token);
+			if (terminal.shellIntegration?.env) {
+				const homeDirCompletion = result.items.find(i => i.label === '~');
+				if (homeDirCompletion && terminal.shellIntegration.env.HOME) {
+					homeDirCompletion.documentation = getFriendlyFilePath(vscode.Uri.file(terminal.shellIntegration.env.HOME), pathSeparator);
+				}
+			}
+
 			if (result.cwd && (result.filesRequested || result.foldersRequested)) {
 				return new vscode.TerminalCompletionList(result.items, { filesRequested: result.filesRequested, foldersRequested: result.foldersRequested, cwd: result.cwd, pathSeparator: isWindows ? '\\' : '/', env: terminal.shellIntegration?.env });
 			}

--- a/extensions/terminal-suggest/src/terminalSuggestMain.ts
+++ b/extensions/terminal-suggest/src/terminalSuggestMain.ts
@@ -138,7 +138,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
 			const result = await getCompletionItemsFromSpecs(availableSpecs, terminalContext, commands, prefix, terminal.shellIntegration?.cwd, token);
 			if (result.cwd && (result.filesRequested || result.foldersRequested)) {
-				return new vscode.TerminalCompletionList(result.items, { filesRequested: result.filesRequested, foldersRequested: result.foldersRequested, cwd: result.cwd, pathSeparator: isWindows ? '\\' : '/' });
+				return new vscode.TerminalCompletionList(result.items, { filesRequested: result.filesRequested, foldersRequested: result.foldersRequested, cwd: result.cwd, pathSeparator: isWindows ? '\\' : '/', env: terminal.shellIntegration?.env });
 			}
 			return result.items;
 		}

--- a/extensions/terminal-suggest/src/terminalSuggestMain.ts
+++ b/extensions/terminal-suggest/src/terminalSuggestMain.ts
@@ -140,7 +140,7 @@ export async function activate(context: vscode.ExtensionContext) {
 			if (terminal.shellIntegration?.env) {
 				const homeDirCompletion = result.items.find(i => i.label === '~');
 				if (homeDirCompletion && terminal.shellIntegration.env.HOME) {
-					homeDirCompletion.documentation = getFriendlyFilePath(vscode.Uri.file(terminal.shellIntegration.env.HOME), pathSeparator);
+					homeDirCompletion.documentation = getFriendlyResourcePath(vscode.Uri.file(terminal.shellIntegration.env.HOME), pathSeparator, vscode.TerminalCompletionItemKind.Folder);
 					homeDirCompletion.kind = vscode.TerminalCompletionItemKind.Folder;
 				}
 			}
@@ -277,7 +277,7 @@ async function getCommandsInPath(env: { [key: string]: string | undefined } = pr
 			const fileResource = vscode.Uri.file(path);
 			const files = await vscode.workspace.fs.readDirectory(fileResource);
 			for (const [file, fileType] of files) {
-				const formattedPath = getFriendlyFilePath(vscode.Uri.joinPath(fileResource, file), pathSeparator);
+				const formattedPath = getFriendlyResourcePath(vscode.Uri.joinPath(fileResource, file), pathSeparator);
 				if (!labels.has(file) && fileType !== vscode.FileType.Unknown && fileType !== vscode.FileType.Directory && await isExecutable(formattedPath, cachedWindowsExecutableExtensions)) {
 					executables.add({ label: file, detail: formattedPath });
 					labels.add(file);
@@ -547,11 +547,16 @@ function getFirstCommand(commandLine: string): string | undefined {
 	return firstCommand;
 }
 
-function getFriendlyFilePath(uri: vscode.Uri, pathSeparator: string): string {
+function getFriendlyResourcePath(uri: vscode.Uri, pathSeparator: string, kind?: vscode.TerminalCompletionItemKind): string {
 	let path = uri.fsPath;
 	// Ensure drive is capitalized on Windows
 	if (pathSeparator === '\\' && path.match(/^[a-zA-Z]:\\/)) {
 		path = `${path[0].toUpperCase()}:${path.slice(2)}`;
+	}
+	if (kind === vscode.TerminalCompletionItemKind.Folder) {
+		if (!path.endsWith(pathSeparator)) {
+			path += pathSeparator;
+		}
 	}
 	return path;
 }

--- a/src/vs/workbench/contrib/terminalContrib/suggest/test/browser/terminalCompletionService.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/test/browser/terminalCompletionService.test.ts
@@ -162,6 +162,20 @@ suite('TerminalCompletionService', () => {
 				{ label: './../', detail: '/' },
 			], { replacementIndex: 3, replacementLength: 3 });
 		});
+		test('cd ~/| should return home folder completions', async () => {
+			const resourceRequestConfig: TerminalResourceRequestConfig = {
+				cwd: URI.parse('file:///test/folder1'),// Updated to reflect home directory
+				foldersRequested: true,
+				pathSeparator,
+				shouldNormalizePrefix: true,
+				env: { HOME: '/test/' }
+			};
+			const result = await terminalCompletionService.resolveResources(resourceRequestConfig, 'cd ~/', 5, provider);
+
+			assertCompletions(result, [
+				{ label: '~/', detail: '/test/' },
+			], { replacementIndex: 3, replacementLength: 2 });
+		});
 	});
 
 	suite('resolveResources should handle file and folder completion requests correctly', () => {

--- a/src/vscode-dts/vscode.proposed.terminalCompletionProvider.d.ts
+++ b/src/vscode-dts/vscode.proposed.terminalCompletionProvider.d.ts
@@ -128,5 +128,9 @@ declare module 'vscode' {
 		 * The path separator to use when constructing paths.
 		 */
 		pathSeparator: string;
+		/**
+		 * Environment variables to use when constructing paths.
+		 */
+		env?: { [key: string]: string | null | undefined };
 	}
 }


### PR DESCRIPTION
Only works for me in brand new`pwsh` terminals atm - `env` is undefined for `bath` and `zsh` 

<img width="479" alt="Screenshot 2025-01-24 at 3 39 36 PM" src="https://github.com/user-attachments/assets/e678f930-bd54-43d7-9c54-967f8c1769ed" />

![Screenshot 2025-01-24 at 4 10 35 PM](https://github.com/user-attachments/assets/648d3774-1799-4bdb-8575-1f237fc1365b)

An issue is it's appearing all the way at the bottom: 

![Screenshot 2025-01-24 at 4 10 49 PM](https://github.com/user-attachments/assets/9245e6b5-c19b-42b0-a69b-396809f78d5e)

We can polish this, but do we want it to be a command with that detail? Or just a folder?

fixes https://github.com/microsoft/vscode/issues/234352