### PR TITLE
fix: check whether lastFocusedList is valid when assigned

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminalActions.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalActions.ts
@@ -61,6 +61,7 @@ import { isKeyboardEvent, isMouseEvent, isPointerEvent } from '../../../../base/
 import { editorGroupToColumn } from '../../../services/editor/common/editorGroupColumn.js';
 import { InstanceContext } from './terminalContextMenu.js';
 import { AccessibleViewProviderId } from '../../../../platform/accessibility/browser/accessibleView.js';
+import { TerminalTabList } from './terminalTabsList.js';
 
 export const switchTerminalActionViewItemSeparator = '\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500';
 export const switchTerminalShowTabsTitle = localize('showTerminalTabs', "Show Tabs");
@@ -1463,7 +1464,8 @@ function getSelectedInstances(accessor: ServicesAccessor, args?: unknown, args2?
 	const terminalGroupService = accessor.get(ITerminalGroupService);
 	const result: ITerminalInstance[] = [];
 
-	const list = listService.lastFocusedList;
+	// Assign list only if it's an instance of TerminalTabList (#234791)
+	const list = listService.lastFocusedList instanceof TerminalTabList ? listService.lastFocusedList : undefined;
 	// Get selected tab list instance(s)
 	const selections = list?.getSelection();
 	// Get inline tab instance if there are not tab list selections #196578


### PR DESCRIPTION
Fixes #234791

## Steps to Reproduce
1. Open a terminal.
2. Click on the terminal name button.
3. Choose "Change color..." and select any color in the modal.
4. Click on the terminal name button again.
5. Try "Rename...", "Split terminal", or "Kill terminal."
6. Notice the buttons don't work.

## Issue
The problem happens when you pick a color from the modal. When the color is selected, the modal briefly grabs focus, which triggers an `onDidFocus` event. This event updates `_lastFocusedWidget` in `listService`, which is then mistakenly used in the function `getSelectedInstances`. The function assumes that `lastFocusedList` is always a `TerminalTabList`, which isn't always true.

## Fix  
The fix ensures `listService.lastFocusedList` is only used when it's a `TerminalTabList`, not when other widgets like the `QuickInputTree` are focused.

---

Let me know if any adjustments are needed!
