### PR TITLE
Fallback to PriorityTaskQueue on Safari

### DIFF
--- a/src/vs/editor/browser/gpu/atlas/textureAtlas.ts
+++ b/src/vs/editor/browser/gpu/atlas/textureAtlas.ts
@@ -14,7 +14,7 @@ import { IThemeService } from '../../../../platform/theme/common/themeService.js
 import { MetadataConsts } from '../../../common/encodedTokenAttributes.js';
 import { GlyphRasterizer } from '../raster/glyphRasterizer.js';
 import type { IGlyphRasterizer } from '../raster/raster.js';
-import { IdleTaskQueue } from '../taskQueue.js';
+import { IdleTaskQueue, type ITaskQueue } from '../taskQueue.js';
 import type { IReadableTextureAtlasPage, ITextureAtlasPageGlyph, GlyphMap } from './atlas.js';
 import { AllocatorType, TextureAtlasPage } from './textureAtlasPage.js';
 
@@ -24,7 +24,7 @@ export interface ITextureAtlasOptions {
 
 export class TextureAtlas extends Disposable {
 	private _colorMap?: string[];
-	private readonly _warmUpTask: MutableDisposable<IdleTaskQueue> = this._register(new MutableDisposable());
+	private readonly _warmUpTask: MutableDisposable<ITaskQueue> = this._register(new MutableDisposable());
 	private readonly _warmedUpRasterizers = new Set<number>();
 	private readonly _allocatorType: AllocatorType;
 

--- a/src/vs/editor/browser/gpu/taskQueue.ts
+++ b/src/vs/editor/browser/gpu/taskQueue.ts
@@ -4,14 +4,14 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { getActiveWindow } from '../../../base/browser/dom.js';
-import { Disposable, toDisposable } from '../../../base/common/lifecycle.js';
+import { Disposable, toDisposable, type IDisposable } from '../../../base/common/lifecycle.js';
 
 /**
  * Copyright (c) 2022 The xterm.js authors. All rights reserved.
  * @license MIT
  */
 
-interface ITaskQueue {
+export interface ITaskQueue extends IDisposable {
 	/**
 	 * Adds a task to the queue which will run in a future idle callback.
 	 * To avoid perceivable stalls on the mainthread, tasks with heavy workload

--- a/src/vs/editor/browser/gpu/taskQueue.ts
+++ b/src/vs/editor/browser/gpu/taskQueue.ts
@@ -134,13 +134,7 @@ export class PriorityTaskQueue extends TaskQueue {
 	}
 }
 
-/**
- * A queue of that runs tasks over several idle callbacks, trying to respect the idle callback's
- * deadline given by the environment. The tasks will run in the order they are enqueued, but they
- * will run some time later, and care should be taken to ensure they're non-urgent and will not
- * introduce race conditions.
- */
-export class IdleTaskQueue extends TaskQueue {
+class IdleTaskQueueInternal extends TaskQueue {
 	protected _requestCallback(callback: IdleRequestCallback): number {
 		return getActiveWindow().requestIdleCallback(callback);
 	}
@@ -149,6 +143,16 @@ export class IdleTaskQueue extends TaskQueue {
 		getActiveWindow().cancelIdleCallback(identifier);
 	}
 }
+
+/**
+ * A queue of that runs tasks over several idle callbacks, trying to respect the idle callback's
+ * deadline given by the environment. The tasks will run in the order they are enqueued, but they
+ * will run some time later, and care should be taken to ensure they're non-urgent and will not
+ * introduce race conditions.
+ *
+ * This reverts to a {@link PriorityTaskQueue} if the environment does not support idle callbacks.
+ */
+export const IdleTaskQueue = ('requestIdleCallback' in getActiveWindow()) ? IdleTaskQueueInternal : PriorityTaskQueue;
 
 /**
  * An object that tracks a single debounced task that will run on the next idle frame. When called


### PR DESCRIPTION
Fixes #238707

Brings back the fallback from xterm.js, not sure why I removed it in the first place.