### PR TITLE
rename `settledAll` methods to `allSettled` for consistency

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatAttachmentModel/chatInstructionsAttachment.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatAttachmentModel/chatInstructionsAttachment.ts
@@ -52,7 +52,7 @@ export class ChatInstructionsAttachmentModel extends Disposable {
 	 * including all its possible nested child references.
 	 */
 	public get allSettled(): Promise<FilePromptParser> {
-		return this.reference.settledAll();
+		return this.reference.allSettled();
 	}
 
 	/**

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/basePromptParser.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/basePromptParser.ts
@@ -129,12 +129,12 @@ export abstract class BasePromptParser<T extends IPromptContentsProvider> extend
 	 * Same as {@linkcode settled} but also waits for all possible
 	 * nested child prompt references and their children to be settled.
 	 */
-	public async settledAll(): Promise<this> {
+	public async allSettled(): Promise<this> {
 		await this.settled();
 
 		await Promise.allSettled(
 			this.references.map((reference) => {
-				return reference.settledAll();
+				return reference.allSettled();
 			}),
 		);
 

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/types.d.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/types.d.ts
@@ -119,7 +119,7 @@ export interface IPromptReference extends IDisposable {
 	 * The same as {@linkcode settled} but for all prompts in
 	 * the reference tree.
 	 */
-	settledAll(): Promise<this>;
+	allSettled(): Promise<this>;
 }
 
 /**

--- a/src/vs/workbench/contrib/chat/test/common/promptSyntax/promptFileReference.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/promptSyntax/promptFileReference.test.ts
@@ -119,7 +119,7 @@ class TestPromptFileReference extends Disposable {
 		).start();
 
 		// wait until entire prompts tree is resolved
-		await rootReference.settledAll();
+		await rootReference.allSettled();
 
 		// resolve the root file reference including all nested references
 		const resolvedReferences: readonly (IPromptFileReference | undefined)[] = rootReference.allReferences;


### PR DESCRIPTION
Renames `settledAll` methods to `allSettled` for consistency with other methods and with the Promises API.