### PR TITLE
Fix #197755

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
@@ -539,6 +539,7 @@ export class SettingsEditor2 extends EditorPane {
 			// Wait for editor to be removed from DOM #106303
 			setTimeout(() => {
 				this.searchWidget.onHide();
+				this.settingRenderers.cancelSuggesters();
 			}, 0);
 		}
 	}


### PR DESCRIPTION
Fixes #197755 

I confirmed that when the user opens an untitled text editor, opens the Settings editor, opens an enum dropdown, and presses Ctrl+W to close the Settings editor, the dropdown is hidden because the program focuses the untitled text editor.

When the user has the welcome view open, opens the Settings editor, opens an enum dropdown, and presses Ctrl+W to close the Settings editor, the program does not seem to focus the welcome view, and the dropdown remains open.

This PR adds a cancelSuggesters call to indicate to the contextViewService to hide context views such as the enum dropdown so that the enum dropdown is always hidden when the Settings editor is hidden.