### PR TITLE
Revert "rm webpack config from terminal-suggest"

### DIFF
--- a/extensions/terminal-suggest/.vscodeignore
+++ b/extensions/terminal-suggest/.vscodeignore
@@ -2,4 +2,6 @@ src/**
 out/**
 tsconfig.json
 .vscode/**
+extension.webpack.config.js
+extension-browser.webpack.config.js
 package-lock.json

--- a/extensions/terminal-suggest/extension-browser.webpack.config.js
+++ b/extensions/terminal-suggest/extension-browser.webpack.config.js
@@ -1,0 +1,25 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+//@ts-check
+
+'use strict';
+
+const withBrowserDefaults = require('../shared.webpack.config').browser;
+
+module.exports = withBrowserDefaults({
+	context: __dirname,
+	entry: {
+		extension: './src/terminalSuggestMain.ts'
+	},
+	output: {
+		filename: 'terminalSuggestMain.js'
+	},
+	resolve: {
+		fallback: {
+			'child_process': false
+		}
+	}
+});

--- a/extensions/terminal-suggest/extension.webpack.config.js
+++ b/extensions/terminal-suggest/extension.webpack.config.js
@@ -1,0 +1,23 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+//@ts-check
+'use strict';
+
+const withDefaults = require('../shared.webpack.config');
+
+module.exports = withDefaults({
+	context: __dirname,
+	entry: {
+		extension: './src/terminalSuggestMain.ts'
+	},
+	output: {
+		filename: 'terminalSuggestMain.js'
+	},
+	resolve: {
+		mainFields: ['module', 'main'],
+		extensions: ['.ts', '.js'] // support ts-files and js-files
+	}
+});

--- a/extensions/terminal-suggest/package.json
+++ b/extensions/terminal-suggest/package.json
@@ -22,6 +22,7 @@
     "compile": "npx gulp compile-extension:terminal-suggest",
     "watch": "npx gulp watch-extension:terminal-suggest"
   },
+
   "main": "./out/terminalSuggestMain",
   "activationEvents": [
     "onTerminalCompletionsRequested"
@@ -29,8 +30,5 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/microsoft/vscode.git"
-  },
-  "extensionKind": [
-    "workspace"
-  ]
+  }
 }


### PR DESCRIPTION
Reverts microsoft/vscode#238874

This caused the extension not to be packaged correctly for insider's, so suggestions aren't provided. 

![Screenshot 2025-01-28 at 10 15 30 AM](https://github.com/user-attachments/assets/da4ec521-ccd7-446f-8406-2f6728ff1c1e)

