### PR TITLE
fix typos

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/attachments/instructionsAttachment/instructionsAttachment.ts
+++ b/src/vs/workbench/contrib/chat/browser/attachments/instructionsAttachment/instructionsAttachment.ts
@@ -26,7 +26,7 @@ import { IContextMenuService } from '../../../../../../platform/contextview/brow
 import { ChatInstructionsAttachmentModel } from '../../chatAttachmentModel/chatInstructionsAttachment.js';
 import { getDefaultHoverDelegate } from '../../../../../../base/browser/ui/hover/hoverDelegateFactory.js';
 import { getFlatContextMenuActions } from '../../../../../../platform/actions/browser/menuEntryActionViewItem.js';
-import { PROMP_SNIPPET_FILE_EXTENSION } from '../../../common/promptSyntax/contentProviders/promptContentsProviderBase.js';
+import { PROMPT_SNIPPET_FILE_EXTENSION } from '../../../common/promptSyntax/contentProviders/promptContentsProviderBase.js';
 
 /**
  * Widget for a single prompt instructions attachment.
@@ -132,7 +132,7 @@ export class InstructionsAttachmentWidget extends Disposable {
 			title += `\n-\n[${errorCaption}]: ${details}`;
 		}
 
-		const fileWithoutExtension = fileBasename.replace(PROMP_SNIPPET_FILE_EXTENSION, '');
+		const fileWithoutExtension = fileBasename.replace(PROMPT_SNIPPET_FILE_EXTENSION, '');
 		label.setFile(URI.file(fileWithoutExtension), {
 			fileKind: FileKind.FILE,
 			hidePath: true,

--- a/src/vs/workbench/contrib/chat/browser/chatAttachmentModel/chatInstructionsFileLocator.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatAttachmentModel/chatInstructionsFileLocator.ts
@@ -9,7 +9,7 @@ import { IFileService } from '../../../../../platform/files/common/files.js';
 import { PromptFilesConfig } from '../../common/promptSyntax/config.js';
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 import { IWorkspaceContextService, WorkbenchState } from '../../../../../platform/workspace/common/workspace.js';
-import { PROMP_SNIPPET_FILE_EXTENSION } from '../../common/promptSyntax/contentProviders/promptContentsProviderBase.js';
+import { PROMPT_SNIPPET_FILE_EXTENSION } from '../../common/promptSyntax/contentProviders/promptContentsProviderBase.js';
 
 /**
  * Class to locate prompt instructions files.
@@ -120,7 +120,7 @@ export class ChatInstructionsFileLocator {
 					continue;
 				}
 
-				if (!name.endsWith(PROMP_SNIPPET_FILE_EXTENSION)) {
+				if (!name.endsWith(PROMPT_SNIPPET_FILE_EXTENSION)) {
 					continue;
 				}
 

--- a/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
@@ -275,7 +275,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 	private chatCursorAtTop: IContextKey<boolean>;
 	private inputEditorHasFocus: IContextKey<boolean>;
 	/**
-	 * Context key is set when prompt instructions are attached.3
+	 * Context key is set when prompt instructions are attached.
 	 */
 	private promptInstructionsAttached: IContextKey<boolean>;
 

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/contentProviders/promptContentsProviderBase.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/contentProviders/promptContentsProviderBase.ts
@@ -17,7 +17,7 @@ import { cancelPreviousCalls } from '../../../../../../base/common/decorators/ca
 /**
  * File extension for the prompt snippets.
  */
-export const PROMP_SNIPPET_FILE_EXTENSION: string = '.prompt.md';
+export const PROMPT_SNIPPET_FILE_EXTENSION: string = '.prompt.md';
 
 /**
  * Base class for prompt contents providers. Classes that extend this one are responsible to:
@@ -149,6 +149,6 @@ export abstract class PromptContentsProviderBase<
 	 * Check if the current URI points to a prompt snippet.
 	 */
 	public isPromptSnippet(): boolean {
-		return this.uri.path.endsWith(PROMP_SNIPPET_FILE_EXTENSION);
+		return this.uri.path.endsWith(PROMPT_SNIPPET_FILE_EXTENSION);
 	}
 }

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/languageFeatures/promptLinkProvider.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/languageFeatures/promptLinkProvider.ts
@@ -15,7 +15,7 @@ import { CancellationToken } from '../../../../../../base/common/cancellation.js
 import { Registry } from '../../../../../../platform/registry/common/platform.js';
 import { LifecyclePhase } from '../../../../../services/lifecycle/common/lifecycle.js';
 import { ILink, ILinksList, LinkProvider } from '../../../../../../editor/common/languages.js';
-import { PROMP_SNIPPET_FILE_EXTENSION } from '../contentProviders/promptContentsProviderBase.js';
+import { PROMPT_SNIPPET_FILE_EXTENSION } from '../contentProviders/promptContentsProviderBase.js';
 import { ILanguageFeaturesService } from '../../../../../../editor/common/services/languageFeatures.js';
 import { IInstantiationService } from '../../../../../../platform/instantiation/common/instantiation.js';
 import { IWorkbenchContributionsRegistry, Extensions as WorkbenchExtensions } from '../../../../../common/contributions.js';
@@ -24,7 +24,7 @@ import { IWorkbenchContributionsRegistry, Extensions as WorkbenchExtensions } fr
  * Prompt files language selector.
  */
 const languageSelector = {
-	pattern: `**/*${PROMP_SNIPPET_FILE_EXTENSION}`,
+	pattern: `**/*${PROMPT_SNIPPET_FILE_EXTENSION}`,
 };
 
 /**

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/basePromptParser.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/basePromptParser.ts
@@ -20,7 +20,7 @@ import { basename, extUri } from '../../../../../../base/common/resources.js';
 import { VSBufferReadableStream } from '../../../../../../base/common/buffer.js';
 import { ObservableDisposable } from '../../../../../../base/common/observableDisposable.js';
 import { FilePromptContentProvider } from '../contentProviders/filePromptContentsProvider.js';
-import { PROMP_SNIPPET_FILE_EXTENSION } from '../contentProviders/promptContentsProviderBase.js';
+import { PROMPT_SNIPPET_FILE_EXTENSION } from '../contentProviders/promptContentsProviderBase.js';
 import { IInstantiationService } from '../../../../../../platform/instantiation/common/instantiation.js';
 import { IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
 import { MarkdownLink } from '../../../../../../editor/common/codecs/markdownCodec/tokens/markdownLink.js';
@@ -507,7 +507,7 @@ export abstract class BasePromptParser<T extends IPromptContentsProvider> extend
 	 * Check if the provided URI points to a prompt snippet.
 	 */
 	public static isPromptSnippet(uri: URI): boolean {
-		return uri.path.endsWith(PROMP_SNIPPET_FILE_EXTENSION);
+		return uri.path.endsWith(PROMPT_SNIPPET_FILE_EXTENSION);
 	}
 
 	/**


### PR DESCRIPTION
Fix typos:

- `PROMP_SNIPPET_FILE_EXTENSION` -> `PROMPT_SNIPPET_FILE_EXTENSION`
- remove redundant `3` in code comment of `[chatInputPart.ts](https://github.com/microsoft/vscode/compare/legomushroom/prompts/fix-typos?expand=1#diff-6b36746056c58bd3066ac70264412e5d4d265bc13068d04ff3a63353c46260ab)`