### PR TITLE
Fix for no results found message on ai results

### DIFF
--- a/src/vs/workbench/contrib/search/browser/searchView.ts
+++ b/src/vs/workbench/contrib/search/browser/searchView.ts
@@ -1657,12 +1657,13 @@ export class SearchView extends ViewPane {
 			await this.refreshAndUpdateCount();
 		}
 
-		const hasResults = !this.viewModel.searchResult.isEmpty();
-		if (completed?.exit === SearchCompletionExitCode.NewSearchStarted) {
+		const allResults = !this.viewModel.searchResult.isEmpty();
+		const aiResults = this.searchResult.getCachedSearchComplete(true);
+		if (completed?.exit === SearchCompletionExitCode.NewSearchStarted || (this.shouldShowAIResults() && !aiResults)) {
 			return;
 		}
 
-		if (!hasResults) {
+		if (!allResults) {
 			const hasExcludes = !!excludePatternText;
 			const hasIncludes = !!includePatternText;
 			let message: string;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Fixes: https://github.com/microsoft/vscode-copilot/issues/12402

Verifying if the user can trigger an AI search and not showing the no results found if that is the case.

We will still show the message when the user already triggered the ai search and also didn't find anything