### PR TITLE
updates the prompt label in the attachments list

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/actions/chatContextActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatContextActions.ts
@@ -834,7 +834,7 @@ export class AttachContextAction extends Action2 {
 			quickPickItems.push({
 				kind: 'prompt-instructions',
 				id: 'prompt-instructions',
-				label: localize('prompt', 'Prompt'),
+				label: localize('promptWithEllipsis', 'Prompt...'),
 				iconClass: ThemeIcon.asClassName(Codicon.lightbulbSparkle),
 			});
 		}


### PR DESCRIPTION
Changes `Prompt` to `Prompt...` in the attachments list because there is the selection dialog that follows it.