### PR TITLE
Fix line replacement view width computation

### DIFF
--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/wordReplacementView.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/wordReplacementView.ts
@@ -325,17 +325,13 @@ export class LineReplacementView extends Disposable implements IInlineEditsView 
 		const scrollLeft = this._editor.scrollLeft.read(reader);
 		const scrollTop = this._editor.scrollTop.read(reader);
 		const editorLeftOffset = contentLeft - scrollLeft;
-		const w = this._editor.getOption(EditorOption.fontInfo).read(reader).typicalHalfwidthCharacterWidth;
 		const PADDING = 4;
 
-		const editorModel = this._editor.editor.getModel()!;
-		const { prefixTrim, prefixLeftOffset } = this._maxPrefixTrim;
+		const textModel = this._editor.editor.getModel()!;
+		const { prefixLeftOffset } = this._maxPrefixTrim;
 
-		// TODO: correctly count tabs
-		const originalLineContents: string[] = [];
-		this._originalRange.forEach(line => originalLineContents.push(editorModel.getLineContent(line)));
-		const maxOriginalLineLength = Math.max(...originalLineContents.map(l => l.length)) - prefixTrim;
-		const maxLineWidth = Math.max(maxOriginalLineLength * w, requiredWidth);
+		const originalLineWidths = this._originalRange.mapToLineArray(line => this._editor.editor.getOffsetForColumn(line, textModel.getLineMaxColumn(line)) - prefixLeftOffset);
+		const maxLineWidth = Math.max(...originalLineWidths, requiredWidth);
 
 		const startLineNumber = this._originalRange.startLineNumber;
 		const endLineNumber = this._originalRange.endLineNumberExclusive - 1;


### PR DESCRIPTION
Correct the computation of line widths in the line replacement view to ensure accurate rendering.

fixes https://github.com/microsoft/vscode-copilot/issues/12434