### PR TITLE
Fix gutter icon positioning over minimap

### DIFF
--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/gutterIndicatorView.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/gutterIndicatorView.ts
@@ -126,7 +126,7 @@ export class InlineEditsGutterIndicator extends Disposable {
 
 		const space = 1;
 
-		const targetRect = Rect.fromRanges(OffsetRange.fromTo(space, layout.lineNumbersLeft + layout.lineNumbersWidth + 4), targetVertRange);
+		const targetRect = Rect.fromRanges(OffsetRange.fromTo(space + layout.glyphMarginLeft, layout.lineNumbersLeft + layout.lineNumbersWidth + 4), targetVertRange);
 
 
 		const lineHeight = this._editorObs.getOption(EditorOption.lineHeight).read(reader);


### PR DESCRIPTION
Adjust the positioning of the gutter icon for inline suggestions to ensure it appears next to the line number, resolving the overlap with the minimap when it is to the left.

Fixes microsoft/vscode-copilot#12501