### PR TITLE
Fix misalignment of arrow and suggestion box in NES Insertion View

### DIFF
--- a/src/vs/editor/browser/rect.ts
+++ b/src/vs/editor/browser/rect.ts
@@ -138,7 +138,15 @@ export class Rect {
 		return new Rect(this.left - delta, this.top, this.right - delta, this.bottom);
 	}
 
+	moveRight(delta: number): Rect {
+		return new Rect(this.left + delta, this.top, this.right + delta, this.bottom);
+	}
+
 	moveUp(delta: number): Rect {
 		return new Rect(this.left, this.top - delta, this.right, this.bottom - delta);
+	}
+
+	moveDown(delta: number): Rect {
+		return new Rect(this.left, this.top + delta, this.right, this.bottom + delta);
 	}
 }

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/gutterIndicatorView.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/gutterIndicatorView.ts
@@ -73,6 +73,7 @@ export class InlineEditsGutterIndicator extends Disposable {
 	constructor(
 		private readonly _editorObs: ObservableCodeEditor,
 		private readonly _originalRange: IObservable<LineRange | undefined>,
+		private readonly _verticalOffset: IObservable<number>,
 		private readonly _model: IObservable<InlineCompletionsModel | undefined>,
 		private readonly _isHoveringOverInlineEdit: IObservable<boolean>,
 		private readonly _focusIsInMenu: ISettableObservable<boolean>,
@@ -130,7 +131,8 @@ export class InlineEditsGutterIndicator extends Disposable {
 
 
 		const lineHeight = this._editorObs.getOption(EditorOption.lineHeight).read(reader);
-		const pillRect = targetRect.withHeight(lineHeight).withWidth(22);
+		const pillOffset = this._verticalOffset.read(reader);
+		const pillRect = targetRect.withHeight(lineHeight).withWidth(22).moveDown(pillOffset);
 		const pillRectMoved = pillRect.moveToBeContainedIn(viewPortWithStickyScroll);
 
 		const rect = targetRect;
@@ -142,7 +144,7 @@ export class InlineEditsGutterIndicator extends Disposable {
 		return {
 			rect,
 			iconRect,
-			arrowDirection: (iconRect.top === targetRect.top ? 'right' as const
+			arrowDirection: (targetRect.containsRect(iconRect) ? 'right' as const
 				: iconRect.top > targetRect.top ? 'top' as const : 'bottom' as const),
 			docked: rect.containsRect(iconRect) && viewPortWithStickyScroll.containsRect(iconRect),
 		};


### PR DESCRIPTION
Adjustments made to the positioning logic of the suggestion box and arrow in the NES Insertion View to ensure proper alignment. This addresses the issue of misalignment reported in microsoft/vscode-copilot#12461.