### PR TITLE
fix: add electron as an external for webpack

### DIFF
--- a/extensions/github-authentication/extension.webpack.config.js
+++ b/extensions/github-authentication/extension.webpack.config.js
@@ -13,5 +13,8 @@ module.exports = withDefaults({
 	context: __dirname,
 	entry: {
 		extension: './src/extension.ts',
+	},
+	externals: {
+		'electron': 'commonjs electron',
 	}
 });

--- a/extensions/github-authentication/extension.webpack.config.js
+++ b/extensions/github-authentication/extension.webpack.config.js
@@ -14,7 +14,4 @@ module.exports = withDefaults({
 	entry: {
 		extension: './src/extension.ts',
 	},
-	externals: {
-		'electron': 'commonjs electron',
-	}
 });

--- a/extensions/shared.webpack.config.js
+++ b/extensions/shared.webpack.config.js
@@ -56,6 +56,7 @@ function withNodeDefaults(/**@type WebpackConfig & { context: string }*/extConfi
 			}]
 		},
 		externals: {
+			'electron': 'commonjs electron', // ignored to avoid bundling from node_modules
 			'vscode': 'commonjs vscode', // ignored because it doesn't exist,
 			'applicationinsights-native-metrics': 'commonjs applicationinsights-native-metrics', // ignored because we don't ship native module
 			'@azure/functions-core': 'commonjs azure/functions-core', // optioinal dependency of appinsights that we don't use
@@ -204,4 +205,3 @@ module.exports.node = withNodeDefaults;
 module.exports.browser = withBrowserDefaults;
 module.exports.nodePlugins = nodePlugins;
 module.exports.browserPlugins = browserPlugins;
-


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This should fix the issue where `require('electron')` does not resolve on the bundled extension after https://github.com/microsoft/vscode/pull/238149

Note, I don't see how to bundle the extension locally to confirm that this is working.

cc https://github.com/microsoft/vscode/issues/207867