### PR TITLE
Made the clipboard error never show again

### DIFF
--- a/src/vs/workbench/services/clipboard/browser/clipboardService.ts
+++ b/src/vs/workbench/services/clipboard/browser/clipboardService.ts
@@ -66,7 +66,8 @@ export class BrowserClipboardService extends BaseBrowserClipboardService {
 						run: () => this.openerService.open('https://go.microsoft.com/fwlink/?linkid=2151362')
 					}],
 					{
-						sticky: true
+						sticky: true,
+						neverShowAgain: true
 					}
 				);
 

--- a/src/vs/workbench/services/clipboard/browser/clipboardService.ts
+++ b/src/vs/workbench/services/clipboard/browser/clipboardService.ts
@@ -7,7 +7,7 @@ import { localize } from '../../../../nls.js';
 import { InstantiationType, registerSingleton } from '../../../../platform/instantiation/common/extensions.js';
 import { IClipboardService } from '../../../../platform/clipboard/common/clipboardService.js';
 import { BrowserClipboardService as BaseBrowserClipboardService } from '../../../../platform/clipboard/browser/clipboardService.js';
-import { INeverShowAgainOptions, INotificationService, Severity } from '../../../../platform/notification/common/notification.js';
+import { INeverShowAgainOptions, NeverShowAgainScope, INotificationService, Severity } from '../../../../platform/notification/common/notification.js';
 import { IOpenerService } from '../../../../platform/opener/common/opener.js';
 import { Event } from '../../../../base/common/event.js';
 import { DisposableStore } from '../../../../base/common/lifecycle.js';

--- a/src/vs/workbench/services/clipboard/browser/clipboardService.ts
+++ b/src/vs/workbench/services/clipboard/browser/clipboardService.ts
@@ -7,7 +7,7 @@ import { localize } from '../../../../nls.js';
 import { InstantiationType, registerSingleton } from '../../../../platform/instantiation/common/extensions.js';
 import { IClipboardService } from '../../../../platform/clipboard/common/clipboardService.js';
 import { BrowserClipboardService as BaseBrowserClipboardService } from '../../../../platform/clipboard/browser/clipboardService.js';
-import { INeverShowAgainOptions, NeverShowAgainScope, INotificationService, Severity } from '../../../../platform/notification/common/notification.js';
+import { INeverShowAgainOptions, INotificationService, NeverShowAgainScope, Severity } from '../../../../platform/notification/common/notification.js';
 import { IOpenerService } from '../../../../platform/opener/common/opener.js';
 import { Event } from '../../../../base/common/event.js';
 import { DisposableStore } from '../../../../base/common/lifecycle.js';

--- a/src/vs/workbench/services/clipboard/browser/clipboardService.ts
+++ b/src/vs/workbench/services/clipboard/browser/clipboardService.ts
@@ -7,7 +7,7 @@ import { localize } from '../../../../nls.js';
 import { InstantiationType, registerSingleton } from '../../../../platform/instantiation/common/extensions.js';
 import { IClipboardService } from '../../../../platform/clipboard/common/clipboardService.js';
 import { BrowserClipboardService as BaseBrowserClipboardService } from '../../../../platform/clipboard/browser/clipboardService.js';
-import { INotificationService, Severity } from '../../../../platform/notification/common/notification.js';
+import { INeverShowAgainOptions, INotificationService, Severity } from '../../../../platform/notification/common/notification.js';
 import { IOpenerService } from '../../../../platform/opener/common/opener.js';
 import { Event } from '../../../../base/common/event.js';
 import { DisposableStore } from '../../../../base/common/lifecycle.js';
@@ -37,6 +37,7 @@ export class BrowserClipboardService extends BaseBrowserClipboardService {
 	}
 
 	override async readText(type?: string): Promise<string> {
+		const neverShowAgain: INeverShowAgainOptions = { id: 'workspaces.clipboardPermissionMissing', scope: NeverShowAgainScope.WORKSPACE, isSecondary: true };
 		if (!!this.environmentService.extensionTestsLocationURI && typeof type !== 'string') {
 			type = 'vscode-tests'; // force in-memory clipboard for tests to avoid permission issues
 		}
@@ -67,7 +68,7 @@ export class BrowserClipboardService extends BaseBrowserClipboardService {
 					}],
 					{
 						sticky: true,
-						neverShowAgain: true
+						neverShowAgain: neverShowAgain
 					}
 				);
 


### PR DESCRIPTION
There is a notification error when the browser doesn't provide permissions for access to the clipboard. 

This is error will stack several times when the user pastes multiple lines of text. Which cause the error to cover part of the screen while the paste still occurs. Causing the this error become more of a nuisance.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
