### PR TITLE
Use `getTitleBarStyle` to fix drag not going to top corner when using native tabs

### DIFF
--- a/src/vs/platform/quickinput/browser/quickInputController.ts
+++ b/src/vs/platform/quickinput/browser/quickInputController.ts
@@ -31,7 +31,7 @@ import { StandardMouseEvent } from '../../../base/browser/mouseEvent.js';
 import { IStorageService, StorageScope, StorageTarget } from '../../storage/common/storage.js';
 import { IConfigurationService } from '../../configuration/common/configuration.js';
 import { Platform, platform } from '../../../base/common/platform.js';
-import { TitleBarSetting, TitlebarStyle } from '../../window/common/window.js';
+import { getTitleBarStyle, TitlebarStyle } from '../../window/common/window.js';
 import { getZoomFactor } from '../../../base/browser/browser.js';
 
 const $ = dom.$;
@@ -919,7 +919,7 @@ class QuickInputDragAndDropController extends Disposable {
 		@IConfigurationService private readonly configurationService: IConfigurationService
 	) {
 		super();
-		const customTitleBar = this.configurationService.getValue<TitlebarStyle>(TitleBarSetting.TITLE_BAR_STYLE) === TitlebarStyle.CUSTOM;
+		const customTitleBar = getTitleBarStyle(this.configurationService) === TitlebarStyle.CUSTOM;
 
 		// Do not allow the widget to overflow or underflow window controls.
 		// Use CSS calculations to avoid having to force layout with `.clientWidth`


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/238941

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
