### PR TITLE
create cwd detection and update it when command detection is deserialized

### DIFF
--- a/src/vs/platform/terminal/common/capabilities/commandDetectionCapability.ts
+++ b/src/vs/platform/terminal/common/capabilities/commandDetectionCapability.ts
@@ -422,7 +422,6 @@ export class CommandDetectionCapability extends Disposable implements ICommandDe
 		if (serialized.isWindowsPty) {
 			this.setIsWindowsPty(serialized.isWindowsPty);
 		}
-		this._cwd = serialized.commands.at(-1)?.cwd;
 		const buffer = this._terminal.buffer.normal;
 		for (const e of serialized.commands) {
 			// Partial command

--- a/src/vs/platform/terminal/common/capabilities/commandDetectionCapability.ts
+++ b/src/vs/platform/terminal/common/capabilities/commandDetectionCapability.ts
@@ -422,6 +422,7 @@ export class CommandDetectionCapability extends Disposable implements ICommandDe
 		if (serialized.isWindowsPty) {
 			this.setIsWindowsPty(serialized.isWindowsPty);
 		}
+		this._cwd = serialized.commands.at(-1)?.cwd;
 		const buffer = this._terminal.buffer.normal;
 		for (const e of serialized.commands) {
 			// Partial command

--- a/src/vs/platform/terminal/common/xterm/shellIntegrationAddon.ts
+++ b/src/vs/platform/terminal/common/xterm/shellIntegrationAddon.ts
@@ -662,6 +662,7 @@ export class ShellIntegrationAddon extends Disposable implements IShellIntegrati
 		const commandDetection = this._createOrGetCommandDetection(this._terminal);
 		commandDetection.deserialize(serialized);
 		if (commandDetection.cwd) {
+			// Cwd gets set when the command is deserialized, so we need to update it here
 			this._updateCwd(commandDetection.cwd);
 		}
 	}

--- a/src/vs/platform/terminal/common/xterm/shellIntegrationAddon.ts
+++ b/src/vs/platform/terminal/common/xterm/shellIntegrationAddon.ts
@@ -660,6 +660,9 @@ export class ShellIntegrationAddon extends Disposable implements IShellIntegrati
 			throw new Error('Cannot restore commands before addon is activated');
 		}
 		this._createOrGetCommandDetection(this._terminal).deserialize(serialized);
+		if (serialized.commands && !!serialized.commands.at(-1)?.cwd) {
+			this._updateCwd(serialized.commands.at(-1)!.cwd!);
+		}
 	}
 
 	protected _createOrGetCwdDetection(): ICwdDetectionCapability {

--- a/src/vs/platform/terminal/common/xterm/shellIntegrationAddon.ts
+++ b/src/vs/platform/terminal/common/xterm/shellIntegrationAddon.ts
@@ -659,9 +659,10 @@ export class ShellIntegrationAddon extends Disposable implements IShellIntegrati
 		if (!this._terminal) {
 			throw new Error('Cannot restore commands before addon is activated');
 		}
-		this._createOrGetCommandDetection(this._terminal).deserialize(serialized);
-		if (serialized.commands && !!serialized.commands.at(-1)?.cwd) {
-			this._updateCwd(serialized.commands.at(-1)!.cwd!);
+		const commandDetection = this._createOrGetCommandDetection(this._terminal);
+		commandDetection.deserialize(serialized);
+		if (commandDetection.cwd) {
+			this._updateCwd(commandDetection.cwd);
 		}
 	}
 


### PR DESCRIPTION
During deserialize, `cwd` was getting set on the command detection capability, but the cwd detection capability wasn't getting created or updated with this value. 

![Screenshot 2025-01-30 at 11 04 47 AM](https://github.com/user-attachments/assets/cb2c6eaf-a359-41be-840a-f25cbd6b4bea)


Fix https://github.com/microsoft/vscode/issues/239027
fix https://github.com/microsoft/vscode/issues/234672

