### PR TITLE
Fix EditFileTool in remote windows

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -79,11 +79,11 @@ import { ChatGettingStartedContribution } from './actions/chatGettingStarted.js'
 import { Extensions, IConfigurationMigrationRegistry } from '../../../common/configuration.js';
 import { ChatRelatedFilesContribution } from './contrib/chatInputRelatedFilesContrib.js';
 import { ChatQuotasService, ChatQuotasStatusBarEntry, IChatQuotasService } from './chatQuotasService.js';
-import { BuiltinToolsContribution } from './tools/tools.js';
 import { ChatSetupContribution } from './chatSetup.js';
 import { ChatEditorOverlayController } from './chatEditorOverlay.js';
 import '../common/promptSyntax/languageFeatures/promptLinkProvider.js';
 import { PromptFilesConfig } from '../common/promptSyntax/config.js';
+import { BuiltinToolsContribution } from '../common/tools/tools.js';
 
 // Register configuration
 const configurationRegistry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration);

--- a/src/vs/workbench/contrib/chat/common/tools/tools.ts
+++ b/src/vs/workbench/contrib/chat/common/tools/tools.ts
@@ -1,0 +1,30 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Disposable } from '../../../../../base/common/lifecycle.js';
+import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
+import { IWorkbenchContribution } from '../../../../common/contributions.js';
+import { ILanguageModelToolsService } from '../../common/languageModelToolsService.js';
+import { EditTool, EditToolData } from './editFileTool.js';
+
+export class BuiltinToolsContribution extends Disposable implements IWorkbenchContribution {
+
+	static readonly ID = 'chat.builtinTools';
+
+	constructor(
+		@ILanguageModelToolsService toolsService: ILanguageModelToolsService,
+		@IInstantiationService instantiationService: IInstantiationService,
+	) {
+		super();
+
+		const editTool = instantiationService.createInstance(EditTool);
+		this._register(toolsService.registerToolData(EditToolData));
+		this._register(toolsService.registerToolImplementation(EditToolData.id, editTool));
+	}
+}
+
+export interface IToolInputProcessor {
+	processInput(input: any): any;
+}


### PR DESCRIPTION
Map the filePath to a URI in the EH, then uriTransformer runs, tool gets a proper URI.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
