### PR TITLE
Reassign event ownership from 'sbatten' to 'benibenj'

### DIFF
--- a/src/vs/workbench/browser/layout.ts
+++ b/src/vs/workbench/browser/layout.ts
@@ -2479,7 +2479,7 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 		};
 
 		type StartupLayoutEventClassification = {
-			owner: 'sbatten';
+			owner: 'benibenj';
 			comment: 'Information about the layout of the workbench during statup';
 			activityBarVisible: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Whether or the not the activity bar is visible' };
 			sideBarVisible: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Whether or the not the primary side bar is visible' };

--- a/src/vs/workbench/browser/parts/paneCompositeBar.ts
+++ b/src/vs/workbench/browser/parts/paneCompositeBar.ts
@@ -843,7 +843,7 @@ class ViewContainerActivityAction extends CompositeBarAction {
 
 	private logAction(action: string) {
 		type ActivityBarActionClassification = {
-			owner: 'sbatten';
+			owner: 'benibenj';
 			comment: 'Event logged when an activity bar action is triggered.';
 			viewletId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The view in the activity bar for which the action was performed.' };
 			action: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The action that was performed. e.g. "hide", "show", or "refocus"' };

--- a/src/vs/workbench/services/views/browser/viewDescriptorService.ts
+++ b/src/vs/workbench/services/views/browser/viewDescriptorService.ts
@@ -425,7 +425,7 @@ export class ViewDescriptorService extends Disposable implements IViewDescriptor
 		}
 
 		type ViewDescriptorServiceMoveViewsClassification = {
-			owner: 'sbatten';
+			owner: 'benibenj';
 			comment: 'Logged when views are moved from one view container to another';
 			viewCount: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The number of views moved' };
 			fromContainer: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The starting view container of the moved views' };


### PR DESCRIPTION
Update event ownership in multiple classifications to reflect the new owner.