### PR TITLE
fix config-context-key handling when config isn't known yet

### DIFF
--- a/src/vs/platform/contextkey/browser/contextKeyService.ts
+++ b/src/vs/platform/contextkey/browser/contextKeyService.ts
@@ -103,6 +103,7 @@ class ConfigAwareContextValuesContainer extends Context {
 	private static readonly _keyPrefix = 'config.';
 
 	private readonly _values = TernarySearchTree.forConfigKeys<any>();
+	private readonly _missed = TernarySearchTree.forConfigKeys<boolean>();
 	private readonly _listener: IDisposable;
 
 	constructor(
@@ -117,7 +118,10 @@ class ConfigAwareContextValuesContainer extends Context {
 				// new setting, reset everything
 				const allKeys = Array.from(this._values, ([k]) => k);
 				this._values.clear();
-				emitter.fire(new ArrayContextKeyChangeEvent(allKeys));
+				emitter.fire(new CompositeContextKeyChangeEvent([
+					new ArrayContextKeyChangeEvent(allKeys),
+					new ArrayContextKeyChangeEvent(Array.from(this._missed, ([k]) => k))
+				]));
 			} else {
 				const changedKeys: string[] = [];
 				for (const configKey of event.affectedKeys) {
@@ -172,6 +176,11 @@ class ConfigAwareContextValuesContainer extends Context {
 		}
 
 		this._values.set(key, value);
+		if (value === undefined) {
+			this._missed.set(key, true);
+		} else {
+			this._missed.delete(key);
+		}
 		return value;
 	}
 

--- a/src/vs/workbench/contrib/chat/browser/languageModelToolsService.ts
+++ b/src/vs/workbench/contrib/chat/browser/languageModelToolsService.ts
@@ -67,7 +67,10 @@ export class LanguageModelToolsService extends Disposable implements ILanguageMo
 		this._tools.set(toolData.id, { data: toolData });
 		this._onDidChangeToolsScheduler.schedule();
 
-		toolData.when?.keys().forEach(key => this._toolContextKeys.add(key));
+		if (toolData.when) {
+			this._contextKeyService.contextMatchesRules(toolData.when);
+			toolData.when.keys().forEach(key => this._toolContextKeys.add(key));
+		}
 
 		return toDisposable(() => {
 			this._tools.delete(toolData.id);

--- a/src/vs/workbench/contrib/chat/common/chatAgents.ts
+++ b/src/vs/workbench/contrib/chat/common/chatAgents.ts
@@ -307,6 +307,8 @@ export class ChatAgentService extends Disposable implements IChatAgentService {
 		this._agents.set(id, entry);
 		this._updateAgentsContextKeys();
 		this._updateContextKeys();
+		this._agentIsEnabled(entry);
+
 		this._onDidChangeAgents.fire(undefined);
 
 		return toDisposable(() => {


### PR DESCRIPTION
* make sure to "read" when-clause of tools and agents as soon as registered
* make sure to record config-context-keys that don't exist yet