### PR TITLE
added message telling the user to add NSS db when the authority cant …

### DIFF
--- a/src/vs/base/common/errors.ts
+++ b/src/vs/base/common/errors.ts
@@ -213,6 +213,16 @@ export class CancellationError extends Error {
 	}
 }
 
+const invalidAuthorityMessage = 'net::ERR_CERT_AUTHORITY_INVALID';
+
+/**
+ * Chromium doesn't care about default OS's certificates, instead, it uses
+ * a NSS certificate stores: https://chromium.googlesource.com/chromium/src/+/lkgr/docs/linux/cert_management.md
+ */
+export function isInvalidAuthorityError(error: any): boolean {
+	return error instanceof Error && error.message === invalidAuthorityMessage;
+}
+
 /**
  * @deprecated use {@link CancellationError `new CancellationError()`} instead
  */

--- a/src/vs/platform/extensionManagement/common/abstractExtensionManagementService.ts
+++ b/src/vs/platform/extensionManagement/common/abstractExtensionManagementService.ts
@@ -6,7 +6,7 @@
 import { distinct, isNonEmptyArray } from '../../../base/common/arrays.js';
 import { Barrier, CancelablePromise, createCancelablePromise } from '../../../base/common/async.js';
 import { CancellationToken } from '../../../base/common/cancellation.js';
-import { CancellationError, getErrorMessage, isCancellationError } from '../../../base/common/errors.js';
+import { CancellationError, getErrorMessage, isCancellationError, isInvalidAuthorityError } from '../../../base/common/errors.js';
 import { Emitter, Event } from '../../../base/common/event.js';
 import { Disposable, toDisposable } from '../../../base/common/lifecycle.js';
 import { ResourceMap } from '../../../base/common/map.js';
@@ -909,7 +909,7 @@ export function toExtensionManagementError(error: Error, code?: ExtensionManagem
 	if (error instanceof ExtensionGalleryError) {
 		extensionManagementError = new ExtensionManagementError(error.message, error.code === ExtensionGalleryErrorCode.DownloadFailedWriting ? ExtensionManagementErrorCode.DownloadFailedWriting : ExtensionManagementErrorCode.Gallery);
 	} else {
-		extensionManagementError = new ExtensionManagementError(error.message, isCancellationError(error) ? ExtensionManagementErrorCode.Cancelled : (code ?? ExtensionManagementErrorCode.Internal));
+		extensionManagementError = new ExtensionManagementError(error.message, isInvalidAuthorityError(error) ? ExtensionManagementErrorCode.InvalidAuthority : isCancellationError(error) ? ExtensionManagementErrorCode.Cancelled : code ?? ExtensionManagementErrorCode.Internal);
 	}
 	extensionManagementError.stack = error.stack;
 	return extensionManagementError;

--- a/src/vs/platform/extensionManagement/common/extensionManagement.ts
+++ b/src/vs/platform/extensionManagement/common/extensionManagement.ts
@@ -450,6 +450,7 @@ export const enum ExtensionManagementErrorCode {
 	IncompatibleTargetPlatform = 'IncompatibleTargetPlatform',
 	ReleaseVersionNotFound = 'ReleaseVersionNotFound',
 	Invalid = 'Invalid',
+	InvalidAuthority = 'InvalidAuthority',
 	Download = 'Download',
 	DownloadSignature = 'DownloadSignature',
 	DownloadFailedWriting = ExtensionGalleryErrorCode.DownloadFailedWriting,

--- a/src/vs/workbench/contrib/extensions/browser/extensionsActions.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionsActions.ts
@@ -178,6 +178,20 @@ export class PromptExtensionInstallFailureAction extends Action {
 			return;
 		}
 
+		if (ExtensionManagementErrorCode.InvalidAuthority === (<ExtensionManagementErrorCode>this.error.name)) {
+			await this.dialogService.prompt({
+				type: 'error',
+				message: localize('invalid certificate authority', "Cannot install '{0}' extension because {1} doesn't recognize the certificate's root authority.", this.extension.displayName, this.productService.nameLong),
+				detail: getErrorMessage(this.error),
+				buttons: [{
+					label: localize('learn more', "Learn More"),
+					run: () => this.openerService.open('https://chromium.googlesource.com/chromium/src/+/lkgr/docs/linux/cert_management.md')
+				}],
+				cancelButton: localize('cancel', "Cancel")
+			});
+			return;
+		}
+
 		const operationMessage = this.installOperation === InstallOperation.Update ? localize('update operation', "Error while updating '{0}' extension.", this.extension.displayName || this.extension.identifier.id)
 			: localize('install operation', "Error while installing '{0}' extension.", this.extension.displayName || this.extension.identifier.id);
 		let additionalMessage;


### PR DESCRIPTION
This solves issue #96247

When chromium cannot download extensions because the authority certificate is invalid, in some cases, the error is specific to scenarios when corporate proxies "inject" new certificates, the only solution is to add the your corporate proxy's certificate using NSS DB (https://chromium.googlesource.com/chromium/src/+/lkgr/docs/linux/cert_management.md#add-a-certificate)

This [stackoverflow question](https://stackoverflow.com/questions/36506539/how-do-i-get-visual-studio-code-to-trust-our-self-signed-proxy-certificate) gives various answers.

This PR recognize these kind of errors based on net::ERR_CERT_AUTHORITY_INVALID message emitted by chromium and display a message to user.
