### PR TITLE
Revert: Editor GPU: Pass content width through to scroll bar

### DIFF
--- a/src/vs/editor/browser/gpu/gpu.ts
+++ b/src/vs/editor/browser/gpu/gpu.ts
@@ -36,10 +36,6 @@ export interface IGpuRenderStrategy extends IDisposable {
 	 * Resets the render strategy, clearing all data and setting up for a new frame.
 	 */
 	reset(): void;
-	update(viewportData: ViewportData, viewLineOptions: ViewLineOptions): IGpuRenderStrategyUpdateResult;
+	update(viewportData: ViewportData, viewLineOptions: ViewLineOptions): number;
 	draw(pass: GPURenderPassEncoder, viewportData: ViewportData): void;
-}
-
-export interface IGpuRenderStrategyUpdateResult {
-	localContentWidth: number;
 }

--- a/src/vs/editor/browser/gpu/renderStrategy/baseRenderStrategy.ts
+++ b/src/vs/editor/browser/gpu/renderStrategy/baseRenderStrategy.ts
@@ -7,7 +7,7 @@ import { ViewEventHandler } from '../../../common/viewEventHandler.js';
 import type { ViewportData } from '../../../common/viewLayout/viewLinesViewportData.js';
 import type { ViewContext } from '../../../common/viewModel/viewContext.js';
 import type { ViewLineOptions } from '../../viewParts/viewLines/viewLineOptions.js';
-import type { IGpuRenderStrategy, IGpuRenderStrategyUpdateResult } from '../gpu.js';
+import type { IGpuRenderStrategy } from '../gpu.js';
 import { GlyphRasterizer } from '../raster/glyphRasterizer.js';
 import type { ViewGpuContext } from '../viewGpuContext.js';
 
@@ -31,6 +31,6 @@ export abstract class BaseRenderStrategy extends ViewEventHandler implements IGp
 	}
 
 	abstract reset(): void;
-	abstract update(viewportData: ViewportData, viewLineOptions: ViewLineOptions): IGpuRenderStrategyUpdateResult;
+	abstract update(viewportData: ViewportData, viewLineOptions: ViewLineOptions): number;
 	abstract draw(pass: GPURenderPassEncoder, viewportData: ViewportData): void;
 }

--- a/src/vs/editor/browser/gpu/renderStrategy/fullFileRenderStrategy.ts
+++ b/src/vs/editor/browser/gpu/renderStrategy/fullFileRenderStrategy.ts
@@ -16,7 +16,7 @@ import type { ViewLineOptions } from '../../viewParts/viewLines/viewLineOptions.
 import type { ITextureAtlasPageGlyph } from '../atlas/atlas.js';
 import { createContentSegmenter, type IContentSegmenter } from '../contentSegmenter.js';
 import { fullFileRenderStrategyWgsl } from './fullFileRenderStrategy.wgsl.js';
-import { BindingId, type IGpuRenderStrategyUpdateResult } from '../gpu.js';
+import { BindingId } from '../gpu.js';
 import { GPULifecycle } from '../gpuDisposable.js';
 import { quadVertices } from '../gpuUtils.js';
 import { GlyphRasterizer } from '../raster/glyphRasterizer.js';
@@ -232,7 +232,7 @@ export class FullFileRenderStrategy extends BaseRenderStrategy {
 		this._finalRenderedLine = 0;
 	}
 
-	update(viewportData: ViewportData, viewLineOptions: ViewLineOptions): IGpuRenderStrategyUpdateResult {
+	update(viewportData: ViewportData, viewLineOptions: ViewLineOptions): number {
 		// IMPORTANT: This is a hot function. Variables are pre-allocated and shared within the
 		// loop. This is done so we don't need to trust the JIT compiler to do this optimization to
 		// avoid potential additional blocking time in garbage collector which is a common cause of
@@ -501,9 +501,7 @@ export class FullFileRenderStrategy extends BaseRenderStrategy {
 
 		this._visibleObjectCount = visibleObjectCount;
 
-		return {
-			localContentWidth: absoluteOffsetX
-		};
+		return visibleObjectCount;
 	}
 
 	draw(pass: GPURenderPassEncoder, viewportData: ViewportData): void {

--- a/src/vs/editor/browser/gpu/renderStrategy/viewportRenderStrategy.ts
+++ b/src/vs/editor/browser/gpu/renderStrategy/viewportRenderStrategy.ts
@@ -16,7 +16,7 @@ import type { ViewContext } from '../../../common/viewModel/viewContext.js';
 import type { ViewLineOptions } from '../../viewParts/viewLines/viewLineOptions.js';
 import type { ITextureAtlasPageGlyph } from '../atlas/atlas.js';
 import { createContentSegmenter, type IContentSegmenter } from '../contentSegmenter.js';
-import { BindingId, type IGpuRenderStrategyUpdateResult } from '../gpu.js';
+import { BindingId } from '../gpu.js';
 import { GPULifecycle } from '../gpuDisposable.js';
 import { quadVertices } from '../gpuUtils.js';
 import { GlyphRasterizer } from '../raster/glyphRasterizer.js';
@@ -184,7 +184,7 @@ export class ViewportRenderStrategy extends BaseRenderStrategy {
 		}
 	}
 
-	update(viewportData: ViewportData, viewLineOptions: ViewLineOptions): IGpuRenderStrategyUpdateResult {
+	update(viewportData: ViewportData, viewLineOptions: ViewLineOptions): number {
 		// IMPORTANT: This is a hot function. Variables are pre-allocated and shared within the
 		// loop. This is done so we don't need to trust the JIT compiler to do this optimization to
 		// avoid potential additional blocking time in garbage collector which is a common cause of
@@ -394,9 +394,8 @@ export class ViewportRenderStrategy extends BaseRenderStrategy {
 		this._activeDoubleBufferIndex = this._activeDoubleBufferIndex ? 0 : 1;
 
 		this._visibleObjectCount = visibleObjectCount;
-		return {
-			localContentWidth: absoluteOffsetX
-		};
+
+		return visibleObjectCount;
 	}
 
 	draw(pass: GPURenderPassEncoder, viewportData: ViewportData): void {

--- a/src/vs/editor/browser/gpu/viewGpuContext.ts
+++ b/src/vs/editor/browser/gpu/viewGpuContext.ts
@@ -33,7 +33,6 @@ export class ViewGpuContext extends Disposable {
 	readonly maxGpuCols = ViewportRenderStrategy.maxSupportedColumns;
 
 	readonly canvas: FastDomNode<HTMLCanvasElement>;
-	readonly scrollWidthElement: FastDomNode<HTMLElement>;
 	readonly ctx: GPUCanvasContext;
 
 	static device: Promise<GPUDevice>;
@@ -88,7 +87,6 @@ export class ViewGpuContext extends Disposable {
 
 		this.canvas = createFastDomNode(document.createElement('canvas'));
 		this.canvas.setClassName('editorCanvas');
-		this.scrollWidthElement = createFastDomNode(document.createElement('div'));
 
 		// Adjust the canvas size to avoid drawing under the scroll bar
 		this._register(Event.runAndSubscribe(configurationService.onDidChangeConfiguration, e => {

--- a/src/vs/editor/browser/view.ts
+++ b/src/vs/editor/browser/view.ts
@@ -256,7 +256,6 @@ export class View extends ViewEventHandler {
 		this._overflowGuardContainer.appendChild(this._scrollbar.getDomNode());
 		if (this._viewGpuContext) {
 			this._overflowGuardContainer.appendChild(this._viewGpuContext.canvas);
-			this._linesContent.appendChild(this._viewGpuContext.scrollWidthElement);
 		}
 		this._overflowGuardContainer.appendChild(scrollDecoration.getDomNode());
 		this._overflowGuardContainer.appendChild(this._overlayWidgets.getDomNode());

--- a/src/vs/editor/browser/viewParts/viewLinesGpu/viewLinesGpu.ts
+++ b/src/vs/editor/browser/viewParts/viewLinesGpu/viewLinesGpu.ts
@@ -49,7 +49,6 @@ export class ViewLinesGpu extends ViewPart implements IViewLines {
 	private _initViewportData?: ViewportData[];
 	private _lastViewportData?: ViewportData;
 	private _lastViewLineOptions?: ViewLineOptions;
-	private _maxLocalContentWidthSoFar = 0;
 
 	private _device!: GPUDevice;
 	private _renderPassDescriptor!: GPURenderPassDescriptor;
@@ -430,6 +429,7 @@ export class ViewLinesGpu extends ViewPart implements IViewLines {
 	override onCursorStateChanged(e: viewEvents.ViewCursorStateChangedEvent): boolean { return true; }
 	override onDecorationsChanged(e: viewEvents.ViewDecorationsChangedEvent): boolean { return true; }
 	override onFlushed(e: viewEvents.ViewFlushedEvent): boolean { return true; }
+
 	override onLinesChanged(e: viewEvents.ViewLinesChangedEvent): boolean { return true; }
 	override onLinesDeleted(e: viewEvents.ViewLinesDeletedEvent): boolean { return true; }
 	override onLinesInserted(e: viewEvents.ViewLinesInsertedEvent): boolean { return true; }
@@ -473,14 +473,7 @@ export class ViewLinesGpu extends ViewPart implements IViewLines {
 
 		const options = new ViewLineOptions(this._context.configuration, this._context.theme.type);
 
-		const { localContentWidth } = this._renderStrategy.value!.update(viewportData, options);
-
-		// Track the largest local content width so far in this session and use it as the scroll
-		// width. This is how the DOM renderer works as well, so you may not be able to scroll to
-		// the right in a file with long lines until you scroll down.
-		this._maxLocalContentWidthSoFar = Math.max(this._maxLocalContentWidthSoFar, localContentWidth / this._viewGpuContext.devicePixelRatio.get());
-		this._context.viewModel.viewLayout.setMaxLineWidth(this._maxLocalContentWidthSoFar);
-		this._viewGpuContext.scrollWidthElement.setWidth(this._context.viewLayout.getScrollWidth());
+		this._renderStrategy.value!.update(viewportData, options);
 
 		this._updateAtlasStorageBufferAndTexture();
 


### PR DESCRIPTION
This was causing the dom and gpu view lines to both update scroll width which caused an infinite loop as that always triggers an update in the current animation frame.

Fixes #239321

---

Reverts https://github.com/microsoft/vscode/pull/238679