### PR TITLE
Center gutter indicator icon in NES view

### DIFF
--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/gutterIndicatorView.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/gutterIndicatorView.ts
@@ -282,6 +282,9 @@ export class InlineEditsGutterIndicator extends Disposable {
 						}
 					}),
 					transition: 'rotate 0.2s ease-in-out',
+					display: 'flex',
+					alignItems: 'center',
+					justifyContent: 'center',
 				}
 			}, [
 				this._tabAction.map(v => v === 'accept' ? renderIcon(Codicon.keyboardTab) : renderIcon(Codicon.arrowRight))

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/view.css
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/view.css
@@ -263,10 +263,6 @@
 	}
 }
 
-.inline-edits-view-gutter-indicator .codicon {
-	margin-top: 1px; /* TODO: Move into gutter DOM initialization */
-}
-
 @keyframes wiggle {
 	0% {
 		transform: rotate(0) scale(1);


### PR DESCRIPTION
Adjustments to the gutter indicator's CSS ensure the icon is centered vertically and horizontally, addressing the issue of misalignment. Fixes microsoft/vscode-copilot#12694