### PR TITLE
Turn local echo off by default and downgrade to preview

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/typeAhead/common/terminalTypeAheadConfiguration.ts
+++ b/src/vs/workbench/contrib/terminalContrib/typeAhead/common/terminalTypeAheadConfiguration.ts
@@ -29,6 +29,7 @@ export const terminalTypeAheadConfiguration: IStringDictionary<IConfigurationPro
 		type: 'integer',
 		minimum: -1,
 		default: 30,
+		tags: ['preview'],
 	},
 	[TerminalTypeAheadSettingId.LocalEchoEnabled]: {
 		markdownDescription: localize('terminal.integrated.localEchoEnabled', "When local echo should be enabled. This will override {0}", '`#terminal.integrated.localEchoLatencyThreshold#`'),
@@ -39,7 +40,8 @@ export const terminalTypeAheadConfiguration: IStringDictionary<IConfigurationPro
 			localize('terminal.integrated.localEchoEnabled.off', "Always disabled"),
 			localize('terminal.integrated.localEchoEnabled.auto', "Enabled only for remote workspaces")
 		],
-		default: 'auto'
+		default: 'off',
+		tags: ['preview'],
 	},
 	[TerminalTypeAheadSettingId.LocalEchoExcludePrograms]: {
 		description: localize('terminal.integrated.localEchoExcludePrograms', "Local echo will be disabled when any of these program names are found in the terminal title."),
@@ -49,6 +51,7 @@ export const terminalTypeAheadConfiguration: IStringDictionary<IConfigurationPro
 			uniqueItems: true
 		},
 		default: DEFAULT_LOCAL_ECHO_EXCLUDE,
+		tags: ['preview'],
 	},
 	[TerminalTypeAheadSettingId.LocalEchoStyle]: {
 		description: localize('terminal.integrated.localEchoStyle', "Terminal style of locally echoed text; either a font style or an RGB color."),
@@ -61,6 +64,7 @@ export const terminalTypeAheadConfiguration: IStringDictionary<IConfigurationPro
 				type: 'string',
 				format: 'color-hex',
 			}
-		]
+		],
+		tags: ['preview'],
 	},
 };


### PR DESCRIPTION
This feature has been a pain point for many remote users for a long time. Something critical to the feature is that it must maintain
consistency and heal "mistakes", but unfortunately this isn't true and it can lead to buffer corruption and therefore could lead the user to run a command they didn't mean to.

Additionally we don't disable the feature after it fails (https://github.com/microsoft/vscode/issues/119103) or respect the ECHO termios mode and can therefore echo password characters to the user (https://github.com/microsoft/vscode/issues/130821).

My plan is to keep it off as a preview for the foreseeable future as we don't have plans to prioritize this work any time soon.

Part of #126209
