### PR TITLE
Add very basic tokenizer for command line

### DIFF
--- a/extensions/terminal-suggest/src/terminalSuggestMain.ts
+++ b/extensions/terminal-suggest/src/terminalSuggestMain.ts
@@ -12,6 +12,7 @@ import cdSpec from './completions/cd';
 import codeInsidersCompletionSpec from './completions/code-insiders';
 import { osIsWindows } from './helpers/os';
 import { isExecutable } from './helpers/executable';
+import { getTokenType, TokenType } from './tokens';
 
 const enum PwshCommandType {
 	Alias = 1
@@ -136,7 +137,8 @@ export async function activate(context: vscode.ExtensionContext) {
 
 			const prefix = getPrefix(terminalContext.commandLine, terminalContext.cursorPosition);
 			const pathSeparator = isWindows ? '\\' : '/';
-			const result = await getCompletionItemsFromSpecs(availableSpecs, terminalContext, commands, prefix, terminal.shellIntegration?.cwd, token);
+			const tokenType = getTokenType(terminalContext, shellType);
+			const result = await getCompletionItemsFromSpecs(availableSpecs, terminalContext, commands, prefix, tokenType, terminal.shellIntegration?.cwd, token);
 			if (terminal.shellIntegration?.env) {
 				const homeDirCompletion = result.items.find(i => i.label === '~');
 				if (homeDirCompletion && terminal.shellIntegration.env.HOME) {
@@ -324,6 +326,7 @@ export async function getCompletionItemsFromSpecs(
 	terminalContext: { commandLine: string; cursorPosition: number },
 	availableCommands: ICompletionResource[],
 	prefix: string,
+	tokenType: TokenType,
 	shellIntegrationCwd?: vscode.Uri,
 	token?: vscode.CancellationToken
 ): Promise<{ items: vscode.TerminalCompletionItem[]; filesRequested: boolean; foldersRequested: boolean; cwd?: vscode.Uri }> {
@@ -331,7 +334,6 @@ export async function getCompletionItemsFromSpecs(
 	let filesRequested = false;
 	let foldersRequested = false;
 
-	const firstCommand = getFirstCommand(terminalContext.commandLine);
 	const precedingText = terminalContext.commandLine.slice(0, terminalContext.cursorPosition + 1);
 
 	for (const spec of specs) {
@@ -347,14 +349,10 @@ export async function getCompletionItemsFromSpecs(
 				continue;
 			}
 
-			if (
-				// If the prompt is empty
-				!terminalContext.commandLine
-				// or the first command matches the command
-				|| !!firstCommand && specLabel.startsWith(firstCommand)
-			) {
-				// push it to the completion items
+			// push it to the completion items
+			if (tokenType === TokenType.Command) {
 				items.push(createCompletionItem(terminalContext.cursorPosition, prefix, { label: specLabel }, getDescription(spec), availableCommand.detail));
+				continue;
 			}
 
 			if (!terminalContext.commandLine.startsWith(specLabel)) {
@@ -385,9 +383,7 @@ export async function getCompletionItemsFromSpecs(
 		!filesRequested &&
 		!foldersRequested;
 
-	const shouldShowCommands = !terminalContext.commandLine.substring(0, terminalContext.cursorPosition).trimStart().includes(' ');
-
-	if (shouldShowCommands && !filesRequested && !foldersRequested) {
+	if (tokenType === TokenType.Command) {
 		// Include builitin/available commands in the results
 		const labels = new Set(items.map((i) => i.label));
 		for (const command of availableCommands) {
@@ -536,19 +532,6 @@ function getCompletionItemsFromArgs(args: Fig.SingleOrArray<Fig.Arg> | undefined
 	return { items, filesRequested, foldersRequested };
 }
 
-
-
-function getFirstCommand(commandLine: string): string | undefined {
-	const wordsOnLine = commandLine.split(' ');
-	let firstCommand: string | undefined = wordsOnLine[0];
-	if (wordsOnLine.length > 1) {
-		firstCommand = undefined;
-	} else if (wordsOnLine.length === 0) {
-		firstCommand = commandLine;
-	}
-	return firstCommand;
-}
-
 function getFriendlyResourcePath(uri: vscode.Uri, pathSeparator: string, kind?: vscode.TerminalCompletionItemKind): string {
 	let path = uri.fsPath;
 	// Ensure drive is capitalized on Windows
@@ -564,7 +547,7 @@ function getFriendlyResourcePath(uri: vscode.Uri, pathSeparator: string, kind?: 
 }
 
 // TODO: remove once API is finalized
-export enum TerminalShellType {
+export const enum TerminalShellType {
 	Sh = 1,
 	Bash = 2,
 	Fish = 3,

--- a/extensions/terminal-suggest/src/test/terminalSuggestMain.test.ts
+++ b/extensions/terminal-suggest/src/test/terminalSuggestMain.test.ts
@@ -12,6 +12,7 @@ import codeCompletionSpec from '../completions/code';
 import codeInsidersCompletionSpec from '../completions/code-insiders';
 import type { Uri } from 'vscode';
 import { basename } from 'path';
+import { getTokenType } from '../tokens';
 
 const fixtureDir = vscode.Uri.joinPath(vscode.Uri.file(__dirname), '../../testWorkspace');
 const testCwdParent = vscode.Uri.joinPath(fixtureDir, 'parent');
@@ -150,7 +151,8 @@ suite('Terminal Suggest', () => {
 					const prefix = commandLine.slice(0, cursorPosition).split(' ').at(-1) || '';
 					const filesRequested = testSpec.expectedResourceRequests?.type === 'files' || testSpec.expectedResourceRequests?.type === 'both';
 					const foldersRequested = testSpec.expectedResourceRequests?.type === 'folders' || testSpec.expectedResourceRequests?.type === 'both';
-					const result = await getCompletionItemsFromSpecs(completionSpecs, { commandLine, cursorPosition }, availableCommands.map(c => { return { label: c }; }), prefix, testCwd);
+					const terminalContext = { commandLine, cursorPosition };
+					const result = await getCompletionItemsFromSpecs(completionSpecs, terminalContext, availableCommands.map(c => { return { label: c }; }), prefix, getTokenType(terminalContext, undefined), testCwd);
 					deepStrictEqual(result.items.map(i => i.label).sort(), (testSpec.expectedCompletions ?? []).sort());
 					strictEqual(result.filesRequested, filesRequested);
 					strictEqual(result.foldersRequested, foldersRequested);

--- a/extensions/terminal-suggest/src/test/tokens.test.ts
+++ b/extensions/terminal-suggest/src/test/tokens.test.ts
@@ -1,0 +1,52 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import 'mocha';
+import { strictEqual } from 'node:assert';
+import { getTokenType, TokenType } from '../tokens';
+import { TerminalShellType } from '../terminalSuggestMain';
+
+suite('Terminal Suggest', () => {
+	test('simple command', () => {
+		strictEqual(getTokenType({ commandLine: 'echo', cursorPosition: 'echo'.length }, undefined), TokenType.Command);
+	});
+	test('simple argument', () => {
+		strictEqual(getTokenType({ commandLine: 'echo hello', cursorPosition: 'echo hello'.length }, undefined), TokenType.Argument);
+	});
+	test('simple command, cursor mid text', () => {
+		strictEqual(getTokenType({ commandLine: 'echo hello', cursorPosition: 'echo'.length }, undefined), TokenType.Command);
+	});
+	test('simple argument, cursor mid text', () => {
+		strictEqual(getTokenType({ commandLine: 'echo hello', cursorPosition: 'echo hel'.length }, undefined), TokenType.Argument);
+	});
+	suite('reset to command', () => {
+		test('|', () => {
+			strictEqual(getTokenType({ commandLine: 'echo hello | ', cursorPosition: 'echo hello | '.length }, undefined), TokenType.Command);
+		});
+		test(';', () => {
+			strictEqual(getTokenType({ commandLine: 'echo hello; ', cursorPosition: 'echo hello; '.length }, undefined), TokenType.Command);
+		});
+		test('&&', () => {
+			strictEqual(getTokenType({ commandLine: 'echo hello && ', cursorPosition: 'echo hello && '.length }, undefined), TokenType.Command);
+		});
+		test('||', () => {
+			strictEqual(getTokenType({ commandLine: 'echo hello || ', cursorPosition: 'echo hello || '.length }, undefined), TokenType.Command);
+		});
+	});
+	suite('pwsh', () => {
+		test('simple command', () => {
+			strictEqual(getTokenType({ commandLine: 'Write-Host', cursorPosition: 'Write-Host'.length }, TerminalShellType.PowerShell), TokenType.Command);
+		});
+		test('simple argument', () => {
+			strictEqual(getTokenType({ commandLine: 'Write-Host hello', cursorPosition: 'Write-Host hello'.length }, TerminalShellType.PowerShell), TokenType.Argument);
+		});
+		test('reset char', () => {
+			strictEqual(getTokenType({ commandLine: `Write-Host hello -and `, cursorPosition: `Write-Host hello -and `.length }, TerminalShellType.PowerShell), TokenType.Command);
+		});
+		test('arguments after reset char', () => {
+			strictEqual(getTokenType({ commandLine: `Write-Host hello -and $true `, cursorPosition: `Write-Host hello -and $true `.length }, TerminalShellType.PowerShell), TokenType.Argument);
+		});
+	});
+});

--- a/extensions/terminal-suggest/src/tokens.ts
+++ b/extensions/terminal-suggest/src/tokens.ts
@@ -1,0 +1,33 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { TerminalShellType } from './terminalSuggestMain';
+
+export const enum TokenType {
+	Command,
+	Argument,
+}
+
+const shellTypeResetChars: { [key: number]: string[] | undefined } = {
+	[TerminalShellType.Bash]: ['>', '>>', '<', '2>', '2>>', '&>', '&>>', '|', '|&', '&&', '||', '&', ';', '(', '{', '<<'],
+	[TerminalShellType.Zsh]: ['>', '>>', '<', '2>', '2>>', '&>', '&>>', '<>', '|', '|&', '&&', '||', '&', ';', '(', '{', '<<', '<<<', '<('],
+	[TerminalShellType.PowerShell]: ['>', '>>', '<', '2>', '2>>', '*>', '*>>', '|', '-and', '-or', '-not', '!', '&', '-eq', '-ne', '-gt', '-lt', '-ge', '-le', '-like', '-notlike', '-match', '-notmatch', '-contains', '-notcontains', '-in', '-notin']
+};
+
+const defaultShellTypeResetChars = shellTypeResetChars[TerminalShellType.Bash]!;
+
+export function getTokenType(ctx: { commandLine: string; cursorPosition: number }, shellType: TerminalShellType | undefined): TokenType {
+	const spaceIndex = ctx.commandLine.substring(0, ctx.cursorPosition).lastIndexOf(' ');
+	if (spaceIndex === -1) {
+		return TokenType.Command;
+	}
+	const tokenIndex = spaceIndex === -1 ? 0 : spaceIndex + 1;
+	const previousTokens = ctx.commandLine.substring(0, tokenIndex).trim();
+	const commandResetChars = shellType === undefined ? defaultShellTypeResetChars : shellTypeResetChars[shellType] ?? defaultShellTypeResetChars;
+	if (commandResetChars.some(e => previousTokens.endsWith(e))) {
+		return TokenType.Command;
+	}
+	return TokenType.Argument;
+}


### PR DESCRIPTION
Fixes #239018

Issue example:

![image](https://github.com/user-attachments/assets/3599f6f6-dc98-444a-8d45-bc2b657c6b4c)
