### PR TITLE
Show only relevant settings in the Gutter Indicator Menu

### DIFF
--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/gutterIndicatorMenu.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/gutterIndicatorMenu.ts
@@ -61,7 +61,7 @@ export class GutterIndicatorMenuContent {
 				...c.map(c => option(createOptionArgs({ id: c.id, title: c.title, icon: Codicon.symbolEvent, commandId: c.id, commandArgs: c.arguments }))),
 				separator()
 			] : []),
-			option(createOptionArgs({ id: 'settings', title: localize('settings', "Settings"), icon: Codicon.gear, commandId: 'workbench.action.openSettings', commandArgs: ['inlineSuggest.edits'] })),
+			option(createOptionArgs({ id: 'settings', title: localize('settings', "Settings"), icon: Codicon.gear, commandId: 'workbench.action.openSettings', commandArgs: ['editor.inlineSuggest.edits.codeShifting editor.inlineSuggest.edits.renderSideBySide nexteditsuggestions'] })), // TODO: better dynamic way to only show settings related to this feature
 		]);
 	}
 


### PR DESCRIPTION
Update the settings menu entry to display only settings related to inline suggestions

microsoft/vscode-copilot#12713