### PR TITLE
fixes https://github.com/microsoft/vscode-copilot-release/issues/3520

### DIFF
--- a/src/vs/platform/actions/browser/dropdownWithPrimaryActionViewItem.ts
+++ b/src/vs/platform/actions/browser/dropdownWithPrimaryActionViewItem.ts
@@ -144,7 +144,7 @@ export class DropdownWithPrimaryActionViewItem extends BaseActionViewItem {
 	update(dropdownAction: IAction, dropdownMenuActions: IAction[], dropdownIcon?: string): void {
 		this._dropdown.dispose();
 		this._dropdown = new DropdownMenuActionViewItem(dropdownAction, dropdownMenuActions, this._contextMenuProvider, {
-			menuAsChild: true,
+			menuAsChild: this._options?.menuAsChild ?? true,
 			classNames: ['codicon', dropdownIcon || 'codicon-chevron-down'],
 			actionRunner: this._options?.actionRunner,
 			hoverDelegate: this._options?.hoverDelegate,

--- a/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
@@ -815,7 +815,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 				if (this.location === ChatAgentLocation.Panel || this.location === ChatAgentLocation.Editor) {
 					if ((action.id === ChatSubmitAction.ID || action.id === CancelAction.ID) && action instanceof MenuItemAction) {
 						const dropdownAction = this.instantiationService.createInstance(MenuItemAction, { id: 'chat.moreExecuteActions', title: localize('notebook.moreExecuteActionsLabel', "More..."), icon: Codicon.chevronDown }, undefined, undefined, undefined, undefined);
-						return this.instantiationService.createInstance(ChatSubmitDropdownActionItem, action, dropdownAction, options);
+						return this.instantiationService.createInstance(ChatSubmitDropdownActionItem, action, dropdownAction, { ...options, menuAsChild: false });
 					}
 				}
 


### PR DESCRIPTION
This fixes a bug where updates to the dropdown did not honor the initial options passed in. It also uses `menuAsChild: false` for the the dropdown menu in the chat widget. This is a tradeoff situation. The context menu rendered as a child of the dropdown button preserves focus state properly. However this often has z-index issues. Setting it to false allows it to render above the rest of the workbench but focus will be sent to an element outside of the chat widget temporarily. This doesn't seem to cause any issues but it is something to be aware of.

