### PR TITLE
Provide error message when it looks like node arch does not match the system

### DIFF
--- a/build/npm/preinstall.js
+++ b/build/npm/preinstall.js
@@ -23,6 +23,7 @@ if (process.env['npm_execpath'].includes('yarn')) {
 const path = require('path');
 const fs = require('fs');
 const cp = require('child_process');
+const os = require('os');
 
 if (process.platform === 'win32') {
 	if (!hasSupportedVisualStudioVersion()) {
@@ -30,6 +31,11 @@ if (process.platform === 'win32') {
 		throw new Error();
 	}
 	installHeaders();
+}
+
+if (process.arch !== os.arch()) {
+	console.error(`\x1b[1;31m*** ARCHITECTURE MISMATCH: The node.js process is ${process.arch}, but your OS architecture is ${os.arch()}. ***\x1b[0;0m`);
+	console.error(`\x1b[1;31m*** This can greatly increase the build time of vs code. ***\x1b[0;0m`);
 }
 
 function hasSupportedVisualStudioVersion() {


### PR DESCRIPTION
build time difference is something like 1.5 minutes -> 18 minutes

cc @joaomoreno 

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
