### PR TITLE
Fix showing wrong welcome view content when offline

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatWidget.ts
@@ -587,7 +587,10 @@ export class ChatWidget extends Disposable implements IChatWidget {
 			const welcomePart = this._register(this.instantiationService.createInstance(
 				ChatViewWelcomePart,
 				{ ...welcomeContent, tips, },
-				{ location: this.location }
+				{
+					location: this.location,
+					isWidgetWelcomeViewContent: true
+				}
 			));
 			dom.append(this.welcomeMessageContainer, welcomePart.element);
 		}

--- a/src/vs/workbench/contrib/chat/browser/viewsWelcome/chatViewWelcomeController.ts
+++ b/src/vs/workbench/contrib/chat/browser/viewsWelcome/chatViewWelcomeController.ts
@@ -116,6 +116,7 @@ export interface IChatViewWelcomeContent {
 export interface IChatViewWelcomeRenderOptions {
 	firstLinkToButton?: boolean;
 	location: ChatAgentLocation;
+	isWidgetWelcomeViewContent?: boolean;
 }
 
 export class ChatViewWelcomePart extends Disposable {
@@ -146,7 +147,7 @@ export class ChatViewWelcomePart extends Disposable {
 			title.textContent = content.title;
 
 			// Preview indicator
-			if (options?.location === ChatAgentLocation.EditingSession && typeof content.message !== 'function' && chatAgentService.toolsAgentModeEnabled) {
+			if (options?.location === ChatAgentLocation.EditingSession && typeof content.message !== 'function' && chatAgentService.toolsAgentModeEnabled && options.isWidgetWelcomeViewContent) {
 				// Override welcome message for the agent. Sort of a hack, should it come from the participant? This case is different because the welcome content typically doesn't change per ChatWidget
 				const agentMessage = localize({ key: 'agentMessage', comment: ['{Locked="["}', '{Locked="]({0})"}'] }, "Ask Copilot to edit your files in [agent mode]({0}). Copilot will automatically use multiple requests to pick files to edit, run terminal commands, and iterate on errors.\n\nCopilot is powered by AI, so mistakes are possible. Review output carefully before use.", 'https://aka.ms/vscode-copilot-agent');
 				content.message = new MarkdownString(agentMessage);


### PR DESCRIPTION
Only apply agent content override hack in chatwidget welcome content, not contributed welcome views
Fix microsoft/vscode-copilot#12726

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
