### PR TITLE
Only invalidate terminal suggestions when whitespace is encountered

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalSuggestAddon.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalSuggestAddon.ts
@@ -322,12 +322,15 @@ export class SuggestAddon extends Disposable implements ITerminalAddon, ISuggest
 			return;
 		}
 
-		// Hide the widget if the cursor moves to the left of the initial position as the
-		// completions are no longer valid
-		// to do: get replacement length to be correct, readd this?
-		if (this._currentPromptInputState && this._currentPromptInputState.cursorIndex <= this._leadingLineContent.length) {
-			this.hideSuggestWidget();
-			return;
+		// Hide the widget if the cursor moves to the left and invalidates the completions.
+		// Originally this was to the left of the initial position that the completions were
+		// requested, but since extensions are expected to allow the client-side to filter, they are
+		// only invalidated when whitespace is encountered.
+		if (this._currentPromptInputState && this._currentPromptInputState.cursorIndex < this._leadingLineContent.length) {
+			if (this._currentPromptInputState.cursorIndex === 0 || this._leadingLineContent[this._currentPromptInputState.cursorIndex - 1].match(/\s/)) {
+				this.hideSuggestWidget();
+				return;
+			}
 		}
 
 		if (this._terminalSuggestWidgetVisibleContextKey.get()) {


### PR DESCRIPTION
Fixes #239017

After:

![Recording 2025-02-01 at 06 15 51](https://github.com/user-attachments/assets/216a96a1-9f97-4d52-a128-4601ea9bd65e)

It's possible after this that the suggestions may not be complete if an extension does not allow us to do the filtering, terminal-suggest should work fine though.