### PR TITLE
Edit Context: early return when edit context primary selection does not correspond to current selection

### DIFF
--- a/src/vs/editor/browser/controller/editContext/native/nativeEditContext.ts
+++ b/src/vs/editor/browser/controller/editContext/native/nativeEditContext.ts
@@ -304,7 +304,7 @@ export class NativeEditContext extends AbstractEditContext {
 			return;
 		}
 		if (!this._editContextPrimarySelection.equalsSelection(this._primarySelection)) {
-			this._updateEditContext();
+			return;
 		}
 		const model = this._context.viewModel.model;
 		const startPositionOfEditContext = this._editContextStartPosition();


### PR DESCRIPTION
fixes https://github.com/microsoft/vscode/issues/238618