### PR TITLE
Fix NES change between side by side and line replace after partial typing

### DIFF
--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/view.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/view.ts
@@ -232,7 +232,7 @@ export class InlineEditsView extends Disposable {
 				(this._useMixedLinesDiff.read(reader) === 'afterJumpWhenPossible' && this._previousView?.view !== 'mixedLines') ||
 				(this._useInterleavedLinesDiff.read(reader) === 'afterJump' && this._previousView?.view !== 'interleavedLines')
 			);
-		const reconsiderViewEditorWidthChange = this._previousView?.editorWidth !== this._editor.getLayoutInfo().width &&
+		const reconsiderViewEditorWidthChange = this._previousView?.editorWidth !== this._editorObs.layoutInfoWidth.read(reader) &&
 			(
 				this._previousView?.view === 'sideBySide' ||
 				this._previousView?.view === 'lineReplacement'


### PR DESCRIPTION
Address an issue where the view did not update correctly between side by side and line replacement modes after typing partially.