### PR TITLE
fix typo in the documentation link title

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/actions/chatContextActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatContextActions.ts
@@ -967,7 +967,7 @@ const selectPromptAttachment = async (options: ISelectPromptOptions): Promise<vo
 	if (files.length === 0) {
 		const docsQuickPick: IQuickPickItem & { value: URI } = {
 			type: 'item',
-			label: localize('noPromptFilesFoundTooltipLabel', 'Learn how create reusable prompts'),
+			label: localize('noPromptFilesFoundTooltipLabel', 'Learn how to create reusable prompts'),
 			description: PromptFilesConfig.DOCUMENTATION_URL,
 			tooltip: PromptFilesConfig.DOCUMENTATION_URL,
 			value: URI.parse(PromptFilesConfig.DOCUMENTATION_URL),


### PR DESCRIPTION
Fix typo in the reusable prompts documentation link title:

<img width="1392" alt="image" src="https://github.com/user-attachments/assets/9c8daaf2-ab8a-449b-bed6-10cd6b03ad08" />
