### PR TITLE
Safer fix for 239274

### DIFF
--- a/src/vs/platform/contextkey/browser/contextKeyService.ts
+++ b/src/vs/platform/contextkey/browser/contextKeyService.ts
@@ -103,7 +103,6 @@ class ConfigAwareContextValuesContainer extends Context {
 	private static readonly _keyPrefix = 'config.';
 
 	private readonly _values = TernarySearchTree.forConfigKeys<any>();
-	private readonly _missed = TernarySearchTree.forConfigKeys<boolean>();
 	private readonly _listener: IDisposable;
 
 	constructor(
@@ -118,10 +117,7 @@ class ConfigAwareContextValuesContainer extends Context {
 				// new setting, reset everything
 				const allKeys = Array.from(this._values, ([k]) => k);
 				this._values.clear();
-				emitter.fire(new CompositeContextKeyChangeEvent([
-					new ArrayContextKeyChangeEvent(allKeys),
-					new ArrayContextKeyChangeEvent(Array.from(this._missed, ([k]) => k))
-				]));
+				emitter.fire(new ArrayContextKeyChangeEvent(allKeys));
 			} else {
 				const changedKeys: string[] = [];
 				for (const configKey of event.affectedKeys) {
@@ -176,11 +172,6 @@ class ConfigAwareContextValuesContainer extends Context {
 		}
 
 		this._values.set(key, value);
-		if (value === undefined) {
-			this._missed.set(key, true);
-		} else {
-			this._missed.delete(key);
-		}
 		return value;
 	}
 

--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -242,8 +242,8 @@ class ChatAgentSettingContribution implements IWorkbenchContribution {
 				this.registerSetting();
 			} else if (value === false) {
 				this.deregisterSetting();
-				expDisabledKey.set(true);
 			}
+			expDisabledKey.set(!value);
 		});
 	}
 

--- a/src/vs/workbench/contrib/chat/browser/languageModelToolsService.ts
+++ b/src/vs/workbench/contrib/chat/browser/languageModelToolsService.ts
@@ -67,10 +67,7 @@ export class LanguageModelToolsService extends Disposable implements ILanguageMo
 		this._tools.set(toolData.id, { data: toolData });
 		this._onDidChangeToolsScheduler.schedule();
 
-		if (toolData.when) {
-			this._contextKeyService.contextMatchesRules(toolData.when);
-			toolData.when.keys().forEach(key => this._toolContextKeys.add(key));
-		}
+		toolData.when?.keys().forEach(key => this._toolContextKeys.add(key));
 
 		return toDisposable(() => {
 			this._tools.delete(toolData.id);

--- a/src/vs/workbench/contrib/chat/common/chatAgents.ts
+++ b/src/vs/workbench/contrib/chat/common/chatAgents.ts
@@ -307,8 +307,6 @@ export class ChatAgentService extends Disposable implements IChatAgentService {
 		this._agents.set(id, entry);
 		this._updateAgentsContextKeys();
 		this._updateContextKeys();
-		this._agentIsEnabled(entry);
-
 		this._onDidChangeAgents.fire(undefined);
 
 		return toDisposable(() => {

--- a/src/vs/workbench/contrib/chat/common/chatContextKeys.ts
+++ b/src/vs/workbench/contrib/chat/common/chatContextKeys.ts
@@ -83,6 +83,6 @@ export namespace ChatContextKeys {
 	export const Editing = {
 		hasToolsAgent: new RawContextKey<boolean>('chatHasToolsAgent', false, { type: 'boolean', description: localize('chatEditingHasToolsAgent', "True when a tools agent is registered.") }),
 		agentMode: new RawContextKey<boolean>('chatAgentMode', false, { type: 'boolean', description: localize('chatEditingAgentMode', "True when edits is in agent mode.") }),
-		agentModeDisallowed: new RawContextKey<boolean>('chatAgentModeDisallowed', false, { type: 'boolean', description: localize('chatAgentModeDisallowed', "True when agent mode is not allowed.") }), // experiment-driven disablement
+		agentModeDisallowed: new RawContextKey<boolean>('chatAgentModeDisallowed', undefined, { type: 'boolean', description: localize('chatAgentModeDisallowed', "True when agent mode is not allowed.") }), // experiment-driven disablement
 	};
 }


### PR DESCRIPTION
#239274 

- Revert previous fix which changed contextKeyService
- Simpler fix by just ensuring that the new non-config context key value always changes when the setting is registered