### PR TITLE
use vscode API vs `fs/promises` for terminal suggest

### DIFF
--- a/extensions/terminal-suggest/src/env/pathExecutableCache.ts
+++ b/extensions/terminal-suggest/src/env/pathExecutableCache.ts
@@ -3,7 +3,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import * as fs from 'fs/promises';
 import * as vscode from 'vscode';
 import { isExecutable } from '../helpers/executable';
 import { osIsWindows } from '../helpers/os';
@@ -86,7 +85,7 @@ export class PathExecutableCache implements vscode.Disposable {
 
 	private async _getFilesInPath(path: string, pathSeparator: string, labels: Set<string>): Promise<Set<ICompletionResource> | undefined> {
 		try {
-			const dirExists = await fs.stat(path).then(stat => stat.isDirectory()).catch(() => false);
+			const dirExists = await vscode.workspace.fs.stat(vscode.Uri.file(path)).then(stat => stat.type === vscode.FileType.Directory, () => false);
 			if (!dirExists) {
 				return undefined;
 			}

--- a/extensions/terminal-suggest/src/env/pathExecutableCache.ts
+++ b/extensions/terminal-suggest/src/env/pathExecutableCache.ts
@@ -85,7 +85,7 @@ export class PathExecutableCache implements vscode.Disposable {
 
 	private async _getFilesInPath(path: string, pathSeparator: string, labels: Set<string>): Promise<Set<ICompletionResource> | undefined> {
 		try {
-			const dirExists = await vscode.workspace.fs.stat(vscode.Uri.file(path)).then(stat => stat.type === vscode.FileType.Directory, () => false);
+			const dirExists = path && await vscode.workspace.fs.stat(vscode.Uri.file(path)).then(stat => stat.type === vscode.FileType.Directory, () => false);
 			if (!dirExists) {
 				return undefined;
 			}

--- a/extensions/terminal-suggest/src/terminalSuggestMain.ts
+++ b/extensions/terminal-suggest/src/terminalSuggestMain.ts
@@ -3,7 +3,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 import * as vscode from 'vscode';
-import * as fs from 'fs/promises';
 import * as path from 'path';
 import { ExecOptionsWithStringEncoding } from 'child_process';
 import { upstreamSpecs } from './constants';
@@ -153,10 +152,10 @@ export async function resolveCwdFromPrefix(prefix: string, currentCwd?: vscode.U
 		// Resolve the absolute path of the prefix
 		const resolvedPath = path.resolve(currentCwd?.fsPath, relativeFolder);
 
-		const stat = await fs.stat(resolvedPath);
+		const stat = await vscode.workspace.fs.stat(vscode.Uri.file(resolvedPath));
 
 		// Check if the resolved path exists and is a directory
-		if (stat.isDirectory()) {
+		if (stat.type === vscode.FileType.Directory) {
 			return currentCwd.with({ path: resolvedPath });
 		}
 	} catch {


### PR DESCRIPTION
fix #236831

Now  `npm run watch-web` runs smoothly.

Noticed we don't use `import * as fs from 'fs/promises';` in any other extensions, seems to cause problems.

Edit: this will break things - we want to look globally - not related to the workspace.