### PR TITLE
Force an update after acquiring a token interactively

### DIFF
--- a/extensions/microsoft-authentication/src/node/authProvider.ts
+++ b/extensions/microsoft-authentication/src/node/authProvider.ts
@@ -233,7 +233,6 @@ export class MsalAuthProvider implements AuthenticationProvider {
 				const session = this.sessionFromAuthenticationResult(result, scopeData.originalScopes);
 				this._telemetryReporter.sendLoginEvent(session.scopes);
 				this._logger.info('[createSession]', `[${scopeData.scopeStr}]`, 'returned session');
-				this._onDidChangeSessionsEmitter.fire({ added: [session], changed: [], removed: [] });
 				return session;
 			} catch (e) {
 				lastError = e;

--- a/extensions/microsoft-authentication/src/node/cachedPublicClientApplication.ts
+++ b/extensions/microsoft-authentication/src/node/cachedPublicClientApplication.ts
@@ -149,22 +149,26 @@ export class CachedPublicClientApplication implements ICachedPublicClientApplica
 
 	async acquireTokenInteractive(request: InteractiveRequest): Promise<AuthenticationResult> {
 		this._logger.debug(`[acquireTokenInteractive] [${this._clientId}] [${this._authority}] [${request.scopes?.join(' ')}] loopbackClientOverride: ${request.loopbackClient ? 'true' : 'false'}`);
-		const result = await window.withProgress(
+		return await window.withProgress(
 			{
 				location: ProgressLocation.Notification,
 				cancellable: true,
 				title: l10n.t('Signing in to Microsoft...')
 			},
-			(_process, token) => this._sequencer.queue(() => raceCancellationAndTimeoutError(
-				this._pca.acquireTokenInteractive(request),
-				token,
-				1000 * 60 * 5
-			))
+			(_process, token) => this._sequencer.queue(async () => {
+				const result = await raceCancellationAndTimeoutError(
+					this._pca.acquireTokenInteractive(request),
+					token,
+					1000 * 60 * 5
+				);
+				if (this._isBrokerAvailable) {
+					await this._accountAccess.setAllowedAccess(result.account!, true);
+				}
+				// Force an update so that the account cache is updated
+				await this._update();
+				return result;
+			})
 		);
-		if (this._isBrokerAvailable) {
-			await this._accountAccess.setAllowedAccess(result.account!, true);
-		}
-		return result;
 	}
 
 	/**


### PR DESCRIPTION
This will make sure the account cache is up-to-date before the `acquireTokenInteractive` ends.

A greater fix is maybe turning the accounts cache to be a promise.. but I won't do that for a candidate.

Fixes https://github.com/microsoft/vscode/issues/235327

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
