### PR TITLE
Force an update after acquiring a token interactively

### DIFF
--- a/extensions/microsoft-authentication/src/node/authProvider.ts
+++ b/extensions/microsoft-authentication/src/node/authProvider.ts
@@ -233,7 +233,6 @@ export class MsalAuthProvider implements AuthenticationProvider {
 				const session = this.sessionFromAuthenticationResult(result, scopeData.originalScopes);
 				this._telemetryReporter.sendLoginEvent(session.scopes);
 				this._logger.info('[createSession]', `[${scopeData.scopeStr}]`, 'returned session');
-				this._onDidChangeSessionsEmitter.fire({ added: [session], changed: [], removed: [] });
 				return session;
 			} catch (e) {
 				lastError = e;


### PR DESCRIPTION
This will make sure the account cache is up-to-date before the acquireTokenInteractive ends.

A greater fix is maybe turning the accounts cache to be a promise... bit this is the candidate fix for now.

Fixes #235327

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
