### PR TITLE
Fix cursor stability when accepting multi-line suggestions

### DIFF
--- a/src/vs/editor/contrib/inlineCompletions/browser/view/ghostText/ghostTextView.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/ghostText/ghostTextView.ts
@@ -43,6 +43,7 @@ export class GhostTextView extends Disposable {
 			extraClasses?: string[];
 			syntaxHighlightingEnabled: boolean;
 		}>,
+		private readonly _shouldKeepCursorStable: boolean,
 		@ILanguageService private readonly _languageService: ILanguageService,
 	) {
 		super();
@@ -151,7 +152,8 @@ export class GhostTextView extends Disposable {
 					minReservedLineCount: uiState.additionalReservedLineCount,
 					targetTextModel: uiState.targetTextModel,
 				} : undefined;
-			})
+			}),
+			this._shouldKeepCursorStable
 		)
 	);
 
@@ -257,7 +259,8 @@ export class AdditionalLinesWidget extends Disposable {
 			lineNumber: number;
 			additionalLines: LineData[];
 			minReservedLineCount: number;
-		} | undefined>
+		} | undefined>,
+		private readonly shouldKeepCursorStable: boolean
 	) {
 		super();
 
@@ -334,6 +337,10 @@ export class AdditionalLinesWidget extends Disposable {
 	}
 
 	private keepCursorStable(lineNumber: number, heightInLines: number): void {
+		if (!this.shouldKeepCursorStable) {
+			return;
+		}
+
 		const cursorLineNumber = this.editor.getSelection()?.getStartPosition()?.lineNumber;
 		if (cursorLineNumber !== undefined && lineNumber < cursorLineNumber) {
 			this.editor.setScrollTop(this.editor.getScrollTop() + heightInLines * this.editor.getOption(EditorOption.lineHeight));

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineCompletionsView.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineCompletionsView.ts
@@ -25,12 +25,16 @@ export class InlineCompletionsView extends Disposable {
 	private readonly _stablizedGhostTexts = convertItemsToStableObservables(this._ghostTexts, this._store);
 	private readonly _editorObs = observableCodeEditor(this._editor);
 
-	private readonly _ghostTextWidgets = mapObservableArrayCached(this, this._stablizedGhostTexts, (ghostText, store) => derivedDisposable((reader) => this._instantiationService.createInstance(readHotReloadableExport(GhostTextView, reader), this._editor, {
-		ghostText: ghostText,
-		minReservedLineCount: constObservable(0),
-		targetTextModel: this._model.map(v => v?.textModel),
-	},
-		this._editorObs.getOption(EditorOption.inlineSuggest).map(v => ({ syntaxHighlightingEnabled: v.syntaxHighlightingEnabled })))
+	private readonly _ghostTextWidgets = mapObservableArrayCached(this, this._stablizedGhostTexts, (ghostText, store) => derivedDisposable((reader) => this._instantiationService.createInstance(readHotReloadableExport(GhostTextView, reader),
+		this._editor,
+		{
+			ghostText: ghostText,
+			minReservedLineCount: constObservable(0),
+			targetTextModel: this._model.map(v => v?.textModel),
+		},
+		this._editorObs.getOption(EditorOption.inlineSuggest).map(v => ({ syntaxHighlightingEnabled: v.syntaxHighlightingEnabled })),
+		false,
+	)
 	).recomputeInitiallyAndOnChange(store)
 	).recomputeInitiallyAndOnChange(this._store);
 

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/insertionView.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/insertionView.ts
@@ -54,6 +54,7 @@ export class InlineEditsInsertionView extends Disposable implements IInlineEdits
 			targetTextModel: this._editorObs.model.map(model => model ?? undefined),
 		},
 		observableValue(this, { syntaxHighlightingEnabled: true, extraClasses: ['inline-edit'] }),
+		true,
 	));
 
 	constructor(


### PR DESCRIPTION
Enhancements ensure that pressing Enter on multi-line inline completions maintains cursor position without causing scrolling. 

Fixes microsoft/vscode#239599