### PR TITLE
Moving away from `execCommand` for pasting

### DIFF
--- a/src/vs/editor/browser/controller/editContext/clipboardUtils.ts
+++ b/src/vs/editor/browser/controller/editContext/clipboardUtils.ts
@@ -115,6 +115,11 @@ export const ClipboardEventUtils = {
 	},
 
 	setTextData(clipboardData: DataTransfer, text: string, html: string | null | undefined, metadata: ClipboardStoredMetadata): void {
+		console.log('setTextData');
+		console.log('clipboardData: ', clipboardData);
+		console.log('text: ', text);
+		console.log('html: ', html);
+		console.log('metadata: ', metadata);
 		clipboardData.setData(Mimes.text, text);
 		if (typeof html === 'string') {
 			clipboardData.setData('text/html', html);

--- a/src/vs/editor/browser/controller/editContext/clipboardUtils.ts
+++ b/src/vs/editor/browser/controller/editContext/clipboardUtils.ts
@@ -117,17 +117,4 @@ export const ClipboardEventUtils = {
 		console.log('metadata: ', metadata);
 		return [text, metadata];
 	},
-
-	setTextData(clipboardData: DataTransfer, text: string, html: string | null | undefined, metadata: ClipboardStoredMetadata): void {
-		console.log('setTextData');
-		console.log('clipboardData: ', clipboardData);
-		console.log('text: ', text);
-		console.log('html: ', html);
-		console.log('metadata: ', metadata);
-		clipboardData.setData(Mimes.text, text);
-		if (typeof html === 'string') {
-			clipboardData.setData('text/html', html);
-		}
-		clipboardData.setData('vscode-editor-data', JSON.stringify(metadata));
-	}
 };

--- a/src/vs/editor/browser/controller/editContext/clipboardUtils.ts
+++ b/src/vs/editor/browser/controller/editContext/clipboardUtils.ts
@@ -49,10 +49,14 @@ export class InMemoryClipboardMetadataManager {
 	}
 
 	public set(lastCopiedValue: string, data: ClipboardStoredMetadata): void {
+		console.log('set in InMemoryClipboardMetadataManager');
+		console.log('lastCopiedValue: ', lastCopiedValue);
+		console.log('data: ', data);
 		this._lastState = { lastCopiedValue, data };
 	}
 
 	public get(pastedText: string): ClipboardStoredMetadata | null {
+		console.log('get in InMemoryClipboardMetadataManager, pastedText: ', pastedText);
 		if (this._lastState && this._lastState.lastCopiedValue === pastedText) {
 			// match!
 			return this._lastState.data;

--- a/src/vs/editor/browser/controller/editContext/clipboardUtils.ts
+++ b/src/vs/editor/browser/controller/editContext/clipboardUtils.ts
@@ -93,6 +93,8 @@ interface InMemoryClipboardMetadata {
 export const ClipboardEventUtils = {
 
 	getTextData(clipboardData: DataTransfer): [string, ClipboardStoredMetadata | null] {
+		console.log('getTextData');
+		console.log('clipboardData : ', clipboardData);
 		const text = clipboardData.getData(Mimes.text);
 		let metadata: ClipboardStoredMetadata | null = null;
 		const rawmetadata = clipboardData.getData('vscode-editor-data');
@@ -111,6 +113,8 @@ export const ClipboardEventUtils = {
 			const files: File[] = Array.prototype.slice.call(clipboardData.files, 0);
 			return [files.map(file => file.name).join('\n'), null];
 		}
+		console.log('text: ', text);
+		console.log('metadata: ', metadata);
 		return [text, metadata];
 	},
 

--- a/src/vs/editor/browser/controller/editContext/native/nativeEditContext.ts
+++ b/src/vs/editor/browser/controller/editContext/native/nativeEditContext.ts
@@ -101,8 +101,12 @@ export class NativeEditContext extends AbstractEditContext {
 
 		this._screenReaderSupport = instantiationService.createInstance(ScreenReaderSupport, this.domNode, context);
 
-		this._register(addDisposableListener(this.domNode.domNode, 'copy', (e) => this._ensureClipboardGetsEditorSelection(e)));
+		this._register(addDisposableListener(this.domNode.domNode, 'copy', (e) => {
+			console.log('copy of NativeEditContext');
+			this._ensureClipboardGetsEditorSelection(e);
+		}));
 		this._register(addDisposableListener(this.domNode.domNode, 'cut', (e) => {
+			console.log('cut of NativeEditContext');
 			// Pretend here we touched the text area, as the `cut` event will most likely
 			// result in a `selectionchange` event which we want to ignore
 			this._screenReaderSupport.setIgnoreSelectionChangeTime('onCut');
@@ -148,6 +152,7 @@ export class NativeEditContext extends AbstractEditContext {
 			this._context.viewModel.onCompositionEnd();
 		}));
 		this._register(addDisposableListener(this.textArea.domNode, 'paste', (e) => {
+			console.log('paste of NativeEditContext');
 			// Pretend here we touched the text area, as the `paste` event will most likely
 			// result in a `selectionchange` event which we want to ignore
 			this._screenReaderSupport.setIgnoreSelectionChangeTime('onPaste');
@@ -170,6 +175,10 @@ export class NativeEditContext extends AbstractEditContext {
 				multicursorText = typeof metadata.multicursorText !== 'undefined' ? metadata.multicursorText : null;
 				mode = metadata.mode;
 			}
+			console.log('text : ', text);
+			console.log('pasteOnNewLine : ', pasteOnNewLine);
+			console.log('multicursorText : ', multicursorText);
+			console.log('mode : ', mode);
 			viewController.paste(text, pasteOnNewLine, multicursorText, mode);
 		}));
 		this._register(NativeEditContextRegistry.register(ownerID, this));
@@ -485,6 +494,7 @@ export class NativeEditContext extends AbstractEditContext {
 	}
 
 	private _ensureClipboardGetsEditorSelection(e: ClipboardEvent): void {
+		console.log('_ensureClipboardGetsEditorSelection e : ', e);
 		const options = this._context.configuration.options;
 		const emptySelectionClipboard = options.get(EditorOption.emptySelectionClipboard);
 		const copyWithSyntaxHighlighting = options.get(EditorOption.copyWithSyntaxHighlighting);

--- a/src/vs/editor/browser/controller/editContext/native/nativeEditContext.ts
+++ b/src/vs/editor/browser/controller/editContext/native/nativeEditContext.ts
@@ -493,8 +493,8 @@ export class NativeEditContext extends AbstractEditContext {
 		this._editContext.updateCharacterBounds(e.rangeStart, characterBounds);
 	}
 
-	private _ensureClipboardGetsEditorSelection(e: ClipboardEvent): void {
-		console.log('_ensureClipboardGetsEditorSelection e : ', e);
+	private _ensureClipboardGetsEditorSelection(clipboardEvent: ClipboardEvent): void {
+		console.log('_ensureClipboardGetsEditorSelection e : ', clipboardEvent);
 		const options = this._context.configuration.options;
 		const emptySelectionClipboard = options.get(EditorOption.emptySelectionClipboard);
 		const copyWithSyntaxHighlighting = options.get(EditorOption.copyWithSyntaxHighlighting);
@@ -512,9 +512,9 @@ export class NativeEditContext extends AbstractEditContext {
 			(isFirefox ? dataToCopy.text.replace(/\r\n/g, '\n') : dataToCopy.text),
 			storedMetadata
 		);
-		e.preventDefault();
-		if (e.clipboardData) {
-			ClipboardEventUtils.setTextData(e.clipboardData, dataToCopy.text, dataToCopy.html, storedMetadata);
+		clipboardEvent.preventDefault();
+		if (clipboardEvent.clipboardData) {
+			ClipboardEventUtils.setTextData(clipboardEvent.clipboardData, dataToCopy.text, dataToCopy.html, storedMetadata);
 		}
 	}
 

--- a/src/vs/editor/browser/controller/editContext/textArea/textAreaEditContext.ts
+++ b/src/vs/editor/browser/controller/editContext/textArea/textAreaEditContext.ts
@@ -308,6 +308,7 @@ export class TextAreaEditContext extends AbstractEditContext {
 		}));
 
 		this._register(this._textAreaInput.onPaste((e: IPasteData) => {
+			console.log('paste of TextAreaEditContext');
 			let pasteOnNewLine = false;
 			let multicursorText: string[] | null = null;
 			let mode: string | null = null;
@@ -316,10 +317,15 @@ export class TextAreaEditContext extends AbstractEditContext {
 				multicursorText = (typeof e.metadata.multicursorText !== 'undefined' ? e.metadata.multicursorText : null);
 				mode = e.metadata.mode;
 			}
+			console.log('e.text : ', e.text);
+			console.log('pasteOnNewLine : ', pasteOnNewLine);
+			console.log('multicursorText : ', multicursorText);
+			console.log('mode : ', mode);
 			this._viewController.paste(e.text, pasteOnNewLine, multicursorText, mode);
 		}));
 
 		this._register(this._textAreaInput.onCut(() => {
+			console.log('cut of TextAreaEditContext');
 			this._viewController.cut();
 		}));
 

--- a/src/vs/editor/browser/controller/editContext/textArea/textAreaEditContextInput.ts
+++ b/src/vs/editor/browser/controller/editContext/textArea/textAreaEditContextInput.ts
@@ -349,6 +349,7 @@ export class TextAreaInput extends Disposable {
 		// --- Clipboard operations
 
 		this._register(this._textArea.onCut((e) => {
+			console.log('onCut of TextAreaInput');
 			// Pretend here we touched the text area, as the `cut` event will most likely
 			// result in a `selectionchange` event which we want to ignore
 			this._textArea.setIgnoreSelectionChangeTime('received cut event');
@@ -358,10 +359,12 @@ export class TextAreaInput extends Disposable {
 		}));
 
 		this._register(this._textArea.onCopy((e) => {
+			console.log('onCopy of TextAreaInput');
 			this._ensureClipboardGetsEditorSelection(e);
 		}));
 
 		this._register(this._textArea.onPaste((e) => {
+			console.log('onPaste of TextAreaInput');
 			// Pretend here we touched the text area, as the `paste` event will most likely
 			// result in a `selectionchange` event which we want to ignore
 			this._textArea.setIgnoreSelectionChangeTime('received paste event');

--- a/src/vs/editor/browser/dnd.ts
+++ b/src/vs/editor/browser/dnd.ts
@@ -9,6 +9,12 @@ import { Mimes } from '../../base/common/mime.js';
 import { URI } from '../../base/common/uri.js';
 import { CodeDataTransfers, getPathForFile } from '../../platform/dnd/browser/dnd.js';
 
+export interface ClipboardCopyData {
+	'text/plain': string;
+	'text/html': string | null;
+	'vscode-editor-data': string;
+	'application/vnd.code.copymetadata'?: string;
+}
 
 export function toVSDataTransfer(dataTransfer: DataTransfer) {
 	const vsDataTransfer = new VSDataTransfer();
@@ -24,6 +30,21 @@ export function toVSDataTransfer(dataTransfer: DataTransfer) {
 			}
 		}
 	}
+	return vsDataTransfer;
+}
+
+export function toVSDataTransfer2(dataTransfer: ClipboardCopyData) {
+	const vsDataTransfer = new VSDataTransfer();
+	const copyMetadata = dataTransfer['application/vnd.code.copymetadata'];
+	if (copyMetadata) {
+		vsDataTransfer.append('application/vnd.code.copymetadata', createStringDataTransferItem(copyMetadata));
+	}
+	const textHTML = dataTransfer['text/html'];
+	if (textHTML) {
+		vsDataTransfer.append('text/html', createStringDataTransferItem(textHTML));
+	}
+	vsDataTransfer.append('text/plain', createStringDataTransferItem(dataTransfer['text/plain']));
+	vsDataTransfer.append('vscode-editor-data', createStringDataTransferItem(dataTransfer['vscode-editor-data']));
 	return vsDataTransfer;
 }
 
@@ -79,5 +100,13 @@ export function toExternalVSDataTransfer(sourceDataTransfer: DataTransfer, overw
 		vsDataTransfer.delete(internal);
 	}
 
+	return vsDataTransfer;
+}
+
+export function toExternalVSDataTransfer2(clipboardData: ClipboardCopyData, overwriteUriList = false): VSDataTransfer {
+	const vsDataTransfer = toVSDataTransfer2(clipboardData);
+	for (const internal of INTERNAL_DND_MIME_TYPES) {
+		vsDataTransfer.delete(internal);
+	}
 	return vsDataTransfer;
 }

--- a/src/vs/editor/browser/editorBrowser.ts
+++ b/src/vs/editor/browser/editorBrowser.ts
@@ -536,7 +536,6 @@ export interface IPartialEditorMouseEvent {
 export interface IPasteEvent {
 	readonly range: Range;
 	readonly languageId: string | null;
-	readonly clipboardEvent?: ClipboardEvent;
 }
 
 /**
@@ -547,7 +546,6 @@ export interface PastePayload {
 	pasteOnNewLine: boolean;
 	multicursorText: string[] | null;
 	mode: string | null;
-	clipboardEvent?: ClipboardEvent;
 }
 
 /**

--- a/src/vs/editor/browser/view/viewController.ts
+++ b/src/vs/editor/browser/view/viewController.ts
@@ -65,6 +65,7 @@ export class ViewController {
 	}
 
 	public paste(text: string, pasteOnNewLine: boolean, multicursorText: string[] | null, mode: string | null): void {
+		console.log('paste of ViewController');
 		this.commandDelegate.paste(text, pasteOnNewLine, multicursorText, mode);
 	}
 
@@ -85,6 +86,7 @@ export class ViewController {
 	}
 
 	public cut(): void {
+		console.log('cut of ViewController');
 		this.commandDelegate.cut();
 	}
 

--- a/src/vs/editor/browser/widget/codeEditor/codeEditorWidget.ts
+++ b/src/vs/editor/browser/widget/codeEditor/codeEditorWidget.ts
@@ -1087,7 +1087,7 @@ export class CodeEditorWidget extends Disposable implements editorBrowser.ICodeE
 				}
 				case editorCommon.Handler.Paste: {
 					const args = <Partial<editorBrowser.PastePayload>>payload;
-					this._paste(source, args.text || '', args.pasteOnNewLine || false, args.multicursorText || null, args.mode || null, args.clipboardEvent);
+					this._paste(source, args.text || '', args.pasteOnNewLine || false, args.multicursorText || null, args.mode || null);
 					return;
 				}
 				case editorCommon.Handler.Cut:
@@ -1157,8 +1157,13 @@ export class CodeEditorWidget extends Disposable implements editorBrowser.ICodeE
 		this._modelData.viewModel.compositionType(text, replacePrevCharCnt, replaceNextCharCnt, positionDelta, source);
 	}
 
-	private _paste(source: string | null | undefined, text: string, pasteOnNewLine: boolean, multicursorText: string[] | null, mode: string | null, clipboardEvent?: ClipboardEvent): void {
+	private _paste(source: string | null | undefined, text: string, pasteOnNewLine: boolean, multicursorText: string[] | null, mode: string | null): void {
 		console.log('_paste');
+		console.log('source : ', source);
+		console.log('text : ', text);
+		console.log('pasteOnNewLine : ', pasteOnNewLine);
+		console.log('multicursorText : ', multicursorText);
+		console.log('mode : ', mode);
 		if (!this._modelData) {
 			return;
 		}
@@ -1168,7 +1173,6 @@ export class CodeEditorWidget extends Disposable implements editorBrowser.ICodeE
 		const endPosition = viewModel.getSelection().getStartPosition();
 		if (source === 'keyboard') {
 			this._onDidPaste.fire({
-				clipboardEvent,
 				range: new Range(startPosition.lineNumber, startPosition.column, endPosition.lineNumber, endPosition.column),
 				languageId: mode
 			});

--- a/src/vs/editor/browser/widget/codeEditor/codeEditorWidget.ts
+++ b/src/vs/editor/browser/widget/codeEditor/codeEditorWidget.ts
@@ -1158,6 +1158,7 @@ export class CodeEditorWidget extends Disposable implements editorBrowser.ICodeE
 	}
 
 	private _paste(source: string | null | undefined, text: string, pasteOnNewLine: boolean, multicursorText: string[] | null, mode: string | null, clipboardEvent?: ClipboardEvent): void {
+		console.log('_paste');
 		if (!this._modelData) {
 			return;
 		}
@@ -1808,6 +1809,7 @@ export class CodeEditorWidget extends Disposable implements editorBrowser.ICodeE
 		if (this.isSimpleWidget) {
 			commandDelegate = {
 				paste: (text: string, pasteOnNewLine: boolean, multicursorText: string[] | null, mode: string | null) => {
+					console.log('paste of _createView 1');
 					this._paste('keyboard', text, pasteOnNewLine, multicursorText, mode);
 				},
 				type: (text: string) => {
@@ -1829,6 +1831,7 @@ export class CodeEditorWidget extends Disposable implements editorBrowser.ICodeE
 		} else {
 			commandDelegate = {
 				paste: (text: string, pasteOnNewLine: boolean, multicursorText: string[] | null, mode: string | null) => {
+					console.log('paste of _createView 2');
 					const payload: editorBrowser.PastePayload = { text, pasteOnNewLine, multicursorText, mode };
 					this._commandService.executeCommand(editorCommon.Handler.Paste, payload);
 				},

--- a/src/vs/editor/common/viewModel/viewModelImpl.ts
+++ b/src/vs/editor/common/viewModel/viewModelImpl.ts
@@ -1064,6 +1064,7 @@ export class ViewModel extends Disposable implements IViewModel {
 		this._executeCursorEdit(eventsCollector => this._cursor.compositionType(eventsCollector, text, replacePrevCharCnt, replaceNextCharCnt, positionDelta, source));
 	}
 	public paste(text: string, pasteOnNewLine: boolean, multicursorText?: string[] | null | undefined, source?: string | null | undefined): void {
+		console.log('paste of ViewModel');
 		this._executeCursorEdit(eventsCollector => this._cursor.paste(eventsCollector, text, pasteOnNewLine, multicursorText, source));
 	}
 	public cut(source?: string | null | undefined): void {

--- a/src/vs/editor/contrib/clipboard/browser/clipboard.ts
+++ b/src/vs/editor/contrib/clipboard/browser/clipboard.ts
@@ -14,14 +14,14 @@ import { ContextKeyExpr } from '../../../../platform/contextkey/common/contextke
 import { ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
 import { KeybindingWeight } from '../../../../platform/keybinding/common/keybindingsRegistry.js';
 import { CopyOptions, InMemoryClipboardMetadataManager } from '../../../browser/controller/editContext/clipboardUtils.js';
-// import { NativeEditContextRegistry } from '../../../browser/controller/editContext/native/nativeEditContextRegistry.js';
+import { NativeEditContextRegistry } from '../../../browser/controller/editContext/native/nativeEditContextRegistry.js';
 import { ICodeEditor } from '../../../browser/editorBrowser.js';
 import { Command, EditorAction, MultiCommand, registerEditorAction } from '../../../browser/editorExtensions.js';
 import { ICodeEditorService } from '../../../browser/services/codeEditorService.js';
 import { EditorOption } from '../../../common/config/editorOptions.js';
 import { Handler } from '../../../common/editorCommon.js';
 import { EditorContextKeys } from '../../../common/editorContextKeys.js';
-// import { CopyPasteController } from '../../dropOrPasteInto/browser/copyPasteController.js';
+import { CopyPasteController } from '../../dropOrPasteInto/browser/copyPasteController.js';
 
 const CLIPBOARD_CONTEXT_MENU_GROUP = '9_cutcopypaste';
 
@@ -194,10 +194,11 @@ function registerExecCommandImpl(target: MultiCommand | undefined, browserComman
 
 	// 1. handle case when focus is in editor.
 	target.addImplementation(10000, 'code-editor', (accessor: ServicesAccessor, args: any) => {
-		console.log('addImplementation');
+		console.log('addImplementation : ', browserCommand);
 		// Only if editor text focus (i.e. not if editor has widget focus).
 		const focusedEditor = accessor.get(ICodeEditorService).getFocusedCodeEditor();
 		if (focusedEditor && focusedEditor.hasTextFocus()) {
+			// TODO: get copyPasteController, write all of the relevant data into the clipboard service using clipboard.write
 			// Do not execute if there is no selection and empty selection clipboard is off
 			const emptySelectionClipboard = focusedEditor.getOption(EditorOption.emptySelectionClipboard);
 			const selection = focusedEditor.getSelection();
@@ -242,7 +243,6 @@ if (PasteAction) {
 		// Only if editor text focus (i.e. not if editor has widget focus).
 		const focusedEditor = codeEditorService.getFocusedCodeEditor();
 		if (focusedEditor && focusedEditor.hasModel() && focusedEditor.hasTextFocus()) {
-			/*
 			// execCommand(paste) does not work with edit context
 			let result: boolean;
 			const experimentalEditContextEnabled = focusedEditor.getOption(EditorOption.experimentalEditContextEnabled);
@@ -279,39 +279,38 @@ if (PasteAction) {
 				// if the result is true, so pasting worked, then finish the paste
 				return CopyPasteController.get(focusedEditor)?.finishedPaste() ?? Promise.resolve();
 			} else if (platform.isWeb) {
-			*/
-			// Else if the result is false, this could be because we are on web, where execCommand is deprecated
-			// Why do we not use the clipboard service directly?
-			// Use the clipboard service if document.execCommand('paste') was not successful
-			return (async () => {
-				// need to call the code in copy/paste controller
-				const clipboardText = await clipboardService.readText();
-				console.log('clipboardText : ', clipboardText);
-				if (clipboardText !== '') {
-					// fetching the text from the instance of the in memory clipboard metadata manager
-					// singleton
-					const metadata = InMemoryClipboardMetadataManager.INSTANCE.get(clipboardText);
-					let pasteOnNewLine = false;
-					let multicursorText: string[] | null = null;
-					let mode: string | null = null;
-					if (metadata) {
-						pasteOnNewLine = (focusedEditor.getOption(EditorOption.emptySelectionClipboard) && !!metadata.isFromEmptySelection);
-						multicursorText = (typeof metadata.multicursorText !== 'undefined' ? metadata.multicursorText : null);
-						mode = metadata.mode;
+				// Else if the result is false, this could be because we are on web, where execCommand is deprecated
+				// Why do we not use the clipboard service directly?
+				// Use the clipboard service if document.execCommand('paste') was not successful
+				return (async () => {
+					// need to call the code in copy/paste controller
+					const clipboardText = await clipboardService.readText();
+					console.log('clipboardText : ', clipboardText);
+					if (clipboardText !== '') {
+						// fetching the text from the instance of the in memory clipboard metadata manager
+						// singleton
+						const metadata = InMemoryClipboardMetadataManager.INSTANCE.get(clipboardText);
+						let pasteOnNewLine = false;
+						let multicursorText: string[] | null = null;
+						let mode: string | null = null;
+						if (metadata) {
+							pasteOnNewLine = (focusedEditor.getOption(EditorOption.emptySelectionClipboard) && !!metadata.isFromEmptySelection);
+							multicursorText = (typeof metadata.multicursorText !== 'undefined' ? metadata.multicursorText : null);
+							mode = metadata.mode;
+						}
+						console.log('pasteOnNewLine : ', pasteOnNewLine);
+						console.log('multicursorText : ', multicursorText);
+						console.log('mode : ', mode);
+						focusedEditor.trigger('keyboard', Handler.Paste, {
+							text: clipboardText,
+							pasteOnNewLine,
+							multicursorText,
+							mode
+						});
 					}
-					console.log('pasteOnNewLine : ', pasteOnNewLine);
-					console.log('multicursorText : ', multicursorText);
-					console.log('mode : ', mode);
-					focusedEditor.trigger('keyboard', Handler.Paste, {
-						text: clipboardText,
-						pasteOnNewLine,
-						multicursorText,
-						mode
-					});
-				}
-			})();
-			/* } */
-			// return true;
+				})();
+			}
+			return true;
 		}
 		// if not focused editor, then return false
 		return false;

--- a/src/vs/editor/contrib/clipboard/browser/clipboard.ts
+++ b/src/vs/editor/contrib/clipboard/browser/clipboard.ts
@@ -187,12 +187,14 @@ class ExecCommandCopyWithSyntaxHighlightingAction extends EditorAction {
 }
 
 function registerExecCommandImpl(target: MultiCommand | undefined, browserCommand: 'cut' | 'copy'): void {
+	console.log('registerExecCommandImpl');
 	if (!target) {
 		return;
 	}
 
 	// 1. handle case when focus is in editor.
 	target.addImplementation(10000, 'code-editor', (accessor: ServicesAccessor, args: any) => {
+		console.log('addImplementation');
 		// Only if editor text focus (i.e. not if editor has widget focus).
 		const focusedEditor = accessor.get(ICodeEditorService).getFocusedCodeEditor();
 		if (focusedEditor && focusedEditor.hasTextFocus()) {

--- a/src/vs/editor/contrib/clipboard/browser/clipboard.ts
+++ b/src/vs/editor/contrib/clipboard/browser/clipboard.ts
@@ -210,9 +210,11 @@ function registerExecCommandImpl(target: MultiCommand | undefined, browserComman
 			if (focusedEditor.getOption(EditorOption.experimentalEditContextEnabled) && browserCommand === 'cut') {
 				// execCommand(copy) works for edit context, but not execCommand(cut).
 				// do the normal copy, but trigger the cut command from the editor
+				console.log('before execCommand : copy');
 				focusedEditor.getContainerDomNode().ownerDocument.execCommand('copy');
 				focusedEditor.trigger(undefined, Handler.Cut, undefined);
 			} else {
+				console.log('before execCommand : ', browserCommand);
 				focusedEditor.getContainerDomNode().ownerDocument.execCommand(browserCommand);
 			}
 			return true;
@@ -233,6 +235,7 @@ registerExecCommandImpl(CopyAction, 'copy');
 if (PasteAction) {
 	// 1. Paste: handle case when focus is in editor.
 	PasteAction.addImplementation(10000, 'code-editor', (accessor: ServicesAccessor, args: any) => {
+		console.log('PasteAction.addImplementation');
 		const codeEditorService = accessor.get(ICodeEditorService);
 		const clipboardService = accessor.get(IClipboardService);
 
@@ -242,6 +245,7 @@ if (PasteAction) {
 			// execCommand(paste) does not work with edit context
 			let result: boolean;
 			const experimentalEditContextEnabled = focusedEditor.getOption(EditorOption.experimentalEditContextEnabled);
+			console.log('experimentalEditContextEnabled ', experimentalEditContextEnabled);
 			if (experimentalEditContextEnabled) {
 				// Since we can not call execCommand('paste') on a dom node with edit context set
 				// we added a hidden text area that receives the paste execution
@@ -269,6 +273,7 @@ if (PasteAction) {
 				// otherwise directly execute the paste command, where the original text area is focused, and so the paste command is done on the hidden text area
 				result = focusedEditor.getContainerDomNode().ownerDocument.execCommand('paste');
 			}
+			console.log('result : ', result);
 			if (result) {
 				// if the result is true, so pasting worked, then finish the paste
 				return CopyPasteController.get(focusedEditor)?.finishedPaste() ?? Promise.resolve();
@@ -278,6 +283,7 @@ if (PasteAction) {
 				// Use the clipboard service if document.execCommand('paste') was not successful
 				return (async () => {
 					const clipboardText = await clipboardService.readText();
+					console.log('clipboardText : ', clipboardText);
 					if (clipboardText !== '') {
 						// fetching the text from the instance of the in memory clipboard metadata manager
 						// singleton
@@ -290,7 +296,6 @@ if (PasteAction) {
 							multicursorText = (typeof metadata.multicursorText !== 'undefined' ? metadata.multicursorText : null);
 							mode = metadata.mode;
 						}
-						console.log('clipboardText : ', clipboardText);
 						console.log('pasteOnNewLine : ', pasteOnNewLine);
 						console.log('multicursorText : ', multicursorText);
 						console.log('mode : ', mode);

--- a/src/vs/editor/contrib/clipboard/browser/clipboard.ts
+++ b/src/vs/editor/contrib/clipboard/browser/clipboard.ts
@@ -14,14 +14,14 @@ import { ContextKeyExpr } from '../../../../platform/contextkey/common/contextke
 import { ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
 import { KeybindingWeight } from '../../../../platform/keybinding/common/keybindingsRegistry.js';
 import { CopyOptions, InMemoryClipboardMetadataManager } from '../../../browser/controller/editContext/clipboardUtils.js';
-import { NativeEditContextRegistry } from '../../../browser/controller/editContext/native/nativeEditContextRegistry.js';
+// import { NativeEditContextRegistry } from '../../../browser/controller/editContext/native/nativeEditContextRegistry.js';
 import { ICodeEditor } from '../../../browser/editorBrowser.js';
 import { Command, EditorAction, MultiCommand, registerEditorAction } from '../../../browser/editorExtensions.js';
 import { ICodeEditorService } from '../../../browser/services/codeEditorService.js';
 import { EditorOption } from '../../../common/config/editorOptions.js';
 import { Handler } from '../../../common/editorCommon.js';
 import { EditorContextKeys } from '../../../common/editorContextKeys.js';
-import { CopyPasteController } from '../../dropOrPasteInto/browser/copyPasteController.js';
+// import { CopyPasteController } from '../../dropOrPasteInto/browser/copyPasteController.js';
 
 const CLIPBOARD_CONTEXT_MENU_GROUP = '9_cutcopypaste';
 
@@ -242,6 +242,7 @@ if (PasteAction) {
 		// Only if editor text focus (i.e. not if editor has widget focus).
 		const focusedEditor = codeEditorService.getFocusedCodeEditor();
 		if (focusedEditor && focusedEditor.hasModel() && focusedEditor.hasTextFocus()) {
+			/*
 			// execCommand(paste) does not work with edit context
 			let result: boolean;
 			const experimentalEditContextEnabled = focusedEditor.getOption(EditorOption.experimentalEditContextEnabled);
@@ -278,37 +279,39 @@ if (PasteAction) {
 				// if the result is true, so pasting worked, then finish the paste
 				return CopyPasteController.get(focusedEditor)?.finishedPaste() ?? Promise.resolve();
 			} else if (platform.isWeb) {
-				// Else if the result is false, this could be because we are on web, where execCommand is deprecated
-				// Why do we not use the clipboard service directly?
-				// Use the clipboard service if document.execCommand('paste') was not successful
-				return (async () => {
-					const clipboardText = await clipboardService.readText();
-					console.log('clipboardText : ', clipboardText);
-					if (clipboardText !== '') {
-						// fetching the text from the instance of the in memory clipboard metadata manager
-						// singleton
-						const metadata = InMemoryClipboardMetadataManager.INSTANCE.get(clipboardText);
-						let pasteOnNewLine = false;
-						let multicursorText: string[] | null = null;
-						let mode: string | null = null;
-						if (metadata) {
-							pasteOnNewLine = (focusedEditor.getOption(EditorOption.emptySelectionClipboard) && !!metadata.isFromEmptySelection);
-							multicursorText = (typeof metadata.multicursorText !== 'undefined' ? metadata.multicursorText : null);
-							mode = metadata.mode;
-						}
-						console.log('pasteOnNewLine : ', pasteOnNewLine);
-						console.log('multicursorText : ', multicursorText);
-						console.log('mode : ', mode);
-						focusedEditor.trigger('keyboard', Handler.Paste, {
-							text: clipboardText,
-							pasteOnNewLine,
-							multicursorText,
-							mode
-						});
+			*/
+			// Else if the result is false, this could be because we are on web, where execCommand is deprecated
+			// Why do we not use the clipboard service directly?
+			// Use the clipboard service if document.execCommand('paste') was not successful
+			return (async () => {
+				// need to call the code in copy/paste controller
+				const clipboardText = await clipboardService.readText();
+				console.log('clipboardText : ', clipboardText);
+				if (clipboardText !== '') {
+					// fetching the text from the instance of the in memory clipboard metadata manager
+					// singleton
+					const metadata = InMemoryClipboardMetadataManager.INSTANCE.get(clipboardText);
+					let pasteOnNewLine = false;
+					let multicursorText: string[] | null = null;
+					let mode: string | null = null;
+					if (metadata) {
+						pasteOnNewLine = (focusedEditor.getOption(EditorOption.emptySelectionClipboard) && !!metadata.isFromEmptySelection);
+						multicursorText = (typeof metadata.multicursorText !== 'undefined' ? metadata.multicursorText : null);
+						mode = metadata.mode;
 					}
-				})();
-			}
-			return true;
+					console.log('pasteOnNewLine : ', pasteOnNewLine);
+					console.log('multicursorText : ', multicursorText);
+					console.log('mode : ', mode);
+					focusedEditor.trigger('keyboard', Handler.Paste, {
+						text: clipboardText,
+						pasteOnNewLine,
+						multicursorText,
+						mode
+					});
+				}
+			})();
+			/* } */
+			// return true;
 		}
 		// if not focused editor, then return false
 		return false;

--- a/src/vs/editor/contrib/dropOrPasteInto/browser/copyPasteController.ts
+++ b/src/vs/editor/contrib/dropOrPasteInto/browser/copyPasteController.ts
@@ -278,6 +278,7 @@ export class CopyPasteController extends Disposable implements IEditorContributi
 		}
 
 		const metadata = this.fetchCopyMetadata(e);
+		console.log('metadata : ', metadata);
 		const dataTransfer = toExternalVSDataTransfer(e.clipboardData);
 		dataTransfer.delete(vscodeClipboardMime);
 
@@ -292,6 +293,7 @@ export class CopyPasteController extends Disposable implements IEditorContributi
 			// We filter providers again once we have the final dataTransfer we will use.
 			Mimes.uriList,
 		];
+		console.log('allPotentialMimeTypes : ', allPotentialMimeTypes);
 
 		const allProviders = this._languageFeaturesService.documentPasteEditProvider
 			.ordered(model)
@@ -307,6 +309,7 @@ export class CopyPasteController extends Disposable implements IEditorContributi
 				// And providers that don't handle any of mime types in the clipboard
 				return provider.pasteMimeTypes?.some(type => matchesMimeType(type, allPotentialMimeTypes));
 			});
+		console.log('allProviders : ', allProviders);
 		if (!allProviders.length) {
 			if (this._pasteAsActionContext?.preferred) {
 				this.showPasteAsNoEditMessage(selections, this._pasteAsActionContext.preferred);
@@ -342,6 +345,7 @@ export class CopyPasteController extends Disposable implements IEditorContributi
 	}
 
 	private doPasteInline(allProviders: readonly DocumentPasteEditProvider[], selections: readonly Selection[], dataTransfer: VSDataTransfer, metadata: CopyMetadata | undefined, clipboardEvent: ClipboardEvent): void {
+		console.log('doPasteInline');
 		const editor = this._editor;
 		if (!editor.hasModel()) {
 			return;
@@ -445,6 +449,7 @@ export class CopyPasteController extends Disposable implements IEditorContributi
 	}
 
 	private showPasteAsPick(preference: PastePreference | undefined, allProviders: readonly DocumentPasteEditProvider[], selections: readonly Selection[], dataTransfer: VSDataTransfer, metadata: CopyMetadata | undefined): void {
+		console.log('showPasteAsPick');
 		const p = createCancelablePromise(async (token) => {
 			const editor = this._editor;
 			if (!editor.hasModel()) {
@@ -661,6 +666,9 @@ export class CopyPasteController extends Disposable implements IEditorContributi
 	}
 
 	private async applyDefaultPasteHandler(dataTransfer: VSDataTransfer, metadata: CopyMetadata | undefined, token: CancellationToken, clipboardEvent: ClipboardEvent) {
+		console.log('applyDefaultPasteHandler');
+		console.log('dataTransfer : ', dataTransfer);
+		console.log('metadata : ', metadata);
 		const textDataTransfer = dataTransfer.get(Mimes.text) ?? dataTransfer.get('text');
 		const text = (await textDataTransfer?.asString()) ?? '';
 		if (token.isCancellationRequested) {

--- a/src/vs/editor/contrib/dropOrPasteInto/browser/copyPasteController.ts
+++ b/src/vs/editor/contrib/dropOrPasteInto/browser/copyPasteController.ts
@@ -169,7 +169,9 @@ export class CopyPasteController extends Disposable implements IEditorContributi
 
 	private handleCopy(e: ClipboardEvent) {
 		console.log('handleCopy of CopyPasteController');
+		console.log('e : ', e);
 		if (!this._editor.hasTextFocus()) {
+			console.log('return 1');
 			return;
 		}
 
@@ -179,12 +181,14 @@ export class CopyPasteController extends Disposable implements IEditorContributi
 		this._clipboardService.clearInternalState?.();
 
 		if (!e.clipboardData || !this.isPasteAsEnabled()) {
+			console.log('return 2');
 			return;
 		}
 
 		const model = this._editor.getModel();
 		const selections = this._editor.getSelections();
 		if (!model || !selections?.length) {
+			console.log('return 3');
 			return;
 		}
 
@@ -194,6 +198,7 @@ export class CopyPasteController extends Disposable implements IEditorContributi
 		const wasFromEmptySelection = selections.length === 1 && selections[0].isEmpty();
 		if (wasFromEmptySelection) {
 			if (!enableEmptySelectionClipboard) {
+				console.log('return 4');
 				return;
 			}
 
@@ -202,6 +207,9 @@ export class CopyPasteController extends Disposable implements IEditorContributi
 
 		const toCopy = this._editor._getViewModel()?.getPlainTextToCopy(selections, enableEmptySelectionClipboard, platform.isWindows);
 		const multicursorText = Array.isArray(toCopy) ? toCopy : null;
+
+		console.log('multicursorText : ', multicursorText);
+		console.log('wasFromEmptySelection : ', wasFromEmptySelection);
 
 		const defaultPastePayload = {
 			multicursorText,
@@ -214,11 +222,13 @@ export class CopyPasteController extends Disposable implements IEditorContributi
 			.filter(x => !!x.prepareDocumentPaste);
 		if (!providers.length) {
 			this.setCopyMetadata(e.clipboardData, { defaultPastePayload });
+			console.log('return 5');
 			return;
 		}
 
 		const dataTransfer = toVSDataTransfer(e.clipboardData);
 		const providerCopyMimeTypes = providers.flatMap(x => x.copyMimeTypes ?? []);
+		console.log('providerCopyMimeTypes : ', providerCopyMimeTypes);
 
 		// Save off a handle pointing to data that VS Code maintains.
 		const handle = generateUuid();
@@ -547,6 +557,9 @@ export class CopyPasteController extends Disposable implements IEditorContributi
 	}
 
 	private setCopyMetadata(dataTransfer: DataTransfer, metadata: CopyMetadata) {
+		console.log('setCopyMetadata');
+		console.log('dataTransfer: ', dataTransfer);
+		console.log('metadata: ', metadata);
 		dataTransfer.setData(vscodeClipboardMime, JSON.stringify(metadata));
 	}
 

--- a/src/vs/editor/contrib/dropOrPasteInto/browser/copyPasteController.ts
+++ b/src/vs/editor/contrib/dropOrPasteInto/browser/copyPasteController.ts
@@ -167,9 +167,9 @@ export class CopyPasteController extends Disposable implements IEditorContributi
 		await this._currentPasteOperation;
 	}
 
-	private handleCopy(e: ClipboardEvent) {
+	private handleCopy(clipboardEvent: ClipboardEvent) {
 		console.log('handleCopy of CopyPasteController');
-		console.log('e : ', e);
+		console.log('e : ', clipboardEvent);
 		if (!this._editor.hasTextFocus()) {
 			console.log('return 1');
 			return;
@@ -180,7 +180,7 @@ export class CopyPasteController extends Disposable implements IEditorContributi
 		// This means the resources clipboard is not properly updated when copying from the editor.
 		this._clipboardService.clearInternalState?.();
 
-		if (!e.clipboardData || !this.isPasteAsEnabled()) {
+		if (!clipboardEvent.clipboardData || !this.isPasteAsEnabled()) {
 			console.log('return 2');
 			return;
 		}
@@ -221,18 +221,18 @@ export class CopyPasteController extends Disposable implements IEditorContributi
 			.ordered(model)
 			.filter(x => !!x.prepareDocumentPaste);
 		if (!providers.length) {
-			this.setCopyMetadata(e.clipboardData, { defaultPastePayload });
+			this.setCopyMetadata(clipboardEvent.clipboardData, { defaultPastePayload });
 			console.log('return 5');
 			return;
 		}
 
-		const dataTransfer = toVSDataTransfer(e.clipboardData);
+		const dataTransfer = toVSDataTransfer(clipboardEvent.clipboardData);
 		const providerCopyMimeTypes = providers.flatMap(x => x.copyMimeTypes ?? []);
 		console.log('providerCopyMimeTypes : ', providerCopyMimeTypes);
 
 		// Save off a handle pointing to data that VS Code maintains.
 		const handle = generateUuid();
-		this.setCopyMetadata(e.clipboardData, {
+		this.setCopyMetadata(clipboardEvent.clipboardData, {
 			id: handle,
 			providerCopyMimeTypes,
 			defaultPastePayload
@@ -282,6 +282,9 @@ export class CopyPasteController extends Disposable implements IEditorContributi
 		const dataTransfer = toExternalVSDataTransfer(clipboardEvent.clipboardData);
 		dataTransfer.delete(vscodeClipboardMime);
 
+		console.log('clipboardEvent.clipboardData.files : ', clipboardEvent.clipboardData.files);
+		// contains formats and those from drag operation
+		console.log('clipboardEvent.clipboardData.types : ', clipboardEvent.clipboardData.types);
 		const fileTypes = Array.from(clipboardEvent.clipboardData.files).map(file => file.type);
 
 		const allPotentialMimeTypes = [
@@ -568,16 +571,16 @@ export class CopyPasteController extends Disposable implements IEditorContributi
 		dataTransfer.setData(vscodeClipboardMime, JSON.stringify(metadata));
 	}
 
-	private fetchCopyMetadata(e: ClipboardEvent): CopyMetadata | undefined {
+	private fetchCopyMetadata(clipboardEvent: ClipboardEvent): CopyMetadata | undefined {
 		console.log('fetchCopyMetadata of CopyPasteController');
-		console.log('e : ', e);
-		if (!e.clipboardData) {
+		console.log('e : ', clipboardEvent);
+		if (!clipboardEvent.clipboardData) {
 			return;
 		}
 
 		// Prefer using the clipboard data we saved off
 		// Getting data from clipboard and then from the clipboard event utils as a fallback
-		const rawMetadata = e.clipboardData.getData(vscodeClipboardMime);
+		const rawMetadata = clipboardEvent.clipboardData.getData(vscodeClipboardMime);
 		console.log('rawMetadata : ', rawMetadata);
 		if (rawMetadata) {
 			try {
@@ -588,7 +591,7 @@ export class CopyPasteController extends Disposable implements IEditorContributi
 		}
 
 		// Otherwise try to extract the generic text editor metadata
-		const [_, metadata] = ClipboardEventUtils.getTextData(e.clipboardData);
+		const [_, metadata] = ClipboardEventUtils.getTextData(clipboardEvent.clipboardData);
 		if (metadata) {
 			return {
 				defaultPastePayload: {

--- a/src/vs/editor/contrib/dropOrPasteInto/browser/copyPasteController.ts
+++ b/src/vs/editor/contrib/dropOrPasteInto/browser/copyPasteController.ts
@@ -168,6 +168,7 @@ export class CopyPasteController extends Disposable implements IEditorContributi
 	}
 
 	private handleCopy(e: ClipboardEvent) {
+		console.log('handleCopy of CopyPasteController');
 		if (!this._editor.hasTextFocus()) {
 			return;
 		}
@@ -244,6 +245,7 @@ export class CopyPasteController extends Disposable implements IEditorContributi
 	}
 
 	private async handlePaste(e: ClipboardEvent) {
+		console.log('handlePaste of CopyPasteController');
 		if (!e.clipboardData || !this._editor.hasTextFocus()) {
 			return;
 		}
@@ -549,12 +551,16 @@ export class CopyPasteController extends Disposable implements IEditorContributi
 	}
 
 	private fetchCopyMetadata(e: ClipboardEvent): CopyMetadata | undefined {
+		console.log('fetchCopyMetadata of CopyPasteController');
+		console.log('e : ', e);
 		if (!e.clipboardData) {
 			return;
 		}
 
 		// Prefer using the clipboard data we saved off
+		// Getting data from clipboard and then from the clipboard event utils as a fallback
 		const rawMetadata = e.clipboardData.getData(vscodeClipboardMime);
+		console.log('rawMetadata : ', rawMetadata);
 		if (rawMetadata) {
 			try {
 				return JSON.parse(rawMetadata);

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -5732,7 +5732,6 @@ declare namespace monaco.editor {
 	export interface IPasteEvent {
 		readonly range: Range;
 		readonly languageId: string | null;
-		readonly clipboardEvent?: ClipboardEvent;
 	}
 
 	export interface IDiffEditorConstructionOptions extends IDiffEditorOptions, IEditorConstructionOptions {

--- a/src/vs/platform/clipboard/browser/clipboardService.ts
+++ b/src/vs/platform/clipboard/browser/clipboardService.ts
@@ -40,17 +40,20 @@ export class BrowserClipboardService extends Disposable implements IClipboardSer
 		// copied resources: since we keep resources in memory
 		// and not in the clipboard, we have to invalidate
 		// that state when the user copies other data.
+		// If we detect copying to the clipboard, then clear the memory
 		this._register(Event.runAndSubscribe(onDidRegisterWindow, ({ window, disposables }) => {
 			disposables.add(addDisposableListener(window.document, 'copy', () => this.clearResourcesState()));
 		}, { window: mainWindow, disposables: this._store }));
 	}
 
 	async readImage(): Promise<Uint8Array> {
+		console.log('readImage of BrowserClipboardService');
 		try {
 			const clipboardItems = await navigator.clipboard.read();
 			const clipboardItem = clipboardItems[0];
 
 			const supportedImageTypes = ['image/png', 'image/jpeg', 'image/gif', 'image/tiff', 'image/bmp'];
+			// we only read specific types of images
 			const mimeType = supportedImageTypes.find(type => clipboardItem.types.includes(type));
 
 			if (mimeType) {
@@ -116,6 +119,7 @@ export class BrowserClipboardService extends Disposable implements IClipboardSer
 
 	async writeText(text: string, type?: string): Promise<void> {
 
+		console.log('writeText of BrowserClipboardService');
 		// Clear resources given we are writing text
 		this.clearResourcesState();
 
@@ -147,9 +151,11 @@ export class BrowserClipboardService extends Disposable implements IClipboardSer
 	}
 
 	private fallbackWriteText(text: string): void {
+		console.log('fallbackWriteText');
 		const activeDocument = getActiveDocument();
 		const activeElement = activeDocument.activeElement;
 
+		// Appending a temporary text area, setting the value of the text area, copying the content by executing the command and then removing it
 		const textArea: HTMLTextAreaElement = activeDocument.body.appendChild($('textarea', { 'aria-hidden': true }));
 		textArea.style.height = '1px';
 		textArea.style.width = '1px';
@@ -169,7 +175,7 @@ export class BrowserClipboardService extends Disposable implements IClipboardSer
 	}
 
 	async readText(type?: string): Promise<string> {
-
+		console.log('readText of BrowserClipboardService');
 		// With type: only in-memory is supported
 		if (type) {
 			return this.mapTextToType.get(type) || '';
@@ -207,6 +213,9 @@ export class BrowserClipboardService extends Disposable implements IClipboardSer
 		// as we have seen DOMExceptions in certain browsers
 		// due to security policies.
 		try {
+
+			// ClipboardItem comes from the dom library
+			// defininig our own mime type
 			await getActiveWindow().navigator.clipboard.write([
 				new ClipboardItem({
 					[`web ${vscodeResourcesMime}`]: new Blob([

--- a/src/vs/platform/native/electron-main/nativeHostMainService.ts
+++ b/src/vs/platform/native/electron-main/nativeHostMainService.ts
@@ -733,34 +733,42 @@ export class NativeHostMainService extends Disposable implements INativeHostMain
 	//#region Clipboard
 
 	async readClipboardText(windowId: number | undefined, type?: 'selection' | 'clipboard'): Promise<string> {
+		console.log('readClipboardText of NativeHostMainService');
 		return clipboard.readText(type);
 	}
 
 	async readImage(): Promise<Uint8Array> {
+		console.log('readImage of NativeHostMainService');
 		return clipboard.readImage().toPNG();
 	}
 
 	async writeClipboardText(windowId: number | undefined, text: string, type?: 'selection' | 'clipboard'): Promise<void> {
+		console.log('writeClipboardText of NativeHostMainService');
 		return clipboard.writeText(text, type);
 	}
 
 	async readClipboardFindText(windowId: number | undefined,): Promise<string> {
+		console.log('readClipboardFindText of NativeHostMainService');
 		return clipboard.readFindText();
 	}
 
 	async writeClipboardFindText(windowId: number | undefined, text: string): Promise<void> {
+		console.log('writeClipboardFindText of NativeHostMainService');
 		return clipboard.writeFindText(text);
 	}
 
 	async writeClipboardBuffer(windowId: number | undefined, format: string, buffer: VSBuffer, type?: 'selection' | 'clipboard'): Promise<void> {
+		console.log('writeClipboardBuffer of NativeHostMainService');
 		return clipboard.writeBuffer(format, Buffer.from(buffer.buffer), type);
 	}
 
 	async readClipboardBuffer(windowId: number | undefined, format: string): Promise<VSBuffer> {
+		console.log('readClipboardBuffer of NativeHostMainService');
 		return VSBuffer.wrap(clipboard.readBuffer(format));
 	}
 
 	async hasClipboard(windowId: number | undefined, format: string, type?: 'selection' | 'clipboard'): Promise<boolean> {
+		console.log('hasClipboard of NativeHostMainService');
 		return clipboard.has(format, type);
 	}
 

--- a/src/vs/workbench/services/clipboard/browser/clipboardService.ts
+++ b/src/vs/workbench/services/clipboard/browser/clipboardService.ts
@@ -29,6 +29,7 @@ export class BrowserClipboardService extends BaseBrowserClipboardService {
 	}
 
 	override async writeText(text: string, type?: string): Promise<void> {
+		console.log('writeText of BrowserClipboardService2');
 		if (!!this.environmentService.extensionTestsLocationURI && typeof type !== 'string') {
 			type = 'vscode-tests'; // force in-memory clipboard for tests to avoid permission issues
 		}
@@ -37,6 +38,7 @@ export class BrowserClipboardService extends BaseBrowserClipboardService {
 	}
 
 	override async readText(type?: string): Promise<string> {
+		console.log('readText of BrowserClipboardService2');
 		if (!!this.environmentService.extensionTestsLocationURI && typeof type !== 'string') {
 			type = 'vscode-tests'; // force in-memory clipboard for tests to avoid permission issues
 		}
@@ -44,6 +46,8 @@ export class BrowserClipboardService extends BaseBrowserClipboardService {
 		if (type) {
 			return super.readText(type);
 		}
+
+		// If type is not defined
 
 		try {
 			return await getActiveWindow().navigator.clipboard.readText();

--- a/src/vs/workbench/services/clipboard/electron-sandbox/clipboardService.ts
+++ b/src/vs/workbench/services/clipboard/electron-sandbox/clipboardService.ts
@@ -21,19 +21,23 @@ export class NativeClipboardService implements IClipboardService {
 	) { }
 
 	async readImage(): Promise<Uint8Array> {
+		console.log('readImage of NativeClipboardService');
 		return this.nativeHostService.readImage();
 	}
 
 	async writeText(text: string, type?: 'selection' | 'clipboard'): Promise<void> {
+		console.log('writeText of NativeClipboardService');
 		return this.nativeHostService.writeClipboardText(text, type);
 	}
 
 	async readText(type?: 'selection' | 'clipboard'): Promise<string> {
+		console.log('readText of NativeClipboardService');
 		return this.nativeHostService.readClipboardText(type);
 	}
 
 	async readFindText(): Promise<string> {
 		if (isMacintosh) {
+			console.log('readFindText of NativeClipboardService');
 			return this.nativeHostService.readClipboardFindText();
 		}
 
@@ -42,6 +46,7 @@ export class NativeClipboardService implements IClipboardService {
 
 	async writeFindText(text: string): Promise<void> {
 		if (isMacintosh) {
+			console.log('writeFindText of NativeClipboardService');
 			return this.nativeHostService.writeClipboardFindText(text);
 		}
 	}


### PR DESCRIPTION
move away from `execCommand` for pasting

Points to discuss:

- Paste from webcontents returns void, not boolean. Is the operation always successful? The paste from dom, returns a boolean.
- Not sure when the second branch is executed. It is apparently executed when the editor does not have focus.