### PR TITLE
[prompts]: implement basic paths autocompletion for `Unix` machines

### DIFF
--- a/src/vs/base/common/types.ts
+++ b/src/vs/base/common/types.ts
@@ -163,6 +163,44 @@ export function assertAllDefined(...args: (unknown | null | undefined)[]): unkno
 	return result;
 }
 
+/**
+ * Asserts that the provided `item` is one of the items in the `list`.
+ * Helps to narrow down broader `TType` of the `item` to the more
+ * specific `TSubtype` type.
+ *
+ * ## Examples
+ *
+ * ```typescript
+ * // note! item type is a `subset of string`
+ * type TItem = ':' | '.' | '/';
+ *
+ * // note! item is type of `string` here
+ * const item: string = ':';
+ * // list of the items to check against
+ * const list: TItem[] = [':', '.'];
+ *
+ * // ok
+ * assertOneOf(
+ *   item,
+ *   list,
+ *   'Must succeed',
+ * );
+ *
+ * // `item` is of `TItem` type now
+ * ```
+ */
+export function assertOneOf<TType, TSubtype extends TType>(
+	item: TType,
+	list: readonly TSubtype[],
+	errorPrefix: string,
+): asserts item is TSubtype {
+	// note! it's ok to type cast here because `TSubtype` is a subtype of `TType`
+	assert(
+		list.includes(item as TSubtype),
+		`${errorPrefix}: Expected '${item}' to be one of [${list.join(', ')}].`,
+	);
+}
+
 const hasOwnProperty = Object.prototype.hasOwnProperty;
 
 /**

--- a/src/vs/base/test/common/types.test.ts
+++ b/src/vs/base/test/common/types.test.ts
@@ -5,8 +5,8 @@
 
 import assert from 'assert';
 import * as types from '../../common/types.js';
+import { assertDefined, assertOneOf } from '../../common/types.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from './utils.js';
-import { assertDefined } from '../../common/types.js';
 
 suite('Types', () => {
 
@@ -301,6 +301,556 @@ suite('Types', () => {
 				errorMessage,
 				'Error must have correct message.',
 			);
+		});
+	});
+
+	suite('assertOneOf', () => {
+		suite('success', () => {
+			/**
+			 * Simple type check function to compile-time validate
+			 * type of passed argument.
+			 */
+			function typeCheck<T extends unknown>(thing: T): T {
+				return thing;
+			}
+
+			suite('string', () => {
+				test('type', () => {
+					assert.doesNotThrow(() => {
+						assertOneOf(
+							'foo',
+							['foo', 'bar'],
+							'Foo must be one of: foo, bar',
+						);
+					});
+				});
+
+				test('subtype', () => {
+					assert.doesNotThrow(() => {
+						const item: string = 'hi';
+						const list: ('hi' | 'ciao' | 'hola')[] = ['hi', 'ciao'];
+
+						assertOneOf(
+							item,
+							list,
+							'Hi must be one of: hi, ciao',
+						);
+
+						typeCheck<'hi' | 'ciao' | 'hola'>(item);
+					});
+				});
+			});
+
+			suite('number', () => {
+				test('type', () => {
+					assert.doesNotThrow(() => {
+						assertOneOf(
+							10,
+							[10, 100],
+							'10 must be one of: 10, 100',
+						);
+					});
+				});
+
+				test('subtype', () => {
+					assert.doesNotThrow(() => {
+						const item: number = 20;
+						const list: (20 | 2000)[] = [20, 2000];
+
+						assertOneOf(
+							item,
+							list,
+							'20 must be one of: 20, 2000',
+						);
+
+						typeCheck<20 | 2000>(item);
+					});
+				});
+
+			});
+
+			suite('boolean', () => {
+				test('type', () => {
+					assert.doesNotThrow(() => {
+						assertOneOf(
+							true,
+							[true, false],
+							'true must be one of: true, false',
+						);
+					});
+
+					assert.doesNotThrow(() => {
+						assertOneOf(
+							false,
+							[true, false],
+							'false must be one of: true, false',
+						);
+					});
+				});
+
+				test('subtype (true)', () => {
+					assert.doesNotThrow(() => {
+						const item: boolean = true;
+						const list: (true)[] = [true, true];
+
+						assertOneOf(
+							item,
+							list,
+							'true must be one of: true, true',
+						);
+
+						typeCheck<true>(item);
+					});
+				});
+
+				test('subtype (false)', () => {
+					assert.doesNotThrow(() => {
+						const item: boolean = false;
+						const list: (false | true)[] = [false, true];
+
+						assertOneOf(
+							item,
+							list,
+							'false must be one of: false, true',
+						);
+
+						typeCheck<false>(item);
+					});
+				});
+			});
+
+			suite('undefined', () => {
+				test('type', () => {
+					assert.doesNotThrow(() => {
+						assertOneOf(
+							undefined,
+							[undefined],
+							'undefined must be one of: undefined',
+						);
+					});
+
+					assert.doesNotThrow(() => {
+						assertOneOf(
+							undefined,
+							[void 0],
+							'undefined must be one of: void 0',
+						);
+					});
+				});
+
+				test('subtype', () => {
+					assert.doesNotThrow(() => {
+						let item: undefined | null;
+						const list: (undefined)[] = [undefined];
+
+						assertOneOf(
+							item,
+							list,
+							'undefined | null must be one of: undefined',
+						);
+
+						typeCheck<undefined>(item);
+					});
+				});
+			});
+
+			suite('null', () => {
+				test('type', () => {
+					assert.doesNotThrow(() => {
+						assertOneOf(
+							null,
+							[null],
+							'null must be one of: null',
+						);
+					});
+				});
+
+				test('subtype', () => {
+					assert.doesNotThrow(() => {
+						const item: undefined | null | string = null;
+						const list: (null)[] = [null];
+
+						assertOneOf(
+							item,
+							list,
+							'null must be one of: null',
+						);
+
+						typeCheck<null>(item);
+					});
+				});
+			});
+
+			suite('any', () => {
+				test('item', () => {
+					assert.doesNotThrow(() => {
+						const item: any = '1';
+						const list: ('1' | '2')[] = ['2', '1'];
+
+						assertOneOf(
+							item,
+							list,
+							'1 must be one of: 2, 1',
+						);
+
+						typeCheck<'1' | '2'>(item);
+					});
+				});
+
+				test('list', () => {
+					assert.doesNotThrow(() => {
+						const item: '5' = '5';
+						const list: any[] = ['3', '5', '2.5'];
+
+						assertOneOf(
+							item,
+							list,
+							'5 must be one of: 3, 5, 2.5',
+						);
+
+						typeCheck<'5'>(item);
+					});
+				});
+
+				test('both', () => {
+					assert.doesNotThrow(() => {
+						const item: any = '12';
+						const list: any[] = ['14.25', '7', '12'];
+
+						assertOneOf(
+							item,
+							list,
+							'12 must be one of: 14.25, 7, 12',
+						);
+
+						typeCheck<any>(item);
+					});
+				});
+			});
+
+			suite('unknown', () => {
+				test('item', () => {
+					assert.doesNotThrow(() => {
+						const item: unknown = '1';
+						const list: ('1' | '2')[] = ['2', '1'];
+
+						assertOneOf(
+							item,
+							list,
+							'1 must be one of: 2, 1',
+						);
+
+						typeCheck<'1' | '2'>(item);
+					});
+				});
+
+				test('both', () => {
+					assert.doesNotThrow(() => {
+						const item: unknown = '12';
+						const list: unknown[] = ['14.25', '7', '12'];
+
+						assertOneOf(
+							item,
+							list,
+							'12 must be one of: 14.25, 7, 12',
+						);
+
+						typeCheck<unknown>(item);
+					});
+				});
+			});
+		});
+
+		suite('failure', () => {
+			suite('string', () => {
+				test('type', () => {
+					assert.throws(() => {
+						assertOneOf(
+							'baz',
+							['foo', 'bar'],
+							'Baz must not be one of: foo, bar',
+						);
+					});
+				});
+
+				test('subtype', () => {
+					assert.throws(() => {
+						const item: string = 'vitannia';
+						const list: ('hi' | 'ciao' | 'hola')[] = ['hi', 'ciao'];
+
+						assertOneOf(
+							item,
+							list,
+							'vitannia must be one of: hi, ciao',
+						);
+					});
+				});
+
+				test('empty', () => {
+					assert.throws(() => {
+						const item: string = 'vitannia';
+						const list: ('hi' | 'ciao' | 'hola')[] = [];
+
+						assertOneOf(
+							item,
+							list,
+							'vitannia must be one of: empty',
+						);
+					});
+				});
+			});
+
+			suite('number', () => {
+				test('type', () => {
+					assert.throws(() => {
+						assertOneOf(
+							19,
+							[10, 100],
+							'19 must not be one of: 10, 100',
+						);
+					});
+				});
+
+				test('subtype', () => {
+					assert.throws(() => {
+						const item: number = 24;
+						const list: (20 | 2000)[] = [20, 2000];
+
+						assertOneOf(
+							item,
+							list,
+							'24 must not be one of: 20, 2000',
+						);
+					});
+				});
+
+				test('empty', () => {
+					assert.throws(() => {
+						const item: number = 20;
+						const list: (20 | 2000)[] = [];
+
+						assertOneOf(
+							item,
+							list,
+							'20 must not be one of: empty',
+						);
+					});
+				});
+			});
+
+			suite('boolean', () => {
+				test('type', () => {
+					assert.throws(() => {
+						assertOneOf(
+							true,
+							[false],
+							'true must not be one of: false',
+						);
+					});
+
+					assert.throws(() => {
+						assertOneOf(
+							false,
+							[true],
+							'false must not be one of: true',
+						);
+					});
+				});
+
+				test('subtype (true)', () => {
+					assert.throws(() => {
+						const item: boolean = true;
+						const list: (true | false)[] = [false];
+
+						assertOneOf(
+							item,
+							list,
+							'true must not be one of: false',
+						);
+					});
+				});
+
+				test('subtype (false)', () => {
+					assert.throws(() => {
+						const item: boolean = false;
+						const list: (false | true)[] = [true, true, true];
+
+						assertOneOf(
+							item,
+							list,
+							'false must be one of: true, true, true',
+						);
+					});
+				});
+
+				test('empty', () => {
+					assert.throws(() => {
+						const item: boolean = true;
+						const list: (false | true)[] = [];
+
+						assertOneOf(
+							item,
+							list,
+							'true must be one of: empty',
+						);
+					});
+				});
+			});
+
+			suite('undefined', () => {
+				test('type', () => {
+					assert.throws(() => {
+						assertOneOf(
+							undefined,
+							[],
+							'undefined must not be one of: empty',
+						);
+					});
+
+					assert.throws(() => {
+						assertOneOf(
+							void 0,
+							[],
+							'void 0 must not be one of: empty',
+						);
+					});
+				});
+
+				test('subtype', () => {
+					assert.throws(() => {
+						let item: undefined | null;
+						const list: (undefined | null)[] = [null];
+
+						assertOneOf(
+							item,
+							list,
+							'undefined must be one of: null',
+						);
+					});
+				});
+
+				test('empty', () => {
+					assert.throws(() => {
+						let item: undefined | null;
+						const list: (undefined | null)[] = [];
+
+						assertOneOf(
+							item,
+							list,
+							'undefined must be one of: empty',
+						);
+					});
+				});
+			});
+
+			suite('null', () => {
+				test('type', () => {
+					assert.throws(() => {
+						assertOneOf(
+							null,
+							[],
+							'null must be one of: empty',
+						);
+					});
+				});
+
+				test('subtype', () => {
+					assert.throws(() => {
+						const item: undefined | null | string = null;
+						const list: null[] = [];
+
+						assertOneOf(
+							item,
+							list,
+							'null must be one of: empty',
+						);
+					});
+				});
+			});
+
+			suite('any', () => {
+				test('item', () => {
+					assert.throws(() => {
+						const item: any = '1';
+						const list: ('1' | '2' | '3' | '4')[] = ['3', '4'];
+
+						assertOneOf(
+							item,
+							list,
+							'1 must not be one of: 3, 4',
+						);
+					});
+				});
+
+				test('list', () => {
+					assert.throws(() => {
+						const item: '5' = '5';
+						const list: any[] = ['3', '6', '2.5'];
+
+						assertOneOf(
+							item,
+							list,
+							'5 must not be one of: 3, 6, 2.5',
+						);
+					});
+				});
+
+				test('both', () => {
+					assert.throws(() => {
+						const item: any = '12';
+						const list: any[] = ['14.25', '7', '15'];
+
+						assertOneOf(
+							item,
+							list,
+							'12 must not be one of: 14.25, 7, 15',
+						);
+					});
+				});
+
+				test('empty', () => {
+					assert.throws(() => {
+						const item: any = '25';
+						const list: any[] = [];
+
+						assertOneOf(
+							item,
+							list,
+							'25 must not be one of: empty',
+						);
+					});
+				});
+			});
+
+			suite('unknown', () => {
+				test('item', () => {
+					assert.throws(() => {
+						const item: unknown = '100';
+						const list: ('11' | '12')[] = ['12', '11'];
+
+						assertOneOf(
+							item,
+							list,
+							'100 must not be one of: 12, 11',
+						);
+
+					});
+
+					test('both', () => {
+						assert.throws(() => {
+							const item: unknown = '21';
+							const list: unknown[] = ['14.25', '7', '12'];
+
+							assertOneOf(
+								item,
+								list,
+								'21 must not be one of: 14.25, 7, 12',
+							);
+
+						});
+					});
+				});
+			});
 		});
 	});
 

--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -82,6 +82,7 @@ import { ChatQuotasService, ChatQuotasStatusBarEntry, IChatQuotasService } from 
 import { ChatSetupContribution } from './chatSetup.js';
 import { ChatEditorOverlayController } from './chatEditing/chatEditingEditorOverlay.js';
 import '../common/promptSyntax/languageFeatures/promptLinkProvider.js';
+import '../common/promptSyntax/languageFeatures/promptPathAutocompletion.js';
 import { PromptFilesConfig } from '../common/promptSyntax/config.js';
 import { BuiltinToolsContribution } from '../common/tools/tools.js';
 import { IWorkbenchAssignmentService } from '../../../services/assignment/common/assignmentService.js';

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/languageFeatures/promptLinkProvider.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/languageFeatures/promptLinkProvider.ts
@@ -93,6 +93,6 @@ export class PromptLinkProvider extends Disposable implements LinkProvider {
 	}
 }
 
-// register this provider as a workbench contribution
+// register the provider as a workbench contribution
 Registry.as<IWorkbenchContributionsRegistry>(WorkbenchExtensions.Workbench)
 	.registerWorkbenchContribution(PromptLinkProvider, LifecyclePhase.Eventually);

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/languageFeatures/promptPathAutocompletion.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/languageFeatures/promptPathAutocompletion.ts
@@ -1,0 +1,372 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { URI } from '../../../../../../base/common/uri.js';
+import { IPromptFileReference } from '../parsers/types.js';
+import { ITextModel } from '../../../../../../editor/common/model.js';
+import { IRange } from '../../../../../../editor/common/core/range.js';
+import { Disposable } from '../../../../../../base/common/lifecycle.js';
+import { ObjectCache } from '../../../../../../base/common/objectCache.js';
+import { CancellationError } from '../../../../../../base/common/errors.js';
+import { TextModelPromptParser } from '../parsers/textModelPromptParser.js';
+import { Position } from '../../../../../../editor/common/core/position.js';
+import { dirname, extUri } from '../../../../../../base/common/resources.js';
+import { assert, assertNever } from '../../../../../../base/common/assert.js';
+import { IFileService } from '../../../../../../platform/files/common/files.js';
+import { CancellationToken } from '../../../../../../base/common/cancellation.js';
+import { Registry } from '../../../../../../platform/registry/common/platform.js';
+import { LifecyclePhase } from '../../../../../services/lifecycle/common/lifecycle.js';
+import { PROMPT_SNIPPET_FILE_EXTENSION } from '../contentProviders/promptContentsProviderBase.js';
+import { ILanguageFeaturesService } from '../../../../../../editor/common/services/languageFeatures.js';
+import { IInstantiationService } from '../../../../../../platform/instantiation/common/instantiation.js';
+import { IWorkbenchContributionsRegistry, Extensions as WorkbenchExtensions } from '../../../../../common/contributions.js';
+import { CompletionContext, CompletionItem, CompletionItemKind, CompletionItemProvider, CompletionList } from '../../../../../../editor/common/languages.js';
+
+/**
+ * TODO: @legomushroom - auto re-trigger on folder selection
+ * TODO: @legomushroom - test absolute paths more
+ */
+
+/**
+ * TODO: @legomushroom
+ */
+const findFileReference = (
+	references: readonly IPromptFileReference[],
+	position: Position,
+): IPromptFileReference | undefined => {
+	for (const reference of references) {
+		const { range } = reference;
+		if (range.startLineNumber !== position.lineNumber) {
+			continue;
+		}
+
+		if (range.endColumn !== position.column) {
+			continue;
+		}
+
+		// TODO: @legomushroom - check that reference is the `#file:` one
+		if (reference.type !== 'file') {
+			return undefined;
+		}
+
+		return reference;
+	}
+
+	return undefined;
+};
+
+/**
+ * TODO: @legomushroom
+ */
+type TFilesystemCompletionItem = CompletionItem & { kind: CompletionItemKind.File | CompletionItemKind.Folder };
+
+/**
+ * TODO: @legomushroom
+ */
+const getReplacementRange = (
+	fileReference: IPromptFileReference,
+): IRange => {
+	return {
+		...fileReference.range,
+		startColumn: fileReference.range.endColumn,
+		endColumn: fileReference.range.endColumn,
+	};
+};
+
+type TFolderSuggestion = Omit<TFilesystemCompletionItem, 'insertText'> & { label: string };
+
+/**
+ * TODO: @legomushroom
+ */
+const getFolderSuggestions = async (
+	uri: URI,
+	fileReference: IPromptFileReference,
+	fileService: IFileService,
+): Promise<TFolderSuggestion[]> => {
+	// TODO: @legomushroom - the range does not really belong to this function
+	const range = getReplacementRange(fileReference);
+
+	const { children } = await fileService.resolve(uri);
+	const suggestions: TFolderSuggestion[] = [];
+
+	// no `children` - no suggestions
+	if (!children) {
+		return suggestions;
+	}
+
+	for (const child of children) {
+		const kind = child.isDirectory
+			? CompletionItemKind.Folder
+			: CompletionItemKind.File;
+
+		const sortText = child.isDirectory
+			? '1'
+			: '2';
+
+		suggestions.push({
+			label: child.name,
+			range,
+			kind,
+			sortText,
+		});
+	}
+
+	return suggestions;
+};
+
+/**
+ * TODO: @legomushroom
+ */
+const getFirstFolderSuggestions = async (
+	character: ':' | '.',
+	fileFolderUri: URI,
+	fileReference: IPromptFileReference,
+	fileService: IFileService,
+): Promise<TFilesystemCompletionItem[]> => {
+	const { linkRange } = fileReference;
+
+	// when character is `:`, there must be no link present yet
+	// otherwise the `:` was used in the middle of the link hence
+	// we don't want to provide suggestions for that
+	if (character === ':' && linkRange !== undefined) {
+		return [];
+	}
+
+	if (character === '.' && linkRange === undefined) {
+		return [];
+	}
+
+	const suggestions = await getFolderSuggestions(fileFolderUri, fileReference, fileService);
+	const range = getReplacementRange(fileReference);
+
+	// when character is `.` we want to also replace it, because
+	// all the `insertText`s already have the dot at the start
+	const replacementRange = (character !== '.')
+		? range
+		: {
+			...range,
+			startColumn: range.endColumn - 1,
+		};
+
+	return [
+		{
+			label: '..',
+			kind: CompletionItemKind.Folder,
+			insertText: '..',
+			range: replacementRange,
+			sortText: '0',
+		},
+		...suggestions
+			.map((suggestion) => {
+				// add space at the end of file names since no completions
+				// that follow the file name are expected anymore
+				const suffix = (suggestion.kind === CompletionItemKind.File)
+					? ' '
+					: '';
+
+				return {
+					...suggestion,
+					range: replacementRange,
+					label: `./${suggestion.label}${suffix}`,
+					// we use the `./` prefix for consistency
+					insertText: `./${suggestion.label}${suffix}`, // TODO: @legomushroom - this won't work on windows?
+				};
+			}),
+	];
+};
+
+/**
+ * TODO: @legomushroom
+ */
+const getNonFirstFolderSuggestions = async (
+	fileFolderUri: URI,
+	fileReference: IPromptFileReference,
+	fileService: IFileService,
+): Promise<TFilesystemCompletionItem[]> => {
+	const { linkRange, uri } = fileReference;
+
+	if (linkRange === undefined) {
+		return [];
+	}
+
+	const currenFolder = extUri.resolvePath(fileFolderUri, uri.path);
+	const suggestions = await getFolderSuggestions(currenFolder, fileReference, fileService);
+	return suggestions
+		.map((suggestion) => {
+			// add space at the end of file names since no completions
+			// that follow the file name are expected anymore
+			const suffix = (suggestion.kind === CompletionItemKind.File)
+				? ' '
+				: '';
+
+			return {
+				...suggestion,
+				insertText: `${suggestion.label}${suffix}`,
+			};
+		});
+};
+
+/**
+ * TODO: @legomushroom
+ */
+const getSuggestions = async (
+	character: TTriggerCharacter,
+	fileFolderUri: URI,
+	fileReference: IPromptFileReference,
+	fileService: IFileService,
+): Promise<TFilesystemCompletionItem[]> => {
+	if (character === ':' || character === '.') {
+		return getFirstFolderSuggestions(character, fileFolderUri, fileReference, fileService);
+	}
+
+	if (character === '/') {
+		return getNonFirstFolderSuggestions(fileFolderUri, fileReference, fileService);
+	}
+
+	assertNever(
+		character,
+		`Unexpected trigger character '${character}'.`,
+	);
+};
+
+/**
+ * Prompt files language selector.
+ * TODO: @legomushroom - move to a common constant
+ */
+const languageSelector = {
+	pattern: `**/*${PROMPT_SNIPPET_FILE_EXTENSION}`,
+};
+
+/**
+ * TODO: @legomushroom
+ */
+type TTriggerCharacter = ':' | '.' | '/';
+
+/**
+ * TODO: @legomushroom
+ */
+function assertOneOf<TType, TSubtype extends TType>(
+	character: TType,
+	validCharacters: readonly TSubtype[],
+	errorPrefix: string,
+): asserts character is TSubtype {
+	// note! its ok to type cast here because `TSubtype` is a subtype of `TType`
+	assert(
+		validCharacters.includes(character as TSubtype),
+		`${errorPrefix}: Expected '${character}' to be one of [${validCharacters.join(', ')}].`,
+	);
+}
+
+/**
+ * Provides link references for prompt files.
+ */
+export class PromptPathAutocompletion extends Disposable implements CompletionItemProvider {
+	/**
+	 * TODO: @legomushroom
+	 */
+	public readonly _debugDisplayName: string = 'PromptPathAutocompletion';
+
+	/**
+	 * TODO: @legomushroom
+	 */
+	public readonly triggerCharacters: TTriggerCharacter[] = [':', '.', '/'];
+
+	/**
+	 * Cache of text model content prompt parsers.
+	 */
+	private readonly parserProvider: ObjectCache<TextModelPromptParser, ITextModel>;
+
+	constructor(
+		@IFileService private readonly fileService: IFileService,
+		@IInstantiationService private readonly initService: IInstantiationService,
+		@ILanguageFeaturesService private readonly languageService: ILanguageFeaturesService,
+	) {
+		super();
+
+		this.languageService.completionProvider.register(languageSelector, this);
+		this.parserProvider = this._register(new ObjectCache(this.createParser.bind(this)));
+	}
+
+	public async provideCompletionItems(
+		model: ITextModel,
+		position: Position,
+		context: CompletionContext,
+		token: CancellationToken,
+	): Promise<CompletionList | undefined> {
+		assert(
+			!token.isCancellationRequested,
+			new CancellationError(),
+		);
+
+		const { triggerCharacter } = context;
+
+		// it must always have been triggered by a character
+		if (!triggerCharacter) {
+			return undefined;
+		}
+
+		assertOneOf(
+			triggerCharacter,
+			this.triggerCharacters,
+			`Prompt path autocompletion provider`,
+		);
+
+		const parser = this.parserProvider.get(model);
+		assert(
+			!parser.disposed,
+			'Prompt parser must not be disposed.',
+		);
+
+		// start the parser in case it was not started yet,
+		// and wait for it to settle to a final result
+		const { references } = await parser
+			.start()
+			.settled();
+
+		// validate that the cancellation was not yet requested
+		assert(
+			!token.isCancellationRequested,
+			new CancellationError(),
+		);
+
+		const fileReference = findFileReference(references, position);
+		if (!fileReference) {
+			return undefined;
+		}
+
+		const suggestions = await getSuggestions(
+			triggerCharacter,
+			dirname(model.uri),
+			fileReference,
+			this.fileService,
+		);
+
+		return {
+			suggestions,
+			incomplete: false,
+		};
+	}
+
+	// TODO: @legomushroom - this should be a part of a common global singleton
+	private createParser(
+		model: ITextModel,
+	): TextModelPromptParser & { disposed: false } {
+		const parser: TextModelPromptParser = this.initService.createInstance(
+			TextModelPromptParser,
+			model,
+			[],
+		);
+
+		parser.assertNotDisposed(
+			'Created prompt parser must not be disposed.',
+		);
+
+		return parser;
+	}
+}
+
+// register the provider as a workbench contribution
+Registry.as<IWorkbenchContributionsRegistry>(WorkbenchExtensions.Workbench)
+	.registerWorkbenchContribution(PromptPathAutocompletion, LifecyclePhase.Eventually);

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/types.d.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/types.d.ts
@@ -56,6 +56,16 @@ export interface IPromptReference extends IDisposable {
 	readonly linkRange: IRange | undefined;
 
 	/**
+	 * Text of the reference as it appears in the source.
+	 */
+	readonly text: string;
+
+	/**
+	 * Original link path as it appears in the source.
+	 */
+	readonly path: string;
+
+	/**
 	 * Whether the current reference points to a prompt snippet file.
 	 */
 	readonly isPromptSnippet: boolean;


### PR DESCRIPTION
The PR adds `#file:` link path autocompletions inside prompt files.

<img width="1393" alt="image" src="https://github.com/user-attachments/assets/caf16b4c-41ab-4163-9612-04d2d94a7d21" />

Misc:

- adds the `assertOneOf` utility for asserts that also downcast types
- extends the `IPromptReference` interface with the `text` and `path` properties