### PR TITLE
fix the `the the` typos

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -56,7 +56,7 @@ Next: **[Try it out!](#try-it)**
 
 You may see improved VNC responsiveness when accessing a codespace from VS Code client since you can use a [VNC Viewer][def]. Here's how to do it.
 
-1. Install [Visual Studio Code Stable](https://code.visualstudio.com/) or [Insiders](https://code.visualstudio.com/insiders/) and the the [GitHub Codespaces extension](https://marketplace.visualstudio.com/items?itemName=GitHub.codespaces).
+1. Install [Visual Studio Code Stable](https://code.visualstudio.com/) or [Insiders](https://code.visualstudio.com/insiders/) and the [GitHub Codespaces extension](https://marketplace.visualstudio.com/items?itemName=GitHub.codespaces).
 
     > **Note:** The GitHub Codespaces extension requires the Visual Studio Code distribution of Code - OSS.
 

--- a/extensions/ipynb/src/notebookModelStoreSync.ts
+++ b/extensions/ipynb/src/notebookModelStoreSync.ts
@@ -14,7 +14,7 @@ const noop = () => {
 };
 
 /**
- * Code here is used to ensure the Notebook Model is in sync the the ipynb JSON file.
+ * Code here is used to ensure the Notebook Model is in sync the ipynb JSON file.
  * E.g. assume you add a new cell, this new cell will not have any metadata at all.
  * However when we save the ipynb, the metadata will be an empty object `{}`.
  * Now thats completely different from the metadata os being `empty/undefined` in the model.

--- a/extensions/vscode-colorize-perf-tests/test/colorize-fixtures/test-treeView.ts
+++ b/extensions/vscode-colorize-perf-tests/test/colorize-fixtures/test-treeView.ts
@@ -300,7 +300,7 @@ abstract class AbstractTreeView extends Disposable implements ITreeView {
 		}
 		this._isInitialized = true;
 
-		// Remember when adding to this method that it isn't called until the the view is visible, meaning that
+		// Remember when adding to this method that it isn't called until the view is visible, meaning that
 		// properties could be set and events could be fired before we're initialized and that this needs to be handled.
 
 		this.contextKeyService.bufferChangeEvents(() => {
@@ -534,7 +534,7 @@ abstract class AbstractTreeView extends Disposable implements ITreeView {
 
 	private initializeShowCollapseAllAction(startingValue: boolean = false) {
 		if (!this.collapseAllContext) {
-			this.collapseAllContextKey = new RawContextKey<boolean>(`treeView.${this.id}.enableCollapseAll`, startingValue, localize('treeView.enableCollapseAll', "Whether the the tree view with id {0} enables collapse all.", this.id));
+			this.collapseAllContextKey = new RawContextKey<boolean>(`treeView.${this.id}.enableCollapseAll`, startingValue, localize('treeView.enableCollapseAll', "Whether the tree view with id {0} enables collapse all.", this.id));
 			this.collapseAllContext = this.collapseAllContextKey.bindTo(this.contextKeyService);
 		}
 		return true;

--- a/src/vs/base/browser/ui/hover/hover.ts
+++ b/src/vs/base/browser/ui/hover/hover.ts
@@ -101,7 +101,7 @@ export interface IHoverDelegate2 {
 	): IDisposable;
 
 	/**
-	 * Hides the hover if it was visible. This call will be ignored if the the hover is currently
+	 * Hides the hover if it was visible. This call will be ignored if the hover is currently
 	 * "locked" via the alt/option key.
 	 */
 	hideHover(): void;

--- a/src/vs/editor/browser/editorDom.ts
+++ b/src/vs/editor/browser/editorDom.ts
@@ -64,7 +64,7 @@ export class EditorPagePosition {
 }
 
 /**
- * Coordinates relative to the the (top;left) of the editor that can be used safely with other internal editor metrics.
+ * Coordinates relative to the (top;left) of the editor that can be used safely with other internal editor metrics.
  * **NOTE**: This position is obtained by taking page coordinates and transforming them relative to the
  * editor's (top;left) position in a way in which scale transformations are taken into account.
  * **NOTE**: These coordinates could be negative if the mouse position is outside the editor.

--- a/src/vs/editor/browser/gpu/atlas/atlas.ts
+++ b/src/vs/editor/browser/gpu/atlas/atlas.ts
@@ -32,14 +32,14 @@ export interface ITextureAtlasPageGlyph {
 	/** The y offset from {@link y} of the glyph's origin. */
 	originOffsetY: number;
 	/**
-	 * The distance from the the glyph baseline to the top of the highest bounding rectangle of all
+	 * The distance from the glyph baseline to the top of the highest bounding rectangle of all
 	 * fonts used to render the text.
 	 *
 	 * @see {@link TextMetrics.fontBoundingBoxAscent}
 	 */
 	fontBoundingBoxAscent: number;
 	/**
-	 * The distance from the the glyph baseline to the bottom of the bounding rectangle of all fonts
+	 * The distance from the glyph baseline to the bottom of the bounding rectangle of all fonts
 	 * used to render the text.
 	 *
 	 * @see {@link TextMetrics.fontBoundingBoxDescent}

--- a/src/vs/editor/browser/gpu/raster/raster.ts
+++ b/src/vs/editor/browser/gpu/raster/raster.ts
@@ -67,14 +67,14 @@ export interface IRasterizedGlyph {
 	 */
 	originOffset: { x: number; y: number };
 	/**
-	 * The distance from the the glyph baseline to the top of the highest bounding rectangle of all
+	 * The distance from the glyph baseline to the top of the highest bounding rectangle of all
 	 * fonts used to render the text.
 	 *
 	 * @see {@link TextMetrics.fontBoundingBoxAscent}
 	 */
 	fontBoundingBoxAscent: number;
 	/**
-	 * The distance from the the glyph baseline to the bottom of the bounding rectangle of all fonts
+	 * The distance from the glyph baseline to the bottom of the bounding rectangle of all fonts
 	 * used to render the text.
 	 *
 	 * @see {@link TextMetrics.fontBoundingBoxDescent}

--- a/src/vs/editor/browser/view/viewLayer.ts
+++ b/src/vs/editor/browser/view/viewLayer.ts
@@ -279,7 +279,7 @@ export class VisibleLinesCollection<T extends IVisibleLine> {
 
 	public onFlushed(e: viewEvents.ViewFlushedEvent, flushDom?: boolean): boolean {
 		// No need to clear the dom node because a full .innerHTML will occur in
-		// ViewLayerRenderer._render, however the the fallbakc mechanism in the
+		// ViewLayerRenderer._render, however the fallback mechanism in the
 		// GPU renderer may cause this to be necessary as the .innerHTML call
 		// may not happen depending on the new state, leaving stale DOM nodes
 		// around.

--- a/src/vs/editor/common/textModelGuides.ts
+++ b/src/vs/editor/common/textModelGuides.ts
@@ -17,7 +17,7 @@ export interface IGuidesTextModelPart {
 	getLinesIndentGuides(startLineNumber: number, endLineNumber: number): number[];
 
 	/**
-	 * Requests the the indent guides for the given range of lines.
+	 * Requests the indent guides for the given range of lines.
 	 * `result[i]` will contain the indent guides of the `startLineNumber + i`th line.
 	 * @internal
 	 */

--- a/src/vs/platform/extensionManagement/common/extensionGalleryService.ts
+++ b/src/vs/platform/extensionManagement/common/extensionGalleryService.ts
@@ -688,7 +688,7 @@ abstract class AbstractExtensionGalleryService implements IExtensionGalleryServi
 				{ count: number },
 				{
 					owner: 'sandy081';
-					comment: 'Report the query to the the Marketplace for fetching extensions by name';
+					comment: 'Report the query to the Marketplace for fetching extensions by name';
 					readonly count: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Number of extensions to fetch' };
 				}>('galleryService:additionalQueryByName', {
 					count: extensionInfosByName.length
@@ -1296,7 +1296,7 @@ abstract class AbstractExtensionGalleryService implements IExtensionGalleryServi
 		finally {
 			type GalleryServiceGetLatestEventClassification = {
 				owner: 'sandy081';
-				comment: 'Report the query to the the Marketplace for fetching latest version of an extension';
+				comment: 'Report the query to the Marketplace for fetching latest version of an extension';
 				extension: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The identifier of the extension' };
 				duration: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'Duration in ms for the query' };
 				errorCode?: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The error code in case of error' };

--- a/src/vs/platform/terminal/common/capabilities/commandDetectionCapability.ts
+++ b/src/vs/platform/terminal/common/capabilities/commandDetectionCapability.ts
@@ -358,7 +358,7 @@ export class CommandDetectionCapability extends Disposable implements ICommandDe
 		this._logService.debug('CommandDetectionCapability#handleCommandFinished', this._terminal.buffer.active.cursorX, options?.marker?.line, this._currentCommand.command, this._currentCommand);
 
 		// HACK: Handle a special case on some versions of bash where identical commands get merged
-		// in the output of `history`, this detects that case and sets the exit code to the the last
+		// in the output of `history`, this detects that case and sets the exit code to the last
 		// command's exit code. This covered the majority of cases but will fail if the same command
 		// runs with a different exit code, that will need a more robust fix where we send the
 		// command ID and exit code over to the capability to adjust there.

--- a/src/vs/workbench/browser/parts/views/treeView.ts
+++ b/src/vs/workbench/browser/parts/views/treeView.ts
@@ -300,7 +300,7 @@ abstract class AbstractTreeView extends Disposable implements ITreeView {
 		}
 		this._isInitialized = true;
 
-		// Remember when adding to this method that it isn't called until the the view is visible, meaning that
+		// Remember when adding to this method that it isn't called until the view is visible, meaning that
 		// properties could be set and events could be fired before we're initialized and that this needs to be handled.
 
 		this.contextKeyService.bufferChangeEvents(() => {
@@ -534,7 +534,7 @@ abstract class AbstractTreeView extends Disposable implements ITreeView {
 
 	private initializeShowCollapseAllAction(startingValue: boolean = false) {
 		if (!this.collapseAllContext) {
-			this.collapseAllContextKey = new RawContextKey<boolean>(`treeView.${this.id}.enableCollapseAll`, startingValue, localize('treeView.enableCollapseAll', "Whether the the tree view with id {0} enables collapse all.", this.id));
+			this.collapseAllContextKey = new RawContextKey<boolean>(`treeView.${this.id}.enableCollapseAll`, startingValue, localize('treeView.enableCollapseAll', "Whether the tree view with id {0} enables collapse all.", this.id));
 			this.collapseAllContext = this.collapseAllContextKey.bindTo(this.contextKeyService);
 		}
 		return true;

--- a/src/vs/workbench/contrib/chat/browser/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/media/chat.css
@@ -996,7 +996,7 @@ have to be updated for changes to the rules above, or to support more deeply nes
 }
 /*
  * This overly-specific CSS selector is needed to beat priority of some
- * styles applied on the the `.chat-attached-context-attachment` element.
+ * styles applied on the `.chat-attached-context-attachment` element.
  */
 .chat-attached-context .chat-prompt-instructions-attachments .chat-prompt-instructions-attachment.error.implicit,
 .chat-attached-context .chat-prompt-instructions-attachments .chat-prompt-instructions-attachment.warning.implicit {

--- a/src/vs/workbench/contrib/comments/browser/commentService.ts
+++ b/src/vs/workbench/contrib/comments/browser/commentService.ts
@@ -293,7 +293,7 @@ export class CommentService extends Disposable implements ICommentService {
 	}
 
 	/**
-	 * The active comment thread is the the thread that is currently being edited.
+	 * The active comment thread is the thread that is currently being edited.
 	 * @param commentThread
 	 */
 	setActiveEditingCommentThread(commentThread: CommentThread | null) {

--- a/src/vs/workbench/contrib/comments/browser/commentsModel.ts
+++ b/src/vs/workbench/contrib/comments/browser/commentsModel.ts
@@ -121,7 +121,7 @@ export class CommentsModel extends Disposable implements ICommentsModel {
 	public hasCommentThreads(): boolean {
 		// There's a resource with at least one thread
 		return !!this._resourceCommentThreads.length && this._resourceCommentThreads.some(resource => {
-			// At least one of the threads in the the resource has comments
+			// At least one of the threads in the resource has comments
 			return (resource.commentThreads.length > 0) && resource.commentThreads.some(thread => {
 				// At least one of the comments in the thread is not empty
 				return threadHasMeaningfulComments(thread.thread);

--- a/src/vs/workbench/contrib/externalUriOpener/common/externalUriOpenerService.ts
+++ b/src/vs/workbench/contrib/externalUriOpener/common/externalUriOpenerService.ts
@@ -45,7 +45,7 @@ export interface IExternalUriOpenerService {
 	registerExternalOpenerProvider(provider: IExternalOpenerProvider): IDisposable;
 
 	/**
-	 * Get the configured IExternalUriOpener for the the uri.
+	 * Get the configured IExternalUriOpener for the uri.
 	 * If there is no opener configured, then returns the first opener that can handle the uri.
 	 */
 	getOpener(uri: URI, ctx: { sourceUri: URI; preferredOpenerId?: string }, token: CancellationToken): Promise<IExternalUriOpener | undefined>;

--- a/src/vs/workbench/contrib/markdown/browser/markdownSettingRenderer.ts
+++ b/src/vs/workbench/contrib/markdown/browser/markdownSettingRenderer.ts
@@ -299,7 +299,7 @@ export class SimpleSettingRenderer {
 		if (uri.scheme === Schemas.codeSetting) {
 			type ReleaseNotesSettingUsedClassification = {
 				owner: 'alexr00';
-				comment: 'Used to understand if the the action to update settings from the release notes is used.';
+				comment: 'Used to understand if the action to update settings from the release notes is used.';
 				settingId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The id of the setting that was clicked on in the release notes' };
 			};
 			type ReleaseNotesSettingUsed = {

--- a/src/vs/workbench/contrib/terminal/browser/terminal.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminal.ts
@@ -973,7 +973,7 @@ export interface ITerminalInstance extends IBaseTerminalInstance {
 
 	/**
 	 * Sets the terminal instance's dimensions to the values provided via the onDidOverrideDimensions event,
-	 * which allows overriding the the regular dimensions (fit to the size of the panel).
+	 * which allows overriding the regular dimensions (fit to the size of the panel).
 	 */
 	setOverrideDimensions(dimensions: ITerminalDimensions): void;
 

--- a/src/vs/workbench/contrib/terminal/browser/terminalActions.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalActions.ts
@@ -204,7 +204,7 @@ export function registerContextualInstanceAction(
 		activeInstanceType?: 'view' | 'editor';
 		run: (instance: ITerminalInstance, c: ITerminalServicesCollection, accessor: ServicesAccessor, args?: unknown) => void | Promise<unknown>;
 		/**
-		 * A callback to run after the the `run` callbacks have completed.
+		 * A callback to run after the `run` callbacks have completed.
 		 * @param instances The selected instance(s) that the command was run on.
 		 */
 		runAfter?: (instances: ITerminalInstance[], c: ITerminalServicesCollection, accessor: ServicesAccessor, args?: unknown) => void | Promise<unknown>;

--- a/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
@@ -951,7 +951,7 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 	}
 
 	/**
-	 * Opens the the terminal instance inside the parent DOM element previously set with
+	 * Opens the terminal instance inside the parent DOM element previously set with
 	 * `attachToElement`, you must ensure the parent DOM element is explicitly visible before
 	 * invoking this function as it performs some DOM calculations internally
 	 */

--- a/src/vs/workbench/contrib/workspace/browser/workspaceTrustEditor.ts
+++ b/src/vs/workbench/contrib/workspace/browser/workspaceTrustEditor.ts
@@ -1091,7 +1091,7 @@ export class WorkspaceTrustEditor extends EditorPane {
 
 		const textElement = append(parent, $('.workspace-trust-untrusted-description'));
 		if (!this.workspaceTrustManagementService.isWorkspaceTrustForced()) {
-			textElement.innerText = this.workspaceService.getWorkbenchState() === WorkbenchState.WORKSPACE ? localize('untrustedWorkspaceReason', "This workspace is trusted via the bolded entries in the trusted folders below.") : localize('untrustedFolderReason', "This folder is trusted via the bolded entries in the the trusted folders below.");
+			textElement.innerText = this.workspaceService.getWorkbenchState() === WorkbenchState.WORKSPACE ? localize('untrustedWorkspaceReason', "This workspace is trusted via the bolded entries in the trusted folders below.") : localize('untrustedFolderReason', "This folder is trusted via the bolded entries in the trusted folders below.");
 		} else {
 			textElement.innerText = localize('trustedForcedReason', "This window is trusted by nature of the workspace that is opened.");
 		}

--- a/src/vscode-dts/vscode.d.ts
+++ b/src/vscode-dts/vscode.d.ts
@@ -11906,7 +11906,7 @@ declare module 'vscode' {
 	 * A map containing a mapping of the mime type of the corresponding transferred data.
 	 *
 	 * Drag and drop controllers that implement {@link TreeDragAndDropController.handleDrag `handleDrag`} can add additional mime types to the
-	 * data transfer. These additional mime types will only be included in the `handleDrop` when the the drag was initiated from
+	 * data transfer. These additional mime types will only be included in the `handleDrop` when the drag was initiated from
 	 * an element in the same drag and drop controller.
 	 */
 	export class DataTransfer implements Iterable<[mimeType: string, item: DataTransferItem]> {

--- a/src/vscode-dts/vscode.proposed.resolvers.d.ts
+++ b/src/vscode-dts/vscode.proposed.resolvers.d.ts
@@ -121,7 +121,7 @@ declare module 'vscode' {
 		tunnelFeatures?: {
 			elevation: boolean;
 			/**
-			 * One of the the options must have the ID "private".
+			 * One of the options must have the ID "private".
 			 */
 			privacyOptions: TunnelPrivacy[];
 			/**

--- a/src/vscode-dts/vscode.proposed.tunnelFactory.d.ts
+++ b/src/vscode-dts/vscode.proposed.tunnelFactory.d.ts
@@ -19,7 +19,7 @@ declare module 'vscode' {
 		tunnelFeatures?: {
 			elevation: boolean;
 			/**
-			 * One of the the options must have the ID "private".
+			 * One of the options must have the ID "private".
 			 */
 			privacyOptions: TunnelPrivacy[];
 			/**

--- a/test/automation/src/terminal.ts
+++ b/test/automation/src/terminal.ts
@@ -210,7 +210,7 @@ export class Terminal {
 				name: title.textContent.replace(/^[├┌└]\s*/, ''),
 				description: description?.textContent
 			};
-			// It's a new group if the the tab does not start with ├ or └
+			// It's a new group if the tab does not start with ├ or └
 			if (title.textContent.match(/^[├└]/)) {
 				groups[groups.length - 1].push(label);
 			} else {


### PR DESCRIPTION
Recently noticed the `the the` typo [in one of my code comments](https://github.com/microsoft/vscode/pull/239646/files#diff-d9537b4703002189d5579da7ffbdd4c0d457f8cebea706f8c0e56cf4861dac44R999). Decided to search for more to see if I made the same mistake elsewhere 🔍 

Turns out it is a very common typo across the code base, so decided to fix all of them in one go 🤗 