### PR TITLE
Register terminal variables from vscode

### DIFF
--- a/src/vs/platform/extensions/common/extensionsApiProposals.ts
+++ b/src/vs/platform/extensions/common/extensionsApiProposals.ts
@@ -33,7 +33,7 @@ const _allApiProposals = {
 	},
 	chatParticipantPrivate: {
 		proposal: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.chatParticipantPrivate.d.ts',
-		version: 2
+		version: 3
 	},
 	chatProvider: {
 		proposal: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.chatProvider.d.ts',

--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -90,6 +90,7 @@ import { IContextKeyService } from '../../../../platform/contextkey/common/conte
 import { ChatContextKeys } from '../common/chatContextKeys.js';
 import { IPromptSyntaxService } from '../common/promptSyntax/service/types.js';
 import { PromptSyntaxService } from '../common/promptSyntax/service/promptSyntaxService.js';
+import { BuiltinVariablesContribution } from './variables/variables.js';
 
 // Register configuration
 const configurationRegistry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration);
@@ -391,6 +392,7 @@ registerWorkbenchContribution2(ChatGettingStartedContribution.ID, ChatGettingSta
 registerWorkbenchContribution2(ChatSetupContribution.ID, ChatSetupContribution, WorkbenchPhase.BlockRestore);
 registerWorkbenchContribution2(ChatQuotasStatusBarEntry.ID, ChatQuotasStatusBarEntry, WorkbenchPhase.Eventually);
 registerWorkbenchContribution2(BuiltinToolsContribution.ID, BuiltinToolsContribution, WorkbenchPhase.Eventually);
+registerWorkbenchContribution2(BuiltinVariablesContribution.ID, BuiltinVariablesContribution, WorkbenchPhase.Eventually);
 registerWorkbenchContribution2(ChatAgentSettingContribution.ID, ChatAgentSettingContribution, WorkbenchPhase.BlockRestore);
 
 registerChatActions();

--- a/src/vs/workbench/contrib/chat/browser/contrib/chatInputCompletions.ts
+++ b/src/vs/workbench/contrib/chat/browser/contrib/chatInputCompletions.ts
@@ -22,7 +22,6 @@ import { IOutlineModelService } from '../../../../../editor/contrib/documentSymb
 import { localize } from '../../../../../nls.js';
 import { Action2, registerAction2 } from '../../../../../platform/actions/common/actions.js';
 import { CommandsRegistry } from '../../../../../platform/commands/common/commands.js';
-import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 import { IInstantiationService, ServicesAccessor } from '../../../../../platform/instantiation/common/instantiation.js';
 import { ILabelService } from '../../../../../platform/label/common/label.js';
 import { Registry } from '../../../../../platform/registry/common/platform.js';
@@ -835,7 +834,6 @@ class VariableCompletions extends Disposable {
 		@ILanguageFeaturesService private readonly languageFeaturesService: ILanguageFeaturesService,
 		@IChatWidgetService private readonly chatWidgetService: IChatWidgetService,
 		@IChatVariablesService private readonly chatVariablesService: IChatVariablesService,
-		@IConfigurationService configService: IConfigurationService,
 		@ILanguageModelToolsService toolsService: ILanguageModelToolsService
 	) {
 		super();

--- a/src/vs/workbench/contrib/chat/browser/variables/variables.ts
+++ b/src/vs/workbench/contrib/chat/browser/variables/variables.ts
@@ -1,0 +1,98 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { CancellationToken } from '../../../../../base/common/cancellation.js';
+import { Codicon } from '../../../../../base/common/codicons.js';
+import { Disposable } from '../../../../../base/common/lifecycle.js';
+import { ProviderResult } from '../../../../../editor/common/languages.js';
+import { localize } from '../../../../../nls.js';
+import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
+import { ITerminalCommand, TerminalCapability } from '../../../../../platform/terminal/common/capabilities/capabilities.js';
+import { IWorkbenchContribution } from '../../../../common/contributions.js';
+import { ITerminalService } from '../../../terminal/browser/terminal.js';
+import { IChatModel } from '../../common/chatModel.js';
+import { IChatRequestVariableValue, IChatVariableResolverProgress, IChatVariablesService } from '../../common/chatVariables.js';
+
+export class BuiltinVariablesContribution extends Disposable implements IWorkbenchContribution {
+
+	static readonly ID = 'chat.builtinVariables';
+
+	constructor(
+		@IChatVariablesService varsService: IChatVariablesService,
+		@IInstantiationService instantiationService: IInstantiationService,
+	) {
+		super();
+
+		const terminalSelectionVar = instantiationService.createInstance(TerminalSelectionVariable);
+		varsService.registerVariable({
+			id: 'copilot.terminalSelection',
+			name: 'terminalSelection',
+			fullName: localize('termSelection', "Terminal Selection"),
+			description: localize('termSelectionDescription', "The active terminal's selection"),
+			icon: Codicon.terminal,
+		}, async (messageText: string, arg: string | undefined, model: IChatModel, progress: (part: IChatVariableResolverProgress) => void, token: CancellationToken): Promise<IChatRequestVariableValue | undefined> => {
+			return await terminalSelectionVar.resolve(token);
+		});
+
+		const terminalLastCommandVar = instantiationService.createInstance(TerminalLastCommandVariable);
+		varsService.registerVariable({
+			id: 'copilot.terminalLastCommand',
+			name: 'terminalLastCommand',
+			fullName: localize('terminalLastCommand', "Terminal Last Command"),
+			description: localize('termLastCommandDesc', "The active terminal's last run command"),
+			icon: Codicon.terminal,
+		}, async (messageText: string, arg: string | undefined, model: IChatModel, progress: (part: IChatVariableResolverProgress) => void, token: CancellationToken): Promise<IChatRequestVariableValue | undefined> => {
+			return await terminalLastCommandVar.resolve(token);
+		});
+	}
+}
+
+class TerminalSelectionVariable {
+	constructor(
+		@ITerminalService private readonly terminalService: ITerminalService
+	) { }
+
+	resolve(token: CancellationToken): ProviderResult<IChatRequestVariableValue> {
+		const terminalSelection = this.terminalService.activeInstance?.selection;
+		return terminalSelection ? `The active terminal's selection:\n${terminalSelection}` : undefined;
+	}
+}
+
+class TerminalLastCommandVariable extends Disposable {
+	private lastCommand: ITerminalCommand | undefined;
+
+	constructor(
+		@ITerminalService private readonly terminalService: ITerminalService
+	) {
+		super();
+
+		const commandDetectionStartEvent = this._store.add(this.terminalService.createOnInstanceCapabilityEvent(TerminalCapability.CommandDetection, e => e.onCommandFinished));
+		this._store.add(commandDetectionStartEvent.event(e => {
+			this.lastCommand = e.data;
+		}));
+	}
+
+	resolve(token: CancellationToken): ProviderResult<IChatRequestVariableValue> {
+		if (!this.lastCommand) {
+			return;
+		}
+
+		const userPrompt: string[] = [];
+		userPrompt.push(`The following is the last command run in the terminal:`);
+		userPrompt.push(this.lastCommand.command);
+		if (this.lastCommand.cwd) {
+			userPrompt.push(`It was run in the directory:`);
+			userPrompt.push(this.lastCommand.cwd);
+		}
+		const output = this.lastCommand.getOutput();
+		if (output) {
+			userPrompt.push(`It has the following output:`);
+			userPrompt.push(output);
+		}
+
+		const prompt = userPrompt.join('\n');
+		return `The active terminal's last run command:\n${prompt}`;
+	}
+}

--- a/src/vscode-dts/vscode.proposed.chatParticipantPrivate.d.ts
+++ b/src/vscode-dts/vscode.proposed.chatParticipantPrivate.d.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-// version: 2
+// version: 3
 
 declare module 'vscode' {
 


### PR DESCRIPTION
chatParticipantPrivate version is bumped to force that the extension and core update are aligned, no duplicate or missing variables.