### PR TITLE
Add command to show telemetry output and some clean up

### DIFF
--- a/src/vs/code/electron-utility/sharedProcess/sharedProcessMain.ts
+++ b/src/vs/code/electron-utility/sharedProcess/sharedProcessMain.ts
@@ -296,7 +296,7 @@ class SharedProcessMain extends Disposable implements IClientConnectionFilter {
 		const appenders: ITelemetryAppender[] = [];
 		const internalTelemetry = isInternalTelemetry(productService, configurationService);
 		if (supportsTelemetry(productService, environmentService)) {
-			const logAppender = new TelemetryLogAppender(logService, loggerService, environmentService, productService);
+			const logAppender = new TelemetryLogAppender('', false, loggerService, environmentService, productService);
 			appenders.push(logAppender);
 			if (!isLoggingOnly(productService, environmentService) && productService.aiConfig?.ariaKey) {
 				const collectorAppender = new OneDataSystemAppender(requestService, internalTelemetry, 'monacoworkbench', null, productService.aiConfig.ariaKey);
@@ -320,7 +320,7 @@ class SharedProcessMain extends Disposable implements IClientConnectionFilter {
 		services.set(ITelemetryService, telemetryService);
 
 		// Custom Endpoint Telemetry
-		const customEndpointTelemetryService = new CustomEndpointTelemetryService(configurationService, telemetryService, logService, loggerService, environmentService, productService);
+		const customEndpointTelemetryService = new CustomEndpointTelemetryService(configurationService, telemetryService, loggerService, environmentService, productService);
 		services.set(ICustomEndpointTelemetryService, customEndpointTelemetryService);
 
 		// Extension Management

--- a/src/vs/platform/telemetry/common/telemetryLogAppender.ts
+++ b/src/vs/platform/telemetry/common/telemetryLogAppender.ts
@@ -6,38 +6,37 @@
 import { Disposable } from '../../../base/common/lifecycle.js';
 import { localize } from '../../../nls.js';
 import { IEnvironmentService } from '../../environment/common/environment.js';
-import { ILogService, ILogger, ILoggerService, LogLevel } from '../../log/common/log.js';
+import { ILogger, ILoggerService } from '../../log/common/log.js';
 import { IProductService } from '../../product/common/productService.js';
-import { ITelemetryAppender, TelemetryLogGroup, isLoggingOnly, supportsTelemetry, telemetryLogId, validateTelemetryData } from './telemetryUtils.js';
+import { ITelemetryAppender, TelemetryLogGroup, isLoggingOnly, telemetryLogId, validateTelemetryData } from './telemetryUtils.js';
 
 export class TelemetryLogAppender extends Disposable implements ITelemetryAppender {
 
 	private readonly logger: ILogger;
 
 	constructor(
-		@ILogService logService: ILogService,
+		private readonly prefix: string,
+		remote: boolean,
 		@ILoggerService loggerService: ILoggerService,
 		@IEnvironmentService environmentService: IEnvironmentService,
 		@IProductService productService: IProductService,
-		private readonly prefix: string = '',
 	) {
 		super();
 
-		const logger = loggerService.getLogger(telemetryLogId);
+		const id = remote ? 'remoteTelemetry' : telemetryLogId;
+		const logger = loggerService.getLogger(id);
 		if (logger) {
 			this.logger = this._register(logger);
 		} else {
 			// Not a perfect check, but a nice way to indicate if we only have logging enabled for debug purposes and nothing is actually being sent
 			const justLoggingAndNotSending = isLoggingOnly(productService, environmentService);
 			const logSuffix = justLoggingAndNotSending ? ' (Not Sent)' : '';
-			const isVisible = () => supportsTelemetry(productService, environmentService) && logService.getLevel() === LogLevel.Trace;
-			this.logger = this._register(loggerService.createLogger(telemetryLogId,
+			this.logger = this._register(loggerService.createLogger(id,
 				{
 					name: localize('telemetryLog', "Telemetry{0}", logSuffix),
-					hidden: !isVisible(),
-					group: TelemetryLogGroup
+					group: TelemetryLogGroup,
+					hidden: true
 				}));
-			this._register(logService.onDidChangeLogLevel(() => loggerService.setVisibility(telemetryLogId, isVisible())));
 		}
 	}
 

--- a/src/vs/platform/telemetry/common/telemetryUtils.ts
+++ b/src/vs/platform/telemetry/common/telemetryUtils.ts
@@ -57,8 +57,7 @@ export class NullEndpointTelemetryService implements ICustomEndpointTelemetrySer
 }
 
 export const telemetryLogId = 'telemetry';
-export const extensionTelemetryLogChannelId = 'extensionTelemetryLog';
-export const TelemetryLogGroup: LoggerGroup = { id: 'telemetry', name: localize('telemetryLogName', "Telemetry") };
+export const TelemetryLogGroup: LoggerGroup = { id: telemetryLogId, name: localize('telemetryLogName', "Telemetry") };
 
 export interface ITelemetryAppender {
 	log(eventName: string, data: any): void;

--- a/src/vs/platform/telemetry/node/customEndpointTelemetryService.ts
+++ b/src/vs/platform/telemetry/node/customEndpointTelemetryService.ts
@@ -7,7 +7,7 @@ import { FileAccess } from '../../../base/common/network.js';
 import { Client as TelemetryClient } from '../../../base/parts/ipc/node/ipc.cp.js';
 import { IConfigurationService } from '../../configuration/common/configuration.js';
 import { IEnvironmentService } from '../../environment/common/environment.js';
-import { ILogService, ILoggerService } from '../../log/common/log.js';
+import { ILoggerService } from '../../log/common/log.js';
 import { IProductService } from '../../product/common/productService.js';
 import { ICustomEndpointTelemetryService, ITelemetryData, ITelemetryEndpoint, ITelemetryService } from '../common/telemetry.js';
 import { TelemetryAppenderClient } from '../common/telemetryIpc.js';
@@ -22,7 +22,6 @@ export class CustomEndpointTelemetryService implements ICustomEndpointTelemetryS
 	constructor(
 		@IConfigurationService private readonly configurationService: IConfigurationService,
 		@ITelemetryService private readonly telemetryService: ITelemetryService,
-		@ILogService private readonly logService: ILogService,
 		@ILoggerService private readonly loggerService: ILoggerService,
 		@IEnvironmentService private readonly environmentService: IEnvironmentService,
 		@IProductService private readonly productService: IProductService
@@ -51,7 +50,7 @@ export class CustomEndpointTelemetryService implements ICustomEndpointTelemetryS
 			const channel = client.getChannel('telemetryAppender');
 			const appenders = [
 				new TelemetryAppenderClient(channel),
-				new TelemetryLogAppender(this.logService, this.loggerService, this.environmentService, this.productService, `[${endpoint.id}] `),
+				new TelemetryLogAppender(`[${endpoint.id}] `, false, this.loggerService, this.environmentService, this.productService),
 			];
 
 			this.customTelemetryServices.set(endpoint.id, new TelemetryService({

--- a/src/vs/platform/telemetry/test/common/telemetryLogAppender.test.ts
+++ b/src/vs/platform/telemetry/test/common/telemetryLogAppender.test.ts
@@ -7,7 +7,7 @@ import { Event } from '../../../../base/common/event.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
 import { IEnvironmentService } from '../../../environment/common/environment.js';
 import { TestInstantiationService } from '../../../instantiation/test/common/instantiationServiceMock.js';
-import { AbstractLogger, DEFAULT_LOG_LEVEL, ILogger, ILoggerService, LogLevel, NullLogService } from '../../../log/common/log.js';
+import { AbstractLogger, DEFAULT_LOG_LEVEL, ILogger, ILoggerService, LogLevel } from '../../../log/common/log.js';
 import { IProductService } from '../../../product/common/productService.js';
 import { TelemetryLogAppender } from '../../common/telemetryLogAppender.js';
 
@@ -91,7 +91,7 @@ suite('TelemetryLogAdapter', () => {
 	test('Do not Log Telemetry if log level is not trace', async () => {
 		const testLoggerService = new TestTelemetryLoggerService(DEFAULT_LOG_LEVEL);
 		const testInstantiationService = new TestInstantiationService();
-		const testObject = new TelemetryLogAppender(new NullLogService(), testLoggerService, testInstantiationService.stub(IEnvironmentService, {}), testInstantiationService.stub(IProductService, {}));
+		const testObject = new TelemetryLogAppender('', false, testLoggerService, testInstantiationService.stub(IEnvironmentService, {}), testInstantiationService.stub(IProductService, {}));
 		testObject.log('testEvent', { hello: 'world', isTrue: true, numberBetween1And3: 2 });
 		assert.strictEqual(testLoggerService.createLogger().logs.length, 0);
 		testObject.dispose();
@@ -101,7 +101,7 @@ suite('TelemetryLogAdapter', () => {
 	test('Log Telemetry if log level is trace', async () => {
 		const testLoggerService = new TestTelemetryLoggerService(LogLevel.Trace);
 		const testInstantiationService = new TestInstantiationService();
-		const testObject = new TelemetryLogAppender(new NullLogService(), testLoggerService, testInstantiationService.stub(IEnvironmentService, {}), testInstantiationService.stub(IProductService, {}));
+		const testObject = new TelemetryLogAppender('', false, testLoggerService, testInstantiationService.stub(IEnvironmentService, {}), testInstantiationService.stub(IProductService, {}));
 		testObject.log('testEvent', { hello: 'world', isTrue: true, numberBetween1And3: 2 });
 		assert.strictEqual(testLoggerService.createLogger().logs[0], 'telemetry/testEvent' + JSON.stringify([{
 			properties: {

--- a/src/vs/server/node/serverServices.ts
+++ b/src/vs/server/node/serverServices.ts
@@ -79,6 +79,7 @@ import { RemoteUserDataProfilesServiceChannel } from '../../platform/userDataPro
 import { NodePtyHostStarter } from '../../platform/terminal/node/nodePtyHostStarter.js';
 import { CSSDevelopmentService, ICSSDevelopmentService } from '../../platform/cssDev/node/cssDevService.js';
 import { AllowedExtensionsService } from '../../platform/extensionManagement/common/allowedExtensionsService.js';
+import { TelemetryLogAppender } from '../../platform/telemetry/common/telemetryLogAppender.js';
 
 const eventPrefix = 'monacoworkbench';
 
@@ -161,7 +162,7 @@ export async function setupServerServices(connectionToken: ServerConnectionToken
 		}
 
 		const config: ITelemetryServiceConfig = {
-			appenders: [oneDsAppender],
+			appenders: [oneDsAppender, new TelemetryLogAppender('', true, loggerService, environmentService, productService)],
 			commonProperties: resolveCommonProperties(release(), hostname(), process.arch, productService.commit, productService.version + '-remote', machineId, sqmId, devDeviceId, isInternal, 'remoteAgent'),
 			piiPaths: getPiiPathsFromEnvironment(environmentService)
 		};

--- a/src/vs/workbench/api/common/extHost.common.services.ts
+++ b/src/vs/workbench/api/common/extHost.common.services.ts
@@ -21,7 +21,6 @@ import { IExtHostWindow, ExtHostWindow } from './extHostWindow.js';
 import { IExtHostConsumerFileSystem, ExtHostConsumerFileSystem } from './extHostFileSystemConsumer.js';
 import { IExtHostFileSystemInfo, ExtHostFileSystemInfo } from './extHostFileSystemInfo.js';
 import { IExtHostSecretState, ExtHostSecretState } from './extHostSecretState.js';
-import { ExtHostTelemetry, IExtHostTelemetry } from './extHostTelemetry.js';
 import { ExtHostEditorTabs, IExtHostEditorTabs } from './extHostEditorTabs.js';
 import { ExtHostLoggerService } from './extHostLoggerService.js';
 import { ILoggerService } from '../../../platform/log/common/log.js';
@@ -57,6 +56,5 @@ registerSingleton(IExtHostTunnelService, ExtHostTunnelService, InstantiationType
 registerSingleton(IExtHostWindow, ExtHostWindow, InstantiationType.Eager);
 registerSingleton(IExtHostWorkspace, ExtHostWorkspace, InstantiationType.Eager);
 registerSingleton(IExtHostSecretState, ExtHostSecretState, InstantiationType.Eager);
-registerSingleton(IExtHostTelemetry, ExtHostTelemetry, InstantiationType.Eager);
 registerSingleton(IExtHostEditorTabs, ExtHostEditorTabs, InstantiationType.Eager);
 registerSingleton(IExtHostVariableResolverProvider, ExtHostVariableResolverProviderService, InstantiationType.Eager);

--- a/src/vs/workbench/api/common/extHostTelemetry.ts
+++ b/src/vs/workbench/api/common/extHostTelemetry.ts
@@ -8,14 +8,13 @@ import { createDecorator } from '../../../platform/instantiation/common/instanti
 import { Event, Emitter } from '../../../base/common/event.js';
 import { ExtHostTelemetryShape } from './extHost.protocol.js';
 import { ICommonProperties, TelemetryLevel } from '../../../platform/telemetry/common/telemetry.js';
-import { ILogger, ILoggerService, LogLevel, isLogLevel } from '../../../platform/log/common/log.js';
+import { ILogger, ILoggerService } from '../../../platform/log/common/log.js';
 import { IExtHostInitDataService } from './extHostInitDataService.js';
 import { ExtensionIdentifier, IExtensionDescription } from '../../../platform/extensions/common/extensions.js';
 import { UIKind } from '../../services/extensions/common/extensionHostProtocol.js';
 import { getRemoteName } from '../../../platform/remote/common/remoteHosts.js';
-import { cleanData, cleanRemoteAuthority, extensionTelemetryLogChannelId, TelemetryLogGroup } from '../../../platform/telemetry/common/telemetryUtils.js';
+import { cleanData, cleanRemoteAuthority, TelemetryLogGroup } from '../../../platform/telemetry/common/telemetryUtils.js';
 import { mixin } from '../../../base/common/objects.js';
-import { URI } from '../../../base/common/uri.js';
 import { Disposable } from '../../../base/common/lifecycle.js';
 import { localize } from '../../../nls.js';
 
@@ -31,38 +30,25 @@ export class ExtHostTelemetry extends Disposable implements ExtHostTelemetryShap
 
 	private _productConfig: { usage: boolean; error: boolean } = { usage: true, error: true };
 	private _level: TelemetryLevel = TelemetryLevel.NONE;
-	// This holds whether or not we're running with --disable-telemetry, etc. Usings supportsTelemtry() from the main thread
-	private _telemetryIsSupported: boolean = false;
 	private _oldTelemetryEnablement: boolean | undefined;
 	private readonly _inLoggingOnlyMode: boolean = false;
-	private readonly extHostTelemetryLogFile: URI;
 	private readonly _outputLogger: ILogger;
 	private readonly _telemetryLoggers = new Map<string, ExtHostTelemetryLogger[]>();
 
 	constructor(
+		isWorker: boolean,
 		@IExtHostInitDataService private readonly initData: IExtHostInitDataService,
-		@ILoggerService private readonly loggerService: ILoggerService,
+		@ILoggerService loggerService: ILoggerService,
 	) {
 		super();
-		this.extHostTelemetryLogFile = URI.revive(this.initData.environment.extensionTelemetryLogResource);
 		this._inLoggingOnlyMode = this.initData.environment.isExtensionTelemetryLoggingOnly;
-		this._outputLogger = loggerService.createLogger(this.extHostTelemetryLogFile,
+		const id = initData.remote.isRemote ? 'remoteExtHostTelemetry' : isWorker ? 'workerExtHostTelemetry' : 'extHostTelemetry';
+		this._outputLogger = this._register(loggerService.createLogger(id,
 			{
-				id: extensionTelemetryLogChannelId,
 				name: localize('extensionTelemetryLog', "Extension Telemetry{0}", this._inLoggingOnlyMode ? ' (Not Sent)' : ''),
 				hidden: true,
 				group: TelemetryLogGroup,
-			});
-		this._register(this._outputLogger);
-		this._register(loggerService.onDidChangeLogLevel(arg => {
-			if (isLogLevel(arg)) {
-				this.updateLoggerVisibility();
-			}
-		}));
-	}
-
-	private updateLoggerVisibility(): void {
-		this.loggerService.setVisibility(this.extHostTelemetryLogFile, this._telemetryIsSupported && this.loggerService.getLogLevel() === LogLevel.Trace);
+			}));
 	}
 
 	getTelemetryConfiguration(): boolean {
@@ -95,9 +81,7 @@ export class ExtHostTelemetry extends Disposable implements ExtHostTelemetryShap
 
 	$initializeTelemetryLevel(level: TelemetryLevel, supportsTelemetry: boolean, productConfig?: { usage: boolean; error: boolean }): void {
 		this._level = level;
-		this._telemetryIsSupported = supportsTelemetry;
 		this._productConfig = productConfig ?? { usage: true, error: true };
-		this.updateLoggerVisibility();
 	}
 
 	getBuiltInCommonProperties(extension: IExtensionDescription): ICommonProperties {
@@ -155,7 +139,6 @@ export class ExtHostTelemetry extends Disposable implements ExtHostTelemetryShap
 			this._onDidChangeTelemetryEnabled.fire(this.getTelemetryConfiguration());
 		}
 		this._onDidChangeTelemetryConfiguration.fire(this.getTelemetryDetails());
-		this.updateLoggerVisibility();
 	}
 
 	onExtensionError(extension: ExtensionIdentifier, error: Error): boolean {

--- a/src/vs/workbench/api/common/extensionHostMain.ts
+++ b/src/vs/workbench/api/common/extensionHostMain.ts
@@ -214,7 +214,6 @@ export class ExtensionHostMain {
 		initData.environment.extensionTestsLocationURI = URI.revive(rpcProtocol.transformIncomingURIs(initData.environment.extensionTestsLocationURI));
 		initData.environment.globalStorageHome = URI.revive(rpcProtocol.transformIncomingURIs(initData.environment.globalStorageHome));
 		initData.environment.workspaceStorageHome = URI.revive(rpcProtocol.transformIncomingURIs(initData.environment.workspaceStorageHome));
-		initData.environment.extensionTelemetryLogResource = URI.revive(rpcProtocol.transformIncomingURIs(initData.environment.extensionTelemetryLogResource));
 		initData.nlsBaseUrl = URI.revive(rpcProtocol.transformIncomingURIs(initData.nlsBaseUrl));
 		initData.logsLocation = URI.revive(rpcProtocol.transformIncomingURIs(initData.logsLocation));
 		initData.workspace = rpcProtocol.transformIncomingURIs(initData.workspace);

--- a/src/vs/workbench/api/node/extHost.node.services.ts
+++ b/src/vs/workbench/api/node/extHost.node.services.ts
@@ -26,6 +26,7 @@ import { ExtHostLogService } from '../common/extHostLogService.js';
 import { SyncDescriptor } from '../../../platform/instantiation/common/descriptors.js';
 import { ISignService } from '../../../platform/sign/common/sign.js';
 import { SignService } from '../../../platform/sign/node/signService.js';
+import { ExtHostTelemetry, IExtHostTelemetry } from '../common/extHostTelemetry.js';
 
 // #########################################################################
 // ###                                                                   ###
@@ -38,6 +39,7 @@ registerSingleton(ILoggerService, ExtHostLoggerService, InstantiationType.Delaye
 registerSingleton(ILogService, new SyncDescriptor(ExtHostLogService, [false], true));
 registerSingleton(ISignService, SignService, InstantiationType.Delayed);
 registerSingleton(IExtensionStoragePaths, ExtensionStoragePaths, InstantiationType.Eager);
+registerSingleton(IExtHostTelemetry, new SyncDescriptor(ExtHostTelemetry, [false], true));
 
 registerSingleton(IExtHostDebugService, ExtHostDebugService, InstantiationType.Eager);
 registerSingleton(IExtHostSearch, NativeExtHostSearch, InstantiationType.Eager);

--- a/src/vs/workbench/api/test/browser/extHostTelemetry.test.ts
+++ b/src/vs/workbench/api/test/browser/extHostTelemetry.test.ts
@@ -31,7 +31,6 @@ suite('ExtHostTelemetry', function () {
 		extensionTestsLocationURI: undefined,
 		appRoot: undefined,
 		appName: 'test',
-		extensionTelemetryLogResource: URI.parse('fake'),
 		isExtensionTelemetryLoggingOnly: false,
 		appHost: 'test',
 		appLanguage: 'en',
@@ -70,7 +69,7 @@ suite('ExtHostTelemetry', function () {
 	};
 
 	const createExtHostTelemetry = () => {
-		const extensionTelemetry = new ExtHostTelemetry(new class extends mock<IExtHostInitDataService>() {
+		const extensionTelemetry = new ExtHostTelemetry(false, new class extends mock<IExtHostInitDataService>() {
 			override environment: IEnvironment = mockEnvironment;
 			override telemetryInfo = mockTelemetryInfo;
 			override remote = mockRemote;
@@ -274,7 +273,7 @@ suite('ExtHostTelemetry', function () {
 
 		// Have to re-duplicate code here because I the logger service isn't exposed in the simple setup functions
 		const loggerService = new TestTelemetryLoggerService(LogLevel.Trace);
-		const extensionTelemetry = new ExtHostTelemetry(new class extends mock<IExtHostInitDataService>() {
+		const extensionTelemetry = new ExtHostTelemetry(false, new class extends mock<IExtHostInitDataService>() {
 			override environment: IEnvironment = mockEnvironment;
 			override telemetryInfo = mockTelemetryInfo;
 			override remote = mockRemote;

--- a/src/vs/workbench/api/worker/extHost.worker.services.ts
+++ b/src/vs/workbench/api/worker/extHost.worker.services.ts
@@ -9,6 +9,7 @@ import { ILogService } from '../../../platform/log/common/log.js';
 import { IExtHostExtensionService } from '../common/extHostExtensionService.js';
 import { ExtHostLogService } from '../common/extHostLogService.js';
 import { ExtensionStoragePaths, IExtensionStoragePaths } from '../common/extHostStoragePaths.js';
+import { ExtHostTelemetry, IExtHostTelemetry } from '../common/extHostTelemetry.js';
 import { ExtHostExtensionService } from './extHostExtensionService.js';
 
 // #########################################################################
@@ -20,3 +21,4 @@ import { ExtHostExtensionService } from './extHostExtensionService.js';
 registerSingleton(ILogService, new SyncDescriptor(ExtHostLogService, [true], true));
 registerSingleton(IExtHostExtensionService, ExtHostExtensionService, InstantiationType.Eager);
 registerSingleton(IExtensionStoragePaths, ExtensionStoragePaths, InstantiationType.Eager);
+registerSingleton(IExtHostTelemetry, new SyncDescriptor(ExtHostTelemetry, [true], true));

--- a/src/vs/workbench/contrib/output/browser/outputServices.ts
+++ b/src/vs/workbench/contrib/output/browser/outputServices.ts
@@ -27,7 +27,7 @@ import { IFileService } from '../../../../platform/files/common/files.js';
 import { localize } from '../../../../nls.js';
 import { joinPath } from '../../../../base/common/resources.js';
 import { VSBuffer } from '../../../../base/common/buffer.js';
-import { extensionTelemetryLogChannelId, telemetryLogId } from '../../../../platform/telemetry/common/telemetryUtils.js';
+import { telemetryLogId } from '../../../../platform/telemetry/common/telemetryUtils.js';
 import { toLocalISOString } from '../../../../base/common/date.js';
 import { IWorkbenchEnvironmentService } from '../../../services/environment/common/environmentService.js';
 
@@ -346,7 +346,7 @@ export class OutputService extends Disposable implements IOutputService, ITextMo
 	}
 
 	canSetLogLevel(channel: IOutputChannelDescriptor): boolean {
-		return channel.log && channel.id !== telemetryLogId && channel.id !== extensionTelemetryLogChannelId;
+		return channel.log && channel.id !== telemetryLogId;
 	}
 
 	getLogLevel(channel: IOutputChannelDescriptor): LogLevel | undefined {

--- a/src/vs/workbench/services/environment/browser/environmentService.ts
+++ b/src/vs/workbench/services/environment/browser/environmentService.ts
@@ -144,11 +144,6 @@ export class BrowserWorkbenchEnvironmentService implements IBrowserWorkbenchEnvi
 	@memoize
 	get extHostLogsPath(): URI { return joinPath(this.logsHome, 'exthost'); }
 
-	@memoize
-	get extHostTelemetryLogFile(): URI {
-		return joinPath(this.extHostLogsPath, 'extensionTelemetry.log');
-	}
-
 	private extensionHostDebugEnvironment: IExtensionHostDebugEnvironment | undefined = undefined;
 
 	@memoize

--- a/src/vs/workbench/services/environment/common/environmentService.ts
+++ b/src/vs/workbench/services/environment/common/environmentService.ts
@@ -26,7 +26,6 @@ export interface IWorkbenchEnvironmentService extends IEnvironmentService {
 	readonly logFile: URI;
 	readonly windowLogsPath: URI;
 	readonly extHostLogsPath: URI;
-	readonly extHostTelemetryLogFile: URI;
 
 	// --- Extensions
 	readonly extensionEnabledProposedApi?: string[];

--- a/src/vs/workbench/services/environment/electron-sandbox/environmentService.ts
+++ b/src/vs/workbench/services/environment/electron-sandbox/environmentService.ts
@@ -105,11 +105,6 @@ export class NativeWorkbenchEnvironmentService extends AbstractNativeEnvironment
 	get extHostLogsPath(): URI { return joinPath(this.windowLogsPath, 'exthost'); }
 
 	@memoize
-	get extHostTelemetryLogFile(): URI {
-		return joinPath(this.extHostLogsPath, 'extensionTelemetry.log');
-	}
-
-	@memoize
 	get webviewExternalEndpoint(): string { return `${Schemas.vscodeWebview}://{{uuid}}`; }
 
 	@memoize

--- a/src/vs/workbench/services/extensions/browser/webWorkerExtensionHost.ts
+++ b/src/vs/workbench/services/extensions/browser/webWorkerExtensionHost.ts
@@ -301,7 +301,6 @@ export class WebWorkerExtensionHost extends Disposable implements IExtensionHost
 				appHost: this._productService.embedderIdentifier ?? (platform.isWeb ? 'web' : 'desktop'),
 				appUriScheme: this._productService.urlProtocol,
 				appLanguage: platform.language,
-				extensionTelemetryLogResource: this._environmentService.extHostTelemetryLogFile,
 				isExtensionTelemetryLoggingOnly: isLoggingOnly(this._productService, this._environmentService),
 				extensionDevelopmentLocationURI: this._environmentService.extensionDevelopmentLocationURI,
 				extensionTestsLocationURI: this._environmentService.extensionTestsLocationURI,

--- a/src/vs/workbench/services/extensions/common/extensionHostProtocol.ts
+++ b/src/vs/workbench/services/extensions/common/extensionHostProtocol.ts
@@ -62,7 +62,6 @@ export interface IEnvironment {
 	appHost: string;
 	appRoot?: URI;
 	appLanguage: string;
-	extensionTelemetryLogResource: URI;
 	isExtensionTelemetryLoggingOnly: boolean;
 	appUriScheme: string;
 	extensionDevelopmentLocationURI?: URI[];

--- a/src/vs/workbench/services/extensions/common/remoteExtensionHost.ts
+++ b/src/vs/workbench/services/extensions/common/remoteExtensionHost.ts
@@ -216,7 +216,6 @@ export class RemoteExtensionHost extends Disposable implements IExtensionHost {
 				appName: this._productService.nameLong,
 				appHost: this._productService.embedderIdentifier || 'desktop',
 				appUriScheme: this._productService.urlProtocol,
-				extensionTelemetryLogResource: this._environmentService.extHostTelemetryLogFile,
 				isExtensionTelemetryLoggingOnly: isLoggingOnly(this._productService, this._environmentService),
 				appLanguage: platform.language,
 				extensionDevelopmentLocationURI: this._environmentService.extensionDevelopmentLocationURI,

--- a/src/vs/workbench/services/extensions/electron-sandbox/localProcessExtensionHost.ts
+++ b/src/vs/workbench/services/extensions/electron-sandbox/localProcessExtensionHost.ts
@@ -473,7 +473,6 @@ export class NativeLocalProcessExtensionHost implements IExtensionHost {
 				appName: this._productService.nameLong,
 				appHost: this._productService.embedderIdentifier || 'desktop',
 				appUriScheme: this._productService.urlProtocol,
-				extensionTelemetryLogResource: this._environmentService.extHostTelemetryLogFile,
 				isExtensionTelemetryLoggingOnly: isLoggingOnly(this._productService, this._environmentService),
 				appLanguage: platform.language,
 				extensionDevelopmentLocationURI: this._environmentService.extensionDevelopmentLocationURI,

--- a/src/vs/workbench/services/telemetry/browser/telemetryService.ts
+++ b/src/vs/workbench/services/telemetry/browser/telemetryService.ts
@@ -84,7 +84,7 @@ export class TelemetryService extends Disposable implements ITelemetryService {
 					appenders.push(new OneDataSystemWebAppender(isInternal, 'monacoworkbench', null, productService.aiConfig?.ariaKey));
 				}
 			}
-			appenders.push(new TelemetryLogAppender(logService, loggerService, environmentService, productService));
+			appenders.push(new TelemetryLogAppender('', false, loggerService, environmentService, productService));
 			const config: ITelemetryServiceConfig = {
 				appenders,
 				commonProperties: resolveWorkbenchCommonProperties(storageService, productService.commit, productService.version, isInternal, environmentService.remoteAuthority, productService.embedderIdentifier, productService.removeTelemetryMachineId, environmentService.options && environmentService.options.resolveCommonTelemetryProperties),


### PR DESCRIPTION
fix #238725

- Added a command `Developer: Show Telemetry` to show telemetry output. This sets log level to trace only for telemetry logs.
- Clean Up:
  - Use single telemetry log file per process (local ext host, remote ext host, web worker ext host) - the log file across processes should not be shared
  - Show server telemetry 