### PR TITLE
Use `textbox` instead of `combobox`

### DIFF
--- a/src/vs/platform/quickinput/browser/quickInputBox.ts
+++ b/src/vs/platform/quickinput/browser/quickInputBox.ts
@@ -29,10 +29,9 @@ export class QuickInputBox extends Disposable {
 		this.container = dom.append(this.parent, $('.quick-input-box'));
 		this.findInput = this._register(new FindInput(this.container, undefined, { label: '', inputBoxStyles, toggleStyles }));
 		const input = this.findInput.inputBox.inputElement;
-		input.role = 'combobox';
+		input.role = 'textbox';
 		input.ariaHasPopup = 'menu';
 		input.ariaAutoComplete = 'list';
-		input.ariaExpanded = 'true';
 	}
 
 	onKeyDown = (handler: (event: StandardKeyboardEvent) => void): IDisposable => {


### PR DESCRIPTION
To get screenreaders to read the input.

Fixes https://github.com/microsoft/vscode/issues/237324

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
