### PR TITLE
Remove aria-activedescendant when typing & remove clearFocus code

### DIFF
--- a/src/vs/platform/quickinput/browser/quickInputBox.ts
+++ b/src/vs/platform/quickinput/browser/quickInputBox.ts
@@ -4,8 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as dom from '../../../base/browser/dom.js';
-import { StandardKeyboardEvent } from '../../../base/browser/keyboardEvent.js';
-import { StandardMouseEvent } from '../../../base/browser/mouseEvent.js';
 import { FindInput } from '../../../base/browser/ui/findinput/findInput.js';
 import { IInputBoxStyles, IRange, MessageType } from '../../../base/browser/ui/inputbox/inputBox.js';
 import { IToggleStyles, Toggle } from '../../../base/browser/ui/toggle/toggle.js';
@@ -34,13 +32,13 @@ export class QuickInputBox extends Disposable {
 		input.ariaAutoComplete = 'list';
 	}
 
-	onKeyDown = (handler: (event: StandardKeyboardEvent) => void): IDisposable => {
-		return dom.addStandardDisposableListener(this.findInput.inputBox.inputElement, dom.EventType.KEY_DOWN, handler);
-	};
+	get onKeyDown() {
+		return this.findInput.onKeyDown;
+	}
 
-	onMouseDown = (handler: (event: StandardMouseEvent) => void): IDisposable => {
-		return dom.addStandardDisposableListener(this.findInput.inputBox.inputElement, dom.EventType.MOUSE_DOWN, handler);
-	};
+	get onMouseDown() {
+		return this.findInput.onMouseDown;
+	}
 
 	onDidChange = (handler: (event: string) => void): IDisposable => {
 		return this.findInput.onDidChange(handler);

--- a/src/vs/platform/quickinput/browser/quickInputController.ts
+++ b/src/vs/platform/quickinput/browser/quickInputController.ts
@@ -262,6 +262,11 @@ export class QuickInputController extends Disposable {
 			if (this.endOfQuickInputBoxContext.get() !== value) {
 				this.endOfQuickInputBoxContext.set(value);
 			}
+			// Allow screenreaders to read what's in the input
+			// Note: this works for arrow keys and selection changes,
+			// but not for deletions since that often triggers a
+			// change in the list.
+			inputBox.removeAttribute('aria-activedescendant');
 		}));
 		this._register(dom.addDisposableListener(container, dom.EventType.FOCUS, (e: FocusEvent) => {
 			inputBox.setFocus();
@@ -313,14 +318,13 @@ export class QuickInputController extends Disposable {
 							selectors.push('.quick-input-html-widget');
 						}
 						const stops = container.querySelectorAll<HTMLElement>(selectors.join(', '));
-						if (event.shiftKey && event.target === stops[0]) {
-							// Clear the focus from the list in order to allow
-							// screen readers to read operations in the input box.
-							dom.EventHelper.stop(event, true);
-							list.clearFocus();
-						} else if (!event.shiftKey && dom.isAncestor(event.target, stops[stops.length - 1])) {
+						if (!event.shiftKey && dom.isAncestor(event.target, stops[stops.length - 1])) {
 							dom.EventHelper.stop(event, true);
 							stops[0].focus();
+						}
+						if (event.shiftKey && dom.isAncestor(event.target, stops[0])) {
+							dom.EventHelper.stop(event, true);
+							stops[stops.length - 1].focus();
 						}
 					}
 					break;


### PR DESCRIPTION
This applies some good feedback from @rperez030 in here:
https://github.com/microsoft/vscode/issues/237324#issuecomment-2640728149

which gave me the idea to just remove `aria-activedescendant` whenever you type in the input box. This allows arrow keys and selections to read out.

Because of that, we can remove this SHIFT+TAB behavior I introduced a while back since that isn't needed to get the screen reader to read out the arrow keys.

Note: deletions in certain quick picks remain a challenge. Since deletion leads to a changed filter, which triggers the list to highlight something new, often deletions are overriden by the list changes. Honestly, even the SHIFT+TAB behavior before didn't improve the deletions... sometimes the screen reader read them, sometimes it didn't.

Fixes https://github.com/microsoft/vscode/issues/180862

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
