### PR TITLE
Fix build, use mutable disposable

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminalView.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalView.ts
@@ -55,6 +55,7 @@ import { MicrotaskDelay } from '../../../../base/common/symbols.js';
 export class TerminalViewPane extends ViewPane {
 	private _parentDomElement: HTMLElement | undefined;
 	private _terminalTabbedView?: TerminalTabbedView;
+	private readonly _singleTabActionViewItem: MutableDisposable<SingleTerminalTabActionViewItem> = this._register(new MutableDisposable());
 	get terminalTabbedView(): TerminalTabbedView | undefined { return this._terminalTabbedView; }
 	private _isInitialized: boolean = false;
 	/**
@@ -279,9 +280,14 @@ export class TerminalViewPane extends ViewPane {
 			}
 			case TerminalCommandId.Focus: {
 				if (action instanceof MenuItemAction) {
+					if (this._singleTabActionViewItem.value) {
+						return this._singleTabActionViewItem.value;
+					}
 					const actions = getFlatContextMenuActions(this._singleTabMenu.getActions({ shouldForwardArgs: true }));
-					return this._disposableStore.add(this._instantiationService.createInstance(SingleTerminalTabActionViewItem, action, actions));
+					this._singleTabActionViewItem.value = this._instantiationService.createInstance(SingleTerminalTabActionViewItem, action, actions);
+					return this._singleTabActionViewItem.value;
 				}
+				break;
 			}
 			case TerminalCommandId.New: {
 				if (action instanceof MenuItemAction) {


### PR DESCRIPTION
Brings back the single terminal tab - adding it as a regular disposable caused issues

cc @tyriar