### PR TITLE
Revert "workspaceFolder variable substitution in launch.json or tasks.json should use URI for virtual filesystems (#235954)"

### DIFF
--- a/src/vs/workbench/api/common/extHostVariableResolverService.ts
+++ b/src/vs/workbench/api/common/extHostVariableResolverService.ts
@@ -18,7 +18,6 @@ import { IConfigurationResolverService } from '../../services/configurationResol
 import { AbstractVariableResolverService } from '../../services/configurationResolver/common/variableResolver.js';
 import * as vscode from 'vscode';
 import { ExtHostConfigProvider, IExtHostConfiguration } from './extHostConfiguration.js';
-import { Schemas } from '../../../base/common/network.js';
 
 export interface IExtHostVariableResolverProvider {
 	readonly _serviceBrand: undefined;
@@ -84,11 +83,7 @@ class ExtHostVariableResolverService extends AbstractVariableResolverService {
 			getFilePath: (): string | undefined => {
 				const activeUri = getActiveUri();
 				if (activeUri) {
-					if (activeUri.scheme === Schemas.file) {
-						return path.normalize(activeUri.fsPath);
-					} else {
-						return activeUri.toString();
-					}
+					return path.normalize(activeUri.fsPath);
 				}
 				return undefined;
 			},
@@ -98,11 +93,7 @@ class ExtHostVariableResolverService extends AbstractVariableResolverService {
 					if (activeUri) {
 						const ws = workspaceService.getWorkspaceFolder(activeUri);
 						if (ws) {
-							if (activeUri.scheme === Schemas.file) {
-								return path.normalize(ws.uri.fsPath);
-							} else {
-								return ws.uri.toString();
-							}
+							return path.normalize(ws.uri.fsPath);
 						}
 					}
 				}


### PR DESCRIPTION
This reverts commit d3145c5087eeb8777b80cda7f38651e1242b2f81.

Fixes https://github.com/microsoft/vscode/issues/239903