### PR TITLE
dedupe property names for `exthostunresponsive` and `startuptimevaried` events

### DIFF
--- a/src/vs/workbench/contrib/extensions/electron-sandbox/extensionsAutoProfiler.ts
+++ b/src/vs/workbench/contrib/extensions/electron-sandbox/extensionsAutoProfiler.ts
@@ -173,7 +173,7 @@ export class ExtensionsAutoProfiler implements IWorkbenchContribution {
 		}
 
 
-		const sessionId = generateUuid();
+		const profilingSessionId = generateUuid();
 
 		// print message to log
 		const path = joinPath(this._environmentServie.tmpDir, `exthost-${Math.random().toString(16).slice(2, 8)}.cpuprofile`);
@@ -182,20 +182,20 @@ export class ExtensionsAutoProfiler implements IWorkbenchContribution {
 
 		type UnresponsiveData = {
 			duration: number;
-			sessionId: string;
+			profilingSessionId: string;
 			data: string[];
 			id: string;
 		};
 		type UnresponsiveDataClassification = {
 			owner: 'jrieken';
 			comment: 'Profiling data that was collected while the extension host was unresponsive';
-			sessionId: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'Identifier of a profiling session' };
+			profilingSessionId: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'Identifier of a profiling session' };
 			duration: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'Duration for which the extension host was unresponsive' };
 			data: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'Extensions ids and core parts that were active while the extension host was frozen' };
 			id: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'Top extensions id that took most of the duration' };
 		};
 		this._telemetryService.publicLog2<UnresponsiveData, UnresponsiveDataClassification>('exthostunresponsive', {
-			sessionId,
+			profilingSessionId,
 			duration: overall,
 			data: data.map(tuple => tuple[0]).flat(),
 			id: ExtensionIdentifier.toKey(extension.identifier),

--- a/src/vs/workbench/services/timer/browser/timerService.ts
+++ b/src/vs/workbench/services/timer/browser/timerService.ts
@@ -37,7 +37,6 @@ export interface IMemoryInfo {
 
 /* __GDPR__FRAGMENT__
 	"IStartupMetrics" : {
-		"version" : { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth" },
 		"ellapsed" : { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "isMeasurement": true },
 		"isLatestVersion": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth" },
 		"didUseCachedData": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth" },
@@ -87,11 +86,6 @@ export interface IMemoryInfo {
 	}
 */
 export interface IStartupMetrics {
-
-	/**
-	 * The version of these metrics.
-	 */
-	readonly version: 2;
 
 	/**
 	 * If this started the main process and renderer or just a renderer (new or reloaded).
@@ -684,7 +678,7 @@ export abstract class AbstractTimerService implements ITimerService {
 		const activeViewlet = this._paneCompositeService.getActivePaneComposite(ViewContainerLocation.Sidebar);
 		const activePanel = this._paneCompositeService.getActivePaneComposite(ViewContainerLocation.Panel);
 		const info: Writeable<IStartupMetrics> = {
-			version: 2,
+
 			ellapsed: this._marks.getDuration(startMark, 'code/didStartWorkbench'),
 
 			// reflections


### PR DESCRIPTION
https://github.com/microsoft/vscode-internalbacklog/issues/5334