### PR TITLE
 Support incoming args for changeIcon & changeColor terminal commands

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminalActions.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalActions.ts
@@ -9,7 +9,8 @@ import { KeyChord, KeyCode, KeyMod } from '../../../../base/common/keyCodes.js';
 import { Schemas } from '../../../../base/common/network.js';
 import { isWindows } from '../../../../base/common/platform.js';
 import { IDisposable } from '../../../../base/common/lifecycle.js';
-import { isObject, isString } from '../../../../base/common/types.js';
+import { ThemeIcon } from '../../../../base/common/themables.js';
+import { isObject, isString, isBoolean } from '../../../../base/common/types.js';
 import { URI } from '../../../../base/common/uri.js';
 import { ICodeEditorService } from '../../../../editor/browser/services/codeEditorService.js';
 import { EndOfLinePreference } from '../../../../editor/common/model.js';
@@ -698,7 +699,9 @@ export function registerTerminalActions() {
 		id: TerminalCommandId.ChangeIcon,
 		title: terminalStrings.changeIcon,
 		precondition: sharedWhenClause.terminalAvailable,
-		run: (c, _, args: unknown) => getResourceOrActiveInstance(c, args)?.changeIcon()
+		run: (c, _, args: unknown) => getResourceOrActiveInstance(c, args)?.changeIcon(
+			isString(args) ? ThemeIcon.fromString(args) || ThemeIcon.fromId(args) : undefined
+		)
 	});
 
 	registerTerminalAction({
@@ -722,7 +725,10 @@ export function registerTerminalActions() {
 		id: TerminalCommandId.ChangeColor,
 		title: terminalStrings.changeColor,
 		precondition: sharedWhenClause.terminalAvailable,
-		run: (c, _, args) => getResourceOrActiveInstance(c, args)?.changeColor()
+		run: (c, _, args1, args2) => getResourceOrActiveInstance(c, args1)?.changeColor(
+			isString(args1) ? args1 : undefined,
+			isBoolean(args2) ? args2 : undefined
+		)
 	});
 
 	registerTerminalAction({


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
This Pull request permit the passing of args to the `changeIcon`/`changeColor` terminal commands.

This way, it’s possible to control icon and color of the terminal tab, from the terminal itself using [remote-control extension](https://github.com/estruyf/vscode-remote-control).

Currently, trying to do so would trigger the prompt to pop up even with a specified arg, as the args are not forwarded.

I tested locally this PR code by adding the remote control extension to the [extensions](https://github.com/AdrieanKhisbe/vscode/tree/master/extensions) , and by running the provided command from a fresh terminal. (`websocat` was installed from brew on a macbook)

I might need some guidance if automated test are to be added, or existing one adapted.


#### Preview
```bash
echo "{ \"command\": \"workbench.action.terminal.changeIcon\", \"args\": \"lightbulb\" }\n{ \"command\": \"workbench.action.terminal.changeColor\", \"args\": [\"terminal.ansiYellow\", false] }" \
    | websocat ws://localhost:$REMOTE_CONTROL_PORT
```

|before|after|
|:-:|:-:|
|![Capture d’écran 2025-02-04 à 18 03 28](https://github.com/user-attachments/assets/deeb8a6e-88e1-42c5-aa8b-0360e39cdb4e)| ![Capture d’écran 2025-02-04 à 18 03 38](https://github.com/user-attachments/assets/b4fe80ee-b930-4557-8e09-19af96893c37)