### PR TITLE
Fix css rule for notebook selection highlighting

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/media/notebook.css
+++ b/src/vs/workbench/contrib/notebook/browser/media/notebook.css
@@ -458,7 +458,7 @@
 
 /** Notebook Textual Selection Highlight */
 .nb-selection-highlight {
-	background-color: var(--vscode-editor-selectionBackground);
+	background-color: var(--vscode-editor-selectionHighlightBackground);
 }
 
 /** Cell Multi-Cursor Cursor highlight */


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Fixes: #236093, #235122

noticed the difference in selectionBackground and selectionHighlightBackground css vars.

Next step to clean selection highlighting/multicursor is to sort out trigging a selection highlight when in multicursor. 

before
![image](https://github.com/user-attachments/assets/f05fccb3-dcad-4efc-8e28-f522ac11a3a4)

after
![image](https://github.com/user-attachments/assets/fb88b0d1-017e-426b-b889-61a4e92b3118)
