### PR TITLE
Highlight active line number correctly regardless of word wrap

### DIFF
--- a/src/vs/editor/browser/viewParts/lineNumbers/lineNumbers.ts
+++ b/src/vs/editor/browser/viewParts/lineNumbers/lineNumbers.ts
@@ -32,7 +32,7 @@ export class LineNumbersOverlay extends DynamicViewOverlay {
 	private _lineNumbersWidth!: number;
 	private _lastCursorModelPosition: Position;
 	private _renderResult: string[] | null;
-	private _activeLineNumber: number;
+	private _activeModelLineNumber: number;
 
 	constructor(context: ViewContext) {
 		super();
@@ -42,7 +42,7 @@ export class LineNumbersOverlay extends DynamicViewOverlay {
 
 		this._lastCursorModelPosition = new Position(1, 1);
 		this._renderResult = null;
-		this._activeLineNumber = 1;
+		this._activeModelLineNumber = 1;
 		this._context.addEventHandler(this);
 	}
 
@@ -75,8 +75,8 @@ export class LineNumbersOverlay extends DynamicViewOverlay {
 		this._lastCursorModelPosition = this._context.viewModel.coordinatesConverter.convertViewPositionToModelPosition(primaryViewPosition);
 
 		let shouldRender = false;
-		if (this._activeLineNumber !== primaryViewPosition.lineNumber) {
-			this._activeLineNumber = primaryViewPosition.lineNumber;
+		if (this._activeModelLineNumber !== this._lastCursorModelPosition.lineNumber) {
+			this._activeModelLineNumber = this._lastCursorModelPosition.lineNumber;
 			shouldRender = true;
 		}
 		if (this._renderLineNumbers === RenderLineNumbersType.Relative || this._renderLineNumbers === RenderLineNumbersType.Interval) {
@@ -162,6 +162,7 @@ export class LineNumbersOverlay extends DynamicViewOverlay {
 		const output: string[] = [];
 		for (let lineNumber = visibleStartLineNumber; lineNumber <= visibleEndLineNumber; lineNumber++) {
 			const lineIndex = lineNumber - visibleStartLineNumber;
+			const modelLineNumber: number = this._context.viewModel.coordinatesConverter.convertViewPositionToModelPosition(new Position(lineNumber, 1)).lineNumber;
 
 			let renderLineNumber = this._getLineRenderLineNumber(lineNumber);
 			let extraClassNames = '';
@@ -191,7 +192,7 @@ export class LineNumbersOverlay extends DynamicViewOverlay {
 					extraClassNames += ' dimmed-line-number';
 				}
 			}
-			if (lineNumber === this._activeLineNumber) {
+			if (modelLineNumber === this._activeModelLineNumber) {
 				extraClassNames += ' active-line-number';
 			}
 


### PR DESCRIPTION
Previously, the line number was only highlighted when cursor was on the first part of a wrapped line.

Fixes #214937

Screenshot before (line number 3 not highlighted):

![before](https://github.com/user-attachments/assets/050bb972-afc0-40b0-9d26-c4aee3eb1804)

Screenshot after (line number 3 highlighted as expected):

![after](https://github.com/user-attachments/assets/0edeea26-6256-4f5e-816e-a32f5937c42c)
