### PR TITLE
Allow detection of powershell-preview snap

### DIFF
--- a/src/vs/platform/shell/node/shellEnv.ts
+++ b/src/vs/platform/shell/node/shellEnv.ts
@@ -129,7 +129,7 @@ async function doResolveUnixShellEnv(logService: ILogService, token: Cancellatio
 		const name = basename(systemShellUnix);
 		let command: string, shellArgs: Array<string>;
 		const extraArgs = '';
-		if (/^(?:pwsh(?:-preview)?|powershell)$/.test(name)) {
+		if (/^(?:pwsh|powershell)(?:-preview)?$/.test(name)) {
 			// Older versions of PowerShell removes double quotes sometimes so we use "double single quotes" which is how
 			// you escape single quotes inside of a single quoted string.
 			command = `& '${process.execPath}' ${extraArgs} -p '''${mark}'' + JSON.stringify(process.env) + ''${mark}'''`;


### PR DESCRIPTION
The executable name can be `pwsh`, `pwsh-preview`, `powershell`, or `powershell-preview`. The new regular expression matches them all.

~~Fixes #240053.~~

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
