### PR TITLE
Fix behavior of terminal.integrated.confirmOnExit

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminalService.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalService.ts
@@ -646,8 +646,8 @@ export class TerminalService extends Disposable implements ITerminalService {
 			const shouldPersistProcesses = this._terminalConfigurationService.config.enablePersistentSessions && reason === ShutdownReason.RELOAD;
 			if (!shouldPersistProcesses) {
 				const hasDirtyInstances = (
-					(this._terminalConfigurationService.config.confirmOnExit === 'always' && this.instances.length > 0) ||
-					(this._terminalConfigurationService.config.confirmOnExit === 'hasChildProcesses' && this.instances.some(e => e.hasChildProcesses))
+					(this._terminalConfigurationService.config.confirmOnExit === 'always' && this.foregroundInstances.length > 0) ||
+					(this._terminalConfigurationService.config.confirmOnExit === 'hasChildProcesses' && this.foregroundInstances.some(e => e.hasChildProcesses))
 				);
 				if (hasDirtyInstances) {
 					return this._onBeforeShutdownConfirmation(reason);

--- a/src/vs/workbench/contrib/terminal/common/terminalConfiguration.ts
+++ b/src/vs/workbench/contrib/terminal/common/terminalConfiguration.ts
@@ -377,7 +377,7 @@ const terminalConfiguration: IConfigurationNode = {
 			scope: ConfigurationScope.RESOURCE
 		},
 		[TerminalSettingId.ConfirmOnExit]: {
-			description: localize('terminal.integrated.confirmOnExit', "Controls whether to confirm when the window closes if there are active terminal sessions.  Background terminals like those launched by some extensions will not trigger the confirmation."),
+			description: localize('terminal.integrated.confirmOnExit', "Controls whether to confirm when the window closes if there are active terminal sessions. Background terminals like those launched by some extensions will not trigger the confirmation."),
 			type: 'string',
 			enum: ['never', 'always', 'hasChildProcesses'],
 			enumDescriptions: [

--- a/src/vs/workbench/contrib/terminal/common/terminalConfiguration.ts
+++ b/src/vs/workbench/contrib/terminal/common/terminalConfiguration.ts
@@ -377,7 +377,7 @@ const terminalConfiguration: IConfigurationNode = {
 			scope: ConfigurationScope.RESOURCE
 		},
 		[TerminalSettingId.ConfirmOnExit]: {
-			description: localize('terminal.integrated.confirmOnExit', "Controls whether to confirm when the window closes if there are active terminal sessions."),
+			description: localize('terminal.integrated.confirmOnExit', "Controls whether to confirm when the window closes if there are active terminal sessions.  Background terminals like those launched by some extensions will not trigger the confirmation."),
 			type: 'string',
 			enum: ['never', 'always', 'hasChildProcesses'],
 			enumDescriptions: [


### PR DESCRIPTION
First of all, thank you so much for providing this fantastic editor 🙂 I use it basically every day and it's amazing. Thank you all guys, and keep up the good work!

This PR fixes https://github.com/microsoft/vscode/issues/235575.

Note that recently there was another PR (https://github.com/microsoft/vscode/pull/236588) that was supposed to fix it, but actually it didn't, because now we have this:

![image_2025-02-08_14-40-11](https://github.com/user-attachments/assets/2bba91bd-1bdf-4591-99da-7e3bc73af5a6)

The current PR should definitely fix this issue and avoid showing that popup message if there are no foreground terminals opened.

## How to test the changes

You can just try to open a **Python project** in a VSCode editor with the [Python extension](https://marketplace.visualstudio.com/items?itemName=ms-python.python) installed. That extension spawns **background terminals**, and those currently trigger the popup message of the screenshot I put above (when `terminal.integrated.confirmOnExit` is set to `always`). With my changes, that shouldn't happen anymore.