### PR TITLE
Fix `Show User Keybindings' option on Keyboard Shortcuts editor (fix #240068)

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/preferences.contribution.ts
+++ b/src/vs/workbench/contrib/preferences/browser/preferences.contribution.ts
@@ -901,7 +901,7 @@ class PreferencesActionsContribution extends Disposable implements IWorkbenchCon
 					]
 				});
 			}
-			run(accessor: ServicesAccessor, args: unknown[]) {
+			run(accessor: ServicesAccessor, ...args: unknown[]) {
 				const group = getEditorGroupFromArguments(accessor, args);
 				const editorPane = group?.activeEditorPane;
 				if (editorPane instanceof KeybindingsEditor) {


### PR DESCRIPTION
This PR fixes #240068