### PR TITLE
Diff editor: Correct `1 files` to `1 file`

### DIFF
--- a/src/vs/workbench/contrib/multiDiffEditor/browser/multiDiffEditorInput.ts
+++ b/src/vs/workbench/contrib/multiDiffEditor/browser/multiDiffEditorInput.ts
@@ -98,9 +98,9 @@ export class MultiDiffEditorInput extends EditorInput implements ILanguageSuppor
 			const resources = this.resources.read(reader);
 			const label = this.label ?? localize('name', "Multi Diff Editor");
 			if (resources && resources.length === 1) {
-				this._name = localize('nameWithOneFile', "{0} (1 file)", label);
+				this._name = localize({ key: 'nameWithOneFile', comment: ['{0} is the name of the editor'] }, "{0} (1 file)", label);
 			} else if (resources) {
-				this._name = localize({ key: 'nameWithFiles', comment: ['the name of the editor', 'the number of files being shown'] }, "{0} ({1} files)", label, resources.length);
+				this._name = localize({ key: 'nameWithFiles', comment: ['{0} is the name of the editor', '{1} is the number of files being shown'] }, "{0} ({1} files)", label, resources.length);
 			} else {
 				this._name = label;
 			}

--- a/src/vs/workbench/contrib/multiDiffEditor/browser/multiDiffEditorInput.ts
+++ b/src/vs/workbench/contrib/multiDiffEditor/browser/multiDiffEditorInput.ts
@@ -98,10 +98,10 @@ export class MultiDiffEditorInput extends EditorInput implements ILanguageSuppor
 			const resources = this.resources.read(reader);
 			const label = this.label ?? localize('name', "Multi Diff Editor");
 			if (resources) {
-				this._name = label + localize({
-					key: 'files',
-					comment: ['the number of files being shown']
-				}, " ({0} files)", resources.length);
+				const fileLabel = resources.length === 1 ?
+					localize({ key: 'file', comment: ['the number of files being shown'] }, " ({0} file)", resources.length) :
+					localize({ key: 'files', comment: ['the number of files being shown'] }, " ({0} files)", resources.length);
+				this._name = label + fileLabel;
 			} else {
 				this._name = label;
 			}

--- a/src/vs/workbench/contrib/multiDiffEditor/browser/multiDiffEditorInput.ts
+++ b/src/vs/workbench/contrib/multiDiffEditor/browser/multiDiffEditorInput.ts
@@ -97,11 +97,10 @@ export class MultiDiffEditorInput extends EditorInput implements ILanguageSuppor
 			/** @description Updates name */
 			const resources = this.resources.read(reader);
 			const label = this.label ?? localize('name', "Multi Diff Editor");
-			if (resources) {
-				const fileLabel = resources.length === 1 ?
-					localize({ key: 'file', comment: ['the number of files being shown'] }, " ({0} file)", resources.length) :
-					localize({ key: 'files', comment: ['the number of files being shown'] }, " ({0} files)", resources.length);
-				this._name = label + fileLabel;
+			if (resources && resources.length === 1) {
+				this._name = localize('nameWithOneFile', "{0} (1 file)", label);
+			} else if (resources) {
+				this._name = localize({ key: 'nameWithFiles', comment: ['the name of the editor', 'the number of files being shown'] }, "{0} ({1} files)", label, resources.length);
 			} else {
 				this._name = label;
 			}


### PR DESCRIPTION
Fix https://github.com/microsoft/vscode/issues/229483 
Introducing a new translation for when only one file exists in the diff editor so it prints 1 file instead of 1 files. 