### PR TITLE
remove chat response timeout

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatWidget.ts
@@ -1199,12 +1199,6 @@ export class ChatWidget extends Disposable implements IChatWidget {
 					}
 				});
 
-				const RESPONSE_TIMEOUT = 20000;
-				setTimeout(() => {
-					// Stop the signal if the promise is still unresolved
-					this.chatAccessibilityService.acceptResponse(undefined, requestId, options?.isVoiceInput);
-				}, RESPONSE_TIMEOUT);
-
 				return result.responseCreatedPromise;
 			}
 		}


### PR DESCRIPTION
Requests can take a really long time to come back. We want to keep playing this regardless of how long it takes. 

fix #239996