### PR TITLE
Fix for double paste when right click action on terminal - macOS

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
@@ -2328,7 +2328,16 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 				}
 				return;
 			}
+			// Ensure paste only executes once
+			if (rightClickBehavior === 'paste') {
+				if (!event.defaultPrevented) { // Check if the event has not been prevented already
+					event.preventDefault(); // Prevent default context menu
+					this._paste(); // Call paste function
+					return { cancelContextMenu: true }; // Ensure no duplicate context menu actions
+				}
+			}
 		}
+
 	}
 }
 


### PR DESCRIPTION
Fix for issue https://github.com/microsoft/vscode/issues/239877 where right click action on macOS was making double paste. 

This fix try to ensure the double paste is not triggered if having the right click.

Please let me know if the fix helps.