### PR TITLE
chat: polish agentic play/pause

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/chatMarkdownContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/chatMarkdownContentPart.ts
@@ -336,7 +336,7 @@ class CollapsedCodeBlock extends Disposable {
 
 		const iconText = this.labelService.getUriBasenameLabel(uri);
 		const modifiedEntry = this.chatEditingService.getEditingSession(this.sessionId)?.getEntry(uri);
-		const isComplete = !modifiedEntry?.isCurrentlyBeingModified.get();
+		const isComplete = !modifiedEntry?.isCurrentlyBeingModifiedBy.get();
 
 		let iconClasses: string[] = [];
 		if (isStreaming || !isComplete) {
@@ -365,7 +365,7 @@ class CollapsedCodeBlock extends Disposable {
 			const rewriteRatio = modifiedEntry?.rewriteRatio.read(r);
 
 			const labelDetail = this.element.querySelector('.label-detail');
-			const isComplete = !modifiedEntry?.isCurrentlyBeingModified.read(r);
+			const isComplete = !modifiedEntry?.isCurrentlyBeingModifiedBy.read(r);
 			if (labelDetail && !isStreaming && !isComplete) {
 				const value = rewriteRatio;
 				labelDetail.textContent = value === 0 || !value ? localize('chat.codeblock.applying', "Applying edits...") : localize('chat.codeblock.applyingPercentage', "Applying edits ({0}%)...", Math.round(value * 100));

--- a/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingEditorController.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingEditorController.ts
@@ -184,7 +184,7 @@ export class ChatEditorController extends Disposable implements IEditorContribut
 			}
 
 			// scrolling logic
-			if (entry.isCurrentlyBeingModified.read(r)) {
+			if (entry.isCurrentlyBeingModifiedBy.read(r)) {
 				// while modified: scroll along unless locked
 				if (!this._scrollLock) {
 					const maxLineNumber = entry.maxLineNumber.read(r);

--- a/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingEditorOverlay.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingEditorOverlay.ts
@@ -222,15 +222,22 @@ class ChatEditorOverlayWidget implements IOverlayWidget {
 		this._entry.set({ entry: activeEntry, next }, undefined);
 
 		this._showStore.add(autorun(r => {
-			const busy = activeEntry.isCurrentlyBeingModified.read(r);
-			this._domNode.classList.toggle('busy', busy);
+			const busy = activeEntry.isCurrentlyBeingModifiedBy.read(r);
+			this._domNode.classList.toggle('busy', !!busy);
 		}));
 
 		this._showStore.add(autorun(r => {
-			const value = activeEntry.rewriteRatio.read(r);
-			reset(this._progressNode, (value === 0
-				? localize('generating', "Generating Edits")
-				: localize('applyingPercentage', "{0}% Applying Edits", Math.round(value * 100))));
+			const paused = activeEntry.isCurrentlyBeingModifiedBy.read(r)?.isPaused.read(r);
+			const progress = activeEntry.rewriteRatio.read(r);
+
+			const text = paused
+				? localize('paused', "Edits Paused")
+				: progress === 0
+					? localize('generating', "Generating Edits")
+					: localize('applyingPercentage', "{0}% Applying Edits", Math.round(progress * 100));
+
+			this._domNode.classList.toggle('paused', !!paused);
+			reset(this._progressNode, text);
 		}));
 
 		this._showStore.add(autorun(r => {

--- a/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingModifiedFileEntry.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingModifiedFileEntry.ts
@@ -36,6 +36,7 @@ import { SaveReason } from '../../../../common/editor.js';
 import { IResolvedTextFileEditorModel, stringToSnapshot } from '../../../../services/textfile/common/textfiles.js';
 import { IChatAgentResult } from '../../common/chatAgents.js';
 import { ChatEditKind, IModifiedFileEntry, WorkingSetEntryState } from '../../common/chatEditingService.js';
+import { IChatResponseModel } from '../../common/chatModel.js';
 import { IChatService } from '../../common/chatService.js';
 import { ChatEditingSnapshotTextModelContentProvider, ChatEditingTextModelContentProvider } from './chatEditingTextModelContentProviders.js';
 
@@ -85,9 +86,9 @@ export class ChatEditingModifiedFileEntry extends Disposable implements IModifie
 		return this._stateObs;
 	}
 
-	private readonly _isCurrentlyBeingModifiedObs = observableValue<boolean>(this, false);
-	public get isCurrentlyBeingModified(): IObservable<boolean> {
-		return this._isCurrentlyBeingModifiedObs;
+	private readonly _isCurrentlyBeingModifiedByObs = observableValue<IChatResponseModel | undefined>(this, undefined);
+	public get isCurrentlyBeingModifiedBy(): IObservable<IChatResponseModel | undefined> {
+		return this._isCurrentlyBeingModifiedByObs;
 	}
 
 	private readonly _rewriteRatioObs = observableValue<number>(this, 0);
@@ -330,7 +331,7 @@ export class ChatEditingModifiedFileEntry extends Disposable implements IModifie
 	}
 
 	private _resetEditsState(tx: ITransaction): void {
-		this._isCurrentlyBeingModifiedObs.set(false, tx);
+		this._isCurrentlyBeingModifiedByObs.set(undefined, tx);
 		this._rewriteRatioObs.set(0, tx);
 		this._clearCurrentEditLineDecoration();
 	}
@@ -379,7 +380,7 @@ export class ChatEditingModifiedFileEntry extends Disposable implements IModifie
 			this._updateDiffInfoSeq();
 		}
 
-		if (!this.isCurrentlyBeingModified.get()) {
+		if (!this.isCurrentlyBeingModifiedBy.get()) {
 			const didResetToOriginalContent = this.doc.getValue() === this.initialContent;
 			const currentState = this._stateObs.get();
 			switch (currentState) {
@@ -392,7 +393,7 @@ export class ChatEditingModifiedFileEntry extends Disposable implements IModifie
 		}
 	}
 
-	acceptAgentEdits(textEdits: TextEdit[], isLastEdits: boolean): void {
+	acceptAgentEdits(textEdits: TextEdit[], isLastEdits: boolean, responseModel: IChatResponseModel): void {
 
 
 		// push stack element for the first edit
@@ -430,7 +431,7 @@ export class ChatEditingModifiedFileEntry extends Disposable implements IModifie
 		transaction((tx) => {
 			if (!isLastEdits) {
 				this._stateObs.set(WorkingSetEntryState.Modified, tx);
-				this._isCurrentlyBeingModifiedObs.set(true, tx);
+				this._isCurrentlyBeingModifiedByObs.set(responseModel, tx);
 				const lineCount = this.doc.getLineCount();
 				this._rewriteRatioObs.set(Math.min(1, maxLineNumber / lineCount), tx);
 				this._maxLineNumberObs.set(maxLineNumber, tx);

--- a/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingServiceImpl.ts
@@ -446,12 +446,12 @@ class ChatDecorationsProvider extends Disposable implements IDecorationsProvider
 
 	private readonly _currentlyEditingUris = derived<URI[]>(this, (r) => {
 		const uri = this._currentEntries.read(r);
-		return uri.filter(entry => entry.isCurrentlyBeingModified.read(r)).map(entry => entry.modifiedURI);
+		return uri.filter(entry => entry.isCurrentlyBeingModifiedBy.read(r)).map(entry => entry.modifiedURI);
 	});
 
 	private readonly _modifiedUris = derived<URI[]>(this, (r) => {
 		const uri = this._currentEntries.read(r);
-		return uri.filter(entry => !entry.isCurrentlyBeingModified.read(r) && entry.state.read(r) === WorkingSetEntryState.Modified).map(entry => entry.modifiedURI);
+		return uri.filter(entry => !entry.isCurrentlyBeingModifiedBy.read(r) && entry.state.read(r) === WorkingSetEntryState.Modified).map(entry => entry.modifiedURI);
 	});
 
 	public readonly onDidChange = Event.any(

--- a/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingSession.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingSession.ts
@@ -731,7 +731,7 @@ export class ChatEditingSession extends Disposable implements IChatEditingSessio
 			get result() { return responseModel.result; }
 		};
 		const entry = await this._getOrCreateModifiedFileEntry(resource, telemetryInfo);
-		entry.acceptAgentEdits(textEdits, isLastEdits);
+		entry.acceptAgentEdits(textEdits, isLastEdits, responseModel);
 	}
 
 	private async _resolve(): Promise<void> {

--- a/src/vs/workbench/contrib/chat/browser/chatListRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatListRenderer.ts
@@ -187,16 +187,18 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 	 * Compute a rate to render at in words/s.
 	 */
 	private getProgressiveRenderRate(element: IChatResponseViewModel): number {
-		if (element.isComplete) {
-			return 80;
+		const enum Rate {
+			Min = 5,
+			Max = 80,
+		}
+
+		if (element.isComplete || element.isPaused.get()) {
+			return Rate.Max;
 		}
 
 		if (element.contentUpdateTimings && element.contentUpdateTimings.impliedWordLoadRate) {
-			const minRate = 5;
-			const maxRate = 80;
-
 			const rate = element.contentUpdateTimings.impliedWordLoadRate;
-			return clamp(rate, minRate, maxRate);
+			return clamp(rate, Rate.Min, Rate.Max);
 		}
 
 		return 8;
@@ -386,7 +388,7 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 		templateData.rowContainer.classList.toggle('editing-session', this.chatWidgetService.getWidgetBySessionId(element.sessionId)?.location === ChatAgentLocation.EditingSession);
 		templateData.rowContainer.classList.toggle('interactive-request', isRequestVM(element));
 		templateData.rowContainer.classList.toggle('interactive-response', isResponseVM(element));
-		templateData.rowContainer.classList.toggle('show-detail-progress', isResponseVM(element) && !element.isComplete && !element.progressMessages.length);
+		templateData.rowContainer.classList.toggle('show-detail-progress', isResponseVM(element) && !element.isComplete && !element.progressMessages.length && !element.model.isPaused.get());
 		templateData.username.textContent = element.username;
 		if (!this.rendererOptions.noHeader) {
 			this.renderAvatar(element, templateData);
@@ -457,8 +459,12 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 				}
 			}));
 
-		} else if (!element.isComplete && this.rendererOptions.renderStyle !== 'minimal') {
-			templateData.detail.textContent = localize('generating', "Generating");
+		} else if (this.rendererOptions.renderStyle !== 'minimal') {
+			if (element.model.isPaused.get()) {
+				templateData.detail.textContent = localize('paused', "Paused");
+			} else {
+				templateData.detail.textContent = localize('generating', "Generating");
+			}
 		}
 	}
 

--- a/src/vs/workbench/contrib/chat/browser/media/chatEditorOverlay.css
+++ b/src/vs/workbench/contrib/chat/browser/media/chatEditorOverlay.css
@@ -78,6 +78,16 @@
 	animation: ellipsis steps(4, end) 1s infinite;
 }
 
+.chat-editor-overlay-widget.busy.paused .chat-editor-overlay-progress {
+	.codicon-loading {
+		display: none;
+	}
+
+	.busy-label::after {
+		animation-duration: 5s;
+	}
+}
+
 .chat-editor-overlay-widget.busy .chat-editor-overlay-toolbar {
 	display: none;
 }

--- a/src/vs/workbench/contrib/chat/common/chatEditingService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatEditingService.ts
@@ -133,7 +133,7 @@ export interface IModifiedFileEntry {
 	readonly originalModel: ITextModel;
 	readonly modifiedURI: URI;
 	readonly state: IObservable<WorkingSetEntryState>;
-	readonly isCurrentlyBeingModified: IObservable<boolean>;
+	readonly isCurrentlyBeingModifiedBy: IObservable<IChatResponseModel | undefined>;
 	readonly rewriteRatio: IObservable<number>;
 	readonly maxLineNumber: IObservable<number>;
 	readonly diffInfo: IObservable<IDocumentDiff>;

--- a/src/vs/workbench/contrib/chat/common/chatViewModel.ts
+++ b/src/vs/workbench/contrib/chat/common/chatViewModel.ts
@@ -4,9 +4,11 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Emitter, Event } from '../../../../base/common/event.js';
+import { hash } from '../../../../base/common/hash.js';
 import { IMarkdownString } from '../../../../base/common/htmlContent.js';
 import { Disposable, dispose } from '../../../../base/common/lifecycle.js';
 import * as marked from '../../../../base/common/marked/marked.js';
+import { IObservable } from '../../../../base/common/observable.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
 import { URI } from '../../../../base/common/uri.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
@@ -18,7 +20,6 @@ import { IParsedChatRequest } from './chatParserTypes.js';
 import { ChatAgentVoteDirection, ChatAgentVoteDownReason, IChatCodeCitation, IChatContentReference, IChatFollowup, IChatProgressMessage, IChatResponseErrorDetails, IChatTask, IChatUsedContext } from './chatService.js';
 import { countWords } from './chatWordCounter.js';
 import { CodeBlockModelCollection } from './codeBlockModelCollection.js';
-import { hash } from '../../../../base/common/hash.js';
 
 export function isRequestVM(item: unknown): item is IChatRequestViewModel {
 	return !!item && typeof item === 'object' && 'message' in item;
@@ -183,6 +184,7 @@ export interface IChatResponseViewModel {
 	readonly contentUpdateTimings?: IChatLiveUpdateData;
 	readonly shouldBeRemovedOnSend: boolean;
 	readonly isCompleteAddedRequest: boolean;
+	readonly isPaused: IObservable<boolean>;
 	renderData?: IChatResponseRenderData;
 	currentRenderedHeight: number | undefined;
 	setVote(vote: ChatAgentVoteDirection): void;
@@ -557,6 +559,10 @@ export class ChatResponseViewModel extends Disposable implements IChatResponseVi
 	private _contentUpdateTimings: IChatLiveUpdateData | undefined = undefined;
 	get contentUpdateTimings(): IChatLiveUpdateData | undefined {
 		return this._contentUpdateTimings;
+	}
+
+	get isPaused() {
+		return this._model.isPaused;
 	}
 
 	constructor(

--- a/src/vs/workbench/contrib/chat/common/tools/editFileTool.ts
+++ b/src/vs/workbench/contrib/chat/common/tools/editFileTool.ts
@@ -140,7 +140,7 @@ export class EditTool implements IToolImpl {
 				const entries = editSession.entries.read(r);
 				const currentFile = entries?.find((e) => e.modifiedURI.toString() === uri.toString());
 				if (currentFile) {
-					if (currentFile.isCurrentlyBeingModified.read(r)) {
+					if (currentFile.isCurrentlyBeingModifiedBy.read(r)) {
 						wasFileBeingModified = true;
 					} else if (wasFileBeingModified) {
 						resolve(true);


### PR DESCRIPTION
- "Generating" text says "Paused" when paused
- Markdown writes out quickly/immdiately when paused
- Edits are paused and the editor overlay reflects it
- Response pause actually happens at the response level, so even if
  an extension/tool doesn't support pausing, it will have the right UI effect

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
