### PR TITLE
Resolve vim flicker issues to maintain consistent behavior during WH delay setting changes

### DIFF
--- a/src/vs/editor/contrib/wordHighlighter/browser/wordHighlighter.ts
+++ b/src/vs/editor/contrib/wordHighlighter/browser/wordHighlighter.ts
@@ -358,18 +358,18 @@ class WordHighlighter {
 		return (this.decorations.length > 0);
 	}
 
-	public restore(): void {
+	public restore(delay: number): void {
 		if (this.occurrencesHighlightEnablement === 'off') {
 			return;
 		}
 
 		this.runDelayer.cancel();
-		this._run();
+		this.runDelayer.trigger(() => { this._run(false, delay); });
 	}
 
 	public trigger() {
 		this.runDelayer.cancel();
-		this._run(false, true); // immediate rendering (noDelay = true)
+		this._run(false, 0); // immediate rendering (delay = 0)
 	}
 
 	public stop(): void {
@@ -548,7 +548,7 @@ class WordHighlighter {
 
 		// ignore typing & other
 		// need to check if the model is a notebook cell, should not stop if nb
-		if (e.reason !== CursorChangeReason.Explicit && this.editor.getModel()?.uri.scheme !== Schemas.vscodeNotebookCell) {
+		if (e.source !== 'api' && e.reason !== CursorChangeReason.Explicit && this.editor.getModel()?.uri.scheme !== Schemas.vscodeNotebookCell) {
 			this._stopAll();
 			return;
 		}
@@ -631,7 +631,7 @@ class WordHighlighter {
 		return currentModels;
 	}
 
-	private async _run(multiFileConfigChange?: boolean, noDelay?: boolean): Promise<void> {
+	private async _run(multiFileConfigChange?: boolean, delay?: number): Promise<void> {
 
 		const hasTextFocus = this.editor.hasTextFocus();
 		if (!hasTextFocus) { // new nb cell scrolled in, didChangeModel fires
@@ -710,7 +710,7 @@ class WordHighlighter {
 					if (myRequestId === this.workerRequestTokenId) {
 						this.workerRequestCompleted = true;
 						this.workerRequestValue = data || [];
-						this._beginRenderDecorations();
+						this._beginRenderDecorations(delay ?? this.occurrencesHighlightDelay);
 					}
 				}, onUnexpectedError);
 			} catch (e) {
@@ -721,8 +721,6 @@ class WordHighlighter {
 
 		} else if (this.model.uri.scheme === Schemas.vscodeNotebookCell) {
 			// new wordHighlighter coming from a different model, NOT the query model, need to create a textModel ref
-
-			// this._stopAll(multiFileConfigChange ? this.model.uri : undefined);
 
 			const myRequestId = ++this.workerRequestTokenId;
 			this.workerRequestCompleted = false;
@@ -738,7 +736,7 @@ class WordHighlighter {
 					if (myRequestId === this.workerRequestTokenId) {
 						this.workerRequestCompleted = true;
 						this.workerRequestValue = data || [];
-						this._beginRenderDecorations(noDelay);
+						this._beginRenderDecorations(delay ?? this.occurrencesHighlightDelay);
 					}
 				}, onUnexpectedError);
 			} catch (e) {
@@ -757,9 +755,9 @@ class WordHighlighter {
 		}
 	}
 
-	private _beginRenderDecorations(noDelay?: boolean): void {
+	private _beginRenderDecorations(delay: number): void {
 		const currentTime = (new Date()).getTime();
-		const minimumRenderTime = this.lastCursorPositionChangeTime + (noDelay ? 0 : this.occurrencesHighlightDelay);
+		const minimumRenderTime = this.lastCursorPositionChangeTime + delay;
 
 		if (currentTime >= minimumRenderTime) {
 			// Synchronous
@@ -886,7 +884,7 @@ export class WordHighlighterContribution extends Disposable implements IEditorCo
 
 	public restoreViewState(state: boolean | undefined): void {
 		if (this._wordHighlighter && state) {
-			this._wordHighlighter.restore();
+			this._wordHighlighter.restore(250); // 250 ms delay to restoring view state, since only exts call this
 		}
 	}
 


### PR DESCRIPTION
Fixes: https://github.com/microsoft/vscode-internalbacklog/issues/5228
(Vim extension + editor.occurrencesHighlightDelay: 0 causes flickering)

cc/ @ulugbekna 

status for vim users:
- currently vim uses an explicit wordhighlight trigger which is no longer necessary. This explicit trigger requires a 250ms delay, meaning that they will not experience the positive effects of the configurable delay, even if the setting lowered to `0`
- if vim wants to take advantage of the configurable delay, they must patch the extension to avoid using the explicit `executeCommand(wordhighlight.trigger)` call.
  - Should be able to just remove [this block from the VSCodeVim extension](https://github.com/VSCodeVim/Vim/blob/4b8237b4ddb5740c558bf18a54dc11102ba8e4a7/src/mode/modeHandler.ts#L1740-L1748). Tested via commenting out the contents of [this function in VS Code core](https://github.com/microsoft/vscode/blob/6b1457b60d5d7cf24d36cba1001fc28572c6482f/src/vs/editor/contrib/wordHighlighter/browser/wordHighlighter.ts#L886-L888).

on allowing `api` source to trigger highlight requests:
- allowing api sources to trigger wordhighlight requests is necessary for the vim extension to trigger requests upon arrow key navigation. the vim extension correctly produces a cursor change event, however it passes the `api` source instead of the `keyboard` source. In the past, we filtered out the `api` source which forced vim to make use of `executeCommand(wh.trigger)`. If the vim extension moves off of the explicit trigger call without us allowing api sources through, we are effectively breaking the experience again.
- At the moment, this PR seems like the safest path forward which would:
  - A- not create any broken behavior with a setting migration to 0 delay by default
  - B- allow vim to patch out the explicit trigger call without breaking cursor navigation highlighting