### PR TITLE
Imporve chat edits accessibility

### DIFF
--- a/src/vs/platform/accessibilitySignal/browser/accessibilitySignalService.ts
+++ b/src/vs/platform/accessibilitySignal/browser/accessibilitySignalService.ts
@@ -541,6 +541,13 @@ export class AccessibilitySignal {
 		settingsKey: 'accessibility.signals.diffLineModified',
 	});
 
+	public static readonly chatEditModifiedFile = AccessibilitySignal.register({
+		name: localize('accessibilitySignals.chatEditModifiedFile', 'Chat Edit Modified File'),
+		sound: Sound.success,
+		announcementMessage: localize('accessibility.signals.chatEditModifiedFile', 'File Modified from Chat Edits'),
+		settingsKey: 'accessibility.signals.chatEditModifiedFile',
+	});
+
 	public static readonly chatRequestSent = AccessibilitySignal.register({
 		name: localize('accessibilitySignals.chatRequestSent', 'Chat Request Sent'),
 		sound: Sound.requestSent,
@@ -631,4 +638,3 @@ export class AccessibilitySignal {
 		settingsKey: 'accessibility.signals.voiceRecordingStopped'
 	});
 }
-

--- a/src/vs/workbench/contrib/accessibility/browser/accessibilityConfiguration.ts
+++ b/src/vs/workbench/contrib/accessibility/browser/accessibilityConfiguration.ts
@@ -506,6 +506,16 @@ const configuration: IConfigurationNode = {
 				}
 			}
 		},
+		'accessibility.signals.chatEditModifiedFile': {
+			...defaultNoAnnouncement,
+			'description': localize('accessibility.signals.chatEditModifiedFile', "Plays a sound / audio cue when revealing a file with changes from chat edits"),
+			'properties': {
+				'sound': {
+					'description': localize('accessibility.signals.chatEditModifiedFile.sound', "Plays a sound when revealing a file with changes from chat edits"),
+					...soundFeatureBase
+				}
+			}
+		},
 		'accessibility.signals.notebookCellCompleted': {
 			...signalFeatureBase,
 			'description': localize('accessibility.signals.notebookCellCompleted', "Plays a signal - sound (audio cue) and/or announcement (alert) - when a notebook cell execution is successfully completed."),

--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -68,6 +68,7 @@ import { ChatAccessibilityService } from './chatAccessibilityService.js';
 import './chatAttachmentModel.js';
 import { ChatMarkdownAnchorService, IChatMarkdownAnchorService } from './chatContentParts/chatMarkdownAnchorService.js';
 import { ChatInputBoxContentProvider } from './chatEdinputInputContentProvider.js';
+import { ChatEditingEditorAccessibility } from './chatEditing/chatEditingEditorAccessibility.js';
 import { registerChatEditorActions } from './chatEditing/chatEditingEditorActions.js';
 import { ChatEditorController } from './chatEditing/chatEditingEditorController.js';
 import { ChatEditorOverlayController } from './chatEditing/chatEditingEditorOverlay.js';
@@ -392,6 +393,7 @@ registerWorkbenchContribution2(ChatSetupContribution.ID, ChatSetupContribution, 
 registerWorkbenchContribution2(ChatQuotasStatusBarEntry.ID, ChatQuotasStatusBarEntry, WorkbenchPhase.Eventually);
 registerWorkbenchContribution2(BuiltinToolsContribution.ID, BuiltinToolsContribution, WorkbenchPhase.Eventually);
 registerWorkbenchContribution2(ChatAgentSettingContribution.ID, ChatAgentSettingContribution, WorkbenchPhase.BlockRestore);
+registerWorkbenchContribution2(ChatEditingEditorAccessibility.ID, ChatEditingEditorAccessibility, WorkbenchPhase.AfterRestored);
 
 registerChatActions();
 registerChatCopyActions();

--- a/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingEditorAccessibility.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingEditorAccessibility.ts
@@ -1,0 +1,44 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { DisposableStore } from '../../../../../base/common/lifecycle.js';
+import { autorun, observableFromEvent } from '../../../../../base/common/observable.js';
+import { AccessibilitySignal, IAccessibilitySignalService } from '../../../../../platform/accessibilitySignal/browser/accessibilitySignalService.js';
+import { IWorkbenchContribution } from '../../../../common/contributions.js';
+import { IEditorService } from '../../../../services/editor/common/editorService.js';
+import { IChatEditingService } from '../../common/chatEditingService.js';
+
+export class ChatEditingEditorAccessibility implements IWorkbenchContribution {
+
+	static readonly ID = 'chat.edits.accessibilty';
+
+	private readonly _store = new DisposableStore();
+
+	constructor(
+		@IChatEditingService chatEditingService: IChatEditingService,
+		@IEditorService editorService: IEditorService,
+		@IAccessibilitySignalService accessibilityService: IAccessibilitySignalService
+	) {
+
+		const activeUri = observableFromEvent(this, editorService.onDidActiveEditorChange, () => editorService.activeEditorPane?.input.resource);
+
+		this._store.add(autorun(r => {
+
+			const editor = activeUri.read(r);
+			if (!editor) {
+				return;
+			}
+
+			const entry = chatEditingService.editingSessionsObs.read(r).find(session => session.readEntry(editor, r));
+			if (entry) {
+				accessibilityService.playSignal(AccessibilitySignal.chatEditModifiedFile);
+			}
+		}));
+	}
+
+	dispose(): void {
+		this._store.dispose();
+	}
+}

--- a/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingEditorController.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingEditorController.ts
@@ -38,6 +38,8 @@ import { EditorsOrder, IEditorIdentifier, isDiffEditorInput } from '../../../../
 import { ChatEditorOverlayController } from './chatEditingEditorOverlay.js';
 import { IChatService } from '../../common/chatService.js';
 import { StableEditorScrollState } from '../../../../../editor/browser/stableEditorScroll.js';
+import { AccessibilitySignal, IAccessibilitySignalService } from '../../../../../platform/accessibilitySignal/browser/accessibilitySignalService.js';
+import { TextEditorSelectionRevealType } from '../../../../../platform/editor/common/editor.js';
 
 export const ctxIsGlobalEditingSession = new RawContextKey<boolean>('chat.isGlobalEditingSession', undefined, localize('chat.ctxEditSessionIsGlobal', "The current editor is part of the global edit session"));
 export const ctxHasEditorModification = new RawContextKey<boolean>('chat.hasEditorModifications', undefined, localize('chat.hasEditorModifications', "The current editor contains chat modifications"));
@@ -83,6 +85,7 @@ export class ChatEditorController extends Disposable implements IEditorContribut
 		@IInstantiationService private readonly _instantiationService: IInstantiationService,
 		@IChatAgentService private readonly _chatAgentService: IChatAgentService,
 		@IEditorService private readonly _editorService: IEditorService,
+		@IAccessibilitySignalService private readonly _accessibilitySignalsService: IAccessibilitySignalService,
 		@IContextKeyService contextKeyService: IContextKeyService,
 		@IChatService chatService: IChatService,
 	) {
@@ -572,10 +575,18 @@ export class ChatEditorController extends Disposable implements IEditorContribut
 
 		this._currentChangeIndex.set(target, undefined);
 
-		const targetPosition = next ? decorations[target].getStartPosition() : decorations[target].getEndPosition();
+
+		const targetRange = decorations[target];
+		const targetPosition = next ? targetRange.getStartPosition() : targetRange.getEndPosition();
 		this._editor.setPosition(targetPosition);
 		this._editor.revealPositionInCenter(targetPosition, scrollType);
 		this._editor.focus();
+
+		if (targetRange.isEmpty()) {
+			this._accessibilitySignalsService.playSignal(AccessibilitySignal.diffLineDeleted);
+		} else {
+			this._accessibilitySignalsService.playSignal(AccessibilitySignal.diffLineModified);
+		}
 
 		return true;
 	}
@@ -635,22 +646,6 @@ export class ChatEditorController extends Disposable implements IEditorContribut
 			return;
 		}
 
-		const lineRelativeTop = this._editor.getTopForLineNumber(this._editor.getPosition().lineNumber) - this._editor.getScrollTop();
-		let closestDistance = Number.MAX_VALUE;
-
-		if (!(widget instanceof DiffHunkWidget)) {
-			for (const candidate of this._diffHunkWidgets) {
-				const widgetTop = (<IOverlayWidgetPositionCoordinates | undefined>candidate.getPosition()?.preference)?.top;
-				if (widgetTop !== undefined) {
-					const distance = Math.abs(widgetTop - lineRelativeTop);
-					if (distance < closestDistance) {
-						closestDistance = distance;
-						widget = candidate;
-					}
-				}
-			}
-		}
-
 		let selection = this._editor.getSelection();
 		if (widget instanceof DiffHunkWidget) {
 			const lineNumber = widget.getStartLineNumber();
@@ -664,7 +659,13 @@ export class ChatEditorController extends Disposable implements IEditorContribut
 
 		if (isDiffEditor) {
 			// normal EDITOR
-			await this._editorService.openEditor({ resource: entry.modifiedURI });
+			await this._editorService.openEditor({
+				resource: entry.modifiedURI,
+				options: {
+					selection,
+					selectionRevealType: TextEditorSelectionRevealType.NearTopIfOutsideViewport
+				}
+			});
 
 		} else {
 			// DIFF editor


### PR DESCRIPTION
* add audio cue for "editor has chat edits"
* play audio cue when navigating chat edits
* for toggleDiff use/trust selection when not hunk widget is present

re https://github.com/microsoft/vscode-copilot/issues/10336