### PR TITLE
Preserve --disable-extensions in extension host development

### DIFF
--- a/src/vs/platform/windows/electron-main/windowsMainService.ts
+++ b/src/vs/platform/windows/electron-main/windowsMainService.ts
@@ -1579,6 +1579,7 @@ export class WindowsMainService extends Disposable implements IWindowsMainServic
 				configuration.extensionEnvironment = currentWindowConfig.extensionEnvironment;
 				configuration['extensions-dir'] = currentWindowConfig['extensions-dir'];
 				configuration['disable-extensions'] = currentWindowConfig['disable-extensions'];
+				configuration['disable-extension'] = currentWindowConfig['disable-extension'];
 			}
 			configuration.loggers = configuration.loggers;
 		}


### PR DESCRIPTION
This is a follow-up to #151872; `--disable-extensions` is preserved, but individually disabled extensions are not preserved, which makes opening new folders in extension dev pretty annoying.