### PR TITLE
[regression] Most `"configurationDefaults"` settings no longer work on VSCode reload (fix #231224)

### DIFF
--- a/src/vs/editor/common/services/textResourceConfigurationService.ts
+++ b/src/vs/editor/common/services/textResourceConfigurationService.ts
@@ -106,7 +106,14 @@ export class TextResourceConfigurationService extends Disposable implements ITex
 			affectedKeys: configurationChangeEvent.affectedKeys,
 			affectsConfiguration: (resource: URI | undefined, configuration: string) => {
 				const overrideIdentifier = resource ? this.getLanguage(resource, null) : undefined;
-				return configurationChangeEvent.affectsConfiguration(configuration, { resource, overrideIdentifier });
+				if (configurationChangeEvent.affectsConfiguration(configuration, { resource, overrideIdentifier })) {
+					return true;
+				}
+				if (overrideIdentifier) {
+					//TODO@bpasero workaround for https://github.com/microsoft/vscode/issues/240410
+					return configurationChangeEvent.affectedKeys.has(`[${overrideIdentifier}]`);
+				}
+				return false;
 			}
 		};
 	}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
