### PR TITLE
retain default prompts location for overwritten config values

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatAttachmentModel/chatInstructionsFileLocator.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatAttachmentModel/chatInstructionsFileLocator.ts
@@ -13,7 +13,7 @@ import { IWorkspaceContextService } from '../../../../../platform/workspace/comm
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 
 /**
- * Class to locate prompt instructions files.
+ * Class to locate prompt files.
  */
 export class ChatInstructionsFileLocator {
 	constructor(
@@ -23,10 +23,10 @@ export class ChatInstructionsFileLocator {
 	) { }
 
 	/**
-	 * List all prompt instructions files from the filesystem.
+	 * List all prompt files from the filesystem.
 	 *
 	 * @param exclude List of `URIs` to exclude from the result.
-	 * @returns List of prompt instructions files found in the workspace.
+	 * @returns List of prompt files found in the workspace.
 	 */
 	public async listFiles(exclude: ReadonlyArray<URI>): Promise<readonly URI[]> {
 		// create a set from the list of URIs for convenience
@@ -45,10 +45,10 @@ export class ChatInstructionsFileLocator {
 	}
 
 	/**
-	 * Get all possible prompt instructions file locations based on the current
+	 * Get all possible prompt file locations based on the current
 	 * workspace folder structure.
 	 *
-	 * @returns List of possible prompt instructions file locations.
+	 * @returns List of possible prompt file locations.
 	 */
 	private getSourceLocations(): readonly URI[] {
 		const paths = new ResourceSet();
@@ -106,11 +106,11 @@ export class ChatInstructionsFileLocator {
 	}
 
 	/**
-	 * Finds all existent prompt instruction files in the provided locations.
+	 * Finds all existent prompt files in the provided locations.
 	 *
-	 * @param locations List of locations to search for prompt instruction files in.
+	 * @param locations List of locations to search for prompt files in.
 	 * @param exclude Map of `path -> boolean` to exclude from the result.
-	 * @returns List of prompt instruction files found in the provided locations.
+	 * @returns List of prompt files found in the provided locations.
 	 */
 	private async findInstructionFiles(
 		locations: readonly URI[],

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/config.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/config.ts
@@ -260,13 +260,14 @@ export namespace PromptFilesConfig {
 	const usageExample1 = nls.localize(
 		`chat.promptFiles.config.description.example1`,
 		"Enable with the default location of prompt files (`{0}`):\n{1}",
-		DEFAULT_LOCATION[0],
+		DEFAULT_LOCATION,
 		`\`\`\`json\n{\n  "${CONFIG_KEY}": true,\n}\n\`\`\``,
 	);
 	const usageExample2 = nls.localize(
 		`chat.promptFiles.config.description.example2`,
-		"Specify custom location(s) of prompt files:\n{0}",
-		`\`\`\`json\n{\n  "${CONFIG_KEY}": {\n    ".github/prompts": true,\n    "/Users/vscode/prompts": true,\n}\n\`\`\``,
+		"Specify custom location(s) of prompt files (in addition to `{0}`):\n{1}",
+		DEFAULT_LOCATION,
+		`\`\`\`json\n{\n  "${CONFIG_KEY}": {\n    ".copilot/prompts": true,\n    "/Users/vscode/prompts": true,\n}\n\`\`\``,
 	);
 
 	/**
@@ -274,10 +275,10 @@ export namespace PromptFilesConfig {
 	 */
 	export const CONFIG_DESCRIPTION = nls.localize(
 		'chat.promptFiles.config.description',
-		"Enable support for attaching reusable prompt files (`*{0}`) for Chat, Edits, and Inline Chat sessions. [Learn More]({1}).\n\nSet to `true` or use the `{ \"/path/to/folder\": boolean }` notation to specify a different path (or multiple). Relative paths are resolved from the root folder(s) of your workspace, and the default value of `{2}` is used if no other paths provided.\n#### Examples\n{3}\n{4}",
+		"Enable support for attaching reusable prompt files (`*{0}`) for Chat, Edits, and Inline Chat sessions. [Learn More]({1}).\n\nSet to `true` or use the `{ \"/path/to/folder\": boolean }` notation to specify a different path (or multiple). Relative paths are resolved from the root folder(s) of your workspace, and the `{2}` path is used by default and in addition to provided custom locations.\n#### Examples\n{3}\n{4}",
 		PROMPT_FILE_EXTENSION,
 		DOCUMENTATION_URL,
-		DEFAULT_LOCATION[0],
+		DEFAULT_LOCATION,
 		usageExample1,
 		usageExample2,
 	);

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/config.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/config.ts
@@ -10,9 +10,6 @@ import { IConfigurationService } from '../../../../../platform/configuration/com
 /**
  * TODO: @legomushroom
  *  - update `config` docs comment
- *  - update `config` unit tests
- *  - update `file locator` docs comment
- *  - update `file locator` unit tests
  */
 
 /**

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/config.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/config.ts
@@ -8,11 +8,6 @@ import { DOCUMENTATION_URL, PROMPT_FILE_EXTENSION } from './constants.js';
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 
 /**
- * TODO: @legomushroom
- *  - update `config` docs comment
- */
-
-/**
  * Configuration helper for the `prompt files` feature.
  * @see {@link CONFIG_KEY} and {@link DEFAULT_LOCATION}
  *
@@ -32,29 +27,30 @@ import { IConfigurationService } from '../../../../../platform/configuration/com
  * }
  * ```
  *
- * Enable the feature, specifying a single prompt files source folder location:
+ * Enable the feature, specifying a single prompt files source folder location,
+ * in addition to the default `'.github/prompts'` one:
  * ```json
  * {
- *   "chat.promptFiles": '.github/prompts',
+ *   "chat.promptFiles": '.copilot/prompts',
  * }
  * ```
  *
- * Enable the feature, specifying multiple prompt files source folder location:
+ * Enable the feature, specifying multiple prompt files source folder locations,
+ * in addition to the default `'.github/prompts'` one:
  * ```json
  * {
  *   "chat.promptFiles": {
- *     ".github/prompts" : true,
  *     ".copilot/prompts" : false,
  *     "/Users/legomushroom/repos/prompts" : true,
  *   },
  * }
  * ```
  *
- * Enable the feature, specifying multiple prompt files source folder location:
+ * Enable the feature, specifying multiple prompt files source folder locations,
+ * in addition to the default `'.github/prompts'` one:
  * ```json
  * {
  *   "chat.promptFiles": [
- *     ".github/prompts",
  *     ".copilot/prompts",
  *     "/Users/legomushroom/repos/prompts",
  *   ],
@@ -63,15 +59,15 @@ import { IConfigurationService } from '../../../../../platform/configuration/com
  *
  * The "array" case is similar to the "object" one, but there is one difference.
  * At the time of writing, configuration settings with the `array` value cannot
- * be merged into a single entry when the setting is specified in both the user
- * and the workspace settings. On the other hand, the "object" case is provides
- * flexibility - the settings are combined into a single object.
+ * be merged into a single entry when the setting is specified in both the `user`
+ * and the `workspace` settings. On the other hand, the "object" case provides
+ * more flexibility - the settings are combined into a single object.
  *
  * Enable the feature, using defaults for prompt files source folder locations
  * (see {@link DEFAULT_LOCATION}):
- * ```json
+ * ```jsonc
  * {
- *   "chat.promptFiles": {},
+ *   "chat.promptFiles": {}, // same as setting to `true`
  * }
  * ```
  *
@@ -87,20 +83,24 @@ import { IConfigurationService } from '../../../../../platform/configuration/com
  * - `string`:
  *   - values that can be mapped to `boolean`(`"true"`, `"FALSE", "TrUe"`, etc.)
  *     are treated the same as the `boolean` case above
- *   - any other `non-empty` string value is treated as a single prompt files source folder path
- *   - `empty` string value is treated the same as the `undefined`/`null` case above
+ *   - any other `non-empty` string value is treated as a single prompt files source folder path,
+ *     which is used in addition to the default {@link DEFAULT_LOCATION}
+ *   - `empty` string value is treated the same as the `undefined`/`null` case above (disabled)
  * - `object`:
  *   - expects the { "string": `boolean` } pairs, where the `string` is a path and the `boolean`
- *     is a flag that defines if the source folder location is enable or disabled
+ *     is a flag that defines if this additional source folder location is enabled or disabled;
+ *     enabled locations are used in addition to the default {@link DEFAULT_LOCATION} location
+ *     you can explicitly disable the default location by setting it to `false` in the object
  *   - value of a record in the object can also be a `string`:
  *     - if the string can be clearly mapped to a `boolean` (e.g., `"true"`, `"FALSE", "TrUe"`, etc.),
  *       it is treated as `boolean` value
  *     - any other string value is treated as `false` and is effectively ignored
- *   - if the record key is an `empty` string, it is ignored
+ *   - if the record `key` is an `empty` string, it is ignored
  *   - if the resulting object is empty, the feature is considered `enabled`, prompt files source
  *     folder locations fallback to {@link DEFAULT_LOCATION}
  * - `array`:
- *   - `string` items in the array are treated as prompt files source folder paths
+ *   - `string` items(non-empty) in the array are treated as prompt files source folder paths,
+ *     in addition to the default {@link DEFAULT_LOCATION} location
  *   - all `non-string` items in the array are `ignored`
  *   - if the resulting array is empty, the feature is considered `enabled`, prompt files
  *     source folder locations fallback to {@link DEFAULT_LOCATION}

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/config.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/config.ts
@@ -135,7 +135,7 @@ export namespace PromptFilesConfig {
 	 */
 	export const getValue = (
 		configService: IConfigurationService,
-	): string | readonly string[] | Map<string, boolean> | boolean | undefined => {
+	): string | string[] | Record<string, boolean> | boolean | undefined => {
 		const configValue = configService.getValue(CONFIG_KEY);
 
 		if (configValue === undefined || configValue === null) {
@@ -166,13 +166,13 @@ export namespace PromptFilesConfig {
 				return typeof item === 'string' && !!item.trim();
 			});
 
-			return Object.freeze(cleanArray);
+			return cleanArray;
 		}
 
 		// note! this would be also true for `null` and `array`,
 		// 		 but those cases are already handled above
 		if (typeof configValue === 'object') {
-			const paths: Map<string, boolean> = new Map();
+			const paths: Record<string, boolean> = {};
 
 			for (const [path, value] of Object.entries(configValue)) {
 				const cleanPath = path.trim();
@@ -181,11 +181,11 @@ export namespace PromptFilesConfig {
 				// if value can be mapped to a boolean, and the clean
 				// path is not empty, add it to the map
 				if ((booleanValue !== undefined) && cleanPath) {
-					paths.set(cleanPath, booleanValue);
+					paths[cleanPath] = booleanValue;
 				}
 			}
 
-			return Object.freeze(paths);
+			return paths;
 		}
 
 		return undefined;
@@ -208,11 +208,11 @@ export namespace PromptFilesConfig {
 	 */
 	export const sourceLocations = (
 		configService: IConfigurationService,
-	): readonly string[] => {
+	): string[] => {
 		const value = getValue(configService);
 
 		if (value === true) {
-			return Object.freeze([DEFAULT_LOCATION]);
+			return [DEFAULT_LOCATION];
 		}
 
 		if (typeof value === 'string') {
@@ -223,41 +223,41 @@ export namespace PromptFilesConfig {
 				result.push(trimmedValue);
 			}
 
-			return Object.freeze(result);
+			return result;
 		}
 
 		if (Array.isArray(value)) {
 			const result = [DEFAULT_LOCATION];
 
-			return Object.freeze([
+			return [
 				...result,
 				...value.filter((item) => {
 					return item !== DEFAULT_LOCATION;
 				}),
-			]);
+			];
 		}
 
 		// note! the `value &&` part handles the `undefined`, `null`, and `false` cases
-		if (value && (value instanceof Map)) {
+		if (value && (typeof value === 'object')) {
 			const paths: string[] = [];
 
 			// if the default location is not explicitly disabled, add it
-			if (value.get(DEFAULT_LOCATION) !== false) {
+			if (value[DEFAULT_LOCATION] !== false) {
 				paths.push(DEFAULT_LOCATION);
 			}
 
 			// copy all the enabled paths to the result list
-			for (const [path, enabled] of value.entries()) {
+			for (const [path, enabled] of Object.entries(value)) {
 				if (enabled && path !== DEFAULT_LOCATION) {
 					paths.push(path);
 				}
 			}
 
-			return Object.freeze(paths);
+			return paths;
 		}
 
 		// `undefined`, `null`, and `false` cases
-		return Object.freeze([]);
+		return [];
 	};
 
 	const usageExample1 = nls.localize(

--- a/src/vs/workbench/contrib/chat/test/browser/chatAttachmentModel/chatInstructionsFileLocator.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/chatAttachmentModel/chatInstructionsFileLocator.test.ts
@@ -6,6 +6,7 @@
 import assert from 'assert';
 import { Schemas } from '../../../../../../base/common/network.js';
 import { basename } from '../../../../../../base/common/resources.js';
+import { isWindows } from '../../../../../../base/common/platform.js';
 import { PromptFilesConfig } from '../../../common/promptSyntax/config.js';
 import { createURI } from '../../common/promptSyntax/testUtils/createUri.js';
 import { IFileService } from '../../../../../../platform/files/common/files.js';
@@ -19,7 +20,6 @@ import { InMemoryFileSystemProvider } from '../../../../../../platform/files/com
 import { TestInstantiationService } from '../../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
 import { IConfigurationOverrides, IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
 import { IWorkspace, IWorkspaceContextService, IWorkspaceFolder } from '../../../../../../platform/workspace/common/workspace.js';
-import { isWindows } from '../../../../../../base/common/platform.js';
 
 /**
  * Mocked mocked instance of {@link IConfigurationService}.
@@ -354,85 +354,172 @@ suite('ChatInstructionsFileLocator', () => {
 
 	suite('• single-root workspace', () => {
 		suite('• non-empty filesystem', () => {
-			test('• object config value', async () => {
-				const locator = await createPromptsLocator(
-					{
-						'/Users/legomushroom/repos/prompts': true,
-						'/tmp/prompts/': true,
-						'/absolute/path/prompts': false,
-						'.copilot/prompts': true,
-						'.github/prompts': false,
-					},
-					[
-						'/Users/legomushroom/repos/vscode',
-					],
-					[
+			suite('• object config value', () => {
+				test('• core logic', async () => {
+					const locator = await createPromptsLocator(
 						{
-							name: '/Users/legomushroom/repos/prompts',
-							children: [
-								{
-									name: 'test.prompt.md',
-									contents: 'Hello, World!',
-								},
-								{
-									name: 'refactor-tests.prompt.md',
-									contents: 'some file content goes here',
-								},
-							],
+							'/Users/legomushroom/repos/prompts': true,
+							'/tmp/prompts/': true,
+							'/absolute/path/prompts': false,
+							'.copilot/prompts': true,
 						},
-						{
-							name: '/tmp/prompts',
-							children: [
-								{
-									name: 'translate.to-rust.prompt.md',
-									contents: 'some more random file contents',
-								},
-							],
-						},
-						{
-							name: '/absolute/path/prompts',
-							children: [
-								{
-									name: 'some-prompt-file.prompt.md',
-									contents: 'hey hey hey',
-								},
-							],
-						},
-						{
-							name: '/Users/legomushroom/repos/vscode',
-							children: [
-								{
-									name: '.copilot/prompts',
-									children: [
-										{
-											name: 'default.prompt.md',
-											contents: 'oh hi, robot!',
-										},
-									],
-								},
-								{
-									name: '.github/prompts',
-									children: [
-										{
-											name: 'default.prompt.md',
-											contents: 'oh hi, bot!',
-										},
-									],
-								},
-							],
-						},
-					]);
+						[
+							'/Users/legomushroom/repos/vscode',
+						],
+						[
+							{
+								name: '/Users/legomushroom/repos/prompts',
+								children: [
+									{
+										name: 'test.prompt.md',
+										contents: 'Hello, World!',
+									},
+									{
+										name: 'refactor-tests.prompt.md',
+										contents: 'some file content goes here',
+									},
+								],
+							},
+							{
+								name: '/tmp/prompts',
+								children: [
+									{
+										name: 'translate.to-rust.prompt.md',
+										contents: 'some more random file contents',
+									},
+								],
+							},
+							{
+								name: '/absolute/path/prompts',
+								children: [
+									{
+										name: 'some-prompt-file.prompt.md',
+										contents: 'hey hey hey',
+									},
+								],
+							},
+							{
+								name: '/Users/legomushroom/repos/vscode',
+								children: [
+									{
+										name: '.copilot/prompts',
+										children: [
+											{
+												name: 'default.prompt.md',
+												contents: 'oh hi, robot!',
+											},
+										],
+									},
+									{
+										name: '.github/prompts',
+										children: [
+											{
+												name: 'my.prompt.md',
+												contents: 'oh hi, bot!',
+											},
+										],
+									},
+								],
+							},
+						]);
 
-				assert.deepStrictEqual(
-					await locator.listFiles([]),
-					[
-						createURI('/Users/legomushroom/repos/prompts/test.prompt.md'),
-						createURI('/Users/legomushroom/repos/prompts/refactor-tests.prompt.md'),
-						createURI('/tmp/prompts/translate.to-rust.prompt.md'),
-						createURI('/Users/legomushroom/repos/vscode/.copilot/prompts/default.prompt.md'),
-					],
-					'Must find correct prompts.',
-				);
+					assert.deepStrictEqual(
+						await locator.listFiles([]),
+						[
+							createURI('/Users/legomushroom/repos/vscode/.github/prompts/my.prompt.md'),
+							createURI('/Users/legomushroom/repos/prompts/test.prompt.md'),
+							createURI('/Users/legomushroom/repos/prompts/refactor-tests.prompt.md'),
+							createURI('/tmp/prompts/translate.to-rust.prompt.md'),
+							createURI('/Users/legomushroom/repos/vscode/.copilot/prompts/default.prompt.md'),
+						],
+						'Must find correct prompts.',
+					);
+				});
+
+				test('• with disabled `.github/prompts` location', async () => {
+					const locator = await createPromptsLocator(
+						{
+							'/Users/legomushroom/repos/prompts': true,
+							'/tmp/prompts/': true,
+							'/absolute/path/prompts': false,
+							'.copilot/prompts': true,
+							'.github/prompts': false,
+						},
+						[
+							'/Users/legomushroom/repos/vscode',
+						],
+						[
+							{
+								name: '/Users/legomushroom/repos/prompts',
+								children: [
+									{
+										name: 'test.prompt.md',
+										contents: 'Hello, World!',
+									},
+									{
+										name: 'refactor-tests.prompt.md',
+										contents: 'some file content goes here',
+									},
+								],
+							},
+							{
+								name: '/tmp/prompts',
+								children: [
+									{
+										name: 'translate.to-rust.prompt.md',
+										contents: 'some more random file contents',
+									},
+								],
+							},
+							{
+								name: '/absolute/path/prompts',
+								children: [
+									{
+										name: 'some-prompt-file.prompt.md',
+										contents: 'hey hey hey',
+									},
+								],
+							},
+							{
+								name: '/Users/legomushroom/repos/vscode',
+								children: [
+									{
+										name: '.copilot/prompts',
+										children: [
+											{
+												name: 'default.prompt.md',
+												contents: 'oh hi, robot!',
+											},
+										],
+									},
+									{
+										name: '.github/prompts',
+										children: [
+											{
+												name: 'my.prompt.md',
+												contents: 'oh hi, bot!',
+											},
+											{
+												name: 'your.prompt.md',
+												contents: 'oh hi, bot!',
+											},
+										],
+									},
+								],
+							},
+						]);
+
+					assert.deepStrictEqual(
+						await locator.listFiles([]),
+						[
+							createURI('/Users/legomushroom/repos/prompts/test.prompt.md'),
+							createURI('/Users/legomushroom/repos/prompts/refactor-tests.prompt.md'),
+							createURI('/tmp/prompts/translate.to-rust.prompt.md'),
+							createURI('/Users/legomushroom/repos/vscode/.copilot/prompts/default.prompt.md'),
+						],
+						'Must find correct prompts.',
+					);
+				});
 			});
 
 			test('• array config value', async () => {
@@ -505,6 +592,7 @@ suite('ChatInstructionsFileLocator', () => {
 				assert.deepStrictEqual(
 					await locator.listFiles([]),
 					[
+						createURI('/Users/legomushroom/repos/vscode/.github/prompts/default.prompt.md'),
 						createURI('/Users/legomushroom/repos/prompts/test.prompt.md'),
 						createURI('/Users/legomushroom/repos/prompts/refactor-tests.prompt.md'),
 						createURI('/tmp/prompts/translate.to-rust.prompt.md'),
@@ -628,7 +716,7 @@ suite('ChatInstructionsFileLocator', () => {
 										name: '.github/prompts',
 										children: [
 											{
-												name: 'default.prompt.md',
+												name: 'file.prompt.md',
 												contents: 'oh hi, bot!',
 											},
 										],
@@ -640,6 +728,7 @@ suite('ChatInstructionsFileLocator', () => {
 					assert.deepStrictEqual(
 						await locator.listFiles([]),
 						[
+							createURI('/Users/legomushroom/test/vscode/.github/prompts/file.prompt.md'),
 							createURI('/Users/legomushroom/test/prompts/test.prompt.md'),
 							createURI('/Users/legomushroom/test/prompts/refactor-tests.prompt.md'),
 						],
@@ -660,7 +749,6 @@ suite('ChatInstructionsFileLocator', () => {
 							'/tmp/prompts/': true,
 							'/absolute/path/prompts': false,
 							'.copilot/prompts': false,
-							'.github/prompts': true,
 						},
 						[
 							'/Users/legomushroom/repos/vscode',
@@ -763,11 +851,11 @@ suite('ChatInstructionsFileLocator', () => {
 					assert.deepStrictEqual(
 						await locator.listFiles([]),
 						[
+							createURI('/Users/legomushroom/repos/vscode/.github/prompts/default.prompt.md'),
+							createURI('/Users/legomushroom/repos/node/.github/prompts/refactor-static-classes.prompt.md'),
 							createURI('/Users/legomushroom/repos/prompts/test.prompt.md'),
 							createURI('/Users/legomushroom/repos/prompts/refactor-tests.prompt.md'),
 							createURI('/tmp/prompts/translate.to-rust.prompt.md'),
-							createURI('/Users/legomushroom/repos/vscode/.github/prompts/default.prompt.md'),
-							createURI('/Users/legomushroom/repos/node/.github/prompts/refactor-static-classes.prompt.md'),
 						],
 						'Must find correct prompts.',
 					);
@@ -780,7 +868,129 @@ suite('ChatInstructionsFileLocator', () => {
 							'/tmp/prompts/': true,
 							'/absolute/path/prompts': false,
 							'.copilot/prompts': false,
-							'.github/prompts': true,
+						},
+						[
+							'/Users/legomushroom/repos/vscode',
+							'/Users/legomushroom/repos/node',
+							'/var/shared/prompts/.github',
+						],
+						[
+							{
+								name: '/Users/legomushroom/repos/prompts',
+								children: [
+									{
+										name: 'test.prompt.md',
+										contents: 'Hello, World!',
+									},
+									{
+										name: 'refactor-tests.prompt.md',
+										contents: 'some file content goes here',
+									},
+								],
+							},
+							{
+								name: '/tmp/prompts',
+								children: [
+									{
+										name: 'translate.to-rust.prompt.md',
+										contents: 'some more random file contents',
+									},
+								],
+							},
+							{
+								name: '/absolute/path/prompts',
+								children: [
+									{
+										name: 'some-prompt-file.prompt.md',
+										contents: 'hey hey hey',
+									},
+								],
+							},
+							{
+								name: '/Users/legomushroom/repos/vscode',
+								children: [
+									{
+										name: '.copilot/prompts',
+										children: [
+											{
+												name: 'prompt1.prompt.md',
+												contents: 'oh hi, robot!',
+											},
+										],
+									},
+									{
+										name: '.github/prompts',
+										children: [
+											{
+												name: 'default.prompt.md',
+												contents: 'oh hi, bot!',
+											},
+										],
+									},
+								],
+							},
+							{
+								name: '/Users/legomushroom/repos/node',
+								children: [
+									{
+										name: '.copilot/prompts',
+										children: [
+											{
+												name: 'prompt5.prompt.md',
+												contents: 'oh hi, robot!',
+											},
+										],
+									},
+									{
+										name: '.github/prompts',
+										children: [
+											{
+												name: 'refactor-static-classes.prompt.md',
+												contents: 'file contents',
+											},
+										],
+									},
+								],
+							},
+							// note! this folder is part of the workspace, so prompt files are `included`
+							{
+								name: '/var/shared/prompts/.github/prompts',
+								children: [
+									{
+										name: 'prompt-name.prompt.md',
+										contents: 'oh hi, robot!',
+									},
+									{
+										name: 'name-of-the-prompt.prompt.md',
+										contents: 'oh hi, raw bot!',
+									},
+								],
+							},
+						]);
+
+					assert.deepStrictEqual(
+						await locator.listFiles([]),
+						[
+							createURI('/Users/legomushroom/repos/vscode/.github/prompts/default.prompt.md'),
+							createURI('/Users/legomushroom/repos/node/.github/prompts/refactor-static-classes.prompt.md'),
+							createURI('/var/shared/prompts/.github/prompts/prompt-name.prompt.md'),
+							createURI('/var/shared/prompts/.github/prompts/name-of-the-prompt.prompt.md'),
+							createURI('/Users/legomushroom/repos/prompts/test.prompt.md'),
+							createURI('/Users/legomushroom/repos/prompts/refactor-tests.prompt.md'),
+							createURI('/tmp/prompts/translate.to-rust.prompt.md'),
+						],
+						'Must find correct prompts.',
+					);
+				});
+
+				test('• with disabled `.github/prompts` location', async () => {
+					const locator = await createPromptsLocator(
+						{
+							'/Users/legomushroom/repos/prompts': true,
+							'/tmp/prompts/': true,
+							'/absolute/path/prompts': false,
+							'.copilot/prompts': false,
+							'.github/prompts': false,
 						},
 						[
 							'/Users/legomushroom/repos/vscode',
@@ -887,10 +1097,6 @@ suite('ChatInstructionsFileLocator', () => {
 							createURI('/Users/legomushroom/repos/prompts/test.prompt.md'),
 							createURI('/Users/legomushroom/repos/prompts/refactor-tests.prompt.md'),
 							createURI('/tmp/prompts/translate.to-rust.prompt.md'),
-							createURI('/Users/legomushroom/repos/vscode/.github/prompts/default.prompt.md'),
-							createURI('/Users/legomushroom/repos/node/.github/prompts/refactor-static-classes.prompt.md'),
-							createURI('/var/shared/prompts/.github/prompts/prompt-name.prompt.md'),
-							createURI('/var/shared/prompts/.github/prompts/name-of-the-prompt.prompt.md'),
 						],
 						'Must find correct prompts.',
 					);
@@ -900,11 +1106,11 @@ suite('ChatInstructionsFileLocator', () => {
 			suite('• array config value', () => {
 				test('• without top-level `copilot` folder', async () => {
 					const locator = await createPromptsLocator(
-						[
-							'/Users/legomushroom/repos/prompts',
-							'/tmp/prompts/',
-							'copilot/PROMPTS/',
-						],
+						{
+							'/Users/legomushroom/repos/prompts': true,
+							'/tmp/prompts/': true,
+							'copilot/PROMPTS/': true,
+						},
 						[
 							'/Users/legomushroom/repos/vscode',
 							'/Users/legomushroom/repos/node',
@@ -961,7 +1167,7 @@ suite('ChatInstructionsFileLocator', () => {
 										name: '.github/prompts',
 										children: [
 											{
-												name: 'default.prompt.md',
+												name: 'prompt.prompt.md',
 												contents: 'oh hi, bot!',
 											},
 										],
@@ -1024,6 +1230,8 @@ suite('ChatInstructionsFileLocator', () => {
 					assert.deepStrictEqual(
 						await locator.listFiles([]),
 						[
+							createURI('/Users/legomushroom/repos/vscode/.github/prompts/prompt.prompt.md'),
+							createURI('/Users/legomushroom/repos/node/.github/prompts/refactor-static-classes.prompt.md'),
 							createURI('/Users/legomushroom/repos/prompts/test.prompt.md'),
 							createURI('/Users/legomushroom/repos/prompts/refactor-tests.prompt.md'),
 							createURI('/tmp/prompts/translate.to-rust.prompt.md'),
@@ -1162,6 +1370,8 @@ suite('ChatInstructionsFileLocator', () => {
 					assert.deepStrictEqual(
 						await locator.listFiles([]),
 						[
+							createURI('/Users/legomushroom/repos/vscode/.github/prompts/default.prompt.md'),
+							createURI('/Users/legomushroom/repos/node/.github/prompts/refactor-static-classes.prompt.md'),
 							createURI('/Users/legomushroom/repos/prompts/test.prompt.md'),
 							createURI('/Users/legomushroom/repos/prompts/refactor-tests.prompt.md'),
 							createURI('/tmp/prompts/translate.to-rust.prompt.md'),
@@ -1255,7 +1465,7 @@ suite('ChatInstructionsFileLocator', () => {
 											name: '.github/prompts',
 											children: [
 												{
-													name: 'default.prompt.md',
+													name: 'bot.prompt.md',
 													contents: 'oh hi, bot!',
 												},
 											],
@@ -1278,7 +1488,7 @@ suite('ChatInstructionsFileLocator', () => {
 											name: '.github/prompts',
 											children: [
 												{
-													name: 'refactor-static-classes.prompt.md',
+													name: 'classes-refactor-static.prompt.md',
 													contents: 'file contents',
 												},
 											],
@@ -1316,6 +1526,8 @@ suite('ChatInstructionsFileLocator', () => {
 						assert.deepStrictEqual(
 							await locator.listFiles([]),
 							[
+								createURI('/Users/legomushroom/repos/vscode/.github/prompts/bot.prompt.md'),
+								createURI('/Users/legomushroom/repos/node/.github/prompts/classes-refactor-static.prompt.md'),
 								createURI('/tmp/prompts/translate.to-go.prompt.md'),
 								createURI('/tmp/prompts/find-mean-error-rate.prompt.md'),
 							],
@@ -1383,8 +1595,12 @@ suite('ChatInstructionsFileLocator', () => {
 											name: '.github/prompts',
 											children: [
 												{
-													name: 'default.prompt.md',
-													contents: 'oh hi, bot!',
+													name: 'hi.prompt.md',
+													contents: 'oh hi, raw bot!',
+												},
+												{
+													name: 'bye.prompt.md',
+													contents: 'oh bye, raw bot!',
 												},
 											],
 										},
@@ -1406,7 +1622,7 @@ suite('ChatInstructionsFileLocator', () => {
 											name: '.github/prompts',
 											children: [
 												{
-													name: 'refactor-static-classes.prompt.md',
+													name: 'static-refactor-classes.prompt.md',
 													contents: 'file contents',
 												},
 											],
@@ -1426,7 +1642,6 @@ suite('ChatInstructionsFileLocator', () => {
 										},
 									],
 								},
-								// note! this folder is not part of the workspace, so prompt files are `ignored`
 								{
 									name: '/Users/legomushroom/repos/.github/prompts',
 									children: [
@@ -1445,6 +1660,11 @@ suite('ChatInstructionsFileLocator', () => {
 						assert.deepStrictEqual(
 							await locator.listFiles([]),
 							[
+								createURI('/Users/legomushroom/repos/vscode/.github/prompts/hi.prompt.md'),
+								createURI('/Users/legomushroom/repos/vscode/.github/prompts/bye.prompt.md'),
+								createURI('/Users/legomushroom/repos/node/.github/prompts/static-refactor-classes.prompt.md'),
+								createURI('/Users/legomushroom/repos/.github/prompts/prompt-name-22.prompt.md'),
+								createURI('/Users/legomushroom/repos/.github/prompts/name-of-the-prompt-56.prompt.md'),
 								createURI('/Users/legomushroom/repos/prompts/test.file.prompt.md'),
 								createURI('/Users/legomushroom/repos/prompts/refactor-tests.file.prompt.md'),
 							],
@@ -1540,7 +1760,7 @@ suite('ChatInstructionsFileLocator', () => {
 											name: '.github/prompts',
 											children: [
 												{
-													name: 'default.prompt.md',
+													name: '1.prompt.md',
 													contents: 'oh hi, bot!',
 												},
 											],
@@ -1563,7 +1783,7 @@ suite('ChatInstructionsFileLocator', () => {
 											name: '.github/prompts',
 											children: [
 												{
-													name: 'refactor-static-classes.prompt.md',
+													name: '55.prompt.md',
 													contents: 'file contents',
 												},
 											],
@@ -1601,6 +1821,8 @@ suite('ChatInstructionsFileLocator', () => {
 						assert.deepStrictEqual(
 							await locator.listFiles([]),
 							[
+								createURI('/Users/legomushroom/repos/vscode/.github/prompts/1.prompt.md'),
+								createURI('/Users/legomushroom/repos/node/.github/prompts/55.prompt.md'),
 								createURI('/Users/legomushroom/repos/vscode/my-prompts/prompt1.prompt.md'),
 								createURI('/Users/legomushroom/repos/vscode/my-prompts/prompt2.prompt.md'),
 								createURI('/Users/legomushroom/repos/node/my-prompts/Build-Constructed-Structures.prompt.md'),
@@ -1757,6 +1979,8 @@ suite('ChatInstructionsFileLocator', () => {
 						assert.deepStrictEqual(
 							await locator.listFiles([]),
 							[
+								createURI('/Users/legomushroom/repos/vscode/.github/prompts/default.prompt.md'),
+								createURI('/Users/legomushroom/repos/node/.github/prompts/refactor-static-classes.prompt.md'),
 								createURI('/Users/legomushroom/repos/vscode/my-prompts/prompt1.prompt.md'),
 								createURI('/Users/legomushroom/repos/vscode/my-prompts/prompt2.prompt.md'),
 								createURI('/Users/legomushroom/repos/node/my-prompts/Build-Constructed-Structures.prompt.md'),

--- a/src/vs/workbench/contrib/chat/test/common/promptSyntax/config.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/promptSyntax/config.test.ts
@@ -407,4 +407,431 @@ suite('PromptFilesConfig', () => {
 			});
 		});
 	});
+
+	suite('• sourceLocations', () => {
+		test('• undefined', () => {
+			const configService = createMock(undefined);
+
+			assert.deepStrictEqual(
+				PromptFilesConfig.sourceLocations(configService),
+				[],
+				'Must read correct value.',
+			);
+		});
+
+		test('• null', () => {
+			const configService = createMock(null);
+
+			assert.deepStrictEqual(
+				PromptFilesConfig.sourceLocations(configService),
+				[],
+				'Must read correct value.',
+			);
+		});
+
+		suite('• string', () => {
+			test('• empty', () => {
+				assert.deepStrictEqual(
+					PromptFilesConfig.sourceLocations(createMock('')),
+					[],
+					'Must read correct value.',
+				);
+
+				assert.deepStrictEqual(
+					PromptFilesConfig.sourceLocations(createMock('  ')),
+					[],
+					'Must read correct value.',
+				);
+
+				assert.deepStrictEqual(
+					PromptFilesConfig.sourceLocations(createMock('\t')),
+					[],
+					'Must read correct value.',
+				);
+
+				assert.deepStrictEqual(
+					PromptFilesConfig.sourceLocations(createMock('\v')),
+					[],
+					'Must read correct value.',
+				);
+
+				assert.deepStrictEqual(
+					PromptFilesConfig.sourceLocations(createMock('\f')),
+					[],
+					'Must read correct value.',
+				);
+
+				assert.deepStrictEqual(
+					PromptFilesConfig.sourceLocations(createMock('\n')),
+					[],
+					'Must read correct value.',
+				);
+
+				assert.deepStrictEqual(
+					PromptFilesConfig.sourceLocations(createMock('\r\n')),
+					[],
+					'Must read correct value.',
+				);
+			});
+
+			test('• true', () => {
+				assert.deepStrictEqual(
+					PromptFilesConfig.sourceLocations(createMock('true')),
+					['.github/prompts'],
+					'Must read correct value.',
+				);
+
+				assert.deepStrictEqual(
+					PromptFilesConfig.sourceLocations(createMock('TRUE')),
+					['.github/prompts'],
+					'Must read correct value.',
+				);
+
+				assert.deepStrictEqual(
+					PromptFilesConfig.sourceLocations(createMock('TrUe')),
+					['.github/prompts'],
+					'Must read correct value.',
+				);
+			});
+
+			test('• false', () => {
+				assert.deepStrictEqual(
+					PromptFilesConfig.sourceLocations(createMock('false')),
+					[],
+					'Must read correct value.',
+				);
+
+				assert.deepStrictEqual(
+					PromptFilesConfig.sourceLocations(createMock('FALSE')),
+					[],
+					'Must read correct value.',
+				);
+
+				assert.deepStrictEqual(
+					PromptFilesConfig.sourceLocations(createMock('fAlSe')),
+					[],
+					'Must read correct value.',
+				);
+			});
+
+			test('• non-empty', () => {
+				assert.deepStrictEqual(
+					PromptFilesConfig.sourceLocations(createMock('/absolute/path/to/folder')),
+					['.github/prompts', '/absolute/path/to/folder'],
+					'Must read correct value.',
+				);
+
+				assert.deepStrictEqual(
+					PromptFilesConfig.sourceLocations(createMock('/Absolute/path/to/folder')),
+					['.github/prompts', '/Absolute/path/to/folder'],
+					'Must read correct value.',
+				);
+
+				assert.deepStrictEqual(
+					PromptFilesConfig.sourceLocations(createMock('./relative-path/to/folder')),
+					['.github/prompts', './relative-path/to/folder'],
+					'Must read correct value.',
+				);
+
+				assert.deepStrictEqual(
+					PromptFilesConfig.sourceLocations(createMock('./relative-path/To/folder')),
+					['.github/prompts', './relative-path/To/folder'],
+					'Must read correct value.',
+				);
+
+				assert.deepStrictEqual(
+					PromptFilesConfig.sourceLocations(createMock('.github/prompts')),
+					['.github/prompts'],
+					'Must read correct value.',
+				);
+
+				assert.deepStrictEqual(
+					PromptFilesConfig.sourceLocations(createMock('.github/Prompts')),
+					['.github/prompts', '.github/Prompts'],
+					'Must read correct value.',
+				);
+
+				assert.deepStrictEqual(
+					PromptFilesConfig.sourceLocations(createMock('/abs/path/to/file.prompt.md')),
+					['.github/prompts', '/abs/path/to/file.prompt.md'],
+					'Must read correct value.',
+				);
+
+				assert.deepStrictEqual(
+					PromptFilesConfig.sourceLocations(createMock('/Abs/Path/To/File.prompt.md')),
+					['.github/prompts', '/Abs/Path/To/File.prompt.md'],
+					'Must read correct value.',
+				);
+			});
+		});
+
+		test('• boolean', () => {
+			assert.deepStrictEqual(
+				PromptFilesConfig.sourceLocations(createMock(true)),
+				['.github/prompts'],
+				'Must read correct value.',
+			);
+
+			assert.deepStrictEqual(
+				PromptFilesConfig.sourceLocations(createMock(false)),
+				[],
+				'Must read correct value.',
+			);
+		});
+
+		suite('• array', () => {
+			test('• empty', () => {
+				assert.deepStrictEqual(
+					PromptFilesConfig.sourceLocations(createMock([])),
+					['.github/prompts'],
+					'Must read correct value.',
+				);
+			});
+
+			test('• valid strings', () => {
+				assert.deepStrictEqual(
+					PromptFilesConfig.sourceLocations(createMock([
+						'/absolute/path/to/folder',
+						'./relative-path/to/folder',
+						'./another-Relative/Path/to/folder',
+						'.github/prompts',
+						'/abs/path/to/file.prompt.md',
+						'.githuB/prompts',
+						'/ABS/path/to/prompts/',
+					])),
+					[
+						'.github/prompts',
+						'/absolute/path/to/folder',
+						'./relative-path/to/folder',
+						'./another-Relative/Path/to/folder',
+						'/abs/path/to/file.prompt.md',
+						'.githuB/prompts',
+						'/ABS/path/to/prompts/',
+					],
+					'Must read correct value.',
+				);
+			});
+
+			test('• filters out not valid string values', () => {
+				assert.deepStrictEqual(
+					PromptFilesConfig.sourceLocations(createMock([
+						'/usr/local/bin/.hidden-tool',
+						'../config/.env.example',
+						[
+							'test',
+							randomInt(Number.MAX_SAFE_INTEGER, Number.MIN_SAFE_INTEGER),
+						],
+						'',
+						'./scripts/BUILD.sh',
+						randomBoolean(),
+						'/home/user/Documents/report.v1.pdf',
+						'tmp/.cache/.session.lock',
+						'/var/log/backup.2025-02-05.log',
+						{
+							'key1': randomBoolean(),
+							'key2': 'value2',
+						},
+						'../.git/hooks/pre-commit.sample',
+						randomInt(Number.MAX_SAFE_INTEGER, Number.MIN_SAFE_INTEGER),
+						'\t\t',
+						'/opt/app/data/config.yaml',
+						'./.config/Subfolder.file',
+						undefined,
+						'/usr/share/man/man1/bash.1',
+						null,
+					])),
+					[
+						'.github/prompts',
+						'/usr/local/bin/.hidden-tool',
+						'../config/.env.example',
+						'./scripts/BUILD.sh',
+						'/home/user/Documents/report.v1.pdf',
+						'tmp/.cache/.session.lock',
+						'/var/log/backup.2025-02-05.log',
+						'../.git/hooks/pre-commit.sample',
+						'/opt/app/data/config.yaml',
+						'./.config/Subfolder.file',
+						'/usr/share/man/man1/bash.1',
+					],
+					'Must read correct value.',
+				);
+			});
+
+			test('• only invalid values', () => {
+				assert.deepStrictEqual(
+					PromptFilesConfig.sourceLocations(createMock([
+						null,
+						undefined,
+						'',
+						'  ',
+						'\t',
+						'\v',
+						'\f',
+						'\n',
+						'\r\n',
+						{
+							'some-key': randomInt(Number.MAX_SAFE_INTEGER, Number.MIN_SAFE_INTEGER),
+							'another-key': randomBoolean(),
+							'one_more_key': '../relative/path.to.file',
+						},
+						[randomBoolean(), randomBoolean()],
+						randomInt(Number.MAX_SAFE_INTEGER, Number.MIN_SAFE_INTEGER),
+					])),
+					['.github/prompts'],
+					'Must read correct value.',
+				);
+			});
+		});
+
+		suite('• object', () => {
+			test('• empty', () => {
+				assert.deepStrictEqual(
+					PromptFilesConfig.sourceLocations(createMock({})),
+					['.github/prompts'],
+					'Must read correct value.',
+				);
+			});
+
+			test('• only valid strings', () => {
+				assert.deepStrictEqual(
+					PromptFilesConfig.sourceLocations(createMock({
+						'/root/.bashrc': true,
+						'../../folder/.hidden-folder/config.xml': true,
+						'/srv/www/Public_html/.htaccess': true,
+						'../../another.folder/.WEIRD_FILE.log': true,
+						'./folder.name/file.name': true,
+						'/media/external/backup.tar.gz': true,
+						'/Media/external/.secret.backup': true,
+						'../relative/path.to.file': true,
+						'./folderName.with.dots/more.dots.extension': true,
+						'some/folder.with.dots/another.file': true,
+						'/var/logs/app.01.05.error': true,
+						'.GitHub/prompts': true,
+						'./.tempfile': true,
+					})),
+					[
+						'.github/prompts',
+						'/root/.bashrc',
+						'../../folder/.hidden-folder/config.xml',
+						'/srv/www/Public_html/.htaccess',
+						'../../another.folder/.WEIRD_FILE.log',
+						'./folder.name/file.name',
+						'/media/external/backup.tar.gz',
+						'/Media/external/.secret.backup',
+						'../relative/path.to.file',
+						'./folderName.with.dots/more.dots.extension',
+						'some/folder.with.dots/another.file',
+						'/var/logs/app.01.05.error',
+						'.GitHub/prompts',
+						'./.tempfile',
+					],
+					'Must read correct value.',
+				);
+			});
+
+			test('• filters out non valid entries', () => {
+				assert.deepStrictEqual(
+					PromptFilesConfig.sourceLocations(createMock({
+						'/etc/hosts.backup': '\t\n\t',
+						'./run.tests.sh': '\v',
+						'../assets/img/logo.v2.png': true,
+						'/mnt/storage/video.archive/episode.01.mkv': false,
+						'../.local/bin/script.sh': true,
+						'/usr/local/share/.fonts/CustomFont.otf': '',
+						'../../development/branch.name/some.test': true,
+						'.giThub/prompts': true,
+						'/Home/user/.ssh/config': true,
+						'./hidden.dir/.subhidden': '\f',
+						'/tmp/.temp.folder/cache.db': true,
+						'.github/prompts': true,
+						'/opt/software/v3.2.1/build.log': '  ',
+						'': true,
+						'./scripts/.old.build.sh': true,
+						'/var/data/datafile.2025-02-05.json': '\n',
+						'\n\n': true,
+						'\t': true,
+						'\v': true,
+						'\f': true,
+						'\r\n': true,
+						'\f\f': true,
+						'../lib/some_library.v1.0.1.so': '\r\n',
+						'/dev/shm/.shared_resource': randomInt(Number.MAX_SAFE_INTEGER, Number.MIN_SAFE_INTEGER),
+					})),
+					[
+						'.github/prompts',
+						'../assets/img/logo.v2.png',
+						'../.local/bin/script.sh',
+						'../../development/branch.name/some.test',
+						'.giThub/prompts',
+						'/Home/user/.ssh/config',
+						'/tmp/.temp.folder/cache.db',
+						'./scripts/.old.build.sh',
+					],
+					'Must read correct value.',
+				);
+			});
+
+			test('• only invalid or false values', () => {
+				assert.deepStrictEqual(
+					PromptFilesConfig.sourceLocations(createMock({
+						'/etc/hosts.backup': '\t\n\t',
+						'./run.tests.sh': '\v',
+						'../assets/IMG/logo.v2.png': '',
+						'/mnt/storage/video.archive/episode.01.mkv': false,
+						'/usr/local/share/.fonts/CustomFont.otf': '',
+						'./hidden.dir/.subhidden': '\f',
+						'/opt/Software/v3.2.1/build.log': '  ',
+						'/var/data/datafile.2025-02-05.json': '\n',
+						'../lib/some_library.v1.0.1.so': '\r\n',
+						'/dev/shm/.shared_resource': randomInt(Number.MAX_SAFE_INTEGER, Number.MIN_SAFE_INTEGER),
+					})),
+					[
+						'.github/prompts',
+					],
+					'Must read correct value.',
+				);
+			});
+
+			test('• filters out disabled default location', () => {
+				assert.deepStrictEqual(
+					PromptFilesConfig.sourceLocations(createMock({
+						'/etc/hosts.backup': '\t\n\t',
+						'./run.tests.sh': '\v',
+						'.github/prompts': false,
+						'../assets/img/logo.v2.png': true,
+						'/mnt/storage/video.archive/episode.01.mkv': false,
+						'../.local/bin/script.sh': true,
+						'/usr/local/share/.fonts/CustomFont.otf': '',
+						'../../development/branch.name/some.test': true,
+						'.giThub/prompts': true,
+						'/Home/user/.ssh/config': true,
+						'./hidden.dir/.subhidden': '\f',
+						'/tmp/.temp.folder/cache.db': true,
+						'/opt/software/v3.2.1/build.log': '  ',
+						'': true,
+						'./scripts/.old.build.sh': true,
+						'/var/data/datafile.2025-02-05.json': '\n',
+						'\n\n': true,
+						'\t': true,
+						'\v': true,
+						'\f': true,
+						'\r\n': true,
+						'\f\f': true,
+						'../lib/some_library.v1.0.1.so': '\r\n',
+						'/dev/shm/.shared_resource': randomInt(Number.MAX_SAFE_INTEGER, Number.MIN_SAFE_INTEGER),
+					})),
+					[
+						'../assets/img/logo.v2.png',
+						'../.local/bin/script.sh',
+						'../../development/branch.name/some.test',
+						'.giThub/prompts',
+						'/Home/user/.ssh/config',
+						'/tmp/.temp.folder/cache.db',
+						'./scripts/.old.build.sh',
+					],
+					'Must read correct value.',
+				);
+			});
+		});
+	});
 });

--- a/src/vs/workbench/contrib/chat/test/common/promptSyntax/config.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/promptSyntax/config.test.ts
@@ -307,7 +307,7 @@ suite('PromptFilesConfig', () => {
 			test('• empty', () => {
 				assert.deepStrictEqual(
 					PromptFilesConfig.getValue(createMock({})),
-					[],
+					{},
 					'Must read correct value.',
 				);
 			});
@@ -328,20 +328,20 @@ suite('PromptFilesConfig', () => {
 						'/var/logs/app.01.05.error': true,
 						'./.tempfile': true,
 					})),
-					[
-						'/root/.bashrc',
-						'../../folder/.hidden-folder/config.xml',
-						'/srv/www/Public_html/.htaccess',
-						'../../another.folder/.WEIRD_FILE.log',
-						'./folder.name/file.name',
-						'/media/external/backup.tar.gz',
-						'/Media/external/.secret.backup',
-						'../relative/path.to.file',
-						'./folderName.with.dots/more.dots.extension',
-						'some/folder.with.dots/another.file',
-						'/var/logs/app.01.05.error',
-						'./.tempfile'
-					],
+					{
+						'/root/.bashrc': true,
+						'../../folder/.hidden-folder/config.xml': true,
+						'/srv/www/Public_html/.htaccess': true,
+						'../../another.folder/.WEIRD_FILE.log': true,
+						'./folder.name/file.name': true,
+						'/media/external/backup.tar.gz': true,
+						'/Media/external/.secret.backup': true,
+						'../relative/path.to.file': true,
+						'./folderName.with.dots/more.dots.extension': true,
+						'some/folder.with.dots/another.file': true,
+						'/var/logs/app.01.05.error': true,
+						'./.tempfile': true,
+					},
 					'Must read correct value.',
 				);
 			});
@@ -372,14 +372,15 @@ suite('PromptFilesConfig', () => {
 						'../lib/some_library.v1.0.1.so': '\r\n',
 						'/dev/shm/.shared_resource': randomInt(Number.MAX_SAFE_INTEGER, Number.MIN_SAFE_INTEGER),
 					})),
-					[
-						'../assets/img/logo.v2.png',
-						'../.local/bin/script.sh',
-						'../../development/branch.name/some.test',
-						'/Home/user/.ssh/config',
-						'/tmp/.temp.folder/cache.db',
-						'./scripts/.old.build.sh',
-					],
+					{
+						'../assets/img/logo.v2.png': true,
+						'/mnt/storage/video.archive/episode.01.mkv': false,
+						'../.local/bin/script.sh': true,
+						'../../development/branch.name/some.test': true,
+						'/Home/user/.ssh/config': true,
+						'/tmp/.temp.folder/cache.db': true,
+						'./scripts/.old.build.sh': true,
+					},
 					'Must read correct value.',
 				);
 			});
@@ -398,94 +399,11 @@ suite('PromptFilesConfig', () => {
 						'../lib/some_library.v1.0.1.so': '\r\n',
 						'/dev/shm/.shared_resource': randomInt(Number.MAX_SAFE_INTEGER, Number.MIN_SAFE_INTEGER),
 					})),
-					[],
+					{
+						'/mnt/storage/video.archive/episode.01.mkv': false,
+					},
 					'Must read correct value.',
 				);
-			});
-		});
-
-		suite('• array immutability', () => {
-			test('• empty input array case', () => {
-				assert.throws(() => {
-					const value = PromptFilesConfig.getValue(createMock([]));
-
-					// sanity check
-					assert(
-						Array.isArray(value),
-						'Must return an array.',
-					);
-
-					// note! we have to type case here to be able to test for immutability
-					(value as unknown as string[]).push('/usr/src/kernel/module.build');
-				});
-			});
-
-			test('• empty result array case', () => {
-				assert.throws(() => {
-					const value = PromptFilesConfig.getValue(createMock([
-						randomBoolean(),
-						'\n\n',
-						'\v\t',
-						randomInt(Number.MAX_SAFE_INTEGER, Number.MIN_SAFE_INTEGER),
-						'   ',
-					]));
-
-					// sanity check
-					assert(
-						Array.isArray(value),
-						'Must return an array.',
-					);
-
-					// note! we have to type case here to be able to test for immutability
-					(value as unknown as string[]).push('../../archive/old.logs/app.10-12-2025.log');
-				});
-			});
-
-			test('• empty input object case', () => {
-				assert.throws(() => {
-					const value = PromptFilesConfig.getValue(createMock({}));
-
-					// sanity check
-					assert(
-						Array.isArray(value),
-						'Must return an array.',
-					);
-
-					// note! we have to type case here to be able to test for immutability
-					(value as unknown as string[]).push('./local.repo/.gitignore');
-				});
-			});
-
-			test('• empty result array case (object input)', () => {
-				assert.throws(() => {
-					const value = PromptFilesConfig.getValue(createMock({
-						'/etc/hostname.backup': '\t\n\t',
-						'./run.tests.bat': '\v',
-						'/mnt/Storage/video.archive/episode.02.mkv': false,
-						'/usr/local/share/.fonts/CustomFont.ttf': '',
-						'./hidden.dir/.SUBHIDDENFILE': '\f',
-						'/opt/software/v3.2.1/build.log.old': '  ',
-						'': true,
-						'/var/data/datafile.2025-03-05.json': '\n',
-						'\n\n': true,
-						'\t': true,
-						'\v': true,
-						'\f': true,
-						'\r\n': true,
-						'\f\f': true,
-						'../lib/some_library.v1.0.2.so': '\r\n',
-						'/dev/shm/.shared_resource.tmp': randomInt(Number.MAX_SAFE_INTEGER, Number.MIN_SAFE_INTEGER),
-					}));
-
-					// sanity check
-					assert(
-						Array.isArray(value),
-						'Must return an array.',
-					);
-
-					// note! we have to type case here to be able to test for immutability
-					(value as unknown as string[]).push('/etc/systemd/system/app.service');
-				});
 			});
 		});
 	});


### PR DESCRIPTION
Keeps the default prompt files location (`.github/prompts`) enabled even when user specifies custom location(s), unless the user explicitly disables this path in the settings.

For [#13086](https://github.com/microsoft/vscode-copilot/issues/13086), part of [#12742](https://github.com/microsoft/vscode-copilot/issues/12742).