### PR TITLE
Support sending image output to chat

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/controller/cellOutputActions.ts
+++ b/src/vs/workbench/contrib/notebook/browser/controller/cellOutputActions.ts
@@ -121,7 +121,7 @@ registerAction2(class CopyCellOutputAction extends Action2 {
 
 });
 
-function getOutputViewModelFromId(outputId: string, notebookEditor: INotebookEditor): ICellOutputViewModel | undefined {
+export function getOutputViewModelFromId(outputId: string, notebookEditor: INotebookEditor): ICellOutputViewModel | undefined {
 	const notebookViewModel = notebookEditor.getViewModel();
 	if (notebookViewModel) {
 		const codeCells = notebookViewModel.viewCells.filter(cell => cell.cellKind === CellKind.Code) as CodeCellViewModel[];

--- a/src/vs/workbench/contrib/notebook/browser/controller/chat/notebook.chat.contribution.ts
+++ b/src/vs/workbench/contrib/notebook/browser/controller/chat/notebook.chat.contribution.ts
@@ -13,8 +13,8 @@ import { CompletionContext, CompletionItemKind, CompletionList } from '../../../
 import { ITextModel } from '../../../../../../editor/common/model.js';
 import { ILanguageFeaturesService } from '../../../../../../editor/common/services/languageFeatures.js';
 import { localize } from '../../../../../../nls.js';
-import { Action2, registerAction2 } from '../../../../../../platform/actions/common/actions.js';
-import { IContextKey, IContextKeyService } from '../../../../../../platform/contextkey/common/contextkey.js';
+import { Action2, MenuId, registerAction2 } from '../../../../../../platform/actions/common/actions.js';
+import { ContextKeyExpr, IContextKey, IContextKeyService } from '../../../../../../platform/contextkey/common/contextkey.js';
 import { ServicesAccessor } from '../../../../../../platform/instantiation/common/instantiation.js';
 import { IQuickInputService, IQuickPickItem } from '../../../../../../platform/quickinput/common/quickInput.js';
 import { IWorkbenchContribution, registerWorkbenchContribution2, WorkbenchPhase } from '../../../../../common/contributions.js';
@@ -24,9 +24,14 @@ import { ChatInputPart } from '../../../../chat/browser/chatInputPart.js';
 import { ChatDynamicVariableModel } from '../../../../chat/browser/contrib/chatDynamicVariables.js';
 import { computeCompletionRanges } from '../../../../chat/browser/contrib/chatInputCompletions.js';
 import { ChatAgentLocation, IChatAgentService } from '../../../../chat/common/chatAgents.js';
+import { IChatRequestPasteVariableEntry } from '../../../../chat/common/chatModel.js';
 import { chatVariableLeader } from '../../../../chat/common/chatParserTypes.js';
+import { NOTEBOOK_CELL_HAS_OUTPUTS, NOTEBOOK_CELL_OUTPUT_MIME_TYPE_LIST_FOR_CHAT, NOTEBOOK_CELL_OUTPUT_MIMETYPE } from '../../../common/notebookContextKeys.js';
 import { INotebookKernelService } from '../../../common/notebookKernelService.js';
-import { getNotebookEditorFromEditorPane } from '../../notebookBrowser.js';
+import { getNotebookEditorFromEditorPane, ICellOutputViewModel, INotebookEditor } from '../../notebookBrowser.js';
+import * as icons from '../../notebookIcons.js';
+import { getOutputViewModelFromId } from '../cellOutputActions.js';
+import { INotebookOutputActionContext, NOTEBOOK_ACTIONS_CATEGORY } from '../coreActions.js';
 import './cellChatActions.js';
 import { CTX_NOTEBOOK_CHAT_HAS_AGENT } from './notebookChatContext.js';
 
@@ -94,6 +99,9 @@ class NotebookChatContribution extends Disposable implements IWorkbenchContribut
 				return result;
 			}
 		}));
+
+		// output context
+		NOTEBOOK_CELL_OUTPUT_MIME_TYPE_LIST_FOR_CHAT.bindTo(contextKeyService).set(['image/png']);
 	}
 
 	private async addKernelVariableCompletion(widget: IChatWidget, result: CompletionList, info: { insert: Range; replace: Range; varWord: IWordAtPosition | null }, token: CancellationToken) {
@@ -227,6 +235,106 @@ export class SelectAndInsertKernelVariableAction extends Action2 {
 		}
 	}
 }
+
+
+registerAction2(class CopyCellOutputAction extends Action2 {
+	constructor() {
+		super({
+			id: 'notebook.cellOutput.addToChat',
+			title: localize('notebookActions.addOutputToChat', "Add Cell Output to Chat"),
+			menu: {
+				id: MenuId.NotebookOutputToolbar,
+				when: ContextKeyExpr.and(NOTEBOOK_CELL_HAS_OUTPUTS, ContextKeyExpr.in(NOTEBOOK_CELL_OUTPUT_MIMETYPE.key, NOTEBOOK_CELL_OUTPUT_MIME_TYPE_LIST_FOR_CHAT.key)),
+				order: 10
+			},
+			category: NOTEBOOK_ACTIONS_CATEGORY,
+			icon: icons.copyIcon,
+		});
+	}
+
+	private getNoteboookEditor(editorService: IEditorService, outputContext: INotebookOutputActionContext | { outputViewModel: ICellOutputViewModel } | undefined): INotebookEditor | undefined {
+		if (outputContext && 'notebookEditor' in outputContext) {
+			return outputContext.notebookEditor;
+		}
+		return getNotebookEditorFromEditorPane(editorService.activeEditorPane);
+	}
+
+	async run(accessor: ServicesAccessor, outputContext: INotebookOutputActionContext | { outputViewModel: ICellOutputViewModel } | undefined): Promise<void> {
+		const notebookEditor = this.getNoteboookEditor(accessor.get(IEditorService), outputContext);
+
+		if (!notebookEditor) {
+			return;
+		}
+
+		let outputViewModel: ICellOutputViewModel | undefined;
+		if (outputContext && 'outputId' in outputContext && typeof outputContext.outputId === 'string') {
+			outputViewModel = getOutputViewModelFromId(outputContext.outputId, notebookEditor);
+		} else if (outputContext && 'outputViewModel' in outputContext) {
+			outputViewModel = outputContext.outputViewModel;
+		}
+
+		if (!outputViewModel) {
+			// not able to find the output from the provided context, use the active cell
+			const activeCell = notebookEditor.getActiveCell();
+			if (!activeCell) {
+				return;
+			}
+
+			if (activeCell.focusedOutputId !== undefined) {
+				outputViewModel = activeCell.outputsViewModels.find(output => {
+					return output.model.outputId === activeCell.focusedOutputId;
+				});
+			} else {
+				outputViewModel = activeCell.outputsViewModels.find(output => output.pickedMimeType?.isTrusted);
+			}
+		}
+
+		if (!outputViewModel) {
+			return;
+		}
+
+		const mimeType = outputViewModel.pickedMimeType?.mimeType;
+
+		if (mimeType === 'image/png') {
+			const chatWidgetService = accessor.get(IChatWidgetService);
+
+			const widget = chatWidgetService.lastFocusedWidget;
+			if (!widget) {
+				return;
+			}
+
+			const imageOutput = outputViewModel.model.outputs.find(output => output.mime === mimeType);
+			if (!imageOutput) {
+				return;
+			}
+
+			const attachedVariables = widget.attachmentModel.attachments;
+			const displayName = localize('cellOutputDisplayname', 'Notebook Cell Output Image');
+			let tempDisplayName = displayName;
+
+			for (let appendValue = 2; attachedVariables.some(attachment => attachment.name === tempDisplayName); appendValue++) {
+				tempDisplayName = `${displayName} ${appendValue}`;
+			}
+
+			const imageData = imageOutput.data;
+			const variableEntry: IChatRequestPasteVariableEntry = {
+				kind: 'paste',
+				code: '',
+				language: '',
+				pastedLines: '',
+				fileName: 'notebook-cell-output-image-' + outputViewModel.model.outputId,
+				copiedFrom: undefined,
+				id: 'notebook-cell-output-image-' + outputViewModel.model.outputId,
+				name: tempDisplayName,
+				isImage: true,
+				value: imageData.buffer,
+			};
+
+			widget.attachmentModel.addContext(variableEntry);
+		}
+	}
+
+});
 
 registerAction2(SelectAndInsertKernelVariableAction);
 registerWorkbenchContribution2(NotebookChatContribution.ID, NotebookChatContribution, WorkbenchPhase.BlockRestore);

--- a/src/vs/workbench/contrib/notebook/browser/view/cellParts/cellOutput.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/cellParts/cellOutput.ts
@@ -32,7 +32,7 @@ import { INotebookKernel } from '../../../common/notebookKernelService.js';
 import { INotebookService } from '../../../common/notebookService.js';
 import { COPY_OUTPUT_COMMAND_ID } from '../../controller/cellOutputActions.js';
 import { autorun, observableValue } from '../../../../../../base/common/observable.js';
-import { NOTEBOOK_CELL_HAS_HIDDEN_OUTPUTS, NOTEBOOK_CELL_IS_FIRST_OUTPUT } from '../../../common/notebookContextKeys.js';
+import { NOTEBOOK_CELL_HAS_HIDDEN_OUTPUTS, NOTEBOOK_CELL_IS_FIRST_OUTPUT, NOTEBOOK_CELL_OUTPUT_MIMETYPE } from '../../../common/notebookContextKeys.js';
 import { TEXT_BASED_MIMETYPES } from '../../viewModel/cellOutputTextHelper.js';
 
 interface IMimeTypeRenderer extends IQuickPickItem {
@@ -327,7 +327,9 @@ class CellOutputElement extends Disposable {
 		const menuContextKeyService = this.toolbarDisposables.add(this.contextKeyService.createScoped(outputItemDiv));
 		const hasHiddenOutputs = NOTEBOOK_CELL_HAS_HIDDEN_OUTPUTS.bindTo(menuContextKeyService);
 		const isFirstCellOutput = NOTEBOOK_CELL_IS_FIRST_OUTPUT.bindTo(menuContextKeyService);
+		const cellOutputMimetype = NOTEBOOK_CELL_OUTPUT_MIMETYPE.bindTo(menuContextKeyService);
 		isFirstCellOutput.set(index === 0);
+		cellOutputMimetype.set(mimeTypes[index].mimeType);
 		this.toolbarDisposables.add(autorun((reader) => { hasHiddenOutputs.set(reader.readObservable(this.cellOutputContainer.hasHiddenOutputs)); }));
 		const menu = this.toolbarDisposables.add(this.menuService.createMenu(MenuId.NotebookOutputToolbar, menuContextKeyService));
 

--- a/src/vs/workbench/contrib/notebook/browser/view/cellParts/cellOutput.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/cellParts/cellOutput.ts
@@ -329,7 +329,9 @@ class CellOutputElement extends Disposable {
 		const isFirstCellOutput = NOTEBOOK_CELL_IS_FIRST_OUTPUT.bindTo(menuContextKeyService);
 		const cellOutputMimetype = NOTEBOOK_CELL_OUTPUT_MIMETYPE.bindTo(menuContextKeyService);
 		isFirstCellOutput.set(index === 0);
-		cellOutputMimetype.set(mimeTypes[index].mimeType);
+		if (mimeTypes[index]) {
+			cellOutputMimetype.set(mimeTypes[index].mimeType);
+		}
 		this.toolbarDisposables.add(autorun((reader) => { hasHiddenOutputs.set(reader.readObservable(this.cellOutputContainer.hasHiddenOutputs)); }));
 		const menu = this.toolbarDisposables.add(this.menuService.createMenu(MenuId.NotebookOutputToolbar, menuContextKeyService));
 

--- a/src/vs/workbench/contrib/notebook/common/notebookContextKeys.ts
+++ b/src/vs/workbench/contrib/notebook/common/notebookContextKeys.ts
@@ -51,11 +51,13 @@ export const NOTEBOOK_CELL_EXECUTING = new RawContextKey<boolean>('notebookCellE
 export const NOTEBOOK_CELL_HAS_OUTPUTS = new RawContextKey<boolean>('notebookCellHasOutputs', false);
 export const NOTEBOOK_CELL_IS_FIRST_OUTPUT = new RawContextKey<boolean>('notebookCellIsFirstOutput', false);
 export const NOTEBOOK_CELL_HAS_HIDDEN_OUTPUTS = new RawContextKey<boolean>('hasHiddenOutputs', false);
+export const NOTEBOOK_CELL_OUTPUT_MIMETYPE = new RawContextKey<string>('notebookCellOutputMimeType', undefined);
 export const NOTEBOOK_CELL_INPUT_COLLAPSED = new RawContextKey<boolean>('notebookCellInputIsCollapsed', false);
 export const NOTEBOOK_CELL_OUTPUT_COLLAPSED = new RawContextKey<boolean>('notebookCellOutputIsCollapsed', false);
 export const NOTEBOOK_CELL_RESOURCE = new RawContextKey<string>('notebookCellResource', '');
 export const NOTEBOOK_CELL_GENERATED_BY_CHAT = new RawContextKey<boolean>('notebookCellGenerateByChat', false);
 export const NOTEBOOK_CELL_HAS_ERROR_DIAGNOSTICS = new RawContextKey<boolean>('notebookCellHasErrorDiagnostics', false);
+export const NOTEBOOK_CELL_OUTPUT_MIME_TYPE_LIST_FOR_CHAT = new RawContextKey<string[]>('notebookCellOutputMimeTypeListForChat', []);
 
 // Kernels
 export const NOTEBOOK_KERNEL = new RawContextKey<string>('notebookKernel', undefined);


### PR DESCRIPTION
Introduce functionality to add cell output images to chat, enhancing the interaction between notebook outputs and chat features. This includes context key updates and new actions for handling image outputs.