### PR TITLE
Hide Inline Edits When Peek Widget Is Visible

### DIFF
--- a/src/vs/editor/browser/observableCodeEditor.ts
+++ b/src/vs/editor/browser/observableCodeEditor.ts
@@ -352,6 +352,8 @@ export class ObservableCodeEditor extends Disposable {
 		}));
 		return result;
 	}
+
+	public readonly openedPeekWidgets = observableValue(this, 0);
 }
 
 interface IObservableOverlayWidget {

--- a/src/vs/editor/contrib/inlineCompletions/browser/controller/inlineCompletionsController.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/controller/inlineCompletionsController.ts
@@ -121,7 +121,7 @@ export class InlineCompletionsController extends Disposable {
 
 	private readonly _hideInlineEditOnSelectionChange = this._editorObs.getOption(EditorOption.inlineSuggest).map(val => true);
 
-	protected readonly _view = this._register(new InlineCompletionsView(this.editor, this.model, this._focusIsInMenu, this._instantiationService));
+	protected readonly _view = this._register(this._instantiationService.createInstance(InlineCompletionsView, this.editor, this.model, this._focusIsInMenu));
 
 	constructor(
 		public readonly editor: ICodeEditor,

--- a/src/vs/editor/contrib/inlineCompletions/browser/model/inlineCompletionsModel.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/model/inlineCompletionsModel.ts
@@ -335,6 +335,8 @@ export class InlineCompletionsModel extends Disposable {
 		}
 	});
 
+	private readonly _hasVisiblePeekWidgets = derived(this, reader => this._editorObs.openedPeekWidgets.read(reader) > 0);
+
 	public readonly state = derivedOpts<{
 		kind: 'ghostText';
 		edits: readonly SingleTextEdit[];
@@ -368,6 +370,9 @@ export class InlineCompletionsModel extends Disposable {
 		const item = this._inlineCompletionItems.read(reader);
 		const inlineEditResult = item?.inlineEdit;
 		if (inlineEditResult) {
+			if (this._hasVisiblePeekWidgets.read(reader)) {
+				return undefined;
+			}
 			let edit = inlineEditResult.toSingleTextEdit(reader);
 			edit = singleTextRemoveCommonPrefix(edit, model);
 

--- a/src/vs/editor/contrib/peekView/browser/peekView.ts
+++ b/src/vs/editor/contrib/peekView/browser/peekView.ts
@@ -26,6 +26,7 @@ import { IContextKeyService, RawContextKey } from '../../../../platform/contextk
 import { InstantiationType, registerSingleton } from '../../../../platform/instantiation/common/extensions.js';
 import { createDecorator, IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { activeContrastBorder, contrastBorder, editorForeground, editorInfoForeground, registerColor } from '../../../../platform/theme/common/colorRegistry.js';
+import { observableCodeEditor } from '../../../browser/observableCodeEditor.js';
 
 export const IPeekViewService = createDecorator<IPeekViewService>('IPeekViewService');
 export interface IPeekViewService {
@@ -117,6 +118,9 @@ export abstract class PeekViewWidget extends ZoneWidget {
 	) {
 		super(editor, options);
 		objects.mixin(this.options, defaultOptions, false);
+
+		const e = observableCodeEditor(this.editor);
+		e.openedPeekWidgets.set(e.openedPeekWidgets.get() + 1, undefined);
 	}
 
 	override dispose(): void {
@@ -124,6 +128,9 @@ export abstract class PeekViewWidget extends ZoneWidget {
 			this.disposed = true; // prevent consumers who dispose on onDidClose from looping
 			super.dispose();
 			this._onDidClose.fire(this);
+
+			const e = observableCodeEditor(this.editor);
+			e.openedPeekWidgets.set(e.openedPeekWidgets.get() - 1, undefined);
 		}
 	}
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-copilot/issues/12835
Fixes https://github.com/microsoft/vscode-copilot/issues/12199