### PR TITLE
[prompts]: update config schema

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -163,11 +163,27 @@ configurationRegistry.registerConfiguration({
 			default: true
 		},
 		[PromptFilesConfig.CONFIG_KEY]: {
-			type: ['boolean', 'object', 'array', 'string', 'null'],
+			type: 'object',
 			title: PromptFilesConfig.CONFIG_TITLE,
 			markdownDescription: PromptFilesConfig.CONFIG_DESCRIPTION,
-			default: null,
+			default: {
+				[PromptFilesConfig.DEFAULT_LOCATION]: false,
+			},
+			required: [PromptFilesConfig.DEFAULT_LOCATION],
+			additionalProperties: { type: 'boolean' },
+			unevaluatedProperties: { type: 'boolean' },
+			restricted: true,
+			disallowConfigurationDefault: true,
 			tags: ['experimental'],
+			examples: [
+				{
+					[PromptFilesConfig.DEFAULT_LOCATION]: true,
+				},
+				{
+					[PromptFilesConfig.DEFAULT_LOCATION]: true,
+					'/Users/vscode/repos/prompts': true,
+				},
+			],
 		},
 	}
 });

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/config.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/config.ts
@@ -257,37 +257,21 @@ export namespace PromptFilesConfig {
 		return [];
 	};
 
-	const usageExample1 = nls.localize(
-		`chat.promptFiles.config.description.example1`,
-		"Enable with the default location of prompt files (`{0}`):\n{1}",
-		DEFAULT_LOCATION,
-		`\`\`\`json\n{\n  "${CONFIG_KEY}": true,\n}\n\`\`\``,
-	);
-	const usageExample2 = nls.localize(
-		`chat.promptFiles.config.description.example2`,
-		"Specify custom location(s) of prompt files (in addition to `{0}`):\n{1}",
-		DEFAULT_LOCATION,
-		`\`\`\`json\n{\n  "${CONFIG_KEY}": {\n    ".copilot/prompts": true,\n    "/Users/vscode/prompts": true,\n}\n\`\`\``,
-	);
-
 	/**
 	 * Configuration setting description to use in the settings UI.
 	 */
 	export const CONFIG_DESCRIPTION = nls.localize(
 		'chat.promptFiles.config.description',
-		"Enable support for attaching reusable prompt files (`*{0}`) for Chat, Edits, and Inline Chat sessions. [Learn More]({1}).\n\nSet to `true` or use the `{ \"/path/to/folder\": boolean }` notation to specify a different path (or multiple). Relative paths are resolved from the root folder(s) of your workspace, and the `{2}` path is used by default and in addition to provided custom locations.\n#### Examples\n{3}\n{4}",
+		"Specify location(s) of reusable prompt files (`*{0}`) that can be attached in Chat, Edits, and Inline Chat sessions. [Learn More]({1}).\n\nRelative paths are resolved from the root folder(s) of your workspace.",
 		PROMPT_FILE_EXTENSION,
 		DOCUMENTATION_URL,
-		DEFAULT_LOCATION,
-		usageExample1,
-		usageExample2,
 	);
 
 	/**
 	 * Configuration setting title to use in the settings UI.
 	 */
 	export const CONFIG_TITLE = nls.localize(
-		`chat.promptFiles.config.title`,
+		'chat.promptFiles.config.title',
 		"Prompt Files",
 	);
 }

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/config.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/config.ts
@@ -8,6 +8,10 @@ import { DOCUMENTATION_URL, PROMPT_FILE_EXTENSION } from './constants.js';
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 
 /**
+ * `!Note!` This doc comment is deprecated and is set to be updated during `debt` week.
+ *         The configuration value can now be one of `{ '/path/to/folder': boolean }` or 'null' types.
+ *         This comment is tracked by [#13119](https://github.com/microsoft/vscode-copilot/issues/13119).
+ *
  * Configuration helper for the `prompt files` feature.
  * @see {@link CONFIG_KEY} and {@link DEFAULT_LOCATION}
  *

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/config.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/config.ts
@@ -125,7 +125,7 @@ export namespace PromptFilesConfig {
 	/**
 	 * Default reusable prompt files location.
 	 */
-	const DEFAULT_LOCATION = '.github/prompts';
+	export const DEFAULT_LOCATION = '.github/prompts';
 
 	/**
 	 * Get value of the `prompt files` configuration setting.


### PR DESCRIPTION
Update config schema to `object`/`null` types only to allow for better setting editing experience.

For [#13088](https://github.com/microsoft/vscode-copilot/issues/13088).