### PR TITLE
ci: debug flaky asset_id step in macOS sign stage

### DIFF
--- a/build/azure-pipelines/darwin/product-build-darwin-sign.yml
+++ b/build/azure-pipelines/darwin/product-build-darwin-sign.yml
@@ -21,6 +21,25 @@ steps:
       Pattern: noop
     displayName: 'Install ESRP Tooling'
 
+  - script: |
+      # For legacy purposes, arch for x64 is just 'darwin'
+      case $VSCODE_ARCH in
+        x64) ASSET_ID="darwin" ;;
+        arm64) ASSET_ID="darwin-arm64" ;;
+        universal) ASSET_ID="darwin-universal" ;;
+      esac
+      echo "##vso[task.setvariable variable=ASSET_ID]$ASSET_ID"
+    displayName: Set asset id variable
+
+  - script: |
+      if [ -z "$(ASSET_ID)" ]; then
+        echo "ASSET_ID is empty"
+        exit 1
+      else
+        echo "ASSET_ID is set to $(ASSET_ID)"
+      fi
+    displayName: Check ASSET_ID variable
+
   - download: current
     artifact: unsigned_vscode_client_darwin_$(VSCODE_ARCH)_archive
     displayName: Download $(VSCODE_ARCH) artifact
@@ -47,16 +66,6 @@ steps:
       "$APP_PATH/Contents/Resources/app/bin/code" --export-default-configuration=.build
     displayName: Verify signature
     condition: and(succeeded(), ne(variables['VSCODE_ARCH'], 'arm64'))
-
-  - script: |
-      # For legacy purposes, arch for x64 is just 'darwin'
-      case $VSCODE_ARCH in
-        x64) ASSET_ID="darwin" ;;
-        arm64) ASSET_ID="darwin-arm64" ;;
-        universal) ASSET_ID="darwin-universal" ;;
-      esac
-      echo "##vso[task.setvariable variable=ASSET_ID]$ASSET_ID"
-    displayName: Set asset id variable
 
   - script: mv $(Pipeline.Workspace)/unsigned_vscode_client_darwin_$(VSCODE_ARCH)_archive/VSCode-darwin-x64.zip $(Pipeline.Workspace)/unsigned_vscode_client_darwin_$(VSCODE_ARCH)_archive/VSCode-darwin.zip
     displayName: Rename x64 build to its legacy name


### PR DESCRIPTION
Possible fix to https://dev.azure.com/monacotools/Monaco/_build/results?buildId=319253&view=logs&j=cc62617d-be77-5d95-d8ac-62a295834e6a&t=8100c606-2f01-5efc-9d76-d31cf2b3de38&s=a56e7651-4213-56af-9488-c25fe636c10c