### PR TITLE
rename `ChatInstructionsFileLocator` utility

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/actions/chatAttachPromptAction/showPromptSelectionDialog.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatAttachPromptAction/showPromptSelectionDialog.ts
@@ -10,8 +10,8 @@ import { isLinux, isWindows } from '../../../../../../base/common/platform.js';
 import { ILabelService } from '../../../../../../platform/label/common/label.js';
 import { IOpenerService } from '../../../../../../platform/opener/common/opener.js';
 import { basename, dirname, extUri } from '../../../../../../base/common/resources.js';
+import { PromptFilesLocator } from '../../../common/promptSyntax/utils/promptFilesLocator.js';
 import { DOCUMENTATION_URL, PROMPT_FILE_EXTENSION } from '../../../common/promptSyntax/constants.js';
-import { ChatInstructionsFileLocator } from '../../chatAttachmentModel/chatInstructionsFileLocator.js';
 import { IInstantiationService } from '../../../../../../platform/instantiation/common/instantiation.js';
 import { IPickOptions, IQuickInputService, IQuickPickItem } from '../../../../../../platform/quickinput/common/quickInput.js';
 
@@ -108,7 +108,7 @@ export const showSelectPromptDialog = async (
 	options: ISelectPromptOptions,
 ): Promise<IPromptSelectionResult | null> => {
 	const { resource, initService, labelService } = options;
-	const promptsLocator = initService.createInstance(ChatInstructionsFileLocator);
+	const promptsLocator = initService.createInstance(PromptFilesLocator);
 
 	// find all prompt instruction files in the user workspace
 	// and present them to the user so they can select one

--- a/src/vs/workbench/contrib/chat/browser/chatAttachmentModel/chatInstructionAttachmentsModel.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatAttachmentModel/chatInstructionAttachmentsModel.ts
@@ -6,11 +6,11 @@
 import { URI } from '../../../../../base/common/uri.js';
 import { Emitter } from '../../../../../base/common/event.js';
 import { IChatRequestVariableEntry } from '../../common/chatModel.js';
-import { ChatInstructionsFileLocator } from './chatInstructionsFileLocator.js';
 import { PromptFilesConfig } from '../../common/promptSyntax/config.js';
 import { IPromptFileReference } from '../../common/promptSyntax/parsers/types.js';
 import { ChatInstructionsAttachmentModel } from './chatInstructionsAttachment.js';
 import { Disposable, DisposableMap } from '../../../../../base/common/lifecycle.js';
+import { PromptFilesLocator } from '../../common/promptSyntax/utils/promptFilesLocator.js';
 import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 
@@ -68,7 +68,7 @@ export class ChatInstructionAttachmentsModel extends Disposable {
 	/**
 	 * Helper to locate prompt instruction files on the disk.
 	 */
-	private readonly instructionsFileReader: ChatInstructionsFileLocator;
+	private readonly instructionsFileReader: PromptFilesLocator;
 
 	/**
 	 * List of all prompt instruction attachments.
@@ -171,7 +171,7 @@ export class ChatInstructionAttachmentsModel extends Disposable {
 		super();
 
 		this._onUpdate.fire = this._onUpdate.fire.bind(this._onUpdate);
-		this.instructionsFileReader = initService.createInstance(ChatInstructionsFileLocator);
+		this.instructionsFileReader = initService.createInstance(PromptFilesLocator);
 	}
 
 	/**

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/utils/promptFilesLocator.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/utils/promptFilesLocator.ts
@@ -3,19 +3,19 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { URI } from '../../../../../base/common/uri.js';
-import { ResourceSet } from '../../../../../base/common/map.js';
-import { PromptFilesConfig } from '../../common/promptSyntax/config.js';
-import { dirname, extUri } from '../../../../../base/common/resources.js';
-import { IFileService } from '../../../../../platform/files/common/files.js';
-import { PROMPT_FILE_EXTENSION } from '../../common/promptSyntax/constants.js';
-import { IWorkspaceContextService } from '../../../../../platform/workspace/common/workspace.js';
-import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
+import { PromptFilesConfig } from '../config.js';
+import { PROMPT_FILE_EXTENSION } from '../constants.js';
+import { URI } from '../../../../../../base/common/uri.js';
+import { ResourceSet } from '../../../../../../base/common/map.js';
+import { dirname, extUri } from '../../../../../../base/common/resources.js';
+import { IFileService } from '../../../../../../platform/files/common/files.js';
+import { IWorkspaceContextService } from '../../../../../../platform/workspace/common/workspace.js';
+import { IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
 
 /**
  * Class to locate prompt files.
  */
-export class ChatInstructionsFileLocator {
+export class PromptFilesLocator {
 	constructor(
 		@IFileService private readonly fileService: IFileService,
 		@IWorkspaceContextService private readonly workspaceService: IWorkspaceContextService,

--- a/src/vs/workbench/contrib/chat/test/common/promptSyntax/config.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/promptSyntax/config.test.ts
@@ -12,7 +12,7 @@ import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/
 import { IConfigurationOverrides, IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
 
 /**
- * Mocked mocked instance of {@link IConfigurationService}.
+ * Mocked instance of {@link IConfigurationService}.
  */
 const createMock = <T>(value: T): IConfigurationService => {
 	return mockService<IConfigurationService>({

--- a/src/vs/workbench/contrib/chat/test/common/promptSyntax/utils/promptFilesLocator.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/promptSyntax/utils/promptFilesLocator.test.ts
@@ -22,7 +22,7 @@ import { IConfigurationOverrides, IConfigurationService } from '../../../../../.
 import { IWorkspace, IWorkspaceContextService, IWorkspaceFolder } from '../../../../../../../platform/workspace/common/workspace.js';
 
 /**
- * Mocked mocked instance of {@link IConfigurationService}.
+ * Mocked instance of {@link IConfigurationService}.
  */
 const mockConfigService = <T>(value: T): IConfigurationService => {
 	return mockService<IConfigurationService>({
@@ -39,7 +39,7 @@ const mockConfigService = <T>(value: T): IConfigurationService => {
 };
 
 /**
- * Mocked mocked instance of {@link IWorkspaceContextService}.
+ * Mocked instance of {@link IWorkspaceContextService}.
  */
 const mockWorkspaceService = (folders: IWorkspaceFolder[]): IWorkspaceContextService => {
 	return mockService<IWorkspaceContextService>({

--- a/src/vs/workbench/contrib/chat/test/common/promptSyntax/utils/promptFilesLocator.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/promptSyntax/utils/promptFilesLocator.test.ts
@@ -4,22 +4,22 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
-import { Schemas } from '../../../../../../base/common/network.js';
-import { basename } from '../../../../../../base/common/resources.js';
-import { isWindows } from '../../../../../../base/common/platform.js';
-import { PromptFilesConfig } from '../../../common/promptSyntax/config.js';
-import { createURI } from '../../common/promptSyntax/testUtils/createUri.js';
-import { IFileService } from '../../../../../../platform/files/common/files.js';
-import { FileService } from '../../../../../../platform/files/common/fileService.js';
-import { mockObject, mockService } from '../../common/promptSyntax/testUtils/mock.js';
-import { ILogService, NullLogService } from '../../../../../../platform/log/common/log.js';
-import { IMockFolder, MockFilesystem } from '../../common/promptSyntax/testUtils/mockFilesystem.js';
-import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
-import { ChatInstructionsFileLocator } from '../../../browser/chatAttachmentModel/chatInstructionsFileLocator.js';
-import { InMemoryFileSystemProvider } from '../../../../../../platform/files/common/inMemoryFilesystemProvider.js';
-import { TestInstantiationService } from '../../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
-import { IConfigurationOverrides, IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
-import { IWorkspace, IWorkspaceContextService, IWorkspaceFolder } from '../../../../../../platform/workspace/common/workspace.js';
+import { createURI } from '../testUtils/createUri.js';
+import { mockObject, mockService } from '../testUtils/mock.js';
+import { Schemas } from '../../../../../../../base/common/network.js';
+import { basename } from '../../../../../../../base/common/resources.js';
+import { isWindows } from '../../../../../../../base/common/platform.js';
+import { IMockFolder, MockFilesystem } from '../testUtils/mockFilesystem.js';
+import { PromptFilesConfig } from '../../../../common/promptSyntax/config.js';
+import { IFileService } from '../../../../../../../platform/files/common/files.js';
+import { FileService } from '../../../../../../../platform/files/common/fileService.js';
+import { ILogService, NullLogService } from '../../../../../../../platform/log/common/log.js';
+import { PromptFilesLocator } from '../../../../common/promptSyntax/utils/promptFilesLocator.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../../base/test/common/utils.js';
+import { InMemoryFileSystemProvider } from '../../../../../../../platform/files/common/inMemoryFilesystemProvider.js';
+import { TestInstantiationService } from '../../../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
+import { IConfigurationOverrides, IConfigurationService } from '../../../../../../../platform/configuration/common/configuration.js';
+import { IWorkspace, IWorkspaceContextService, IWorkspaceFolder } from '../../../../../../../platform/workspace/common/workspace.js';
 
 /**
  * Mocked mocked instance of {@link IConfigurationService}.
@@ -51,7 +51,7 @@ const mockWorkspaceService = (folders: IWorkspaceFolder[]): IWorkspaceContextSer
 	});
 };
 
-suite('ChatInstructionsFileLocator', () => {
+suite('PromptFilesLocator', () => {
 	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
 
 	if (isWindows) {
@@ -71,14 +71,14 @@ suite('ChatInstructionsFileLocator', () => {
 	});
 
 	/**
-	 * Create a new instance of {@link ChatInstructionsFileLocator} with provided mocked
+	 * Create a new instance of {@link PromptFilesLocator} with provided mocked
 	 * values for configuration and workspace services.
 	 */
 	const createPromptsLocator = async (
 		configValue: unknown,
 		workspaceFolderPaths: string[],
 		filesystem: IMockFolder[],
-	): Promise<ChatInstructionsFileLocator> => {
+	): Promise<PromptFilesLocator> => {
 		await (initService.createInstance(MockFilesystem, filesystem)).mock();
 
 		initService.stub(IConfigurationService, mockConfigService(configValue));
@@ -94,7 +94,7 @@ suite('ChatInstructionsFileLocator', () => {
 		});
 		initService.stub(IWorkspaceContextService, mockWorkspaceService(workspaceFolders));
 
-		return initService.createInstance(ChatInstructionsFileLocator);
+		return initService.createInstance(PromptFilesLocator);
 	};
 
 	suite('• empty workspace', () => {


### PR DESCRIPTION
Renames `ChatInstructionsFileLocator` utility and move it under `/common` to be used by more code.

Needed for https://github.com/microsoft/vscode-copilot/issues/13087.