### PR TITLE
refactor prompts syntax service

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/actions/chatAttachPromptAction.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatAttachPromptAction.ts
@@ -15,6 +15,7 @@ import { ServicesAccessor } from '../../../../../editor/browser/editorExtensions
 import { IQuickInputService } from '../../../../../platform/quickinput/common/quickInput.js';
 import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
 import { ISelectPromptOptions, showSelectPromptDialog } from './chatAttachPromptAction/showPromptSelectionDialog.js';
+import { IPromptsService } from '../../common/promptSyntax/service/types.js';
 
 /**
  * Action ID for the `Attach Prompt` action.
@@ -48,6 +49,7 @@ export class AttachPromptAction extends Action2 {
 		const labelService = accessor.get(ILabelService);
 		const viewsService = accessor.get(IViewsService);
 		const openerService = accessor.get(IOpenerService);
+		const promptsService = accessor.get(IPromptsService);
 		const initService = accessor.get(IInstantiationService);
 		const quickInputService = accessor.get(IQuickInputService);
 
@@ -55,8 +57,9 @@ export class AttachPromptAction extends Action2 {
 			...options,
 			initService,
 			labelService,
-			quickInputService,
 			openerService,
+			promptsService,
+			quickInputService,
 		});
 
 		// no prompt selected, nothing to do

--- a/src/vs/workbench/contrib/chat/browser/actions/chatAttachPromptAction/showPromptSelectionDialog.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatAttachPromptAction/showPromptSelectionDialog.ts
@@ -7,7 +7,7 @@ import { IChatWidget } from '../../chat.js';
 import { localize } from '../../../../../../nls.js';
 import { URI } from '../../../../../../base/common/uri.js';
 import { isLinux, isWindows } from '../../../../../../base/common/platform.js';
-import { IPromptsService } from '../../../common/promptSyntax/service/types.js';
+import { IPrompt, IPromptsService } from '../../../common/promptSyntax/service/types.js';
 import { ILabelService } from '../../../../../../platform/label/common/label.js';
 import { IOpenerService } from '../../../../../../platform/opener/common/opener.js';
 import { basename, dirname, extUri } from '../../../../../../base/common/resources.js';
@@ -67,18 +67,18 @@ interface IPromptSelectionResult {
  * Creates a quick pick item for a prompt.
  */
 const createPickItem = (
-	promptUri: URI,
+	{ uri }: IPrompt,
 	labelService: ILabelService,
 ): WithUriValue<IQuickPickItem> => {
-	const fileBasename = basename(promptUri);
+	const fileBasename = basename(uri);
 	const fileWithoutExtension = fileBasename.replace(PROMPT_FILE_EXTENSION, '');
 
 	return {
 		type: 'item',
 		label: fileWithoutExtension,
-		description: labelService.getUriLabel(dirname(promptUri), { relative: true }),
-		tooltip: promptUri.fsPath,
-		value: promptUri,
+		description: labelService.getUriLabel(dirname(uri), { relative: true }),
+		tooltip: uri.fsPath,
+		value: uri,
 	};
 };
 
@@ -113,9 +113,9 @@ export const showSelectPromptDialog = async (
 	// find all prompt instruction files in the user workspace
 	// and present them to the user so they can select one
 	const files = await promptsService.listPromptFiles()
-		.then((files) => {
-			return files.map((file) => {
-				return createPickItem(file, labelService);
+		.then((promptFiles) => {
+			return promptFiles.map((promptFile) => {
+				return createPickItem(promptFile, labelService);
 			});
 		});
 

--- a/src/vs/workbench/contrib/chat/browser/actions/chatAttachPromptAction/showPromptSelectionDialog.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatAttachPromptAction/showPromptSelectionDialog.ts
@@ -7,10 +7,10 @@ import { IChatWidget } from '../../chat.js';
 import { localize } from '../../../../../../nls.js';
 import { URI } from '../../../../../../base/common/uri.js';
 import { isLinux, isWindows } from '../../../../../../base/common/platform.js';
+import { IPromptsService } from '../../../common/promptSyntax/service/types.js';
 import { ILabelService } from '../../../../../../platform/label/common/label.js';
 import { IOpenerService } from '../../../../../../platform/opener/common/opener.js';
 import { basename, dirname, extUri } from '../../../../../../base/common/resources.js';
-import { PromptFilesLocator } from '../../../common/promptSyntax/utils/promptFilesLocator.js';
 import { DOCUMENTATION_URL, PROMPT_FILE_EXTENSION } from '../../../common/promptSyntax/constants.js';
 import { IInstantiationService } from '../../../../../../platform/instantiation/common/instantiation.js';
 import { IPickOptions, IQuickInputService, IQuickPickItem } from '../../../../../../platform/quickinput/common/quickInput.js';
@@ -42,6 +42,7 @@ export interface ISelectPromptOptions {
 
 	labelService: ILabelService;
 	openerService: IOpenerService;
+	promptsService: IPromptsService;
 	initService: IInstantiationService;
 	quickInputService: IQuickInputService;
 }
@@ -107,12 +108,11 @@ const createPlaceholderText = (widget?: IChatWidget): string => {
 export const showSelectPromptDialog = async (
 	options: ISelectPromptOptions,
 ): Promise<IPromptSelectionResult | null> => {
-	const { resource, initService, labelService } = options;
-	const promptsLocator = initService.createInstance(PromptFilesLocator);
+	const { resource, labelService, promptsService } = options;
 
 	// find all prompt instruction files in the user workspace
 	// and present them to the user so they can select one
-	const files = await promptsLocator.listFiles([])
+	const files = await promptsService.listPromptFiles()
 		.then((files) => {
 			return files.map((file) => {
 				return createPickItem(file, labelService);

--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -44,8 +44,8 @@ import { ILanguageModelToolsService } from '../common/languageModelToolsService.
 import { PromptFilesConfig } from '../common/promptSyntax/config.js';
 import '../common/promptSyntax/languageFeatures/promptLinkProvider.js';
 import '../common/promptSyntax/languageFeatures/promptPathAutocompletion.js';
-import { PromptSyntaxService } from '../common/promptSyntax/service/promptSyntaxService.js';
-import { IPromptSyntaxService } from '../common/promptSyntax/service/types.js';
+import { PromptsService } from '../common/promptSyntax/service/promptsService.js';
+import { IPromptsService } from '../common/promptSyntax/service/types.js';
 import './promptSyntax/contributions/usePromptCommand.js';
 import { LanguageModelToolsExtensionPointHandler } from '../common/tools/languageModelToolsContribution.js';
 import { BuiltinToolsContribution } from '../common/tools/tools.js';
@@ -451,4 +451,4 @@ registerSingleton(IChatMarkdownAnchorService, ChatMarkdownAnchorService, Instant
 registerSingleton(ILanguageModelIgnoredFilesService, LanguageModelIgnoredFilesService, InstantiationType.Delayed);
 registerSingleton(IChatQuotasService, ChatQuotasService, InstantiationType.Delayed);
 
-registerSingleton(IPromptSyntaxService, PromptSyntaxService, InstantiationType.Delayed);
+registerSingleton(IPromptsService, PromptsService, InstantiationType.Delayed);

--- a/src/vs/workbench/contrib/chat/browser/chatAttachmentModel/chatInstructionAttachmentsModel.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatAttachmentModel/chatInstructionAttachmentsModel.ts
@@ -10,7 +10,6 @@ import { PromptFilesConfig } from '../../common/promptSyntax/config.js';
 import { IPromptFileReference } from '../../common/promptSyntax/parsers/types.js';
 import { ChatInstructionsAttachmentModel } from './chatInstructionsAttachment.js';
 import { Disposable, DisposableMap } from '../../../../../base/common/lifecycle.js';
-import { PromptFilesLocator } from '../../common/promptSyntax/utils/promptFilesLocator.js';
 import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 
@@ -65,11 +64,6 @@ export const toChatVariable = (
  * See {@linkcode ChatInstructionsAttachmentModel} for individual attachment.
  */
 export class ChatInstructionAttachmentsModel extends Disposable {
-	/**
-	 * Helper to locate prompt instruction files on the disk.
-	 */
-	private readonly instructionsFileReader: PromptFilesLocator;
-
 	/**
 	 * List of all prompt instruction attachments.
 	 */
@@ -171,7 +165,6 @@ export class ChatInstructionAttachmentsModel extends Disposable {
 		super();
 
 		this._onUpdate.fire = this._onUpdate.fire.bind(this._onUpdate);
-		this.instructionsFileReader = initService.createInstance(PromptFilesLocator);
 	}
 
 	/**
@@ -215,13 +208,6 @@ export class ChatInstructionAttachmentsModel extends Disposable {
 		this.attachments.deleteAndDispose(uri.path);
 
 		return this;
-	}
-
-	/**
-	 * List prompt instruction files available and not attached yet.
-	 */
-	public async listNonAttachedFiles(): Promise<readonly URI[]> {
-		return await this.instructionsFileReader.listFiles(this.references);
 	}
 
 	/**

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/languageFeatures/promptLinkProvider.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/languageFeatures/promptLinkProvider.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { LANGUAGE_SELECTOR } from '../constants.js';
-import { IPromptSyntaxService } from '../service/types.js';
+import { IPromptsService } from '../service/types.js';
 import { assert } from '../../../../../../base/common/assert.js';
 import { ITextModel } from '../../../../../../editor/common/model.js';
 import { assertDefined } from '../../../../../../base/common/types.js';
@@ -23,7 +23,7 @@ import { IWorkbenchContributionsRegistry, Extensions as WorkbenchExtensions } fr
  */
 export class PromptLinkProvider extends Disposable implements LinkProvider {
 	constructor(
-		@IPromptSyntaxService private readonly promptSyntaxService: IPromptSyntaxService,
+		@IPromptsService private readonly promptSyntaxService: IPromptsService,
 		@ILanguageFeaturesService private readonly languageService: ILanguageFeaturesService,
 	) {
 		super();
@@ -43,7 +43,7 @@ export class PromptLinkProvider extends Disposable implements LinkProvider {
 			new CancellationError(),
 		);
 
-		const parser = this.promptSyntaxService.getParserFor(model);
+		const parser = this.promptSyntaxService.getSyntaxParserFor(model);
 		assert(
 			!parser.disposed,
 			'Prompt parser must not be disposed.',

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/languageFeatures/promptPathAutocompletion.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/languageFeatures/promptPathAutocompletion.ts
@@ -15,7 +15,7 @@
  */
 
 import { LANGUAGE_SELECTOR } from '../constants.js';
-import { IPromptSyntaxService } from '../service/types.js';
+import { IPromptsService } from '../service/types.js';
 import { URI } from '../../../../../../base/common/uri.js';
 import { IPromptFileReference } from '../parsers/types.js';
 import { FileReference } from '../codecs/tokens/fileReference.js';
@@ -101,7 +101,7 @@ export class PromptPathAutocompletion extends Disposable implements CompletionIt
 
 	constructor(
 		@IFileService private readonly fileService: IFileService,
-		@IPromptSyntaxService private readonly promptSyntaxService: IPromptSyntaxService,
+		@IPromptsService private readonly promptSyntaxService: IPromptsService,
 		@ILanguageFeaturesService private readonly languageService: ILanguageFeaturesService,
 	) {
 		super();
@@ -137,7 +137,7 @@ export class PromptPathAutocompletion extends Disposable implements CompletionIt
 			`Prompt path autocompletion provider`,
 		);
 
-		const parser = this.promptSyntaxService.getParserFor(model);
+		const parser = this.promptSyntaxService.getSyntaxParserFor(model);
 		assert(
 			!parser.disposed,
 			'Prompt parser must not be disposed.',

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsService.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsService.ts
@@ -3,8 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { IPromptsService } from './types.js';
-import { URI } from '../../../../../../base/common/uri.js';
+import { IPrompt, IPromptsService } from './types.js';
 import { assert } from '../../../../../../base/common/assert.js';
 import { PromptFilesLocator } from '../utils/promptFilesLocator.js';
 import { ITextModel } from '../../../../../../editor/common/model.js';
@@ -79,7 +78,15 @@ export class PromptsService extends Disposable implements IPromptsService {
 		return this.cache.get(model);
 	}
 
-	public async listPromptFiles(): Promise<readonly URI[]> {
-		return await this.fileLocator.listFiles([]);
+	public async listPromptFiles(): Promise<readonly IPrompt[]> {
+		const promptFiles = await this.fileLocator.listFiles([]);
+
+		return promptFiles.map((uri) => {
+			return {
+				uri,
+				// right now all prompts are coming from the local disk
+				source: 'local',
+			};
+		});
 	}
 }

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsService.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsService.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { IPromptSyntaxService } from './types.js';
+import { IPromptsService } from './types.js';
 import { assert } from '../../../../../../base/common/assert.js';
 import { ITextModel } from '../../../../../../editor/common/model.js';
 import { Disposable } from '../../../../../../base/common/lifecycle.js';
@@ -12,9 +12,9 @@ import { TextModelPromptParser } from '../parsers/textModelPromptParser.js';
 import { IInstantiationService } from '../../../../../../platform/instantiation/common/instantiation.js';
 
 /**
- * Provides prompt syntax services.
+ * Provides prompt services.
  */
-export class PromptSyntaxService extends Disposable implements IPromptSyntaxService {
+export class PromptsService extends Disposable implements IPromptsService {
 	declare readonly _serviceBrand: undefined;
 
 	/**
@@ -34,7 +34,7 @@ export class PromptSyntaxService extends Disposable implements IPromptSyntaxServ
 				/**
 				 * Note! When/if shared with "file" prompts, the `seenReferences` array below must be taken into account.
 				 * Otherwise consumers will either see incorrect failing or incorrect successful results, based on their
-				 * use case, timing of their calls to the {@link getParserFor} function, and state of this service.
+				 * use case, timing of their calls to the {@link getSyntaxParserFor} function, and state of this service.
 				 */
 				const parser: TextModelPromptParser = initService.createInstance(
 					TextModelPromptParser,
@@ -63,7 +63,7 @@ export class PromptSyntaxService extends Disposable implements IPromptSyntaxServ
 	 * 	- newly created parser is disposed immediately on initialization.
 	 * 	  See factory function in the {@link constructor} for more info.
 	 */
-	public getParserFor(
+	public getSyntaxParserFor(
 		model: ITextModel,
 	): TextModelPromptParser & { disposed: false } {
 		assert(

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsService.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsService.ts
@@ -4,7 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { IPromptsService } from './types.js';
+import { URI } from '../../../../../../base/common/uri.js';
 import { assert } from '../../../../../../base/common/assert.js';
+import { PromptFilesLocator } from '../utils/promptFilesLocator.js';
 import { ITextModel } from '../../../../../../editor/common/model.js';
 import { Disposable } from '../../../../../../base/common/lifecycle.js';
 import { ObjectCache } from '../../../../../../base/common/objectCache.js';
@@ -22,8 +24,13 @@ export class PromptsService extends Disposable implements IPromptsService {
 	 */
 	private readonly cache: ObjectCache<TextModelPromptParser, ITextModel>;
 
+	/**
+	 * Prompt files locator utility.
+	 */
+	private readonly fileLocator = this.initService.createInstance(PromptFilesLocator);
+
 	constructor(
-		@IInstantiationService initService: IInstantiationService,
+		@IInstantiationService private readonly initService: IInstantiationService,
 	) {
 		super();
 
@@ -56,8 +63,6 @@ export class PromptsService extends Disposable implements IPromptsService {
 	}
 
 	/**
-	 * Gets a prompt syntax parser for the provided text model.
-	 *
 	 * @throws {Error} if:
 	 * 	- the provided model is disposed
 	 * 	- newly created parser is disposed immediately on initialization.
@@ -68,9 +73,13 @@ export class PromptsService extends Disposable implements IPromptsService {
 	): TextModelPromptParser & { disposed: false } {
 		assert(
 			!model.isDisposed(),
-			'Cannot create a prompt parser for a disposed model.',
+			'Cannot create a prompt syntax parser for a disposed model.',
 		);
 
 		return this.cache.get(model);
+	}
+
+	public async listPromptFiles(): Promise<readonly URI[]> {
+		return await this.fileLocator.listFiles([]);
 	}
 }

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/service/types.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/service/types.ts
@@ -15,6 +15,23 @@ import { createDecorator } from '../../../../../../platform/instantiation/common
 export const IPromptsService = createDecorator<IPromptsService>('IPromptsService');
 
 /**
+ * Represents a prompt reference.
+ */
+export interface IPrompt {
+	/**
+	 * The URI of the prompt.
+	 */
+	readonly uri: URI;
+
+	/**
+	 * The source of the prompt.
+	 * - `local` means the prompt is a local file.
+	 * - `global` means a "roamble" global prompt file.
+	 */
+	readonly source: 'local' | 'global';
+}
+
+/**
  * Provides prompt services.
  */
 export interface IPromptsService extends IDisposable {
@@ -31,5 +48,5 @@ export interface IPromptsService extends IDisposable {
 	/**
 	 * List all available prompt files.
 	 */
-	listPromptFiles(): Promise<readonly URI[]>;
+	listPromptFiles(): Promise<readonly IPrompt[]>;
 }

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/service/types.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/service/types.ts
@@ -11,12 +11,12 @@ import { createDecorator } from '../../../../../../platform/instantiation/common
 /**
  * Provides prompt syntax services.
  */
-export const IPromptSyntaxService = createDecorator<IPromptSyntaxService>('IPromptSyntaxService');
+export const IPromptsService = createDecorator<IPromptsService>('IPromptsService');
 
 /**
- * Provides prompt syntax services.
+ * Provides prompt services.
  */
-export interface IPromptSyntaxService extends IDisposable {
+export interface IPromptsService extends IDisposable {
 	readonly _serviceBrand: undefined;
 
 	/**
@@ -25,7 +25,7 @@ export interface IPromptSyntaxService extends IDisposable {
 	 *
 	 * @throws {Error} If a newly created parser gets immediately disposed.
 	 */
-	getParserFor(
+	getSyntaxParserFor(
 		model: ITextModel,
 	): TextModelPromptParser & { disposed: false };
 }

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/service/types.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/service/types.ts
@@ -3,13 +3,14 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { URI } from '../../../../../../base/common/uri.js';
 import { ITextModel } from '../../../../../../editor/common/model.js';
 import { IDisposable } from '../../../../../../base/common/lifecycle.js';
 import { TextModelPromptParser } from '../parsers/textModelPromptParser.js';
 import { createDecorator } from '../../../../../../platform/instantiation/common/instantiation.js';
 
 /**
- * Provides prompt syntax services.
+ * Provides prompt services.
  */
 export const IPromptsService = createDecorator<IPromptsService>('IPromptsService');
 
@@ -21,11 +22,14 @@ export interface IPromptsService extends IDisposable {
 
 	/**
 	 * Get a prompt syntax parser for the provided text model.
-	 * See {@link TextModelPromptParser} for more info on the parse API.
-	 *
-	 * @throws {Error} If a newly created parser gets immediately disposed.
+	 * See {@link TextModelPromptParser} for more info on the parser API.
 	 */
 	getSyntaxParserFor(
 		model: ITextModel,
 	): TextModelPromptParser & { disposed: false };
+
+	/**
+	 * List all available prompt files.
+	 */
+	listPromptFiles(): Promise<readonly URI[]>;
 }

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/utils/promptFilesLocator.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/utils/promptFilesLocator.ts
@@ -28,7 +28,26 @@ export class PromptFilesLocator {
 	 * @param exclude List of `URIs` to exclude from the result.
 	 * @returns List of prompt files found in the workspace.
 	 */
-	public async listFiles(exclude: ReadonlyArray<URI>): Promise<readonly URI[]> {
+	public async listFiles(
+		exclude: readonly URI[],
+	): Promise<readonly URI[]> {
+		return await this.listFilesIn(
+			this.getSourceLocations(),
+			exclude,
+		);
+	}
+
+	/**
+	 * Lists all prompt files in the provided locations.
+	 *
+	 * @param locations List of `URIs` to search for prompt files in.
+	 * @param exclude List of `URIs` to exclude from the result.
+	 * @returns List of prompt files found in the provided locations.
+	 */
+	public async listFilesIn(
+		locations: readonly URI[],
+		exclude: readonly URI[],
+	): Promise<readonly URI[]> {
 		// create a set from the list of URIs for convenience
 		const excludeSet: Set<string> = new Set();
 		for (const excludeUri of exclude) {
@@ -36,12 +55,12 @@ export class PromptFilesLocator {
 		}
 
 		// filter out the excluded paths from the locations list
-		const locations = this.getSourceLocations()
+		const cleanLocations = locations
 			.filter((location) => {
 				return !excludeSet.has(location.path);
 			});
 
-		return await this.findInstructionFiles(locations, excludeSet);
+		return await this.findInstructionFiles(cleanLocations, excludeSet);
 	}
 
 	/**

--- a/src/vs/workbench/contrib/chat/test/common/promptSyntax/service/promptsService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/promptSyntax/service/promptsService.test.ts
@@ -89,7 +89,7 @@ const assertLinks = (
 	);
 };
 
-suite('PromptSyntaxService', () => {
+suite('PromptsService', () => {
 	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
 
 	let service: IPromptsService;
@@ -104,8 +104,8 @@ suite('PromptSyntaxService', () => {
 		service = disposables.add(instantiationService.createInstance(PromptsService));
 	});
 
-	suite('getParserFor', () => {
-		test('provides cached parser instance', async () => {
+	suite('• getParserFor', () => {
+		test('• provides cached parser instance', async () => {
 			const langId = 'fooLang';
 
 			/**
@@ -427,7 +427,7 @@ suite('PromptSyntaxService', () => {
 			);
 		});
 
-		test('auto-updated on model changes', async () => {
+		test('• auto-updated on model changes', async () => {
 			const langId = 'bazLang';
 
 			const model = disposables.add(createTextModel(
@@ -495,7 +495,7 @@ suite('PromptSyntaxService', () => {
 			);
 		});
 
-		test('throws if disposed model provided', async function () {
+		test('• throws if disposed model provided', async function () {
 			const model = disposables.add(createTextModel(
 				'test1\ntest2\n\ntest3\t\n',
 				'barLang',

--- a/src/vs/workbench/contrib/chat/test/common/promptSyntax/service/promptsService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/promptSyntax/service/promptsService.test.ts
@@ -9,13 +9,13 @@ import { URI } from '../../../../../../../base/common/uri.js';
 import { Range } from '../../../../../../../editor/common/core/range.js';
 import { assertDefined } from '../../../../../../../base/common/types.js';
 import { waitRandom } from '../../../../../../../base/test/common/testUtils.js';
+import { IPromptsService } from '../../../../common/promptSyntax/service/types.js';
 import { IFileService } from '../../../../../../../platform/files/common/files.js';
 import { IPromptFileReference } from '../../../../common/promptSyntax/parsers/types.js';
-import { IPromptSyntaxService } from '../../../../common/promptSyntax/service/types.js';
 import { FileService } from '../../../../../../../platform/files/common/fileService.js';
 import { createTextModel } from '../../../../../../../editor/test/common/testTextModel.js';
 import { ILogService, NullLogService } from '../../../../../../../platform/log/common/log.js';
-import { PromptSyntaxService } from '../../../../common/promptSyntax/service/promptSyntaxService.js';
+import { PromptsService } from '../../../../common/promptSyntax/service/promptsService.js';
 import { TextModelPromptParser } from '../../../../common/promptSyntax/parsers/textModelPromptParser.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../../base/test/common/utils.js';
 import { IConfigurationService } from '../../../../../../../platform/configuration/common/configuration.js';
@@ -92,7 +92,7 @@ const assertLinks = (
 suite('PromptSyntaxService', () => {
 	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
 
-	let service: IPromptSyntaxService;
+	let service: IPromptsService;
 	let instantiationService: TestInstantiationService;
 
 	setup(async () => {
@@ -101,7 +101,7 @@ suite('PromptSyntaxService', () => {
 		instantiationService.stub(IConfigurationService, new TestConfigurationService());
 		instantiationService.stub(IFileService, disposables.add(instantiationService.createInstance(FileService)));
 
-		service = disposables.add(instantiationService.createInstance(PromptSyntaxService));
+		service = disposables.add(instantiationService.createInstance(PromptsService));
 	});
 
 	suite('getParserFor', () => {
@@ -119,7 +119,7 @@ suite('PromptSyntaxService', () => {
 				createURI('/Users/vscode/repos/test/file1.txt'),
 			));
 
-			const parser1 = service.getParserFor(model1);
+			const parser1 = service.getSyntaxParserFor(model1);
 			assert.strictEqual(
 				parser1.uri.toString(),
 				model1.uri.toString(),
@@ -166,7 +166,7 @@ suite('PromptSyntaxService', () => {
 			 */
 
 			// get the same parser again, the call must return the same object
-			const parser1_1 = service.getParserFor(model1);
+			const parser1_1 = service.getSyntaxParserFor(model1);
 			assert.strictEqual(
 				parser1,
 				parser1_1,
@@ -193,7 +193,7 @@ suite('PromptSyntaxService', () => {
 			// wait for some random amount of time
 			await waitRandom(5);
 
-			const parser2 = service.getParserFor(model2);
+			const parser2 = service.getSyntaxParserFor(model2);
 
 			assert.strictEqual(
 				parser2.uri.toString(),
@@ -303,7 +303,7 @@ suite('PromptSyntaxService', () => {
 			 * a new non-disposed parser object back with correct properties.
 			 */
 
-			const parser1_2 = service.getParserFor(model1);
+			const parser1_2 = service.getSyntaxParserFor(model1);
 
 			assert(
 				!parser1_2.disposed,
@@ -382,7 +382,7 @@ suite('PromptSyntaxService', () => {
 				undefined,
 				createURI('/Users/vscode/repos/test/some-folder/file.md'),
 			));
-			const parser2_1 = service.getParserFor(model2_1);
+			const parser2_1 = service.getSyntaxParserFor(model2_1);
 
 			assert(
 				!parser2_1.disposed,
@@ -437,7 +437,7 @@ suite('PromptSyntaxService', () => {
 				createURI('/repos/test/file1.txt'),
 			));
 
-			const parser = service.getParserFor(model);
+			const parser = service.getSyntaxParserFor(model);
 
 			// sanity checks
 			assert(
@@ -507,7 +507,7 @@ suite('PromptSyntaxService', () => {
 			model.dispose();
 
 			assert.throws(() => {
-				service.getParserFor(model);
+				service.getSyntaxParserFor(model);
 			}, 'Cannot create a prompt parser for a disposed model.');
 		});
 	});


### PR DESCRIPTION
Refactors `PromptsSyntaxService` into more general `PromptsService` and adds new `listPromptFiles()` method to it.

Needed for https://github.com/microsoft/vscode-copilot/issues/13087.