### PR TITLE
shellKind proposed api should replace shellType proposed api 

### DIFF
--- a/src/vs/platform/extensions/common/extensionsApiProposals.ts
+++ b/src/vs/platform/extensions/common/extensionsApiProposals.ts
@@ -352,6 +352,9 @@ const _allApiProposals = {
 	terminalShellEnv: {
 		proposal: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.terminalShellEnv.d.ts',
 	},
+	terminalShellKind: {
+		proposal: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.terminalShellKind.d.ts',
+	},
 	terminalShellType: {
 		proposal: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.terminalShellType.d.ts',
 	},

--- a/src/vscode-dts/vscode.proposed.terminalShellKind.d.ts
+++ b/src/vscode-dts/vscode.proposed.terminalShellKind.d.ts
@@ -1,0 +1,36 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+declare module 'vscode' {
+
+	// https://github.com/microsoft/vscode/issues/230165
+
+	/**
+	 * Standardize on shell binary with list of possibilities.
+	 * For example, 'bash' for bash, 'pwsh' for powershell, 'zsh' for zsh, etc..
+	 */
+	export type TerminalShellKind = string;
+
+
+	// Part of TerminalState since the shellKind can change multiple times and this comes with an event.
+	// Should remain on state since it is one of those things about terminal that could change, like isinteracted with
+
+	// Discuss reason why string would be better than enum with numbers:
+	// 1. String is better for future asks, could never "remove a enum shell with number once added (breaking change)"
+	// 2. Its more obvious on extension side (extensions wont have to decode what the enum numbers are equivalent to)
+	// 3. Not as messy to maintenance (we already have huge list of enum shell types), for string we don't need to save anything? (But would we have to keep a list of all the possiblities with the binary?)
+	export interface TerminalState {
+		/**
+		 * The current detected shell type of the terminal. New shell types may be added in the
+		 * future in which case they will be returned as a number that is not part of
+		 * {@link TerminalShellKind}.
+		 * Includes number type to prevent the breaking change when new enum members are added?
+		 */
+		readonly shellKind?: TerminalShellKind | undefined;
+
+		// TODO: update terminal suggest, python env ext.
+	}
+
+}

--- a/src/vscode-dts/vscode.proposed.terminalShellType.d.ts
+++ b/src/vscode-dts/vscode.proposed.terminalShellType.d.ts
@@ -26,7 +26,7 @@ declare module 'vscode' {
 		Node = 13
 	}
 
-
+	// Part of TerminalState since the shellType can change multiple times and this comes with an event.
 	export interface TerminalState {
 		/**
 		 * The current detected shell type of the terminal. New shell types may be added in the
@@ -36,4 +36,5 @@ declare module 'vscode' {
 		 */
 		readonly shellType?: TerminalShellType | number | undefined;
 	}
+
 }

--- a/src/vscode-dts/vscode.proposed.terminalShellType.d.ts
+++ b/src/vscode-dts/vscode.proposed.terminalShellType.d.ts
@@ -27,7 +27,6 @@ declare module 'vscode' {
 	}
 
 
-	// Part of TerminalState since the shellType can change multiple times and this comes with an event.
 	export interface TerminalState {
 		/**
 		 * The current detected shell type of the terminal. New shell types may be added in the
@@ -36,8 +35,5 @@ declare module 'vscode' {
 		 * Includes number type to prevent the breaking change when new enum members are added?
 		 */
 		readonly shellType?: TerminalShellType | number | undefined;
-		// readonly shellType?: string | undefined; better for future ask, not as messy to maintenance (we already have huge list of enum shell types)
-		// if change, update terminal suggest, python env ext.
 	}
-	// state: things about terminal that could change, like isinteracted with
 }

--- a/src/vscode-dts/vscode.proposed.terminalShellType.d.ts
+++ b/src/vscode-dts/vscode.proposed.terminalShellType.d.ts
@@ -26,6 +26,7 @@ declare module 'vscode' {
 		Node = 13
 	}
 
+
 	// Part of TerminalState since the shellType can change multiple times and this comes with an event.
 	export interface TerminalState {
 		/**
@@ -35,6 +36,8 @@ declare module 'vscode' {
 		 * Includes number type to prevent the breaking change when new enum members are added?
 		 */
 		readonly shellType?: TerminalShellType | number | undefined;
+		// readonly shellType?: string | undefined; better for future ask, not as messy to maintenance (we already have huge list of enum shell types)
+		// if change, update terminal suggest, python env ext.
 	}
-
+	// state: things about terminal that could change, like isinteracted with
 }


### PR DESCRIPTION
Resolves: https://github.com/microsoft/vscode/issues/230165 

Instead of: https://github.com/microsoft/vscode/pull/238071 

It looks like we should really try to go for string instead of huge list of enum numbers.