### PR TITLE
build: remove broken @vscode/node-addon-api

### DIFF
--- a/build/.moduleignore
+++ b/build/.moduleignore
@@ -135,6 +135,7 @@ vsda/**
 !@vscode/windows-ca-certs/package.json
 !@vscode/windows-ca-certs/**/*.node
 
+@vscode/node-addon-api/**/*
 node-addon-api/**/*
 prebuild-install/**/*
 


### PR DESCRIPTION
Seems like there is a race condition with `npm ci` in building native modules where `node-addon-api` generated build files is temporarily hoisted to `node_modules/@vscode` due to dependencies (spdlog, windows-process-tree, windows-mutex etc) sharing the package. This ends up creating a file with the following contents that gets bundled into the final product. The issue does not happen with `npm i` probably has to do with how the tree gets created.

```
# This file is generated by gyp; do not edit.

export builddir_name ?= ./build/../../node-addon-api/.
.PHONY: all
all:
	$(MAKE) -C ../windows-process-tree/build node_addon_api_except
```