### PR TITLE
Only cancel requests when hiding widget inside sync

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminal.suggest.contribution.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminal.suggest.contribution.ts
@@ -159,7 +159,7 @@ class TerminalSuggestContribution extends DisposableStore implements ITerminalCo
 				// Don't hide the suggest widget if the focus is moving to the details
 				return;
 			}
-			addon.hideSuggestWidget();
+			addon.hideSuggestWidget(true);
 		}));
 
 		this.add(addon.onAcceptedCompletion(async text => {
@@ -355,7 +355,7 @@ registerActiveInstanceAction({
 		// Escape is bound to other workbench keybindings that this needs to beat
 		weight: KeybindingWeight.WorkbenchContrib + 1
 	},
-	run: (activeInstance) => TerminalSuggestContribution.get(activeInstance)?.addon?.hideSuggestWidget()
+	run: (activeInstance) => TerminalSuggestContribution.get(activeInstance)?.addon?.hideSuggestWidget(true)
 });
 
 registerActiveInstanceAction({


### PR DESCRIPTION
sync may request completions beforehand so we don't want to cancel these ones.

Fixes #240656

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
