### PR TITLE
Add terminal inline suggest setting and exclude prefix before space

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalCompletionItem.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalCompletionItem.ts
@@ -15,6 +15,7 @@ export enum TerminalCompletionItemKind {
 	Argument = 4,
 	Alias = 5,
 	InlineSuggestion = 6,
+	InlineSuggestionAlwaysOnTop = 7,
 }
 
 export interface ITerminalCompletion extends ISimpleCompletion {

--- a/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalCompletionModel.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalCompletionModel.ts
@@ -18,11 +18,11 @@ export class TerminalCompletionModel extends SimpleCompletionModel<TerminalCompl
 }
 
 const compareCompletionsFn = (leadingLineContent: string, a: TerminalCompletionItem, b: TerminalCompletionItem) => {
-	// Boost inline completions first as matches should be first regardless of score
-	if (a.completion.kind === TerminalCompletionItemKind.InlineSuggestion && a.completion.kind !== b.completion.kind) {
+	// Boost always on top inline completions
+	if (a.completion.kind === TerminalCompletionItemKind.InlineSuggestionAlwaysOnTop && a.completion.kind !== b.completion.kind) {
 		return -1;
 	}
-	if (b.completion.kind === TerminalCompletionItemKind.InlineSuggestion && a.completion.kind !== b.completion.kind) {
+	if (b.completion.kind === TerminalCompletionItemKind.InlineSuggestionAlwaysOnTop && a.completion.kind !== b.completion.kind) {
 		return 1;
 	}
 
@@ -30,6 +30,14 @@ const compareCompletionsFn = (leadingLineContent: string, a: TerminalCompletionI
 	let score = b.score[0] - a.score[0];
 	if (score !== 0) {
 		return score;
+	}
+
+	// Boost inline completions
+	if (a.completion.kind === TerminalCompletionItemKind.InlineSuggestion && a.completion.kind !== b.completion.kind) {
+		return -1;
+	}
+	if (b.completion.kind === TerminalCompletionItemKind.InlineSuggestion && a.completion.kind !== b.completion.kind) {
+		return 1;
 	}
 
 	// Sort by underscore penalty (eg. `__init__/` should be penalized)

--- a/src/vs/workbench/contrib/terminalContrib/suggest/common/terminalSuggestConfiguration.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/common/terminalSuggestConfiguration.ts
@@ -17,6 +17,7 @@ export const enum TerminalSuggestSettingId {
 	Providers = 'terminal.integrated.suggest.providers',
 	ShowStatusBar = 'terminal.integrated.suggest.showStatusBar',
 	CdPath = 'terminal.integrated.suggest.cdPath',
+	InlineSuggestion = 'terminal.integrated.suggest.inlineSuggestion',
 }
 
 export const windowsDefaultExecutableExtensions: string[] = [
@@ -45,10 +46,14 @@ export interface ITerminalSuggestConfiguration {
 	quickSuggestions: boolean;
 	suggestOnTriggerCharacters: boolean;
 	runOnEnter: 'never' | 'exactMatch' | 'exactMatchIgnoreExtension' | 'always';
+	windowsExecutableExtensions: { [key: string]: boolean };
 	providers: {
 		'terminal-suggest': boolean;
 		'pwsh-shell-integration': boolean;
 	};
+	showStatusBar: boolean;
+	cdPath: 'off' | 'relative' | 'absolute';
+	inlineSuggestion: 'off' | 'alwaysOnTopExceptExactMatch' | 'alwaysOnTop';
 }
 
 export const terminalSuggestConfiguration: IStringDictionary<IConfigurationPropertySchema> = {
@@ -126,6 +131,19 @@ export const terminalSuggestConfiguration: IStringDictionary<IConfigurationPrope
 		default: 'absolute',
 		tags: ['preview']
 	},
+	[TerminalSuggestSettingId.InlineSuggestion]: {
+		restricted: true,
+		markdownDescription: localize('suggest.inlineSuggestion', "Controls whether the shell's inline suggestion should be detected and how it is scored."),
+		type: 'string',
+		enum: ['off', 'alwaysOnTopExceptExactMatch', 'alwaysOnTop'],
+		markdownEnumDescriptions: [
+			localize('suggest.inlineSuggestion.off', "Disable the feature."),
+			localize('suggest.inlineSuggestion.alwaysOnTopExceptExactMatch', "Enable the feature and sort the inline suggestion without forcing it to be on top. This means that exact matches will be will be above the inline suggestion."),
+			localize('suggest.inlineSuggestion.alwaysOnTop', "Enable the feature and always put the inline suggestion on top."),
+		],
+		default: 'alwaysOnTop',
+		tags: ['preview']
+	}
 };
 
 

--- a/src/vs/workbench/contrib/terminalContrib/suggest/test/browser/terminalCompletionModel.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/test/browser/terminalCompletionModel.test.ts
@@ -2,7 +2,7 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import assert from 'assert';
+import assert, { notStrictEqual, strictEqual } from 'assert';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
 import { TerminalCompletionModel } from '../../browser/terminalCompletionModel.js';
 import { LineContext } from '../../../../../services/suggest/browser/simpleCompletionModel.js';
@@ -214,6 +214,43 @@ suite('TerminalCompletionModel', function () {
 				'__init__.py',
 				'__pycache',
 			]);
+		});
+	});
+
+	suite('inline completions', () => {
+		function createItems(kind: TerminalCompletionItemKind.InlineSuggestion | TerminalCompletionItemKind.InlineSuggestionAlwaysOnTop) {
+			return [
+				...createFolderItems('a', 'c'),
+				...createFileItems('b', 'd'),
+				new TerminalCompletionItem({
+					label: 'ab',
+					provider: 'core',
+					replacementIndex: 0,
+					replacementLength: 0,
+					kind
+				})
+			];
+		}
+		suite('InlineSuggestion', () => {
+			test('should put on top generally', function () {
+				const model = new TerminalCompletionModel(createItems(TerminalCompletionItemKind.InlineSuggestion), new LineContext('', 0));
+				strictEqual(model.items[0].completion.label, 'ab');
+			});
+			test('should NOT put on top when there\'s an exact match of another item', function () {
+				const model = new TerminalCompletionModel(createItems(TerminalCompletionItemKind.InlineSuggestion), new LineContext('a', 0));
+				notStrictEqual(model.items[0].completion.label, 'ab');
+				strictEqual(model.items[1].completion.label, 'ab');
+			});
+		});
+		suite('InlineSuggestionAlwaysOnTop', () => {
+			test('should put on top generally', function () {
+				const model = new TerminalCompletionModel(createItems(TerminalCompletionItemKind.InlineSuggestionAlwaysOnTop), new LineContext('', 0));
+				strictEqual(model.items[0].completion.label, 'ab');
+			});
+			test('should put on top even if there\'s an exact match of another item', function () {
+				const model = new TerminalCompletionModel(createItems(TerminalCompletionItemKind.InlineSuggestionAlwaysOnTop), new LineContext('a', 0));
+				strictEqual(model.items[0].completion.label, 'ab');
+			});
 		});
 	});
 });


### PR DESCRIPTION
Fixes #240661

Before:

![image](https://github.com/user-attachments/assets/0c06cb34-3583-492c-b894-d812c12db211)

After:

![image](https://github.com/user-attachments/assets/7bc74680-ee74-4cb2-bd29-25976b68876b)

Notice the `git ` prefix isn't there in the after, this was required to get the new `"terminal.integrated.suggest.inlineSuggestion": "alwaysOnTopExceptExactMatch"` setting to work. That setting should put it on top always unless there's an exact match with another suggestion:

![image](https://github.com/user-attachments/assets/3a8589c9-ad71-481b-a5f5-b10a152d890b)
