### PR TITLE
Engineering - switch Compile stage to macOS ARM64

### DIFF
--- a/build/azure-pipelines/product-build.yml
+++ b/build/azure-pipelines/product-build.yml
@@ -194,11 +194,11 @@ extends:
         exclusionsFilePath: $(Build.SourcesDirectory)/.eslint-ignore
       sourceAnalysisPool: 1es-windows-2022-x64
       createAdoIssuesForJustificationsForDisablement: false
-    containers:
-      snapcraft:
-        image: vscodehub.azurecr.io/vscode-linux-build-agent:snapcraft-x64
-      ubuntu-2004-arm64:
-        image: onebranch.azurecr.io/linux/ubuntu-2004-arm64:latest
+    # containers:
+    #   snapcraft:
+    #     image: vscodehub.azurecr.io/vscode-linux-build-agent:snapcraft-x64
+    #   ubuntu-2004-arm64:
+    #     image: onebranch.azurecr.io/linux/ubuntu-2004-arm64:latest
     authenticatedContainerRegistries:
       - registry: onebranch.azurecr.io
         tenant: AME
@@ -257,18 +257,18 @@ extends:
                       VSCODE_QUALITY: ${{ variables.VSCODE_QUALITY }}
                       VSCODE_BUILD_ALPINE: ${{ parameters.VSCODE_BUILD_ALPINE }}
 
-            - ${{ if and(eq(variables['VSCODE_CIBUILD'], false), eq(parameters.VSCODE_BUILD_ALPINE_ARM64, true)) }}:
-              - job: CLIAlpineARM64
-                pool:
-                  name: 1es-mariner-2.0-arm64
-                  os: linux
-                  hostArchitecture: arm64
-                container: ubuntu-2004-arm64
-                steps:
-                  - template: build/azure-pipelines/alpine/cli-build-alpine.yml@self
-                    parameters:
-                      VSCODE_QUALITY: ${{ variables.VSCODE_QUALITY }}
-                      VSCODE_BUILD_ALPINE_ARM64: ${{ parameters.VSCODE_BUILD_ALPINE_ARM64 }}
+            # - ${{ if and(eq(variables['VSCODE_CIBUILD'], false), eq(parameters.VSCODE_BUILD_ALPINE_ARM64, true)) }}:
+            #   - job: CLIAlpineARM64
+            #     pool:
+            #       name: 1es-mariner-2.0-arm64
+            #       os: linux
+            #       hostArchitecture: arm64
+            #     container: ubuntu-2004-arm64
+            #     steps:
+            #       - template: build/azure-pipelines/alpine/cli-build-alpine.yml@self
+            #         parameters:
+            #           VSCODE_QUALITY: ${{ variables.VSCODE_QUALITY }}
+            #           VSCODE_BUILD_ALPINE_ARM64: ${{ parameters.VSCODE_BUILD_ALPINE_ARM64 }}
 
             - ${{ if eq(parameters.VSCODE_BUILD_MACOS, true) }}:
               - job: CLIMacOSX64
@@ -499,15 +499,15 @@ extends:
                       VSCODE_RUN_INTEGRATION_TESTS: ${{ eq(parameters.VSCODE_STEP_ON_IT, false) }}
                       VSCODE_RUN_SMOKE_TESTS: ${{ eq(parameters.VSCODE_STEP_ON_IT, false) }}
 
-            - ${{ if and(eq(variables['VSCODE_CIBUILD'], false), eq(parameters.VSCODE_BUILD_LINUX, true)) }}:
-              - job: LinuxSnap
-                dependsOn:
-                  - Linuxx64
-                container: snapcraft
-                variables:
-                  VSCODE_ARCH: x64
-                steps:
-                  - template: build/azure-pipelines/linux/snap-build-linux.yml@self
+            # - ${{ if and(eq(variables['VSCODE_CIBUILD'], false), eq(parameters.VSCODE_BUILD_LINUX, true)) }}:
+            #   - job: LinuxSnap
+            #     dependsOn:
+            #       - Linuxx64
+            #     container: snapcraft
+            #     variables:
+            #       VSCODE_ARCH: x64
+            #     steps:
+            #       - template: build/azure-pipelines/linux/snap-build-linux.yml@self
 
             - ${{ if and(eq(variables['VSCODE_CIBUILD'], false), eq(parameters.VSCODE_BUILD_LINUX_ARMHF, true)) }}:
               - job: LinuxArmhf

--- a/build/azure-pipelines/product-build.yml
+++ b/build/azure-pipelines/product-build.yml
@@ -194,15 +194,11 @@ extends:
         exclusionsFilePath: $(Build.SourcesDirectory)/.eslint-ignore
       sourceAnalysisPool: 1es-windows-2022-x64
       createAdoIssuesForJustificationsForDisablement: false
-    # containers:
-    #   snapcraft:
-    #     image: vscodehub.azurecr.io/vscode-linux-build-agent:snapcraft-x64
-    #   ubuntu-2004-arm64:
-    #     image: onebranch.azurecr.io/linux/ubuntu-2004-arm64:latest
-    authenticatedContainerRegistries:
-      - registry: onebranch.azurecr.io
-        tenant: AME
-        identity: 1ESPipelineIdentity
+    containers:
+      snapcraft:
+        image: vscodehub.azurecr.io/vscode-linux-build-agent:snapcraft-x64
+      ubuntu-2004-arm64:
+        image: onebranch.azurecr.io/linux/ubuntu-2004-arm64:latest
     stages:
       - stage: Compile
         jobs:
@@ -257,18 +253,23 @@ extends:
                       VSCODE_QUALITY: ${{ variables.VSCODE_QUALITY }}
                       VSCODE_BUILD_ALPINE: ${{ parameters.VSCODE_BUILD_ALPINE }}
 
-            # - ${{ if and(eq(variables['VSCODE_CIBUILD'], false), eq(parameters.VSCODE_BUILD_ALPINE_ARM64, true)) }}:
-            #   - job: CLIAlpineARM64
-            #     pool:
-            #       name: 1es-mariner-2.0-arm64
-            #       os: linux
-            #       hostArchitecture: arm64
-            #     container: ubuntu-2004-arm64
-            #     steps:
-            #       - template: build/azure-pipelines/alpine/cli-build-alpine.yml@self
-            #         parameters:
-            #           VSCODE_QUALITY: ${{ variables.VSCODE_QUALITY }}
-            #           VSCODE_BUILD_ALPINE_ARM64: ${{ parameters.VSCODE_BUILD_ALPINE_ARM64 }}
+            - ${{ if and(eq(variables['VSCODE_CIBUILD'], false), eq(parameters.VSCODE_BUILD_ALPINE_ARM64, true)) }}:
+              - job: CLIAlpineARM64
+                pool:
+                  name: 1es-mariner-2.0-arm64
+                  os: linux
+                  hostArchitecture: arm64
+                container: ubuntu-2004-arm64
+                templateContext:
+                  authenticatedContainerRegistries:
+                    - registry: onebranch.azurecr.io
+                      tenant: AME
+                      identity: 1ESPipelineIdentity
+                steps:
+                  - template: build/azure-pipelines/alpine/cli-build-alpine.yml@self
+                    parameters:
+                      VSCODE_QUALITY: ${{ variables.VSCODE_QUALITY }}
+                      VSCODE_BUILD_ALPINE_ARM64: ${{ parameters.VSCODE_BUILD_ALPINE_ARM64 }}
 
             - ${{ if eq(parameters.VSCODE_BUILD_MACOS, true) }}:
               - job: CLIMacOSX64
@@ -499,15 +500,20 @@ extends:
                       VSCODE_RUN_INTEGRATION_TESTS: ${{ eq(parameters.VSCODE_STEP_ON_IT, false) }}
                       VSCODE_RUN_SMOKE_TESTS: ${{ eq(parameters.VSCODE_STEP_ON_IT, false) }}
 
-            # - ${{ if and(eq(variables['VSCODE_CIBUILD'], false), eq(parameters.VSCODE_BUILD_LINUX, true)) }}:
-            #   - job: LinuxSnap
-            #     dependsOn:
-            #       - Linuxx64
-            #     container: snapcraft
-            #     variables:
-            #       VSCODE_ARCH: x64
-            #     steps:
-            #       - template: build/azure-pipelines/linux/snap-build-linux.yml@self
+            - ${{ if and(eq(variables['VSCODE_CIBUILD'], false), eq(parameters.VSCODE_BUILD_LINUX, true)) }}:
+              - job: LinuxSnap
+                dependsOn:
+                  - Linuxx64
+                container: snapcraft
+                variables:
+                  VSCODE_ARCH: x64
+                templateContext:
+                  authenticatedContainerRegistries:
+                    - registry: onebranch.azurecr.io
+                      tenant: AME
+                      identity: 1ESPipelineIdentity
+                steps:
+                  - template: build/azure-pipelines/linux/snap-build-linux.yml@self
 
             - ${{ if and(eq(variables['VSCODE_CIBUILD'], false), eq(parameters.VSCODE_BUILD_LINUX_ARMHF, true)) }}:
               - job: LinuxArmhf

--- a/build/azure-pipelines/product-build.yml
+++ b/build/azure-pipelines/product-build.yml
@@ -209,10 +209,10 @@ extends:
           - job: Compile
             timeoutInMinutes: 90
             pool:
-              name: 1es-ubuntu-22.04-x64
-              os: linux
+              name: AcesShared
+              os: macOS
             variables:
-              VSCODE_ARCH: x64
+              VSCODE_ARCH: arm64
             steps:
               - template: build/azure-pipelines/product-compile.yml@self
                 parameters:

--- a/build/azure-pipelines/product-compile.yml
+++ b/build/azure-pipelines/product-compile.yml
@@ -53,6 +53,11 @@ steps:
     condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'), ne(variables['NPM_REGISTRY'], 'none'))
     displayName: Setup NPM Authentication
 
+  - ${{ if eq(parameters.VSCODE_QUALITY, 'oss') }}:
+    - script: sudo apt update -y && sudo apt install -y build-essential pkg-config libx11-dev libx11-xcb-dev libxkbfile-dev libnotify-bin libkrb5-dev
+      displayName: Install build tools
+      condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'))
+
   - script: |
       set -e
 
@@ -148,8 +153,13 @@ steps:
     - script: ./build/azure-pipelines/common/extract-telemetry.sh
       displayName: Generate lists of telemetry events
 
-    - script: tar -cz --exclude='.build/node_modules_cache' --exclude='.build/node_modules_list.txt' --exclude='.build/distro' -f $(Build.ArtifactStagingDirectory)/compilation.tar.gz .build out-* test/integration/browser/out test/smoke/out test/automation/out
-      displayName: Compress compilation artifact
+    - ${{ if eq(parameters.VSCODE_QUALITY, 'oss') }}:
+      - script: tar -cz --ignore-failed-read --exclude='.build/node_modules_cache' --exclude='.build/node_modules_list.txt' --exclude='.build/distro' -f $(Build.ArtifactStagingDirectory)/compilation.tar.gz .build out-* test/integration/browser/out test/smoke/out test/automation/out
+        displayName: Compress compilation artifact
+
+    - ${{ if ne(parameters.VSCODE_QUALITY, 'oss') }}:
+      - script: tar -cz --exclude='.build/node_modules_cache' --exclude='.build/node_modules_list.txt' --exclude='.build/distro' -f $(Build.ArtifactStagingDirectory)/compilation.tar.gz .build out-* test/integration/browser/out test/smoke/out test/automation/out
+        displayName: Compress compilation artifact
 
     - task: 1ES.PublishPipelineArtifact@1
       inputs:

--- a/build/azure-pipelines/product-compile.yml
+++ b/build/azure-pipelines/product-compile.yml
@@ -148,7 +148,7 @@ steps:
     - script: ./build/azure-pipelines/common/extract-telemetry.sh
       displayName: Generate lists of telemetry events
 
-    - script: tar -cz --ignore-failed-read --exclude='.build/node_modules_cache' --exclude='.build/node_modules_list.txt' --exclude='.build/distro' -f $(Build.ArtifactStagingDirectory)/compilation.tar.gz .build out-* test/integration/browser/out test/smoke/out test/automation/out
+    - script: tar -cz --exclude='.build/node_modules_cache' --exclude='.build/node_modules_list.txt' --exclude='.build/distro' -f $(Build.ArtifactStagingDirectory)/compilation.tar.gz .build out-* test/integration/browser/out test/smoke/out test/automation/out
       displayName: Compress compilation artifact
 
     - task: 1ES.PublishPipelineArtifact@1

--- a/build/azure-pipelines/product-compile.yml
+++ b/build/azure-pipelines/product-compile.yml
@@ -23,7 +23,7 @@ steps:
     condition: and(succeeded(), ne(variables['NPM_REGISTRY'], 'none'))
     displayName: Setup NPM Registry
 
-  - script: mkdir -p .build && node build/azure-pipelines/common/computeNodeModulesCacheKey.js compile > .build/packagelockhash
+  - script: mkdir -p .build && node build/azure-pipelines/common/computeNodeModulesCacheKey.js compile $VSCODE_ARCH > .build/packagelockhash
     displayName: Prepare node_modules cache key
 
   - task: Cache@2
@@ -52,10 +52,6 @@ steps:
       workingFile: $(NPMRC_PATH)
     condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'), ne(variables['NPM_REGISTRY'], 'none'))
     displayName: Setup NPM Authentication
-
-  - script: sudo apt update -y && sudo apt install -y build-essential pkg-config libx11-dev libx11-xcb-dev libxkbfile-dev libnotify-bin libkrb5-dev
-    displayName: Install build tools
-    condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'))
 
   - script: |
       set -e


### PR DESCRIPTION
* Use ARCH in cache file to avoid reusing old Compile stage cache
* Move `authenticatedContainerRegistries` to the job level
* Only install builds tools for the PR build as that continues to run on Linux
* Linux and macOS run different versions of `tar` so we have to account for that