### PR TITLE
chat: add incremental undo stops for edits in a single turn

### DIFF
--- a/src/vs/base/common/assert.ts
+++ b/src/vs/base/common/assert.ts
@@ -54,9 +54,9 @@ export function assert(
 /**
  * Like assert, but doesn't throw.
  */
-export function softAssert(condition: boolean): void {
+export function softAssert(condition: boolean, message = 'Soft Assertion Failed'): void {
 	if (!condition) {
-		onUnexpectedError(new BugIndicatingError('Soft Assertion Failed'));
+		onUnexpectedError(new BugIndicatingError(message));
 	}
 }
 

--- a/src/vs/workbench/contrib/chat/browser/actions/chatTitleActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatTitleActions.ts
@@ -261,10 +261,10 @@ export function registerChatTitleActions() {
 					await configurationService.updateValue('chat.editing.confirmEditRequestRetry', false);
 				}
 
-				// Reset the snapshot
+				// Reset the snapshot to the first stop (undefined undo index)
 				const snapshotRequest = chatRequests[itemIndex];
 				if (snapshotRequest) {
-					await currentEditingSession.restoreSnapshot(snapshotRequest.id);
+					await currentEditingSession.restoreSnapshot(snapshotRequest.id, undefined);
 				}
 			}
 			const request = chatModel?.getRequests().find(candidate => candidate.id === item.requestId);

--- a/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingActions.ts
@@ -572,7 +572,7 @@ registerAction2(class RemoveAction extends Action2 {
 
 			// Restore the snapshot to what it was before the request(s) that we deleted
 			const snapshotRequestId = chatRequests[itemIndex].id;
-			await session.restoreSnapshot(snapshotRequestId);
+			await session.restoreSnapshot(snapshotRequestId, undefined);
 
 			// Remove the request and all that come after it
 			for (const request of requestsToRemove) {

--- a/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingModifiedFileEntry.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingModifiedFileEntry.ts
@@ -266,12 +266,12 @@ export class ChatEditingModifiedFileEntry extends Disposable implements IModifie
 		this._telemetryInfo = telemetryInfo;
 	}
 
-	createSnapshot(requestId: string | undefined): ISnapshotEntry {
+	createSnapshot(requestId: string | undefined, undoStop: string | undefined): ISnapshotEntry {
 		this._isFirstEditAfterStartOrSnapshot = true;
 		return {
 			resource: this.modifiedURI,
 			languageId: this.modifiedModel.getLanguageId(),
-			snapshotUri: ChatEditingSnapshotTextModelContentProvider.getSnapshotFileURI(this._telemetryInfo.sessionId, requestId, this.modifiedURI.path),
+			snapshotUri: ChatEditingSnapshotTextModelContentProvider.getSnapshotFileURI(this._telemetryInfo.sessionId, requestId, undoStop, this.modifiedURI.path),
 			original: this.originalModel.getValue(),
 			current: this.modifiedModel.getValue(),
 			originalToCurrentEdit: this._edit,

--- a/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingSession.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingSession.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { binarySearch2 } from '../../../../../base/common/arrays.js';
 import { ITask, Sequencer, timeout } from '../../../../../base/common/async.js';
 import { VSBuffer } from '../../../../../base/common/buffer.js';
 import { BugIndicatingError } from '../../../../../base/common/errors.js';
@@ -40,7 +41,7 @@ import { MultiDiffEditorInput } from '../../../multiDiffEditor/browser/multiDiff
 import { isNotebookEditorInput } from '../../../notebook/common/notebookEditorInput.js';
 import { INotebookService } from '../../../notebook/common/notebookService.js';
 import { ChatEditingSessionChangeType, ChatEditingSessionState, ChatEditKind, getMultiDiffSourceUri, IChatEditingSession, IModifiedFileEntry, WorkingSetDisplayMetadata, WorkingSetEntryRemovalReason, WorkingSetEntryState } from '../../common/chatEditingService.js';
-import { IChatResponseModel } from '../../common/chatModel.js';
+import { IChatRequestDisablement, IChatResponseModel } from '../../common/chatModel.js';
 import { IChatService } from '../../common/chatService.js';
 import { ChatEditingModifiedFileEntry, IModifiedEntryTelemetryInfo, ISnapshotEntry } from './chatEditingModifiedFileEntry.js';
 import { ChatEditingModifiedNotebookEntry } from './chatEditingModifiedNotebookEntry.js';
@@ -84,10 +85,15 @@ class ThrottledSequencer extends Sequencer {
 	}
 }
 
+function getMaxHistoryIndex(history: readonly IChatEditingSessionSnapshot[]) {
+	const lastHistory = history.at(-1);
+	return lastHistory ? lastHistory.startIndex + lastHistory.stops.length : 0;
+}
+
 export class ChatEditingSession extends Disposable implements IChatEditingSession {
 
 	private readonly _state = observableValue<ChatEditingSessionState>(this, ChatEditingSessionState.Initial);
-	private readonly _linearHistory = observableValue<IChatEditingSessionSnapshot[]>(this, []);
+	private readonly _linearHistory = observableValue<readonly IChatEditingSessionSnapshot[]>(this, []);
 	private readonly _linearHistoryIndex = observableValue<number>(this, 0);
 
 	/**
@@ -135,16 +141,15 @@ export class ChatEditingSession extends Disposable implements IChatEditingSessio
 		if (this.state.read(r) !== ChatEditingSessionState.Idle) {
 			return false;
 		}
-		const linearHistory = this._linearHistory.read(r);
 		const linearHistoryIndex = this._linearHistoryIndex.read(r);
-		return linearHistoryIndex < linearHistory.length;
+		return linearHistoryIndex < getMaxHistoryIndex(this._linearHistory.read(r));
 	});
 
-	public hiddenRequestIds = derived<string[]>((r) => {
-		const linearHistory = this._linearHistory.read(r);
-		const linearHistoryIndex = this._linearHistoryIndex.read(r);
-		return linearHistory.slice(linearHistoryIndex).map(s => s.requestId).filter((r): r is string => !!r);
-	});
+	// public hiddenRequestIds = derived<string[]>((r) => {
+	// 	const linearHistory = this._linearHistory.read(r);
+	// 	const linearHistoryIndex = this._linearHistoryIndex.read(r);
+	// 	return linearHistory.slice(linearHistoryIndex).map(s => s.requestId).filter((r): r is string => !!r);
+	// });
 
 	private readonly _onDidChange = this._register(new Emitter<ChatEditingSessionChangeType>());
 	get onDidChange() {
@@ -189,8 +194,8 @@ export class ChatEditingSession extends Disposable implements IChatEditingSessio
 			}
 			this._pendingSnapshot = restoredSessionState.pendingSnapshot;
 			await this._restoreSnapshot(restoredSessionState.recentSnapshot);
-			this._linearHistoryIndex.set(restoredSessionState.linearHistoryIndex, undefined);
 			this._linearHistory.set(restoredSessionState.linearHistory, undefined);
+			this._linearHistoryIndex.set(restoredSessionState.linearHistoryIndex, undefined);
 			this._state.set(ChatEditingSessionState.Idle, undefined);
 		}
 
@@ -222,7 +227,7 @@ export class ChatEditingSession extends Disposable implements IChatEditingSessio
 		const state: StoredSessionState = {
 			initialFileContents: this._initialFileContents,
 			pendingSnapshot: this._pendingSnapshot,
-			recentSnapshot: this._createSnapshot(undefined),
+			recentSnapshot: this._createSnapshot(undefined, undefined),
 			linearHistoryIndex: this._linearHistoryIndex.get(),
 			linearHistory: this._linearHistory.get(),
 		};
@@ -318,45 +323,65 @@ export class ChatEditingSession extends Disposable implements IChatEditingSessio
 		return this._linearHistory.get().find(s => s.requestId === requestId);
 	}
 
-	public createSnapshot(requestId: string | undefined): void {
-		const snapshot = this._createSnapshot(requestId);
+	private _findEditStop(requestId: string, undoStop: string | undefined): IChatEditingSessionStop | undefined {
+		return this._findSnapshot(requestId)?.stops.find(s => s.stopId === undoStop);
+	}
+
+	public createSnapshot(requestId: string | undefined, undoStop: string | undefined): void {
+		const snapshot = this._createSnapshot(requestId, undoStop);
 		if (requestId) {
 			for (const [uri, data] of this._workingSet) {
 				if (data.state !== WorkingSetEntryState.Suggested) {
 					this._workingSet.set(uri, { state: WorkingSetEntryState.Sent, isMarkedReadonly: data.isMarkedReadonly });
 				}
 			}
-			const linearHistory = this._linearHistory.get();
-			const linearHistoryIndex = this._linearHistoryIndex.get();
-			const newLinearHistory = linearHistory.slice(0, linearHistoryIndex);
-			newLinearHistory.push(snapshot);
+			const linearHistoryPtr = this._linearHistoryIndex.get();
+
+			const newLinearHistory: IChatEditingSessionSnapshot[] = [];
+			for (const entry of this._linearHistory.get()) {
+				if (linearHistoryPtr - entry.startIndex < entry.stops.length) {
+					newLinearHistory.push({ requestId: entry.requestId, stops: entry.stops.slice(0, linearHistoryPtr - entry.startIndex), startIndex: entry.startIndex });
+				} else {
+					newLinearHistory.push(entry);
+				}
+			}
+
+			const lastEntry = newLinearHistory.at(-1);
+			if (requestId && lastEntry?.requestId === requestId) {
+				newLinearHistory[newLinearHistory.length - 1] = { ...lastEntry, stops: [...lastEntry.stops, snapshot] };
+			} else {
+				newLinearHistory.push({ requestId, startIndex: lastEntry ? lastEntry.startIndex + lastEntry.stops.length : 0, stops: [snapshot] });
+			}
+
 			transaction((tx) => {
+				const last = newLinearHistory[newLinearHistory.length - 1];
 				this._linearHistory.set(newLinearHistory, tx);
-				this._linearHistoryIndex.set(newLinearHistory.length, tx);
+				this._linearHistoryIndex.set(last.startIndex + last.stops.length, tx);
 			});
 		} else {
 			this._pendingSnapshot = snapshot;
 		}
 	}
 
-	private _createSnapshot(requestId: string | undefined): IChatEditingSessionSnapshot {
+	private _createSnapshot(requestId: string | undefined, undoStop: string | undefined): IChatEditingSessionStop {
 		const workingSet = new ResourceMap<WorkingSetDisplayMetadata>();
 		for (const [file, state] of this._workingSet) {
 			workingSet.set(file, state);
 		}
 		const entries = new ResourceMap<ISnapshotEntry>();
 		for (const entry of this._entriesObs.get()) {
-			entries.set(entry.modifiedURI, entry.createSnapshot(requestId));
+			entries.set(entry.modifiedURI, entry.createSnapshot(requestId, undoStop));
 		}
+
 		return {
-			requestId,
+			stopId: undoStop,
 			workingSet,
-			entries
+			entries,
 		};
 	}
 
-	public async getSnapshotModel(requestId: string, snapshotUri: URI): Promise<ITextModel | null> {
-		const entries = this._findSnapshot(requestId)?.entries;
+	public async getSnapshotModel(requestId: string, undoStop: string | undefined, snapshotUri: URI): Promise<ITextModel | null> {
+		const entries = this._findEditStop(requestId, undoStop)?.entries;
 		if (!entries) {
 			return null;
 		}
@@ -369,27 +394,35 @@ export class ChatEditingSession extends Disposable implements IChatEditingSessio
 		return this._modelService.createModel(snapshotEntry.current, this._languageService.createById(snapshotEntry.languageId), snapshotUri, false);
 	}
 
-	public getSnapshot(requestId: string, uri: URI): ISnapshotEntry | undefined {
-		const snapshot = this._findSnapshot(requestId);
-		const snapshotEntries = snapshot?.entries;
-		return snapshotEntries?.get(uri);
-	}
-
 	public getSnapshotUri(requestId: string, uri: URI): URI | undefined {
-		return this.getSnapshot(requestId, uri)?.snapshotUri;
+		// todo@connor4312: this is used in code block links in chat, ad hoc this just gets the last snapshot
+		// of the file in the request but we should plumb stops through here too
+		const snapshot = this._findSnapshot(requestId);
+		if (!snapshot) {
+			return undefined;
+		}
+
+		for (let k = snapshot.stops.length - 1; k >= 0; k--) {
+			const entry = snapshot.stops[k].entries.get(uri);
+			if (entry) {
+				return entry.snapshotUri;
+			}
+		}
+
+		return undefined;
 	}
 
 	/**
 	 * A snapshot representing the state of the working set before a new request has been sent
 	 */
-	private _pendingSnapshot: IChatEditingSessionSnapshot | undefined;
-	public async restoreSnapshot(requestId: string | undefined): Promise<void> {
+	private _pendingSnapshot: IChatEditingSessionStop | undefined;
+	public async restoreSnapshot(requestId: string | undefined, stopId: string | undefined): Promise<void> {
 		if (requestId !== undefined) {
-			const snapshot = this._findSnapshot(requestId);
+			const snapshot = this._findEditStop(requestId, stopId);
 			if (snapshot) {
 				if (!this._pendingSnapshot) {
 					// Create and save a pending snapshot
-					this.createSnapshot(undefined);
+					this.createSnapshot(undefined, undefined);
 				}
 				await this._restoreSnapshot(snapshot);
 			}
@@ -404,14 +437,14 @@ export class ChatEditingSession extends Disposable implements IChatEditingSessio
 	}
 
 
-	private async _restoreSnapshot(snapshot: IChatEditingSessionSnapshot): Promise<void> {
+	private async _restoreSnapshot({ workingSet, entries }: IChatEditingSessionStop): Promise<void> {
 		this._workingSet = new ResourceMap();
-		snapshot.workingSet.forEach((state, uri) => this._workingSet.set(uri, state));
+		workingSet.forEach((state, uri) => this._workingSet.set(uri, state));
 
 		// Reset all the files which are modified in this session state
 		// but which are not found in the snapshot
 		for (const entry of this._entriesObs.get()) {
-			const snapshotEntry = snapshot.entries.get(entry.modifiedURI);
+			const snapshotEntry = entries.get(entry.modifiedURI);
 			if (!snapshotEntry) {
 				entry.resetToInitialValue();
 				entry.dispose();
@@ -420,7 +453,7 @@ export class ChatEditingSession extends Disposable implements IChatEditingSessio
 
 		const entriesArr: ChatEditingModifiedFileEntry[] = [];
 		// Restore all entries from the snapshot
-		for (const snapshotEntry of snapshot.entries.values()) {
+		for (const snapshotEntry of entries.values()) {
 			const entry = await this._getOrCreateModifiedFileEntry(snapshotEntry.resource, snapshotEntry.telemetryInfo);
 			entry.restoreFromSnapshot(snapshotEntry);
 			entriesArr.push(entry);
@@ -662,37 +695,64 @@ export class ChatEditingSession extends Disposable implements IChatEditingSessio
 		}
 	}
 
+	private _getHistoryEntryByLinearIndex(index: number) {
+		const history = this._linearHistory.get();
+		const searchedIndex = binarySearch2(history.length, (e) => history[e].startIndex - index);
+		const entry = history[searchedIndex < 0 ? (~searchedIndex) - 1 : searchedIndex];
+		if (!entry || index - entry.startIndex >= entry.stops.length) {
+			return undefined;
+		}
+
+		return {
+			entry,
+			stop: entry.stops[index - entry.startIndex]
+		};
+	}
+
 	async undoInteraction(): Promise<void> {
-		const linearHistory = this._linearHistory.get();
 		const newIndex = this._linearHistoryIndex.get() - 1;
-		if (newIndex < 0) {
+		const previousSnapshot = this._getHistoryEntryByLinearIndex(newIndex);
+		if (!previousSnapshot) {
 			return;
 		}
-		const previousSnapshot = linearHistory[newIndex];
-		await this.restoreSnapshot(previousSnapshot.requestId);
+		await this._restoreSnapshot(previousSnapshot.stop);
 		this._linearHistoryIndex.set(newIndex, undefined);
 		this._updateRequestHiddenState();
-
 	}
 
 	async redoInteraction(): Promise<void> {
-		const linearHistory = this._linearHistory.get();
+		const maxIndex = getMaxHistoryIndex(this._linearHistory.get());
 		const newIndex = this._linearHistoryIndex.get() + 1;
-		if (newIndex > linearHistory.length) {
+		if (newIndex > maxIndex) {
 			return;
 		}
-		const nextSnapshot = newIndex < linearHistory.length ? linearHistory[newIndex] : this._pendingSnapshot;
+
+		const nextSnapshot = newIndex === maxIndex ? this._pendingSnapshot : this._getHistoryEntryByLinearIndex(newIndex)?.stop;
 		if (!nextSnapshot) {
 			return;
 		}
-		await this.restoreSnapshot(nextSnapshot.requestId);
+		await this._restoreSnapshot(nextSnapshot);
 		this._linearHistoryIndex.set(newIndex, undefined);
 		this._updateRequestHiddenState();
 	}
 
+
 	private _updateRequestHiddenState() {
-		const hiddenRequestIds = this._linearHistory.get().slice(this._linearHistoryIndex.get()).map(s => s.requestId).filter((r): r is string => !!r);
-		this._chatService.getSession(this.chatSessionId)?.disableRequests(hiddenRequestIds);
+		const history = this._linearHistory.get();
+		const index = this._linearHistoryIndex.get();
+
+		const undoRequests: IChatRequestDisablement[] = [];
+		for (const entry of history) {
+			if (!entry.requestId) {
+				// ignored
+			} else if (entry.startIndex >= index) {
+				undoRequests.push({ requestId: entry.requestId });
+			} else if (entry.startIndex + entry.stops.length > index) {
+				undoRequests.push({ requestId: entry.requestId, afterUndoStop: entry.stops[index - entry.startIndex].stopId });
+			}
+		}
+
+		this._chatService.getSession(this.chatSessionId)?.setDisabledRequests(undoRequests);
 	}
 
 	private async _acceptStreamingEditsStart(): Promise<void> {
@@ -822,10 +882,10 @@ export class ChatEditingSession extends Disposable implements IChatEditingSessio
 
 interface StoredSessionState {
 	readonly initialFileContents: ResourceMap<string>;
-	readonly pendingSnapshot?: IChatEditingSessionSnapshot;
-	readonly recentSnapshot: IChatEditingSessionSnapshot;
+	readonly pendingSnapshot?: IChatEditingSessionStop;
+	readonly recentSnapshot: IChatEditingSessionStop;
 	readonly linearHistoryIndex: number;
-	readonly linearHistory: IChatEditingSessionSnapshot[];
+	readonly linearHistory: readonly IChatEditingSessionSnapshot[];
 }
 
 class ChatEditingSessionStorage {
@@ -853,17 +913,24 @@ class ChatEditingSessionStorage {
 			});
 			return result;
 		};
-		const deserializeChatEditingSessionSnapshot = async (snapshot: IChatEditingSessionSnapshotDTO) => {
-			const entriesMap = new ResourceMap<ISnapshotEntry>();
-			for (const entryDTO of snapshot.entries) {
+		const deserializeChatEditingStopDTO = async (stopDTO: IChatEditingSessionStopDTO | IChatEditingSessionSnapshotDTO): Promise<IChatEditingSessionStop> => {
+			const entries = new ResourceMap<ISnapshotEntry>();
+			for (const entryDTO of stopDTO.entries) {
 				const entry = await deserializeSnapshotEntry(entryDTO);
-				entriesMap.set(entry.resource, entry);
+				entries.set(entry.resource, entry);
 			}
-			return ({
-				requestId: snapshot.requestId,
-				workingSet: deserializeResourceMap(snapshot.workingSet, (value) => value, new ResourceMap()),
-				entries: entriesMap
-			} satisfies IChatEditingSessionSnapshot);
+			const workingSet = deserializeResourceMap(stopDTO.workingSet, (value) => value, new ResourceMap());
+			return { stopId: 'stopId' in stopDTO ? stopDTO.stopId : undefined, workingSet, entries };
+		};
+		const normalizeSnapshotDtos = (snapshot: IChatEditingSessionSnapshotDTO | IChatEditingSessionSnapshotDTO2): IChatEditingSessionSnapshotDTO2 => {
+			if ('stops' in snapshot) {
+				return snapshot;
+			}
+			return { requestId: snapshot.requestId, stops: [{ stopId: undefined, entries: snapshot.entries, workingSet: snapshot.workingSet }] };
+		};
+		const deserializeChatEditingSessionSnapshot = async (startIndex: number, snapshot: IChatEditingSessionSnapshotDTO2): Promise<IChatEditingSessionSnapshot> => {
+			const stops = await Promise.all(snapshot.stops.map(deserializeChatEditingStopDTO));
+			return { startIndex, requestId: snapshot.requestId, stops };
 		};
 		const deserializeSnapshotEntry = async (entry: ISnapshotEntryDTO) => {
 			return {
@@ -890,14 +957,20 @@ class ChatEditingSessionStorage {
 				return undefined;
 			}
 
-			const linearHistory = await Promise.all(data.linearHistory.map(deserializeChatEditingSessionSnapshot));
+			let linearHistoryIndex = 0;
+			const linearHistory = await Promise.all(data.linearHistory.map(snapshot => {
+				const norm = normalizeSnapshotDtos(snapshot);
+				const result = deserializeChatEditingSessionSnapshot(linearHistoryIndex, norm);
+				linearHistoryIndex += norm.stops.length;
+				return result;
+			}));
 
 			const initialFileContents = new ResourceMap<string>();
 			for (const fileContentDTO of data.initialFileContents) {
 				initialFileContents.set(URI.parse(fileContentDTO[0]), await getFileContent(fileContentDTO[1]));
 			}
-			const pendingSnapshot = data.pendingSnapshot ? await deserializeChatEditingSessionSnapshot(data.pendingSnapshot) : undefined;
-			const recentSnapshot = await deserializeChatEditingSessionSnapshot(data.recentSnapshot);
+			const pendingSnapshot = data.pendingSnapshot ? await deserializeChatEditingStopDTO(data.pendingSnapshot) : undefined;
+			const recentSnapshot = await deserializeChatEditingStopDTO(data.recentSnapshot);
 
 			return {
 				initialFileContents,
@@ -948,14 +1021,20 @@ class ChatEditingSessionStorage {
 		const serializeResourceMap = <T>(resourceMap: ResourceMap<T>, serialize: (value: T) => any): ResourceMapDTO<T> => {
 			return Array.from(resourceMap.entries()).map(([resourceURI, value]) => [resourceURI.toString(), serialize(value)]);
 		};
-		const serializeChatEditingSessionSnapshot = (snapshot: IChatEditingSessionSnapshot) => {
-			return ({
-				requestId: snapshot.requestId,
-				workingSet: serializeResourceMap(snapshot.workingSet, value => value),
-				entries: Array.from(snapshot.entries.values()).map(serializeSnapshotEntry)
-			} satisfies IChatEditingSessionSnapshotDTO);
+		const serializeChatEditingSessionStop = (stop: IChatEditingSessionStop): IChatEditingSessionStopDTO => {
+			return {
+				stopId: stop.stopId,
+				workingSet: serializeResourceMap(stop.workingSet, value => value),
+				entries: Array.from(stop.entries.values()).map(serializeSnapshotEntry)
+			};
 		};
-		const serializeSnapshotEntry = (entry: ISnapshotEntry) => {
+		const serializeChatEditingSessionSnapshot = (snapshot: IChatEditingSessionSnapshot): IChatEditingSessionSnapshotDTO2 => {
+			return {
+				requestId: snapshot.requestId,
+				stops: snapshot.stops.map(serializeChatEditingSessionStop),
+			};
+		};
+		const serializeSnapshotEntry = (entry: ISnapshotEntry): ISnapshotEntryDTO => {
 			return {
 				resource: entry.resource.toString(),
 				languageId: entry.languageId,
@@ -965,19 +1044,19 @@ class ChatEditingSessionStorage {
 				state: entry.state,
 				snapshotUri: entry.snapshotUri.toString(),
 				telemetryInfo: { requestId: entry.telemetryInfo.requestId, agentId: entry.telemetryInfo.agentId, command: entry.telemetryInfo.command }
-			} satisfies ISnapshotEntryDTO;
+			};
 		};
 
 		try {
-			const data = {
+			const data: IChatEditingSessionDTO = {
 				version: STORAGE_VERSION,
 				sessionId: this.chatSessionId,
 				linearHistory: state.linearHistory.map(serializeChatEditingSessionSnapshot),
 				linearHistoryIndex: state.linearHistoryIndex,
 				initialFileContents: serializeResourceMap(state.initialFileContents, value => addFileContent(value)),
-				pendingSnapshot: state.pendingSnapshot ? serializeChatEditingSessionSnapshot(state.pendingSnapshot) : undefined,
-				recentSnapshot: serializeChatEditingSessionSnapshot(state.recentSnapshot),
-			} satisfies IChatEditingSessionDTO;
+				pendingSnapshot: state.pendingSnapshot ? serializeChatEditingSessionStop(state.pendingSnapshot) : undefined,
+				recentSnapshot: serializeChatEditingSessionStop(state.recentSnapshot),
+			};
 
 			this._logService.debug(`chatEditingSession: Storing editing session at ${storageFolder.toString()}: ${fileContents.size} files`);
 
@@ -1006,15 +1085,46 @@ class ChatEditingSessionStorage {
 }
 
 export interface IChatEditingSessionSnapshot {
+	/**
+	 * Index of this session in the linear history. It's the sum of the lengths
+	 * of all {@link stops} prior this one.
+	 */
+	readonly startIndex: number;
+
 	readonly requestId: string | undefined;
+	/**
+	 * Edit stops in the request. Always initially populatd with stopId: undefind
+	 * for th request's initial state.
+	 *
+	 * Invariant: never empty.
+	 */
+	readonly stops: IChatEditingSessionStop[];
+}
+
+interface IChatEditingSessionStop {
+	/** Edit stop ID, first for a request is always undefined. */
+	stopId: string | undefined;
 	readonly workingSet: ResourceMap<WorkingSetDisplayMetadata>;
+	/** todo@connor4312: for stops that don't modify (all) files, we can probably skip creating new snapshot entries */
 	readonly entries: ResourceMap<ISnapshotEntry>;
 }
+
+interface IChatEditingSessionStopDTO {
+	readonly stopId: string | undefined;
+	readonly workingSet: ResourceMapDTO<WorkingSetDisplayMetadata>;
+	readonly entries: ISnapshotEntryDTO[];
+}
+
 
 interface IChatEditingSessionSnapshotDTO {
 	readonly requestId: string | undefined;
 	readonly workingSet: ResourceMapDTO<WorkingSetDisplayMetadata>;
 	readonly entries: ISnapshotEntryDTO[];
+}
+
+interface IChatEditingSessionSnapshotDTO2 {
+	readonly requestId: string | undefined;
+	readonly stops: IChatEditingSessionStopDTO[];
 }
 
 interface ISnapshotEntryDTO {
@@ -1038,12 +1148,13 @@ type ResourceMapDTO<T> = [string, T][];
 
 const STORAGE_VERSION = 1;
 
+/** Old history uses IChatEditingSessionSnapshotDTO, new history uses IChatEditingSessionSnapshotDTO. */
 interface IChatEditingSessionDTO {
 	readonly version: number;
 	readonly sessionId: string;
-	readonly recentSnapshot: IChatEditingSessionSnapshotDTO;
-	readonly linearHistory: IChatEditingSessionSnapshotDTO[];
+	readonly recentSnapshot: (IChatEditingSessionStopDTO | IChatEditingSessionSnapshotDTO);
+	readonly linearHistory: (IChatEditingSessionSnapshotDTO2 | IChatEditingSessionSnapshotDTO)[];
 	readonly linearHistoryIndex: number;
-	readonly pendingSnapshot: IChatEditingSessionSnapshotDTO | undefined;
+	readonly pendingSnapshot: (IChatEditingSessionStopDTO | IChatEditingSessionSnapshotDTO) | undefined;
 	readonly initialFileContents: ResourceMapDTO<string>;
 }

--- a/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingTextModelContentProviders.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingTextModelContentProviders.ts
@@ -47,16 +47,16 @@ export class ChatEditingTextModelContentProvider implements ITextModelContentPro
 	}
 }
 
-type ChatEditingSnapshotTextModelContentQueryData = { sessionId: string; requestId: string | undefined };
+type ChatEditingSnapshotTextModelContentQueryData = { sessionId: string; requestId: string | undefined; undoStop: string | undefined };
 
 export class ChatEditingSnapshotTextModelContentProvider implements ITextModelContentProvider {
 	public static readonly scheme = 'chat-editing-snapshot-text-model';
 
-	public static getSnapshotFileURI(chatSessionId: string, requestId: string | undefined, path: string): URI {
+	public static getSnapshotFileURI(chatSessionId: string, requestId: string | undefined, undoStop: string | undefined, path: string): URI {
 		return URI.from({
 			scheme: ChatEditingSnapshotTextModelContentProvider.scheme,
 			path,
-			query: JSON.stringify({ sessionId: chatSessionId, requestId: requestId ?? '' } satisfies ChatEditingSnapshotTextModelContentQueryData),
+			query: JSON.stringify({ sessionId: chatSessionId, requestId: requestId ?? '', undoStop: undoStop ?? '' } satisfies ChatEditingSnapshotTextModelContentQueryData),
 		});
 	}
 
@@ -78,6 +78,6 @@ export class ChatEditingSnapshotTextModelContentProvider implements ITextModelCo
 			return null;
 		}
 
-		return session.getSnapshotModel(data.requestId, resource);
+		return session.getSnapshotModel(data.requestId, data.undoStop || undefined, resource);
 	}
 }

--- a/src/vs/workbench/contrib/chat/browser/chatListRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatListRenderer.ts
@@ -846,6 +846,10 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 			return this.renderCodeCitations(content, context, templateData);
 		} else if (content.kind === 'toolInvocation' || content.kind === 'toolInvocationSerialized') {
 			return this.renderToolInvocation(content, context, templateData);
+		} else if (content.kind === 'undoStop') {
+			const el = document.createElement('div'); // todo@connor4312 !!DEBUG!!
+			el.textContent = `Undo stop ${content.id}`;
+			return { domNode: el, hasSameContent: () => false, dispose: () => { } };
 		}
 
 		return undefined;

--- a/src/vs/workbench/contrib/chat/browser/chatListRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatListRenderer.ts
@@ -846,10 +846,6 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 			return this.renderCodeCitations(content, context, templateData);
 		} else if (content.kind === 'toolInvocation' || content.kind === 'toolInvocationSerialized') {
 			return this.renderToolInvocation(content, context, templateData);
-		} else if (content.kind === 'undoStop') {
-			const el = document.createElement('div'); // todo@connor4312 !!DEBUG!!
-			el.textContent = `Undo stop ${content.id}`;
-			return { domNode: el, hasSameContent: () => false, dispose: () => { } };
 		}
 
 		return undefined;

--- a/src/vs/workbench/contrib/chat/browser/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatWidget.ts
@@ -593,7 +593,7 @@ export class ChatWidget extends Disposable implements IChatWidget {
 							// Re-render once content references are loaded
 							(isResponseVM(element) ? `_${element.contentReferences.length}` : '') +
 							// Re-render if element becomes hidden due to undo/redo
-							`_${element.shouldBeRemovedOnSend ? '1' : '0'}` +
+							`_${element.shouldBeRemovedOnSend ? `${element.shouldBeRemovedOnSend.afterUndoStop || '1'}` : '0'}` +
 							// Rerender request if we got new content references in the response
 							// since this may change how we render the corresponding attachments in the request
 							(isRequestVM(element) && element.contentReferences ? `_${element.contentReferences?.length}` : '');

--- a/src/vs/workbench/contrib/chat/common/chatEditingService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatEditingService.ts
@@ -91,7 +91,7 @@ export interface IChatEditingSession extends IDisposable {
 	getEntry(uri: URI): IModifiedFileEntry | undefined;
 	readEntry(uri: URI, reader?: IReader): IModifiedFileEntry | undefined;
 
-	restoreSnapshot(requestId: string): Promise<void>;
+	restoreSnapshot(requestId: string, stopId: string | undefined): Promise<void>;
 	getSnapshotUri(requestId: string, uri: URI): URI | undefined;
 
 	/**

--- a/src/vs/workbench/contrib/chat/common/chatModel.ts
+++ b/src/vs/workbench/contrib/chat/common/chatModel.ts
@@ -7,7 +7,7 @@ import { asArray } from '../../../../base/common/arrays.js';
 import { DeferredPromise } from '../../../../base/common/async.js';
 import { Emitter, Event } from '../../../../base/common/event.js';
 import { IMarkdownString, MarkdownString, isMarkdownString } from '../../../../base/common/htmlContent.js';
-import { Disposable } from '../../../../base/common/lifecycle.js';
+import { Disposable, IDisposable } from '../../../../base/common/lifecycle.js';
 import { revive } from '../../../../base/common/marshalling.js';
 import { Schemas } from '../../../../base/common/network.js';
 import { equals } from '../../../../base/common/objects.js';
@@ -200,7 +200,10 @@ export interface IChatResponseModel {
 	readonly progressMessages: ReadonlyArray<IChatProgressMessage>;
 	readonly slashCommand?: IChatAgentCommand;
 	readonly agentOrSlashCommandDetected: boolean;
+	/** View of the response shown to the user, may have parts omitted from undo stops. */
 	readonly response: IResponse;
+	/** Entire response from the model. */
+	readonly entireResponse: IResponse;
 	readonly isComplete: boolean;
 	readonly isCanceled: boolean;
 	readonly isPaused: IObservable<boolean>;
@@ -217,6 +220,13 @@ export interface IChatResponseModel {
 	setVoteDownReason(reason: ChatAgentVoteDownReason | undefined): void;
 	setEditApplied(edit: IChatTextEditGroup, editCount: number): boolean;
 	setPaused(isPause: boolean, tx?: ITransaction): void;
+	/**
+	 * Adopts any partially-undo {@link response} as the {@link entireResponse}.
+	 * Only valid when {@link isComplete}. This is needed because otherwise an
+	 * undone and then diverged state would start showing old data because the
+	 * undo stops would no longer exist in the model.
+	 */
+	finalizeUndoState(): void;
 }
 
 export type ChatResponseModelChangeReason =
@@ -295,40 +305,29 @@ export class ChatRequestModel implements IChatRequestModel {
 	}
 }
 
-export class Response extends Disposable implements IResponse {
-	private _onDidChangeValue = this._register(new Emitter<void>());
-	public get onDidChangeValue() {
-		return this._onDidChangeValue.event;
-	}
-
-	private _responseParts: IChatProgressResponseContent[];
+class AbstractResponse implements IResponse {
+	protected _responseParts: IChatProgressResponseContent[];
 
 	/**
 	 * A stringified representation of response data which might be presented to a screenreader or used when copying a response.
 	 */
-	private _responseRepr = '';
+	protected _responseRepr = '';
 
 	/**
 	 * Just the markdown content of the response, used for determining the rendering rate of markdown
 	 */
-	private _markdownContent = '';
-
-	private _citations: IChatCodeCitation[] = [];
+	protected _markdownContent = '';
 
 	get value(): IChatProgressResponseContent[] {
 		return this._responseParts;
 	}
 
-	constructor(value: IMarkdownString | ReadonlyArray<IMarkdownString | IChatResponseProgressFileTreeData | IChatContentInlineReference | IChatAgentMarkdownContentWithVulnerability | IChatResponseCodeblockUriPart>) {
-		super();
-		this._responseParts = asArray(value).map((v) => (isMarkdownString(v) ?
-			{ content: v, kind: 'markdownContent' } satisfies IChatMarkdownContent :
-			'kind' in v ? v : { kind: 'treeData', treeData: v }));
-
-		this._updateRepr(true);
+	constructor(value: IChatProgressResponseContent[]) {
+		this._responseParts = value;
+		this._updateRepr();
 	}
 
-	override toString(): string {
+	toString(): string {
 		return this._responseRepr;
 	}
 
@@ -338,6 +337,122 @@ export class Response extends Disposable implements IResponse {
 	getMarkdown(): string {
 		return this._markdownContent;
 	}
+
+	protected _updateRepr() {
+		this._responseRepr = this.partsToRepr(this._responseParts);
+
+		this._markdownContent = this._responseParts.map(part => {
+			if (part.kind === 'inlineReference') {
+				return this.inlineRefToRepr(part);
+			} else if (part.kind === 'markdownContent' || part.kind === 'markdownVuln') {
+				return part.content.value;
+			} else {
+				return '';
+			}
+		})
+			.filter(s => s.length > 0)
+			.join('');
+	}
+
+	private partsToRepr(parts: readonly IChatProgressResponseContent[]): string {
+		const blocks: string[] = [];
+		let currentBlockSegments: string[] = [];
+
+		for (const part of parts) {
+			let segment: { text: string; isBlock?: boolean } | undefined;
+			switch (part.kind) {
+				case 'treeData':
+				case 'progressMessage':
+				case 'codeblockUri':
+				case 'toolInvocation':
+				case 'toolInvocationSerialized':
+				case 'undoStop':
+					// Ignore
+					continue;
+				case 'inlineReference':
+					segment = { text: this.inlineRefToRepr(part) };
+					break;
+				case 'command':
+					segment = { text: part.command.title, isBlock: true };
+					break;
+				case 'textEditGroup':
+					segment = { text: localize('editsSummary', "Made changes."), isBlock: true };
+					break;
+				case 'confirmation':
+					segment = { text: `${part.title}\n${part.message}`, isBlock: true };
+					break;
+				default:
+					segment = { text: part.content.value };
+					break;
+			}
+
+			if (segment.isBlock) {
+				if (currentBlockSegments.length) {
+					blocks.push(currentBlockSegments.join(''));
+					currentBlockSegments = [];
+				}
+				blocks.push(segment.text);
+			} else {
+				currentBlockSegments.push(segment.text);
+			}
+		}
+
+		if (currentBlockSegments.length) {
+			blocks.push(currentBlockSegments.join(''));
+		}
+
+		return blocks.join('\n\n');
+	}
+
+	private inlineRefToRepr(part: IChatContentInlineReference) {
+		if ('uri' in part.inlineReference) {
+			return this.uriToRepr(part.inlineReference.uri);
+		}
+
+		return 'name' in part.inlineReference
+			? '`' + part.inlineReference.name + '`'
+			: this.uriToRepr(part.inlineReference);
+	}
+
+	private uriToRepr(uri: URI): string {
+		if (uri.scheme === Schemas.http || uri.scheme === Schemas.https) {
+			return uri.toString(false);
+		}
+
+		return basename(uri);
+	}
+}
+
+/** A view of a subset of a response */
+class ResponseView extends AbstractResponse {
+	constructor(
+		_response: IResponse,
+		public readonly undoStop: string,
+	) {
+		const idx = _response.value.findIndex(v => v.kind === 'undoStop' && v.id === undoStop);
+		super(idx === -1 ? _response.value.slice() : _response.value.slice(0, idx));
+	}
+}
+
+export class Response extends AbstractResponse implements IDisposable {
+	private _onDidChangeValue = new Emitter<void>();
+	public get onDidChangeValue() {
+		return this._onDidChangeValue.event;
+	}
+
+	private _citations: IChatCodeCitation[] = [];
+
+
+	constructor(value: IMarkdownString | ReadonlyArray<IMarkdownString | IChatResponseProgressFileTreeData | IChatContentInlineReference | IChatAgentMarkdownContentWithVulnerability | IChatResponseCodeblockUriPart>) {
+		super(asArray(value).map((v) => (isMarkdownString(v) ?
+			{ content: v, kind: 'markdownContent' } satisfies IChatMarkdownContent :
+			'kind' in v ? v : { kind: 'treeData', treeData: v })));
+	}
+
+	dispose(): void {
+		this._onDidChangeValue.dispose();
+	}
+
 
 	clear(): void {
 		this._responseParts = [];
@@ -422,93 +537,17 @@ export class Response extends Disposable implements IResponse {
 		this._updateRepr();
 	}
 
-	private _updateRepr(quiet?: boolean) {
-		this._responseRepr = this.partsToRepr(this._responseParts);
-		this._responseRepr += this._citations.length ? '\n\n' + getCodeCitationsMessage(this._citations) : '';
+	protected override _updateRepr(quiet?: boolean) {
+		super._updateRepr();
+		if (!this._onDidChangeValue) {
+			return; // called from parent constructor
+		}
 
-		this._markdownContent = this._responseParts.map(part => {
-			if (part.kind === 'inlineReference') {
-				return this.inlineRefToRepr(part);
-			} else if (part.kind === 'markdownContent' || part.kind === 'markdownVuln') {
-				return part.content.value;
-			} else {
-				return '';
-			}
-		})
-			.filter(s => s.length > 0)
-			.join('');
+		this._responseRepr += this._citations.length ? '\n\n' + getCodeCitationsMessage(this._citations) : '';
 
 		if (!quiet) {
 			this._onDidChangeValue.fire();
 		}
-	}
-
-	private partsToRepr(parts: readonly IChatProgressResponseContent[]): string {
-		const blocks: string[] = [];
-		let currentBlockSegments: string[] = [];
-
-		for (const part of parts) {
-			let segment: { text: string; isBlock?: boolean } | undefined;
-			switch (part.kind) {
-				case 'treeData':
-				case 'progressMessage':
-				case 'codeblockUri':
-				case 'toolInvocation':
-				case 'toolInvocationSerialized':
-				case 'undoStop':
-					// Ignore
-					continue;
-				case 'inlineReference':
-					segment = { text: this.inlineRefToRepr(part) };
-					break;
-				case 'command':
-					segment = { text: part.command.title, isBlock: true };
-					break;
-				case 'textEditGroup':
-					segment = { text: localize('editsSummary', "Made changes."), isBlock: true };
-					break;
-				case 'confirmation':
-					segment = { text: `${part.title}\n${part.message}`, isBlock: true };
-					break;
-				default:
-					segment = { text: part.content.value };
-					break;
-			}
-
-			if (segment.isBlock) {
-				if (currentBlockSegments.length) {
-					blocks.push(currentBlockSegments.join(''));
-					currentBlockSegments = [];
-				}
-				blocks.push(segment.text);
-			} else {
-				currentBlockSegments.push(segment.text);
-			}
-		}
-
-		if (currentBlockSegments.length) {
-			blocks.push(currentBlockSegments.join(''));
-		}
-
-		return blocks.join('\n\n');
-	}
-
-	private inlineRefToRepr(part: IChatContentInlineReference) {
-		if ('uri' in part.inlineReference) {
-			return this.uriToRepr(part.inlineReference.uri);
-		}
-
-		return 'name' in part.inlineReference
-			? '`' + part.inlineReference.name + '`'
-			: this.uriToRepr(part.inlineReference);
-	}
-
-	private uriToRepr(uri: URI): string {
-		if (uri.scheme === Schemas.http || uri.scheme === Schemas.https) {
-			return uri.toString(false);
-		}
-
-		return basename(uri);
 	}
 }
 
@@ -553,8 +592,9 @@ export class ChatResponseModel extends Disposable implements IChatResponseModel 
 	}
 
 	private _response: Response;
-	public get response(): IResponse {
-		return this._response;
+	private _finalizedResponse?: IResponse;
+	public get entireResponse(): IResponse {
+		return this._finalizedResponse || this._response;
 	}
 
 	public get result(): IChatAgentResult | undefined {
@@ -618,6 +658,20 @@ export class ChatResponseModel extends Disposable implements IChatResponseModel 
 		return this._response.value.some(part =>
 			part.kind === 'toolInvocation' && part.isConfirmed === undefined
 			|| part.kind === 'confirmation' && part.isUsed === false);
+	}
+
+	private _responseView?: ResponseView;
+	public get response(): IResponse {
+		const undoStop = this._shouldBeRemovedOnSend?.afterUndoStop;
+		if (!undoStop) {
+			return this._finalizedResponse || this._response;
+		}
+
+		if (this._responseView?.undoStop !== undoStop) {
+			this._responseView = new ResponseView(this._response, undoStop);
+		}
+
+		return this._responseView;
 	}
 
 	/** Functions run once the chat response is unpaused. */
@@ -752,6 +806,12 @@ export class ChatResponseModel extends Disposable implements IChatResponseModel 
 		this.bufferedPauseContent = undefined;
 	}
 
+	finalizeUndoState(): void {
+		this._finalizedResponse = this.response;
+		this._responseView = undefined;
+		this._shouldBeRemovedOnSend = undefined;
+	}
+
 	private bufferWhenPaused(apply: () => void) {
 		if (!this._isPaused.get()) {
 			apply();
@@ -811,7 +871,8 @@ export interface ISerializableChatRequestData {
 	response: ReadonlyArray<IMarkdownString | IChatResponseProgressFileTreeData | IChatContentInlineReference | IChatAgentMarkdownContentWithVulnerability> | undefined;
 
 	/**Old, persisted name for shouldBeRemovedOnSend */
-	isHidden: boolean;
+	isHidden?: boolean;
+	shouldBeRemovedOnSend?: IChatRequestDisablement;
 	responseId?: string;
 	agent?: ISerializableChatAgentData;
 	workingSet?: UriComponents[];
@@ -1179,7 +1240,7 @@ export class ChatModel extends Disposable implements IChatModel {
 				// Old messages don't have variableData, or have it in the wrong (non-array) shape
 				const variableData: IChatRequestVariableData = this.reviveVariableData(raw.variableData);
 				const request = new ChatRequestModel(this, parsedRequest, variableData, raw.timestamp ?? -1, undefined, undefined, undefined, undefined, raw.workingSet?.map((uri) => URI.revive(uri)), undefined, raw.requestId);
-				request.shouldBeRemovedOnSend = raw.isHidden ? { requestId: raw.requestId } : undefined;
+				request.shouldBeRemovedOnSend = raw.isHidden ? { requestId: raw.requestId } : raw.shouldBeRemovedOnSend;
 				if (raw.response || raw.result || (raw as any).responseErrorDetails) {
 					const agent = (raw.agent && 'metadata' in raw.agent) ? // Check for the new format, ignore entries in the old format
 						reviveSerializedAgent(raw.agent) : undefined;
@@ -1189,7 +1250,7 @@ export class ChatModel extends Disposable implements IChatModel {
 						// eslint-disable-next-line local/code-no-dangerous-type-assertions
 						{ errorDetails: raw.responseErrorDetails } as IChatAgentResult : raw.result;
 					request.response = new ChatResponseModel(raw.response ?? [new MarkdownString(raw.response)], this, agent, raw.slashCommand, request.id, true, raw.isCanceled, raw.vote, raw.voteDownReason, result, raw.followups, undefined, undefined, raw.responseId);
-					request.response.shouldBeRemovedOnSend = raw.isHidden ? { requestId: raw.requestId } : undefined;
+					request.response.shouldBeRemovedOnSend = raw.isHidden ? { requestId: raw.requestId } : raw.shouldBeRemovedOnSend;
 					if (raw.usedContext) { // @ulugbekna: if this's a new vscode sessions, doc versions are incorrect anyway?
 						request.response.applyReference(revive(raw.usedContext));
 					}
@@ -1297,8 +1358,6 @@ export class ChatModel extends Disposable implements IChatModel {
 	}
 
 	setDisabledRequests(requestIds: IChatRequestDisablement[]) {
-
-
 		this._requests.forEach((request) => {
 			const shouldBeRemovedOnSend = requestIds.find(r => r.requestId === request.id);
 			request.shouldBeRemovedOnSend = shouldBeRemovedOnSend;
@@ -1454,7 +1513,7 @@ export class ChatModel extends Disposable implements IChatModel {
 					message,
 					variableData: r.variableData,
 					response: r.response ?
-						r.response.response.value.map(item => {
+						r.response.entireResponse.value.map(item => {
 							// Keeping the shape of the persisted data the same for back compat
 							if (item.kind === 'treeData') {
 								return item.treeData;
@@ -1466,7 +1525,7 @@ export class ChatModel extends Disposable implements IChatModel {
 						})
 						: undefined,
 					responseId: r.response?.id,
-					isHidden: !!r.shouldBeRemovedOnSend,
+					shouldBeRemovedOnSend: r.shouldBeRemovedOnSend,
 					result: r.response?.result,
 					followups: r.response?.followups,
 					isCanceled: r.response?.isCanceled,

--- a/src/vs/workbench/contrib/chat/common/chatService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService.ts
@@ -132,6 +132,11 @@ export interface IChatTask extends IChatTaskDto {
 	isSettled: () => boolean;
 }
 
+export interface IChatUndoStop {
+	kind: 'undoStop';
+	id: string;
+}
+
 export interface IChatTaskDto {
 	content: IMarkdownString;
 	kind: 'progressTask';
@@ -236,7 +241,8 @@ export type IChatProgress =
 	| IChatResponseCodeblockUriPart
 	| IChatConfirmation
 	| IChatToolInvocation
-	| IChatToolInvocationSerialized;
+	| IChatToolInvocationSerialized
+	| IChatUndoStop;
 
 export interface IChatFollowup {
 	kind: 'reply';

--- a/src/vs/workbench/contrib/chat/common/chatServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/chatServiceImpl.ts
@@ -512,7 +512,11 @@ export class ChatService extends Disposable implements IChatService {
 		for (let i = requests.length - 1; i >= 0; i -= 1) {
 			const request = requests[i];
 			if (request.shouldBeRemovedOnSend) {
-				this.removeRequest(sessionId, request.id);
+				if (request.shouldBeRemovedOnSend.afterUndoStop) {
+					request.response?.finalizeUndoState();
+				} else {
+					this.removeRequest(sessionId, request.id);
+				}
 			}
 		}
 

--- a/src/vs/workbench/contrib/chat/common/chatViewModel.ts
+++ b/src/vs/workbench/contrib/chat/common/chatViewModel.ts
@@ -15,7 +15,7 @@ import { IInstantiationService } from '../../../../platform/instantiation/common
 import { ILogService } from '../../../../platform/log/common/log.js';
 import { annotateVulnerabilitiesInText } from './annotations.js';
 import { getFullyQualifiedId, IChatAgentCommand, IChatAgentData, IChatAgentNameService, IChatAgentResult } from './chatAgents.js';
-import { ChatModelInitState, ChatPauseState, IChatModel, IChatProgressRenderableResponseContent, IChatRequestModel, IChatRequestVariableEntry, IChatResponseModel, IChatTextEditGroup, IResponse } from './chatModel.js';
+import { ChatModelInitState, ChatPauseState, IChatModel, IChatProgressRenderableResponseContent, IChatRequestDisablement, IChatRequestModel, IChatRequestVariableEntry, IChatResponseModel, IChatTextEditGroup, IResponse } from './chatModel.js';
 import { IParsedChatRequest } from './chatParserTypes.js';
 import { ChatAgentVoteDirection, ChatAgentVoteDownReason, IChatCodeCitation, IChatContentReference, IChatFollowup, IChatProgressMessage, IChatResponseErrorDetails, IChatTask, IChatUsedContext } from './chatService.js';
 import { countWords } from './chatWordCounter.js';
@@ -76,7 +76,7 @@ export interface IChatRequestViewModel {
 	readonly contentReferences?: ReadonlyArray<IChatContentReference>;
 	readonly workingSet?: ReadonlyArray<URI>;
 	readonly confirmation?: string;
-	readonly shouldBeRemovedOnSend: boolean;
+	readonly shouldBeRemovedOnSend: IChatRequestDisablement | undefined;
 	readonly isComplete: boolean;
 	readonly isCompleteAddedRequest: boolean;
 	readonly slashCommand: IChatAgentCommand | undefined;
@@ -182,7 +182,7 @@ export interface IChatResponseViewModel {
 	readonly errorDetails?: IChatResponseErrorDetails;
 	readonly result?: IChatAgentResult;
 	readonly contentUpdateTimings?: IChatLiveUpdateData;
-	readonly shouldBeRemovedOnSend: boolean;
+	readonly shouldBeRemovedOnSend: IChatRequestDisablement | undefined;
 	readonly isCompleteAddedRequest: boolean;
 	readonly isPaused: IObservable<boolean>;
 	renderData?: IChatResponseRenderData;

--- a/src/vs/workbench/contrib/chat/common/chatViewModel.ts
+++ b/src/vs/workbench/contrib/chat/common/chatViewModel.ts
@@ -306,7 +306,7 @@ export class ChatViewModel extends Disposable implements IChatViewModel {
 	}
 
 	getItems(): (IChatRequestViewModel | IChatResponseViewModel)[] {
-		return this._items.filter((item) => !item.shouldBeRemovedOnSend);
+		return this._items.filter((item) => !item.shouldBeRemovedOnSend || item.shouldBeRemovedOnSend.afterUndoStop);
 	}
 
 	override dispose() {
@@ -586,7 +586,7 @@ export class ChatResponseViewModel extends Disposable implements IChatResponseVi
 			// This should be true, if the model is changing
 			if (this._contentUpdateTimings) {
 				const now = Date.now();
-				const wordCount = countWords(_model.response.getMarkdown());
+				const wordCount = countWords(_model.entireResponse.getMarkdown());
 
 				if (wordCount > 0 && wordCount === this._contentUpdateTimings.lastWordCount) {
 					this.trace('onDidChange', `Update- no new words`);

--- a/src/vs/workbench/contrib/chat/common/tools/editFileTool.ts
+++ b/src/vs/workbench/contrib/chat/common/tools/editFileTool.ts
@@ -8,6 +8,7 @@ import { MarkdownString } from '../../../../../base/common/htmlContent.js';
 import { IDisposable } from '../../../../../base/common/lifecycle.js';
 import { autorun } from '../../../../../base/common/observable.js';
 import { URI, UriComponents } from '../../../../../base/common/uri.js';
+import { generateUuid } from '../../../../../base/common/uuid.js';
 import { localize } from '../../../../../nls.js';
 import { IWorkspaceContextService } from '../../../../../platform/workspace/common/workspace.js';
 import { SaveReason } from '../../../../common/editor.js';
@@ -94,7 +95,13 @@ export class EditTool implements IToolImpl {
 
 		const model = this.chatService.getSession(invocation.context?.sessionId) as ChatModel;
 		const request = model.getRequests().at(-1)!;
-
+		// slightly hacky way to avoid an extra 'no-op' undo stop at the start of responses that are just edits
+		if (request.response?.response.getMarkdown().length) {
+			model.acceptResponseProgress(request, {
+				kind: 'undoStop',
+				id: generateUuid(),
+			});
+		}
 		model.acceptResponseProgress(request, {
 			kind: 'markdownContent',
 			content: new MarkdownString('\n````\n')

--- a/src/vs/workbench/contrib/chat/test/common/__snapshots__/ChatService_can_deserialize.0.snap
+++ b/src/vs/workbench/contrib/chat/test/common/__snapshots__/ChatService_can_deserialize.0.snap
@@ -57,7 +57,7 @@
       variableData: { variables: [  ] },
       response: [  ],
       responseId: undefined,
-      isHidden: false,
+      shouldBeRemovedOnSend: undefined,
       result: { metadata: { metadataKey: "value" } },
       followups: undefined,
       isCanceled: false,

--- a/src/vs/workbench/contrib/chat/test/common/__snapshots__/ChatService_can_deserialize_with_response.0.snap
+++ b/src/vs/workbench/contrib/chat/test/common/__snapshots__/ChatService_can_deserialize_with_response.0.snap
@@ -57,7 +57,7 @@
       variableData: { variables: [  ] },
       response: [  ],
       responseId: undefined,
-      isHidden: false,
+      shouldBeRemovedOnSend: undefined,
       result: { errorDetails: { message: "No activated agent with id \"ChatProviderWithUsedContext\"" } },
       followups: undefined,
       isCanceled: false,

--- a/src/vs/workbench/contrib/chat/test/common/__snapshots__/ChatService_can_serialize.1.snap
+++ b/src/vs/workbench/contrib/chat/test/common/__snapshots__/ChatService_can_serialize.1.snap
@@ -57,7 +57,7 @@
       variableData: { variables: [  ] },
       response: [  ],
       responseId: undefined,
-      isHidden: false,
+      shouldBeRemovedOnSend: undefined,
       result: { metadata: { metadataKey: "value" } },
       followups: [
         {
@@ -132,7 +132,7 @@
       variableData: { variables: [  ] },
       response: [  ],
       responseId: undefined,
-      isHidden: false,
+      shouldBeRemovedOnSend: undefined,
       result: {  },
       followups: [  ],
       isCanceled: false,

--- a/src/vs/workbench/contrib/chat/test/common/__snapshots__/ChatService_sendRequest_fails.0.snap
+++ b/src/vs/workbench/contrib/chat/test/common/__snapshots__/ChatService_sendRequest_fails.0.snap
@@ -57,7 +57,7 @@
       variableData: { variables: [  ] },
       response: [  ],
       responseId: undefined,
-      isHidden: false,
+      shouldBeRemovedOnSend: undefined,
       result: { errorDetails: { message: "No activated agent with id \"ChatProviderWithUsedContext\"" } },
       followups: undefined,
       isCanceled: false,

--- a/src/vs/workbench/contrib/chat/test/common/chatModel.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/chatModel.test.ts
@@ -163,8 +163,8 @@ suite('ChatModel', () => {
 
 		assert.strictEqual(request1.isCompleteAddedRequest, true);
 		assert.strictEqual(request1.response!.isCompleteAddedRequest, true);
-		assert.strictEqual(request1.shouldBeRemovedOnSend, false);
-		assert.strictEqual(request1.response!.shouldBeRemovedOnSend, false);
+		assert.strictEqual(request1.shouldBeRemovedOnSend, undefined);
+		assert.strictEqual(request1.response!.shouldBeRemovedOnSend, undefined);
 	});
 });
 

--- a/src/vs/workbench/contrib/terminalContrib/chat/browser/terminalChatWidget.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chat/browser/terminalChatWidget.ts
@@ -382,7 +382,6 @@ export class TerminalChatWidget extends Disposable {
 		this._activeRequestCts = new CancellationTokenSource();
 		const store = new DisposableStore();
 		this._requestActiveContextKey.set(true);
-		let responseContent = '';
 		const response = await this._inlineChatWidget.chatWidget.acceptInput(lastInput, { isVoiceInput: options?.isVoiceInput });
 		this._currentRequestId = response?.requestId;
 		const responsePromise = new DeferredPromise<IChatResponseModel | undefined>();
@@ -390,7 +389,6 @@ export class TerminalChatWidget extends Disposable {
 			this._requestActiveContextKey.set(true);
 			if (response) {
 				store.add(response.onDidChange(async () => {
-					responseContent += response.response.value;
 					if (response.isCanceled) {
 						this._requestActiveContextKey.set(false);
 						responsePromise.complete(undefined);


### PR DESCRIPTION
Allows undoing edits mad by agents, one-by-one. Validated it works and is restored well from storage and on followup requests.

It works by putting `undoStop`s into the response stream, snapshotting at the same time those are added, and using that to display the correct data. It currently only undoes edits, but we could support undo's from other tools by adding commands or other instruction metadata to undo stops.