### PR TITLE
Fix: Prevent unnecessary warning when startup editor userRemoteValue is 'undefined'

### DIFF
--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/startupPage.ts
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/startupPage.ts
@@ -129,6 +129,14 @@ export class StartupPageRunnerContribution extends Disposable implements IWorkbe
 			if (!this.editorService.activeEditor || this.layoutService.openedDefaultEditors) {
 				const startupEditorSetting = this.configurationService.inspect<string>(configurationKey);
 
+				this.logService.debug('Startup Editor Values:', {
+					value: startupEditorSetting.value,
+					userRemoteValue: startupEditorSetting.userRemoteValue,
+					userValue: startupEditorSetting.userValue,
+					workspaceValue: startupEditorSetting.workspaceValue,
+					defaultValue: startupEditorSetting.defaultValue
+				});
+
 				if (startupEditorSetting.value === 'readme') {
 					await this.openReadme();
 				} else if (startupEditorSetting.value === 'welcomePage' || startupEditorSetting.value === 'welcomePageInEmptyWorkbench') {
@@ -214,6 +222,15 @@ function isStartupPageEnabled(configurationService: IConfigurationService, conte
 	}
 
 	const startupEditor = configurationService.inspect<string>(configurationKey);
+
+	logService.debug('Startup Editor Values:', {
+		value: startupEditor.value,
+		userRemoteValue: startupEditor.userRemoteValue,
+		userValue: startupEditor.userValue,
+		workspaceValue: startupEditor.workspaceValue,
+		defaultValue: startupEditor.defaultValue
+	});
+
 	if (!startupEditor.userValue && !startupEditor.workspaceValue) {
 		const welcomeEnabled = configurationService.inspect(oldConfigurationKey);
 		if (welcomeEnabled.value !== undefined && welcomeEnabled.value !== null) {
@@ -221,7 +238,13 @@ function isStartupPageEnabled(configurationService: IConfigurationService, conte
 		}
 	}
 
-	if (startupEditor.value !== startupEditor.userRemoteValue) {
+	const validStartupEditorValues = ['welcomePage', 'readme', 'welcomePageInEmptyWorkbench', 'terminal', 'none', 'newUntitledFile'];
+
+	if (startupEditor.value !== startupEditor.userRemoteValue &&
+		startupEditor.userRemoteValue &&
+		startupEditor.userRemoteValue !== 'undefined' &&
+		typeof startupEditor.userRemoteValue === 'string' &&
+		validStartupEditorValues.includes(startupEditor.userRemoteValue)) {
 		logService.info(`Startup editor is configured to be "${startupEditor.value}". This setting will be overridden by "${startupEditor.userRemoteValue}".`);
 	}
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
When userRemoteValue is "undefined", the log shows a misleading warning:
  `INFO Startup editor is configured to be 'welcomePage'. This setting will be overridden by 'undefined'`
 
This warning is unnecessary because "undefined" is not a valid startup editor value and shouldn't trigger an override warning.
Added additional validation checks before logging the warning:

- Check if userRemoteValue exists
- Check if it's not the string "undefined"
- Verify it's a valid startup editor value

Testing steps:

1. Set a startup editor value (e.g. 'welcomePage')
2. Set userRemoteValue to "undefined"
3. Verify that no warning appears
4. Set userRemoteValue to a valid value (e.g. 'readme')
5. Verify that the warning still appears correctly