### PR TITLE
Use notebook cell id when computing diff of notebooks

### DIFF
--- a/src/vs/workbench/contrib/notebook/common/services/notebookSimpleWorker.ts
+++ b/src/vs/workbench/contrib/notebook/common/services/notebookSimpleWorker.ts
@@ -231,16 +231,19 @@ export class NotebookEditorSimpleWorker implements IRequestHandler, IDisposable 
 		const modifiedMetadata = filter(modified.metadata, key => !modified.transientDocumentMetadata[key]);
 		return {
 			metadataChanged: JSON.stringify(originalMetadata) !== JSON.stringify(modifiedMetadata),
-			cellsDiff: diffResult,
+			cellsDiff: await this.$computeDiffWithCellIds(original, modified) || diffResult,
 			// linesDiff: cellLineChanges
 		};
 	}
 
 	async $computeDiffWithCellIds(original: MirrorNotebookDocument, modified: MirrorNotebookDocument): Promise<IDiffResult | undefined> {
-		const originalCellIds = original.cells.map((cell, index) => ({ index, id: (cell.metadata?.id || '') as string }));
-		const modifiedCellIds = modified.cells.map((cell, index) => ({ index, id: (cell.metadata?.id || '') as string }));
-
-		if (originalCellIds.some(c => !c.id) || modifiedCellIds.some(c => !c.id)) {
+		const originalCellIndexIds = original.cells.map((cell, index) => ({ index, id: (cell.metadata?.id || cell.internalMetadata?.cellId || '') as string }));
+		const modifiedCellIndexIds = modified.cells.map((cell, index) => ({ index, id: (cell.metadata?.id || cell.internalMetadata?.cellId || '') as string }));
+		const originalCellIds = originalCellIndexIds.map(c => c.id);
+		const modifiedCellIds = modifiedCellIndexIds.map(c => c.id);
+		const orderOrOriginalCellIds = originalCellIds.filter(id => modifiedCellIds.includes(id)).join(',');
+		const orderOrModifiedCellIds = modifiedCellIds.filter(id => originalCellIds.includes(id)).join(',');
+		if (originalCellIndexIds.some(c => !c.id) || modifiedCellIndexIds.some(c => !c.id) || orderOrOriginalCellIds !== orderOrModifiedCellIds) {
 			return;
 		}
 
@@ -259,13 +262,13 @@ export class NotebookEditorSimpleWorker implements IRequestHandler, IDisposable 
 
 		const [originalSeq, modifiedSeq] = await Promise.all([computeCellHashesById(original), computeCellHashesById(modified)]);
 
-		while (modifiedCellIds.length) {
-			const modifiedCell = modifiedCellIds.shift()!;
-			const originalCell = originalCellIds.find(c => c.id === modifiedCell.id);
+		while (modifiedCellIndexIds.length) {
+			const modifiedCell = modifiedCellIndexIds.shift()!;
+			const originalCell = originalCellIndexIds.find(c => c.id === modifiedCell.id);
 			if (originalCell) {
 				// Everything before this cell is a deletion
-				const index = originalCellIds.indexOf(originalCell);
-				const deletedFromOriginal = originalCellIds.splice(0, index + 1);
+				const index = originalCellIndexIds.indexOf(originalCell);
+				const deletedFromOriginal = originalCellIndexIds.splice(0, index + 1);
 
 				if (deletedFromOriginal.length === 1) {
 					if (originalSeq.get(originalCell.id) === modifiedSeq.get(originalCell.id)) {
@@ -294,7 +297,7 @@ export class NotebookEditorSimpleWorker implements IRequestHandler, IDisposable 
 			else {
 				// This is a new cell.
 				diffResult.changes.push({
-					originalStart: originalCellIds.length ? originalCellIds[0].index : original.cells.length,
+					originalStart: originalCellIndexIds.length ? originalCellIndexIds[0].index : original.cells.length,
 					originalLength: 0,
 					modifiedStart: modifiedCell.index,
 					modifiedLength: 1
@@ -303,11 +306,11 @@ export class NotebookEditorSimpleWorker implements IRequestHandler, IDisposable 
 		}
 
 		// If we still have some original cells, then those have been removed.
-		if (originalCellIds.length) {
+		if (originalCellIndexIds.length) {
 			diffResult.changes.push({
-				originalStart: originalCellIds[0].index,
-				originalLength: originalCellIds.length,
-				modifiedStart: modifiedCellIds.length,
+				originalStart: originalCellIndexIds[0].index,
+				originalLength: originalCellIndexIds.length,
+				modifiedStart: modifiedCellIndexIds.length,
 				modifiedLength: 0
 			});
 		}

--- a/src/vs/workbench/contrib/notebook/common/services/notebookSimpleWorker.ts
+++ b/src/vs/workbench/contrib/notebook/common/services/notebookSimpleWorker.ts
@@ -237,8 +237,8 @@ export class NotebookEditorSimpleWorker implements IRequestHandler, IDisposable 
 	}
 
 	async $computeDiffWithCellIds(original: MirrorNotebookDocument, modified: MirrorNotebookDocument): Promise<IDiffResult | undefined> {
-		const originalCellIndexIds = original.cells.map((cell, index) => ({ index, id: (cell.metadata?.id || cell.internalMetadata?.cellId || '') as string }));
-		const modifiedCellIndexIds = modified.cells.map((cell, index) => ({ index, id: (cell.metadata?.id || cell.internalMetadata?.cellId || '') as string }));
+		const originalCellIndexIds = original.cells.map((cell, index) => ({ index, id: (cell.metadata?.id || '') as string }));
+		const modifiedCellIndexIds = modified.cells.map((cell, index) => ({ index, id: (cell.metadata?.id || '') as string }));
 		const originalCellIds = originalCellIndexIds.map(c => c.id);
 		const modifiedCellIds = modifiedCellIndexIds.map(c => c.id);
 		const orderOrOriginalCellIds = originalCellIds.filter(id => modifiedCellIds.includes(id)).join(',');


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
Fixes the case where you add a new cell at the top or middle and view the diff of notebook, then all cells are red and green. We do not identify an insertion, but detect them as cells changed and one insertiong at the bottom of the notebook