### PR TITLE
Prevent delayed hovers being recreated when locked manually

### DIFF
--- a/src/vs/editor/browser/services/hoverService/hoverService.ts
+++ b/src/vs/editor/browser/services/hoverService/hoverService.ts
@@ -82,8 +82,8 @@ export class HoverService extends Disposable implements IHoverService {
 		lifecycleOptions: Pick<IHoverLifecycleOptions, 'groupId'>,
 	): IHoverWidget | undefined {
 		if (!this._currentDelayedHover || this._currentDelayedHoverWasShown) {
-			// Current hover is sticky, reject
-			if (this._currentHover && this._currentHoverOptions?.persistence?.sticky) {
+			// Current hover is locked, reject
+			if (this._currentHover?.isLocked) {
 				return undefined;
 			}
 
@@ -183,7 +183,7 @@ export class HoverService extends Disposable implements IHoverService {
 	private _createHover(options: IHoverOptions, skipLastFocusedUpdate?: boolean): HoverWidget | undefined {
 		this._currentDelayedHover = undefined;
 
-		if (this._currentHover && this._currentHoverOptions?.persistence?.sticky) {
+		if (this._currentHover?.isLocked) {
 			return undefined;
 		}
 		if (getHoverOptionsIdentity(this._currentHoverOptions) === getHoverOptionsIdentity(options)) {


### PR DESCRIPTION
Sticky the option maps to widget locked state, we should be using the latter when checking whether the current state is good since it also includes holding alt.

Fixes #240787

cc @roblourens @benibenj 