### PR TITLE
chat: make edits distinct per text edit group

### DIFF
--- a/src/vs/base/common/arraysFind.ts
+++ b/src/vs/base/common/arraysFind.ts
@@ -5,15 +5,15 @@
 
 import { Comparator } from './arrays.js';
 
-export function findLast<T>(array: readonly T[], predicate: (item: T) => boolean): T | undefined {
-	const idx = findLastIdx(array, predicate);
+export function findLast<T>(array: readonly T[], predicate: (item: T) => unknown, fromIndex = array.length - 1): T | undefined {
+	const idx = findLastIdx(array, predicate, fromIndex);
 	if (idx === -1) {
 		return undefined;
 	}
 	return array[idx];
 }
 
-export function findLastIdx<T>(array: readonly T[], predicate: (item: T) => boolean, fromIndex = array.length - 1): number {
+export function findLastIdx<T>(array: readonly T[], predicate: (item: T) => unknown, fromIndex = array.length - 1): number {
 	for (let i = fromIndex; i >= 0; i--) {
 		const element = array[i];
 

--- a/src/vs/base/common/async.ts
+++ b/src/vs/base/common/async.ts
@@ -298,6 +298,10 @@ export class SequencerByKey<TKey> {
 		this.promiseMap.set(key, newPromise);
 		return newPromise;
 	}
+
+	keys(): IterableIterator<TKey> {
+		return this.promiseMap.keys();
+	}
 }
 
 interface IScheduledLater extends IDisposable {

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/chatMarkdownContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/chatMarkdownContentPart.ts
@@ -5,6 +5,7 @@
 
 import * as dom from '../../../../../base/browser/dom.js';
 import { StandardMouseEvent } from '../../../../../base/browser/mouseEvent.js';
+import { findLast } from '../../../../../base/common/arraysFind.js';
 import { Codicon } from '../../../../../base/common/codicons.js';
 import { Emitter } from '../../../../../base/common/event.js';
 import { Disposable, DisposableStore, IDisposable } from '../../../../../base/common/lifecycle.js';
@@ -14,6 +15,7 @@ import { ThemeIcon } from '../../../../../base/common/themables.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { MarkdownRenderer } from '../../../../../editor/browser/widget/markdownRenderer/browser/markdownRenderer.js';
 import { Range } from '../../../../../editor/common/core/range.js';
+import { IDocumentDiff } from '../../../../../editor/common/diff/documentDiffProvider.js';
 import { ILanguageService } from '../../../../../editor/common/languages/language.js';
 import { ITextModel } from '../../../../../editor/common/model.js';
 import { getIconClasses } from '../../../../../editor/common/services/getIconClasses.js';
@@ -31,7 +33,7 @@ import { IEditorService } from '../../../../services/editor/common/editorService
 import { IMarkdownVulnerability } from '../../common/annotations.js';
 import { IChatEditingService } from '../../common/chatEditingService.js';
 import { IChatProgressRenderableResponseContent } from '../../common/chatModel.js';
-import { IChatMarkdownContent } from '../../common/chatService.js';
+import { IChatMarkdownContent, IChatUndoStop } from '../../common/chatService.js';
 import { isRequestVM, isResponseVM } from '../../common/chatViewModel.js';
 import { CodeBlockModelCollection } from '../../common/codeBlockModelCollection.js';
 import { IChatCodeBlockInfo, IChatListItemRendererOptions } from '../chat.js';
@@ -73,6 +75,7 @@ export class ChatMarkdownContentPart extends Disposable implements IChatContentP
 		super();
 
 		const element = context.element;
+		const inUndoStop = (findLast(context.content, e => e.kind === 'undoStop', context.contentIndex) as IChatUndoStop | undefined)?.id;
 
 		// We release editors in order so that it's more likely that the same editor will be assigned if this element is re-rendered right away, like it often is during progressive rendering
 		const orderedDisposablesList: IDisposable[] = [];
@@ -149,7 +152,7 @@ export class ChatMarkdownContentPart extends Disposable implements IChatContentP
 					return ref.object.element;
 				} else {
 					const requestId = isRequestVM(element) ? element.id : element.requestId;
-					const ref = this.renderCodeBlockPill(element.sessionId, requestId, codeBlockInfo.codemapperUri, !isCodeBlockComplete);
+					const ref = this.renderCodeBlockPill(element.sessionId, requestId, inUndoStop, codeBlockInfo.codemapperUri, !isCodeBlockComplete);
 					if (isResponseVM(codeBlockInfo.element)) {
 						// TODO@joyceerhl: remove this code when we change the codeblockUri API to make the URI available synchronously
 						this.codeBlockModelCollection.update(codeBlockInfo.element.sessionId, codeBlockInfo.element, codeBlockInfo.codeBlockIndex, { text, languageId: codeBlockInfo.languageId, isComplete: isCodeBlockComplete }).then((e) => {
@@ -192,8 +195,8 @@ export class ChatMarkdownContentPart extends Disposable implements IChatContentP
 		this.domNode = result.element;
 	}
 
-	private renderCodeBlockPill(sessionId: string, requestId: string, codemapperUri: URI | undefined, isStreaming: boolean): IDisposableReference<CollapsedCodeBlock> {
-		const codeBlock = this.instantiationService.createInstance(CollapsedCodeBlock, sessionId, requestId);
+	private renderCodeBlockPill(sessionId: string, requestId: string, inUndoStop: string | undefined, codemapperUri: URI | undefined, isStreaming: boolean): IDisposableReference<CollapsedCodeBlock> {
+		const codeBlock = this.instantiationService.createInstance(CollapsedCodeBlock, sessionId, requestId, inUndoStop);
 		if (codemapperUri) {
 			codeBlock.render(codemapperUri, isStreaming);
 		}
@@ -296,7 +299,8 @@ class CollapsedCodeBlock extends Disposable {
 
 	constructor(
 		private readonly sessionId: string,
-		requestId: string,
+		private readonly requestId: string,
+		private readonly inUndoStop: string | undefined,
 		@ILabelService private readonly labelService: ILabelService,
 		@IEditorService private readonly editorService: IEditorService,
 		@IModelService private readonly modelService: IModelService,
@@ -335,7 +339,8 @@ class CollapsedCodeBlock extends Disposable {
 		this._uri = uri;
 
 		const iconText = this.labelService.getUriBasenameLabel(uri);
-		const modifiedEntry = this.chatEditingService.getEditingSession(this.sessionId)?.getEntry(uri);
+		const editSession = this.chatEditingService.getEditingSession(this.sessionId);
+		const modifiedEntry = editSession?.getEntry(uri);
 		const isComplete = !modifiedEntry?.isCurrentlyBeingModifiedBy.get();
 
 		let iconClasses: string[] = [];
@@ -359,6 +364,25 @@ class CollapsedCodeBlock extends Disposable {
 		this.element.replaceChildren(iconEl, ...children);
 		this.element.title = this.labelService.getUriLabel(uri, { relative: false });
 
+
+		const renderDiff = (changes: IDocumentDiff | undefined) => {
+			const labelAdded = this.element.querySelector('.label-added') ?? this.element.appendChild(dom.$('span.label-added'));
+			const labelRemoved = this.element.querySelector('.label-removed') ?? this.element.appendChild(dom.$('span.label-removed'));
+			if (changes && !changes?.identical && !changes?.quitEarly) {
+				let removedLines = 0;
+				let addedLines = 0;
+				for (const change of changes.changes) {
+					removedLines += change.original.endLineNumberExclusive - change.original.startLineNumber;
+					addedLines += change.modified.endLineNumberExclusive - change.modified.startLineNumber;
+				}
+				labelAdded.textContent = `+${addedLines}`;
+				labelRemoved.textContent = `-${removedLines}`;
+				const insertionsFragment = addedLines === 1 ? localize('chat.codeblock.insertions.one', "1 insertion") : localize('chat.codeblock.insertions', "{0} insertions", addedLines);
+				const deletionsFragment = removedLines === 1 ? localize('chat.codeblock.deletions.one', "1 deletion") : localize('chat.codeblock.deletions', "{0} deletions", removedLines);
+				this.element.ariaLabel = this.element.title = localize('summary', 'Edited {0}, {1}, {2}', iconText, insertionsFragment, deletionsFragment);
+			}
+		};
+
 		// Show a percentage progress that is driven by the rewrite
 
 		this._progressStore.add(autorun(r => {
@@ -376,23 +400,10 @@ class CollapsedCodeBlock extends Disposable {
 				labelDetail.textContent = '';
 			}
 
-			if (!isStreaming && isComplete) {
-				const labelAdded = this.element.querySelector('.label-added') ?? this.element.appendChild(dom.$('span.label-added'));
-				const labelRemoved = this.element.querySelector('.label-removed') ?? this.element.appendChild(dom.$('span.label-removed'));
-				const changes = modifiedEntry?.diffInfo.read(r);
-				if (changes && !changes?.identical && !changes?.quitEarly) {
-					let removedLines = 0;
-					let addedLines = 0;
-					for (const change of changes.changes) {
-						removedLines += change.original.endLineNumberExclusive - change.original.startLineNumber;
-						addedLines += change.modified.endLineNumberExclusive - change.modified.startLineNumber;
-					}
-					labelAdded.textContent = `+${addedLines}`;
-					labelRemoved.textContent = `-${removedLines}`;
-					const insertionsFragment = addedLines === 1 ? localize('chat.codeblock.insertions.one', "1 insertion") : localize('chat.codeblock.insertions', "{0} insertions", addedLines);
-					const deletionsFragment = removedLines === 1 ? localize('chat.codeblock.deletions.one', "1 deletion") : localize('chat.codeblock.deletions', "{0} deletions", removedLines);
-					this.element.ariaLabel = this.element.title = localize('summary', 'Edited {0}, {1}, {2}', iconText, insertionsFragment, deletionsFragment);
-				}
+			if (!isStreaming && isComplete && modifiedEntry) {
+				const betweenStopDiff = editSession?.getEntryDiffBetweenStops(modifiedEntry.modifiedURI, this.requestId, this.inUndoStop);
+				const changes = (betweenStopDiff || modifiedEntry.diffInfo).read(r);
+				renderDiff(changes);
 			}
 		}));
 	}

--- a/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingModifiedFileEntry.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingModifiedFileEntry.ts
@@ -300,6 +300,16 @@ export class ChatEditingModifiedFileEntry extends Disposable implements IModifie
 		this._telemetryInfo = telemetryInfo;
 	}
 
+	equalsSnapshot(snapshot: ISnapshotEntry | undefined): boolean {
+		return !!snapshot &&
+			this.modifiedURI.toString() === snapshot.resource.toString() &&
+			this.modifiedModel.getLanguageId() === snapshot.languageId &&
+			this.originalModel.getValue() === snapshot.original &&
+			this.modifiedModel.getValue() === snapshot.current &&
+			this._edit.equals(snapshot.originalToCurrentEdit) &&
+			this.state.get() === snapshot.state;
+	}
+
 	createSnapshot(requestId: string | undefined, undoStop: string | undefined): ISnapshotEntry {
 		this._isFirstEditAfterStartOrSnapshot = true;
 		return {

--- a/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingServiceImpl.ts
@@ -4,16 +4,17 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { coalesce, compareBy, delta } from '../../../../../base/common/arrays.js';
-import { AsyncIterableSource } from '../../../../../base/common/async.js';
+import { findLastIdx } from '../../../../../base/common/arraysFind.js';
 import { CancellationToken } from '../../../../../base/common/cancellation.js';
 import { Codicon } from '../../../../../base/common/codicons.js';
-import { BugIndicatingError, ErrorNoTelemetry } from '../../../../../base/common/errors.js';
+import { ErrorNoTelemetry } from '../../../../../base/common/errors.js';
 import { Emitter, Event } from '../../../../../base/common/event.js';
 import { Iterable } from '../../../../../base/common/iterator.js';
 import { Disposable, DisposableStore, dispose, IDisposable, toDisposable } from '../../../../../base/common/lifecycle.js';
 import { LinkedList } from '../../../../../base/common/linkedList.js';
 import { ResourceMap } from '../../../../../base/common/map.js';
 import { derived, IObservable, observableValueOpts, runOnChange, ValueWithChangeEventFromObservable } from '../../../../../base/common/observable.js';
+import { isEqual } from '../../../../../base/common/resources.js';
 import { compare } from '../../../../../base/common/strings.js';
 import { ThemeIcon } from '../../../../../base/common/themables.js';
 import { assertType, isString } from '../../../../../base/common/types.js';
@@ -34,8 +35,8 @@ import { ILifecycleService } from '../../../../services/lifecycle/common/lifecyc
 import { IMultiDiffSourceResolver, IMultiDiffSourceResolverService, IResolvedMultiDiffSource, MultiDiffEditorItem } from '../../../multiDiffEditor/browser/multiDiffSourceResolverService.js';
 import { CellUri, ICellEditOperation } from '../../../notebook/common/notebookCommon.js';
 import { ChatAgentLocation, IChatAgentService } from '../../common/chatAgents.js';
-import { CHAT_EDITING_MULTI_DIFF_SOURCE_RESOLVER_SCHEME, chatEditingAgentSupportsReadonlyReferencesContextKey, chatEditingResourceContextKey, ChatEditingSessionState, IChatEditingService, IChatEditingSession, IChatEditingSessionStream, IChatRelatedFile, IChatRelatedFilesProvider, IModifiedFileEntry, inChatEditingSessionContextKey, WorkingSetEntryState } from '../../common/chatEditingService.js';
-import { IChatNotebookEditGroup, IChatResponseModel, IChatTextEditGroup } from '../../common/chatModel.js';
+import { CHAT_EDITING_MULTI_DIFF_SOURCE_RESOLVER_SCHEME, chatEditingAgentSupportsReadonlyReferencesContextKey, chatEditingResourceContextKey, ChatEditingSessionState, IChatEditingService, IChatEditingSession, IChatRelatedFile, IChatRelatedFilesProvider, IModifiedFileEntry, inChatEditingSessionContextKey, IStreamingEdits, WorkingSetEntryState } from '../../common/chatEditingService.js';
+import { IChatResponseModel } from '../../common/chatModel.js';
 import { IChatService } from '../../common/chatService.js';
 import { ChatEditingModifiedFileEntry } from './chatEditingModifiedFileEntry.js';
 import { ChatEditingSession } from './chatEditingSession.js';
@@ -215,7 +216,6 @@ export class ChatEditingService extends Disposable implements IChatEditingServic
 	}
 
 	private installAutoApplyObserver(session: ChatEditingSession): IDisposable {
-
 		const chatModel = this._chatService.getOrRestoreSession(session.chatSessionId);
 		if (!chatModel) {
 			throw new ErrorNoTelemetry(`Edit session was created for a non-existing chat session: ${session.chatSessionId}`);
@@ -223,150 +223,135 @@ export class ChatEditingService extends Disposable implements IChatEditingServic
 
 		const observerDisposables = new DisposableStore();
 
-		let editsSource: AsyncIterableSource<IChatTextEditGroup | IChatNotebookEditGroup> | undefined;
-		let editsPromise: Promise<void> | undefined;
-		const editsSeen = new ResourceMap<{ seen: number }>();
-		const editedFilesExist = new ResourceMap<Promise<void>>();
-
-		const onResponseComplete = (responseModel: IChatResponseModel) => {
-			if (responseModel.result?.errorDetails && !responseModel.result.errorDetails.responseIsIncomplete) {
-				// Roll back everything
-				session.restoreSnapshot(responseModel.requestId, undefined);
-			}
-
-			editsSource?.resolve();
-			editsSource = undefined;
-			editsSeen.clear();
-			editedFilesExist.clear();
-		};
-
-
-		const handleResponseParts = async (responseModel: IChatResponseModel) => {
-
-			if (responseModel.isCanceled) {
-				return;
-			}
-
-			for (const part of responseModel.response.value) {
-				if (part.kind !== 'codeblockUri' && part.kind !== 'textEditGroup' && part.kind !== 'notebookEditGroup') {
-					continue;
-				}
-				// ensure editor is open asap
-				const uri = CellUri.parse(part.uri)?.notebook ?? part.uri;
-				if (!editedFilesExist.get(uri)) {
-					editedFilesExist.set(uri, this._fileService.exists(uri).then((e) => {
-						if (!e) {
-							return;
-						}
-						const activeUri = this._editorService.activeEditorPane?.input.resource;
-						const inactive = activeUri && session.workingSet.has(activeUri);
-						this._editorService.openEditor({ resource: uri, options: { inactive, preserveFocus: true, pinned: true } });
-					}));
-				}
-
-				// get new edits and start editing session
-				const first = editsSeen.size === 0;
-				let entry = editsSeen.get(part.uri);
-				if (!entry) {
-					entry = { seen: 0 };
-					editsSeen.set(part.uri, entry);
-				}
-
-				const allEdits = part.kind !== 'codeblockUri' ? part.edits : [];
-				const newEdits = allEdits.slice(entry.seen);
-				entry.seen += newEdits.length;
-
-				if (newEdits.length > 0 || entry.seen === 0) {
-					// only allow empty edits when having just started, ignore otherwise to avoid unneccessary work
-					editsSource ??= new AsyncIterableSource();
-					if (part.kind === 'notebookEditGroup') {
-						editsSource.emitOne({ uri: part.uri, edits: newEdits as ICellEditOperation[][], kind: part.kind, done: part.done });
-					} else if (part.kind === 'textEditGroup') {
-						editsSource.emitOne({ uri: part.uri, edits: newEdits as TextEdit[][], kind: part.kind, done: part.done });
-					}
-				}
-
-				if (first) {
-
-					await editsPromise;
-
-					editsPromise = this._continueEditingSession(session, async (builder) => {
-						for await (const item of editsSource!.asyncIterable) {
-							if (responseModel.isCanceled) {
-								break;
-							}
-							if (item.edits.length === 0) {
-								// EMPTY edit, just signal via empty edits that work is starting
-								builder.textEdits(item.uri, [], item.done ?? false, responseModel);
-								continue;
-							}
-							for (let i = 0; i < item.edits.length; i++) {
-								const isLastGroup = i === item.edits.length - 1;
-								if (item.kind === 'notebookEditGroup') {
-									const group = item.edits[i];
-									builder.notebookEdits(item.uri, group, isLastGroup && (item.done ?? false), responseModel);
-								} else {
-									const group = item.edits[i];
-									builder.textEdits(item.uri, group, isLastGroup && (item.done ?? false), responseModel);
-								}
-							}
-						}
-					}).finally(() => {
-						editsPromise = undefined;
-					});
-				}
-			}
-		};
-
 		observerDisposables.add(chatModel.onDidChange(async e => {
 			if (e.kind !== 'addRequest') {
 				return;
 			}
 			session.createSnapshot(e.request.id, undefined);
 			const responseModel = e.request.response;
-			if (!responseModel) {
-				return;
-			}
-			if (responseModel.isComplete) {
-				await handleResponseParts(responseModel);
-				onResponseComplete(responseModel);
-			} else {
-				const disposable = observerDisposables.add(responseModel.onDidChange(e2 => {
-					if (e2.reason === 'undoStop') {
-						session.createSnapshot(e.request.id, e2.id);
-					} else {
-						handleResponseParts(responseModel).then(() => {
-							if (responseModel.isComplete) {
-								onResponseComplete(responseModel);
-								observerDisposables.delete(disposable);
-							}
-						});
-					}
-				}));
+			if (responseModel) {
+				this.observerEditsInResponse(e.request.id, responseModel, session, observerDisposables);
 			}
 		}));
 		observerDisposables.add(chatModel.onDidDispose(() => observerDisposables.dispose()));
 		return observerDisposables;
 	}
 
-	private async _continueEditingSession(session: ChatEditingSession, builder: (stream: IChatEditingSessionStream) => Promise<void>): Promise<void> {
-		if (session.state.get() === ChatEditingSessionState.StreamingEdits) {
-			throw new BugIndicatingError('Cannot continue session that is still streaming');
-		}
+	private observerEditsInResponse(requestId: string, responseModel: IChatResponseModel, session: ChatEditingSession, observerDisposables: DisposableStore) {
+		// Sparse array: the indicies are indexes of `responseModel.response.value`
+		// that are edit groups, and then this tracks the edit application for
+		// each of them. Note that text edit groups can be updated
+		// multiple times during the process of response streaming.
+		const editsSeen: ({ seen: number; streaming: IStreamingEdits } | undefined)[] = [];
+		// Same deal as above, but for code block URIs. Code block URIs preceed a
+		// text edit group, and are used to allow us to start an editing state
+		// prior to the code actually streaming in. When a new edit block it seen,
+		// it'll look back and 'claim' the last unclaimed matchin codeblock URI.
+		const codeBlockUrisSeen: ({ uri: URI; streaming?: IStreamingEdits } | undefined)[] = [];
 
-		const stream: IChatEditingSessionStream = {
-			textEdits: (resource: URI, textEdits: TextEdit[], isDone: boolean, responseModel: IChatResponseModel) => {
-				session.acceptTextEdits(resource, textEdits, isDone, responseModel);
-			},
-			notebookEdits(resource: URI, edits: ICellEditOperation[], isLastEdits: boolean, responseModel: IChatResponseModel) {
-				session.acceptNotebookEdits(resource, edits, isLastEdits, responseModel);
-			},
+		const editedFilesExist = new ResourceMap<Promise<void>>();
+		const ensureEditorOpen = (partUri: URI) => {
+			const uri = CellUri.parse(partUri)?.notebook ?? partUri;
+			if (editedFilesExist.has(uri)) {
+				return;
+			}
+
+			editedFilesExist.set(uri, this._fileService.exists(uri).then((e) => {
+				if (!e) {
+					return;
+				}
+				const activeUri = this._editorService.activeEditorPane?.input.resource;
+				const inactive = activeUri && session.workingSet.has(activeUri);
+				this._editorService.openEditor({ resource: uri, options: { inactive, preserveFocus: true, pinned: true } });
+			}));
 		};
-		session.acceptStreamingEditsStart();
-		try {
-			await builder(stream);
-		} finally {
-			session.resolve();
+
+		const onResponseComplete = () => {
+			for (const remaining of editsSeen) {
+				remaining?.streaming.complete();
+			}
+			if (responseModel.result?.errorDetails && !responseModel.result.errorDetails.responseIsIncomplete) {
+				// Roll back everything
+				session.restoreSnapshot(responseModel.requestId, undefined);
+			}
+
+			editsSeen.length = 0;
+			editedFilesExist.clear();
+		};
+
+		const handleResponseParts = async () => {
+			if (responseModel.isCanceled) {
+				return;
+			}
+
+			let undoStop: undefined | string;
+			for (let i = 0; i < responseModel.response.value.length; i++) {
+				const part = responseModel.response.value[i];
+
+				if (part.kind === 'undoStop') {
+					undoStop = part.id;
+					continue;
+				}
+
+				if (part.kind === 'codeblockUri') {
+					ensureEditorOpen(part.uri);
+					codeBlockUrisSeen[i] ??= { uri: part.uri, streaming: session.startStreamingEdits(part.uri, responseModel, undoStop) };
+					continue;
+				}
+
+				if (part.kind !== 'textEditGroup' && part.kind !== 'notebookEditGroup') {
+					continue;
+				}
+
+
+				// get new edits and start editing session
+				let entry = editsSeen[i];
+				if (!entry) {
+					const codeBlockIndex = findLastIdx(codeBlockUrisSeen, e => e?.streaming && isEqual(e.uri, part.uri), i - 1);
+					if (codeBlockIndex) {
+						entry = { seen: 0, streaming: codeBlockUrisSeen[codeBlockIndex]!.streaming! };
+						codeBlockUrisSeen[codeBlockIndex]!.streaming = undefined;
+					} else {
+						entry = { seen: 0, streaming: session.startStreamingEdits(part.uri, responseModel, undoStop) };
+					}
+
+					editsSeen[i] = entry;
+				}
+
+				const newEdits = part.edits.slice(entry.seen).flat();
+				entry.seen = part.edits.length;
+
+				if (newEdits.length > 0) {
+					if (part.kind === 'notebookEditGroup') {
+						entry.streaming.pushNotebook(newEdits as ICellEditOperation[]);
+					} else if (part.kind === 'textEditGroup') {
+						entry.streaming.pushText(newEdits as TextEdit[]);
+					}
+				}
+
+				if (part.done) {
+					entry.streaming.complete();
+				}
+			}
+		};
+
+		if (responseModel.isComplete) {
+			handleResponseParts().then(() => {
+				onResponseComplete();
+			});
+		} else {
+			const disposable = observerDisposables.add(responseModel.onDidChange(e2 => {
+				if (e2.reason === 'undoStop') {
+					session.createSnapshot(requestId, e2.id);
+				} else {
+					handleResponseParts().then(() => {
+						if (responseModel.isComplete) {
+							onResponseComplete();
+							observerDisposables.delete(disposable);
+						}
+					});
+				}
+			}));
 		}
 	}
 

--- a/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingSession.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingSession.ts
@@ -4,11 +4,12 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { binarySearch2 } from '../../../../../base/common/arrays.js';
-import { ITask, Sequencer, timeout } from '../../../../../base/common/async.js';
+import { DeferredPromise, ITask, Sequencer, SequencerByKey, timeout } from '../../../../../base/common/async.js';
 import { VSBuffer } from '../../../../../base/common/buffer.js';
 import { BugIndicatingError } from '../../../../../base/common/errors.js';
 import { Emitter } from '../../../../../base/common/event.js';
 import { StringSHA1 } from '../../../../../base/common/hash.js';
+import { Iterable } from '../../../../../base/common/iterator.js';
 import { Disposable, DisposableMap, DisposableStore, dispose } from '../../../../../base/common/lifecycle.js';
 import { ResourceMap, ResourceSet } from '../../../../../base/common/map.js';
 import { Schemas } from '../../../../../base/common/network.js';
@@ -19,12 +20,15 @@ import { URI } from '../../../../../base/common/uri.js';
 import { isCodeEditor, isDiffEditor } from '../../../../../editor/browser/editorBrowser.js';
 import { IBulkEditService } from '../../../../../editor/browser/services/bulkEditService.js';
 import { IOffsetEdit, ISingleOffsetEdit, OffsetEdit } from '../../../../../editor/common/core/offsetEdit.js';
+import { IDocumentDiff } from '../../../../../editor/common/diff/documentDiffProvider.js';
 import { TextEdit } from '../../../../../editor/common/languages.js';
 import { ILanguageService } from '../../../../../editor/common/languages/language.js';
 import { ITextModel } from '../../../../../editor/common/model.js';
+import { IEditorWorkerService } from '../../../../../editor/common/services/editorWorker.js';
 import { IModelService } from '../../../../../editor/common/services/model.js';
 import { ITextModelService } from '../../../../../editor/common/services/resolverService.js';
 import { localize } from '../../../../../nls.js';
+import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 import { EditorActivation } from '../../../../../platform/editor/common/editor.js';
 import { IEnvironmentService } from '../../../../../platform/environment/common/environment.js';
 import { IFileService } from '../../../../../platform/files/common/files.js';
@@ -38,10 +42,9 @@ import { IEditorService } from '../../../../services/editor/common/editorService
 import { ITextFileService } from '../../../../services/textfile/common/textfiles.js';
 import { MultiDiffEditor } from '../../../multiDiffEditor/browser/multiDiffEditor.js';
 import { MultiDiffEditorInput } from '../../../multiDiffEditor/browser/multiDiffEditorInput.js';
-import { ICellEditOperation } from '../../../notebook/common/notebookCommon.js';
 import { isNotebookEditorInput } from '../../../notebook/common/notebookEditorInput.js';
 import { INotebookService } from '../../../notebook/common/notebookService.js';
-import { ChatEditingSessionChangeType, ChatEditingSessionState, ChatEditKind, getMultiDiffSourceUri, IChatEditingSession, IModifiedFileEntry, WorkingSetDisplayMetadata, WorkingSetEntryRemovalReason, WorkingSetEntryState } from '../../common/chatEditingService.js';
+import { ChatEditingSessionChangeType, ChatEditingSessionState, ChatEditKind, getMultiDiffSourceUri, IChatEditingSession, IModifiedFileEntry, IStreamingEdits, WorkingSetDisplayMetadata, WorkingSetEntryRemovalReason, WorkingSetEntryState } from '../../common/chatEditingService.js';
 import { IChatRequestDisablement, IChatResponseModel } from '../../common/chatModel.js';
 import { IChatService } from '../../common/chatService.js';
 import { ChatEditingModifiedFileEntry, IModifiedEntryTelemetryInfo, ISnapshotEntry } from './chatEditingModifiedFileEntry.js';
@@ -107,7 +110,6 @@ export class ChatEditingSession extends Disposable implements IChatEditingSessio
 		this._assertNotDisposed();
 		return this._entriesObs;
 	}
-	private readonly _sequencer = new ThrottledSequencer(15, 1000);
 
 	private _workingSet = new ResourceMap<WorkingSetDisplayMetadata>();
 	get workingSet() {
@@ -164,11 +166,6 @@ export class ChatEditingSession extends Disposable implements IChatEditingSessio
 		return this._onDidDispose.event;
 	}
 
-	private _isToolsAgentSession = false;
-	get isToolsAgentSession(): boolean {
-		return this._isToolsAgentSession;
-	}
-
 	constructor(
 		readonly chatSessionId: string,
 		readonly isGlobalEditingSession: boolean,
@@ -183,6 +180,8 @@ export class ChatEditingSession extends Disposable implements IChatEditingSessio
 		@IChatService private readonly _chatService: IChatService,
 		@INotebookService private readonly _notebookService: INotebookService,
 		@ITextFileService private readonly _textFileService: ITextFileService,
+		@IEditorWorkerService private readonly _editorWorkerService: IEditorWorkerService,
+		@IConfigurationService private readonly _configurationService: IConfigurationService,
 	) {
 		super();
 	}
@@ -215,8 +214,12 @@ export class ChatEditingSession extends Disposable implements IChatEditingSessio
 		}));
 	}
 
-	public getEntry(uri: URI): IModifiedFileEntry | undefined {
+	private _getEntry(uri: URI): ChatEditingModifiedFileEntry | undefined {
 		return this._entriesObs.get().find(e => isEqual(e.modifiedURI, uri));
+	}
+
+	public getEntry(uri: URI): IModifiedFileEntry | undefined {
+		return this._getEntry(uri);
 	}
 
 	public readEntry(uri: URI, reader: IReader | undefined): IModifiedFileEntry | undefined {
@@ -332,6 +335,60 @@ export class ChatEditingSession extends Disposable implements IChatEditingSessio
 		this._pendingSnapshot ??= this._createSnapshot(undefined, undefined);
 	}
 
+	private _diffsBetweenStops = new Map<string, IObservable<IDocumentDiff | undefined>>();
+	public getEntryDiffBetweenStops(uri: URI, requestId: string, stopId: string | undefined) {
+		const key = `${uri}\0${requestId}\0${stopId}`;
+		const existing = this._diffsBetweenStops.get(key);
+		if (existing) {
+			return existing;
+		}
+
+		const history = this._linearHistory.get();
+		const snapshotIndex = history.findIndex(s => s.requestId === requestId);
+		if (snapshotIndex === -1) { return undefined; }
+		const stopIndex = history[snapshotIndex].stops.findIndex(s => s.stopId === stopId);
+		if (stopIndex === -1) { return undefined; }
+
+		const currentStop = history[snapshotIndex].stops[stopIndex];
+		const nextStop = stopIndex === history[snapshotIndex].stops.length - 1 ? history[snapshotIndex + 1]?.stops[0] : history[snapshotIndex].stops[stopIndex + 1];
+		if (!nextStop) { return undefined; }
+
+		const before = currentStop.entries.get(uri);
+		const after = nextStop.entries.get(uri);
+		if (!before || !after) { return undefined; }
+
+		// todo@connor4312: make this _actually_ observable to react to change to the
+		// whitespace setting changes and changes from {@link ensureEditInUndoStopMatches}
+		// May also want to move this onto the ChatEditingModifiedFileEntry.
+		const value = observableValue<IDocumentDiff | undefined>('getEntryDiffBetweenStops', undefined);
+		this._diffsBetweenStops.set(key, value);
+
+		const store = new DisposableStore();
+		(async () => {
+			const [refA, refB] = await Promise.all([
+				this._textModelService.createModelReference(before.snapshotUri),
+				this._textModelService.createModelReference(after.snapshotUri),
+			]);
+			store.add(refA);
+			store.add(refB);
+
+			const diff = await this._editorWorkerService.computeDiff(
+				refA.object.textEditorModel.uri,
+				refB.object.textEditorModel.uri,
+				{ ignoreTrimWhitespace: this._configurationService.getValue('diffEditor.ignoreTrimWhitespace') ?? true, computeMoves: false, maxComputationTimeMs: 3000 },
+				'advanced'
+			);
+			if (diff) {
+				value.set(diff, undefined);
+			}
+		})().finally(() => {
+			store.dispose();
+		});
+
+
+		return value;
+	}
+
 	public createSnapshot(requestId: string, undoStop: string | undefined): void {
 		const snapshot = this._createSnapshot(requestId, undoStop);
 		for (const [uri, data] of this._workingSet) {
@@ -365,10 +422,7 @@ export class ChatEditingSession extends Disposable implements IChatEditingSessio
 	}
 
 	private _createSnapshot(requestId: string | undefined, undoStop: string | undefined): IChatEditingSessionStop {
-		const workingSet = new ResourceMap<WorkingSetDisplayMetadata>();
-		for (const [file, state] of this._workingSet) {
-			workingSet.set(file, state);
-		}
+		const workingSet = new ResourceMap<WorkingSetDisplayMetadata>(this._workingSet);
 		const entries = new ResourceMap<ISnapshotEntry>();
 		for (const entry of this._entriesObs.get()) {
 			entries.set(entry.modifiedURI, entry.createSnapshot(requestId, undoStop));
@@ -435,8 +489,7 @@ export class ChatEditingSession extends Disposable implements IChatEditingSessio
 	}
 
 	private async _restoreSnapshot({ workingSet, entries }: IChatEditingSessionStop): Promise<void> {
-		this._workingSet = new ResourceMap();
-		workingSet.forEach((state, uri) => this._workingSet.set(uri, state));
+		this._workingSet = new ResourceMap(workingSet);
 
 		// Reset all the files which are modified in this session state
 		// but which are not found in the snapshot
@@ -603,39 +656,64 @@ export class ChatEditingSession extends Disposable implements IChatEditingSessio
 		this._onDidDispose.dispose();
 	}
 
-	acceptStreamingEditsStart(): void {
-		if (this._state.get() === ChatEditingSessionState.Disposed) {
-			// we don't throw in this case because there could be a builder still connected to a disposed session
-			return;
-		}
+	private _streamingEditLocks = new SequencerByKey</* URI */ string>();
 
-		// ensure that the edits are processed sequentially
-		this._sequencer.queue(() => this._acceptStreamingEditsStart());
+	private get isDisposed() {
+		return this._state.get() === ChatEditingSessionState.Disposed;
 	}
 
-	acceptTextEdits(resource: URI, textEdits: TextEdit[], isLastEdits: boolean, responseModel: IChatResponseModel): void {
-		if (this._state.get() === ChatEditingSessionState.Disposed) {
-			// we don't throw in this case because there could be a builder still connected to a disposed session
-			return;
-		}
+	startStreamingEdits(resource: URI, responseModel: IChatResponseModel, inUndoStop: string | undefined): IStreamingEdits {
+		const completePromise = new DeferredPromise<void>();
+		const startPromise = new DeferredPromise<void>();
 
-		this._isToolsAgentSession = !!responseModel.agent?.isToolsAgent;
+		// Sequence all edits made this this resource in this streaming edits instance,
+		// and also sequence the resource overall in the rare (currently invalid?) case
+		// that edits are made in parallel to the same resource,
+		const sequencer = new ThrottledSequencer(15, 1000);
+		sequencer.queue(() => startPromise.p);
 
-		// ensure that the edits are processed sequentially
-		this._sequencer.queue(() => this._acceptTextEdits(resource, textEdits, isLastEdits, responseModel));
-	}
-	acceptNotebookEdits(_resource: URI, _edits: ICellEditOperation[], _isLastEdits: boolean, _responseModel: IChatResponseModel): void {
-		//
-	}
+		this._streamingEditLocks.queue(resource.toString(), async () => {
+			if (!this.isDisposed) {
+				await this._acceptStreamingEditsStart(responseModel, inUndoStop, resource);
+			}
 
-	resolve(): void {
-		if (this._state.get() === ChatEditingSessionState.Disposed) {
-			// we don't throw in this case because there could be a builder still connected to a disposed session
-			return;
-		}
+			startPromise.complete();
+			return completePromise.p;
+		});
 
-		// ensure that the edits are processed sequentially
-		this._sequencer.queue(() => this._resolve());
+
+		let didComplete = false;
+
+		return {
+			pushText: edits => {
+				sequencer.queue(async () => {
+					if (!this.isDisposed) {
+						await this._acceptTextEdits(resource, edits, false, responseModel);
+					}
+				});
+			},
+			pushNotebook: _edits => {
+				sequencer.queue(async () => {
+					if (!this.isDisposed) {
+						// todo@DonJayamanne
+					}
+				});
+			},
+			complete: () => {
+				if (didComplete) {
+					return;
+				}
+
+				didComplete = true;
+				sequencer.queue(async () => {
+					if (!this.isDisposed) {
+						await this._acceptTextEdits(resource, [], true, responseModel);
+						await this._resolve(responseModel.requestId, inUndoStop, resource);
+						completePromise.complete();
+					}
+				});
+			},
+		};
 	}
 
 	private _trackUntitledWorkingSetEntry(resource: URI) {
@@ -754,48 +832,97 @@ export class ChatEditingSession extends Disposable implements IChatEditingSessio
 		this._chatService.getSession(this.chatSessionId)?.setDisabledRequests(undoRequests);
 	}
 
-	private async _acceptStreamingEditsStart(): Promise<void> {
+	private async _acceptStreamingEditsStart(responseModel: IChatResponseModel, undoStop: string | undefined, resource: URI) {
+		const entry = await this._getOrCreateModifiedFileEntry(resource, this._getTelemetryInfoForModel(responseModel));
 		transaction((tx) => {
 			this._state.set(ChatEditingSessionState.StreamingEdits, tx);
-			for (const entry of this._entriesObs.get()) {
-				entry.acceptStreamingEditsStart(tx);
-			}
+			entry.acceptStreamingEditsStart(tx);
+			this.ensureEditInUndoStopMatches(responseModel.requestId, undoStop, entry, false, tx);
 		});
 	}
 
+	/**
+	 * Ensures the state of the file in the given snapshot matches the current
+	 * state of the {@param entry}. This is used to handle concurrent file edits.
+	 *
+	 * Given the case of two different edits, we will place and undo stop right
+	 * before we `textEditGroup` in the underlying markdown stream, but at the
+	 * time those are added the edits haven't been made yet, so both files will
+	 * simply have the unmodified state.
+	 *
+	 * This method is called after each edit, so after the first file finishes
+	 * being edits, it will update its content in the second undo snapshot such
+	 * that it can be undone successfully.
+	 *
+	 * We ensure that the same file is not concurrently edited via the
+	 * {@link _streamingEditLocks}, avoiding race conditions.
+	 *
+	 * @param next If true, this will edit the snapshot _after_ the undo stop
+	 */
+	private ensureEditInUndoStopMatches(requestId: string, undoStop: string | undefined, entry: ChatEditingModifiedFileEntry, next: boolean, tx: ITransaction) {
+		const history = this._linearHistory.get();
+		const snapIndex = history.findIndex(s => s.requestId === requestId);
+		if (snapIndex === -1) {
+			return;
+		}
+
+		const snap = history[snapIndex];
+		let stopIndex = snap.stops.findIndex(s => s.stopId === undoStop);
+		if (stopIndex === -1 || (next && stopIndex === snap.stops.length - 1)) {
+			return;
+		}
+		if (next) {
+			stopIndex++;
+		}
+
+		const stop = snap.stops[stopIndex];
+		if (entry.equalsSnapshot(stop.entries.get(entry.modifiedURI))) {
+			return;
+		}
+
+		const newMap = new ResourceMap(stop.entries);
+		newMap.set(entry.modifiedURI, entry.createSnapshot(requestId, stop.stopId));
+
+		const newStop = snap.stops.slice();
+		newStop[stopIndex] = { ...stop, entries: newMap };
+
+		const newHistory = history.slice();
+		newHistory[snapIndex] = { ...snap, stops: newStop };
+		this._linearHistory.set(newHistory, tx);
+	}
+
 	private async _acceptTextEdits(resource: URI, textEdits: TextEdit[], isLastEdits: boolean, responseModel: IChatResponseModel): Promise<void> {
+		const entry = await this._getOrCreateModifiedFileEntry(resource, this._getTelemetryInfoForModel(responseModel));
+		entry.acceptAgentEdits(textEdits, isLastEdits, responseModel);
+	}
+
+	private _getTelemetryInfoForModel(responseModel: IChatResponseModel): IModifiedEntryTelemetryInfo {
 		// Make these getters because the response result is not available when the file first starts to be edited
-		const telemetryInfo = new class {
+		return new class {
 			get agentId() { return responseModel.agent?.id; }
 			get command() { return responseModel.slashCommand?.name; }
 			get sessionId() { return responseModel.session.sessionId; }
 			get requestId() { return responseModel.requestId; }
 			get result() { return responseModel.result; }
 		};
-		const entry = await this._getOrCreateModifiedFileEntry(resource, telemetryInfo);
-		entry.acceptAgentEdits(textEdits, isLastEdits, responseModel);
 	}
 
-	private async _resolve(): Promise<void> {
+	private async _resolve(requestId: string, undoStop: string | undefined, resource: URI): Promise<void> {
 		await asyncTransaction(async (tx) => {
-
-			const entriesWithoutChange = new ResourceMap<ChatEditingModifiedFileEntry>();
-
-			for (const entry of this._entriesObs.get()) {
-				await entry.acceptStreamingEditsEnd(tx);
-				if (entry.diffInfo.get().identical) {
-					entriesWithoutChange.set(entry.modifiedURI, entry);
-				}
+			const hasOtherTasks = Iterable.some(this._streamingEditLocks.keys(), k => k !== resource.toString());
+			if (!hasOtherTasks) {
+				this._state.set(ChatEditingSessionState.Idle, tx);
 			}
 
-			if (entriesWithoutChange.size > 0) {
-				const newEntries = this._entriesObs.get().filter(e => !entriesWithoutChange.has(e.modifiedURI));
-				this._entriesObs.set(newEntries, tx);
-
-				dispose(entriesWithoutChange.values());
+			const entry = this._getEntry(resource);
+			if (!entry) {
+				return;
 			}
-			this._state.set(ChatEditingSessionState.Idle, tx);
+
+			this.ensureEditInUndoStopMatches(requestId, undoStop, entry, /* next= */ true, tx);
+			return entry.acceptStreamingEditsEnd(tx);
 		});
+
 		this._onDidChange.fire(ChatEditingSessionChangeType.Other);
 	}
 
@@ -1103,8 +1230,8 @@ export interface IChatEditingSessionSnapshot {
 interface IChatEditingSessionStop {
 	/** Edit stop ID, first for a request is always undefined. */
 	stopId: string | undefined;
+
 	readonly workingSet: ResourceMap<WorkingSetDisplayMetadata>;
-	/** todo@connor4312: for stops that don't modify (all) files, we can probably skip creating new snapshot entries */
 	readonly entries: ResourceMap<ISnapshotEntry>;
 }
 

--- a/src/vs/workbench/contrib/chat/browser/chatListRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatListRenderer.ts
@@ -13,6 +13,7 @@ import { IListVirtualDelegate } from '../../../../base/browser/ui/list/list.js';
 import { ITreeNode, ITreeRenderer } from '../../../../base/browser/ui/tree/tree.js';
 import { IAction } from '../../../../base/common/actions.js';
 import { coalesce, distinct } from '../../../../base/common/arrays.js';
+import { findLast } from '../../../../base/common/arraysFind.js';
 import { Codicon } from '../../../../base/common/codicons.js';
 import { Emitter, Event } from '../../../../base/common/event.js';
 import { FuzzyScore } from '../../../../base/common/filters.js';

--- a/src/vs/workbench/contrib/chat/browser/chatListRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatListRenderer.ts
@@ -13,7 +13,6 @@ import { IListVirtualDelegate } from '../../../../base/browser/ui/list/list.js';
 import { ITreeNode, ITreeRenderer } from '../../../../base/browser/ui/tree/tree.js';
 import { IAction } from '../../../../base/common/actions.js';
 import { coalesce, distinct } from '../../../../base/common/arrays.js';
-import { findLast } from '../../../../base/common/arraysFind.js';
 import { Codicon } from '../../../../base/common/codicons.js';
 import { Emitter, Event } from '../../../../base/common/event.js';
 import { FuzzyScore } from '../../../../base/common/filters.js';

--- a/src/vs/workbench/contrib/chat/common/chatModel.ts
+++ b/src/vs/workbench/contrib/chat/common/chatModel.ts
@@ -226,6 +226,7 @@ export interface IChatResponseModel {
 	readonly voteDownReason: ChatAgentVoteDownReason | undefined;
 	readonly followups?: IChatFollowup[] | undefined;
 	readonly result?: IChatAgentResult;
+	addUndoStop(undoStop: IChatUndoStop): void;
 	setVote(vote: ChatAgentVoteDirection): void;
 	setVoteDownReason(reason: ChatAgentVoteDownReason | undefined): void;
 	setEditApplied(edit: IChatTextEditGroup, editCount: number): boolean;
@@ -494,7 +495,7 @@ export class Response extends AbstractResponse implements IDisposable {
 			let found = false;
 			for (let i = 0; !found && i < this._responseParts.length; i++) {
 				const candidate = this._responseParts[i];
-				if (candidate.kind === groupKind && isEqual(candidate.uri, progress.uri)) {
+				if (candidate.kind === groupKind && !candidate.done && isEqual(candidate.uri, progress.uri)) {
 					candidate.edits.push(progress.edits as any);
 					candidate.done = progress.done;
 					found = true;

--- a/src/vs/workbench/contrib/chat/common/tools/editFileTool.ts
+++ b/src/vs/workbench/contrib/chat/common/tools/editFileTool.ts
@@ -95,13 +95,17 @@ export class EditTool implements IToolImpl {
 
 		const model = this.chatService.getSession(invocation.context?.sessionId) as ChatModel;
 		const request = model.getRequests().at(-1)!;
-		// slightly hacky way to avoid an extra 'no-op' undo stop at the start of responses that are just edits
+
+		// Undo stops mark groups of response data in the output. Operations, such
+		// as text edits, that happen between undo stops are all done or undone together.
 		if (request.response?.response.getMarkdown().length) {
+			// slightly hacky way to avoid an extra 'no-op' undo stop at the start of responses that are just edits
 			model.acceptResponseProgress(request, {
 				kind: 'undoStop',
 				id: generateUuid(),
 			});
 		}
+
 		model.acceptResponseProgress(request, {
 			kind: 'markdownContent',
 			content: new MarkdownString('\n````\n')


### PR DESCRIPTION
In previous undo/redo work, it was pointed out that there could be
concurrency issues if multiple edits were made in a single turn. In
that case we could place an undo stop at the same time, and both edits
get made and we're left in a bad state where they can't be undone
individually and we have a no-op undo stop. It was also pointed out that
we have a longstanding issues with the chat edit 'pills' not individually
showing multiple edits in a single turn.

This fixes that.

In `chatEditingServiceImpl.ts`, I replace the async iterable approach
with one that more imperatively looks at each entry in the response
value and keeps an `IStreamingEdits` for each of them. When done,
it signals completion, and we no longer merge text edit groups once
they're done.

`IStreamingEdits` serializes its operations for a resource the model
shouldn't try to edit the same file concurrently, but if it does this
might help avoid issues. When started, it makes sure there's a snapshot
of the file at the current undo stop, and when it's finished it makes
sure the snapshot in the `N+1` stop is the same. This converges the
undo history, fixing the concurrency issue above.

Because we have undo stops in the message content and now are keeping
snapshots before and after the stop, we can fix the diff pill issue.

This is a good foundation and should be strictly better improvement, but
there are still some todo's (heading out early today for valentines stuff):

- The last pill always shows the complete diff because we lack an N+1
  stop, it should instead diff against the _pendingSnapshot
- Clicking on pills should open the granular diff when appropriate
- The observable stuff for the between-snapshot diffs is janky and I
  will clean it up later.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
