### PR TITLE
fix: improve Wayland detection and environment setup

### DIFF
--- a/resources/linux/snap/electron-launch
+++ b/resources/linux/snap/electron-launch
@@ -151,18 +151,21 @@ if [[ -n "$XDG_RUNTIME_DIR" && -z "$DISABLE_WAYLAND" ]]; then
     if [ -n "$WAYLAND_DISPLAY" ]; then
         wdisplay="$WAYLAND_DISPLAY"
     fi
-    wayland_sockpath="$XDG_RUNTIME_DIR/../$wdisplay"
-    wayland_snappath="$XDG_RUNTIME_DIR/$wdisplay"
+    wayland_sockpath="$XDG_RUNTIME_DIR/$wdisplay"
     if [ -S "$wayland_sockpath" ]; then
-        # if running under wayland, use it
-        #export WAYLAND_DEBUG=1
-        # shellcheck disable=SC2034
         wayland_available=true
-        # create the compat symlink for now
-        if [ ! -e "$wayland_snappath" ]; then
-            ln -s "$wayland_sockpath" "$wayland_snappath"
-        fi
+        export GDK_BACKEND=wayland
+    else
+        # Fallback to X11 if Wayland socket not found
+        export GDK_BACKEND=x11
     fi
+fi
+
+# Add session type check
+if [ "$XDG_SESSION_TYPE" = "wayland" ]; then
+    export GDK_BACKEND=wayland
+    export WEBKIT_FORCE_WAYLAND=1
+    export MOZ_ENABLE_WAYLAND=1
 fi
 
 # Keep an array of data dirs, for looping through them


### PR DESCRIPTION
**Overview**
This PR fixes the Wayland detection and environment setup issues when launching browsers through xdg-open in VS Code.

**Issue**
When running `xdg-open` commands from VS Code's integrated terminal under Wayland sessions, users encounter the error:
"Failed to open Wayland display, fallback to X11"

Fixes #229096

**Changes**
- Fixed Wayland socket path detection by using correct XDG_RUNTIME_DIR path
- Added proper GDK_BACKEND environment setup
- Added Wayland-specific environment variables for browser compatibility
- Maintained X11 fallback when Wayland is not available

**Testing Notes**
This change requires a Linux system running a Wayland session to test. I have tested the changes on Fedora 40 with:
- Wayland session (XDG_SESSION_TYPE=wayland)
- VS Code 1.91.1
- Firefox as default browser

The fix can be verified by:
1. Running VS Code in a Wayland session
2. Opening the integrated terminal
3. Running `xdg-open https://www.google.es`
4. Verifying the browser opens without the "Failed to open Wayland display" error

