### PR TITLE
High contrast gutter items

### DIFF
--- a/build/lib/stylelint/vscode-known-variables.json
+++ b/build/lib/stylelint/vscode-known-variables.json
@@ -232,6 +232,8 @@
 		"--vscode-editorGutter-commentGlyphForeground",
 		"--vscode-editorGutter-commentRangeForeground",
 		"--vscode-editorGutter-commentUnresolvedGlyphForeground",
+		"--vscode-editorGutter-itemGlyphForeground",
+		"--vscode-editorGutter-itemBackground",
 		"--vscode-editorGutter-deletedBackground",
 		"--vscode-editorGutter-foldingControlForeground",
 		"--vscode-editorGutter-modifiedBackground",

--- a/src/vs/editor/browser/widget/diffEditor/style.css
+++ b/src/vs/editor/browser/widget/diffEditor/style.css
@@ -382,7 +382,7 @@
 					.actions-container {
 						width: fit-content;
 						border-radius: 4px;
-						background: var(--vscode-editorGutter-commentRangeForeground);
+						background: var(--vscode-editorGutter-itemBackground);
 
 						.action-item {
 							&:hover {
@@ -390,6 +390,7 @@
 							}
 
 							.action-label {
+								color: var(--vscode-editorGutter-itemGlyphForeground);
 								padding: 1px 2px;
 							}
 						}

--- a/src/vs/workbench/contrib/scm/common/quickDiff.ts
+++ b/src/vs/workbench/contrib/scm/common/quickDiff.ts
@@ -14,7 +14,10 @@ import { LineRangeMapping } from '../../../../editor/common/diff/rangeMapping.js
 import { IChange } from '../../../../editor/common/diff/legacyLinesDiffComputer.js';
 import { IColorTheme } from '../../../../platform/theme/common/themeService.js';
 import { Color } from '../../../../base/common/color.js';
-import { editorErrorForeground, registerColor, transparent } from '../../../../platform/theme/common/colorRegistry.js';
+import {
+	darken, editorBackground, editorForeground, listInactiveSelectionBackground, opaque,
+	editorErrorForeground, registerColor, transparent
+} from '../../../../platform/theme/common/colorRegistry.js';
 
 export const IQuickDiffService = createDecorator<IQuickDiffService>('quickDiff');
 
@@ -44,6 +47,12 @@ export const overviewRulerAddedForeground = registerColor('editorOverviewRuler.a
 	transparent(editorGutterAddedBackground, 0.6), nls.localize('overviewRulerAddedForeground', 'Overview ruler marker color for added content.'));
 export const overviewRulerDeletedForeground = registerColor('editorOverviewRuler.deletedForeground',
 	transparent(editorGutterDeletedBackground, 0.6), nls.localize('overviewRulerDeletedForeground', 'Overview ruler marker color for deleted content.'));
+
+export const editorGutterItemGlyphForeground = registerColor('editorGutter.itemGlyphForeground',
+	{ dark: editorForeground, light: editorForeground, hcDark: Color.black, hcLight: Color.white },
+	nls.localize('editorGutterItemGlyphForeground', 'Editor gutter decoration color for gutter item glyphs.')
+);
+export const editorGutterItemBackground = registerColor('editorGutter.itemBackground', { dark: opaque(listInactiveSelectionBackground, editorBackground), light: darken(opaque(listInactiveSelectionBackground, editorBackground), .05), hcDark: Color.white, hcLight: Color.black }, nls.localize('editorGutterItemBackground', 'Editor gutter decoration color for gutter item background. This color should be opaque.'));
 
 export interface QuickDiffProvider {
 	label: string;


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/227619 by introducing 2 theming variables for the foreground and background of gutter items in the editor gutter. The theming behind it, is copied from the commenting widget where these buttons already display correctly.

From left to right: dark, light, high contrast dark, high contrast light
![image](https://github.com/user-attachments/assets/24b477b1-edb8-4daa-85be-f0f4976bb73a)
