### PR TITLE
Improve agent codeblock pill updating

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/chatMarkdownContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/chatMarkdownContentPart.ts
@@ -356,11 +356,12 @@ class CollapsedCodeBlock extends Disposable {
 		iconEl.classList.add(...iconClasses);
 
 		const children = [dom.$('span.icon-label', {}, iconText)];
+		const labelDetail = dom.$('span.label-detail', {}, '');
+		children.push(labelDetail);
 		if (isStreaming) {
-			children.push(dom.$('span.label-detail', {}, localize('chat.codeblock.generating', "Generating edits...")));
-		} else if (!isComplete) {
-			children.push(dom.$('span.label-detail', {}, ''));
+			labelDetail.textContent = localize('chat.codeblock.generating', "Generating edits...");
 		}
+
 		this.element.replaceChildren(iconEl, ...children);
 		this.element.title = this.labelService.getUriLabel(uri, { relative: false });
 
@@ -388,12 +389,11 @@ class CollapsedCodeBlock extends Disposable {
 		this._progressStore.add(autorun(r => {
 			const rewriteRatio = modifiedEntry?.rewriteRatio.read(r);
 
-			const labelDetail = this.element.querySelector('.label-detail');
 			const isComplete = !modifiedEntry?.isCurrentlyBeingModifiedBy.read(r);
-			if (labelDetail && !isStreaming && !isComplete) {
+			if (!isStreaming && !isComplete) {
 				const value = rewriteRatio;
-				labelDetail.textContent = value === 0 || !value ? localize('chat.codeblock.applying', "Applying edits...") : localize('chat.codeblock.applyingPercentage', "Applying edits ({0}%)...", Math.round(value * 100));
-			} else if (labelDetail && !isStreaming && isComplete) {
+				labelDetail.textContent = value === 0 || !value ? localize('chat.codeblock.generating', "Generating edits...") : localize('chat.codeblock.applyingPercentage', "Applying edits ({0}%)...", Math.round(value * 100));
+			} else if (!isStreaming && isComplete) {
 				iconEl.classList.remove(...iconClasses);
 				const fileKind = uri.path.endsWith('/') ? FileKind.FOLDER : FileKind.FILE;
 				iconEl.classList.add(...getIconClasses(this.modelService, this.languageService, uri, fileKind));

--- a/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingServiceImpl.ts
@@ -318,10 +318,11 @@ export class ChatEditingService extends Disposable implements IChatEditingServic
 					editsSeen[i] = entry;
 				}
 
+				const isFirst = entry.seen === 0;
 				const newEdits = part.edits.slice(entry.seen).flat();
 				entry.seen = part.edits.length;
 
-				if (newEdits.length > 0) {
+				if (newEdits.length > 0 || isFirst) {
 					if (part.kind === 'notebookEditGroup') {
 						entry.streaming.pushNotebook(newEdits as ICellEditOperation[]);
 					} else if (part.kind === 'textEditGroup') {

--- a/src/vs/workbench/contrib/chat/browser/media/chatCodeBlockPill.css
+++ b/src/vs/workbench/contrib/chat/browser/media/chatCodeBlockPill.css
@@ -49,6 +49,10 @@ span.label-detail {
 	padding-left: 4px;
 	font-style: italic;
 	color: var(--vscode-descriptionForeground);
+
+	&:empty {
+		display: none;
+	}
 }
 
 span.label-added {

--- a/src/vs/workbench/contrib/chat/common/chatViewModel.ts
+++ b/src/vs/workbench/contrib/chat/common/chatViewModel.ts
@@ -593,8 +593,8 @@ export class ChatResponseViewModel extends Disposable implements IChatResponseVi
 				} else {
 					const timeDiff = Math.min(now - this._contentUpdateTimings.lastUpdateTime, 1000);
 					const newTotalTime = Math.max(this._contentUpdateTimings.totalTime + timeDiff, 250);
-					const impliedWordLoadRate = this._contentUpdateTimings.lastWordCount / (newTotalTime / 1000);
-					this.trace('onDidChange', `Update- got ${this._contentUpdateTimings.lastWordCount} words over last ${newTotalTime}ms = ${impliedWordLoadRate} words/s. ${wordCount} words are now available.`);
+					const impliedWordLoadRate = wordCount / (newTotalTime / 1000);
+					this.trace('onDidChange', `Update- got ${wordCount} words over last ${newTotalTime}ms = ${impliedWordLoadRate} words/s`);
 					this._contentUpdateTimings = {
 						totalTime: this._contentUpdateTimings.totalTime !== 0 || this.response.value.some(v => v.kind === 'markdownContent') ?
 							newTotalTime :

--- a/src/vs/workbench/contrib/chat/common/tools/editFileTool.ts
+++ b/src/vs/workbench/contrib/chat/common/tools/editFileTool.ts
@@ -116,7 +116,12 @@ export class EditTool implements IToolImpl {
 		});
 		model.acceptResponseProgress(request, {
 			kind: 'markdownContent',
-			content: new MarkdownString(parameters.code + '\n````\n')
+			content: new MarkdownString('// placeholder\n```')
+		});
+		model.acceptResponseProgress(request, {
+			kind: 'textEdit',
+			edits: [],
+			uri
 		});
 
 		const editSession = this.chatEditingService.getEditingSession(model.sessionId);

--- a/src/vs/workbench/contrib/chat/common/tools/editFileTool.ts
+++ b/src/vs/workbench/contrib/chat/common/tools/editFileTool.ts
@@ -116,7 +116,7 @@ export class EditTool implements IToolImpl {
 		});
 		model.acceptResponseProgress(request, {
 			kind: 'markdownContent',
-			content: new MarkdownString('// placeholder\n```')
+			content: new MarkdownString(parameters.code + '\n````\n')
 		});
 		model.acceptResponseProgress(request, {
 			kind: 'textEdit',


### PR DESCRIPTION
- Fix #240957
- Fix word counting when many words appear right before a pause. This changes it from how I prefer for chat scenarios (more consistent streaming with fewer pauses) but it's fine and there's no other way to get the right computed rate for scenarios with tool pauses
- Don't create label-detail element lazily, but hide it when empty
- Show "generating edits" instead of "applying edits" when we have 0%. We can stay in that state for awhile and it matches what the editor overlay widget shows.
- EditFileTool adds an empty textEdit to the model when it runs, signaling that edits will happen, matching what Edits does