### PR TITLE
Rename press to reveal to show collapsed

### DIFF
--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -4231,7 +4231,7 @@ export interface IInlineSuggestOptions {
 
 		renderSideBySide?: 'never' | 'auto';
 
-		pressToReveal?: boolean;
+		showCollapsed?: boolean;
 
 		/**
 		* @internal
@@ -4280,7 +4280,7 @@ class InlineEditorSuggest extends BaseEditorOption<EditorOption.inlineSuggest, I
 			syntaxHighlightingEnabled: false,
 			edits: {
 				enabled: true,
-				pressToReveal: false,
+				showCollapsed: false,
 				useMixedLinesDiff: 'forStableInsertions',
 				useInterleavedLinesDiff: 'never',
 				renderSideBySide: 'auto',
@@ -4347,10 +4347,10 @@ class InlineEditorSuggest extends BaseEditorOption<EditorOption.inlineSuggest, I
 					],
 					tags: ['nextEditSuggestions']
 				},
-				'editor.inlineSuggest.edits.pressToReveal': {
+				'editor.inlineSuggest.edits.showCollapsed': {
 					type: 'boolean',
-					default: defaults.edits.pressToReveal,
-					description: nls.localize('inlineSuggest.edits.pressToReveal', "Controls whether the suggestion will always reveal or after jumping to it."),
+					default: defaults.edits.showCollapsed,
+					description: nls.localize('inlineSuggest.edits.showCollapsed', "Controls whether the suggestion will show as collapsed until jumping to it."),
 					tags: ['nextEditSuggestions']
 				},
 				/* 'editor.inlineSuggest.edits.useMultiLineGhostText': {
@@ -4388,7 +4388,7 @@ class InlineEditorSuggest extends BaseEditorOption<EditorOption.inlineSuggest, I
 			syntaxHighlightingEnabled: boolean(input.syntaxHighlightingEnabled, this.defaultValue.syntaxHighlightingEnabled),
 			edits: {
 				enabled: boolean(input.edits?.enabled, this.defaultValue.edits.enabled),
-				pressToReveal: boolean(input.edits?.pressToReveal, this.defaultValue.edits.pressToReveal),
+				showCollapsed: boolean(input.edits?.showCollapsed, this.defaultValue.edits.showCollapsed),
 				useMixedLinesDiff: stringSet(input.edits?.useMixedLinesDiff, this.defaultValue.edits.useMixedLinesDiff, ['never', 'whenPossible', 'forStableInsertions', 'afterJumpWhenPossible']),
 				codeShifting: boolean(input.edits?.codeShifting, this.defaultValue.edits.codeShifting),
 				renderSideBySide: stringSet(input.edits?.renderSideBySide, this.defaultValue.edits.renderSideBySide, ['never', 'auto']),

--- a/src/vs/editor/contrib/inlineCompletions/browser/controller/commandIds.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/controller/commandIds.ts
@@ -13,4 +13,4 @@ export const jumpToNextInlineEditId = 'editor.action.inlineSuggest.jump';
 
 export const hideInlineCompletionId = 'editor.action.inlineSuggest.hide';
 
-export const togglePressToRevealId = 'editor.action.inlineSuggest.togglePressToReveal';
+export const toggleShowCollapsedId = 'editor.action.inlineSuggest.toggleShowCollapsed';

--- a/src/vs/editor/contrib/inlineCompletions/browser/controller/commands.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/controller/commands.ts
@@ -17,7 +17,7 @@ import { ICodeEditor } from '../../../../browser/editorBrowser.js';
 import { EditorAction, EditorCommand, ServicesAccessor } from '../../../../browser/editorExtensions.js';
 import { EditorContextKeys } from '../../../../common/editorContextKeys.js';
 import { Context as SuggestContext } from '../../../suggest/browser/suggest.js';
-import { hideInlineCompletionId, inlineSuggestCommitId, jumpToNextInlineEditId, showNextInlineSuggestionActionId, showPreviousInlineSuggestionActionId, togglePressToRevealId } from './commandIds.js';
+import { hideInlineCompletionId, inlineSuggestCommitId, jumpToNextInlineEditId, showNextInlineSuggestionActionId, showPreviousInlineSuggestionActionId, toggleShowCollapsedId } from './commandIds.js';
 import { InlineCompletionContextKeys } from './inlineCompletionContextKeys.js';
 import { InlineCompletionsController } from './inlineCompletionsController.js';
 
@@ -291,21 +291,21 @@ export class HideInlineCompletion extends EditorAction {
 	}
 }
 
-export class ToggleInlineCompletionPressToReveal extends EditorAction {
-	public static ID = togglePressToRevealId;
+export class ToggleInlineCompletionShowCollapsed extends EditorAction {
+	public static ID = toggleShowCollapsedId;
 
 	constructor() {
 		super({
-			id: ToggleInlineCompletionPressToReveal.ID,
-			label: nls.localize2('action.inlineSuggest.togglePressToShow', "Toggle Inline Suggestions Press To Show"),
+			id: ToggleInlineCompletionShowCollapsed.ID,
+			label: nls.localize2('action.inlineSuggest.toggleShowCollapsed', "Toggle Inline Suggestions Show Collapsed"),
 			precondition: ContextKeyExpr.true(),
 		});
 	}
 
 	public async run(accessor: ServicesAccessor, editor: ICodeEditor): Promise<void> {
 		const configurationService = accessor.get(IConfigurationService);
-		const pressToReveal = configurationService.getValue<boolean>('editor.inlineSuggest.edits.pressToReveal');
-		configurationService.updateValue('editor.inlineSuggest.edits.pressToReveal', !pressToReveal);
+		const showCollapsed = configurationService.getValue<boolean>('editor.inlineSuggest.edits.showCollapsed');
+		configurationService.updateValue('editor.inlineSuggest.edits.showCollapsed', !showCollapsed);
 	}
 }
 

--- a/src/vs/editor/contrib/inlineCompletions/browser/inlineCompletions.contribution.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/inlineCompletions.contribution.ts
@@ -8,7 +8,7 @@ import { registerAction2 } from '../../../../platform/actions/common/actions.js'
 import { wrapInHotClass1 } from '../../../../platform/observable/common/wrapInHotClass.js';
 import { EditorContributionInstantiation, registerEditorAction, registerEditorCommand, registerEditorContribution } from '../../../browser/editorExtensions.js';
 import { HoverParticipantRegistry } from '../../hover/browser/hoverTypes.js';
-import { AcceptInlineCompletion, AcceptNextLineOfInlineCompletion, AcceptNextWordOfInlineCompletion, DevExtractReproSample, HideInlineCompletion, JumpToNextInlineEdit, ShowNextInlineSuggestionAction, ShowPreviousInlineSuggestionAction, ToggleAlwaysShowInlineSuggestionToolbar, ExplicitTriggerInlineEditAction, TriggerInlineSuggestionAction, TriggerInlineEditAction, ToggleInlineCompletionPressToReveal } from './controller/commands.js';
+import { AcceptInlineCompletion, AcceptNextLineOfInlineCompletion, AcceptNextWordOfInlineCompletion, DevExtractReproSample, HideInlineCompletion, JumpToNextInlineEdit, ShowNextInlineSuggestionAction, ShowPreviousInlineSuggestionAction, ToggleAlwaysShowInlineSuggestionToolbar, ExplicitTriggerInlineEditAction, TriggerInlineSuggestionAction, TriggerInlineEditAction, ToggleInlineCompletionShowCollapsed } from './controller/commands.js';
 import { InlineCompletionsController } from './controller/inlineCompletionsController.js';
 import { InlineCompletionsHoverParticipant } from './hintsWidget/hoverParticipant.js';
 import { InlineCompletionsAccessibleView } from './inlineCompletionsAccessibleView.js';
@@ -27,7 +27,7 @@ registerEditorAction(ShowPreviousInlineSuggestionAction);
 registerEditorAction(AcceptNextWordOfInlineCompletion);
 registerEditorAction(AcceptNextLineOfInlineCompletion);
 registerEditorAction(AcceptInlineCompletion);
-registerEditorAction(ToggleInlineCompletionPressToReveal);
+registerEditorAction(ToggleInlineCompletionShowCollapsed);
 registerEditorAction(HideInlineCompletion);
 registerEditorAction(JumpToNextInlineEdit);
 registerAction2(ToggleAlwaysShowInlineSuggestionToolbar);

--- a/src/vs/editor/contrib/inlineCompletions/browser/model/inlineCompletionsModel.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/model/inlineCompletionsModel.ts
@@ -62,7 +62,7 @@ export class InlineCompletionsModel extends Disposable {
 	private readonly _suggestPreviewMode = this._editorObs.getOption(EditorOption.suggest).map(v => v.previewMode);
 	private readonly _inlineSuggestMode = this._editorObs.getOption(EditorOption.inlineSuggest).map(v => v.mode);
 	private readonly _inlineEditsEnabled = this._editorObs.getOption(EditorOption.inlineSuggest).map(v => !!v.edits.enabled);
-	private readonly _inlineEditsPressToReveal = this._editorObs.getOption(EditorOption.inlineSuggest).map(s => s.edits.pressToReveal);
+	private readonly _inlineEditsShowCollapsed = this._editorObs.getOption(EditorOption.inlineSuggest).map(s => s.edits.showCollapsed);
 
 	constructor(
 		public readonly textModel: ITextModel,
@@ -545,7 +545,7 @@ export class InlineCompletionsModel extends Disposable {
 			return false;
 		}
 
-		if (this._inlineEditsPressToReveal.read(reader)) {
+		if (this._inlineEditsShowCollapsed.read(reader)) {
 			return !this._jumpedTo.read(reader);
 		}
 
@@ -557,7 +557,7 @@ export class InlineCompletionsModel extends Disposable {
 		if (!s) {
 			return false;
 		}
-		if (this._inlineEditsPressToReveal.read(reader)) {
+		if (this._inlineEditsShowCollapsed.read(reader)) {
 			return this._jumpedTo.read(reader);
 		}
 		if (s.inlineEdit.range.startLineNumber === this._editorObs.cursorLineNumber.read(reader)) {

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/components/gutterIndicatorMenu.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/components/gutterIndicatorMenu.ts
@@ -21,13 +21,13 @@ import { IKeybindingService } from '../../../../../../../platform/keybinding/com
 import { asCssVariable, descriptionForeground, editorActionListForeground, editorHoverBorder } from '../../../../../../../platform/theme/common/colorRegistry.js';
 import { ObservableCodeEditor } from '../../../../../../browser/observableCodeEditor.js';
 import { EditorOption } from '../../../../../../common/config/editorOptions.js';
-import { hideInlineCompletionId, inlineSuggestCommitId, jumpToNextInlineEditId, togglePressToRevealId } from '../../../controller/commandIds.js';
+import { hideInlineCompletionId, inlineSuggestCommitId, jumpToNextInlineEditId, toggleShowCollapsedId } from '../../../controller/commandIds.js';
 import { IInlineEditsViewHost } from '../inlineEditsViewInterface.js';
 import { FirstFnArg, InlineEditTabAction } from '../utils/utils.js';
 
 export class GutterIndicatorMenuContent {
 
-	private readonly _inlineEditsPressToReveal = this._editorObs.getOption(EditorOption.inlineSuggest).map(s => s.edits.pressToReveal);
+	private readonly _inlineEditsShowCollapsed = this._editorObs.getOption(EditorOption.inlineSuggest).map(s => s.edits.showCollapsed);
 
 	constructor(
 		private readonly _host: IInlineEditsViewHost,
@@ -70,9 +70,9 @@ export class GutterIndicatorMenuContent {
 			})),
 			option(createOptionArgs({ id: 'reject', title: localize('reject', "Reject"), icon: Codicon.close, commandId: hideInlineCompletionId })),
 			separator(),
-			this._inlineEditsPressToReveal.map(pressToReveal => pressToReveal ?
-				option(createOptionArgs({ id: 'alwaysReveal', title: localize('alwaysReveal', "Always Reveal"), icon: Codicon.expandAll, commandId: togglePressToRevealId })) :
-				option(createOptionArgs({ id: 'pressToReveal', title: localize('pressToReveal', "Press to Reveal"), icon: Codicon.collapseAll, commandId: togglePressToRevealId }))
+			this._inlineEditsShowCollapsed.map(showCollapsed => showCollapsed ?
+				option(createOptionArgs({ id: 'showExpanded', title: localize('showExpanded', "Show Expanded"), icon: Codicon.expandAll, commandId: toggleShowCollapsedId })) :
+				option(createOptionArgs({ id: 'showCollapsed', title: localize('showCollapsed', "Show Collapsed"), icon: Codicon.collapseAll, commandId: toggleShowCollapsedId }))
 			),
 			this._host.extensionCommands?.map(c => c && c.length > 0 ? [
 				...c.map(c => option(createOptionArgs({ id: c.id, title: c.title, icon: Codicon.symbolEvent, commandId: c.id, commandArgs: c.arguments }))),

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsView.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsView.ts
@@ -38,7 +38,7 @@ export class InlineEditsView extends Disposable {
 	private readonly _useInterleavedLinesDiff = this._editorObs.getOption(EditorOption.inlineSuggest).map(s => s.edits.useInterleavedLinesDiff);
 	private readonly _useCodeShifting = this._editorObs.getOption(EditorOption.inlineSuggest).map(s => s.edits.codeShifting);
 	private readonly _renderSideBySide = this._editorObs.getOption(EditorOption.inlineSuggest).map(s => s.edits.renderSideBySide);
-	private readonly _pressToReveal = this._editorObs.getOption(EditorOption.inlineSuggest).map(s => s.edits.pressToReveal);
+	private readonly _showCollapsed = this._editorObs.getOption(EditorOption.inlineSuggest).map(s => s.edits.showCollapsed);
 	private readonly _useMultiLineGhostText = this._editorObs.getOption(EditorOption.inlineSuggest).map(s => s.edits.useMultiLineGhostText);
 
 	private _previousView: {
@@ -105,7 +105,7 @@ export class InlineEditsView extends Disposable {
 			this._previewTextModel.setValue(newText);
 		}
 
-		if (this._pressToReveal.read(reader) && this._host.tabAction.read(reader) !== InlineEditTabAction.Accept) {
+		if (this._showCollapsed.read(reader) && this._host.tabAction.read(reader) !== InlineEditTabAction.Accept) {
 			state = { kind: 'hidden' };
 		}
 


### PR DESCRIPTION
Update references from "pressToReveal" to "showCollapsed" for improved clarity in inline suggestion options.