### PR TITLE
introduce `AbstractChatEditingModifiedFileEntry`

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingModifiedFileEntry.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingModifiedFileEntry.ts
@@ -59,53 +59,25 @@ const pendingRewriteMinimap = registerColor('chatEdits.minimapColor',
 	localize('editorSelectionBackground', "Color of pending edit regions in the minimap"));
 
 
-export class ChatEditingModifiedFileEntry extends Disposable implements IModifiedFileEntry {
+export abstract class AbstractChatEditingModifiedFileEntry extends Disposable implements IModifiedFileEntry {
 
-	public static readonly scheme = 'modified-file-entry';
+	static readonly scheme = 'modified-file-entry';
+
 	private static lastEntryId = 0;
-	public readonly entryId = `${ChatEditingModifiedFileEntry.scheme}::${++ChatEditingModifiedFileEntry.lastEntryId}`;
 
-	private readonly docSnapshot: ITextModel;
-	public readonly initialContent: string;
-	private readonly doc: ITextModel;
-	private readonly docFileEditorModel: IResolvedTextFileEditorModel;
-	private _allEditsAreFromUs: boolean = true;
+	readonly entryId = `${AbstractChatEditingModifiedFileEntry.scheme}::${++AbstractChatEditingModifiedFileEntry.lastEntryId}`;
 
-	private readonly _onDidDelete = this._register(new Emitter<void>());
-	public get onDidDelete() {
-		return this._onDidDelete.event;
-	}
+	protected readonly _onDidDelete = this._register(new Emitter<void>());
+	readonly onDidDelete = this._onDidDelete.event;
 
-	get originalURI(): URI {
-		return this.docSnapshot.uri;
-	}
+	protected readonly _stateObs = observableValue<WorkingSetEntryState>(this, WorkingSetEntryState.Modified);
+	readonly state: IObservable<WorkingSetEntryState> = this._stateObs;
 
-	get originalModel(): ITextModel {
-		return this.docSnapshot;
-	}
+	protected readonly _isCurrentlyBeingModifiedByObs = observableValue<IChatResponseModel | undefined>(this, undefined);
+	readonly isCurrentlyBeingModifiedBy: IObservable<IChatResponseModel | undefined> = this._isCurrentlyBeingModifiedByObs;
 
-	get modifiedURI(): URI {
-		return this.modifiedModel.uri;
-	}
-
-	get modifiedModel(): ITextModel {
-		return this.doc;
-	}
-
-	private readonly _stateObs = observableValue<WorkingSetEntryState>(this, WorkingSetEntryState.Modified);
-	public get state(): IObservable<WorkingSetEntryState> {
-		return this._stateObs;
-	}
-
-	private readonly _isCurrentlyBeingModifiedByObs = observableValue<IChatResponseModel | undefined>(this, undefined);
-	public get isCurrentlyBeingModifiedBy(): IObservable<IChatResponseModel | undefined> {
-		return this._isCurrentlyBeingModifiedByObs;
-	}
-
-	private readonly _rewriteRatioObs = observableValue<number>(this, 0);
-	public get rewriteRatio(): IObservable<number> {
-		return this._rewriteRatioObs;
-	}
+	protected readonly _rewriteRatioObs = observableValue<number>(this, 0);
+	readonly rewriteRatio: IObservable<number> = this._rewriteRatioObs;
 
 	private readonly _reviewModeTempObs = observableValue<true | undefined>(this, undefined);
 	readonly reviewMode: IObservable<boolean>;
@@ -113,42 +85,7 @@ export class ChatEditingModifiedFileEntry extends Disposable implements IModifie
 	private readonly _autoAcceptCtrl = observableValue<AutoAcceptControl | undefined>(this, undefined);
 	readonly autoAcceptController: IObservable<AutoAcceptControl | undefined> = this._autoAcceptCtrl;
 
-	private _isFirstEditAfterStartOrSnapshot: boolean = true;
-	private _edit: OffsetEdit = OffsetEdit.empty;
-	private _isEditFromUs: boolean = false;
-	private _diffOperation: Promise<any> | undefined;
-	private _diffOperationIds: number = 0;
-
-	private readonly _diffInfo = observableValue<IDocumentDiff>(this, nullDocumentDiff);
-	get diffInfo(): IObservable<IDocumentDiff> {
-		return this._diffInfo;
-	}
-
-	readonly changesCount = this._diffInfo.map(diff => diff.changes.length);
-
-	private readonly _editDecorationClear = this._register(new RunOnceScheduler(() => { this._editDecorations = this.doc.deltaDecorations(this._editDecorations, []); }, 500));
-	private _editDecorations: string[] = [];
-
-	private static readonly _lastEditDecorationOptions = ModelDecorationOptions.register({
-		isWholeLine: true,
-		description: 'chat-last-edit',
-		className: 'chat-editing-last-edit-line',
-		marginClassName: 'chat-editing-last-edit',
-		overviewRuler: {
-			position: OverviewRulerLane.Full,
-			color: themeColorFromId(editorSelectionBackground)
-		},
-	});
-
-	private static readonly _pendingEditDecorationOptions = ModelDecorationOptions.register({
-		isWholeLine: true,
-		description: 'chat-pending-edit',
-		className: 'chat-editing-pending-edit',
-		minimap: {
-			position: MinimapPosition.Inline,
-			color: themeColorFromId(pendingRewriteMinimap)
-		}
-	});
+	protected readonly _autoAcceptTimeout: IObservable<number>;
 
 	get telemetryInfo(): IModifiedEntryTelemetryInfo {
 		return this._telemetryInfo;
@@ -160,59 +97,26 @@ export class ChatEditingModifiedFileEntry extends Disposable implements IModifie
 		return this._telemetryInfo.requestId;
 	}
 
-	private readonly _diffTrimWhitespace: IObservable<boolean>;
-
 	private _refCounter: number = 1;
 
-	private readonly _autoAcceptTimeout: IObservable<number>;
+	readonly originalURI: URI;
 
 	constructor(
-		resourceRef: IReference<IResolvedTextEditorModel>,
-		private readonly _multiDiffEntryDelegate: { collapse: (transaction: ITransaction | undefined) => void },
-		private _telemetryInfo: IModifiedEntryTelemetryInfo,
+		readonly modifiedURI: URI,
+		protected _telemetryInfo: IModifiedEntryTelemetryInfo,
 		kind: ChatEditKind,
-		initialContent: string | undefined,
-		@IModelService modelService: IModelService,
-		@ITextModelService textModelService: ITextModelService,
-		@ILanguageService languageService: ILanguageService,
 		@IConfigurationService configService: IConfigurationService,
-		@IChatService private readonly _chatService: IChatService,
-		@IEditorWorkerService private readonly _editorWorkerService: IEditorWorkerService,
-		@IUndoRedoService private readonly _undoRedoService: IUndoRedoService,
-		@IFileService private readonly _fileService: IFileService,
-		@ITextFileService textFileService: ITextFileService,
-		@ILabelService labelService: ILabelService,
-		@IInstantiationService private readonly _instantiationService: IInstantiationService,
+		@IChatService protected readonly _chatService: IChatService,
+		@IFileService protected readonly _fileService: IFileService,
+		@IInstantiationService protected readonly _instantiationService: IInstantiationService,
 	) {
 		super();
+
+		this.originalURI = ChatEditingTextModelContentProvider.getFileURI(_telemetryInfo.sessionId, this.entryId, modifiedURI.path);
+
 		if (kind === ChatEditKind.Created) {
 			this.createdInRequestId = this._telemetryInfo.requestId;
 		}
-		this.docFileEditorModel = this._register(resourceRef).object as IResolvedTextFileEditorModel;
-		this.doc = resourceRef.object.textEditorModel;
-
-		this.initialContent = initialContent ?? this.doc.getValue();
-		const docSnapshot = this.docSnapshot = this._register(
-			modelService.createModel(
-				createTextBufferFactoryFromSnapshot(initialContent ? stringToSnapshot(initialContent) : this.doc.createSnapshot()),
-				languageService.createById(this.doc.getLanguageId()),
-				ChatEditingTextModelContentProvider.getFileURI(_telemetryInfo.sessionId, this.entryId, this.modifiedURI.path),
-				false
-			)
-		);
-
-		// Create a reference to this model to avoid it being disposed from under our nose
-		(async () => {
-			const reference = await textModelService.createModelReference(docSnapshot.uri);
-			if (this._store.isDisposed) {
-				reference.dispose();
-				return;
-			}
-			this._register(reference);
-		})();
-
-
-		this._register(this.doc.onDidChangeContent(e => this._mirrorEdits(e)));
 
 		if (this.modifiedURI.scheme !== Schemas.untitled && this.modifiedURI.scheme !== Schemas.vscodeNotebookCell) {
 			this._register(this._fileService.watch(this.modifiedURI));
@@ -222,16 +126,6 @@ export class ChatEditingModifiedFileEntry extends Disposable implements IModifie
 				}
 			}));
 		}
-
-		this._register(toDisposable(() => {
-			this._clearCurrentEditLineDecoration();
-		}));
-
-		this._diffTrimWhitespace = observableConfigValue('diffEditor.ignoreTrimWhitespace', true, configService);
-		this._register(autorun(r => {
-			this._diffTrimWhitespace.read(r);
-			this._updateDiffInfoSeq();
-		}));
 
 		// review mode depends on setting and temporary override
 		const autoAcceptRaw = observableConfigValue('chat.editing.autoAcceptDelay', 0, configService);
@@ -244,26 +138,6 @@ export class ChatEditingModifiedFileEntry extends Disposable implements IModifie
 			const tempValue = this._reviewModeTempObs.read(r);
 			return tempValue ?? configuredValue === 0;
 		});
-
-		// block auto-save while rewrite is in progress
-
-		this._register(textFileService.files.addSaveParticipant({
-
-			ordinal: Number.MIN_SAFE_INTEGER,
-
-			participate: async (model, context, progress, token) => {
-				if (!isEqual(model.resource, this.modifiedURI) || context.reason === SaveReason.EXPLICIT) {
-					return;
-				}
-
-				progress.report({ message: localize('saveBlock', "Save waits for Chat Edits rewriting {0}...", labelService.getUriBasenameLabel(this.modifiedURI)) });
-
-				await raceCancellation(
-					waitForState(this.isCurrentlyBeingModifiedBy, value => !value),
-					token
-				);
-			},
-		}));
 	}
 
 	override dispose(): void {
@@ -293,12 +167,262 @@ export class ChatEditingModifiedFileEntry extends Disposable implements IModifie
 		this._store.add(cleanup);
 	}
 
-	private _clearCurrentEditLineDecoration() {
-		this._editDecorations = this.doc.deltaDecorations(this._editDecorations, []);
-	}
-
 	updateTelemetryInfo(telemetryInfo: IModifiedEntryTelemetryInfo) {
 		this._telemetryInfo = telemetryInfo;
+	}
+
+	async accept(tx: ITransaction | undefined): Promise<void> {
+		if (this._stateObs.get() !== WorkingSetEntryState.Modified) {
+			// already accepted or rejected
+			return;
+		}
+
+		await this._doAccept(tx);
+		this._stateObs.set(WorkingSetEntryState.Accepted, tx);
+		this._autoAcceptCtrl.set(undefined, tx);
+
+		this._notifyAction('accepted');
+	}
+
+	protected abstract _doAccept(tx: ITransaction | undefined): Promise<void>;
+
+	async reject(tx: ITransaction | undefined): Promise<void> {
+		if (this._stateObs.get() !== WorkingSetEntryState.Modified) {
+			// already accepted or rejected
+			return;
+		}
+
+		await this._doReject(tx);
+		this._stateObs.set(WorkingSetEntryState.Rejected, tx);
+		this._autoAcceptCtrl.set(undefined, tx);
+		this._notifyAction('rejected');
+	}
+
+	protected abstract _doReject(tx: ITransaction | undefined): Promise<void>;
+
+	private _notifyAction(outcome: 'accepted' | 'rejected') {
+		this._chatService.notifyUserAction({
+			action: { kind: 'chatEditingSessionAction', uri: this.modifiedURI, hasRemainingEdits: false, outcome },
+			agentId: this._telemetryInfo.agentId,
+			command: this._telemetryInfo.command,
+			sessionId: this._telemetryInfo.sessionId,
+			requestId: this._telemetryInfo.requestId,
+			result: this._telemetryInfo.result
+		});
+	}
+
+	private readonly _editorIntegrations = this._register(new DisposableMap<IEditorPane, IModifiedFileEntryEditorIntegration>());
+
+	getEditorIntegration(pane: IEditorPane): IModifiedFileEntryEditorIntegration {
+		let value = this._editorIntegrations.get(pane);
+		if (!value) {
+			value = this._createEditorIntegration(pane);
+			this._editorIntegrations.set(pane, value);
+		}
+		return value;
+	}
+
+	/**
+	 * Create the editor integration for this entry and the given editor pane. This will only be called
+	 * once (and cached) per pane. The integration is meant to be scoped to this entry only and when the
+	 * passed pane/editor changes input, then the editor integration must handle that, e.g use default/null
+	 * values
+	 */
+	protected abstract _createEditorIntegration(editor: IEditorPane): IModifiedFileEntryEditorIntegration;
+
+	abstract readonly diffInfo: IObservable<IDocumentDiff>;
+	abstract readonly changesCount: IObservable<number>;
+
+	acceptStreamingEditsStart(responseModel: IChatResponseModel, tx: ITransaction) {
+		this._resetEditsState(tx);
+		this._isCurrentlyBeingModifiedByObs.set(responseModel, tx);
+		this._autoAcceptCtrl.get()?.cancel();
+	}
+
+	async acceptStreamingEditsEnd(tx: ITransaction) {
+		this._resetEditsState(tx);
+
+		// AUTO accept mode
+		if (!this.reviewMode.get() && !this._autoAcceptCtrl.get()) {
+
+			const acceptTimeout = this._autoAcceptTimeout.get() * 1000;
+			const future = Date.now() + acceptTimeout;
+			const update = () => {
+
+				const reviewMode = this.reviewMode.get();
+				if (reviewMode) {
+					// switched back to review mode
+					this._autoAcceptCtrl.set(undefined, undefined);
+					return;
+				}
+
+				const remain = Math.round(future - Date.now());
+				if (remain <= 0) {
+					this.accept(undefined);
+				} else {
+					const handle = setTimeout(update, 100);
+					this._autoAcceptCtrl.set(new AutoAcceptControl(acceptTimeout, remain, () => {
+						clearTimeout(handle);
+						this._autoAcceptCtrl.set(undefined, undefined);
+					}), undefined);
+				}
+			};
+			update();
+		}
+	}
+
+	protected _resetEditsState(tx: ITransaction): void {
+		this._isCurrentlyBeingModifiedByObs.set(undefined, tx);
+		this._rewriteRatioObs.set(0, tx);
+	}
+}
+
+export class ChatEditingModifiedFileEntry extends AbstractChatEditingModifiedFileEntry implements IModifiedFileEntry {
+
+	private static readonly _lastEditDecorationOptions = ModelDecorationOptions.register({
+		isWholeLine: true,
+		description: 'chat-last-edit',
+		className: 'chat-editing-last-edit-line',
+		marginClassName: 'chat-editing-last-edit',
+		overviewRuler: {
+			position: OverviewRulerLane.Full,
+			color: themeColorFromId(editorSelectionBackground)
+		},
+	});
+
+	private static readonly _pendingEditDecorationOptions = ModelDecorationOptions.register({
+		isWholeLine: true,
+		description: 'chat-pending-edit',
+		className: 'chat-editing-pending-edit',
+		minimap: {
+			position: MinimapPosition.Inline,
+			color: themeColorFromId(pendingRewriteMinimap)
+		}
+	});
+
+
+	private readonly docSnapshot: ITextModel;
+	readonly initialContent: string;
+	private readonly doc: ITextModel;
+	private readonly docFileEditorModel: IResolvedTextFileEditorModel;
+	private _allEditsAreFromUs: boolean = true;
+
+	get originalModel(): ITextModel {
+		return this.docSnapshot;
+	}
+
+	get modifiedModel(): ITextModel {
+		return this.doc;
+	}
+
+	private _isFirstEditAfterStartOrSnapshot: boolean = true;
+	private _edit: OffsetEdit = OffsetEdit.empty;
+	private _isEditFromUs: boolean = false;
+	private _diffOperation: Promise<any> | undefined;
+	private _diffOperationIds: number = 0;
+
+	private readonly _diffInfo = observableValue<IDocumentDiff>(this, nullDocumentDiff);
+	get diffInfo(): IObservable<IDocumentDiff> {
+		return this._diffInfo;
+	}
+
+	readonly changesCount = this._diffInfo.map(diff => diff.changes.length);
+
+	private readonly _editDecorationClear = this._register(new RunOnceScheduler(() => { this._editDecorations = this.doc.deltaDecorations(this._editDecorations, []); }, 500));
+	private _editDecorations: string[] = [];
+
+
+	private readonly _diffTrimWhitespace: IObservable<boolean>;
+
+	constructor(
+		resourceRef: IReference<IResolvedTextEditorModel>,
+		private readonly _multiDiffEntryDelegate: { collapse: (transaction: ITransaction | undefined) => void },
+		telemetryInfo: IModifiedEntryTelemetryInfo,
+		kind: ChatEditKind,
+		initialContent: string | undefined,
+		@IModelService modelService: IModelService,
+		@ITextModelService textModelService: ITextModelService,
+		@ILanguageService languageService: ILanguageService,
+		@IConfigurationService configService: IConfigurationService,
+		@IChatService chatService: IChatService,
+		@IEditorWorkerService private readonly _editorWorkerService: IEditorWorkerService,
+		@IUndoRedoService private readonly _undoRedoService: IUndoRedoService,
+		@IFileService fileService: IFileService,
+		@ITextFileService textFileService: ITextFileService,
+		@ILabelService labelService: ILabelService,
+		@IInstantiationService instantiationService: IInstantiationService,
+	) {
+		super(
+			resourceRef.object.textEditorModel.uri,
+			telemetryInfo,
+			kind,
+			configService,
+			chatService,
+			fileService,
+			instantiationService
+		);
+
+		this.docFileEditorModel = this._register(resourceRef).object as IResolvedTextFileEditorModel;
+		this.doc = resourceRef.object.textEditorModel;
+
+		this.initialContent = initialContent ?? this.doc.getValue();
+		const docSnapshot = this.docSnapshot = this._register(
+			modelService.createModel(
+				createTextBufferFactoryFromSnapshot(initialContent ? stringToSnapshot(initialContent) : this.doc.createSnapshot()),
+				languageService.createById(this.doc.getLanguageId()),
+				this.originalURI,
+				false
+			)
+		);
+
+		// Create a reference to this model to avoid it being disposed from under our nose
+		(async () => {
+			const reference = await textModelService.createModelReference(docSnapshot.uri);
+			if (this._store.isDisposed) {
+				reference.dispose();
+				return;
+			}
+			this._register(reference);
+		})();
+
+
+		this._register(this.doc.onDidChangeContent(e => this._mirrorEdits(e)));
+
+
+
+		this._register(toDisposable(() => {
+			this._clearCurrentEditLineDecoration();
+		}));
+
+		this._diffTrimWhitespace = observableConfigValue('diffEditor.ignoreTrimWhitespace', true, configService);
+		this._register(autorun(r => {
+			this._diffTrimWhitespace.read(r);
+			this._updateDiffInfoSeq();
+		}));
+
+
+		// block auto-save while rewrite is in progress
+		this._register(textFileService.files.addSaveParticipant({
+
+			ordinal: Number.MIN_SAFE_INTEGER,
+
+			participate: async (model, context, progress, token) => {
+				if (!isEqual(model.resource, this.modifiedURI) || context.reason === SaveReason.EXPLICIT) {
+					return;
+				}
+
+				progress.report({ message: localize('saveBlock', "Save waits for Chat Edits rewriting {0}...", labelService.getUriBasenameLabel(this.modifiedURI)) });
+
+				await raceCancellation(
+					waitForState(this.isCurrentlyBeingModifiedBy, value => !value),
+					token
+				);
+			},
+		}));
+	}
+
+	private _clearCurrentEditLineDecoration() {
+		this._editDecorations = this.doc.deltaDecorations(this._editDecorations, []);
 	}
 
 	equalsSnapshot(snapshot: ISnapshotEntry | undefined): boolean {
@@ -337,48 +461,13 @@ export class ChatEditingModifiedFileEntry extends Disposable implements IModifie
 		this._setDocValue(this.initialContent);
 	}
 
-	acceptStreamingEditsStart(responseModel: IChatResponseModel, tx: ITransaction) {
-		this._resetEditsState(tx);
-		this._isCurrentlyBeingModifiedByObs.set(responseModel, tx);
-		this._autoAcceptCtrl.get()?.cancel();
-	}
-
-	async acceptStreamingEditsEnd(tx: ITransaction) {
-		this._resetEditsState(tx);
+	override async acceptStreamingEditsEnd(tx: ITransaction) {
 		await this._diffOperation;
-
-		// AUTO accept mode
-		if (!this.reviewMode.get() && !this._autoAcceptCtrl.get()) {
-
-			const acceptTimeout = this._autoAcceptTimeout.get() * 1000;
-			const future = Date.now() + acceptTimeout;
-			const update = () => {
-
-				const reviewMode = this.reviewMode.get();
-				if (reviewMode) {
-					// switched back to review mode
-					this._autoAcceptCtrl.set(undefined, undefined);
-					return;
-				}
-
-				const remain = Math.round(future - Date.now());
-				if (remain <= 0) {
-					this.accept(undefined);
-				} else {
-					const handle = setTimeout(update, 100);
-					this._autoAcceptCtrl.set(new AutoAcceptControl(acceptTimeout, remain, () => {
-						clearTimeout(handle);
-						this._autoAcceptCtrl.set(undefined, undefined);
-					}), undefined);
-				}
-			};
-			update();
-		}
+		super.acceptStreamingEditsEnd(tx);
 	}
 
-	private _resetEditsState(tx: ITransaction): void {
-		this._isCurrentlyBeingModifiedByObs.set(undefined, tx);
-		this._rewriteRatioObs.set(0, tx);
+	protected override _resetEditsState(tx: ITransaction): void {
+		super._resetEditsState(tx);
 		this._clearCurrentEditLineDecoration();
 	}
 
@@ -440,7 +529,6 @@ export class ChatEditingModifiedFileEntry extends Disposable implements IModifie
 	}
 
 	acceptAgentEdits(textEdits: TextEdit[], isLastEdits: boolean, responseModel: IChatResponseModel): void {
-
 
 		// push stack element for the first edit
 		if (this._isFirstEditAfterStartOrSnapshot) {
@@ -580,27 +668,14 @@ export class ChatEditingModifiedFileEntry extends Disposable implements IModifie
 		}
 	}
 
-	async accept(transaction: ITransaction | undefined): Promise<void> {
-		if (this._stateObs.get() !== WorkingSetEntryState.Modified) {
-			// already accepted or rejected
-			return;
-		}
-
+	protected override async _doAccept(tx: ITransaction | undefined): Promise<void> {
 		this.docSnapshot.setValue(this.doc.createSnapshot());
-		this._diffInfo.set(nullDocumentDiff, transaction);
+		this._diffInfo.set(nullDocumentDiff, tx);
 		this._edit = OffsetEdit.empty;
-		this._stateObs.set(WorkingSetEntryState.Accepted, transaction);
-		this._autoAcceptCtrl.set(undefined, transaction);
-		await this._collapse(transaction);
-		this._notifyAction('accepted');
+		await this._collapse(tx);
 	}
 
-	async reject(transaction: ITransaction | undefined): Promise<void> {
-		if (this._stateObs.get() !== WorkingSetEntryState.Modified) {
-			// already accepted or rejected
-			return;
-		}
-
+	protected override async _doReject(tx: ITransaction | undefined): Promise<void> {
 		if (this.createdInRequestId === this._telemetryInfo.requestId) {
 			await this.docFileEditorModel.revert({ soft: true });
 			await this._fileService.del(this.modifiedURI);
@@ -612,11 +687,8 @@ export class ChatEditingModifiedFileEntry extends Disposable implements IModifie
 				// and so that an intermediate saved state gets reverted
 				await this.docFileEditorModel.save({ reason: SaveReason.EXPLICIT, skipSaveParticipants: true });
 			}
-			await this._collapse(transaction);
+			await this._collapse(tx);
 		}
-		this._stateObs.set(WorkingSetEntryState.Rejected, transaction);
-		this._autoAcceptCtrl.set(undefined, transaction);
-		this._notifyAction('rejected');
 	}
 
 	private _setDocValue(value: string): void {
@@ -635,29 +707,7 @@ export class ChatEditingModifiedFileEntry extends Disposable implements IModifie
 		this._multiDiffEntryDelegate.collapse(transaction);
 	}
 
-	private _notifyAction(outcome: 'accepted' | 'rejected') {
-		this._chatService.notifyUserAction({
-			action: { kind: 'chatEditingSessionAction', uri: this.modifiedURI, hasRemainingEdits: false, outcome },
-			agentId: this._telemetryInfo.agentId,
-			command: this._telemetryInfo.command,
-			sessionId: this._telemetryInfo.sessionId,
-			requestId: this._telemetryInfo.requestId,
-			result: this._telemetryInfo.result
-		});
-	}
-
-	private readonly _editorIntegrations = this._register(new DisposableMap<IEditorPane, IModifiedFileEntryEditorIntegration>());
-
-	getEditorIntegration(pane: IEditorPane): IModifiedFileEntryEditorIntegration {
-		let value = this._editorIntegrations.get(pane);
-		if (!value) {
-			value = this._createEditorIntegration(pane);
-			this._editorIntegrations.set(pane, value);
-		}
-		return value;
-	}
-
-	private _createEditorIntegration(editor: IEditorPane): ChatEditingCodeEditorIntegration {
+	protected _createEditorIntegration(editor: IEditorPane): IModifiedFileEntryEditorIntegration {
 		const codeEditor = getCodeEditor(editor.getControl());
 		assertType(codeEditor);
 		return this._instantiationService.createInstance(ChatEditingCodeEditorIntegration, codeEditor, this);

--- a/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingSession.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingSession.ts
@@ -47,7 +47,7 @@ import { INotebookService } from '../../../notebook/common/notebookService.js';
 import { ChatEditingSessionChangeType, ChatEditingSessionState, ChatEditKind, getMultiDiffSourceUri, IChatEditingSession, IModifiedFileEntry, IStreamingEdits, WorkingSetDisplayMetadata, WorkingSetEntryRemovalReason, WorkingSetEntryState } from '../../common/chatEditingService.js';
 import { IChatRequestDisablement, IChatResponseModel } from '../../common/chatModel.js';
 import { IChatService } from '../../common/chatService.js';
-import { ChatEditingModifiedFileEntry, IModifiedEntryTelemetryInfo, ISnapshotEntry } from './chatEditingModifiedFileEntry.js';
+import { AbstractChatEditingModifiedFileEntry, ChatEditingModifiedFileEntry, IModifiedEntryTelemetryInfo, ISnapshotEntry } from './chatEditingModifiedFileEntry.js';
 import { ChatEditingModifiedNotebookEntry } from './chatEditingModifiedNotebookEntry.js';
 import { ChatEditingTextModelContentProvider } from './chatEditingTextModelContentProviders.js';
 
@@ -628,7 +628,7 @@ export class ChatEditingSession extends Disposable implements IChatEditingSessio
 
 	private async _performStop(): Promise<void> {
 		// Close out all open files
-		const schemes = [ChatEditingModifiedFileEntry.scheme, ChatEditingTextModelContentProvider.scheme];
+		const schemes = [AbstractChatEditingModifiedFileEntry.scheme, ChatEditingTextModelContentProvider.scheme];
 		await Promise.allSettled(this._editorGroupsService.groups.flatMap(async (g) => {
 			return g.editors.map(async (e) => {
 				if ((e instanceof MultiDiffEditorInput && e.initialResources?.some(r => r.originalUri && schemes.indexOf(r.originalUri.scheme) !== -1))

--- a/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
@@ -1322,21 +1322,20 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 			this._chatEditsDisposables.add(list.onDidFocus(() => {
 				this._onDidFocus.fire();
 			}));
-			this._chatEditsDisposables.add(list.onDidOpen((e) => {
+			this._chatEditsDisposables.add(list.onDidOpen(async (e) => {
 				if (e.element?.kind === 'reference' && URI.isUri(e.element.reference)) {
 					const modifiedFileUri = e.element.reference;
 
 					const entry = chatEditingSession.getEntry(modifiedFileUri);
-					const diffInfo = entry?.diffInfo.get();
-					const range = diffInfo?.changes.at(0)?.modified.toExclusiveRange();
 
-					this.editorService.openEditor({
+					const pane = await this.editorService.openEditor({
 						resource: modifiedFileUri,
-						options: {
-							...e.editorOptions,
-							selection: range,
-						}
+						options: e.editorOptions
 					}, e.sideBySide ? SIDE_GROUP : ACTIVE_GROUP);
+
+					if (pane) {
+						entry?.getEditorIntegration(pane).reveal(true);
+					}
 				}
 			}));
 			this._chatEditsDisposables.add(addDisposableListener(list.getHTMLElement(), 'click', e => {

--- a/src/vs/workbench/contrib/chat/common/chatEditingService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatEditingService.ts
@@ -11,7 +11,6 @@ import { IObservable, IReader, ITransaction } from '../../../../base/common/obse
 import { URI } from '../../../../base/common/uri.js';
 import { IDocumentDiff } from '../../../../editor/common/diff/documentDiffProvider.js';
 import { TextEdit } from '../../../../editor/common/languages.js';
-import { ITextModel } from '../../../../editor/common/model.js';
 import { localize } from '../../../../nls.js';
 import { RawContextKey } from '../../../../platform/contextkey/common/contextkey.js';
 import { createDecorator } from '../../../../platform/instantiation/common/instantiation.js';
@@ -203,7 +202,6 @@ export interface IModifiedFileEntryEditorIntegration extends IDisposable {
 export interface IModifiedFileEntry {
 	readonly entryId: string;
 	readonly originalURI: URI;
-	readonly originalModel: ITextModel;
 	readonly modifiedURI: URI;
 
 	readonly lastModifyingRequestId: string;
@@ -212,11 +210,13 @@ export interface IModifiedFileEntry {
 	readonly isCurrentlyBeingModifiedBy: IObservable<IChatResponseModel | undefined>;
 	readonly rewriteRatio: IObservable<number>;
 
+	/**
+	 * @deprecated
+	 */
 	readonly diffInfo: IObservable<IDocumentDiff>;
 
 	accept(transaction: ITransaction | undefined): Promise<void>;
 	reject(transaction: ITransaction | undefined): Promise<void>;
-
 
 	reviewMode: IObservable<boolean>;
 	autoAcceptController: IObservable<{ total: number; remaining: number; cancel(): void } | undefined>;

--- a/src/vs/workbench/contrib/notebook/browser/contrib/chatEdit/notebookOriginalModelRefFactory.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/chatEdit/notebookOriginalModelRefFactory.ts
@@ -9,6 +9,7 @@ import { INotebookService } from '../../../common/notebookService.js';
 import { bufferToStream, VSBuffer } from '../../../../../../base/common/buffer.js';
 import { NotebookTextModel } from '../../../common/model/notebookTextModel.js';
 import { createDecorator, IInstantiationService } from '../../../../../../platform/instantiation/common/instantiation.js';
+import { ChatEditingModifiedFileEntry } from '../../../../chat/browser/chatEditing/chatEditingModifiedFileEntry.js';
 
 
 export const INotebookOriginalModelReferenceFactory = createDecorator<INotebookOriginalModelReferenceFactory>('INotebookOriginalModelReferenceFactory');
@@ -32,7 +33,8 @@ export class OriginalNotebookModelReferenceCollection extends ReferenceCollectio
 		if (model) {
 			return model;
 		}
-		const bytes = VSBuffer.fromString(fileEntry.originalModel.getValue());
+		// TODO@DonJayamanne FIX ME, don't use `originalModel`
+		const bytes = VSBuffer.fromString((fileEntry as ChatEditingModifiedFileEntry).originalModel.getValue());
 		const stream = bufferToStream(bytes);
 
 		return this.notebookService.createNotebookTextModel(viewType, uri, stream);
@@ -87,4 +89,3 @@ export class NotebookOriginalModelReferenceFactory implements INotebookOriginalM
 		return this.asyncModelCollection.acquire(fileEntry.originalURI.toString(), fileEntry, viewType);
 	}
 }
-

--- a/src/vs/workbench/contrib/notebook/browser/contrib/chatEdit/notebookSynchronizer.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/chatEdit/notebookSynchronizer.ts
@@ -128,10 +128,12 @@ export class NotebookModelSynchronizer extends Disposable {
 				snapshotCreated = true;
 			}
 
+			// TODO@DonJayamanne FIX ME, don't use `modifiedModel`
 			const modifiedModel = (entry as ChatEditingModifiedFileEntry).modifiedModel;
 			let cancellationToken = store.add(new CancellationTokenSource());
 			store.add(modifiedModel.onDidChangeContent(async () => {
-				if (!this.isTextEditFromUs && !modifiedModel.isDisposed() && !entry.originalModel.isDisposed() && modifiedModel.getValue() !== entry.originalModel.getValue()) {
+				// TODO@DonJayamanne FIX ME, don't use `originalModel`
+				if (!this.isTextEditFromUs && !modifiedModel.isDisposed() && !(entry as ChatEditingModifiedFileEntry).originalModel.isDisposed() && modifiedModel.getValue() !== (entry as ChatEditingModifiedFileEntry).originalModel.getValue()) {
 					cancellationToken = store.add(new CancellationTokenSource());
 					updateNotebookModel(entry, cancellationToken.token);
 				}


### PR DESCRIPTION
* add first version of `AbstractChatEditingModifiedFileEntry`
* remove `IModifiedFileEntry#originalModel`
* reduce usage of `IModifiedFileEntry#diffInfo`

fyi @DonJayamanne notebook world needs cleanup here, it should not depend on modified file entries for text documents anymore