### PR TITLE
chat: code pill polishes

### DIFF
--- a/src/vs/base/common/observableInternal/derived.ts
+++ b/src/vs/base/common/observableInternal/derived.ts
@@ -112,16 +112,23 @@ export function derivedWithStore<T>(computeFnOrOwner: ((reader: IReader, store: 
 		computeFn = computeFnOrUndefined as any;
 	}
 
-	const store = new DisposableStore();
+	// Intentionally re-assigned in case an inactive observable is re-used later
+	// eslint-disable-next-line local/code-no-potentially-unsafe-disposables
+	let store = new DisposableStore();
+
 	return new Derived(
 		new DebugNameData(owner, undefined, computeFn),
 		r => {
-			store.clear();
+			if (store.isDisposed) {
+				store = new DisposableStore();
+			} else {
+				store.clear();
+			}
 			return computeFn(r, store);
 		}, undefined,
 		undefined,
 		() => store.dispose(),
-		strictEquals
+		strictEquals,
 	);
 }
 

--- a/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingActions.ts
@@ -584,12 +584,11 @@ registerAction2(class RemoveAction extends Action2 {
 
 registerAction2(class OpenWorkingSetHistoryAction extends Action2 {
 
-	static readonly id = 'chat.openFileSnapshot';
+	static readonly id = 'chat.openFileUpdatedBySnapshot';
 	constructor() {
 		super({
 			id: OpenWorkingSetHistoryAction.id,
-			title: localize('chat.openSnapshot.label', "Open File Snapshot"),
-			precondition: ContextKeyExpr.notIn(ChatContextKeys.itemId.key, ChatContextKeys.lastItemId.key),
+			title: localize('chat.openFileUpdatedBySnapshot.label', "Open File"),
 			menu: [{
 				id: MenuId.ChatEditingCodeBlockContext,
 				group: 'navigation',
@@ -599,7 +598,33 @@ registerAction2(class OpenWorkingSetHistoryAction extends Action2 {
 	}
 
 	override async run(accessor: ServicesAccessor, ...args: any[]): Promise<void> {
-		const context: { sessionId: string; requestId: string; uri: URI } | undefined = args[0];
+		const context: { sessionId: string; requestId: string; uri: URI; stopId: string | undefined } | undefined = args[0];
+		if (!context?.sessionId) {
+			return;
+		}
+
+		const editorService = accessor.get(IEditorService);
+		await editorService.openEditor({ resource: context.uri });
+	}
+});
+
+registerAction2(class OpenWorkingSetHistoryAction extends Action2 {
+
+	static readonly id = 'chat.openFileSnapshot';
+	constructor() {
+		super({
+			id: OpenWorkingSetHistoryAction.id,
+			title: localize('chat.openSnapshot.label', "Open File Snapshot"),
+			menu: [{
+				id: MenuId.ChatEditingCodeBlockContext,
+				group: 'navigation',
+				order: 1,
+			},]
+		});
+	}
+
+	override async run(accessor: ServicesAccessor, ...args: any[]): Promise<void> {
+		const context: { sessionId: string; requestId: string; uri: URI; stopId: string | undefined } | undefined = args[0];
 		if (!context?.sessionId) {
 			return;
 		}
@@ -612,19 +637,12 @@ registerAction2(class OpenWorkingSetHistoryAction extends Action2 {
 		if (!chatModel) {
 			return;
 		}
-		const requests = chatModel.getRequests();
-		const snapshotRequestIndex = requests.findIndex((v, i) => i > 0 && requests[i - 1]?.id === context.requestId);
-		if (snapshotRequestIndex < 1) {
-			return;
-		}
-		const snapshotRequestId = requests[snapshotRequestIndex]?.id;
-		if (snapshotRequestId) {
-			const snapshot = chatEditingService.getEditingSession(chatModel.sessionId)?.getSnapshotUri(snapshotRequestId, context.uri);
-			if (snapshot) {
-				const editor = await editorService.openEditor({ resource: snapshot, label: localize('chatEditing.snapshot', '{0} (Snapshot {1})', basename(context.uri), snapshotRequestIndex - 1), options: { transient: true, activation: EditorActivation.ACTIVATE } });
-				if (isCodeEditor(editor)) {
-					editor.updateOptions({ readOnly: true });
-				}
+
+		const snapshot = chatEditingService.getEditingSession(chatModel.sessionId)?.getSnapshotUri(context.requestId, context.uri, context.stopId);
+		if (snapshot) {
+			const editor = await editorService.openEditor({ resource: snapshot, label: localize('chatEditing.snapshot', '{0} (Snapshot)', basename(context.uri)), options: { transient: true, activation: EditorActivation.ACTIVATE } });
+			if (isCodeEditor(editor)) {
+				editor.updateOptions({ readOnly: true });
 			}
 		}
 	}

--- a/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingServiceImpl.ts
@@ -35,7 +35,7 @@ import { ILifecycleService } from '../../../../services/lifecycle/common/lifecyc
 import { IMultiDiffSourceResolver, IMultiDiffSourceResolverService, IResolvedMultiDiffSource, MultiDiffEditorItem } from '../../../multiDiffEditor/browser/multiDiffSourceResolverService.js';
 import { CellUri, ICellEditOperation } from '../../../notebook/common/notebookCommon.js';
 import { ChatAgentLocation, IChatAgentService } from '../../common/chatAgents.js';
-import { CHAT_EDITING_MULTI_DIFF_SOURCE_RESOLVER_SCHEME, chatEditingAgentSupportsReadonlyReferencesContextKey, chatEditingResourceContextKey, ChatEditingSessionState, IChatEditingService, IChatEditingSession, IChatRelatedFile, IChatRelatedFilesProvider, IModifiedFileEntry, inChatEditingSessionContextKey, IStreamingEdits, WorkingSetEntryState } from '../../common/chatEditingService.js';
+import { CHAT_EDITING_MULTI_DIFF_SOURCE_RESOLVER_SCHEME, chatEditingAgentSupportsReadonlyReferencesContextKey, chatEditingResourceContextKey, ChatEditingSessionState, chatEditingSnapshotScheme, IChatEditingService, IChatEditingSession, IChatRelatedFile, IChatRelatedFilesProvider, IModifiedFileEntry, inChatEditingSessionContextKey, IStreamingEdits, WorkingSetEntryState } from '../../common/chatEditingService.js';
 import { IChatResponseModel } from '../../common/chatModel.js';
 import { IChatService } from '../../common/chatService.js';
 import { ChatEditingModifiedFileEntry } from './chatEditingModifiedFileEntry.js';
@@ -80,7 +80,7 @@ export class ChatEditingService extends Disposable implements IChatEditingServic
 		this._register(decorationsService.registerDecorationsProvider(_instantiationService.createInstance(ChatDecorationsProvider, this.editingSessionsObs)));
 		this._register(multiDiffSourceResolverService.registerResolver(_instantiationService.createInstance(ChatEditingMultiDiffSourceResolver)));
 		this._register(textModelService.registerTextModelContentProvider(ChatEditingTextModelContentProvider.scheme, _instantiationService.createInstance(ChatEditingTextModelContentProvider)));
-		this._register(textModelService.registerTextModelContentProvider(ChatEditingSnapshotTextModelContentProvider.scheme, _instantiationService.createInstance(ChatEditingSnapshotTextModelContentProvider)));
+		this._register(textModelService.registerTextModelContentProvider(chatEditingSnapshotScheme, _instantiationService.createInstance(ChatEditingSnapshotTextModelContentProvider)));
 
 
 		this._register(this._chatService.onDidDisposeSession((e) => {

--- a/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingSession.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingSession.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { binarySearch2 } from '../../../../../base/common/arrays.js';
+import { equals as arraysEqual, binarySearch2 } from '../../../../../base/common/arrays.js';
 import { DeferredPromise, ITask, Sequencer, SequencerByKey, timeout } from '../../../../../base/common/async.js';
 import { VSBuffer } from '../../../../../base/common/buffer.js';
 import { BugIndicatingError } from '../../../../../base/common/errors.js';
@@ -13,14 +13,13 @@ import { Iterable } from '../../../../../base/common/iterator.js';
 import { Disposable, DisposableMap, DisposableStore, dispose } from '../../../../../base/common/lifecycle.js';
 import { ResourceMap, ResourceSet } from '../../../../../base/common/map.js';
 import { Schemas } from '../../../../../base/common/network.js';
-import { asyncTransaction, autorun, derived, IObservable, IReader, ITransaction, observableValue, transaction } from '../../../../../base/common/observable.js';
+import { asyncTransaction, autorun, derived, derivedOpts, derivedWithStore, IObservable, IReader, ITransaction, ObservablePromise, observableValue, transaction } from '../../../../../base/common/observable.js';
 import { autorunDelta, autorunIterableDelta } from '../../../../../base/common/observableInternal/autorun.js';
 import { isEqual, joinPath } from '../../../../../base/common/resources.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { isCodeEditor, isDiffEditor } from '../../../../../editor/browser/editorBrowser.js';
 import { IBulkEditService } from '../../../../../editor/browser/services/bulkEditService.js';
 import { IOffsetEdit, ISingleOffsetEdit, OffsetEdit } from '../../../../../editor/common/core/offsetEdit.js';
-import { IDocumentDiff } from '../../../../../editor/common/diff/documentDiffProvider.js';
 import { TextEdit } from '../../../../../editor/common/languages.js';
 import { ILanguageService } from '../../../../../editor/common/languages/language.js';
 import { ITextModel } from '../../../../../editor/common/model.js';
@@ -34,6 +33,7 @@ import { IEnvironmentService } from '../../../../../platform/environment/common/
 import { IFileService } from '../../../../../platform/files/common/files.js';
 import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
 import { ILogService } from '../../../../../platform/log/common/log.js';
+import { observableConfigValue } from '../../../../../platform/observable/common/platformObservableUtils.js';
 import { IWorkspaceContextService } from '../../../../../platform/workspace/common/workspace.js';
 import { IEditorCloseEvent, SaveReason } from '../../../../common/editor.js';
 import { DiffEditorInput } from '../../../../common/editor/diffEditorInput.js';
@@ -44,7 +44,7 @@ import { MultiDiffEditor } from '../../../multiDiffEditor/browser/multiDiffEdito
 import { MultiDiffEditorInput } from '../../../multiDiffEditor/browser/multiDiffEditorInput.js';
 import { isNotebookEditorInput } from '../../../notebook/common/notebookEditorInput.js';
 import { INotebookService } from '../../../notebook/common/notebookService.js';
-import { ChatEditingSessionChangeType, ChatEditingSessionState, ChatEditKind, getMultiDiffSourceUri, IChatEditingSession, IModifiedFileEntry, IStreamingEdits, WorkingSetDisplayMetadata, WorkingSetEntryRemovalReason, WorkingSetEntryState } from '../../common/chatEditingService.js';
+import { ChatEditingSessionChangeType, ChatEditingSessionState, chatEditingSnapshotScheme, ChatEditKind, getMultiDiffSourceUri, IChatEditingSession, IEditSessionEntryDiff, IModifiedFileEntry, IStreamingEdits, WorkingSetDisplayMetadata, WorkingSetEntryRemovalReason, WorkingSetEntryState } from '../../common/chatEditingService.js';
 import { IChatRequestDisablement, IChatResponseModel } from '../../common/chatModel.js';
 import { IChatService } from '../../common/chatService.js';
 import { AbstractChatEditingModifiedFileEntry, ChatEditingModifiedFileEntry, IModifiedEntryTelemetryInfo, ISnapshotEntry } from './chatEditingModifiedFileEntry.js';
@@ -53,7 +53,11 @@ import { ChatEditingTextModelContentProvider } from './chatEditingTextModelConte
 
 const STORAGE_CONTENTS_FOLDER = 'contents';
 const STORAGE_STATE_FILE = 'state.json';
+const POST_EDIT_STOP_ID = 'd19944f6-f46c-4e17-911b-79a8e843c7c0'; // randomly generated
 
+const untrackedSchemes: readonly string[] = [
+	chatEditingSnapshotScheme,
+];
 
 class ThrottledSequencer extends Sequencer {
 
@@ -92,6 +96,34 @@ class ThrottledSequencer extends Sequencer {
 function getMaxHistoryIndex(history: readonly IChatEditingSessionSnapshot[]) {
 	const lastHistory = history.at(-1);
 	return lastHistory ? lastHistory.startIndex + lastHistory.stops.length : 0;
+}
+
+function snapshotsEqualForDiff(a: ISnapshotEntry | undefined, b: ISnapshotEntry | undefined) {
+	if (!a || !b) {
+		return a === b;
+	}
+
+	return isEqual(a.snapshotUri, b.snapshotUri) && a.current === b.current;
+}
+
+function getCurrentAndNextStop(requestId: string, stopId: string | undefined, history: readonly IChatEditingSessionSnapshot[]) {
+	const snapshotIndex = history.findIndex(s => s.requestId === requestId);
+	if (snapshotIndex === -1) { return undefined; }
+	const snapshot = history[snapshotIndex];
+	const stopIndex = snapshot.stops.findIndex(s => s.stopId === stopId);
+	if (stopIndex === -1) { return undefined; }
+
+	const current = snapshot.stops[stopIndex].entries;
+	const next = stopIndex < snapshot.stops.length - 1
+		? snapshot.stops[stopIndex + 1].entries
+		: snapshot.postEdit || history[snapshotIndex + 1]?.stops[0].entries;
+
+
+	if (!next) {
+		return undefined;
+	}
+
+	return { current, next };
 }
 
 export class ChatEditingSession extends Disposable implements IChatEditingSession {
@@ -192,11 +224,13 @@ export class ChatEditingSession extends Disposable implements IChatEditingSessio
 			for (const [uri, content] of restoredSessionState.initialFileContents) {
 				this._initialFileContents.set(uri, content);
 			}
-			this._pendingSnapshot = restoredSessionState.pendingSnapshot;
-			await this._restoreSnapshot(restoredSessionState.recentSnapshot);
-			this._linearHistory.set(restoredSessionState.linearHistory, undefined);
-			this._linearHistoryIndex.set(restoredSessionState.linearHistoryIndex, undefined);
-			this._state.set(ChatEditingSessionState.Idle, undefined);
+			await asyncTransaction(async tx => {
+				this._pendingSnapshot = restoredSessionState.pendingSnapshot;
+				await this._restoreSnapshot(restoredSessionState.recentSnapshot, tx);
+				this._linearHistory.set(restoredSessionState.linearHistory, tx);
+				this._linearHistoryIndex.set(restoredSessionState.linearHistoryIndex, tx);
+				this._state.set(ChatEditingSessionState.Idle, tx);
+			});
 		}
 
 		// Add the currently active editors to the working set
@@ -299,6 +333,9 @@ export class ChatEditingSession extends Disposable implements IChatEditingSessio
 			if (!uri) {
 				return;
 			}
+			if (untrackedSchemes.includes(uri.scheme)) {
+				return;
+			}
 			if (existingTransientEntries.has(uri)) {
 				existingTransientEntries.delete(uri);
 			} else if ((!this._workingSet.has(uri) || this._workingSet.get(uri)?.state === WorkingSetEntryState.Suggested) && !this._removedTransientEntries.has(uri)) {
@@ -335,58 +372,112 @@ export class ChatEditingSession extends Disposable implements IChatEditingSessio
 		this._pendingSnapshot ??= this._createSnapshot(undefined, undefined);
 	}
 
-	private _diffsBetweenStops = new Map<string, IObservable<IDocumentDiff | undefined>>();
-	public getEntryDiffBetweenStops(uri: URI, requestId: string, stopId: string | undefined) {
-		const key = `${uri}\0${requestId}\0${stopId}`;
-		const existing = this._diffsBetweenStops.get(key);
-		if (existing) {
-			return existing;
-		}
+	private _diffsBetweenStops = new Map<string, IObservable<IEditSessionEntryDiff | undefined>>();
 
-		const history = this._linearHistory.get();
-		const snapshotIndex = history.findIndex(s => s.requestId === requestId);
-		if (snapshotIndex === -1) { return undefined; }
-		const stopIndex = history[snapshotIndex].stops.findIndex(s => s.stopId === stopId);
-		if (stopIndex === -1) { return undefined; }
+	private readonly _ignoreTrimWhitespaceObservable = observableConfigValue('diffEditor.ignoreTrimWhitespace', true, this._configurationService);
 
-		const currentStop = history[snapshotIndex].stops[stopIndex];
-		const nextStop = stopIndex === history[snapshotIndex].stops.length - 1 ? history[snapshotIndex + 1]?.stops[0] : history[snapshotIndex].stops[stopIndex + 1];
-		if (!nextStop) { return undefined; }
+	/**
+	 * Gets diff for text entries between stops.
+	 * @param entriesContent Observable that observes either snapshot entry
+	 * @param modelUrisObservable Observable that observes only the snapshot URIs.
+	 */
+	private _entryDiffBetweenTextStops(
+		entriesContent: IObservable<{ before: ISnapshotEntry; after: ISnapshotEntry } | undefined>,
+		modelUrisObservable: IObservable<[URI, URI] | undefined>,
+	): IObservable<ObservablePromise<IEditSessionEntryDiff> | undefined> {
+		const modelRefsPromise = derivedWithStore(this, (reader, store) => {
+			const modelUris = modelUrisObservable.read(reader);
+			if (!modelUris) { return undefined; }
 
-		const before = currentStop.entries.get(uri);
-		const after = nextStop.entries.get(uri);
-		if (!before || !after) { return undefined; }
+			const promise = Promise.all(modelUris.map(u => this._textModelService.createModelReference(u))).then(refs => {
+				if (store.isDisposed) {
+					refs.forEach(r => r.dispose());
+				} else {
+					refs.forEach(r => store.add(r));
+				}
 
-		// todo@connor4312: make this _actually_ observable to react to change to the
-		// whitespace setting changes and changes from {@link ensureEditInUndoStopMatches}
-		// May also want to move this onto the ChatEditingModifiedFileEntry.
-		const value = observableValue<IDocumentDiff | undefined>('getEntryDiffBetweenStops', undefined);
-		this._diffsBetweenStops.set(key, value);
+				return refs;
+			});
 
-		const store = new DisposableStore();
-		(async () => {
-			const [refA, refB] = await Promise.all([
-				this._textModelService.createModelReference(before.snapshotUri),
-				this._textModelService.createModelReference(after.snapshotUri),
-			]);
-			store.add(refA);
-			store.add(refB);
-
-			const diff = await this._editorWorkerService.computeDiff(
-				refA.object.textEditorModel.uri,
-				refB.object.textEditorModel.uri,
-				{ ignoreTrimWhitespace: this._configurationService.getValue('diffEditor.ignoreTrimWhitespace') ?? true, computeMoves: false, maxComputationTimeMs: 3000 },
-				'advanced'
-			);
-			if (diff) {
-				value.set(diff, undefined);
-			}
-		})().finally(() => {
-			store.dispose();
+			return new ObservablePromise(promise);
 		});
 
+		return derived((reader): ObservablePromise<IEditSessionEntryDiff> | undefined => {
+			const refs = modelRefsPromise.read(reader)?.promiseResult.read(reader)?.data;
+			if (!refs) {
+				return;
+			}
 
-		return value;
+			entriesContent.read(reader); // trigger re-diffing when contents change
+
+			const ignoreTrimWhitespace = this._ignoreTrimWhitespaceObservable.read(reader);
+			const promise = this._editorWorkerService.computeDiff(
+				refs[0].object.textEditorModel.uri,
+				refs[1].object.textEditorModel.uri,
+				{ ignoreTrimWhitespace, computeMoves: false, maxComputationTimeMs: 3000 },
+				'advanced'
+			).then((diff): IEditSessionEntryDiff => {
+				const entryDiff: IEditSessionEntryDiff = {
+					originalURI: refs[0].object.textEditorModel.uri,
+					modifiedURI: refs[1].object.textEditorModel.uri,
+					identical: !!diff?.identical,
+					quitEarly: !diff || diff.quitEarly,
+					added: 0,
+					removed: 0,
+				};
+				if (diff) {
+					for (const change of diff.changes) {
+						entryDiff.removed += change.original.endLineNumberExclusive - change.original.startLineNumber;
+						entryDiff.added += change.modified.endLineNumberExclusive - change.modified.startLineNumber;
+					}
+				}
+
+				return entryDiff;
+			});
+
+			return new ObservablePromise(promise);
+		});
+	}
+
+	private _createDiffBetweenStopsObservable(uri: URI, requestId: string, stopId: string | undefined): IObservable<IEditSessionEntryDiff | undefined> {
+		const entries = derivedOpts<undefined | { before: ISnapshotEntry; after: ISnapshotEntry }>(
+			{
+				equalsFn: (a, b) => snapshotsEqualForDiff(a?.before, b?.before) && snapshotsEqualForDiff(a?.after, b?.after),
+			},
+			reader => {
+				const stops = getCurrentAndNextStop(requestId, stopId, this._linearHistory.read(reader));
+				if (!stops) { return undefined; }
+				const before = stops.current.get(uri);
+				const after = stops.next.get(uri);
+				if (!before || !after) { return undefined; }
+				return { before, after };
+			},
+		);
+
+		// Separate observable for model refs to avoid unnecessary disposal
+		const modelUrisObservable = derivedOpts<[URI, URI] | undefined>({ equalsFn: (a, b) => arraysEqual(a, b, isEqual) }, reader => {
+			const entriesValue = entries.read(reader);
+			if (!entriesValue) { return undefined; }
+			return [entriesValue.before.snapshotUri, entriesValue.after.snapshotUri];
+		});
+
+		// todo@DonJayamanne support notebooks here too
+		const diff = this._entryDiffBetweenTextStops(entries, modelUrisObservable);
+
+		return derived(reader => {
+			return diff.read(reader)?.promiseResult.read(reader)?.data || undefined;
+		});
+	}
+
+	public getEntryDiffBetweenStops(uri: URI, requestId: string, stopId: string | undefined) {
+		const key = `${uri}\0${requestId}\0${stopId}`;
+		let observable = this._diffsBetweenStops.get(key);
+		if (!observable) {
+			observable = this._createDiffBetweenStopsObservable(uri, requestId, stopId);
+			this._diffsBetweenStops.set(key, observable);
+		}
+
+		return observable;
 	}
 
 	public createSnapshot(requestId: string, undoStop: string | undefined): void {
@@ -401,7 +492,7 @@ export class ChatEditingSession extends Disposable implements IChatEditingSessio
 		const newLinearHistory: IChatEditingSessionSnapshot[] = [];
 		for (const entry of this._linearHistory.get()) {
 			if (linearHistoryPtr - entry.startIndex < entry.stops.length) {
-				newLinearHistory.push({ requestId: entry.requestId, stops: entry.stops.slice(0, linearHistoryPtr - entry.startIndex), startIndex: entry.startIndex });
+				newLinearHistory.push({ requestId: entry.requestId, stops: entry.stops.slice(0, linearHistoryPtr - entry.startIndex), startIndex: entry.startIndex, postEdit: undefined });
 			} else {
 				newLinearHistory.push(entry);
 			}
@@ -409,9 +500,9 @@ export class ChatEditingSession extends Disposable implements IChatEditingSessio
 
 		const lastEntry = newLinearHistory.at(-1);
 		if (requestId && lastEntry?.requestId === requestId) {
-			newLinearHistory[newLinearHistory.length - 1] = { ...lastEntry, stops: [...lastEntry.stops, snapshot] };
+			newLinearHistory[newLinearHistory.length - 1] = { ...lastEntry, stops: [...lastEntry.stops, snapshot], postEdit: undefined };
 		} else {
-			newLinearHistory.push({ requestId, startIndex: lastEntry ? lastEntry.startIndex + lastEntry.stops.length : 0, stops: [snapshot] });
+			newLinearHistory.push({ requestId, startIndex: lastEntry ? lastEntry.startIndex + lastEntry.stops.length : 0, stops: [snapshot], postEdit: undefined });
 		}
 
 		transaction((tx) => {
@@ -436,7 +527,9 @@ export class ChatEditingSession extends Disposable implements IChatEditingSessio
 	}
 
 	public async getSnapshotModel(requestId: string, undoStop: string | undefined, snapshotUri: URI): Promise<ITextModel | null> {
-		const entries = this._findEditStop(requestId, undoStop)?.entries;
+		const entries = undoStop === POST_EDIT_STOP_ID
+			? this._findSnapshot(requestId)?.postEdit
+			: this._findEditStop(requestId, undoStop)?.entries;
 		if (!entries) {
 			return null;
 		}
@@ -449,22 +542,9 @@ export class ChatEditingSession extends Disposable implements IChatEditingSessio
 		return this._modelService.createModel(snapshotEntry.current, this._languageService.createById(snapshotEntry.languageId), snapshotUri, false);
 	}
 
-	public getSnapshotUri(requestId: string, uri: URI): URI | undefined {
-		// todo@connor4312: this is used in code block links in chat, ad hoc this just gets the last snapshot
-		// of the file in the request but we should plumb stops through here too
-		const snapshot = this._findSnapshot(requestId);
-		if (!snapshot) {
-			return undefined;
-		}
-
-		for (let k = snapshot.stops.length - 1; k >= 0; k--) {
-			const entry = snapshot.stops[k].entries.get(uri);
-			if (entry) {
-				return entry.snapshotUri;
-			}
-		}
-
-		return undefined;
+	public getSnapshotUri(requestId: string, uri: URI, stopId: string | undefined): URI | undefined {
+		const stops = getCurrentAndNextStop(requestId, stopId, this._linearHistory.get());
+		return stops?.next.get(uri)?.snapshotUri;
 	}
 
 	/**
@@ -476,19 +556,19 @@ export class ChatEditingSession extends Disposable implements IChatEditingSessio
 			const snapshot = this._findEditStop(requestId, stopId);
 			if (snapshot) {
 				this._ensurePendingSnapshot();
-				await this._restoreSnapshot(snapshot);
+				await this._restoreSnapshot(snapshot, undefined);
 			}
 		} else {
-			if (!this._pendingSnapshot) {
+			const pendingSnapshot = this._pendingSnapshot;
+			if (!pendingSnapshot) {
 				return; // We don't have a pending snapshot that we can restore
 			}
-			const snapshot = this._pendingSnapshot;
 			this._pendingSnapshot = undefined;
-			await this._restoreSnapshot(snapshot);
+			await this._restoreSnapshot(pendingSnapshot, undefined);
 		}
 	}
 
-	private async _restoreSnapshot({ workingSet, entries }: IChatEditingSessionStop): Promise<void> {
+	private async _restoreSnapshot({ workingSet, entries }: IChatEditingSessionStop, tx: ITransaction | undefined): Promise<void> {
 		this._workingSet = new ResourceMap(workingSet);
 
 		// Reset all the files which are modified in this session state
@@ -509,7 +589,7 @@ export class ChatEditingSession extends Disposable implements IChatEditingSessio
 			entriesArr.push(entry);
 		}
 
-		this._entriesObs.set(entriesArr, undefined);
+		this._entriesObs.set(entriesArr, tx);
 	}
 
 	remove(reason: WorkingSetEntryRemovalReason, ...uris: URI[]): void {
@@ -791,9 +871,12 @@ export class ChatEditingSession extends Disposable implements IChatEditingSessio
 		if (!previousSnapshot) {
 			return;
 		}
+
 		this._ensurePendingSnapshot();
-		await this._restoreSnapshot(previousSnapshot.stop);
-		this._linearHistoryIndex.set(newIndex, undefined);
+		await asyncTransaction(async tx => {
+			await this._restoreSnapshot(previousSnapshot.stop, tx);
+			this._linearHistoryIndex.set(newIndex, tx);
+		});
 		this._updateRequestHiddenState();
 	}
 
@@ -808,8 +891,10 @@ export class ChatEditingSession extends Disposable implements IChatEditingSessio
 		if (!nextSnapshot) {
 			return;
 		}
-		await this._restoreSnapshot(nextSnapshot);
-		this._linearHistoryIndex.set(newIndex, undefined);
+		await asyncTransaction(async tx => {
+			await this._restoreSnapshot(nextSnapshot, tx);
+			this._linearHistoryIndex.set(newIndex, tx);
+		});
 		this._updateRequestHiddenState();
 	}
 
@@ -868,10 +953,22 @@ export class ChatEditingSession extends Disposable implements IChatEditingSessio
 
 		const snap = history[snapIndex];
 		let stopIndex = snap.stops.findIndex(s => s.stopId === undoStop);
-		if (stopIndex === -1 || (next && stopIndex === snap.stops.length - 1)) {
+		if (stopIndex === -1) {
 			return;
 		}
+
+		// special case: put the last change in the pendingSnapshot as needed
 		if (next) {
+			if (stopIndex === snap.stops.length - 1) {
+				const postEdit = new ResourceMap(snap.postEdit || this._createSnapshot(undefined, undefined).entries);
+				if (!snap.postEdit || !entry.equalsSnapshot(postEdit.get(entry.modifiedURI))) {
+					postEdit.set(entry.modifiedURI, entry.createSnapshot(requestId, POST_EDIT_STOP_ID));
+					const newHistory = history.slice();
+					newHistory[snapIndex] = { ...snap, postEdit };
+					this._linearHistory.set(newHistory, tx);
+				}
+				return;
+			}
 			stopIndex++;
 		}
 
@@ -1039,12 +1136,16 @@ class ChatEditingSessionStorage {
 			});
 			return result;
 		};
-		const deserializeChatEditingStopDTO = async (stopDTO: IChatEditingSessionStopDTO | IChatEditingSessionSnapshotDTO): Promise<IChatEditingSessionStop> => {
+		const deserializeSnapshotEntriesDTO = async (dtoEntries: ISnapshotEntryDTO[]): Promise<ResourceMap<ISnapshotEntry>> => {
 			const entries = new ResourceMap<ISnapshotEntry>();
-			for (const entryDTO of stopDTO.entries) {
+			for (const entryDTO of dtoEntries) {
 				const entry = await deserializeSnapshotEntry(entryDTO);
 				entries.set(entry.resource, entry);
 			}
+			return entries;
+		};
+		const deserializeChatEditingStopDTO = async (stopDTO: IChatEditingSessionStopDTO | IChatEditingSessionSnapshotDTO): Promise<IChatEditingSessionStop> => {
+			const entries = await deserializeSnapshotEntriesDTO(stopDTO.entries);
 			const workingSet = deserializeResourceMap(stopDTO.workingSet, (value) => value, new ResourceMap());
 			return { stopId: 'stopId' in stopDTO ? stopDTO.stopId : undefined, workingSet, entries };
 		};
@@ -1052,11 +1153,11 @@ class ChatEditingSessionStorage {
 			if ('stops' in snapshot) {
 				return snapshot;
 			}
-			return { requestId: snapshot.requestId, stops: [{ stopId: undefined, entries: snapshot.entries, workingSet: snapshot.workingSet }] };
+			return { requestId: snapshot.requestId, stops: [{ stopId: undefined, entries: snapshot.entries, workingSet: snapshot.workingSet }], postEdit: undefined };
 		};
 		const deserializeChatEditingSessionSnapshot = async (startIndex: number, snapshot: IChatEditingSessionSnapshotDTO2): Promise<IChatEditingSessionSnapshot> => {
 			const stops = await Promise.all(snapshot.stops.map(deserializeChatEditingStopDTO));
-			return { startIndex, requestId: snapshot.requestId, stops };
+			return { startIndex, requestId: snapshot.requestId, stops, postEdit: snapshot.postEdit && await deserializeSnapshotEntriesDTO(snapshot.postEdit) };
 		};
 		const deserializeSnapshotEntry = async (entry: ISnapshotEntryDTO) => {
 			return {
@@ -1158,6 +1259,7 @@ class ChatEditingSessionStorage {
 			return {
 				requestId: snapshot.requestId,
 				stops: snapshot.stops.map(serializeChatEditingSessionStop),
+				postEdit: snapshot.postEdit ? Array.from(snapshot.postEdit.values()).map(serializeSnapshotEntry) : undefined
 			};
 		};
 		const serializeSnapshotEntry = (entry: ISnapshotEntry): ISnapshotEntryDTO => {
@@ -1207,7 +1309,6 @@ class ChatEditingSessionStorage {
 			}
 		}
 	}
-
 }
 
 export interface IChatEditingSessionSnapshot {
@@ -1225,6 +1326,9 @@ export interface IChatEditingSessionSnapshot {
 	 * Invariant: never empty.
 	 */
 	readonly stops: IChatEditingSessionStop[];
+
+	/** Stop that represents changes after the last undo stop, kept for diffing purposes. */
+	readonly postEdit: ResourceMap<ISnapshotEntry> | undefined;
 }
 
 interface IChatEditingSessionStop {
@@ -1251,6 +1355,7 @@ interface IChatEditingSessionSnapshotDTO {
 interface IChatEditingSessionSnapshotDTO2 {
 	readonly requestId: string | undefined;
 	readonly stops: IChatEditingSessionStopDTO[];
+	readonly postEdit: ISnapshotEntryDTO[] | undefined;
 }
 
 interface ISnapshotEntryDTO {

--- a/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingTextModelContentProviders.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingTextModelContentProviders.ts
@@ -7,7 +7,7 @@ import { URI } from '../../../../../base/common/uri.js';
 import { ITextModel } from '../../../../../editor/common/model.js';
 import { IModelService } from '../../../../../editor/common/services/model.js';
 import { ITextModelContentProvider } from '../../../../../editor/common/services/resolverService.js';
-import { IChatEditingService } from '../../common/chatEditingService.js';
+import { chatEditingSnapshotScheme, IChatEditingService } from '../../common/chatEditingService.js';
 import { ChatEditingSession } from './chatEditingSession.js';
 
 type ChatEditingTextModelContentQueryData = { kind: 'doc'; documentId: string; chatSessionId: string };
@@ -50,11 +50,9 @@ export class ChatEditingTextModelContentProvider implements ITextModelContentPro
 type ChatEditingSnapshotTextModelContentQueryData = { sessionId: string; requestId: string | undefined; undoStop: string | undefined };
 
 export class ChatEditingSnapshotTextModelContentProvider implements ITextModelContentProvider {
-	public static readonly scheme = 'chat-editing-snapshot-text-model';
-
 	public static getSnapshotFileURI(chatSessionId: string, requestId: string | undefined, undoStop: string | undefined, path: string): URI {
 		return URI.from({
-			scheme: ChatEditingSnapshotTextModelContentProvider.scheme,
+			scheme: chatEditingSnapshotScheme,
 			path,
 			query: JSON.stringify({ sessionId: chatSessionId, requestId: requestId ?? '', undoStop: undoStop ?? '' } satisfies ChatEditingSnapshotTextModelContentQueryData),
 		});


### PR DESCRIPTION
- We now keep a 'postEdit' snapshot so we can make sure we're always
  able to show diffs, fixing the issue with the last pill and some
  other state bugs. I think this fixes https://github.com/microsoft/vscode-copilot/issues/13229
- Made the observable for `getEntryDiffBetweenStops` proper and react to
  various updates. Made its type independent of the IDocumentDiff @jrieken
- Clicking on a pill now opens the change made at that point in time.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
