### PR TITLE
Fix missing response toolbar

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatListRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatListRenderer.ts
@@ -773,7 +773,7 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 					}
 					break;
 				}
-			} else {
+			} else if (part.kind !== 'undoStop') {
 				partsToRender.push(part);
 			}
 		}


### PR DESCRIPTION
If we have a part that isn't rendered, then we loop forever trying to render it and the response is never marked as complete, so the toolbar is hidden. Should have a nicer way to handle this and I've been meaning to write tests...

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
