### PR TITLE
Fix chat icon label padding for no icon cases

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/media/chat.css
@@ -1070,10 +1070,10 @@ have to be updated for changes to the rules above, or to support more deeply nes
 
 .interactive-session .chat-attached-context .chat-attached-context-attachment {
 	display: flex;
-	gap: 4px;
+	gap: 2px;
 	overflow: hidden;
 	font-size: 11px;
-	padding: 0 4px 0 2px;
+	padding: 0 4px;
 	border: 1px solid var(--vscode-chat-requestBorder, var(--vscode-input-background, transparent));
 	border-radius: 4px;
 	height: 18px;
@@ -1178,9 +1178,14 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	opacity: 0.8;
 }
 
+.interactive-session .chat-attached-context .chat-attached-context-attachment .monaco-icon-label {
+	gap: 3px;
+}
+
 .interactive-session .chat-attached-context .chat-attached-context-attachment .monaco-icon-label::before {
-	padding: 0 2px 0 0;
-	height: 1em;
+	height: 90%;
+	width: auto;
+	padding: 0;
 	line-height: 1em !important;
 	align-self: center;
 

--- a/src/vs/workbench/contrib/chat/browser/media/chatInlineAnchorWidget.css
+++ b/src/vs/workbench/contrib/chat/browser/media/chatInlineAnchorWidget.css
@@ -15,7 +15,7 @@
 }
 
 .chat-inline-anchor-widget .icon-label {
-	padding-right: 3px;
+	padding: 0 3px;
 }
 
 .interactive-item-container .value .rendered-markdown .chat-inline-anchor-widget {
@@ -45,7 +45,6 @@
 	background-repeat: no-repeat;
 
 	padding: 0 !important;
-	margin-right: 3px;
 	margin-bottom: 1px;
 
 	flex-shrink: 0;


### PR DESCRIPTION
Fixes #241139

This tries to simplify the styling to work in case when there is/isn't a file icon

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
