### PR TITLE
remove `IModifiedFileEntry#diffInfo`

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditing.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditing.ts
@@ -9,7 +9,7 @@ import { findDiffEditorContainingCodeEditor } from '../../../../../editor/browse
 import { ServicesAccessor } from '../../../../../platform/instantiation/common/instantiation.js';
 import { IModifiedFileEntry } from '../../common/chatEditingService.js';
 
-export function isDiffEditorForEntry(accessor: ServicesAccessor, entry: IModifiedFileEntry, editor: ICodeEditor) {
+export function isTextDiffEditorForEntry(accessor: ServicesAccessor, entry: IModifiedFileEntry, editor: ICodeEditor) {
 	const diffEditor = findDiffEditorContainingCodeEditor(accessor, editor);
 	if (!diffEditor) {
 		return false;

--- a/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingCodeEditorIntegration.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingCodeEditorIntegration.ts
@@ -38,7 +38,7 @@ import { IEditorService } from '../../../../services/editor/common/editorService
 import { overviewRulerModifiedForeground, minimapGutterModifiedBackground, overviewRulerAddedForeground, minimapGutterAddedBackground, overviewRulerDeletedForeground, minimapGutterDeletedBackground } from '../../../scm/common/quickDiff.js';
 import { ChatAgentLocation, IChatAgentService } from '../../common/chatAgents.js';
 import { ChatEditingSessionState, IChatEditingService, IModifiedFileEntry, IModifiedFileEntryChangeHunk, IModifiedFileEntryEditorIntegration, WorkingSetEntryState } from '../../common/chatEditingService.js';
-import { isDiffEditorForEntry } from './chatEditing.js';
+import { isTextDiffEditorForEntry } from './chatEditing.js';
 import { ChatEditingModifiedDocumentEntry } from './chatEditingModifiedDocumentEntry.js';
 
 export class ChatEditingCodeEditorIntegration implements IModifiedFileEntryEditorIntegration {
@@ -61,6 +61,7 @@ export class ChatEditingCodeEditorIntegration implements IModifiedFileEntryEdito
 	constructor(
 		private readonly _editor: ICodeEditor,
 		private readonly _entry: ChatEditingModifiedDocumentEntry,
+		documentDiffInfo: IObservable<IDocumentDiff>,
 		@IChatEditingService chatEditingService: IChatEditingService,
 		@IChatAgentService private readonly _chatAgentService: IChatAgentService,
 		@IEditorService private readonly _editorService: IEditorService,
@@ -74,7 +75,7 @@ export class ChatEditingCodeEditorIntegration implements IModifiedFileEntryEdito
 			if (!isEqual(codeEditorObs.model.read(r)?.uri, _entry.modifiedURI)) {
 				return false;
 			}
-			if (this._editor.getOption(EditorOption.inDiffEditor) && !instantiationService.invokeFunction(isDiffEditorForEntry, _entry, this._editor)) {
+			if (this._editor.getOption(EditorOption.inDiffEditor) && !instantiationService.invokeFunction(isTextDiffEditorForEntry, _entry, this._editor)) {
 				return false;
 			}
 			return true;
@@ -90,7 +91,7 @@ export class ChatEditingCodeEditorIntegration implements IModifiedFileEntryEdito
 			}
 
 			const data: IModelDeltaDecoration[] = [];
-			const diff = _entry.diffInfo.read(r);
+			const diff = documentDiffInfo.read(r);
 			for (const diffEntry of diff.changes) {
 				data.push({
 					range: diffEntry.modified.toInclusiveRange() ?? new Range(diffEntry.modified.startLineNumber, 1, diffEntry.modified.startLineNumber, Number.MAX_SAFE_INTEGER),
@@ -107,7 +108,7 @@ export class ChatEditingCodeEditorIntegration implements IModifiedFileEntryEdito
 			if (enabledObs.read(r)
 				&& !_entry.isCurrentlyBeingModifiedBy.read(r)
 				&& lastModifyingRequestId !== _entry.lastModifyingRequestId
-				&& !_entry.diffInfo.read(r).identical
+				&& !documentDiffInfo.read(r).identical
 			) {
 				lastModifyingRequestId = _entry.lastModifyingRequestId;
 				const position = _editor.getPosition() ?? new Position(1, 1);
@@ -145,7 +146,7 @@ export class ChatEditingCodeEditorIntegration implements IModifiedFileEntryEdito
 					codeEditorObs.getOption(EditorOption.lineHeight).read(r);
 
 					const reviewMode = _entry.reviewMode.read(r);
-					const diff = _entry.diffInfo.read(r);
+					const diff = documentDiffInfo.read(r);
 					this._updateDiffRendering(_entry, diff, reviewMode);
 
 				} else {
@@ -162,7 +163,7 @@ export class ChatEditingCodeEditorIntegration implements IModifiedFileEntryEdito
 				return;
 			}
 
-			const diff = _entry.diffInfo.read(r);
+			const diff = documentDiffInfo.read(r);
 			const mapping = diff.changes.find(m => m.modified.contains(position.lineNumber) || m.modified.isEmpty && m.modified.startLineNumber === position.lineNumber);
 			if (mapping?.modified.isEmpty) {
 				this._accessibilitySignalsService.playSignal(AccessibilitySignal.diffLineDeleted, { source: 'chatEditingEditor.cursorPositionChanged' });
@@ -194,8 +195,8 @@ export class ChatEditingCodeEditorIntegration implements IModifiedFileEntryEdito
 				constObservable(true),
 				codeEditorObs.layoutInfo.map((v, r) => v.width),
 				codeEditorObs.layoutInfo.map((v, r) => v.height),
-				_entry.diffInfo.map(diff => diff.changes.slice()),
-				instantiationService.createInstance(AccessibleDiffViewerModel, _entry, _editor),
+				documentDiffInfo.map(diff => diff.changes.slice()),
+				instantiationService.createInstance(AccessibleDiffViewerModel, _entry, documentDiffInfo, _editor),
 			));
 		}));
 
@@ -788,6 +789,7 @@ class AccessibleDiffViewContainer implements IOverlayWidget {
 class AccessibleDiffViewerModel implements IAccessibleDiffViewerModel {
 	constructor(
 		private readonly entry: IModifiedFileEntry,
+		private readonly _documentDiffInfo: IObservable<IDocumentDiff>,
 		private readonly _editor: ICodeEditor,
 		@IModelService private readonly _modelService: IModelService,
 	) { }
@@ -801,7 +803,7 @@ class AccessibleDiffViewerModel implements IAccessibleDiffViewerModel {
 	}
 
 	originalReveal(range: Range) {
-		const changes = this.entry.diffInfo.get().changes;
+		const changes = this._documentDiffInfo.get().changes;
 		const idx = changes.findIndex(value => value.original.intersect(LineRange.fromRange(range)));
 		if (idx >= 0) {
 			range = changes[idx].modified.toInclusiveRange() ?? range;

--- a/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingModifiedDocumentEntry.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingModifiedDocumentEntry.ts
@@ -87,9 +87,6 @@ export class ChatEditingModifiedDocumentEntry extends AbstractChatEditingModifie
 	private _diffOperationIds: number = 0;
 
 	private readonly _diffInfo = observableValue<IDocumentDiff>(this, nullDocumentDiff);
-	get diffInfo(): IObservable<IDocumentDiff> {
-		return this._diffInfo;
-	}
 
 	readonly changesCount = this._diffInfo.map(diff => diff.changes.length);
 
@@ -332,7 +329,7 @@ export class ChatEditingModifiedDocumentEntry extends AbstractChatEditingModifie
 		}
 		this.docSnapshot.pushEditOperations(null, edits, _ => null);
 		await this._updateDiffInfoSeq();
-		if (this.diffInfo.get().identical) {
+		if (this._diffInfo.get().identical) {
 			this._stateObs.set(WorkingSetEntryState.Accepted, undefined);
 		}
 		return true;
@@ -349,7 +346,7 @@ export class ChatEditingModifiedDocumentEntry extends AbstractChatEditingModifie
 		}
 		this.doc.pushEditOperations(null, edits, _ => null);
 		await this._updateDiffInfoSeq();
-		if (this.diffInfo.get().identical) {
+		if (this._diffInfo.get().identical) {
 			this._stateObs.set(WorkingSetEntryState.Rejected, undefined);
 		}
 		return true;
@@ -452,6 +449,6 @@ export class ChatEditingModifiedDocumentEntry extends AbstractChatEditingModifie
 	protected _createEditorIntegration(editor: IEditorPane): IModifiedFileEntryEditorIntegration {
 		const codeEditor = getCodeEditor(editor.getControl());
 		assertType(codeEditor);
-		return this._instantiationService.createInstance(ChatEditingCodeEditorIntegration, codeEditor, this);
+		return this._instantiationService.createInstance(ChatEditingCodeEditorIntegration, codeEditor, this, this._diffInfo);
 	}
 }

--- a/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingModifiedFileEntry.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingModifiedFileEntry.ts
@@ -10,7 +10,6 @@ import { clamp } from '../../../../../base/common/numbers.js';
 import { autorun, derived, IObservable, ITransaction, observableValue } from '../../../../../base/common/observable.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { OffsetEdit } from '../../../../../editor/common/core/offsetEdit.js';
-import { IDocumentDiff } from '../../../../../editor/common/diff/documentDiffProvider.js';
 import { localize } from '../../../../../nls.js';
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 import { IFileService } from '../../../../../platform/files/common/files.js';
@@ -219,7 +218,6 @@ export abstract class AbstractChatEditingModifiedFileEntry extends Disposable im
 	 */
 	protected abstract _createEditorIntegration(editor: IEditorPane): IModifiedFileEntryEditorIntegration;
 
-	abstract readonly diffInfo: IObservable<IDocumentDiff>;
 	abstract readonly changesCount: IObservable<number>;
 
 	acceptStreamingEditsStart(responseModel: IChatResponseModel, tx: ITransaction) {

--- a/src/vs/workbench/contrib/chat/common/chatEditingService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatEditingService.ts
@@ -9,7 +9,6 @@ import { IDisposable } from '../../../../base/common/lifecycle.js';
 import { ResourceMap } from '../../../../base/common/map.js';
 import { IObservable, IReader, ITransaction } from '../../../../base/common/observable.js';
 import { URI } from '../../../../base/common/uri.js';
-import { IDocumentDiff } from '../../../../editor/common/diff/documentDiffProvider.js';
 import { TextEdit } from '../../../../editor/common/languages.js';
 import { localize } from '../../../../nls.js';
 import { RawContextKey } from '../../../../platform/contextkey/common/contextkey.js';
@@ -231,11 +230,6 @@ export interface IModifiedFileEntry {
 	readonly state: IObservable<WorkingSetEntryState>;
 	readonly isCurrentlyBeingModifiedBy: IObservable<IChatResponseModel | undefined>;
 	readonly rewriteRatio: IObservable<number>;
-
-	/**
-	 * @deprecated
-	 */
-	readonly diffInfo: IObservable<IDocumentDiff>;
 
 	accept(transaction: ITransaction | undefined): Promise<void>;
 	reject(transaction: ITransaction | undefined): Promise<void>;

--- a/src/vs/workbench/contrib/notebook/browser/contrib/chatEdit/notebookChatActionsOverlay.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/chatEdit/notebookChatActionsOverlay.ts
@@ -13,7 +13,6 @@ import { ActionRunner, IAction, IActionRunner } from '../../../../../../base/com
 import { $ } from '../../../../../../base/browser/dom.js';
 import { IChatEditingService, IModifiedFileEntry } from '../../../../chat/common/chatEditingService.js';
 import { ACTIVE_GROUP, IEditorService } from '../../../../../services/editor/common/editorService.js';
-import { Range } from '../../../../../../editor/common/core/range.js';
 import { autorun, autorunWithStore, IObservable, ISettableObservable, observableFromEvent, observableValue } from '../../../../../../base/common/observable.js';
 import { isEqual } from '../../../../../../base/common/resources.js';
 import { CellDiffInfo } from '../../diff/notebookDiffViewModel.js';
@@ -67,7 +66,7 @@ export class NotebookChatActionsOverlay extends Disposable {
 		nextEntry: IModifiedFileEntry,
 		previousEntry: IModifiedFileEntry,
 		deletedCellDecorator: INotebookDeletedCellDecorator,
-		@IEditorService private readonly _editorService: IEditorService,
+		@IEditorService _editorService: IEditorService,
 		@IInstantiationService instaService: IInstantiationService,
 	) {
 		super();
@@ -106,7 +105,6 @@ export class NotebookChatActionsOverlay extends Disposable {
 			},
 			menuOptions: { renderShortTitle: true },
 			actionViewItemProvider: (action, options) => {
-				const that = this;
 
 				if (action.id === navigationBearingFakeActionId) {
 					return new class extends ActionViewItem {
@@ -137,15 +135,7 @@ export class NotebookChatActionsOverlay extends Disposable {
 								if (entry === nextEntry) {
 									return;
 								}
-								const change = nextEntry.diffInfo.get().changes.at(0);
-								return that._editorService.openEditor({
-									resource: nextEntry.modifiedURI,
-									options: {
-										selection: change && Range.fromPositions({ lineNumber: change.original.startLineNumber, column: 1 }),
-										revealIfOpened: false,
-										revealIfVisible: false,
-									}
-								}, ACTIVE_GROUP);
+
 							}));
 
 							this._reveal.value = store;
@@ -319,12 +309,10 @@ class NextPreviousChangeActionRunner extends ActionRunner {
 			return;
 		}
 		// For now just go to next/previous file.
-		const change = this.next.diffInfo.get().changes.at(0);
 		this.focusedDiff.set(undefined, undefined);
 		await this.editorService.openEditor({
 			resource: this.next.modifiedURI,
 			options: {
-				selection: change && Range.fromPositions({ lineNumber: change.original.startLineNumber, column: 1 }),
 				revealIfOpened: false,
 				revealIfVisible: false,
 			}


### PR DESCRIPTION
fyi @DonJayamanne this removes (w/o replacement) usages from the deprecated notebook overlay