### PR TITLE
more work on `AbstractChatEditingModifiedFileEntry` 

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingModifiedDocumentEntry.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingModifiedDocumentEntry.ts
@@ -3,9 +3,11 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { assert } from '../../../../../base/common/assert.js';
 import { RunOnceScheduler } from '../../../../../base/common/async.js';
 import { IReference, toDisposable } from '../../../../../base/common/lifecycle.js';
 import { observableValue, IObservable, ITransaction, autorun, transaction } from '../../../../../base/common/observable.js';
+import { isEqual } from '../../../../../base/common/resources.js';
 import { themeColorFromId } from '../../../../../base/common/themables.js';
 import { assertType } from '../../../../../base/common/types.js';
 import { URI } from '../../../../../base/common/uri.js';
@@ -35,6 +37,7 @@ import { IUndoRedoService } from '../../../../../platform/undoRedo/common/undoRe
 import { SaveReason, IEditorPane } from '../../../../common/editor.js';
 import { IFilesConfigurationService } from '../../../../services/filesConfiguration/common/filesConfigurationService.js';
 import { IResolvedTextFileEditorModel, stringToSnapshot } from '../../../../services/textfile/common/textfiles.js';
+import { ICellEditOperation } from '../../../notebook/common/notebookCommon.js';
 import { IModifiedFileEntry, ChatEditKind, WorkingSetEntryState, IModifiedFileEntryEditorIntegration } from '../../common/chatEditingService.js';
 import { IChatResponseModel } from '../../common/chatModel.js';
 import { IChatService } from '../../common/chatService.js';
@@ -66,12 +69,11 @@ export class ChatEditingModifiedDocumentEntry extends AbstractChatEditingModifie
 		}
 	});
 
+	readonly initialContent: string;
 
 	private readonly docSnapshot: ITextModel;
-	readonly initialContent: string;
 	private readonly doc: ITextModel;
-	private readonly docFileEditorModel: IResolvedTextFileEditorModel;
-	private _allEditsAreFromUs: boolean = true;
+	readonly docFileEditorModel: IResolvedTextFileEditorModel;
 
 	get originalModel(): ITextModel {
 		return this.docSnapshot;
@@ -84,6 +86,7 @@ export class ChatEditingModifiedDocumentEntry extends AbstractChatEditingModifie
 	private _isFirstEditAfterStartOrSnapshot: boolean = true;
 	private _edit: OffsetEdit = OffsetEdit.empty;
 	private _isEditFromUs: boolean = false;
+	private _allEditsAreFromUs: boolean = true;
 	private _diffOperation: Promise<any> | undefined;
 	private _diffOperationIds: number = 0;
 
@@ -154,8 +157,6 @@ export class ChatEditingModifiedDocumentEntry extends AbstractChatEditingModifie
 
 		this._register(this.doc.onDidChangeContent(e => this._mirrorEdits(e)));
 
-
-
 		this._register(toDisposable(() => {
 			this._clearCurrentEditLineDecoration();
 		}));
@@ -203,7 +204,7 @@ export class ChatEditingModifiedDocumentEntry extends AbstractChatEditingModifie
 		this._updateDiffInfoSeq();
 	}
 
-	resetToInitialValue() {
+	resetToInitialContent() {
 		this._setDocValue(this.initialContent);
 	}
 
@@ -271,7 +272,10 @@ export class ChatEditingModifiedDocumentEntry extends AbstractChatEditingModifie
 		}
 	}
 
-	acceptAgentEdits(textEdits: TextEdit[], isLastEdits: boolean, responseModel: IChatResponseModel): void {
+	acceptAgentEdits(resource: URI, textEdits: (TextEdit | ICellEditOperation)[], isLastEdits: boolean, responseModel: IChatResponseModel): void {
+
+		assertType(textEdits.every(TextEdit.isTextEdit), 'INVALID args, can only handle text edits');
+		assert(isEqual(resource, this.modifiedURI), ' INVALID args, can only edit THIS document');
 
 		// push stack element for the first edit
 		if (this._isFirstEditAfterStartOrSnapshot) {

--- a/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingModifiedFileEntry.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingModifiedFileEntry.ts
@@ -10,6 +10,7 @@ import { clamp } from '../../../../../base/common/numbers.js';
 import { autorun, derived, IObservable, ITransaction, observableValue } from '../../../../../base/common/observable.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { OffsetEdit } from '../../../../../editor/common/core/offsetEdit.js';
+import { TextEdit } from '../../../../../editor/common/languages.js';
 import { localize } from '../../../../../nls.js';
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 import { IFileService } from '../../../../../platform/files/common/files.js';
@@ -18,6 +19,7 @@ import { observableConfigValue } from '../../../../../platform/observable/common
 import { editorBackground, registerColor, transparent } from '../../../../../platform/theme/common/colorRegistry.js';
 import { IEditorPane } from '../../../../common/editor.js';
 import { IFilesConfigurationService } from '../../../../services/filesConfiguration/common/filesConfigurationService.js';
+import { ICellEditOperation } from '../../../notebook/common/notebookCommon.js';
 import { IChatAgentResult } from '../../common/chatAgents.js';
 import { ChatEditKind, IModifiedFileEntry, IModifiedFileEntryEditorIntegration, WorkingSetEntryState } from '../../common/chatEditingService.js';
 import { IChatResponseModel } from '../../common/chatModel.js';
@@ -223,6 +225,8 @@ export abstract class AbstractChatEditingModifiedFileEntry extends Disposable im
 		this._autoAcceptCtrl.get()?.cancel();
 	}
 
+	abstract acceptAgentEdits(uri: URI, edits: (TextEdit | ICellEditOperation)[], isLastEdits: boolean, responseModel: IChatResponseModel): void;
+
 	async acceptStreamingEditsEnd(tx: ITransaction) {
 		this._resetEditsState(tx);
 
@@ -259,6 +263,20 @@ export abstract class AbstractChatEditingModifiedFileEntry extends Disposable im
 		this._isCurrentlyBeingModifiedByObs.set(undefined, tx);
 		this._rewriteRatioObs.set(0, tx);
 	}
+
+	// --- snapshot
+
+	abstract createSnapshot(requestId: string | undefined, undoStop: string | undefined): ISnapshotEntry;
+
+	abstract equalsSnapshot(snapshot: ISnapshotEntry | undefined): boolean;
+
+	abstract restoreFromSnapshot(snapshot: ISnapshotEntry): void;
+
+	// --- inital content
+
+	abstract resetToInitialContent(): void;
+
+	abstract initialContent: string;
 }
 
 export interface IModifiedEntryTelemetryInfo {

--- a/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingModifiedNotebookEntry.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingModifiedNotebookEntry.ts
@@ -3,53 +3,63 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { IReference } from '../../../../../base/common/lifecycle.js';
-import { ITransaction } from '../../../../../base/common/observable.js';
-import { ILanguageService } from '../../../../../editor/common/languages/language.js';
-import { IEditorWorkerService } from '../../../../../editor/common/services/editorWorker.js';
-import { IModelService } from '../../../../../editor/common/services/model.js';
-import { IResolvedTextEditorModel, ITextModelService } from '../../../../../editor/common/services/resolverService.js';
-import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
-import { IFileService } from '../../../../../platform/files/common/files.js';
-import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
-import { IUndoRedoService } from '../../../../../platform/undoRedo/common/undoRedo.js';
-import { SaveReason } from '../../../../common/editor.js';
-import { IFilesConfigurationService } from '../../../../services/filesConfiguration/common/filesConfigurationService.js';
-import { IResolvedTextFileEditorModel } from '../../../../services/textfile/common/textfiles.js';
-import { ChatEditKind } from '../../common/chatEditingService.js';
-import { IChatService } from '../../common/chatService.js';
-import { IModifiedEntryTelemetryInfo } from './chatEditingModifiedFileEntry.js';
-import { ChatEditingModifiedDocumentEntry } from './chatEditingModifiedDocumentEntry.js';
+import { assert } from '../../../../../base/common/assert.js';
+import { Schemas } from '../../../../../base/common/network.js';
+import { ITransaction, IObservable, constObservable } from '../../../../../base/common/observable.js';
+import { isEqual } from '../../../../../base/common/resources.js';
+import { assertType } from '../../../../../base/common/types.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { TextEdit } from '../../../../../editor/common/languages.js';
+import { IEditorPane } from '../../../../common/editor.js';
+import { ICellEditOperation } from '../../../notebook/common/notebookCommon.js';
+import { IModifiedFileEntryEditorIntegration } from '../../common/chatEditingService.js';
+import { IChatResponseModel } from '../../common/chatModel.js';
+import { AbstractChatEditingModifiedFileEntry, ISnapshotEntry } from './chatEditingModifiedFileEntry.js';
 
-export class ChatEditingModifiedNotebookEntry extends ChatEditingModifiedDocumentEntry {
-	private readonly resolveTextFileEditorModel: IResolvedTextFileEditorModel;
+export class ChatEditingModifiedNotebookEntry extends AbstractChatEditingModifiedFileEntry {
 
-	constructor(
-		resourceRef: IReference<IResolvedTextEditorModel>,
-		_multiDiffEntryDelegate: { collapse: (transaction: ITransaction | undefined) => void },
-		_telemetryInfo: IModifiedEntryTelemetryInfo,
-		kind: ChatEditKind,
-		initialContent: string | undefined,
-		@IModelService modelService: IModelService,
-		@ITextModelService textModelService: ITextModelService,
-		@ILanguageService languageService: ILanguageService,
-		@IChatService _chatService: IChatService,
-		@IEditorWorkerService _editorWorkerService: IEditorWorkerService,
-		@IUndoRedoService _undoRedoService: IUndoRedoService,
-		@IFileService _fileService: IFileService,
-		@IConfigurationService configService: IConfigurationService,
-		@IFilesConfigurationService fileConfigService: IFilesConfigurationService,
-		@IInstantiationService instaService: IInstantiationService
-	) {
-		super(resourceRef, _multiDiffEntryDelegate, _telemetryInfo, kind, initialContent, modelService, textModelService, languageService, configService, fileConfigService, _chatService, _editorWorkerService, _undoRedoService, _fileService, instaService);
-		this.resolveTextFileEditorModel = resourceRef.object as IResolvedTextFileEditorModel;
+	override originalURI: URI = URI.parse('todo://todo/todo');
+
+	override initialContent: string = 'JSON.stringify(NotebookData)';
+
+	override changesCount: IObservable<number> = constObservable(Number.MAX_SAFE_INTEGER);
+
+	protected override _doAccept(tx: ITransaction | undefined): Promise<void> {
+		throw new Error('Method not implemented.');
 	}
 
-	async saveMirrorDocument(): Promise<void> {
-		await this.resolveTextFileEditorModel.save({ reason: SaveReason.EXPLICIT, ignoreModifiedSince: true });
+	protected override _doReject(tx: ITransaction | undefined): Promise<void> {
+		throw new Error('Method not implemented.');
 	}
 
-	async revertMirrorDocument(): Promise<void> {
-		await this.resolveTextFileEditorModel.revert({ soft: true });
+	protected override _createEditorIntegration(editor: IEditorPane): IModifiedFileEntryEditorIntegration {
+		throw new Error('Method not implemented.');
+	}
+
+	override acceptAgentEdits(resource: URI, edits: (TextEdit | ICellEditOperation)[], isLastEdits: boolean, responseModel: IChatResponseModel): void {
+
+		const isCellUri = resource.scheme === Schemas.vscodeNotebookCell;
+		assert(isCellUri || isEqual(resource, this.modifiedURI));
+		assertType(edits.every(edit => !TextEdit.isTextEdit(edit) || isCellUri));
+
+		// needs to handle notebook and textual cell edits
+
+		throw new Error('Method not implemented.');
+	}
+
+	override createSnapshot(requestId: string | undefined, undoStop: string | undefined): ISnapshotEntry {
+		throw new Error('Method not implemented.');
+	}
+
+	override equalsSnapshot(snapshot: ISnapshotEntry | undefined): boolean {
+		throw new Error('Method not implemented.');
+	}
+
+	override restoreFromSnapshot(snapshot: ISnapshotEntry): void {
+		throw new Error('Method not implemented.');
+	}
+
+	override resetToInitialContent(): void {
+		throw new Error('Method not implemented.');
 	}
 }

--- a/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingTextModelContentProviders.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingTextModelContentProviders.ts
@@ -24,8 +24,8 @@ export class ChatEditingTextModelContentProvider implements ITextModelContentPro
 	}
 
 	constructor(
+		private readonly _chatEditingService: IChatEditingService,
 		@IModelService private readonly _modelService: IModelService,
-		@IChatEditingService private readonly _chatEditingService: IChatEditingService
 	) { }
 
 	async provideTextContent(resource: URI): Promise<ITextModel | null> {
@@ -59,8 +59,8 @@ export class ChatEditingSnapshotTextModelContentProvider implements ITextModelCo
 	}
 
 	constructor(
+		private readonly _chatEditingService: IChatEditingService,
 		@IModelService private readonly _modelService: IModelService,
-		@IChatEditingService private readonly _chatEditingService: IChatEditingService
 	) { }
 
 	async provideTextContent(resource: URI): Promise<ITextModel | null> {

--- a/src/vs/workbench/contrib/chat/test/browser/chatEditingService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/chatEditingService.test.ts
@@ -1,0 +1,103 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { workbenchInstantiationService } from '../../../../test/browser/workbenchTestServices.js';
+import { ChatEditingService } from '../../browser/chatEditing/chatEditingServiceImpl.js';
+import { Disposable, DisposableStore, IDisposable } from '../../../../../base/common/lifecycle.js';
+import { ServiceCollection } from '../../../../../platform/instantiation/common/serviceCollection.js';
+import { IMultiDiffSourceResolver, IMultiDiffSourceResolverService } from '../../../multiDiffEditor/browser/multiDiffSourceResolverService.js';
+import { mock } from '../../../../../base/test/common/mock.js';
+import { IChatService } from '../../common/chatService.js';
+import { SyncDescriptor } from '../../../../../platform/instantiation/common/descriptors.js';
+import { ChatService } from '../../common/chatServiceImpl.js';
+import { IChatEditingService } from '../../common/chatEditingService.js';
+import { assertThrowsAsync, ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { IChatVariablesService } from '../../common/chatVariables.js';
+import { MockChatVariablesService } from '../common/mockChatVariables.js';
+import { ChatAgentLocation, ChatAgentService, IChatAgentImplementation, IChatAgentService } from '../../common/chatAgents.js';
+import { IChatSlashCommandService } from '../../common/chatSlashCommands.js';
+import { IWorkbenchAssignmentService } from '../../../../services/assignment/common/assignmentService.js';
+import { NullWorkbenchAssignmentService } from '../../../../services/assignment/test/common/nullAssignmentService.js';
+import { CancellationToken } from '../../../../../base/common/cancellation.js';
+import { nullExtensionDescription } from '../../../../services/extensions/common/extensions.js';
+
+function getAgentData(id: string) {
+	return {
+		name: id,
+		id: id,
+		extensionId: nullExtensionDescription.identifier,
+		extensionPublisherId: '',
+		publisherDisplayName: '',
+		extensionDisplayName: '',
+		locations: [ChatAgentLocation.Panel],
+		metadata: {},
+		slashCommands: [],
+		disambiguation: [],
+	};
+}
+
+suite('ChatEditingService', function () {
+
+	const store = new DisposableStore();
+	let editingService: ChatEditingService;
+	let chatService: IChatService;
+
+	setup(function () {
+		const collection = new ServiceCollection();
+		collection.set(IWorkbenchAssignmentService, new NullWorkbenchAssignmentService());
+		collection.set(IChatAgentService, new SyncDescriptor(ChatAgentService));
+		collection.set(IChatVariablesService, new MockChatVariablesService());
+		collection.set(IChatSlashCommandService, new class extends mock<IChatSlashCommandService>() { });
+		collection.set(IChatEditingService, new SyncDescriptor(ChatEditingService));
+		collection.set(IChatService, new SyncDescriptor(ChatService));
+		collection.set(IMultiDiffSourceResolverService, new class extends mock<IMultiDiffSourceResolverService>() {
+			override registerResolver(_resolver: IMultiDiffSourceResolver): IDisposable {
+				return Disposable.None;
+			}
+		});
+		const insta = store.add(store.add(workbenchInstantiationService(undefined, store)).createChild(collection));
+		const value = insta.get(IChatEditingService);
+		assert.ok(value instanceof ChatEditingService);
+		editingService = value;
+
+		chatService = insta.get(IChatService);
+
+		const chatAgentService = insta.get(IChatAgentService);
+
+		const agent: IChatAgentImplementation = {
+			async invoke(request, progress, history, token) {
+				return {};
+			},
+		};
+		store.add(chatAgentService.registerAgent('testAgent', { ...getAgentData('testAgent'), isDefault: true }));
+		store.add(chatAgentService.registerAgentImplementation('testAgent', agent));
+	});
+
+	teardown(() => {
+		store.clear();
+	});
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('create session', async function () {
+		assert.ok(editingService);
+
+		const model = chatService.startSession(ChatAgentLocation.EditingSession, CancellationToken.None);
+		const session = await editingService.createEditingSession(model.sessionId, true);
+
+		assert.strictEqual(session.chatSessionId, model.sessionId);
+		assert.strictEqual(session.isGlobalEditingSession, true);
+
+		await assertThrowsAsync(async () => {
+			// DUPE not allowed
+			await editingService.createEditingSession(model.sessionId);
+		});
+
+		session.dispose();
+		model.dispose();
+	});
+
+});


### PR DESCRIPTION
* `ChatEditingSession` should work with `AbstractChatEditingModifiedFileEntry` unless for when it creates entries
* beginning of chat editing service test
* replace `ChatEditingModifiedNotebookEntry` with new implementation stub