### PR TITLE
Create Enhancing Inline Diff Selection in VSCode

### DIFF
--- a/Enhancing Inline Diff Selection in VSCode
+++ b/Enhancing Inline Diff Selection in VSCode
@@ -1,0 +1,1 @@
+The issue at hand is the inability to select text from deleted lines in the inline diff view of Visual Studio Code (VSCode) version 1.3.0-insider on OS X 10.11. Users can select deleted lines in the side-by-side view, but not in the inline mode, which hampers the ability to restore or revert small pieces of code.


### PR DESCRIPTION
To address the feature request for enabling text selection from deleted lines in the inline diff view of VSCode, a pull request (PR) can be proposed. The solution involves modifying the diff editor's rendering logic to allow selection of red-highlighted lines. Below is a conceptual outline of the changes needed:

Identify the Diff Rendering Logic: Locate the component responsible for rendering the inline diff view.
Modify Selection Handling: Update the event listeners to include selection capabilities for deleted lines. This may involve adjusting CSS styles to ensure that the deleted lines are selectable.
Testing: Implement unit tests to verify that the selection functionality works as intended without introducing regressions.
Here is a simplified code snippet to illustrate the concept:
.diff-editor {
  &.deleted {
    user-select: text; // Allow text selection for deleted lines
    background-color: #ffcccc; // Maintain visibility
  }
}

