### PR TITLE
indicate how to navigate toolbar in editor's a11y help dialog

### DIFF
--- a/src/vs/editor/common/standaloneStrings.ts
+++ b/src/vs/editor/common/standaloneStrings.ts
@@ -13,6 +13,7 @@ export namespace AccessibilityHelpNLS {
 	export const readonlyEditor = nls.localize("readonlyEditor", "You are in a read-only code editor.");
 	export const editableEditor = nls.localize("editableEditor", "You are in a code editor.");
 	export const activeEditorState = nls.localize("activeEditorState", "Get information about the active editor such as Modified, Problems, and more by setting activeEditorState as a part of the window.title setting.");
+	export const toolbar = nls.localize("toolbar", "Around the workbench, when the screen reader announces you've landed in a toolbar, use narrow keys to navigate between the toolbar's actions.");
 	export const changeConfigToOnMac = nls.localize("changeConfigToOnMac", "Configure the application to be optimized for usage with a Screen Reader (Command+E).");
 	export const changeConfigToOnWinLinux = nls.localize("changeConfigToOnWinLinux", "Configure the application to be optimized for usage with a Screen Reader (Control+E).");
 	export const auto_on = nls.localize("auto_on", "The application is configured to be optimized for usage with a Screen Reader.");

--- a/src/vs/workbench/contrib/accessibility/browser/editorAccessibilityHelp.ts
+++ b/src/vs/workbench/contrib/accessibility/browser/editorAccessibilityHelp.ts
@@ -73,6 +73,7 @@ class EditorAccessibilityHelpProvider extends Disposable implements IAccessibleV
 			}
 		}
 		content.push(AccessibilityHelpNLS.activeEditorState);
+		content.push(AccessibilityHelpNLS.toolbar);
 
 		const chatEditInfo = getChatEditInfo(this._keybindingService, this._contextKeyService, this._editor);
 		if (chatEditInfo) {


### PR DESCRIPTION
It was brought to my attention that users know how to interact with native elements like checkboxes, but might not know that they can use arrow keys to explore toolbar elements. 

fix #239995