### PR TITLE
feat: add more match types for new Settings search

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/preferencesSearch.ts
+++ b/src/vs/workbench/contrib/preferences/browser/preferencesSearch.ts
@@ -233,6 +233,7 @@ export class SettingMatches {
 				}
 			}
 		} else {
+			// Fall back to the old algorithm.
 			const keyIdMatches = matchesContiguousSubString(searchString, setting.key);
 			if (keyIdMatches?.length) {
 				// Handles cases such as "editor.formatonpaste" where the user tries searching for the ID.

--- a/src/vs/workbench/contrib/preferences/browser/preferencesSearch.ts
+++ b/src/vs/workbench/contrib/preferences/browser/preferencesSearch.ts
@@ -122,7 +122,9 @@ export class LocalSearchProvider implements ISearchProvider {
 				null;
 		};
 
-		const filterMatches = preferencesModel.filterSettings(this._filter, this.getGroupFilter(this._filter), settingMatcher);
+		const filterMatches = preferencesModel
+			.filterSettings(this._filter, this.getGroupFilter(this._filter), settingMatcher)
+			.filter(match => match.matchType !== SettingMatchType.None);
 		const exactMatch = filterMatches.find(m => m.score === LocalSearchProvider.EXACT_MATCH_SCORE);
 		if (exactMatch) {
 			return Promise.resolve({
@@ -207,6 +209,10 @@ export class SettingMatches {
 		if (this.useNewKeyMatchingSearch) {
 			if (keyMatchingWords.size === queryWords.size) {
 				this.matchType |= SettingMatchType.AllWordsKeyMatch;
+			} else if (keyMatchingWords.size >= 2) {
+				// At least two words matched.
+				this.matchType |= SettingMatchType.KeyMatch;
+				this.keyMatchScore = keyMatchingWords.size;
 			}
 		} else {
 			// Fall back to the old algorithm.

--- a/src/vs/workbench/contrib/preferences/browser/preferencesSearch.ts
+++ b/src/vs/workbench/contrib/preferences/browser/preferencesSearch.ts
@@ -207,8 +207,6 @@ export class SettingMatches {
 		if (this.useNewKeyMatchingSearch) {
 			if (keyMatchingWords.size === queryWords.size) {
 				this.matchType |= SettingMatchType.AllWordsKeyMatch;
-				// Penalize longer setting names.
-				this.keyMatchScore = 1 / setting.key.length;
 			}
 		} else {
 			// Fall back to the old algorithm.
@@ -222,7 +220,7 @@ export class SettingMatches {
 			// Reduce the query and the key to get rid of punctuation and spaces.
 			const queryNoPunctuation = searchString.replace(/[^a-zA-Z0-9]/g, '');
 			const keyNoPunctuation = setting.key.replace(/[^a-zA-Z0-9]/g, '');
-			// Does a contiguous search, and does a non-contiguous search if that fails.
+			// Do a contiguous search, and do a non-contiguous search if that fails.
 			const keyIdMatches = matchesContiguousSubString(queryNoPunctuation, keyNoPunctuation);
 			if (keyIdMatches?.length) {
 				keyMatchingWords.set(setting.key, keyIdMatches.map(match => this.toKeyRange(setting, match)));

--- a/src/vs/workbench/services/preferences/common/preferences.ts
+++ b/src/vs/workbench/services/preferences/common/preferences.ts
@@ -139,7 +139,9 @@ export enum SettingMatchType {
 	RemoteMatch = 1 << 1,
 	DescriptionOrValueMatch = 1 << 2,
 	KeyMatch = 1 << 3,
-	KeyIdMatch = 1 << 4,
+	NonContiguousKeyIdMatch = 1 << 4,
+	ContiguousKeyIdMatch = 1 << 5,
+	AllWordsKeyMatch = 1 << 6,
 }
 
 export interface ISettingMatch {


### PR DESCRIPTION
Fixes #221535
Fixes #238933

This PR rewrites the new Settings search to use more match types instead of numeric scores. It also adds a significant change to `searchModel()` to only return results of the top match type.

![stickyscrolle in Settings editor only showing three settings](https://github.com/user-attachments/assets/13696acb-1cb0-417e-aa07-f749f7d55d6f)
![editor fomonpast in Settings editor showing a single setting](https://github.com/user-attachments/assets/1c5a3019-36fd-48b6-9ebb-0b36532e8528)
