### PR TITLE
handle folder references in prompt files

### DIFF
--- a/src/vs/workbench/contrib/chat/common/promptFileReferenceErrors.ts
+++ b/src/vs/workbench/contrib/chat/common/promptFileReferenceErrors.ts
@@ -84,10 +84,29 @@ export class FileOpenFailed extends FailedToResolveContentsStream {
 		super(
 			uri,
 			originalError,
-			`Failed to open file '${uri.toString()}': ${originalError}.`,
+			`Failed to open file '${uri.fsPath}': ${originalError}.`,
 		);
 	}
 }
+
+// /**
+//  * TODO: @legomushroom
+//  */
+// export class FolderReference extends FailedToResolveContentsStream {
+// 	public override errorType = 'FolderReferenceError';
+
+// 	constructor(
+// 		uri: URI,
+// 		originalError: unknown,
+// 	) {
+// 		super(
+// 			uri,
+// 			originalError,
+// 			`Entity at '${uri.fsPath}' is a folder.`,
+// 		);
+// 	}
+// }
+
 
 /**
  * Error that reflects the case when attempt resolve nested file

--- a/src/vs/workbench/contrib/chat/common/promptFileReferenceErrors.ts
+++ b/src/vs/workbench/contrib/chat/common/promptFileReferenceErrors.ts
@@ -74,8 +74,8 @@ export abstract class ResolveError extends ParseError {
 /**
  * Error that reflects the case when attempt to open target file fails.
  */
-export class FileOpenFailed extends FailedToResolveContentsStream {
-	public override errorType = 'FileOpenError';
+export class OpenFailed extends FailedToResolveContentsStream {
+	public override errorType = 'OpenError';
 
 	constructor(
 		uri: URI,
@@ -84,29 +84,10 @@ export class FileOpenFailed extends FailedToResolveContentsStream {
 		super(
 			uri,
 			originalError,
-			`Failed to open file '${uri.fsPath}': ${originalError}.`,
+			`Failed to open '${uri.fsPath}': ${originalError}.`,
 		);
 	}
 }
-
-// /**
-//  * TODO: @legomushroom
-//  */
-// export class FolderReference extends FailedToResolveContentsStream {
-// 	public override errorType = 'FolderReferenceError';
-
-// 	constructor(
-// 		uri: URI,
-// 		originalError: unknown,
-// 	) {
-// 		super(
-// 			uri,
-// 			originalError,
-// 			`Entity at '${uri.fsPath}' is a folder.`,
-// 		);
-// 	}
-// }
-
 
 /**
  * Error that reflects the case when attempt resolve nested file
@@ -169,11 +150,10 @@ export class RecursiveReference extends ResolveError {
 }
 
 /**
- * Error that reflects the case when resource URI does not point to
- * a prompt snippet file, hence was not attempted to be resolved.
+ * Error for the case when a resource URI doesn't point to a prompt file.
  */
-export class NonPromptSnippetFile extends ResolveError {
-	public override errorType = 'NonPromptSnippetFileError';
+export class NotPromptFile extends ResolveError {
+	public override errorType = 'NotPromptFileError';
 
 	constructor(
 		uri: URI,
@@ -184,7 +164,7 @@ export class NonPromptSnippetFile extends ResolveError {
 
 		super(
 			uri,
-			`Resource at ${uri.path} is not a prompt snippet file${suffix}`,
+			`Resource at ${uri.path} is not a prompt file${suffix}`,
 		);
 	}
 }

--- a/src/vs/workbench/contrib/chat/common/promptFileReferenceErrors.ts
+++ b/src/vs/workbench/contrib/chat/common/promptFileReferenceErrors.ts
@@ -168,3 +168,23 @@ export class NotPromptFile extends ResolveError {
 		);
 	}
 }
+
+/**
+ * Error for the case when a resource URI points to a folder.
+ */
+export class FolderReference extends NotPromptFile {
+	public override errorType = 'FolderReferenceError';
+
+	constructor(
+		uri: URI,
+		message: string = '',
+	) {
+
+		const suffix = message ? `: ${message}` : '';
+
+		super(
+			uri,
+			`Entity at '${uri.path}' is a folder${suffix}`,
+		);
+	}
+}

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/contentProviders/filePromptContentsProvider.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/contentProviders/filePromptContentsProvider.ts
@@ -11,7 +11,7 @@ import { CancellationError } from '../../../../../../base/common/errors.js';
 import { PromptContentsProviderBase } from './promptContentsProviderBase.js';
 import { VSBufferReadableStream } from '../../../../../../base/common/buffer.js';
 import { CancellationToken } from '../../../../../../base/common/cancellation.js';
-import { FileOpenFailed, NonPromptSnippetFile, ParseError } from '../../promptFileReferenceErrors.js';
+import { OpenFailed, NotPromptFile, ParseError } from '../../promptFileReferenceErrors.js';
 import { FileChangesEvent, FileChangeType, IFileService } from '../../../../../../platform/files/common/files.js';
 
 /**
@@ -69,7 +69,7 @@ export class FilePromptContentProvider extends PromptContentsProviderBase<FileCh
 			const info = await this.fileService.resolve(this.uri);
 			assert(
 				info.isFile,
-				new NonPromptSnippetFile(this.uri),
+				new NotPromptFile(this.uri),
 			);
 
 			fileStream = await this.fileService.readFileStream(this.uri);
@@ -78,12 +78,12 @@ export class FilePromptContentProvider extends PromptContentsProviderBase<FileCh
 				throw error;
 			}
 
-			throw new FileOpenFailed(this.uri, error);
+			throw new OpenFailed(this.uri, error);
 		}
 
 		assertDefined(
 			fileStream,
-			new FileOpenFailed(this.uri, 'Failed to open file stream.'),
+			new OpenFailed(this.uri, 'Failed to open file stream.'),
 		);
 
 		// after the promise above complete, this object can be already disposed or
@@ -96,7 +96,7 @@ export class FilePromptContentProvider extends PromptContentsProviderBase<FileCh
 
 		// if URI doesn't point to a prompt snippet file, don't try to resolve it
 		if (!this.isPromptSnippet()) {
-			throw new NonPromptSnippetFile(this.uri);
+			throw new NotPromptFile(this.uri);
 		}
 
 		return fileStream.value;

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/contentProviders/filePromptContentsProvider.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/contentProviders/filePromptContentsProvider.ts
@@ -11,7 +11,7 @@ import { CancellationError } from '../../../../../../base/common/errors.js';
 import { PromptContentsProviderBase } from './promptContentsProviderBase.js';
 import { VSBufferReadableStream } from '../../../../../../base/common/buffer.js';
 import { CancellationToken } from '../../../../../../base/common/cancellation.js';
-import { OpenFailed, NotPromptFile, ParseError } from '../../promptFileReferenceErrors.js';
+import { OpenFailed, NotPromptFile, ParseError, FolderReference } from '../../promptFileReferenceErrors.js';
 import { FileChangesEvent, FileChangeType, IFileService } from '../../../../../../platform/files/common/files.js';
 
 /**
@@ -67,9 +67,16 @@ export class FilePromptContentProvider extends PromptContentsProviderBase<FileCh
 			// ensure that the referenced URI points to a file before
 			// trying to get a stream for its contents
 			const info = await this.fileService.resolve(this.uri);
+
+			// validate that the cancellation was not yet requested
+			assert(
+				!cancellationToken?.isCancellationRequested,
+				new CancellationError(),
+			);
+
 			assert(
 				info.isFile,
-				new NotPromptFile(this.uri),
+				new FolderReference(this.uri),
 			);
 
 			fileStream = await this.fileService.readFileStream(this.uri);

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/languageFeatures/promptLinkProvider.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/languageFeatures/promptLinkProvider.ts
@@ -6,24 +6,24 @@
 import { LANGUAGE_SELECTOR } from '../constants.js';
 import { IPromptsService } from '../service/types.js';
 import { assert } from '../../../../../../base/common/assert.js';
+import { FolderReference, NotPromptFile } from '../../promptFileReferenceErrors.js';
 import { ITextModel } from '../../../../../../editor/common/model.js';
 import { assertDefined } from '../../../../../../base/common/types.js';
 import { Disposable } from '../../../../../../base/common/lifecycle.js';
-import { NotPromptFile } from '../../promptFileReferenceErrors.js';
 import { CancellationError } from '../../../../../../base/common/errors.js';
 import { CancellationToken } from '../../../../../../base/common/cancellation.js';
 import { Registry } from '../../../../../../platform/registry/common/platform.js';
 import { LifecyclePhase } from '../../../../../services/lifecycle/common/lifecycle.js';
 import { ILink, ILinksList, LinkProvider } from '../../../../../../editor/common/languages.js';
+import { IWorkbenchContributionsRegistry, Extensions } from '../../../../../common/contributions.js';
 import { ILanguageFeaturesService } from '../../../../../../editor/common/services/languageFeatures.js';
-import { IWorkbenchContributionsRegistry, Extensions as WorkbenchExtensions } from '../../../../../common/contributions.js';
 
 /**
  * Provides link references for prompt files.
  */
 export class PromptLinkProvider extends Disposable implements LinkProvider {
 	constructor(
-		@IPromptsService private readonly promptSyntaxService: IPromptsService,
+		@IPromptsService private readonly promptsService: IPromptsService,
 		@ILanguageFeaturesService private readonly languageService: ILanguageFeaturesService,
 	) {
 		super();
@@ -43,7 +43,7 @@ export class PromptLinkProvider extends Disposable implements LinkProvider {
 			new CancellationError(),
 		);
 
-		const parser = this.promptSyntaxService.getSyntaxParserFor(model);
+		const parser = this.promptsService.getSyntaxParserFor(model);
 		assert(
 			!parser.disposed,
 			'Prompt parser must not be disposed.',
@@ -69,11 +69,15 @@ export class PromptLinkProvider extends Disposable implements LinkProvider {
 					return true;
 				}
 
-				// TODO: @legomushroom - add the "folder" error
+				// don't provide links for folder references
+				if (errorCondition instanceof FolderReference) {
+					return false;
+				}
+
 				return errorCondition instanceof NotPromptFile;
 			})
 			.map((reference) => {
-				const { linkRange } = reference;
+				const { uri, linkRange } = reference;
 
 				// must always be true because of the filter above
 				assertDefined(
@@ -83,7 +87,7 @@ export class PromptLinkProvider extends Disposable implements LinkProvider {
 
 				return {
 					range: linkRange,
-					url: reference.uri,
+					url: uri,
 				};
 			});
 
@@ -94,5 +98,5 @@ export class PromptLinkProvider extends Disposable implements LinkProvider {
 }
 
 // register the provider as a workbench contribution
-Registry.as<IWorkbenchContributionsRegistry>(WorkbenchExtensions.Workbench)
+Registry.as<IWorkbenchContributionsRegistry>(Extensions.Workbench)
 	.registerWorkbenchContribution(PromptLinkProvider, LifecyclePhase.Eventually);

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/languageFeatures/promptLinkProvider.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/languageFeatures/promptLinkProvider.ts
@@ -9,7 +9,7 @@ import { assert } from '../../../../../../base/common/assert.js';
 import { ITextModel } from '../../../../../../editor/common/model.js';
 import { assertDefined } from '../../../../../../base/common/types.js';
 import { Disposable } from '../../../../../../base/common/lifecycle.js';
-import { NonPromptSnippetFile } from '../../promptFileReferenceErrors.js';
+import { NotPromptFile } from '../../promptFileReferenceErrors.js';
 import { CancellationError } from '../../../../../../base/common/errors.js';
 import { CancellationToken } from '../../../../../../base/common/cancellation.js';
 import { Registry } from '../../../../../../platform/registry/common/platform.js';
@@ -69,7 +69,8 @@ export class PromptLinkProvider extends Disposable implements LinkProvider {
 					return true;
 				}
 
-				return errorCondition instanceof NonPromptSnippetFile;
+				// TODO: @legomushroom - add the "folder" error
+				return errorCondition instanceof NotPromptFile;
 			})
 			.map((reference) => {
 				const { linkRange } = reference;
@@ -79,7 +80,6 @@ export class PromptLinkProvider extends Disposable implements LinkProvider {
 					linkRange,
 					'Link range must be defined.',
 				);
-
 
 				return {
 					range: linkRange,

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/basePromptParser.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/basePromptParser.ts
@@ -23,7 +23,7 @@ import { ObservableDisposable } from '../../../../../../base/common/observableDi
 import { FilePromptContentProvider } from '../contentProviders/filePromptContentsProvider.js';
 import { IInstantiationService } from '../../../../../../platform/instantiation/common/instantiation.js';
 import { MarkdownLink } from '../../../../../../editor/common/codecs/markdownCodec/tokens/markdownLink.js';
-import { OpenFailed, NotPromptFile, RecursiveReference, ParseError, FailedToResolveContentsStream } from '../../promptFileReferenceErrors.js';
+import { OpenFailed, NotPromptFile, RecursiveReference, FolderReference, ParseError, FailedToResolveContentsStream } from '../../promptFileReferenceErrors.js';
 
 /**
  * Well-known localized error messages.
@@ -38,7 +38,7 @@ const errorMessages = {
 /**
  * Error conditions that may happen during the file reference resolution.
  */
-export type TErrorCondition = OpenFailed | RecursiveReference | NotPromptFile;
+export type TErrorCondition = OpenFailed | RecursiveReference | FolderReference | NotPromptFile;
 
 /**
  * Base prompt parser class that provides a common interface for all
@@ -376,7 +376,18 @@ export abstract class BasePromptParser<T extends IPromptContentsProvider> extend
 			.filter((reference) => {
 				const { errorCondition } = reference;
 
-				return !errorCondition || (errorCondition instanceof NotPromptFile);
+				// include all references without errors
+				if (!errorCondition) {
+					return true;
+				}
+
+				// filter out folder references from the list
+				if (errorCondition instanceof FolderReference) {
+					return false;
+				}
+
+				// include non-prompt file references
+				return (errorCondition instanceof NotPromptFile);
 			});
 	}
 

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/basePromptParser.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/basePromptParser.ts
@@ -23,7 +23,7 @@ import { ObservableDisposable } from '../../../../../../base/common/observableDi
 import { FilePromptContentProvider } from '../contentProviders/filePromptContentsProvider.js';
 import { IInstantiationService } from '../../../../../../platform/instantiation/common/instantiation.js';
 import { MarkdownLink } from '../../../../../../editor/common/codecs/markdownCodec/tokens/markdownLink.js';
-import { FileOpenFailed, NonPromptSnippetFile, RecursiveReference, ParseError, FailedToResolveContentsStream } from '../../promptFileReferenceErrors.js';
+import { OpenFailed, NotPromptFile, RecursiveReference, ParseError, FailedToResolveContentsStream } from '../../promptFileReferenceErrors.js';
 
 /**
  * Well-known localized error messages.
@@ -38,7 +38,7 @@ const errorMessages = {
 /**
  * Error conditions that may happen during the file reference resolution.
  */
-export type TErrorCondition = FileOpenFailed | RecursiveReference | NonPromptSnippetFile;
+export type TErrorCondition = OpenFailed | RecursiveReference | NotPromptFile;
 
 /**
  * Base prompt parser class that provides a common interface for all
@@ -376,7 +376,7 @@ export abstract class BasePromptParser<T extends IPromptContentsProvider> extend
 			.filter((reference) => {
 				const { errorCondition } = reference;
 
-				return !errorCondition || (errorCondition instanceof NonPromptSnippetFile);
+				return !errorCondition || (errorCondition instanceof NotPromptFile);
 			});
 	}
 
@@ -404,7 +404,7 @@ export abstract class BasePromptParser<T extends IPromptContentsProvider> extend
 			.filter((childReference) => {
 				const { errorCondition } = childReference;
 
-				return errorCondition && !(errorCondition instanceof NonPromptSnippetFile);
+				return errorCondition && !(errorCondition instanceof NotPromptFile);
 			})
 			// map to error condition objects
 			.map((childReference): ParseError => {
@@ -471,7 +471,7 @@ export abstract class BasePromptParser<T extends IPromptContentsProvider> extend
 	 * @returns Error message.
 	 */
 	protected getErrorMessage<TError extends ParseError>(error: TError): string {
-		if (error instanceof FileOpenFailed) {
+		if (error instanceof OpenFailed) {
 			return `${errorMessages.fileOpenFailed} '${error.uri.path}'.`;
 		}
 
@@ -598,7 +598,7 @@ export class PromptFileReference extends BasePromptParser<FilePromptContentProvi
 	 */
 	protected override getErrorMessage(error: ParseError): string {
 		// if failed to open a file, return approprivate message and the file path
-		if (error instanceof FileOpenFailed) {
+		if (error instanceof OpenFailed) {
 			return `${errorMessages.fileOpenFailed} '${error.uri.path}'.`;
 		}
 

--- a/src/vs/workbench/contrib/chat/test/common/promptSyntax/parsers/textModelPromptParser.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/promptSyntax/parsers/textModelPromptParser.test.ts
@@ -10,7 +10,7 @@ import { Schemas } from '../../../../../../../base/common/network.js';
 import { ExpectedReference } from '../testUtils/expectedReference.js';
 import { ITextModel } from '../../../../../../../editor/common/model.js';
 import { Disposable } from '../../../../../../../base/common/lifecycle.js';
-import { FileOpenFailed } from '../../../../common/promptFileReferenceErrors.js';
+import { OpenFailed } from '../../../../common/promptFileReferenceErrors.js';
 import { IFileService } from '../../../../../../../platform/files/common/files.js';
 import { randomBoolean } from '../../../../../../../base/test/common/testUtils.js';
 import { FileService } from '../../../../../../../platform/files/common/fileService.js';
@@ -143,7 +143,7 @@ suite('TextModelPromptParser', () => {
 				startLine: 1,
 				startColumn: 27,
 				pathStartColumn: 33,
-				childrenOrError: new FileOpenFailed(createURI('/abs/path/to/file.md'), 'File not found.'),
+				childrenOrError: new OpenFailed(createURI('/abs/path/to/file.md'), 'File not found.'),
 			}),
 			new ExpectedReference({
 				uri: createURI('/foo/folder/binary.file'),
@@ -152,7 +152,7 @@ suite('TextModelPromptParser', () => {
 				startLine: 7,
 				startColumn: 10,
 				pathStartColumn: 16,
-				childrenOrError: new FileOpenFailed(createURI('/foo/folder/binary.file'), 'File not found.'),
+				childrenOrError: new OpenFailed(createURI('/foo/folder/binary.file'), 'File not found.'),
 			}),
 			new ExpectedReference({
 				uri: createURI('/etc/hosts/random-file.txt'),
@@ -161,7 +161,7 @@ suite('TextModelPromptParser', () => {
 				startLine: 7,
 				startColumn: 81,
 				pathStartColumn: 91,
-				childrenOrError: new FileOpenFailed(createURI('/etc/hosts/random-file.txt'), 'File not found.'),
+				childrenOrError: new OpenFailed(createURI('/etc/hosts/random-file.txt'), 'File not found.'),
 			}),
 		]);
 	});
@@ -196,7 +196,7 @@ suite('TextModelPromptParser', () => {
 				startLine: 3,
 				startColumn: 43,
 				pathStartColumn: 55,
-				childrenOrError: new FileOpenFailed(createURI('/absolute/folder/and/a/foo-bar-baz/another-file.ts'), 'File not found.'),
+				childrenOrError: new OpenFailed(createURI('/absolute/folder/and/a/foo-bar-baz/another-file.ts'), 'File not found.'),
 			}),
 			new ExpectedReference({
 				uri: createURI('/absolute/c/file_name.prompt.md'),
@@ -205,7 +205,7 @@ suite('TextModelPromptParser', () => {
 				startLine: 6,
 				startColumn: 7,
 				pathStartColumn: 17,
-				childrenOrError: new FileOpenFailed(createURI('/absolute/c/file_name.prompt.md'), 'File not found.'),
+				childrenOrError: new OpenFailed(createURI('/absolute/c/file_name.prompt.md'), 'File not found.'),
 			}),
 			new ExpectedReference({
 				uri: createURI('/absolute/folder/main.rs'),
@@ -214,7 +214,7 @@ suite('TextModelPromptParser', () => {
 				startLine: 11,
 				startColumn: 36,
 				pathStartColumn: 42,
-				childrenOrError: new FileOpenFailed(createURI('/absolute/folder/main.rs'), 'File not found.'),
+				childrenOrError: new OpenFailed(createURI('/absolute/folder/main.rs'), 'File not found.'),
 			}),
 			new ExpectedReference({
 				uri: createURI('/absolute/folder/and/a/samefile.jpeg'),
@@ -223,7 +223,7 @@ suite('TextModelPromptParser', () => {
 				startLine: 11,
 				startColumn: 56,
 				pathStartColumn: 62,
-				childrenOrError: new FileOpenFailed(createURI('/absolute/folder/and/a/samefile.jpeg'), 'File not found.'),
+				childrenOrError: new OpenFailed(createURI('/absolute/folder/and/a/samefile.jpeg'), 'File not found.'),
 			}),
 		]);
 	});

--- a/src/vs/workbench/contrib/chat/test/common/promptSyntax/promptFileReference.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/promptSyntax/promptFileReference.test.ts
@@ -23,9 +23,9 @@ import { waitRandom, randomBoolean } from '../../../../../../base/test/common/te
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
 import { IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
 import { IInstantiationService } from '../../../../../../platform/instantiation/common/instantiation.js';
+import { NotPromptFile, RecursiveReference, OpenFailed } from '../../../common/promptFileReferenceErrors.js';
 import { ConfigurationService } from '../../../../../../platform/configuration/common/configurationService.js';
 import { InMemoryFileSystemProvider } from '../../../../../../platform/files/common/inMemoryFilesystemProvider.js';
-import { NonPromptSnippetFile, RecursiveReference, FileOpenFailed } from '../../../common/promptFileReferenceErrors.js';
 import { TestInstantiationService } from '../../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
 
 /**
@@ -189,7 +189,7 @@ suite('PromptFileReference (Unix)', function () {
 		instantiationService.stub(IConfigurationService, nullConfigService);
 	});
 
-	test('resolves nested file references', async function () {
+	test('• resolves nested file references', async function () {
 		if (isWindows) {
 			this.skip();
 		}
@@ -269,7 +269,7 @@ suite('PromptFileReference (Unix)', function () {
 						2,
 						1,
 					),
-					new FileOpenFailed(
+					new OpenFailed(
 						URI.joinPath(rootUri, './folder1/some-other-folder/non-existing-folder'),
 						'Reference to non-existing file cannot be opened.',
 					),
@@ -285,7 +285,7 @@ suite('PromptFileReference (Unix)', function () {
 				new ExpectedReference(
 					URI.joinPath(rootUri, './folder1/some-other-folder'),
 					createTestFileReference('.', 1, 1),
-					new NonPromptSnippetFile(
+					new NotPromptFile(
 						URI.joinPath(rootUri, './folder1/some-other-folder'),
 						'This folder is not a prompt file!',
 					),
@@ -293,7 +293,7 @@ suite('PromptFileReference (Unix)', function () {
 				new ExpectedReference(
 					URI.joinPath(rootUri, './folder1/some-other-folder/yetAnotherFolder🤭'),
 					createTestFileReference('../file.txt', 2, 35),
-					new NonPromptSnippetFile(
+					new NotPromptFile(
 						URI.joinPath(rootUri, './folder1/some-other-folder/file.txt'),
 						'Ughh oh, that is not a prompt file!',
 					),
@@ -305,7 +305,7 @@ suite('PromptFileReference (Unix)', function () {
 				new ExpectedReference(
 					URI.joinPath(rootUri, './folder1/some-other-folder'),
 					createTestFileReference('./some-non-existing/file.prompt.md', 1, 30),
-					new FileOpenFailed(
+					new OpenFailed(
 						URI.joinPath(rootUri, './folder1/some-other-folder/some-non-existing/file.prompt.md'),
 						'Failed to open non-existring prompt snippets file',
 					),
@@ -313,7 +313,7 @@ suite('PromptFileReference (Unix)', function () {
 				new ExpectedReference(
 					URI.joinPath(rootUri, './folder1/some-other-folder'),
 					createTestFileReference('./some-non-prompt-file.md', 5, 13),
-					new FileOpenFailed(
+					new OpenFailed(
 						URI.joinPath(rootUri, './folder1/some-other-folder/some-non-prompt-file.md'),
 						'Oh no!',
 					),
@@ -321,7 +321,7 @@ suite('PromptFileReference (Unix)', function () {
 				new ExpectedReference(
 					URI.joinPath(rootUri, './some-other-folder/folder1'),
 					createTestFileReference('../../folder1', 5, 48),
-					new NonPromptSnippetFile(
+					new NotPromptFile(
 						URI.joinPath(rootUri, './folder1'),
 						'Uggh ohh!',
 					),
@@ -332,7 +332,7 @@ suite('PromptFileReference (Unix)', function () {
 		await test.run();
 	});
 
-	test('does not fall into infinite reference recursion', async function () {
+	test('• does not fall into infinite reference recursion', async function () {
 		if (isWindows) {
 			this.skip();
 		}
@@ -439,7 +439,7 @@ suite('PromptFileReference (Unix)', function () {
 				new ExpectedReference(
 					URI.joinPath(rootUri, './folder1/some-other-folder'),
 					createTestFileReference('../some-non-existing/file.prompt.md', 1, 30),
-					new FileOpenFailed(
+					new OpenFailed(
 						URI.joinPath(rootUri, './folder1/some-non-existing/file.prompt.md'),
 						'Uggh ohh!',
 					),
@@ -472,7 +472,7 @@ suite('PromptFileReference (Unix)', function () {
 				new ExpectedReference(
 					rootUri,
 					createTestFileReference('./file1.md', 6, 2),
-					new NonPromptSnippetFile(
+					new NotPromptFile(
 						URI.joinPath(rootUri, './file1.md'),
 						'Uggh oh!',
 					),

--- a/src/vs/workbench/contrib/chat/test/common/promptSyntax/promptFileReference.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/promptSyntax/promptFileReference.test.ts
@@ -23,10 +23,10 @@ import { waitRandom, randomBoolean } from '../../../../../../base/test/common/te
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
 import { IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
 import { IInstantiationService } from '../../../../../../platform/instantiation/common/instantiation.js';
-import { NotPromptFile, RecursiveReference, OpenFailed } from '../../../common/promptFileReferenceErrors.js';
 import { ConfigurationService } from '../../../../../../platform/configuration/common/configurationService.js';
 import { InMemoryFileSystemProvider } from '../../../../../../platform/files/common/inMemoryFilesystemProvider.js';
 import { TestInstantiationService } from '../../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
+import { NotPromptFile, RecursiveReference, OpenFailed, FolderReference } from '../../../common/promptFileReferenceErrors.js';
 
 /**
  * Represents a file reference with an expected
@@ -285,7 +285,7 @@ suite('PromptFileReference (Unix)', function () {
 				new ExpectedReference(
 					URI.joinPath(rootUri, './folder1/some-other-folder'),
 					createTestFileReference('.', 1, 1),
-					new NotPromptFile(
+					new FolderReference(
 						URI.joinPath(rootUri, './folder1/some-other-folder'),
 						'This folder is not a prompt file!',
 					),
@@ -321,7 +321,7 @@ suite('PromptFileReference (Unix)', function () {
 				new ExpectedReference(
 					URI.joinPath(rootUri, './some-other-folder/folder1'),
 					createTestFileReference('../../folder1', 5, 48),
-					new NotPromptFile(
+					new FolderReference(
 						URI.joinPath(rootUri, './folder1'),
 						'Uggh ohh!',
 					),

--- a/src/vs/workbench/contrib/chat/test/common/promptSyntax/promptFileReference.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/promptSyntax/promptFileReference.test.ts
@@ -147,6 +147,8 @@ class TestPromptFileReference extends Disposable {
 /**
  * Create expected file reference for testing purposes.
  *
+ * Note! This utility also use for `markdown links` at the moment.
+ *
  * @param filePath The expected path of the file reference (without the `#file:` prefix).
  * @param lineNumber The expected line number of the file reference.
  * @param startColumnNumber The expected start column number of the file reference.
@@ -216,14 +218,14 @@ suite('PromptFileReference (Unix)', function () {
 						children: [
 							{
 								name: 'file3.prompt.md',
-								contents: `\n\n\t- some seemingly random #file:${rootFolder}/folder1/some-other-folder/yetAnotherFolder🤭/another-file.prompt.md contents\n some more\t content`,
+								contents: `\n[](./some-other-folder/non-existing-folder)\n\t- some seemingly random #file:${rootFolder}/folder1/some-other-folder/yetAnotherFolder🤭/another-file.prompt.md contents\n some more\t content`,
 							},
 							{
 								name: 'some-other-folder',
 								children: [
 									{
 										name: 'file4.prompt.md',
-										contents: 'this file has a non-existing #file:./some-non-existing/file.prompt.md\t\treference\n\n\nand some\n non-prompt #file:./some-non-prompt-file.md',
+										contents: 'this file has a non-existing #file:./some-non-existing/file.prompt.md\t\treference\n\n\nand some\n non-prompt #file:./some-non-prompt-file.md\t\t \t[](../../folder1/)\t',
 									},
 									{
 										name: 'file.txt',
@@ -234,7 +236,7 @@ suite('PromptFileReference (Unix)', function () {
 										children: [
 											{
 												name: 'another-file.prompt.md',
-												contents: 'another-file.prompt.md contents\t [#file:file.txt](../file.txt)',
+												contents: `[](${rootFolder}/folder1/some-other-folder)\nanother-file.prompt.md contents\t [#file:file.txt](../file.txt)`,
 											},
 											{
 												name: 'one_more_file_just_in_case.prompt.md',
@@ -263,14 +265,34 @@ suite('PromptFileReference (Unix)', function () {
 				new ExpectedReference(
 					URI.joinPath(rootUri, './folder1'),
 					createTestFileReference(
+						`./some-other-folder/non-existing-folder`,
+						2,
+						1,
+					),
+					new FileOpenFailed(
+						URI.joinPath(rootUri, './folder1/some-other-folder/non-existing-folder'),
+						'Reference to non-existing file cannot be opened.',
+					),
+				),
+				new ExpectedReference(
+					URI.joinPath(rootUri, './folder1'),
+					createTestFileReference(
 						`/${rootFolderName}/folder1/some-other-folder/yetAnotherFolder🤭/another-file.prompt.md`,
 						3,
 						26,
 					),
 				),
 				new ExpectedReference(
+					URI.joinPath(rootUri, './folder1/some-other-folder'),
+					createTestFileReference('.', 1, 1),
+					new NonPromptSnippetFile(
+						URI.joinPath(rootUri, './folder1/some-other-folder'),
+						'This folder is not a prompt file!',
+					),
+				),
+				new ExpectedReference(
 					URI.joinPath(rootUri, './folder1/some-other-folder/yetAnotherFolder🤭'),
-					createTestFileReference('../file.txt', 1, 35),
+					createTestFileReference('../file.txt', 2, 35),
 					new NonPromptSnippetFile(
 						URI.joinPath(rootUri, './folder1/some-other-folder/file.txt'),
 						'Ughh oh, that is not a prompt file!',
@@ -294,6 +316,14 @@ suite('PromptFileReference (Unix)', function () {
 					new FileOpenFailed(
 						URI.joinPath(rootUri, './folder1/some-other-folder/some-non-prompt-file.md'),
 						'Oh no!',
+					),
+				),
+				new ExpectedReference(
+					URI.joinPath(rootUri, './some-other-folder/folder1'),
+					createTestFileReference('../../folder1', 5, 48),
+					new NonPromptSnippetFile(
+						URI.joinPath(rootUri, './folder1'),
+						'Uggh ohh!',
 					),
 				),
 			]


### PR DESCRIPTION
For https://github.com/microsoft/vscode-copilot/issues/13091.

The PR adds logic to handle folder references inside prompt files. For now it ignores these references - does not provide document links for them(md extension already does that better) and not sending the references to the copilot (not useful).
