### PR TITLE
Ensure proper sequencing of notebook cell edits

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingSession.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingSession.ts
@@ -708,10 +708,17 @@ export class ChatEditingSession extends Disposable implements IChatEditingSessio
 		let didComplete = false;
 
 		return {
-			pushText: edits => {
+			pushText: (edits) => {
 				sequencer.queue(async () => {
 					if (!this.isDisposed) {
 						await this._acceptEdits(resource, edits, false, responseModel);
+					}
+				});
+			},
+			pushNotebookCellText: (cell, edits) => {
+				sequencer.queue(async () => {
+					if (!this.isDisposed) {
+						await this._acceptEdits(cell, edits, false, responseModel);
 					}
 				});
 			},

--- a/src/vs/workbench/contrib/chat/browser/chatQuick.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatQuick.ts
@@ -20,7 +20,7 @@ import { editorBackground, inputBackground, quickInputBackground, quickInputFore
 import { IQuickChatOpenOptions, IQuickChatService, showChatView } from './chat.js';
 import { ChatWidget } from './chatWidget.js';
 import { ChatAgentLocation } from '../common/chatAgents.js';
-import { ChatModel } from '../common/chatModel.js';
+import { ChatModel, isCellTextEditOperation } from '../common/chatModel.js';
 import { IParsedChatRequest } from '../common/chatParserTypes.js';
 import { IChatProgress, IChatService } from '../common/chatService.js';
 import { IViewsService } from '../../../services/views/common/viewsService.js';
@@ -300,11 +300,19 @@ class QuickChat extends Disposable {
 						}
 					} else if (item.kind === 'notebookEditGroup') {
 						for (const group of item.edits) {
-							message.push({
-								kind: 'notebookEdit',
-								edits: group,
-								uri: item.uri
-							});
+							if (isCellTextEditOperation(group)) {
+								message.push({
+									kind: 'textEdit',
+									edits: [group.edit],
+									uri: group.uri
+								});
+							} else {
+								message.push({
+									kind: 'notebookEdit',
+									edits: [group],
+									uri: item.uri
+								});
+							}
 						}
 					} else {
 						message.push(item);

--- a/src/vs/workbench/contrib/chat/common/chatEditingService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatEditingService.ts
@@ -73,6 +73,7 @@ export interface WorkingSetDisplayMetadata {
 
 export interface IStreamingEdits {
 	pushText(edits: TextEdit[]): void;
+	pushNotebookCellText(cell: URI, edits: TextEdit[]): void;
 	pushNotebook(edits: ICellEditOperation[]): void;
 	/** Marks edits as done, idempotent */
 	complete(): void;

--- a/src/vs/workbench/contrib/chat/common/chatModel.ts
+++ b/src/vs/workbench/contrib/chat/common/chatModel.ts
@@ -549,7 +549,7 @@ export class Response extends AbstractResponse implements IDisposable {
 				this._responseParts.push({
 					kind: groupKind,
 					uri,
-					edits,
+					edits: groupKind === 'textEditGroup' ? [edits] : edits,
 					done: progress.done
 				});
 			}

--- a/src/vs/workbench/contrib/terminalContrib/chat/browser/terminalChatWidget.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chat/browser/terminalChatWidget.ts
@@ -22,7 +22,7 @@ import { CancelablePromise, createCancelablePromise, DeferredPromise } from '../
 import { IStorageService, StorageScope, StorageTarget } from '../../../../../platform/storage/common/storage.js';
 import { IViewsService } from '../../../../services/views/common/viewsService.js';
 import { IChatAcceptInputOptions, showChatView } from '../../../chat/browser/chat.js';
-import { ChatModel, IChatResponseModel } from '../../../chat/common/chatModel.js';
+import { ChatModel, IChatResponseModel, isCellTextEditOperation } from '../../../chat/common/chatModel.js';
 import { IChatService, IChatProgress } from '../../../chat/common/chatService.js';
 import { CancellationTokenSource } from '../../../../../base/common/cancellation.js';
 import { MenuId } from '../../../../../platform/actions/common/actions.js';
@@ -448,11 +448,19 @@ export class TerminalChatWidget extends Disposable {
 				}
 			} else if (item.kind === 'notebookEditGroup') {
 				for (const group of item.edits) {
-					message.push({
-						kind: 'notebookEdit',
-						edits: group,
-						uri: item.uri
-					});
+					if (isCellTextEditOperation(group)) {
+						message.push({
+							kind: 'textEdit',
+							edits: [group.edit],
+							uri: group.uri
+						});
+					} else {
+						message.push({
+							kind: 'notebookEdit',
+							edits: [group],
+							uri: item.uri
+						});
+					}
 				}
 			} else {
 				message.push(item);


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

**Problem**
Assume we generate a single text edit for a single cell in a notebook
Sequence of messages emitted is as follows
````
1. Empty NotebookEdit [] (URI = Notebook URI `file://sample.ipynb`)
2. Text Edit for Cell URI  (URI = Cell URI= `vscode-notebook-cell://sample.ipynb?w234`)
3. NotebookEdito isDone=true (URI = Notebook URI `file://sample.ipynb`)
```

What happens with the the messages is as follows:
UpdateContent of `changeModel.ts` stores the messages in the following manner
_responseParts = [
    { 
        kind: 'notebookEditGroup',
        uri: <Notebook URI>,
        edits: [[]],
        done: true
    },
    { 
        kind: 'textEditGroup',
        uri: <Cell URI>,
        edits: [[]],
        done: true
    },
]
````

And they get process as follows in `handleResponseParts` of `chatEditingServiceImpl`:
```
1. First process the first empty element in `notebookEditGroup`
2. After we're done processing all `edits` in the `notebookEditGroup`, we then move onto `done`.
3. At this point `done = true` for `notebookEditGroup`, hence the ModifiedFileEntry gets the `done` and we complete the stream and resolve chat session, etc.

NOTE: None of the cell edits have been handled.
I.e. the order is now wrong, the text edits were sent before the `notebook.done = true`.

4. Now we process the notebook cell edit operations.
However this is out of sequence.
```

I think the problem lies with the fact that the `textEdits` are not treated as part of the `notebookEditGroup`.
Ideally they should be part of that so that they are processes in order.
Or we bring the knowledge of notebook Cell Edits into this area and look at the Uris and do something else to ensure any text edits for a cell URI that belong to an existing `notebookgroup` must be processed first and the `notebookGroup.done` must be processed after all other `textEditGroup`... feels icky..

@jrieken @connor4312 /cc