### PR TITLE
don't launch contributed profile that's not been for custom execution tasks

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminalService.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalService.ts
@@ -977,7 +977,9 @@ export class TerminalService extends Disposable implements ITerminalService {
 		await this._resolveCwd(shellLaunchConfig, splitActiveTerminal, options);
 
 		// Launch the contributed profile
-		if (contributedProfile) {
+		// If it's a custom pty implementation, we did not await the profiles ready, so
+		// we cannot launch the contributed profile and doing so would cause an error
+		if (!shellLaunchConfig.customPtyImplementation && contributedProfile) {
 			const resolvedLocation = await this.resolveLocation(options?.location);
 			let location: TerminalLocation | { viewColumn: number; preserveState?: boolean } | { splitActiveTerminal: boolean } | undefined;
 			if (splitActiveTerminal) {


### PR DESCRIPTION
fix #200558

This was happening because we don't await profiles for custom execution ptys by design, but then were allowing the contributed profile to get created, which would fail because it wasn't available.

tested with this in an extension's `package.json`, setting that as the default profile

```
"contributes": {
  "terminal": {
    "profiles": [
        {
            "id": "extension.terminal",
            "title": "Custom profile"
        }
    ]
  }
```
and this in the `activate` of the extension:
```
context.subscriptions.push(vscode.window.registerTerminalProfileProvider(
		'extension.terminal',
		{
			provideTerminalProfile: async (token: vscode.CancellationToken): Promise<vscode.TerminalProfile | undefined> => {

				return {
					options: {
						name: 'Custom profile',
						shellPath: 'bash',
					}
				};
			}
		}));
	const writer = new vscode.EventEmitter<string>();
	vscode.tasks.executeTask({
		definition: {
			type: 'custom',
		},
		name: 'Test task',
		isBackground: false,
		presentationOptions: {},
		runOptions: {},
		source: 'My extension',
		problemMatchers: [],
		scope: vscode.TaskScope.Workspace,
		execution: new vscode.CustomExecution(async () => ({
			onDidWrite: writer.event,
			open: () => writer.fire('open'),
			close: () => {
				throw new Error('Method not implemented.');
			},
		})),
	});
```
