### PR TITLE
Fix #238815 by using a function that calls `downloadAndInstall` for local downloads

### DIFF
--- a/src/vs/server/node/remoteExtensionsScanner.ts
+++ b/src/vs/server/node/remoteExtensionsScanner.ts
@@ -88,10 +88,12 @@ export class RemoteExtensionsScannerService implements IRemoteExtensionsScannerS
 						}
 					}
 
-					if (failed.length) {
-						_logService.info(`Reporting the following extensions as failed to install: ${failed.map(f => f.id).join(', ')}`);
+					if (!failed.length) {
+						_logService.trace(`No extensions to report as failed`);
+						return { failed: [] };
 					}
 
+					_logService.info(`Relaying the following extensions to install later: ${failed.map(f => f.id).join(', ')}`);
 					return { failed };
 				});
 		}


### PR DESCRIPTION
Ref https://github.com/microsoft/vscode-remote-release/issues/9090
Follow up to https://github.com/microsoft/vscode/pull/238815

We need to call a function that will eventually call [`RemoteExtensionManagementService.downloadAndInstall`](https://github.com/microsoft/vscode/blob/34835fbea9a3c595c79d17abdb1a038767181682/src/vs/workbench/services/extensionManagement/electron-sandbox/remoteExtensionManagementService.ts#L94C16-L107), since that is the one able to download extensions on the local side. 


In the `window` log on your client
```
2025-02-20 14:32:01.820 [info] [Window] Downloading the 'joshspicer.touchbarcommandshortcuts' extension locally and install
2025-02-20 14:32:02.348 [info] [Window] Downloaded extension: joshspicer.touchbarcommandshortcuts /Users/jospicer/.vscode-oss-dev/CachedExtensionVSIXs/joshspicer.touchbarcommandshortcuts-0.0.2
2025-02-20 14:32:02.498 [info] [Window] Successfully installed 'joshspicer.touchbarcommandshortcuts' extension
```


<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
