### PR TITLE
Skip resolving save conxflict when the contents between disk and editor are equal (fix #241381)

### DIFF
--- a/src/vs/base/common/buffer.ts
+++ b/src/vs/base/common/buffer.ts
@@ -175,6 +175,18 @@ export class VSBuffer {
 	indexOf(subarray: VSBuffer | Uint8Array, offset = 0) {
 		return binaryIndexOf(this.buffer, subarray instanceof VSBuffer ? subarray.buffer : subarray, offset);
 	}
+
+	equals(other: VSBuffer): boolean {
+		if (this === other) {
+			return true;
+		}
+
+		if (this.byteLength !== other.byteLength) {
+			return false;
+		}
+
+		return this.buffer.every((value, index) => value === other.buffer[index]);
+	}
 }
 
 /**

--- a/src/vs/base/test/common/buffer.test.ts
+++ b/src/vs/base/test/common/buffer.test.ts
@@ -429,7 +429,106 @@ suite('Buffer', () => {
 		assert.strictEqual(haystack.indexOf(VSBuffer.fromString('ccc')), 15);
 
 		assert.strictEqual(haystack.indexOf(VSBuffer.fromString('cccb')), -1);
+	});
 
+	test('wrap', () => {
+		const actual = new Uint8Array([1, 2, 3]);
+		const wrapped = VSBuffer.wrap(actual);
+		assert.strictEqual(wrapped.byteLength, 3);
+		assert.deepStrictEqual(Array.from(wrapped.buffer), [1, 2, 3]);
+	});
+
+	test('fromString', () => {
+		const value = 'Hello World';
+		const buff = VSBuffer.fromString(value);
+		assert.strictEqual(buff.toString(), value);
+	});
+
+	test('fromByteArray', () => {
+		const array = [1, 2, 3, 4, 5];
+		const buff = VSBuffer.fromByteArray(array);
+		assert.strictEqual(buff.byteLength, array.length);
+		assert.deepStrictEqual(Array.from(buff.buffer), array);
+	});
+
+	test('concat', () => {
+		const chunks = [
+			VSBuffer.fromString('abc'),
+			VSBuffer.fromString('def'),
+			VSBuffer.fromString('ghi')
+		];
+
+		// Test without total length
+		const result1 = VSBuffer.concat(chunks);
+		assert.strictEqual(result1.toString(), 'abcdefghi');
+
+		// Test with total length
+		const result2 = VSBuffer.concat(chunks, 9);
+		assert.strictEqual(result2.toString(), 'abcdefghi');
+	});
+
+	test('clone', () => {
+		const original = VSBuffer.fromString('test');
+		const clone = original.clone();
+
+		assert.notStrictEqual(original.buffer, clone.buffer);
+		assert.deepStrictEqual(Array.from(original.buffer), Array.from(clone.buffer));
+	});
+
+	test('slice', () => {
+		const buff = VSBuffer.fromString('Hello World');
+
+		const slice1 = buff.slice(0, 5);
+		assert.strictEqual(slice1.toString(), 'Hello');
+
+		const slice2 = buff.slice(6);
+		assert.strictEqual(slice2.toString(), 'World');
+	});
+
+	test('set', () => {
+		const buff = VSBuffer.alloc(5);
+
+		// Test setting from VSBuffer
+		buff.set(VSBuffer.fromString('ab'), 0);
+		assert.strictEqual(buff.toString().substring(0, 2), 'ab');
+
+		// Test setting from Uint8Array
+		buff.set(new Uint8Array([99, 100]), 2); // 'cd'
+		assert.strictEqual(buff.toString().substring(2, 4), 'cd');
+
+		// Test invalid input
+		assert.throws(() => {
+			buff.set({} as any);
+		});
+	});
+
+	test('equals', () => {
+		const buff1 = VSBuffer.fromString('test');
+		const buff2 = VSBuffer.fromString('test');
+		const buff3 = VSBuffer.fromString('different');
+		const buff4 = VSBuffer.fromString('tes1');
+
+		assert.strictEqual(buff1.equals(buff1), true);
+		assert.strictEqual(buff1.equals(buff2), true);
+		assert.strictEqual(buff1.equals(buff3), false);
+		assert.strictEqual(buff1.equals(buff4), false);
+	});
+
+	test('read/write methods', () => {
+		const buff = VSBuffer.alloc(8);
+
+		// Test UInt32BE
+		buff.writeUInt32BE(0x12345678, 0);
+		assert.strictEqual(buff.readUInt32BE(0), 0x12345678);
+
+		// Test UInt32LE
+		buff.writeUInt32LE(0x12345678, 4);
+		assert.strictEqual(buff.readUInt32LE(4), 0x12345678);
+
+		// Test UInt8
+		const buff2 = VSBuffer.alloc(1);
+		buff2.writeUInt8(123, 0);
+		assert.strictEqual(buff2.readUInt8(0), 123);
 	});
 
 	suite('base64', () => {

--- a/src/vs/platform/files/common/fileService.ts
+++ b/src/vs/platform/files/common/fileService.ts
@@ -379,8 +379,8 @@ export class FileService extends Disposable implements IFileService {
 
 		try {
 
-			// validate write
-			const stat = await this.validateWriteFile(provider, resource, writeFileOptions);
+			// validate write (this may already return a peeked-at buffer)
+			let { stat, buffer: bufferOrReadableOrStreamOrBufferedStream } = await this.validateWriteFile(provider, resource, bufferOrReadableOrStream, writeFileOptions);
 
 			// mkdir recursively as needed
 			if (!stat) {
@@ -391,20 +391,8 @@ export class FileService extends Disposable implements IFileService {
 			// to write is not a buffer, we consume up to 3 chunks and try to write the data
 			// unbuffered to reduce the overhead. If the stream or readable has more data
 			// to provide we continue to write buffered.
-			let bufferOrReadableOrStreamOrBufferedStream: VSBuffer | VSBufferReadable | VSBufferReadableStream | VSBufferReadableBufferedStream;
-			if (hasReadWriteCapability(provider) && !(bufferOrReadableOrStream instanceof VSBuffer)) {
-				if (isReadableStream(bufferOrReadableOrStream)) {
-					const bufferedStream = await peekStream(bufferOrReadableOrStream, 3);
-					if (bufferedStream.ended) {
-						bufferOrReadableOrStreamOrBufferedStream = VSBuffer.concat(bufferedStream.buffer);
-					} else {
-						bufferOrReadableOrStreamOrBufferedStream = bufferedStream;
-					}
-				} else {
-					bufferOrReadableOrStreamOrBufferedStream = peekReadable(bufferOrReadableOrStream, data => VSBuffer.concat(data), 3);
-				}
-			} else {
-				bufferOrReadableOrStreamOrBufferedStream = bufferOrReadableOrStream;
+			if (!bufferOrReadableOrStreamOrBufferedStream) {
+				bufferOrReadableOrStreamOrBufferedStream = await this.peekBufferForWriting(provider, bufferOrReadableOrStream);
 			}
 
 			// write file: unbuffered
@@ -430,7 +418,28 @@ export class FileService extends Disposable implements IFileService {
 		return this.resolve(resource, { resolveMetadata: true });
 	}
 
-	private async validateWriteFile(provider: IFileSystemProvider, resource: URI, options?: IWriteFileOptions): Promise<IStat | undefined> {
+
+	private async peekBufferForWriting(provider: IFileSystemProviderWithFileReadWriteCapability | IFileSystemProviderWithOpenReadWriteCloseCapability, bufferOrReadableOrStream: VSBuffer | VSBufferReadable | VSBufferReadableStream): Promise<VSBuffer | VSBufferReadable | VSBufferReadableStream | VSBufferReadableBufferedStream> {
+		let peekResult: VSBuffer | VSBufferReadable | VSBufferReadableStream | VSBufferReadableBufferedStream;
+		if (hasReadWriteCapability(provider) && !(bufferOrReadableOrStream instanceof VSBuffer)) {
+			if (isReadableStream(bufferOrReadableOrStream)) {
+				const bufferedStream = await peekStream(bufferOrReadableOrStream, 3);
+				if (bufferedStream.ended) {
+					peekResult = VSBuffer.concat(bufferedStream.buffer);
+				} else {
+					peekResult = bufferedStream;
+				}
+			} else {
+				peekResult = peekReadable(bufferOrReadableOrStream, data => VSBuffer.concat(data), 3);
+			}
+		} else {
+			peekResult = bufferOrReadableOrStream;
+		}
+
+		return peekResult;
+	}
+
+	private async validateWriteFile(provider: IFileSystemProviderWithFileReadWriteCapability | IFileSystemProviderWithOpenReadWriteCloseCapability, resource: URI, bufferOrReadableOrStream: VSBuffer | VSBufferReadable | VSBufferReadableStream, options?: IWriteFileOptions): Promise<{ stat: IStat | undefined; buffer: VSBuffer | VSBufferReadable | VSBufferReadableStream | VSBufferReadableBufferedStream | undefined }> {
 
 		// Validate unlock support
 		const unlock = !!options?.unlock;
@@ -459,7 +468,7 @@ export class FileService extends Disposable implements IFileService {
 		try {
 			stat = await provider.stat(resource);
 		} catch (error) {
-			return undefined; // file might not exist
+			return Object.create(null); // file might not exist
 		}
 
 		// File cannot be directory
@@ -482,15 +491,32 @@ export class FileService extends Disposable implements IFileService {
 		// check for size is a weaker check because it can return a false negative if the file has changed
 		// but to the same length. This is a compromise we take to avoid having to produce checksums of
 		// the file content for comparison which would be much slower to compute.
+		//
+		// Third, if the etag() turns out to be different, we do one attempt to compare the buffer we
+		// are about to write with the contents on disk to figure out if the contents are identical.
+		// In that case we allow the writing as it would result in the same contents in the file.
+		let buffer: VSBuffer | VSBufferReadable | VSBufferReadableStream | VSBufferReadableBufferedStream | undefined;
 		if (
 			typeof options?.mtime === 'number' && typeof options.etag === 'string' && options.etag !== ETAG_DISABLED &&
 			typeof stat.mtime === 'number' && typeof stat.size === 'number' &&
 			options.mtime < stat.mtime && options.etag !== etag({ mtime: options.mtime /* not using stat.mtime for a reason, see above */, size: stat.size })
 		) {
+			buffer = await this.peekBufferForWriting(provider, bufferOrReadableOrStream);
+			if (buffer instanceof VSBuffer && buffer.byteLength === stat.size) {
+				try {
+					const { value } = await this.readFile(resource);
+					if (buffer.equals(value)) {
+						return { stat, buffer }; // allow writing since contents are identical
+					}
+				} catch (error) {
+					// ignore, throw the FILE_MODIFIED_SINCE error
+				}
+			}
+
 			throw new FileOperationError(localize('fileModifiedError', "File Modified Since"), FileOperationResult.FILE_MODIFIED_SINCE, options);
 		}
 
-		return stat;
+		return { stat, buffer };
 	}
 
 	async readFile(resource: URI, options?: IReadFileOptions, token?: CancellationToken): Promise<IFileContent> {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
