### PR TITLE
Adjust command started X when prompt is reprinted

### DIFF
--- a/src/vs/platform/terminal/common/capabilities/commandDetection/promptInputModel.ts
+++ b/src/vs/platform/terminal/common/capabilities/commandDetection/promptInputModel.ts
@@ -105,6 +105,7 @@ export class PromptInputModel extends Disposable implements IPromptInputModel {
 	constructor(
 		private readonly _xterm: Terminal,
 		onCommandStart: Event<ITerminalCommand>,
+		onCommandStartChanged: Event<ITerminalCommand>,
 		onCommandExecuted: Event<ITerminalCommand>,
 		@ILogService private readonly _logService: ILogService
 	) {
@@ -118,6 +119,7 @@ export class PromptInputModel extends Disposable implements IPromptInputModel {
 		this._register(this._xterm.onData(e => this._handleUserInput(e)));
 
 		this._register(onCommandStart(e => this._handleCommandStart(e as { marker: IMarker })));
+		this._register(onCommandStartChanged(() => this._handleCommandStartChanged()));
 		this._register(onCommandExecuted(() => this._handleCommandExecuted()));
 
 		this._register(this.onDidStartInput(() => this._logCombinedStringIfTrace('PromptInputModel#onDidStartInput')));
@@ -213,6 +215,16 @@ export class PromptInputModel extends Disposable implements IPromptInputModel {
 				}
 			}
 		}
+	}
+
+	private _handleCommandStartChanged() {
+		if (this._state !== PromptInputState.Input) {
+			return;
+		}
+
+		this._commandStartX = this._xterm.buffer.active.cursorX;
+		this._onDidChangeInput.fire(this._createStateObject());
+		this._sync();
 	}
 
 	private _handleCommandExecuted() {

--- a/src/vs/platform/terminal/common/capabilities/commandDetectionCapability.ts
+++ b/src/vs/platform/terminal/common/capabilities/commandDetectionCapability.ts
@@ -332,7 +332,7 @@ export class CommandDetectionCapability extends Disposable implements ICommandDe
 		this._currentCommand.commandStartMarker = options?.marker || this._currentCommand.commandStartMarker;
 		if (this._currentCommand.commandStartMarker?.line === this._terminal.buffer.active.cursorY) {
 			this._currentCommand.commandStartX = this._terminal.buffer.active.cursorX;
-			this._onCommandStartChanged.fire(this._currentCommand as any);
+			this._onCommandStartChanged.fire(this._currentCommand as any as ITerminalCommand);
 			this._logService.debug('CommandDetectionCapability#handleCommandStart', this._currentCommand.commandStartX, this._currentCommand.commandStartMarker?.line);
 			return;
 		}

--- a/src/vs/platform/terminal/common/capabilities/commandDetectionCapability.ts
+++ b/src/vs/platform/terminal/common/capabilities/commandDetectionCapability.ts
@@ -61,6 +61,8 @@ export class CommandDetectionCapability extends Disposable implements ICommandDe
 
 	private readonly _onCommandStarted = this._register(new Emitter<ITerminalCommand>());
 	readonly onCommandStarted = this._onCommandStarted.event;
+	private readonly _onCommandStartChanged = this._register(new Emitter<ITerminalCommand>());
+	readonly onCommandStartChanged = this._onCommandStartChanged.event;
 	private readonly _onBeforeCommandFinished = this._register(new Emitter<ITerminalCommand>());
 	readonly onBeforeCommandFinished = this._onBeforeCommandFinished.event;
 	private readonly _onCommandFinished = this._register(new Emitter<ITerminalCommand>());
@@ -78,7 +80,7 @@ export class CommandDetectionCapability extends Disposable implements ICommandDe
 	) {
 		super();
 
-		this._promptInputModel = this._register(new PromptInputModel(this._terminal, this.onCommandStarted, this.onCommandExecuted, this._logService));
+		this._promptInputModel = this._register(new PromptInputModel(this._terminal, this.onCommandStarted, this.onCommandStartChanged, this.onCommandExecuted, this._logService));
 
 		// Pull command line from the buffer if it was not set explicitly
 		this._register(this.onCommandExecuted(command => {
@@ -330,6 +332,7 @@ export class CommandDetectionCapability extends Disposable implements ICommandDe
 		this._currentCommand.commandStartMarker = options?.marker || this._currentCommand.commandStartMarker;
 		if (this._currentCommand.commandStartMarker?.line === this._terminal.buffer.active.cursorY) {
 			this._currentCommand.commandStartX = this._terminal.buffer.active.cursorX;
+			this._onCommandStartChanged.fire(this._currentCommand as any);
 			this._logService.debug('CommandDetectionCapability#handleCommandStart', this._currentCommand.commandStartX, this._currentCommand.commandStartMarker?.line);
 			return;
 		}

--- a/src/vs/platform/terminal/test/common/capabilities/commandDetection/promptInputModel.test.ts
+++ b/src/vs/platform/terminal/test/common/capabilities/commandDetection/promptInputModel.test.ts
@@ -19,6 +19,7 @@ suite('PromptInputModel', () => {
 	let promptInputModel: PromptInputModel;
 	let xterm: Terminal;
 	let onCommandStart: Emitter<ITerminalCommand>;
+	let onCommandStartChanged: Emitter<ITerminalCommand>;
 	let onCommandExecuted: Emitter<ITerminalCommand>;
 
 	async function writePromise(data: string) {
@@ -62,8 +63,9 @@ suite('PromptInputModel', () => {
 		const TerminalCtor = (await importAMDNodeModule<typeof import('@xterm/xterm')>('@xterm/xterm', 'lib/xterm.js')).Terminal;
 		xterm = store.add(new TerminalCtor({ allowProposedApi: true }));
 		onCommandStart = store.add(new Emitter());
+		onCommandStartChanged = store.add(new Emitter());
 		onCommandExecuted = store.add(new Emitter());
-		promptInputModel = store.add(new PromptInputModel(xterm, onCommandStart.event, onCommandExecuted.event, new NullLogService));
+		promptInputModel = store.add(new PromptInputModel(xterm, onCommandStart.event, onCommandStartChanged.event, onCommandExecuted.event, new NullLogService));
 	});
 
 	test('basic input and execute', async () => {


### PR DESCRIPTION
This handles properly when plugins are loaded after the initial print in zsh.

fixes #241353

---

Same zsh session that was broken now working immediately:

<img width="621" alt="Screenshot 2025-02-21 at 6 34 26 am" src="https://github.com/user-attachments/assets/8f15e412-9a90-4091-bd83-68288881b695" />
