### PR TITLE
Introduce action to accept next inline edit part

### DIFF
--- a/src/vs/editor/contrib/inlineCompletions/browser/controller/commands.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/controller/commands.ts
@@ -261,6 +261,26 @@ export class JumpToNextInlineEdit extends EditorAction {
 	}
 }
 
+export class AcceptNextInlineEditPart extends EditorAction {
+	constructor() {
+		super({
+			id: 'editor.action.inlineSuggest.acceptNextInlineEditPart',
+			label: nls.localize2('action.inlineSuggest.acceptNextInlineEditPart', "Accept Next Inline Edit Part"),
+			precondition: ContextKeyExpr.and(EditorContextKeys.writable, InlineCompletionContextKeys.inlineEditVisible),
+			kbOpts: {
+				weight: KeybindingWeight.EditorContrib + 1,
+				primary: KeyMod.CtrlCmd | KeyCode.RightArrow,
+				kbExpr: ContextKeyExpr.and(EditorContextKeys.writable, InlineCompletionContextKeys.inlineEditVisible),
+			},
+		});
+	}
+
+	public async run(accessor: ServicesAccessor | undefined, editor: ICodeEditor): Promise<void> {
+		const controller = InlineCompletionsController.get(editor);
+		await controller?.model.get()?.acceptNextInlineEditPart(controller.editor);
+	}
+}
+
 export class HideInlineCompletion extends EditorAction {
 	public static ID = hideInlineCompletionId;
 

--- a/src/vs/editor/contrib/inlineCompletions/browser/inlineCompletions.contribution.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/inlineCompletions.contribution.ts
@@ -8,7 +8,7 @@ import { registerAction2 } from '../../../../platform/actions/common/actions.js'
 import { wrapInHotClass1 } from '../../../../platform/observable/common/wrapInHotClass.js';
 import { EditorContributionInstantiation, registerEditorAction, registerEditorCommand, registerEditorContribution } from '../../../browser/editorExtensions.js';
 import { HoverParticipantRegistry } from '../../hover/browser/hoverTypes.js';
-import { AcceptInlineCompletion, AcceptNextLineOfInlineCompletion, AcceptNextWordOfInlineCompletion, DevExtractReproSample, HideInlineCompletion, JumpToNextInlineEdit, ShowNextInlineSuggestionAction, ShowPreviousInlineSuggestionAction, ToggleAlwaysShowInlineSuggestionToolbar, ExplicitTriggerInlineEditAction, TriggerInlineSuggestionAction, TriggerInlineEditAction, ToggleInlineCompletionShowCollapsed } from './controller/commands.js';
+import { AcceptInlineCompletion, AcceptNextLineOfInlineCompletion, AcceptNextWordOfInlineCompletion, DevExtractReproSample, HideInlineCompletion, JumpToNextInlineEdit, ShowNextInlineSuggestionAction, ShowPreviousInlineSuggestionAction, ToggleAlwaysShowInlineSuggestionToolbar, ExplicitTriggerInlineEditAction, TriggerInlineSuggestionAction, TriggerInlineEditAction, ToggleInlineCompletionShowCollapsed, AcceptNextInlineEditPart } from './controller/commands.js';
 import { InlineCompletionsController } from './controller/inlineCompletionsController.js';
 import { InlineCompletionsHoverParticipant } from './hintsWidget/hoverParticipant.js';
 import { InlineCompletionsAccessibleView } from './inlineCompletionsAccessibleView.js';
@@ -29,6 +29,7 @@ registerEditorAction(AcceptNextLineOfInlineCompletion);
 registerEditorAction(AcceptInlineCompletion);
 registerEditorAction(ToggleInlineCompletionShowCollapsed);
 registerEditorAction(HideInlineCompletion);
+registerEditorAction(AcceptNextInlineEditPart);
 registerEditorAction(JumpToNextInlineEdit);
 registerAction2(ToggleAlwaysShowInlineSuggestionToolbar);
 registerEditorAction(DevExtractReproSample);

--- a/src/vs/editor/contrib/inlineCompletions/browser/model/inlineCompletionsSource.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/model/inlineCompletionsSource.ts
@@ -702,6 +702,14 @@ class SingleUpdatedNextEdit extends SingleUpdatedEdit {
 				continue;
 			}
 
+			// user did exactly the edit
+			if (change.equals(edit)) {
+				editHasChanged = true;
+				editStart = change.replaceRange.endExclusive;
+				editReplaceText = '';
+				continue;
+			}
+
 			// MOVE EDIT
 			if (change.replaceRange.start > editEnd) {
 				// the change happens after the completion range

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsView.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsView.ts
@@ -270,9 +270,17 @@ export class InlineEditsView extends Disposable {
 		}
 	}).recomputeInitiallyAndOnChange(this._store);
 
+	private getCacheId(edit: InlineEditWithChanges) {
+		if (this._model.get()?.inAcceptPartialFlow.get()) {
+			return `${edit.inlineCompletion.id}_${edit.edit.edits.map(edit => edit.range.toString() + edit.text).join(',')}`;
+		}
+
+		return edit.inlineCompletion.id;
+	}
+
 	private determineView(edit: InlineEditWithChanges, reader: IReader, diff: DetailedLineRangeMapping[], newText: StringText, originalDisplayRange: LineRange): string {
 		// Check if we can use the previous view if it is the same InlineCompletion as previously shown
-		const canUseCache = this._previousView?.id === edit.inlineCompletion.id;
+		const canUseCache = this._previousView?.id === this.getCacheId(edit);
 		const reconsiderViewAfterJump = edit.userJumpedToIt !== this._previousView?.userJumpedToIt &&
 			(
 				(this._useMixedLinesDiff.read(reader) === 'afterJumpWhenPossible' && this._previousView?.view !== 'mixedLines') ||
@@ -349,7 +357,7 @@ export class InlineEditsView extends Disposable {
 
 		const view = this.determineView(edit, reader, diff, newText, originalDisplayRange);
 
-		this._previousView = { id: edit.inlineCompletion.id, view, userJumpedToIt: edit.userJumpedToIt, editorWidth: this._editor.getLayoutInfo().width };
+		this._previousView = { id: this.getCacheId(edit), view, userJumpedToIt: edit.userJumpedToIt, editorWidth: this._editor.getLayoutInfo().width };
 
 		switch (view) {
 			case 'insertionInline': return { kind: 'insertionInline' as const };

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/viewAndDiffProducer.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/viewAndDiffProducer.ts
@@ -30,7 +30,8 @@ export class InlineEditsViewAndDiffProducer extends Disposable { // TODO: This c
 		const editOffset = model.inlineEditState.get()?.inlineCompletion.updatedEdit.read(reader);
 		if (!editOffset) { return undefined; }
 
-		const edits = editOffset.edits.map(e => {
+		const offsetEdits = model.inAcceptPartialFlow.read(reader) ? [editOffset.edits[0]] : editOffset.edits;
+		const edits = offsetEdits.map(e => {
 			const innerEditRange = Range.fromPositions(
 				textModel.getPositionAt(e.replaceRange.start),
 				textModel.getPositionAt(e.replaceRange.endExclusive)


### PR DESCRIPTION
```Copilot Generated Description:``` Introduce a new action to accept the next inline edit part. Update the inline edits handling to support partial acceptance of edits. Adjust caching logic to accommodate the new flow.