### PR TITLE
Fix ghost text cursor style

### DIFF
--- a/src/vs/editor/contrib/inlineCompletions/browser/view/ghostText/ghostTextView.css
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/ghostText/ghostTextView.css
@@ -24,15 +24,16 @@
 	font-size: 0;
 }
 
-.monaco-editor .ghost-text-decoration, .monaco-editor .suggest-preview-text.clickable .view-line {
-	z-index: 1;
-}
-
-.monaco-editor .ghost-text-decoration, .monaco-editor .suggest-preview-text .ghost-text {
+.monaco-editor .ghost-text-decoration,
+.monaco-editor .suggest-preview-text .ghost-text {
 	font-style: italic;
 }
 
-.monaco-editor .ghost-text-decoration, .monaco-editor .suggest-preview-text.clickable .ghost-text {
+.monaco-editor .suggest-preview-text.clickable .view-line {
+	z-index: 1;
+}
+
+.monaco-editor .suggest-preview-text.clickable .ghost-text {
 	cursor: pointer;
 }
 


### PR DESCRIPTION
```Copilot Generated Description:``` Update the cursor style for ghost text to ensure it appears as a pointer when appropriate. 