### PR TITLE
Cygwin retain cwd for login shells

### DIFF
--- a/src/vs/platform/terminal/node/terminalProfiles.ts
+++ b/src/vs/platform/terminal/node/terminalProfiles.ts
@@ -122,6 +122,8 @@ async function detectAvailableWindowsProfiles(
 				{ path: `${process.env['HOMEDRIVE']}\\cygwin\\bin\\bash.exe`, isUnsafe: true }
 			],
 			args: ['--login'],
+			// CHERE_INVOKING retains current working directory
+			env: { CHERE_INVOKING: '1' },
 			isAutoDetected: true
 		});
 		detectedProfiles.set('bash (MSYS2)', {


### PR DESCRIPTION
Cygwin login shells that source /etc/profile will cwd to ~. Setting "CHERE_INVOKING=1" disables this behavior.