### PR TITLE
ensure completion items are returned

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalCompletionService.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalCompletionService.ts
@@ -191,7 +191,7 @@ export class TerminalCompletionService extends Disposable implements ITerminalCo
 				}
 				return completionItems;
 			}
-			return;
+			return completionItems.length ? completionItems : undefined;
 		});
 
 		const results = await Promise.all(completionPromises);


### PR DESCRIPTION
Because we now always return a `TerminalCompletionsList` from the ext host, it's possible `resourceRequestConfig` is undefined. We still want to return the items. 

https://github.com/microsoft/vscode/blob/ad1bc3e2051d1e7dc95a0154635e525f6f07e348/src/vs/workbench/api/common/extHostTerminalService.ts#L797

![Screenshot 2025-02-21 at 10 12 16 AM](https://github.com/user-attachments/assets/310ce8d5-aa15-4514-84e6-6823f6ad16de)
