### PR TITLE
Tweak chat stream rate computation again

### DIFF
--- a/src/vs/workbench/contrib/chat/common/chatViewModel.ts
+++ b/src/vs/workbench/contrib/chat/common/chatViewModel.ts
@@ -588,9 +588,13 @@ export class ChatResponseViewModel extends Disposable implements IChatResponseVi
 				const now = Date.now();
 				const wordCount = countWords(_model.entireResponse.getMarkdown());
 
-				if (wordCount > 0 && wordCount === this._contentUpdateTimings.lastWordCount) {
+				if (wordCount === this._contentUpdateTimings.lastWordCount) {
 					this.trace('onDidChange', `Update- no new words`);
 				} else {
+					if (this._contentUpdateTimings.lastWordCount === 0) {
+						this._contentUpdateTimings.lastUpdateTime = now;
+					}
+
 					const timeDiff = Math.min(now - this._contentUpdateTimings.lastUpdateTime, 1000);
 					const newTotalTime = Math.max(this._contentUpdateTimings.totalTime + timeDiff, 250);
 					const impliedWordLoadRate = wordCount / (newTotalTime / 1000);


### PR DESCRIPTION
Now, just ignoring the initial pause entirely. Don't start counting until we have some words. This is especially helpful for Claude which has a long initial pause. Previously the timer would be started by some references showing up.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
