### PR TITLE
chore: add support to collect memory-infra traces

### DIFF
--- a/src/vs/platform/environment/common/argv.ts
+++ b/src/vs/platform/environment/common/argv.ts
@@ -51,6 +51,7 @@ export interface NativeParsedArgs {
 	'no-cached-data'?: boolean;
 	verbose?: boolean;
 	trace?: boolean;
+	'trace-memory-infra'?: boolean;
 	'trace-category-filter'?: string;
 	'trace-options'?: string;
 	'open-devtools'?: boolean;

--- a/src/vs/platform/environment/node/argv.ts
+++ b/src/vs/platform/environment/node/argv.ts
@@ -167,6 +167,7 @@ export const OPTIONS: OptionDescriptions<Required<NativeParsedArgs>> = {
 	'do-not-sync': { type: 'boolean' },
 	'do-not-include-pack-dependencies': { type: 'boolean' },
 	'trace': { type: 'boolean' },
+	'trace-memory-infra': { type: 'boolean' },
 	'trace-category-filter': { type: 'string' },
 	'trace-options': { type: 'string' },
 	'preserve-env': { type: 'boolean' },


### PR DESCRIPTION
Supports collection of allocation samples from chromium process, refs https://chromium.googlesource.com/chromium/src.git/+/refs/heads/main/docs/memory-infra/

<img width="1438" alt="Screenshot 2025-02-22 at 4 59 20" src="https://github.com/user-attachments/assets/8bca4cda-01c6-498f-a630-721aeb046445" />
