### PR TITLE
add `fileExtensions` to terminal completion resource request config

### DIFF
--- a/extensions/terminal-suggest/src/completions/upstream/apt.ts
+++ b/extensions/terminal-suggest/src/completions/upstream/apt.ts
@@ -1,4 +1,5 @@
 // import { filepaths } from "@fig/autocomplete-generators";
+import { filepaths } from '../../helpers/filepaths';
 
 const packages: Fig.Generator = {
 	// only trigger when the token length transitions to or from 0
@@ -137,7 +138,7 @@ const completionSpec: Fig.Spec = {
 				template: 'filepaths',
 				generators: [
 					packages,
-					// filepaths({ extensions: ["deb"] })
+					filepaths({ extensions: ["deb"] })
 				],
 			},
 			options: [

--- a/extensions/terminal-suggest/src/completions/upstream/apt.ts
+++ b/extensions/terminal-suggest/src/completions/upstream/apt.ts
@@ -135,7 +135,6 @@ const completionSpec: Fig.Spec = {
 				name: "package",
 				description: "The package you want to install",
 				isVariadic: true,
-				template: 'filepaths',
 				generators: [
 					packages,
 					filepaths({ extensions: ["deb"] })

--- a/extensions/terminal-suggest/src/completions/upstream/apt.ts
+++ b/extensions/terminal-suggest/src/completions/upstream/apt.ts
@@ -1,4 +1,3 @@
-// import { filepaths } from "@fig/autocomplete-generators";
 import { filepaths } from '../../helpers/filepaths';
 
 const packages: Fig.Generator = {

--- a/extensions/terminal-suggest/src/completions/upstream/node.ts
+++ b/extensions/terminal-suggest/src/completions/upstream/node.ts
@@ -1,4 +1,3 @@
-// import { filepaths } from "@fig/autocomplete-generators";
 import { filepaths } from '../../helpers/filepaths';
 
 const completionSpec: Fig.Subcommand = {

--- a/extensions/terminal-suggest/src/completions/upstream/node.ts
+++ b/extensions/terminal-suggest/src/completions/upstream/node.ts
@@ -1,4 +1,5 @@
 // import { filepaths } from "@fig/autocomplete-generators";
+import { filepaths } from '../../helpers/filepaths';
 
 const completionSpec: Fig.Subcommand = {
 	name: "node",
@@ -6,11 +7,10 @@ const completionSpec: Fig.Subcommand = {
 	args: {
 		name: "node script",
 		isScript: true,
-		template: 'folders',
-		// generators: filepaths({
-		//   extensions: ["mjs", "js", "cjs"],
-		//   editFileSuggestions: { priority: 76 },
-		// }),
+		generators: filepaths({
+			extensions: ["mjs", "js", "cjs"],
+			editFileSuggestions: { priority: 76 },
+		}),
 	},
 	options: [
 		{

--- a/extensions/terminal-suggest/src/completions/upstream/python.ts
+++ b/extensions/terminal-suggest/src/completions/upstream/python.ts
@@ -1,5 +1,3 @@
-// import { filepaths } from "@fig/autocomplete-generators";
-
 import { filepaths } from '../../helpers/filepaths';
 
 const completionSpec: Fig.Spec = {

--- a/extensions/terminal-suggest/src/completions/upstream/python.ts
+++ b/extensions/terminal-suggest/src/completions/upstream/python.ts
@@ -3,7 +3,7 @@
 import { filepaths } from '../../helpers/filepaths';
 
 const completionSpec: Fig.Spec = {
-	name: "python",
+	name: ["python", "python3"],
 	description: "Run the python interpreter",
 	generateSpec: async (tokens, executeShellCommand) => {
 		const isDjangoManagePyFilePresentCommand = "cat manage.py | grep -q django";

--- a/extensions/terminal-suggest/src/completions/upstream/python.ts
+++ b/extensions/terminal-suggest/src/completions/upstream/python.ts
@@ -23,7 +23,6 @@ const completionSpec: Fig.Spec = {
 	},
 	args: {
 		name: "python script",
-		template: "filepaths",
 		generators: filepaths({
 			extensions: ["py"],
 			editFileSuggestions: { priority: 76 },

--- a/extensions/terminal-suggest/src/completions/upstream/python.ts
+++ b/extensions/terminal-suggest/src/completions/upstream/python.ts
@@ -1,5 +1,7 @@
 // import { filepaths } from "@fig/autocomplete-generators";
 
+import { filepaths } from '../../helpers/filepaths';
+
 const completionSpec: Fig.Spec = {
 	name: "python",
 	description: "Run the python interpreter",
@@ -22,10 +24,10 @@ const completionSpec: Fig.Spec = {
 	args: {
 		name: "python script",
 		template: "filepaths",
-		// generators: filepaths({
-		// 	extensions: ["py"],
-		// 	editFileSuggestions: { priority: 76 },
-		// }),
+		generators: filepaths({
+			extensions: ["py"],
+			editFileSuggestions: { priority: 76 },
+		}),
 	},
 	options: [
 		{

--- a/extensions/terminal-suggest/src/fig/figInterface.ts
+++ b/extensions/terminal-suggest/src/fig/figInterface.ts
@@ -160,6 +160,7 @@ export async function collectCompletionItemResult(
 ): Promise<{ filesRequested: boolean; foldersRequested: boolean } | undefined> {
 	let filesRequested = false;
 	let foldersRequested = false;
+	let fileExtensions: string[] | undefined;
 
 	const addSuggestions = async (specArgs: SpecArg[] | Record<string, SpecArg> | undefined, kind: vscode.TerminalCompletionItemKind, parsedArguments?: ArgumentParserResult) => {
 		if (kind === vscode.TerminalCompletionItemKind.Argument && parsedArguments?.currentArg?.generators) {
@@ -199,6 +200,14 @@ export async function collectCompletionItemResult(
 			const generatorResults = s.triggerGenerators(parsedArguments, executeExternals);
 			for (const generatorResult of generatorResults) {
 				for (const item of (await generatorResult?.request) ?? []) {
+					if (item.type === 'file') {
+						filesRequested = true;
+						fileExtensions = item._internal?.fileExtensions as string[] | undefined;
+					}
+					if (item.type === 'folder') {
+						foldersRequested = true;
+					}
+
 					if (!item.name) {
 						continue;
 					}

--- a/extensions/terminal-suggest/src/helpers/filepaths.ts
+++ b/extensions/terminal-suggest/src/helpers/filepaths.ts
@@ -1,0 +1,17 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+export function filepaths(options: { extensions?: string[]; editFileSuggestions?: { priority: number } }): Fig.Generator {
+	return {
+		custom: async (tokens, executeCommand, generatorContext) => {
+			const fileExtensionsMap: Record<string, string[]> = { fileExtensions: options.extensions || [] };
+			return [{ type: 'file', _internal: fileExtensionsMap }, { type: 'folder' }];
+		},
+		trigger: (oldToken, newToken) => {
+			return true;
+		},
+		getQueryTerm: (token) => token
+	};
+}

--- a/extensions/terminal-suggest/src/terminalSuggestMain.ts
+++ b/extensions/terminal-suggest/src/terminalSuggestMain.ts
@@ -120,7 +120,7 @@ export async function activate(context: vscode.ExtensionContext) {
 			}
 
 			if (result.cwd && (result.filesRequested || result.foldersRequested)) {
-				return new vscode.TerminalCompletionList(result.items, { filesRequested: result.filesRequested, foldersRequested: result.foldersRequested, cwd: result.cwd, env: terminal.shellIntegration?.env.value });
+				return new vscode.TerminalCompletionList(result.items, { filesRequested: result.filesRequested, foldersRequested: result.foldersRequested, fileExtensions: result.fileExtensions, cwd: result.cwd, env: terminal.shellIntegration?.env.value });
 			}
 			return result.items;
 		}
@@ -209,11 +209,12 @@ export async function getCompletionItemsFromSpecs(
 	name: string,
 	token?: vscode.CancellationToken,
 	executeExternals?: IFigExecuteExternals,
-): Promise<{ items: vscode.TerminalCompletionItem[]; filesRequested: boolean; foldersRequested: boolean; cwd?: vscode.Uri }> {
+): Promise<{ items: vscode.TerminalCompletionItem[]; filesRequested: boolean; foldersRequested: boolean; fileExtensions?: string[]; cwd?: vscode.Uri }> {
 	const items: vscode.TerminalCompletionItem[] = [];
 	let filesRequested = false;
 	let foldersRequested = false;
 	let hasCurrentArg = false;
+	let fileExtensions: string[] | undefined;
 
 	let precedingText = terminalContext.commandLine.slice(0, terminalContext.cursorPosition + 1);
 	if (isWindows) {
@@ -230,6 +231,7 @@ export async function getCompletionItemsFromSpecs(
 		hasCurrentArg ||= result.hasCurrentArg;
 		filesRequested ||= result.filesRequested;
 		foldersRequested ||= result.foldersRequested;
+		fileExtensions = result.fileExtensions;
 		if (result.items) {
 			items.push(...result.items);
 		}
@@ -276,7 +278,7 @@ export async function getCompletionItemsFromSpecs(
 		cwd = await resolveCwdFromPrefix(prefix, shellIntegrationCwd) ?? shellIntegrationCwd;
 	}
 
-	return { items, filesRequested, foldersRequested, cwd };
+	return { items, filesRequested, foldersRequested, fileExtensions, cwd };
 }
 
 function compareItems(existingItem: vscode.TerminalCompletionItem, command: ICompletionResource): vscode.TerminalCompletionItem | undefined {

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -2480,6 +2480,7 @@ export class TerminalCompletionListDto<T extends ITerminalCompletionItemDto = IT
 export interface TerminalResourceRequestConfigDto {
 	filesRequested?: boolean;
 	foldersRequested?: boolean;
+	fileExtensions?: string[];
 	cwd?: UriComponents;
 	pathSeparator: string;
 }

--- a/src/vs/workbench/api/common/extHostTypes.ts
+++ b/src/vs/workbench/api/common/extHostTypes.ts
@@ -2202,6 +2202,7 @@ export class TerminalCompletionList<T extends TerminalCompletionItem = TerminalC
 export interface TerminalResourceRequestConfig {
 	filesRequested?: boolean;
 	foldersRequested?: boolean;
+	fileExtensions?: string[];
 	cwd?: vscode.Uri;
 }
 

--- a/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalCompletionService.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalCompletionService.ts
@@ -50,6 +50,7 @@ export class TerminalCompletionList<ITerminalCompletion> {
 export interface TerminalResourceRequestConfig {
 	filesRequested?: boolean;
 	foldersRequested?: boolean;
+	fileExtensions?: string[];
 	cwd?: UriComponents;
 	pathSeparator: string;
 	env?: { [key: string]: string | null | undefined };
@@ -209,6 +210,7 @@ export class TerminalCompletionService extends Disposable implements ITerminalCo
 		// provide diagnostics when a folder is provided where a file is expected.
 		const foldersRequested = (resourceRequestConfig.foldersRequested || resourceRequestConfig.filesRequested) ?? false;
 		const filesRequested = resourceRequestConfig.filesRequested ?? false;
+		const fileExtensions = resourceRequestConfig.fileExtensions ?? undefined;
 
 		const cwd = URI.revive(resourceRequestConfig.cwd);
 		if (!cwd || (!foldersRequested && !filesRequested)) {
@@ -376,6 +378,13 @@ export class TerminalCompletionService extends Disposable implements ITerminalCo
 			}
 			if (child.isDirectory && !label.endsWith(resourceRequestConfig.pathSeparator)) {
 				label += resourceRequestConfig.pathSeparator;
+			}
+
+			if (child.isFile && fileExtensions) {
+				const extension = child.name.split('.').length > 1 ? child.name.split('.').at(-1) : undefined;
+				if (extension && !fileExtensions.includes(extension)) {
+					continue;
+				}
 			}
 
 			resourceCompletions.push({

--- a/src/vscode-dts/vscode.proposed.terminalCompletionProvider.d.ts
+++ b/src/vscode-dts/vscode.proposed.terminalCompletionProvider.d.ts
@@ -127,6 +127,10 @@ declare module 'vscode' {
 		 */
 		foldersRequested?: boolean;
 		/**
+		 * File extensions to filter by.
+		 */
+		fileExtensions?: string[];
+		/**
 		 * If no cwd is provided, no resources will be shown as completions.
 		 */
 		cwd?: Uri;


### PR DESCRIPTION
fixes https://github.com/microsoft/vscode/issues/240104

Tested with `node` and `python3` - `apt` doesn't work on mac