### PR TITLE
Resolve compiler errors that appear due to useDefineForClassFields

### DIFF
--- a/src/vs/base/common/arrays.ts
+++ b/src/vs/base/common/arrays.ts
@@ -702,12 +702,14 @@ export function compareUndefinedSmallest<T>(comparator: Comparator<T>): Comparat
 
 export class ArrayQueue<T> {
 	private firstIdx = 0;
-	private lastIdx = this.items.length - 1;
+	private lastIdx: number;
 
 	/**
 	 * Constructs a queue that is backed by the given array. Runtime is O(1).
 	*/
-	constructor(private readonly items: readonly T[]) { }
+	constructor(private readonly items: readonly T[]) {
+		this.lastIdx = this.items.length - 1;
+	}
 
 	get length(): number {
 		return this.lastIdx - this.firstIdx + 1;

--- a/src/vs/base/parts/ipc/common/ipc.mp.ts
+++ b/src/vs/base/parts/ipc/common/ipc.mp.ts
@@ -41,14 +41,16 @@ export interface MessagePort {
  */
 export class Protocol implements IMessagePassingProtocol {
 
-	readonly onMessage = Event.fromDOMEventEmitter<VSBuffer>(this.port, 'message', (e: MessageEvent) => {
-		if (e.data) {
-			return VSBuffer.wrap(e.data);
-		}
-		return VSBuffer.alloc(0);
-	});
+	readonly onMessage: Event<VSBuffer>;
 
 	constructor(private port: MessagePort) {
+
+		this.onMessage = Event.fromDOMEventEmitter<VSBuffer>(this.port, 'message', (e: MessageEvent) => {
+			if (e.data) {
+				return VSBuffer.wrap(e.data);
+			}
+			return VSBuffer.alloc(0);
+		});
 
 		// we must call start() to ensure messages are flowing
 		port.start();

--- a/src/vs/base/parts/ipc/node/ipc.mp.ts
+++ b/src/vs/base/parts/ipc/node/ipc.mp.ts
@@ -15,14 +15,16 @@ import { assertType } from '../../../common/types.js';
  */
 class Protocol implements IMessagePassingProtocol {
 
-	readonly onMessage = Event.fromNodeEventEmitter<VSBuffer>(this.port, 'message', (e: MessageEvent) => {
-		if (e.data) {
-			return VSBuffer.wrap(e.data);
-		}
-		return VSBuffer.alloc(0);
-	});
+	readonly onMessage: Event<VSBuffer>;
 
 	constructor(private port: MessagePortMain) {
+
+		this.onMessage = Event.fromNodeEventEmitter<VSBuffer>(this.port, 'message', (e: MessageEvent) => {
+			if (e.data) {
+				return VSBuffer.wrap(e.data);
+			}
+			return VSBuffer.alloc(0);
+		});
 
 		// we must call start() to ensure messages are flowing
 		port.start();

--- a/src/vs/base/parts/storage/node/storage.ts
+++ b/src/vs/base/parts/storage/node/storage.ts
@@ -38,13 +38,19 @@ export class SQLiteStorageDatabase implements IStorageDatabase {
 	private static readonly BUSY_OPEN_TIMEOUT = 2000; // timeout in ms to retry when opening DB fails with SQLITE_BUSY
 	private static readonly MAX_HOST_PARAMETERS = 256; // maximum number of parameters within a statement
 
-	private readonly name = basename(this.path);
+	private readonly name: string;
 
-	private readonly logger = new SQLiteStorageDatabaseLogger(this.options.logging);
+	private readonly logger: SQLiteStorageDatabaseLogger;
 
-	private readonly whenConnected = this.connect(this.path);
+	private readonly whenConnected: Promise<IDatabaseConnection>;
 
-	constructor(private readonly path: string, private readonly options: ISQLiteStorageDatabaseOptions = Object.create(null)) { }
+	constructor(private readonly path: string, private readonly options: ISQLiteStorageDatabaseOptions = Object.create(null)) {
+		this.name = basename(this.path);
+
+		this.logger = new SQLiteStorageDatabaseLogger(this.options.logging);
+
+		this.whenConnected = this.connect(this.path);
+	}
 
 	async getItems(): Promise<Map<string, string>> {
 		const connection = await this.whenConnected;

--- a/src/vs/code/electron-utility/sharedProcess/contrib/codeCacheCleaner.ts
+++ b/src/vs/code/electron-utility/sharedProcess/contrib/codeCacheCleaner.ts
@@ -14,9 +14,7 @@ import { IProductService } from '../../../../platform/product/common/productServ
 
 export class CodeCacheCleaner extends Disposable {
 
-	private readonly _DataMaxAge = this.productService.quality !== 'stable'
-		? 1000 * 60 * 60 * 24 * 7 		// roughly 1 week (insiders)
-		: 1000 * 60 * 60 * 24 * 30 * 3; // roughly 3 months (stable)
+	private readonly _DataMaxAge: number;
 
 	constructor(
 		currentCodeCachePath: string | undefined,
@@ -24,6 +22,10 @@ export class CodeCacheCleaner extends Disposable {
 		@ILogService private readonly logService: ILogService
 	) {
 		super();
+
+		this._DataMaxAge = this.productService.quality !== 'stable'
+			? 1000 * 60 * 60 * 24 * 7 		// roughly 1 week (insiders)
+			: 1000 * 60 * 60 * 24 * 30 * 3; // roughly 3 months (stable)
 
 		// Cached data is stored as user data and we run a cleanup task every time
 		// the editor starts. The strategy is to delete all files that are older than

--- a/src/vs/code/electron-utility/sharedProcess/contrib/languagePackCachedDataCleaner.ts
+++ b/src/vs/code/electron-utility/sharedProcess/contrib/languagePackCachedDataCleaner.ts
@@ -33,9 +33,7 @@ interface ILanguagePackFile {
 
 export class LanguagePackCachedDataCleaner extends Disposable {
 
-	private readonly _DataMaxAge = this.productService.quality !== 'stable'
-		? 1000 * 60 * 60 * 24 * 7 		// roughly 1 week (insiders)
-		: 1000 * 60 * 60 * 24 * 30 * 3; // roughly 3 months (stable)
+	private readonly _DataMaxAge: number;
 
 	constructor(
 		@INativeEnvironmentService private readonly environmentService: INativeEnvironmentService,
@@ -43,6 +41,10 @@ export class LanguagePackCachedDataCleaner extends Disposable {
 		@IProductService private readonly productService: IProductService
 	) {
 		super();
+
+		this._DataMaxAge = this.productService.quality !== 'stable'
+			? 1000 * 60 * 60 * 24 * 7 		// roughly 1 week (insiders)
+			: 1000 * 60 * 60 * 24 * 30 * 3; // roughly 3 months (stable)
 
 		// We have no Language pack support for dev version (run from source)
 		// So only cleanup when we have a build version.

--- a/src/vs/editor/browser/controller/editContext/textArea/textAreaEditContextInput.ts
+++ b/src/vs/editor/browser/controller/editContext/textArea/textAreaEditContextInput.ts
@@ -619,19 +619,19 @@ export class TextAreaInput extends Disposable {
 
 export class TextAreaWrapper extends Disposable implements ICompleteTextAreaWrapper {
 
-	public readonly onKeyDown = this._register(new DomEmitter(this._actual, 'keydown')).event;
-	public readonly onKeyPress = this._register(new DomEmitter(this._actual, 'keypress')).event;
-	public readonly onKeyUp = this._register(new DomEmitter(this._actual, 'keyup')).event;
-	public readonly onCompositionStart = this._register(new DomEmitter(this._actual, 'compositionstart')).event;
-	public readonly onCompositionUpdate = this._register(new DomEmitter(this._actual, 'compositionupdate')).event;
-	public readonly onCompositionEnd = this._register(new DomEmitter(this._actual, 'compositionend')).event;
-	public readonly onBeforeInput = this._register(new DomEmitter(this._actual, 'beforeinput')).event;
-	public readonly onInput = <Event<InputEvent>>this._register(new DomEmitter(this._actual, 'input')).event;
-	public readonly onCut = this._register(new DomEmitter(this._actual, 'cut')).event;
-	public readonly onCopy = this._register(new DomEmitter(this._actual, 'copy')).event;
-	public readonly onPaste = this._register(new DomEmitter(this._actual, 'paste')).event;
-	public readonly onFocus = this._register(new DomEmitter(this._actual, 'focus')).event;
-	public readonly onBlur = this._register(new DomEmitter(this._actual, 'blur')).event;
+	public readonly onKeyDown: Event<KeyboardEvent>;
+	public readonly onKeyPress: Event<KeyboardEvent>;
+	public readonly onKeyUp: Event<KeyboardEvent>;
+	public readonly onCompositionStart: Event<CompositionEvent>;
+	public readonly onCompositionUpdate: Event<CompositionEvent>;
+	public readonly onCompositionEnd: Event<CompositionEvent>;
+	public readonly onBeforeInput: Event<InputEvent>;
+	public readonly onInput: Event<InputEvent>;
+	public readonly onCut: Event<ClipboardEvent>;
+	public readonly onCopy: Event<ClipboardEvent>;
+	public readonly onPaste: Event<ClipboardEvent>;
+	public readonly onFocus: Event<FocusEvent>;
+	public readonly onBlur: Event<FocusEvent>;
 
 	public get ownerDocument(): Document {
 		return this._actual.ownerDocument;
@@ -646,6 +646,21 @@ export class TextAreaWrapper extends Disposable implements ICompleteTextAreaWrap
 		private readonly _actual: HTMLTextAreaElement
 	) {
 		super();
+
+		this.onKeyDown = this._register(new DomEmitter(this._actual, 'keydown')).event;
+		this.onKeyPress = this._register(new DomEmitter(this._actual, 'keypress')).event;
+		this.onKeyUp = this._register(new DomEmitter(this._actual, 'keyup')).event;
+		this.onCompositionStart = this._register(new DomEmitter(this._actual, 'compositionstart')).event;
+		this.onCompositionUpdate = this._register(new DomEmitter(this._actual, 'compositionupdate')).event;
+		this.onCompositionEnd = this._register(new DomEmitter(this._actual, 'compositionend')).event;
+		this.onBeforeInput = this._register(new DomEmitter(this._actual, 'beforeinput')).event;
+		this.onInput = <Event<InputEvent>>this._register(new DomEmitter(this._actual, 'input')).event;
+		this.onCut = this._register(new DomEmitter(this._actual, 'cut')).event;
+		this.onCopy = this._register(new DomEmitter(this._actual, 'copy')).event;
+		this.onPaste = this._register(new DomEmitter(this._actual, 'paste')).event;
+		this.onFocus = this._register(new DomEmitter(this._actual, 'focus')).event;
+		this.onBlur = this._register(new DomEmitter(this._actual, 'blur')).event;
+
 		this._ignoreSelectionChangeTime = 0;
 
 		this._register(this.onKeyDown(() => inputLatency.onKeyDown()));

--- a/src/vs/editor/browser/view/viewLayer.ts
+++ b/src/vs/editor/browser/view/viewLayer.ts
@@ -252,11 +252,12 @@ export class RenderedLinesCollection<T extends ILine> {
 export class VisibleLinesCollection<T extends IVisibleLine> {
 
 	public readonly domNode: FastDomNode<HTMLElement> = this._createDomNode();
-	private readonly _linesCollection: RenderedLinesCollection<T> = new RenderedLinesCollection<T>(this._lineFactory);
+	private readonly _linesCollection: RenderedLinesCollection<T>;
 
 	constructor(
 		private readonly _lineFactory: ILineFactory<T>
 	) {
+		this._linesCollection = new RenderedLinesCollection<T>(this._lineFactory);
 	}
 
 	private _createDomNode(): FastDomNode<HTMLElement> {

--- a/src/vs/editor/browser/widget/codeEditor/codeEditorWidget.ts
+++ b/src/vs/editor/browser/widget/codeEditor/codeEditorWidget.ts
@@ -2029,11 +2029,11 @@ const enum BooleanEventValue {
 }
 
 export class BooleanEventEmitter extends Disposable {
-	private readonly _onDidChangeToTrue: Emitter<void> = this._register(new Emitter<void>(this._emitterOptions));
-	public readonly onDidChangeToTrue: Event<void> = this._onDidChangeToTrue.event;
+	private readonly _onDidChangeToTrue: Emitter<void>;
+	public readonly onDidChangeToTrue: Event<void>;
 
-	private readonly _onDidChangeToFalse: Emitter<void> = this._register(new Emitter<void>(this._emitterOptions));
-	public readonly onDidChangeToFalse: Event<void> = this._onDidChangeToFalse.event;
+	private readonly _onDidChangeToFalse: Emitter<void>;
+	public readonly onDidChangeToFalse: Event<void>;
 
 	private _value: BooleanEventValue;
 
@@ -2041,6 +2041,12 @@ export class BooleanEventEmitter extends Disposable {
 		private readonly _emitterOptions: EmitterOptions
 	) {
 		super();
+		this._onDidChangeToTrue = this._register(new Emitter<void>(this._emitterOptions));
+		this.onDidChangeToTrue = this._onDidChangeToTrue.event;
+
+		this._onDidChangeToFalse = this._register(new Emitter<void>(this._emitterOptions));
+		this.onDidChangeToFalse = this._onDidChangeToFalse.event;
+
 		this._value = BooleanEventValue.NotSet;
 	}
 

--- a/src/vs/editor/browser/widget/diffEditor/components/diffEditorSash.ts
+++ b/src/vs/editor/browser/widget/diffEditor/components/diffEditorSash.ts
@@ -50,11 +50,7 @@ export class SashLayout {
 }
 
 export class DiffEditorSash extends Disposable {
-	private readonly _sash = this._register(new Sash(this._domNode, {
-		getVerticalSashTop: (_sash: Sash): number => 0,
-		getVerticalSashLeft: (_sash: Sash): number => this.sashLeft.get(),
-		getVerticalSashHeight: (_sash: Sash): number => this._dimensions.height.get(),
-	}, { orientation: Orientation.VERTICAL }));
+	private readonly _sash: Sash;
 
 	private _startSashPosition: number | undefined = undefined;
 
@@ -67,6 +63,12 @@ export class DiffEditorSash extends Disposable {
 		private readonly _resetSash: () => void,
 	) {
 		super();
+
+		this._sash = this._register(new Sash(this._domNode, {
+			getVerticalSashTop: (_sash: Sash): number => 0,
+			getVerticalSashLeft: (_sash: Sash): number => this.sashLeft.get(),
+			getVerticalSashHeight: (_sash: Sash): number => this._dimensions.height.get(),
+		}, { orientation: Orientation.VERTICAL }));
 
 		this._register(this._sash.onDidStart(() => {
 			this._startSashPosition = this.sashLeft.get();

--- a/src/vs/editor/browser/widget/diffEditor/components/diffEditorViewZones/diffEditorViewZones.ts
+++ b/src/vs/editor/browser/widget/diffEditor/components/diffEditorViewZones/diffEditorViewZones.ts
@@ -43,12 +43,12 @@ export class DiffEditorViewZones extends Disposable {
 	private readonly _originalTopPadding = observableValue(this, 0);
 	private readonly _originalScrollTop: IObservable<number>;
 	private readonly _originalScrollOffset = observableValue<number, boolean>(this, 0);
-	private readonly _originalScrollOffsetAnimated = animatedObservable(this._targetWindow, this._originalScrollOffset, this._store);
+	private readonly _originalScrollOffsetAnimated: IObservable<number>;
 
 	private readonly _modifiedTopPadding = observableValue(this, 0);
 	private readonly _modifiedScrollTop: IObservable<number>;
 	private readonly _modifiedScrollOffset = observableValue<number, boolean>(this, 0);
-	private readonly _modifiedScrollOffsetAnimated = animatedObservable(this._targetWindow, this._modifiedScrollOffset, this._store);
+	private readonly _modifiedScrollOffsetAnimated: IObservable<number>;
 
 	public readonly viewZones: IObservable<{ orig: IObservableViewZone[]; mod: IObservableViewZone[] }>;
 
@@ -65,6 +65,10 @@ export class DiffEditorViewZones extends Disposable {
 		@IContextMenuService private readonly _contextMenuService: IContextMenuService,
 	) {
 		super();
+
+		this._originalScrollOffsetAnimated = animatedObservable(this._targetWindow, this._originalScrollOffset, this._store);
+
+		this._modifiedScrollOffsetAnimated = animatedObservable(this._targetWindow, this._modifiedScrollOffset, this._store);
 
 		const state = observableValue('invalidateAlignmentsState', 0);
 

--- a/src/vs/editor/browser/widget/diffEditor/diffEditorOptions.ts
+++ b/src/vs/editor/browser/widget/diffEditor/diffEditorOptions.ts
@@ -19,7 +19,7 @@ export class DiffEditorOptions {
 
 	private readonly _diffEditorWidth = observableValue<number>(this, 0);
 
-	private readonly _screenReaderMode = observableFromEvent(this, this._accessibilityService.onDidChangeScreenReaderOptimized, () => this._accessibilityService.isScreenReaderOptimized());
+	private readonly _screenReaderMode: IObservable<boolean>;
 
 	constructor(
 		options: Readonly<IDiffEditorOptions>,
@@ -27,6 +27,8 @@ export class DiffEditorOptions {
 	) {
 		const optionsCopy = { ...options, ...validateDiffEditorOptions(options, diffEditorDefaultOptions) };
 		this._options = observableValue(this, optionsCopy);
+
+		this._screenReaderMode = observableFromEvent(this, this._accessibilityService.onDidChangeScreenReaderOptimized, () => this._accessibilityService.isScreenReaderOptimized());
 	}
 
 	public readonly couldShowInlineViewBecauseOfSize = derived(this, reader =>

--- a/src/vs/editor/browser/widget/diffEditor/diffEditorWidget.ts
+++ b/src/vs/editor/browser/widget/diffEditor/diffEditorWidget.ts
@@ -11,7 +11,7 @@ import { readHotReloadableExport } from '../../../../base/common/hotReloadHelper
 import { toDisposable } from '../../../../base/common/lifecycle.js';
 import { IObservable, ITransaction, autorun, autorunWithStore, derived, derivedDisposable, disposableObservableValue, observableFromEvent, observableValue, recomputeInitiallyAndOnChange, subtransaction, transaction } from '../../../../base/common/observable.js';
 import { AccessibilitySignal, IAccessibilitySignalService } from '../../../../platform/accessibilitySignal/browser/accessibilitySignalService.js';
-import { IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
+import { IContextKeyService, IScopedContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { ServiceCollection } from '../../../../platform/instantiation/common/serviceCollection.js';
 import { bindContextKey } from '../../../../platform/observable/common/platformObservableUtils.js';
@@ -67,10 +67,8 @@ export class DiffEditorWidget extends DelegatingEditor implements IDiffEditor {
 
 	public get onDidContentSizeChange() { return this._editors.onDidContentSizeChange; }
 
-	private readonly _contextKeyService = this._register(this._parentContextKeyService.createScoped(this._domElement));
-	private readonly _instantiationService = this._register(this._parentInstantiationService.createChild(
-		new ServiceCollection([IContextKeyService, this._contextKeyService])
-	));
+	private readonly _contextKeyService: IScopedContextKeyService;
+	private readonly _instantiationService: IInstantiationService;
 	private readonly _rootSizeObserver: ObservableElementSizeObserver;
 
 
@@ -107,6 +105,11 @@ export class DiffEditorWidget extends DelegatingEditor implements IDiffEditor {
 	) {
 		super();
 		codeEditorService.willCreateDiffEditor();
+
+		this._contextKeyService = this._register(this._parentContextKeyService.createScoped(this._domElement));
+		this._instantiationService = this._register(this._parentInstantiationService.createChild(
+			new ServiceCollection([IContextKeyService, this._contextKeyService])
+		));
 
 		this._contextKeyService.createKey('isInDiffEditor', true);
 

--- a/src/vs/editor/browser/widget/diffEditor/features/movedBlocksLinesFeature.ts
+++ b/src/vs/editor/browser/widget/diffEditor/features/movedBlocksLinesFeature.ts
@@ -26,9 +26,9 @@ export class MovedBlocksLinesFeature extends Disposable {
 	public static readonly movedCodeBlockPadding = 4;
 
 	private readonly _element: SVGElement;
-	private readonly _originalScrollTop = observableFromEvent(this, this._editors.original.onDidScrollChange, () => this._editors.original.getScrollTop());
-	private readonly _modifiedScrollTop = observableFromEvent(this, this._editors.modified.onDidScrollChange, () => this._editors.modified.getScrollTop());
-	private readonly _viewZonesChanged = observableSignalFromEvent('onDidChangeViewZones', this._editors.modified.onDidChangeViewZones);
+	private readonly _originalScrollTop: IObservable<number>;
+	private readonly _modifiedScrollTop: IObservable<number>;
+	private readonly _viewZonesChanged: IObservable<void>;
 
 	public readonly width = observableValue(this, 0);
 
@@ -40,6 +40,13 @@ export class MovedBlocksLinesFeature extends Disposable {
 		private readonly _editors: DiffEditorEditors,
 	) {
 		super();
+
+		this._originalScrollTop = observableFromEvent(this, this._editors.original.onDidScrollChange, () => this._editors.original.getScrollTop());
+		this._modifiedScrollTop = observableFromEvent(this, this._editors.modified.onDidScrollChange, () => this._editors.modified.getScrollTop());
+		this._viewZonesChanged = observableSignalFromEvent('onDidChangeViewZones', this._editors.modified.onDidChangeViewZones);
+
+		this._modifiedViewZonesChangedSignal = observableSignalFromEvent('modified.onDidChangeViewZones', this._editors.modified.onDidChangeViewZones);
+		this._originalViewZonesChangedSignal = observableSignalFromEvent('original.onDidChangeViewZones', this._editors.original.onDidChangeViewZones);
 
 		this._element = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
 		this._element.setAttribute('class', 'moved-blocks-lines');
@@ -133,8 +140,8 @@ export class MovedBlocksLinesFeature extends Disposable {
 		}));
 	}
 
-	private readonly _modifiedViewZonesChangedSignal = observableSignalFromEvent('modified.onDidChangeViewZones', this._editors.modified.onDidChangeViewZones);
-	private readonly _originalViewZonesChangedSignal = observableSignalFromEvent('original.onDidChangeViewZones', this._editors.original.onDidChangeViewZones);
+	private readonly _modifiedViewZonesChangedSignal: IObservable<void>;
+	private readonly _originalViewZonesChangedSignal: IObservable<void>;
 
 	private readonly _state = derivedWithStore(this, (reader, store) => {
 		/** @description state */

--- a/src/vs/editor/browser/widget/diffEditor/features/revertButtonsFeature.ts
+++ b/src/vs/editor/browser/widget/diffEditor/features/revertButtonsFeature.ts
@@ -111,13 +111,7 @@ export class RevertButton extends Disposable implements IGlyphMarginWidget {
 
 	getId(): string { return this._id; }
 
-	private readonly _domNode = h('div.revertButton', {
-		title: this._revertSelection
-			? localize('revertSelectedChanges', 'Revert Selected Changes')
-			: localize('revertChange', 'Revert Change')
-	},
-		[renderIcon(Codicon.arrowRight)]
-	).root;
+	private readonly _domNode: HTMLDivElement;
 
 	constructor(
 		private readonly _lineNumber: number,
@@ -127,6 +121,13 @@ export class RevertButton extends Disposable implements IGlyphMarginWidget {
 	) {
 		super();
 
+		this._domNode = h('div.revertButton', {
+			title: this._revertSelection
+				? localize('revertSelectedChanges', 'Revert Selected Changes')
+				: localize('revertChange', 'Revert Change')
+		},
+			[renderIcon(Codicon.arrowRight)]
+		).root;
 
 		this._register(addDisposableListener(this._domNode, EventType.MOUSE_DOWN, e => {
 			// don't prevent context menu from showing up

--- a/src/vs/editor/browser/widget/diffEditor/utils.ts
+++ b/src/vs/editor/browser/widget/diffEditor/utils.ts
@@ -231,12 +231,13 @@ export class PlaceholderViewZone implements IObservableViewZone {
 
 	public get afterLineNumber(): number { return this._afterLineNumber.get(); }
 
-	public readonly onChange?: IObservable<unknown> = this._afterLineNumber;
+	public readonly onChange?: IObservable<unknown>;
 
 	constructor(
 		private readonly _afterLineNumber: IObservable<number>,
 		public readonly heightInPx: number,
 	) {
+		this.onChange = this._afterLineNumber;
 	}
 
 	onDomNodeTop = (top: number) => {

--- a/src/vs/editor/browser/widget/diffEditor/utils/editorGutter.ts
+++ b/src/vs/editor/browser/widget/diffEditor/utils/editorGutter.ts
@@ -11,18 +11,12 @@ import { LineRange } from '../../../../common/core/lineRange.js';
 import { OffsetRange } from '../../../../common/core/offsetRange.js';
 
 export class EditorGutter<T extends IGutterItemInfo = IGutterItemInfo> extends Disposable {
-	private readonly scrollTop = observableFromEvent(this,
-		this._editor.onDidScrollChange,
-		(e) => /** @description editor.onDidScrollChange */ this._editor.getScrollTop()
-	);
-	private readonly isScrollTopZero = this.scrollTop.map((scrollTop) => /** @description isScrollTopZero */ scrollTop === 0);
-	private readonly modelAttached = observableFromEvent(this,
-		this._editor.onDidChangeModel,
-		(e) => /** @description editor.onDidChangeModel */ this._editor.hasModel()
-	);
+	private readonly scrollTop: IObservable<number>;
+	private readonly isScrollTopZero: IObservable<boolean>;
+	private readonly modelAttached: IObservable<boolean>;
 
-	private readonly editorOnDidChangeViewZones = observableSignalFromEvent('onDidChangeViewZones', this._editor.onDidChangeViewZones);
-	private readonly editorOnDidContentSizeChange = observableSignalFromEvent('onDidContentSizeChange', this._editor.onDidContentSizeChange);
+	private readonly editorOnDidChangeViewZones: IObservable<void>;
+	private readonly editorOnDidContentSizeChange: IObservable<void>;
 	private readonly domNodeSizeChanged = observableSignal('domNodeSizeChanged');
 
 	constructor(
@@ -31,6 +25,20 @@ export class EditorGutter<T extends IGutterItemInfo = IGutterItemInfo> extends D
 		private readonly itemProvider: IGutterItemProvider<T>
 	) {
 		super();
+
+		this.scrollTop = observableFromEvent(this,
+			this._editor.onDidScrollChange,
+			(e) => /** @description editor.onDidScrollChange */ this._editor.getScrollTop()
+		);
+		this.isScrollTopZero = this.scrollTop.map((scrollTop) => /** @description isScrollTopZero */ scrollTop === 0);
+		this.modelAttached = observableFromEvent(this,
+			this._editor.onDidChangeModel,
+			(e) => /** @description editor.onDidChangeModel */ this._editor.hasModel()
+		);
+
+		this.editorOnDidChangeViewZones = observableSignalFromEvent('onDidChangeViewZones', this._editor.onDidChangeViewZones);
+		this.editorOnDidContentSizeChange = observableSignalFromEvent('onDidContentSizeChange', this._editor.onDidContentSizeChange);
+
 		this._domNode.className = 'gutter monaco-editor';
 		const scrollDecoration = this._domNode.appendChild(
 			h('div.scroll-decoration', { role: 'presentation', ariaHidden: 'true', style: { width: '100%' } })

--- a/src/vs/editor/browser/widget/multiDiffEditor/multiDiffEditorWidgetImpl.ts
+++ b/src/vs/editor/browser/widget/multiDiffEditor/multiDiffEditorWidgetImpl.ts
@@ -13,7 +13,7 @@ import { IObservable, IReader, ITransaction, autorun, autorunWithStore, derived,
 import { Scrollable, ScrollbarVisibility } from '../../../../base/common/scrollable.js';
 import { URI } from '../../../../base/common/uri.js';
 import { localize } from '../../../../nls.js';
-import { ContextKeyValue, IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
+import { ContextKeyValue, IContextKeyService, IScopedContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
 import { ITextEditorOptions } from '../../../../platform/editor/common/editor.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { ServiceCollection } from '../../../../platform/instantiation/common/serviceCollection.js';
@@ -60,7 +60,7 @@ export class MultiDiffEditorWidgetImpl extends Disposable {
 		h('div.placeholder@placeholder', {}, [h('div')]),
 	]);
 
-	private readonly _sizeObserver = this._register(new ObservableElementSizeObserver(this._element, undefined));
+	private readonly _sizeObserver: ObservableElementSizeObserver;
 
 	private readonly _objectPool = this._register(new ObjectPool<TemplateData, DiffEditorItemTemplate>((data) => {
 		const template = this._instantiationService.createInstance(
@@ -113,10 +113,8 @@ export class MultiDiffEditorWidgetImpl extends Disposable {
 		return viewItem.template.read(reader)?.editor;
 	});
 
-	private readonly _contextKeyService = this._register(this._parentContextKeyService.createScoped(this._element));
-	private readonly _instantiationService = this._register(this._parentInstantiationService.createChild(
-		new ServiceCollection([IContextKeyService, this._contextKeyService])
-	));
+	private readonly _contextKeyService: IScopedContextKeyService;
+	private readonly _instantiationService: IInstantiationService;
 
 	constructor(
 		private readonly _element: HTMLElement,
@@ -127,6 +125,13 @@ export class MultiDiffEditorWidgetImpl extends Disposable {
 		@IInstantiationService private readonly _parentInstantiationService: IInstantiationService,
 	) {
 		super();
+
+		this._sizeObserver = this._register(new ObservableElementSizeObserver(this._element, undefined));
+
+		this._contextKeyService = this._register(this._parentContextKeyService.createScoped(this._element));
+		this._instantiationService = this._register(this._parentInstantiationService.createChild(
+			new ServiceCollection([IContextKeyService, this._contextKeyService])
+		));
 
 		this._register(autorunWithStore((reader, store) => {
 			const viewModel = this._viewModel.read(reader);

--- a/src/vs/editor/common/core/textEdit.ts
+++ b/src/vs/editor/common/core/textEdit.ts
@@ -384,10 +384,12 @@ export class ArrayText extends LineBasedText {
 }
 
 export class StringText extends AbstractText {
-	private readonly _t = new PositionOffsetTransformer(this.value);
+	private readonly _t: PositionOffsetTransformer;
 
 	constructor(public readonly value: string) {
 		super();
+
+		this._t = new PositionOffsetTransformer(this.value);
 	}
 
 	getValueOfRange(range: Range): string {

--- a/src/vs/editor/common/model/bracketPairsTextModelPart/bracketPairsTree/bracketPairsTree.ts
+++ b/src/vs/editor/common/model/bracketPairsTextModelPart/bracketPairsTree/bracketPairsTree.ts
@@ -40,7 +40,7 @@ export class BracketPairsTree extends Disposable {
 	private astWithTokens: AstNode | undefined;
 
 	private readonly denseKeyProvider = new DenseKeyProvider<string>();
-	private readonly brackets = new LanguageAgnosticBracketTokens(this.denseKeyProvider, this.getLanguageConfiguration);
+	private readonly brackets: LanguageAgnosticBracketTokens;
 
 	public didLanguageChange(languageId: string): boolean {
 		return this.brackets.didLanguageChange(languageId);
@@ -55,6 +55,8 @@ export class BracketPairsTree extends Disposable {
 		private readonly getLanguageConfiguration: (languageId: string) => ResolvedLanguageConfiguration
 	) {
 		super();
+
+		this.brackets = new LanguageAgnosticBracketTokens(this.denseKeyProvider, this.getLanguageConfiguration);
 
 		if (!textModel.tokenization.hasTokens) {
 			const brackets = this.brackets.getSingleLanguageBracketTokens(this.textModel.getLanguageId());

--- a/src/vs/editor/common/model/bracketPairsTextModelPart/bracketPairsTree/tokenizer.ts
+++ b/src/vs/editor/common/model/bracketPairsTextModelPart/bracketPairsTree/tokenizer.ts
@@ -64,7 +64,7 @@ export class TextBufferTokenizer implements Tokenizer {
 	private readonly textBufferLineCount: number;
 	private readonly textBufferLastLineLength: number;
 
-	private readonly reader = new NonPeekableTextBufferTokenizer(this.textModel, this.bracketTokens);
+	private readonly reader: NonPeekableTextBufferTokenizer;
 
 	constructor(
 		private readonly textModel: ITokenizerSource,
@@ -72,6 +72,8 @@ export class TextBufferTokenizer implements Tokenizer {
 	) {
 		this.textBufferLineCount = textModel.getLineCount();
 		this.textBufferLastLineLength = textModel.getLineLength(this.textBufferLineCount);
+
+		this.reader = new NonPeekableTextBufferTokenizer(this.textModel, this.bracketTokens); // rebuild here
 	}
 
 	private _offset: Length = lengthZero;

--- a/src/vs/editor/common/model/textModelTokens.ts
+++ b/src/vs/editor/common/model/textModelTokens.ts
@@ -25,7 +25,7 @@ const enum Constants {
 }
 
 export class TokenizerWithStateStore<TState extends IState = IState> {
-	private readonly initialState = this.tokenizationSupport.getInitialState() as TState;
+	private readonly initialState: TState;
 
 	public readonly store: TrackingTokenizationStateStore<TState>;
 
@@ -33,6 +33,7 @@ export class TokenizerWithStateStore<TState extends IState = IState> {
 		lineCount: number,
 		public readonly tokenizationSupport: ITokenizationSupport
 	) {
+		this.initialState = this.tokenizationSupport.getInitialState() as TState;
 		this.store = new TrackingTokenizationStateStore<TState>(lineCount);
 	}
 

--- a/src/vs/editor/common/model/tokenizationTextModelPart.ts
+++ b/src/vs/editor/common/model/tokenizationTextModelPart.ts
@@ -34,7 +34,7 @@ import { SparseTokensStore } from '../tokens/sparseTokensStore.js';
 import { IInstantiationService } from '../../../platform/instantiation/common/instantiation.js';
 
 export class TokenizationTextModelPart extends TextModelPart implements ITokenizationTextModelPart {
-	private readonly _semanticTokens: SparseTokensStore = new SparseTokensStore(this._languageService.languageIdCodec);
+	private readonly _semanticTokens: SparseTokensStore;
 
 	private readonly _onDidChangeLanguage: Emitter<IModelLanguageChangedEvent> = this._register(new Emitter<IModelLanguageChangedEvent>());
 	public readonly onDidChangeLanguage: Event<IModelLanguageChangedEvent> = this._onDidChangeLanguage.event;
@@ -58,6 +58,8 @@ export class TokenizationTextModelPart extends TextModelPart implements ITokeniz
 		@IInstantiationService private readonly _instantiationService: IInstantiationService
 	) {
 		super();
+
+		this._semanticTokens = new SparseTokensStore(this._languageService.languageIdCodec);
 
 		// We just look at registry changes to determine whether to use tree sitter.
 		// This means that removing a language from the setting will not cause a switch to textmate and will require a reload.

--- a/src/vs/editor/contrib/colorPicker/browser/colorDetector.ts
+++ b/src/vs/editor/contrib/colorPicker/browser/colorDetector.ts
@@ -15,7 +15,7 @@ import { DynamicCssRules } from '../../../browser/editorDom.js';
 import { EditorOption } from '../../../common/config/editorOptions.js';
 import { Position } from '../../../common/core/position.js';
 import { Range } from '../../../common/core/range.js';
-import { IEditorContribution } from '../../../common/editorCommon.js';
+import { IEditorContribution, IEditorDecorationsCollection } from '../../../common/editorCommon.js';
 import { IModelDecoration, IModelDeltaDecoration } from '../../../common/model.js';
 import { ModelDecorationOptions } from '../../../common/model/textModel.js';
 import { IFeatureDebounceInformation, ILanguageFeatureDebounceService } from '../../../common/services/languageFeatureDebounce.js';
@@ -40,12 +40,12 @@ export class ColorDetector extends Disposable implements IEditorContribution {
 	private _decorationsIds: string[] = [];
 	private _colorDatas = new Map<string, IColorData>();
 
-	private readonly _colorDecoratorIds = this._editor.createDecorationsCollection();
+	private readonly _colorDecoratorIds: IEditorDecorationsCollection;
 
 	private _isColorDecoratorsEnabled: boolean;
 	private _defaultColorDecoratorsEnablement: 'auto' | 'always' | 'never';
 
-	private readonly _ruleFactory = new DynamicCssRules(this._editor);
+	private readonly _ruleFactory: DynamicCssRules;
 
 	private readonly _decoratorLimitReporter = new DecoratorLimitReporter();
 
@@ -56,6 +56,10 @@ export class ColorDetector extends Disposable implements IEditorContribution {
 		@ILanguageFeatureDebounceService languageFeatureDebounceService: ILanguageFeatureDebounceService,
 	) {
 		super();
+
+		this._colorDecoratorIds = this._editor.createDecorationsCollection();
+		this._ruleFactory = new DynamicCssRules(this._editor);
+
 		this._debounceInformation = languageFeatureDebounceService.for(_languageFeaturesService.colorProvider, 'Document Colors', { min: ColorDetector.RECOMPUTE_TIME });
 		this._register(_editor.onDidChangeModel(() => {
 			this._isColorDecoratorsEnabled = this.isEnabled();

--- a/src/vs/editor/contrib/inlayHints/browser/inlayHintsController.ts
+++ b/src/vs/editor/contrib/inlayHints/browser/inlayHintsController.ts
@@ -111,7 +111,7 @@ export class InlayHintsController implements IEditorContribution {
 	private readonly _sessionDisposables = new DisposableStore();
 	private readonly _debounceInfo: IFeatureDebounceInformation;
 	private readonly _decorationsMetadata = new Map<string, InlayHintDecorationRenderInfo>();
-	private readonly _ruleFactory = new DynamicCssRules(this._editor);
+	private readonly _ruleFactory: DynamicCssRules;
 
 	private _cursorInfo?: { position: Position; notEarlierThan: number };
 	private _activeRenderMode = RenderMode.Normal;
@@ -127,6 +127,7 @@ export class InlayHintsController implements IEditorContribution {
 		@IInstantiationService private readonly _instaService: IInstantiationService,
 	) {
 		this._debounceInfo = _featureDebounce.for(_languageFeaturesService.inlayHintsProvider, 'InlayHint', { min: 25 });
+		this._ruleFactory = new DynamicCssRules(this._editor);
 		this._disposables.add(_languageFeaturesService.inlayHintsProvider.onDidChange(() => this._update()));
 		this._disposables.add(_editor.onDidChangeModel(() => this._update()));
 		this._disposables.add(_editor.onDidChangeModelLanguage(() => this._update()));

--- a/src/vs/editor/contrib/inlineCompletions/browser/inlineCompletionsAccessibleView.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/inlineCompletionsAccessibleView.ts
@@ -44,11 +44,13 @@ class InlineCompletionsAccessibleViewContentProvider extends Disposable implemen
 		private readonly _model: InlineCompletionsModel,
 	) {
 		super();
+
+		this.options = { language: this._editor.getModel()?.getLanguageId() ?? undefined, type: AccessibleViewType.View };
 	}
 
 	public readonly id = AccessibleViewProviderId.InlineCompletions;
 	public readonly verbositySettingKey = 'accessibility.verbosity.inlineCompletions';
-	public readonly options = { language: this._editor.getModel()?.getLanguageId() ?? undefined, type: AccessibleViewType.View };
+	public readonly options: { language: string | undefined; type: AccessibleViewType };
 
 	public provideContent(): string {
 		const state = this._model.inlineCompletionState.get();

--- a/src/vs/editor/contrib/inlineCompletions/browser/model/changeRecorder.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/model/changeRecorder.ts
@@ -11,15 +11,18 @@ import { CodeEditorWidget } from '../../../../browser/widget/codeEditor/codeEdit
 import { IRecordableEditorLogEntry, StructuredLogger } from './inlineCompletionsSource.js';
 
 export class TextModelChangeRecorder extends Disposable {
-	private readonly _structuredLogger = this._register(this._instantiationService.createInstance(StructuredLogger.cast<IRecordableEditorLogEntry & { source: string }>(),
-		'editor.inlineSuggest.logChangeReason.commandId'
-	));
+	private readonly _structuredLogger: StructuredLogger<IRecordableEditorLogEntry & { source: string }>;
 
 	constructor(
 		private readonly _editor: ICodeEditor,
 		@IInstantiationService private readonly _instantiationService: IInstantiationService,
 	) {
 		super();
+
+		this._structuredLogger = this._register(this._instantiationService.createInstance(StructuredLogger.cast<IRecordableEditorLogEntry & { source: string }>(),
+			'editor.inlineSuggest.logChangeReason.commandId'
+		));
+
 		this._register(autorunWithStore((reader, store) => {
 			if (!(this._editor instanceof CodeEditorWidget)) { return; }
 			if (!this._structuredLogger.isEnabled.read(reader)) { return; }

--- a/src/vs/editor/contrib/inlineCompletions/browser/model/ghostText.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/model/ghostText.ts
@@ -78,12 +78,13 @@ export class GhostTextPart {
 		readonly preview: boolean,
 		private _inlineDecorations: InlineDecoration[] = [],
 	) {
+		this.lines = splitLines(this.text).map((line, i) => ({
+			line,
+			lineDecorations: LineDecoration.filter(this._inlineDecorations, i + 1, 1, line.length + 1)
+		}));
 	}
 
-	readonly lines: IGhostTextLine[] = splitLines(this.text).map((line, i) => ({
-		line,
-		lineDecorations: LineDecoration.filter(this._inlineDecorations, i + 1, 1, line.length + 1)
-	}));
+	readonly lines: IGhostTextLine[];
 
 	equals(other: GhostTextPart): boolean {
 		return this.column === other.column &&
@@ -96,22 +97,25 @@ export class GhostTextPart {
 }
 
 export class GhostTextReplacement {
-	public readonly parts: ReadonlyArray<GhostTextPart> = [
-		new GhostTextPart(
-			this.columnRange.endColumnExclusive,
-			this.text,
-			false
-		),
-	];
+	public readonly parts: ReadonlyArray<GhostTextPart>;
 
 	constructor(
 		readonly lineNumber: number,
 		readonly columnRange: ColumnRange,
 		readonly text: string,
 		public readonly additionalReservedLineCount: number = 0,
-	) { }
+	) {
+		this.parts = [
+			new GhostTextPart(
+				this.columnRange.endColumnExclusive,
+				this.text,
+				false
+			),
+		];
+		this.newLines = splitLines(this.text);
+	}
 
-	readonly newLines = splitLines(this.text);
+	readonly newLines: string[];
 
 	renderForScreenReader(_lineText: string): string {
 		return this.newLines.join('\n');

--- a/src/vs/editor/contrib/inlineCompletions/browser/model/suggestWidgetAdapter.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/model/suggestWidgetAdapter.ts
@@ -240,17 +240,7 @@ function suggestItemInfoEquals(a: SuggestItemInfo | undefined, b: SuggestItemInf
 }
 
 export class ObservableSuggestWidgetAdapter extends Disposable {
-	private readonly _suggestWidgetAdaptor = this._register(new SuggestWidgetAdaptor(
-		this._editorObs.editor,
-		() => {
-			this._editorObs.forceUpdate();
-			return this._suggestControllerPreselector();
-		},
-		(item) => this._editorObs.forceUpdate(_tx => {
-			/** @description InlineCompletionsController.handleSuggestAccepted */
-			this._handleSuggestAccepted(item);
-		})
-	));
+	private readonly _suggestWidgetAdaptor: SuggestWidgetAdaptor;
 
 	public readonly selectedItem = observableFromEvent(this, cb => this._suggestWidgetAdaptor.onDidSelectedItemChange(() => {
 		this._editorObs.forceUpdate(_tx => cb(undefined));
@@ -263,6 +253,18 @@ export class ObservableSuggestWidgetAdapter extends Disposable {
 		private readonly _suggestControllerPreselector: () => SingleTextEdit | undefined,
 	) {
 		super();
+
+		this._suggestWidgetAdaptor = this._register(new SuggestWidgetAdaptor(
+			this._editorObs.editor,
+			() => {
+				this._editorObs.forceUpdate();
+				return this._suggestControllerPreselector();
+			},
+			(item) => this._editorObs.forceUpdate(_tx => {
+				/** @description InlineCompletionsController.handleSuggestAccepted */
+				this._handleSuggestAccepted(item);
+			})
+		));
 	}
 
 	public stopForceRenderingAbove(): void {

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineCompletionsView.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineCompletionsView.ts
@@ -8,53 +8,29 @@ import { Disposable } from '../../../../../base/common/lifecycle.js';
 import { derived, mapObservableArrayCached, derivedDisposable, constObservable, derivedObservableWithCache, IObservable, ISettableObservable } from '../../../../../base/common/observable.js';
 import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
 import { ICodeEditor } from '../../../../browser/editorBrowser.js';
-import { observableCodeEditor } from '../../../../browser/observableCodeEditor.js';
+import { ObservableCodeEditor, observableCodeEditor } from '../../../../browser/observableCodeEditor.js';
 import { EditorOption } from '../../../../common/config/editorOptions.js';
 import { InlineCompletionsHintsWidget } from '../hintsWidget/inlineCompletionsHintsWidget.js';
+import { GhostTextOrReplacement } from '../model/ghostText.js';
 import { InlineCompletionsModel } from '../model/inlineCompletionsModel.js';
+import { InlineEdit } from '../model/inlineEdit.js';
 import { convertItemsToStableObservables } from '../utils.js';
 import { GhostTextView } from './ghostText/ghostTextView.js';
 import { InlineEditsViewAndDiffProducer } from './inlineEdits/viewAndDiffProducer.js';
 
 export class InlineCompletionsView extends Disposable {
-	private readonly _ghostTexts = derived(this, (reader) => {
-		const model = this._model.read(reader);
-		return model?.ghostTexts.read(reader) ?? [];
-	});
+	private readonly _ghostTexts: IObservable<readonly GhostTextOrReplacement[]>;
 
-	private readonly _stablizedGhostTexts = convertItemsToStableObservables(this._ghostTexts, this._store);
-	private readonly _editorObs = observableCodeEditor(this._editor);
+	private readonly _stablizedGhostTexts: IObservable<IObservable<GhostTextOrReplacement>[]>;
+	private readonly _editorObs: ObservableCodeEditor;
 
-	private readonly _ghostTextWidgets = mapObservableArrayCached(this, this._stablizedGhostTexts, (ghostText, store) => derivedDisposable((reader) => this._instantiationService.createInstance(
-		GhostTextView.hot.read(reader),
-		this._editor,
-		{
-			ghostText: ghostText,
-			warning: this._model.map((m, reader) => {
-				const warning = m?.warning?.read(reader);
-				return warning ? { icon: warning.icon } : undefined;
-			}),
-			minReservedLineCount: constObservable(0),
-			targetTextModel: this._model.map(v => v?.textModel),
-		},
-		this._editorObs.getOption(EditorOption.inlineSuggest).map(v => ({ syntaxHighlightingEnabled: v.syntaxHighlightingEnabled })),
-		false,
-		false
-	)
-	).recomputeInitiallyAndOnChange(store)
-	).recomputeInitiallyAndOnChange(this._store);
+	private readonly _ghostTextWidgets: IObservable<readonly IObservable<GhostTextView>[]>;
 
-	private readonly _inlineEdit = derived(this, reader => this._model.read(reader)?.inlineEditState.read(reader)?.inlineEdit);
-	private readonly _everHadInlineEdit = derivedObservableWithCache<boolean>(this, (reader, last) => last || !!this._inlineEdit.read(reader) || !!this._model.read(reader)?.inlineCompletionState.read(reader)?.inlineCompletion?.sourceInlineCompletion.showInlineEditMenu);
-	protected readonly _inlineEditWidget = derivedDisposable(reader => {
-		if (!this._everHadInlineEdit.read(reader)) {
-			return undefined;
-		}
-		return this._instantiationService.createInstance(InlineEditsViewAndDiffProducer.hot.read(reader), this._editor, this._inlineEdit, this._model, this._focusIsInMenu);
-	})
-		.recomputeInitiallyAndOnChange(this._store);
+	private readonly _inlineEdit: IObservable<InlineEdit | undefined>;
+	private readonly _everHadInlineEdit: IObservable<boolean>;
+	protected readonly _inlineEditWidget: IObservable<InlineEditsViewAndDiffProducer | undefined>;
 
-	private readonly _fontFamily = this._editorObs.getOption(EditorOption.inlineSuggest).map(val => val.fontFamily);
+	private readonly _fontFamily: IObservable<string>;
 
 	constructor(
 		private readonly _editor: ICodeEditor,
@@ -63,6 +39,45 @@ export class InlineCompletionsView extends Disposable {
 		@IInstantiationService private readonly _instantiationService: IInstantiationService,
 	) {
 		super();
+
+		this._ghostTexts = derived(this, (reader) => {
+			const model = this._model.read(reader);
+			return model?.ghostTexts.read(reader) ?? [];
+		});
+
+		this._stablizedGhostTexts = convertItemsToStableObservables(this._ghostTexts, this._store);
+		this._editorObs = observableCodeEditor(this._editor);
+
+		this._ghostTextWidgets = mapObservableArrayCached(this, this._stablizedGhostTexts, (ghostText, store) => derivedDisposable((reader) => this._instantiationService.createInstance(
+			GhostTextView.hot.read(reader),
+			this._editor,
+			{
+				ghostText: ghostText,
+				warning: this._model.map((m, reader) => {
+					const warning = m?.warning?.read(reader);
+					return warning ? { icon: warning.icon } : undefined;
+				}),
+				minReservedLineCount: constObservable(0),
+				targetTextModel: this._model.map(v => v?.textModel),
+			},
+			this._editorObs.getOption(EditorOption.inlineSuggest).map(v => ({ syntaxHighlightingEnabled: v.syntaxHighlightingEnabled })),
+			false,
+			false
+		)
+		).recomputeInitiallyAndOnChange(store)
+		).recomputeInitiallyAndOnChange(this._store);
+
+		this._inlineEdit = derived(this, reader => this._model.read(reader)?.inlineEditState.read(reader)?.inlineEdit);
+		this._everHadInlineEdit = derivedObservableWithCache<boolean>(this, (reader, last) => last || !!this._inlineEdit.read(reader) || !!this._model.read(reader)?.inlineCompletionState.read(reader)?.inlineCompletion?.sourceInlineCompletion.showInlineEditMenu);
+		this._inlineEditWidget = derivedDisposable(reader => {
+			if (!this._everHadInlineEdit.read(reader)) {
+				return undefined;
+			}
+			return this._instantiationService.createInstance(InlineEditsViewAndDiffProducer.hot.read(reader), this._editor, this._inlineEdit, this._model, this._focusIsInMenu);
+		})
+			.recomputeInitiallyAndOnChange(this._store);
+
+		this._fontFamily = this._editorObs.getOption(EditorOption.inlineSuggest).map(val => val.fontFamily);
 
 		this._register(createStyleSheetFromObservable(derived(reader => {
 			const fontFamily = this._fontFamily.read(reader);

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/components/gutterIndicatorMenu.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/components/gutterIndicatorMenu.ts
@@ -27,7 +27,7 @@ import { FirstFnArg, InlineEditTabAction } from '../utils/utils.js';
 
 export class GutterIndicatorMenuContent {
 
-	private readonly _inlineEditsShowCollapsed = this._editorObs.getOption(EditorOption.inlineSuggest).map(s => s.edits.showCollapsed);
+	private readonly _inlineEditsShowCollapsed: IObservable<boolean>;
 
 	constructor(
 		private readonly _host: IInlineEditsViewHost,
@@ -37,6 +37,7 @@ export class GutterIndicatorMenuContent {
 		@IKeybindingService private readonly _keybindingService: IKeybindingService,
 		@ICommandService private readonly _commandService: ICommandService,
 	) {
+		this._inlineEditsShowCollapsed = this._editorObs.getOption(EditorOption.inlineSuggest).map(s => s.edits.showCollapsed);
 	}
 
 	public toDisposableLiveElement(): LiveElement {

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditWithChanges.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditWithChanges.ts
@@ -4,16 +4,17 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { SingleLineEdit } from '../../../../../common/core/lineEdit.js';
+import { LineRange } from '../../../../../common/core/lineRange.js';
 import { Position } from '../../../../../common/core/position.js';
 import { AbstractText, TextEdit } from '../../../../../common/core/textEdit.js';
 import { Command } from '../../../../../common/languages.js';
 import { InlineCompletionItem } from '../../model/provideInlineCompletions.js';
 
 export class InlineEditWithChanges {
-	public readonly lineEdit = SingleLineEdit.fromSingleTextEdit(this.edit.toSingle(this.originalText), this.originalText);
+	public readonly lineEdit: SingleLineEdit;
 
-	public readonly originalLineRange = this.lineEdit.lineRange;
-	public readonly modifiedLineRange = this.lineEdit.toLineEdit().getNewLineRanges()[0];
+	public readonly originalLineRange: LineRange;
+	public readonly modifiedLineRange: LineRange;
 
 	constructor(
 		public readonly originalText: AbstractText,
@@ -23,6 +24,10 @@ export class InlineEditWithChanges {
 		public readonly commands: readonly Command[],
 		public readonly inlineCompletion: InlineCompletionItem
 	) {
+		this.lineEdit = SingleLineEdit.fromSingleTextEdit(this.edit.toSingle(this.originalText), this.originalText);
+
+		this.originalLineRange = this.lineEdit.lineRange;
+		this.modifiedLineRange = this.lineEdit.toLineEdit().getNewLineRanges()[0];
 	}
 
 	equals(other: InlineEditWithChanges) {

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/inlineEditsWordInsertView.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/inlineEditsWordInsertView.ts
@@ -23,7 +23,7 @@ export class InlineEditsWordInsertView extends Disposable implements IInlineEdit
 	private readonly _onDidClick = this._register(new Emitter<IMouseEvent>());
 	readonly onDidClick = this._onDidClick.event;
 
-	private readonly _start = this._editor.observePosition(constObservable(this._edit.range.getStartPosition()), this._store);
+	private readonly _start: IObservable<Point | null>;
 
 	private readonly _layout = derived(this, reader => {
 		const start = this._start.read(reader);
@@ -124,6 +124,8 @@ export class InlineEditsWordInsertView extends Disposable implements IInlineEdit
 		private readonly _tabAction: IObservable<InlineEditTabAction>
 	) {
 		super();
+
+		this._start = this._editor.observePosition(constObservable(this._edit.range.getStartPosition()), this._store);
 
 		this._register(this._editor.createOverlayWidget({
 			domNode: this._div.element,

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/originalEditorInlineDiffView.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/originalEditorInlineDiffView.ts
@@ -40,12 +40,9 @@ export class OriginalEditorInlineDiffView extends Disposable implements IInlineE
 	private readonly _onDidClick = this._register(new Emitter<IMouseEvent>());
 	readonly onDidClick = this._onDidClick.event;
 
-	readonly isHovered = observableCodeEditor(this._originalEditor).isTargetHovered(
-		p => p.target.type === MouseTargetType.CONTENT_TEXT && p.target.detail.injectedText?.options.attachedData instanceof InlineEditAttachedData,
-		this._store
-	);
+	readonly isHovered: IObservable<boolean>;
 
-	private readonly _tokenizationFinished = modelTokenizationFinished(this._modifiedTextModel);
+	private readonly _tokenizationFinished: IObservable<number>;
 
 	constructor(
 		private readonly _originalEditor: ICodeEditor,
@@ -53,6 +50,13 @@ export class OriginalEditorInlineDiffView extends Disposable implements IInlineE
 		private readonly _modifiedTextModel: ITextModel,
 	) {
 		super();
+
+		this.isHovered = observableCodeEditor(this._originalEditor).isTargetHovered(
+			p => p.target.type === MouseTargetType.CONTENT_TEXT && p.target.detail.injectedText?.options.attachedData instanceof InlineEditAttachedData,
+			this._store
+		);
+
+		this._tokenizationFinished = modelTokenizationFinished(this._modifiedTextModel);
 
 		this._register(observableCodeEditor(this._originalEditor).setDecorations(this._decorations.map(d => d?.originalDecorations ?? [])));
 

--- a/src/vs/editor/contrib/multicursor/browser/multicursor.ts
+++ b/src/vs/editor/contrib/multicursor/browser/multicursor.ts
@@ -803,7 +803,7 @@ export class CompatChangeAll extends MultiCursorSelectionControllerAction {
 }
 
 class SelectionHighlighterState {
-	private readonly _modelVersionId: number = this._model.getVersionId();
+	private readonly _modelVersionId: number;
 	private _cachedFindMatches: Range[] | null = null;
 
 	constructor(
@@ -813,6 +813,8 @@ class SelectionHighlighterState {
 		private readonly _wordSeparators: string | null,
 		prevState: SelectionHighlighterState | null
 	) {
+		this._modelVersionId = this._model.getVersionId();
+
 		if (prevState
 			&& this._model === prevState._model
 			&& this._searchText === prevState._searchText

--- a/src/vs/editor/contrib/placeholderText/browser/placeholderTextContribution.ts
+++ b/src/vs/editor/contrib/placeholderText/browser/placeholderTextContribution.ts
@@ -8,7 +8,7 @@ import { structuralEquals } from '../../../../base/common/equals.js';
 import { Disposable } from '../../../../base/common/lifecycle.js';
 import { autorun, constObservable, DebugOwner, derivedObservableWithCache, derivedOpts, derivedWithStore, IObservable, IReader } from '../../../../base/common/observable.js';
 import { ICodeEditor } from '../../../browser/editorBrowser.js';
-import { observableCodeEditor } from '../../../browser/observableCodeEditor.js';
+import { ObservableCodeEditor, observableCodeEditor } from '../../../browser/observableCodeEditor.js';
 import { EditorOption } from '../../../common/config/editorOptions.js';
 import { IEditorContribution } from '../../../common/editorCommon.js';
 
@@ -21,9 +21,9 @@ export class PlaceholderTextContribution extends Disposable implements IEditorCo
 	}
 
 	public static readonly ID = 'editor.contrib.placeholderText';
-	private readonly _editorObs = observableCodeEditor(this._editor);
+	private readonly _editorObs: ObservableCodeEditor;
 
-	private readonly _placeholderText = this._editorObs.getOption(EditorOption.placeholder);
+	private readonly _placeholderText: IObservable<string>;
 
 	private readonly _state = derivedOpts<{ placeholder: string } | undefined>({ owner: this, equalsFn: structuralEquals }, reader => {
 		const p = this._placeholderText.read(reader);
@@ -68,6 +68,11 @@ export class PlaceholderTextContribution extends Disposable implements IEditorCo
 		private readonly _editor: ICodeEditor,
 	) {
 		super();
+
+		this._editorObs = observableCodeEditor(this._editor);
+
+		this._placeholderText = this._editorObs.getOption(EditorOption.placeholder);
+
 		this._view.recomputeInitiallyAndOnChange(this._store);
 	}
 }

--- a/src/vs/editor/contrib/sectionHeaders/browser/sectionHeaders.ts
+++ b/src/vs/editor/contrib/sectionHeaders/browser/sectionHeaders.ts
@@ -8,7 +8,7 @@ import { Disposable } from '../../../../base/common/lifecycle.js';
 import { ICodeEditor } from '../../../browser/editorBrowser.js';
 import { EditorContributionInstantiation, registerEditorContribution } from '../../../browser/editorExtensions.js';
 import { EditorOption, IEditorMinimapOptions } from '../../../common/config/editorOptions.js';
-import { IEditorContribution } from '../../../common/editorCommon.js';
+import { IEditorContribution, IEditorDecorationsCollection } from '../../../common/editorCommon.js';
 import { StandardTokenType } from '../../../common/encodedTokenAttributes.js';
 import { ILanguageConfigurationService } from '../../../common/languages/languageConfigurationRegistry.js';
 import { IModelDeltaDecoration, MinimapPosition, MinimapSectionHeaderStyle, TrackedRangeStickiness } from '../../../common/model.js';
@@ -21,7 +21,7 @@ export class SectionHeaderDetector extends Disposable implements IEditorContribu
 	public static readonly ID: string = 'editor.sectionHeaderDetector';
 
 	private options: FindSectionHeaderOptions | undefined;
-	private decorations = this.editor.createDecorationsCollection();
+	private decorations: IEditorDecorationsCollection;
 	private computeSectionHeaders: RunOnceScheduler;
 	private computePromise: CancelablePromise<SectionHeader[]> | null;
 	private currentOccurrences: { [decorationId: string]: SectionHeaderOccurrence };
@@ -34,6 +34,7 @@ export class SectionHeaderDetector extends Disposable implements IEditorContribu
 		super();
 
 		this.options = this.createOptions(editor.getOption(EditorOption.minimap));
+		this.decorations = this.editor.createDecorationsCollection();
 		this.computePromise = null;
 		this.currentOccurrences = {};
 

--- a/src/vs/editor/contrib/stickyScroll/browser/stickyScrollWidget.ts
+++ b/src/vs/editor/contrib/stickyScroll/browser/stickyScrollWidget.ts
@@ -57,7 +57,7 @@ export class StickyScrollWidget extends Disposable implements IOverlayWidget {
 	private readonly _linesDomNode: HTMLElement = document.createElement('div');
 
 	private _previousState: StickyScrollWidgetState | undefined;
-	private _lineHeight: number = this._editor.getOption(EditorOption.lineHeight);
+	private _lineHeight: number;
 	private _renderedStickyLines: RenderedStickyLine[] = [];
 	private _lineNumbers: number[] = [];
 	private _lastLineRelativePosition: number = 0;
@@ -74,6 +74,8 @@ export class StickyScrollWidget extends Disposable implements IOverlayWidget {
 		private readonly _editor: ICodeEditor
 	) {
 		super();
+
+		this._lineHeight = this._editor.getOption(EditorOption.lineHeight);
 
 		this._lineNumbersDomNode.className = 'sticky-widget-line-numbers';
 		this._lineNumbersDomNode.setAttribute('role', 'none');

--- a/src/vs/editor/contrib/unicodeHighlighter/browser/unicodeHighlighter.ts
+++ b/src/vs/editor/contrib/unicodeHighlighter/browser/unicodeHighlighter.ts
@@ -15,7 +15,7 @@ import { IActiveCodeEditor, ICodeEditor } from '../../../browser/editorBrowser.j
 import { EditorAction, EditorContributionInstantiation, registerEditorAction, registerEditorContribution, ServicesAccessor } from '../../../browser/editorExtensions.js';
 import { InUntrustedWorkspace, inUntrustedWorkspace, EditorOption, InternalUnicodeHighlightOptions, unicodeHighlightConfigKeys } from '../../../common/config/editorOptions.js';
 import { Range } from '../../../common/core/range.js';
-import { IEditorContribution } from '../../../common/editorCommon.js';
+import { IEditorContribution, IEditorDecorationsCollection } from '../../../common/editorCommon.js';
 import { IModelDecoration, IModelDeltaDecoration, ITextModel, TrackedRangeStickiness } from '../../../common/model.js';
 import { ModelDecorationOptions } from '../../../common/model/textModel.js';
 import { UnicodeHighlighterOptions, UnicodeHighlighterReason, UnicodeHighlighterReasonKind, UnicodeTextModelHighlighter } from '../../../common/services/unicodeTextModelHighlighter.js';
@@ -212,9 +212,9 @@ function resolveOptions(trusted: boolean, options: InternalUnicodeHighlightOptio
 }
 
 class DocumentUnicodeHighlighter extends Disposable {
-	private readonly _model: ITextModel = this._editor.getModel();
+	private readonly _model: ITextModel;
 	private readonly _updateSoon: RunOnceScheduler;
-	private _decorations = this._editor.createDecorationsCollection();
+	private _decorations: IEditorDecorationsCollection;
 
 	constructor(
 		private readonly _editor: IActiveCodeEditor,
@@ -223,7 +223,9 @@ class DocumentUnicodeHighlighter extends Disposable {
 		@IEditorWorkerService private readonly _editorWorkerService: IEditorWorkerService,
 	) {
 		super();
+		this._model = this._editor.getModel();
 		this._updateSoon = this._register(new RunOnceScheduler(() => this._update(), 250));
+		this._decorations = this._editor.createDecorationsCollection();
 
 		this._register(this._editor.onDidChangeModelContent(() => {
 			this._updateSoon.schedule();
@@ -296,9 +298,9 @@ class DocumentUnicodeHighlighter extends Disposable {
 
 class ViewportUnicodeHighlighter extends Disposable {
 
-	private readonly _model: ITextModel = this._editor.getModel();
+	private readonly _model: ITextModel;
 	private readonly _updateSoon: RunOnceScheduler;
-	private readonly _decorations = this._editor.createDecorationsCollection();
+	private readonly _decorations: IEditorDecorationsCollection;
 
 	constructor(
 		private readonly _editor: IActiveCodeEditor,
@@ -307,7 +309,9 @@ class ViewportUnicodeHighlighter extends Disposable {
 	) {
 		super();
 
+		this._model = this._editor.getModel();
 		this._updateSoon = this._register(new RunOnceScheduler(() => this._update(), 250));
+		this._decorations = this._editor.createDecorationsCollection();
 
 		this._register(this._editor.onDidLayoutChange(() => {
 			this._updateSoon.schedule();

--- a/src/vs/editor/contrib/zoneWidget/browser/zoneWidget.ts
+++ b/src/vs/editor/contrib/zoneWidget/browser/zoneWidget.ts
@@ -117,13 +117,15 @@ class Arrow {
 	private static readonly _IdGenerator = new IdGenerator('.arrow-decoration-');
 
 	private readonly _ruleName = Arrow._IdGenerator.nextId();
-	private readonly _decorations = this._editor.createDecorationsCollection();
+	private readonly _decorations: IEditorDecorationsCollection;
 	private _color: string | null = null;
 	private _height: number = -1;
 
 	constructor(
 		private readonly _editor: ICodeEditor
-	) { }
+	) {
+		this._decorations = this._editor.createDecorationsCollection();
+	}
 
 	dispose(): void {
 		this.hide();

--- a/src/vs/editor/standalone/browser/quickInput/standaloneQuickInputService.ts
+++ b/src/vs/editor/standalone/browser/quickInput/standaloneQuickInputService.ts
@@ -174,9 +174,11 @@ export class QuickInputEditorContribution implements IEditorContribution {
 		return editor.getContribution<QuickInputEditorContribution>(QuickInputEditorContribution.ID);
 	}
 
-	readonly widget = new QuickInputEditorWidget(this.editor);
+	readonly widget: QuickInputEditorWidget;
 
-	constructor(private editor: ICodeEditor) { }
+	constructor(private editor: ICodeEditor) {
+		this.widget = new QuickInputEditorWidget(this.editor);
+	}
 
 	dispose(): void {
 		this.widget.dispose();

--- a/src/vs/platform/auxiliaryWindow/electron-main/auxiliaryWindow.ts
+++ b/src/vs/platform/auxiliaryWindow/electron-main/auxiliaryWindow.ts
@@ -20,7 +20,7 @@ export interface IAuxiliaryWindow extends IBaseWindow {
 
 export class AuxiliaryWindow extends BaseWindow implements IAuxiliaryWindow {
 
-	readonly id = this.webContents.id;
+	readonly id: number;
 	parentId = -1;
 
 	override get win() {
@@ -42,6 +42,8 @@ export class AuxiliaryWindow extends BaseWindow implements IAuxiliaryWindow {
 		@ILifecycleMainService private readonly lifecycleMainService: ILifecycleMainService
 	) {
 		super(configurationService, stateService, environmentMainService, logService);
+
+		this.id = this.webContents.id;
 
 		// Try to claim window
 		this.tryClaimWindow();

--- a/src/vs/platform/backup/electron-main/backupMainService.ts
+++ b/src/vs/platform/backup/electron-main/backupMainService.ts
@@ -27,7 +27,7 @@ export class BackupMainService implements IBackupMainService {
 
 	private static readonly backupWorkspacesMetadataStorageKey = 'backupWorkspaces';
 
-	protected backupHome = this.environmentMainService.backupHome;
+	protected backupHome: string;
 
 	private workspaces: IWorkspaceBackupInfo[] = [];
 	private folders: IFolderBackupInfo[] = [];
@@ -45,6 +45,7 @@ export class BackupMainService implements IBackupMainService {
 		@ILogService private readonly logService: ILogService,
 		@IStateService private readonly stateService: IStateService
 	) {
+		this.backupHome = this.environmentMainService.backupHome;
 	}
 
 	async initialize(): Promise<void> {

--- a/src/vs/platform/configuration/common/configurations.ts
+++ b/src/vs/platform/configuration/common/configurations.ts
@@ -22,13 +22,15 @@ export class DefaultConfiguration extends Disposable {
 	private readonly _onDidChangeConfiguration = this._register(new Emitter<{ defaults: ConfigurationModel; properties: string[] }>());
 	readonly onDidChangeConfiguration = this._onDidChangeConfiguration.event;
 
-	private _configurationModel = ConfigurationModel.createEmptyModel(this.logService);
+	private _configurationModel: ConfigurationModel;
 	get configurationModel(): ConfigurationModel {
 		return this._configurationModel;
 	}
 
 	constructor(private readonly logService: ILogService) {
 		super();
+
+		this._configurationModel = ConfigurationModel.createEmptyModel(this.logService);
 	}
 
 	async initialize(): Promise<ConfigurationModel> {
@@ -91,7 +93,7 @@ export class PolicyConfiguration extends Disposable implements IPolicyConfigurat
 	private readonly _onDidChangeConfiguration = this._register(new Emitter<ConfigurationModel>());
 	readonly onDidChangeConfiguration = this._onDidChangeConfiguration.event;
 
-	private _configurationModel = ConfigurationModel.createEmptyModel(this.logService);
+	private _configurationModel: ConfigurationModel;
 	get configurationModel() { return this._configurationModel; }
 
 	constructor(
@@ -100,6 +102,8 @@ export class PolicyConfiguration extends Disposable implements IPolicyConfigurat
 		@ILogService private readonly logService: ILogService
 	) {
 		super();
+
+		this._configurationModel = ConfigurationModel.createEmptyModel(this.logService);
 	}
 
 	async initialize(): Promise<ConfigurationModel> {

--- a/src/vs/platform/contextview/browser/contextViewService.ts
+++ b/src/vs/platform/contextview/browser/contextViewService.ts
@@ -12,12 +12,14 @@ import { getWindow } from '../../../base/browser/dom.js';
 export class ContextViewHandler extends Disposable implements IContextViewProvider {
 
 	private openContextView: IOpenContextView | undefined;
-	protected readonly contextView = this._register(new ContextView(this.layoutService.mainContainer, ContextViewDOMPosition.ABSOLUTE));
+	protected readonly contextView: ContextView;
 
 	constructor(
 		@ILayoutService private readonly layoutService: ILayoutService
 	) {
 		super();
+
+		this.contextView = this._register(new ContextView(this.layoutService.mainContainer, ContextViewDOMPosition.ABSOLUTE));
 
 		this.layout();
 		this._register(layoutService.onDidLayoutContainer(() => this.layout()));

--- a/src/vs/platform/extensionManagement/common/extensionsScannerService.ts
+++ b/src/vs/platform/extensionManagement/common/extensionsScannerService.ts
@@ -149,9 +149,9 @@ export abstract class AbstractExtensionsScannerService extends Disposable implem
 	private readonly _onDidChangeCache = this._register(new Emitter<ExtensionType>());
 	readonly onDidChangeCache = this._onDidChangeCache.event;
 
-	private readonly systemExtensionsCachedScanner = this._register(this.instantiationService.createInstance(CachedExtensionsScanner, this.currentProfile));
-	private readonly userExtensionsCachedScanner = this._register(this.instantiationService.createInstance(CachedExtensionsScanner, this.currentProfile));
-	private readonly extensionsScanner = this._register(this.instantiationService.createInstance(ExtensionsScanner));
+	private readonly systemExtensionsCachedScanner: CachedExtensionsScanner;
+	private readonly userExtensionsCachedScanner: CachedExtensionsScanner;
+	private readonly extensionsScanner: ExtensionsScanner;
 
 	constructor(
 		readonly systemExtensionsLocation: URI,
@@ -168,6 +168,10 @@ export abstract class AbstractExtensionsScannerService extends Disposable implem
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
 	) {
 		super();
+
+		this.systemExtensionsCachedScanner = this._register(this.instantiationService.createInstance(CachedExtensionsScanner, this.currentProfile));
+		this.userExtensionsCachedScanner = this._register(this.instantiationService.createInstance(CachedExtensionsScanner, this.currentProfile));
+		this.extensionsScanner = this._register(this.instantiationService.createInstance(ExtensionsScanner));
 
 		this._register(this.systemExtensionsCachedScanner.onDidChangeCache(() => this._onDidChangeCache.fire(ExtensionType.System)));
 		this._register(this.userExtensionsCachedScanner.onDidChangeCache(() => this._onDidChangeCache.fire(ExtensionType.User)));

--- a/src/vs/platform/files/node/diskFileSystemProviderServer.ts
+++ b/src/vs/platform/files/node/diskFileSystemProviderServer.ts
@@ -272,7 +272,7 @@ export abstract class AbstractSessionFileWatcher extends Disposable implements I
 	// This is important because we want to ensure that we only
 	// forward events from the watched paths for this session and
 	// not other clients that asked to watch other paths.
-	private readonly fileWatcher = this._register(new DiskFileSystemProvider(this.logService));
+	private readonly fileWatcher: DiskFileSystemProvider;
 
 	constructor(
 		private readonly uriTransformer: IURITransformer,
@@ -281,6 +281,8 @@ export abstract class AbstractSessionFileWatcher extends Disposable implements I
 		private readonly environmentService: IEnvironmentService
 	) {
 		super();
+
+		this.fileWatcher = this._register(new DiskFileSystemProvider(this.logService));
 
 		this.registerListeners(sessionEmitter);
 	}

--- a/src/vs/platform/files/node/watcher/parcel/parcelWatcher.ts
+++ b/src/vs/platform/files/node/watcher/parcel/parcelWatcher.ts
@@ -12,7 +12,7 @@ import { CancellationToken, CancellationTokenSource } from '../../../../../base/
 import { toErrorMessage } from '../../../../../base/common/errorMessage.js';
 import { Emitter, Event } from '../../../../../base/common/event.js';
 import { randomPath, isEqual, isEqualOrParent } from '../../../../../base/common/extpath.js';
-import { GLOBSTAR, patternsEquals } from '../../../../../base/common/glob.js';
+import { GLOBSTAR, ParsedPattern, patternsEquals } from '../../../../../base/common/glob.js';
 import { BaseWatcher } from '../baseWatcher.js';
 import { TernarySearchTree } from '../../../../../base/common/ternarySearchTree.js';
 import { normalizeNFC } from '../../../../../base/common/normalization.js';
@@ -37,8 +37,8 @@ export class ParcelWatcherInstance extends Disposable {
 	private didStop = false;
 	get stopped(): boolean { return this.didStop; }
 
-	private readonly includes = this.request.includes ? parseWatcherPatterns(this.request.path, this.request.includes) : undefined;
-	private readonly excludes = this.request.excludes ? parseWatcherPatterns(this.request.path, this.request.excludes) : undefined;
+	private readonly includes: ParsedPattern[] | undefined;
+	private readonly excludes: ParsedPattern[] | undefined;
 
 	private readonly subscriptions = new Map<string, Set<(change: IFileChange) => void>>();
 
@@ -64,6 +64,9 @@ export class ParcelWatcherInstance extends Disposable {
 		private readonly stopFn: () => Promise<void>
 	) {
 		super();
+
+		this.includes = this.request.includes ? parseWatcherPatterns(this.request.path, this.request.includes) : undefined;
+		this.excludes = this.request.excludes ? parseWatcherPatterns(this.request.path, this.request.excludes) : undefined;
 
 		this._register(toDisposable(() => this.subscriptions.clear()));
 	}

--- a/src/vs/platform/quickinput/browser/commandsQuickAccess.ts
+++ b/src/vs/platform/quickinput/browser/commandsQuickAccess.ts
@@ -49,7 +49,7 @@ export abstract class AbstractCommandsQuickAccessProvider extends PickerQuickAcc
 
 	private static WORD_FILTER = or(matchesPrefix, matchesWords, matchesContiguousSubString);
 
-	private readonly commandsHistory = this._register(this.instantiationService.createInstance(CommandsHistory));
+	private readonly commandsHistory: CommandsHistory;
 
 	protected override readonly options: ICommandsQuickAccessOptions;
 
@@ -62,6 +62,8 @@ export abstract class AbstractCommandsQuickAccessProvider extends PickerQuickAcc
 		@IDialogService private readonly dialogService: IDialogService
 	) {
 		super(AbstractCommandsQuickAccessProvider.PREFIX, options);
+
+		this.commandsHistory = this._register(this.instantiationService.createInstance(CommandsHistory));
 
 		this.options = options;
 	}

--- a/src/vs/platform/quickinput/browser/quickInputController.ts
+++ b/src/vs/platform/quickinput/browser/quickInputController.ts
@@ -17,14 +17,14 @@ import { Disposable, DisposableStore, dispose } from '../../../base/common/lifec
 import Severity from '../../../base/common/severity.js';
 import { isString } from '../../../base/common/types.js';
 import { localize } from '../../../nls.js';
-import { IInputBox, IInputOptions, IKeyMods, IPickOptions, IQuickInput, IQuickInputButton, IQuickNavigateConfiguration, IQuickPick, IQuickPickItem, IQuickWidget, QuickInputHideReason, QuickPickInput, QuickPickFocus } from '../common/quickInput.js';
+import { IInputBox, IInputOptions, IKeyMods, IPickOptions, IQuickInput, IQuickInputButton, IQuickNavigateConfiguration, IQuickPick, IQuickPickItem, IQuickWidget, QuickInputHideReason, QuickPickInput, QuickPickFocus, QuickInputType } from '../common/quickInput.js';
 import { QuickInputBox } from './quickInputBox.js';
 import { QuickInputUI, Writeable, IQuickInputStyles, IQuickInputOptions, QuickPick, backButton, InputBox, Visibilities, QuickWidget, InQuickInputContextKey, QuickInputTypeContextKey, EndOfQuickInputBoxContextKey, QuickInputAlignmentContextKey } from './quickInput.js';
 import { ILayoutService } from '../../layout/browser/layoutService.js';
 import { mainWindow } from '../../../base/browser/window.js';
 import { IInstantiationService } from '../../instantiation/common/instantiation.js';
 import { QuickInputTree } from './quickInputTree.js';
-import { IContextKeyService } from '../../contextkey/common/contextkey.js';
+import { IContextKey, IContextKeyService } from '../../contextkey/common/contextkey.js';
 import './quickInputActions.js';
 import { autorun, observableValue } from '../../../base/common/observable.js';
 import { StandardMouseEvent } from '../../../base/browser/mouseEvent.js';
@@ -75,9 +75,9 @@ export class QuickInputController extends Disposable {
 	private viewState: QuickInputViewState | undefined;
 	private dndController: QuickInputDragAndDropController | undefined;
 
-	private readonly inQuickInputContext = InQuickInputContextKey.bindTo(this.contextKeyService);
-	private readonly quickInputTypeContext = QuickInputTypeContextKey.bindTo(this.contextKeyService);
-	private readonly endOfQuickInputBoxContext = EndOfQuickInputBoxContextKey.bindTo(this.contextKeyService);
+	private readonly inQuickInputContext: IContextKey<boolean>;
+	private readonly quickInputTypeContext: IContextKey<QuickInputType>;
+	private readonly endOfQuickInputBoxContext: IContextKey<boolean>;
 
 	constructor(
 		private options: IQuickInputOptions,
@@ -102,6 +102,9 @@ export class QuickInputController extends Disposable {
 			}
 		}));
 		this.viewState = this.loadViewState();
+		this.inQuickInputContext = InQuickInputContextKey.bindTo(this.contextKeyService);
+		this.quickInputTypeContext = QuickInputTypeContextKey.bindTo(this.contextKeyService);
+		this.endOfQuickInputBoxContext = EndOfQuickInputBoxContextKey.bindTo(this.contextKeyService);
 	}
 
 	private registerKeyModsListeners(window: Window, disposables: DisposableStore): void {
@@ -911,7 +914,7 @@ class QuickInputDragAndDropController extends Disposable {
 	private readonly _controlsOnLeft: boolean;
 	private readonly _controlsOnRight: boolean;
 
-	private _quickInputAlignmentContext = QuickInputAlignmentContextKey.bindTo(this._contextKeyService);
+	private _quickInputAlignmentContext: IContextKey<'top' | 'center' | undefined>;
 
 	constructor(
 		private _container: HTMLElement,
@@ -929,6 +932,7 @@ class QuickInputDragAndDropController extends Disposable {
 		// Use CSS calculations to avoid having to force layout with `.clientWidth`
 		this._controlsOnLeft = customTitleBar && platform === Platform.Mac;
 		this._controlsOnRight = customTitleBar && (platform === Platform.Windows || platform === Platform.Linux);
+		this._quickInputAlignmentContext = QuickInputAlignmentContextKey.bindTo(this._contextKeyService);
 		this._registerLayoutListener();
 		this.registerMouseListeners();
 		this.dndViewState.set({ ...initialViewState, done: true }, undefined);

--- a/src/vs/platform/state/node/stateService.ts
+++ b/src/vs/platform/state/node/stateService.ts
@@ -25,7 +25,7 @@ export class FileStorage extends Disposable {
 	private storage: StorageDatabase = Object.create(null);
 	private lastSavedStorageContents = '';
 
-	private readonly flushDelayer = this._register(new ThrottledDelayer<void>(this.saveStrategy === SaveStrategy.IMMEDIATE ? 0 : 100 /* buffer saves over a short time */));
+	private readonly flushDelayer: ThrottledDelayer<void>;
 
 	private initializing: Promise<void> | undefined = undefined;
 	private closing: Promise<void> | undefined = undefined;
@@ -37,6 +37,8 @@ export class FileStorage extends Disposable {
 		private readonly fileService: IFileService,
 	) {
 		super();
+
+		this.flushDelayer = this._register(new ThrottledDelayer<void>(this.saveStrategy === SaveStrategy.IMMEDIATE ? 0 : 100 /* buffer saves over a short time */));
 	}
 
 	init(): Promise<void> {

--- a/src/vs/platform/storage/common/storage.ts
+++ b/src/vs/platform/storage/common/storage.ts
@@ -328,11 +328,13 @@ export abstract class AbstractStorageService extends Disposable implements IStor
 
 	private initializationPromise: Promise<void> | undefined;
 
-	private readonly flushWhenIdleScheduler = this._register(new RunOnceScheduler(() => this.doFlushWhenIdle(), this.options.flushInterval));
+	private readonly flushWhenIdleScheduler: RunOnceScheduler;
 	private readonly runFlushWhenIdle = this._register(new MutableDisposable());
 
 	constructor(private readonly options: IStorageServiceOptions = { flushInterval: AbstractStorageService.DEFAULT_FLUSH_INTERVAL }) {
 		super();
+
+		this.flushWhenIdleScheduler = this._register(new RunOnceScheduler(() => this.doFlushWhenIdle(), this.options.flushInterval));
 	}
 
 	onDidChangeValue(scope: StorageScope.WORKSPACE, key: string | undefined, disposable: DisposableStore): Event<IWorkspaceStorageValueChangeEvent>;

--- a/src/vs/platform/storage/common/storageService.ts
+++ b/src/vs/platform/storage/common/storageService.ts
@@ -17,16 +17,16 @@ import { IAnyWorkspaceIdentifier } from '../../workspace/common/workspace.js';
 
 export class RemoteStorageService extends AbstractStorageService {
 
-	private readonly applicationStorageProfile = this.initialProfiles.defaultProfile;
-	private readonly applicationStorage = this.createApplicationStorage();
+	private readonly applicationStorageProfile: IUserDataProfile;
+	private readonly applicationStorage: IStorage;
 
-	private profileStorageProfile = this.initialProfiles.currentProfile;
+	private profileStorageProfile: IUserDataProfile;
 	private readonly profileStorageDisposables = this._register(new DisposableStore());
-	private profileStorage = this.createProfileStorage(this.profileStorageProfile);
+	private profileStorage: IStorage;
 
-	private workspaceStorageId = this.initialWorkspace?.id;
+	private workspaceStorageId: string | undefined;
 	private readonly workspaceStorageDisposables = this._register(new DisposableStore());
-	private workspaceStorage = this.createWorkspaceStorage(this.initialWorkspace);
+	private workspaceStorage: IStorage | undefined;
 
 	constructor(
 		private readonly initialWorkspace: IAnyWorkspaceIdentifier | undefined,
@@ -35,6 +35,15 @@ export class RemoteStorageService extends AbstractStorageService {
 		private readonly environmentService: IEnvironmentService
 	) {
 		super();
+
+		this.applicationStorageProfile = this.initialProfiles.defaultProfile;
+		this.applicationStorage = this.createApplicationStorage();
+
+		this.profileStorageProfile = this.initialProfiles.currentProfile;
+		this.profileStorage = this.createProfileStorage(this.profileStorageProfile);
+
+		this.workspaceStorageId = this.initialWorkspace?.id;
+		this.workspaceStorage = this.createWorkspaceStorage(this.initialWorkspace);
 	}
 
 	private createApplicationStorage(): IStorage {

--- a/src/vs/platform/storage/electron-main/storageMainService.ts
+++ b/src/vs/platform/storage/electron-main/storageMainService.ts
@@ -332,13 +332,15 @@ export class ApplicationStorageMainService extends AbstractStorageService implem
 
 	declare readonly _serviceBrand: undefined;
 
-	readonly whenReady = this.storageMainService.applicationStorage.whenInit;
+	readonly whenReady: Promise<void>;
 
 	constructor(
 		@IUserDataProfilesService private readonly userDataProfilesService: IUserDataProfilesService,
 		@IStorageMainService private readonly storageMainService: IStorageMainService
 	) {
 		super();
+
+		this.whenReady = this.storageMainService.applicationStorage.whenInit;
 	}
 
 	protected doInitialize(): Promise<void> {

--- a/src/vs/platform/terminal/common/capabilities/commandDetectionCapability.ts
+++ b/src/vs/platform/terminal/common/capabilities/commandDetectionCapability.ts
@@ -28,7 +28,7 @@ export class CommandDetectionCapability extends Disposable implements ICommandDe
 	protected _commands: TerminalCommand[] = [];
 	private _cwd: string | undefined;
 	private _promptTerminator: string | undefined;
-	private _currentCommand: PartialTerminalCommand = new PartialTerminalCommand(this._terminal);
+	private _currentCommand: PartialTerminalCommand;
 	private _commandMarkers: IMarker[] = [];
 	private _dimensions: ITerminalDimensions;
 	private __isCommandStorageDisabled: boolean = false;
@@ -79,6 +79,8 @@ export class CommandDetectionCapability extends Disposable implements ICommandDe
 		super();
 
 		this._promptInputModel = this._register(new PromptInputModel(this._terminal, this.onCommandStarted, this.onCommandStartChanged, this.onCommandExecuted, this._logService));
+
+		this._currentCommand = new PartialTerminalCommand(this._terminal);
 
 		// Pull command line from the buffer if it was not set explicitly
 		this._register(this.onCommandExecuted(command => {

--- a/src/vs/platform/terminal/node/ptyService.ts
+++ b/src/vs/platform/terminal/node/ptyService.ts
@@ -78,7 +78,7 @@ export class PtyService extends Disposable implements IPtyService {
 
 	// #region Pty service contribution RPC calls
 
-	private readonly _autoRepliesContribution = new AutoRepliesPtyServiceContribution(this._logService);
+	private readonly _autoRepliesContribution: AutoRepliesPtyServiceContribution;
 	@traceRpc
 	async installAutoReply(match: string, reply: string) {
 		await this._autoRepliesContribution.installAutoReply(match, reply);
@@ -89,10 +89,7 @@ export class PtyService extends Disposable implements IPtyService {
 	}
 
 	// #endregion
-
-	private readonly _contributions: IPtyServiceContribution[] = [
-		this._autoRepliesContribution
-	];
+	private readonly _contributions: IPtyServiceContribution[];
 
 	private _lastPtyId: number = 0;
 
@@ -138,6 +135,12 @@ export class PtyService extends Disposable implements IPtyService {
 		private readonly _simulatedLatency: number
 	) {
 		super();
+
+		this._autoRepliesContribution = new AutoRepliesPtyServiceContribution(this._logService);
+
+		this._contributions = [
+			this._autoRepliesContribution
+		];
 
 		this._register(toDisposable(() => {
 			for (const pty of this._ptys.values()) {

--- a/src/vs/platform/userData/common/fileUserDataProvider.ts
+++ b/src/vs/platform/userData/common/fileUserDataProvider.ts
@@ -2,7 +2,7 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import { Emitter } from '../../../base/common/event.js';
+import { Emitter, Event } from '../../../base/common/event.js';
 import { Disposable, IDisposable, toDisposable } from '../../../base/common/lifecycle.js';
 import { IFileSystemProviderWithFileReadWriteCapability, IFileChange, IWatchOptions, IStat, IFileOverwriteOptions, FileType, IFileWriteOptions, IFileDeleteOptions, FileSystemProviderCapabilities, IFileSystemProviderWithFileReadStreamCapability, IFileReadStreamOptions, IFileSystemProviderWithFileAtomicReadCapability, hasFileFolderCopyCapability, IFileSystemProviderWithOpenReadWriteCloseCapability, IFileOpenOptions, IFileSystemProviderWithFileAtomicWriteCapability, IFileSystemProviderWithFileAtomicDeleteCapability, IFileSystemProviderWithFileFolderCopyCapability, IFileSystemProviderWithFileCloneCapability, hasFileCloneCapability, IFileAtomicReadOptions, IFileAtomicOptions } from '../../files/common/files.js';
 import { URI } from '../../../base/common/uri.js';
@@ -29,8 +29,8 @@ export class FileUserDataProvider extends Disposable implements
 	IFileSystemProviderWithFileAtomicDeleteCapability,
 	IFileSystemProviderWithFileCloneCapability {
 
-	readonly capabilities = this.fileSystemProvider.capabilities;
-	readonly onDidChangeCapabilities = this.fileSystemProvider.onDidChangeCapabilities;
+	readonly capabilities: FileSystemProviderCapabilities;
+	readonly onDidChangeCapabilities: Event<void>;
 
 	private readonly _onDidChangeFile = this._register(new Emitter<readonly IFileChange[]>());
 	readonly onDidChangeFile = this._onDidChangeFile.event;
@@ -47,6 +47,10 @@ export class FileUserDataProvider extends Disposable implements
 		private readonly logService: ILogService,
 	) {
 		super();
+
+		this.capabilities = this.fileSystemProvider.capabilities;
+		this.onDidChangeCapabilities = this.fileSystemProvider.onDidChangeCapabilities;
+
 		this.updateAtomicReadWritesResources();
 		this._register(userDataProfilesService.onDidChangeProfiles(() => this.updateAtomicReadWritesResources()));
 		this._register(this.fileSystemProvider.onDidChangeFile(e => this.handleFileChanges(e)));

--- a/src/vs/platform/userDataSync/common/abstractSynchronizer.ts
+++ b/src/vs/platform/userDataSync/common/abstractSynchronizer.ts
@@ -145,13 +145,13 @@ export abstract class AbstractSynchroniser extends Disposable implements IUserDa
 	readonly onDidChangeLocal: Event<void> = this._onDidChangeLocal.event;
 
 	protected readonly lastSyncResource: URI;
-	private readonly lastSyncUserDataStateKey = `${this.collection ? `${this.collection}.` : ''}${this.syncResource.syncResource}.lastSyncUserData`;
+	private readonly lastSyncUserDataStateKey: string;
 	private hasSyncResourceStateVersionChanged: boolean = false;
 	protected readonly syncResourceLogLabel: string;
 
 	protected syncHeaders: IHeaders = {};
 
-	readonly resource = this.syncResource.syncResource;
+	readonly resource: SyncResource;
 
 	constructor(
 		readonly syncResource: IUserDataSyncResource,
@@ -173,6 +173,9 @@ export abstract class AbstractSynchroniser extends Disposable implements IUserDa
 		this.syncFolder = this.extUri.joinPath(environmentService.userDataSyncHome, ...getPathSegments(syncResource.profile.isDefault ? undefined : syncResource.profile.id, syncResource.syncResource));
 		this.syncPreviewFolder = this.extUri.joinPath(this.syncFolder, PREVIEW_DIR_NAME);
 		this.lastSyncResource = getLastSyncResourceUri(syncResource.profile.isDefault ? undefined : syncResource.profile.id, syncResource.syncResource, environmentService, this.extUri);
+		this.lastSyncUserDataStateKey = `${this.collection ? `${this.collection}.` : ''}${this.syncResource.syncResource}.lastSyncUserData`;
+		this.resource = this.syncResource.syncResource;
+
 		this.currentMachineIdPromise = getServiceMachineId(environmentService, fileService, storageService);
 	}
 

--- a/src/vs/platform/utilityProcess/electron-main/utilityProcessWorkerMainService.ts
+++ b/src/vs/platform/utilityProcess/electron-main/utilityProcessWorkerMainService.ts
@@ -99,7 +99,7 @@ class UtilityProcessWorker extends Disposable {
 	private readonly _onDidTerminate = this._register(new Emitter<IUtilityProcessWorkerProcessExit>());
 	readonly onDidTerminate = this._onDidTerminate.event;
 
-	private readonly utilityProcess = this._register(new WindowUtilityProcess(this.logService, this.windowsMainService, this.telemetryService, this.lifecycleMainService));
+	private readonly utilityProcess: WindowUtilityProcess;
 
 	constructor(
 		@ILogService private readonly logService: ILogService,
@@ -109,6 +109,8 @@ class UtilityProcessWorker extends Disposable {
 		private readonly configuration: IUtilityProcessWorkerCreateConfiguration
 	) {
 		super();
+
+		this.utilityProcess = this._register(new WindowUtilityProcess(this.logService, this.windowsMainService, this.telemetryService, this.lifecycleMainService));
 
 		this.registerListeners();
 	}

--- a/src/vs/platform/windows/electron-main/windowImpl.ts
+++ b/src/vs/platform/windows/electron-main/windowImpl.ts
@@ -26,7 +26,7 @@ import { IFileService } from '../../files/common/files.js';
 import { ILifecycleMainService } from '../../lifecycle/electron-main/lifecycleMainService.js';
 import { ILogService } from '../../log/common/log.js';
 import { IProductService } from '../../product/common/productService.js';
-import { IProtocolMainService } from '../../protocol/electron-main/protocol.js';
+import { IIPCObjectUrl, IProtocolMainService } from '../../protocol/electron-main/protocol.js';
 import { resolveMarketplaceHeaders } from '../../externalServices/common/marketplace.js';
 import { IApplicationStorageMainService, IStorageMainService } from '../../storage/electron-main/storageMainService.js';
 import { ITelemetryService } from '../../telemetry/common/telemetry.js';
@@ -536,7 +536,7 @@ export class CodeWindow extends BaseWindow implements ICodeWindow {
 
 	private customZoomLevel: number | undefined = undefined;
 
-	private readonly configObjectUrl = this._register(this.protocolMainService.createIPCObjectUrl<INativeWindowConfiguration>());
+	private readonly configObjectUrl: IIPCObjectUrl<INativeWindowConfiguration>;
 	private pendingLoadConfig: INativeWindowConfiguration | undefined;
 	private wasLoaded = false;
 
@@ -564,6 +564,8 @@ export class CodeWindow extends BaseWindow implements ICodeWindow {
 		@IInstantiationService instantiationService: IInstantiationService
 	) {
 		super(configurationService, stateService, environmentMainService, logService);
+
+		this.configObjectUrl = this._register(this.protocolMainService.createIPCObjectUrl<INativeWindowConfiguration>());
 
 		//#region create browser window
 		{

--- a/src/vs/platform/windows/electron-main/windowsMainService.ts
+++ b/src/vs/platform/windows/electron-main/windowsMainService.ts
@@ -210,7 +210,7 @@ export class WindowsMainService extends Disposable implements IWindowsMainServic
 
 	private readonly windows = new Map<number, ICodeWindow>();
 
-	private readonly windowsStateHandler = this._register(new WindowsStateHandler(this, this.stateService, this.lifecycleMainService, this.logService, this.configurationService));
+	private readonly windowsStateHandler: WindowsStateHandler;
 
 	constructor(
 		private readonly machineId: string,
@@ -237,6 +237,8 @@ export class WindowsMainService extends Disposable implements IWindowsMainServic
 		@ICSSDevelopmentService private readonly cssDevelopmentService: ICSSDevelopmentService
 	) {
 		super();
+
+		this.windowsStateHandler = this._register(new WindowsStateHandler(this, this.stateService, this.lifecycleMainService, this.logService, this.configurationService));
 
 		this.registerListeners();
 	}

--- a/src/vs/platform/windows/electron-main/windowsStateHandler.ts
+++ b/src/vs/platform/windows/electron-main/windowsStateHandler.ts
@@ -55,7 +55,7 @@ export class WindowsStateHandler extends Disposable {
 	private static readonly windowsStateStorageKey = 'windowsState';
 
 	get state() { return this._state; }
-	private readonly _state = restoreWindowsState(this.stateService.getItem<ISerializedWindowsState>(WindowsStateHandler.windowsStateStorageKey));
+	private readonly _state: IWindowsState;
 
 	private lastClosedState: IWindowState | undefined = undefined;
 
@@ -69,6 +69,8 @@ export class WindowsStateHandler extends Disposable {
 		@IConfigurationService private readonly configurationService: IConfigurationService
 	) {
 		super();
+
+		this._state = restoreWindowsState(this.stateService.getItem<ISerializedWindowsState>(WindowsStateHandler.windowsStateStorageKey));
 
 		this.registerListeners();
 	}

--- a/src/vs/platform/workspace/common/workspace.ts
+++ b/src/vs/platform/workspace/common/workspace.ts
@@ -329,7 +329,7 @@ export function isWorkspaceFolder(thing: unknown): thing is IWorkspaceFolder {
 
 export class Workspace implements IWorkspace {
 
-	private _foldersMap: TernarySearchTree<URI, WorkspaceFolder> = TernarySearchTree.forUris<WorkspaceFolder>(this._ignorePathCasing, () => true);
+	private _foldersMap: TernarySearchTree<URI, WorkspaceFolder>;
 	private _folders!: WorkspaceFolder[];
 
 	constructor(
@@ -339,6 +339,7 @@ export class Workspace implements IWorkspace {
 		private _configuration: URI | null,
 		private _ignorePathCasing: (key: URI) => boolean,
 	) {
+		this._foldersMap = TernarySearchTree.forUris<WorkspaceFolder>(this._ignorePathCasing, () => true);
 		this.folders = folders;
 	}
 

--- a/src/vs/platform/workspaces/electron-main/workspacesMainService.ts
+++ b/src/vs/platform/workspaces/electron-main/workspacesMainService.ts
@@ -12,6 +12,7 @@ import { IWorkspaceIdentifier } from '../../workspace/common/workspace.js';
 import { IWorkspacesHistoryMainService } from './workspacesHistoryMainService.js';
 import { IWorkspacesManagementMainService } from './workspacesManagementMainService.js';
 import { IWorkspaceBackupInfo, IFolderBackupInfo } from '../../backup/common/backup.js';
+import { Event as CommonEvent } from '../../../base/common/event.js';
 
 export class WorkspacesMainService implements AddFirstParameterToFunctions<IWorkspacesService, Promise<unknown> /* only methods, not events */, number /* window ID */> {
 
@@ -23,6 +24,7 @@ export class WorkspacesMainService implements AddFirstParameterToFunctions<IWork
 		@IWorkspacesHistoryMainService private readonly workspacesHistoryMainService: IWorkspacesHistoryMainService,
 		@IBackupMainService private readonly backupMainService: IBackupMainService
 	) {
+		this.onDidChangeRecentlyOpened = this.workspacesHistoryMainService.onDidChangeRecentlyOpened;
 	}
 
 	//#region Workspace Management
@@ -52,7 +54,7 @@ export class WorkspacesMainService implements AddFirstParameterToFunctions<IWork
 
 	//#region Workspaces History
 
-	readonly onDidChangeRecentlyOpened = this.workspacesHistoryMainService.onDidChangeRecentlyOpened;
+	readonly onDidChangeRecentlyOpened: CommonEvent<void>;
 
 	getRecentlyOpened(windowId: number): Promise<IRecentlyOpened> {
 		return this.workspacesHistoryMainService.getRecentlyOpened();

--- a/src/vs/platform/workspaces/electron-main/workspacesManagementMainService.ts
+++ b/src/vs/platform/workspaces/electron-main/workspacesManagementMainService.ts
@@ -64,7 +64,7 @@ export class WorkspacesManagementMainService extends Disposable implements IWork
 	private readonly _onDidEnterWorkspace = this._register(new Emitter<IWorkspaceEnteredEvent>());
 	readonly onDidEnterWorkspace: Event<IWorkspaceEnteredEvent> = this._onDidEnterWorkspace.event;
 
-	private readonly untitledWorkspacesHome = this.environmentMainService.untitledWorkspacesHome; // local URI that contains all untitled workspaces
+	private readonly untitledWorkspacesHome: URI; // local URI that contains all untitled workspaces
 
 	private untitledWorkspaces: IUntitledWorkspaceInfo[] = [];
 
@@ -76,6 +76,8 @@ export class WorkspacesManagementMainService extends Disposable implements IWork
 		@IDialogMainService private readonly dialogMainService: IDialogMainService
 	) {
 		super();
+
+		this.untitledWorkspacesHome = this.environmentMainService.untitledWorkspacesHome;
 	}
 
 	async initialize(): Promise<void> {

--- a/src/vs/server/node/remoteExtensionHostAgentServer.ts
+++ b/src/vs/server/node/remoteExtensionHostAgentServer.ts
@@ -64,7 +64,7 @@ class RemoteExtensionHostAgentServer extends Disposable implements IServerAPI {
 	private readonly _managementConnections: { [reconnectionToken: string]: ManagementConnection };
 	private readonly _allReconnectionTokens: Set<string>;
 	private readonly _webClientServer: WebClientServer | null;
-	private readonly _webEndpointOriginChecker = WebEndpointOriginChecker.create(this._productService);
+	private readonly _webEndpointOriginChecker: WebEndpointOriginChecker;
 
 	private readonly _serverBasePath: string | undefined;
 	private readonly _serverProductPath: string;
@@ -83,6 +83,8 @@ class RemoteExtensionHostAgentServer extends Disposable implements IServerAPI {
 		@IInstantiationService private readonly _instantiationService: IInstantiationService,
 	) {
 		super();
+
+		this._webEndpointOriginChecker = WebEndpointOriginChecker.create(this._productService);
 
 		if (serverBasePath !== undefined && serverBasePath.charCodeAt(serverBasePath.length - 1) === CharCode.Slash) {
 			// Remove trailing slash from base path

--- a/src/vs/workbench/api/browser/mainThreadWorkspace.ts
+++ b/src/vs/workbench/api/browser/mainThreadWorkspace.ts
@@ -39,7 +39,7 @@ export class MainThreadWorkspace implements MainThreadWorkspaceShape {
 	private readonly _toDispose = new DisposableStore();
 	private readonly _activeCancelTokens: { [id: number]: CancellationTokenSource } = Object.create(null);
 	private readonly _proxy: ExtHostWorkspaceShape;
-	private readonly _queryBuilder = this._instantiationService.createInstance(QueryBuilder);
+	private readonly _queryBuilder: QueryBuilder;
 
 	constructor(
 		extHostContext: IExtHostContext,
@@ -60,6 +60,7 @@ export class MainThreadWorkspace implements MainThreadWorkspaceShape {
 		@ITextFileService private readonly _textFileService: ITextFileService,
 	) {
 		this._proxy = extHostContext.getProxy(ExtHostContext.ExtHostWorkspace);
+		this._queryBuilder = this._instantiationService.createInstance(QueryBuilder);
 		const workspace = this._contextService.getWorkspace();
 		// The workspace file is provided be a unknown file system provider. It might come
 		// from the extension host. So initialize now knowing that `rootPath` is undefined.

--- a/src/vs/workbench/api/common/extHostApiCommands.ts
+++ b/src/vs/workbench/api/common/extHostApiCommands.ts
@@ -60,7 +60,7 @@ const newCommands: ApiCommand[] = [
 				range!: vscode.Range;
 				selectionRange!: vscode.Range;
 				children!: vscode.DocumentSymbol[];
-				override containerName!: string;
+				declare containerName: string;
 			}
 			return value.map(MergedInfo.to);
 

--- a/src/vs/workbench/api/common/extHostFileSystemEventService.ts
+++ b/src/vs/workbench/api/common/extHostFileSystemEventService.ts
@@ -243,9 +243,11 @@ interface IExtensionListener<E> {
 
 class LazyRevivedFileSystemEvents implements FileSystemEvents {
 
-	constructor(private readonly _events: FileSystemEvents) { }
+	constructor(private readonly _events: FileSystemEvents) {
+		this.session = this._events.session;
+	}
 
-	readonly session = this._events.session;
+	readonly session: number | undefined;
 
 	private _created = new Lazy(() => this._events.created.map(URI.revive) as URI[]);
 	get created(): URI[] { return this._created.value; }

--- a/src/vs/workbench/api/common/extHostLanguageFeatures.ts
+++ b/src/vs/workbench/api/common/extHostLanguageFeatures.ts
@@ -1306,7 +1306,7 @@ class InlineCompletionAdapter {
 		items: readonly vscode.InlineCompletionItem[];
 	}>();
 
-	private readonly _isAdditionsProposedApiEnabled = isProposedApiEnabled(this._extension, 'inlineCompletionsAdditions');
+	private readonly _isAdditionsProposedApiEnabled: boolean;
 
 	constructor(
 		private readonly _extension: IExtensionDescription,
@@ -1314,6 +1314,8 @@ class InlineCompletionAdapter {
 		private readonly _provider: vscode.InlineCompletionItemProvider,
 		private readonly _commands: CommandsConverter,
 	) {
+
+		this._isAdditionsProposedApiEnabled = isProposedApiEnabled(this._extension, 'inlineCompletionsAdditions');
 	}
 
 	public get supportsHandleEvents(): boolean {

--- a/src/vs/workbench/api/common/extHostSearch.ts
+++ b/src/vs/workbench/api/common/extHostSearch.ts
@@ -31,7 +31,7 @@ export const IExtHostSearch = createDecorator<IExtHostSearch>('IExtHostSearch');
 
 export class ExtHostSearch implements IExtHostSearch {
 
-	protected readonly _proxy: MainThreadSearchShape = this.extHostRpc.getProxy(MainContext.MainThreadSearch);
+	protected readonly _proxy: MainThreadSearchShape;
 	protected _handlePool: number = 0;
 
 	private readonly _textSearchProvider = new Map<number, vscode.TextSearchProvider2>();
@@ -49,7 +49,9 @@ export class ExtHostSearch implements IExtHostSearch {
 		@IExtHostRpcService private extHostRpc: IExtHostRpcService,
 		@IURITransformerService protected _uriTransformer: IURITransformerService,
 		@ILogService protected _logService: ILogService,
-	) { }
+	) {
+		this._proxy = this.extHostRpc.getProxy(MainContext.MainThreadSearch);
+	}
 
 	protected _transformScheme(scheme: string): string {
 		return this._uriTransformer.transformOutgoingScheme(scheme);

--- a/src/vs/workbench/api/node/extHostDebugService.ts
+++ b/src/vs/workbench/api/node/extHostDebugService.ts
@@ -31,7 +31,7 @@ import { IExtHostTerminalShellIntegration } from '../common/extHostTerminalShell
 
 export class ExtHostDebugService extends ExtHostDebugServiceBase {
 
-	override readonly _serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private _integratedTerminalInstances = new DebugTerminalCollection();
 	private _terminalDisposedListener: IDisposable | undefined;

--- a/src/vs/workbench/api/node/extHostDiskFileSystemProvider.ts
+++ b/src/vs/workbench/api/node/extHostDiskFileSystemProvider.ts
@@ -27,9 +27,11 @@ export class ExtHostDiskFileSystemProvider {
 
 class DiskFileSystemProviderAdapter implements vscode.FileSystemProvider {
 
-	private readonly impl = new DiskFileSystemProvider(this.logService);
+	private readonly impl: DiskFileSystemProvider;
 
-	constructor(private readonly logService: ILogService) { }
+	constructor(private readonly logService: ILogService) {
+		this.impl = new DiskFileSystemProvider(this.logService);
+	}
 
 	async stat(uri: vscode.Uri): Promise<vscode.FileStat> {
 		const stat = await this.impl.stat(uri);

--- a/src/vs/workbench/browser/parts/dialogs/dialogHandler.ts
+++ b/src/vs/workbench/browser/parts/dialogs/dialogHandler.ts
@@ -33,7 +33,7 @@ export class BrowserDialogHandler extends AbstractDialogHandler {
 		'editor.action.clipboardPasteAction'
 	];
 
-	private readonly markdownRenderer = this.instantiationService.createInstance(MarkdownRenderer, {});
+	private readonly markdownRenderer: MarkdownRenderer;
 
 	constructor(
 		@ILogService private readonly logService: ILogService,
@@ -45,6 +45,8 @@ export class BrowserDialogHandler extends AbstractDialogHandler {
 		@IOpenerService private readonly openerService: IOpenerService
 	) {
 		super();
+
+		this.markdownRenderer = this.instantiationService.createInstance(MarkdownRenderer, {});
 	}
 
 	async prompt<T>(prompt: IPrompt<T>): Promise<IAsyncPromptResult<T>> {

--- a/src/vs/workbench/browser/parts/editor/editorGroupWatermark.ts
+++ b/src/vs/workbench/browser/parts/editor/editorGroupWatermark.ts
@@ -71,14 +71,14 @@ export class EditorGroupWatermark extends Disposable {
 
 	private static readonly CACHED_WHEN = 'editorGroupWatermark.whenConditions';
 
-	private readonly cachedWhen: { [when: string]: boolean } = this.storageService.getObject(EditorGroupWatermark.CACHED_WHEN, StorageScope.PROFILE, Object.create(null));
+	private readonly cachedWhen: { [when: string]: boolean };
 
 	private readonly shortcuts: HTMLElement;
 	private readonly transientDisposables = this._register(new DisposableStore());
 	private readonly keybindingLabels = this._register(new DisposableStore());
 
 	private enabled = false;
-	private workbenchState = this.contextService.getWorkbenchState();
+	private workbenchState: WorkbenchState;
 
 	constructor(
 		container: HTMLElement,
@@ -90,6 +90,8 @@ export class EditorGroupWatermark extends Disposable {
 	) {
 		super();
 
+		this.cachedWhen = this.storageService.getObject(EditorGroupWatermark.CACHED_WHEN, StorageScope.PROFILE, Object.create(null));
+
 		const elements = h('.editor-group-watermark', [
 			h('.letterpress'),
 			h('.shortcuts@shortcuts'),
@@ -97,6 +99,8 @@ export class EditorGroupWatermark extends Disposable {
 
 		append(container, elements.root);
 		this.shortcuts = elements.shortcuts;
+
+		this.workbenchState = this.contextService.getWorkbenchState();
 
 		this.registerListeners();
 

--- a/src/vs/workbench/browser/parts/editor/editorPanes.ts
+++ b/src/vs/workbench/browser/parts/editor/editorPanes.ts
@@ -89,7 +89,7 @@ export class EditorPanes extends Disposable {
 	private readonly activeEditorPaneDisposables = this._register(new DisposableStore());
 	private pagePosition: IDomNodePagePosition | undefined;
 	private boundarySashes: IBoundarySashes | undefined;
-	private readonly editorOperation = this._register(new LongRunningOperation(this.editorProgressService));
+	private readonly editorOperation: LongRunningOperation;
 	private readonly editorPanesRegistry = Registry.as<IEditorPaneRegistry>(EditorExtensions.EditorPane);
 
 	constructor(
@@ -105,6 +105,8 @@ export class EditorPanes extends Disposable {
 		@IHostService private readonly hostService: IHostService
 	) {
 		super();
+
+		this.editorOperation = this._register(new LongRunningOperation(this.editorProgressService));
 
 		this.registerListeners();
 	}

--- a/src/vs/workbench/browser/parts/editor/editorPart.ts
+++ b/src/vs/workbench/browser/parts/editor/editorPart.ts
@@ -170,6 +170,8 @@ export class EditorPart extends Part implements IEditorPart, IEditorGroupsView {
 	) {
 		super(id, { hasTitle: false }, themeService, storageService, layoutService);
 
+		this._partOptions = getEditorPartOptions(this.configurationService, this.themeService);
+
 		this.registerListeners();
 	}
 
@@ -200,7 +202,7 @@ export class EditorPart extends Part implements IEditorPart, IEditorGroupsView {
 
 	private enforcedPartOptions: DeepPartial<IEditorPartOptions>[] = [];
 
-	private _partOptions = getEditorPartOptions(this.configurationService, this.themeService);
+	private _partOptions: IEditorPartOptions;
 	get partOptions(): IEditorPartOptions { return this._partOptions; }
 
 	enforcePartOptions(options: DeepPartial<IEditorPartOptions>): IDisposable {

--- a/src/vs/workbench/browser/parts/editor/editorStatus.ts
+++ b/src/vs/workbench/browser/parts/editor/editorStatus.ts
@@ -353,9 +353,9 @@ class EditorStatus extends Disposable {
 	private readonly languageElement = this._register(new MutableDisposable<IStatusbarEntryAccessor>());
 	private readonly metadataElement = this._register(new MutableDisposable<IStatusbarEntryAccessor>());
 
-	private readonly currentMarkerStatus = this._register(this.instantiationService.createInstance(ShowCurrentMarkerInStatusbarContribution));
-	private readonly tabFocusMode = this._register(this.instantiationService.createInstance(TabFocusMode));
-	private readonly inputMode = this._register(this.instantiationService.createInstance(StatusInputMode));
+	private readonly currentMarkerStatus: ShowCurrentMarkerInStatusbarContribution;
+	private readonly tabFocusMode: TabFocusMode;
+	private readonly inputMode: StatusInputMode;
 
 	private readonly state = new State();
 	private toRender: StateChange | undefined = undefined;
@@ -374,6 +374,10 @@ class EditorStatus extends Disposable {
 		@IConfigurationService private readonly configurationService: IConfigurationService
 	) {
 		super();
+
+		this.currentMarkerStatus = this._register(this.instantiationService.createInstance(ShowCurrentMarkerInStatusbarContribution));
+		this.tabFocusMode = this._register(this.instantiationService.createInstance(TabFocusMode));
+		this.inputMode = this._register(this.instantiationService.createInstance(StatusInputMode));
 
 		this.registerCommands();
 		this.registerListeners();

--- a/src/vs/workbench/browser/parts/editor/sideBySideEditor.ts
+++ b/src/vs/workbench/browser/parts/editor/sideBySideEditor.ts
@@ -116,7 +116,7 @@ export class SideBySideEditor extends AbstractEditorWithViewState<ISideBySideEdi
 	private readonly splitviewDisposables = this._register(new DisposableStore());
 	private readonly editorDisposables = this._register(new DisposableStore());
 
-	private orientation = this.configurationService.getValue<'vertical' | 'horizontal'>(SideBySideEditor.SIDE_BY_SIDE_LAYOUT_SETTING) === 'vertical' ? Orientation.VERTICAL : Orientation.HORIZONTAL;
+	private orientation: Orientation;
 	private dimension = new Dimension(0, 0);
 
 	private lastFocusedSide: Side.PRIMARY | Side.SECONDARY | undefined = undefined;
@@ -133,6 +133,8 @@ export class SideBySideEditor extends AbstractEditorWithViewState<ISideBySideEdi
 		@IEditorGroupsService editorGroupService: IEditorGroupsService
 	) {
 		super(SideBySideEditor.ID, group, SideBySideEditor.VIEW_STATE_PREFERENCE_KEY, telemetryService, instantiationService, storageService, textResourceConfigurationService, themeService, editorService, editorGroupService);
+
+		this.orientation = this.configurationService.getValue<'vertical' | 'horizontal'>(SideBySideEditor.SIDE_BY_SIDE_LAYOUT_SETTING) === 'vertical' ? Orientation.VERTICAL : Orientation.HORIZONTAL;
 
 		this.registerListeners();
 	}

--- a/src/vs/workbench/browser/parts/notifications/notificationsCenter.ts
+++ b/src/vs/workbench/browser/parts/notifications/notificationsCenter.ts
@@ -10,7 +10,7 @@ import { IThemeService, Themable } from '../../../../platform/theme/common/theme
 import { INotificationsModel, INotificationChangeEvent, NotificationChangeType, NotificationViewItemContentChangeKind } from '../../../common/notifications.js';
 import { IWorkbenchLayoutService, Parts } from '../../../services/layout/browser/layoutService.js';
 import { Emitter } from '../../../../base/common/event.js';
-import { IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
+import { IContextKey, IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
 import { INotificationsCenterController, NotificationActionRunner } from './notificationsCommands.js';
 import { NotificationsList } from './notificationsList.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
@@ -45,7 +45,7 @@ export class NotificationsCenter extends Themable implements INotificationsCente
 	private notificationsList: NotificationsList | undefined;
 	private _isVisible: boolean | undefined;
 	private workbenchDimensions: Dimension | undefined;
-	private readonly notificationsCenterVisibleContextKey = NotificationsCenterVisibleContext.bindTo(this.contextKeyService);
+	private readonly notificationsCenterVisibleContextKey: IContextKey<boolean>;
 	private clearAllAction: ClearAllNotificationsAction | undefined;
 	private configureDoNotDisturbAction: ConfigureDoNotDisturbAction | undefined;
 
@@ -64,7 +64,7 @@ export class NotificationsCenter extends Themable implements INotificationsCente
 	) {
 		super(themeService);
 
-		this.notificationsCenterVisibleContextKey = NotificationsCenterVisibleContext.bindTo(contextKeyService);
+		this.notificationsCenterVisibleContextKey = NotificationsCenterVisibleContext.bindTo(this.contextKeyService);
 
 		this.registerListeners();
 	}

--- a/src/vs/workbench/browser/parts/notifications/notificationsToasts.ts
+++ b/src/vs/workbench/browser/parts/notifications/notificationsToasts.ts
@@ -17,7 +17,7 @@ import { IThemeService, Themable } from '../../../../platform/theme/common/theme
 import { widgetShadow } from '../../../../platform/theme/common/colorRegistry.js';
 import { IEditorGroupsService } from '../../../services/editor/common/editorGroupsService.js';
 import { INotificationsToastController } from './notificationsCommands.js';
-import { IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
+import { IContextKey, IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
 import { Severity, NotificationsFilter, NotificationPriority } from '../../../../platform/notification/common/notification.js';
 import { ScrollbarVisibility } from '../../../../base/common/scrollable.js';
 import { ILifecycleService, LifecyclePhase } from '../../../services/lifecycle/common/lifecycle.js';
@@ -71,7 +71,7 @@ export class NotificationsToasts extends Themable implements INotificationsToast
 	private readonly mapNotificationToToast = new Map<INotificationViewItem, INotificationToast>();
 	private readonly mapNotificationToDisposable = new Map<INotificationViewItem, IDisposable>();
 
-	private readonly notificationsToastsVisibleContextKey = NotificationsToastsVisibleContext.bindTo(this.contextKeyService);
+	private readonly notificationsToastsVisibleContextKey: IContextKey<boolean>;
 
 	private readonly addedToastsIntervalCounter = new IntervalCounter(NotificationsToasts.SPAM_PROTECTION.interval);
 
@@ -87,6 +87,8 @@ export class NotificationsToasts extends Themable implements INotificationsToast
 		@IHostService private readonly hostService: IHostService
 	) {
 		super(themeService);
+
+		this.notificationsToastsVisibleContextKey = NotificationsToastsVisibleContext.bindTo(this.contextKeyService);
 
 		this.registerListeners();
 	}

--- a/src/vs/workbench/browser/parts/titlebar/titlebarPart.ts
+++ b/src/vs/workbench/browser/parts/titlebar/titlebarPart.ts
@@ -8,7 +8,7 @@ import { localize, localize2 } from '../../../../nls.js';
 import { MultiWindowParts, Part } from '../../part.js';
 import { ITitleService } from '../../../services/title/browser/titleService.js';
 import { getWCOTitlebarAreaRect, getZoomFactor, isWCOEnabled } from '../../../../base/browser/browser.js';
-import { MenuBarVisibility, getTitleBarStyle, getMenuBarVisibility, hasCustomTitlebar, hasNativeTitlebar, DEFAULT_CUSTOM_TITLEBAR_HEIGHT } from '../../../../platform/window/common/window.js';
+import { MenuBarVisibility, getTitleBarStyle, getMenuBarVisibility, hasCustomTitlebar, hasNativeTitlebar, DEFAULT_CUSTOM_TITLEBAR_HEIGHT, TitlebarStyle } from '../../../../platform/window/common/window.js';
 import { IContextMenuService } from '../../../../platform/contextview/browser/contextView.js';
 import { StandardMouseEvent } from '../../../../base/browser/mouseEvent.js';
 import { IConfigurationService, IConfigurationChangeEvent } from '../../../../platform/configuration/common/configuration.js';
@@ -267,7 +267,7 @@ export class BrowserTitlebarPart extends Part implements ITitlebarPart {
 	private readonly editorActionsChangeDisposable = this._register(new DisposableStore());
 	private actionToolBarElement!: HTMLElement;
 
-	private globalToolbarMenu = this._register(this.menuService.createMenu(MenuId.TitleBar, this.contextKeyService));
+	private globalToolbarMenu: IMenu;
 	private hasGlobalToolbarEntries = false;
 	private layoutToolbarMenu: IMenu | undefined;
 
@@ -279,7 +279,7 @@ export class BrowserTitlebarPart extends Part implements ITitlebarPart {
 	private readonly hoverDelegate: IHoverDelegate;
 
 	private readonly titleDisposables = this._register(new DisposableStore());
-	private titleBarStyle = getTitleBarStyle(this.configurationService);
+	private titleBarStyle: TitlebarStyle;
 
 	private isInactive: boolean = false;
 	private readonly isAuxiliary: boolean;
@@ -308,6 +308,10 @@ export class BrowserTitlebarPart extends Part implements ITitlebarPart {
 		@IKeybindingService private readonly keybindingService: IKeybindingService
 	) {
 		super(id, { hasTitle: false }, themeService, storageService, layoutService);
+
+		this.globalToolbarMenu = this._register(this.menuService.createMenu(MenuId.TitleBar, this.contextKeyService));
+
+		this.titleBarStyle = getTitleBarStyle(this.configurationService);
 
 		this.isAuxiliary = editorGroupsContainer !== 'main';
 		this.editorService = editorService.createScoped(editorGroupsContainer, this._store);

--- a/src/vs/workbench/common/editor/sideBySideEditorInput.ts
+++ b/src/vs/workbench/common/editor/sideBySideEditorInput.ts
@@ -60,7 +60,7 @@ export class SideBySideEditorInput extends EditorInput implements ISideBySideEdi
 		return undefined;
 	}
 
-	private hasIdenticalSides = this.primary.matches(this.secondary);
+	private hasIdenticalSides: boolean;
 
 	constructor(
 		protected readonly preferredName: string | undefined,
@@ -70,6 +70,8 @@ export class SideBySideEditorInput extends EditorInput implements ISideBySideEdi
 		@IEditorService private readonly editorService: IEditorService
 	) {
 		super();
+
+		this.hasIdenticalSides = this.primary.matches(this.secondary);
 
 		this.registerListeners();
 	}

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/chatAttachmentsContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/chatAttachmentsContentPart.ts
@@ -51,7 +51,7 @@ export class ChatAttachmentsContentPart extends Disposable {
 	private readonly attachedContextDisposables = this._register(new DisposableStore());
 
 	private readonly _onDidChangeVisibility = this._register(new Emitter<boolean>());
-	private readonly _contextResourceLabels = this._register(this.instantiationService.createInstance(ResourceLabels, { onDidChangeVisibility: this._onDidChangeVisibility.event }));
+	private readonly _contextResourceLabels: ResourceLabels;
 
 	constructor(
 		private readonly variables: IChatRequestVariableEntry[],
@@ -67,6 +67,8 @@ export class ChatAttachmentsContentPart extends Disposable {
 		@ILabelService private readonly labelService: ILabelService,
 	) {
 		super();
+
+		this._contextResourceLabels = this._register(this.instantiationService.createInstance(ResourceLabels, { onDidChangeVisibility: this._onDidChangeVisibility.event }));
 
 		this.initAttachedContext(domNode);
 		if (!domNode.childElementCount) {

--- a/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingCodeEditorIntegration.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingCodeEditorIntegration.ts
@@ -38,6 +38,7 @@ import { overviewRulerModifiedForeground, minimapGutterModifiedBackground, overv
 import { ChatAgentLocation, IChatAgentService } from '../../common/chatAgents.js';
 import { ChatEditingSessionState, IChatEditingService, IModifiedFileEntry, IModifiedFileEntryChangeHunk, IModifiedFileEntryEditorIntegration, WorkingSetEntryState } from '../../common/chatEditingService.js';
 import { isTextDiffEditorForEntry } from './chatEditing.js';
+import { IEditorDecorationsCollection } from '../../../../../editor/common/editorCommon.js';
 
 export interface IDocumentDiff2 extends IDocumentDiff {
 
@@ -56,9 +57,9 @@ export class ChatEditingCodeEditorIntegration implements IModifiedFileEntryEdito
 	readonly currentIndex: IObservable<number> = this._currentIndex;
 	private readonly _store = new DisposableStore();
 
-	private readonly _diffLineDecorations = this._editor.createDecorationsCollection(); // tracks the line range w/o visuals (used for navigate)
+	private readonly _diffLineDecorations: IEditorDecorationsCollection; // tracks the line range w/o visuals (used for navigate)
 
-	private readonly _diffVisualDecorations = this._editor.createDecorationsCollection(); // tracks the real diff with character level inserts
+	private readonly _diffVisualDecorations: IEditorDecorationsCollection; // tracks the real diff with character level inserts
 	private readonly _diffHunksRenderStore = this._store.add(new DisposableStore());
 	private readonly _diffHunkWidgets: DiffHunkWidget[] = [];
 	private _viewZones: string[] = [];
@@ -76,6 +77,8 @@ export class ChatEditingCodeEditorIntegration implements IModifiedFileEntryEdito
 		@IInstantiationService instantiationService: IInstantiationService,
 	) {
 		this._diffLineDecorations = _editor.createDecorationsCollection();
+		this._diffVisualDecorations = this._editor.createDecorationsCollection();
+
 		const codeEditorObs = observableCodeEditor(_editor);
 
 		const enabledObs = derived(r => {

--- a/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingSession.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingSession.ts
@@ -212,6 +212,8 @@ export class ChatEditingSession extends Disposable implements IChatEditingSessio
 		@IConfigurationService private readonly _configurationService: IConfigurationService,
 	) {
 		super();
+
+		this._ignoreTrimWhitespaceObservable = observableConfigValue('diffEditor.ignoreTrimWhitespace', true, this._configurationService);
 	}
 
 	public async init(): Promise<void> {
@@ -312,7 +314,7 @@ export class ChatEditingSession extends Disposable implements IChatEditingSessio
 
 	private _diffsBetweenStops = new Map<string, IObservable<IEditSessionEntryDiff | undefined>>();
 
-	private readonly _ignoreTrimWhitespaceObservable = observableConfigValue('diffEditor.ignoreTrimWhitespace', true, this._configurationService);
+	private readonly _ignoreTrimWhitespaceObservable: IObservable<boolean>;
 
 	/**
 	 * Gets diff for text entries between stops.

--- a/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
@@ -225,7 +225,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 	private _hasFileAttachmentContextKey: IContextKey<boolean>;
 
 	private readonly _onDidChangeVisibility = this._register(new Emitter<boolean>());
-	private readonly _contextResourceLabels = this.instantiationService.createInstance(ResourceLabels, { onDidChangeVisibility: this._onDidChangeVisibility.event });
+	private readonly _contextResourceLabels: ResourceLabels;
 
 	private readonly inputEditorMaxHeight: number;
 	private inputEditorHeight = 0;
@@ -390,6 +390,8 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 		this._chatEditsListPool = this._register(this.instantiationService.createInstance(CollapsibleListPool, this._onDidChangeVisibility.event, MenuId.ChatEditingWidgetModifiedFilesToolbar));
 
 		this._hasFileAttachmentContextKey = ChatContextKeys.hasFileAttachments.bindTo(contextKeyService);
+
+		this._contextResourceLabels = this.instantiationService.createInstance(ResourceLabels, { onDidChangeVisibility: this._onDidChangeVisibility.event });
 
 		this.instructionAttachmentsPart = this._register(
 			instantiationService.createInstance(

--- a/src/vs/workbench/contrib/chat/browser/chatSetup.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSetup.ts
@@ -23,7 +23,7 @@ import { localize, localize2 } from '../../../../nls.js';
 import { Action2, MenuId, registerAction2 } from '../../../../platform/actions/common/actions.js';
 import { ICommandService } from '../../../../platform/commands/common/commands.js';
 import { ConfigurationTarget, IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
-import { ContextKeyExpr, IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
+import { ContextKeyExpr, IContextKey, IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
 import { IContextMenuService } from '../../../../platform/contextview/browser/contextView.js';
 import { IDialogService } from '../../../../platform/dialogs/common/dialogs.js';
 import { ExtensionIdentifier } from '../../../../platform/extensions/common/extensions.js';
@@ -409,7 +409,7 @@ class ChatSetupRequests extends Disposable {
 		return defaultChat.providerId;
 	}
 
-	private state: IChatEntitlements = { entitlement: this.context.state.entitlement };
+	private state: IChatEntitlements;
 
 	private pendingResolveCts = new CancellationTokenSource();
 	private didResolveEntitlements = false;
@@ -426,6 +426,8 @@ class ChatSetupRequests extends Disposable {
 		@IConfigurationService private readonly configurationService: IConfigurationService
 	) {
 		super();
+
+		this.state = { entitlement: this.context.state.entitlement };
 
 		this.registerListeners();
 
@@ -1260,14 +1262,14 @@ class ChatSetupContext extends Disposable {
 
 	private static readonly CHAT_SETUP_CONTEXT_STORAGE_KEY = 'chat.setupContext';
 
-	private readonly canSignUpContextKey = ChatContextKeys.Setup.canSignUp.bindTo(this.contextKeyService);
-	private readonly signedOutContextKey = ChatContextKeys.Setup.signedOut.bindTo(this.contextKeyService);
-	private readonly limitedContextKey = ChatContextKeys.Setup.limited.bindTo(this.contextKeyService);
-	private readonly proContextKey = ChatContextKeys.Setup.pro.bindTo(this.contextKeyService);
-	private readonly hiddenContext = ChatContextKeys.Setup.hidden.bindTo(this.contextKeyService);
-	private readonly installedContext = ChatContextKeys.Setup.installed.bindTo(this.contextKeyService);
+	private readonly canSignUpContextKey: IContextKey<boolean>;
+	private readonly signedOutContextKey: IContextKey<boolean>;
+	private readonly limitedContextKey: IContextKey<boolean>;
+	private readonly proContextKey: IContextKey<boolean>;
+	private readonly hiddenContext: IContextKey<boolean>;
+	private readonly installedContext: IContextKey<boolean>;
 
-	private _state: IChatSetupContextState = this.storageService.getObject<IChatSetupContextState>(ChatSetupContext.CHAT_SETUP_CONTEXT_STORAGE_KEY, StorageScope.PROFILE) ?? { entitlement: ChatEntitlement.Unknown };
+	private _state: IChatSetupContextState;
 	private suspendedState: IChatSetupContextState | undefined = undefined;
 	get state(): IChatSetupContextState {
 		return this.suspendedState ?? this._state;
@@ -1287,6 +1289,15 @@ class ChatSetupContext extends Disposable {
 		@IExtensionsWorkbenchService private readonly extensionsWorkbenchService: IExtensionsWorkbenchService,
 	) {
 		super();
+
+		this.canSignUpContextKey = ChatContextKeys.Setup.canSignUp.bindTo(this.contextKeyService);
+		this.signedOutContextKey = ChatContextKeys.Setup.signedOut.bindTo(this.contextKeyService);
+		this.limitedContextKey = ChatContextKeys.Setup.limited.bindTo(this.contextKeyService);
+		this.proContextKey = ChatContextKeys.Setup.pro.bindTo(this.contextKeyService);
+		this.hiddenContext = ChatContextKeys.Setup.hidden.bindTo(this.contextKeyService);
+		this.installedContext = ChatContextKeys.Setup.installed.bindTo(this.contextKeyService);
+
+		this._state = this.storageService.getObject<IChatSetupContextState>(ChatSetupContext.CHAT_SETUP_CONTEXT_STORAGE_KEY, StorageScope.PROFILE) ?? { entitlement: ChatEntitlement.Unknown };
 
 		this.checkExtensionInstallation();
 		this.updateContextSync();

--- a/src/vs/workbench/contrib/chat/browser/chatStatus.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatStatus.ts
@@ -20,7 +20,7 @@ export class ChatStatusBarEntry extends Disposable implements IWorkbenchContribu
 
 	static readonly ID = 'chat.statusBarEntry';
 
-	private readonly treatment = this.assignmentService.getTreatment<boolean>('config.chat.experimental.statusIndicator.enabled'); //TODO@bpasero remove this experiment eventually
+	private readonly treatment: Promise<boolean | undefined>;
 
 	private entry: IStatusbarEntryAccessor | undefined = undefined;
 
@@ -33,6 +33,8 @@ export class ChatStatusBarEntry extends Disposable implements IWorkbenchContribu
 		@IKeybindingService private readonly keybindingService: IKeybindingService
 	) {
 		super();
+
+		this.treatment = this.assignmentService.getTreatment<boolean>('config.chat.experimental.statusIndicator.enabled'); //TODO@bpasero remove this experiment eventually
 
 		this.create();
 		this.registerListeners();

--- a/src/vs/workbench/contrib/chat/common/chatQuotasService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatQuotasService.ts
@@ -5,7 +5,7 @@
 
 import { Emitter, Event } from '../../../../base/common/event.js';
 import { Disposable } from '../../../../base/common/lifecycle.js';
-import { IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
+import { IContextKey, IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
 import { createDecorator } from '../../../../platform/instantiation/common/instantiation.js';
 import { ChatContextKeys } from './chatContextKeys.js';
 
@@ -44,8 +44,8 @@ export class ChatQuotasService extends Disposable implements IChatQuotasService 
 	private _quotas: IChatQuotas = { chatQuotaExceeded: false, completionsQuotaExceeded: false, quotaResetDate: undefined };
 	get quotas(): IChatQuotas { return this._quotas; }
 
-	private readonly chatQuotaExceededContextKey = ChatContextKeys.chatQuotaExceeded.bindTo(this.contextKeyService);
-	private readonly completionsQuotaExceededContextKey = ChatContextKeys.completionsQuotaExceeded.bindTo(this.contextKeyService);
+	private readonly chatQuotaExceededContextKey: IContextKey<boolean>;
+	private readonly completionsQuotaExceededContextKey: IContextKey<boolean>;
 
 	private ExtensionQuotaContextKeys = {
 		chatQuotaExceeded: 'github.copilot.chat.quotaExceeded',
@@ -56,6 +56,9 @@ export class ChatQuotasService extends Disposable implements IChatQuotasService 
 		@IContextKeyService private readonly contextKeyService: IContextKeyService,
 	) {
 		super();
+
+		this.chatQuotaExceededContextKey = ChatContextKeys.chatQuotaExceeded.bindTo(this.contextKeyService);
+		this.completionsQuotaExceededContextKey = ChatContextKeys.completionsQuotaExceeded.bindTo(this.contextKeyService);
 
 		this.registerListeners();
 	}

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/contentProviders/textModelContentsProvider.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/contentProviders/textModelContentsProvider.ts
@@ -10,6 +10,7 @@ import { PromptContentsProviderBase } from './promptContentsProviderBase.js';
 import { CancellationToken } from '../../../../../../base/common/cancellation.js';
 import { newWriteableStream, ReadableStream } from '../../../../../../base/common/stream.js';
 import { IModelContentChangedEvent } from '../../../../../../editor/common/textModelEvents.js';
+import { URI } from '../../../../../../base/common/uri.js';
 
 /**
  * Prompt contents provider for a {@linkcode ITextModel} instance.
@@ -18,12 +19,14 @@ export class TextModelContentsProvider extends PromptContentsProviderBase<IModel
 	/**
 	 * URI component of the prompt associated with this contents provider.
 	 */
-	public readonly uri = this.model.uri;
+	public readonly uri: URI;
 
 	constructor(
 		private readonly model: ITextModel,
 	) {
 		super();
+
+		this.uri = this.model.uri;
 
 		this._register(this.model.onWillDispose(this.dispose.bind(this)));
 		this._register(this.model.onDidChangeContent(this.onChangeEmitter.fire));

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/basePromptParser.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/basePromptParser.ts
@@ -11,7 +11,7 @@ import { assert } from '../../../../../../base/common/assert.js';
 import { IPromptFileReference, IResolveError } from './types.js';
 import { FileReference } from '../codecs/tokens/fileReference.js';
 import { ChatPromptDecoder } from '../codecs/chatPromptDecoder.js';
-import { IRange } from '../../../../../../editor/common/core/range.js';
+import { IRange, Range } from '../../../../../../editor/common/core/range.js';
 import { assertDefined } from '../../../../../../base/common/types.js';
 import { IPromptContentsProvider } from '../contentProviders/types.js';
 import { DeferredPromise } from '../../../../../../base/common/async.js';
@@ -552,9 +552,9 @@ export abstract class BasePromptParser<T extends IPromptContentsProvider> extend
 export class PromptFileReference extends BasePromptParser<FilePromptContentProvider> implements IPromptFileReference {
 	public readonly type = 'file';
 
-	public readonly range = this.token.range;
-	public readonly path: string = this.token.path;
-	public readonly text: string = this.token.text;
+	public readonly range: Range;
+	public readonly path: string;
+	public readonly text: string;
 
 	constructor(
 		public readonly token: FileReference | MarkdownLink,
@@ -567,6 +567,10 @@ export class PromptFileReference extends BasePromptParser<FilePromptContentProvi
 		const provider = initService.createInstance(FilePromptContentProvider, fileUri);
 
 		super(provider, seenReferences, initService, logService);
+
+		this.range = this.token.range;
+		this.path = this.token.path;
+		this.text = this.token.text;
 	}
 
 	/**

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsService.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsService.ts
@@ -28,13 +28,15 @@ export class PromptsService extends Disposable implements IPromptsService {
 	/**
 	 * Prompt files locator utility.
 	 */
-	private readonly fileLocator = this.initService.createInstance(PromptFilesLocator);
+	private readonly fileLocator: PromptFilesLocator;
 
 	constructor(
 		@IInstantiationService private readonly initService: IInstantiationService,
 		@IUserDataProfileService private readonly userDataService: IUserDataProfileService,
 	) {
 		super();
+
+		this.fileLocator = this.initService.createInstance(PromptFilesLocator);
 
 		// the factory function below creates a new prompt parser object
 		// for the provided model, if no active non-disposed parser exists

--- a/src/vs/workbench/contrib/chat/common/voiceChatService.ts
+++ b/src/vs/workbench/contrib/chat/common/voiceChatService.ts
@@ -8,7 +8,7 @@ import { CancellationToken } from '../../../../base/common/cancellation.js';
 import { Emitter, Event } from '../../../../base/common/event.js';
 import { Disposable, DisposableStore } from '../../../../base/common/lifecycle.js';
 import { rtrim } from '../../../../base/common/strings.js';
-import { IContextKeyService, RawContextKey } from '../../../../platform/contextkey/common/contextkey.js';
+import { IContextKey, IContextKeyService, RawContextKey } from '../../../../platform/contextkey/common/contextkey.js';
 import { createDecorator } from '../../../../platform/instantiation/common/instantiation.js';
 import { IChatAgentService } from './chatAgents.js';
 import { IChatModel } from './chatModel.js';
@@ -81,7 +81,7 @@ export class VoiceChatService extends Disposable implements IVoiceChatService {
 
 	private static readonly CHAT_AGENT_ALIAS = new Map<string, string>([['vscode', 'code']]);
 
-	private readonly voiceChatInProgress = VoiceChatInProgress.bindTo(this.contextKeyService);
+	private readonly voiceChatInProgress: IContextKey<boolean>;
 	private activeVoiceChatSessions = 0;
 
 	constructor(
@@ -90,6 +90,8 @@ export class VoiceChatService extends Disposable implements IVoiceChatService {
 		@IContextKeyService private readonly contextKeyService: IContextKeyService
 	) {
 		super();
+
+		this.voiceChatInProgress = VoiceChatInProgress.bindTo(this.contextKeyService);
 	}
 
 	private createPhrases(model?: IChatModel): Map<string, IPhraseValue> {

--- a/src/vs/workbench/contrib/codeEditor/browser/dictation/editorDictation.ts
+++ b/src/vs/workbench/contrib/codeEditor/browser/dictation/editorDictation.ts
@@ -10,7 +10,7 @@ import { CancellationTokenSource } from '../../../../../base/common/cancellation
 import { Disposable, DisposableStore, MutableDisposable, toDisposable } from '../../../../../base/common/lifecycle.js';
 import { ContentWidgetPositionPreference, ICodeEditor, IContentWidget, IContentWidgetPosition } from '../../../../../editor/browser/editorBrowser.js';
 import { IEditorContribution } from '../../../../../editor/common/editorCommon.js';
-import { ContextKeyExpr, IContextKeyService, RawContextKey } from '../../../../../platform/contextkey/common/contextkey.js';
+import { ContextKeyExpr, IContextKey, IContextKeyService, RawContextKey } from '../../../../../platform/contextkey/common/contextkey.js';
 import { HasSpeechProvider, ISpeechService, SpeechToTextInProgress, SpeechToTextStatus } from '../../../speech/common/speechService.js';
 import { Codicon } from '../../../../../base/common/codicons.js';
 import { EditorOption } from '../../../../../editor/common/config/editorOptions.js';
@@ -187,8 +187,8 @@ export class EditorDictation extends Disposable implements IEditorContribution {
 		return editor.getContribution<EditorDictation>(EditorDictation.ID);
 	}
 
-	private readonly widget = this._register(new DictationWidget(this.editor, this.keybindingService));
-	private readonly editorDictationInProgress = EDITOR_DICTATION_IN_PROGRESS.bindTo(this.contextKeyService);
+	private readonly widget: DictationWidget;
+	private readonly editorDictationInProgress: IContextKey<boolean>;
 
 	private readonly sessionDisposables = this._register(new MutableDisposable());
 
@@ -199,6 +199,9 @@ export class EditorDictation extends Disposable implements IEditorContribution {
 		@IKeybindingService private readonly keybindingService: IKeybindingService
 	) {
 		super();
+
+		this.widget = this._register(new DictationWidget(this.editor, this.keybindingService));
+		this.editorDictationInProgress = EDITOR_DICTATION_IN_PROGRESS.bindTo(this.contextKeyService);
 	}
 
 	async start(): Promise<void> {

--- a/src/vs/workbench/contrib/codeEditor/browser/quickaccess/gotoLineQuickAccess.ts
+++ b/src/vs/workbench/contrib/codeEditor/browser/quickaccess/gotoLineQuickAccess.ts
@@ -19,10 +19,11 @@ import { KeybindingWeight } from '../../../../../platform/keybinding/common/keyb
 import { IQuickAccessTextEditorContext } from '../../../../../editor/contrib/quickAccess/browser/editorNavigationQuickAccess.js';
 import { ITextEditorOptions } from '../../../../../platform/editor/common/editor.js';
 import { IEditorGroupsService } from '../../../../services/editor/common/editorGroupsService.js';
+import { Event } from '../../../../../base/common/event.js';
 
 export class GotoLineQuickAccessProvider extends AbstractGotoLineQuickAccessProvider {
 
-	protected readonly onDidActiveTextEditorControlChange = this.editorService.onDidActiveEditorChange;
+	protected readonly onDidActiveTextEditorControlChange: Event<void>;
 
 	constructor(
 		@IEditorService private readonly editorService: IEditorService,
@@ -30,6 +31,8 @@ export class GotoLineQuickAccessProvider extends AbstractGotoLineQuickAccessProv
 		@IConfigurationService private readonly configurationService: IConfigurationService
 	) {
 		super();
+
+		this.onDidActiveTextEditorControlChange = this.editorService.onDidActiveEditorChange;
 	}
 
 	private get configuration() {

--- a/src/vs/workbench/contrib/codeEditor/browser/quickaccess/gotoSymbolQuickAccess.ts
+++ b/src/vs/workbench/contrib/codeEditor/browser/quickaccess/gotoSymbolQuickAccess.ts
@@ -34,10 +34,11 @@ import { ILanguageFeaturesService } from '../../../../../editor/common/services/
 import { ContextKeyExpr } from '../../../../../platform/contextkey/common/contextkey.js';
 import { accessibilityHelpIsShown, accessibleViewIsShown } from '../../../accessibility/browser/accessibilityConfiguration.js';
 import { matchesFuzzyIconAware, parseLabelWithIcons } from '../../../../../base/common/iconLabels.js';
+import { Event } from '../../../../../base/common/event.js';
 
 export class GotoSymbolQuickAccessProvider extends AbstractGotoSymbolQuickAccessProvider {
 
-	protected readonly onDidActiveTextEditorControlChange = this.editorService.onDidActiveEditorChange;
+	protected readonly onDidActiveTextEditorControlChange: Event<void>;
 
 	constructor(
 		@IEditorService private readonly editorService: IEditorService,
@@ -50,6 +51,8 @@ export class GotoSymbolQuickAccessProvider extends AbstractGotoSymbolQuickAccess
 		super(languageFeaturesService, outlineModelService, {
 			openSideBySideDirection: () => this.configuration.openSideBySideDirection
 		});
+
+		this.onDidActiveTextEditorControlChange = this.editorService.onDidActiveEditorChange;
 	}
 
 	//#region DocumentSymbols (text editor required)

--- a/src/vs/workbench/contrib/comments/browser/commentsAccessibleView.ts
+++ b/src/vs/workbench/contrib/comments/browser/commentsAccessibleView.ts
@@ -23,6 +23,7 @@ import { isCodeEditor } from '../../../../editor/browser/editorBrowser.js';
 import { URI } from '../../../../base/common/uri.js';
 import { CommentThread, Comment } from '../../../../editor/common/languages.js';
 import { IRange } from '../../../../editor/common/core/range.js';
+import { IAction } from '../../../../base/common/actions.js';
 
 export class CommentsAccessibleView extends Disposable implements IAccessibleViewImplementation {
 	readonly priority = 90;
@@ -78,24 +79,26 @@ class CommentsAccessibleContentProvider extends Disposable implements IAccessibl
 		private readonly _menus: CommentsMenus,
 	) {
 		super();
+
+		this.actions = [...this._menus.getResourceContextActions(this._focusedCommentNode)].filter(i => i.enabled).map(action => {
+			return {
+				...action,
+				run: () => {
+					this._commentsView.focus();
+					action.run({
+						thread: this._focusedCommentNode.thread,
+						$mid: MarshalledId.CommentThread,
+						commentControlHandle: this._focusedCommentNode.controllerHandle,
+						commentThreadHandle: this._focusedCommentNode.threadHandle,
+					});
+				}
+			};
+		});
 	}
 	readonly id = AccessibleViewProviderId.Comments;
 	readonly verbositySettingKey = AccessibilityVerbositySettingId.Comments;
 	readonly options = { type: AccessibleViewType.View };
-	public actions = [...this._menus.getResourceContextActions(this._focusedCommentNode)].filter(i => i.enabled).map(action => {
-		return {
-			...action,
-			run: () => {
-				this._commentsView.focus();
-				action.run({
-					thread: this._focusedCommentNode.thread,
-					$mid: MarshalledId.CommentThread,
-					commentControlHandle: this._focusedCommentNode.controllerHandle,
-					commentThreadHandle: this._focusedCommentNode.threadHandle,
-				});
-			}
-		};
-	});
+	public actions: IAction[];
 	provideContent(): string {
 		const commentNode = this._commentsView.focusedCommentNode;
 		const content = this._commentsView.focusedCommentInfo?.toString();

--- a/src/vs/workbench/contrib/comments/browser/commentsViewActions.ts
+++ b/src/vs/workbench/contrib/comments/browser/commentsViewActions.ts
@@ -47,12 +47,17 @@ export class CommentsFilters extends Disposable {
 
 	constructor(options: CommentsFiltersOptions, private readonly contextKeyService: IContextKeyService) {
 		super();
+
+		this._showUnresolved = CONTEXT_KEY_SHOW_UNRESOLVED.bindTo(this.contextKeyService);
+		this._showResolved = CONTEXT_KEY_SHOW_RESOLVED.bindTo(this.contextKeyService);
+		this._sortBy = CONTEXT_KEY_SORT_BY.bindTo(this.contextKeyService);
+
 		this._showResolved.set(options.showResolved);
 		this._showUnresolved.set(options.showUnresolved);
 		this._sortBy.set(options.sortBy);
 	}
 
-	private readonly _showUnresolved = CONTEXT_KEY_SHOW_UNRESOLVED.bindTo(this.contextKeyService);
+	private readonly _showUnresolved: IContextKey<boolean>;
 	get showUnresolved(): boolean {
 		return !!this._showUnresolved.get();
 	}
@@ -63,7 +68,7 @@ export class CommentsFilters extends Disposable {
 		}
 	}
 
-	private _showResolved = CONTEXT_KEY_SHOW_RESOLVED.bindTo(this.contextKeyService);
+	private _showResolved: IContextKey<boolean>;
 	get showResolved(): boolean {
 		return !!this._showResolved.get();
 	}
@@ -74,7 +79,7 @@ export class CommentsFilters extends Disposable {
 		}
 	}
 
-	private _sortBy: IContextKey<CommentsSortOrder> = CONTEXT_KEY_SORT_BY.bindTo(this.contextKeyService);
+	private _sortBy: IContextKey<CommentsSortOrder>;
 	get sortBy(): CommentsSortOrder {
 		return this._sortBy.get() ?? CommentsSortOrder.ResourceAscending;
 	}

--- a/src/vs/workbench/contrib/debug/browser/callStackEditorContribution.ts
+++ b/src/vs/workbench/contrib/debug/browser/callStackEditorContribution.ts
@@ -9,7 +9,7 @@ import { Disposable } from '../../../../base/common/lifecycle.js';
 import { Constants } from '../../../../base/common/uint.js';
 import { ICodeEditor } from '../../../../editor/browser/editorBrowser.js';
 import { Range } from '../../../../editor/common/core/range.js';
-import { IEditorContribution } from '../../../../editor/common/editorCommon.js';
+import { IEditorContribution, IEditorDecorationsCollection } from '../../../../editor/common/editorCommon.js';
 import { GlyphMarginLane, IModelDecorationOptions, IModelDeltaDecoration, OverviewRulerLane, TrackedRangeStickiness } from '../../../../editor/common/model.js';
 import { localize } from '../../../../nls.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
@@ -116,7 +116,7 @@ export function createDecorationsForStackFrame(stackFrame: IStackFrame, isFocuse
 }
 
 export class CallStackEditorContribution extends Disposable implements IEditorContribution {
-	private decorations = this.editor.createDecorationsCollection();
+	private decorations: IEditorDecorationsCollection;
 
 	constructor(
 		private readonly editor: ICodeEditor,
@@ -125,6 +125,8 @@ export class CallStackEditorContribution extends Disposable implements IEditorCo
 		@ILogService private readonly logService: ILogService,
 	) {
 		super();
+
+		this.decorations = this.editor.createDecorationsCollection();
 
 		const setDecorations = () => this.decorations.set(this.createCallStackDecorations());
 		this._register(Event.any(this.debugService.getViewModel().onDidFocusStackFrame, this.debugService.getModel().onDidChangeCallStack)(() => {

--- a/src/vs/workbench/contrib/debug/browser/debugEditorContribution.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugEditorContribution.ts
@@ -30,7 +30,7 @@ import { EditOperation } from '../../../../editor/common/core/editOperation.js';
 import { Position } from '../../../../editor/common/core/position.js';
 import { IRange, Range } from '../../../../editor/common/core/range.js';
 import { DEFAULT_WORD_REGEXP } from '../../../../editor/common/core/wordHelper.js';
-import { ScrollType } from '../../../../editor/common/editorCommon.js';
+import { IEditorDecorationsCollection, ScrollType } from '../../../../editor/common/editorCommon.js';
 import { StandardTokenType } from '../../../../editor/common/encodedTokenAttributes.js';
 import { InlineValue, InlineValueContext } from '../../../../editor/common/languages.js';
 import { IModelDeltaDecoration, ITextModel, InjectedTextCursorStops } from '../../../../editor/common/model.js';
@@ -209,7 +209,7 @@ export class DebugEditorContribution implements IDebugEditorContribution {
 	private configurationWidget: FloatingEditorClickWidget | undefined;
 	private readonly altListener = new MutableDisposable();
 	private altPressed = false;
-	private oldDecorations = this.editor.createDecorationsCollection();
+	private oldDecorations: IEditorDecorationsCollection;
 	private readonly displayedStore = new DisposableStore();
 	private editorHoverOptions: IEditorHoverOptions | undefined;
 	private readonly debounceInfo: IFeatureDebounceInformation;
@@ -229,6 +229,7 @@ export class DebugEditorContribution implements IDebugEditorContribution {
 		@ILanguageFeaturesService private readonly languageFeaturesService: ILanguageFeaturesService,
 		@ILanguageFeatureDebounceService featureDebounceService: ILanguageFeatureDebounceService
 	) {
+		this.oldDecorations = this.editor.createDecorationsCollection();
 		this.debounceInfo = featureDebounceService.for(languageFeaturesService.inlineValuesProvider, 'InlineValues', { min: DEAFULT_INLINE_DEBOUNCE_DELAY });
 		this.hoverWidget = this.instantiationService.createInstance(DebugHoverWidget, this.editor);
 		this.toDispose = [this.defaultHoverLockout, this.altListener, this.displayedStore];

--- a/src/vs/workbench/contrib/debug/browser/debugHover.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugHover.ts
@@ -23,6 +23,7 @@ import { ConfigurationChangedEvent, EditorOption } from '../../../../editor/comm
 import { IDimension } from '../../../../editor/common/core/dimension.js';
 import { Position } from '../../../../editor/common/core/position.js';
 import { Range } from '../../../../editor/common/core/range.js';
+import { IEditorDecorationsCollection } from '../../../../editor/common/editorCommon.js';
 import { ModelDecorationOptions } from '../../../../editor/common/model/textModel.js';
 import { ILanguageFeaturesService } from '../../../../editor/common/services/languageFeatures.js';
 import * as nls from '../../../../nls.js';
@@ -93,7 +94,7 @@ export class DebugHoverWidget implements IContentWidget {
 	private tree!: AsyncDataTree<IExpression, IExpression, any>;
 	private showAtPosition: Position | null;
 	private positionPreference: ContentWidgetPositionPreference[];
-	private readonly highlightDecorations = this.editor.createDecorationsCollection();
+	private readonly highlightDecorations: IEditorDecorationsCollection;
 	private complexValueContainer!: HTMLElement;
 	private complexValueTitle!: HTMLElement;
 	private valueContainer!: HTMLElement;
@@ -118,6 +119,8 @@ export class DebugHoverWidget implements IContentWidget {
 		@IContextKeyService private readonly contextKeyService: IContextKeyService,
 		@IContextMenuService private readonly contextMenuService: IContextMenuService,
 	) {
+		this.highlightDecorations = this.editor.createDecorationsCollection();
+
 		this.toDispose = [];
 
 		this.showAtPosition = null;

--- a/src/vs/workbench/contrib/debug/browser/debugMemory.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugMemory.ts
@@ -235,11 +235,12 @@ class MemoryRegionView extends Disposable implements IMemoryRegion {
 
 	public readonly onDidInvalidate = this.invalidateEmitter.event;
 	public readonly writable: boolean;
-	private readonly width = this.range.toOffset - this.range.fromOffset;
+	private readonly width: number;
 
 	constructor(private readonly parent: IMemoryRegion, public readonly range: { fromOffset: number; toOffset: number }) {
 		super();
 		this.writable = parent.writable;
+		this.width = this.range.toOffset - this.range.fromOffset;
 
 		this._register(parent);
 		this._register(parent.onDidInvalidate(e => {

--- a/src/vs/workbench/contrib/debug/common/debugModel.ts
+++ b/src/vs/workbench/contrib/debug/common/debugModel.ts
@@ -744,10 +744,13 @@ export class MemoryRegion extends Disposable implements IMemoryRegion {
 	public readonly onDidInvalidate = this.invalidateEmitter.event;
 
 	/** @inheritdoc */
-	public readonly writable = !!this.session.capabilities.supportsWriteMemoryRequest;
+	public readonly writable: boolean;
 
 	constructor(private readonly memoryReference: string, private readonly session: IDebugSession) {
 		super();
+
+		this.writable = !!this.session.capabilities.supportsWriteMemoryRequest;
+
 		this._register(session.onDidInvalidateMemory(e => {
 			if (e.body.memoryReference === memoryReference) {
 				this.invalidate(e.body.offset, e.body.count - e.body.offset);

--- a/src/vs/workbench/contrib/editSessions/browser/editSessionsStorageService.ts
+++ b/src/vs/workbench/contrib/editSessions/browser/editSessionsStorageService.ts
@@ -25,6 +25,7 @@ import { Emitter } from '../../../../base/common/event.js';
 import { CancellationError } from '../../../../base/common/errors.js';
 import { EditSessionsStoreClient } from '../common/editSessionsStorageClient.js';
 import { ISecretStorageService } from '../../../../platform/secrets/common/secrets.js';
+import { ConfigurationSyncStore } from '../../../../base/common/product.js';
 
 type ExistingSession = IQuickPickItem & { session: AuthenticationSession & { providerId: string } };
 type AuthenticationProviderOption = IQuickPickItem & { provider: IAuthenticationProvider };
@@ -35,7 +36,7 @@ export class EditSessionsWorkbenchService extends Disposable implements IEditSes
 
 	public readonly SIZE_LIMIT = Math.floor(1024 * 1024 * 1.9); // 2 MB
 
-	private serverConfiguration = this.productService['editSessions.store'];
+	private serverConfiguration: Omit<ConfigurationSyncStore, 'insidersUrl' | 'stableUrl'> | undefined;
 	private machineClient: IUserDataSyncMachinesService | undefined;
 
 	private authenticationInfo: { sessionId: string; token: string; providerId: string } | undefined;
@@ -84,6 +85,8 @@ export class EditSessionsWorkbenchService extends Disposable implements IEditSes
 		@ISecretStorageService private readonly secretStorageService: ISecretStorageService
 	) {
 		super();
+
+		this.serverConfiguration = this.productService['editSessions.store'];
 
 		// If the user signs out of the current session, reset our cached auth state in memory and on disk
 		this._register(this.authenticationService.onDidChangeSessions((e) => this.onDidChangeSessions(e.event)));

--- a/src/vs/workbench/contrib/extensions/browser/extensionsWorkbenchService.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionsWorkbenchService.ts
@@ -928,7 +928,7 @@ export class ExtensionsWorkbenchService extends Disposable implements IExtension
 	private readonly _onReset = new Emitter<void>();
 	get onReset() { return this._onReset.event; }
 
-	readonly preferPreReleases = this.productService.quality !== 'stable';
+	readonly preferPreReleases: boolean;
 
 	private installing: IExtension[] = [];
 	private tasksInProgress: CancelablePromise<any>[] = [];
@@ -972,6 +972,9 @@ export class ExtensionsWorkbenchService extends Disposable implements IExtension
 		@IAllowedExtensionsService private readonly allowedExtensionsService: IAllowedExtensionsService,
 	) {
 		super();
+
+		this.preferPreReleases = this.productService.quality !== 'stable';
+
 		const preferPreReleasesValue = configurationService.getValue('_extensions.preferPreReleases');
 		if (!isUndefined(preferPreReleasesValue)) {
 			this.preferPreReleases = !!preferPreReleasesValue;

--- a/src/vs/workbench/contrib/files/browser/editors/textFileSaveErrorHandler.ts
+++ b/src/vs/workbench/contrib/files/browser/editors/textFileSaveErrorHandler.ts
@@ -16,7 +16,7 @@ import { IWorkbenchContribution } from '../../../../common/contributions.js';
 import { ITextModelService } from '../../../../../editor/common/services/resolverService.js';
 import { ResourceMap } from '../../../../../base/common/map.js';
 import { DiffEditorInput } from '../../../../common/editor/diffEditorInput.js';
-import { IContextKeyService, RawContextKey } from '../../../../../platform/contextkey/common/contextkey.js';
+import { IContextKey, IContextKeyService, RawContextKey } from '../../../../../platform/contextkey/common/contextkey.js';
 import { TextFileContentProvider } from '../../common/files.js';
 import { FileEditorInput } from './fileEditorInput.js';
 import { SAVE_FILE_AS_LABEL } from '../fileConstants.js';
@@ -45,7 +45,7 @@ export class TextFileSaveErrorHandler extends Disposable implements ISaveErrorHa
 	static readonly ID = 'workbench.contrib.textFileSaveErrorHandler';
 
 	private readonly messages = new ResourceMap<INotificationHandle>();
-	private readonly conflictResolutionContext = new RawContextKey<boolean>(CONFLICT_RESOLUTION_CONTEXT, false, true).bindTo(this.contextKeyService);
+	private readonly conflictResolutionContext: IContextKey<boolean>;
 	private activeConflictResolutionResource: URI | undefined = undefined;
 
 	constructor(
@@ -58,6 +58,8 @@ export class TextFileSaveErrorHandler extends Disposable implements ISaveErrorHa
 		@IStorageService private readonly storageService: IStorageService
 	) {
 		super();
+
+		this.conflictResolutionContext = new RawContextKey<boolean>(CONFLICT_RESOLUTION_CONTEXT, false, true).bindTo(this.contextKeyService);
 
 		const provider = this._register(instantiationService.createInstance(TextFileContentProvider));
 		this._register(textModelService.registerTextModelContentProvider(CONFLICT_RESOLUTION_SCHEME, provider));

--- a/src/vs/workbench/contrib/files/browser/views/openEditorsView.ts
+++ b/src/vs/workbench/contrib/files/browser/views/openEditorsView.ts
@@ -639,8 +639,8 @@ class EditorGroupRenderer implements IListRenderer<IEditorGroup, IEditorGroupTem
 class OpenEditorRenderer implements IListRenderer<OpenEditor, IOpenEditorTemplateData> {
 	static readonly ID = 'openeditor';
 
-	private readonly closeEditorAction = this.instantiationService.createInstance(CloseEditorAction, CloseEditorAction.ID, CloseEditorAction.LABEL);
-	private readonly unpinEditorAction = this.instantiationService.createInstance(UnpinEditorAction, UnpinEditorAction.ID, UnpinEditorAction.LABEL);
+	private readonly closeEditorAction: CloseEditorAction;
+	private readonly unpinEditorAction: UnpinEditorAction;
 
 	constructor(
 		private labels: ResourceLabels,
@@ -648,7 +648,8 @@ class OpenEditorRenderer implements IListRenderer<OpenEditor, IOpenEditorTemplat
 		private keybindingService: IKeybindingService,
 		private configurationService: IConfigurationService
 	) {
-		// noop
+		this.closeEditorAction = this.instantiationService.createInstance(CloseEditorAction, CloseEditorAction.ID, CloseEditorAction.LABEL);
+		this.unpinEditorAction = this.instantiationService.createInstance(UnpinEditorAction, UnpinEditorAction.ID, UnpinEditorAction.LABEL);
 	}
 
 	get templateId() {

--- a/src/vs/workbench/contrib/inlineCompletions/browser/inlineCompletionLanguageStatusBarContribution.ts
+++ b/src/vs/workbench/contrib/inlineCompletions/browser/inlineCompletionLanguageStatusBarContribution.ts
@@ -18,7 +18,7 @@ export class InlineCompletionLanguageStatusBarContribution extends Disposable {
 
 	public static Id = 'vs.editor.contrib.inlineCompletionLanguageStatusBarContribution';
 
-	private readonly _c = InlineCompletionsController.get(this._editor);
+	private readonly _c: InlineCompletionsController | null;
 
 	private readonly _state = derived(this, reader => {
 		const model = this._c?.model.read(reader);
@@ -35,6 +35,8 @@ export class InlineCompletionLanguageStatusBarContribution extends Disposable {
 		@ILanguageStatusService private readonly _languageStatusService: ILanguageStatusService,
 	) {
 		super();
+
+		this._c = InlineCompletionsController.get(this._editor);
 
 		this._register(autorunWithStore((reader, store) => {
 			const state = this._state.read(reader);

--- a/src/vs/workbench/contrib/markers/browser/markersViewActions.ts
+++ b/src/vs/workbench/contrib/markers/browser/markersViewActions.ts
@@ -9,7 +9,7 @@ import { IContextMenuService } from '../../../../platform/contextview/browser/co
 import Messages from './messages.js';
 import { Disposable } from '../../../../base/common/lifecycle.js';
 import { Marker } from './markersModel.js';
-import { IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
+import { IContextKey, IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
 import { Event, Emitter } from '../../../../base/common/event.js';
 import { Codicon } from '../../../../base/common/codicons.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
@@ -42,6 +42,12 @@ export class MarkersFilters extends Disposable {
 	constructor(options: IMarkersFiltersOptions, private readonly contextKeyService: IContextKeyService) {
 		super();
 
+		this._excludedFiles = MarkersContextKeys.ShowExcludedFilesFilterContextKey.bindTo(this.contextKeyService);
+		this._activeFile = MarkersContextKeys.ShowActiveFileFilterContextKey.bindTo(this.contextKeyService);
+		this._showWarnings = MarkersContextKeys.ShowWarningsFilterContextKey.bindTo(this.contextKeyService);
+		this._showErrors = MarkersContextKeys.ShowErrorsFilterContextKey.bindTo(this.contextKeyService);
+		this._showInfos = MarkersContextKeys.ShowInfoFilterContextKey.bindTo(this.contextKeyService);
+
 		this._showErrors.set(options.showErrors);
 		this._showWarnings.set(options.showWarnings);
 		this._showInfos.set(options.showInfos);
@@ -52,7 +58,7 @@ export class MarkersFilters extends Disposable {
 
 	filterHistory: string[];
 
-	private readonly _excludedFiles = MarkersContextKeys.ShowExcludedFilesFilterContextKey.bindTo(this.contextKeyService);
+	private readonly _excludedFiles: IContextKey<boolean>;
 	get excludedFiles(): boolean {
 		return !!this._excludedFiles.get();
 	}
@@ -63,7 +69,7 @@ export class MarkersFilters extends Disposable {
 		}
 	}
 
-	private readonly _activeFile = MarkersContextKeys.ShowActiveFileFilterContextKey.bindTo(this.contextKeyService);
+	private readonly _activeFile: IContextKey<boolean>;
 	get activeFile(): boolean {
 		return !!this._activeFile.get();
 	}
@@ -74,7 +80,7 @@ export class MarkersFilters extends Disposable {
 		}
 	}
 
-	private readonly _showWarnings = MarkersContextKeys.ShowWarningsFilterContextKey.bindTo(this.contextKeyService);
+	private readonly _showWarnings: IContextKey<boolean>;
 	get showWarnings(): boolean {
 		return !!this._showWarnings.get();
 	}
@@ -85,7 +91,7 @@ export class MarkersFilters extends Disposable {
 		}
 	}
 
-	private readonly _showErrors = MarkersContextKeys.ShowErrorsFilterContextKey.bindTo(this.contextKeyService);
+	private readonly _showErrors: IContextKey<boolean>;
 	get showErrors(): boolean {
 		return !!this._showErrors.get();
 	}
@@ -96,7 +102,7 @@ export class MarkersFilters extends Disposable {
 		}
 	}
 
-	private readonly _showInfos = MarkersContextKeys.ShowInfoFilterContextKey.bindTo(this.contextKeyService);
+	private readonly _showInfos: IContextKey<boolean>;
 	get showInfos(): boolean {
 		return !!this._showInfos.get();
 	}

--- a/src/vs/workbench/contrib/mergeEditor/browser/mergeEditorInput.ts
+++ b/src/vs/workbench/contrib/mergeEditor/browser/mergeEditorInput.ts
@@ -67,6 +67,13 @@ export class MergeEditorInput extends AbstractTextResourceEditorInput implements
 		@ICustomEditorLabelService customEditorLabelService: ICustomEditorLabelService,
 	) {
 		super(result, undefined, editorService, textFileService, labelService, fileService, filesConfigurationService, textResourceConfigurationService, customEditorLabelService);
+
+		this.mergeEditorModeFactory = this._instaService.createInstance(
+			this.useWorkingCopy
+				? TempFileMergeEditorModeFactory
+				: WorkspaceMergeEditorModeFactory,
+			this._instaService.createInstance(MergeEditorTelemetry),
+		);
 	}
 
 	override dispose(): void {
@@ -93,12 +100,7 @@ export class MergeEditorInput extends AbstractTextResourceEditorInput implements
 		return localize('name', "Merging: {0}", super.getName());
 	}
 
-	private readonly mergeEditorModeFactory = this._instaService.createInstance(
-		this.useWorkingCopy
-			? TempFileMergeEditorModeFactory
-			: WorkspaceMergeEditorModeFactory,
-		this._instaService.createInstance(MergeEditorTelemetry),
-	);
+	private readonly mergeEditorModeFactory: TempFileMergeEditorModeFactory | WorkspaceMergeEditorModeFactory;
 
 	override async resolve(): Promise<IMergeEditorInputModel> {
 		if (!this._inputModel) {

--- a/src/vs/workbench/contrib/mergeEditor/browser/model/diffComputer.ts
+++ b/src/vs/workbench/contrib/mergeEditor/browser/model/diffComputer.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { assertFn, checkAdjacentItems } from '../../../../../base/common/assert.js';
-import { IReader } from '../../../../../base/common/observable.js';
+import { IObservable, IReader } from '../../../../../base/common/observable.js';
 import { RangeMapping as DiffRangeMapping } from '../../../../../editor/common/diff/rangeMapping.js';
 import { ITextModel } from '../../../../../editor/common/model.js';
 import { IEditorWorkerService } from '../../../../../editor/common/services/editorWorker.js';
@@ -23,14 +23,15 @@ export interface IMergeDiffComputerResult {
 }
 
 export class MergeDiffComputer implements IMergeDiffComputer {
-	private readonly mergeAlgorithm = observableConfigValue<'smart' | 'experimental' | 'legacy' | 'advanced'>(
-		'mergeEditor.diffAlgorithm', 'advanced', this.configurationService)
-		.map(v => v === 'smart' ? 'legacy' : v === 'experimental' ? 'advanced' : v);
+	private readonly mergeAlgorithm: IObservable<'legacy' | 'advanced'>;
 
 	constructor(
 		@IEditorWorkerService private readonly editorWorkerService: IEditorWorkerService,
 		@IConfigurationService private readonly configurationService: IConfigurationService,
 	) {
+		this.mergeAlgorithm = observableConfigValue<'smart' | 'experimental' | 'legacy' | 'advanced'>(
+			'mergeEditor.diffAlgorithm', 'advanced', this.configurationService)
+			.map(v => v === 'smart' ? 'legacy' : v === 'experimental' ? 'advanced' : v);
 	}
 
 	async computeDiff(textModel1: ITextModel, textModel2: ITextModel, reader: IReader): Promise<IMergeDiffComputerResult> {

--- a/src/vs/workbench/contrib/mergeEditor/browser/model/modifiedBaseRange.ts
+++ b/src/vs/workbench/contrib/mergeEditor/browser/model/modifiedBaseRange.ts
@@ -45,9 +45,9 @@ export class ModifiedBaseRange {
 		);
 	}
 
-	public readonly input1CombinedDiff = DetailedLineRangeMapping.join(this.input1Diffs);
-	public readonly input2CombinedDiff = DetailedLineRangeMapping.join(this.input2Diffs);
-	public readonly isEqualChange = equals(this.input1Diffs, this.input2Diffs, (a, b) => a.getLineEdit().equals(b.getLineEdit()));
+	public readonly input1CombinedDiff: DetailedLineRangeMapping | undefined;
+	public readonly input2CombinedDiff: DetailedLineRangeMapping | undefined;
+	public readonly isEqualChange: boolean;
 
 	constructor(
 		public readonly baseRange: LineRange,
@@ -67,6 +67,10 @@ export class ModifiedBaseRange {
 		*/
 		public readonly input2Diffs: readonly DetailedLineRangeMapping[]
 	) {
+		this.input1CombinedDiff = DetailedLineRangeMapping.join(this.input1Diffs);
+		this.input2CombinedDiff = DetailedLineRangeMapping.join(this.input2Diffs);
+		this.isEqualChange = equals(this.input1Diffs, this.input2Diffs, (a, b) => a.getLineEdit().equals(b.getLineEdit()));
+
 		if (this.input1Diffs.length === 0 && this.input2Diffs.length === 0) {
 			throw new BugIndicatingError('must have at least one diff');
 		}

--- a/src/vs/workbench/contrib/mergeEditor/browser/view/editorGutter.ts
+++ b/src/vs/workbench/contrib/mergeEditor/browser/view/editorGutter.ts
@@ -5,23 +5,17 @@
 
 import { h, reset } from '../../../../../base/browser/dom.js';
 import { Disposable, IDisposable, toDisposable } from '../../../../../base/common/lifecycle.js';
-import { autorun, IReader, observableFromEvent, observableSignal, observableSignalFromEvent, transaction } from '../../../../../base/common/observable.js';
+import { autorun, IObservable, IReader, observableFromEvent, observableSignal, observableSignalFromEvent, transaction } from '../../../../../base/common/observable.js';
 import { CodeEditorWidget } from '../../../../../editor/browser/widget/codeEditor/codeEditorWidget.js';
 import { LineRange } from '../model/lineRange.js';
 
 export class EditorGutter<T extends IGutterItemInfo = IGutterItemInfo> extends Disposable {
-	private readonly scrollTop = observableFromEvent(this,
-		this._editor.onDidScrollChange,
-		(e) => /** @description editor.onDidScrollChange */ this._editor.getScrollTop()
-	);
-	private readonly isScrollTopZero = this.scrollTop.map((scrollTop) => /** @description isScrollTopZero */ scrollTop === 0);
-	private readonly modelAttached = observableFromEvent(this,
-		this._editor.onDidChangeModel,
-		(e) => /** @description editor.onDidChangeModel */ this._editor.hasModel()
-	);
+	private readonly scrollTop: IObservable<number>;
+	private readonly isScrollTopZero: IObservable<boolean>;
+	private readonly modelAttached: IObservable<boolean>;
 
-	private readonly editorOnDidChangeViewZones = observableSignalFromEvent('onDidChangeViewZones', this._editor.onDidChangeViewZones);
-	private readonly editorOnDidContentSizeChange = observableSignalFromEvent('onDidContentSizeChange', this._editor.onDidContentSizeChange);
+	private readonly editorOnDidChangeViewZones: IObservable<void>;
+	private readonly editorOnDidContentSizeChange: IObservable<void>;
 	private readonly domNodeSizeChanged = observableSignal('domNodeSizeChanged');
 
 	constructor(
@@ -30,6 +24,20 @@ export class EditorGutter<T extends IGutterItemInfo = IGutterItemInfo> extends D
 		private readonly itemProvider: IGutterItemProvider<T>
 	) {
 		super();
+
+		this.scrollTop = observableFromEvent(this,
+			this._editor.onDidScrollChange,
+			(e) => /** @description editor.onDidScrollChange */ this._editor.getScrollTop()
+		);
+		this.isScrollTopZero = this.scrollTop.map((scrollTop) => /** @description isScrollTopZero */ scrollTop === 0);
+		this.modelAttached = observableFromEvent(this,
+			this._editor.onDidChangeModel,
+			(e) => /** @description editor.onDidChangeModel */ this._editor.hasModel()
+		);
+
+		this.editorOnDidChangeViewZones = observableSignalFromEvent('onDidChangeViewZones', this._editor.onDidChangeViewZones);
+		this.editorOnDidContentSizeChange = observableSignalFromEvent('onDidContentSizeChange', this._editor.onDidContentSizeChange);
+
 		this._domNode.className = 'gutter monaco-editor';
 		const scrollDecoration = this._domNode.appendChild(
 			h('div.scroll-decoration', { role: 'presentation', ariaHidden: 'true', style: { width: '100%' } })

--- a/src/vs/workbench/contrib/mergeEditor/browser/view/mergeEditor.ts
+++ b/src/vs/workbench/contrib/mergeEditor/browser/view/mergeEditor.ts
@@ -75,13 +75,13 @@ export class MergeEditor extends AbstractTextEditor<IMergeEditorViewState> {
 	private readonly inputResultView = this._register(this.instantiationService.createInstance(ResultCodeEditorView, this._viewModel));
 	private readonly _layoutMode = this.instantiationService.createInstance(MergeEditorLayoutStore);
 	private readonly _layoutModeObs = observableValue(this, this._layoutMode.value);
-	private readonly _ctxIsMergeEditor: IContextKey<boolean> = ctxIsMergeEditor.bindTo(this.contextKeyService);
-	private readonly _ctxUsesColumnLayout: IContextKey<string> = ctxMergeEditorLayout.bindTo(this.contextKeyService);
-	private readonly _ctxShowBase: IContextKey<boolean> = ctxMergeEditorShowBase.bindTo(this.contextKeyService);
-	private readonly _ctxShowBaseAtTop = ctxMergeEditorShowBaseAtTop.bindTo(this.contextKeyService);
-	private readonly _ctxResultUri: IContextKey<string> = ctxMergeResultUri.bindTo(this.contextKeyService);
-	private readonly _ctxBaseUri: IContextKey<string> = ctxMergeBaseUri.bindTo(this.contextKeyService);
-	private readonly _ctxShowNonConflictingChanges: IContextKey<boolean> = ctxMergeEditorShowNonConflictingChanges.bindTo(this.contextKeyService);
+	private readonly _ctxIsMergeEditor: IContextKey<boolean>;
+	private readonly _ctxUsesColumnLayout: IContextKey<string>;
+	private readonly _ctxShowBase: IContextKey<boolean>;
+	private readonly _ctxShowBaseAtTop: IContextKey<boolean>;
+	private readonly _ctxResultUri: IContextKey<string>;
+	private readonly _ctxBaseUri: IContextKey<string>;
+	private readonly _ctxShowNonConflictingChanges: IContextKey<boolean>;
 	private readonly _inputModel = observableValue<IMergeEditorInputModel | undefined>(this, undefined);
 	public get inputModel(): IObservable<IMergeEditorInputModel | undefined> {
 		return this._inputModel;
@@ -100,11 +100,7 @@ export class MergeEditor extends AbstractTextEditor<IMergeEditorViewState> {
 		this.inputResultView.editor,
 	);
 
-	protected readonly codeLensesVisible = observableConfigValue<boolean>(
-		'mergeEditor.showCodeLenses',
-		true,
-		this.configurationService,
-	);
+	protected readonly codeLensesVisible: IObservable<boolean>;
 
 	private readonly scrollSynchronizer = this._register(new ScrollSynchronizer(this._viewModel, this.input1View, this.input2View, this.baseView, this.inputResultView, this._layoutModeObs));
 
@@ -124,6 +120,20 @@ export class MergeEditor extends AbstractTextEditor<IMergeEditorViewState> {
 		@IConfigurationService private readonly configurationService: IConfigurationService
 	) {
 		super(MergeEditor.ID, group, telemetryService, instantiation, storageService, textResourceConfigurationService, themeService, editorService, editorGroupService, fileService);
+
+		this._ctxIsMergeEditor = ctxIsMergeEditor.bindTo(this.contextKeyService);
+		this._ctxUsesColumnLayout = ctxMergeEditorLayout.bindTo(this.contextKeyService);
+		this._ctxShowBase = ctxMergeEditorShowBase.bindTo(this.contextKeyService);
+		this._ctxShowBaseAtTop = ctxMergeEditorShowBaseAtTop.bindTo(this.contextKeyService);
+		this._ctxResultUri = ctxMergeResultUri.bindTo(this.contextKeyService);
+		this._ctxBaseUri = ctxMergeBaseUri.bindTo(this.contextKeyService);
+		this._ctxShowNonConflictingChanges = ctxMergeEditorShowNonConflictingChanges.bindTo(this.contextKeyService);
+
+		this.codeLensesVisible = observableConfigValue<boolean>(
+			'mergeEditor.showCodeLenses',
+			true,
+			this.configurationService,
+		);
 	}
 
 	override dispose(): void {

--- a/src/vs/workbench/contrib/mergeEditor/browser/view/viewZones.ts
+++ b/src/vs/workbench/contrib/mergeEditor/browser/view/viewZones.ts
@@ -17,15 +17,19 @@ import { getAlignments } from './lineAlignment.js';
 import { MergeEditorViewModel } from './viewModel.js';
 
 export class ViewZoneComputer {
-	private readonly conflictActionsFactoryInput1 = new ConflictActionsFactory(this.input1Editor);
-	private readonly conflictActionsFactoryInput2 = new ConflictActionsFactory(this.input2Editor);
-	private readonly conflictActionsFactoryResult = new ConflictActionsFactory(this.resultEditor);
+	private readonly conflictActionsFactoryInput1: ConflictActionsFactory;
+	private readonly conflictActionsFactoryInput2: ConflictActionsFactory;
+	private readonly conflictActionsFactoryResult: ConflictActionsFactory;
 
 	constructor(
 		private readonly input1Editor: ICodeEditor,
 		private readonly input2Editor: ICodeEditor,
 		private readonly resultEditor: ICodeEditor,
-	) { }
+	) {
+		this.conflictActionsFactoryInput1 = new ConflictActionsFactory(this.input1Editor);
+		this.conflictActionsFactoryInput2 = new ConflictActionsFactory(this.input2Editor);
+		this.conflictActionsFactoryResult = new ConflictActionsFactory(this.resultEditor);
+	}
 
 	public computeViewZones(
 		reader: IReader,

--- a/src/vs/workbench/contrib/multiDiffEditor/browser/multiDiffEditorInput.ts
+++ b/src/vs/workbench/contrib/multiDiffEditor/browser/multiDiffEditorInput.ts
@@ -93,6 +93,12 @@ export class MultiDiffEditorInput extends EditorInput implements ILanguageSuppor
 	) {
 		super();
 
+		this.textFileServiceOnDidChange = new FastEventDispatcher<ITextFileEditorModel, URI>(
+			this._textFileService.files.onDidChangeDirty,
+			item => item.resource.toString(),
+			uri => uri.toString()
+		);
+
 		this._register(autorun((reader) => {
 			/** @description Updates name */
 			const resources = this.resources.read(reader);
@@ -233,11 +239,7 @@ export class MultiDiffEditorInput extends EditorInput implements ILanguageSuppor
 
 	public readonly resources = derived(this, reader => this._resolvedSource.cachedPromiseResult.read(reader)?.data?.resources.read(reader));
 
-	private readonly textFileServiceOnDidChange = new FastEventDispatcher<ITextFileEditorModel, URI>(
-		this._textFileService.files.onDidChangeDirty,
-		item => item.resource.toString(),
-		uri => uri.toString()
-	);
+	private readonly textFileServiceOnDidChange: FastEventDispatcher<ITextFileEditorModel, URI>;
 
 	private readonly _isDirtyObservables = mapObservableArrayCached(this, this.resources.map(r => r ?? []), res => {
 		const isModifiedDirty = res.modifiedUri ? isUriDirty(this.textFileServiceOnDidChange, this._textFileService, res.modifiedUri) : constObservable(false);

--- a/src/vs/workbench/contrib/multiDiffEditor/browser/scmMultiDiffSourceResolver.ts
+++ b/src/vs/workbench/contrib/multiDiffEditor/browser/scmMultiDiffSourceResolver.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Disposable } from '../../../../base/common/lifecycle.js';
-import { observableFromEvent, ValueWithChangeEventFromObservable, waitForState } from '../../../../base/common/observable.js';
+import { IObservable, observableFromEvent, ValueWithChangeEventFromObservable, waitForState } from '../../../../base/common/observable.js';
 import { URI, UriComponents } from '../../../../base/common/uri.js';
 import { IMultiDiffEditorOptions } from '../../../../editor/browser/widget/multiDiffEditor/multiDiffEditorWidgetImpl.js';
 import { localize2 } from '../../../../nls.js';
@@ -84,21 +84,26 @@ export class ScmMultiDiffSourceResolver implements IMultiDiffSourceResolver {
 }
 
 class ScmResolvedMultiDiffSource implements IResolvedMultiDiffSource {
-	private readonly _resources = observableFromEvent<MultiDiffEditorItem[]>(
-		this._group.onDidChangeResources,
-		() => /** @description resources */ this._group.resources.map(e => new MultiDiffEditorItem(e.multiDiffEditorOriginalUri, e.multiDiffEditorModifiedUri, e.sourceUri))
-	);
-	readonly resources = new ValueWithChangeEventFromObservable(this._resources);
+	private readonly _resources: IObservable<MultiDiffEditorItem[]>;
+	readonly resources: ValueWithChangeEventFromObservable<MultiDiffEditorItem[]>;
 
-	public readonly contextKeys: Record<string, ContextKeyValue> = {
-		scmResourceGroup: this._group.id,
-		scmProvider: this._repository.provider.contextValue,
-	};
+	public readonly contextKeys: Record<string, ContextKeyValue>;
 
 	constructor(
 		private readonly _group: ISCMResourceGroup,
 		private readonly _repository: ISCMRepository,
-	) { }
+	) {
+		this._resources = observableFromEvent<MultiDiffEditorItem[]>(
+			this._group.onDidChangeResources,
+			() => /** @description resources */ this._group.resources.map(e => new MultiDiffEditorItem(e.multiDiffEditorOriginalUri, e.multiDiffEditorModifiedUri, e.sourceUri))
+		);
+		this.resources = new ValueWithChangeEventFromObservable(this._resources);
+
+		this.contextKeys = {
+			scmResourceGroup: this._group.id,
+			scmProvider: this._repository.provider.contextValue,
+		};
+	}
 }
 
 interface UriFields {

--- a/src/vs/workbench/contrib/notebook/browser/contrib/multicursor/notebookMulticursor.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/multicursor/notebookMulticursor.ts
@@ -35,7 +35,7 @@ import { WordHighlighterContribution } from '../../../../../../editor/contrib/wo
 import { IAccessibilityService } from '../../../../../../platform/accessibility/common/accessibility.js';
 import { MenuId, registerAction2 } from '../../../../../../platform/actions/common/actions.js';
 import { IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
-import { ContextKeyExpr, IContextKeyService, RawContextKey } from '../../../../../../platform/contextkey/common/contextkey.js';
+import { ContextKeyExpr, IContextKey, IContextKeyService, RawContextKey } from '../../../../../../platform/contextkey/common/contextkey.js';
 import { ServicesAccessor } from '../../../../../../platform/instantiation/common/instantiation.js';
 import { KeybindingWeight } from '../../../../../../platform/keybinding/common/keybindingsRegistry.js';
 import { IPastFutureElements, IUndoRedoElement, IUndoRedoService, UndoRedoElementType } from '../../../../../../platform/undoRedo/common/undoRedo.js';
@@ -111,8 +111,8 @@ export class NotebookMultiCursorController extends Disposable implements INotebo
 		return this.state;
 	}
 
-	private _nbIsMultiSelectSession = NOTEBOOK_MULTI_CURSOR_CONTEXT.IsNotebookMultiCursor.bindTo(this.contextKeyService);
-	private _nbMultiSelectState = NOTEBOOK_MULTI_CURSOR_CONTEXT.NotebookMultiSelectCursorState.bindTo(this.contextKeyService);
+	private _nbIsMultiSelectSession: IContextKey<boolean>;
+	private _nbMultiSelectState: IContextKey<NotebookMultiCursorState>;
 
 	constructor(
 		private readonly notebookEditor: INotebookEditor,
@@ -126,6 +126,9 @@ export class NotebookMultiCursorController extends Disposable implements INotebo
 		super();
 
 		this.anchorCell = this.notebookEditor.activeCellAndCodeEditor;
+
+		this._nbIsMultiSelectSession = NOTEBOOK_MULTI_CURSOR_CONTEXT.IsNotebookMultiCursor.bindTo(this.contextKeyService);
+		this._nbMultiSelectState = NOTEBOOK_MULTI_CURSOR_CONTEXT.NotebookMultiSelectCursorState.bindTo(this.contextKeyService);
 
 		// anchor cell will catch and relay all type, cut, paste events to the cursors controllers
 		// need to create new controllers when the anchor cell changes, then update their listeners

--- a/src/vs/workbench/contrib/notebook/browser/diff/diffElementViewModel.ts
+++ b/src/vs/workbench/contrib/notebook/browser/diff/diffElementViewModel.ts
@@ -680,8 +680,8 @@ export class SideBySideDiffElementViewModel extends DiffElementCellViewModelBase
 		return this.mainDocumentTextModel;
 	}
 
-	override readonly original!: DiffNestedCellViewModel;
-	override readonly modified!: DiffNestedCellViewModel;
+	declare readonly original: DiffNestedCellViewModel;
+	declare readonly modified: DiffNestedCellViewModel;
 	override readonly type: 'unchanged' | 'modified';
 
 	/**

--- a/src/vs/workbench/contrib/notebook/browser/diff/notebookMultiDiffEditor.ts
+++ b/src/vs/workbench/contrib/notebook/browser/diff/notebookMultiDiffEditor.ts
@@ -12,7 +12,7 @@ import { IEditorOpenContext } from '../../../../common/editor.js';
 import { IEditorGroup } from '../../../../services/editor/common/editorGroupsService.js';
 import { CancellationToken, CancellationTokenSource } from '../../../../../base/common/cancellation.js';
 import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
-import { IContextKeyService } from '../../../../../platform/contextkey/common/contextkey.js';
+import { IContextKey, IContextKeyService } from '../../../../../platform/contextkey/common/contextkey.js';
 import { INotebookEditorWorkerService } from '../../common/services/notebookWorkerService.js';
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 import { IEditorOptions as ICodeEditorOptions } from '../../../../../editor/common/config/editorOptions.js';
@@ -57,9 +57,9 @@ export class NotebookMultiTextDiffEditor extends EditorPane {
 	get notebookOptions() {
 		return this._notebookOptions;
 	}
-	private readonly ctxAllCollapsed = this._parentContextKeyService.createKey<boolean>(NOTEBOOK_DIFF_CELLS_COLLAPSED.key, false);
-	private readonly ctxHasUnchangedCells = this._parentContextKeyService.createKey<boolean>(NOTEBOOK_DIFF_HAS_UNCHANGED_CELLS.key, false);
-	private readonly ctxHiddenUnchangedCells = this._parentContextKeyService.createKey<boolean>(NOTEBOOK_DIFF_UNCHANGED_CELLS_HIDDEN.key, true);
+	private readonly ctxAllCollapsed: IContextKey<boolean>;
+	private readonly ctxHasUnchangedCells: IContextKey<boolean>;
+	private readonly ctxHiddenUnchangedCells: IContextKey<boolean>;
 
 	constructor(
 		group: IEditorGroup,
@@ -73,6 +73,11 @@ export class NotebookMultiTextDiffEditor extends EditorPane {
 		@INotebookService private readonly notebookService: INotebookService,
 	) {
 		super(NotebookMultiTextDiffEditor.ID, group, telemetryService, themeService, storageService);
+
+		this.ctxAllCollapsed = this._parentContextKeyService.createKey<boolean>(NOTEBOOK_DIFF_CELLS_COLLAPSED.key, false);
+		this.ctxHasUnchangedCells = this._parentContextKeyService.createKey<boolean>(NOTEBOOK_DIFF_HAS_UNCHANGED_CELLS.key, false);
+		this.ctxHiddenUnchangedCells = this._parentContextKeyService.createKey<boolean>(NOTEBOOK_DIFF_UNCHANGED_CELLS_HIDDEN.key, true);
+
 		this._notebookOptions = instantiationService.createInstance(NotebookOptions, this.window, false, undefined);
 		this._register(this._notebookOptions);
 	}

--- a/src/vs/workbench/contrib/notebook/browser/services/notebookServiceImpl.ts
+++ b/src/vs/workbench/contrib/notebook/browser/services/notebookServiceImpl.ts
@@ -483,7 +483,7 @@ export class NotebookService extends Disposable implements INotebookService {
 
 		return this._notebookProviderInfoStore;
 	}
-	private readonly _notebookRenderersInfoStore = this._instantiationService.createInstance(NotebookOutputRendererInfoStore);
+	private readonly _notebookRenderersInfoStore: NotebookOutputRendererInfoStore;
 	private readonly _onDidChangeOutputRenderers = this._register(new Emitter<void>());
 	readonly onDidChangeOutputRenderers = this._onDidChangeOutputRenderers.event;
 
@@ -524,6 +524,8 @@ export class NotebookService extends Disposable implements INotebookService {
 		@INotebookDocumentService private readonly _notebookDocumentService: INotebookDocumentService
 	) {
 		super();
+
+		this._notebookRenderersInfoStore = this._instantiationService.createInstance(NotebookOutputRendererInfoStore);
 
 		notebookRendererExtensionPoint.setHandler((renderers) => {
 			this._notebookRenderersInfoStore.clear();

--- a/src/vs/workbench/contrib/notebook/browser/view/notebookCellList.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/notebookCellList.ts
@@ -77,7 +77,7 @@ function validateWebviewBoundary(element: HTMLElement) {
 }
 
 export class NotebookCellList extends WorkbenchList<CellViewModel> implements IDisposable, IStyleController, INotebookCellList {
-	protected override readonly view!: NotebookCellListView<CellViewModel>;
+	protected declare readonly view: NotebookCellListView<CellViewModel>;
 	private viewZones!: NotebookViewZones;
 	get onWillScroll(): Event<ScrollEvent> { return this.view.onWillScroll; }
 

--- a/src/vs/workbench/contrib/output/browser/outputServices.ts
+++ b/src/vs/workbench/contrib/output/browser/outputServices.ts
@@ -108,6 +108,13 @@ class OutputViewFilters extends Disposable implements IOutputViewFilters {
 	) {
 		super();
 
+		this._trace = SHOW_TRACE_FILTER_CONTEXT.bindTo(this.contextKeyService);
+		this._debug = SHOW_DEBUG_FILTER_CONTEXT.bindTo(this.contextKeyService);
+		this._info = SHOW_INFO_FILTER_CONTEXT.bindTo(this.contextKeyService);
+		this._warning = SHOW_WARNING_FILTER_CONTEXT.bindTo(this.contextKeyService);
+		this._error = SHOW_ERROR_FILTER_CONTEXT.bindTo(this.contextKeyService);
+		this._categories = HIDE_CATEGORY_FILTER_CONTEXT.bindTo(this.contextKeyService);
+
 		this._trace.set(options.trace);
 		this._debug.set(options.debug);
 		this._info.set(options.info);
@@ -131,7 +138,7 @@ class OutputViewFilters extends Disposable implements IOutputViewFilters {
 		}
 	}
 
-	private readonly _trace = SHOW_TRACE_FILTER_CONTEXT.bindTo(this.contextKeyService);
+	private readonly _trace: IContextKey<boolean>;
 	get trace(): boolean {
 		return !!this._trace.get();
 	}
@@ -142,7 +149,7 @@ class OutputViewFilters extends Disposable implements IOutputViewFilters {
 		}
 	}
 
-	private readonly _debug = SHOW_DEBUG_FILTER_CONTEXT.bindTo(this.contextKeyService);
+	private readonly _debug: IContextKey<boolean>;
 	get debug(): boolean {
 		return !!this._debug.get();
 	}
@@ -153,7 +160,7 @@ class OutputViewFilters extends Disposable implements IOutputViewFilters {
 		}
 	}
 
-	private readonly _info = SHOW_INFO_FILTER_CONTEXT.bindTo(this.contextKeyService);
+	private readonly _info: IContextKey<boolean>;
 	get info(): boolean {
 		return !!this._info.get();
 	}
@@ -164,7 +171,7 @@ class OutputViewFilters extends Disposable implements IOutputViewFilters {
 		}
 	}
 
-	private readonly _warning = SHOW_WARNING_FILTER_CONTEXT.bindTo(this.contextKeyService);
+	private readonly _warning: IContextKey<boolean>;
 	get warning(): boolean {
 		return !!this._warning.get();
 	}
@@ -175,7 +182,7 @@ class OutputViewFilters extends Disposable implements IOutputViewFilters {
 		}
 	}
 
-	private readonly _error = SHOW_ERROR_FILTER_CONTEXT.bindTo(this.contextKeyService);
+	private readonly _error: IContextKey<boolean>;
 	get error(): boolean {
 		return !!this._error.get();
 	}
@@ -186,7 +193,7 @@ class OutputViewFilters extends Disposable implements IOutputViewFilters {
 		}
 	}
 
-	private readonly _categories = HIDE_CATEGORY_FILTER_CONTEXT.bindTo(this.contextKeyService);
+	private readonly _categories: IContextKey<string>;
 	get categories(): string {
 		return this._categories.get() || ',';
 	}

--- a/src/vs/workbench/contrib/preferences/browser/keybindingsEditorContribution.ts
+++ b/src/vs/workbench/contrib/preferences/browser/keybindingsEditorContribution.ts
@@ -26,6 +26,7 @@ import { assertIsDefined } from '../../../../base/common/types.js';
 import { isEqual } from '../../../../base/common/resources.js';
 import { IUserDataProfileService } from '../../../services/userDataProfile/common/userDataProfile.js';
 import { DEFINE_KEYBINDING_EDITOR_CONTRIB_ID, IDefineKeybindingEditorContribution } from '../../../services/preferences/common/preferences.js';
+import { IEditorDecorationsCollection } from '../../../../editor/common/editorCommon.js';
 
 const NLS_KB_LAYOUT_ERROR_MESSAGE = nls.localize('defineKeybinding.kbLayoutErrorMessage', "You won't be able to produce this key combination under your current keyboard layout.");
 
@@ -88,7 +89,7 @@ class DefineKeybindingEditorContribution extends Disposable implements IDefineKe
 export class KeybindingEditorDecorationsRenderer extends Disposable {
 
 	private _updateDecorations: RunOnceScheduler;
-	private readonly _dec = this._editor.createDecorationsCollection();
+	private readonly _dec: IEditorDecorationsCollection;
 
 	constructor(
 		private _editor: ICodeEditor,
@@ -97,6 +98,7 @@ export class KeybindingEditorDecorationsRenderer extends Disposable {
 		super();
 
 		this._updateDecorations = this._register(new RunOnceScheduler(() => this._updateDecorationsNow(), 500));
+		this._dec = this._editor.createDecorationsCollection();
 
 		const model = assertIsDefined(this._editor.getModel());
 		this._register(model.onDidChangeContent(() => this._updateDecorations.schedule()));

--- a/src/vs/workbench/contrib/preferences/browser/preferencesRenderers.ts
+++ b/src/vs/workbench/contrib/preferences/browser/preferencesRenderers.ts
@@ -787,7 +787,7 @@ class UnsupportedSettingsRenderer extends Disposable implements languages.CodeAc
 class WorkspaceConfigurationRenderer extends Disposable {
 	private static readonly supportedKeys = ['folders', 'tasks', 'launch', 'extensions', 'settings', 'remoteAuthority', 'transient'];
 
-	private readonly decorations = this.editor.createDecorationsCollection();
+	private readonly decorations: editorCommon.IEditorDecorationsCollection;
 	private renderingDelayer: Delayer<void> = new Delayer<void>(200);
 
 	constructor(private editor: ICodeEditor, private workspaceSettingsEditorModel: SettingsEditorModel,
@@ -795,6 +795,9 @@ class WorkspaceConfigurationRenderer extends Disposable {
 		@IMarkerService private readonly markerService: IMarkerService
 	) {
 		super();
+
+		this.decorations = this.editor.createDecorationsCollection();
+
 		this._register(this.editor.getModel()!.onDidChangeContent(() => this.renderingDelayer.trigger(() => this.render())));
 	}
 

--- a/src/vs/workbench/contrib/preferences/browser/preferencesWidgets.ts
+++ b/src/vs/workbench/contrib/preferences/browser/preferencesWidgets.ts
@@ -37,6 +37,7 @@ import { ILanguageService } from '../../../../editor/common/languages/language.j
 import { getDefaultHoverDelegate } from '../../../../base/browser/ui/hover/hoverDelegateFactory.js';
 import type { IManagedHover } from '../../../../base/browser/ui/hover/hover.js';
 import { IHoverService } from '../../../../platform/hover/browser/hover.js';
+import { IEditorDecorationsCollection } from '../../../../editor/common/editorCommon.js';
 
 export class FolderSettingsActionViewItem extends BaseActionViewItem {
 
@@ -500,13 +501,16 @@ export class EditPreferenceWidget<T> extends Disposable {
 	private _line: number = -1;
 	private _preferences: T[] = [];
 
-	private readonly _editPreferenceDecoration = this.editor.createDecorationsCollection();
+	private readonly _editPreferenceDecoration: IEditorDecorationsCollection;
 
 	private readonly _onClick = this._register(new Emitter<IEditorMouseEvent>());
 	readonly onClick: Event<IEditorMouseEvent> = this._onClick.event;
 
 	constructor(private editor: ICodeEditor) {
 		super();
+
+		this._editPreferenceDecoration = this.editor.createDecorationsCollection();
+
 		this._register(this.editor.onMouseDown((e: IEditorMouseEvent) => {
 			if (e.target.type !== MouseTargetType.GUTTER_GLYPH_MARGIN || e.target.detail.isAfterLines || !this.isVisible()) {
 				return;

--- a/src/vs/workbench/contrib/quickaccess/browser/commandsQuickAccess.ts
+++ b/src/vs/workbench/contrib/quickaccess/browser/commandsQuickAccess.ts
@@ -49,7 +49,7 @@ export class CommandsQuickAccessProvider extends AbstractEditorCommandsQuickAcce
 	// a chance to register so that the complete set of commands shows up as result
 	// We do not want to delay functionality beyond that time though to keep the commands
 	// functional.
-	private readonly extensionRegistrationRace = raceTimeout(this.extensionService.whenInstalledExtensionsRegistered(), 800);
+	private readonly extensionRegistrationRace: Promise<boolean | undefined>;
 
 	private useAiRelatedInfo = false;
 
@@ -86,6 +86,8 @@ export class CommandsQuickAccessProvider extends AbstractEditorCommandsQuickAcce
 				commandId: ''
 			}),
 		}, instantiationService, keybindingService, commandService, telemetryService, dialogService);
+
+		this.extensionRegistrationRace = raceTimeout(this.extensionService.whenInstalledExtensionsRegistered(), 800);
 
 		this._register(configurationService.onDidChangeConfiguration((e) => this.updateOptions(e)));
 		this.updateOptions();

--- a/src/vs/workbench/contrib/scm/browser/activity.ts
+++ b/src/vs/workbench/contrib/scm/browser/activity.ts
@@ -30,11 +30,9 @@ const ActiveRepositoryContextKeys = {
 };
 
 export class SCMActiveRepositoryController extends Disposable implements IWorkbenchContribution {
-	private readonly _countBadgeConfig = observableConfigValue<'all' | 'focused' | 'off'>('scm.countBadge', 'all', this.configurationService);
+	private readonly _countBadgeConfig: IObservable<'all' | 'focused' | 'off'>;
 
-	private readonly _repositories = observableFromEvent(this,
-		Event.any(this.scmService.onDidAddRepository, this.scmService.onDidRemoveRepository),
-		() => this.scmService.repositories);
+	private readonly _repositories: IObservable<Iterable<ISCMRepository>>;
 
 	private readonly _activeRepositoryHistoryItemRefName = derived(reader => {
 		const repository = this.scmViewService.activeRepository.read(reader);
@@ -87,6 +85,11 @@ export class SCMActiveRepositoryController extends Disposable implements IWorkbe
 		@ITitleService private readonly titleService: ITitleService
 	) {
 		super();
+
+		this._countBadgeConfig = observableConfigValue<'all' | 'focused' | 'off'>('scm.countBadge', 'all', this.configurationService);
+		this._repositories = observableFromEvent(this,
+			Event.any(this.scmService.onDidAddRepository, this.scmService.onDidRemoveRepository),
+			() => this.scmService.repositories);
 
 		this._activeRepositoryNameContextKey = ActiveRepositoryContextKeys.ActiveRepositoryName.bindTo(this.contextKeyService);
 		this._activeRepositoryBranchNameContextKey = ActiveRepositoryContextKeys.ActiveRepositoryBranchName.bindTo(this.contextKeyService);
@@ -177,9 +180,7 @@ export class SCMActiveRepositoryController extends Disposable implements IWorkbe
 }
 
 export class SCMActiveResourceContextKeyController extends Disposable implements IWorkbenchContribution {
-	private readonly _repositories = observableFromEvent(this,
-		Event.any(this.scmService.onDidAddRepository, this.scmService.onDidRemoveRepository),
-		() => this.scmService.repositories);
+	private readonly _repositories: IObservable<Iterable<ISCMRepository>>;
 
 	private readonly _onDidRepositoryChange = new Emitter<void>();
 
@@ -189,6 +190,10 @@ export class SCMActiveResourceContextKeyController extends Disposable implements
 		@IUriIdentityService private readonly uriIdentityService: IUriIdentityService
 	) {
 		super();
+
+		this._repositories = observableFromEvent(this,
+			Event.any(this.scmService.onDidAddRepository, this.scmService.onDidRemoveRepository),
+			() => this.scmService.repositories);
 
 		const activeResourceHasChangesContextKey = new RawContextKey<boolean>('scmActiveResourceHasChanges', false, localize('scmActiveResourceHasChanges', "Whether the active resource has changes"));
 		const activeResourceRepositoryContextKey = new RawContextKey<string | undefined>('scmActiveResourceRepository', undefined, localize('scmActiveResourceRepository', "The active resource's repository"));

--- a/src/vs/workbench/contrib/scm/browser/quickDiffDecorator.ts
+++ b/src/vs/workbench/contrib/scm/browser/quickDiffDecorator.ts
@@ -22,7 +22,8 @@ import { IWorkbenchContribution } from '../../../common/contributions.js';
 import { ResourceMap } from '../../../../base/common/map.js';
 import { IUriIdentityService } from '../../../../platform/uriIdentity/common/uriIdentity.js';
 import { IContextKey, IContextKeyService, RawContextKey } from '../../../../platform/contextkey/common/contextkey.js';
-import { autorun, autorunWithStore, observableFromEvent } from '../../../../base/common/observable.js';
+import { IObservable, autorun, autorunWithStore, observableFromEvent } from '../../../../base/common/observable.js';
+import { EditorInput } from '../../../common/editor/editorInput.js';
 
 export const quickDiffDecorationCount = new RawContextKey<number>('quickDiffDecorationCount', 0);
 
@@ -188,8 +189,7 @@ export class QuickDiffWorkbenchController extends Disposable implements IWorkben
 	private enabled = false;
 	private readonly quickDiffDecorationCount: IContextKey<number>;
 
-	private readonly activeEditor = observableFromEvent(this,
-		this.editorService.onDidActiveEditorChange, () => this.editorService.activeEditor);
+	private readonly activeEditor: IObservable<EditorInput | undefined>;
 
 	// Resource URI -> Code Editor Id -> Decoration (Disposable)
 	private readonly decorators = new ResourceMap<DisposableMap<string>>();
@@ -208,6 +208,9 @@ export class QuickDiffWorkbenchController extends Disposable implements IWorkben
 		this.stylesheet = domStylesheetsJs.createStyleSheet(undefined, undefined, this._store);
 
 		this.quickDiffDecorationCount = quickDiffDecorationCount.bindTo(contextKeyService);
+
+		this.activeEditor = observableFromEvent(this,
+			this.editorService.onDidActiveEditorChange, () => this.editorService.activeEditor);
 
 		const onDidChangeConfiguration = Event.filter(configurationService.onDidChangeConfiguration, e => e.affectsConfiguration('scm.diffDecorations'));
 		this._register(onDidChangeConfiguration(this.onDidChangeConfiguration, this));

--- a/src/vs/workbench/contrib/scm/browser/scmViewService.ts
+++ b/src/vs/workbench/contrib/scm/browser/scmViewService.ts
@@ -18,9 +18,10 @@ import { binarySearch } from '../../../../base/common/arrays.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { IContextKey, IContextKeyService, RawContextKey } from '../../../../platform/contextkey/common/contextkey.js';
 import { IExtensionService } from '../../../services/extensions/common/extensions.js';
-import { derivedObservableWithCache, derivedOpts, latestChangedValue, observableFromEventOpts } from '../../../../base/common/observable.js';
+import { IObservable, derivedObservableWithCache, derivedOpts, latestChangedValue, observableFromEventOpts } from '../../../../base/common/observable.js';
 import { IEditorService } from '../../../services/editor/common/editorService.js';
 import { EditorResourceAccessor } from '../../../common/editor.js';
+import { EditorInput } from '../../../common/editor/editorInput.js';
 
 function getProviderStorageKey(provider: ISCMProvider): string {
 	return `${provider.contextValue}:${provider.label}${provider.rootUri ? `:${provider.rootUri.toString()}` : ''}`;
@@ -164,12 +165,7 @@ export class SCMViewService implements ISCMViewService {
 		}, this.onDidFocusRepository,
 		() => this.focusedRepository);
 
-	private readonly _activeEditor = observableFromEventOpts(
-		{
-			owner: this,
-			equalsFn: () => false
-		}, this.editorService.onDidActiveEditorChange,
-		() => this.editorService.activeEditor);
+	private readonly _activeEditor: IObservable<EditorInput | undefined>;
 
 	private readonly _activeEditorRepository = derivedObservableWithCache<ISCMRepository | undefined>(this,
 		(reader, lastValue) => {
@@ -221,6 +217,13 @@ export class SCMViewService implements ISCMViewService {
 		} catch {
 			// noop
 		}
+
+		this._activeEditor = observableFromEventOpts(
+			{
+				owner: this,
+				equalsFn: () => false
+			}, this.editorService.onDidActiveEditorChange,
+			() => this.editorService.activeEditor);
 
 		this._repositoriesSortKey = this.previousState?.sortKey ?? this.getViewSortOrder();
 		this._sortKeyContextKey = RepositoryContextKeys.RepositorySortKey.bindTo(contextKeyService);

--- a/src/vs/workbench/contrib/scm/browser/workingSet.ts
+++ b/src/vs/workbench/contrib/scm/browser/workingSet.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Disposable, DisposableMap, DisposableStore } from '../../../../base/common/lifecycle.js';
-import { autorun, autorunWithStore, derived } from '../../../../base/common/observable.js';
+import { IObservable, autorun, autorunWithStore, derived } from '../../../../base/common/observable.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { observableConfigValue } from '../../../../platform/observable/common/platformObservableUtils.js';
 import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
@@ -29,7 +29,7 @@ export class SCMWorkingSetController extends Disposable implements IWorkbenchCon
 	static readonly ID = 'workbench.contrib.scmWorkingSets';
 
 	private _workingSets!: Map<string, ISCMRepositoryWorkingSet>;
-	private _enabledConfig = observableConfigValue<boolean>('scm.workingSets.enabled', false, this.configurationService);
+	private _enabledConfig: IObservable<boolean>;
 
 	private readonly _repositoryDisposables = new DisposableMap<ISCMRepository>();
 
@@ -41,6 +41,8 @@ export class SCMWorkingSetController extends Disposable implements IWorkbenchCon
 		@IWorkbenchLayoutService private readonly layoutService: IWorkbenchLayoutService
 	) {
 		super();
+
+		this._enabledConfig = observableConfigValue<boolean>('scm.workingSets.enabled', false, this.configurationService);
 
 		this._store.add(autorunWithStore((reader, store) => {
 			if (!this._enabledConfig.read(reader)) {

--- a/src/vs/workbench/contrib/search/browser/anythingQuickAccess.ts
+++ b/src/vs/workbench/contrib/search/browser/anythingQuickAccess.ts
@@ -85,56 +85,7 @@ export class AnythingQuickAccessProvider extends PickerQuickAccessProvider<IAnyt
 
 	private static SYMBOL_PICKS_MERGE_DELAY = 200; // allow some time to merge fast and slow picks to reduce flickering
 
-	private readonly pickState = this._register(new class extends Disposable {
-
-		picker: IQuickPick<IAnythingQuickPickItem, { useSeparators: true }> | undefined = undefined;
-
-		editorViewState = this._register(this.instantiationService.createInstance(PickerEditorState));
-
-		scorerCache: FuzzyScorerCache = Object.create(null);
-		fileQueryCache: FileQueryCacheState | undefined = undefined;
-
-		lastOriginalFilter: string | undefined = undefined;
-		lastFilter: string | undefined = undefined;
-		lastRange: IRange | undefined = undefined;
-
-		lastGlobalPicks: PicksWithActive<IAnythingQuickPickItem> | undefined = undefined;
-
-		isQuickNavigating: boolean | undefined = undefined;
-
-		constructor(
-			private readonly provider: AnythingQuickAccessProvider,
-			private readonly instantiationService: IInstantiationService
-		) {
-			super();
-		}
-
-		set(picker: IQuickPick<IAnythingQuickPickItem, { useSeparators: true }>): void {
-
-			// Picker for this run
-			this.picker = picker;
-			Event.once(picker.onDispose)(() => {
-				if (picker === this.picker) {
-					this.picker = undefined; // clear the picker when disposed to not keep it in memory for too long
-				}
-			});
-
-			// Caches
-			const isQuickNavigating = !!picker.quickNavigate;
-			if (!isQuickNavigating) {
-				this.fileQueryCache = this.provider.createFileQueryCache();
-				this.scorerCache = Object.create(null);
-			}
-
-			// Other
-			this.isQuickNavigating = isQuickNavigating;
-			this.lastOriginalFilter = undefined;
-			this.lastFilter = undefined;
-			this.lastRange = undefined;
-			this.lastGlobalPicks = undefined;
-			this.editorViewState.reset();
-		}
-	}(this, this.instantiationService));
+	private readonly pickState;
 
 	get defaultFilterValue(): DefaultQuickAccessFilterValue | undefined {
 		if (this.configuration.preserveInput) {
@@ -171,6 +122,65 @@ export class AnythingQuickAccessProvider extends PickerQuickAccessProvider<IAnyt
 			canAcceptInBackground: true,
 			noResultsPick: AnythingQuickAccessProvider.NO_RESULTS_PICK
 		});
+
+		this.pickState = this._register(new class extends Disposable {
+
+			picker: IQuickPick<IAnythingQuickPickItem, { useSeparators: true }> | undefined = undefined;
+
+			editorViewState: PickerEditorState;
+
+			scorerCache: FuzzyScorerCache = Object.create(null);
+			fileQueryCache: FileQueryCacheState | undefined = undefined;
+
+			lastOriginalFilter: string | undefined = undefined;
+			lastFilter: string | undefined = undefined;
+			lastRange: IRange | undefined = undefined;
+
+			lastGlobalPicks: PicksWithActive<IAnythingQuickPickItem> | undefined = undefined;
+
+			isQuickNavigating: boolean | undefined = undefined;
+
+			constructor(
+				private readonly provider: AnythingQuickAccessProvider,
+				private readonly instantiationService: IInstantiationService
+			) {
+				super();
+
+				this.editorViewState = this._register(this.instantiationService.createInstance(PickerEditorState));
+			}
+
+			set(picker: IQuickPick<IAnythingQuickPickItem, { useSeparators: true }>): void {
+
+				// Picker for this run
+				this.picker = picker;
+				Event.once(picker.onDispose)(() => {
+					if (picker === this.picker) {
+						this.picker = undefined; // clear the picker when disposed to not keep it in memory for too long
+					}
+				});
+
+				// Caches
+				const isQuickNavigating = !!picker.quickNavigate;
+				if (!isQuickNavigating) {
+					this.fileQueryCache = this.provider.createFileQueryCache();
+					this.scorerCache = Object.create(null);
+				}
+
+				// Other
+				this.isQuickNavigating = isQuickNavigating;
+				this.lastOriginalFilter = undefined;
+				this.lastFilter = undefined;
+				this.lastRange = undefined;
+				this.lastGlobalPicks = undefined;
+				this.editorViewState.reset();
+			}
+		}(this, this.instantiationService));
+
+		this.fileQueryBuilder = this.instantiationService.createInstance(QueryBuilder);
+
+		this.workspaceSymbolsQuickAccess = this._register(this.instantiationService.createInstance(SymbolsQuickAccessProvider));
+
+		this.editorSymbolsQuickAccess = this.instantiationService.createInstance(GotoSymbolQuickAccessProvider);
 	}
 
 	private get configuration() {
@@ -519,7 +529,7 @@ export class AnythingQuickAccessProvider extends PickerQuickAccessProvider<IAnyt
 
 	private readonly fileQueryDelayer = this._register(new ThrottledDelayer<URI[]>(AnythingQuickAccessProvider.TYPING_SEARCH_DELAY));
 
-	private readonly fileQueryBuilder = this.instantiationService.createInstance(QueryBuilder);
+	private readonly fileQueryBuilder: QueryBuilder;
 
 	private createFileQueryCache(): FileQueryCacheState {
 		return new FileQueryCacheState(
@@ -825,7 +835,7 @@ export class AnythingQuickAccessProvider extends PickerQuickAccessProvider<IAnyt
 
 	//#region Workspace Symbols (if enabled)
 
-	private workspaceSymbolsQuickAccess = this._register(this.instantiationService.createInstance(SymbolsQuickAccessProvider));
+	private workspaceSymbolsQuickAccess: SymbolsQuickAccessProvider;
 
 	private async getWorkspaceSymbolPicks(query: IPreparedQuery, includeSymbols: boolean, token: CancellationToken): Promise<Array<IAnythingQuickPickItem>> {
 		if (
@@ -850,7 +860,7 @@ export class AnythingQuickAccessProvider extends PickerQuickAccessProvider<IAnyt
 
 	//#region Editor Symbols (if narrowing down into a global pick via `@`)
 
-	private readonly editorSymbolsQuickAccess = this.instantiationService.createInstance(GotoSymbolQuickAccessProvider);
+	private readonly editorSymbolsQuickAccess: GotoSymbolQuickAccessProvider;
 
 	private getEditorSymbolPicks(query: IPreparedQuery, disposables: DisposableStore, token: CancellationToken): Promise<Picks<IAnythingQuickPickItem>> | null {
 		const filterSegments = query.original.split(GotoSymbolQuickAccessProvider.PREFIX);

--- a/src/vs/workbench/contrib/search/common/cacheState.ts
+++ b/src/vs/workbench/contrib/search/common/cacheState.ts
@@ -38,7 +38,7 @@ export class FileQueryCacheState {
 		return isUpdating || !this.previousCacheState ? isUpdating : this.previousCacheState.isUpdating;
 	}
 
-	private readonly query = this.cacheQuery(this._cacheKey);
+	private readonly query: IFileQuery;
 
 	private loadingPhase = LoadingPhase.Created;
 	private loadPromise: Promise<void> | undefined;
@@ -49,6 +49,8 @@ export class FileQueryCacheState {
 		private disposeFn: (cacheKey: string) => Promise<void>,
 		private previousCacheState: FileQueryCacheState | undefined
 	) {
+		this.query = this.cacheQuery(this._cacheKey);
+
 		if (this.previousCacheState) {
 			const current = Object.assign({}, this.query, { cacheKey: null });
 			const previous = Object.assign({}, this.previousCacheState.query, { cacheKey: null });

--- a/src/vs/workbench/contrib/speech/browser/speechService.ts
+++ b/src/vs/workbench/contrib/speech/browser/speechService.ts
@@ -7,7 +7,7 @@ import { localize } from '../../../../nls.js';
 import { CancellationToken, CancellationTokenSource } from '../../../../base/common/cancellation.js';
 import { Emitter, Event } from '../../../../base/common/event.js';
 import { Disposable, DisposableStore, IDisposable, toDisposable } from '../../../../base/common/lifecycle.js';
-import { IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
+import { IContextKey, IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
 import { IHostService } from '../../../services/host/browser/host.js';
 import { DeferredPromise } from '../../../../base/common/async.js';
@@ -58,7 +58,7 @@ export class SpeechService extends Disposable implements ISpeechService {
 	private readonly providers = new Map<string, ISpeechProvider>();
 	private readonly providerDescriptors = new Map<string, ISpeechProviderDescriptor>();
 
-	private readonly hasSpeechProviderContext = HasSpeechProvider.bindTo(this.contextKeyService);
+	private readonly hasSpeechProviderContext: IContextKey<boolean>;
 
 	constructor(
 		@ILogService private readonly logService: ILogService,
@@ -69,6 +69,10 @@ export class SpeechService extends Disposable implements ISpeechService {
 		@IExtensionService private readonly extensionService: IExtensionService
 	) {
 		super();
+
+		this.hasSpeechProviderContext = HasSpeechProvider.bindTo(this.contextKeyService);
+		this.speechToTextInProgress = SpeechToTextInProgress.bindTo(this.contextKeyService);
+		this.textToSpeechInProgress = TextToSpeechInProgress.bindTo(this.contextKeyService);
 
 		this.handleAndRegisterSpeechExtensions();
 	}
@@ -136,7 +140,7 @@ export class SpeechService extends Disposable implements ISpeechService {
 	private activeSpeechToTextSessions = 0;
 	get hasActiveSpeechToTextSession() { return this.activeSpeechToTextSessions > 0; }
 
-	private readonly speechToTextInProgress = SpeechToTextInProgress.bindTo(this.contextKeyService);
+	private readonly speechToTextInProgress: IContextKey<boolean>;
 
 	async createSpeechToTextSession(token: CancellationToken, context: string = 'speech'): Promise<ISpeechToTextSession> {
 		const provider = await this.getProvider();
@@ -249,7 +253,7 @@ export class SpeechService extends Disposable implements ISpeechService {
 	private activeTextToSpeechSessions = 0;
 	get hasActiveTextToSpeechSession() { return this.activeTextToSpeechSessions > 0; }
 
-	private readonly textToSpeechInProgress = TextToSpeechInProgress.bindTo(this.contextKeyService);
+	private readonly textToSpeechInProgress: IContextKey<boolean>;
 
 	async createTextToSpeechSession(token: CancellationToken, context: string = 'speech'): Promise<ITextToSpeechSession> {
 		const provider = await this.getProvider();

--- a/src/vs/workbench/contrib/terminalContrib/suggest/browser/pwshCompletionProviderAddon.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/browser/pwshCompletionProviderAddon.ts
@@ -52,10 +52,10 @@ const enum RequestCompletionsSequence {
 }
 
 export class PwshCompletionProviderAddon extends Disposable implements ITerminalAddon, ITerminalCompletionProvider {
+	static readonly ID = 'pwsh-shell-integration';
 	id: string = PwshCompletionProviderAddon.ID;
 	triggerCharacters?: string[] | undefined;
 	isBuiltin?: boolean = true;
-	static readonly ID = 'pwsh-shell-integration';
 	static cachedPwshCommands: Set<ITerminalCompletion>;
 	readonly shellTypes = [GeneralShellType.PowerShell];
 	private _lastUserDataTimestamp: number = 0;

--- a/src/vs/workbench/contrib/terminalContrib/typeAhead/browser/terminalTypeAheadAddon.ts
+++ b/src/vs/workbench/contrib/terminalContrib/typeAhead/browser/terminalTypeAheadAddon.ts
@@ -1290,8 +1290,8 @@ export const enum CharPredictState {
 
 export class TypeAheadAddon extends Disposable implements ITerminalAddon {
 	private _typeaheadStyle?: TypeAheadStyle;
-	private _typeaheadThreshold = this._configurationService.getValue<ITerminalTypeAheadConfiguration>(TERMINAL_CONFIG_SECTION).localEchoLatencyThreshold;
-	private _excludeProgramRe = compileExcludeRegexp(this._configurationService.getValue<ITerminalTypeAheadConfiguration>(TERMINAL_CONFIG_SECTION).localEchoExcludePrograms);
+	private _typeaheadThreshold: number;
+	private _excludeProgramRe: RegExp;
 	protected _lastRow?: { y: number; startingX: number; endingX: number; charState: CharPredictState };
 	protected _timeline?: PredictionTimeline;
 	private _terminalTitle = '';
@@ -1308,6 +1308,10 @@ export class TypeAheadAddon extends Disposable implements ITerminalAddon {
 		@ITelemetryService private readonly _telemetryService: ITelemetryService,
 	) {
 		super();
+
+		this._typeaheadThreshold = this._configurationService.getValue<ITerminalTypeAheadConfiguration>(TERMINAL_CONFIG_SECTION).localEchoLatencyThreshold;
+		this._excludeProgramRe = compileExcludeRegexp(this._configurationService.getValue<ITerminalTypeAheadConfiguration>(TERMINAL_CONFIG_SECTION).localEchoExcludePrograms);
+
 		this._register(toDisposable(() => this._clearPredictionDebounce?.dispose()));
 	}
 

--- a/src/vs/workbench/contrib/testing/browser/explorerProjections/index.ts
+++ b/src/vs/workbench/contrib/testing/browser/explorerProjections/index.ts
@@ -74,7 +74,7 @@ export abstract class TestItemTreeElement {
 	/**
 	 * Depth of the element in the tree.
 	 */
-	public depth: number = this.parent ? this.parent.depth + 1 : 0;
+	public depth: number;
 
 	/**
 	 * Whether the node's test result is 'retired' -- from an outdated test run.
@@ -104,7 +104,9 @@ export abstract class TestItemTreeElement {
 		 * in a 'flat' projection.
 		 */
 		public readonly parent: TestItemTreeElement | null = null,
-	) { }
+	) {
+		this.depth = this.parent ? this.parent.depth + 1 : 0;
+	}
 
 	public toJSON() {
 		if (this.depth === 0) {

--- a/src/vs/workbench/contrib/testing/browser/testResultsView/testResultsOutput.ts
+++ b/src/vs/workbench/contrib/testing/browser/testResultsView/testResultsOutput.ts
@@ -41,17 +41,21 @@ import { ITaskRawOutput, ITestResult, ITestRunTaskResults, LiveTestResult, TestR
 import { ITestMessage, TestMessageType, getMarkId } from '../../common/testTypes.js';
 import { ScrollEvent } from '../../../../../base/common/scrollable.js';
 import { CALL_STACK_WIDGET_HEADER_HEIGHT } from '../../../debug/browser/callStackWidget.js';
+import { ITextModel } from '../../../../../editor/common/model.js';
 
 
 class SimpleDiffEditorModel extends EditorModel {
-	public readonly original = this._original.object.textEditorModel;
-	public readonly modified = this._modified.object.textEditorModel;
+	public readonly original: ITextModel;
+	public readonly modified: ITextModel;
 
 	constructor(
 		private readonly _original: IReference<IResolvedTextEditorModel>,
 		private readonly _modified: IReference<IResolvedTextEditorModel>,
 	) {
 		super();
+
+		this.original = this._original.object.textEditorModel;
+		this.modified = this._modified.object.textEditorModel;
 	}
 
 	public override dispose() {

--- a/src/vs/workbench/contrib/testing/browser/testResultsView/testResultsTree.ts
+++ b/src/vs/workbench/contrib/testing/browser/testResultsView/testResultsTree.ts
@@ -79,9 +79,9 @@ class TestResultElement implements ITreeElement {
 	public readonly changeEmitter = new Emitter<void>();
 	public readonly onDidChange = this.changeEmitter.event;
 	public readonly type = 'result';
-	public readonly context = this.value.id;
-	public readonly id = this.value.id;
-	public readonly label = this.value.name;
+	public readonly context: string;
+	public readonly id: string;
+	public readonly label: string;
 
 	public get icon() {
 		return icons.testingStatesToIcons.get(
@@ -91,7 +91,11 @@ class TestResultElement implements ITreeElement {
 		);
 	}
 
-	constructor(public readonly value: ITestResult) { }
+	constructor(public readonly value: ITestResult) {
+		this.context = this.value.id;
+		this.id = this.value.id;
+		this.label = this.value.name;
+	}
 }
 
 const openCoverageLabel = localize('openTestCoverage', 'View Test Coverage');
@@ -100,7 +104,7 @@ const closeCoverageLabel = localize('closeTestCoverage', 'Close Test Coverage');
 class CoverageElement implements ITreeElement {
 	public readonly type = 'coverage';
 	public readonly context: undefined;
-	public readonly id = `coverage-${this.results.id}/${this.task.id}`;
+	public readonly id: string;
 	public readonly onDidChange: Event<void>;
 
 	public get label() {
@@ -120,6 +124,7 @@ class CoverageElement implements ITreeElement {
 		public readonly task: ITestRunTaskResults,
 		private readonly coverageService: ITestCoverageService,
 	) {
+		this.id = `coverage-${this.results.id}/${this.task.id}`;
 		this.onDidChange = Event.fromObservableLight(coverageService.selected);
 	}
 }
@@ -127,11 +132,12 @@ class CoverageElement implements ITreeElement {
 class OlderResultsElement implements ITreeElement {
 	public readonly type = 'older';
 	public readonly context: undefined;
-	public readonly id = `older-${this.n}`;
+	public readonly id: string;
 	public readonly onDidChange = Event.None;
 	public readonly label: string;
 
 	constructor(private readonly n: number) {
+		this.id = `older-${this.n}`;
 		this.label = localize('nOlderResults', '{0} older results', n);
 
 	}
@@ -139,11 +145,8 @@ class OlderResultsElement implements ITreeElement {
 
 class TestCaseElement implements ITreeElement {
 	public readonly type = 'test';
-	public readonly context: ITestItemContext = {
-		$mid: MarshalledId.TestItemContext,
-		tests: [InternalTestItem.serialize(this.test)],
-	};
-	public readonly id = `${this.results.id}/${this.test.item.extId}`;
+	public readonly context: ITestItemContext;
+	public readonly id: string;
 	public readonly description?: string;
 
 	public get onDidChange() {
@@ -179,7 +182,13 @@ class TestCaseElement implements ITreeElement {
 		public readonly results: ITestResult,
 		public readonly test: TestResultItem,
 		public readonly taskIndex: number,
-	) { }
+	) {
+		this.context = {
+			$mid: MarshalledId.TestItemContext,
+			tests: [InternalTestItem.serialize(this.test)],
+		};
+		this.id = `${this.results.id}/${this.test.item.extId}`;
+	}
 }
 
 class TaskElement implements ITreeElement {

--- a/src/vs/workbench/contrib/testing/browser/testingExplorerFilter.ts
+++ b/src/vs/workbench/contrib/testing/browser/testingExplorerFilter.ts
@@ -37,11 +37,7 @@ export class TestingExplorerFilter extends BaseActionViewItem {
 	private wrapper!: HTMLDivElement;
 	private readonly focusEmitter = this._register(new Emitter<void>());
 	public readonly onDidFocus = this.focusEmitter.event;
-	private readonly history: StoredValue<{ values: string[]; lastValue: string } | string[]> = this._register(this.instantiationService.createInstance(StoredValue, {
-		key: 'testing.filterHistory2',
-		scope: StorageScope.WORKSPACE,
-		target: StorageTarget.MACHINE
-	}));
+	private readonly history: StoredValue<{ values: string[]; lastValue: string } | string[]>;
 
 	private readonly filtersAction = new Action('markersFiltersAction', localize('testing.filters.menu', "More Filters..."), 'testing-filter-button ' + ThemeIcon.asClassName(testingFilterIcon));
 
@@ -53,6 +49,13 @@ export class TestingExplorerFilter extends BaseActionViewItem {
 		@ITestService private readonly testService: ITestService,
 	) {
 		super(null, action, options);
+
+		this.history = this._register(this.instantiationService.createInstance(StoredValue, {
+			key: 'testing.filterHistory2',
+			scope: StorageScope.WORKSPACE,
+			target: StorageTarget.MACHINE
+		}));
+
 		this.updateFilterActiveState();
 		this._register(testService.excluded.onTestExclusionsChanged(this.updateFilterActiveState, this));
 	}

--- a/src/vs/workbench/contrib/testing/browser/testingExplorerView.ts
+++ b/src/vs/workbench/contrib/testing/browser/testingExplorerView.ts
@@ -36,7 +36,7 @@ import { MenuEntryActionViewItem, createActionViewItem, getActionBarActions, get
 import { IMenuService, MenuId, MenuItemAction } from '../../../../platform/actions/common/actions.js';
 import { ICommandService } from '../../../../platform/commands/common/commands.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
-import { IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
+import { IContextKey, IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
 import { IContextMenuService } from '../../../../platform/contextview/browser/contextView.js';
 import { IHoverService } from '../../../../platform/hover/browser/hover.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
@@ -703,15 +703,11 @@ class TestingExplorerViewModel extends Disposable {
 	public readonly projection = this._register(new MutableDisposable<ITestTreeProjection>());
 
 	private readonly revealTimeout = new MutableDisposable();
-	private readonly _viewMode = TestingContextKeys.viewMode.bindTo(this.contextKeyService);
-	private readonly _viewSorting = TestingContextKeys.viewSorting.bindTo(this.contextKeyService);
+	private readonly _viewMode: IContextKey<TestExplorerViewMode>;
+	private readonly _viewSorting: IContextKey<TestExplorerViewSorting>;
 	private readonly welcomeVisibilityEmitter = new Emitter<WelcomeExperience>();
 	private readonly actionRunner = this._register(new TestExplorerActionRunner(() => this.tree.getSelection().filter(isDefined)));
-	private readonly lastViewState = this._register(new StoredValue<ISerializedTestTreeCollapseState>({
-		key: 'testing.treeState',
-		scope: StorageScope.WORKSPACE,
-		target: StorageTarget.MACHINE,
-	}, this.storageService));
+	private readonly lastViewState: StoredValue<ISerializedTestTreeCollapseState>;
 	private readonly noTestForDocumentWidget: NoTestsForDocumentWidget;
 
 	/**
@@ -780,6 +776,16 @@ class TestingExplorerViewModel extends Disposable {
 		@ICommandService commandService: ICommandService,
 	) {
 		super();
+
+		this._viewMode = TestingContextKeys.viewMode.bindTo(this.contextKeyService);
+
+		this._viewSorting = TestingContextKeys.viewSorting.bindTo(this.contextKeyService);
+
+		this.lastViewState = this._register(new StoredValue<ISerializedTestTreeCollapseState>({
+			key: 'testing.treeState',
+			scope: StorageScope.WORKSPACE,
+			target: StorageTarget.MACHINE,
+		}, this.storageService));
 
 		this.hasPendingReveal = !!filterState.reveal.get();
 		this.noTestForDocumentWidget = this._register(instantiationService.createInstance(NoTestsForDocumentWidget, listContainer));

--- a/src/vs/workbench/contrib/testing/browser/testingOutputPeek.ts
+++ b/src/vs/workbench/contrib/testing/browser/testingOutputPeek.ts
@@ -117,11 +117,7 @@ export class TestingPeekOpener extends Disposable implements ITestingPeekOpener 
 	private lastUri?: TestUriWithDocument;
 
 	/** @inheritdoc */
-	public readonly historyVisible = this._register(MutableObservableValue.stored(new StoredValue<boolean>({
-		key: 'testHistoryVisibleInPeek',
-		scope: StorageScope.PROFILE,
-		target: StorageTarget.USER,
-	}, this.storageService), false));
+	public readonly historyVisible: MutableObservableValue<boolean>;
 
 	constructor(
 		@IConfigurationService private readonly configuration: IConfigurationService,
@@ -135,6 +131,13 @@ export class TestingPeekOpener extends Disposable implements ITestingPeekOpener 
 		@INotificationService private readonly notificationService: INotificationService,
 	) {
 		super();
+
+		this.historyVisible = this._register(MutableObservableValue.stored(new StoredValue<boolean>({
+			key: 'testHistoryVisibleInPeek',
+			scope: StorageScope.PROFILE,
+			target: StorageTarget.USER,
+		}, this.storageService), false));
+
 		this._register(testResults.onTestChanged(this.openPeekOnFailure, this));
 	}
 

--- a/src/vs/workbench/contrib/testing/common/testExclusions.ts
+++ b/src/vs/workbench/contrib/testing/common/testExclusions.ts
@@ -12,26 +12,31 @@ import { StoredValue } from './storedValue.js';
 import { InternalTestItem } from './testTypes.js';
 
 export class TestExclusions extends Disposable {
-	private readonly excluded = this._register(
-		MutableObservableValue.stored(new StoredValue<ReadonlySet<string>>({
-			key: 'excludedTestItems',
-			scope: StorageScope.WORKSPACE,
-			target: StorageTarget.MACHINE,
-			serialization: {
-				deserialize: v => new Set(JSON.parse(v)),
-				serialize: v => JSON.stringify([...v])
-			},
-		}, this.storageService), new Set())
-	);
+	private readonly excluded: MutableObservableValue<ReadonlySet<string>>;
 
 	constructor(@IStorageService private readonly storageService: IStorageService) {
 		super();
+
+		this.excluded = this._register(
+			MutableObservableValue.stored(new StoredValue<ReadonlySet<string>>({
+				key: 'excludedTestItems',
+				scope: StorageScope.WORKSPACE,
+				target: StorageTarget.MACHINE,
+				serialization: {
+					deserialize: v => new Set(JSON.parse(v)),
+					serialize: v => JSON.stringify([...v])
+				},
+			}, this.storageService), new Set())
+		);
+
+		this.onTestExclusionsChanged = this.excluded.onDidChange;
+
 	}
 
 	/**
 	 * Event that fires when the excluded tests change.
 	 */
-	public readonly onTestExclusionsChanged: Event<unknown> = this.excluded.onDidChange;
+	public readonly onTestExclusionsChanged: Event<unknown>;
 
 	/**
 	 * Gets whether there's any excluded tests.

--- a/src/vs/workbench/contrib/testing/common/testExplorerFilterState.ts
+++ b/src/vs/workbench/contrib/testing/common/testExplorerFilterState.ts
@@ -99,11 +99,7 @@ export class TestExplorerFilterState extends Disposable implements ITestExplorer
 	public readonly text = this._register(new MutableObservableValue(''));
 
 	/** @inheritdoc */
-	public readonly fuzzy = this._register(MutableObservableValue.stored(new StoredValue<boolean>({
-		key: 'testHistoryFuzzy',
-		scope: StorageScope.PROFILE,
-		target: StorageTarget.USER,
-	}, this.storageService), false));
+	public readonly fuzzy: MutableObservableValue<boolean>;
 
 	public readonly reveal: ISettableObservable<string | undefined> = observableValue('TestExplorerFilterState.reveal', undefined);
 
@@ -116,6 +112,12 @@ export class TestExplorerFilterState extends Disposable implements ITestExplorer
 		@IStorageService private readonly storageService: IStorageService,
 	) {
 		super();
+
+		this.fuzzy = this._register(MutableObservableValue.stored(new StoredValue<boolean>({
+			key: 'testHistoryFuzzy',
+			scope: StorageScope.PROFILE,
+			target: StorageTarget.USER,
+		}, this.storageService), false));
 	}
 
 	/** @inheritdoc */

--- a/src/vs/workbench/contrib/testing/common/testResultStorage.ts
+++ b/src/vs/workbench/contrib/testing/common/testResultStorage.ts
@@ -49,11 +49,7 @@ const currentRevision = 1;
 export abstract class BaseTestResultStorage extends Disposable implements ITestResultStorage {
 	declare readonly _serviceBrand: undefined;
 
-	protected readonly stored = this._register(new StoredValue<ReadonlyArray<{ rev: number; id: string; bytes: number }>>({
-		key: 'storedTestResults',
-		scope: StorageScope.WORKSPACE,
-		target: StorageTarget.MACHINE
-	}, this.storageService));
+	protected readonly stored: StoredValue<ReadonlyArray<{ rev: number; id: string; bytes: number }>>;
 
 	constructor(
 		@IUriIdentityService private readonly uriIdentityService: IUriIdentityService,
@@ -61,6 +57,12 @@ export abstract class BaseTestResultStorage extends Disposable implements ITestR
 		@ILogService private readonly logService: ILogService,
 	) {
 		super();
+
+		this.stored = this._register(new StoredValue<ReadonlyArray<{ rev: number; id: string; bytes: number }>>({
+			key: 'storedTestResults',
+			scope: StorageScope.WORKSPACE,
+			target: StorageTarget.MACHINE
+		}, this.storageService));
 	}
 
 	/**

--- a/src/vs/workbench/contrib/testing/common/testServiceImpl.ts
+++ b/src/vs/workbench/contrib/testing/common/testServiceImpl.ts
@@ -72,7 +72,7 @@ export class TestService extends Disposable implements ITestService {
 	/**
 	 * @inheritdoc
 	 */
-	public readonly collection = new MainThreadTestCollection(this.uriIdentityService, this.expandTest.bind(this));
+	public readonly collection: MainThreadTestCollection;
 
 	/**
 	 * @inheritdoc
@@ -82,11 +82,7 @@ export class TestService extends Disposable implements ITestService {
 	/**
 	 * @inheritdoc
 	 */
-	public readonly showInlineOutput = this._register(MutableObservableValue.stored(new StoredValue<boolean>({
-		key: 'inlineTestOutputVisible',
-		scope: StorageScope.WORKSPACE,
-		target: StorageTarget.USER
-	}, this.storage), true));
+	public readonly showInlineOutput: MutableObservableValue<boolean>;
 
 	constructor(
 		@IContextKeyService contextKeyService: IContextKeyService,
@@ -101,7 +97,13 @@ export class TestService extends Disposable implements ITestService {
 		@IWorkspaceTrustRequestService private readonly workspaceTrustRequestService: IWorkspaceTrustRequestService,
 	) {
 		super();
+		this.collection = new MainThreadTestCollection(this.uriIdentityService, this.expandTest.bind(this));
 		this.excluded = instantiationService.createInstance(TestExclusions);
+		this.showInlineOutput = this._register(MutableObservableValue.stored(new StoredValue<boolean>({
+			key: 'inlineTestOutputVisible',
+			scope: StorageScope.WORKSPACE,
+			target: StorageTarget.USER
+		}, this.storage), true));
 		this.isRefreshingTests = TestingContextKeys.isRefreshingTests.bindTo(contextKeyService);
 		this.activeEditorHasTests = TestingContextKeys.activeEditorHasTests.bindTo(contextKeyService);
 

--- a/src/vs/workbench/contrib/testing/test/common/testStubs.ts
+++ b/src/vs/workbench/contrib/testing/test/common/testStubs.ts
@@ -7,7 +7,7 @@ import { URI } from '../../../../../base/common/uri.js';
 import { MainThreadTestCollection } from '../../common/mainThreadTestCollection.js';
 import { ITestItem, TestsDiff } from '../../common/testTypes.js';
 import { TestId } from '../../common/testId.js';
-import { createTestItemChildren, ITestItemApi, ITestItemLike, TestItemCollection, TestItemEventOp } from '../../common/testItemCollection.js';
+import { createTestItemChildren, ITestItemApi, ITestItemChildren, ITestItemLike, TestItemCollection, TestItemEventOp } from '../../common/testItemCollection.js';
 
 export class TestTestItem implements ITestItemLike {
 	private readonly props: ITestItem;
@@ -39,9 +39,9 @@ export class TestTestItem implements ITestItemLike {
 		return this._extId.localId;
 	}
 
-	public api: ITestItemApi<TestTestItem> = { controllerId: this._extId.controllerId };
+	public api: ITestItemApi<TestTestItem>;
 
-	public children = createTestItemChildren(this.api, i => i.api, TestTestItem);
+	public children: ITestItemChildren<TestTestItem>;
 
 	constructor(
 		private readonly _extId: TestId,
@@ -59,6 +59,10 @@ export class TestTestItem implements ITestItemLike {
 			tags: [],
 			uri,
 		};
+
+		this.api = { controllerId: this._extId.controllerId };
+
+		this.children = createTestItemChildren(this.api, i => i.api, TestTestItem);
 	}
 
 	public get<K extends keyof ITestItem>(key: K): ITestItem[K] {

--- a/src/vs/workbench/contrib/welcomeDialog/browser/welcomeWidget.ts
+++ b/src/vs/workbench/contrib/welcomeDialog/browser/welcomeWidget.ts
@@ -34,7 +34,7 @@ export class WelcomeWidget extends Disposable implements IOverlayWidget {
 	private readonly _rootDomNode: HTMLElement;
 	private readonly element: HTMLElement;
 	private readonly messageContainer: HTMLElement;
-	private readonly markdownRenderer = this.instantiationService.createInstance(MarkdownRenderer, {});
+	private readonly markdownRenderer: MarkdownRenderer;
 
 	constructor(
 		private readonly _editor: ICodeEditor,
@@ -44,6 +44,9 @@ export class WelcomeWidget extends Disposable implements IOverlayWidget {
 		private readonly openerService: IOpenerService
 	) {
 		super();
+
+		this.markdownRenderer = this.instantiationService.createInstance(MarkdownRenderer, {});
+
 		this._rootDomNode = document.createElement('div');
 		this._rootDomNode.className = 'welcome-widget';
 

--- a/src/vs/workbench/services/authentication/browser/authenticationExtensionsService.ts
+++ b/src/vs/workbench/services/authentication/browser/authenticationExtensionsService.ts
@@ -42,13 +42,8 @@ export class AuthenticationExtensionsService extends Disposable implements IAuth
 	private _onDidAccountPreferenceChange: Emitter<{ providerId: string; extensionIds: string[] }> = this._register(new Emitter<{ providerId: string; extensionIds: string[] }>());
 	readonly onDidChangeAccountPreference = this._onDidAccountPreferenceChange.event;
 
-	private _inheritAuthAccountPreferenceParentToChildren: Record<string, string[]> = this._productService.inheritAuthAccountPreference || {};
-	private _inheritAuthAccountPreferenceChildToParent = Object.entries(this._inheritAuthAccountPreferenceParentToChildren).reduce<{ [extensionId: string]: string }>((acc, [parent, children]) => {
-		children.forEach((child: string) => {
-			acc[child] = parent;
-		});
-		return acc;
-	}, {});
+	private _inheritAuthAccountPreferenceParentToChildren: Record<string, string[]>;
+	private _inheritAuthAccountPreferenceChildToParent: { [extensionId: string]: string };
 
 	constructor(
 		@IActivityService private readonly activityService: IActivityService,
@@ -61,6 +56,16 @@ export class AuthenticationExtensionsService extends Disposable implements IAuth
 		@IAuthenticationAccessService private readonly _authenticationAccessService: IAuthenticationAccessService
 	) {
 		super();
+
+		this._inheritAuthAccountPreferenceParentToChildren = this._productService.inheritAuthAccountPreference || {};
+
+		this._inheritAuthAccountPreferenceChildToParent = Object.entries(this._inheritAuthAccountPreferenceParentToChildren).reduce<{ [extensionId: string]: string }>((acc, [parent, children]) => {
+			children.forEach((child: string) => {
+				acc[child] = parent;
+			});
+			return acc;
+		}, {});
+
 		this.registerListeners();
 	}
 

--- a/src/vs/workbench/services/extensionManagement/common/webExtensionManagementService.ts
+++ b/src/vs/workbench/services/extensionManagement/common/webExtensionManagementService.ts
@@ -250,7 +250,7 @@ class InstallExtensionTask extends AbstractExtensionTask<ILocalExtension> implem
 	readonly identifier: IExtensionIdentifier;
 	readonly source: URI | IGalleryExtension;
 
-	private _profileLocation = this.options.profileLocation;
+	private _profileLocation: URI;
 	get profileLocation() { return this._profileLocation; }
 
 	private _operation = InstallOperation.Install;
@@ -266,6 +266,7 @@ class InstallExtensionTask extends AbstractExtensionTask<ILocalExtension> implem
 		super();
 		this.identifier = URI.isUri(extension) ? { id: getGalleryExtensionId(manifest.publisher, manifest.name) } : extension.identifier;
 		this.source = extension;
+		this._profileLocation = this.options.profileLocation;
 	}
 
 	protected async doRun(token: CancellationToken): Promise<ILocalExtension> {

--- a/src/vs/workbench/services/files/electron-sandbox/diskFileSystemProvider.ts
+++ b/src/vs/workbench/services/files/electron-sandbox/diskFileSystemProvider.ts
@@ -32,7 +32,7 @@ export class DiskFileSystemProvider extends AbstractDiskFileSystemProvider imple
 	IFileSystemProviderWithFileAtomicReadCapability,
 	IFileSystemProviderWithFileCloneCapability {
 
-	private readonly provider = this._register(new DiskFileSystemProviderClient(this.mainProcessService.getChannel(LOCAL_FILE_SYSTEM_CHANNEL_NAME), { pathCaseSensitive: isLinux, trash: true }));
+	private readonly provider: DiskFileSystemProviderClient;
 
 	constructor(
 		private readonly mainProcessService: IMainProcessService,
@@ -41,6 +41,8 @@ export class DiskFileSystemProvider extends AbstractDiskFileSystemProvider imple
 		private readonly loggerService: ILoggerService
 	) {
 		super(logService, { watcher: { forceUniversal: true /* send all requests to universal watcher process */ } });
+
+		this.provider = this._register(new DiskFileSystemProviderClient(this.mainProcessService.getChannel(LOCAL_FILE_SYSTEM_CHANNEL_NAME), { pathCaseSensitive: isLinux, trash: true }));
 
 		this.registerListeners();
 	}

--- a/src/vs/workbench/services/filesConfiguration/common/filesConfigurationService.ts
+++ b/src/vs/workbench/services/filesConfiguration/common/filesConfigurationService.ts
@@ -8,7 +8,7 @@ import { createDecorator } from '../../../../platform/instantiation/common/insta
 import { InstantiationType, registerSingleton } from '../../../../platform/instantiation/common/extensions.js';
 import { Event, Emitter } from '../../../../base/common/event.js';
 import { Disposable, IDisposable, toDisposable } from '../../../../base/common/lifecycle.js';
-import { RawContextKey, IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
+import { RawContextKey, IContextKeyService, IContextKey } from '../../../../platform/contextkey/common/contextkey.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { IFilesConfiguration, AutoSaveConfiguration, HotExitConfiguration, FILES_READONLY_INCLUDE_CONFIG, FILES_READONLY_EXCLUDE_CONFIG, IFileStatWithMetadata, IFileService, IBaseFileStat, hasReadonlyCapability, IFilesConfigurationNode } from '../../../../platform/files/common/files.js';
 import { equals } from '../../../../base/common/objects.js';
@@ -149,7 +149,7 @@ export class FilesConfigurationService extends Disposable implements IFilesConfi
 	private readonly autoSaveConfigurationCache = new LRUCache<URI, ICachedAutoSaveConfiguration>(1000);
 	private readonly autoSaveDisabledOverrides = new ResourceMap<number /* counter */>();
 
-	private readonly autoSaveAfterShortDelayContext = AutoSaveAfterShortDelayContext.bindTo(this.contextKeyService);
+	private readonly autoSaveAfterShortDelayContext: IContextKey<boolean>;
 
 	private readonly readonlyIncludeMatcher = this._register(new GlobalIdleValue(() => this.createReadonlyMatcher(FILES_READONLY_INCLUDE_CONFIG)));
 	private readonly readonlyExcludeMatcher = this._register(new GlobalIdleValue(() => this.createReadonlyMatcher(FILES_READONLY_EXCLUDE_CONFIG)));
@@ -174,6 +174,8 @@ export class FilesConfigurationService extends Disposable implements IFilesConfi
 		this.currentGlobalAutoSaveConfiguration = this.computeAutoSaveConfiguration(undefined, configuration.files);
 		this.currentFilesAssociationConfiguration = configuration?.files?.associations;
 		this.currentHotExitConfiguration = configuration?.files?.hotExit || HotExitConfiguration.ON_EXIT;
+
+		this.autoSaveAfterShortDelayContext = AutoSaveAfterShortDelayContext.bindTo(this.contextKeyService);
 
 		this.onFilesConfigurationChange(configuration, false);
 

--- a/src/vs/workbench/services/history/browser/historyService.ts
+++ b/src/vs/workbench/services/history/browser/historyService.ts
@@ -21,7 +21,7 @@ import { getExcludes, ISearchConfiguration, SEARCH_EXCLUDE_CONFIG } from '../../
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { EditorServiceImpl } from '../../../browser/parts/editor/editor.js';
 import { IWorkbenchLayoutService } from '../../layout/browser/layoutService.js';
-import { IContextKeyService, RawContextKey } from '../../../../platform/contextkey/common/contextkey.js';
+import { IContextKey, IContextKeyService, RawContextKey } from '../../../../platform/contextkey/common/contextkey.js';
 import { coalesce, remove } from '../../../../base/common/arrays.js';
 import { InstantiationType, registerSingleton } from '../../../../platform/instantiation/common/extensions.js';
 import { addDisposableListener, EventType, EventHelper, WindowIdleValue } from '../../../../base/browser/dom.js';
@@ -60,7 +60,7 @@ export class HistoryService extends Disposable implements IHistoryService {
 	private readonly activeEditorListeners = this._register(new DisposableStore());
 	private lastActiveEditor: IEditorIdentifier | undefined = undefined;
 
-	private readonly editorHelper = this.instantiationService.createInstance(EditorHelper);
+	private readonly editorHelper: EditorHelper;
 
 	constructor(
 		@IEditorService private readonly editorService: EditorServiceImpl,
@@ -76,6 +76,21 @@ export class HistoryService extends Disposable implements IHistoryService {
 		@ILogService private readonly logService: ILogService
 	) {
 		super();
+
+		this.editorHelper = this.instantiationService.createInstance(EditorHelper);
+
+		this.canNavigateBackContextKey = (new RawContextKey<boolean>('canNavigateBack', false, localize('canNavigateBack', "Whether it is possible to navigate back in editor history"))).bindTo(this.contextKeyService);
+		this.canNavigateForwardContextKey = (new RawContextKey<boolean>('canNavigateForward', false, localize('canNavigateForward', "Whether it is possible to navigate forward in editor history"))).bindTo(this.contextKeyService);
+
+		this.canNavigateBackInNavigationsContextKey = (new RawContextKey<boolean>('canNavigateBackInNavigationLocations', false, localize('canNavigateBackInNavigationLocations', "Whether it is possible to navigate back in editor navigation locations history"))).bindTo(this.contextKeyService);
+		this.canNavigateForwardInNavigationsContextKey = (new RawContextKey<boolean>('canNavigateForwardInNavigationLocations', false, localize('canNavigateForwardInNavigationLocations', "Whether it is possible to navigate forward in editor navigation locations history"))).bindTo(this.contextKeyService);
+		this.canNavigateToLastNavigationLocationContextKey = (new RawContextKey<boolean>('canNavigateToLastNavigationLocation', false, localize('canNavigateToLastNavigationLocation', "Whether it is possible to navigate to the last editor navigation location"))).bindTo(this.contextKeyService);
+
+		this.canNavigateBackInEditsContextKey = (new RawContextKey<boolean>('canNavigateBackInEditLocations', false, localize('canNavigateBackInEditLocations', "Whether it is possible to navigate back in editor edit locations history"))).bindTo(this.contextKeyService);
+		this.canNavigateForwardInEditsContextKey = (new RawContextKey<boolean>('canNavigateForwardInEditLocations', false, localize('canNavigateForwardInEditLocations', "Whether it is possible to navigate forward in editor edit locations history"))).bindTo(this.contextKeyService);
+		this.canNavigateToLastEditLocationContextKey = (new RawContextKey<boolean>('canNavigateToLastEditLocation', false, localize('canNavigateToLastEditLocation', "Whether it is possible to navigate to the last editor edit location"))).bindTo(this.contextKeyService);
+
+		this.canReopenClosedEditorContextKey = (new RawContextKey<boolean>('canReopenClosedEditor', false, localize('canReopenClosedEditor', "Whether it is possible to reopen the last closed editor"))).bindTo(this.contextKeyService);
 
 		this.registerListeners();
 
@@ -302,18 +317,18 @@ export class HistoryService extends Disposable implements IHistoryService {
 
 	//#region History Context Keys
 
-	private readonly canNavigateBackContextKey = (new RawContextKey<boolean>('canNavigateBack', false, localize('canNavigateBack', "Whether it is possible to navigate back in editor history"))).bindTo(this.contextKeyService);
-	private readonly canNavigateForwardContextKey = (new RawContextKey<boolean>('canNavigateForward', false, localize('canNavigateForward', "Whether it is possible to navigate forward in editor history"))).bindTo(this.contextKeyService);
+	private readonly canNavigateBackContextKey: IContextKey<boolean>;
+	private readonly canNavigateForwardContextKey: IContextKey<boolean>;
 
-	private readonly canNavigateBackInNavigationsContextKey = (new RawContextKey<boolean>('canNavigateBackInNavigationLocations', false, localize('canNavigateBackInNavigationLocations', "Whether it is possible to navigate back in editor navigation locations history"))).bindTo(this.contextKeyService);
-	private readonly canNavigateForwardInNavigationsContextKey = (new RawContextKey<boolean>('canNavigateForwardInNavigationLocations', false, localize('canNavigateForwardInNavigationLocations', "Whether it is possible to navigate forward in editor navigation locations history"))).bindTo(this.contextKeyService);
-	private readonly canNavigateToLastNavigationLocationContextKey = (new RawContextKey<boolean>('canNavigateToLastNavigationLocation', false, localize('canNavigateToLastNavigationLocation', "Whether it is possible to navigate to the last editor navigation location"))).bindTo(this.contextKeyService);
+	private readonly canNavigateBackInNavigationsContextKey: IContextKey<boolean>;
+	private readonly canNavigateForwardInNavigationsContextKey: IContextKey<boolean>;
+	private readonly canNavigateToLastNavigationLocationContextKey: IContextKey<boolean>;
 
-	private readonly canNavigateBackInEditsContextKey = (new RawContextKey<boolean>('canNavigateBackInEditLocations', false, localize('canNavigateBackInEditLocations', "Whether it is possible to navigate back in editor edit locations history"))).bindTo(this.contextKeyService);
-	private readonly canNavigateForwardInEditsContextKey = (new RawContextKey<boolean>('canNavigateForwardInEditLocations', false, localize('canNavigateForwardInEditLocations', "Whether it is possible to navigate forward in editor edit locations history"))).bindTo(this.contextKeyService);
-	private readonly canNavigateToLastEditLocationContextKey = (new RawContextKey<boolean>('canNavigateToLastEditLocation', false, localize('canNavigateToLastEditLocation', "Whether it is possible to navigate to the last editor edit location"))).bindTo(this.contextKeyService);
+	private readonly canNavigateBackInEditsContextKey: IContextKey<boolean>;
+	private readonly canNavigateForwardInEditsContextKey: IContextKey<boolean>;
+	private readonly canNavigateToLastEditLocationContextKey: IContextKey<boolean>;
 
-	private readonly canReopenClosedEditorContextKey = (new RawContextKey<boolean>('canReopenClosedEditor', false, localize('canReopenClosedEditor', "Whether it is possible to reopen the last closed editor"))).bindTo(this.contextKeyService);
+	private readonly canReopenClosedEditorContextKey: IContextKey<boolean>;
 
 	updateContextKeys(): void {
 		this.contextKeyService.bufferChangeEvents(() => {
@@ -1257,27 +1272,35 @@ interface IEditorNavigationStacks extends IDisposable {
 
 class EditorNavigationStacks extends Disposable implements IEditorNavigationStacks {
 
-	private readonly selectionsStack = this._register(this.instantiationService.createInstance(EditorNavigationStack, GoFilter.NONE, this.scope));
-	private readonly editsStack = this._register(this.instantiationService.createInstance(EditorNavigationStack, GoFilter.EDITS, this.scope));
-	private readonly navigationsStack = this._register(this.instantiationService.createInstance(EditorNavigationStack, GoFilter.NAVIGATION, this.scope));
+	private readonly selectionsStack: EditorNavigationStack;
+	private readonly editsStack: EditorNavigationStack;
+	private readonly navigationsStack: EditorNavigationStack;
 
-	private readonly stacks: EditorNavigationStack[] = [
-		this.selectionsStack,
-		this.editsStack,
-		this.navigationsStack
-	];
+	private readonly stacks: EditorNavigationStack[];
 
-	readonly onDidChange = Event.any(
-		this.selectionsStack.onDidChange,
-		this.editsStack.onDidChange,
-		this.navigationsStack.onDidChange
-	);
+	readonly onDidChange: Event<void>;
 
 	constructor(
 		private readonly scope: GoScope,
 		@IInstantiationService private readonly instantiationService: IInstantiationService
 	) {
 		super();
+
+		this.selectionsStack = this._register(this.instantiationService.createInstance(EditorNavigationStack, GoFilter.NONE, this.scope));
+		this.editsStack = this._register(this.instantiationService.createInstance(EditorNavigationStack, GoFilter.EDITS, this.scope));
+		this.navigationsStack = this._register(this.instantiationService.createInstance(EditorNavigationStack, GoFilter.NAVIGATION, this.scope));
+
+		this.stacks = [
+			this.selectionsStack,
+			this.editsStack,
+			this.navigationsStack
+		];
+
+		this.onDidChange = Event.any(
+			this.selectionsStack.onDidChange,
+			this.editsStack.onDidChange,
+			this.navigationsStack.onDidChange
+		);
 	}
 
 	canGoForward(filter?: GoFilter): boolean {
@@ -1414,7 +1437,7 @@ export class EditorNavigationStack extends Disposable {
 	private readonly mapEditorToDisposable = new Map<EditorInput, DisposableStore>();
 	private readonly mapGroupToDisposable = new Map<GroupIdentifier, IDisposable>();
 
-	private readonly editorHelper = this.instantiationService.createInstance(EditorHelper);
+	private readonly editorHelper: EditorHelper;
 
 	private stack: IEditorNavigationStackEntry[] = [];
 
@@ -1444,6 +1467,8 @@ export class EditorNavigationStack extends Disposable {
 		@ILogService private readonly logService: ILogService
 	) {
 		super();
+
+		this.editorHelper = this.instantiationService.createInstance(EditorHelper);
 
 		this.registerListeners();
 	}

--- a/src/vs/workbench/services/host/electron-sandbox/nativeHostService.ts
+++ b/src/vs/workbench/services/host/electron-sandbox/nativeHostService.ts
@@ -39,17 +39,21 @@ class WorkbenchHostService extends Disposable implements IHostService {
 		@IWorkbenchEnvironmentService private readonly environmentService: IWorkbenchEnvironmentService
 	) {
 		super();
+
+		this.onDidChangeFocus = Event.latch(
+			Event.any(
+				Event.map(Event.filter(this.nativeHostService.onDidFocusMainOrAuxiliaryWindow, id => hasWindow(id), this._store), () => this.hasFocus, this._store),
+				Event.map(Event.filter(this.nativeHostService.onDidBlurMainOrAuxiliaryWindow, id => hasWindow(id), this._store), () => this.hasFocus, this._store),
+				Event.map(this.onDidChangeActiveWindow, () => this.hasFocus, this._store)
+			), undefined, this._store
+		);
+
+		this.onDidChangeFullScreen = Event.filter(this.nativeHostService.onDidChangeWindowFullScreen, e => hasWindow(e.windowId), this._store);
 	}
 
 	//#region Focus
 
-	readonly onDidChangeFocus = Event.latch(
-		Event.any(
-			Event.map(Event.filter(this.nativeHostService.onDidFocusMainOrAuxiliaryWindow, id => hasWindow(id), this._store), () => this.hasFocus, this._store),
-			Event.map(Event.filter(this.nativeHostService.onDidBlurMainOrAuxiliaryWindow, id => hasWindow(id), this._store), () => this.hasFocus, this._store),
-			Event.map(this.onDidChangeActiveWindow, () => this.hasFocus, this._store)
-		), undefined, this._store
-	);
+	readonly onDidChangeFocus: Event<boolean>;
 
 	get hasFocus(): boolean {
 		return getActiveDocument().hasFocus();
@@ -94,7 +98,7 @@ class WorkbenchHostService extends Disposable implements IHostService {
 		return Event.latch(emitter.event, undefined, this._store);
 	}
 
-	readonly onDidChangeFullScreen = Event.filter(this.nativeHostService.onDidChangeWindowFullScreen, e => hasWindow(e.windowId), this._store);
+	readonly onDidChangeFullScreen: Event<{ windowId: number; fullscreen: boolean }>;
 
 	openWindow(options?: IOpenEmptyWindowOptions): Promise<void>;
 	openWindow(toOpen: IWindowOpenable[], options?: IOpenWindowOptions): Promise<void>;

--- a/src/vs/workbench/services/integrity/electron-sandbox/integrityService.ts
+++ b/src/vs/workbench/services/integrity/electron-sandbox/integrityService.ts
@@ -59,7 +59,7 @@ export class IntegrityService implements IIntegrityService {
 
 	declare readonly _serviceBrand: undefined;
 
-	private readonly _storage = new IntegrityStorage(this.storageService);
+	private readonly _storage: IntegrityStorage;
 
 	private readonly _isPurePromise = this._isPure();
 	isPure(): Promise<IntegrityTestResult> {
@@ -75,6 +75,8 @@ export class IntegrityService implements IIntegrityService {
 		@IChecksumService private readonly checksumService: IChecksumService,
 		@ILogService private readonly logService: ILogService
 	) {
+		this._storage = new IntegrityStorage(this.storageService);
+
 		this._compute();
 	}
 

--- a/src/vs/workbench/services/notification/common/notificationService.ts
+++ b/src/vs/workbench/services/notification/common/notificationService.ts
@@ -29,6 +29,8 @@ export class NotificationService extends Disposable implements INotificationServ
 	) {
 		super();
 
+		this.globalFilterEnabled = this.storageService.getBoolean(NotificationService.GLOBAL_FILTER_SETTINGS_KEY, StorageScope.APPLICATION, false);
+
 		this.updateFilters();
 		this.registerListeners();
 	}
@@ -81,7 +83,7 @@ export class NotificationService extends Disposable implements INotificationServ
 	private readonly _onDidChangeFilter = this._register(new Emitter<void>());
 	readonly onDidChangeFilter = this._onDidChangeFilter.event;
 
-	private globalFilterEnabled = this.storageService.getBoolean(NotificationService.GLOBAL_FILTER_SETTINGS_KEY, StorageScope.APPLICATION, false);
+	private globalFilterEnabled: boolean;
 
 	private readonly mapSourceToFilter: Map<string /** source id */, INotificationSourceFilter> = (() => {
 		const map = new Map<string, INotificationSourceFilter>();

--- a/src/vs/workbench/services/storage/browser/storageService.ts
+++ b/src/vs/workbench/services/storage/browser/storageService.ts
@@ -29,7 +29,7 @@ export class BrowserStorageService extends AbstractStorageService {
 
 	private profileStorage: IStorage | undefined;
 	private profileStorageDatabase: IIndexedDBStorageDatabase | undefined;
-	private profileStorageProfile = this.userDataProfileService.currentProfile;
+	private profileStorageProfile: IUserDataProfile;
 	private readonly profileStorageDisposables = this._register(new DisposableStore());
 
 	private workspaceStorage: IStorage | undefined;
@@ -49,6 +49,8 @@ export class BrowserStorageService extends AbstractStorageService {
 		@ILogService private readonly logService: ILogService,
 	) {
 		super({ flushInterval: BrowserStorageService.BROWSER_DEFAULT_FLUSH_INTERVAL });
+
+		this.profileStorageProfile = this.userDataProfileService.currentProfile;
 
 		this.registerListeners();
 	}

--- a/src/vs/workbench/services/textMate/browser/backgroundTokenization/textMateWorkerTokenizerController.ts
+++ b/src/vs/workbench/services/textMate/browser/backgroundTokenization/textMateWorkerTokenizerController.ts
@@ -33,7 +33,7 @@ export class TextMateWorkerTokenizerController extends Disposable {
 	 */
 	private readonly _states = new TokenizationStateStore<StateStack>();
 
-	private readonly _loggingEnabled = observableConfigValue('editor.experimental.asyncTokenizationLogging', false, this._configurationService);
+	private readonly _loggingEnabled: IObservable<boolean>;
 
 	private _applyStateStackDiffFn?: typeof applyStateStackDiff;
 	private _initialState?: StateStack;
@@ -48,6 +48,7 @@ export class TextMateWorkerTokenizerController extends Disposable {
 	) {
 		super();
 
+		this._loggingEnabled = observableConfigValue('editor.experimental.asyncTokenizationLogging', false, this._configurationService);
 		this._register(keepObserved(this._loggingEnabled));
 
 		this._register(this._model.onDidChangeContent((e) => {

--- a/src/vs/workbench/services/textMate/browser/textMateTokenizationFeatureImpl.ts
+++ b/src/vs/workbench/services/textMate/browser/textMateTokenizationFeatureImpl.ts
@@ -55,11 +55,7 @@ export class TextMateTokenizationFeature extends Disposable implements ITextMate
 	private readonly _tokenizersRegistrations = new DisposableStore();
 	private _currentTheme: IRawTheme | null = null;
 	private _currentTokenColorMap: string[] | null = null;
-	private readonly _threadedBackgroundTokenizerFactory = this._instantiationService.createInstance(
-		ThreadedBackgroundTokenizerFactory,
-		(timeMs, languageId, sourceExtensionId, lineLength, isRandomSample) => this._reportTokenizationTime(timeMs, languageId, sourceExtensionId, lineLength, true, isRandomSample),
-		() => this.getAsyncTokenizationEnabled(),
-	);
+	private readonly _threadedBackgroundTokenizerFactory: ThreadedBackgroundTokenizerFactory;
 
 	constructor(
 		@ILanguageService private readonly _languageService: ILanguageService,
@@ -77,6 +73,12 @@ export class TextMateTokenizationFeature extends Disposable implements ITextMate
 
 		this._styleElement = domStylesheets.createStyleSheet();
 		this._styleElement.className = 'vscode-tokens-styles';
+
+		this._threadedBackgroundTokenizerFactory = this._instantiationService.createInstance(
+			ThreadedBackgroundTokenizerFactory,
+			(timeMs, languageId, sourceExtensionId, lineLength, isRandomSample) => this._reportTokenizationTime(timeMs, languageId, sourceExtensionId, lineLength, true, isRandomSample),
+			() => this.getAsyncTokenizationEnabled(),
+		);
 
 		grammarsExtPoint.setHandler((extensions) => this._handleGrammarsExtPoint(extensions));
 

--- a/src/vs/workbench/services/textfile/browser/textFileService.ts
+++ b/src/vs/workbench/services/textfile/browser/textFileService.ts
@@ -51,9 +51,9 @@ export abstract class AbstractTextFileService extends Disposable implements ITex
 	private static readonly TEXTFILE_SAVE_CREATE_SOURCE = SaveSourceRegistry.registerSource('textFileCreate.source', localize('textFileCreate.source', "File Created"));
 	private static readonly TEXTFILE_SAVE_REPLACE_SOURCE = SaveSourceRegistry.registerSource('textFileOverwrite.source', localize('textFileOverwrite.source', "File Replaced"));
 
-	readonly files: ITextFileEditorModelManager = this._register(this.instantiationService.createInstance(TextFileEditorModelManager));
+	readonly files: ITextFileEditorModelManager;
 
-	readonly untitled: IUntitledTextEditorModelManager = this.untitledTextEditorService;
+	readonly untitled: IUntitledTextEditorModelManager;
 
 	constructor(
 		@IFileService protected readonly fileService: IFileService,
@@ -76,6 +76,10 @@ export abstract class AbstractTextFileService extends Disposable implements ITex
 		@IDecorationsService private readonly decorationsService: IDecorationsService
 	) {
 		super();
+
+		this.files = this._register(this.instantiationService.createInstance(TextFileEditorModelManager));
+
+		this.untitled = this.untitledTextEditorService;
 
 		this.provideDecorations();
 	}

--- a/src/vs/workbench/services/textfile/common/textFileEditorModel.ts
+++ b/src/vs/workbench/services/textfile/common/textFileEditorModel.ts
@@ -86,8 +86,8 @@ export class TextFileEditorModel extends BaseTextEditorModel implements ITextFil
 
 	readonly capabilities = WorkingCopyCapabilities.None;
 
-	readonly name = basename(this.labelService.getUriLabel(this.resource));
-	private resourceHasExtension: boolean = !!extUri.extname(this.resource);
+	readonly name: string;
+	private resourceHasExtension: boolean;
 
 	private contentEncoding: string | undefined; // encoding as reported from disk
 
@@ -129,6 +129,10 @@ export class TextFileEditorModel extends BaseTextEditorModel implements ITextFil
 		@IProgressService private readonly progressService: IProgressService
 	) {
 		super(modelService, languageService, languageDetectionService, accessibilityService);
+
+		this.name = basename(this.labelService.getUriLabel(this.resource));
+
+		this.resourceHasExtension = !!extUri.extname(this.resource);
 
 		// Make known to working copy service
 		this._register(this.workingCopyService.registerWorkingCopy(this));

--- a/src/vs/workbench/services/textfile/common/textFileEditorModelManager.ts
+++ b/src/vs/workbench/services/textfile/common/textFileEditorModelManager.ts
@@ -99,6 +99,8 @@ export class TextFileEditorModelManager extends Disposable implements ITextFileE
 	) {
 		super();
 
+		this.saveParticipants = this._register(this.instantiationService.createInstance(TextFileSaveParticipant));
+
 		this.registerListeners();
 	}
 
@@ -558,7 +560,7 @@ export class TextFileEditorModelManager extends Disposable implements ITextFileE
 
 	//#region Save participants
 
-	private readonly saveParticipants = this._register(this.instantiationService.createInstance(TextFileSaveParticipant));
+	private readonly saveParticipants: TextFileSaveParticipant;
 
 	addSaveParticipant(participant: ITextFileSaveParticipant): IDisposable {
 		return this.saveParticipants.addSaveParticipant(participant);

--- a/src/vs/workbench/services/untitled/common/untitledTextEditorModel.ts
+++ b/src/vs/workbench/services/untitled/common/untitledTextEditorModel.ts
@@ -144,6 +144,8 @@ export class UntitledTextEditorModel extends BaseTextEditorModel implements IUnt
 	) {
 		super(modelService, languageService, languageDetectionService, accessibilityService);
 
+		this.dirty = this.hasAssociatedFilePath || !!this.initialValue;
+
 		// Make known to working copy service
 		this._register(this.workingCopyService.registerWorkingCopy(this));
 
@@ -237,7 +239,7 @@ export class UntitledTextEditorModel extends BaseTextEditorModel implements IUnt
 
 	//#region Dirty
 
-	private dirty = this.hasAssociatedFilePath || !!this.initialValue;
+	private dirty: boolean;
 
 	isDirty(): boolean {
 		return this.dirty;

--- a/src/vs/workbench/services/userDataProfile/browser/snippetsResource.ts
+++ b/src/vs/workbench/services/userDataProfile/browser/snippetsResource.ts
@@ -99,7 +99,7 @@ export class SnippetsResource implements IProfileResource {
 export class SnippetsResourceTreeItem implements IProfileResourceTreeItem {
 
 	readonly type = ProfileResourceType.Snippets;
-	readonly handle = this.profile.snippetsHome.toString();
+	readonly handle: string;
 	readonly label = { label: localize('snippets', "Snippets") };
 	readonly collapsibleState = TreeItemCollapsibleState.Collapsed;
 	checkbox: ITreeItemCheckboxState | undefined;
@@ -110,7 +110,9 @@ export class SnippetsResourceTreeItem implements IProfileResourceTreeItem {
 		private readonly profile: IUserDataProfile,
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
 		@IUriIdentityService private readonly uriIdentityService: IUriIdentityService,
-	) { }
+	) {
+		this.handle = this.profile.snippetsHome.toString();
+	}
 
 	async getChildren(): Promise<IProfileResourceChildTreeItem[] | undefined> {
 		const snippetsResources = await this.instantiationService.createInstance(SnippetsResource).getSnippetsResources(this.profile);

--- a/src/vs/workbench/services/workingCopy/common/untitledFileWorkingCopy.ts
+++ b/src/vs/workbench/services/workingCopy/common/untitledFileWorkingCopy.ts
@@ -92,7 +92,7 @@ export interface IUntitledFileWorkingCopyInitialContents {
 
 export class UntitledFileWorkingCopy<M extends IUntitledFileWorkingCopyModel> extends Disposable implements IUntitledFileWorkingCopy<M> {
 
-	readonly capabilities = this.isScratchpad ? WorkingCopyCapabilities.Untitled | WorkingCopyCapabilities.Scratchpad : WorkingCopyCapabilities.Untitled;
+	readonly capabilities: number;
 
 	private _model: M | undefined = undefined;
 	get model(): M | undefined { return this._model; }
@@ -131,13 +131,16 @@ export class UntitledFileWorkingCopy<M extends IUntitledFileWorkingCopyModel> ex
 	) {
 		super();
 
+		this.capabilities = this.isScratchpad ? WorkingCopyCapabilities.Untitled | WorkingCopyCapabilities.Scratchpad : WorkingCopyCapabilities.Untitled;
+		this.modified = this.hasAssociatedFilePath || Boolean(this.initialContents && this.initialContents.markModified !== false);
+
 		// Make known to working copy service
 		this._register(workingCopyService.registerWorkingCopy(this));
 	}
 
 	//#region Dirty/Modified
 
-	private modified = this.hasAssociatedFilePath || Boolean(this.initialContents && this.initialContents.markModified !== false);
+	private modified: boolean;
 
 	isDirty(): boolean {
 		return this.modified && !this.isScratchpad; // Scratchpad working copies are never dirty

--- a/src/vs/workbench/services/workingCopy/common/workingCopyFileService.ts
+++ b/src/vs/workbench/services/workingCopy/common/workingCopyFileService.ts
@@ -314,6 +314,10 @@ export class WorkingCopyFileService extends Disposable implements IWorkingCopyFi
 	) {
 		super();
 
+		this.fileOperationParticipants = this._register(this.instantiationService.createInstance(WorkingCopyFileOperationParticipant));
+
+		this.saveParticipants = this._register(this.instantiationService.createInstance(StoredFileWorkingCopySaveParticipant));
+
 		// register a default working copy provider that uses the working copy service
 		this._register(this.registerWorkingCopyProvider(resource => {
 			return this.workingCopyService.workingCopies.filter(workingCopy => {
@@ -491,7 +495,7 @@ export class WorkingCopyFileService extends Disposable implements IWorkingCopyFi
 
 	//#region File operation participants
 
-	private readonly fileOperationParticipants = this._register(this.instantiationService.createInstance(WorkingCopyFileOperationParticipant));
+	private readonly fileOperationParticipants: WorkingCopyFileOperationParticipant;
 
 	addFileOperationParticipant(participant: IWorkingCopyFileOperationParticipant): IDisposable {
 		return this.fileOperationParticipants.addFileOperationParticipant(participant);
@@ -505,7 +509,7 @@ export class WorkingCopyFileService extends Disposable implements IWorkingCopyFi
 
 	//#region Save participants (stored file working copies only)
 
-	private readonly saveParticipants = this._register(this.instantiationService.createInstance(StoredFileWorkingCopySaveParticipant));
+	private readonly saveParticipants: StoredFileWorkingCopySaveParticipant;
 
 	get hasSaveParticipants(): boolean { return this.saveParticipants.length > 0; }
 

--- a/src/vs/workbench/test/browser/parts/editor/editorGroupModel.test.ts
+++ b/src/vs/workbench/test/browser/parts/editor/editorGroupModel.test.ts
@@ -236,10 +236,12 @@ suite('EditorGroupModel', () => {
 
 	class TestFileEditorInput extends EditorInput implements IFileEditorInput {
 
-		readonly preferredResource = this.resource;
+		readonly preferredResource: URI;
 
 		constructor(public id: string, public resource: URI) {
 			super();
+
+			this.preferredResource = this.resource;
 		}
 		override get typeId() { return 'testFileEditorInputForGroups'; }
 		override get editorId() { return this.id; }

--- a/src/vs/workbench/test/browser/parts/editor/filteredEditorGroupModel.test.ts
+++ b/src/vs/workbench/test/browser/parts/editor/filteredEditorGroupModel.test.ts
@@ -104,10 +104,12 @@ suite('FilteredEditorGroupModel', () => {
 
 	class TestFileEditorInput extends EditorInput implements IFileEditorInput {
 
-		readonly preferredResource = this.resource;
+		readonly preferredResource: URI;
 
 		constructor(public id: string, public resource: URI) {
 			super();
+
+			this.preferredResource = this.resource;
 		}
 		override get typeId() { return 'testFileEditorInputForGroups'; }
 		override get editorId() { return this.id; }

--- a/src/vs/workbench/test/common/workbenchTestServices.ts
+++ b/src/vs/workbench/test/common/workbenchTestServices.ts
@@ -181,13 +181,14 @@ export class TestWorkingCopy extends Disposable implements IWorkingCopy {
 
 	readonly capabilities = WorkingCopyCapabilities.None;
 
-	readonly name = basename(this.resource);
+	readonly name: string;
 
 	private dirty = false;
 
 	constructor(readonly resource: URI, isDirty = false, readonly typeId = 'testWorkingCopyType') {
 		super();
 
+		this.name = basename(this.resource);
 		this.dirty = isDirty;
 	}
 


### PR DESCRIPTION
These changes go a ways towards addressing https://github.com/microsoft/vscode/issues/186726

These changes DO NOT include setting `useDefineForClassFields` to `true` so backsliding is still possible.

These changes were done by hand over a period of about five focused hours. There were 500 errors when I started.

The process I used was:

* Enable `useDefineForClassFields` in the base tsconfig file (NOT IN THIS PR)
* Run `npm run watch`
* Identify an error and open the file with an error
* For any field initialization that references a parameter property:
    * Move the initialization into the constructor
    * Explicitly add the type via a plugin
    * Repeat for any remaining + new errors
* Look for usages of `waitForState` and `recomputeInitiallyAndOnChange` and inline any impacted `derived` fields

To truly enable `useDefineForClassFields`, more changes will more than likely need to be made. For now, I was interested in tackling the compilation errors.

All tests pass with these changes.

If the VSCode team would like to take over this PR, that's fine.

The motivation for making these changes is that, at Google, we build this codebase internally. We are going to enable the compilation errors related to `useDefineForClassFields` in our internal typescript compiler settings (without actually turning on those transpilation changes, similar to https://github.com/microsoft/TypeScript/pull/59623). So we would much prefer to fix these issues in your codebase rather than maintain a huge 200 file patch :P