### PR TITLE
Enable rendering tool progress/confirmation messages with codeblocks

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chat.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.ts
@@ -142,7 +142,6 @@ export interface IChatCodeBlockInfo {
 	codemapperUri: URI | undefined;
 	readonly isStreaming: boolean;
 	focus(): void;
-	getContent(): string;
 }
 
 export interface IChatFileTreeInfo {

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/chatContentParts.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/chatContentParts.ts
@@ -4,11 +4,21 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { IDisposable } from '../../../../../base/common/lifecycle.js';
-import { ChatTreeItem } from '../chat.js';
+import { ChatTreeItem, IChatCodeBlockInfo } from '../chat.js';
 import { IChatRendererContent } from '../../common/chatViewModel.js';
 
 export interface IChatContentPart extends IDisposable {
 	domNode: HTMLElement;
+
+	/**
+	 * Used to indicate a part's ownership of a code block.
+	 */
+	codeblocksPartId?: string;
+
+	/**
+	 * Codeblocks that were rendered by this part into CodeBlockModelCollection.
+	 */
+	codeblocks?: IChatCodeBlockInfo[];
 
 	/**
 	 * Returns true if the other content is equivalent to what is already rendered in this content part.
@@ -16,6 +26,8 @@ export interface IChatContentPart extends IDisposable {
 	 * followingContent is all the content that will be rendered after this content part (to support progress messages' behavior).
 	 */
 	hasSameContent(other: IChatRendererContent, followingContent: IChatRendererContent[], element: ChatTreeItem): boolean;
+
+	addDisposable?(disposable: IDisposable): void;
 }
 
 export interface IChatContentPartRenderContext {

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/chatMarkdownContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/chatMarkdownContentPart.ts
@@ -138,7 +138,7 @@ export class ChatMarkdownContentPart extends Disposable implements IChatContentP
 					this._register(ref.object.onDidChangeContentHeight(() => this._onDidChangeHeight.fire()));
 
 					const ownerMarkdownPartId = this.codeblocksPartId;
-					const info: IChatCodeBlockInfo = new class {
+					const info: IChatCodeBlockInfo = new class implements IChatCodeBlockInfo {
 						readonly ownerMarkdownPartId = ownerMarkdownPartId;
 						readonly codeBlockIndex = globalIndex;
 						readonly elementId = element.id;
@@ -173,7 +173,7 @@ export class ChatMarkdownContentPart extends Disposable implements IChatContentP
 					}
 					this.allRefs.push(ref);
 					const ownerMarkdownPartId = this.codeblocksPartId;
-					const info: IChatCodeBlockInfo = new class {
+					const info: IChatCodeBlockInfo = new class implements IChatCodeBlockInfo {
 						readonly ownerMarkdownPartId = ownerMarkdownPartId;
 						readonly codeBlockIndex = globalIndex;
 						readonly elementId = element.id;

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/chatMarkdownContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/chatMarkdownContentPart.ts
@@ -153,9 +153,6 @@ export class ChatMarkdownContentPart extends Disposable implements IChatContentP
 						public focus() {
 							ref.object.focus();
 						}
-						public getContent(): string {
-							return ref.object.editor.getValue();
-						}
 					}();
 					this.codeblocks.push(info);
 					orderedDisposablesList.push(ref);
@@ -185,9 +182,6 @@ export class ChatMarkdownContentPart extends Disposable implements IChatContentP
 						readonly uriPromise = Promise.resolve(undefined);
 						public focus() {
 							return ref.object.element.focus();
-						}
-						public getContent(): string {
-							return ''; // Not needed for collapsed code blocks
 						}
 					}();
 					this.codeblocks.push(info);

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/chatProgressContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/chatProgressContentPart.ts
@@ -117,3 +117,20 @@ export class ChatWorkingProgressContentPart extends ChatProgressContentPart impl
 		return other.kind === 'working' && this.workingProgress.isPaused === other.isPaused;
 	}
 }
+
+export class ChatCustomProgressPart {
+	public readonly domNode: HTMLElement;
+
+	constructor(
+		messageElement: HTMLElement,
+		icon: ThemeIcon,
+	) {
+		this.domNode = $('.progress-container');
+		const iconElement = $('div');
+		iconElement.classList.add(...ThemeIcon.asClassNameArray(icon));
+		append(this.domNode, iconElement);
+
+		messageElement.classList.add('progress-step');
+		append(this.domNode, messageElement);
+	}
+}

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/chatToolInvocationPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/chatToolInvocationPart.ts
@@ -179,7 +179,10 @@ class ChatToolInvocationSubPart extends Disposable {
 			const codeBlockRenderOptions: ICodeBlockRenderOptions = {
 				hideToolbar: true,
 				reserveWidth: 19,
-				verticalPadding: 5
+				verticalPadding: 5,
+				editorOptions: {
+					wordWrap: 'on'
+				}
 			};
 			this.markdownPart = this._register(this.instantiationService.createInstance(ChatMarkdownContentPart, chatMarkdownContent, this.context, this.editorPool, false, this.codeBlockStartIndex, this.renderer, this.currentWidth, this.codeBlockModelCollection, { codeBlockRenderOptions }));
 			this._register(this.markdownPart.onDidChangeHeight(() => this._onDidChangeHeight.fire()));
@@ -241,7 +244,10 @@ class ChatToolInvocationSubPart extends Disposable {
 		const codeBlockRenderOptions: ICodeBlockRenderOptions = {
 			hideToolbar: true,
 			reserveWidth: 19,
-			verticalPadding: 5
+			verticalPadding: 5,
+			editorOptions: {
+				wordWrap: 'on'
+			}
 		};
 		this.markdownPart = this._register(this.instantiationService.createInstance(ChatMarkdownContentPart, chatMarkdownContent, this.context, this.editorPool, false, this.codeBlockStartIndex, this.renderer, this.currentWidth, this.codeBlockModelCollection, { codeBlockRenderOptions }));
 		this._register(this.markdownPart.onDidChangeHeight(() => this._onDidChangeHeight.fire()));

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/chatWarningContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/chatWarningContentPart.ts
@@ -42,7 +42,7 @@ export class ChatWarningContentPart extends Disposable implements IChatContentPa
 				break;
 		}
 		this.domNode.appendChild($(iconClass, undefined, renderIcon(icon)));
-		const markdownContent = renderer.render(content);
+		const markdownContent = this._register(renderer.render(content));
 		this.domNode.appendChild(markdownContent.element);
 	}
 

--- a/src/vs/workbench/contrib/chat/browser/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatWidget.ts
@@ -302,7 +302,7 @@ export class ChatWidget extends Disposable implements IChatWidget {
 			return lastResponse?.result?.errorDetails && !lastResponse?.result?.errorDetails.responseIsIncomplete;
 		}));
 
-		this._codeBlockModelCollection = this._register(instantiationService.createInstance(CodeBlockModelCollection));
+		this._codeBlockModelCollection = this._register(instantiationService.createInstance(CodeBlockModelCollection, undefined));
 
 		this._register(this.configurationService.onDidChangeConfiguration((e) => {
 			if (e.affectsConfiguration('chat.renderRelatedFiles')) {

--- a/src/vs/workbench/contrib/chat/browser/codeBlockPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/codeBlockPart.ts
@@ -86,7 +86,7 @@ export interface ICodeBlockData {
 	readonly range?: Range;
 
 	readonly parentContextKeyService?: IContextKeyService;
-	readonly hideToolbar?: boolean;
+	readonly renderOptions?: ICodeBlockRenderOptions;
 }
 
 /**
@@ -135,6 +135,12 @@ export interface ICodeBlockActionContext {
 	element: unknown;
 }
 
+export interface ICodeBlockRenderOptions {
+	hideToolbar?: boolean;
+	verticalPadding?: number;
+	reserveWidth?: number;
+}
+
 const defaultCodeblockPadding = 10;
 export class CodeBlockPart extends Disposable {
 	protected readonly _onDidChangeContentHeight = this._register(new Emitter<void>());
@@ -156,8 +162,12 @@ export class CodeBlockPart extends Disposable {
 
 	private resourceContextKey: ResourceContextKey;
 
+	private get verticalPadding(): number {
+		return this.currentCodeBlockData?.renderOptions?.verticalPadding ?? defaultCodeblockPadding;
+	}
+
 	constructor(
-		private readonly options: ChatEditorOptions,
+		private readonly editorOptions: ChatEditorOptions,
 		readonly menuId: MenuId,
 		delegate: IChatRendererDelegate,
 		overflowWidgetsDomNode: HTMLElement | undefined,
@@ -182,7 +192,7 @@ export class CodeBlockPart extends Disposable {
 			scrollBeyondLastLine: false,
 			lineDecorationsWidth: 8,
 			dragAndDrop: false,
-			padding: { top: defaultCodeblockPadding, bottom: defaultCodeblockPadding },
+			padding: { top: this.verticalPadding, bottom: this.verticalPadding },
 			mouseWheelZoom: false,
 			scrollbar: {
 				vertical: 'hidden',
@@ -246,7 +256,7 @@ export class CodeBlockPart extends Disposable {
 			}
 		}));
 
-		this._register(this.options.onDidChange(() => {
+		this._register(this.editorOptions.onDidChange(() => {
 			this.editor.updateOptions(this.getEditorOptionsFromConfig());
 		}));
 
@@ -319,9 +329,9 @@ export class CodeBlockPart extends Disposable {
 		const horizontalScrollbarVisible = this.currentScrollWidth > this.editor.getLayoutInfo().contentWidth;
 		const scrollbarHeight = this.editor.getLayoutInfo().horizontalScrollbarHeight;
 		const bottomPadding = horizontalScrollbarVisible ?
-			Math.max(defaultCodeblockPadding - scrollbarHeight, 2) :
-			defaultCodeblockPadding;
-		this.editor.updateOptions({ padding: { top: defaultCodeblockPadding, bottom: bottomPadding } });
+			Math.max(this.verticalPadding - scrollbarHeight, 2) :
+			this.verticalPadding;
+		this.editor.updateOptions({ padding: { top: this.verticalPadding, bottom: bottomPadding } });
 	}
 
 	private _configureForScreenReader(): void {
@@ -336,22 +346,23 @@ export class CodeBlockPart extends Disposable {
 
 	private getEditorOptionsFromConfig(): IEditorOptions {
 		return {
-			wordWrap: this.options.configuration.resultEditor.wordWrap,
-			fontLigatures: this.options.configuration.resultEditor.fontLigatures,
-			bracketPairColorization: this.options.configuration.resultEditor.bracketPairColorization,
-			fontFamily: this.options.configuration.resultEditor.fontFamily === 'default' ?
+			wordWrap: this.editorOptions.configuration.resultEditor.wordWrap,
+			fontLigatures: this.editorOptions.configuration.resultEditor.fontLigatures,
+			bracketPairColorization: this.editorOptions.configuration.resultEditor.bracketPairColorization,
+			fontFamily: this.editorOptions.configuration.resultEditor.fontFamily === 'default' ?
 				EDITOR_FONT_DEFAULTS.fontFamily :
-				this.options.configuration.resultEditor.fontFamily,
-			fontSize: this.options.configuration.resultEditor.fontSize,
-			fontWeight: this.options.configuration.resultEditor.fontWeight,
-			lineHeight: this.options.configuration.resultEditor.lineHeight,
+				this.editorOptions.configuration.resultEditor.fontFamily,
+			fontSize: this.editorOptions.configuration.resultEditor.fontSize,
+			fontWeight: this.editorOptions.configuration.resultEditor.fontWeight,
+			lineHeight: this.editorOptions.configuration.resultEditor.lineHeight,
 		};
 	}
 
 	layout(width: number): void {
 		const contentHeight = this.getContentHeight();
 		const editorBorder = 2;
-		this.editor.layout({ width: width - editorBorder, height: contentHeight });
+		width = width - editorBorder - (this.currentCodeBlockData?.renderOptions?.reserveWidth ?? 0);
+		this.editor.layout({ width, height: contentHeight });
 		this.updatePaddingForLayout();
 	}
 
@@ -370,7 +381,7 @@ export class CodeBlockPart extends Disposable {
 			this.contextKeyService.updateParent(data.parentContextKeyService);
 		}
 
-		if (this.options.configuration.resultEditor.wordWrap === 'on') {
+		if (this.editorOptions.configuration.resultEditor.wordWrap === 'on') {
 			// Initialize the editor with the new proper width so that getContentHeight
 			// will be computed correctly in the next call to layout()
 			this.layout(width);
@@ -384,7 +395,7 @@ export class CodeBlockPart extends Disposable {
 		this.layout(width);
 		this.editor.updateOptions({ ariaLabel: localize('chat.codeBlockLabel', "Code block {0}", data.codeBlockIndex + 1) });
 		this.toolbar.setAriaLabel(localize('chat.codeBlockToolbarLabel', "Toolbar for code block {0}", data.codeBlockIndex + 1));
-		if (data.hideToolbar) {
+		if (data.renderOptions?.hideToolbar) {
 			dom.hide(this.toolbar.getElement());
 		} else {
 			dom.show(this.toolbar.getElement());

--- a/src/vs/workbench/contrib/chat/browser/codeBlockPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/codeBlockPart.ts
@@ -139,6 +139,7 @@ export interface ICodeBlockRenderOptions {
 	hideToolbar?: boolean;
 	verticalPadding?: number;
 	reserveWidth?: number;
+	editorOptions?: IEditorOptions;
 }
 
 const defaultCodeblockPadding = 10;
@@ -355,6 +356,7 @@ export class CodeBlockPart extends Disposable {
 			fontSize: this.editorOptions.configuration.resultEditor.fontSize,
 			fontWeight: this.editorOptions.configuration.resultEditor.fontWeight,
 			lineHeight: this.editorOptions.configuration.resultEditor.lineHeight,
+			...this.currentCodeBlockData?.renderOptions?.editorOptions,
 		};
 	}
 
@@ -381,7 +383,7 @@ export class CodeBlockPart extends Disposable {
 			this.contextKeyService.updateParent(data.parentContextKeyService);
 		}
 
-		if (this.editorOptions.configuration.resultEditor.wordWrap === 'on') {
+		if (this.getEditorOptionsFromConfig().wordWrap === 'on') {
 			// Initialize the editor with the new proper width so that getContentHeight
 			// will be computed correctly in the next call to layout()
 			this.layout(width);
@@ -393,7 +395,10 @@ export class CodeBlockPart extends Disposable {
 		}
 
 		this.layout(width);
-		this.editor.updateOptions({ ariaLabel: localize('chat.codeBlockLabel', "Code block {0}", data.codeBlockIndex + 1) });
+		this.editor.updateOptions({
+			...this.getEditorOptionsFromConfig(),
+			ariaLabel: localize('chat.codeBlockLabel', "Code block {0}", data.codeBlockIndex + 1),
+		});
 		this.toolbar.setAriaLabel(localize('chat.codeBlockToolbarLabel', "Toolbar for code block {0}", data.codeBlockIndex + 1));
 		if (data.renderOptions?.hideToolbar) {
 			dom.hide(this.toolbar.getElement());

--- a/src/vs/workbench/contrib/chat/browser/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/media/chat.css
@@ -370,6 +370,10 @@
 		margin: 0 0 6px 0;
 	}
 
+	.rendered-markdown [data-code] {
+		margin: 0;
+	}
+
 	.progress-container {
 		padding-top: 2px;
 	}

--- a/src/vs/workbench/contrib/chat/common/codeBlockModelCollection.ts
+++ b/src/vs/workbench/contrib/chat/common/codeBlockModelCollection.ts
@@ -43,6 +43,7 @@ export class CodeBlockModelCollection extends Disposable {
 	private readonly maxModelCount = 100;
 
 	constructor(
+		private readonly tag: string | undefined,
 		@ILanguageService private readonly languageService: ILanguageService,
 		@ITextModelService private readonly textModelService: ITextModelService,
 	) {
@@ -201,10 +202,11 @@ export class CodeBlockModelCollection extends Disposable {
 
 	private getCodeBlockUri(sessionId: string, chat: IChatRequestViewModel | IChatResponseViewModel, index: number): URI {
 		const metadata = this.getUriMetaData(chat);
+		const indexPart = this.tag ? `${this.tag}-${index}` : `${index}`;
 		return URI.from({
 			scheme: Schemas.vscodeChatCodeBlock,
 			authority: sessionId,
-			path: `/${chat.id}/${index}`,
+			path: `/${chat.id}/${indexPart}`,
 			fragment: metadata ? JSON.stringify(metadata) : undefined,
 		});
 	}

--- a/src/vs/workbench/contrib/chat/common/languageModelToolsService.ts
+++ b/src/vs/workbench/contrib/chat/common/languageModelToolsService.ts
@@ -72,7 +72,7 @@ export interface IPreparedToolInvocation {
 	pastTenseMessage?: string | IMarkdownString;
 	tooltip?: string | IMarkdownString;
 	confirmationMessages?: IToolConfirmationMessages;
-	presentation?: 'hidden' | undefined;
+	presentation?: 'withCodeblocks' | 'hidden' | undefined;
 }
 
 export interface IToolImpl {

--- a/src/vscode-dts/vscode.proposed.chatParticipantPrivate.d.ts
+++ b/src/vscode-dts/vscode.proposed.chatParticipantPrivate.d.ts
@@ -121,7 +121,7 @@ declare module 'vscode' {
 	export interface PreparedToolInvocation {
 		pastTenseMessage?: string | MarkdownString;
 		tooltip?: string | MarkdownString;
-		presentation?: 'hidden' | undefined;
+		presentation?: 'withCodeblocks' | 'hidden' | undefined;
 	}
 
 	export class ExtendedLanguageModelToolResult extends LanguageModelToolResult {


### PR DESCRIPTION
Needs a little cleanup, this should probably not use the `CodeBlockModelCollection` but I need to think about the right approach