### PR TITLE
feat: let TokenSelector support multi-languages

### DIFF
--- a/src/vs/workbench/services/themes/common/colorThemeData.ts
+++ b/src/vs/workbench/services/themes/common/colorThemeData.ts
@@ -154,7 +154,7 @@ export class ColorThemeData implements IWorkbenchColorTheme {
 		return undefined;
 	}
 
-	private getTokenStyle(type: string, modifiers: string[], language: string, useDefault = true, definitions: TokenStyleDefinitions = {}): TokenStyle | undefined {
+	private getTokenStyle(type: string, modifiers: string[], languages: string[], useDefault = true, definitions: TokenStyleDefinitions = {}): TokenStyle | undefined {
 		const result: any = {
 			foreground: undefined,
 			bold: undefined,
@@ -189,7 +189,7 @@ export class ColorThemeData implements IWorkbenchColorTheme {
 			}
 		}
 		function _processSemanticTokenRule(rule: SemanticTokenRule) {
-			const matchScore = rule.selector.match(type, modifiers, language);
+			const matchScore = rule.selector.match(type, modifiers, languages);
 			if (matchScore >= 0) {
 				_processStyle(matchScore, rule.style, rule);
 			}
@@ -209,7 +209,7 @@ export class ColorThemeData implements IWorkbenchColorTheme {
 		}
 		if (hasUndefinedStyleProperty) {
 			for (const rule of tokenClassificationRegistry.getTokenStylingDefaultRules()) {
-				const matchScore = rule.selector.match(type, modifiers, language);
+				const matchScore = rule.selector.match(type, modifiers, languages);
 				if (matchScore >= 0) {
 					let style: TokenStyle | undefined;
 					if (rule.defaults.scopesToProbe) {
@@ -239,8 +239,8 @@ export class ColorThemeData implements IWorkbenchColorTheme {
 		if (tokenStyleValue === undefined) {
 			return undefined;
 		} else if (typeof tokenStyleValue === 'string') {
-			const { type, modifiers, language } = parseClassifierString(tokenStyleValue, '');
-			return this.getTokenStyle(type, modifiers, language);
+			const { type, modifiers, languages } = parseClassifierString(tokenStyleValue, '');
+			return this.getTokenStyle(type, modifiers, languages);
 		} else if (typeof tokenStyleValue === 'object') {
 			return tokenStyleValue;
 		}
@@ -275,8 +275,8 @@ export class ColorThemeData implements IWorkbenchColorTheme {
 	}
 
 	public getTokenStyleMetadata(typeWithLanguage: string, modifiers: string[], defaultLanguage: string, useDefault = true, definitions: TokenStyleDefinitions = {}): ITokenStyle | undefined {
-		const { type, language } = parseClassifierString(typeWithLanguage, defaultLanguage);
-		const style = this.getTokenStyle(type, modifiers, language, useDefault, definitions);
+		const { type, languages } = parseClassifierString(typeWithLanguage, defaultLanguage);
+		const style = this.getTokenStyle(type, modifiers, languages, useDefault, definitions);
 		if (!style) {
 			return undefined;
 		}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
Related to #66729 #181360 #199569.
Recently, I encountered an issue when trying to add language-specific token colors using `editor.semanticTokenColorCustomizations`. As noted in [VS Code's semantic highlighting guide](https://code.visualstudio.com/api/language-extensions/semantic-highlight-guide#semantic-coloring-in-color-themes), the current implementation only supports grouping tokens under a single language.

This patch extends support for multiple languages by allowing definitions like class:c,cpp,python, enabling semantic token customization across multiple languages.