### PR TITLE
Add set-location spec for pwsh

### DIFF
--- a/extensions/terminal-suggest/src/completions/set-location.ts
+++ b/extensions/terminal-suggest/src/completions/set-location.ts
@@ -12,12 +12,12 @@ const cdSpec: Fig.Spec = {
 		suggestions: [
 			{
 				name: '-',
-				description: 'Go to previous directory',
+				description: 'Go to previous directory in history stack',
 				hidden: true,
 			},
 			{
 				name: '+',
-				description: 'Go to next directory',
+				description: 'Go to next directory in history stack',
 				hidden: true,
 			},
 		],

--- a/extensions/terminal-suggest/src/completions/set-location.ts
+++ b/extensions/terminal-suggest/src/completions/set-location.ts
@@ -1,0 +1,27 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+const cdSpec: Fig.Spec = {
+	name: 'Set-Location',
+	description: 'Change the shell working directory',
+	args: {
+		name: 'folder',
+		template: 'folders',
+		suggestions: [
+			{
+				name: '-',
+				description: 'Go to previous directory',
+				hidden: true,
+			},
+			{
+				name: '+',
+				description: 'Go to next directory',
+				hidden: true,
+			},
+		],
+	}
+};
+
+export default cdSpec;

--- a/extensions/terminal-suggest/src/terminalSuggestMain.ts
+++ b/extensions/terminal-suggest/src/terminalSuggestMain.ts
@@ -10,6 +10,7 @@ import * as vscode from 'vscode';
 import cdSpec from './completions/cd';
 import codeCompletionSpec from './completions/code';
 import codeInsidersCompletionSpec from './completions/code-insiders';
+import setLocationSpec from './completions/set-location';
 import { upstreamSpecs } from './constants';
 import { PathExecutableCache } from './env/pathExecutableCache';
 import { osIsWindows } from './helpers/os';
@@ -49,6 +50,7 @@ export const availableSpecs: Fig.Spec[] = [
 	cdSpec,
 	codeInsidersCompletionSpec,
 	codeCompletionSpec,
+	setLocationSpec,
 ];
 for (const spec of upstreamSpecs) {
 	availableSpecs.push(require(`./completions/upstream/${spec}`).default);


### PR DESCRIPTION
Without this, there are no file/folder completions when the quickSuggestions setting has unknown as off (default).

Fixes #241583

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
