### PR TITLE
Handle no environment reporting properly

### DIFF
--- a/extensions/terminal-suggest/src/terminalSuggestMain.ts
+++ b/extensions/terminal-suggest/src/terminalSuggestMain.ts
@@ -100,7 +100,7 @@ export async function activate(context: vscode.ExtensionContext) {
 				return;
 			}
 
-			const commandsInPath = await pathExecutableCache.getExecutablesInPath(terminal.shellIntegration?.env.value);
+			const commandsInPath = await pathExecutableCache.getExecutablesInPath(terminal.shellIntegration?.env?.value);
 			const shellGlobals = await getShellGlobals(shellType, commandsInPath?.labels) ?? [];
 			if (!commandsInPath?.completionResources) {
 				return;
@@ -110,7 +110,7 @@ export async function activate(context: vscode.ExtensionContext) {
 			const prefix = getPrefix(terminalContext.commandLine, terminalContext.cursorPosition);
 			const pathSeparator = isWindows ? '\\' : '/';
 			const tokenType = getTokenType(terminalContext, shellType);
-			const result = await getCompletionItemsFromSpecs(availableSpecs, terminalContext, commands, prefix, tokenType, terminal.shellIntegration?.cwd, getEnvAsRecord(terminal.shellIntegration?.env.value), terminal.name, token);
+			const result = await getCompletionItemsFromSpecs(availableSpecs, terminalContext, commands, prefix, tokenType, terminal.shellIntegration?.cwd, getEnvAsRecord(terminal.shellIntegration?.env?.value), terminal.name, token);
 			if (terminal.shellIntegration?.env) {
 				const homeDirCompletion = result.items.find(i => i.label === '~');
 				if (homeDirCompletion && terminal.shellIntegration.env?.value?.HOME) {
@@ -120,7 +120,7 @@ export async function activate(context: vscode.ExtensionContext) {
 			}
 
 			if (result.cwd && (result.filesRequested || result.foldersRequested)) {
-				return new vscode.TerminalCompletionList(result.items, { filesRequested: result.filesRequested, foldersRequested: result.foldersRequested, fileExtensions: result.fileExtensions, cwd: result.cwd, env: terminal.shellIntegration?.env.value });
+				return new vscode.TerminalCompletionList(result.items, { filesRequested: result.filesRequested, foldersRequested: result.foldersRequested, fileExtensions: result.fileExtensions, cwd: result.cwd, env: terminal.shellIntegration?.env?.value });
 			}
 			return result.items;
 		}

--- a/src/vs/workbench/api/common/extHostTerminalShellIntegration.ts
+++ b/src/vs/workbench/api/common/extHostTerminalShellIntegration.ts
@@ -151,7 +151,7 @@ class InternalTerminalShellIntegration extends Disposable {
 	get currentExecution(): InternalTerminalShellExecution | undefined { return this._currentExecution; }
 
 	private _ignoreNextExecution: boolean = false;
-	private _env: vscode.TerminalShellIntegrationEnvironment = { value: {}, isTrusted: false };
+	private _env: vscode.TerminalShellIntegrationEnvironment | undefined;
 	private _cwd: URI | undefined;
 
 	readonly store: DisposableStore = this._register(new DisposableStore());
@@ -176,7 +176,7 @@ class InternalTerminalShellIntegration extends Disposable {
 			get cwd(): URI | undefined {
 				return that._cwd;
 			},
-			get env(): vscode.TerminalShellIntegrationEnvironment {
+			get env(): vscode.TerminalShellIntegrationEnvironment | undefined {
 				return that._env;
 			},
 			// executeCommand(commandLine: string): vscode.TerminalShellExecution;

--- a/src/vscode-dts/vscode.proposed.terminalShellEnv.d.ts
+++ b/src/vscode-dts/vscode.proposed.terminalShellEnv.d.ts
@@ -29,7 +29,7 @@ declare module 'vscode' {
 		 * The environment of the shell process. This is undefined if the shell integration script
 		 * does not send the environment.
 		 */
-		readonly env: TerminalShellIntegrationEnvironment;
+		readonly env: TerminalShellIntegrationEnvironment | undefined;
 	}
 
 	// TODO: Is it fine that this shares onDidChangeTerminalShellIntegration with cwd and the shellIntegration object itself?


### PR DESCRIPTION
We need to differentiate undefined (no env reporting ever) and an empty environment (env was reported, but maybe incomplete).

Fixes #241504

cc @anthonykim1 