### PR TITLE
Ensure terminal data is segmented by C and D sequences

### DIFF
--- a/extensions/vscode-api-tests/src/singlefolder-tests/terminal.shellIntegration.test.ts
+++ b/extensions/vscode-api-tests/src/singlefolder-tests/terminal.shellIntegration.test.ts
@@ -142,7 +142,7 @@ import { assertNoRpc } from '../utils';
 		await closeTerminalAsync(terminal);
 	});
 
-	test.skip('TerminalShellExecution.read iterables should be available between the start and end execution events', async () => {
+	test('TerminalShellExecution.read iterables should be available between the start and end execution events', async () => {
 		const { terminal, shellIntegration } = await createTerminalAndWaitForShellIntegration();
 		const events: string[] = [];
 		disposables.push(window.onDidStartTerminalShellExecution(() => events.push('start')));
@@ -164,7 +164,7 @@ import { assertNoRpc } from '../utils';
 		await closeTerminalAsync(terminal);
 	});
 
-	test.skip('TerminalShellExecution.read events should fire with contents of command', async () => {
+	test('TerminalShellExecution.read events should fire with contents of command', async () => {
 		const { terminal, shellIntegration } = await createTerminalAndWaitForShellIntegration();
 		const events: string[] = [];
 
@@ -179,7 +179,7 @@ import { assertNoRpc } from '../utils';
 		await closeTerminalAsync(terminal);
 	});
 
-	test.skip('TerminalShellExecution.read events should give separate iterables per call', async () => {
+	test('TerminalShellExecution.read events should give separate iterables per call', async () => {
 		const { terminal, shellIntegration } = await createTerminalAndWaitForShellIntegration();
 
 		const { execution, endEvent } = executeCommandAsync(shellIntegration, 'echo hello');


### PR DESCRIPTION
The tests failed because on mac the 633;C and 633;D events both appear in the same event. The change ensures we match globally on the regex and cleans up handling of multiple events. This went from failing consistently to passing consistently on my mac.

Fixes #241592

cc @meganrogge 