### PR TITLE
Fix not uri-transforming links in tool invocations

### DIFF
--- a/src/vs/base/common/htmlContent.ts
+++ b/src/vs/base/common/htmlContent.ts
@@ -34,6 +34,18 @@ export class MarkdownString implements IMarkdownString {
 	public supportThemeIcons?: boolean;
 	public supportHtml?: boolean;
 	public baseUri?: URI;
+	public uris?: { [href: string]: UriComponents } | undefined;
+
+	public static lift(dto: IMarkdownString): MarkdownString {
+		if (dto instanceof MarkdownString) {
+			return dto;
+		}
+
+		const markdownString = new MarkdownString(dto.value, dto);
+		markdownString.uris = dto.uris;
+		markdownString.baseUri = dto.baseUri ? URI.revive(dto.baseUri) : undefined;
+		return markdownString;
+	}
 
 	constructor(
 		value: string = '',

--- a/src/vs/base/test/common/markdownString.test.ts
+++ b/src/vs/base/test/common/markdownString.test.ts
@@ -4,8 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
-import { MarkdownString } from '../../common/htmlContent.js';
+import { IMarkdownString, MarkdownString } from '../../common/htmlContent.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from './utils.js';
+import { URI } from '../../common/uri.js';
 
 suite('MarkdownString', () => {
 
@@ -63,6 +64,27 @@ suite('MarkdownString', () => {
 			'foo)', 'hello]', 'title"',
 			'[hello\\]](foo\\) "title\\"")'
 		);
+	});
+
+	test('lift', () => {
+		const dto: IMarkdownString = {
+			value: 'hello',
+			baseUri: URI.file('/foo/bar'),
+			supportThemeIcons: true,
+			isTrusted: true,
+			supportHtml: true,
+			uris: {
+				[URI.file('/foo/bar2').toString()]: URI.file('/foo/bar2'),
+				[URI.file('/foo/bar3').toString()]: URI.file('/foo/bar3')
+			}
+		};
+		const mds = MarkdownString.lift(dto);
+		assert.strictEqual(mds.value, dto.value);
+		assert.strictEqual(mds.baseUri?.toString(), dto.baseUri?.toString());
+		assert.strictEqual(mds.supportThemeIcons, dto.supportThemeIcons);
+		assert.strictEqual(mds.isTrusted, dto.isTrusted);
+		assert.strictEqual(mds.supportHtml, dto.supportHtml);
+		assert.deepStrictEqual(mds.uris, dto.uris);
 	});
 
 	suite('appendCodeBlock', () => {

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/chatProgressContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/chatProgressContentPart.ts
@@ -70,11 +70,14 @@ export class ChatProgressContentPart extends Disposable implements IChatContentP
 	private renderFileWidgets(element: HTMLElement): void {
 		const links = element.querySelectorAll('a');
 		links.forEach(a => {
-			const href = a.getAttribute('data-href');
-			const uri = href ? URI.parse(href) : undefined;
-			if (uri?.scheme) {
-				const widget = this._register(this.instantiationService.createInstance(InlineAnchorWidget, a, { kind: 'inlineReference', inlineReference: uri }));
-				this._register(this.chatMarkdownAnchorService.register(widget));
+			// Empty link text -> render file widget
+			if (!a.textContent?.trim()) {
+				const href = a.getAttribute('data-href');
+				const uri = href ? URI.parse(href) : undefined;
+				if (uri?.scheme) {
+					const widget = this._register(this.instantiationService.createInstance(InlineAnchorWidget, a, { kind: 'inlineReference', inlineReference: uri }));
+					this._register(this.chatMarkdownAnchorService.register(widget));
+				}
 			}
 		});
 	}

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/chatToolInvocationPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/chatToolInvocationPart.ts
@@ -124,7 +124,7 @@ class ChatToolInvocationSubPart extends Disposable {
 		if (toolInvocation.kind === 'toolInvocation' && toolInvocation.confirmationMessages) {
 			this.domNode = this.createConfirmationWidget(toolInvocation);
 		} else if (toolInvocation.presentation === 'withCodeblocks' && typeof toolInvocation.invocationMessage !== 'string') {
-			this.domNode = this.createMarkdownProgressPart(toolInvocation);
+			this.domNode = this.createMarkdownWithCodeblocksProgressPart(toolInvocation);
 		} else if (toolInvocation.resultDetails?.length) {
 			this.domNode = this.createResultList(toolInvocation.pastTenseMessage ?? toolInvocation.invocationMessage, toolInvocation.resultDetails);
 		} else {
@@ -211,7 +211,7 @@ class ChatToolInvocationSubPart extends Disposable {
 		} else {
 			content = typeof this.toolInvocation.invocationMessage === 'string' ?
 				new MarkdownString().appendText(this.toolInvocation.invocationMessage + '…') :
-				new MarkdownString(this.toolInvocation.invocationMessage.value + '…');
+				MarkdownString.lift(this.toolInvocation.invocationMessage).appendText('…');
 		}
 
 		const progressMessage: IChatProgressMessage = {
@@ -226,7 +226,7 @@ class ChatToolInvocationSubPart extends Disposable {
 		return progressPart.domNode;
 	}
 
-	private createMarkdownProgressPart(toolInvocation: IChatToolInvocation | IChatToolInvocationSerialized): HTMLElement {
+	private createMarkdownWithCodeblocksProgressPart(toolInvocation: IChatToolInvocation | IChatToolInvocationSerialized): HTMLElement {
 		const content = toolInvocation.isComplete ?
 			(toolInvocation.pastTenseMessage ?? toolInvocation.invocationMessage)
 			: toolInvocation.invocationMessage;

--- a/src/vs/workbench/contrib/chat/browser/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/media/chat.css
@@ -373,10 +373,6 @@
 	.progress-container .rendered-markdown [data-code] {
 		margin: 0;
 	}
-
-	.progress-container {
-		padding-top: 2px;
-	}
 }
 
 .interactive-item-container .value > .rendered-markdown li > p {
@@ -1537,6 +1533,10 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	align-items: center;
 	gap: 7px;
 	margin: 0 0 6px 4px;
+
+	/* Tool calls transition from a progress to a collapsible list part, which needs to have this top padding.
+	The working progress also can be replaced by a tool progress part. So align this padding so the text doesn't appear to shift. */
+	padding-top: 2px;
 
 	> .codicon[class*='codicon-'] {
 		height: 12px;


### PR DESCRIPTION
Was recreating the markdown string and dropping the uri objects

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
