### PR TITLE
feat: enable gpu channel async from the runtime

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -313,8 +313,10 @@ function configureCommandlineSwitchesSync(cliArgs: NativeParsedArgs) {
 
 	// Following features are enabled from the runtime:
 	// `DocumentPolicyIncludeJSCallStacksInCrashReports` - https://www.electronjs.org/docs/latest/api/web-frame-main#framecollectjavascriptcallstack-experimental
+	// `EarlyEstablishGpuChannel` - Refs https://issues.chromium.org/issues/40208065
+	// `EstablishGpuChannelAsync` - Refs https://issues.chromium.org/issues/40208065
 	const featuresToEnable =
-		`DocumentPolicyIncludeJSCallStacksInCrashReports, ${app.commandLine.getSwitchValue('enable-features')}`;
+		`DocumentPolicyIncludeJSCallStacksInCrashReports,EarlyEstablishGpuChannel,EstablishGpuChannelAsync,${app.commandLine.getSwitchValue('enable-features')}`;
 	app.commandLine.appendSwitch('enable-features', featuresToEnable);
 
 	// Following features are disabled from the runtime:


### PR DESCRIPTION
While investigating https://github.com/microsoft/vscode/issues/240767 I see that the renderer main thread is blocked around 1s in establishing the gpu channel on the perf bot. Upstream has finished evaluation of the gpu async channel and has enabled it by default since Chromium 134 https://chromium-review.googlesource.com/c/chromium/src/+/6094045. Here is the before and after with the feature enabled, `CrRendererMain` is the main thread of the renderer, with the feature enabled we now push the channel establishing task to a different thread and free up main thread for other tasks.

***Before:***

[perf] code/willOpenNewWindow-code/willLoadWorkbenchMain: 1295ms (fastest), 1295ms (slowest), 1295ms (median)

![gpu-sync](https://github.com/user-attachments/assets/cb254cd3-8e81-42ee-8720-2f4d07caee64)



***After:***

[perf] code/willOpenNewWindow-code/willLoadWorkbenchMain: 310ms (fastest), 310ms (slowest), 310ms (median)

![gpu-async](https://github.com/user-attachments/assets/5b890e0c-a783-41c0-be8f-ee6cf7eb5a77)
