### PR TITLE
Update IChatTransfer to store location and toolsAgentEnablement state and fix restoring chat to correct ChatViewPane

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadChatAgents2.ts
+++ b/src/vs/workbench/api/browser/mainThreadChatAgents2.ts
@@ -137,7 +137,8 @@ export class MainThreadChatAgents2 extends Disposable implements MainThreadChatA
 		}
 
 		const inputValue = widget?.inputEditor.getValue() ?? '';
-		this._chatService.transferChatSession({ sessionId, inputValue }, URI.revive(toWorkspace));
+		const location = widget.location;
+		this._chatService.transferChatSession({ sessionId, inputValue, location }, URI.revive(toWorkspace));
 	}
 
 	async $registerAgent(handle: number, extension: ExtensionIdentifier, id: string, metadata: IExtensionChatAgentMetadata, dynamicProps: IDynamicChatAgentProps | undefined): Promise<void> {

--- a/src/vs/workbench/api/browser/mainThreadChatAgents2.ts
+++ b/src/vs/workbench/api/browser/mainThreadChatAgents2.ts
@@ -138,7 +138,8 @@ export class MainThreadChatAgents2 extends Disposable implements MainThreadChatA
 
 		const inputValue = widget?.inputEditor.getValue() ?? '';
 		const location = widget.location;
-		this._chatService.transferChatSession({ sessionId, inputValue, location }, URI.revive(toWorkspace));
+		const toolsAgentModeEnabled = this._chatAgentService.toolsAgentModeEnabled;
+		this._chatService.transferChatSession({ sessionId, inputValue, location, toolsAgentModeEnabled }, URI.revive(toWorkspace));
 	}
 
 	async $registerAgent(handle: number, extension: ExtensionIdentifier, id: string, metadata: IExtensionChatAgentMetadata, dynamicProps: IDynamicChatAgentProps | undefined): Promise<void> {

--- a/src/vs/workbench/contrib/chat/browser/chatViewPane.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatViewPane.ts
@@ -120,7 +120,7 @@ export class ChatViewPane extends ViewPane implements IViewWelcomeDelegate {
 	private updateModel(model?: IChatModel | undefined, viewState?: IChatViewState): void {
 		this.modelDisposables.clear();
 
-		model = model ?? (this.chatService.transferredSessionData?.sessionId
+		model = model ?? (this.chatService.transferredSessionData?.sessionId && this.chatService.transferredSessionData?.location === this.chatOptions.location
 			? this.chatService.getOrRestoreSession(this.chatService.transferredSessionData.sessionId)
 			: this.chatService.startSession(this.chatOptions.location, CancellationToken.None));
 		if (!model) {
@@ -148,7 +148,7 @@ export class ChatViewPane extends ViewPane implements IViewWelcomeDelegate {
 
 	private getSessionId() {
 		let sessionId: string | undefined;
-		if (this.chatService.transferredSessionData) {
+		if (this.chatService.transferredSessionData?.location === this.chatOptions.location) {
 			sessionId = this.chatService.transferredSessionData.sessionId;
 			this.viewState.inputValue = this.chatService.transferredSessionData.inputValue;
 		} else {

--- a/src/vs/workbench/contrib/chat/common/chatModel.ts
+++ b/src/vs/workbench/contrib/chat/common/chatModel.ts
@@ -982,15 +982,20 @@ export interface ISerializableChatData3 extends Omit<ISerializableChatData2, 've
 	customTitle: string | undefined;
 }
 
+export interface ISerializableChatData4 extends Omit<ISerializableChatData3, 'version'> {
+	version: 4;
+	isToolsAgentModeEnabled: boolean;
+}
+
 /**
  * Chat data that has been parsed and normalized to the current format.
  */
-export type ISerializableChatData = ISerializableChatData3;
+export type ISerializableChatData = ISerializableChatData4;
 
 /**
  * Chat data that has been loaded but not normalized, and could be any format
  */
-export type ISerializableChatDataIn = ISerializableChatData1 | ISerializableChatData2 | ISerializableChatData3;
+export type ISerializableChatDataIn = ISerializableChatData1 | ISerializableChatData2 | ISerializableChatData3 | ISerializableChatData4;
 
 /**
  * Normalize chat data from storage to the current format.
@@ -1001,18 +1006,28 @@ export function normalizeSerializableChatData(raw: ISerializableChatDataIn): ISe
 
 	if (!('version' in raw)) {
 		return {
-			version: 3,
+			version: 4,
 			...raw,
 			lastMessageDate: raw.creationDate,
 			customTitle: undefined,
+			isToolsAgentModeEnabled: false,
+		};
+	}
+
+	if (raw.version === 3) {
+		return {
+			...raw,
+			version: 4,
+			isToolsAgentModeEnabled: false,
 		};
 	}
 
 	if (raw.version === 2) {
 		return {
 			...raw,
-			version: 3,
-			customTitle: raw.computedTitle
+			version: 4,
+			customTitle: raw.computedTitle,
+			isToolsAgentModeEnabled: false,
 		};
 	}
 
@@ -1256,6 +1271,10 @@ export class ChatModel extends Disposable implements IChatModel {
 
 	get initialLocation() {
 		return this._initialLocation;
+	}
+
+	get toolsAgentModeEnabled() {
+		return this.chatAgentService.toolsAgentModeEnabled;
 	}
 
 	constructor(
@@ -1604,13 +1623,14 @@ export class ChatModel extends Disposable implements IChatModel {
 
 	toJSON(): ISerializableChatData {
 		return {
-			version: 3,
+			version: 4,
 			...this.toExport(),
 			sessionId: this.sessionId,
 			creationDate: this._creationDate,
 			isImported: this._isImported,
 			lastMessageDate: this._lastMessageDate,
-			customTitle: this._customTitle
+			customTitle: this._customTitle,
+			isToolsAgentModeEnabled: this.toolsAgentModeEnabled,
 		};
 	}
 

--- a/src/vs/workbench/contrib/chat/common/chatModel.ts
+++ b/src/vs/workbench/contrib/chat/common/chatModel.ts
@@ -1610,7 +1610,7 @@ export class ChatModel extends Disposable implements IChatModel {
 			creationDate: this._creationDate,
 			isImported: this._isImported,
 			lastMessageDate: this._lastMessageDate,
-			customTitle: this._customTitle,
+			customTitle: this._customTitle
 		};
 	}
 

--- a/src/vs/workbench/contrib/chat/common/chatModel.ts
+++ b/src/vs/workbench/contrib/chat/common/chatModel.ts
@@ -980,7 +980,6 @@ export interface ISerializableChatData2 extends ISerializableChatData1 {
 export interface ISerializableChatData3 extends Omit<ISerializableChatData2, 'version' | 'computedTitle'> {
 	version: 3;
 	customTitle: string | undefined;
-	isToolsAgentModeEnabled?: boolean;
 }
 
 /**
@@ -1257,10 +1256,6 @@ export class ChatModel extends Disposable implements IChatModel {
 
 	get initialLocation() {
 		return this._initialLocation;
-	}
-
-	get toolsAgentModeEnabled() {
-		return this.chatAgentService.toolsAgentModeEnabled;
 	}
 
 	constructor(
@@ -1616,7 +1611,6 @@ export class ChatModel extends Disposable implements IChatModel {
 			isImported: this._isImported,
 			lastMessageDate: this._lastMessageDate,
 			customTitle: this._customTitle,
-			isToolsAgentModeEnabled: this.toolsAgentModeEnabled,
 		};
 	}
 

--- a/src/vs/workbench/contrib/chat/common/chatModel.ts
+++ b/src/vs/workbench/contrib/chat/common/chatModel.ts
@@ -1013,7 +1013,7 @@ export function normalizeSerializableChatData(raw: ISerializableChatDataIn): ISe
 		return {
 			...raw,
 			version: 3,
-			customTitle: raw.computedTitle,
+			customTitle: raw.computedTitle
 		};
 	}
 

--- a/src/vs/workbench/contrib/chat/common/chatModel.ts
+++ b/src/vs/workbench/contrib/chat/common/chatModel.ts
@@ -980,22 +980,18 @@ export interface ISerializableChatData2 extends ISerializableChatData1 {
 export interface ISerializableChatData3 extends Omit<ISerializableChatData2, 'version' | 'computedTitle'> {
 	version: 3;
 	customTitle: string | undefined;
-}
-
-export interface ISerializableChatData4 extends Omit<ISerializableChatData3, 'version'> {
-	version: 4;
-	isToolsAgentModeEnabled: boolean;
+	isToolsAgentModeEnabled?: boolean;
 }
 
 /**
  * Chat data that has been parsed and normalized to the current format.
  */
-export type ISerializableChatData = ISerializableChatData4;
+export type ISerializableChatData = ISerializableChatData3;
 
 /**
  * Chat data that has been loaded but not normalized, and could be any format
  */
-export type ISerializableChatDataIn = ISerializableChatData1 | ISerializableChatData2 | ISerializableChatData3 | ISerializableChatData4;
+export type ISerializableChatDataIn = ISerializableChatData1 | ISerializableChatData2 | ISerializableChatData3;
 
 /**
  * Normalize chat data from storage to the current format.
@@ -1006,28 +1002,18 @@ export function normalizeSerializableChatData(raw: ISerializableChatDataIn): ISe
 
 	if (!('version' in raw)) {
 		return {
-			version: 4,
+			version: 3,
 			...raw,
 			lastMessageDate: raw.creationDate,
 			customTitle: undefined,
-			isToolsAgentModeEnabled: false,
-		};
-	}
-
-	if (raw.version === 3) {
-		return {
-			...raw,
-			version: 4,
-			isToolsAgentModeEnabled: false,
 		};
 	}
 
 	if (raw.version === 2) {
 		return {
 			...raw,
-			version: 4,
+			version: 3,
 			customTitle: raw.computedTitle,
-			isToolsAgentModeEnabled: false,
 		};
 	}
 
@@ -1623,7 +1609,7 @@ export class ChatModel extends Disposable implements IChatModel {
 
 	toJSON(): ISerializableChatData {
 		return {
-			version: 4,
+			version: 3,
 			...this.toExport(),
 			sessionId: this.sessionId,
 			creationDate: this._creationDate,

--- a/src/vs/workbench/contrib/chat/common/chatService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService.ts
@@ -395,6 +395,7 @@ export interface IChatProviderInfo {
 export interface IChatTransferredSessionData {
 	sessionId: string;
 	inputValue: string;
+	location: ChatAgentLocation;
 }
 
 export interface IChatSendRequestResponseState {

--- a/src/vs/workbench/contrib/chat/common/chatService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService.ts
@@ -396,6 +396,7 @@ export interface IChatTransferredSessionData {
 	sessionId: string;
 	inputValue: string;
 	location: ChatAgentLocation;
+	toolsAgentModeEnabled: boolean;
 }
 
 export interface IChatSendRequestResponseState {

--- a/src/vs/workbench/contrib/chat/common/chatServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/chatServiceImpl.ts
@@ -44,6 +44,8 @@ interface IChatTransfer {
 	timestampInMilliseconds: number;
 	chat: ISerializableChatData;
 	inputValue: string;
+	location: ChatAgentLocation;
+	toolsAgentModeEnabled: boolean;
 }
 const SESSION_TRANSFER_EXPIRATION_IN_MILLISECONDS = 1000 * 60;
 
@@ -168,8 +170,8 @@ export class ChatService extends Disposable implements IChatService {
 			this._transferredSessionData = {
 				sessionId: transferredChat.sessionId,
 				inputValue: transferredData.inputValue,
-				location: transferredChat.initialLocation ?? ChatAgentLocation.Panel,
-				toolsAgentModeEnabled: transferredChat.isToolsAgentModeEnabled ?? false,
+				location: transferredData.location,
+				toolsAgentModeEnabled: transferredData.toolsAgentModeEnabled,
 			};
 		}
 
@@ -1009,6 +1011,8 @@ export class ChatService extends Disposable implements IChatService {
 			timestampInMilliseconds: Date.now(),
 			toWorkspace: toWorkspace,
 			inputValue: transferredSessionData.inputValue,
+			location: transferredSessionData.location,
+			toolsAgentModeEnabled: transferredSessionData.toolsAgentModeEnabled,
 		});
 
 		this.storageService.store(globalChatKey, JSON.stringify(existingRaw), StorageScope.PROFILE, StorageTarget.MACHINE);

--- a/src/vs/workbench/contrib/chat/common/chatServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/chatServiceImpl.ts
@@ -165,7 +165,7 @@ export class ChatService extends Disposable implements IChatService {
 		if (transferredChat) {
 			this.trace('constructor', `Transferred session ${transferredChat.sessionId}`);
 			this._persistedSessions[transferredChat.sessionId] = transferredChat;
-			this._transferredSessionData = { sessionId: transferredChat.sessionId, inputValue: transferredData.inputValue };
+			this._transferredSessionData = { sessionId: transferredChat.sessionId, inputValue: transferredData.inputValue, location: transferredChat.initialLocation ?? ChatAgentLocation.Panel };
 		}
 
 		this._register(storageService.onWillSaveState(() => this.saveState()));
@@ -395,6 +395,12 @@ export class ChatService extends Disposable implements IChatService {
 		const model = this.instantiationService.createInstance(ChatModel, someSessionHistory, location);
 		this._sessionModels.set(model.sessionId, model);
 		this.initializeSession(model, token);
+
+		if (someSessionHistory) {
+			if ('isToolsAgentModeEnabled' in someSessionHistory) {
+				this.chatAgentService.toggleToolsAgentMode(someSessionHistory.isToolsAgentModeEnabled);
+			}
+		}
 		return model;
 	}
 


### PR DESCRIPTION
- Added a check in ChatViewPane to ensure that the location matches before attempting to restore the session. This prevents chat sessions from the Edits view from being restored to the Panel view when transferring chat (created first).
- Updated the IChatTransfer to hold both the location and the status of agent mode enablement, allowing the restoration of the Edits view session state to be in "Agents" mode.