### PR TITLE
Remove keybinding for partial accept

### DIFF
--- a/src/vs/editor/contrib/inlineCompletions/browser/controller/commands.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/controller/commands.ts
@@ -269,7 +269,6 @@ export class AcceptNextInlineEditPart extends EditorAction {
 			precondition: ContextKeyExpr.and(EditorContextKeys.writable, InlineCompletionContextKeys.inlineEditVisible),
 			kbOpts: {
 				weight: KeybindingWeight.EditorContrib + 1,
-				primary: KeyMod.CtrlCmd | KeyCode.RightArrow,
 				kbExpr: ContextKeyExpr.and(EditorContextKeys.writable, InlineCompletionContextKeys.inlineEditVisible),
 			},
 		});


### PR DESCRIPTION
```Copilot Generated Description:``` Remove the keybinding for the partial accept action in the editor.