### PR TITLE
Prevent new search regressing issue #239936

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/preferencesSearch.ts
+++ b/src/vs/workbench/contrib/preferences/browser/preferencesSearch.ts
@@ -131,9 +131,11 @@ export class LocalSearchProvider implements ISearchProvider {
 				exactMatch: true
 			});
 		} else if (useNewKeyMatchAlgorithm) {
-			// Filter by the top match type.
+			// Check the top match type.
 			const topMatchType = Math.max(...filterMatches.map(m => m.matchType));
-			const filteredMatches = filterMatches.filter(m => m.matchType === topMatchType);
+			// Still allow description matches as part of https://github.com/microsoft/vscode/issues/239936.
+			const alwaysAllowedTypes = SettingMatchType.DescriptionOrValueMatch | SettingMatchType.LanguageTagSettingMatch;
+			const filteredMatches = filterMatches.filter(m => (m.matchType === topMatchType) || (m.matchType & alwaysAllowedTypes));
 			return Promise.resolve({
 				filterMatches: filteredMatches,
 				exactMatch: false

--- a/src/vs/workbench/contrib/preferences/browser/preferencesSearch.ts
+++ b/src/vs/workbench/contrib/preferences/browser/preferencesSearch.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ISettingsEditorModel, ISetting, ISettingsGroup, ISearchResult, IGroupFilter, SettingMatchType, ISettingMatch } from '../../../services/preferences/common/preferences.js';
+import { ISettingsEditorModel, ISetting, ISettingsGroup, ISearchResult, IGroupFilter, SettingMatchType, ISettingMatch, SettingKeyMatchTypes } from '../../../services/preferences/common/preferences.js';
 import { IRange } from '../../../../editor/common/core/range.js';
 import { distinct } from '../../../../base/common/arrays.js';
 import * as strings from '../../../../base/common/strings.js';
@@ -131,11 +131,11 @@ export class LocalSearchProvider implements ISearchProvider {
 				exactMatch: true
 			});
 		} else if (useNewKeyMatchAlgorithm) {
-			// Check the top match type.
-			const topMatchType = Math.max(...filterMatches.map(m => m.matchType));
-			// Still allow description matches as part of https://github.com/microsoft/vscode/issues/239936.
-			const alwaysAllowedTypes = SettingMatchType.DescriptionOrValueMatch | SettingMatchType.LanguageTagSettingMatch;
-			const filteredMatches = filterMatches.filter(m => (m.matchType === topMatchType) || (m.matchType & alwaysAllowedTypes));
+			// Check the top key match type.
+			const topKeyMatchType = Math.max(...filterMatches.map(m => (m.matchType & SettingKeyMatchTypes)));
+			// Always allow description matches as part of https://github.com/microsoft/vscode/issues/239936.
+			const alwaysAllowedMatchTypes = SettingMatchType.DescriptionOrValueMatch | SettingMatchType.LanguageTagSettingMatch;
+			const filteredMatches = filterMatches.filter(m => (m.matchType & topKeyMatchType) || (m.matchType & alwaysAllowedMatchTypes));
 			return Promise.resolve({
 				filterMatches: filteredMatches,
 				exactMatch: false

--- a/src/vs/workbench/contrib/preferences/browser/settingsTreeModels.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsTreeModels.ts
@@ -971,10 +971,9 @@ export class SearchResultModel extends SettingsTreeModel {
 				// Sort by match type if the match types are not the same.
 				// The priority of the match type is given by the SettingMatchType enum.
 				return b.matchType - a.matchType;
-			} else if (a.matchType === SettingMatchType.NonContiguousWordsInSettingsLabel || a.matchType === SettingMatchType.ContiguousWordsInSettingsLabel) {
-				// The match types are the same.
-				// Sort by the number of words matched in the key.
-				// If those are the same, sort by the order in the table of contents.
+			} else if ((a.matchType & SettingMatchType.NonContiguousWordsInSettingsLabel) || (a.matchType & SettingMatchType.ContiguousWordsInSettingsLabel)) {
+				// The match types of a and b are the same and can be sorted by their number of matched words.
+				// If those numbers are the same, sort by the order in the table of contents.
 				return (b.keyMatchScore - a.keyMatchScore) || compareTwoNullableNumbers(a.setting.internalOrder, b.setting.internalOrder);
 			} else if (a.matchType === SettingMatchType.RemoteMatch) {
 				// The match types are the same and are RemoteMatch.

--- a/src/vs/workbench/services/preferences/common/preferences.ts
+++ b/src/vs/workbench/services/preferences/common/preferences.ts
@@ -144,6 +144,11 @@ export enum SettingMatchType {
 	ContiguousQueryInSettingId = 1 << 6,
 	AllWordsInSettingsLabel = 1 << 7,
 }
+export const SettingKeyMatchTypes = (SettingMatchType.AllWordsInSettingsLabel
+	| SettingMatchType.ContiguousWordsInSettingsLabel
+	| SettingMatchType.NonContiguousWordsInSettingsLabel
+	| SettingMatchType.NonContiguousQueryInSettingId
+	| SettingMatchType.ContiguousQueryInSettingId);
 
 export interface ISettingMatch {
 	setting: ISetting;


### PR DESCRIPTION
This PR changes the new settings search algorithm to always include description results so that we don't repeat #239936.
Description-only matches will still be sorted behind most key matches, so I do not expect this change to add that much noise.

CC @sbatten