### PR TITLE
Always try sending along project root paths

### DIFF
--- a/extensions/typescript-language-features/src/typescriptServiceClient.ts
+++ b/extensions/typescript-language-features/src/typescriptServiceClient.ts
@@ -836,9 +836,10 @@ export default class TypeScriptServiceClient extends Disposable implements IType
 			}
 		}
 
-		for (const root of roots.sort((a, b) => a.uri.fsPath.length - b.uri.fsPath.length)) {
+		// Find the highest level workspace folder that contains the file
+		for (const root of roots.sort((a, b) => a.uri.path.length - b.uri.path.length)) {
 			if (root.uri.scheme === resource.scheme && root.uri.authority === resource.authority) {
-				if (resource.fsPath.startsWith(root.uri.fsPath + path.sep)) {
+				if (resource.path.startsWith(root.uri.path + '/')) {
 					return root.uri;
 				}
 			}


### PR DESCRIPTION
If the user opens a ts file outside of any workspace, currently we may not send along a project root path to TS. This can result in extra projects being loaded

Instead we should tell TS about the current workspace we have opened

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
