### PR TITLE
Generate macOS configuration profiles

### DIFF
--- a/build/azure-pipelines/darwin/product-build-darwin.yml
+++ b/build/azure-pipelines/darwin/product-build-darwin.yml
@@ -122,7 +122,7 @@ steps:
   - template: ../common/install-builtin-extensions.yml@self
 
   - ${{ if and(ne(parameters.VSCODE_CIBUILD, true), ne(parameters.VSCODE_QUALITY, 'oss')) }}:
-    - script: node build/lib/policies
+    - script: node build/lib/policies darwin
       displayName: Generate Configuration Profile policy definitions
       retryCountOnTaskFailure: 3
 

--- a/build/azure-pipelines/darwin/product-build-darwin.yml
+++ b/build/azure-pipelines/darwin/product-build-darwin.yml
@@ -193,21 +193,6 @@ steps:
         chmod +x "$APP_PATH/Contents/Resources/app/bin/$CLI_APP_NAME"
       displayName: Make CLI executable
 
-    - ${{ if and(ne(parameters.VSCODE_CIBUILD, true), ne(parameters.VSCODE_QUALITY, 'oss')) }}:
-      - script: |
-          set -e
-          APP_ROOT="$(Agent.BuildDirectory)/VSCode-darwin-$(VSCODE_ARCH)"
-          APP_NAME="`ls $APP_ROOT | head -n 1`"
-          APP_PATH="$APP_ROOT/$APP_NAME"
-          POLICIES_DIR=".build/policies/darwin"
-          if [ ! -d "$POLICIES_DIR" ]; then
-            echo "Missing $POLICIES_DIR"
-            exit 1
-          fi
-          mkdir -p "$APP_PATH/Contents/Resources/app/policies"
-          cp -r "$POLICIES_DIR/" "$APP_PATH/Contents/Resources/app/policies/"
-        displayName: Copy policy definitions
-
     - script: |
         set -e
         APP_ROOT="$(Agent.BuildDirectory)/VSCode-darwin-$(VSCODE_ARCH)"

--- a/build/azure-pipelines/darwin/product-build-darwin.yml
+++ b/build/azure-pipelines/darwin/product-build-darwin.yml
@@ -121,6 +121,11 @@ steps:
 
   - template: ../common/install-builtin-extensions.yml@self
 
+  - ${{ if and(ne(parameters.VSCODE_CIBUILD, true), ne(parameters.VSCODE_QUALITY, 'oss')) }}:
+    - script: node build/lib/policies
+      displayName: Generate Configuration Profile policy definitions
+      retryCountOnTaskFailure: 3
+
   - ${{ if ne(parameters.VSCODE_QUALITY, 'oss') }}:
     - script: |
         set -e

--- a/build/azure-pipelines/darwin/product-build-darwin.yml
+++ b/build/azure-pipelines/darwin/product-build-darwin.yml
@@ -123,7 +123,7 @@ steps:
 
   - ${{ if and(ne(parameters.VSCODE_CIBUILD, true), ne(parameters.VSCODE_QUALITY, 'oss')) }}:
     - script: node build/lib/policies darwin
-      displayName: Generate Configuration Profile policy definitions
+      displayName: Generate policy definitions
       retryCountOnTaskFailure: 3
 
   - ${{ if ne(parameters.VSCODE_QUALITY, 'oss') }}:
@@ -192,6 +192,21 @@ steps:
         mv "$(Build.ArtifactStagingDirectory)/cli/$APP_NAME" "$APP_PATH/Contents/Resources/app/bin/$CLI_APP_NAME"
         chmod +x "$APP_PATH/Contents/Resources/app/bin/$CLI_APP_NAME"
       displayName: Make CLI executable
+
+    - ${{ if and(ne(parameters.VSCODE_CIBUILD, true), ne(parameters.VSCODE_QUALITY, 'oss')) }}:
+      - script: |
+          set -e
+          APP_ROOT="$(Agent.BuildDirectory)/VSCode-darwin-$(VSCODE_ARCH)"
+          APP_NAME="`ls $APP_ROOT | head -n 1`"
+          APP_PATH="$APP_ROOT/$APP_NAME"
+          POLICIES_DIR=".build/policies/darwin"
+          if [ ! -d "$POLICIES_DIR" ]; then
+            echo "Missing $POLICIES_DIR"
+            exit 1
+          fi
+          mkdir -p "$APP_PATH/Contents/Resources/app/policies"
+          cp -r "$POLICIES_DIR/" "$APP_PATH/Contents/Resources/app/policies/"
+        displayName: Copy policy definitions
 
     - script: |
         set -e

--- a/build/azure-pipelines/win32/product-build-win32.yml
+++ b/build/azure-pipelines/win32/product-build-win32.yml
@@ -124,7 +124,7 @@ steps:
   - template: ../common/install-builtin-extensions.yml@self
 
   - ${{ if and(ne(parameters.VSCODE_CIBUILD, true), ne(parameters.VSCODE_QUALITY, 'oss')) }}:
-    - powershell: node build\lib\policies
+    - powershell: node build\lib\policies win32
       displayName: Generate Group Policy definitions
       retryCountOnTaskFailure: 3
 

--- a/build/darwin/create-universal-app.js
+++ b/build/darwin/create-universal-app.js
@@ -27,6 +27,7 @@ async function main(buildDir) {
     const filesToSkip = [
         '**/CodeResources',
         '**/Credits.rtf',
+        '**/policies/{*.mobileconfig,**/*.plist}',
         // TODO: Should we consider expanding this to other files in this area?
         '**/node_modules/@parcel/node-addon-api/nothing.target.mk'
     ];

--- a/build/darwin/create-universal-app.ts
+++ b/build/darwin/create-universal-app.ts
@@ -28,6 +28,7 @@ async function main(buildDir?: string) {
 	const filesToSkip = [
 		'**/CodeResources',
 		'**/Credits.rtf',
+		'**/policies/{*.mobileconfig,**/*.plist}',
 		// TODO: Should we consider expanding this to other files in this area?
 		'**/node_modules/@parcel/node-addon-api/nothing.target.mk'
 	];

--- a/build/gulpfile.vscode.js
+++ b/build/gulpfile.vscode.js
@@ -372,8 +372,9 @@ function packageTask(platform, arch, sourceFolderName, destinationFolderName, op
 			const shortcut = gulp.src('resources/darwin/bin/code.sh')
 				.pipe(replace('@@APPNAME@@', product.applicationName))
 				.pipe(rename('bin/code'));
-
-			all = es.merge(all, shortcut);
+			const policyDest = gulp.src('.build/policies/darwin/**', { base: '.build/policies/darwin' })
+				.pipe(rename(f => f.dirname = `policies/${f.dirname}`));
+			all = es.merge(all, shortcut, policyDest);
 		}
 
 		let result = all
@@ -424,10 +425,6 @@ function packageTask(platform, arch, sourceFolderName, destinationFolderName, op
 				.pipe(replace('@@PRODNAME@@', product.nameLong))
 				.pipe(replace('@@APPNAME@@', product.applicationName))
 				.pipe(rename('bin/' + product.applicationName)));
-		} else if (platform === 'darwin') {
-			const policyDest = path.join(`${product.nameLong}.app`, 'Contents', 'Resources', 'app', 'policies');
-			result = es.merge(result, gulp.src('.build/policies/darwin/**', { base: '.build/policies/darwin' })
-				.pipe(rename(f => f.dirname = path.join(policyDest, f.dirname))));
 		}
 
 		result = inlineMeta(result, {

--- a/build/gulpfile.vscode.js
+++ b/build/gulpfile.vscode.js
@@ -424,6 +424,10 @@ function packageTask(platform, arch, sourceFolderName, destinationFolderName, op
 				.pipe(replace('@@PRODNAME@@', product.nameLong))
 				.pipe(replace('@@APPNAME@@', product.applicationName))
 				.pipe(rename('bin/' + product.applicationName)));
+		} else if (platform === 'darwin') {
+			const policyDest = path.join(`${product.nameLong}.app`, 'Contents', 'Resources', 'app', 'policies');
+			result = es.merge(result, gulp.src('.build/policies/darwin/**', { base: '.build/policies/darwin' })
+				.pipe(rename(f => f.dirname = path.join(policyDest, f.dirname))));
 		}
 
 		result = inlineMeta(result, {

--- a/build/lib/policies.js
+++ b/build/lib/policies.js
@@ -654,8 +654,8 @@ function renderProfileManifest(appName, bundleIdentifier, _versions, _categories
 function renderMacOSPolicy(policies, translations) {
     const appName = product.nameLong;
     const bundleIdentifier = product.darwinBundleIdentifier;
-    const payloadUUID = '9F957DE8-6596-4CD6-A54E-D3A20F2B1C37';
-    const contentUUID = '3AD1E08A-673E-4C62-AA68-D43ED8180249';
+    const payloadUUID = product.darwinProfilePayloadUUID;
+    const UUID = product.darwinProfileUUID;
     const versions = [...new Set(policies.map(p => p.minimumVersion)).values()].sort();
     const categories = [...new Set(policies.map(p => p.category))];
     const policyEntries = policies.map(policy => policy.renderProfile())
@@ -673,11 +673,11 @@ function renderMacOSPolicy(policies, translations) {
 				<key>PayloadDisplayName</key>
 				<string>${appName}</string>
 				<key>PayloadIdentifier</key>
-				<string>${bundleIdentifier}.${contentUUID}</string>
+				<string>${bundleIdentifier}.${UUID}</string>
 				<key>PayloadType</key>
 				<string>${bundleIdentifier}</string>
 				<key>PayloadUUID</key>
-				<string>${contentUUID}</string>
+				<string>${UUID}</string>
 				<key>PayloadVersion</key>
 				<integer>1</integer>
 ${policyEntries}
@@ -835,7 +835,7 @@ async function windowsMain(policies, translations) {
 }
 async function darwinMain(policies, translations) {
     const bundleIdentifier = product.darwinBundleIdentifier;
-    if (!bundleIdentifier) {
+    if (!bundleIdentifier || !product.darwinProfilePayloadUUID || !product.darwinProfileUUID) {
         throw new Error(`Missing required product information.`);
     }
     const root = '.build/policies/darwin';

--- a/build/lib/policies.js
+++ b/build/lib/policies.js
@@ -611,21 +611,7 @@ function renderProfileManifest(appName, bundleIdentifier, _versions, _categories
 			<string>Payload Organization</string>
 			<key>pfm_type</key>
 			<string>string</string>
-		</dict>
-		<dict>
-            <key>pfm_default</key>
-            <integer>5</integer>
-            <key>pfm_name</key>
-            <string>TargetDeviceType</string>
-            <key>pfm_title</key>
-            <string>Target Device Type</string>
-            <key>pfm_type</key>
-            <string>integer</string>
-            <key>pfm_range_list</key>
-            <array>
-                <integer>5</integer>
-            </array>
-        </dict>`;
+		</dict>`;
     const profileManifestSubkeys = policies.map(policy => {
         return policy.renderProfileManifest(translations);
     }).join('');

--- a/build/lib/policies.js
+++ b/build/lib/policies.js
@@ -593,7 +593,21 @@ function renderProfileManifest(appName, bundleIdentifier, _versions, _categories
 			<string>Payload Organization</string>
 			<key>pfm_type</key>
 			<string>string</string>
-		</dict>`;
+		</dict>
+		<dict>
+            <key>pfm_default</key>
+            <integer>5</integer>
+            <key>pfm_name</key>
+            <string>TargetDeviceType</string>
+            <key>pfm_title</key>
+            <string>Target Device Type</string>
+            <key>pfm_type</key>
+            <string>integer</string>
+            <key>pfm_range_list</key>
+            <array>
+                <integer>5</integer>
+            </array>
+        </dict>`;
     const profileManifestSubkeys = policies.map(policy => {
         return policy.renderProfileManifest(translations);
     }).join('');
@@ -614,7 +628,7 @@ function renderProfileManifest(appName, bundleIdentifier, _versions, _categories
     <key>pfm_interaction</key>
     <string>combined</string>
     <key>pfm_last_modified</key>
-    <date>2025-02-14T10:00:00Z</date>
+    <date>${new Date().toISOString().replace(/\.\d+Z$/, 'Z')}</date>
     <key>pfm_platforms</key>
     <array>
         <string>macOS</string>
@@ -649,11 +663,6 @@ function renderMacOSPolicy(policies, translations) {
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 	<dict>
-		<key>ConsentText</key>
-		<dict>
-			<key>default</key>
-			<string>This profile manages ${appName}. For more information see https://code.visualstudio.com/docs/setup/enterprise</string>
-		</dict>
 		<key>PayloadContent</key>
 		<array>
 			<dict>
@@ -671,7 +680,7 @@ ${policyEntries}
 			</dict>
 		</array>
 		<key>PayloadDescription</key>
-		<string>https://code.visualstudio.com/docs/setup/enterprise</string>
+		<string>This profile manages ${appName}. For more information see https://code.visualstudio.com/docs/setup/enterprise</string>
 		<key>PayloadDisplayName</key>
 		<string>${appName}</string>
 		<key>PayloadIdentifier</key>

--- a/build/lib/policies.js
+++ b/build/lib/policies.js
@@ -128,10 +128,19 @@ class BooleanPolicy extends BasePolicy {
         return `<checkBox refId="${this.name}">${this.name}</checkBox>`;
     }
     renderProfileValue() {
-        throw new Error(`Boolean policy '${this.name}' cannot be rendered in Profile.`);
+        return `<false/>`;
     }
-    renderProfileManifestValue(_) {
-        throw new Error(`Boolean policy '${this.name}' cannot be rendered in Profile Manifest.`);
+    renderProfileManifestValue(translations) {
+        return `<key>pfm_default</key>
+<false/>
+<key>pfm_description</key>
+<string>${renderProfileString(this.name, this.moduleName, this.description, translations)}</string>
+<key>pfm_name</key>
+<string>${this.name}</string>
+<key>pfm_title</key>
+<string>${this.name}</string>
+<key>pfm_type</key>
+<string>boolean</string>`;
     }
 }
 class ParseError extends Error {
@@ -199,10 +208,19 @@ class StringPolicy extends BasePolicy {
         return `<textBox refId="${this.name}"><label>${this.name}:</label></textBox>`;
     }
     renderProfileValue() {
-        throw new Error(`String policy '${this.name}' cannot be rendered in Profile.`);
+        return `<string></string>`;
     }
-    renderProfileManifestValue(_) {
-        throw new Error(`String policy '${this.name}' cannot be rendered in Profile Manifest.`);
+    renderProfileManifestValue(translations) {
+        return `<key>pfm_default</key>
+<string></string>
+<key>pfm_description</key>
+<string>${renderProfileString(this.name, this.moduleName, this.description, translations)}</string>
+<key>pfm_name</key>
+<string>${this.name}</string>
+<key>pfm_title</key>
+<string>${this.name}</string>
+<key>pfm_type</key>
+<string>string</string>`;
     }
 }
 class ObjectPolicy extends BasePolicy {

--- a/build/lib/policies.js
+++ b/build/lib/policies.js
@@ -46,6 +46,19 @@ function renderADMLString(prefix, moduleName, nlsString, translations) {
     }
     return `<string id="${prefix}_${nlsString.nlsKey.replace(/\./g, '_')}">${value}</string>`;
 }
+function renderProfileString(_prefix, moduleName, nlsString, translations) {
+    let value;
+    if (translations) {
+        const moduleTranslations = translations[moduleName];
+        if (moduleTranslations) {
+            value = moduleTranslations[nlsString.nlsKey];
+        }
+    }
+    if (!value) {
+        value = nlsString.value;
+    }
+    return value;
+}
 class BasePolicy {
     type;
     name;
@@ -84,6 +97,14 @@ class BasePolicy {
     renderADMLPresentation() {
         return `<presentation id="${this.name}">${this.renderADMLPresentationContents()}</presentation>`;
     }
+    renderProfile() {
+        return [`<key>${this.name}</key>`, this.renderProfileValue()];
+    }
+    renderProfileManifest(translations) {
+        return `<dict>
+${this.renderProfileManifestValue(translations)}
+</dict>`;
+    }
 }
 class BooleanPolicy extends BasePolicy {
     static from(name, category, minimumVersion, description, moduleName, settingNode) {
@@ -105,6 +126,12 @@ class BooleanPolicy extends BasePolicy {
     }
     renderADMLPresentationContents() {
         return `<checkBox refId="${this.name}">${this.name}</checkBox>`;
+    }
+    renderProfileValue() {
+        throw new Error(`Boolean policy '${this.name}' cannot be rendered in Profile.`);
+    }
+    renderProfileManifestValue(_) {
+        throw new Error(`Boolean policy '${this.name}' cannot be rendered in Profile Manifest.`);
     }
 }
 class ParseError extends Error {
@@ -138,6 +165,21 @@ class NumberPolicy extends BasePolicy {
     renderADMLPresentationContents() {
         return `<decimalTextBox refId="${this.name}" defaultValue="${this.defaultValue}">${this.name}</decimalTextBox>`;
     }
+    renderProfileValue() {
+        return `<integer>${this.defaultValue}</integer>`;
+    }
+    renderProfileManifestValue(translations) {
+        return `<key>pfm_default</key>
+<integer>${this.defaultValue}</integer>
+<key>pfm_description</key>
+<string>${renderProfileString(this.name, this.moduleName, this.description, translations)}</string>
+<key>pfm_name</key>
+<string>${this.name}</string>
+<key>pfm_title</key>
+<string>${this.name}</string>
+<key>pfm_type</key>
+<string>integer</string>`;
+    }
 }
 class StringPolicy extends BasePolicy {
     static from(name, category, minimumVersion, description, moduleName, settingNode) {
@@ -156,6 +198,12 @@ class StringPolicy extends BasePolicy {
     renderADMLPresentationContents() {
         return `<textBox refId="${this.name}"><label>${this.name}:</label></textBox>`;
     }
+    renderProfileValue() {
+        throw new Error(`String policy '${this.name}' cannot be rendered in Profile.`);
+    }
+    renderProfileManifestValue(_) {
+        throw new Error(`String policy '${this.name}' cannot be rendered in Profile Manifest.`);
+    }
 }
 class ObjectPolicy extends BasePolicy {
     static from(name, category, minimumVersion, description, moduleName, settingNode) {
@@ -173,6 +221,22 @@ class ObjectPolicy extends BasePolicy {
     }
     renderADMLPresentationContents() {
         return `<multiTextBox refId="${this.name}" />`;
+    }
+    renderProfileValue() {
+        return `<string></string>`;
+    }
+    renderProfileManifestValue(translations) {
+        return `<key>pfm_default</key>
+<string></string>
+<key>pfm_description</key>
+<string>${renderProfileString(this.name, this.moduleName, this.description, translations)}</string>
+<key>pfm_name</key>
+<string>${this.name}</string>
+<key>pfm_title</key>
+<string>${this.name}</string>
+<key>pfm_type</key>
+<string>string</string>
+`;
     }
 }
 class StringEnumPolicy extends BasePolicy {
@@ -219,6 +283,25 @@ class StringEnumPolicy extends BasePolicy {
     }
     renderADMLPresentationContents() {
         return `<dropdownList refId="${this.name}" />`;
+    }
+    renderProfileValue() {
+        return `<string>${this.enum_[0]}</string>`;
+    }
+    renderProfileManifestValue(translations) {
+        return `<key>pfm_default</key>
+<string>${this.enum_[0]}</string>
+<key>pfm_description</key>
+<string>${renderProfileString(this.name, this.moduleName, this.description, translations)}</string>
+<key>pfm_name</key>
+<string>${this.name}</string>
+<key>pfm_title</key>
+<string>${this.name}</string>
+<key>pfm_type</key>
+<string>string</string>
+<key>pfm_range_list</key>
+<array>
+	${this.enum_.map(e => `<string>${e}</string>`).join('\n	')}
+</array>`;
     }
 }
 const NumberQ = {
@@ -425,6 +508,191 @@ function renderADML(appName, versions, categories, policies, translations) {
 </policyDefinitionResources>
 `;
 }
+function renderProfileManifest(appName, bundleIdentifier, _versions, _categories, policies, translations) {
+    const requiredPayloadFields = `
+		<dict>
+			<key>pfm_default</key>
+			<string>Configure ${appName}</string>
+			<key>pfm_name</key>
+			<string>PayloadDescription</string>
+			<key>pfm_title</key>
+			<string>Payload Description</string>
+			<key>pfm_type</key>
+			<string>string</string>
+		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<string>${appName}</string>
+			<key>pfm_name</key>
+			<string>PayloadDisplayName</string>
+			<key>pfm_require</key>
+			<string>always</string>
+			<key>pfm_title</key>
+			<string>Payload Display Name</string>
+			<key>pfm_type</key>
+			<string>string</string>
+		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<string>${bundleIdentifier}</string>
+			<key>pfm_name</key>
+			<string>PayloadIdentifier</string>
+			<key>pfm_require</key>
+			<string>always</string>
+			<key>pfm_title</key>
+			<string>Payload Identifier</string>
+			<key>pfm_type</key>
+			<string>string</string>
+		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<string>${bundleIdentifier}</string>
+			<key>pfm_name</key>
+			<string>PayloadType</string>
+			<key>pfm_require</key>
+			<string>always</string>
+			<key>pfm_title</key>
+			<string>Payload Type</string>
+			<key>pfm_type</key>
+			<string>string</string>
+		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<string></string>
+			<key>pfm_name</key>
+			<string>PayloadUUID</string>
+			<key>pfm_require</key>
+			<string>always</string>
+			<key>pfm_title</key>
+			<string>Payload UUID</string>
+			<key>pfm_type</key>
+			<string>string</string>
+		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<integer>1</integer>
+			<key>pfm_name</key>
+			<string>PayloadVersion</string>
+			<key>pfm_range_list</key>
+			<array>
+				<integer>1</integer>
+			</array>
+			<key>pfm_require</key>
+			<string>always</string>
+			<key>pfm_title</key>
+			<string>Payload Version</string>
+			<key>pfm_type</key>
+			<string>integer</string>
+		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<string>Microsoft</string>
+			<key>pfm_name</key>
+			<string>PayloadOrganization</string>
+			<key>pfm_title</key>
+			<string>Payload Organization</string>
+			<key>pfm_type</key>
+			<string>string</string>
+		</dict>`;
+    const profileManifestSubkeys = policies.map(policy => {
+        return policy.renderProfileManifest(translations);
+    }).join('');
+    return `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>pfm_app_url</key>
+    <string>https://code.visualstudio.com/</string>
+    <key>pfm_description</key>
+    <string>${appName} Managed Settings</string>
+    <key>pfm_documentation_url</key>
+    <string>https://code.visualstudio.com/docs/setup/enterprise</string>
+    <key>pfm_domain</key>
+    <string>${bundleIdentifier}</string>
+    <key>pfm_format_version</key>
+    <integer>1</integer>
+    <key>pfm_interaction</key>
+    <string>combined</string>
+    <key>pfm_last_modified</key>
+    <date>2025-02-14T10:00:00Z</date>
+    <key>pfm_platforms</key>
+    <array>
+        <string>macOS</string>
+    </array>
+    <key>pfm_subkeys</key>
+    <array>
+	${requiredPayloadFields}
+	${profileManifestSubkeys}
+    </array>
+    <key>pfm_title</key>
+    <string>${appName}</string>
+    <key>pfm_unique</key>
+    <true/>
+    <key>pfm_version</key>
+    <integer>1</integer>
+</dict>
+</plist>`;
+}
+function renderMacOSPolicy(policies, translations) {
+    const appName = product.nameLong;
+    const bundleIdentifier = product.darwinBundleIdentifier;
+    const payloadUUID = '9F957DE8-6596-4CD6-A54E-D3A20F2B1C37';
+    const contentUUID = '3AD1E08A-673E-4C62-AA68-D43ED8180249';
+    const versions = [...new Set(policies.map(p => p.minimumVersion)).values()].sort();
+    const categories = [...new Set(policies.map(p => p.category))];
+    const policyEntries = policies.map(policy => policy.renderProfile())
+        .flat()
+        .map(entry => `\t\t\t\t${entry}`)
+        .join('\n');
+    return {
+        profile: `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+	<dict>
+		<key>ConsentText</key>
+		<dict>
+			<key>default</key>
+			<string>This profile manages ${appName}. For more information see https://code.visualstudio.com/docs/setup/enterprise</string>
+		</dict>
+		<key>PayloadContent</key>
+		<array>
+			<dict>
+				<key>PayloadDisplayName</key>
+				<string>${appName}</string>
+				<key>PayloadIdentifier</key>
+				<string>${bundleIdentifier}.${contentUUID}</string>
+				<key>PayloadType</key>
+				<string>${bundleIdentifier}</string>
+				<key>PayloadUUID</key>
+				<string>${contentUUID}</string>
+				<key>PayloadVersion</key>
+				<integer>1</integer>
+${policyEntries}
+			</dict>
+		</array>
+		<key>PayloadDescription</key>
+		<string>https://code.visualstudio.com/docs/setup/enterprise</string>
+		<key>PayloadDisplayName</key>
+		<string>${appName}</string>
+		<key>PayloadIdentifier</key>
+		<string>${bundleIdentifier}</string>
+		<key>PayloadOrganization</key>
+		<string>Microsoft</string>
+		<key>PayloadType</key>
+		<string>Configuration</string>
+		<key>PayloadUUID</key>
+		<string>${payloadUUID}</string>
+		<key>PayloadVersion</key>
+		<integer>1</integer>
+		<key>TargetDeviceType</key>
+		<integer>5</integer>
+	</dict>
+</plist>`,
+        manifests: [{ languageId: 'en-us', contents: renderProfileManifest(appName, bundleIdentifier, versions, categories, policies) },
+            ...translations.map(({ languageId, languageTranslations }) => ({ languageId, contents: renderProfileManifest(appName, bundleIdentifier, versions, categories, policies, languageTranslations) }))
+        ]
+    };
+}
 function renderGP(policies, translations) {
     const appName = product.nameLong;
     const regKey = product.win32RegValueName;
@@ -540,14 +808,9 @@ async function getTranslations() {
     return await Promise.all(languageIds.map(languageId => getNLS(extensionGalleryServiceUrl, resourceUrlTemplate, languageId, version)
         .then(languageTranslations => ({ languageId, languageTranslations }))));
 }
-async function main() {
-    const [policies, translations] = await Promise.all([parsePolicies(), getTranslations()]);
-    console.log(`Found ${policies.length} policies:`);
-    for (const policy of policies) {
-        console.log(`- ${policy.name} (${policy.type})`);
-    }
-    const { admx, adml } = await renderGP(policies, translations);
+async function windowsMain(policies, translations) {
     const root = '.build/policies/win32';
+    const { admx, adml } = await renderGP(policies, translations);
     await fs_1.promises.rm(root, { recursive: true, force: true });
     await fs_1.promises.mkdir(root, { recursive: true });
     await fs_1.promises.writeFile(path_1.default.join(root, `${product.win32RegValueName}.admx`), admx.replace(/\r?\n/g, '\n'));
@@ -555,6 +818,36 @@ async function main() {
         const languagePath = path_1.default.join(root, languageId === 'en-us' ? 'en-us' : Languages[languageId]);
         await fs_1.promises.mkdir(languagePath, { recursive: true });
         await fs_1.promises.writeFile(path_1.default.join(languagePath, `${product.win32RegValueName}.adml`), contents.replace(/\r?\n/g, '\n'));
+    }
+}
+async function darwinMain(policies, translations) {
+    const bundleIdentifier = product.darwinBundleIdentifier;
+    if (!bundleIdentifier) {
+        throw new Error(`Missing required product information.`);
+    }
+    const root = '.build/policies/darwin';
+    const { profile, manifests } = await renderMacOSPolicy(policies, translations);
+    await fs_1.promises.rm(root, { recursive: true, force: true });
+    await fs_1.promises.mkdir(root, { recursive: true });
+    await fs_1.promises.writeFile(path_1.default.join(root, `${bundleIdentifier}.mobileconfig`), profile.replace(/\r?\n/g, '\n'));
+    for (const { languageId, contents } of manifests) {
+        const languagePath = path_1.default.join(root, languageId === 'en-us' ? 'en-us' : Languages[languageId]);
+        await fs_1.promises.mkdir(languagePath, { recursive: true });
+        await fs_1.promises.writeFile(path_1.default.join(languagePath, `${bundleIdentifier}.plist`), contents.replace(/\r?\n/g, '\n'));
+    }
+}
+async function main() {
+    const [policies, translations] = await Promise.all([parsePolicies(), getTranslations()]);
+    const platform = process.argv[2];
+    if (platform === 'darwin') {
+        await darwinMain(policies, translations);
+    }
+    else if (platform === 'win32') {
+        await windowsMain(policies, translations);
+    }
+    else {
+        console.error(`Usage: node build/lib/policies <darwin|win32>`);
+        process.exit(1);
     }
 }
 if (require.main === module) {

--- a/build/lib/policies.ts
+++ b/build/lib/policies.ts
@@ -48,7 +48,7 @@ interface Policy {
 	renderADMX(regKey: string): string[];
 	renderADMLStrings(translations?: LanguageTranslations): string[];
 	renderADMLPresentation(): string;
-	renderProfile(): string;
+	renderProfile(): string[];
 	// https://github.com/ProfileManifests/ProfileManifests/wiki/Manifest-Format
 	renderProfileManifest(translations?: LanguageTranslations): string;
 }
@@ -131,8 +131,7 @@ abstract class BasePolicy implements Policy {
 	protected abstract renderADMLPresentationContents(): string;
 
 	renderProfile() {
-		return `			<key>${this.name}</key>
-			${this.renderProfileValue()}`;
+		return [`<key>${this.name}</key>`, this.renderProfileValue()];
 	}
 
 	renderProfileManifest(translations?: LanguageTranslations): string {
@@ -351,7 +350,7 @@ class ObjectPolicy extends BasePolicy {
 	}
 
 	renderProfileValue(): string {
-		return `<string>${this.name}</string>`;
+		return `<string></string>`;
 	}
 
 	renderProfileManifestValue(translations?: LanguageTranslations): string {
@@ -852,9 +851,12 @@ function renderMacOSPolicy(policies: Policy[], translations: Translations) {
 	const versions = [...new Set(policies.map(p => p.minimumVersion)).values()].sort();
 	const categories = [...new Set(policies.map(p => p.category))];
 
-	const policyEntries = policies.map(policy => policy.renderProfile())
-		.filter(Boolean)
-		.join('\n');
+	const policyEntries =
+		policies.map(policy => policy.renderProfile())
+			.flat()
+			.map(entry => `\t\t\t\t${entry}`)
+			.join('\n');
+
 
 	return {
 		profile: `<?xml version="1.0" encoding="UTF-8"?>
@@ -879,7 +881,7 @@ function renderMacOSPolicy(policies: Policy[], translations: Translations) {
 				<string>${contentUUID}</string>
 				<key>PayloadVersion</key>
 				<integer>1</integer>
-				${policyEntries}
+${policyEntries}
 			</dict>
 		</array>
 		<key>PayloadDescription</key>

--- a/build/lib/policies.ts
+++ b/build/lib/policies.ts
@@ -799,7 +799,21 @@ function renderProfileManifest(appName: string, bundleIdentifier: string, _versi
 			<string>Payload Organization</string>
 			<key>pfm_type</key>
 			<string>string</string>
-		</dict>`;
+		</dict>
+		<dict>
+            <key>pfm_default</key>
+            <integer>5</integer>
+            <key>pfm_name</key>
+            <string>TargetDeviceType</string>
+            <key>pfm_title</key>
+            <string>Target Device Type</string>
+            <key>pfm_type</key>
+            <string>integer</string>
+            <key>pfm_range_list</key>
+            <array>
+                <integer>5</integer>
+            </array>
+        </dict>`;
 
 	const profileManifestSubkeys = policies.map(policy => {
 		return policy.renderProfileManifest(translations);
@@ -822,7 +836,7 @@ function renderProfileManifest(appName: string, bundleIdentifier: string, _versi
     <key>pfm_interaction</key>
     <string>combined</string>
     <key>pfm_last_modified</key>
-    <date>2025-02-14T10:00:00Z</date>
+    <date>${new Date().toISOString().replace(/\.\d+Z$/, 'Z')}</date>
     <key>pfm_platforms</key>
     <array>
         <string>macOS</string>
@@ -863,11 +877,6 @@ function renderMacOSPolicy(policies: Policy[], translations: Translations) {
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 	<dict>
-		<key>ConsentText</key>
-		<dict>
-			<key>default</key>
-			<string>This profile manages ${appName}. For more information see https://code.visualstudio.com/docs/setup/enterprise</string>
-		</dict>
 		<key>PayloadContent</key>
 		<array>
 			<dict>
@@ -885,7 +894,7 @@ ${policyEntries}
 			</dict>
 		</array>
 		<key>PayloadDescription</key>
-		<string>https://code.visualstudio.com/docs/setup/enterprise</string>
+		<string>This profile manages ${appName}. For more information see https://code.visualstudio.com/docs/setup/enterprise</string>
 		<key>PayloadDisplayName</key>
 		<string>${appName}</string>
 		<key>PayloadIdentifier</key>

--- a/build/lib/policies.ts
+++ b/build/lib/policies.ts
@@ -186,11 +186,20 @@ class BooleanPolicy extends BasePolicy {
 	}
 
 	renderProfileValue(): string {
-		throw new Error(`Boolean policy '${this.name}' cannot be rendered in Profile.`);
+		return `<false/>`;
 	}
 
-	renderProfileManifestValue(_?: LanguageTranslations): string {
-		throw new Error(`Boolean policy '${this.name}' cannot be rendered in Profile Manifest.`);
+	renderProfileManifestValue(translations?: LanguageTranslations): string {
+		return `<key>pfm_default</key>
+<false/>
+<key>pfm_description</key>
+<string>${renderProfileString(this.name, this.moduleName, this.description, translations)}</string>
+<key>pfm_name</key>
+<string>${this.name}</string>
+<key>pfm_title</key>
+<string>${this.name}</string>
+<key>pfm_type</key>
+<string>boolean</string>`;
 	}
 }
 
@@ -303,13 +312,21 @@ class StringPolicy extends BasePolicy {
 	}
 
 	renderProfileValue(): string {
-		throw new Error(`String policy '${this.name}' cannot be rendered in Profile.`);
+		return `<string></string>`;
 	}
 
-	renderProfileManifestValue(_?: LanguageTranslations): string {
-		throw new Error(`String policy '${this.name}' cannot be rendered in Profile Manifest.`);
+	renderProfileManifestValue(translations?: LanguageTranslations): string {
+		return `<key>pfm_default</key>
+<string></string>
+<key>pfm_description</key>
+<string>${renderProfileString(this.name, this.moduleName, this.description, translations)}</string>
+<key>pfm_name</key>
+<string>${this.name}</string>
+<key>pfm_title</key>
+<string>${this.name}</string>
+<key>pfm_type</key>
+<string>string</string>`;
 	}
-
 }
 
 class ObjectPolicy extends BasePolicy {

--- a/build/lib/policies.ts
+++ b/build/lib/policies.ts
@@ -862,8 +862,8 @@ function renderProfileManifest(appName: string, bundleIdentifier: string, _versi
 function renderMacOSPolicy(policies: Policy[], translations: Translations) {
 	const appName = product.nameLong;
 	const bundleIdentifier = product.darwinBundleIdentifier;
-	const payloadUUID = '9F957DE8-6596-4CD6-A54E-D3A20F2B1C37';
-	const contentUUID = '3AD1E08A-673E-4C62-AA68-D43ED8180249';
+	const payloadUUID = product.darwinProfilePayloadUUID;
+	const UUID = product.darwinProfileUUID;
 
 	const versions = [...new Set(policies.map(p => p.minimumVersion)).values()].sort();
 	const categories = [...new Set(policies.map(p => p.category))];
@@ -886,11 +886,11 @@ function renderMacOSPolicy(policies: Policy[], translations: Translations) {
 				<key>PayloadDisplayName</key>
 				<string>${appName}</string>
 				<key>PayloadIdentifier</key>
-				<string>${bundleIdentifier}.${contentUUID}</string>
+				<string>${bundleIdentifier}.${UUID}</string>
 				<key>PayloadType</key>
 				<string>${bundleIdentifier}</string>
 				<key>PayloadUUID</key>
-				<string>${contentUUID}</string>
+				<string>${UUID}</string>
 				<key>PayloadVersion</key>
 				<integer>1</integer>
 ${policyEntries}
@@ -1084,7 +1084,7 @@ async function windowsMain(policies: Policy[], translations: Translations) {
 
 async function darwinMain(policies: Policy[], translations: Translations) {
 	const bundleIdentifier = product.darwinBundleIdentifier;
-	if (!bundleIdentifier) {
+	if (!bundleIdentifier || !product.darwinProfilePayloadUUID || !product.darwinProfileUUID) {
 		throw new Error(`Missing required product information.`);
 	}
 	const root = '.build/policies/darwin';

--- a/build/lib/policies.ts
+++ b/build/lib/policies.ts
@@ -48,6 +48,9 @@ interface Policy {
 	renderADMX(regKey: string): string[];
 	renderADMLStrings(translations?: LanguageTranslations): string[];
 	renderADMLPresentation(): string;
+	renderProfile(): string;
+	// https://github.com/ProfileManifests/ProfileManifests/wiki/Manifest-Format
+	renderProfileManifest(translations?: LanguageTranslations): string;
 }
 
 function renderADMLString(prefix: string, moduleName: string, nlsString: NlsString, translations?: LanguageTranslations): string {
@@ -66,6 +69,24 @@ function renderADMLString(prefix: string, moduleName: string, nlsString: NlsStri
 	}
 
 	return `<string id="${prefix}_${nlsString.nlsKey.replace(/\./g, '_')}">${value}</string>`;
+}
+
+function renderProfileString(_prefix: string, moduleName: string, nlsString: NlsString, translations?: LanguageTranslations): string {
+	let value: string | undefined;
+
+	if (translations) {
+		const moduleTranslations = translations[moduleName];
+
+		if (moduleTranslations) {
+			value = moduleTranslations[nlsString.nlsKey];
+		}
+	}
+
+	if (!value) {
+		value = nlsString.value;
+	}
+
+	return value;
 }
 
 abstract class BasePolicy implements Policy {
@@ -108,6 +129,20 @@ abstract class BasePolicy implements Policy {
 	}
 
 	protected abstract renderADMLPresentationContents(): string;
+
+	renderProfile() {
+		return `			<key>${this.name}</key>
+			${this.renderProfileValue()}`;
+	}
+
+	renderProfileManifest(translations?: LanguageTranslations): string {
+		return `<dict>
+${this.renderProfileManifestValue(translations)}
+</dict>`;
+	}
+
+	abstract renderProfileValue(): string;
+	abstract renderProfileManifestValue(translations?: LanguageTranslations): string;
 }
 
 class BooleanPolicy extends BasePolicy {
@@ -149,6 +184,14 @@ class BooleanPolicy extends BasePolicy {
 
 	renderADMLPresentationContents() {
 		return `<checkBox refId="${this.name}">${this.name}</checkBox>`;
+	}
+
+	renderProfileValue(): string {
+		throw new Error(`Boolean policy '${this.name}' cannot be rendered in Profile.`);
+	}
+
+	renderProfileManifestValue(_?: LanguageTranslations): string {
+		throw new Error(`Boolean policy '${this.name}' cannot be rendered in Profile Manifest.`);
 	}
 }
 
@@ -204,6 +247,23 @@ class NumberPolicy extends BasePolicy {
 	renderADMLPresentationContents() {
 		return `<decimalTextBox refId="${this.name}" defaultValue="${this.defaultValue}">${this.name}</decimalTextBox>`;
 	}
+
+	renderProfileValue() {
+		return `<integer>${this.defaultValue}</integer>`;
+	}
+
+	renderProfileManifestValue(translations?: LanguageTranslations) {
+		return `<key>pfm_default</key>
+<integer>${this.defaultValue}</integer>
+<key>pfm_description</key>
+<string>${renderProfileString(this.name, this.moduleName, this.description, translations)}</string>
+<key>pfm_name</key>
+<string>${this.name}</string>
+<key>pfm_title</key>
+<string>${this.name}</string>
+<key>pfm_type</key>
+<string>integer</string>`;
+	}
 }
 
 class StringPolicy extends BasePolicy {
@@ -242,6 +302,15 @@ class StringPolicy extends BasePolicy {
 	renderADMLPresentationContents() {
 		return `<textBox refId="${this.name}"><label>${this.name}:</label></textBox>`;
 	}
+
+	renderProfileValue(): string {
+		throw new Error(`String policy '${this.name}' cannot be rendered in Profile.`);
+	}
+
+	renderProfileManifestValue(_?: LanguageTranslations): string {
+		throw new Error(`String policy '${this.name}' cannot be rendered in Profile Manifest.`);
+	}
+
 }
 
 class ObjectPolicy extends BasePolicy {
@@ -279,6 +348,24 @@ class ObjectPolicy extends BasePolicy {
 
 	renderADMLPresentationContents() {
 		return `<multiTextBox refId="${this.name}" />`;
+	}
+
+	renderProfileValue(): string {
+		return `<string>${this.name}</string>`;
+	}
+
+	renderProfileManifestValue(translations?: LanguageTranslations): string {
+		return `<key>pfm_default</key>
+<string></string>
+<key>pfm_description</key>
+<string>${renderProfileString(this.name, this.moduleName, this.description, translations)}</string>
+<key>pfm_name</key>
+<string>${this.name}</string>
+<key>pfm_title</key>
+<string>${this.name}</string>
+<key>pfm_type</key>
+<string>string</string>
+`;
 	}
 }
 
@@ -348,6 +435,27 @@ class StringEnumPolicy extends BasePolicy {
 
 	renderADMLPresentationContents() {
 		return `<dropdownList refId="${this.name}" />`;
+	}
+
+	renderProfileValue() {
+		return `<string>${this.enum_[0]}</string>`;
+	}
+
+	renderProfileManifestValue(translations?: LanguageTranslations): string {
+		return `<key>pfm_default</key>
+<string>${this.enum_[0]}</string>
+<key>pfm_description</key>
+<string>${renderProfileString(this.name, this.moduleName, this.description, translations)}</string>
+<key>pfm_name</key>
+<string>${this.name}</string>
+<key>pfm_title</key>
+<string>${this.name}</string>
+<key>pfm_type</key>
+<string>string</string>
+<key>pfm_range_list</key>
+<array>
+	${this.enum_.map(e => `<string>${e}</string>`).join('\n	')}
+</array>`;
 	}
 }
 
@@ -606,6 +714,199 @@ function renderADML(appName: string, versions: string[], categories: Category[],
 `;
 }
 
+function renderProfileManifest(appName: string, bundleIdentifier: string, _versions: string[], _categories: Category[], policies: Policy[], translations?: LanguageTranslations) {
+
+	const requiredPayloadFields = `
+		<dict>
+			<key>pfm_default</key>
+			<string>Configure ${appName}</string>
+			<key>pfm_name</key>
+			<string>PayloadDescription</string>
+			<key>pfm_title</key>
+			<string>Payload Description</string>
+			<key>pfm_type</key>
+			<string>string</string>
+		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<string>${appName}</string>
+			<key>pfm_name</key>
+			<string>PayloadDisplayName</string>
+			<key>pfm_require</key>
+			<string>always</string>
+			<key>pfm_title</key>
+			<string>Payload Display Name</string>
+			<key>pfm_type</key>
+			<string>string</string>
+		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<string>${bundleIdentifier}</string>
+			<key>pfm_name</key>
+			<string>PayloadIdentifier</string>
+			<key>pfm_require</key>
+			<string>always</string>
+			<key>pfm_title</key>
+			<string>Payload Identifier</string>
+			<key>pfm_type</key>
+			<string>string</string>
+		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<string>${bundleIdentifier}</string>
+			<key>pfm_name</key>
+			<string>PayloadType</string>
+			<key>pfm_require</key>
+			<string>always</string>
+			<key>pfm_title</key>
+			<string>Payload Type</string>
+			<key>pfm_type</key>
+			<string>string</string>
+		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<string></string>
+			<key>pfm_name</key>
+			<string>PayloadUUID</string>
+			<key>pfm_require</key>
+			<string>always</string>
+			<key>pfm_title</key>
+			<string>Payload UUID</string>
+			<key>pfm_type</key>
+			<string>string</string>
+		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<integer>1</integer>
+			<key>pfm_name</key>
+			<string>PayloadVersion</string>
+			<key>pfm_range_list</key>
+			<array>
+				<integer>1</integer>
+			</array>
+			<key>pfm_require</key>
+			<string>always</string>
+			<key>pfm_title</key>
+			<string>Payload Version</string>
+			<key>pfm_type</key>
+			<string>integer</string>
+		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<string>Microsoft</string>
+			<key>pfm_name</key>
+			<string>PayloadOrganization</string>
+			<key>pfm_title</key>
+			<string>Payload Organization</string>
+			<key>pfm_type</key>
+			<string>string</string>
+		</dict>`;
+
+	const profileManifestSubkeys = policies.map(policy => {
+		return policy.renderProfileManifest(translations);
+	}).join('');
+
+	return `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>pfm_app_url</key>
+    <string>https://code.visualstudio.com/</string>
+    <key>pfm_description</key>
+    <string>${appName} Managed Settings</string>
+    <key>pfm_documentation_url</key>
+    <string>https://code.visualstudio.com/docs/setup/enterprise</string>
+    <key>pfm_domain</key>
+    <string>${bundleIdentifier}</string>
+    <key>pfm_format_version</key>
+    <integer>1</integer>
+    <key>pfm_interaction</key>
+    <string>combined</string>
+    <key>pfm_last_modified</key>
+    <date>2025-02-14T10:00:00Z</date>
+    <key>pfm_platforms</key>
+    <array>
+        <string>macOS</string>
+    </array>
+    <key>pfm_subkeys</key>
+    <array>
+	${requiredPayloadFields}
+	${profileManifestSubkeys}
+    </array>
+    <key>pfm_title</key>
+    <string>${appName}</string>
+    <key>pfm_unique</key>
+    <true/>
+    <key>pfm_version</key>
+    <integer>1</integer>
+</dict>
+</plist>`;
+}
+
+function renderMacOSPolicy(policies: Policy[], translations: Translations) {
+	const appName = product.nameLong;
+	const bundleIdentifier = product.darwinBundleIdentifier;
+	const payloadUUID = '9F957DE8-6596-4CD6-A54E-D3A20F2B1C37';
+	const contentUUID = '3AD1E08A-673E-4C62-AA68-D43ED8180249';
+
+	const versions = [...new Set(policies.map(p => p.minimumVersion)).values()].sort();
+	const categories = [...new Set(policies.map(p => p.category))];
+
+	const policyEntries = policies.map(policy => policy.renderProfile())
+		.filter(Boolean)
+		.join('\n');
+
+	return {
+		profile: `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+	<dict>
+		<key>ConsentText</key>
+		<dict>
+			<key>default</key>
+			<string>This profile manages ${appName}. For more information see https://code.visualstudio.com/docs/setup/enterprise</string>
+		</dict>
+		<key>PayloadContent</key>
+		<array>
+			<dict>
+				<key>PayloadDisplayName</key>
+				<string>${appName}</string>
+				<key>PayloadIdentifier</key>
+				<string>${bundleIdentifier}.${contentUUID}</string>
+				<key>PayloadType</key>
+				<string>${bundleIdentifier}</string>
+				<key>PayloadUUID</key>
+				<string>${contentUUID}</string>
+				<key>PayloadVersion</key>
+				<integer>1</integer>
+				${policyEntries}
+			</dict>
+		</array>
+		<key>PayloadDescription</key>
+		<string>https://code.visualstudio.com/docs/setup/enterprise</string>
+		<key>PayloadDisplayName</key>
+		<string>${appName}</string>
+		<key>PayloadIdentifier</key>
+		<string>${bundleIdentifier}</string>
+		<key>PayloadOrganization</key>
+		<string>Microsoft</string>
+		<key>PayloadType</key>
+		<string>Configuration</string>
+		<key>PayloadUUID</key>
+		<string>${payloadUUID}</string>
+		<key>PayloadVersion</key>
+		<integer>1</integer>
+		<key>TargetDeviceType</key>
+		<integer>5</integer>
+	</dict>
+</plist>`,
+		manifests: [{ languageId: 'en-us', contents: renderProfileManifest(appName, bundleIdentifier, versions, categories, policies) },
+		...translations.map(({ languageId, languageTranslations }) =>
+			({ languageId, contents: renderProfileManifest(appName, bundleIdentifier, versions, categories, policies, languageTranslations) }))
+		]
+	};
+}
+
 function renderGP(policies: Policy[], translations: Translations) {
 	const appName = product.nameLong;
 	const regKey = product.win32RegValueName;
@@ -751,18 +1052,10 @@ async function getTranslations(): Promise<Translations> {
 	));
 }
 
-async function main() {
-	const [policies, translations] = await Promise.all([parsePolicies(), getTranslations()]);
-
-	console.log(`Found ${policies.length} policies:`);
-
-	for (const policy of policies) {
-		console.log(`- ${policy.name} (${policy.type})`);
-	}
-
+async function windowsMain(policies: Policy[], translations: Translations) {
+	const root = '.build/policies/win32';
 	const { admx, adml } = await renderGP(policies, translations);
 
-	const root = '.build/policies/win32';
 	await fs.rm(root, { recursive: true, force: true });
 	await fs.mkdir(root, { recursive: true });
 
@@ -773,6 +1066,33 @@ async function main() {
 		await fs.mkdir(languagePath, { recursive: true });
 		await fs.writeFile(path.join(languagePath, `${product.win32RegValueName}.adml`), contents.replace(/\r?\n/g, '\n'));
 	}
+}
+
+async function darwinMain(policies: Policy[], translations: Translations) {
+	const bundleIdentifier = product.darwinBundleIdentifier;
+	if (!bundleIdentifier) {
+		throw new Error(`Missing required product information.`);
+	}
+	const root = '.build/policies/darwin';
+	const { profile, manifests } = await renderMacOSPolicy(policies, translations);
+
+	await fs.rm(root, { recursive: true, force: true });
+	await fs.mkdir(root, { recursive: true });
+	await fs.writeFile(path.join(root, `${bundleIdentifier}.mobileconfig`), profile.replace(/\r?\n/g, '\n'));
+
+	for (const { languageId, contents } of manifests) {
+		const languagePath = path.join(root, languageId === 'en-us' ? 'en-us' : Languages[languageId as keyof typeof Languages]);
+		await fs.mkdir(languagePath, { recursive: true });
+		await fs.writeFile(path.join(languagePath, `${bundleIdentifier}.plist`), contents.replace(/\r?\n/g, '\n'));
+	}
+}
+
+async function main() {
+	const [policies, translations] = await Promise.all([parsePolicies(), getTranslations()]);
+	await Promise.all([
+		windowsMain(policies, translations),
+		darwinMain(policies, translations)
+	]);
 }
 
 if (require.main === module) {

--- a/build/lib/policies.ts
+++ b/build/lib/policies.ts
@@ -816,21 +816,7 @@ function renderProfileManifest(appName: string, bundleIdentifier: string, _versi
 			<string>Payload Organization</string>
 			<key>pfm_type</key>
 			<string>string</string>
-		</dict>
-		<dict>
-            <key>pfm_default</key>
-            <integer>5</integer>
-            <key>pfm_name</key>
-            <string>TargetDeviceType</string>
-            <key>pfm_title</key>
-            <string>Target Device Type</string>
-            <key>pfm_type</key>
-            <string>integer</string>
-            <key>pfm_range_list</key>
-            <array>
-                <integer>5</integer>
-            </array>
-        </dict>`;
+		</dict>`;
 
 	const profileManifestSubkeys = policies.map(policy => {
 		return policy.renderProfileManifest(translations);

--- a/build/lib/policies.ts
+++ b/build/lib/policies.ts
@@ -1089,10 +1089,16 @@ async function darwinMain(policies: Policy[], translations: Translations) {
 
 async function main() {
 	const [policies, translations] = await Promise.all([parsePolicies(), getTranslations()]);
-	await Promise.all([
-		windowsMain(policies, translations),
-		darwinMain(policies, translations)
-	]);
+	const platform = process.argv[2];
+
+	if (platform === 'darwin') {
+		await darwinMain(policies, translations);
+	} else if (platform === 'win32') {
+		await windowsMain(policies, translations);
+	} else {
+		console.error(`Usage: node build/lib/policies <darwin|win32>`);
+		process.exit(1);
+	}
 }
 
 if (require.main === module) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "code-oss-dev",
   "version": "1.99.0",
-  "distro": "034ea95a21e3eb734fd22bf565a1e2e80d62ea9b",
+  "distro": "c3ec5ba4852b5682b94358c92bf31484d2739db9",
   "author": {
     "name": "Microsoft Corporation"
   },

--- a/product.json
+++ b/product.json
@@ -25,6 +25,8 @@
 	"win32TunnelServiceMutex": "vscodeoss-tunnelservice",
 	"win32TunnelMutex": "vscodeoss-tunnel",
 	"darwinBundleIdentifier": "com.visualstudio.code.oss",
+	"darwinProfileUUID": "47827DD9-4734-49A0-AF80-7E19B11495CC",
+	"darwinProfilePayloadUUID": "CF808BE7-53F3-46C6-A7E2-7EDB98A5E959",
 	"linuxIconName": "code-oss",
 	"licenseFileName": "LICENSE.txt",
 	"reportIssueUrl": "https://github.com/microsoft/vscode/issues/new",


### PR DESCRIPTION
ref: https://github.com/microsoft/vscode/issues/148942

Generates a sample `.mobileconfig` profile, similar to how the ADMX file is generated for Windows. 

Also generates localized files following [this specification](https://github.com/ProfileManifests/ProfileManifests/wiki/Manifest-Format) to aid in producing customized `.mobileconfig` profiles.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

