### PR TITLE
chat: fix diff not showing for streaming chat pills

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/chatContentParts.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/chatContentParts.ts
@@ -8,7 +8,7 @@ import { ChatTreeItem, IChatCodeBlockInfo } from '../chat.js';
 import { IChatRendererContent } from '../../common/chatViewModel.js';
 
 export interface IChatContentPart extends IDisposable {
-	domNode: HTMLElement;
+	domNode: HTMLElement | undefined;
 
 	/**
 	 * Used to indicate a part's ownership of a code block.


### PR DESCRIPTION
The addition of `typesToSkip` broke because the code pill looks back for
the last undo stop to know what to diff between. See:
https://github.com/microsoft/vscode-copilot/issues/13229#issuecomment-2679994707

This gets rid of that, and instead allows IChatContentPart to choose
not to render a domNode. We can then 'render' undo stops without
side-effects and fix the issue. This is kind of special but I feel like
this is the cleanest way to do things now, and I can imagine other parts
might use this in the future.

Fixes https://github.com/microsoft/vscode-copilot/issues/13229

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
