### PR TITLE
ensure window title is updated (considered custom) when in screen reader mode

### DIFF
--- a/src/vs/workbench/browser/parts/titlebar/windowTitle.ts
+++ b/src/vs/workbench/browser/parts/titlebar/windowTitle.ts
@@ -413,6 +413,11 @@ export class WindowTitle extends Disposable {
 	}
 
 	isCustomTitleFormat(): boolean {
+		if (this.accessibilityService.isScreenReaderOptimized()) {
+			// We add activeEditorState by default when screen reader optimized,
+			// make sure that gets applied
+			return true;
+		}
 		const title = this.configurationService.inspect<string>(WindowSettingNames.title);
 		const titleSeparator = this.configurationService.inspect<string>(WindowSettingNames.titleSeparator);
 


### PR DESCRIPTION
We need to make sure the window title is updated when in screen reader mode

https://github.com/microsoft/vscode/blob/ae78db39cd1f64ae22a52c141c64663f72c8dd17/src/vs/workbench/browser/parts/titlebar/commandCenterControl.ts#L184-L186

fixes #241848
fixes #241882
