### PR TITLE
hover - render focus border for beak

### DIFF
--- a/src/vs/editor/browser/services/hoverService/hover.css
+++ b/src/vs/editor/browser/services/hoverService/hover.css
@@ -33,12 +33,8 @@
 .monaco-workbench .workbench-hover-container.locked .workbench-hover {
 	outline: 1px solid var(--vscode-editorHoverWidget-border);
 }
-.monaco-workbench .workbench-hover-container.locked .workbench-hover:focus,
-.monaco-workbench .workbench-hover-lock:focus {
+.monaco-workbench .workbench-hover-container.locked .workbench-hover:focus {
 	outline: 1px solid var(--vscode-focusBorder);
-}
-.monaco-workbench .workbench-hover-container.locked .workbench-hover-lock:hover {
-	background: var(--vscode-toolbar-hoverBackground);
 }
 
 .monaco-workbench .workbench-hover-pointer {
@@ -62,6 +58,8 @@
 	height: 4px;
 	border-right-width: 2px;
 	border-bottom-width: 2px;
+	border-right: 1px solid var(--vscode-focusBorder);
+	border-bottom: 1px solid var(--vscode-focusBorder);
 }
 
 .monaco-workbench .workbench-hover-pointer.left   { left: -3px; }


### PR DESCRIPTION
fyi @Tyriar @benibenj 

Before:

<img width="216" alt="image" src="https://github.com/user-attachments/assets/2f48d210-850b-43fb-8e7a-65392bec2ec7" />

After:

<img width="389" alt="image" src="https://github.com/user-attachments/assets/8606089e-d2e1-46b1-b802-3b6421e79beb" />

Idea from @mrleemurray 