### PR TITLE
Fix ghost text view clickability

### DIFF
--- a/src/vs/editor/contrib/inlineCompletions/browser/view/ghostText/ghostTextView.css
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/ghostText/ghostTextView.css
@@ -33,6 +33,8 @@
 	z-index: 1;
 }
 
+.monaco-editor .ghost-text-decoration.clickable,
+.monaco-editor .ghost-text-decoration-preview.clickable,
 .monaco-editor .suggest-preview-text.clickable .ghost-text {
 	cursor: pointer;
 }

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/ghostText/ghostTextView.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/ghostText/ghostTextView.ts
@@ -224,7 +224,10 @@ export class GhostTextView extends Disposable {
 					after: {
 						content: p.text,
 						tokens: p.tokens,
-						inlineClassName: p.preview ? 'ghost-text-decoration-preview' : 'ghost-text-decoration' + extraClassNames + p.lineDecorations.map(d => ' ' + d.className).join(' '), // TODO: take the ranges into account for line decorations
+						inlineClassName: (p.preview ? 'ghost-text-decoration-preview' : 'ghost-text-decoration')
+							+ (this._isClickable ? ' clickable' : '')
+							+ extraClassNames
+							+ p.lineDecorations.map(d => ' ' + d.className).join(' '), // TODO: take the ranges into account for line decorations
 						cursorStops: InjectedTextCursorStops.Left,
 						attachedData: new GhostTextAttachedData(),
 					},


### PR DESCRIPTION
```Copilot Generated Description:``` Enhance the ghost text view to support clickability by adding a clickable class to the appropriate elements.