### PR TITLE
Update C# onEnterRules to account for documentation comments

### DIFF
--- a/extensions/csharp/language-configuration.json
+++ b/extensions/csharp/language-configuration.json
@@ -84,9 +84,10 @@
 	},
 	"onEnterRules": [
 		// Add // when pressing enter from inside line comment
+		// We do not want to match /// (a documentation comment)
 		{
 			"beforeText": {
-				"pattern": "\/\/.*"
+				"pattern": "[^\/]\/\/[^\/].*"
 			},
 			"afterText": {
 				"pattern": "^(?!\\s*$).+"
@@ -94,6 +95,17 @@
 			"action": {
 				"indent": "none",
 				"appendText": "// "
+			}
+		},
+		// Add /// when pressing enter from anywhere inside a documentation comment.
+		// Documentation comments are not valid after non-whitespace.
+		{
+			"beforeText": {
+				"pattern": "^\\s*\/\/\/"
+			},
+			"action": {
+				"indent": "none",
+				"appendText": "/// "
 			}
 		},
 	]


### PR DESCRIPTION
Resolves https://github.com/dotnet/vscode-csharp/issues/8025

A couple months ago it looks like, an onEnter rule was added to 'continue' a comment if enter is pressed inside a line comment.  This is generally fine, however it causes problems when writing documentation comments which use `///` instead.  You end up with something like the following (see also video in linked issue):
```
/// <summary>
/// This is a documentation 
// comment
/// </summary>
```

This PR modifies the line comment enter rule to avoid inserting the line comment if it detects a triple comment.

Additionally, I added an on enter rule for `///` to auto insert `///` when hitting enter anywhere inside a documentation comment.  Currently that is handled in the server side of the C# extension, but it can be slow and finicky.  Better to just have the client handle it via an on enter rule.

This shows the new behavior:
![on_enter_rules_new](https://github.com/user-attachments/assets/e3a89128-c40a-4d61-9151-97fc8b82761c)

