### PR TITLE
chat: add #problems reference to core

### DIFF
--- a/src/vs/platform/severityIcon/browser/media/severityIcon.css
+++ b/src/vs/platform/severityIcon/browser/media/severityIcon.css
@@ -8,7 +8,8 @@
 .text-search-provider-messages .providerMessage .codicon.codicon-error,
 .extensions-viewlet > .extensions .codicon.codicon-error,
 .extension-editor .codicon.codicon-error,
-.preferences-editor .codicon.codicon-error {
+.preferences-editor .codicon.codicon-error,
+.chat-attached-context-attachment .codicon.codicon-error {
 	color: var(--vscode-problemsErrorIcon-foreground);
 }
 

--- a/src/vs/workbench/contrib/chat/browser/actions/chatContextActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatContextActions.ts
@@ -852,7 +852,7 @@ export class AttachContextAction extends Action2 {
 		});
 
 		const filter = await instantiationService.invokeFunction(accessor =>
-			createMarkersQuickPick(accessor, items => onBackgroundAccept(items.map(convert))));
+			createMarkersQuickPick(accessor, 'problem', items => onBackgroundAccept(items.map(convert))));
 		return filter && convert(filter);
 	}
 

--- a/src/vs/workbench/contrib/chat/browser/chatDragAndDrop.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatDragAndDrop.ts
@@ -383,10 +383,7 @@ export class ChatDragAndDrop extends Themable {
 				filter = IDiagnosticVariableEntryFilterData.fromMarker(marker);
 			}
 
-			return {
-				...IDiagnosticVariableEntryFilterData.toEntry(filter),
-				...filter,
-			};
+			return IDiagnosticVariableEntryFilterData.toEntry(filter);
 		});
 	}
 

--- a/src/vs/workbench/contrib/chat/browser/chatVariables.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatVariables.ts
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { coalesce } from '../../../../base/common/arrays.js';
-import { ThemeIcon } from '../../../../base/common/themables.js';
 import { URI } from '../../../../base/common/uri.js';
 import { Location } from '../../../../editor/common/languages.js';
 import { IViewsService } from '../../../services/views/common/viewsService.js';
@@ -29,10 +28,8 @@ export class ChatVariablesService implements IChatVariablesService {
 
 		prompt.parts
 			.forEach((part, i) => {
-				if (part instanceof ChatRequestDynamicVariablePart) {
-					resolvedVariables[i] = { id: part.id, name: part.referenceText, range: part.range, value: part.data, fullName: part.fullName, icon: part.icon, isFile: part.isFile, isDirectory: part.isDirectory };
-				} else if (part instanceof ChatRequestToolPart) {
-					resolvedVariables[i] = { id: part.toolId, name: part.toolName, range: part.range, value: undefined, isTool: true, icon: ThemeIcon.isThemeIcon(part.icon) ? part.icon : undefined, fullName: part.displayName };
+				if (part instanceof ChatRequestDynamicVariablePart || part instanceof ChatRequestToolPart) {
+					resolvedVariables[i] = part.toVariableEntry();
 				}
 			});
 

--- a/src/vs/workbench/contrib/chat/common/chatModel.ts
+++ b/src/vs/workbench/contrib/chat/common/chatModel.ts
@@ -104,7 +104,7 @@ export interface IDiagnosticVariableEntryFilterData {
 }
 
 export namespace IDiagnosticVariableEntryFilterData {
-	export const icon = Codicon.warning;
+	export const icon = Codicon.error;
 
 	export function fromMarker(marker: IMarker): IDiagnosticVariableEntryFilterData {
 		return {
@@ -115,7 +115,7 @@ export namespace IDiagnosticVariableEntryFilterData {
 		};
 	}
 
-	export function toEntry(data: IDiagnosticVariableEntryFilterData) {
+	export function toEntry(data: IDiagnosticVariableEntryFilterData): IDiagnosticVariableEntry {
 		return {
 			id: id(data),
 			name: label(data),
@@ -123,6 +123,7 @@ export namespace IDiagnosticVariableEntryFilterData {
 			value: data,
 			kind: 'diagnostic' as const,
 			range: data.filterRange ? new OffsetRange(data.filterRange.startLineNumber, data.filterRange.endLineNumber) : undefined,
+			...data,
 		};
 	}
 

--- a/src/vs/workbench/contrib/chat/common/chatParserTypes.ts
+++ b/src/vs/workbench/contrib/chat/common/chatParserTypes.ts
@@ -8,8 +8,9 @@ import { ThemeIcon } from '../../../../base/common/themables.js';
 import { IOffsetRange, OffsetRange } from '../../../../editor/common/core/offsetRange.js';
 import { IRange } from '../../../../editor/common/core/range.js';
 import { ChatAgentLocation, IChatAgentCommand, IChatAgentData, IChatAgentService, reviveSerializedAgent } from './chatAgents.js';
+import { IChatRequestVariableEntry, IDiagnosticVariableEntryFilterData } from './chatModel.js';
 import { IChatSlashData } from './chatSlashCommands.js';
-import { IChatRequestVariableValue } from './chatVariables.js';
+import { IChatRequestProblemsVariable, IChatRequestVariableValue } from './chatVariables.js';
 import { IToolData } from './languageModelToolsService.js';
 
 // These are in a separate file to avoid circular dependencies with the dependencies of the parser
@@ -84,6 +85,10 @@ export class ChatRequestToolPart implements IParsedChatRequestPart {
 	get promptText(): string {
 		return this.text;
 	}
+
+	toVariableEntry(): IChatRequestVariableEntry {
+		return { id: this.toolId, name: this.toolName, range: this.range, value: undefined, isTool: true, icon: ThemeIcon.isThemeIcon(this.icon) ? this.icon : undefined, fullName: this.displayName };
+	}
 }
 
 /**
@@ -151,6 +156,14 @@ export class ChatRequestDynamicVariablePart implements IParsedChatRequestPart {
 
 	get promptText(): string {
 		return this.text;
+	}
+
+	toVariableEntry(): IChatRequestVariableEntry {
+		if (this.id === 'vscode.problems') {
+			return IDiagnosticVariableEntryFilterData.toEntry((this.data as IChatRequestProblemsVariable).filter);
+		}
+
+		return { id: this.id, name: this.referenceText, range: this.range, value: this.data, fullName: this.fullName, icon: this.icon, isFile: this.isFile, isDirectory: this.isDirectory };
 	}
 }
 

--- a/src/vs/workbench/contrib/chat/common/chatVariables.ts
+++ b/src/vs/workbench/contrib/chat/common/chatVariables.ts
@@ -10,7 +10,7 @@ import { IRange } from '../../../../editor/common/core/range.js';
 import { Location } from '../../../../editor/common/languages.js';
 import { createDecorator } from '../../../../platform/instantiation/common/instantiation.js';
 import { ChatAgentLocation } from './chatAgents.js';
-import { IChatModel, IChatRequestVariableData, IChatRequestVariableEntry } from './chatModel.js';
+import { IChatModel, IChatRequestVariableData, IChatRequestVariableEntry, IDiagnosticVariableEntryFilterData } from './chatModel.js';
 import { IParsedChatRequest } from './chatParserTypes.js';
 import { IChatContentReference, IChatProgressMessage } from './chatService.js';
 
@@ -24,7 +24,15 @@ export interface IChatVariableData {
 	canTakeArgument?: boolean;
 }
 
-export type IChatRequestVariableValue = string | URI | Location | unknown | Uint8Array;
+export interface IChatRequestProblemsVariable {
+	id: 'vscode.problems';
+	filter: IDiagnosticVariableEntryFilterData;
+}
+
+export const isIChatRequestProblemsVariable = (obj: unknown): obj is IChatRequestProblemsVariable =>
+	typeof obj === 'object' && obj !== null && 'id' in obj && (obj as IChatRequestProblemsVariable).id === 'vscode.problems';
+
+export type IChatRequestVariableValue = string | URI | Location | unknown | Uint8Array | IChatRequestProblemsVariable;
 
 export type IChatVariableResolverProgress =
 	| IChatContentReference


### PR DESCRIPTION
- Users can reference #problems in core now
- It will ask the user to pick a file, or all files, when there's >1
  file with errors. ([demo](https://memes.peet.io/img/25-02-8fbc8580-5f13-4714-b9d3-231edb53bdf7.mp4))
- Tweaked the icon to match the error icon in the markers view

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
