### PR TITLE
Add ChatErrorLevel to ChatErrorDetails

### DIFF
--- a/src/vs/platform/extensions/common/extensionsApiProposals.ts
+++ b/src/vs/platform/extensions/common/extensionsApiProposals.ts
@@ -33,7 +33,7 @@ const _allApiProposals = {
 	},
 	chatParticipantPrivate: {
 		proposal: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.chatParticipantPrivate.d.ts',
-		version: 4
+		version: 5
 	},
 	chatProvider: {
 		proposal: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.chatProvider.d.ts',

--- a/src/vs/workbench/api/common/extHost.api.impl.ts
+++ b/src/vs/workbench/api/common/extHost.api.impl.ts
@@ -1806,6 +1806,7 @@ export function createApiFactoryAndRegisterActors(accessor: ServicesAccessor): I
 			TextSearchContext2: TextSearchContext2,
 			TextSearchMatch2: TextSearchMatch2,
 			TextSearchCompleteMessageTypeNew: TextSearchCompleteMessageType,
+			ChatErrorLevel: extHostTypes.ChatErrorLevel,
 		};
 	};
 }

--- a/src/vs/workbench/api/common/extHostTypes.ts
+++ b/src/vs/workbench/api/common/extHostTypes.ts
@@ -4750,6 +4750,12 @@ export class PreparedTerminalToolInvocation {
 	) { }
 }
 
+export enum ChatErrorLevel {
+	Info = 0,
+	Warning = 1,
+	Error = 2
+}
+
 export class LanguageModelChatMessage implements vscode.LanguageModelChatMessage {
 
 	static User(content: string | (LanguageModelTextPart | LanguageModelToolResultPart | LanguageModelToolCallPart)[], name?: string): LanguageModelChatMessage {

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/chatWarningContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/chatWarningContentPart.ts
@@ -11,6 +11,7 @@ import { Disposable } from '../../../../../base/common/lifecycle.js';
 import { MarkdownRenderer } from '../../../../../editor/browser/widget/markdownRenderer/browser/markdownRenderer.js';
 import { IChatContentPart } from './chatContentParts.js';
 import { IChatProgressRenderableResponseContent } from '../../common/chatModel.js';
+import { ChatErrorLevel } from '../../common/chatService.js';
 
 const $ = dom.$;
 
@@ -18,7 +19,7 @@ export class ChatWarningContentPart extends Disposable implements IChatContentPa
 	public readonly domNode: HTMLElement;
 
 	constructor(
-		kind: 'info' | 'warning' | 'error',
+		kind: ChatErrorLevel,
 		content: IMarkdownString,
 		renderer: MarkdownRenderer,
 	) {
@@ -28,15 +29,15 @@ export class ChatWarningContentPart extends Disposable implements IChatContentPa
 		let icon;
 		let iconClass;
 		switch (kind) {
-			case 'warning':
+			case ChatErrorLevel.Warning:
 				icon = Codicon.warning;
 				iconClass = '.chat-warning-codicon';
 				break;
-			case 'error':
+			case ChatErrorLevel.Error:
 				icon = Codicon.error;
 				iconClass = '.chat-error-codicon';
 				break;
-			case 'info':
+			case ChatErrorLevel.Info:
 				icon = Codicon.info;
 				iconClass = '.chat-info-codicon';
 				break;

--- a/src/vs/workbench/contrib/chat/browser/chatListRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatListRenderer.ts
@@ -47,7 +47,7 @@ import { ChatAgentLocation, IChatAgentMetadata } from '../common/chatAgents.js';
 import { ChatContextKeys } from '../common/chatContextKeys.js';
 import { IChatRequestVariableEntry, IChatTextEditGroup } from '../common/chatModel.js';
 import { chatSubcommandLeader } from '../common/chatParserTypes.js';
-import { ChatAgentVoteDirection, ChatAgentVoteDownReason, IChatConfirmation, IChatContentReference, IChatFollowup, IChatMarkdownContent, IChatTask, IChatToolInvocation, IChatToolInvocationSerialized, IChatTreeData, IChatUndoStop } from '../common/chatService.js';
+import { ChatAgentVoteDirection, ChatAgentVoteDownReason, ChatErrorLevel, IChatConfirmation, IChatContentReference, IChatFollowup, IChatMarkdownContent, IChatTask, IChatToolInvocation, IChatToolInvocationSerialized, IChatTreeData, IChatUndoStop } from '../common/chatService.js';
 import { IChatCodeCitations, IChatReferences, IChatRendererContent, IChatRequestViewModel, IChatResponseViewModel, IChatWorkingProgress, isRequestVM, isResponseVM } from '../common/chatViewModel.js';
 import { getNWords } from '../common/chatWordCounter.js';
 import { CodeBlockModelCollection } from '../common/codeBlockModelCollection.js';
@@ -613,7 +613,8 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 				templateData.value.appendChild(renderedError.domNode);
 				templateData.elementDisposables.add(renderedError.onDidChangeHeight(() => this.updateItemHeight(templateData)));
 			} else {
-				const renderedError = this.instantiationService.createInstance(ChatWarningContentPart, element.errorDetails.responseIsFiltered ? 'info' : 'error', new MarkdownString(element.errorDetails.message), this.renderer);
+				const level = element.errorDetails.level ?? (element.errorDetails.responseIsFiltered ? ChatErrorLevel.Info : ChatErrorLevel.Error);
+				const renderedError = this.instantiationService.createInstance(ChatWarningContentPart, level, new MarkdownString(element.errorDetails.message), this.renderer);
 				templateData.elementDisposables.add(renderedError);
 				templateData.value.appendChild(renderedError.domNode);
 			}
@@ -882,7 +883,7 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 		} else if (content.kind === 'confirmation') {
 			return this.renderConfirmation(context, content, templateData);
 		} else if (content.kind === 'warning') {
-			return this.instantiationService.createInstance(ChatWarningContentPart, 'warning', content.content, this.renderer);
+			return this.instantiationService.createInstance(ChatWarningContentPart, ChatErrorLevel.Warning, content.content, this.renderer);
 		} else if (content.kind === 'markdownContent') {
 			return this.renderMarkdown(content, templateData, context);
 		} else if (content.kind === 'references') {

--- a/src/vs/workbench/contrib/chat/common/chatService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService.ts
@@ -28,12 +28,19 @@ export interface IChatRequest {
 	variables: Record<string, IChatRequestVariableValue[]>;
 }
 
+export enum ChatErrorLevel {
+	Info = 0,
+	Warning = 1,
+	Error = 2
+}
+
 export interface IChatResponseErrorDetails {
 	message: string;
 	responseIsIncomplete?: boolean;
 	responseIsFiltered?: boolean;
 	responseIsRedacted?: boolean;
 	isQuotaExceeded?: boolean;
+	level?: ChatErrorLevel;
 }
 
 export interface IChatResponseProgressFileTreeData {

--- a/src/vscode-dts/vscode.proposed.chatParticipantPrivate.d.ts
+++ b/src/vscode-dts/vscode.proposed.chatParticipantPrivate.d.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-// version: 4
+// version: 5
 
 declare module 'vscode' {
 
@@ -83,6 +83,12 @@ declare module 'vscode' {
 		supportIssueReporting?: boolean;
 	}
 
+	export enum ChatErrorLevel {
+		Info = 0,
+		Warning = 1,
+		Error = 2,
+	}
+
 	export interface ChatErrorDetails {
 		/**
 		 * If set to true, the message content is completely hidden. Only ChatErrorDetails#message will be shown.
@@ -90,6 +96,8 @@ declare module 'vscode' {
 		responseIsRedacted?: boolean;
 
 		isQuotaExceeded?: boolean;
+
+		level?: ChatErrorLevel;
 	}
 
 	export namespace chat {


### PR DESCRIPTION
We need this so that the error when the rate limit is exceeded can show as 'info' without having to set `responseIsFiltered`

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
