### PR TITLE
rename chatEdits.minimapColor to minimap.chatEditHighlight

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingModifiedFileEntry.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingModifiedFileEntry.ts
@@ -33,7 +33,7 @@ class AutoAcceptControl {
 	) { }
 }
 
-export const pendingRewriteMinimap = registerColor('chatEdits.minimapColor',
+export const pendingRewriteMinimap = registerColor('minimap.chatEditHighlight',
 	transparent(editorBackground, 0.6),
 	localize('editorSelectionBackground', "Color of pending edit regions in the minimap"));
 


### PR DESCRIPTION
For consisteny with the existing minimap colors: https://code.visualstudio.com/api/references/theme-color#minimap