### PR TITLE
`super` key modifier for the `use prompt` command

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/actions/chatAttachPromptAction/chatAttachPromptAction.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatAttachPromptAction/chatAttachPromptAction.ts
@@ -24,7 +24,7 @@ export const ATTACH_PROMPT_ACTION_ID = 'workbench.action.chat.attach.prompt';
  * Options for the {@link AttachPromptAction} action.
  */
 export interface IChatAttachPromptActionOptions extends Pick<
-	ISelectPromptOptions, 'resource' | 'widget'
+	ISelectPromptOptions, 'resource' | 'widget' | 'viewsService'
 > { }
 
 /**

--- a/src/vs/workbench/contrib/chat/browser/actions/chatAttachPromptAction/chatAttachPromptAction.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatAttachPromptAction/chatAttachPromptAction.ts
@@ -64,6 +64,7 @@ export class AttachPromptAction extends Action2 {
 				promptFiles,
 				labelService,
 				viewsService,
+				openerService,
 				quickInputService,
 			});
 	}

--- a/src/vs/workbench/contrib/chat/browser/actions/chatAttachPromptAction/dialogs/askToSelectPrompt.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatAttachPromptAction/dialogs/askToSelectPrompt.ts
@@ -181,15 +181,29 @@ const createPlaceholderText = (options: ISelectPromptOptions): string => {
 		'Select a prompt to use',
 	);
 
-	// if no widget reference is provided, add the note about
-	// the `alt`/`option` key modifier users can use
+	// if no widget reference is provided, add the note about `options`
+	// and `cmd` modifiers users can use to alter the command behavior
 	if (!widget) {
-		const key = (isWindows || isLinux) ? 'alt' : 'option';
+		const altOptionkey = (isWindows || isLinux) ? 'Alt' : 'Option';
 
-		text += ' ' + localize(
+		const altOptionModifierNote = localize(
 			'commands.prompts.use.select-dialog.alt-modifier-note',
-			'(hold `{0}` to use in Edits)',
-			key,
+			'{0}-key to use in Edits',
+			altOptionkey,
+		);
+
+		const cmdCtrlkey = (isWindows || isLinux) ? 'Ctrl' : 'Cmd';
+		const superModifierNote = localize(
+			'commands.prompts.use.select-dialog.super-modifier-note',
+			'{0}-key to open in editor',
+			cmdCtrlkey,
+		);
+
+		text += localize(
+			'commands.prompts.use.select-dialog.modifier-notes',
+			' (hold {0} or {1})',
+			altOptionModifierNote,
+			superModifierNote,
 		);
 	}
 

--- a/src/vs/workbench/contrib/chat/browser/actions/chatContextActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatContextActions.ts
@@ -615,7 +615,7 @@ export class AttachContextAction extends Action2 {
 					toAttach.push(convertBufferToScreenshotVariable(blob));
 				}
 			} else if (isPromptInstructionsQuickPickItem(pick)) {
-				const options: IChatAttachPromptActionOptions = { widget };
+				const options: IChatAttachPromptActionOptions = { widget, viewsService };
 				await commandService.executeCommand(ATTACH_PROMPT_ACTION_ID, options);
 			} else {
 				// Anything else is an attachment

--- a/src/vs/workbench/contrib/chat/browser/promptSyntax/contributions/usePromptCommand.ts
+++ b/src/vs/workbench/contrib/chat/browser/promptSyntax/contributions/usePromptCommand.ts
@@ -8,6 +8,7 @@ import { URI } from '../../../../../../base/common/uri.js';
 import { CHAT_CATEGORY } from '../../actions/chatActions.js';
 import { IChatWidget, IChatWidgetService } from '../../chat.js';
 import { KeyMod, KeyCode } from '../../../../../../base/common/keyCodes.js';
+import { IViewsService } from '../../../../../services/views/common/viewsService.js';
 import { isPromptFile } from '../../../../../../platform/prompts/common/constants.js';
 import { IEditorService } from '../../../../../services/editor/common/editorService.js';
 import { ICommandService } from '../../../../../../platform/commands/common/commands.js';
@@ -51,10 +52,12 @@ const command = async (
 	accessor: ServicesAccessor,
 ): Promise<void> => {
 	const commandService = accessor.get(ICommandService);
+	const viewsService = accessor.get(IViewsService);
 
 	const options: IChatAttachPromptActionOptions = {
 		resource: getActivePromptUri(accessor),
 		widget: getFocusedChatWidget(accessor),
+		viewsService,
 	};
 
 	await commandService.executeCommand(ATTACH_PROMPT_ACTION_ID, options);


### PR DESCRIPTION
For [#13636](https://github.com/microsoft/vscode-copilot/issues/13636) and [#13595](https://github.com/microsoft/vscode-copilot/issues/13595).

- adds `super` modifier support that allows to open a prompt file in editor
- updates the placeholder text with the new modifier info and for consistency with similar dialogs