### PR TITLE
Fix to respect environment reporting setting in fish 

### DIFF
--- a/src/vs/workbench/contrib/terminal/common/scripts/shellIntegration.fish
+++ b/src/vs/workbench/contrib/terminal/common/scripts/shellIntegration.fish
@@ -151,8 +151,8 @@ function __vsc_update_cwd --on-event fish_prompt
 	end
 end
 
-function __vsc_update_env --on-event fish_prompt
-	if test $__vscode_shell_env_reporting -eq 1
+if test "$__vscode_shell_env_reporting" = "1"
+	function __vsc_update_env --on-event fish_prompt
 		__vsc_esc EnvSingleStart 1
 		for line in (env)
 			set myVar (echo $line | awk -F= '{print $1}')

--- a/src/vs/workbench/contrib/terminal/common/scripts/shellIntegration.fish
+++ b/src/vs/workbench/contrib/terminal/common/scripts/shellIntegration.fish
@@ -21,6 +21,8 @@ and ! set --query VSCODE_SHELL_INTEGRATION
 or exit
 
 set --global VSCODE_SHELL_INTEGRATION 1
+set --global __vscode_shell_env_reporting $VSCODE_SHELL_ENV_REPORTING
+set -e VSCODE_SHELL_ENV_REPORTING
 
 # Apply any explicit path prefix (see #99878)
 # On fish, '$fish_user_paths' is always prepended to the PATH, for both login and non-login shells, so we need
@@ -150,13 +152,15 @@ function __vsc_update_cwd --on-event fish_prompt
 end
 
 function __vsc_update_env --on-event fish_prompt
-	__vsc_esc EnvSingleStart 1
-	for line in (env)
-		set myVar (echo $line | awk -F= '{print $1}')
-		set myVal (echo $line | awk -F= '{print $2}')
-		__vsc_esc EnvSingleEntry $myVar (__vsc_escape_value "$myVal")
+	if test $__vscode_shell_env_reporting -eq 1
+		__vsc_esc EnvSingleStart 1
+		for line in (env)
+			set myVar (echo $line | awk -F= '{print $1}')
+			set myVal (echo $line | awk -F= '{print $2}')
+			__vsc_esc EnvSingleEntry $myVar (__vsc_escape_value "$myVal")
+		end
+		__vsc_esc EnvSingleEnd
 	end
-	__vsc_esc EnvSingleEnd
 end
 
 # Sent at the start of the prompt.


### PR DESCRIPTION
Further resolves: https://github.com/microsoft/vscode/issues/241991

This will not send env info if user setting is off on fish, and respect the env reporting setting on fish just like we do for pwsh,bash,zsh. 