### PR TITLE
Improve help dialog wording for activeEditorState inclusion

### DIFF
--- a/src/vs/editor/common/standaloneStrings.ts
+++ b/src/vs/editor/common/standaloneStrings.ts
@@ -12,7 +12,8 @@ export namespace AccessibilityHelpNLS {
 	export const editableDiffEditor = nls.localize("editableDiffEditor", "You are in a pane of a diff editor.");
 	export const readonlyEditor = nls.localize("readonlyEditor", "You are in a read-only code editor.");
 	export const editableEditor = nls.localize("editableEditor", "You are in a code editor.");
-	export const activeEditorState = nls.localize("activeEditorState", "Get information about the active editor such as Modified, Problems, and more by setting activeEditorState as a part of the window.title setting.");
+	export const defaultWindowTitleIncludesEditorState = nls.localize("defaultWindowTitleIncludesEditorState", "activeEditorState - such as modified, problems, and more, is included as a part of the window.title setting by default. Disable it with accessibility.windowTitleOptimized.");
+	export const defaultWindowTitleExcludingEditorState = nls.localize("defaultWindowTitleExcludingEditorState", "activeEditorState - such as modified, problems, and more, is currently not included as a part of the window.title setting by default. Enable it with accessibility.windowTitleOptimized.");
 	export const toolbar = nls.localize("toolbar", "Around the workbench, when the screen reader announces you've landed in a toolbar, use narrow keys to navigate between the toolbar's actions.");
 	export const changeConfigToOnMac = nls.localize("changeConfigToOnMac", "Configure the application to be optimized for usage with a Screen Reader (Command+E).");
 	export const changeConfigToOnWinLinux = nls.localize("changeConfigToOnWinLinux", "Configure the application to be optimized for usage with a Screen Reader (Control+E).");

--- a/src/vs/workbench/contrib/accessibility/browser/editorAccessibilityHelp.ts
+++ b/src/vs/workbench/contrib/accessibility/browser/editorAccessibilityHelp.ts
@@ -20,6 +20,8 @@ import { NEW_UNTITLED_FILE_COMMAND_ID } from '../../files/browser/fileConstants.
 import { IAccessibleViewService, IAccessibleViewContentProvider, AccessibleViewProviderId, IAccessibleViewOptions, AccessibleViewType } from '../../../../platform/accessibility/browser/accessibleView.js';
 import { AccessibilityVerbositySettingId } from './accessibilityConfiguration.js';
 import { ctxHasEditorModification, ctxHasRequestInProgress } from '../../chat/browser/chatEditing/chatEditingEditorContextKeys.js';
+import { IAccessibilityService } from '../../../../platform/accessibility/common/accessibility.js';
+import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 
 export class EditorAccessibilityHelpContribution extends Disposable {
 	static ID: 'editorAccessibilityHelpContribution';
@@ -50,7 +52,9 @@ class EditorAccessibilityHelpProvider extends Disposable implements IAccessibleV
 	constructor(
 		private readonly _editor: ICodeEditor,
 		@IKeybindingService private readonly _keybindingService: IKeybindingService,
-		@IContextKeyService private readonly _contextKeyService: IContextKeyService
+		@IContextKeyService private readonly _contextKeyService: IContextKeyService,
+		@IAccessibilityService private readonly accessibilityService: IAccessibilityService,
+		@IConfigurationService private readonly _configurationService: IConfigurationService,
 	) {
 		super();
 	}
@@ -72,7 +76,11 @@ class EditorAccessibilityHelpProvider extends Disposable implements IAccessibleV
 				content.push(AccessibilityHelpNLS.editableEditor);
 			}
 		}
-		content.push(AccessibilityHelpNLS.activeEditorState);
+		if (this.accessibilityService.isScreenReaderOptimized() && this._configurationService.getValue('accessibility.windowTitleOptimized')) {
+			content.push(AccessibilityHelpNLS.defaultWindowTitleIncludesEditorState);
+		} else {
+			content.push(AccessibilityHelpNLS.defaultWindowTitleExcludingEditorState);
+		}
 		content.push(AccessibilityHelpNLS.toolbar);
 
 		const chatEditInfo = getChatEditInfo(this._keybindingService, this._contextKeyService, this._editor);


### PR DESCRIPTION
The help dialog now clearly indicates that `activeEditorState` is included by default in the window title setting and provides instructions on how to disable this feature. This is important because it is a big change for screen reader users, so we need to indicate clearly how to go back to the old behavior.

Fixes #242244