### PR TITLE
rename "global prompts" feature into "user prompts"

### DIFF
--- a/src/vs/platform/userDataSync/common/promptsSync/promptsSync.ts
+++ b/src/vs/platform/userDataSync/common/promptsSync/promptsSync.ts
@@ -34,7 +34,7 @@ export function parsePrompts(syncData: ISyncData): IStringDictionary<string> {
 }
 
 /**
- * Synchronizer class for the global prompt files.
+ * Synchronizer class for the "user" prompt files.
  * Adopted from {@link SnippetsSynchroniser}.
  */
 export class PromptsSynchronizer extends AbstractSynchroniser implements IUserDataSynchroniser {

--- a/src/vs/workbench/contrib/chat/browser/actions/chatAttachPromptAction/dialogs/askToSelectPrompt.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatAttachPromptAction/dialogs/askToSelectPrompt.ts
@@ -76,12 +76,6 @@ export const askToSelectPrompt = async (
 ): Promise<void> => {
 	const { promptFiles, resource, quickInputService, labelService } = options;
 
-	// a sanity check - this function must be used only if there are prompt files to show
-	assert(
-		promptFiles.length > 0,
-		'Prompt files list must not be empty.',
-	);
-
 	const fileOptions = promptFiles.map((promptFile) => {
 		return createPickItem(promptFile, labelService);
 	});

--- a/src/vs/workbench/contrib/chat/browser/actions/chatAttachPromptAction/dialogs/askToSelectPrompt.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatAttachPromptAction/dialogs/askToSelectPrompt.ts
@@ -76,8 +76,14 @@ export const askToSelectPrompt = async (
 ): Promise<void> => {
 	const { promptFiles, resource, quickInputService, labelService } = options;
 
-	const fileOptions = promptFiles.map(({ uri }) => {
-		return createPickItem(uri, labelService);
+	// a sanity check - this function must be used only if there are prompt files to show
+	assert(
+		promptFiles.length > 0,
+		'Prompt files list must not be empty.',
+	);
+
+	const fileOptions = promptFiles.map((promptFile) => {
+		return createPickItem(promptFile, labelService);
 	});
 
 	/**
@@ -98,7 +104,12 @@ export const askToSelectPrompt = async (
 		// the currently active prompt file is always available in the selection dialog,
 		// even if it is not included in the prompts list otherwise(from location setting)
 		if (!activeItem) {
-			activeItem = createPickItem(resource, labelService);
+			activeItem = createPickItem({
+				uri: resource,
+				// "user" prompts are always registered in the prompts list, hence it
+				// should be safe to assume that `resource` is not "user" prompt here
+				type: 'local',
+			}, labelService);
 			fileOptions.push(activeItem);
 		}
 
@@ -191,16 +202,30 @@ export const askToSelectPrompt = async (
  * Creates a quick pick item for a prompt.
  */
 const createPickItem = (
-	uri: URI,
+	promptFile: IPromptPath,
 	labelService: ILabelService,
 ): WithUriValue<IQuickPickItem> => {
+	const { uri, type } = promptFile;
 	const fileWithoutExtension = getCleanPromptName(uri);
+
+	// if a "user" prompt, don't show its filesystem path in
+	// the user interface, but do that for all the "local" ones
+	const description = (type === 'user')
+		? localize(
+			'user-prompt.capitalized',
+			'User prompt',
+		)
+		: labelService.getUriLabel(dirname(uri), { relative: true });
+
+	const tooltip = (type === 'user')
+		? description
+		: uri.fsPath;
 
 	return {
 		type: 'item',
 		label: fileWithoutExtension,
-		description: labelService.getUriLabel(dirname(uri), { relative: true }),
-		tooltip: uri.fsPath,
+		description,
+		tooltip,
 		value: uri,
 		id: uri.toString(),
 	};

--- a/src/vs/workbench/contrib/chat/browser/promptSyntax/contributions/createPromptCommand/createPromptCommand.ts
+++ b/src/vs/workbench/contrib/chat/browser/promptSyntax/contributions/createPromptCommand/createPromptCommand.ts
@@ -30,9 +30,9 @@ const BASE_COMMAND_ID = 'workbench.command.prompts.create';
 const LOCAL_COMMAND_ID = `${BASE_COMMAND_ID}.local`;
 
 /**
- * Command ID for creating a 'global' prompt.
+ * Command ID for creating a 'user' prompt.
  */
-const GLOBAL_COMMAND_ID = `${BASE_COMMAND_ID}.global`;
+const USER_COMMAND_ID = `${BASE_COMMAND_ID}.user`;
 
 /**
  * Title of the 'create local prompt' command.
@@ -40,9 +40,9 @@ const GLOBAL_COMMAND_ID = `${BASE_COMMAND_ID}.global`;
 const LOCAL_COMMAND_TITLE = localize('commands.prompts.create.title.local', "Create Prompt");
 
 /**
- * Title of the 'create global prompt' command.
+ * Title of the 'create user prompt' command.
  */
-const GLOBAL_COMMAND_TITLE = localize('commands.prompts.create.title.global', "Create Global Prompt");
+const USER_COMMAND_TITLE = localize('commands.prompts.create.title.user', "Create User Prompt");
 
 /**
  * The command implementation.
@@ -95,7 +95,7 @@ const command = async (
 /**
  * Factory for creating the command handler with specific prompt `type`.
  */
-const commandFactory = (type: 'local' | 'global') => {
+const commandFactory = (type: 'local' | 'user') => {
 	return async (accessor: ServicesAccessor): Promise<void> => {
 		return command(accessor, type);
 	};
@@ -111,12 +111,12 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 });
 
 /**
- * Register the "Create Global Prompt" command.
+ * Register the "Create User Prompt" command.
  */
 KeybindingsRegistry.registerCommandAndKeybindingRule({
-	id: GLOBAL_COMMAND_ID,
+	id: USER_COMMAND_ID,
 	weight: KeybindingWeight.WorkbenchContrib,
-	handler: commandFactory('global'),
+	handler: commandFactory('user'),
 });
 
 /**
@@ -131,12 +131,12 @@ appendToCommandPalette(
 );
 
 /**
- * Register the "Create Global Prompt" command in the command palette.
+ * Register the "Create User Prompt" command in the command palette.
  */
 appendToCommandPalette(
 	{
-		id: GLOBAL_COMMAND_ID,
-		title: GLOBAL_COMMAND_TITLE,
+		id: USER_COMMAND_ID,
+		title: USER_COMMAND_TITLE,
 		category: CHAT_CATEGORY,
 	},
 );

--- a/src/vs/workbench/contrib/chat/browser/promptSyntax/contributions/createPromptCommand/dialogs/askForPromptName.ts
+++ b/src/vs/workbench/contrib/chat/browser/promptSyntax/contributions/createPromptCommand/dialogs/askForPromptName.ts
@@ -11,7 +11,7 @@ import { IQuickInputService } from '../../../../../../../../platform/quickinput/
  * Asks the user for a prompt name.
  */
 export const askForPromptName = async (
-	_type: 'local' | 'global',
+	_type: 'local' | 'user',
 	quickInputService: IQuickInputService,
 ): Promise<string | undefined> => {
 	const result = await quickInputService.input(

--- a/src/vs/workbench/contrib/chat/browser/promptSyntax/contributions/createPromptCommand/dialogs/askForPromptSourceFolder.ts
+++ b/src/vs/workbench/contrib/chat/browser/promptSyntax/contributions/createPromptCommand/dialogs/askForPromptSourceFolder.ts
@@ -21,7 +21,7 @@ interface IAskForFolderOptions {
 	/**
 	 * Prompt type.
 	 */
-	readonly type: 'local' | 'global';
+	readonly type: 'local' | 'user';
 
 	readonly labelService: ILabelService;
 	readonly openerService: IOpenerService;

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsService.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsService.ts
@@ -82,11 +82,11 @@ export class PromptsService extends Disposable implements IPromptsService {
 	}
 
 	public async listPromptFiles(): Promise<readonly IPromptPath[]> {
-		const globalLocations = [this.userDataService.currentProfile.promptsHome];
+		const userLocations = [this.userDataService.currentProfile.promptsHome];
 
 		const prompts = await Promise.all([
-			this.fileLocator.listFilesIn(globalLocations, [])
-				.then(withType('global')),
+			this.fileLocator.listFilesIn(userLocations, [])
+				.then(withType('user')),
 			this.fileLocator.listFiles([])
 				.then(withType('local')),
 		]);
@@ -100,11 +100,11 @@ export class PromptsService extends Disposable implements IPromptsService {
 		// sanity check to make sure we don't miss a new prompt type
 		// added in the future
 		assert(
-			type === 'local' || type === 'global',
+			type === 'local' || type === 'user',
 			`Unknown prompt type '${type}'.`,
 		);
 
-		const prompts = (type === 'global')
+		const prompts = (type === 'user')
 			? [this.userDataService.currentProfile.promptsHome]
 			: this.fileLocator.getConfigBasedSourceFolders();
 
@@ -116,7 +116,7 @@ export class PromptsService extends Disposable implements IPromptsService {
  * Utility to add a provided prompt `type` to a prompt URI.
  */
 const addType = (
-	type: 'local' | 'global',
+	type: 'local' | 'user',
 ): (uri: URI) => IPromptPath => {
 	return (uri) => {
 		return { uri, type: type };
@@ -127,7 +127,7 @@ const addType = (
  * Utility to add a provided prompt `type` to a list of prompt URIs.
  */
 const withType = (
-	type: 'local' | 'global',
+	type: 'local' | 'user',
 ): (uris: readonly URI[]) => (readonly IPromptPath[]) => {
 	return (uris) => {
 		return uris

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/service/types.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/service/types.ts
@@ -17,9 +17,9 @@ export const IPromptsService = createDecorator<IPromptsService>('IPromptsService
 /**
 * Supported prompt types.
 *  - `local` means the prompt is a local file.
-*  - `global` means a "roamble" prompt file (similar to snippets).
+*  - `user` means a "roamble" prompt file (similar to snippets).
 */
-type TPromptsType = 'local' | 'global';
+type TPromptsType = 'local' | 'user';
 
 /**
  * Represents a prompt path with its type.


### PR DESCRIPTION
For [#13563](https://github.com/microsoft/vscode-copilot/issues/13563) and [#13644](https://github.com/microsoft/vscode-copilot/issues/13644).

The PR:

- renames "global prompts" feature into "user prompts"
- hides the file path of "user" prompt files as an implementation detail