### PR TITLE
add second config setting for the `reusable prompts` feature

### DIFF
--- a/src/vs/platform/prompts/common/config.ts
+++ b/src/vs/platform/prompts/common/config.ts
@@ -3,11 +3,8 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { IConfigurationService } from '../../configuration/common/configuration.js';
 import { ContextKeyExpr } from '../../contextkey/common/contextkey.js';
-
-// TODO: @lego - update the docs
-// TODO: @lego - update unit tests
+import { IConfigurationService } from '../../configuration/common/configuration.js';
 
 /**
  * Configuration helper for the `reusable prompts` feature.
@@ -15,49 +12,9 @@ import { ContextKeyExpr } from '../../contextkey/common/contextkey.js';
  *
  * ### Functions
  *
- * - {@link getLocationsValue} allows to current read configuration value
  * - {@link enabled} allows to check if the feature is enabled
+ * - {@link getLocationsValue} allows to current read configuration value
  * - {@link promptSourceFolders} gets list of source folders for prompt files
- *
- * ### Configuration Examples
- *
- * Enable the feature using the default `'.github/prompts'` folder as a source of prompt files:
- * ```json
- * {
- *   "chat.promptFiles": {},
- * }
- * ```
- *
- * Enable the feature, providing multiple source folder paths for prompt files,
- * in addition to the default `'.github/prompts'` one:
- * ```json
- * {
- *   "chat.promptFiles": {
- *     ".copilot/prompts" : false,
- *     "/Users/legomushroom/repos/prompts" : true,
- *   },
- * }
- * ```
- *
- * See the next section for details on how we treat the config value.
- *
- * ### Possible Values
- *
- * - `undefined`/`null`: feature is disabledx
- * - `object`:
- *   - expects the { "string": `boolean` } pairs, where the `string` is a path and the `boolean`
- *     is a flag that defines if this additional source folder is enabled or disabled;
- *     enabled source folders are used in addition to the default {@link DEFAULT_SOURCE_FOLDER} path;
- *     you can explicitly disable the default source folder by setting it to `false` in the object
- *   - value of a record in the object can also be a `string`:
- *     - if the string can be clearly mapped to a `boolean` (e.g., `"true"`, `"FALSE", "TrUe"`, etc.),
- *       it is treated as `boolean` value
- *     - any other string value is treated as `false` and is effectively ignored
- *   - if the record `key` is an `empty` string, it is ignored
- *   - if the resulting object is empty, the feature is considered `enabled`, prompt files source
- *     folders fallback to the default {@link DEFAULT_SOURCE_FOLDER} path
- *   - if the resulting object is not empty, and the default {@link DEFAULT_SOURCE_FOLDER} path
- *     is not explicitly disabled, it is added to the list of prompt files source folders
  *
  * ### File Paths Resolution
  *
@@ -74,12 +31,12 @@ export namespace PromptsConfig {
 	 * Configuration key for the `reusable prompts` feature
 	 * (also known as `prompt files`, `prompt instructions`, etc.).
 	 */
-	export const CONFIG_KEY: string = 'chat.reusablePrompts';
+	export const CONFIG_KEY: string = 'chat.promptFiles';
 
 	/**
 	 * Configuration key for the locations of reusable prompt files.
 	 */
-	export const LOCATIONS_CONFIG_KEY: string = 'chat.reusablePromptsLocations';
+	export const LOCATIONS_CONFIG_KEY: string = 'chat.promptFilesLocations';
 
 	/**
 	 * Default reusable prompt files source folder.

--- a/src/vs/platform/prompts/common/config.ts
+++ b/src/vs/platform/prompts/common/config.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { IConfigurationService } from '../../configuration/common/configuration.js';
+import { ContextKeyExpr } from '../../contextkey/common/contextkey.js';
 
 // TODO: @lego - update the docs
 // TODO: @lego - update unit tests
@@ -96,6 +97,11 @@ export namespace PromptsConfig {
 
 		return asBoolean(enabledValue) ?? false;
 	};
+
+	/**
+	 * TODO: @lego
+	 */
+	export const ENABLED_CTX = ContextKeyExpr.equals(`config.${CONFIG_KEY}`, true);
 
 	/**
 	 * Get value of the `reusable prompt locations` configuration setting.

--- a/src/vs/platform/prompts/common/config.ts
+++ b/src/vs/platform/prompts/common/config.ts
@@ -99,9 +99,9 @@ export namespace PromptsConfig {
 	};
 
 	/**
-	 * TODO: @lego
+	 * Context key expression for the `reusable prompts` feature `enabled` status.
 	 */
-	export const ENABLED_CTX = ContextKeyExpr.equals(`config.${CONFIG_KEY}`, true);
+	export const enabledCtx = ContextKeyExpr.equals(`config.${CONFIG_KEY}`, true);
 
 	/**
 	 * Get value of the `reusable prompt locations` configuration setting.

--- a/src/vs/platform/prompts/common/config.ts
+++ b/src/vs/platform/prompts/common/config.ts
@@ -7,11 +7,11 @@ import { IConfigurationService } from '../../configuration/common/configuration.
 
 /**
  * Configuration helper for the `reusable prompts` feature.
- * @see {@link CONFIG_KEY}.
+ * @see {@link CONFIG_KEY} and {@link LOCATIONS_CONFIG_KEY}.
  *
  * ### Functions
  *
- * - {@link getValue} allows to current read configuration value
+ * - {@link getLocationsValue} allows to current read configuration value
  * - {@link enabled} allows to check if the feature is enabled
  * - {@link promptSourceFolders} gets list of source folders for prompt files
  *
@@ -70,7 +70,12 @@ export namespace PromptsConfig {
 	 * Configuration key for the `prompt files` feature (also
 	 * known as `prompt files`, `prompt instructions`, etc.).
 	 */
-	export const CONFIG_KEY: string = 'chat.promptFiles';
+	export const CONFIG_KEY: string = 'chat.reusablePrompts';
+
+	/**
+	 * Configuration key for the locations of reusable prompt files.
+	 */
+	export const LOCATIONS_CONFIG_KEY: string = 'chat.reusablePrompt.locations';
 
 	/**
 	 * Default reusable prompt files source folder.
@@ -78,12 +83,25 @@ export namespace PromptsConfig {
 	export const DEFAULT_SOURCE_FOLDER = '.github/prompts';
 
 	/**
-	 * Get value of the `prompt files` configuration setting.
+	 * Checks if the feature is enabled.
+	 * @see {@link CONFIG_KEY}.
 	 */
-	export const getValue = (
+	export const enabled = (
+		configService: IConfigurationService,
+	): boolean => {
+		const enabledValue = configService.getValue(CONFIG_KEY);
+
+		return asBoolean(enabledValue) ?? false;
+	};
+
+	/**
+	 * Get value of the `reusable prompt locations` configuration setting.
+	 * @see {@link LOCATIONS_CONFIG_KEY}.
+	 */
+	export const getLocationsValue = (
 		configService: IConfigurationService,
 	): Record<string, boolean> | undefined => {
-		const configValue = configService.getValue(CONFIG_KEY);
+		const configValue = configService.getValue(LOCATIONS_CONFIG_KEY);
 
 		if (configValue === undefined || configValue === null || Array.isArray(configValue)) {
 			return undefined;
@@ -112,24 +130,13 @@ export namespace PromptsConfig {
 	};
 
 	/**
-	 * Checks if the feature is enabled.
-	 */
-	export const enabled = (
-		configService: IConfigurationService,
-	): boolean => {
-		const value = getValue(configService);
-
-		return value !== undefined;
-	};
-
-	/**
 	 * Gets list of source folders for prompt files.
 	 * Defaults to {@link DEFAULT_SOURCE_FOLDER}.
 	 */
 	export const promptSourceFolders = (
 		configService: IConfigurationService,
 	): string[] => {
-		const value = getValue(configService);
+		const value = getLocationsValue(configService);
 
 		// note! the `value &&` part handles the `undefined`, `null`, and `false` cases
 		if (value && (typeof value === 'object')) {

--- a/src/vs/platform/prompts/common/config.ts
+++ b/src/vs/platform/prompts/common/config.ts
@@ -5,6 +5,9 @@
 
 import { IConfigurationService } from '../../configuration/common/configuration.js';
 
+// TODO: @lego - update the docs
+// TODO: @lego - update unit tests
+
 /**
  * Configuration helper for the `reusable prompts` feature.
  * @see {@link CONFIG_KEY} and {@link LOCATIONS_CONFIG_KEY}.
@@ -67,15 +70,15 @@ import { IConfigurationService } from '../../configuration/common/configuration.
  */
 export namespace PromptsConfig {
 	/**
-	 * Configuration key for the `prompt files` feature (also
-	 * known as `prompt files`, `prompt instructions`, etc.).
+	 * Configuration key for the `reusable prompts` feature
+	 * (also known as `prompt files`, `prompt instructions`, etc.).
 	 */
 	export const CONFIG_KEY: string = 'chat.reusablePrompts';
 
 	/**
 	 * Configuration key for the locations of reusable prompt files.
 	 */
-	export const LOCATIONS_CONFIG_KEY: string = 'chat.reusablePrompt.locations';
+	export const LOCATIONS_CONFIG_KEY: string = 'chat.reusablePromptsLocations';
 
 	/**
 	 * Default reusable prompt files source folder.

--- a/src/vs/platform/prompts/test/common/config.test.ts
+++ b/src/vs/platform/prompts/test/common/config.test.ts
@@ -16,10 +16,14 @@ import { IConfigurationOverrides, IConfigurationService } from '../../../configu
 const createMock = <T>(value: T): IConfigurationService => {
 	return mockService<IConfigurationService>({
 		getValue(key?: string | IConfigurationOverrides) {
-			assert.strictEqual(
-				key,
-				PromptsConfig.CONFIG_KEY,
-				`Mocked service supports only one configuration key: '${PromptsConfig.CONFIG_KEY}'.`,
+			assert(
+				typeof key === 'string',
+				`Expected string configuration key, got '${typeof key}'.`,
+			);
+
+			assert(
+				[PromptsConfig.CONFIG_KEY, PromptsConfig.LOCATIONS_CONFIG_KEY].includes(key),
+				`Unsupported configuration key '${key}'.`,
 			);
 
 			return value;
@@ -35,7 +39,7 @@ suite('PromptsConfig', () => {
 			const configService = createMock(undefined);
 
 			assert.strictEqual(
-				PromptsConfig.getValue(configService),
+				PromptsConfig.getLocationsValue(configService),
 				undefined,
 				'Must read correct value.',
 			);
@@ -45,7 +49,7 @@ suite('PromptsConfig', () => {
 			const configService = createMock(null);
 
 			assert.strictEqual(
-				PromptsConfig.getValue(configService),
+				PromptsConfig.getLocationsValue(configService),
 				undefined,
 				'Must read correct value.',
 			);
@@ -54,7 +58,7 @@ suite('PromptsConfig', () => {
 		suite('• object', () => {
 			test('• empty', () => {
 				assert.deepStrictEqual(
-					PromptsConfig.getValue(createMock({})),
+					PromptsConfig.getLocationsValue(createMock({})),
 					{},
 					'Must read correct value.',
 				);
@@ -62,7 +66,7 @@ suite('PromptsConfig', () => {
 
 			test('• only valid strings', () => {
 				assert.deepStrictEqual(
-					PromptsConfig.getValue(createMock({
+					PromptsConfig.getLocationsValue(createMock({
 						'/root/.bashrc': true,
 						'../../folder/.hidden-folder/config.xml': true,
 						'/srv/www/Public_html/.htaccess': true,
@@ -96,7 +100,7 @@ suite('PromptsConfig', () => {
 
 			test('• filters out non valid entries', () => {
 				assert.deepStrictEqual(
-					PromptsConfig.getValue(createMock({
+					PromptsConfig.getLocationsValue(createMock({
 						'/etc/hosts.backup': '\t\n\t',
 						'./run.tests.sh': '\v',
 						'../assets/img/logo.v2.png': true,
@@ -135,7 +139,7 @@ suite('PromptsConfig', () => {
 
 			test('• only invalid or false values', () => {
 				assert.deepStrictEqual(
-					PromptsConfig.getValue(createMock({
+					PromptsConfig.getLocationsValue(createMock({
 						'/etc/hosts.backup': '\t\n\t',
 						'./run.tests.sh': '\v',
 						'../assets/IMG/logo.v2.png': '',

--- a/src/vs/platform/prompts/test/common/config.test.ts
+++ b/src/vs/platform/prompts/test/common/config.test.ts
@@ -34,7 +34,7 @@ const createMock = <T>(value: T): IConfigurationService => {
 suite('PromptsConfig', () => {
 	ensureNoDisposablesAreLeakedInTestSuite();
 
-	suite('• getValue', () => {
+	suite('• getLocationsValue', () => {
 		test('• undefined', () => {
 			const configService = createMock(undefined);
 

--- a/src/vs/workbench/contrib/chat/browser/actions/chatContextActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatContextActions.ts
@@ -152,7 +152,7 @@ function isPromptInstructionsQuickPickItem(obj: unknown): obj is IReusablePrompt
 		return false;
 	}
 
-	return ('kind' in obj && obj.kind === 'prompt-instructions');
+	return ('kind' in obj && obj.kind === 'reusable-prompt');
 }
 
 interface IRelatedFilesQuickPickItem extends IQuickPickItem {
@@ -235,16 +235,17 @@ interface IDiagnosticsQuickPickItemWithFilter extends IQuickPickItem {
 /**
  * Quick pick item for reusable prompt attachment.
  */
+const REUSABLE_PROMPT_PICK_ID = 'reusable-prompt';
 interface IReusablePromptQuickPickItem extends IQuickPickItem {
 	/**
 	 * The ID of the quick pick item.
 	 */
-	id: 'reusable-prompt';
+	id: typeof REUSABLE_PROMPT_PICK_ID;
 
 	/**
 	 * Unique kind identifier of the reusable prompt attachment.
 	 */
-	kind: 'reusable-prompt';
+	kind: typeof REUSABLE_PROMPT_PICK_ID;
 
 	/**
 	 * Keybinding of the command.
@@ -825,8 +826,8 @@ export class AttachContextAction extends Action2 {
 			const keybinding = keybindingService.lookupKeybinding(USE_PROMPT_COMMAND_ID, contextKeyService);
 
 			quickPickItems.push({
-				kind: 'reusable-prompt',
-				id: 'reusable-prompt',
+				id: REUSABLE_PROMPT_PICK_ID,
+				kind: REUSABLE_PROMPT_PICK_ID,
 				label: localize('chatContext.attach.prompt.label', 'Prompt...'),
 				iconClass: ThemeIcon.asClassName(Codicon.bookmark),
 				keybinding,

--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -200,19 +200,36 @@ configurationRegistry.registerConfiguration({
 			tags: ['experimental', 'onExp']
 		},
 		[PromptsConfig.CONFIG_KEY]: {
-			type: 'object',
+			type: 'boolean',
 			title: nls.localize(
-				'chat.promptFiles.config.title',
-				"Prompt Files",
+				'chat.reusablePrompts.config.enabled.title',
+				"Reusable Prompts",
 			),
 			markdownDescription: nls.localize(
-				'chat.promptFiles.config.description',
+				'chat.reusablePrompts.config.enabled.description',
+				"Enable reusable prompts (`*{0}`) in Chat, Edits, and Inline Chat sessions. [Learn More]({0}).",
+				PROMPT_FILE_EXTENSION,
+				DOCUMENTATION_URL,
+			),
+			default: true,
+			restricted: true,
+			disallowConfigurationDefault: true,
+			tags: ['experimental'],
+		},
+		[PromptsConfig.LOCATIONS_CONFIG_KEY]: {
+			type: 'object',
+			title: nls.localize(
+				'chat.reusablePrompts.config.locations.title',
+				"Reusable Prompt Locations",
+			),
+			markdownDescription: nls.localize(
+				'chat.reusablePrompts.config.locations.description',
 				"Specify location(s) of reusable prompt files (`*{0}`) that can be attached in Chat, Edits, and Inline Chat sessions. [Learn More]({1}).\n\nRelative paths are resolved from the root folder(s) of your workspace.",
 				PROMPT_FILE_EXTENSION,
 				DOCUMENTATION_URL,
 			),
 			default: {
-				[PromptsConfig.DEFAULT_SOURCE_FOLDER]: false,
+				[PromptsConfig.DEFAULT_SOURCE_FOLDER]: true,
 			},
 			required: [PromptsConfig.DEFAULT_SOURCE_FOLDER],
 			additionalProperties: { type: 'boolean' },

--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -216,6 +216,7 @@ configurationRegistry.registerConfiguration({
 			disallowConfigurationDefault: true,
 			tags: ['experimental'],
 		},
+		// TODO: @lego - add more tags?
 		[PromptsConfig.LOCATIONS_CONFIG_KEY]: {
 			type: 'object',
 			title: nls.localize(

--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -203,25 +203,24 @@ configurationRegistry.registerConfiguration({
 			type: 'boolean',
 			title: nls.localize(
 				'chat.reusablePrompts.config.enabled.title',
-				"Reusable Prompts",
+				"Prompt Files",
 			),
 			markdownDescription: nls.localize(
 				'chat.reusablePrompts.config.enabled.description',
-				"Enable reusable prompts (`*{0}`) in Chat, Edits, and Inline Chat sessions. [Learn More]({0}).",
+				"Enable reusable prompt files (`*{0}`) in Chat, Edits, and Inline Chat sessions. [Learn More]({0}).",
 				PROMPT_FILE_EXTENSION,
 				DOCUMENTATION_URL,
 			),
 			default: true,
 			restricted: true,
 			disallowConfigurationDefault: true,
-			tags: ['experimental'],
+			tags: ['experimental', 'prompts', 'reusable prompts', 'prompt snippets', 'instructions'],
 		},
-		// TODO: @lego - add more tags?
 		[PromptsConfig.LOCATIONS_CONFIG_KEY]: {
 			type: 'object',
 			title: nls.localize(
 				'chat.reusablePrompts.config.locations.title',
-				"Reusable Prompt Locations",
+				"Prompt File Locations",
 			),
 			markdownDescription: nls.localize(
 				'chat.reusablePrompts.config.locations.description',
@@ -237,7 +236,7 @@ configurationRegistry.registerConfiguration({
 			unevaluatedProperties: { type: 'boolean' },
 			restricted: true,
 			disallowConfigurationDefault: true,
-			tags: ['experimental'],
+			tags: ['experimental', 'prompts', 'reusable prompts', 'prompt snippets', 'instructions'],
 			examples: [
 				{
 					[PromptsConfig.DEFAULT_SOURCE_FOLDER]: true,

--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -207,7 +207,7 @@ configurationRegistry.registerConfiguration({
 			),
 			markdownDescription: nls.localize(
 				'chat.reusablePrompts.config.enabled.description',
-				"Enable reusable prompt files (`*{0}`) in Chat, Edits, and Inline Chat sessions. [Learn More]({0}).",
+				"Enable reusable prompt files (`*{0}`) in Chat, Edits, and Inline Chat sessions. [Learn More]({1}).",
 				PROMPT_FILE_EXTENSION,
 				DOCUMENTATION_URL,
 			),

--- a/src/vs/workbench/contrib/chat/browser/promptSyntax/contributions/createPromptCommand/createPromptCommand.ts
+++ b/src/vs/workbench/contrib/chat/browser/promptSyntax/contributions/createPromptCommand/createPromptCommand.ts
@@ -109,7 +109,7 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 	id: LOCAL_COMMAND_ID,
 	weight: KeybindingWeight.WorkbenchContrib,
 	handler: commandFactory('local'),
-	when: PromptsConfig.ENABLED_CTX,
+	when: PromptsConfig.enabledCtx,
 });
 
 /**
@@ -119,7 +119,7 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 	id: USER_COMMAND_ID,
 	weight: KeybindingWeight.WorkbenchContrib,
 	handler: commandFactory('user'),
-	when: PromptsConfig.ENABLED_CTX,
+	when: PromptsConfig.enabledCtx,
 });
 
 /**
@@ -131,7 +131,7 @@ appendToCommandPalette(
 		title: LOCAL_COMMAND_TITLE,
 		category: CHAT_CATEGORY,
 	},
-	PromptsConfig.ENABLED_CTX,
+	PromptsConfig.enabledCtx,
 );
 
 /**
@@ -143,5 +143,5 @@ appendToCommandPalette(
 		title: USER_COMMAND_TITLE,
 		category: CHAT_CATEGORY,
 	},
-	PromptsConfig.ENABLED_CTX,
+	PromptsConfig.enabledCtx,
 );

--- a/src/vs/workbench/contrib/chat/browser/promptSyntax/contributions/createPromptCommand/createPromptCommand.ts
+++ b/src/vs/workbench/contrib/chat/browser/promptSyntax/contributions/createPromptCommand/createPromptCommand.ts
@@ -11,6 +11,7 @@ import { askForPromptSourceFolder } from './dialogs/askForPromptSourceFolder.js'
 import { IFileService } from '../../../../../../../platform/files/common/files.js';
 import { ILabelService } from '../../../../../../../platform/label/common/label.js';
 import { IOpenerService } from '../../../../../../../platform/opener/common/opener.js';
+import { PromptsConfig } from '../../../../../../../platform/prompts/common/config.js';
 import { ICommandService } from '../../../../../../../platform/commands/common/commands.js';
 import { IPromptPath, IPromptsService } from '../../../../common/promptSyntax/service/types.js';
 import { appendToCommandPalette } from '../../../../../files/browser/fileActions.contribution.js';
@@ -108,6 +109,7 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 	id: LOCAL_COMMAND_ID,
 	weight: KeybindingWeight.WorkbenchContrib,
 	handler: commandFactory('local'),
+	when: PromptsConfig.ENABLED_CTX,
 });
 
 /**
@@ -117,6 +119,7 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 	id: USER_COMMAND_ID,
 	weight: KeybindingWeight.WorkbenchContrib,
 	handler: commandFactory('user'),
+	when: PromptsConfig.ENABLED_CTX,
 });
 
 /**
@@ -128,6 +131,7 @@ appendToCommandPalette(
 		title: LOCAL_COMMAND_TITLE,
 		category: CHAT_CATEGORY,
 	},
+	PromptsConfig.ENABLED_CTX,
 );
 
 /**
@@ -139,4 +143,5 @@ appendToCommandPalette(
 		title: USER_COMMAND_TITLE,
 		category: CHAT_CATEGORY,
 	},
+	PromptsConfig.ENABLED_CTX,
 );

--- a/src/vs/workbench/contrib/chat/browser/promptSyntax/contributions/usePromptCommand.ts
+++ b/src/vs/workbench/contrib/chat/browser/promptSyntax/contributions/usePromptCommand.ts
@@ -133,7 +133,7 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 	weight: KeybindingWeight.WorkbenchContrib,
 	primary: COMMAND_KEY_BINDING,
 	handler: command,
-	when: PromptsConfig.ENABLED_CTX,
+	when: PromptsConfig.enabledCtx,
 });
 
 /**
@@ -145,5 +145,5 @@ appendToCommandPalette(
 		title: localize('commands.prompts.use.title', "Use Prompt"),
 		category: CHAT_CATEGORY,
 	},
-	PromptsConfig.ENABLED_CTX,
+	PromptsConfig.enabledCtx,
 );

--- a/src/vs/workbench/contrib/chat/browser/promptSyntax/contributions/usePromptCommand.ts
+++ b/src/vs/workbench/contrib/chat/browser/promptSyntax/contributions/usePromptCommand.ts
@@ -8,15 +8,13 @@ import { URI } from '../../../../../../base/common/uri.js';
 import { CHAT_CATEGORY } from '../../actions/chatActions.js';
 import { IChatWidget, IChatWidgetService } from '../../chat.js';
 import { KeyMod, KeyCode } from '../../../../../../base/common/keyCodes.js';
-import { Registry } from '../../../../../../platform/registry/common/platform.js';
+import { PromptsConfig } from '../../../../../../platform/prompts/common/config.js';
 import { IViewsService } from '../../../../../services/views/common/viewsService.js';
 import { isPromptFile } from '../../../../../../platform/prompts/common/constants.js';
-import { LifecyclePhase } from '../../../../../services/lifecycle/common/lifecycle.js';
 import { IEditorService } from '../../../../../services/editor/common/editorService.js';
 import { ICommandService } from '../../../../../../platform/commands/common/commands.js';
 import { appendToCommandPalette } from '../../../../files/browser/fileActions.contribution.js';
 import { ServicesAccessor } from '../../../../../../platform/instantiation/common/instantiation.js';
-import { IWorkbenchContributionsRegistry, Extensions } from '../../../../../common/contributions.js';
 import { IActiveCodeEditor, isCodeEditor, isDiffEditor } from '../../../../../../editor/browser/editorBrowser.js';
 import { KeybindingsRegistry, KeybindingWeight } from '../../../../../../platform/keybinding/common/keybindingsRegistry.js';
 import { IChatAttachPromptActionOptions, ATTACH_PROMPT_ACTION_ID } from '../../actions/chatAttachPromptAction/chatAttachPromptAction.js';
@@ -135,6 +133,7 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 	weight: KeybindingWeight.WorkbenchContrib,
 	primary: COMMAND_KEY_BINDING,
 	handler: command,
+	when: PromptsConfig.ENABLED_CTX,
 });
 
 /**
@@ -146,10 +145,5 @@ appendToCommandPalette(
 		title: localize('commands.prompts.use.title', "Use Prompt"),
 		category: CHAT_CATEGORY,
 	},
+	PromptsConfig.ENABLED_CTX,
 );
-
-class RunIfEnabled { }
-
-// register the command as a workbench contribution
-Registry.as<IWorkbenchContributionsRegistry>(Extensions.Workbench)
-	.registerWorkbenchContribution(RunIfEnabled, LifecyclePhase.Eventually);

--- a/src/vs/workbench/contrib/chat/browser/promptSyntax/contributions/usePromptCommand.ts
+++ b/src/vs/workbench/contrib/chat/browser/promptSyntax/contributions/usePromptCommand.ts
@@ -8,12 +8,15 @@ import { URI } from '../../../../../../base/common/uri.js';
 import { CHAT_CATEGORY } from '../../actions/chatActions.js';
 import { IChatWidget, IChatWidgetService } from '../../chat.js';
 import { KeyMod, KeyCode } from '../../../../../../base/common/keyCodes.js';
+import { Registry } from '../../../../../../platform/registry/common/platform.js';
 import { IViewsService } from '../../../../../services/views/common/viewsService.js';
 import { isPromptFile } from '../../../../../../platform/prompts/common/constants.js';
+import { LifecyclePhase } from '../../../../../services/lifecycle/common/lifecycle.js';
 import { IEditorService } from '../../../../../services/editor/common/editorService.js';
 import { ICommandService } from '../../../../../../platform/commands/common/commands.js';
 import { appendToCommandPalette } from '../../../../files/browser/fileActions.contribution.js';
 import { ServicesAccessor } from '../../../../../../platform/instantiation/common/instantiation.js';
+import { IWorkbenchContributionsRegistry, Extensions } from '../../../../../common/contributions.js';
 import { IActiveCodeEditor, isCodeEditor, isDiffEditor } from '../../../../../../editor/browser/editorBrowser.js';
 import { KeybindingsRegistry, KeybindingWeight } from '../../../../../../platform/keybinding/common/keybindingsRegistry.js';
 import { IChatAttachPromptActionOptions, ATTACH_PROMPT_ACTION_ID } from '../../actions/chatAttachPromptAction/chatAttachPromptAction.js';
@@ -62,27 +65,6 @@ const command = async (
 
 	await commandService.executeCommand(ATTACH_PROMPT_ACTION_ID, options);
 };
-
-/**
- * Register the "Use Prompt" command with its keybinding.
- */
-KeybindingsRegistry.registerCommandAndKeybindingRule({
-	id: COMMAND_ID,
-	weight: KeybindingWeight.WorkbenchContrib,
-	primary: COMMAND_KEY_BINDING,
-	handler: command,
-});
-
-/**
- * Register the "Use Prompt" command in the `command palette`.
- */
-appendToCommandPalette(
-	{
-		id: COMMAND_ID,
-		title: localize('commands.prompts.use.title', "Use Prompt"),
-		category: CHAT_CATEGORY,
-	},
-);
 
 /**
  * Get chat widget reference to attach prompt to.
@@ -144,3 +126,30 @@ const getActivePromptUri = (
 
 	return undefined;
 };
+
+/**
+ * Register the "Use Prompt" command with its keybinding.
+ */
+KeybindingsRegistry.registerCommandAndKeybindingRule({
+	id: COMMAND_ID,
+	weight: KeybindingWeight.WorkbenchContrib,
+	primary: COMMAND_KEY_BINDING,
+	handler: command,
+});
+
+/**
+ * Register the "Use Prompt" command in the `command palette`.
+ */
+appendToCommandPalette(
+	{
+		id: COMMAND_ID,
+		title: localize('commands.prompts.use.title', "Use Prompt"),
+		category: CHAT_CATEGORY,
+	},
+);
+
+class RunIfEnabled { }
+
+// register the command as a workbench contribution
+Registry.as<IWorkbenchContributionsRegistry>(Extensions.Workbench)
+	.registerWorkbenchContribution(RunIfEnabled, LifecyclePhase.Eventually);

--- a/src/vs/workbench/contrib/chat/test/common/promptSyntax/utils/promptFilesLocator.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/promptSyntax/utils/promptFilesLocator.test.ts
@@ -27,10 +27,14 @@ import { IWorkspace, IWorkspaceContextService, IWorkspaceFolder } from '../../..
 const mockConfigService = <T>(value: T): IConfigurationService => {
 	return mockService<IConfigurationService>({
 		getValue(key?: string | IConfigurationOverrides) {
-			assert.strictEqual(
-				key,
-				PromptsConfig.CONFIG_KEY,
-				`Mocked service supports only one configuration key: '${PromptsConfig.CONFIG_KEY}'.`,
+			assert(
+				typeof key === 'string',
+				`Expected string configuration key, got '${typeof key}'.`,
+			);
+
+			assert(
+				[PromptsConfig.CONFIG_KEY, PromptsConfig.LOCATIONS_CONFIG_KEY].includes(key),
+				`Unsupported configuration key '${key}'.`,
 			);
 
 			return value;


### PR DESCRIPTION
The PR:

- adds the second config setting for the `reusable prompts` feature dedicated solely to the feature enablement
- registers the `use prompt` and `create prompt` (and their keybindings) conditionally, based on the new config setting state (enabled/disabled)
- fixes issue prompt attachment ID issue