### PR TITLE
# Signal rejection on inline completion drop

### DIFF
--- a/src/vs/editor/common/languages.ts
+++ b/src/vs/editor/common/languages.ts
@@ -855,7 +855,7 @@ export interface InlineCompletionsProvider<T extends InlineCompletions = InlineC
 	 */
 	handlePartialAccept?(completions: T, item: T['items'][number], acceptedCharacters: number, info: PartialAcceptInfo): void;
 
-	handleRejection?(completions: T, item: T['items'][number]): void;
+	handleRejection?(completions: T, item: T['items'][number], isExplicit: boolean): void;
 
 	/**
 	 * Will be called when a completions list is no longer in use and can be garbage-collected.

--- a/src/vs/editor/contrib/inlineCompletions/browser/model/inlineCompletionsModel.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/model/inlineCompletionsModel.ts
@@ -87,6 +87,11 @@ export class InlineCompletionsModel extends Disposable {
 			const item = this.inlineCompletionState.read(reader);
 			const completion = item?.inlineCompletion;
 			if (completion?.semanticId !== lastItem?.semanticId) {
+				if (!completion && lastItem) {
+					const i = lastItem.inlineCompletion;
+					const src = i.source;
+					src.provider.handleRejection?.(src.inlineCompletions, i.sourceInlineCompletion, /*isExplicit=*/false);
+				}
 				lastItem = completion;
 				if (completion) {
 					const i = completion.inlineCompletion;
@@ -265,7 +270,7 @@ export class InlineCompletionsModel extends Disposable {
 				const source = inlineCompletion?.source;
 				const sourceInlineCompletion = inlineCompletion?.sourceInlineCompletion;
 				if (sourceInlineCompletion && source?.provider.handleRejection) {
-					source.provider.handleRejection(source.inlineCompletions, sourceInlineCompletion);
+					source.provider.handleRejection(source.inlineCompletions, sourceInlineCompletion, /*isExplicit=*/true);
 				}
 			}
 

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -7352,7 +7352,7 @@ declare namespace monaco.languages {
 		 * @param acceptedCharacters Deprecated. Use `info.acceptedCharacters` instead.
 		 */
 		handlePartialAccept?(completions: T, item: T['items'][number], acceptedCharacters: number, info: PartialAcceptInfo): void;
-		handleRejection?(completions: T, item: T['items'][number]): void;
+		handleRejection?(completions: T, item: T['items'][number], isExplicit: boolean): void;
 		/**
 		 * Will be called when a completions list is no longer in use and can be garbage-collected.
 		*/


### PR DESCRIPTION
# Problem statement
With the current inline completion, we are aware only of completions being accepted and made visible. With the introduction of the rejection handler we are aware also of explicit rejection. **What is still missing though** is understanding when a completion has been discarded by natural means, such as changing a character (without having completion reretrieved), or typing through without having extensions recalculate possible visibility of a completion (Which can also reduce load on the client, assuming that there can be multiple extensions set up which consume & provide completions).

# Proposal

Extend the rejection handler to provide the Explicit/Implicit signal (can be made more elaborate in to a enum if neccessary to signal different kind of rejections, such as type through/location change.... but that doesn't seem to be that neccessary), and allow the Show handler to also signal rejection when a **No successive completion is to be shown**.

As a continuation it would be great if the rejection signals flowed in to the extension https://github.com/microsoft/vscode/pull/241328

Closes https://github.com/microsoft/vscode/issues/192546