### PR TITLE
# Allow inlineEdits to signal visibility

### DIFF
--- a/src/vs/editor/contrib/inlineCompletions/browser/model/inlineCompletionsModel.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/model/inlineCompletionsModel.ts
@@ -85,7 +85,8 @@ export class InlineCompletionsModel extends Disposable {
 		this._register(autorun(reader => {
 			/** @description call handleItemDidShow */
 			const item = this.inlineCompletionState.read(reader);
-			const completion = item?.inlineCompletion;
+			const inlineEdit = this.inlineEditState.read(reader);
+			const completion = item?.inlineCompletion ?? inlineEdit?.inlineCompletion;
 			if (completion?.semanticId !== lastItem?.semanticId) {
 				lastItem = completion;
 				if (completion) {


### PR DESCRIPTION
# Problem Statement

Current inlineEdits inherited the inlineCompletion pathways, but are not fully integrated. So while we can listen to acceptance of inlineEdit, we can't listen to inlineEdit being visible.

# Proposal

Add the inlineEdit state in to the show handler & use the inlineEdit completion content as well as the lastItem. This would allow downstream consumers to listen to changes and react to either inline completion or the inline edit being visible & apply logging heuristicts (such as visibility after certain period of time).

The extensions should be easily able to draw the line between the inlineEdits and the inlineCompletions by filtering on the isInlineEdit property.