### PR TITLE
# Full acceptance signal for the inlineCompletions

### DIFF
--- a/src/vs/editor/common/languages.ts
+++ b/src/vs/editor/common/languages.ts
@@ -635,6 +635,7 @@ export const enum PartialAcceptTriggerKind {
 	Word = 0,
 	Line = 1,
 	Suggest = 2,
+	Full = 3,
 }
 
 /**

--- a/src/vs/editor/common/standalone/standaloneEnums.ts
+++ b/src/vs/editor/common/standalone/standaloneEnums.ts
@@ -778,7 +778,8 @@ export enum OverviewRulerLane {
 export enum PartialAcceptTriggerKind {
 	Word = 0,
 	Line = 1,
-	Suggest = 2
+	Suggest = 2,
+	Full = 3
 }
 
 export enum PositionAffinity {

--- a/src/vs/editor/contrib/inlineCompletions/browser/model/inlineCompletionsModel.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/model/inlineCompletionsModel.ts
@@ -731,7 +731,7 @@ export class InlineCompletionsModel extends Disposable {
 
 		if (completion.snippetInfo || completion.filterText !== completion.insertText) {
 			// not in WYSIWYG mode, partial commit might change completion, thus it is not supported
-			await this.accept(editor);
+			await this.accept(editor, kind);
 			return;
 		}
 
@@ -740,7 +740,7 @@ export class InlineCompletionsModel extends Disposable {
 		const ghostTextVal = firstPart.text;
 		const acceptUntilIndexExclusive = getAcceptUntilIndex(ghostTextPos, ghostTextVal);
 		if (acceptUntilIndexExclusive === ghostTextVal.length && ghostText.parts.length === 1) {
-			this.accept(editor);
+			this.accept(editor, kind);
 			return;
 		}
 		const partialGhostTextVal = ghostTextVal.substring(0, acceptUntilIndexExclusive);

--- a/src/vs/editor/contrib/inlineCompletions/browser/model/inlineCompletionsModel.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/model/inlineCompletionsModel.ts
@@ -619,10 +619,8 @@ export class InlineCompletionsModel extends Disposable {
 
 		const completion = completionWithUpdatedRange.toInlineCompletion(undefined);
 
-		if (completion.command) {
-			// Make sure the completion list will not be disposed.
-			completion.source.addRef();
-		}
+
+		completion.source.addRef();
 
 		try {
 			this._isAcceptingFully.set(true, undefined);
@@ -671,10 +669,10 @@ export class InlineCompletionsModel extends Disposable {
 				await this._commandService
 					.executeCommand(completion.command.id, ...(completion.command.arguments || []))
 					.then(undefined, onUnexpectedExternalError);
-				completion.source.removeRef();
 			}
 		} finally {
 			this._isAcceptingFully.set(false, undefined);
+			completion.source.removeRef();
 		}
 
 		this._inAcceptFlow.set(true, undefined);

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -7179,7 +7179,8 @@ declare namespace monaco.languages {
 	export enum PartialAcceptTriggerKind {
 		Word = 0,
 		Line = 1,
-		Suggest = 2
+		Suggest = 2,
+		Full = 3
 	}
 
 	/**

--- a/src/vs/workbench/api/common/extHostTypeConverters.ts
+++ b/src/vs/workbench/api/common/extHostTypeConverters.ts
@@ -3031,6 +3031,8 @@ export namespace PartialAcceptTriggerKind {
 				return types.PartialAcceptTriggerKind.Line;
 			case languages.PartialAcceptTriggerKind.Suggest:
 				return types.PartialAcceptTriggerKind.Suggest;
+			case languages.PartialAcceptTriggerKind.Full:
+				return types.PartialAcceptTriggerKind.Full;
 			default:
 				return types.PartialAcceptTriggerKind.Unknown;
 		}

--- a/src/vs/workbench/api/common/extHostTypes.ts
+++ b/src/vs/workbench/api/common/extHostTypes.ts
@@ -1863,6 +1863,7 @@ export enum PartialAcceptTriggerKind {
 	Word = 1,
 	Line = 2,
 	Suggest = 3,
+	Full = 4,
 }
 
 export enum ViewColumn {

--- a/src/vscode-dts/vscode.proposed.inlineCompletionsAdditions.d.ts
+++ b/src/vscode-dts/vscode.proposed.inlineCompletionsAdditions.d.ts
@@ -116,6 +116,7 @@ declare module 'vscode' {
 		Word = 1,
 		Line = 2,
 		Suggest = 3,
+		Full = 4,
 	}
 
 	// When finalizing `commands`, make sure to add a corresponding constructor parameter.


### PR DESCRIPTION
# Problem statement

The current acceptance always signals only partial edits. Once the full edit is hit the full acceptance command is triggered (even though this was signalled from the partial acceptance), this reduces understanding in to when the partial acceptance signals are used (e.g. users accepting completions via line acceptances at all times).

The patial acceptance handler also can carry more data that can be core calculated, improving the data flow without need for extension overwork.

lastly it allows to paint the full picture with the handlers without the dichotomy of "handlers+commands", and always expects the show->accept->show/reject as next signal. (Note that [242284](https://github.com/microsoft/vscode/pull/242284) tries to add the reject)

# Proposal

Extend the current Accept handler to allow the partial accepts to signal through it that they have been invoked.
Add observable value in the didShow to allow it to be always outside ot the Acceptance, allowing for correct interpretation of show->accept->reject/show

note that with https://github.com/microsoft/vscode/pull/241356 a much better picture could be captured of the whole code completion lifecycle.