### PR TITLE
Fixes #241866

### DIFF
--- a/src/vs/workbench/contrib/inlineCompletions/browser/inlineCompletionLanguageStatusBarContribution.ts
+++ b/src/vs/workbench/contrib/inlineCompletions/browser/inlineCompletionLanguageStatusBarContribution.ts
@@ -5,24 +5,29 @@
 
 import { localize } from '../../../../nls.js';
 import { createHotClass } from '../../../../base/common/hotReloadHelpers.js';
-import { Disposable } from '../../../../base/common/lifecycle.js';
+import { Disposable, DisposableStore } from '../../../../base/common/lifecycle.js';
 import { autorunWithStore, derived } from '../../../../base/common/observable.js';
 import { debouncedObservable } from '../../../../base/common/observableInternal/utils.js';
 import Severity from '../../../../base/common/severity.js';
 import { ICodeEditor } from '../../../../editor/browser/editorBrowser.js';
 import { InlineCompletionsController } from '../../../../editor/contrib/inlineCompletions/browser/controller/inlineCompletionsController.js';
 import { ILanguageStatusService } from '../../../services/languageStatus/common/languageStatusService.js';
+import { observableCodeEditor } from '../../../../editor/browser/observableCodeEditor.js';
 
 export class InlineCompletionLanguageStatusBarContribution extends Disposable {
 	public static readonly hot = createHotClass(InlineCompletionLanguageStatusBarContribution);
 
 	public static Id = 'vs.editor.contrib.inlineCompletionLanguageStatusBarContribution';
+	public static readonly languageStatusBarDisposables = new Set<DisposableStore>();
 
 	private readonly _c = InlineCompletionsController.get(this._editor);
 
 	private readonly _state = derived(this, reader => {
 		const model = this._c?.model.read(reader);
 		if (!model) { return undefined; }
+		if (!observableCodeEditor(this._editor).isFocused.read(reader)) {
+			return undefined;
+		}
 
 		return {
 			model,
@@ -50,6 +55,15 @@ export class InlineCompletionLanguageStatusBarContribution extends Disposable {
 				inlineEdit: { shortLabel: '$(lightbulb-sparkle)', label: '$(copilot) ' + localize('inlineEditAvailable', "Inline edit available"), loading: false, },
 				noSuggestion: { shortLabel: '$(circle-slash)', label: '$(copilot) ' + localize('noInlineSuggestionAvailable', "No inline suggestion available"), loading: false, },
 			};
+
+			// Make sure previous status is cleared before the new is registered. This works, but is a bit hacky.
+			// TODO: Use a workbench contribution to get singleton behavior.
+			InlineCompletionLanguageStatusBarContribution.languageStatusBarDisposables.forEach(d => d.clear());
+
+			InlineCompletionLanguageStatusBarContribution.languageStatusBarDisposables.add(store);
+			store.add({
+				dispose: () => InlineCompletionLanguageStatusBarContribution.languageStatusBarDisposables.delete(store)
+			});
 
 			store.add(this._languageStatusService.addStatus({
 				accessibilityInfo: undefined,


### PR DESCRIPTION
Fixes #241866

This makes sure that:
* The inline completion status bar is only shown for the focused editor
* No two status bars are ever registered at the same time