### PR TITLE
Revert "The code background and foreground color are inversed for the default high contrast theme"

### DIFF
--- a/src/vs/platform/theme/common/colors/baseColors.ts
+++ b/src/vs/platform/theme/common/colors/baseColors.ts
@@ -65,11 +65,11 @@ export const textSeparatorForeground = registerColor('textSeparator.foreground',
 // ------ text preformat
 
 export const textPreformatForeground = registerColor('textPreformat.foreground',
-	{ light: '#A31515', dark: '#D7BA7D', hcDark: Color.white, hcLight: '#292929' },
+	{ light: '#A31515', dark: '#D7BA7D', hcDark: '#000000', hcLight: '#FFFFFF' },
 	nls.localize('textPreformatForeground', "Foreground color for preformatted text segments."));
 
 export const textPreformatBackground = registerColor('textPreformat.background',
-	{ light: '#0000001A', dark: '#FFFFFF1A', hcDark: Color.black, hcLight: '#F2F2F2' },
+	{ light: '#0000001A', dark: '#FFFFFF1A', hcDark: '#FFFFFF', hcLight: '#09345f' },
 	nls.localize('textPreformatBackground', "Background color for preformatted text segments."));
 
 


### PR DESCRIPTION
This reverts commit 75237f1e98ef3fe0f7273cea64cfe7518e5daad7.

Fixes https://github.com/microsoft/vscode/issues/242313
