### PR TITLE
fix terminal suggest bug where unexpected completions are returned

### DIFF
--- a/extensions/terminal-suggest/src/fig/figInterface.ts
+++ b/extensions/terminal-suggest/src/fig/figInterface.ts
@@ -52,11 +52,10 @@ export async function getFigSuggestions(
 		if (!specLabels) {
 			continue;
 		}
-
 		for (const specLabel of specLabels) {
 			const availableCommand = (osIsWindows()
 				? availableCommands.find(command => (typeof command.label === 'string' ? command.label : command.label.label).match(new RegExp(`${specLabel}(\\.[^ ]+)?$`)))
-				: availableCommands.find(command => (typeof command.label === 'string' ? command.label : command.label.label).startsWith(specLabel)));
+				: availableCommands.find(command => (typeof command.label === 'string' ? command.label : command.label.label) === (specLabel)));
 			if (!availableCommand || (token && token.isCancellationRequested)) {
 				continue;
 			}
@@ -81,13 +80,12 @@ export async function getFigSuggestions(
 
 			const commandAndAliases = (osIsWindows()
 				? availableCommands.filter(command => specLabel === removeAnyFileExtension(command.definitionCommand ?? (typeof command.label === 'string' ? command.label : command.label.label)))
-				: availableCommands.filter(command => specLabel === (command.definitionCommand ?? command.label)));
+				: availableCommands.filter(command => specLabel === (typeof command.label === 'string' ? command.label : command.label.label) || command.definitionCommand));
 			if (
 				!(osIsWindows()
 					? commandAndAliases.some(e => precedingText.startsWith(`${removeAnyFileExtension((typeof e.label === 'string' ? e.label : e.label.label))} `))
-					: commandAndAliases.some(e => precedingText.startsWith(`${e.label} `)))
+					: commandAndAliases.some(e => precedingText.startsWith(`${typeof e.label === 'string' ? e.label : e.label.label} `)))
 			) {
-				// the spec label is not the first word in the command line, so do not provide options or args
 				continue;
 			}
 

--- a/extensions/terminal-suggest/src/fig/figInterface.ts
+++ b/extensions/terminal-suggest/src/fig/figInterface.ts
@@ -54,8 +54,8 @@ export async function getFigSuggestions(
 		}
 		for (const specLabel of specLabels) {
 			const availableCommand = (osIsWindows()
-				? availableCommands.find(command => (typeof command.label === 'string' ? command.label : command.label.label).match(new RegExp(`${specLabel}(\\.[^ ]+)?$`)))
-				: availableCommands.find(command => (typeof command.label === 'string' ? command.label : command.label.label) === (specLabel)));
+				? availableCommands.find(command => (command.definitionCommand ?? (typeof command.label === 'string' ? command.label : command.label.label)).match(new RegExp(`${specLabel}(\\.[^ ]+)?$`)))
+				: availableCommands.find(command => (command.definitionCommand ?? (typeof command.label === 'string' ? command.label : command.label.label) === (specLabel))));
 			if (!availableCommand || (token && token.isCancellationRequested)) {
 				continue;
 			}

--- a/extensions/terminal-suggest/src/fig/figInterface.ts
+++ b/extensions/terminal-suggest/src/fig/figInterface.ts
@@ -80,7 +80,7 @@ export async function getFigSuggestions(
 
 			const commandAndAliases = (osIsWindows()
 				? availableCommands.filter(command => specLabel === removeAnyFileExtension(command.definitionCommand ?? (typeof command.label === 'string' ? command.label : command.label.label)))
-				: availableCommands.filter(command => specLabel === (typeof command.label === 'string' ? command.label : command.label.label) || command.definitionCommand));
+				: availableCommands.filter(command => specLabel === (command.definitionCommand ?? (typeof command.label === 'string' ? command.label : command.label.label))));
 			if (
 				!(osIsWindows()
 					? commandAndAliases.some(e => precedingText.startsWith(`${removeAnyFileExtension((typeof e.label === 'string' ? e.label : e.label.label))} `))

--- a/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalSuggestAddon.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalSuggestAddon.ts
@@ -257,6 +257,7 @@ export class SuggestAddon extends Disposable implements ITerminalAddon, ISuggest
 
 		const completions = providedCompletions?.flat() || [];
 		if (!explicitlyInvoked && !completions.length) {
+			this.hideSuggestWidget(true);
 			return;
 		}
 


### PR DESCRIPTION
- We were adding the spec completion item even when there was no matching available command because of a `startsWith` check - for example,`python3.13` in `availableCommands` would be the reason we add the `python` spec as a command completion. Now, we ensure there's an exact match. for `python`, this means it won't show up unless a user has defined that `alias`. 
- We were checking if `specLabel === command.label` when `command.label` can be an `object`.
- We weren't hiding the widget when there are 0 provided completions _when not manually invoked, IE typing ./_, so it would stick around with the latest model's values.

fixes https://github.com/microsoft/vscode/issues/241909
fixes [#241964](https://github.com/microsoft/vscode/issues/241964)