### PR TITLE
Add PowerShell logic to prevent hanging installer Fix #239521

### DIFF
--- a/build/win32/code.iss
+++ b/build/win32/code.iss
@@ -109,7 +109,7 @@ Filename: "{app}\{#ExeBasename}.exe"; Description: "{cm:LaunchProgram,{#NameLong
 
 #ifdef AppxPackageFullname
 [UninstallRun]
-Filename: "powershell.exe"; Parameters: "Invoke-Command -ScriptBlock {{Remove-AppxPackage -Package ""{#AppxPackageFullname}""}"; Check: IsWindows11OrLater and QualityIsInsiders; Flags: shellexec waituntilterminated runhidden
+Filename: "powershell.exe"; Parameters: "-Command 'Invoke-Command -ScriptBlock {{Remove-AppxPackage -Package \"{#AppxPackageFullname}\"}}' -NonInteractive -NoProfile -NoLogo"; Check: IsWindows11OrLater and QualityIsInsiders; Flags: shellexec waituntilterminated runhidden
 #endif
 
 [Registry]
@@ -1489,7 +1489,7 @@ procedure RemoveAppxPackage();
 var
   RemoveAppxPackageResultCode: Integer;
 begin
-  ShellExec('', 'powershell.exe', '-Command ' + AddQuotes('Remove-AppxPackage -Package ''{#AppxPackageFullname}'''), '', SW_HIDE, ewWaitUntilTerminated, RemoveAppxPackageResultCode);
+  ShellExec('', 'powershell.exe', '-NonInteractive -NoProfile -NoLogo -Command ' + AddQuotes('Remove-AppxPackage -Package ''{#AppxPackageFullname}'' -Confirm:$false -ErrorAction SilentlyContinue'), '', SW_HIDE, ewWaitUntilTerminated, RemoveAppxPackageResultCode);
   if not WizardIsTaskSelected('addcontextmenufiles') then begin
     RegDeleteKeyIncludingSubkeys({#EnvironmentRootKey}, 'Software\Classes\{#RegValueName}ContextMenu');
   end;

--- a/build/win32/code.iss
+++ b/build/win32/code.iss
@@ -109,7 +109,7 @@ Filename: "{app}\{#ExeBasename}.exe"; Description: "{cm:LaunchProgram,{#NameLong
 
 #ifdef AppxPackageFullname
 [UninstallRun]
-Filename: "powershell.exe"; Parameters: "-Command 'Invoke-Command -ScriptBlock {{Remove-AppxPackage -Package \"{#AppxPackageFullname}\"}}' -NonInteractive -NoProfile -NoLogo"; Check: IsWindows11OrLater and QualityIsInsiders; Flags: shellexec waituntilterminated runhidden
+Filename: "powershell.exe"; Parameters: "-Command 'Invoke-Command -ScriptBlock {{Remove-AppxPackage -Package \"{#AppxPackageFullname}\" -Confirm:$false -ErrorAction SilentlyContinue}}' -NonInteractive -NoProfile -NoLogo"; Check: IsWindows11OrLater and QualityIsInsiders; Flags: shellexec waituntilterminated runhidden
 #endif
 
 [Registry]


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Here's a pull request description based on the provided changes:

---

### Pull Request Description

#### Summary

This pull request addresses the issue #239521, where the PowerShell hanging on update is caused by the `Remove-AppxPackage` failure. The changes ensure that:

1. PowerShell does not attempt to load the user's profile, which might itself cause the install to hang.
2. If the `Remove-AppxPackage` fails, the PowerShell instance gracefully exits.

#### Details

**Changes in `code.iss`:**

1. Added the following parameters to the PowerShell command: `-NonInteractive -NoProfile -NoLogo -Confirm:$false -ErrorAction SilentlyContinue`.
2. Modified the `UninstallRun` and `RemoveAppxPackage` procedure to include these parameters.

These changes need to be tested to determine if the single-quoting on the commands is sufficient and well-formed.