### PR TITLE
Add folder action support

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/actions/chatContextActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatContextActions.ts
@@ -68,8 +68,10 @@ import { ATTACH_PROMPT_ACTION_ID, AttachPromptAction, IChatAttachPromptActionOpt
 export function registerChatContextActions() {
 	registerAction2(AttachContextAction);
 	registerAction2(AttachFileToChatAction);
+	registerAction2(AttachFolderToChatAction);
 	registerAction2(AttachSelectionToChatAction);
 	registerAction2(AttachFileToEditingSessionAction);
+	registerAction2(AttachFolderToEditingSessionAction);
 	registerAction2(AttachSelectionToEditingSessionAction);
 }
 
@@ -253,8 +255,8 @@ interface IReusablePromptQuickPickItem extends IQuickPickItem {
 	keybinding?: ResolvedKeybinding;
 }
 
-abstract class AttachFileAction extends Action2 {
-	getFiles(accessor: ServicesAccessor, ...args: any[]): URI[] {
+abstract class AttachResourceAction extends Action2 {
+	getResources(accessor: ServicesAccessor, ...args: any[]): URI[] {
 		const editorService = accessor.get(IEditorService);
 
 		const contexts = Array.isArray(args[1]) ? args[1] : [args[0]];
@@ -280,7 +282,7 @@ abstract class AttachFileAction extends Action2 {
 	}
 }
 
-class AttachFileToChatAction extends AttachFileAction {
+class AttachFileToChatAction extends AttachResourceAction {
 
 	static readonly ID = 'workbench.action.chat.attachFile';
 
@@ -301,12 +303,38 @@ class AttachFileToChatAction extends AttachFileAction {
 
 	override async run(accessor: ServicesAccessor, ...args: any[]): Promise<void> {
 		const variablesService = accessor.get(IChatVariablesService);
-		const files = this.getFiles(accessor, ...args);
+		const files = this.getResources(accessor, ...args);
 
 		if (files.length) {
 			(await showChatView(accessor.get(IViewsService)))?.focusInput();
 			for (const file of files) {
 				variablesService.attachContext('file', file, ChatAgentLocation.Panel);
+			}
+		}
+	}
+}
+
+class AttachFolderToChatAction extends AttachResourceAction {
+
+	static readonly ID = 'workbench.action.chat.attachFolder';
+
+	constructor() {
+		super({
+			id: AttachFolderToChatAction.ID,
+			title: localize2('workbench.action.chat.attachFolder.label', "Add Folder to Chat"),
+			category: CHAT_CATEGORY,
+			f1: false,
+		});
+	}
+
+	override async run(accessor: ServicesAccessor, ...args: any[]): Promise<void> {
+		const variablesService = accessor.get(IChatVariablesService);
+		const folders = this.getResources(accessor, ...args);
+
+		if (folders.length) {
+			(await showChatView(accessor.get(IViewsService)))?.focusInput();
+			for (const folder of folders) {
+				variablesService.attachContext('folder', folder, ChatAgentLocation.Panel);
 			}
 		}
 	}
@@ -373,7 +401,7 @@ class AttachSelectionToChatAction extends Action2 {
 	}
 }
 
-class AttachFileToEditingSessionAction extends AttachFileAction {
+class AttachFileToEditingSessionAction extends AttachResourceAction {
 
 	static readonly ID = 'workbench.action.edits.attachFile';
 
@@ -394,12 +422,38 @@ class AttachFileToEditingSessionAction extends AttachFileAction {
 
 	override async run(accessor: ServicesAccessor, ...args: any[]): Promise<void> {
 		const variablesService = accessor.get(IChatVariablesService);
-		const files = this.getFiles(accessor, ...args);
+		const files = this.getResources(accessor, ...args);
 
 		if (files.length) {
 			(await showEditsView(accessor.get(IViewsService)))?.focusInput();
 			for (const file of files) {
 				variablesService.attachContext('file', file, ChatAgentLocation.EditingSession);
+			}
+		}
+	}
+}
+
+class AttachFolderToEditingSessionAction extends AttachResourceAction {
+
+	static readonly ID = 'workbench.action.edits.attachFolder';
+
+	constructor() {
+		super({
+			id: AttachFolderToEditingSessionAction.ID,
+			title: localize2('workbench.action.edits.attachFolder.label', "Add Folder to {0}", 'Copilot Edits'),
+			category: CHAT_CATEGORY,
+			f1: false,
+		});
+	}
+
+	override async run(accessor: ServicesAccessor, ...args: any[]): Promise<void> {
+		const variablesService = accessor.get(IChatVariablesService);
+		const folders = this.getResources(accessor, ...args);
+
+		if (folders.length) {
+			(await showEditsView(accessor.get(IViewsService)))?.focusInput();
+			for (const folder of folders) {
+				variablesService.attachContext('folder', folder, ChatAgentLocation.EditingSession);
 			}
 		}
 	}

--- a/src/vs/workbench/contrib/chat/browser/chatAttachmentModel.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatAttachmentModel.ts
@@ -71,6 +71,16 @@ export class ChatAttachmentModel extends Disposable {
 		this.addContext(this.asVariableEntry(uri, range));
 	}
 
+	addFolder(uri: URI) {
+		this.addContext({
+			value: uri,
+			id: uri.toString(),
+			name: basename(uri),
+			isFile: false,
+			isDirectory: true,
+		});
+	}
+
 	asVariableEntry(uri: URI, range?: IRange, isMarkedReadonly?: boolean): IChatRequestVariableEntry {
 		return {
 			value: range ? { uri, range } : uri,

--- a/src/vs/workbench/contrib/chat/browser/chatVariables.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatVariables.ts
@@ -87,5 +87,10 @@ export class ChatVariablesService implements IChatVariablesService {
 			widget.attachmentModel.addFile(uri, range);
 			return;
 		}
+
+		if (key === 'folder' && URI.isUri(value)) {
+			widget.attachmentModel.addFolder(value);
+			return;
+		}
 	}
 }


### PR DESCRIPTION
```Copilot Generated Description:``` Introduce actions to attach folders to chat and editing sessions, enhancing the functionality for managing folder attachments. Additionally, update the attachment model to handle folder contexts.

https://github.com/microsoft/vscode/issues/237319