### PR TITLE
Fix ghost text clickable bug

### DIFF
--- a/src/vs/editor/contrib/inlineCompletions/browser/view/ghostText/ghostTextView.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/ghostText/ghostTextView.ts
@@ -81,7 +81,7 @@ export class GhostTextView extends Disposable {
 					return;
 				}
 				const a = e.target.detail.injectedText?.options.attachedData;
-				if (a instanceof GhostTextAttachedData) {
+				if (a instanceof GhostTextAttachedData && a.owner === this) {
 					this._onDidClick.fire(e.event);
 				}
 			}));
@@ -229,7 +229,7 @@ export class GhostTextView extends Disposable {
 							+ extraClassNames
 							+ p.lineDecorations.map(d => ' ' + d.className).join(' '), // TODO: take the ranges into account for line decorations
 						cursorStops: InjectedTextCursorStops.Left,
-						attachedData: new GhostTextAttachedData(),
+						attachedData: new GhostTextAttachedData(this),
 					},
 					showIfCollapsed: true,
 				}
@@ -258,7 +258,9 @@ export class GhostTextView extends Disposable {
 	);
 
 	private readonly _isInlineTextHovered = this._editorObs.isTargetHovered(
-		p => p.target.type === MouseTargetType.CONTENT_TEXT && p.target.detail.injectedText?.options.attachedData instanceof GhostTextAttachedData,
+		p => p.target.type === MouseTargetType.CONTENT_TEXT &&
+			p.target.detail.injectedText?.options.attachedData instanceof GhostTextAttachedData &&
+			p.target.detail.injectedText.options.attachedData.owner === this,
 		this._store
 	);
 
@@ -277,7 +279,9 @@ export class GhostTextView extends Disposable {
 	}
 }
 
-class GhostTextAttachedData { }
+class GhostTextAttachedData {
+	constructor(public readonly owner: GhostTextView) { }
+}
 
 interface WidgetDomElement {
 	ghostTextViewWarningWidgetData?: {

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/originalEditorInlineDiffView.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/originalEditorInlineDiffView.ts
@@ -41,7 +41,9 @@ export class OriginalEditorInlineDiffView extends Disposable implements IInlineE
 	readonly onDidClick = this._onDidClick.event;
 
 	readonly isHovered = observableCodeEditor(this._originalEditor).isTargetHovered(
-		p => p.target.type === MouseTargetType.CONTENT_TEXT && p.target.detail.injectedText?.options.attachedData instanceof InlineEditAttachedData,
+		p => p.target.type === MouseTargetType.CONTENT_TEXT &&
+			p.target.detail.injectedText?.options.attachedData instanceof InlineEditAttachedData &&
+			p.target.detail.injectedText.options.attachedData.owner === this,
 		this._store
 	);
 
@@ -71,7 +73,7 @@ export class OriginalEditorInlineDiffView extends Disposable implements IInlineE
 				return;
 			}
 			const a = e.target.detail.injectedText?.options.attachedData;
-			if (a instanceof InlineEditAttachedData) {
+			if (a instanceof InlineEditAttachedData && a.owner === this) {
 				this._onDidClick.fire(e.event);
 			}
 		}));
@@ -263,7 +265,7 @@ export class OriginalEditorInlineDiffView extends Disposable implements IInlineE
 											...extraClasses // include extraClasses for additional styling if provided
 										),
 										cursorStops: InjectedTextCursorStops.None,
-										attachedData: new InlineEditAttachedData(),
+										attachedData: new InlineEditAttachedData(this),
 									},
 									zIndex: 2,
 									showIfCollapsed: true,
@@ -280,6 +282,7 @@ export class OriginalEditorInlineDiffView extends Disposable implements IInlineE
 }
 
 class InlineEditAttachedData {
+	constructor(public readonly owner: OriginalEditorInlineDiffView) { }
 }
 
 function allowsTrueInlineDiffRendering(mapping: DetailedLineRangeMapping): boolean {


### PR DESCRIPTION
```Copilot Generated Description:``` Ensure that ghost text and inline edit elements are only clickable by their respective owners. This change adds an owner property to the attached data classes to enforce this behavior.