### PR TITLE
status - try to align icons and text in language status

### DIFF
--- a/src/vs/workbench/contrib/languageStatus/browser/languageStatus.ts
+++ b/src/vs/workbench/contrib/languageStatus/browser/languageStatus.ts
@@ -308,16 +308,10 @@ class LanguageStatus {
 		left.classList.add('left');
 		element.appendChild(left);
 
-		const label = document.createElement('span');
-		label.classList.add('label');
-		const labelValue = typeof status.label === 'string' ? status.label : status.label.value;
-		dom.append(label, ...renderLabelWithIcons(computeText(labelValue, status.busy)));
-		left.appendChild(label);
+		const label = typeof status.label === 'string' ? status.label : status.label.value;
+		dom.append(left, ...renderLabelWithIcons(computeText(label, status.busy)));
 
-		const detail = document.createElement('span');
-		detail.classList.add('detail');
-		this._renderTextPlus(detail, status.detail, store);
-		left.appendChild(detail);
+		this._renderTextPlus(left, status.detail, store);
 
 		const right = document.createElement('div');
 		right.classList.add('right');
@@ -379,7 +373,12 @@ class LanguageStatus {
 	}
 
 	private _renderTextPlus(target: HTMLElement, text: string, store: DisposableStore): void {
+		let didRenderSeparator = false;
 		for (const node of parseLinkedText(text).nodes) {
+			if (!didRenderSeparator) {
+				dom.append(target, dom.$('span.separator'));
+				didRenderSeparator = true;
+			}
 			if (typeof node === 'string') {
 				const parts = renderLabelWithIcons(node);
 				dom.append(target, ...parts);

--- a/src/vs/workbench/contrib/languageStatus/browser/media/languageStatus.css
+++ b/src/vs/workbench/contrib/languageStatus/browser/media/languageStatus.css
@@ -87,18 +87,22 @@
 	flex-grow: 100;
 }
 
-.monaco-workbench .hover-language-status > .element > .left > .detail:not(:empty)::before {
+.monaco-workbench .hover-language-status > .element > .left > .separator::before {
 	content: '\2013';
-	padding: 0 4px;
+	padding: 0 2px;
 	opacity: 0.6;
 }
 
-.monaco-workbench .hover-language-status > .element > .left > .label:empty {
+.monaco-workbench .hover-language-status > .element > .left:empty {
 	display: none;
 }
 
 .monaco-workbench .hover-language-status > .element .left {
 	margin: auto 0;
+	display: flex;
+	align-items: center;
+	gap: 3px;
+	white-space: nowrap;
 }
 
 .monaco-workbench .hover-language-status > .element .right {


### PR DESCRIPTION
An attempt to better align codicons and text in language status indicators.

**Before (codicon and text are not perfectly aligned)**
![Screenshot 2025-03-03 at 16 03 30](https://github.com/user-attachments/assets/0054d70a-5c8f-49bf-8663-673f57c2913b)


**After**

![Screenshot 2025-03-03 at 16 02 56](https://github.com/user-attachments/assets/765e2d81-dc5d-4814-89d5-56590b4ac69c)

Using `flex` layout, which requires all elements to be direct children to be properly aligned among each other. I also had to explicitly disable whitespace wrapping.

cc @mrleemurray 
