### PR TITLE
add setting to configure what up arrow does when focus is on first suggestion for terminal completions

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminal.suggest.contribution.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminal.suggest.contribution.ts
@@ -57,7 +57,7 @@ class TerminalSuggestContribution extends DisposableStore implements ITerminalCo
 		@IContextKeyService private readonly _contextKeyService: IContextKeyService,
 		@IConfigurationService private readonly _configurationService: IConfigurationService,
 		@IInstantiationService private readonly _instantiationService: IInstantiationService,
-		@ITerminalCompletionService private readonly _terminalCompletionService: ITerminalCompletionService
+		@ITerminalCompletionService private readonly _terminalCompletionService: ITerminalCompletionService,
 	) {
 		super();
 		this.add(toDisposable(() => {
@@ -228,7 +228,8 @@ registerActiveInstanceAction({
 	keybinding: {
 		// Up is bound to other workbench keybindings that this needs to beat
 		primary: KeyCode.UpArrow,
-		weight: KeybindingWeight.WorkbenchContrib + 1
+		weight: KeybindingWeight.WorkbenchContrib + 1,
+		when: ContextKeyExpr.or(SimpleSuggestContext.FocusedFirstSuggestion.negate(), ContextKeyExpr.equals(`config.${TerminalSuggestSettingId.UpArrowNavigatesHistory}`, false))
 	},
 	run: (activeInstance) => TerminalSuggestContribution.get(activeInstance)?.addon?.selectPreviousSuggestion()
 });
@@ -351,11 +352,16 @@ registerActiveInstanceAction({
 	title: localize2('workbench.action.terminal.hideSuggestWidget', 'Hide Suggest Widget'),
 	f1: false,
 	precondition: ContextKeyExpr.and(ContextKeyExpr.or(TerminalContextKeys.processSupported, TerminalContextKeys.terminalHasBeenCreated), TerminalContextKeys.focus, TerminalContextKeys.isOpen, TerminalContextKeys.suggestWidgetVisible),
-	keybinding: {
+	keybinding: [{
 		primary: KeyCode.Escape,
 		// Escape is bound to other workbench keybindings that this needs to beat
 		weight: KeybindingWeight.WorkbenchContrib + 1
 	},
+	{
+		primary: KeyCode.UpArrow,
+		when: ContextKeyExpr.and(SimpleSuggestContext.FocusedFirstSuggestion, ContextKeyExpr.equals(`config.${TerminalSuggestSettingId.UpArrowNavigatesHistory}`, true)),
+		weight: KeybindingWeight.WorkbenchContrib + 2
+	}],
 	run: (activeInstance) => TerminalSuggestContribution.get(activeInstance)?.addon?.hideSuggestWidget(true)
 });
 

--- a/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminal.suggest.contribution.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminal.suggest.contribution.ts
@@ -57,7 +57,7 @@ class TerminalSuggestContribution extends DisposableStore implements ITerminalCo
 		@IContextKeyService private readonly _contextKeyService: IContextKeyService,
 		@IConfigurationService private readonly _configurationService: IConfigurationService,
 		@IInstantiationService private readonly _instantiationService: IInstantiationService,
-		@ITerminalCompletionService private readonly _terminalCompletionService: ITerminalCompletionService,
+		@ITerminalCompletionService private readonly _terminalCompletionService: ITerminalCompletionService
 	) {
 		super();
 		this.add(toDisposable(() => {

--- a/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminal.suggest.contribution.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminal.suggest.contribution.ts
@@ -229,7 +229,7 @@ registerActiveInstanceAction({
 		// Up is bound to other workbench keybindings that this needs to beat
 		primary: KeyCode.UpArrow,
 		weight: KeybindingWeight.WorkbenchContrib + 1,
-		when: ContextKeyExpr.or(SimpleSuggestContext.FocusedFirstSuggestion.negate(), ContextKeyExpr.equals(`config.${TerminalSuggestSettingId.UpArrowNavigatesHistory}`, false))
+		when: ContextKeyExpr.or(SimpleSuggestContext.HasNavigated, ContextKeyExpr.equals(`config.${TerminalSuggestSettingId.UpArrowNavigatesHistory}`, false))
 	},
 	run: (activeInstance) => TerminalSuggestContribution.get(activeInstance)?.addon?.selectPreviousSuggestion()
 });
@@ -368,7 +368,7 @@ registerActiveInstanceAction({
 	keybinding:
 	{
 		primary: KeyCode.UpArrow,
-		when: ContextKeyExpr.and(SimpleSuggestContext.FocusedFirstSuggestion, ContextKeyExpr.equals(`config.${TerminalSuggestSettingId.UpArrowNavigatesHistory}`, true)),
+		when: ContextKeyExpr.and(SimpleSuggestContext.HasNavigated.negate(), ContextKeyExpr.equals(`config.${TerminalSuggestSettingId.UpArrowNavigatesHistory}`, true)),
 		weight: KeybindingWeight.WorkbenchContrib + 2
 	},
 	run: (activeInstance) => {

--- a/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminal.suggest.contribution.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminal.suggest.contribution.ts
@@ -352,17 +352,29 @@ registerActiveInstanceAction({
 	title: localize2('workbench.action.terminal.hideSuggestWidget', 'Hide Suggest Widget'),
 	f1: false,
 	precondition: ContextKeyExpr.and(ContextKeyExpr.or(TerminalContextKeys.processSupported, TerminalContextKeys.terminalHasBeenCreated), TerminalContextKeys.focus, TerminalContextKeys.isOpen, TerminalContextKeys.suggestWidgetVisible),
-	keybinding: [{
+	keybinding: {
 		primary: KeyCode.Escape,
 		// Escape is bound to other workbench keybindings that this needs to beat
 		weight: KeybindingWeight.WorkbenchContrib + 1
 	},
+	run: (activeInstance) => TerminalSuggestContribution.get(activeInstance)?.addon?.hideSuggestWidget(true)
+});
+
+registerActiveInstanceAction({
+	id: TerminalSuggestCommandId.HideSuggestWidgetAndNavigateHistory,
+	title: localize2('workbench.action.terminal.hideSuggestWidgetAndNavigateHistory', 'Hide Suggest Widget and Navigate History'),
+	f1: false,
+	precondition: ContextKeyExpr.and(ContextKeyExpr.or(TerminalContextKeys.processSupported, TerminalContextKeys.terminalHasBeenCreated), TerminalContextKeys.focus, TerminalContextKeys.isOpen, TerminalContextKeys.suggestWidgetVisible),
+	keybinding:
 	{
 		primary: KeyCode.UpArrow,
 		when: ContextKeyExpr.and(SimpleSuggestContext.FocusedFirstSuggestion, ContextKeyExpr.equals(`config.${TerminalSuggestSettingId.UpArrowNavigatesHistory}`, true)),
 		weight: KeybindingWeight.WorkbenchContrib + 2
-	}],
-	run: (activeInstance) => TerminalSuggestContribution.get(activeInstance)?.addon?.hideSuggestWidget(true)
+	},
+	run: (activeInstance) => {
+		TerminalSuggestContribution.get(activeInstance)?.addon?.hideSuggestWidget(true);
+		activeInstance.sendText('\u001b[A', false); // Up arrow
+	}
 });
 
 registerActiveInstanceAction({

--- a/src/vs/workbench/contrib/terminalContrib/suggest/common/terminal.suggest.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/common/terminal.suggest.ts
@@ -11,6 +11,7 @@ export const enum TerminalSuggestCommandId {
 	AcceptSelectedSuggestion = 'workbench.action.terminal.acceptSelectedSuggestion',
 	AcceptSelectedSuggestionEnter = 'workbench.action.terminal.acceptSelectedSuggestionEnter',
 	HideSuggestWidget = 'workbench.action.terminal.hideSuggestWidget',
+	HideSuggestWidgetAndNavigateHistory = 'workbench.action.terminal.hideSuggestWidgetAndNavigateHistory',
 	ClearSuggestCache = 'workbench.action.terminal.clearSuggestCache',
 	RequestCompletions = 'workbench.action.terminal.requestCompletions',
 	ResetWidgetSize = 'workbench.action.terminal.resetSuggestWidgetSize',

--- a/src/vs/workbench/contrib/terminalContrib/suggest/common/terminalSuggestConfiguration.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/common/terminalSuggestConfiguration.ts
@@ -173,7 +173,7 @@ export const terminalSuggestConfiguration: IStringDictionary<IConfigurationPrope
 	},
 	[TerminalSuggestSettingId.UpArrowNavigatesHistory]: {
 		restricted: true,
-		markdownDescription: localize('suggest.upArrowNavigatesHistory', "Determines whether the up arrow key navigates the command history when focus is on the first suggestion. When set to false, the up arrow will move focus to the last suggestion instead."),
+		markdownDescription: localize('suggest.upArrowNavigatesHistory', "Determines whether the up arrow key navigates the command history when focus is on the first suggestion and navigation has not yet occurred. When set to false, the up arrow will move focus to the last suggestion instead."),
 		type: 'boolean',
 		default: true,
 		tags: ['preview']

--- a/src/vs/workbench/contrib/terminalContrib/suggest/common/terminalSuggestConfiguration.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/common/terminalSuggestConfiguration.ts
@@ -18,6 +18,7 @@ export const enum TerminalSuggestSettingId {
 	ShowStatusBar = 'terminal.integrated.suggest.showStatusBar',
 	CdPath = 'terminal.integrated.suggest.cdPath',
 	InlineSuggestion = 'terminal.integrated.suggest.inlineSuggestion',
+	UpArrowNavigatesHistory = 'terminal.integrated.suggest.upArrowNavigatesHistory',
 }
 
 export const windowsDefaultExecutableExtensions: string[] = [
@@ -169,7 +170,14 @@ export const terminalSuggestConfiguration: IStringDictionary<IConfigurationPrope
 		],
 		default: 'alwaysOnTop',
 		tags: ['preview']
-	}
+	},
+	[TerminalSuggestSettingId.UpArrowNavigatesHistory]: {
+		restricted: true,
+		markdownDescription: localize('suggest.upArrowNavigatesHistory', "Determines whether the up arrow key navigates the command history when focus is on the first suggestion. When set to false, the up arrow will move focus to the last suggestion instead."),
+		type: 'boolean',
+		default: true,
+		tags: ['preview']
+	},
 };
 
 

--- a/src/vs/workbench/services/suggest/browser/simpleSuggestWidget.ts
+++ b/src/vs/workbench/services/suggest/browser/simpleSuggestWidget.ts
@@ -55,6 +55,7 @@ const enum WidgetPositionPreference {
 
 export const SimpleSuggestContext = {
 	HasFocusedSuggestion: new RawContextKey<boolean>('simpleSuggestWidgetHasFocusedSuggestion', false, localize('simpleSuggestWidgetHasFocusedSuggestion', "Whether any simple suggestion is focused")),
+	FocusedFirstSuggestion: new RawContextKey<boolean>('simpleSuggestWidgetFocusedFirstSuggestion', false, localize('simpleSuggestWidgetFocusedFirstSuggestion', "Whether the first simple suggestion is focused")),
 };
 
 export interface IWorkbenchSuggestWidgetOptions {
@@ -110,6 +111,7 @@ export class SimpleSuggestWidget<TModel extends SimpleCompletionModel<TItem>, TI
 	get list(): List<TItem> { return this._list; }
 
 	private readonly _ctxSuggestWidgetHasFocusedSuggestion: IContextKey<boolean>;
+	private readonly _ctxSuggestWidgetFocusedFirstSuggestion: IContextKey<boolean>;
 
 	constructor(
 		private readonly _container: HTMLElement,
@@ -128,6 +130,7 @@ export class SimpleSuggestWidget<TModel extends SimpleCompletionModel<TItem>, TI
 		this.element.domNode.classList.add('workbench-suggest-widget');
 		this._container.appendChild(this.element.domNode);
 		this._ctxSuggestWidgetHasFocusedSuggestion = SimpleSuggestContext.HasFocusedSuggestion.bindTo(_contextKeyService);
+		this._ctxSuggestWidgetFocusedFirstSuggestion = SimpleSuggestContext.FocusedFirstSuggestion.bindTo(_contextKeyService);
 
 		class ResizeState {
 			constructor(
@@ -217,7 +220,13 @@ export class SimpleSuggestWidget<TModel extends SimpleCompletionModel<TItem>, TI
 				},
 			}
 		}));
-
+		this._register(this._list.onDidChangeFocus(e => {
+			if (e.indexes[0] === 0) {
+				this._ctxSuggestWidgetFocusedFirstSuggestion.set(true);
+			} else {
+				this._ctxSuggestWidgetFocusedFirstSuggestion.set(false);
+			}
+		}));
 		this._messageElement = dom.append(this.element.domNode, dom.$('.message'));
 
 		const details: SimpleSuggestDetailsWidget = this._register(instantiationService.createInstance(SimpleSuggestDetailsWidget, this._getFontInfo.bind(this), this._onDidFontConfigurationChange.bind(this)));

--- a/src/vs/workbench/services/suggest/browser/simpleSuggestWidget.ts
+++ b/src/vs/workbench/services/suggest/browser/simpleSuggestWidget.ts
@@ -55,7 +55,7 @@ const enum WidgetPositionPreference {
 
 export const SimpleSuggestContext = {
 	HasFocusedSuggestion: new RawContextKey<boolean>('simpleSuggestWidgetHasFocusedSuggestion', false, localize('simpleSuggestWidgetHasFocusedSuggestion', "Whether any simple suggestion is focused")),
-	FocusedFirstSuggestion: new RawContextKey<boolean>('simpleSuggestWidgetFocusedFirstSuggestion', false, localize('simpleSuggestWidgetFocusedFirstSuggestion', "Whether the first simple suggestion is focused")),
+	HasNavigated: new RawContextKey<boolean>('simpleSuggestWidgetHasNavigated', false, localize('simpleSuggestWidgetHasNavigated', "Whether the simple suggestion widget has been navigated downwards")),
 };
 
 export interface IWorkbenchSuggestWidgetOptions {
@@ -111,7 +111,7 @@ export class SimpleSuggestWidget<TModel extends SimpleCompletionModel<TItem>, TI
 	get list(): List<TItem> { return this._list; }
 
 	private readonly _ctxSuggestWidgetHasFocusedSuggestion: IContextKey<boolean>;
-	private readonly _ctxSuggestWidgetFocusedFirstSuggestion: IContextKey<boolean>;
+	private readonly _ctxSuggestWidgetHasBeenNavigated: IContextKey<boolean>;
 
 	constructor(
 		private readonly _container: HTMLElement,
@@ -130,7 +130,7 @@ export class SimpleSuggestWidget<TModel extends SimpleCompletionModel<TItem>, TI
 		this.element.domNode.classList.add('workbench-suggest-widget');
 		this._container.appendChild(this.element.domNode);
 		this._ctxSuggestWidgetHasFocusedSuggestion = SimpleSuggestContext.HasFocusedSuggestion.bindTo(_contextKeyService);
-		this._ctxSuggestWidgetFocusedFirstSuggestion = SimpleSuggestContext.FocusedFirstSuggestion.bindTo(_contextKeyService);
+		this._ctxSuggestWidgetHasBeenNavigated = SimpleSuggestContext.HasNavigated.bindTo(_contextKeyService);
 
 		class ResizeState {
 			constructor(
@@ -221,10 +221,8 @@ export class SimpleSuggestWidget<TModel extends SimpleCompletionModel<TItem>, TI
 			}
 		}));
 		this._register(this._list.onDidChangeFocus(e => {
-			if (e.indexes[0] === 0) {
-				this._ctxSuggestWidgetFocusedFirstSuggestion.set(true);
-			} else {
-				this._ctxSuggestWidgetFocusedFirstSuggestion.set(false);
+			if (e.indexes.length && e.indexes[0] !== 0) {
+				this._ctxSuggestWidgetHasBeenNavigated.set(true);
 			}
 		}));
 		this._messageElement = dom.append(this.element.domNode, dom.$('.message'));


### PR DESCRIPTION
To avoid breaking muscle memory, when focus is on the first suggestion, up arrow hides the widget by default so history navigation prevails.

fix #241833

https://github.com/user-attachments/assets/fefa1a13-0648-45bf-a22d-ca78858a36ce

