### PR TITLE
debug: fix stopDebugging needing to be called twice for test-init debug sessions

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/debugService.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugService.ts
@@ -867,7 +867,7 @@ export class DebugService implements IDebugService {
 		// the session, then start the test run again; tests have no notion of restarts.
 		if (session.correlatedTestRun) {
 			if (!session.correlatedTestRun.completedAt) {
-				this.testService.cancelTestRun(session.correlatedTestRun.id);
+				session.cancelCorrelatedTestRun();
 				await Event.toPromise(session.correlatedTestRun.onComplete);
 				// todo@connor4312 is there any reason to wait for the debug session to
 				// terminate? I don't think so, test extension should already handle any

--- a/src/vs/workbench/contrib/debug/browser/debugSession.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugSession.ts
@@ -403,6 +403,16 @@ export class DebugSession implements IDebugSession, IDisposable {
 	}
 
 	/**
+	 * Terminate any linked test run.
+	 */
+	cancelCorrelatedTestRun() {
+		if (this.correlatedTestRun && !this.correlatedTestRun.completedAt) {
+			this.didTerminateTestRun = true;
+			this.testService.cancelTestRun(this.correlatedTestRun.id);
+		}
+	}
+
+	/**
 	 * terminate the current debug adapter session
 	 */
 	async terminate(restart = false): Promise<void> {
@@ -415,8 +425,7 @@ export class DebugSession implements IDebugSession, IDisposable {
 		if (this._options.lifecycleManagedByParent && this.parentSession) {
 			await this.parentSession.terminate(restart);
 		} else if (this.correlatedTestRun && !this.correlatedTestRun.completedAt && !this.didTerminateTestRun) {
-			this.didTerminateTestRun = true;
-			this.testService.cancelTestRun(this.correlatedTestRun.id);
+			this.cancelCorrelatedTestRun();
 		} else if (this.raw) {
 			if (this.raw.capabilities.supportsTerminateRequest && this._configuration.resolved.request === 'launch') {
 				await this.raw.terminate(restart);

--- a/src/vs/workbench/contrib/debug/common/debug.ts
+++ b/src/vs/workbench/contrib/debug/common/debug.ts
@@ -412,6 +412,8 @@ export interface IDebugSession extends ITreeElement {
 	removeReplExpressions(): void;
 	addReplExpression(stackFrame: IStackFrame | undefined, name: string): Promise<void>;
 	appendToRepl(data: INewReplElementData): void;
+	/** Cancel any associated test run set through the DebugSessionOptions */
+	cancelCorrelatedTestRun(): void;
 
 	// session events
 	readonly onDidEndAdapter: Event<AdapterEndEvent | undefined>;

--- a/src/vs/workbench/contrib/debug/test/common/mockDebug.ts
+++ b/src/vs/workbench/contrib/debug/test/common/mockDebug.ts
@@ -195,6 +195,10 @@ export class MockSession implements IDebugSession {
 		throw new Error('Method not implemented.');
 	}
 
+	cancelCorrelatedTestRun(): void {
+
+	}
+
 	get compoundRoot(): DebugCompoundRoot | undefined {
 		return undefined;
 	}


### PR DESCRIPTION
Fixes #242124

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
