### PR TITLE
Fix configured deprecated settings not showing up

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
@@ -1540,7 +1540,9 @@ export class SettingsEditor2 extends EditorPane {
 
 	private refreshSingleElement(element: SettingsTreeSettingElement): void {
 		if (this.isVisible()) {
-			this.settingsTree.rerender(element);
+			if (!element.setting.deprecationMessage || element.isConfigured) {
+				this.settingsTree.rerender(element);
+			}
 		}
 	}
 

--- a/src/vs/workbench/contrib/preferences/browser/settingsTreeModels.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsTreeModels.ts
@@ -596,10 +596,15 @@ export class SettingsTreeModel implements IDisposable {
 		if (tocEntry.settings) {
 			const settingChildren = tocEntry.settings.map(s => this.createSettingsTreeSettingElement(s, element));
 			for (const child of settingChildren) {
-				if (!child.setting.deprecationMessage || child.isConfigured) {
+				if (!child.setting.deprecationMessage) {
 					children.push(child);
 				} else {
-					child.dispose();
+					child.inspectSelf();
+					if (child.isConfigured) {
+						children.push(child);
+					} else {
+						child.dispose();
+					}
 				}
 			}
 		}


### PR DESCRIPTION
The OSS console error about a setting not being found while refreshing the Settings editor uncovered a bug: configured deprecated settings were not showing up in the Settings editor in general because of a missing `inspectSelf` call.