### PR TITLE
Fix italic text cutoff in tabs and settings

### DIFF
--- a/src/vs/workbench/browser/parts/editor/media/multieditortabscontrol.css
+++ b/src/vs/workbench/browser/parts/editor/media/multieditortabscontrol.css
@@ -367,6 +367,10 @@
 	}
 }
 
+.monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.sizing-fit .monaco-icon-label.italic {
+	padding-right: 3px; /* https://github.com/microsoft/vscode/issues/207409 */
+}
+
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.sizing-shrink > .monaco-icon-label > .monaco-icon-label-container,
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.sizing-fixed > .monaco-icon-label > .monaco-icon-label-container {
 	text-overflow: clip;


### PR DESCRIPTION
```Copilot Generated Description:``` Adjust the padding for italic text in tabs to prevent it from being cut off at the end. This change addresses the issue reported in microsoft/vscode#207409.