### PR TITLE
require 'prompt files' synchronization to be explicitly enabled by users

### DIFF
--- a/src/vs/platform/userDataSync/common/userDataSync.ts
+++ b/src/vs/platform/userDataSync/common/userDataSync.ts
@@ -532,7 +532,7 @@ export interface IUserDataSyncEnablementService {
 	setEnablement(enabled: boolean): void;
 
 	readonly onDidChangeResourceEnablement: Event<[SyncResource, boolean]>;
-	isResourceEnabled(resource: SyncResource): boolean;
+	isResourceEnabled(resource: SyncResource, defaultValue?: boolean): boolean;
 	setResourceEnablement(resource: SyncResource, enabled: boolean): void;
 
 	getResourceSyncStateVersion(resource: SyncResource): string | undefined;

--- a/src/vs/platform/userDataSync/common/userDataSyncEnablementService.ts
+++ b/src/vs/platform/userDataSync/common/userDataSyncEnablementService.ts
@@ -52,8 +52,10 @@ export class UserDataSyncEnablementService extends Disposable implements IUserDa
 		this.storageService.store(enablementKey, enabled, StorageScope.APPLICATION, StorageTarget.MACHINE);
 	}
 
-	isResourceEnabled(resource: SyncResource): boolean {
-		return this.storageService.getBoolean(getEnablementKey(resource), StorageScope.APPLICATION, true);
+	isResourceEnabled(resource: SyncResource, defaultValue?: boolean): boolean {
+		const storedValue = this.storageService.getBoolean(getEnablementKey(resource), StorageScope.APPLICATION);
+		defaultValue = defaultValue ?? resource !== SyncResource.Prompts;
+		return storedValue ?? defaultValue;
 	}
 
 	setResourceEnablement(resource: SyncResource, enabled: boolean): void {

--- a/src/vs/platform/userDataSync/test/common/userDataSyncClient.ts
+++ b/src/vs/platform/userDataSync/test/common/userDataSyncClient.ts
@@ -141,6 +141,11 @@ export class UserDataSyncClient extends Disposable {
 			await fileService.writeFile(environmentService.argvResource, VSBuffer.fromString(JSON.stringify({ 'locale': 'en' })));
 		}
 		await configurationService.reloadConfiguration();
+
+		// `prompts` resource is disabled by default, so enable it for tests
+		this.instantiationService
+			.get(IUserDataSyncEnablementService)
+			.setResourceEnablement(SyncResource.Prompts, true);
 	}
 
 	async sync(): Promise<void> {

--- a/src/vs/workbench/contrib/userDataSync/browser/userDataSync.ts
+++ b/src/vs/workbench/contrib/userDataSync/browser/userDataSync.ts
@@ -529,7 +529,7 @@ export class UserDataSyncWorkbenchContribution extends Disposable implements IWo
 
 			const items = this.getConfigureSyncQuickPickItems();
 			quickPick.items = items;
-			quickPick.selectedItems = items.filter(item => this.userDataSyncEnablementService.isResourceEnabled(item.id));
+			quickPick.selectedItems = items.filter(item => this.userDataSyncEnablementService.isResourceEnabled(item.id, true));
 			let accepted: boolean = false;
 			disposables.add(Event.any(quickPick.onDidAccept, quickPick.onDidCustom)(() => {
 				accepted = true;


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/pull/242360

Changes by @legomushroom And @sandy081 

What it does:
- disables the syncing of prompts by default (see `isResourceEnabled`) unless the user has set it
- when the user first time turns on setting sync, `prompts` are selected by default (userDataSync.ts, line 532)
- when the user has settings sync running already and opens the config dialog, it will reflect the current behavior (prompts disabled) (userDataSync.ts, line 611)