### PR TITLE
Revert "Bundle TS 5.8.2" in wrong branch

### DIFF
--- a/extensions/package-lock.json
+++ b/extensions/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "typescript": "^5.8.2"
+        "typescript": "^5.7.3"
       },
       "devDependencies": {
         "@parcel/watcher": "2.5.0",
@@ -897,9 +897,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.8.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
-      "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
+      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/extensions/package.json
+++ b/extensions/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "description": "Dependencies shared by all extensions",
   "dependencies": {
-    "typescript": "^5.8.2"
+    "typescript": "^5.7.3"
   },
   "scripts": {
     "postinstall": "node ./postinstall.mjs"


### PR DESCRIPTION
Reverts microsoft/vscode#242362 which went into 1.97 instead of 1.98. 