### PR TITLE
track pending layouts and dispose them

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/notebookEditorWidget.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebookEditorWidget.ts
@@ -2343,6 +2343,7 @@ export class NotebookEditorWidget extends Disposable implements INotebookEditorD
 
 	//#region Cell operations/layout API
 	private _pendingLayouts: WeakMap<ICellViewModel, IDisposable> | null = new WeakMap<ICellViewModel, IDisposable>();
+	private _layoutDisposables: Set<IDisposable> = new Set<IDisposable>();
 	async layoutNotebookCell(cell: ICellViewModel, height: number, context?: CellLayoutContext): Promise<void> {
 		this._debug('layout cell', cell.handle, height);
 		const viewIndex = this._list.getViewIndex(cell);
@@ -2394,16 +2395,21 @@ export class NotebookEditorWidget extends Disposable implements INotebookEditorD
 
 			this._list.updateElementHeight2(cell, height);
 			deferred.complete(undefined);
-			pendingLayout?.dispose();
+			if (pendingLayout) {
+				pendingLayout.dispose();
+				this._layoutDisposables.delete(pendingLayout);
+			}
 		};
 
 		if (this._list.inRenderingTransaction) {
 			const layoutDisposable = DOM.scheduleAtNextAnimationFrame(DOM.getWindow(this.getDomNode()), doLayout);
 
-			this._pendingLayouts?.set(cell, toDisposable(() => {
+			const disposable = toDisposable(() => {
 				layoutDisposable.dispose();
 				deferred.complete(undefined);
-			}));
+			});
+			this._pendingLayouts?.set(cell, disposable);
+			this._layoutDisposables.add(disposable);
 		} else {
 			doLayout();
 		}
@@ -3268,6 +3274,8 @@ export class NotebookEditorWidget extends Disposable implements INotebookEditorD
 		// dispose webview first
 		this._webview?.dispose();
 		this._webview = null;
+
+		this._layoutDisposables.forEach(d => d.dispose());
 
 		this.notebookEditorService.removeNotebookEditor(this);
 		dispose(this._contributions.values());


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

We're using a weakMap so that we don't hold a reference to the cell's viewModel, but if that viewModel goes away then we lose track of the disposable.
This change will track those disposables independently. 
