### PR TITLE
Italic text is cut off at the end in tabs and settings (fix #207409)

### DIFF
--- a/src/vs/base/browser/ui/iconLabel/iconlabel.css
+++ b/src/vs/base/browser/ui/iconLabel/iconlabel.css
@@ -89,11 +89,6 @@
 	opacity: 0.66;
 }
 
-/* make sure apply italic font style to decorations as well */
-.monaco-icon-label.italic::after {
-	font-style: italic;
-}
-
 .monaco-icon-label.strikethrough > .monaco-icon-label-container > .monaco-icon-name-container > .label-name,
 .monaco-icon-label.strikethrough > .monaco-icon-label-container > .monaco-icon-description-container > .label-description {
 	text-decoration: line-through;

--- a/src/vs/workbench/browser/parts/editor/media/multieditortabscontrol.css
+++ b/src/vs/workbench/browser/parts/editor/media/multieditortabscontrol.css
@@ -367,10 +367,6 @@
 	}
 }
 
-.monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.sizing-fit .monaco-icon-label.italic {
-	padding-right: 3px; /* https://github.com/microsoft/vscode/issues/207409 */
-}
-
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.sizing-shrink > .monaco-icon-label > .monaco-icon-label-container,
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.sizing-fixed > .monaco-icon-label > .monaco-icon-label-container {
 	text-overflow: clip;
@@ -382,6 +378,16 @@
 .monaco-workbench.hc-black .part.editor > .content .editor-group-container > .title .tabs-container > .tab.sizing-fixed > .monaco-icon-label > .monaco-icon-label-container,
 .monaco-workbench.hc-light .part.editor > .content .editor-group-container > .title .tabs-container > .tab.sizing-fixed > .monaco-icon-label > .monaco-icon-label-container {
 	text-overflow: ellipsis;
+}
+
+.monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab > .monaco-icon-label.italic > .monaco-icon-label-container {
+	/**
+	 * Browser rendering engines seem to have trouble to render italic labels
+	 * fully without clipping in case the parent container has `overflow: hidden`
+	 * and/or `flex: none`. We added those styles to fix other issues so a pragmatic
+	 * solution is to give the label container a bit more room to fully render.
+	 */
+	padding-right: 1px; /* https://github.com/microsoft/vscode/issues/207409 */
 }
 
 /* Tab Actions */

--- a/src/vs/workbench/browser/parts/editor/media/multieditortabscontrol.css
+++ b/src/vs/workbench/browser/parts/editor/media/multieditortabscontrol.css
@@ -386,8 +386,10 @@
 	 * fully without clipping in case the parent container has `overflow: hidden`
 	 * and/or `flex: none`. We added those styles to fix other issues so a pragmatic
 	 * solution is to give the label container a bit more room to fully render.
+	 * 
+	 * Refs: https://github.com/microsoft/vscode/issues/207409
 	 */
-	padding-right: 1px; /* https://github.com/microsoft/vscode/issues/207409 */
+	padding-right: 1px;
 }
 
 /* Tab Actions */


### PR DESCRIPTION
Also remove the italic font style from label decorations: since decorations are typically icons, italic font style does not really apply well to them. For example, a square turns into a parallelogram.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
