### PR TITLE
Git - use `editorInlayHint.foreground` for the git blame editor decoration as it is lighter than `editorCodeLens.foreground`

### DIFF
--- a/extensions/git/package.json
+++ b/extensions/git/package.json
@@ -3434,10 +3434,10 @@
         "id": "git.blame.editorDecorationForeground",
         "description": "%colors.blameEditorDecoration%",
         "defaults": {
-          "dark": "editorCodeLens.foreground",
-          "light": "editorCodeLens.foreground",
-          "highContrast": "editorCodeLens.foreground",
-          "highContrastLight": "editorCodeLens.foreground"
+          "dark": "editorInlayHint.foreground",
+          "light": "editorInlayHint.foreground",
+          "highContrast": "editorInlayHint.foreground",
+          "highContrastLight": "editorInlayHint.foreground"
         }
       }
     ],


### PR DESCRIPTION
Related #234568