### PR TITLE
Prototype for #53557

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/debugAdapterManager.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugAdapterManager.ts
@@ -202,12 +202,15 @@ export class AdapterManager extends Disposable implements IAdapterManager {
 						type: 'boolean',
 						description: nls.localize('suppressMultipleSessionWarning', "Disable the warning when trying to start the same debug configuration more than once."),
 						default: true
+					},
+					'extends': {
+						type: 'string'
 					}
 				}
 			}
 		};
 		launchSchema.definitions = definitions;
-		items.oneOf = [];
+		items.oneOf = [{ type: 'object', properties: { extends: { type: 'string' } }, required: ['extends'] }];
 		items.defaultSnippets = [];
 		this.debuggers.forEach(adapter => {
 			const schemaAttributes = adapter.getSchemaAttributes(definitions);

--- a/src/vs/workbench/contrib/debug/common/debug.ts
+++ b/src/vs/workbench/contrib/debug/common/debug.ts
@@ -868,6 +868,8 @@ export interface IConfig extends IEnvConfig {
 	__restart?: any;
 	__autoAttach?: boolean;
 	port?: number; // TODO
+
+	extends?: string;
 }
 
 export interface ICompound {


### PR DESCRIPTION
Prototype for #53557

Allows configurations to use `extends` to extend a given launch config, e.g.:
```jsonc
  {
	  "name": "Launch VS Code Internal",
	 // ...
  },
  {
	  "name": "Launch VS Code Internal With Observable Debugging",
	  "extends": "Launch VS Code Internal",
	  "env": {
		  "DEBUG_OBSERVABLES": "1"
	  }
  },
```

This would allow to cleanup the vscode launch.json a bit ([also this one](https://github.com/PowerShell/vscode-powershell/blob/43c8bff8bd316684fb4bc82cdbed36ceb7988904/pwsh-extension-dev.code-workspace#L311)), but also enable more advanced configurations .

* [ ] needs more testing
* [ ] needs improved json schema descriptions

Configurations can only extend within one source (e.g. one launch.json file), but I think that is fine.

What do you think of this?