### PR TITLE
add `--locate-shell-integration-path` to `code` spec with suggestions

### DIFF
--- a/extensions/terminal-suggest/src/completions/code.ts
+++ b/extensions/terminal-suggest/src/completions/code.ts
@@ -135,6 +135,22 @@ const commonOptions: Fig.Option[] = [
 		name: ['-h', '--help'],
 		description: 'Print usage',
 	},
+	{
+		name: '--locate-shell-integration-path',
+		description:
+			'Print the path to the shell integration script for the provided shell',
+		args: {
+			isOptional: false,
+			name: 'shell',
+			description: 'The shell to locate the integration script for',
+			suggestions: [
+				'bash',
+				'fish',
+				'pwsh',
+				'zsh',
+			]
+		}
+	}
 ];
 
 const extensionManagementOptions: Fig.Option[] = [

--- a/extensions/terminal-suggest/src/test/completions/code.test.ts
+++ b/extensions/terminal-suggest/src/test/completions/code.test.ts
@@ -8,7 +8,7 @@ import codeCompletionSpec from '../../completions/code';
 import { testPaths, type ISuiteSpec, type ITestSpec } from '../helpers';
 import codeInsidersCompletionSpec from '../../completions/code-insiders';
 
-export const codeSpecOptions = ['-', '--add', '--category', '--diff', '--disable-extension', '--disable-extensions', '--disable-gpu', '--enable-proposed-api', '--extensions-dir', '--goto', '--help', '--inspect-brk-extensions', '--inspect-extensions', '--install-extension', '--list-extensions', '--locale', '--log', '--max-memory', '--merge', '--new-window', '--pre-release', '--prof-startup', '--profile', '--reuse-window', '--show-versions', '--status', '--sync', '--telemetry', '--uninstall-extension', '--user-data-dir', '--verbose', '--version', '--wait', '-a', '-d', '-g', '-h', '-m', '-n', '-r', '-s', '-v', '-w'];
+export const codeSpecOptions = ['-', '--add', '--category', '--diff', '--disable-extension', '--disable-extensions', '--disable-gpu', '--enable-proposed-api', '--extensions-dir', '--goto', '--help', '--inspect-brk-extensions', '--inspect-extensions', '--install-extension', '--list-extensions', '--locale', '--locate-shell-integration-path', '--log', '--max-memory', '--merge', '--new-window', '--pre-release', '--prof-startup', '--profile', '--reuse-window', '--show-versions', '--status', '--sync', '--telemetry', '--uninstall-extension', '--user-data-dir', '--verbose', '--version', '--wait', '-a', '-d', '-g', '-h', '-m', '-n', '-r', '-s', '-v', '-w'];
 
 
 export function createCodeTestSpecs(executable: string): ITestSpec[] {


### PR DESCRIPTION
fix #242467

<img width="758" alt="Screenshot 2025-03-05 at 11 54 15 AM" src="https://github.com/user-attachments/assets/f74b98a8-a160-481b-abcb-8c51330bc2c6" />
<img width="692" alt="Screenshot 2025-03-05 at 11 54 22 AM" src="https://github.com/user-attachments/assets/045a0bcb-d750-404f-bd5b-1047af9a1770" />
