### PR TITLE
Make account access cross client ids

### DIFF
--- a/extensions/microsoft-authentication/src/node/cachedPublicClientApplication.ts
+++ b/extensions/microsoft-authentication/src/node/cachedPublicClientApplication.ts
@@ -10,7 +10,7 @@ import { raceCancellationAndTimeoutError } from '../common/async';
 import { SecretStorageCachePlugin } from '../common/cachePlugin';
 import { MsalLoggerOptions } from '../common/loggerOptions';
 import { ICachedPublicClientApplication } from '../common/publicClientCache';
-import { ScopedAccountAccess } from '../common/accountAccess';
+import { IAccountAccess } from '../common/accountAccess';
 
 export class CachedPublicClientApplication implements ICachedPublicClientApplication {
 	// Core properties
@@ -27,7 +27,6 @@ export class CachedPublicClientApplication implements ICachedPublicClientApplica
 	);
 
 	// Broker properties
-	private readonly _accountAccess = new ScopedAccountAccess(this._secretStorage, this._cloudName, this.clientId, this._logger, this._authoritiesToMigrate);
 	private readonly _isBrokerAvailable: boolean;
 
 	//#region Events
@@ -42,10 +41,9 @@ export class CachedPublicClientApplication implements ICachedPublicClientApplica
 
 	constructor(
 		private readonly _clientId: string,
-		private readonly _cloudName: string,
 		private readonly _secretStorage: SecretStorage,
+		private readonly _accountAccess: IAccountAccess,
 		private readonly _logger: LogOutputChannel,
-		private readonly _authoritiesToMigrate?: string[],
 	) {
 		const loggerOptions = new MsalLoggerOptions(_logger);
 		const nativeBrokerPlugin = new NativeBrokerPlugin();


### PR DESCRIPTION
The point here is that the user already allowed access to the account for one client id, so that should just apply to any client id that is being used since:
* If we don't actually _have_ an auth token, the user will be asked to log in - so they will see a prompt as expected
* If we _do_ have an auth token, then we rely on extension auth access to gate access to the account

Fixes https://github.com/microsoft/vscode/issues/241526

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
