### PR TITLE
Trigger CHANGE_CELL_LANGUAGE on "Select language" in the empty notebook cell hint.

### DIFF
--- a/src/vs/workbench/contrib/codeEditor/browser/emptyTextEditorHint/emptyTextEditorHint.ts
+++ b/src/vs/workbench/contrib/codeEditor/browser/emptyTextEditorHint/emptyTextEditorHint.ts
@@ -51,6 +51,8 @@ export class EmptyTextEditorHintContribution implements IEditorContribution {
 	protected toDispose: IDisposable[];
 	private textHintContentWidget: EmptyTextEditorHintContentWidget | undefined;
 
+	protected readonly changeLanguageCommandId: string = ChangeLanguageAction.ID;
+
 	constructor(
 		protected readonly editor: ICodeEditor,
 		@IEditorGroupsService private readonly editorGroupsService: IEditorGroupsService,
@@ -149,7 +151,8 @@ export class EmptyTextEditorHintContribution implements IEditorContribution {
 				this.chatAgentService,
 				this.telemetryService,
 				this.productService,
-				this.contextMenuService
+				this.contextMenuService,
+				this.changeLanguageCommandId
 			);
 		} else if (!shouldRenderHint && this.textHintContentWidget) {
 			this.textHintContentWidget.dispose();
@@ -184,6 +187,7 @@ class EmptyTextEditorHintContentWidget implements IContentWidget {
 		private readonly telemetryService: ITelemetryService,
 		private readonly productService: IProductService,
 		private readonly contextMenuService: IContextMenuService,
+		private readonly changeLanguageCommandId: string,
 	) {
 		this.toDispose = new DisposableStore();
 		this.toDispose.add(this.editor.onDidChangeConfiguration((e: ConfigurationChangedEvent) => {
@@ -345,10 +349,10 @@ class EmptyTextEditorHintContentWidget implements IContentWidget {
 			// Need to focus editor before so current editor becomes active and the command is properly executed
 			this.editor.focus();
 			this.telemetryService.publicLog2<WorkbenchActionExecutedEvent, WorkbenchActionExecutedClassification>('workbenchActionExecuted', {
-				id: ChangeLanguageAction.ID,
+				id: this.changeLanguageCommandId,
 				from: 'hint'
 			});
-			await this.commandService.executeCommand(ChangeLanguageAction.ID);
+			await this.commandService.executeCommand(this.changeLanguageCommandId);
 			this.editor.focus();
 		};
 

--- a/src/vs/workbench/contrib/notebook/browser/contrib/editorHint/emptyCellEditorHint.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/editorHint/emptyCellEditorHint.ts
@@ -16,7 +16,7 @@ import { ITelemetryService } from '../../../../../../platform/telemetry/common/t
 import { IChatAgentService } from '../../../../chat/common/chatAgents.js';
 import { EmptyTextEditorHintContribution, IEmptyTextEditorHintOptions } from '../../../../codeEditor/browser/emptyTextEditorHint/emptyTextEditorHint.js';
 import { IInlineChatSessionService } from '../../../../inlineChat/browser/inlineChatSessionService.js';
-import { getNotebookEditorFromEditorPane } from '../../notebookBrowser.js';
+import { getNotebookEditorFromEditorPane, CHANGE_CELL_LANGUAGE } from '../../notebookBrowser.js';
 import { IEditorGroupsService } from '../../../../../services/editor/common/editorGroupsService.js';
 import { IEditorService } from '../../../../../services/editor/common/editorService.js';
 
@@ -58,6 +58,8 @@ export class EmptyCellEditorHintContribution extends EmptyTextEditorHintContribu
 
 		this.toDispose.push(activeEditor.onDidChangeActiveCell(() => this.update()));
 	}
+
+	protected override readonly changeLanguageCommandId: string = CHANGE_CELL_LANGUAGE;
 
 	protected override _getOptions(): IEmptyTextEditorHintOptions {
 		return { clickable: false };


### PR DESCRIPTION
In the notebook empty cell editor override the default language selection command with CHANGE_CELL_LANGUAGE command.

Steps to test:
- Create a notebook file.
- Create a code cell.
- Click on "Select a language" in the cell hint "Select language, or fill with template ...".
(Note: if the hint is not visible, please patch the fix: https://github.com/microsoft/vscode/pull/242479)
- Choose a language.
- Verify that the cell language is updated.

Fixes: #242826