### PR TITLE
Create a strong tie between exthost and renderer executions

### DIFF
--- a/src/vs/platform/extensions/common/extensionsApiProposals.ts
+++ b/src/vs/platform/extensions/common/extensionsApiProposals.ts
@@ -355,6 +355,9 @@ const _allApiProposals = {
 	terminalShellEnv: {
 		proposal: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.terminalShellEnv.d.ts',
 	},
+	terminalShellIntegrationRich: {
+		proposal: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.terminalShellIntegrationRich.d.ts',
+	},
 	terminalShellType: {
 		proposal: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.terminalShellType.d.ts',
 	},

--- a/src/vs/platform/terminal/common/capabilities/capabilities.ts
+++ b/src/vs/platform/terminal/common/capabilities/capabilities.ts
@@ -214,6 +214,7 @@ export interface ICommandDetectionCapability {
 	readonly executingCommandConfidence: 'low' | 'medium' | 'high' | undefined;
 	/** The current cwd at the cursor's position. */
 	readonly cwd: string | undefined;
+	readonly hasRichCommandDetection: boolean;
 	readonly currentCommand: ICurrentPartialCommand | undefined;
 	readonly onCommandStarted: Event<ITerminalCommand>;
 	readonly onCommandFinished: Event<ITerminalCommand>;
@@ -239,6 +240,7 @@ export interface ICommandDetectionCapability {
 	handleCommandStart(options?: IHandleCommandOptions): void;
 	handleCommandExecuted(options?: IHandleCommandOptions): void;
 	handleCommandFinished(exitCode?: number, options?: IHandleCommandOptions): void;
+	setHasRichCommandDetection(value: boolean): void;
 	/**
 	 * Set the command line explicitly.
 	 * @param commandLine The command line being set.
@@ -345,6 +347,7 @@ export interface IMarkProperties {
 }
 export interface ISerializedCommandDetectionCapability {
 	isWindowsPty: boolean;
+	hasRichCommandDetection: boolean;
 	commands: ISerializedTerminalCommand[];
 	promptInputModel: ISerializedPromptInputModel | undefined;
 }

--- a/src/vs/platform/terminal/common/capabilities/capabilities.ts
+++ b/src/vs/platform/terminal/common/capabilities/capabilities.ts
@@ -221,6 +221,7 @@ export interface ICommandDetectionCapability {
 	readonly onCommandExecuted: Event<ITerminalCommand>;
 	readonly onCommandInvalidated: Event<ITerminalCommand[]>;
 	readonly onCurrentCommandInvalidated: Event<ICommandInvalidationRequest>;
+	readonly onSetRichCommandDetection: Event<boolean>;
 	setContinuationPrompt(value: string): void;
 	setPromptTerminator(value: string, lastPromptLine: string): void;
 	setCwd(value: string): void;

--- a/src/vs/platform/terminal/common/capabilities/commandDetectionCapability.ts
+++ b/src/vs/platform/terminal/common/capabilities/commandDetectionCapability.ts
@@ -33,6 +33,8 @@ export class CommandDetectionCapability extends Disposable implements ICommandDe
 	private _dimensions: ITerminalDimensions;
 	private __isCommandStorageDisabled: boolean = false;
 	private _handleCommandStartOptions?: IHandleCommandOptions;
+	private _hasRichCommandDetection: boolean = false;
+	get hasRichCommandDetection() { return this._hasRichCommandDetection; }
 
 	private _ptyHeuristicsHooks: ICommandDetectionHeuristicsHooks;
 	private readonly _ptyHeuristics: MandatoryMutableDisposable<IPtyHeuristics>;
@@ -71,6 +73,8 @@ export class CommandDetectionCapability extends Disposable implements ICommandDe
 	readonly onCommandInvalidated = this._onCommandInvalidated.event;
 	private readonly _onCurrentCommandInvalidated = this._register(new Emitter<ICommandInvalidationRequest>());
 	readonly onCurrentCommandInvalidated = this._onCurrentCommandInvalidated.event;
+	private readonly _onSetRichCommandDetection = this._register(new Emitter<void>());
+	readonly onSetRichCommandDetection = this._onSetRichCommandDetection.event;
 
 	constructor(
 		private readonly _terminal: Terminal,
@@ -221,6 +225,11 @@ export class CommandDetectionCapability extends Disposable implements ICommandDe
 		} else if (!value && !(this._ptyHeuristics.value instanceof UnixPtyHeuristics)) {
 			this._ptyHeuristics.value = new UnixPtyHeuristics(this._terminal, this, this._ptyHeuristicsHooks, this._logService);
 		}
+	}
+
+	setHasRichCommandDetection(value: boolean): void {
+		this._hasRichCommandDetection = value;
+		this._onSetRichCommandDetection.fire();
 	}
 
 	setIsCommandStorageDisabled(): void {
@@ -403,6 +412,7 @@ export class CommandDetectionCapability extends Disposable implements ICommandDe
 		}
 		return {
 			isWindowsPty: this._ptyHeuristics.value instanceof WindowsPtyHeuristics,
+			hasRichCommandDetection: this._hasRichCommandDetection,
 			commands,
 			promptInputModel: this._promptInputModel.serialize(),
 		};
@@ -411,6 +421,9 @@ export class CommandDetectionCapability extends Disposable implements ICommandDe
 	deserialize(serialized: ISerializedCommandDetectionCapability): void {
 		if (serialized.isWindowsPty) {
 			this.setIsWindowsPty(serialized.isWindowsPty);
+		}
+		if (serialized.hasRichCommandDetection) {
+			this.setHasRichCommandDetection(serialized.hasRichCommandDetection);
 		}
 		const buffer = this._terminal.buffer.normal;
 		for (const e of serialized.commands) {

--- a/src/vs/platform/terminal/common/capabilities/commandDetectionCapability.ts
+++ b/src/vs/platform/terminal/common/capabilities/commandDetectionCapability.ts
@@ -73,7 +73,7 @@ export class CommandDetectionCapability extends Disposable implements ICommandDe
 	readonly onCommandInvalidated = this._onCommandInvalidated.event;
 	private readonly _onCurrentCommandInvalidated = this._register(new Emitter<ICommandInvalidationRequest>());
 	readonly onCurrentCommandInvalidated = this._onCurrentCommandInvalidated.event;
-	private readonly _onSetRichCommandDetection = this._register(new Emitter<void>());
+	private readonly _onSetRichCommandDetection = this._register(new Emitter<boolean>());
 	readonly onSetRichCommandDetection = this._onSetRichCommandDetection.event;
 
 	constructor(
@@ -229,7 +229,7 @@ export class CommandDetectionCapability extends Disposable implements ICommandDe
 
 	setHasRichCommandDetection(value: boolean): void {
 		this._hasRichCommandDetection = value;
-		this._onSetRichCommandDetection.fire();
+		this._onSetRichCommandDetection.fire(value);
 	}
 
 	setIsCommandStorageDisabled(): void {

--- a/src/vs/platform/terminal/common/terminal.ts
+++ b/src/vs/platform/terminal/common/terminal.ts
@@ -949,9 +949,11 @@ export type ITerminalProfileObject = ITerminalExecutable | ITerminalProfileSourc
 
 export interface IShellIntegration {
 	readonly capabilities: ITerminalCapabilityStore;
+	readonly seenSequences: ReadonlySet<string>;
 	readonly status: ShellIntegrationStatus;
 
 	readonly onDidChangeStatus: Event<ShellIntegrationStatus>;
+	readonly onDidChangeSeenSequences: Event<ReadonlySet<string>>;
 
 	deserialize(serialized: ISerializedCommandDetectionCapability): void;
 }

--- a/src/vs/platform/terminal/common/terminalRecorder.ts
+++ b/src/vs/platform/terminal/common/terminalRecorder.ts
@@ -91,6 +91,7 @@ export class TerminalRecorder {
 			// No command restoration is needed when relaunching terminals
 			commands: {
 				isWindowsPty: false,
+				hasRichCommandDetection: false,
 				commands: [],
 				promptInputModel: undefined,
 			}

--- a/src/vs/platform/terminal/common/xterm/shellIntegrationAddon.ts
+++ b/src/vs/platform/terminal/common/xterm/shellIntegrationAddon.ts
@@ -209,10 +209,10 @@ const enum VSCodeOscPt {
 	 *   integration sequences are not guaranteed to be correct. Valid values: `True`, `False`.
 	 * - `ContinuationPrompt` - Reports the continuation prompt that is printed at the start of
 	 *   multi-line inputs.
-	 * - `HasRichCmdDetection` - Reports whether the shell has rich command line detection, meaning
-	 *   that sequences A, B, C, D and E are exactly where they're meant to be. In particular,
-	 *   {@link CommandLine} must happen immediately before {@link CommandExecuted} so VS Code knows
-	 *   the command line when the execution begins.
+	 * - `HasRichCommandDetection` - Reports whether the shell has rich command line detection,
+	 *   meaning that sequences A, B, C, D and E are exactly where they're meant to be. In
+	 *   particular, {@link CommandLine} must happen immediately before {@link CommandExecuted} so
+	 *   VS Code knows the command line when the execution begins.
 	 *
 	 * WARNING: Any other properties may be changed and are not guaranteed to work in the future.
 	 */
@@ -557,7 +557,7 @@ export class ShellIntegrationAddon extends Disposable implements IShellIntegrati
 						this._createOrGetCommandDetection(this._terminal).setIsWindowsPty(value === 'True' ? true : false);
 						return true;
 					}
-					case 'HasRichCmdDetection': {
+					case 'HasRichCommandDetection': {
 						this._createOrGetCommandDetection(this._terminal).setHasRichCommandDetection(value === 'True' ? true : false);
 						return true;
 					}

--- a/src/vs/platform/terminal/common/xterm/shellIntegrationAddon.ts
+++ b/src/vs/platform/terminal/common/xterm/shellIntegrationAddon.ts
@@ -204,11 +204,15 @@ const enum VSCodeOscPt {
 	 * Known properties:
 	 *
 	 * - `Cwd` - Reports the current working directory to the terminal.
-	 * - `IsWindows` - Indicates whether the terminal is using a Windows backend like winpty or
-	 *   conpty. This may be used to enable additional heuristics as the positioning of the shell
+	 * - `IsWindows` - Reports whether the shell is using a Windows backend like winpty or conpty.
+	 *   This may be used to enable additional heuristics as the positioning of the shell
 	 *   integration sequences are not guaranteed to be correct. Valid values: `True`, `False`.
 	 * - `ContinuationPrompt` - Reports the continuation prompt that is printed at the start of
 	 *   multi-line inputs.
+	 * - `HasRichCmdDetection` - Reports whether the shell has rich command line detection, meaning
+	 *   that sequences A, B, C, D and E are exactly where they're meant to be. In particular,
+	 *   {@link CommandLine} must happen immediately before {@link CommandExecuted} so VS Code knows
+	 *   the command line when the execution begins.
 	 *
 	 * WARNING: Any other properties may be changed and are not guaranteed to work in the future.
 	 */
@@ -553,6 +557,10 @@ export class ShellIntegrationAddon extends Disposable implements IShellIntegrati
 						this._createOrGetCommandDetection(this._terminal).setIsWindowsPty(value === 'True' ? true : false);
 						return true;
 					}
+					case 'HasRichCmdDetection': {
+						this._createOrGetCommandDetection(this._terminal).setHasRichCommandDetection(value === 'True' ? true : false);
+						return true;
+					}
 					case 'Prompt': {
 						// Remove escape sequences from the user's prompt
 						const sanitizedValue = value.replace(/\x1b\[[0-9;]*m/g, '');
@@ -680,6 +688,7 @@ export class ShellIntegrationAddon extends Disposable implements IShellIntegrati
 		if (!this._terminal || !this.capabilities.has(TerminalCapability.CommandDetection)) {
 			return {
 				isWindowsPty: false,
+				hasRichCommandDetection: false,
 				commands: [],
 				promptInputModel: undefined,
 			};

--- a/src/vs/workbench/api/browser/mainThreadTerminalShellIntegration.ts
+++ b/src/vs/workbench/api/browser/mainThreadTerminalShellIntegration.ts
@@ -35,7 +35,8 @@ export class MainThreadTerminalShellIntegration extends Disposable implements Ma
 
 		// onDidchangeTerminalShellIntegration initial state
 		for (const terminal of this._terminalService.instances) {
-			if (terminal.capabilities.has(TerminalCapability.CommandDetection)) {
+			const cmdDetection = terminal.capabilities.get(TerminalCapability.CommandDetection);
+			if (cmdDetection?.hasRichCommandDetection) {
 				this._proxy.$shellIntegrationChange(terminal.instanceId);
 				const cwdDetection = terminal.capabilities.get(TerminalCapability.CwdDetection);
 				if (cwdDetection) {
@@ -48,7 +49,11 @@ export class MainThreadTerminalShellIntegration extends Disposable implements Ma
 		const onDidAddCommandDetection = this._store.add(this._terminalService.createOnInstanceEvent(instance => {
 			return Event.map(
 				Event.filter(instance.capabilities.onDidAddCapabilityType, e => {
-					return e === TerminalCapability.CommandDetection || e === TerminalCapability.CwdDetection;
+					if (e !== TerminalCapability.CommandDetection) {
+						return false;
+					}
+					const cmdDetection = instance.capabilities.get(TerminalCapability.CommandDetection);
+					return !!cmdDetection?.hasRichCommandDetection;
 				}), () => instance
 			);
 		})).event;

--- a/src/vs/workbench/api/browser/mainThreadTerminalShellIntegration.ts
+++ b/src/vs/workbench/api/browser/mainThreadTerminalShellIntegration.ts
@@ -46,8 +46,6 @@ export class MainThreadTerminalShellIntegration extends Disposable implements Ma
 			}
 		}
 
-		// TODO: Rich isn't set on reconnected terminals
-
 		// onDidChangeTerminalShellIntegration via command detection
 		const onDidAddCommandDetection = this._store.add(this._terminalService.createOnInstanceEvent(instance => {
 			return Event.map(

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -2523,6 +2523,7 @@ export interface ExtHostTerminalShellIntegrationShape {
 	$shellExecutionData(instanceId: number, data: string): void;
 	$shellEnvChange(instanceId: number, shellEnvKeys: string[], shellEnvValues: string[], isTrusted: boolean): void;
 	$cwdChange(instanceId: number, cwd: UriComponents | undefined): void;
+	$setHasRichCommandDetection(instanceId: number, value: boolean): void;
 	$closeTerminal(instanceId: number): void;
 }
 

--- a/src/vs/workbench/api/common/extHostTerminalShellIntegration.ts
+++ b/src/vs/workbench/api/common/extHostTerminalShellIntegration.ts
@@ -143,7 +143,10 @@ export class ExtHostTerminalShellIntegration extends Disposable implements IExtH
 	public $closeTerminal(instanceId: number): void {
 		this._activeShellIntegrations.get(instanceId)?.dispose();
 		this._activeShellIntegrations.delete(instanceId);
+	}
 
+	public $setHasRichCommandDetection(instanceId: number, value: boolean): void {
+		this._activeShellIntegrations.get(instanceId)?.setHasRichCommandDetection(value);
 	}
 }
 
@@ -155,6 +158,7 @@ class InternalTerminalShellIntegration extends Disposable {
 
 	private _env: vscode.TerminalShellIntegrationEnvironment | undefined;
 	private _cwd: URI | undefined;
+	private _hasRichCommandDetection: boolean = false;
 
 	readonly store: DisposableStore = this._register(new DisposableStore());
 
@@ -182,6 +186,9 @@ class InternalTerminalShellIntegration extends Disposable {
 			},
 			get env(): vscode.TerminalShellIntegrationEnvironment | undefined {
 				return that._env;
+			},
+			get hasRichCommandDetection(): boolean {
+				return that._hasRichCommandDetection;
 			},
 			// executeCommand(commandLine: string): vscode.TerminalShellExecution;
 			// executeCommand(executable: string, args: string[]): vscode.TerminalShellExecution;
@@ -256,6 +263,13 @@ class InternalTerminalShellIntegration extends Disposable {
 					this._currentExecution = undefined;
 				}
 			});
+		}
+	}
+
+	setHasRichCommandDetection(value: boolean): void {
+		if (this._hasRichCommandDetection !== value) {
+			this._hasRichCommandDetection = value;
+			this._fireChangeEvent();
 		}
 	}
 

--- a/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
@@ -90,6 +90,7 @@ import type { IMenu } from '../../../../platform/actions/common/actions.js';
 import { IContextMenuService } from '../../../../platform/contextview/browser/contextView.js';
 import { TerminalContribCommandId } from '../terminalContribExports.js';
 import type { IProgressState } from '@xterm/addon-progress';
+import { refreshShellIntegrationInfoStatus } from './terminalTooltip.js';
 
 const enum Constants {
 	/**
@@ -859,6 +860,13 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 			}
 		}));
 		this._register(xterm.onDidChangeProgress(() => this._labelComputer?.refreshLabel(this)));
+
+		// Register and update the terminal's shell integration status
+		this._register(Event.runAndSubscribe(xterm.shellIntegration.onDidChangeSeenSequences, () => {
+			if (xterm.shellIntegration.seenSequences.size > 0) {
+				refreshShellIntegrationInfoStatus(this);
+			}
+		}));
 
 		// Set up updating of the process cwd on key press, this is only needed when the cwd
 		// detection capability has not been registered

--- a/src/vs/workbench/contrib/terminal/browser/terminalStatusList.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalStatusList.ts
@@ -24,6 +24,7 @@ export const enum TerminalStatus {
 	Disconnected = 'disconnected',
 	RelaunchNeeded = 'relaunch-needed',
 	EnvironmentVariableInfoChangesActive = 'env-var-info-changes-active',
+	ShellIntegrationInfo = 'shell-integration-info',
 	ShellIntegrationAttentionNeeded = 'shell-integration-attention-needed'
 }
 

--- a/src/vs/workbench/contrib/terminal/browser/terminalTooltip.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalTooltip.ts
@@ -55,12 +55,12 @@ export function refreshShellIntegrationInfoStatus(instance: ITerminalInstance) {
 	}
 	const cmdDetectionType = (
 		instance.capabilities.get(TerminalCapability.CommandDetection)?.hasRichCommandDetection
-			? 'Rich'
+			? localize('shellIntegration.rich', 'Rich')
 			: instance.capabilities.has(TerminalCapability.CommandDetection)
-				? 'Basic'
+				? localize('shellIntegration.basic', 'Basic')
 				: instance.usedShellIntegrationInjection
 					? localize('shellIntegration.injectionFailed', "Injection failed to activate")
-					: 'No'
+					: localize('shellIntegration.no', 'No')
 	);
 	const seenSequences = Array.from(instance.xterm.shellIntegration.seenSequences);
 	const seenSequencesString = (

--- a/src/vs/workbench/contrib/terminal/common/scripts/shellIntegration-bash.sh
+++ b/src/vs/workbench/contrib/terminal/common/scripts/shellIntegration-bash.sh
@@ -198,6 +198,9 @@ if [ "$__vsc_stable" = "0" ]; then
 	builtin printf "\e]633;P;ContinuationPrompt=$(echo "$PS2" | sed 's/\x1b/\\\\x1b/g')\a"
 fi
 
+# Report this shell supports rich command detection
+builtin printf '\e]633;P;HasRichCommandDetection=True\a'
+
 __vsc_report_prompt() {
 	# Expand the original PS1 similarly to how bash would normally
 	# See https://stackoverflow.com/a/37137981 for technique

--- a/src/vs/workbench/contrib/terminal/common/scripts/shellIntegration-rc.zsh
+++ b/src/vs/workbench/contrib/terminal/common/scripts/shellIntegration-rc.zsh
@@ -112,6 +112,9 @@ unset VSCODE_NONCE
 __vscode_shell_env_reporting="$VSCODE_SHELL_ENV_REPORTING"
 unset VSCODE_SHELL_ENV_REPORTING
 
+# Report this shell supports rich command detection
+builtin printf '\e]633;P;HasRichCommandDetection=True\a'
+
 __vsc_prompt_start() {
 	builtin printf '\e]633;A\a'
 }

--- a/src/vs/workbench/contrib/terminal/common/scripts/shellIntegration.fish
+++ b/src/vs/workbench/contrib/terminal/common/scripts/shellIntegration.fish
@@ -207,4 +207,8 @@ function __init_vscode_shell_integration
 		end
 	end
 end
+
+# Report this shell supports rich command detection
+__vsc_esc P HasRichCommandDetection=True
+
 __preserve_fish_prompt

--- a/src/vs/workbench/contrib/terminal/common/scripts/shellIntegration.ps1
+++ b/src/vs/workbench/contrib/terminal/common/scripts/shellIntegration.ps1
@@ -124,7 +124,7 @@ function Global:Prompt() {
 # Only send the command executed sequence when PSReadLine is loaded, if not shell integration should
 # still work thanks to the command line sequence
 if (Get-Module -Name PSReadLine) {
-	[Console]::Write("$([char]0x1b)]633;P;HasRichCmdDetection=True`a")
+	[Console]::Write("$([char]0x1b)]633;P;HasRichCommandDetection=True`a")
 	$__VSCodeOriginalPSConsoleHostReadLine = $function:PSConsoleHostReadLine
 	function Global:PSConsoleHostReadLine {
 		$CommandLine = $__VSCodeOriginalPSConsoleHostReadLine.Invoke()

--- a/src/vs/workbench/contrib/terminal/common/scripts/shellIntegration.ps1
+++ b/src/vs/workbench/contrib/terminal/common/scripts/shellIntegration.ps1
@@ -124,6 +124,7 @@ function Global:Prompt() {
 # Only send the command executed sequence when PSReadLine is loaded, if not shell integration should
 # still work thanks to the command line sequence
 if (Get-Module -Name PSReadLine) {
+	[Console]::Write("$([char]0x1b)]633;P;HasRichCmdDetection=True`a")
 	$__VSCodeOriginalPSConsoleHostReadLine = $function:PSConsoleHostReadLine
 	function Global:PSConsoleHostReadLine {
 		$CommandLine = $__VSCodeOriginalPSConsoleHostReadLine.Invoke()

--- a/src/vscode-dts/vscode.proposed.terminalShellIntegrationRich.d.ts
+++ b/src/vscode-dts/vscode.proposed.terminalShellIntegrationRich.d.ts
@@ -1,0 +1,20 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+declare module 'vscode' {
+	// @tyriar https://github.com/microsoft/vscode/issues/227467
+
+	export interface TerminalShellIntegration {
+		/**
+		 * Whether this shell supports rich command detection. This means that the shell has
+		 * declared that it will report the required shell integation sequences in the exact order
+		 * they're expected, so {@link TerminalShellExecutionCommandLine.value} should always be set
+		 * and {@link TerminalShellExecutionCommandLine.confidence} should always be
+		 * {@link TerminalShellExecutionCommandLineConfidence.High} at the time
+		 * {@link onDidStartTerminalShellExecution} fires.
+		 */
+		readonly hasRichCommandDetection: boolean;
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/242195
Fixes https://github.com/microsoft/vscode/issues/242075
Part of #242897

## Strong tie between exthost and renderer shell executions

When rich command detection is enabled, the execution objects on the exthost and the renderer sides are now more strongly linked. Executions aren't started immediately on the exthost but instead only requested of the renderer and when they actually start the command line attempts to get matched.

When rich command detection is not present, `executeCommand` can still be confused like before, but this is now an edge case and only applies to those without "official" shell integration.

## New sequence for rich command detection

This adds the sequence `633 P HasRichCommandDetection=<True|False>` that allows a shell integration scripts to declare ahead of time that it supports "rich command detection" which essentially means that the sequences `A B E C D` will all happen and in that exact order. The need for this is because we don't know whether E will actually happen before the first `executeCommand` is called. This means that we should know the command line when the execute `C` sequence happens which gives the best experience in the API.

The only current usage of this sequence is to pass along to extensions, log when something unexpected happens and to provide diagnostics to the user in the tab hover.

## New proposed API

For the above, there's a new `TerminalShellIntegration.hasRichCommandDetection` API that allows an extension to check whether the SI is "rich" or not. See https://github.com/microsoft/vscode/issues/242897 for more context

## New tab hover section

This also moves the shell integration info in the terminal tab to the status system and adds more details which will be very useful for quickly diagnosing issues:

![image](https://github.com/user-attachments/assets/22dc1872-7cf3-43f0-af6a-5e1e4afe699b)

This should be fairly small but we can move some details into the "detailed hover" if/when we end up doing that https://github.com/microsoft/vscode/issues/242103
