### PR TITLE
call the generator function

### DIFF
--- a/extensions/ipynb/src/helper.ts
+++ b/extensions/ipynb/src/helper.ts
@@ -155,7 +155,7 @@ export function generateUuid(): string {
 		// > usable feature in insecure contexts: the getRandomValues() method.
 		// > In general, you should use this API only in secure contexts.
 
-		return crypto.randomUUID.bind(crypto).toString();
+		return crypto.randomUUID.bind(crypto)();
 	}
 
 	// prep-work

--- a/test/automation/src/profiler.ts
+++ b/test/automation/src/profiler.ts
@@ -66,7 +66,7 @@ export function generateUuid(): string {
 		// > usable feature in insecure contexts: the getRandomValues() method.
 		// > In general, you should use this API only in secure contexts.
 
-		return crypto.randomUUID.bind(crypto).toString();
+		return crypto.randomUUID.bind(crypto)();
 	}
 
 	// prep-work


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

the toString was being called on a function definition and therefore always returning 'function' as the unique identifier.
The common library from which this was copied was returning a function, not a string.