### PR TITLE
Remove border height from suggest widget height calculation

### DIFF
--- a/src/vs/editor/contrib/suggest/browser/suggestWidget.ts
+++ b/src/vs/editor/contrib/suggest/browser/suggestWidget.ts
@@ -832,7 +832,7 @@ export class SuggestWidget implements IDisposable {
 
 		if (this._state === State.Empty || this._state === State.Loading) {
 			// showing a message only
-			height = info.itemHeight + info.borderHeight;
+			height = info.itemHeight;
 			width = info.defaultSize.width / 2;
 			this.element.enableSashes(false, false, false, false);
 			this.element.minSize = this.element.maxSize = new dom.Dimension(width, height);
@@ -849,7 +849,7 @@ export class SuggestWidget implements IDisposable {
 			const preferredWidth = this._completionModel ? this._completionModel.stats.pLabelLen * info.typicalHalfwidthCharacterWidth : width;
 
 			// height math
-			const fullHeight = info.statusBarHeight + this._list.contentHeight + info.borderHeight;
+			const fullHeight = info.statusBarHeight + this._list.contentHeight;
 			const minHeight = info.itemHeight + info.statusBarHeight;
 			const editorBox = dom.getDomNodePagePosition(this.editor.getDomNode());
 			const cursorBox = this.editor.getScrolledVisiblePosition(this.editor.getPosition());
@@ -857,7 +857,7 @@ export class SuggestWidget implements IDisposable {
 			const maxHeightBelow = Math.min(bodyBox.height - cursorBottom - info.verticalPadding, fullHeight);
 			const availableSpaceAbove = editorBox.top + cursorBox.top - info.verticalPadding;
 			const maxHeightAbove = Math.min(availableSpaceAbove, fullHeight);
-			let maxHeight = Math.min(Math.max(maxHeightAbove, maxHeightBelow) + info.borderHeight, fullHeight);
+			let maxHeight = Math.min(Math.max(maxHeightAbove, maxHeightBelow), fullHeight);
 
 			if (height === this._cappedHeight?.capped) {
 				// Restore the old (wanted) height when the current


### PR DESCRIPTION
Fixes #242956.

The suggest widget height calculations include the border height, but the result is used to set the inner height of the widget (excluding the border). This causes the widget to be two or four pixels too high, depending on whether a high-contrast theme is used.

This PR removes the border height from the suggest widget height calculation, similar to https://github.com/microsoft/vscode/commit/d66eb6b82f4fd73db17a4b7cc0799f90a09207bc, which addressed the same issue for the default size of the widget.

![Before and after](https://github.com/user-attachments/assets/463c94ba-2c40-42f7-8278-107383c943f1)