### PR TITLE
Allow hiding window controls

### DIFF
--- a/src/vs/platform/window/common/window.ts
+++ b/src/vs/platform/window/common/window.ts
@@ -152,6 +152,7 @@ export interface IWindowSettings {
 	readonly restoreFullscreen: boolean;
 	readonly zoomLevel: number;
 	readonly titleBarStyle: TitlebarStyle;
+	readonly showTitleBarControls: boolean;
 	readonly autoDetectHighContrast: boolean;
 	readonly autoDetectColorScheme: boolean;
 	readonly menuBarVisibility: MenuBarVisibility;
@@ -172,6 +173,7 @@ export interface IDensitySettings {
 export const enum TitleBarSetting {
 	TITLE_BAR_STYLE = 'window.titleBarStyle',
 	CUSTOM_TITLE_BAR_VISIBILITY = 'window.customTitleBarVisibility',
+	SHOW_TITLE_BAR_CONTROLS = 'window.showTitleBarControls',
 }
 
 export const enum TitlebarStyle {
@@ -197,6 +199,10 @@ export function hasNativeTitlebar(configurationService: IConfigurationService, t
 	}
 
 	return titleBarStyle === TitlebarStyle.NATIVE;
+}
+
+export function showTitlebarControls(configurationService: IConfigurationService): boolean {
+	return configurationService.getValue<boolean>(TitleBarSetting.SHOW_TITLE_BAR_CONTROLS) ?? true;
 }
 
 export function getTitleBarStyle(configurationService: IConfigurationService): TitlebarStyle {
@@ -236,7 +242,7 @@ export function useWindowControlsOverlay(configurationService: IConfigurationSer
 		return false; // only supported when title bar is custom
 	}
 
-	return true; // default
+	return showTitlebarControls(configurationService);
 }
 
 export function useNativeFullScreen(configurationService: IConfigurationService): boolean {

--- a/src/vs/workbench/browser/parts/titlebar/titlebarActions.ts
+++ b/src/vs/workbench/browser/parts/titlebar/titlebarActions.ts
@@ -70,6 +70,12 @@ registerAction2(class ToggleLayoutControl extends ToggleTitleBarConfigAction {
 	}
 });
 
+registerAction2(class ToggleWindowControls extends ToggleTitleBarConfigAction {
+	constructor() {
+		super(LayoutSettings.WINDOW_CONTROLS, localize('toggle.windowControls', 'Window Controls'), localize('toggle.windowControlsDescription', "Toggle visibility of Minimize, Maximize and Close buttons in title bar"), 5, false);
+	}
+});
+
 registerAction2(class ToggleCustomTitleBar extends Action2 {
 	constructor() {
 		super({

--- a/src/vs/workbench/browser/parts/titlebar/titlebarPart.ts
+++ b/src/vs/workbench/browser/parts/titlebar/titlebarPart.ts
@@ -8,7 +8,7 @@ import { localize, localize2 } from '../../../../nls.js';
 import { MultiWindowParts, Part } from '../../part.js';
 import { ITitleService } from '../../../services/title/browser/titleService.js';
 import { getWCOTitlebarAreaRect, getZoomFactor, isWCOEnabled } from '../../../../base/browser/browser.js';
-import { MenuBarVisibility, getTitleBarStyle, getMenuBarVisibility, hasCustomTitlebar, hasNativeTitlebar, DEFAULT_CUSTOM_TITLEBAR_HEIGHT } from '../../../../platform/window/common/window.js';
+import { MenuBarVisibility, getTitleBarStyle, getMenuBarVisibility, hasCustomTitlebar, hasNativeTitlebar, showTitlebarControls, DEFAULT_CUSTOM_TITLEBAR_HEIGHT } from '../../../../platform/window/common/window.js';
 import { IContextMenuService } from '../../../../platform/contextview/browser/contextView.js';
 import { StandardMouseEvent } from '../../../../base/browser/mouseEvent.js';
 import { IConfigurationService, IConfigurationChangeEvent } from '../../../../platform/configuration/common/configuration.js';
@@ -482,7 +482,7 @@ export class BrowserTitlebarPart extends Part implements ITitlebarPart {
 				// for something, except for web where a custom menu being supported). not putting the
 				// container helps with allowing to move the window when clicking very close to the
 				// window control buttons.
-			} else {
+			} else if (showTitlebarControls(this.configurationService)) {
 				const windowControlsContainer = append(primaryWindowControlsLocation === 'left' ? this.leftContent : this.rightContent, $('div.window-controls-container'));
 				if (isWeb) {
 					// Web: its possible to have control overlays on both sides, for example on macOS

--- a/src/vs/workbench/contrib/debug/browser/debugToolBar.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugToolBar.ts
@@ -32,7 +32,7 @@ import { IStorageService, StorageScope, StorageTarget } from '../../../../platfo
 import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry.js';
 import { widgetBorder, widgetShadow } from '../../../../platform/theme/common/colorRegistry.js';
 import { IThemeService, Themable } from '../../../../platform/theme/common/themeService.js';
-import { getTitleBarStyle, TitlebarStyle } from '../../../../platform/window/common/window.js';
+import { getTitleBarStyle, showTitlebarControls, TitlebarStyle } from '../../../../platform/window/common/window.js';
 import { IWorkbenchContribution } from '../../../common/contributions.js';
 import { EditorTabsMode, IWorkbenchLayoutService, LayoutSettings, Parts } from '../../../services/layout/browser/layoutService.js';
 import { CONTEXT_DEBUG_STATE, CONTEXT_FOCUSED_SESSION_IS_ATTACH, CONTEXT_FOCUSED_SESSION_IS_NO_DEBUG, CONTEXT_IN_DEBUG_MODE, CONTEXT_MULTI_SESSION_DEBUG, CONTEXT_STEP_BACK_SUPPORTED, CONTEXT_SUSPEND_DEBUGGEE_SUPPORTED, CONTEXT_TERMINATE_DEBUGGEE_SUPPORTED, IDebugConfiguration, IDebugService, State, VIEWLET_ID } from '../common/debug.js';
@@ -79,8 +79,8 @@ export class DebugToolBar extends Themable implements IWorkbenchContribution {
 
 		this.$el = dom.$('div.debug-toolbar');
 
-		// Note: changes to this setting require a restart, so no need to listen to it.
-		const customTitleBar = getTitleBarStyle(this.configurationService) === TitlebarStyle.CUSTOM;
+		// Note: changes to these settings require a restart, so no need to listen to them
+		const customTitleBar = getTitleBarStyle(this.configurationService) === TitlebarStyle.CUSTOM && showTitlebarControls(this.configurationService);
 
 		// Do not allow the widget to overflow or underflow window controls.
 		// Use CSS calculations to avoid having to force layout with `.clientWidth`

--- a/src/vs/workbench/contrib/relauncher/browser/relauncher.contribution.ts
+++ b/src/vs/workbench/contrib/relauncher/browser/relauncher.contribution.ts
@@ -38,6 +38,7 @@ export class SettingsChangeRelauncher extends Disposable implements IWorkbenchCo
 
 	private static SETTINGS = [
 		TitleBarSetting.TITLE_BAR_STYLE,
+		TitleBarSetting.SHOW_TITLE_BAR_CONTROLS,
 		'window.nativeTabs',
 		'window.nativeFullScreen',
 		'window.clickThroughInactive',
@@ -52,6 +53,7 @@ export class SettingsChangeRelauncher extends Disposable implements IWorkbenchCo
 
 	private readonly titleBarStyle = new ChangeObserver<TitlebarStyle>('string');
 	private readonly nativeTabs = new ChangeObserver('boolean');
+	private readonly showTitleBarControls = new ChangeObserver('boolean');
 	private readonly nativeFullScreen = new ChangeObserver('boolean');
 	private readonly clickThroughInactive = new ChangeObserver('boolean');
 	private readonly updateMode = new ChangeObserver('string');
@@ -107,6 +109,9 @@ export class SettingsChangeRelauncher extends Disposable implements IWorkbenchCo
 
 			// Titlebar style
 			processChanged((config.window.titleBarStyle === TitlebarStyle.NATIVE || config.window.titleBarStyle === TitlebarStyle.CUSTOM) && this.titleBarStyle.handleChange(config.window?.titleBarStyle));
+
+			// Titlebar controls
+			processChanged(this.showTitleBarControls.handleChange(config.window?.showTitleBarControls));
 
 			// macOS: Native tabs
 			processChanged(isMacintosh && this.nativeTabs.handleChange(config.window?.nativeTabs));

--- a/src/vs/workbench/electron-sandbox/desktop.contribution.ts
+++ b/src/vs/workbench/electron-sandbox/desktop.contribution.ts
@@ -248,6 +248,12 @@ import { MAX_ZOOM_LEVEL, MIN_ZOOM_LEVEL } from '../../platform/window/electron-s
 				'scope': ConfigurationScope.APPLICATION,
 				'markdownDescription': localize('window.customTitleBarVisibility', "Adjust when the custom title bar should be shown. The custom title bar can be hidden when in full screen mode with `windowed`. The custom title bar can only be hidden in non full screen mode with `never` when {0} is set to `native`.", '`#window.titleBarStyle#`'),
 			},
+			'window.showTitleBarControls': {
+				'type': 'boolean',
+				'default': true,
+				'scope': ConfigurationScope.APPLICATION,
+				'markdownDescription': localize('window.showTitleBarControls', "Controls whether the Minimize, Maximize, and Close buttons should be shown in the custom title bar. This setting is effective only if {0} is set to `custom`.", '`#window.titleBarStyle#`')
+			},
 			'window.dialogStyle': {
 				'type': 'string',
 				'enum': ['native', 'custom'],

--- a/src/vs/workbench/services/layout/browser/layoutService.ts
+++ b/src/vs/workbench/services/layout/browser/layoutService.ts
@@ -45,7 +45,8 @@ export const enum LayoutSettings {
 	EDITOR_TABS_MODE = 'workbench.editor.showTabs',
 	EDITOR_ACTIONS_LOCATION = 'workbench.editor.editorActionsLocation',
 	COMMAND_CENTER = 'window.commandCenter',
-	LAYOUT_ACTIONS = 'workbench.layoutControl.enabled'
+	LAYOUT_ACTIONS = 'workbench.layoutControl.enabled',
+	WINDOW_CONTROLS = 'window.showTitleBarControls'
 }
 
 export const enum ActivityBarPosition {


### PR DESCRIPTION
Adds a new setting `window.showTitleBarControls` to allow hiding the window control buttons (maximize, minimize, close) when using the custom title bar.

When using a tiling window manager (like i3, sway, hyprland, etc.), those buttons don't even work and should be hidden. However, setting the title bar to `native` has some serious drawbacks:
- Forces the use of "native" context menus, which are inferior to VSCode's custom context menu styles. See #224515 and #224629.
- Removes the quick access to the command center, layout controls and copilot button.
- Doesn't look as good and well integrated as the custom title bar.

Therefore, I believe that using the custom title bar but adding the option to hide those buttons is the perfect solution.

I only tested it on Linux, feedback from people using Windows and macOS would be appreciated.

## How to use

Right-click the title bar and toggle "Window controls".

![image](https://github.com/user-attachments/assets/8d2e6aae-d4c4-4fb8-9fe6-4a41c9f994b6)

The relaunch popup will be shown, and after restarting the window control buttons will be hidden.

![image](https://github.com/user-attachments/assets/792121b2-d2ac-4631-baa1-ed6b25036bb3)

Alternatively, the setting can be changed directly:

![image](https://github.com/user-attachments/assets/68427313-9d1f-450c-8bce-e8489ff6887a)

