### PR TITLE
Add 'workbench.fontFamily' config option

### DIFF
--- a/src/vs/workbench/browser/workbench.contribution.ts
+++ b/src/vs/workbench/browser/workbench.contribution.ts
@@ -582,6 +582,10 @@ const registry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Con
 				},
 				'additionalProperties': false
 			},
+			'workbench.fontFamily': {
+				'type': 'string',
+				'description': localize('workbench.fontFamily', "Controls the font family of the workbench.")
+			},
 			'workbench.fontAliasing': {
 				'type': 'string',
 				'enum': ['default', 'antialiased', 'none', 'auto'],

--- a/src/vs/workbench/browser/workbench.ts
+++ b/src/vs/workbench/browser/workbench.ts
@@ -214,6 +214,10 @@ export class Workbench extends Layout {
 
 	private registerListeners(lifecycleService: ILifecycleService, storageService: IStorageService, configurationService: IConfigurationService, hostService: IHostService, dialogService: IDialogService): void {
 
+		this._register(configurationService.onDidChangeConfiguration(() => {
+			this.mainContainer.style.fontFamily = configurationService.getValue('workbench.fontFamily');
+		}));
+
 		// Configuration changes
 		this._register(configurationService.onDidChangeConfiguration(e => this.updateFontAliasing(e, configurationService)));
 


### PR DESCRIPTION
Hi,

## How It Works

This is a super simple PR (only 7 lines) that simply adds a string field option in **Settings > Workbench** to customize the `font-family` of the workbench.

It listens for configuration changes and adds the `font-family` CSS property (with the user-configured value) to the main container of the workbench (`.monaco-workbench`).

## Video Preview

https://github.com/user-attachments/assets/cb267d7d-05d3-43c8-918d-1f3260c7070a

## Why Accept This PR

- It doesn't harm anyone or break anything.
- It satisfies the simple needs of so many people.
- It improves UX and user satisfaction.
- It reduces negativity, frustration towards vsCode, maintainers and Microsoft Corporation.
- It just gives people what they want.
- It reduces possible risks of users getting infected with malware caused by the action taken to change the `font-family` of the workbench.
- Users can simply ignore it if it causes issues for them, just like other settings where an option may not work as expected for some users.
- The maintainer who merges this PR will receive many ❤️s :)

## Related Issues

- #519 (the PR doesn't close this issue).

---

@bpasero
@isidorn
@alexr00