### PR TITLE
Add discovery of PowerShell Core user installation

### DIFF
--- a/src/vs/base/node/powershell.ts
+++ b/src/vs/base/node/powershell.ts
@@ -230,7 +230,7 @@ function findPSCoreScoopInstallation(): IPossiblePowerShellExe {
 	const scoopAppsDir = path.join(os.homedir(), 'scoop', 'apps');
 	const scoopPwsh = path.join(scoopAppsDir, 'pwsh', 'current', 'pwsh.exe');
 
-	return new PossiblePowerShellExe(scoopPwsh, 'PowerShell Core Scoop Installation');
+	return new PossiblePowerShellExe(scoopPwsh, 'PowerShell (Scoop)');
 }
 
 function findWinPS(): IPossiblePowerShellExe | null {

--- a/src/vs/base/node/powershell.ts
+++ b/src/vs/base/node/powershell.ts
@@ -226,7 +226,7 @@ function findPSCoreDotnetGlobalTool(): IPossiblePowerShellExe {
 	return new PossiblePowerShellExe(dotnetGlobalToolExePath, '.NET Core PowerShell Global Tool');
 }
 
-function findPSCoreUserInstallation(): IPossiblePowerShellExe {
+function findPSCoreScoopInstallation(): IPossiblePowerShellExe {
 	const scoopAppsDir = path.join(os.homedir(), 'scoop', 'apps');
 	const scoopPwsh = path.join(scoopAppsDir, 'pwsh', 'current', 'pwsh.exe');
 
@@ -292,7 +292,7 @@ async function* enumerateDefaultPowerShellInstallations(): AsyncIterable<IPossib
 		yield pwshExe;
 	}
 
-	pwshExe = await findPSCoreUserInstallation();
+	pwshExe = await findPSCoreScoopInstallation();
 	if (pwshExe) {
 		yield pwshExe;
 	}

--- a/src/vs/base/node/powershell.ts
+++ b/src/vs/base/node/powershell.ts
@@ -230,7 +230,7 @@ function findPSCoreScoopInstallation(): IPossiblePowerShellExe {
 	const scoopAppsDir = path.join(os.homedir(), 'scoop', 'apps');
 	const scoopPwsh = path.join(scoopAppsDir, 'pwsh', 'current', 'pwsh.exe');
 
-	return new PossiblePowerShellExe(scoopPwsh, 'PowerShell Core User Installation');
+	return new PossiblePowerShellExe(scoopPwsh, 'PowerShell Core Scoop Installation');
 }
 
 function findWinPS(): IPossiblePowerShellExe | null {

--- a/src/vs/base/node/powershell.ts
+++ b/src/vs/base/node/powershell.ts
@@ -226,6 +226,13 @@ function findPSCoreDotnetGlobalTool(): IPossiblePowerShellExe {
 	return new PossiblePowerShellExe(dotnetGlobalToolExePath, '.NET Core PowerShell Global Tool');
 }
 
+function findPSCoreUserInstallation(): IPossiblePowerShellExe {
+	const scoopAppsDir = path.join(os.homedir(), 'scoop', 'apps');
+	const scoopPwsh = path.join(scoopAppsDir, 'pwsh', 'current', 'pwsh.exe');
+
+	return new PossiblePowerShellExe(scoopPwsh, 'PowerShell Core User Installation');
+}
+
 function findWinPS(): IPossiblePowerShellExe | null {
 	const winPSPath = path.join(
 		process.env.windir!,
@@ -281,6 +288,11 @@ async function* enumerateDefaultPowerShellInstallations(): AsyncIterable<IPossib
 
 	// Look for pwsh-preview with the opposite bitness
 	pwshExe = await findPSCoreWindowsInstallation({ useAlternateBitness: true, findPreview: true });
+	if (pwshExe) {
+		yield pwshExe;
+	}
+
+	pwshExe = await findPSCoreUserInstallation();
 	if (pwshExe) {
 		yield pwshExe;
 	}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Closes #137323.

This simple change adds ability to discover PowerShell Core installed to user's home directory.

> I'm not planning on adding this, but if a PR came in for it, I wouldn't reject it.

Here it [came](https://github.com/microsoft/vscode/issues/137323#issuecomment-985573854).