### PR TITLE
Fixing property initialization order in stickyScrollWidget.ts file

### DIFF
--- a/build/lib/propertyInitOrderChecker.js
+++ b/build/lib/propertyInitOrderChecker.js
@@ -118,7 +118,6 @@ const ignored = new Set([
     'vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditWithChanges.ts',
     'vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsModel.ts',
     'vs/platform/contextview/browser/contextViewService.ts',
-    'vs/editor/contrib/stickyScroll/browser/stickyScrollWidget.ts',
     'vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/components/gutterIndicatorMenu.ts',
     'vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/components/gutterIndicatorView.ts',
     'vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/inlineEditsDeletionView.ts',

--- a/build/lib/propertyInitOrderChecker.ts
+++ b/build/lib/propertyInitOrderChecker.ts
@@ -87,7 +87,6 @@ const ignored = new Set([
 	'vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditWithChanges.ts',
 	'vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsModel.ts',
 	'vs/platform/contextview/browser/contextViewService.ts',
-	'vs/editor/contrib/stickyScroll/browser/stickyScrollWidget.ts',
 	'vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/components/gutterIndicatorMenu.ts',
 	'vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/components/gutterIndicatorView.ts',
 	'vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/inlineEditsDeletionView.ts',

--- a/src/vs/editor/contrib/stickyScroll/browser/stickyScrollWidget.ts
+++ b/src/vs/editor/contrib/stickyScroll/browser/stickyScrollWidget.ts
@@ -57,7 +57,6 @@ export class StickyScrollWidget extends Disposable implements IOverlayWidget {
 	private readonly _linesDomNode: HTMLElement = document.createElement('div');
 
 	private _previousState: StickyScrollWidgetState | undefined;
-	private _lineHeight: number = this._editor.getOption(EditorOption.lineHeight);
 	private _renderedStickyLines: RenderedStickyLine[] = [];
 	private _lineNumbers: number[] = [];
 	private _lastLineRelativePosition: number = 0;
@@ -65,16 +64,21 @@ export class StickyScrollWidget extends Disposable implements IOverlayWidget {
 	private _isOnGlyphMargin: boolean = false;
 	private _height: number = -1;
 
+	private readonly _editor: ICodeEditor;
+	private _lineHeight: number;
+
 	public get height(): number { return this._height; }
 
 	private readonly _onDidChangeStickyScrollHeight = this._register(new Emitter<{ height: number }>());
 	public readonly onDidChangeStickyScrollHeight = this._onDidChangeStickyScrollHeight.event;
 
 	constructor(
-		private readonly _editor: ICodeEditor
+		editor: ICodeEditor
 	) {
 		super();
 
+		this._editor = editor;
+		this._lineHeight = editor.getOption(EditorOption.lineHeight);
 		this._lineNumbersDomNode.className = 'sticky-widget-line-numbers';
 		this._lineNumbersDomNode.setAttribute('role', 'none');
 
@@ -85,7 +89,7 @@ export class StickyScrollWidget extends Disposable implements IOverlayWidget {
 		this._linesDomNodeScrollable.appendChild(this._linesDomNode);
 
 		this._rootDomNode.className = 'sticky-widget';
-		this._rootDomNode.classList.toggle('peek', _editor instanceof EmbeddedCodeEditorWidget);
+		this._rootDomNode.classList.toggle('peek', editor instanceof EmbeddedCodeEditorWidget);
 		this._rootDomNode.appendChild(this._lineNumbersDomNode);
 		this._rootDomNode.appendChild(this._linesDomNodeScrollable);
 		this._setHeight(0);

--- a/src/vs/editor/contrib/stickyScroll/browser/stickyScrollWidget.ts
+++ b/src/vs/editor/contrib/stickyScroll/browser/stickyScrollWidget.ts
@@ -56,16 +56,16 @@ export class StickyScrollWidget extends Disposable implements IOverlayWidget {
 	private readonly _linesDomNodeScrollable: HTMLElement = document.createElement('div');
 	private readonly _linesDomNode: HTMLElement = document.createElement('div');
 
+	private readonly _editor: ICodeEditor;
+
 	private _previousState: StickyScrollWidgetState | undefined;
+	private _lineHeight: number;
 	private _renderedStickyLines: RenderedStickyLine[] = [];
 	private _lineNumbers: number[] = [];
 	private _lastLineRelativePosition: number = 0;
 	private _minContentWidthInPx: number = 0;
 	private _isOnGlyphMargin: boolean = false;
 	private _height: number = -1;
-
-	private readonly _editor: ICodeEditor;
-	private _lineHeight: number;
 
 	public get height(): number { return this._height; }
 


### PR DESCRIPTION
Ref: https://github.com/microsoft/vscode/issues/243049