### PR TITLE
Fix shell integration smoke test flake

### DIFF
--- a/test/smoke/src/areas/terminal/terminal-shellIntegration.test.ts
+++ b/test/smoke/src/areas/terminal/terminal-shellIntegration.test.ts
@@ -95,8 +95,8 @@ export function setup(options?: { skipSuite: boolean }) {
 				await settingsEditor.clearUserSettings();
 			});
 			beforeEach(async function () {
-				// Create the simplest system profile to get as little process interaction as possible
-				await terminal.createTerminal();
+				// Use the simplest profile to get as little process interaction as possible
+				await terminal.createEmptyTerminal();
 				// Erase all content and reset cursor to top
 				await terminal.runCommandWithValue(TerminalCommandIdWithValue.WriteDataToTerminal, `${csi('2J')}${csi('H')}`);
 			});
@@ -114,8 +114,7 @@ export function setup(options?: { skipSuite: boolean }) {
 					await terminal.assertCommandDecorations({ placeholder: 1, success: 1, error: 1 });
 				});
 			});
-			// TODO: This depends on https://github.com/microsoft/vscode/issues/146587
-			describe.skip('Final Term sequences', () => {
+			describe('Final Term sequences', () => {
 				it('should handle the simple case', async () => {
 					await terminal.runCommandWithValue(TerminalCommandIdWithValue.WriteDataToTerminal, `${ft('A')}Prompt> ${ft('B')}exitcode 0`);
 					await terminal.assertCommandDecorations({ placeholder: 1, success: 0, error: 0 });


### PR DESCRIPTION
The problem was caused by zsh being out of date causing the shell initialized check to not work properly as the prompt was delayed after that.

Fixes #242739

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
