### PR TITLE
Allow suggestions to pass through if outside accept flow

### DIFF
--- a/src/vs/editor/contrib/inlineCompletions/browser/model/inlineCompletionsModel.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/model/inlineCompletionsModel.ts
@@ -375,7 +375,7 @@ export class InlineCompletionsModel extends Disposable {
 
 		const item = this._inlineCompletionItems.read(reader);
 		const inlineEditResult = item?.inlineEdit;
-		if (inlineEditResult) {
+		if (inlineEditResult && this._inAcceptFlow.read(reader)) {
 			if (this._hasVisiblePeekWidgets.read(reader)) {
 				return undefined;
 			}
@@ -386,7 +386,7 @@ export class InlineCompletionsModel extends Disposable {
 			const cursorAtInlineEdit = LineRange.fromRangeInclusive(edit.range).addMargin(1, 1).contains(cursorPos.lineNumber);
 			const cursorInsideShowRange = cursorAtInlineEdit || (inlineEditResult.inlineCompletion.cursorShowRange?.containsPosition(cursorPos) ?? true);
 
-			if (!cursorInsideShowRange && !this._inAcceptFlow.read(reader)) {
+			if (!cursorInsideShowRange) {
 				return undefined;
 			}
 


### PR DESCRIPTION
Updates the accept flow check to consider suggestion items if outside the accept flow.

Putting the check for the accept flow inside this block seems to prevent suggestions from being triggered if there is an inline edit but the user is outside the accept flow, but showing an inline completion is still possible.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
