### PR TITLE
macOS: window controls stop working when zoomed in (fix #242890)

### DIFF
--- a/src/vs/platform/windows/electron-main/windows.ts
+++ b/src/vs/platform/windows/electron-main/windows.ts
@@ -192,21 +192,23 @@ export function defaultBrowserWindowOptions(accessor: ServicesAccessor, windowSt
 		}
 
 		if (useWindowControlsOverlay(configurationService)) {
+			if (isMacintosh) {
+				options.titleBarOverlay = true;
+			} else {
 
-			// This logic will not perfectly guess the right colors
-			// to use on initialization, but prefer to keep things
-			// simple as it is temporary and not noticeable
-			// On macOS, only the presence of `titleBarOverlay` is
-			// considered, the properties are ignored.
+				// This logic will not perfectly guess the right colors
+				// to use on initialization, but prefer to keep things
+				// simple as it is temporary and not noticeable
 
-			const titleBarColor = themeMainService.getWindowSplash(undefined)?.colorInfo.titleBarBackground ?? themeMainService.getBackgroundColor();
-			const symbolColor = Color.fromHex(titleBarColor).isDarker() ? '#FFFFFF' : '#000000';
+				const titleBarColor = themeMainService.getWindowSplash(undefined)?.colorInfo.titleBarBackground ?? themeMainService.getBackgroundColor();
+				const symbolColor = Color.fromHex(titleBarColor).isDarker() ? '#FFFFFF' : '#000000';
 
-			options.titleBarOverlay = {
-				height: 29, // the smallest size of the title bar on windows accounting for the border on windows 11
-				color: titleBarColor,
-				symbolColor
-			};
+				options.titleBarOverlay = {
+					height: 29, // the smallest size of the title bar on windows accounting for the border on windows 11
+					color: titleBarColor,
+					symbolColor
+				};
+			}
 		}
 	}
 


### PR DESCRIPTION
@deepak1556 looks like buggy stuff is happening if on macOS we define a `height: 29` in `titleBarOverlay` and later call `setWindowButtonPosition`.

I had thought that all properties on macOS are ignored, but that does not seem to be the case, so the safest seems to be to go with the `titleBarOverlay: true` option?