### PR TITLE
Hover Identity check not working

### DIFF
--- a/src/vs/editor/browser/services/hoverService/hoverService.ts
+++ b/src/vs/editor/browser/services/hoverService/hoverService.ts
@@ -186,6 +186,16 @@ export class HoverService extends Disposable implements IHoverService {
 		if (this._currentHover?.isLocked) {
 			return undefined;
 		}
+
+		// Set `id` to default if it's undefined
+		if (options.id === undefined) {
+			options.id = isHTMLElement(options.content)
+				? undefined
+				: typeof options.content === 'string'
+					? options.content.toString()
+					: options.content.value;
+		}
+
 		if (getHoverOptionsIdentity(this._currentHoverOptions) === getHoverOptionsIdentity(options)) {
 			return undefined;
 		}
@@ -202,15 +212,6 @@ export class HoverService extends Disposable implements IHoverService {
 			} else {
 				this._lastFocusedElementBeforeOpen = undefined;
 			}
-		}
-
-		// Set `id` to default if it's undefined
-		if (options.id === undefined) {
-			options.id = isHTMLElement(options.content)
-				? undefined
-				: typeof options.content === 'string'
-					? options.content.toString()
-					: options.content.value;
 		}
 
 		const hoverDisposables = new DisposableStore();


### PR DESCRIPTION
I noticed that the hover would flicker when moving the mouse inside an HTML Element which had a hover on it and nested HTML Elements. Each time the mouse would move over a different nested HTML Element, `_createHover()` would be called and the identity check would fail. Also, `hideOnKeyDown` did not work for delayed hovers.

This seems to be because we set the id of the hover after comparing identities, meaning the current hover option id will always be undefined if not explicitly set by hover service consumer

fixes https://github.com/microsoft/vscode/issues/243163