### PR TITLE
update quick access promises to check prototype instead of instanceof

### DIFF
--- a/src/vs/platform/quickinput/browser/pickerQuickAccess.ts
+++ b/src/vs/platform/quickinput/browser/pickerQuickAccess.ts
@@ -121,10 +121,14 @@ function isPicksWithActive<T>(obj: unknown): obj is PicksWithActive<T> {
 	return Array.isArray(candidate.items);
 }
 
+function isPromise<T>(obj: unknown): obj is Promise<T> {
+	return Object.prototype.toString.call(obj) === '[object Promise]';
+}
+
 function isFastAndSlowPicks<T>(obj: unknown): obj is FastAndSlowPicks<T> {
 	const candidate = obj as FastAndSlowPicks<T>;
 
-	return !!candidate.picks && candidate.additionalPicks instanceof Promise;
+	return !!candidate.picks && isPromise(candidate.additionalPicks);
 }
 
 export abstract class PickerQuickAccessProvider<T extends IPickerQuickAccessItem> extends Disposable implements IQuickAccessProvider {
@@ -296,7 +300,7 @@ export abstract class PickerQuickAccessProvider<T extends IPickerQuickAccessItem
 			}
 
 			// Fast Picks
-			else if (!(providedPicks instanceof Promise)) {
+			else if (!(isPromise(providedPicks))) {
 				applyPicks(providedPicks);
 			}
 


### PR DESCRIPTION
Updating the pickerQuickAccess to check the object prototype for Promise compat.  Due to how the monaco editor core uses promises, specifically the cancellation token based promise types using its own async bundle, Angular is unable to intercept these promises as ZoneAwarePromise, which causes an error whenever the monaco editor is used within the angular boundary.  As this instanceof call compares with the internal Promise type for the instanceof call, but it is a ZoneAwarePromise.  This prototype comparison is equivalent in all scenarios as ZoneAwarePromise is a patched promise type, and the prototype is Promise.

https://github.com/microsoft/monaco-editor/issues/4372
