### PR TITLE
mcp: securely store mcp inputs

### DIFF
--- a/build/lib/layersChecker.js
+++ b/build/lib/layersChecker.js
@@ -81,7 +81,8 @@ const CORE_TYPES = [
     'ImportMeta',
     // webcrypto has been available since Node.js 19, but still live in dom.d.ts
     'Crypto',
-    'SubtleCrypto'
+    'SubtleCrypto',
+    'JsonWebKey',
 ];
 // Types that are defined in a common layer but are known to be only
 // available in native environments should not be allowed in browser

--- a/build/lib/layersChecker.ts
+++ b/build/lib/layersChecker.ts
@@ -80,7 +80,8 @@ const CORE_TYPES = [
 
 	// webcrypto has been available since Node.js 19, but still live in dom.d.ts
 	'Crypto',
-	'SubtleCrypto'
+	'SubtleCrypto',
+	'JsonWebKey',
 ];
 
 // Types that are defined in a common layer but are known to be only

--- a/src/vs/platform/secrets/test/common/testSecretStorageService.ts
+++ b/src/vs/platform/secrets/test/common/testSecretStorageService.ts
@@ -1,0 +1,36 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Emitter } from '../../../../base/common/event.js';
+import { ISecretStorageService } from '../../common/secrets.js';
+
+export class TestSecretStorageService implements ISecretStorageService {
+	declare readonly _serviceBrand: undefined;
+
+	private readonly _storage = new Map<string, string>();
+	private readonly _onDidChangeSecretEmitter = new Emitter<string>();
+	readonly onDidChangeSecret = this._onDidChangeSecretEmitter.event;
+
+	type = 'in-memory' as const;
+
+	async get(key: string): Promise<string | undefined> {
+		return this._storage.get(key);
+	}
+
+	async set(key: string, value: string): Promise<void> {
+		this._storage.set(key, value);
+		this._onDidChangeSecretEmitter.fire(key);
+	}
+
+	async delete(key: string): Promise<void> {
+		this._storage.delete(key);
+		this._onDidChangeSecretEmitter.fire(key);
+	}
+
+	// Helper method for tests to clear all secrets
+	clear(): void {
+		this._storage.clear();
+	}
+}

--- a/src/vs/workbench/contrib/mcp/common/mcpRegistryInputStorage.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpRegistryInputStorage.ts
@@ -1,0 +1,192 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Sequencer } from '../../../../base/common/async.js';
+import { decodeBase64, encodeBase64, VSBuffer } from '../../../../base/common/buffer.js';
+import { Lazy } from '../../../../base/common/lazy.js';
+import { Disposable } from '../../../../base/common/lifecycle.js';
+import { isEmptyObject } from '../../../../base/common/types.js';
+import { ILogService } from '../../../../platform/log/common/log.js';
+import { ISecretStorageService } from '../../../../platform/secrets/common/secrets.js';
+import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
+
+const MCP_ENCRYPTION_KEY_NAME = 'mcpEncryptionKey';
+const MCP_ENCRYPTION_KEY_ALGORITHM = 'AES-GCM';
+const MCP_ENCRYPTION_KEY_LEN = 256;
+const MCP_ENCRYPTION_IV_LENGTH = 12; // 96 bits
+const MCP_DATA_STORED_VERSION = 1;
+const MCP_DATA_STORED_KEY = 'mcpInputs';
+
+interface IStoredData {
+	version: number;
+	values: Record<string, string>;
+	secrets?: { value: string; iv: string }; // base64, encrypted
+}
+
+interface IHydratedData extends IStoredData {
+	unsealedSecrets?: Record<string, string>;
+}
+
+export class McpRegistryInputStorage extends Disposable {
+	private static secretSequencer = new Sequencer();
+	private readonly _secretsSealerSequencer = new Sequencer();
+
+	private readonly _getEncryptionKey = new Lazy(() => {
+		return McpRegistryInputStorage.secretSequencer.queue(async () => {
+			const existing = await this._secretStorageService.get(MCP_ENCRYPTION_KEY_NAME);
+			if (existing) {
+				try {
+					const parsed: JsonWebKey = JSON.parse(existing);
+					return await crypto.subtle.importKey('jwk', parsed, MCP_ENCRYPTION_KEY_ALGORITHM, false, ['encrypt', 'decrypt']);
+				} catch {
+					// fall through
+				}
+			}
+
+			const key = await crypto.subtle.generateKey(
+				{ name: MCP_ENCRYPTION_KEY_ALGORITHM, length: MCP_ENCRYPTION_KEY_LEN },
+				true,
+				['encrypt', 'decrypt'],
+			);
+
+			const exported = await crypto.subtle.exportKey('jwk', key);
+			await this._secretStorageService.set(MCP_ENCRYPTION_KEY_NAME, JSON.stringify(exported));
+			return key;
+		});
+	});
+
+	private _didChange = false;
+
+	private _record = new Lazy<IHydratedData>(() => {
+		const stored = this._storageService.getObject<IStoredData>(MCP_DATA_STORED_KEY, this._scope);
+		return stored?.version === MCP_DATA_STORED_VERSION ? { ...stored } : { version: MCP_DATA_STORED_VERSION, values: {} };
+	});
+
+
+	constructor(
+		private readonly _scope: StorageScope,
+		_target: StorageTarget,
+		@IStorageService private readonly _storageService: IStorageService,
+		@ISecretStorageService private readonly _secretStorageService: ISecretStorageService,
+		@ILogService private readonly _logService: ILogService,
+	) {
+		super();
+
+		this._register(_storageService.onWillSaveState(() => {
+			if (this._didChange) {
+				this._storageService.store(MCP_DATA_STORED_KEY, {
+					version: MCP_DATA_STORED_VERSION,
+					values: this._record.value.values,
+					secrets: this._record.value.secrets,
+				} satisfies IStoredData, this._scope, _target);
+				this._didChange = false;
+			}
+		}));
+	}
+
+	/** Deletes all collection data from storage. */
+	public clearAll() {
+		this._record.value.values = {};
+		this._record.value.secrets = undefined;
+		this._record.value.unsealedSecrets = undefined;
+		this._didChange = true;
+	}
+
+	/** Delete a single collection data from the storage. */
+	public async clear(inputKey: string) {
+		const secrets = await this._unsealSecrets();
+		delete this._record.value.values[inputKey];
+		this._didChange = true;
+
+		if (secrets.hasOwnProperty(inputKey)) {
+			delete secrets[inputKey];
+			await this._sealSecrets();
+		}
+	}
+
+	/** Gets a mapping of saved input data. */
+	public async getMap() {
+		const secrets = await this._unsealSecrets();
+		return { ...this._record.value.values, ...secrets };
+	}
+
+	/** Updates the input data mapping. */
+	public async setPlainText(values: Record<string, string>) {
+		Object.assign(this._record.value.values, values);
+		this._didChange = true;
+	}
+
+	/** Updates the input secrets mapping. */
+	public async setSecrets(values: Record<string, string>) {
+		const unsealed = await this._unsealSecrets();
+		Object.assign(unsealed, values);
+		await this._sealSecrets();
+	}
+
+	private async _sealSecrets() {
+		return this._secretsSealerSequencer.queue(async () => {
+			if (!this._record.value.unsealedSecrets || isEmptyObject(this._record.value.unsealedSecrets)) {
+				this._record.value.secrets = undefined;
+				return;
+			}
+
+			if (!this._record.value.secrets) {
+				const iv = crypto.getRandomValues(new Uint8Array(MCP_ENCRYPTION_IV_LENGTH));
+				this._record.value.secrets = {
+					value: '',
+					iv: encodeBase64(VSBuffer.wrap(iv)),
+				};
+			}
+
+			const toSeal = JSON.stringify(this._record.value.unsealedSecrets);
+			const iv = decodeBase64(this._record.value.secrets.iv);
+			const key = await this._getEncryptionKey.value;
+			const encrypted = await crypto.subtle.encrypt(
+				{ name: MCP_ENCRYPTION_KEY_ALGORITHM, iv: iv.buffer },
+				key,
+				new TextEncoder().encode(toSeal).buffer,
+			);
+
+			const enc = encodeBase64(VSBuffer.wrap(new Uint8Array(encrypted)));
+			if (this._record.value.secrets.value === enc) {
+				return;
+			}
+
+			this._record.value.secrets.value = enc;
+			this._didChange = true;
+		});
+	}
+
+	private async _unsealSecrets(): Promise<Record<string, string>> {
+		if (!this._record.value.secrets) {
+			return this._record.value.unsealedSecrets ??= {};
+		}
+
+		if (this._record.value.unsealedSecrets) {
+			return this._record.value.unsealedSecrets;
+		}
+
+		try {
+			const key = await this._getEncryptionKey.value;
+			const iv = decodeBase64(this._record.value.secrets.iv);
+			const encrypted = decodeBase64(this._record.value.secrets.value);
+
+			const decrypted = await crypto.subtle.decrypt(
+				{ name: MCP_ENCRYPTION_KEY_ALGORITHM, iv: iv.buffer },
+				key,
+				encrypted.buffer,
+			);
+
+			const unsealedSecrets = JSON.parse(new TextDecoder().decode(decrypted));
+			this._record.value.unsealedSecrets = unsealedSecrets;
+			return unsealedSecrets;
+		} catch (e) {
+			this._logService.warn('Error unsealing MCP secrets', e);
+			this._record.value.secrets = undefined;
+		}
+
+		return {};
+	}
+}

--- a/src/vs/workbench/contrib/mcp/common/mcpRegistryTypes.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpRegistryTypes.ts
@@ -35,8 +35,6 @@ export interface IMcpRegistry {
 	registerDelegate(delegate: IMcpHostDelegate): IDisposable;
 	registerCollection(collection: McpCollectionDefinition): IDisposable;
 
-	/** Gets whether there are saved inputs used to resolve the connection */
-	hasSavedInputs(collection: McpCollectionDefinition, definition: McpServerDefinition): boolean;
 	/** Resets any saved inputs for the connection. */
 	clearSavedInputs(collection: McpCollectionDefinition, definition: McpServerDefinition): void;
 	/** Createse a connection for the collection and definition. */

--- a/src/vs/workbench/contrib/mcp/test/common/mcpRegistry.test.ts
+++ b/src/vs/workbench/contrib/mcp/test/common/mcpRegistry.test.ts
@@ -13,7 +13,9 @@ import { ConfigurationTarget } from '../../../../../platform/configuration/commo
 import { ServiceCollection } from '../../../../../platform/instantiation/common/serviceCollection.js';
 import { TestInstantiationService } from '../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
 import { ILoggerService } from '../../../../../platform/log/common/log.js';
-import { IStorageService, StorageScope, StorageTarget } from '../../../../../platform/storage/common/storage.js';
+import { ISecretStorageService } from '../../../../../platform/secrets/common/secrets.js';
+import { TestSecretStorageService } from '../../../../../platform/secrets/test/common/testSecretStorageService.js';
+import { IStorageService, StorageScope } from '../../../../../platform/storage/common/storage.js';
 import { IConfigurationResolverService } from '../../../../services/configurationResolver/common/configurationResolver.js';
 import { IOutputService } from '../../../../services/output/common/output.js';
 import { TestLoggerService, TestStorageService } from '../../../../test/common/workbenchTestServices.js';
@@ -22,8 +24,6 @@ import { IMcpHostDelegate, IMcpMessageTransport } from '../../common/mcpRegistry
 import { McpServerConnection } from '../../common/mcpServerConnection.js';
 import { McpCollectionDefinition, McpServerDefinition, McpServerTransportType } from '../../common/mcpTypes.js';
 import { TestMcpMessageTransport } from './mcpRegistryTypes.js';
-import { ISecretStorageService } from '../../../../../platform/secrets/common/secrets.js';
-import { TestSecretStorageService } from '../../../../../platform/secrets/test/common/testSecretStorageService.js';
 
 class TestConfigurationResolverService implements Partial<IConfigurationResolverService> {
 	declare readonly _serviceBrand: undefined;

--- a/src/vs/workbench/contrib/mcp/test/common/mcpRegistry.test.ts
+++ b/src/vs/workbench/contrib/mcp/test/common/mcpRegistry.test.ts
@@ -22,6 +22,8 @@ import { IMcpHostDelegate, IMcpMessageTransport } from '../../common/mcpRegistry
 import { McpServerConnection } from '../../common/mcpServerConnection.js';
 import { McpCollectionDefinition, McpServerDefinition, McpServerTransportType } from '../../common/mcpTypes.js';
 import { TestMcpMessageTransport } from './mcpRegistryTypes.js';
+import { ISecretStorageService } from '../../../../../platform/secrets/common/secrets.js';
+import { TestSecretStorageService } from '../../../../../platform/secrets/test/common/testSecretStorageService.js';
 
 class TestConfigurationResolverService implements Partial<IConfigurationResolverService> {
 	declare readonly _serviceBrand: undefined;
@@ -131,6 +133,7 @@ suite('Workbench - MCP - Registry', () => {
 		const services = new ServiceCollection(
 			[IConfigurationResolverService, testConfigResolverService],
 			[IStorageService, testStorageService],
+			[ISecretStorageService, new TestSecretStorageService()],
 			[ILoggerService, store.add(new TestLoggerService())],
 			[IOutputService, upcast({ showChannel: () => { } })],
 		);
@@ -183,27 +186,6 @@ suite('Workbench - MCP - Registry', () => {
 
 		disposable.dispose();
 		assert.strictEqual(registry.delegates.length, 0);
-	});
-
-	test('hasSavedInputs returns false when no inputs are saved', () => {
-		assert.strictEqual(registry.hasSavedInputs(testCollection, baseDefinition), false);
-	});
-
-	test('clearSavedInputs removes stored inputs', () => {
-		const definition: McpServerDefinition = {
-			...baseDefinition,
-			variableReplacement: {
-				section: 'mcp'
-			}
-		};
-
-		// Save some mock inputs
-		const key = `mcpConfig.${testCollection.id}.${definition.id}`;
-		testStorageService.store(key, JSON.stringify({ 'input:foo': 'bar' }), StorageScope.APPLICATION, StorageTarget.MACHINE);
-
-		assert.strictEqual(registry.hasSavedInputs(testCollection, definition), true);
-		registry.clearSavedInputs(testCollection, definition);
-		assert.strictEqual(registry.hasSavedInputs(testCollection, definition), false);
 	});
 
 	test('resolveConnection creates connection with resolved variables and memorizes them', async () => {

--- a/src/vs/workbench/contrib/mcp/test/common/mcpRegistryInputStorage.test.ts
+++ b/src/vs/workbench/contrib/mcp/test/common/mcpRegistryInputStorage.test.ts
@@ -1,0 +1,178 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { ILogService, NullLogService } from '../../../../../platform/log/common/log.js';
+import { TestSecretStorageService } from '../../../../../platform/secrets/test/common/testSecretStorageService.js';
+import { StorageScope, StorageTarget } from '../../../../../platform/storage/common/storage.js';
+import { TestStorageService } from '../../../../test/common/workbenchTestServices.js';
+import { McpRegistryInputStorage } from '../../common/mcpRegistryInputStorage.js';
+
+suite('Workbench - MCP - RegistryInputStorage', () => {
+	const store = ensureNoDisposablesAreLeakedInTestSuite();
+
+	let testStorageService: TestStorageService;
+	let testSecretStorageService: TestSecretStorageService;
+	let testLogService: ILogService;
+	let mcpInputStorage: McpRegistryInputStorage;
+
+	setup(() => {
+		testStorageService = store.add(new TestStorageService());
+		testSecretStorageService = new TestSecretStorageService();
+		testLogService = store.add(new NullLogService());
+
+		// Create the input storage with APPLICATION scope
+		mcpInputStorage = store.add(new McpRegistryInputStorage(
+			StorageScope.APPLICATION,
+			StorageTarget.MACHINE,
+			testStorageService,
+			testSecretStorageService,
+			testLogService
+		));
+	});
+
+	test('setPlainText stores values that can be retrieved with getMap', async () => {
+		const values = {
+			'key1': 'value1',
+			'key2': 'value2'
+		};
+
+		await mcpInputStorage.setPlainText(values);
+		const result = await mcpInputStorage.getMap();
+
+		assert.strictEqual(result.key1, 'value1');
+		assert.strictEqual(result.key2, 'value2');
+	});
+
+	test('setSecrets stores encrypted values that can be retrieved with getMap', async () => {
+		const secrets = {
+			'secretKey1': 'secretValue1',
+			'secretKey2': 'secretValue2'
+		};
+
+		await mcpInputStorage.setSecrets(secrets);
+		const result = await mcpInputStorage.getMap();
+
+		assert.strictEqual(result.secretKey1, 'secretValue1');
+		assert.strictEqual(result.secretKey2, 'secretValue2');
+	});
+
+	test('getMap returns combined plain text and secret values', async () => {
+		await mcpInputStorage.setPlainText({
+			'plainKey': 'plainValue'
+		});
+
+		await mcpInputStorage.setSecrets({
+			'secretKey': 'secretValue'
+		});
+
+		const result = await mcpInputStorage.getMap();
+
+		assert.strictEqual(result.plainKey, 'plainValue');
+		assert.strictEqual(result.secretKey, 'secretValue');
+	});
+
+	test('clear removes specific values', async () => {
+		await mcpInputStorage.setPlainText({
+			'key1': 'value1',
+			'key2': 'value2'
+		});
+
+		await mcpInputStorage.setSecrets({
+			'secretKey1': 'secretValue1',
+			'secretKey2': 'secretValue2'
+		});
+
+		// Clear one plain and one secret value
+		await mcpInputStorage.clear('key1');
+		await mcpInputStorage.clear('secretKey1');
+
+		const result = await mcpInputStorage.getMap();
+
+		assert.strictEqual(result.key1, undefined);
+		assert.strictEqual(result.key2, 'value2');
+		assert.strictEqual(result.secretKey1, undefined);
+		assert.strictEqual(result.secretKey2, 'secretValue2');
+	});
+
+	test('clearAll removes all values', async () => {
+		await mcpInputStorage.setPlainText({
+			'key1': 'value1'
+		});
+
+		await mcpInputStorage.setSecrets({
+			'secretKey1': 'secretValue1'
+		});
+
+		mcpInputStorage.clearAll();
+
+		const result = await mcpInputStorage.getMap();
+
+		assert.deepStrictEqual(result, {});
+	});
+
+	test('updates to plain text values overwrite existing values', async () => {
+		await mcpInputStorage.setPlainText({
+			'key1': 'value1',
+			'key2': 'value2'
+		});
+
+		await mcpInputStorage.setPlainText({
+			'key1': 'updatedValue1'
+		});
+
+		const result = await mcpInputStorage.getMap();
+
+		assert.strictEqual(result.key1, 'updatedValue1');
+		assert.strictEqual(result.key2, 'value2');
+	});
+
+	test('updates to secret values overwrite existing values', async () => {
+		await mcpInputStorage.setSecrets({
+			'secretKey1': 'secretValue1',
+			'secretKey2': 'secretValue2'
+		});
+
+		await mcpInputStorage.setSecrets({
+			'secretKey1': 'updatedSecretValue1'
+		});
+
+		const result = await mcpInputStorage.getMap();
+
+		assert.strictEqual(result.secretKey1, 'updatedSecretValue1');
+		assert.strictEqual(result.secretKey2, 'secretValue2');
+	});
+
+	test('storage persists values across instances', async () => {
+		// Set values on first instance
+		await mcpInputStorage.setPlainText({
+			'key1': 'value1'
+		});
+
+		await mcpInputStorage.setSecrets({
+			'secretKey1': 'secretValue1'
+		});
+
+		await testStorageService.flush();
+
+		// Create a second instance that should have access to the same storage
+		const secondInstance = store.add(new McpRegistryInputStorage(
+			StorageScope.APPLICATION,
+			StorageTarget.MACHINE,
+			testStorageService,
+			testSecretStorageService,
+			testLogService
+		));
+
+		const result = await secondInstance.getMap();
+
+		assert.strictEqual(result.key1, 'value1');
+		assert.strictEqual(result.secretKey1, 'secretValue1');
+
+		assert.ok(!testStorageService.get('mcpInputs', StorageScope.APPLICATION)?.includes('secretValue1'));
+	});
+});
+


### PR DESCRIPTION
This just treats everything as a secret for now, I want to do some work on the IConfigurationResolverService so we can differentiate password versus non-password input, among other work

Fixes #243226

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
