### PR TITLE
Fix line comment action for makefiles (Fixes #234464)

### DIFF
--- a/extensions/make/language-configuration.json
+++ b/extensions/make/language-configuration.json
@@ -1,7 +1,9 @@
 {
 	"comments": {
-		"lineComment": "#",
-		"lineCommentTokenFirstColumn": true
+		"lineComment": {
+			"comment": "#",
+			"noIndent": true
+		}
 	},
 	"brackets": [
 		[

--- a/extensions/make/language-configuration.json
+++ b/extensions/make/language-configuration.json
@@ -1,6 +1,7 @@
 {
 	"comments": {
-		"lineComment": "#"
+		"lineComment": "#",
+		"lineCommentTokenColumn": 0
 	},
 	"brackets": [
 		[

--- a/extensions/make/language-configuration.json
+++ b/extensions/make/language-configuration.json
@@ -1,7 +1,7 @@
 {
 	"comments": {
 		"lineComment": "#",
-		"lineCommentTokenColumn": 0
+		"lineCommentTokenFirstColumn": true
 	},
 	"brackets": [
 		[

--- a/src/vs/editor/common/languages/languageConfiguration.ts
+++ b/src/vs/editor/common/languages/languageConfiguration.ts
@@ -18,7 +18,7 @@ export interface CommentRule {
 	/**
 	 * Where on the line the token should be placed.
 	 */
-	lineCommentTokenColumn?: number | null;
+	lineCommentTokenFirstColumn?: boolean | null;
 	/**
 	 * The block comment character pair, like `/* block comment *&#47;`
 	 */

--- a/src/vs/editor/common/languages/languageConfiguration.ts
+++ b/src/vs/editor/common/languages/languageConfiguration.ts
@@ -16,6 +16,10 @@ export interface CommentRule {
 	 */
 	lineComment?: string | null;
 	/**
+	 * Where on the line the token should be placed.
+	 */
+	lineCommentTokenColumn?: number | null;
+	/**
 	 * The block comment character pair, like `/* block comment *&#47;`
 	 */
 	blockComment?: CharacterPair | null;

--- a/src/vs/editor/common/languages/languageConfiguration.ts
+++ b/src/vs/editor/common/languages/languageConfiguration.ts
@@ -12,7 +12,7 @@ import { ScopedLineTokens } from './supports.js';
  */
 export interface LineCommentConfig {
 	/**
-	 * The line comment token, like `// this is a comment`
+	 * The line comment token, like `//`
 	 */
 	comment: string;
 	/**

--- a/src/vs/editor/common/languages/languageConfiguration.ts
+++ b/src/vs/editor/common/languages/languageConfiguration.ts
@@ -8,17 +8,29 @@ import { StandardTokenType } from '../encodedTokenAttributes.js';
 import { ScopedLineTokens } from './supports.js';
 
 /**
+ * Configuration for line comments.
+ */
+export interface LineCommentConfig {
+	/**
+	 * The line comment token, like `// this is a comment`
+	 */
+	comment: string;
+	/**
+	 * Whether the comment token should not be indented and placed at the first column.
+	 * Defaults to false.
+	 */
+	noIndent?: boolean;
+}
+
+/**
  * Describes how comments for a language work.
  */
 export interface CommentRule {
 	/**
-	 * The line comment token, like `// this is a comment`
+	 * The line comment token, like `// this is a comment`.
+	 * Can be a string or an object with comment and optional noIndent properties.
 	 */
-	lineComment?: string | null;
-	/**
-	 * Where on the line the token should be placed.
-	 */
-	lineCommentTokenFirstColumn?: boolean | null;
+	lineComment?: string | LineCommentConfig | null;
 	/**
 	 * The block comment character pair, like `/* block comment *&#47;`
 	 */

--- a/src/vs/editor/common/languages/languageConfigurationRegistry.ts
+++ b/src/vs/editor/common/languages/languageConfigurationRegistry.ts
@@ -460,11 +460,8 @@ export class ResolvedLanguageConfiguration {
 			if (typeof commentRule.lineComment === 'string') {
 				comments.lineCommentToken = commentRule.lineComment;
 			} else {
-				// LineCommentConfig object
 				comments.lineCommentToken = commentRule.lineComment.comment;
-				if (commentRule.lineComment.noIndent !== undefined) {
-					comments.lineCommentNoIndent = commentRule.lineComment.noIndent;
-				}
+				comments.lineCommentNoIndent = commentRule.lineComment.noIndent;
 			}
 		}
 		if (commentRule.blockComment) {

--- a/src/vs/editor/common/languages/languageConfigurationRegistry.ts
+++ b/src/vs/editor/common/languages/languageConfigurationRegistry.ts
@@ -27,7 +27,7 @@ import { LanguageBracketsConfiguration } from './supports/languageBracketsConfig
  */
 export interface ICommentsConfiguration {
 	lineCommentToken?: string;
-	lineCommentTokenColumn?: number;
+	lineCommentTokenFirstColumn?: boolean;
 	blockCommentStartToken?: string;
 	blockCommentEndToken?: string;
 }
@@ -464,8 +464,8 @@ export class ResolvedLanguageConfiguration {
 			comments.blockCommentStartToken = blockStart;
 			comments.blockCommentEndToken = blockEnd;
 		}
-		if (typeof commentRule.lineCommentTokenColumn !== 'undefined' && commentRule.lineCommentTokenColumn !== null) {
-			comments.lineCommentTokenColumn = commentRule.lineCommentTokenColumn;
+		if (typeof commentRule.lineCommentTokenFirstColumn !== 'undefined' && commentRule.lineCommentTokenFirstColumn !== null) {
+			comments.lineCommentTokenFirstColumn = commentRule.lineCommentTokenFirstColumn;
 		}
 
 		return comments;

--- a/src/vs/editor/common/languages/languageConfigurationRegistry.ts
+++ b/src/vs/editor/common/languages/languageConfigurationRegistry.ts
@@ -27,7 +27,7 @@ import { LanguageBracketsConfiguration } from './supports/languageBracketsConfig
  */
 export interface ICommentsConfiguration {
 	lineCommentToken?: string;
-	lineCommentTokenFirstColumn?: boolean;
+	lineCommentNoIndent?: boolean;
 	blockCommentStartToken?: string;
 	blockCommentEndToken?: string;
 }
@@ -457,15 +457,20 @@ export class ResolvedLanguageConfiguration {
 		const comments: ICommentsConfiguration = {};
 
 		if (commentRule.lineComment) {
-			comments.lineCommentToken = commentRule.lineComment;
+			if (typeof commentRule.lineComment === 'string') {
+				comments.lineCommentToken = commentRule.lineComment;
+			} else {
+				// LineCommentConfig object
+				comments.lineCommentToken = commentRule.lineComment.comment;
+				if (commentRule.lineComment.noIndent !== undefined) {
+					comments.lineCommentNoIndent = commentRule.lineComment.noIndent;
+				}
+			}
 		}
 		if (commentRule.blockComment) {
 			const [blockStart, blockEnd] = commentRule.blockComment;
 			comments.blockCommentStartToken = blockStart;
 			comments.blockCommentEndToken = blockEnd;
-		}
-		if (typeof commentRule.lineCommentTokenFirstColumn !== 'undefined' && commentRule.lineCommentTokenFirstColumn !== null) {
-			comments.lineCommentTokenFirstColumn = commentRule.lineCommentTokenFirstColumn;
 		}
 
 		return comments;

--- a/src/vs/editor/common/languages/languageConfigurationRegistry.ts
+++ b/src/vs/editor/common/languages/languageConfigurationRegistry.ts
@@ -27,6 +27,7 @@ import { LanguageBracketsConfiguration } from './supports/languageBracketsConfig
  */
 export interface ICommentsConfiguration {
 	lineCommentToken?: string;
+	lineCommentTokenColumn?: number;
 	blockCommentStartToken?: string;
 	blockCommentEndToken?: string;
 }
@@ -462,6 +463,9 @@ export class ResolvedLanguageConfiguration {
 			const [blockStart, blockEnd] = commentRule.blockComment;
 			comments.blockCommentStartToken = blockStart;
 			comments.blockCommentEndToken = blockEnd;
+		}
+		if (typeof commentRule.lineCommentTokenColumn !== 'undefined' && commentRule.lineCommentTokenColumn !== null) {
+			comments.lineCommentTokenColumn = commentRule.lineCommentTokenColumn;
 		}
 
 		return comments;

--- a/src/vs/editor/contrib/comment/browser/lineCommentCommand.ts
+++ b/src/vs/editor/contrib/comment/browser/lineCommentCommand.ts
@@ -154,7 +154,7 @@ export class LineCommentCommand implements ICommand {
 			lineData.ignore = false;
 			lineData.commentStrOffset = lineCommentTokenFirstColumn ? 0 : lineContentStartOffset;
 
-			if (shouldRemoveComments && !BlockCommentCommand._haystackHasNeedleAtOffset(lineContent, lineData.commentStr, lineContentStartOffset)) {
+			if (shouldRemoveComments && !BlockCommentCommand._haystackHasNeedleAtOffset(lineContent, lineData.commentStr, lineCommentTokenFirstColumn ? 0 : lineContentStartOffset)) {
 				if (type === Type.Toggle) {
 					// Every line so far has been a line comment, but this one is not
 					shouldRemoveComments = false;

--- a/src/vs/editor/contrib/comment/browser/lineCommentCommand.ts
+++ b/src/vs/editor/contrib/comment/browser/lineCommentCommand.ts
@@ -167,7 +167,7 @@ export class LineCommentCommand implements ICommand {
 
 			if (shouldRemoveComments && insertSpace) {
 				// Remove a following space if present
-				const commentStrEndOffset = lineCommentNoIndent ? 0 : lineContentStartOffset + lineData.commentStrLength;
+				const commentStrEndOffset = lineContentStartOffset + lineData.commentStrLength;
 				if (commentStrEndOffset < lineContent.length && lineContent.charCodeAt(commentStrEndOffset) === CharCode.Space) {
 					lineData.commentStrLength += 1;
 				}

--- a/src/vs/editor/contrib/comment/browser/lineCommentCommand.ts
+++ b/src/vs/editor/contrib/comment/browser/lineCommentCommand.ts
@@ -115,10 +115,10 @@ export class LineCommentCommand implements ICommand {
 	public static _analyzeLines(type: Type, insertSpace: boolean, model: ISimpleModel, lines: ILinePreflightData[], startLineNumber: number, ignoreEmptyLines: boolean, ignoreFirstLine: boolean, languageConfigurationService: ILanguageConfigurationService, languageId: string): IPreflightData {
 		let onlyWhitespaceLines = true;
 
-		let lineCommentTokenFirstColumn = false;
+		let lineCommentNoIndent = false;
 		const config = languageConfigurationService.getLanguageConfiguration(languageId).comments;
-		if (config && config.lineCommentTokenFirstColumn !== undefined) {
-			lineCommentTokenFirstColumn = config.lineCommentTokenFirstColumn;
+		if (config && config.lineCommentNoIndent !== undefined) {
+			lineCommentNoIndent = config.lineCommentNoIndent;
 		}
 
 		let shouldRemoveComments: boolean;
@@ -146,15 +146,15 @@ export class LineCommentCommand implements ICommand {
 			if (lineContentStartOffset === -1) {
 				// Empty or whitespace only line
 				lineData.ignore = ignoreEmptyLines;
-				lineData.commentStrOffset = lineCommentTokenFirstColumn ? 0 : lineContent.length;
+				lineData.commentStrOffset = lineCommentNoIndent ? 0 : lineContent.length;
 				continue;
 			}
 
 			onlyWhitespaceLines = false;
 			lineData.ignore = false;
-			lineData.commentStrOffset = lineCommentTokenFirstColumn ? 0 : lineContentStartOffset;
+			lineData.commentStrOffset = lineCommentNoIndent ? 0 : lineContentStartOffset;
 
-			if (shouldRemoveComments && !BlockCommentCommand._haystackHasNeedleAtOffset(lineContent, lineData.commentStr, lineCommentTokenFirstColumn ? 0 : lineContentStartOffset)) {
+			if (shouldRemoveComments && !BlockCommentCommand._haystackHasNeedleAtOffset(lineContent, lineData.commentStr, lineCommentNoIndent ? 0 : lineContentStartOffset)) {
 				if (type === Type.Toggle) {
 					// Every line so far has been a line comment, but this one is not
 					shouldRemoveComments = false;
@@ -167,7 +167,7 @@ export class LineCommentCommand implements ICommand {
 
 			if (shouldRemoveComments && insertSpace) {
 				// Remove a following space if present
-				const commentStrEndOffset = lineCommentTokenFirstColumn ? 0 : lineContentStartOffset + lineData.commentStrLength;
+				const commentStrEndOffset = lineCommentNoIndent ? 0 : lineContentStartOffset + lineData.commentStrLength;
 				if (commentStrEndOffset < lineContent.length && lineContent.charCodeAt(commentStrEndOffset) === CharCode.Space) {
 					lineData.commentStrLength += 1;
 				}

--- a/src/vs/editor/contrib/comment/browser/lineCommentCommand.ts
+++ b/src/vs/editor/contrib/comment/browser/lineCommentCommand.ts
@@ -115,10 +115,10 @@ export class LineCommentCommand implements ICommand {
 	public static _analyzeLines(type: Type, insertSpace: boolean, model: ISimpleModel, lines: ILinePreflightData[], startLineNumber: number, ignoreEmptyLines: boolean, ignoreFirstLine: boolean, languageConfigurationService: ILanguageConfigurationService, languageId: string): IPreflightData {
 		let onlyWhitespaceLines = true;
 
-		let lineCommentTokenColumn = undefined;
+		let lineCommentTokenFirstColumn = false;
 		const config = languageConfigurationService.getLanguageConfiguration(languageId).comments;
-		if (config) {
-			lineCommentTokenColumn = config.lineCommentTokenColumn;
+		if (config && config.lineCommentTokenFirstColumn !== undefined) {
+			lineCommentTokenFirstColumn = config.lineCommentTokenFirstColumn;
 		}
 
 		let shouldRemoveComments: boolean;
@@ -146,13 +146,13 @@ export class LineCommentCommand implements ICommand {
 			if (lineContentStartOffset === -1) {
 				// Empty or whitespace only line
 				lineData.ignore = ignoreEmptyLines;
-				lineData.commentStrOffset = (lineCommentTokenColumn !== undefined) ? lineCommentTokenColumn : lineContent.length;
+				lineData.commentStrOffset = lineCommentTokenFirstColumn ? 0 : lineContent.length;
 				continue;
 			}
 
 			onlyWhitespaceLines = false;
 			lineData.ignore = false;
-			lineData.commentStrOffset = (lineCommentTokenColumn !== undefined) ? lineCommentTokenColumn : lineContentStartOffset;
+			lineData.commentStrOffset = lineCommentTokenFirstColumn ? 0 : lineContentStartOffset;
 
 			if (shouldRemoveComments && !BlockCommentCommand._haystackHasNeedleAtOffset(lineContent, lineData.commentStr, lineContentStartOffset)) {
 				if (type === Type.Toggle) {

--- a/src/vs/editor/contrib/comment/browser/lineCommentCommand.ts
+++ b/src/vs/editor/contrib/comment/browser/lineCommentCommand.ts
@@ -167,7 +167,7 @@ export class LineCommentCommand implements ICommand {
 
 			if (shouldRemoveComments && insertSpace) {
 				// Remove a following space if present
-				const commentStrEndOffset = lineContentStartOffset + lineData.commentStrLength;
+				const commentStrEndOffset = lineCommentTokenFirstColumn ? 0 : lineContentStartOffset + lineData.commentStrLength;
 				if (commentStrEndOffset < lineContent.length && lineContent.charCodeAt(commentStrEndOffset) === CharCode.Space) {
 					lineData.commentStrLength += 1;
 				}

--- a/src/vs/editor/contrib/comment/browser/lineCommentCommand.ts
+++ b/src/vs/editor/contrib/comment/browser/lineCommentCommand.ts
@@ -115,11 +115,8 @@ export class LineCommentCommand implements ICommand {
 	public static _analyzeLines(type: Type, insertSpace: boolean, model: ISimpleModel, lines: ILinePreflightData[], startLineNumber: number, ignoreEmptyLines: boolean, ignoreFirstLine: boolean, languageConfigurationService: ILanguageConfigurationService, languageId: string): IPreflightData {
 		let onlyWhitespaceLines = true;
 
-		let lineCommentNoIndent = false;
 		const config = languageConfigurationService.getLanguageConfiguration(languageId).comments;
-		if (config && config.lineCommentNoIndent !== undefined) {
-			lineCommentNoIndent = config.lineCommentNoIndent;
-		}
+		const lineCommentNoIndent = config?.lineCommentNoIndent ?? false;
 
 		let shouldRemoveComments: boolean;
 		if (type === Type.Toggle) {
@@ -151,10 +148,11 @@ export class LineCommentCommand implements ICommand {
 			}
 
 			onlyWhitespaceLines = false;
+			const offset = lineCommentNoIndent ? 0 : lineContentStartOffset;
 			lineData.ignore = false;
-			lineData.commentStrOffset = lineCommentNoIndent ? 0 : lineContentStartOffset;
+			lineData.commentStrOffset = offset;
 
-			if (shouldRemoveComments && !BlockCommentCommand._haystackHasNeedleAtOffset(lineContent, lineData.commentStr, lineCommentNoIndent ? 0 : lineContentStartOffset)) {
+			if (shouldRemoveComments && !BlockCommentCommand._haystackHasNeedleAtOffset(lineContent, lineData.commentStr, offset)) {
 				if (type === Type.Toggle) {
 					// Every line so far has been a line comment, but this one is not
 					shouldRemoveComments = false;

--- a/src/vs/editor/contrib/comment/test/browser/lineCommentCommand.test.ts
+++ b/src/vs/editor/contrib/comment/test/browser/lineCommentCommand.test.ts
@@ -49,7 +49,7 @@ suite('Editor Contrib - Line Comment Command', () => {
 	);
 
 	const testLineCommentCommandTokenFirstColumn = createTestCommandHelper(
-		{ lineComment: '!@#', lineCommentTokenFirstColumn: true, blockComment: ['<!@#', '#@!>'] },
+		{ lineComment: { comment: '!@#', noIndent: true }, blockComment: ['<!@#', '#@!>'] },
 		(accessor, sel) => new LineCommentCommand(accessor.get(ILanguageConfigurationService), sel, 4, Type.Toggle, true, true)
 	);
 

--- a/src/vs/editor/contrib/comment/test/browser/lineCommentCommand.test.ts
+++ b/src/vs/editor/contrib/comment/test/browser/lineCommentCommand.test.ts
@@ -48,6 +48,11 @@ suite('Editor Contrib - Line Comment Command', () => {
 		(accessor, sel) => new LineCommentCommand(accessor.get(ILanguageConfigurationService), sel, 4, Type.ForceAdd, true, true)
 	);
 
+	const testLineCommentCommandColumnFixed = createTestCommandHelper(
+		{ lineComment: '!@#', lineCommentTokenColumn: 0, blockComment: ['<!@#', '#@!>'] },
+		(accessor, sel) => new LineCommentCommand(accessor.get(ILanguageConfigurationService), sel, 4, Type.Toggle, true, true)
+	);
+
 	test('comment single line', function () {
 		testLineCommentCommand(
 			[
@@ -81,6 +86,21 @@ suite('Editor Contrib - Line Comment Command', () => {
 		);
 	});
 
+	test('comment with token column fixed', function () {
+		testLineCommentCommandColumnFixed(
+			[
+				'some text',
+				'\tsome more text'
+			],
+			new Selection(2, 1, 2, 1),
+			[
+				'some text',
+				'!@# \tsome more text'
+			],
+			new Selection(2, 5, 2, 5)
+		);
+	});
+
 	function createSimpleModel(lines: string[]): ISimpleModel {
 		return {
 			getLineContent: (lineNumber: number) => {
@@ -110,7 +130,7 @@ suite('Editor Contrib - Line Comment Command', () => {
 			'    ',
 			'    c',
 			'\t\td'
-		]), createBasicLinePreflightData(['//', 'rem', '!@#', '!@#']), 1, true, false, disposable.add(new TestLanguageConfigurationService()));
+		]), createBasicLinePreflightData(['//', 'rem', '!@#', '!@#']), 1, true, false, disposable.add(new TestLanguageConfigurationService()), 'plaintext');
 		if (!r.supported) {
 			throw new Error(`unexpected`);
 		}
@@ -141,7 +161,7 @@ suite('Editor Contrib - Line Comment Command', () => {
 			'    rem ',
 			'    !@# c',
 			'\t\t!@#d'
-		]), createBasicLinePreflightData(['//', 'rem', '!@#', '!@#']), 1, true, false, disposable.add(new TestLanguageConfigurationService()));
+		]), createBasicLinePreflightData(['//', 'rem', '!@#', '!@#']), 1, true, false, disposable.add(new TestLanguageConfigurationService()), 'plaintext');
 		if (!r.supported) {
 			throw new Error(`unexpected`);
 		}
@@ -165,81 +185,6 @@ suite('Editor Contrib - Line Comment Command', () => {
 		assert.strictEqual(r.lines[1].commentStrOffset, 4);
 		assert.strictEqual(r.lines[2].commentStrOffset, 4);
 		assert.strictEqual(r.lines[3].commentStrOffset, 2);
-
-		// Fills in `commentStrLength`
-		assert.strictEqual(r.lines[0].commentStrLength, 2);
-		assert.strictEqual(r.lines[1].commentStrLength, 4);
-		assert.strictEqual(r.lines[2].commentStrLength, 4);
-		assert.strictEqual(r.lines[3].commentStrLength, 3);
-
-		disposable.dispose();
-	});
-
-	// Makefile Test. Comment tokens should always be placed on the first column.
-	test('_analyzeLines for Makefiles', () => {
-		const disposable = new DisposableStore();
-		let r: IPreflightData;
-
-		r = LineCommentCommand._analyzeLines(Type.Toggle, true, createSimpleModel([
-			'\t\t',
-			'    ',
-			'    c',
-			'\t\td'
-		]), createBasicLinePreflightData(['//', 'rem', '!@#', '!@#']), 1, true, false, disposable.add(new TestLanguageConfigurationService()), 'makefile');
-		if (!r.supported) {
-			throw new Error(`unexpected`);
-		}
-
-		assert.strictEqual(r.shouldRemoveComments, false);
-
-		// Does not change `commentStr`
-		assert.strictEqual(r.lines[0].commentStr, '//');
-		assert.strictEqual(r.lines[1].commentStr, 'rem');
-		assert.strictEqual(r.lines[2].commentStr, '!@#');
-		assert.strictEqual(r.lines[3].commentStr, '!@#');
-
-		// Fills in `isWhitespace`
-		assert.strictEqual(r.lines[0].ignore, true);
-		assert.strictEqual(r.lines[1].ignore, true);
-		assert.strictEqual(r.lines[2].ignore, false);
-		assert.strictEqual(r.lines[3].ignore, false);
-
-		// Fills in `commentStrOffset` (all zeros because it's a makefile)
-		assert.strictEqual(r.lines[0].commentStrOffset, 0);
-		assert.strictEqual(r.lines[1].commentStrOffset, 0);
-		assert.strictEqual(r.lines[2].commentStrOffset, 0);
-		assert.strictEqual(r.lines[3].commentStrOffset, 0);
-
-
-		r = LineCommentCommand._analyzeLines(Type.Toggle, true, createSimpleModel([
-			'\t\t',
-			'    rem ',
-			'    !@# c',
-			'\t\t!@#d'
-		]), createBasicLinePreflightData(['//', 'rem', '!@#', '!@#']), 1, true, false, disposable.add(new TestLanguageConfigurationService()), 'makefile');
-		if (!r.supported) {
-			throw new Error(`unexpected`);
-		}
-
-		assert.strictEqual(r.shouldRemoveComments, true);
-
-		// Does not change `commentStr`
-		assert.strictEqual(r.lines[0].commentStr, '//');
-		assert.strictEqual(r.lines[1].commentStr, 'rem');
-		assert.strictEqual(r.lines[2].commentStr, '!@#');
-		assert.strictEqual(r.lines[3].commentStr, '!@#');
-
-		// Fills in `isWhitespace`
-		assert.strictEqual(r.lines[0].ignore, true);
-		assert.strictEqual(r.lines[1].ignore, false);
-		assert.strictEqual(r.lines[2].ignore, false);
-		assert.strictEqual(r.lines[3].ignore, false);
-
-		// Fills in `commentStrOffset`
-		assert.strictEqual(r.lines[0].commentStrOffset, 0);
-		assert.strictEqual(r.lines[1].commentStrOffset, 0);
-		assert.strictEqual(r.lines[2].commentStrOffset, 0);
-		assert.strictEqual(r.lines[3].commentStrOffset, 0);
 
 		// Fills in `commentStrLength`
 		assert.strictEqual(r.lines[0].commentStrLength, 2);

--- a/src/vs/editor/contrib/comment/test/browser/lineCommentCommand.test.ts
+++ b/src/vs/editor/contrib/comment/test/browser/lineCommentCommand.test.ts
@@ -48,8 +48,8 @@ suite('Editor Contrib - Line Comment Command', () => {
 		(accessor, sel) => new LineCommentCommand(accessor.get(ILanguageConfigurationService), sel, 4, Type.ForceAdd, true, true)
 	);
 
-	const testLineCommentCommandColumnFixed = createTestCommandHelper(
-		{ lineComment: '!@#', lineCommentTokenColumn: 0, blockComment: ['<!@#', '#@!>'] },
+	const testLineCommentCommandTokenFirstColumn = createTestCommandHelper(
+		{ lineComment: '!@#', lineCommentTokenFirstColumn: true, blockComment: ['<!@#', '#@!>'] },
 		(accessor, sel) => new LineCommentCommand(accessor.get(ILanguageConfigurationService), sel, 4, Type.Toggle, true, true)
 	);
 
@@ -87,7 +87,7 @@ suite('Editor Contrib - Line Comment Command', () => {
 	});
 
 	test('comment with token column fixed', function () {
-		testLineCommentCommandColumnFixed(
+		testLineCommentCommandTokenFirstColumn(
 			[
 				'some text',
 				'\tsome more text'

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -6718,6 +6718,10 @@ declare namespace monaco.languages {
 		 */
 		lineComment?: string | null;
 		/**
+		 * Where on the line the token should be placed.
+		 */
+		lineCommentTokenColumn?: number | null;
+		/**
 		 * The block comment character pair, like `/* block comment *&#47;`
 		 */
 		blockComment?: CharacterPair | null;

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -6710,17 +6710,29 @@ declare namespace monaco.languages {
 	}
 
 	/**
+	 * Configuration for line comments.
+	 */
+	export interface LineCommentConfig {
+		/**
+		 * The line comment token, like `// this is a comment`
+		 */
+		comment: string;
+		/**
+		 * Whether the comment token should not be indented and placed at the first column.
+		 * Defaults to false.
+		 */
+		noIndent?: boolean;
+	}
+
+	/**
 	 * Describes how comments for a language work.
 	 */
 	export interface CommentRule {
 		/**
-		 * The line comment token, like `// this is a comment`
+		 * The line comment token, like `// this is a comment`.
+		 * Can be a string or an object with comment and optional noIndent properties.
 		 */
-		lineComment?: string | null;
-		/**
-		 * Where on the line the token should be placed.
-		 */
-		lineCommentTokenFirstColumn?: boolean | null;
+		lineComment?: string | LineCommentConfig | null;
 		/**
 		 * The block comment character pair, like `/* block comment *&#47;`
 		 */

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -6720,7 +6720,7 @@ declare namespace monaco.languages {
 		/**
 		 * Where on the line the token should be placed.
 		 */
-		lineCommentTokenColumn?: number | null;
+		lineCommentTokenFirstColumn?: boolean | null;
 		/**
 		 * The block comment character pair, like `/* block comment *&#47;`
 		 */

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -6714,7 +6714,7 @@ declare namespace monaco.languages {
 	 */
 	export interface LineCommentConfig {
 		/**
-		 * The line comment token, like `// this is a comment`
+		 * The line comment token, like `//`
 		 */
 		comment: string;
 		/**

--- a/src/vs/workbench/contrib/codeEditor/common/languageConfigurationExtensionPoint.ts
+++ b/src/vs/workbench/contrib/codeEditor/common/languageConfigurationExtensionPoint.ts
@@ -168,12 +168,12 @@ export class LanguageConfigurationFileHandler extends Disposable {
 				result.lineComment = source.lineComment;
 			}
 		}
-		if (typeof source.lineCommentTokenColumn !== 'undefined') {
-			if (typeof source.lineCommentTokenColumn !== 'number') {
-				console.warn(`[${languageId}]: language configuration: expected \`comments.lineCommentTokenColumn\` to be a number.`);
+		if (typeof source.lineCommentTokenFirstColumn !== 'undefined') {
+			if (typeof source.lineCommentTokenFirstColumn !== 'boolean') {
+				console.warn(`[${languageId}]: language configuration: expected \`comments.lineCommentTokenColumn\` to be a boolean.`);
 			} else {
 				result = result || {};
-				result.lineCommentTokenColumn = source.lineCommentTokenColumn;
+				result.lineCommentTokenFirstColumn = source.lineCommentTokenFirstColumn;
 			}
 		}
 		if (typeof source.blockComment !== 'undefined') {

--- a/src/vs/workbench/contrib/codeEditor/common/languageConfigurationExtensionPoint.ts
+++ b/src/vs/workbench/contrib/codeEditor/common/languageConfigurationExtensionPoint.ts
@@ -8,7 +8,7 @@ import { ParseError, parse, getNodeType } from '../../../../base/common/json.js'
 import { IJSONSchema } from '../../../../base/common/jsonSchema.js';
 import * as types from '../../../../base/common/types.js';
 import { URI } from '../../../../base/common/uri.js';
-import { CharacterPair, CommentRule, EnterAction, ExplicitLanguageConfiguration, FoldingMarkers, FoldingRules, IAutoClosingPair, IAutoClosingPairConditional, IndentAction, IndentationRule, LineCommentConfig, OnEnterRule } from '../../../../editor/common/languages/languageConfiguration.js';
+import { CharacterPair, CommentRule, EnterAction, ExplicitLanguageConfiguration, FoldingMarkers, FoldingRules, IAutoClosingPair, IAutoClosingPairConditional, IndentAction, IndentationRule, OnEnterRule } from '../../../../editor/common/languages/languageConfiguration.js';
 import { ILanguageConfigurationService } from '../../../../editor/common/languages/languageConfigurationRegistry.js';
 import { ILanguageService } from '../../../../editor/common/languages/language.js';
 import { Extensions, IJSONContributionRegistry } from '../../../../platform/jsonschemas/common/jsonContributionRegistry.js';
@@ -168,13 +168,10 @@ export class LanguageConfigurationFileHandler extends Disposable {
 				const lineCommentObj = source.lineComment as any;
 				if (typeof lineCommentObj.comment === 'string') {
 					result = result || {};
-					const lineCommentConfig: LineCommentConfig = {
-						comment: lineCommentObj.comment
+					result.lineComment = {
+						comment: lineCommentObj.comment,
+						noIndent: lineCommentObj.noIndent
 					};
-					if (typeof lineCommentObj.noIndent === 'boolean') {
-						lineCommentConfig.noIndent = lineCommentObj.noIndent;
-					}
-					result.lineComment = lineCommentConfig;
 				} else {
 					console.warn(`[${languageId}]: language configuration: expected \`comments.lineComment.comment\` to be a string.`);
 				}

--- a/src/vs/workbench/contrib/codeEditor/common/languageConfigurationExtensionPoint.ts
+++ b/src/vs/workbench/contrib/codeEditor/common/languageConfigurationExtensionPoint.ts
@@ -168,6 +168,14 @@ export class LanguageConfigurationFileHandler extends Disposable {
 				result.lineComment = source.lineComment;
 			}
 		}
+		if (typeof source.lineCommentTokenColumn !== 'undefined') {
+			if (typeof source.lineCommentTokenColumn !== 'number') {
+				console.warn(`[${languageId}]: language configuration: expected \`comments.lineCommentTokenColumn\` to be a number.`);
+			} else {
+				result = result || {};
+				result.lineCommentTokenColumn = source.lineCommentTokenColumn;
+			}
+		}
 		if (typeof source.blockComment !== 'undefined') {
 			if (!isCharacterPair(source.blockComment)) {
 				console.warn(`[${languageId}]: language configuration: expected \`comments.blockComment\` to be an array of two strings.`);


### PR DESCRIPTION
This pull request addresses an old bug (issue #234464) where the line comment action in VS Code failed to correctly handle makefiles. By default, VS Code uses `Ctrl + /` to comment lines, but for makefiles, comment tokens must be placed in the first column to avoid being just forwarded to the shell.

The issue happened because the line comment action didn't account for the language being edited. This fix passes the `languageId` to the comment function, allowing it to handle makefiles differently. A new test has been added to verify this functionality.

To test this in practice, open any makefile and try using the keybind `Ctrl + /` on an indented line of code, with and without my fix. You will notice the different placement of the comment token.