### PR TITLE
Don't move cursor when going to next problem

### DIFF
--- a/src/vs/editor/contrib/gotoError/browser/gotoError.ts
+++ b/src/vs/editor/contrib/gotoError/browser/gotoError.ts
@@ -148,7 +148,9 @@ export class MarkerController implements IEditorContribution {
 
 		const textModel = this._editor.getModel();
 		const model = this._getOrCreateModel(multiFile ? undefined : textModel.uri);
-		model.move(next, textModel, this._editor.getPosition());
+        const previousPosition = this._editor.getPosition();
+
+        model.move(next, textModel, previousPosition);
 		if (!model.selected) {
 			return;
 		}


### PR DESCRIPTION
Fixes #156782

Changed the navigate() function in vscode/src/vs/editor/contrib/gotoError/browser/gotoError.ts so that the cursor is not moved when invoking editor.action.marker.next.

You can test these changes by opening a file with at least 2 problems/linting errors in it, and moving on to the next problem. If these proposed changes were successful, the cursor should not change positions when you do so.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
