### PR TITLE
Update command labels to meet capitalization guidance

### DIFF
--- a/src/vs/editor/contrib/clipboard/browser/clipboard.ts
+++ b/src/vs/editor/contrib/clipboard/browser/clipboard.ts
@@ -157,7 +157,7 @@ class ExecCommandCopyWithSyntaxHighlightingAction extends EditorAction {
 	constructor() {
 		super({
 			id: 'editor.action.clipboardCopyWithSyntaxHighlightingAction',
-			label: nls.localize2('actions.clipboard.copyWithSyntaxHighlightingLabel', "Copy With Syntax Highlighting"),
+			label: nls.localize2('actions.clipboard.copyWithSyntaxHighlightingLabel', "Copy with Syntax Highlighting"),
 			precondition: undefined,
 			kbOpts: {
 				kbExpr: EditorContextKeys.textInputFocus,

--- a/src/vs/editor/contrib/codelens/browser/codelensController.ts
+++ b/src/vs/editor/contrib/codelens/browser/codelensController.ts
@@ -465,7 +465,7 @@ registerEditorAction(class ShowLensesInCurrentLine extends EditorAction {
 		super({
 			id: 'codelens.showLensesInCurrentLine',
 			precondition: EditorContextKeys.hasCodeLensProvider,
-			label: localize2('showLensOnLine', "Show CodeLens Commands For Current Line"),
+			label: localize2('showLensOnLine', "Show CodeLens Commands for Current Line"),
 		});
 	}
 

--- a/src/vs/editor/contrib/find/browser/findController.ts
+++ b/src/vs/editor/contrib/find/browser/findController.ts
@@ -584,7 +584,7 @@ export class StartFindWithArgsAction extends EditorAction {
 	constructor() {
 		super({
 			id: FIND_IDS.StartFindWithArgs,
-			label: nls.localize2('startFindWithArgsAction', "Find With Arguments"),
+			label: nls.localize2('startFindWithArgsAction', "Find with Arguments"),
 			precondition: undefined,
 			kbOpts: {
 				kbExpr: null,
@@ -633,7 +633,7 @@ export class StartFindWithSelectionAction extends EditorAction {
 	constructor() {
 		super({
 			id: FIND_IDS.StartFindWithSelection,
-			label: nls.localize2('startFindWithSelectionAction', "Find With Selection"),
+			label: nls.localize2('startFindWithSelectionAction', "Find with Selection"),
 			precondition: undefined,
 			kbOpts: {
 				kbExpr: null,

--- a/src/vs/editor/contrib/multicursor/browser/multicursor.ts
+++ b/src/vs/editor/contrib/multicursor/browser/multicursor.ts
@@ -201,7 +201,7 @@ class InsertCursorAtEndOfLineSelected extends EditorAction {
 	constructor() {
 		super({
 			id: 'editor.action.addCursorsToBottom',
-			label: nls.localize2('mutlicursor.addCursorsToBottom', "Add Cursors To Bottom"),
+			label: nls.localize2('mutlicursor.addCursorsToBottom', "Add Cursors to Bottom"),
 			precondition: undefined
 		});
 	}
@@ -233,7 +233,7 @@ class InsertCursorAtTopOfLineSelected extends EditorAction {
 	constructor() {
 		super({
 			id: 'editor.action.addCursorsToTop',
-			label: nls.localize2('mutlicursor.addCursorsToTop', "Add Cursors To Top"),
+			label: nls.localize2('mutlicursor.addCursorsToTop', "Add Cursors to Top"),
 			precondition: undefined
 		});
 	}
@@ -686,7 +686,7 @@ export class AddSelectionToNextFindMatchAction extends MultiCursorSelectionContr
 	constructor() {
 		super({
 			id: 'editor.action.addSelectionToNextFindMatch',
-			label: nls.localize2('addSelectionToNextFindMatch', "Add Selection To Next Find Match"),
+			label: nls.localize2('addSelectionToNextFindMatch', "Add Selection to Next Find Match"),
 			precondition: undefined,
 			kbOpts: {
 				kbExpr: EditorContextKeys.focus,
@@ -710,7 +710,7 @@ export class AddSelectionToPreviousFindMatchAction extends MultiCursorSelectionC
 	constructor() {
 		super({
 			id: 'editor.action.addSelectionToPreviousFindMatch',
-			label: nls.localize2('addSelectionToPreviousFindMatch', "Add Selection To Previous Find Match"),
+			label: nls.localize2('addSelectionToPreviousFindMatch', "Add Selection to Previous Find Match"),
 			precondition: undefined,
 			menuOpts: {
 				menuId: MenuId.MenubarSelectionMenu,
@@ -729,7 +729,7 @@ export class MoveSelectionToNextFindMatchAction extends MultiCursorSelectionCont
 	constructor() {
 		super({
 			id: 'editor.action.moveSelectionToNextFindMatch',
-			label: nls.localize2('moveSelectionToNextFindMatch', "Move Last Selection To Next Find Match"),
+			label: nls.localize2('moveSelectionToNextFindMatch', "Move Last Selection to Next Find Match"),
 			precondition: undefined,
 			kbOpts: {
 				kbExpr: EditorContextKeys.focus,
@@ -747,7 +747,7 @@ export class MoveSelectionToPreviousFindMatchAction extends MultiCursorSelection
 	constructor() {
 		super({
 			id: 'editor.action.moveSelectionToPreviousFindMatch',
-			label: nls.localize2('moveSelectionToPreviousFindMatch', "Move Last Selection To Previous Find Match"),
+			label: nls.localize2('moveSelectionToPreviousFindMatch', "Move Last Selection to Previous Find Match"),
 			precondition: undefined
 		});
 	}

--- a/src/vs/workbench/browser/parts/editor/editorActions.ts
+++ b/src/vs/workbench/browser/parts/editor/editorActions.ts
@@ -2493,7 +2493,7 @@ export class ReOpenInTextEditorAction extends Action2 {
 	constructor() {
 		super({
 			id: 'workbench.action.reopenTextEditor',
-			title: localize2('reopenTextEditor', 'Reopen Editor With Text Editor'),
+			title: localize2('reopenTextEditor', 'Reopen Editor with Text Editor'),
 			f1: true,
 			category: Categories.View,
 			precondition: ActiveEditorAvailableEditorIdsContext

--- a/src/vs/workbench/contrib/inlayHints/browser/inlayHintsAccessibilty.ts
+++ b/src/vs/workbench/contrib/inlayHints/browser/inlayHintsAccessibilty.ts
@@ -174,7 +174,7 @@ registerAction2(class StartReadHints extends EditorAction2 {
 	constructor() {
 		super({
 			id: 'inlayHints.startReadingLineWithHint',
-			title: localize2('read.title', "Read Line With Inline Hints"),
+			title: localize2('read.title', "Read Line with Inline Hints"),
 			precondition: EditorContextKeys.hasInlayHintsProvider,
 			f1: true
 		});

--- a/src/vs/workbench/contrib/notebook/browser/contrib/multicursor/notebookMulticursor.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/multicursor/notebookMulticursor.ts
@@ -1035,7 +1035,7 @@ class NotebookAddMatchToMultiSelectionAction extends NotebookAction {
 	constructor() {
 		super({
 			id: NOTEBOOK_ADD_FIND_MATCH_TO_SELECTION_ID,
-			title: localize('addFindMatchToSelection', "Add Selection To Next Find Match"),
+			title: localize('addFindMatchToSelection', "Add Selection to Next Find Match"),
 			precondition: ContextKeyExpr.and(
 				ContextKeyExpr.equals('config.notebook.multiCursor.enabled', true),
 				NOTEBOOK_IS_ACTIVE_EDITOR,

--- a/src/vs/workbench/contrib/terminal/browser/terminalActions.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalActions.ts
@@ -904,7 +904,7 @@ export function registerTerminalActions() {
 
 	registerActiveInstanceAction({
 		id: TerminalCommandId.SelectToPreviousCommand,
-		title: localize2('workbench.action.terminal.selectToPreviousCommand', 'Select To Previous Command'),
+		title: localize2('workbench.action.terminal.selectToPreviousCommand', 'Select to Previous Command'),
 		keybinding: {
 			primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.UpArrow,
 			when: TerminalContextKeys.focus,
@@ -919,7 +919,7 @@ export function registerTerminalActions() {
 
 	registerActiveInstanceAction({
 		id: TerminalCommandId.SelectToNextCommand,
-		title: localize2('workbench.action.terminal.selectToNextCommand', 'Select To Next Command'),
+		title: localize2('workbench.action.terminal.selectToNextCommand', 'Select to Next Command'),
 		keybinding: {
 			primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.DownArrow,
 			when: TerminalContextKeys.focus,
@@ -934,7 +934,7 @@ export function registerTerminalActions() {
 
 	registerActiveXtermAction({
 		id: TerminalCommandId.SelectToPreviousLine,
-		title: localize2('workbench.action.terminal.selectToPreviousLine', 'Select To Previous Line'),
+		title: localize2('workbench.action.terminal.selectToPreviousLine', 'Select to Previous Line'),
 		precondition: sharedWhenClause.terminalAvailable,
 		run: async (xterm, _, instance) => {
 			xterm.markTracker.selectToPreviousLine();
@@ -945,7 +945,7 @@ export function registerTerminalActions() {
 
 	registerActiveXtermAction({
 		id: TerminalCommandId.SelectToNextLine,
-		title: localize2('workbench.action.terminal.selectToNextLine', 'Select To Next Line'),
+		title: localize2('workbench.action.terminal.selectToNextLine', 'Select to Next Line'),
 		precondition: sharedWhenClause.terminalAvailable,
 		run: async (xterm, _, instance) => {
 			xterm.markTracker.selectToNextLine();

--- a/src/vs/workbench/contrib/terminal/common/terminalStrings.ts
+++ b/src/vs/workbench/contrib/terminal/common/terminalStrings.ts
@@ -36,9 +36,9 @@ export const terminalStrings = {
 	rename: localize2('workbench.action.terminal.rename', "Rename..."),
 	toggleSizeToContentWidth: localize2('workbench.action.terminal.sizeToContentWidthInstance', "Toggle Size to Content Width"),
 	focusHover: localize2('workbench.action.terminal.focusHover', "Focus Hover"),
-	sendSequence: localize2('workbench.action.terminal.sendSequence', "Send Custom Sequence To Terminal"),
+	sendSequence: localize2('workbench.action.terminal.sendSequence', "Send Custom Sequence to Terminal"),
 	newWithCwd: localize2('workbench.action.terminal.newWithCwd', "Create New Terminal Starting in a Custom Working Directory"),
 	renameWithArgs: localize2('workbench.action.terminal.renameWithArg', "Rename the Currently Active Terminal"),
-	scrollToPreviousCommand: localize2('workbench.action.terminal.scrollToPreviousCommand', "Scroll To Previous Command"),
-	scrollToNextCommand: localize2('workbench.action.terminal.scrollToNextCommand', "Scroll To Next Command")
+	scrollToPreviousCommand: localize2('workbench.action.terminal.scrollToPreviousCommand', "Scroll to Previous Command"),
+	scrollToNextCommand: localize2('workbench.action.terminal.scrollToNextCommand', "Scroll to Next Command")
 };

--- a/src/vs/workbench/electron-sandbox/actions/developerActions.ts
+++ b/src/vs/workbench/electron-sandbox/actions/developerActions.ts
@@ -73,7 +73,7 @@ export class ReloadWindowWithExtensionsDisabledAction extends Action2 {
 	constructor() {
 		super({
 			id: 'workbench.action.reloadWindowWithExtensionsDisabled',
-			title: localize2('reloadWindowWithExtensionsDisabled', 'Reload With Extensions Disabled'),
+			title: localize2('reloadWindowWithExtensionsDisabled', 'Reload with Extensions Disabled'),
 			category: Categories.Developer,
 			f1: true
 		});


### PR DESCRIPTION
Command labels should use title-style casing. Don't capitalize prepositions of four or fewer letters (such as to, for, with) unless the preposition is the first or last word. Guidance: <https://learn.microsoft.com/en-us/style-guide/capitalization#title-style-capitalization>

Updating command labels in VS Code core to align with this guidance.

Ref: https://github.com/microsoft/vscode/issues/242707
