### PR TITLE
Hide terminal hover details by default

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/environmentVariableInfo.ts
+++ b/src/vs/workbench/contrib/terminal/browser/environmentVariableInfo.ts
@@ -87,7 +87,8 @@ export class EnvironmentVariableInfoChangesActive implements IEnvironmentVariabl
 		return {
 			id: TerminalStatus.EnvironmentVariableInfoChangesActive,
 			severity: Severity.Info,
-			tooltip: this._getInfo(scope),
+			tooltip: undefined, // The action is present when details aren't shown
+			detailedTooltip: this._getInfo(scope),
 			hoverActions: this._getActions(scope)
 		};
 	}

--- a/src/vs/workbench/contrib/terminal/browser/terminalTabbedView.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalTabbedView.ts
@@ -459,7 +459,7 @@ export class TerminalTabbedView extends Disposable {
 			return;
 		}
 		this._hoverService.showHover({
-			...getInstanceHoverInfo(instance),
+			...getInstanceHoverInfo(instance, this._storageService),
 			target: this._terminalContainer,
 			trapFocus: true
 		}, true);

--- a/src/vs/workbench/contrib/terminal/browser/terminalTabsList.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalTabsList.ts
@@ -53,6 +53,8 @@ import { TerminalContextActionRunner } from './terminalContextMenu.js';
 import type { IHoverAction } from '../../../../base/browser/ui/hover/hover.js';
 import { HoverPosition } from '../../../../base/browser/ui/hover/hoverWidget.js';
 import { ICommandService } from '../../../../platform/commands/common/commands.js';
+import { IStorageService, StorageScope } from '../../../../platform/storage/common/storage.js';
+import { TerminalStorageKeys } from '../common/terminalStorageKeys.js';
 
 const $ = DOM.$;
 
@@ -82,6 +84,7 @@ export class TerminalTabList extends WorkbenchList<ITerminalInstance> {
 		@IInstantiationService instantiationService: IInstantiationService,
 		@IDecorationsService decorationsService: IDecorationsService,
 		@IThemeService private readonly _themeService: IThemeService,
+		@IStorageService private readonly _storageService: IStorageService,
 		@ILifecycleService lifecycleService: ILifecycleService,
 		@IHoverService private readonly _hoverService: IHoverService,
 	) {
@@ -128,7 +131,8 @@ export class TerminalTabList extends WorkbenchList<ITerminalInstance> {
 					this.reveal(i);
 				}
 				this.refresh();
-			})
+			}),
+			this._storageService.onDidChangeValue(StorageScope.APPLICATION, TerminalStorageKeys.TabsShowDetailed, this.disposables)(() => this.refresh()),
 		];
 
 		// Dispose of instance listeners on shutdown to avoid extra work and so tabs don't disappear
@@ -230,7 +234,7 @@ export class TerminalTabList extends WorkbenchList<ITerminalInstance> {
 		}
 
 		this._hoverService.showHover({
-			...getInstanceHoverInfo(instance),
+			...getInstanceHoverInfo(instance, this._storageService),
 			target: this.getHTMLElement(),
 			trapFocus: true
 		}, true);
@@ -257,6 +261,7 @@ class TerminalTabsRenderer extends Disposable implements IListRenderer<ITerminal
 		@IHoverService private readonly _hoverService: IHoverService,
 		@IKeybindingService private readonly _keybindingService: IKeybindingService,
 		@IListService private readonly _listService: IListService,
+		@IStorageService private readonly _storageService: IStorageService,
 		@IThemeService private readonly _themeService: IThemeService,
 		@IContextViewService private readonly _contextViewService: IContextViewService,
 		@ICommandService private readonly _commandService: ICommandService,
@@ -339,7 +344,7 @@ class TerminalTabsRenderer extends Disposable implements IListRenderer<ITerminal
 			}
 		}
 
-		const hoverInfo = getInstanceHoverInfo(instance);
+		const hoverInfo = getInstanceHoverInfo(instance, this._storageService);
 		template.context.hoverActions = hoverInfo.actions;
 
 		const iconId = this._instantiationService.invokeFunction(getIconId, instance);

--- a/src/vs/workbench/contrib/terminal/browser/terminalTooltip.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalTooltip.ts
@@ -11,25 +11,45 @@ import type { IHoverAction } from '../../../../base/browser/ui/hover/hover.js';
 import { TerminalCapability } from '../../../../platform/terminal/common/capabilities/capabilities.js';
 import { TerminalStatus } from './terminalStatusList.js';
 import Severity from '../../../../base/common/severity.js';
+import { StorageScope, StorageTarget, type IStorageService } from '../../../../platform/storage/common/storage.js';
+import { TerminalStorageKeys } from '../common/terminalStorageKeys.js';
+import type { ITerminalStatusHoverAction } from '../common/terminal.js';
+import { basename } from '../../../../base/common/path.js';
 
-export function getInstanceHoverInfo(instance: ITerminalInstance): { content: MarkdownString; actions: IHoverAction[] } {
+export function getInstanceHoverInfo(instance: ITerminalInstance, storageService: IStorageService): { content: MarkdownString; actions: IHoverAction[] } {
+	const showDetailed = parseInt(storageService.get(TerminalStorageKeys.TabsShowDetailed, StorageScope.APPLICATION) ?? '0');
 	let statusString = '';
 	const statuses = instance.statusList.statuses;
-	const actions = [];
+	const actions: ITerminalStatusHoverAction[] = [];
 	for (const status of statuses) {
-		statusString += `\n\n---\n\n${status.icon ? `$(${status.icon?.id}) ` : ''}${status.tooltip || status.id}`;
+		if (showDetailed) {
+			if (status.detailedTooltip ?? status.tooltip) {
+				statusString += `\n\n---\n\n${status.icon ? `$(${status.icon?.id}) ` : ''}` + (status.detailedTooltip ?? status.tooltip ?? '');
+			}
+		} else {
+			if (status.tooltip) {
+				statusString += `\n\n---\n\n${status.icon ? `$(${status.icon?.id}) ` : ''}` + (status.tooltip ?? '');
+			}
+		}
 		if (status.hoverActions) {
 			actions.push(...status.hoverActions);
 		}
 	}
+	actions.push({
+		commandId: 'toggleDetailedInfo',
+		label: showDetailed ? localize('hideDetails', 'Hide Details') : localize('showDetails', 'Show Details'),
+		run() {
+			storageService.store(TerminalStorageKeys.TabsShowDetailed, (showDetailed + 1) % 2, StorageScope.APPLICATION, StorageTarget.USER);
+		},
+	});
 
-	const shellProcessString = getShellProcessTooltip(instance, true);
+	const shellProcessString = getShellProcessTooltip(instance, !!showDetailed);
 	const content = new MarkdownString(instance.title + shellProcessString + statusString, { supportThemeIcons: true });
 
 	return { content, actions };
 }
 
-export function getShellProcessTooltip(instance: ITerminalInstance, markdown: boolean): string {
+export function getShellProcessTooltip(instance: ITerminalInstance, showDetailed: boolean): string {
 	const lines: string[] = [];
 
 	if (instance.processId && instance.processId > 0) {
@@ -37,8 +57,16 @@ export function getShellProcessTooltip(instance: ITerminalInstance, markdown: bo
 	}
 
 	if (instance.shellLaunchConfig.executable) {
-		let commandLine = instance.shellLaunchConfig.executable;
-		const args = asArray(instance.injectedArgs || instance.shellLaunchConfig.args || []).map(x => `'${x}'`).join(' ');
+		let commandLine = '';
+		if (!showDetailed && instance.shellLaunchConfig.executable.length > 32) {
+			const base = basename(instance.shellLaunchConfig.executable);
+			const sepIndex = instance.shellLaunchConfig.executable.length - base.length - 1;
+			const sep = instance.shellLaunchConfig.executable.substring(sepIndex, sepIndex + 1);
+			commandLine += `…${sep}${base}`;
+		} else {
+			commandLine += instance.shellLaunchConfig.executable;
+		}
+		const args = asArray(instance.injectedArgs || instance.shellLaunchConfig.args || []).map(x => x.match(/\s/) ? `'${x}'` : x).join(' ');
 		if (args) {
 			commandLine += ` ${args}`;
 		}
@@ -46,7 +74,7 @@ export function getShellProcessTooltip(instance: ITerminalInstance, markdown: bo
 		lines.push(localize('shellProcessTooltip.commandLine', 'Command line: {0}', commandLine));
 	}
 
-	return lines.length ? `${markdown ? '\n\n---\n\n' : '\n\n'}${lines.join('\n')}` : '';
+	return lines.length ? `\n\n---\n\n${lines.join('\n')}` : '';
 }
 
 export function refreshShellIntegrationInfoStatus(instance: ITerminalInstance) {
@@ -71,6 +99,7 @@ export function refreshShellIntegrationInfoStatus(instance: ITerminalInstance) {
 	instance.statusList.add({
 		id: TerminalStatus.ShellIntegrationInfo,
 		severity: Severity.Info,
-		tooltip: `${localize('shellIntegration', "Shell integration")}: ${cmdDetectionType}${seenSequencesString}`
+		tooltip: `${localize('shellIntegration', "Shell integration")}: ${cmdDetectionType}`,
+		detailedTooltip: `${localize('shellIntegration', "Shell integration")}: ${cmdDetectionType}${seenSequencesString}`
 	});
 }

--- a/src/vs/workbench/contrib/terminal/browser/terminalView.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalView.ts
@@ -50,6 +50,7 @@ import { IHoverService } from '../../../../platform/hover/browser/hover.js';
 import { IAccessibilityService } from '../../../../platform/accessibility/common/accessibility.js';
 import { InstanceContext, TerminalContextActionRunner } from './terminalContextMenu.js';
 import { MicrotaskDelay } from '../../../../base/common/symbols.js';
+import { IStorageService } from '../../../../platform/storage/common/storage.js';
 
 export class TerminalViewPane extends ViewPane {
 	private _parentDomElement: HTMLElement | undefined;
@@ -660,7 +661,8 @@ class SingleTabHoverDelegate implements IHoverDelegate {
 	constructor(
 		@IConfigurationService private readonly _configurationService: IConfigurationService,
 		@IHoverService private readonly _hoverService: IHoverService,
-		@ITerminalGroupService private readonly _terminalGroupService: ITerminalGroupService
+		@IStorageService private readonly _storageService: IStorageService,
+		@ITerminalGroupService private readonly _terminalGroupService: ITerminalGroupService,
 	) {
 	}
 
@@ -675,7 +677,7 @@ class SingleTabHoverDelegate implements IHoverDelegate {
 		if (!instance) {
 			return;
 		}
-		const hoverInfo = getInstanceHoverInfo(instance);
+		const hoverInfo = getInstanceHoverInfo(instance, this._storageService);
 		return this._hoverService.showHover({
 			...options,
 			content: hoverInfo.content,

--- a/src/vs/workbench/contrib/terminal/browser/terminalView.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalView.ts
@@ -678,7 +678,7 @@ class SingleTabHoverDelegate implements IHoverDelegate {
 			return;
 		}
 		const hoverInfo = getInstanceHoverInfo(instance, this._storageService);
-		return this._hoverService.getInstanceHoverInfo({
+		return this._hoverService.showInstantHover({
 			...options,
 			content: hoverInfo.content,
 			actions: hoverInfo.actions

--- a/src/vs/workbench/contrib/terminal/common/terminal.ts
+++ b/src/vs/workbench/contrib/terminal/common/terminal.ts
@@ -371,6 +371,10 @@ export interface ITerminalStatus {
 	 */
 	tooltip?: string | undefined;
 	/**
+	 * What to show for this status in the terminal's hover when details are toggled.
+	 */
+	detailedTooltip?: string | undefined;
+	/**
 	 * Actions to expose on hover.
 	 */
 	hoverActions?: ITerminalStatusHoverAction[];

--- a/src/vs/workbench/contrib/terminal/common/terminalStorageKeys.ts
+++ b/src/vs/workbench/contrib/terminal/common/terminalStorageKeys.ts
@@ -7,6 +7,7 @@ export const enum TerminalStorageKeys {
 	SuggestedRendererType = 'terminal.integrated.suggestedRendererType',
 	TabsListWidthHorizontal = 'tabs-list-width-horizontal',
 	TabsListWidthVertical = 'tabs-list-width-vertical',
+	TabsShowDetailed = 'terminal.integrated.tabs.showDetailed',
 	DeprecatedEnvironmentVariableCollections = 'terminal.integrated.environmentVariableCollections',
 	EnvironmentVariableCollections = 'terminal.integrated.environmentVariableCollectionsV2',
 	TerminalBufferState = 'terminal.integrated.bufferState',


### PR DESCRIPTION
Fixes #242103

New default:

![image](https://github.com/user-attachments/assets/426bbfa4-63c8-4883-9f0d-92becec1c7ac)

Clicking Show Details:

![image](https://github.com/user-attachments/assets/e32e0ba9-8d13-44ee-a49a-4bf962834ed2)
