### PR TITLE
showHover -> showInstantHover

### DIFF
--- a/src/vs/base/browser/ui/hover/hover.ts
+++ b/src/vs/base/browser/ui/hover/hover.ts
@@ -14,32 +14,6 @@ import type { IDisposable } from '../../../common/lifecycle.js';
  */
 export interface IHoverDelegate2 {
 	/**
-	 * Shows a hover immediately, provided a hover with the same {@link options} object is not
-	 * already visible.
-	 *
-	 * Use this method when you want to:
-	 *
-	 * - Control showing the hover yourself.
-	 * - Show the hover immediately.
-	 *
-	 * @param options A set of options defining the characteristics of the hover.
-	 * @param focus Whether to focus the hover (useful for keyboard accessibility).
-	 *
-	 * @example A simple usage with a single element target.
-	 *
-	 * ```typescript
-	 * showHover({
-	 *   text: new MarkdownString('Hello world'),
-	 *   target: someElement
-	 * });
-	 * ```
-	 */
-	showHover(
-		options: IHoverOptions,
-		focus?: boolean
-	): IHoverWidget | undefined;
-
-	/**
 	 * Shows a hover after a delay, or immediately if the {@link groupId} matches the currently
 	 * shown hover.
 	 *
@@ -101,6 +75,32 @@ export interface IHoverDelegate2 {
 	): IDisposable;
 
 	/**
+	 * Shows a hover immediately, provided a hover with the same {@link options} object is not
+	 * already visible.
+	 *
+	 * Use this method when you want to:
+	 *
+	 * - Control showing the hover yourself.
+	 * - Show the hover immediately.
+	 *
+	 * @param options A set of options defining the characteristics of the hover.
+	 * @param focus Whether to focus the hover (useful for keyboard accessibility).
+	 *
+	 * @example A simple usage with a single element target.
+	 *
+	 * ```typescript
+	 * showInstantHover({
+	 *   text: new MarkdownString('Hello world'),
+	 *   target: someElement
+	 * });
+	 * ```
+	 */
+	showInstantHover(
+		options: IHoverOptions,
+		focus?: boolean
+	): IHoverWidget | undefined;
+
+	/**
 	 * Hides the hover if it was visible. This call will be ignored if the hover is currently
 	 * "locked" via the alt/option key unless `force` is set.
 	 */
@@ -116,8 +116,8 @@ export interface IHoverDelegate2 {
 	 * Sets up a managed hover for the given element. A managed hover will set up listeners for
 	 * mouse events, show the hover after a delay and provide hooks to easily update the content.
 	 *
-	 * This should be used over {@link showHover} when fine-grained control is not needed. The
-	 * managed hover also does not scale well, consider using {@link showHover} when showing hovers
+	 * This should be used over {@link showInstantHover} when fine-grained control is not needed. The
+	 * managed hover also does not scale well, consider using {@link showInstantHover} when showing hovers
 	 * for many elements.
 	 *
 	 * @param hoverDelegate The hover delegate containing hooks and configuration for the hover.

--- a/src/vs/base/browser/ui/hover/hoverDelegate2.ts
+++ b/src/vs/base/browser/ui/hover/hoverDelegate2.ts
@@ -7,7 +7,7 @@ import { Disposable } from '../../../common/lifecycle.js';
 import type { IHoverDelegate2 } from './hover.js';
 
 let baseHoverDelegate: IHoverDelegate2 = {
-	showHover: () => undefined,
+	showInstantHover: () => undefined,
 	showDelayedHover: () => undefined,
 	setupDelayedHover: () => Disposable.None,
 	setupDelayedHoverAtMouse: () => Disposable.None,

--- a/src/vs/editor/browser/services/hoverService/hoverService.ts
+++ b/src/vs/editor/browser/services/hoverService/hoverService.ts
@@ -69,7 +69,7 @@ export class HoverService extends Disposable implements IHoverService {
 		}));
 	}
 
-	showHover(options: IHoverOptions, focus?: boolean, skipLastFocusedUpdate?: boolean, dontShow?: boolean): IHoverWidget | undefined {
+	showInstantHover(options: IHoverOptions, focus?: boolean, skipLastFocusedUpdate?: boolean, dontShow?: boolean): IHoverWidget | undefined {
 		const hover = this._createHover(options, skipLastFocusedUpdate);
 		if (!hover) {
 			return undefined;
@@ -100,7 +100,7 @@ export class HoverService extends Disposable implements IHoverService {
 
 			// Check group identity, if it's the same skip the delay and show the hover immediately
 			if (this._currentHover && !this._currentHover.isDisposed && this._currentDelayedHoverGroupId !== undefined && this._currentDelayedHoverGroupId === lifecycleOptions?.groupId) {
-				return this.showHover({
+				return this.showInstantHover({
 					...options,
 					appearance: {
 						...options.appearance,
@@ -177,12 +177,12 @@ export class HoverService extends Disposable implements IHoverService {
 			store.add(addDisposableListener(target, EventType.KEY_DOWN, e => {
 				const evt = new StandardKeyboardEvent(e);
 				if (evt.equals(KeyCode.Space) || evt.equals(KeyCode.Enter)) {
-					this.showHover(resolveHoverOptions(), true);
+					this.showInstantHover(resolveHoverOptions(), true);
 				}
 			}));
 		}
 
-		this._delayedHovers.set(target, { show: (focus: boolean) => { this.showHover(resolveHoverOptions(), focus); } });
+		this._delayedHovers.set(target, { show: (focus: boolean) => { this.showInstantHover(resolveHoverOptions(), focus); } });
 		store.add(toDisposable(() => this._delayedHovers.delete(target)));
 
 		return store;
@@ -320,7 +320,7 @@ export class HoverService extends Disposable implements IHoverService {
 		if (!this._lastHoverOptions) {
 			return;
 		}
-		this.showHover(this._lastHoverOptions, true, true);
+		this.showInstantHover(this._lastHoverOptions, true, true);
 	}
 
 	private _showAndFocusHoverForActiveElement(): void {

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/components/gutterIndicatorView.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/components/gutterIndicatorView.ts
@@ -154,7 +154,7 @@ export class InlineEditsGutterIndicator extends Disposable {
 		disposableStore.add(focusTracker.onDidFocus(() => this._focusIsInMenu.set(true, undefined)));
 		disposableStore.add(toDisposable(() => this._focusIsInMenu.set(false, undefined)));
 
-		const h = this._hoverService.showHover({
+		const h = this._hoverService.showInstantHover({
 			target: this._iconRef.element,
 			content: content.element,
 		}) as HoverWidget | undefined;

--- a/src/vs/platform/hover/browser/hover.ts
+++ b/src/vs/platform/hover/browser/hover.ts
@@ -79,7 +79,7 @@ export class WorkbenchHoverDelegate extends Disposable implements IHoverDelegate
 				? options.content.toString()
 				: options.content.value;
 
-		return this.hoverService.showHover({
+		return this.hoverService.showInstantHover({
 			...options,
 			...overrideOptions,
 			persistence: {

--- a/src/vs/platform/hover/test/browser/nullHoverService.ts
+++ b/src/vs/platform/hover/test/browser/nullHoverService.ts
@@ -9,7 +9,7 @@ import type { IHoverService } from '../../browser/hover.js';
 export const NullHoverService: IHoverService = {
 	_serviceBrand: undefined,
 	hideHover: () => undefined,
-	showHover: () => undefined,
+	showInstantHover: () => undefined,
 	showDelayedHover: () => undefined,
 	setupDelayedHover: () => Disposable.None,
 	setupDelayedHoverAtMouse: () => Disposable.None,

--- a/src/vs/workbench/contrib/chat/browser/chatListRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatListRenderer.ts
@@ -346,7 +346,7 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 			if (ev.equals(KeyCode.Space) || ev.equals(KeyCode.Enter)) {
 				const content = hoverContent();
 				if (content) {
-					this.hoverService.showHover({ content, target: user, trapFocus: true, actions: hoverOptions.actions }, true);
+					this.hoverService.showInstantHover({ content, target: user, trapFocus: true, actions: hoverOptions.actions }, true);
 				}
 			} else if (ev.equals(KeyCode.Escape)) {
 				this.hoverService.hideHover();

--- a/src/vs/workbench/contrib/debug/browser/breakpointsView.ts
+++ b/src/vs/workbench/contrib/debug/browser/breakpointsView.ts
@@ -224,7 +224,7 @@ export class BreakpointsView extends ViewPane {
 		const iconLabelContainer = dom.append(container, $('span.breakpoint-warning'));
 		this.hintContainer = this._register(new IconLabel(iconLabelContainer, {
 			supportIcons: true, hoverDelegate: {
-				showHover: (options, focus?) => this.hoverService.showHover({ content: options.content, target: this.hintContainer!.element }, focus),
+				showHover: (options, focus?) => this.hoverService.showInstantHover({ content: options.content, target: this.hintContainer!.element }, focus),
 				delay: <number>this.configurationService.getValue('workbench.hover.delay')
 			}
 		}));

--- a/src/vs/workbench/contrib/extensions/browser/extensionFeaturesTab.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionFeaturesTab.ts
@@ -292,7 +292,7 @@ class RuntimeStatusMarkdownRenderer extends Disposable implements IExtensionFeat
 				highlightCircle.style.display = 'block';
 				tooltip.style.left = `${closestPoint.x + 24}px`;
 				tooltip.style.top = `${closestPoint.y + 14}px`;
-				hoverDisposable.value = this.hoverService.showHover({
+				hoverDisposable.value = this.hoverService.showInstantHover({
 					content: new MarkdownString(`${closestPoint.date}: ${closestPoint.count} requests`),
 					target: tooltip,
 					appearance: {

--- a/src/vs/workbench/contrib/extensions/browser/extensionsWidgets.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionsWidgets.ts
@@ -555,7 +555,7 @@ export class ExtensionHoverWidget extends ExtensionWidget {
 			this.hover.value = this.hoverService.setupManagedHover({
 				delay: this.configurationService.getValue<number>('workbench.hover.delay'),
 				showHover: (options, focus) => {
-					return this.hoverService.showHover({
+					return this.hoverService.showInstantHover({
 						...options,
 						additionalClasses: ['extension-hover'],
 						position: {

--- a/src/vs/workbench/contrib/notebook/browser/view/cellParts/cellStatusPart.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/cellParts/cellStatusPart.ts
@@ -79,7 +79,7 @@ export class CellEditorStatusBar extends CellContentPart {
 			readonly showHover = (options: IHoverDelegateOptions) => {
 				options.position = options.position ?? {};
 				options.position.hoverPosition = HoverPosition.ABOVE;
-				return hoverService.showHover(options);
+				return hoverService.showInstantHover(options);
 			};
 
 			readonly placement = 'element';

--- a/src/vs/workbench/contrib/preferences/browser/settingsEditorSettingIndicators.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsEditorSettingIndicators.ts
@@ -145,7 +145,7 @@ export class SettingsTreeIndicatorsLabel implements IDisposable {
 
 		const content = localize('trustLabel', "The setting value can only be applied in a trusted workspace.");
 		const showHover = (focus: boolean) => {
-			return this.hoverService.showHover({
+			return this.hoverService.showInstantHover({
 				...this.defaultHoverOptions,
 				content,
 				target: workspaceTrustElement,
@@ -186,7 +186,7 @@ export class SettingsTreeIndicatorsLabel implements IDisposable {
 
 		const syncIgnoredHoverContent = localize('syncIgnoredTitle', "This setting is ignored during sync");
 		const showHover = (focus: boolean) => {
-			return this.hoverService.showHover({
+			return this.hoverService.showInstantHover({
 				...this.defaultHoverOptions,
 				content: syncIgnoredHoverContent,
 				target: syncIgnoredElement
@@ -329,7 +329,7 @@ export class SettingsTreeIndicatorsLabel implements IDisposable {
 
 		const content = isPreviewSetting ? PREVIEW_INDICATOR_DESCRIPTION : EXPERIMENTAL_INDICATOR_DESCRIPTION;
 		const showHover = (focus: boolean) => {
-			return this.hoverService.showHover({
+			return this.hoverService.showInstantHover({
 				...this.defaultHoverOptions,
 				content,
 				target: this.previewIndicator.element
@@ -374,7 +374,7 @@ export class SettingsTreeIndicatorsLabel implements IDisposable {
 			this.scopeOverridesIndicator.label.text = '$(briefcase) ' + localize('policyLabelText', "Managed by organization");
 			const content = localize('policyDescription', "This setting is managed by your organization and its actual value cannot be changed.");
 			const showHover = (focus: boolean) => {
-				return this.hoverService.showHover({
+				return this.hoverService.showInstantHover({
 					...this.defaultHoverOptions,
 					content,
 					actions: [{
@@ -396,7 +396,7 @@ export class SettingsTreeIndicatorsLabel implements IDisposable {
 
 			const content = localize('applicationSettingDescription', "The setting is not specific to the current profile, and will retain its value when switching profiles.");
 			const showHover = (focus: boolean) => {
-				return this.hoverService.showHover({
+				return this.hoverService.showInstantHover({
 					...this.defaultHoverOptions,
 					content,
 					target: this.scopeOverridesIndicator.element
@@ -512,7 +512,7 @@ export class SettingsTreeIndicatorsLabel implements IDisposable {
 			}
 
 			const showHover = (focus: boolean) => {
-				return this.hoverService.showHover({
+				return this.hoverService.showInstantHover({
 					content: new MarkdownString().appendMarkdown(defaultOverrideHoverContent),
 					target: this.defaultOverrideIndicator.element,
 					position: {

--- a/src/vs/workbench/contrib/terminal/browser/terminalIconPicker.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalIconPicker.ts
@@ -58,7 +58,7 @@ export class TerminalIconPicker extends Disposable {
 				this._iconSelectBox.dispose();
 			}));
 			this._iconSelectBox.clearInput();
-			const hoverWidget = this._hoverService.showHover({
+			const hoverWidget = this._hoverService.showInstantHover({
 				content: this._iconSelectBox.domNode,
 				target: getActiveDocument().body,
 				position: {

--- a/src/vs/workbench/contrib/terminal/browser/terminalTabbedView.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalTabbedView.ts
@@ -458,7 +458,7 @@ export class TerminalTabbedView extends Disposable {
 		if (!instance) {
 			return;
 		}
-		this._hoverService.showHover({
+		this._hoverService.showInstantHover({
 			...getInstanceHoverInfo(instance),
 			target: this._terminalContainer,
 			trapFocus: true

--- a/src/vs/workbench/contrib/terminal/browser/terminalTabsList.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalTabsList.ts
@@ -229,7 +229,7 @@ export class TerminalTabList extends WorkbenchList<ITerminalInstance> {
 			return;
 		}
 
-		this._hoverService.showHover({
+		this._hoverService.showInstantHover({
 			...getInstanceHoverInfo(instance),
 			target: this.getHTMLElement(),
 			trapFocus: true

--- a/src/vs/workbench/contrib/terminal/browser/terminalView.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalView.ts
@@ -676,7 +676,7 @@ class SingleTabHoverDelegate implements IHoverDelegate {
 			return;
 		}
 		const hoverInfo = getInstanceHoverInfo(instance);
-		return this._hoverService.showHover({
+		return this._hoverService.showInstantHover({
 			...options,
 			content: hoverInfo.content,
 			actions: hoverInfo.actions

--- a/src/vs/workbench/contrib/terminal/browser/widgets/terminalHoverWidget.ts
+++ b/src/vs/workbench/contrib/terminal/browser/widgets/terminalHoverWidget.ts
@@ -44,7 +44,7 @@ export class TerminalHover extends Disposable implements ITerminalWidget {
 			return;
 		}
 		const target = new CellHoverTarget(container, this._targetOptions);
-		const hover = this._hoverService.showHover({
+		const hover = this._hoverService.showInstantHover({
 			target,
 			content: this._text,
 			actions: this._actions,

--- a/src/vs/workbench/contrib/userDataProfile/browser/userDataProfilesEditor.ts
+++ b/src/vs/workbench/contrib/userDataProfile/browser/userDataProfilesEditor.ts
@@ -1047,7 +1047,7 @@ class ProfileIconRenderer extends ProfilePropertyRenderer {
 				return;
 			}
 			iconSelectBox.clearInput();
-			hoverWidget = this.hoverService.showHover({
+			hoverWidget = this.hoverService.showInstantHover({
 				content: iconSelectBox.domNode,
 				target: iconElement,
 				position: {


### PR DESCRIPTION
This rename and moving the interface a little lower is designed to dissuade the use of the API in favor of the delayed ones.

Part of #243348

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
