### PR TITLE
Onboard onto 1ES template's BinSkim

### DIFF
--- a/build/azure-pipelines/cli/cli-compile.yml
+++ b/build/azure-pipelines/cli/cli-compile.yml
@@ -119,22 +119,6 @@ steps:
           ArtifactServices.Symbol.UseAAD: false
         displayName: Publish Symbols
 
-      - task: CopyFiles@2
-        inputs:
-          SourceFolder: $(Build.SourcesDirectory)/cli/target/${{ parameters.VSCODE_CLI_TARGET }}/release
-          Contents: 'code.*'
-          TargetFolder: $(Agent.TempDirectory)/binskim-cli
-        displayName: Copy files for BinSkim
-
-      - task: BinSkim@4
-        inputs:
-          InputType: Basic
-          Function: analyze
-          TargetPattern: guardianGlob
-          AnalyzeTargetGlob: $(Agent.TempDirectory)/binskim-cli/*.*
-          AnalyzeSymPath: $(Agent.TempDirectory)/binskim-cli
-        displayName: Run BinSkim
-
       - powershell: |
           . build/azure-pipelines/win32/exec.ps1
           $ErrorActionPreference = "Stop"

--- a/build/azure-pipelines/product-build.yml
+++ b/build/azure-pipelines/product-build.yml
@@ -167,7 +167,7 @@ extends:
   parameters:
     sdl:
       tsa:
-        enabled: true
+        enabled: false
         configFile: $(Build.SourcesDirectory)/build/azure-pipelines/config/tsaoptions.json
       binskim:
         analyzeTargetGlob: '+:file|**\*.exe;-:file|**\VSCodeSetup*.exe'

--- a/build/azure-pipelines/product-build.yml
+++ b/build/azure-pipelines/product-build.yml
@@ -167,7 +167,7 @@ extends:
   parameters:
     sdl:
       tsa:
-        enabled: false
+        enabled: true
         configFile: $(Build.SourcesDirectory)/build/azure-pipelines/config/tsaoptions.json
       binskim:
         analyzeTargetGlob: '+:file|$(Agent.BuildDirectory)/VSCode-*/**/*.exe;+:file|$(Agent.BuildDirectory)/VSCode-*/**/*.node;+:file|$(Agent.BuildDirectory)/VSCode-*/**/*.dll;-:file|**/VSCodeSetup*.exe'

--- a/build/azure-pipelines/product-build.yml
+++ b/build/azure-pipelines/product-build.yml
@@ -170,7 +170,7 @@ extends:
         enabled: false
         configFile: $(Build.SourcesDirectory)/build/azure-pipelines/config/tsaoptions.json
       binskim:
-        analyzeTargetGlob: '+:file|**\*.exe;-:file|**\VSCodeSetup*.exe'
+        analyzeTargetGlob: '+:file|$(Agent.BuildDirectory)/VSCode-*/**/*.exe;-:file|**/VSCodeSetup*.exe'
       codeql:
         runSourceLanguagesInSourceAnalysis: true
         compiled:

--- a/build/azure-pipelines/product-build.yml
+++ b/build/azure-pipelines/product-build.yml
@@ -170,7 +170,7 @@ extends:
         enabled: false
         configFile: $(Build.SourcesDirectory)/build/azure-pipelines/config/tsaoptions.json
       binskim:
-        analyzeTargetGlob: '+:file|$(Agent.BuildDirectory)/VSCode-*/**/*.exe;-:file|**/VSCodeSetup*.exe'
+        analyzeTargetGlob: '+:file|$(Agent.BuildDirectory)/VSCode-*/**/*.exe;+:file|$(Agent.BuildDirectory)/VSCode-*/**/*.node;+:file|$(Agent.BuildDirectory)/VSCode-*/**/*.dll;-:file|**/VSCodeSetup*.exe'
       codeql:
         runSourceLanguagesInSourceAnalysis: true
         compiled:

--- a/build/azure-pipelines/product-build.yml
+++ b/build/azure-pipelines/product-build.yml
@@ -169,6 +169,8 @@ extends:
       tsa:
         enabled: true
         configFile: $(Build.SourcesDirectory)/build/azure-pipelines/config/tsaoptions.json
+      binskim:
+        analyzeTargetGlob: '+:file|**\*.exe;-:file|**\VSCodeSetup*.exe'
       codeql:
         runSourceLanguagesInSourceAnalysis: true
         compiled:

--- a/build/azure-pipelines/product-build.yml
+++ b/build/azure-pipelines/product-build.yml
@@ -318,13 +318,13 @@ extends:
                       VSCODE_BUILD_WIN32_ARM64: ${{ parameters.VSCODE_BUILD_WIN32_ARM64 }}
 
       - ${{ if and(eq(variables['VSCODE_CIBUILD'], false), eq(parameters.VSCODE_COMPILE_ONLY, false)) }}:
-        - stage: CustomSDL
+        - stage: APIScan
           dependsOn: []
           pool:
             name: 1es-windows-2019-x64
             os: windows
           jobs:
-            - job: WindowsSDL
+            - job: WindowsAPIScan
               steps:
                 - template: build/azure-pipelines/win32/sdl-scan-win32.yml@self
                   parameters:

--- a/build/azure-pipelines/win32/product-build-win32.yml
+++ b/build/azure-pipelines/win32/product-build-win32.yml
@@ -145,7 +145,7 @@ steps:
         exec { npm run gulp "vscode-win32-$(VSCODE_ARCH)-min-ci" }
         exec { npm run gulp "vscode-win32-$(VSCODE_ARCH)-inno-updater" }
         echo "##vso[task.setvariable variable=BUILT_CLIENT]true"
-        echo "##vso[task.setvariable variable=CodeSigningFolderPath]$(agent.builddirectory)/VSCode-win32-$(VSCODE_ARCH)"
+        echo "##vso[task.setvariable variable=CodeSigningFolderPath]$(Agent.BuildDirectory)/VSCode-win32-$(VSCODE_ARCH)"
       env:
         GITHUB_TOKEN: "$(github-distro-mixin-password)"
       displayName: Build client
@@ -156,7 +156,7 @@ steps:
         exec { npm run gulp "vscode-reh-win32-$(VSCODE_ARCH)-min-ci" }
         mv ..\vscode-reh-win32-$(VSCODE_ARCH) ..\vscode-server-win32-$(VSCODE_ARCH) # TODO@joaomoreno
         echo "##vso[task.setvariable variable=BUILT_SERVER]true"
-        echo "##vso[task.setvariable variable=CodeSigningFolderPath]$(CodeSigningFolderPath),$(agent.builddirectory)/vscode-server-win32-$(VSCODE_ARCH)"
+        echo "##vso[task.setvariable variable=CodeSigningFolderPath]$(CodeSigningFolderPath),$(Agent.BuildDirectory)/vscode-server-win32-$(VSCODE_ARCH)"
       env:
         GITHUB_TOKEN: "$(github-distro-mixin-password)"
       displayName: Build server
@@ -196,10 +196,10 @@ steps:
           $ErrorActionPreference = "Stop"
           $ArtifactName = (gci -Path "$(Build.ArtifactStagingDirectory)/cli" | Select-Object -last 1).FullName
           Expand-Archive -Path $ArtifactName -DestinationPath "$(Build.ArtifactStagingDirectory)/cli"
-          $AppProductJson = Get-Content -Raw -Path "$(agent.builddirectory)\VSCode-win32-$(VSCODE_ARCH)\resources\app\product.json" | ConvertFrom-Json
+          $AppProductJson = Get-Content -Raw -Path "$(Agent.BuildDirectory)\VSCode-win32-$(VSCODE_ARCH)\resources\app\product.json" | ConvertFrom-Json
           $CliAppName = $AppProductJson.tunnelApplicationName
           $AppName = $AppProductJson.applicationName
-          Move-Item -Path "$(Build.ArtifactStagingDirectory)/cli/$AppName.exe" -Destination "$(agent.builddirectory)/VSCode-win32-$(VSCODE_ARCH)/bin/$CliAppName.exe"
+          Move-Item -Path "$(Build.ArtifactStagingDirectory)/cli/$AppName.exe" -Destination "$(Agent.BuildDirectory)/VSCode-win32-$(VSCODE_ARCH)/bin/$CliAppName.exe"
         displayName: Move VS Code CLI
 
       - task: UseDotNet@2

--- a/build/azure-pipelines/win32/sdl-scan-win32.yml
+++ b/build/azure-pipelines/win32/sdl-scan-win32.yml
@@ -102,13 +102,6 @@ steps:
   - powershell: npm run compile
     displayName: Compile
 
-  - powershell: |
-      Get-ChildItem '$(Build.SourcesDirectory)' -Recurse -Filter "*.exe"
-      Get-ChildItem '$(Build.SourcesDirectory)' -Recurse -Filter "*.dll"
-      Get-ChildItem '$(Build.SourcesDirectory)' -Recurse -Filter "*.node"
-      Get-ChildItem '$(Build.SourcesDirectory)' -Recurse -Filter "*.pdb"
-    displayName: List files
-
   - powershell: npm run gulp "vscode-symbols-win32-${{ parameters.VSCODE_ARCH }}"
     env:
       GITHUB_TOKEN: "$(github-distro-mixin-password)"
@@ -119,16 +112,16 @@ steps:
       Get-ChildItem '$(Agent.BuildDirectory)\scanbin' -Recurse -Filter "*.dll"
       Get-ChildItem '$(Agent.BuildDirectory)\scanbin' -Recurse -Filter "*.node"
       Get-ChildItem '$(Agent.BuildDirectory)\scanbin' -Recurse -Filter "*.pdb"
-    displayName: List files again
+    displayName: List files
 
-  - task: BinSkim@4
-    inputs:
-      InputType: "Basic"
-      Function: "analyze"
-      TargetPattern: "guardianGlob"
-      AnalyzeIgnorePdbLoadError: true
-      AnalyzeTargetGlob: '$(Agent.BuildDirectory)\scanbin\**.dll;$(Agent.BuildDirectory)\scanbin\**.exe;$(Agent.BuildDirectory)\scanbin\**.node'
-      AnalyzeLocalSymbolDirectories: '$(Agent.BuildDirectory)\scanbin\VSCode-win32-${{ parameters.VSCODE_ARCH }}\pdb'
+  # - task: BinSkim@4
+  #   inputs:
+  #     InputType: "Basic"
+  #     Function: "analyze"
+  #     TargetPattern: "guardianGlob"
+  #     AnalyzeIgnorePdbLoadError: true
+  #     AnalyzeTargetGlob: '$(Agent.BuildDirectory)\scanbin\**.dll;$(Agent.BuildDirectory)\scanbin\**.exe;$(Agent.BuildDirectory)\scanbin\**.node'
+  #     AnalyzeLocalSymbolDirectories: '$(Agent.BuildDirectory)\scanbin\VSCode-win32-${{ parameters.VSCODE_ARCH }}\pdb'
 
   - task: CopyFiles@2
     displayName: 'Collect Symbols for API Scan'
@@ -139,18 +132,18 @@ steps:
       flattenFolders: true
     condition: succeeded()
 
-  - task: PublishSymbols@2
-    inputs:
-      IndexSources: false
-      SymbolsFolder: '$(Agent.BuildDirectory)\symbols'
-      SearchPattern: '**\*.pdb'
-      SymbolServerType: TeamServices
-      SymbolsProduct: 'code'
-      ArtifactServices.Symbol.AccountName: microsoft
-      ArtifactServices.Symbol.PAT: $(System.AccessToken)
-      ArtifactServices.Symbol.UseAAD: false
-    displayName: Publish Symbols
-    condition: succeeded()
+  # - task: PublishSymbols@2
+  #   inputs:
+  #     IndexSources: false
+  #     SymbolsFolder: '$(Agent.BuildDirectory)\symbols'
+  #     SearchPattern: '**\*.pdb'
+  #     SymbolServerType: TeamServices
+  #     SymbolsProduct: 'code'
+  #     ArtifactServices.Symbol.AccountName: microsoft
+  #     ArtifactServices.Symbol.PAT: $(System.AccessToken)
+  #     ArtifactServices.Symbol.UseAAD: false
+  #   displayName: Publish Symbols
+  #   condition: succeeded()
 
   - task: APIScan@2
     inputs:

--- a/build/azure-pipelines/win32/sdl-scan-win32.yml
+++ b/build/azure-pipelines/win32/sdl-scan-win32.yml
@@ -114,15 +114,6 @@ steps:
       Get-ChildItem '$(Agent.BuildDirectory)\scanbin' -Recurse -Filter "*.pdb"
     displayName: List files
 
-  # - task: BinSkim@4
-  #   inputs:
-  #     InputType: "Basic"
-  #     Function: "analyze"
-  #     TargetPattern: "guardianGlob"
-  #     AnalyzeIgnorePdbLoadError: true
-  #     AnalyzeTargetGlob: '$(Agent.BuildDirectory)\scanbin\**.dll;$(Agent.BuildDirectory)\scanbin\**.exe;$(Agent.BuildDirectory)\scanbin\**.node'
-  #     AnalyzeLocalSymbolDirectories: '$(Agent.BuildDirectory)\scanbin\VSCode-win32-${{ parameters.VSCODE_ARCH }}\pdb'
-
   - task: CopyFiles@2
     displayName: 'Collect Symbols for API Scan'
     inputs:
@@ -131,19 +122,6 @@ steps:
       TargetFolder: '$(Agent.BuildDirectory)\symbols'
       flattenFolders: true
     condition: succeeded()
-
-  # - task: PublishSymbols@2
-  #   inputs:
-  #     IndexSources: false
-  #     SymbolsFolder: '$(Agent.BuildDirectory)\symbols'
-  #     SearchPattern: '**\*.pdb'
-  #     SymbolServerType: TeamServices
-  #     SymbolsProduct: 'code'
-  #     ArtifactServices.Symbol.AccountName: microsoft
-  #     ArtifactServices.Symbol.PAT: $(System.AccessToken)
-  #     ArtifactServices.Symbol.UseAAD: false
-  #   displayName: Publish Symbols
-  #   condition: succeeded()
 
   - task: APIScan@2
     inputs:


### PR DESCRIPTION
This PR onboards the VS Code pipeline onto the 1ES template's BinSkim task instead of using our own BinSkim tasks. As a result, we obtain more accurate and up-to-date BinSkim results and can exclude false positives from the scan more easily.

This PR also renames the CustomSDL stage back to APIScan now that APIScan is the only scan that runs in that stage.

I have confirmed that we do not need the symbol publishing task in the APIScan stage for the product build BinSkim tasks, and that we do not need to move the sdl-scan-win32.yml's "Create include.gypi" task over to the Windows product build stage.

Verification build: https://dev.azure.com/monacotools/Monaco/_build/results?buildId=324410&view=results
