### PR TITLE
mcp: warn on invalid properties, automatically migrate any 'mcpServers'

### DIFF
--- a/src/vs/platform/mcp/common/mcpPlatformTypes.ts
+++ b/src/vs/platform/mcp/common/mcpPlatformTypes.ts
@@ -5,6 +5,8 @@
 
 export interface IMcpConfiguration {
 	inputs: unknown[];
+	/** @deprecated Only for rough cross-compat with other formats */
+	mcpServers?: Record<string, IMcpConfigurationServer>;
 	servers: Record<string, IMcpConfigurationServer>;
 }
 

--- a/src/vs/workbench/contrib/mcp/common/discovery/configMcpDiscovery.ts
+++ b/src/vs/workbench/contrib/mcp/common/discovery/configMcpDiscovery.ts
@@ -91,7 +91,14 @@ export class ConfigMcpDiscovery extends Disposable implements IMcpDiscovery {
 
 		for (const src of this.configSources) {
 			const collectionId = `mcp.config.${src.key}`;
-			const value = configurationKey[src.key];
+			let value = configurationKey[src.key];
+
+			// If we see there are MCP servers, migrate them automatically
+			if (value?.mcpServers) {
+				value = { ...value, servers: { ...value.servers, ...value.mcpServers }, mcpServers: undefined };
+				this._configurationService.updateValue(mcpConfigurationSection, value, {}, src.target, { donotNotifyError: true });
+			}
+
 			const nextDefinitions = Object.entries(value?.servers || {}).map(([name, value]): McpServerDefinition => ({
 				id: `${collectionId}.${name}`,
 				label: name,

--- a/src/vs/workbench/contrib/mcp/common/mcpConfiguration.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpConfiguration.ts
@@ -32,6 +32,7 @@ export const mcpServerSchema: IJSONSchema = {
 	title: localize('app.mcp.json.title', "Model Context Protocol Servers"),
 	allowTrailingCommas: true,
 	allowComments: true,
+	additionalProperties: false,
 	properties: {
 		servers: {
 			examples: [mcpSchemaExampleServers],


### PR DESCRIPTION
This keeps our 'servers' key but fixes up if people paste in other editors configuration into us

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
