### PR TITLE
[prompts]: support `markdown image` links syntax

### DIFF
--- a/src/vs/editor/common/codecs/markdownCodec/markdownDecoder.ts
+++ b/src/vs/editor/common/codecs/markdownCodec/markdownDecoder.ts
@@ -12,6 +12,8 @@ import { BaseDecoder } from '../../../../base/common/codecs/baseDecoder.js';
 import { SimpleDecoder, TSimpleToken } from '../simpleCodec/simpleDecoder.js';
 import { MarkdownCommentStart, PartialMarkdownCommentStart } from './parsers/markdownComment.js';
 import { MarkdownLinkCaption, PartialMarkdownLink, PartialMarkdownLinkCaption } from './parsers/markdownLink.js';
+import { ExclamationMark } from '../simpleCodec/tokens/exclamationMark.js';
+import { PartialMarkdownImage } from './parsers/markdownImage.js';
 
 /**
  * Tokens handled by this decoder.
@@ -28,7 +30,8 @@ export class MarkdownDecoder extends BaseDecoder<TMarkdownToken, TSimpleToken> {
 	 */
 	private current?:
 		PartialMarkdownLinkCaption | MarkdownLinkCaption | PartialMarkdownLink |
-		PartialMarkdownCommentStart | MarkdownCommentStart;
+		PartialMarkdownCommentStart | MarkdownCommentStart |
+		PartialMarkdownImage;
 
 	constructor(
 		stream: ReadableStream<VSBuffer>,
@@ -37,7 +40,7 @@ export class MarkdownDecoder extends BaseDecoder<TMarkdownToken, TSimpleToken> {
 	}
 
 	protected override onStreamData(token: TSimpleToken): void {
-		// markdown links start with `[` character, so here we can
+		// `markdown links` start with `[` character, so here we can
 		// initiate the process of parsing a markdown link
 		if (token instanceof LeftBracket && !this.current) {
 			this.current = new PartialMarkdownLinkCaption(token);
@@ -45,8 +48,18 @@ export class MarkdownDecoder extends BaseDecoder<TMarkdownToken, TSimpleToken> {
 			return;
 		}
 
+		// `markdown comments` start with `<` character, so here we can
+		// initiate the process of parsing a markdown comment
 		if (token instanceof LeftAngleBracket && !this.current) {
 			this.current = new PartialMarkdownCommentStart(token);
+
+			return;
+		}
+
+		// `markdown image links` start with `!` character, so here we can
+		// initiate the process of parsing a markdown image
+		if (token instanceof ExclamationMark && !this.current) {
+			this.current = new PartialMarkdownImage(token);
 
 			return;
 		}

--- a/src/vs/editor/common/codecs/markdownCodec/parsers/markdownImage.ts
+++ b/src/vs/editor/common/codecs/markdownCodec/parsers/markdownImage.ts
@@ -1,0 +1,99 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { MarkdownLink } from '../tokens/markdownLink.js';
+import { MarkdownImage } from '../tokens/markdownImage.js';
+import { TSimpleToken } from '../../simpleCodec/simpleDecoder.js';
+import { LeftBracket } from '../../simpleCodec/tokens/brackets.js';
+import { ExclamationMark } from '../../simpleCodec/tokens/exclamationMark.js';
+import { assertNotConsumed, ParserBase, TAcceptTokenResult } from '../../simpleCodec/parserBase.js';
+import { MarkdownLinkCaption, PartialMarkdownLink, PartialMarkdownLinkCaption } from './markdownLink.js';
+
+/**
+ * The parser responsible for parsing the `<!--` sequence - the start of a `markdown comment`.
+ * TODO: @lego - update the docs
+ */
+export class PartialMarkdownImage extends ParserBase<TSimpleToken, PartialMarkdownImage | MarkdownImage> {
+	/**
+	 * TODO: @lego
+	 */
+	private markdownLinkParser: PartialMarkdownLinkCaption | MarkdownLinkCaption | PartialMarkdownLink | undefined;
+
+	constructor(token: ExclamationMark) {
+		super([token]);
+	}
+
+	/**
+	 * TODO: @lego - implement
+	 */
+	public override get tokens(): readonly TSimpleToken[] {
+		const linkTokens = this.markdownLinkParser?.tokens ?? [];
+
+		return [
+			...this.currentTokens,
+			...linkTokens,
+		];
+	}
+
+	@assertNotConsumed
+	public accept(token: TSimpleToken): TAcceptTokenResult<PartialMarkdownImage | MarkdownImage> {
+		// on the first call we expect a character that begins `markdown link` sequence
+		// hence we initiate the markdown link parsing process, otherwise we fail
+		if (!this.markdownLinkParser) {
+			if (token instanceof LeftBracket) {
+				this.markdownLinkParser = new PartialMarkdownLinkCaption(token);
+
+				return {
+					result: 'success',
+					nextParser: this,
+					wasTokenConsumed: true,
+				};
+			}
+
+			return {
+				result: 'failure',
+				wasTokenConsumed: false,
+			};
+		}
+
+		// handle subsequent tokens next
+
+		const acceptResult = this.markdownLinkParser.accept(token);
+		const { result, wasTokenConsumed } = acceptResult;
+
+		if (result === 'success') {
+			const { nextParser } = acceptResult;
+
+			// if full markdown link was parsed out, the process completes
+			if (nextParser instanceof MarkdownLink) {
+				this.isConsumed = true;
+
+				const firstToken = this.currentTokens[0];
+				return {
+					result,
+					wasTokenConsumed,
+					nextParser: new MarkdownImage(
+						firstToken.range.startLineNumber,
+						firstToken.range.startColumn,
+						`${firstToken.text}${nextParser.caption}`,
+						nextParser.reference,
+					),
+				};
+			}
+
+			// otherwise save new link parser reference and continue
+			this.markdownLinkParser = nextParser;
+			return {
+				result,
+				wasTokenConsumed,
+				nextParser: this,
+			};
+		}
+
+		// return the failure result
+		this.isConsumed = true;
+		return acceptResult;
+	}
+}

--- a/src/vs/editor/common/codecs/markdownCodec/tokens/markdownImage.ts
+++ b/src/vs/editor/common/codecs/markdownCodec/tokens/markdownImage.ts
@@ -9,32 +9,32 @@ import { IRange, Range } from '../../../core/range.js';
 import { assert } from '../../../../../base/common/assert.js';
 
 /**
- * A token that represent a `markdown link` with a `range`. The `range`
+ * A token that represent a `markdown image` with a `range`. The `range`
  * value reflects the position of the token in the original data.
  */
-export class MarkdownLink extends MarkdownToken {
+export class MarkdownImage extends MarkdownToken {
 	/**
-	 * Check if this `markdown link` points to a valid URL address.
+	 * Check if this `markdown image link` points to a valid URL address.
 	 */
 	public readonly isURL: boolean;
 
 	constructor(
 		/**
-		 * The starting line number of the link (1-based indexing).
+		 * The starting line number of the image (1-based indexing).
 		 */
 		lineNumber: number,
 		/**
-		 * The starting column number of the link (1-based indexing).
+		 * The starting column number of the image (1-based indexing).
 		 */
 		columnNumber: number,
 		/**
-		 * The caption of the original link, including the square brackets.
+		 * The caption of the image, including the `!` and `square brackets`.
 		 */
-		public readonly caption: string,
+		private readonly caption: string,
 		/**
-		 * The reference of the original link, including the parentheses.
+		 * The reference of the image, including the parentheses.
 		 */
-		public readonly reference: string,
+		private readonly reference: string,
 	) {
 		assert(
 			!isNaN(lineNumber),
@@ -52,7 +52,12 @@ export class MarkdownLink extends MarkdownToken {
 		);
 
 		assert(
-			caption[0] === '[' && caption[caption.length - 1] === ']',
+			caption[0] === '!',
+			`The caption must start with '!' character, got "${caption}".`,
+		);
+
+		assert(
+			caption[1] === '[' && caption[caption.length - 1] === ']',
 			`The caption must be enclosed in square brackets, got "${caption}".`,
 		);
 
@@ -98,7 +103,7 @@ export class MarkdownLink extends MarkdownToken {
 			return false;
 		}
 
-		if (!(other instanceof MarkdownLink)) {
+		if (!(other instanceof MarkdownImage)) {
 			return false;
 		}
 
@@ -131,6 +136,6 @@ export class MarkdownLink extends MarkdownToken {
 	 * Returns a string representation of the token.
 	 */
 	public override toString(): string {
-		return `md-link("${this.text}")${this.range}`;
+		return `md-image("${this.text}")${this.range}`;
 	}
 }

--- a/src/vs/editor/common/codecs/simpleCodec/tokens/word.ts
+++ b/src/vs/editor/common/codecs/simpleCodec/tokens/word.ts
@@ -67,6 +67,6 @@ export class Word extends BaseToken {
 	 * Returns a string representation of the token.
 	 */
 	public override toString(): string {
-		return `word("${this.text.slice(0, 8)}")${this.range}`;
+		return `word("${this.text}")${this.range}`;
 	}
 }

--- a/src/vs/editor/test/common/codecs/markdownDecoder.test.ts
+++ b/src/vs/editor/test/common/codecs/markdownDecoder.test.ts
@@ -24,6 +24,7 @@ import { LeftBracket, RightBracket } from '../../../common/codecs/simpleCodec/to
 import { MarkdownDecoder, TMarkdownToken } from '../../../common/codecs/markdownCodec/markdownDecoder.js';
 import { LeftParenthesis, RightParenthesis } from '../../../common/codecs/simpleCodec/tokens/parentheses.js';
 import { LeftAngleBracket, RightAngleBracket } from '../../../common/codecs/simpleCodec/tokens/angleBrackets.js';
+import { MarkdownImage } from '../../../common/codecs/markdownCodec/tokens/markdownImage.js';
 
 /**
  * A reusable test utility that asserts that a `TestMarkdownDecoder` instance
@@ -363,6 +364,287 @@ suite('MarkdownDecoder', () => {
 		});
 	});
 
+
+	suite('• images', () => {
+		suite('• general', () => {
+			test('• base cases', async () => {
+				const test = testDisposables.add(
+					new TestMarkdownDecoder(),
+				);
+
+				const inputData = [
+					'\t![alt text](./some/path/to/file.jpg) ',
+					'plain text \f![label](./image.png)\v and more text',
+					// '<!-- comment\r\ntext\n\ngoes here --> usual text follows',
+					// '\t<!---->\t',
+					// 'haalo\t<!-- [link label](/some/path/to/file.md)',
+				];
+
+				await test.run(
+					inputData,
+					[
+						// `1st`
+						new Tab(new Range(1, 1, 1, 2)),
+						new MarkdownImage(1, 2, '![alt text]', '(./some/path/to/file.jpg)'),
+						new Space(new Range(1, 38, 1, 39)),
+						new NewLine(new Range(1, 39, 1, 40)),
+						// `2nd`
+						new Word(new Range(2, 1, 2, 6), 'plain'),
+						new Space(new Range(2, 6, 2, 7)),
+						new Word(new Range(2, 7, 2, 11), 'text'),
+						new Space(new Range(2, 11, 2, 12)),
+						new FormFeed(new Range(2, 12, 2, 13)),
+						new MarkdownImage(2, 13, '![label]', '(./image.png)'),
+						new VerticalTab(new Range(2, 34, 2, 35)),
+						new Space(new Range(2, 35, 2, 36)),
+						new Word(new Range(2, 36, 2, 39), 'and'),
+						new Space(new Range(2, 39, 2, 40)),
+						new Word(new Range(2, 40, 2, 44), 'more'),
+						new Space(new Range(2, 44, 2, 45)),
+						new Word(new Range(2, 45, 2, 49), 'text'),
+						// new NewLine(new Range(2, 49, 2, 50)),
+					],
+				);
+			});
+
+			// test('• nuanced', async () => {
+			// 	const test = testDisposables.add(
+			// 		new TestMarkdownDecoder(),
+			// 	);
+
+			// 	const inputData = [
+			// 		// comment inside `<>` brackets
+			// 		' \f <<!--commen\t-->>',
+			// 		// comment contains `<[]>` brackets and `!`
+			// 		'<!--<[!c⚽︎mment!]>-->\t\t',
+			// 		// comment contains `<!--` and new lines
+			// 		'\v<!--some\r\ntext\n\t<!--inner\r\ntext-->\t\t',
+			// 		// comment contains `<!--` and never closed properly
+			// 		' <!--<!--inner\r\ntext-- >\t\v\f ',
+			// 	];
+
+			// 	await test.run(
+			// 		inputData,
+			// 		[
+			// 			// `1st`
+			// 			new Space(new Range(1, 1, 1, 2)),
+			// 			new FormFeed(new Range(1, 2, 1, 3)),
+			// 			new Space(new Range(1, 3, 1, 4)),
+			// 			new LeftAngleBracket(new Range(1, 4, 1, 5)),
+			// 			new MarkdownComment(new Range(1, 5, 1, 5 + 14), '<!--commen\t-->'),
+			// 			new RightAngleBracket(new Range(1, 19, 1, 20)),
+			// 			new NewLine(new Range(1, 20, 1, 21)),
+			// 			// `2nd`
+			// 			new MarkdownComment(new Range(2, 1, 2, 1 + 21), '<!--<[!c⚽︎mment!]>-->'),
+			// 			new Tab(new Range(2, 22, 2, 23)),
+			// 			new Tab(new Range(2, 23, 2, 24)),
+			// 			new NewLine(new Range(2, 24, 2, 25)),
+			// 			// `3rd`
+			// 			new VerticalTab(new Range(3, 1, 3, 2)),
+			// 			new MarkdownComment(new Range(3, 2, 3 + 3, 1 + 7), '<!--some\r\ntext\n\t<!--inner\r\ntext-->'),
+			// 			new Tab(new Range(6, 8, 6, 9)),
+			// 			new Tab(new Range(6, 9, 6, 10)),
+			// 			new NewLine(new Range(6, 10, 6, 11)),
+			// 			// `4rd`
+			// 			new Space(new Range(7, 1, 7, 2)),
+			// 			// note! comment does not have correct closing `-->`, hence the comment extends
+			// 			//       to the end of the text, and therefore includes the \t\v\f and space at the end
+			// 			new MarkdownComment(new Range(7, 2, 8, 1 + 12), '<!--<!--inner\r\ntext-- >\t\v\f '),
+			// 		],
+			// 	);
+			// });
+		});
+
+		// suite('• broken', () => {
+		// 	test('• invalid', async () => {
+		// 		const test = testDisposables.add(
+		// 			new TestMarkdownDecoder(),
+		// 		);
+
+		// 		const inputLines = [
+		// 			// incomplete link reference with empty caption
+		// 			'[ ](./real/file path/file⇧name.md',
+		// 			// space between caption and reference is disallowed
+		// 			'[link text] (./file path/name.txt)',
+		// 		];
+
+		// 		await test.run(
+		// 			inputLines,
+		// 			[
+		// 				// `1st` line
+		// 				new LeftBracket(new Range(1, 1, 1, 2)),
+		// 				new Space(new Range(1, 2, 1, 3)),
+		// 				new RightBracket(new Range(1, 3, 1, 4)),
+		// 				new LeftParenthesis(new Range(1, 4, 1, 5)),
+		// 				new Word(new Range(1, 5, 1, 5 + 11), './real/file'),
+		// 				new Space(new Range(1, 16, 1, 17)),
+		// 				new Word(new Range(1, 17, 1, 17 + 17), 'path/file⇧name.md'),
+		// 				new NewLine(new Range(1, 34, 1, 35)),
+		// 				// `2nd` line
+		// 				new LeftBracket(new Range(2, 1, 2, 2)),
+		// 				new Word(new Range(2, 2, 2, 2 + 4), 'link'),
+		// 				new Space(new Range(2, 6, 2, 7)),
+		// 				new Word(new Range(2, 7, 2, 7 + 4), 'text'),
+		// 				new RightBracket(new Range(2, 11, 2, 12)),
+		// 				new Space(new Range(2, 12, 2, 13)),
+		// 				new LeftParenthesis(new Range(2, 13, 2, 14)),
+		// 				new Word(new Range(2, 14, 2, 14 + 6), './file'),
+		// 				new Space(new Range(2, 20, 2, 21)),
+		// 				new Word(new Range(2, 21, 2, 21 + 13), 'path/name.txt'),
+		// 				new RightParenthesis(new Range(2, 34, 2, 35)),
+		// 			],
+		// 		);
+		// 	});
+
+		// 	suite('• stop characters inside caption/reference (new lines)', () => {
+		// 		for (const stopCharacter of [CarriageReturn, NewLine]) {
+		// 			let characterName = '';
+
+		// 			if (stopCharacter === CarriageReturn) {
+		// 				characterName = '\\r';
+		// 			}
+		// 			if (stopCharacter === NewLine) {
+		// 				characterName = '\\n';
+		// 			}
+
+		// 			assert(
+		// 				characterName !== '',
+		// 				'The "characterName" must be set, got "empty line".',
+		// 			);
+
+		// 			test(`• stop character - "${characterName}"`, async () => {
+		// 				const test = testDisposables.add(
+		// 					new TestMarkdownDecoder(),
+		// 				);
+
+		// 				const inputLines = [
+		// 					// stop character inside link caption
+		// 					`[haa${stopCharacter.symbol}loů](./real/💁/name.txt)`,
+		// 					// stop character inside link reference
+		// 					`[ref text](/etc/pat${stopCharacter.symbol}h/to/file.md)`,
+		// 					// stop character between line caption and link reference is disallowed
+		// 					`[text]${stopCharacter.symbol}(/etc/ path/file.md)`,
+		// 				];
+
+
+		// 				await test.run(
+		// 					inputLines,
+		// 					[
+		// 						// `1st` input line
+		// 						new LeftBracket(new Range(1, 1, 1, 2)),
+		// 						new Word(new Range(1, 2, 1, 2 + 3), 'haa'),
+		// 						new stopCharacter(new Range(1, 5, 1, 6)), // <- stop character
+		// 						new Word(new Range(2, 1, 2, 1 + 3), 'loů'),
+		// 						new RightBracket(new Range(2, 4, 2, 5)),
+		// 						new LeftParenthesis(new Range(2, 5, 2, 6)),
+		// 						new Word(new Range(2, 6, 2, 6 + 18), './real/💁/name.txt'),
+		// 						new RightParenthesis(new Range(2, 24, 2, 25)),
+		// 						new NewLine(new Range(2, 25, 2, 26)),
+		// 						// `2nd` input line
+		// 						new LeftBracket(new Range(3, 1, 3, 2)),
+		// 						new Word(new Range(3, 2, 3, 2 + 3), 'ref'),
+		// 						new Space(new Range(3, 5, 3, 6)),
+		// 						new Word(new Range(3, 6, 3, 6 + 4), 'text'),
+		// 						new RightBracket(new Range(3, 10, 3, 11)),
+		// 						new LeftParenthesis(new Range(3, 11, 3, 12)),
+		// 						new Word(new Range(3, 12, 3, 12 + 8), '/etc/pat'),
+		// 						new stopCharacter(new Range(3, 20, 3, 21)), // <- stop character
+		// 						new Word(new Range(4, 1, 4, 1 + 12), 'h/to/file.md'),
+		// 						new RightParenthesis(new Range(4, 13, 4, 14)),
+		// 						new NewLine(new Range(4, 14, 4, 15)),
+		// 						// `3nd` input line
+		// 						new LeftBracket(new Range(5, 1, 5, 2)),
+		// 						new Word(new Range(5, 2, 5, 2 + 4), 'text'),
+		// 						new RightBracket(new Range(5, 6, 5, 7)),
+		// 						new stopCharacter(new Range(5, 7, 5, 8)), // <- stop character
+		// 						new LeftParenthesis(new Range(6, 1, 6, 2)),
+		// 						new Word(new Range(6, 2, 6, 2 + 5), '/etc/'),
+		// 						new Space(new Range(6, 7, 6, 8)),
+		// 						new Word(new Range(6, 8, 6, 8 + 12), 'path/file.md'),
+		// 						new RightParenthesis(new Range(6, 20, 6, 21)),
+		// 					],
+		// 				);
+		// 			});
+		// 		}
+		// 	});
+
+		// 	/**
+		// 	 * Same as above but these stop characters do not move the caret to the next line.
+		// 	 */
+		// 	suite('• stop characters inside caption/reference (same line)', () => {
+		// 		for (const stopCharacter of [VerticalTab, FormFeed]) {
+		// 			let characterName = '';
+
+		// 			if (stopCharacter === VerticalTab) {
+		// 				characterName = '\\v';
+		// 			}
+		// 			if (stopCharacter === FormFeed) {
+		// 				characterName = '\\f';
+		// 			}
+
+		// 			assert(
+		// 				characterName !== '',
+		// 				'The "characterName" must be set, got "empty line".',
+		// 			);
+
+		// 			test(`• stop character - "${characterName}"`, async () => {
+		// 				const test = testDisposables.add(
+		// 					new TestMarkdownDecoder(),
+		// 				);
+
+		// 				const inputLines = [
+		// 					// stop character inside link caption
+		// 					`[haa${stopCharacter.symbol}loů](./real/💁/name.txt)`,
+		// 					// stop character inside link reference
+		// 					`[ref text](/etc/pat${stopCharacter.symbol}h/to/file.md)`,
+		// 					// stop character between line caption and link reference is disallowed
+		// 					`[text]${stopCharacter.symbol}(/etc/ path/file.md)`,
+		// 				];
+
+
+		// 				await test.run(
+		// 					inputLines,
+		// 					[
+		// 						// `1st` input line
+		// 						new LeftBracket(new Range(1, 1, 1, 2)),
+		// 						new Word(new Range(1, 2, 1, 2 + 3), 'haa'),
+		// 						new stopCharacter(new Range(1, 5, 1, 6)), // <- stop character
+		// 						new Word(new Range(1, 6, 1, 6 + 3), 'loů'),
+		// 						new RightBracket(new Range(1, 9, 1, 10)),
+		// 						new LeftParenthesis(new Range(1, 10, 1, 11)),
+		// 						new Word(new Range(1, 11, 1, 11 + 18), './real/💁/name.txt'),
+		// 						new RightParenthesis(new Range(1, 29, 1, 30)),
+		// 						new NewLine(new Range(1, 30, 1, 31)),
+		// 						// `2nd` input line
+		// 						new LeftBracket(new Range(2, 1, 2, 2)),
+		// 						new Word(new Range(2, 2, 2, 2 + 3), 'ref'),
+		// 						new Space(new Range(2, 5, 2, 6)),
+		// 						new Word(new Range(2, 6, 2, 6 + 4), 'text'),
+		// 						new RightBracket(new Range(2, 10, 2, 11)),
+		// 						new LeftParenthesis(new Range(2, 11, 2, 12)),
+		// 						new Word(new Range(2, 12, 2, 12 + 8), '/etc/pat'),
+		// 						new stopCharacter(new Range(2, 20, 2, 21)), // <- stop character
+		// 						new Word(new Range(2, 21, 2, 21 + 12), 'h/to/file.md'),
+		// 						new RightParenthesis(new Range(2, 33, 2, 34)),
+		// 						new NewLine(new Range(2, 34, 2, 35)),
+		// 						// `3nd` input line
+		// 						new LeftBracket(new Range(3, 1, 3, 2)),
+		// 						new Word(new Range(3, 2, 3, 2 + 4), 'text'),
+		// 						new RightBracket(new Range(3, 6, 3, 7)),
+		// 						new stopCharacter(new Range(3, 7, 3, 8)), // <- stop character
+		// 						new LeftParenthesis(new Range(3, 8, 3, 9)),
+		// 						new Word(new Range(3, 9, 3, 9 + 5), '/etc/'),
+		// 						new Space(new Range(3, 14, 3, 15)),
+		// 						new Word(new Range(3, 15, 3, 15 + 12), 'path/file.md'),
+		// 						new RightParenthesis(new Range(3, 27, 3, 28)),
+		// 					],
+		// 				);
+		// 			});
+		// 		}
+		// 	});
+		// });
+	});
+
 	suite('• comments', () => {
 		suite('• general', () => {
 			test('• base cases', async () => {
@@ -472,7 +754,6 @@ suite('MarkdownDecoder', () => {
 				);
 			});
 		});
-
 
 		test('• invalid', async () => {
 			const test = testDisposables.add(

--- a/src/vs/editor/test/common/codecs/markdownDecoder.test.ts
+++ b/src/vs/editor/test/common/codecs/markdownDecoder.test.ts
@@ -375,9 +375,7 @@ suite('MarkdownDecoder', () => {
 				const inputData = [
 					'\t![alt text](./some/path/to/file.jpg) ',
 					'plain text \f![label](./image.png)\v and more text',
-					// '<!-- comment\r\ntext\n\ngoes here --> usual text follows',
-					// '\t<!---->\t',
-					// 'haalo\t<!-- [link label](/some/path/to/file.md)',
+					'![](/var/images/default) following text',
 				];
 
 				await test.run(
@@ -402,247 +400,54 @@ suite('MarkdownDecoder', () => {
 						new Word(new Range(2, 40, 2, 44), 'more'),
 						new Space(new Range(2, 44, 2, 45)),
 						new Word(new Range(2, 45, 2, 49), 'text'),
-						// new NewLine(new Range(2, 49, 2, 50)),
+						new NewLine(new Range(2, 49, 2, 50)),
+						// `3rd`
+						new MarkdownImage(3, 1, '![]', '(/var/images/default)'),
+						new Space(new Range(3, 25, 3, 26)),
+						new Word(new Range(3, 26, 3, 35), 'following'),
+						new Space(new Range(3, 35, 3, 36)),
+						new Word(new Range(3, 36, 3, 40), 'text'),
 					],
 				);
 			});
 
-			// test('• nuanced', async () => {
-			// 	const test = testDisposables.add(
-			// 		new TestMarkdownDecoder(),
-			// 	);
+			test('• nuanced', async () => {
+				const test = testDisposables.add(
+					new TestMarkdownDecoder(),
+				);
 
-			// 	const inputData = [
-			// 		// comment inside `<>` brackets
-			// 		' \f <<!--commen\t-->>',
-			// 		// comment contains `<[]>` brackets and `!`
-			// 		'<!--<[!c⚽︎mment!]>-->\t\t',
-			// 		// comment contains `<!--` and new lines
-			// 		'\v<!--some\r\ntext\n\t<!--inner\r\ntext-->\t\t',
-			// 		// comment contains `<!--` and never closed properly
-			// 		' <!--<!--inner\r\ntext-- >\t\v\f ',
-			// 	];
+				const inputData = [
+					'\t![<!-- comment -->](./s☻me/path/to/file.jpeg) ',
+					'raw text \f![(/1.png)](./image-🥸.png)\v and more text',
+					// '![](/var/images/default) following text',
+				];
 
-			// 	await test.run(
-			// 		inputData,
-			// 		[
-			// 			// `1st`
-			// 			new Space(new Range(1, 1, 1, 2)),
-			// 			new FormFeed(new Range(1, 2, 1, 3)),
-			// 			new Space(new Range(1, 3, 1, 4)),
-			// 			new LeftAngleBracket(new Range(1, 4, 1, 5)),
-			// 			new MarkdownComment(new Range(1, 5, 1, 5 + 14), '<!--commen\t-->'),
-			// 			new RightAngleBracket(new Range(1, 19, 1, 20)),
-			// 			new NewLine(new Range(1, 20, 1, 21)),
-			// 			// `2nd`
-			// 			new MarkdownComment(new Range(2, 1, 2, 1 + 21), '<!--<[!c⚽︎mment!]>-->'),
-			// 			new Tab(new Range(2, 22, 2, 23)),
-			// 			new Tab(new Range(2, 23, 2, 24)),
-			// 			new NewLine(new Range(2, 24, 2, 25)),
-			// 			// `3rd`
-			// 			new VerticalTab(new Range(3, 1, 3, 2)),
-			// 			new MarkdownComment(new Range(3, 2, 3 + 3, 1 + 7), '<!--some\r\ntext\n\t<!--inner\r\ntext-->'),
-			// 			new Tab(new Range(6, 8, 6, 9)),
-			// 			new Tab(new Range(6, 9, 6, 10)),
-			// 			new NewLine(new Range(6, 10, 6, 11)),
-			// 			// `4rd`
-			// 			new Space(new Range(7, 1, 7, 2)),
-			// 			// note! comment does not have correct closing `-->`, hence the comment extends
-			// 			//       to the end of the text, and therefore includes the \t\v\f and space at the end
-			// 			new MarkdownComment(new Range(7, 2, 8, 1 + 12), '<!--<!--inner\r\ntext-- >\t\v\f '),
-			// 		],
-			// 	);
-			// });
+				await test.run(
+					inputData,
+					[
+						// `1st`
+						new Tab(new Range(1, 1, 1, 2)),
+						new MarkdownImage(1, 2, '![<!-- comment -->]', '(./s☻me/path/to/file.jpeg)'),
+						new Space(new Range(1, 47, 1, 48)),
+						new NewLine(new Range(1, 48, 1, 49)),
+						// `2nd`
+						new Word(new Range(2, 1, 2, 4), 'raw'),
+						new Space(new Range(2, 4, 2, 5)),
+						new Word(new Range(2, 5, 2, 9), 'text'),
+						new Space(new Range(2, 9, 2, 10)),
+						new FormFeed(new Range(2, 10, 2, 11)),
+						new MarkdownImage(2, 11, '![(/1.png)]', '(./image-🥸.png)'),
+						new VerticalTab(new Range(2, 38, 2, 39)),
+						new Space(new Range(2, 39, 2, 40)),
+						new Word(new Range(2, 40, 2, 43), 'and'),
+						new Space(new Range(2, 43, 2, 44)),
+						new Word(new Range(2, 44, 2, 48), 'more'),
+						new Space(new Range(2, 48, 2, 49)),
+						new Word(new Range(2, 49, 2, 53), 'text'),
+					],
+				);
+			});
 		});
-
-		// suite('• broken', () => {
-		// 	test('• invalid', async () => {
-		// 		const test = testDisposables.add(
-		// 			new TestMarkdownDecoder(),
-		// 		);
-
-		// 		const inputLines = [
-		// 			// incomplete link reference with empty caption
-		// 			'[ ](./real/file path/file⇧name.md',
-		// 			// space between caption and reference is disallowed
-		// 			'[link text] (./file path/name.txt)',
-		// 		];
-
-		// 		await test.run(
-		// 			inputLines,
-		// 			[
-		// 				// `1st` line
-		// 				new LeftBracket(new Range(1, 1, 1, 2)),
-		// 				new Space(new Range(1, 2, 1, 3)),
-		// 				new RightBracket(new Range(1, 3, 1, 4)),
-		// 				new LeftParenthesis(new Range(1, 4, 1, 5)),
-		// 				new Word(new Range(1, 5, 1, 5 + 11), './real/file'),
-		// 				new Space(new Range(1, 16, 1, 17)),
-		// 				new Word(new Range(1, 17, 1, 17 + 17), 'path/file⇧name.md'),
-		// 				new NewLine(new Range(1, 34, 1, 35)),
-		// 				// `2nd` line
-		// 				new LeftBracket(new Range(2, 1, 2, 2)),
-		// 				new Word(new Range(2, 2, 2, 2 + 4), 'link'),
-		// 				new Space(new Range(2, 6, 2, 7)),
-		// 				new Word(new Range(2, 7, 2, 7 + 4), 'text'),
-		// 				new RightBracket(new Range(2, 11, 2, 12)),
-		// 				new Space(new Range(2, 12, 2, 13)),
-		// 				new LeftParenthesis(new Range(2, 13, 2, 14)),
-		// 				new Word(new Range(2, 14, 2, 14 + 6), './file'),
-		// 				new Space(new Range(2, 20, 2, 21)),
-		// 				new Word(new Range(2, 21, 2, 21 + 13), 'path/name.txt'),
-		// 				new RightParenthesis(new Range(2, 34, 2, 35)),
-		// 			],
-		// 		);
-		// 	});
-
-		// 	suite('• stop characters inside caption/reference (new lines)', () => {
-		// 		for (const stopCharacter of [CarriageReturn, NewLine]) {
-		// 			let characterName = '';
-
-		// 			if (stopCharacter === CarriageReturn) {
-		// 				characterName = '\\r';
-		// 			}
-		// 			if (stopCharacter === NewLine) {
-		// 				characterName = '\\n';
-		// 			}
-
-		// 			assert(
-		// 				characterName !== '',
-		// 				'The "characterName" must be set, got "empty line".',
-		// 			);
-
-		// 			test(`• stop character - "${characterName}"`, async () => {
-		// 				const test = testDisposables.add(
-		// 					new TestMarkdownDecoder(),
-		// 				);
-
-		// 				const inputLines = [
-		// 					// stop character inside link caption
-		// 					`[haa${stopCharacter.symbol}loů](./real/💁/name.txt)`,
-		// 					// stop character inside link reference
-		// 					`[ref text](/etc/pat${stopCharacter.symbol}h/to/file.md)`,
-		// 					// stop character between line caption and link reference is disallowed
-		// 					`[text]${stopCharacter.symbol}(/etc/ path/file.md)`,
-		// 				];
-
-
-		// 				await test.run(
-		// 					inputLines,
-		// 					[
-		// 						// `1st` input line
-		// 						new LeftBracket(new Range(1, 1, 1, 2)),
-		// 						new Word(new Range(1, 2, 1, 2 + 3), 'haa'),
-		// 						new stopCharacter(new Range(1, 5, 1, 6)), // <- stop character
-		// 						new Word(new Range(2, 1, 2, 1 + 3), 'loů'),
-		// 						new RightBracket(new Range(2, 4, 2, 5)),
-		// 						new LeftParenthesis(new Range(2, 5, 2, 6)),
-		// 						new Word(new Range(2, 6, 2, 6 + 18), './real/💁/name.txt'),
-		// 						new RightParenthesis(new Range(2, 24, 2, 25)),
-		// 						new NewLine(new Range(2, 25, 2, 26)),
-		// 						// `2nd` input line
-		// 						new LeftBracket(new Range(3, 1, 3, 2)),
-		// 						new Word(new Range(3, 2, 3, 2 + 3), 'ref'),
-		// 						new Space(new Range(3, 5, 3, 6)),
-		// 						new Word(new Range(3, 6, 3, 6 + 4), 'text'),
-		// 						new RightBracket(new Range(3, 10, 3, 11)),
-		// 						new LeftParenthesis(new Range(3, 11, 3, 12)),
-		// 						new Word(new Range(3, 12, 3, 12 + 8), '/etc/pat'),
-		// 						new stopCharacter(new Range(3, 20, 3, 21)), // <- stop character
-		// 						new Word(new Range(4, 1, 4, 1 + 12), 'h/to/file.md'),
-		// 						new RightParenthesis(new Range(4, 13, 4, 14)),
-		// 						new NewLine(new Range(4, 14, 4, 15)),
-		// 						// `3nd` input line
-		// 						new LeftBracket(new Range(5, 1, 5, 2)),
-		// 						new Word(new Range(5, 2, 5, 2 + 4), 'text'),
-		// 						new RightBracket(new Range(5, 6, 5, 7)),
-		// 						new stopCharacter(new Range(5, 7, 5, 8)), // <- stop character
-		// 						new LeftParenthesis(new Range(6, 1, 6, 2)),
-		// 						new Word(new Range(6, 2, 6, 2 + 5), '/etc/'),
-		// 						new Space(new Range(6, 7, 6, 8)),
-		// 						new Word(new Range(6, 8, 6, 8 + 12), 'path/file.md'),
-		// 						new RightParenthesis(new Range(6, 20, 6, 21)),
-		// 					],
-		// 				);
-		// 			});
-		// 		}
-		// 	});
-
-		// 	/**
-		// 	 * Same as above but these stop characters do not move the caret to the next line.
-		// 	 */
-		// 	suite('• stop characters inside caption/reference (same line)', () => {
-		// 		for (const stopCharacter of [VerticalTab, FormFeed]) {
-		// 			let characterName = '';
-
-		// 			if (stopCharacter === VerticalTab) {
-		// 				characterName = '\\v';
-		// 			}
-		// 			if (stopCharacter === FormFeed) {
-		// 				characterName = '\\f';
-		// 			}
-
-		// 			assert(
-		// 				characterName !== '',
-		// 				'The "characterName" must be set, got "empty line".',
-		// 			);
-
-		// 			test(`• stop character - "${characterName}"`, async () => {
-		// 				const test = testDisposables.add(
-		// 					new TestMarkdownDecoder(),
-		// 				);
-
-		// 				const inputLines = [
-		// 					// stop character inside link caption
-		// 					`[haa${stopCharacter.symbol}loů](./real/💁/name.txt)`,
-		// 					// stop character inside link reference
-		// 					`[ref text](/etc/pat${stopCharacter.symbol}h/to/file.md)`,
-		// 					// stop character between line caption and link reference is disallowed
-		// 					`[text]${stopCharacter.symbol}(/etc/ path/file.md)`,
-		// 				];
-
-
-		// 				await test.run(
-		// 					inputLines,
-		// 					[
-		// 						// `1st` input line
-		// 						new LeftBracket(new Range(1, 1, 1, 2)),
-		// 						new Word(new Range(1, 2, 1, 2 + 3), 'haa'),
-		// 						new stopCharacter(new Range(1, 5, 1, 6)), // <- stop character
-		// 						new Word(new Range(1, 6, 1, 6 + 3), 'loů'),
-		// 						new RightBracket(new Range(1, 9, 1, 10)),
-		// 						new LeftParenthesis(new Range(1, 10, 1, 11)),
-		// 						new Word(new Range(1, 11, 1, 11 + 18), './real/💁/name.txt'),
-		// 						new RightParenthesis(new Range(1, 29, 1, 30)),
-		// 						new NewLine(new Range(1, 30, 1, 31)),
-		// 						// `2nd` input line
-		// 						new LeftBracket(new Range(2, 1, 2, 2)),
-		// 						new Word(new Range(2, 2, 2, 2 + 3), 'ref'),
-		// 						new Space(new Range(2, 5, 2, 6)),
-		// 						new Word(new Range(2, 6, 2, 6 + 4), 'text'),
-		// 						new RightBracket(new Range(2, 10, 2, 11)),
-		// 						new LeftParenthesis(new Range(2, 11, 2, 12)),
-		// 						new Word(new Range(2, 12, 2, 12 + 8), '/etc/pat'),
-		// 						new stopCharacter(new Range(2, 20, 2, 21)), // <- stop character
-		// 						new Word(new Range(2, 21, 2, 21 + 12), 'h/to/file.md'),
-		// 						new RightParenthesis(new Range(2, 33, 2, 34)),
-		// 						new NewLine(new Range(2, 34, 2, 35)),
-		// 						// `3nd` input line
-		// 						new LeftBracket(new Range(3, 1, 3, 2)),
-		// 						new Word(new Range(3, 2, 3, 2 + 4), 'text'),
-		// 						new RightBracket(new Range(3, 6, 3, 7)),
-		// 						new stopCharacter(new Range(3, 7, 3, 8)), // <- stop character
-		// 						new LeftParenthesis(new Range(3, 8, 3, 9)),
-		// 						new Word(new Range(3, 9, 3, 9 + 5), '/etc/'),
-		// 						new Space(new Range(3, 14, 3, 15)),
-		// 						new Word(new Range(3, 15, 3, 15 + 12), 'path/file.md'),
-		// 						new RightParenthesis(new Range(3, 27, 3, 28)),
-		// 					],
-		// 				);
-		// 			});
-		// 		}
-		// 	});
-		// });
 	});
 
 	suite('• comments', () => {


### PR DESCRIPTION
The PR adds the `markdown image` links (`![alt text](/path/to/image.jpeg)`) support the prompt syntax parsers.

Part of https://github.com/microsoft/vscode-copilot/issues/13952.