### PR TITLE
#8226 :  Enable text selection in deleted lines in diff view

### DIFF
--- a/src/vs/editor/browser/widget/diffEditor/components/diffEditorViewZones/renderLines.ts
+++ b/src/vs/editor/browser/widget/diffEditor/components/diffEditorViewZones/renderLines.ts
@@ -198,11 +198,11 @@ function renderOriginalLine(
 		options.fontInfo.middotWidth,
 		options.fontInfo.wsmiddotWidth,
 		options.stopRenderingLineAfter,
-		options.renderWhitespace,
-		options.renderControlCharacters,
-		options.fontLigatures !== EditorFontLigatures.OFF,
-		null // Send no selections, original line cannot be selected
-	), sb);
+			options.renderWhitespace,
+			options.renderControlCharacters,
+			options.fontLigatures !== EditorFontLigatures.OFF,
+			[] // Allow selections by passing empty array instead of null
+		), sb);
 
 	sb.appendString('</div>');
 


### PR DESCRIPTION
Fixes #8226 

This change enables text selection in deleted lines within the diff view by passing an empty array instead of null for selections in the renderOriginalLine function.

How to test ? 
1. Open a file with changes in diff view
2. Try to select text in deleted (red) lines
3. Verify that text selection works as expected in deleted lines