### PR TITLE
mcp: add status indicator for mcp tools, discovery setting

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -100,7 +100,7 @@ import { ChatStatusBarEntry } from './chatStatus.js';
 import product from '../../../../platform/product/common/product.js';
 import { Event } from '../../../../base/common/event.js';
 import { ChatEditingNotebookFileSystemProviderContrib } from './chatEditing/notebook/chatEditingNotebookFileSystemProvider.js';
-import { mcpConfigurationSection, mcpSchemaExampleServers } from '../../mcp/common/mcpConfiguration.js';
+import { mcpConfigurationSection, mcpDiscoverySection, mcpSchemaExampleServers } from '../../mcp/common/mcpConfiguration.js';
 import { mcpSchemaId } from '../../../services/configuration/common/configuration.js';
 import { ChatTransferService, IChatTransferService } from '../common/chatTransferService.js';
 import { ChatTransferContribution } from './actions/chatTransfer.js';
@@ -211,6 +211,11 @@ configurationRegistry.registerConfiguration({
 			},
 			description: nls.localize('workspaceConfig.mcp.description', "Model Context Protocol server configurations"),
 			$ref: mcpSchemaId
+		},
+		[mcpDiscoverySection]: {
+			type: 'boolean',
+			default: false,
+			description: nls.localize('mpc.discovery.enabled', "Enable discovery of Model Context Protocol servers on the machine."),
 		},
 		[PromptsConfig.CONFIG_KEY]: {
 			type: 'boolean',

--- a/src/vs/workbench/contrib/chat/browser/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/media/chat.css
@@ -1149,6 +1149,45 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	gap: 5px;
 }
 
+.action-item.chat-mcp {
+	display: flex !important;
+
+	&.chat-mcp-has-action .action-label {
+		border-top-right-radius: 0;
+		border-bottom-right-radius: 0;
+		border-right: 0;
+	}
+
+	.chat-mcp-action {
+		align-self: stretch;
+		padding: 0 2px;
+		border-radius: 0;
+		outline: 0;
+		border: 0;
+		border-top-right-radius: 4px;
+		border-bottom-right-radius: 4px;
+		background: var(--vscode-button-background);
+		cursor: pointer;
+
+		.codicon {
+			width: fit-content;
+			color: var(--vscode-button-foreground);
+		}
+
+		.codicon::before {
+			font-size: 14px;
+		}
+
+		&.chat-mcp-action-error {
+			background: var(--vscode-activityErrorBadge-background);
+
+			.codicon {
+				color: var(--vscode-activityErrorBadge-foreground);
+			}
+		}
+	}
+}
+
 .action-item.chat-attached-context-attachment.chat-add-files .action-label.codicon::before {
 	font: normal normal normal 16px/1 codicon;
 }

--- a/src/vs/workbench/contrib/mcp/common/discovery/configMcpDiscovery.ts
+++ b/src/vs/workbench/contrib/mcp/common/discovery/configMcpDiscovery.ts
@@ -119,8 +119,10 @@ export class ConfigMcpDiscovery extends Disposable implements IMcpDiscovery {
 				continue;
 			}
 
+
 			if (!nextDefinitions.length) {
 				src.disposable.clear();
+				src.serverDefinitions.set(nextDefinitions, undefined);
 			} else {
 				src.serverDefinitions.set(nextDefinitions, undefined);
 				src.disposable.value ??= this._mcpRegistry.registerCollection({

--- a/src/vs/workbench/contrib/mcp/common/discovery/nativeMcpDiscoveryAbstract.ts
+++ b/src/vs/workbench/contrib/mcp/common/discovery/nativeMcpDiscoveryAbstract.ts
@@ -6,15 +6,18 @@
 import { RunOnceScheduler } from '../../../../../base/common/async.js';
 import { Disposable, MutableDisposable } from '../../../../../base/common/lifecycle.js';
 import { Schemas } from '../../../../../base/common/network.js';
-import { observableValue } from '../../../../../base/common/observable.js';
+import { autorunWithStore, IObservable, observableValue } from '../../../../../base/common/observable.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { localize } from '../../../../../nls.js';
+import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 import { IFileService } from '../../../../../platform/files/common/files.js';
 import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
 import { ILabelService } from '../../../../../platform/label/common/label.js';
 import { INativeMcpDiscoveryData } from '../../../../../platform/mcp/common/nativeMcpDiscoveryHelper.js';
+import { observableConfigValue } from '../../../../../platform/observable/common/platformObservableUtils.js';
 import { StorageScope } from '../../../../../platform/storage/common/storage.js';
 import { Dto } from '../../../../services/extensions/common/proxyIdentifier.js';
+import { mcpDiscoverySection } from '../mcpConfiguration.js';
 import { IMcpRegistry } from '../mcpRegistryTypes.js';
 import { McpCollectionDefinition, McpCollectionSortOrder, McpServerDefinition } from '../mcpTypes.js';
 import { IMcpDiscovery } from './mcpDiscovery.js';
@@ -26,6 +29,7 @@ import { ClaudeDesktopMpcDiscoveryAdapter, NativeMpcDiscoveryAdapter } from './n
  */
 export abstract class FilesystemMpcDiscovery extends Disposable implements IMcpDiscovery {
 	private readonly adapters: readonly NativeMpcDiscoveryAdapter[];
+	private _fsDiscoveryEnabled: IObservable<boolean>;
 	private suffix = '';
 
 	constructor(
@@ -34,11 +38,14 @@ export abstract class FilesystemMpcDiscovery extends Disposable implements IMcpD
 		@IFileService private readonly fileService: IFileService,
 		@IInstantiationService instantiationService: IInstantiationService,
 		@IMcpRegistry private readonly mcpRegistry: IMcpRegistry,
+		@IConfigurationService configurationService: IConfigurationService,
 	) {
 		super();
 		if (remoteAuthority) {
 			this.suffix = ' ' + localize('onRemoteLabel', ' on {0}', labelService.getHostLabel(Schemas.vscodeRemote, remoteAuthority));
 		}
+
+		this._fsDiscoveryEnabled = observableConfigValue(mcpDiscoverySection, false, configurationService);
 
 		this.adapters = [
 			instantiationService.createInstance(ClaudeDesktopMpcDiscoveryAdapter, remoteAuthority)
@@ -97,10 +104,17 @@ export abstract class FilesystemMpcDiscovery extends Disposable implements IMcpD
 				}
 			};
 
-			const watcher = this._register(this.fileService.createWatcher(file, { recursive: false, excludes: [] }));
-			const throttler = this._register(new RunOnceScheduler(updateFile, 500));
-			this._register(watcher.onDidChange(() => throttler.schedule()));
-			updateFile();
+			this._register(autorunWithStore((reader, store) => {
+				if (!this._fsDiscoveryEnabled.read(reader)) {
+					collectionRegistration.clear();
+					return;
+				}
+
+				const throttler = store.add(new RunOnceScheduler(updateFile, 500));
+				const watcher = store.add(this.fileService.createWatcher(file, { recursive: false, excludes: [] }));
+				store.add(watcher.onDidChange(() => throttler.schedule()));
+				updateFile();
+			}));
 		}
 	}
 }

--- a/src/vs/workbench/contrib/mcp/common/discovery/nativeMcpRemoteDiscovery.ts
+++ b/src/vs/workbench/contrib/mcp/common/discovery/nativeMcpRemoteDiscovery.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { ProxyChannel } from '../../../../../base/parts/ipc/common/ipc.js';
+import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 import { IFileService } from '../../../../../platform/files/common/files.js';
 import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
 import { ILabelService } from '../../../../../platform/label/common/label.js';
@@ -24,8 +25,9 @@ export class RemoteNativeMpcDiscovery extends FilesystemMpcDiscovery {
 		@IFileService fileService: IFileService,
 		@IInstantiationService instantiationService: IInstantiationService,
 		@IMcpRegistry mcpRegistry: IMcpRegistry,
+		@IConfigurationService configurationService: IConfigurationService,
 	) {
-		super(remoteAgent.getConnection()?.remoteAuthority || null, labelService, fileService, instantiationService, mcpRegistry);
+		super(remoteAgent.getConnection()?.remoteAuthority || null, labelService, fileService, instantiationService, mcpRegistry, configurationService);
 	}
 
 	public override async start() {

--- a/src/vs/workbench/contrib/mcp/common/mcpConfiguration.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpConfiguration.ts
@@ -17,6 +17,7 @@ const mcpSchemaExampleServer = {
 };
 
 export const mcpConfigurationSection = 'mcp';
+export const mcpDiscoverySection = 'chat.mpc.discovery.enabled';
 
 export const mcpSchemaExampleServers = {
 	'mcp-server-time': {

--- a/src/vs/workbench/contrib/mcp/common/mcpServer.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpServer.ts
@@ -12,7 +12,7 @@ import { IStorageService, StorageScope, StorageTarget } from '../../../../platfo
 import { IWorkspaceContextService } from '../../../../platform/workspace/common/workspace.js';
 import { IMcpRegistry } from './mcpRegistryTypes.js';
 import { McpServerRequestHandler } from './mcpServerRequestHandler.js';
-import { McpCollectionDefinition, IMcpServer, IMcpServerConnection, McpServerDefinition, IMcpTool, McpConnectionFailedError, McpConnectionState } from './mcpTypes.js';
+import { McpCollectionDefinition, IMcpServer, IMcpServerConnection, McpServerDefinition, IMcpTool, McpConnectionFailedError, McpConnectionState, McpServerToolsState } from './mcpTypes.js';
 import { MCP } from './modelContextProtocol.js';
 
 
@@ -63,7 +63,7 @@ export class McpServer extends Disposable implements IMcpServer {
 	private readonly _connectionSequencer = new Sequencer();
 	private readonly _connection = this._register(disposableObservableValue<IMcpServerConnection | undefined>(this, undefined));
 
-	public readonly state: IObservable<McpConnectionState> = derived(reader => this._connection.read(reader)?.state.read(reader) ?? { state: McpConnectionState.Kind.Stopped });
+	public readonly connectionState: IObservable<McpConnectionState> = derived(reader => this._connection.read(reader)?.state.read(reader) ?? { state: McpConnectionState.Kind.Stopped });
 
 	private get toolsFromCache() {
 		return this._toolCache.getTools(this.definition.id);
@@ -75,6 +75,20 @@ export class McpServer extends Disposable implements IMcpServer {
 		const serverTools = this.toolsFromServer.read(reader);
 		const definitions = serverTools ?? this.toolsFromCache ?? [];
 		return definitions.map(def => new McpTool(this, def));
+	});
+
+	public readonly toolsState = derived(reader => {
+		const fromServer = this.toolsFromServerPromise.read(reader);
+		if (!fromServer) {
+			return this.toolsFromCache ? McpServerToolsState.Cached : McpServerToolsState.Unknown;
+		}
+
+		const fromServerResult = fromServer?.promiseResult.read(reader);
+		if (!fromServerResult) {
+			return this.toolsFromCache ? McpServerToolsState.RefreshingFromCached : McpServerToolsState.RefreshingFromUnknown;
+		}
+
+		return fromServerResult.error ? (this.toolsFromCache ? McpServerToolsState.Cached : McpServerToolsState.Unknown) : McpServerToolsState.Live;
 	});
 
 	constructor(

--- a/src/vs/workbench/contrib/mcp/common/mcpTypes.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpTypes.ts
@@ -101,7 +101,7 @@ export const IMcpService = createDecorator<IMcpService>('IMcpService');
 export interface IMcpServer extends IDisposable {
 	readonly collection: McpCollectionDefinition;
 	readonly definition: McpServerDefinition;
-	readonly state: IObservable<McpConnectionState>;
+	readonly connectionState: IObservable<McpConnectionState>;
 	showOutput(): void;
 	/**
 	 * Starts the server and returns its resulting state. One of:
@@ -112,9 +112,22 @@ export interface IMcpServer extends IDisposable {
 	start(isFromInteraction?: boolean): Promise<McpConnectionState>;
 	stop(): Promise<void>;
 
+	readonly toolsState: IObservable<McpServerToolsState>;
 	readonly tools: IObservable<readonly IMcpTool[]>;
 }
 
+export const enum McpServerToolsState {
+	/** Tools have not been read before */
+	Unknown,
+	/** Tools were read from the cache */
+	Cached,
+	/** Tools are refreshing for the first time */
+	RefreshingFromUnknown,
+	/** Tools are refreshing and the current tools are cached */
+	RefreshingFromCached,
+	/** Tool state is live, server is connected */
+	Live,
+}
 
 export interface IMcpTool {
 

--- a/src/vs/workbench/contrib/mcp/electron-sandbox/nativeMpcDiscovery.ts
+++ b/src/vs/workbench/contrib/mcp/electron-sandbox/nativeMpcDiscovery.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { ProxyChannel } from '../../../../base/parts/ipc/common/ipc.js';
+import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { IFileService } from '../../../../platform/files/common/files.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { IMainProcessService } from '../../../../platform/ipc/common/mainProcessService.js';
@@ -21,8 +22,9 @@ export class NativeMcpDiscovery extends FilesystemMpcDiscovery {
 		@IFileService fileService: IFileService,
 		@IInstantiationService instantiationService: IInstantiationService,
 		@IMcpRegistry mcpRegistry: IMcpRegistry,
+		@IConfigurationService configurationService: IConfigurationService,
 	) {
-		super(null, labelService, fileService, instantiationService, mcpRegistry);
+		super(null, labelService, fileService, instantiationService, mcpRegistry, configurationService);
 	}
 
 	public override start(): void {


### PR DESCRIPTION
The tool indicator in chat now has:
- A "refresh" action if there are new MCP servers with undiscovered
  tools (clicking starts the servers)
- An error if any tool fails to start (clicking opens the first failing
  tool options quickpick)
- A loading indicator while they're starting (clicking opens output)

This also adds a `chat.mpc.discovery.enabled` setting, off by default
for now, to configure whether filesystem discovery is enabled. I expect
to turn this on as we gain confidence with the feature.


https://github.com/user-attachments/assets/4d51ad0d-a9f3-42ca-9aa7-47fa701dd9a4



Refs #243229

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
