### PR TITLE
fix policy generation

### DIFF
--- a/build/lib/policies.ts
+++ b/build/lib/policies.ts
@@ -33,10 +33,16 @@ interface Category {
 }
 
 enum PolicyType {
-	StringEnum
+	Boolean = 'boolean',
+	Number = 'number',
+	Object = 'object',
+	String = 'string',
+	StringEnum = 'stringEnum',
 }
 
 interface Policy {
+	readonly name: string;
+	readonly type: PolicyType;
 	readonly category: Category;
 	readonly minimumVersion: string;
 	renderADMX(regKey: string): string[];
@@ -64,8 +70,8 @@ function renderADMLString(prefix: string, moduleName: string, nlsString: NlsStri
 
 abstract class BasePolicy implements Policy {
 	constructor(
-		protected policyType: PolicyType,
-		protected name: string,
+		readonly type: PolicyType,
+		readonly name: string,
 		readonly category: Category,
 		readonly minimumVersion: string,
 		protected description: NlsString,
@@ -114,7 +120,7 @@ class BooleanPolicy extends BasePolicy {
 		moduleName: string,
 		settingNode: Parser.SyntaxNode
 	): BooleanPolicy | undefined {
-		const type = getStringProperty(settingNode, 'type');
+		const type = getStringProperty(moduleName, settingNode, 'type');
 
 		if (type !== 'boolean') {
 			return undefined;
@@ -130,7 +136,7 @@ class BooleanPolicy extends BasePolicy {
 		description: NlsString,
 		moduleName: string,
 	) {
-		super(PolicyType.StringEnum, name, category, minimumVersion, description, moduleName);
+		super(PolicyType.Boolean, name, category, minimumVersion, description, moduleName);
 	}
 
 	protected renderADMXElements(): string[] {
@@ -146,7 +152,13 @@ class BooleanPolicy extends BasePolicy {
 	}
 }
 
-class IntPolicy extends BasePolicy {
+class ParseError extends Error {
+	constructor(message: string, moduleName: string, node: Parser.SyntaxNode) {
+		super(`${message}. ${moduleName}.ts:${node.startPosition.row + 1}`);
+	}
+}
+
+class NumberPolicy extends BasePolicy {
 
 	static from(
 		name: string,
@@ -155,20 +167,20 @@ class IntPolicy extends BasePolicy {
 		description: NlsString,
 		moduleName: string,
 		settingNode: Parser.SyntaxNode
-	): IntPolicy | undefined {
-		const type = getStringProperty(settingNode, 'type');
+	): NumberPolicy | undefined {
+		const type = getStringProperty(moduleName, settingNode, 'type');
 
 		if (type !== 'number') {
 			return undefined;
 		}
 
-		const defaultValue = getIntProperty(settingNode, 'default');
+		const defaultValue = getNumberProperty(moduleName, settingNode, 'default');
 
 		if (typeof defaultValue === 'undefined') {
-			throw new Error(`Missing required 'default' property.`);
+			throw new ParseError(`Missing required 'default' property.`, moduleName, settingNode);
 		}
 
-		return new IntPolicy(name, category, minimumVersion, description, moduleName, defaultValue);
+		return new NumberPolicy(name, category, minimumVersion, description, moduleName, defaultValue);
 	}
 
 	private constructor(
@@ -204,7 +216,7 @@ class StringPolicy extends BasePolicy {
 		moduleName: string,
 		settingNode: Parser.SyntaxNode
 	): StringPolicy | undefined {
-		const type = getStringProperty(settingNode, 'type');
+		const type = getStringProperty(moduleName, settingNode, 'type');
 
 		if (type !== 'string') {
 			return undefined;
@@ -220,7 +232,7 @@ class StringPolicy extends BasePolicy {
 		description: NlsString,
 		moduleName: string,
 	) {
-		super(PolicyType.StringEnum, name, category, minimumVersion, description, moduleName);
+		super(PolicyType.String, name, category, minimumVersion, description, moduleName);
 	}
 
 	protected renderADMXElements(): string[] {
@@ -242,7 +254,7 @@ class ObjectPolicy extends BasePolicy {
 		moduleName: string,
 		settingNode: Parser.SyntaxNode
 	): ObjectPolicy | undefined {
-		const type = getStringProperty(settingNode, 'type');
+		const type = getStringProperty(moduleName, settingNode, 'type');
 
 		if (type !== 'object' && type !== 'array') {
 			return undefined;
@@ -258,7 +270,7 @@ class ObjectPolicy extends BasePolicy {
 		description: NlsString,
 		moduleName: string,
 	) {
-		super(PolicyType.StringEnum, name, category, minimumVersion, description, moduleName);
+		super(PolicyType.Object, name, category, minimumVersion, description, moduleName);
 	}
 
 	protected renderADMXElements(): string[] {
@@ -280,28 +292,28 @@ class StringEnumPolicy extends BasePolicy {
 		moduleName: string,
 		settingNode: Parser.SyntaxNode
 	): StringEnumPolicy | undefined {
-		const type = getStringProperty(settingNode, 'type');
+		const type = getStringProperty(moduleName, settingNode, 'type');
 
 		if (type !== 'string') {
 			return undefined;
 		}
 
-		const enum_ = getStringArrayProperty(settingNode, 'enum');
+		const enum_ = getStringArrayProperty(moduleName, settingNode, 'enum');
 
 		if (!enum_) {
 			return undefined;
 		}
 
 		if (!isStringArray(enum_)) {
-			throw new Error(`Property 'enum' should not be localized.`);
+			throw new ParseError(`Property 'enum' should not be localized.`, moduleName, settingNode);
 		}
 
-		const enumDescriptions = getStringArrayProperty(settingNode, 'enumDescriptions');
+		const enumDescriptions = getStringArrayProperty(moduleName, settingNode, 'enumDescriptions');
 
 		if (!enumDescriptions) {
-			throw new Error(`Missing required 'enumDescriptions' property.`);
+			throw new ParseError(`Missing required 'enumDescriptions' property.`, moduleName, settingNode);
 		} else if (!isNlsStringArray(enumDescriptions)) {
-			throw new Error(`Property 'enumDescriptions' should be localized.`);
+			throw new ParseError(`Property 'enumDescriptions' should be localized.`, moduleName, settingNode);
 		}
 
 		return new StringEnumPolicy(name, category, minimumVersion, description, moduleName, enum_, enumDescriptions);
@@ -344,7 +356,7 @@ interface QType<T> {
 	value(matches: Parser.QueryMatch[]): T | undefined;
 }
 
-const IntQ: QType<number> = {
+const NumberQ: QType<number> = {
 	Q: `(number) @value`,
 
 	value(matches: Parser.QueryMatch[]): number | undefined {
@@ -407,7 +419,7 @@ const StringArrayQ: QType<(string | NlsString)[]> = {
 	}
 };
 
-function getProperty<T>(qtype: QType<T>, node: Parser.SyntaxNode, key: string): T | undefined {
+function getProperty<T>(qtype: QType<T>, moduleName: string, node: Parser.SyntaxNode, key: string): T | undefined {
 	const query = new Parser.Query(
 		typescript,
 		`(
@@ -415,29 +427,33 @@ function getProperty<T>(qtype: QType<T>, node: Parser.SyntaxNode, key: string): 
 				key: [(property_identifier)(string)] @key
 				value: ${qtype.Q}
 			)
-			(#eq? @key ${key})
+			(#any-of? @key "${key}" "'${key}'")
 		)`
 	);
 
-	return qtype.value(query.matches(node));
+	try {
+		return qtype.value(query.matches(node));
+	} catch (e) {
+		throw new ParseError(e.message, moduleName, node);
+	}
 }
 
-function getIntProperty(node: Parser.SyntaxNode, key: string): number | undefined {
-	return getProperty(IntQ, node, key);
+function getNumberProperty(moduleName: string, node: Parser.SyntaxNode, key: string): number | undefined {
+	return getProperty(NumberQ, moduleName, node, key);
 }
 
-function getStringProperty(node: Parser.SyntaxNode, key: string): string | NlsString | undefined {
-	return getProperty(StringQ, node, key);
+function getStringProperty(moduleName: string, node: Parser.SyntaxNode, key: string): string | NlsString | undefined {
+	return getProperty(StringQ, moduleName, node, key);
 }
 
-function getStringArrayProperty(node: Parser.SyntaxNode, key: string): (string | NlsString)[] | undefined {
-	return getProperty(StringArrayQ, node, key);
+function getStringArrayProperty(moduleName: string, node: Parser.SyntaxNode, key: string): (string | NlsString)[] | undefined {
+	return getProperty(StringArrayQ, moduleName, node, key);
 }
 
 // TODO: add more policy types
 const PolicyTypes = [
 	BooleanPolicy,
-	IntPolicy,
+	NumberPolicy,
 	StringEnumPolicy,
 	StringPolicy,
 	ObjectPolicy
@@ -450,20 +466,20 @@ function getPolicy(
 	policyNode: Parser.SyntaxNode,
 	categories: Map<string, Category>
 ): Policy {
-	const name = getStringProperty(policyNode, 'name');
+	const name = getStringProperty(moduleName, policyNode, 'name');
 
 	if (!name) {
-		throw new Error(`Missing required 'name' property.`);
+		throw new ParseError(`Missing required 'name' property`, moduleName, policyNode);
 	} else if (isNlsString(name)) {
-		throw new Error(`Property 'name' should be a literal string.`);
+		throw new ParseError(`Property 'name' should be a literal string`, moduleName, policyNode);
 	}
 
-	const categoryName = getStringProperty(configurationNode, 'title');
+	const categoryName = getStringProperty(moduleName, configurationNode, 'title');
 
 	if (!categoryName) {
-		throw new Error(`Missing required 'title' property.`);
+		throw new ParseError(`Missing required 'title' property`, moduleName, configurationNode);
 	} else if (!isNlsString(categoryName)) {
-		throw new Error(`Property 'title' should be localized.`);
+		throw new ParseError(`Property 'title' should be localized`, moduleName, configurationNode);
 	}
 
 	const categoryKey = `${categoryName.nlsKey}:${categoryName.value}`;
@@ -474,20 +490,20 @@ function getPolicy(
 		categories.set(categoryKey, category);
 	}
 
-	const minimumVersion = getStringProperty(policyNode, 'minimumVersion');
+	const minimumVersion = getStringProperty(moduleName, policyNode, 'minimumVersion');
 
 	if (!minimumVersion) {
-		throw new Error(`Missing required 'minimumVersion' property.`);
+		throw new ParseError(`Missing required 'minimumVersion' property.`, moduleName, policyNode);
 	} else if (isNlsString(minimumVersion)) {
-		throw new Error(`Property 'minimumVersion' should be a literal string.`);
+		throw new ParseError(`Property 'minimumVersion' should be a literal string.`, moduleName, policyNode);
 	}
 
-	const description = getStringProperty(settingNode, 'description');
+	const description = getStringProperty(moduleName, policyNode, 'description') ?? getStringProperty(moduleName, settingNode, 'description');
 
 	if (!description) {
-		throw new Error(`Missing required 'description' property.`);
+		throw new ParseError(`Missing required 'description' property.`, moduleName, settingNode);
 	} if (!isNlsString(description)) {
-		throw new Error(`Property 'description' should be localized.`);
+		throw new ParseError(`Property 'description' should be localized.`, moduleName, settingNode);
 	}
 
 	let result: Policy | undefined;
@@ -499,7 +515,7 @@ function getPolicy(
 	}
 
 	if (!result) {
-		throw new Error(`Failed to parse policy '${name}'.`);
+		throw new ParseError(`Failed to parse policy '${name}'.`, moduleName, settingNode);
 	}
 
 	return result;
@@ -511,11 +527,11 @@ function getPolicies(moduleName: string, node: Parser.SyntaxNode): Policy[] {
 			(call_expression
 				function: (member_expression property: (property_identifier) @registerConfigurationFn) (#eq? @registerConfigurationFn registerConfiguration)
 				arguments: (arguments	(object	(pair
-					key: [(property_identifier)(string)] @propertiesKey (#eq? @propertiesKey properties)
+					key: [(property_identifier)(string)] @propertiesKey (#any-of? @propertiesKey "properties" "'properties'")
 					value: (object (pair
 						key: [(property_identifier)(string)(computed_property_name)]
 						value: (object (pair
-							key: [(property_identifier)(string)] @policyKey (#eq? @policyKey policy)
+							key: [(property_identifier)(string)] @policyKey (#any-of? @policyKey "policy" "'policy'")
 							value: (object) @policy
 						)) @setting
 					))
@@ -737,6 +753,13 @@ async function getTranslations(): Promise<Translations> {
 
 async function main() {
 	const [policies, translations] = await Promise.all([parsePolicies(), getTranslations()]);
+
+	console.log(`Found ${policies.length} policies:`);
+
+	for (const policy of policies) {
+		console.log(`- ${policy.name} (${policy.type})`);
+	}
+
 	const { admx, adml } = await renderGP(policies, translations);
 
 	const root = '.build/policies/win32';
@@ -754,7 +777,11 @@ async function main() {
 
 if (require.main === module) {
 	main().catch(err => {
-		console.error(err);
+		if (err instanceof ParseError) {
+			console.error(`Parse Error:`, err.message);
+		} else {
+			console.error(err);
+		}
 		process.exit(1);
 	});
 }

--- a/build/package-lock.json
+++ b/build/package-lock.json
@@ -8,6 +8,9 @@
       "name": "code-oss-dev-build",
       "version": "1.0.0",
       "license": "MIT",
+      "dependencies": {
+        "tree-sitter-typescript": "0.23.2"
+      },
       "devDependencies": {
         "@azure/core-auth": "^1.9.0",
         "@azure/cosmos": "^3",
@@ -57,13 +60,13 @@
         "source-map": "0.6.1",
         "ternary-stream": "^3.0.0",
         "through2": "^4.0.2",
-        "tree-sitter": "^0.20.5",
+        "tree-sitter": "^0.22.4",
         "vscode-universal-bundler": "^0.1.3",
         "workerpool": "^6.4.0",
         "yauzl": "^2.10.0"
       },
       "optionalDependencies": {
-        "tree-sitter-typescript": "^0.20.5",
+        "tree-sitter-typescript": "^0.23.2",
         "vscode-gulp-watch": "^5.0.3"
       }
     },
@@ -1551,7 +1554,7 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "devOptional": true,
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -1580,7 +1583,8 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
       "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-      "devOptional": true,
+      "dev": true,
+      "optional": true,
       "dependencies": {
         "buffer": "^5.5.0",
         "inherits": "^2.0.4",
@@ -1632,7 +1636,7 @@
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
       "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "devOptional": true,
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -1647,6 +1651,7 @@
           "url": "https://feross.org/support"
         }
       ],
+      "optional": true,
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
@@ -1821,7 +1826,8 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-      "devOptional": true
+      "dev": true,
+      "optional": true
     },
     "node_modules/clone": {
       "version": "2.1.2",
@@ -1991,7 +1997,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
       "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "mimic-response": "^3.1.0"
       },
@@ -2006,7 +2012,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
       "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
-      "devOptional": true,
+      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -2018,7 +2024,8 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
       "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-      "devOptional": true,
+      "dev": true,
+      "optional": true,
       "engines": {
         "node": ">=4.0.0"
       }
@@ -2075,7 +2082,8 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.1.tgz",
       "integrity": "sha512-463v3ZeIrcWtdgIg6vI6XUncguvr2TnGl4SzDXinkt9mSLpBJKXT3mW6xT3VQdDN11+WVs29pgvivTc4Lp8v+w==",
-      "devOptional": true,
+      "dev": true,
+      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -2214,7 +2222,7 @@
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
       "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "once": "^1.4.0"
       }
@@ -2331,7 +2339,8 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
       "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
-      "devOptional": true,
+      "dev": true,
+      "optional": true,
       "engines": {
         "node": ">=6"
       }
@@ -2471,7 +2480,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-      "devOptional": true
+      "dev": true,
+      "optional": true
     },
     "node_modules/fs-extra": {
       "version": "8.1.0",
@@ -2553,7 +2563,8 @@
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
       "integrity": "sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4= sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
-      "devOptional": true
+      "dev": true,
+      "optional": true
     },
     "node_modules/glob": {
       "version": "7.2.3",
@@ -2867,7 +2878,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "devOptional": true,
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -2881,7 +2892,8 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ]
+      ],
+      "optional": true
     },
     "node_modules/inflight": {
       "version": "1.0.6",
@@ -2904,7 +2916,8 @@
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-      "devOptional": true
+      "dev": true,
+      "optional": true
     },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
@@ -3222,7 +3235,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -3330,13 +3343,14 @@
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
       "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/mkdirp-classic": {
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
-      "devOptional": true
+      "dev": true,
+      "optional": true
     },
     "node_modules/ms": {
       "version": "2.1.2",
@@ -3350,23 +3364,19 @@
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
       "dev": true
     },
-    "node_modules/nan": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.19.0.tgz",
-      "integrity": "sha512-nO1xXxfh/RWNxfd/XPfbIfFk5vgLsAxUR9y5O0cHMJu/AW9U95JLXqthYHjEp+8gQ5p96K9jUp8nbVOxCdRbtw==",
-      "devOptional": true
-    },
     "node_modules/napi-build-utils": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
       "integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg==",
-      "devOptional": true
+      "dev": true,
+      "optional": true
     },
     "node_modules/node-abi": {
       "version": "3.30.0",
       "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.30.0.tgz",
       "integrity": "sha512-qWO5l3SCqbwQavymOmtTVuCWZE23++S+rxyoHjXqUmPyzRcaoI4lA2gO55/drddGnedAyjA7sk76SfQ5lfUMnw==",
-      "devOptional": true,
+      "dev": true,
+      "optional": true,
       "dependencies": {
         "semver": "^7.3.5"
       },
@@ -3378,7 +3388,8 @@
       "version": "7.5.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
       "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "devOptional": true,
+      "dev": true,
+      "optional": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -3401,6 +3412,18 @@
       "integrity": "sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==",
       "dev": true,
       "optional": true
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
+      }
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
@@ -3470,7 +3493,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E= sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -3646,7 +3669,8 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.1.tgz",
       "integrity": "sha512-jAXscXWMcCK8GgCoHOfIr0ODh5ai8mj63L2nWrjuAgXE6tDyYGnx4/8o/rCgU+B4JSyZBKbeZqzhtwtC3ovxjw==",
-      "devOptional": true,
+      "dev": true,
+      "optional": true,
       "dependencies": {
         "detect-libc": "^2.0.0",
         "expand-template": "^2.0.3",
@@ -3700,7 +3724,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
       "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -3737,7 +3761,8 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
       "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-      "devOptional": true,
+      "dev": true,
+      "optional": true,
       "dependencies": {
         "deep-extend": "^0.6.0",
         "ini": "~1.3.0",
@@ -3950,27 +3975,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
       "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
-      "devOptional": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
-    },
-    "node_modules/simple-get": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
-      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
-      "devOptional": true,
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -3985,6 +3990,28 @@
           "url": "https://feross.org/support"
         }
       ],
+      "optional": true
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "optional": true,
       "dependencies": {
         "decompress-response": "^6.0.0",
         "once": "^1.3.1",
@@ -4079,7 +4106,8 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo= sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
-      "devOptional": true,
+      "dev": true,
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4119,7 +4147,8 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
       "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
-      "devOptional": true,
+      "dev": true,
+      "optional": true,
       "dependencies": {
         "chownr": "^1.1.1",
         "mkdirp-classic": "^0.5.2",
@@ -4131,7 +4160,8 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
       "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
-      "devOptional": true,
+      "dev": true,
+      "optional": true,
       "dependencies": {
         "bl": "^4.0.3",
         "end-of-stream": "^1.4.1",
@@ -4211,25 +4241,86 @@
       }
     },
     "node_modules/tree-sitter": {
-      "version": "0.20.6",
-      "resolved": "https://registry.npmjs.org/tree-sitter/-/tree-sitter-0.20.6.tgz",
-      "integrity": "sha512-GxJodajVpfgb3UREzzIbtA1hyRnTxVbWVXrbC6sk4xTMH5ERMBJk9HJNq4c8jOJeUaIOmLcwg+t6mez/PDvGqg==",
-      "devOptional": true,
+      "version": "0.22.4",
+      "resolved": "https://registry.npmjs.org/tree-sitter/-/tree-sitter-0.22.4.tgz",
+      "integrity": "sha512-usbHZP9/oxNsUY65MQUsduGRqDHQOou1cagUSwjhoSYAmSahjQDAVsh9s+SlZkn8X8+O1FULRGwHu7AFP3kjzg==",
+      "dev": true,
       "hasInstallScript": true,
+      "license": "MIT",
       "dependencies": {
-        "nan": "^2.18.0",
-        "prebuild-install": "^7.1.1"
+        "node-addon-api": "^8.3.0",
+        "node-gyp-build": "^4.8.4"
+      }
+    },
+    "node_modules/tree-sitter-javascript": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/tree-sitter-javascript/-/tree-sitter-javascript-0.23.1.tgz",
+      "integrity": "sha512-/bnhbrTD9frUYHQTiYnPcxyHORIw157ERBa6dqzaKxvR/x3PC4Yzd+D1pZIMS6zNg2v3a8BZ0oK7jHqsQo9fWA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-addon-api": "^8.2.2",
+        "node-gyp-build": "^4.8.2"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.21.1"
+      },
+      "peerDependenciesMeta": {
+        "tree-sitter": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tree-sitter-javascript/node_modules/node-addon-api": {
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.3.1.tgz",
+      "integrity": "sha512-lytcDEdxKjGJPTLEfW4mYMigRezMlyJY8W4wxJK8zE533Jlb8L8dRuObJFWg2P+AuOIxoCgKF+2Oq4d4Zd0OUA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
       }
     },
     "node_modules/tree-sitter-typescript": {
-      "version": "0.20.5",
-      "resolved": "https://registry.npmjs.org/tree-sitter-typescript/-/tree-sitter-typescript-0.20.5.tgz",
-      "integrity": "sha512-RzK/Pc6k4GiXvInIBlo8ZggekP6rODfW2P6KHFCTSUHENsw6ynh+iacFhfkJRa4MT8EIN2WHygFJ7076/+eHKg==",
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/tree-sitter-typescript/-/tree-sitter-typescript-0.23.2.tgz",
+      "integrity": "sha512-e04JUUKxTT53/x3Uq1zIL45DoYKVfHH4CZqwgZhPg5qYROl5nQjV+85ruFzFGZxu+QeFVbRTPDRnqL9UbU4VeA==",
       "hasInstallScript": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
-        "nan": "^2.18.0",
-        "tree-sitter": "^0.20.6"
+        "node-addon-api": "^8.2.2",
+        "node-gyp-build": "^4.8.2",
+        "tree-sitter-javascript": "^0.23.1"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.21.0"
+      },
+      "peerDependenciesMeta": {
+        "tree-sitter": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tree-sitter-typescript/node_modules/node-addon-api": {
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.3.1.tgz",
+      "integrity": "sha512-lytcDEdxKjGJPTLEfW4mYMigRezMlyJY8W4wxJK8zE533Jlb8L8dRuObJFWg2P+AuOIxoCgKF+2Oq4d4Zd0OUA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
+      }
+    },
+    "node_modules/tree-sitter/node_modules/node-addon-api": {
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.3.1.tgz",
+      "integrity": "sha512-lytcDEdxKjGJPTLEfW4mYMigRezMlyJY8W4wxJK8zE533Jlb8L8dRuObJFWg2P+AuOIxoCgKF+2Oq4d4Zd0OUA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
       }
     },
     "node_modules/tslib": {
@@ -4251,7 +4342,8 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0= sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
-      "devOptional": true,
+      "dev": true,
+      "optional": true,
       "dependencies": {
         "safe-buffer": "^5.0.1"
       },
@@ -4500,7 +4592,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8= sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/xml2js": {
       "version": "0.5.0",
@@ -4546,7 +4638,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/yauzl": {
       "version": "2.10.0",

--- a/build/package.json
+++ b/build/package.json
@@ -51,7 +51,7 @@
     "source-map": "0.6.1",
     "ternary-stream": "^3.0.0",
     "through2": "^4.0.2",
-    "tree-sitter": "^0.20.5",
+    "tree-sitter": "^0.22.4",
     "vscode-universal-bundler": "^0.1.3",
     "workerpool": "^6.4.0",
     "yauzl": "^2.10.0"
@@ -63,7 +63,7 @@
     "npmCheckJs": "../node_modules/.bin/tsc --noEmit"
   },
   "optionalDependencies": {
-    "tree-sitter-typescript": "^0.20.5",
+    "tree-sitter-typescript": "^0.23.2",
     "vscode-gulp-watch": "^5.0.3"
   }
 }

--- a/src/vs/platform/configuration/common/configurationRegistry.ts
+++ b/src/vs/platform/configuration/common/configurationRegistry.ts
@@ -164,8 +164,13 @@ export interface IPolicy {
 
 	/**
 	 * The Code version in which this policy was introduced.
-	 */
+	*/
 	readonly minimumVersion: `${number}.${number}`;
+
+	/**
+	 * The policy description (optional).
+	 */
+	readonly description?: string;
 }
 
 export interface IConfigurationPropertySchema extends IJSONSchema {

--- a/src/vs/platform/telemetry/common/telemetryService.ts
+++ b/src/vs/platform/telemetry/common/telemetryService.ts
@@ -200,7 +200,8 @@ ${deprecatedSettingNote}
 	return telemetryDescription;
 }
 
-Registry.as<IConfigurationRegistry>(Extensions.Configuration).registerConfiguration({
+const configurationRegistry = Registry.as<IConfigurationRegistry>(Extensions.Configuration);
+configurationRegistry.registerConfiguration({
 	'id': TELEMETRY_SECTION_ID,
 	'order': 1,
 	'type': 'object',
@@ -223,33 +224,19 @@ Registry.as<IConfigurationRegistry>(Extensions.Configuration).registerConfigurat
 			'policy': {
 				name: 'TelemetryLevel',
 				minimumVersion: '1.99',
+				description: localize('telemetry.telemetryLevel.policyDescription', "Controls the level of telemetry."),
 			}
-		}
-	},
-});
-
-Registry.as<IConfigurationRegistry>(Extensions.Configuration).registerConfiguration({
-	'id': TELEMETRY_SECTION_ID,
-	properties: {
+		},
 		'telemetry.disableFeedback': {
 			type: 'boolean',
 			default: false,
-			description: 'Disable feedback options.',
+			description: localize('telemetry.disableFeedback', "Disable feedback options."),
 			policy: {
 				name: 'DisableFeedback',
 				minimumVersion: '1.99',
 			}
 		},
-	},
-});
-
-// Deprecated telemetry setting
-Registry.as<IConfigurationRegistry>(Extensions.Configuration).registerConfiguration({
-	'id': TELEMETRY_SECTION_ID,
-	'order': 110,
-	'type': 'object',
-	'title': localize('telemetryConfigurationTitle', "Telemetry"),
-	'properties': {
+		// Deprecated telemetry setting
 		[TELEMETRY_OLD_SETTING_ID]: {
 			'type': 'boolean',
 			'markdownDescription':
@@ -262,6 +249,5 @@ Registry.as<IConfigurationRegistry>(Extensions.Configuration).registerConfigurat
 			'scope': ConfigurationScope.APPLICATION,
 			'tags': ['usesOnlineServices', 'telemetry']
 		}
-	}
+	},
 });
-


### PR DESCRIPTION
- Make policy parsing more resilient by understanding string properties
- Have policy parsing spit out parse errors with locations
- Fix missing `PolicyType` enum values
- Make policy parsing spit out detected policies
- Bump tree sitter (for no good reason)
- Support optional policy `description` key
- Fix telemetry usage of policy config contributions, merge all of those into a single `registerConfiguration` call
- Fix telemetry contribution missing `localize` call

cc @justschen