### PR TITLE
add terminal suggest telemetry

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminal.suggest.contribution.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminal.suggest.contribution.ts
@@ -160,7 +160,7 @@ class TerminalSuggestContribution extends DisposableStore implements ITerminalCo
 				// Don't hide the suggest widget if the focus is moving to the details
 				return;
 			}
-			addon.hideSuggestWidget(true, true);
+			addon.hideSuggestWidget(true);
 		}));
 
 		this.add(addon.onAcceptedCompletion(async text => {
@@ -374,7 +374,7 @@ registerActiveInstanceAction({
 		// Escape is bound to other workbench keybindings that this needs to beat
 		weight: KeybindingWeight.WorkbenchContrib + 1
 	},
-	run: (activeInstance) => TerminalSuggestContribution.get(activeInstance)?.addon?.hideSuggestWidget(true, true)
+	run: (activeInstance) => TerminalSuggestContribution.get(activeInstance)?.addon?.hideSuggestWidget(true)
 });
 
 registerActiveInstanceAction({
@@ -389,7 +389,7 @@ registerActiveInstanceAction({
 		weight: KeybindingWeight.WorkbenchContrib + 2
 	},
 	run: (activeInstance) => {
-		TerminalSuggestContribution.get(activeInstance)?.addon?.hideSuggestWidget(true, true);
+		TerminalSuggestContribution.get(activeInstance)?.addon?.hideSuggestWidget(true);
 		activeInstance.sendText('\u001b[A', false); // Up arrow
 	}
 });

--- a/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminal.suggest.contribution.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminal.suggest.contribution.ts
@@ -160,7 +160,7 @@ class TerminalSuggestContribution extends DisposableStore implements ITerminalCo
 				// Don't hide the suggest widget if the focus is moving to the details
 				return;
 			}
-			addon.hideSuggestWidget(true);
+			addon.hideSuggestWidget(true, true);
 		}));
 
 		this.add(addon.onAcceptedCompletion(async text => {
@@ -374,7 +374,7 @@ registerActiveInstanceAction({
 		// Escape is bound to other workbench keybindings that this needs to beat
 		weight: KeybindingWeight.WorkbenchContrib + 1
 	},
-	run: (activeInstance) => TerminalSuggestContribution.get(activeInstance)?.addon?.hideSuggestWidget(true)
+	run: (activeInstance) => TerminalSuggestContribution.get(activeInstance)?.addon?.hideSuggestWidget(true, true)
 });
 
 registerActiveInstanceAction({
@@ -389,7 +389,7 @@ registerActiveInstanceAction({
 		weight: KeybindingWeight.WorkbenchContrib + 2
 	},
 	run: (activeInstance) => {
-		TerminalSuggestContribution.get(activeInstance)?.addon?.hideSuggestWidget(true);
+		TerminalSuggestContribution.get(activeInstance)?.addon?.hideSuggestWidget(true, true);
 		activeInstance.sendText('\u001b[A', false); // Up arrow
 	}
 });

--- a/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalSuggestAddon.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalSuggestAddon.ts
@@ -250,27 +250,15 @@ export class SuggestAddon extends Disposable implements ITerminalAddon, ISuggest
 			outcome = CompletionOutcome.Deleted;
 		}
 		this._telemetryService.publicLog2<{
-			label: string;
 			kind: string | undefined;
-			commandLine: string;
 			outcome: CompletionOutcome;
 		}, {
 			owner: 'meganrogge';
 			comment: 'This data is collected to understand the outcome of a terminal completion acceptance.';
-			label: {
-				classification: 'SystemMetaData';
-				purpose: 'FeatureInsight';
-				comment: 'The completion item\'s label';
-			};
 			kind: {
 				classification: 'SystemMetaData';
 				purpose: 'FeatureInsight';
 				comment: 'The completion item\'s kind';
-			};
-			commandLine: {
-				classification: 'SystemMetaData';
-				purpose: 'FeatureInsight';
-				comment: 'The full command line';
 			};
 			outcome: {
 				classification: 'SystemMetaData';
@@ -278,9 +266,7 @@ export class SuggestAddon extends Disposable implements ITerminalAddon, ISuggest
 				comment: 'The outcome of the accepted completion';
 			};
 		}>('terminal.suggest.acceptedCompletion', {
-			label,
 			kind,
-			commandLine,
 			outcome
 		});
 	}

--- a/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalSuggestAddon.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalSuggestAddon.ts
@@ -242,9 +242,9 @@ export class SuggestAddon extends Disposable implements ITerminalAddon, ISuggest
 		let outcome: CompletionOutcome;
 		if (fromInterrupt) {
 			outcome = CompletionOutcome.Interrupted;
-		} else if (commandLine.trim() && commandLine.endsWith(label)) {
+		} else if (commandLine.trim() && commandLine.includes(label)) {
 			outcome = CompletionOutcome.Accepted;
-		} else if (inputMostlyMatchesLabel(commandLine, label)) {
+		} else if (inputContainsFirstHalfOfLabel(commandLine, label)) {
 			outcome = CompletionOutcome.AcceptedWithEdit;
 		} else {
 			outcome = CompletionOutcome.Deleted;
@@ -904,25 +904,8 @@ export function normalizePathSeparator(path: string, sep: string): string {
 	return path.replaceAll('/', '\\');
 }
 
-function inputMostlyMatchesLabel(commandLine: string, label: string): boolean {
-	const lastWordOfCommandLine = commandLine.split(' ').pop() ?? '';
-	let labelIndex = 0;
-	let matchedChars = 0;
-	// At least half of label must be matched
-	const requiredMatches = Math.ceil(label.length / 2);
-
-	for (const char of lastWordOfCommandLine) {
-		if (char === label[labelIndex]) {
-			matchedChars++;
-			labelIndex++;
-		}
-		if (matchedChars >= requiredMatches) {
-			// We've matched enough in order
-			return true;
-		}
-	}
-
-	return false;
+function inputContainsFirstHalfOfLabel(commandLine: string, label: string): boolean {
+	return commandLine.includes(label.substring(0, Math.ceil(label.length / 2)));
 }
 
 const enum CompletionOutcome {

--- a/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalSuggestAddon.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalSuggestAddon.ts
@@ -186,6 +186,10 @@ export class SuggestAddon extends Disposable implements ITerminalAddon, ISuggest
 						this._promptInputModel.onDidChangeInput(e => this._sync(e)),
 						this._promptInputModel.onDidFinishInput(() => {
 							this.hideSuggestWidget(true);
+						}),
+						this._promptInputModel.onDidInterrupt(() => {
+							this._sendTelemetryInfo(true);
+							this._mostRecentAcceptedCompletionsForCurrentExecution = undefined;
 						})
 					);
 					if (this._shouldSyncWhenReady) {
@@ -223,13 +227,6 @@ export class SuggestAddon extends Disposable implements ITerminalAddon, ISuggest
 		this._register(xterm.onKey(async e => {
 			this._lastUserData = e.key;
 			this._lastUserDataTimestamp = Date.now();
-		}));
-		this._register(this._terminal.onData(e => {
-			if (e === '\x03') {
-				// Ctrl+C
-				this._sendTelemetryInfo(true);
-				this._mostRecentAcceptedCompletionsForCurrentExecution = undefined;
-			}
 		}));
 	}
 

--- a/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalSuggestAddon.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalSuggestAddon.ts
@@ -183,7 +183,7 @@ export class SuggestAddon extends Disposable implements ITerminalAddon, ISuggest
 						this._promptInputModel.onDidFinishInput(() => {
 							this._sendTelemetryInfo();
 							this._mostRecentPromptInputState = undefined;
-							this.hideSuggestWidget(true);
+							this.hideSuggestWidget(true, true);
 						})
 					);
 					if (this._shouldSyncWhenReady) {

--- a/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalSuggestTelemetry.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalSuggestTelemetry.ts
@@ -18,7 +18,7 @@ export class TerminalSuggestTelemetry extends Disposable {
 		@ITelemetryService private readonly _telemetryService: ITelemetryService,
 	) {
 		super();
-		this._register(commandDetection?.onCommandFinished((e) => {
+		this._register(commandDetection.onCommandFinished((e) => {
 			this._sendTelemetryInfo(false, e.exitCode);
 			this._acceptedCompletions = undefined;
 		}));

--- a/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalSuggestTelemetry.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalSuggestTelemetry.ts
@@ -1,0 +1,97 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Disposable } from '../../../../../base/common/lifecycle.js';
+import { ITelemetryService } from '../../../../../platform/telemetry/common/telemetry.js';
+import { ICommandDetectionCapability } from '../../../../../platform/terminal/common/capabilities/capabilities.js';
+import { IPromptInputModel } from '../../../../../platform/terminal/common/capabilities/commandDetection/promptInputModel.js';
+import { ITerminalCompletion } from './terminalCompletionItem.js';
+
+export class TerminalSuggestTelemetry extends Disposable {
+	private _acceptedCompletions: Array<{ label: string; kindLabel?: string }> | undefined;
+
+	constructor(
+		commandDetection: ICommandDetectionCapability,
+		private readonly _promptInputModel: IPromptInputModel,
+		@ITelemetryService private readonly _telemetryService: ITelemetryService,
+	) {
+		super();
+		this._register(commandDetection?.onCommandFinished((e) => {
+			this._sendTelemetryInfo(false, e.exitCode);
+			this._acceptedCompletions = undefined;
+		}));
+		this._register(this._promptInputModel.onDidInterrupt(() => {
+			this._sendTelemetryInfo(true);
+			this._acceptedCompletions = undefined;
+		}));
+	}
+	acceptCompletion(completion: ITerminalCompletion | undefined, commandLine?: string): void {
+		if (!completion || !commandLine) {
+			this._acceptedCompletions = undefined;
+			return;
+		}
+		this._acceptedCompletions = this._acceptedCompletions || [];
+		this._acceptedCompletions.push({ label: typeof completion.label === 'string' ? completion.label : completion.label.label, kindLabel: completion.kindLabel });
+	}
+	private _sendTelemetryInfo(fromInterrupt?: boolean, exitCode?: number): void {
+		const commandLine = this._promptInputModel?.value;
+		for (const completion of this._acceptedCompletions || []) {
+			const label = completion?.label;
+			const kind = completion?.kindLabel;
+			if (label === undefined || commandLine === undefined || kind === undefined) {
+				return;
+			}
+
+			let outcome: CompletionOutcome;
+			if (fromInterrupt) {
+				outcome = CompletionOutcome.Interrupted;
+			} else if (commandLine.trim() && commandLine.includes(label)) {
+				outcome = CompletionOutcome.Accepted;
+			} else if (inputContainsFirstHalfOfLabel(commandLine, label)) {
+				outcome = CompletionOutcome.AcceptedWithEdit;
+			} else {
+				outcome = CompletionOutcome.Deleted;
+			}
+			this._telemetryService.publicLog2<{
+				kind: string | undefined;
+				outcome: CompletionOutcome;
+				exitCode: number | undefined;
+			}, {
+				owner: 'meganrogge';
+				comment: 'This data is collected to understand the outcome of a terminal completion acceptance.';
+				kind: {
+					classification: 'SystemMetaData';
+					purpose: 'FeatureInsight';
+					comment: 'The completion item\'s kind';
+				};
+				outcome: {
+					classification: 'SystemMetaData';
+					purpose: 'FeatureInsight';
+					comment: 'The outcome of the accepted completion';
+				};
+				exitCode: {
+					classification: 'SystemMetaData';
+					purpose: 'FeatureInsight';
+					comment: 'The exit code from the command';
+				};
+			}>('terminal.suggest.acceptedCompletion', {
+				kind,
+				outcome,
+				exitCode
+			});
+		}
+	}
+}
+
+function inputContainsFirstHalfOfLabel(commandLine: string, label: string): boolean {
+	return commandLine.includes(label.substring(0, Math.ceil(label.length / 2)));
+}
+
+const enum CompletionOutcome {
+	Accepted = 'Accepted',
+	Deleted = 'Deleted',
+	AcceptedWithEdit = 'AcceptedWithEdit',
+	Interrupted = 'Interrupted'
+}


### PR DESCRIPTION
fixes https://github.com/microsoft/vscode-internalbacklog/issues/5399

Sends telemetry info when input finishes (a command is executed). Stores the accepted completion, clearing it when the user manually hides the suggest widget and right after the telemetry event is sent.

https://github.com/microsoft/vscode/blob/0e93547d4f3e1e920d94b1d288b36d8ae97ee0ff/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalSuggestAddon.ts#L924-L930

https://github.com/microsoft/vscode/blob/0e93547d4f3e1e920d94b1d288b36d8ae97ee0ff/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalSuggestAddon.ts#L261-L278

