### PR TITLE
timeout if terminal completion provider takes too long

### DIFF
--- a/extensions/terminal-suggest/src/helpers/promise.ts
+++ b/extensions/terminal-suggest/src/helpers/promise.ts
@@ -1,0 +1,8 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+export function createTimeoutPromise<T>(timeout: number, defaultValue: T): Promise<T> {
+	return new Promise(resolve => setTimeout(() => resolve(defaultValue), timeout));
+}

--- a/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalCompletionService.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalCompletionService.ts
@@ -166,7 +166,10 @@ export class TerminalCompletionService extends Disposable implements ITerminalCo
 			if (provider.shellTypes && !provider.shellTypes.includes(shellType)) {
 				return undefined;
 			}
-			const completions = await provider.provideCompletions(promptValue, cursorPosition, allowFallbackCompletions, token);
+			const completions = await Promise.race([
+				provider.provideCompletions(promptValue, cursorPosition, allowFallbackCompletions, token),
+				new Promise<undefined>(resolve => setTimeout(() => resolve(undefined), 5000))
+			]);
 			if (!completions) {
 				return undefined;
 			}

--- a/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalCompletionService.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalCompletionService.ts
@@ -169,7 +169,7 @@ export class TerminalCompletionService extends Disposable implements ITerminalCo
 			}
 			const completions = await Promise.race([
 				provider.provideCompletions(promptValue, cursorPosition, allowFallbackCompletions, token),
-				timeout(300)
+				timeout(5000)
 			]);
 			if (!completions) {
 				return undefined;

--- a/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalCompletionService.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalCompletionService.ts
@@ -16,6 +16,7 @@ import { TerminalSuggestSettingId } from '../common/terminalSuggestConfiguration
 import { TerminalCompletionItemKind, type ITerminalCompletion } from './terminalCompletionItem.js';
 import { env as processEnv } from '../../../../../base/common/process.js';
 import type { IProcessEnvironment } from '../../../../../base/common/platform.js';
+import { timeout } from '../../../../../base/common/async.js';
 
 export const ITerminalCompletionService = createDecorator<ITerminalCompletionService>('terminalCompletionService');
 
@@ -168,7 +169,7 @@ export class TerminalCompletionService extends Disposable implements ITerminalCo
 			}
 			const completions = await Promise.race([
 				provider.provideCompletions(promptValue, cursorPosition, allowFallbackCompletions, token),
-				new Promise<undefined>(resolve => setTimeout(() => resolve(undefined), 5000))
+				timeout(5000)
 			]);
 			if (!completions) {
 				return undefined;

--- a/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalCompletionService.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalCompletionService.ts
@@ -169,7 +169,7 @@ export class TerminalCompletionService extends Disposable implements ITerminalCo
 			}
 			const completions = await Promise.race([
 				provider.provideCompletions(promptValue, cursorPosition, allowFallbackCompletions, token),
-				timeout(5000)
+				timeout(300)
 			]);
 			if (!completions) {
 				return undefined;


### PR DESCRIPTION
fix #243355

The analogous thing in the editor is on `resolveCompletions` and we don't have that mechanism yet, tracked here. https://github.com/microsoft/vscode/issues/240236

https://github.com/microsoft/vscode/blob/fb7dfdb303b17e5d07427f4c045f701649ad6f1c/extensions/typescript-language-features/src/languageFeatures/completions.ts#L153-L166