### PR TITLE
mcp: various fixes around trust and indicator

### DIFF
--- a/src/vs/platform/observable/common/observableMemento.ts
+++ b/src/vs/platform/observable/common/observableMemento.ts
@@ -1,0 +1,96 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { strictEquals } from '../../../base/common/equals.js';
+import { DisposableStore, IDisposable } from '../../../base/common/lifecycle.js';
+import { ISettableObservable } from '../../../base/common/observable.js';
+import { ObservableValue } from '../../../base/common/observableInternal/base.js';
+import { DebugNameData } from '../../../base/common/observableInternal/debugName.js';
+import { IStorageService, StorageScope, StorageTarget } from '../../storage/common/storage.js';
+
+interface IObservableMementoOpts<T> {
+	defaultValue: T;
+	key: string;
+	/** Storage options, defaults to JSON storage if the defaultValue is an object */
+	toStorage?: (value: T) => string;
+	fromStorage?: (value: string) => T;
+}
+
+/**
+ * Defines an observable memento. Returns a function that can be called with
+ * the specific storage scope, target, and service to use in a class.
+ *
+ * Note that the returned Observable is a disposable, because it interacts
+ * with storage service events, and must be tracked appropriately.
+ */
+export function observableMemento<T>(opts: IObservableMementoOpts<T>) {
+	return (scope: StorageScope, target: StorageTarget, storageService: IStorageService): ISettableObservable<T> & IDisposable => {
+		return new ObservableMemento<T>(opts, scope, target, storageService);
+	};
+}
+
+/**
+ * A value that is stored, and is also observable. Note: T should be readonly.
+ */
+class ObservableMemento<T> extends ObservableValue<T> implements IDisposable {
+	private readonly _store = new DisposableStore();
+	private _didChange = false;
+
+	constructor(
+		opts: IObservableMementoOpts<T>,
+		storageScope: StorageScope,
+		storageTarget: StorageTarget,
+		@IStorageService storageService: IStorageService,
+	) {
+		if (opts.defaultValue && typeof opts.defaultValue === 'object') {
+			opts.toStorage ??= (value: T) => JSON.stringify(value);
+			opts.fromStorage ??= (value: string) => JSON.parse(value);
+		}
+
+		let initialValue = opts.defaultValue;
+
+		const fromStorage = storageService.get(opts.key, storageScope);
+		if (fromStorage !== undefined) {
+			if (opts.fromStorage) {
+				try {
+					initialValue = opts.fromStorage(fromStorage);
+				} catch {
+					initialValue = opts.defaultValue;
+				}
+			}
+		}
+
+		super(new DebugNameData(undefined, `storage/${opts.key}`, undefined), initialValue, strictEquals);
+
+		const didChange = storageService.onDidChangeValue(storageScope, opts.key, this._store);
+		// only take external changes if there aren't local changes we've made
+		this._store.add(didChange((e) => {
+			if (e.external && e.key === opts.key && !this._didChange) {
+				this.set(opts.defaultValue, undefined);
+			}
+		}));
+
+		this._store.add(storageService.onWillSaveState(() => {
+			if (this._didChange) {
+				this._didChange = false;
+				const value = this.get();
+				if (opts.toStorage) {
+					storageService.store(opts.key, opts.toStorage(value), storageScope, storageTarget);
+				} else {
+					storageService.store(opts.key, String(value), storageScope, storageTarget);
+				}
+			}
+		}));
+	}
+
+	protected override _setValue(newValue: T): void {
+		super._setValue(newValue);
+		this._didChange = true;
+	}
+
+	dispose(): void {
+		this._store.dispose();
+	}
+}

--- a/src/vs/workbench/contrib/mcp/browser/mcp.contribution.ts
+++ b/src/vs/workbench/contrib/mcp/browser/mcp.contribution.ts
@@ -19,7 +19,7 @@ import { McpService } from '../common/mcpService.js';
 import { IMcpService } from '../common/mcpTypes.js';
 import { McpDiscovery } from './mcpDiscovery.js';
 
-import { AttachMCPToolsAction, AttachMCPToolsActionRendering, ListMcpServerCommand, McpServerOptionsCommand } from './mcpCommands.js';
+import { AttachMCPToolsAction, AttachMCPToolsActionRendering, ListMcpServerCommand, ResetMcpTrustCommand, McpServerOptionsCommand } from './mcpCommands.js';
 
 import { registerAction2 } from '../../../../platform/actions/common/actions.js';
 import { McpContextKeysController } from '../common/mcpContextKeys.js';
@@ -36,6 +36,7 @@ registerWorkbenchContribution2('mcpContextKeys', McpContextKeysController, Workb
 registerAction2(ListMcpServerCommand);
 registerAction2(McpServerOptionsCommand);
 registerAction2(AttachMCPToolsAction);
+registerAction2(ResetMcpTrustCommand);
 registerWorkbenchContribution2('mcpActionRendering', AttachMCPToolsActionRendering, WorkbenchPhase.BlockRestore);
 
 const jsonRegistry = <jsonContributionRegistry.IJSONContributionRegistry>Registry.as(jsonContributionRegistry.Extensions.JSONContribution);

--- a/src/vs/workbench/contrib/mcp/common/mcpContextKeys.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpContextKeys.ts
@@ -9,12 +9,13 @@ import { autorun } from '../../../../base/common/observable.js';
 import { localize } from '../../../../nls.js';
 import { IContextKeyService, RawContextKey } from '../../../../platform/contextkey/common/contextkey.js';
 import { IWorkbenchContribution } from '../../../common/contributions.js';
-import { IMcpService } from './mcpTypes.js';
+import { IMcpService, McpServerToolsState } from './mcpTypes.js';
 
 
 export namespace McpContextKeys {
 
 	export const serverCount = new RawContextKey<number>('mcp.serverCount', undefined, { type: 'number', description: localize('mcp.serverCount.description', "Context key that has the number of registered MCP servers") });
+	export const hasUnknownTools = new RawContextKey<boolean>('mcp.hasUnknownTools', undefined, { type: 'boolean', description: localize('mcp.hasUnknownTools.description', "Indicates whether there are MCP servers with unknown tools.") });
 	export const toolsCount = new RawContextKey<number>('mcp.toolsCount', undefined, { type: 'number', description: localize('mcp.toolsCount.description', "Context key that has the number of registered MCP tools") });
 }
 
@@ -31,10 +32,21 @@ export class McpContextKeysController extends Disposable implements IWorkbenchCo
 
 		const ctxServerCount = McpContextKeys.serverCount.bindTo(contextKeyService);
 		const ctxToolsCount = McpContextKeys.toolsCount.bindTo(contextKeyService);
+		const ctxHasUnknownTools = McpContextKeys.hasUnknownTools.bindTo(contextKeyService);
 
 		this._store.add(autorun(r => {
-			ctxServerCount.set(mcpService.servers.read(r).length);
-			ctxToolsCount.set(mcpService.servers.read(r).reduce((count, server) => count + server.tools.read(r).length, 0));
+			const servers = mcpService.servers.read(r);
+			const serverTools = servers.map(s => s.tools.read(r));
+			ctxServerCount.set(servers.length);
+			ctxToolsCount.set(serverTools.reduce((count, tools) => count + tools.length, 0));
+			ctxHasUnknownTools.set(servers.some(s => {
+				if (s.trusted.read(r) === false) {
+					return false;
+				}
+
+				const toolState = s.toolsState.read(r);
+				return toolState === McpServerToolsState.Unknown || toolState === McpServerToolsState.RefreshingFromUnknown;
+			}));
 		}));
 	}
 }

--- a/src/vs/workbench/contrib/mcp/common/mcpRegistryTypes.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpRegistryTypes.ts
@@ -42,6 +42,12 @@ export interface IMcpRegistry {
 	registerDelegate(delegate: IMcpHostDelegate): IDisposable;
 	registerCollection(collection: McpCollectionDefinition): IDisposable;
 
+	/** Resets the trust state of all collections. */
+	resetTrust(): void;
+
+	/** Gets whether the collection is trusted. */
+	getTrust(collection: McpCollectionDefinition): IObservable<boolean | undefined>;
+
 	/** Resets any saved inputs for the connection. */
 	clearSavedInputs(collection: McpCollectionDefinition, definition: McpServerDefinition): void;
 	/** Creates a connection for the collection and definition. */

--- a/src/vs/workbench/contrib/mcp/common/mcpServer.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpServer.ts
@@ -79,7 +79,9 @@ export class McpServer extends Disposable implements IMcpServer {
 
 	public readonly toolsState = derived(reader => {
 		const fromServer = this.toolsFromServerPromise.read(reader);
-		if (!fromServer) {
+		const connectionState = this.connectionState.read(reader);
+		const isIdle = McpConnectionState.canBeStarted(connectionState.state) && !fromServer;
+		if (isIdle) {
 			return this.toolsFromCache ? McpServerToolsState.Cached : McpServerToolsState.Unknown;
 		}
 
@@ -90,6 +92,10 @@ export class McpServer extends Disposable implements IMcpServer {
 
 		return fromServerResult.error ? (this.toolsFromCache ? McpServerToolsState.Cached : McpServerToolsState.Unknown) : McpServerToolsState.Live;
 	});
+
+	public get trusted() {
+		return this._mcpRegistry.getTrust(this.collection);
+	}
 
 	constructor(
 		public readonly collection: McpCollectionDefinition,

--- a/src/vs/workbench/contrib/mcp/common/mcpTypes.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpTypes.ts
@@ -102,6 +102,12 @@ export interface IMcpServer extends IDisposable {
 	readonly collection: McpCollectionDefinition;
 	readonly definition: McpServerDefinition;
 	readonly connectionState: IObservable<McpConnectionState>;
+	/**
+	 * Reflects the MCP server trust state. True if trusted, false if untrusted,
+	 * undefined if consent is required but not indicated.
+	 */
+	readonly trusted: IObservable<boolean | undefined>;
+
 	showOutput(): void;
 	/**
 	 * Starts the server and returns its resulting state. One of:

--- a/src/vs/workbench/contrib/mcp/test/common/mcpRegistry.test.ts
+++ b/src/vs/workbench/contrib/mcp/test/common/mcpRegistry.test.ts
@@ -26,7 +26,6 @@ import { IMcpHostDelegate, IMcpMessageTransport } from '../../common/mcpRegistry
 import { McpServerConnection } from '../../common/mcpServerConnection.js';
 import { McpCollectionDefinition, McpServerDefinition, McpServerTransportType } from '../../common/mcpTypes.js';
 import { TestMcpMessageTransport } from './mcpRegistryTypes.js';
-import { Memento } from '../../../../common/memento.js';
 
 class TestConfigurationResolverService implements Partial<IConfigurationResolverService> {
 	declare readonly _serviceBrand: undefined;
@@ -195,10 +194,6 @@ suite('Workbench - MCP - Registry', () => {
 				cwd: URI.parse('file:///test')
 			}
 		};
-	});
-
-	teardown(() => {
-		Memento.clear(StorageScope.APPLICATION);
 	});
 
 	test('registerCollection adds collection to registry', () => {


### PR DESCRIPTION
- Show the tools indicator as spinning while a server is staring up
- Don't show it if there are unknown tools from untrusted servers
- Fix some state issues around the trust storage, don't pop multiple dialogs
- Add a reset trust command

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
