### PR TITLE
Fix inline chat after updating to use "edit2" in the extension

### DIFF
--- a/src/vs/platform/extensions/common/extensionsApiProposals.ts
+++ b/src/vs/platform/extensions/common/extensionsApiProposals.ts
@@ -33,7 +33,7 @@ const _allApiProposals = {
 	},
 	chatParticipantPrivate: {
 		proposal: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.chatParticipantPrivate.d.ts',
-		version: 5
+		version: 6
 	},
 	chatProvider: {
 		proposal: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.chatProvider.d.ts',

--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChatSessionServiceImpl.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChatSessionServiceImpl.ts
@@ -409,10 +409,10 @@ export class InlineChatEnabler {
 
 		const updateAgent = () => {
 			const agent = chatAgentService.getDefaultAgent(ChatAgentLocation.Editor);
-			if (agent?.locations.length === 1) {
+			if (agent?.id === 'github.copilot.editor') {
 				this._ctxHasProvider.set(true);
 				this._ctxHasProvider2.reset();
-			} else if (agent?.locations.includes(ChatAgentLocation.EditingSession)) {
+			} else if (agent?.id === 'github.copilot.editingSessionEditor') {
 				this._ctxHasProvider.reset();
 				this._ctxHasProvider2.set(true);
 			} else {

--- a/src/vscode-dts/vscode.proposed.chatParticipantPrivate.d.ts
+++ b/src/vscode-dts/vscode.proposed.chatParticipantPrivate.d.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-// version: 5
+// version: 6
 
 declare module 'vscode' {
 


### PR DESCRIPTION
Bump API version because these have to be aligned

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
