### PR TITLE
make select tools for all tools, not just MCP tools

### DIFF
--- a/src/vs/workbench/api/common/extHost.api.impl.ts
+++ b/src/vs/workbench/api/common/extHost.api.impl.ts
@@ -212,8 +212,8 @@ export function createApiFactoryAndRegisterActors(accessor: ServicesAccessor): I
 	const extHostUriOpeners = rpcProtocol.set(ExtHostContext.ExtHostUriOpeners, new ExtHostUriOpeners(rpcProtocol));
 	const extHostProfileContentHandlers = rpcProtocol.set(ExtHostContext.ExtHostProfileContentHandlers, new ExtHostProfileContentHandlers(rpcProtocol));
 	rpcProtocol.set(ExtHostContext.ExtHostInteractive, new ExtHostInteractive(rpcProtocol, extHostNotebook, extHostDocumentsAndEditors, extHostCommands, extHostLogService));
-	const extHostChatAgents2 = rpcProtocol.set(ExtHostContext.ExtHostChatAgents2, new ExtHostChatAgents2(rpcProtocol, extHostLogService, extHostCommands, extHostDocuments, extHostLanguageModels, extHostDiagnostics));
 	const extHostLanguageModelTools = rpcProtocol.set(ExtHostContext.ExtHostLanguageModelTools, new ExtHostLanguageModelTools(rpcProtocol));
+	const extHostChatAgents2 = rpcProtocol.set(ExtHostContext.ExtHostChatAgents2, new ExtHostChatAgents2(rpcProtocol, extHostLogService, extHostCommands, extHostDocuments, extHostLanguageModels, extHostDiagnostics, extHostLanguageModelTools));
 	const extHostAiRelatedInformation = rpcProtocol.set(ExtHostContext.ExtHostAiRelatedInformation, new ExtHostRelatedInformation(rpcProtocol));
 	const extHostAiEmbeddingVector = rpcProtocol.set(ExtHostContext.ExtHostAiEmbeddingVector, new ExtHostAiEmbeddingVector(rpcProtocol));
 	const extHostStatusBar = rpcProtocol.set(ExtHostContext.ExtHostStatusBar, new ExtHostStatusBar(rpcProtocol, extHostCommands.converter));

--- a/src/vs/workbench/api/common/extHostChatAgents2.ts
+++ b/src/vs/workbench/api/common/extHostChatAgents2.ts
@@ -559,10 +559,10 @@ export class ExtHostChatAgents2 extends Disposable implements ExtHostChatAgentsS
 	}
 
 	private getToolsForRequest(extension: IExtensionDescription, request: Dto<IChatAgentRequest>) {
-		if (!isNonEmptyArray(request.useSelectedTools)) {
+		if (!isNonEmptyArray(request.userSelectedTools)) {
 			return undefined;
 		}
-		const selector = new Set(request.useSelectedTools);
+		const selector = new Set(request.userSelectedTools);
 		return this._tools.getTools(extension).filter(candidate => selector.has(candidate.name));
 	}
 

--- a/src/vs/workbench/api/common/extHostTypeConverters.ts
+++ b/src/vs/workbench/api/common/extHostTypeConverters.ts
@@ -2766,7 +2766,7 @@ export namespace ChatResponsePart {
 }
 
 export namespace ChatAgentRequest {
-	export function to(request: IChatAgentRequest, location2: vscode.ChatRequestEditorData | vscode.ChatRequestNotebookData | undefined, model: vscode.LanguageModelChat, diagnostics: readonly [vscode.Uri, readonly vscode.Diagnostic[]][]): vscode.ChatRequest {
+	export function to(request: IChatAgentRequest, location2: vscode.ChatRequestEditorData | vscode.ChatRequestNotebookData | undefined, model: vscode.LanguageModelChat, diagnostics: readonly [vscode.Uri, readonly vscode.Diagnostic[]][], tools: vscode.LanguageModelToolInformation[] | undefined): vscode.ChatRequest {
 		const toolReferences = request.variables.variables.filter(v => v.isTool);
 		const variableReferences = request.variables.variables.filter(v => !v.isTool);
 		const requestWithoutId = {
@@ -2782,6 +2782,7 @@ export namespace ChatAgentRequest {
 			rejectedConfirmationData: request.rejectedConfirmationData,
 			location2,
 			toolInvocationToken: Object.freeze({ sessionId: request.sessionId }) as never,
+			tools,
 			model
 		};
 		if (request.requestId) {

--- a/src/vs/workbench/contrib/chat/browser/actions/chatToolActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatToolActions.ts
@@ -3,16 +3,26 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { Codicon } from '../../../../../base/common/codicons.js';
+import { diffSets } from '../../../../../base/common/collections.js';
+import { Event } from '../../../../../base/common/event.js';
 import { KeyCode, KeyMod } from '../../../../../base/common/keyCodes.js';
+import { DisposableStore } from '../../../../../base/common/lifecycle.js';
 import { ServicesAccessor } from '../../../../../editor/browser/editorExtensions.js';
-import { localize2 } from '../../../../../nls.js';
-import { Action2, registerAction2 } from '../../../../../platform/actions/common/actions.js';
+import { localize, localize2 } from '../../../../../nls.js';
+import { Action2, MenuId, registerAction2 } from '../../../../../platform/actions/common/actions.js';
 import { ContextKeyExpr } from '../../../../../platform/contextkey/common/contextkey.js';
+import { ExtensionIdentifier } from '../../../../../platform/extensions/common/extensions.js';
 import { KeybindingWeight } from '../../../../../platform/keybinding/common/keybindingsRegistry.js';
+import { IQuickInputService, IQuickPickItem, IQuickPickSeparator } from '../../../../../platform/quickinput/common/quickInput.js';
+import { IExtensionService } from '../../../../services/extensions/common/extensions.js';
+import { IMcpService, IMcpServer, McpConnectionState } from '../../../mcp/common/mcpTypes.js';
 import { ChatContextKeys } from '../../common/chatContextKeys.js';
 import { IChatToolInvocation } from '../../common/chatService.js';
 import { isResponseVM } from '../../common/chatViewModel.js';
-import { IChatWidgetService } from '../chat.js';
+import { ChatMode } from '../../common/constants.js';
+import { ILanguageModelToolsService, IToolData } from '../../common/languageModelToolsService.js';
+import { IChatWidget, IChatWidgetService } from '../chat.js';
 import { CHAT_CATEGORY } from './chatActions.js';
 
 export const AcceptToolConfirmationActionId = 'workbench.action.chat.acceptTool';
@@ -51,6 +61,223 @@ class AcceptToolConfirmation extends Action2 {
 	}
 }
 
+export class AttachToolsAction extends Action2 {
+
+	static readonly id = 'workbench.action.chat.attachTools';
+
+	constructor() {
+		super({
+			id: AttachToolsAction.id,
+			title: localize('label', "Select Tools..."),
+			icon: Codicon.tools,
+			f1: false,
+			category: CHAT_CATEGORY,
+			precondition: ContextKeyExpr.and(
+				ContextKeyExpr.or(ChatContextKeys.Tools.toolsCount.greater(0)),
+				ChatContextKeys.chatMode.isEqualTo(ChatMode.Agent)
+			),
+			menu: {
+				when: ContextKeyExpr.and(
+					ContextKeyExpr.or(ChatContextKeys.Tools.toolsCount.greater(0)),
+					ChatContextKeys.chatMode.isEqualTo(ChatMode.Agent)
+				),
+				id: MenuId.ChatInputAttachmentToolbar,
+				group: 'navigation',
+				order: 1
+			},
+			keybinding: {
+				when: ContextKeyExpr.and(ChatContextKeys.inChatInput, ChatContextKeys.chatMode.isEqualTo(ChatMode.Agent)),
+				primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.Slash,
+				weight: KeybindingWeight.EditorContrib
+			}
+		});
+	}
+
+	override async run(accessor: ServicesAccessor, ...args: any[]): Promise<void> {
+
+		const quickPickService = accessor.get(IQuickInputService);
+		const mcpService = accessor.get(IMcpService);
+		const toolsService = accessor.get(ILanguageModelToolsService);
+		const extensionService = accessor.get(IExtensionService);
+		const chatWidgetService = accessor.get(IChatWidgetService);
+
+		let widget = chatWidgetService.lastFocusedWidget;
+		if (!widget) {
+			type ChatActionContext = { widget: IChatWidget };
+			function isChatActionContext(obj: any): obj is ChatActionContext {
+				return obj && typeof obj === 'object' && (obj as ChatActionContext).widget;
+			}
+			const context = args[0];
+			if (isChatActionContext(context)) {
+				widget = context.widget;
+			}
+		}
+
+		if (!widget) {
+			return;
+		}
+
+		const mcpServerByTool = new Map<string, IMcpServer>();
+		for (const server of mcpService.servers.get()) {
+			for (const tool of server.tools.get()) {
+				mcpServerByTool.set(tool.id, server);
+			}
+		}
+
+		const enum BucketOrdinal { Extension, Mcp, Other }
+		type BucketPick = IQuickPickItem & { picked: boolean; ordinal: BucketOrdinal; status?: string; children: ToolPick[] };
+		type ToolPick = IQuickPickItem & { picked: boolean; tool: IToolData; parent: BucketPick };
+		type MyPick = ToolPick | BucketPick;
+
+		const defaultBucket: BucketPick = {
+			type: 'item',
+			children: [],
+			label: localize('defaultBucketLabel', "Other Tools"),
+			ordinal: BucketOrdinal.Other,
+			picked: true,
+		};
+
+		const toolBuckets = new Map<string, BucketPick>();
+
+		for (const tool of toolsService.getTools()) {
+
+			if (!tool.canBeReferencedInPrompt) {
+				continue;
+			}
+
+			let bucket: BucketPick;
+
+			const mcpServer = mcpServerByTool.get(tool.id);
+			const ext = extensionService.extensions.find(value => ExtensionIdentifier.equals(value.identifier, tool.extensionId));
+			if (mcpServer) {
+				bucket = toolBuckets.get(mcpServer.definition.id) ?? {
+					type: 'item',
+					label: mcpServer.definition.label,
+					// description: mcpServer.definition.,
+					status: localize('desc', "MCP - {0} ({1})", mcpServer.collection.label, McpConnectionState.toString(mcpServer.connectionState.get())),
+					ordinal: BucketOrdinal.Mcp,
+					picked: true,
+					children: []
+				};
+				toolBuckets.set(mcpServer.definition.id, bucket);
+			} else if (ext) {
+				bucket = toolBuckets.get(ExtensionIdentifier.toKey(ext.identifier)) ?? {
+					type: 'item',
+					label: ext.displayName ?? ext.name,
+					ordinal: BucketOrdinal.Extension,
+					picked: true,
+					children: []
+				};
+				toolBuckets.set(ExtensionIdentifier.toKey(ext.identifier), bucket);
+			} else {
+				bucket = defaultBucket;
+			}
+
+			bucket.children.push({
+				tool,
+				parent: bucket,
+				type: 'item',
+				label: `$(tools) ${tool.displayName}`,
+				description: tool.userDescription,
+				picked: true,
+				iconClasses: ['tool-pick']
+			});
+		}
+
+		function isBucketPick(obj: any): obj is BucketPick {
+			return Boolean((obj as BucketPick).children);
+		}
+		function isToolPick(obj: any): obj is ToolPick {
+			return Boolean((obj as ToolPick).tool);
+		}
+
+		const store = new DisposableStore();
+		const picker = store.add(quickPickService.createQuickPick<MyPick>({ useSeparators: true }));
+
+		const picks: (MyPick | IQuickPickSeparator)[] = [];
+
+		for (const bucket of Array.from(toolBuckets.values()).sort((a, b) => a.ordinal - b.ordinal)) {
+			picks.push({
+				type: 'separator',
+				label: bucket.status
+			});
+
+			picks.push(bucket);
+			picks.push(...bucket.children);
+		}
+
+
+		picker.placeholder = localize('placeholder', "Select tools that are available to chat");
+		picker.canSelectMany = true;
+
+		let lastSelectedItems = new Set<MyPick>();
+		let ignoreEvent = false;
+
+		const _update = () => {
+			ignoreEvent = true;
+			try {
+				const items = picks.filter((p): p is MyPick => p.type === 'item' && Boolean(p.picked));
+				lastSelectedItems = new Set(items);
+				picker.items = picks;
+				picker.selectedItems = items;
+			} finally {
+				ignoreEvent = false;
+			}
+		};
+
+		_update();
+		picker.show();
+
+		store.add(picker.onDidChangeSelection(selectedPicks => {
+			if (ignoreEvent) {
+				return;
+			}
+
+			const { added, removed } = diffSets(lastSelectedItems, new Set(selectedPicks));
+
+			for (const item of added) {
+				item.picked = true;
+
+				if (isBucketPick(item)) {
+					// add server -> add back tools
+					for (const toolPick of item.children) {
+						toolPick.picked = true;
+					}
+				} else if (isToolPick(item)) {
+					// add server when tool is picked
+					item.parent.picked = true;
+				}
+			}
+
+			for (const item of removed) {
+				item.picked = false;
+
+				if (isBucketPick(item)) {
+					// removed server -> remove tools
+					for (const toolPick of item.children) {
+						toolPick.picked = false;
+					}
+				} else if (isToolPick(item) && item.parent.children.every(child => !child.picked)) {
+					// remove LAST tool -> remove server
+					item.parent.picked = false;
+				}
+			}
+
+			_update();
+		}));
+
+
+		await Promise.race([Event.toPromise(Event.any(picker.onDidAccept, picker.onDidHide))]);
+
+		const selectedTools = picker.selectedItems.filter(isToolPick);
+
+		store.dispose();
+
+		widget.input.selectedToolsModel.update(selectedTools.map(tool => tool.tool));
+	}
+}
+
 export function registerChatToolActions() {
 	registerAction2(AcceptToolConfirmation);
+	registerAction2(AttachToolsAction);
 }

--- a/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
@@ -90,6 +90,7 @@ import { CollapsibleListPool, IChatCollapsibleListItem } from './chatContentPart
 import { ChatDragAndDrop } from './chatDragAndDrop.js';
 import { ChatEditingRemoveAllFilesAction, ChatEditingShowChangesAction } from './chatEditing/chatEditingActions.js';
 import { ChatFollowups } from './chatFollowups.js';
+import { ChatSelectedTools } from './chatSelectedTools.js';
 import { IChatViewState } from './chatWidget.js';
 import { ChatFileReference } from './contrib/chatDynamicVariables/chatFileReference.js';
 import { ChatImplicitContext } from './contrib/chatImplicitContext.js';
@@ -150,6 +151,8 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 	public get attachmentModel(): ChatAttachmentModel {
 		return this._attachmentModel;
 	}
+
+	readonly selectedToolsModel: ChatSelectedTools;
 
 	public getAttachedAndImplicitContext(sessionId: string): IChatRequestVariableEntry[] {
 		const contextArr = [...this.attachmentModel.attachments];
@@ -384,6 +387,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 		super();
 
 		this._attachmentModel = this._register(this.instantiationService.createInstance(ChatAttachmentModel));
+		this.selectedToolsModel = this._register(this.instantiationService.createInstance(ChatSelectedTools));
 		this.dnd = this._register(this.instantiationService.createInstance(ChatDragAndDrop, this._attachmentModel, styles));
 
 		this.getInputState = (): IChatInputState => {

--- a/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
@@ -199,19 +199,6 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 		contextArr
 			.push(...this.instructionAttachmentsPart.chatAttachments);
 
-
-		// // TODO@jrieken use only selected servers
-		// for (const server of this.mcpService.servers.get()) {
-		// 	for (const { id, definition } of server.tools.get()) {
-		// 		contextArr.push({
-		// 			isTool: true,
-		// 			id,
-		// 			name: definition.name,
-		// 			value: undefined
-		// 		});
-		// 	}
-		// }
-
 		return contextArr;
 	}
 

--- a/src/vs/workbench/contrib/chat/browser/chatSelectedTools.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSelectedTools.ts
@@ -1,0 +1,90 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+
+import { reset } from '../../../../base/browser/dom.js';
+import { renderLabelWithIcons } from '../../../../base/browser/ui/iconLabel/iconLabels.js';
+import { Event } from '../../../../base/common/event.js';
+import { Disposable } from '../../../../base/common/lifecycle.js';
+import { autorun, derived, IObservable, observableFromEvent, observableValue } from '../../../../base/common/observable.js';
+import { assertType } from '../../../../base/common/types.js';
+import { localize } from '../../../../nls.js';
+import { IActionViewItemService } from '../../../../platform/actions/browser/actionViewItemService.js';
+import { MenuEntryActionViewItem } from '../../../../platform/actions/browser/menuEntryActionViewItem.js';
+import { MenuId, MenuItemAction } from '../../../../platform/actions/common/actions.js';
+import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
+import { ILanguageModelToolsService, IToolData } from '../common/languageModelToolsService.js';
+import { AttachToolsAction } from './actions/chatToolActions.js';
+
+export class ChatSelectedTools extends Disposable {
+
+	private readonly _selectedTools = observableValue<IToolData[] | undefined>(this, undefined);
+
+	readonly tools: IObservable<IToolData[]>;
+
+	constructor(
+		@IActionViewItemService actionViewItemService: IActionViewItemService,
+		@ILanguageModelToolsService toolsService: ILanguageModelToolsService,
+		@IInstantiationService instaService: IInstantiationService
+	) {
+		super();
+
+		const allTools = observableFromEvent(
+			toolsService.onDidChangeTools,
+			() => Array.from(toolsService.getTools()).filter(t => t.canBeReferencedInPrompt)
+		);
+
+		this.tools = derived(r => {
+			const custom = this._selectedTools.read(r);
+			return custom ?? allTools.read(r);
+		});
+
+		const toolsCount = derived(r => {
+			const count = allTools.read(r).length;
+			const enabled = this.tools.read(r).length;
+			return { count, enabled };
+		});
+
+		this._store.add(actionViewItemService.register(MenuId.ChatInputAttachmentToolbar, AttachToolsAction.id, (action, options) => {
+			if (!(action instanceof MenuItemAction)) {
+				return undefined;
+			}
+
+			return instaService.createInstance(class extends MenuEntryActionViewItem {
+
+				override render(container: HTMLElement): void {
+					this.options.icon = false;
+					this.options.label = true;
+					container.classList.add('chat-mcp');
+					super.render(container);
+				}
+
+				protected override updateLabel(): void {
+					this._store.add(autorun(r => {
+						assertType(this.label);
+
+						const { enabled, count } = toolsCount.read(r);
+
+						if (count === 0) {
+							super.updateLabel();
+							return;
+						}
+
+						const message = enabled !== count
+							? localize('tool.1', "{0} {1} of {2}", '$(tools)', enabled, count)
+							: localize('tool.0', "{0} {1}", '$(tools)', count);
+						reset(this.label, ...renderLabelWithIcons(message));
+					}));
+				}
+
+			}, action, { ...options, keybindingNotRenderedWithLabel: true });
+
+		}, Event.fromObservable(toolsCount)));
+	}
+
+	update(tools: IToolData[] | undefined): void {
+		this._selectedTools.set(tools, undefined);
+	}
+}

--- a/src/vs/workbench/contrib/chat/browser/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatWidget.ts
@@ -1161,6 +1161,7 @@ export class ChatWidget extends Disposable implements IChatWidget {
 				attachedContext,
 				noCommandDetection: options?.noCommandDetection,
 				hasInstructionAttachments: this.inputPart.hasInstructionAttachments,
+				userSelectedTools: this.inputPart.selectedToolsModel.tools.get().map(tool => tool.id)
 			});
 
 			if (result) {

--- a/src/vs/workbench/contrib/chat/browser/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/media/chat.css
@@ -1137,7 +1137,7 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	max-width: 100%;
 	width: fit-content;
 }
-.action-item.chat-mcp .action-label,
+
 .action-item.chat-attached-context-attachment.chat-add-files .action-label {
 	color: var(--vscode-descriptionForeground);
 	font-family: unset;
@@ -1183,7 +1183,7 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	}
 }
 
-.quick-input-list .quick-input-list-rows > .quick-input-list-row .monaco-icon-label.mcp-tool .codicon[class*='codicon-'] {
+.quick-input-list .quick-input-list-rows > .quick-input-list-row .monaco-icon-label.tool-pick .codicon[class*='codicon-'] {
 	font-size: 14px;
 }
 

--- a/src/vs/workbench/contrib/chat/common/chatAgents.ts
+++ b/src/vs/workbench/contrib/chat/common/chatAgents.ts
@@ -143,7 +143,7 @@ export interface IChatAgentRequest {
 	acceptedConfirmationData?: any[];
 	rejectedConfirmationData?: any[];
 	userSelectedModelId?: string;
-	useSelectedTools?: string[];
+	userSelectedTools?: string[];
 }
 
 export interface IChatQuestion {

--- a/src/vs/workbench/contrib/chat/common/chatAgents.ts
+++ b/src/vs/workbench/contrib/chat/common/chatAgents.ts
@@ -143,6 +143,7 @@ export interface IChatAgentRequest {
 	acceptedConfirmationData?: any[];
 	rejectedConfirmationData?: any[];
 	userSelectedModelId?: string;
+	useSelectedTools?: string[];
 }
 
 export interface IChatQuestion {

--- a/src/vs/workbench/contrib/chat/common/chatContextKeys.ts
+++ b/src/vs/workbench/contrib/chat/common/chatContextKeys.ts
@@ -87,6 +87,11 @@ export namespace ChatContextKeys {
 		agentModeDisallowed: new RawContextKey<boolean>('chatAgentModeDisallowed', undefined, { type: 'boolean', description: localize('chatAgentModeDisallowed', "True when agent mode is not allowed.") }), // experiment-driven disablement
 		hasToolConfirmation: new RawContextKey<boolean>('chatHasToolConfirmation', false, { type: 'boolean', description: localize('chatEditingHasToolConfirmation', "True when a tool confirmation is present.") }),
 	};
+
+	export const Tools = {
+
+		toolsCount: new RawContextKey<number>('toolsCount', 0, { type: 'number', description: localize('toolsCount', "The count of tools available in the chat.") })
+	};
 }
 
 export namespace ChatContextKeyExprs {

--- a/src/vs/workbench/contrib/chat/common/chatService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService.ts
@@ -447,6 +447,7 @@ export type IChatLocationData = IChatEditorLocationData | IChatNotebookLocationD
 export interface IChatSendRequestOptions {
 	mode?: ChatMode;
 	userSelectedModelId?: string;
+	userSelectedTools?: string[];
 	location?: ChatAgentLocation;
 	locationData?: IChatLocationData;
 	parserContext?: IChatParserContext;

--- a/src/vs/workbench/contrib/chat/common/chatServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/chatServiceImpl.ts
@@ -705,7 +705,8 @@ export class ChatService extends Disposable implements IChatService {
 							locationData: request.locationData,
 							acceptedConfirmationData: options?.acceptedConfirmationData,
 							rejectedConfirmationData: options?.rejectedConfirmationData,
-							userSelectedModelId: options?.userSelectedModelId
+							userSelectedModelId: options?.userSelectedModelId,
+							userSelectedTools: options?.userSelectedTools
 						} satisfies IChatAgentRequest;
 					};
 

--- a/src/vs/workbench/contrib/mcp/browser/mcp.contribution.ts
+++ b/src/vs/workbench/contrib/mcp/browser/mcp.contribution.ts
@@ -19,7 +19,7 @@ import { McpService } from '../common/mcpService.js';
 import { IMcpService } from '../common/mcpTypes.js';
 import { McpDiscovery } from './mcpDiscovery.js';
 
-import { AttachMCPToolsAction, AttachMCPToolsActionRendering, ListMcpServerCommand, ResetMcpTrustCommand, McpServerOptionsCommand } from './mcpCommands.js';
+import { MCPServerActionRendering, ListMcpServerCommand, ResetMcpTrustCommand, McpServerOptionsCommand } from './mcpCommands.js';
 
 import { registerAction2 } from '../../../../platform/actions/common/actions.js';
 import { McpContextKeysController } from '../common/mcpContextKeys.js';
@@ -35,9 +35,8 @@ registerWorkbenchContribution2('mcpContextKeys', McpContextKeysController, Workb
 
 registerAction2(ListMcpServerCommand);
 registerAction2(McpServerOptionsCommand);
-registerAction2(AttachMCPToolsAction);
 registerAction2(ResetMcpTrustCommand);
-registerWorkbenchContribution2('mcpActionRendering', AttachMCPToolsActionRendering, WorkbenchPhase.BlockRestore);
+registerWorkbenchContribution2('mcpActionRendering', MCPServerActionRendering, WorkbenchPhase.BlockRestore);
 
 const jsonRegistry = <jsonContributionRegistry.IJSONContributionRegistry>Registry.as(jsonContributionRegistry.Extensions.JSONContribution);
 jsonRegistry.registerSchema(mcpSchemaId, mcpServerSchema);

--- a/src/vs/workbench/contrib/mcp/browser/mcpCommands.ts
+++ b/src/vs/workbench/contrib/mcp/browser/mcpCommands.ts
@@ -3,17 +3,13 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { addDisposableListener, EventType, h, reset } from '../../../../base/browser/dom.js';
-import { renderLabelWithIcons } from '../../../../base/browser/ui/iconLabel/iconLabels.js';
-import { assertNever } from '../../../../base/common/assert.js';
+import { h } from '../../../../base/browser/dom.js';
 import { Codicon } from '../../../../base/common/codicons.js';
-import { diffSets, groupBy } from '../../../../base/common/collections.js';
+import { groupBy } from '../../../../base/common/collections.js';
 import { Event } from '../../../../base/common/event.js';
-import { KeyCode, KeyMod } from '../../../../base/common/keyCodes.js';
 import { Disposable, DisposableStore } from '../../../../base/common/lifecycle.js';
-import { autorun, derived, transaction } from '../../../../base/common/observable.js';
+import { autorun, derived } from '../../../../base/common/observable.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
-import { assertType } from '../../../../base/common/types.js';
 import { ILocalizedString, localize, localize2 } from '../../../../nls.js';
 import { IActionViewItemService } from '../../../../platform/actions/browser/actionViewItemService.js';
 import { MenuEntryActionViewItem } from '../../../../platform/actions/browser/menuEntryActionViewItem.js';
@@ -21,16 +17,14 @@ import { Action2, MenuId, MenuItemAction } from '../../../../platform/actions/co
 import { ICommandService } from '../../../../platform/commands/common/commands.js';
 import { ContextKeyExpr } from '../../../../platform/contextkey/common/contextkey.js';
 import { IInstantiationService, ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
-import { KeybindingWeight } from '../../../../platform/keybinding/common/keybindingsRegistry.js';
-import { IQuickInputService, IQuickPickItem, IQuickPickSeparator } from '../../../../platform/quickinput/common/quickInput.js';
+import { IQuickInputService, IQuickPickItem } from '../../../../platform/quickinput/common/quickInput.js';
 import { spinningLoading } from '../../../../platform/theme/common/iconRegistry.js';
 import { IWorkbenchContribution } from '../../../common/contributions.js';
-import { CHAT_CATEGORY } from '../../chat/browser/actions/chatActions.js';
 import { ChatContextKeys } from '../../chat/common/chatContextKeys.js';
 import { ChatMode } from '../../chat/common/constants.js';
 import { McpContextKeys } from '../common/mcpContextKeys.js';
 import { IMcpRegistry } from '../common/mcpRegistryTypes.js';
-import { IMcpServer, IMcpService, IMcpTool, McpConnectionState, McpServerToolsState } from '../common/mcpTypes.js';
+import { IMcpServer, IMcpService, McpConnectionState, McpServerToolsState } from '../common/mcpTypes.js';
 
 // acroynms do not get localized
 const category: ILocalizedString = {
@@ -44,6 +38,7 @@ export class ListMcpServerCommand extends Action2 {
 		super({
 			id: ListMcpServerCommand.id,
 			title: localize2('mcp.list', 'List Servers'),
+			icon: Codicon.server,
 			category,
 			f1: true,
 		});
@@ -104,7 +99,17 @@ export class McpServerOptionsCommand extends Action2 {
 			id: McpServerOptionsCommand.id,
 			title: localize2('mcp.options', 'Server Options'),
 			category,
+			icon: Codicon.server,
 			f1: true,
+			menu: {
+				when: ContextKeyExpr.and(
+					McpContextKeys.hasUnknownTools,
+					ChatContextKeys.chatMode.isEqualTo(ChatMode.Agent)
+				),
+				id: MenuId.ChatInputAttachmentToolbar,
+				group: 'navigation',
+				order: 0
+			},
 		});
 	}
 
@@ -174,172 +179,7 @@ export class McpServerOptionsCommand extends Action2 {
 }
 
 
-export class AttachMCPToolsAction extends Action2 {
-
-	static readonly id = 'workbench.action.chat.mcp.attachMcpTools';
-
-	constructor() {
-		super({
-			id: AttachMCPToolsAction.id,
-			title: localize2('workbench.action.chat.editing.attachContext.shortLabel', "Select Tools..."),
-			icon: Codicon.tools,
-			f1: false,
-			category: CHAT_CATEGORY,
-			precondition: ContextKeyExpr.and(
-				ContextKeyExpr.or(McpContextKeys.toolsCount.greater(0), McpContextKeys.hasUnknownTools),
-				ChatContextKeys.chatMode.isEqualTo(ChatMode.Agent)
-			),
-			menu: {
-				when: ContextKeyExpr.and(
-					ContextKeyExpr.or(McpContextKeys.toolsCount.greater(0), McpContextKeys.hasUnknownTools),
-					ChatContextKeys.chatMode.isEqualTo(ChatMode.Agent)
-				),
-				id: MenuId.ChatInputAttachmentToolbar,
-				group: 'navigation',
-				order: 1
-			},
-			keybinding: {
-				when: ContextKeyExpr.and(ChatContextKeys.inChatInput, ChatContextKeys.chatMode.isEqualTo(ChatMode.Agent)),
-				primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.Slash,
-				weight: KeybindingWeight.EditorContrib
-			}
-		});
-	}
-
-	override async run(accessor: ServicesAccessor, ...args: any[]): Promise<void> {
-
-		const quickPickService = accessor.get(IQuickInputService);
-		const mcpService = accessor.get(IMcpService);
-
-		type ToolPick = IQuickPickItem & { picked: boolean; tool: IMcpTool; parent: ServerPick };
-		type ServerPick = IQuickPickItem & { picked: boolean; server: IMcpServer; toolPicks: ToolPick[] };
-		type McpPick = ToolPick | ServerPick;
-
-		function isServerPick(obj: any): obj is ServerPick {
-			return Boolean((obj as ServerPick).server);
-		}
-		function isToolPick(obj: any): obj is ToolPick {
-			return Boolean((obj as ToolPick).tool);
-		}
-
-		const store = new DisposableStore();
-		const picker = store.add(quickPickService.createQuickPick<McpPick>({ useSeparators: true }));
-
-		const picks: (McpPick | IQuickPickSeparator)[] = [];
-
-		for (const server of mcpService.servers.get()) {
-
-			const tools = server.tools.get();
-
-			if (tools.length === 0) {
-				continue;
-			}
-			picks.push({
-				type: 'separator',
-				label: localize('desc', "MCP Server - {0}", McpConnectionState.toString(server.connectionState.get()))
-			});
-
-			const item: ServerPick = {
-				server,
-				type: 'item',
-				label: `${server.definition.label}`,
-				picked: tools.some(tool => tool.enabled.get()),
-				toolPicks: []
-			};
-
-			picks.push(item);
-
-			for (const tool of tools) {
-				const toolItem: ToolPick = {
-					tool,
-					parent: item,
-					type: 'item',
-					label: `$(tools) ${tool.definition.name}`,
-					description: tool.definition.description,
-					picked: tool.enabled.get(),
-					iconClasses: ['mcp-tool']
-				};
-				item.toolPicks.push(toolItem);
-				picks.push(toolItem);
-			}
-		}
-
-		picker.placeholder = localize('placeholder', "Select tools that are available to chat");
-		picker.canSelectMany = true;
-
-		let lastSelectedItems = new Set<McpPick>();
-		let ignoreEvent = false;
-
-		const _update = () => {
-			ignoreEvent = true;
-			try {
-				const items = picks.filter((p): p is McpPick => p.type === 'item' && Boolean(p.picked));
-				lastSelectedItems = new Set(items);
-				picker.items = picks;
-				picker.selectedItems = items;
-			} finally {
-				ignoreEvent = false;
-			}
-		};
-
-		_update();
-		picker.show();
-
-		store.add(picker.onDidChangeSelection(selectedPicks => {
-			if (ignoreEvent) {
-				return;
-			}
-
-			const { added, removed } = diffSets(lastSelectedItems, new Set(selectedPicks));
-
-			for (const item of added) {
-				item.picked = true;
-
-				if (isServerPick(item)) {
-					// add server -> add back tools
-					for (const toolPick of item.toolPicks) {
-						toolPick.picked = true;
-					}
-				} else if (isToolPick(item)) {
-					// add server when tool is picked
-					item.parent.picked = true;
-				}
-			}
-
-			for (const item of removed) {
-				item.picked = false;
-
-				if (isServerPick(item)) {
-					// removed server -> remove tools
-					for (const toolPick of item.toolPicks) {
-						toolPick.picked = false;
-					}
-				} else if (isToolPick(item) && item.parent.toolPicks.every(child => !child.picked)) {
-					// remove LAST tool -> remove server
-					item.parent.picked = false;
-				}
-			}
-
-			transaction(tx => {
-				for (const item of picks) {
-					if (isToolPick(item)) {
-						item.tool.updateEnablement(item.picked, tx);
-					}
-				}
-			});
-
-			_update();
-		}));
-
-
-		await Promise.race([Event.toPromise(Event.any(picker.onDidAccept, picker.onDidHide))]);
-
-		store.dispose();
-
-	}
-}
-
-export class AttachMCPToolsActionRendering extends Disposable implements IWorkbenchContribution {
+export class MCPServerActionRendering extends Disposable implements IWorkbenchContribution {
 	public static readonly ID = 'workbench.contrib.mcp.discovery';
 
 	constructor(
@@ -356,19 +196,6 @@ export class AttachMCPToolsActionRendering extends Disposable implements IWorkbe
 			Error,
 			Refreshing,
 		}
-
-		const toolsCount = derived(r => {
-			let count = 0;
-			let enabled = 0;
-			const servers = mcpService.servers.read(r);
-			for (const server of servers) {
-				for (const tool of server.tools.read(r)) {
-					count += 1;
-					enabled += tool.enabled.read(r) ? 1 : 0;
-				}
-			}
-			return { count, enabled };
-		});
 
 		const displayedState = derived(reader => {
 			const servers = mcpService.servers.read(reader);
@@ -399,7 +226,7 @@ export class AttachMCPToolsActionRendering extends Disposable implements IWorkbe
 			return { state: maxState, servers: serversPerState[maxState] };
 		});
 
-		this._store.add(actionViewItemService.register(MenuId.ChatInputAttachmentToolbar, AttachMCPToolsAction.id, (action, options) => {
+		this._store.add(actionViewItemService.register(MenuId.ChatInputAttachmentToolbar, McpServerOptionsCommand.id, (action, options) => {
 			if (!(action instanceof MenuItemAction)) {
 				return undefined;
 			}
@@ -407,10 +234,9 @@ export class AttachMCPToolsActionRendering extends Disposable implements IWorkbe
 			return instaService.createInstance(class extends MenuEntryActionViewItem {
 
 				override render(container: HTMLElement): void {
-					this.options.icon = false;
-					this.options.label = true;
-					container.classList.add('chat-mcp');
+
 					super.render(container);
+					container.classList.add('chat-mcp');
 
 					const action = h('button.chat-mcp-action', [h('span@icon')]);
 
@@ -419,11 +245,6 @@ export class AttachMCPToolsActionRendering extends Disposable implements IWorkbe
 						const { root, icon } = action;
 						this.updateTooltip();
 						container.classList.toggle('chat-mcp-has-action', state !== DisplayedState.None);
-
-						if (state === DisplayedState.None) {
-							root.remove();
-							return;
-						}
 
 						if (!root.parentElement) {
 							container.appendChild(root);
@@ -442,26 +263,28 @@ export class AttachMCPToolsActionRendering extends Disposable implements IWorkbe
 							root.classList.add('chat-mcp-action-refreshing');
 							icon.classList.add(...ThemeIcon.asClassNameArray(spinningLoading));
 						} else {
-							assertNever(state);
+							root.remove();
 						}
 					}));
+				}
 
-					this._register(addDisposableListener(action.root, EventType.CLICK, e => {
-						e.preventDefault();
-						e.stopPropagation();
+				override async onClick(e: MouseEvent): Promise<void> {
+					e.preventDefault();
+					e.stopPropagation();
 
-						const { state, servers } = displayedState.get();
-						if (state === DisplayedState.NewTools) {
-							servers.forEach(server => server.start());
-						} else if (state === DisplayedState.Refreshing) {
-							servers.at(-1)?.showOutput();
-						} else if (state === DisplayedState.Error) {
-							const server = servers.at(-1);
-							if (server) {
-								commandService.executeCommand(McpServerOptionsCommand.id, server.definition.id);
-							}
+					const { state, servers } = displayedState.get();
+					if (state === DisplayedState.NewTools) {
+						servers.forEach(server => server.start());
+					} else if (state === DisplayedState.Refreshing) {
+						servers.at(-1)?.showOutput();
+					} else if (state === DisplayedState.Error) {
+						const server = servers.at(-1);
+						if (server) {
+							commandService.executeCommand(McpServerOptionsCommand.id, server.definition.id);
 						}
-					}));
+					} else {
+						commandService.executeCommand(ListMcpServerCommand.id);
+					}
 				}
 
 				protected override getTooltip(): string {
@@ -480,27 +303,10 @@ export class AttachMCPToolsActionRendering extends Disposable implements IWorkbe
 					}
 				}
 
-				protected override updateLabel(): void {
-					this._store.add(autorun(r => {
-						assertType(this.label);
-
-						const { enabled, count } = toolsCount.read(r);
-
-						if (count === 0) {
-							super.updateLabel();
-							return;
-						}
-
-						const message = enabled !== count
-							? localize('tool.1', "{0} {1} of {2}", '$(tools)', enabled, count)
-							: localize('tool.0', "{0} {1}", '$(tools)', count);
-						reset(this.label, ...renderLabelWithIcons(message));
-					}));
-				}
 
 			}, action, { ...options, keybindingNotRenderedWithLabel: true });
 
-		}, Event.fromObservable(toolsCount)));
+		}, Event.fromObservable(displayedState)));
 	}
 }
 
@@ -522,4 +328,3 @@ export class ResetMcpTrustCommand extends Action2 {
 		mcpService.resetTrust();
 	}
 }
-

--- a/src/vs/workbench/contrib/mcp/common/mcpServer.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpServer.ts
@@ -247,19 +247,11 @@ export class McpTool implements IMcpTool {
 
 	readonly id: string;
 
-	private _enabled = observableValue<boolean>(this, true);
-
-	readonly enabled: IObservable<boolean> = this._enabled;
-
 	constructor(
 		private readonly _server: McpServer,
 		public readonly definition: MCP.Tool,
 	) {
 		this.id = `${_server.definition.id}_${definition.name}`.replaceAll('.', '_');
-	}
-
-	updateEnablement(value: boolean, tx?: ITransaction): void {
-		this._enabled.set(value, tx);
 	}
 
 	call(params: Record<string, unknown>, token?: CancellationToken): Promise<MCP.CallToolResult> {

--- a/src/vs/workbench/contrib/mcp/common/mcpTypes.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpTypes.ts
@@ -7,7 +7,7 @@ import { assertNever } from '../../../../base/common/assert.js';
 import { CancellationToken } from '../../../../base/common/cancellation.js';
 import { IDisposable } from '../../../../base/common/lifecycle.js';
 import { equals as objectsEqual } from '../../../../base/common/objects.js';
-import { IObservable, ITransaction } from '../../../../base/common/observable.js';
+import { IObservable } from '../../../../base/common/observable.js';
 import { URI } from '../../../../base/common/uri.js';
 import { localize } from '../../../../nls.js';
 import { ConfigurationTarget } from '../../../../platform/configuration/common/configuration.js';
@@ -140,10 +140,6 @@ export interface IMcpTool {
 	readonly id: string;
 
 	readonly definition: MCP.Tool;
-
-	readonly enabled: IObservable<boolean>;
-
-	updateEnablement(value: boolean, tx?: ITransaction): void;
 
 	/**
 	 * Calls a tool

--- a/src/vscode-dts/vscode.proposed.chatParticipantAdditions.d.ts
+++ b/src/vscode-dts/vscode.proposed.chatParticipantAdditions.d.ts
@@ -218,6 +218,20 @@ declare module 'vscode' {
 		Omitted = 3
 	}
 
+
+	export interface ChatRequest {
+
+		/**
+		 * A list of tools that the user selected for this request, when `undefined` any tool
+		 * from {@link lm.tools} should be used.
+		 *
+		 * Tools can be called with {@link lm.invokeTool} with input that match their
+		 * declared `inputSchema`.
+		 */
+		readonly tools: readonly LanguageModelToolInformation[] | undefined;
+	}
+
+
 	/**
 	 * Does this piggy-back on the existing ChatRequest, or is it a different type of request entirely?
 	 * Does it show up in history?


### PR DESCRIPTION
* make the select tools work with all tools, group by MCP server, extension, and rest
* fill in the new ChatRequest#selectTools API with selected tools
* have the MCP server command be its own command with its own custom rendering