### PR TITLE
Add manage models entry point to model picker

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
@@ -1466,9 +1466,15 @@ class ModelPickerActionViewItem extends DropdownMenuActionViewItemWithKeybinding
 
 				const models: ILanguageModelChatMetadataAndIdentifier[] = this.delegate.getModels();
 				const actions = models.map(entry => setLanguageModelAction(entry));
-				if (chatEntitlementService.entitlement === ChatEntitlement.Limited) {
+				const supportsBYOK = !!contextKeyService.getContextKeyValue<boolean>('github.copilot.byokEnabled');
+				if (supportsBYOK || chatEntitlementService.entitlement === ChatEntitlement.Limited) {
 					actions.push(new Separator());
-					actions.push(toAction({ id: 'moreModels', label: localize('chat.moreModels', "Add More Models..."), run: () => commandService.executeCommand('workbench.action.chat.upgradePlan', 'chat-models') }));
+				}
+				if (chatEntitlementService.entitlement === ChatEntitlement.Limited) {
+					actions.push(toAction({ id: 'moreModels', label: localize('chat.moreModels', "Upgrade Plan to Access More Models..."), run: () => commandService.executeCommand('workbench.action.chat.upgradePlan', 'chat-models') }));
+				}
+				if (supportsBYOK) {
+					actions.push(toAction({ id: 'byokModels', label: localize('chat.byokModels', "Manage Models..."), run: () => commandService.executeCommand('github.copilot.chat.manageModels') }));
 				}
 
 				return actions;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This doesn't feel like the right approach as it relies on copilot specific context keys and commands so I'm open to other ideas.

The main issue with core owning this is that core should not change a language model it did not register. So if you register something as user selectable, it doesn't make sense for core to then change the registration metadata, does it? Also, with many of these providers they require API keys, or further configuration which makes it impossible to register all the models up front on the extension side and then have them manageable by core. We don't have this concept of a LanguageModelProviderFactory which says "hey the user is requesting that you register language models, what do you need to do this". 

The simplest option would likely be making it so that the Copilot Chat extension could contribute to the model picker menu.