### PR TITLE
mcp: compress tool prefix length

### DIFF
--- a/src/vs/workbench/contrib/mcp/common/mcpRegistryTypes.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpRegistryTypes.ts
@@ -40,6 +40,9 @@ export interface IMcpRegistry {
 	readonly collections: IObservable<readonly McpCollectionDefinition[]>;
 	readonly delegates: readonly IMcpHostDelegate[];
 
+	/** Gets the prefix that should be applied to a collection's tools in order to avoid ID conflicts */
+	collectionToolPrefix(collection: McpCollectionReference): IObservable<string>;
+
 	/** Whether there are new collections that can be resolved with a discover() call */
 	readonly lazyCollectionState: IObservable<LazyCollectionState>;
 	/** Discover new collections, returning newly-discovered ones. */

--- a/src/vs/workbench/contrib/mcp/common/mcpServer.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpServer.ts
@@ -110,11 +110,7 @@ export class McpServer extends Disposable implements IMcpServer {
 	private readonly toolsFromServerPromise = observableValue<ObservablePromise<readonly MCP.Tool[]> | undefined>(this, undefined);
 	private readonly toolsFromServer = derived(reader => this.toolsFromServerPromise.read(reader)?.promiseResult.read(reader)?.data);
 
-	public readonly tools = derived(reader => {
-		const serverTools = this.toolsFromServer.read(reader);
-		const definitions = serverTools ?? this.toolsFromCache ?? [];
-		return definitions.map(def => new McpTool(this, def));
-	});
+	public readonly tools: IObservable<readonly IMcpTool[]>;
 
 	public readonly toolsState = derived(reader => {
 		const fromServer = this.toolsFromServerPromise.read(reader);
@@ -183,6 +179,15 @@ export class McpServer extends Disposable implements IMcpServer {
 				this._toolCache.storeTools(definition.id, tools);
 			}
 		}));
+
+		// 4. Publish tools
+		const toolPrefix = this._mcpRegistry.collectionToolPrefix(this.collection);
+		this.tools = derived(reader => {
+			const serverTools = this.toolsFromServer.read(reader);
+			const definitions = serverTools ?? this.toolsFromCache ?? [];
+			const prefix = toolPrefix.read(reader);
+			return definitions.map(def => new McpTool(this, prefix, def));
+		});
 	}
 
 	public showOutput(): void {
@@ -302,9 +307,10 @@ export class McpTool implements IMcpTool {
 
 	constructor(
 		private readonly _server: McpServer,
+		idPrefix: string,
 		public readonly definition: MCP.Tool,
 	) {
-		this.id = `${_server.definition.id}_${definition.name}`.replaceAll('.', '_');
+		this.id = (idPrefix + definition.name).replaceAll('.', '_');
 	}
 
 	call(params: Record<string, unknown>, token?: CancellationToken): Promise<MCP.CallToolResult> {

--- a/src/vs/workbench/contrib/mcp/test/common/mcpRegistry.test.ts
+++ b/src/vs/workbench/contrib/mcp/test/common/mcpRegistry.test.ts
@@ -518,8 +518,8 @@ suite('Workbench - MCP - Registry', () => {
 			const prefix2 = registry.collectionToolPrefix(collection2).get();
 
 			assert.notStrictEqual(prefix1, prefix2);
-			assert.match(prefix1, /^[a-f0-9]{3}\.$/);
-			assert.match(prefix2, /^[a-f0-9]{3}\.$/);
+			assert.ok(/^[a-f0-9]{3}\.$/.test(prefix1));
+			assert.ok(/^[a-f0-9]{3}\.$/.test(prefix2));
 		});
 
 		test('handles hash collisions by incrementing view', () => {
@@ -549,8 +549,8 @@ suite('Workbench - MCP - Registry', () => {
 			const prefix2 = registry.collectionToolPrefix(collection2).get();
 
 			assert.notStrictEqual(prefix1, prefix2);
-			assert.match(prefix1, /^[a-f0-9]{3}\.$/);
-			assert.match(prefix2, /^[a-f0-9]{3}\.$/);
+			assert.ok(/^[a-f0-9]{3}\.$/.test(prefix1));
+			assert.ok(/^[a-f0-9]{3}\.$/.test(prefix2));
 		});
 
 		test('prefix changes when collections change', () => {

--- a/src/vs/workbench/contrib/mcp/test/common/mcpRegistry.test.ts
+++ b/src/vs/workbench/contrib/mcp/test/common/mcpRegistry.test.ts
@@ -24,7 +24,7 @@ import { TestLoggerService, TestStorageService } from '../../../../test/common/w
 import { McpRegistry } from '../../common/mcpRegistry.js';
 import { IMcpHostDelegate, IMcpMessageTransport } from '../../common/mcpRegistryTypes.js';
 import { McpServerConnection } from '../../common/mcpServerConnection.js';
-import { LazyCollectionState, McpCollectionDefinition, McpServerDefinition, McpServerTransportType } from '../../common/mcpTypes.js';
+import { LazyCollectionState, McpCollectionDefinition, McpCollectionReference, McpServerDefinition, McpServerTransportType } from '../../common/mcpTypes.js';
 import { TestMcpMessageTransport } from './mcpRegistryTypes.js';
 import { timeout } from '../../../../../base/common/async.js';
 
@@ -488,6 +488,102 @@ suite('Workbench - MCP - Registry', () => {
 			store.add(registry.registerCollection(uncachedLazy));
 
 			assert.strictEqual(registry.lazyCollectionState.get(), LazyCollectionState.HasUnknown);
+		});
+	});
+
+	suite('Collection Tool Prefixes', () => {
+		test('assigns unique prefixes to collections', () => {
+			const collection1: McpCollectionDefinition = {
+				id: 'collection1',
+				label: 'Collection 1',
+				remoteAuthority: null,
+				serverDefinitions: observableValue('serverDefs', []),
+				isTrustedByDefault: true,
+				scope: StorageScope.APPLICATION
+			};
+
+			const collection2: McpCollectionDefinition = {
+				id: 'collection2',
+				label: 'Collection 2',
+				remoteAuthority: null,
+				serverDefinitions: observableValue('serverDefs', []),
+				isTrustedByDefault: true,
+				scope: StorageScope.APPLICATION
+			};
+
+			store.add(registry.registerCollection(collection1));
+			store.add(registry.registerCollection(collection2));
+
+			const prefix1 = registry.collectionToolPrefix(collection1).get();
+			const prefix2 = registry.collectionToolPrefix(collection2).get();
+
+			assert.notStrictEqual(prefix1, prefix2);
+			assert.match(prefix1, /^[a-f0-9]{3}\.$/);
+			assert.match(prefix2, /^[a-f0-9]{3}\.$/);
+		});
+
+		test('handles hash collisions by incrementing view', () => {
+			// These strings are known to have SHA1 hash collisions in their first 3 characters
+			const collection1: McpCollectionDefinition = {
+				id: 'potato',
+				label: 'Collection 1',
+				remoteAuthority: null,
+				serverDefinitions: observableValue('serverDefs', []),
+				isTrustedByDefault: true,
+				scope: StorageScope.APPLICATION
+			};
+
+			const collection2: McpCollectionDefinition = {
+				id: 'candidate_83048',
+				label: 'Collection 2',
+				remoteAuthority: null,
+				serverDefinitions: observableValue('serverDefs', []),
+				isTrustedByDefault: true,
+				scope: StorageScope.APPLICATION
+			};
+
+			store.add(registry.registerCollection(collection1));
+			store.add(registry.registerCollection(collection2));
+
+			const prefix1 = registry.collectionToolPrefix(collection1).get();
+			const prefix2 = registry.collectionToolPrefix(collection2).get();
+
+			assert.notStrictEqual(prefix1, prefix2);
+			assert.match(prefix1, /^[a-f0-9]{3}\.$/);
+			assert.match(prefix2, /^[a-f0-9]{3}\.$/);
+		});
+
+		test('prefix changes when collections change', () => {
+			const collection1: McpCollectionDefinition = {
+				id: 'collection1',
+				label: 'Collection 1',
+				remoteAuthority: null,
+				serverDefinitions: observableValue('serverDefs', []),
+				isTrustedByDefault: true,
+				scope: StorageScope.APPLICATION
+			};
+
+			const disposable = registry.registerCollection(collection1);
+			store.add(disposable);
+
+			const prefix1 = registry.collectionToolPrefix(collection1).get();
+			assert.ok(!!prefix1);
+
+			disposable.dispose();
+
+			const prefix2 = registry.collectionToolPrefix(collection1).get();
+
+			assert.strictEqual(prefix2, '');
+		});
+
+		test('prefix is empty for unknown collections', () => {
+			const unknownCollection: McpCollectionReference = {
+				id: 'unknown',
+				label: 'Unknown'
+			};
+
+			const prefix = registry.collectionToolPrefix(unknownCollection).get();
+			assert.strictEqual(prefix, '');
 		});
 	});
 });


### PR DESCRIPTION
Use a simple sha1 hash to avoid collisions between tool names instead of
the full collection ID, fixes https://github.com/microsoft/vscode/issues/243602

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
