### PR TITLE
Initial cut of WebContentExtractorService & a fetch tool

### DIFF
--- a/src/vs/code/electron-main/app.ts
+++ b/src/vs/code/electron-main/app.ts
@@ -120,6 +120,8 @@ import { normalizeNFC } from '../../base/common/normalization.js';
 import { ICSSDevelopmentService, CSSDevelopmentService } from '../../platform/cssDev/node/cssDevService.js';
 import { INativeMcpDiscoveryHelperService, NativeMcpDiscoveryHelperChannelName } from '../../platform/mcp/common/nativeMcpDiscoveryHelper.js';
 import { NativeMcpDiscoveryHelperService } from '../../platform/mcp/node/nativeMcpDiscoveryHelperService.js';
+import { IWebContentExtractorService } from '../../platform/webContentExtractor/common/webContentExtractor.js';
+import { NativeWebContentExtractorService } from '../../platform/webContentExtractor/electron-main/webContentExtractorService.js';
 
 /**
  * The main VS Code application. There will only ever be one instance,
@@ -1048,6 +1050,9 @@ export class CodeApplication extends Disposable {
 		// Native Host
 		services.set(INativeHostMainService, new SyncDescriptor(NativeHostMainService, undefined, false /* proxied to other processes */));
 
+		// Dev Tools Accessibility Service
+		services.set(IWebContentExtractorService, new SyncDescriptor(NativeWebContentExtractorService, undefined, false /* proxied to other processes */));
+
 		// Webview Manager
 		services.set(IWebviewManagerService, new SyncDescriptor(WebviewMainService));
 
@@ -1194,6 +1199,10 @@ export class CodeApplication extends Disposable {
 		const nativeHostChannel = ProxyChannel.fromService(this.nativeHostMainService, disposables);
 		mainProcessElectronServer.registerChannel('nativeHost', nativeHostChannel);
 		sharedProcessClient.then(client => client.registerChannel('nativeHost', nativeHostChannel));
+
+		// Dev Tools Accessibility Service
+		const devToolsAccessibilityChannel = ProxyChannel.fromService(accessor.get(IWebContentExtractorService), disposables);
+		mainProcessElectronServer.registerChannel('webContentExtractor', devToolsAccessibilityChannel);
 
 		// Workspaces
 		const workspacesChannel = ProxyChannel.fromService(accessor.get(IWorkspacesService), disposables);

--- a/src/vs/code/electron-main/app.ts
+++ b/src/vs/code/electron-main/app.ts
@@ -1050,7 +1050,7 @@ export class CodeApplication extends Disposable {
 		// Native Host
 		services.set(INativeHostMainService, new SyncDescriptor(NativeHostMainService, undefined, false /* proxied to other processes */));
 
-		// Dev Tools Accessibility Service
+		// Web Contents Extractor
 		services.set(IWebContentExtractorService, new SyncDescriptor(NativeWebContentExtractorService, undefined, false /* proxied to other processes */));
 
 		// Webview Manager
@@ -1200,9 +1200,9 @@ export class CodeApplication extends Disposable {
 		mainProcessElectronServer.registerChannel('nativeHost', nativeHostChannel);
 		sharedProcessClient.then(client => client.registerChannel('nativeHost', nativeHostChannel));
 
-		// Dev Tools Accessibility Service
-		const devToolsAccessibilityChannel = ProxyChannel.fromService(accessor.get(IWebContentExtractorService), disposables);
-		mainProcessElectronServer.registerChannel('webContentExtractor', devToolsAccessibilityChannel);
+		// Web Content Extractor
+		const webContentExtractorChannel = ProxyChannel.fromService(accessor.get(IWebContentExtractorService), disposables);
+		mainProcessElectronServer.registerChannel('webContentExtractor', webContentExtractorChannel);
 
 		// Workspaces
 		const workspacesChannel = ProxyChannel.fromService(accessor.get(IWorkspacesService), disposables);

--- a/src/vs/platform/webContentExtractor/common/webContentExtractor.ts
+++ b/src/vs/platform/webContentExtractor/common/webContentExtractor.ts
@@ -1,0 +1,27 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { URI } from '../../../base/common/uri.js';
+import { createDecorator } from '../../instantiation/common/instantiation.js';
+
+export const IWebContentExtractorService = createDecorator<IWebContentExtractorService>('IWebContentExtractorService');
+
+export interface IWebContentExtractorService {
+	_serviceBrand: undefined;
+	extract(uri: URI[]): Promise<string[]>;
+}
+
+/**
+ * A service that extracts web content from a given URI.
+ * This is a placeholder implementation that does not perform any actual extraction.
+ * It's intended to be used on platforms where web content extraction is not supported such as in the browser.
+ */
+export class NullWebContentExtractorService implements IWebContentExtractorService {
+	_serviceBrand: undefined;
+
+	extract(_uri: URI[]): Promise<string[]> {
+		throw new Error('Not implemented');
+	}
+}

--- a/src/vs/platform/webContentExtractor/electron-main/cdpAccessibilityDomain.ts
+++ b/src/vs/platform/webContentExtractor/electron-main/cdpAccessibilityDomain.ts
@@ -1,0 +1,199 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Contains types from https://chromedevtools.github.io/devtools-protocol/tot/Accessibility/
+ */
+
+export interface AXProperty {
+	name: string;
+	value: AXValue;
+}
+
+export interface AXValue {
+	type: string;
+	value: any;
+}
+
+export interface AXNode {
+	nodeId: string;
+	ignored?: boolean;
+	ignoredReasons?: AXProperty[];
+	role?: AXValue;
+	chromeRole?: AXValue;
+	name?: AXValue;
+	description?: AXValue;
+	value?: AXValue;
+	properties?: AXProperty[];
+	parentId?: string;
+	childIds?: string[];
+	backendDOMNodeId?: number;
+	frameId?: string;
+}
+
+/**
+ * Converts an array of AXNode objects to a readable format.
+ * It processes the nodes to extract their text content, ignoring navigation elements and
+ * formatting them in a structured way.
+ *
+ * @remarks We can do more here, but this is a good start.
+ * @param axNodes - The array of AXNode objects to be converted to a readable format.
+ * @returns string
+ */
+export function convertToReadibleFormat(axNodes: AXNode[]): string {
+	if (!axNodes.length) {
+		return '';
+	}
+
+	const nodeMap = new Map<string, AXNode>();
+	const processedNodes = new Set<string>();
+	const rootNodes: AXNode[] = [];
+
+	// Build node map and identify root nodes
+	for (const node of axNodes) {
+		nodeMap.set(node.nodeId, node);
+		if (!node.parentId || !axNodes.some(n => n.nodeId === node.parentId)) {
+			rootNodes.push(node);
+		}
+	}
+
+	function isNavigationElement(node: AXNode): boolean {
+		// Skip navigation and UI elements that don't contribute to content
+		const skipRoles = [
+			'navigation',
+			'banner',
+			'complementary',
+			'toolbar',
+			'menu',
+			'menuitem',
+			'tab',
+			'tablist'
+		];
+		const skipTexts = [
+			'Skip to main content',
+			'Toggle navigation',
+			'Previous',
+			'Next',
+			'Copy',
+			'Direct link to',
+			'On this page',
+			'Edit this page',
+			'Search',
+			'Command+K'
+		];
+
+		const text = getNodeText(node);
+		const role = node.role?.value?.toString().toLowerCase() || '';
+		// allow-any-unicode-next-line
+		return skipRoles.includes(role) ||
+			skipTexts.some(skipText => text.includes(skipText)) ||
+			text.startsWith('Direct link to') ||
+			text.startsWith('\xAB ') || // Left-pointing double angle quotation mark
+			text.endsWith(' \xBB') || // Right-pointing double angle quotation mark
+			/^#\s*$/.test(text) || // Skip standalone # characters
+			text === '\u200B'; // Zero-width space character
+	}
+
+	function getNodeText(node: AXNode): string {
+		const parts: string[] = [];
+
+		// Add name if available
+		if (node.name?.value) {
+			parts.push(String(node.name.value));
+		}
+
+		// Add value if available and different from name
+		if (node.value?.value && node.value.value !== node.name?.value) {
+			parts.push(String(node.value.value));
+		}
+
+		// Add description if available and different from name and value
+		if (node.description?.value &&
+			node.description.value !== node.name?.value &&
+			node.description.value !== node.value?.value) {
+			parts.push(String(node.description.value));
+		}
+
+		return parts.join(' ').trim();
+	}
+
+	function isCodeBlock(node: AXNode): boolean {
+		return node.role?.value === 'code' ||
+			(node.properties || []).some(p => p.name === 'code-block' || p.name === 'pre');
+	}
+
+	function processNode(node: AXNode, depth: number = 0, parentContext: { inCodeBlock: boolean; codeText: string[] } = { inCodeBlock: false, codeText: [] }): string[] {
+		if (!node || node.ignored || processedNodes.has(node.nodeId)) {
+			return [];
+		}
+
+		if (isNavigationElement(node)) {
+			return [];
+		}
+
+		processedNodes.add(node.nodeId);
+		const lines: string[] = [];
+		const text = getNodeText(node);
+		const currentIsCode = isCodeBlock(node);
+		const context = currentIsCode ? { inCodeBlock: true, codeText: [] } : parentContext;
+
+		if (text) {
+			const indent = '  '.repeat(depth);
+			if (currentIsCode || context.inCodeBlock) {
+				// For code blocks, collect text without adding newlines
+				context.codeText.push(text.trim());
+			} else {
+				lines.push(indent + text);
+			}
+		}
+
+		// Process children
+		if (node.childIds) {
+			for (const childId of node.childIds) {
+				const child = nodeMap.get(childId);
+				if (child) {
+					const childLines = processNode(child, depth + 1, context);
+					lines.push(...childLines);
+				}
+			}
+		}
+
+		// If this is the root code block node, join all collected code text
+		if (currentIsCode && context.codeText.length > 0) {
+			const indent = '  '.repeat(depth);
+			lines.push(indent + context.codeText.join(' '));
+		}
+
+		return lines;
+	}
+
+	// Process all nodes starting from roots
+	const allLines: string[] = [];
+	for (const node of rootNodes) {
+		const nodeLines = processNode(node);
+		if (nodeLines.length > 0) {
+			allLines.push(...nodeLines);
+		}
+	}
+
+	// Process any remaining unprocessed nodes
+	for (const node of axNodes) {
+		if (!processedNodes.has(node.nodeId)) {
+			const nodeLines = processNode(node);
+			if (nodeLines.length > 0) {
+				allLines.push(...nodeLines);
+			}
+		}
+	}
+
+	// Clean up empty lines and trim
+	return allLines
+		.filter((line, index, array) => {
+			// Keep the line if it's not empty or if it's not adjacent to another empty line
+			return line.trim() || (index > 0 && array[index - 1].trim());
+		})
+		.join('\n')
+		.trim();
+}

--- a/src/vs/platform/webContentExtractor/electron-main/webContentExtractorService.ts
+++ b/src/vs/platform/webContentExtractor/electron-main/webContentExtractorService.ts
@@ -1,0 +1,73 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { BrowserWindow } from 'electron';
+import { IWebContentExtractorService } from '../common/webContentExtractor.js';
+import { URI } from '../../../base/common/uri.js';
+import { AXNode, convertToReadibleFormat } from './cdpAccessibilityDomain.js';
+import { Limiter } from '../../../base/common/async.js';
+import { ResourceMap } from '../../../base/common/map.js';
+
+interface CacheEntry {
+	content: string;
+	timestamp: number;
+}
+
+export class NativeWebContentExtractorService implements IWebContentExtractorService {
+	_serviceBrand: undefined;
+
+	// Only allow 3 windows to be opened at a time
+	// to avoid overwhelming the system with too many processes.
+	private _limiter = new Limiter<string>(3);
+	private _webContentsCache = new ResourceMap<CacheEntry>();
+	private readonly _cacheDuration = 24 * 60 * 60 * 1000; // 1 day in milliseconds
+
+	private isExpired(entry: CacheEntry): boolean {
+		return Date.now() - entry.timestamp > this._cacheDuration;
+	}
+
+	extract(uris: URI[]): Promise<string[]> {
+		if (uris.length === 0) {
+			return Promise.resolve([]);
+		}
+		return Promise.all(uris.map((uri) => this._limiter.queue(() => this.doExtract(uri))));
+	}
+
+	async doExtract(uri: URI): Promise<string> {
+		const cached = this._webContentsCache.get(uri);
+		if (cached) {
+			if (this.isExpired(cached)) {
+				this._webContentsCache.delete(uri);
+			} else {
+				return cached.content;
+			}
+		}
+
+		const win = new BrowserWindow({
+			width: 800,
+			height: 600,
+			show: false,
+			webPreferences: {
+				javascript: false,
+				offscreen: true,
+				sandbox: true,
+				webgl: false
+			}
+		});
+		try {
+			await win.loadURL(uri.toString(true));
+			win.webContents.debugger.attach('1.1');
+			const result: { nodes: AXNode[] } = await win.webContents.debugger.sendCommand('Accessibility.getFullAXTree');
+			const str = convertToReadibleFormat(result.nodes);
+			this._webContentsCache.set(uri, { content: str, timestamp: Date.now() });
+			return str;
+		} catch (err) {
+			console.log(err);
+		} finally {
+			win.destroy();
+		}
+		return '';
+	}
+}

--- a/src/vs/platform/webContentExtractor/electron-sandbox/webContentExtractorService.ts
+++ b/src/vs/platform/webContentExtractor/electron-sandbox/webContentExtractorService.ts
@@ -1,0 +1,9 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { registerMainProcessRemoteService } from '../../ipc/electron-sandbox/services.js';
+import { IWebContentExtractorService } from '../common/webContentExtractor.js';
+
+registerMainProcessRemoteService(IWebContentExtractorService, 'webContentExtractor');

--- a/src/vs/workbench/contrib/chat/electron-sandbox/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/electron-sandbox/chat.contribution.ts
@@ -5,7 +5,27 @@
 
 import { InlineVoiceChatAction, QuickVoiceChatAction, StartVoiceChatAction, VoiceChatInChatViewAction, StopListeningAction, StopListeningAndSubmitAction, KeywordActivationContribution, InstallSpeechProviderForVoiceChatAction, HoldToVoiceChatInChatViewAction, ReadChatResponseAloud, StopReadAloud, StopReadChatItemAloud } from './actions/voiceChatActions.js';
 import { registerAction2 } from '../../../../platform/actions/common/actions.js';
-import { WorkbenchPhase, registerWorkbenchContribution2 } from '../../../common/contributions.js';
+import { IWorkbenchContribution, WorkbenchPhase, registerWorkbenchContribution2 } from '../../../common/contributions.js';
+import { Disposable } from '../../../../base/common/lifecycle.js';
+import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
+import { ILanguageModelToolsService } from '../common/languageModelToolsService.js';
+import { FetchWebPageTool, FetchWebPageToolData } from './tools/fetchPageTool.js';
+
+class NativeBuiltinToolsContribution extends Disposable implements IWorkbenchContribution {
+
+	static readonly ID = 'chat.nativeBuiltinTools';
+
+	constructor(
+		@ILanguageModelToolsService toolsService: ILanguageModelToolsService,
+		@IInstantiationService instantiationService: IInstantiationService,
+	) {
+		super();
+
+		const editTool = instantiationService.createInstance(FetchWebPageTool);
+		this._register(toolsService.registerToolData(FetchWebPageToolData));
+		this._register(toolsService.registerToolImplementation(FetchWebPageToolData.id, editTool));
+	}
+}
 
 registerAction2(StartVoiceChatAction);
 registerAction2(InstallSpeechProviderForVoiceChatAction);
@@ -23,3 +43,4 @@ registerAction2(StopReadChatItemAloud);
 registerAction2(StopReadAloud);
 
 registerWorkbenchContribution2(KeywordActivationContribution.ID, KeywordActivationContribution, WorkbenchPhase.AfterRestored);
+registerWorkbenchContribution2(NativeBuiltinToolsContribution.ID, NativeBuiltinToolsContribution, WorkbenchPhase.AfterRestored);

--- a/src/vs/workbench/contrib/chat/electron-sandbox/tools/fetchPageTool.ts
+++ b/src/vs/workbench/contrib/chat/electron-sandbox/tools/fetchPageTool.ts
@@ -1,0 +1,155 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { localize } from '../../../../../nls.js';
+import { CancellationToken } from '../../../../../base/common/cancellation.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { IWebContentExtractorService } from '../../../../../platform/webContentExtractor/common/webContentExtractor.js';
+import { ITrustedDomainService } from '../../../url/browser/trustedDomainService.js';
+import { CountTokensCallback, IPreparedToolInvocation, IToolData, IToolImpl, IToolInvocation, IToolResult } from '../../common/languageModelToolsService.js';
+import { MarkdownString } from '../../../../../base/common/htmlContent.js';
+
+export const InternalFetchWebPageToolId = 'vscode_fetchWebPage_internal';
+export const FetchWebPageToolData: IToolData = {
+	id: InternalFetchWebPageToolId,
+	displayName: 'Fetch Web Page',
+	tags: ['vscode_editing'],
+	modelDescription: localize('fetchWebPage.modelDescription', 'Fetches the main content from a web page. This tool is useful for summarizing or analyzing the content of a webpage.'),
+	userDescription: localize('fetchWebPage.userDescription', 'Fetch the main content from a web page. This tool is useful for summarizing or analyzing the content of a webpage.'),
+	inputSchema: {
+		type: 'object',
+		properties: {
+			urls: {
+				type: 'array',
+				items: {
+					type: 'string',
+				},
+				description: localize('fetchWebPage.urlsDescription', 'An array of URLs to fetch content from.')
+			}
+		},
+		required: ['urls']
+	}
+};
+
+export class FetchWebPageTool implements IToolImpl {
+	private _alreadyApprovedDomains = new Set<string>();
+
+	constructor(
+		@IWebContentExtractorService private readonly _readerModeService: IWebContentExtractorService,
+		@ITrustedDomainService private readonly _trustedDomainService: ITrustedDomainService,
+	) { }
+
+	async invoke(invocation: IToolInvocation, _countTokens: CountTokensCallback, _token: CancellationToken): Promise<IToolResult> {
+		const { valid } = this._parseUris((invocation.parameters as { urls?: string[] }).urls);
+		if (!valid.length) {
+			return {
+				content: [{ kind: 'text', value: localize('fetchWebPage.noValidUrls', 'No valid URLs provided.') }]
+			};
+		}
+
+		for (const uri of valid) {
+			if (!this._trustedDomainService.isValid(uri)) {
+				this._alreadyApprovedDomains.add(uri.toString(true));
+			}
+		}
+
+		const result = await this._readerModeService.extract(valid);
+		// Right now there's a bug when returning multiple text content parts so we're merging into one.
+		// When that's fixed we can use the helper function _getPromptPartForWebPageContents.
+		const value = result.map((content, index) => localize(
+			'fetchWebPage.promptPart',
+			'Below is the main content extracted from the webpage ({0}). Please read and analyze this content to assist with any follow-up questions:\n\n{1}',
+			valid[index].toString(),
+			content
+		)).join('\n\n---\n\n');
+		return { content: [{ kind: 'text', value }] };
+	}
+
+	async prepareToolInvocation(parameters: any, token: CancellationToken): Promise<IPreparedToolInvocation | undefined> {
+		const { invalid, valid } = this._parseUris(parameters.urls);
+		const urlsNeedingConfirmation = valid.filter(url => !this._trustedDomainService.isValid(url) && !this._alreadyApprovedDomains.has(url.toString(true)));
+
+		const pastTenseMessage = invalid.length
+			? invalid.length > 1
+				? new MarkdownString(
+					localize(
+						'fetchWebPage.pastTenseMessage.plural',
+						'Fetched {0} web pages, but the following were invalid URLs:\n\n{1}\n\n', valid.length, invalid.map(url => `- ${url}`).join('\n')
+					))
+				: new MarkdownString(
+					localize(
+						'fetchWebPage.pastTenseMessage.singular',
+						'Fetched web page, but the following was an invalid URL:\n\n{0}\n\n', invalid[0]
+					))
+			: new MarkdownString();
+		pastTenseMessage.appendMarkdown(valid.length > 1
+			? localize('fetchWebPage.pastTenseMessageResult.plural', 'Fetched {0} web pages', valid.length)
+			: localize('fetchWebPage.pastTenseMessageResult.singular', 'Fetched [web page]({0})', valid[0].toString())
+		);
+
+		const result: IPreparedToolInvocation = {
+			invocationMessage: valid.length > 1
+				? new MarkdownString(localize('fetchWebPage.invocationMessage.plural', 'Fetching {0} web pages', valid.length))
+				: new MarkdownString(localize('fetchWebPage.invocationMessage.singular', 'Fetching [web page]({0})', valid[0].toString())),
+			pastTenseMessage
+		};
+
+		if (urlsNeedingConfirmation.length) {
+			const confirmationTitle = urlsNeedingConfirmation.length > 1
+				? localize('fetchWebPage.confirmationTitle.plural', 'Fetch untrusted web pages?')
+				: localize('fetchWebPage.confirmationTitle.singular', 'Fetch untrusted web page?');
+
+			const managedTrustedDomainsCommand = 'workbench.action.manageTrustedDomain';
+			const confirmationMessage = new MarkdownString(
+				urlsNeedingConfirmation.length > 1
+					? urlsNeedingConfirmation.map(uri => `- ${uri.toString()}`).join('\n')
+					: urlsNeedingConfirmation[0].toString(),
+				{
+					isTrusted: { enabledCommands: [managedTrustedDomainsCommand] },
+					supportThemeIcons: true
+				}
+			);
+
+			confirmationMessage.appendMarkdown(
+				'\n\n$(info)' + localize(
+					'fetchWebPage.confirmationMessageManageTrustedDomains',
+					'You can [manage your trusted domains]({0}) to skip this confirmation in the future.',
+					`command:${managedTrustedDomainsCommand}`
+				)
+			);
+
+			result.confirmationMessages = { title: confirmationTitle, message: confirmationMessage };
+		}
+
+		return result;
+	}
+
+	private _parseUris(urls?: string[]): { invalid: string[]; valid: URI[] } {
+		const invalidUrls: string[] = [];
+		const validUrls: URI[] = [];
+		urls?.forEach(uri => {
+			try {
+				const uriObj = URI.parse(uri);
+				validUrls.push(uriObj);
+			} catch (e) {
+				invalidUrls.push(uri);
+			}
+		});
+
+		return { invalid: invalidUrls, valid: validUrls };
+	}
+
+	// private _getPromptPartForWebPageContents(webPageContents: string, uri: URI): IToolResultTextPart {
+	// 	return {
+	// 		kind: 'text',
+	// 		value: localize(
+	// 			'fetchWebPage.promptPart',
+	// 			'Below is the main content extracted from the webpage ({0}). Please read and analyze this content to assist with any follow-up questions:\n\n{1}',
+	// 			uri.toString(),
+	// 			webPageContents
+	// 		)
+	// 	};
+	// }
+}

--- a/src/vs/workbench/workbench.desktop.main.ts
+++ b/src/vs/workbench/workbench.desktop.main.ts
@@ -85,6 +85,7 @@ import './services/extensions/electron-sandbox/nativeExtensionService.js';
 import '../platform/userDataProfile/electron-sandbox/userDataProfileStorageService.js';
 import './services/auxiliaryWindow/electron-sandbox/auxiliaryWindowService.js';
 import '../platform/extensionManagement/electron-sandbox/extensionsProfileScannerService.js';
+import '../platform/webContentExtractor/electron-sandbox/webContentExtractorService.js';
 
 import { registerSingleton } from '../platform/instantiation/common/extensions.js';
 import { IUserDataInitializationService, UserDataInitializationService } from './services/userData/browser/userDataInit.js';

--- a/src/vs/workbench/workbench.web.main.internal.ts
+++ b/src/vs/workbench/workbench.web.main.internal.ts
@@ -94,6 +94,7 @@ import { ILanguagePackService } from '../platform/languagePacks/common/languageP
 import { WebLanguagePacksService } from '../platform/languagePacks/browser/languagePacks.js';
 import { IExtensionGalleryManifestService } from '../platform/extensionManagement/common/extensionGalleryManifest.js';
 import { ExtensionGalleryManifestService } from '../platform/extensionManagement/common/extensionGalleryManifestService.js';
+import { IWebContentExtractorService, NullWebContentExtractorService } from '../platform/webContentExtractor/common/webContentExtractor.js';
 
 registerSingleton(IWorkbenchExtensionManagementService, ExtensionManagementService, InstantiationType.Delayed);
 registerSingleton(IAccessibilityService, AccessibilityService, InstantiationType.Delayed);
@@ -112,6 +113,7 @@ registerSingleton(ICustomEndpointTelemetryService, NullEndpointTelemetryService,
 registerSingleton(IDiagnosticsService, NullDiagnosticsService, InstantiationType.Delayed);
 registerSingleton(ILanguagePackService, WebLanguagePacksService, InstantiationType.Delayed);
 registerSingleton(IExtensionGalleryManifestService, ExtensionGalleryManifestService, InstantiationType.Delayed);
+registerSingleton(IWebContentExtractorService, NullWebContentExtractorService, InstantiationType.Delayed);
 
 //#endregion
 


### PR DESCRIPTION
I will likely move the tool into Copilot so it can take advantage of prompt-tsx and embeddings indexing... but this is the first cut to play around with it.

This leverages Chrome DevTools Protocol's `Accessibility.getFullAXTree` command in order to get a representation of a page while marking what is useful on the page and what is not. We take the output of the command and turn it into a string that the caller can easily consume. This transformer will get more sophisticated over time to make sure we keep content that's important, and ditch content that is not.

On the tool side of things... this implements a Confirmation flow that verifies if the urls being requested is a trusted domain. We are _rendering_ these urls (albiet, sandboxed without JS) so we want to make sure they're safe. If it's not trusted, they'll be asked to confirm.

Couple of screenshots:

<img width="712" alt="image" src="https://github.com/user-attachments/assets/4d5da08c-4fdd-4b9f-aba2-b76f17d54d73" />

<img width="725" alt="image" src="https://github.com/user-attachments/assets/1361bc7e-a371-4334-9fd7-019e205e1167" />


<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
