### PR TITLE
Fix 243417: sanitize env command output for bash integration

### DIFF
--- a/src/vs/workbench/contrib/terminal/common/scripts/shellIntegration-bash.sh
+++ b/src/vs/workbench/contrib/terminal/common/scripts/shellIntegration-bash.sh
@@ -233,7 +233,7 @@ __vsc_update_cwd() {
 
 # Filtered env output without exported functions
 __vsc_env() {
-	command env -0 | tr '\0\n' '\n\r' | grep -Ev '^BASH_FUNC'
+	command env -0 | tr '\0\n' '\n\r' | sort | grep -Ev '^BASH_FUNC'
 }
 
 __updateEnvCacheAA() {

--- a/src/vs/workbench/contrib/terminal/common/scripts/shellIntegration-bash.sh
+++ b/src/vs/workbench/contrib/terminal/common/scripts/shellIntegration-bash.sh
@@ -252,7 +252,7 @@ __trackMissingEnvVarsAA() {
 		declare -A currentEnvMap
 		while IFS='=' read -r key value; do
 			currentEnvMap["$key"]="$value"
-		done < <(__vsc_env)
+		done
 
 		for key in "${!vsc_aa_env[@]}"; do
 			if [ -z "${currentEnvMap[$key]}" ]; then
@@ -287,7 +287,7 @@ __trackMissingEnvVars() {
 
 	while IFS='=' read -r key value; do
 		current_env_keys+=("$key")
-	done < <(__vsc_env)
+	done
 
 	# Compare vsc_env_keys with user's current_env_keys
 	for key in "${vsc_env_keys[@]}"; do
@@ -311,6 +311,7 @@ __trackMissingEnvVars() {
 }
 
 __vsc_update_env() {
+	local VSC_ENV="$(__vsc_env)"
 	if [[ "$__vscode_shell_env_reporting" == "1" ]]; then
 		builtin printf '\e]633;EnvSingleStart;%s;%s\a' 0 $__vsc_nonce
 
@@ -320,13 +321,13 @@ __vsc_update_env() {
 				while IFS='=' read -r key value; do
 					vsc_aa_env["$key"]="$value"
 					builtin printf '\e]633;EnvSingleEntry;%s;%s;%s\a' "$key" "$(__vsc_escape_value "$value")" "$__vsc_nonce"
-				done < <(__vsc_env)
+				done <<< "$VSC_ENV"
 			else
 				# Diff approach for associative array
 				while IFS='=' read -r key value; do
 					__updateEnvCacheAA "$key" "$value"
-				done < <(__vsc_env)
-				__trackMissingEnvVarsAA
+				done <<< "$VSC_ENV"
+				__trackMissingEnvVarsAA <<< "$VSC_ENV"
 			fi
 
 		else
@@ -336,13 +337,13 @@ __vsc_update_env() {
 					vsc_env_keys+=("$key")
 					vsc_env_values+=("$value")
 					builtin printf '\e]633;EnvSingleEntry;%s;%s;%s\a' "$key" "$(__vsc_escape_value "$value")" "$__vsc_nonce"
-				done < <(__vsc_env)
+				done <<< "$VSC_ENV"
 			else
 				# Diff approach for non-associative arrays
 				while IFS='=' read -r key value; do
 					__updateEnvCache "$key" "$value"
-				done < <(__vsc_env)
-				__trackMissingEnvVars
+				done <<< "$VSC_ENV"
+				__trackMissingEnvVars <<< "$VSC_ENV"
 			fi
 
 		fi


### PR DESCRIPTION
In the current bash shell integration implementation, it only considers the lines of simple key/value pairs while processing the output of the env command. However, when there're exported shell functions, which are typically printed over multiple lines, there could be lines with arbitrary shell script that might lead to unexpected result, causing errors like:

    bash: vsc_aa_env: bad array subscript
    bash: currentEnvMap["$key"]: bad array subscript

Fortunately with `env -0`, it becomes possible to join the lines of an exported function into one line with a custom line separator, such as '\r', or any other unused ascii control characters. With that we could also exclude the exported functions from code completion suggestions:

> <img width="540" alt="image" src="https://github.com/user-attachments/assets/f583a4a5-6db3-4464-9a7a-6a281f63c61e" />

Fixes #243417