### PR TITLE
mcp: button/command for adding MCP servers

### DIFF
--- a/src/vs/platform/configuration/common/configuration.ts
+++ b/src/vs/platform/configuration/common/configuration.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { assertNever } from '../../../base/common/assert.js';
 import { IStringDictionary } from '../../../base/common/collections.js';
 import { Event } from '../../../base/common/event.js';
 import * as types from '../../../base/common/types.js';
@@ -101,6 +102,29 @@ export interface IConfigurationValue<T> {
 	readonly policy?: { value?: T };
 
 	readonly overrideIdentifiers?: string[];
+}
+
+export function getConfigValueInTarget<T>(configValue: IConfigurationValue<T>, scope: ConfigurationTarget): T | undefined {
+	switch (scope) {
+		case ConfigurationTarget.APPLICATION:
+			return configValue.applicationValue;
+		case ConfigurationTarget.USER:
+			return configValue.userValue;
+		case ConfigurationTarget.USER_LOCAL:
+			return configValue.userLocalValue;
+		case ConfigurationTarget.USER_REMOTE:
+			return configValue.userRemoteValue;
+		case ConfigurationTarget.WORKSPACE:
+			return configValue.workspaceValue;
+		case ConfigurationTarget.WORKSPACE_FOLDER:
+			return configValue.workspaceFolderValue;
+		case ConfigurationTarget.DEFAULT:
+			return configValue.defaultValue;
+		case ConfigurationTarget.MEMORY:
+			return configValue.memoryValue;
+		default:
+			assertNever(scope);
+	}
 }
 
 export function isConfigured<T>(configValue: IConfigurationValue<T>): configValue is IConfigurationValue<T> & { value: T } {

--- a/src/vs/platform/mcp/common/mcpPlatformTypes.ts
+++ b/src/vs/platform/mcp/common/mcpPlatformTypes.ts
@@ -4,11 +4,13 @@
  *--------------------------------------------------------------------------------------------*/
 
 export interface IMcpConfiguration {
-	inputs: unknown[];
+	inputs?: unknown[];
 	/** @deprecated Only for rough cross-compat with other formats */
 	mcpServers?: Record<string, IMcpConfigurationStdio>;
-	servers: Record<string, IMcpConfigurationStdio | IMcpConfigurationSSE>;
+	servers?: Record<string, IMcpConfigurationStdio | IMcpConfigurationSSE>;
 }
+
+export type McpConfigurationServer = IMcpConfigurationStdio | IMcpConfigurationSSE;
 
 export interface IMcpConfigurationStdio {
 	type?: 'stdio';

--- a/src/vs/workbench/contrib/mcp/browser/mcp.contribution.ts
+++ b/src/vs/workbench/contrib/mcp/browser/mcp.contribution.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { registerAction2 } from '../../../../platform/actions/common/actions.js';
 import { SyncDescriptor } from '../../../../platform/instantiation/common/descriptors.js';
 import { InstantiationType, registerSingleton } from '../../../../platform/instantiation/common/extensions.js';
 import * as jsonContributionRegistry from '../../../../platform/jsonschemas/common/jsonContributionRegistry.js';
@@ -10,19 +11,17 @@ import { Registry } from '../../../../platform/registry/common/platform.js';
 import { registerWorkbenchContribution2, WorkbenchPhase } from '../../../common/contributions.js';
 import { mcpSchemaId } from '../../../services/configuration/common/configuration.js';
 import { ConfigMcpDiscovery } from '../common/discovery/configMcpDiscovery.js';
+import { ExtensionMcpDiscovery } from '../common/discovery/extensionMcpDiscovery.js';
 import { mcpDiscoveryRegistry } from '../common/discovery/mcpDiscovery.js';
 import { RemoteNativeMpcDiscovery } from '../common/discovery/nativeMcpRemoteDiscovery.js';
 import { mcpServerSchema } from '../common/mcpConfiguration.js';
+import { McpContextKeysController } from '../common/mcpContextKeys.js';
 import { McpRegistry } from '../common/mcpRegistry.js';
 import { IMcpRegistry } from '../common/mcpRegistryTypes.js';
 import { McpService } from '../common/mcpService.js';
 import { IMcpService } from '../common/mcpTypes.js';
+import { AddConfigurationAction, ListMcpServerCommand, MCPServerActionRendering, McpServerOptionsCommand, ResetMcpCachedTools, ResetMcpTrustCommand } from './mcpCommands.js';
 import { McpDiscovery } from './mcpDiscovery.js';
-
-import { MCPServerActionRendering, ListMcpServerCommand, ResetMcpTrustCommand, McpServerOptionsCommand, ResetMcpCachedTools } from './mcpCommands.js';
-import { registerAction2 } from '../../../../platform/actions/common/actions.js';
-import { McpContextKeysController } from '../common/mcpContextKeys.js';
-import { ExtensionMcpDiscovery } from '../common/discovery/extensionMcpDiscovery.js';
 
 registerSingleton(IMcpRegistry, McpRegistry, InstantiationType.Delayed);
 registerSingleton(IMcpService, McpService, InstantiationType.Delayed);
@@ -38,6 +37,8 @@ registerAction2(ListMcpServerCommand);
 registerAction2(McpServerOptionsCommand);
 registerAction2(ResetMcpTrustCommand);
 registerAction2(ResetMcpCachedTools);
+registerAction2(AddConfigurationAction);
+
 registerWorkbenchContribution2('mcpActionRendering', MCPServerActionRendering, WorkbenchPhase.BlockRestore);
 
 const jsonRegistry = <jsonContributionRegistry.IJSONContributionRegistry>Registry.as(jsonContributionRegistry.Extensions.JSONContribution);

--- a/src/vs/workbench/contrib/mcp/browser/mcpCommands.ts
+++ b/src/vs/workbench/contrib/mcp/browser/mcpCommands.ts
@@ -10,21 +10,31 @@ import { Event } from '../../../../base/common/event.js';
 import { Disposable, DisposableStore } from '../../../../base/common/lifecycle.js';
 import { autorun, derived } from '../../../../base/common/observable.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
+import { URI } from '../../../../base/common/uri.js';
+import { generateUuid } from '../../../../base/common/uuid.js';
 import { ILocalizedString, localize, localize2 } from '../../../../nls.js';
 import { IActionViewItemService } from '../../../../platform/actions/browser/actionViewItemService.js';
 import { MenuEntryActionViewItem } from '../../../../platform/actions/browser/menuEntryActionViewItem.js';
 import { Action2, MenuId, MenuItemAction } from '../../../../platform/actions/common/actions.js';
 import { ICommandService } from '../../../../platform/commands/common/commands.js';
+import { ConfigurationTarget, getConfigValueInTarget, IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { ContextKeyExpr } from '../../../../platform/contextkey/common/contextkey.js';
 import { IInstantiationService, ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
+import { IMcpConfiguration, IMcpConfigurationSSE } from '../../../../platform/mcp/common/mcpPlatformTypes.js';
 import { IQuickInputService, IQuickPickItem } from '../../../../platform/quickinput/common/quickInput.js';
 import { spinningLoading } from '../../../../platform/theme/common/iconRegistry.js';
+import { IWorkspace, IWorkspaceContextService } from '../../../../platform/workspace/common/workspace.js';
+import { ActiveEditorContext, ResourceContextKey } from '../../../common/contextkeys.js';
 import { IWorkbenchContribution } from '../../../common/contributions.js';
+import { IJSONEditingService } from '../../../services/configuration/common/jsonEditing.js';
+import { IWorkbenchEnvironmentService } from '../../../services/environment/common/environmentService.js';
 import { ChatContextKeys } from '../../chat/common/chatContextKeys.js';
 import { ChatMode } from '../../chat/common/constants.js';
+import { TEXT_FILE_EDITOR_ID } from '../../files/common/files.js';
+import { IMcpConfigurationStdio } from '../common/mcpConfiguration.js';
 import { McpContextKeys } from '../common/mcpContextKeys.js';
 import { IMcpRegistry } from '../common/mcpRegistryTypes.js';
-import { LazyCollectionState, IMcpServer, IMcpService, McpConnectionState, McpServerToolsState } from '../common/mcpTypes.js';
+import { IMcpServer, IMcpService, LazyCollectionState, McpConnectionState, McpServerToolsState } from '../common/mcpTypes.js';
 
 // acroynms do not get localized
 const category: ILocalizedString = {
@@ -355,5 +365,170 @@ export class ResetMcpCachedTools extends Action2 {
 	run(accessor: ServicesAccessor): void {
 		const mcpService = accessor.get(IMcpService);
 		mcpService.resetCaches();
+	}
+}
+
+export class AddConfigurationAction extends Action2 {
+	static readonly ID = 'workbench.mcp.addConfiguration';
+
+	constructor() {
+		super({
+			id: AddConfigurationAction.ID,
+			title: localize2('mcp.addConfiguration', "Add Server..."),
+			metadata: {
+				description: localize2('mcp.addConfiguration.description', "Installs a new Model Context protocol to the mcp.json settings"),
+			},
+			category,
+			f1: true,
+			menu: {
+				id: MenuId.EditorContent,
+				when: ContextKeyExpr.and(
+					ContextKeyExpr.regex(ResourceContextKey.Path.key, /\.vscode[/\\]mcp\.json$/),
+					ActiveEditorContext.isEqualTo(TEXT_FILE_EDITOR_ID)
+				)
+			}
+		});
+	}
+
+	private async getServerType(quickInputService: IQuickInputService): Promise<{ id: 'stdio' | 'sse' } | undefined> {
+		return quickInputService.pick([
+			{ id: 'stdio', label: localize('mcp.serverType.command', "Command (stdio)"), description: localize('mcp.serverType.command.description', "Run a local command that implements the MCP protocol") },
+			{ id: 'sse', label: localize('mcp.serverType.http', "HTTP (server-sent events)"), description: localize('mcp.serverType.http.description', "Connect to a remote HTTP server that implements the MCP protocol") }
+		], {
+			title: localize('mcp.serverType.title', "Select Server Type"),
+			placeHolder: localize('mcp.serverType.placeholder', "Choose the type of MCP server to add")
+		}) as Promise<{ id: 'stdio' | 'sse' } | undefined>;
+	}
+
+	private async getStdioConfig(quickInputService: IQuickInputService): Promise<IMcpConfigurationStdio | undefined> {
+		const command = await quickInputService.input({
+			title: localize('mcp.command.title', "Enter Command"),
+			placeHolder: localize('mcp.command.placeholder', "Command to run (with optional arguments)"),
+			ignoreFocusLost: true,
+		});
+
+		if (!command) {
+			return undefined;
+		}
+
+		// Split command into command and args, handling quotes
+		const parts = command.match(/(?:[^\s"]+|"[^"]*")+/g)!;
+		return {
+			type: 'stdio',
+			command: parts[0].replace(/"/g, ''),
+			args: parts.slice(1).map(arg => arg.replace(/"/g, ''))
+		};
+	}
+
+	private async getSSEConfig(quickInputService: IQuickInputService): Promise<IMcpConfigurationSSE | undefined> {
+		const url = await quickInputService.input({
+			title: localize('mcp.url.title', "Enter Server URL"),
+			placeHolder: localize('mcp.url.placeholder', "URL of the MCP server (e.g., http://localhost:3000)"),
+			ignoreFocusLost: true,
+		});
+
+		if (!url) {
+			return undefined;
+		}
+
+		return {
+			type: 'sse',
+			url
+		};
+	}
+
+	private async getServerId(quickInputService: IQuickInputService): Promise<string | undefined> {
+		const suggestedId = `my-mcp-server-${generateUuid().split('-')[0]}`;
+		const id = await quickInputService.input({
+			title: localize('mcp.serverId.title', "Enter Server ID"),
+			placeHolder: localize('mcp.serverId.placeholder', "Unique identifier for this server"),
+			value: suggestedId,
+			ignoreFocusLost: true,
+		});
+
+		return id;
+	}
+
+	private async getConfigurationTarget(quickInputService: IQuickInputService, workspace: IWorkspace, isInRemote: boolean): Promise<ConfigurationTarget | undefined> {
+		const options: (IQuickPickItem & { target: ConfigurationTarget })[] = [
+			{ target: ConfigurationTarget.USER, label: localize('mcp.target.user', "User Settings"), description: localize('mcp.target.user.description', "Available in all workspaces") }
+		];
+
+		if (isInRemote) {
+			options.push({ target: ConfigurationTarget.USER_REMOTE, label: localize('mcp.target.remote', "Remote Settings"), description: localize('mcp.target..remote.description', "Available on this remote machine") });
+		}
+
+		if (workspace.folders.length > 0) {
+			options.push({ target: ConfigurationTarget.WORKSPACE, label: localize('mcp.target.workspace', "Workspace Settings"), description: localize('mcp.target.workspace.description', "Available in this workspace") });
+		}
+
+		if (options.length === 1) {
+			return options[0].target;
+		}
+
+
+		const targetPick = await quickInputService.pick(options, {
+			title: localize('mcp.target.title', "Choose where to save the configuration"),
+		});
+
+		return targetPick?.target;
+	}
+
+	async run(accessor: ServicesAccessor, configUri?: string): Promise<void> {
+		const quickInputService = accessor.get(IQuickInputService);
+		const configurationService = accessor.get(IConfigurationService);
+		const jsonEditingService = accessor.get(IJSONEditingService);
+		const workspaceService = accessor.get(IWorkspaceContextService);
+		const environmentService = accessor.get(IWorkbenchEnvironmentService);
+
+		// Step 1: Choose server type
+		const serverType = await this.getServerType(quickInputService);
+		if (!serverType) {
+			return;
+		}
+
+		// Step 2: Get server details based on type
+		const serverConfig = await (serverType.id === 'stdio'
+			? this.getStdioConfig(quickInputService)
+			: this.getSSEConfig(quickInputService));
+
+		if (!serverConfig) {
+			return;
+		}
+
+		// Step 3: Get server ID
+		const serverId = await this.getServerId(quickInputService);
+		if (!serverId) {
+			return;
+		}
+
+		// Step 4: Choose configuration target if no configUri provided
+		let target: ConfigurationTarget | undefined;
+		const workspace = workspaceService.getWorkspace();
+		if (!configUri) {
+			target = await this.getConfigurationTarget(quickInputService, workspace, !!environmentService.remoteAuthority);
+			if (!target) {
+				return;
+			}
+		}
+
+		// Step 5: Update configuration
+		const writeToUriDirect = configUri
+			? URI.parse(configUri)
+			: target === ConfigurationTarget.WORKSPACE && workspace.folders.length === 1
+				? URI.joinPath(workspace.folders[0].uri, '.vscode', 'mcp.json')
+				: undefined;
+
+		if (writeToUriDirect) {
+			await jsonEditingService.write(writeToUriDirect, [{
+				path: ['servers', serverId],
+				value: serverConfig
+			}], true);
+		} else {
+			const settings: IMcpConfiguration = { ...getConfigValueInTarget(configurationService.inspect<IMcpConfiguration>('mcp'), target!) };
+			settings.servers ??= {};
+			settings.servers[serverId] = serverConfig;
+			await configurationService.updateValue('mcp', settings, target!);
+		}
 	}
 }

--- a/src/vs/workbench/contrib/mcp/common/mcpConfiguration.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpConfiguration.ts
@@ -10,7 +10,7 @@ import { mcpSchemaId } from '../../../services/configuration/common/configuratio
 import { inputsSchema } from '../../../services/configurationResolver/common/configurationResolverSchema.js';
 import { IExtensionPointDescriptor } from '../../../services/extensions/common/extensionsRegistry.js';
 
-export type { IMcpConfigurationStdio, IMcpConfiguration } from '../../../../platform/mcp/common/mcpPlatformTypes.js';
+export type { McpConfigurationServer, IMcpConfigurationStdio, IMcpConfiguration } from '../../../../platform/mcp/common/mcpPlatformTypes.js';
 
 const mcpActivationEventPrefix = 'onMcpCollection:';
 

--- a/src/vs/workbench/services/configuration/common/configurationEditing.ts
+++ b/src/vs/workbench/services/configuration/common/configurationEditing.ts
@@ -531,7 +531,7 @@ export class ConfigurationEditing {
 
 		if (operation.workspaceStandAloneConfigurationKey) {
 			// Global launches are not supported
-			if ((operation.workspaceStandAloneConfigurationKey !== TASKS_CONFIGURATION_KEY) && (target === EditableConfigurationTarget.USER_LOCAL || target === EditableConfigurationTarget.USER_REMOTE)) {
+			if ((operation.workspaceStandAloneConfigurationKey !== TASKS_CONFIGURATION_KEY) && (operation.workspaceStandAloneConfigurationKey !== MCP_CONFIGURATION_KEY) && (target === EditableConfigurationTarget.USER_LOCAL || target === EditableConfigurationTarget.USER_REMOTE)) {
 				throw this.toConfigurationEditingError(ConfigurationEditingErrorCode.ERROR_INVALID_USER_TARGET, target, operation);
 			}
 		}
@@ -590,15 +590,16 @@ export class ConfigurationEditing {
 				const resource = this.getConfigurationFileResource(target, key, standaloneConfigurationMap[key], overrides.resource, undefined);
 
 				// Check for prefix
+				const keyRemainsNested = this.isWorkspaceConfigurationResource(resource) || resource?.fsPath === this.userDataProfileService.currentProfile.settingsResource.fsPath;
 				if (config.key === key) {
-					const jsonPath = this.isWorkspaceConfigurationResource(resource) ? [key] : [];
+					const jsonPath = keyRemainsNested ? [key] : [];
 					return { key: jsonPath[jsonPath.length - 1], jsonPath, value: config.value, resource: resource ?? undefined, workspaceStandAloneConfigurationKey: key, target };
 				}
 
 				// Check for prefix.<setting>
 				const keyPrefix = `${key}.`;
 				if (config.key.indexOf(keyPrefix) === 0) {
-					const jsonPath = this.isWorkspaceConfigurationResource(resource) ? [key, config.key.substr(keyPrefix.length)] : [config.key.substr(keyPrefix.length)];
+					const jsonPath = keyRemainsNested ? [key, config.key.substr(keyPrefix.length)] : [config.key.substr(keyPrefix.length)];
 					return { key: jsonPath[jsonPath.length - 1], jsonPath, value: config.value, resource: resource ?? undefined, workspaceStandAloneConfigurationKey: key, target };
 				}
 			}


### PR DESCRIPTION
An editor content button is shown on mcp.json to add a server.
Additionally, the command is accessible on the command palette and when
invoked from there will prompt the user to pick where to save their
config.

With registry support I envision the "Select Server Type" would list
servers in addition to letting users provide their own.

Closes #243617

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
