### PR TITLE
[reusable prompts]: support glob patterns in configuration settings

### DIFF
--- a/src/vs/platform/prompts/common/config.ts
+++ b/src/vs/platform/prompts/common/config.ts
@@ -115,9 +115,12 @@ export namespace PromptsConfig {
 
 			// copy all the enabled paths to the result list
 			for (const [path, enabled] of Object.entries(value)) {
-				if (enabled && path !== DEFAULT_SOURCE_FOLDER) {
-					paths.push(path);
+				// we already added the default source folder, so skip it
+				if ((enabled === false) || (path === DEFAULT_SOURCE_FOLDER)) {
+					continue;
 				}
+
+				paths.push(path);
 			}
 
 			return paths;

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsService.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsService.ts
@@ -85,9 +85,9 @@ export class PromptsService extends Disposable implements IPromptsService {
 		const userLocations = [this.userDataService.currentProfile.promptsHome];
 
 		const prompts = await Promise.all([
-			this.fileLocator.listFilesIn(userLocations, [])
+			this.fileLocator.listFilesIn(userLocations)
 				.then(withType('user')),
-			this.fileLocator.listFiles([])
+			this.fileLocator.listFiles()
 				.then(withType('local')),
 		]);
 

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsService.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsService.ts
@@ -97,8 +97,8 @@ export class PromptsService extends Disposable implements IPromptsService {
 	public getSourceFolders(
 		type: IPromptPath['type'],
 	): readonly IPromptPath[] {
-		// sanity check to make sure we don't miss a new prompt type
-		// added in the future
+		// sanity check to make sure we don't miss a new
+		// prompt type that could be added in the future
 		assert(
 			type === 'local' || type === 'user',
 			`Unknown prompt type '${type}'.`,

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/utils/promptFilesLocator.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/utils/promptFilesLocator.ts
@@ -4,13 +4,16 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { URI } from '../../../../../../base/common/uri.js';
+import { match } from '../../../../../../base/common/glob.js';
+import { assert } from '../../../../../../base/common/assert.js';
+import { isAbsolute } from '../../../../../../base/common/path.js';
 import { ResourceSet } from '../../../../../../base/common/map.js';
 import { dirname, extUri } from '../../../../../../base/common/resources.js';
 import { IFileService } from '../../../../../../platform/files/common/files.js';
 import { PromptsConfig } from '../../../../../../platform/prompts/common/config.js';
-import { isPromptFile } from '../../../../../../platform/prompts/common/constants.js';
 import { IWorkspaceContextService } from '../../../../../../platform/workspace/common/workspace.js';
 import { IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
+import { isPromptFile, PROMPT_FILE_EXTENSION } from '../../../../../../platform/prompts/common/constants.js';
 
 /**
  * Utility class to locate prompt files.
@@ -153,4 +156,230 @@ export class PromptFilesLocator {
 
 		return files;
 	}
+
+	/**
+	* TODO: @lego
+	*
+	* @throws if any of the provided locations is not an `absolute path`.
+	*/
+	public async findAllMatchingPromptFiles(
+		// configuredLocations: readonly string[],
+		// fileService: IFileService,
+		// workspaceService: IWorkspaceContextService,
+	): Promise<readonly URI[]> {
+		const configuredLocations = PromptsConfig.promptSourceFolders(this.configService);
+		// convert locations from settings to absolute paths based on the current workspace folders
+		const absoluteLocations = toAbsoluteLocations(configuredLocations, this.workspaceService);
+
+		// find all prompt files in the provided locations, then match
+		// the found file paths against (possible) glob patterns
+		const paths = new ResourceSet();
+		for (const absoluteLocation of absoluteLocations) {
+			// assert(
+			// 	isAbsolute(location),
+			// 	`Provided location must be an absolute path, got '${location}'.`,
+			// );
+
+			// normalize the glob pattern to always end with "any prompt file" pattern
+			const location = (absoluteLocation.path.endsWith(PROMPT_FILE_EXTENSION))
+				? absoluteLocation
+				: extUri.joinPath(absoluteLocation, `*${PROMPT_FILE_EXTENSION}`);
+
+			// find all prompt files in entire file tree, starting from
+			// a first parent folder that does not contain a glob pattern
+			const promptFiles = await findAllPromptFiles(
+				firstNonGlobParent(location),
+				this.fileService,
+			);
+
+			// filter out found prompt files to only include those that match
+			// the original glob pattern specified in the settings (if any)
+			for (const file of promptFiles) {
+				if (match(location.path, file.path)) {
+					paths.add(file);
+				}
+			}
+		}
+
+		return [...paths];
+	}
 }
+
+/**
+ * Checks if the provided `pattern` could be a valid glob pattern.
+ */
+export const isValidGlob = (pattern: string): boolean => {
+	let squareBrackets = false;
+	let squareBracketsCount = 0;
+
+	let curlyBrackets = false;
+	let curlyBracketsCount = 0;
+
+	for (const char of pattern) {
+		if (char === '*') {
+			return true;
+		}
+
+		if (char === '?') {
+			return true;
+		}
+
+		// TODO: @lego - check that these are not escaped?
+		if (char === '[') {
+			squareBrackets = true;
+
+			squareBracketsCount++;
+		}
+
+		if (char === ']') {
+			squareBrackets = true;
+
+			// if there are no matching opening square brackets, this is an `invalid glob`
+			if (squareBracketsCount % 2 === 0) {
+				return false;
+			}
+
+			squareBracketsCount--;
+		}
+
+		if (char === '{') {
+			curlyBrackets = true;
+
+			curlyBracketsCount++;
+		}
+
+		if (char === '}') {
+			curlyBrackets = true;
+
+			// if there are no matching opening curly brackets, this is an `invalid glob`
+			if (curlyBracketsCount % 2 === 0) {
+				return false;
+			}
+
+			curlyBracketsCount--;
+		}
+	}
+
+	// if square brackets exist and are in pairs, this is a `valid glob`
+	if (squareBrackets && squareBracketsCount === 0) {
+		return true;
+	}
+
+	// if curly brackets exist and are in pairs, this is a `valid glob`
+	if (curlyBrackets && curlyBracketsCount === 0) {
+		return true;
+	}
+
+	return false;
+};
+
+/**
+ * TODO: @lego - notes
+ * - if path `starts with a glob`, it must be relative to current workspace folders, otherwise we would need to scan through entire filesystem of the machine
+ * - likewise if a `relative path`, it must be relative to current workspace folders
+ * - only if path is `absolute`, we can try to resolve all prompt files in it and its subfolders, and then try to match the files against a glob pattern
+ */
+
+/**
+ * Finds the first parent of the provided location that does not contain a `glob pattern`.
+ *
+ * @throws if the provided location is not an `absolute path`.
+ */
+// TODO: @lego - add examples?
+export const firstNonGlobParent = (
+	location: URI,
+): URI => {
+	// sanity check of the provided location
+	assert(
+		isAbsolute(location.path),
+		`Provided location must be an absolute path, got '${location.path}'.`,
+	);
+
+	// note! if though the folder name can be `invalid glob` here, it is still OK to
+	//       use it as we don't really known if that is a glob pattern, or the folder
+	//       name contains characters that can also be used in a glob pattern
+	if (isValidGlob(location.path) === false) {
+		return location;
+	}
+
+	// if location is the root of the filesystem, we are done
+	const parent = dirname(location);
+	if (extUri.isEqual(parent, location)) {
+		return location;
+	}
+
+	// otherwise, try again starting with the parent folder
+	return firstNonGlobParent(parent);
+};
+
+/**
+ * TODO: @lego
+ */
+const findAllPromptFiles = async (
+	location: URI,
+	fileService: IFileService,
+): Promise<readonly URI[]> => {
+	const result: URI[] = [];
+	const info = await fileService.resolve(location);
+
+	if (info.isFile && isPromptFile(info.resource)) {
+		result.push(info.resource);
+
+		return result;
+	}
+
+	if (info.isDirectory && info.children) {
+		for (const child of info.children) {
+			if (child.isFile && isPromptFile(child.resource)) {
+				result.push(child.resource);
+
+				continue;
+			}
+
+			if (child.isDirectory) {
+				const promptFiles = await findAllPromptFiles(child.resource, fileService);
+				result.push(...promptFiles);
+
+				continue;
+			}
+		}
+
+		return result;
+	}
+
+	return result;
+};
+
+/**
+ * Converts locations from settings to absolute paths
+ * based on the current workspace folders.
+ */
+const toAbsoluteLocations = (
+	configuredLocations: readonly string[],
+	workspaceService: IWorkspaceContextService,
+): readonly URI[] => {
+	const { folders } = workspaceService.getWorkspace();
+
+	const result: URI[] = [];
+	for (const configuredLocation of configuredLocations) {
+		if (isAbsolute(configuredLocation)) {
+			result.push(URI.file(configuredLocation));
+
+			continue;
+		}
+
+		for (const workspaceFolder of folders) {
+			const absolutePath = extUri.resolvePath(workspaceFolder.uri, configuredLocation);
+
+			// a sanity check on the expected outcome of the `resolvePath()` call
+			assert(
+				isAbsolute(absolutePath.path),
+				`Provided location must be an absolute path, got '${absolutePath.path}'.`,
+			);
+
+			result.push(absolutePath);
+		}
+	}
+
+	return result;
+};

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/utils/promptFilesLocator.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/utils/promptFilesLocator.ts
@@ -28,12 +28,9 @@ export class PromptFilesLocator {
 	 * @param exclude List of `URIs` to exclude from the result.
 	 * @returns List of prompt files found in the workspace.
 	 */
-	public async listFiles(
-		exclude: readonly URI[],
-	): Promise<readonly URI[]> {
+	public async listFiles(): Promise<readonly URI[]> {
 		return await this.listFilesIn(
 			this.getConfigBasedSourceFolders(),
-			exclude,
 		);
 	}
 
@@ -46,21 +43,8 @@ export class PromptFilesLocator {
 	 */
 	public async listFilesIn(
 		folders: readonly URI[],
-		exclude: readonly URI[],
 	): Promise<readonly URI[]> {
-		// create a set from the list of URIs for convenience
-		const excludeSet: Set<string> = new Set();
-		for (const excludeUri of exclude) {
-			excludeSet.add(excludeUri.path);
-		}
-
-		// filter out the excluded paths from the folders list
-		const cleanFolders = folders
-			.filter((folder) => {
-				return !excludeSet.has(folder.path);
-			});
-
-		return await this.findInstructionFiles(cleanFolders, excludeSet);
+		return await this.findInstructionFiles(folders);
 	}
 
 	/**
@@ -133,7 +117,6 @@ export class PromptFilesLocator {
 	 */
 	private async findInstructionFiles(
 		folders: readonly URI[],
-		exclude: ReadonlySet<string>,
 	): Promise<readonly URI[]> {
 		const results = await this.fileService.resolveAll(
 			folders.map((resource) => {
@@ -161,10 +144,6 @@ export class PromptFilesLocator {
 				}
 
 				if (!isPromptFile(resource)) {
-					continue;
-				}
-
-				if (exclude.has(resource.path)) {
 					continue;
 				}
 

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/utils/promptFilesLocator.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/utils/promptFilesLocator.ts
@@ -28,7 +28,6 @@ export class PromptFilesLocator {
 	/**
 	 * List all prompt files from the filesystem.
 	 *
-	 * @param exclude List of `URIs` to exclude from the result.
 	 * @returns List of prompt files found in the workspace.
 	 */
 	public async listFiles(): Promise<readonly URI[]> {
@@ -44,7 +43,6 @@ export class PromptFilesLocator {
 	 * @throws if any of the provided folder paths is not an `absolute path`.
 	 *
 	 * @param absoluteLocations List of prompt file source folders to search for prompt files in. Must be absolute paths.
-	 * @param exclude List of `URIs` to exclude from the result.
 	 * @returns List of prompt files found in the provided folders.
 	 */
 	public async listFilesIn(
@@ -54,8 +52,14 @@ export class PromptFilesLocator {
 	}
 
 	/**
-	 * Get all possible unambiguous prompt file source folders based
-	 * on the current workspace folder structure.
+	 * Get all possible unambiguous prompt file source folders based on
+	 * the current workspace folder structure.
+	 *
+	 * This method is currently primarily used by the `> Create Prompt`
+	 * command that providers users with the list of destination folders
+	 * for a newly created prompt file. Because such a list cannot contain
+	 * paths that include `glob pattern` in them, we need to process config
+	 * values and try to create a list of clear and unambiguous locations.
 	 *
 	 * @returns List of possible unambiguous prompt file folders.
 	 */
@@ -106,7 +110,6 @@ export class PromptFilesLocator {
 	 * @throws if any of the provided folder paths is not an `absolute path`.
 	 *
 	 * @param absoluteLocations List of prompt file source folders to search for prompt files in. Must be absolute paths.
-	 * @param exclude Map of `path -> boolean` to exclude from the result.
 	 * @returns List of prompt files found in the provided source folders.
 	 */
 	private async findInstructionFiles(
@@ -218,13 +221,6 @@ export const isValidGlob = (pattern: string): boolean => {
 
 	return false;
 };
-
-/**
- * TODO: @lego - notes
- * - if path `starts with a glob`, it must be relative to current workspace folders, otherwise we would need to scan through entire filesystem of the machine
- * - likewise if a `relative path`, it must be relative to current workspace folders
- * - only if path is `absolute`, we can try to resolve all prompt files in it and its subfolders, and then try to match the files against a glob pattern
- */
 
 /**
  * Finds the first parent of the provided location that does not contain a `glob pattern`.

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/utils/promptFilesLocator.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/utils/promptFilesLocator.ts
@@ -16,6 +16,11 @@ import { IConfigurationService } from '../../../../../../platform/configuration/
 import { isPromptFile, PROMPT_FILE_EXTENSION } from '../../../../../../platform/prompts/common/constants.js';
 
 /**
+ * TODO: @lego - list
+ *  - update `getConfigBasedSourceFolders()` logic / make the `> Create Prompt` command work with exising prompt file locations
+ */
+
+/**
  * Utility class to locate prompt files.
  */
 export class PromptFilesLocator {
@@ -174,7 +179,14 @@ export const isValidGlob = (pattern: string): boolean => {
 	let curlyBrackets = false;
 	let curlyBracketsCount = 0;
 
+	let previousCharacter: string | undefined;
 	for (const char of pattern) {
+		// skip all escaped characters
+		if (previousCharacter === '\\') {
+			previousCharacter = char;
+			continue;
+		}
+
 		if (char === '*') {
 			return true;
 		}
@@ -183,49 +195,44 @@ export const isValidGlob = (pattern: string): boolean => {
 			return true;
 		}
 
-		// TODO: @lego - check that these are not escaped?
 		if (char === '[') {
 			squareBrackets = true;
-
 			squareBracketsCount++;
+
+			previousCharacter = char;
+			continue;
 		}
 
 		if (char === ']') {
 			squareBrackets = true;
-
-			// if there are no matching opening square brackets, this is an `invalid glob`
-			if (squareBracketsCount % 2 === 0) {
-				return false;
-			}
-
 			squareBracketsCount--;
+			previousCharacter = char;
+			continue;
 		}
 
 		if (char === '{') {
 			curlyBrackets = true;
-
 			curlyBracketsCount++;
+			continue;
 		}
 
 		if (char === '}') {
 			curlyBrackets = true;
-
-			// if there are no matching opening curly brackets, this is an `invalid glob`
-			if (curlyBracketsCount % 2 === 0) {
-				return false;
-			}
-
 			curlyBracketsCount--;
+			previousCharacter = char;
+			continue;
 		}
+
+		previousCharacter = char;
 	}
 
 	// if square brackets exist and are in pairs, this is a `valid glob`
-	if (squareBrackets && squareBracketsCount === 0) {
+	if (squareBrackets && (squareBracketsCount === 0)) {
 		return true;
 	}
 
 	// if curly brackets exist and are in pairs, this is a `valid glob`
-	if (curlyBrackets && curlyBracketsCount === 0) {
+	if (curlyBrackets && (curlyBracketsCount === 0)) {
 		return true;
 	}
 

--- a/src/vs/workbench/contrib/chat/test/common/promptSyntax/utils/promptFilesLocator.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/promptSyntax/utils/promptFilesLocator.test.ts
@@ -22,6 +22,12 @@ import { IConfigurationOverrides, IConfigurationService } from '../../../../../.
 import { IWorkspace, IWorkspaceContextService, IWorkspaceFolder } from '../../../../../../../platform/workspace/common/workspace.js';
 
 /**
+ * TODO: @lego - list
+ *  - add `empty workspace` unit tests
+ *  - add `all together` unit tests
+ */
+
+/**
  * Mocked instance of {@link IConfigurationService}.
  */
 const mockConfigService = <T>(value: T): IConfigurationService => {
@@ -109,7 +115,8 @@ suite('PromptFilesLocator', () => {
 				const locator = await createPromptsLocator(undefined, EMPTY_WORKSPACE, []);
 
 				assert.deepStrictEqual(
-					await locator.listFiles(),
+					(await locator.listFiles())
+						.map((file) => file.fsPath),
 					[],
 					'No prompts must be found.',
 				);
@@ -145,7 +152,8 @@ suite('PromptFilesLocator', () => {
 				const locator = await createPromptsLocator(null, EMPTY_WORKSPACE, []);
 
 				assert.deepStrictEqual(
-					await locator.listFiles(),
+					(await locator.listFiles())
+						.map((file) => file.fsPath),
 					[],
 					'No prompts must be found.',
 				);
@@ -155,7 +163,8 @@ suite('PromptFilesLocator', () => {
 				const locator = await createPromptsLocator('/etc/hosts/prompts', EMPTY_WORKSPACE, []);
 
 				assert.deepStrictEqual(
-					await locator.listFiles(),
+					(await locator.listFiles())
+						.map((file) => file.fsPath),
 					[],
 					'No prompts must be found.',
 				);
@@ -163,7 +172,7 @@ suite('PromptFilesLocator', () => {
 		});
 
 		suite('• non-empty filesystem', () => {
-			test('• object config value', async () => {
+			test('• core logic', async () => {
 				const locator = await createPromptsLocator(
 					{
 						'/Users/legomushroom/repos/prompts': true,
@@ -207,11 +216,12 @@ suite('PromptFilesLocator', () => {
 					]);
 
 				assert.deepStrictEqual(
-					await locator.listFiles(),
+					(await locator.listFiles())
+						.map((file) => file.fsPath),
 					[
-						createURI('/Users/legomushroom/repos/prompts/test.prompt.md'),
-						createURI('/Users/legomushroom/repos/prompts/refactor-tests.prompt.md'),
-						createURI('/tmp/prompts/translate.to-rust.prompt.md'),
+						createURI('/Users/legomushroom/repos/prompts/test.prompt.md').path,
+						createURI('/Users/legomushroom/repos/prompts/refactor-tests.prompt.md').path,
+						createURI('/tmp/prompts/translate.to-rust.prompt.md').path,
 					],
 					'Must find correct prompts.',
 				);
@@ -220,655 +230,655 @@ suite('PromptFilesLocator', () => {
 	});
 
 	suite('• single-root workspace', () => {
-		suite('• findAllMatchingPromptFiles', () => {
-			suite('• glob pattern', () => {
-				suite('• relative', () => {
-					suite('• wild card', () => {
-						const testSettings = [
-							'**',
-							'**/*.prompt.md',
-							'**/*.md',
-							'**/*',
-							'deps/**',
-							'deps/**/*.prompt.md',
-							'deps/**/*',
-							'deps/**/*.md',
-							'**/text/**',
-							'**/text/**/*',
-							'**/text/**/*.md',
-							'**/text/**/*.prompt.md',
-							'deps/text/**',
-							'deps/text/**/*',
-							'deps/text/**/*.md',
-							'deps/text/**/*.prompt.md',
-						];
+		suite('• glob pattern', () => {
+			suite('• relative', () => {
+				suite('• wild card', () => {
+					const testSettings = [
+						'**',
+						'**/*.prompt.md',
+						'**/*.md',
+						'**/*',
+						'deps/**',
+						'deps/**/*.prompt.md',
+						'deps/**/*',
+						'deps/**/*.md',
+						'**/text/**',
+						'**/text/**/*',
+						'**/text/**/*.md',
+						'**/text/**/*.prompt.md',
+						'deps/text/**',
+						'deps/text/**/*',
+						'deps/text/**/*.md',
+						'deps/text/**/*.prompt.md',
+					];
 
-						for (const setting of testSettings) {
-							test(`• '${setting}'`, async () => {
-								const locator = await createPromptsLocator(
-									{ [setting]: true },
-									['/Users/legomushroom/repos/vscode'],
-									[
-										{
-											name: '/Users/legomushroom/repos/vscode',
-											children: [
-												{
-													name: 'deps/text',
-													children: [
-														{
-															name: 'my.prompt.md',
-															contents: 'oh hi, bot!',
-														},
-														{
-															name: 'nested',
-															children: [
-																{
-																	name: 'specific.prompt.md',
-																	contents: 'oh hi, bot!',
-																},
-																{
-																	name: 'unspecific1.prompt.md',
-																	contents: 'oh hi, robot!',
-																},
-																{
-																	name: 'unspecific2.prompt.md',
-																	contents: 'oh hi, rabot!',
-																},
-																{
-																	name: 'readme.md',
-																	contents: 'non prompt file',
-																},
-															],
-														}
-													],
-												},
-											],
-										},
-									],
-								);
+					for (const setting of testSettings) {
+						test(`• '${setting}'`, async () => {
+							const locator = await createPromptsLocator(
+								{ [setting]: true },
+								['/Users/legomushroom/repos/vscode'],
+								[
+									{
+										name: '/Users/legomushroom/repos/vscode',
+										children: [
+											{
+												name: 'deps/text',
+												children: [
+													{
+														name: 'my.prompt.md',
+														contents: 'oh hi, bot!',
+													},
+													{
+														name: 'nested',
+														children: [
+															{
+																name: 'specific.prompt.md',
+																contents: 'oh hi, bot!',
+															},
+															{
+																name: 'unspecific1.prompt.md',
+																contents: 'oh hi, robot!',
+															},
+															{
+																name: 'unspecific2.prompt.md',
+																contents: 'oh hi, rabot!',
+															},
+															{
+																name: 'readme.md',
+																contents: 'non prompt file',
+															},
+														],
+													}
+												],
+											},
+										],
+									},
+								],
+							);
 
-								assert.deepStrictEqual(
-									(await locator.findAllMatchingPromptFiles())
-										.map((file) => file.fsPath),
-									[
-										createURI('/Users/legomushroom/repos/vscode/deps/text/my.prompt.md').fsPath,
-										createURI('/Users/legomushroom/repos/vscode/deps/text/nested/specific.prompt.md').fsPath,
-										createURI('/Users/legomushroom/repos/vscode/deps/text/nested/unspecific1.prompt.md').fsPath,
-										createURI('/Users/legomushroom/repos/vscode/deps/text/nested/unspecific2.prompt.md').fsPath,
-									],
-									'Must find correct prompts.',
-								);
-							});
-						}
-					});
-
-					suite(`• specific`, () => {
-						const testSettings = [
-							[
-								'**/*specific*',
-							],
-							[
-								'**/*specific*.prompt.md',
-							],
-							[
-								'**/*specific*.md',
-							],
-							[
-								'**/specific*',
-								'**/unspecific1.prompt.md',
-								'**/unspecific2.prompt.md',
-							],
-							[
-								'**/specific.prompt.md',
-								'**/unspecific*.prompt.md',
-							],
-							[
-								'**/nested/specific.prompt.md',
-								'**/nested/unspecific*.prompt.md',
-							],
-							[
-								'**/nested/*specific*',
-							],
-							[
-								'**/*spec*.prompt.md',
-							],
-							[
-								'**/*spec*',
-							],
-							[
-								'**/*spec*.md',
-							],
-							[
-								'**/deps/**/*spec*.md',
-							],
-							[
-								'**/text/**/*spec*.md',
-							],
-							[
-								'deps/text/nested/*spec*',
-							],
-							[
-								'deps/text/nested/*specific*',
-							],
-							[
-								'deps/**/*specific*',
-							],
-							[
-								'deps/**/specific*',
-								'deps/**/unspecific*.prompt.md',
-							],
-							[
-								'deps/**/specific*.md',
-								'deps/**/unspecific*.md',
-							],
-							[
-								'deps/**/specific.prompt.md',
-								'deps/**/unspecific1.prompt.md',
-								'deps/**/unspecific2.prompt.md',
-							],
-							[
-								'deps/**/specific.prompt.md',
-								'deps/**/unspecific1*.md',
-								'deps/**/unspecific2*.md',
-							],
-							[
-								'deps/text/**/*specific*',
-							],
-							[
-								'deps/text/**/specific*',
-								'deps/text/**/unspecific*.prompt.md',
-							],
-							[
-								'deps/text/**/specific*.md',
-								'deps/text/**/unspecific*.md',
-							],
-							[
-								'deps/text/**/specific.prompt.md',
-								'deps/text/**/unspecific1.prompt.md',
-								'deps/text/**/unspecific2.prompt.md',
-							],
-							[
-								'deps/text/**/specific.prompt.md',
-								'deps/text/**/unspecific1*.md',
-								'deps/text/**/unspecific2*.md',
-							],
-						];
-
-						for (const settings of testSettings) {
-							test(`• '${JSON.stringify(settings)}'`, async () => {
-								const vscodeSettings: Record<string, boolean> = {};
-								for (const setting of settings) {
-									vscodeSettings[setting] = true;
-								}
-
-								const locator = await createPromptsLocator(
-									vscodeSettings,
-									['/Users/legomushroom/repos/vscode'],
-									[
-										{
-											name: '/Users/legomushroom/repos/vscode',
-											children: [
-												{
-													name: 'deps/text',
-													children: [
-														{
-															name: 'my.prompt.md',
-															contents: 'oh hi, bot!',
-														},
-														{
-															name: 'nested',
-															children: [
-																{
-																	name: 'default.prompt.md',
-																	contents: 'oh hi, bot!',
-																},
-																{
-																	name: 'specific.prompt.md',
-																	contents: 'oh hi, bot!',
-																},
-																{
-																	name: 'unspecific1.prompt.md',
-																	contents: 'oh hi, robot!',
-																},
-																{
-																	name: 'unspecific2.prompt.md',
-																	contents: 'oh hi, rawbot!',
-																},
-																{
-																	name: 'readme.md',
-																	contents: 'non prompt file',
-																},
-															],
-														}
-													],
-												},
-											],
-										},
-									],
-								);
-
-								assert.deepStrictEqual(
-									(await locator.findAllMatchingPromptFiles())
-										.map((file) => file.fsPath),
-									[
-										createURI('/Users/legomushroom/repos/vscode/deps/text/nested/specific.prompt.md').fsPath,
-										createURI('/Users/legomushroom/repos/vscode/deps/text/nested/unspecific1.prompt.md').fsPath,
-										createURI('/Users/legomushroom/repos/vscode/deps/text/nested/unspecific2.prompt.md').fsPath,
-									],
-									'Must find correct prompts.',
-								);
-							});
-						}
-					});
+							assert.deepStrictEqual(
+								(await locator.listFiles())
+									.map((file) => file.fsPath),
+								[
+									createURI('/Users/legomushroom/repos/vscode/deps/text/my.prompt.md').fsPath,
+									createURI('/Users/legomushroom/repos/vscode/deps/text/nested/specific.prompt.md').fsPath,
+									createURI('/Users/legomushroom/repos/vscode/deps/text/nested/unspecific1.prompt.md').fsPath,
+									createURI('/Users/legomushroom/repos/vscode/deps/text/nested/unspecific2.prompt.md').fsPath,
+								],
+								'Must find correct prompts.',
+							);
+						});
+					}
 				});
 
-				suite('• absolute', () => {
-					suite('• wild card', () => {
-						const settings = [
-							'/Users/legomushroom/repos/vscode/**',
-							'/Users/legomushroom/repos/vscode/**/*.prompt.md',
-							'/Users/legomushroom/repos/vscode/**/*.md',
-							'/Users/legomushroom/repos/vscode/**/*',
-							'/Users/legomushroom/repos/vscode/deps/**',
-							'/Users/legomushroom/repos/vscode/deps/**/*.prompt.md',
-							'/Users/legomushroom/repos/vscode/deps/**/*',
-							'/Users/legomushroom/repos/vscode/deps/**/*.md',
-							'/Users/legomushroom/repos/vscode/**/text/**',
-							'/Users/legomushroom/repos/vscode/**/text/**/*',
-							'/Users/legomushroom/repos/vscode/**/text/**/*.md',
-							'/Users/legomushroom/repos/vscode/**/text/**/*.prompt.md',
-							'/Users/legomushroom/repos/vscode/deps/text/**',
-							'/Users/legomushroom/repos/vscode/deps/text/**/*',
-							'/Users/legomushroom/repos/vscode/deps/text/**/*.md',
-							'/Users/legomushroom/repos/vscode/deps/text/**/*.prompt.md',
-						];
+				suite(`• specific`, () => {
+					const testSettings = [
+						[
+							'**/*specific*',
+						],
+						[
+							'**/*specific*.prompt.md',
+						],
+						[
+							'**/*specific*.md',
+						],
+						[
+							'**/specific*',
+							'**/unspecific1.prompt.md',
+							'**/unspecific2.prompt.md',
+						],
+						[
+							'**/specific.prompt.md',
+							'**/unspecific*.prompt.md',
+						],
+						[
+							'**/nested/specific.prompt.md',
+							'**/nested/unspecific*.prompt.md',
+						],
+						[
+							'**/nested/*specific*',
+						],
+						[
+							'**/*spec*.prompt.md',
+						],
+						[
+							'**/*spec*',
+						],
+						[
+							'**/*spec*.md',
+						],
+						[
+							'**/deps/**/*spec*.md',
+						],
+						[
+							'**/text/**/*spec*.md',
+						],
+						[
+							'deps/text/nested/*spec*',
+						],
+						[
+							'deps/text/nested/*specific*',
+						],
+						[
+							'deps/**/*specific*',
+						],
+						[
+							'deps/**/specific*',
+							'deps/**/unspecific*.prompt.md',
+						],
+						[
+							'deps/**/specific*.md',
+							'deps/**/unspecific*.md',
+						],
+						[
+							'deps/**/specific.prompt.md',
+							'deps/**/unspecific1.prompt.md',
+							'deps/**/unspecific2.prompt.md',
+						],
+						[
+							'deps/**/specific.prompt.md',
+							'deps/**/unspecific1*.md',
+							'deps/**/unspecific2*.md',
+						],
+						[
+							'deps/text/**/*specific*',
+						],
+						[
+							'deps/text/**/specific*',
+							'deps/text/**/unspecific*.prompt.md',
+						],
+						[
+							'deps/text/**/specific*.md',
+							'deps/text/**/unspecific*.md',
+						],
+						[
+							'deps/text/**/specific.prompt.md',
+							'deps/text/**/unspecific1.prompt.md',
+							'deps/text/**/unspecific2.prompt.md',
+						],
+						[
+							'deps/text/**/specific.prompt.md',
+							'deps/text/**/unspecific1*.md',
+							'deps/text/**/unspecific2*.md',
+						],
+					];
 
-						for (const setting of settings) {
-							test(`• '${setting}'`, async () => {
-								const locator = await createPromptsLocator(
-									{ [setting]: true },
-									['/Users/legomushroom/repos/vscode'],
-									[
-										{
-											name: '/Users/legomushroom/repos/vscode',
-											children: [
-												{
-													name: 'deps/text',
-													children: [
-														{
-															name: 'my.prompt.md',
-															contents: 'oh hi, bot!',
-														},
-														{
-															name: 'nested',
-															children: [
-																{
-																	name: 'specific.prompt.md',
-																	contents: 'oh hi, bot!',
-																},
-																{
-																	name: 'unspecific1.prompt.md',
-																	contents: 'oh hi, robot!',
-																},
-																{
-																	name: 'unspecific2.prompt.md',
-																	contents: 'oh hi, rabot!',
-																},
-																{
-																	name: 'readme.md',
-																	contents: 'non prompt file',
-																},
-															],
-														}
-													],
-												},
-											],
-										},
-									],
-								);
+					for (const settings of testSettings) {
+						test(`• '${JSON.stringify(settings)}'`, async () => {
+							const vscodeSettings: Record<string, boolean> = {};
+							for (const setting of settings) {
+								vscodeSettings[setting] = true;
+							}
 
-								assert.deepStrictEqual(
-									(await locator.findAllMatchingPromptFiles())
-										.map((file) => file.fsPath),
-									[
-										createURI('/Users/legomushroom/repos/vscode/deps/text/my.prompt.md').fsPath,
-										createURI('/Users/legomushroom/repos/vscode/deps/text/nested/specific.prompt.md').fsPath,
-										createURI('/Users/legomushroom/repos/vscode/deps/text/nested/unspecific1.prompt.md').fsPath,
-										createURI('/Users/legomushroom/repos/vscode/deps/text/nested/unspecific2.prompt.md').fsPath,
-									],
-									'Must find correct prompts.',
-								);
-							});
-						}
-					});
+							const locator = await createPromptsLocator(
+								vscodeSettings,
+								['/Users/legomushroom/repos/vscode'],
+								[
+									{
+										name: '/Users/legomushroom/repos/vscode',
+										children: [
+											{
+												name: 'deps/text',
+												children: [
+													{
+														name: 'my.prompt.md',
+														contents: 'oh hi, bot!',
+													},
+													{
+														name: 'nested',
+														children: [
+															{
+																name: 'default.prompt.md',
+																contents: 'oh hi, bot!',
+															},
+															{
+																name: 'specific.prompt.md',
+																contents: 'oh hi, bot!',
+															},
+															{
+																name: 'unspecific1.prompt.md',
+																contents: 'oh hi, robot!',
+															},
+															{
+																name: 'unspecific2.prompt.md',
+																contents: 'oh hi, rawbot!',
+															},
+															{
+																name: 'readme.md',
+																contents: 'non prompt file',
+															},
+														],
+													}
+												],
+											},
+										],
+									},
+								],
+							);
 
-					suite(`• specific`, () => {
-						const testSettings = [
-							[
-								'/Users/legomushroom/repos/vscode/**/*specific*',
-							],
-							[
-								'/Users/legomushroom/repos/vscode/**/*specific*.prompt.md',
-							],
-							[
-								'/Users/legomushroom/repos/vscode/**/*specific*.md',
-							],
-							[
-								'/Users/legomushroom/repos/vscode/**/specific*',
-								'/Users/legomushroom/repos/vscode/**/unspecific1.prompt.md',
-								'/Users/legomushroom/repos/vscode/**/unspecific2.prompt.md',
-							],
-							[
-								'/Users/legomushroom/repos/vscode/**/specific.prompt.md',
-								'/Users/legomushroom/repos/vscode/**/unspecific*.prompt.md',
-							],
-							[
-								'/Users/legomushroom/repos/vscode/**/nested/specific.prompt.md',
-								'/Users/legomushroom/repos/vscode/**/nested/unspecific*.prompt.md',
-							],
-							[
-								'/Users/legomushroom/repos/vscode/**/nested/*specific*',
-							],
-							[
-								'/Users/legomushroom/repos/vscode/**/*spec*.prompt.md',
-							],
-							[
-								'/Users/legomushroom/repos/vscode/**/*spec*',
-							],
-							[
-								'/Users/legomushroom/repos/vscode/**/*spec*.md',
-							],
-							[
-								'/Users/legomushroom/repos/vscode/**/deps/**/*spec*.md',
-							],
-							[
-								'/Users/legomushroom/repos/vscode/**/text/**/*spec*.md',
-							],
-							[
-								'/Users/legomushroom/repos/vscode/deps/text/nested/*spec*',
-							],
-							[
-								'/Users/legomushroom/repos/vscode/deps/text/nested/*specific*',
-							],
-							[
-								'/Users/legomushroom/repos/vscode/deps/**/*specific*',
-							],
-							[
-								'/Users/legomushroom/repos/vscode/deps/**/specific*',
-								'/Users/legomushroom/repos/vscode/deps/**/unspecific*.prompt.md',
-							],
-							[
-								'/Users/legomushroom/repos/vscode/deps/**/specific*.md',
-								'/Users/legomushroom/repos/vscode/deps/**/unspecific*.md',
-							],
-							[
-								'/Users/legomushroom/repos/vscode/deps/**/specific.prompt.md',
-								'/Users/legomushroom/repos/vscode/deps/**/unspecific1.prompt.md',
-								'/Users/legomushroom/repos/vscode/deps/**/unspecific2.prompt.md',
-							],
-							[
-								'/Users/legomushroom/repos/vscode/deps/**/specific.prompt.md',
-								'/Users/legomushroom/repos/vscode/deps/**/unspecific1*.md',
-								'/Users/legomushroom/repos/vscode/deps/**/unspecific2*.md',
-							],
-							[
-								'/Users/legomushroom/repos/vscode/deps/text/**/*specific*',
-							],
-							[
-								'/Users/legomushroom/repos/vscode/deps/text/**/specific*',
-								'/Users/legomushroom/repos/vscode/deps/text/**/unspecific*.prompt.md',
-							],
-							[
-								'/Users/legomushroom/repos/vscode/deps/text/**/specific*.md',
-								'/Users/legomushroom/repos/vscode/deps/text/**/unspecific*.md',
-							],
-							[
-								'/Users/legomushroom/repos/vscode/deps/text/**/specific.prompt.md',
-								'/Users/legomushroom/repos/vscode/deps/text/**/unspecific1.prompt.md',
-								'/Users/legomushroom/repos/vscode/deps/text/**/unspecific2.prompt.md',
-							],
-							[
-								'/Users/legomushroom/repos/vscode/deps/text/**/specific.prompt.md',
-								'/Users/legomushroom/repos/vscode/deps/text/**/unspecific1*.md',
-								'/Users/legomushroom/repos/vscode/deps/text/**/unspecific2*.md',
-							],
-						];
+							assert.deepStrictEqual(
+								(await locator.listFiles())
+									.map((file) => file.fsPath),
+								[
+									createURI('/Users/legomushroom/repos/vscode/deps/text/nested/specific.prompt.md').fsPath,
+									createURI('/Users/legomushroom/repos/vscode/deps/text/nested/unspecific1.prompt.md').fsPath,
+									createURI('/Users/legomushroom/repos/vscode/deps/text/nested/unspecific2.prompt.md').fsPath,
+								],
+								'Must find correct prompts.',
+							);
+						});
+					}
+				});
+			});
 
-						for (const settings of testSettings) {
-							test(`• '${JSON.stringify(settings)}'`, async () => {
-								const vscodeSettings: Record<string, boolean> = {};
-								for (const setting of settings) {
-									vscodeSettings[setting] = true;
-								}
+			suite('• absolute', () => {
+				suite('• wild card', () => {
+					const settings = [
+						'/Users/legomushroom/repos/vscode/**',
+						'/Users/legomushroom/repos/vscode/**/*.prompt.md',
+						'/Users/legomushroom/repos/vscode/**/*.md',
+						'/Users/legomushroom/repos/vscode/**/*',
+						'/Users/legomushroom/repos/vscode/deps/**',
+						'/Users/legomushroom/repos/vscode/deps/**/*.prompt.md',
+						'/Users/legomushroom/repos/vscode/deps/**/*',
+						'/Users/legomushroom/repos/vscode/deps/**/*.md',
+						'/Users/legomushroom/repos/vscode/**/text/**',
+						'/Users/legomushroom/repos/vscode/**/text/**/*',
+						'/Users/legomushroom/repos/vscode/**/text/**/*.md',
+						'/Users/legomushroom/repos/vscode/**/text/**/*.prompt.md',
+						'/Users/legomushroom/repos/vscode/deps/text/**',
+						'/Users/legomushroom/repos/vscode/deps/text/**/*',
+						'/Users/legomushroom/repos/vscode/deps/text/**/*.md',
+						'/Users/legomushroom/repos/vscode/deps/text/**/*.prompt.md',
+					];
 
-								const locator = await createPromptsLocator(
-									vscodeSettings,
-									['/Users/legomushroom/repos/vscode'],
-									[
-										{
-											name: '/Users/legomushroom/repos/vscode',
-											children: [
-												{
-													name: 'deps/text',
-													children: [
-														{
-															name: 'my.prompt.md',
-															contents: 'oh hi, bot!',
-														},
-														{
-															name: 'nested',
-															children: [
-																{
-																	name: 'default.prompt.md',
-																	contents: 'oh hi, bot!',
-																},
-																{
-																	name: 'specific.prompt.md',
-																	contents: 'oh hi, bot!',
-																},
-																{
-																	name: 'unspecific1.prompt.md',
-																	contents: 'oh hi, robot!',
-																},
-																{
-																	name: 'unspecific2.prompt.md',
-																	contents: 'oh hi, rawbot!',
-																},
-																{
-																	name: 'readme.md',
-																	contents: 'non prompt file',
-																},
-															],
-														}
-													],
-												},
-											],
-										},
-									],
-								);
+					for (const setting of settings) {
+						test(`• '${setting}'`, async () => {
+							const locator = await createPromptsLocator(
+								{ [setting]: true },
+								['/Users/legomushroom/repos/vscode'],
+								[
+									{
+										name: '/Users/legomushroom/repos/vscode',
+										children: [
+											{
+												name: 'deps/text',
+												children: [
+													{
+														name: 'my.prompt.md',
+														contents: 'oh hi, bot!',
+													},
+													{
+														name: 'nested',
+														children: [
+															{
+																name: 'specific.prompt.md',
+																contents: 'oh hi, bot!',
+															},
+															{
+																name: 'unspecific1.prompt.md',
+																contents: 'oh hi, robot!',
+															},
+															{
+																name: 'unspecific2.prompt.md',
+																contents: 'oh hi, rabot!',
+															},
+															{
+																name: 'readme.md',
+																contents: 'non prompt file',
+															},
+														],
+													}
+												],
+											},
+										],
+									},
+								],
+							);
 
-								assert.deepStrictEqual(
-									(await locator.findAllMatchingPromptFiles())
-										.map((file) => file.fsPath),
-									[
-										createURI('/Users/legomushroom/repos/vscode/deps/text/nested/specific.prompt.md').fsPath,
-										createURI('/Users/legomushroom/repos/vscode/deps/text/nested/unspecific1.prompt.md').fsPath,
-										createURI('/Users/legomushroom/repos/vscode/deps/text/nested/unspecific2.prompt.md').fsPath,
-									],
-									'Must find correct prompts.',
-								);
-							});
-						}
-					});
+							assert.deepStrictEqual(
+								(await locator.listFiles())
+									.map((file) => file.fsPath),
+								[
+									createURI('/Users/legomushroom/repos/vscode/deps/text/my.prompt.md').fsPath,
+									createURI('/Users/legomushroom/repos/vscode/deps/text/nested/specific.prompt.md').fsPath,
+									createURI('/Users/legomushroom/repos/vscode/deps/text/nested/unspecific1.prompt.md').fsPath,
+									createURI('/Users/legomushroom/repos/vscode/deps/text/nested/unspecific2.prompt.md').fsPath,
+								],
+								'Must find correct prompts.',
+							);
+						});
+					}
+				});
+
+				suite(`• specific`, () => {
+					const testSettings = [
+						[
+							'/Users/legomushroom/repos/vscode/**/*specific*',
+						],
+						[
+							'/Users/legomushroom/repos/vscode/**/*specific*.prompt.md',
+						],
+						[
+							'/Users/legomushroom/repos/vscode/**/*specific*.md',
+						],
+						[
+							'/Users/legomushroom/repos/vscode/**/specific*',
+							'/Users/legomushroom/repos/vscode/**/unspecific1.prompt.md',
+							'/Users/legomushroom/repos/vscode/**/unspecific2.prompt.md',
+						],
+						[
+							'/Users/legomushroom/repos/vscode/**/specific.prompt.md',
+							'/Users/legomushroom/repos/vscode/**/unspecific*.prompt.md',
+						],
+						[
+							'/Users/legomushroom/repos/vscode/**/nested/specific.prompt.md',
+							'/Users/legomushroom/repos/vscode/**/nested/unspecific*.prompt.md',
+						],
+						[
+							'/Users/legomushroom/repos/vscode/**/nested/*specific*',
+						],
+						[
+							'/Users/legomushroom/repos/vscode/**/*spec*.prompt.md',
+						],
+						[
+							'/Users/legomushroom/repos/vscode/**/*spec*',
+						],
+						[
+							'/Users/legomushroom/repos/vscode/**/*spec*.md',
+						],
+						[
+							'/Users/legomushroom/repos/vscode/**/deps/**/*spec*.md',
+						],
+						[
+							'/Users/legomushroom/repos/vscode/**/text/**/*spec*.md',
+						],
+						[
+							'/Users/legomushroom/repos/vscode/deps/text/nested/*spec*',
+						],
+						[
+							'/Users/legomushroom/repos/vscode/deps/text/nested/*specific*',
+						],
+						[
+							'/Users/legomushroom/repos/vscode/deps/**/*specific*',
+						],
+						[
+							'/Users/legomushroom/repos/vscode/deps/**/specific*',
+							'/Users/legomushroom/repos/vscode/deps/**/unspecific*.prompt.md',
+						],
+						[
+							'/Users/legomushroom/repos/vscode/deps/**/specific*.md',
+							'/Users/legomushroom/repos/vscode/deps/**/unspecific*.md',
+						],
+						[
+							'/Users/legomushroom/repos/vscode/deps/**/specific.prompt.md',
+							'/Users/legomushroom/repos/vscode/deps/**/unspecific1.prompt.md',
+							'/Users/legomushroom/repos/vscode/deps/**/unspecific2.prompt.md',
+						],
+						[
+							'/Users/legomushroom/repos/vscode/deps/**/specific.prompt.md',
+							'/Users/legomushroom/repos/vscode/deps/**/unspecific1*.md',
+							'/Users/legomushroom/repos/vscode/deps/**/unspecific2*.md',
+						],
+						[
+							'/Users/legomushroom/repos/vscode/deps/text/**/*specific*',
+						],
+						[
+							'/Users/legomushroom/repos/vscode/deps/text/**/specific*',
+							'/Users/legomushroom/repos/vscode/deps/text/**/unspecific*.prompt.md',
+						],
+						[
+							'/Users/legomushroom/repos/vscode/deps/text/**/specific*.md',
+							'/Users/legomushroom/repos/vscode/deps/text/**/unspecific*.md',
+						],
+						[
+							'/Users/legomushroom/repos/vscode/deps/text/**/specific.prompt.md',
+							'/Users/legomushroom/repos/vscode/deps/text/**/unspecific1.prompt.md',
+							'/Users/legomushroom/repos/vscode/deps/text/**/unspecific2.prompt.md',
+						],
+						[
+							'/Users/legomushroom/repos/vscode/deps/text/**/specific.prompt.md',
+							'/Users/legomushroom/repos/vscode/deps/text/**/unspecific1*.md',
+							'/Users/legomushroom/repos/vscode/deps/text/**/unspecific2*.md',
+						],
+					];
+
+					for (const settings of testSettings) {
+						test(`• '${JSON.stringify(settings)}'`, async () => {
+							const vscodeSettings: Record<string, boolean> = {};
+							for (const setting of settings) {
+								vscodeSettings[setting] = true;
+							}
+
+							const locator = await createPromptsLocator(
+								vscodeSettings,
+								['/Users/legomushroom/repos/vscode'],
+								[
+									{
+										name: '/Users/legomushroom/repos/vscode',
+										children: [
+											{
+												name: 'deps/text',
+												children: [
+													{
+														name: 'my.prompt.md',
+														contents: 'oh hi, bot!',
+													},
+													{
+														name: 'nested',
+														children: [
+															{
+																name: 'default.prompt.md',
+																contents: 'oh hi, bot!',
+															},
+															{
+																name: 'specific.prompt.md',
+																contents: 'oh hi, bot!',
+															},
+															{
+																name: 'unspecific1.prompt.md',
+																contents: 'oh hi, robot!',
+															},
+															{
+																name: 'unspecific2.prompt.md',
+																contents: 'oh hi, rawbot!',
+															},
+															{
+																name: 'readme.md',
+																contents: 'non prompt file',
+															},
+														],
+													}
+												],
+											},
+										],
+									},
+								],
+							);
+
+							assert.deepStrictEqual(
+								(await locator.listFiles())
+									.map((file) => file.fsPath),
+								[
+									createURI('/Users/legomushroom/repos/vscode/deps/text/nested/specific.prompt.md').fsPath,
+									createURI('/Users/legomushroom/repos/vscode/deps/text/nested/unspecific1.prompt.md').fsPath,
+									createURI('/Users/legomushroom/repos/vscode/deps/text/nested/unspecific2.prompt.md').fsPath,
+								],
+								'Must find correct prompts.',
+							);
+						});
+					}
 				});
 			});
 		});
+	});
 
-		test('• core logic', async () => {
-			const locator = await createPromptsLocator(
+	test('• core logic', async () => {
+		const locator = await createPromptsLocator(
+			{
+				'/Users/legomushroom/repos/prompts': true,
+				'/tmp/prompts/': true,
+				'/absolute/path/prompts': false,
+				'.copilot/prompts': true,
+			},
+			[
+				'/Users/legomushroom/repos/vscode',
+			],
+			[
 				{
-					'/Users/legomushroom/repos/prompts': true,
-					'/tmp/prompts/': true,
-					'/absolute/path/prompts': false,
-					'.copilot/prompts': true,
+					name: '/Users/legomushroom/repos/prompts',
+					children: [
+						{
+							name: 'test.prompt.md',
+							contents: 'Hello, World!',
+						},
+						{
+							name: 'refactor-tests.prompt.md',
+							contents: 'some file content goes here',
+						},
+					],
 				},
-				[
-					'/Users/legomushroom/repos/vscode',
-				],
-				[
-					{
-						name: '/Users/legomushroom/repos/prompts',
-						children: [
-							{
-								name: 'test.prompt.md',
-								contents: 'Hello, World!',
-							},
-							{
-								name: 'refactor-tests.prompt.md',
-								contents: 'some file content goes here',
-							},
-						],
-					},
-					{
-						name: '/tmp/prompts',
-						children: [
-							{
-								name: 'translate.to-rust.prompt.md',
-								contents: 'some more random file contents',
-							},
-						],
-					},
-					{
-						name: '/absolute/path/prompts',
-						children: [
-							{
-								name: 'some-prompt-file.prompt.md',
-								contents: 'hey hey hey',
-							},
-						],
-					},
-					{
-						name: '/Users/legomushroom/repos/vscode',
-						children: [
-							{
-								name: '.copilot/prompts',
-								children: [
-									{
-										name: 'default.prompt.md',
-										contents: 'oh hi, robot!',
-									},
-								],
-							},
-							{
-								name: '.github/prompts',
-								children: [
-									{
-										name: 'my.prompt.md',
-										contents: 'oh hi, bot!',
-									},
-								],
-							},
-						],
-					},
-				]);
-
-			assert.deepStrictEqual(
-				await locator.listFiles(),
-				[
-					createURI('/Users/legomushroom/repos/vscode/.github/prompts/my.prompt.md'),
-					createURI('/Users/legomushroom/repos/prompts/test.prompt.md'),
-					createURI('/Users/legomushroom/repos/prompts/refactor-tests.prompt.md'),
-					createURI('/tmp/prompts/translate.to-rust.prompt.md'),
-					createURI('/Users/legomushroom/repos/vscode/.copilot/prompts/default.prompt.md'),
-				],
-				'Must find correct prompts.',
-			);
-		});
-
-		test('• with disabled `.github/prompts` location', async () => {
-			const locator = await createPromptsLocator(
 				{
-					'/Users/legomushroom/repos/prompts': true,
-					'/tmp/prompts/': true,
-					'/absolute/path/prompts': false,
-					'.copilot/prompts': true,
-					'.github/prompts': false,
+					name: '/tmp/prompts',
+					children: [
+						{
+							name: 'translate.to-rust.prompt.md',
+							contents: 'some more random file contents',
+						},
+					],
 				},
-				[
-					'/Users/legomushroom/repos/vscode',
-				],
-				[
-					{
-						name: '/Users/legomushroom/repos/prompts',
-						children: [
-							{
-								name: 'test.prompt.md',
-								contents: 'Hello, World!',
-							},
-							{
-								name: 'refactor-tests.prompt.md',
-								contents: 'some file content goes here',
-							},
-						],
-					},
-					{
-						name: '/tmp/prompts',
-						children: [
-							{
-								name: 'translate.to-rust.prompt.md',
-								contents: 'some more random file contents',
-							},
-						],
-					},
-					{
-						name: '/absolute/path/prompts',
-						children: [
-							{
-								name: 'some-prompt-file.prompt.md',
-								contents: 'hey hey hey',
-							},
-						],
-					},
-					{
-						name: '/Users/legomushroom/repos/vscode',
-						children: [
-							{
-								name: '.copilot/prompts',
-								children: [
-									{
-										name: 'default.prompt.md',
-										contents: 'oh hi, robot!',
-									},
-								],
-							},
-							{
-								name: '.github/prompts',
-								children: [
-									{
-										name: 'my.prompt.md',
-										contents: 'oh hi, bot!',
-									},
-									{
-										name: 'your.prompt.md',
-										contents: 'oh hi, bot!',
-									},
-								],
-							},
-						],
-					},
-				]);
+				{
+					name: '/absolute/path/prompts',
+					children: [
+						{
+							name: 'some-prompt-file.prompt.md',
+							contents: 'hey hey hey',
+						},
+					],
+				},
+				{
+					name: '/Users/legomushroom/repos/vscode',
+					children: [
+						{
+							name: '.copilot/prompts',
+							children: [
+								{
+									name: 'default.prompt.md',
+									contents: 'oh hi, robot!',
+								},
+							],
+						},
+						{
+							name: '.github/prompts',
+							children: [
+								{
+									name: 'my.prompt.md',
+									contents: 'oh hi, bot!',
+								},
+							],
+						},
+					],
+				},
+			]);
 
-			assert.deepStrictEqual(
-				await locator.listFiles(),
-				[
-					createURI('/Users/legomushroom/repos/prompts/test.prompt.md'),
-					createURI('/Users/legomushroom/repos/prompts/refactor-tests.prompt.md'),
-					createURI('/tmp/prompts/translate.to-rust.prompt.md'),
-					createURI('/Users/legomushroom/repos/vscode/.copilot/prompts/default.prompt.md'),
-				],
-				'Must find correct prompts.',
-			);
-		});
+		assert.deepStrictEqual(
+			(await locator.listFiles())
+				.map((file) => file.fsPath),
+			[
+				createURI('/Users/legomushroom/repos/vscode/.github/prompts/my.prompt.md').fsPath,
+				createURI('/Users/legomushroom/repos/prompts/test.prompt.md').fsPath,
+				createURI('/Users/legomushroom/repos/prompts/refactor-tests.prompt.md').fsPath,
+				createURI('/tmp/prompts/translate.to-rust.prompt.md').fsPath,
+				createURI('/Users/legomushroom/repos/vscode/.copilot/prompts/default.prompt.md').fsPath,
+			],
+			'Must find correct prompts.',
+		);
+	});
+
+	test('• with disabled `.github/prompts` location', async () => {
+		const locator = await createPromptsLocator(
+			{
+				'/Users/legomushroom/repos/prompts': true,
+				'/tmp/prompts/': true,
+				'/absolute/path/prompts': false,
+				'.copilot/prompts': true,
+				'.github/prompts': false,
+			},
+			[
+				'/Users/legomushroom/repos/vscode',
+			],
+			[
+				{
+					name: '/Users/legomushroom/repos/prompts',
+					children: [
+						{
+							name: 'test.prompt.md',
+							contents: 'Hello, World!',
+						},
+						{
+							name: 'refactor-tests.prompt.md',
+							contents: 'some file content goes here',
+						},
+					],
+				},
+				{
+					name: '/tmp/prompts',
+					children: [
+						{
+							name: 'translate.to-rust.prompt.md',
+							contents: 'some more random file contents',
+						},
+					],
+				},
+				{
+					name: '/absolute/path/prompts',
+					children: [
+						{
+							name: 'some-prompt-file.prompt.md',
+							contents: 'hey hey hey',
+						},
+					],
+				},
+				{
+					name: '/Users/legomushroom/repos/vscode',
+					children: [
+						{
+							name: '.copilot/prompts',
+							children: [
+								{
+									name: 'default.prompt.md',
+									contents: 'oh hi, robot!',
+								},
+							],
+						},
+						{
+							name: '.github/prompts',
+							children: [
+								{
+									name: 'my.prompt.md',
+									contents: 'oh hi, bot!',
+								},
+								{
+									name: 'your.prompt.md',
+									contents: 'oh hi, bot!',
+								},
+							],
+						},
+					],
+				},
+			]);
+
+		assert.deepStrictEqual(
+			(await locator.listFiles())
+				.map((file) => file.fsPath),
+			[
+				createURI('/Users/legomushroom/repos/prompts/test.prompt.md').path,
+				createURI('/Users/legomushroom/repos/prompts/refactor-tests.prompt.md').path,
+				createURI('/tmp/prompts/translate.to-rust.prompt.md').path,
+				createURI('/Users/legomushroom/repos/vscode/.copilot/prompts/default.prompt.md').path,
+			],
+			'Must find correct prompts.',
+		);
 	});
 
 	suite('• multi-root workspace', () => {
@@ -980,13 +990,14 @@ suite('PromptFilesLocator', () => {
 					]);
 
 				assert.deepStrictEqual(
-					await locator.listFiles(),
+					(await locator.listFiles())
+						.map((file) => file.fsPath),
 					[
-						createURI('/Users/legomushroom/repos/vscode/.github/prompts/default.prompt.md'),
-						createURI('/Users/legomushroom/repos/node/.github/prompts/refactor-static-classes.prompt.md'),
-						createURI('/Users/legomushroom/repos/prompts/test.prompt.md'),
-						createURI('/Users/legomushroom/repos/prompts/refactor-tests.prompt.md'),
-						createURI('/tmp/prompts/translate.to-rust.prompt.md'),
+						createURI('/Users/legomushroom/repos/vscode/.github/prompts/default.prompt.md').path,
+						createURI('/Users/legomushroom/repos/node/.github/prompts/refactor-static-classes.prompt.md').path,
+						createURI('/Users/legomushroom/repos/prompts/test.prompt.md').path,
+						createURI('/Users/legomushroom/repos/prompts/refactor-tests.prompt.md').path,
+						createURI('/tmp/prompts/translate.to-rust.prompt.md').path,
 					],
 					'Must find correct prompts.',
 				);
@@ -1100,15 +1111,16 @@ suite('PromptFilesLocator', () => {
 					]);
 
 				assert.deepStrictEqual(
-					await locator.listFiles(),
+					(await locator.listFiles())
+						.map((file) => file.fsPath),
 					[
-						createURI('/Users/legomushroom/repos/vscode/.github/prompts/default.prompt.md'),
-						createURI('/Users/legomushroom/repos/node/.github/prompts/refactor-static-classes.prompt.md'),
-						createURI('/var/shared/prompts/.github/prompts/prompt-name.prompt.md'),
-						createURI('/var/shared/prompts/.github/prompts/name-of-the-prompt.prompt.md'),
-						createURI('/Users/legomushroom/repos/prompts/test.prompt.md'),
-						createURI('/Users/legomushroom/repos/prompts/refactor-tests.prompt.md'),
-						createURI('/tmp/prompts/translate.to-rust.prompt.md'),
+						createURI('/Users/legomushroom/repos/vscode/.github/prompts/default.prompt.md').fsPath,
+						createURI('/Users/legomushroom/repos/node/.github/prompts/refactor-static-classes.prompt.md').fsPath,
+						createURI('/var/shared/prompts/.github/prompts/prompt-name.prompt.md').fsPath,
+						createURI('/var/shared/prompts/.github/prompts/name-of-the-prompt.prompt.md').fsPath,
+						createURI('/Users/legomushroom/repos/prompts/test.prompt.md').fsPath,
+						createURI('/Users/legomushroom/repos/prompts/refactor-tests.prompt.md').fsPath,
+						createURI('/tmp/prompts/translate.to-rust.prompt.md').fsPath,
 					],
 					'Must find correct prompts.',
 				);
@@ -1223,697 +1235,696 @@ suite('PromptFilesLocator', () => {
 					]);
 
 				assert.deepStrictEqual(
-					await locator.listFiles(),
+					(await locator.listFiles())
+						.map((file) => file.fsPath),
 					[
-						createURI('/Users/legomushroom/repos/prompts/test.prompt.md'),
-						createURI('/Users/legomushroom/repos/prompts/refactor-tests.prompt.md'),
-						createURI('/tmp/prompts/translate.to-rust.prompt.md'),
+						createURI('/Users/legomushroom/repos/prompts/test.prompt.md').path,
+						createURI('/Users/legomushroom/repos/prompts/refactor-tests.prompt.md').path,
+						createURI('/tmp/prompts/translate.to-rust.prompt.md').path,
 					],
 					'Must find correct prompts.',
 				);
 			});
 		});
 
-		suite('• findAllMatchingPromptFiles', () => {
-			suite('• glob pattern', () => {
-				suite('• relative', () => {
-					suite('• wild card', () => {
-						const testSettings = [
-							'**',
-							'**/*.prompt.md',
-							'**/*.md',
-							'**/*',
-							'gen*/**',
-							'gen*/**/*.prompt.md',
-							'gen*/**/*',
-							'gen*/**/*.md',
-							'**/gen*/**',
-							'**/gen*/**/*',
-							'**/gen*/**/*.md',
-							'**/gen*/**/*.prompt.md',
-							'{generic,general,gen}/**',
-							'{generic,general,gen}/**/*.prompt.md',
-							'{generic,general,gen}/**/*',
-							'{generic,general,gen}/**/*.md',
-							'**/{generic,general,gen}/**',
-							'**/{generic,general,gen}/**/*',
-							'**/{generic,general,gen}/**/*.md',
-							'**/{generic,general,gen}/**/*.prompt.md',
-						];
+		suite('• glob pattern', () => {
+			suite('• relative', () => {
+				suite('• wild card', () => {
+					const testSettings = [
+						'**',
+						'**/*.prompt.md',
+						'**/*.md',
+						'**/*',
+						'gen*/**',
+						'gen*/**/*.prompt.md',
+						'gen*/**/*',
+						'gen*/**/*.md',
+						'**/gen*/**',
+						'**/gen*/**/*',
+						'**/gen*/**/*.md',
+						'**/gen*/**/*.prompt.md',
+						'{generic,general,gen}/**',
+						'{generic,general,gen}/**/*.prompt.md',
+						'{generic,general,gen}/**/*',
+						'{generic,general,gen}/**/*.md',
+						'**/{generic,general,gen}/**',
+						'**/{generic,general,gen}/**/*',
+						'**/{generic,general,gen}/**/*.md',
+						'**/{generic,general,gen}/**/*.prompt.md',
+					];
 
-						for (const setting of testSettings) {
-							test(`• '${setting}'`, async () => {
-								const locator = await createPromptsLocator(
-									{ [setting]: true },
-									[
-										'/Users/legomushroom/repos/vscode',
-										'/Users/legomushroom/repos/prompts',
-									],
-									[
-										{
-											name: '/Users/legomushroom/repos/vscode',
-											children: [
-												{
-													name: 'gen/text',
-													children: [
-														{
-															name: 'my.prompt.md',
-															contents: 'oh hi, bot!',
-														},
-														{
-															name: 'nested',
-															children: [
-																{
-																	name: 'specific.prompt.md',
-																	contents: 'oh hi, bot!',
-																},
-																{
-																	name: 'unspecific1.prompt.md',
-																	contents: 'oh hi, robot!',
-																},
-																{
-																	name: 'unspecific2.prompt.md',
-																	contents: 'oh hi, rabot!',
-																},
-																{
-																	name: 'readme.md',
-																	contents: 'non prompt file',
-																},
-															],
-														}
-													],
-												},
-											],
-										},
-										{
-											name: '/Users/legomushroom/repos/prompts',
-											children: [
-												{
-													name: 'general',
-													children: [
-														{
-															name: 'common.prompt.md',
-															contents: 'oh hi, bot!',
-														},
-														{
-															name: 'uncommon-10.prompt.md',
-															contents: 'oh hi, robot!',
-														},
-														{
-															name: 'license.md',
-															contents: 'non prompt file',
-														},
-													],
-												}
-											],
-										},
-									],
-								);
+					for (const setting of testSettings) {
+						test(`• '${setting}'`, async () => {
+							const locator = await createPromptsLocator(
+								{ [setting]: true },
+								[
+									'/Users/legomushroom/repos/vscode',
+									'/Users/legomushroom/repos/prompts',
+								],
+								[
+									{
+										name: '/Users/legomushroom/repos/vscode',
+										children: [
+											{
+												name: 'gen/text',
+												children: [
+													{
+														name: 'my.prompt.md',
+														contents: 'oh hi, bot!',
+													},
+													{
+														name: 'nested',
+														children: [
+															{
+																name: 'specific.prompt.md',
+																contents: 'oh hi, bot!',
+															},
+															{
+																name: 'unspecific1.prompt.md',
+																contents: 'oh hi, robot!',
+															},
+															{
+																name: 'unspecific2.prompt.md',
+																contents: 'oh hi, rabot!',
+															},
+															{
+																name: 'readme.md',
+																contents: 'non prompt file',
+															},
+														],
+													}
+												],
+											},
+										],
+									},
+									{
+										name: '/Users/legomushroom/repos/prompts',
+										children: [
+											{
+												name: 'general',
+												children: [
+													{
+														name: 'common.prompt.md',
+														contents: 'oh hi, bot!',
+													},
+													{
+														name: 'uncommon-10.prompt.md',
+														contents: 'oh hi, robot!',
+													},
+													{
+														name: 'license.md',
+														contents: 'non prompt file',
+													},
+												],
+											}
+										],
+									},
+								],
+							);
 
-								assert.deepStrictEqual(
-									(await locator.findAllMatchingPromptFiles())
-										.map((file) => file.fsPath),
-									[
-										createURI('/Users/legomushroom/repos/vscode/gen/text/my.prompt.md').fsPath,
-										createURI('/Users/legomushroom/repos/vscode/gen/text/nested/specific.prompt.md').fsPath,
-										createURI('/Users/legomushroom/repos/vscode/gen/text/nested/unspecific1.prompt.md').fsPath,
-										createURI('/Users/legomushroom/repos/vscode/gen/text/nested/unspecific2.prompt.md').fsPath,
-										// -
-										createURI('/Users/legomushroom/repos/prompts/general/common.prompt.md').fsPath,
-										createURI('/Users/legomushroom/repos/prompts/general/uncommon-10.prompt.md').fsPath,
-									],
-									'Must find correct prompts.',
-								);
-							});
-						}
-					});
-
-					suite(`• specific`, () => {
-						const testSettings = [
-							[
-								'**/my.prompt.md',
-								'**/*specific*',
-								'**/*common*',
-							],
-							[
-								'**/my.prompt.md',
-								'**/*specific*.prompt.md',
-								'**/*common*.prompt.md',
-							],
-							[
-								'**/my*.md',
-								'**/*specific*.md',
-								'**/*common*.md',
-							],
-							[
-								'**/my*.md',
-								'**/specific*',
-								'**/unspecific*',
-								'**/common*',
-								'**/uncommon*',
-							],
-							[
-								'**/my.prompt.md',
-								'**/specific.prompt.md',
-								'**/unspecific1.prompt.md',
-								'**/unspecific2.prompt.md',
-								'**/common.prompt.md',
-								'**/uncommon-10.prompt.md',
-							],
-							[
-								'gen*/**/my.prompt.md',
-								'gen*/**/*specific*',
-								'gen*/**/*common*',
-							],
-							[
-								'gen*/**/my.prompt.md',
-								'gen*/**/*specific*.prompt.md',
-								'gen*/**/*common*.prompt.md',
-							],
-							[
-								'gen*/**/my*.md',
-								'gen*/**/*specific*.md',
-								'gen*/**/*common*.md',
-							],
-							[
-								'gen*/**/my*.md',
-								'gen*/**/specific*',
-								'gen*/**/unspecific*',
-								'gen*/**/common*',
-								'gen*/**/uncommon*',
-							],
-							[
-								'gen*/**/my.prompt.md',
-								'gen*/**/specific.prompt.md',
-								'gen*/**/unspecific1.prompt.md',
-								'gen*/**/unspecific2.prompt.md',
-								'gen*/**/common.prompt.md',
-								'gen*/**/uncommon-10.prompt.md',
-							],
-							[
-								'gen/text/my.prompt.md',
-								'gen/text/nested/specific.prompt.md',
-								'gen/text/nested/unspecific1.prompt.md',
-								'gen/text/nested/unspecific2.prompt.md',
-								'general/common.prompt.md',
-								'general/uncommon-10.prompt.md',
-							],
-							[
-								'gen/text/my.prompt.md',
-								'gen/text/nested/*specific*',
-								'general/*common*',
-							],
-							[
-								'gen/text/my.prompt.md',
-								'gen/text/**/specific.prompt.md',
-								'gen/text/**/unspecific1.prompt.md',
-								'gen/text/**/unspecific2.prompt.md',
-								'general/*',
-							],
-							[
-								'{gen,general}/**/my.prompt.md',
-								'{gen,general}/**/*specific*',
-								'{gen,general}/**/*common*',
-							],
-							[
-								'{gen,general}/**/my.prompt.md',
-								'{gen,general}/**/*specific*.prompt.md',
-								'{gen,general}/**/*common*.prompt.md',
-							],
-							[
-								'{gen,general}/**/my*.md',
-								'{gen,general}/**/*specific*.md',
-								'{gen,general}/**/*common*.md',
-							],
-							[
-								'{gen,general}/**/my*.md',
-								'{gen,general}/**/specific*',
-								'{gen,general}/**/unspecific*',
-								'{gen,general}/**/common*',
-								'{gen,general}/**/uncommon*',
-							],
-							[
-								'{gen,general}/**/my.prompt.md',
-								'{gen,general}/**/specific.prompt.md',
-								'{gen,general}/**/unspecific1.prompt.md',
-								'{gen,general}/**/unspecific2.prompt.md',
-								'{gen,general}/**/common.prompt.md',
-								'{gen,general}/**/uncommon-10.prompt.md',
-							],
-						];
-
-						for (const settings of testSettings) {
-							test(`• '${JSON.stringify(settings)}'`, async () => {
-								const vscodeSettings: Record<string, boolean> = {};
-								for (const setting of settings) {
-									vscodeSettings[setting] = true;
-								}
-
-								const locator = await createPromptsLocator(
-									vscodeSettings,
-									[
-										'/Users/legomushroom/repos/vscode',
-										'/Users/legomushroom/repos/prompts',
-									],
-									[
-										{
-											name: '/Users/legomushroom/repos/vscode',
-											children: [
-												{
-													name: 'gen/text',
-													children: [
-														{
-															name: 'my.prompt.md',
-															contents: 'oh hi, bot!',
-														},
-														{
-															name: 'nested',
-															children: [
-																{
-																	name: 'specific.prompt.md',
-																	contents: 'oh hi, bot!',
-																},
-																{
-																	name: 'unspecific1.prompt.md',
-																	contents: 'oh hi, robot!',
-																},
-																{
-																	name: 'unspecific2.prompt.md',
-																	contents: 'oh hi, rabot!',
-																},
-																{
-																	name: 'readme.md',
-																	contents: 'non prompt file',
-																},
-															],
-														}
-													],
-												},
-											],
-										},
-										{
-											name: '/Users/legomushroom/repos/prompts',
-											children: [
-												{
-													name: 'general',
-													children: [
-														{
-															name: 'common.prompt.md',
-															contents: 'oh hi, bot!',
-														},
-														{
-															name: 'uncommon-10.prompt.md',
-															contents: 'oh hi, robot!',
-														},
-														{
-															name: 'license.md',
-															contents: 'non prompt file',
-														},
-													],
-												}
-											],
-										},
-									],
-								);
-
-								assert.deepStrictEqual(
-									(await locator.findAllMatchingPromptFiles())
-										.map((file) => file.fsPath),
-									[
-										createURI('/Users/legomushroom/repos/vscode/gen/text/my.prompt.md').fsPath,
-										createURI('/Users/legomushroom/repos/vscode/gen/text/nested/specific.prompt.md').fsPath,
-										createURI('/Users/legomushroom/repos/vscode/gen/text/nested/unspecific1.prompt.md').fsPath,
-										createURI('/Users/legomushroom/repos/vscode/gen/text/nested/unspecific2.prompt.md').fsPath,
-										// -
-										createURI('/Users/legomushroom/repos/prompts/general/common.prompt.md').fsPath,
-										createURI('/Users/legomushroom/repos/prompts/general/uncommon-10.prompt.md').fsPath,
-									],
-									'Must find correct prompts.',
-								);
-							});
-						}
-					});
+							assert.deepStrictEqual(
+								(await locator.listFiles())
+									.map((file) => file.fsPath),
+								[
+									createURI('/Users/legomushroom/repos/vscode/gen/text/my.prompt.md').fsPath,
+									createURI('/Users/legomushroom/repos/vscode/gen/text/nested/specific.prompt.md').fsPath,
+									createURI('/Users/legomushroom/repos/vscode/gen/text/nested/unspecific1.prompt.md').fsPath,
+									createURI('/Users/legomushroom/repos/vscode/gen/text/nested/unspecific2.prompt.md').fsPath,
+									// -
+									createURI('/Users/legomushroom/repos/prompts/general/common.prompt.md').fsPath,
+									createURI('/Users/legomushroom/repos/prompts/general/uncommon-10.prompt.md').fsPath,
+								],
+								'Must find correct prompts.',
+							);
+						});
+					}
 				});
 
-				suite('• absolute', () => {
-					suite('• wild card', () => {
-						const testSettings = [
-							'/Users/legomushroom/repos/**',
-							'/Users/legomushroom/repos/**/*.prompt.md',
-							'/Users/legomushroom/repos/**/*.md',
-							'/Users/legomushroom/repos/**/*',
-							'/Users/legomushroom/repos/**/gen*/**',
-							'/Users/legomushroom/repos/**/gen*/**/*.prompt.md',
-							'/Users/legomushroom/repos/**/gen*/**/*',
-							'/Users/legomushroom/repos/**/gen*/**/*.md',
-							'/Users/legomushroom/repos/**/gen*/**',
-							'/Users/legomushroom/repos/**/gen*/**/*',
-							'/Users/legomushroom/repos/**/gen*/**/*.md',
-							'/Users/legomushroom/repos/**/gen*/**/*.prompt.md',
-							'/Users/legomushroom/repos/{vscode,prompts}/**',
-							'/Users/legomushroom/repos/{vscode,prompts}/**/*.prompt.md',
-							'/Users/legomushroom/repos/{vscode,prompts}/**/*.md',
-							'/Users/legomushroom/repos/{vscode,prompts}/**/*',
-							'/Users/legomushroom/repos/{vscode,prompts}/**/gen*/**',
-							'/Users/legomushroom/repos/{vscode,prompts}/**/gen*/**/*.prompt.md',
-							'/Users/legomushroom/repos/{vscode,prompts}/**/gen*/**/*',
-							'/Users/legomushroom/repos/{vscode,prompts}/**/gen*/**/*.md',
-							'/Users/legomushroom/repos/{vscode,prompts}/**/gen*/**',
-							'/Users/legomushroom/repos/{vscode,prompts}/**/gen*/**/*',
-							'/Users/legomushroom/repos/{vscode,prompts}/**/gen*/**/*.md',
-							'/Users/legomushroom/repos/{vscode,prompts}/**/gen*/**/*.prompt.md',
-							'/Users/legomushroom/repos/{vscode,prompts}/**/{general,gen}/**',
-							'/Users/legomushroom/repos/{vscode,prompts}/**/{general,gen}/**/*.prompt.md',
-							'/Users/legomushroom/repos/{vscode,prompts}/**/{general,gen}/**/*',
-							'/Users/legomushroom/repos/{vscode,prompts}/**/{general,gen}/**/*.md',
-							'/Users/legomushroom/repos/{vscode,prompts}/**/{general,gen}/**',
-							'/Users/legomushroom/repos/{vscode,prompts}/**/{general,gen}/**/*',
-							'/Users/legomushroom/repos/{vscode,prompts}/**/{general,gen}/**/*.md',
-							'/Users/legomushroom/repos/{vscode,prompts}/**/{general,gen}/**/*.prompt.md',
-						];
+				suite(`• specific`, () => {
+					const testSettings = [
+						[
+							'**/my.prompt.md',
+							'**/*specific*',
+							'**/*common*',
+						],
+						[
+							'**/my.prompt.md',
+							'**/*specific*.prompt.md',
+							'**/*common*.prompt.md',
+						],
+						[
+							'**/my*.md',
+							'**/*specific*.md',
+							'**/*common*.md',
+						],
+						[
+							'**/my*.md',
+							'**/specific*',
+							'**/unspecific*',
+							'**/common*',
+							'**/uncommon*',
+						],
+						[
+							'**/my.prompt.md',
+							'**/specific.prompt.md',
+							'**/unspecific1.prompt.md',
+							'**/unspecific2.prompt.md',
+							'**/common.prompt.md',
+							'**/uncommon-10.prompt.md',
+						],
+						[
+							'gen*/**/my.prompt.md',
+							'gen*/**/*specific*',
+							'gen*/**/*common*',
+						],
+						[
+							'gen*/**/my.prompt.md',
+							'gen*/**/*specific*.prompt.md',
+							'gen*/**/*common*.prompt.md',
+						],
+						[
+							'gen*/**/my*.md',
+							'gen*/**/*specific*.md',
+							'gen*/**/*common*.md',
+						],
+						[
+							'gen*/**/my*.md',
+							'gen*/**/specific*',
+							'gen*/**/unspecific*',
+							'gen*/**/common*',
+							'gen*/**/uncommon*',
+						],
+						[
+							'gen*/**/my.prompt.md',
+							'gen*/**/specific.prompt.md',
+							'gen*/**/unspecific1.prompt.md',
+							'gen*/**/unspecific2.prompt.md',
+							'gen*/**/common.prompt.md',
+							'gen*/**/uncommon-10.prompt.md',
+						],
+						[
+							'gen/text/my.prompt.md',
+							'gen/text/nested/specific.prompt.md',
+							'gen/text/nested/unspecific1.prompt.md',
+							'gen/text/nested/unspecific2.prompt.md',
+							'general/common.prompt.md',
+							'general/uncommon-10.prompt.md',
+						],
+						[
+							'gen/text/my.prompt.md',
+							'gen/text/nested/*specific*',
+							'general/*common*',
+						],
+						[
+							'gen/text/my.prompt.md',
+							'gen/text/**/specific.prompt.md',
+							'gen/text/**/unspecific1.prompt.md',
+							'gen/text/**/unspecific2.prompt.md',
+							'general/*',
+						],
+						[
+							'{gen,general}/**/my.prompt.md',
+							'{gen,general}/**/*specific*',
+							'{gen,general}/**/*common*',
+						],
+						[
+							'{gen,general}/**/my.prompt.md',
+							'{gen,general}/**/*specific*.prompt.md',
+							'{gen,general}/**/*common*.prompt.md',
+						],
+						[
+							'{gen,general}/**/my*.md',
+							'{gen,general}/**/*specific*.md',
+							'{gen,general}/**/*common*.md',
+						],
+						[
+							'{gen,general}/**/my*.md',
+							'{gen,general}/**/specific*',
+							'{gen,general}/**/unspecific*',
+							'{gen,general}/**/common*',
+							'{gen,general}/**/uncommon*',
+						],
+						[
+							'{gen,general}/**/my.prompt.md',
+							'{gen,general}/**/specific.prompt.md',
+							'{gen,general}/**/unspecific1.prompt.md',
+							'{gen,general}/**/unspecific2.prompt.md',
+							'{gen,general}/**/common.prompt.md',
+							'{gen,general}/**/uncommon-10.prompt.md',
+						],
+					];
 
-						for (const setting of testSettings) {
-							test(`• '${setting}'`, async () => {
-								const locator = await createPromptsLocator(
-									{ [setting]: true },
-									[
-										'/Users/legomushroom/repos/vscode',
-										'/Users/legomushroom/repos/prompts',
-									],
-									[
-										{
-											name: '/Users/legomushroom/repos/vscode',
-											children: [
-												{
-													name: 'gen/text',
-													children: [
-														{
-															name: 'my.prompt.md',
-															contents: 'oh hi, bot!',
-														},
-														{
-															name: 'nested',
-															children: [
-																{
-																	name: 'specific.prompt.md',
-																	contents: 'oh hi, bot!',
-																},
-																{
-																	name: 'unspecific1.prompt.md',
-																	contents: 'oh hi, robot!',
-																},
-																{
-																	name: 'unspecific2.prompt.md',
-																	contents: 'oh hi, rabot!',
-																},
-																{
-																	name: 'readme.md',
-																	contents: 'non prompt file',
-																},
-															],
-														}
-													],
-												},
-											],
-										},
-										{
-											name: '/Users/legomushroom/repos/prompts',
-											children: [
-												{
-													name: 'general',
-													children: [
-														{
-															name: 'common.prompt.md',
-															contents: 'oh hi, bot!',
-														},
-														{
-															name: 'uncommon-10.prompt.md',
-															contents: 'oh hi, robot!',
-														},
-														{
-															name: 'license.md',
-															contents: 'non prompt file',
-														},
-													],
-												}
-											],
-										},
-									],
-								);
+					for (const settings of testSettings) {
+						test(`• '${JSON.stringify(settings)}'`, async () => {
+							const vscodeSettings: Record<string, boolean> = {};
+							for (const setting of settings) {
+								vscodeSettings[setting] = true;
+							}
 
-								assert.deepStrictEqual(
-									(await locator.findAllMatchingPromptFiles())
-										.map((file) => file.fsPath),
-									[
-										createURI('/Users/legomushroom/repos/vscode/gen/text/my.prompt.md').fsPath,
-										createURI('/Users/legomushroom/repos/vscode/gen/text/nested/specific.prompt.md').fsPath,
-										createURI('/Users/legomushroom/repos/vscode/gen/text/nested/unspecific1.prompt.md').fsPath,
-										createURI('/Users/legomushroom/repos/vscode/gen/text/nested/unspecific2.prompt.md').fsPath,
-										// -
-										createURI('/Users/legomushroom/repos/prompts/general/common.prompt.md').fsPath,
-										createURI('/Users/legomushroom/repos/prompts/general/uncommon-10.prompt.md').fsPath,
-									],
-									'Must find correct prompts.',
-								);
-							});
-						}
-					});
+							const locator = await createPromptsLocator(
+								vscodeSettings,
+								[
+									'/Users/legomushroom/repos/vscode',
+									'/Users/legomushroom/repos/prompts',
+								],
+								[
+									{
+										name: '/Users/legomushroom/repos/vscode',
+										children: [
+											{
+												name: 'gen/text',
+												children: [
+													{
+														name: 'my.prompt.md',
+														contents: 'oh hi, bot!',
+													},
+													{
+														name: 'nested',
+														children: [
+															{
+																name: 'specific.prompt.md',
+																contents: 'oh hi, bot!',
+															},
+															{
+																name: 'unspecific1.prompt.md',
+																contents: 'oh hi, robot!',
+															},
+															{
+																name: 'unspecific2.prompt.md',
+																contents: 'oh hi, rabot!',
+															},
+															{
+																name: 'readme.md',
+																contents: 'non prompt file',
+															},
+														],
+													}
+												],
+											},
+										],
+									},
+									{
+										name: '/Users/legomushroom/repos/prompts',
+										children: [
+											{
+												name: 'general',
+												children: [
+													{
+														name: 'common.prompt.md',
+														contents: 'oh hi, bot!',
+													},
+													{
+														name: 'uncommon-10.prompt.md',
+														contents: 'oh hi, robot!',
+													},
+													{
+														name: 'license.md',
+														contents: 'non prompt file',
+													},
+												],
+											}
+										],
+									},
+								],
+							);
 
-					suite(`• specific`, () => {
-						const testSettings = [
-							[
-								'/Users/legomushroom/repos/**/my.prompt.md',
-								'/Users/legomushroom/repos/**/*specific*',
-								'/Users/legomushroom/repos/**/*common*',
-							],
-							[
-								'/Users/legomushroom/repos/**/my.prompt.md',
-								'/Users/legomushroom/repos/**/*specific*.prompt.md',
-								'/Users/legomushroom/repos/**/*common*.prompt.md',
-							],
-							[
-								'/Users/legomushroom/repos/**/my*.md',
-								'/Users/legomushroom/repos/**/*specific*.md',
-								'/Users/legomushroom/repos/**/*common*.md',
-							],
-							[
-								'/Users/legomushroom/repos/**/my*.md',
-								'/Users/legomushroom/repos/**/specific*',
-								'/Users/legomushroom/repos/**/unspecific*',
-								'/Users/legomushroom/repos/**/common*',
-								'/Users/legomushroom/repos/**/uncommon*',
-							],
-							[
-								'/Users/legomushroom/repos/**/my.prompt.md',
-								'/Users/legomushroom/repos/**/specific.prompt.md',
-								'/Users/legomushroom/repos/**/unspecific1.prompt.md',
-								'/Users/legomushroom/repos/**/unspecific2.prompt.md',
-								'/Users/legomushroom/repos/**/common.prompt.md',
-								'/Users/legomushroom/repos/**/uncommon-10.prompt.md',
-							],
-							[
-								'/Users/legomushroom/repos/**/gen*/**/my.prompt.md',
-								'/Users/legomushroom/repos/**/gen*/**/*specific*',
-								'/Users/legomushroom/repos/**/gen*/**/*common*',
-							],
-							[
-								'/Users/legomushroom/repos/**/gen*/**/my.prompt.md',
-								'/Users/legomushroom/repos/**/gen*/**/*specific*.prompt.md',
-								'/Users/legomushroom/repos/**/gen*/**/*common*.prompt.md',
-							],
-							[
-								'/Users/legomushroom/repos/**/gen*/**/my*.md',
-								'/Users/legomushroom/repos/**/gen*/**/*specific*.md',
-								'/Users/legomushroom/repos/**/gen*/**/*common*.md',
-							],
-							[
-								'/Users/legomushroom/repos/**/gen*/**/my*.md',
-								'/Users/legomushroom/repos/**/gen*/**/specific*',
-								'/Users/legomushroom/repos/**/gen*/**/unspecific*',
-								'/Users/legomushroom/repos/**/gen*/**/common*',
-								'/Users/legomushroom/repos/**/gen*/**/uncommon*',
-							],
-							[
-								'/Users/legomushroom/repos/**/gen*/**/my.prompt.md',
-								'/Users/legomushroom/repos/**/gen*/**/specific.prompt.md',
-								'/Users/legomushroom/repos/**/gen*/**/unspecific1.prompt.md',
-								'/Users/legomushroom/repos/**/gen*/**/unspecific2.prompt.md',
-								'/Users/legomushroom/repos/**/gen*/**/common.prompt.md',
-								'/Users/legomushroom/repos/**/gen*/**/uncommon-10.prompt.md',
-							],
-							[
-								'/Users/legomushroom/repos/vscode/gen/text/my.prompt.md',
-								'/Users/legomushroom/repos/vscode/gen/text/nested/specific.prompt.md',
-								'/Users/legomushroom/repos/vscode/gen/text/nested/unspecific1.prompt.md',
-								'/Users/legomushroom/repos/vscode/gen/text/nested/unspecific2.prompt.md',
-								'/Users/legomushroom/repos/prompts/general/common.prompt.md',
-								'/Users/legomushroom/repos/prompts/general/uncommon-10.prompt.md',
-							],
-							[
-								'/Users/legomushroom/repos/vscode/gen/text/my.prompt.md',
-								'/Users/legomushroom/repos/vscode/gen/text/nested/*specific*',
-								'/Users/legomushroom/repos/prompts/general/*common*',
-							],
-							[
-								'/Users/legomushroom/repos/vscode/gen/text/my.prompt.md',
-								'/Users/legomushroom/repos/vscode/gen/text/**/specific.prompt.md',
-								'/Users/legomushroom/repos/vscode/gen/text/**/unspecific1.prompt.md',
-								'/Users/legomushroom/repos/vscode/gen/text/**/unspecific2.prompt.md',
-								'/Users/legomushroom/repos/prompts/general/*',
-							],
-							[
-								'/Users/legomushroom/repos/**/{gen,general}/**/my.prompt.md',
-								'/Users/legomushroom/repos/**/{gen,general}/**/*specific*',
-								'/Users/legomushroom/repos/**/{gen,general}/**/*common*',
-							],
-							[
-								'/Users/legomushroom/repos/**/{gen,general}/**/my.prompt.md',
-								'/Users/legomushroom/repos/**/{gen,general}/**/*specific*.prompt.md',
-								'/Users/legomushroom/repos/**/{gen,general}/**/*common*.prompt.md',
-							],
-							[
-								'/Users/legomushroom/repos/**/{gen,general}/**/my*.md',
-								'/Users/legomushroom/repos/**/{gen,general}/**/*specific*.md',
-								'/Users/legomushroom/repos/**/{gen,general}/**/*common*.md',
-							],
-							[
-								'/Users/legomushroom/repos/**/{gen,general}/**/my*.md',
-								'/Users/legomushroom/repos/**/{gen,general}/**/specific*',
-								'/Users/legomushroom/repos/**/{gen,general}/**/unspecific*',
-								'/Users/legomushroom/repos/**/{gen,general}/**/common*',
-								'/Users/legomushroom/repos/**/{gen,general}/**/uncommon*',
-							],
-							[
-								'/Users/legomushroom/repos/**/{gen,general}/**/my.prompt.md',
-								'/Users/legomushroom/repos/**/{gen,general}/**/specific.prompt.md',
-								'/Users/legomushroom/repos/**/{gen,general}/**/unspecific1.prompt.md',
-								'/Users/legomushroom/repos/**/{gen,general}/**/unspecific2.prompt.md',
-								'/Users/legomushroom/repos/**/{gen,general}/**/common.prompt.md',
-								'/Users/legomushroom/repos/**/{gen,general}/**/uncommon-10.prompt.md',
-							],
-							[
-								'/Users/legomushroom/repos/{prompts,vscode,copilot}/{gen,general}/**/my.prompt.md',
-								'/Users/legomushroom/repos/{prompts,vscode,copilot}/{gen,general}/**/*specific*',
-								'/Users/legomushroom/repos/{prompts,vscode,copilot}/{gen,general}/**/*common*',
-							],
-							[
-								'/Users/legomushroom/repos/{prompts,vscode,copilot}/{gen,general}/**/my.prompt.md',
-								'/Users/legomushroom/repos/{prompts,vscode,copilot}/{gen,general}/**/*specific*.prompt.md',
-								'/Users/legomushroom/repos/{prompts,vscode,copilot}/{gen,general}/**/*common*.prompt.md',
-							],
-							[
-								'/Users/legomushroom/repos/{prompts,vscode,copilot}/{gen,general}/**/my*.md',
-								'/Users/legomushroom/repos/{prompts,vscode,copilot}/{gen,general}/**/*specific*.md',
-								'/Users/legomushroom/repos/{prompts,vscode,copilot}/{gen,general}/**/*common*.md',
-							],
-							[
-								'/Users/legomushroom/repos/{prompts,vscode,copilot}/{gen,general}/**/my*.md',
-								'/Users/legomushroom/repos/{prompts,vscode,copilot}/{gen,general}/**/specific*',
-								'/Users/legomushroom/repos/{prompts,vscode,copilot}/{gen,general}/**/unspecific*',
-								'/Users/legomushroom/repos/{prompts,vscode,copilot}/{gen,general}/**/common*',
-								'/Users/legomushroom/repos/{prompts,vscode,copilot}/{gen,general}/**/uncommon*',
-							],
-							[
-								'/Users/legomushroom/repos/{prompts,vscode,copilot}/{gen,general}/**/my.prompt.md',
-								'/Users/legomushroom/repos/{prompts,vscode,copilot}/{gen,general}/**/specific.prompt.md',
-								'/Users/legomushroom/repos/{prompts,vscode,copilot}/{gen,general}/**/unspecific1.prompt.md',
-								'/Users/legomushroom/repos/{prompts,vscode,copilot}/{gen,general}/**/unspecific2.prompt.md',
-								'/Users/legomushroom/repos/{prompts,vscode,copilot}/{gen,general}/**/common.prompt.md',
-								'/Users/legomushroom/repos/{prompts,vscode,copilot}/{gen,general}/**/uncommon-10.prompt.md',
-							],
-						];
+							assert.deepStrictEqual(
+								(await locator.listFiles())
+									.map((file) => file.fsPath),
+								[
+									createURI('/Users/legomushroom/repos/vscode/gen/text/my.prompt.md').fsPath,
+									createURI('/Users/legomushroom/repos/vscode/gen/text/nested/specific.prompt.md').fsPath,
+									createURI('/Users/legomushroom/repos/vscode/gen/text/nested/unspecific1.prompt.md').fsPath,
+									createURI('/Users/legomushroom/repos/vscode/gen/text/nested/unspecific2.prompt.md').fsPath,
+									// -
+									createURI('/Users/legomushroom/repos/prompts/general/common.prompt.md').fsPath,
+									createURI('/Users/legomushroom/repos/prompts/general/uncommon-10.prompt.md').fsPath,
+								],
+								'Must find correct prompts.',
+							);
+						});
+					}
+				});
+			});
 
-						for (const settings of testSettings) {
-							test(`• '${JSON.stringify(settings)}'`, async () => {
-								const vscodeSettings: Record<string, boolean> = {};
-								for (const setting of settings) {
-									vscodeSettings[setting] = true;
-								}
+			suite('• absolute', () => {
+				suite('• wild card', () => {
+					const testSettings = [
+						'/Users/legomushroom/repos/**',
+						'/Users/legomushroom/repos/**/*.prompt.md',
+						'/Users/legomushroom/repos/**/*.md',
+						'/Users/legomushroom/repos/**/*',
+						'/Users/legomushroom/repos/**/gen*/**',
+						'/Users/legomushroom/repos/**/gen*/**/*.prompt.md',
+						'/Users/legomushroom/repos/**/gen*/**/*',
+						'/Users/legomushroom/repos/**/gen*/**/*.md',
+						'/Users/legomushroom/repos/**/gen*/**',
+						'/Users/legomushroom/repos/**/gen*/**/*',
+						'/Users/legomushroom/repos/**/gen*/**/*.md',
+						'/Users/legomushroom/repos/**/gen*/**/*.prompt.md',
+						'/Users/legomushroom/repos/{vscode,prompts}/**',
+						'/Users/legomushroom/repos/{vscode,prompts}/**/*.prompt.md',
+						'/Users/legomushroom/repos/{vscode,prompts}/**/*.md',
+						'/Users/legomushroom/repos/{vscode,prompts}/**/*',
+						'/Users/legomushroom/repos/{vscode,prompts}/**/gen*/**',
+						'/Users/legomushroom/repos/{vscode,prompts}/**/gen*/**/*.prompt.md',
+						'/Users/legomushroom/repos/{vscode,prompts}/**/gen*/**/*',
+						'/Users/legomushroom/repos/{vscode,prompts}/**/gen*/**/*.md',
+						'/Users/legomushroom/repos/{vscode,prompts}/**/gen*/**',
+						'/Users/legomushroom/repos/{vscode,prompts}/**/gen*/**/*',
+						'/Users/legomushroom/repos/{vscode,prompts}/**/gen*/**/*.md',
+						'/Users/legomushroom/repos/{vscode,prompts}/**/gen*/**/*.prompt.md',
+						'/Users/legomushroom/repos/{vscode,prompts}/**/{general,gen}/**',
+						'/Users/legomushroom/repos/{vscode,prompts}/**/{general,gen}/**/*.prompt.md',
+						'/Users/legomushroom/repos/{vscode,prompts}/**/{general,gen}/**/*',
+						'/Users/legomushroom/repos/{vscode,prompts}/**/{general,gen}/**/*.md',
+						'/Users/legomushroom/repos/{vscode,prompts}/**/{general,gen}/**',
+						'/Users/legomushroom/repos/{vscode,prompts}/**/{general,gen}/**/*',
+						'/Users/legomushroom/repos/{vscode,prompts}/**/{general,gen}/**/*.md',
+						'/Users/legomushroom/repos/{vscode,prompts}/**/{general,gen}/**/*.prompt.md',
+					];
 
-								const locator = await createPromptsLocator(
-									vscodeSettings,
-									[
-										'/Users/legomushroom/repos/vscode',
-										'/Users/legomushroom/repos/prompts',
-									],
-									[
-										{
-											name: '/Users/legomushroom/repos/vscode',
-											children: [
-												{
-													name: 'gen/text',
-													children: [
-														{
-															name: 'my.prompt.md',
-															contents: 'oh hi, bot!',
-														},
-														{
-															name: 'nested',
-															children: [
-																{
-																	name: 'specific.prompt.md',
-																	contents: 'oh hi, bot!',
-																},
-																{
-																	name: 'unspecific1.prompt.md',
-																	contents: 'oh hi, robot!',
-																},
-																{
-																	name: 'unspecific2.prompt.md',
-																	contents: 'oh hi, rabot!',
-																},
-																{
-																	name: 'readme.md',
-																	contents: 'non prompt file',
-																},
-															],
-														}
-													],
-												},
-											],
-										},
-										{
-											name: '/Users/legomushroom/repos/prompts',
-											children: [
-												{
-													name: 'general',
-													children: [
-														{
-															name: 'common.prompt.md',
-															contents: 'oh hi, bot!',
-														},
-														{
-															name: 'uncommon-10.prompt.md',
-															contents: 'oh hi, robot!',
-														},
-														{
-															name: 'license.md',
-															contents: 'non prompt file',
-														},
-													],
-												}
-											],
-										},
-									],
-								);
+					for (const setting of testSettings) {
+						test(`• '${setting}'`, async () => {
+							const locator = await createPromptsLocator(
+								{ [setting]: true },
+								[
+									'/Users/legomushroom/repos/vscode',
+									'/Users/legomushroom/repos/prompts',
+								],
+								[
+									{
+										name: '/Users/legomushroom/repos/vscode',
+										children: [
+											{
+												name: 'gen/text',
+												children: [
+													{
+														name: 'my.prompt.md',
+														contents: 'oh hi, bot!',
+													},
+													{
+														name: 'nested',
+														children: [
+															{
+																name: 'specific.prompt.md',
+																contents: 'oh hi, bot!',
+															},
+															{
+																name: 'unspecific1.prompt.md',
+																contents: 'oh hi, robot!',
+															},
+															{
+																name: 'unspecific2.prompt.md',
+																contents: 'oh hi, rabot!',
+															},
+															{
+																name: 'readme.md',
+																contents: 'non prompt file',
+															},
+														],
+													}
+												],
+											},
+										],
+									},
+									{
+										name: '/Users/legomushroom/repos/prompts',
+										children: [
+											{
+												name: 'general',
+												children: [
+													{
+														name: 'common.prompt.md',
+														contents: 'oh hi, bot!',
+													},
+													{
+														name: 'uncommon-10.prompt.md',
+														contents: 'oh hi, robot!',
+													},
+													{
+														name: 'license.md',
+														contents: 'non prompt file',
+													},
+												],
+											}
+										],
+									},
+								],
+							);
 
-								assert.deepStrictEqual(
-									(await locator.findAllMatchingPromptFiles())
-										.map((file) => file.fsPath),
-									[
-										createURI('/Users/legomushroom/repos/vscode/gen/text/my.prompt.md').fsPath,
-										createURI('/Users/legomushroom/repos/vscode/gen/text/nested/specific.prompt.md').fsPath,
-										createURI('/Users/legomushroom/repos/vscode/gen/text/nested/unspecific1.prompt.md').fsPath,
-										createURI('/Users/legomushroom/repos/vscode/gen/text/nested/unspecific2.prompt.md').fsPath,
-										// -
-										createURI('/Users/legomushroom/repos/prompts/general/common.prompt.md').fsPath,
-										createURI('/Users/legomushroom/repos/prompts/general/uncommon-10.prompt.md').fsPath,
-									],
-									'Must find correct prompts.',
-								);
-							});
-						}
-					});
+							assert.deepStrictEqual(
+								(await locator.listFiles())
+									.map((file) => file.fsPath),
+								[
+									createURI('/Users/legomushroom/repos/vscode/gen/text/my.prompt.md').fsPath,
+									createURI('/Users/legomushroom/repos/vscode/gen/text/nested/specific.prompt.md').fsPath,
+									createURI('/Users/legomushroom/repos/vscode/gen/text/nested/unspecific1.prompt.md').fsPath,
+									createURI('/Users/legomushroom/repos/vscode/gen/text/nested/unspecific2.prompt.md').fsPath,
+									// -
+									createURI('/Users/legomushroom/repos/prompts/general/common.prompt.md').fsPath,
+									createURI('/Users/legomushroom/repos/prompts/general/uncommon-10.prompt.md').fsPath,
+								],
+								'Must find correct prompts.',
+							);
+						});
+					}
+				});
+
+				suite(`• specific`, () => {
+					const testSettings = [
+						[
+							'/Users/legomushroom/repos/**/my.prompt.md',
+							'/Users/legomushroom/repos/**/*specific*',
+							'/Users/legomushroom/repos/**/*common*',
+						],
+						[
+							'/Users/legomushroom/repos/**/my.prompt.md',
+							'/Users/legomushroom/repos/**/*specific*.prompt.md',
+							'/Users/legomushroom/repos/**/*common*.prompt.md',
+						],
+						[
+							'/Users/legomushroom/repos/**/my*.md',
+							'/Users/legomushroom/repos/**/*specific*.md',
+							'/Users/legomushroom/repos/**/*common*.md',
+						],
+						[
+							'/Users/legomushroom/repos/**/my*.md',
+							'/Users/legomushroom/repos/**/specific*',
+							'/Users/legomushroom/repos/**/unspecific*',
+							'/Users/legomushroom/repos/**/common*',
+							'/Users/legomushroom/repos/**/uncommon*',
+						],
+						[
+							'/Users/legomushroom/repos/**/my.prompt.md',
+							'/Users/legomushroom/repos/**/specific.prompt.md',
+							'/Users/legomushroom/repos/**/unspecific1.prompt.md',
+							'/Users/legomushroom/repos/**/unspecific2.prompt.md',
+							'/Users/legomushroom/repos/**/common.prompt.md',
+							'/Users/legomushroom/repos/**/uncommon-10.prompt.md',
+						],
+						[
+							'/Users/legomushroom/repos/**/gen*/**/my.prompt.md',
+							'/Users/legomushroom/repos/**/gen*/**/*specific*',
+							'/Users/legomushroom/repos/**/gen*/**/*common*',
+						],
+						[
+							'/Users/legomushroom/repos/**/gen*/**/my.prompt.md',
+							'/Users/legomushroom/repos/**/gen*/**/*specific*.prompt.md',
+							'/Users/legomushroom/repos/**/gen*/**/*common*.prompt.md',
+						],
+						[
+							'/Users/legomushroom/repos/**/gen*/**/my*.md',
+							'/Users/legomushroom/repos/**/gen*/**/*specific*.md',
+							'/Users/legomushroom/repos/**/gen*/**/*common*.md',
+						],
+						[
+							'/Users/legomushroom/repos/**/gen*/**/my*.md',
+							'/Users/legomushroom/repos/**/gen*/**/specific*',
+							'/Users/legomushroom/repos/**/gen*/**/unspecific*',
+							'/Users/legomushroom/repos/**/gen*/**/common*',
+							'/Users/legomushroom/repos/**/gen*/**/uncommon*',
+						],
+						[
+							'/Users/legomushroom/repos/**/gen*/**/my.prompt.md',
+							'/Users/legomushroom/repos/**/gen*/**/specific.prompt.md',
+							'/Users/legomushroom/repos/**/gen*/**/unspecific1.prompt.md',
+							'/Users/legomushroom/repos/**/gen*/**/unspecific2.prompt.md',
+							'/Users/legomushroom/repos/**/gen*/**/common.prompt.md',
+							'/Users/legomushroom/repos/**/gen*/**/uncommon-10.prompt.md',
+						],
+						[
+							'/Users/legomushroom/repos/vscode/gen/text/my.prompt.md',
+							'/Users/legomushroom/repos/vscode/gen/text/nested/specific.prompt.md',
+							'/Users/legomushroom/repos/vscode/gen/text/nested/unspecific1.prompt.md',
+							'/Users/legomushroom/repos/vscode/gen/text/nested/unspecific2.prompt.md',
+							'/Users/legomushroom/repos/prompts/general/common.prompt.md',
+							'/Users/legomushroom/repos/prompts/general/uncommon-10.prompt.md',
+						],
+						[
+							'/Users/legomushroom/repos/vscode/gen/text/my.prompt.md',
+							'/Users/legomushroom/repos/vscode/gen/text/nested/*specific*',
+							'/Users/legomushroom/repos/prompts/general/*common*',
+						],
+						[
+							'/Users/legomushroom/repos/vscode/gen/text/my.prompt.md',
+							'/Users/legomushroom/repos/vscode/gen/text/**/specific.prompt.md',
+							'/Users/legomushroom/repos/vscode/gen/text/**/unspecific1.prompt.md',
+							'/Users/legomushroom/repos/vscode/gen/text/**/unspecific2.prompt.md',
+							'/Users/legomushroom/repos/prompts/general/*',
+						],
+						[
+							'/Users/legomushroom/repos/**/{gen,general}/**/my.prompt.md',
+							'/Users/legomushroom/repos/**/{gen,general}/**/*specific*',
+							'/Users/legomushroom/repos/**/{gen,general}/**/*common*',
+						],
+						[
+							'/Users/legomushroom/repos/**/{gen,general}/**/my.prompt.md',
+							'/Users/legomushroom/repos/**/{gen,general}/**/*specific*.prompt.md',
+							'/Users/legomushroom/repos/**/{gen,general}/**/*common*.prompt.md',
+						],
+						[
+							'/Users/legomushroom/repos/**/{gen,general}/**/my*.md',
+							'/Users/legomushroom/repos/**/{gen,general}/**/*specific*.md',
+							'/Users/legomushroom/repos/**/{gen,general}/**/*common*.md',
+						],
+						[
+							'/Users/legomushroom/repos/**/{gen,general}/**/my*.md',
+							'/Users/legomushroom/repos/**/{gen,general}/**/specific*',
+							'/Users/legomushroom/repos/**/{gen,general}/**/unspecific*',
+							'/Users/legomushroom/repos/**/{gen,general}/**/common*',
+							'/Users/legomushroom/repos/**/{gen,general}/**/uncommon*',
+						],
+						[
+							'/Users/legomushroom/repos/**/{gen,general}/**/my.prompt.md',
+							'/Users/legomushroom/repos/**/{gen,general}/**/specific.prompt.md',
+							'/Users/legomushroom/repos/**/{gen,general}/**/unspecific1.prompt.md',
+							'/Users/legomushroom/repos/**/{gen,general}/**/unspecific2.prompt.md',
+							'/Users/legomushroom/repos/**/{gen,general}/**/common.prompt.md',
+							'/Users/legomushroom/repos/**/{gen,general}/**/uncommon-10.prompt.md',
+						],
+						[
+							'/Users/legomushroom/repos/{prompts,vscode,copilot}/{gen,general}/**/my.prompt.md',
+							'/Users/legomushroom/repos/{prompts,vscode,copilot}/{gen,general}/**/*specific*',
+							'/Users/legomushroom/repos/{prompts,vscode,copilot}/{gen,general}/**/*common*',
+						],
+						[
+							'/Users/legomushroom/repos/{prompts,vscode,copilot}/{gen,general}/**/my.prompt.md',
+							'/Users/legomushroom/repos/{prompts,vscode,copilot}/{gen,general}/**/*specific*.prompt.md',
+							'/Users/legomushroom/repos/{prompts,vscode,copilot}/{gen,general}/**/*common*.prompt.md',
+						],
+						[
+							'/Users/legomushroom/repos/{prompts,vscode,copilot}/{gen,general}/**/my*.md',
+							'/Users/legomushroom/repos/{prompts,vscode,copilot}/{gen,general}/**/*specific*.md',
+							'/Users/legomushroom/repos/{prompts,vscode,copilot}/{gen,general}/**/*common*.md',
+						],
+						[
+							'/Users/legomushroom/repos/{prompts,vscode,copilot}/{gen,general}/**/my*.md',
+							'/Users/legomushroom/repos/{prompts,vscode,copilot}/{gen,general}/**/specific*',
+							'/Users/legomushroom/repos/{prompts,vscode,copilot}/{gen,general}/**/unspecific*',
+							'/Users/legomushroom/repos/{prompts,vscode,copilot}/{gen,general}/**/common*',
+							'/Users/legomushroom/repos/{prompts,vscode,copilot}/{gen,general}/**/uncommon*',
+						],
+						[
+							'/Users/legomushroom/repos/{prompts,vscode,copilot}/{gen,general}/**/my.prompt.md',
+							'/Users/legomushroom/repos/{prompts,vscode,copilot}/{gen,general}/**/specific.prompt.md',
+							'/Users/legomushroom/repos/{prompts,vscode,copilot}/{gen,general}/**/unspecific1.prompt.md',
+							'/Users/legomushroom/repos/{prompts,vscode,copilot}/{gen,general}/**/unspecific2.prompt.md',
+							'/Users/legomushroom/repos/{prompts,vscode,copilot}/{gen,general}/**/common.prompt.md',
+							'/Users/legomushroom/repos/{prompts,vscode,copilot}/{gen,general}/**/uncommon-10.prompt.md',
+						],
+					];
+
+					for (const settings of testSettings) {
+						test(`• '${JSON.stringify(settings)}'`, async () => {
+							const vscodeSettings: Record<string, boolean> = {};
+							for (const setting of settings) {
+								vscodeSettings[setting] = true;
+							}
+
+							const locator = await createPromptsLocator(
+								vscodeSettings,
+								[
+									'/Users/legomushroom/repos/vscode',
+									'/Users/legomushroom/repos/prompts',
+								],
+								[
+									{
+										name: '/Users/legomushroom/repos/vscode',
+										children: [
+											{
+												name: 'gen/text',
+												children: [
+													{
+														name: 'my.prompt.md',
+														contents: 'oh hi, bot!',
+													},
+													{
+														name: 'nested',
+														children: [
+															{
+																name: 'specific.prompt.md',
+																contents: 'oh hi, bot!',
+															},
+															{
+																name: 'unspecific1.prompt.md',
+																contents: 'oh hi, robot!',
+															},
+															{
+																name: 'unspecific2.prompt.md',
+																contents: 'oh hi, rabot!',
+															},
+															{
+																name: 'readme.md',
+																contents: 'non prompt file',
+															},
+														],
+													}
+												],
+											},
+										],
+									},
+									{
+										name: '/Users/legomushroom/repos/prompts',
+										children: [
+											{
+												name: 'general',
+												children: [
+													{
+														name: 'common.prompt.md',
+														contents: 'oh hi, bot!',
+													},
+													{
+														name: 'uncommon-10.prompt.md',
+														contents: 'oh hi, robot!',
+													},
+													{
+														name: 'license.md',
+														contents: 'non prompt file',
+													},
+												],
+											}
+										],
+									},
+								],
+							);
+
+							assert.deepStrictEqual(
+								(await locator.listFiles())
+									.map((file) => file.fsPath),
+								[
+									createURI('/Users/legomushroom/repos/vscode/gen/text/my.prompt.md').fsPath,
+									createURI('/Users/legomushroom/repos/vscode/gen/text/nested/specific.prompt.md').fsPath,
+									createURI('/Users/legomushroom/repos/vscode/gen/text/nested/unspecific1.prompt.md').fsPath,
+									createURI('/Users/legomushroom/repos/vscode/gen/text/nested/unspecific2.prompt.md').fsPath,
+									// -
+									createURI('/Users/legomushroom/repos/prompts/general/common.prompt.md').fsPath,
+									createURI('/Users/legomushroom/repos/prompts/general/uncommon-10.prompt.md').fsPath,
+								],
+								'Must find correct prompts.',
+							);
+						});
+					}
 				});
 			});
 		});

--- a/src/vs/workbench/contrib/chat/test/common/promptSyntax/utils/promptFilesLocator.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/promptSyntax/utils/promptFilesLocator.test.ts
@@ -221,164 +221,496 @@ suite('PromptFilesLocator', () => {
 
 	suite('• single-root workspace', () => {
 		suite('• findAllMatchingPromptFiles', () => {
-			test('• relative glob pattern', async () => {
-				const locator = await createPromptsLocator(
-					{
-						'.github/prompts': false,
-						'/Users/legomushroom/repos/prompts': false,
-						// -
-						'.copilot/prompts/**': true,
-						'**/my-prompts/': true,
-						'.github/prompts/nested/specific.prompt.md': true,
-						'.github/prompts/nested/unspecific*.prompt.md': true,
-						// '.github/prompts/nested/unspecific': true,
-						// '.github/prompts/nested/unspecific*': true,
-						// '.github/prompts/nested/unspecific*-prompt': true,
-						// '.github/prompts/nested/*unspecific*-prompt': true,
-						// '.github/prompts/nested/*.prompt.md': true,
-						// '.github/**/nested/*.prompt.md': true,
-						// '.github/prompts/**/*.prompt.md': true,
-					},
-					[
-						'/Users/legomushroom/repos/vscode',
-					],
-					[
-						{
-							name: '/Users/legomushroom/repos/prompts',
-							children: [
-								{
-									name: 'test.prompt.md',
-									contents: 'Hello, World!',
-								},
-								{
-									name: 'refactor-tests.prompt.md',
-									contents: 'some file content goes here',
-								},
-							],
-						},
-						{
-							name: '/tmp/prompts',
-							children: [
-								{
-									name: 'translate.to-rust.prompt.md',
-									contents: 'some more random file contents',
-								},
-							],
-						},
-						{
-							name: '/absolute/path/prompts',
-							children: [
-								{
-									name: 'some-prompt-file.prompt.md',
-									contents: 'hey hey hey',
-								},
-							],
-						},
-						{
-							name: '/Users/legomushroom/repos/vscode',
-							children: [
-								{
-									name: '.copilot/prompts',
-									children: [
-										{
-											name: 'default.prompt.md',
-											contents: 'oh hi, robot!',
-										},
-										{
-											name: 'misc',
-											children: [
-												{
-													name: 'child.prompt.md',
-													contents: 'contents',
-												},
-											],
-										}
-									],
-								},
-								{
-									name: '.github/prompts',
-									children: [
-										{
-											name: 'my.prompt.md',
-											contents: 'oh hi, bot!',
-										},
-										{
-											name: 'nested',
-											children: [
-												{
-													name: 'specific.prompt.md',
-													contents: 'oh hi, bot!',
-												},
-												{
-													name: 'unspecific1.prompt.md',
-													contents: 'oh hi, bot!',
-												},
-												{
-													name: 'unspecific2.prompt.md',
-													contents: 'oh hi, bot!',
-												},
-											],
-										}
-									],
-								},
-								{
-									name: 'deps/text',
-									children: [
-										{
-											name: 'my.prompt.md',
-											contents: 'oh hi, bot!',
-										},
-										{
-											name: 'my-prompts',
-											children: [
-												{
-													name: 'your.prompt.md',
-													contents: 'oh hi, bot!',
-												},
-											],
-										},
-									],
-								},
-							],
-						},
-					]);
+			suite('• glob pattern', () => {
+				suite('• relative', () => {
+					suite('• wild card', () => {
+						const testSettings = [
+							'**',
+							'**/*.prompt.md',
+							'**/*.md',
+							'**/*',
+							'deps/**',
+							'deps/**/*.prompt.md',
+							'deps/**/*',
+							'deps/**/*.md',
+							'**/text/**',
+							'**/text/**/*',
+							'**/text/**/*.md',
+							'**/text/**/*.prompt.md',
+							'deps/text/**',
+							'deps/text/**/*',
+							'deps/text/**/*.md',
+							'deps/text/**/*.prompt.md',
+						];
 
-				assert.deepStrictEqual(
-					(await locator.findAllMatchingPromptFiles())
-						.map((file) => file.fsPath),
-					[
-						// createURI('/Users/legomushroom/repos/vscode/.github/prompts/my.prompt.md'),
-						// createURI('/Users/legomushroom/repos/prompts/test.prompt.md'),
-						// createURI('/Users/legomushroom/repos/prompts/refactor-tests.prompt.md'),
-						createURI('/Users/legomushroom/repos/vscode/.copilot/prompts/default.prompt.md').fsPath,
-						createURI('/Users/legomushroom/repos/vscode/.copilot/prompts/misc/child.prompt.md').fsPath,
-						createURI('/Users/legomushroom/repos/vscode/deps/text/my-prompts/your.prompt.md').fsPath,
-						createURI('/Users/legomushroom/repos/vscode/.github/prompts/nested/specific.prompt.md').fsPath,
-						createURI('/Users/legomushroom/repos/vscode/.github/prompts/nested/unspecific1.prompt.md').fsPath,
-						createURI('/Users/legomushroom/repos/vscode/.github/prompts/nested/unspecific2.prompt.md').fsPath,
-					],
-					'Must find correct prompts.',
-				);
+						for (const setting of testSettings) {
+							test(`• '${setting}'`, async () => {
+								const locator = await createPromptsLocator(
+									{ [setting]: true },
+									['/Users/legomushroom/repos/vscode'],
+									[
+										{
+											name: '/Users/legomushroom/repos/vscode',
+											children: [
+												{
+													name: 'deps/text',
+													children: [
+														{
+															name: 'my.prompt.md',
+															contents: 'oh hi, bot!',
+														},
+														{
+															name: 'nested',
+															children: [
+																{
+																	name: 'specific.prompt.md',
+																	contents: 'oh hi, bot!',
+																},
+																{
+																	name: 'unspecific1.prompt.md',
+																	contents: 'oh hi, robot!',
+																},
+																{
+																	name: 'unspecific2.prompt.md',
+																	contents: 'oh hi, rabot!',
+																},
+																{
+																	name: 'readme.md',
+																	contents: 'non prompt file',
+																},
+															],
+														}
+													],
+												},
+											],
+										},
+									],
+								);
+
+								assert.deepStrictEqual(
+									(await locator.findAllMatchingPromptFiles())
+										.map((file) => file.fsPath),
+									[
+										createURI('/Users/legomushroom/repos/vscode/deps/text/my.prompt.md').fsPath,
+										createURI('/Users/legomushroom/repos/vscode/deps/text/nested/specific.prompt.md').fsPath,
+										createURI('/Users/legomushroom/repos/vscode/deps/text/nested/unspecific1.prompt.md').fsPath,
+										createURI('/Users/legomushroom/repos/vscode/deps/text/nested/unspecific2.prompt.md').fsPath,
+									],
+									'Must find correct prompts.',
+								);
+							});
+						}
+					});
+
+					suite(`• specific`, () => {
+						const testSettings = [
+							[
+								'**/*specific*',
+							],
+							[
+								'**/*specific*.prompt.md',
+							],
+							[
+								'**/*specific*.md',
+							],
+							[
+								'**/specific*',
+								'**/unspecific1.prompt.md',
+								'**/unspecific2.prompt.md',
+							],
+							[
+								'**/specific.prompt.md',
+								'**/unspecific*.prompt.md',
+							],
+							[
+								'**/nested/specific.prompt.md',
+								'**/nested/unspecific*.prompt.md',
+							],
+							[
+								'**/nested/*specific*',
+							],
+							[
+								'**/*spec*.prompt.md',
+							],
+							[
+								'**/*spec*',
+							],
+							[
+								'**/*spec*.md',
+							],
+							[
+								'**/deps/**/*spec*.md',
+							],
+							[
+								'**/text/**/*spec*.md',
+							],
+							[
+								'deps/text/nested/*spec*',
+							],
+							[
+								'deps/text/nested/*specific*',
+							],
+							[
+								'deps/**/*specific*',
+							],
+							[
+								'deps/**/specific*',
+								'deps/**/unspecific*.prompt.md',
+							],
+							[
+								'deps/**/specific*.md',
+								'deps/**/unspecific*.md',
+							],
+							[
+								'deps/**/specific.prompt.md',
+								'deps/**/unspecific1.prompt.md',
+								'deps/**/unspecific2.prompt.md',
+							],
+							[
+								'deps/**/specific.prompt.md',
+								'deps/**/unspecific1*.md',
+								'deps/**/unspecific2*.md',
+							],
+							[
+								'deps/text/**/*specific*',
+							],
+							[
+								'deps/text/**/specific*',
+								'deps/text/**/unspecific*.prompt.md',
+							],
+							[
+								'deps/text/**/specific*.md',
+								'deps/text/**/unspecific*.md',
+							],
+							[
+								'deps/text/**/specific.prompt.md',
+								'deps/text/**/unspecific1.prompt.md',
+								'deps/text/**/unspecific2.prompt.md',
+							],
+							[
+								'deps/text/**/specific.prompt.md',
+								'deps/text/**/unspecific1*.md',
+								'deps/text/**/unspecific2*.md',
+							],
+						];
+
+						for (const settings of testSettings) {
+							test(`• '${JSON.stringify(settings)}'`, async () => {
+								const vscodeSettings: Record<string, boolean> = {};
+								for (const setting of settings) {
+									vscodeSettings[setting] = true;
+								}
+
+								const locator = await createPromptsLocator(
+									vscodeSettings,
+									['/Users/legomushroom/repos/vscode'],
+									[
+										{
+											name: '/Users/legomushroom/repos/vscode',
+											children: [
+												{
+													name: 'deps/text',
+													children: [
+														{
+															name: 'my.prompt.md',
+															contents: 'oh hi, bot!',
+														},
+														{
+															name: 'nested',
+															children: [
+																{
+																	name: 'default.prompt.md',
+																	contents: 'oh hi, bot!',
+																},
+																{
+																	name: 'specific.prompt.md',
+																	contents: 'oh hi, bot!',
+																},
+																{
+																	name: 'unspecific1.prompt.md',
+																	contents: 'oh hi, robot!',
+																},
+																{
+																	name: 'unspecific2.prompt.md',
+																	contents: 'oh hi, rawbot!',
+																},
+																{
+																	name: 'readme.md',
+																	contents: 'non prompt file',
+																},
+															],
+														}
+													],
+												},
+											],
+										},
+									],
+								);
+
+								assert.deepStrictEqual(
+									(await locator.findAllMatchingPromptFiles())
+										.map((file) => file.fsPath),
+									[
+										createURI('/Users/legomushroom/repos/vscode/deps/text/nested/specific.prompt.md').fsPath,
+										createURI('/Users/legomushroom/repos/vscode/deps/text/nested/unspecific1.prompt.md').fsPath,
+										createURI('/Users/legomushroom/repos/vscode/deps/text/nested/unspecific2.prompt.md').fsPath,
+									],
+									'Must find correct prompts.',
+								);
+							});
+						}
+					});
+				});
+
+				suite('• absolute', () => {
+					suite('• wild card', () => {
+						const settings = [
+							'/Users/legomushroom/repos/vscode/**',
+							'/Users/legomushroom/repos/vscode/**/*.prompt.md',
+							'/Users/legomushroom/repos/vscode/**/*.md',
+							'/Users/legomushroom/repos/vscode/**/*',
+							'/Users/legomushroom/repos/vscode/deps/**',
+							'/Users/legomushroom/repos/vscode/deps/**/*.prompt.md',
+							'/Users/legomushroom/repos/vscode/deps/**/*',
+							'/Users/legomushroom/repos/vscode/deps/**/*.md',
+							'/Users/legomushroom/repos/vscode/**/text/**',
+							'/Users/legomushroom/repos/vscode/**/text/**/*',
+							'/Users/legomushroom/repos/vscode/**/text/**/*.md',
+							'/Users/legomushroom/repos/vscode/**/text/**/*.prompt.md',
+							'/Users/legomushroom/repos/vscode/deps/text/**',
+							'/Users/legomushroom/repos/vscode/deps/text/**/*',
+							'/Users/legomushroom/repos/vscode/deps/text/**/*.md',
+							'/Users/legomushroom/repos/vscode/deps/text/**/*.prompt.md',
+						];
+
+						for (const setting of settings) {
+							test(`• '${setting}'`, async () => {
+								const locator = await createPromptsLocator(
+									{ [setting]: true },
+									['/Users/legomushroom/repos/vscode'],
+									[
+										{
+											name: '/Users/legomushroom/repos/vscode',
+											children: [
+												{
+													name: 'deps/text',
+													children: [
+														{
+															name: 'my.prompt.md',
+															contents: 'oh hi, bot!',
+														},
+														{
+															name: 'nested',
+															children: [
+																{
+																	name: 'specific.prompt.md',
+																	contents: 'oh hi, bot!',
+																},
+																{
+																	name: 'unspecific1.prompt.md',
+																	contents: 'oh hi, robot!',
+																},
+																{
+																	name: 'unspecific2.prompt.md',
+																	contents: 'oh hi, rabot!',
+																},
+																{
+																	name: 'readme.md',
+																	contents: 'non prompt file',
+																},
+															],
+														}
+													],
+												},
+											],
+										},
+									],
+								);
+
+								assert.deepStrictEqual(
+									(await locator.findAllMatchingPromptFiles())
+										.map((file) => file.fsPath),
+									[
+										createURI('/Users/legomushroom/repos/vscode/deps/text/my.prompt.md').fsPath,
+										createURI('/Users/legomushroom/repos/vscode/deps/text/nested/specific.prompt.md').fsPath,
+										createURI('/Users/legomushroom/repos/vscode/deps/text/nested/unspecific1.prompt.md').fsPath,
+										createURI('/Users/legomushroom/repos/vscode/deps/text/nested/unspecific2.prompt.md').fsPath,
+									],
+									'Must find correct prompts.',
+								);
+							});
+						}
+					});
+
+					suite(`• specific`, () => {
+						const testSettings = [
+							[
+								'/Users/legomushroom/repos/vscode/**/*specific*',
+							],
+							[
+								'/Users/legomushroom/repos/vscode/**/*specific*.prompt.md',
+							],
+							[
+								'/Users/legomushroom/repos/vscode/**/*specific*.md',
+							],
+							[
+								'/Users/legomushroom/repos/vscode/**/specific*',
+								'/Users/legomushroom/repos/vscode/**/unspecific1.prompt.md',
+								'/Users/legomushroom/repos/vscode/**/unspecific2.prompt.md',
+							],
+							[
+								'/Users/legomushroom/repos/vscode/**/specific.prompt.md',
+								'/Users/legomushroom/repos/vscode/**/unspecific*.prompt.md',
+							],
+							[
+								'/Users/legomushroom/repos/vscode/**/nested/specific.prompt.md',
+								'/Users/legomushroom/repos/vscode/**/nested/unspecific*.prompt.md',
+							],
+							[
+								'/Users/legomushroom/repos/vscode/**/nested/*specific*',
+							],
+							[
+								'/Users/legomushroom/repos/vscode/**/*spec*.prompt.md',
+							],
+							[
+								'/Users/legomushroom/repos/vscode/**/*spec*',
+							],
+							[
+								'/Users/legomushroom/repos/vscode/**/*spec*.md',
+							],
+							[
+								'/Users/legomushroom/repos/vscode/**/deps/**/*spec*.md',
+							],
+							[
+								'/Users/legomushroom/repos/vscode/**/text/**/*spec*.md',
+							],
+							[
+								'/Users/legomushroom/repos/vscode/deps/text/nested/*spec*',
+							],
+							[
+								'/Users/legomushroom/repos/vscode/deps/text/nested/*specific*',
+							],
+							[
+								'/Users/legomushroom/repos/vscode/deps/**/*specific*',
+							],
+							[
+								'/Users/legomushroom/repos/vscode/deps/**/specific*',
+								'/Users/legomushroom/repos/vscode/deps/**/unspecific*.prompt.md',
+							],
+							[
+								'/Users/legomushroom/repos/vscode/deps/**/specific*.md',
+								'/Users/legomushroom/repos/vscode/deps/**/unspecific*.md',
+							],
+							[
+								'/Users/legomushroom/repos/vscode/deps/**/specific.prompt.md',
+								'/Users/legomushroom/repos/vscode/deps/**/unspecific1.prompt.md',
+								'/Users/legomushroom/repos/vscode/deps/**/unspecific2.prompt.md',
+							],
+							[
+								'/Users/legomushroom/repos/vscode/deps/**/specific.prompt.md',
+								'/Users/legomushroom/repos/vscode/deps/**/unspecific1*.md',
+								'/Users/legomushroom/repos/vscode/deps/**/unspecific2*.md',
+							],
+							[
+								'/Users/legomushroom/repos/vscode/deps/text/**/*specific*',
+							],
+							[
+								'/Users/legomushroom/repos/vscode/deps/text/**/specific*',
+								'/Users/legomushroom/repos/vscode/deps/text/**/unspecific*.prompt.md',
+							],
+							[
+								'/Users/legomushroom/repos/vscode/deps/text/**/specific*.md',
+								'/Users/legomushroom/repos/vscode/deps/text/**/unspecific*.md',
+							],
+							[
+								'/Users/legomushroom/repos/vscode/deps/text/**/specific.prompt.md',
+								'/Users/legomushroom/repos/vscode/deps/text/**/unspecific1.prompt.md',
+								'/Users/legomushroom/repos/vscode/deps/text/**/unspecific2.prompt.md',
+							],
+							[
+								'/Users/legomushroom/repos/vscode/deps/text/**/specific.prompt.md',
+								'/Users/legomushroom/repos/vscode/deps/text/**/unspecific1*.md',
+								'/Users/legomushroom/repos/vscode/deps/text/**/unspecific2*.md',
+							],
+						];
+
+						for (const settings of testSettings) {
+							test(`• '${JSON.stringify(settings)}'`, async () => {
+								const vscodeSettings: Record<string, boolean> = {};
+								for (const setting of settings) {
+									vscodeSettings[setting] = true;
+								}
+
+								const locator = await createPromptsLocator(
+									vscodeSettings,
+									['/Users/legomushroom/repos/vscode'],
+									[
+										{
+											name: '/Users/legomushroom/repos/vscode',
+											children: [
+												{
+													name: 'deps/text',
+													children: [
+														{
+															name: 'my.prompt.md',
+															contents: 'oh hi, bot!',
+														},
+														{
+															name: 'nested',
+															children: [
+																{
+																	name: 'default.prompt.md',
+																	contents: 'oh hi, bot!',
+																},
+																{
+																	name: 'specific.prompt.md',
+																	contents: 'oh hi, bot!',
+																},
+																{
+																	name: 'unspecific1.prompt.md',
+																	contents: 'oh hi, robot!',
+																},
+																{
+																	name: 'unspecific2.prompt.md',
+																	contents: 'oh hi, rawbot!',
+																},
+																{
+																	name: 'readme.md',
+																	contents: 'non prompt file',
+																},
+															],
+														}
+													],
+												},
+											],
+										},
+									],
+								);
+
+								assert.deepStrictEqual(
+									(await locator.findAllMatchingPromptFiles())
+										.map((file) => file.fsPath),
+									[
+										createURI('/Users/legomushroom/repos/vscode/deps/text/nested/specific.prompt.md').fsPath,
+										createURI('/Users/legomushroom/repos/vscode/deps/text/nested/unspecific1.prompt.md').fsPath,
+										createURI('/Users/legomushroom/repos/vscode/deps/text/nested/unspecific2.prompt.md').fsPath,
+									],
+									'Must find correct prompts.',
+								);
+							});
+						}
+					});
+				});
 			});
 		});
 
-		test('• relative glob pattern #2', async () => {
+		test('• core logic', async () => {
 			const locator = await createPromptsLocator(
 				{
-					'.github/prompts': false,
-					'/Users/legomushroom/repos/prompts': false,
-					// -
-					'.copilot/prompts/**': true,
-					'**/my-prompts/': true,
-					'.github/prompts/nested/specific.prompt.md': true,
-					// '.github/prompts/nested/unspecific*.prompt.md': true,
-					// '.github/prompts/nested/unspecific': true,
-					'.github/prompts/nested/unspecific*': true,
-					// '.github/prompts/nested/unspecific*-prompt': true,
-					// '.github/prompts/nested/*unspecific*-prompt': true,
-					// '.github/prompts/nested/*.prompt.md': true,
-					// '.github/**/nested/*.prompt.md': true,
-					// '.github/prompts/**/*.prompt.md': true,
+					'/Users/legomushroom/repos/prompts': true,
+					'/tmp/prompts/': true,
+					'/absolute/path/prompts': false,
+					'.copilot/prompts': true,
 				},
 				[
 					'/Users/legomushroom/repos/vscode',
@@ -425,15 +757,88 @@ suite('PromptFilesLocator', () => {
 										name: 'default.prompt.md',
 										contents: 'oh hi, robot!',
 									},
+								],
+							},
+							{
+								name: '.github/prompts',
+								children: [
 									{
-										name: 'misc',
-										children: [
-											{
-												name: 'child.prompt.md',
-												contents: 'contents',
-											},
-										],
-									}
+										name: 'my.prompt.md',
+										contents: 'oh hi, bot!',
+									},
+								],
+							},
+						],
+					},
+				]);
+
+			assert.deepStrictEqual(
+				await locator.listFiles(),
+				[
+					createURI('/Users/legomushroom/repos/vscode/.github/prompts/my.prompt.md'),
+					createURI('/Users/legomushroom/repos/prompts/test.prompt.md'),
+					createURI('/Users/legomushroom/repos/prompts/refactor-tests.prompt.md'),
+					createURI('/tmp/prompts/translate.to-rust.prompt.md'),
+					createURI('/Users/legomushroom/repos/vscode/.copilot/prompts/default.prompt.md'),
+				],
+				'Must find correct prompts.',
+			);
+		});
+
+		test('• with disabled `.github/prompts` location', async () => {
+			const locator = await createPromptsLocator(
+				{
+					'/Users/legomushroom/repos/prompts': true,
+					'/tmp/prompts/': true,
+					'/absolute/path/prompts': false,
+					'.copilot/prompts': true,
+					'.github/prompts': false,
+				},
+				[
+					'/Users/legomushroom/repos/vscode',
+				],
+				[
+					{
+						name: '/Users/legomushroom/repos/prompts',
+						children: [
+							{
+								name: 'test.prompt.md',
+								contents: 'Hello, World!',
+							},
+							{
+								name: 'refactor-tests.prompt.md',
+								contents: 'some file content goes here',
+							},
+						],
+					},
+					{
+						name: '/tmp/prompts',
+						children: [
+							{
+								name: 'translate.to-rust.prompt.md',
+								contents: 'some more random file contents',
+							},
+						],
+					},
+					{
+						name: '/absolute/path/prompts',
+						children: [
+							{
+								name: 'some-prompt-file.prompt.md',
+								contents: 'hey hey hey',
+							},
+						],
+					},
+					{
+						name: '/Users/legomushroom/repos/vscode',
+						children: [
+							{
+								name: '.copilot/prompts',
+								children: [
+									{
+										name: 'default.prompt.md',
+										contents: 'oh hi, robot!',
+									},
 								],
 							},
 							{
@@ -444,49 +849,8 @@ suite('PromptFilesLocator', () => {
 										contents: 'oh hi, bot!',
 									},
 									{
-										name: 'nested',
-										children: [
-											{
-												name: 'specific.prompt.md',
-												contents: 'oh hi, bot!',
-											},
-											{
-												name: 'unspecific1',
-												children: [
-													{
-														name: 'file.prompt.md',
-														contents: 'oh hi, bot!',
-													},
-												],
-											},
-											{
-												name: 'unspecific2',
-												children: [
-													{
-														name: 'file.prompt.md',
-														contents: 'oh hi, bot!',
-													},
-												],
-											},
-										],
-									}
-								],
-							},
-							{
-								name: 'deps/text',
-								children: [
-									{
-										name: 'my.prompt.md',
+										name: 'your.prompt.md',
 										contents: 'oh hi, bot!',
-									},
-									{
-										name: 'my-prompts',
-										children: [
-											{
-												name: 'your.prompt.md',
-												contents: 'oh hi, bot!',
-											},
-										],
 									},
 								],
 							},
@@ -495,188 +859,16 @@ suite('PromptFilesLocator', () => {
 				]);
 
 			assert.deepStrictEqual(
-				(await locator.findAllMatchingPromptFiles())
-					.map((file) => file.fsPath),
+				await locator.listFiles(),
 				[
-					// createURI('/Users/legomushroom/repos/vscode/.github/prompts/my.prompt.md'),
-					// createURI('/Users/legomushroom/repos/prompts/test.prompt.md'),
-					// createURI('/Users/legomushroom/repos/prompts/refactor-tests.prompt.md'),
-					createURI('/Users/legomushroom/repos/vscode/.copilot/prompts/default.prompt.md').fsPath,
-					createURI('/Users/legomushroom/repos/vscode/.copilot/prompts/misc/child.prompt.md').fsPath,
-					createURI('/Users/legomushroom/repos/vscode/deps/text/my-prompts/your.prompt.md').fsPath,
-					createURI('/Users/legomushroom/repos/vscode/.github/prompts/nested/specific.prompt.md').fsPath,
-					createURI('/Users/legomushroom/repos/vscode/.github/prompts/nested/unspecific1/file.prompt.md').fsPath,
-					createURI('/Users/legomushroom/repos/vscode/.github/prompts/nested/unspecific2/file.prompt.md').fsPath,
+					createURI('/Users/legomushroom/repos/prompts/test.prompt.md'),
+					createURI('/Users/legomushroom/repos/prompts/refactor-tests.prompt.md'),
+					createURI('/tmp/prompts/translate.to-rust.prompt.md'),
+					createURI('/Users/legomushroom/repos/vscode/.copilot/prompts/default.prompt.md'),
 				],
 				'Must find correct prompts.',
 			);
 		});
-
-		// test('• core logic', async () => {
-		// 	const locator = await createPromptsLocator(
-		// 		{
-		// 			'/Users/legomushroom/repos/prompts': true,
-		// 			'/tmp/prompts/': true,
-		// 			'/absolute/path/prompts': false,
-		// 			'.copilot/prompts': true,
-		// 		},
-		// 		[
-		// 			'/Users/legomushroom/repos/vscode',
-		// 		],
-		// 		[
-		// 			{
-		// 				name: '/Users/legomushroom/repos/prompts',
-		// 				children: [
-		// 					{
-		// 						name: 'test.prompt.md',
-		// 						contents: 'Hello, World!',
-		// 					},
-		// 					{
-		// 						name: 'refactor-tests.prompt.md',
-		// 						contents: 'some file content goes here',
-		// 					},
-		// 				],
-		// 			},
-		// 			{
-		// 				name: '/tmp/prompts',
-		// 				children: [
-		// 					{
-		// 						name: 'translate.to-rust.prompt.md',
-		// 						contents: 'some more random file contents',
-		// 					},
-		// 				],
-		// 			},
-		// 			{
-		// 				name: '/absolute/path/prompts',
-		// 				children: [
-		// 					{
-		// 						name: 'some-prompt-file.prompt.md',
-		// 						contents: 'hey hey hey',
-		// 					},
-		// 				],
-		// 			},
-		// 			{
-		// 				name: '/Users/legomushroom/repos/vscode',
-		// 				children: [
-		// 					{
-		// 						name: '.copilot/prompts',
-		// 						children: [
-		// 							{
-		// 								name: 'default.prompt.md',
-		// 								contents: 'oh hi, robot!',
-		// 							},
-		// 						],
-		// 					},
-		// 					{
-		// 						name: '.github/prompts',
-		// 						children: [
-		// 							{
-		// 								name: 'my.prompt.md',
-		// 								contents: 'oh hi, bot!',
-		// 							},
-		// 						],
-		// 					},
-		// 				],
-		// 			},
-		// 		]);
-
-		// 	assert.deepStrictEqual(
-		// 		await locator.listFiles(),
-		// 		[
-		// 			createURI('/Users/legomushroom/repos/vscode/.github/prompts/my.prompt.md'),
-		// 			createURI('/Users/legomushroom/repos/prompts/test.prompt.md'),
-		// 			createURI('/Users/legomushroom/repos/prompts/refactor-tests.prompt.md'),
-		// 			createURI('/tmp/prompts/translate.to-rust.prompt.md'),
-		// 			createURI('/Users/legomushroom/repos/vscode/.copilot/prompts/default.prompt.md'),
-		// 		],
-		// 		'Must find correct prompts.',
-		// 	);
-		// });
-
-		// test('• with disabled `.github/prompts` location', async () => {
-		// 	const locator = await createPromptsLocator(
-		// 		{
-		// 			'/Users/legomushroom/repos/prompts': true,
-		// 			'/tmp/prompts/': true,
-		// 			'/absolute/path/prompts': false,
-		// 			'.copilot/prompts': true,
-		// 			'.github/prompts': false,
-		// 		},
-		// 		[
-		// 			'/Users/legomushroom/repos/vscode',
-		// 		],
-		// 		[
-		// 			{
-		// 				name: '/Users/legomushroom/repos/prompts',
-		// 				children: [
-		// 					{
-		// 						name: 'test.prompt.md',
-		// 						contents: 'Hello, World!',
-		// 					},
-		// 					{
-		// 						name: 'refactor-tests.prompt.md',
-		// 						contents: 'some file content goes here',
-		// 					},
-		// 				],
-		// 			},
-		// 			{
-		// 				name: '/tmp/prompts',
-		// 				children: [
-		// 					{
-		// 						name: 'translate.to-rust.prompt.md',
-		// 						contents: 'some more random file contents',
-		// 					},
-		// 				],
-		// 			},
-		// 			{
-		// 				name: '/absolute/path/prompts',
-		// 				children: [
-		// 					{
-		// 						name: 'some-prompt-file.prompt.md',
-		// 						contents: 'hey hey hey',
-		// 					},
-		// 				],
-		// 			},
-		// 			{
-		// 				name: '/Users/legomushroom/repos/vscode',
-		// 				children: [
-		// 					{
-		// 						name: '.copilot/prompts',
-		// 						children: [
-		// 							{
-		// 								name: 'default.prompt.md',
-		// 								contents: 'oh hi, robot!',
-		// 							},
-		// 						],
-		// 					},
-		// 					{
-		// 						name: '.github/prompts',
-		// 						children: [
-		// 							{
-		// 								name: 'my.prompt.md',
-		// 								contents: 'oh hi, bot!',
-		// 							},
-		// 							{
-		// 								name: 'your.prompt.md',
-		// 								contents: 'oh hi, bot!',
-		// 							},
-		// 						],
-		// 					},
-		// 				],
-		// 			},
-		// 		]);
-
-		// 	assert.deepStrictEqual(
-		// 		await locator.listFiles(),
-		// 		[
-		// 			createURI('/Users/legomushroom/repos/prompts/test.prompt.md'),
-		// 			createURI('/Users/legomushroom/repos/prompts/refactor-tests.prompt.md'),
-		// 			createURI('/tmp/prompts/translate.to-rust.prompt.md'),
-		// 			createURI('/Users/legomushroom/repos/vscode/.copilot/prompts/default.prompt.md'),
-		// 		],
-		// 		'Must find correct prompts.',
-		// 	);
-		// });
 	});
 
 	// suite('• multi-root workspace', () => {

--- a/src/vs/workbench/contrib/chat/test/common/promptSyntax/utils/promptFilesLocator.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/promptSyntax/utils/promptFilesLocator.test.ts
@@ -23,7 +23,6 @@ import { IWorkspace, IWorkspaceContextService, IWorkspaceFolder } from '../../..
 
 /**
  * TODO: @lego - list
- *  - add `empty workspace` unit tests
  *  - add `all together` unit tests
  */
 
@@ -225,6 +224,246 @@ suite('PromptFilesLocator', () => {
 					],
 					'Must find correct prompts.',
 				);
+			});
+
+			suite('• absolute', () => {
+				suite('• wild card', () => {
+					const settings = [
+						'/Users/legomushroom/repos/vscode/**',
+						'/Users/legomushroom/repos/vscode/**/*.prompt.md',
+						'/Users/legomushroom/repos/vscode/**/*.md',
+						'/Users/legomushroom/repos/vscode/**/*',
+						'/Users/legomushroom/repos/vscode/deps/**',
+						'/Users/legomushroom/repos/vscode/deps/**/*.prompt.md',
+						'/Users/legomushroom/repos/vscode/deps/**/*',
+						'/Users/legomushroom/repos/vscode/deps/**/*.md',
+						'/Users/legomushroom/repos/vscode/**/text/**',
+						'/Users/legomushroom/repos/vscode/**/text/**/*',
+						'/Users/legomushroom/repos/vscode/**/text/**/*.md',
+						'/Users/legomushroom/repos/vscode/**/text/**/*.prompt.md',
+						'/Users/legomushroom/repos/vscode/deps/text/**',
+						'/Users/legomushroom/repos/vscode/deps/text/**/*',
+						'/Users/legomushroom/repos/vscode/deps/text/**/*.md',
+						'/Users/legomushroom/repos/vscode/deps/text/**/*.prompt.md',
+					];
+
+					for (const setting of settings) {
+						test(`• '${setting}'`, async () => {
+							const locator = await createPromptsLocator(
+								{ [setting]: true },
+								EMPTY_WORKSPACE,
+								[
+									{
+										name: '/Users/legomushroom/repos/vscode',
+										children: [
+											{
+												name: 'deps/text',
+												children: [
+													{
+														name: 'my.prompt.md',
+														contents: 'oh hi, bot!',
+													},
+													{
+														name: 'nested',
+														children: [
+															{
+																name: 'specific.prompt.md',
+																contents: 'oh hi, bot!',
+															},
+															{
+																name: 'unspecific1.prompt.md',
+																contents: 'oh hi, robot!',
+															},
+															{
+																name: 'unspecific2.prompt.md',
+																contents: 'oh hi, rabot!',
+															},
+															{
+																name: 'readme.md',
+																contents: 'non prompt file',
+															},
+														],
+													}
+												],
+											},
+										],
+									},
+								],
+							);
+
+							assert.deepStrictEqual(
+								(await locator.listFiles())
+									.map((file) => file.fsPath),
+								[
+									createURI('/Users/legomushroom/repos/vscode/deps/text/my.prompt.md').fsPath,
+									createURI('/Users/legomushroom/repos/vscode/deps/text/nested/specific.prompt.md').fsPath,
+									createURI('/Users/legomushroom/repos/vscode/deps/text/nested/unspecific1.prompt.md').fsPath,
+									createURI('/Users/legomushroom/repos/vscode/deps/text/nested/unspecific2.prompt.md').fsPath,
+								],
+								'Must find correct prompts.',
+							);
+						});
+					}
+				});
+
+				suite(`• specific`, () => {
+					const testSettings = [
+						[
+							'/Users/legomushroom/repos/vscode/**/*specific*',
+						],
+						[
+							'/Users/legomushroom/repos/vscode/**/*specific*.prompt.md',
+						],
+						[
+							'/Users/legomushroom/repos/vscode/**/*specific*.md',
+						],
+						[
+							'/Users/legomushroom/repos/vscode/**/specific*',
+							'/Users/legomushroom/repos/vscode/**/unspecific1.prompt.md',
+							'/Users/legomushroom/repos/vscode/**/unspecific2.prompt.md',
+						],
+						[
+							'/Users/legomushroom/repos/vscode/**/specific.prompt.md',
+							'/Users/legomushroom/repos/vscode/**/unspecific*.prompt.md',
+						],
+						[
+							'/Users/legomushroom/repos/vscode/**/nested/specific.prompt.md',
+							'/Users/legomushroom/repos/vscode/**/nested/unspecific*.prompt.md',
+						],
+						[
+							'/Users/legomushroom/repos/vscode/**/nested/*specific*',
+						],
+						[
+							'/Users/legomushroom/repos/vscode/**/*spec*.prompt.md',
+						],
+						[
+							'/Users/legomushroom/repos/vscode/**/*spec*',
+						],
+						[
+							'/Users/legomushroom/repos/vscode/**/*spec*.md',
+						],
+						[
+							'/Users/legomushroom/repos/vscode/**/deps/**/*spec*.md',
+						],
+						[
+							'/Users/legomushroom/repos/vscode/**/text/**/*spec*.md',
+						],
+						[
+							'/Users/legomushroom/repos/vscode/deps/text/nested/*spec*',
+						],
+						[
+							'/Users/legomushroom/repos/vscode/deps/text/nested/*specific*',
+						],
+						[
+							'/Users/legomushroom/repos/vscode/deps/**/*specific*',
+						],
+						[
+							'/Users/legomushroom/repos/vscode/deps/**/specific*',
+							'/Users/legomushroom/repos/vscode/deps/**/unspecific*.prompt.md',
+						],
+						[
+							'/Users/legomushroom/repos/vscode/deps/**/specific*.md',
+							'/Users/legomushroom/repos/vscode/deps/**/unspecific*.md',
+						],
+						[
+							'/Users/legomushroom/repos/vscode/deps/**/specific.prompt.md',
+							'/Users/legomushroom/repos/vscode/deps/**/unspecific1.prompt.md',
+							'/Users/legomushroom/repos/vscode/deps/**/unspecific2.prompt.md',
+						],
+						[
+							'/Users/legomushroom/repos/vscode/deps/**/specific.prompt.md',
+							'/Users/legomushroom/repos/vscode/deps/**/unspecific1*.md',
+							'/Users/legomushroom/repos/vscode/deps/**/unspecific2*.md',
+						],
+						[
+							'/Users/legomushroom/repos/vscode/deps/text/**/*specific*',
+						],
+						[
+							'/Users/legomushroom/repos/vscode/deps/text/**/specific*',
+							'/Users/legomushroom/repos/vscode/deps/text/**/unspecific*.prompt.md',
+						],
+						[
+							'/Users/legomushroom/repos/vscode/deps/text/**/specific*.md',
+							'/Users/legomushroom/repos/vscode/deps/text/**/unspecific*.md',
+						],
+						[
+							'/Users/legomushroom/repos/vscode/deps/text/**/specific.prompt.md',
+							'/Users/legomushroom/repos/vscode/deps/text/**/unspecific1.prompt.md',
+							'/Users/legomushroom/repos/vscode/deps/text/**/unspecific2.prompt.md',
+						],
+						[
+							'/Users/legomushroom/repos/vscode/deps/text/**/specific.prompt.md',
+							'/Users/legomushroom/repos/vscode/deps/text/**/unspecific1*.md',
+							'/Users/legomushroom/repos/vscode/deps/text/**/unspecific2*.md',
+						],
+					];
+
+					for (const settings of testSettings) {
+						test(`• '${JSON.stringify(settings)}'`, async () => {
+							const vscodeSettings: Record<string, boolean> = {};
+							for (const setting of settings) {
+								vscodeSettings[setting] = true;
+							}
+
+							const locator = await createPromptsLocator(
+								vscodeSettings,
+								EMPTY_WORKSPACE,
+								[
+									{
+										name: '/Users/legomushroom/repos/vscode',
+										children: [
+											{
+												name: 'deps/text',
+												children: [
+													{
+														name: 'my.prompt.md',
+														contents: 'oh hi, bot!',
+													},
+													{
+														name: 'nested',
+														children: [
+															{
+																name: 'default.prompt.md',
+																contents: 'oh hi, bot!',
+															},
+															{
+																name: 'specific.prompt.md',
+																contents: 'oh hi, bot!',
+															},
+															{
+																name: 'unspecific1.prompt.md',
+																contents: 'oh hi, robot!',
+															},
+															{
+																name: 'unspecific2.prompt.md',
+																contents: 'oh hi, rawbot!',
+															},
+															{
+																name: 'readme.md',
+																contents: 'non prompt file',
+															},
+														],
+													}
+												],
+											},
+										],
+									},
+								],
+							);
+
+							assert.deepStrictEqual(
+								(await locator.listFiles())
+									.map((file) => file.fsPath),
+								[
+									createURI('/Users/legomushroom/repos/vscode/deps/text/nested/specific.prompt.md').fsPath,
+									createURI('/Users/legomushroom/repos/vscode/deps/text/nested/unspecific1.prompt.md').fsPath,
+									createURI('/Users/legomushroom/repos/vscode/deps/text/nested/unspecific2.prompt.md').fsPath,
+								],
+								'Must find correct prompts.',
+							);
+						});
+					}
+				});
 			});
 		});
 	});

--- a/src/vs/workbench/contrib/chat/test/common/promptSyntax/utils/promptFilesLocator.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/promptSyntax/utils/promptFilesLocator.test.ts
@@ -220,152 +220,268 @@ suite('PromptFilesLocator', () => {
 	});
 
 	suite('• single-root workspace', () => {
-		suite('• non-empty filesystem', () => {
-			suite('• object config value', () => {
-				test('• core logic', async () => {
-					const locator = await createPromptsLocator(
+		suite('• findAllMatchingPromptFiles', () => {
+			test('• relative glob pattern', async () => {
+				const locator = await createPromptsLocator(
+					{
+						'.github/prompts': false,
+						'/Users/legomushroom/repos/prompts': false,
+						// -
+						'.copilot/prompts/**': true,
+						'**/my-prompts/': true,
+						'.github/prompts/nested/specific.prompt.md': true,
+						'.github/prompts/nested/unspecific*.prompt.md': true,
+						// '.github/prompts/nested/unspecific': true,
+						// '.github/prompts/nested/unspecific*': true,
+						// '.github/prompts/nested/unspecific*-prompt': true,
+						// '.github/prompts/nested/*unspecific*-prompt': true,
+						// '.github/prompts/nested/*.prompt.md': true,
+						// '.github/**/nested/*.prompt.md': true,
+						// '.github/prompts/**/*.prompt.md': true,
+					},
+					[
+						'/Users/legomushroom/repos/vscode',
+					],
+					[
 						{
-							'/Users/legomushroom/repos/prompts': true,
-							'/tmp/prompts/': true,
-							'/absolute/path/prompts': false,
-							'.copilot/prompts': true,
+							name: '/Users/legomushroom/repos/prompts',
+							children: [
+								{
+									name: 'test.prompt.md',
+									contents: 'Hello, World!',
+								},
+								{
+									name: 'refactor-tests.prompt.md',
+									contents: 'some file content goes here',
+								},
+							],
 						},
-						[
-							'/Users/legomushroom/repos/vscode',
+						{
+							name: '/tmp/prompts',
+							children: [
+								{
+									name: 'translate.to-rust.prompt.md',
+									contents: 'some more random file contents',
+								},
+							],
+						},
+						{
+							name: '/absolute/path/prompts',
+							children: [
+								{
+									name: 'some-prompt-file.prompt.md',
+									contents: 'hey hey hey',
+								},
+							],
+						},
+						{
+							name: '/Users/legomushroom/repos/vscode',
+							children: [
+								{
+									name: '.copilot/prompts',
+									children: [
+										{
+											name: 'default.prompt.md',
+											contents: 'oh hi, robot!',
+										},
+										{
+											name: 'misc',
+											children: [
+												{
+													name: 'child.prompt.md',
+													contents: 'contents',
+												},
+											],
+										}
+									],
+								},
+								{
+									name: '.github/prompts',
+									children: [
+										{
+											name: 'my.prompt.md',
+											contents: 'oh hi, bot!',
+										},
+										{
+											name: 'nested',
+											children: [
+												{
+													name: 'specific.prompt.md',
+													contents: 'oh hi, bot!',
+												},
+												{
+													name: 'unspecific1.prompt.md',
+													contents: 'oh hi, bot!',
+												},
+												{
+													name: 'unspecific2.prompt.md',
+													contents: 'oh hi, bot!',
+												},
+											],
+										}
+									],
+								},
+								{
+									name: 'deps/text',
+									children: [
+										{
+											name: 'my.prompt.md',
+											contents: 'oh hi, bot!',
+										},
+										{
+											name: 'my-prompts',
+											children: [
+												{
+													name: 'your.prompt.md',
+													contents: 'oh hi, bot!',
+												},
+											],
+										},
+									],
+								},
+							],
+						},
+					]);
+
+				assert.deepStrictEqual(
+					(await locator.findAllMatchingPromptFiles())
+						.map((file) => file.fsPath),
+					[
+						// createURI('/Users/legomushroom/repos/vscode/.github/prompts/my.prompt.md'),
+						// createURI('/Users/legomushroom/repos/prompts/test.prompt.md'),
+						// createURI('/Users/legomushroom/repos/prompts/refactor-tests.prompt.md'),
+						createURI('/Users/legomushroom/repos/vscode/.copilot/prompts/default.prompt.md').fsPath,
+						createURI('/Users/legomushroom/repos/vscode/.copilot/prompts/misc/child.prompt.md').fsPath,
+						createURI('/Users/legomushroom/repos/vscode/deps/text/my-prompts/your.prompt.md').fsPath,
+						createURI('/Users/legomushroom/repos/vscode/.github/prompts/nested/specific.prompt.md').fsPath,
+						createURI('/Users/legomushroom/repos/vscode/.github/prompts/nested/unspecific1.prompt.md').fsPath,
+						createURI('/Users/legomushroom/repos/vscode/.github/prompts/nested/unspecific2.prompt.md').fsPath,
+					],
+					'Must find correct prompts.',
+				);
+			});
+		});
+
+		test('• relative glob pattern #2', async () => {
+			const locator = await createPromptsLocator(
+				{
+					'.github/prompts': false,
+					'/Users/legomushroom/repos/prompts': false,
+					// -
+					'.copilot/prompts/**': true,
+					'**/my-prompts/': true,
+					'.github/prompts/nested/specific.prompt.md': true,
+					// '.github/prompts/nested/unspecific*.prompt.md': true,
+					// '.github/prompts/nested/unspecific': true,
+					'.github/prompts/nested/unspecific*': true,
+					// '.github/prompts/nested/unspecific*-prompt': true,
+					// '.github/prompts/nested/*unspecific*-prompt': true,
+					// '.github/prompts/nested/*.prompt.md': true,
+					// '.github/**/nested/*.prompt.md': true,
+					// '.github/prompts/**/*.prompt.md': true,
+				},
+				[
+					'/Users/legomushroom/repos/vscode',
+				],
+				[
+					{
+						name: '/Users/legomushroom/repos/prompts',
+						children: [
+							{
+								name: 'test.prompt.md',
+								contents: 'Hello, World!',
+							},
+							{
+								name: 'refactor-tests.prompt.md',
+								contents: 'some file content goes here',
+							},
 						],
-						[
+					},
+					{
+						name: '/tmp/prompts',
+						children: [
 							{
-								name: '/Users/legomushroom/repos/prompts',
-								children: [
-									{
-										name: 'test.prompt.md',
-										contents: 'Hello, World!',
-									},
-									{
-										name: 'refactor-tests.prompt.md',
-										contents: 'some file content goes here',
-									},
-								],
+								name: 'translate.to-rust.prompt.md',
+								contents: 'some more random file contents',
 							},
+						],
+					},
+					{
+						name: '/absolute/path/prompts',
+						children: [
 							{
-								name: '/tmp/prompts',
-								children: [
-									{
-										name: 'translate.to-rust.prompt.md',
-										contents: 'some more random file contents',
-									},
-								],
+								name: 'some-prompt-file.prompt.md',
+								contents: 'hey hey hey',
 							},
+						],
+					},
+					{
+						name: '/Users/legomushroom/repos/vscode',
+						children: [
 							{
-								name: '/absolute/path/prompts',
+								name: '.copilot/prompts',
 								children: [
 									{
-										name: 'some-prompt-file.prompt.md',
-										contents: 'hey hey hey',
+										name: 'default.prompt.md',
+										contents: 'oh hi, robot!',
 									},
-								],
-							},
-							{
-								name: '/Users/legomushroom/repos/vscode',
-								children: [
 									{
-										name: '.copilot/prompts',
+										name: 'misc',
 										children: [
 											{
-												name: 'default.prompt.md',
-												contents: 'oh hi, robot!',
+												name: 'child.prompt.md',
+												contents: 'contents',
 											},
 										],
+									}
+								],
+							},
+							{
+								name: '.github/prompts',
+								children: [
+									{
+										name: 'my.prompt.md',
+										contents: 'oh hi, bot!',
 									},
 									{
-										name: '.github/prompts',
+										name: 'nested',
 										children: [
 											{
-												name: 'my.prompt.md',
+												name: 'specific.prompt.md',
 												contents: 'oh hi, bot!',
 											},
-										],
-									},
-								],
-							},
-						]);
-
-					assert.deepStrictEqual(
-						await locator.listFiles(),
-						[
-							createURI('/Users/legomushroom/repos/vscode/.github/prompts/my.prompt.md'),
-							createURI('/Users/legomushroom/repos/prompts/test.prompt.md'),
-							createURI('/Users/legomushroom/repos/prompts/refactor-tests.prompt.md'),
-							createURI('/tmp/prompts/translate.to-rust.prompt.md'),
-							createURI('/Users/legomushroom/repos/vscode/.copilot/prompts/default.prompt.md'),
-						],
-						'Must find correct prompts.',
-					);
-				});
-
-				test('• with disabled `.github/prompts` location', async () => {
-					const locator = await createPromptsLocator(
-						{
-							'/Users/legomushroom/repos/prompts': true,
-							'/tmp/prompts/': true,
-							'/absolute/path/prompts': false,
-							'.copilot/prompts': true,
-							'.github/prompts': false,
-						},
-						[
-							'/Users/legomushroom/repos/vscode',
-						],
-						[
-							{
-								name: '/Users/legomushroom/repos/prompts',
-								children: [
-									{
-										name: 'test.prompt.md',
-										contents: 'Hello, World!',
-									},
-									{
-										name: 'refactor-tests.prompt.md',
-										contents: 'some file content goes here',
-									},
-								],
-							},
-							{
-								name: '/tmp/prompts',
-								children: [
-									{
-										name: 'translate.to-rust.prompt.md',
-										contents: 'some more random file contents',
-									},
-								],
-							},
-							{
-								name: '/absolute/path/prompts',
-								children: [
-									{
-										name: 'some-prompt-file.prompt.md',
-										contents: 'hey hey hey',
-									},
-								],
-							},
-							{
-								name: '/Users/legomushroom/repos/vscode',
-								children: [
-									{
-										name: '.copilot/prompts',
-										children: [
 											{
-												name: 'default.prompt.md',
-												contents: 'oh hi, robot!',
+												name: 'unspecific1',
+												children: [
+													{
+														name: 'file.prompt.md',
+														contents: 'oh hi, bot!',
+													},
+												],
+											},
+											{
+												name: 'unspecific2',
+												children: [
+													{
+														name: 'file.prompt.md',
+														contents: 'oh hi, bot!',
+													},
+												],
 											},
 										],
+									}
+								],
+							},
+							{
+								name: 'deps/text',
+								children: [
+									{
+										name: 'my.prompt.md',
+										contents: 'oh hi, bot!',
 									},
 									{
-										name: '.github/prompts',
+										name: 'my-prompts',
 										children: [
-											{
-												name: 'my.prompt.md',
-												contents: 'oh hi, bot!',
-											},
 											{
 												name: 'your.prompt.md',
 												contents: 'oh hi, bot!',
@@ -374,386 +490,558 @@ suite('PromptFilesLocator', () => {
 									},
 								],
 							},
-						]);
-
-					assert.deepStrictEqual(
-						await locator.listFiles(),
-						[
-							createURI('/Users/legomushroom/repos/prompts/test.prompt.md'),
-							createURI('/Users/legomushroom/repos/prompts/refactor-tests.prompt.md'),
-							createURI('/tmp/prompts/translate.to-rust.prompt.md'),
-							createURI('/Users/legomushroom/repos/vscode/.copilot/prompts/default.prompt.md'),
 						],
-						'Must find correct prompts.',
-					);
-				});
-			});
+					},
+				]);
+
+			assert.deepStrictEqual(
+				(await locator.findAllMatchingPromptFiles())
+					.map((file) => file.fsPath),
+				[
+					// createURI('/Users/legomushroom/repos/vscode/.github/prompts/my.prompt.md'),
+					// createURI('/Users/legomushroom/repos/prompts/test.prompt.md'),
+					// createURI('/Users/legomushroom/repos/prompts/refactor-tests.prompt.md'),
+					createURI('/Users/legomushroom/repos/vscode/.copilot/prompts/default.prompt.md').fsPath,
+					createURI('/Users/legomushroom/repos/vscode/.copilot/prompts/misc/child.prompt.md').fsPath,
+					createURI('/Users/legomushroom/repos/vscode/deps/text/my-prompts/your.prompt.md').fsPath,
+					createURI('/Users/legomushroom/repos/vscode/.github/prompts/nested/specific.prompt.md').fsPath,
+					createURI('/Users/legomushroom/repos/vscode/.github/prompts/nested/unspecific1/file.prompt.md').fsPath,
+					createURI('/Users/legomushroom/repos/vscode/.github/prompts/nested/unspecific2/file.prompt.md').fsPath,
+				],
+				'Must find correct prompts.',
+			);
 		});
+
+		// test('• core logic', async () => {
+		// 	const locator = await createPromptsLocator(
+		// 		{
+		// 			'/Users/legomushroom/repos/prompts': true,
+		// 			'/tmp/prompts/': true,
+		// 			'/absolute/path/prompts': false,
+		// 			'.copilot/prompts': true,
+		// 		},
+		// 		[
+		// 			'/Users/legomushroom/repos/vscode',
+		// 		],
+		// 		[
+		// 			{
+		// 				name: '/Users/legomushroom/repos/prompts',
+		// 				children: [
+		// 					{
+		// 						name: 'test.prompt.md',
+		// 						contents: 'Hello, World!',
+		// 					},
+		// 					{
+		// 						name: 'refactor-tests.prompt.md',
+		// 						contents: 'some file content goes here',
+		// 					},
+		// 				],
+		// 			},
+		// 			{
+		// 				name: '/tmp/prompts',
+		// 				children: [
+		// 					{
+		// 						name: 'translate.to-rust.prompt.md',
+		// 						contents: 'some more random file contents',
+		// 					},
+		// 				],
+		// 			},
+		// 			{
+		// 				name: '/absolute/path/prompts',
+		// 				children: [
+		// 					{
+		// 						name: 'some-prompt-file.prompt.md',
+		// 						contents: 'hey hey hey',
+		// 					},
+		// 				],
+		// 			},
+		// 			{
+		// 				name: '/Users/legomushroom/repos/vscode',
+		// 				children: [
+		// 					{
+		// 						name: '.copilot/prompts',
+		// 						children: [
+		// 							{
+		// 								name: 'default.prompt.md',
+		// 								contents: 'oh hi, robot!',
+		// 							},
+		// 						],
+		// 					},
+		// 					{
+		// 						name: '.github/prompts',
+		// 						children: [
+		// 							{
+		// 								name: 'my.prompt.md',
+		// 								contents: 'oh hi, bot!',
+		// 							},
+		// 						],
+		// 					},
+		// 				],
+		// 			},
+		// 		]);
+
+		// 	assert.deepStrictEqual(
+		// 		await locator.listFiles(),
+		// 		[
+		// 			createURI('/Users/legomushroom/repos/vscode/.github/prompts/my.prompt.md'),
+		// 			createURI('/Users/legomushroom/repos/prompts/test.prompt.md'),
+		// 			createURI('/Users/legomushroom/repos/prompts/refactor-tests.prompt.md'),
+		// 			createURI('/tmp/prompts/translate.to-rust.prompt.md'),
+		// 			createURI('/Users/legomushroom/repos/vscode/.copilot/prompts/default.prompt.md'),
+		// 		],
+		// 		'Must find correct prompts.',
+		// 	);
+		// });
+
+		// test('• with disabled `.github/prompts` location', async () => {
+		// 	const locator = await createPromptsLocator(
+		// 		{
+		// 			'/Users/legomushroom/repos/prompts': true,
+		// 			'/tmp/prompts/': true,
+		// 			'/absolute/path/prompts': false,
+		// 			'.copilot/prompts': true,
+		// 			'.github/prompts': false,
+		// 		},
+		// 		[
+		// 			'/Users/legomushroom/repos/vscode',
+		// 		],
+		// 		[
+		// 			{
+		// 				name: '/Users/legomushroom/repos/prompts',
+		// 				children: [
+		// 					{
+		// 						name: 'test.prompt.md',
+		// 						contents: 'Hello, World!',
+		// 					},
+		// 					{
+		// 						name: 'refactor-tests.prompt.md',
+		// 						contents: 'some file content goes here',
+		// 					},
+		// 				],
+		// 			},
+		// 			{
+		// 				name: '/tmp/prompts',
+		// 				children: [
+		// 					{
+		// 						name: 'translate.to-rust.prompt.md',
+		// 						contents: 'some more random file contents',
+		// 					},
+		// 				],
+		// 			},
+		// 			{
+		// 				name: '/absolute/path/prompts',
+		// 				children: [
+		// 					{
+		// 						name: 'some-prompt-file.prompt.md',
+		// 						contents: 'hey hey hey',
+		// 					},
+		// 				],
+		// 			},
+		// 			{
+		// 				name: '/Users/legomushroom/repos/vscode',
+		// 				children: [
+		// 					{
+		// 						name: '.copilot/prompts',
+		// 						children: [
+		// 							{
+		// 								name: 'default.prompt.md',
+		// 								contents: 'oh hi, robot!',
+		// 							},
+		// 						],
+		// 					},
+		// 					{
+		// 						name: '.github/prompts',
+		// 						children: [
+		// 							{
+		// 								name: 'my.prompt.md',
+		// 								contents: 'oh hi, bot!',
+		// 							},
+		// 							{
+		// 								name: 'your.prompt.md',
+		// 								contents: 'oh hi, bot!',
+		// 							},
+		// 						],
+		// 					},
+		// 				],
+		// 			},
+		// 		]);
+
+		// 	assert.deepStrictEqual(
+		// 		await locator.listFiles(),
+		// 		[
+		// 			createURI('/Users/legomushroom/repos/prompts/test.prompt.md'),
+		// 			createURI('/Users/legomushroom/repos/prompts/refactor-tests.prompt.md'),
+		// 			createURI('/tmp/prompts/translate.to-rust.prompt.md'),
+		// 			createURI('/Users/legomushroom/repos/vscode/.copilot/prompts/default.prompt.md'),
+		// 		],
+		// 		'Must find correct prompts.',
+		// 	);
+		// });
 	});
 
-	suite('• multi-root workspace', () => {
-		suite('• non-empty filesystem', () => {
-			suite('• object config value', () => {
-				test('• without top-level `.github` folder', async () => {
-					const locator = await createPromptsLocator(
-						{
-							'/Users/legomushroom/repos/prompts': true,
-							'/tmp/prompts/': true,
-							'/absolute/path/prompts': false,
-							'.copilot/prompts': false,
-						},
-						[
-							'/Users/legomushroom/repos/vscode',
-							'/Users/legomushroom/repos/node',
-						],
-						[
-							{
-								name: '/Users/legomushroom/repos/prompts',
-								children: [
-									{
-										name: 'test.prompt.md',
-										contents: 'Hello, World!',
-									},
-									{
-										name: 'refactor-tests.prompt.md',
-										contents: 'some file content goes here',
-									},
-								],
-							},
-							{
-								name: '/tmp/prompts',
-								children: [
-									{
-										name: 'translate.to-rust.prompt.md',
-										contents: 'some more random file contents',
-									},
-								],
-							},
-							{
-								name: '/absolute/path/prompts',
-								children: [
-									{
-										name: 'some-prompt-file.prompt.md',
-										contents: 'hey hey hey',
-									},
-								],
-							},
-							{
-								name: '/Users/legomushroom/repos/vscode',
-								children: [
-									{
-										name: '.copilot/prompts',
-										children: [
-											{
-												name: 'prompt1.prompt.md',
-												contents: 'oh hi, robot!',
-											},
-										],
-									},
-									{
-										name: '.github/prompts',
-										children: [
-											{
-												name: 'default.prompt.md',
-												contents: 'oh hi, bot!',
-											},
-										],
-									},
-								],
-							},
-							{
-								name: '/Users/legomushroom/repos/node',
-								children: [
-									{
-										name: '.copilot/prompts',
-										children: [
-											{
-												name: 'prompt5.prompt.md',
-												contents: 'oh hi, robot!',
-											},
-										],
-									},
-									{
-										name: '.github/prompts',
-										children: [
-											{
-												name: 'refactor-static-classes.prompt.md',
-												contents: 'file contents',
-											},
-										],
-									},
-								],
-							},
-							// note! this folder is not part of the workspace, so prompt files are `ignored`
-							{
-								name: '/Users/legomushroom/repos/.github/prompts',
-								children: [
-									{
-										name: 'prompt-name.prompt.md',
-										contents: 'oh hi, robot!',
-									},
-									{
-										name: 'name-of-the-prompt.prompt.md',
-										contents: 'oh hi, raw bot!',
-									},
-								],
-							},
-						]);
+	// suite('• multi-root workspace', () => {
+	// 	suite('• non-empty filesystem', () => {
+	// 		suite('• object config value', () => {
+	// 			test('• without top-level `.github` folder', async () => {
+	// 				const locator = await createPromptsLocator(
+	// 					{
+	// 						'/Users/legomushroom/repos/prompts': true,
+	// 						'/tmp/prompts/': true,
+	// 						'/absolute/path/prompts': false,
+	// 						'.copilot/prompts': false,
+	// 					},
+	// 					[
+	// 						'/Users/legomushroom/repos/vscode',
+	// 						'/Users/legomushroom/repos/node',
+	// 					],
+	// 					[
+	// 						{
+	// 							name: '/Users/legomushroom/repos/prompts',
+	// 							children: [
+	// 								{
+	// 									name: 'test.prompt.md',
+	// 									contents: 'Hello, World!',
+	// 								},
+	// 								{
+	// 									name: 'refactor-tests.prompt.md',
+	// 									contents: 'some file content goes here',
+	// 								},
+	// 							],
+	// 						},
+	// 						{
+	// 							name: '/tmp/prompts',
+	// 							children: [
+	// 								{
+	// 									name: 'translate.to-rust.prompt.md',
+	// 									contents: 'some more random file contents',
+	// 								},
+	// 							],
+	// 						},
+	// 						{
+	// 							name: '/absolute/path/prompts',
+	// 							children: [
+	// 								{
+	// 									name: 'some-prompt-file.prompt.md',
+	// 									contents: 'hey hey hey',
+	// 								},
+	// 							],
+	// 						},
+	// 						{
+	// 							name: '/Users/legomushroom/repos/vscode',
+	// 							children: [
+	// 								{
+	// 									name: '.copilot/prompts',
+	// 									children: [
+	// 										{
+	// 											name: 'prompt1.prompt.md',
+	// 											contents: 'oh hi, robot!',
+	// 										},
+	// 									],
+	// 								},
+	// 								{
+	// 									name: '.github/prompts',
+	// 									children: [
+	// 										{
+	// 											name: 'default.prompt.md',
+	// 											contents: 'oh hi, bot!',
+	// 										},
+	// 									],
+	// 								},
+	// 							],
+	// 						},
+	// 						{
+	// 							name: '/Users/legomushroom/repos/node',
+	// 							children: [
+	// 								{
+	// 									name: '.copilot/prompts',
+	// 									children: [
+	// 										{
+	// 											name: 'prompt5.prompt.md',
+	// 											contents: 'oh hi, robot!',
+	// 										},
+	// 									],
+	// 								},
+	// 								{
+	// 									name: '.github/prompts',
+	// 									children: [
+	// 										{
+	// 											name: 'refactor-static-classes.prompt.md',
+	// 											contents: 'file contents',
+	// 										},
+	// 									],
+	// 								},
+	// 							],
+	// 						},
+	// 						// note! this folder is not part of the workspace, so prompt files are `ignored`
+	// 						{
+	// 							name: '/Users/legomushroom/repos/.github/prompts',
+	// 							children: [
+	// 								{
+	// 									name: 'prompt-name.prompt.md',
+	// 									contents: 'oh hi, robot!',
+	// 								},
+	// 								{
+	// 									name: 'name-of-the-prompt.prompt.md',
+	// 									contents: 'oh hi, raw bot!',
+	// 								},
+	// 							],
+	// 						},
+	// 					]);
 
-					assert.deepStrictEqual(
-						await locator.listFiles(),
-						[
-							createURI('/Users/legomushroom/repos/vscode/.github/prompts/default.prompt.md'),
-							createURI('/Users/legomushroom/repos/node/.github/prompts/refactor-static-classes.prompt.md'),
-							createURI('/Users/legomushroom/repos/prompts/test.prompt.md'),
-							createURI('/Users/legomushroom/repos/prompts/refactor-tests.prompt.md'),
-							createURI('/tmp/prompts/translate.to-rust.prompt.md'),
-						],
-						'Must find correct prompts.',
-					);
-				});
+	// 				assert.deepStrictEqual(
+	// 					await locator.listFiles(),
+	// 					[
+	// 						createURI('/Users/legomushroom/repos/vscode/.github/prompts/default.prompt.md'),
+	// 						createURI('/Users/legomushroom/repos/node/.github/prompts/refactor-static-classes.prompt.md'),
+	// 						createURI('/Users/legomushroom/repos/prompts/test.prompt.md'),
+	// 						createURI('/Users/legomushroom/repos/prompts/refactor-tests.prompt.md'),
+	// 						createURI('/tmp/prompts/translate.to-rust.prompt.md'),
+	// 					],
+	// 					'Must find correct prompts.',
+	// 				);
+	// 			});
 
-				test('• with top-level `.github` folder', async () => {
-					const locator = await createPromptsLocator(
-						{
-							'/Users/legomushroom/repos/prompts': true,
-							'/tmp/prompts/': true,
-							'/absolute/path/prompts': false,
-							'.copilot/prompts': false,
-						},
-						[
-							'/Users/legomushroom/repos/vscode',
-							'/Users/legomushroom/repos/node',
-							'/var/shared/prompts/.github',
-						],
-						[
-							{
-								name: '/Users/legomushroom/repos/prompts',
-								children: [
-									{
-										name: 'test.prompt.md',
-										contents: 'Hello, World!',
-									},
-									{
-										name: 'refactor-tests.prompt.md',
-										contents: 'some file content goes here',
-									},
-								],
-							},
-							{
-								name: '/tmp/prompts',
-								children: [
-									{
-										name: 'translate.to-rust.prompt.md',
-										contents: 'some more random file contents',
-									},
-								],
-							},
-							{
-								name: '/absolute/path/prompts',
-								children: [
-									{
-										name: 'some-prompt-file.prompt.md',
-										contents: 'hey hey hey',
-									},
-								],
-							},
-							{
-								name: '/Users/legomushroom/repos/vscode',
-								children: [
-									{
-										name: '.copilot/prompts',
-										children: [
-											{
-												name: 'prompt1.prompt.md',
-												contents: 'oh hi, robot!',
-											},
-										],
-									},
-									{
-										name: '.github/prompts',
-										children: [
-											{
-												name: 'default.prompt.md',
-												contents: 'oh hi, bot!',
-											},
-										],
-									},
-								],
-							},
-							{
-								name: '/Users/legomushroom/repos/node',
-								children: [
-									{
-										name: '.copilot/prompts',
-										children: [
-											{
-												name: 'prompt5.prompt.md',
-												contents: 'oh hi, robot!',
-											},
-										],
-									},
-									{
-										name: '.github/prompts',
-										children: [
-											{
-												name: 'refactor-static-classes.prompt.md',
-												contents: 'file contents',
-											},
-										],
-									},
-								],
-							},
-							// note! this folder is part of the workspace, so prompt files are `included`
-							{
-								name: '/var/shared/prompts/.github/prompts',
-								children: [
-									{
-										name: 'prompt-name.prompt.md',
-										contents: 'oh hi, robot!',
-									},
-									{
-										name: 'name-of-the-prompt.prompt.md',
-										contents: 'oh hi, raw bot!',
-									},
-								],
-							},
-						]);
+	// 			test('• with top-level `.github` folder', async () => {
+	// 				const locator = await createPromptsLocator(
+	// 					{
+	// 						'/Users/legomushroom/repos/prompts': true,
+	// 						'/tmp/prompts/': true,
+	// 						'/absolute/path/prompts': false,
+	// 						'.copilot/prompts': false,
+	// 					},
+	// 					[
+	// 						'/Users/legomushroom/repos/vscode',
+	// 						'/Users/legomushroom/repos/node',
+	// 						'/var/shared/prompts/.github',
+	// 					],
+	// 					[
+	// 						{
+	// 							name: '/Users/legomushroom/repos/prompts',
+	// 							children: [
+	// 								{
+	// 									name: 'test.prompt.md',
+	// 									contents: 'Hello, World!',
+	// 								},
+	// 								{
+	// 									name: 'refactor-tests.prompt.md',
+	// 									contents: 'some file content goes here',
+	// 								},
+	// 							],
+	// 						},
+	// 						{
+	// 							name: '/tmp/prompts',
+	// 							children: [
+	// 								{
+	// 									name: 'translate.to-rust.prompt.md',
+	// 									contents: 'some more random file contents',
+	// 								},
+	// 							],
+	// 						},
+	// 						{
+	// 							name: '/absolute/path/prompts',
+	// 							children: [
+	// 								{
+	// 									name: 'some-prompt-file.prompt.md',
+	// 									contents: 'hey hey hey',
+	// 								},
+	// 							],
+	// 						},
+	// 						{
+	// 							name: '/Users/legomushroom/repos/vscode',
+	// 							children: [
+	// 								{
+	// 									name: '.copilot/prompts',
+	// 									children: [
+	// 										{
+	// 											name: 'prompt1.prompt.md',
+	// 											contents: 'oh hi, robot!',
+	// 										},
+	// 									],
+	// 								},
+	// 								{
+	// 									name: '.github/prompts',
+	// 									children: [
+	// 										{
+	// 											name: 'default.prompt.md',
+	// 											contents: 'oh hi, bot!',
+	// 										},
+	// 									],
+	// 								},
+	// 							],
+	// 						},
+	// 						{
+	// 							name: '/Users/legomushroom/repos/node',
+	// 							children: [
+	// 								{
+	// 									name: '.copilot/prompts',
+	// 									children: [
+	// 										{
+	// 											name: 'prompt5.prompt.md',
+	// 											contents: 'oh hi, robot!',
+	// 										},
+	// 									],
+	// 								},
+	// 								{
+	// 									name: '.github/prompts',
+	// 									children: [
+	// 										{
+	// 											name: 'refactor-static-classes.prompt.md',
+	// 											contents: 'file contents',
+	// 										},
+	// 									],
+	// 								},
+	// 							],
+	// 						},
+	// 						// note! this folder is part of the workspace, so prompt files are `included`
+	// 						{
+	// 							name: '/var/shared/prompts/.github/prompts',
+	// 							children: [
+	// 								{
+	// 									name: 'prompt-name.prompt.md',
+	// 									contents: 'oh hi, robot!',
+	// 								},
+	// 								{
+	// 									name: 'name-of-the-prompt.prompt.md',
+	// 									contents: 'oh hi, raw bot!',
+	// 								},
+	// 							],
+	// 						},
+	// 					]);
 
-					assert.deepStrictEqual(
-						await locator.listFiles(),
-						[
-							createURI('/Users/legomushroom/repos/vscode/.github/prompts/default.prompt.md'),
-							createURI('/Users/legomushroom/repos/node/.github/prompts/refactor-static-classes.prompt.md'),
-							createURI('/var/shared/prompts/.github/prompts/prompt-name.prompt.md'),
-							createURI('/var/shared/prompts/.github/prompts/name-of-the-prompt.prompt.md'),
-							createURI('/Users/legomushroom/repos/prompts/test.prompt.md'),
-							createURI('/Users/legomushroom/repos/prompts/refactor-tests.prompt.md'),
-							createURI('/tmp/prompts/translate.to-rust.prompt.md'),
-						],
-						'Must find correct prompts.',
-					);
-				});
+	// 				assert.deepStrictEqual(
+	// 					await locator.listFiles(),
+	// 					[
+	// 						createURI('/Users/legomushroom/repos/vscode/.github/prompts/default.prompt.md'),
+	// 						createURI('/Users/legomushroom/repos/node/.github/prompts/refactor-static-classes.prompt.md'),
+	// 						createURI('/var/shared/prompts/.github/prompts/prompt-name.prompt.md'),
+	// 						createURI('/var/shared/prompts/.github/prompts/name-of-the-prompt.prompt.md'),
+	// 						createURI('/Users/legomushroom/repos/prompts/test.prompt.md'),
+	// 						createURI('/Users/legomushroom/repos/prompts/refactor-tests.prompt.md'),
+	// 						createURI('/tmp/prompts/translate.to-rust.prompt.md'),
+	// 					],
+	// 					'Must find correct prompts.',
+	// 				);
+	// 			});
 
-				test('• with disabled `.github/prompts` location', async () => {
-					const locator = await createPromptsLocator(
-						{
-							'/Users/legomushroom/repos/prompts': true,
-							'/tmp/prompts/': true,
-							'/absolute/path/prompts': false,
-							'.copilot/prompts': false,
-							'.github/prompts': false,
-						},
-						[
-							'/Users/legomushroom/repos/vscode',
-							'/Users/legomushroom/repos/node',
-							'/var/shared/prompts/.github',
-						],
-						[
-							{
-								name: '/Users/legomushroom/repos/prompts',
-								children: [
-									{
-										name: 'test.prompt.md',
-										contents: 'Hello, World!',
-									},
-									{
-										name: 'refactor-tests.prompt.md',
-										contents: 'some file content goes here',
-									},
-								],
-							},
-							{
-								name: '/tmp/prompts',
-								children: [
-									{
-										name: 'translate.to-rust.prompt.md',
-										contents: 'some more random file contents',
-									},
-								],
-							},
-							{
-								name: '/absolute/path/prompts',
-								children: [
-									{
-										name: 'some-prompt-file.prompt.md',
-										contents: 'hey hey hey',
-									},
-								],
-							},
-							{
-								name: '/Users/legomushroom/repos/vscode',
-								children: [
-									{
-										name: '.copilot/prompts',
-										children: [
-											{
-												name: 'prompt1.prompt.md',
-												contents: 'oh hi, robot!',
-											},
-										],
-									},
-									{
-										name: '.github/prompts',
-										children: [
-											{
-												name: 'default.prompt.md',
-												contents: 'oh hi, bot!',
-											},
-										],
-									},
-								],
-							},
-							{
-								name: '/Users/legomushroom/repos/node',
-								children: [
-									{
-										name: '.copilot/prompts',
-										children: [
-											{
-												name: 'prompt5.prompt.md',
-												contents: 'oh hi, robot!',
-											},
-										],
-									},
-									{
-										name: '.github/prompts',
-										children: [
-											{
-												name: 'refactor-static-classes.prompt.md',
-												contents: 'file contents',
-											},
-										],
-									},
-								],
-							},
-							// note! this folder is part of the workspace, so prompt files are `included`
-							{
-								name: '/var/shared/prompts/.github/prompts',
-								children: [
-									{
-										name: 'prompt-name.prompt.md',
-										contents: 'oh hi, robot!',
-									},
-									{
-										name: 'name-of-the-prompt.prompt.md',
-										contents: 'oh hi, raw bot!',
-									},
-								],
-							},
-						]);
+	// 			test('• with disabled `.github/prompts` location', async () => {
+	// 				const locator = await createPromptsLocator(
+	// 					{
+	// 						'/Users/legomushroom/repos/prompts': true,
+	// 						'/tmp/prompts/': true,
+	// 						'/absolute/path/prompts': false,
+	// 						'.copilot/prompts': false,
+	// 						'.github/prompts': false,
+	// 					},
+	// 					[
+	// 						'/Users/legomushroom/repos/vscode',
+	// 						'/Users/legomushroom/repos/node',
+	// 						'/var/shared/prompts/.github',
+	// 					],
+	// 					[
+	// 						{
+	// 							name: '/Users/legomushroom/repos/prompts',
+	// 							children: [
+	// 								{
+	// 									name: 'test.prompt.md',
+	// 									contents: 'Hello, World!',
+	// 								},
+	// 								{
+	// 									name: 'refactor-tests.prompt.md',
+	// 									contents: 'some file content goes here',
+	// 								},
+	// 							],
+	// 						},
+	// 						{
+	// 							name: '/tmp/prompts',
+	// 							children: [
+	// 								{
+	// 									name: 'translate.to-rust.prompt.md',
+	// 									contents: 'some more random file contents',
+	// 								},
+	// 							],
+	// 						},
+	// 						{
+	// 							name: '/absolute/path/prompts',
+	// 							children: [
+	// 								{
+	// 									name: 'some-prompt-file.prompt.md',
+	// 									contents: 'hey hey hey',
+	// 								},
+	// 							],
+	// 						},
+	// 						{
+	// 							name: '/Users/legomushroom/repos/vscode',
+	// 							children: [
+	// 								{
+	// 									name: '.copilot/prompts',
+	// 									children: [
+	// 										{
+	// 											name: 'prompt1.prompt.md',
+	// 											contents: 'oh hi, robot!',
+	// 										},
+	// 									],
+	// 								},
+	// 								{
+	// 									name: '.github/prompts',
+	// 									children: [
+	// 										{
+	// 											name: 'default.prompt.md',
+	// 											contents: 'oh hi, bot!',
+	// 										},
+	// 									],
+	// 								},
+	// 							],
+	// 						},
+	// 						{
+	// 							name: '/Users/legomushroom/repos/node',
+	// 							children: [
+	// 								{
+	// 									name: '.copilot/prompts',
+	// 									children: [
+	// 										{
+	// 											name: 'prompt5.prompt.md',
+	// 											contents: 'oh hi, robot!',
+	// 										},
+	// 									],
+	// 								},
+	// 								{
+	// 									name: '.github/prompts',
+	// 									children: [
+	// 										{
+	// 											name: 'refactor-static-classes.prompt.md',
+	// 											contents: 'file contents',
+	// 										},
+	// 									],
+	// 								},
+	// 							],
+	// 						},
+	// 						// note! this folder is part of the workspace, so prompt files are `included`
+	// 						{
+	// 							name: '/var/shared/prompts/.github/prompts',
+	// 							children: [
+	// 								{
+	// 									name: 'prompt-name.prompt.md',
+	// 									contents: 'oh hi, robot!',
+	// 								},
+	// 								{
+	// 									name: 'name-of-the-prompt.prompt.md',
+	// 									contents: 'oh hi, raw bot!',
+	// 								},
+	// 							],
+	// 						},
+	// 					]);
 
-					assert.deepStrictEqual(
-						await locator.listFiles(),
-						[
-							createURI('/Users/legomushroom/repos/prompts/test.prompt.md'),
-							createURI('/Users/legomushroom/repos/prompts/refactor-tests.prompt.md'),
-							createURI('/tmp/prompts/translate.to-rust.prompt.md'),
-						],
-						'Must find correct prompts.',
-					);
-				});
-			});
-		});
-	});
+	// 				assert.deepStrictEqual(
+	// 					await locator.listFiles(),
+	// 					[
+	// 						createURI('/Users/legomushroom/repos/prompts/test.prompt.md'),
+	// 						createURI('/Users/legomushroom/repos/prompts/refactor-tests.prompt.md'),
+	// 						createURI('/tmp/prompts/translate.to-rust.prompt.md'),
+	// 					],
+	// 					'Must find correct prompts.',
+	// 				);
+	// 			});
+	// 		});
+	// 	});
+	// });
 });

--- a/src/vs/workbench/contrib/chat/test/common/promptSyntax/utils/promptFilesLocator.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/promptSyntax/utils/promptFilesLocator.test.ts
@@ -109,7 +109,7 @@ suite('PromptFilesLocator', () => {
 				const locator = await createPromptsLocator(undefined, EMPTY_WORKSPACE, []);
 
 				assert.deepStrictEqual(
-					await locator.listFiles([]),
+					await locator.listFiles(),
 					[],
 					'No prompts must be found.',
 				);
@@ -122,7 +122,7 @@ suite('PromptFilesLocator', () => {
 				}, EMPTY_WORKSPACE, []);
 
 				assert.deepStrictEqual(
-					await locator.listFiles([]),
+					await locator.listFiles(),
 					[],
 					'No prompts must be found.',
 				);
@@ -135,7 +135,7 @@ suite('PromptFilesLocator', () => {
 				], EMPTY_WORKSPACE, []);
 
 				assert.deepStrictEqual(
-					await locator.listFiles([]),
+					await locator.listFiles(),
 					[],
 					'No prompts must be found.',
 				);
@@ -145,7 +145,7 @@ suite('PromptFilesLocator', () => {
 				const locator = await createPromptsLocator(null, EMPTY_WORKSPACE, []);
 
 				assert.deepStrictEqual(
-					await locator.listFiles([]),
+					await locator.listFiles(),
 					[],
 					'No prompts must be found.',
 				);
@@ -155,7 +155,7 @@ suite('PromptFilesLocator', () => {
 				const locator = await createPromptsLocator('/etc/hosts/prompts', EMPTY_WORKSPACE, []);
 
 				assert.deepStrictEqual(
-					await locator.listFiles([]),
+					await locator.listFiles(),
 					[],
 					'No prompts must be found.',
 				);
@@ -207,7 +207,7 @@ suite('PromptFilesLocator', () => {
 					]);
 
 				assert.deepStrictEqual(
-					await locator.listFiles([]),
+					await locator.listFiles(),
 					[
 						createURI('/Users/legomushroom/repos/prompts/test.prompt.md'),
 						createURI('/Users/legomushroom/repos/prompts/refactor-tests.prompt.md'),
@@ -291,7 +291,7 @@ suite('PromptFilesLocator', () => {
 						]);
 
 					assert.deepStrictEqual(
-						await locator.listFiles([]),
+						await locator.listFiles(),
 						[
 							createURI('/Users/legomushroom/repos/vscode/.github/prompts/my.prompt.md'),
 							createURI('/Users/legomushroom/repos/prompts/test.prompt.md'),
@@ -377,7 +377,7 @@ suite('PromptFilesLocator', () => {
 						]);
 
 					assert.deepStrictEqual(
-						await locator.listFiles([]),
+						await locator.listFiles(),
 						[
 							createURI('/Users/legomushroom/repos/prompts/test.prompt.md'),
 							createURI('/Users/legomushroom/repos/prompts/refactor-tests.prompt.md'),
@@ -501,7 +501,7 @@ suite('PromptFilesLocator', () => {
 						]);
 
 					assert.deepStrictEqual(
-						await locator.listFiles([]),
+						await locator.listFiles(),
 						[
 							createURI('/Users/legomushroom/repos/vscode/.github/prompts/default.prompt.md'),
 							createURI('/Users/legomushroom/repos/node/.github/prompts/refactor-static-classes.prompt.md'),
@@ -621,7 +621,7 @@ suite('PromptFilesLocator', () => {
 						]);
 
 					assert.deepStrictEqual(
-						await locator.listFiles([]),
+						await locator.listFiles(),
 						[
 							createURI('/Users/legomushroom/repos/vscode/.github/prompts/default.prompt.md'),
 							createURI('/Users/legomushroom/repos/node/.github/prompts/refactor-static-classes.prompt.md'),
@@ -744,7 +744,7 @@ suite('PromptFilesLocator', () => {
 						]);
 
 					assert.deepStrictEqual(
-						await locator.listFiles([]),
+						await locator.listFiles(),
 						[
 							createURI('/Users/legomushroom/repos/prompts/test.prompt.md'),
 							createURI('/Users/legomushroom/repos/prompts/refactor-tests.prompt.md'),

--- a/src/vs/workbench/contrib/chat/test/common/promptSyntax/utils/promptFilesLocator.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/promptSyntax/utils/promptFilesLocator.test.ts
@@ -871,369 +871,1051 @@ suite('PromptFilesLocator', () => {
 		});
 	});
 
-	// suite('• multi-root workspace', () => {
-	// 	suite('• non-empty filesystem', () => {
-	// 		suite('• object config value', () => {
-	// 			test('• without top-level `.github` folder', async () => {
-	// 				const locator = await createPromptsLocator(
-	// 					{
-	// 						'/Users/legomushroom/repos/prompts': true,
-	// 						'/tmp/prompts/': true,
-	// 						'/absolute/path/prompts': false,
-	// 						'.copilot/prompts': false,
-	// 					},
-	// 					[
-	// 						'/Users/legomushroom/repos/vscode',
-	// 						'/Users/legomushroom/repos/node',
-	// 					],
-	// 					[
-	// 						{
-	// 							name: '/Users/legomushroom/repos/prompts',
-	// 							children: [
-	// 								{
-	// 									name: 'test.prompt.md',
-	// 									contents: 'Hello, World!',
-	// 								},
-	// 								{
-	// 									name: 'refactor-tests.prompt.md',
-	// 									contents: 'some file content goes here',
-	// 								},
-	// 							],
-	// 						},
-	// 						{
-	// 							name: '/tmp/prompts',
-	// 							children: [
-	// 								{
-	// 									name: 'translate.to-rust.prompt.md',
-	// 									contents: 'some more random file contents',
-	// 								},
-	// 							],
-	// 						},
-	// 						{
-	// 							name: '/absolute/path/prompts',
-	// 							children: [
-	// 								{
-	// 									name: 'some-prompt-file.prompt.md',
-	// 									contents: 'hey hey hey',
-	// 								},
-	// 							],
-	// 						},
-	// 						{
-	// 							name: '/Users/legomushroom/repos/vscode',
-	// 							children: [
-	// 								{
-	// 									name: '.copilot/prompts',
-	// 									children: [
-	// 										{
-	// 											name: 'prompt1.prompt.md',
-	// 											contents: 'oh hi, robot!',
-	// 										},
-	// 									],
-	// 								},
-	// 								{
-	// 									name: '.github/prompts',
-	// 									children: [
-	// 										{
-	// 											name: 'default.prompt.md',
-	// 											contents: 'oh hi, bot!',
-	// 										},
-	// 									],
-	// 								},
-	// 							],
-	// 						},
-	// 						{
-	// 							name: '/Users/legomushroom/repos/node',
-	// 							children: [
-	// 								{
-	// 									name: '.copilot/prompts',
-	// 									children: [
-	// 										{
-	// 											name: 'prompt5.prompt.md',
-	// 											contents: 'oh hi, robot!',
-	// 										},
-	// 									],
-	// 								},
-	// 								{
-	// 									name: '.github/prompts',
-	// 									children: [
-	// 										{
-	// 											name: 'refactor-static-classes.prompt.md',
-	// 											contents: 'file contents',
-	// 										},
-	// 									],
-	// 								},
-	// 							],
-	// 						},
-	// 						// note! this folder is not part of the workspace, so prompt files are `ignored`
-	// 						{
-	// 							name: '/Users/legomushroom/repos/.github/prompts',
-	// 							children: [
-	// 								{
-	// 									name: 'prompt-name.prompt.md',
-	// 									contents: 'oh hi, robot!',
-	// 								},
-	// 								{
-	// 									name: 'name-of-the-prompt.prompt.md',
-	// 									contents: 'oh hi, raw bot!',
-	// 								},
-	// 							],
-	// 						},
-	// 					]);
+	suite('• multi-root workspace', () => {
+		suite('• core logic', () => {
+			test('• without top-level `.github` folder', async () => {
+				const locator = await createPromptsLocator(
+					{
+						'/Users/legomushroom/repos/prompts': true,
+						'/tmp/prompts/': true,
+						'/absolute/path/prompts': false,
+						'.copilot/prompts': false,
+					},
+					[
+						'/Users/legomushroom/repos/vscode',
+						'/Users/legomushroom/repos/node',
+					],
+					[
+						{
+							name: '/Users/legomushroom/repos/prompts',
+							children: [
+								{
+									name: 'test.prompt.md',
+									contents: 'Hello, World!',
+								},
+								{
+									name: 'refactor-tests.prompt.md',
+									contents: 'some file content goes here',
+								},
+							],
+						},
+						{
+							name: '/tmp/prompts',
+							children: [
+								{
+									name: 'translate.to-rust.prompt.md',
+									contents: 'some more random file contents',
+								},
+							],
+						},
+						{
+							name: '/absolute/path/prompts',
+							children: [
+								{
+									name: 'some-prompt-file.prompt.md',
+									contents: 'hey hey hey',
+								},
+							],
+						},
+						{
+							name: '/Users/legomushroom/repos/vscode',
+							children: [
+								{
+									name: '.copilot/prompts',
+									children: [
+										{
+											name: 'prompt1.prompt.md',
+											contents: 'oh hi, robot!',
+										},
+									],
+								},
+								{
+									name: '.github/prompts',
+									children: [
+										{
+											name: 'default.prompt.md',
+											contents: 'oh hi, bot!',
+										},
+									],
+								},
+							],
+						},
+						{
+							name: '/Users/legomushroom/repos/node',
+							children: [
+								{
+									name: '.copilot/prompts',
+									children: [
+										{
+											name: 'prompt5.prompt.md',
+											contents: 'oh hi, robot!',
+										},
+									],
+								},
+								{
+									name: '.github/prompts',
+									children: [
+										{
+											name: 'refactor-static-classes.prompt.md',
+											contents: 'file contents',
+										},
+									],
+								},
+							],
+						},
+						// note! this folder is not part of the workspace, so prompt files are `ignored`
+						{
+							name: '/Users/legomushroom/repos/.github/prompts',
+							children: [
+								{
+									name: 'prompt-name.prompt.md',
+									contents: 'oh hi, robot!',
+								},
+								{
+									name: 'name-of-the-prompt.prompt.md',
+									contents: 'oh hi, raw bot!',
+								},
+							],
+						},
+					]);
 
-	// 				assert.deepStrictEqual(
-	// 					await locator.listFiles(),
-	// 					[
-	// 						createURI('/Users/legomushroom/repos/vscode/.github/prompts/default.prompt.md'),
-	// 						createURI('/Users/legomushroom/repos/node/.github/prompts/refactor-static-classes.prompt.md'),
-	// 						createURI('/Users/legomushroom/repos/prompts/test.prompt.md'),
-	// 						createURI('/Users/legomushroom/repos/prompts/refactor-tests.prompt.md'),
-	// 						createURI('/tmp/prompts/translate.to-rust.prompt.md'),
-	// 					],
-	// 					'Must find correct prompts.',
-	// 				);
-	// 			});
+				assert.deepStrictEqual(
+					await locator.listFiles(),
+					[
+						createURI('/Users/legomushroom/repos/vscode/.github/prompts/default.prompt.md'),
+						createURI('/Users/legomushroom/repos/node/.github/prompts/refactor-static-classes.prompt.md'),
+						createURI('/Users/legomushroom/repos/prompts/test.prompt.md'),
+						createURI('/Users/legomushroom/repos/prompts/refactor-tests.prompt.md'),
+						createURI('/tmp/prompts/translate.to-rust.prompt.md'),
+					],
+					'Must find correct prompts.',
+				);
+			});
 
-	// 			test('• with top-level `.github` folder', async () => {
-	// 				const locator = await createPromptsLocator(
-	// 					{
-	// 						'/Users/legomushroom/repos/prompts': true,
-	// 						'/tmp/prompts/': true,
-	// 						'/absolute/path/prompts': false,
-	// 						'.copilot/prompts': false,
-	// 					},
-	// 					[
-	// 						'/Users/legomushroom/repos/vscode',
-	// 						'/Users/legomushroom/repos/node',
-	// 						'/var/shared/prompts/.github',
-	// 					],
-	// 					[
-	// 						{
-	// 							name: '/Users/legomushroom/repos/prompts',
-	// 							children: [
-	// 								{
-	// 									name: 'test.prompt.md',
-	// 									contents: 'Hello, World!',
-	// 								},
-	// 								{
-	// 									name: 'refactor-tests.prompt.md',
-	// 									contents: 'some file content goes here',
-	// 								},
-	// 							],
-	// 						},
-	// 						{
-	// 							name: '/tmp/prompts',
-	// 							children: [
-	// 								{
-	// 									name: 'translate.to-rust.prompt.md',
-	// 									contents: 'some more random file contents',
-	// 								},
-	// 							],
-	// 						},
-	// 						{
-	// 							name: '/absolute/path/prompts',
-	// 							children: [
-	// 								{
-	// 									name: 'some-prompt-file.prompt.md',
-	// 									contents: 'hey hey hey',
-	// 								},
-	// 							],
-	// 						},
-	// 						{
-	// 							name: '/Users/legomushroom/repos/vscode',
-	// 							children: [
-	// 								{
-	// 									name: '.copilot/prompts',
-	// 									children: [
-	// 										{
-	// 											name: 'prompt1.prompt.md',
-	// 											contents: 'oh hi, robot!',
-	// 										},
-	// 									],
-	// 								},
-	// 								{
-	// 									name: '.github/prompts',
-	// 									children: [
-	// 										{
-	// 											name: 'default.prompt.md',
-	// 											contents: 'oh hi, bot!',
-	// 										},
-	// 									],
-	// 								},
-	// 							],
-	// 						},
-	// 						{
-	// 							name: '/Users/legomushroom/repos/node',
-	// 							children: [
-	// 								{
-	// 									name: '.copilot/prompts',
-	// 									children: [
-	// 										{
-	// 											name: 'prompt5.prompt.md',
-	// 											contents: 'oh hi, robot!',
-	// 										},
-	// 									],
-	// 								},
-	// 								{
-	// 									name: '.github/prompts',
-	// 									children: [
-	// 										{
-	// 											name: 'refactor-static-classes.prompt.md',
-	// 											contents: 'file contents',
-	// 										},
-	// 									],
-	// 								},
-	// 							],
-	// 						},
-	// 						// note! this folder is part of the workspace, so prompt files are `included`
-	// 						{
-	// 							name: '/var/shared/prompts/.github/prompts',
-	// 							children: [
-	// 								{
-	// 									name: 'prompt-name.prompt.md',
-	// 									contents: 'oh hi, robot!',
-	// 								},
-	// 								{
-	// 									name: 'name-of-the-prompt.prompt.md',
-	// 									contents: 'oh hi, raw bot!',
-	// 								},
-	// 							],
-	// 						},
-	// 					]);
+			test('• with top-level `.github` folder', async () => {
+				const locator = await createPromptsLocator(
+					{
+						'/Users/legomushroom/repos/prompts': true,
+						'/tmp/prompts/': true,
+						'/absolute/path/prompts': false,
+						'.copilot/prompts': false,
+					},
+					[
+						'/Users/legomushroom/repos/vscode',
+						'/Users/legomushroom/repos/node',
+						'/var/shared/prompts/.github',
+					],
+					[
+						{
+							name: '/Users/legomushroom/repos/prompts',
+							children: [
+								{
+									name: 'test.prompt.md',
+									contents: 'Hello, World!',
+								},
+								{
+									name: 'refactor-tests.prompt.md',
+									contents: 'some file content goes here',
+								},
+							],
+						},
+						{
+							name: '/tmp/prompts',
+							children: [
+								{
+									name: 'translate.to-rust.prompt.md',
+									contents: 'some more random file contents',
+								},
+							],
+						},
+						{
+							name: '/absolute/path/prompts',
+							children: [
+								{
+									name: 'some-prompt-file.prompt.md',
+									contents: 'hey hey hey',
+								},
+							],
+						},
+						{
+							name: '/Users/legomushroom/repos/vscode',
+							children: [
+								{
+									name: '.copilot/prompts',
+									children: [
+										{
+											name: 'prompt1.prompt.md',
+											contents: 'oh hi, robot!',
+										},
+									],
+								},
+								{
+									name: '.github/prompts',
+									children: [
+										{
+											name: 'default.prompt.md',
+											contents: 'oh hi, bot!',
+										},
+									],
+								},
+							],
+						},
+						{
+							name: '/Users/legomushroom/repos/node',
+							children: [
+								{
+									name: '.copilot/prompts',
+									children: [
+										{
+											name: 'prompt5.prompt.md',
+											contents: 'oh hi, robot!',
+										},
+									],
+								},
+								{
+									name: '.github/prompts',
+									children: [
+										{
+											name: 'refactor-static-classes.prompt.md',
+											contents: 'file contents',
+										},
+									],
+								},
+							],
+						},
+						// note! this folder is part of the workspace, so prompt files are `included`
+						{
+							name: '/var/shared/prompts/.github/prompts',
+							children: [
+								{
+									name: 'prompt-name.prompt.md',
+									contents: 'oh hi, robot!',
+								},
+								{
+									name: 'name-of-the-prompt.prompt.md',
+									contents: 'oh hi, raw bot!',
+								},
+							],
+						},
+					]);
 
-	// 				assert.deepStrictEqual(
-	// 					await locator.listFiles(),
-	// 					[
-	// 						createURI('/Users/legomushroom/repos/vscode/.github/prompts/default.prompt.md'),
-	// 						createURI('/Users/legomushroom/repos/node/.github/prompts/refactor-static-classes.prompt.md'),
-	// 						createURI('/var/shared/prompts/.github/prompts/prompt-name.prompt.md'),
-	// 						createURI('/var/shared/prompts/.github/prompts/name-of-the-prompt.prompt.md'),
-	// 						createURI('/Users/legomushroom/repos/prompts/test.prompt.md'),
-	// 						createURI('/Users/legomushroom/repos/prompts/refactor-tests.prompt.md'),
-	// 						createURI('/tmp/prompts/translate.to-rust.prompt.md'),
-	// 					],
-	// 					'Must find correct prompts.',
-	// 				);
-	// 			});
+				assert.deepStrictEqual(
+					await locator.listFiles(),
+					[
+						createURI('/Users/legomushroom/repos/vscode/.github/prompts/default.prompt.md'),
+						createURI('/Users/legomushroom/repos/node/.github/prompts/refactor-static-classes.prompt.md'),
+						createURI('/var/shared/prompts/.github/prompts/prompt-name.prompt.md'),
+						createURI('/var/shared/prompts/.github/prompts/name-of-the-prompt.prompt.md'),
+						createURI('/Users/legomushroom/repos/prompts/test.prompt.md'),
+						createURI('/Users/legomushroom/repos/prompts/refactor-tests.prompt.md'),
+						createURI('/tmp/prompts/translate.to-rust.prompt.md'),
+					],
+					'Must find correct prompts.',
+				);
+			});
 
-	// 			test('• with disabled `.github/prompts` location', async () => {
-	// 				const locator = await createPromptsLocator(
-	// 					{
-	// 						'/Users/legomushroom/repos/prompts': true,
-	// 						'/tmp/prompts/': true,
-	// 						'/absolute/path/prompts': false,
-	// 						'.copilot/prompts': false,
-	// 						'.github/prompts': false,
-	// 					},
-	// 					[
-	// 						'/Users/legomushroom/repos/vscode',
-	// 						'/Users/legomushroom/repos/node',
-	// 						'/var/shared/prompts/.github',
-	// 					],
-	// 					[
-	// 						{
-	// 							name: '/Users/legomushroom/repos/prompts',
-	// 							children: [
-	// 								{
-	// 									name: 'test.prompt.md',
-	// 									contents: 'Hello, World!',
-	// 								},
-	// 								{
-	// 									name: 'refactor-tests.prompt.md',
-	// 									contents: 'some file content goes here',
-	// 								},
-	// 							],
-	// 						},
-	// 						{
-	// 							name: '/tmp/prompts',
-	// 							children: [
-	// 								{
-	// 									name: 'translate.to-rust.prompt.md',
-	// 									contents: 'some more random file contents',
-	// 								},
-	// 							],
-	// 						},
-	// 						{
-	// 							name: '/absolute/path/prompts',
-	// 							children: [
-	// 								{
-	// 									name: 'some-prompt-file.prompt.md',
-	// 									contents: 'hey hey hey',
-	// 								},
-	// 							],
-	// 						},
-	// 						{
-	// 							name: '/Users/legomushroom/repos/vscode',
-	// 							children: [
-	// 								{
-	// 									name: '.copilot/prompts',
-	// 									children: [
-	// 										{
-	// 											name: 'prompt1.prompt.md',
-	// 											contents: 'oh hi, robot!',
-	// 										},
-	// 									],
-	// 								},
-	// 								{
-	// 									name: '.github/prompts',
-	// 									children: [
-	// 										{
-	// 											name: 'default.prompt.md',
-	// 											contents: 'oh hi, bot!',
-	// 										},
-	// 									],
-	// 								},
-	// 							],
-	// 						},
-	// 						{
-	// 							name: '/Users/legomushroom/repos/node',
-	// 							children: [
-	// 								{
-	// 									name: '.copilot/prompts',
-	// 									children: [
-	// 										{
-	// 											name: 'prompt5.prompt.md',
-	// 											contents: 'oh hi, robot!',
-	// 										},
-	// 									],
-	// 								},
-	// 								{
-	// 									name: '.github/prompts',
-	// 									children: [
-	// 										{
-	// 											name: 'refactor-static-classes.prompt.md',
-	// 											contents: 'file contents',
-	// 										},
-	// 									],
-	// 								},
-	// 							],
-	// 						},
-	// 						// note! this folder is part of the workspace, so prompt files are `included`
-	// 						{
-	// 							name: '/var/shared/prompts/.github/prompts',
-	// 							children: [
-	// 								{
-	// 									name: 'prompt-name.prompt.md',
-	// 									contents: 'oh hi, robot!',
-	// 								},
-	// 								{
-	// 									name: 'name-of-the-prompt.prompt.md',
-	// 									contents: 'oh hi, raw bot!',
-	// 								},
-	// 							],
-	// 						},
-	// 					]);
+			test('• with disabled `.github/prompts` location', async () => {
+				const locator = await createPromptsLocator(
+					{
+						'/Users/legomushroom/repos/prompts': true,
+						'/tmp/prompts/': true,
+						'/absolute/path/prompts': false,
+						'.copilot/prompts': false,
+						'.github/prompts': false,
+					},
+					[
+						'/Users/legomushroom/repos/vscode',
+						'/Users/legomushroom/repos/node',
+						'/var/shared/prompts/.github',
+					],
+					[
+						{
+							name: '/Users/legomushroom/repos/prompts',
+							children: [
+								{
+									name: 'test.prompt.md',
+									contents: 'Hello, World!',
+								},
+								{
+									name: 'refactor-tests.prompt.md',
+									contents: 'some file content goes here',
+								},
+							],
+						},
+						{
+							name: '/tmp/prompts',
+							children: [
+								{
+									name: 'translate.to-rust.prompt.md',
+									contents: 'some more random file contents',
+								},
+							],
+						},
+						{
+							name: '/absolute/path/prompts',
+							children: [
+								{
+									name: 'some-prompt-file.prompt.md',
+									contents: 'hey hey hey',
+								},
+							],
+						},
+						{
+							name: '/Users/legomushroom/repos/vscode',
+							children: [
+								{
+									name: '.copilot/prompts',
+									children: [
+										{
+											name: 'prompt1.prompt.md',
+											contents: 'oh hi, robot!',
+										},
+									],
+								},
+								{
+									name: '.github/prompts',
+									children: [
+										{
+											name: 'default.prompt.md',
+											contents: 'oh hi, bot!',
+										},
+									],
+								},
+							],
+						},
+						{
+							name: '/Users/legomushroom/repos/node',
+							children: [
+								{
+									name: '.copilot/prompts',
+									children: [
+										{
+											name: 'prompt5.prompt.md',
+											contents: 'oh hi, robot!',
+										},
+									],
+								},
+								{
+									name: '.github/prompts',
+									children: [
+										{
+											name: 'refactor-static-classes.prompt.md',
+											contents: 'file contents',
+										},
+									],
+								},
+							],
+						},
+						// note! this folder is part of the workspace, so prompt files are `included`
+						{
+							name: '/var/shared/prompts/.github/prompts',
+							children: [
+								{
+									name: 'prompt-name.prompt.md',
+									contents: 'oh hi, robot!',
+								},
+								{
+									name: 'name-of-the-prompt.prompt.md',
+									contents: 'oh hi, raw bot!',
+								},
+							],
+						},
+					]);
 
-	// 				assert.deepStrictEqual(
-	// 					await locator.listFiles(),
-	// 					[
-	// 						createURI('/Users/legomushroom/repos/prompts/test.prompt.md'),
-	// 						createURI('/Users/legomushroom/repos/prompts/refactor-tests.prompt.md'),
-	// 						createURI('/tmp/prompts/translate.to-rust.prompt.md'),
-	// 					],
-	// 					'Must find correct prompts.',
-	// 				);
-	// 			});
-	// 		});
-	// 	});
-	// });
+				assert.deepStrictEqual(
+					await locator.listFiles(),
+					[
+						createURI('/Users/legomushroom/repos/prompts/test.prompt.md'),
+						createURI('/Users/legomushroom/repos/prompts/refactor-tests.prompt.md'),
+						createURI('/tmp/prompts/translate.to-rust.prompt.md'),
+					],
+					'Must find correct prompts.',
+				);
+			});
+		});
+
+		suite('• findAllMatchingPromptFiles', () => {
+			suite('• glob pattern', () => {
+				suite('• relative', () => {
+					suite('• wild card', () => {
+						const testSettings = [
+							'**',
+							'**/*.prompt.md',
+							'**/*.md',
+							'**/*',
+							'gen*/**',
+							'gen*/**/*.prompt.md',
+							'gen*/**/*',
+							'gen*/**/*.md',
+							'**/gen*/**',
+							'**/gen*/**/*',
+							'**/gen*/**/*.md',
+							'**/gen*/**/*.prompt.md',
+							'{generic,general,gen}/**',
+							'{generic,general,gen}/**/*.prompt.md',
+							'{generic,general,gen}/**/*',
+							'{generic,general,gen}/**/*.md',
+							'**/{generic,general,gen}/**',
+							'**/{generic,general,gen}/**/*',
+							'**/{generic,general,gen}/**/*.md',
+							'**/{generic,general,gen}/**/*.prompt.md',
+						];
+
+						for (const setting of testSettings) {
+							test(`• '${setting}'`, async () => {
+								const locator = await createPromptsLocator(
+									{ [setting]: true },
+									[
+										'/Users/legomushroom/repos/vscode',
+										'/Users/legomushroom/repos/prompts',
+									],
+									[
+										{
+											name: '/Users/legomushroom/repos/vscode',
+											children: [
+												{
+													name: 'gen/text',
+													children: [
+														{
+															name: 'my.prompt.md',
+															contents: 'oh hi, bot!',
+														},
+														{
+															name: 'nested',
+															children: [
+																{
+																	name: 'specific.prompt.md',
+																	contents: 'oh hi, bot!',
+																},
+																{
+																	name: 'unspecific1.prompt.md',
+																	contents: 'oh hi, robot!',
+																},
+																{
+																	name: 'unspecific2.prompt.md',
+																	contents: 'oh hi, rabot!',
+																},
+																{
+																	name: 'readme.md',
+																	contents: 'non prompt file',
+																},
+															],
+														}
+													],
+												},
+											],
+										},
+										{
+											name: '/Users/legomushroom/repos/prompts',
+											children: [
+												{
+													name: 'general',
+													children: [
+														{
+															name: 'common.prompt.md',
+															contents: 'oh hi, bot!',
+														},
+														{
+															name: 'uncommon-10.prompt.md',
+															contents: 'oh hi, robot!',
+														},
+														{
+															name: 'license.md',
+															contents: 'non prompt file',
+														},
+													],
+												}
+											],
+										},
+									],
+								);
+
+								assert.deepStrictEqual(
+									(await locator.findAllMatchingPromptFiles())
+										.map((file) => file.fsPath),
+									[
+										createURI('/Users/legomushroom/repos/vscode/gen/text/my.prompt.md').fsPath,
+										createURI('/Users/legomushroom/repos/vscode/gen/text/nested/specific.prompt.md').fsPath,
+										createURI('/Users/legomushroom/repos/vscode/gen/text/nested/unspecific1.prompt.md').fsPath,
+										createURI('/Users/legomushroom/repos/vscode/gen/text/nested/unspecific2.prompt.md').fsPath,
+										// -
+										createURI('/Users/legomushroom/repos/prompts/general/common.prompt.md').fsPath,
+										createURI('/Users/legomushroom/repos/prompts/general/uncommon-10.prompt.md').fsPath,
+									],
+									'Must find correct prompts.',
+								);
+							});
+						}
+					});
+
+					suite(`• specific`, () => {
+						const testSettings = [
+							[
+								'**/my.prompt.md',
+								'**/*specific*',
+								'**/*common*',
+							],
+							[
+								'**/my.prompt.md',
+								'**/*specific*.prompt.md',
+								'**/*common*.prompt.md',
+							],
+							[
+								'**/my*.md',
+								'**/*specific*.md',
+								'**/*common*.md',
+							],
+							[
+								'**/my*.md',
+								'**/specific*',
+								'**/unspecific*',
+								'**/common*',
+								'**/uncommon*',
+							],
+							[
+								'**/my.prompt.md',
+								'**/specific.prompt.md',
+								'**/unspecific1.prompt.md',
+								'**/unspecific2.prompt.md',
+								'**/common.prompt.md',
+								'**/uncommon-10.prompt.md',
+							],
+							[
+								'gen*/**/my.prompt.md',
+								'gen*/**/*specific*',
+								'gen*/**/*common*',
+							],
+							[
+								'gen*/**/my.prompt.md',
+								'gen*/**/*specific*.prompt.md',
+								'gen*/**/*common*.prompt.md',
+							],
+							[
+								'gen*/**/my*.md',
+								'gen*/**/*specific*.md',
+								'gen*/**/*common*.md',
+							],
+							[
+								'gen*/**/my*.md',
+								'gen*/**/specific*',
+								'gen*/**/unspecific*',
+								'gen*/**/common*',
+								'gen*/**/uncommon*',
+							],
+							[
+								'gen*/**/my.prompt.md',
+								'gen*/**/specific.prompt.md',
+								'gen*/**/unspecific1.prompt.md',
+								'gen*/**/unspecific2.prompt.md',
+								'gen*/**/common.prompt.md',
+								'gen*/**/uncommon-10.prompt.md',
+							],
+							[
+								'gen/text/my.prompt.md',
+								'gen/text/nested/specific.prompt.md',
+								'gen/text/nested/unspecific1.prompt.md',
+								'gen/text/nested/unspecific2.prompt.md',
+								'general/common.prompt.md',
+								'general/uncommon-10.prompt.md',
+							],
+							[
+								'gen/text/my.prompt.md',
+								'gen/text/nested/*specific*',
+								'general/*common*',
+							],
+							[
+								'gen/text/my.prompt.md',
+								'gen/text/**/specific.prompt.md',
+								'gen/text/**/unspecific1.prompt.md',
+								'gen/text/**/unspecific2.prompt.md',
+								'general/*',
+							],
+							[
+								'{gen,general}/**/my.prompt.md',
+								'{gen,general}/**/*specific*',
+								'{gen,general}/**/*common*',
+							],
+							[
+								'{gen,general}/**/my.prompt.md',
+								'{gen,general}/**/*specific*.prompt.md',
+								'{gen,general}/**/*common*.prompt.md',
+							],
+							[
+								'{gen,general}/**/my*.md',
+								'{gen,general}/**/*specific*.md',
+								'{gen,general}/**/*common*.md',
+							],
+							[
+								'{gen,general}/**/my*.md',
+								'{gen,general}/**/specific*',
+								'{gen,general}/**/unspecific*',
+								'{gen,general}/**/common*',
+								'{gen,general}/**/uncommon*',
+							],
+							[
+								'{gen,general}/**/my.prompt.md',
+								'{gen,general}/**/specific.prompt.md',
+								'{gen,general}/**/unspecific1.prompt.md',
+								'{gen,general}/**/unspecific2.prompt.md',
+								'{gen,general}/**/common.prompt.md',
+								'{gen,general}/**/uncommon-10.prompt.md',
+							],
+						];
+
+						for (const settings of testSettings) {
+							test(`• '${JSON.stringify(settings)}'`, async () => {
+								const vscodeSettings: Record<string, boolean> = {};
+								for (const setting of settings) {
+									vscodeSettings[setting] = true;
+								}
+
+								const locator = await createPromptsLocator(
+									vscodeSettings,
+									[
+										'/Users/legomushroom/repos/vscode',
+										'/Users/legomushroom/repos/prompts',
+									],
+									[
+										{
+											name: '/Users/legomushroom/repos/vscode',
+											children: [
+												{
+													name: 'gen/text',
+													children: [
+														{
+															name: 'my.prompt.md',
+															contents: 'oh hi, bot!',
+														},
+														{
+															name: 'nested',
+															children: [
+																{
+																	name: 'specific.prompt.md',
+																	contents: 'oh hi, bot!',
+																},
+																{
+																	name: 'unspecific1.prompt.md',
+																	contents: 'oh hi, robot!',
+																},
+																{
+																	name: 'unspecific2.prompt.md',
+																	contents: 'oh hi, rabot!',
+																},
+																{
+																	name: 'readme.md',
+																	contents: 'non prompt file',
+																},
+															],
+														}
+													],
+												},
+											],
+										},
+										{
+											name: '/Users/legomushroom/repos/prompts',
+											children: [
+												{
+													name: 'general',
+													children: [
+														{
+															name: 'common.prompt.md',
+															contents: 'oh hi, bot!',
+														},
+														{
+															name: 'uncommon-10.prompt.md',
+															contents: 'oh hi, robot!',
+														},
+														{
+															name: 'license.md',
+															contents: 'non prompt file',
+														},
+													],
+												}
+											],
+										},
+									],
+								);
+
+								assert.deepStrictEqual(
+									(await locator.findAllMatchingPromptFiles())
+										.map((file) => file.fsPath),
+									[
+										createURI('/Users/legomushroom/repos/vscode/gen/text/my.prompt.md').fsPath,
+										createURI('/Users/legomushroom/repos/vscode/gen/text/nested/specific.prompt.md').fsPath,
+										createURI('/Users/legomushroom/repos/vscode/gen/text/nested/unspecific1.prompt.md').fsPath,
+										createURI('/Users/legomushroom/repos/vscode/gen/text/nested/unspecific2.prompt.md').fsPath,
+										// -
+										createURI('/Users/legomushroom/repos/prompts/general/common.prompt.md').fsPath,
+										createURI('/Users/legomushroom/repos/prompts/general/uncommon-10.prompt.md').fsPath,
+									],
+									'Must find correct prompts.',
+								);
+							});
+						}
+					});
+				});
+
+				suite('• absolute', () => {
+					suite('• wild card', () => {
+						const testSettings = [
+							'/Users/legomushroom/repos/**',
+							'/Users/legomushroom/repos/**/*.prompt.md',
+							'/Users/legomushroom/repos/**/*.md',
+							'/Users/legomushroom/repos/**/*',
+							'/Users/legomushroom/repos/**/gen*/**',
+							'/Users/legomushroom/repos/**/gen*/**/*.prompt.md',
+							'/Users/legomushroom/repos/**/gen*/**/*',
+							'/Users/legomushroom/repos/**/gen*/**/*.md',
+							'/Users/legomushroom/repos/**/gen*/**',
+							'/Users/legomushroom/repos/**/gen*/**/*',
+							'/Users/legomushroom/repos/**/gen*/**/*.md',
+							'/Users/legomushroom/repos/**/gen*/**/*.prompt.md',
+							'/Users/legomushroom/repos/{vscode,prompts}/**',
+							'/Users/legomushroom/repos/{vscode,prompts}/**/*.prompt.md',
+							'/Users/legomushroom/repos/{vscode,prompts}/**/*.md',
+							'/Users/legomushroom/repos/{vscode,prompts}/**/*',
+							'/Users/legomushroom/repos/{vscode,prompts}/**/gen*/**',
+							'/Users/legomushroom/repos/{vscode,prompts}/**/gen*/**/*.prompt.md',
+							'/Users/legomushroom/repos/{vscode,prompts}/**/gen*/**/*',
+							'/Users/legomushroom/repos/{vscode,prompts}/**/gen*/**/*.md',
+							'/Users/legomushroom/repos/{vscode,prompts}/**/gen*/**',
+							'/Users/legomushroom/repos/{vscode,prompts}/**/gen*/**/*',
+							'/Users/legomushroom/repos/{vscode,prompts}/**/gen*/**/*.md',
+							'/Users/legomushroom/repos/{vscode,prompts}/**/gen*/**/*.prompt.md',
+							'/Users/legomushroom/repos/{vscode,prompts}/**/{general,gen}/**',
+							'/Users/legomushroom/repos/{vscode,prompts}/**/{general,gen}/**/*.prompt.md',
+							'/Users/legomushroom/repos/{vscode,prompts}/**/{general,gen}/**/*',
+							'/Users/legomushroom/repos/{vscode,prompts}/**/{general,gen}/**/*.md',
+							'/Users/legomushroom/repos/{vscode,prompts}/**/{general,gen}/**',
+							'/Users/legomushroom/repos/{vscode,prompts}/**/{general,gen}/**/*',
+							'/Users/legomushroom/repos/{vscode,prompts}/**/{general,gen}/**/*.md',
+							'/Users/legomushroom/repos/{vscode,prompts}/**/{general,gen}/**/*.prompt.md',
+						];
+
+						for (const setting of testSettings) {
+							test(`• '${setting}'`, async () => {
+								const locator = await createPromptsLocator(
+									{ [setting]: true },
+									[
+										'/Users/legomushroom/repos/vscode',
+										'/Users/legomushroom/repos/prompts',
+									],
+									[
+										{
+											name: '/Users/legomushroom/repos/vscode',
+											children: [
+												{
+													name: 'gen/text',
+													children: [
+														{
+															name: 'my.prompt.md',
+															contents: 'oh hi, bot!',
+														},
+														{
+															name: 'nested',
+															children: [
+																{
+																	name: 'specific.prompt.md',
+																	contents: 'oh hi, bot!',
+																},
+																{
+																	name: 'unspecific1.prompt.md',
+																	contents: 'oh hi, robot!',
+																},
+																{
+																	name: 'unspecific2.prompt.md',
+																	contents: 'oh hi, rabot!',
+																},
+																{
+																	name: 'readme.md',
+																	contents: 'non prompt file',
+																},
+															],
+														}
+													],
+												},
+											],
+										},
+										{
+											name: '/Users/legomushroom/repos/prompts',
+											children: [
+												{
+													name: 'general',
+													children: [
+														{
+															name: 'common.prompt.md',
+															contents: 'oh hi, bot!',
+														},
+														{
+															name: 'uncommon-10.prompt.md',
+															contents: 'oh hi, robot!',
+														},
+														{
+															name: 'license.md',
+															contents: 'non prompt file',
+														},
+													],
+												}
+											],
+										},
+									],
+								);
+
+								assert.deepStrictEqual(
+									(await locator.findAllMatchingPromptFiles())
+										.map((file) => file.fsPath),
+									[
+										createURI('/Users/legomushroom/repos/vscode/gen/text/my.prompt.md').fsPath,
+										createURI('/Users/legomushroom/repos/vscode/gen/text/nested/specific.prompt.md').fsPath,
+										createURI('/Users/legomushroom/repos/vscode/gen/text/nested/unspecific1.prompt.md').fsPath,
+										createURI('/Users/legomushroom/repos/vscode/gen/text/nested/unspecific2.prompt.md').fsPath,
+										// -
+										createURI('/Users/legomushroom/repos/prompts/general/common.prompt.md').fsPath,
+										createURI('/Users/legomushroom/repos/prompts/general/uncommon-10.prompt.md').fsPath,
+									],
+									'Must find correct prompts.',
+								);
+							});
+						}
+					});
+
+					suite(`• specific`, () => {
+						const testSettings = [
+							[
+								'/Users/legomushroom/repos/**/my.prompt.md',
+								'/Users/legomushroom/repos/**/*specific*',
+								'/Users/legomushroom/repos/**/*common*',
+							],
+							[
+								'/Users/legomushroom/repos/**/my.prompt.md',
+								'/Users/legomushroom/repos/**/*specific*.prompt.md',
+								'/Users/legomushroom/repos/**/*common*.prompt.md',
+							],
+							[
+								'/Users/legomushroom/repos/**/my*.md',
+								'/Users/legomushroom/repos/**/*specific*.md',
+								'/Users/legomushroom/repos/**/*common*.md',
+							],
+							[
+								'/Users/legomushroom/repos/**/my*.md',
+								'/Users/legomushroom/repos/**/specific*',
+								'/Users/legomushroom/repos/**/unspecific*',
+								'/Users/legomushroom/repos/**/common*',
+								'/Users/legomushroom/repos/**/uncommon*',
+							],
+							[
+								'/Users/legomushroom/repos/**/my.prompt.md',
+								'/Users/legomushroom/repos/**/specific.prompt.md',
+								'/Users/legomushroom/repos/**/unspecific1.prompt.md',
+								'/Users/legomushroom/repos/**/unspecific2.prompt.md',
+								'/Users/legomushroom/repos/**/common.prompt.md',
+								'/Users/legomushroom/repos/**/uncommon-10.prompt.md',
+							],
+							[
+								'/Users/legomushroom/repos/**/gen*/**/my.prompt.md',
+								'/Users/legomushroom/repos/**/gen*/**/*specific*',
+								'/Users/legomushroom/repos/**/gen*/**/*common*',
+							],
+							[
+								'/Users/legomushroom/repos/**/gen*/**/my.prompt.md',
+								'/Users/legomushroom/repos/**/gen*/**/*specific*.prompt.md',
+								'/Users/legomushroom/repos/**/gen*/**/*common*.prompt.md',
+							],
+							[
+								'/Users/legomushroom/repos/**/gen*/**/my*.md',
+								'/Users/legomushroom/repos/**/gen*/**/*specific*.md',
+								'/Users/legomushroom/repos/**/gen*/**/*common*.md',
+							],
+							[
+								'/Users/legomushroom/repos/**/gen*/**/my*.md',
+								'/Users/legomushroom/repos/**/gen*/**/specific*',
+								'/Users/legomushroom/repos/**/gen*/**/unspecific*',
+								'/Users/legomushroom/repos/**/gen*/**/common*',
+								'/Users/legomushroom/repos/**/gen*/**/uncommon*',
+							],
+							[
+								'/Users/legomushroom/repos/**/gen*/**/my.prompt.md',
+								'/Users/legomushroom/repos/**/gen*/**/specific.prompt.md',
+								'/Users/legomushroom/repos/**/gen*/**/unspecific1.prompt.md',
+								'/Users/legomushroom/repos/**/gen*/**/unspecific2.prompt.md',
+								'/Users/legomushroom/repos/**/gen*/**/common.prompt.md',
+								'/Users/legomushroom/repos/**/gen*/**/uncommon-10.prompt.md',
+							],
+							[
+								'/Users/legomushroom/repos/vscode/gen/text/my.prompt.md',
+								'/Users/legomushroom/repos/vscode/gen/text/nested/specific.prompt.md',
+								'/Users/legomushroom/repos/vscode/gen/text/nested/unspecific1.prompt.md',
+								'/Users/legomushroom/repos/vscode/gen/text/nested/unspecific2.prompt.md',
+								'/Users/legomushroom/repos/prompts/general/common.prompt.md',
+								'/Users/legomushroom/repos/prompts/general/uncommon-10.prompt.md',
+							],
+							[
+								'/Users/legomushroom/repos/vscode/gen/text/my.prompt.md',
+								'/Users/legomushroom/repos/vscode/gen/text/nested/*specific*',
+								'/Users/legomushroom/repos/prompts/general/*common*',
+							],
+							[
+								'/Users/legomushroom/repos/vscode/gen/text/my.prompt.md',
+								'/Users/legomushroom/repos/vscode/gen/text/**/specific.prompt.md',
+								'/Users/legomushroom/repos/vscode/gen/text/**/unspecific1.prompt.md',
+								'/Users/legomushroom/repos/vscode/gen/text/**/unspecific2.prompt.md',
+								'/Users/legomushroom/repos/prompts/general/*',
+							],
+							[
+								'/Users/legomushroom/repos/**/{gen,general}/**/my.prompt.md',
+								'/Users/legomushroom/repos/**/{gen,general}/**/*specific*',
+								'/Users/legomushroom/repos/**/{gen,general}/**/*common*',
+							],
+							[
+								'/Users/legomushroom/repos/**/{gen,general}/**/my.prompt.md',
+								'/Users/legomushroom/repos/**/{gen,general}/**/*specific*.prompt.md',
+								'/Users/legomushroom/repos/**/{gen,general}/**/*common*.prompt.md',
+							],
+							[
+								'/Users/legomushroom/repos/**/{gen,general}/**/my*.md',
+								'/Users/legomushroom/repos/**/{gen,general}/**/*specific*.md',
+								'/Users/legomushroom/repos/**/{gen,general}/**/*common*.md',
+							],
+							[
+								'/Users/legomushroom/repos/**/{gen,general}/**/my*.md',
+								'/Users/legomushroom/repos/**/{gen,general}/**/specific*',
+								'/Users/legomushroom/repos/**/{gen,general}/**/unspecific*',
+								'/Users/legomushroom/repos/**/{gen,general}/**/common*',
+								'/Users/legomushroom/repos/**/{gen,general}/**/uncommon*',
+							],
+							[
+								'/Users/legomushroom/repos/**/{gen,general}/**/my.prompt.md',
+								'/Users/legomushroom/repos/**/{gen,general}/**/specific.prompt.md',
+								'/Users/legomushroom/repos/**/{gen,general}/**/unspecific1.prompt.md',
+								'/Users/legomushroom/repos/**/{gen,general}/**/unspecific2.prompt.md',
+								'/Users/legomushroom/repos/**/{gen,general}/**/common.prompt.md',
+								'/Users/legomushroom/repos/**/{gen,general}/**/uncommon-10.prompt.md',
+							],
+							[
+								'/Users/legomushroom/repos/{prompts,vscode,copilot}/{gen,general}/**/my.prompt.md',
+								'/Users/legomushroom/repos/{prompts,vscode,copilot}/{gen,general}/**/*specific*',
+								'/Users/legomushroom/repos/{prompts,vscode,copilot}/{gen,general}/**/*common*',
+							],
+							[
+								'/Users/legomushroom/repos/{prompts,vscode,copilot}/{gen,general}/**/my.prompt.md',
+								'/Users/legomushroom/repos/{prompts,vscode,copilot}/{gen,general}/**/*specific*.prompt.md',
+								'/Users/legomushroom/repos/{prompts,vscode,copilot}/{gen,general}/**/*common*.prompt.md',
+							],
+							[
+								'/Users/legomushroom/repos/{prompts,vscode,copilot}/{gen,general}/**/my*.md',
+								'/Users/legomushroom/repos/{prompts,vscode,copilot}/{gen,general}/**/*specific*.md',
+								'/Users/legomushroom/repos/{prompts,vscode,copilot}/{gen,general}/**/*common*.md',
+							],
+							[
+								'/Users/legomushroom/repos/{prompts,vscode,copilot}/{gen,general}/**/my*.md',
+								'/Users/legomushroom/repos/{prompts,vscode,copilot}/{gen,general}/**/specific*',
+								'/Users/legomushroom/repos/{prompts,vscode,copilot}/{gen,general}/**/unspecific*',
+								'/Users/legomushroom/repos/{prompts,vscode,copilot}/{gen,general}/**/common*',
+								'/Users/legomushroom/repos/{prompts,vscode,copilot}/{gen,general}/**/uncommon*',
+							],
+							[
+								'/Users/legomushroom/repos/{prompts,vscode,copilot}/{gen,general}/**/my.prompt.md',
+								'/Users/legomushroom/repos/{prompts,vscode,copilot}/{gen,general}/**/specific.prompt.md',
+								'/Users/legomushroom/repos/{prompts,vscode,copilot}/{gen,general}/**/unspecific1.prompt.md',
+								'/Users/legomushroom/repos/{prompts,vscode,copilot}/{gen,general}/**/unspecific2.prompt.md',
+								'/Users/legomushroom/repos/{prompts,vscode,copilot}/{gen,general}/**/common.prompt.md',
+								'/Users/legomushroom/repos/{prompts,vscode,copilot}/{gen,general}/**/uncommon-10.prompt.md',
+							],
+						];
+
+						for (const settings of testSettings) {
+							test(`• '${JSON.stringify(settings)}'`, async () => {
+								const vscodeSettings: Record<string, boolean> = {};
+								for (const setting of settings) {
+									vscodeSettings[setting] = true;
+								}
+
+								const locator = await createPromptsLocator(
+									vscodeSettings,
+									[
+										'/Users/legomushroom/repos/vscode',
+										'/Users/legomushroom/repos/prompts',
+									],
+									[
+										{
+											name: '/Users/legomushroom/repos/vscode',
+											children: [
+												{
+													name: 'gen/text',
+													children: [
+														{
+															name: 'my.prompt.md',
+															contents: 'oh hi, bot!',
+														},
+														{
+															name: 'nested',
+															children: [
+																{
+																	name: 'specific.prompt.md',
+																	contents: 'oh hi, bot!',
+																},
+																{
+																	name: 'unspecific1.prompt.md',
+																	contents: 'oh hi, robot!',
+																},
+																{
+																	name: 'unspecific2.prompt.md',
+																	contents: 'oh hi, rabot!',
+																},
+																{
+																	name: 'readme.md',
+																	contents: 'non prompt file',
+																},
+															],
+														}
+													],
+												},
+											],
+										},
+										{
+											name: '/Users/legomushroom/repos/prompts',
+											children: [
+												{
+													name: 'general',
+													children: [
+														{
+															name: 'common.prompt.md',
+															contents: 'oh hi, bot!',
+														},
+														{
+															name: 'uncommon-10.prompt.md',
+															contents: 'oh hi, robot!',
+														},
+														{
+															name: 'license.md',
+															contents: 'non prompt file',
+														},
+													],
+												}
+											],
+										},
+									],
+								);
+
+								assert.deepStrictEqual(
+									(await locator.findAllMatchingPromptFiles())
+										.map((file) => file.fsPath),
+									[
+										createURI('/Users/legomushroom/repos/vscode/gen/text/my.prompt.md').fsPath,
+										createURI('/Users/legomushroom/repos/vscode/gen/text/nested/specific.prompt.md').fsPath,
+										createURI('/Users/legomushroom/repos/vscode/gen/text/nested/unspecific1.prompt.md').fsPath,
+										createURI('/Users/legomushroom/repos/vscode/gen/text/nested/unspecific2.prompt.md').fsPath,
+										// -
+										createURI('/Users/legomushroom/repos/prompts/general/common.prompt.md').fsPath,
+										createURI('/Users/legomushroom/repos/prompts/general/uncommon-10.prompt.md').fsPath,
+									],
+									'Must find correct prompts.',
+								);
+							});
+						}
+					});
+				});
+			});
+		});
+	});
 });

--- a/src/vs/workbench/contrib/chat/test/common/promptSyntax/utils/promptFilesLocator.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/promptSyntax/utils/promptFilesLocator.test.ts
@@ -22,11 +22,6 @@ import { IConfigurationOverrides, IConfigurationService } from '../../../../../.
 import { IWorkspace, IWorkspaceContextService, IWorkspaceFolder } from '../../../../../../../platform/workspace/common/workspace.js';
 
 /**
- * TODO: @lego - list
- *  - add `all together` unit tests
- */
-
-/**
  * Mocked instance of {@link IConfigurationService}.
  */
 const mockConfigService = <T>(value: T): IConfigurationService => {
@@ -1480,6 +1475,136 @@ suite('PromptFilesLocator', () => {
 						createURI('/Users/legomushroom/repos/prompts/test.prompt.md').path,
 						createURI('/Users/legomushroom/repos/prompts/refactor-tests.prompt.md').path,
 						createURI('/tmp/prompts/translate.to-rust.prompt.md').path,
+					],
+					'Must find correct prompts.',
+				);
+			});
+
+			test('• mixed', async () => {
+				const locator = await createPromptsLocator(
+					{
+						'/Users/legomushroom/repos/**/*test*': true,
+						'.copilot/prompts': false,
+						'.github/prompts': true,
+						'/absolute/path/prompts/some-prompt-file.prompt.md': true,
+					},
+					[
+						'/Users/legomushroom/repos/vscode',
+						'/Users/legomushroom/repos/node',
+						'/var/shared/prompts/.github',
+					],
+					[
+						{
+							name: '/Users/legomushroom/repos/prompts',
+							children: [
+								{
+									name: 'test.prompt.md',
+									contents: 'Hello, World!',
+								},
+								{
+									name: 'refactor-tests.prompt.md',
+									contents: 'some file content goes here',
+								},
+								{
+									name: 'elf.prompt.md',
+									contents: 'haalo!',
+								},
+							],
+						},
+						{
+							name: '/tmp/prompts',
+							children: [
+								{
+									name: 'translate.to-rust.prompt.md',
+									contents: 'some more random file contents',
+								},
+							],
+						},
+						{
+							name: '/absolute/path/prompts',
+							children: [
+								{
+									name: 'some-prompt-file.prompt.md',
+									contents: 'hey hey hey',
+								},
+							],
+						},
+						{
+							name: '/Users/legomushroom/repos/vscode',
+							children: [
+								{
+									name: '.copilot/prompts',
+									children: [
+										{
+											name: 'prompt1.prompt.md',
+											contents: 'oh hi, robot!',
+										},
+									],
+								},
+								{
+									name: '.github/prompts',
+									children: [
+										{
+											name: 'default.prompt.md',
+											contents: 'oh hi, bot!',
+										},
+									],
+								},
+							],
+						},
+						{
+							name: '/Users/legomushroom/repos/node',
+							children: [
+								{
+									name: '.copilot/prompts',
+									children: [
+										{
+											name: 'prompt5.prompt.md',
+											contents: 'oh hi, robot!',
+										},
+									],
+								},
+								{
+									name: '.github/prompts',
+									children: [
+										{
+											name: 'refactor-static-classes.prompt.md',
+											contents: 'file contents',
+										},
+									],
+								},
+							],
+						},
+						// note! this folder is part of the workspace, so prompt files are `included`
+						{
+							name: '/var/shared/prompts/.github/prompts',
+							children: [
+								{
+									name: 'prompt-name.prompt.md',
+									contents: 'oh hi, robot!',
+								},
+								{
+									name: 'name-of-the-prompt.prompt.md',
+									contents: 'oh hi, raw bot!',
+								},
+							],
+						},
+					]);
+
+				assert.deepStrictEqual(
+					(await locator.listFiles())
+						.map((file) => file.fsPath),
+					[
+						// all of these are due to the `.github/prompts` setting
+						createURI('/Users/legomushroom/repos/vscode/.github/prompts/default.prompt.md').fsPath,
+						createURI('/Users/legomushroom/repos/node/.github/prompts/refactor-static-classes.prompt.md').fsPath,
+						createURI('/var/shared/prompts/.github/prompts/prompt-name.prompt.md').fsPath,
+						createURI('/var/shared/prompts/.github/prompts/name-of-the-prompt.prompt.md').fsPath,
+						// all of these are due to the `/Users/legomushroom/repos/**/*test*` setting
+						createURI('/Users/legomushroom/repos/prompts/test.prompt.md').fsPath,
+						createURI('/Users/legomushroom/repos/prompts/refactor-tests.prompt.md').fsPath,
+						// this one is due to the specific `/absolute/path/prompts/some-prompt-file.prompt.md` setting
+						createURI('/absolute/path/prompts/some-prompt-file.prompt.md').fsPath,
 					],
 					'Must find correct prompts.',
 				);

--- a/src/vs/workbench/contrib/chat/test/common/promptSyntax/utils/promptFilesLocator.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/promptSyntax/utils/promptFilesLocator.test.ts
@@ -13,7 +13,7 @@ import { IFileService } from '../../../../../../../platform/files/common/files.j
 import { PromptsConfig } from '../../../../../../../platform/prompts/common/config.js';
 import { FileService } from '../../../../../../../platform/files/common/fileService.js';
 import { ILogService, NullLogService } from '../../../../../../../platform/log/common/log.js';
-import { PromptFilesLocator } from '../../../../common/promptSyntax/utils/promptFilesLocator.js';
+import { isValidGlob, PromptFilesLocator } from '../../../../common/promptSyntax/utils/promptFilesLocator.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../../base/test/common/utils.js';
 import { mockObject, mockService } from '../../../../../../../platform/prompts/test/common/utils/mock.js';
 import { InMemoryFileSystemProvider } from '../../../../../../../platform/files/common/inMemoryFilesystemProvider.js';
@@ -2291,6 +2291,81 @@ suite('PromptFilesLocator', () => {
 					}
 				});
 			});
+		});
+	});
+
+	suite('• isValidGlob', () => {
+		test('• valid patterns', () => {
+			const globs = [
+				'**',
+				'\*',
+				'\**',
+				'**/*',
+				'**/*.prompt.md',
+				'/Users/legomushroom/**/*.prompt.md',
+				'/Users/legomushroom/*.prompt.md',
+				'/Users/legomushroom/*',
+				'/Users/legomushroom/repos/{repo1,test}',
+				'/Users/legomushroom/repos/{repo1,test}/**',
+				'/Users/legomushroom/repos/{repo1,test}/*',
+				'/Users/legomushroom/**/{repo1,test}/**',
+				'/Users/legomushroom/**/{repo1,test}',
+				'/Users/legomushroom/**/{repo1,test}/*',
+				'/Users/legomushroom/**/repo[1,2,3]',
+				'/Users/legomushroom/**/repo[1,2,3]/**',
+				'/Users/legomushroom/**/repo[1,2,3]/*',
+				'/Users/legomushroom/**/repo[1,2,3]/**/*.prompt.md',
+				'repo[1,2,3]/**/*.prompt.md',
+				'repo[[1,2,3]/**/*.prompt.md',
+				'{repo1,test}/*.prompt.md',
+				'{repo1,test}/*',
+				'/{repo1,test}/*',
+				'/{repo1,test}}/*',
+			];
+
+			for (const glob of globs) {
+				assert(
+					(isValidGlob(glob) === true),
+					`'${glob}' must be a 'valid' glob pattern.`,
+				);
+			}
+		});
+
+		test('• invalid patterns', () => {
+			const globs = [
+				'.',
+				'\\*',
+				'\\?',
+				'\\*\\?\\*',
+				'repo[1,2,3',
+				'repo1,2,3]',
+				'repo\\[1,2,3]',
+				'repo[1,2,3\\]',
+				'repo\\[1,2,3\\]',
+				'{repo1,repo2',
+				'repo1,repo2}',
+				'\\{repo1,repo2}',
+				'{repo1,repo2\\}',
+				'\\{repo1,repo2\\}',
+				'/Users/legomushroom/repos',
+				'/Users/legomushroom/repo[1,2,3',
+				'/Users/legomushroom/repo1,2,3]',
+				'/Users/legomushroom/repo\\[1,2,3]',
+				'/Users/legomushroom/repo[1,2,3\\]',
+				'/Users/legomushroom/repo\\[1,2,3\\]',
+				'/Users/legomushroom/{repo1,repo2',
+				'/Users/legomushroom/repo1,repo2}',
+				'/Users/legomushroom/\\{repo1,repo2}',
+				'/Users/legomushroom/{repo1,repo2\\}',
+				'/Users/legomushroom/\\{repo1,repo2\\}',
+			];
+
+			for (const glob of globs) {
+				assert(
+					(isValidGlob(glob) === false),
+					`'${glob}' must be an 'invalid' glob pattern.`,
+				);
+			}
 		});
 	});
 });


### PR DESCRIPTION
For https://github.com/microsoft/vscode-copilot/issues/14346, part of https://github.com/microsoft/vscode-copilot/issues/13952.

The PR adds support for `glob patterns` for `locations` settings of "prompt files" feature.