### PR TITLE
chore: bump node-pty to 1.1.0-beta32

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
         "native-is-elevated": "0.7.0",
         "native-keymap": "^3.3.5",
         "native-watchdog": "^1.4.1",
-        "node-pty": "1.1.0-beta31",
+        "node-pty": "1.1.0-beta32",
         "open": "^8.4.2",
         "tas-client-umd": "0.2.0",
         "v8-inspect-profiler": "^0.1.1",
@@ -12648,9 +12648,9 @@
       }
     },
     "node_modules/node-pty": {
-      "version": "1.1.0-beta31",
-      "resolved": "https://registry.npmjs.org/node-pty/-/node-pty-1.1.0-beta31.tgz",
-      "integrity": "sha512-DwNyk7nQ8NfHX7NrIqvNQ5GiK6eBbsRYJ+hvHK04PTzZ6o5j1Qsc67g0QxXW8tki/ZJmE9Zxw6PEGncvDshdVw==",
+      "version": "1.1.0-beta32",
+      "resolved": "https://registry.npmjs.org/node-pty/-/node-pty-1.1.0-beta32.tgz",
+      "integrity": "sha512-4sp3VUcZuInNOpd0F7Ai8I0z3is5JEfs+4kJECx32u0y64BsoeKKUzPBwWYE4A0kpIeBSFmjDGmkQA317cD/eg==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "native-is-elevated": "0.7.0",
     "native-keymap": "^3.3.5",
     "native-watchdog": "^1.4.1",
-    "node-pty": "1.1.0-beta31",
+    "node-pty": "1.1.0-beta32",
     "open": "^8.4.2",
     "tas-client-umd": "0.2.0",
     "v8-inspect-profiler": "^0.1.1",

--- a/remote/package-lock.json
+++ b/remote/package-lock.json
@@ -37,7 +37,7 @@
         "kerberos": "2.1.1",
         "minimist": "^1.2.6",
         "native-watchdog": "^1.4.1",
-        "node-pty": "1.1.0-beta31",
+        "node-pty": "1.1.0-beta32",
         "tas-client-umd": "0.2.0",
         "vscode-oniguruma": "1.7.0",
         "vscode-regexpp": "^3.1.0",
@@ -1098,9 +1098,9 @@
       }
     },
     "node_modules/node-pty": {
-      "version": "1.1.0-beta31",
-      "resolved": "https://registry.npmjs.org/node-pty/-/node-pty-1.1.0-beta31.tgz",
-      "integrity": "sha512-DwNyk7nQ8NfHX7NrIqvNQ5GiK6eBbsRYJ+hvHK04PTzZ6o5j1Qsc67g0QxXW8tki/ZJmE9Zxw6PEGncvDshdVw==",
+      "version": "1.1.0-beta32",
+      "resolved": "https://registry.npmjs.org/node-pty/-/node-pty-1.1.0-beta32.tgz",
+      "integrity": "sha512-4sp3VUcZuInNOpd0F7Ai8I0z3is5JEfs+4kJECx32u0y64BsoeKKUzPBwWYE4A0kpIeBSFmjDGmkQA317cD/eg==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/remote/package.json
+++ b/remote/package.json
@@ -32,7 +32,7 @@
     "kerberos": "2.1.1",
     "minimist": "^1.2.6",
     "native-watchdog": "^1.4.1",
-    "node-pty": "1.1.0-beta31",
+    "node-pty": "1.1.0-beta32",
     "tas-client-umd": "0.2.0",
     "vscode-oniguruma": "1.7.0",
     "vscode-regexpp": "^3.1.0",


### PR DESCRIPTION
This PR resolves various node-pty BinSkim issues and brings in some more conpty fixes.