### PR TITLE
track continuation prompt for zsh, add last line value when continuation prompt is defined and it's not on the last line

### DIFF
--- a/src/vs/platform/terminal/common/capabilities/commandDetection/promptInputModel.ts
+++ b/src/vs/platform/terminal/common/capabilities/commandDetection/promptInputModel.ts
@@ -322,7 +322,15 @@ export class PromptInputModel extends Disposable implements IPromptInputModel {
 					} else {
 						cursorIndex += trimmedLineText.length + 1;
 					}
-				} else {
+				} else if (absoluteCursorY === y && this._continuationPrompt && !this._lineContainsContinuationPrompt(lineText)) {
+					// We're on the last line and the continuation prompt is not present, so we need to add the value
+					value += `${lineText}`;
+					const relativeCursorIndex = this._getRelativeCursorIndex(0, buffer, line);
+					if (absoluteCursorY === y) {
+						cursorIndex += relativeCursorIndex;
+					} else {
+						cursorIndex += lineText.length;
+					}
 					break;
 				}
 			}

--- a/src/vs/workbench/contrib/terminal/common/scripts/shellIntegration-rc.zsh
+++ b/src/vs/workbench/contrib/terminal/common/scripts/shellIntegration-rc.zsh
@@ -112,6 +112,8 @@ unset VSCODE_NONCE
 __vscode_shell_env_reporting="$VSCODE_SHELL_ENV_REPORTING"
 unset VSCODE_SHELL_ENV_REPORTING
 
+builtin printf "\e]633;P;ContinuationPrompt=%s\a" "$(echo "$PS2" | sed 's/\x1b/\\\\x1b/g')"
+
 # Report this shell supports rich command detection
 builtin printf '\e]633;P;HasRichCommandDetection=True\a'
 


### PR DESCRIPTION
fixes https://github.com/microsoft/vscode/issues/242700

fish will be trickier as it does not have a continuation prompt 