### PR TITLE
Fix prompt glitch on zsh, bash when environment reporting is set to true

### DIFF
--- a/src/vs/platform/terminal/node/terminalEnvironment.ts
+++ b/src/vs/platform/terminal/node/terminalEnvironment.ts
@@ -89,7 +89,7 @@ export function getShellIntegrationInjection(
 	}
 	if (shellLaunchConfig.shellIntegrationEnvironmentReporting) {
 		if (isWindows) {
-			const enableWindowsEnvReporting = options.windowsUseConptyDll || options.windowsEnableConpty && getWindowsBuildNumber() >= 22631;
+			const enableWindowsEnvReporting = options.windowsUseConptyDll || options.windowsEnableConpty && getWindowsBuildNumber() >= 22631 && shell !== 'bash.exe';
 			if (enableWindowsEnvReporting) {
 				envMixin['VSCODE_SHELL_ENV_REPORTING'] = '1';
 			}

--- a/src/vs/workbench/contrib/terminal/common/scripts/shellIntegration-bash.sh
+++ b/src/vs/workbench/contrib/terminal/common/scripts/shellIntegration-bash.sh
@@ -316,31 +316,31 @@ __vsc_update_env() {
 		if [ "$use_associative_array" = 1 ]; then
 			if [ ${#vsc_aa_env[@]} -eq 0 ]; then
 				# Associative array is empty, do not diff, just add
-				while IFS= read -r line; do
+				# Use env followed by null bytes to properly handle multiline values
+				while IFS= read -r -d $'\0' line; do
 					if [[ "$line" == *"="* ]]; then
 						local key="${line%%=*}"
 						local value="${line#*=}"
-
 						vsc_aa_env["$key"]="$value"
 						builtin printf '\e]633;EnvSingleEntry;%s;%s;%s\a' "$key" "$(__vsc_escape_value "$value")" "$__vsc_nonce"
 					fi
-				done < <(env)
+				done < <(env -0)
 			else
 				# Diff approach for associative array
-				while IFS= read -r line; do
+				while IFS= read -r -d $'\0' line; do
 					if [[ "$line" == *"="* ]]; then
 						local key="${line%%=*}"
 						local value="${line#*=}"
 						__updateEnvCacheAA "$key" "$value"
 					fi
-				done < <(env)
+				done < <(env -0)
 				__trackMissingEnvVarsAA
 			fi
 
 		else
 			if [[ -z ${vsc_env_keys[@]} ]] && [[ -z ${vsc_env_values[@]} ]]; then
 				# Non associative arrays are both empty, do not diff, just add
-				while IFS= read -r line; do
+				while IFS= read -r -d $'\0' line; do
 					if [[ "$line" == *"="* ]]; then
 						local key="${line%%=*}"
 						local value="${line#*=}"
@@ -348,16 +348,16 @@ __vsc_update_env() {
 						vsc_env_values+=("$value")
 						builtin printf '\e]633;EnvSingleEntry;%s;%s;%s\a' "$key" "$(__vsc_escape_value "$value")" "$__vsc_nonce"
 					fi
-				done < <(env)
+				done < <(env -0)
 			else
 				# Diff approach for non-associative arrays
-				while IFS= read -r line; do
+				while IFS= read -r -d $'\0' line; do
 					if [[ "$line" == *"="* ]]; then
 						local key="${line%%=*}"
 						local value="${line#*=}"
 						__updateEnvCache "$key" "$value"
 					fi
-				done < <(env)
+				done < <(env -0)
 				__trackMissingEnvVars
 			fi
 		fi

--- a/src/vs/workbench/contrib/terminal/common/scripts/shellIntegration-bash.sh
+++ b/src/vs/workbench/contrib/terminal/common/scripts/shellIntegration-bash.sh
@@ -322,9 +322,6 @@ __vsc_update_env() {
 						local value="${line#*=}"
 
 						vsc_aa_env["$key"]="$value"
-						builtin printf 'this is the key that I will be sending. Key: %s \n' "$key"
-						builtin printf 'this is the value that I will be sending. Value: %s \n' "$value"
-						builtin printf ' thank you\n'
 						builtin printf '\e]633;EnvSingleEntry;%s;%s;%s\a' "$key" "$(__vsc_escape_value "$value")" "$__vsc_nonce"
 					fi
 				done < <(env)

--- a/src/vs/workbench/contrib/terminal/common/scripts/shellIntegration-bash.sh
+++ b/src/vs/workbench/contrib/terminal/common/scripts/shellIntegration-bash.sh
@@ -313,7 +313,7 @@ __vsc_update_env() {
 	local __vsc_start_time
 	local __vsc_end_time
 
-	# Get start time - use perl for cross-platform millisecond precision
+	# REMOVE AFTER DEMO: Get start time - use perl for cross-platform millisecond precision
 	__vsc_start_time=$(perl -MTime::HiRes -e 'printf("%.0f\n",Time::HiRes::time()*1000)')
 
 	if [[ "$__vscode_shell_env_reporting" == "1" ]]; then
@@ -322,15 +322,17 @@ __vsc_update_env() {
 		if [ "$use_associative_array" = 1 ]; then
 			if [ ${#vsc_aa_env[@]} -eq 0 ]; then
 				# Associative array is empty, do not diff, just add
-				# Use env followed by null bytes to properly handle multiline values
+				# Use null byte instead of a newline to support multi-line values (e.g. PS1 values)
 				while IFS= read -r -d $'\0' line; do
 					if [[ "$line" == *"="* ]]; then
+						# %% removes longest match of =* Ensure we get everything before first equal sign.
 						local key="${line%%=*}"
+						# # removes shortest match of *= Ensure we get everything after first equal sign. Preserving additional equal signs.
 						local value="${line#*=}"
 						vsc_aa_env["$key"]="$value"
 						builtin printf '\e]633;EnvSingleEntry;%s;%s;%s\a' "$key" "$(__vsc_escape_value "$value")" "$__vsc_nonce"
 					fi
-				done < <(env -0)
+				done < <(env -0) # env command with null bytes as separator instead of newlines
 			else
 				# Diff approach for associative array
 				while IFS= read -r -d $'\0' line; do

--- a/src/vs/workbench/contrib/terminal/common/scripts/shellIntegration-bash.sh
+++ b/src/vs/workbench/contrib/terminal/common/scripts/shellIntegration-bash.sh
@@ -310,6 +310,12 @@ __trackMissingEnvVars() {
 }
 
 __vsc_update_env() {
+	local __vsc_start_time
+	local __vsc_end_time
+
+	# Get start time - use perl for cross-platform millisecond precision
+	__vsc_start_time=$(perl -MTime::HiRes -e 'printf("%.0f\n",Time::HiRes::time()*1000)')
+
 	if [[ "$__vscode_shell_env_reporting" == "1" ]]; then
 		builtin printf '\e]633;EnvSingleStart;%s;%s\a' 0 $__vsc_nonce
 
@@ -363,6 +369,11 @@ __vsc_update_env() {
 		fi
 		builtin printf '\e]633;EnvSingleEnd;%s;\a' $__vsc_nonce
 	fi
+
+	# Get end time and calculate difference in milliseconds
+	__vsc_end_time=$(perl -MTime::HiRes -e 'printf("%.0f\n",Time::HiRes::time()*1000)')
+	local __vsc_total_time=$(( __vsc_end_time - __vsc_start_time ))
+	builtin printf 'vsc_update_env execution time: %s ms\n' "$__vsc_total_time"
 }
 
 __vsc_command_output_start() {

--- a/src/vs/workbench/contrib/terminal/common/scripts/shellIntegration-rc.zsh
+++ b/src/vs/workbench/contrib/terminal/common/scripts/shellIntegration-rc.zsh
@@ -83,7 +83,7 @@ __vsc_escape_value() {
 	builtin local LC_ALL=C str="$1" i byte token out='' val
 
 	for (( i = 0; i < ${#str}; ++i )); do
-	# Escape backslashes, semi-colons and special characters, similar to bash shell integration
+	# Escape backslashes, semi-colons specially, then special ASCII chars below space (0x20).
 		byte="${str:$i:1}"
 		val=$(printf "%d" "'$byte")
 		if (( val < 31 )); then

--- a/src/vs/workbench/contrib/terminal/common/scripts/shellIntegration-rc.zsh
+++ b/src/vs/workbench/contrib/terminal/common/scripts/shellIntegration-rc.zsh
@@ -113,8 +113,6 @@ unset VSCODE_NONCE
 __vscode_shell_env_reporting="$VSCODE_SHELL_ENV_REPORTING"
 unset VSCODE_SHELL_ENV_REPORTING
 
-builtin printf "\e]633;P;ContinuationPrompt=%s\a" "$(echo "$PS2" | sed 's/\x1b/\\\\x1b/g')"
-
 # Report this shell supports rich command detection
 builtin printf '\e]633;P;HasRichCommandDetection=True\a'
 

--- a/src/vs/workbench/contrib/terminal/common/scripts/shellIntegration-rc.zsh
+++ b/src/vs/workbench/contrib/terminal/common/scripts/shellIntegration-rc.zsh
@@ -74,6 +74,8 @@ if [ -z "$VSCODE_SHELL_INTEGRATION" ]; then
 	builtin return
 fi
 
+# The property (P) and command (E) codes embed values which require escaping.
+# Backslashes are doubled. Non-alphanumeric characters are converted to escaped hex.
 __vsc_escape_value() {
 	builtin emulate -L zsh
 
@@ -110,6 +112,8 @@ unset VSCODE_NONCE
 
 __vscode_shell_env_reporting="$VSCODE_SHELL_ENV_REPORTING"
 unset VSCODE_SHELL_ENV_REPORTING
+
+builtin printf "\e]633;P;ContinuationPrompt=%s\a" "$(echo "$PS2" | sed 's/\x1b/\\\\x1b/g')"
 
 # Report this shell supports rich command detection
 builtin printf '\e]633;P;HasRichCommandDetection=True\a'
@@ -211,11 +215,7 @@ __vsc_update_env() {
 				# Associative array is empty, do not diff, just add
 				while IFS='=' read -r key value; do
 					vsc_aa_env["$key"]="$value"
-					# print key value pair
-					# builtin printf ' Iterating through single key, value: \n'
-					# builtin printf 'my key is %s and my escaped value is %s \n' "$key" "$(__vsc_escape_value "$value")"
 					builtin printf '\e]633;EnvSingleEntry;%s;%s;%s\a' "$key" "$(__vsc_escape_value "$value")" "$__vsc_nonce"
-					# builtin printf ' Done iterating through single key, value: \n\n '
 				done < <(env)
 			else
 				# Diff approach for associative array
@@ -232,12 +232,7 @@ __vsc_update_env() {
 				while IFS='=' read -r key value; do
 					__vsc_env_keys+=("$key")
 					__vsc_env_values+=("$value")
-					if [[ "$key" == "PS1" ]]; then
-						builtin printf '\e]633;EnvSingleEntry;%s;%s;%s\a' "$key" "$value" "$__vsc_nonce"
-					else
-						builtin printf '\e]633;EnvSingleEntry;%s;%s;%s\a' "$key" "$(__vsc_escape_value "$value")" "$__vsc_nonce"
-					fi
-
+					builtin printf '\e]633;EnvSingleEntry;%s;%s;%s\a' "$key" "$(__vsc_escape_value "$value")" "$__vsc_nonce"
 				done < <(env)
 			else
 				# Diff approach for non-associative arrays
@@ -292,12 +287,6 @@ __vsc_update_prompt() {
 	__vsc_prior_prompt="$PS1"
 	__vsc_prior_prompt2="$PS2"
 	__vsc_in_command_execution=""
-	# builtin print value of __vsc_prompt_start, ps1, __vsc_prompt_end
-	# builtin printf 'printing value of __vsc_prompt_start, ps1, __vsc_prompt_end'
-	# builtin printf 'my __vsc_prompt_start is %s \n' "$__vsc_prompt_start"
-	# builtin printf 'my PS1 is %s \n' "$PS1"
-	# builtin printf 'my __vsc_prompt_end %s \n' "$__vsc_prompt_end"
-
 	PS1="%{$(__vsc_prompt_start)%}$PS1%{$(__vsc_prompt_end)%}"
 	PS2="%{$(__vsc_continuation_start)%}$PS2%{$(__vsc_continuation_end)%}"
 	if [ -n "$RPROMPT" ]; then

--- a/src/vs/workbench/contrib/terminal/common/scripts/shellIntegration.ps1
+++ b/src/vs/workbench/contrib/terminal/common/scripts/shellIntegration.ps1
@@ -58,7 +58,7 @@ if ($env:VSCODE_ENV_APPEND) {
 function Global:__VSCode-Escape-Value([string]$value) {
 	# NOTE: In PowerShell v6.1+, this can be written `$value -replace '…', { … }` instead of `[regex]::Replace`.
 	# Replace any non-alphanumeric characters.
-	[regex]::Replace($value, "[$([char]0x00)-$([char]0x1f)\\\n;]", { param($match) # TODO: Need to do the same in zsh, bash
+	[regex]::Replace($value, "[$([char]0x00)-$([char]0x1f)\\\n;]", { param($match)
 			# Encode the (ascii) matches as `\x<hex>`
 			-Join (
 				[System.Text.Encoding]::UTF8.GetBytes($match.Value) | ForEach-Object { '\x{0:x2}' -f $_ }

--- a/src/vs/workbench/contrib/terminal/common/scripts/shellIntegration.ps1
+++ b/src/vs/workbench/contrib/terminal/common/scripts/shellIntegration.ps1
@@ -58,7 +58,7 @@ if ($env:VSCODE_ENV_APPEND) {
 function Global:__VSCode-Escape-Value([string]$value) {
 	# NOTE: In PowerShell v6.1+, this can be written `$value -replace '…', { … }` instead of `[regex]::Replace`.
 	# Replace any non-alphanumeric characters.
-	[regex]::Replace($value, "[$([char]0x00)-$([char]0x1f)\\\n;]", { param($match)
+	[regex]::Replace($value, "[$([char]0x00)-$([char]0x1f)\\\n;]", { param($match) # TODO: Need to do the same in zsh, bash
 			# Encode the (ascii) matches as `\x<hex>`
 			-Join (
 				[System.Text.Encoding]::UTF8.GetBytes($match.Value) | ForEach-Object { '\x{0:x2}' -f $_ }


### PR DESCRIPTION
Resolves: https://github.com/microsoft/vscode/issues/242845 
I believe: https://github.com/microsoft/vscode/issues/242885 will be resolved from this too.

In this PR, I tackle the prompt glitch for both zsh and bash.

Zsh one seems to be removed via https://github.com/microsoft/vscode/pull/243804/commits/dd3e070d1f0abd969f86f1550550714a5589c6ba
But I've also noticed there is similar problem in bash (bash one seem worse)


(As of March 18th, 12:20AM) 
Each of them resolved with different fix (They had different causes, surprisingly):

- zsh: Fixed via essentially matching what we do in bash shell integration script 
   When we iterate through each byte, we now do (for both zsh, bash):
```
		builtin printf -v val '%d' "'$byte"
		if  (( val < 31 )); then
			builtin printf -v token '\\x%02x' "'$byte"
```

- bash: Fixed via improving how we separate key, value for when we store env. 