### PR TITLE
Add proposed API for trusted domains and for web page extraction

### DIFF
--- a/extensions/vscode-api-tests/package.json
+++ b/extensions/vscode-api-tests/package.json
@@ -17,6 +17,7 @@
     "documentFiltersExclusive",
     "editorInsets",
     "embeddings",
+    "envExtractUri",
     "extensionRuntime",
     "extensionsAny",
     "externalUriOpener",

--- a/extensions/vscode-api-tests/src/singlefolder-tests/env.test.ts
+++ b/extensions/vscode-api-tests/src/singlefolder-tests/env.test.ts
@@ -77,42 +77,4 @@ suite('vscode API - env', () => {
 			assert.ok(result.scheme === 'http' || result.scheme === 'https');
 		}
 	});
-
-	test('env.isTrustedExternalUris', function () {
-		// Test exact domain match
-		const azureUri = Uri.parse('https://portal.azure.com');
-
-		// Test subdomain wildcard match
-		const galleryCdnUri = Uri.parse('https://foo.gallerycdn.vsassets.io/extension');
-
-		// Test exact domain without specific scheme (should work with https)
-		const marketplaceUri = Uri.parse('https://marketplace.visualstudio.com/items');
-
-		// Test untrusted domain
-		const untrustedUri = Uri.parse('https://example.com');
-
-		// Test with path
-		const docsUri = Uri.parse('https://code.visualstudio.com/api');
-
-		const result = env.isTrustedExternalUris([
-			azureUri,
-			galleryCdnUri,
-			marketplaceUri,
-			untrustedUri,
-			docsUri
-		]);
-
-		assert.strictEqual(result.length, 5, 'Expected 5 trusted URIs');
-		assert.strictEqual(result[0], true, 'Expected github URI to be trusted');
-		assert.strictEqual(result[1], true, 'Expected gallery CDN URI to be trusted');
-		assert.strictEqual(result[2], true, 'Expected marketplace URI to be trusted');
-		assert.strictEqual(result[3], false, 'Expected untrusted URI to be undefined');
-		assert.strictEqual(result[4], true, 'Expected docs URI to be trusted');
-	});
-
-	// Depends on web request
-	test.skip('env.extractExternalUris', async function () {
-		const result = await env.extractExternalUris([Uri.parse('http://content-security-policy.com')]);
-		assert.ok(result[0].includes('Content Security Policy Reference'));
-	});
 });

--- a/extensions/vscode-api-tests/src/singlefolder-tests/env.test.ts
+++ b/extensions/vscode-api-tests/src/singlefolder-tests/env.test.ts
@@ -79,8 +79,8 @@ suite('vscode API - env', () => {
 	});
 
 	test('env.isTrustedExternalUris', function () {
-		// Test exact domain match with https
-		const githubUri = Uri.parse('https://github.com/microsoft/vscode');
+		// Test exact domain match
+		const azureUri = Uri.parse('https://portal.azure.com');
 
 		// Test subdomain wildcard match
 		const galleryCdnUri = Uri.parse('https://foo.gallerycdn.vsassets.io/extension');
@@ -95,7 +95,7 @@ suite('vscode API - env', () => {
 		const docsUri = Uri.parse('https://code.visualstudio.com/api');
 
 		const result = env.isTrustedExternalUris([
-			githubUri,
+			azureUri,
 			galleryCdnUri,
 			marketplaceUri,
 			untrustedUri,

--- a/extensions/vscode-api-tests/src/singlefolder-tests/env.test.ts
+++ b/extensions/vscode-api-tests/src/singlefolder-tests/env.test.ts
@@ -77,4 +77,42 @@ suite('vscode API - env', () => {
 			assert.ok(result.scheme === 'http' || result.scheme === 'https');
 		}
 	});
+
+	test('env.isTrustedExternalUris', function () {
+		// Test exact domain match with https
+		const githubUri = Uri.parse('https://github.com/microsoft/vscode');
+
+		// Test subdomain wildcard match
+		const galleryCdnUri = Uri.parse('https://foo.gallerycdn.vsassets.io/extension');
+
+		// Test exact domain without specific scheme (should work with https)
+		const marketplaceUri = Uri.parse('https://marketplace.visualstudio.com/items');
+
+		// Test untrusted domain
+		const untrustedUri = Uri.parse('https://example.com');
+
+		// Test with path
+		const docsUri = Uri.parse('https://code.visualstudio.com/api');
+
+		const result = env.isTrustedExternalUris([
+			githubUri,
+			galleryCdnUri,
+			marketplaceUri,
+			untrustedUri,
+			docsUri
+		]);
+
+		assert.strictEqual(result.length, 5, 'Expected 5 trusted URIs');
+		assert.strictEqual(result[0], true, 'Expected github URI to be trusted');
+		assert.strictEqual(result[1], true, 'Expected gallery CDN URI to be trusted');
+		assert.strictEqual(result[2], true, 'Expected marketplace URI to be trusted');
+		assert.strictEqual(result[3], false, 'Expected untrusted URI to be undefined');
+		assert.strictEqual(result[4], true, 'Expected docs URI to be trusted');
+	});
+
+	// Depends on web request
+	test.skip('env.extractExternalUris', async function () {
+		const result = await env.extractExternalUris([Uri.parse('http://content-security-policy.com')]);
+		assert.ok(result[0].includes('Content Security Policy Reference'));
+	});
 });

--- a/src/vs/platform/extensions/common/extensionsApiProposals.ts
+++ b/src/vs/platform/extensions/common/extensionsApiProposals.ts
@@ -174,6 +174,9 @@ const _allApiProposals = {
 	embeddings: {
 		proposal: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.embeddings.d.ts',
 	},
+	envExtractUri: {
+		proposal: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.envExtractUri.d.ts',
+	},
 	extensionRuntime: {
 		proposal: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.extensionRuntime.d.ts',
 	},

--- a/src/vs/workbench/api/common/extHost.api.impl.ts
+++ b/src/vs/workbench/api/common/extHost.api.impl.ts
@@ -416,6 +416,14 @@ export function createApiFactoryAndRegisterActors(accessor: ServicesAccessor): I
 					throw err;
 				}
 			},
+			isTrustedExternalUris(uris: URI[]): boolean[] {
+				checkProposedApiEnabled(extension, 'envExtractUri');
+				return extHostUrls.isTrustedExternalUris(uris);
+			},
+			extractExternalUris(uris: URI[]): Promise<string[]> {
+				checkProposedApiEnabled(extension, 'envExtractUri');
+				return extHostUrls.extractExternalUris(uris);
+			},
 			get remoteName() {
 				return getRemoteName(initData.remote.authority);
 			},

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -1399,6 +1399,7 @@ export interface MainThreadUrlsShape extends IDisposable {
 	$registerUriHandler(handle: number, extensionId: ExtensionIdentifier, extensionDisplayName: string): Promise<void>;
 	$unregisterUriHandler(handle: number): Promise<void>;
 	$createAppUri(uri: UriComponents): Promise<UriComponents>;
+	$extractExternalUris(uris: UriComponents[]): Promise<string[]>;
 }
 
 export interface IChatDto {
@@ -1436,6 +1437,7 @@ export type IChatProgressDto =
 
 export interface ExtHostUrlsShape {
 	$handleExternalUri(handle: number, uri: UriComponents): Promise<void>;
+	$updateTrustedDomains(trustedDomains: string[]): Promise<void>;
 }
 
 export interface MainThreadUriOpenersShape extends IDisposable {

--- a/src/vs/workbench/contrib/url/browser/trustedDomainService.ts
+++ b/src/vs/workbench/contrib/url/browser/trustedDomainService.ts
@@ -10,13 +10,14 @@ import { URI } from '../../../../base/common/uri.js';
 import { IInstantiationService, createDecorator } from '../../../../platform/instantiation/common/instantiation.js';
 import { IStorageService, StorageScope } from '../../../../platform/storage/common/storage.js';
 import { TRUSTED_DOMAINS_STORAGE_KEY, readStaticTrustedDomains } from './trustedDomains.js';
-import { testUrlMatchesGlob } from '../common/urlGlob.js';
+import { isURLDomainTrusted } from '../common/trustedDomains.js';
+import { Event, Emitter } from '../../../../base/common/event.js';
 
 export const ITrustedDomainService = createDecorator<ITrustedDomainService>('ITrustedDomainService');
 
 export interface ITrustedDomainService {
 	_serviceBrand: undefined;
-
+	onDidChangeTrustedDomains: Event<void>;
 	isValid(resource: URI): boolean;
 }
 
@@ -24,6 +25,9 @@ export class TrustedDomainService extends Disposable implements ITrustedDomainSe
 	_serviceBrand: undefined;
 
 	private _staticTrustedDomainsResult!: WindowIdleValue<string[]>;
+
+	private _onDidChangeTrustedDomains: Emitter<void> = this._register(new Emitter<void>());
+	onDidChangeTrustedDomains: Event<void> = this._onDidChangeTrustedDomains.event;
 
 	constructor(
 		@IInstantiationService private readonly _instantiationService: IInstantiationService,
@@ -44,6 +48,7 @@ export class TrustedDomainService extends Disposable implements ITrustedDomainSe
 		this._register(this._storageService.onDidChangeValue(StorageScope.APPLICATION, TRUSTED_DOMAINS_STORAGE_KEY, this._store)(() => {
 			this._staticTrustedDomainsResult?.dispose();
 			this._staticTrustedDomainsResult = initStaticDomainsResult();
+			this._onDidChangeTrustedDomains.fire();
 		}));
 	}
 
@@ -53,55 +58,4 @@ export class TrustedDomainService extends Disposable implements ITrustedDomainSe
 
 		return isURLDomainTrusted(resource, allTrustedDomains);
 	}
-}
-
-const rLocalhost = /^localhost(:\d+)?$/i;
-const r127 = /^127.0.0.1(:\d+)?$/;
-
-function isLocalhostAuthority(authority: string) {
-	return rLocalhost.test(authority) || r127.test(authority);
-}
-
-/**
- * Case-normalize some case-insensitive URLs, such as github.
- */
-function normalizeURL(url: string | URI): string {
-	const caseInsensitiveAuthorities = ['github.com'];
-	try {
-		const parsed = typeof url === 'string' ? URI.parse(url, true) : url;
-		if (caseInsensitiveAuthorities.includes(parsed.authority)) {
-			return parsed.with({ path: parsed.path.toLowerCase() }).toString(true);
-		} else {
-			return parsed.toString(true);
-		}
-	} catch { return url.toString(); }
-}
-
-/**
- * Check whether a domain like https://www.microsoft.com matches
- * the list of trusted domains.
- *
- * - Schemes must match
- * - There's no subdomain matching. For example https://microsoft.com doesn't match https://www.microsoft.com
- * - Star matches all subdomains. For example https://*.microsoft.com matches https://www.microsoft.com and https://foo.bar.microsoft.com
- */
-export function isURLDomainTrusted(url: URI, trustedDomains: string[]): boolean {
-	url = URI.parse(normalizeURL(url));
-	trustedDomains = trustedDomains.map(normalizeURL);
-
-	if (isLocalhostAuthority(url.authority)) {
-		return true;
-	}
-
-	for (let i = 0; i < trustedDomains.length; i++) {
-		if (trustedDomains[i] === '*') {
-			return true;
-		}
-
-		if (testUrlMatchesGlob(url, trustedDomains[i])) {
-			return true;
-		}
-	}
-
-	return false;
 }

--- a/src/vs/workbench/contrib/url/browser/trustedDomainsValidator.ts
+++ b/src/vs/workbench/contrib/url/browser/trustedDomainsValidator.ts
@@ -18,7 +18,8 @@ import { IStorageService } from '../../../../platform/storage/common/storage.js'
 import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry.js';
 import { IWorkspaceTrustManagementService } from '../../../../platform/workspace/common/workspaceTrust.js';
 import { IWorkbenchContribution } from '../../../common/contributions.js';
-import { ITrustedDomainService, isURLDomainTrusted } from './trustedDomainService.js';
+import { ITrustedDomainService } from './trustedDomainService.js';
+import { isURLDomainTrusted } from '../common/trustedDomains.js';
 import { configureOpenerTrustedDomainsHandler, readStaticTrustedDomains } from './trustedDomains.js';
 import { IEditorService } from '../../../services/editor/common/editorService.js';
 

--- a/src/vs/workbench/contrib/url/common/trustedDomains.ts
+++ b/src/vs/workbench/contrib/url/common/trustedDomains.ts
@@ -1,0 +1,59 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import { URI } from '../../../../base/common/uri.js';
+import { testUrlMatchesGlob } from './urlGlob.js';
+
+
+/**
+ * Check whether a domain like https://www.microsoft.com matches
+ * the list of trusted domains.
+ *
+ * - Schemes must match
+ * - There's no subdomain matching. For example https://microsoft.com doesn't match https://www.microsoft.com
+ * - Star matches all subdomains. For example https://*.microsoft.com matches https://www.microsoft.com and https://foo.bar.microsoft.com
+ */
+
+export function isURLDomainTrusted(url: URI, trustedDomains: string[]): boolean {
+	url = URI.parse(normalizeURL(url));
+	trustedDomains = trustedDomains.map(normalizeURL);
+
+	if (isLocalhostAuthority(url.authority)) {
+		return true;
+	}
+
+	for (let i = 0; i < trustedDomains.length; i++) {
+		if (trustedDomains[i] === '*') {
+			return true;
+		}
+
+		if (testUrlMatchesGlob(url, trustedDomains[i])) {
+			return true;
+		}
+	}
+
+	return false;
+}
+/**
+ * Case-normalize some case-insensitive URLs, such as github.
+ */
+
+export function normalizeURL(url: string | URI): string {
+	const caseInsensitiveAuthorities = ['github.com'];
+	try {
+		const parsed = typeof url === 'string' ? URI.parse(url, true) : url;
+		if (caseInsensitiveAuthorities.includes(parsed.authority)) {
+			return parsed.with({ path: parsed.path.toLowerCase() }).toString(true);
+		} else {
+			return parsed.toString(true);
+		}
+	} catch { return url.toString(); }
+}
+const rLocalhost = /^localhost(:\d+)?$/i;
+const r127 = /^127.0.0.1(:\d+)?$/;
+
+export function isLocalhostAuthority(authority: string) {
+	return rLocalhost.test(authority) || r127.test(authority);
+}
+

--- a/src/vs/workbench/contrib/url/test/browser/mockTrustedDomainService.ts
+++ b/src/vs/workbench/contrib/url/test/browser/mockTrustedDomainService.ts
@@ -3,14 +3,18 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { Event } from '../../../../../base/common/event.js';
 import { URI } from '../../../../../base/common/uri.js';
-import { isURLDomainTrusted, ITrustedDomainService } from '../../browser/trustedDomainService.js';
+import { ITrustedDomainService } from '../../browser/trustedDomainService.js';
+import { isURLDomainTrusted } from '../../common/trustedDomains.js';
 
 export class MockTrustedDomainService implements ITrustedDomainService {
 	_serviceBrand: undefined;
 
 	constructor(private readonly _trustedDomains: string[] = []) {
 	}
+
+	onDidChangeTrustedDomains: Event<void> = Event.None;
 
 	isValid(resource: URI): boolean {
 		return isURLDomainTrusted(resource, this._trustedDomains);

--- a/src/vs/workbench/contrib/url/test/browser/trustedDomains.test.ts
+++ b/src/vs/workbench/contrib/url/test/browser/trustedDomains.test.ts
@@ -7,7 +7,7 @@ import assert from 'assert';
 
 import { URI } from '../../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
-import { isURLDomainTrusted } from '../../browser/trustedDomainService.js';
+import { isURLDomainTrusted } from '../../common/trustedDomains.js';
 
 function linkAllowedByRules(link: string, rules: string[]) {
 	assert.ok(isURLDomainTrusted(URI.parse(link), rules), `Link\n${link}\n should be allowed by rules\n${JSON.stringify(rules)}`);

--- a/src/vscode-dts/vscode.proposed.envExtractUri.d.ts
+++ b/src/vscode-dts/vscode.proposed.envExtractUri.d.ts
@@ -1,0 +1,14 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+declare module 'vscode' {
+
+	// https://github.com/microsoft/vscode/issues/243615
+
+	export namespace env {
+		export function isTrustedExternalUris(uri: Uri[]): boolean[];
+		export function extractExternalUris(uris: Uri[]): Thenable<string[]>;
+	}
+}


### PR DESCRIPTION
I don't love the shape of this API but I'm going with this for now to play with it.

This will help Chat provide contents of web pages as context but also allow it full control of the tool.

ref https://github.com/microsoft/vscode/issues/243615

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
