### PR TITLE
drag-and-drop: ensure correct drag image for panel tabs (Fixes  #239048)

### DIFF
--- a/src/vs/workbench/browser/dnd.ts
+++ b/src/vs/workbench/browser/dnd.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { DataTransfers, IDragAndDropData } from '../../base/browser/dnd.js';
-import { DragAndDropObserver, EventType, addDisposableListener, onDidRegisterWindow } from '../../base/browser/dom.js';
+import { DragAndDropObserver, EventType, addDisposableListener, onDidRegisterWindow, isHTMLElement } from '../../base/browser/dom.js';
 import { DragMouseEvent } from '../../base/browser/mouseEvent.js';
 import { IListDragAndDrop } from '../../base/browser/ui/list/list.js';
 import { ElementsDragAndDropData, ListViewTargetSector } from '../../base/browser/ui/list/listView.js';
@@ -546,7 +546,14 @@ export class CompositeDragAndDropObserver extends Disposable {
 				const { id, type } = draggedItemProvider();
 				this.writeDragData(id, type);
 
-				e.dataTransfer?.setDragImage(element, 0, 0);
+				if (e.dataTransfer) {
+					const actionLabel = element.querySelector('.action-label');
+					if (actionLabel && isHTMLElement(actionLabel)) {
+						e.dataTransfer.setDragImage(actionLabel, 0, 0);
+					} else {
+						e.dataTransfer.setDragImage(element, 0, 0);
+					}
+				}
 
 				this.onDragStart.fire({ eventData: e, dragAndDropData: this.readDragData(type)! });
 			},

--- a/src/vs/workbench/test/browser/parts/editor/dnd.test.ts
+++ b/src/vs/workbench/test/browser/parts/editor/dnd.test.ts
@@ -1,0 +1,97 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { CompositeDragAndDropObserver } from '../../../../browser/dnd.js';
+import { DisposableStore } from '../../../../../base/common/lifecycle.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+
+suite('CompositeDragAndDropObserver - Drag Image', () => {
+	let disposables: DisposableStore;
+	let observer: CompositeDragAndDropObserver;
+
+	setup(() => {
+		disposables = new DisposableStore();
+		observer = CompositeDragAndDropObserver.INSTANCE;
+	});
+
+	teardown(() => {
+		disposables.dispose();
+	});
+
+	test('setDragImage should use action-label element when available', () => {
+		const container = document.createElement('div');
+		const actionLabel = document.createElement('div');
+		actionLabel.className = 'action-label';
+		container.appendChild(actionLabel);
+
+		let dragImageElement: HTMLElement | undefined;
+		let dragImageX = -1;
+		let dragImageY = -1;
+
+		const dragEvent = new DragEvent('dragstart', { bubbles: true, cancelable: true });
+
+		const dataTransfer = {
+			setDragImage: (element: HTMLElement, x: number, y: number) => {
+				dragImageElement = element;
+				dragImageX = x;
+				dragImageY = y;
+			}
+		};
+
+		Object.defineProperty(dragEvent, 'dataTransfer', { value: dataTransfer });
+
+		const registration = observer.registerDraggable(container,
+			() => ({ type: 'view', id: 'test' }),
+			{
+				onDragStart: event => {
+					assert.notStrictEqual(dragImageElement, container, 'Should not use container as drag image when action-label is available');
+					assert.strictEqual(dragImageElement, actionLabel, 'Expected action-label to be used');
+					assert.strictEqual(dragImageX, 0, 'X offset should be 0');
+					assert.strictEqual(dragImageY, 0, 'Y offset should be 0');
+				}
+			}
+		);
+
+		disposables.add(registration);
+		container.dispatchEvent(dragEvent);
+	});
+
+	test('setDragImage should fall back to container when no action-label exists', () => {
+		const container = document.createElement('div');
+
+		let dragImageElement: HTMLElement | undefined;
+		let dragImageX = -1;
+		let dragImageY = -1;
+
+		const dragEvent = new DragEvent('dragstart', { bubbles: true, cancelable: true });
+
+		const dataTransfer = {
+			setDragImage: (element: HTMLElement, x: number, y: number) => {
+				dragImageElement = element;
+				dragImageX = x;
+				dragImageY = y;
+			}
+		};
+
+		Object.defineProperty(dragEvent, 'dataTransfer', { value: dataTransfer });
+
+		const registration = observer.registerDraggable(container,
+			() => ({ type: 'view', id: 'test' }),
+			{
+				onDragStart: event => {
+					assert.strictEqual(dragImageElement, container, 'Expected container to be used as fallback');
+					assert.strictEqual(dragImageX, 0, 'X offset should be 0');
+					assert.strictEqual(dragImageY, 0, 'Y offset should be 0');
+				}
+			}
+		);
+
+		disposables.add(registration);
+		container.dispatchEvent(dragEvent);
+	});
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+});


### PR DESCRIPTION
This pull request fixes #239048 where dragging the title of a tab in the lower panel would display incorrect text in the drag image. This issue was caused by the drag operation defaulting to the entire container, which could include unexpected text from adjacent UI elements.  

Modified the drag-and-drop handler to prioritise using the .action-label element as the drag image when available, ensuring a more accurate and visually consistent drag representation. If no .action-label is found, the fallback is the entire container to maintain expected behaviour.  

Added tests to verify that:  
- When an .action-label exists, it is correctly set as the drag image.  
- When no .action-label is available, the container itself is used as a fallback.  
- The drag image always maintains the correct offset (0,0) for proper positioning.  
