### PR TITLE
Fix hasEdits flag's value when updating multiple values in JSONEditingService 

### DIFF
--- a/src/vs/workbench/services/configuration/common/jsonEditingService.ts
+++ b/src/vs/workbench/services/configuration/common/jsonEditingService.ts
@@ -61,7 +61,7 @@ export class JSONEditingService implements IJSONEditingService {
 			let hasEdits: boolean = false;
 			for (const value of values) {
 				const edit = this.getEdits(model, value)[0];
-				hasEdits = !!edit && this.applyEditsToBuffer(edit, model);
+				hasEdits = (!!edit && this.applyEditsToBuffer(edit, model)) || hasEdits;
 			}
 			if (hasEdits) {
 				return this.textFileService.save(model.uri);


### PR DESCRIPTION
Hi @sandy081,

This commit (https://github.com/microsoft/vscode/commit/5bca175608c28e428d3dc1aab4c747fe35d9e183#diff-4c16f60ba3ea06c8c7dfd2a525ab8bbd55ebf12a7914855cb0f56bdfc9c3c1e7R53) added support for updating multiple values in the `JSONEditingService`. The `hasEdits` flag is used to check whether there are actual changes and whether the JSON needs to be saved.

However, based on the code, it appears that the value of `hasEdits` only reflects from the last value. Shouldn't `hasEdits` be true as long as any one of the values actually modifies the JSON, rather than only being true if the last value modifies the JSON?