### PR TITLE
Handle long merge conflict splitter markers

### DIFF
--- a/extensions/merge-conflict/src/mergeConflictParser.ts
+++ b/extensions/merge-conflict/src/mergeConflictParser.ts
@@ -59,7 +59,7 @@ export class MergeConflictParser {
 				currentConflict.commonAncestors.push(line);
 			}
 			// Are we within a conflict block and is this a splitter? =======
-			else if (currentConflict && !currentConflict.splitter && line.text === splitterMarker) {
+			else if (currentConflict && !currentConflict.splitter && line.text.startsWith(splitterMarker)) {
 				currentConflict.splitter = line;
 			}
 			// Are we within a conflict block and is this a footer? >>>>>>>


### PR DESCRIPTION
# Problem statement

Currently VSCode does not highlight merge conflicts with long splitter markers (`=======`). All other markers — `<<<<<<<`, `|||||||`, `>>>>>>>` — are handled correctly. 

Short `===` works:

<img width="678" alt="image" src="https://github.com/user-attachments/assets/ce12ab61-4f26-4cb9-93a6-36481cac377b" />

Long `===` doesn't:

<img width="678" alt="image" src="https://github.com/user-attachments/assets/c782e219-26b3-4a39-a6bf-96119b4fe605" />

# Why I care

Tools like https://jj-vcs.github.io/jj/latest/ generate proper-length `===` splitters when a shorter conflict marker would be ambiguous, and then VSCode doesn't recognize those conflicts.

# Proposed fix

Use the same `startsWith` logic for the splitter markers.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
