### PR TITLE
Revert "Hide modelpicker when too small (#243666)"

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
@@ -1484,7 +1484,7 @@ class ModelPickerActionViewItem extends DropdownMenuActionViewItemWithKeybinding
 
 	override render(container: HTMLElement): void {
 		super.render(container);
-		container.classList.add('chat-modelPicker-item', 'chat-dropdown-item');
+		container.classList.add('chat-modelPicker-item');
 	}
 }
 
@@ -1559,7 +1559,7 @@ class ToggleChatModeActionViewItem extends DropdownMenuActionViewItemWithKeybind
 
 	override render(container: HTMLElement): void {
 		super.render(container);
-		container.classList.add('chat-dropdown-item');
+		container.classList.add('chat-modelPicker-item');
 	}
 }
 

--- a/src/vs/workbench/contrib/chat/browser/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/media/chat.css
@@ -886,27 +886,12 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	display: flex;
 }
 
-@container chat-input-container (max-width: 130px) {
-	.interactive-session .chat-input-toolbars .chat-modelPicker-item {
-		/* Hides modelpicker when the container width is 130px or less */
-		display: none;
-	}
-}
-
-.interactive-session .interactive-input-part:not(.compact) .chat-input-toolbars > .chat-execute-toolbar {
-	container-type: inline-size;
-	container-name: chat-input-container;
-	flex: 1;
-	display: flex;
-	justify-content: flex-end;
+.interactive-session .chat-input-toolbars :first-child {
+	margin-right: auto;
 }
 
 .interactive-session .chat-input-toolbars > .chat-execute-toolbar {
 	min-width: 0px;
-
-	.monaco-action-bar {
-		min-width: 0px;
-	}
 
 	.chat-modelPicker-item {
 		min-width: 0px;
@@ -930,7 +915,7 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	color: var(--vscode-icon-foreground) !important;
 }
 
-.interactive-session .chat-input-toolbars .chat-dropdown-item .action-label {
+.interactive-session .chat-input-toolbars .chat-modelPicker-item .action-label {
 	height: 16px;
 	padding: 3px 0px 3px 6px;
 	display: flex;
@@ -938,7 +923,7 @@ have to be updated for changes to the rules above, or to support more deeply nes
 }
 
 
-.interactive-session .chat-input-toolbars .chat-dropdown-item .action-label .codicon-chevron-down {
+.interactive-session .chat-input-toolbars .chat-modelPicker-item .action-label .codicon-chevron-down {
 	font-size: 12px;
 	margin-left: 2px;
 }


### PR DESCRIPTION
This reverts commit a41a4ba14b3a983fc1ecd3a2fabe5b5d4a8b6575.

accessibility