### PR TITLE
remove shell type api from terminal suggest proposal

### DIFF
--- a/extensions/terminal-suggest/package.json
+++ b/extensions/terminal-suggest/package.json
@@ -15,8 +15,7 @@
   ],
   "enabledApiProposals": [
     "terminalCompletionProvider",
-    "terminalShellEnv",
-    "terminalShellType"
+    "terminalShellEnv"
   ],
   "scripts": {
     "compile": "npx gulp compile-extension:terminal-suggest",


### PR DESCRIPTION
/cc @meganrogge @Tyriar 

Sorry I missed this in PR https://github.com/microsoft/vscode/pull/243274/files#diff-f08ce82292615e46333d24ce54f9493b28b273af83114da82a9ae5d56866a635 , and this was causing
```
ERR Extension 'vscode.terminal-suggest' wants API proposal 'terminalShellType' but that proposal DOES NOT EXIST. Likely, the proposal has been finalized (check 'vscode.d.ts') or was abandoned.
```
in dev tools.
