### PR TITLE
refactor: setup errorTelemetry from electron-main

### DIFF
--- a/src/vs/platform/telemetry/electron-main/errorTelemetry.ts
+++ b/src/vs/platform/telemetry/electron-main/errorTelemetry.ts
@@ -1,0 +1,38 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { isSigPipeError, onUnexpectedError, setUnexpectedErrorHandler } from '../../../base/common/errors.js';
+import BaseErrorTelemetry from '../common/errorTelemetry.js';
+import { ITelemetryService } from '../common/telemetry.js';
+import { ILogService } from '../../../platform/log/common/log.js';
+
+export default class ErrorTelemetry extends BaseErrorTelemetry {
+	constructor(
+		private readonly logService: ILogService,
+		@ITelemetryService telemetryService: ITelemetryService
+	) {
+		super(telemetryService);
+	}
+
+	protected override installErrorListeners(): void {
+		// We handle uncaught exceptions here to prevent electron from opening a dialog to the user
+		setUnexpectedErrorHandler(error => this.onUnexpectedError(error));
+
+		process.on('uncaughtException', error => {
+			if (!isSigPipeError(error)) {
+				onUnexpectedError(error);
+			}
+		});
+
+		process.on('unhandledRejection', (reason: unknown) => onUnexpectedError(reason));
+	}
+
+	private onUnexpectedError(error: Error): void {
+		this.logService.error(`[uncaught exception in main]: ${error}`);
+		if (error.stack) {
+			this.logService.error(error.stack);
+		}
+	}
+}

--- a/src/vs/workbench/electron-sandbox/window.ts
+++ b/src/vs/workbench/electron-sandbox/window.ts
@@ -6,7 +6,6 @@
 import './media/window.css';
 import { localize } from '../../nls.js';
 import { URI } from '../../base/common/uri.js';
-import { onUnexpectedError } from '../../base/common/errors.js';
 import { equals } from '../../base/common/objects.js';
 import { EventType, EventHelper, addDisposableListener, ModifierKeyEmitter, getActiveElement, hasWindow, getWindowById, getWindows, $ } from '../../base/browser/dom.js';
 import { Action, Separator, WorkbenchActionExecutedClassification, WorkbenchActionExecutedEvent } from '../../base/common/actions.js';
@@ -184,13 +183,6 @@ export class NativeWindow extends BaseWindow {
 			const activeElement = getActiveElement();
 			if (activeElement) {
 				this.keybindingService.dispatchByUserSettingsLabel(request.userSettingsLabel, activeElement);
-			}
-		});
-
-		// Error reporting from main
-		ipcRenderer.on('vscode:reportError', (event: unknown, error: string) => {
-			if (error) {
-				onUnexpectedError(JSON.parse(error));
 			}
 		});
 


### PR DESCRIPTION
Needed for https://github.com/microsoft/vscode/pull/241390

Currently errors from electron-main are sent to the focused window via `vscode:reportError` channel to forward them to error telemetry. However, we also would like to send error telemetry for unresponsive windows in which case we need the capability to send telemetry from main process.