### PR TITLE
Filter out offscreen windows from getAllWindows call sites

### DIFF
--- a/src/vs/code/electron-main/app.ts
+++ b/src/vs/code/electron-main/app.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { app, BrowserWindow, protocol, session, Session, systemPreferences, WebFrameMain } from 'electron';
+import { app, protocol, session, Session, systemPreferences, WebFrameMain } from 'electron';
 import { addUNCHostToAllowlist, disableUNCAccessRestrictions } from '../../base/node/unc.js';
 import { validatedIpcMain } from '../../base/parts/ipc/electron-main/ipcMain.js';
 import { hostname, release } from 'os';
@@ -122,6 +122,7 @@ import { INativeMcpDiscoveryHelperService, NativeMcpDiscoveryHelperChannelName }
 import { NativeMcpDiscoveryHelperService } from '../../platform/mcp/node/nativeMcpDiscoveryHelperService.js';
 import { IWebContentExtractorService } from '../../platform/webContentExtractor/common/webContentExtractor.js';
 import { NativeWebContentExtractorService } from '../../platform/webContentExtractor/electron-main/webContentExtractorService.js';
+import { getAllWindowsExcludingOffscreen } from '../../platform/windows/electron-main/windowUtils.js';
 
 /**
  * The main VS Code application. There will only ever be one instance,
@@ -232,7 +233,7 @@ export class CodeApplication extends Disposable {
 			}
 
 			// Check to see if the request comes from one of the main windows (or shared process) and not from embedded content
-			const windows = BrowserWindow.getAllWindows();
+			const windows = getAllWindowsExcludingOffscreen();
 			for (const window of windows) {
 				if (frame.processId === window.webContents.mainFrame.processId) {
 					return true;

--- a/src/vs/platform/diagnostics/electron-main/diagnosticsMainService.ts
+++ b/src/vs/platform/diagnostics/electron-main/diagnosticsMainService.ts
@@ -16,6 +16,7 @@ import { IWorkspacesManagementMainService } from '../../workspaces/electron-main
 import { assertIsDefined } from '../../../base/common/types.js';
 import { ILogService } from '../../log/common/log.js';
 import { UtilityProcess } from '../../utilityProcess/electron-main/utilityProcess.js';
+import { getAllWindowsExcludingOffscreen } from '../../windows/electron-main/windowUtils.js';
 
 export const ID = 'diagnosticsMainService';
 export const IDiagnosticsMainService = createDecorator<IDiagnosticsMainService>(ID);
@@ -80,7 +81,7 @@ export class DiagnosticsMainService implements IDiagnosticsMainService {
 		this.logService.trace('Received request for main process info from other instance.');
 
 		const windows: IWindowDiagnostics[] = [];
-		for (const window of BrowserWindow.getAllWindows()) {
+		for (const window of getAllWindowsExcludingOffscreen()) {
 			const codeWindow = this.windowsMainService.getWindowById(window.id);
 			if (codeWindow) {
 				windows.push(await this.codeWindowToInfo(codeWindow));

--- a/src/vs/platform/lifecycle/electron-main/lifecycleMainService.ts
+++ b/src/vs/platform/lifecycle/electron-main/lifecycleMainService.ts
@@ -19,6 +19,7 @@ import { ICodeWindow, LoadReason, UnloadReason } from '../../window/electron-mai
 import { ISingleFolderWorkspaceIdentifier, IWorkspaceIdentifier } from '../../workspace/common/workspace.js';
 import { IEnvironmentMainService } from '../../environment/electron-main/environmentMainService.js';
 import { IAuxiliaryWindow } from '../../auxiliaryWindow/electron-main/auxiliaryWindow.js';
+import { getAllWindowsExcludingOffscreen } from '../../windows/electron-main/windowUtils.js';
 
 export const ILifecycleMainService = createDecorator<ILifecycleMainService>('lifecycleMainService');
 
@@ -727,7 +728,7 @@ export class LifecycleMainService extends Disposable implements ILifecycleMainSe
 			// to a participant within the window. this is not wanted when we
 			// are asked to kill the application.
 			(async () => {
-				for (const window of electron.BrowserWindow.getAllWindows()) {
+				for (const window of getAllWindowsExcludingOffscreen()) {
 					if (window && !window.isDestroyed()) {
 						let whenWindowClosed: Promise<void>;
 						if (window.webContents && !window.webContents.isDestroyed()) {

--- a/src/vs/platform/theme/electron-main/themeMainService.ts
+++ b/src/vs/platform/theme/electron-main/themeMainService.ts
@@ -15,6 +15,7 @@ import { IColorScheme } from '../../window/common/window.js';
 import { ThemeTypeSelector } from '../common/theme.js';
 import { IBaseWorkspaceIdentifier } from '../../workspace/common/workspace.js';
 import { coalesce } from '../../../base/common/arrays.js';
+import { getAllWindowsExcludingOffscreen } from '../../windows/electron-main/windowUtils.js';
 
 // These default colors match our default themes
 // editor background color ("Dark Modern", etc...)
@@ -219,7 +220,7 @@ export class ThemeMainService extends Disposable implements IThemeMainService {
 	}
 
 	private updateBackgroundColor(windowId: number, splash: IPartsSplash): void {
-		for (const window of electron.BrowserWindow.getAllWindows()) {
+		for (const window of getAllWindowsExcludingOffscreen()) {
 			if (window.id === windowId) {
 				window.setBackgroundColor(splash.colorInfo.background);
 				break;

--- a/src/vs/platform/windows/electron-main/windowImpl.ts
+++ b/src/vs/platform/windows/electron-main/windowImpl.ts
@@ -44,6 +44,7 @@ import { IUserDataProfilesMainService } from '../../userDataProfile/electron-mai
 import { ILoggerMainService } from '../../log/electron-main/loggerService.js';
 import { IInstantiationService } from '../../instantiation/common/instantiation.js';
 import { VSBuffer } from '../../../base/common/buffer.js';
+import { getAllWindowsExcludingOffscreen } from './windowUtils.js';
 
 export interface IWindowCreationOptions {
 	readonly state: IWindowState;
@@ -232,7 +233,7 @@ export abstract class BaseWindow extends Disposable implements IBaseWindow {
 
 		const windowSettings = this.configurationService.getValue<IWindowSettings | undefined>('window');
 		const useNativeTabs = isMacintosh && windowSettings?.nativeTabs === true;
-		if ((isMacintosh || isWindows) && hasMultipleDisplays && (!useNativeTabs || electron.BrowserWindow.getAllWindows().length === 1)) {
+		if ((isMacintosh || isWindows) && hasMultipleDisplays && (!useNativeTabs || getAllWindowsExcludingOffscreen().length === 1)) {
 			if ([state.width, state.height, state.x, state.y].every(value => typeof value === 'number')) {
 				this._win?.setBounds({
 					width: state.width,

--- a/src/vs/platform/windows/electron-main/windowUtils.ts
+++ b/src/vs/platform/windows/electron-main/windowUtils.ts
@@ -1,0 +1,16 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import electron from 'electron';
+
+/**
+ * We have some components like `NativeWebContentExtractorService` that create offscreen windows
+ * to extract content from web pages. These windows are not visible to the user and are not
+ * considered part of the main application window. This function filters out those offscreen
+ * windows from the list of all windows.
+ * @returns An array of all BrowserWindow instances that are not offscreen.
+ */
+export function getAllWindowsExcludingOffscreen() {
+	return electron.BrowserWindow.getAllWindows().filter(win => !win.webContents.isOffscreen());
+}


### PR DESCRIPTION
We don't want these extra windows to cause anything to go wrong, so we replace explicit calls of `getAllWindows` with a wrapper that excludes them.

@deepak1556 and I also went through all other static APIs on BrowserWindow and found none that would be problematic to these new offscreen windows.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
