### PR TITLE
tools: allow saving trust for MCP tools

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/actions/chatActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatActions.ts
@@ -29,6 +29,7 @@ import { IsLinuxContext, IsWindowsContext } from '../../../../../platform/contex
 import { IDialogService } from '../../../../../platform/dialogs/common/dialogs.js';
 import { IInstantiationService, ServicesAccessor } from '../../../../../platform/instantiation/common/instantiation.js';
 import { KeybindingWeight } from '../../../../../platform/keybinding/common/keybindingsRegistry.js';
+import { INotificationService } from '../../../../../platform/notification/common/notification.js';
 import { IOpenerService } from '../../../../../platform/opener/common/opener.js';
 import product from '../../../../../platform/product/common/product.js';
 import { IQuickInputButton, IQuickInputService, IQuickPickItem, IQuickPickSeparator } from '../../../../../platform/quickinput/common/quickInput.js';
@@ -696,6 +697,21 @@ registerAction2(class ToggleCopilotControl extends ToggleTitleBarConfigAction {
 			localize('toggle.chatControlsDescription', "Toggle visibility of the Copilot Controls in title bar"), 5, false,
 			ChatContextKeys.supported
 		);
+	}
+});
+
+registerAction2(class ResetTrustedToolsAction extends Action2 {
+	constructor() {
+		super({
+			id: 'workbench.action.chat.resetTrustedTools',
+			title: localize2('resetTrustedTools', "Reset Tool Confirmations"),
+			category: CHAT_CATEGORY,
+			f1: true,
+		});
+	}
+	override run(accessor: ServicesAccessor): void {
+		accessor.get(ILanguageModelToolsService).resetToolAutoConfirmation();
+		accessor.get(INotificationService).info(localize('resetTrustedToolsSuccess', "Tool confirmation preferences have been reset."));
 	}
 });
 

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/chatToolInvocationPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/chatToolInvocationPart.ts
@@ -178,6 +178,7 @@ class ChatToolInvocationSubPart extends Disposable {
 			Disallow,
 			AllowWorkspace,
 			AllowGlobally,
+			AllowSession,
 		}
 
 		const buttons: IChatConfirmationButton[] = [
@@ -186,7 +187,8 @@ class ChatToolInvocationSubPart extends Disposable {
 				data: ConfirmationOutcome.Allow,
 				tooltip: continueTooltip,
 				moreActions: !allowAutoConfirm ? undefined : [
-					{ label: localize('allowWorkspace', 'Always Allow in Workspace'), data: ConfirmationOutcome.AllowWorkspace, tooltip: localize('allowWorkspaceTooltip', 'Allow this tool to run in this workspace without confirmation.') },
+					{ label: localize('allowSession', 'Allow in this Session'), data: ConfirmationOutcome.AllowWorkspace, tooltip: localize('allowSesssionTooltip', 'Allow this tool to run in this session without confirmation.') },
+					{ label: localize('allowWorkspace', 'Allow in this Workspace'), data: ConfirmationOutcome.AllowWorkspace, tooltip: localize('allowWorkspaceTooltip', 'Allow this tool to run in this workspace without confirmation.') },
 					{ label: localize('allowGlobally', 'Always Allow'), data: ConfirmationOutcome.AllowGlobally, tooltip: localize('allowGloballTooltip', 'Always allow this tool to run without confirmation.') },
 				],
 			},
@@ -293,6 +295,10 @@ class ChatToolInvocationSubPart extends Disposable {
 					break;
 				case ConfirmationOutcome.AllowWorkspace:
 					this.languageModelToolsService.setToolAutoConfirmation(toolInvocation.toolId, 'workspace', true);
+					toolInvocation.confirmed.complete(true);
+					break;
+				case ConfirmationOutcome.AllowSession:
+					this.languageModelToolsService.setToolAutoConfirmation(toolInvocation.toolId, 'memory', true);
 					toolInvocation.confirmed.complete(true);
 					break;
 				case ConfirmationOutcome.Allow:

--- a/src/vs/workbench/contrib/chat/browser/languageModelToolsService.ts
+++ b/src/vs/workbench/contrib/chat/browser/languageModelToolsService.ts
@@ -9,10 +9,14 @@ import { CancellationToken, CancellationTokenSource } from '../../../../base/com
 import { CancellationError, isCancellationError } from '../../../../base/common/errors.js';
 import { Emitter } from '../../../../base/common/event.js';
 import { Iterable } from '../../../../base/common/iterator.js';
+import { Lazy } from '../../../../base/common/lazy.js';
 import { Disposable, DisposableStore, dispose, IDisposable, toDisposable } from '../../../../base/common/lifecycle.js';
+import { LRUCache } from '../../../../base/common/map.js';
 import { IContextKey, IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
 import { IDialogService } from '../../../../platform/dialogs/common/dialogs.js';
+import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
+import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
 import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry.js';
 import { IExtensionService } from '../../../services/extensions/common/extensions.js';
 import { ChatContextKeys } from '../common/chatContextKeys.js';
@@ -41,7 +45,11 @@ export class LanguageModelToolsService extends Disposable implements ILanguageMo
 
 	private _callsByRequestId = new Map<string, IDisposable[]>();
 
+	private _workspaceToolConfirmStore: Lazy<ToolConfirmStore>;
+	private _profileToolConfirmStore: Lazy<ToolConfirmStore>;
+
 	constructor(
+		@IInstantiationService private readonly _instantiationService: IInstantiationService,
 		@IExtensionService private readonly _extensionService: IExtensionService,
 		@IContextKeyService private readonly _contextKeyService: IContextKeyService,
 		@IChatService private readonly _chatService: IChatService,
@@ -50,6 +58,9 @@ export class LanguageModelToolsService extends Disposable implements ILanguageMo
 		@ILogService private readonly _logService: ILogService,
 	) {
 		super();
+
+		this._workspaceToolConfirmStore = new Lazy(() => this._instantiationService.createInstance(ToolConfirmStore, StorageScope.WORKSPACE));
+		this._profileToolConfirmStore = new Lazy(() => this._instantiationService.createInstance(ToolConfirmStore, StorageScope.PROFILE));
 
 		this._register(this._contextKeyService.onDidChangeContext(e => {
 			if (e.affectsSome(this._toolContextKeys)) {
@@ -130,6 +141,19 @@ export class LanguageModelToolsService extends Disposable implements ILanguageMo
 		return undefined;
 	}
 
+	setToolAutoConfirmation(toolId: string, scope: 'workspace' | 'profile', autoConfirm = true): void {
+		if (scope === 'workspace') {
+			this._workspaceToolConfirmStore.value.setAutoConfirm(toolId, autoConfirm);
+		} else {
+			this._profileToolConfirmStore.value.setAutoConfirm(toolId, autoConfirm);
+		}
+	}
+
+	resetToolAutoConfirmation(): void {
+		this._workspaceToolConfirmStore.value.reset();
+		this._profileToolConfirmStore.value.reset();
+	}
+
 	async invokeTool(dto: IToolInvocation, countTokens: CountTokensCallback, token: CancellationToken): Promise<IToolResult> {
 		this._logService.trace(`[LanguageModelToolsService#invokeTool] Invoking tool ${dto.toolId} with parameters ${JSON.stringify(dto.parameters)}`);
 
@@ -190,6 +214,10 @@ export class LanguageModelToolsService extends Disposable implements ILanguageMo
 					: undefined;
 
 				toolInvocation = new ChatToolInvocation(prepared, tool.data);
+				if (this._workspaceToolConfirmStore.value.getAutoConfirm(tool.data.id) || this._profileToolConfirmStore.value.getAutoConfirm(tool.data.id)) {
+					toolInvocation.confirmed.complete(true);
+				}
+
 				model.acceptResponseProgress(request, toolInvocation);
 				if (prepared?.confirmationMessages) {
 					const userConfirmed = await toolInvocation.confirmed.p;
@@ -296,3 +324,54 @@ type LanguageModelToolInvokedClassification = {
 	owner: 'roblourens';
 	comment: 'Provides insight into the usage of language model tools.';
 };
+
+class ToolConfirmStore extends Disposable {
+	private static readonly STORED_KEY = 'chat/autoconfirm';
+
+	private _autoConfirmTools: LRUCache<string, boolean> = new LRUCache<string, boolean>(100);
+	private _didChange = false;
+
+	constructor(
+		private readonly _scope: StorageScope,
+		@IStorageService private readonly storageService: IStorageService,
+	) {
+		super();
+
+		const stored = storageService.getObject<string[]>(ToolConfirmStore.STORED_KEY, this._scope);
+		if (stored) {
+			for (const key of stored) {
+				this._autoConfirmTools.set(key, true);
+			}
+		}
+
+		this._register(storageService.onWillSaveState(() => {
+			if (this._didChange) {
+				this.storageService.store(ToolConfirmStore.STORED_KEY, [...this._autoConfirmTools.keys()], this._scope, StorageTarget.MACHINE);
+				this._didChange = false;
+			}
+		}));
+	}
+
+	public reset() {
+		this._autoConfirmTools.clear();
+		this._didChange = true;
+	}
+
+	public getAutoConfirm(toolId: string): boolean {
+		if (this._autoConfirmTools.get(toolId)) {
+			this._didChange = true;
+			return true;
+		}
+
+		return false;
+	}
+
+	public setAutoConfirm(toolId: string, autoConfirm: boolean): void {
+		if (autoConfirm) {
+			this._autoConfirmTools.set(toolId, true);
+		} else {
+			this._autoConfirmTools.delete(toolId);
+		}
+		this._didChange = true;
+	}
+}

--- a/src/vs/workbench/contrib/chat/common/chatProgressTypes/chatToolInvocation.ts
+++ b/src/vs/workbench/contrib/chat/common/chatProgressTypes/chatToolInvocation.ts
@@ -41,6 +41,7 @@ export class ChatToolInvocation implements IChatToolInvocation {
 	public pastTenseMessage: string | IMarkdownString | undefined;
 	private _confirmationMessages: IToolConfirmationMessages | undefined;
 	public readonly presentation: IPreparedToolInvocation['presentation'];
+	public readonly toolId: string;
 
 	public readonly toolSpecificData?: IChatTerminalToolInvocationData | IChatToolInputInvocationData;
 
@@ -52,6 +53,7 @@ export class ChatToolInvocation implements IChatToolInvocation {
 		this._confirmationMessages = preparedInvocation?.confirmationMessages;
 		this.presentation = preparedInvocation?.presentation;
 		this.toolSpecificData = preparedInvocation?.toolSpecificData;
+		this.toolId = toolData.id;
 
 		if (!this._confirmationMessages) {
 			// No confirmation needed

--- a/src/vs/workbench/contrib/chat/common/chatService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService.ts
@@ -233,6 +233,7 @@ export interface IChatToolInvocation {
 	invocationMessage: string | IMarkdownString;
 	pastTenseMessage: string | IMarkdownString | undefined;
 	resultDetails: IToolResult['toolResultDetails'];
+	readonly toolId: string;
 
 	isCompletePromise: Promise<void>;
 	isComplete: boolean;

--- a/src/vs/workbench/contrib/chat/common/languageModelToolsService.ts
+++ b/src/vs/workbench/contrib/chat/common/languageModelToolsService.ts
@@ -77,6 +77,7 @@ export interface IToolResultTextPart {
 export interface IToolConfirmationMessages {
 	title: string;
 	message: string | IMarkdownString;
+	allowAutoConfirm?: boolean;
 }
 
 export interface IPreparedToolInvocation {
@@ -105,5 +106,7 @@ export interface ILanguageModelToolsService {
 	getTool(id: string): IToolData | undefined;
 	getToolByName(name: string): IToolData | undefined;
 	invokeTool(invocation: IToolInvocation, countTokens: CountTokensCallback, token: CancellationToken): Promise<IToolResult>;
+	setToolAutoConfirmation(toolId: string, scope: 'workspace' | 'profile', autoConfirm?: boolean): void;
+	resetToolAutoConfirmation(): void;
 	cancelToolCallsForRequest(requestId: string): void;
 }

--- a/src/vs/workbench/contrib/chat/common/languageModelToolsService.ts
+++ b/src/vs/workbench/contrib/chat/common/languageModelToolsService.ts
@@ -106,7 +106,7 @@ export interface ILanguageModelToolsService {
 	getTool(id: string): IToolData | undefined;
 	getToolByName(name: string): IToolData | undefined;
 	invokeTool(invocation: IToolInvocation, countTokens: CountTokensCallback, token: CancellationToken): Promise<IToolResult>;
-	setToolAutoConfirmation(toolId: string, scope: 'workspace' | 'profile', autoConfirm?: boolean): void;
+	setToolAutoConfirmation(toolId: string, scope: 'workspace' | 'profile' | 'memory', autoConfirm?: boolean): void;
 	resetToolAutoConfirmation(): void;
 	cancelToolCallsForRequest(requestId: string): void;
 }

--- a/src/vs/workbench/contrib/chat/test/common/mockLanguageModelToolsService.ts
+++ b/src/vs/workbench/contrib/chat/test/common/mockLanguageModelToolsService.ts
@@ -22,6 +22,14 @@ export class MockLanguageModelToolsService implements ILanguageModelToolsService
 		return Disposable.None;
 	}
 
+	resetToolAutoConfirmation(): void {
+
+	}
+
+	setToolAutoConfirmation(toolId: string, scope: 'workspace' | 'profile', autoConfirm?: boolean): void {
+
+	}
+
 	registerToolImplementation(name: string, tool: IToolImpl): IDisposable {
 		return Disposable.None;
 	}

--- a/src/vs/workbench/contrib/mcp/common/mcpService.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpService.ts
@@ -220,6 +220,7 @@ class McpToolImplementation implements IToolImpl {
 			confirmationMessages: {
 				title: localize('msg.title', "Run `{0}`", tool.definition.name, server.definition.label),
 				message: new MarkdownString(localize('msg.msg', "{0}\n\n {1}", tool.definition.description, mcpToolWarning), { supportThemeIcons: true }),
+				allowAutoConfirm: true,
 			},
 			invocationMessage: new MarkdownString(localize('msg.run', "Running `{0}`", tool.definition.name, server.definition.label)),
 			pastTenseMessage: new MarkdownString(localize('msg.ran', "Ran `{0}` ", tool.definition.name, server.definition.label)),


### PR DESCRIPTION
This adds an optional `allowAutoConfirm`, set for MCP tools, to the
`IToolConfirmationMessages`. When preset users have the option to allow,
deny, always allow in workspace, or always allow the tool to run
globally.

This closes #243620 with a better solution imo, because it doesn't
require extra manual configuration from the user and can is done at a
per-tool level. While we could have some tool-to-confirmation map
in mcp.json, I think this much easier to deal with.

The `Chat: Reset Tool Confirmations` can be used to forget trusted
too preferences.

cc @jrieken, let me know if you want me to clean up anything here

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
