### PR TITLE
tweak prompt input model so values, cursor indices, and ghost text are correct

### DIFF
--- a/src/vs/platform/terminal/common/capabilities/commandDetection/promptInputModel.ts
+++ b/src/vs/platform/terminal/common/capabilities/commandDetection/promptInputModel.ts
@@ -291,9 +291,6 @@ export class PromptInputModel extends Disposable implements IPromptInputModel {
 				commandLine = line.translateToString(true);
 				cursorIndex = absoluteCursorY === commandStartY ? buffer.cursorX : commandLine?.trimEnd().length;
 			}
-			if (commandLine === undefined || !line) {
-				return;
-			}
 		}
 		if (line === undefined || commandLine === undefined) {
 			this._logService.trace(`PromptInputModel#_sync: no line`);

--- a/src/vs/platform/terminal/common/capabilities/commandDetection/promptInputModel.ts
+++ b/src/vs/platform/terminal/common/capabilities/commandDetection/promptInputModel.ts
@@ -367,10 +367,10 @@ export class PromptInputModel extends Disposable implements IPromptInputModel {
 			line = buffer.getLine(y);
 			const lineText = line?.translateToString(true);
 			if (lineText && line) {
-				if (this._continuationPrompt === undefined || this._lineContainsContinuationPrompt(lineText)) {
+				if (this._continuationPrompt === undefined && this._shellType !== PosixShellType.Fish || this._lineContainsContinuationPrompt(lineText)) {
 					value += `\n${this._trimContinuationPrompt(lineText)}`;
 				} else {
-					break;
+					value += `${lineText}`;
 				}
 			} else {
 				break;

--- a/src/vs/platform/terminal/common/capabilities/commandDetection/promptInputModel.ts
+++ b/src/vs/platform/terminal/common/capabilities/commandDetection/promptInputModel.ts
@@ -294,7 +294,8 @@ export class PromptInputModel extends Disposable implements IPromptInputModel {
 			if (commandLine === undefined || !line) {
 				return;
 			}
-		} else if (line === undefined || commandLine === undefined) {
+		}
+		if (line === undefined || commandLine === undefined) {
 			this._logService.trace(`PromptInputModel#_sync: no line`);
 			return;
 		}

--- a/src/vs/platform/terminal/common/capabilities/commandDetection/promptInputModel.ts
+++ b/src/vs/platform/terminal/common/capabilities/commandDetection/promptInputModel.ts
@@ -454,7 +454,7 @@ export class PromptInputModel extends Disposable implements IPromptInputModel {
 
 	/**
 	 * Detect ghost text by looking for italic or dim text in or after the cursor and
-	 * non-italic/dim text in the first non-whitespace cell following command start.
+	 * non-italic/dim text in the first non-whitespace cell following command start and before the cursor.
 	 */
 	private _scanForGhostText(buffer: IBuffer, line: IBufferLine, cursorIndex: number): number {
 		if (!this.value.trim().length) {

--- a/src/vs/platform/terminal/common/capabilities/commandDetection/promptInputModel.ts
+++ b/src/vs/platform/terminal/common/capabilities/commandDetection/promptInputModel.ts
@@ -454,7 +454,7 @@ export class PromptInputModel extends Disposable implements IPromptInputModel {
 
 	/**
 	 * Detect ghost text by looking for italic or dim text in or after the cursor and
-	 * non-italic/dim text in the cell before the cursor after command start.
+	 * non-italic/dim text in the first non-whitespace cell following command start.
 	 */
 	private _scanForGhostText(buffer: IBuffer, line: IBufferLine, cursorIndex: number): number {
 		if (!this.value.trim().length) {

--- a/src/vs/platform/terminal/common/capabilities/commandDetection/promptInputModel.ts
+++ b/src/vs/platform/terminal/common/capabilities/commandDetection/promptInputModel.ts
@@ -367,7 +367,7 @@ export class PromptInputModel extends Disposable implements IPromptInputModel {
 				} else if (this._continuationPrompt === undefined || this._lineContainsContinuationPrompt(lineText)) {
 					value += `\n${this._trimContinuationPrompt(lineText)}`;
 				} else {
-					value += `${lineText}`;
+					value += lineText;
 				}
 			} else {
 				break;

--- a/src/vs/platform/terminal/test/common/capabilities/commandDetection/promptInputModel.test.ts
+++ b/src/vs/platform/terminal/test/common/capabilities/commandDetection/promptInputModel.test.ts
@@ -12,7 +12,7 @@ import type { ITerminalCommand } from '../../../../common/capabilities/capabilit
 import { ok, notDeepStrictEqual, strictEqual } from 'assert';
 import { timeout } from '../../../../../../base/common/async.js';
 import { importAMDNodeModule } from '../../../../../../amdX.js';
-import { PosixShellType } from '../../../../common/terminal.js';
+import { GeneralShellType, PosixShellType } from '../../../../common/terminal.js';
 
 suite('PromptInputModel', () => {
 	const store = ensureNoDisposablesAreLeakedInTestSuite();
@@ -381,6 +381,52 @@ suite('PromptInputModel', () => {
 			);
 
 			await assertPromptInput('STRIKE1 normal STRIKE2|'); // No ghost text expected
+		});
+		suite('With wrapping', () => {
+			test('Fish ghost text in long line with wrapped content', async () => {
+				promptInputModel.setShellType(PosixShellType.Fish);
+				await writePromise('$ ');
+				fireCommandStart();
+				await assertPromptInput('|');
+
+				// Write a command with ghost text that will wrap
+				await writePromise('find . -name');
+				await assertPromptInput(`find . -name|`);
+
+				// Add ghost text with dim style
+				await writePromise('\x1b[2m test\x1b[0m\x1b[4D');
+				await assertPromptInput(`find . -name |[test]`);
+
+				// Move cursor within the ghost text
+				await writePromise('\x1b[C');
+				await assertPromptInput(`find . -name t|[est]`);
+
+				// Accept ghost text
+				await writePromise('\x1b[C\x1b[C\x1b[C\x1b[C\x1b[C');
+				await assertPromptInput(`find . -name test|`);
+			});
+			test('Pwsh ghost text in long line with wrapped content', async () => {
+				promptInputModel.setShellType(GeneralShellType.PowerShell);
+				await writePromise('$ ');
+				fireCommandStart();
+				await assertPromptInput('|');
+
+				// Write a command with ghost text that will wrap
+				await writePromise('find . -name');
+				await assertPromptInput(`find . -name|`);
+
+				// Add ghost text with dim style
+				await writePromise('\x1b[2m test\x1b[0m\x1b[4D');
+				await assertPromptInput(`find . -name |[test]`);
+
+				// Move cursor within the ghost text
+				await writePromise('\x1b[C');
+				await assertPromptInput(`find . -name t|[est]`);
+
+				// Accept ghost text
+				await writePromise('\x1b[C\x1b[C\x1b[C\x1b[C\x1b[C');
+				await assertPromptInput(`find . -name test|`);
+			});
 		});
 	});
 


### PR DESCRIPTION
fixes #243906 

Before `pwsh`:
![Screenshot 2025-03-19 at 4 53 52 PM](https://github.com/user-attachments/assets/69d55dfe-5397-46c6-a8d9-700ae96a7e4b)

After `pwsh`:
![Screenshot 2025-03-19 at 4 56 10 PM](https://github.com/user-attachments/assets/3955bccd-f232-4383-9236-8ed16f7662cd)

Before `fish`:
![Screenshot 2025-03-19 at 4 59 12 PM](https://github.com/user-attachments/assets/37ec95d1-b2f4-48e3-a487-dbea28d91bd9)

After `fish`:
![Screenshot 2025-03-19 at 4 59 56 PM](https://github.com/user-attachments/assets/7f3f10ff-3388-4777-b80e-16a588a0a941)


