### PR TITLE
git: fix message box on git commit errors is too short

### DIFF
--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -4744,7 +4744,7 @@ export class CommandCenter {
 							.replace(/^> husky.*$/mi, '')
 							.split(/[\r\n]/)
 							.filter((line: string) => !!line)
-						[0];
+							.join("\n");
 
 						message = hint
 							? l10n.t('Git: {0}', hint)


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Fixes #169871

Tested manually, the error message is now multiline:

![Capture d'écran 2025-03-19 232116](https://github.com/user-attachments/assets/f9c5a901-2a2d-465a-abce-a87f839b2fa3)