### PR TITLE
mcp: support workspace folder-level servers

### DIFF
--- a/src/vs/workbench/contrib/mcp/browser/mcpLanguageFeatures.ts
+++ b/src/vs/workbench/contrib/mcp/browser/mcpLanguageFeatures.ts
@@ -32,7 +32,11 @@ export class McpLanguageFeatures extends Disposable implements IWorkbenchContrib
 	) {
 		super();
 
-		const patterns = [{ pattern: '**/.vscode/mcp.json' }, { pattern: '**/settings.json' }];
+		const patterns = [
+			{ pattern: '**/.vscode/mcp.json' },
+			{ pattern: '**/settings.json' },
+			{ pattern: '**/workspace.json' },
+		];
 
 		const onDidChangeCodeLens = this._register(new Emitter<CodeLensProvider>());
 		const codeLensProvider: CodeLensProvider = {
@@ -61,13 +65,13 @@ export class McpLanguageFeatures extends Disposable implements IWorkbenchContrib
 	}
 
 	private async _provideCodeLenses(model: ITextModel, onDidChangeCodeLens: () => void): Promise<CodeLensList | undefined> {
-		const inConfig = this._mcpConfigPathsService.paths.find(u => isEqual(u.uri, model.uri));
+		const inConfig = this._mcpConfigPathsService.paths.get().find(u => isEqual(u.uri, model.uri));
 		if (!inConfig) {
 			return undefined;
 		}
 
 		const tree = this._parseModel(model);
-		const serversNode = findNodeAtLocation(tree, inConfig.section ? [inConfig.section, 'servers'] : ['servers']);
+		const serversNode = findNodeAtLocation(tree, inConfig.section ? [...inConfig.section, 'servers'] : ['servers']);
 		if (!serversNode) {
 			return undefined;
 		}
@@ -171,13 +175,13 @@ export class McpLanguageFeatures extends Disposable implements IWorkbenchContrib
 	}
 
 	private async _provideInlayHints(model: ITextModel, range: Range): Promise<InlayHintList | undefined> {
-		const inConfig = this._mcpConfigPathsService.paths.find(u => isEqual(u.uri, model.uri));
+		const inConfig = this._mcpConfigPathsService.paths.get().find(u => isEqual(u.uri, model.uri));
 		if (!inConfig) {
 			return undefined;
 		}
 
 		const tree = this._parseModel(model);
-		const mcpSection = inConfig.section ? findNodeAtLocation(tree, [inConfig.section]) : tree;
+		const mcpSection = inConfig.section ? findNodeAtLocation(tree, [...inConfig.section]) : tree;
 		if (!mcpSection) {
 			return undefined;
 		}

--- a/src/vs/workbench/contrib/mcp/common/discovery/nativeMcpDiscoveryAbstract.ts
+++ b/src/vs/workbench/contrib/mcp/common/discovery/nativeMcpDiscoveryAbstract.ts
@@ -81,7 +81,7 @@ export abstract class FilesystemMpcDiscovery extends Disposable implements IMcpD
 				serverDefinitions: observableValue<readonly McpServerDefinition[]>(this, []),
 				presentation: {
 					origin: file,
-					order: adapter.order + (adapter.remoteAuthority ? McpCollectionSortOrder.RemotePenalty : 0),
+					order: adapter.order + (adapter.remoteAuthority ? McpCollectionSortOrder.RemoteBoost : 0),
 				},
 			} satisfies McpCollectionDefinition;
 

--- a/src/vs/workbench/contrib/mcp/common/mcpConfigPathsService.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpConfigPathsService.ts
@@ -3,9 +3,10 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Emitter, Event } from '../../../../base/common/event.js';
 import { Disposable } from '../../../../base/common/lifecycle.js';
 import { Schemas } from '../../../../base/common/network.js';
+import { IObservable, ISettableObservable, observableValue } from '../../../../base/common/observable.js';
+import { isDefined } from '../../../../base/common/types.js';
 import { URI } from '../../../../base/common/uri.js';
 import { localize } from '../../../../nls.js';
 import { ConfigurationTarget } from '../../../../platform/configuration/common/configuration.js';
@@ -13,15 +14,18 @@ import { createDecorator } from '../../../../platform/instantiation/common/insta
 import { ILabelService } from '../../../../platform/label/common/label.js';
 import { IProductService } from '../../../../platform/product/common/productService.js';
 import { StorageScope } from '../../../../platform/storage/common/storage.js';
+import { IWorkspaceContextService, IWorkspaceFolder } from '../../../../platform/workspace/common/workspace.js';
 import { IWorkbenchEnvironmentService } from '../../../services/environment/common/environmentService.js';
-import { IPreferencesService } from '../../../services/preferences/common/preferences.js';
+import { FOLDER_SETTINGS_PATH, IPreferencesService } from '../../../services/preferences/common/preferences.js';
 import { IRemoteAgentService } from '../../../services/remote/common/remoteAgentService.js';
 import { mcpConfigurationSection } from './mcpConfiguration.js';
 import { McpCollectionSortOrder } from './mcpTypes.js';
 
 export interface IMcpConfigPath {
+	/** Short, unique ID for this config. */
+	id: string;
 	/** Configuration scope that maps to this path.  */
-	key: 'userLocalValue' | 'userRemoteValue' | 'workspaceValue';
+	key: 'userLocalValue' | 'userRemoteValue' | 'workspaceValue' | 'workspaceFolderValue';
 	/** Display name */
 	label: string;
 	/** Storage where associated data should be stored. */
@@ -35,14 +39,15 @@ export interface IMcpConfigPath {
 	/** Config file URI. */
 	uri: URI | undefined;
 	/** When MCP config is nested in a config file, the parent nested key. */
-	section?: string;
+	section?: string[];
+	/** Workspace folder, when the config refers to a workspace folder value. */
+	workspaceFolder?: IWorkspaceFolder;
 }
 
 export interface IMcpConfigPathsService {
 	_serviceBrand: undefined;
 
-	readonly onDidAddPath: Event<IMcpConfigPath>;
-	readonly paths: readonly IMcpConfigPath[];
+	readonly paths: IObservable<readonly IMcpConfigPath[]>;
 }
 
 export const IMcpConfigPathsService = createDecorator<IMcpConfigPathsService>('IMcpConfigPathsService');
@@ -50,13 +55,14 @@ export const IMcpConfigPathsService = createDecorator<IMcpConfigPathsService>('I
 export class McpConfigPathsService extends Disposable implements IMcpConfigPathsService {
 	_serviceBrand: undefined;
 
-	private readonly _onDidAddPath = this._register(new Emitter<IMcpConfigPath>());
-	public readonly onDidAddPath = this._onDidAddPath.event;
+	private readonly _paths: ISettableObservable<readonly IMcpConfigPath[]>;
 
-	public readonly paths: IMcpConfigPath[] = [];
+	public get paths(): IObservable<readonly IMcpConfigPath[]> {
+		return this._paths;
+	}
 
 	constructor(
-
+		@IWorkspaceContextService workspaceContextService: IWorkspaceContextService,
 		@IProductService productService: IProductService,
 		@ILabelService labelService: ILabelService,
 		@IWorkbenchEnvironmentService environmentService: IWorkbenchEnvironmentService,
@@ -65,44 +71,79 @@ export class McpConfigPathsService extends Disposable implements IMcpConfigPaths
 	) {
 		super();
 
-		this.paths.push(
+		const workspaceConfig = workspaceContextService.getWorkspace().configuration;
+		const initialPaths: (IMcpConfigPath | undefined | null)[] = [
 			{
+				id: 'usrlocal',
 				key: 'userLocalValue',
 				target: ConfigurationTarget.USER_LOCAL,
 				label: localize('mcp.configuration.userLocalValue', 'Global in {0}', productService.nameShort),
 				scope: StorageScope.PROFILE,
 				order: McpCollectionSortOrder.User,
 				uri: preferencesService.userSettingsResource,
-				section: mcpConfigurationSection,
+				section: [mcpConfigurationSection],
 			},
-			{
+			workspaceConfig && {
+				id: 'workspace',
 				key: 'workspaceValue',
 				target: ConfigurationTarget.WORKSPACE,
 				label: localize('mcp.configuration.workspaceValue', 'From your workspace'),
 				scope: StorageScope.WORKSPACE,
 				order: McpCollectionSortOrder.Workspace,
-				uri: preferencesService.workspaceSettingsResource ? URI.joinPath(preferencesService.workspaceSettingsResource, '../mcp.json') : undefined,
+				uri: workspaceConfig,
+				section: ['settings', mcpConfigurationSection],
 			},
-		);
+			...workspaceContextService.getWorkspace()
+				.folders
+				.map(wf => this._fromWorkspaceFolder(wf))
+		];
+
+		this._paths = observableValue('mcpConfigPaths', initialPaths.filter(isDefined));
 
 		remoteAgentService.getEnvironment().then((env) => {
 			const label = environmentService.remoteAuthority ? labelService.getHostLabel(Schemas.vscodeRemote, environmentService.remoteAuthority) : 'Remote';
 
-			this._addPath({
-				key: 'userRemoteValue',
-				target: ConfigurationTarget.USER_REMOTE,
-				label: localize('mcp.configuration.userRemoteValue', 'From {0}', label),
-				scope: StorageScope.PROFILE,
-				order: McpCollectionSortOrder.User + McpCollectionSortOrder.RemotePenalty,
-				uri: env?.settingsPath,
-				remoteAuthority: environmentService.remoteAuthority,
-				section: mcpConfigurationSection,
-			});
+			this._paths.set([
+				...this.paths.get(),
+				{
+					id: 'usrremote',
+					key: 'userRemoteValue',
+					target: ConfigurationTarget.USER_REMOTE,
+					label: localize('mcp.configuration.userRemoteValue', 'From {0}', label),
+					scope: StorageScope.PROFILE,
+					order: McpCollectionSortOrder.User + McpCollectionSortOrder.RemoteBoost,
+					uri: env?.settingsPath,
+					remoteAuthority: environmentService.remoteAuthority,
+					section: [mcpConfigurationSection],
+				}
+			], undefined);
 		});
+
+		this._register(workspaceContextService.onDidChangeWorkspaceFolders(e => {
+			const next = this._paths.get().slice();
+			for (const folder of e.added) {
+				next.push(this._fromWorkspaceFolder(folder));
+			}
+			for (const folder of e.removed) {
+				const idx = next.findIndex(c => c.workspaceFolder === folder);
+				if (idx !== -1) {
+					next.splice(idx, 1);
+				}
+			}
+			this._paths.set(next, undefined);
+		}));
 	}
 
-	private _addPath(path: IMcpConfigPath): void {
-		this.paths.push(path);
-		this._onDidAddPath.fire(path);
+	private _fromWorkspaceFolder(workspaceFolder: IWorkspaceFolder): IMcpConfigPath {
+		return {
+			id: `wf${workspaceFolder.index}`,
+			key: 'workspaceFolderValue',
+			target: ConfigurationTarget.WORKSPACE_FOLDER,
+			label: localize('mcp.configuration.workspaceFolter', 'From folder {0}', workspaceFolder.name),
+			scope: StorageScope.WORKSPACE,
+			order: McpCollectionSortOrder.WorkspaceFolder,
+			uri: URI.joinPath(workspaceFolder.uri, FOLDER_SETTINGS_PATH, '../mcp.json'),
+			workspaceFolder,
+		};
 	}
 }

--- a/src/vs/workbench/contrib/mcp/common/mcpService.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpService.ts
@@ -175,7 +175,14 @@ export class McpService extends Disposable implements IMcpService {
 		// Create any new servers that are needed.
 		for (const def of nextDefinitions) {
 			const store = new DisposableStore();
-			const object = this._instantiationService.createInstance(McpServer, def.collectionDefinition, def.serverDefinition, !!def.collectionDefinition.lazy, def.collectionDefinition.scope === StorageScope.WORKSPACE ? this.workspaceCache : this.userCache);
+			const object = this._instantiationService.createInstance(
+				McpServer,
+				def.collectionDefinition,
+				def.serverDefinition,
+				def.serverDefinition.roots,
+				!!def.collectionDefinition.lazy,
+				def.collectionDefinition.scope === StorageScope.WORKSPACE ? this.workspaceCache : this.userCache,
+			);
 			store.add(object);
 			this._syncTools(object, store);
 

--- a/src/vs/workbench/contrib/mcp/common/mcpTypes.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpTypes.ts
@@ -7,6 +7,7 @@ import { assertNever } from '../../../../base/common/assert.js';
 import { CancellationToken } from '../../../../base/common/cancellation.js';
 import { IDisposable } from '../../../../base/common/lifecycle.js';
 import { equals as objectsEqual } from '../../../../base/common/objects.js';
+import { equals as arraysEqual } from '../../../../base/common/arrays.js';
 import { IObservable } from '../../../../base/common/observable.js';
 import { URI, UriComponents } from '../../../../base/common/uri.js';
 import { Location } from '../../../../editor/common/languages.js';
@@ -62,12 +63,13 @@ export interface McpCollectionDefinition {
 }
 
 export const enum McpCollectionSortOrder {
-	Workspace = 0,
-	User = 100,
-	Extension = 200,
-	Filesystem = 300,
+	WorkspaceFolder = 0,
+	Workspace = 100,
+	User = 200,
+	Extension = 300,
+	Filesystem = 400,
 
-	RemotePenalty = 50,
+	RemoteBoost = -50,
 }
 
 export namespace McpCollectionDefinition {
@@ -93,6 +95,8 @@ export interface McpServerDefinition {
 	readonly label: string;
 	/** Descriptor defining how the configuration should be launched. */
 	readonly launch: McpServerLaunch;
+	/** Explicit roots. If undefined, all workspace folders. */
+	readonly roots?: URI[] | undefined;
 	/** If set, allows configuration variables to be resolved in the {@link launch} with the given context */
 	readonly variableReplacement?: McpServerDefinitionVariableReplacement;
 
@@ -128,7 +132,9 @@ export namespace McpServerDefinition {
 	export function equals(a: McpServerDefinition, b: McpServerDefinition): boolean {
 		return a.id === b.id
 			&& a.label === b.label
+			&& arraysEqual(a.roots, b.roots, (a, b) => a.toString() === b.toString())
 			&& objectsEqual(a.launch, b.launch)
+			&& objectsEqual(a.presentation, b.presentation)
 			&& objectsEqual(a.variableReplacement, b.variableReplacement);
 	}
 }


### PR DESCRIPTION
Rationalizes some of our workspace vs workspace folder handling. Both
should now work, and this adds proper support for workspace folder-level
servers (detectable where previously resolving `${workspaceFolder}`
would not work, mcp servers would only be found in the 1st folder, etc).

MCP servers defined in a workspace folder are `root`ed to that single
folder instead of seeing the entire workspace. #244064 for more future
discussion there.

Fixes #244029

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
