### PR TITLE
mcp: fix server lenses click issues

### DIFF
--- a/src/vs/workbench/contrib/mcp/browser/mcp.contribution.ts
+++ b/src/vs/workbench/contrib/mcp/browser/mcp.contribution.ts
@@ -21,7 +21,7 @@ import { McpRegistry } from '../common/mcpRegistry.js';
 import { IMcpRegistry } from '../common/mcpRegistryTypes.js';
 import { McpService } from '../common/mcpService.js';
 import { IMcpService } from '../common/mcpTypes.js';
-import { AddConfigurationAction, EditStoredInput, InstallFromActivation, ListMcpServerCommand, MCPServerActionRendering, McpServerOptionsCommand, RemoveStoredInput, ResetMcpCachedTools, ResetMcpTrustCommand, ShowOutput, StartServer, StopServer } from './mcpCommands.js';
+import { AddConfigurationAction, EditStoredInput, InstallFromActivation, ListMcpServerCommand, MCPServerActionRendering, McpServerOptionsCommand, RemoveStoredInput, ResetMcpCachedTools, ResetMcpTrustCommand, RestartServer, ShowOutput, StartServer, StopServer } from './mcpCommands.js';
 import { McpDiscovery } from './mcpDiscovery.js';
 import { McpLanguageFeatures } from './mcpLanguageFeatures.js';
 import { McpUrlHandler } from './mcpUrlHandler.js';
@@ -50,6 +50,7 @@ registerAction2(StartServer);
 registerAction2(StopServer);
 registerAction2(ShowOutput);
 registerAction2(InstallFromActivation);
+registerAction2(RestartServer);
 
 registerWorkbenchContribution2('mcpActionRendering', MCPServerActionRendering, WorkbenchPhase.BlockRestore);
 

--- a/src/vs/workbench/contrib/mcp/browser/mcpCommands.ts
+++ b/src/vs/workbench/contrib/mcp/browser/mcpCommands.ts
@@ -471,6 +471,26 @@ export class ShowOutput extends Action2 {
 	}
 }
 
+export class RestartServer extends Action2 {
+	static readonly ID = 'workbench.mcp.restartServer';
+
+	constructor() {
+		super({
+			id: RestartServer.ID,
+			title: localize2('mcp.command.restartServer', "Restart Server"),
+			category,
+			f1: false,
+		});
+	}
+
+	async run(accessor: ServicesAccessor, serverId: string) {
+		const s = accessor.get(IMcpService).servers.get().find(s => s.definition.id === serverId);
+		s?.showOutput();
+		await s?.stop();
+		await s?.start();
+	}
+}
+
 export class StartServer extends Action2 {
 	static readonly ID = 'workbench.mcp.startServer';
 
@@ -485,7 +505,6 @@ export class StartServer extends Action2 {
 
 	async run(accessor: ServicesAccessor, serverId: string) {
 		const s = accessor.get(IMcpService).servers.get().find(s => s.definition.id === serverId);
-		await s?.stop();
 		await s?.start();
 	}
 }

--- a/src/vs/workbench/contrib/mcp/browser/mcpLanguageFeatures.ts
+++ b/src/vs/workbench/contrib/mcp/browser/mcpLanguageFeatures.ts
@@ -19,7 +19,7 @@ import { ConfigurationResolverExpression, IResolvedValue } from '../../../servic
 import { IMcpConfigPathsService } from '../common/mcpConfigPathsService.js';
 import { IMcpRegistry } from '../common/mcpRegistryTypes.js';
 import { IMcpService, McpConnectionState } from '../common/mcpTypes.js';
-import { EditStoredInput, RemoveStoredInput, ShowOutput, StartServer, StopServer } from './mcpCommands.js';
+import { EditStoredInput, RemoveStoredInput, RestartServer, ShowOutput, StartServer, StopServer } from './mcpCommands.js';
 
 export class McpLanguageFeatures extends Disposable implements IWorkbenchContribution {
 	private readonly _cachedMcpSection = this._register(new MutableDisposable<{ model: ITextModel; node: Node } & IDisposable>());
@@ -109,7 +109,7 @@ export class McpLanguageFeatures extends Disposable implements IWorkbenchContrib
 					}, {
 						range,
 						command: {
-							id: StartServer.ID,
+							id: RestartServer.ID,
 							title: localize('mcp.restart', "Restart"),
 							arguments: [server.definition.id],
 						},
@@ -143,19 +143,19 @@ export class McpLanguageFeatures extends Disposable implements IWorkbenchContrib
 					}, {
 						range,
 						command: {
-							id: StartServer.ID,
+							id: RestartServer.ID,
 							title: localize('mcp.restart', "Restart"),
 							arguments: [server.definition.id],
 						},
 					}, {
 						range,
 						command: {
-							id: 'workbench.action.chat.attachTools',
+							id: '',
 							title: localize('server.toolCount', '{0} tools', read(server.tools).length),
 						},
 					});
 					break;
-				case McpConnectionState.Kind.Stopped:
+				case McpConnectionState.Kind.Stopped: {
 					lenses.lenses.push({
 						range,
 						command: {
@@ -164,6 +164,17 @@ export class McpLanguageFeatures extends Disposable implements IWorkbenchContrib
 							arguments: [server.definition.id],
 						},
 					});
+					const toolCount = read(server.tools).length;
+					if (toolCount) {
+						lenses.lenses.push({
+							range,
+							command: {
+								id: '',
+								title: localize('server.toolCountCached', '{0} cached tools', toolCount),
+							}
+						});
+					}
+				}
 			}
 		}
 

--- a/src/vs/workbench/contrib/mcp/common/mcpRegistry.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpRegistry.ts
@@ -293,7 +293,7 @@ export class McpRegistry extends Disposable implements IMcpRegistry {
 		return await this._configurationResolverService.resolveAsync(folder, expr);
 	}
 
-	public async resolveConnection({ collectionRef, definitionRef, forceTrust }: IMcpResolveConnectionOptions): Promise<IMcpServerConnection | undefined> {
+	public async resolveConnection({ collectionRef, definitionRef, forceTrust, logger }: IMcpResolveConnectionOptions): Promise<IMcpServerConnection | undefined> {
 		const collection = this._collections.get().find(c => c.id === collectionRef.id);
 		const definition = collection?.serverDefinitions.get().find(s => s.id === definitionRef.id);
 		if (!collection || !definition) {
@@ -356,6 +356,7 @@ export class McpRegistry extends Disposable implements IMcpRegistry {
 			definition,
 			delegate,
 			launch,
+			logger,
 		);
 	}
 }

--- a/src/vs/workbench/contrib/mcp/common/mcpRegistryTypes.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpRegistryTypes.ts
@@ -8,6 +8,7 @@ import { IDisposable } from '../../../../base/common/lifecycle.js';
 import { IObservable } from '../../../../base/common/observable.js';
 import { ConfigurationTarget } from '../../../../platform/configuration/common/configuration.js';
 import { createDecorator } from '../../../../platform/instantiation/common/instantiation.js';
+import { ILogger } from '../../../../platform/log/common/log.js';
 import { StorageScope } from '../../../../platform/storage/common/storage.js';
 import { IWorkspaceFolderData } from '../../../../platform/workspace/common/workspace.js';
 import { IResolvedValue } from '../../../services/configurationResolver/common/configurationResolverExpression.js';
@@ -32,6 +33,7 @@ export interface IMcpHostDelegate {
 }
 
 export interface IMcpResolveConnectionOptions {
+	logger: ILogger;
 	collectionRef: McpCollectionReference;
 	definitionRef: McpDefinitionReference;
 	/** If set, the user will be asked to trust the collection even if they untrusted it previously */

--- a/src/vs/workbench/contrib/mcp/common/mcpServer.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpServer.ts
@@ -8,9 +8,11 @@ import { CancellationToken, CancellationTokenSource } from '../../../../base/com
 import { Disposable, DisposableStore, IDisposable, toDisposable } from '../../../../base/common/lifecycle.js';
 import { LRUCache } from '../../../../base/common/map.js';
 import { autorun, autorunWithStore, derived, disposableObservableValue, IObservable, ITransaction, observableFromEvent, ObservablePromise, observableValue, transaction } from '../../../../base/common/observable.js';
+import { ILogger, ILoggerService } from '../../../../platform/log/common/log.js';
 import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
 import { IWorkspaceContextService } from '../../../../platform/workspace/common/workspace.js';
 import { IExtensionService } from '../../../services/extensions/common/extensions.js';
+import { IOutputService } from '../../../services/output/common/output.js';
 import { mcpActivationEvent } from './mcpConfiguration.js';
 import { IMcpRegistry } from './mcpRegistryTypes.js';
 import { McpServerRequestHandler } from './mcpServerRequestHandler.js';
@@ -128,6 +130,9 @@ export class McpServer extends Disposable implements IMcpServer {
 		return fromServerResult.error ? (this.toolsFromCache ? McpServerToolsState.Cached : McpServerToolsState.Unknown) : McpServerToolsState.Live;
 	});
 
+	private readonly _loggerId: string;
+	private readonly _logger: ILogger;
+
 	public get trusted() {
 		return this._mcpRegistry.getTrust(this.collection);
 	}
@@ -140,8 +145,16 @@ export class McpServer extends Disposable implements IMcpServer {
 		@IMcpRegistry private readonly _mcpRegistry: IMcpRegistry,
 		@IWorkspaceContextService workspacesService: IWorkspaceContextService,
 		@IExtensionService private readonly _extensionService: IExtensionService,
+		@ILoggerService private readonly _loggerService: ILoggerService,
+		@IOutputService private readonly _outputService: IOutputService,
 	) {
 		super();
+
+		this._loggerId = `mcpServer/${definition.id}`;
+		this._logger = this._register(_loggerService.createLogger(this._loggerId, { hidden: true, name: `MCP: ${definition.label}` }));
+		// If the logger is disposed but not deregistered, then the disposed instance
+		// is reused and no-ops. todo@sandy081 this seems like a bug.
+		this._register(toDisposable(() => _loggerService.deregisterLogger(this._loggerId)));
 
 		// 1. Reflect workspaces into the MCP roots
 		const workspaces = observableFromEvent(
@@ -191,7 +204,8 @@ export class McpServer extends Disposable implements IMcpServer {
 	}
 
 	public showOutput(): void {
-		this._connection.get()?.showOutput();
+		this._loggerService.setVisibility(this._loggerId, true);
+		this._outputService.showChannel(this._loggerId);
 	}
 
 	public start(isFromInteraction?: boolean): Promise<McpConnectionState> {
@@ -217,6 +231,7 @@ export class McpServer extends Disposable implements IMcpServer {
 
 			if (!connection) {
 				connection = await this._mcpRegistry.resolveConnection({
+					logger: this._logger,
 					collectionRef: this.collection,
 					definitionRef: this.definition,
 					forceTrust: isFromInteraction,

--- a/src/vs/workbench/contrib/mcp/common/mcpServerConnection.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpServerConnection.ts
@@ -8,11 +8,10 @@ import { Disposable, DisposableStore, IReference, MutableDisposable, toDisposabl
 import { autorun, IObservable, observableValue } from '../../../../base/common/observable.js';
 import { localize } from '../../../../nls.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
-import { ILogger, ILoggerService } from '../../../../platform/log/common/log.js';
-import { IOutputService } from '../../../services/output/common/output.js';
+import { ILogger } from '../../../../platform/log/common/log.js';
 import { IMcpHostDelegate, IMcpMessageTransport } from './mcpRegistryTypes.js';
 import { McpServerRequestHandler } from './mcpServerRequestHandler.js';
-import { McpCollectionDefinition, IMcpServerConnection, McpServerDefinition, McpConnectionState, McpServerLaunch } from './mcpTypes.js';
+import { IMcpServerConnection, McpCollectionDefinition, McpConnectionState, McpServerDefinition, McpServerLaunch } from './mcpTypes.js';
 
 export class McpServerConnection extends Disposable implements IMcpServerConnection {
 	private readonly _launch = this._register(new MutableDisposable<IReference<IMcpMessageTransport>>());
@@ -22,8 +21,6 @@ export class McpServerConnection extends Disposable implements IMcpServerConnect
 	public readonly state: IObservable<McpConnectionState> = this._state;
 	public readonly handler: IObservable<McpServerRequestHandler | undefined> = this._requestHandler;
 
-	private readonly _loggerId: string;
-	private readonly _logger: ILogger;
 	private _launchId = 0;
 
 	constructor(
@@ -31,22 +28,10 @@ export class McpServerConnection extends Disposable implements IMcpServerConnect
 		public readonly definition: McpServerDefinition,
 		private readonly _delegate: IMcpHostDelegate,
 		public readonly launchDefinition: McpServerLaunch,
-		@ILoggerService private readonly _loggerService: ILoggerService,
-		@IOutputService private readonly _outputService: IOutputService,
+		private readonly _logger: ILogger,
 		@IInstantiationService private readonly _instantiationService: IInstantiationService,
 	) {
 		super();
-		this._loggerId = `mcpServer/${definition.id}`;
-		this._logger = this._register(_loggerService.createLogger(this._loggerId, { hidden: true, name: `MCP: ${definition.label}` }));
-		// If the logger is disposed but not deregistered, then the disposed instance
-		// is reused and no-ops. todo@sandy081 this seems like a bug.
-		this._register(toDisposable(() => _loggerService.deregisterLogger(this._loggerId)));
-	}
-
-	/** @inheritdoc */
-	public showOutput(): void {
-		this._loggerService.setVisibility(this._loggerId, true);
-		this._outputService.showChannel(this._loggerId);
 	}
 
 	/** @inheritdoc */

--- a/src/vs/workbench/contrib/mcp/common/mcpTypes.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpTypes.ts
@@ -315,11 +315,6 @@ export interface IMcpServerConnection extends IDisposable {
 	readonly handler: IObservable<McpServerRequestHandler | undefined>;
 
 	/**
-	 * Shows the current server output.
-	 */
-	showOutput(): void;
-
-	/**
 	 * Starts the server if it's stopped. Returns a promise that resolves once
 	 * server exits a 'starting' state.
 	 */

--- a/src/vs/workbench/contrib/mcp/test/common/mcpServerConnection.test.ts
+++ b/src/vs/workbench/contrib/mcp/test/common/mcpServerConnection.test.ts
@@ -12,7 +12,7 @@ import { URI } from '../../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { ServiceCollection } from '../../../../../platform/instantiation/common/serviceCollection.js';
 import { TestInstantiationService } from '../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
-import { ILogger, ILoggerService } from '../../../../../platform/log/common/log.js';
+import { ILogger, ILoggerService, NullLogger } from '../../../../../platform/log/common/log.js';
 import { IProductService } from '../../../../../platform/product/common/productService.js';
 import { IStorageService, StorageScope } from '../../../../../platform/storage/common/storage.js';
 import { IOutputService } from '../../../../services/output/common/output.js';
@@ -127,7 +127,8 @@ suite('Workbench - MCP - ServerConnection', () => {
 			collection,
 			serverDefinition,
 			delegate,
-			serverDefinition.launch
+			serverDefinition.launch,
+			new NullLogger(),
 		);
 		store.add(connection);
 
@@ -154,7 +155,8 @@ suite('Workbench - MCP - ServerConnection', () => {
 			collection,
 			serverDefinition,
 			delegate,
-			serverDefinition.launch
+			serverDefinition.launch,
+			new NullLogger(),
 		);
 		store.add(connection);
 
@@ -172,7 +174,8 @@ suite('Workbench - MCP - ServerConnection', () => {
 			collection,
 			serverDefinition,
 			delegate,
-			serverDefinition.launch
+			serverDefinition.launch,
+			new NullLogger(),
 		);
 		store.add(connection);
 
@@ -197,7 +200,8 @@ suite('Workbench - MCP - ServerConnection', () => {
 			collection,
 			serverDefinition,
 			delegate,
-			serverDefinition.launch
+			serverDefinition.launch,
+			new NullLogger(),
 		);
 		store.add(connection);
 
@@ -220,7 +224,8 @@ suite('Workbench - MCP - ServerConnection', () => {
 			collection,
 			serverDefinition,
 			delegate,
-			serverDefinition.launch
+			serverDefinition.launch,
+			new NullLogger(),
 		);
 		store.add(connection);
 
@@ -251,7 +256,8 @@ suite('Workbench - MCP - ServerConnection', () => {
 			collection,
 			serverDefinition,
 			delegate,
-			serverDefinition.launch
+			serverDefinition.launch,
+			new NullLogger(),
 		);
 
 		// Start the connection
@@ -265,81 +271,24 @@ suite('Workbench - MCP - ServerConnection', () => {
 		assert.strictEqual(connection.state.get().state, McpConnectionState.Kind.Stopped);
 	});
 
-	test('showOutput should call logger and output services', () => {
-		let channelShown = false;
-		const outputService = {
-			showChannel: (id: string) => {
-				assert.strictEqual(id, `mcpServer/${serverDefinition.id}`);
-				channelShown = true;
-			}
-		};
-
-		let loggerVisible = false;
-		const loggerService = new class extends TestLoggerService {
-			override setVisibility(id: string, visible: boolean): void {
-				assert.strictEqual(id, `mcpServer/${serverDefinition.id}`);
-				assert.strictEqual(visible, true);
-				loggerVisible = true;
-			}
-		};
-
-		// Override services
-		const services = new ServiceCollection(
-			[ILoggerService, store.add(loggerService)],
-			[IOutputService, upcast(outputService)],
-			[IStorageService, store.add(new TestStorageService())]
-		);
-
-		const localInstantiationService = store.add(new TestInstantiationService(services));
-
-		// Create server connection
-		const connection = localInstantiationService.createInstance(
-			McpServerConnection,
-			collection,
-			serverDefinition,
-			delegate,
-			serverDefinition.launch
-		);
-		store.add(connection);
-
-		// Show output
-		connection.showOutput();
-
-		assert.strictEqual(channelShown, true);
-		assert.strictEqual(loggerVisible, true);
-	});
-
 	test('should log transport messages', async () => {
 		// Track logged messages
 		const loggedMessages: string[] = [];
-		const loggerService = new class extends TestLoggerService {
-			override createLogger(id: string) {
-				return {
-					info: (message: string) => {
-						loggedMessages.push(message);
-					},
-					error: () => { },
-					dispose: () => { }
-				} as Partial<ILogger> as ILogger;
-			}
-		};
-
-		// Override services
-		const services = new ServiceCollection(
-			[ILoggerService, store.add(loggerService)],
-			[IOutputService, upcast({ showChannel: () => { } })],
-			[IStorageService, store.add(new TestStorageService())]
-		);
-
-		const localInstantiationService = store.add(new TestInstantiationService(services));
 
 		// Create server connection
-		const connection = localInstantiationService.createInstance(
+		const connection = instantiationService.createInstance(
 			McpServerConnection,
 			collection,
 			serverDefinition,
 			delegate,
-			serverDefinition.launch
+			serverDefinition.launch,
+			{
+				info: (message: string) => {
+					loggedMessages.push(message);
+				},
+				error: () => { },
+				dispose: () => { }
+			} as Partial<ILogger> as ILogger,
 		);
 		store.add(connection);
 
@@ -355,6 +304,9 @@ suite('Workbench - MCP - ServerConnection', () => {
 
 		// Check that the message was logged
 		assert.ok(loggedMessages.some(msg => msg === 'Test log message'));
+
+		connection.dispose();
+		await timeout(10);
 	});
 
 	test('should correctly handle transitions to and from error state', async () => {
@@ -364,7 +316,8 @@ suite('Workbench - MCP - ServerConnection', () => {
 			collection,
 			serverDefinition,
 			delegate,
-			serverDefinition.launch
+			serverDefinition.launch,
+			new NullLogger(),
 		);
 		store.add(connection);
 
@@ -401,7 +354,8 @@ suite('Workbench - MCP - ServerConnection', () => {
 			collection,
 			serverDefinition,
 			delegate,
-			serverDefinition.launch
+			serverDefinition.launch,
+			new NullLogger(),
 		);
 		store.add(connection);
 


### PR DESCRIPTION
Slight refactor: moved the logger to be owned by the McpServer rather than the McpServerRequestHandler so it doesn't disappear when a server is restarting.

Fixes #244058

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
