### PR TITLE
mcp: pick up configs from other apps when enabled

### DIFF
--- a/src/vs/workbench/contrib/mcp/browser/mcp.contribution.ts
+++ b/src/vs/workbench/contrib/mcp/browser/mcp.contribution.ts
@@ -14,6 +14,7 @@ import { ConfigMcpDiscovery } from '../common/discovery/configMcpDiscovery.js';
 import { ExtensionMcpDiscovery } from '../common/discovery/extensionMcpDiscovery.js';
 import { mcpDiscoveryRegistry } from '../common/discovery/mcpDiscovery.js';
 import { RemoteNativeMpcDiscovery } from '../common/discovery/nativeMcpRemoteDiscovery.js';
+import { CursorWorkspaceMcpDiscoveryAdapter } from '../common/discovery/workspaceMcpDiscoveryAdapter.js';
 import { IMcpConfigPathsService, McpConfigPathsService } from '../common/mcpConfigPathsService.js';
 import { mcpServerSchema } from '../common/mcpConfiguration.js';
 import { McpContextKeysController } from '../common/mcpContextKeys.js';
@@ -33,6 +34,7 @@ registerSingleton(IMcpConfigPathsService, McpConfigPathsService, InstantiationTy
 mcpDiscoveryRegistry.register(new SyncDescriptor(RemoteNativeMpcDiscovery));
 mcpDiscoveryRegistry.register(new SyncDescriptor(ConfigMcpDiscovery));
 mcpDiscoveryRegistry.register(new SyncDescriptor(ExtensionMcpDiscovery));
+mcpDiscoveryRegistry.register(new SyncDescriptor(CursorWorkspaceMcpDiscoveryAdapter));
 
 registerWorkbenchContribution2('mcpDiscovery', McpDiscovery, WorkbenchPhase.AfterRestored);
 registerWorkbenchContribution2('mcpContextKeys', McpContextKeysController, WorkbenchPhase.BlockRestore);

--- a/src/vs/workbench/contrib/mcp/common/discovery/nativeMcpDiscoveryAbstract.ts
+++ b/src/vs/workbench/contrib/mcp/common/discovery/nativeMcpDiscoveryAbstract.ts
@@ -4,9 +4,10 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { RunOnceScheduler } from '../../../../../base/common/async.js';
-import { Disposable, MutableDisposable } from '../../../../../base/common/lifecycle.js';
+import { VSBuffer } from '../../../../../base/common/buffer.js';
+import { Disposable, DisposableStore, IDisposable, MutableDisposable } from '../../../../../base/common/lifecycle.js';
 import { Schemas } from '../../../../../base/common/network.js';
-import { autorunWithStore, IObservable, observableValue } from '../../../../../base/common/observable.js';
+import { autorunWithStore, IObservable, ISettableObservable, observableValue } from '../../../../../base/common/observable.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { localize } from '../../../../../nls.js';
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
@@ -21,34 +22,89 @@ import { mcpDiscoverySection } from '../mcpConfiguration.js';
 import { IMcpRegistry } from '../mcpRegistryTypes.js';
 import { McpCollectionDefinition, McpCollectionSortOrder, McpServerDefinition } from '../mcpTypes.js';
 import { IMcpDiscovery } from './mcpDiscovery.js';
-import { ClaudeDesktopMpcDiscoveryAdapter, NativeMpcDiscoveryAdapter } from './nativeMcpDiscoveryAdapters.js';
+import { ClaudeDesktopMpcDiscoveryAdapter, CursorDesktopMpcDiscoveryAdapter, NativeMpcDiscoveryAdapter, WindsurfDesktopMpcDiscoveryAdapter } from './nativeMcpDiscoveryAdapters.js';
+
+export type WritableMcpCollectionDefinition = McpCollectionDefinition & { serverDefinitions: ISettableObservable<readonly McpServerDefinition[]> };
+
+export abstract class FilesytemMcpDiscovery extends Disposable {
+	protected _fsDiscoveryEnabled: IObservable<boolean>;
+
+	constructor(
+		@IConfigurationService configurationService: IConfigurationService,
+		@IFileService private readonly _fileService: IFileService,
+		@IMcpRegistry private readonly _mcpRegistry: IMcpRegistry,
+	) {
+		super();
+
+		this._fsDiscoveryEnabled = observableConfigValue(mcpDiscoverySection, false, configurationService);
+	}
+
+	protected watchFile(
+		file: URI,
+		collection: WritableMcpCollectionDefinition,
+		adaptFile: (contents: VSBuffer) => McpServerDefinition[] | undefined,
+	): IDisposable {
+		const store = new DisposableStore();
+		const collectionRegistration = store.add(new MutableDisposable());
+		const updateFile = async () => {
+			let definitions: McpServerDefinition[] = [];
+			try {
+				const contents = await this._fileService.readFile(file);
+				definitions = adaptFile(contents.value) || [];
+			} catch {
+				// ignored
+			}
+			if (!definitions.length) {
+				collectionRegistration.clear();
+			} else {
+				collection.serverDefinitions.set(definitions, undefined);
+				if (!collectionRegistration.value) {
+					collectionRegistration.value = this._mcpRegistry.registerCollection(collection);
+				}
+			}
+		};
+
+		store.add(autorunWithStore((reader, store) => {
+			if (!this._fsDiscoveryEnabled.read(reader)) {
+				collectionRegistration.clear();
+				return;
+			}
+
+			const throttler = store.add(new RunOnceScheduler(updateFile, 500));
+			const watcher = store.add(this._fileService.createWatcher(file, { recursive: false, excludes: [] }));
+			store.add(watcher.onDidChange(() => throttler.schedule()));
+			updateFile();
+		}));
+
+		return store;
+	}
+}
 
 /**
  * Base class that discovers MCP servers on a filesystem, outside of the ones
  * defined in VS Code settings.
  */
-export abstract class FilesystemMpcDiscovery extends Disposable implements IMcpDiscovery {
+export abstract class NativeFilesystemMcpDiscovery extends FilesytemMcpDiscovery implements IMcpDiscovery {
 	private readonly adapters: readonly NativeMpcDiscoveryAdapter[];
-	private _fsDiscoveryEnabled: IObservable<boolean>;
 	private suffix = '';
 
 	constructor(
 		remoteAuthority: string | null,
 		@ILabelService labelService: ILabelService,
-		@IFileService private readonly fileService: IFileService,
+		@IFileService fileService: IFileService,
 		@IInstantiationService instantiationService: IInstantiationService,
-		@IMcpRegistry private readonly mcpRegistry: IMcpRegistry,
+		@IMcpRegistry mcpRegistry: IMcpRegistry,
 		@IConfigurationService configurationService: IConfigurationService,
 	) {
-		super();
+		super(configurationService, fileService, mcpRegistry);
 		if (remoteAuthority) {
 			this.suffix = ' ' + localize('onRemoteLabel', ' on {0}', labelService.getHostLabel(Schemas.vscodeRemote, remoteAuthority));
 		}
 
-		this._fsDiscoveryEnabled = observableConfigValue(mcpDiscoverySection, false, configurationService);
-
 		this.adapters = [
-			instantiationService.createInstance(ClaudeDesktopMpcDiscoveryAdapter, remoteAuthority)
+			instantiationService.createInstance(ClaudeDesktopMpcDiscoveryAdapter, remoteAuthority),
+			instantiationService.createInstance(CursorDesktopMpcDiscoveryAdapter, remoteAuthority),
+			instantiationService.createInstance(WindsurfDesktopMpcDiscoveryAdapter, remoteAuthority),
 		];
 	}
 
@@ -72,7 +128,7 @@ export abstract class FilesystemMpcDiscovery extends Disposable implements IMcpD
 				continue;
 			}
 
-			const collection = {
+			const collection: WritableMcpCollectionDefinition = {
 				id: adapter.id,
 				label: adapter.label + this.suffix,
 				remoteAuthority: adapter.remoteAuthority,
@@ -83,38 +139,9 @@ export abstract class FilesystemMpcDiscovery extends Disposable implements IMcpD
 					origin: file,
 					order: adapter.order + (adapter.remoteAuthority ? McpCollectionSortOrder.RemoteBoost : 0),
 				},
-			} satisfies McpCollectionDefinition;
-
-			const collectionRegistration = this._register(new MutableDisposable());
-			const updateFile = async () => {
-				let definitions: McpServerDefinition[] = [];
-				try {
-					const contents = await this.fileService.readFile(file);
-					definitions = adapter.adaptFile(contents.value, details) || [];
-				} catch {
-					// ignored
-				}
-				if (!definitions.length) {
-					collectionRegistration.clear();
-				} else {
-					collection.serverDefinitions.set(definitions, undefined);
-					if (!collectionRegistration.value) {
-						collectionRegistration.value = this.mcpRegistry.registerCollection(collection);
-					}
-				}
 			};
 
-			this._register(autorunWithStore((reader, store) => {
-				if (!this._fsDiscoveryEnabled.read(reader)) {
-					collectionRegistration.clear();
-					return;
-				}
-
-				const throttler = store.add(new RunOnceScheduler(updateFile, 500));
-				const watcher = store.add(this.fileService.createWatcher(file, { recursive: false, excludes: [] }));
-				store.add(watcher.onDidChange(() => throttler.schedule()));
-				updateFile();
-			}));
+			this._register(this.watchFile(file, collection, contents => adapter.adaptFile(contents, details)));
 		}
 	}
 }

--- a/src/vs/workbench/contrib/mcp/common/discovery/nativeMcpDiscoveryAdapters.ts
+++ b/src/vs/workbench/contrib/mcp/common/discovery/nativeMcpDiscoveryAdapters.ts
@@ -5,6 +5,7 @@
 
 import { VSBuffer } from '../../../../../base/common/buffer.js';
 import { Platform } from '../../../../../base/common/platform.js';
+import { Mutable } from '../../../../../base/common/types.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { INativeMcpDiscoveryData } from '../../../../../platform/mcp/common/nativeMcpDiscoveryHelper.js';
 import { McpCollectionSortOrder, McpServerDefinition, McpServerTransportType } from '../mcpTypes.js';
@@ -19,8 +20,39 @@ export interface NativeMpcDiscoveryAdapter {
 	adaptFile(contents: VSBuffer, details: INativeMcpDiscoveryData): McpServerDefinition[] | undefined;
 }
 
+export function claudeConfigToServerDefinition(idPrefix: string, contents: VSBuffer, cwd?: URI) {
+	let parsed: {
+		mcpServers: Record<string, {
+			command: string;
+			args?: string[];
+			env?: Record<string, string>;
+		}>;
+	};
+
+	try {
+		parsed = JSON.parse(contents.toString());
+	} catch {
+		return;
+	}
+
+	return Object.entries(parsed.mcpServers).map(([name, server]): Mutable<McpServerDefinition> => {
+		return {
+			id: `${idPrefix}.${name}`,
+			label: name,
+			launch: {
+				type: McpServerTransportType.Stdio,
+				args: server.args || [],
+				command: server.command,
+				env: server.env || {},
+				envFile: undefined,
+				cwd,
+			}
+		};
+	});
+}
+
 export class ClaudeDesktopMpcDiscoveryAdapter implements NativeMpcDiscoveryAdapter {
-	public readonly id: string;
+	public id: string;
 	public readonly label: string = 'Claude Desktop';
 	public readonly order = McpCollectionSortOrder.Filesystem;
 
@@ -41,32 +73,32 @@ export class ClaudeDesktopMpcDiscoveryAdapter implements NativeMpcDiscoveryAdapt
 	}
 
 	adaptFile(contents: VSBuffer, { homedir }: INativeMcpDiscoveryData): McpServerDefinition[] | undefined {
-		let parsed: {
-			mcpServers: Record<string, {
-				command: string;
-				args?: string[];
-				env?: Record<string, string>;
-			}>;
-		};
+		return claudeConfigToServerDefinition(this.id, contents, homedir);
+	}
+}
 
-		try {
-			parsed = JSON.parse(contents.toString());
-		} catch {
-			return;
-		}
-		return Object.entries(parsed.mcpServers).map(([name, server]): McpServerDefinition => {
-			return {
-				id: `claude_desktop_config.${name}`,
-				label: name,
-				launch: {
-					type: McpServerTransportType.Stdio,
-					args: server.args || [],
-					command: server.command,
-					env: server.env || {},
-					envFile: undefined,
-					cwd: homedir,
-				}
-			};
-		});
+export class WindsurfDesktopMpcDiscoveryAdapter extends ClaudeDesktopMpcDiscoveryAdapter {
+	public override readonly label: string = 'Windsurf';
+
+	constructor(remoteAuthority: string | null) {
+		super(remoteAuthority);
+		this.id = `windsurf.${this.remoteAuthority}`;
+	}
+
+	override getFilePath({ homedir }: INativeMcpDiscoveryData): URI | undefined {
+		return URI.joinPath(homedir, '.codeium', 'windsurf', 'mcp_config.json');
+	}
+}
+
+export class CursorDesktopMpcDiscoveryAdapter extends ClaudeDesktopMpcDiscoveryAdapter {
+	public override readonly label: string = 'Cursor';
+
+	constructor(remoteAuthority: string | null) {
+		super(remoteAuthority);
+		this.id = `cursor.${this.remoteAuthority}`;
+	}
+
+	override getFilePath({ homedir }: INativeMcpDiscoveryData): URI | undefined {
+		return URI.joinPath(homedir, '.cursor', 'mcp.json');
 	}
 }

--- a/src/vs/workbench/contrib/mcp/common/discovery/nativeMcpRemoteDiscovery.ts
+++ b/src/vs/workbench/contrib/mcp/common/discovery/nativeMcpRemoteDiscovery.ts
@@ -12,12 +12,12 @@ import { ILogService } from '../../../../../platform/log/common/log.js';
 import { INativeMcpDiscoveryHelperService, NativeMcpDiscoveryHelperChannelName } from '../../../../../platform/mcp/common/nativeMcpDiscoveryHelper.js';
 import { IRemoteAgentService } from '../../../../services/remote/common/remoteAgentService.js';
 import { IMcpRegistry } from '../mcpRegistryTypes.js';
-import { FilesystemMpcDiscovery } from './nativeMcpDiscoveryAbstract.js';
+import { NativeFilesystemMcpDiscovery } from './nativeMcpDiscoveryAbstract.js';
 
 /**
  * Discovers MCP servers on the remote filesystem, if any.
  */
-export class RemoteNativeMpcDiscovery extends FilesystemMpcDiscovery {
+export class RemoteNativeMpcDiscovery extends NativeFilesystemMcpDiscovery {
 	constructor(
 		@IRemoteAgentService private readonly remoteAgent: IRemoteAgentService,
 		@ILogService private readonly logService: ILogService,

--- a/src/vs/workbench/contrib/mcp/common/discovery/workspaceMcpDiscoveryAdapter.ts
+++ b/src/vs/workbench/contrib/mcp/common/discovery/workspaceMcpDiscoveryAdapter.ts
@@ -1,0 +1,78 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { DisposableMap, IDisposable } from '../../../../../base/common/lifecycle.js';
+import { observableValue } from '../../../../../base/common/observable.js';
+import { joinPath } from '../../../../../base/common/resources.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
+import { IFileService } from '../../../../../platform/files/common/files.js';
+import { StorageScope } from '../../../../../platform/storage/common/storage.js';
+import { IWorkspaceContextService, IWorkspaceFolder } from '../../../../../platform/workspace/common/workspace.js';
+import { IRemoteAgentService } from '../../../../services/remote/common/remoteAgentService.js';
+import { IMcpRegistry } from '../mcpRegistryTypes.js';
+import { McpCollectionSortOrder } from '../mcpTypes.js';
+import { IMcpDiscovery } from './mcpDiscovery.js';
+import { FilesytemMcpDiscovery, WritableMcpCollectionDefinition } from './nativeMcpDiscoveryAbstract.js';
+import { claudeConfigToServerDefinition } from './nativeMcpDiscoveryAdapters.js';
+
+export class CursorWorkspaceMcpDiscoveryAdapter extends FilesytemMcpDiscovery implements IMcpDiscovery {
+	private readonly _collections = this._register(new DisposableMap<string, IDisposable>());
+
+	constructor(
+		@IFileService fileService: IFileService,
+		@IWorkspaceContextService private readonly _workspaceContextService: IWorkspaceContextService,
+		@IMcpRegistry mcpRegistry: IMcpRegistry,
+		@IConfigurationService configurationService: IConfigurationService,
+		@IRemoteAgentService private readonly _remoteAgentService: IRemoteAgentService,
+	) {
+		super(configurationService, fileService, mcpRegistry);
+	}
+
+	start(): void {
+		this._register(this._workspaceContextService.onDidChangeWorkspaceFolders(e => {
+			if (!this._fsDiscoveryEnabled.get()) {
+				return;
+			}
+
+			for (const removed of e.removed) {
+				this._collections.deleteAndDispose(removed.uri.toString());
+			}
+			for (const added of e.added) {
+				this.watchFolder(added);
+			}
+		}));
+
+		for (const folder of this._workspaceContextService.getWorkspace().folders) {
+			this.watchFolder(folder);
+		}
+	}
+
+	private watchFolder(folder: IWorkspaceFolder) {
+		const configFile = joinPath(folder.uri, '.cursor', 'mcp.json');
+		const collection: WritableMcpCollectionDefinition = {
+			id: `cursor-workspace.${folder.index}`,
+			label: `From ${folder.name}/.cursor/mcp.json`,
+			remoteAuthority: this._remoteAgentService.getConnection()?.remoteAuthority || null,
+			scope: StorageScope.WORKSPACE,
+			isTrustedByDefault: false,
+			serverDefinitions: observableValue(this, []),
+			presentation: {
+				origin: configFile,
+				order: McpCollectionSortOrder.WorkspaceFolder + 1,
+			},
+		};
+
+		return this.watchFile(
+			URI.joinPath(folder.uri, '.cursor', 'mcp.json'),
+			collection,
+			contents => {
+				const defs = claudeConfigToServerDefinition(collection.id, contents, folder.uri);
+				defs?.forEach(d => d.roots = [folder.uri]);
+				return defs;
+			}
+		);
+	}
+}

--- a/src/vs/workbench/contrib/mcp/electron-sandbox/nativeMpcDiscovery.ts
+++ b/src/vs/workbench/contrib/mcp/electron-sandbox/nativeMpcDiscovery.ts
@@ -11,10 +11,10 @@ import { IMainProcessService } from '../../../../platform/ipc/common/mainProcess
 import { ILabelService } from '../../../../platform/label/common/label.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
 import { INativeMcpDiscoveryHelperService, NativeMcpDiscoveryHelperChannelName } from '../../../../platform/mcp/common/nativeMcpDiscoveryHelper.js';
-import { FilesystemMpcDiscovery } from '../common/discovery/nativeMcpDiscoveryAbstract.js';
+import { NativeFilesystemMcpDiscovery } from '../common/discovery/nativeMcpDiscoveryAbstract.js';
 import { IMcpRegistry } from '../common/mcpRegistryTypes.js';
 
-export class NativeMcpDiscovery extends FilesystemMpcDiscovery {
+export class NativeMcpDiscovery extends NativeFilesystemMcpDiscovery {
 	constructor(
 		@IMainProcessService private readonly mainProcess: IMainProcessService,
 		@ILogService private readonly logService: ILogService,


### PR DESCRIPTION
Looks for global Windsurf and Cursor configs, and also supports
Cursor's `.cursor/mcp.json` workspace config.

Note: builds on some changes in https://github.com/microsoft/vscode/pull/244066, only the last commit in this PR is new