### PR TITLE
mcp: various sync feedback

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -216,6 +216,14 @@ configurationRegistry.registerConfiguration({
 			description: nls.localize('chat.focusWindowOnConfirmation', "Controls whether the Copilot window should be focused when a confirmation is needed."),
 			default: true,
 		},
+		'chat.tools.autoApprove': {
+			default: false,
+			description: nls.localize('chat.tools.autoApprove', "Controls whether tool use should be automatically approved ('YOLO mode'). Can be set to `true`, or an array of tool names to automatically approve."),
+			oneOf: [
+				{ type: 'boolean' },
+				{ type: 'array', items: { type: 'string' } }
+			],
+		},
 		[mcpConfigurationSection]: {
 			type: 'object',
 			default: {

--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -211,6 +211,11 @@ configurationRegistry.registerConfiguration({
 			default: product.quality !== 'stable',
 			tags: ['experimental', 'onExp']
 		},
+		'chat.focusWindowOnConfirmation': {
+			type: 'boolean',
+			description: nls.localize('chat.focusWindowOnConfirmation', "Controls whether the Copilot window should be focused when a confirmation is needed."),
+			default: true,
+		},
 		[mcpConfigurationSection]: {
 			type: 'object',
 			default: {

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/chatConfirmationWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/chatConfirmationWidget.ts
@@ -16,6 +16,8 @@ import { autorun, observableValue } from '../../../../../base/common/observable.
 import { Codicon } from '../../../../../base/common/codicons.js';
 import { Action } from '../../../../../base/common/actions.js';
 import { IContextMenuService } from '../../../../../platform/contextview/browser/contextView.js';
+import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
+import { IHostService } from '../../../../services/host/browser/host.js';
 
 export interface IChatConfirmationButton {
 	label: string;
@@ -50,6 +52,8 @@ abstract class BaseChatConfirmationWidget extends Disposable {
 		expandableMessage: boolean,
 		@IInstantiationService protected readonly instantiationService: IInstantiationService,
 		@IContextMenuService contextMenuService: IContextMenuService,
+		@IConfigurationService private readonly _configurationService: IConfigurationService,
+		@IHostService private readonly _hostService: IHostService,
 	) {
 		super();
 
@@ -116,6 +120,13 @@ abstract class BaseChatConfirmationWidget extends Disposable {
 
 	protected renderMessage(element: HTMLElement): void {
 		this.messageElement.append(element);
+
+		if (this._configurationService.getValue<boolean>('chat.focusWindowOnConfirmation')) {
+			const targetWindow = dom.getWindow(element);
+			if (!targetWindow.document.hasFocus()) {
+				this._hostService.focus(targetWindow, { force: true /* Application may not be active */ });
+			}
+		}
 	}
 }
 
@@ -126,8 +137,10 @@ export class ChatConfirmationWidget extends BaseChatConfirmationWidget {
 		buttons: IChatConfirmationButton[],
 		@IInstantiationService instantiationService: IInstantiationService,
 		@IContextMenuService contextMenuService: IContextMenuService,
+		@IConfigurationService configurationService: IConfigurationService,
+		@IHostService hostService: IHostService,
 	) {
-		super(title, buttons, false, instantiationService, contextMenuService);
+		super(title, buttons, false, instantiationService, contextMenuService, configurationService, hostService);
 
 		const renderedMessage = this._register(this.markdownRenderer.render(
 			typeof this.message === 'string' ? new MarkdownString(this.message) : this.message,
@@ -145,8 +158,10 @@ export class ChatCustomConfirmationWidget extends BaseChatConfirmationWidget {
 		buttons: IChatConfirmationButton[],
 		@IInstantiationService instantiationService: IInstantiationService,
 		@IContextMenuService contextMenuService: IContextMenuService,
+		@IConfigurationService configurationService: IConfigurationService,
+		@IHostService hostService: IHostService,
 	) {
-		super(title, buttons, messageElementIsExpandable, instantiationService, contextMenuService);
+		super(title, buttons, messageElementIsExpandable, instantiationService, contextMenuService, configurationService, hostService);
 		this.renderMessage(messageElement);
 	}
 }

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/chatToolInvocationPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/chatToolInvocationPart.ts
@@ -240,11 +240,11 @@ class ChatToolInvocationSubPart extends Disposable {
 				};
 
 				const langId = this.languageService.getLanguageIdByLanguageName('json');
-				const model = this.modelService.createModel(
+				const model = this._register(this.modelService.createModel(
 					JSON.stringify(inputData.rawInput, undefined, 2),
 					this.languageService.createById(langId),
 					createToolInputUri(toolInvocation.toolId)
-				);
+				));
 				const editor = this._register(this.editorPool.get());
 				editor.object.render({
 					codeBlockIndex: this.codeBlockStartIndex,

--- a/src/vs/workbench/contrib/chat/browser/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/media/chat.css
@@ -1662,10 +1662,14 @@ have to be updated for changes to the rules above, or to support more deeply nes
 }
 
 .interactive-item-container .chat-command-button .monaco-button,
-.chat-confirmation-widget .chat-confirmation-buttons-container .monaco-button {
+.chat-confirmation-widget .chat-confirmation-buttons-container .monaco-button:not(.monaco-dropdown-button) {
 	text-align: left;
 	width: initial;
 	padding: 4px 8px;
+}
+
+.chat-confirmation-widget .chat-confirmation-buttons-container .monaco-button.monaco-dropdown-button {
+	padding: 0 3px;
 }
 
 .interactive-item-container .chat-confirmation-widget .interactive-result-code-block {

--- a/src/vs/workbench/contrib/chat/common/languageModelToolsService.ts
+++ b/src/vs/workbench/contrib/chat/common/languageModelToolsService.ts
@@ -29,6 +29,11 @@ export interface IToolData {
 	modelDescription: string;
 	inputSchema?: IJSONSchema;
 	canBeReferencedInPrompt?: boolean;
+	/**
+	 * True if the tool runs in the (possibly remote) workspace, false if it runs
+	 * on the host, undefined if known.
+	 */
+	runsInWorkspace?: boolean;
 }
 
 export interface IToolInvocation {

--- a/src/vs/workbench/contrib/mcp/browser/mcpCommands.ts
+++ b/src/vs/workbench/contrib/mcp/browser/mcpCommands.ts
@@ -8,12 +8,10 @@ import { assertNever } from '../../../../base/common/assert.js';
 import { Codicon } from '../../../../base/common/codicons.js';
 import { groupBy } from '../../../../base/common/collections.js';
 import { Event } from '../../../../base/common/event.js';
-import { parse as jsoncParse } from '../../../../base/common/jsonc.js';
 import { Disposable, DisposableStore } from '../../../../base/common/lifecycle.js';
 import { autorun, derived } from '../../../../base/common/observable.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
 import { URI } from '../../../../base/common/uri.js';
-import { IModelService } from '../../../../editor/common/services/model.js';
 import { ILocalizedString, localize, localize2 } from '../../../../nls.js';
 import { IActionViewItemService } from '../../../../platform/actions/browser/actionViewItemService.js';
 import { MenuEntryActionViewItem } from '../../../../platform/actions/browser/menuEntryActionViewItem.js';
@@ -544,9 +542,7 @@ export class InstallFromActivation extends Action2 {
 	}
 
 	async run(accessor: ServicesAccessor, uri: URI) {
-		const editorService = accessor.get(IModelService);
 		const addConfigHelper = accessor.get(IInstantiationService).createInstance(McpAddConfigurationCommand, undefined);
-
-		addConfigHelper.pickForUrlHandler(uri, jsoncParse(editorService.getModel(uri)!.getValue()));
+		addConfigHelper.pickForUrlHandler(uri);
 	}
 }

--- a/src/vs/workbench/contrib/mcp/browser/mcpCommandsAddConfiguration.ts
+++ b/src/vs/workbench/contrib/mcp/browser/mcpCommandsAddConfiguration.ts
@@ -357,13 +357,13 @@ export class McpAddConfigurationCommand {
 
 	public async pickForUrlHandler(resource: URI, config: McpConfigurationServer): Promise<void> {
 		const name = decodeURIComponent(basename(resource)).replace(/\.json$/, '');
-		const title = localize('install.title', 'Install MCP server {0}', name);
+		const placeHolder = localize('install.title', 'Install MCP server {0}', name);
 		const pick = await this._quickInputService.pick([
 			{ id: 'show', label: localize('install.show', 'Show Configuration', name) },
 			{ id: 'install', label: localize('install.start', 'Install Server'), description: localize('install.description', 'Install in your user settings') },
 			{ id: 'rename', label: localize('install.rename', 'Rename "{0}"', name) },
 			{ id: 'cancel', label: localize('cancel', 'Cancel') },
-		], { title, ignoreFocusLost: true });
+		], { placeHolder, ignoreFocusLost: true });
 		switch (pick?.id) {
 			case 'show': {
 				await this._editorService.openEditor({ resource });
@@ -378,7 +378,7 @@ export class McpAddConfigurationCommand {
 				break;
 			}
 			case 'rename': {
-				const newName = await this._quickInputService.input({ title, placeHolder: localize('install.newName', 'Enter new name'), value: name });
+				const newName = await this._quickInputService.input({ placeHolder: localize('install.newName', 'Enter new name'), value: name });
 				if (newName) {
 					return this.pickForUrlHandler(resource.with({ path: `/${encodeURIComponent(newName)}.json` }), config);
 				}

--- a/src/vs/workbench/contrib/mcp/browser/mcpCommandsAddConfiguration.ts
+++ b/src/vs/workbench/contrib/mcp/browser/mcpCommandsAddConfiguration.ts
@@ -6,6 +6,7 @@
 import { mapFindFirst } from '../../../../base/common/arraysFind.js';
 import { assertNever } from '../../../../base/common/assert.js';
 import { disposableTimeout } from '../../../../base/common/async.js';
+import { parse as parseJsonc } from '../../../../base/common/jsonc.js';
 import { DisposableStore } from '../../../../base/common/lifecycle.js';
 import { autorun } from '../../../../base/common/observable.js';
 import { basename } from '../../../../base/common/resources.js';
@@ -14,7 +15,9 @@ import { generateUuid } from '../../../../base/common/uuid.js';
 import { localize } from '../../../../nls.js';
 import { ICommandService } from '../../../../platform/commands/common/commands.js';
 import { ConfigurationTarget, getConfigValueInTarget, IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
+import { IFileService } from '../../../../platform/files/common/files.js';
 import { IMcpConfiguration, IMcpConfigurationSSE, McpConfigurationServer } from '../../../../platform/mcp/common/mcpPlatformTypes.js';
+import { INotificationService } from '../../../../platform/notification/common/notification.js';
 import { IQuickInputService, IQuickPickItem, QuickPickInput } from '../../../../platform/quickinput/common/quickInput.js';
 import { IWorkspaceContextService } from '../../../../platform/workspace/common/workspace.js';
 import { EditorsOrder } from '../../../common/editor.js';
@@ -58,6 +61,8 @@ export class McpAddConfigurationCommand {
 		@IMcpRegistry private readonly _mcpRegistry: IMcpRegistry,
 		@IEditorService private readonly _openerService: IEditorService,
 		@IEditorService private readonly _editorService: IEditorService,
+		@IFileService private readonly _fileService: IFileService,
+		@INotificationService private readonly _notificationService: INotificationService,
 	) { }
 
 	private async getServerType(): Promise<AddConfigurationType | undefined> {
@@ -355,32 +360,48 @@ export class McpAddConfigurationCommand {
 		this.showOnceDiscovered(serverId);
 	}
 
-	public async pickForUrlHandler(resource: URI, config: McpConfigurationServer): Promise<void> {
+	public async pickForUrlHandler(resource: URI, showIsPrimary = false): Promise<void> {
 		const name = decodeURIComponent(basename(resource)).replace(/\.json$/, '');
 		const placeHolder = localize('install.title', 'Install MCP server {0}', name);
-		const pick = await this._quickInputService.pick([
-			{ id: 'show', label: localize('install.show', 'Show Configuration', name) },
+
+		const items: IQuickPickItem[] = [
 			{ id: 'install', label: localize('install.start', 'Install Server'), description: localize('install.description', 'Install in your user settings') },
+			{ id: 'show', label: localize('install.show', 'Show Configuration', name) },
 			{ id: 'rename', label: localize('install.rename', 'Rename "{0}"', name) },
 			{ id: 'cancel', label: localize('cancel', 'Cancel') },
-		], { placeHolder, ignoreFocusLost: true });
+		];
+		if (showIsPrimary) {
+			[items[0], items[1]] = [items[1], items[0]];
+		}
+
+		const pick = await this._quickInputService.pick(items, { placeHolder, ignoreFocusLost: true });
+		const getEditors = () => this._editorService.getEditors(EditorsOrder.MOST_RECENTLY_ACTIVE)
+			.filter(e => e.editor.resource?.toString() === resource.toString());
+
 		switch (pick?.id) {
-			case 'show': {
+			case 'show':
 				await this._editorService.openEditor({ resource });
 				break;
-			}
-			case 'install': {
-				await this.writeToUserSetting(name, config, ConfigurationTarget.USER_LOCAL);
-				this._editorService.closeEditors(
-					this._editorService.getEditors(EditorsOrder.MOST_RECENTLY_ACTIVE).filter(e => e.editor.resource?.toString() === resource.toString())
-				);
-				this.showOnceDiscovered(name);
+			case 'install':
+				await this._editorService.save(getEditors());
+				try {
+					const contents = await this._fileService.readFile(resource);
+					const config: McpConfigurationServer = parseJsonc(contents.value.toString());
+					await this.writeToUserSetting(name, config, ConfigurationTarget.USER_LOCAL);
+					this._editorService.closeEditors(getEditors());
+					this.showOnceDiscovered(name);
+				} catch (e) {
+					this._notificationService.error(localize('install.error', 'Error installing MCP server {0}: {1}', name, e.message));
+					await this._editorService.openEditor({ resource });
+				}
 				break;
-			}
 			case 'rename': {
 				const newName = await this._quickInputService.input({ placeHolder: localize('install.newName', 'Enter new name'), value: name });
 				if (newName) {
-					return this.pickForUrlHandler(resource.with({ path: `/${encodeURIComponent(newName)}.json` }), config);
+					const newURI = resource.with({ path: `/${encodeURIComponent(newName)}.json` });
+					await this._editorService.save(getEditors());
+					await this._fileService.move(resource, newURI);
+					return this.pickForUrlHandler(newURI, showIsPrimary);
 				}
 				break;
 			}

--- a/src/vs/workbench/contrib/mcp/common/discovery/nativeMcpDiscoveryAdapters.ts
+++ b/src/vs/workbench/contrib/mcp/common/discovery/nativeMcpDiscoveryAdapters.ts
@@ -26,6 +26,7 @@ export function claudeConfigToServerDefinition(idPrefix: string, contents: VSBuf
 			command: string;
 			args?: string[];
 			env?: Record<string, string>;
+			url?: string;
 		}>;
 	};
 
@@ -39,7 +40,11 @@ export function claudeConfigToServerDefinition(idPrefix: string, contents: VSBuf
 		return {
 			id: `${idPrefix}.${name}`,
 			label: name,
-			launch: {
+			launch: server.url ? {
+				type: McpServerTransportType.SSE,
+				uri: URI.parse(server.url),
+				headers: [],
+			} : {
 				type: McpServerTransportType.Stdio,
 				args: server.args || [],
 				command: server.command,

--- a/src/vs/workbench/contrib/mcp/common/mcpService.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpService.ts
@@ -95,6 +95,7 @@ export class McpService extends Disposable implements IMcpService {
 			const toDelete = new Set(tools.keys());
 			for (const tool of server.tools.read(reader)) {
 				const existing = tools.get(tool.id);
+				const collection = this._mcpRegistry.collections.get().find(c => c.id === server.collection.id);
 				const toolData: IToolData = {
 					id: tool.id,
 					displayName: tool.definition.name,
@@ -103,6 +104,7 @@ export class McpService extends Disposable implements IMcpService {
 					userDescription: tool.definition.description ?? '',
 					inputSchema: tool.definition.inputSchema,
 					canBeReferencedInPrompt: true,
+					runsInWorkspace: collection?.scope === StorageScope.WORKSPACE || !!collection?.remoteAuthority,
 					tags: ['mcp', 'vscode_editing'], // TODO@jrieken remove this tag
 				};
 


### PR DESCRIPTION
See individual commits.

Notably this adds a `chat.tools.autoApprove` 'yolo' mode. It behaves as follows:

- When set to true/false, turn it off and on. It can also be set to an array of tool names to enable or disable.
- When set at a user level, it applies to all tools in the application.
- When set at a workspace or remote level, it will _not_ apply to tools that run on the host machine (i.e. it would not auto-approve MCP calls for MCP servers configured in user settings.json)