### PR TITLE
Add isEdit to ChatResponseCodeblockUriPart

### DIFF
--- a/src/vs/workbench/api/common/extHostChatAgents2.ts
+++ b/src/vs/workbench/api/common/extHostChatAgents2.ts
@@ -127,10 +127,10 @@ class ChatAgentResponseStream {
 					_report(dto);
 					return this;
 				},
-				codeblockUri(value) {
+				codeblockUri(value, isEdit) {
 					throwIfDone(this.codeblockUri);
 					checkProposedApiEnabled(that._extension, 'chatParticipantAdditions');
-					const part = new extHostTypes.ChatResponseCodeblockUriPart(value);
+					const part = new extHostTypes.ChatResponseCodeblockUriPart(value, isEdit);
 					const dto = typeConvert.ChatResponseCodeblockUriPart.from(part);
 					_report(dto);
 					return this;

--- a/src/vs/workbench/api/common/extHostTypeConverters.ts
+++ b/src/vs/workbench/api/common/extHostTypeConverters.ts
@@ -2529,10 +2529,11 @@ export namespace ChatResponseCodeblockUriPart {
 		return {
 			kind: 'codeblockUri',
 			uri: part.value,
+			isEdit: part.isEdit,
 		};
 	}
 	export function to(part: Dto<IChatResponseCodeblockUriPart>): vscode.ChatResponseCodeblockUriPart {
-		return new types.ChatResponseCodeblockUriPart(URI.revive(part.uri));
+		return new types.ChatResponseCodeblockUriPart(URI.revive(part.uri), part.isEdit);
 	}
 }
 

--- a/src/vs/workbench/api/common/extHostTypes.ts
+++ b/src/vs/workbench/api/common/extHostTypes.ts
@@ -4647,9 +4647,11 @@ export class ChatResponseReferencePart {
 }
 
 export class ChatResponseCodeblockUriPart {
+	isEdit?: boolean;
 	value: vscode.Uri;
-	constructor(value: vscode.Uri) {
+	constructor(value: vscode.Uri, isEdit?: boolean) {
 		this.value = value;
+		this.isEdit = isEdit;
 	}
 }
 

--- a/src/vs/workbench/contrib/chat/common/chatService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService.ts
@@ -169,6 +169,7 @@ export interface IChatAgentVulnerabilityDetails {
 export interface IChatResponseCodeblockUriPart {
 	kind: 'codeblockUri';
 	uri: URI;
+	isEdit?: boolean;
 }
 
 export interface IChatAgentMarkdownContentWithVulnerability {

--- a/src/vs/workbench/contrib/chat/common/codeBlockModelCollection.ts
+++ b/src/vs/workbench/contrib/chat/common/codeBlockModelCollection.ts
@@ -21,10 +21,11 @@ interface CodeBlockContent {
 	readonly isComplete: boolean;
 }
 
-interface CodeBlockEntry {
+export interface CodeBlockEntry {
 	readonly model: Promise<ITextModel>;
 	readonly vulns: readonly IMarkdownVulnerability[];
 	readonly codemapperUri?: URI;
+	readonly isEdit?: boolean;
 }
 
 export class CodeBlockModelCollection extends Disposable {
@@ -33,6 +34,7 @@ export class CodeBlockModelCollection extends Disposable {
 		model: Promise<IReference<IResolvedTextEditorModel>>;
 		vulns: readonly IMarkdownVulnerability[];
 		codemapperUri?: URI;
+		isEdit?: boolean;
 	}>();
 
 	/**
@@ -63,7 +65,8 @@ export class CodeBlockModelCollection extends Disposable {
 		return {
 			model: entry.model.then(ref => ref.object.textEditorModel),
 			vulns: entry.vulns,
-			codemapperUri: entry.codemapperUri
+			codemapperUri: entry.codemapperUri,
+			isEdit: entry.isEdit,
 		};
 	}
 
@@ -117,7 +120,7 @@ export class CodeBlockModelCollection extends Disposable {
 
 		const codeblockUri = extractCodeblockUrisFromText(newText);
 		if (codeblockUri) {
-			this.setCodemapperUri(sessionId, chat, codeBlockIndex, codeblockUri.uri);
+			this.setCodemapperUri(sessionId, chat, codeBlockIndex, codeblockUri.uri, codeblockUri.isEdit);
 		}
 
 		if (content.isComplete) {
@@ -144,7 +147,7 @@ export class CodeBlockModelCollection extends Disposable {
 
 		const codeblockUri = extractCodeblockUrisFromText(newText);
 		if (codeblockUri) {
-			this.setCodemapperUri(sessionId, chat, codeBlockIndex, codeblockUri.uri);
+			this.setCodemapperUri(sessionId, chat, codeBlockIndex, codeblockUri.uri, codeblockUri.isEdit);
 			newText = codeblockUri.textWithoutResult;
 		}
 
@@ -182,10 +185,11 @@ export class CodeBlockModelCollection extends Disposable {
 		return entry;
 	}
 
-	private setCodemapperUri(sessionId: string, chat: IChatRequestViewModel | IChatResponseViewModel, codeBlockIndex: number, codemapperUri: URI) {
+	private setCodemapperUri(sessionId: string, chat: IChatRequestViewModel | IChatResponseViewModel, codeBlockIndex: number, codemapperUri: URI, isEdit?: boolean) {
 		const entry = this._models.get(this.getKey(sessionId, chat, codeBlockIndex));
 		if (entry) {
 			entry.codemapperUri = codemapperUri;
+			entry.isEdit = isEdit;
 		}
 	}
 

--- a/src/vs/workbench/contrib/chat/common/tools/editFileTool.ts
+++ b/src/vs/workbench/contrib/chat/common/tools/editFileTool.ts
@@ -129,7 +129,8 @@ export class EditTool implements IToolImpl {
 		});
 		model.acceptResponseProgress(request, {
 			kind: 'codeblockUri',
-			uri
+			uri,
+			isEdit: true
 		});
 		model.acceptResponseProgress(request, {
 			kind: 'markdownContent',

--- a/src/vscode-dts/vscode.proposed.chatParticipantAdditions.d.ts
+++ b/src/vscode-dts/vscode.proposed.chatParticipantAdditions.d.ts
@@ -30,8 +30,9 @@ declare module 'vscode' {
 	}
 
 	export class ChatResponseCodeblockUriPart {
+		isEdit?: boolean;
 		value: Uri;
-		constructor(value: Uri);
+		constructor(value: Uri, isEdit?: boolean);
 	}
 
 	/**
@@ -179,7 +180,7 @@ declare module 'vscode' {
 		notebookEdit(target: Uri, isDone: true): void;
 
 		markdownWithVulnerabilities(value: string | MarkdownString, vulnerabilities: ChatVulnerability[]): void;
-		codeblockUri(uri: Uri): void;
+		codeblockUri(uri: Uri, isEdit?: boolean): void;
 		push(part: ChatResponsePart | ChatResponseTextEditPart | ChatResponseWarningPart | ChatResponseProgressPart2): void;
 
 		/**


### PR DESCRIPTION
We need to distinguish between codeblocks that have URIs and should be rendered as codeblock pills, vs ones that should be rendered as normal codeblocks but get the "apply in foo.js" handling due to having URIs. Previously this was just based on the mode, but in order to render chat codeblocks and also edits codeblocks, we need this tracking of whether a codeblockuri represents an edited file, which comes from the intent invocation.

When we clean up codeblock-based edits in favor of tools all the time, we can clean up this crazy code...

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
