### PR TITLE
SCM - vertically align the `$(repo)` icon in the status bar

### DIFF
--- a/src/vs/workbench/contrib/scm/browser/media/scm.css
+++ b/src/vs/workbench/contrib/scm/browser/media/scm.css
@@ -650,3 +650,7 @@
 	border-radius: 2px;
 	opacity: 0.5;
 }
+
+.monaco-workbench .part.statusbar > .items-container > .statusbar-item .codicon.codicon-repo {
+	padding-top: 1px;
+}


### PR DESCRIPTION
Temporary solution until we get an updated icon that is vertically aligned.

//cc @mrleemurray 