### PR TITLE
Close all unused ports command

### DIFF
--- a/src/vs/workbench/contrib/remote/electron-sandbox/remote.contribution.ts
+++ b/src/vs/workbench/contrib/remote/electron-sandbox/remote.contribution.ts
@@ -270,7 +270,7 @@ registerAction2(class extends Action2 {
 		// collect all forwarded ports and filter out those who do not have a process running
 		const forwarded = remoteExplorerService.tunnelModel.forwarded;
 		for (const [_, tunnel] of forwarded) {
-			if (!tunnel.hasRunningProcess) {
+			if (tunnel.hasRunningProcess === false) {
 				ports.push(tunnel);
 			}
 		}

--- a/src/vs/workbench/contrib/remote/electron-sandbox/remote.contribution.ts
+++ b/src/vs/workbench/contrib/remote/electron-sandbox/remote.contribution.ts
@@ -32,9 +32,10 @@ import { INativeHostService } from '../../../../platform/native/common/native.js
 import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
 import { Action2, MenuId, registerAction2 } from '../../../../platform/actions/common/actions.js';
 import { ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
-import { IRemoteExplorerService } from '../../../services/remote/common/remoteExplorerService.js';
+import { IRemoteExplorerService, PORT_AUTO_SOURCE_SETTING, PORT_AUTO_SOURCE_SETTING_OUTPUT } from '../../../services/remote/common/remoteExplorerService.js';
 import { Tunnel, TunnelCloseReason } from '../../../services/remote/common/tunnelModel.js';
-import { localize, localize2 } from '../../../../nls.js';
+import { localize } from '../../../../nls.js';
+import { RemoteNameContext } from '../../../common/contextkeys.js';
 
 class RemoteAgentDiagnosticListener implements IWorkbenchContribution {
 	constructor(
@@ -250,32 +251,16 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 	handler: SaveLocalFileCommand.handler()
 });
 
-// --- Close Unused Forwarded Ports Action ---
-
-const REMOTE_CATEGORY = localize2('remote.category', 'Remote');
-
-namespace RemoteCommandIds {
-	export const closeUnusedPorts = 'workbench.remote.action.closeUnusedPorts';
-}
-
-namespace RemoteCommandLabels {
-	export const closeUnusedPorts = localize('remote.actions.closeUnusedPorts', 'Close Unused Forwarded Ports');
-}
-
 registerAction2(class extends Action2 {
 	constructor() {
 		super({
-			id: RemoteCommandIds.closeUnusedPorts,
-			title: RemoteCommandLabels.closeUnusedPorts,
-			category: REMOTE_CATEGORY,
+			id: 'workbench.remote.action.closeUnusedPorts',
+			title: localize('remote.actions.closeUnusedPorts', 'Close Unused Forwarded Ports'),
+			category: localize('remote.category', 'Remote'),
 			menu: [{
-				id: MenuId.CommandPalette,
-				when: ContextKeyExpr.and(
-					ContextKeyExpr.equals('isLinux', true),
-					ContextKeyExpr.notEquals('config.remote.autoForwardPortsSource', 'output')
-				)
+				id: MenuId.CommandPalette
 			}],
-			precondition: ContextKeyExpr.equals('isWindows', false)
+			precondition: ContextKeyExpr.and(ContextKeyExpr.notEquals(`config.${PORT_AUTO_SOURCE_SETTING}`, PORT_AUTO_SOURCE_SETTING_OUTPUT), RemoteNameContext)
 		});
 	}
 

--- a/src/vs/workbench/contrib/remoteTunnel/electron-sandbox/remoteTunnel.contribution.ts
+++ b/src/vs/workbench/contrib/remoteTunnel/electron-sandbox/remoteTunnel.contribution.ts
@@ -65,7 +65,6 @@ enum RemoteTunnelCommandIds {
 	showLog = 'workbench.remoteTunnel.actions.showLog',
 	configure = 'workbench.remoteTunnel.actions.configure',
 	copyToClipboard = 'workbench.remoteTunnel.actions.copyToClipboard',
-	closeUnusedPorts = 'workbench.remoteTunnel.actions.closeUnusedPorts',
 	learnMore = 'workbench.remoteTunnel.actions.learnMore',
 }
 
@@ -76,7 +75,6 @@ namespace RemoteTunnelCommandLabels {
 	export const showLog = localize('remoteTunnel.actions.showLog', 'Show Remote Tunnel Service Log');
 	export const configure = localize('remoteTunnel.actions.configure', 'Configure Tunnel Name...');
 	export const copyToClipboard = localize('remoteTunnel.actions.copyToClipboard', 'Copy Browser URI to Clipboard');
-	export const closeUnusedPorts = localize('remoteTunnel.actions.closeUnusedPorts', 'Close Unused Ports');
 	export const learnMore = localize('remoteTunnel.actions.learnMore', 'Get Started with Tunnels');
 }
 

--- a/src/vs/workbench/contrib/remoteTunnel/electron-sandbox/remoteTunnel.contribution.ts
+++ b/src/vs/workbench/contrib/remoteTunnel/electron-sandbox/remoteTunnel.contribution.ts
@@ -35,8 +35,6 @@ import { IExtensionService } from '../../../services/extensions/common/extension
 import { LifecyclePhase } from '../../../services/lifecycle/common/lifecycle.js';
 import { IOutputService } from '../../../services/output/common/output.js';
 import { IPreferencesService } from '../../../services/preferences/common/preferences.js';
-import { IRemoteExplorerService } from '../../../services/remote/common/remoteExplorerService.js';
-import { Tunnel, TunnelCloseReason } from '../../../services/remote/common/tunnelModel.js';
 
 export const REMOTE_TUNNEL_CATEGORY = localize2('remoteTunnel.category', 'Remote Tunnels');
 
@@ -714,42 +712,6 @@ export class RemoteTunnelWorkbenchContribution extends Disposable implements IWo
 					clipboardService.writeText(linkToOpen.toString(true));
 				}
 
-			}
-		}));
-
-		this._register(registerAction2(class extends Action2 {
-			constructor() {
-				super({
-					id: RemoteTunnelCommandIds.closeUnusedPorts,
-					title: RemoteTunnelCommandLabels.closeUnusedPorts,
-					category: REMOTE_TUNNEL_CATEGORY,
-					precondition: ContextKeyExpr.equals(REMOTE_TUNNEL_CONNECTION_STATE_KEY, 'connected'),
-					menu: [{
-						id: MenuId.CommandPalette,
-					}]
-				});
-			}
-
-			async run(accessor: ServicesAccessor) {
-				const remoteExplorerService = accessor.get(IRemoteExplorerService);
-				const ports: Tunnel[] = [];
-				// collect all forwarded ports and filter out those who do not have a process running
-				const forwarded = remoteExplorerService.tunnelModel.forwarded;
-				for (const [_, tunnel] of forwarded) {
-					if (!tunnel.hasRunningProcess) {
-						ports.push(tunnel);
-					}
-				}
-
-				// Close the collected unused ports
-				if (ports.length) {
-					for (const port of ports) {
-						await remoteExplorerService.close({
-							host: port.remoteHost,
-							port: port.remotePort
-						}, TunnelCloseReason.User);
-					}
-				}
 			}
 		}));
 

--- a/src/vs/workbench/contrib/remoteTunnel/electron-sandbox/remoteTunnel.contribution.ts
+++ b/src/vs/workbench/contrib/remoteTunnel/electron-sandbox/remoteTunnel.contribution.ts
@@ -723,7 +723,10 @@ export class RemoteTunnelWorkbenchContribution extends Disposable implements IWo
 					id: RemoteTunnelCommandIds.closeUnusedPorts,
 					title: RemoteTunnelCommandLabels.closeUnusedPorts,
 					category: REMOTE_TUNNEL_CATEGORY,
-					menu: []
+					precondition: ContextKeyExpr.equals(REMOTE_TUNNEL_CONNECTION_STATE_KEY, 'connected'),
+					menu: [{
+						id: MenuId.CommandPalette,
+					}]
 				});
 			}
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Hello,

When connecting to a remote dev container, we often encounter the issue where forwarded ports remain open even after the remote process has stopped running. This occurs due to our setup, and VSCode cannot always detect when this happens.

![image](https://github.com/user-attachments/assets/a1babad9-fcf4-4996-8020-127f92f20aa6)

We would like to propose adding a command that automatically clears all forwarded ports without an active process.

Would this feature be accepted?

If so, how can I test this locally? I attempted to install a local VSIX of the remote container extension, but I'm unable to start a dev container. I believe this issue may stem from proprietary boundaries. I’m open to any suggestions on how to test this in another way.
