### PR TITLE
[prompts]: make the default `.github/prompts` config location entry non-required.

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -276,11 +276,9 @@ configurationRegistry.registerConfiguration({
 			default: {
 				[PromptsConfig.DEFAULT_SOURCE_FOLDER]: true,
 			},
-			required: [PromptsConfig.DEFAULT_SOURCE_FOLDER],
 			additionalProperties: { type: 'boolean' },
 			unevaluatedProperties: { type: 'boolean' },
 			restricted: true,
-			disallowConfigurationDefault: true,
 			tags: ['experimental', 'prompts', 'reusable prompts', 'prompt snippets', 'instructions'],
 			examples: [
 				{


### PR DESCRIPTION
Makes the default `.github/prompts` config location entry non-required.