### PR TITLE
align the look of paths for executables/specs in terminal completions

### DIFF
--- a/extensions/terminal-suggest/src/env/pathExecutableCache.ts
+++ b/extensions/terminal-suggest/src/env/pathExecutableCache.ts
@@ -96,7 +96,7 @@ export class PathExecutableCache implements vscode.Disposable {
 			for (const [file, fileType] of files) {
 				const formattedPath = getFriendlyResourcePath(vscode.Uri.joinPath(fileResource, file), pathSeparator);
 				if (!labels.has(file) && fileType !== vscode.FileType.Unknown && fileType !== vscode.FileType.Directory && await isExecutable(formattedPath, this._cachedWindowsExeExtensions)) {
-					result.add({ label: file, detail: formattedPath });
+					result.add({ label: file, documentation: formattedPath });
 					labels.add(file);
 				}
 			}


### PR DESCRIPTION
fix #242191

Note that I'm looking into what caused the icon to be `abc` here - not this change. edit: fix for that here #244301

![Screenshot 2025-03-21 at 3 20 26 PM](https://github.com/user-attachments/assets/46703dc2-5cc9-4f69-8af1-a42a851664af)

![Screenshot 2025-03-21 at 3 20 18 PM](https://github.com/user-attachments/assets/d2b0933f-7651-4310-995e-2d9a211b9d85)
