### PR TITLE
Fix some attachment styling issues

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
@@ -1014,7 +1014,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 		this.addFilesToolbar.context = { widget, placeholder: localize('chatAttachFiles', 'Search for files and context to add to your request') };
 		this._register(this.addFilesToolbar.onDidChangeMenuItems(() => {
 			if (this.cachedDimensions) {
-				this.layout(this.cachedDimensions.height, this.cachedDimensions.width);
+				this._onDidChangeHeight.fire();
 			}
 		}));
 	}

--- a/src/vs/workbench/contrib/chat/browser/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/media/chat.css
@@ -715,6 +715,7 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	gap: 4px;
 	margin-top: 6px;
 	flex-wrap: wrap;
+	cursor: default;
 }
 
 .chat-related-files {
@@ -1137,10 +1138,6 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	padding: 8px 0 0 0
 }
 
-.chat-attachment-toolbar .action-item:not(:last-child) {
-	margin-right: 4px;
-}
-
 .action-item.chat-attached-context-attachment.chat-add-files {
 	height: 20px;
 	color: var(--vscode-descriptionForeground);
@@ -1261,11 +1258,12 @@ have to be updated for changes to the rules above, or to support more deeply nes
 }
 
 .interactive-session .chat-attached-context {
-	display: flex;
-	flex-wrap: wrap;
-	cursor: default;
+	display: contents;
+}
+
+.interactive-session .chat-attachment-toolbar .actions-container {
 	gap: 4px;
-	max-width: 100%;
+	flex-wrap: wrap;
 }
 
 .interactive-session .interactive-input-part.compact .chat-attached-context {


### PR DESCRIPTION
- Fix flickering when changing modes- `addFilesToolbar.onDidChangeMenuItems` can change the height of the input, so it should fire the event so ChatWidget can relayout
- Wrap all the different types of buttons naturally
- Make the toolbar buttons not overflow
cc @joyceerhl 