### PR TITLE
chat: improve tool selection rememberance

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/actions/chatToolActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatToolActions.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { assertNever } from '../../../../../base/common/assert.js';
 import { Codicon } from '../../../../../base/common/codicons.js';
 import { diffSets } from '../../../../../base/common/collections.js';
 import { Event } from '../../../../../base/common/event.js';
@@ -23,7 +24,7 @@ import { ChatContextKeys } from '../../common/chatContextKeys.js';
 import { IChatToolInvocation } from '../../common/chatService.js';
 import { isResponseVM } from '../../common/chatViewModel.js';
 import { ChatMode } from '../../common/constants.js';
-import { ILanguageModelToolsService, IToolData } from '../../common/languageModelToolsService.js';
+import { ILanguageModelToolsService, IToolData, ToolDataSource } from '../../common/languageModelToolsService.js';
 import { IChatWidget, IChatWidgetService } from '../chat.js';
 import { CHAT_CATEGORY } from './chatActions.js';
 
@@ -140,7 +141,7 @@ export class AttachToolsAction extends Action2 {
 		}
 
 		const enum BucketOrdinal { Extension, Mcp, Other }
-		type BucketPick = IQuickPickItem & { picked: boolean; ordinal: BucketOrdinal; status?: string; children: ToolPick[] };
+		type BucketPick = IQuickPickItem & { picked: boolean; ordinal: BucketOrdinal; status?: string; children: ToolPick[]; source: ToolDataSource };
 		type ToolPick = IQuickPickItem & { picked: boolean; tool: IToolData; parent: BucketPick };
 		type MyPick = ToolPick | BucketPick;
 
@@ -148,6 +149,7 @@ export class AttachToolsAction extends Action2 {
 			type: 'item',
 			children: [],
 			label: localize('defaultBucketLabel', "Other Tools"),
+			source: { type: 'internal' },
 			ordinal: BucketOrdinal.Other,
 			picked: true,
 		};
@@ -156,36 +158,47 @@ export class AttachToolsAction extends Action2 {
 		const toolBuckets = new Map<string, BucketPick>();
 
 		for (const tool of toolsService.getTools()) {
-
 			if (!tool.canBeReferencedInPrompt) {
 				continue;
 			}
 
 			let bucket: BucketPick;
 
-			const mcpServer = mcpServerByTool.get(tool.id);
-			const ext = extensionService.extensions.find(value => ExtensionIdentifier.equals(value.identifier, tool.extensionId));
-			if (mcpServer) {
-				bucket = toolBuckets.get(mcpServer.definition.id) ?? {
+			if (tool.source.type === 'mcp') {
+				const mcpServer = mcpServerByTool.get(tool.id);
+				if (!mcpServer) {
+					continue;
+				}
+				bucket = toolBuckets.get(tool.source.collectionId) ?? {
 					type: 'item',
-					label: localize('mcplabel', "MCP Server: {0}", mcpServer.definition.label),
+					label: localize('mcplabel', "MCP Server: {0}", mcpServer?.definition.label),
 					status: localize('mcpstatus', "From {0} ({1})", mcpServer.collection.label, McpConnectionState.toString(mcpServer.connectionState.get())),
 					ordinal: BucketOrdinal.Mcp,
+					source: tool.source,
 					picked: false,
 					children: []
 				};
-				toolBuckets.set(mcpServer.definition.id, bucket);
-			} else if (ext) {
-				bucket = toolBuckets.get(ExtensionIdentifier.toKey(ext.identifier)) ?? {
+				toolBuckets.set(tool.source.collectionId, bucket);
+			} else if (tool.source.type === 'extension') {
+				const extensionId = tool.source.extensionId;
+				const ext = extensionService.extensions.find(value => ExtensionIdentifier.equals(value.identifier, extensionId));
+				if (!ext) {
+					continue;
+				}
+
+				bucket = toolBuckets.get(ExtensionIdentifier.toKey(extensionId)) ?? {
 					type: 'item',
 					label: ext.displayName ?? ext.name,
 					ordinal: BucketOrdinal.Extension,
 					picked: false,
+					source: tool.source,
 					children: []
 				};
 				toolBuckets.set(ExtensionIdentifier.toKey(ext.identifier), bucket);
-			} else {
+			} else if (tool.source.type === 'internal') {
 				bucket = defaultBucket;
+			} else {
+				assertNever(tool.source);
 			}
 
 			const picked = nowSelectedTools.has(tool);
@@ -243,13 +256,19 @@ export class AttachToolsAction extends Action2 {
 				lastSelectedItems = new Set(items);
 				picker.selectedItems = items;
 
-				const toolPicks = items.filter(isToolPick);
-				const allTools = picks.filter(isToolPick);
-				if (toolPicks.length === allTools.length) {
-					widget.input.selectedToolsModel.reset();
-				} else {
-					widget.input.selectedToolsModel.update(items.filter(isToolPick).map(tool => tool.tool));
+				const disableBuckets: ToolDataSource[] = [];
+				const disableTools: IToolData[] = [];
+				for (const item of picks) {
+					if (item.type === 'item' && !item.picked) {
+						if (isBucketPick(item)) {
+							disableBuckets.push(item.source);
+						} else if (isToolPick(item) && item.parent.picked) {
+							disableTools.push(item.tool);
+						}
+					}
 				}
+
+				widget.input.selectedToolsModel.update(disableBuckets, disableTools);
 			} finally {
 				ignoreEvent = false;
 			}

--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -240,13 +240,18 @@ configurationRegistry.registerConfiguration({
 			tags: ['experimental'],
 		},
 		[mcpDiscoverySection]: {
-			type: 'object',
-			default: Object.fromEntries(allDiscoverySources.map(k => [k, true])),
-			properties: Object.fromEntries(allDiscoverySources.map(k => [
-				k,
-				{ type: 'boolean', description: nls.localize('mcp.discovery.source', "Enables discovery of {0} servers", discoverySourceLabel[k]) }
-			])),
-			markdownDescription: nls.localize('mpc.discovery.enabled', "Configures discovery of Model Context Protocol servers on the machine. It may be set to `true` or `false` to disable or enable all sources, and an array of sources you wish to enable."),
+			oneOf: [
+				{ type: 'boolean' },
+				{
+					type: 'object',
+					default: Object.fromEntries(allDiscoverySources.map(k => [k, true])),
+					properties: Object.fromEntries(allDiscoverySources.map(k => [
+						k,
+						{ type: 'boolean', description: nls.localize('mcp.discovery.source', "Enables discovery of {0} servers", discoverySourceLabel[k]) }
+					])),
+				}
+			],
+			markdownDescription: nls.localize('mpc.discovery.enabled', "Configures discovery of Model Context Protocol servers on the machine. It may be set to `true` or `false` to disable or enable all sources, and an mapping sources you wish to enable."),
 		},
 		[PromptsConfig.KEY]: {
 			type: 'boolean',

--- a/src/vs/workbench/contrib/chat/browser/languageModelToolsService.ts
+++ b/src/vs/workbench/contrib/chat/browser/languageModelToolsService.ts
@@ -281,7 +281,8 @@ export class LanguageModelToolsService extends Disposable implements ILanguageMo
 					result: 'success',
 					chatSessionId: dto.context?.sessionId,
 					toolId: tool.data.id,
-					toolExtensionId: tool.data.extensionId?.value,
+					toolExtensionId: tool.data.source.type === 'extension' ? tool.data.source.extensionId.value : undefined,
+					toolSourceKind: tool.data.source.type,
 				});
 			return toolResult;
 		} catch (err) {
@@ -292,7 +293,8 @@ export class LanguageModelToolsService extends Disposable implements ILanguageMo
 					result,
 					chatSessionId: dto.context?.sessionId,
 					toolId: tool.data.id,
-					toolExtensionId: tool.data.extensionId?.value,
+					toolExtensionId: tool.data.source.type === 'extension' ? tool.data.source.extensionId.value : undefined,
+					toolSourceKind: tool.data.source.type,
 				});
 			throw err;
 		} finally {
@@ -359,6 +361,7 @@ type LanguageModelToolInvokedEvent = {
 	chatSessionId: string | undefined;
 	toolId: string;
 	toolExtensionId: string | undefined;
+	toolSourceKind: string;
 };
 
 type LanguageModelToolInvokedClassification = {
@@ -366,6 +369,7 @@ type LanguageModelToolInvokedClassification = {
 	chatSessionId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The ID of the chat session that the tool was used within, if applicable.' };
 	toolId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The ID of the tool used.' };
 	toolExtensionId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The extension that contributed the tool.' };
+	toolSourceKind: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The source (mcp/extension/internal) of the tool.' };
 	owner: 'roblourens';
 	comment: 'Provides insight into the usage of language model tools.';
 };

--- a/src/vs/workbench/contrib/chat/common/languageModelToolsService.ts
+++ b/src/vs/workbench/contrib/chat/common/languageModelToolsService.ts
@@ -19,7 +19,7 @@ import { Schemas } from '../../../../base/common/network.js';
 
 export interface IToolData {
 	id: string;
-	extensionId?: ExtensionIdentifier;
+	source: ToolDataSource;
 	toolReferenceName?: string;
 	icon?: { dark: URI; light?: URI } | ThemeIcon;
 	when?: ContextKeyExpression;
@@ -34,6 +34,21 @@ export interface IToolData {
 	 * on the host, undefined if known.
 	 */
 	runsInWorkspace?: boolean;
+}
+
+export type ToolDataSource =
+	| { type: 'extension'; extensionId: ExtensionIdentifier }
+	| { type: 'mcp'; collectionId: string }
+	| { type: 'internal' };
+
+export namespace ToolDataSource {
+	export function toKey(source: ToolDataSource): string {
+		switch (source.type) {
+			case 'extension': return `extension:${source.extensionId.value}`;
+			case 'mcp': return `mcp:${source.collectionId}`;
+			case 'internal': return 'internal';
+		}
+	}
 }
 
 export interface IToolInvocation {

--- a/src/vs/workbench/contrib/chat/common/tools/editFileTool.ts
+++ b/src/vs/workbench/contrib/chat/common/tools/editFileTool.ts
@@ -50,6 +50,7 @@ export const EditToolData: IToolData = {
 	id: InternalEditToolId,
 	displayName: localize('chat.tools.editFile', "Edit File"),
 	modelDescription: `Edit a file in the workspace. Use this tool once per file that needs to be modified, even if there are multiple changes for a file. Generate the "explanation" property first. ${codeInstructions}`,
+	source: { type: 'internal' },
 	inputSchema: {
 		type: 'object',
 		properties: {

--- a/src/vs/workbench/contrib/chat/common/tools/insertNotebookCellsTool.ts
+++ b/src/vs/workbench/contrib/chat/common/tools/insertNotebookCellsTool.ts
@@ -33,6 +33,7 @@ export const EditToolData: IToolData = {
 	id: InternalEditToolId,
 	displayName: localize('chat.tools.editFile', "Edit File"),
 	modelDescription: `Insert cells into a new notebook n the workspace. Use this tool once per file that needs to be modified, even if there are multiple changes for a file. Generate the "explanation" property first. ${codeInstructions}`,
+	source: { type: 'internal' },
 	inputSchema: {
 		type: 'object',
 		properties: {

--- a/src/vs/workbench/contrib/chat/common/tools/languageModelToolsContribution.ts
+++ b/src/vs/workbench/contrib/chat/common/tools/languageModelToolsContribution.ts
@@ -197,7 +197,7 @@ export class LanguageModelToolsExtensionPointHandler implements IWorkbenchContri
 
 					const tool: IToolData = {
 						...rawTool,
-						extensionId: extension.description.identifier,
+						source: { type: 'extension', extensionId: extension.description.identifier },
 						inputSchema: rawTool.inputSchema,
 						id: rawTool.name,
 						icon,

--- a/src/vs/workbench/contrib/chat/electron-sandbox/tools/fetchPageTool.ts
+++ b/src/vs/workbench/contrib/chat/electron-sandbox/tools/fetchPageTool.ts
@@ -17,6 +17,7 @@ export const FetchWebPageToolData: IToolData = {
 	displayName: 'Fetch Web Page',
 	canBeReferencedInPrompt: false,
 	modelDescription: localize('fetchWebPage.modelDescription', 'Fetches the main content from a web page. This tool is useful for summarizing or analyzing the content of a webpage.'),
+	source: { type: 'internal' },
 	inputSchema: {
 		type: 'object',
 		properties: {

--- a/src/vs/workbench/contrib/chat/test/browser/languageModelToolsService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/languageModelToolsService.test.ts
@@ -39,7 +39,8 @@ suite('LanguageModelToolsService', () => {
 		const toolData: IToolData = {
 			id: 'testTool',
 			modelDescription: 'Test Tool',
-			displayName: 'Test Tool'
+			displayName: 'Test Tool',
+			source: { type: 'internal' },
 		};
 
 		const disposable = service.registerToolData(toolData);
@@ -52,7 +53,8 @@ suite('LanguageModelToolsService', () => {
 		const toolData: IToolData = {
 			id: 'testTool',
 			modelDescription: 'Test Tool',
-			displayName: 'Test Tool'
+			displayName: 'Test Tool',
+			source: { type: 'internal' },
 		};
 
 		store.add(service.registerToolData(toolData));
@@ -71,20 +73,23 @@ suite('LanguageModelToolsService', () => {
 			id: 'testTool1',
 			modelDescription: 'Test Tool 1',
 			when: ContextKeyEqualsExpr.create('testKey', false),
-			displayName: 'Test Tool'
+			displayName: 'Test Tool',
+			source: { type: 'internal' },
 		};
 
 		const toolData2: IToolData = {
 			id: 'testTool2',
 			modelDescription: 'Test Tool 2',
 			when: ContextKeyEqualsExpr.create('testKey', true),
-			displayName: 'Test Tool'
+			displayName: 'Test Tool',
+			source: { type: 'internal' },
 		};
 
 		const toolData3: IToolData = {
 			id: 'testTool3',
 			modelDescription: 'Test Tool 3',
-			displayName: 'Test Tool'
+			displayName: 'Test Tool',
+			source: { type: 'internal' },
 		};
 
 		store.add(service.registerToolData(toolData1));
@@ -101,7 +106,8 @@ suite('LanguageModelToolsService', () => {
 		const toolData: IToolData = {
 			id: 'testTool',
 			modelDescription: 'Test Tool',
-			displayName: 'Test Tool'
+			displayName: 'Test Tool',
+			source: { type: 'internal' },
 		};
 
 		store.add(service.registerToolData(toolData));
@@ -135,7 +141,8 @@ suite('LanguageModelToolsService', () => {
 		const toolData: IToolData = {
 			id: 'testTool',
 			modelDescription: 'Test Tool',
-			displayName: 'Test Tool'
+			displayName: 'Test Tool',
+			source: { type: 'internal' },
 		};
 
 		store.add(service.registerToolData(toolData));

--- a/src/vs/workbench/contrib/chat/test/common/chatRequestParser.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/chatRequestParser.test.ts
@@ -198,8 +198,8 @@ suite('ChatRequestParser', () => {
 		agentsService.getAgentsByName.returns([getAgentWithSlashCommands([{ name: 'subCommand', description: '' }])]);
 		instantiationService.stub(IChatAgentService, agentsService as any);
 
-		toolsService.getToolByName.onCall(0).returns({ id: 'get_selection', canBeReferencedInPrompt: true, displayName: '', modelDescription: '' } satisfies IToolData);
-		toolsService.getToolByName.onCall(1).returns({ id: 'get_debugConsole', canBeReferencedInPrompt: true, displayName: '', modelDescription: '' } satisfies IToolData);
+		toolsService.getToolByName.onCall(0).returns({ id: 'get_selection', canBeReferencedInPrompt: true, displayName: '', modelDescription: '', source: { type: 'internal' } } satisfies IToolData);
+		toolsService.getToolByName.onCall(1).returns({ id: 'get_debugConsole', canBeReferencedInPrompt: true, displayName: '', modelDescription: '', source: { type: 'internal' } } satisfies IToolData);
 
 		parser = instantiationService.createInstance(ChatRequestParser);
 		const result = parser.parseChatRequest('1', '@agent /subCommand \nPlease do with #selection\nand #debugConsole');
@@ -211,8 +211,8 @@ suite('ChatRequestParser', () => {
 		agentsService.getAgentsByName.returns([getAgentWithSlashCommands([{ name: 'subCommand', description: '' }])]);
 		instantiationService.stub(IChatAgentService, agentsService as any);
 
-		toolsService.getToolByName.onCall(0).returns({ id: 'get_selection', canBeReferencedInPrompt: true, displayName: '', modelDescription: '' } satisfies IToolData);
-		toolsService.getToolByName.onCall(1).returns({ id: 'get_debugConsole', canBeReferencedInPrompt: true, displayName: '', modelDescription: '' } satisfies IToolData);
+		toolsService.getToolByName.onCall(0).returns({ id: 'get_selection', canBeReferencedInPrompt: true, displayName: '', modelDescription: '', source: { type: 'internal' } } satisfies IToolData);
+		toolsService.getToolByName.onCall(1).returns({ id: 'get_debugConsole', canBeReferencedInPrompt: true, displayName: '', modelDescription: '', source: { type: 'internal' } } satisfies IToolData);
 
 		parser = instantiationService.createInstance(ChatRequestParser);
 		const result = parser.parseChatRequest('1', '@agent Please \ndo /subCommand with #selection\nand #debugConsole');

--- a/src/vs/workbench/contrib/mcp/common/mcpService.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpService.ts
@@ -43,7 +43,6 @@ export class McpService extends Disposable implements IMcpService {
 		@IInstantiationService private readonly _instantiationService: IInstantiationService,
 		@IMcpRegistry private readonly _mcpRegistry: IMcpRegistry,
 		@ILanguageModelToolsService private readonly _toolsService: ILanguageModelToolsService,
-		@IProductService productService: IProductService,
 		@ILogService private readonly _logService: ILogService,
 	) {
 		super();
@@ -98,6 +97,7 @@ export class McpService extends Disposable implements IMcpService {
 				const collection = this._mcpRegistry.collections.get().find(c => c.id === server.collection.id);
 				const toolData: IToolData = {
 					id: tool.id,
+					source: { type: 'mcp', collectionId: server.collection.id },
 					displayName: tool.definition.name,
 					toolReferenceName: tool.definition.name,
 					modelDescription: tool.definition.description ?? '',


### PR DESCRIPTION
Previously we just stored tool IDs that were selected. The downside is
any new tools would never get selected, including new built-in ones,
which could cause issues.

This changes the model to instead remember the tools or tool sources
that were unselected, such that new data sources or new tools added to
existing undisabled data sources would get selected.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
