### PR TITLE
Fix double-disposing edit session

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingSession.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingSession.ts
@@ -604,11 +604,6 @@ export class ChatEditingSession extends Disposable implements IChatEditingSessio
 				}
 			});
 		}));
-
-		if (this._state.get() !== ChatEditingSessionState.Disposed) {
-			// session got disposed while we were closing editors and clearing state
-			this.dispose();
-		}
 	}
 
 	override dispose() {

--- a/src/vs/workbench/contrib/chat/common/chatService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService.ts
@@ -491,7 +491,7 @@ export interface IChatService {
 
 	isEnabled(location: ChatAgentLocation): boolean;
 	hasSessions(): boolean;
-	startSession(location: ChatAgentLocation, token: CancellationToken): ChatModel;
+	startSession(location: ChatAgentLocation, token: CancellationToken, isGlobalEditingSession?: boolean): ChatModel;
 	getSession(sessionId: string): IChatModel | undefined;
 	getOrRestoreSession(sessionId: string): Promise<IChatModel | undefined>;
 	isPersistedSessionEmpty(sessionId: string): boolean;

--- a/src/vs/workbench/contrib/chat/test/browser/chatEditingService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/chatEditingService.test.ts
@@ -136,7 +136,10 @@ suite('ChatEditingService', function () {
 		const uri = URI.from({ scheme: 'test', path: 'HelloWorld' });
 
 		const model = chatService.startSession(ChatAgentLocation.EditingSession, CancellationToken.None);
-		const session = await editingService.createEditingSession(model, true);
+		const session = await model.editingSessionObs?.promise;
+		if (!session) {
+			assert.fail('session not created');
+		}
 
 		const chatRequest = model?.addRequest({ text: '', parts: [] }, { variables: [] }, 0);
 		assertType(chatRequest.response);
@@ -159,7 +162,6 @@ suite('ChatEditingService', function () {
 
 		await entry.reject(undefined);
 
-		session.dispose();
 		model.dispose();
 	});
 

--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChatController.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChatController.ts
@@ -1422,7 +1422,7 @@ export async function reviewEdits(accessor: ServicesAccessor, editor: ICodeEdito
 	const chatEditingService = accessor.get(IChatEditingService);
 
 	const uri = editor.getModel().uri;
-	const chatModel = chatService.startSession(ChatAgentLocation.Editor, token);
+	const chatModel = chatService.startSession(ChatAgentLocation.Editor, token, false);
 
 	const editSession = await chatEditingService.createEditingSession(chatModel);
 

--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChatSessionServiceImpl.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChatSessionServiceImpl.ts
@@ -5,11 +5,16 @@
 import { CancellationToken } from '../../../../base/common/cancellation.js';
 import { Emitter, Event } from '../../../../base/common/event.js';
 import { DisposableStore, IDisposable, MutableDisposable, toDisposable } from '../../../../base/common/lifecycle.js';
+import { ResourceMap } from '../../../../base/common/map.js';
 import { Schemas } from '../../../../base/common/network.js';
+import { autorun } from '../../../../base/common/observable.js';
+import { isEqual } from '../../../../base/common/resources.js';
+import { assertType } from '../../../../base/common/types.js';
 import { URI } from '../../../../base/common/uri.js';
 import { generateUuid } from '../../../../base/common/uuid.js';
 import { IActiveCodeEditor, ICodeEditor, isCodeEditor, isCompositeEditor, isDiffEditor } from '../../../../editor/browser/editorBrowser.js';
 import { Range } from '../../../../editor/common/core/range.js';
+import { ILanguageService } from '../../../../editor/common/languages/language.js';
 import { IValidEditOperation } from '../../../../editor/common/model.js';
 import { createTextBufferFactoryFromSnapshot } from '../../../../editor/common/model/textModel.js';
 import { IEditorWorkerService } from '../../../../editor/common/services/editorWorker.js';
@@ -20,22 +25,17 @@ import { IInstantiationService } from '../../../../platform/instantiation/common
 import { ILogService } from '../../../../platform/log/common/log.js';
 import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry.js';
 import { DEFAULT_EDITOR_ASSOCIATION } from '../../../common/editor.js';
-import { IChatAgentService } from '../../chat/common/chatAgents.js';
-import { IChatService } from '../../chat/common/chatService.js';
-import { CTX_INLINE_CHAT_HAS_AGENT, CTX_INLINE_CHAT_HAS_AGENT2, CTX_INLINE_CHAT_POSSIBLE } from '../common/inlineChat.js';
 import { IEditorService } from '../../../services/editor/common/editorService.js';
+import { ITextFileService } from '../../../services/textfile/common/textfiles.js';
 import { UntitledTextEditorInput } from '../../../services/untitled/common/untitledTextEditorInput.js';
+import { IChatWidgetService } from '../../chat/browser/chat.js';
+import { IChatAgentService } from '../../chat/common/chatAgents.js';
+import { WorkingSetEntryState } from '../../chat/common/chatEditingService.js';
+import { IChatService } from '../../chat/common/chatService.js';
+import { ChatAgentLocation } from '../../chat/common/constants.js';
+import { CTX_INLINE_CHAT_HAS_AGENT, CTX_INLINE_CHAT_HAS_AGENT2, CTX_INLINE_CHAT_POSSIBLE } from '../common/inlineChat.js';
 import { HunkData, Session, SessionWholeRange, StashedSession, TelemetryData, TelemetryDataClassification } from './inlineChatSession.js';
 import { IInlineChatSession2, IInlineChatSessionEndEvent, IInlineChatSessionEvent, IInlineChatSessionService, ISessionKeyComputer } from './inlineChatSessionService.js';
-import { isEqual } from '../../../../base/common/resources.js';
-import { ILanguageService } from '../../../../editor/common/languages/language.js';
-import { ITextFileService } from '../../../services/textfile/common/textfiles.js';
-import { IChatEditingService, WorkingSetEntryState } from '../../chat/common/chatEditingService.js';
-import { assertType } from '../../../../base/common/types.js';
-import { autorun } from '../../../../base/common/observable.js';
-import { ResourceMap } from '../../../../base/common/map.js';
-import { IChatWidgetService } from '../../chat/browser/chat.js';
-import { ChatAgentLocation } from '../../chat/common/constants.js';
 
 
 type SessionData = {
@@ -86,7 +86,6 @@ export class InlineChatSessionServiceImpl implements IInlineChatSessionService {
 		@ILanguageService private readonly _languageService: ILanguageService,
 		@IChatService private readonly _chatService: IChatService,
 		@IChatAgentService private readonly _chatAgentService: IChatAgentService,
-		@IChatEditingService private readonly _chatEditingService: IChatEditingService,
 		@IChatWidgetService private readonly _chatWidgetService: IChatWidgetService,
 	) { }
 
@@ -338,9 +337,9 @@ export class InlineChatSessionServiceImpl implements IInlineChatSessionService {
 
 		this._onWillStartSession.fire(editor as IActiveCodeEditor);
 
-		const chatModel = this._chatService.startSession(ChatAgentLocation.EditingSession, token);
+		const chatModel = this._chatService.startSession(ChatAgentLocation.EditingSession, token, false);
 
-		const editingSession = await this._chatEditingService.createEditingSession(chatModel);
+		const editingSession = await chatModel.editingSessionObs?.promise!;
 		const widget = this._chatWidgetService.getWidgetBySessionId(chatModel.sessionId);
 		widget?.attachmentModel.addFile(uri);
 
@@ -351,7 +350,6 @@ export class InlineChatSessionServiceImpl implements IInlineChatSessionService {
 			this._sessions2.delete(uri);
 			this._onDidChangeSessions.fire(this);
 		}));
-		store.add(editingSession);
 		store.add(chatModel);
 
 		store.add(autorun(r => {


### PR DESCRIPTION
And fix inline chat 2
This is complicated. The way that I expect it to work now
- The ChatModel creates the editing session for the right locations and based on the isGlobalEditingSession flag passed in
- stop doesn't dispose the editing session, so it doesn't get disposed twice, but it gets disposed when the ChatModel is disposed

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
