### PR TITLE
fixed disable extension dropdown with incorrect disable globally option

### DIFF
--- a/src/vs/workbench/contrib/extensions/browser/extensionsActions.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionsActions.ts
@@ -1718,7 +1718,7 @@ export class DisableGloballyAction extends ExtensionAction {
 		this.enabled = false;
 		if (this.extension && this.extension.local && !this.extension.isWorkspaceScoped && this.extensionService.extensions.some(e => areSameExtensions({ id: e.identifier.value, uuid: e.uuid }, this.extension!.identifier))) {
 			this.enabled = this.extension.state === ExtensionState.Installed
-				&& (this.extension.enablementState === EnablementState.EnabledGlobally || this.extension.enablementState === EnablementState.EnabledWorkspace)
+				&& (this.extension.enablementState === EnablementState.EnabledGlobally)
 				&& this.extensionEnablementService.canChangeEnablement(this.extension.local);
 		}
 	}

--- a/src/vs/workbench/contrib/extensions/browser/extensionsActions.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionsActions.ts
@@ -1718,7 +1718,7 @@ export class DisableGloballyAction extends ExtensionAction {
 		this.enabled = false;
 		if (this.extension && this.extension.local && !this.extension.isWorkspaceScoped && this.extensionService.extensions.some(e => areSameExtensions({ id: e.identifier.value, uuid: e.uuid }, this.extension!.identifier))) {
 			this.enabled = this.extension.state === ExtensionState.Installed
-				&& (this.extension.enablementState === EnablementState.EnabledGlobally)
+				&& this.extension.enablementState === EnablementState.EnabledGlobally
 				&& this.extensionEnablementService.canChangeEnablement(this.extension.local);
 		}
 	}


### PR DESCRIPTION
Fixes #244138

The change fixes a bug (it is a really small or (`||`) check that is kinda hard to spot) where there shouldn't be a dropdown with the option to disable the extension globally, it should just be a button with the text "Disable (Workspace)"

here are some visuals to better understand:

**Before fix:**

https://github.com/user-attachments/assets/8488fe18-36d7-46f7-aca2-5be946c1ab33

**After fix:**

https://github.com/user-attachments/assets/5aa9a576-a33f-464c-ab72-43cefa773626


thanks for reading! and please consider my pull request because I wanna be a part of this community :)
