### PR TITLE
Reorder menu and remove separator

### DIFF
--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/components/gutterIndicatorMenu.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/components/gutterIndicatorMenu.ts
@@ -119,13 +119,11 @@ export class GutterIndicatorMenuContent {
 			title,
 			gotoAndAccept,
 			reject,
-			separator(),
-
-			...extensionCommands,
-			extensionCommands.length ? separator() : undefined,
-
 			toggleCollapsedMode,
 			settings,
+
+			extensionCommands.length ? separator() : undefined,
+			...extensionCommands,
 
 			actionBarFooter ? separator() : undefined,
 			actionBarFooter


### PR DESCRIPTION
```Copilot Generated Description:``` Reorder the menu items and remove unnecessary separators for improved clarity.