### PR TITLE
Fix custom dialog button hover issue

### DIFF
--- a/src/vs/base/browser/ui/dialog/dialog.css
+++ b/src/vs/base/browser/ui/dialog/dialog.css
@@ -8,9 +8,9 @@
 	position: fixed;
 	height: 100%;
 	width: 100%;
-	left:0;
-	top:0;
-	z-index: 2600;
+	left: 0;
+	top: 0;
+	z-index: 2575; /* Above Context Views, Below Workbench Hover */
 	display: flex;
 	justify-content: center;
 	align-items: center;


### PR DESCRIPTION
```Copilot Generated Description:``` Adjust the z-index of the custom dialog to ensure button hovers appear above the dialog, resolving the issue of hovers being obscured.

Fixes microsoft/vscode#244125