### PR TITLE
Fix non-transparent background in inline edits

### DIFF
--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/inlineEditsWordReplacementView.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/inlineEditsWordReplacementView.ts
@@ -95,8 +95,7 @@ export class InlineEditsWordReplacementView extends Disposable implements IInlin
 		const originalLine = Rect.fromPoints(widgetStart, widgetEnd).withHeight(lineHeight).translateX(-scrollLeft);
 		const modifiedLine = Rect.fromPointSize(originalLine.getLeftBottom().add(modifiedOffset), new Point(this._edit.text.length * w, originalLine.height));
 
-		const background = Rect.hull([originalLine, modifiedLine]);
-		const lowerBackground = background.intersectVertical(new OffsetRange(originalLine.bottom, Number.MAX_SAFE_INTEGER));
+		const lowerBackground = modifiedLine.withLeft(originalLine.left);
 
 		// debugView(debugLogRects({ lowerBackground }, this._editor.editor.getContainerDomNode()), reader);
 
@@ -118,6 +117,7 @@ export class InlineEditsWordReplacementView extends Disposable implements IInlin
 			}
 
 			const contentLeft = this._editor.layoutInfoContentLeft.read(reader);
+			const borderWidth = 1;
 
 			const originalBorderColor = getOriginalBorderColor(this._tabAction).map(c => asCssVariable(c)).read(reader);
 			const modifiedBorderColor = getModifiedBorderColor(this._tabAction).map(c => asCssVariable(c)).read(reader);
@@ -137,7 +137,7 @@ export class InlineEditsWordReplacementView extends Disposable implements IInlin
 					n.div({
 						style: {
 							position: 'absolute',
-							...rectToProps(reader => layout.read(reader).lowerBackground.withMargin(0, 2, 0, 0)),
+							...rectToProps(reader => layout.read(reader).lowerBackground.withMargin(borderWidth, 2 * borderWidth, borderWidth, 0)),
 							background: asCssVariable(editorBackground),
 							//boxShadow: `${asCssVariable(scrollbarShadow)} 0 6px 6px -6px`,
 							cursor: 'pointer',
@@ -162,7 +162,7 @@ export class InlineEditsWordReplacementView extends Disposable implements IInlin
 							pointerEvents: 'none',
 							boxSizing: 'border-box',
 							borderRadius: '4px',
-							border: `1px solid ${modifiedBorderColor}`,
+							border: `${borderWidth}px solid ${modifiedBorderColor}`,
 
 							background: asCssVariable(modifiedChangedTextOverlayColor),
 							display: 'flex',
@@ -178,7 +178,7 @@ export class InlineEditsWordReplacementView extends Disposable implements IInlin
 							...rectToProps(reader => layout.read(reader).originalLine.withMargin(1)),
 							boxSizing: 'border-box',
 							borderRadius: '4px',
-							border: `1px solid ${originalBorderColor}`,
+							border: `${borderWidth}px solid ${originalBorderColor}`,
 							background: asCssVariable(originalChangedTextOverlayColor),
 							pointerEvents: 'none',
 						}


### PR DESCRIPTION
```Copilot Generated Description:``` Adjust the background rendering for inline edits to ensure transparency is maintained, resolving the issue of an opaque white background. Changes include modifications to background calculations and border styling for improved visual consistency.

Fixes microsoft/vscode-copilot#14725