### PR TITLE
fix parsing policies

### DIFF
--- a/build/lib/policies.js
+++ b/build/lib/policies.js
@@ -339,7 +339,16 @@ const NumberQ = {
 const StringQ = {
     Q: `[
 		(string (string_fragment) @value)
-		(call_expression function: (identifier) @localizeFn arguments: (arguments (string (string_fragment) @nlsKey) (string (string_fragment) @value)) (#eq? @localizeFn localize))
+		(call_expression
+			function: [
+				(identifier) @localizeFn (#eq? @localizeFn localize)
+				(member_expression
+					object: (identifier) @nlsObj (#eq? @nlsObj nls)
+					property: (property_identifier) @localizeFn (#eq? @localizeFn localize)
+				)
+			]
+			arguments: (arguments (string (string_fragment) @nlsKey) (string (string_fragment) @value))
+		)
 	]`,
     value(matches) {
         const match = matches[0];

--- a/build/lib/policies.ts
+++ b/build/lib/policies.ts
@@ -503,7 +503,16 @@ const NumberQ: QType<number> = {
 const StringQ: QType<string | NlsString> = {
 	Q: `[
 		(string (string_fragment) @value)
-		(call_expression function: (identifier) @localizeFn arguments: (arguments (string (string_fragment) @nlsKey) (string (string_fragment) @value)) (#eq? @localizeFn localize))
+		(call_expression
+			function: [
+				(identifier) @localizeFn (#eq? @localizeFn localize)
+				(member_expression
+					object: (identifier) @nlsObj (#eq? @nlsObj nls)
+					property: (property_identifier) @localizeFn (#eq? @localizeFn localize)
+				)
+			]
+			arguments: (arguments (string (string_fragment) @nlsKey) (string (string_fragment) @value))
+		)
 	]`,
 
 	value(matches: Parser.QueryMatch[]): string | NlsString | undefined {

--- a/src/vs/platform/configuration/common/configurationRegistry.ts
+++ b/src/vs/platform/configuration/common/configurationRegistry.ts
@@ -35,7 +35,7 @@ export interface IConfigurationRegistry {
 	/**
 	 * Register a configuration to the registry.
 	 */
-	registerConfiguration(configuration: IConfigurationNode): void;
+	registerConfiguration(configuration: IConfigurationNode): IConfigurationNode;
 
 	/**
 	 * Register multiple configurations to the registry.
@@ -313,8 +313,9 @@ class ConfigurationRegistry implements IConfigurationRegistry {
 		this.registerOverridePropertyPatternKey();
 	}
 
-	public registerConfiguration(configuration: IConfigurationNode, validate: boolean = true): void {
+	public registerConfiguration(configuration: IConfigurationNode, validate: boolean = true): IConfigurationNode {
 		this.registerConfigurations([configuration], validate);
+		return configuration;
 	}
 
 	public registerConfigurations(configurations: IConfigurationNode[], validate: boolean = true): void {

--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -289,6 +289,7 @@ configurationRegistry.registerConfiguration({
 			policy: {
 				name: 'ChatPromptFiles',
 				minimumVersion: '1.99',
+				description: nls.localize('chat.promptFiles.policy', "Enables reusable prompt files in Chat, Edits, and Inline Chat sessions."),
 				previewFeature: true,
 				defaultValue: false
 			}
@@ -413,7 +414,7 @@ class ChatAgentSettingContribution extends Disposable implements IWorkbenchContr
 			return;
 		}
 
-		this.registeredNode = {
+		this.registeredNode = configurationRegistry.registerConfiguration({
 			id: 'chatAgent',
 			title: nls.localize('interactiveSessionConfigurationTitle', "Chat"),
 			type: 'object',
@@ -431,8 +432,7 @@ class ChatAgentSettingContribution extends Disposable implements IWorkbenchContr
 					}
 				},
 			}
-		};
-		configurationRegistry.registerConfiguration(this.registeredNode);
+		});
 	}
 
 	private deregisterSetting() {


### PR DESCRIPTION
Fixes:

1. Modify the tree-sitter query to handle both direct localize() calls and calls via the nls namespace like nls.localize()

2. Fix the policy setting to include required description

3. Fix the policy setting to pass the configuration node directly instead of passing a varaible to which the configuration node is assigned. Policy parsing is not recognising this kind of usage.