### PR TITLE
chat: fix 'select tools' bucketing mcp servers incorrectly

### DIFF
--- a/src/vs/workbench/contrib/chat/common/languageModelToolsService.ts
+++ b/src/vs/workbench/contrib/chat/common/languageModelToolsService.ts
@@ -39,14 +39,14 @@ export interface IToolData {
 
 export type ToolDataSource =
 	| { type: 'extension'; extensionId: ExtensionIdentifier }
-	| { type: 'mcp'; collectionId: string }
+	| { type: 'mcp'; collectionId: string; definitionId: string }
 	| { type: 'internal' };
 
 export namespace ToolDataSource {
 	export function toKey(source: ToolDataSource): string {
 		switch (source.type) {
 			case 'extension': return `extension:${source.extensionId.value}`;
-			case 'mcp': return `mcp:${source.collectionId}`;
+			case 'mcp': return `mcp:${source.collectionId}:${source.definitionId}`;
 			case 'internal': return 'internal';
 		}
 	}

--- a/src/vs/workbench/contrib/mcp/common/mcpService.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpService.ts
@@ -97,7 +97,7 @@ export class McpService extends Disposable implements IMcpService {
 				const collection = this._mcpRegistry.collections.get().find(c => c.id === server.collection.id);
 				const toolData: IToolData = {
 					id: tool.id,
-					source: { type: 'mcp', collectionId: server.collection.id },
+					source: { type: 'mcp', collectionId: server.collection.id, definitionId: server.definition.id },
 					displayName: tool.definition.name,
 					toolReferenceName: tool.definition.name,
 					modelDescription: tool.definition.description ?? '',


### PR DESCRIPTION
toolBuckets in the pick was correctly fixed to use the server definition ID, but the selected tool model was still only using the collection ID

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
