### PR TITLE
fix bugs with merge editor a11y help

### DIFF
--- a/src/vs/workbench/contrib/mergeEditor/browser/mergeEditorAccessibilityHelp.ts
+++ b/src/vs/workbench/contrib/mergeEditor/browser/mergeEditorAccessibilityHelp.ts
@@ -7,28 +7,18 @@ import { ICodeEditorService } from '../../../../editor/browser/services/codeEdit
 import { localize } from '../../../../nls.js';
 import { AccessibleContentProvider, AccessibleViewProviderId, AccessibleViewType } from '../../../../platform/accessibility/browser/accessibleView.js';
 import { IAccessibleViewImplementation } from '../../../../platform/accessibility/browser/accessibleViewRegistry.js';
-import { ContextKeyEqualsExpr, IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
+import { ContextKeyEqualsExpr } from '../../../../platform/contextkey/common/contextkey.js';
 import { ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
-import { IKeybindingService } from '../../../../platform/keybinding/common/keybinding.js';
-import { IEditorService } from '../../../services/editor/common/editorService.js';
 import { AccessibilityVerbositySettingId } from '../../accessibility/browser/accessibilityConfiguration.js';
-import { getCommentCommandInfo } from '../../accessibility/browser/editorAccessibilityHelp.js';
-import { MergeEditor } from './view/mergeEditor.js';
+
 
 export class MergeEditorAccessibilityHelpProvider implements IAccessibleViewImplementation {
 	readonly name = 'mergeEditor';
 	readonly type = AccessibleViewType.Help;
-	readonly priority = 105;
+	readonly priority = 125;
 	readonly when = ContextKeyEqualsExpr.create('isMergeEditor', true);
 	getProvider(accessor: ServicesAccessor) {
-		const editorService = accessor.get(IEditorService);
 		const codeEditorService = accessor.get(ICodeEditorService);
-		const keybindingService = accessor.get(IKeybindingService);
-		const contextKeyService = accessor.get(IContextKeyService);
-
-		if (!(editorService.activeTextEditorControl instanceof MergeEditor)) {
-			return;
-		}
 
 		const codeEditor = codeEditorService.getActiveCodeEditor() || codeEditorService.getFocusedCodeEditor();
 		if (!codeEditor) {
@@ -37,13 +27,10 @@ export class MergeEditorAccessibilityHelpProvider implements IAccessibleViewImpl
 
 		const content = [
 			localize('msg1', "You are in a merge editor."),
-			localize('msg2', "Navigate between merge conflicts using the commands Go to Next Unhandled Conflict and Go to Previous Unhandled Conflict."),
-			localize('msg3', "Run the command Merge Editor: Accept Merge to accept the current conflict."),
+			localize('msg2', "Navigate between merge conflicts using the commands Go to Next Unhandled Conflict{0} and Go to Previous Unhandled Conflict{1}.", '<keybinding:merge.goToNextUnhandledConflict>', '<keybinding:merge.goToPreviousUnhandledConflict>'),
+			localize('msg3', "Run the command Merge Editor: Accept All Changes from the Left{0} and Merge Editor: Accept All Changes from the Right{1}", '<keybinding:merge.acceptAllInput1>', '<keybinding:merge.acceptAllInput2>'),
 		];
-		const commentCommandInfo = getCommentCommandInfo(keybindingService, contextKeyService, codeEditor);
-		if (commentCommandInfo) {
-			content.push(commentCommandInfo);
-		}
+
 		return new AccessibleContentProvider(
 			AccessibleViewProviderId.MergeEditor,
 			{ type: AccessibleViewType.Help },


### PR DESCRIPTION
Before it:
- didn't open when `alt+f1` was invoked in the merge editor
- included a non-existent command
- didn't provide keybindings for commands (follow suit with other help dialogs)
- didn't include various helpful commands
- included comment info, unrelated to this dialog

Now it:
- actually shows up when `alt+f1` is invoked in a merge editor
- provides the keybindings (all currently unassigned) to users, allowing them to configure them
- removes a non-existent command in favor of the actual ones
- removes unnecessary comment info from the dialog

fixes #244656
fixes #227844