### PR TITLE
codelens: fix vertical alignment with icons

### DIFF
--- a/src/vs/editor/contrib/codelens/browser/codelensWidget.css
+++ b/src/vs/editor/contrib/codelens/browser/codelensWidget.css
@@ -5,7 +5,8 @@
 
 .monaco-editor .codelens-decoration {
 	overflow: hidden;
-	display: inline-block;
+	display: inline-flex !important; /* !important to override inline display:block style */
+	align-items: center;
 	text-overflow: ellipsis;
 	white-space: nowrap;
 	color: var(--vscode-editorCodeLens-foreground);


### PR DESCRIPTION
Individual spans in the codelens were flexbox enabled, but the codelens
container was not, so multiple lenses at the same location could be
misaligned if some of them had icons and some did not.

![](https://memes.peet.io/img/25-03-257742c3-649a-4835-84cc-8c2ed8cb8a77.png)

Fixes #244601

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
