### PR TITLE
fix: extension uncaughtException listen Maximum call stack size exceeded

### DIFF
--- a/src/vs/workbench/api/node/extensionHostProcess.ts
+++ b/src/vs/workbench/api/node/extensionHostProcess.ts
@@ -102,7 +102,7 @@ function patchProcess(allowExit: boolean) {
 	process.env['ELECTRON_RUN_AS_NODE'] = '1';
 
 	process.on = <any>function (event: string, listener: (...args: any[]) => void) {
-		let newListener = listener
+		let newListener = listener;
 		if (event === 'uncaughtException') {
 			newListener = function () {
 				try {

--- a/src/vs/workbench/api/node/extensionHostProcess.ts
+++ b/src/vs/workbench/api/node/extensionHostProcess.ts
@@ -102,11 +102,11 @@ function patchProcess(allowExit: boolean) {
 	process.env['ELECTRON_RUN_AS_NODE'] = '1';
 
 	process.on = <any>function (event: string, listener: (...args: any[]) => void) {
-		let newListener = listener;
 		if (event === 'uncaughtException') {
-			newListener = function () {
+			const actualListener = listener;
+			listener = function (...args: any[]) {
 				try {
-					return listener.apply(undefined, (arguments as unknown as any[]));
+					return actualListener.apply(undefined, args);
 				} catch {
 					// DO NOT HANDLE NOR PRINT the error here because this can and will lead to
 					// more errors which will cause error handling to be reentrant and eventually
@@ -115,7 +115,7 @@ function patchProcess(allowExit: boolean) {
 				}
 			};
 		}
-		nativeOn(event, newListener);
+		nativeOn(event, listener);
 	};
 
 }

--- a/src/vs/workbench/api/node/extensionHostProcess.ts
+++ b/src/vs/workbench/api/node/extensionHostProcess.ts
@@ -102,8 +102,9 @@ function patchProcess(allowExit: boolean) {
 	process.env['ELECTRON_RUN_AS_NODE'] = '1';
 
 	process.on = <any>function (event: string, listener: (...args: any[]) => void) {
+		let newListener = listener
 		if (event === 'uncaughtException') {
-			listener = function () {
+			newListener = function () {
 				try {
 					return listener.call(undefined, arguments);
 				} catch {
@@ -114,7 +115,7 @@ function patchProcess(allowExit: boolean) {
 				}
 			};
 		}
-		nativeOn(event, listener);
+		nativeOn(event, newListener);
 	};
 
 }

--- a/src/vs/workbench/api/node/extensionHostProcess.ts
+++ b/src/vs/workbench/api/node/extensionHostProcess.ts
@@ -106,7 +106,7 @@ function patchProcess(allowExit: boolean) {
 		if (event === 'uncaughtException') {
 			newListener = function () {
 				try {
-					return listener.call(undefined, arguments);
+					return listener.apply(undefined, (arguments as unknown as any[]));
 				} catch {
 					// DO NOT HANDLE NOR PRINT the error here because this can and will lead to
 					// more errors which will cause error handling to be reentrant and eventually


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
The problem can be abstracted into the following code
```ts
  function test(fn: any) {
    fn = () => {
      return fn();
    };
    return fn();
  }
  test(() => {
    console.log('call');
  });
```

```
RangeError: Maximum call stack size exceeded
    at fn (c:\code\my-project\ts-test\error-test2.ts:5:7)
    at fn (c:\code\my-project\ts-test\error-test2.ts:5:14)
    at fn (c:\code\my-project\ts-test\error-test2.ts:5:14)
    at fn (c:\code\my-project\ts-test\error-test2.ts:5:14)
    at fn (c:\code\my-project\ts-test\error-test2.ts:5:14)
    at fn (c:\code\my-project\ts-test\error-test2.ts:5:14)
    at fn (c:\code\my-project\ts-test\error-test2.ts:5:14)
    at fn (c:\code\my-project\ts-test\error-test2.ts:5:14)
    at fn (c:\code\my-project\ts-test\error-test2.ts:5:14)
    at fn (c:\code\my-project\ts-test\error-test2.ts:5:14)
```

fix
```ts
global.process.on('uncaughtException',()=>{
// not work
})
```
Due to the reuse of variables, the extension listens for infinite recursive calls of events