### PR TITLE
Restore builtin tool custom confirmations

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/languageModelToolsService.ts
+++ b/src/vs/workbench/contrib/chat/browser/languageModelToolsService.ts
@@ -327,22 +327,24 @@ export class LanguageModelToolsService extends Disposable implements ILanguageMo
 			};
 		}
 
-		if (prepared?.toolSpecificData?.kind !== 'terminal' && prepared?.confirmationMessages) {
-			prepared.confirmationMessages!.allowAutoConfirm = true;
-		}
+		if (prepared?.confirmationMessages) {
+			if (prepared.toolSpecificData?.kind !== 'terminal' && typeof prepared.confirmationMessages.allowAutoConfirm !== 'boolean') {
+				prepared.confirmationMessages.allowAutoConfirm = true;
+			}
 
-		if (prepared?.confirmationMessages && !prepared.toolSpecificData) {
-			prepared.toolSpecificData = {
-				kind: 'input',
-				rawInput: dto.parameters,
-			};
+			if (!prepared.toolSpecificData && tool.data.alwaysDisplayInputOutput) {
+				prepared.toolSpecificData = {
+					kind: 'input',
+					rawInput: dto.parameters,
+				};
+			}
 		}
 
 		return prepared;
 	}
 
 	private ensureToolDetails(dto: IToolInvocation, toolResult: IToolResult, toolData: IToolData): void {
-		if (!toolResult.toolResultDetails && toolData.alwaysDisplayOutput) {
+		if (!toolResult.toolResultDetails && toolData.alwaysDisplayInputOutput) {
 			toolResult.toolResultDetails = {
 				input: JSON.stringify(dto.parameters, undefined, 2),
 				output: this.toolResultToString(toolResult),

--- a/src/vs/workbench/contrib/chat/common/languageModelToolsService.ts
+++ b/src/vs/workbench/contrib/chat/common/languageModelToolsService.ts
@@ -36,7 +36,7 @@ export interface IToolData {
 	 */
 	runsInWorkspace?: boolean;
 	requiresConfirmation?: boolean;
-	alwaysDisplayOutput?: boolean;
+	alwaysDisplayInputOutput?: boolean;
 	supportsToolPicker?: boolean;
 }
 

--- a/src/vs/workbench/contrib/chat/common/tools/languageModelToolsContribution.ts
+++ b/src/vs/workbench/contrib/chat/common/tools/languageModelToolsContribution.ts
@@ -204,7 +204,7 @@ export class LanguageModelToolsExtensionPointHandler implements IWorkbenchContri
 						icon,
 						when: rawTool.when ? ContextKeyExpr.deserialize(rawTool.when) : undefined,
 						requiresConfirmation: !isBuiltinTool,
-						alwaysDisplayOutput: !isBuiltinTool,
+						alwaysDisplayInputOutput: !isBuiltinTool,
 						supportsToolPicker: isBuiltinTool ?
 							false :
 							rawTool.canBeReferencedInPrompt

--- a/src/vs/workbench/contrib/chat/electron-sandbox/tools/fetchPageTool.ts
+++ b/src/vs/workbench/contrib/chat/electron-sandbox/tools/fetchPageTool.ts
@@ -157,7 +157,7 @@ export class FetchWebPageTool implements IToolImpl {
 				)
 			);
 
-			result.confirmationMessages = { title: confirmationTitle, message: confirmationMessage };
+			result.confirmationMessages = { title: confirmationTitle, message: confirmationMessage, allowAutoConfirm: false };
 		}
 
 		return result;


### PR DESCRIPTION
And disable 'auto allow'. This is mainly about bringing back the fetch tool's nicer confirmation and custom logic.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
