### PR TITLE
Don't enable shell integration API when only cwd is reported

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadTerminalShellIntegration.ts
+++ b/src/vs/workbench/api/browser/mainThreadTerminalShellIntegration.ts
@@ -8,7 +8,7 @@ import { Disposable, toDisposable, type IDisposable } from '../../../base/common
 import { URI } from '../../../base/common/uri.js';
 import { TerminalCapability, type ITerminalCommand } from '../../../platform/terminal/common/capabilities/capabilities.js';
 import { ExtHostContext, MainContext, type ExtHostTerminalShellIntegrationShape, type MainThreadTerminalShellIntegrationShape } from '../common/extHost.protocol.js';
-import { ITerminalService } from '../../contrib/terminal/browser/terminal.js';
+import { ITerminalService, type ITerminalInstance } from '../../contrib/terminal/browser/terminal.js';
 import { IWorkbenchEnvironmentService } from '../../services/environment/common/environmentService.js';
 import { extHostNamedCustomer, type IExtHostContext } from '../../services/extensions/common/extHostCustomers.js';
 import { TerminalShellExecutionCommandLineConfidence } from '../common/extHostTypes.js';
@@ -37,24 +37,18 @@ export class MainThreadTerminalShellIntegration extends Disposable implements Ma
 		for (const terminal of this._terminalService.instances) {
 			const cmdDetection = terminal.capabilities.get(TerminalCapability.CommandDetection);
 			if (cmdDetection) {
-				this._proxy.$shellIntegrationChange(terminal.instanceId);
-			}
-			const cwdDetection = terminal.capabilities.get(TerminalCapability.CwdDetection);
-			if (cwdDetection) {
-				this._proxy.$cwdChange(terminal.instanceId, this._convertCwdToUri(cwdDetection.getCwd()));
+				this._enableShellIntegration(terminal);
 			}
 		}
 
 		// onDidChangeTerminalShellIntegration via command detection
 		const onDidAddCommandDetection = this._store.add(this._terminalService.createOnInstanceEvent(instance => {
 			return Event.map(
-				Event.filter(instance.capabilities.onDidAddCapabilityType, e => {
-					return (e === TerminalCapability.CwdDetection || e === TerminalCapability.CommandDetection);
-				}),
+				Event.filter(instance.capabilities.onDidAddCapabilityType, e => e === TerminalCapability.CommandDetection),
 				() => instance
 			);
 		})).event;
-		this._store.add(onDidAddCommandDetection(e => this._proxy.$shellIntegrationChange(e.instanceId)));
+		this._store.add(onDidAddCommandDetection(e => this._enableShellIntegration(e)));
 
 		// onDidChangeTerminalShellIntegration via cwd
 		const cwdChangeEvent = this._store.add(this._terminalService.createOnInstanceCapabilityEvent(TerminalCapability.CwdDetection, e => e.onDidChangeCwd));
@@ -119,6 +113,14 @@ export class MainThreadTerminalShellIntegration extends Disposable implements Ma
 
 	private _convertCwdToUri(cwd: string | undefined): URI | undefined {
 		return cwd ? URI.file(cwd) : undefined;
+	}
+
+	private _enableShellIntegration(instance: ITerminalInstance): void {
+		this._proxy.$shellIntegrationChange(instance.instanceId);
+		const cwdDetection = instance.capabilities.get(TerminalCapability.CwdDetection);
+		if (cwdDetection) {
+			this._proxy.$cwdChange(instance.instanceId, this._convertCwdToUri(cwdDetection.getCwd()));
+		}
 	}
 }
 


### PR DESCRIPTION
This was causing the run in terminal tool to hang since executeCommand is not actually functional in this case. This also reports cwd always after enabling and reduces duplication.

Fixes microsoft/vscode-copilot#14545

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
