### PR TITLE
This PR adds support for when clauses in custom editor contributions, allowing developers to specify contextual conditions for when their custom editors should be available. #244703

### DIFF
--- a/src/vs/workbench/contrib/customEditor/browser/customEditors.ts
+++ b/src/vs/workbench/contrib/customEditor/browser/customEditors.ts
@@ -134,7 +134,8 @@ export class CustomEditorService extends Disposable implements ICustomEditorServ
 						priority: contributedEditor.priority,
 					},
 					{
-						singlePerResource: () => !(this.getCustomEditorCapabilities(contributedEditor.id)?.supportsMultipleEditorsPerDocument ?? false)
+						singlePerResource: () => !(this.getCustomEditorCapabilities(contributedEditor.id)?.supportsMultipleEditorsPerDocument ?? false),
+						when: contributedEditor.whenClause
 					},
 					{
 						createEditorInput: ({ resource }, group) => {

--- a/src/vs/workbench/contrib/customEditor/common/contributedCustomEditors.ts
+++ b/src/vs/workbench/contrib/customEditor/common/contributedCustomEditors.ts
@@ -52,6 +52,7 @@ export class ContributedCustomEditors extends Disposable {
 					providerDisplayName: extension.description.isBuiltin ? nls.localize('builtinProviderDisplayName', "Built-in") : extension.description.displayName || extension.description.identifier.value,
 					selector: webviewEditorContribution.selector || [],
 					priority: getPriorityFromContribution(webviewEditorContribution, extension.description),
+					whenClause: webviewEditorContribution.when,
 				}));
 			}
 		}

--- a/src/vs/workbench/contrib/customEditor/common/customEditor.ts
+++ b/src/vs/workbench/contrib/customEditor/common/customEditor.ts
@@ -90,6 +90,7 @@ export interface CustomEditorDescriptor {
 	readonly providerDisplayName: string;
 	readonly priority: RegisteredEditorPriority;
 	readonly selector: readonly CustomEditorSelector[];
+	readonly whenClause?: string;
 }
 
 export class CustomEditorInfo implements CustomEditorDescriptor {
@@ -99,6 +100,7 @@ export class CustomEditorInfo implements CustomEditorDescriptor {
 	public readonly providerDisplayName: string;
 	public readonly priority: RegisteredEditorPriority;
 	public readonly selector: readonly CustomEditorSelector[];
+	public readonly whenClause?: string;
 
 	constructor(descriptor: CustomEditorDescriptor) {
 		this.id = descriptor.id;
@@ -106,6 +108,7 @@ export class CustomEditorInfo implements CustomEditorDescriptor {
 		this.providerDisplayName = descriptor.providerDisplayName;
 		this.priority = descriptor.priority;
 		this.selector = descriptor.selector;
+		this.whenClause = descriptor.whenClause;
 	}
 
 	matches(resource: URI): boolean {

--- a/src/vs/workbench/contrib/customEditor/common/extensionPoint.ts
+++ b/src/vs/workbench/contrib/customEditor/common/extensionPoint.ts
@@ -20,6 +20,7 @@ const Fields = Object.freeze({
 	displayName: 'displayName',
 	selector: 'selector',
 	priority: 'priority',
+	when: 'when'
 });
 
 export interface ICustomEditorsExtensionPoint {
@@ -27,6 +28,7 @@ export interface ICustomEditorsExtensionPoint {
 	readonly [Fields.displayName]: string;
 	readonly [Fields.selector]?: readonly CustomEditorSelector[];
 	readonly [Fields.priority]?: string;
+	readonly [Fields.when]?: string;
 }
 
 const CustomEditorsContribution: IJSONSchema = {
@@ -87,6 +89,10 @@ const CustomEditorsContribution: IJSONSchema = {
 					nls.localize('contributes.priority.option', 'The editor is not automatically used when the user opens a resource, but a user can switch to the editor using the `Reopen With` command.'),
 				],
 				default: 'default'
+			},
+			[Fields.when]: {
+				type: 'string',
+				description: nls.localize('contributes.customEditors.when', "Condition which must be true to show this custom editor.")
 			}
 		}
 	}

--- a/src/vs/workbench/services/editor/common/editorResolverService.ts
+++ b/src/vs/workbench/services/editor/common/editorResolverService.ts
@@ -91,6 +91,12 @@ export type RegisteredEditorOptions = {
 	 * If omitted we assume you can open everything
 	 */
 	canSupportResource?: (resource: URI) => boolean;
+
+	/**
+	* Context when this editor should be available
+	* Uses the same format as other 'when' clauses in VS Code
+	*/
+	when?: string;
 };
 
 export type RegisteredEditorInfo = {


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/244703

This PR adds support for when clauses in custom editor contributions, allowing developers to specify contextual conditions for when their custom editors should be available.

### Changes:
- Added 'when' property to the custom editors extension point schema
- Updated CustomEditorInfo to include when clause
- Added when clause handling in EditorResolverService to filter editors based on context conditions

### Example Usage:
```json
"customEditors": [
  {
    "viewType": "myExtension.customEditor",
    "displayName": "My Custom Editor",
    "selector": [
      {
        "filenamePattern": "*.custom"
      }
    ],
    "when": "sideBarFocus && activeViewlet !== 'workbench.view.search'",
    "priority": "default"
  }
]