### PR TITLE
Fix strange NES rendering issue

### DIFF
--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/inlineEditsLineReplacementView.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/inlineEditsLineReplacementView.ts
@@ -253,6 +253,9 @@ export class InlineEditsLineReplacementView extends Disposable implements IInlin
 							fontSize: this._editor.getOption(EditorOption.fontSize),
 							fontWeight: this._editor.getOption(EditorOption.fontWeight),
 							pointerEvents: 'none',
+							whiteSpace: 'nowrap',
+							borderRadius: '4px',
+							overflow: 'hidden',
 						}
 					}, [...modifiedLineElements.lines]),
 				])


### PR DESCRIPTION
```Copilot Generated Description:``` Add CSS properties to the inline edits line replacement view to improve rendering, including `whiteSpace`, `borderRadius`, and `overflow`.

Fixes microsoft/vscode-copilot#15036