### PR TITLE
Fix flickering focus color on editor tab click

### DIFF
--- a/src/vs/workbench/browser/parts/editor/media/multieditortabscontrol.css
+++ b/src/vs/workbench/browser/parts/editor/media/multieditortabscontrol.css
@@ -104,6 +104,7 @@
 	height: var(--editor-group-tab-height);
 	box-sizing: border-box;
 	padding-left: 10px;
+	outline-offset: -2px;
 }
 
 /* Tab Background Color in/active group/tab */
@@ -298,10 +299,6 @@
 	bottom: 0;
 	height: 1px;
 	background-color: var(--tab-border-bottom-color);
-}
-
-.monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.active.tab-border-bottom:focus > .tab-border-bottom-container {
-	background-color: var(--vscode-focusBorder);
 }
 
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.dirty-border-top:not(:focus) > .tab-border-top-container {


### PR DESCRIPTION
```Copilot Generated Description:``` Adjust the CSS to prevent the editor tab's bottom border from briefly using the focus color on mouse click by modifying the outline offset and removing the focus background color for active tabs.

Fixes microsoft/vscode#242691