### PR TITLE
Fix Inline edit gutter indicator overflowing line numbers that are 3 …

### DIFF
--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/components/gutterIndicatorView.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/components/gutterIndicatorView.ts
@@ -487,6 +487,7 @@ export class InlineEditsGutterIndicator extends Disposable {
 				justifyContent: 'center',
 				transition: 'background-color 0.2s ease-in-out, width 0.2s ease-in-out',
 				...rectToProps(reader => layout.read(reader).pillRect),
+				width: 'auto',
 			}
 		}, [
 			n.div({


### PR DESCRIPTION
…or more digits long.

Fixes: https://github.com/microsoft/vscode/issues/244777

Before: 
![image](https://github.com/user-attachments/assets/c82db486-dddc-4060-8c8e-7f83ad18e4fa)

After:  
![image](https://github.com/user-attachments/assets/09f1713b-b5c6-457a-9acf-3701f66c004d)


<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
