### PR TITLE
add a 'json.validate' command

### DIFF
--- a/extensions/json-language-features/package.json
+++ b/extensions/json-language-features/package.json
@@ -16,7 +16,8 @@
   "activationEvents": [
     "onLanguage:json",
     "onLanguage:jsonc",
-    "onLanguage:snippets"
+    "onLanguage:snippets",
+    "onCommand:json.validate"
   ],
   "main": "./client/out/node/jsonClientMain",
   "browser": "./client/dist/browser/jsonClientMain",

--- a/extensions/json-language-features/server/src/jsonServer.ts
+++ b/extensions/json-language-features/server/src/jsonServer.ts
@@ -40,6 +40,10 @@ namespace LanguageStatusRequest {
 	export const type: RequestType<string, JSONLanguageStatus, any> = new RequestType('json/languageStatus');
 }
 
+namespace ValidateContentRequest {
+	export const type: RequestType<{ schemaUri: string; content: string }, Diagnostic[], any> = new RequestType('json/validateContent');
+}
+
 export interface DocumentSortingParams {
 	/**
 	 * The uri of the document to sort.
@@ -299,6 +303,14 @@ export function startServer(connection: Connection, runtime: RuntimeEnvironment)
 		return [];
 	});
 
+	connection.onRequest(ValidateContentRequest.type, async ({ schemaUri, content }) => {
+		const docURI = 'vscode://schemas/temp/' + new Date().getTime();
+		const document = TextDocument.create(docURI, 'json', 1, content);
+		updateConfiguration([{ uri: schemaUri, fileMatch: [docURI] }]);
+		return await validateTextDocument(document);
+	});
+
+
 	connection.onRequest(LanguageStatusRequest.type, async uri => {
 		const document = documents.get(uri);
 		if (document) {
@@ -319,7 +331,7 @@ export function startServer(connection: Connection, runtime: RuntimeEnvironment)
 		return [];
 	});
 
-	function updateConfiguration() {
+	function updateConfiguration(extraSchemas?: SchemaConfiguration[]) {
 		const languageSettings = {
 			validate: validateEnabled,
 			allowComments: true,
@@ -350,6 +362,10 @@ export function startServer(connection: Connection, runtime: RuntimeEnvironment)
 				}
 			});
 		}
+		if (extraSchemas) {
+			languageSettings.schemas.push(...extraSchemas);
+		}
+
 		languageService.configure(languageSettings);
 
 		diagnosticsSupport?.requestRefresh();
@@ -529,3 +545,7 @@ export function startServer(connection: Connection, runtime: RuntimeEnvironment)
 function getFullRange(document: TextDocument): Range {
 	return Range.create(Position.create(0, 0), document.positionAt(document.getText().length));
 }
+
+
+
+


### PR DESCRIPTION
Allow to validate JSON from core until we have a better solution

When run from core:
```
		const schemaUri = URI.parse('https://json-schema.org/draft-07/schema');
		const content = JSON.stringify({ type: 'foo' });
		commandService.executeCommand('json.validate', schemaUri, content).then(result => {
			console.log('Validation result', result);
		});
```

Result:
```
[
    {
        "severity": "Warning",
        "message": "Value is not accepted. Valid values: \"array\", \"boolean\", \"integer\", \"null\", \"number\", \"object\", \"string\".",
        "range": [
            {
                "line": 0,
                "character": 8
            },
            {
                "line": 0,
                "character": 13
            }
        ],
        "code": 1
    }
]
```