### PR TITLE
Add floating window support for MacOS

### DIFF
--- a/src/vs/platform/window/common/window.ts
+++ b/src/vs/platform/window/common/window.ts
@@ -164,10 +164,18 @@ export interface IWindowSettings {
 	readonly clickThroughInactive: boolean;
 	readonly newWindowProfile: string;
 	readonly density: IDensitySettings;
+	readonly workspacesOverlay: IWorkspacesOverlay;
 }
 
 export interface IDensitySettings {
 	readonly editorTabHeight: 'default' | 'compact';
+}
+
+export interface IWorkspacesOverlay {
+	readonly enabled: boolean;
+	readonly hotKey: string;
+	readonly alwaysOnTop: boolean;
+	readonly snapMode: 'bottom' | 'top' | 'left' | 'right';
 }
 
 export const enum TitleBarSetting {

--- a/src/vs/platform/windows/electron-main/windowImpl.ts
+++ b/src/vs/platform/windows/electron-main/windowImpl.ts
@@ -238,7 +238,7 @@ export abstract class BaseWindow extends Disposable implements IBaseWindow {
 			});
 		};
 
-		// Snap the window to top, bottom, left or right
+		// Snap the window to either top, bottom, left or right
 		const snapWindow = (win: BrowserWindow) => {
 			const [winWidth, winHeight] = win.getSize();
 			const currentDisplay = screen.getDisplayMatching(win.getBounds());

--- a/src/vs/workbench/electron-sandbox/desktop.contribution.ts
+++ b/src/vs/workbench/electron-sandbox/desktop.contribution.ts
@@ -279,6 +279,35 @@ import { registerWorkbenchContribution2, WorkbenchPhase } from '../common/contri
 				'scope': ConfigurationScope.APPLICATION,
 				'included': isMacintosh
 			},
+			'window.workspacesOverlay': {
+				'type': 'object',
+				'description': localize('window.workspacesOverlay', "macOS-specific feature to keep the main window on top of all workspaces."),
+				'scope': ConfigurationScope.APPLICATION,
+				'included': isMacintosh,
+				'properties': {
+					'enabled': {
+						'type': 'boolean',
+						'default': false,
+						'description': localize('window.workspacesOverlay.enabled', "Enables a macOS-specific feature that keeps the main window on top of all workspaces, visible across fullscreen apps, dynamically sized to the primary display, and toggleable via a keyboard shortcut when set to true."),
+					},
+					'hotKey': {
+						'type': 'string',
+						'default': 'CommandOrControl+Enter',
+						'description': localize('window.workspacesOverlay.hotKey', "Specifies the keyboard shortcut used to toggle the workspaces overlay on and off, following the Electron accelerator format (see https://www.electronjs.org/docs/latest/api/accelerator). Only applicable when the overlay is enabled."),
+					},
+					'alwaysOnTop': {
+						'type': 'boolean',
+						'default': true,
+						'description': localize('window.workspacesOverlay.alwaysOnTop', "When true, ensures the overlay remains above all other windows and fullscreen applications on macOS, enhancing accessibility across workspaces."),
+					},
+					'snapMode': {
+						'type': 'string',
+						'enum': ['bottom', 'top', 'left', 'right'],
+						'default': 'bottom',
+						'description': localize('window.workspacesOverlay.snapMode', "Defines the edge of the screen where the overlay docks when active. Options include 'bottom', 'top', 'left', or 'right', adapting to user preference and display layout."),
+					},
+				}
+			},
 			'window.clickThroughInactive': {
 				'type': 'boolean',
 				'default': true,


### PR DESCRIPTION
### Key Features

- **Floating Window:** Using Electron's `setVisibleOnAllWorkspaces` method.
- **Hot Key:** To show or hide the VSCode window globally.
- **Always On Top:** Option to keep the window above all other windows and apps.
- **Snap to Edge:** The window snaps to the specified edge of the current display (`bottom`, `top`, `left`, or `right`).
