### PR TITLE
Keep barrier around when it's open

### DIFF
--- a/src/vs/workbench/api/common/extHostTerminalShellIntegration.ts
+++ b/src/vs/workbench/api/common/extHostTerminalShellIntegration.ts
@@ -444,7 +444,6 @@ class ShellExecutionDataStream extends Disposable {
 
 	endExecution(): void {
 		this._barrier?.open();
-		this._barrier = undefined;
 	}
 
 	async flush(): Promise<void> {


### PR DESCRIPTION
Possible root cause of microsoft/vscode-copilot#15107, if createIterable is called after endExecution (but before flush finishes), it could never be resolved.
