### PR TITLE
Very precise side by side width approximation

### DIFF
--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsView.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsView.ts
@@ -352,7 +352,7 @@ export class InlineEditsView extends Disposable {
 			}
 		}
 		if (numOriginalLines > 0 && numModifiedLines > 0) {
-			if (this._renderSideBySide.read(reader) !== 'never' && InlineEditsSideBySideView.fitsInsideViewport(this._editor, inlineEdit, originalDisplayRange, reader)) {
+			if (this._renderSideBySide.read(reader) !== 'never' && InlineEditsSideBySideView.fitsInsideViewport(this._editor, this._previewTextModel, inlineEdit, originalDisplayRange, reader)) {
 				return 'sideBySide';
 			}
 


### PR DESCRIPTION
```Copilot Generated Description:``` Enhance the side-by-side view by improving the width approximation calculations for inline edits, ensuring better fitting within the editor's viewport. Introduce a new utility function to calculate content render width accurately.