### PR TITLE
Ensure shell launch config is fully resolved

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminalTelemetry.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalTelemetry.ts
@@ -19,7 +19,11 @@ export class TerminalTelemetryContribution extends Disposable implements IWorkbe
 	) {
 		super();
 
-		this._register(terminalService.onDidCreateInstance(e => this._logCreateInstance(e.shellLaunchConfig)));
+		this._register(terminalService.onDidCreateInstance(async instance => {
+			// Wait for process ready so the shell launch config is fully resolved
+			await instance.processReady;
+			this._logCreateInstance(instance.shellLaunchConfig);
+		}));
 	}
 
 	private _logCreateInstance(shellLaunchConfig: IShellLaunchConfig): void {


### PR DESCRIPTION
The executable may not be available on onDidCreateInstance

Following up #244727

JS Debug Terminal reported shell wrong before, correct after this change.

cc @meganrogge 