### PR TITLE
Fixes microsoft/vscode#240654: Avoid encoding reserved chars in JSON schema URL

### DIFF
--- a/extensions/json-language-features/client/src/jsonClient.ts
+++ b/extensions/json-language-features/client/src/jsonClient.ts
@@ -363,7 +363,7 @@ async function startClientWithParticipants(_context: ExtensionContext, languageP
 	// handle content request
 	client.onRequest(VSCodeContentRequest.type, async (uriPath: string) => {
 		const uri = Uri.parse(uriPath);
-		const uriString = uri.toString();
+		const uriString = uri.toString(true);
 		if (uri.scheme === 'untitled') {
 			throw new ResponseError(3, l10n.t('Unable to load {0}', uriString));
 		}


### PR DESCRIPTION
Fixes microsoft/vscode#240654

**Title:** Prevent percent‑encoding of query parameters when building JSON schema URI

**Description:**  
This change uses `skipEncoding` in `uri.toString(true)` to avoid percent‑encoding characters such as `:`, `&`, and `=` when constructing the schema URL. By preserving these characters, the generated URI remains valid and the JSON schema can be successfully retrieved.

**Verification:**  
I deployed a test endpoint at https://vscode-json-bug.vercel.app/ and confirmed that the schema file is reachable only after applying this change.

**Reproduction steps:**  
1. Add the following to your `settings.json`:
   ```jsonc
   "json.schemas": [
     {
       "fileMatch": ["associations.config*.json"],
       "url": "https://vscode-json-bug.vercel.app/api/my-file?cmd=readdoc1&downloadid=(9CF9004A-DC3C-746A-97F5-7960CF3BDE0D)&fname=associations.config.schema.json"
     }
   ]
   ```  
2. Create `associations.config.json` with `{}` as its content.  
3. Open the **Problems** panel — there should be **no errors** loading the schema URL.

**Before this change:**  
Loading failed with:  
> Unable to load schema from ‘…’: Not Found. The requested location could not be found.

**After this change:**  
The schema URL is valid and loads successfully.