### PR TITLE
Git - integration tests should use workspace path and not the real path to avoid random failures

### DIFF
--- a/extensions/git/src/test/smoke.test.ts
+++ b/extensions/git/src/test/smoke.test.ts
@@ -13,7 +13,7 @@ import { GitExtension, API, Repository, Status } from '../api/git';
 import { eventToPromise } from '../util';
 
 suite('git smoke test', function () {
-	const cwd = fs.realpathSync(workspace.workspaceFolders![0].uri.fsPath);
+	const cwd = workspace.workspaceFolders![0].uri.fsPath;
 
 	function file(relativePath: string) {
 		return path.join(cwd, relativePath);
@@ -61,7 +61,7 @@ suite('git smoke test', function () {
 		}
 
 		assert.strictEqual(git.repositories.length, 1);
-		assert.strictEqual(fs.realpathSync(git.repositories[0].rootUri.fsPath), cwd);
+		assert.strictEqual(git.repositories[0].rootUri.fsPath, cwd);
 
 		repository = git.repositories[0];
 	});


### PR DESCRIPTION
Related https://github.com/microsoft/vscode/issues/244439