### PR TITLE
Remove Inline Edit accept partial flow

### DIFF
--- a/src/vs/editor/contrib/inlineCompletions/browser/controller/commands.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/controller/commands.ts
@@ -261,25 +261,6 @@ export class JumpToNextInlineEdit extends EditorAction {
 	}
 }
 
-export class AcceptNextInlineEditPart extends EditorAction {
-	constructor() {
-		super({
-			id: 'editor.action.inlineSuggest.acceptNextInlineEditPart',
-			label: nls.localize2('action.inlineSuggest.acceptNextInlineEditPart', "Accept Next Inline Edit Part"),
-			precondition: ContextKeyExpr.and(EditorContextKeys.writable, InlineCompletionContextKeys.inlineEditVisible),
-			kbOpts: {
-				weight: KeybindingWeight.EditorContrib + 1,
-				kbExpr: ContextKeyExpr.and(EditorContextKeys.writable, InlineCompletionContextKeys.inlineEditVisible),
-			},
-		});
-	}
-
-	public async run(accessor: ServicesAccessor | undefined, editor: ICodeEditor): Promise<void> {
-		const controller = InlineCompletionsController.get(editor);
-		await controller?.model.get()?.acceptNextInlineEditPart(controller.editor);
-	}
-}
-
 export class HideInlineCompletion extends EditorAction {
 	public static ID = hideInlineCompletionId;
 

--- a/src/vs/editor/contrib/inlineCompletions/browser/inlineCompletions.contribution.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/inlineCompletions.contribution.ts
@@ -8,7 +8,7 @@ import { registerAction2 } from '../../../../platform/actions/common/actions.js'
 import { wrapInHotClass1 } from '../../../../platform/observable/common/wrapInHotClass.js';
 import { EditorContributionInstantiation, registerEditorAction, registerEditorCommand, registerEditorContribution } from '../../../browser/editorExtensions.js';
 import { HoverParticipantRegistry } from '../../hover/browser/hoverTypes.js';
-import { AcceptInlineCompletion, AcceptNextLineOfInlineCompletion, AcceptNextWordOfInlineCompletion, DevExtractReproSample, HideInlineCompletion, JumpToNextInlineEdit, ShowNextInlineSuggestionAction, ShowPreviousInlineSuggestionAction, ToggleAlwaysShowInlineSuggestionToolbar, ExplicitTriggerInlineEditAction, TriggerInlineSuggestionAction, TriggerInlineEditAction, ToggleInlineCompletionShowCollapsed, AcceptNextInlineEditPart } from './controller/commands.js';
+import { AcceptInlineCompletion, AcceptNextLineOfInlineCompletion, AcceptNextWordOfInlineCompletion, DevExtractReproSample, HideInlineCompletion, JumpToNextInlineEdit, ShowNextInlineSuggestionAction, ShowPreviousInlineSuggestionAction, ToggleAlwaysShowInlineSuggestionToolbar, ExplicitTriggerInlineEditAction, TriggerInlineSuggestionAction, TriggerInlineEditAction, ToggleInlineCompletionShowCollapsed } from './controller/commands.js';
 import { InlineCompletionsController } from './controller/inlineCompletionsController.js';
 import { InlineCompletionsHoverParticipant } from './hintsWidget/hoverParticipant.js';
 import { InlineCompletionsAccessibleView } from './inlineCompletionsAccessibleView.js';
@@ -29,7 +29,6 @@ registerEditorAction(AcceptNextLineOfInlineCompletion);
 registerEditorAction(AcceptInlineCompletion);
 registerEditorAction(ToggleInlineCompletionShowCollapsed);
 registerEditorAction(HideInlineCompletion);
-registerEditorAction(AcceptNextInlineEditPart);
 registerEditorAction(JumpToNextInlineEdit);
 registerAction2(ToggleAlwaysShowInlineSuggestionToolbar);
 registerEditorAction(DevExtractReproSample);

--- a/src/vs/editor/contrib/inlineCompletions/browser/model/inlineCompletionsModel.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/model/inlineCompletionsModel.ts
@@ -33,7 +33,7 @@ import { TextModelText } from '../../../../common/model/textModelText.js';
 import { IFeatureDebounceInformation } from '../../../../common/services/languageFeatureDebounce.js';
 import { IModelContentChangedEvent } from '../../../../common/textModelEvents.js';
 import { SnippetController2 } from '../../../snippet/browser/snippetController2.js';
-import { addPositions, getEndPositionsAfterApplying, getModifiedRangesAfterApplying, substringPos, subtractPositions } from '../utils.js';
+import { addPositions, getEndPositionsAfterApplying, substringPos, subtractPositions } from '../utils.js';
 import { AnimatedValue, easeOutCubic, ObservableAnimatedValue } from './animation.js';
 import { computeGhostText } from './computeGhostText.js';
 import { GhostText, GhostTextOrReplacement, ghostTextOrReplacementEquals, ghostTextsOrReplacementsEqual } from './ghostText.js';
@@ -339,7 +339,6 @@ export class InlineCompletionsModel extends Disposable {
 				}
 			}
 
-			this._inAcceptPartialFlow.set(false, tx);
 			this._isActive.set(false, tx);
 			this._source.clear(tx);
 		});
@@ -674,12 +673,6 @@ export class InlineCompletionsModel extends Disposable {
 			throw new BugIndicatingError();
 		}
 
-		if (this._inAcceptPartialFlow.get()) {
-			this._inAcceptPartialFlow.set(false, undefined);
-			this.jump();
-			return;
-		}
-
 		let completionWithUpdatedRange: InlineCompletionWithUpdatedRange;
 
 		const state = this.state.get();
@@ -845,68 +838,6 @@ export class InlineCompletionsModel extends Disposable {
 					acceptedLength,
 					{ kind, acceptedLength: acceptedLength, }
 				);
-			}
-		} finally {
-			completion.source.removeRef();
-		}
-	}
-
-	// TODO: clean this up if we keep it
-	private readonly _inAcceptPartialFlow = observableValue(this, false);
-	public readonly inPartialAcceptFlow: IObservable<boolean> = this._inAcceptPartialFlow;
-	public async acceptNextInlineEditPart(editor: ICodeEditor): Promise<void> {
-		if (editor.getModel() !== this.textModel) {
-			throw new BugIndicatingError();
-		}
-
-		const state = this.inlineEditState.get();
-		const updatedEdit = state?.inlineCompletion.updatedEdit.get();
-		const completion = state?.inlineCompletion.toInlineCompletion(undefined);
-		if (!updatedEdit || updatedEdit.isEmpty || !completion) {
-			return;
-		}
-
-		const nextPart = updatedEdit.edits[0];
-
-		const edit = new SingleTextEdit(Range.fromPositions(
-			this.textModel.getPositionAt(nextPart.replaceRange.start),
-			this.textModel.getPositionAt(nextPart.replaceRange.endExclusive)
-		), nextPart.newText);
-
-		const cursorAtStartPosition = this._editor.getSelection()?.getStartPosition().equals(edit.range.getStartPosition());
-		if (!cursorAtStartPosition || !this._inAcceptPartialFlow.get()) {
-			this._inAcceptPartialFlow.set(true, undefined);
-			this.jump();
-			return;
-		}
-
-		const partToJumpToNext = updatedEdit.edits[1] ?? undefined;
-		const editToJumpToNext = partToJumpToNext ? new SingleTextEdit(Range.fromPositions(
-			this.textModel.getPositionAt(partToJumpToNext.replaceRange.start),
-			this.textModel.getPositionAt(partToJumpToNext.replaceRange.endExclusive)
-		), partToJumpToNext.newText) : undefined;
-
-		// Executing the edit might free the completion, so we have to hold a reference on it.
-		completion.source.addRef();
-		try {
-			this._isAcceptingPartially = true;
-			try {
-				editor.pushUndoStop();
-
-				let selections;
-				if (editToJumpToNext) {
-					const [_, rangeOfEditToJumpTo] = getModifiedRangesAfterApplying([edit, editToJumpToNext]);
-					selections = [Selection.fromPositions(rangeOfEditToJumpTo.getStartPosition())];
-				} else {
-					selections = getEndPositionsAfterApplying([edit]).map(p => Selection.fromPositions(p));
-				}
-
-				const edits = [edit];
-				editor.executeEdits('inlineSuggestion.accept', edits.map(edit => EditOperation.replace(edit.range, edit.text)));
-				editor.setSelections(selections, 'inlineCompletionPartialAccept');
-				editor.revealPositionInCenterIfOutsideViewport(editor.getPosition()!, ScrollType.Immediate);
-			} finally {
-				this._isAcceptingPartially = false;
 			}
 		} finally {
 			completion.source.removeRef();

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsModel.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsModel.ts
@@ -57,14 +57,12 @@ export class InlineEditModel implements IInlineEditModel {
 export class InlineEditHost implements IInlineEditHost {
 	readonly onDidAccept: Event<void>;
 	readonly inAcceptFlow: IObservable<boolean>;
-	readonly inPartialAcceptFlow: IObservable<boolean>;
 
 	constructor(
 		private readonly _model: InlineCompletionsModel,
 	) {
 		this.onDidAccept = this._model.onDidAccept;
 		this.inAcceptFlow = this._model.inAcceptFlow;
-		this.inPartialAcceptFlow = this._model.inPartialAcceptFlow;
 	}
 }
 

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsView.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsView.ts
@@ -296,12 +296,7 @@ export class InlineEditsView extends Disposable {
 	));
 
 	private getCacheId(model: IInlineEditModel) {
-		const inlineEdit = model.inlineEdit;
-		if (this._host.get()?.inPartialAcceptFlow.get()) {
-			return `${inlineEdit.inlineCompletion.id}_${inlineEdit.edit.edits.map(innerEdit => innerEdit.range.toString() + innerEdit.text).join(',')}`;
-		}
-
-		return inlineEdit.inlineCompletion.id;
+		return model.inlineEdit.inlineCompletion.id;
 	}
 
 	private determineView(model: IInlineEditModel, reader: IReader, diff: DetailedLineRangeMapping[], newText: StringText, originalDisplayRange: LineRange): string {

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViewInterface.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViewInterface.ts
@@ -22,7 +22,6 @@ export interface IInlineEditsView {
 
 export interface IInlineEditHost {
 	inAcceptFlow: IObservable<boolean>;
-	inPartialAcceptFlow: IObservable<boolean>;
 }
 
 export interface IInlineEditModel {

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViewProducer.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViewProducer.ts
@@ -36,8 +36,7 @@ export class InlineEditsViewAndDiffProducer extends Disposable { // TODO: This c
 		const editOffset = model.inlineEditState.get()?.inlineCompletion.updatedEdit.read(reader);
 		if (!editOffset) { return undefined; }
 
-		const offsetEdits = model.inPartialAcceptFlow.read(reader) ? [editOffset.edits[0]] : editOffset.edits;
-		const edits = offsetEdits.map(e => {
+		const edits = editOffset.edits.map(e => {
 			const innerEditRange = Range.fromPositions(
 				textModel.getPositionAt(e.replaceRange.start),
 				textModel.getPositionAt(e.replaceRange.endExclusive)


### PR DESCRIPTION
```Copilot Generated Description:``` Eliminate the partial accept flow from the inline edit functionality, including the removal of related properties and actions.