### PR TITLE
Unfolderize Windows Start Menu entry

### DIFF
--- a/build/win32/code.iss
+++ b/build/win32/code.iss
@@ -99,7 +99,7 @@ Source: "appx\*"; DestDir: "{app}\appx"; BeforeInstall: RemoveAppxPackage; After
 #endif
 
 [Icons]
-Name: "{group}\{#NameLong}"; Filename: "{app}\{#ExeBasename}.exe"; AppUserModelID: "{#AppUserId}"
+Name: "{autostartmenu}\{#NameLong}"; Filename: "{app}\{#ExeBasename}.exe"; AppUserModelID: "{#AppUserId}"
 Name: "{autodesktop}\{#NameLong}"; Filename: "{app}\{#ExeBasename}.exe"; Tasks: desktopicon; AppUserModelID: "{#AppUserId}"
 Name: "{userappdata}\Microsoft\Internet Explorer\Quick Launch\{#NameLong}"; Filename: "{app}\{#ExeBasename}.exe"; Tasks: quicklaunchicon; AppUserModelID: "{#AppUserId}"
 


### PR DESCRIPTION
This simple change causes the Windows installer to place the entry directly in the Start Menu, instead of creating an entire folder, which does not make much sense for a single entry. This cleans up the appearance of the Start Menu and removes the need for expanding a folder each time in Windows 10 (W11 hides the folder automatically if there is just one content). Solves issue https://github.com/microsoft/vscode/issues/234217

The resulting change is as following:

From

%appdata%\Microsoft\Windows\Start Menu\Programs\Visual Studio Code\Visual Studio Code.lnk
![image](https://github.com/user-attachments/assets/e8fcb026-61f6-4cbe-9291-23a214e49380)

To

%appdata%\Microsoft\Windows\Start Menu\Programs\Visual Studio Code.lnk
![image](https://github.com/user-attachments/assets/69d48eae-f040-4d60-ba36-6d9173a79ffe)
