### PR TITLE
SCM Graph - Allow default history filter to be changed through user's config

### DIFF
--- a/src/vs/workbench/contrib/scm/browser/scm.contribution.ts
+++ b/src/vs/workbench/contrib/scm/browser/scm.contribution.ts
@@ -368,6 +368,16 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).regis
 			description: localize('scm.compactFolders', "Controls whether the Source Control view should render folders in a compact form. In such a form, single child folders will be compressed in a combined tree element."),
 			default: true
 		},
+		'scm.graph.defaultHistoryFilter': {
+			type: 'string',
+			enum: ['all', 'auto'],
+			enumDescriptions: [
+				localize('scm.graph.defaultHistoryFilter.all', "Get references from all branches."),
+				localize('scm.graph.defaultHistoryFilter.auto', "Get references only from the current working branch(s).")
+			],
+			description: localize('scm.graph.defaultHistoryFilter', "Controls default history references used in the Source Control Graph view."),
+			default: 'auto',
+		},
 		'scm.graph.pageOnScroll': {
 			type: 'boolean',
 			description: localize('scm.graph.pageOnScroll', "Controls whether the Source Control Graph view will load the next page of items when you scroll to the end of the list."),

--- a/src/vs/workbench/contrib/scm/browser/scm.contribution.ts
+++ b/src/vs/workbench/contrib/scm/browser/scm.contribution.ts
@@ -373,7 +373,7 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).regis
 			enum: ['all', 'auto'],
 			enumDescriptions: [
 				localize('scm.graph.defaultHistoryFilter.all', "Get references from all branches."),
-				localize('scm.graph.defaultHistoryFilter.auto', "Get references only from the current working branch(s).")
+				localize('scm.graph.defaultHistoryFilter.auto', "Get references only from the current working branch(es).")
 			],
 			description: localize('scm.graph.defaultHistoryFilter', "Controls default history references used in the Source Control Graph view."),
 			default: 'auto',

--- a/src/vs/workbench/contrib/scm/browser/scmHistoryViewPane.ts
+++ b/src/vs/workbench/contrib/scm/browser/scmHistoryViewPane.ts
@@ -834,7 +834,8 @@ class SCMHistoryViewModel extends Disposable {
 			return;
 		}
 
-		const filterState = this._repositoryFilterState.get(getProviderKey(repository.provider)) ?? 'auto';
+		const defaultFilter = this._configurationService.getValue<'all' | 'auto'>('scm.graph.defaultHistoryFilter');
+		const filterState = this._repositoryFilterState.get(getProviderKey(repository.provider)) ?? defaultFilter;
 		if (filterState === 'all' || filterState === 'auto') {
 			return filterState;
 		}
@@ -934,7 +935,8 @@ class SCMHistoryViewModel extends Disposable {
 			return;
 		}
 
-		if (filter !== 'auto') {
+		const defaultFilter = this._configurationService.getValue<'all' | 'auto'>('scm.graph.defaultHistoryFilter');
+		if (filter !== defaultFilter) {
 			this._repositoryFilterState.set(getProviderKey(repository.provider), filter);
 		} else {
 			this._repositoryFilterState.delete(getProviderKey(repository.provider));
@@ -979,7 +981,8 @@ class SCMHistoryViewModel extends Disposable {
 
 	private async _resolveHistoryItemFilter(repository: ISCMRepository, historyProvider: ISCMHistoryProvider): Promise<ISCMHistoryItemRef[]> {
 		const historyItemRefs: ISCMHistoryItemRef[] = [];
-		const historyItemsFilter = this._repositoryFilterState.get(getProviderKey(repository.provider)) ?? 'auto';
+		const defaultFilter = this._configurationService.getValue<'all' | 'auto'>('scm.graph.defaultHistoryFilter');
+		const historyItemsFilter = this._repositoryFilterState.get(getProviderKey(repository.provider)) ?? defaultFilter;
 
 		switch (historyItemsFilter) {
 			case 'all':


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Close #244866

## Description

The fallback value of filterState will now rely on `scm.graph.defaultHistoryFilter` instead of just being `'auto'`.