### PR TITLE
Native policy watcher is not given full set of definitions

### DIFF
--- a/src/vs/platform/policy/common/policy.ts
+++ b/src/vs/platform/policy/common/policy.ts
@@ -39,7 +39,7 @@ export abstract class AbstractPolicyService extends Disposable implements IPolic
 		this.policyDefinitions = { ...policyDefinitions, ...this.policyDefinitions };
 
 		if (size !== Object.keys(this.policyDefinitions).length) {
-			await this._updatePolicyDefinitions(policyDefinitions);
+			await this._updatePolicyDefinitions(this.policyDefinitions);
 		}
 
 		return Iterable.reduce(this.policies.entries(), (r, [name, value]) => ({ ...r, [name]: value }), {});


### PR DESCRIPTION
closes https://github.com/microsoft/vscode/issues/244531

When VS Code starts up `_updatePolicyDefinitions` is called several times to re-initialize the watcher's list of "known policy definitions".  

We should provide the watcher with `this.policyDefinitions` (constructed on like 39), instead of the partial `policyDefinitions`

Before this change, that means that after initialization, the watcher would only continue watching for a subset of policy.

As can be seen from [this example in the native policy watcher package](https://github.com/microsoft/vscode-policy-watcher/blob/main/index.js#L15-L18), the watcher is passed an explicit set of definitions to watch for

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
