### PR TITLE
make sure to wait for task start before firing problem matcher started event

### DIFF
--- a/src/vs/workbench/contrib/tasks/browser/terminalTaskSystem.ts
+++ b/src/vs/workbench/contrib/tasks/browser/terminalTaskSystem.ts
@@ -833,7 +833,6 @@ export class TerminalTaskSystem extends Disposable implements ITaskSystem {
 					eventCounter++;
 					this._busyTasks[mapKey] = task;
 					this._fireTaskEvent(TaskEvent.general(TaskEventKind.Active, task, terminal?.instanceId));
-					this._fireTaskEvent(TaskEvent.general(TaskEventKind.ProblemMatcherStarted, task, terminal?.instanceId));
 				} else if (event.kind === ProblemCollectorEventKind.BackgroundProcessingEnds) {
 					eventCounter--;
 					if (this._busyTasks[mapKey]) {

--- a/src/vs/workbench/contrib/tasks/browser/terminalTaskSystem.ts
+++ b/src/vs/workbench/contrib/tasks/browser/terminalTaskSystem.ts
@@ -882,6 +882,7 @@ export class TerminalTaskSystem extends Disposable implements ITaskSystem {
 			this._fireTaskEvent(TaskEvent.start(task, terminal.instanceId, resolver.values));
 			let onData: IDisposable | undefined;
 			if (problemMatchers.length) {
+				this._fireTaskEvent(TaskEvent.general(TaskEventKind.ProblemMatcherStarted, task, terminal.instanceId));
 				// prevent https://github.com/microsoft/vscode/issues/174511 from happening
 				onData = terminal.onLineData((line) => {
 					watchingProblemMatcher.processLine(line);

--- a/src/vs/workbench/contrib/tasks/common/problemCollectors.ts
+++ b/src/vs/workbench/contrib/tasks/common/problemCollectors.ts
@@ -362,8 +362,6 @@ export class StartStopProblemCollector extends AbstractProblemCollector implemen
 	private currentOwner: string | undefined;
 	private currentResource: string | undefined;
 
-	private _hasStarted: boolean = false;
-
 	constructor(problemMatchers: ProblemMatcher[], markerService: IMarkerService, modelService: IModelService, _strategy: ProblemHandlingStrategy = ProblemHandlingStrategy.Clean, fileService?: IFileService) {
 		super(problemMatchers, markerService, modelService, fileService);
 		const ownerSet: { [key: string]: boolean } = Object.create(null);
@@ -372,13 +370,10 @@ export class StartStopProblemCollector extends AbstractProblemCollector implemen
 		this.owners.forEach((owner) => {
 			this.recordResourcesToClean(owner);
 		});
+		this._onDidStateChange.fire(IProblemCollectorEvent.create(ProblemCollectorEventKind.BackgroundProcessingBegins));
 	}
 
 	protected async processLineInternal(line: string): Promise<void> {
-		if (!this._hasStarted) {
-			this._hasStarted = true;
-			this._onDidStateChange.fire(IProblemCollectorEvent.create(ProblemCollectorEventKind.BackgroundProcessingBegins));
-		}
 		const markerMatch = this.tryFindMarker(line);
 		if (!markerMatch) {
 			return;

--- a/src/vs/workbench/contrib/tasks/common/problemCollectors.ts
+++ b/src/vs/workbench/contrib/tasks/common/problemCollectors.ts
@@ -362,6 +362,8 @@ export class StartStopProblemCollector extends AbstractProblemCollector implemen
 	private currentOwner: string | undefined;
 	private currentResource: string | undefined;
 
+	private _hasStarted: boolean = false;
+
 	constructor(problemMatchers: ProblemMatcher[], markerService: IMarkerService, modelService: IModelService, _strategy: ProblemHandlingStrategy = ProblemHandlingStrategy.Clean, fileService?: IFileService) {
 		super(problemMatchers, markerService, modelService, fileService);
 		const ownerSet: { [key: string]: boolean } = Object.create(null);
@@ -370,10 +372,13 @@ export class StartStopProblemCollector extends AbstractProblemCollector implemen
 		this.owners.forEach((owner) => {
 			this.recordResourcesToClean(owner);
 		});
-		this._onDidStateChange.fire(IProblemCollectorEvent.create(ProblemCollectorEventKind.BackgroundProcessingBegins));
 	}
 
 	protected async processLineInternal(line: string): Promise<void> {
+		if (!this._hasStarted) {
+			this._hasStarted = true;
+			this._onDidStateChange.fire(IProblemCollectorEvent.create(ProblemCollectorEventKind.BackgroundProcessingBegins));
+		}
 		const markerMatch = this.tryFindMarker(line);
 		if (!markerMatch) {
 			return;


### PR DESCRIPTION
fixes #244625

This was happening because task start had not yet happened in some cases. 

<img width="675" alt="demo" src="https://github.com/user-attachments/assets/a9157b54-359b-476b-a5e5-e86e4fa87090" />

Now works:
<img width="319" alt="Screenshot 2025-03-28 at 4 14 36 PM" src="https://github.com/user-attachments/assets/5e1730d4-ff22-41ef-8cdc-48ca1d06d8de" />
