### PR TITLE
chore: scan parcel/watcher again

### DIFF
--- a/build/gulpfile.scan.js
+++ b/build/gulpfile.scan.js
@@ -84,9 +84,8 @@ function nodeModules(destinationExe, destinationPdb, platform) {
 				'**/*.node',
 				// Exclude these paths.
 				// We don't build the prebuilt node files so we don't scan them
-				'!**/prebuilds/**/*.node',
-				// These are 3rd party modules that we should ignore
-				'!**/@parcel/watcher/**/*']))
+				'!**/prebuilds/**/*.node'
+			]))
 			.pipe(gulp.dest(destinationExe));
 	};
 


### PR DESCRIPTION
This PR includes parcel/watcher in the compliance scans again so we at least know what potential compliance issues our usage of it could bring.

In the worst case, BinSkim issues can be closed as External, but APIScan issues would need to be resolved through upstream patches or through forking and patching.