### PR TITLE
Enhance GithHub publishing logic to handle renamed repositories

### DIFF
--- a/extensions/github/src/publish.ts
+++ b/extensions/github/src/publish.ts
@@ -99,7 +99,7 @@ export async function publishRepository(gitAPI: GitAPI, repository?: Repository)
 		if (repo) {
 			try {
 				quickpick.busy = true;
-				let result = await octokit.repos.get({ owner, repo: repo });
+				const result = await octokit.repos.get({ owner, repo: repo });
 				if (result['data']['name'] !== repo) { // happens when the repo was renamed
 					break;
 				}

--- a/extensions/github/src/publish.ts
+++ b/extensions/github/src/publish.ts
@@ -99,7 +99,10 @@ export async function publishRepository(gitAPI: GitAPI, repository?: Repository)
 		if (repo) {
 			try {
 				quickpick.busy = true;
-				await octokit.repos.get({ owner, repo: repo });
+				let result = await octokit.repos.get({ owner, repo: repo });
+				if (result['data']['name'] !== repo) { // happens when the repo was renamed
+					break;
+				}
 				quickpick.items = [{ label: `$(error) GitHub repository already exists`, description: `$(github) ${owner}/${repo}`, alwaysShow: true }];
 			} catch {
 				break;

--- a/extensions/github/src/publish.ts
+++ b/extensions/github/src/publish.ts
@@ -99,11 +99,13 @@ export async function publishRepository(gitAPI: GitAPI, repository?: Repository)
 		if (repo) {
 			try {
 				quickpick.busy = true;
+				const fullName = `${owner}/${repo}`;
 				const result = await octokit.repos.get({ owner, repo: repo });
-				if (result['data']['name'] !== repo) { // happens when the repo was renamed
+				if (result.data.full_name.toLowerCase() !== fullName.toLowerCase()) {
+					// Repository has moved permanently due to it being renamed
 					break;
 				}
-				quickpick.items = [{ label: `$(error) GitHub repository already exists`, description: `$(github) ${owner}/${repo}`, alwaysShow: true }];
+				quickpick.items = [{ label: `$(error) GitHub repository already exists`, description: `$(github) ${fullName}`, alwaysShow: true }];
 			} catch {
 				break;
 			} finally {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
Fixes #245022.

# Steps to test the fix

1. Sign up for GitHub
2. Create repository "test" on GitHub
3. Rename that repository to "test-renamed"
4. Login to your GitHub account from within vscode
5. Initialize a new git repository in vscode and commit a test file
6. Chose the "Publish to GitHub" command
7. Use "test" as a repository name

With the current version, vscode will complain that the repository already exists, even though it no longer does.
My MR fixes this, publishing is now possible again.

# Testing

I don't thing it's feasible to write a unit test for this, as that would require a GitHub account and a repository which needs to be created and deleted on each test run.