### PR TITLE
Correct `1 older results`

### DIFF
--- a/src/vs/workbench/contrib/testing/browser/testResultsView/testResultsTree.ts
+++ b/src/vs/workbench/contrib/testing/browser/testResultsView/testResultsTree.ts
@@ -132,8 +132,9 @@ class OlderResultsElement implements ITreeElement {
 	public readonly label: string;
 
 	constructor(private readonly n: number) {
-		this.label = localize('nOlderResults', '{0} older results', n);
-
+		this.label = n === 1 ?
+			localize('oneOlderResult', '1 older result') :
+			localize('nOlderResults', '{0} older results', n);
 	}
 }
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/244218
