### PR TITLE
Rename 'chatSessionStoreError.reason'

### DIFF
--- a/src/vs/workbench/contrib/chat/common/chatSessionStore.ts
+++ b/src/vs/workbench/contrib/chat/common/chatSessionStore.ts
@@ -224,19 +224,17 @@ export class ChatSessionStore extends Disposable {
 
 		const fileOperationReason = error && toFileOperationResult(error);
 		type ChatSessionStoreErrorData = {
-			reason: string;
+			errorReason: string;
 			fileOperationReason: number;
-			// error: Error;
 		};
 		type ChatSessionStoreErrorClassification = {
 			owner: 'roblourens';
 			comment: 'Detect issues related to managing chat sessions';
-			reason: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'Info about the error that occurred' };
+			errorReason: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'Info about the error that occurred' };
 			fileOperationReason: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'An error code from the file service' };
-			// error: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'Info about the error that occurred' };
 		};
 		this.telemetryService.publicLog2<ChatSessionStoreErrorData, ChatSessionStoreErrorClassification>('chatSessionStoreError', {
-			reason: reasonForTelemetry,
+			errorReason: reasonForTelemetry,
 			fileOperationReason: fileOperationReason ?? -1
 		});
 	}


### PR DESCRIPTION
This is not showing up in telemetry, not sure why, maybe there is a problem with this property name.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
