### PR TITLE
Feature: don't show error peek overlay when navigating over errors (next/prev error by F8 hotkey)

### DIFF
--- a/src/vs/editor/contrib/gotoError/browser/gotoError.ts
+++ b/src/vs/editor/contrib/gotoError/browser/gotoError.ts
@@ -36,7 +36,7 @@ export class MarkerController implements IEditorContribution {
 	private readonly _editor: ICodeEditor;
 
 	private readonly _widgetVisible: IContextKey<boolean>;
-	private readonly _sessionDispoables = new DisposableStore();
+	private readonly _sessionDisposables = new DisposableStore();
 
 	private _model?: MarkerList;
 	private _widget?: MarkerNavigationWidget;
@@ -54,12 +54,12 @@ export class MarkerController implements IEditorContribution {
 
 	dispose(): void {
 		this._cleanUp();
-		this._sessionDispoables.dispose();
+		this._sessionDisposables.dispose();
 	}
 
 	private _cleanUp(): void {
 		this._widgetVisible.reset();
-		this._sessionDispoables.clear();
+		this._sessionDisposables.clear();
 		this._widget = undefined;
 		this._model = undefined;
 	}
@@ -81,21 +81,21 @@ export class MarkerController implements IEditorContribution {
 		}
 
 		this._widget = this._instantiationService.createInstance(MarkerNavigationWidget, this._editor);
-		this._widget.onDidClose(() => this.close(), this, this._sessionDispoables);
+		this._widget.onDidClose(() => this.close(), this, this._sessionDisposables);
 		this._widgetVisible.set(true);
 
-		this._sessionDispoables.add(this._model);
-		this._sessionDispoables.add(this._widget);
+		this._sessionDisposables.add(this._model);
+		this._sessionDisposables.add(this._widget);
 
 		// follow cursor
-		this._sessionDispoables.add(this._editor.onDidChangeCursorPosition(e => {
+		this._sessionDisposables.add(this._editor.onDidChangeCursorPosition(e => {
 			if (!this._model?.selected || !Range.containsPosition(this._model?.selected.marker, e.position)) {
 				this._model?.resetIndex();
 			}
 		}));
 
 		// update markers
-		this._sessionDispoables.add(this._model.onDidChange(() => {
+		this._sessionDisposables.add(this._model.onDidChange(() => {
 			if (!this._widget || !this._widget.position || !this._model) {
 				return;
 			}
@@ -108,14 +108,14 @@ export class MarkerController implements IEditorContribution {
 		}));
 
 		// open related
-		this._sessionDispoables.add(this._widget.onDidSelectRelatedInformation(related => {
+		this._sessionDisposables.add(this._widget.onDidSelectRelatedInformation(related => {
 			this._editorService.openCodeEditor({
 				resource: related.resource,
 				options: { pinned: true, revealIfOpened: true, selection: Range.lift(related).collapseToStart() }
 			}, this._editor);
 			this.close(false);
 		}));
-		this._sessionDispoables.add(this._editor.onDidChangeModel(() => this._cleanUp()));
+		this._sessionDisposables.add(this._editor.onDidChangeModel(() => this._cleanUp()));
 
 		return this._model;
 	}

--- a/src/vs/editor/contrib/gotoError/browser/gotoErrorWidget.ts
+++ b/src/vs/editor/contrib/gotoError/browser/gotoErrorWidget.ts
@@ -29,6 +29,7 @@ import { IOpenerService } from '../../../../platform/opener/common/opener.js';
 import { SeverityIcon } from '../../../../base/browser/ui/severityIcon/severityIcon.js';
 import { contrastBorder, editorBackground, editorErrorBorder, editorErrorForeground, editorInfoBorder, editorInfoForeground, editorWarningBorder, editorWarningForeground, oneOf, registerColor, transparent } from '../../../../platform/theme/common/colorRegistry.js';
 import { IColorTheme, IThemeService } from '../../../../platform/theme/common/themeService.js';
+import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 
 class MessageWidget {
 
@@ -248,11 +249,13 @@ export class MarkerNavigationWidget extends PeekViewWidget {
 		@IMenuService private readonly _menuService: IMenuService,
 		@IInstantiationService instantiationService: IInstantiationService,
 		@IContextKeyService private readonly _contextKeyService: IContextKeyService,
-		@ILabelService private readonly _labelService: ILabelService
+		@ILabelService private readonly _labelService: ILabelService,
+		@IConfigurationService private readonly _configService: IConfigurationService
 	) {
 		super(editor, { showArrow: true, showFrame: true, isAccessible: true, frameWidth: 1 }, instantiationService);
 		this._severity = MarkerSeverity.Warning;
 		this._backgroundColor = Color.white;
+		this.options.showOverlay = this._configService.getValue<boolean>('problems.gotoError.showOverlay');
 
 		this._applyTheme(_themeService.getColorTheme());
 		this._callOnDispose.add(_themeService.onDidColorThemeChange(this._applyTheme.bind(this)));

--- a/src/vs/editor/contrib/gotoError/browser/gotoErrorWidget.ts
+++ b/src/vs/editor/contrib/gotoError/browser/gotoErrorWidget.ts
@@ -29,7 +29,6 @@ import { IOpenerService } from '../../../../platform/opener/common/opener.js';
 import { SeverityIcon } from '../../../../base/browser/ui/severityIcon/severityIcon.js';
 import { contrastBorder, editorBackground, editorErrorBorder, editorErrorForeground, editorInfoBorder, editorInfoForeground, editorWarningBorder, editorWarningForeground, oneOf, registerColor, transparent } from '../../../../platform/theme/common/colorRegistry.js';
 import { IColorTheme, IThemeService } from '../../../../platform/theme/common/themeService.js';
-import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 
 class MessageWidget {
 
@@ -244,18 +243,17 @@ export class MarkerNavigationWidget extends PeekViewWidget {
 
 	constructor(
 		editor: ICodeEditor,
+		showOverlay: boolean,
 		@IThemeService private readonly _themeService: IThemeService,
 		@IOpenerService private readonly _openerService: IOpenerService,
 		@IMenuService private readonly _menuService: IMenuService,
 		@IInstantiationService instantiationService: IInstantiationService,
 		@IContextKeyService private readonly _contextKeyService: IContextKeyService,
 		@ILabelService private readonly _labelService: ILabelService,
-		@IConfigurationService private readonly _configService: IConfigurationService
 	) {
-		super(editor, { showArrow: true, showFrame: true, isAccessible: true, frameWidth: 1 }, instantiationService);
+		super(editor, { showArrow: true, showFrame: true, isAccessible: true, frameWidth: 1, showOverlay }, instantiationService);
 		this._severity = MarkerSeverity.Warning;
 		this._backgroundColor = Color.white;
-		this.options.showOverlay = this._configService.getValue<boolean>('problems.gotoError.showOverlay');
 
 		this._applyTheme(_themeService.getColorTheme());
 		this._callOnDispose.add(_themeService.onDidColorThemeChange(this._applyTheme.bind(this)));

--- a/src/vs/editor/contrib/hover/browser/markerHoverParticipant.ts
+++ b/src/vs/editor/contrib/hover/browser/markerHoverParticipant.ts
@@ -190,10 +190,10 @@ export class MarkerHoverParticipant implements IEditorHoverParticipant<MarkerHov
 			if (markerController) {
 				context.statusBar.addAction({
 					label: nls.localize('view problem', "View Problem"),
-					commandId: NextMarkerAction.ID,
+					commandId: markerController.showsOverlayOnNavigate ? NextMarkerAction.ID : '',
 					run: () => {
 						context.hide();
-						markerController.showAtMarker(markerHover.marker);
+						markerController.showAtMarker(markerHover.marker, true);
 						this._editor.focus();
 					}
 				});

--- a/src/vs/editor/contrib/zoneWidget/browser/zoneWidget.ts
+++ b/src/vs/editor/contrib/zoneWidget/browser/zoneWidget.ts
@@ -20,6 +20,7 @@ import { TrackedRangeStickiness } from '../../../common/model.js';
 import { ModelDecorationOptions } from '../../../common/model/textModel.js';
 
 export interface IOptions {
+	showOverlay?: boolean;
 	showFrame?: boolean;
 	showArrow?: boolean;
 	frameWidth?: number;
@@ -41,6 +42,7 @@ export interface IStyles {
 const defaultColor = new Color(new RGBA(0, 122, 204));
 
 const defaultOptions: IOptions = {
+	showOverlay: true,
 	showArrow: true,
 	showFrame: true,
 	className: '',
@@ -383,6 +385,22 @@ export abstract class ZoneWidget implements IHorizontalSashLayoutProvider {
 	}
 
 	private _showImpl(where: Range, heightInLines: number): void {
+		if (this.options.showOverlay) {
+			this._insertOverlayWidget(where, heightInLines);
+		}
+
+		if (!this.options.keepEditorSelection) {
+			this.editor.setSelection(where);
+		}
+
+		const model = this.editor.getModel();
+		if (model) {
+			const range = model.validateRange(new Range(where.startLineNumber, 1, where.endLineNumber + 1, 1));
+			this.revealRange(range, range.startLineNumber === model.getLineCount());
+		}
+	}
+
+	private _insertOverlayWidget(where: Range, heightInLines: number): void {
 		const position = where.getStartPosition();
 		const layoutInfo = this.editor.getLayoutInfo();
 		const width = this._getWidth(layoutInfo);
@@ -456,16 +474,6 @@ export abstract class ZoneWidget implements IHorizontalSashLayoutProvider {
 		}
 
 		this._doLayout(containerHeight, width);
-
-		if (!this.options.keepEditorSelection) {
-			this.editor.setSelection(where);
-		}
-
-		const model = this.editor.getModel();
-		if (model) {
-			const range = model.validateRange(new Range(where.startLineNumber, 1, where.endLineNumber + 1, 1));
-			this.revealRange(range, range.startLineNumber === model.getLineCount());
-		}
 	}
 
 	protected revealRange(range: Range, isLastLine: boolean) {

--- a/src/vs/workbench/contrib/markers/browser/markers.contribution.ts
+++ b/src/vs/workbench/contrib/markers/browser/markers.contribution.ts
@@ -105,6 +105,11 @@ Registry.as<IConfigurationRegistry>(Extensions.Configuration).registerConfigurat
 			'default': 'tree',
 			'enum': ['table', 'tree'],
 		},
+		'problems.gotoError.showOverlay': {
+			'description': Messages.PROBLEMS_GOTOERROR_CONFIGURATION_SHOWOVERLAY,
+			'type': 'boolean',
+			'default': true
+		},
 		'problems.showCurrentInStatus': {
 			'description': Messages.PROBLEMS_PANEL_CONFIGURATION_SHOW_CURRENT_STATUS,
 			'type': 'boolean',

--- a/src/vs/workbench/contrib/markers/browser/messages.ts
+++ b/src/vs/workbench/contrib/markers/browser/messages.ts
@@ -14,6 +14,8 @@ export default class Messages {
 	public static MARKERS_PANEL_TOGGLE_LABEL: string = nls.localize('problems.view.toggle.label', "Toggle Problems (Errors, Warnings, Infos)");
 	public static MARKERS_PANEL_SHOW_LABEL = nls.localize2('problems.view.focus.label', "Focus Problems (Errors, Warnings, Infos)");
 
+	public static PROBLEMS_GOTOERROR_CONFIGURATION_SHOWOVERLAY: string = nls.localize('problems.gotoError.configuration.showOverlay', "Show error peek overlay when navigating over errors");
+
 	public static PROBLEMS_PANEL_CONFIGURATION_TITLE: string = nls.localize('problems.panel.configuration.title', "Problems View");
 	public static PROBLEMS_PANEL_CONFIGURATION_AUTO_REVEAL: string = nls.localize('problems.panel.configuration.autoreveal', "Controls whether Problems view should automatically reveal files when opening them.");
 	public static PROBLEMS_PANEL_CONFIGURATION_VIEW_MODE: string = nls.localize('problems.panel.configuration.viewMode', "Controls the default view mode of the Problems view.");


### PR DESCRIPTION
Adds ZoneWidget `showOverlay` (`true`) option to skip insertion of overlayWidget if set to `false`

Adds `problems.gotoError.showOverlay` setting to make use of it when navigating over errors (next/prev error by F8 hotkey)

Fixes #51787
Fixes #63591