### PR TITLE
Fix php highlighting codeblocks with uris

### DIFF
--- a/src/vs/workbench/contrib/chat/common/codeBlockModelCollection.ts
+++ b/src/vs/workbench/contrib/chat/common/codeBlockModelCollection.ts
@@ -250,7 +250,8 @@ export class CodeBlockModelCollection extends Disposable {
 
 function fixCodeText(text: string, languageId: string | undefined): string {
 	if (languageId === 'php') {
-		if (!text.trim().startsWith('<')) {
+		// <?php or short tag version <?
+		if (!text.trim().startsWith('<?')) {
 			return `<?php\n${text}`;
 		}
 	}


### PR DESCRIPTION
Fix microsoft/vscode-copilot-release#7030
Codeblocks with uris get the special `<vscode_codeblock_uri>` tag which broke this check

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
