### PR TITLE
fix: early exit status code

### DIFF
--- a/src/vs/workbench/contrib/terminal/common/scripts/shellIntegration.fish
+++ b/src/vs/workbench/contrib/terminal/common/scripts/shellIntegration.fish
@@ -18,7 +18,7 @@
 status is-interactive
 and string match --quiet "$TERM_PROGRAM" "vscode"
 and ! set --query VSCODE_SHELL_INTEGRATION
-or exit
+or exit 0
 
 set --global VSCODE_SHELL_INTEGRATION 1
 set --global __vscode_shell_env_reporting $VSCODE_SHELL_ENV_REPORTING


### PR DESCRIPTION
When running outside vscode terminal exit code would be non zero even when no error occurred

Adresses #169407 

## Testing
* Run the integration script in a non vscode terminal and check exit status
* Run the integration script in a vscode terminal and check integration works
