### PR TITLE
ensure spec descriptions come through

### DIFF
--- a/extensions/terminal-suggest/src/terminalSuggestMain.ts
+++ b/extensions/terminal-suggest/src/terminalSuggestMain.ts
@@ -284,7 +284,6 @@ export async function getCompletionItemsFromSpecs(
 
 				existingItem.documentation ??= command.documentation;
 				existingItem.detail ??= command.detail;
-				existingItem.kind ??= command.kind;
 			}
 		}
 		filesRequested = true;

--- a/extensions/terminal-suggest/src/terminalSuggestMain.ts
+++ b/extensions/terminal-suggest/src/terminalSuggestMain.ts
@@ -275,16 +275,16 @@ export async function getCompletionItemsFromSpecs(
 					vscode.TerminalCompletionItemKind.Method
 				));
 				labels.add(commandTextLabel);
-			} else {
+			}
+			else {
 				const existingItem = items.find(i => (typeof i.label === 'string' ? i.label : i.label.label) === commandTextLabel);
 				if (!existingItem) {
 					continue;
 				}
-				const preferredItem = compareItems(existingItem, command);
-				if (preferredItem) {
-					preferredItem.kind = vscode.TerminalCompletionItemKind.Method;
-					items.splice(items.indexOf(existingItem), 1, preferredItem);
-				}
+
+				existingItem.documentation ??= command.documentation;
+				existingItem.detail ??= command.detail;
+				existingItem.kind ??= command.kind;
 			}
 		}
 		filesRequested = true;
@@ -304,20 +304,6 @@ export async function getCompletionItemsFromSpecs(
 	}
 
 	return { items, filesRequested, foldersRequested, fileExtensions, cwd };
-}
-
-function compareItems(existingItem: vscode.TerminalCompletionItem, command: ICompletionResource): vscode.TerminalCompletionItem | undefined {
-	let score = typeof command.label === 'object' ? (command.label.detail !== undefined ? 1 : 0) : 0;
-	score += typeof command.label === 'object' ? (command.label.description !== undefined ? 2 : 0) : 0;
-	score += command.documentation ? typeof command.documentation === 'string' ? 2 : 3 : 0;
-	if (score > 0) {
-		score -= typeof existingItem.label === 'object' ? (existingItem.label.detail !== undefined ? 1 : 0) : 0;
-		score -= typeof existingItem.label === 'object' ? (existingItem.label.description !== undefined ? 2 : 0) : 0;
-		score -= existingItem.documentation ? typeof existingItem.documentation === 'string' ? 2 : 3 : 0;
-		if (score >= 0) {
-			return { ...command, replacementIndex: existingItem.replacementIndex, replacementLength: existingItem.replacementLength };
-		}
-	}
 }
 
 function getEnvAsRecord(shellIntegrationEnv: ITerminalEnvironment): Record<string, string> {


### PR DESCRIPTION
fix #245155

Before, we were comparing the spec item and the builtin to decide which should take priority /be added to the list. That was inefficient and also wrong - we want properties from both. Now, we apply any properties that aren't defined for the spec item from the builtin. 

<img width="744" alt="Screenshot 2025-03-31 at 1 04 23 PM" src="https://github.com/user-attachments/assets/b7b42f3a-9acd-4a46-8505-b9e85ce3fa69" />
