### PR TITLE
mcp: open to-trust config in aux window instead of main window

### DIFF
--- a/src/vs/platform/dialogs/common/dialogs.ts
+++ b/src/vs/platform/dialogs/common/dialogs.ts
@@ -283,7 +283,8 @@ export interface ICustomDialogOptions {
 export interface ICustomDialogMarkdown {
 	readonly markdown: IMarkdownString;
 	readonly classes?: string[];
-	readonly dismissOnLinkClick?: boolean;
+	/** Custom link handler for markdown content, see {@link IContentActionHandler}. Defaults to {@link openLinkFromMarkdown}. */
+	actionHandler?(link: string): Promise<boolean>;
 }
 
 /**

--- a/src/vs/workbench/browser/parts/dialogs/dialogHandler.ts
+++ b/src/vs/workbench/browser/parts/dialogs/dialogHandler.ts
@@ -114,12 +114,9 @@ export class BrowserDialogHandler extends AbstractDialogHandler {
 			customOptions.markdownDetails?.forEach(markdownDetail => {
 				const result = this.markdownRenderer.render(markdownDetail.markdown, {
 					actionHandler: {
-						callback: link => {
-							if (markdownDetail.dismissOnLinkClick) {
-								dialog.dispose();
-							}
+						callback: markdownDetail.actionHandler || (link => {
 							return openLinkFromMarkdown(this.openerService, link, markdownDetail.markdown.isTrusted, true /* skip URL validation to prevent another dialog from showing which is unsupported */);
-						},
+						}),
 						disposables: dialogDisposables
 					}
 				});

--- a/src/vs/workbench/contrib/mcp/common/mcpRegistry.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpRegistry.ts
@@ -263,7 +263,7 @@ export class McpRegistry extends Disposable implements IMcpRegistry {
 					markdownDetails: [{
 						markdown: new MarkdownString(localize('mcp.trust.details', '{0} discovered Model Context Protocol servers from {1} (`{2}`). {0} can use their capabilities in Chat.\n\nDo you want to allow running MCP servers from {3}?', this._productService.nameShort, collection.label, collection.serverDefinitions.get().map(s => s.label).join('`, `'), labelWithOrigin)),
 						actionHandler: () => {
-							const editor = this._editorService.openEditor({ resource: collection.presentation!.origin!, options: { transient: true } }, AUX_WINDOW_GROUP);
+							const editor = this._editorService.openEditor({ resource: collection.presentation!.origin! }, AUX_WINDOW_GROUP);
 							return editor.then(Boolean);
 						},
 					}]

--- a/src/vs/workbench/contrib/mcp/common/mcpRegistry.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpRegistry.ts
@@ -21,7 +21,7 @@ import { IStorageService, StorageScope, StorageTarget } from '../../../../platfo
 import { IWorkspaceFolderData } from '../../../../platform/workspace/common/workspace.js';
 import { IConfigurationResolverService } from '../../../services/configurationResolver/common/configurationResolver.js';
 import { ConfigurationResolverExpression, IResolvedValue } from '../../../services/configurationResolver/common/configurationResolverExpression.js';
-import { IEditorService } from '../../../services/editor/common/editorService.js';
+import { AUX_WINDOW_GROUP, IEditorService } from '../../../services/editor/common/editorService.js';
 import { McpRegistryInputStorage } from './mcpRegistryInputStorage.js';
 import { IMcpHostDelegate, IMcpRegistry, IMcpResolveConnectionOptions } from './mcpRegistryTypes.js';
 import { McpServerConnection } from './mcpServerConnection.js';
@@ -246,7 +246,10 @@ export class McpRegistry extends Disposable implements IMcpRegistry {
 				custom: {
 					markdownDetails: [{
 						markdown: new MarkdownString(localize('mcp.trust.details', '{0} discovered Model Context Protocol servers from {1} (`{2}`). {0} can use their capabilities in Chat.\n\nDo you want to allow running MCP servers from {3}?', this._productService.nameShort, collection.label, collection.serverDefinitions.get().map(s => s.label).join('`, `'), labelWithOrigin)),
-						dismissOnLinkClick: true,
+						actionHandler: () => {
+							const editor = this._editorService.openEditor({ resource: collection.presentation!.origin!, options: { transient: true } }, AUX_WINDOW_GROUP);
+							return editor.then(Boolean);
+						},
 					}]
 				},
 				buttons: [


### PR DESCRIPTION
Fixes #245162

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
