### PR TITLE
ESM for extensions

### DIFF
--- a/src/vs/platform/extensions/common/extensions.ts
+++ b/src/vs/platform/extensions/common/extensions.ts
@@ -280,6 +280,7 @@ export interface IRelaxedExtensionManifest {
 	engines: { readonly vscode: string };
 	description?: string;
 	main?: string;
+	type?: string;
 	browser?: string;
 	preview?: boolean;
 	// For now this only supports pointing to l10n bundle files

--- a/src/vs/workbench/api/common/extHostRequireInterceptor.ts
+++ b/src/vs/workbench/api/common/extHostRequireInterceptor.ts
@@ -27,7 +27,7 @@ interface IAlternativeModuleProvider {
 	alternativeModuleName(name: string): string | undefined;
 }
 
-interface INodeModuleFactory extends Partial<IAlternativeModuleProvider> {
+export interface INodeModuleFactory extends Partial<IAlternativeModuleProvider> {
 	readonly nodeModuleName: string | string[];
 	load(request: string, parent: URI, original: LoadFunction): any;
 }

--- a/src/vs/workbench/api/node/extHostExtensionService.ts
+++ b/src/vs/workbench/api/node/extHostExtensionService.ts
@@ -141,7 +141,7 @@ class NodeModuleESMInterceptor extends RequireInterceptor {
 
 		let apiModuleFactory: INodeModuleFactory | undefined;
 
-		port1.onmessage = (e: { data: Message }) => {
+		port1.onmessage = (e) => {
 
 			// Get the vscode-module factory - which is the same logic that's also used by
 			// the CommonJS require interceptor

--- a/src/vs/workbench/api/node/extHostExtensionService.ts
+++ b/src/vs/workbench/api/node/extHostExtensionService.ts
@@ -141,7 +141,7 @@ class NodeModuleESMInterceptor extends RequireInterceptor {
 
 		let apiModuleFactory: INodeModuleFactory | undefined;
 
-		port1.onmessage = (e) => {
+		port1.onmessage = (e: { data: Message }) => {
 
 			// Get the vscode-module factory - which is the same logic that's also used by
 			// the CommonJS require interceptor

--- a/src/vs/workbench/api/node/extHostExtensionService.ts
+++ b/src/vs/workbench/api/node/extHostExtensionService.ts
@@ -141,7 +141,11 @@ class NodeModuleESMInterceptor extends RequireInterceptor {
 
 		let apiModuleFactory: INodeModuleFactory | undefined;
 
-		port1.onmessage = (e) => {
+		// this is a workaround for the fact that the layer checker does not understand
+		// that onmessage is NodeJS API here
+		const port1LayerCheckerWorkaround: any = port1;
+
+		port1LayerCheckerWorkaround.onmessage = (e: { data: Message }) => {
 
 			// Get the vscode-module factory - which is the same logic that's also used by
 			// the CommonJS require interceptor
@@ -150,7 +154,7 @@ class NodeModuleESMInterceptor extends RequireInterceptor {
 				assertType(apiModuleFactory);
 			}
 
-			const { id, url } = <Message>e.data;
+			const { id, url } = e.data;
 			const uri = URI.parse(url);
 
 			// Get or create the API instance. The interface is per extension and extensions are

--- a/src/vs/workbench/api/worker/extHostExtensionService.ts
+++ b/src/vs/workbench/api/worker/extHostExtensionService.ts
@@ -125,6 +125,10 @@ export class ExtHostExtensionService extends AbstractExtHostExtensionService {
 		}
 	}
 
+	protected override _loadESMModule<T>(extension: IExtensionDescription | null, module: URI, activationTimesBuilder: ExtensionActivationTimesBuilder): Promise<T> {
+		throw new Error('ESM modules are not supported in the web worker extension host');
+	}
+
 	async $setRemoteEnvironment(_env: { [key: string]: string | null }): Promise<void> {
 		return;
 	}


### PR DESCRIPTION
This is for https://github.com/microsoft/vscode/issues/130367 and adds native ESM support for extensions. 

* use `import` to load extensions (when they signal ESM support via `type: module` or the `.mjs` suffix
* enables `import('vscode')` for extensions the same way `require('vscode')` works
* enables other, regular ESM imports
* enables ESM extension tests

Support is ONLY for the nodejs extension host and not yet for the web worker extension host.