### PR TITLE
Feature: Explorer: add 'Find Files in Explorer' button for convenience

### DIFF
--- a/src/vs/workbench/contrib/files/browser/views/explorerView.ts
+++ b/src/vs/workbench/contrib/files/browser/views/explorerView.ts
@@ -22,7 +22,7 @@ import { IContextMenuService } from '../../../../../platform/contextview/browser
 import { IContextKeyService, IContextKey, ContextKeyExpr } from '../../../../../platform/contextkey/common/contextkey.js';
 import { ResourceContextKey } from '../../../../common/contextkeys.js';
 import { IDecorationsService } from '../../../../services/decorations/common/decorations.js';
-import { WorkbenchCompressibleAsyncDataTree } from '../../../../../platform/list/browser/listService.js';
+import { IListService, WorkbenchCompressibleAsyncDataTree } from '../../../../../platform/list/browser/listService.js';
 import { DelayedDragHandler } from '../../../../../base/browser/dnd.js';
 import { IEditorService, SIDE_GROUP, ACTIVE_GROUP } from '../../../../services/editor/common/editorService.js';
 import { IViewPaneOptions, ViewPane } from '../../../../browser/parts/views/viewPane.js';
@@ -36,7 +36,7 @@ import { ITelemetryService } from '../../../../../platform/telemetry/common/tele
 import { ExplorerItem, NewExplorerItem } from '../../common/explorerModel.js';
 import { ResourceLabels } from '../../../../browser/labels.js';
 import { IStorageService, StorageScope, StorageTarget } from '../../../../../platform/storage/common/storage.js';
-import { IAsyncDataTreeViewState } from '../../../../../base/browser/ui/tree/asyncDataTree.js';
+import { AsyncDataTree, IAsyncDataTreeViewState } from '../../../../../base/browser/ui/tree/asyncDataTree.js';
 import { FuzzyScore } from '../../../../../base/common/filters.js';
 import { IClipboardService } from '../../../../../platform/clipboard/common/clipboardService.js';
 import { IFileService, FileSystemProviderCapabilities } from '../../../../../platform/files/common/files.js';
@@ -53,7 +53,7 @@ import { ICommandService } from '../../../../../platform/commands/common/command
 import { IEditorResolverService } from '../../../../services/editor/common/editorResolverService.js';
 import { EditorOpenSource } from '../../../../../platform/editor/common/editor.js';
 import { ResourceMap } from '../../../../../base/common/map.js';
-import { AbstractTreePart } from '../../../../../base/browser/ui/tree/abstractTree.js';
+import { AbstractTree, AbstractTreePart } from '../../../../../base/browser/ui/tree/abstractTree.js';
 import { IHoverService } from '../../../../../platform/hover/browser/hover.js';
 
 
@@ -1092,6 +1092,36 @@ registerAction2(class extends Action2 {
 		if (view !== null) {
 			const explorerView = view as ExplorerView;
 			explorerView.collapseAll();
+		}
+	}
+});
+
+registerAction2(class extends Action2 {
+	constructor() {
+		super({
+			id: 'workbench.files.action.findFilesInExplorer',
+			title: nls.localize('findFilesInExplorer', "Find Files in Explorer"),
+			f1: false,
+			icon: Codicon.filter,
+			precondition: CanCreateContext,
+			menu: {
+				id: MenuId.ViewTitle,
+				group: 'navigation',
+				when: ContextKeyExpr.equals('view', VIEW_ID),
+				order: 50
+			}
+		});
+	}
+
+	run(accessor: ServicesAccessor): void {
+		const viewsService = accessor.get(IViewsService);
+		const view = viewsService.getViewWithId(VIEW_ID);
+		if (view !== null) {
+			view.focus();
+			const widget = accessor.get(IListService).lastFocusedList;
+			if (widget instanceof AbstractTree || widget instanceof AsyncDataTree) {
+				widget.openFind();
+			}
 		}
 	}
 });


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Although the 'Find Files in Explorer' operation has provided a shortcut `list.find` (default to `Ctrl+Alt+F`):
* It is not easy to discover
* Users must first switch the focus to the explorer (mouse click or shortcut 'View: Show Explorer' `Ctrl+Shift+E`)

What does this button do?
1. Set focus to Explorer file tree
2. Open find widget

Showcase:

![image](https://github.com/user-attachments/assets/cbd3d41c-a824-467b-b5c8-7e6c3ad720f7)
![image](https://github.com/user-attachments/assets/3377f961-9e5e-45fc-af5d-a1adb986fbb6)

