### PR TITLE
fix #236138: incorrect indentation for TypeScript opening curly brace

### DIFF
--- a/src/vs/editor/common/languages/supports/onEnter.ts
+++ b/src/vs/editor/common/languages/supports/onEnter.ts
@@ -90,6 +90,17 @@ export class OnEnterSupport {
 			}
 		}
 
+		// (3): Cursor right before open bracker logic
+		if (autoIndent >= EditorAutoIndentStrategy.Brackets) {
+			if (afterEnterText.length > 0) {
+				for (let i = 0, len = this._brackets.length; i < len; i++) {
+					const bracket = this._brackets[i];
+					if (afterEnterText.trim().startsWith(bracket.open)) {
+						return { indentAction: IndentAction.None };
+					}
+				}
+			}
+		}
 
 		// (4): Open bracket based logic
 		if (autoIndent >= EditorAutoIndentStrategy.Brackets) {

--- a/src/vs/editor/test/common/modes/supports/onEnter.test.ts
+++ b/src/vs/editor/test/common/modes/supports/onEnter.test.ts
@@ -189,4 +189,28 @@ suite('OnEnter', () => {
 		testIndentAction('const r = /{[0-9]/;', '', IndentAction.None);
 		testIndentAction('const r = /[a-zA-Z]{/;', '', IndentAction.None);
 	});
+
+	test('issue #236138', () => {
+		const brackets: CharacterPair[] = [
+			['{', '}'],
+			['(', ')'],
+			['[', ']']
+		];
+		const support = new OnEnterSupport({
+			brackets: brackets
+		});
+		const testIndentAction = (beforeText: string, afterText: string, expected: IndentAction) => {
+			const actual = support.onEnter(EditorAutoIndentStrategy.Advanced, '', beforeText, afterText);
+			if (expected === IndentAction.None) {
+				assert.deepStrictEqual(actual, { indentAction: IndentAction.None });
+			} else {
+				assert.strictEqual(actual!.indentAction, expected);
+			}
+		};
+
+		testIndentAction('public test()', '{', IndentAction.None);
+		testIndentAction('if (condition)', '{', IndentAction.None);
+		testIndentAction('const v =', '(', IndentAction.None);
+		testIndentAction('rules:', '[', IndentAction.None);
+	});
 });


### PR DESCRIPTION
This pull request addresses a bug (issue #236138) where, in a TypeScript file, if the cursor is immediately before an open bracket and Enter is clicked, the bracket would be indented instead of aligned with the previous line.
This issue happened because in the conditions of onEnter the case where the cursor was before an open bracket was never checked.
To fix this, a condition was added to check if the new line created with Enter starts with an open bracket and set IndentAction to None if this condition is satisfied. 
A test was added to verify this solution for the different types of brackets.