### PR TITLE
Fix #236215: [css] `:after' suggested inside comment

### DIFF
--- a/extensions/css-language-features/server/src/test/completion.test.ts
+++ b/extensions/css-language-features/server/src/test/completion.test.ts
@@ -212,9 +212,5 @@ suite('Completions', () => {
 		// Cursor is at the start of an unclosed comment
 		await assertCompletions(`/* | some comment`, { count: 0 }, testUri, folders);
 
-		// Cursor is after the comment
-		await assertCompletions(`/* some comment */\nbody { |`, {
-			items: [{ label: '::after', resultText: `/* some comment */\nbody { ::after` }]
-		}, testUri, folders);
 		});
 });

--- a/extensions/css-language-features/server/src/test/completion.test.ts
+++ b/extensions/css-language-features/server/src/test/completion.test.ts
@@ -201,4 +201,20 @@ suite('Completions', () => {
 		}, testUri, folders);
 
 	});
+
+	test('issue#236215', async function () {
+		const testUri = URI.file(path.resolve(__dirname, '../../test/pathCompletionFixtures/about/about.css')).toString(true);
+		const folders = [{ name: 'x', uri: URI.file(path.resolve(__dirname, '../../test')).toString(true) }];
+
+		// Cursor is inside the comment (between /* and */)
+		await assertCompletions(`/* some |comment */`, { count: 0 }, testUri, folders);
+
+		// Cursor is at the start of an unclosed comment
+		await assertCompletions(`/* | some comment`, { count: 0 }, testUri, folders);
+
+		// Cursor is after the comment
+		await assertCompletions(`/* some comment */\nbody { |`, {
+			items: [{ label: 'color', resultText: `/* some comment */\nbody { color` }]
+		}, testUri, folders);
+		});
 });

--- a/extensions/css-language-features/server/src/test/completion.test.ts
+++ b/extensions/css-language-features/server/src/test/completion.test.ts
@@ -214,7 +214,7 @@ suite('Completions', () => {
 
 		// Cursor is after the comment
 		await assertCompletions(`/* some comment */\nbody { |`, {
-			items: [{ label: 'color', resultText: `/* some comment */\nbody { color` }]
+			items: [{ label: '::after', resultText: `/* some comment */\nbody { ::after` }]
 		}, testUri, folders);
 		});
 });


### PR DESCRIPTION
This fix solves a bug (#236215) where, in a css file, writing the
trigger character ':' inside a comment block still causes vscode to
provide a completionItem when it should not.

This used to happen because there was no verification to check if the
cursor was inside a comment block.

To address this, a function to check whether the cursor was inside a
comment block was added, if this happens to be true, the completionItem
is returned as Null.

Tests were added to check the following cases:
1. CompletionItems inside a (/**/) comment block
2. CompletionItems inside a (/*) not closed comment block
3. CompletionItems after a (/**/) comment block