### PR TITLE
testing: fix "1 older results" in "Show Output" window has grammatical error

### DIFF
--- a/src/vs/workbench/contrib/testing/browser/testResultsView/testResultsTree.ts
+++ b/src/vs/workbench/contrib/testing/browser/testResultsView/testResultsTree.ts
@@ -137,7 +137,9 @@ class OlderResultsElement implements ITreeElement {
 	public readonly label: string;
 
 	constructor(private readonly n: number) {
-		this.label = localize('nOlderResults', '{0} older results', n);
+		this.label = n === 1
+			? localize('oneOlderResult', '1 older result')
+			: localize('nOlderResults', '{0} older results', n);
 		this.id = `older-${this.n}`;
 
 	}


### PR DESCRIPTION
Fixes #244218

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
