### PR TITLE
Extension search box updates

### DIFF
--- a/src/vs/workbench/contrib/extensions/browser/media/extensionsViewlet.css
+++ b/src/vs/workbench/contrib/extensions/browser/media/extensionsViewlet.css
@@ -52,6 +52,10 @@
 	height: 100%;
 }
 
+.extensions-viewlet > .header  > .extensions-search-container >  .extensions-search-actions-container > .monaco-toolbar > .monaco-action-bar {
+	background-color: blue;
+}
+
 .extensions-viewlet > .header > .notification-container {
 	margin-top: 10px;
 	display: flex;

--- a/src/vs/workbench/contrib/extensions/browser/media/extensionsViewlet.css
+++ b/src/vs/workbench/contrib/extensions/browser/media/extensionsViewlet.css
@@ -32,6 +32,10 @@
 	position: relative;
 }
 
+.extensions-viewlet > .header  > .extensions-search-container > .suggest-input-container {
+	padding: 4px 6px;
+}
+
 .extensions-viewlet > .header  > .extensions-search-container >  .search-box {
 	width: 100%;
 	height: 28px;
@@ -48,12 +52,15 @@
 	align-items: center;
 	position: absolute;
 	top: 0;
-	right: 0;
+	right: 4px;
 	height: 100%;
 }
 
-.extensions-viewlet > .header  > .extensions-search-container >  .extensions-search-actions-container > .monaco-toolbar > .monaco-action-bar {
-	background-color: blue;
+.extensions-viewlet > .header > .extensions-search-container > .extensions-search-actions-container >
+.monaco-toolbar > .monaco-action-bar > .actions-container > * > .action-label,
+.extensions-viewlet > .header > .extensions-search-container > .extensions-search-actions-container >
+.monaco-toolbar > .monaco-action-bar > .actions-container > * > .monaco-dropdown > * > .action-label {
+	padding: 4px;
 }
 
 .extensions-viewlet > .header > .notification-container {


### PR DESCRIPTION
Addresses #222103 

This pull request includes changes to the `src/vs/workbench/contrib/extensions/browser/media/extensionsViewlet.css` file to improve the layout and padding of the extensions viewlet's search container and actions, in order to meet mininum accessible button sizes for `clear` & `filter`

Styling improvements:

* Added padding to the `.suggest-input-container` within the `.extensions-search-container` to enhance spacing.
* Adjusted the `right` position of the `.search-box` to 4px for better alignment.
* Added padding to the `.action-label` within the `.extensions-search-actions-container` for consistent spacing in the toolbar.<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
