### PR TITLE
chat: don't duplicate modified entries in every edit stop

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingSession.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingSession.ts
@@ -4,19 +4,18 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { equals as arraysEqual, binarySearch2 } from '../../../../../base/common/arrays.js';
+import { findLast } from '../../../../../base/common/arraysFind.js';
 import { DeferredPromise, ITask, Sequencer, SequencerByKey, timeout } from '../../../../../base/common/async.js';
-import { VSBuffer } from '../../../../../base/common/buffer.js';
+import { CancellationToken } from '../../../../../base/common/cancellation.js';
 import { BugIndicatingError } from '../../../../../base/common/errors.js';
 import { Emitter } from '../../../../../base/common/event.js';
-import { StringSHA1 } from '../../../../../base/common/hash.js';
 import { Iterable } from '../../../../../base/common/iterator.js';
 import { Disposable, dispose } from '../../../../../base/common/lifecycle.js';
 import { ResourceMap } from '../../../../../base/common/map.js';
 import { asyncTransaction, autorun, derived, derivedOpts, derivedWithStore, IObservable, IReader, ITransaction, ObservablePromise, observableValue, transaction } from '../../../../../base/common/observable.js';
-import { isEqual, joinPath } from '../../../../../base/common/resources.js';
+import { isEqual } from '../../../../../base/common/resources.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { IBulkEditService } from '../../../../../editor/browser/services/bulkEditService.js';
-import { IOffsetEdit, ISingleOffsetEdit, OffsetEdit } from '../../../../../editor/common/core/offsetEdit.js';
 import { TextEdit } from '../../../../../editor/common/languages.js';
 import { ILanguageService } from '../../../../../editor/common/languages/language.js';
 import { ITextModel } from '../../../../../editor/common/model.js';
@@ -24,34 +23,28 @@ import { IEditorWorkerService } from '../../../../../editor/common/services/edit
 import { IModelService } from '../../../../../editor/common/services/model.js';
 import { ITextModelService } from '../../../../../editor/common/services/resolverService.js';
 import { localize } from '../../../../../nls.js';
+import { AccessibilitySignal, IAccessibilitySignalService } from '../../../../../platform/accessibilitySignal/browser/accessibilitySignalService.js';
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 import { EditorActivation } from '../../../../../platform/editor/common/editor.js';
-import { IEnvironmentService } from '../../../../../platform/environment/common/environment.js';
-import { IFileService } from '../../../../../platform/files/common/files.js';
 import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
-import { ILogService } from '../../../../../platform/log/common/log.js';
 import { observableConfigValue } from '../../../../../platform/observable/common/platformObservableUtils.js';
-import { IWorkspaceContextService } from '../../../../../platform/workspace/common/workspace.js';
 import { DiffEditorInput } from '../../../../common/editor/diffEditorInput.js';
 import { IEditorGroupsService } from '../../../../services/editor/common/editorGroupsService.js';
 import { IEditorService } from '../../../../services/editor/common/editorService.js';
 import { MultiDiffEditor } from '../../../multiDiffEditor/browser/multiDiffEditor.js';
 import { MultiDiffEditorInput } from '../../../multiDiffEditor/browser/multiDiffEditorInput.js';
+import { CellUri, ICellEditOperation } from '../../../notebook/common/notebookCommon.js';
 import { INotebookService } from '../../../notebook/common/notebookService.js';
-import { ChatEditingSessionState, ChatEditKind, getMultiDiffSourceUri, IChatEditingSession, IEditSessionEntryDiff, IModifiedFileEntry, IStreamingEdits, WorkingSetDisplayMetadata, ModifiedFileEntryState } from '../../common/chatEditingService.js';
+import { ChatEditingSessionState, ChatEditKind, getMultiDiffSourceUri, IChatEditingSession, IEditSessionEntryDiff, IModifiedFileEntry, IStreamingEdits, ModifiedFileEntryState } from '../../common/chatEditingService.js';
 import { IChatRequestDisablement, IChatResponseModel } from '../../common/chatModel.js';
 import { IChatService } from '../../common/chatService.js';
-import { AbstractChatEditingModifiedFileEntry, IModifiedEntryTelemetryInfo, ISnapshotEntry } from './chatEditingModifiedFileEntry.js';
 import { ChatEditingModifiedDocumentEntry } from './chatEditingModifiedDocumentEntry.js';
-import { ChatEditingTextModelContentProvider } from './chatEditingTextModelContentProviders.js';
-import { CellUri, ICellEditOperation } from '../../../notebook/common/notebookCommon.js';
+import { AbstractChatEditingModifiedFileEntry, IModifiedEntryTelemetryInfo, ISnapshotEntry } from './chatEditingModifiedFileEntry.js';
 import { ChatEditingModifiedNotebookEntry } from './chatEditingModifiedNotebookEntry.js';
-import { CancellationToken } from '../../../../../base/common/cancellation.js';
+import { ChatEditingSessionStorage, IChatEditingSessionSnapshot, IChatEditingSessionStop, StoredSessionState } from './chatEditingSessionStorage.js';
+import { ChatEditingTextModelContentProvider } from './chatEditingTextModelContentProviders.js';
 import { ChatEditingModifiedNotebookDiff } from './notebook/chatEditingModifiedNotebookDiff.js';
-import { AccessibilitySignal, IAccessibilitySignalService } from '../../../../../platform/accessibilitySignal/browser/accessibilitySignalService.js';
 
-const STORAGE_CONTENTS_FOLDER = 'contents';
-const STORAGE_STATE_FILE = 'state.json';
 const POST_EDIT_STOP_ID = 'd19944f6-f46c-4e17-911b-79a8e843c7c0'; // randomly generated
 
 class ThrottledSequencer extends Sequencer {
@@ -130,15 +123,21 @@ function getFirstAndLastStop(uri: URI, history: readonly IChatEditingSessionSnap
 			break;
 		}
 	}
-	const lastSnapshot = history.at(-1);
 
-	const last = lastSnapshot?.postEdit ?? lastSnapshot?.stops.at(-1)?.entries;
+	let lastStopWithUri: IChatEditingSessionStop | undefined;
+	for (let i = history.length - 1; i >= 0; i--) {
+		const stop = findLast(history[i].stops, s => s.entries.has(uri));
+		if (stop) {
+			lastStopWithUri = stop;
+			break;
+		}
+	}
 
-	if (!firstStopWithUri || !last) {
+	if (!firstStopWithUri || !lastStopWithUri) {
 		return undefined;
 	}
 
-	return { current: firstStopWithUri.entries, next: last };
+	return { current: firstStopWithUri.entries, next: lastStopWithUri.entries };
 }
 
 export class ChatEditingSession extends Disposable implements IChatEditingSession {
@@ -408,8 +407,8 @@ export class ChatEditingSession extends Disposable implements IChatEditingSessio
 		}
 	}
 
-	public createSnapshot(requestId: string, undoStop: string | undefined): void {
-		const snapshot = this._createSnapshot(requestId, undoStop);
+	public createSnapshot(requestId: string, undoStop: string | undefined, makeEmpty = undoStop !== undefined): void {
+		const snapshot = makeEmpty ? this._createEmptySnapshot(undoStop) : this._createSnapshot(requestId, undoStop);
 
 		const linearHistoryPtr = this._linearHistoryIndex.get();
 		const newLinearHistory: IChatEditingSessionSnapshot[] = [];
@@ -433,6 +432,13 @@ export class ChatEditingSession extends Disposable implements IChatEditingSessio
 			this._linearHistory.set(newLinearHistory, tx);
 			this._linearHistoryIndex.set(last.startIndex + last.stops.length, tx);
 		});
+	}
+
+	private _createEmptySnapshot(undoStop: string | undefined): IChatEditingSessionStop {
+		return {
+			stopId: undoStop,
+			entries: new ResourceMap(),
+		};
 	}
 
 	private _createSnapshot(requestId: string | undefined, undoStop: string | undefined): IChatEditingSessionStop {
@@ -812,7 +818,7 @@ export class ChatEditingSession extends Disposable implements IChatEditingSessio
 		// special case: put the last change in the pendingSnapshot as needed
 		if (next) {
 			if (stopIndex === snap.stops.length - 1) {
-				const postEdit = new ResourceMap(snap.postEdit || this._createSnapshot(requestId, undefined).entries);
+				const postEdit = new ResourceMap(snap.postEdit || this._createEmptySnapshot(undefined).entries);
 				if (!snap.postEdit || !entry.equalsSnapshot(postEdit.get(entry.modifiedURI))) {
 					postEdit.set(entry.modifiedURI, entry.createSnapshot(requestId, POST_EDIT_STOP_ID));
 					const newHistory = history.slice();
@@ -963,288 +969,4 @@ export class ChatEditingSession extends Disposable implements IChatEditingSessio
 				?.collapsed.set(true, transaction);
 		}
 	}
-}
-
-interface StoredSessionState {
-	readonly initialFileContents: ResourceMap<string>;
-	readonly pendingSnapshot?: IChatEditingSessionStop;
-	readonly recentSnapshot: IChatEditingSessionStop;
-	readonly linearHistoryIndex: number;
-	readonly linearHistory: readonly IChatEditingSessionSnapshot[];
-}
-
-class ChatEditingSessionStorage {
-	constructor(
-		private readonly chatSessionId: string,
-		@IFileService private readonly _fileService: IFileService,
-		@IEnvironmentService private readonly _environmentService: IEnvironmentService,
-		@ILogService private readonly _logService: ILogService,
-		@IWorkspaceContextService private readonly _workspaceContextService: IWorkspaceContextService,
-	) { }
-
-	private _getStorageLocation(): URI {
-		const workspaceId = this._workspaceContextService.getWorkspace().id;
-		return joinPath(this._environmentService.workspaceStorageHome, workspaceId, 'chatEditingSessions', this.chatSessionId);
-	}
-
-	public async restoreState(): Promise<StoredSessionState | undefined> {
-		const storageLocation = this._getStorageLocation();
-		const fileContents = new Map<string, Promise<string>>();
-		const getFileContent = (hash: string) => {
-			let readPromise = fileContents.get(hash);
-			if (!readPromise) {
-				readPromise = this._fileService.readFile(joinPath(storageLocation, STORAGE_CONTENTS_FOLDER, hash)).then(content => content.value.toString());
-				fileContents.set(hash, readPromise);
-			}
-			return readPromise;
-		};
-		const deserializeSnapshotEntriesDTO = async (dtoEntries: ISnapshotEntryDTO[]): Promise<ResourceMap<ISnapshotEntry>> => {
-			const entries = new ResourceMap<ISnapshotEntry>();
-			for (const entryDTO of dtoEntries) {
-				const entry = await deserializeSnapshotEntry(entryDTO);
-				entries.set(entry.resource, entry);
-			}
-			return entries;
-		};
-		const deserializeChatEditingStopDTO = async (stopDTO: IChatEditingSessionStopDTO | IChatEditingSessionSnapshotDTO): Promise<IChatEditingSessionStop> => {
-			const entries = await deserializeSnapshotEntriesDTO(stopDTO.entries);
-			return { stopId: 'stopId' in stopDTO ? stopDTO.stopId : undefined, entries };
-		};
-		const normalizeSnapshotDtos = (snapshot: IChatEditingSessionSnapshotDTO | IChatEditingSessionSnapshotDTO2): IChatEditingSessionSnapshotDTO2 => {
-			if ('stops' in snapshot) {
-				return snapshot;
-			}
-			return { requestId: snapshot.requestId, stops: [{ stopId: undefined, entries: snapshot.entries }], postEdit: undefined };
-		};
-		const deserializeChatEditingSessionSnapshot = async (startIndex: number, snapshot: IChatEditingSessionSnapshotDTO2): Promise<IChatEditingSessionSnapshot> => {
-			const stops = await Promise.all(snapshot.stops.map(deserializeChatEditingStopDTO));
-			return { startIndex, requestId: snapshot.requestId, stops, postEdit: snapshot.postEdit && await deserializeSnapshotEntriesDTO(snapshot.postEdit) };
-		};
-		const deserializeSnapshotEntry = async (entry: ISnapshotEntryDTO) => {
-			return {
-				resource: URI.parse(entry.resource),
-				languageId: entry.languageId,
-				original: await getFileContent(entry.originalHash),
-				current: await getFileContent(entry.currentHash),
-				originalToCurrentEdit: OffsetEdit.fromJson(entry.originalToCurrentEdit),
-				state: entry.state,
-				snapshotUri: URI.parse(entry.snapshotUri),
-				telemetryInfo: { requestId: entry.telemetryInfo.requestId, agentId: entry.telemetryInfo.agentId, command: entry.telemetryInfo.command, sessionId: this.chatSessionId, result: undefined }
-			} satisfies ISnapshotEntry;
-		};
-		try {
-			const stateFilePath = joinPath(storageLocation, STORAGE_STATE_FILE);
-			if (! await this._fileService.exists(stateFilePath)) {
-				this._logService.debug(`chatEditingSession: No editing session state found at ${stateFilePath.toString()}`);
-				return undefined;
-			}
-			this._logService.debug(`chatEditingSession: Restoring editing session at ${stateFilePath.toString()}`);
-			const stateFileContent = await this._fileService.readFile(stateFilePath);
-			const data = JSON.parse(stateFileContent.value.toString()) as IChatEditingSessionDTO;
-			if (!COMPATIBLE_STORAGE_VERSIONS.includes(data.version)) {
-				return undefined;
-			}
-
-			let linearHistoryIndex = 0;
-			const linearHistory = await Promise.all(data.linearHistory.map(snapshot => {
-				const norm = normalizeSnapshotDtos(snapshot);
-				const result = deserializeChatEditingSessionSnapshot(linearHistoryIndex, norm);
-				linearHistoryIndex += norm.stops.length;
-				return result;
-			}));
-
-			const initialFileContents = new ResourceMap<string>();
-			for (const fileContentDTO of data.initialFileContents) {
-				initialFileContents.set(URI.parse(fileContentDTO[0]), await getFileContent(fileContentDTO[1]));
-			}
-			const pendingSnapshot = data.pendingSnapshot ? await deserializeChatEditingStopDTO(data.pendingSnapshot) : undefined;
-			const recentSnapshot = await deserializeChatEditingStopDTO(data.recentSnapshot);
-
-			return {
-				initialFileContents,
-				pendingSnapshot,
-				recentSnapshot,
-				linearHistoryIndex: data.linearHistoryIndex,
-				linearHistory
-			};
-		} catch (e) {
-			this._logService.error(`Error restoring chat editing session from ${storageLocation.toString()}`, e);
-		}
-		return undefined;
-	}
-
-	public async storeState(state: StoredSessionState): Promise<void> {
-		const storageFolder = this._getStorageLocation();
-		const contentsFolder = URI.joinPath(storageFolder, STORAGE_CONTENTS_FOLDER);
-
-		// prepare the content folder
-		const existingContents = new Set<string>();
-		try {
-			const stat = await this._fileService.resolve(contentsFolder);
-			stat.children?.forEach(child => {
-				if (child.isFile) {
-					existingContents.add(child.name);
-				}
-			});
-		} catch (e) {
-			try {
-				// does not exist, create
-				await this._fileService.createFolder(contentsFolder);
-			} catch (e) {
-				this._logService.error(`Error creating chat editing session content folder ${contentsFolder.toString()}`, e);
-				return;
-			}
-		}
-
-		const fileContents = new Map<string, string>();
-		const addFileContent = (content: string): string => {
-			const shaComputer = new StringSHA1();
-			shaComputer.update(content);
-			const sha = shaComputer.digest().substring(0, 7);
-			fileContents.set(sha, content);
-			return sha;
-		};
-		const serializeResourceMap = <T>(resourceMap: ResourceMap<T>, serialize: (value: T) => any): ResourceMapDTO<T> => {
-			return Array.from(resourceMap.entries()).map(([resourceURI, value]) => [resourceURI.toString(), serialize(value)]);
-		};
-		const serializeChatEditingSessionStop = (stop: IChatEditingSessionStop): IChatEditingSessionStopDTO => {
-			return {
-				stopId: stop.stopId,
-				entries: Array.from(stop.entries.values()).map(serializeSnapshotEntry)
-			};
-		};
-		const serializeChatEditingSessionSnapshot = (snapshot: IChatEditingSessionSnapshot): IChatEditingSessionSnapshotDTO2 => {
-			return {
-				requestId: snapshot.requestId,
-				stops: snapshot.stops.map(serializeChatEditingSessionStop),
-				postEdit: snapshot.postEdit ? Array.from(snapshot.postEdit.values()).map(serializeSnapshotEntry) : undefined
-			};
-		};
-		const serializeSnapshotEntry = (entry: ISnapshotEntry): ISnapshotEntryDTO => {
-			return {
-				resource: entry.resource.toString(),
-				languageId: entry.languageId,
-				originalHash: addFileContent(entry.original),
-				currentHash: addFileContent(entry.current),
-				originalToCurrentEdit: entry.originalToCurrentEdit.edits.map(edit => ({ pos: edit.replaceRange.start, len: edit.replaceRange.length, txt: edit.newText } satisfies ISingleOffsetEdit)),
-				state: entry.state,
-				snapshotUri: entry.snapshotUri.toString(),
-				telemetryInfo: { requestId: entry.telemetryInfo.requestId, agentId: entry.telemetryInfo.agentId, command: entry.telemetryInfo.command }
-			};
-		};
-
-		try {
-			const data: IChatEditingSessionDTO = {
-				version: STORAGE_VERSION,
-				sessionId: this.chatSessionId,
-				linearHistory: state.linearHistory.map(serializeChatEditingSessionSnapshot),
-				linearHistoryIndex: state.linearHistoryIndex,
-				initialFileContents: serializeResourceMap(state.initialFileContents, value => addFileContent(value)),
-				pendingSnapshot: state.pendingSnapshot ? serializeChatEditingSessionStop(state.pendingSnapshot) : undefined,
-				recentSnapshot: serializeChatEditingSessionStop(state.recentSnapshot),
-			};
-
-			this._logService.debug(`chatEditingSession: Storing editing session at ${storageFolder.toString()}: ${fileContents.size} files`);
-
-			for (const [hash, content] of fileContents) {
-				if (!existingContents.has(hash)) {
-					await this._fileService.writeFile(joinPath(contentsFolder, hash), VSBuffer.fromString(content));
-				}
-			}
-
-			await this._fileService.writeFile(joinPath(storageFolder, STORAGE_STATE_FILE), VSBuffer.fromString(JSON.stringify(data, undefined, 2)));
-		} catch (e) {
-			this._logService.debug(`Error storing chat editing session to ${storageFolder.toString()}`, e);
-		}
-	}
-
-	public async clearState(): Promise<void> {
-		const storageFolder = this._getStorageLocation();
-		if (await this._fileService.exists(storageFolder)) {
-			this._logService.debug(`chatEditingSession: Clearing editing session at ${storageFolder.toString()}`);
-			try {
-				await this._fileService.del(storageFolder, { recursive: true });
-			} catch (e) {
-				this._logService.debug(`Error clearing chat editing session from ${storageFolder.toString()}`, e);
-			}
-		}
-	}
-}
-
-export interface IChatEditingSessionSnapshot {
-	/**
-	 * Index of this session in the linear history. It's the sum of the lengths
-	 * of all {@link stops} prior this one.
-	 */
-	readonly startIndex: number;
-
-	readonly requestId: string | undefined;
-	/**
-	 * Edit stops in the request. Always initially populatd with stopId: undefind
-	 * for th request's initial state.
-	 *
-	 * Invariant: never empty.
-	 */
-	readonly stops: IChatEditingSessionStop[];
-
-	/** Stop that represents changes after the last undo stop, kept for diffing purposes. */
-	readonly postEdit: ResourceMap<ISnapshotEntry> | undefined;
-}
-
-interface IChatEditingSessionStop {
-	/** Edit stop ID, first for a request is always undefined. */
-	stopId: string | undefined;
-
-	readonly entries: ResourceMap<ISnapshotEntry>;
-}
-
-interface IChatEditingSessionStopDTO {
-	readonly stopId: string | undefined;
-	readonly entries: ISnapshotEntryDTO[];
-}
-
-
-interface IChatEditingSessionSnapshotDTO {
-	readonly requestId: string | undefined;
-	readonly workingSet: ResourceMapDTO<WorkingSetDisplayMetadata>;
-	readonly entries: ISnapshotEntryDTO[];
-}
-
-interface IChatEditingSessionSnapshotDTO2 {
-	readonly requestId: string | undefined;
-	readonly stops: IChatEditingSessionStopDTO[];
-	readonly postEdit: ISnapshotEntryDTO[] | undefined;
-}
-
-interface ISnapshotEntryDTO {
-	readonly resource: string;
-	readonly languageId: string;
-	readonly originalHash: string;
-	readonly currentHash: string;
-	readonly originalToCurrentEdit: IOffsetEdit;
-	readonly state: ModifiedFileEntryState;
-	readonly snapshotUri: string;
-	readonly telemetryInfo: IModifiedEntryTelemetryInfoDTO;
-}
-
-interface IModifiedEntryTelemetryInfoDTO {
-	readonly requestId: string;
-	readonly agentId?: string;
-	readonly command?: string;
-}
-
-type ResourceMapDTO<T> = [string, T][];
-
-const COMPATIBLE_STORAGE_VERSIONS = [1, 2];
-const STORAGE_VERSION = 2;
-
-/** Old history uses IChatEditingSessionSnapshotDTO, new history uses IChatEditingSessionSnapshotDTO. */
-interface IChatEditingSessionDTO {
-	readonly version: number;
-	readonly sessionId: string;
-	readonly recentSnapshot: (IChatEditingSessionStopDTO | IChatEditingSessionSnapshotDTO);
-	readonly linearHistory: (IChatEditingSessionSnapshotDTO2 | IChatEditingSessionSnapshotDTO)[];
-	readonly linearHistoryIndex: number;
-	readonly pendingSnapshot: (IChatEditingSessionStopDTO | IChatEditingSessionSnapshotDTO) | undefined;
-	readonly initialFileContents: ResourceMapDTO<string>;
 }

--- a/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingSessionStorage.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingSessionStorage.ts
@@ -1,0 +1,304 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { VSBuffer } from '../../../../../base/common/buffer.js';
+import { StringSHA1 } from '../../../../../base/common/hash.js';
+import { ResourceMap } from '../../../../../base/common/map.js';
+import { joinPath } from '../../../../../base/common/resources.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { OffsetEdit, ISingleOffsetEdit, IOffsetEdit } from '../../../../../editor/common/core/offsetEdit.js';
+import { IEnvironmentService } from '../../../../../platform/environment/common/environment.js';
+import { IFileService } from '../../../../../platform/files/common/files.js';
+import { ILogService } from '../../../../../platform/log/common/log.js';
+import { IWorkspaceContextService } from '../../../../../platform/workspace/common/workspace.js';
+import { ISnapshotEntry } from './chatEditingModifiedFileEntry.js';
+import { WorkingSetDisplayMetadata, ModifiedFileEntryState } from '../../common/chatEditingService.js';
+
+const STORAGE_CONTENTS_FOLDER = 'contents';
+const STORAGE_STATE_FILE = 'state.json';
+
+export interface StoredSessionState {
+	readonly initialFileContents: ResourceMap<string>;
+	readonly pendingSnapshot?: IChatEditingSessionStop;
+	readonly recentSnapshot: IChatEditingSessionStop;
+	readonly linearHistoryIndex: number;
+	readonly linearHistory: readonly IChatEditingSessionSnapshot[];
+}
+
+export class ChatEditingSessionStorage {
+	constructor(
+		private readonly chatSessionId: string,
+		@IFileService private readonly _fileService: IFileService,
+		@IEnvironmentService private readonly _environmentService: IEnvironmentService,
+		@ILogService private readonly _logService: ILogService,
+		@IWorkspaceContextService private readonly _workspaceContextService: IWorkspaceContextService,
+	) { }
+
+	protected _getStorageLocation(): URI {
+		const workspaceId = this._workspaceContextService.getWorkspace().id;
+		return joinPath(this._environmentService.workspaceStorageHome, workspaceId, 'chatEditingSessions', this.chatSessionId);
+	}
+
+	public async restoreState(): Promise<StoredSessionState | undefined> {
+		const storageLocation = this._getStorageLocation();
+		const fileContents = new Map<string, Promise<string>>();
+		const getFileContent = (hash: string) => {
+			let readPromise = fileContents.get(hash);
+			if (!readPromise) {
+				readPromise = this._fileService.readFile(joinPath(storageLocation, STORAGE_CONTENTS_FOLDER, hash)).then(content => content.value.toString());
+				fileContents.set(hash, readPromise);
+			}
+			return readPromise;
+		};
+		const deserializeSnapshotEntriesDTO = async (dtoEntries: ISnapshotEntryDTO[]): Promise<ResourceMap<ISnapshotEntry>> => {
+			const entries = new ResourceMap<ISnapshotEntry>();
+			for (const entryDTO of dtoEntries) {
+				const entry = await deserializeSnapshotEntry(entryDTO);
+				entries.set(entry.resource, entry);
+			}
+			return entries;
+		};
+		const deserializeChatEditingStopDTO = async (stopDTO: IChatEditingSessionStopDTO | IChatEditingSessionSnapshotDTO): Promise<IChatEditingSessionStop> => {
+			const entries = await deserializeSnapshotEntriesDTO(stopDTO.entries);
+			return { stopId: 'stopId' in stopDTO ? stopDTO.stopId : undefined, entries };
+		};
+		const normalizeSnapshotDtos = (snapshot: IChatEditingSessionSnapshotDTO | IChatEditingSessionSnapshotDTO2): IChatEditingSessionSnapshotDTO2 => {
+			if ('stops' in snapshot) {
+				return snapshot;
+			}
+			return { requestId: snapshot.requestId, stops: [{ stopId: undefined, entries: snapshot.entries }], postEdit: undefined };
+		};
+		const deserializeChatEditingSessionSnapshot = async (startIndex: number, snapshot: IChatEditingSessionSnapshotDTO2): Promise<IChatEditingSessionSnapshot> => {
+			const stops = await Promise.all(snapshot.stops.map(deserializeChatEditingStopDTO));
+			return { startIndex, requestId: snapshot.requestId, stops, postEdit: snapshot.postEdit && await deserializeSnapshotEntriesDTO(snapshot.postEdit) };
+		};
+		const deserializeSnapshotEntry = async (entry: ISnapshotEntryDTO) => {
+			return {
+				resource: URI.parse(entry.resource),
+				languageId: entry.languageId,
+				original: await getFileContent(entry.originalHash),
+				current: await getFileContent(entry.currentHash),
+				originalToCurrentEdit: OffsetEdit.fromJson(entry.originalToCurrentEdit),
+				state: entry.state,
+				snapshotUri: URI.parse(entry.snapshotUri),
+				telemetryInfo: { requestId: entry.telemetryInfo.requestId, agentId: entry.telemetryInfo.agentId, command: entry.telemetryInfo.command, sessionId: this.chatSessionId, result: undefined }
+			} satisfies ISnapshotEntry;
+		};
+		try {
+			const stateFilePath = joinPath(storageLocation, STORAGE_STATE_FILE);
+			if (! await this._fileService.exists(stateFilePath)) {
+				this._logService.debug(`chatEditingSession: No editing session state found at ${stateFilePath.toString()}`);
+				return undefined;
+			}
+			this._logService.debug(`chatEditingSession: Restoring editing session at ${stateFilePath.toString()}`);
+			const stateFileContent = await this._fileService.readFile(stateFilePath);
+			const data = JSON.parse(stateFileContent.value.toString()) as IChatEditingSessionDTO;
+			if (!COMPATIBLE_STORAGE_VERSIONS.includes(data.version)) {
+				return undefined;
+			}
+
+			let linearHistoryIndex = 0;
+			const linearHistory = await Promise.all(data.linearHistory.map(snapshot => {
+				const norm = normalizeSnapshotDtos(snapshot);
+				const result = deserializeChatEditingSessionSnapshot(linearHistoryIndex, norm);
+				linearHistoryIndex += norm.stops.length;
+				return result;
+			}));
+
+			const initialFileContents = new ResourceMap<string>();
+			for (const fileContentDTO of data.initialFileContents) {
+				initialFileContents.set(URI.parse(fileContentDTO[0]), await getFileContent(fileContentDTO[1]));
+			}
+			const pendingSnapshot = data.pendingSnapshot ? await deserializeChatEditingStopDTO(data.pendingSnapshot) : undefined;
+			const recentSnapshot = await deserializeChatEditingStopDTO(data.recentSnapshot);
+
+			return {
+				initialFileContents,
+				pendingSnapshot,
+				recentSnapshot,
+				linearHistoryIndex: data.linearHistoryIndex,
+				linearHistory
+			};
+		} catch (e) {
+			this._logService.error(`Error restoring chat editing session from ${storageLocation.toString()}`, e);
+		}
+		return undefined;
+	}
+
+	public async storeState(state: StoredSessionState): Promise<void> {
+		const storageFolder = this._getStorageLocation();
+		const contentsFolder = URI.joinPath(storageFolder, STORAGE_CONTENTS_FOLDER);
+
+		// prepare the content folder
+		const existingContents = new Set<string>();
+		try {
+			const stat = await this._fileService.resolve(contentsFolder);
+			stat.children?.forEach(child => {
+				if (child.isFile) {
+					existingContents.add(child.name);
+				}
+			});
+		} catch (e) {
+			try {
+				// does not exist, create
+				await this._fileService.createFolder(contentsFolder);
+			} catch (e) {
+				this._logService.error(`Error creating chat editing session content folder ${contentsFolder.toString()}`, e);
+				return;
+			}
+		}
+
+		const fileContents = new Map<string, string>();
+		const addFileContent = (content: string): string => {
+			const shaComputer = new StringSHA1();
+			shaComputer.update(content);
+			const sha = shaComputer.digest().substring(0, 7);
+			fileContents.set(sha, content);
+			return sha;
+		};
+		const serializeResourceMap = <T>(resourceMap: ResourceMap<T>, serialize: (value: T) => any): ResourceMapDTO<T> => {
+			return Array.from(resourceMap.entries()).map(([resourceURI, value]) => [resourceURI.toString(), serialize(value)]);
+		};
+		const serializeChatEditingSessionStop = (stop: IChatEditingSessionStop): IChatEditingSessionStopDTO => {
+			return {
+				stopId: stop.stopId,
+				entries: Array.from(stop.entries.values()).map(serializeSnapshotEntry)
+			};
+		};
+		const serializeChatEditingSessionSnapshot = (snapshot: IChatEditingSessionSnapshot): IChatEditingSessionSnapshotDTO2 => {
+			return {
+				requestId: snapshot.requestId,
+				stops: snapshot.stops.map(serializeChatEditingSessionStop),
+				postEdit: snapshot.postEdit ? Array.from(snapshot.postEdit.values()).map(serializeSnapshotEntry) : undefined
+			};
+		};
+		const serializeSnapshotEntry = (entry: ISnapshotEntry): ISnapshotEntryDTO => {
+			return {
+				resource: entry.resource.toString(),
+				languageId: entry.languageId,
+				originalHash: addFileContent(entry.original),
+				currentHash: addFileContent(entry.current),
+				originalToCurrentEdit: entry.originalToCurrentEdit.edits.map(edit => ({ pos: edit.replaceRange.start, len: edit.replaceRange.length, txt: edit.newText } satisfies ISingleOffsetEdit)),
+				state: entry.state,
+				snapshotUri: entry.snapshotUri.toString(),
+				telemetryInfo: { requestId: entry.telemetryInfo.requestId, agentId: entry.telemetryInfo.agentId, command: entry.telemetryInfo.command }
+			};
+		};
+
+		try {
+			const data: IChatEditingSessionDTO = {
+				version: STORAGE_VERSION,
+				sessionId: this.chatSessionId,
+				linearHistory: state.linearHistory.map(serializeChatEditingSessionSnapshot),
+				linearHistoryIndex: state.linearHistoryIndex,
+				initialFileContents: serializeResourceMap(state.initialFileContents, value => addFileContent(value)),
+				pendingSnapshot: state.pendingSnapshot ? serializeChatEditingSessionStop(state.pendingSnapshot) : undefined,
+				recentSnapshot: serializeChatEditingSessionStop(state.recentSnapshot),
+			};
+
+			this._logService.debug(`chatEditingSession: Storing editing session at ${storageFolder.toString()}: ${fileContents.size} files`);
+
+			for (const [hash, content] of fileContents) {
+				if (!existingContents.has(hash)) {
+					await this._fileService.writeFile(joinPath(contentsFolder, hash), VSBuffer.fromString(content));
+				}
+			}
+
+			await this._fileService.writeFile(joinPath(storageFolder, STORAGE_STATE_FILE), VSBuffer.fromString(JSON.stringify(data)));
+		} catch (e) {
+			this._logService.debug(`Error storing chat editing session to ${storageFolder.toString()}`, e);
+		}
+	}
+
+	public async clearState(): Promise<void> {
+		const storageFolder = this._getStorageLocation();
+		if (await this._fileService.exists(storageFolder)) {
+			this._logService.debug(`chatEditingSession: Clearing editing session at ${storageFolder.toString()}`);
+			try {
+				await this._fileService.del(storageFolder, { recursive: true });
+			} catch (e) {
+				this._logService.debug(`Error clearing chat editing session from ${storageFolder.toString()}`, e);
+			}
+		}
+	}
+}
+
+export interface IChatEditingSessionSnapshot {
+	/**
+	 * Index of this session in the linear history. It's the sum of the lengths
+	 * of all {@link stops} prior this one.
+	 */
+	readonly startIndex: number;
+
+	readonly requestId: string | undefined;
+	/**
+	 * Edit stops in the request. Always initially populatd with stopId: undefind
+	 * for th request's initial state.
+	 *
+	 * Invariant: never empty.
+	 */
+	readonly stops: IChatEditingSessionStop[];
+
+	/** Stop that represents changes after the last undo stop, kept for diffing purposes. */
+	readonly postEdit: ResourceMap<ISnapshotEntry> | undefined;
+}
+
+export interface IChatEditingSessionStop {
+	/** Edit stop ID, first for a request is always undefined. */
+	stopId: string | undefined;
+
+	readonly entries: ResourceMap<ISnapshotEntry>;
+}
+
+interface IChatEditingSessionStopDTO {
+	readonly stopId: string | undefined;
+	readonly entries: ISnapshotEntryDTO[];
+}
+
+
+interface IChatEditingSessionSnapshotDTO {
+	readonly requestId: string | undefined;
+	readonly workingSet: ResourceMapDTO<WorkingSetDisplayMetadata>;
+	readonly entries: ISnapshotEntryDTO[];
+}
+
+interface IChatEditingSessionSnapshotDTO2 {
+	readonly requestId: string | undefined;
+	readonly stops: IChatEditingSessionStopDTO[];
+	readonly postEdit: ISnapshotEntryDTO[] | undefined;
+}
+
+interface ISnapshotEntryDTO {
+	readonly resource: string;
+	readonly languageId: string;
+	readonly originalHash: string;
+	readonly currentHash: string;
+	readonly originalToCurrentEdit: IOffsetEdit;
+	readonly state: ModifiedFileEntryState;
+	readonly snapshotUri: string;
+	readonly telemetryInfo: IModifiedEntryTelemetryInfoDTO;
+}
+
+interface IModifiedEntryTelemetryInfoDTO {
+	readonly requestId: string;
+	readonly agentId?: string;
+	readonly command?: string;
+}
+
+type ResourceMapDTO<T> = [string, T][];
+
+const COMPATIBLE_STORAGE_VERSIONS = [1, 2];
+const STORAGE_VERSION = 2;
+
+/** Old history uses IChatEditingSessionSnapshotDTO, new history uses IChatEditingSessionSnapshotDTO. */
+interface IChatEditingSessionDTO {
+	readonly version: number;
+	readonly sessionId: string;
+	readonly recentSnapshot: (IChatEditingSessionStopDTO | IChatEditingSessionSnapshotDTO);
+	readonly linearHistory: (IChatEditingSessionSnapshotDTO2 | IChatEditingSessionSnapshotDTO)[];
+	readonly linearHistoryIndex: number;
+	readonly pendingSnapshot: (IChatEditingSessionStopDTO | IChatEditingSessionSnapshotDTO) | undefined;
+	readonly initialFileContents: ResourceMapDTO<string>;
+}

--- a/src/vs/workbench/contrib/chat/test/browser/chatEditingSessionStorage.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/chatEditingSessionStorage.test.ts
@@ -1,0 +1,100 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { ResourceMap } from '../../../../../base/common/map.js';
+import { cloneAndChange } from '../../../../../base/common/objects.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { generateUuid } from '../../../../../base/common/uuid.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { OffsetEdit } from '../../../../../editor/common/core/offsetEdit.js';
+import { OffsetRange } from '../../../../../editor/common/core/offsetRange.js';
+import { FileService } from '../../../../../platform/files/common/fileService.js';
+import { InMemoryFileSystemProvider } from '../../../../../platform/files/common/inMemoryFilesystemProvider.js';
+import { NullLogService } from '../../../../../platform/log/common/log.js';
+import { TestEnvironmentService } from '../../../../test/browser/workbenchTestServices.js';
+import { ISnapshotEntry } from '../../browser/chatEditing/chatEditingModifiedFileEntry.js';
+import { ChatEditingSessionStorage, IChatEditingSessionStop, StoredSessionState } from '../../browser/chatEditing/chatEditingSessionStorage.js';
+import { ChatEditingSnapshotTextModelContentProvider } from '../../browser/chatEditing/chatEditingTextModelContentProviders.js';
+import { ModifiedFileEntryState } from '../../common/chatEditingService.js';
+
+suite('ChatEditingSessionStorage', () => {
+	const ds = ensureNoDisposablesAreLeakedInTestSuite();
+	const sessionId = generateUuid();
+	let fs: FileService;
+	let storage: TestChatEditingSessionStorage;
+
+	class TestChatEditingSessionStorage extends ChatEditingSessionStorage {
+		public get storageLocation() {
+			return super._getStorageLocation();
+		}
+	}
+
+	setup(() => {
+		fs = ds.add(new FileService(new NullLogService()));
+		ds.add(fs.registerProvider(TestEnvironmentService.workspaceStorageHome.scheme, ds.add(new InMemoryFileSystemProvider())));
+
+		storage = new TestChatEditingSessionStorage(
+			sessionId,
+			fs,
+			TestEnvironmentService,
+			new NullLogService(),
+			{ getWorkspace: () => ({ id: 'workspaceId' }) } as any,
+		);
+	});
+
+	function makeStop(requestId: string | undefined, before: string, after: string): IChatEditingSessionStop {
+		const stopId = generateUuid();
+		const resource = URI.file('/foo.js');
+		return {
+			stopId,
+			entries: new ResourceMap([
+				[resource, { resource, languageId: 'javascript', snapshotUri: ChatEditingSnapshotTextModelContentProvider.getSnapshotFileURI(sessionId, requestId, stopId, resource.path), original: `contents${before}}`, current: `contents${after}`, originalToCurrentEdit: OffsetEdit.replace(OffsetRange.ofLength(42), 'newtext'), state: ModifiedFileEntryState.Modified, telemetryInfo: { agentId: 'agentId', command: 'cmd', requestId: generateUuid(), result: undefined, sessionId } } satisfies ISnapshotEntry],
+			]),
+		};
+	}
+
+	function generateState(): StoredSessionState {
+		const initialFileContents = new ResourceMap<string>();
+		for (let i = 0; i < 10; i++) { initialFileContents.set(URI.file(`/foo${i}.js`), `fileContents${Math.floor(i / 2)}`); }
+
+		const r1 = generateUuid();
+		const r2 = generateUuid();
+		return {
+			initialFileContents,
+			pendingSnapshot: makeStop(undefined, 'd', 'e'),
+			recentSnapshot: makeStop(undefined, 'd', 'e'),
+			linearHistoryIndex: 3,
+			linearHistory: [
+				{ startIndex: 0, requestId: r1, stops: [makeStop(r1, 'a', 'b')], postEdit: makeStop(r1, 'b', 'c').entries },
+				{ startIndex: 1, requestId: r2, stops: [makeStop(r2, 'c', 'd'), makeStop(r2, 'd', 'd')], postEdit: makeStop(r2, 'd', 'd').entries },
+			]
+		};
+	}
+
+	test('state is empty initially', async () => {
+		const s = await storage.restoreState();
+		assert.strictEqual(s, undefined);
+	});
+
+	test('round trips state', async () => {
+		const original = generateState();
+		await storage.storeState(original);
+
+		const changer = (x: any) => {
+			return URI.isUri(x) ? x.toString() : x instanceof Map ? cloneAndChange([...x.values()], changer) : undefined;
+		};
+
+		const restored = await storage.restoreState();
+		assert.deepStrictEqual(cloneAndChange(restored, changer), cloneAndChange(original, changer));
+	});
+
+	test('clears state', async () => {
+		await storage.storeState(generateState());
+		await storage.clearState();
+		const s = await storage.restoreState();
+		assert.strictEqual(s, undefined);
+	});
+});


### PR DESCRIPTION
Now that we have `ensureEditInUndoStopMatches`, we don't need to
aggressively store every file in every snapshot. In this change, the
file is only stored at the initial complete snapshot for each request,
and then in each edit stop in which it changes. Only requires a slight
change in getFirstAndLastStop.

Also popped storage out to its own file and wrote some sanity tests for
it, although I didn't find much low hanging fruit there.

Fixes https://github.com/microsoft/vscode-copilot/issues/14687

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
