### PR TITLE
[release/1.99] bump distro commit (removing NES setting policy)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "code-oss-dev",
   "version": "1.99.0",
-  "distro": "d42d927c558e17ea6e489cff62878654737d85f7",
+  "distro": "21c8d8ea1e46d97c5639a7cabda6c0e063cc8dd5",
   "author": {
     "name": "Microsoft Corporation"
   },


### PR DESCRIPTION
closes https://github.com/microsoft/vscode-internalbacklog/issues/5443

https://github.com/microsoft/vscode-distro/commit/21c8d8ea1e46d97c5639a7cabda6c0e063cc8dd5

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
