### PR TITLE
 remove  keybindings being included from allcommands

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/preferencesActions.ts
+++ b/src/vs/workbench/contrib/preferences/browser/preferencesActions.ts
@@ -19,7 +19,6 @@ import { MenuId, MenuRegistry, isIMenuItem } from '../../../../platform/actions/
 import { IKeybindingService } from '../../../../platform/keybinding/common/keybinding.js';
 import { isLocalizedString } from '../../../../platform/action/common/action.js';
 import { IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
-import { KeybindingsRegistry } from '../../../../platform/keybinding/common/keybindingsRegistry.js';
 
 export class ConfigureLanguageBasedSettingsAction extends Action {
 
@@ -119,26 +118,6 @@ CommandsRegistry.registerCommand('_getAllCommands', function (accessor, filterBy
 				keybinding: keybinding?.getLabel() ?? 'Not set'
 			});
 		}
-	}
-	for (const command of KeybindingsRegistry.getDefaultKeybindings()) {
-		if (filterByPrecondition && !contextKeyService.contextMatchesRules(command.when ?? undefined)) {
-			continue;
-		}
-
-		const keybinding = keybindingService.lookupKeybinding(command.command ?? '');
-		if (!keybinding) {
-			continue;
-		}
-
-		if (actions.some(a => a.command === command.command)) {
-			continue;
-		}
-		actions.push({
-			command: command.command ?? '',
-			label: command.command ?? '',
-			keybinding: keybinding?.getLabel() ?? 'Not set',
-			precondition: command.when?.serialize()
-		});
 	}
 
 	return actions;


### PR DESCRIPTION
Reverting: https://github.com/microsoft/vscode/pull/238163 since we get too many un usable key binding commands which cannot be indexed properly.