### PR TITLE
API proposal: `save` options

### DIFF
--- a/src/vs/platform/extensions/common/extensionsApiProposals.ts
+++ b/src/vs/platform/extensions/common/extensionsApiProposals.ts
@@ -307,6 +307,9 @@ const _allApiProposals = {
 	resolvers: {
 		proposal: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.resolvers.d.ts',
 	},
+	saveOptions: {
+		proposal: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.saveOptions.d.ts',
+	},
 	scmActionButton: {
 		proposal: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.scmActionButton.d.ts',
 	},

--- a/src/vs/workbench/api/browser/mainThreadDocuments.ts
+++ b/src/vs/workbench/api/browser/mainThreadDocuments.ts
@@ -12,7 +12,7 @@ import { IModelService } from '../../../editor/common/services/model.js';
 import { ITextModelService } from '../../../editor/common/services/resolverService.js';
 import { IFileService, FileOperation } from '../../../platform/files/common/files.js';
 import { ExtHostContext, ExtHostDocumentsShape, MainThreadDocumentsShape } from '../common/extHost.protocol.js';
-import { EncodingMode, ITextFileEditorModel, ITextFileService, TextFileResolveReason } from '../../services/textfile/common/textfiles.js';
+import { EncodingMode, ITextFileEditorModel, ITextFileSaveOptions, ITextFileService, TextFileResolveReason } from '../../services/textfile/common/textfiles.js';
 import { IUntitledTextEditorModel } from '../../services/untitled/common/untitledTextEditorModel.js';
 import { IWorkbenchEnvironmentService } from '../../services/environment/common/environmentService.js';
 import { toLocalResource, extUri, IExtUri } from '../../../base/common/resources.js';
@@ -214,8 +214,8 @@ export class MainThreadDocuments extends Disposable implements MainThreadDocumen
 
 	// --- from extension host process
 
-	async $trySaveDocument(uri: UriComponents): Promise<boolean> {
-		const target = await this._textFileService.save(URI.revive(uri));
+	async $trySaveDocument(uri: UriComponents, options?: ITextFileSaveOptions): Promise<boolean> {
+		const target = await this._textFileService.save(URI.revive(uri), options);
 		return Boolean(target);
 	}
 

--- a/src/vs/workbench/api/browser/mainThreadNotebookDocuments.ts
+++ b/src/vs/workbench/api/browser/mainThreadNotebookDocuments.ts
@@ -14,6 +14,7 @@ import { INotebookEditorModelResolverService } from '../../contrib/notebook/comm
 import { IUriIdentityService } from '../../../platform/uriIdentity/common/uriIdentity.js';
 import { ExtHostContext, ExtHostNotebookDocumentsShape, MainThreadNotebookDocumentsShape, NotebookCellDto, NotebookCellsChangedEventDto, NotebookDataDto } from '../common/extHost.protocol.js';
 import { NotebookDto } from './mainThreadNotebookDto.js';
+import { ISaveOptions } from '../../common/editor.js';
 import { SerializableObjectWithBuffers } from '../../services/extensions/common/proxyIdentifier.js';
 import { IExtHostContext } from '../../services/extensions/common/extHostCustomers.js';
 
@@ -169,11 +170,11 @@ export class MainThreadNotebookDocuments implements MainThreadNotebookDocumentsS
 		return uri;
 	}
 
-	async $trySaveNotebook(uriComponents: UriComponents) {
+	async $trySaveNotebook(uriComponents: UriComponents, options?: ISaveOptions) {
 		const uri = URI.revive(uriComponents);
 
 		const ref = await this._notebookEditorModelResolverService.resolve(uri);
-		const saveResult = await ref.object.save();
+		const saveResult = await ref.object.save(options);
 		ref.dispose();
 		return saveResult;
 	}

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -48,7 +48,7 @@ import { ICreateContributedTerminalProfileOptions, IProcessProperty, IProcessRea
 import { ProvidedPortAttributes, TunnelCreationOptions, TunnelOptions, TunnelPrivacyId, TunnelProviderFeatures } from '../../../platform/tunnel/common/tunnel.js';
 import { EditSessionIdentityMatch } from '../../../platform/workspace/common/editSessions.js';
 import { WorkspaceTrustRequestOptions } from '../../../platform/workspace/common/workspaceTrust.js';
-import { SaveReason } from '../../common/editor.js';
+import { ISaveOptions, SaveReason } from '../../common/editor.js';
 import { IRevealOptions, ITreeItem, IViewBadge } from '../../common/views.js';
 import { CallHierarchyItem } from '../../contrib/callHierarchy/common/callHierarchy.js';
 import { IChatAgentMetadata, IChatAgentRequest, IChatAgentResult } from '../../contrib/chat/common/chatAgents.js';
@@ -86,6 +86,7 @@ import { CandidatePort } from '../../services/remote/common/tunnelModel.js';
 import { IFileQueryBuilderOptions, ITextQueryBuilderOptions } from '../../services/search/common/queryBuilder.js';
 import * as search from '../../services/search/common/search.js';
 import { TextSearchCompleteMessage } from '../../services/search/common/searchExtTypes.js';
+import { ITextFileSaveOptions } from '../../services/textfile/common/textfiles.js';
 import { ISaveProfileResult } from '../../services/userDataProfile/common/userDataProfile.js';
 import { TerminalShellExecutionCommandLineConfidence } from './extHostTypes.js';
 import * as tasks from './shared/tasks.js';
@@ -242,7 +243,7 @@ export interface MainThreadDocumentContentProvidersShape extends IDisposable {
 export interface MainThreadDocumentsShape extends IDisposable {
 	$tryCreateDocument(options?: { language?: string; content?: string; encoding?: string }): Promise<UriComponents>;
 	$tryOpenDocument(uri: UriComponents, options?: { encoding?: string }): Promise<UriComponents>;
-	$trySaveDocument(uri: UriComponents): Promise<boolean>;
+	$trySaveDocument(uri: UriComponents, options?: ITextFileSaveOptions): Promise<boolean>;
 }
 
 export interface ITextEditorConfigurationUpdate {
@@ -1132,7 +1133,7 @@ export interface MainThreadNotebookEditorsShape extends IDisposable {
 export interface MainThreadNotebookDocumentsShape extends IDisposable {
 	$tryCreateNotebook(options: { viewType: string; content?: NotebookDataDto }): Promise<UriComponents>;
 	$tryOpenNotebook(uriComponents: UriComponents): Promise<UriComponents>;
-	$trySaveNotebook(uri: UriComponents): Promise<boolean>;
+	$trySaveNotebook(uri: UriComponents, options?: ISaveOptions): Promise<boolean>;
 }
 
 export interface INotebookKernelDto2 {

--- a/src/vs/workbench/api/common/extHostDocumentData.ts
+++ b/src/vs/workbench/api/common/extHostDocumentData.ts
@@ -68,7 +68,7 @@ export class ExtHostDocumentData extends MirrorTextModel {
 				get isClosed() { return that._isDisposed; },
 				get isDirty() { return that._isDirty; },
 				get encoding() { return that._encoding; },
-				save() { return that._save(); },
+				save(options?: vscode.SaveOptions) { return that._save(options); },
 				getText(range?) { return range ? that._getTextInRange(range) : that.getText(); },
 				get eol() { return that._eol === '\n' ? EndOfLine.LF : EndOfLine.CRLF; },
 				get lineCount() { return that._lines.length; },
@@ -101,11 +101,15 @@ export class ExtHostDocumentData extends MirrorTextModel {
 		this._encoding = encoding;
 	}
 
-	private _save(): Promise<boolean> {
+	private _save(options?: vscode.SaveOptions): Promise<boolean> {
 		if (this._isDisposed) {
 			return Promise.reject(new Error('Document has been closed'));
 		}
-		return this._proxy.$trySaveDocument(this._uri);
+		const { skipSaveParticipants } = options ?? {};
+		// I know I need to somehow use `isProposedApiEnabled` to check if the
+		// `saveOptions` API proposal is enabled, but I don't know how to get a
+		// reference to any specific extension from here.
+		return this._proxy.$trySaveDocument(this._uri, { skipSaveParticipants });
 	}
 
 	private _getTextInRange(_range: vscode.Range): string {

--- a/src/vs/workbench/api/common/extHostNotebookDocument.ts
+++ b/src/vs/workbench/api/common/extHostNotebookDocument.ts
@@ -210,8 +210,8 @@ export class ExtHostNotebookDocument {
 					const cells = range ? that._getCells(range) : that._cells;
 					return cells.map(cell => cell.apiCell);
 				},
-				save() {
-					return that._save();
+				save(options?: vscode.SaveOptions) {
+					return that._save(options);
 				},
 				[Symbol.for('debug.description')]() {
 					return `NotebookDocument(${this.uri.toString()})`;
@@ -346,11 +346,15 @@ export class ExtHostNotebookDocument {
 		return result;
 	}
 
-	private async _save(): Promise<boolean> {
+	private async _save(options?: vscode.SaveOptions): Promise<boolean> {
 		if (this._disposed) {
 			return Promise.reject(new Error('Notebook has been closed'));
 		}
-		return this._proxy.$trySaveNotebook(this.uri);
+		const { skipSaveParticipants } = options ?? {};
+		// I know I need to somehow use `isProposedApiEnabled` to check if the
+		// `saveOptions` API proposal is enabled, but I don't know how to get a
+		// reference to any specific extension from here.
+		return this._proxy.$trySaveNotebook(this.uri, { skipSaveParticipants });
 	}
 
 	private _spliceNotebookCells(splices: notebookCommon.NotebookCellTextModelSplice<extHostProtocol.NotebookCellDto>[], initialization: boolean, bucket: vscode.NotebookDocumentContentChange[] | undefined): void {

--- a/src/vscode-dts/vscode.proposed.saveOptions.d.ts
+++ b/src/vscode-dts/vscode.proposed.saveOptions.d.ts
@@ -1,0 +1,22 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+declare module 'vscode' {
+	/** Represents options to configure the behavior of saving a {@link TextDocument text document} or a {@link NotebookDocument notebook document}. */
+	export interface SaveOptions {
+		/**
+		 * Instructs the save operation to skip any save participants.
+		 */
+		skipSaveParticipants?: boolean;
+	}
+
+	export interface TextDocument {
+		save(options?: SaveOptions): Thenable<boolean>;
+	}
+
+	export interface NotebookDocument {
+		save(options?: SaveOptions): Thenable<boolean>;
+	}
+}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR resolves #245405 by proposing that the `save` method on `TextDocument` and `NotebookDocument` take an optional argument of type `SaveOptions`, which is essentially just a public subset of the options in the private [`ISaveOptions`](https://github.com/microsoft/vscode/blob/4aca8e1591c7009688edefe5c2a0cfbd6242c37d/src/vs/workbench/common/editor.ts/#L727-L756) interface. Specifically, the only one I've made public here is `skipSaveParticipants`; in keeping with the [API guidelines](https://github.com/microsoft/vscode/wiki/Extension-API-guidelines#breakage), I've tried to be conservative while also making it easy to make other `ISaveOptions` properties public in the future, if desired.

This PR has a couple issues currently, for which I need a maintainer's help:

1. The implementation is not gated behind `isProposedApiEnabled`. I tried to do this, but I could not figure out how to get a reference to any specific extension from within the `src/vs/workbench/api/common/extHostDocumentData.ts` and `src/vs/workbench/api/common/extHostNotebookDocument.ts` files where the code changes needed to occur. Please let me know how I can gate these properly!

2. No tests. I wanted to add a couple tests, but it looked like they would belong in `extensions/vscode-api-tests/src/singlefolder-tests/editor.test.ts` and `extensions/vscode-api-tests/src/singlefolder-tests/notebook.document.test.ts`, and for the life of me I could not figure out how to run any of the tests under `extensions/vscode-api-tests`. Could information about that be added to the wiki? Once I know how to do it, I'd be happy to add those tests!

I also have a question about the [weekly API call](https://github.com/Microsoft/vscode/wiki/Extension-API-process#weekly-api-call): the wiki page says it's "open to everyone", but I'm having trouble finding information about when it takes place and how to join. When is the next API call and how can I attend it?