### PR TITLE
Fix rounded borders on modified editor

### DIFF
--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/inlineEditsLineReplacementView.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/inlineEditsLineReplacementView.ts
@@ -222,7 +222,7 @@ export class InlineEditsLineReplacementView extends Disposable implements IInlin
 						style: {
 							position: 'absolute',
 							...rectToProps(reader => layout.read(reader).lowerBackground.translateX(-contentLeft)),
-							borderRadius: '4px',
+							borderRadius: '0 0 4px 4px',
 							background: asCssVariable(editorBackground),
 							boxShadow: `${asCssVariable(scrollbarShadow)} 0 6px 6px -6px`,
 							border: `1px solid ${asCssVariable(modifiedBorderColor)}`,
@@ -254,7 +254,7 @@ export class InlineEditsLineReplacementView extends Disposable implements IInlin
 							fontWeight: this._editor.getOption(EditorOption.fontWeight),
 							pointerEvents: 'none',
 							whiteSpace: 'nowrap',
-							borderRadius: '4px',
+							borderRadius: '0 0 4px 4px',
 							overflow: 'hidden',
 						}
 					}, [...modifiedLineElements.lines]),


### PR DESCRIPTION
```Copilot Generated Description:``` Adjust the border radius of the modified editor's top borders to remove the rounding, ensuring a clearer distinction between the original and modified blocks.

Fixes microsoft/vscode-copilot#15505