### PR TITLE
Avoid performance.now.bind call in `StopWatch`

### DIFF
--- a/src/vs/base/common/stopwatch.ts
+++ b/src/vs/base/common/stopwatch.ts
@@ -4,9 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 
 // fake definition so that the valid layers check won't trip on this
-declare const globalThis: { performance?: { now(): number } };
+declare const globalThis: { performance: { now(): number } };
 
-const hasPerformanceNow = (globalThis.performance && typeof globalThis.performance.now === 'function');
+const performanceNow = globalThis.performance.now.bind(globalThis.performance);
 
 export class StopWatch {
 
@@ -20,7 +20,7 @@ export class StopWatch {
 	}
 
 	constructor(highResolution?: boolean) {
-		this._now = hasPerformanceNow && highResolution === false ? Date.now : globalThis.performance!.now.bind(globalThis.performance);
+		this._now = highResolution === false ? Date.now : performanceNow;
 		this._startTime = this._now();
 		this._stopTime = -1;
 	}


### PR DESCRIPTION
This removes the `bind` call and skips the check for `performance.now` existing since I believe it's widely supported in all environments. Other places in our code seem to be using it directly too

This extra bind isn't expensive on its own but some code paths call this inside of tight loops where it does matter

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
