### PR TITLE
cli: make the build faster

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -77,7 +77,6 @@ russh-keys = { git = "https://github.com/microsoft/vscode-russh", branch = "main
 [profile.release]
 strip = true
 lto = true
-codegen-units = 1
 
 [features]
 default = []


### PR DESCRIPTION
codegen-units=1 lets the compiler optimize more aggressively, but it
makes things _much_ slower. The benefits of this has been evaporating
as the compiler has improved, and now that the CLI build is a bottleneck,
let's just remove it.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
