### PR TITLE
Ensure confirmation widget doesn't break when rendering empty tool args

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/chatToolInvocationPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/chatToolInvocationPart.ts
@@ -247,7 +247,7 @@ class ChatToolInvocationSubPart extends Disposable {
 
 				const langId = this.languageService.getLanguageIdByLanguageName('json');
 				const model = this._register(this.modelService.createModel(
-					JSON.stringify(inputData.rawInput, undefined, 2),
+					JSON.stringify(inputData.rawInput ?? {}, undefined, 2),
 					this.languageService.createById(langId),
 					createToolInputUri(toolInvocation.toolId)
 				));


### PR DESCRIPTION
Related to https://github.com/microsoft/vscode-copilot/pull/15573