### PR TITLE
remove background colors from combination setters as well

### DIFF
--- a/extensions/notebook-renderers/src/stackTraceHelper.ts
+++ b/extensions/notebook-renderers/src/stackTraceHelper.ts
@@ -11,6 +11,7 @@ export function formatStackTrace(stack: string): { formattedStack: string; error
 	// Remove background colors. The ones from IPython don't work well with
 	// themes 40-49 sets background color
 	cleaned = stack.replace(/\u001b\[4\dm/g, '');
+	cleaned = cleaned.replace(/(?<=\u001b\[[\d;]*?);4\d(?=m)/g, '');
 
 	// Also remove specific foreground colors (38 is the ascii code for picking one) (they don't translate either)
 	// Turn them into default foreground

--- a/extensions/notebook-renderers/src/test/stackTraceHelper.test.ts
+++ b/extensions/notebook-renderers/src/test/stackTraceHelper.test.ts
@@ -105,4 +105,13 @@ suite('StackTraceHelper', () => {
 		formattedLines.slice(1).forEach(line => assert.ok(!/<a href=.*>/.test(line), 'line should not contain a link: ' + line));
 	});
 
+	test('background (40-49) ANSI colors are removed', () => {
+		const stack =
+			'open\u001b[39;49m\u001b[43m(\u001b[49m\u001b[33;43m\'\u001b[39;49m\u001b[33;43minput.txt\u001b[39;49m\u001b[33;43m\'\u001b[39;49m\u001b[43m)\u001b[49m;';
+
+		const formattedLines = formatStackTrace(stack).formattedStack.split('\n');
+		assert.ok(!/4\d/.test(formattedLines[0]), 'should not contain background colors ' + formattedLines[0]);
+		formattedLines.slice(1).forEach(line => assert.ok(!/<a href=.*>/.test(line), 'line should not contain a link: ' + line));
+	});
+
 });


### PR DESCRIPTION
fix https://github.com/microsoft/vscode-jupyter/issues/16532

we were removing things like `\[44m`, but not `\[34;44m`, which can also set the background