### PR TITLE
Fix template.expression brackets #190564

### DIFF
--- a/extensions/javascript/package.json
+++ b/extensions/javascript/package.json
@@ -69,9 +69,7 @@
           "meta.embedded.expression.js": "javascriptreact"
         },
         "tokenTypes": {
-          "meta.template.expression": "other",
-          "meta.template.expression string": "string",
-          "meta.template.expression comment": "comment",
+          "punctuation.definition.template-expression": "other",
           "entity.name.type.instance.jsdoc": "other",
           "entity.name.function.tagged-template": "other",
           "meta.import string.quoted": "other",
@@ -89,9 +87,7 @@
           "meta.embedded.expression.js": "javascript"
         },
         "tokenTypes": {
-          "meta.template.expression": "other",
-          "meta.template.expression string": "string",
-          "meta.template.expression comment": "comment",
+          "punctuation.definition.template-expression": "other",
           "entity.name.type.instance.jsdoc": "other",
           "entity.name.function.tagged-template": "other",
           "meta.import string.quoted": "other",

--- a/extensions/typescript-basics/package.json
+++ b/extensions/typescript-basics/package.json
@@ -75,9 +75,7 @@
           "keyword.operator.assignment.compound.bitwise.ts"
         ],
         "tokenTypes": {
-          "meta.template.expression": "other",
-          "meta.template.expression string": "string",
-          "meta.template.expression comment": "comment",
+          "punctuation.definition.template-expression": "other",
           "entity.name.type.instance.jsdoc": "other",
           "entity.name.function.tagged-template": "other",
           "meta.import string.quoted": "other",
@@ -102,9 +100,7 @@
           "meta.embedded.expression.tsx": "typescriptreact"
         },
         "tokenTypes": {
-          "meta.template.expression": "other",
-          "meta.template.expression string": "string",
-          "meta.template.expression comment": "comment",
+          "punctuation.definition.template-expression": "other",
           "entity.name.type.instance.jsdoc": "other",
           "entity.name.function.tagged-template": "other",
           "meta.import string.quoted": "other",


### PR DESCRIPTION
fixes #190564
*  #190564
* #134662
* #127005
* #124270
* old PR: #195557

removes broken `tokenTypes`
https://github.com/microsoft/vscode/blob/920fbe590bec1a91a334ddb913787813b015e334/extensions/typescript-basics/package.json#L77-L80
leaving `meta.embedded.line.ts` to do the correct job with embedded brackets `()`
and adds `"punctuation.definition.template-expression": "other"` to mark the template expression brackets `${}` as brackets

if you wish to have the expression brackets `${}` be colour highlighted
then `${`, `}` should be add to `"colorizedBracketPairs"` in:
https://github.com/microsoft/vscode/blob/920fbe590bec1a91a334ddb913787813b015e334/extensions/typescript-basics/language-configuration.json#L102-L119

before:
![image](https://github.com/user-attachments/assets/efb4d006-7594-4b54-9204-f3a694f4739b)

after:
![image](https://github.com/user-attachments/assets/91fec96d-9070-44bc-a870-b65ab85e97a6)

with coloured `${}`:
![image](https://github.com/user-attachments/assets/0fc8907c-8f2d-4c02-81de-70a114c131d9)

```ts
`${`${("{")}`}`;
const str = `${("{")}`
```