### PR TITLE
Consolidate welcome message handling

### DIFF
--- a/src/vs/workbench/api/common/extHostChatAgents2.ts
+++ b/src/vs/workbench/api/common/extHostChatAgents2.ts
@@ -732,7 +732,7 @@ class ExtHostChatAgent {
 	private _supportIssueReporting: boolean | undefined;
 	private _agentVariableProvider?: { provider: vscode.ChatParticipantCompletionItemProvider; triggerCharacters: string[] };
 	private _welcomeMessageProvider?: vscode.ChatWelcomeMessageProvider | undefined;
-	private _welcomeMessageContent?: vscode.ChatWelcomeMessageContent | undefined;
+	private _additionalWelcomeMessage?: string | vscode.MarkdownString | undefined;
 	private _titleProvider?: vscode.ChatTitleProvider | undefined;
 	private _requester: vscode.ChatRequesterInformation | undefined;
 	private _pauseStateEmitter = new Emitter<vscode.ChatParticipantPauseStateEvent>();
@@ -828,10 +828,7 @@ class ExtHostChatAgent {
 					helpTextPostfix: (!this._helpTextPostfix || typeof this._helpTextPostfix === 'string') ? this._helpTextPostfix : typeConvert.MarkdownString.from(this._helpTextPostfix),
 					supportIssueReporting: this._supportIssueReporting,
 					requester: this._requester,
-					welcomeMessageContent: this._welcomeMessageContent && {
-						...this._welcomeMessageContent,
-						message: typeConvert.MarkdownString.from(this._welcomeMessageContent.message),
-					}
+					additionalWelcomeMessage: (!this._additionalWelcomeMessage || typeof this._additionalWelcomeMessage === 'string') ? this._additionalWelcomeMessage : typeConvert.MarkdownString.from(this._additionalWelcomeMessage),
 				});
 				updateScheduled = false;
 			});
@@ -928,14 +925,14 @@ class ExtHostChatAgent {
 				checkProposedApiEnabled(that.extension, 'defaultChatParticipant');
 				return that._welcomeMessageProvider;
 			},
-			set welcomeMessageContent(v) {
+			set additionalWelcomeMessage(v) {
 				checkProposedApiEnabled(that.extension, 'defaultChatParticipant');
-				that._welcomeMessageContent = v;
+				that._additionalWelcomeMessage = v;
 				updateMetadataSoon();
 			},
-			get welcomeMessageContent() {
+			get additionalWelcomeMessage() {
 				checkProposedApiEnabled(that.extension, 'defaultChatParticipant');
-				return that._welcomeMessageContent;
+				return that._additionalWelcomeMessage;
 			},
 			set titleProvider(v) {
 				checkProposedApiEnabled(that.extension, 'defaultChatParticipant');

--- a/src/vs/workbench/contrib/chat/browser/chatSetup.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSetup.ts
@@ -58,7 +58,7 @@ import { ILifecycleService } from '../../../services/lifecycle/common/lifecycle.
 import { IStatusbarService } from '../../../services/statusbar/browser/statusbar.js';
 import { IViewsService } from '../../../services/views/common/viewsService.js';
 import { IExtensionsWorkbenchService } from '../../extensions/common/extensions.js';
-import { IChatAgentImplementation, IChatAgentRequest, IChatAgentResult, IChatAgentService, IChatWelcomeMessageContent } from '../common/chatAgents.js';
+import { IChatAgentImplementation, IChatAgentRequest, IChatAgentResult, IChatAgentService } from '../common/chatAgents.js';
 import { ChatContextKeys } from '../common/chatContextKeys.js';
 import { ChatEntitlement, ChatEntitlementContext, ChatEntitlementRequests, ChatEntitlementService, IChatEntitlementService } from '../common/chatEntitlementService.js';
 import { IChatRequestModel } from '../common/chatModel.js';
@@ -108,33 +108,16 @@ class SetupChatAgentImplementation extends Disposable implements IChatAgentImple
 
 			let id: string;
 			let description = localize('chatDescription', "Ask Copilot");
-			let welcomeMessageContent: IChatWelcomeMessageContent | undefined;
-			const baseMessage = localize('chatMessage', "Copilot is powered by AI, so mistakes are possible. Review output carefully before use.");
 			switch (location) {
 				case ChatAgentLocation.Panel:
 					if (mode === ChatMode.Ask) {
 						id = 'setup.chat';
-						welcomeMessageContent = {
-							title: description,
-							message: new MarkdownString(baseMessage),
-							icon: Codicon.copilotLarge
-						};
 					} else if (mode === ChatMode.Edit) {
 						id = 'setup.edits';
 						description = localize('editsDescription', "Edit files in your workspace");
-						welcomeMessageContent = {
-							title: localize('editsTitle', "Edit with Copilot"),
-							message: new MarkdownString(localize('editsMessage', "Start your editing session by defining a set of files that you want to work with. Then ask Copilot for the changes you want to make.") + `\n\n${baseMessage}`),
-							icon: Codicon.copilotLarge
-						};
 					} else {
 						id = 'setup.agent';
 						description = localize('agentDescription', "Edit files in your workspace in agent mode");
-						welcomeMessageContent = {
-							title: localize('editsTitle', "Edit with Copilot"),
-							message: new MarkdownString(localize('agentMessage', "Ask Copilot to edit your files in [agent mode]({0}). Copilot will automatically use multiple requests to pick files to edit, run terminal commands, and iterate on errors.", 'https://aka.ms/vscode-copilot-agent') + `\n\n${baseMessage}`),
-							icon: Codicon.copilotLarge
-						};
 					}
 					break;
 				case ChatAgentLocation.Terminal:
@@ -161,7 +144,6 @@ class SetupChatAgentImplementation extends Disposable implements IChatAgentImple
 				disambiguation: [],
 				locations: [location],
 				metadata: {
-					welcomeMessageContent,
 					helpTextPrefix: SetupChatAgentImplementation.SETUP_NEEDED_MESSAGE
 				},
 				description,

--- a/src/vs/workbench/contrib/chat/common/chatAgents.ts
+++ b/src/vs/workbench/contrib/chat/common/chatAgents.ts
@@ -7,7 +7,7 @@ import { findLast } from '../../../../base/common/arraysFind.js';
 import { timeout } from '../../../../base/common/async.js';
 import { CancellationToken } from '../../../../base/common/cancellation.js';
 import { Emitter, Event } from '../../../../base/common/event.js';
-import { IMarkdownString, isMarkdownString } from '../../../../base/common/htmlContent.js';
+import { IMarkdownString } from '../../../../base/common/htmlContent.js';
 import { Iterable } from '../../../../base/common/iterator.js';
 import { Disposable, IDisposable, toDisposable } from '../../../../base/common/lifecycle.js';
 import { revive } from '../../../../base/common/marshalling.js';
@@ -68,13 +68,6 @@ export interface IChatWelcomeMessageContent {
 	message: IMarkdownString;
 }
 
-export function isChatWelcomeMessageContent(obj: any): obj is IChatWelcomeMessageContent {
-	return obj &&
-		ThemeIcon.isThemeIcon(obj.icon) &&
-		typeof obj.title === 'string' &&
-		isMarkdownString(obj.message);
-}
-
 export interface IChatAgentImplementation {
 	invoke(request: IChatAgentRequest, progress: (part: IChatProgress) => void, history: IChatAgentHistoryEntry[], token: CancellationToken): Promise<IChatAgentResult>;
 	setRequestPaused?(requestId: string, isPaused: boolean): void;
@@ -126,7 +119,7 @@ export interface IChatAgentMetadata {
 	followupPlaceholder?: string;
 	isSticky?: boolean;
 	requester?: IChatRequesterInformation;
-	welcomeMessageContent?: IChatWelcomeMessageContent;
+	additionalWelcomeMessage?: string | IMarkdownString;
 }
 
 

--- a/src/vs/workbench/contrib/chat/common/chatAgents.ts
+++ b/src/vs/workbench/contrib/chat/common/chatAgents.ts
@@ -72,7 +72,6 @@ export interface IChatAgentImplementation {
 	invoke(request: IChatAgentRequest, progress: (part: IChatProgress) => void, history: IChatAgentHistoryEntry[], token: CancellationToken): Promise<IChatAgentResult>;
 	setRequestPaused?(requestId: string, isPaused: boolean): void;
 	provideFollowups?(request: IChatAgentRequest, result: IChatAgentResult, history: IChatAgentHistoryEntry[], token: CancellationToken): Promise<IChatFollowup[]>;
-	provideWelcomeMessage?(token: CancellationToken): ProviderResult<IChatWelcomeMessageContent | undefined>;
 	provideChatTitle?: (history: IChatAgentHistoryEntry[], token: CancellationToken) => Promise<string | undefined>;
 	provideSampleQuestions?(location: ChatAgentLocation, token: CancellationToken): ProviderResult<IChatFollowup[] | undefined>;
 }
@@ -597,14 +596,6 @@ export class MergedChatAgent implements IChatAgent {
 		}
 
 		return [];
-	}
-
-	provideWelcomeMessage(token: CancellationToken): ProviderResult<IChatWelcomeMessageContent | undefined> {
-		if (this.impl.provideWelcomeMessage) {
-			return this.impl.provideWelcomeMessage(token);
-		}
-
-		return undefined;
 	}
 
 	provideSampleQuestions(location: ChatAgentLocation, token: CancellationToken): ProviderResult<IChatFollowup[] | undefined> {

--- a/src/vs/workbench/contrib/chat/test/common/voiceChatService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/voiceChatService.test.ts
@@ -13,11 +13,11 @@ import { ExtensionIdentifier } from '../../../../../platform/extensions/common/e
 import { MockContextKeyService } from '../../../../../platform/keybinding/test/common/mockKeybindingService.js';
 import { nullExtensionDescription } from '../../../../services/extensions/common/extensions.js';
 import { ISpeechProvider, ISpeechService, ISpeechToTextEvent, ISpeechToTextSession, ITextToSpeechSession, KeywordRecognitionStatus, SpeechToTextStatus } from '../../../speech/common/speechService.js';
-import { IChatAgent, IChatAgentCommand, IChatAgentCompletionItem, IChatAgentData, IChatAgentHistoryEntry, IChatAgentImplementation, IChatAgentMetadata, IChatAgentRequest, IChatAgentResult, IChatAgentService, IChatParticipantDetectionProvider, IChatWelcomeMessageContent } from '../../common/chatAgents.js';
+import { IChatAgent, IChatAgentCommand, IChatAgentCompletionItem, IChatAgentData, IChatAgentHistoryEntry, IChatAgentImplementation, IChatAgentMetadata, IChatAgentRequest, IChatAgentResult, IChatAgentService, IChatParticipantDetectionProvider } from '../../common/chatAgents.js';
 import { IChatModel } from '../../common/chatModel.js';
 import { IChatFollowup, IChatProgress } from '../../common/chatService.js';
-import { IVoiceChatSessionOptions, IVoiceChatTextEvent, VoiceChatService } from '../../common/voiceChatService.js';
 import { ChatAgentLocation, ChatMode } from '../../common/constants.js';
+import { IVoiceChatSessionOptions, IVoiceChatTextEvent, VoiceChatService } from '../../common/voiceChatService.js';
 
 suite('VoiceChat', () => {
 
@@ -51,7 +51,6 @@ suite('VoiceChat', () => {
 			throw new Error('Method not implemented.');
 		}
 		invoke(request: IChatAgentRequest, progress: (part: IChatProgress) => void, history: IChatAgentHistoryEntry[], token: CancellationToken): Promise<IChatAgentResult> { throw new Error('Method not implemented.'); }
-		provideWelcomeMessage?(token: CancellationToken): ProviderResult<IChatWelcomeMessageContent | undefined> { throw new Error('Method not implemented.'); }
 		metadata = {};
 	}
 

--- a/src/vscode-dts/vscode.proposed.defaultChatParticipant.d.ts
+++ b/src/vscode-dts/vscode.proposed.defaultChatParticipant.d.ts
@@ -50,7 +50,7 @@ declare module 'vscode' {
 		helpTextPostfix?: string | MarkdownString;
 
 		welcomeMessageProvider?: ChatWelcomeMessageProvider;
-		welcomeMessageContent?: ChatWelcomeMessageContent;
+		additionalWelcomeMessage?: string | MarkdownString;
 		titleProvider?: ChatTitleProvider;
 		requester?: ChatRequesterInformation;
 	}


### PR DESCRIPTION
Centralize welcome message content management by moving it to a single location and removing the deprecated `provideWelcomeMessage` method.

cc @bpasero