### PR TITLE
[prompts]: @mention syntax support

### DIFF
--- a/src/vs/editor/common/codecs/linesCodec/linesDecoder.ts
+++ b/src/vs/editor/common/codecs/linesCodec/linesDecoder.ts
@@ -66,9 +66,10 @@ export class LinesDecoder extends BaseDecoder<TLineToken, VSBuffer> {
 			const endOfLineTokens = this.findEndOfLineTokens(lineNumber);
 			const firstToken = endOfLineTokens[0];
 
-			// if no end-of-the-line tokens found, stop processing because we
-			// either (1)need more data to arraive or (2)the stream has ended
-			// in the case (2) remaining data must be emitted as the last line
+			// if no end-of-the-line tokens found, stop the current processing
+			// attempt because we either (1) need more data to be received or
+			// (2) the stream has ended; in the case (2) remaining data must
+			// be emitted as the last line
 			if (!firstToken) {
 				// (2) if `streamEnded`, we need to emit the whole remaining
 				// data as the last line immediately

--- a/src/vs/editor/common/codecs/linesCodec/linesDecoder.ts
+++ b/src/vs/editor/common/codecs/linesCodec/linesDecoder.ts
@@ -53,7 +53,7 @@ export class LinesDecoder extends BaseDecoder<TLineToken, VSBuffer> {
 	 */
 	private processData(
 		streamEnded: boolean,
-	) {
+	): void {
 		// iterate over each line of the data buffer, emitting each line
 		// as a `Line` token followed by a `NewLine` token, if applies
 		while (this.buffer.byteLength > 0) {
@@ -63,14 +63,17 @@ export class LinesDecoder extends BaseDecoder<TLineToken, VSBuffer> {
 				: 1;
 
 			// find the `\r`, `\n`, or `\r\n` tokens in the data
-			const endOfLineTokens = this.findEndOfLineTokens(lineNumber);
-			const firstToken = endOfLineTokens[0];
+			const endOfLineTokens = this.findEndOfLineTokens(
+				lineNumber,
+				streamEnded,
+			);
+			const firstToken: (NewLine | CarriageReturn | undefined) = endOfLineTokens[0];
 
 			// if no end-of-the-line tokens found, stop the current processing
 			// attempt because we either (1) need more data to be received or
 			// (2) the stream has ended; in the case (2) remaining data must
 			// be emitted as the last line
-			if (!firstToken) {
+			if (firstToken === undefined) {
 				// (2) if `streamEnded`, we need to emit the whole remaining
 				// data as the last line immediately
 				if (streamEnded) {
@@ -89,15 +92,25 @@ export class LinesDecoder extends BaseDecoder<TLineToken, VSBuffer> {
 				'No last emitted line found.',
 			);
 
+			// Note! A standalone `\r` token case is not a well-defined case, and
+			// 		 was primarily used by old Mac OSx systems which treated it as
+			// 		 a line ending (same as `\n`). Hence for backward compatibility
+			// 		 with those systems, we treat it as a new line token as well.
+			// 		 We do that by replacing standalone `\r` token with `\n` one.
+			if ((endOfLineTokens.length === 1) && (firstToken instanceof CarriageReturn)) {
+				endOfLineTokens.splice(0, 1, new NewLine(firstToken.range));
+			}
+
 			// emit the end-of-the-line tokens
 			let startColumn = this.lastEmittedLine.range.endColumn;
 			for (const token of endOfLineTokens) {
-				const endColumn = startColumn + token.byte.byteLength;
+				const byteLength = token.byte.byteLength;
+				const endColumn = startColumn + byteLength;
 				// emit the token updating its column start/end numbers based on
 				// the emitted line text length and previous end-of-the-line token
 				this._onData.fire(token.withRange({ startColumn, endColumn }));
 				// shorten the data buffer by the length of the token
-				this.buffer = this.buffer.slice(token.byte.byteLength);
+				this.buffer = this.buffer.slice(byteLength);
 				// update the start column for the next token
 				startColumn = endColumn;
 			}
@@ -123,6 +136,7 @@ export class LinesDecoder extends BaseDecoder<TLineToken, VSBuffer> {
 	 */
 	private findEndOfLineTokens(
 		lineNumber: number,
+		streamEnded: boolean,
 	): (CarriageReturn | NewLine)[] {
 		const result = [];
 
@@ -131,7 +145,7 @@ export class LinesDecoder extends BaseDecoder<TLineToken, VSBuffer> {
 		const newLineIndex = this.buffer.indexOf(NewLine.byte);
 
 		// if the `\r` comes before the `\n`(if `\n` present at all)
-		if (carriageReturnIndex >= 0 && (carriageReturnIndex < newLineIndex || newLineIndex === -1)) {
+		if (carriageReturnIndex >= 0 && ((carriageReturnIndex < newLineIndex) || (newLineIndex === -1))) {
 			// add the carriage return token first
 			result.push(
 				new CarriageReturn(new Range(
@@ -155,11 +169,15 @@ export class LinesDecoder extends BaseDecoder<TLineToken, VSBuffer> {
 				);
 			}
 
-			if (this.buffer.byteLength > carriageReturnIndex + 1) {
-				// either `\r` or `\r\n` cases found
+			// either `\r` or `\r\n` cases found; if we have the `\r` token, we can return
+			// the end-of-line tokens only, if the `\r` is followed by at least one more
+			// character (it could be a `\n` or any other character), or if the stream has
+			// ended (which means the `\r` is at the end of the line)
+			if ((this.buffer.byteLength > carriageReturnIndex + 1) || streamEnded) {
 				return result;
 			}
 
+			// in all other cases, return the empty array (no lend-of-line tokens found)
 			return [];
 		}
 

--- a/src/vs/editor/common/codecs/simpleCodec/simpleDecoder.ts
+++ b/src/vs/editor/common/codecs/simpleCodec/simpleDecoder.ts
@@ -47,15 +47,11 @@ const WELL_KNOWN_TOKENS = Object.freeze([
  * 	     already handles the `carriagereturn`/`newline` cases and emits lines that don't contain them.
  */
 const WORD_STOP_CHARACTERS: readonly string[] = Object.freeze([
-	Space.symbol, Tab.symbol, VerticalTab.symbol, FormFeed.symbol,
+	Space.symbol, Tab.symbol, VerticalTab.symbol, FormFeed.symbol, At.symbol,
 	LeftBracket.symbol, RightBracket.symbol,
 	LeftParenthesis.symbol, RightParenthesis.symbol,
 	LeftAngleBracket.symbol, RightAngleBracket.symbol,
 	Colon.symbol, Hash.symbol, Dash.symbol, ExclamationMark.symbol,
-	CarriageReturn.symbol,
-	/**
-	 * TODO: @legomushroom - add `@` token here?
-	 */
 ]);
 
 /**

--- a/src/vs/editor/common/codecs/simpleCodec/tokens/at.ts
+++ b/src/vs/editor/common/codecs/simpleCodec/tokens/at.ts
@@ -1,0 +1,51 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { BaseToken } from '../../baseToken.js';
+import { Line } from '../../linesCodec/tokens/line.js';
+import { Range } from '../../../../../editor/common/core/range.js';
+
+/**
+ * A token that represent a `@` with a `range`. The `range`
+ * value reflects the position of the token in the original data.
+ */
+export class At extends BaseToken {
+	/**
+	 * The underlying symbol of the token.
+	 */
+	public static readonly symbol: string = '@';
+
+	/**
+	 * Return text representation of the token.
+	 */
+	public get text(): string {
+		return At.symbol;
+	}
+
+	/**
+	 * Create new token with range inside
+	 * the given `Line` at the given `column number`.
+	 */
+	public static newOnLine(
+		line: Line,
+		atColumnNumber: number,
+	): At {
+		const { range } = line;
+
+		return new At(new Range(
+			range.startLineNumber,
+			atColumnNumber,
+			range.startLineNumber,
+			atColumnNumber + this.symbol.length,
+		));
+	}
+
+	/**
+	 * Returns a string representation of the token.
+	 */
+	public override toString(): string {
+		return `at${this.range}`;
+	}
+}

--- a/src/vs/editor/test/common/codecs/linesDecoder.test.ts
+++ b/src/vs/editor/test/common/codecs/linesDecoder.test.ts
@@ -26,14 +26,14 @@ suite('LinesDecoder', () => {
 	 * Test the core logic with specific method of consuming
 	 * tokens that are produced by a lines decoder instance.
 	 */
-	suite('core logic', () => {
+	suite('• core logic', () => {
 		testLinesDecoder('async-generator', disposables);
 		testLinesDecoder('consume-all-method', disposables);
 		testLinesDecoder('on-data-event', disposables);
 	});
 
-	suite('settled promise', () => {
-		test('throws if accessed on not-yet-started decoder instance', () => {
+	suite('• settled promise', () => {
+		test('• throws if accessed on not-yet-started decoder instance', () => {
 			const test = disposables.add(new TestLinesDecoder());
 
 			assert.throws(
@@ -51,8 +51,8 @@ suite('LinesDecoder', () => {
 		});
 	});
 
-	suite('start', () => {
-		test('throws if the decoder object is already `disposed`', () => {
+	suite('• start', () => {
+		test('• throws if the decoder object is already `disposed`', () => {
 			const test = disposables.add(new TestLinesDecoder());
 			const { decoder } = test;
 			decoder.dispose();
@@ -63,7 +63,7 @@ suite('LinesDecoder', () => {
 			);
 		});
 
-		test('throws if the decoder object is already `ended`', async () => {
+		test('• throws if the decoder object is already `ended`', async () => {
 			const inputStream = newWriteableStream<VSBuffer>(null);
 			const test = disposables.add(new TestLinesDecoder(inputStream));
 			const { decoder } = test;
@@ -141,8 +141,8 @@ function testLinesDecoder(
 	disposables: Pick<DisposableStore, "add">,
 ) {
 	suite(tokensConsumeMethod, () => {
-		suite('produces expected tokens', () => {
-			test('input starts with line data', async () => {
+		suite('• produces expected tokens', () => {
+			test('• input starts with line data', async () => {
 				const test = disposables.add(new TestLinesDecoder());
 
 				await test.run(
@@ -160,7 +160,7 @@ function testLinesDecoder(
 				);
 			});
 
-			test('standalone \\r is treated as new line', async () => {
+			test('• standalone \\r is treated as new line', async () => {
 				const test = disposables.add(new TestLinesDecoder());
 
 				await test.run(
@@ -179,7 +179,7 @@ function testLinesDecoder(
 				);
 			});
 
-			test('input starts with a new line', async () => {
+			test('• input starts with a new line', async () => {
 				const test = disposables.add(new TestLinesDecoder());
 
 				await test.run(
@@ -202,7 +202,7 @@ function testLinesDecoder(
 				);
 			});
 
-			test('input starts and ends with multiple new lines', async () => {
+			test('• input starts and ends with multiple new lines', async () => {
 				const test = disposables.add(new TestLinesDecoder());
 
 				await test.run(
@@ -229,7 +229,7 @@ function testLinesDecoder(
 				);
 			});
 
-			test('single carriage return is treated as new line', async () => {
+			test('• single carriage return is treated as new line', async () => {
 				const test = disposables.add(new TestLinesDecoder());
 
 				await test.run(

--- a/src/vs/editor/test/common/codecs/linesDecoder.test.ts
+++ b/src/vs/editor/test/common/codecs/linesDecoder.test.ts
@@ -146,6 +146,24 @@ function testLinesDecoder(
 				const test = disposables.add(new TestLinesDecoder());
 
 				await test.run(
+					' hello world\nhow are you doing?\n\n 😊 \r',
+					[
+						new Line(1, ' hello world'),
+						new NewLine(new Range(1, 13, 1, 14)),
+						new Line(2, 'how are you doing?'),
+						new NewLine(new Range(2, 19, 2, 20)),
+						new Line(3, ''),
+						new NewLine(new Range(3, 1, 3, 2)),
+						new Line(4, ' 😊 '),
+						new NewLine(new Range(4, 5, 4, 6)),
+					],
+				);
+			});
+
+			test('standalone \\r is treated as new line', async () => {
+				const test = disposables.add(new TestLinesDecoder());
+
+				await test.run(
 					' hello world\nhow are you doing?\n\n 😊 \r ',
 					[
 						new Line(1, ' hello world'),
@@ -155,7 +173,7 @@ function testLinesDecoder(
 						new Line(3, ''),
 						new NewLine(new Range(3, 1, 3, 2)),
 						new Line(4, ' 😊 '),
-						new CarriageReturn(new Range(4, 5, 4, 6)),
+						new NewLine(new Range(4, 5, 4, 6)),
 						new Line(5, ' '),
 					],
 				);
@@ -218,11 +236,11 @@ function testLinesDecoder(
 					'\r\rhaalo! 💥💥 how\'re you?\r ?!\r\n\r\n ',
 					[
 						new Line(1, ''),
-						new CarriageReturn(new Range(1, 1, 1, 2)),
+						new NewLine(new Range(1, 1, 1, 2)),
 						new Line(2, ''),
-						new CarriageReturn(new Range(2, 1, 2, 2)),
+						new NewLine(new Range(2, 1, 2, 2)),
 						new Line(3, 'haalo! 💥💥 how\'re you?'),
-						new CarriageReturn(new Range(3, 24, 3, 25)),
+						new NewLine(new Range(3, 24, 3, 25)),
 						new Line(4, ' ?!'),
 						new CarriageReturn(new Range(4, 4, 4, 5)),
 						new NewLine(new Range(4, 5, 4, 6)),

--- a/src/vs/editor/test/common/codecs/markdownDecoder.test.ts
+++ b/src/vs/editor/test/common/codecs/markdownDecoder.test.ts
@@ -252,7 +252,7 @@ suite('MarkdownDecoder', () => {
 								// `1st` input line
 								new LeftBracket(new Range(1, 1, 1, 2)),
 								new Word(new Range(1, 2, 1, 2 + 3), 'haa'),
-								new stopCharacter(new Range(1, 5, 1, 6)), // <- stop character
+								new NewLine(new Range(1, 5, 1, 6)), // a single CR token is treated as a `new line`
 								new Word(new Range(2, 1, 2, 1 + 3), 'loů'),
 								new RightBracket(new Range(2, 4, 2, 5)),
 								new LeftParenthesis(new Range(2, 5, 2, 6)),
@@ -267,7 +267,7 @@ suite('MarkdownDecoder', () => {
 								new RightBracket(new Range(3, 10, 3, 11)),
 								new LeftParenthesis(new Range(3, 11, 3, 12)),
 								new Word(new Range(3, 12, 3, 12 + 8), '/etc/pat'),
-								new stopCharacter(new Range(3, 20, 3, 21)), // <- stop character
+								new NewLine(new Range(3, 20, 3, 21)), // a single CR token is treated as a `new line`
 								new Word(new Range(4, 1, 4, 1 + 12), 'h/to/file.md'),
 								new RightParenthesis(new Range(4, 13, 4, 14)),
 								new NewLine(new Range(4, 14, 4, 15)),
@@ -275,7 +275,7 @@ suite('MarkdownDecoder', () => {
 								new LeftBracket(new Range(5, 1, 5, 2)),
 								new Word(new Range(5, 2, 5, 2 + 4), 'text'),
 								new RightBracket(new Range(5, 6, 5, 7)),
-								new stopCharacter(new Range(5, 7, 5, 8)), // <- stop character
+								new NewLine(new Range(5, 7, 5, 8)), // a single CR token is treated as a `new line`
 								new LeftParenthesis(new Range(6, 1, 6, 2)),
 								new Word(new Range(6, 2, 6, 2 + 5), '/etc/'),
 								new Space(new Range(6, 7, 6, 8)),
@@ -546,7 +546,7 @@ suite('MarkdownDecoder', () => {
 								new ExclamationMark(new Range(1, 1, 1, 2)),
 								new LeftBracket(new Range(1, 2, 1, 3)),
 								new Word(new Range(1, 3, 1, 3 + 3), 'haa'),
-								new stopCharacter(new Range(1, 6, 1, 7)), // <- stop character
+								new NewLine(new Range(1, 6, 1, 7)),  // a single CR token is treated as a `new line`
 								new Word(new Range(2, 1, 2, 1 + 3), 'loů'),
 								new RightBracket(new Range(2, 4, 2, 5)),
 								new LeftParenthesis(new Range(2, 5, 2, 6)),
@@ -562,7 +562,7 @@ suite('MarkdownDecoder', () => {
 								new RightBracket(new Range(3, 11, 3, 12)),
 								new LeftParenthesis(new Range(3, 12, 3, 13)),
 								new Word(new Range(3, 13, 3, 13 + 8), '/etc/pat'),
-								new stopCharacter(new Range(3, 21, 3, 22)), // <- stop character
+								new NewLine(new Range(3, 21, 3, 22)),  // a single CR token is treated as a `new line`
 								new Word(new Range(4, 1, 4, 1 + 14), 'h/to/file.webp'),
 								new RightParenthesis(new Range(4, 15, 4, 16)),
 								new NewLine(new Range(4, 16, 4, 17)),
@@ -571,7 +571,7 @@ suite('MarkdownDecoder', () => {
 								new LeftBracket(new Range(5, 2, 5, 3)),
 								new Word(new Range(5, 3, 5, 3 + 4), 'text'),
 								new RightBracket(new Range(5, 7, 5, 8)),
-								new stopCharacter(new Range(5, 8, 5, 9)), // <- stop character
+								new NewLine(new Range(5, 8, 5, 9)),  // a single CR token is treated as a `new line`
 								new LeftParenthesis(new Range(6, 1, 6, 2)),
 								new Word(new Range(6, 2, 6, 2 + 5), '/etc/'),
 								new Space(new Range(6, 7, 6, 8)),

--- a/src/vs/editor/test/common/codecs/simpleDecoder.test.ts
+++ b/src/vs/editor/test/common/codecs/simpleDecoder.test.ts
@@ -55,10 +55,6 @@ export class TestSimpleDecoder extends TestDecoder<TSimpleToken, SimpleDecoder> 
 	}
 }
 
-/**
- * TODO: @legomushroom - test `\r` in the middle of a line
- */
-
 suite('SimpleDecoder', () => {
 	const testDisposables = ensureNoDisposablesAreLeakedInTestSuite();
 

--- a/src/vs/editor/test/common/codecs/simpleDecoder.test.ts
+++ b/src/vs/editor/test/common/codecs/simpleDecoder.test.ts
@@ -6,6 +6,7 @@
 import { TestDecoder } from '../utils/testDecoder.js';
 import { Range } from '../../../common/core/range.js';
 import { VSBuffer } from '../../../../base/common/buffer.js';
+import { At } from '../../../common/codecs/simpleCodec/tokens/at.js';
 import { newWriteableStream } from '../../../../base/common/stream.js';
 import { Tab } from '../../../common/codecs/simpleCodec/tokens/tab.js';
 import { Hash } from '../../../common/codecs/simpleCodec/tokens/hash.js';
@@ -16,13 +17,12 @@ import { NewLine } from '../../../common/codecs/linesCodec/tokens/newLine.js';
 import { FormFeed } from '../../../common/codecs/simpleCodec/tokens/formFeed.js';
 import { VerticalTab } from '../../../common/codecs/simpleCodec/tokens/verticalTab.js';
 import { CarriageReturn } from '../../../common/codecs/linesCodec/tokens/carriageReturn.js';
+import { ExclamationMark } from '../../../common/codecs/simpleCodec/tokens/exclamationMark.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
 import { SimpleDecoder, TSimpleToken } from '../../../common/codecs/simpleCodec/simpleDecoder.js';
 import { LeftBracket, RightBracket } from '../../../common/codecs/simpleCodec/tokens/brackets.js';
 import { LeftParenthesis, RightParenthesis } from '../../../common/codecs/simpleCodec/tokens/parentheses.js';
 import { LeftAngleBracket, RightAngleBracket } from '../../../common/codecs/simpleCodec/tokens/angleBrackets.js';
-import { ExclamationMark } from '../../../common/codecs/simpleCodec/tokens/exclamationMark.js';
-import { At } from '../../../common/codecs/simpleCodec/tokens/at.js';
 
 /**
  * A reusable test utility that asserts that a `SimpleDecoder` instance
@@ -75,7 +75,7 @@ suite('SimpleDecoder', () => {
 				'   (test)  [!@#$%^🦄&*_+=-]\f  ',
 				'\t<hi 👋>\t🤗❤ \t',
 				' hey\v-\tthere\r',
-				'',
+				' @workspace@legomushroom',
 			],
 			[
 				// first line
@@ -137,6 +137,12 @@ suite('SimpleDecoder', () => {
 				new Word(new Range(6, 8, 6, 13), 'there'),
 				new CarriageReturn(new Range(6, 13, 6, 14)),
 				new NewLine(new Range(6, 14, 6, 15)),
+				// seventh line
+				new Space(new Range(7, 1, 7, 2)),
+				new At(new Range(7, 2, 7, 3)),
+				new Word(new Range(7, 3, 7, 12), 'workspace'),
+				new At(new Range(7, 12, 7, 13)),
+				new Word(new Range(7, 13, 7, 25), 'legomushroom'),
 			],
 		);
 	});

--- a/src/vs/editor/test/common/codecs/simpleDecoder.test.ts
+++ b/src/vs/editor/test/common/codecs/simpleDecoder.test.ts
@@ -22,6 +22,7 @@ import { LeftBracket, RightBracket } from '../../../common/codecs/simpleCodec/to
 import { LeftParenthesis, RightParenthesis } from '../../../common/codecs/simpleCodec/tokens/parentheses.js';
 import { LeftAngleBracket, RightAngleBracket } from '../../../common/codecs/simpleCodec/tokens/angleBrackets.js';
 import { ExclamationMark } from '../../../common/codecs/simpleCodec/tokens/exclamationMark.js';
+import { At } from '../../../common/codecs/simpleCodec/tokens/at.js';
 
 /**
  * A reusable test utility that asserts that a `SimpleDecoder` instance
@@ -54,6 +55,10 @@ export class TestSimpleDecoder extends TestDecoder<TSimpleToken, SimpleDecoder> 
 	}
 }
 
+/**
+ * TODO: @legomushroom - test `\r` in the middle of a line
+ */
+
 suite('SimpleDecoder', () => {
 	const testDisposables = ensureNoDisposablesAreLeakedInTestSuite();
 
@@ -63,7 +68,15 @@ suite('SimpleDecoder', () => {
 		);
 
 		await test.run(
-			' hello world!\nhow are\t you?\v\n\n   (test)  [!@#$%^🦄&*_+=-]\f  \n\t<hi 👋>\t🤗❤ \t\n hey\v-\tthere\r\n\r\n',
+			[
+				' hello world!',
+				'how are\t you?\v',
+				'',
+				'   (test)  [!@#$%^🦄&*_+=-]\f  ',
+				'\t<hi 👋>\t🤗❤ \t',
+				' hey\v-\tthere\r',
+				'',
+			],
 			[
 				// first line
 				new Space(new Range(1, 1, 1, 2)),
@@ -94,7 +107,7 @@ suite('SimpleDecoder', () => {
 				new Space(new Range(4, 11, 4, 12)),
 				new LeftBracket(new Range(4, 12, 4, 13)),
 				new ExclamationMark(new Range(4, 13, 4, 14)),
-				new Word(new Range(4, 14, 4, 15), '@'),
+				new At(new Range(4, 14, 4, 15)),
 				new Hash(new Range(4, 15, 4, 16)),
 				new Word(new Range(4, 16, 4, 16 + 10), '$%^🦄&*_+='),
 				new Dash(new Range(4, 26, 4, 27)),
@@ -124,9 +137,6 @@ suite('SimpleDecoder', () => {
 				new Word(new Range(6, 8, 6, 13), 'there'),
 				new CarriageReturn(new Range(6, 13, 6, 14)),
 				new NewLine(new Range(6, 14, 6, 15)),
-				// seventh line
-				new CarriageReturn(new Range(7, 1, 7, 2)),
-				new NewLine(new Range(7, 2, 7, 3)),
 			],
 		);
 	});

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/codecs/parsers/promptAtMentionParser.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/codecs/parsers/promptAtMentionParser.ts
@@ -1,0 +1,127 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { PromptAtMention } from '../tokens/promptAtMention.js';
+import { pick } from '../../../../../../../base/common/arrays.js';
+import { assert } from '../../../../../../../base/common/assert.js';
+import { Range } from '../../../../../../../editor/common/core/range.js';
+import { At } from '../../../../../../../editor/common/codecs/simpleCodec/tokens/at.js';
+import { Tab } from '../../../../../../../editor/common/codecs/simpleCodec/tokens/tab.js';
+import { Hash } from '../../../../../../../editor/common/codecs/simpleCodec/tokens/hash.js';
+import { Space } from '../../../../../../../editor/common/codecs/simpleCodec/tokens/space.js';
+import { Colon } from '../../../../../../../editor/common/codecs/simpleCodec/tokens/colon.js';
+import { NewLine } from '../../../../../../../editor/common/codecs/linesCodec/tokens/newLine.js';
+import { FormFeed } from '../../../../../../../editor/common/codecs/simpleCodec/tokens/formFeed.js';
+import { TSimpleToken } from '../../../../../../../editor/common/codecs/simpleCodec/simpleDecoder.js';
+import { VerticalTab } from '../../../../../../../editor/common/codecs/simpleCodec/tokens/verticalTab.js';
+import { CarriageReturn } from '../../../../../../../editor/common/codecs/linesCodec/tokens/carriageReturn.js';
+import { ExclamationMark } from '../../../../../../../editor/common/codecs/simpleCodec/tokens/exclamationMark.js';
+import { LeftBracket, RightBracket } from '../../../../../../../editor/common/codecs/simpleCodec/tokens/brackets.js';
+import { LeftAngleBracket, RightAngleBracket } from '../../../../../../../editor/common/codecs/simpleCodec/tokens/angleBrackets.js';
+import { assertNotConsumed, ParserBase, TAcceptTokenResult } from '../../../../../../../editor/common/codecs/simpleCodec/parserBase.js';
+
+/**
+ * List of characters that terminate the prompt at-mention sequence.
+ */
+export const STOP_CHARACTERS: readonly string[] = [Space, Tab, NewLine, CarriageReturn, VerticalTab, FormFeed, At, Colon]
+	.map((token) => { return token.symbol; });
+
+/**
+ * List of characters that cannot be in an at-mention name (excluding the {@link STOP_CHARACTERS}).
+ */
+export const INVALID_NAME_CHARACTERS: readonly string[] = [Hash, At, Colon, ExclamationMark, LeftAngleBracket, RightAngleBracket, LeftBracket, RightBracket]
+	.map((token) => { return token.symbol; });
+
+/**
+ * TODO: @legomushroom - update the comment
+ */
+/**
+ * The parser responsible for parsing a `prompt @mention` sequences.
+ * E.g., `@workspace` or `#workspace` variable. If the `:` character follows
+ * the variable name, the parser transitions to {@link PartialPromptVariableWithData}
+ * that is also able to parse the `data` part of the variable. E.g., the `#file` part
+ * of the `#file:/path/to/something.md` sequence.
+ */
+export class PartialPromptAtMention extends ParserBase<TSimpleToken, PartialPromptAtMention | PromptAtMention> {
+	constructor(token: At) {
+		super([token]);
+	}
+
+	@assertNotConsumed
+	public accept(token: TSimpleToken): TAcceptTokenResult<PartialPromptAtMention | PromptAtMention> {
+		// if a `stop` character is encountered, finish the parsing process
+		if (STOP_CHARACTERS.includes(token.text)) {
+			try {
+				// if it is possible to convert current parser to `PromptAtMention`, return success result
+				return {
+					result: 'success',
+					nextParser: this.asPromptAtMention(),
+					wasTokenConsumed: false,
+				};
+			} catch (error) {
+				// otherwise fail
+				return {
+					result: 'failure',
+					wasTokenConsumed: false,
+				};
+			} finally {
+				// in any case this is an end of the parsing process
+				this.isConsumed = true;
+			}
+		}
+
+		// variables cannot have {@link INVALID_NAME_CHARACTERS} in their names
+		if (INVALID_NAME_CHARACTERS.includes(token.text)) {
+			this.isConsumed = true;
+
+			return {
+				result: 'failure',
+				wasTokenConsumed: false,
+			};
+		}
+
+		// otherwise it is a valid name character, so add it to the list of
+		// the current tokens and continue the parsing process
+		this.currentTokens.push(token);
+
+		return {
+			result: 'success',
+			nextParser: this,
+			wasTokenConsumed: true,
+		};
+	}
+
+	/**
+	 * Try to convert current parser instance into a fully-parsed {@link PromptAtMention} token.
+	 *
+	 * @throws if sequence of tokens received so far do not constitute a valid prompt variable,
+	 *        for instance, if there is only `1` starting `@` token is available.
+	 */
+	public asPromptAtMention(): PromptAtMention {
+		// if there is only one token before the stop character
+		// must be the starting `@` one), then fail
+		assert(
+			this.currentTokens.length > 1,
+			'Cannot create a prompt @mention out of incomplete token sequence.',
+		);
+
+		const firstToken = this.currentTokens[0];
+		const lastToken = this.currentTokens[this.currentTokens.length - 1];
+
+		// render the characters above into strings, excluding the starting `@` character
+		const nameTokens = this.currentTokens.slice(1);
+		const atMentionName = nameTokens.map(pick('text')).join('');
+
+		return new PromptAtMention(
+			new Range(
+				firstToken.range.startLineNumber,
+				firstToken.range.startColumn,
+				lastToken.range.endLineNumber,
+				lastToken.range.endColumn,
+			),
+			atMentionName,
+		);
+	}
+}

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/codecs/parsers/promptAtMentionParser.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/codecs/parsers/promptAtMentionParser.ts
@@ -25,13 +25,13 @@ import { assertNotConsumed, ParserBase, TAcceptTokenResult } from '../../../../.
 /**
  * List of characters that terminate the prompt at-mention sequence.
  */
-export const STOP_CHARACTERS: readonly string[] = [Space, Tab, NewLine, CarriageReturn, VerticalTab, FormFeed, At, Colon]
+export const STOP_CHARACTERS: readonly string[] = [Space, Tab, NewLine, CarriageReturn, VerticalTab, FormFeed, At, Colon, Hash]
 	.map((token) => { return token.symbol; });
 
 /**
  * List of characters that cannot be in an at-mention name (excluding the {@link STOP_CHARACTERS}).
  */
-export const INVALID_NAME_CHARACTERS: readonly string[] = [Hash, At, Colon, ExclamationMark, LeftAngleBracket, RightAngleBracket, LeftBracket, RightBracket]
+export const INVALID_NAME_CHARACTERS: readonly string[] = [ExclamationMark, LeftAngleBracket, RightAngleBracket, LeftBracket, RightBracket]
 	.map((token) => { return token.symbol; });
 
 /**

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/codecs/parsers/promptAtMentionParser.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/codecs/parsers/promptAtMentionParser.ts
@@ -35,14 +35,8 @@ export const INVALID_NAME_CHARACTERS: readonly string[] = [Hash, At, Colon, Excl
 	.map((token) => { return token.symbol; });
 
 /**
- * TODO: @legomushroom - update the comment
- */
-/**
  * The parser responsible for parsing a `prompt @mention` sequences.
- * E.g., `@workspace` or `#workspace` variable. If the `:` character follows
- * the variable name, the parser transitions to {@link PartialPromptVariableWithData}
- * that is also able to parse the `data` part of the variable. E.g., the `#file` part
- * of the `#file:/path/to/something.md` sequence.
+ * E.g., `@workspace` or `@github` participant mention.
  */
 export class PartialPromptAtMention extends ParserBase<TSimpleToken, PartialPromptAtMention | PromptAtMention> {
 	constructor(token: At) {

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/codecs/parsers/promptVariableParser.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/codecs/parsers/promptVariableParser.ts
@@ -7,6 +7,7 @@ import { pick } from '../../../../../../../base/common/arrays.js';
 import { assert } from '../../../../../../../base/common/assert.js';
 import { Range } from '../../../../../../../editor/common/core/range.js';
 import { PromptVariable, PromptVariableWithData } from '../tokens/promptVariable.js';
+import { At } from '../../../../../../../editor/common/codecs/simpleCodec/tokens/at.js';
 import { Tab } from '../../../../../../../editor/common/codecs/simpleCodec/tokens/tab.js';
 import { Hash } from '../../../../../../../editor/common/codecs/simpleCodec/tokens/hash.js';
 import { Space } from '../../../../../../../editor/common/codecs/simpleCodec/tokens/space.js';
@@ -22,13 +23,9 @@ import { LeftAngleBracket, RightAngleBracket } from '../../../../../../../editor
 import { assertNotConsumed, ParserBase, TAcceptTokenResult } from '../../../../../../../editor/common/codecs/simpleCodec/parserBase.js';
 
 /**
- * TODO: @legomushroom - the new @ character should stop variable parsing
- */
-
-/**
  * List of characters that terminate the prompt variable sequence.
  */
-export const STOP_CHARACTERS: readonly string[] = [Space, Tab, NewLine, CarriageReturn, VerticalTab, FormFeed]
+export const STOP_CHARACTERS: readonly string[] = [Space, Tab, NewLine, CarriageReturn, VerticalTab, FormFeed, Hash, At]
 	.map((token) => { return token.symbol; });
 
 /**

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/codecs/parsers/promptVariableParser.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/codecs/parsers/promptVariableParser.ts
@@ -22,6 +22,10 @@ import { LeftAngleBracket, RightAngleBracket } from '../../../../../../../editor
 import { assertNotConsumed, ParserBase, TAcceptTokenResult } from '../../../../../../../editor/common/codecs/simpleCodec/parserBase.js';
 
 /**
+ * TODO: @legomushroom - the new @ character should stop variable parsing
+ */
+
+/**
  * List of characters that terminate the prompt variable sequence.
  */
 export const STOP_CHARACTERS: readonly string[] = [Space, Tab, NewLine, CarriageReturn, VerticalTab, FormFeed]
@@ -35,7 +39,7 @@ export const INVALID_NAME_CHARACTERS: readonly string[] = [Hash, Colon, Exclamat
 
 /**
  * The parser responsible for parsing a `prompt variable name`.
- * E.g., `#selection` or `#workspace` variable. If the `:` character follows
+ * E.g., `#selection` or `#codebase` variable. If the `:` character follows
  * the variable name, the parser transitions to {@link PartialPromptVariableWithData}
  * that is also able to parse the `data` part of the variable. E.g., the `#file` part
  * of the `#file:/path/to/something.md` sequence.

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/codecs/tokens/promptAtMention.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/codecs/tokens/promptAtMention.ts
@@ -1,0 +1,72 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { PromptToken } from './promptToken.js';
+import { assert } from '../../../../../../../base/common/assert.js';
+import { Range } from '../../../../../../../editor/common/core/range.js';
+import { BaseToken } from '../../../../../../../editor/common/codecs/baseToken.js';
+import { INVALID_NAME_CHARACTERS, STOP_CHARACTERS } from '../parsers/promptVariableParser.js';
+
+/**
+ * All prompt at-mentions start with `@` character.
+ */
+const START_CHARACTER: string = '@';
+
+/**
+ * Represents a `@mention` token in a prompt text.
+ */
+export class PromptAtMention extends PromptToken {
+	constructor(
+		range: Range,
+		/**
+		 * The name of a mention, excluding the `@` character at the start.
+		 */
+		public readonly name: string,
+	) {
+		// sanity check of characters used in the provided mention name
+		for (const character of name) {
+			assert(
+				(INVALID_NAME_CHARACTERS.includes(character) === false) &&
+				(STOP_CHARACTERS.includes(character) === false),
+				`Mention 'name' cannot contain character '${character}', got '${name}'.`,
+			);
+		}
+
+		super(range);
+	}
+
+	/**
+	 * Get full text of the token.
+	 */
+	public get text(): string {
+		return `${START_CHARACTER}${this.name}`;
+	}
+
+	/**
+	 * Check if this token is equal to another one.
+	 */
+	public override equals<T extends BaseToken>(other: T): boolean {
+		if (!super.sameRange(other.range)) {
+			return false;
+		}
+
+		if ((other instanceof PromptAtMention) === false) {
+			return false;
+		}
+
+		if (this.text.length !== other.text.length) {
+			return false;
+		}
+
+		return this.text === other.text;
+	}
+
+	/**
+	 * Return a string representation of the token.
+	 */
+	public override toString(): string {
+		return `${this.text}${this.range}`;
+	}
+}

--- a/src/vs/workbench/contrib/chat/test/common/promptSyntax/codecs/chatPromptDecoder.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/promptSyntax/codecs/chatPromptDecoder.test.ts
@@ -8,6 +8,7 @@ import { Range } from '../../../../../../../editor/common/core/range.js';
 import { newWriteableStream } from '../../../../../../../base/common/stream.js';
 import { TestDecoder } from '../../../../../../../editor/test/common/utils/testDecoder.js';
 import { FileReference } from '../../../../common/promptSyntax/codecs/tokens/fileReference.js';
+import { PromptAtMention } from '../../../../common/promptSyntax/codecs/tokens/promptAtMention.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../../base/test/common/utils.js';
 import { MarkdownLink } from '../../../../../../../editor/common/codecs/markdownCodec/tokens/markdownLink.js';
 import { ChatPromptDecoder, TChatPromptToken } from '../../../../common/promptSyntax/codecs/chatPromptDecoder.js';
@@ -53,18 +54,22 @@ suite('ChatPromptDecoder', () => {
 
 		const contents = [
 			'',
-			'haalo!',
+			'haalo! @workspace',
 			' message 👾 message #file:./path/to/file1.md',
 			'',
 			'## Heading Title',
 			' \t#file:a/b/c/filename2.md\t🖖\t#file:other-file.md',
 			' [#file:reference.md](./reference.md)some text #file:/some/file/with/absolute/path.md',
-			'text text #file: another text',
+			'text text #file: another @github text',
 		];
 
 		await test.run(
 			contents,
 			[
+				new PromptAtMention(
+					new Range(2, 8, 2, 18),
+					'workspace',
+				),
 				new FileReference(
 					new Range(3, 21, 3, 21 + 24),
 					'./path/to/file1.md',
@@ -90,6 +95,10 @@ suite('ChatPromptDecoder', () => {
 				new FileReference(
 					new Range(8, 11, 8, 11 + 6),
 					'',
+				),
+				new PromptAtMention(
+					new Range(8, 26, 8, 33),
+					'github',
 				),
 			],
 		);

--- a/src/vs/workbench/contrib/chat/test/common/promptSyntax/codecs/chatPromptDecoder.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/promptSyntax/codecs/chatPromptDecoder.test.ts
@@ -114,4 +114,42 @@ suite('ChatPromptDecoder', () => {
 			],
 		);
 	});
+
+	suite('variables', () => {
+		test('• produces expected tokens', async () => {
+			const test = testDisposables.add(
+				new TestChatPromptDecoder(),
+			);
+
+			const contents = [
+				'',
+				'\t\v#variable@',
+				' #selection#your-variable',
+				'some-text #var:12:67# some text',
+			];
+
+			await test.run(
+				contents,
+				[
+					new PromptVariable(
+						new Range(2, 3, 2, 3 + 9),
+						'variable',
+					),
+					new PromptVariable(
+						new Range(3, 2, 3, 2 + 10),
+						'selection',
+					),
+					new PromptVariable(
+						new Range(3, 12, 3, 12 + 14),
+						'your-variable',
+					),
+					new PromptVariableWithData(
+						new Range(4, 11, 4, 11 + 10),
+						'var',
+						'12:67',
+					),
+				],
+			);
+		});
+	});
 });

--- a/src/vs/workbench/contrib/chat/test/common/promptSyntax/codecs/chatPromptDecoder.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/promptSyntax/codecs/chatPromptDecoder.test.ts
@@ -12,6 +12,7 @@ import { PromptAtMention } from '../../../../common/promptSyntax/codecs/tokens/p
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../../base/test/common/utils.js';
 import { MarkdownLink } from '../../../../../../../editor/common/codecs/markdownCodec/tokens/markdownLink.js';
 import { ChatPromptDecoder, TChatPromptToken } from '../../../../common/promptSyntax/codecs/chatPromptDecoder.js';
+import { PromptVariable, PromptVariableWithData } from '../../../../common/promptSyntax/codecs/tokens/promptVariable.js';
 
 /**
  * A reusable test utility that asserts that a `ChatPromptDecoder` instance
@@ -60,7 +61,8 @@ suite('ChatPromptDecoder', () => {
 			'## Heading Title',
 			' \t#file:a/b/c/filename2.md\t🖖\t#file:other-file.md',
 			' [#file:reference.md](./reference.md)some text #file:/some/file/with/absolute/path.md',
-			'text text #file: another @github text',
+			'text text #file: another @github text #selection even more text',
+			'\t\v#my-name:metadata:1:20 \t\t\t',
 		];
 
 		await test.run(
@@ -99,6 +101,15 @@ suite('ChatPromptDecoder', () => {
 				new PromptAtMention(
 					new Range(8, 26, 8, 33),
 					'github',
+				),
+				new PromptVariable(
+					new Range(8, 39, 8, 49),
+					'selection',
+				),
+				new PromptVariableWithData(
+					new Range(9, 3, 9, 3 + 22),
+					'my-name',
+					'metadata:1:20',
 				),
 			],
 		);


### PR DESCRIPTION
Adds `@mention` syntax support inside reusable prompt files.

Part of https://github.com/microsoft/vscode-copilot/issues/15596

cc @aeschli 