### PR TITLE
fix image hover wonkiness

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/media/chat.css
@@ -1723,9 +1723,11 @@ have to be updated for changes to the rules above, or to support more deeply nes
 .chat-attached-context-hover .chat-attached-context-image-container .chat-attached-context-image {
 	height: auto;
 	width: 100%;
+	height: 100%;
+	object-fit: contain;
 	display: block;
 	max-height: 350px;
-	max-width: 400px;
+	max-width: 100%;
 }
 
 .chat-attached-context-hover .chat-attached-context-url {

--- a/src/vs/workbench/contrib/chat/browser/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/media/chat.css
@@ -1721,7 +1721,6 @@ have to be updated for changes to the rules above, or to support more deeply nes
 }
 
 .chat-attached-context-hover .chat-attached-context-image-container .chat-attached-context-image {
-	height: auto;
 	width: 100%;
 	height: 100%;
 	object-fit: contain;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

fix some weirdness with how the image is set in the hover

example 1: a tall image (way larger than 350px) tries to squeeze in a 350px space.
![Screenshot 2025-04-07 at 11 37 23 AM](https://github.com/user-attachments/assets/e906caa3-d9ee-4e83-b912-55c05b55fd07)

example 2: a wide image (but not wide enough) does not fill up the entire space like he should
![Screenshot 2025-04-07 at 11 34 55 AM](https://github.com/user-attachments/assets/9602e31e-2873-44a7-901c-515bb02d34f6)

branch:
![139-Omastar](https://github.com/user-attachments/assets/60cc6d38-4e21-4e9c-8977-90af15b97fc8)

