### PR TITLE
[prompts]: /command syntax support

### DIFF
--- a/src/vs/editor/common/codecs/simpleCodec/simpleDecoder.ts
+++ b/src/vs/editor/common/codecs/simpleCodec/simpleDecoder.ts
@@ -22,13 +22,14 @@ import { LeftBracket, RightBracket, TBracket } from './tokens/brackets.js';
 import { BaseDecoder } from '../../../../base/common/codecs/baseDecoder.js';
 import { LeftParenthesis, RightParenthesis, TParenthesis } from './tokens/parentheses.js';
 import { LeftAngleBracket, RightAngleBracket, TAngleBracket } from './tokens/angleBrackets.js';
+import { Slash } from './tokens/slash.js';
 
 /**
  * A token type that this decoder can handle.
  */
 export type TSimpleToken = Word | Space | Tab | VerticalTab | At | NewLine | FormFeed
 	| CarriageReturn | TBracket | TAngleBracket | TParenthesis
-	| Colon | Hash | Dash | ExclamationMark;
+	| Colon | Hash | Dash | ExclamationMark | Slash;
 
 /**
  * List of well-known distinct tokens that this decoder emits (excluding
@@ -38,7 +39,7 @@ export type TSimpleToken = Word | Space | Tab | VerticalTab | At | NewLine | For
 const WELL_KNOWN_TOKENS = Object.freeze([
 	Space, Tab, VerticalTab, FormFeed,
 	LeftBracket, RightBracket, LeftAngleBracket, RightAngleBracket,
-	LeftParenthesis, RightParenthesis, Colon, Hash, Dash, ExclamationMark, At,
+	LeftParenthesis, RightParenthesis, Colon, Hash, Dash, ExclamationMark, At, Slash,
 ]);
 
 /**
@@ -47,11 +48,11 @@ const WELL_KNOWN_TOKENS = Object.freeze([
  * 	     already handles the `carriagereturn`/`newline` cases and emits lines that don't contain them.
  */
 const WORD_STOP_CHARACTERS: readonly string[] = Object.freeze([
-	Space.symbol, Tab.symbol, VerticalTab.symbol, FormFeed.symbol, At.symbol,
+	Space.symbol, Tab.symbol, VerticalTab.symbol, FormFeed.symbol, At.symbol, Slash.symbol,
+	Colon.symbol, Hash.symbol, Dash.symbol, ExclamationMark.symbol,
 	LeftBracket.symbol, RightBracket.symbol,
 	LeftParenthesis.symbol, RightParenthesis.symbol,
 	LeftAngleBracket.symbol, RightAngleBracket.symbol,
-	Colon.symbol, Hash.symbol, Dash.symbol, ExclamationMark.symbol,
 ]);
 
 /**

--- a/src/vs/editor/common/codecs/simpleCodec/tokens/slash.ts
+++ b/src/vs/editor/common/codecs/simpleCodec/tokens/slash.ts
@@ -1,0 +1,51 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { BaseToken } from '../../baseToken.js';
+import { Line } from '../../linesCodec/tokens/line.js';
+import { Range } from '../../../../../editor/common/core/range.js';
+
+/**
+ * A token that represent a `/` with a `range`. The `range`
+ * value reflects the position of the token in the original data.
+ */
+export class Slash extends BaseToken {
+	/**
+	 * The underlying symbol of the token.
+	 */
+	public static readonly symbol: string = '/';
+
+	/**
+	 * Return text representation of the token.
+	 */
+	public get text(): string {
+		return Slash.symbol;
+	}
+
+	/**
+	 * Create new token with range inside
+	 * the given `Line` at the given `column number`.
+	 */
+	public static newOnLine(
+		line: Line,
+		atColumnNumber: number,
+	): Slash {
+		const { range } = line;
+
+		return new Slash(new Range(
+			range.startLineNumber,
+			atColumnNumber,
+			range.startLineNumber,
+			atColumnNumber + this.symbol.length,
+		));
+	}
+
+	/**
+	 * Returns a string representation of the token.
+	 */
+	public override toString(): string {
+		return `slash${this.range}`;
+	}
+}

--- a/src/vs/editor/test/common/codecs/markdownDecoder.test.ts
+++ b/src/vs/editor/test/common/codecs/markdownDecoder.test.ts
@@ -12,6 +12,7 @@ import { Tab } from '../../../common/codecs/simpleCodec/tokens/tab.js';
 import { Word } from '../../../common/codecs/simpleCodec/tokens/word.js';
 import { Dash } from '../../../common/codecs/simpleCodec/tokens/dash.js';
 import { Space } from '../../../common/codecs/simpleCodec/tokens/space.js';
+import { Slash } from '../../../common/codecs/simpleCodec/tokens/slash.js';
 import { NewLine } from '../../../common/codecs/linesCodec/tokens/newLine.js';
 import { FormFeed } from '../../../common/codecs/simpleCodec/tokens/formFeed.js';
 import { VerticalTab } from '../../../common/codecs/simpleCodec/tokens/verticalTab.js';
@@ -195,9 +196,15 @@ suite('MarkdownDecoder', () => {
 						new Space(new Range(1, 2, 1, 3)),
 						new RightBracket(new Range(1, 3, 1, 4)),
 						new LeftParenthesis(new Range(1, 4, 1, 5)),
-						new Word(new Range(1, 5, 1, 5 + 11), './real/file'),
+						new Word(new Range(1, 5, 1, 5 + 1), '.'),
+						new Slash(new Range(1, 6, 1, 7)),
+						new Word(new Range(1, 7, 1, 7 + 4), 'real'),
+						new Slash(new Range(1, 11, 1, 12)),
+						new Word(new Range(1, 12, 1, 12 + 4), 'file'),
 						new Space(new Range(1, 16, 1, 17)),
-						new Word(new Range(1, 17, 1, 17 + 17), 'path/file⇧name.md'),
+						new Word(new Range(1, 17, 1, 17 + 4), 'path'),
+						new Slash(new Range(1, 21, 1, 22)),
+						new Word(new Range(1, 22, 1, 22 + 12), 'file⇧name.md'),
 						new NewLine(new Range(1, 34, 1, 35)),
 						// `2nd` line
 						new LeftBracket(new Range(2, 1, 2, 2)),
@@ -207,22 +214,26 @@ suite('MarkdownDecoder', () => {
 						new RightBracket(new Range(2, 11, 2, 12)),
 						new Space(new Range(2, 12, 2, 13)),
 						new LeftParenthesis(new Range(2, 13, 2, 14)),
-						new Word(new Range(2, 14, 2, 14 + 6), './file'),
+						new Word(new Range(2, 14, 2, 14 + 1), '.'),
+						new Slash(new Range(2, 15, 2, 16)),
+						new Word(new Range(2, 16, 2, 16 + 4), 'file'),
 						new Space(new Range(2, 20, 2, 21)),
-						new Word(new Range(2, 21, 2, 21 + 13), 'path/name.txt'),
+						new Word(new Range(2, 21, 2, 21 + 4), 'path'),
+						new Slash(new Range(2, 25, 2, 26)),
+						new Word(new Range(2, 26, 2, 26 + 8), 'name.txt'),
 						new RightParenthesis(new Range(2, 34, 2, 35)),
 					],
 				);
 			});
 
 			suite('• stop characters inside caption/reference (new lines)', () => {
-				for (const stopCharacter of [CarriageReturn, NewLine]) {
+				for (const StopCharacter of [CarriageReturn, NewLine]) {
 					let characterName = '';
 
-					if (stopCharacter === CarriageReturn) {
+					if (StopCharacter === CarriageReturn) {
 						characterName = '\\r';
 					}
-					if (stopCharacter === NewLine) {
+					if (StopCharacter === NewLine) {
 						characterName = '\\n';
 					}
 
@@ -238,11 +249,11 @@ suite('MarkdownDecoder', () => {
 
 						const inputLines = [
 							// stop character inside link caption
-							`[haa${stopCharacter.symbol}loů](./real/💁/name.txt)`,
+							`[haa${StopCharacter.symbol}loů](./real/💁/name.txt)`,
 							// stop character inside link reference
-							`[ref text](/etc/pat${stopCharacter.symbol}h/to/file.md)`,
+							`[ref text](/etc/pat${StopCharacter.symbol}h/to/file.md)`,
 							// stop character between line caption and link reference is disallowed
-							`[text]${stopCharacter.symbol}(/etc/ path/file.md)`,
+							`[text]${StopCharacter.symbol}(/etc/ path/main.mdc)`,
 						];
 
 
@@ -256,7 +267,13 @@ suite('MarkdownDecoder', () => {
 								new Word(new Range(2, 1, 2, 1 + 3), 'loů'),
 								new RightBracket(new Range(2, 4, 2, 5)),
 								new LeftParenthesis(new Range(2, 5, 2, 6)),
-								new Word(new Range(2, 6, 2, 6 + 18), './real/💁/name.txt'),
+								new Word(new Range(2, 6, 2, 6 + 1), '.'),
+								new Slash(new Range(2, 7, 2, 8)),
+								new Word(new Range(2, 8, 2, 8 + 4), 'real'),
+								new Slash(new Range(2, 12, 2, 13)),
+								new Word(new Range(2, 13, 2, 13 + 2), '💁'),
+								new Slash(new Range(2, 15, 2, 16)),
+								new Word(new Range(2, 16, 2, 16 + 8), 'name.txt'),
 								new RightParenthesis(new Range(2, 24, 2, 25)),
 								new NewLine(new Range(2, 25, 2, 26)),
 								// `2nd` input line
@@ -266,9 +283,16 @@ suite('MarkdownDecoder', () => {
 								new Word(new Range(3, 6, 3, 6 + 4), 'text'),
 								new RightBracket(new Range(3, 10, 3, 11)),
 								new LeftParenthesis(new Range(3, 11, 3, 12)),
-								new Word(new Range(3, 12, 3, 12 + 8), '/etc/pat'),
+								new Slash(new Range(3, 12, 3, 13)),
+								new Word(new Range(3, 13, 3, 13 + 3), 'etc'),
+								new Slash(new Range(3, 16, 3, 17)),
+								new Word(new Range(3, 17, 3, 17 + 3), 'pat'),
 								new NewLine(new Range(3, 20, 3, 21)), // a single CR token is treated as a `new line`
-								new Word(new Range(4, 1, 4, 1 + 12), 'h/to/file.md'),
+								new Word(new Range(4, 1, 4, 1 + 1), 'h'),
+								new Slash(new Range(4, 2, 4, 3)),
+								new Word(new Range(4, 3, 4, 3 + 2), 'to'),
+								new Slash(new Range(4, 5, 4, 6)),
+								new Word(new Range(4, 6, 4, 6 + 7), 'file.md'),
 								new RightParenthesis(new Range(4, 13, 4, 14)),
 								new NewLine(new Range(4, 14, 4, 15)),
 								// `3nd` input line
@@ -277,10 +301,14 @@ suite('MarkdownDecoder', () => {
 								new RightBracket(new Range(5, 6, 5, 7)),
 								new NewLine(new Range(5, 7, 5, 8)), // a single CR token is treated as a `new line`
 								new LeftParenthesis(new Range(6, 1, 6, 2)),
-								new Word(new Range(6, 2, 6, 2 + 5), '/etc/'),
+								new Slash(new Range(6, 2, 6, 3)),
+								new Word(new Range(6, 3, 6, 3 + 3), 'etc'),
+								new Slash(new Range(6, 6, 6, 7)),
 								new Space(new Range(6, 7, 6, 8)),
-								new Word(new Range(6, 8, 6, 8 + 12), 'path/file.md'),
-								new RightParenthesis(new Range(6, 20, 6, 21)),
+								new Word(new Range(6, 8, 6, 8 + 4), 'path'),
+								new Slash(new Range(6, 12, 6, 13)),
+								new Word(new Range(6, 13, 6, 13 + 8), 'main.mdc'),
+								new RightParenthesis(new Range(6, 21, 6, 22)),
 							],
 						);
 					});
@@ -291,13 +319,13 @@ suite('MarkdownDecoder', () => {
 			 * Same as above but these stop characters do not move the caret to the next line.
 			 */
 			suite('• stop characters inside caption/reference (same line)', () => {
-				for (const stopCharacter of [VerticalTab, FormFeed]) {
+				for (const StopCharacter of [VerticalTab, FormFeed]) {
 					let characterName = '';
 
-					if (stopCharacter === VerticalTab) {
+					if (StopCharacter === VerticalTab) {
 						characterName = '\\v';
 					}
-					if (stopCharacter === FormFeed) {
+					if (StopCharacter === FormFeed) {
 						characterName = '\\f';
 					}
 
@@ -313,11 +341,11 @@ suite('MarkdownDecoder', () => {
 
 						const inputLines = [
 							// stop character inside link caption
-							`[haa${stopCharacter.symbol}loů](./real/💁/name.txt)`,
+							`[haa${StopCharacter.symbol}loů](./real/💁/name.txt)`,
 							// stop character inside link reference
-							`[ref text](/etc/pat${stopCharacter.symbol}h/to/file.md)`,
+							`[ref text](/etc/pat${StopCharacter.symbol}h/to/file.md)`,
 							// stop character between line caption and link reference is disallowed
-							`[text]${stopCharacter.symbol}(/etc/ path/file.md)`,
+							`[text]${StopCharacter.symbol}(/etc/ path/file.md)`,
 						];
 
 
@@ -327,11 +355,17 @@ suite('MarkdownDecoder', () => {
 								// `1st` input line
 								new LeftBracket(new Range(1, 1, 1, 2)),
 								new Word(new Range(1, 2, 1, 2 + 3), 'haa'),
-								new stopCharacter(new Range(1, 5, 1, 6)), // <- stop character
+								new StopCharacter(new Range(1, 5, 1, 6)), // <- stop character
 								new Word(new Range(1, 6, 1, 6 + 3), 'loů'),
 								new RightBracket(new Range(1, 9, 1, 10)),
 								new LeftParenthesis(new Range(1, 10, 1, 11)),
-								new Word(new Range(1, 11, 1, 11 + 18), './real/💁/name.txt'),
+								new Word(new Range(1, 11, 1, 11 + 1), '.'),
+								new Slash(new Range(1, 12, 1, 13)),
+								new Word(new Range(1, 13, 1, 13 + 4), 'real'),
+								new Slash(new Range(1, 17, 1, 18)),
+								new Word(new Range(1, 18, 1, 18 + 2), '💁'),
+								new Slash(new Range(1, 20, 1, 21)),
+								new Word(new Range(1, 21, 1, 21 + 8), 'name.txt'),
 								new RightParenthesis(new Range(1, 29, 1, 30)),
 								new NewLine(new Range(1, 30, 1, 31)),
 								// `2nd` input line
@@ -341,20 +375,31 @@ suite('MarkdownDecoder', () => {
 								new Word(new Range(2, 6, 2, 6 + 4), 'text'),
 								new RightBracket(new Range(2, 10, 2, 11)),
 								new LeftParenthesis(new Range(2, 11, 2, 12)),
-								new Word(new Range(2, 12, 2, 12 + 8), '/etc/pat'),
-								new stopCharacter(new Range(2, 20, 2, 21)), // <- stop character
-								new Word(new Range(2, 21, 2, 21 + 12), 'h/to/file.md'),
+								new Slash(new Range(2, 12, 2, 13)),
+								new Word(new Range(2, 13, 2, 13 + 3), 'etc'),
+								new Slash(new Range(2, 16, 2, 17)),
+								new Word(new Range(2, 17, 2, 17 + 3), 'pat'),
+								new StopCharacter(new Range(2, 20, 2, 21)), // <- stop character
+								new Word(new Range(2, 21, 2, 21 + 1), 'h'),
+								new Slash(new Range(2, 22, 2, 23)),
+								new Word(new Range(2, 23, 2, 23 + 2), 'to'),
+								new Slash(new Range(2, 25, 2, 26)),
+								new Word(new Range(2, 26, 2, 26 + 7), 'file.md'),
 								new RightParenthesis(new Range(2, 33, 2, 34)),
 								new NewLine(new Range(2, 34, 2, 35)),
 								// `3nd` input line
 								new LeftBracket(new Range(3, 1, 3, 2)),
 								new Word(new Range(3, 2, 3, 2 + 4), 'text'),
 								new RightBracket(new Range(3, 6, 3, 7)),
-								new stopCharacter(new Range(3, 7, 3, 8)), // <- stop character
+								new StopCharacter(new Range(3, 7, 3, 8)), // <- stop character
 								new LeftParenthesis(new Range(3, 8, 3, 9)),
-								new Word(new Range(3, 9, 3, 9 + 5), '/etc/'),
+								new Slash(new Range(3, 9, 3, 10)),
+								new Word(new Range(3, 10, 3, 10 + 3), 'etc'),
+								new Slash(new Range(3, 13, 3, 14)),
 								new Space(new Range(3, 14, 3, 15)),
-								new Word(new Range(3, 15, 3, 15 + 12), 'path/file.md'),
+								new Word(new Range(3, 15, 3, 15 + 4), 'path'),
+								new Slash(new Range(3, 19, 3, 20)),
+								new Word(new Range(3, 20, 3, 20 + 7), 'file.md'),
 								new RightParenthesis(new Range(3, 27, 3, 28)),
 							],
 						);
@@ -461,7 +506,7 @@ suite('MarkdownDecoder', () => {
 					// space between caption and reference is disallowed
 					'\f![link text] (./file path/name.jpg)',
 					// new line inside the link reference
-					'\v![ ](./file\npath/name.jpg )',
+					'\v![ ](./file\npath/name.jpeg )',
 				];
 
 				await test.run(
@@ -473,9 +518,15 @@ suite('MarkdownDecoder', () => {
 						new Space(new Range(1, 3, 1, 4)),
 						new RightBracket(new Range(1, 4, 1, 5)),
 						new LeftParenthesis(new Range(1, 5, 1, 6)),
-						new Word(new Range(1, 6, 1, 6 + 11), './real/file'),
+						new Word(new Range(1, 6, 1, 6 + 1), '.'),
+						new Slash(new Range(1, 7, 1, 8)),
+						new Word(new Range(1, 8, 1, 8 + 4), 'real'),
+						new Slash(new Range(1, 12, 1, 13)),
+						new Word(new Range(1, 13, 1, 13 + 4), 'file'),
 						new Space(new Range(1, 17, 1, 18)),
-						new Word(new Range(1, 18, 1, 18 + 19), 'path/file★name.webp'),
+						new Word(new Range(1, 18, 1, 18 + 4), 'path'),
+						new Slash(new Range(1, 22, 1, 23)),
+						new Word(new Range(1, 23, 1, 23 + 14), 'file★name.webp'),
 						new NewLine(new Range(1, 37, 1, 38)),
 						// `2nd` line
 						new FormFeed(new Range(2, 1, 2, 2)),
@@ -487,9 +538,13 @@ suite('MarkdownDecoder', () => {
 						new RightBracket(new Range(2, 13, 2, 14)),
 						new Space(new Range(2, 14, 2, 15)),
 						new LeftParenthesis(new Range(2, 15, 2, 16)),
-						new Word(new Range(2, 16, 2, 16 + 6), './file'),
+						new Word(new Range(2, 16, 2, 16 + 1), '.'),
+						new Slash(new Range(2, 17, 2, 18)),
+						new Word(new Range(2, 18, 2, 18 + 4), 'file'),
 						new Space(new Range(2, 22, 2, 23)),
-						new Word(new Range(2, 23, 2, 23 + 13), 'path/name.jpg'),
+						new Word(new Range(2, 23, 2, 23 + 4), 'path'),
+						new Slash(new Range(2, 27, 2, 28)),
+						new Word(new Range(2, 28, 2, 28 + 8), 'name.jpg'),
 						new RightParenthesis(new Range(2, 36, 2, 37)),
 						new NewLine(new Range(2, 37, 2, 38)),
 						// `3rd` line
@@ -499,23 +554,27 @@ suite('MarkdownDecoder', () => {
 						new Space(new Range(3, 4, 3, 5)),
 						new RightBracket(new Range(3, 5, 3, 6)),
 						new LeftParenthesis(new Range(3, 6, 3, 7)),
-						new Word(new Range(3, 7, 3, 7 + 6), './file'),
+						new Word(new Range(3, 7, 3, 7 + 1), '.'),
+						new Slash(new Range(3, 8, 3, 9)),
+						new Word(new Range(3, 9, 3, 9 + 4), 'file'),
 						new NewLine(new Range(3, 13, 3, 14)),
-						new Word(new Range(4, 1, 4, 1 + 13), 'path/name.jpg'),
-						new Space(new Range(4, 14, 4, 15)),
-						new RightParenthesis(new Range(4, 15, 4, 16)),
+						new Word(new Range(4, 1, 4, 1 + 4), 'path'),
+						new Slash(new Range(4, 5, 4, 6)),
+						new Word(new Range(4, 6, 4, 6 + 9), 'name.jpeg'),
+						new Space(new Range(4, 15, 4, 16)),
+						new RightParenthesis(new Range(4, 16, 4, 17)),
 					],
 				);
 			});
 
 			suite('• stop characters inside caption/reference (new lines)', () => {
-				for (const stopCharacter of [CarriageReturn, NewLine]) {
+				for (const StopCharacter of [CarriageReturn, NewLine]) {
 					let characterName = '';
 
-					if (stopCharacter === CarriageReturn) {
+					if (StopCharacter === CarriageReturn) {
 						characterName = '\\r';
 					}
-					if (stopCharacter === NewLine) {
+					if (StopCharacter === NewLine) {
 						characterName = '\\n';
 					}
 
@@ -531,11 +590,11 @@ suite('MarkdownDecoder', () => {
 
 						const inputLines = [
 							// stop character inside link caption
-							`![haa${stopCharacter.symbol}loů](./real/💁/name.png)`,
+							`![haa${StopCharacter.symbol}loů](./real/💁/name.png)`,
 							// stop character inside link reference
-							`![ref text](/etc/pat${stopCharacter.symbol}h/to/file.webp)`,
+							`![ref text](/etc/pat${StopCharacter.symbol}h/to/file.webp)`,
 							// stop character between line caption and link reference is disallowed
-							`![text]${stopCharacter.symbol}(/etc/ path/file.jpeg)`,
+							`![text]${StopCharacter.symbol}(/etc/ path/file.jpeg)`,
 						];
 
 
@@ -546,11 +605,17 @@ suite('MarkdownDecoder', () => {
 								new ExclamationMark(new Range(1, 1, 1, 2)),
 								new LeftBracket(new Range(1, 2, 1, 3)),
 								new Word(new Range(1, 3, 1, 3 + 3), 'haa'),
-								new NewLine(new Range(1, 6, 1, 7)),  // a single CR token is treated as a `new line`
+								new NewLine(new Range(1, 6, 1, 7)), // a single CR token is treated as a `new line`
 								new Word(new Range(2, 1, 2, 1 + 3), 'loů'),
 								new RightBracket(new Range(2, 4, 2, 5)),
 								new LeftParenthesis(new Range(2, 5, 2, 6)),
-								new Word(new Range(2, 6, 2, 6 + 18), './real/💁/name.png'),
+								new Word(new Range(2, 6, 2, 6 + 1), '.'),
+								new Slash(new Range(2, 7, 2, 8)),
+								new Word(new Range(2, 8, 2, 8 + 4), 'real'),
+								new Slash(new Range(2, 12, 2, 13)),
+								new Word(new Range(2, 13, 2, 13 + 2), '💁'),
+								new Slash(new Range(2, 15, 2, 16)),
+								new Word(new Range(2, 16, 2, 16 + 8), 'name.png'),
 								new RightParenthesis(new Range(2, 24, 2, 25)),
 								new NewLine(new Range(2, 25, 2, 26)),
 								// `2nd` input line
@@ -561,9 +626,16 @@ suite('MarkdownDecoder', () => {
 								new Word(new Range(3, 7, 3, 7 + 4), 'text'),
 								new RightBracket(new Range(3, 11, 3, 12)),
 								new LeftParenthesis(new Range(3, 12, 3, 13)),
-								new Word(new Range(3, 13, 3, 13 + 8), '/etc/pat'),
-								new NewLine(new Range(3, 21, 3, 22)),  // a single CR token is treated as a `new line`
-								new Word(new Range(4, 1, 4, 1 + 14), 'h/to/file.webp'),
+								new Slash(new Range(3, 13, 3, 14)),
+								new Word(new Range(3, 14, 3, 14 + 3), 'etc'),
+								new Slash(new Range(3, 17, 3, 18)),
+								new Word(new Range(3, 18, 3, 18 + 3), 'pat'),
+								new NewLine(new Range(3, 21, 3, 22)), // a single CR token is treated as a `new line`
+								new Word(new Range(4, 1, 4, 1 + 1), 'h'),
+								new Slash(new Range(4, 2, 4, 3)),
+								new Word(new Range(4, 3, 4, 3 + 2), 'to'),
+								new Slash(new Range(4, 5, 4, 6)),
+								new Word(new Range(4, 6, 4, 6 + 9), 'file.webp'),
 								new RightParenthesis(new Range(4, 15, 4, 16)),
 								new NewLine(new Range(4, 16, 4, 17)),
 								// `3nd` input line
@@ -571,11 +643,15 @@ suite('MarkdownDecoder', () => {
 								new LeftBracket(new Range(5, 2, 5, 3)),
 								new Word(new Range(5, 3, 5, 3 + 4), 'text'),
 								new RightBracket(new Range(5, 7, 5, 8)),
-								new NewLine(new Range(5, 8, 5, 9)),  // a single CR token is treated as a `new line`
+								new NewLine(new Range(5, 8, 5, 9)), // a single CR token is treated as a `new line`
 								new LeftParenthesis(new Range(6, 1, 6, 2)),
-								new Word(new Range(6, 2, 6, 2 + 5), '/etc/'),
+								new Slash(new Range(6, 2, 6, 3)),
+								new Word(new Range(6, 3, 6, 3 + 3), 'etc'),
+								new Slash(new Range(6, 6, 6, 7)),
 								new Space(new Range(6, 7, 6, 8)),
-								new Word(new Range(6, 8, 6, 8 + 14), 'path/file.jpeg'),
+								new Word(new Range(6, 8, 6, 8 + 4), 'path'),
+								new Slash(new Range(6, 12, 6, 13)),
+								new Word(new Range(6, 13, 6, 13 + 9), 'file.jpeg'),
 								new RightParenthesis(new Range(6, 22, 6, 23)),
 							],
 						);
@@ -628,7 +704,13 @@ suite('MarkdownDecoder', () => {
 								new Word(new Range(1, 7, 1, 7 + 3), 'loů'),
 								new RightBracket(new Range(1, 10, 1, 11)),
 								new LeftParenthesis(new Range(1, 11, 1, 12)),
-								new Word(new Range(1, 12, 1, 12 + 14), './real/💁/name'),
+								new Word(new Range(1, 12, 1, 12 + 1), '.'),
+								new Slash(new Range(1, 13, 1, 14)),
+								new Word(new Range(1, 14, 1, 14 + 4), 'real'),
+								new Slash(new Range(1, 18, 1, 19)),
+								new Word(new Range(1, 19, 1, 19 + 2), '💁'),
+								new Slash(new Range(1, 21, 1, 22)),
+								new Word(new Range(1, 22, 1, 22 + 4), 'name'),
 								new RightParenthesis(new Range(1, 26, 1, 27)),
 								new NewLine(new Range(1, 27, 1, 28)),
 								// `2nd` input line
@@ -639,9 +721,16 @@ suite('MarkdownDecoder', () => {
 								new Word(new Range(2, 7, 2, 7 + 4), 'text'),
 								new RightBracket(new Range(2, 11, 2, 12)),
 								new LeftParenthesis(new Range(2, 12, 2, 13)),
-								new Word(new Range(2, 13, 2, 13 + 8), '/etc/pat'),
+								new Slash(new Range(2, 13, 2, 14)),
+								new Word(new Range(2, 14, 2, 14 + 3), 'etc'),
+								new Slash(new Range(2, 17, 2, 18)),
+								new Word(new Range(2, 18, 2, 18 + 3), 'pat'),
 								new stopCharacter(new Range(2, 21, 2, 22)), // <- stop character
-								new Word(new Range(2, 22, 2, 22 + 14), 'h/to/file.webp'),
+								new Word(new Range(2, 22, 2, 22 + 1), 'h'),
+								new Slash(new Range(2, 23, 2, 24)),
+								new Word(new Range(2, 24, 2, 24 + 2), 'to'),
+								new Slash(new Range(2, 26, 2, 27)),
+								new Word(new Range(2, 27, 2, 27 + 9), 'file.webp'),
 								new RightParenthesis(new Range(2, 36, 2, 37)),
 								new NewLine(new Range(2, 37, 2, 38)),
 								// `3nd` input line
@@ -651,9 +740,13 @@ suite('MarkdownDecoder', () => {
 								new RightBracket(new Range(3, 7, 3, 8)),
 								new stopCharacter(new Range(3, 8, 3, 9)), // <- stop character
 								new LeftParenthesis(new Range(3, 9, 3, 10)),
-								new Word(new Range(3, 10, 3, 10 + 5), '/etc/'),
+								new Slash(new Range(3, 10, 3, 11)),
+								new Word(new Range(3, 11, 3, 11 + 3), 'etc'),
+								new Slash(new Range(3, 14, 3, 15)),
 								new Space(new Range(3, 15, 3, 16)),
-								new Word(new Range(3, 16, 3, 16 + 14), 'path/image.gif'),
+								new Word(new Range(3, 16, 3, 16 + 4), 'path'),
+								new Slash(new Range(3, 20, 3, 21)),
+								new Word(new Range(3, 21, 3, 21 + 9), 'image.gif'),
 								new RightParenthesis(new Range(3, 30, 3, 31)),
 							],
 						);

--- a/src/vs/editor/test/common/codecs/simpleDecoder.test.ts
+++ b/src/vs/editor/test/common/codecs/simpleDecoder.test.ts
@@ -3,8 +3,8 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { TestDecoder } from '../utils/testDecoder.js';
 import { Range } from '../../../common/core/range.js';
+import { TestDecoder } from '../utils/testDecoder.js';
 import { VSBuffer } from '../../../../base/common/buffer.js';
 import { At } from '../../../common/codecs/simpleCodec/tokens/at.js';
 import { newWriteableStream } from '../../../../base/common/stream.js';
@@ -13,6 +13,7 @@ import { Hash } from '../../../common/codecs/simpleCodec/tokens/hash.js';
 import { Word } from '../../../common/codecs/simpleCodec/tokens/word.js';
 import { Dash } from '../../../common/codecs/simpleCodec/tokens/dash.js';
 import { Space } from '../../../common/codecs/simpleCodec/tokens/space.js';
+import { Slash } from '../../../common/codecs/simpleCodec/tokens/slash.js';
 import { NewLine } from '../../../common/codecs/linesCodec/tokens/newLine.js';
 import { FormFeed } from '../../../common/codecs/simpleCodec/tokens/formFeed.js';
 import { VerticalTab } from '../../../common/codecs/simpleCodec/tokens/verticalTab.js';
@@ -72,6 +73,7 @@ suite('SimpleDecoder', () => {
 				'\t<hi 👋>\t🤗❤ \t',
 				' hey\v-\tthere\r',
 				' @workspace@legomushroom',
+				'my text /run',
 			],
 			[
 				// first line
@@ -139,7 +141,77 @@ suite('SimpleDecoder', () => {
 				new Word(new Range(7, 3, 7, 12), 'workspace'),
 				new At(new Range(7, 12, 7, 13)),
 				new Word(new Range(7, 13, 7, 25), 'legomushroom'),
+				new NewLine(new Range(7, 25, 7, 26)),
+				// eighth line
+				new Word(new Range(8, 1, 8, 3), 'my'),
+				new Space(new Range(8, 3, 8, 4)),
+				new Word(new Range(8, 4, 8, 8), 'text'),
+				new Space(new Range(8, 8, 8, 9)),
+				new Slash(new Range(8, 9, 8, 10)),
+				new Word(new Range(8, 10, 8, 10 + 3), 'run'),
 			],
 		);
+	});
+
+	suite('slash commands', () => {
+		test('produces expected tokens', async () => {
+			const test = testDisposables.add(
+				new TestSimpleDecoder(),
+			);
+
+			await test.run(
+				[
+					'your command is /catch',
+					'\t\t/command1/command2 ',
+					'  /cmd#var ',
+					'/test@github\t\t',
+					'/update\r',
+					'',
+				],
+				[
+					// first line
+					new Word(new Range(1, 1, 1, 5), 'your'),
+					new Space(new Range(1, 5, 1, 6)),
+					new Word(new Range(1, 6, 1, 6 + 7), 'command'),
+					new Space(new Range(1, 13, 1, 14)),
+					new Word(new Range(1, 14, 1, 14 + 2), 'is'),
+					new Space(new Range(1, 16, 1, 17)),
+					new Slash(new Range(1, 17, 1, 18)),
+					new Word(new Range(1, 18, 1, 18 + 5), 'catch'),
+					new NewLine(new Range(1, 23, 1, 24)),
+					// second line
+					new Tab(new Range(2, 1, 2, 2)),
+					new Tab(new Range(2, 2, 2, 3)),
+					new Slash(new Range(2, 3, 2, 4)),
+					new Word(new Range(2, 4, 2, 4 + 8), 'command1'),
+					new Slash(new Range(2, 12, 2, 13)),
+					new Word(new Range(2, 13, 2, 13 + 8), 'command2'),
+					new Space(new Range(2, 21, 2, 22)),
+					new NewLine(new Range(2, 22, 2, 23)),
+					// third line
+					new Space(new Range(3, 1, 3, 2)),
+					new Space(new Range(3, 2, 3, 3)),
+					new Slash(new Range(3, 3, 3, 4)),
+					new Word(new Range(3, 4, 3, 4 + 3), 'cmd'),
+					new Hash(new Range(3, 7, 3, 8)),
+					new Word(new Range(3, 8, 3, 8 + 3), 'var'),
+					new Space(new Range(3, 11, 3, 12)),
+					new NewLine(new Range(3, 12, 3, 13)),
+					// fourth line
+					new Slash(new Range(4, 1, 4, 2)),
+					new Word(new Range(4, 2, 4, 2 + 4), 'test'),
+					new At(new Range(4, 6, 4, 7)),
+					new Word(new Range(4, 7, 4, 7 + 6), 'github'),
+					new Tab(new Range(4, 13, 4, 14)),
+					new Tab(new Range(4, 14, 4, 15)),
+					new NewLine(new Range(4, 15, 4, 16)),
+					// fifth line
+					new Slash(new Range(5, 1, 5, 2)),
+					new Word(new Range(5, 2, 5, 2 + 6), 'update'),
+					new CarriageReturn(new Range(5, 8, 5, 9)),
+					new NewLine(new Range(5, 9, 5, 10)),
+				],
+			);
+		});
 	});
 });

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/codecs/parsers/promptSlashCommandParser.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/codecs/parsers/promptSlashCommandParser.ts
@@ -1,0 +1,131 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { PromptAtMention } from '../tokens/promptAtMention.js';
+import { pick } from '../../../../../../../base/common/arrays.js';
+import { assert } from '../../../../../../../base/common/assert.js';
+import { Range } from '../../../../../../../editor/common/core/range.js';
+import { At } from '../../../../../../../editor/common/codecs/simpleCodec/tokens/at.js';
+import { Tab } from '../../../../../../../editor/common/codecs/simpleCodec/tokens/tab.js';
+import { Hash } from '../../../../../../../editor/common/codecs/simpleCodec/tokens/hash.js';
+import { Space } from '../../../../../../../editor/common/codecs/simpleCodec/tokens/space.js';
+import { Colon } from '../../../../../../../editor/common/codecs/simpleCodec/tokens/colon.js';
+import { NewLine } from '../../../../../../../editor/common/codecs/linesCodec/tokens/newLine.js';
+import { FormFeed } from '../../../../../../../editor/common/codecs/simpleCodec/tokens/formFeed.js';
+import { TSimpleToken } from '../../../../../../../editor/common/codecs/simpleCodec/simpleDecoder.js';
+import { VerticalTab } from '../../../../../../../editor/common/codecs/simpleCodec/tokens/verticalTab.js';
+import { CarriageReturn } from '../../../../../../../editor/common/codecs/linesCodec/tokens/carriageReturn.js';
+import { ExclamationMark } from '../../../../../../../editor/common/codecs/simpleCodec/tokens/exclamationMark.js';
+import { LeftBracket, RightBracket } from '../../../../../../../editor/common/codecs/simpleCodec/tokens/brackets.js';
+import { LeftAngleBracket, RightAngleBracket } from '../../../../../../../editor/common/codecs/simpleCodec/tokens/angleBrackets.js';
+import { assertNotConsumed, ParserBase, TAcceptTokenResult } from '../../../../../../../editor/common/codecs/simpleCodec/parserBase.js';
+
+/**
+ * TODO: @legomushroom - implement this
+ */
+
+/**
+ * List of characters that terminate the prompt at-mention sequence.
+ */
+export const STOP_CHARACTERS: readonly string[] = [Space, Tab, NewLine, CarriageReturn, VerticalTab, FormFeed, At, Colon]
+	.map((token) => { return token.symbol; });
+
+/**
+ * List of characters that cannot be in an at-mention name (excluding the {@link STOP_CHARACTERS}).
+ */
+export const INVALID_NAME_CHARACTERS: readonly string[] = [Hash, At, Colon, ExclamationMark, LeftAngleBracket, RightAngleBracket, LeftBracket, RightBracket]
+	.map((token) => { return token.symbol; });
+
+/**
+ * TODO: @legomushroom - update the comment
+ */
+/**
+ * The parser responsible for parsing a `prompt @mention` sequences.
+ * E.g., `@workspace` or `#workspace` variable. If the `:` character follows
+ * the variable name, the parser transitions to {@link PartialPromptVariableWithData}
+ * that is also able to parse the `data` part of the variable. E.g., the `#file` part
+ * of the `#file:/path/to/something.md` sequence.
+ */
+export class PartialPromptSlashCommand extends ParserBase<TSimpleToken, PartialPromptSlashCommand | PromptAtMention> {
+	constructor(token: At) {
+		super([token]);
+	}
+
+	@assertNotConsumed
+	public accept(token: TSimpleToken): TAcceptTokenResult<PartialPromptSlashCommand | PromptAtMention> {
+		// if a `stop` character is encountered, finish the parsing process
+		if (STOP_CHARACTERS.includes(token.text)) {
+			try {
+				// if it is possible to convert current parser to `PromptAtMention`, return success result
+				return {
+					result: 'success',
+					nextParser: this.asPromptAtMention(),
+					wasTokenConsumed: false,
+				};
+			} catch (error) {
+				// otherwise fail
+				return {
+					result: 'failure',
+					wasTokenConsumed: false,
+				};
+			} finally {
+				// in any case this is an end of the parsing process
+				this.isConsumed = true;
+			}
+		}
+
+		// variables cannot have {@link INVALID_NAME_CHARACTERS} in their names
+		if (INVALID_NAME_CHARACTERS.includes(token.text)) {
+			this.isConsumed = true;
+
+			return {
+				result: 'failure',
+				wasTokenConsumed: false,
+			};
+		}
+
+		// otherwise it is a valid name character, so add it to the list of
+		// the current tokens and continue the parsing process
+		this.currentTokens.push(token);
+
+		return {
+			result: 'success',
+			nextParser: this,
+			wasTokenConsumed: true,
+		};
+	}
+
+	/**
+	 * Try to convert current parser instance into a fully-parsed {@link PromptAtMention} token.
+	 *
+	 * @throws if sequence of tokens received so far do not constitute a valid prompt variable,
+	 *        for instance, if there is only `1` starting `@` token is available.
+	 */
+	public asPromptAtMention(): PromptAtMention {
+		// if there is only one token before the stop character
+		// must be the starting `@` one), then fail
+		assert(
+			this.currentTokens.length > 1,
+			'Cannot create a prompt @mention out of incomplete token sequence.',
+		);
+
+		const firstToken = this.currentTokens[0];
+		const lastToken = this.currentTokens[this.currentTokens.length - 1];
+
+		// render the characters above into strings, excluding the starting `@` character
+		const nameTokens = this.currentTokens.slice(1);
+		const atMentionName = nameTokens.map(pick('text')).join('');
+
+		return new PromptAtMention(
+			new Range(
+				firstToken.range.startLineNumber,
+				firstToken.range.startColumn,
+				lastToken.range.endLineNumber,
+				lastToken.range.endColumn,
+			),
+			atMentionName,
+		);
+	}
+}

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/codecs/parsers/promptSlashCommandParser.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/codecs/parsers/promptSlashCommandParser.ts
@@ -26,13 +26,13 @@ import { assertNotConsumed, ParserBase, TAcceptTokenResult } from '../../../../.
 /**
  * List of characters that terminate the prompt at-mention sequence.
  */
-export const STOP_CHARACTERS: readonly string[] = [Space, Tab, NewLine, CarriageReturn, VerticalTab, FormFeed, At, Colon, Hash, Slash]
+export const STOP_CHARACTERS: readonly string[] = [Space, Tab, NewLine, CarriageReturn, VerticalTab, FormFeed, Colon, At, Hash, Slash]
 	.map((token) => { return token.symbol; });
 
 /**
  * List of characters that cannot be in an at-mention name (excluding the {@link STOP_CHARACTERS}).
  */
-export const INVALID_NAME_CHARACTERS: readonly string[] = [Hash, At, Slash, Colon, ExclamationMark, LeftAngleBracket, RightAngleBracket, LeftBracket, RightBracket]
+export const INVALID_NAME_CHARACTERS: readonly string[] = [ExclamationMark, LeftAngleBracket, RightAngleBracket, LeftBracket, RightBracket]
 	.map((token) => { return token.symbol; });
 
 /**

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/codecs/tokens/promptSlashCommand.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/codecs/tokens/promptSlashCommand.ts
@@ -1,0 +1,72 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { PromptToken } from './promptToken.js';
+import { assert } from '../../../../../../../base/common/assert.js';
+import { Range } from '../../../../../../../editor/common/core/range.js';
+import { BaseToken } from '../../../../../../../editor/common/codecs/baseToken.js';
+import { INVALID_NAME_CHARACTERS, STOP_CHARACTERS } from '../parsers/promptSlashCommandParser.js';
+
+/**
+ * All prompt at-mentions start with `/` character.
+ */
+const START_CHARACTER: string = '/';
+
+/**
+ * Represents a `/command` token in a prompt text.
+ */
+export class PromptSlashCommand extends PromptToken {
+	constructor(
+		range: Range,
+		/**
+		 * The name of a command, excluding the `/` character at the start.
+		 */
+		public readonly name: string,
+	) {
+		// sanity check of characters used in the provided command name
+		for (const character of name) {
+			assert(
+				(INVALID_NAME_CHARACTERS.includes(character) === false) &&
+				(STOP_CHARACTERS.includes(character) === false),
+				`Slash command 'name' cannot contain character '${character}', got '${name}'.`,
+			);
+		}
+
+		super(range);
+	}
+
+	/**
+	 * Get full text of the token.
+	 */
+	public get text(): string {
+		return `${START_CHARACTER}${this.name}`;
+	}
+
+	/**
+	 * Check if this token is equal to another one.
+	 */
+	public override equals<T extends BaseToken>(other: T): boolean {
+		if (!super.sameRange(other.range)) {
+			return false;
+		}
+
+		if ((other instanceof PromptSlashCommand) === false) {
+			return false;
+		}
+
+		if (this.text.length !== other.text.length) {
+			return false;
+		}
+
+		return this.text === other.text;
+	}
+
+	/**
+	 * Return a string representation of the token.
+	 */
+	public override toString(): string {
+		return `${this.text}${this.range}`;
+	}
+}

--- a/src/vs/workbench/contrib/chat/test/common/promptSyntax/codecs/chatPromptDecoder.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/promptSyntax/codecs/chatPromptDecoder.test.ts
@@ -134,7 +134,7 @@ suite('ChatPromptDecoder', () => {
 				'',
 				'\t\v#variable@',
 				' #selection#your-variable',
-				'some-text #var:12:67# some text',
+				'some-text #var:12-67# some text',
 			];
 
 			await test.run(
@@ -155,16 +155,13 @@ suite('ChatPromptDecoder', () => {
 					new PromptVariableWithData(
 						new Range(4, 11, 4, 11 + 10),
 						'var',
-						'12:67',
+						'12-67',
 					),
 				],
 			);
 		});
 	});
 
-	/**
-	 * TODO: @legomushroom - add more unit tests
-	 */
 	suite('• commands', () => {
 		test('• produces expected tokens', async () => {
 			const test = testDisposables.add(
@@ -173,14 +170,41 @@ suite('ChatPromptDecoder', () => {
 
 			const contents = [
 				'my command is \t/run',
+				'your /command\v is done',
+				'/their#command is a pun',
+				'and the /none@cmd made by a nun',
 			];
 
 			await test.run(
 				contents,
 				[
+					// first line
 					new PromptSlashCommand(
 						new Range(1, 16, 1, 16 + 4),
 						'run',
+					),
+					// second line
+					new PromptSlashCommand(
+						new Range(2, 6, 2, 6 + 8),
+						'command',
+					),
+					// third line
+					new PromptSlashCommand(
+						new Range(3, 1, 3, 1 + 6),
+						'their',
+					),
+					new PromptVariable(
+						new Range(3, 7, 3, 7 + 8),
+						'command',
+					),
+					// forth line
+					new PromptSlashCommand(
+						new Range(4, 9, 4, 9 + 5),
+						'none',
+					),
+					new PromptAtMention(
+						new Range(4, 14, 4, 14 + 4),
+						'cmd',
 					),
 				],
 			);


### PR DESCRIPTION
Adds `/command` syntax support inside reusable prompt files.

Part of https://github.com/microsoft/vscode-copilot/issues/15596

cc @aeschli 