### PR TITLE
make maximum number of lines in debug console configurable

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/debug.contribution.ts
+++ b/src/vs/workbench/contrib/debug/browser/debug.contribution.ts
@@ -599,6 +599,11 @@ configurationRegistry.registerConfiguration({
 			description: nls.localize('debug.console.acceptSuggestionOnEnter', "Controls whether suggestions should be accepted on Enter in the Debug Console. Enter is also used to evaluate whatever is typed in the Debug Console."),
 			default: 'off'
 		},
+		'debug.console.maximumLines': {
+			type: 'number',
+			description: nls.localize('debug.console.maximumLines', "Controls the maximum number of lines in the Debug Console."),
+			default: 10000
+		},
 		'launch': {
 			type: 'object',
 			description: nls.localize({ comment: ['This is the description for a setting'], key: 'launch' }, "Global debug launch configuration. Should be used as an alternative to 'launch.json' that is shared across workspaces."),

--- a/src/vs/workbench/contrib/debug/common/debug.ts
+++ b/src/vs/workbench/contrib/debug/common/debug.ts
@@ -809,6 +809,7 @@ export interface IDebugConfiguration {
 		collapseIdenticalLines: boolean;
 		historySuggestions: boolean;
 		acceptSuggestionOnEnter: 'off' | 'on';
+		maximumLines: number;
 	};
 	focusWindowOnBreak: boolean;
 	focusEditorOnBreak: boolean;

--- a/src/vs/workbench/contrib/debug/common/replModel.ts
+++ b/src/vs/workbench/contrib/debug/common/replModel.ts
@@ -12,7 +12,6 @@ import { IConfigurationService } from '../../../../platform/configuration/common
 import { IDebugConfiguration, IDebugSession, IExpression, INestingReplElement, IReplElement, IReplElementSource, IStackFrame } from './debug.js';
 import { ExpressionContainer } from './debugModel.js';
 
-const MAX_REPL_LENGTH = 10000;
 let topReplElementCounter = 0;
 const getUniqueId = () => `topReplElement:${topReplElementCounter++}`;
 
@@ -343,8 +342,9 @@ export class ReplModel {
 			lastElement.addChild(newElement);
 		} else {
 			this.replElements.push(newElement);
-			if (this.replElements.length > MAX_REPL_LENGTH) {
-				this.replElements.splice(0, this.replElements.length - MAX_REPL_LENGTH);
+			const config = this.configurationService.getValue<IDebugConfiguration>('debug');
+			if (this.replElements.length > config.console.maximumLines) {
+				this.replElements.splice(0, this.replElements.length - config.console.maximumLines);
 			}
 		}
 		this._onDidChangeElements.fire(newElement);


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Adds a configuration value to control the maximum number of lines in the debug console.

This is needed because today with the DAP protocol many debugger extensions (i.e `lldb-dap`) send the debuggee stdout to the debug console by default, so this configuration lets the user the option to control the number of lines of stdout visible in a session.

Closes #129493 