### PR TITLE
[prompts]: add markdown extensions decoder and front matter header syntax support

### DIFF
--- a/src/vs/base/common/codecs/baseDecoder.ts
+++ b/src/vs/base/common/codecs/baseDecoder.ts
@@ -275,7 +275,7 @@ export abstract class BaseDecoder<
 	}
 
 	/**
-	 * Removes a priorly-registered event listener for a specified event.
+	 * Removes a previously-registered event listener for a specified event.
 	 *
 	 * Note!
 	 *  - the callback function must be the same as the one that was used when
@@ -283,7 +283,7 @@ export abstract class BaseDecoder<
 	 *    remove the listener
 	 *  - this method is idempotent and results in no-op if the listener is
 	 *    not found, therefore passing incorrect `callback` function may
-	 *    result in silent unexpected behaviour
+	 *    result in silent unexpected behavior
 	 */
 	public removeListener(event: string, callback: Function): void {
 		for (const [nameName, listeners] of this._listeners.entries()) {

--- a/src/vs/editor/common/codecs/baseToken.ts
+++ b/src/vs/editor/common/codecs/baseToken.ts
@@ -107,4 +107,17 @@ export abstract class BaseToken {
 			lastToken.range.endColumn,
 		);
 	}
+
+	/**
+	 * Shorten version of the {@link text} property.
+	 */
+	public shortText(
+		maxLength: number = 32,
+	): string {
+		if (this.text.length <= maxLength) {
+			return this.text;
+		}
+
+		return `${this.text.slice(0, maxLength - 1)}...`;
+	}
 }

--- a/src/vs/editor/common/codecs/baseToken.ts
+++ b/src/vs/editor/common/codecs/baseToken.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { pick } from '../../../base/common/arrays.js';
 import { assert } from '../../../base/common/assert.js';
 import { IRange, Range } from '../../../editor/common/core/range.js';
 
@@ -65,9 +66,7 @@ export abstract class BaseToken {
 	 * Render a list of tokens into a string.
 	 */
 	public static render(tokens: readonly BaseToken[]): string {
-		return tokens.map((token) => {
-			return token.text;
-		}).join('');
+		return tokens.map(pick('text')).join('');
 	}
 
 	/**

--- a/src/vs/editor/common/codecs/linesCodec/tokens/line.ts
+++ b/src/vs/editor/common/codecs/linesCodec/tokens/line.ts
@@ -58,6 +58,6 @@ export class Line extends BaseToken {
 	 * Returns a string representation of the token.
 	 */
 	public override toString(): string {
-		return `line("${this.text}")${this.range}`;
+		return `line("${this.shortText()}")${this.range}`;
 	}
 }

--- a/src/vs/editor/common/codecs/markdownCodec/markdownDecoder.ts
+++ b/src/vs/editor/common/codecs/markdownCodec/markdownDecoder.ts
@@ -8,15 +8,16 @@ import { VSBuffer } from '../../../../base/common/buffer.js';
 import { LeftBracket } from '../simpleCodec/tokens/brackets.js';
 import { PartialMarkdownImage } from './parsers/markdownImage.js';
 import { ReadableStream } from '../../../../base/common/stream.js';
+import { TSimpleDecoderToken } from '../simpleCodec/simpleDecoder.js';
 import { LeftAngleBracket } from '../simpleCodec/tokens/angleBrackets.js';
 import { ExclamationMark } from '../simpleCodec/tokens/exclamationMark.js';
 import { BaseDecoder } from '../../../../base/common/codecs/baseDecoder.js';
-import { SimpleDecoder, TSimpleDecoderToken } from '../simpleCodec/simpleDecoder.js';
 import { MarkdownCommentStart, PartialMarkdownCommentStart } from './parsers/markdownComment.js';
+import { MarkdownExtensionsDecoder } from '../markdownExtensionsCodec/markdownExtensionsDecoder.js';
 import { MarkdownLinkCaption, PartialMarkdownLink, PartialMarkdownLinkCaption } from './parsers/markdownLink.js';
 
 /**
- * Tokens handled by this decoder.
+ * Tokens produced by this decoder.
  */
 export type TMarkdownToken = MarkdownToken | TSimpleDecoderToken;
 
@@ -36,7 +37,7 @@ export class MarkdownDecoder extends BaseDecoder<TMarkdownToken, TSimpleDecoderT
 	constructor(
 		stream: ReadableStream<VSBuffer>,
 	) {
-		super(new SimpleDecoder(stream));
+		super(new MarkdownExtensionsDecoder(stream));
 	}
 
 	protected override onStreamData(token: TSimpleDecoderToken): void {

--- a/src/vs/editor/common/codecs/markdownCodec/markdownDecoder.ts
+++ b/src/vs/editor/common/codecs/markdownCodec/markdownDecoder.ts
@@ -93,8 +93,9 @@ export class MarkdownDecoder extends BaseDecoder<TMarkdownToken, TSimpleDecoderT
 			// then reset the current parser object
 			for (const token of this.current.tokens) {
 				this._onData.fire(token);
-				delete this.current;
 			}
+
+			delete this.current;
 		}
 
 		// if token was not consumed by the parser, call `onStreamData` again
@@ -120,11 +121,12 @@ export class MarkdownDecoder extends BaseDecoder<TMarkdownToken, TSimpleDecoderT
 
 			// in all other cases, re-emit existing parser tokens
 			const { tokens } = this.current;
-			delete this.current;
 
 			for (const token of [...tokens]) {
 				this._onData.fire(token);
 			}
+
+			delete this.current;
 		}
 
 		super.onStreamEnd();

--- a/src/vs/editor/common/codecs/markdownCodec/parsers/markdownComment.ts
+++ b/src/vs/editor/common/codecs/markdownCodec/parsers/markdownComment.ts
@@ -125,7 +125,7 @@ export class MarkdownCommentStart extends ParserBase<TSimpleDecoderToken, Markdo
 	/**
 	 * Convert the current token sequence into a {@link MarkdownComment} token.
 	 *
-	 * Note! that this method marks the current parser object as "consumend"
+	 * Note! that this method marks the current parser object as "consumed"
 	 *       hence it should not be used after this method is called.
 	 */
 	public asMarkdownComment(): MarkdownComment {

--- a/src/vs/editor/common/codecs/markdownCodec/tokens/markdownComment.ts
+++ b/src/vs/editor/common/codecs/markdownCodec/tokens/markdownComment.ts
@@ -51,6 +51,6 @@ export class MarkdownComment extends MarkdownToken {
 	 * Returns a string representation of the token.
 	 */
 	public override toString(): string {
-		return `md-comment("${this.text}")${this.range}`;
+		return `md-comment("${this.shortText()}")${this.range}`;
 	}
 }

--- a/src/vs/editor/common/codecs/markdownCodec/tokens/markdownImage.ts
+++ b/src/vs/editor/common/codecs/markdownCodec/tokens/markdownImage.ts
@@ -136,6 +136,6 @@ export class MarkdownImage extends MarkdownToken {
 	 * Returns a string representation of the token.
 	 */
 	public override toString(): string {
-		return `md-image("${this.text}")${this.range}`;
+		return `md-image("${this.shortText()}")${this.range}`;
 	}
 }

--- a/src/vs/editor/common/codecs/markdownCodec/tokens/markdownLink.ts
+++ b/src/vs/editor/common/codecs/markdownCodec/tokens/markdownLink.ts
@@ -131,6 +131,6 @@ export class MarkdownLink extends MarkdownToken {
 	 * Returns a string representation of the token.
 	 */
 	public override toString(): string {
-		return `md-link("${this.text}")${this.range}`;
+		return `md-link("${this.shortText()}")${this.range}`;
 	}
 }

--- a/src/vs/editor/common/codecs/markdownExtensionsCodec/markdownExtensionsDecoder.ts
+++ b/src/vs/editor/common/codecs/markdownExtensionsCodec/markdownExtensionsDecoder.ts
@@ -1,0 +1,117 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Dash } from '../simpleCodec/tokens/dash.js';
+import { VSBuffer } from '../../../../base/common/buffer.js';
+import { ReadableStream } from '../../../../base/common/stream.js';
+import { BaseDecoder } from '../../../../base/common/codecs/baseDecoder.js';
+import { MarkdownExtensionsToken } from './tokens/markdownExtensionsToken.js';
+import { SimpleDecoder, TSimpleDecoderToken } from '../simpleCodec/simpleDecoder.js';
+import { PartialFrontMatterHeader, PartialFrontMatterStartMarker } from './parsers/frontMatterHeader.js';
+
+/**
+ * TODO: @legomushroom - list
+ * - split to multiple commits/branches
+ * - use the decoder
+ * - add tests
+ */
+
+/**
+ * Tokens produced by this decoder.
+ */
+export type TMarkdownExtensionsToken = MarkdownExtensionsToken | TSimpleDecoderToken;
+
+/**
+ * TODO: @legomushroom
+ */
+export class MarkdownExtensionsDecoder extends BaseDecoder<TMarkdownExtensionsToken, TSimpleDecoderToken> {
+	/**
+	 * Current parser object that is responsible for parsing a sequence of tokens into
+	 * some markdown entity. Set to `undefined` when no parsing is in progress at the moment.
+	 */
+	private current?: PartialFrontMatterStartMarker | PartialFrontMatterHeader;
+
+	constructor(
+		stream: ReadableStream<VSBuffer>,
+	) {
+		super(new SimpleDecoder(stream));
+	}
+
+	protected override onStreamData(token: TSimpleDecoderToken): void {
+		// `markdown links` start with `[` character, so here we can
+		// initiate the process of parsing a markdown link
+		if (token instanceof Dash && !this.current) {
+			this.current = new PartialFrontMatterStartMarker(token);
+
+			return;
+		}
+
+		// if current parser is not initiated, - we are not inside a sequence of tokens
+		// we care about, therefore re-emit the token immediately and continue
+		if (this.current === undefined) {
+			this._onData.fire(token);
+			return;
+		}
+
+		// if there is a current parser object, submit the token to it
+		// so it can progress with parsing the tokens sequence
+		const parseResult = this.current.accept(token);
+		if (parseResult.result === 'success') {
+			const { nextParser } = parseResult;
+
+			// if got a fully parsed out token back, emit it and reset
+			// the current parser object so a new parsing process can start
+			if (nextParser instanceof MarkdownExtensionsToken) {
+				this._onData.fire(nextParser);
+				delete this.current;
+			} else {
+				// otherwise, update the current parser object
+				this.current = nextParser;
+			}
+		} else {
+			// if failed to parse a sequence of a tokens as a single markdown
+			// entity (e.g., a link), re-emit the tokens accumulated so far
+			// then reset the currently initialized parser object
+			for (const token of this.current.tokens) {
+				this._onData.fire(token);
+				delete this.current;
+			}
+		}
+
+		// if token was not consumed by the parser, call `onStreamData` again
+		// so the token is properly handled by the decoder in the case when a
+		// new sequence starts with this token
+		if (!parseResult.wasTokenConsumed) {
+			this.onStreamData(token);
+		}
+	}
+
+	protected override onStreamEnd(): void {
+		// if the stream has ended and there is a current incomplete parser
+		// object present, handle the remaining parser object
+		if (this.current) {
+			// if current parser can be converted into a valid Front Matter
+			// header, then emit it and reset the current parser object
+			if (this.current instanceof PartialFrontMatterHeader) {
+				const maybeHeader = this.current.asFrontMatterHeader();
+				if (maybeHeader) {
+					this._onData.fire(maybeHeader);
+					delete this.current;
+					return;
+				}
+			}
+
+			// in all other cases, re-emit existing parser tokens
+			const { tokens } = this.current;
+			delete this.current;
+
+			for (const token of [...tokens]) {
+				this._onData.fire(token);
+			}
+		}
+
+		super.onStreamEnd();
+	}
+}

--- a/src/vs/editor/common/codecs/markdownExtensionsCodec/markdownExtensionsDecoder.ts
+++ b/src/vs/editor/common/codecs/markdownExtensionsCodec/markdownExtensionsDecoder.ts
@@ -3,7 +3,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Dash } from '../simpleCodec/tokens/dash.js';
 import { VSBuffer } from '../../../../base/common/buffer.js';
 import { ReadableStream } from '../../../../base/common/stream.js';
 import { BaseDecoder } from '../../../../base/common/codecs/baseDecoder.js';
@@ -12,17 +11,13 @@ import { SimpleDecoder, TSimpleDecoderToken } from '../simpleCodec/simpleDecoder
 import { PartialFrontMatterHeader, PartialFrontMatterStartMarker } from './parsers/frontMatterHeader.js';
 
 /**
- * TODO: @legomushroom - list
- * - add tests
- */
-
-/**
  * Tokens produced by this decoder.
  */
 export type TMarkdownExtensionsToken = MarkdownExtensionsToken | TSimpleDecoderToken;
 
 /**
- * TODO: @legomushroom
+ * Decoder responsible for decoding extensions of markdown syntax,
+ * e.g., a `Front Matter` header, etc.
  */
 export class MarkdownExtensionsDecoder extends BaseDecoder<TMarkdownExtensionsToken, TSimpleDecoderToken> {
 	/**
@@ -39,8 +34,7 @@ export class MarkdownExtensionsDecoder extends BaseDecoder<TMarkdownExtensionsTo
 
 	protected override onStreamData(token: TSimpleDecoderToken): void {
 		// front matter headers start with a `-` at the first column of the first line
-		const maybeFrontMatter = (token instanceof Dash) && (token.range.startLineNumber === 1) && (token.range.startColumn === 1);
-		if ((this.current === undefined) && maybeFrontMatter) {
+		if ((this.current === undefined) && PartialFrontMatterStartMarker.mayStartHeader(token)) {
 			this.current = new PartialFrontMatterStartMarker(token);
 
 			return;

--- a/src/vs/editor/common/codecs/markdownExtensionsCodec/parsers/frontMatterHeader.ts
+++ b/src/vs/editor/common/codecs/markdownExtensionsCodec/parsers/frontMatterHeader.ts
@@ -1,0 +1,395 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { BaseToken } from '../../baseToken.js';
+import { Dash } from '../../simpleCodec/tokens/dash.js';
+import { NewLine } from '../../linesCodec/tokens/newLine.js';
+import { assertDefined } from '../../../../../base/common/types.js';
+import { TSimpleDecoderToken } from '../../simpleCodec/simpleDecoder.js';
+import { assert, assertNever } from '../../../../../base/common/assert.js';
+import { CarriageReturn } from '../../linesCodec/tokens/carriageReturn.js';
+import { FrontMatterHeaderToken } from '../tokens/frontMatterHeaderToken.js';
+import { assertNotConsumed, ParserBase, TAcceptTokenResult } from '../../simpleCodec/parserBase.js';
+
+/**
+ * TODO: @legomushroom
+ */
+class FrontMatterMarker {
+	/**
+	 * TODO: @legomushroom
+	 */
+	public readonly dashCount: number;
+
+	/**
+	 * Full range of the token.
+	 */
+	public get range() {
+		return BaseToken.fullRange(this.tokens);
+	}
+
+	constructor(
+		public readonly tokens: readonly (Dash | CarriageReturn | NewLine)[],
+	) {
+		const lastToken = tokens[tokens.length - 1];
+
+		assert(
+			lastToken instanceof NewLine,
+			`Front Matter header must end with a new line token, got '${lastToken}'.`,
+		);
+
+		this.dashCount = this.tokens
+			.filter((token) => { return token instanceof Dash; })
+			.length;
+	}
+
+	/**
+	 * Returns a string representation of the token.
+	 */
+	public toString(): string {
+		return `frontmatter-marker(${this.dashCount}:${this.range})`;
+	}
+}
+
+/**
+ * TODO: @legomushroom
+ */
+type TMarkerToken = Dash | CarriageReturn | NewLine;
+
+/**
+ * TODO: @legomushroom
+ */
+export class PartialFrontMatterStartMarker extends ParserBase<TMarkerToken, PartialFrontMatterStartMarker | PartialFrontMatterHeader> {
+	constructor(token: Dash) {
+		const { range } = token;
+
+		assert(
+			range.startLineNumber === 1,
+			`Front Matter header must start at the first line, but it starts at line #${range.startLineNumber}.`,
+		);
+
+		assert(
+			range.startColumn === 1,
+			`Front Matter header must start at the beginning of the line, but it starts at ${range.startColumn}.`,
+		);
+
+		super([token]);
+	}
+
+	@assertNotConsumed
+	public accept(token: TSimpleDecoderToken): TAcceptTokenResult<PartialFrontMatterStartMarker | PartialFrontMatterHeader> {
+		const previousToken = this.currentTokens[this.currentTokens.length - 1];
+
+		// collect a sequence of dash tokens that may end with a CR token
+		// TODO: @legomushroom - include `Space` token?
+		if ((token instanceof Dash) || (token instanceof CarriageReturn)) {
+			// a dash or CR tokens can go only after another dash token
+			if ((previousToken instanceof Dash) === false) {
+				this.isConsumed = true;
+
+				return {
+					result: 'failure',
+					wasTokenConsumed: false,
+				};
+			}
+
+
+			this.currentTokens.push(token);
+
+			return {
+				result: 'success',
+				wasTokenConsumed: true,
+				nextParser: this,
+			};
+		}
+
+		// stop collecting dash tokens when a new line token is encountered
+		if (token instanceof NewLine) {
+			this.isConsumed = true;
+
+			return {
+				result: 'success',
+				wasTokenConsumed: true,
+				nextParser: new PartialFrontMatterHeader(
+					new FrontMatterMarker([
+						...this.currentTokens,
+						token,
+					]),
+				),
+			};
+		}
+
+		// any other token is invalid for the `start marker`
+		this.isConsumed = true;
+		return {
+			result: 'failure',
+			wasTokenConsumed: false,
+		};
+	}
+}
+
+/**
+ * TODO: @legomushroom
+ */
+export class PartialFrontMatterHeader extends ParserBase<TSimpleDecoderToken, PartialFrontMatterHeader | FrontMatterHeaderToken> {
+	/**
+	 * TODO: @legomushroom
+	 */
+	private partialEndMarker?: PartialFrontMatterEndMarker;
+
+	/**
+	 * TODO: @legomushroom
+	 */
+	private maybeEndMarker?: FrontMatterMarker;
+
+	constructor(
+		public readonly startMarker: FrontMatterMarker,
+	) {
+		super([]);
+	}
+
+	public override get tokens(): readonly TSimpleDecoderToken[] {
+		return [
+			...this.startMarker.tokens,
+			...this.currentTokens,
+			...(this.maybeEndMarker?.tokens ?? []), // TODO: @legomushroom
+		];
+	}
+
+	/**
+	 * TODO: @legomushroom
+	 */
+	/**
+	 * Convert the current token sequence into a {@link MarkdownComment} token.
+	 *
+	 * Note! that this method marks the current parser object as "consumed"
+	 *       hence it should not be used after this method is called.
+	 */
+	public asFrontMatterHeader(): FrontMatterHeaderToken | null {
+		if (this.partialEndMarker === undefined) {
+			return null;
+		}
+
+		if (this.partialEndMarker.dashCount !== this.startMarker.dashCount) {
+			return null;
+		}
+
+		this.isConsumed = true;
+
+		return FrontMatterHeaderToken.fromTokens(
+			this.startMarker.tokens,
+			this.currentTokens,
+			this.partialEndMarker.tokens,
+		);
+	}
+
+	@assertNotConsumed
+	public accept(token: TSimpleDecoderToken): TAcceptTokenResult<PartialFrontMatterHeader | FrontMatterHeaderToken> {
+
+		// if in the mode of parsing the end marker sequence, forward
+		// the token to the current end marker parser instance
+		if (this.partialEndMarker !== undefined) {
+			return this.acceptEndMarkerToken(token);
+		}
+
+
+		// collect all tokens until a `dash token at the beginning of a line` is found
+		if (((token instanceof Dash) === false) || (token.range.startColumn !== 1)) {
+			this.currentTokens.push(token);
+
+			return {
+				result: 'success',
+				wasTokenConsumed: true,
+				nextParser: this,
+			};
+		}
+
+		// a dash token at the beginning of the line might be a start of the `end marker`
+		// sequence of the front matter header, hence initialize appropriate parser object
+		assert(
+			this.partialEndMarker === undefined,
+			`End marker parser must not be present.`,
+		);
+		this.partialEndMarker = new PartialFrontMatterEndMarker(token);
+
+		return {
+			result: 'success',
+			wasTokenConsumed: true,
+			nextParser: this,
+		};
+	}
+
+	/**
+	 * TODO: @legomushroom
+	 * @throws
+	 */
+	private acceptEndMarkerToken(
+		token: TSimpleDecoderToken,
+	): TAcceptTokenResult<PartialFrontMatterHeader | FrontMatterHeaderToken> {
+		assertDefined(
+			this.partialEndMarker,
+			`Partial end marker parser must be initialized.`,
+		);
+
+		// if we have a partial end marker, we are in the process of parsing
+		// the end marker, so just pass the token to it and return
+		const acceptResult = this.partialEndMarker.accept(token);
+		const { result, wasTokenConsumed } = acceptResult;
+
+		// TODO: @legomushroom
+		if (result === 'success') {
+			const { nextParser } = acceptResult;
+			const endMarkerParsingComplete = (nextParser instanceof FrontMatterMarker);
+
+			if (endMarkerParsingComplete === false) {
+				return {
+					result: 'success',
+					wasTokenConsumed,
+					nextParser: this,
+				};
+			}
+
+			const endMarker = nextParser;
+
+			// start and end markers must have the same number of dashes, hence
+			// if they don't match, we would like to continue parsing the header
+			// until we find an end marker with the same number of dashes
+			if (endMarker.dashCount !== this.startMarker.dashCount) {
+				return this.handleEndMarkerParsingFailure(
+					endMarker.tokens,
+					wasTokenConsumed,
+					token,
+				);
+			}
+
+			// found a valid end marker, so the parsing process is complete
+			this.maybeEndMarker = endMarker;
+			delete this.partialEndMarker;
+
+			this.isConsumed = true;
+			return {
+				result: 'success',
+				wasTokenConsumed: true,
+				nextParser: FrontMatterHeaderToken.fromTokens(
+					this.startMarker.tokens,
+					this.currentTokens,
+					this.maybeEndMarker.tokens,
+				),
+			};
+		}
+
+		// if failed to parse the end marker, we would like to continue parsing
+		// the header until we find a valid end marker
+		if (result === 'failure') {
+			return this.handleEndMarkerParsingFailure(
+				this.partialEndMarker.tokens,
+				wasTokenConsumed,
+				token,
+			);
+		}
+
+		assertNever(
+			result,
+			`Unexpected result '${result}' while parsing the end marker.`,
+		);
+	}
+
+	/**
+	 * TODO: @legomushroom
+	 */
+	private handleEndMarkerParsingFailure(
+		accumulatedTokens: readonly TSimpleDecoderToken[],
+		wasTokenConsumed: boolean,
+		token: TSimpleDecoderToken,
+	): TAcceptTokenResult<PartialFrontMatterHeader> {
+		this.currentTokens.push(...accumulatedTokens);
+
+		if (wasTokenConsumed === false) {
+			this.currentTokens.push(token);
+		}
+
+		delete this.partialEndMarker;
+		delete this.maybeEndMarker;
+
+		return {
+			result: 'success',
+			wasTokenConsumed: true,
+			nextParser: this,
+		};
+	}
+}
+
+/**
+ * TODO: @legomushroom
+ */
+class PartialFrontMatterEndMarker extends ParserBase<TMarkerToken, PartialFrontMatterEndMarker | FrontMatterMarker> {
+	constructor(token: Dash) {
+		const { range } = token;
+
+		assert(
+			range.startColumn === 1,
+			`Front Matter header must start at the beginning of the line, but it starts at ${range.startColumn}.`,
+		);
+
+		super([token]);
+	}
+
+	/**
+	 * TODO: @legomushroom
+	 */
+	public get dashCount(): number {
+		return this.tokens
+			.filter((token) => { return token instanceof Dash; })
+			.length;
+	}
+
+	@assertNotConsumed
+	public accept(token: TSimpleDecoderToken): TAcceptTokenResult<PartialFrontMatterEndMarker | FrontMatterMarker> {
+		const previousToken = this.currentTokens[this.currentTokens.length - 1];
+
+		// collect a sequence of dash tokens that may end with a CR token
+		// TODO: @legomushroom - include `Space` token?
+		if ((token instanceof Dash) || (token instanceof CarriageReturn)) {
+			// a dash or CR tokens can go only after another dash token
+			if ((previousToken instanceof Dash) === false) {
+				this.isConsumed = true;
+
+				return {
+					result: 'failure',
+					wasTokenConsumed: false,
+				};
+			}
+
+
+			this.currentTokens.push(token);
+
+			return {
+				result: 'success',
+				wasTokenConsumed: true,
+				nextParser: this,
+			};
+		}
+
+		// stop collecting dash tokens when a new line token is encountered
+		if (token instanceof NewLine) {
+			this.isConsumed = true;
+
+			return {
+				result: 'success',
+				wasTokenConsumed: true,
+				nextParser: new FrontMatterMarker([
+					...this.currentTokens,
+					token,
+				]),
+			};
+		}
+
+		// any other token is invalid for the `start marker`
+		this.isConsumed = true;
+		return {
+			result: 'failure',
+			wasTokenConsumed: false,
+		};
+	}
+}

--- a/src/vs/editor/common/codecs/markdownExtensionsCodec/parsers/frontMatterHeader.ts
+++ b/src/vs/editor/common/codecs/markdownExtensionsCodec/parsers/frontMatterHeader.ts
@@ -10,8 +10,8 @@ import { TSimpleDecoderToken } from '../../simpleCodec/simpleDecoder.js';
 import { assert, assertNever } from '../../../../../base/common/assert.js';
 import { CarriageReturn } from '../../linesCodec/tokens/carriageReturn.js';
 import { FrontMatterHeaderToken } from '../tokens/frontMatterHeaderToken.js';
-import { assertNotConsumed, IAcceptTokenSuccess, ParserBase, TAcceptTokenResult } from '../../simpleCodec/parserBase.js';
 import { FrontMatterHeaderMarkerToken, TMarkerToken } from '../tokens/frontMatterHeaderMarkerToken.js';
+import { assertNotConsumed, IAcceptTokenSuccess, ParserBase, TAcceptTokenResult } from '../../simpleCodec/parserBase.js';
 
 /**
  * Parses the start marker of a Front Matter header.

--- a/src/vs/editor/common/codecs/markdownExtensionsCodec/tokens/frontMatterHeaderMarkerToken.ts
+++ b/src/vs/editor/common/codecs/markdownExtensionsCodec/tokens/frontMatterHeaderMarkerToken.ts
@@ -1,0 +1,58 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { BaseToken } from '../../baseToken.js';
+import { Dash } from '../../simpleCodec/tokens/dash.js';
+import { NewLine } from '../../linesCodec/tokens/newLine.js';
+import { assert } from '../../../../../base/common/assert.js';
+import { CarriageReturn } from '../../linesCodec/tokens/carriageReturn.js';
+import { MarkdownExtensionsToken } from '../tokens/markdownExtensionsToken.js';
+
+/**
+ * Type for tokens inside a Front Matter header marker.
+ */
+export type TMarkerToken = Dash | CarriageReturn | NewLine;
+
+/**
+ * Marker for the start and end of a Front Matter header.
+ */
+export class FrontMatterHeaderMarkerToken extends MarkdownExtensionsToken {
+	/**
+	 * Number of dashes in the marker.
+	 */
+	public readonly dashCount: number;
+
+	/**
+	 * Returns complete text representation of the token.
+	 */
+	public get text(): string {
+		return BaseToken.render(this.tokens);
+	}
+
+	constructor(
+		public readonly tokens: readonly (Dash | CarriageReturn | NewLine)[],
+	) {
+		const lastToken = tokens[tokens.length - 1];
+
+		assert(
+			lastToken instanceof NewLine,
+			`Front Matter header must end with a new line token, got '${lastToken}'.`,
+		);
+
+		const range = BaseToken.fullRange(tokens);
+		super(range);
+
+		this.dashCount = this.tokens
+			.filter((token) => { return token instanceof Dash; })
+			.length;
+	}
+
+	/**
+	 * Returns a string representation of the token.
+	 */
+	public toString(): string {
+		return `frontmatter-marker(${this.dashCount}:${this.range})`;
+	}
+}

--- a/src/vs/editor/common/codecs/markdownExtensionsCodec/tokens/frontMatterHeaderToken.ts
+++ b/src/vs/editor/common/codecs/markdownExtensionsCodec/tokens/frontMatterHeaderToken.ts
@@ -1,0 +1,75 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Range } from '../../../core/range.js';
+import { BaseToken } from '../../baseToken.js';
+import { MarkdownExtensionsToken } from './markdownExtensionsToken.js';
+import { TSimpleDecoderToken } from '../../simpleCodec/simpleDecoder.js';
+
+/**
+ * TODO: @legomushroom
+ */
+export class FrontMatterHeaderToken extends MarkdownExtensionsToken {
+	constructor(
+		range: Range,
+		public readonly startMarker: string,
+		public readonly contents: string,
+		public readonly endMarker: string,
+	) {
+		// TODO: @legomushroom - validate text?
+
+		super(range);
+	}
+
+	/**
+	 * TODO: @legomushroom
+	 */
+	public get text(): string {
+		return [
+			this.startMarker,
+			this.contents,
+			this.endMarker,
+		].join('');
+	}
+
+	/**
+	 * Check if this token is equal to another one.
+	 */
+	public override equals<T extends BaseToken>(other: T): boolean {
+		if (!super.sameRange(other.range)) {
+			return false;
+		}
+
+		if (!(other instanceof FrontMatterHeaderToken)) {
+			return false;
+		}
+
+		return this.text === other.text;
+	}
+
+	/**
+	 * TODO: @legomushroom
+	 */
+	public static fromTokens(
+		startMarkerTokens: readonly TSimpleDecoderToken[],
+		contentTokens: readonly TSimpleDecoderToken[],
+		endMarkerTokens: readonly TSimpleDecoderToken[],
+	): FrontMatterHeaderToken {
+		return new FrontMatterHeaderToken(
+			BaseToken.fullRange([...startMarkerTokens, ...endMarkerTokens]),
+			BaseToken.render(startMarkerTokens),
+			BaseToken.render(contentTokens),
+			BaseToken.render(endMarkerTokens),
+		);
+	}
+
+	/**
+	 * Returns a string representation of the token.
+	 */
+	public override toString(): string {
+		// TODO: @legomushroom - add an utility to truncate strings
+		return `frontmatter("${this.text.slice(0, 16)}")${this.range}`;
+	}
+}

--- a/src/vs/editor/common/codecs/markdownExtensionsCodec/tokens/frontMatterHeaderToken.ts
+++ b/src/vs/editor/common/codecs/markdownExtensionsCodec/tokens/frontMatterHeaderToken.ts
@@ -5,11 +5,13 @@
 
 import { Range } from '../../../core/range.js';
 import { BaseToken } from '../../baseToken.js';
+import { assert } from '../../../../../base/common/assert.js';
 import { MarkdownExtensionsToken } from './markdownExtensionsToken.js';
 import { TSimpleDecoderToken } from '../../simpleCodec/simpleDecoder.js';
+import { NewLine } from '../../linesCodec/tokens/newLine.js';
 
 /**
- * TODO: @legomushroom
+ * Token that represents a `Front Matter` header in a text.
  */
 export class FrontMatterHeaderToken extends MarkdownExtensionsToken {
 	constructor(
@@ -18,13 +20,31 @@ export class FrontMatterHeaderToken extends MarkdownExtensionsToken {
 		public readonly contents: string,
 		public readonly endMarker: string,
 	) {
-		// TODO: @legomushroom - validate text?
+		// sanity check of the `start marker` string
+		assert(
+			startMarker.length > 0,
+			'Front Matter header start marker must not be empty.',
+		);
+		assert(
+			startMarker.endsWith(NewLine.symbol),
+			'Front Matter header start marker must end with a new line.',
+		);
+
+		// sanity check of the `end marker` string
+		assert(
+			endMarker.length > 0,
+			'Front Matter header end marker must not be empty.',
+		);
+		assert(
+			endMarker.endsWith(NewLine.symbol),
+			'Front Matter header end marker must end with a new line.',
+		);
 
 		super(range);
 	}
 
 	/**
-	 * TODO: @legomushroom
+	 * Return complete text representation of the token.
 	 */
 	public get text(): string {
 		return [
@@ -54,7 +74,7 @@ export class FrontMatterHeaderToken extends MarkdownExtensionsToken {
 	}
 
 	/**
-	 * TODO: @legomushroom
+	 * Create new instance of the token from the given tokens.
 	 */
 	public static fromTokens(
 		startMarkerTokens: readonly TSimpleDecoderToken[],
@@ -74,6 +94,6 @@ export class FrontMatterHeaderToken extends MarkdownExtensionsToken {
 	 */
 	public override toString(): string {
 		// TODO: @legomushroom - add an utility to truncate strings
-		return `frontmatter("${this.text.slice(0, 16)}")${this.range}`;
+		return `frontmatter("${this.text.slice(0, 10)}")${this.range}`;
 	}
 }

--- a/src/vs/editor/common/codecs/markdownExtensionsCodec/tokens/frontMatterHeaderToken.ts
+++ b/src/vs/editor/common/codecs/markdownExtensionsCodec/tokens/frontMatterHeaderToken.ts
@@ -5,10 +5,10 @@
 
 import { Range } from '../../../core/range.js';
 import { BaseToken } from '../../baseToken.js';
+import { NewLine } from '../../linesCodec/tokens/newLine.js';
 import { assert } from '../../../../../base/common/assert.js';
 import { MarkdownExtensionsToken } from './markdownExtensionsToken.js';
 import { TSimpleDecoderToken } from '../../simpleCodec/simpleDecoder.js';
-import { NewLine } from '../../linesCodec/tokens/newLine.js';
 
 /**
  * Token that represents a `Front Matter` header in a text.
@@ -93,7 +93,6 @@ export class FrontMatterHeaderToken extends MarkdownExtensionsToken {
 	 * Returns a string representation of the token.
 	 */
 	public override toString(): string {
-		// TODO: @legomushroom - add an utility to truncate strings
-		return `frontmatter("${this.text.slice(0, 10)}")${this.range}`;
+		return `frontmatter("${this.shortText()}")${this.range}`;
 	}
 }

--- a/src/vs/editor/common/codecs/markdownExtensionsCodec/tokens/frontMatterHeaderToken.ts
+++ b/src/vs/editor/common/codecs/markdownExtensionsCodec/tokens/frontMatterHeaderToken.ts
@@ -46,7 +46,11 @@ export class FrontMatterHeaderToken extends MarkdownExtensionsToken {
 			return false;
 		}
 
-		return this.text === other.text;
+		if (this.text.length !== other.text.length) {
+			return false;
+		}
+
+		return (this.text === other.text);
 	}
 
 	/**

--- a/src/vs/editor/common/codecs/markdownExtensionsCodec/tokens/markdownExtensionsToken.ts
+++ b/src/vs/editor/common/codecs/markdownExtensionsCodec/tokens/markdownExtensionsToken.ts
@@ -1,0 +1,11 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { MarkdownToken } from '../../markdownCodec/tokens/markdownToken.js';
+
+/**
+ * TODO: @legomushroom
+ */
+export abstract class MarkdownExtensionsToken extends MarkdownToken { }

--- a/src/vs/editor/common/codecs/markdownExtensionsCodec/tokens/markdownExtensionsToken.ts
+++ b/src/vs/editor/common/codecs/markdownExtensionsCodec/tokens/markdownExtensionsToken.ts
@@ -6,6 +6,6 @@
 import { MarkdownToken } from '../../markdownCodec/tokens/markdownToken.js';
 
 /**
- * TODO: @legomushroom
+ * Base class for all tokens produced by the `MarkdownExtensionsDecoder`.
  */
 export abstract class MarkdownExtensionsToken extends MarkdownToken { }

--- a/src/vs/editor/common/codecs/simpleCodec/simpleDecoder.ts
+++ b/src/vs/editor/common/codecs/simpleCodec/simpleDecoder.ts
@@ -100,6 +100,7 @@ export class SimpleDecoder extends BaseDecoder<TSimpleDecoderToken, TLineToken> 
 			// check if the current character is a well-known token
 			const tokenConstructor = WELL_KNOWN_TOKENS
 				.find((wellKnownToken) => {
+					// TODO: @legomushroom - indexing inside the string is incorrect
 					return wellKnownToken.symbol === line.text[i];
 				});
 
@@ -116,6 +117,7 @@ export class SimpleDecoder extends BaseDecoder<TSimpleDecoderToken, TLineToken> 
 			// read all the characters until a stop character is encountered
 			let word = '';
 			while (i < line.text.length && !(WORD_STOP_CHARACTERS.includes(line.text[i]))) {
+				// TODO: @legomushroom - indexing inside the string is incorrect
 				word += line.text[i];
 				i++;
 			}

--- a/src/vs/editor/common/codecs/simpleCodec/simpleDecoder.ts
+++ b/src/vs/editor/common/codecs/simpleCodec/simpleDecoder.ts
@@ -92,16 +92,16 @@ export class SimpleDecoder extends BaseDecoder<TSimpleDecoderToken, TLineToken> 
 		}
 
 		// loop through the text separating it into `Word` and `well-known` tokens
+		const lineText = line.text.split('');
 		let i = 0;
-		while (i < line.text.length) {
+		while (i < lineText.length) {
 			// index is 0-based, but column numbers are 1-based
 			const columnNumber = i + 1;
 
 			// check if the current character is a well-known token
 			const tokenConstructor = WELL_KNOWN_TOKENS
 				.find((wellKnownToken) => {
-					// TODO: @legomushroom - indexing inside the string is incorrect
-					return wellKnownToken.symbol === line.text[i];
+					return wellKnownToken.symbol === lineText[i];
 				});
 
 			// if it is a well-known token, emit it and continue to the next one
@@ -116,9 +116,8 @@ export class SimpleDecoder extends BaseDecoder<TSimpleDecoderToken, TLineToken> 
 			// that needs to be collected into a single `Word` token, hence
 			// read all the characters until a stop character is encountered
 			let word = '';
-			while (i < line.text.length && !(WORD_STOP_CHARACTERS.includes(line.text[i]))) {
-				// TODO: @legomushroom - indexing inside the string is incorrect
-				word += line.text[i];
+			while (i < lineText.length && !(WORD_STOP_CHARACTERS.includes(lineText[i]))) {
+				word += lineText[i];
 				i++;
 			}
 

--- a/src/vs/editor/common/codecs/simpleCodec/tokens/word.ts
+++ b/src/vs/editor/common/codecs/simpleCodec/tokens/word.ts
@@ -67,6 +67,6 @@ export class Word extends BaseToken {
 	 * Returns a string representation of the token.
 	 */
 	public override toString(): string {
-		return `word("${this.text}")${this.range}`;
+		return `word("${this.shortText()}")${this.range}`;
 	}
 }

--- a/src/vs/editor/test/common/utils/testDecoder.ts
+++ b/src/vs/editor/test/common/utils/testDecoder.ts
@@ -102,45 +102,8 @@ export class TestDecoder<T extends BaseToken, D extends BaseDecoder<T>> extends 
 			// initiate the data sending flow
 			this.sendData(inputData);
 
-			// consume the decoder tokens based on specified
-			// (or randomly generated) tokens consume method
-			const receivedTokens: T[] = [];
-			switch (tokensConsumeMethod) {
-				// test the `async iterator` code path
-				case 'async-generator': {
-					for await (const token of this.decoder) {
-						if (token === null) {
-							break;
-						}
-
-						receivedTokens.push(token);
-					}
-
-					break;
-				}
-				// test the `.consumeAll()` method code path
-				case 'consume-all-method': {
-					receivedTokens.push(...(await this.decoder.consumeAll()));
-					break;
-				}
-				// test the `.onData()` event consume flow
-				case 'on-data-event': {
-					this.decoder.onData((token) => {
-						receivedTokens.push(token);
-					});
-
-					this.decoder.start();
-
-					// in this case we also test the `settled` promise of the decoder
-					await this.decoder.settled;
-
-					break;
-				}
-				// ensure that the switch block is exhaustive
-				default: {
-					throw new Error(`Unknown consume method '${tokensConsumeMethod}'.`);
-				}
-			}
+			// receive tokens from the decoder stream
+			const receivedTokens = await this.receiveTokens(tokensConsumeMethod);
 
 			// validate the received tokens
 			this.validateReceivedTokens(
@@ -189,6 +152,55 @@ export class TestDecoder<T extends BaseToken, D extends BaseDecoder<T>> extends 
 				throw new Error(`Unknown consume method index '${testConsumeMethodIndex}'.`);
 			}
 		}
+	}
+
+	/**
+	 * TODO: @legomushroom
+	 */
+	public async receiveTokens(
+		tokensConsumeMethod: TTokensConsumeMethod = this.randomTokensConsumeMethod(),
+	): Promise<readonly T[]> {
+		// consume the decoder tokens based on specified
+		// (or randomly generated) tokens consume method
+		const receivedTokens: T[] = [];
+		switch (tokensConsumeMethod) {
+			// test the `async iterator` code path
+			case 'async-generator': {
+				for await (const token of this.decoder) {
+					if (token === null) {
+						break;
+					}
+
+					receivedTokens.push(token);
+				}
+
+				break;
+			}
+			// test the `.consumeAll()` method code path
+			case 'consume-all-method': {
+				receivedTokens.push(...(await this.decoder.consumeAll()));
+				break;
+			}
+			// test the `.onData()` event consume flow
+			case 'on-data-event': {
+				this.decoder.onData((token) => {
+					receivedTokens.push(token);
+				});
+
+				this.decoder.start();
+
+				// in this case we also test the `settled` promise of the decoder
+				await this.decoder.settled;
+
+				break;
+			}
+			// ensure that the switch block is exhaustive
+			default: {
+				throw new Error(`Unknown consume method '${tokensConsumeMethod}'.`);
+			}
+		}
+
+		return receivedTokens;
 	}
 
 	/**

--- a/src/vs/editor/test/common/utils/testDecoder.ts
+++ b/src/vs/editor/test/common/utils/testDecoder.ts
@@ -155,7 +155,7 @@ export class TestDecoder<T extends BaseToken, D extends BaseDecoder<T>> extends 
 	}
 
 	/**
-	 * TODO: @legomushroom
+	 * Receive all tokens from the decoder stream using the specified consume method.
 	 */
 	public async receiveTokens(
 		tokensConsumeMethod: TTokensConsumeMethod = this.randomTokensConsumeMethod(),

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/codecs/chatPromptDecoder.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/codecs/chatPromptDecoder.ts
@@ -169,7 +169,7 @@ export class ChatPromptDecoder extends BaseDecoder<TChatPromptToken, TMarkdownTo
 				this.current,
 				`Unknown parser object '${this.current}'`,
 			);
-		} catch (error) {
+		} catch (_error) {
 			// if failed to convert current parser object to a token,
 			// re-emit the tokens accumulated so far
 			this.reEmitCurrentTokens();

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/codecs/chatPromptDecoder.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/codecs/chatPromptDecoder.ts
@@ -18,7 +18,6 @@ import { At } from '../../../../../../editor/common/codecs/simpleCodec/tokens/at
 import { Hash } from '../../../../../../editor/common/codecs/simpleCodec/tokens/hash.js';
 import { Slash } from '../../../../../../editor/common/codecs/simpleCodec/tokens/slash.js';
 import { DollarSign } from '../../../../../../editor/common/codecs/simpleCodec/tokens/dollarSign.js';
-import { MarkdownLink } from '../../../../../../editor/common/codecs/markdownCodec/tokens/markdownLink.js';
 import { PartialPromptVariableName, PartialPromptVariableWithData } from './parsers/promptVariableParser.js';
 import { MarkdownDecoder, TMarkdownToken } from '../../../../../../editor/common/codecs/markdownCodec/markdownDecoder.js';
 import { PartialPromptTemplateVariable, PartialPromptTemplateVariableStart, TPromptTemplateVariableParser } from './parsers/promptTemplateVariableParser.js';
@@ -26,7 +25,7 @@ import { PartialPromptTemplateVariable, PartialPromptTemplateVariableStart, TPro
 /**
  * Tokens produced by this decoder.
  */
-export type TChatPromptToken = MarkdownLink | (PromptVariable | PromptVariableWithData)
+export type TChatPromptToken = TMarkdownToken | (PromptVariable | PromptVariableWithData)
 	| PromptAtMention | PromptSlashCommand | PromptTemplateVariable;
 
 /**
@@ -89,17 +88,7 @@ export class ChatPromptDecoder extends BaseDecoder<TChatPromptToken, TMarkdownTo
 		// if current parser was not yet initiated, - we are in the general "text"
 		// parsing mode, therefore re-emit the token immediately and continue
 		if (!this.current) {
-			// at the moment, the decoder outputs only specific markdown tokens, like
-			// the `markdown link` one, so re-emit only these tokens ignoring the rest
-			//
-			// note! to make the decoder consistent with others we would need to:
-			// 	- re-emit all tokens here
-			//  - collect all "text" sequences of tokens and emit them as a single
-			// 	  "text" sequence token
-			if (token instanceof MarkdownLink) {
-				this._onData.fire(token);
-			}
-
+			this._onData.fire(token);
 			return;
 		}
 
@@ -129,11 +118,9 @@ export class ChatPromptDecoder extends BaseDecoder<TChatPromptToken, TMarkdownTo
 			}
 			// in the case of failure, reset the current parser object
 			case 'failure': {
-				delete this.current;
-
-				// note! when this decoder becomes consistent with other ones and hence starts emitting
-				// 		 all token types, not just links, we would need to re-emit all the tokens that
-				//       the parser object has accumulated so far
+				// if failed to parse a sequence of a tokens, re-emit the tokens accumulated
+				// so far then reset the current parser object
+				this.reEmitCurrentTokens();
 				break;
 			}
 		}
@@ -149,7 +136,7 @@ export class ChatPromptDecoder extends BaseDecoder<TChatPromptToken, TMarkdownTo
 	protected override onStreamEnd(): void {
 		try {
 			// if there is no currently active parser object present, nothing to do
-			if (!this.current) {
+			if (this.current === undefined) {
 				return;
 			}
 
@@ -183,12 +170,27 @@ export class ChatPromptDecoder extends BaseDecoder<TChatPromptToken, TMarkdownTo
 				`Unknown parser object '${this.current}'`,
 			);
 		} catch (error) {
-			// note! when this decoder becomes consistent with other ones and hence starts emitting
-			// 		 all token types, not just links, we would need to re-emit all the tokens that
-			//       the parser object has accumulated so far
+			// if failed to convert current parser object to a token,
+			// re-emit the tokens accumulated so far
+			this.reEmitCurrentTokens();
 		} finally {
 			delete this.current;
 			super.onStreamEnd();
 		}
+	}
+
+	/**
+	 * Re-emit tokens accumulated so far in the current parser object.
+	 */
+	// TODO: @legomushroom - move to a base class
+	protected reEmitCurrentTokens(): void {
+		if (this.current === undefined) {
+			return;
+		}
+
+		for (const token of this.current.tokens) {
+			this._onData.fire(token);
+		}
+		delete this.current;
 	}
 }

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/codecs/chatPromptDecoder.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/codecs/chatPromptDecoder.ts
@@ -182,7 +182,7 @@ export class ChatPromptDecoder extends BaseDecoder<TChatPromptToken, TMarkdownTo
 	/**
 	 * Re-emit tokens accumulated so far in the current parser object.
 	 */
-	// TODO: @legomushroom - move to a base class
+	// TODO: @legomushroom - move to a base class?
 	protected reEmitCurrentTokens(): void {
 		if (this.current === undefined) {
 			return;

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/codecs/chatPromptDecoder.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/codecs/chatPromptDecoder.ts
@@ -182,7 +182,6 @@ export class ChatPromptDecoder extends BaseDecoder<TChatPromptToken, TMarkdownTo
 	/**
 	 * Re-emit tokens accumulated so far in the current parser object.
 	 */
-	// TODO: @legomushroom - move to a base class?
 	protected reEmitCurrentTokens(): void {
 		if (this.current === undefined) {
 			return;

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/codecs/parsers/promptTemplateVariableParser.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/codecs/parsers/promptTemplateVariableParser.ts
@@ -56,7 +56,6 @@ export class PartialPromptTemplateVariable extends ParserBase<TSimpleDecoderToke
 	@assertNotConsumed
 	public accept(token: TSimpleDecoderToken): TAcceptTokenResult<PartialPromptTemplateVariable | PromptTemplateVariable> {
 		// template variables are terminated by the `}` character
-		// TODO: @legomushroom - support escaped `}` characters?
 		if (token instanceof RightCurlyBrace) {
 			this.currentTokens.push(token);
 

--- a/src/vs/workbench/contrib/chat/test/common/promptSyntax/codecs/chatPromptCodec.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/promptSyntax/codecs/chatPromptCodec.test.ts
@@ -9,6 +9,8 @@ import { newWriteableStream } from '../../../../../../../base/common/stream.js';
 import { TestDecoder } from '../../../../../../../editor/test/common/utils/testDecoder.js';
 import { ChatPromptCodec } from '../../../../common/promptSyntax/codecs/chatPromptCodec.js';
 import { FileReference } from '../../../../common/promptSyntax/codecs/tokens/fileReference.js';
+import { NewLine } from '../../../../../../../editor/common/codecs/linesCodec/tokens/newLine.js';
+import { Space, Tab, Word } from '../../../../../../../editor/common/codecs/simpleCodec/tokens/index.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../../base/test/common/utils.js';
 import { ChatPromptDecoder, TChatPromptToken } from '../../../../common/promptSyntax/codecs/chatPromptDecoder.js';
 
@@ -51,30 +53,76 @@ suite('ChatPromptCodec', () => {
 		await test.run(
 			'#file:/etc/hosts some text\t\n  for #file:./README.md\t testing\n ✔ purposes\n#file:LICENSE.md ✌ \t#file:.gitignore\n\n\n\t   #file:/Users/legomushroom/repos/vscode   \n\nsomething #file:\tsomewhere\n',
 			[
+				// reference
 				new FileReference(
 					new Range(1, 1, 1, 1 + 16),
 					'/etc/hosts',
 				),
+				new Space(new Range(1, 17, 1, 17 + 1)),
+				new Word(new Range(1, 18, 1, 18 + 4), 'some'),
+				new Space(new Range(1, 22, 1, 22 + 1)),
+				new Word(new Range(1, 23, 1, 23 + 4), 'text'),
+				new Tab(new Range(1, 27, 1, 27 + 1)),
+				new NewLine(new Range(1, 28, 1, 28 + 1)),
+				new Space(new Range(2, 1, 2, 1 + 1)),
+				new Space(new Range(2, 2, 2, 2 + 1)),
+				new Word(new Range(2, 3, 2, 3 + 3), 'for'),
+				new Space(new Range(2, 6, 2, 6 + 1)),
+				// reference
 				new FileReference(
 					new Range(2, 7, 2, 7 + 17),
 					'./README.md',
 				),
+				new Tab(new Range(2, 24, 2, 24 + 1)),
+				new Space(new Range(2, 25, 2, 25 + 1)),
+				new Word(new Range(2, 26, 2, 26 + 7), 'testing'),
+				new NewLine(new Range(2, 33, 2, 33 + 1)),
+				new Space(new Range(3, 1, 3, 1 + 1)),
+				new Word(new Range(3, 2, 3, 2 + 1), '✔'),
+				new Space(new Range(3, 3, 3, 3 + 1)),
+				new Word(new Range(3, 4, 3, 4 + 8), 'purposes'),
+				new NewLine(new Range(3, 12, 3, 12 + 1)),
+				// reference
 				new FileReference(
 					new Range(4, 1, 4, 1 + 16),
 					'LICENSE.md',
 				),
+				new Space(new Range(4, 17, 4, 17 + 1)),
+				new Word(new Range(4, 18, 4, 18 + 1), '✌'),
+				new Space(new Range(4, 19, 4, 19 + 1)),
+				new Tab(new Range(4, 20, 4, 20 + 1)),
+				// reference
 				new FileReference(
 					new Range(4, 21, 4, 21 + 16),
 					'.gitignore',
 				),
+				new NewLine(new Range(4, 37, 4, 37 + 1)),
+				new NewLine(new Range(5, 1, 5, 1 + 1)),
+				new NewLine(new Range(6, 1, 6, 1 + 1)),
+				new Tab(new Range(7, 1, 7, 1 + 1)),
+				new Space(new Range(7, 2, 7, 2 + 1)),
+				new Space(new Range(7, 3, 7, 3 + 1)),
+				new Space(new Range(7, 4, 7, 4 + 1)),
+				// reference
 				new FileReference(
 					new Range(7, 5, 7, 5 + 38),
 					'/Users/legomushroom/repos/vscode',
 				),
+				new Space(new Range(7, 43, 7, 43 + 1)),
+				new Space(new Range(7, 44, 7, 44 + 1)),
+				new Space(new Range(7, 45, 7, 45 + 1)),
+				new NewLine(new Range(7, 46, 7, 46 + 1)),
+				new NewLine(new Range(8, 1, 8, 1 + 1)),
+				new Word(new Range(9, 1, 9, 1 + 9), 'something'),
+				new Space(new Range(9, 10, 9, 10 + 1)),
+				// reference
 				new FileReference(
 					new Range(9, 11, 9, 11 + 6),
 					'',
 				),
+				new Tab(new Range(9, 17, 9, 17 + 1)),
+				new Word(new Range(9, 18, 9, 18 + 9), 'somewhere'),
+				new NewLine(new Range(9, 27, 9, 27 + 1)),
 			],
 		);
 	});

--- a/src/vs/workbench/contrib/chat/test/common/promptSyntax/codecs/chatPromptDecoder.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/promptSyntax/codecs/chatPromptDecoder.test.ts
@@ -8,6 +8,7 @@ import { Range } from '../../../../../../../editor/common/core/range.js';
 import { newWriteableStream } from '../../../../../../../base/common/stream.js';
 import { TestDecoder } from '../../../../../../../editor/test/common/utils/testDecoder.js';
 import { FileReference } from '../../../../common/promptSyntax/codecs/tokens/fileReference.js';
+import { NewLine } from '../../../../../../../editor/common/codecs/linesCodec/tokens/newLine.js';
 import { PromptAtMention } from '../../../../common/promptSyntax/codecs/tokens/promptAtMention.js';
 import { PromptSlashCommand } from '../../../../common/promptSyntax/codecs/tokens/promptSlashCommand.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../../base/test/common/utils.js';
@@ -15,6 +16,7 @@ import { MarkdownLink } from '../../../../../../../editor/common/codecs/markdown
 import { PromptTemplateVariable } from '../../../../common/promptSyntax/codecs/tokens/promptTemplateVariable.js';
 import { ChatPromptDecoder, TChatPromptToken } from '../../../../common/promptSyntax/codecs/chatPromptDecoder.js';
 import { PromptVariable, PromptVariableWithData } from '../../../../common/promptSyntax/codecs/tokens/promptVariable.js';
+import { At, Dash, ExclamationMark, FormFeed, Hash, Space, Tab, VerticalTab, Word } from '../../../../../../../editor/common/codecs/simpleCodec/tokens/index.js';
 
 /**
  * A reusable test utility that asserts that a `ChatPromptDecoder` instance
@@ -59,7 +61,7 @@ suite('ChatPromptDecoder', () => {
 			'',
 			'haalo! @workspace',
 			' message 👾 message #file:./path/to/file1.md',
-			'',
+			'\f',
 			'## Heading Title',
 			' \t#file:a/b/c/filename2.md\t🖖\t#file:other-file.md',
 			' [#file:reference.md](./reference.md)some text #file:/some/file/with/absolute/path.md',
@@ -70,61 +72,130 @@ suite('ChatPromptDecoder', () => {
 		await test.run(
 			contents,
 			[
+				// first line
+				new NewLine(new Range(1, 1, 1, 2)),
+				// second line
+				new Word(new Range(2, 1, 2, 6), 'haalo'),
+				new ExclamationMark(new Range(2, 6, 2, 7)),
+				new Space(new Range(2, 7, 2, 8)),
 				new PromptAtMention(
 					new Range(2, 8, 2, 18),
 					'workspace',
 				),
+				new NewLine(new Range(2, 18, 2, 19)),
+				// third line
+				new Space(new Range(3, 1, 3, 2)),
+				new Word(new Range(3, 2, 3, 9), 'message'),
+				new Space(new Range(3, 9, 3, 10)),
+				new Word(new Range(3, 10, 3, 12), '👾'),
+				new Space(new Range(3, 12, 3, 13)),
+				new Word(new Range(3, 13, 3, 20), 'message'),
+				new Space(new Range(3, 20, 3, 21)),
 				new FileReference(
 					new Range(3, 21, 3, 21 + 24),
 					'./path/to/file1.md',
 				),
+				new NewLine(new Range(3, 45, 3, 46)),
+				// fourth line
+				new FormFeed(new Range(4, 1, 4, 2)),
+				new NewLine(new Range(4, 2, 4, 3)),
+				// fifth line
+				new Hash(new Range(5, 1, 5, 2)),
+				new Hash(new Range(5, 2, 5, 3)),
+				new Space(new Range(5, 3, 5, 4)),
+				new Word(new Range(5, 4, 5, 11), 'Heading'),
+				new Space(new Range(5, 11, 5, 12)),
+				new Word(new Range(5, 12, 5, 17), 'Title'),
+				new NewLine(new Range(5, 17, 5, 18)),
+				// sixth line
+				new Space(new Range(6, 1, 6, 2)),
+				new Tab(new Range(6, 2, 6, 3)),
 				new FileReference(
 					new Range(6, 3, 6, 3 + 24),
 					'a/b/c/filename2.md',
 				),
+				new Tab(new Range(6, 27, 6, 28)),
+				new Word(new Range(6, 28, 6, 30), '🖖'),
+				new Tab(new Range(6, 30, 6, 31)),
 				new FileReference(
 					new Range(6, 31, 6, 31 + 19),
 					'other-file.md',
 				),
+				new NewLine(new Range(6, 50, 6, 51)),
+				// seventh line
+				new Space(new Range(7, 1, 7, 2)),
 				new MarkdownLink(
 					7,
 					2,
 					'[#file:reference.md]',
 					'(./reference.md)',
 				),
+				new Word(new Range(7, 38, 7, 38 + 4), 'some'),
+				new Space(new Range(7, 42, 7, 43)),
+				new Word(new Range(7, 43, 7, 43 + 4), 'text'),
+				new Space(new Range(7, 47, 7, 48)),
 				new FileReference(
 					new Range(7, 48, 7, 48 + 38),
 					'/some/file/with/absolute/path.md',
 				),
+				new NewLine(new Range(7, 86, 7, 87)),
+				// eighth line
+				new Word(new Range(8, 1, 8, 5), 'text'),
+				new Space(new Range(8, 5, 8, 6)),
 				new PromptSlashCommand(
 					new Range(8, 6, 8, 6 + 4),
 					'run',
 				),
+				new Space(new Range(8, 10, 8, 11)),
+				new Word(new Range(8, 11, 8, 11 + 4), 'text'),
+				new Space(new Range(8, 15, 8, 16)),
 				new FileReference(
 					new Range(8, 16, 8, 16 + 6),
 					'',
 				),
+				new Space(new Range(8, 22, 8, 23)),
+				new Word(new Range(8, 23, 8, 23 + 7), 'another'),
+				new Space(new Range(8, 30, 8, 31)),
 				new PromptAtMention(
 					new Range(8, 31, 8, 32 + 6),
 					'github',
 				),
+				new Space(new Range(8, 38, 8, 39)),
+				new Word(new Range(8, 39, 8, 39 + 4), 'text'),
+				new Space(new Range(8, 43, 8, 44)),
 				new PromptVariable(
 					new Range(8, 44, 8, 44 + 10),
 					'selection',
 				),
+				new Space(new Range(8, 54, 8, 55)),
+				new Word(new Range(8, 55, 8, 55 + 4), 'even'),
+				new Space(new Range(8, 59, 8, 60)),
+				new Word(new Range(8, 60, 8, 60 + 4), 'more'),
+				new Space(new Range(8, 64, 8, 65)),
+				new Word(new Range(8, 65, 8, 65 + 4), 'text'),
+				new NewLine(new Range(8, 69, 8, 70)),
+				// ninth line
+				new Tab(new Range(9, 1, 9, 2)),
+				new VerticalTab(new Range(9, 2, 9, 3)),
 				new PromptVariableWithData(
 					new Range(9, 3, 9, 3 + 22),
 					'my-name',
 					'metadata:1:20',
 				),
+				new Space(new Range(9, 25, 9, 26)),
+				new Tab(new Range(9, 26, 9, 27)),
+				new Tab(new Range(9, 27, 9, 28)),
 				new PromptSlashCommand(
 					new Range(9, 28, 9, 28 + 8),
 					'command',
 				),
+				new Tab(new Range(9, 36, 9, 37)),
+				new VerticalTab(new Range(9, 37, 9, 38)),
 				new PromptTemplateVariable(
 					new Range(9, 38, 9, 38 + 12),
 					'inputs:id',
 				),
+				new Tab(new Range(9, 50, 9, 51)),
 			],
 		);
 	});
@@ -145,10 +216,19 @@ suite('ChatPromptDecoder', () => {
 			await test.run(
 				contents,
 				[
+					// first line
+					new NewLine(new Range(1, 1, 1, 2)),
+					// second line
+					new Tab(new Range(2, 1, 2, 2)),
+					new VerticalTab(new Range(2, 2, 2, 3)),
 					new PromptVariable(
 						new Range(2, 3, 2, 3 + 9),
 						'variable',
 					),
+					new At(new Range(2, 12, 2, 13)),
+					new NewLine(new Range(2, 13, 2, 14)),
+					// third line
+					new Space(new Range(3, 1, 3, 2)),
 					new PromptVariable(
 						new Range(3, 2, 3, 2 + 10),
 						'selection',
@@ -157,11 +237,22 @@ suite('ChatPromptDecoder', () => {
 						new Range(3, 12, 3, 12 + 14),
 						'your-variable',
 					),
+					new NewLine(new Range(3, 26, 3, 27)),
+					// forth line
+					new Word(new Range(4, 1, 4, 5), 'some'),
+					new Dash(new Range(4, 5, 4, 6)),
+					new Word(new Range(4, 6, 4, 6 + 4), 'text'),
+					new Space(new Range(4, 10, 4, 11)),
 					new PromptVariableWithData(
 						new Range(4, 11, 4, 11 + 10),
 						'var',
 						'12-67',
 					),
+					new Hash(new Range(4, 21, 4, 22)),
+					new Space(new Range(4, 22, 4, 23)),
+					new Word(new Range(4, 23, 4, 23 + 4), 'some'),
+					new Space(new Range(4, 27, 4, 28)),
+					new Word(new Range(4, 28, 4, 28 + 4), 'text'),
 				],
 			);
 		});
@@ -176,7 +267,7 @@ suite('ChatPromptDecoder', () => {
 			const contents = [
 				'my command is \t/run',
 				'your /command\v is done',
-				'/their#command is a pun',
+				'/their#command is  a pun',
 				'and the /none@cmd was made by a nun',
 			];
 
@@ -184,15 +275,31 @@ suite('ChatPromptDecoder', () => {
 				contents,
 				[
 					// first line
+					new Word(new Range(1, 1, 1, 3), 'my'),
+					new Space(new Range(1, 3, 1, 4)),
+					new Word(new Range(1, 4, 1, 11), 'command'),
+					new Space(new Range(1, 11, 1, 12)),
+					new Word(new Range(1, 12, 1, 12 + 2), 'is'),
+					new Space(new Range(1, 14, 1, 15)),
+					new Tab(new Range(1, 15, 1, 16)),
 					new PromptSlashCommand(
 						new Range(1, 16, 1, 16 + 4),
 						'run',
 					),
+					new NewLine(new Range(1, 20, 1, 21)),
 					// second line
+					new Word(new Range(2, 1, 2, 5), 'your'),
+					new Space(new Range(2, 5, 2, 6)),
 					new PromptSlashCommand(
 						new Range(2, 6, 2, 6 + 8),
 						'command',
 					),
+					new VerticalTab(new Range(2, 14, 2, 15)),
+					new Space(new Range(2, 15, 2, 16)),
+					new Word(new Range(2, 16, 2, 16 + 2), 'is'),
+					new Space(new Range(2, 18, 2, 19)),
+					new Word(new Range(2, 19, 2, 19 + 4), 'done'),
+					new NewLine(new Range(2, 23, 2, 24)),
 					// third line
 					new PromptSlashCommand(
 						new Range(3, 1, 3, 1 + 6),
@@ -202,7 +309,19 @@ suite('ChatPromptDecoder', () => {
 						new Range(3, 7, 3, 7 + 8),
 						'command',
 					),
+					new Space(new Range(3, 15, 3, 16)),
+					new Word(new Range(3, 16, 3, 16 + 2), 'is'),
+					new Space(new Range(3, 18, 3, 19)),
+					new Space(new Range(3, 19, 3, 20)),
+					new Word(new Range(3, 20, 3, 20 + 1), 'a'),
+					new Space(new Range(3, 21, 3, 22)),
+					new Word(new Range(3, 22, 3, 22 + 3), 'pun'),
+					new NewLine(new Range(3, 25, 3, 26)),
 					// forth line
+					new Word(new Range(4, 1, 4, 4), 'and'),
+					new Space(new Range(4, 4, 4, 5)),
+					new Word(new Range(4, 5, 4, 5 + 3), 'the'),
+					new Space(new Range(4, 8, 4, 9)),
 					new PromptSlashCommand(
 						new Range(4, 9, 4, 9 + 5),
 						'none',
@@ -211,6 +330,16 @@ suite('ChatPromptDecoder', () => {
 						new Range(4, 14, 4, 14 + 4),
 						'cmd',
 					),
+					new Space(new Range(4, 18, 4, 19)),
+					new Word(new Range(4, 19, 4, 19 + 3), 'was'),
+					new Space(new Range(4, 22, 4, 23)),
+					new Word(new Range(4, 23, 4, 23 + 4), 'made'),
+					new Space(new Range(4, 27, 4, 28)),
+					new Word(new Range(4, 28, 4, 28 + 2), 'by'),
+					new Space(new Range(4, 30, 4, 31)),
+					new Word(new Range(4, 31, 4, 31 + 1), 'a'),
+					new Space(new Range(4, 32, 4, 33)),
+					new Word(new Range(4, 33, 4, 33 + 3), 'nun'),
 				],
 			);
 		});
@@ -226,32 +355,67 @@ suite('ChatPromptDecoder', () => {
 				'my command is \t${run}',
 				'your ${variable}\v is done',
 				'${their:variable} is a pun',
-				'and the ${none:var} is made by a nun',
+				'and the ${none:var} is made for fun',
 			];
 
 			await test.run(
 				contents,
 				[
 					// first line
+					new Word(new Range(1, 1, 1, 3), 'my'),
+					new Space(new Range(1, 3, 1, 4)),
+					new Word(new Range(1, 4, 1, 11), 'command'),
+					new Space(new Range(1, 11, 1, 12)),
+					new Word(new Range(1, 12, 1, 12 + 2), 'is'),
+					new Space(new Range(1, 14, 1, 15)),
+					new Tab(new Range(1, 15, 1, 16)),
 					new PromptTemplateVariable(
 						new Range(1, 16, 1, 16 + 6),
 						'run',
 					),
+					new NewLine(new Range(1, 22, 1, 23)),
 					// second line
+					new Word(new Range(2, 1, 2, 5), 'your'),
+					new Space(new Range(2, 5, 2, 6)),
 					new PromptTemplateVariable(
 						new Range(2, 6, 2, 6 + 11),
 						'variable',
 					),
+					new VerticalTab(new Range(2, 17, 2, 18)),
+					new Space(new Range(2, 18, 2, 19)),
+					new Word(new Range(2, 19, 2, 19 + 2), 'is'),
+					new Space(new Range(2, 21, 2, 22)),
+					new Word(new Range(2, 22, 2, 22 + 4), 'done'),
+					new NewLine(new Range(2, 26, 2, 27)),
 					// third line
 					new PromptTemplateVariable(
 						new Range(3, 1, 3, 1 + 17),
 						'their:variable',
 					),
+					new Space(new Range(3, 18, 3, 19)),
+					new Word(new Range(3, 19, 3, 19 + 2), 'is'),
+					new Space(new Range(3, 21, 3, 22)),
+					new Word(new Range(3, 22, 3, 22 + 1), 'a'),
+					new Space(new Range(3, 23, 3, 24)),
+					new Word(new Range(3, 24, 3, 24 + 3), 'pun'),
+					new NewLine(new Range(3, 27, 3, 28)),
 					// forth line
+					new Word(new Range(4, 1, 4, 4), 'and'),
+					new Space(new Range(4, 4, 4, 5)),
+					new Word(new Range(4, 5, 4, 5 + 3), 'the'),
+					new Space(new Range(4, 8, 4, 9)),
 					new PromptTemplateVariable(
 						new Range(4, 9, 4, 9 + 11),
 						'none:var',
 					),
+					new Space(new Range(4, 20, 4, 21)),
+					new Word(new Range(4, 21, 4, 21 + 2), 'is'),
+					new Space(new Range(4, 23, 4, 24)),
+					new Word(new Range(4, 24, 4, 24 + 4), 'made'),
+					new Space(new Range(4, 28, 4, 29)),
+					new Word(new Range(4, 29, 4, 29 + 3), 'for'),
+					new Space(new Range(4, 32, 4, 33)),
+					new Word(new Range(4, 33, 4, 33 + 3), 'fun'),
 				],
 			);
 		});

--- a/src/vs/workbench/contrib/chat/test/common/promptSyntax/codecs/markdownExtensionsDecoder.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/promptSyntax/codecs/markdownExtensionsDecoder.test.ts
@@ -1,0 +1,203 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { VSBuffer } from '../../../../../../../base/common/buffer.js';
+import { randomInt } from '../../../../../../../base/common/numbers.js';
+import { Range } from '../../../../../../../editor/common/core/range.js';
+import { newWriteableStream } from '../../../../../../../base/common/stream.js';
+import { randomBoolean } from '../../../../../../../base/test/common/testUtils.js';
+import { TestDecoder } from '../../../../../../../editor/test/common/utils/testDecoder.js';
+import { Word } from '../../../../../../../editor/common/codecs/simpleCodec/tokens/word.js';
+import { Space } from '../../../../../../../editor/common/codecs/simpleCodec/tokens/index.js';
+import { TChatPromptToken } from '../../../../common/promptSyntax/codecs/chatPromptDecoder.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../../base/test/common/utils.js';
+import { TestSimpleDecoder } from '../../../../../../../editor/test/common/codecs/simpleDecoder.test.js';
+import { MarkdownExtensionsDecoder } from '../../../../../../../editor/common/codecs/markdownExtensionsCodec/markdownExtensionsDecoder.js';
+import { FrontMatterHeaderToken } from '../../../../../../../editor/common/codecs/markdownExtensionsCodec/tokens/frontMatterHeaderToken.js';
+
+/**
+ * Test decoder for the `MarkdownExtensionsDecoder` class.
+ */
+export class TestMarkdownExtensionsDecoder extends TestDecoder<TChatPromptToken, MarkdownExtensionsDecoder> {
+	constructor(
+	) {
+		const stream = newWriteableStream<VSBuffer>(null);
+		const decoder = new MarkdownExtensionsDecoder(stream);
+
+		super(stream, decoder);
+	}
+}
+
+suite('MarkdownExtensionsDecoder', () => {
+	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
+
+	/**
+	 * Create a Front Matter header start/end marker with a random length.
+	 */
+	const randomMarker = (max: number = 10): string => {
+		const dashCount = randomInt(max, 1);
+
+		return new Array(dashCount).fill('-').join('');
+	};
+
+	suite('• Front Matter header', () => {
+		suite('• successful cases', () => {
+			test('• produces expected tokens', async () => {
+				const test = disposables.add(
+					new TestMarkdownExtensionsDecoder(),
+				);
+
+				const marker = randomMarker();
+
+				const promptContents = [
+					marker,
+					'variables:',
+					'  - name: value',
+					marker,
+					'some text',
+				];
+
+				// both line ending should result in the same result
+				const newLine = (randomBoolean())
+					? '\n'
+					: '\r\n';
+
+				await test.run(
+					promptContents.join(newLine),
+					[
+						// header
+						new FrontMatterHeaderToken(
+							new Range(1, 1, 4, 1 + marker.length + newLine.length),
+							`${marker}${newLine}`,
+							`variables:${newLine}  - name: value${newLine}`,
+							`${marker}${newLine}`,
+						),
+						// content after the header
+						new Word(new Range(5, 1, 5, 1 + 4), 'some'),
+						new Space(new Range(5, 5, 5, 6)),
+						new Word(new Range(5, 6, 5, 6 + 4), 'text'),
+					],
+				);
+			});
+		});
+
+		suite('• failure cases', () => {
+			test('• fails if header starts not on the first line', async () => {
+				const test = disposables.add(
+					new TestMarkdownExtensionsDecoder(),
+				);
+
+				const simpleDecoder = disposables.add(
+					new TestSimpleDecoder(),
+				);
+
+				const marker = randomMarker(5);
+
+				// prompt contents
+				const contents = [
+					'',
+					marker,
+					'variables:',
+					'  - name: value',
+					marker,
+					'some text',
+				];
+
+				// both line ending should result in the same result
+				const newLine = (randomBoolean())
+					? '\n'
+					: '\r\n';
+
+				const stringContents = contents.join(newLine);
+
+				// send the same contents to the simple decoder
+				simpleDecoder.sendData(stringContents);
+
+				// in the failure case we expect tokens to be re-emitted, therefore
+				// the list of tokens produced must be equal to the one of SimpleDecoder
+				await test.run(
+					stringContents,
+					(await simpleDecoder.receiveTokens()),
+				);
+			});
+
+			test('• fails if header markers do not match (start marker is longer)', async () => {
+				const test = disposables.add(
+					new TestMarkdownExtensionsDecoder(),
+				);
+
+				const simpleDecoder = disposables.add(
+					new TestSimpleDecoder(),
+				);
+
+				const marker = randomMarker(5);
+
+				// prompt contents
+				const contents = [
+					`${marker}${marker}`,
+					'variables:',
+					'  - name: value',
+					marker,
+					'some text',
+				];
+
+				// both line ending should result in the same result
+				const newLine = (randomBoolean())
+					? '\n'
+					: '\r\n';
+
+				const stringContents = contents.join(newLine);
+
+				// send the same contents to the simple decoder
+				simpleDecoder.sendData(stringContents);
+
+				// in the failure case we expect tokens to be re-emitted, therefore
+				// the list of tokens produced must be equal to the one of SimpleDecoder
+				await test.run(
+					stringContents,
+					(await simpleDecoder.receiveTokens()),
+				);
+			});
+		});
+
+		test('• fails if header markers do not match (end marker is longer)', async () => {
+			const test = disposables.add(
+				new TestMarkdownExtensionsDecoder(),
+			);
+
+			const simpleDecoder = disposables.add(
+				new TestSimpleDecoder(),
+			);
+
+			const marker = randomMarker(5);
+
+			// prompt contents
+			const contents = [
+				marker,
+				'variables:',
+				'  - name: value',
+				`${marker}${marker}`,
+				'some text',
+			];
+
+			// both line ending should result in the same result
+			const newLine = (randomBoolean())
+				? '\n'
+				: '\r\n';
+
+			const stringContents = contents.join(newLine);
+
+			// send the same contents to the simple decoder
+			simpleDecoder.sendData(stringContents);
+
+			// in the failure case we expect tokens to be re-emitted, therefore
+			// the list of tokens produced must be equal to the one of SimpleDecoder
+			await test.run(
+				stringContents,
+				(await simpleDecoder.receiveTokens()),
+			);
+		});
+	});
+});


### PR DESCRIPTION
Adds markdown "extensions" decoder and Front Matter header syntax support.

Part of https://github.com/microsoft/vscode-copilot/issues/15596

cc @aeschli 