### PR TITLE
[prompts]: improve front matter header in-editor decoration

### DIFF
--- a/src/vs/workbench/contrib/chat/common/promptSyntax/languageFeatures/providers/decorationsProvider/decorations/frontMatterMarkerDecoration.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/languageFeatures/providers/decorationsProvider/decorations/frontMatterMarkerDecoration.ts
@@ -3,26 +3,39 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { TDecorationStyles, DecorationBase } from './utils/index.js';
+import { CssClassModifiers } from '../../../../service/types.js';
+import { TDecorationStyles, ReactiveDecorationBase } from './utils/index.js';
 import { FrontMatterMarker } from '../../../../../../../../../editor/common/codecs/markdownExtensionsCodec/tokens/frontMatterMarker.js';
 
 /**
  * Decoration CSS class names.
  */
 export enum CssClassNames {
-	main = '.prompt-front-matter-marker',
-	inline = '.prompt-front-matter-marker-inline',
+	main = '.prompt-front-matter-decoration-marker',
+	inline = '.prompt-front-matter-decoration-marker-inline',
+	mainInactive = `${CssClassNames.main}${CssClassModifiers.Inactive}`,
+	inlineInactive = `${CssClassNames.inline}${CssClassModifiers.Inactive}`,
 }
 
 /**
  * Editor decoration for a `marker` token of a Front Matter header.
  */
-export class FrontMatterMarkerDecoration extends DecorationBase<FrontMatterMarker, CssClassNames> {
-	protected override get className(): CssClassNames {
-		return CssClassNames.main;
+export class FrontMatterMarkerDecoration extends ReactiveDecorationBase<FrontMatterMarker, CssClassNames> {
+	/**
+	 * Activate/deactivate the decoration.
+	 */
+	public activate(state: boolean): this {
+		const position = (state === true)
+			? this.token.range.getStartPosition()
+			: null;
+
+		this.setCursorPosition(position);
+
+		return this;
 	}
-	protected override get inlineClassName(): CssClassNames {
-		return CssClassNames.inline;
+
+	protected override get classNames() {
+		return CssClassNames;
 	}
 
 	protected override get description(): string {
@@ -32,7 +45,10 @@ export class FrontMatterMarkerDecoration extends DecorationBase<FrontMatterMarke
 	public static get cssStyles(): TDecorationStyles {
 		return {
 			[CssClassNames.inline]: [
-				'opacity: 0.5;',
+				'color: var(--vscode-disabledForeground);',
+			],
+			[CssClassNames.inlineInactive]: [
+				'opacity: 0.25;',
 			],
 		};
 	}

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/languageFeatures/providers/decorationsProvider/decorations/frontMatterMarkerDecoration.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/languageFeatures/providers/decorationsProvider/decorations/frontMatterMarkerDecoration.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { DecorationBase, TDecorationStyles } from './decorationBase.js';
+import { TDecorationStyles, DecorationBase } from './utils/index.js';
 import { FrontMatterMarker } from '../../../../../../../../../editor/common/codecs/markdownExtensionsCodec/tokens/frontMatterMarker.js';
 
 /**
@@ -15,7 +15,7 @@ export enum CssClassNames {
 }
 
 /**
- * Editor decoration for a marker token of Front Matter header.
+ * Editor decoration for a `marker` token of a Front Matter header.
  */
 export class FrontMatterMarkerDecoration extends DecorationBase<FrontMatterMarker, CssClassNames> {
 	protected override get className(): CssClassNames {
@@ -26,13 +26,13 @@ export class FrontMatterMarkerDecoration extends DecorationBase<FrontMatterMarke
 	}
 
 	protected override get description(): string {
-		return 'Front Matter marker editor decoration.';
+		return 'Marker decoration of a Front Matter header.';
 	}
 
 	public static get cssStyles(): TDecorationStyles {
 		return {
 			[CssClassNames.inline]: [
-				'opacity: 0.6;',
+				'opacity: 0.5;',
 			],
 		};
 	}

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/languageFeatures/providers/decorationsProvider/decorations/frontMatterMarkerDecoration.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/languageFeatures/providers/decorationsProvider/decorations/frontMatterMarkerDecoration.ts
@@ -1,0 +1,39 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { DecorationBase, TDecorationStyles } from './decorationBase.js';
+import { FrontMatterMarker } from '../../../../../../../../../editor/common/codecs/markdownExtensionsCodec/tokens/frontMatterMarker.js';
+
+/**
+ * Decoration CSS class names.
+ */
+export enum CssClassNames {
+	main = '.prompt-front-matter-marker',
+	inline = '.prompt-front-matter-marker-inline',
+}
+
+/**
+ * Editor decoration for a marker token of Front Matter header.
+ */
+export class FrontMatterMarkerDecoration extends DecorationBase<FrontMatterMarker, CssClassNames> {
+	protected override get className(): CssClassNames {
+		return CssClassNames.main;
+	}
+	protected override get inlineClassName(): CssClassNames {
+		return CssClassNames.inline;
+	}
+
+	protected override get description(): string {
+		return 'Front Matter marker editor decoration.';
+	}
+
+	public static get cssStyles(): TDecorationStyles {
+		return {
+			[CssClassNames.inline]: [
+				'opacity: 0.6;',
+			],
+		};
+	}
+}

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/languageFeatures/providers/decorationsProvider/decorations/utils/decorationBase.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/languageFeatures/providers/decorationsProvider/decorations/utils/decorationBase.ts
@@ -68,7 +68,7 @@ export abstract class DecorationBase<
 	/**
 	 * Changes the decoration in the editor.
 	 */
-	public changes(
+	public change(
 		accessor: TChangeAccessor,
 	): this {
 		accessor.changeDecorationOptions(

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/languageFeatures/providers/decorationsProvider/decorations/utils/decorationBase.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/languageFeatures/providers/decorationsProvider/decorations/utils/decorationBase.ts
@@ -3,11 +3,12 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Range } from '../../../../../../../../../editor/common/core/range.js';
-import { IMarkdownString } from '../../../../../../../../../base/common/htmlContent.js';
-import { BaseToken } from '../../../../../../../../../editor/common/codecs/baseToken.js';
-import { ModelDecorationOptions } from '../../../../../../../../../editor/common/model/textModel.js';
-import { IModelDecorationsChangeAccessor, TrackedRangeStickiness } from '../../../../../../../../../editor/common/model.js';
+import { Range } from '../../../../../../../../../../editor/common/core/range.js';
+import { IMarkdownString } from '../../../../../../../../../../base/common/htmlContent.js';
+import { BaseToken } from '../../../../../../../../../../editor/common/codecs/baseToken.js';
+import { TrackedRangeStickiness } from '../../../../../../../../../../editor/common/model.js';
+import type { TAddAccessor, TChangeAccessor, TDecorationStyles, TRemoveAccessor } from './types.js';
+import { ModelDecorationOptions } from '../../../../../../../../../../editor/common/model/textModel.js';
 
 /**
  * Base class for all editor decorations.
@@ -51,7 +52,7 @@ export abstract class DecorationBase<
 	public readonly id: string;
 
 	constructor(
-		accessor: Pick<IModelDecorationsChangeAccessor, 'addDecoration'>,
+		accessor: TAddAccessor,
 		protected readonly token: TPromptToken,
 	) {
 		this.id = accessor.addDecoration(this.range, this.decorationOptions);
@@ -65,10 +66,10 @@ export abstract class DecorationBase<
 	}
 
 	/**
-	 * Renders (updates) the decoration in the editor.
+	 * Changes the decoration in the editor.
 	 */
-	public render(
-		accessor: Pick<IModelDecorationsChangeAccessor, 'changeDecoration' | 'changeDecorationOptions'>,
+	public changes(
+		accessor: TChangeAccessor,
 	): this {
 		accessor.changeDecorationOptions(
 			this.id,
@@ -82,7 +83,7 @@ export abstract class DecorationBase<
 	 * Removes associated editor decoration(s).
 	 */
 	public remove(
-		accessor: Pick<IModelDecorationsChangeAccessor, 'removeDecoration'>,
+		accessor: TRemoveAccessor,
 	): this {
 		accessor.removeDecoration(this.id);
 
@@ -106,18 +107,11 @@ export abstract class DecorationBase<
 }
 
 /**
- * CSS styles for a decoration to be registered.
- */
-export type TDecorationStyles<TClassNames extends string = string> = {
-	readonly [key in TClassNames]: readonly string[];
-};
-
-/**
  * Type of a generic decoration class.
  */
 export type TDecorationClass<TPromptToken extends BaseToken = BaseToken> = {
 	new(
-		accessor: Pick<IModelDecorationsChangeAccessor, 'addDecoration'>,
+		accessor: TAddAccessor,
 		token: TPromptToken,
 	): DecorationBase<TPromptToken>;
 

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/languageFeatures/providers/decorationsProvider/decorations/utils/index.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/languageFeatures/providers/decorationsProvider/decorations/utils/index.ts
@@ -1,0 +1,15 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+export type * from './types.js';
+export { TDecorationClass, DecorationBase } from './decorationBase.js';
+export { ReactiveDecorationBase, TChangedDecorator } from './reactiveDecorationBase.js';
+
+/**
+ * Convert a registered color name to a CSS variable string.
+ */
+export const asCssVariable = (colorName: string): string => {
+	return `var(--vscode-${colorName.replaceAll('.', '-')})`;
+};

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/languageFeatures/providers/decorationsProvider/decorations/utils/index.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/languageFeatures/providers/decorationsProvider/decorations/utils/index.ts
@@ -3,13 +3,16 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { ColorIdentifier } from '../../../../../../../../../../platform/theme/common/colorUtils.js';
+
+/**
+ * Convert a registered color to a CSS variable string.
+ */
+export const asCssVariable = (color: ColorIdentifier): string => {
+	return `var(--vscode-${color.replaceAll('.', '-')})`;
+};
+
 export type * from './types.js';
 export { TDecorationClass, DecorationBase } from './decorationBase.js';
 export { ReactiveDecorationBase, TChangedDecorator } from './reactiveDecorationBase.js';
 
-/**
- * Convert a registered color name to a CSS variable string.
- */
-export const asCssVariable = (colorName: string): string => {
-	return `var(--vscode-${colorName.replaceAll('.', '-')})`;
-};

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/languageFeatures/providers/decorationsProvider/decorations/utils/index.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/languageFeatures/providers/decorationsProvider/decorations/utils/index.ts
@@ -13,6 +13,6 @@ export const asCssVariable = (color: ColorIdentifier): string => {
 };
 
 export type * from './types.js';
-export { TDecorationClass, DecorationBase } from './decorationBase.js';
-export { ReactiveDecorationBase, TChangedDecorator } from './reactiveDecorationBase.js';
+export { DecorationBase, type TDecorationClass } from './decorationBase.js';
+export { ReactiveDecorationBase, type TChangedDecorator } from './reactiveDecorationBase.js';
 

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/languageFeatures/providers/decorationsProvider/decorations/utils/reactiveDecorationBase.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/languageFeatures/providers/decorationsProvider/decorations/utils/reactiveDecorationBase.ts
@@ -4,38 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { DecorationBase } from './decorationBase.js';
-import { Position } from '../../../../../../../../../editor/common/core/position.js';
-import { BaseToken } from '../../../../../../../../../editor/common/codecs/baseToken.js';
-import { IModelDecorationsChangeAccessor } from '../../../../../../../../../editor/common/model.js';
-
-/**
- * CSS class names of the decoration.
- */
-interface IClassNames<T extends string = string> {
-	/**
-	 * Main, default CSS class name of the decoration
-	 * for the `active` decoration state.
-	 */
-	readonly main: T;
-
-	/**
-	 * CSS class name of the decoration for the `inline`(text)
-	 * styles.
-	 */
-	readonly inline: T;
-
-	/**
-	 * main CSS class name of the decoration for the `inactive`
-	 * decoration state.
-	 */
-	readonly mainInactive: T;
-
-	/**
-	 * CSS class name of the decoration for the `inline`(text)
-	 * styles when decoration is in the `inactive` state.
-	 */
-	readonly inlineInactive: T;
-}
+import type { IReactiveDecorationClassNames, TChangeAccessor } from './types.js';
+import { Position } from '../../../../../../../../../../editor/common/core/position.js';
+import { BaseToken } from '../../../../../../../../../../editor/common/codecs/baseToken.js';
 
 /**
  * Base class for all reactive editor decorations. A reactive decoration
@@ -49,10 +20,10 @@ export abstract class ReactiveDecorationBase<
 	/**
 	 * CSS class names of the decoration.
 	 */
-	protected abstract get classNames(): IClassNames<TCssClassName>;
+	protected abstract get classNames(): IReactiveDecorationClassNames<TCssClassName>;
 
 	/**
-	 * Whether the decoration has changed since the last {@link render}.
+	 * Whether the decoration has changed since the last {@link changes}.
 	 */
 	public get changed(): boolean {
 		return this.didChange;
@@ -67,13 +38,6 @@ export abstract class ReactiveDecorationBase<
 	 * Private field for the {@link changed} property.
 	 */
 	private didChange = true;
-
-	constructor(
-		accessor: Pick<IModelDecorationsChangeAccessor, 'addDecoration'>,
-		token: TPromptToken,
-	) {
-		super(accessor, token);
-	}
 
 	/**
 	 * Whether cursor is currently inside the decoration range.
@@ -112,14 +76,14 @@ export abstract class ReactiveDecorationBase<
 		return this.didChange;
 	}
 
-	public override render(
-		accessor: Pick<IModelDecorationsChangeAccessor, 'changeDecoration' | 'changeDecorationOptions'>,
+	public override changes(
+		accessor: TChangeAccessor,
 	): this {
 		if (this.didChange === false) {
 			return this;
 		}
 
-		super.render(accessor);
+		super.changes(accessor);
 		this.didChange = false;
 
 		return this;

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/languageFeatures/providers/decorationsProvider/decorations/utils/types.d.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/languageFeatures/providers/decorationsProvider/decorations/utils/types.d.ts
@@ -1,0 +1,55 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IModelDecorationsChangeAccessor, TrackedRangeStickiness } from '../../../../../../../../../../editor/common/model.js';
+
+/**
+ * CSS class names of a `reactive` decoration.
+ */
+export interface IReactiveDecorationClassNames<T extends string = string> {
+	/**
+	 * Main, default CSS class name of the decoration.
+	 */
+	readonly main: T;
+
+	/**
+	 * CSS class name of the decoration for the `inline`(text) styles.
+	 */
+	readonly inline: T;
+
+	/**
+	 * main CSS class name of the decoration for the `inactive`
+	 * decoration state.
+	 */
+	readonly mainInactive: T;
+
+	/**
+	 * CSS class name of the decoration for the `inline`(text)
+	 * styles when decoration is in the `inactive` state.
+	 */
+	readonly inlineInactive: T;
+}
+
+/**
+ * CSS styles for a decoration to be registered with editor.
+ */
+export type TDecorationStyles<TClassNames extends string = string> = {
+	readonly [key in TClassNames]: readonly string[];
+};
+
+/**
+ * A model decorations accessor that can be used to `add` a decoration.
+ */
+export type TAddAccessor = Pick<IModelDecorationsChangeAccessor, 'addDecoration'>;
+
+/**
+ * A model decorations accessor that can be used to `change` a decoration.
+ */
+export type TChangeAccessor = Pick<IModelDecorationsChangeAccessor, 'changeDecoration' | 'changeDecorationOptions'>;
+
+/**
+ * A model decorations accessor that can be used to `remove` a decoration.
+ */
+export type TRemoveAccessor = Pick<IModelDecorationsChangeAccessor, 'removeDecoration'>;

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/languageFeatures/providers/decorationsProvider/promptDecorationsProvider.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/languageFeatures/providers/decorationsProvider/promptDecorationsProvider.ts
@@ -6,12 +6,11 @@
 import { IPromptsService } from '../../../service/types.js';
 import { ProviderInstanceBase } from '../providerInstanceBase.js';
 import { toDisposable } from '../../../../../../../../base/common/lifecycle.js';
-import { DecorationBase, TDecorationClass } from './decorations/decorationBase.js';
-import { FrontMatterHeaderDecoration } from './decorations/frontMatterDecoration.js';
+import { FrontMatterDecoration } from './decorations/frontMatterDecoration.js';
 import { BaseToken } from '../../../../../../../../editor/common/codecs/baseToken.js';
 import { IPromptFileEditor, ProviderInstanceManagerBase } from '../providerInstanceManagerBase.js';
-import { ReactiveDecorationBase, TChangedDecorator } from './decorations/reactiveDecorationBase.js';
 import { registerThemingParticipant } from '../../../../../../../../platform/theme/common/themeService.js';
+import { DecorationBase, TDecorationClass, ReactiveDecorationBase, TChangedDecorator } from './decorations/utils/index.js';
 import { FrontMatterHeader } from '../../../../../../../../editor/common/codecs/markdownExtensionsCodec/tokens/frontMatterHeader.js';
 
 /**
@@ -23,7 +22,7 @@ type TDecoratedToken = FrontMatterHeader;
  * List of all supported decorations.
  */
 const SUPPORTED_DECORATIONS: readonly TDecorationClass<TDecoratedToken>[] = Object.freeze([
-	FrontMatterHeaderDecoration,
+	FrontMatterDecoration,
 ]);
 
 /**
@@ -93,7 +92,7 @@ export class TextModelPromptDecorator extends ProviderInstanceBase {
 	): this {
 		this.editor.changeDecorations((accessor) => {
 			for (const decoration of decorations) {
-				decoration.render(accessor);
+				decoration.changes(accessor);
 			}
 		});
 

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/languageFeatures/providers/decorationsProvider/promptDecorationsProvider.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/languageFeatures/providers/decorationsProvider/promptDecorationsProvider.ts
@@ -92,7 +92,7 @@ export class TextModelPromptDecorator extends ProviderInstanceBase {
 	): this {
 		this.editor.changeDecorations((accessor) => {
 			for (const decoration of decorations) {
-				decoration.changes(accessor);
+				decoration.change(accessor);
 			}
 		});
 
@@ -166,7 +166,7 @@ export class TextModelPromptDecorator extends ProviderInstanceBase {
 registerThemingParticipant((_theme, collector) => {
 	for (const Decoration of SUPPORTED_DECORATIONS) {
 		for (const [className, styles] of Object.entries(Decoration.cssStyles)) {
-			collector.addRule(`${className} { ${styles.join(' ')} }`);
+			collector.addRule(`.monaco-editor ${className} { ${styles.join(' ')} }`);
 		}
 	}
 });

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/languageFeatures/providers/decorationsProvider/promptDecorationsProvider.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/languageFeatures/providers/decorationsProvider/promptDecorationsProvider.ts
@@ -10,8 +10,8 @@ import { FrontMatterDecoration } from './decorations/frontMatterDecoration.js';
 import { BaseToken } from '../../../../../../../../editor/common/codecs/baseToken.js';
 import { IPromptFileEditor, ProviderInstanceManagerBase } from '../providerInstanceManagerBase.js';
 import { registerThemingParticipant } from '../../../../../../../../platform/theme/common/themeService.js';
-import { DecorationBase, TDecorationClass, ReactiveDecorationBase, TChangedDecorator } from './decorations/utils/index.js';
 import { FrontMatterHeader } from '../../../../../../../../editor/common/codecs/markdownExtensionsCodec/tokens/frontMatterHeader.js';
+import { DecorationBase, ReactiveDecorationBase, type TDecorationClass, type TChangedDecorator } from './decorations/utils/index.js';
 
 /**
  * Prompt tokens that are decorated by this provider.

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/service/types.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/service/types.ts
@@ -17,7 +17,7 @@ export const IPromptsService = createDecorator<IPromptsService>('IPromptsService
 /**
 * Supported prompt types.
 *  - `local` means the prompt is a local file.
-*  - `user` means a "roamble" prompt file (similar to snippets).
+*  - `user` means a "roam-able" prompt file (similar to snippets).
 */
 type TPromptsType = 'local' | 'user';
 
@@ -60,4 +60,11 @@ export interface IPromptsService extends IDisposable {
 	 * Get a list of prompt source folders based on the provided prompt type.
 	 */
 	getSourceFolders(type: TPromptsType): readonly IPromptPath[];
+}
+
+/**
+ * Decoration CSS class modifiers.
+ */
+export enum CssClassModifiers {
+	Inactive = '.prompt-decoration-inactive',
 }


### PR DESCRIPTION

<img width="1393" alt="image" src="https://github.com/user-attachments/assets/93cf1d00-30b3-4638-9ab8-2ddbf611ff8e" />

Improves Front Matter header in-editor decorations.

Part of https://github.com/microsoft/vscode-copilot/issues/15596

cc @aeschli 