### PR TITLE
NES: use keyboard icon above/below

### DIFF
--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/components/gutterIndicatorView.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/components/gutterIndicatorView.ts
@@ -268,7 +268,18 @@ export class InlineEditsGutterIndicator extends Disposable {
 
 		// The icon which will be rendered in the pill
 		const iconNoneDocked = this._tabAction.map(action => action === InlineEditTabAction.Accept ? Codicon.keyboardTab : Codicon.arrowRight);
-		const iconDocked = derived(reader => this._isHoveredOverIconDebounced.read(reader) || this._isHoveredOverInlineEditDebounced.read(reader) ? Codicon.check : iconNoneDocked.read(reader));
+		const iconDocked = derived(reader => {
+			if (this._isHoveredOverIconDebounced.read(reader) || this._isHoveredOverInlineEditDebounced.read(reader)) {
+				return Codicon.check;
+			}
+			if (this._tabAction.read(reader) === InlineEditTabAction.Accept) {
+				return Codicon.keyboardTab;
+			}
+			const cursorLineNumber = this._editorObs.cursorLineNumber.read(reader) ?? 0;
+			const editStartLineNumber = s.range.read(reader).startLineNumber;
+			return cursorLineNumber <= editStartLineNumber ? Codicon.keyboardTabAbove : Codicon.keyboardTabBelow;
+		});
+
 		const idealIconWidth = 22;
 		const minimalIconWidth = 16; // codicon size
 		const iconWidth = (pillRect: Rect) => {


### PR DESCRIPTION
```Copilot Generated Description:``` Update the icon logic to display keyboard icons above or below based on the cursor position relative to the edit start line number.