### PR TITLE
Fix gutter indicator arrow position in diff editor

### DIFF
--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/components/gutterIndicatorView.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/components/gutterIndicatorView.ts
@@ -280,7 +280,8 @@ export class InlineEditsGutterIndicator extends Disposable {
 			const pillRect = pillFullyDockedRect;
 			const lineNumberWidth = Math.max(layout.lineNumbersLeft + layout.lineNumbersWidth - gutterViewPortWithStickyScroll.left, 0);
 			const lineNumberRect = pillRect.withWidth(lineNumberWidth);
-			const iconRect = pillRect.withWidth(idealIconWidth).translateX(lineNumberWidth);
+			const iconWidth = Math.max(Math.min(layout.decorationsWidth, idealIconWidth), minimalIconWidth);
+			const iconRect = pillRect.withWidth(iconWidth).translateX(lineNumberWidth);
 
 			return {
 				gutterEditArea,


### PR DESCRIPTION
```Copilot Generated Description:``` Adjust the icon width calculation for the gutter indicator arrow to ensure it appears correctly within the decoration margin in the diff editor.

Fixes microsoft/vscode-copilot#15660