### PR TITLE
Refactor inline completion source access

### DIFF
--- a/src/vs/editor/contrib/inlineCompletions/browser/model/inlineCompletionsModel.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/model/inlineCompletionsModel.ts
@@ -94,7 +94,7 @@ export class InlineCompletionsModel extends Disposable {
 				lastItem = completion;
 				if (completion) {
 					const src = completion.source;
-					src.provider.handleItemDidShow?.(src.inlineSuggestions, completion.sourceInlineCompletion, completion.insertText);
+					src.provider.handleItemDidShow?.(src.inlineSuggestions, completion.getSourceCompletion(), completion.insertText);
 				}
 			}
 		}));
@@ -316,7 +316,7 @@ export class InlineCompletionsModel extends Disposable {
 			if (stopReason === 'explicitCancel') {
 				const inlineCompletion = this.state.get()?.inlineCompletion;
 				const source = inlineCompletion?.source;
-				const sourceInlineCompletion = inlineCompletion?.sourceInlineCompletion;
+				const sourceInlineCompletion = inlineCompletion?.getSourceCompletion();
 				if (sourceInlineCompletion && source?.provider.handleRejection) {
 					source.provider.handleRejection(source.inlineSuggestions, sourceInlineCompletion);
 				}
@@ -534,7 +534,7 @@ export class InlineCompletionsModel extends Disposable {
 	}
 
 	public readonly warning = derived(this, reader => {
-		return this.inlineCompletionState.read(reader)?.inlineCompletion?.sourceInlineCompletion.warning;
+		return this.inlineCompletionState.read(reader)?.inlineCompletion?.warning;
 	});
 
 	public readonly ghostTexts = derivedOpts({ owner: this, equalsFn: ghostTextsOrReplacementsEqual }, reader => {
@@ -809,7 +809,7 @@ export class InlineCompletionsModel extends Disposable {
 				const acceptedLength = text.length;
 				completion.source.provider.handlePartialAccept(
 					completion.source.inlineSuggestions,
-					completion.sourceInlineCompletion,
+					completion.getSourceCompletion(),
 					acceptedLength,
 					{ kind, acceptedLength: acceptedLength, }
 				);
@@ -831,7 +831,7 @@ export class InlineCompletionsModel extends Disposable {
 		const source = augmentedCompletion.completion.source;
 		source.provider.handlePartialAccept?.(
 			source.inlineSuggestions,
-			augmentedCompletion.completion.sourceInlineCompletion,
+			augmentedCompletion.completion.getSourceCompletion(),
 			itemEdit.text.length,
 			{
 				kind: PartialAcceptTriggerKind.Suggest,
@@ -845,7 +845,7 @@ export class InlineCompletionsModel extends Disposable {
 		const item = this.state.get()?.inlineCompletion;
 		return {
 			documentValue: value,
-			inlineCompletion: item?.sourceInlineCompletion,
+			inlineCompletion: item?.getSourceCompletion(),
 		};
 	}
 
@@ -882,7 +882,7 @@ export class InlineCompletionsModel extends Disposable {
 		}
 		inlineCompletion.didShow = true;
 
-		inlineCompletion.source.provider.handleItemDidShow?.(inlineCompletion.source.inlineSuggestions, inlineCompletion.sourceInlineCompletion, inlineCompletion.insertText);
+		inlineCompletion.source.provider.handleItemDidShow?.(inlineCompletion.source.inlineSuggestions, inlineCompletion.getSourceCompletion(), inlineCompletion.insertText);
 
 		if (inlineCompletion.shownCommand) {
 			await this._commandService.executeCommand(inlineCompletion.shownCommand.id, ...(inlineCompletion.shownCommand.arguments || []));

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineCompletionsView.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineCompletionsView.ts
@@ -45,7 +45,7 @@ export class InlineCompletionsView extends Disposable {
 	).recomputeInitiallyAndOnChange(this._store);
 
 	private readonly _inlineEdit = derived(this, reader => this._model.read(reader)?.inlineEditState.read(reader)?.inlineEdit);
-	private readonly _everHadInlineEdit = derivedObservableWithCache<boolean>(this, (reader, last) => last || !!this._inlineEdit.read(reader) || !!this._model.read(reader)?.inlineCompletionState.read(reader)?.inlineCompletion?.sourceInlineCompletion.showInlineEditMenu);
+	private readonly _everHadInlineEdit = derivedObservableWithCache<boolean>(this, (reader, last) => last || !!this._inlineEdit.read(reader) || !!this._model.read(reader)?.inlineCompletionState.read(reader)?.inlineCompletion?.showInlineEditMenu);
 	protected readonly _inlineEditWidget = derivedDisposable(reader => {
 		if (!this._everHadInlineEdit.read(reader)) {
 			return undefined;

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsModel.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsModel.ts
@@ -79,7 +79,7 @@ export class GhostTextIndicator {
 		const editorObs = observableCodeEditor(editor);
 		const tabAction = derived<InlineEditTabAction>(this, reader => {
 			if (editorObs.isFocused.read(reader)) {
-				if (model.inlineCompletionState.read(reader)?.inlineCompletion?.sourceInlineCompletion.showInlineEditMenu) {
+				if (model.inlineCompletionState.read(reader)?.inlineCompletion?.showInlineEditMenu) {
 					return InlineEditTabAction.Accept;
 				}
 			}

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViewProducer.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViewProducer.ts
@@ -81,7 +81,7 @@ export class InlineEditsViewAndDiffProducer extends Disposable { // TODO: This c
 		const inlineCompletion = state.inlineCompletion;
 		if (!inlineCompletion) { return undefined; }
 
-		if (!inlineCompletion.sourceInlineCompletion.showInlineEditMenu) {
+		if (!inlineCompletion.showInlineEditMenu) {
 			return undefined;
 		}
 


### PR DESCRIPTION
```Copilot Generated Description:``` Simplify access to inline completion properties by exposing `sourceInlineCompletion` through a method and updating references accordingly.