### PR TITLE
[prompts]: run immediately on editor play action

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/actions/reusablePromptActions/chatAttachPromptAction.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/reusablePromptActions/chatAttachPromptAction.ts
@@ -19,7 +19,7 @@ import { ICommandService } from '../../../../../../platform/commands/common/comm
 import { ContextKeyExpr } from '../../../../../../platform/contextkey/common/contextkey.js';
 import { Action2, registerAction2 } from '../../../../../../platform/actions/common/actions.js';
 import { IQuickInputService } from '../../../../../../platform/quickinput/common/quickInput.js';
-import { attachPrompts, IAttachPromptOptions } from './dialogs/askToSelectPrompt/utils/attachPrompts.js';
+import { attachPrompt, IAttachPromptOptions } from './dialogs/askToSelectPrompt/utils/attachPrompt.js';
 import { ISelectPromptOptions, askToSelectPrompt } from './dialogs/askToSelectPrompt/askToSelectPrompt.js';
 
 /**
@@ -89,8 +89,8 @@ class AttachPromptAction extends Action2 {
 				commandService,
 			};
 
-			const widget = await attachPrompts(
-				[{ value: resource }],
+			const { widget } = await attachPrompt(
+				resource,
 				attachOptions,
 			);
 

--- a/src/vs/workbench/contrib/chat/browser/actions/reusablePromptActions/chatRunPromptAction.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/reusablePromptActions/chatRunPromptAction.ts
@@ -5,6 +5,7 @@
 
 import { CHAT_CATEGORY } from '../chatActions.js';
 import { URI } from '../../../../../../base/common/uri.js';
+import { ChatSubmitAction } from '../chatExecuteActions.js';
 import { Codicon } from '../../../../../../base/common/codicons.js';
 import { runAttachPromptAction } from './chatAttachPromptAction.js';
 import { ChatContextKeys } from '../../../common/chatContextKeys.js';
@@ -101,11 +102,14 @@ abstract class RunPromptBaseAction extends Action2 {
 			'Cannot find URI resource for an active text editor.',
 		);
 
-		return await runAttachPromptAction({
+		await runAttachPromptAction({
 			resource,
 			inNewChat,
 			skipSelectionDialog: true,
 		}, commandService);
+
+		// submit the prompt immediately
+		await commandService.executeCommand(ChatSubmitAction.ID);
 	}
 }
 

--- a/src/vs/workbench/contrib/chat/browser/actions/reusablePromptActions/chatRunPromptAction.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/reusablePromptActions/chatRunPromptAction.ts
@@ -3,19 +3,21 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { IChatWidget } from '../../chat.js';
 import { CHAT_CATEGORY } from '../chatActions.js';
 import { URI } from '../../../../../../base/common/uri.js';
-import { ChatSubmitAction } from '../chatExecuteActions.js';
 import { Codicon } from '../../../../../../base/common/codicons.js';
-import { runAttachPromptAction } from './chatAttachPromptAction.js';
 import { ChatContextKeys } from '../../../common/chatContextKeys.js';
 import { assertDefined } from '../../../../../../base/common/types.js';
 import { ILocalizedString, localize2 } from '../../../../../../nls.js';
 import { ThemeIcon } from '../../../../../../base/common/themables.js';
 import { TEXT_FILE_EDITOR_ID } from '../../../../files/common/files.js';
 import { KeyCode, KeyMod } from '../../../../../../base/common/keyCodes.js';
+import { attachPrompt } from './dialogs/askToSelectPrompt/utils/attachPrompt.js';
+import { detachPrompt } from './dialogs/askToSelectPrompt/utils/detachPrompt.js';
 import { PromptsConfig } from '../../../../../../platform/prompts/common/config.js';
 import { ICommandAction } from '../../../../../../platform/action/common/action.js';
+import { IViewsService } from '../../../../../services/views/common/viewsService.js';
 import { ServicesAccessor } from '../../../../../../editor/browser/editorExtensions.js';
 import { EditorContextKeys } from '../../../../../../editor/common/editorContextKeys.js';
 import { ICommandService } from '../../../../../../platform/commands/common/commands.js';
@@ -93,7 +95,8 @@ abstract class RunPromptBaseAction extends Action2 {
 		resource: URI | undefined,
 		inNewChat: boolean,
 		accessor: ServicesAccessor,
-	): Promise<void> {
+	): Promise<IChatWidget> {
+		const viewsService = accessor.get(IViewsService);
 		const commandService = accessor.get(ICommandService);
 
 		resource ||= getActivePromptUri(accessor);
@@ -102,14 +105,25 @@ abstract class RunPromptBaseAction extends Action2 {
 			'Cannot find URI resource for an active text editor.',
 		);
 
-		await runAttachPromptAction({
+		const { widget, wasAlreadyAttached } = await attachPrompt(
 			resource,
-			inNewChat,
-			skipSelectionDialog: true,
-		}, commandService);
+			{
+				inNewChat,
+				commandService,
+				viewsService,
+			},
+		);
 
 		// submit the prompt immediately
-		await commandService.executeCommand(ChatSubmitAction.ID);
+		await widget.acceptInput();
+
+		// detach the prompt immediately, unless was attached
+		// before the action was executed
+		if (wasAlreadyAttached === false) {
+			await detachPrompt(resource, { widget });
+		}
+
+		return widget;
 	}
 }
 
@@ -159,7 +173,7 @@ class RunCurrentPromptAction extends RunPromptBaseAction {
 	public override async run(
 		accessor: ServicesAccessor,
 		resource: URI | undefined,
-	): Promise<void> {
+	): Promise<IChatWidget> {
 		return await super.execute(
 			resource,
 			false,
@@ -199,7 +213,7 @@ class RunCurrentPromptInNewChatAction extends RunPromptBaseAction {
 	public override async run(
 		accessor: ServicesAccessor,
 		resource: URI,
-	): Promise<void> {
+	): Promise<IChatWidget> {
 		return await super.execute(
 			resource,
 			true,

--- a/src/vs/workbench/contrib/chat/browser/actions/reusablePromptActions/dialogs/askToSelectPrompt/askToSelectPrompt.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/reusablePromptActions/dialogs/askToSelectPrompt/askToSelectPrompt.ts
@@ -5,7 +5,7 @@
 
 import { DOCS_OPTION } from './constants.js';
 import { IChatWidget } from '../../../../chat.js';
-import { attachPrompts } from './utils/attachPrompts.js';
+import { attachPrompt } from './utils/attachPrompt.js';
 import { handleButtonClick } from './utils/handleButtonClick.js';
 import { URI } from '../../../../../../../../base/common/uri.js';
 import { assert } from '../../../../../../../../base/common/assert.js';
@@ -174,13 +174,14 @@ export const askToSelectPrompt = async (
 			}
 
 			// otherwise attach the selected prompt to a chat input
-			lastActiveWidget = await attachPrompts(
-				selectedItems,
+			const attachResult = await attachPrompt(
+				selectedOption.value,
 				{
 					...options,
 					inNewChat: keyMods.ctrlCmd,
 				},
 			);
+			lastActiveWidget = attachResult.widget;
 
 			// if user submitted their selection, close the dialog
 			if (!event.inBackground) {

--- a/src/vs/workbench/contrib/chat/browser/actions/reusablePromptActions/dialogs/askToSelectPrompt/utils/attachPrompt.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/reusablePromptActions/dialogs/askToSelectPrompt/utils/attachPrompt.ts
@@ -4,14 +4,15 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { IChatWidget, showChatView } from '../../../../../chat.js';
+import { URI } from '../../../../../../../../../base/common/uri.js';
 import { ACTION_ID_NEW_CHAT } from '../../../../chatClearActions.js';
+import { assertDefined } from '../../../../../../../../../base/common/types.js';
 import { IChatAttachPromptActionOptions } from '../../../chatAttachPromptAction.js';
-import { assertDefined, WithUriValue } from '../../../../../../../../../base/common/types.js';
 import { IViewsService } from '../../../../../../../../services/views/common/viewsService.js';
 import { ICommandService } from '../../../../../../../../../platform/commands/common/commands.js';
 
 /**
- * Options for the {@link attachPrompts} function.
+ * Options for the {@link attachPrompt} function.
  */
 export interface IAttachPromptOptions {
 	/**
@@ -29,22 +30,28 @@ export interface IAttachPromptOptions {
 }
 
 /**
+ * Return value of the {@link attachPrompt} function.
+ */
+interface IAttachResult {
+	readonly widget: IChatWidget;
+	readonly wasAlreadyAttached: boolean;
+}
+
+/**
  * Attaches provided prompts to a chat input.
  */
-export const attachPrompts = async (
-	files: readonly WithUriValue<Object>[],
+export const attachPrompt = async (
+	file: URI,
 	options: IAttachPromptOptions,
-): Promise<IChatWidget> => {
+): Promise<IAttachResult> => {
 	const widget = await getChatWidgetObject(options);
 
-	for (const file of files) {
-		widget
-			.attachmentModel
-			.promptInstructions
-			.add(file.value);
-	}
+	const wasAlreadyAttached = widget
+		.attachmentModel
+		.promptInstructions
+		.add(file);
 
-	return widget;
+	return { widget, wasAlreadyAttached };
 };
 
 /**

--- a/src/vs/workbench/contrib/chat/browser/actions/reusablePromptActions/dialogs/askToSelectPrompt/utils/detachPrompt.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/reusablePromptActions/dialogs/askToSelectPrompt/utils/detachPrompt.ts
@@ -1,0 +1,34 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IChatWidget } from '../../../../../chat.js';
+import { URI } from '../../../../../../../../../base/common/uri.js';
+
+/**
+ * Options for the {@link detachPrompt} function.
+ */
+export interface IDetachPromptOptions {
+	/**
+	 * Chat widget instance to attach the prompt to.
+	 */
+	readonly widget: IChatWidget;
+}
+
+/**
+ * Detaches provided prompts to a chat input.
+ */
+export const detachPrompt = async (
+	file: URI,
+	options: IDetachPromptOptions,
+): Promise<IChatWidget> => {
+	const { widget } = options;
+
+	widget
+		.attachmentModel
+		.promptInstructions
+		.remove(file);
+
+	return widget;
+};

--- a/src/vs/workbench/contrib/chat/browser/chatAttachmentModel/chatPromptAttachmentsCollection.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatAttachmentModel/chatPromptAttachmentsCollection.ts
@@ -169,11 +169,13 @@ export class ChatPromptAttachmentsCollection extends Disposable {
 	/**
 	 * Add a prompt instruction attachment instance with the provided `URI`.
 	 * @param uri URI of the prompt instruction attachment to add.
+	 *
+	 * @returns `true` if the attachment already exists, `false` otherwise.
 	 */
-	public add(uri: URI): this {
+	public add(uri: URI): boolean {
 		// if already exists, nothing to do
 		if (this.attachments.has(uri.path)) {
-			return this;
+			return true;
 		}
 
 		const instruction = this.initService.createInstance(ChatPromptAttachmentModel, uri)
@@ -191,7 +193,7 @@ export class ChatPromptAttachmentsCollection extends Disposable {
 		this._onAdd.fire(instruction);
 		this._onUpdate.fire();
 
-		return this;
+		return false;
 	}
 
 	/**


### PR DESCRIPTION
Changes behavior of the editor "play" action to immediately execute the current prompt file.

For https://github.com/microsoft/vscode-copilot/issues/15596