### PR TITLE
Chat variables and decorations

### DIFF
--- a/src/vs/editor/browser/editorBrowser.ts
+++ b/src/vs/editor/browser/editorBrowser.ts
@@ -1019,7 +1019,7 @@ export interface ICodeEditor extends editorCommon.IEditor {
 	/**
 	 * @internal
 	 */
-	setDecorationsByType(description: string, decorationTypeKey: string, ranges: editorCommon.IDecorationOptions[]): void;
+	setDecorationsByType(description: string, decorationTypeKey: string, ranges: editorCommon.IDecorationOptions[]): readonly string[];
 
 	/**
 	 * @internal

--- a/src/vs/editor/browser/widget/codeEditor/codeEditorWidget.ts
+++ b/src/vs/editor/browser/widget/codeEditor/codeEditorWidget.ts
@@ -1314,7 +1314,7 @@ export class CodeEditorWidget extends Disposable implements editorBrowser.ICodeE
 		});
 	}
 
-	public setDecorationsByType(description: string, decorationTypeKey: string, decorationOptions: editorCommon.IDecorationOptions[]): void {
+	public setDecorationsByType(description: string, decorationTypeKey: string, decorationOptions: editorCommon.IDecorationOptions[]): readonly string[] {
 
 		const newDecorationsSubTypes: { [key: string]: boolean } = {};
 		const oldDecorationsSubTypes = this._decorationTypeSubtypes[decorationTypeKey] || {};
@@ -1354,6 +1354,7 @@ export class CodeEditorWidget extends Disposable implements editorBrowser.ICodeE
 		// update all decorations
 		const oldDecorationsIds = this._decorationTypeKeysToIds[decorationTypeKey] || [];
 		this.changeDecorations(accessor => this._decorationTypeKeysToIds[decorationTypeKey] = accessor.deltaDecorations(oldDecorationsIds, newModelDecorations));
+		return this._decorationTypeKeysToIds[decorationTypeKey] || [];
 	}
 
 	public setDecorationsByTypeFast(decorationTypeKey: string, ranges: IRange[]): void {

--- a/src/vs/workbench/contrib/chat/browser/contrib/chatDynamicVariables.ts
+++ b/src/vs/workbench/contrib/chat/browser/contrib/chatDynamicVariables.ts
@@ -11,7 +11,7 @@ import { Codicon } from '../../../../../base/common/codicons.js';
 import { isCancellationError } from '../../../../../base/common/errors.js';
 import * as glob from '../../../../../base/common/glob.js';
 import { IMarkdownString, MarkdownString } from '../../../../../base/common/htmlContent.js';
-import { Disposable, DisposableStore, isDisposable } from '../../../../../base/common/lifecycle.js';
+import { Disposable, DisposableStore, dispose, isDisposable } from '../../../../../base/common/lifecycle.js';
 import { ResourceSet } from '../../../../../base/common/map.js';
 import { basename, dirname, joinPath, relativePath } from '../../../../../base/common/resources.js';
 import { ThemeIcon } from '../../../../../base/common/themables.js';
@@ -43,20 +43,6 @@ import { ChatFileReference } from './chatDynamicVariables/chatFileReference.js';
 
 export const dynamicVariableDecorationType = 'chat-dynamic-variable';
 
-function changeIsBeforeVariable(changeRange: IRange, variableRange: IRange): boolean {
-	return (
-		changeRange.endLineNumber < variableRange.startLineNumber ||
-		(changeRange.endLineNumber === variableRange.startLineNumber && changeRange.endColumn <= variableRange.startColumn)
-	);
-}
-
-function changeIsAfterVariable(changeRange: IRange, variableRange: IRange): boolean {
-	return (
-		changeRange.startLineNumber > variableRange.endLineNumber ||
-		(changeRange.startLineNumber === variableRange.endLineNumber && changeRange.startColumn >= variableRange.endColumn)
-	);
-}
-
 /**
  * Type of dynamic variables. Can be either a file reference or
  * another dynamic variable (e.g., a `#sym`, `#kb`, etc.).
@@ -75,6 +61,8 @@ export class ChatDynamicVariableModel extends Disposable implements IChatWidgetC
 		return ChatDynamicVariableModel.ID;
 	}
 
+	private decorationData: { id: string; text: string }[] = [];
+
 	constructor(
 		private readonly widget: IChatWidget,
 		@ILabelService private readonly labelService: ILabelService,
@@ -84,91 +72,62 @@ export class ChatDynamicVariableModel extends Disposable implements IChatWidgetC
 		super();
 
 		this._register(widget.inputEditor.onDidChangeModelContent(e => {
-			e.changes.forEach(c => {
-				// Don't mutate entries in _variables, since they will be returned from the getter
-				this._variables = coalesce(this._variables.map((ref): TDynamicVariable | null => {
-					const intersection = Range.intersectRanges(ref.range, c.range);
-					if (intersection && !intersection.isEmpty()) {
-						// The reference text was changed, it's broken.
-						// But if the whole reference range was deleted (eg history navigation) then don't try to change the editor.
-						if (!Range.containsRange(c.range, ref.range)) {
-							const rangeToDelete = new Range(ref.range.startLineNumber, ref.range.startColumn, ref.range.endLineNumber, ref.range.endColumn - 1);
-							this.widget.inputEditor.executeEdits(this.id, [{
-								range: rangeToDelete,
-								text: '',
-							}]);
-							this.widget.refreshParsedInput();
-						}
 
-						// dispose the reference if possible before dropping it off
-						if (isDisposable(ref)) {
-							ref.dispose();
-						}
+			const removed: TDynamicVariable[] = [];
+			let didChange = false;
 
-						return null;
-					} else if (Range.compareRangesUsingStarts(ref.range, c.range) > 0) {
-						// Determine if the change is before, after, or overlaps with the variable range.
-						if (changeIsBeforeVariable(c.range, ref.range)) {
+			// Don't mutate entries in _variables, since they will be returned from the getter
+			this._variables = coalesce(this._variables.map((ref, idx): TDynamicVariable | null => {
+				const model = widget.inputEditor.getModel();
 
-							// Calculate line delta
-							const linesInserted = c.text.split('\n').length - 1;
-							const linesRemoved = c.range.endLineNumber - c.range.startLineNumber;
-							const lineDelta = linesInserted - linesRemoved;
+				if (!model) {
+					removed.push(ref);
+					return null;
+				}
 
-							// Initialize column delta
-							let columnDelta = 0;
+				const data = this.decorationData[idx];
+				const newRange = model.getDecorationRange(data.id);
 
-							// Check if change is on the same line as the variable start
-							if (c.range.endLineNumber === ref.range.startLineNumber) {
-								// Change is on the same line
-								if (c.range.endColumn <= ref.range.startColumn) {
-									// Change occurs before the variable start column
-									if (linesInserted === 0) {
-										// Single-line change
-										const charsInserted = c.text.length;
-										const charsRemoved = c.rangeLength;
-										columnDelta = charsInserted - charsRemoved;
-									} else {
-										// Multi-line change (newline inserted)
-										columnDelta = - (c.range.endColumn - 1);
-										// The variable column should be adjusted to account for the reset after newline
-									}
-								} else {
-									// Change occurs after the variable start column
-									columnDelta = 0;
-								}
-							} else if (c.range.endLineNumber < ref.range.startLineNumber) {
-								// Change is on lines before the variable line
-								columnDelta = 0;
-							}
+				if (!newRange) {
+					// gone
+					removed.push(ref);
+					return null;
+				}
 
-							const newRange = {
-								startLineNumber: ref.range.startLineNumber + lineDelta,
-								startColumn: ref.range.startColumn + columnDelta,
-								endLineNumber: ref.range.endLineNumber + lineDelta,
-								endColumn: ref.range.endColumn + columnDelta
-							};
-							if (ref instanceof ChatFileReference) {
-								ref.range = newRange;
-								return ref;
-							} else {
-								return {
-									...ref,
-									range: newRange
-								};
-							}
-						} else if (changeIsAfterVariable(c.range, ref.range)) {
-							// Change is after the variable no adjustment needed.
-							return ref;
-						} else {
-							// Change overlaps with the variable the variable is broken.
-							return null;
-						}
-					}
+				const newText = model.getValueInRange(newRange);
+				if (newText !== data.text) {
 
+					this.widget.inputEditor.executeEdits(this.id, [{
+						range: newRange,
+						text: '',
+					}]);
+					this.widget.refreshParsedInput();
+
+					removed.push(ref);
+					return null;
+				}
+
+				if (newRange.equalsRange(ref.range)) {
+					// all good
 					return ref;
-				}));
-			});
+				}
+
+				didChange = true;
+
+				if (ref instanceof ChatFileReference) {
+					ref.range = newRange;
+					return ref;
+				} else {
+					return { ...ref, range: newRange };
+				}
+			}));
+
+			// cleanup disposable variables
+			dispose(removed.filter(isDisposable));
+
+			if (didChange || removed.length > 0) {
+				this.widget.refreshParsedInput();
+			}
 
 			this.updateDecorations();
 		}));
@@ -227,10 +186,20 @@ export class ChatDynamicVariableModel extends Disposable implements IChatWidgetC
 	}
 
 	private updateDecorations(): void {
-		this.widget.inputEditor.setDecorationsByType('chat', dynamicVariableDecorationType, this._variables.map((r): IDecorationOptions => ({
+
+		const decorations = this._variables.map((r): IDecorationOptions => ({
 			range: r.range,
 			hoverMessage: this.getHoverForReference(r)
-		})));
+		}));
+		const decorationIds = this.widget.inputEditor.setDecorationsByType('chat', dynamicVariableDecorationType, decorations);
+
+		this.decorationData = [];
+		for (let i = 0; i < decorationIds.length; i++) {
+			this.decorationData.push({
+				id: decorationIds[i],
+				text: this.widget.inputEditor.getModel()!.getValueInRange(this._variables[i].range)
+			});
+		}
 	}
 
 	private getHoverForReference(ref: IDynamicVariable): IMarkdownString | undefined {


### PR DESCRIPTION
* use `themeColorFromId` so that decoration types don't nee dto get cleared
* use decoration ranges as source-of-truth when updating dynamic variables
* let `ICodeEditor#setDecorationsByType` return decoration ids fyi @hediet

fyi @roblourens