### PR TITLE
add "prompt-basics" language extension

### DIFF
--- a/extensions/prompt-basics/.vscodeignore
+++ b/extensions/prompt-basics/.vscodeignore
@@ -1,0 +1,4 @@
+test/**
+src/**
+tsconfig.json
+cgmanifest.json

--- a/extensions/prompt-basics/cgmanifest.json
+++ b/extensions/prompt-basics/cgmanifest.json
@@ -1,0 +1,4 @@
+{
+	"registrations": [],
+	"version": 1
+}

--- a/extensions/prompt-basics/cgmanifest.json
+++ b/extensions/prompt-basics/cgmanifest.json
@@ -1,4 +1,44 @@
 {
-	"registrations": [],
+	"registrations": [
+		{
+			"component": {
+				"type": "git",
+				"git": {
+					"name": "textmate/markdown.tmbundle",
+					"repositoryUrl": "https://github.com/textmate/markdown.tmbundle",
+					"commitHash": "11cf764606cb2cde54badb5d0e5a0758a8871c4b"
+				}
+			},
+			"licenseDetail": [
+				"Copyright (c) markdown.tmbundle authors",
+				"",
+				"If not otherwise specified (see below), files in this repository fall under the following license:",
+				"",
+				"Permission to copy, use, modify, sell and distribute this",
+				"software is granted. This software is provided \"as is\" without",
+				"express or implied warranty, and with no claim as to its",
+				"suitability for any purpose.",
+				"",
+				"An exception is made for files in readable text which contain their own license information,",
+				"or files where an accompanying file exists (in the same directory) with a \"-license\" suffix added",
+				"to the base-name name of the original file, and an extension of txt, html, or similar. For example",
+				"\"tidy\" is accompanied by \"tidy-license.txt\"."
+			],
+			"license": "TextMate Bundle License",
+			"version": "0.0.0"
+		},
+		{
+			"component": {
+				"type": "git",
+				"git": {
+					"name": "microsoft/vscode-markdown-tm-grammar",
+					"repositoryUrl": "https://github.com/microsoft/vscode-markdown-tm-grammar",
+					"commitHash": "7418dd20d76c72e82fadee2909e03239e9973b35"
+				}
+			},
+			"license": "MIT",
+			"version": "1.0.0"
+		}
+	],
 	"version": 1
 }

--- a/extensions/prompt-basics/language-configuration.json
+++ b/extensions/prompt-basics/language-configuration.json
@@ -1,0 +1,103 @@
+{
+	"comments": {
+		// symbols used for start and end a block comment. Remove this entry if your language does not support block comments
+		"blockComment": [
+			"<!--",
+			"-->"
+		]
+	},
+	// symbols used as brackets
+	"brackets": [
+		[
+			"{",
+			"}"
+		],
+		[
+			"[",
+			"]"
+		],
+		[
+			"(",
+			")"
+		]
+	],
+	"colorizedBracketPairs": [],
+	"autoClosingPairs": [
+		{
+			"open": "{",
+			"close": "}"
+		},
+		{
+			"open": "[",
+			"close": "]"
+		},
+		{
+			"open": "(",
+			"close": ")"
+		},
+		{
+			"open": "<",
+			"close": ">",
+			"notIn": [
+				"string"
+			]
+		},
+	],
+	"surroundingPairs": [
+		[
+			"(",
+			")"
+		],
+		[
+			"[",
+			"]"
+		],
+		[
+			"`",
+			"`"
+		],
+		[
+			"_",
+			"_"
+		],
+		[
+			"*",
+			"*"
+		],
+		[
+			"{",
+			"}"
+		],
+		[
+			"'",
+			"'"
+		],
+		[
+			"\"",
+			"\""
+		],
+		[
+			"<",
+			">"
+		],
+		[
+			"~",
+			"~"
+		],
+		[
+			"$",
+			"$"
+		]
+	],
+	"folding": {
+		"offSide": true,
+		"markers": {
+			"start": "^\\s*<!--\\s*#?region\\b.*-->",
+			"end": "^\\s*<!--\\s*#?endregion\\b.*-->"
+		}
+	},
+	"wordPattern": {
+		"pattern": "(\\p{Alphabetic}|\\p{Number}|\\p{Nonspacing_Mark})(((\\p{Alphabetic}|\\p{Number}|\\p{Nonspacing_Mark})|[_])?(\\p{Alphabetic}|\\p{Number}|\\p{Nonspacing_Mark}))*",
+		"flags": "ug"
+	},
+}

--- a/extensions/prompt-basics/package.json
+++ b/extensions/prompt-basics/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "prompt",
+  "displayName": "%displayName%",
+  "description": "%description%",
+  "version": "0.1.0",
+  "publisher": "vscode",
+  "license": "MIT",
+  "engines": {
+    "vscode": "^1.20.0"
+  },
+  "categories": ["Programming Languages"],
+  "contributes": {
+    "languages": [
+      {
+        "id": "prompt.md",
+        "aliases": [
+          "Prompt",
+          "prompt"
+        ],
+        "extensions": [
+          ".prompt.md",
+          "copilot-instructions.md"
+        ],
+        "configuration": "./language-configuration.json"
+      }
+    ],
+    "grammars": [
+      {
+        "language": "prompt.md",
+        "path": "./syntaxes/prompt.tmLanguage.json",
+        "scopeName": "text.html.markdown.prompt"
+      }
+    ],
+
+    "configurationDefaults": {
+      "[prompt.md]": {
+        "editor.unicodeHighlight.ambiguousCharacters": false,
+        "editor.unicodeHighlight.invisibleCharacters": false,
+        "diffEditor.ignoreTrimWhitespace": false
+      }
+    }
+  },
+  "scripts": {},
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/microsoft/vscode.git"
+  }
+}

--- a/extensions/prompt-basics/package.json
+++ b/extensions/prompt-basics/package.json
@@ -2,7 +2,7 @@
   "name": "prompt",
   "displayName": "%displayName%",
   "description": "%description%",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "publisher": "vscode",
   "license": "MIT",
   "engines": {
@@ -28,10 +28,13 @@
       {
         "language": "prompt.md",
         "path": "./syntaxes/prompt.tmLanguage.json",
-        "scopeName": "text.html.markdown.prompt"
+        "scopeName": "text.html.markdown.prompt",
+        "unbalancedBracketScopes": [
+          "markup.underline.link.markdown",
+          "punctuation.definition.list.begin.markdown"
+        ]
       }
     ],
-
     "configurationDefaults": {
       "[prompt.md]": {
         "editor.unicodeHighlight.ambiguousCharacters": false,

--- a/extensions/prompt-basics/package.nls.json
+++ b/extensions/prompt-basics/package.nls.json
@@ -1,0 +1,4 @@
+{
+	"displayName": "Prompt Language Basics",
+	"description": "Syntax highlighting for Prompt documents."
+}

--- a/extensions/prompt-basics/syntaxes/prompt.tmLanguage.json
+++ b/extensions/prompt-basics/syntaxes/prompt.tmLanguage.json
@@ -1,0 +1,15 @@
+{
+	"information_for_contributors": [
+		"This file has been converted from https://github.com/microsoft/vscode-markdown-tm-grammar/blob/master/syntaxes/markdown.tmLanguage",
+		"If you want to provide a fix or improvement, please create a pull request against the original repository.",
+		"Once accepted there, we are happy to receive an update request."
+	],
+	"version": "0.1.0",
+	"name": "Prompt",
+	"scopeName": "text.html.markdown.prompt",
+	"patterns": [
+		{
+			"include": "text.html.markdown"
+		}
+	]
+}

--- a/src/vs/platform/prompts/common/constants.ts
+++ b/src/vs/platform/prompts/common/constants.ts
@@ -56,6 +56,11 @@ export const isPromptFile = (
 export const getCleanPromptName = (
 	fileUri: URI,
 ): string => {
+	// TODO: @legomushroom
+	if (fileUri.scheme === 'untitled') {
+		return fileUri.path;
+	}
+
 	assert(
 		isPromptFile(fileUri),
 		`Provided path '${fileUri.fsPath}' is not a prompt file.`,

--- a/src/vs/workbench/contrib/chat/browser/actions/reusablePromptActions/chatRunPromptAction.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/reusablePromptActions/chatRunPromptAction.ts
@@ -11,7 +11,7 @@ import { ChatContextKeys } from '../../../common/chatContextKeys.js';
 import { assertDefined } from '../../../../../../base/common/types.js';
 import { ILocalizedString, localize2 } from '../../../../../../nls.js';
 import { ThemeIcon } from '../../../../../../base/common/themables.js';
-import { TEXT_FILE_EDITOR_ID } from '../../../../files/common/files.js';
+// import { TEXT_FILE_EDITOR_ID } from '../../../../files/common/files.js';
 import { KeyCode, KeyMod } from '../../../../../../base/common/keyCodes.js';
 import { attachPrompt } from './dialogs/askToSelectPrompt/utils/attachPrompt.js';
 import { detachPrompt } from './dialogs/askToSelectPrompt/utils/detachPrompt.js';
@@ -23,7 +23,7 @@ import { EditorContextKeys } from '../../../../../../editor/common/editorContext
 import { ICommandService } from '../../../../../../platform/commands/common/commands.js';
 import { getActivePromptUri } from '../../promptSyntax/contributions/usePromptCommand.js';
 import { ContextKeyExpr } from '../../../../../../platform/contextkey/common/contextkey.js';
-import { ActiveEditorContext, ResourceContextKey } from '../../../../../common/contextkeys.js';
+import { ResourceContextKey } from '../../../../../common/contextkeys.js';
 import { KeybindingWeight } from '../../../../../../platform/keybinding/common/keybindingsRegistry.js';
 import { Action2, MenuId, registerAction2 } from '../../../../../../platform/actions/common/actions.js';
 
@@ -132,12 +132,13 @@ abstract class RunPromptBaseAction extends Action2 {
  */
 const EDITOR_ACTIONS_CONDITION = ContextKeyExpr.and(
 	ContextKeyExpr.and(PromptsConfig.enabledCtx, ChatContextKeys.enabled),
-	ResourceContextKey.HasResource,
-	ContextKeyExpr.regex(
-		ResourceContextKey.Filename.key,
-		/\.prompt\.md|copilot-instructions\.md$/,
-	),
-	ActiveEditorContext.isEqualTo(TEXT_FILE_EDITOR_ID),
+	// ResourceContextKey.HasResource,
+	// ContextKeyExpr.regex(
+	// 	ResourceContextKey.Filename.key,
+	// 	/\.prompt\.md|copilot-instructions\.md$/,
+	// ),
+	ResourceContextKey.LangId.isEqualTo('prompt.md'),
+	// ActiveEditorContext.isEqualTo(TEXT_FILE_EDITOR_ID),
 );
 
 /**

--- a/src/vs/workbench/contrib/chat/browser/chatAttachmentModel/chatPromptAttachmentsCollection.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatAttachmentModel/chatPromptAttachmentsCollection.ts
@@ -28,14 +28,15 @@ import { IConfigurationService } from '../../../../../platform/configuration/com
 export const toChatVariable = (
 	reference: Pick<IPromptFileReference, 'uri' | 'isPromptFile'>,
 	isRoot: boolean,
+	isPromptAttachment?: boolean,
 ): IChatRequestVariableEntry => {
-	const { uri, isPromptFile: isPromptFile } = reference;
+	const { uri, isPromptFile } = reference;
 
 	// default `id` is the stringified `URI`
 	let id = `${uri}`;
 
 	// for prompt files, we add a prefix to the `id`
-	if (isPromptFile) {
+	if (isPromptAttachment || isPromptFile) {
 		// the default prefix that is used for all prompt files
 		let prefix = 'vscode.prompt.instructions';
 		// if the reference is the root object, add the `.root` suffix
@@ -93,7 +94,7 @@ export class ChatPromptAttachmentsCollection extends Disposable {
 			const { reference } = attachment;
 
 			// the usual URIs list of prompt instructions is `bottom-up`, therefore
-			// we do the same herfe - first add all child references of the model
+			// we do the same here - first add all child references of the model
 			result.push(
 				...reference.allValidReferences.map((link) => {
 					return toChatVariable(link, false);
@@ -102,7 +103,7 @@ export class ChatPromptAttachmentsCollection extends Disposable {
 
 			// then add the root reference of the model itself
 			result.push(
-				toChatVariable(reference, true),
+				toChatVariable(reference, true, true),
 			);
 		}
 

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/constants.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/constants.ts
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { LanguageFilter } from '../../../../../editor/common/languageSelector.js';
-import { COPILOT_CUSTOM_INSTRUCTIONS_FILENAME, PROMPT_FILE_EXTENSION } from '../../../../../platform/prompts/common/constants.js';
 
 /**
  * Documentation link for the reusable prompts feature.
@@ -12,24 +11,13 @@ import { COPILOT_CUSTOM_INSTRUCTIONS_FILENAME, PROMPT_FILE_EXTENSION } from '../
 export const DOCUMENTATION_URL = 'https://aka.ms/vscode-ghcp-prompt-snippets';
 
 /**
- * Supported reusable prompt file patterns.
+ * Language ID for the reusable prompt syntax.
  */
-const REUSABLE_PROMPT_FILE_PATTERNS = Object.freeze([
-	/**
-	 * Any file that has the prompt file extension.
-	 * See {@link PROMPT_FILE_EXTENSION}.
-	 */
-	`**/*${PROMPT_FILE_EXTENSION}`,
-
-	/**
-	 * Copilot custom instructions file inside a `.github` folder.
-	 */
-	`**/.github/${COPILOT_CUSTOM_INSTRUCTIONS_FILENAME}`,
-]);
+export const PROMPT_LANGUAGE_ID = 'prompt.md';
 
 /**
  * Prompt files language selector.
  */
 export const LANGUAGE_SELECTOR: LanguageFilter = Object.freeze({
-	pattern: `{${REUSABLE_PROMPT_FILE_PATTERNS.join(',')}}`,
+	language: PROMPT_LANGUAGE_ID,
 });

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/contentProviders/promptContentsProviderBase.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/contentProviders/promptContentsProviderBase.ts
@@ -17,15 +17,15 @@ import { cancelPreviousCalls } from '../../../../../../base/common/decorators/ca
 /**
  * Base class for prompt contents providers. Classes that extend this one are responsible to:
  *
- * - implement the {@linkcode getContentsStream} method to provide the contents stream
+ * - implement the {@link getContentsStream} method to provide the contents stream
  *   of a prompt; this method should throw a `ResolveError` or its derivative if the contents
  *   cannot be parsed for any reason
- * - fire a {@linkcode TChangeEvent} event on the {@linkcode onChangeEmitter} event when
+ * - fire a {@link TChangeEvent} event on the {@link onChangeEmitter} event when
  * 	 prompt contents change
  * - misc:
- *   - provide the {@linkcode uri} property that represents the URI of a prompt that
+ *   - provide the {@link uri} property that represents the URI of a prompt that
  *     the contents are for
- *   - implement the {@linkcode toString} method to return a string representation of this
+ *   - implement the {@link toString} method to return a string representation of this
  *     provider type to aid with debugging/tracing
  */
 export abstract class PromptContentsProviderBase<
@@ -65,7 +65,7 @@ export abstract class PromptContentsProviderBase<
 
 	/**
 	 * Event emitter for the prompt contents change event.
-	 * See {@linkcode onContentChanged} for more details.
+	 * See {@link onContentChanged} for more details.
 	 */
 	private readonly onContentChangedEmitter = this._register(new Emitter<VSBufferReadableStream | ResolveError>());
 
@@ -76,7 +76,7 @@ export abstract class PromptContentsProviderBase<
 	 *
 	 * `Note!` this field is meant to be used by the external consumers of the prompt
 	 *         contents provider that the classes that extend this abstract class.
-	 *         Please use the {@linkcode onChangeEmitter} event to provide a change
+	 *         Please use the {@link onChangeEmitter} event to provide a change
 	 *         event in your prompt contents implementation instead.
 	 */
 	public readonly onContentChanged = this.onContentChangedEmitter.event;

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/contentProviders/textModelContentsProvider.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/contentProviders/textModelContentsProvider.ts
@@ -15,6 +15,7 @@ import { CancellationToken } from '../../../../../../base/common/cancellation.js
 import { newWriteableStream, ReadableStream } from '../../../../../../base/common/stream.js';
 import { IModelContentChangedEvent } from '../../../../../../editor/common/textModelEvents.js';
 import { IInstantiationService } from '../../../../../../platform/instantiation/common/instantiation.js';
+import { ILogService } from '../../../../../../platform/log/common/log.js';
 
 /**
  * Prompt contents provider for a {@link ITextModel} instance.
@@ -30,6 +31,7 @@ export class TextModelContentsProvider extends PromptContentsProviderBase<IModel
 	constructor(
 		private readonly model: ITextModel,
 		@IInstantiationService private readonly initService: IInstantiationService,
+		@ILogService private readonly logService: ILogService,
 	) {
 		super();
 
@@ -90,7 +92,13 @@ export class TextModelContentsProvider extends PromptContentsProviderBase<IModel
 					);
 				}
 			} catch (error) {
-				console.log(this.uri, i, error);
+				this.logService.error(
+					[
+						'[text model contents provider]: ',
+						`Failed to write line #${i} of text model '${this.uri.path}' to stream: `,
+					].join(''),
+					error,
+				);
 			}
 
 			// use the next line in the next iteration

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/languageFeatures/providers/index.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/languageFeatures/providers/index.ts
@@ -9,8 +9,8 @@ import { PromptPathAutocompletion } from './promptPathAutocompletion.js';
 import { Registry } from '../../../../../../../platform/registry/common/platform.js';
 import { LifecyclePhase } from '../../../../../../services/lifecycle/common/lifecycle.js';
 import { PromptLinkDiagnosticsInstanceManager } from './promptLinkDiagnosticsProvider.js';
-import { PromptDecorationsProviderInstanceManager } from './decorationsProvider/promptDecorationsProvider.js';
 import { BrandedService } from '../../../../../../../platform/instantiation/common/instantiation.js';
+import { PromptDecorationsProviderInstanceManager } from './decorationsProvider/promptDecorationsProvider.js';
 import { IWorkbenchContributionsRegistry, Extensions, IWorkbenchContribution } from '../../../../../../common/contributions.js';
 
 /**

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/languageFeatures/providers/providerInstanceManagerBase.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/languageFeatures/providers/providerInstanceManagerBase.ts
@@ -3,17 +3,17 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { PROMPT_LANGUAGE_ID } from '../../constants.js';
 import { ProviderInstanceBase } from './providerInstanceBase.js';
 import { ITextModel } from '../../../../../../../editor/common/model.js';
+import { assertDefined } from '../../../../../../../base/common/types.js';
 import { Disposable } from '../../../../../../../base/common/lifecycle.js';
 import { ObjectCache } from '../../../../../../../base/common/objectCache.js';
 import { PromptsConfig } from '../../../../../../../platform/prompts/common/config.js';
-import { isPromptFile } from '../../../../../../../platform/prompts/common/constants.js';
 import { IDiffEditor, IEditor } from '../../../../../../../editor/common/editorCommon.js';
 import { IEditorService } from '../../../../../../services/editor/common/editorService.js';
 import { IInstantiationService } from '../../../../../../../platform/instantiation/common/instantiation.js';
 import { IConfigurationService } from '../../../../../../../platform/configuration/common/configuration.js';
-import { assertDefined } from '../../../../../../../base/common/types.js';
 
 /**
  * Type for a text editor that is used for reusable prompt files.
@@ -123,9 +123,8 @@ const isPromptFileEditor = (
 		return false;
 	}
 
-	// enable this on editors of the reusable prompt files only
-	if (isPromptFile(model.uri) === false) {
-		return false;
+	if (model.getLanguageId() === PROMPT_LANGUAGE_ID) {
+		return true;
 	}
 
 	// override the `getModel()` method to align with the `IPromptFileEditor` interface

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/basePromptParser.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/basePromptParser.ts
@@ -133,7 +133,7 @@ export class BasePromptParser<TContentsProvider extends IPromptContentsProvider>
 	}
 
 	/**
-	 * Same as {@linkcode settled} but also waits for all possible
+	 * Same as {@link settled} but also waits for all possible
 	 * nested child prompt references and their children to be settled.
 	 */
 	public async allSettled(): Promise<this> {
@@ -333,7 +333,7 @@ export class BasePromptParser<TContentsProvider extends IPromptContentsProvider>
 	}
 
 	/**
-	 * Private attribute to track if the {@linkcode start}
+	 * Private attribute to track if the {@link start}
 	 * method has been already called at least once.
 	 */
 	private started: boolean = false;


### PR DESCRIPTION
Defines the "prompt" language by adding a built-in language extension that extends markdown's text mate definition and reuses its configuration file.

Part of https://github.com/microsoft/vscode-copilot/issues/15596