### PR TITLE
[prompts]: add "prompt-basics" language extension

### DIFF
--- a/extensions/prompt-basics/.vscodeignore
+++ b/extensions/prompt-basics/.vscodeignore
@@ -1,0 +1,4 @@
+test/**
+src/**
+tsconfig.json
+cgmanifest.json

--- a/extensions/prompt-basics/cgmanifest.json
+++ b/extensions/prompt-basics/cgmanifest.json
@@ -1,0 +1,4 @@
+{
+	"registrations": [],
+	"version": 1
+}

--- a/extensions/prompt-basics/language-configuration.json
+++ b/extensions/prompt-basics/language-configuration.json
@@ -1,0 +1,103 @@
+{
+	"comments": {
+		// symbols used for start and end a block comment. Remove this entry if your language does not support block comments
+		"blockComment": [
+			"<!--",
+			"-->"
+		]
+	},
+	// symbols used as brackets
+	"brackets": [
+		[
+			"{",
+			"}"
+		],
+		[
+			"[",
+			"]"
+		],
+		[
+			"(",
+			")"
+		]
+	],
+	"colorizedBracketPairs": [],
+	"autoClosingPairs": [
+		{
+			"open": "{",
+			"close": "}"
+		},
+		{
+			"open": "[",
+			"close": "]"
+		},
+		{
+			"open": "(",
+			"close": ")"
+		},
+		{
+			"open": "<",
+			"close": ">",
+			"notIn": [
+				"string"
+			]
+		},
+	],
+	"surroundingPairs": [
+		[
+			"(",
+			")"
+		],
+		[
+			"[",
+			"]"
+		],
+		[
+			"`",
+			"`"
+		],
+		[
+			"_",
+			"_"
+		],
+		[
+			"*",
+			"*"
+		],
+		[
+			"{",
+			"}"
+		],
+		[
+			"'",
+			"'"
+		],
+		[
+			"\"",
+			"\""
+		],
+		[
+			"<",
+			">"
+		],
+		[
+			"~",
+			"~"
+		],
+		[
+			"$",
+			"$"
+		]
+	],
+	"folding": {
+		"offSide": true,
+		"markers": {
+			"start": "^\\s*<!--\\s*#?region\\b.*-->",
+			"end": "^\\s*<!--\\s*#?endregion\\b.*-->"
+		}
+	},
+	"wordPattern": {
+		"pattern": "(\\p{Alphabetic}|\\p{Number}|\\p{Nonspacing_Mark})(((\\p{Alphabetic}|\\p{Number}|\\p{Nonspacing_Mark})|[_])?(\\p{Alphabetic}|\\p{Number}|\\p{Nonspacing_Mark}))*",
+		"flags": "ug"
+	},
+}

--- a/extensions/prompt-basics/package.json
+++ b/extensions/prompt-basics/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "prompt",
+  "displayName": "%displayName%",
+  "description": "%description%",
+  "version": "0.1.0",
+  "publisher": "vscode",
+  "license": "MIT",
+  "engines": {
+    "vscode": "^1.20.0"
+  },
+  "categories": ["Programming Languages"],
+  "contributes": {
+    "languages": [
+      {
+        "id": "prompt.md",
+        "aliases": [
+          "Prompt",
+          "prompt"
+        ],
+        "extensions": [
+          ".prompt.md",
+          "copilot-instructions.md"
+        ],
+        "configuration": "./language-configuration.json"
+      }
+    ],
+    "grammars": [
+      {
+        "language": "prompt.md",
+        "path": "./syntaxes/prompt.tmLanguage.json",
+        "scopeName": "text.html.markdown.prompt"
+      }
+    ],
+
+    "configurationDefaults": {
+      "[prompt.md]": {
+        "editor.unicodeHighlight.ambiguousCharacters": false,
+        "editor.unicodeHighlight.invisibleCharacters": false,
+        "diffEditor.ignoreTrimWhitespace": false
+      }
+    }
+  },
+  "scripts": {},
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/microsoft/vscode.git"
+  }
+}

--- a/extensions/prompt-basics/package.json
+++ b/extensions/prompt-basics/package.json
@@ -2,7 +2,7 @@
   "name": "prompt",
   "displayName": "%displayName%",
   "description": "%description%",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "publisher": "vscode",
   "license": "MIT",
   "engines": {
@@ -28,10 +28,13 @@
       {
         "language": "prompt.md",
         "path": "./syntaxes/prompt.tmLanguage.json",
-        "scopeName": "text.html.markdown.prompt"
+        "scopeName": "text.html.markdown.prompt",
+        "unbalancedBracketScopes": [
+          "markup.underline.link.markdown",
+          "punctuation.definition.list.begin.markdown"
+        ]
       }
     ],
-
     "configurationDefaults": {
       "[prompt.md]": {
         "editor.unicodeHighlight.ambiguousCharacters": false,

--- a/extensions/prompt-basics/package.json
+++ b/extensions/prompt-basics/package.json
@@ -12,7 +12,7 @@
   "contributes": {
     "languages": [
       {
-        "id": "prompt.md",
+        "id": "prompt",
         "aliases": [
           "Prompt",
           "prompt"
@@ -26,7 +26,7 @@
     ],
     "grammars": [
       {
-        "language": "prompt.md",
+        "language": "prompt",
         "path": "./syntaxes/prompt.tmLanguage.json",
         "scopeName": "text.html.markdown.prompt",
         "unbalancedBracketScopes": [
@@ -36,7 +36,7 @@
       }
     ],
     "configurationDefaults": {
-      "[prompt.md]": {
+      "[prompt]": {
         "editor.unicodeHighlight.ambiguousCharacters": false,
         "editor.unicodeHighlight.invisibleCharacters": false,
         "diffEditor.ignoreTrimWhitespace": false

--- a/extensions/prompt-basics/package.nls.json
+++ b/extensions/prompt-basics/package.nls.json
@@ -1,0 +1,4 @@
+{
+	"displayName": "Prompt Language Basics",
+	"description": "Syntax highlighting for Prompt documents."
+}

--- a/extensions/prompt-basics/syntaxes/prompt.tmLanguage.json
+++ b/extensions/prompt-basics/syntaxes/prompt.tmLanguage.json
@@ -1,0 +1,15 @@
+{
+	"information_for_contributors": [
+		"This file has been converted from https://github.com/microsoft/vscode-markdown-tm-grammar/blob/master/syntaxes/markdown.tmLanguage",
+		"If you want to provide a fix or improvement, please create a pull request against the original repository.",
+		"Once accepted there, we are happy to receive an update request."
+	],
+	"version": "0.1.0",
+	"name": "Prompt",
+	"scopeName": "text.html.markdown.prompt",
+	"patterns": [
+		{
+			"include": "text.html.markdown"
+		}
+	]
+}


### PR DESCRIPTION
Defines the "prompt" language by adding a built-in language extension that extends markdown's text mate definition and reuses its configuration file.

Part of https://github.com/microsoft/vscode-copilot/issues/15596