### PR TITLE
[prompts]: enable untitled prompt documents to be "run" in chat

### DIFF
--- a/src/vs/platform/prompts/common/constants.ts
+++ b/src/vs/platform/prompts/common/constants.ts
@@ -48,6 +48,15 @@ export const isPromptFile = (
 };
 
 /**
+ * Check whether provided URI belongs to an `untitled` document.
+ */
+const isUntitledDocument = (
+	fileUri: URI,
+): boolean => {
+	return fileUri.scheme === 'untitled';
+};
+
+/**
  * Gets clean prompt name without file extension.
  *
  * @throws If provided path is not a prompt file
@@ -56,6 +65,11 @@ export const isPromptFile = (
 export const getCleanPromptName = (
 	fileUri: URI,
 ): string => {
+	// if an untitled document, use it's `path` component as the name
+	if (isUntitledDocument(fileUri)) {
+		return fileUri.path;
+	}
+
 	assert(
 		isPromptFile(fileUri),
 		`Provided path '${fileUri.fsPath}' is not a prompt file.`,

--- a/src/vs/platform/prompts/common/constants.ts
+++ b/src/vs/platform/prompts/common/constants.ts
@@ -34,11 +34,15 @@ export const LOCATIONS_CONFIG_KEY: string = 'chat.promptFilesLocations';
 export const DEFAULT_SOURCE_FOLDER = '.github/prompts';
 
 /**
- * Check if provided path is a reusable prompt file.
+ * Check if provided URI points to a file that with prompt file extension.
  */
 export const isPromptFile = (
 	fileUri: URI,
 ): boolean => {
+	if (fileUri.scheme !== 'file') {
+		return false;
+	}
+
 	const filename = basename(fileUri.path);
 
 	const hasPromptFileExtension = filename.endsWith(PROMPT_FILE_EXTENSION);
@@ -50,7 +54,7 @@ export const isPromptFile = (
 /**
  * Check whether provided URI belongs to an `untitled` document.
  */
-const isUntitledDocument = (
+export const isUntitled = (
 	fileUri: URI,
 ): boolean => {
 	return fileUri.scheme === 'untitled';
@@ -66,7 +70,7 @@ export const getCleanPromptName = (
 	fileUri: URI,
 ): string => {
 	// if an untitled document, use it's `path` component as the name
-	if (isUntitledDocument(fileUri)) {
+	if (isUntitled(fileUri)) {
 		return fileUri.path;
 	}
 

--- a/src/vs/platform/prompts/common/constants.ts
+++ b/src/vs/platform/prompts/common/constants.ts
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { URI } from '../../../base/common/uri.js';
-import { assert } from '../../../base/common/assert.js';
 import { basename } from '../../../base/common/path.js';
 
 /**
@@ -70,10 +69,11 @@ export const getCleanPromptName = (
 		return fileUri.path;
 	}
 
-	assert(
-		isPromptFile(fileUri),
-		`Provided path '${fileUri.fsPath}' is not a prompt file.`,
-	);
+	// any file can be a prompt file if user selects the "prompt" language in
+	// the editor, so in this case return the full file name with file extension
+	if (isPromptFile(fileUri) === false) {
+		return basename(fileUri.path);
+	}
 
 	// if a Copilot custom instructions file, remove `markdown` file extension
 	// otherwise, remove the `prompt` file extension

--- a/src/vs/platform/prompts/common/constants.ts
+++ b/src/vs/platform/prompts/common/constants.ts
@@ -39,10 +39,6 @@ export const DEFAULT_SOURCE_FOLDER = '.github/prompts';
 export const isPromptFile = (
 	fileUri: URI,
 ): boolean => {
-	if (fileUri.scheme !== 'file') {
-		return false;
-	}
-
 	const filename = basename(fileUri.path);
 
 	const hasPromptFileExtension = filename.endsWith(PROMPT_FILE_EXTENSION);

--- a/src/vs/platform/prompts/test/common/constants.test.ts
+++ b/src/vs/platform/prompts/test/common/constants.test.ts
@@ -35,25 +35,21 @@ suite('Prompt Constants', () => {
 				getCleanPromptName(URI.file('.github/copilot-instructions.md')),
 				'copilot-instructions',
 			);
-		});
 
-		test('• throws if not a prompt file URI provided', () => {
-			assert.throws(() => {
-				getCleanPromptName(URI.file('/path/to/default.prompt.md1'));
-			});
+			assert.strictEqual(
+				getCleanPromptName(URI.file('/etc/prompts/my-prompt')),
+				'my-prompt',
+			);
 
-			assert.throws(() => {
-				getCleanPromptName(URI.file('./some.md'));
-			});
+			assert.strictEqual(
+				getCleanPromptName(URI.file('../some-folder/frequent.txt')),
+				'frequent.txt',
+			);
 
-
-			assert.throws(() => {
-				getCleanPromptName(URI.file('../some-folder/frequent.txt'));
-			});
-
-			assert.throws(() => {
-				getCleanPromptName(URI.file('/etc/prompts/my-prompt'));
-			});
+			assert.strictEqual(
+				getCleanPromptName(URI.parse('untitled:Untitled-1')),
+				'Untitled-1',
+			);
 		});
 	});
 

--- a/src/vs/workbench/contrib/chat/browser/actions/reusablePromptActions/chatRunPromptAction.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/reusablePromptActions/chatRunPromptAction.ts
@@ -28,6 +28,25 @@ import { KeybindingWeight } from '../../../../../../platform/keybinding/common/k
 import { Action2, MenuId, registerAction2 } from '../../../../../../platform/actions/common/actions.js';
 
 /**
+ * Condition for the `Run Current Prompt` action.
+ */
+const EDITOR_ACTIONS_CONDITION = ContextKeyExpr.and(
+	ContextKeyExpr.and(PromptsConfig.enabledCtx, ChatContextKeys.enabled),
+	ResourceContextKey.HasResource,
+	ResourceContextKey.LangId.isEqualTo(PROMPT_LANGUAGE_ID),
+);
+
+/**
+ * Keybinding of the action.
+ */
+const COMMAND_KEY_BINDING = KeyMod.WinCtrl | KeyCode.Slash | KeyMod.Alt;
+
+/**
+ * Action ID for the `Run Current Prompt` action.
+ */
+const RUN_CURRENT_PROMPT_ACTION_ID = 'workbench.action.chat.run.prompt.current';
+
+/**
  * Constructor options for the `Run Prompt` base action.
  */
 interface IRunPromptBaseActionConstructorOptions {
@@ -72,7 +91,10 @@ abstract class RunPromptBaseAction extends Action2 {
 			category: CHAT_CATEGORY,
 			icon: options.icon,
 			keybinding: {
-				when: EditorContextKeys.editorTextFocus,
+				when: ContextKeyExpr.and(
+					EditorContextKeys.editorTextFocus,
+					EDITOR_ACTIONS_CONDITION,
+				),
 				weight: KeybindingWeight.WorkbenchContrib,
 				primary: options.keybinding,
 			},
@@ -126,25 +148,6 @@ abstract class RunPromptBaseAction extends Action2 {
 		return widget;
 	}
 }
-
-/**
- * Condition for the `Run Current Prompt` action.
- */
-const EDITOR_ACTIONS_CONDITION = ContextKeyExpr.and(
-	ContextKeyExpr.and(PromptsConfig.enabledCtx, ChatContextKeys.enabled),
-	ResourceContextKey.HasResource,
-	ResourceContextKey.LangId.isEqualTo(PROMPT_LANGUAGE_ID),
-);
-
-/**
- * Keybinding of the action.
- */
-const COMMAND_KEY_BINDING = KeyMod.WinCtrl | KeyCode.Slash | KeyMod.Alt;
-
-/**
- * Action ID for the `Run Current Prompt` action.
- */
-const RUN_CURRENT_PROMPT_ACTION_ID = 'workbench.action.chat.run.prompt.current';
 
 /**
  * The default `Run Current Prompt` action.

--- a/src/vs/workbench/contrib/chat/browser/actions/reusablePromptActions/chatRunPromptAction.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/reusablePromptActions/chatRunPromptAction.ts
@@ -11,8 +11,9 @@ import { ChatContextKeys } from '../../../common/chatContextKeys.js';
 import { assertDefined } from '../../../../../../base/common/types.js';
 import { ILocalizedString, localize2 } from '../../../../../../nls.js';
 import { ThemeIcon } from '../../../../../../base/common/themables.js';
-import { TEXT_FILE_EDITOR_ID } from '../../../../files/common/files.js';
+import { ResourceContextKey } from '../../../../../common/contextkeys.js';
 import { KeyCode, KeyMod } from '../../../../../../base/common/keyCodes.js';
+import { PROMPT_LANGUAGE_ID } from '../../../common/promptSyntax/constants.js';
 import { attachPrompt } from './dialogs/askToSelectPrompt/utils/attachPrompt.js';
 import { detachPrompt } from './dialogs/askToSelectPrompt/utils/detachPrompt.js';
 import { PromptsConfig } from '../../../../../../platform/prompts/common/config.js';
@@ -23,7 +24,6 @@ import { EditorContextKeys } from '../../../../../../editor/common/editorContext
 import { ICommandService } from '../../../../../../platform/commands/common/commands.js';
 import { getActivePromptUri } from '../../promptSyntax/contributions/usePromptCommand.js';
 import { ContextKeyExpr } from '../../../../../../platform/contextkey/common/contextkey.js';
-import { ActiveEditorContext, ResourceContextKey } from '../../../../../common/contextkeys.js';
 import { KeybindingWeight } from '../../../../../../platform/keybinding/common/keybindingsRegistry.js';
 import { Action2, MenuId, registerAction2 } from '../../../../../../platform/actions/common/actions.js';
 
@@ -133,11 +133,7 @@ abstract class RunPromptBaseAction extends Action2 {
 const EDITOR_ACTIONS_CONDITION = ContextKeyExpr.and(
 	ContextKeyExpr.and(PromptsConfig.enabledCtx, ChatContextKeys.enabled),
 	ResourceContextKey.HasResource,
-	ContextKeyExpr.regex(
-		ResourceContextKey.Filename.key,
-		/\.prompt\.md|copilot-instructions\.md$/,
-	),
-	ActiveEditorContext.isEqualTo(TEXT_FILE_EDITOR_ID),
+	ResourceContextKey.LangId.isEqualTo(PROMPT_LANGUAGE_ID),
 );
 
 /**

--- a/src/vs/workbench/contrib/chat/browser/chatAttachmentModel/chatPromptAttachmentsCollection.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatAttachmentModel/chatPromptAttachmentsCollection.ts
@@ -29,7 +29,7 @@ export const toChatVariable = (
 	reference: Pick<IPromptFileReference, 'uri' | 'isPromptFile'>,
 	isRoot: boolean,
 ): IChatRequestVariableEntry => {
-	const { uri, isPromptFile: isPromptFile } = reference;
+	const { uri, isPromptFile } = reference;
 
 	// default `id` is the stringified `URI`
 	let id = `${uri}`;
@@ -93,7 +93,7 @@ export class ChatPromptAttachmentsCollection extends Disposable {
 			const { reference } = attachment;
 
 			// the usual URIs list of prompt instructions is `bottom-up`, therefore
-			// we do the same herfe - first add all child references of the model
+			// we do the same here - first add all child references of the model
 			result.push(
 				...reference.allValidReferences.map((link) => {
 					return toChatVariable(link, false);
@@ -102,7 +102,13 @@ export class ChatPromptAttachmentsCollection extends Disposable {
 
 			// then add the root reference of the model itself
 			result.push(
-				toChatVariable(reference, true),
+				toChatVariable({
+					uri: reference.uri,
+					// the attached file must have been a prompt file therefore
+					// we force that assumption here; this makes sure that prompts
+					// in untitled documents can be also attached to the chat input
+					isPromptFile: true,
+				}, true),
 			);
 		}
 

--- a/src/vs/workbench/contrib/chat/browser/promptSyntax/contributions/usePromptCommand.ts
+++ b/src/vs/workbench/contrib/chat/browser/promptSyntax/contributions/usePromptCommand.ts
@@ -9,6 +9,7 @@ import { CHAT_CATEGORY } from '../../actions/chatActions.js';
 import { IChatWidget, IChatWidgetService } from '../../chat.js';
 import { ChatContextKeys } from '../../../common/chatContextKeys.js';
 import { KeyMod, KeyCode } from '../../../../../../base/common/keyCodes.js';
+import { PROMPT_LANGUAGE_ID } from '../../../common/promptSyntax/constants.js';
 import { PromptsConfig } from '../../../../../../platform/prompts/common/config.js';
 import { isPromptFile } from '../../../../../../platform/prompts/common/constants.js';
 import { runAttachPromptAction } from '../../actions/reusablePromptActions/index.js';
@@ -114,9 +115,13 @@ export const getActivePromptUri = (
 		return undefined;
 	}
 
-	const { uri } = activeEditor.getModel();
-	if (isPromptFile(uri)) {
-		return uri;
+	const model = activeEditor.getModel();
+	if (model.getLanguageId() === PROMPT_LANGUAGE_ID) {
+		return model.uri;
+	}
+
+	if (isPromptFile(model.uri)) {
+		return model.uri;
 	}
 
 	return undefined;


### PR DESCRIPTION
Enables `untitled` prompt documents to be "run" in chat through the editor's "play" action.

Part of https://github.com/microsoft/vscode-copilot/issues/15596