### PR TITLE
Fix access to element reference in gutterIndicatorView

### DIFF
--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/components/gutterIndicatorView.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/components/gutterIndicatorView.ts
@@ -83,6 +83,8 @@ export class InlineEditsGutterIndicator extends Disposable {
 
 		this._register(this._editorObs.editor.onMouseMove((e: IEditorMouseEvent) => {
 			const el = this._iconRef.element;
+			if (el === undefined) { return; }
+
 			const rect = el.getBoundingClientRect();
 			const rectangularArea = Rect.fromLeftTopWidthHeight(rect.left, rect.top, rect.width, rect.height);
 			const point = new Point(e.event.posx, e.event.posy);

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/components/gutterIndicatorView.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/components/gutterIndicatorView.ts
@@ -82,9 +82,10 @@ export class InlineEditsGutterIndicator extends Disposable {
 		}));
 
 		this._register(this._editorObs.editor.onMouseMove((e: IEditorMouseEvent) => {
-			const el = this._iconRef.element;
-			if (el === undefined) { return; }
+			const state = this._state.get();
+			if (state === undefined) { return; }
 
+			const el = this._iconRef.element;
 			const rect = el.getBoundingClientRect();
 			const rectangularArea = Rect.fromLeftTopWidthHeight(rect.left, rect.top, rect.width, rect.height);
 			const point = new Point(e.event.posx, e.event.posy);


### PR DESCRIPTION
```Copilot Generated Description:``` Ensure the element reference is checked before accessing it in the InlineEditsGutterIndicator class to prevent errors related to uninitialized references.

Fixes microsoft/vscode#245343