### PR TITLE
Tree-sitter: TypeScript expressions inside templated strings are colored as strings

### DIFF
--- a/extensions/vscode-colorize-tests/test/colorize-tree-sitter-results/test-issue5431_ts.json
+++ b/extensions/vscode-colorize-tests/test/colorize-tree-sitter-results/test-issue5431_ts.json
@@ -281,7 +281,7 @@
 	},
 	{
 		"c": "${",
-		"t": "string.template.ts punctuation.definition.template-expression.begin.ts",
+		"t": "string.template.ts meta.template.expression.ts punctuation.definition.template-expression.begin.ts",
 		"r": {
 			"dark_plus": "punctuation.definition.template-expression.begin: #569CD6",
 			"light_plus": "punctuation.definition.template-expression.begin: #0000FF",
@@ -295,12 +295,12 @@
 	},
 	{
 		"c": "startTime",
-		"t": "string.template.ts variable.ts",
+		"t": "string.template.ts meta.template.expression.ts variable.ts",
 		"r": {
 			"dark_plus": "variable: #9CDCFE",
 			"light_plus": "variable: #001080",
-			"dark_vs": "string: #CE9178",
-			"light_vs": "string: #A31515",
+			"dark_vs": "meta.template.expression: #D4D4D4",
+			"light_vs": "meta.template.expression: #000000",
 			"hc_black": "variable: #9CDCFE",
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
@@ -309,7 +309,7 @@
 	},
 	{
 		"c": "}",
-		"t": "string.template.ts punctuation.ts punctuation.definition.template-expression.end.ts",
+		"t": "string.template.ts meta.template.expression.ts punctuation.ts punctuation.definition.template-expression.end.ts",
 		"r": {
 			"dark_plus": "punctuation.definition.template-expression.end: #569CD6",
 			"light_plus": "punctuation.definition.template-expression.end: #0000FF",
@@ -337,7 +337,7 @@
 	},
 	{
 		"c": "${",
-		"t": "string.template.ts punctuation.definition.template-expression.begin.ts",
+		"t": "string.template.ts meta.template.expression.ts punctuation.definition.template-expression.begin.ts",
 		"r": {
 			"dark_plus": "punctuation.definition.template-expression.begin: #569CD6",
 			"light_plus": "punctuation.definition.template-expression.begin: #0000FF",
@@ -351,12 +351,12 @@
 	},
 	{
 		"c": "endTime",
-		"t": "string.template.ts variable.ts",
+		"t": "string.template.ts meta.template.expression.ts variable.ts",
 		"r": {
 			"dark_plus": "variable: #9CDCFE",
 			"light_plus": "variable: #001080",
-			"dark_vs": "string: #CE9178",
-			"light_vs": "string: #A31515",
+			"dark_vs": "meta.template.expression: #D4D4D4",
+			"light_vs": "meta.template.expression: #000000",
 			"hc_black": "variable: #9CDCFE",
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
@@ -365,7 +365,7 @@
 	},
 	{
 		"c": "}",
-		"t": "string.template.ts punctuation.ts punctuation.definition.template-expression.end.ts",
+		"t": "string.template.ts meta.template.expression.ts punctuation.ts punctuation.definition.template-expression.end.ts",
 		"r": {
 			"dark_plus": "punctuation.definition.template-expression.end: #569CD6",
 			"light_plus": "punctuation.definition.template-expression.end: #0000FF",

--- a/extensions/vscode-colorize-tests/test/colorize-tree-sitter-results/test-strings_ts.json
+++ b/extensions/vscode-colorize-tests/test/colorize-tree-sitter-results/test-strings_ts.json
@@ -71,7 +71,7 @@
 	},
 	{
 		"c": "${",
-		"t": "string.template.ts punctuation.definition.template-expression.begin.ts",
+		"t": "string.template.ts meta.template.expression.ts punctuation.definition.template-expression.begin.ts",
 		"r": {
 			"dark_plus": "punctuation.definition.template-expression.begin: #569CD6",
 			"light_plus": "punctuation.definition.template-expression.begin: #0000FF",
@@ -85,12 +85,12 @@
 	},
 	{
 		"c": "foo",
-		"t": "string.template.ts variable.ts",
+		"t": "string.template.ts meta.template.expression.ts variable.ts",
 		"r": {
 			"dark_plus": "variable: #9CDCFE",
 			"light_plus": "variable: #001080",
-			"dark_vs": "string: #CE9178",
-			"light_vs": "string: #A31515",
+			"dark_vs": "meta.template.expression: #D4D4D4",
+			"light_vs": "meta.template.expression: #000000",
 			"hc_black": "variable: #9CDCFE",
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
@@ -99,7 +99,7 @@
 	},
 	{
 		"c": "}",
-		"t": "string.template.ts punctuation.ts punctuation.definition.template-expression.end.ts",
+		"t": "string.template.ts meta.template.expression.ts punctuation.ts punctuation.definition.template-expression.end.ts",
 		"r": {
 			"dark_plus": "punctuation.definition.template-expression.end: #569CD6",
 			"light_plus": "punctuation.definition.template-expression.end: #0000FF",
@@ -351,7 +351,7 @@
 	},
 	{
 		"c": "${",
-		"t": "string.template.ts punctuation.definition.template-expression.begin.ts",
+		"t": "string.template.ts meta.template.expression.ts punctuation.definition.template-expression.begin.ts",
 		"r": {
 			"dark_plus": "punctuation.definition.template-expression.begin: #569CD6",
 			"light_plus": "punctuation.definition.template-expression.begin: #0000FF",
@@ -365,12 +365,12 @@
 	},
 	{
 		"c": "a",
-		"t": "string.template.ts variable.ts",
+		"t": "string.template.ts meta.template.expression.ts variable.ts",
 		"r": {
 			"dark_plus": "variable: #9CDCFE",
 			"light_plus": "variable: #001080",
-			"dark_vs": "string: #CE9178",
-			"light_vs": "string: #A31515",
+			"dark_vs": "meta.template.expression: #D4D4D4",
+			"light_vs": "meta.template.expression: #000000",
 			"hc_black": "variable: #9CDCFE",
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
@@ -379,7 +379,7 @@
 	},
 	{
 		"c": "+",
-		"t": "string.template.ts keyword.operator.arithmetic.ts",
+		"t": "string.template.ts meta.template.expression.ts keyword.operator.arithmetic.ts",
 		"r": {
 			"dark_plus": "keyword.operator: #D4D4D4",
 			"light_plus": "keyword.operator: #000000",
@@ -393,12 +393,12 @@
 	},
 	{
 		"c": "b",
-		"t": "string.template.ts variable.ts",
+		"t": "string.template.ts meta.template.expression.ts variable.ts",
 		"r": {
 			"dark_plus": "variable: #9CDCFE",
 			"light_plus": "variable: #001080",
-			"dark_vs": "string: #CE9178",
-			"light_vs": "string: #A31515",
+			"dark_vs": "meta.template.expression: #D4D4D4",
+			"light_vs": "meta.template.expression: #000000",
 			"hc_black": "variable: #9CDCFE",
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
@@ -407,7 +407,7 @@
 	},
 	{
 		"c": "}",
-		"t": "string.template.ts punctuation.ts punctuation.definition.template-expression.end.ts",
+		"t": "string.template.ts meta.template.expression.ts punctuation.ts punctuation.definition.template-expression.end.ts",
 		"r": {
 			"dark_plus": "punctuation.definition.template-expression.end: #569CD6",
 			"light_plus": "punctuation.definition.template-expression.end: #0000FF",
@@ -435,7 +435,7 @@
 	},
 	{
 		"c": "${",
-		"t": "string.template.ts punctuation.definition.template-expression.begin.ts",
+		"t": "string.template.ts meta.template.expression.ts punctuation.definition.template-expression.begin.ts",
 		"r": {
 			"dark_plus": "punctuation.definition.template-expression.begin: #569CD6",
 			"light_plus": "punctuation.definition.template-expression.begin: #0000FF",
@@ -449,12 +449,12 @@
 	},
 	{
 		"c": "a",
-		"t": "string.template.ts variable.ts",
+		"t": "string.template.ts meta.template.expression.ts variable.ts",
 		"r": {
 			"dark_plus": "variable: #9CDCFE",
 			"light_plus": "variable: #001080",
-			"dark_vs": "string: #CE9178",
-			"light_vs": "string: #A31515",
+			"dark_vs": "meta.template.expression: #D4D4D4",
+			"light_vs": "meta.template.expression: #000000",
 			"hc_black": "variable: #9CDCFE",
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
@@ -463,7 +463,7 @@
 	},
 	{
 		"c": "*",
-		"t": "string.template.ts keyword.operator.arithmetic.ts",
+		"t": "string.template.ts meta.template.expression.ts keyword.operator.arithmetic.ts",
 		"r": {
 			"dark_plus": "keyword.operator: #D4D4D4",
 			"light_plus": "keyword.operator: #000000",
@@ -477,12 +477,12 @@
 	},
 	{
 		"c": "b",
-		"t": "string.template.ts variable.ts",
+		"t": "string.template.ts meta.template.expression.ts variable.ts",
 		"r": {
 			"dark_plus": "variable: #9CDCFE",
 			"light_plus": "variable: #001080",
-			"dark_vs": "string: #CE9178",
-			"light_vs": "string: #A31515",
+			"dark_vs": "meta.template.expression: #D4D4D4",
+			"light_vs": "meta.template.expression: #000000",
 			"hc_black": "variable: #9CDCFE",
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
@@ -491,7 +491,7 @@
 	},
 	{
 		"c": "}",
-		"t": "string.template.ts punctuation.ts punctuation.definition.template-expression.end.ts",
+		"t": "string.template.ts meta.template.expression.ts punctuation.ts punctuation.definition.template-expression.end.ts",
 		"r": {
 			"dark_plus": "punctuation.definition.template-expression.end: #569CD6",
 			"light_plus": "punctuation.definition.template-expression.end: #0000FF",

--- a/src/vs/editor/common/languages/highlights/typescript.scm
+++ b/src/vs/editor/common/languages/highlights/typescript.scm
@@ -28,6 +28,8 @@
   (template_literal_type)
 ] @string.template.ts)
 
+(template_substitution) @meta.template.expression.ts
+
 (string .
   ([
     "\""


### PR DESCRIPTION
Fixes #246310