### PR TITLE
[prompts]: allow 'use prompt' command for all files/documents

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatAttachmentModel/chatPromptAttachmentModel.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatAttachmentModel/chatPromptAttachmentModel.ts
@@ -143,12 +143,16 @@ export class ChatPromptAttachmentModel extends Disposable {
 			return this.initService.createInstance(TextModelContentsProvider, model);
 		}
 
-		// use file contents provider for all other file documents
-		if (uri.scheme === 'file') {
-			return this._register(this.initService.createInstance(FilePromptContentProvider, uri));
-		}
-
-		throw new Error(`Cannot create prompt contents provider for URI scheme '${uri.scheme}'.`);
+		// use file contents provider for all other documents; in this case
+		// we know that the attached file must have been a prompt file,
+		// hence we pass the `allowNonPromptFiles` option to the provider
+		return this._register(
+			this.initService.createInstance(
+				FilePromptContentProvider,
+				uri,
+				{ allowNonPromptFiles: true },
+			),
+		);
 	}
 
 	/**

--- a/src/vs/workbench/contrib/chat/browser/contrib/chatDynamicVariables/chatFileReference.ts
+++ b/src/vs/workbench/contrib/chat/browser/contrib/chatDynamicVariables/chatFileReference.ts
@@ -34,7 +34,7 @@ export class ChatFileReference extends FilePromptParser implements IDynamicVaria
 			`Variable data must be an URI, got '${data}'.`,
 		);
 
-		super(data, [], initService, workspaceService, logService);
+		super(data, {}, initService, workspaceService, logService);
 	}
 
 	/**

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/contentProviders/filePromptContentsProvider.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/contentProviders/filePromptContentsProvider.ts
@@ -15,15 +15,45 @@ import { OpenFailed, NotPromptFile, ResolveError, FolderReference } from '../../
 import { FileChangesEvent, FileChangeType, IFileService } from '../../../../../../platform/files/common/files.js';
 
 /**
- * Prompt contents provider for a file on the disk referenced
- * by a provided {@link URI}.
+ * Options of the {@link FilePromptContentProvider} class.
+ */
+export interface IFileContentsProviderOptions {
+	/**
+	 * Whether to allow files that don't have usual prompt
+	 * file extension to be treated as a prompt file.
+	 */
+	allowNonPromptFiles: boolean;
+}
+
+/**
+ * Default options of the {@link FilePromptContentProvider} class.
+ */
+const DEFAULT_OPTIONS: IFileContentsProviderOptions = {
+	allowNonPromptFiles: false,
+};
+
+/**
+ * Prompt contents provider for a file on the disk referenced by
+ * a provided {@link URI}.
  */
 export class FilePromptContentProvider extends PromptContentsProviderBase<FileChangesEvent> implements IPromptContentsProvider {
+	/**
+	 * Options passed to the constructor, extended with
+	 * value defaults from {@link DEFAULT_OPTIONS}.
+	 */
+	private readonly options: IFileContentsProviderOptions;
+
 	constructor(
 		public readonly uri: URI,
+		options: Partial<IFileContentsProviderOptions> = {},
 		@IFileService private readonly fileService: IFileService,
 	) {
 		super();
+
+		this.options = {
+			...DEFAULT_OPTIONS,
+			...options,
+		};
 
 		// make sure the object is updated on file changes
 		this._register(
@@ -80,8 +110,11 @@ export class FilePromptContentProvider extends PromptContentsProviderBase<FileCh
 				new FolderReference(this.uri),
 			);
 
-			// if URI doesn't point to a prompt snippet file, don't try to resolve it
-			if (isPromptFile(this.uri) === false) {
+			const { allowNonPromptFiles } = this.options;
+
+			// if URI doesn't point to a prompt file, don't try to resolve it,
+			// unless the `allowNonPromptFiles` option is set to `true`
+			if ((allowNonPromptFiles !== true) && (isPromptFile(this.uri) === false)) {
 				throw new NotPromptFile(this.uri);
 			}
 
@@ -107,9 +140,11 @@ export class FilePromptContentProvider extends PromptContentsProviderBase<FileCh
 
 	public override createNew(
 		promptContentsSource: { uri: URI },
+		options: Partial<IFileContentsProviderOptions> = {},
 	): IPromptContentsProvider {
 		return new FilePromptContentProvider(
 			promptContentsSource.uri,
+			options,
 			this.fileService,
 		);
 	}

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/contentProviders/textModelContentsProvider.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/contentProviders/textModelContentsProvider.ts
@@ -131,6 +131,7 @@ export class TextModelContentsProvider extends PromptContentsProviderBase<IModel
 		return this.initService.createInstance(
 			FilePromptContentProvider,
 			promptContentsSource.uri,
+			{},
 		);
 	}
 

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/filePromptParser.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/filePromptParser.ts
@@ -6,9 +6,9 @@
 import { BasePromptParser } from './basePromptParser.js';
 import { URI } from '../../../../../../base/common/uri.js';
 import { ILogService } from '../../../../../../platform/log/common/log.js';
-import { FilePromptContentProvider } from '../contentProviders/filePromptContentsProvider.js';
 import { IWorkspaceContextService } from '../../../../../../platform/workspace/common/workspace.js';
 import { IInstantiationService } from '../../../../../../platform/instantiation/common/instantiation.js';
+import { FilePromptContentProvider, IFileContentsProviderOptions } from '../contentProviders/filePromptContentsProvider.js';
 
 /**
  * Class capable of parsing prompt syntax out of a provided file,
@@ -17,13 +17,13 @@ import { IInstantiationService } from '../../../../../../platform/instantiation/
 export class FilePromptParser extends BasePromptParser<FilePromptContentProvider> {
 	constructor(
 		uri: URI,
-		seenReferences: string[] = [],
+		options: Partial<IFileContentsProviderOptions> = {},
 		@IInstantiationService initService: IInstantiationService,
 		@IWorkspaceContextService workspaceService: IWorkspaceContextService,
 		@ILogService logService: ILogService,
 	) {
-		const contentsProvider = initService.createInstance(FilePromptContentProvider, uri);
-		super(contentsProvider, seenReferences, initService, workspaceService, logService);
+		const contentsProvider = initService.createInstance(FilePromptContentProvider, uri, options);
+		super(contentsProvider, [], initService, workspaceService, logService);
 
 		this._register(contentsProvider);
 	}

--- a/src/vs/workbench/contrib/chat/test/common/promptSyntax/contentProviders/filePromptContentsProvider.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/promptSyntax/contentProviders/filePromptContentsProvider.test.ts
@@ -9,7 +9,7 @@ import { VSBuffer } from '../../../../../../../base/common/buffer.js';
 import { Schemas } from '../../../../../../../base/common/network.js';
 import { randomInt } from '../../../../../../../base/common/numbers.js';
 import { assertDefined } from '../../../../../../../base/common/types.js';
-import { wait } from '../../../../../../../base/test/common/testUtils.js';
+import { randomBoolean, wait } from '../../../../../../../base/test/common/testUtils.js';
 import { ReadableStream } from '../../../../../../../base/common/stream.js';
 import { IFileService } from '../../../../../../../platform/files/common/files.js';
 import { FileService } from '../../../../../../../platform/files/common/fileService.js';
@@ -23,8 +23,9 @@ import { ConfigurationService } from '../../../../../../../platform/configuratio
 import { InMemoryFileSystemProvider } from '../../../../../../../platform/files/common/inMemoryFilesystemProvider.js';
 import { FilePromptContentProvider } from '../../../../common/promptSyntax/contentProviders/filePromptContentsProvider.js';
 import { TestInstantiationService } from '../../../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
+import { NotPromptFile } from '../../../../common/promptFileReferenceErrors.js';
 
-suite('FilePromptContentsProvider', function () {
+suite('FilePromptContentsProvider', () => {
 	const testDisposables = ensureNoDisposablesAreLeakedInTestSuite();
 
 	let instantiationService: TestInstantiationService;
@@ -48,7 +49,7 @@ suite('FilePromptContentsProvider', function () {
 		instantiationService.stub(IConfigurationService, nullConfigService);
 	});
 
-	test('provides contents of a file', async function () {
+	test('• provides contents of a file', async () => {
 		const fileService = instantiationService.get(IFileService);
 
 		const fileName = `file-${randomInt(10000)}.prompt.md`;
@@ -99,5 +100,145 @@ suite('FilePromptContentsProvider', function () {
 			receivedLine.equals(expectedLine),
 			`Expected to receive '${expectedLine}', got '${receivedLine}'.`,
 		);
+	});
+
+	suite('• options', () => {
+		suite('• allowNonPromptFiles', () => {
+			test('• true', async () => {
+				const fileService = instantiationService.get(IFileService);
+
+				const fileName = (randomBoolean() === true)
+					? `file-${randomInt(10_000)}.md`
+					: `file-${randomInt(10_000)}.txt`;
+
+				const fileUri = URI.file(`/${fileName}`);
+
+				if (await fileService.exists(fileUri)) {
+					await fileService.del(fileUri);
+				}
+				await fileService.writeFile(fileUri, VSBuffer.fromString('Hello, world!'));
+				await wait(5);
+
+				const contentsProvider = testDisposables.add(instantiationService.createInstance(
+					FilePromptContentProvider,
+					fileUri,
+					{ allowNonPromptFiles: true },
+				));
+
+				let streamOrError: ReadableStream<VSBuffer> | Error | undefined;
+				testDisposables.add(contentsProvider.onContentChanged((event) => {
+					streamOrError = event;
+				}));
+				contentsProvider.start();
+
+				await wait(25);
+
+				assertDefined(
+					streamOrError,
+					'The `streamOrError` must be defined.',
+				);
+
+				assert(
+					!(streamOrError instanceof Error),
+					`Provider must produce a byte stream, got '${streamOrError}'.`,
+				);
+
+				const stream = new LinesDecoder(streamOrError);
+
+				const receivedLines = await stream.consumeAll();
+				assert.strictEqual(
+					receivedLines.length,
+					1,
+					'Must read the correct number of lines from the provider.',
+				);
+
+				const expectedLine = new Line(1, 'Hello, world!');
+				const receivedLine = receivedLines[0];
+				assert(
+					receivedLine.equals(expectedLine),
+					`Expected to receive '${expectedLine}', got '${receivedLine}'.`,
+				);
+			});
+
+			test('• false', async () => {
+				const fileService = instantiationService.get(IFileService);
+
+				const fileName = (randomBoolean() === true)
+					? `file-${randomInt(10_000)}.md`
+					: `file-${randomInt(10_000)}.txt`;
+
+				const fileUri = URI.file(`/${fileName}`);
+
+				if (await fileService.exists(fileUri)) {
+					await fileService.del(fileUri);
+				}
+				await fileService.writeFile(fileUri, VSBuffer.fromString('Hello, world!'));
+				await wait(5);
+
+				const contentsProvider = testDisposables.add(instantiationService.createInstance(
+					FilePromptContentProvider,
+					fileUri,
+					{ allowNonPromptFiles: false },
+				));
+
+				let streamOrError: ReadableStream<VSBuffer> | Error | undefined;
+				testDisposables.add(contentsProvider.onContentChanged((event) => {
+					streamOrError = event;
+				}));
+				contentsProvider.start();
+
+				await wait(25);
+
+				assertDefined(
+					streamOrError,
+					'The `streamOrError` must be defined.',
+				);
+
+				assert(
+					streamOrError instanceof NotPromptFile,
+					`Provider must produce an 'NotPromptFile' error, got '${streamOrError}'.`,
+				);
+			});
+
+			test('• undefined', async () => {
+				const fileService = instantiationService.get(IFileService);
+
+				const fileName = (randomBoolean() === true)
+					? `file-${randomInt(10_000)}.md`
+					: `file-${randomInt(10_000)}.txt`;
+
+				const fileUri = URI.file(`/${fileName}`);
+
+				if (await fileService.exists(fileUri)) {
+					await fileService.del(fileUri);
+				}
+				await fileService.writeFile(fileUri, VSBuffer.fromString('Hello, world!'));
+				await wait(5);
+
+				const contentsProvider = testDisposables.add(instantiationService.createInstance(
+					FilePromptContentProvider,
+					fileUri,
+					{},
+				));
+
+				let streamOrError: ReadableStream<VSBuffer> | Error | undefined;
+				testDisposables.add(contentsProvider.onContentChanged((event) => {
+					streamOrError = event;
+				}));
+				contentsProvider.start();
+
+				await wait(25);
+
+				assertDefined(
+					streamOrError,
+					'The `streamOrError` must be defined.',
+				);
+
+				assert(
+					streamOrError instanceof NotPromptFile,
+					`Provider must produce an 'NotPromptFile' error, got '${streamOrError}'.`,
+				);
+			});
+		});
 	});
 });

--- a/src/vs/workbench/contrib/chat/test/common/promptSyntax/contentProviders/filePromptContentsProvider.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/promptSyntax/contentProviders/filePromptContentsProvider.test.ts
@@ -63,6 +63,7 @@ suite('FilePromptContentsProvider', function () {
 		const contentsProvider = testDisposables.add(instantiationService.createInstance(
 			FilePromptContentProvider,
 			fileUri,
+			{},
 		));
 
 		let streamOrError: ReadableStream<VSBuffer> | Error | undefined;

--- a/src/vs/workbench/contrib/chat/test/common/promptSyntax/promptFileReference.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/promptSyntax/promptFileReference.test.ts
@@ -90,7 +90,7 @@ class TestPromptFileReference extends Disposable {
 			this.initService.createInstance(
 				FilePromptParser,
 				this.rootFileUri,
-				[],
+				{},
 			),
 		).start();
 

--- a/src/vs/workbench/contrib/chat/test/common/promptSyntax/promptFileReference.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/promptSyntax/promptFileReference.test.ts
@@ -27,6 +27,7 @@ import { ConfigurationService } from '../../../../../../platform/configuration/c
 import { InMemoryFileSystemProvider } from '../../../../../../platform/files/common/inMemoryFilesystemProvider.js';
 import { TestInstantiationService } from '../../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
 import { NotPromptFile, RecursiveReference, OpenFailed, FolderReference } from '../../../common/promptFileReferenceErrors.js';
+import { IFileContentsProviderOptions } from '../../../common/promptSyntax/contentProviders/filePromptContentsProvider.js';
 
 /**
  * Represents a file reference with an expected
@@ -75,7 +76,9 @@ class TestPromptFileReference extends Disposable {
 	/**
 	 * Run the test.
 	 */
-	public async run() {
+	public async run(
+		options: Partial<IFileContentsProviderOptions> = {},
+	) {
 		// create the files structure on the disk
 		await (this.initService.createInstance(MockFilesystem, this.fileStructure)).mock();
 
@@ -90,7 +93,7 @@ class TestPromptFileReference extends Disposable {
 			this.initService.createInstance(
 				FilePromptParser,
 				this.rootFileUri,
-				{},
+				options,
 			),
 		).start();
 
@@ -481,5 +484,150 @@ suite('PromptFileReference (Unix)', function () {
 		));
 
 		await test.run();
+	});
+
+	suite('• options', () => {
+		test('• allowNonPromptFiles', async function () {
+			if (isWindows) {
+				this.skip();
+			}
+
+			const rootFolderName = 'resolves-nested-file-references';
+			const rootFolder = `/${rootFolderName}`;
+			const rootUri = URI.file(rootFolder);
+
+			const test = testDisposables.add(instantiationService.createInstance(TestPromptFileReference,
+				/**
+				 * The file structure to be created on the disk for the test.
+				 */
+				[{
+					name: rootFolderName,
+					children: [
+						{
+							name: 'file1.prompt.md',
+							contents: '## Some Header\nsome contents\n ',
+						},
+						{
+							name: 'file2.md',
+							contents: '## Files\n\t- this file #file:folder1/file3.prompt.md \n\t- also this [file4.prompt.md](./folder1/some-other-folder/file4.prompt.md) please!\n ',
+						},
+						{
+							name: 'folder1',
+							children: [
+								{
+									name: 'file3.prompt.md',
+									contents: `\n[](./some-other-folder/non-existing-folder)\n\t- some seemingly random #file:${rootFolder}/folder1/some-other-folder/yetAnotherFolder🤭/another-file.prompt.md contents\n some more\t content`,
+								},
+								{
+									name: 'some-other-folder',
+									children: [
+										{
+											name: 'file4.prompt.md',
+											contents: 'this file has a non-existing #file:./some-non-existing/file.prompt.md\t\treference\n\n\nand some\n non-prompt #file:./some-non-prompt-file.md\t\t \t[](../../folder1/)\t',
+										},
+										{
+											name: 'file.txt',
+											contents: 'contents of a non-prompt-snippet file',
+										},
+										{
+											name: 'yetAnotherFolder🤭',
+											children: [
+												{
+													name: 'another-file.prompt.md',
+													contents: `[](${rootFolder}/folder1/some-other-folder)\nanother-file.prompt.md contents\t [#file:file.txt](../file.txt)`,
+												},
+												{
+													name: 'one_more_file_just_in_case.prompt.md',
+													contents: 'one_more_file_just_in_case.prompt.md contents',
+												},
+											],
+										},
+									],
+								},
+							],
+						},
+					],
+				}],
+				/**
+				 * The root file path to start the resolve process from.
+				 */
+				URI.file(`/${rootFolderName}/file2.md`),
+				/**
+				 * The expected references to be resolved.
+				 */
+				[
+					new ExpectedReference(
+						rootUri,
+						createTestFileReference('folder1/file3.prompt.md', 2, 14),
+					),
+					new ExpectedReference(
+						URI.joinPath(rootUri, './folder1'),
+						createTestFileReference(
+							`./some-other-folder/non-existing-folder`,
+							2,
+							1,
+						),
+						new OpenFailed(
+							URI.joinPath(rootUri, './folder1/some-other-folder/non-existing-folder'),
+							'Reference to non-existing file cannot be opened.',
+						),
+					),
+					new ExpectedReference(
+						URI.joinPath(rootUri, './folder1'),
+						createTestFileReference(
+							`/${rootFolderName}/folder1/some-other-folder/yetAnotherFolder🤭/another-file.prompt.md`,
+							3,
+							26,
+						),
+					),
+					new ExpectedReference(
+						URI.joinPath(rootUri, './folder1/some-other-folder'),
+						createTestFileReference('.', 1, 1),
+						new FolderReference(
+							URI.joinPath(rootUri, './folder1/some-other-folder'),
+							'This folder is not a prompt file!',
+						),
+					),
+					new ExpectedReference(
+						URI.joinPath(rootUri, './folder1/some-other-folder/yetAnotherFolder🤭'),
+						createTestFileReference('../file.txt', 2, 35),
+						new NotPromptFile(
+							URI.joinPath(rootUri, './folder1/some-other-folder/file.txt'),
+							'Ughh oh, that is not a prompt file!',
+						),
+					),
+					new ExpectedReference(
+						rootUri,
+						createTestFileReference('./folder1/some-other-folder/file4.prompt.md', 3, 14),
+					),
+					new ExpectedReference(
+						URI.joinPath(rootUri, './folder1/some-other-folder'),
+						createTestFileReference('./some-non-existing/file.prompt.md', 1, 30),
+						new OpenFailed(
+							URI.joinPath(rootUri, './folder1/some-other-folder/some-non-existing/file.prompt.md'),
+							'Failed to open non-existring prompt snippets file',
+						),
+					),
+					new ExpectedReference(
+						URI.joinPath(rootUri, './folder1/some-other-folder'),
+						createTestFileReference('./some-non-prompt-file.md', 5, 13),
+						new OpenFailed(
+							URI.joinPath(rootUri, './folder1/some-other-folder/some-non-prompt-file.md'),
+							'Oh no!',
+						),
+					),
+					new ExpectedReference(
+						URI.joinPath(rootUri, './some-other-folder/folder1'),
+						createTestFileReference('../../folder1', 5, 48),
+						new FolderReference(
+							URI.joinPath(rootUri, './folder1'),
+							'Uggh ohh!',
+						),
+					),
+				]
+			));
+
+			await test.run({ allowNonPromptFiles: true });
+		});
 	});
 });


### PR DESCRIPTION
Allows the `> User Prompt` command to be used with any files, including untitled documents.

Part of https://github.com/microsoft/vscode-copilot/issues/15596