### PR TITLE
[prompts]: handle prompts attached as "current file" as actual prompts

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/attachments/implicitContextAttachment.ts
+++ b/src/vs/workbench/contrib/chat/browser/attachments/implicitContextAttachment.ts
@@ -10,6 +10,7 @@ import { getDefaultHoverDelegate } from '../../../../../base/browser/ui/hover/ho
 import { Codicon } from '../../../../../base/common/codicons.js';
 import { Disposable, DisposableStore } from '../../../../../base/common/lifecycle.js';
 import { basename, dirname } from '../../../../../base/common/resources.js';
+import { ThemeIcon } from '../../../../../base/common/themables.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { ILanguageService } from '../../../../../editor/common/languages/language.js';
 import { IModelService } from '../../../../../editor/common/services/model.js';
@@ -52,6 +53,10 @@ export class ImplicitContextAttachmentWidget extends Disposable {
 		dom.clearNode(this.domNode);
 		this.renderDisposables.clear();
 
+		const attachmentTypeName = (this.attachment.isPrompt === false)
+			? localize('file.lowercase', "file")
+			: localize('prompt.lowercase', "prompt");
+
 		this.domNode.classList.toggle('disabled', !this.attachment.enabled);
 		const label = this.resourceLabels.create(this.domNode, { supportIcons: true });
 		const file = URI.isUri(this.attachment.value) ? this.attachment.value : this.attachment.value!.uri;
@@ -60,25 +65,33 @@ export class ImplicitContextAttachmentWidget extends Disposable {
 		const fileBasename = basename(file);
 		const fileDirname = dirname(file);
 		const friendlyName = `${fileBasename} ${fileDirname}`;
-		const ariaLabel = range ? localize('chat.fileAttachmentWithRange', "Attached file, {0}, line {1} to line {2}", friendlyName, range.startLineNumber, range.endLineNumber) : localize('chat.fileAttachment', "Attached file, {0}", friendlyName);
+		const ariaLabel = range ? localize('chat.fileAttachmentWithRange', "Attached {0}, {1}, line {2} to line {3}", attachmentTypeName, friendlyName, range.startLineNumber, range.endLineNumber) : localize('chat.fileAttachment', "Attached {0}, {1}", attachmentTypeName, friendlyName);
 
 		const uriLabel = this.labelService.getUriLabel(file, { relative: true });
-		const currentFile = localize('openEditor', "Current file context");
+		const currentFile = localize('openEditor', "Current {0} context", attachmentTypeName);
 		const inactive = localize('enableHint', "disabled");
 		const currentFileHint = currentFile + (this.attachment.enabled ? '' : ` (${inactive})`);
 		const title = `${currentFileHint}\n${uriLabel}`;
+
+		const icon = (this.attachment.isPrompt)
+			? ThemeIcon.fromId(Codicon.bookmark.id)
+			: undefined;
+
 		label.setFile(file, {
 			fileKind: FileKind.FILE,
 			hidePath: true,
 			range,
-			title
+			title,
+			icon,
 		});
 		this.domNode.ariaLabel = ariaLabel;
 		this.domNode.tabIndex = 0;
-		const hintElement = dom.append(this.domNode, dom.$('span.chat-implicit-hint', undefined, 'Current file'));
+
+		const hintLabel = localize('hint.label.current', "Current {0}", attachmentTypeName);
+		const hintElement = dom.append(this.domNode, dom.$('span.chat-implicit-hint', undefined, hintLabel));
 		this._register(this.hoverService.setupManagedHover(getDefaultHoverDelegate('element'), hintElement, title));
 
-		const buttonMsg = this.attachment.enabled ? localize('disable', "Disable current file context") : localize('enable', "Enable current file context");
+		const buttonMsg = this.attachment.enabled ? localize('disable', "Disable current {0} context", attachmentTypeName) : localize('enable', "Enable current {0} context", attachmentTypeName);
 		const toggleButton = this.renderDisposables.add(new Button(this.domNode, { supportIcons: true, title: buttonMsg }));
 		toggleButton.icon = this.attachment.enabled ? Codicon.eye : Codicon.eyeClosed;
 		this.renderDisposables.add(toggleButton.onDidClick((e) => {

--- a/src/vs/workbench/contrib/chat/browser/chatAttachmentModel/chatPromptAttachmentsCollection.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatAttachmentModel/chatPromptAttachmentsCollection.ts
@@ -64,11 +64,20 @@ export const toChatVariable = (
 		id = createPromptVariableId(uri, isRoot);
 	}
 
+	const name = (isPromptFile)
+		? `prompt:${basename(uri)}`
+		: `file:${basename(uri)}`;
+
+	const modelDescription = (isPromptFile)
+		? 'Prompt instructions file that user expects you to follow'
+		: undefined;
+
 	return {
 		id,
-		name: `file:${basename(uri)}`,
+		name,
 		value: uri,
 		kind: 'file',
+		modelDescription,
 	};
 };
 

--- a/src/vs/workbench/contrib/chat/browser/chatAttachmentModel/chatPromptAttachmentsCollection.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatAttachmentModel/chatPromptAttachmentsCollection.ts
@@ -69,7 +69,7 @@ export const toChatVariable = (
 		: `file:${basename(uri)}`;
 
 	const modelDescription = (isPromptFile)
-		? 'Prompt instructions file that user expects you to follow'
+		? 'Prompt instructions file'
 		: undefined;
 
 	return {

--- a/src/vs/workbench/contrib/chat/browser/contrib/chatImplicitContext.ts
+++ b/src/vs/workbench/contrib/chat/browser/contrib/chatImplicitContext.ts
@@ -244,11 +244,11 @@ export class ChatImplicitContext extends Disposable implements IChatRequestImpli
 				'Implicit prompt attachments must have a value.',
 			);
 
-			if (URI.isUri(this.value)) {
-				return createPromptVariableId(this.value, true);
-			}
+			const uri = URI.isUri(this.value)
+				? this.value
+				: this.value.uri;
 
-			return createPromptVariableId(this.value.uri, true);
+			return createPromptVariableId(uri, true);
 		}
 
 		if (URI.isUri(this.value)) {
@@ -314,12 +314,8 @@ export class ChatImplicitContext extends Disposable implements IChatRequestImpli
 	}
 
 	private _languageId: string | undefined;
-	get languageId() {
-		return this._languageId;
-	}
-
 	get isPrompt() {
-		return (this.languageId === PROMPT_LANGUAGE_ID);
+		return (this._languageId === PROMPT_LANGUAGE_ID);
 	}
 
 	private _enabled = true;

--- a/src/vs/workbench/contrib/chat/browser/contrib/chatImplicitContext.ts
+++ b/src/vs/workbench/contrib/chat/browser/contrib/chatImplicitContext.ts
@@ -281,11 +281,11 @@ export class ChatImplicitContext extends Disposable implements IChatRequestImpli
 	get modelDescription(): string {
 		if (this.isPrompt) {
 			if (URI.isUri(this.value)) {
-				return `User's active prompt instructions file that user expects you to follow`;
+				return `User's active prompt instructions file`;
 			} else if (this._isSelection) {
-				return `User's active selection inside prompt instructions that user expects you to follow`;
+				return `User's active selection inside prompt instructions`;
 			} else {
-				return `User's current visible prompt instructions text that user expects you to follow`;
+				return `User's current visible prompt instructions text`;
 			}
 		}
 

--- a/src/vs/workbench/contrib/chat/browser/contrib/chatImplicitContext.ts
+++ b/src/vs/workbench/contrib/chat/browser/contrib/chatImplicitContext.ts
@@ -265,10 +265,12 @@ export class ChatImplicitContext extends Disposable implements IChatRequestImpli
 	}
 
 	get name(): string {
+		const fileType = this.isPrompt ? 'prompt' : 'file';
+
 		if (URI.isUri(this.value)) {
-			return `file:${basename(this.value)}`;
+			return `${fileType}:${basename(this.value)}`;
 		} else if (this.value) {
-			return `file:${basename(this.value.uri)}`;
+			return `${fileType}:${basename(this.value.uri)}`;
 		} else {
 			return 'implicit';
 		}
@@ -277,6 +279,16 @@ export class ChatImplicitContext extends Disposable implements IChatRequestImpli
 	readonly kind = 'implicit';
 
 	get modelDescription(): string {
+		if (this.isPrompt) {
+			if (URI.isUri(this.value)) {
+				return `User's active prompt instructions file that user expects you to follow`;
+			} else if (this._isSelection) {
+				return `User's active selection inside prompt instructions that user expects you to follow`;
+			} else {
+				return `User's current visible prompt instructions text that user expects you to follow`;
+			}
+		}
+
 		if (URI.isUri(this.value)) {
 			return `User's active file`;
 		} else if (this._isSelection) {

--- a/src/vs/workbench/contrib/chat/browser/contrib/chatImplicitContext.ts
+++ b/src/vs/workbench/contrib/chat/browser/contrib/chatImplicitContext.ts
@@ -56,7 +56,8 @@ export class ChatImplicitContextContribution extends Disposable implements IWork
 						Event.any(
 							codeEditor.onDidChangeModel,
 							codeEditor.onDidChangeCursorSelection,
-							codeEditor.onDidScrollChange),
+							codeEditor.onDidScrollChange,
+							codeEditor.onDidChangeModelLanguage),
 						() => undefined,
 						500)(() => this.updateImplicitContext()));
 				}
@@ -223,7 +224,6 @@ export class ChatImplicitContextContribution extends Disposable implements IWork
 			if (setting === 'first' && !isFirstInteraction) {
 				widget.input.implicitContext.setValue(undefined, false, languageId);
 			} else if (setting === 'always' || setting === 'first' && isFirstInteraction) {
-				// TODO: @legomushroom - set language id if model language changes
 				widget.input.implicitContext.setValue(newValue, isSelection, languageId);
 			} else if (setting === 'never') {
 				widget.input.implicitContext.setValue(undefined, false, languageId);

--- a/src/vs/workbench/contrib/chat/common/chatModel.ts
+++ b/src/vs/workbench/contrib/chat/common/chatModel.ts
@@ -76,7 +76,6 @@ export interface IChatRequestImplicitVariableEntry extends IBaseChatRequestVaria
 	readonly isFile: true;
 	readonly value: URI | Location | undefined;
 	readonly isSelection: boolean;
-	readonly languageId: string | undefined;
 	readonly isPrompt: boolean;
 	enabled: boolean;
 }

--- a/src/vs/workbench/contrib/chat/common/chatModel.ts
+++ b/src/vs/workbench/contrib/chat/common/chatModel.ts
@@ -76,6 +76,8 @@ export interface IChatRequestImplicitVariableEntry extends IBaseChatRequestVaria
 	readonly isFile: true;
 	readonly value: URI | Location | undefined;
 	readonly isSelection: boolean;
+	readonly languageId: string | undefined;
+	readonly isPrompt: boolean;
 	enabled: boolean;
 }
 


### PR DESCRIPTION
<img width="1393" alt="image" src="https://github.com/user-attachments/assets/bea171a0-89a0-4ae0-9f37-a0e38b4f86f4" />

Makes implicit context of prompt files be treated as a prompt attachment:

- renders attachment as a prompt file
- uses correct chat variable IDs and other attributes for the prompts

Part of https://github.com/microsoft/vscode-copilot/issues/15596