### PR TITLE
Fix test items sorting in Testing Explorer to use natural file order

### DIFF
--- a/src/vs/workbench/contrib/testing/browser/testingExplorerView.ts
+++ b/src/vs/workbench/contrib/testing/browser/testingExplorerView.ts
@@ -19,6 +19,7 @@ import { mapFindFirst } from '../../../../base/common/arraysFind.js';
 import { RunOnceScheduler, disposableTimeout } from '../../../../base/common/async.js';
 import { groupBy } from '../../../../base/common/collections.js';
 import { Color, RGBA } from '../../../../base/common/color.js';
+import { compareFileNames } from '../../../../base/common/comparers.js';
 import { Emitter, Event } from '../../../../base/common/event.js';
 import { FuzzyScore } from '../../../../base/common/filters.js';
 import { Iterable } from '../../../../base/common/iterator.js';
@@ -1351,7 +1352,9 @@ class TreeSorter implements ITreeSorter<TestExplorerTreeElement> {
 		const sb = b.test.item.sortText;
 		// If tests are in the same location and there's no preferred sortText,
 		// keep the extension's insertion order (#163449).
-		return inSameLocation && !sa && !sb ? 0 : (sa || a.test.item.label).localeCompare(sb || b.test.item.label);
+		return inSameLocation && !sa && !sb
+			? 0
+			: compareFileNames(sa || a.test.item.label, sb || b.test.item.label);
 	}
 }
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

**Addresses #245624**

This PR improves test item sorting in Testing Explorer by replacing naive string comparison with compareFileNames() from vs/base/common/comparers.ts. This change ensures that files like test_1.py, test_2.py, test_10.py are sorted numerically instead of lexically. This fix also maintains the behavior of #173350, which fixes the behavior of #163449.

**Reproduction steps before fix:**

1. Create files test_1.py, test_2.py, test_10.py
2. Observe Test Explorer sorts them lexically: test_1.py, test_10.py, test_2.py

**Reproduction steps after fix:**

1. Create files as previous
2. Observe Test Explorer sorts them naturally, consistent with File Explorer

**Location of change**: vs/workbench/contrib/testing/browser/testingExplorerView.ts



