### PR TITLE
[prompts]: handle language id changes inside language feature providers

### DIFF
--- a/src/vs/workbench/contrib/chat/common/promptSyntax/languageFeatures/providers/promptLinkDiagnosticsProvider.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/languageFeatures/providers/promptLinkDiagnosticsProvider.ts
@@ -8,8 +8,9 @@ import { IPromptFileReference } from '../../parsers/types.js';
 import { ProviderInstanceBase } from './providerInstanceBase.js';
 import { assert } from '../../../../../../../base/common/assert.js';
 import { NotPromptFile } from '../../../promptFileReferenceErrors.js';
+import { ITextModel } from '../../../../../../../editor/common/model.js';
 import { assertDefined } from '../../../../../../../base/common/types.js';
-import { IPromptFileEditor, ProviderInstanceManagerBase } from './providerInstanceManagerBase.js';
+import { ProviderInstanceManagerBase } from './providerInstanceManagerBase.js';
 import { IMarkerData, IMarkerService, MarkerSeverity } from '../../../../../../../platform/markers/common/markers.js';
 
 /**
@@ -22,11 +23,11 @@ const MARKERS_OWNER_ID = 'reusable-prompts-syntax';
  */
 class PromptLinkDiagnosticsProvider extends ProviderInstanceBase {
 	constructor(
-		editor: IPromptFileEditor,
+		model: ITextModel,
 		@IPromptsService promptsService: IPromptsService,
 		@IMarkerService private readonly markerService: IMarkerService,
 	) {
-		super(editor, promptsService);
+		super(model, promptsService);
 	}
 
 	/**

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/languageFeatures/providers/providerInstanceBase.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/languageFeatures/providers/providerInstanceBase.ts
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { IPromptsService } from '../../service/types.js';
-import { IPromptFileEditor } from './providerInstanceManagerBase.js';
 import { ITextModel } from '../../../../../../../editor/common/model.js';
 import { TextModelPromptParser } from '../../parsers/textModelPromptParser.js';
 import { ObservableDisposable } from '../../../../../../../base/common/observableDisposable.js';
@@ -29,24 +28,17 @@ export abstract class ProviderInstanceBase extends ObservableDisposable {
 	protected readonly parser: TextModelPromptParser;
 
 	constructor(
-		protected readonly editor: IPromptFileEditor,
+		protected readonly model: ITextModel,
 		@IPromptsService promptsService: IPromptsService,
 	) {
 		super();
 
-		this.parser = promptsService.getSyntaxParserFor(this.model);
+		this.parser = promptsService.getSyntaxParserFor(model);
 		this.parser.onUpdate(this.onPromptParserUpdate.bind(this));
 		this.parser.onDispose(this.dispose.bind(this));
 		this.parser.start();
 
 		// initialize an update
 		this.onPromptParserUpdate();
-	}
-
-	/**
-	 * Underlying text model of the editor.
-	 */
-	protected get model(): ITextModel {
-		return this.editor.getModel();
 	}
 }

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/languageFeatures/providers/providerInstanceManagerBase.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/languageFeatures/providers/providerInstanceManagerBase.ts
@@ -30,12 +30,12 @@ export abstract class ProviderInstanceManagerBase<TInstance extends ProviderInst
 	/**
 	 * Currently available {@link TInstance} instances.
 	 */
-	private readonly instances: ObjectCache<TInstance, IPromptFileEditor>;
+	private readonly instances: ObjectCache<TInstance, ITextModel>;
 
 	/**
 	 * Class object of the managed {@link TInstance}.
 	 */
-	protected abstract get InstanceClass(): new (editor: IPromptFileEditor, ...args: any[]) => TInstance;
+	protected abstract get InstanceClass(): new (editor: ITextModel, ...args: any[]) => TInstance;
 
 	constructor(
 		@IEditorService editorService: IEditorService,
@@ -46,7 +46,7 @@ export abstract class ProviderInstanceManagerBase<TInstance extends ProviderInst
 
 		// cache of managed instances
 		this.instances = this._register(
-			new ObjectCache((editor: IPromptFileEditor) => {
+			new ObjectCache((model: ITextModel) => {
 				// sanity check - the new TS/JS discrepancies regarding fields initialization
 				// logic mean that this can be `undefined` during runtime while defined in TS
 				assertDefined(
@@ -56,7 +56,7 @@ export abstract class ProviderInstanceManagerBase<TInstance extends ProviderInst
 
 				const instance: TInstance = initService.createInstance(
 					this.InstanceClass,
-					editor,
+					model,
 				);
 
 				// this is a sanity check and the contract of the object cache,
@@ -100,7 +100,7 @@ export abstract class ProviderInstanceManagerBase<TInstance extends ProviderInst
 
 		// note! calling `get` also creates a provider if it does not exist;
 		// 		and the provider is auto-removed when the editor is disposed
-		this.instances.get(editor);
+		this.instances.get(editor.getModel());
 
 		return this;
 	}
@@ -130,12 +130,6 @@ const isPromptFileEditor = (
 	if (model.getLanguageId() !== PROMPT_LANGUAGE_ID) {
 		return false;
 	}
-
-	// override the `getModel()` method to align with the `IPromptFileEditor` interface
-	// which guarantees that the `getModel()` always returns a non-null model
-	editor.getModel = () => {
-		return model;
-	};
 
 	return true;
 };


### PR DESCRIPTION
Adds logic to handle language id changes inside language feature providers for prompt documents.

Part of https://github.com/microsoft/vscode-copilot/issues/15596