### PR TITLE
[prompts]: enable chat submit button if prompts attached as an implicit (current file) context and other improvements

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/actions/reusablePromptActions/chatRunPromptAction.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/reusablePromptActions/chatRunPromptAction.ts
@@ -131,6 +131,7 @@ abstract class RunPromptBaseAction extends Action2 {
 			resource,
 			{
 				inNewChat,
+				skipIfImplicitlyAttached: true,
 				commandService,
 				viewsService,
 			},


### PR DESCRIPTION
- ensures that prompt files from implicit attachment context can be run through the `> Run Prompt` command
- removes duplicate attachments when a prompt is "run" from the editor and is attached as an implicit context at the same time
- enables submit button in the chat if there is an implicit prompt file attachment and no text in the chat input to be consistent with current "explicit" prompt attachment behaviour

Part of https://github.com/microsoft/vscode-copilot/issues/15596