### PR TITLE
chat - detect enterprise auth accordingly

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatSetup.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSetup.ts
@@ -427,7 +427,7 @@ class ChatSetup {
 			setupStrategy = await this.showDialog();
 		}
 
-		if (setupStrategy === ChatSetupStrategy.DefaultSetup && this.controller.value.hasProviderConfigured()) {
+		if (setupStrategy === ChatSetupStrategy.DefaultSetup && this.controller.value.hasEnterpriseProviderConfigured()) {
 			setupStrategy = ChatSetupStrategy.SetupWithEnterpriseProvider; // users with a configured provider go through provider setup
 		}
 
@@ -1015,9 +1015,9 @@ class ChatSetupController extends Disposable {
 		}
 	}
 
-	hasProviderConfigured(): boolean {
-		const setting = this.configurationService.getValue<{ authProvider: string | undefined }>(defaultChat.completionsAdvancedSetting);
-		return typeof setting.authProvider === 'string';
+	hasEnterpriseProviderConfigured(): boolean {
+		const setting = this.configurationService.getValue<{ authProvider: unknown }>(defaultChat.completionsAdvancedSetting);
+		return setting.authProvider === defaultChat.enterpriseProviderId;
 	}
 
 	async setupWithProvider(options: { useEnterpriseProvider: boolean }): Promise<boolean> {


### PR DESCRIPTION
The primary "Sign-in" button neither touches the `github.copilot.advanced.authProvider` setting, nor the `github-enterprise.uri` setting, it simply signs in. However, it is possible that a user has configured `github.copilot.advanced.authProvider` as `github-enterprise` without configuring the `github-enterprise.uri` setting. In this case we want to show the picker to the user to ask for the enterprise URI.

@TylerLeonhardt let me know if we still need custom handling for when `github.copilot.advanced.authProvider` is set to `github`? We could treat that as a sign to use the "GitHub" login flow, where from the setup we actually remove both the `github.copilot.advanced.authProvider` setting as well as any possible `github-enterprise.uri` setting.