### PR TITLE
Remove zIndex from inline edit views

### DIFF
--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/components/gutterIndicatorView.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/components/gutterIndicatorView.ts
@@ -438,7 +438,7 @@ export class InlineEditsGutterIndicator extends Disposable {
 			},
 			style: {
 				cursor: 'pointer',
-				zIndex: '1000',
+				zIndex: '20',
 				position: 'absolute',
 				backgroundColor: this._gutterIndicatorStyles.map(v => v.background),
 				['--vscodeIconForeground' as any]: this._gutterIndicatorStyles.map(v => v.foreground),

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/inlineEditsCollapsedView.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/inlineEditsCollapsedView.ts
@@ -57,7 +57,6 @@ export class InlineEditsCollapsedView extends Disposable implements IInlineEdits
 				overflow: 'visible',
 				top: '0px',
 				left: '0px',
-				zIndex: '0',
 				display: 'block',
 			},
 		}, [

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/inlineEditsCustomView.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/inlineEditsCustomView.ts
@@ -86,7 +86,6 @@ export class InlineEditsCustomView extends Disposable implements IInlineEditsVie
 				overflow: 'visible',
 				top: '0px',
 				left: '0px',
-				zIndex: '0',
 				display: 'block',
 			},
 		}, [view]).keepUpdated(this._store).element;

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/inlineEditsDeletionView.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/inlineEditsDeletionView.ts
@@ -198,7 +198,6 @@ export class InlineEditsDeletionView extends Disposable implements IInlineEditsV
 			overflow: 'visible',
 			top: '0px',
 			left: '0px',
-			zIndex: '0',
 			display: this._display,
 		},
 	}, [

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/inlineEditsInsertionView.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/inlineEditsInsertionView.ts
@@ -302,7 +302,6 @@ export class InlineEditsInsertionView extends Disposable implements IInlineEdits
 			overflow: 'visible',
 			top: '0px',
 			left: '0px',
-			zIndex: '0',
 			display: this._display,
 		},
 	}, [

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/inlineEditsSideBySideView.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/inlineEditsSideBySideView.ts
@@ -581,7 +581,6 @@ export class InlineEditsSideBySideView extends Disposable implements IInlineEdit
 			overflow: 'visible',
 			top: '0px',
 			left: '0px',
-			zIndex: '0',
 			display: this._display,
 		},
 	}, [


### PR DESCRIPTION
```Copilot Generated Description:``` Eliminate the zIndex property from multiple inline edit view classes to prevent the NES gutter indicator from rendering over overflow editor widgets.

Fixes microsoft/vscode-copilot#15155