### PR TITLE
make tmp dir for zsh if it doesn't exist

### DIFF
--- a/src/vs/platform/terminal/common/terminal.ts
+++ b/src/vs/platform/terminal/common/terminal.ts
@@ -1009,6 +1009,11 @@ export const enum ShellIntegrationInjectionFailureReason {
 	 * won't have shell integration in the end.
 	 */
 	UnsupportedShell = 'unsupportedShell',
+
+	/**
+	 * For zsh, we failed to create a temp directory for the shell integration script.
+	 */
+	FailedToCreateTmpDir = 'failedToCreateTmpDir',
 }
 
 export enum TerminalExitReason {

--- a/src/vs/platform/terminal/common/terminal.ts
+++ b/src/vs/platform/terminal/common/terminal.ts
@@ -1010,6 +1010,12 @@ export const enum ShellIntegrationInjectionFailureReason {
 	 */
 	UnsupportedShell = 'unsupportedShell',
 
+
+	/**
+	 * For zsh, we failed to set the sticky bit on the shell integration script folder.
+	 */
+	FailedToSetStickyBit = 'failedToSetStickyBit',
+
 	/**
 	 * For zsh, we failed to create a temp directory for the shell integration script.
 	 */

--- a/src/vs/platform/terminal/node/terminalEnvironment.ts
+++ b/src/vs/platform/terminal/node/terminalEnvironment.ts
@@ -15,7 +15,7 @@ import { IShellLaunchConfig, ITerminalEnvironment, ITerminalProcessOptions, Shel
 import { EnvironmentVariableMutatorType } from '../common/environmentVariable.js';
 import { deserializeEnvironmentVariableCollections } from '../common/environmentVariableShared.js';
 import { MergedEnvironmentVariableCollection } from '../common/environmentVariableCollection.js';
-import { chmod, realpathSync, existsSync, mkdirSync } from 'fs';
+import { chmod, realpathSync, mkdirSync } from 'fs';
 import { promisify } from 'util';
 
 export function getWindowsBuildNumber(): number {

--- a/src/vs/platform/terminal/node/terminalEnvironment.ts
+++ b/src/vs/platform/terminal/node/terminalEnvironment.ts
@@ -242,7 +242,7 @@ export async function getShellIntegrationInjection(
 				// Ensure the ZDOTDIR exists
 				if (!existsSync(zdotdir)) {
 					try {
-						mkdirSync(zdotdir, { recursive: true });
+						mkdirSync(zdotdir);
 					} catch (err) {
 						logService.error(`Failed to create zdotdir at ${zdotdir}: ${err}`);
 						return { type: 'failure', reason: ShellIntegrationInjectionFailureReason.FailedToCreateTmpDir };

--- a/src/vs/platform/terminal/node/terminalEnvironment.ts
+++ b/src/vs/platform/terminal/node/terminalEnvironment.ts
@@ -230,15 +230,6 @@ export async function getShellIntegrationInjection(
 			const realTmpDir = realpathSync(os.tmpdir());
 			const zdotdir = path.join(realTmpDir, `${username}-${productService.applicationName}-zsh`);
 
-			// Ensure the ZDOTDIR exists
-			if (!existsSync(zdotdir)) {
-				try {
-					mkdirSync(zdotdir, { recursive: true });
-				} catch (err) {
-					logService.error(`Failed to create zdotdir at ${zdotdir}: ${err}`);
-					return { type: 'failure', reason: ShellIntegrationInjectionFailureReason.FailedToCreateTmpDir };
-				}
-			}
 			// Set directory permissions using octal notation:
 			// - 0o1700:
 			// - Sticky bit is set, preventing non-owners from deleting or renaming files within this directory (1)
@@ -247,6 +238,16 @@ export async function getShellIntegrationInjection(
 			// - Others have no permissions (0)
 			if (!skipStickyBit) {
 				// skip for tests
+
+				// Ensure the ZDOTDIR exists
+				if (!existsSync(zdotdir)) {
+					try {
+						mkdirSync(zdotdir, { recursive: true });
+					} catch (err) {
+						logService.error(`Failed to create zdotdir at ${zdotdir}: ${err}`);
+						return { type: 'failure', reason: ShellIntegrationInjectionFailureReason.FailedToCreateTmpDir };
+					}
+				}
 				try {
 					const chmodAsync = promisify(chmod);
 					await chmodAsync(zdotdir, 0o1700);

--- a/src/vs/workbench/contrib/terminal/common/scripts/shellIntegration-rc.zsh
+++ b/src/vs/workbench/contrib/terminal/common/scripts/shellIntegration-rc.zsh
@@ -3,7 +3,7 @@
 #   Licensed under the MIT License. See License.txt in the project root for license information.
 # ---------------------------------------------------------------------------------------------
 builtin autoload -Uz add-zsh-hook is-at-least
-
+echo $ZDOTDIR
 # Prevent the script recursing when setting up
 if [ -n "$VSCODE_SHELL_INTEGRATION" ]; then
 	ZDOTDIR=$USER_ZDOTDIR

--- a/src/vs/workbench/contrib/terminal/common/scripts/shellIntegration-rc.zsh
+++ b/src/vs/workbench/contrib/terminal/common/scripts/shellIntegration-rc.zsh
@@ -3,7 +3,7 @@
 #   Licensed under the MIT License. See License.txt in the project root for license information.
 # ---------------------------------------------------------------------------------------------
 builtin autoload -Uz add-zsh-hook is-at-least
-echo $ZDOTDIR
+
 # Prevent the script recursing when setting up
 if [ -n "$VSCODE_SHELL_INTEGRATION" ]; then
 	ZDOTDIR=$USER_ZDOTDIR


### PR DESCRIPTION
We set the sticky bit on a temporary directory used to store our zsh shell integration script. In most cases, the temporary directory already exists. If this directory doesn't exist, setting the sticky bit fails and shell integration for zsh won’t be activated.

This PR addresses that case by creating the directory if it's missing, ensuring shell integration proceeds as expected.

Shell integration is required for terminal tool calls to function correctly. Since zsh is the default shell on macOS, we aim to ensure shell integration is as consistent and reliable as possible for zsh users.

fixes #246531

cc @tyriar
