### PR TITLE
extensionTipService does not find possible executables for nu, etc

### DIFF
--- a/src/vs/platform/extensionManagement/common/extensionTipsService.ts
+++ b/src/vs/platform/extensionManagement/common/extensionTipsService.ts
@@ -148,6 +148,10 @@ export abstract class AbstractNativeExtensionTipsService extends ExtensionTipsSe
 					this.allOtherExecutableTips.set(key, { exeFriendlyName: exeBasedExtensionTip.friendlyName, windowsPath: exeBasedExtensionTip.windowsPath, recommendations: otherRecommendations });
 				}
 			});
+			console.log('these recommendations(both highImportanceRecommendations and  mediumImportanceRecommendations) always seem to be empty: ');
+			console.log('Not getting these logs triggered, nor code breakpoints');
+			console.log('highImportanceRecommendations', this.highImportanceExecutableTips);
+			console.log('mediumImportanceRecommendations', this.mediumImportanceExecutableTips);
 		}
 
 		/*
@@ -351,6 +355,8 @@ export abstract class AbstractNativeExtensionTipsService extends ExtensionTipsSe
 	}
 
 	private async getValidExecutableBasedExtensionTips(executableTips: Map<string, IExeBasedExtensionTips>): Promise<IExecutableBasedExtensionTip[]> {
+		console.log('getValidExecutableBasedExtensionTips', executableTips); // Always 0.
+
 		const result: IExecutableBasedExtensionTip[] = [];
 
 		const checkedExecutables: Map<string, boolean> = new Map<string, boolean>();
@@ -368,11 +374,17 @@ export abstract class AbstractNativeExtensionTipsService extends ExtensionTipsSe
 						.replace('%ProgramFiles%', () => env['ProgramFiles']!)
 						.replace('%APPDATA%', () => env['APPDATA']!)
 						.replace('%WINDIR%', () => env['WINDIR']!));
+					// TODO: Should we look for <LOCALAPPDATA>?
+					// .replace('%LOCALAPPDATA%', () => env['LOCALAPPDATA']!)
+					// Example we are missing out on: <C:\Users\myName\AppData\Local\Programs>
 				}
 			} else {
 				exePaths.push(join('/usr/local/bin', exeName));
 				exePaths.push(join('/usr/bin', exeName));
 				exePaths.push(join(this.userHome.fsPath, exeName));
+				// TODO: Should we look for </opt/homebrew/bin>?
+				exePaths.push(join('/opt/homebrew/bin', exeName));
+				// Example we are missing out on: </opt/homebrew/bin/nu>
 			}
 
 			for (const exePath of exePaths) {
@@ -396,6 +408,17 @@ export abstract class AbstractNativeExtensionTipsService extends ExtensionTipsSe
 				}
 			}
 		}
+		// Uncomment to see hard-coded nu-shell language extension recommendation to show up.
+
+		// result.push({
+		// 	extensionId: 'TheNuProjectContributors.vscode-nushell-lang',
+		// 	extensionName: 'yooooo',
+		// 	isExtensionPack: true,
+		// 	exeName: 'nu.exeman',
+		// 	exeFriendlyName: 'nu.exe',
+		// 	windowsPath: 'dontknow.exe',
+		// 	whenNotInstalled: ['yolo']
+		// });
 
 		return result;
 	}


### PR DESCRIPTION
While trying to figure out: https://github.com/microsoft/vscode/issues/245698,

I noticed that there was already some logic where we search for executables and try to recommend appropriate extensions to install. I've noticed that I wasn't getting expected result (for example, nu language extension should've be suggested if nu executable was detected on my system).

It seems like in https://github.com/microsoft/vscode/blob/c586d5cdee0a9ec762df914faf42247ddf1e06e0/src/vs/platform/extensionManagement/common/extensionTipsService.ts#L353 we are missing some location where we could look to find executables. Such as homebrew directory for Mac and LOCALAPPDATA for Windows. 

I can't really test this change since:
- the executableTips(in `getValidExecutableBasedExtensionTips`) always seem empty for me. 
- Blocked on testing if adding `homebrew directory for Mac and LOCALAPPDATA for Windows. ` works since the `executableTips` were always empty, and `highImportanceRecommendations` and `mediumImportanceRecommendations` seemed to empty as well from the constructor.

I tried to set bunch of logs, breakpoints but it seems like breakpoints inside the constructor of `AbstractNativeExtensionTipsService` never hits and I can't get any of the console.logs to show up in my dev tools.

Can I get some help? @sandy081 