### PR TITLE
Fix inline completion provider handling

### DIFF
--- a/src/vs/editor/contrib/inlineCompletions/browser/model/inlineCompletionsModel.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/model/inlineCompletionsModel.ts
@@ -315,7 +315,7 @@ export class InlineCompletionsModel extends Disposable {
 
 		const providers = changeSummary.provider ? [changeSummary.provider] : this._languageFeaturesService.inlineCompletionsProvider.all(this.textModel);
 
-		return this._source.fetch(providers, cursorPosition, context, itemToPreserve?.identity, changeSummary.shouldDebounce, userJumpedToActiveCompletion);
+		return this._source.fetch(providers, cursorPosition, context, itemToPreserve?.identity, changeSummary.shouldDebounce, userJumpedToActiveCompletion, !!changeSummary.provider);
 	});
 
 	public async trigger(tx?: ITransaction, options?: { onlyFetchInlineEdits?: boolean; noDelay?: boolean }): Promise<void> {

--- a/src/vs/editor/contrib/inlineCompletions/browser/model/inlineCompletionsSource.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/model/inlineCompletionsSource.ts
@@ -107,12 +107,12 @@ export class InlineCompletionsSource extends Disposable {
 	private readonly _loadingCount = observableValue(this, 0);
 	public readonly loading = this._loadingCount.map(this, v => v > 0);
 
-	public fetch(providers: InlineCompletionsProvider[], position: Position, context: InlineCompletionContext, activeInlineCompletion: InlineSuggestionIdentity | undefined, withDebounce: boolean, userJumpedToActiveCompletion: IObservable<boolean>): Promise<boolean> {
+	public fetch(providers: InlineCompletionsProvider[], position: Position, context: InlineCompletionContext, activeInlineCompletion: InlineSuggestionIdentity | undefined, withDebounce: boolean, userJumpedToActiveCompletion: IObservable<boolean>, providerhasChangedCompletion: boolean): Promise<boolean> {
 		const request = new UpdateRequest(position, context, this._textModel.getVersionId());
 
 		const target = context.selectedSuggestionInfo ? this.suggestWidgetInlineCompletions.get() : this.inlineCompletions.get();
 
-		if (this._updateOperation.value?.request.satisfies(request)) {
+		if (!providerhasChangedCompletion && this._updateOperation.value?.request.satisfies(request)) {
 			return this._updateOperation.value.promise;
 		} else if (target?.request?.satisfies(request)) {
 			return Promise.resolve(true);


### PR DESCRIPTION
```Copilot Generated Description:``` Update the inline completions model and source to correctly handle changes in the completion provider, ensuring that the appropriate fetch logic is executed based on provider changes.

Fixes microsoft/vscode-copilot#15996