### PR TITLE
If format on paste is disabled, do early return, in formatOnPaste

### DIFF
--- a/src/vs/editor/contrib/indentation/browser/indentation.ts
+++ b/src/vs/editor/contrib/indentation/browser/indentation.ts
@@ -386,7 +386,7 @@ export class AutoIndentOnPaste implements IEditorContribution {
 		this.callOnModel.clear();
 
 		// we are disabled
-		if (this.editor.getOption(EditorOption.autoIndent) < EditorAutoIndentStrategy.Full || this.editor.getOption(EditorOption.formatOnPaste)) {
+		if (this.editor.getOption(EditorOption.autoIndent) < EditorAutoIndentStrategy.Full || !this.editor.getOption(EditorOption.formatOnPaste)) {
 			return;
 		}
 


### PR DESCRIPTION
fixes https://github.com/microsoft/vscode/issues/242196
fixes https://github.com/microsoft/vscode/issues/246322
fixes https://github.com/microsoft/vscode/issues/241337