### PR TITLE
editor - omit `options` from side-by-side/diff inputs

### DIFF
--- a/src/vs/workbench/browser/parts/editor/diffEditorCommands.ts
+++ b/src/vs/workbench/browser/parts/editor/diffEditorCommands.ts
@@ -16,6 +16,7 @@ import { TextDiffEditor } from './textDiffEditor.js';
 import { ActiveCompareEditorCanSwapContext, TextCompareEditorActiveContext, TextCompareEditorVisibleContext } from '../../../common/contextkeys.js';
 import { DiffEditorInput } from '../../../common/editor/diffEditorInput.js';
 import { IEditorService } from '../../../services/editor/common/editorService.js';
+import { IUntypedEditorInput } from '../../../common/editor.js';
 
 export const TOGGLE_DIFF_SIDE_BY_SIDE = 'toggle.diff.renderSideBySide';
 export const GOTO_NEXT_CHANGE = 'workbench.action.compareEditor.nextChange';
@@ -150,14 +151,14 @@ export function registerDiffEditorCommands(): void {
 		// yet opened. This ensures that the swapping is not
 		// bringing up a confirmation dialog to save.
 		if (diffInput.modified.isModified() && editorService.findEditors({ resource: diffInput.modified.resource, typeId: diffInput.modified.typeId, editorId: diffInput.modified.editorId }).length === 0) {
-			await editorService.openEditor({
-				...untypedDiffInput.modified,
-				options: {
-					...untypedDiffInput.modified.options,
-					pinned: true,
-					inactive: true
-				}
-			}, activeGroup);
+			const editorToOpen: IUntypedEditorInput = { ...untypedDiffInput.modified };
+			if (!editorToOpen.options) {
+				editorToOpen.options = {};
+			}
+			editorToOpen.options.pinned = true;
+			editorToOpen.options.inactive = true;
+
+			await editorService.openEditor(editorToOpen, activeGroup);
 		}
 
 		// Replace the input with the swapped variant

--- a/src/vs/workbench/common/editor.ts
+++ b/src/vs/workbench/common/editor.ts
@@ -504,12 +504,12 @@ export interface IResourceSideBySideEditorInput extends IBaseUntypedEditorInput 
 	/**
 	 * The right hand side editor to open inside a side-by-side editor.
 	 */
-	readonly primary: IResourceEditorInput | ITextResourceEditorInput | IUntitledTextResourceEditorInput;
+	readonly primary: Omit<IResourceEditorInput, 'options'> | Omit<ITextResourceEditorInput, 'options'> | Omit<IUntitledTextResourceEditorInput, 'options'>;
 
 	/**
 	 * The left hand side editor to open inside a side-by-side editor.
 	 */
-	readonly secondary: IResourceEditorInput | ITextResourceEditorInput | IUntitledTextResourceEditorInput;
+	readonly secondary: Omit<IResourceEditorInput, 'options'> | Omit<ITextResourceEditorInput, 'options'> | Omit<IUntitledTextResourceEditorInput, 'options'>;
 }
 
 /**
@@ -524,12 +524,12 @@ export interface IResourceDiffEditorInput extends IBaseUntypedEditorInput {
 	/**
 	 * The left hand side editor to open inside a diff editor.
 	 */
-	readonly original: IResourceEditorInput | ITextResourceEditorInput | IUntitledTextResourceEditorInput;
+	readonly original: Omit<IResourceEditorInput, 'options'> | Omit<ITextResourceEditorInput, 'options'> | Omit<IUntitledTextResourceEditorInput, 'options'>;
 
 	/**
 	 * The right hand side editor to open inside a diff editor.
 	 */
-	readonly modified: IResourceEditorInput | ITextResourceEditorInput | IUntitledTextResourceEditorInput;
+	readonly modified: Omit<IResourceEditorInput, 'options'> | Omit<ITextResourceEditorInput, 'options'> | Omit<IUntitledTextResourceEditorInput, 'options'>;
 }
 
 export interface ITextResourceDiffEditorInput extends IBaseTextResourceEditorInput {
@@ -537,12 +537,12 @@ export interface ITextResourceDiffEditorInput extends IBaseTextResourceEditorInp
 	/**
 	 * The left hand side text editor to open inside a diff editor.
 	 */
-	readonly original: ITextResourceEditorInput | IUntitledTextResourceEditorInput;
+	readonly original: Omit<ITextResourceEditorInput, 'options'> | Omit<IUntitledTextResourceEditorInput, 'options'>;
 
 	/**
 	 * The right hand side text editor to open inside a diff editor.
 	 */
-	readonly modified: ITextResourceEditorInput | IUntitledTextResourceEditorInput;
+	readonly modified: Omit<ITextResourceEditorInput, 'options'> | Omit<IUntitledTextResourceEditorInput, 'options'>;
 }
 
 /**
@@ -571,7 +571,7 @@ export interface IResourceMultiDiffEditorInput extends IBaseUntypedEditorInput {
 export interface IMultiDiffEditorResource extends IResourceDiffEditorInput {
 	readonly goToFileResource?: URI;
 }
-export type IResourceMergeEditorInputSide = (IResourceEditorInput | ITextResourceEditorInput) & { detail?: string };
+export type IResourceMergeEditorInputSide = (Omit<IResourceEditorInput, 'options'> | Omit<ITextResourceEditorInput, 'options'>) & { detail?: string };
 
 /**
  * A resource merge editor input compares multiple editors
@@ -595,12 +595,12 @@ export interface IResourceMergeEditorInput extends IBaseUntypedEditorInput {
 	/**
 	 * The base common ancestor of the file to merge.
 	 */
-	readonly base: IResourceEditorInput | ITextResourceEditorInput;
+	readonly base: Omit<IResourceEditorInput, 'options'> | Omit<ITextResourceEditorInput, 'options'>;
 
 	/**
 	 * The resulting output of the merge.
 	 */
-	readonly result: IResourceEditorInput | ITextResourceEditorInput;
+	readonly result: Omit<IResourceEditorInput, 'options'> | Omit<ITextResourceEditorInput, 'options'>;
 }
 
 export function isResourceEditorInput(editor: unknown): editor is IResourceEditorInput {

--- a/src/vs/workbench/contrib/chat/browser/chatEditing/notebook/chatEditingNotebookEditorIntegration.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditing/notebook/chatEditingNotebookEditorIntegration.ts
@@ -633,13 +633,13 @@ class ChatEditingNotebookEditorWidgetIntegration extends Disposable implements I
 	}
 	async toggleDiff(_change: IModifiedFileEntryChangeHunk | undefined): Promise<void> {
 		const defaultAgentName = this._chatAgentService.getDefaultAgent(ChatAgentLocation.Panel)?.fullName;
-		const diffInput = {
-			original: { resource: this._entry.originalURI, options: { selection: undefined } },
-			modified: { resource: this._entry.modifiedURI, options: { selection: undefined } },
+		const diffInput: IResourceDiffEditorInput = {
+			original: { resource: this._entry.originalURI },
+			modified: { resource: this._entry.modifiedURI },
 			label: defaultAgentName
 				? localize('diff.agent', '{0} (changes from {1})', basename(this._entry.modifiedURI), defaultAgentName)
 				: localize('diff.generic', '{0} (changes from chat)', basename(this._entry.modifiedURI))
-		} satisfies IResourceDiffEditorInput;
+		};
 		await this._editorService.openEditor(diffInput);
 
 	}


### PR DESCRIPTION
We only apply the `options` on the overall input, not the sides within.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
