### PR TITLE
config: Resolve variables returned by commands

### DIFF
--- a/src/vs/workbench/services/configurationResolver/browser/baseConfigurationResolverService.ts
+++ b/src/vs/workbench/services/configurationResolver/browser/baseConfigurationResolverService.ts
@@ -144,10 +144,6 @@ export abstract class BaseConfigurationResolverService extends AbstractVariableR
 	}
 
 	override async resolveWithInteractionReplace(folder: IWorkspaceFolderData | undefined, config: any, section?: string, variables?: IStringDictionary<string>, target?: ConfigurationTarget): Promise<any> {
-		// First resolve any non-interactive variables and any contributed variables
-		config = await this.resolveAsync(folder, config);
-
-		// Then resolve input variables in the order in which they are encountered
 		const parsed = ConfigurationResolverExpression.parse(config);
 		await this.resolveWithInteraction(folder, parsed, section, variables, target);
 

--- a/src/vs/workbench/services/configurationResolver/browser/baseConfigurationResolverService.ts
+++ b/src/vs/workbench/services/configurationResolver/browser/baseConfigurationResolverService.ts
@@ -180,9 +180,14 @@ export abstract class BaseConfigurationResolverService extends AbstractVariableR
 			else if (this._contributedVariables.has(variable.inner)) {
 				result = { value: await this._contributedVariables.get(variable.inner)!() };
 			}
-			// Not something we can handle
 			else {
-				continue;
+				// Fallback to parent evaluation
+				const resolvedValue = await this.evaluateSingleVariable(variable, folder?.uri);
+				if (resolvedValue === undefined) {
+					// Not something we can handle
+					continue;
+				}
+				result = typeof resolvedValue === 'string' ? { value: resolvedValue } : resolvedValue;
 			}
 
 			if (result === undefined) {

--- a/src/vs/workbench/services/configurationResolver/common/variableResolver.ts
+++ b/src/vs/workbench/services/configurationResolver/common/variableResolver.ts
@@ -69,13 +69,9 @@ export abstract class AbstractVariableResolverService implements IConfigurationR
 
 	public async resolveWithEnvironment(environment: IProcessEnvironment, folder: IWorkspaceFolderData | undefined, value: string): Promise<string> {
 		const expr = ConfigurationResolverExpression.parse(value);
-		const env: Environment = {
-			env: this.prepareEnv(environment),
-			userHome: undefined
-		};
 
 		for (const replacement of expr.unresolved()) {
-			const resolvedValue = await this.evaluateSingleVariable(env, replacement, folder?.uri);
+			const resolvedValue = await this.evaluateSingleVariable(replacement, folder?.uri, environment);
 			if (resolvedValue !== undefined) {
 				expr.resolve(replacement, String(resolvedValue));
 			}
@@ -87,13 +83,8 @@ export abstract class AbstractVariableResolverService implements IConfigurationR
 	public async resolveAsync<T>(folder: IWorkspaceFolderData | undefined, config: T): Promise<T extends ConfigurationResolverExpression<infer R> ? R : T> {
 		const expr = ConfigurationResolverExpression.parse(config);
 
-		const environment: Environment = {
-			env: await this._envVariablesPromise,
-			userHome: await this._userHomePromise
-		};
-
 		for (const replacement of expr.unresolved()) {
-			const resolvedValue = await this.evaluateSingleVariable(environment, replacement, folder?.uri);
+			const resolvedValue = await this.evaluateSingleVariable(replacement, folder?.uri);
 			if (resolvedValue !== undefined) {
 				expr.resolve(replacement, String(resolvedValue));
 			}
@@ -123,7 +114,14 @@ export abstract class AbstractVariableResolverService implements IConfigurationR
 		return this._labelService ? this._labelService.getUriLabel(displayUri, { noPrefix: true }) : displayUri.fsPath;
 	}
 
-	private async evaluateSingleVariable(environment: Environment, replacement: Replacement, folderUri: uri | undefined, commandValueMapping?: IStringDictionary<IResolvedValue>): Promise<IResolvedValue | string | undefined> {
+	protected async evaluateSingleVariable(replacement: Replacement, folderUri: uri | undefined, processEnvironment?: IProcessEnvironment, commandValueMapping?: IStringDictionary<IResolvedValue>): Promise<IResolvedValue | string | undefined> {
+
+
+		const environment: Environment = {
+			env: (processEnvironment !== undefined) ? this.prepareEnv(processEnvironment) : await this._envVariablesPromise,
+			userHome: (processEnvironment !== undefined) ? undefined : await this._userHomePromise
+		};
+
 		const { name: variable, arg: argument } = replacement;
 
 		// common error handling for all variables that require an open editor


### PR DESCRIPTION
Fixes #246633

This PR fixes a regression on https://github.com/microsoft/vscode/commit/c22175d4217b5cf6b76d857d6e87ac05723c3eff#diff-e482f7894e136562bb05760b6da7f5d40e4721aa06b1432c753cdec530d23850 that causes variables returned by commands not being resolved.

The proposed solution is expose `AbstractVariableResolverService.evaluateSingleVariable` to child classes so `BaseConfigurationResolverService` can use the default resolution method for any variable nested within a command or input variable.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
