### PR TITLE
[Draft] Respect gitignore file when file watching (fixes #231140)

### DIFF
--- a/extensions/git/src/repository.ts
+++ b/extensions/git/src/repository.ts
@@ -2018,15 +2018,16 @@ export class Repository implements Disposable {
 			const fileContents = fs.readFileSync(this.gitIgnorePath, { encoding: 'utf8' });
 			// convert each line in the glob file to be a negated pattern separarted by a comma
 			// e.g. *.js -> !*.js, *.ts -> !*.ts
-			const globPatternForIgnored = '{' + fileContents
+			const globPatternForIgnored = fileContents
 				.split('\n')
 				.map(line => line.trim())
 				.filter(line => line && !line.startsWith('#'))
 				.map(pattern => {
 					return `!${pattern}`;
 				})
-				.join(',') + '}';
-			return globPatternForIgnored;
+				.join(',');
+
+			return `{**/*,${globPatternForIgnored}}`;
 		}
 
 		return '**';


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This fixes #231140, this should reduce the amount of file watching happening on large repositories and less triggering of git status.


This will read the  .gitignore file and fetch the values which can then be passed to the file watcher, however, it does seem like the filewatcher only accepts a single glob pattern, so there doesn't seem to be a way for me to watch the directory but exclude the paths from the `.gitignore`.

@lszomoru do you have any idea on how to fix this or if there is a workaround?
For now on vscode's repo the pattern that gets passed through to the watcher looks like this:

```
{**/*,!.DS_Store,!.cache,!npm-debug.log,!Thumbs.db,!node_modules/,!.build/,!.vscode/extensions/**/out/,!extensions/**/dist/,!/out*/,!/extensions/**/out/,!build/node_modules,!coverage/,!test_data/,!test-results/,!test-results.xml,!vscode.lsif,!vscode.db,!/.profile-oss,!/cli/target,!/cli/openssl,!product.overrides.json,!*.snap.actual,!.vscode-test}
```

My assumtion for this not working is the `**/*` at the beginning is matching, however if i take that out of the group match and have it at the start, then followed by the group match nothing matches. So it doesn't look like VS Code's built in glob allows for both checks here (or maybe im using it wrong)

The same doesn't seem to work on the glob playground with parenthesis due to `/` being used in the patterns:
https://www.digitalocean.com/community/tools/glob?comments=true&glob=%2A%2A%2F%21%28.DS_Store%7C.cache%7Cnpm-debug.log%7CThumbs.db%7Cnode_modules%2F%7C.build%2F%7C.vscode%2Fextensions%2F%2A%2A%2Fout%2F%7Cextensions%2F%2A%2A%2Fdist%2F%7C%2Fout%2A%2F%7C%2Fextensions%2F%2A%2A%2Fout%2F%7Cbuild%2Fnode_modules%7Ccoverage%2F%7Ctest_data%2F%7Ctest-results%2F%7Ctest-results.xml%7Cvscode.lsif%7Cvscode.db%7C%2F.profile-oss%7C%2Fcli%2Ftarget%7C%2Fcli%2Fopenssl%7Cproduct.overrides.json%7C%2A.snap.actual%7C.vscode-test%29&matches=false&tests=positive-match.jpg&tests=npm-debug.log&tests=Thumbs.d%C2%A0&tests=this-should-match.txt

## Steps to reproduce
- open the vscode repo with this built and running
- change a file from the gitignore
- the  [`onChange`](https://github.com/microsoft/vscode/blob/95b030057bd25030e6f7b710c0a0542c8838529e/extensions/git/src/repository.ts#L2545) handler will fire (it shouldn't)