### PR TITLE
[prompts]: parse front matter header contents

### DIFF
--- a/src/vs/editor/common/codecs/frontMatterCodec/frontMatterDecoder.ts
+++ b/src/vs/editor/common/codecs/frontMatterCodec/frontMatterDecoder.ts
@@ -5,6 +5,7 @@
 
 import { VALID_SPACE_TOKENS } from './constants.js';
 import { Word } from '../simpleCodec/tokens/index.js';
+import { TokenStream } from '../utils/tokensStream.js';
 import { VSBuffer } from '../../../../base/common/buffer.js';
 import { ReadableStream } from '../../../../base/common/stream.js';
 import { FrontMatterToken, FrontMatterRecord } from './tokens/index.js';
@@ -28,8 +29,14 @@ export class FrontMatterDecoder extends BaseDecoder<TFrontMatterToken, TSimpleDe
 	private current?: PartialFrontMatterRecordName | PartialFrontMatterRecordNameWithDelimiter | PartialFrontMatterRecord;
 
 	constructor(
-		stream: ReadableStream<VSBuffer>,
+		stream: ReadableStream<VSBuffer> | TokenStream<TSimpleDecoderToken>,
 	) {
+		if (stream instanceof TokenStream) {
+			super(stream);
+
+			return;
+		}
+
 		super(new SimpleDecoder(stream));
 	}
 

--- a/src/vs/editor/common/codecs/frontMatterCodec/frontMatterDecoder.ts
+++ b/src/vs/editor/common/codecs/frontMatterCodec/frontMatterDecoder.ts
@@ -5,7 +5,7 @@
 
 import { VALID_SPACE_TOKENS } from './constants.js';
 import { Word } from '../simpleCodec/tokens/index.js';
-import { TokenStream } from '../utils/tokensStream.js';
+import { TokenStream } from '../utils/tokenStream.js';
 import { VSBuffer } from '../../../../base/common/buffer.js';
 import { ReadableStream } from '../../../../base/common/stream.js';
 import { FrontMatterToken, FrontMatterRecord } from './tokens/index.js';

--- a/src/vs/editor/common/codecs/frontMatterCodec/tokens/frontMatterArray.ts
+++ b/src/vs/editor/common/codecs/frontMatterCodec/tokens/frontMatterArray.ts
@@ -4,13 +4,18 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { BaseToken } from '../../baseToken.js';
-import { FrontMatterValueToken } from './frontMatterToken.js';
+import { FrontMatterValueToken, TValueTypeName } from './frontMatterToken.js';
 import { LeftBracket, RightBracket } from '../../simpleCodec/tokens/index.js';
 
 /**
  * Token that represents an `array` value in a Front Matter header.
  */
-export class FrontMatterArray extends FrontMatterValueToken {
+export class FrontMatterArray extends FrontMatterValueToken<'array'> {
+	/**
+	 * Name of the `array` value type.
+	 */
+	public override readonly valueTypeName = 'array';
+
 	constructor(
 		/**
 		 * List of tokens of the array value. Must start and end
@@ -19,13 +24,28 @@ export class FrontMatterArray extends FrontMatterValueToken {
 		 */
 		public readonly tokens: readonly [
 			LeftBracket,
-			...FrontMatterValueToken[],
+			...FrontMatterValueToken<TValueTypeName>[],
 			RightBracket,
 		],
 	) {
 		super(
 			BaseToken.fullRange(tokens),
 		);
+	}
+
+	/**
+	 * List of the array items.
+	 */
+	public get items(): readonly FrontMatterValueToken<TValueTypeName>[] {
+		const result = [];
+
+		for (const token of this.tokens) {
+			if (token instanceof FrontMatterValueToken) {
+				result.push(token);
+			}
+		}
+
+		return result;
 	}
 
 	public override get text(): string {

--- a/src/vs/editor/common/codecs/frontMatterCodec/tokens/frontMatterBoolean.ts
+++ b/src/vs/editor/common/codecs/frontMatterCodec/tokens/frontMatterBoolean.ts
@@ -11,7 +11,12 @@ import { assertDefined } from '../../../../../base/common/types.js';
 /**
  * Token that represents a `boolean` value in a Front Matter header.
  */
-export class FrontMatterBoolean extends FrontMatterValueToken {
+export class FrontMatterBoolean extends FrontMatterValueToken<'boolean'> {
+	/**
+	 * Name of the `boolean` value type.
+	 */
+	public override readonly valueTypeName = 'boolean';
+
 	constructor(
 		range: Range,
 		public readonly value: boolean,

--- a/src/vs/editor/common/codecs/frontMatterCodec/tokens/frontMatterRecord.ts
+++ b/src/vs/editor/common/codecs/frontMatterCodec/tokens/frontMatterRecord.ts
@@ -6,7 +6,7 @@
 import { BaseToken } from '../../baseToken.js';
 import { assert } from '../../../../../base/common/assert.js';
 import { Colon, Word, Dash, Space, Tab } from '../../simpleCodec/tokens/index.js';
-import { FrontMatterToken, FrontMatterValueToken } from '../tokens/frontMatterToken.js';
+import { FrontMatterToken, FrontMatterValueToken, TValueTypeName } from '../tokens/frontMatterToken.js';
 
 /**
  * Type for tokens that can be used inside a record name.
@@ -14,7 +14,8 @@ import { FrontMatterToken, FrontMatterValueToken } from '../tokens/frontMatterTo
 export type TNameToken = Word | Dash;
 
 /**
- * Type for tokens that can be used as "space" inside a record.
+ * Type for tokens that can be used as "space" in-between record
+ * name, delimiter and value.
  */
 export type TSpaceToken = Space | Tab;
 
@@ -87,11 +88,41 @@ export class FrontMatterRecordDelimiter extends FrontMatterToken {
  */
 export class FrontMatterRecord extends FrontMatterToken {
 	constructor(
-		public readonly tokens: readonly [FrontMatterRecordName, FrontMatterRecordDelimiter, FrontMatterValueToken],
+		private readonly tokens: readonly [FrontMatterRecordName, FrontMatterRecordDelimiter, FrontMatterValueToken<TValueTypeName>],
 	) {
 		super(
 			BaseToken.fullRange(tokens),
 		);
+	}
+
+	/**
+	 * Token that represent `name` of the record.
+	 *
+	 * E.g., `tools` in the example below:
+	 *
+	 * ```
+	 * ---
+	 * tools: ['value']
+	 * ---
+	 * ```
+	 */
+	public get nameToken(): FrontMatterRecordName {
+		return this.tokens[0];
+	}
+
+	/**
+	 * Token that represent `value` of the record.
+	 *
+	 * E.g., `['value']` in the example below:
+	 *
+	 * ```
+	 * ---
+	 * tools: ['value']
+	 * ---
+	 * ```
+	 */
+	public get valueToken(): FrontMatterValueToken<TValueTypeName> {
+		return this.tokens[2];
 	}
 
 	/**

--- a/src/vs/editor/common/codecs/frontMatterCodec/tokens/frontMatterString.ts
+++ b/src/vs/editor/common/codecs/frontMatterCodec/tokens/frontMatterString.ts
@@ -15,11 +15,25 @@ export type TQuoteToken = Quote | DoubleQuote;
 /**
  * Token that represents a string value in a Front Matter header.
  */
-export class FrontMatterString<TQuote extends TQuoteToken = Quote> extends FrontMatterValueToken {
+export class FrontMatterString<TQuote extends TQuoteToken = Quote> extends FrontMatterValueToken<'string'> {
+	/**
+	 * Name of the `string` value type.
+	 */
+	public override readonly valueTypeName = 'string';
+
 	constructor(
 		public readonly tokens: readonly [TQuote, ...BaseToken[], TQuote],
 	) {
 		super(BaseToken.fullRange(tokens));
+	}
+
+	/**
+	 * Text of the string value without the wrapping quotes.
+	 */
+	public get cleanText(): string {
+		return BaseToken.render(
+			this.tokens.slice(1, this.tokens.length - 1),
+		);
 	}
 
 	public override get text(): string {

--- a/src/vs/editor/common/codecs/frontMatterCodec/tokens/frontMatterToken.ts
+++ b/src/vs/editor/common/codecs/frontMatterCodec/tokens/frontMatterToken.ts
@@ -11,6 +11,16 @@ import { BaseToken } from '../../baseToken.js';
 export abstract class FrontMatterToken extends BaseToken { }
 
 /**
+ * List of all currently supported value types.
+ */
+export type TValueTypeName = 'string' | 'boolean' | 'array';
+
+/**
  * Base class for all tokens that represent a `value` inside a Front Matter header.
  */
-export abstract class FrontMatterValueToken extends FrontMatterToken { }
+export abstract class FrontMatterValueToken<TTypeName extends TValueTypeName = TValueTypeName> extends FrontMatterToken {
+	/**
+	 * Type name of the `value` represented by this token.
+	 */
+	public abstract readonly valueTypeName: TTypeName;
+}

--- a/src/vs/editor/common/codecs/frontMatterCodec/tokens/index.ts
+++ b/src/vs/editor/common/codecs/frontMatterCodec/tokens/index.ts
@@ -7,4 +7,10 @@ export { FrontMatterArray } from './frontMatterArray.js';
 export { FrontMatterString } from './frontMatterString.js';
 export { FrontMatterBoolean } from './frontMatterBoolean.js';
 export { FrontMatterToken, FrontMatterValueToken } from './frontMatterToken.js';
-export { FrontMatterRecordName, FrontMatterRecordDelimiter, FrontMatterRecord, type TNameToken as TRecordNameToken, type TSpaceToken as TRecordSpaceToken } from './frontMatterRecord.js';
+export {
+	FrontMatterRecordName,
+	FrontMatterRecordDelimiter,
+	FrontMatterRecord,
+	type TNameToken as TRecordNameToken,
+	type TSpaceToken as TRecordSpaceToken,
+} from './frontMatterRecord.js';

--- a/src/vs/editor/common/codecs/markdownExtensionsCodec/tokens/frontMatterHeader.ts
+++ b/src/vs/editor/common/codecs/markdownExtensionsCodec/tokens/frontMatterHeader.ts
@@ -43,6 +43,13 @@ export class FrontMatterHeader extends MarkdownExtensionsToken {
 	}
 
 	/**
+	 * Content token of the Front Matter header.
+	 */
+	public get contentToken(): Text {
+		return this.content;
+	}
+
+	/**
 	 * Check if this token is equal to another one.
 	 */
 	public override equals<T extends BaseToken>(other: T): boolean {
@@ -69,8 +76,12 @@ export class FrontMatterHeader extends MarkdownExtensionsToken {
 		contentTokens: readonly TSimpleDecoderToken[],
 		endMarkerTokens: readonly TMarkerToken[],
 	): FrontMatterHeader {
+		const range = BaseToken.fullRange(
+			[...startMarkerTokens, ...endMarkerTokens],
+		);
+
 		return new FrontMatterHeader(
-			BaseToken.fullRange([...startMarkerTokens, ...endMarkerTokens]),
+			range,
 			FrontMatterMarker.fromTokens(startMarkerTokens),
 			Text.fromTokens(contentTokens),
 			FrontMatterMarker.fromTokens(endMarkerTokens),

--- a/src/vs/editor/common/codecs/utils/tokenStream.ts
+++ b/src/vs/editor/common/codecs/utils/tokenStream.ts
@@ -26,7 +26,7 @@ export class TokenStream<T extends BaseToken> extends ObservableDisposable imple
 	 * Interval reference that is used to periodically send
 	 * tokens to the stream in the background.
 	 */
-	private interval: NodeJS.Timeout | undefined;
+	private interval: ReturnType<typeof setInterval> | undefined;
 
 	/**
 	 * Number of tokens left to be sent.

--- a/src/vs/editor/common/codecs/utils/tokensStream.ts
+++ b/src/vs/editor/common/codecs/utils/tokensStream.ts
@@ -1,0 +1,180 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { BaseToken } from '../baseToken.js';
+import { assert, assertNever } from '../../../../base/common/assert.js';
+import { ObservableDisposable } from '../../../../base/common/observableDisposable.js';
+import { newWriteableStream, WriteableStream, ReadableStream } from '../../../../base/common/stream.js';
+
+/**
+ * A readable stream of provided tokens.
+ */
+export class TokenStream<T extends BaseToken> extends ObservableDisposable implements ReadableStream<T> {
+	/**
+	 * Underlying writable stream instance.
+	 */
+	private readonly stream: WriteableStream<T>;
+
+	/**
+	 * Index of the next token to be sent.
+	 */
+	private index: number;
+
+	/**
+	 * Interval reference that is used to periodically send
+	 * tokens to the stream in the background.
+	 */
+	private interval: NodeJS.Timeout | undefined;
+
+	/**
+	 * Number of tokens left to be sent.
+	 */
+	private get tokensLeft(): number {
+		return this.tokens.length - this.index;
+	}
+
+	constructor(
+		private readonly tokens: readonly T[],
+	) {
+		super();
+
+		this.stream = newWriteableStream<T>(null);
+		this.index = 0;
+
+		// send couple of tokens immediately
+		this.sendTokens();
+	}
+
+	/**
+	 * Start periodically sending tokens to the stream
+	 * asynchronously in the background.
+	 */
+	public startStream(): this {
+		// already running, noop
+		if (this.interval !== undefined) {
+			return this;
+		}
+
+		// no tokens to send, end the stream immediately
+		if (this.tokens.length === 0) {
+			this.stream.end();
+			return this;
+		}
+
+		// periodically send tokens to the stream
+		this.interval = setInterval(() => {
+			if (this.tokensLeft === 0) {
+				clearInterval(this.interval);
+				delete this.interval;
+
+				return;
+			}
+
+			this.sendTokens();
+		}, 1);
+
+		return this;
+	}
+
+	/**
+	 * Stop tokens sending interval.
+	 */
+	public stopStream(): this {
+		if (this.interval === undefined) {
+			return this;
+		}
+
+		clearInterval(this.interval);
+		delete this.interval;
+
+		return this;
+	}
+
+	/**
+	 * Sends a provided number of tokens to the stream.
+	 */
+	private sendTokens(
+		tokensCount: number = 25,
+	): void {
+		if (this.tokensLeft <= 0) {
+			return;
+		}
+
+		// send up to 10 tokens at a time
+		let tokensToSend = Math.min(this.tokensLeft, tokensCount);
+		while (tokensToSend > 0) {
+			assert(
+				this.index < this.tokens.length,
+				`Token index '${this.index}' is out of bounds.`,
+			);
+
+			this.stream.write(this.tokens[this.index]);
+			this.index++;
+			tokensToSend--;
+		}
+
+		// if sent all tokens, end the stream immediately
+		if (this.tokensLeft === 0) {
+			this.stream.end();
+		}
+	}
+
+	public pause(): void {
+		this.stopStream();
+
+		return this.stream.pause();
+	}
+
+	public resume(): void {
+		this.startStream();
+
+		return this.stream.resume();
+	}
+
+	public destroy(): void {
+		this.dispose();
+	}
+
+	public removeListener(event: string, callback: Function): void {
+		return this.stream.removeListener(event, callback);
+	}
+
+	public on(event: 'data', callback: (data: T) => void): void;
+	public on(event: 'error', callback: (err: Error) => void): void;
+	public on(event: 'end', callback: () => void): void;
+	public on(event: 'data' | 'error' | 'end', callback: (arg?: any) => void): void {
+		if (event === 'data') {
+			this.stream.on(event, callback);
+			// this is the convention of the readable stream, - when
+			// the `data` event is registered, the stream is started
+			this.startStream();
+
+			return;
+		}
+
+		if (event === 'error') {
+			return this.stream.on(event, callback);
+		}
+
+		if (event === 'end') {
+			return this.stream.on(event, callback);
+		}
+
+		assertNever(
+			event,
+			`Unexpected event name '${event}'.`,
+		);
+	}
+
+	/**
+	 * Cleanup send interval and destroy the stream.
+	 */
+	public override dispose(): void {
+		this.stopStream();
+		this.stream.destroy();
+
+		super.dispose();
+	}
+}


### PR DESCRIPTION
Adds logic to parse contents of the Front Matter header inside prompt files.

Part of https://github.com/microsoft/vscode-copilot/issues/15596, https://github.com/microsoft/vscode-copilot/issues/15420 and https://github.com/microsoft/vscode-copilot/issues/12203