### PR TITLE
Fix cell output action grouping

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/controller/chat/notebook.chat.contribution.ts
+++ b/src/vs/workbench/contrib/notebook/browser/controller/chat/notebook.chat.contribution.ts
@@ -249,7 +249,8 @@ registerAction2(class CopyCellOutputAction extends Action2 {
 			menu: {
 				id: MenuId.NotebookOutputToolbar,
 				when: ContextKeyExpr.and(NOTEBOOK_CELL_HAS_OUTPUTS, ContextKeyExpr.in(NOTEBOOK_CELL_OUTPUT_MIMETYPE.key, NOTEBOOK_CELL_OUTPUT_MIME_TYPE_LIST_FOR_CHAT.key)),
-				order: 10
+				order: 10,
+				group: 'notebook_chat_actions'
 			},
 			category: NOTEBOOK_ACTIONS_CATEGORY,
 			icon: icons.copyIcon,


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
cc/ @eleanorjboyd 

Adds a group identifier to the action in the NotebookOutputToolbar

stable:
three dot
![image](https://github.com/user-attachments/assets/3152397a-39b3-4f40-ba1a-1e972eca8a01)
right click context
![image](https://github.com/user-attachments/assets/ef4a3168-46c7-4b7e-838b-999f81a54031)

Fixed:
three dot
![image](https://github.com/user-attachments/assets/a4554848-4def-4976-8eca-70e904f5d3a1)

