### PR TITLE
[prompts]: parse 'tools' metadata inside prompt header

### DIFF
--- a/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/basePromptParser.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/basePromptParser.ts
@@ -16,9 +16,9 @@ import { IPromptReference, IResolveError, ITopError } from './types.js';
 import { DeferredPromise } from '../../../../../../base/common/async.js';
 import { ILogService } from '../../../../../../platform/log/common/log.js';
 import { PromptVariableWithData } from '../codecs/tokens/promptVariable.js';
+import { IRange, Range } from '../../../../../../editor/common/core/range.js';
 import { assert, assertNever } from '../../../../../../base/common/assert.js';
 import { BaseToken } from '../../../../../../editor/common/codecs/baseToken.js';
-import { IRange, Range } from '../../../../../../editor/common/core/range.js';
 import { VSBufferReadableStream } from '../../../../../../base/common/buffer.js';
 import { isPromptFile } from '../../../../../../platform/prompts/common/constants.js';
 import { basename, dirname, extUri } from '../../../../../../base/common/resources.js';
@@ -28,6 +28,8 @@ import { IInstantiationService } from '../../../../../../platform/instantiation/
 import { MarkdownLink } from '../../../../../../editor/common/codecs/markdownCodec/tokens/markdownLink.js';
 import { MarkdownToken } from '../../../../../../editor/common/codecs/markdownCodec/tokens/markdownToken.js';
 import { OpenFailed, NotPromptFile, RecursiveReference, FolderReference, ResolveError } from '../../promptFileReferenceErrors.js';
+import { FrontMatterHeader } from '../../../../../../editor/common/codecs/markdownExtensionsCodec/tokens/frontMatterHeader.js';
+import { PromptHeader } from './promptHeader/header.js';
 
 /**
  * Error conditions that may happen during the file reference resolution.
@@ -54,6 +56,18 @@ export class BasePromptParser<TContentsProvider extends IPromptContentsProvider>
 	 * List of file references in the current branch of the file reference tree.
 	 */
 	private readonly _references: IPromptReference[] = [];
+
+	/**
+	 * TODO: @legomushroom
+	 */
+	private promptHeader?: PromptHeader;
+
+	/**
+	 * TODO: @legomushroom
+	 */
+	public get header(): PromptHeader | undefined {
+		return this.promptHeader;
+	}
 
 	/**
 	 * The event is fired when lines or their content change.
@@ -129,6 +143,11 @@ export class BasePromptParser<TContentsProvider extends IPromptContentsProvider>
 		);
 
 		await this.stream.settled;
+
+		// TODO: @legomushroom
+		if (this.promptHeader) {
+			await this.promptHeader.settled;
+		}
 
 		return this;
 	}
@@ -221,6 +240,9 @@ export class BasePromptParser<TContentsProvider extends IPromptContentsProvider>
 		delete this._errorCondition;
 		this.receivedTokens = [];
 
+		this.promptHeader?.dispose();
+		delete this.promptHeader;
+
 		// dispose all currently existing references
 		this.disposeReferences();
 
@@ -244,6 +266,12 @@ export class BasePromptParser<TContentsProvider extends IPromptContentsProvider>
 			// store all markdown and prompt token references
 			if ((token instanceof MarkdownToken) || (token instanceof PromptToken)) {
 				this.receivedTokens.push(token);
+			}
+
+			if (token instanceof FrontMatterHeader) {
+				this.promptHeader = new PromptHeader(token.contentToken);
+				this.promptHeader.start();
+				return;
 			}
 
 			// try to convert a prompt variable with data token into a file reference

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/basePromptParser.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/basePromptParser.ts
@@ -604,7 +604,13 @@ export class BasePromptParser<TContentsProvider extends IPromptContentsProvider>
 		}
 
 		this.disposeReferences();
+
 		this.stream?.dispose();
+		delete this.stream;
+
+		this.promptHeader?.dispose();
+		delete this.promptHeader;
+
 		this._onUpdate.fire();
 
 		super.dispose();

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/basePromptParser.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/basePromptParser.ts
@@ -58,12 +58,14 @@ export class BasePromptParser<TContentsProvider extends IPromptContentsProvider>
 	private readonly _references: IPromptReference[] = [];
 
 	/**
-	 * TODO: @legomushroom
+	 * Reference to the prompt header object that holds metadata associated
+	 * with the prompt.
 	 */
 	private promptHeader?: PromptHeader;
 
 	/**
-	 * TODO: @legomushroom
+	 * Reference to the prompt header object that holds metadata associated
+	 * with the prompt.
 	 */
 	public get header(): PromptHeader | undefined {
 		return this.promptHeader;
@@ -144,7 +146,7 @@ export class BasePromptParser<TContentsProvider extends IPromptContentsProvider>
 
 		await this.stream.settled;
 
-		// TODO: @legomushroom
+		// if prompt header exists, also wait for it to be settled
 		if (this.promptHeader) {
 			await this.promptHeader.settled;
 		}
@@ -240,6 +242,7 @@ export class BasePromptParser<TContentsProvider extends IPromptContentsProvider>
 		delete this._errorCondition;
 		this.receivedTokens = [];
 
+		// cleanup current prompt header object
 		this.promptHeader?.dispose();
 		delete this.promptHeader;
 
@@ -268,6 +271,7 @@ export class BasePromptParser<TContentsProvider extends IPromptContentsProvider>
 				this.receivedTokens.push(token);
 			}
 
+			// if a prompt header token received, create a new prompt header instance
 			if (token instanceof FrontMatterHeader) {
 				this.promptHeader = new PromptHeader(token.contentToken);
 				this.promptHeader.start();

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/promptHeader/diagnostics.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/promptHeader/diagnostics.ts
@@ -1,0 +1,35 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { ILocalizedString } from '../../../../../../../nls.js';
+import { Range } from '../../../../../../../editor/common/core/range.js';
+
+/**
+ * List of all currently supported diagnostic types.
+ */
+export type TDiagnostic = PromptMetadataWarning | PromptMetadataError;
+
+/**
+ * Diagnostics object that hold information about some issue
+ * related to the prompt header metadata.
+ */
+export abstract class PromptMetadataDiagnostic {
+	constructor(
+		public readonly range: Range,
+		public readonly message: string | ILocalizedString,
+	) { }
+}
+
+/**
+ * Diagnostics object that hold information about some
+ * non-fatal issue related to the prompt header metadata.
+ */
+export class PromptMetadataWarning extends PromptMetadataDiagnostic { }
+
+/**
+ * Diagnostics object that hold information about some
+ * fatal issue related to the prompt header metadata.
+ */
+export class PromptMetadataError extends PromptMetadataDiagnostic { }

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/promptHeader/header.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/promptHeader/header.ts
@@ -1,0 +1,185 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { PromptTools } from './metadata/tools.js';
+import { localize2 } from '../../../../../../../nls.js';
+import { Disposable } from '../../../../../../../base/common/lifecycle.js';
+import { Text } from '../../../../../../../editor/common/codecs/baseToken.js';
+import { PromptMetadataError, PromptMetadataWarning, TDiagnostic } from './diagnostics.js';
+import { TokenStream } from '../../../../../../../editor/common/codecs/utils/tokenStream.js';
+import { SimpleToken } from '../../../../../../../editor/common/codecs/simpleCodec/tokens/index.js';
+import { FrontMatterRecord } from '../../../../../../../editor/common/codecs/frontMatterCodec/tokens/index.js';
+import { FrontMatterDecoder, TFrontMatterToken } from '../../../../../../../editor/common/codecs/frontMatterCodec/frontMatterDecoder.js';
+
+/**
+ * Type of all known metadata records inside the prompt header.
+ */
+type TMetadataRecord = PromptTools;
+
+/**
+ * Prompt header holds all metadata records for a prompt.
+ */
+export class PromptHeader extends Disposable {
+	/**
+	 * Underlying decoder for a Front Matter header.
+	 */
+	private readonly stream: FrontMatterDecoder;
+
+	/**
+	 * List of all unique metadata records inside the prompt header.
+	 */
+	private readonly metadata: TMetadataRecord[];
+
+	/**
+	 * List of all unique metadata record names.
+	 */
+	private readonly recordNames: Set<string>;
+
+	/**
+	 * List of all issues found while parsing the prompt header.
+	 */
+	private readonly issues: TDiagnostic[];
+
+	/**
+	 * List of all diagnostic issues found while parsing
+	 * the prompt header.
+	 */
+	public get diagnostics(): readonly TDiagnostic[] {
+		const result = [];
+
+		// collect all issue of the metadata records
+		for (const metadata of this.metadata) {
+			result.push(...metadata.diagnostics);
+		}
+
+		// then add all issues from this header object itself
+		result.push(...this.issues);
+
+		return result;
+	}
+
+	constructor(
+		public readonly contentsToken: Text,
+	) {
+		super();
+
+		this.issues = [];
+		this.metadata = [];
+		this.recordNames = new Set<string>();
+
+		this.stream = this._register(
+			new FrontMatterDecoder(
+				new TokenStream(contentsToken.tokens),
+			),
+		);
+		this.stream.onData(this.onData.bind(this));
+		this.stream.onError(this.onError.bind(this));
+	}
+
+	/**
+	 * Process front matter tokens, converting them into
+	 * well-known prompt metadata records.
+	 */
+	private onData(token: TFrontMatterToken): void {
+		// we currently expect only front matter 'records' for
+		// the prompt metadata, hence add diagnostics for all
+		// other tokens and ignore them
+		if ((token instanceof FrontMatterRecord) === false) {
+			// unless its a simple token, in which case we just ignore it
+			if (token instanceof SimpleToken) {
+				return;
+			}
+
+			this.issues.push(
+				new PromptMetadataError(
+					token.range,
+					localize2(
+						'prompt.header.diagnostics.unexpected-token',
+						"Unexpected token '{0}'.",
+						token.text,
+					),
+				),
+			);
+
+			return;
+		}
+
+		const recordName = token.nameToken.text;
+
+		// if we already have a record with this name,
+		// add a warning diagnostic and ignore it
+		if (this.recordNames.has(recordName)) {
+			this.issues.push(
+				new PromptMetadataWarning(
+					token.range,
+					localize2(
+						'prompt.header.metadata.diagnostics.duplicate-record',
+						"Duplicate metadata record '{0}' will be ignored.",
+						recordName,
+					),
+				),
+			);
+
+			return;
+		}
+
+		// if the record might be a "tools" metadata
+		// add it to the list of parsed metadata records
+		if (PromptTools.isToolsRecord(token)) {
+			this.metadata.push(
+				new PromptTools(token),
+			);
+
+			this.recordNames.add(recordName);
+
+			return;
+		}
+
+		// all other records are currently not supported
+		this.issues.push(
+			new PromptMetadataWarning(
+				token.range,
+				localize2(
+					'prompt.header.metadata.diagnostics.unknown-record',
+					"Unknown metadata record '{0}' will be ignored.",
+					recordName,
+				),
+			),
+		);
+	}
+
+	/**
+	 * Process errors from the underlying front matter decoder.
+	 */
+	private onError(error: Error): void {
+		this.issues.push(
+			new PromptMetadataError(
+				this.contentsToken.range,
+				localize2(
+					'prompt.header.diagnostics.parsing-error',
+					"Failed to parse prompt header: {0}",
+					error.message,
+				),
+			),
+		);
+	}
+
+	/**
+	 * Promise that resolves when parsing process of
+	 * the prompt header completes.
+	 */
+	public get settled(): Promise<void> {
+		return this.stream.settled;
+	}
+
+	/**
+	 * Starts the parsing process of the prompt header.
+	 */
+	public start(): this {
+		this.stream.start();
+
+		return this;
+	}
+}

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/promptHeader/metadata/metadataToken.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/promptHeader/metadata/metadataToken.ts
@@ -1,0 +1,18 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { PromptMetadataDiagnostic } from '../diagnostics.js';
+import { FrontMatterToken } from '../../../../../../../../editor/common/codecs/frontMatterCodec/tokens/index.js';
+
+/**
+ * Abstract class for all metadata records in the prompt header.
+ */
+// TODO: @legomushroom - can drop the extension of `FrontMatterToken`?
+export abstract class PromptMetadataToken extends FrontMatterToken {
+	/**
+	 * List of diagnostic objects related to this metadata record.
+	 */
+	abstract readonly diagnostics: readonly PromptMetadataDiagnostic[];
+}

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/promptHeader/metadata/record.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/promptHeader/metadata/record.ts
@@ -4,15 +4,21 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { PromptMetadataDiagnostic } from '../diagnostics.js';
-import { FrontMatterToken } from '../../../../../../../../editor/common/codecs/frontMatterCodec/tokens/index.js';
+import { Range } from '../../../../../../../../editor/common/core/range.js';
 
 /**
  * Abstract class for all metadata records in the prompt header.
  */
-// TODO: @legomushroom - can drop the extension of `FrontMatterToken`?
-export abstract class PromptMetadataToken extends FrontMatterToken {
+export abstract class PromptMetadataRecord {
 	/**
 	 * List of diagnostic objects related to this metadata record.
 	 */
 	abstract readonly diagnostics: readonly PromptMetadataDiagnostic[];
+
+	constructor(
+		/**
+		 * Full range of the metadata's record text in the prompt header.
+		 */
+		public readonly range: Range,
+	) { }
 }

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/promptHeader/metadata/record.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/promptHeader/metadata/record.ts
@@ -3,8 +3,8 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { PromptMetadataDiagnostic } from '../diagnostics.js';
 import { Range } from '../../../../../../../../editor/common/core/range.js';
+import { PromptMetadataDiagnostic, PromptMetadataError, PromptMetadataWarning } from '../diagnostics.js';
 
 /**
  * Abstract class for all metadata records in the prompt header.
@@ -21,4 +21,24 @@ export abstract class PromptMetadataRecord {
 		 */
 		public readonly range: Range,
 	) { }
+
+	/**
+	 * List of all `error` issue diagnostics.
+	 */
+	public get errorDiagnostics(): readonly PromptMetadataError[] {
+		return this.diagnostics
+			.filter((diagnostic) => {
+				return (diagnostic instanceof PromptMetadataError);
+			});
+	}
+
+	/**
+	 * List of all `warning` issue diagnostics.
+	 */
+	public get warningDiagnostics(): readonly PromptMetadataWarning[] {
+		return this.diagnostics
+			.filter((diagnostic) => {
+				return (diagnostic instanceof PromptMetadataWarning);
+			});
+	}
 }

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/promptHeader/metadata/tools.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/promptHeader/metadata/tools.ts
@@ -1,0 +1,182 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { PromptMetadataToken } from './metadataToken.js';
+import { localize2 } from '../../../../../../../../nls.js';
+import { assert } from '../../../../../../../../base/common/assert.js';
+import { PromptMetadataDiagnostic, PromptMetadataError, PromptMetadataWarning } from '../diagnostics.js';
+import { FrontMatterArray, FrontMatterRecord, FrontMatterString, FrontMatterToken, FrontMatterValueToken } from '../../../../../../../../editor/common/codecs/frontMatterCodec/tokens/index.js';
+
+/**
+ * Name of the `tools` metadata record in the prompt header.
+ */
+const TOOLS_NAME = 'tools';
+
+/**
+ * Prompt `tools` metadata record inside the prompt header.
+ */
+export class PromptTools extends PromptMetadataToken {
+	/**
+	 * Private field for tracking all diagnostic issues
+	 * related to this metadata record.
+	 */
+	private readonly issues: PromptMetadataDiagnostic[];
+
+	/**
+	 * List of all diagnostic issues related to this metadata record.
+	 */
+	public get diagnostics(): readonly PromptMetadataDiagnostic[] {
+		return this.issues;
+	}
+
+	/**
+	 * List of all valid tool names that were found in
+	 * this metadata record.
+	 */
+	private validToolNames: Set<string>;
+
+	/**
+	 * List of all valid tool names that were found in
+	 * this metadata record.
+	 */
+	public get toolNames(): readonly string[] {
+		return [...this.validToolNames.values()];
+	}
+
+	constructor(
+		private readonly recordToken: FrontMatterRecord,
+	) {
+		// sanity check on the name of the tools record
+		assert(
+			PromptTools.isToolsRecord(recordToken),
+			`Record token must be a tools token, got '${recordToken.nameToken.text}'.`,
+		);
+
+		super(recordToken.range);
+
+		this.issues = [];
+		this.validToolNames = new Set<string>();
+		this.collectDiagnostics();
+	}
+
+	/**
+	 * Validate the metadata record and collect all issues
+	 * related to its content.
+	 */
+	private collectDiagnostics(): void {
+		const { valueToken } = this.recordToken;
+
+		// validate that the record value is an array
+		if ((valueToken instanceof FrontMatterArray) === false) {
+			this.issues.push(
+				new PromptMetadataError(
+					valueToken.range,
+					localize2(
+						'prompt.header.metadata.tools.diagnostics.invalid-value-type',
+						"Value of the '{0}' metadata must be '{1}', got '{2}.",
+						TOOLS_NAME,
+						'array',
+						valueToken.valueTypeName,
+					),
+				),
+			);
+
+			return;
+		}
+
+		const arrayValue: FrontMatterArray = valueToken;
+
+		// validate that all array items
+		for (const item of arrayValue.items) {
+			this.validateToolName(item);
+		}
+	}
+
+	/**
+	 * Validate an individual provided value token that
+	 * is used for a tool name.
+	 */
+	private validateToolName(
+		valueToken: FrontMatterValueToken,
+	): void {
+		// tool name must be a string
+		if ((valueToken instanceof FrontMatterString) === false) {
+			this.issues.push(
+				new PromptMetadataError(
+					valueToken.range,
+					localize2(
+						'prompt.header.metadata.tools.diagnostics.invalid-tool-name-type',
+						"Expected a tool name ({0}), got '{2}'.",
+						'string',
+						valueToken.text,
+					),
+				),
+			);
+
+			return;
+		}
+
+		const cleanToolName = valueToken.cleanText.trim();
+		// the tool name should not be empty
+		if (cleanToolName.length === 0) {
+			this.issues.push(
+				new PromptMetadataWarning(
+					valueToken.range,
+					localize2(
+						'prompt.header.metadata.tools.diagnostics.empty-tool-name',
+						"Tool name cannot be empty.",
+					),
+				),
+			);
+
+			return;
+		}
+
+		// the tool name should not be duplicated
+		if (this.validToolNames.has(cleanToolName)) {
+			this.issues.push(
+				new PromptMetadataWarning(
+					valueToken.range,
+					localize2(
+						'prompt.header.metadata.tools.diagnostics.duplicate-tool-name',
+						"Duplicate tool name {0}.",
+						cleanToolName,
+					),
+				),
+			);
+
+			return;
+		}
+
+		// collect all valid tool names
+		this.validToolNames.add(cleanToolName);
+	}
+
+	/**
+	 * Check if a provided front matter token is a metadata record
+	 * with name equal to `tools`.
+	 */
+	public static isToolsRecord(
+		token: FrontMatterToken,
+	): boolean {
+		if ((token instanceof FrontMatterRecord) === false) {
+			return false;
+		}
+
+		if (token.nameToken.text === TOOLS_NAME) {
+			return true;
+		}
+
+		return false;
+	}
+
+	public override get text(): string {
+		return this.recordToken.text;
+	}
+
+	public override toString(): string {
+		return `prompt - tools(${this.shortText()})${this.range}`;
+	}
+}

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/promptHeader/metadata/tools.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/promptHeader/metadata/tools.ts
@@ -45,13 +45,6 @@ export class PromptToolsMetadata extends PromptMetadataRecord {
 		return [...this.validToolNames.values()];
 	}
 
-	/**
-	 * TODO: @legomushroom
-	 */
-	public get validValueType(): readonly string[] {
-		return [...this.validToolNames.values()];
-	}
-
 	constructor(
 		private readonly recordToken: FrontMatterRecord,
 	) {

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/promptHeader/metadata/tools.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/promptHeader/metadata/tools.ts
@@ -17,7 +17,7 @@ const TOOLS_NAME = 'tools';
 /**
  * Prompt `tools` metadata record inside the prompt header.
  */
-export class PromptTools extends PromptMetadataRecord {
+export class PromptToolsMetadata extends PromptMetadataRecord {
 	/**
 	 * Private field for tracking all diagnostic issues
 	 * related to this metadata record.
@@ -45,12 +45,19 @@ export class PromptTools extends PromptMetadataRecord {
 		return [...this.validToolNames.values()];
 	}
 
+	/**
+	 * TODO: @legomushroom
+	 */
+	public get validValueType(): readonly string[] {
+		return [...this.validToolNames.values()];
+	}
+
 	constructor(
 		private readonly recordToken: FrontMatterRecord,
 	) {
 		// sanity check on the name of the tools record
 		assert(
-			PromptTools.isToolsRecord(recordToken),
+			PromptToolsMetadata.isToolsRecord(recordToken),
 			`Record token must be a tools token, got '${recordToken.nameToken.text}'.`,
 		);
 
@@ -104,7 +111,7 @@ export class PromptTools extends PromptMetadataRecord {
 		// tool name must be a string
 		if ((valueToken instanceof FrontMatterString) === false) {
 			this.issues.push(
-				new PromptMetadataError(
+				new PromptMetadataWarning(
 					valueToken.range,
 					localize2(
 						'prompt.header.metadata.tools.diagnostics.invalid-tool-name-type',

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/promptHeader/metadata/tools.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/promptHeader/metadata/tools.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { PromptMetadataToken } from './metadataToken.js';
+import { PromptMetadataRecord } from './record.js';
 import { localize2 } from '../../../../../../../../nls.js';
 import { assert } from '../../../../../../../../base/common/assert.js';
 import { PromptMetadataDiagnostic, PromptMetadataError, PromptMetadataWarning } from '../diagnostics.js';
@@ -17,7 +17,7 @@ const TOOLS_NAME = 'tools';
 /**
  * Prompt `tools` metadata record inside the prompt header.
  */
-export class PromptTools extends PromptMetadataToken {
+export class PromptTools extends PromptMetadataRecord {
 	/**
 	 * Private field for tracking all diagnostic issues
 	 * related to this metadata record.
@@ -170,13 +170,5 @@ export class PromptTools extends PromptMetadataToken {
 		}
 
 		return false;
-	}
-
-	public override get text(): string {
-		return this.recordToken.text;
-	}
-
-	public override toString(): string {
-		return `prompt - tools(${this.shortText()})${this.range}`;
 	}
 }

--- a/src/vs/workbench/contrib/chat/test/common/promptSyntax/parsers/textModelPromptParser.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/promptSyntax/parsers/textModelPromptParser.test.ts
@@ -125,7 +125,7 @@ suite('TextModelPromptParser', () => {
 		);
 	};
 
-	test('core logic #1', async () => {
+	test('• core logic #1', async () => {
 		const test = createTest(
 			createURI('/foo/bar.md'),
 			[
@@ -136,11 +136,11 @@ suite('TextModelPromptParser', () => {
 				/* 05 */"Sometimes, the best code is the one you never have to write.",
 				/* 06 */"A lone kangaroo once hopped into the local cafe, seeking free Wi-Fi.",
 				/* 07 */"Critical #file:./folder/binary.file thinking is like coffee; best served strong [md link](/etc/hosts/random-file.txt) and without sugar.",
-				/* 08 */"Music is the mind’s way of doodling in the air.",
+				/* 08 */"Music is the mind's way of doodling in the air.",
 				/* 09 */"Stargazing is just turning your eyes into cosmic explorers.",
 				/* 10 */"Never trust a balloon salesman who hates birthdays.",
 				/* 11 */"Running backward can be surprisingly enlightening.",
-				/* 12 */"There’s an art to whispering loudly.",
+				/* 12 */"There's an art to whispering loudly.",
 			],
 		);
 
@@ -175,7 +175,7 @@ suite('TextModelPromptParser', () => {
 		]);
 	});
 
-	test('core logic #2', async () => {
+	test('• core logic #2', async () => {
 		const test = createTest(
 			createURI('/absolute/folder/and/a/filename.txt'),
 			[
@@ -300,7 +300,7 @@ suite('TextModelPromptParser', () => {
 		});
 	});
 
-	test('gets disposed with the model', async () => {
+	test('• gets disposed with the model', async () => {
 		const test = createTest(
 			createURI('/some/path/file.prompt.md'),
 			[
@@ -321,7 +321,7 @@ suite('TextModelPromptParser', () => {
 		);
 	});
 
-	test('toString() implementation', async () => {
+	test('• toString() implementation', async () => {
 		const modelUri = createURI('/Users/legomushroom/repos/prompt-snippets/README.md');
 		const test = createTest(
 			modelUri,

--- a/src/vs/workbench/contrib/chat/test/common/promptSyntax/promptFileReference.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/promptSyntax/promptFileReference.test.ts
@@ -25,9 +25,9 @@ import { IConfigurationService } from '../../../../../../platform/configuration/
 import { IInstantiationService } from '../../../../../../platform/instantiation/common/instantiation.js';
 import { ConfigurationService } from '../../../../../../platform/configuration/common/configurationService.js';
 import { InMemoryFileSystemProvider } from '../../../../../../platform/files/common/inMemoryFilesystemProvider.js';
+import { IFileContentsProviderOptions } from '../../../common/promptSyntax/contentProviders/filePromptContentsProvider.js';
 import { TestInstantiationService } from '../../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
 import { NotPromptFile, RecursiveReference, OpenFailed, FolderReference } from '../../../common/promptFileReferenceErrors.js';
-import { IFileContentsProviderOptions } from '../../../common/promptSyntax/contentProviders/filePromptContentsProvider.js';
 
 /**
  * Represents a file reference with an expected
@@ -310,7 +310,7 @@ suite('PromptFileReference (Unix)', function () {
 					createTestFileReference('./some-non-existing/file.prompt.md', 1, 30),
 					new OpenFailed(
 						URI.joinPath(rootUri, './folder1/some-other-folder/some-non-existing/file.prompt.md'),
-						'Failed to open non-existring prompt snippets file',
+						'Failed to open non-existing prompt snippets file',
 					),
 				),
 				new ExpectedReference(
@@ -605,7 +605,7 @@ suite('PromptFileReference (Unix)', function () {
 						createTestFileReference('./some-non-existing/file.prompt.md', 1, 30),
 						new OpenFailed(
 							URI.joinPath(rootUri, './folder1/some-other-folder/some-non-existing/file.prompt.md'),
-							'Failed to open non-existring prompt snippets file',
+							'Failed to open non-existing prompt snippets file',
 						),
 					),
 					new ExpectedReference(


### PR DESCRIPTION
Adds logic to parse list of `tools` inside a prompt header.

Part of https://github.com/microsoft/vscode-copilot/issues/15596, https://github.com/microsoft/vscode-copilot/issues/15420 and https://github.com/microsoft/vscode-copilot/issues/12203