### PR TITLE
[prompts]: add diagnostics support for the 'tools' metadata in prompt file headers

### DIFF
--- a/src/vs/workbench/contrib/chat/common/promptSyntax/languageFeatures/providers/index.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/languageFeatures/providers/index.ts
@@ -9,6 +9,7 @@ import { PromptPathAutocompletion } from './promptPathAutocompletion.js';
 import { Registry } from '../../../../../../../platform/registry/common/platform.js';
 import { LifecyclePhase } from '../../../../../../services/lifecycle/common/lifecycle.js';
 import { PromptLinkDiagnosticsInstanceManager } from './promptLinkDiagnosticsProvider.js';
+import { PromptHeaderDiagnosticsInstanceManager } from './promptHeaderDiagnosticsProvider.js';
 import { BrandedService } from '../../../../../../../platform/instantiation/common/instantiation.js';
 import { PromptDecorationsProviderInstanceManager } from './decorationsProvider/promptDecorationsProvider.js';
 import { IWorkbenchContributionsRegistry, Extensions, IWorkbenchContribution } from '../../../../../../common/contributions.js';
@@ -24,6 +25,7 @@ export const DECORATIONS_ENABLED = false;
 export const registerReusablePromptLanguageFeatures = () => {
 	registerContribution(PromptLinkProvider);
 	registerContribution(PromptLinkDiagnosticsInstanceManager);
+	registerContribution(PromptHeaderDiagnosticsInstanceManager);
 
 	if (DECORATIONS_ENABLED) {
 		registerContribution(PromptDecorationsProviderInstanceManager);

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/languageFeatures/providers/promptHeaderDiagnosticsProvider.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/languageFeatures/providers/promptHeaderDiagnosticsProvider.ts
@@ -1,0 +1,107 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IPromptsService } from '../../service/types.js';
+import { ProviderInstanceBase } from './providerInstanceBase.js';
+import { assertNever } from '../../../../../../../base/common/assert.js';
+import { ITextModel } from '../../../../../../../editor/common/model.js';
+import { ProviderInstanceManagerBase } from './providerInstanceManagerBase.js';
+import { TDiagnostic, PromptMetadataError, PromptMetadataWarning } from '../../parsers/promptHeader/diagnostics.js';
+import { IMarkerData, IMarkerService, MarkerSeverity } from '../../../../../../../platform/markers/common/markers.js';
+
+/**
+ * Unique ID of the markers provider class.
+ */
+const MARKERS_OWNER_ID = 'prompts-header-diagnostics-provider';
+
+/**
+ * Prompt header diagnostics provider for an individual text model
+ * of a prompt file.
+ */
+class PromptHeaderDiagnosticsProvider extends ProviderInstanceBase {
+	constructor(
+		model: ITextModel,
+		@IPromptsService promptsService: IPromptsService,
+		@IMarkerService private readonly markerService: IMarkerService,
+	) {
+		super(model, promptsService);
+	}
+
+	/**
+	 * Update diagnostic markers for the current editor.
+	 */
+	protected override async onPromptParserUpdate(): Promise<this> {
+		// ensure that parsing process is settled
+		await this.parser.allSettled();
+
+		// clean up all previously added markers
+		this.markerService.remove(MARKERS_OWNER_ID, [this.model.uri]);
+
+		const { header } = this.parser;
+
+		if (header === undefined) {
+			return this;
+		}
+
+		const markers: IMarkerData[] = [];
+		for (const link of header.diagnostics) {
+			markers.push(toMarker(link));
+		}
+
+		this.markerService.changeOne(
+			MARKERS_OWNER_ID,
+			this.model.uri,
+			markers,
+		);
+
+		return this;
+	}
+
+	/**
+	 * Returns a string representation of this object.
+	 */
+	public override toString() {
+		return `prompt-link-diagnostics:${this.model.uri.path}`;
+	}
+}
+
+/**
+ * Convert a provided diagnostic object into a marker data object.
+ */
+const toMarker = (
+	diagnostic: TDiagnostic,
+): IMarkerData => {
+	if (diagnostic instanceof PromptMetadataWarning) {
+		return {
+			message: diagnostic.message.toString(),
+			severity: MarkerSeverity.Warning,
+			...diagnostic.range,
+		};
+	}
+
+	if (diagnostic instanceof PromptMetadataError) {
+		return {
+			message: diagnostic.message.toString(),
+			severity: MarkerSeverity.Error,
+			...diagnostic.range,
+		};
+	}
+
+
+	assertNever(
+		diagnostic,
+		`Unknown prompt metadata diagnostic type '${diagnostic}'.`,
+	);
+};
+
+/**
+ * The class that manages creation and disposal of {@link PromptHeaderDiagnosticsProvider}
+ * classes for each specific editor text model.
+ */
+export class PromptHeaderDiagnosticsInstanceManager extends ProviderInstanceManagerBase<PromptHeaderDiagnosticsProvider> {
+	protected override get InstanceClass() {
+		return PromptHeaderDiagnosticsProvider;
+	}
+}

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/languageFeatures/providers/promptHeaderDiagnosticsProvider.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/languageFeatures/providers/promptHeaderDiagnosticsProvider.ts
@@ -75,7 +75,7 @@ const toMarker = (
 ): IMarkerData => {
 	if (diagnostic instanceof PromptMetadataWarning) {
 		return {
-			message: diagnostic.message.toString(),
+			message: diagnostic.message,
 			severity: MarkerSeverity.Warning,
 			...diagnostic.range,
 		};
@@ -83,7 +83,7 @@ const toMarker = (
 
 	if (diagnostic instanceof PromptMetadataError) {
 		return {
-			message: diagnostic.message.toString(),
+			message: diagnostic.message,
 			severity: MarkerSeverity.Error,
 			...diagnostic.range,
 		};

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/basePromptParser.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/basePromptParser.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { TopError } from './topError.js';
+import { PromptHeader } from './promptHeader/header.js';
 import { URI } from '../../../../../../base/common/uri.js';
 import { PromptToken } from '../codecs/tokens/promptToken.js';
 import { ChatPromptCodec } from '../codecs/chatPromptCodec.js';
@@ -29,7 +30,6 @@ import { MarkdownLink } from '../../../../../../editor/common/codecs/markdownCod
 import { MarkdownToken } from '../../../../../../editor/common/codecs/markdownCodec/tokens/markdownToken.js';
 import { OpenFailed, NotPromptFile, RecursiveReference, FolderReference, ResolveError } from '../../promptFileReferenceErrors.js';
 import { FrontMatterHeader } from '../../../../../../editor/common/codecs/markdownExtensionsCodec/tokens/frontMatterHeader.js';
-import { PromptHeader } from './promptHeader/header.js';
 
 /**
  * Error conditions that may happen during the file reference resolution.

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/promptHeader/diagnostics.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/promptHeader/diagnostics.ts
@@ -3,7 +3,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ILocalizedString } from '../../../../../../../nls.js';
 import { Range } from '../../../../../../../editor/common/core/range.js';
 
 /**
@@ -18,18 +17,31 @@ export type TDiagnostic = PromptMetadataWarning | PromptMetadataError;
 export abstract class PromptMetadataDiagnostic {
 	constructor(
 		public readonly range: Range,
-		public readonly message: string | ILocalizedString,
+		public readonly message: string,
 	) { }
+
+	/**
+	 * String representation of the diagnostic object.
+	 */
+	public abstract toString(): string;
 }
 
 /**
  * Diagnostics object that hold information about some
  * non-fatal issue related to the prompt header metadata.
  */
-export class PromptMetadataWarning extends PromptMetadataDiagnostic { }
+export class PromptMetadataWarning extends PromptMetadataDiagnostic {
+	public override toString(): string {
+		return `warning(${this.message})${this.range}`;
+	}
+}
 
 /**
  * Diagnostics object that hold information about some
  * fatal issue related to the prompt header metadata.
  */
-export class PromptMetadataError extends PromptMetadataDiagnostic { }
+export class PromptMetadataError extends PromptMetadataDiagnostic {
+	public override toString(): string {
+		return `error(${this.message})${this.range}`;
+	}
+}

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/promptHeader/header.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/promptHeader/header.ts
@@ -3,8 +3,8 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { localize } from '../../../../../../../nls.js';
 import { PromptToolsMetadata } from './metadata/tools.js';
-import { localize2 } from '../../../../../../../nls.js';
 import { Disposable } from '../../../../../../../base/common/lifecycle.js';
 import { Text } from '../../../../../../../editor/common/codecs/baseToken.js';
 import { PromptMetadataError, PromptMetadataWarning, TDiagnostic } from './diagnostics.js';
@@ -56,17 +56,7 @@ export class PromptHeader extends Disposable {
 	 * the prompt header.
 	 */
 	public get diagnostics(): readonly TDiagnostic[] {
-		const result = [];
-
-		// collect all issue of the metadata records
-		for (const metadata of this.records) {
-			result.push(...metadata.diagnostics);
-		}
-
-		// then add all issues from this header object itself
-		result.push(...this.issues);
-
-		return result;
+		return this.issues;
 	}
 
 	constructor(
@@ -104,7 +94,7 @@ export class PromptHeader extends Disposable {
 			this.issues.push(
 				new PromptMetadataError(
 					token.range,
-					localize2(
+					localize(
 						'prompt.header.diagnostics.unexpected-token',
 						"Unexpected token '{0}'.",
 						token.text,
@@ -123,7 +113,7 @@ export class PromptHeader extends Disposable {
 			this.issues.push(
 				new PromptMetadataWarning(
 					token.range,
-					localize2(
+					localize(
 						'prompt.header.metadata.diagnostics.duplicate-record',
 						"Duplicate metadata record '{0}' will be ignored.",
 						recordName,
@@ -138,15 +128,9 @@ export class PromptHeader extends Disposable {
 		// add it to the list of parsed metadata records
 		if (PromptToolsMetadata.isToolsRecord(token)) {
 			const toolsMetadata = new PromptToolsMetadata(token);
-			const { errorDiagnostics } = toolsMetadata;
+			const { diagnostics } = toolsMetadata;
 
-			// if tools metadata is not valid, copy its error
-			// diagnostic objects and ignore the record
-			if (errorDiagnostics.length !== 0) {
-				this.issues.push(...errorDiagnostics);
-				return;
-			}
-
+			this.issues.push(...diagnostics);
 			this.records.push(toolsMetadata);
 			this.recordNames.add(recordName);
 
@@ -157,7 +141,7 @@ export class PromptHeader extends Disposable {
 		this.issues.push(
 			new PromptMetadataWarning(
 				token.range,
-				localize2(
+				localize(
 					'prompt.header.metadata.diagnostics.unknown-record',
 					"Unknown metadata record '{0}' will be ignored.",
 					recordName,
@@ -173,7 +157,7 @@ export class PromptHeader extends Disposable {
 		this.issues.push(
 			new PromptMetadataError(
 				this.contentsToken.range,
-				localize2(
+				localize(
 					'prompt.header.diagnostics.parsing-error',
 					"Failed to parse prompt header: {0}",
 					error.message,

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/promptHeader/metadata/tools.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/promptHeader/metadata/tools.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { PromptMetadataRecord } from './record.js';
-import { localize2 } from '../../../../../../../../nls.js';
+import { localize } from '../../../../../../../../nls.js';
 import { assert } from '../../../../../../../../base/common/assert.js';
 import { PromptMetadataDiagnostic, PromptMetadataError, PromptMetadataWarning } from '../diagnostics.js';
 import { FrontMatterArray, FrontMatterRecord, FrontMatterString, FrontMatterToken, FrontMatterValueToken } from '../../../../../../../../editor/common/codecs/frontMatterCodec/tokens/index.js';
@@ -73,7 +73,7 @@ export class PromptToolsMetadata extends PromptMetadataRecord {
 			this.issues.push(
 				new PromptMetadataError(
 					valueToken.range,
-					localize2(
+					localize(
 						'prompt.header.metadata.tools.diagnostics.invalid-value-type',
 						"Value of the '{0}' metadata must be '{1}', got '{2}.",
 						TOOLS_NAME,
@@ -106,9 +106,9 @@ export class PromptToolsMetadata extends PromptMetadataRecord {
 			this.issues.push(
 				new PromptMetadataWarning(
 					valueToken.range,
-					localize2(
+					localize(
 						'prompt.header.metadata.tools.diagnostics.invalid-tool-name-type',
-						"Expected a tool name ({0}), got '{2}'.",
+						"Expected a tool name ({0}), got '{1}'.",
 						'string',
 						valueToken.text,
 					),
@@ -124,7 +124,7 @@ export class PromptToolsMetadata extends PromptMetadataRecord {
 			this.issues.push(
 				new PromptMetadataWarning(
 					valueToken.range,
-					localize2(
+					localize(
 						'prompt.header.metadata.tools.diagnostics.empty-tool-name',
 						"Tool name cannot be empty.",
 					),
@@ -139,9 +139,9 @@ export class PromptToolsMetadata extends PromptMetadataRecord {
 			this.issues.push(
 				new PromptMetadataWarning(
 					valueToken.range,
-					localize2(
+					localize(
 						'prompt.header.metadata.tools.diagnostics.duplicate-tool-name',
-						"Duplicate tool name {0}.",
+						"Duplicate tool name '{0}'.",
 						cleanToolName,
 					),
 				),

--- a/src/vs/workbench/contrib/chat/test/common/promptSyntax/parsers/textModelPromptParser.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/promptSyntax/parsers/textModelPromptParser.test.ts
@@ -18,10 +18,10 @@ import { randomBoolean } from '../../../../../../../base/test/common/testUtils.j
 import { FileService } from '../../../../../../../platform/files/common/fileService.js';
 import { createTextModel } from '../../../../../../../editor/test/common/testTextModel.js';
 import { ILogService, NullLogService } from '../../../../../../../platform/log/common/log.js';
+import { ExpectedDiagnosticWarning, TExpectedDiagnostic } from '../testUtils/expectedDiagnostic.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../../base/test/common/utils.js';
 import { TextModelPromptParser } from '../../../../common/promptSyntax/parsers/textModelPromptParser.js';
 import { IInstantiationService } from '../../../../../../../platform/instantiation/common/instantiation.js';
-import { PromptMetadataWarning } from '../../../../common/promptSyntax/parsers/promptHeader/diagnostics.js';
 import { PromptToolsMetadata } from '../../../../common/promptSyntax/parsers/promptHeader/metadata/tools.js';
 import { InMemoryFileSystemProvider } from '../../../../../../../platform/files/common/inMemoryFilesystemProvider.js';
 import { TestInstantiationService } from '../../../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
@@ -96,6 +96,39 @@ class TextModelPromptParserTest extends Disposable {
 			expectedReferences.length,
 			references.length,
 			`[${this.model.uri}] Unexpected number of references.`,
+		);
+	}
+
+	/**
+	 * Validate list of diagnostic objects of the prompt header.
+	 */
+	public async validateHeaderDiagnostics(
+		expectedDiagnostics: readonly TExpectedDiagnostic[],
+	) {
+		await this.parser.allSettled();
+
+		const { header } = this.parser;
+		assertDefined(
+			header,
+			'Prompt header must be defined.',
+		);
+		const { diagnostics } = header;
+
+		for (let i = 0; i < expectedDiagnostics.length; i++) {
+			const diagnostic = diagnostics[i];
+
+			assertDefined(
+				diagnostic,
+				`Expected diagnostic #${i} be ${expectedDiagnostics[i]}, got 'undefined'.`,
+			);
+
+			expectedDiagnostics[i].validateEqual(diagnostic);
+		}
+
+		assert.strictEqual(
+			expectedDiagnostics.length,
+			diagnostics.length,
+			`Expected '${expectedDiagnostics.length}' diagnostic objects, got '${diagnostics.length}'.`,
 		);
 	}
 }
@@ -349,188 +382,40 @@ suite('TextModelPromptParser', () => {
 				`Prompt header must have tools metadata record, got '${tools}'.`,
 			);
 
-			const { diagnostics } = header;
-
-			const diagnostics1 = diagnostics[0];
-			const expectedRange1 = new Range(2, 2, 2, 2 + 15);
-
-			assert(
-				diagnostics1 instanceof PromptMetadataWarning,
-				`Expected diagnostic object #1 to be of 'warning' type, got '${diagnostics1}'.`,
-			);
-
-			assert(
-				diagnostics1
-					.range
-					.equalsRange(expectedRange1),
-				`Expected diagnostic #1 range to be '${expectedRange1}', got '${diagnostics1.range}'.`,
-			);
-
-			assert.strictEqual(
-				diagnostics1.message,
-				'Unknown metadata record \'something\' will be ignored.',
-				`Incorrect message of diagnostic object #1.`,
-			);
-
-			const diagnostics2 = diagnostics[1];
-			const expectedRange2 = new Range(3, 38, 3, 38 + 12);
-
-			assert(
-				diagnostics2 instanceof PromptMetadataWarning,
-				`Expected diagnostic object #2 to be of 'warning' type, got '${diagnostics2}'.`,
-			);
-
-			assert(
-				diagnostics2
-					.range
-					.equalsRange(expectedRange2),
-				`Expected diagnostic #2 range to be '${expectedRange2}', got '${diagnostics2.range}'.`,
-			);
-
-			assert.strictEqual(
-				diagnostics2.message,
-				'Duplicate tool name \'tool_name1\'.',
-				`Incorrect message of diagnostic object #2.`,
-			);
-
-			const diagnostics3 = diagnostics[2];
-			const expectedRange3 = new Range(3, 52, 3, 52 + 4);
-
-			assert(
-				diagnostics3 instanceof PromptMetadataWarning,
-				`Expected diagnostic object #3 to be of 'warning' type, got '${diagnostics3}'.`,
-			);
-
-			assert(
-				diagnostics3
-					.range
-					.equalsRange(expectedRange3),
-				`Expected diagnostic #3 range to be '${expectedRange3}', got '${diagnostics3.range}'.`,
-			);
-
-			assert.strictEqual(
-				diagnostics3.message,
-				'Expected a tool name (string), got \'true\'.',
-				`Incorrect message of diagnostic object #3.`,
-			);
-
-
-			const diagnostics4 = diagnostics[3];
-			const expectedRange4 = new Range(3, 58, 3, 58 + 5);
-
-			assert(
-				diagnostics4 instanceof PromptMetadataWarning,
-				`Expected diagnostic object #4 to be of 'warning' type, got '${diagnostics4}'.`,
-			);
-
-			assert(
-				diagnostics4
-					.range
-					.equalsRange(expectedRange4),
-				`Expected diagnostic #4 range to be '${expectedRange4}', got '${diagnostics4.range}'.`,
-			);
-
-			assert.strictEqual(
-				diagnostics4.message,
-				'Expected a tool name (string), got \'false\'.',
-				`Incorrect message of diagnostic object #4.`,
-			);
-
-
-			const diagnostics5 = diagnostics[4];
-			const expectedRange5 = new Range(3, 65, 3, 65 + 2);
-
-			assert(
-				diagnostics5 instanceof PromptMetadataWarning,
-				`Expected diagnostic object #5 to be of 'warning' type, got '${diagnostics5}'.`,
-			);
-
-			assert(
-				diagnostics5
-					.range
-					.equalsRange(expectedRange5),
-				`Expected diagnostic #5 range to be '${expectedRange5}', got '${diagnostics5.range}'.`,
-			);
-
-			assert.strictEqual(
-				diagnostics5.message,
-				'Tool name cannot be empty.',
-				`Incorrect message of diagnostic object #5.`,
-			);
-
-
-			const diagnostics6 = diagnostics[5];
-			const expectedRange6 = new Range(3, 70, 3, 70 + 12);
-
-			assert.strictEqual(
-				diagnostics6.message,
-				'Duplicate tool name \'tool_name2\'.',
-				`Incorrect message of diagnostic object #6.`,
-			);
-
-			assert(
-				diagnostics6 instanceof PromptMetadataWarning,
-				`Expected diagnostic object #6 to be of 'warning' type, got '${diagnostics6}'.`,
-			);
-
-			assert(
-				diagnostics6
-					.range
-					.equalsRange(expectedRange6),
-				`Expected diagnostic #6 range to be '${expectedRange6}', got '${diagnostics6.range}'.`,
-			);
-
-
-			const diagnostics7 = diagnostics[6];
-			const expectedRange7 = new Range(4, 3, 4, 3 + 37);
-
-			assert.strictEqual(
-				diagnostics7.message,
-				'Duplicate metadata record \'tools\' will be ignored.',
-				`Incorrect message of diagnostic object #7.`,
-			);
-
-			assert(
-				diagnostics7 instanceof PromptMetadataWarning,
-				`Expected diagnostic object #7 to be of 'warning' type, got '${diagnostics7}'.`,
-			);
-
-			assert(
-				diagnostics7
-					.range
-					.equalsRange(expectedRange7),
-				`Expected diagnostic #7 range to be '${expectedRange7}', got '${diagnostics7.range}'.`,
-			);
-
-
-
-			const diagnostics8 = diagnostics[7];
-			const expectedRange8 = new Range(5, 1, 5, 1 + 19);
-
-			assert.strictEqual(
-				diagnostics8.message,
-				'Duplicate metadata record \'tools\' will be ignored.',
-				`Incorrect message of diagnostic object #8.`,
-			);
-
-			assert(
-				diagnostics8 instanceof PromptMetadataWarning,
-				`Expected diagnostic object #8 to be of 'warning' type, got '${diagnostics8}'.`,
-			);
-
-			assert(
-				diagnostics8
-					.range
-					.equalsRange(expectedRange8),
-				`Expected diagnostic #8 range to be '${expectedRange8}', got '${diagnostics8.range}'.`,
-			);
-
-
-			assert.strictEqual(
-				diagnostics.length,
-				8,
-				`Prompt header must have correct number of diagnostic objects.`,
-			);
+			await test.validateHeaderDiagnostics([
+				new ExpectedDiagnosticWarning(
+					new Range(2, 2, 2, 2 + 15),
+					'Unknown metadata record \'something\' will be ignored.',
+				),
+				new ExpectedDiagnosticWarning(
+					new Range(3, 38, 3, 38 + 12),
+					'Duplicate tool name \'tool_name1\'.',
+				),
+				new ExpectedDiagnosticWarning(
+					new Range(3, 52, 3, 52 + 4),
+					'Expected a tool name (string), got \'true\'.',
+				),
+				new ExpectedDiagnosticWarning(
+					new Range(3, 58, 3, 58 + 5),
+					'Expected a tool name (string), got \'false\'.',
+				),
+				new ExpectedDiagnosticWarning(
+					new Range(3, 65, 3, 65 + 2),
+					'Tool name cannot be empty.',
+				),
+				new ExpectedDiagnosticWarning(
+					new Range(3, 70, 3, 70 + 12),
+					'Duplicate tool name \'tool_name2\'.',
+				),
+				new ExpectedDiagnosticWarning(
+					new Range(4, 3, 4, 3 + 37),
+					'Duplicate metadata record \'tools\' will be ignored.',
+				),
+				new ExpectedDiagnosticWarning(
+					new Range(5, 1, 5, 1 + 19),
+					'Duplicate metadata record \'tools\' will be ignored.',
+				),
+			]);
 		});
 	});
 

--- a/src/vs/workbench/contrib/chat/test/common/promptSyntax/testUtils/expectedDiagnostic.ts
+++ b/src/vs/workbench/contrib/chat/test/common/promptSyntax/testUtils/expectedDiagnostic.ts
@@ -23,7 +23,7 @@ abstract class ExpectedDiagnostic extends PromptMetadataDiagnostic {
 			`Expected message '${this.message}', got '${other.message}'.`,
 		);
 
-		assert.strictEqual(
+		assert(
 			this.range
 				.equalsRange(other.range),
 			`Expected range '${this.range}', got '${other.range}'.`,
@@ -58,24 +58,31 @@ abstract class ExpectedDiagnostic extends PromptMetadataDiagnostic {
 			`Unknown diagnostic type '${other}'.`,
 		);
 	}
-
-	/**
-	 * Returns a string representation of this object.
-	 */
-	public toString(): string {
-		return `expected-diagnostic/${this}`;
-	}
 }
 
 /**
  * Expected warning diagnostic object for testing purposes.
  */
-export class ExpectedDiagnosticWarning extends ExpectedDiagnostic { }
+export class ExpectedDiagnosticWarning extends ExpectedDiagnostic {
+	/**
+	 * Returns a string representation of this object.
+	 */
+	public override toString(): string {
+		return `expected-diagnostic/warning(${this.message})${this.range}`;
+	}
+}
 
 /**
  * Expected error diagnostic object for testing purposes.
  */
-export class ExpectedDiagnosticError extends ExpectedDiagnostic { }
+export class ExpectedDiagnosticError extends ExpectedDiagnostic {
+	/**
+	 * Returns a string representation of this object.
+	 */
+	public override toString(): string {
+		return `expected-diagnostic/error(${this.message})${this.range}`;
+	}
+}
 
 /**
  * Type for any expected diagnostic object.

--- a/src/vs/workbench/contrib/chat/test/common/promptSyntax/testUtils/expectedDiagnostic.ts
+++ b/src/vs/workbench/contrib/chat/test/common/promptSyntax/testUtils/expectedDiagnostic.ts
@@ -1,0 +1,83 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { assertNever } from '../../../../../../../base/common/assert.js';
+import { PromptMetadataDiagnostic, PromptMetadataError, PromptMetadataWarning, TDiagnostic } from '../../../../common/promptSyntax/parsers/promptHeader/diagnostics.js';
+
+/**
+ * Base class for all expected diagnostics used in the unit tests.
+ */
+abstract class ExpectedDiagnostic extends PromptMetadataDiagnostic {
+	/**
+	 * Validate that the provided diagnostic is equal to this object.
+	 */
+	public validateEqual(other: TDiagnostic) {
+		this.validateTypesEqual(other);
+
+		assert.strictEqual(
+			this.message,
+			other.message,
+			`Expected message '${this.message}', got '${other.message}'.`,
+		);
+
+		assert.strictEqual(
+			this.range
+				.equalsRange(other.range),
+			`Expected range '${this.range}', got '${other.range}'.`,
+		);
+	}
+
+	/**
+	 * Validate that the provided diagnostic is of the same
+	 * diagnostic type as this object.
+	 */
+	private validateTypesEqual(other: TDiagnostic) {
+		if (other instanceof PromptMetadataWarning) {
+			assert(
+				this instanceof ExpectedDiagnosticWarning,
+				`Expected a warning diagnostic object, got '${other}'.`,
+			);
+
+			return;
+		}
+
+		if (other instanceof PromptMetadataError) {
+			assert(
+				this instanceof ExpectedDiagnosticError,
+				`Expected a error diagnostic object, got '${other}'.`,
+			);
+
+			return;
+		}
+
+		assertNever(
+			other,
+			`Unknown diagnostic type '${other}'.`,
+		);
+	}
+
+	/**
+	 * Returns a string representation of this object.
+	 */
+	public toString(): string {
+		return `expected-diagnostic/${this}`;
+	}
+}
+
+/**
+ * Expected warning diagnostic object for testing purposes.
+ */
+export class ExpectedDiagnosticWarning extends ExpectedDiagnostic { }
+
+/**
+ * Expected error diagnostic object for testing purposes.
+ */
+export class ExpectedDiagnosticError extends ExpectedDiagnostic { }
+
+/**
+ * Type for any expected diagnostic object.
+ */
+export type TExpectedDiagnostic = ExpectedDiagnosticWarning | ExpectedDiagnosticError;


### PR DESCRIPTION
<img width="1840" alt="image" src="https://github.com/user-attachments/assets/f9156abf-721b-4bd7-9020-cf93fd8f3dfb" />


Adds diagnostics support for the 'tools' metadata in prompt file headers.

Part of https://github.com/microsoft/vscode-copilot/issues/15596, https://github.com/microsoft/vscode-copilot/issues/15420 and https://github.com/microsoft/vscode-copilot/issues/12203