### PR TITLE
[prompts]: improve and enable prompt decoration providers

### DIFF
--- a/src/vs/workbench/contrib/chat/common/promptSyntax/languageFeatures/providers/decorationsProvider/decorations/frontMatterDecoration.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/languageFeatures/providers/decorationsProvider/decorations/frontMatterDecoration.ts
@@ -28,7 +28,7 @@ export enum CssClassNames {
  */
 export const BACKGROUND_COLOR: ColorIdentifier = registerColor(
 	'prompt.frontMatter.background',
-	{ dark: darken(editorBackground, 0.2), light: darken(editorBackground, 0.2), hcDark: contrastBorder, hcLight: contrastBorder },
+	{ dark: darken(editorBackground, 0.2), light: darken(editorBackground, 0.05), hcDark: contrastBorder, hcLight: contrastBorder },
 	localize('chat.prompt.frontMatter.background.description', "Background color of a Front Matter header block."),
 );
 
@@ -37,7 +37,7 @@ export const BACKGROUND_COLOR: ColorIdentifier = registerColor(
  */
 export const INACTIVE_BACKGROUND_COLOR: ColorIdentifier = registerColor(
 	'prompt.frontMatter.inactiveBackground',
-	{ dark: darken(editorBackground, 0.1), light: darken(editorBackground, 0.1), hcDark: contrastBorder, hcLight: contrastBorder },
+	{ dark: darken(editorBackground, 0.1), light: darken(editorBackground, 0.025), hcDark: contrastBorder, hcLight: contrastBorder },
 	localize('chat.prompt.frontMatter.inactiveBackground.description', "Background color of an inactive Front Matter header block."),
 );
 

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/languageFeatures/providers/decorationsProvider/decorations/utils/reactiveDecorationBase.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/languageFeatures/providers/decorationsProvider/decorations/utils/reactiveDecorationBase.ts
@@ -71,16 +71,24 @@ export abstract class ReactiveDecorationBase<
 	 * Whether cursor is currently inside the decoration range.
 	 */
 	protected get active(): boolean {
-		if (!this.cursorPosition) {
-			return false;
-		}
+		return true;
 
-		// when cursor is at the end of a range, the range considered to
-		// not contain the position, but we want to include it
-		const atEnd = (this.range.endLineNumber === this.cursorPosition.lineNumber)
-			&& (this.range.endColumn === this.cursorPosition.column);
-
-		return atEnd || this.range.containsPosition(this.cursorPosition);
+		/**
+		 * Temporarily disable until we have a proper way to get
+		 * the cursor position inside active editor.
+		 */
+		/**
+		 * if (!this.cursorPosition) {
+		 * 	return false;
+		 * }
+		 *
+		 * // when cursor is at the end of a range, the range considered to
+		 * // not contain the position, but we want to include it
+		 * const atEnd = (this.range.endLineNumber === this.cursorPosition.lineNumber)
+		 * 	&& (this.range.endColumn === this.cursorPosition.column);
+		 *
+		 * return atEnd || this.range.containsPosition(this.cursorPosition);
+		 */
 	}
 
 	/**

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/languageFeatures/providers/decorationsProvider/promptDecorationsProvider.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/languageFeatures/providers/decorationsProvider/promptDecorationsProvider.ts
@@ -12,7 +12,6 @@ import { ProviderInstanceManagerBase } from '../providerInstanceManagerBase.js';
 import { Position } from '../../../../../../../../editor/common/core/position.js';
 import { BaseToken } from '../../../../../../../../editor/common/codecs/baseToken.js';
 import { registerThemingParticipant } from '../../../../../../../../platform/theme/common/themeService.js';
-import { ITreeSitterParserService } from '../../../../../../../../editor/common/services/treeSitterParserService.js';
 import { FrontMatterHeader } from '../../../../../../../../editor/common/codecs/markdownExtensionsCodec/tokens/frontMatterHeader.js';
 import { DecorationBase, ReactiveDecorationBase, type TDecorationClass, type TChangedDecorator } from './decorations/utils/index.js';
 
@@ -40,7 +39,6 @@ export class PromptDecorator extends ProviderInstanceBase {
 	constructor(
 		model: ITextModel,
 		@IPromptsService promptsService: IPromptsService,
-		@ITreeSitterParserService private readonly parserService: ITreeSitterParserService,
 	) {
 		super(model, promptsService);
 
@@ -51,10 +49,7 @@ export class PromptDecorator extends ProviderInstanceBase {
 		await this.parser.allSettled();
 
 		this.removeAllDecorations();
-		this.addDecorations(this.parser.tokens);
-
-		const result = this.parserService.getOrInitLanguage('test');
-		console.log('result', result);
+		this.addDecorations();
 
 		return this;
 	}
@@ -122,14 +117,14 @@ export class PromptDecorator extends ProviderInstanceBase {
 	/**
 	 * Add a decorations for all prompt tokens.
 	 */
-	private addDecorations(
-		tokens: readonly BaseToken[],
-	): this {
-		if (tokens.length === 0) {
-			return this;
-		}
-
+	private addDecorations(): this {
 		this.model.changeDecorations((accessor) => {
+			const { tokens } = this.parser;
+
+			if (tokens.length === 0) {
+				return;
+			}
+
 			for (const token of tokens) {
 				for (const Decoration of SUPPORTED_DECORATIONS) {
 					if (Decoration.handles(token) === false) {

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/languageFeatures/providers/index.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/languageFeatures/providers/index.ts
@@ -16,7 +16,7 @@ import { IWorkbenchContributionsRegistry, Extensions, IWorkbenchContribution } f
 /**
  * Whether to enable decorations in the prompt editor.
  */
-export const DECORATIONS_ENABLED = false;
+export const DECORATIONS_ENABLED = true;
 
 /**
  * Register all language features related to reusable prompts files.

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/languageFeatures/providers/promptLinkDiagnosticsProvider.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/languageFeatures/providers/promptLinkDiagnosticsProvider.ts
@@ -16,7 +16,7 @@ import { IMarkerData, IMarkerService, MarkerSeverity } from '../../../../../../.
 /**
  * Unique ID of the markers provider class.
  */
-const MARKERS_OWNER_ID = 'reusable-prompts-syntax';
+const MARKERS_OWNER_ID = 'prompt-link-diagnostics-provider';
 
 /**
  * Prompt links diagnostics provider for a single text model.


### PR DESCRIPTION
<img width="1840" alt="image" src="https://github.com/user-attachments/assets/e63a1f9e-874d-40a0-8a83-fb883eedcd9a" />

Improves and re-enables prompt decorations providers.

Part of https://github.com/microsoft/vscode-copilot/issues/15596, https://github.com/microsoft/vscode-copilot/issues/15420 and https://github.com/microsoft/vscode-copilot/issues/12203