### PR TITLE
fix double icons for symbols in chat

### DIFF
--- a/src/vs/workbench/contrib/search/browser/symbolsQuickAccess.ts
+++ b/src/vs/workbench/contrib/search/browser/symbolsQuickAccess.ts
@@ -129,8 +129,6 @@ export class SymbolsQuickAccessProvider extends PickerQuickAccessProvider<ISymbo
 			}
 
 			const symbolLabel = symbol.name;
-			const symbolLabelWithIcon = `$(${SymbolKinds.toIcon(symbol.kind).id}) ${symbolLabel}`;
-			const symbolLabelIconOffset = symbolLabelWithIcon.length - symbolLabel.length;
 
 			// Score by symbol label if searching
 			let symbolScore: number | undefined = undefined;
@@ -143,7 +141,7 @@ export class SymbolsQuickAccessProvider extends PickerQuickAccessProvider<ISymbo
 				// can be a match on a markdown symbol "change log"). In that
 				// case we want to skip the container query altogether.
 				if (symbolQuery !== query) {
-					[symbolScore, symbolMatches] = scoreFuzzy2(symbolLabelWithIcon, { ...query, values: undefined /* disable multi-query support */ }, 0, symbolLabelIconOffset);
+					[symbolScore, symbolMatches] = scoreFuzzy2(symbolLabel, { ...query, values: undefined /* disable multi-query support */ }, 0, 0);
 					if (typeof symbolScore === 'number') {
 						skipContainerQuery = true; // since we consumed the query, skip any container matching
 					}
@@ -151,7 +149,7 @@ export class SymbolsQuickAccessProvider extends PickerQuickAccessProvider<ISymbo
 
 				// Otherwise: score on the symbol query and match on the container later
 				if (typeof symbolScore !== 'number') {
-					[symbolScore, symbolMatches] = scoreFuzzy2(symbolLabelWithIcon, symbolQuery, 0, symbolLabelIconOffset);
+					[symbolScore, symbolMatches] = scoreFuzzy2(symbolLabel, symbolQuery, 0, 0);
 					if (typeof symbolScore !== 'number') {
 						continue;
 					}
@@ -192,7 +190,8 @@ export class SymbolsQuickAccessProvider extends PickerQuickAccessProvider<ISymbo
 				symbol,
 				resource: symbolUri,
 				score: symbolScore,
-				label: symbolLabelWithIcon,
+				iconClass: ThemeIcon.asClassName(SymbolKinds.toIcon(symbol.kind)),
+				label: symbolLabel,
 				ariaLabel: symbolLabel,
 				highlights: deprecated ? undefined : {
 					label: symbolMatches,


### PR DESCRIPTION
use icon class, not string-icon rendering