### PR TITLE
Revert "SCM - 💄 cleanup `isSCM` property from quick diff providers (#246711)"

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadQuickDiff.ts
+++ b/src/vs/workbench/api/browser/mainThreadQuickDiff.ts
@@ -28,6 +28,7 @@ export class MainThreadQuickDiff implements MainThreadQuickDiffShape {
 			label,
 			rootUri: URI.revive(rootUri),
 			selector,
+			isSCM: false,
 			visible,
 			kind: 'contributed',
 			getOriginalResource: async (uri: URI) => {

--- a/src/vs/workbench/api/browser/mainThreadSCM.ts
+++ b/src/vs/workbench/api/browser/mainThreadSCM.ts
@@ -336,6 +336,7 @@ class MainThreadSCMProvider implements ISCMProvider {
 			this._quickDiff = this._quickDiffService.addQuickDiffProvider({
 				label: features.quickDiffLabel ?? this.label,
 				rootUri: this.rootUri,
+				isSCM: true,
 				visible: true,
 				kind: 'primary',
 				getOriginalResource: async (uri: URI) => {
@@ -356,6 +357,7 @@ class MainThreadSCMProvider implements ISCMProvider {
 			this._stagedQuickDiff = this._quickDiffService.addQuickDiffProvider({
 				label: features.secondaryQuickDiffLabel ?? this.label,
 				rootUri: this.rootUri,
+				isSCM: true,
 				visible: true,
 				kind: 'secondary',
 				getOriginalResource: async (uri: URI) => {

--- a/src/vs/workbench/contrib/scm/common/quickDiff.ts
+++ b/src/vs/workbench/contrib/scm/common/quickDiff.ts
@@ -70,6 +70,7 @@ export interface QuickDiffProvider {
 	label: string;
 	rootUri: URI | undefined;
 	selector?: LanguageSelector;
+	isSCM: boolean;
 	visible: boolean;
 	readonly kind: 'primary' | 'secondary' | 'contributed';
 	getOriginalResource(uri: URI): Promise<URI | null>;
@@ -78,6 +79,7 @@ export interface QuickDiffProvider {
 export interface QuickDiff {
 	label: string;
 	originalResource: URI;
+	isSCM: boolean;
 	visible: boolean;
 	readonly kind: 'primary' | 'secondary' | 'contributed';
 }

--- a/src/vs/workbench/contrib/scm/common/quickDiffService.ts
+++ b/src/vs/workbench/contrib/scm/common/quickDiffService.ts
@@ -81,6 +81,7 @@ export class QuickDiffService extends Disposable implements IQuickDiffService {
 			const diff: Partial<QuickDiff> = {
 				originalResource: scoreValue > 0 ? await provider.getOriginalResource(uri) ?? undefined : undefined,
 				label: provider.label,
+				isSCM: provider.isSCM,
 				visible: provider.visible,
 				kind: provider.kind
 			};


### PR DESCRIPTION
This reverts commit 2a68b9df491c0ecfb12d912554d9700a29e7f257.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
