### PR TITLE
Deemphasize old JSX transform

### DIFF
--- a/extensions/typescript-language-features/src/tsconfig.ts
+++ b/extensions/typescript-language-features/src/tsconfig.ts
@@ -29,7 +29,7 @@ export function inferredProjectCompilerOptions(
 		module: (version.gte(API.v540) ? 'Preserve' : 'ESNext') as Proto.ModuleKind,
 		moduleResolution: (version.gte(API.v540) ? 'Bundler' : 'Node') as Proto.ModuleResolutionKind,
 		target: 'ES2022' as Proto.ScriptTarget,
-		jsx: 'react' as Proto.JsxEmit,
+		jsx: 'react-jsx' as Proto.JsxEmit,
 	};
 
 	if (version.gte(API.v500)) {


### PR DESCRIPTION
The old JSX transform requires a React import so you get a "This JSX tag requires 'React' to be in scope, but it could not be found.ts(2874)" for files without a tsconfig in VSCode by default.

However, the default nowadays is the new, automatic JSX transform in React which doesn't need a React import so VSCode should default to that.

Related:
- https://github.com/microsoft/TypeScript-Website/pull/2994 
- https://github.com/microsoft/TypeScript/pull/61586