### PR TITLE
Feat: Allow for relative movement in gotoLineQuickAccess

### DIFF
--- a/src/vs/editor/contrib/quickAccess/browser/gotoLineQuickAccess.ts
+++ b/src/vs/editor/contrib/quickAccess/browser/gotoLineQuickAccess.ts
@@ -111,12 +111,21 @@ export abstract class AbstractGotoLineQuickAccessProvider extends AbstractEditor
 	private parsePosition(editor: IEditor, value: string): IPosition {
 
 		// Support line-col formats of `line,col`, `line:col`, `line#col`
-		const numbers = value.split(/,|:|#/).map(part => parseInt(part, 10)).filter(part => !isNaN(part));
-		const endLine = this.lineCount(editor) + 1;
+		const parts = value.split(/,|:|#/).filter(part => !isNaN(parseInt(part, 10)));
+		const numbers = parts.map(part => parseInt(part, 10));
+
+		// If number starts with + or - we add it to the current cursor position for relative positioning
+		const currentPosition = editor.getPosition() || { lineNumber: 1, column: 1 };
+		const lineNumberRelative = parts.length > 0 && /^[+-]/.test(parts[0]);
+		const columnRelative = parts.length > 1 && /^[+-]/.test(parts[1]);
 
 		return {
-			lineNumber: numbers[0] > 0 ? numbers[0] : endLine + numbers[0],
-			column: numbers[1]
+			lineNumber: lineNumberRelative
+				? (numbers[0] + currentPosition.lineNumber)
+				: numbers[0],
+			column: columnRelative
+				? (numbers[1] + currentPosition.column)
+				: numbers[1]
 		};
 	}
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This is a small change to how gotoLine behaves. If the number entered starts with a plus + or minus - it will move the cursor relative to it's current position.
E.g.
:+20 will move 20 lines down.
:20 will move to line 20 as before.
:-20 will move 20 lines up.