### PR TITLE
#245665 fix early task exit with empty promptString input

### DIFF
--- a/src/vs/workbench/services/configurationResolver/browser/baseConfigurationResolverService.ts
+++ b/src/vs/workbench/services/configurationResolver/browser/baseConfigurationResolverService.ts
@@ -277,7 +277,7 @@ export abstract class BaseConfigurationResolverService extends AbstractVariableR
 						if (typeof resolvedInput === 'string') {
 							this.storeInputLru(defaultValueMap.set(defaultValueKey, resolvedInput));
 						}
-						return resolvedInput ? { value: resolvedInput as string, input: info } : undefined;
+						return resolvedInput !== undefined ? { value: resolvedInput as string, input: info } : undefined;
 					});
 				}
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
address issue #245665 

tested with the following tasks.json file:

```json
{
  "version": "2.0.0",
  "tasks": [
    {
      "command": "echo",
      "label": "echo",
      "args": [
        "${input:test1}",
        "${input:test2}"
      ]
    }
  ],
  "inputs": [
    {
      "id": "test1",
      "type": "promptString",
      "default": "",
      "description": "test1"
    },
    {
      "id": "test2",
      "type": "promptString",
      "default": "",
      "description": "test2"
    }
  ]
}
```
entering empty strings into the prompts, before my change it ends early after `test1` after it goes all the way through to `echo` both inputs
