### PR TITLE
don't show warning when `!waitForActivate` for task config that's not recognized

### DIFF
--- a/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts
+++ b/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts
@@ -2249,7 +2249,6 @@ export abstract class AbstractTaskService extends Disposable implements ITaskSer
 								configuringTask.configures.type,
 								JSON.stringify(configuringTask._source.config.element, undefined, 4)
 							));
-							this._showOutput();
 						}
 					});
 


### PR DESCRIPTION
I added this line and I don't actually think we want to surface this.