### PR TITLE
Switch model picker to use action widget

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/modelPicker/modelPickerActionItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/modelPicker/modelPickerActionItem.ts
@@ -1,0 +1,115 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IAction } from '../../../../../base/common/actions.js';
+import { Event } from '../../../../../base/common/event.js';
+import { ILanguageModelChatMetadataAndIdentifier } from '../../common/languageModels.js';
+import { localize } from '../../../../../nls.js';
+import { ModelPickerWidget } from './modelPickerWidget.js';
+import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
+import * as dom from '../../../../../base/browser/dom.js';
+import { renderLabelWithIcons } from '../../../../../base/browser/ui/iconLabel/iconLabels.js';
+import { Codicon } from '../../../../../base/common/codicons.js';
+import { ActionViewItem } from '../../../../../base/browser/ui/actionbar/actionViewItems.js';
+
+export interface IModelPickerDelegate {
+	readonly onDidChangeModel: Event<ILanguageModelChatMetadataAndIdentifier>;
+	setModel(model: ILanguageModelChatMetadataAndIdentifier): void;
+	getModels(): ILanguageModelChatMetadataAndIdentifier[];
+}
+
+/**
+ * Action view item for selecting a language model in the chat interface.
+ */
+export class ModelPickerActionItem extends ActionViewItem {
+	private widget: ModelPickerWidget | undefined;
+
+	constructor(
+		action: IAction,
+		private readonly currentModel: ILanguageModelChatMetadataAndIdentifier,
+		private readonly delegate: IModelPickerDelegate,
+		@IInstantiationService private readonly instantiationService: IInstantiationService,
+	) {
+		// Modify the original action with a different label and make it show the current model
+		const actionWithLabel: IAction = {
+			...action,
+			label: currentModel.metadata.name,
+			tooltip: localize('chat.modelPicker.label', "Pick Model"),
+			run: () => { /* Will be overridden by our click handler */ }
+		};
+
+		super(undefined, actionWithLabel, { label: true });
+
+		// Listen for model changes from the delegate
+		this._register(delegate.onDidChangeModel(model => {
+			this.action.label = model.metadata.name;
+			this.updateLabel();
+		}));
+	}
+
+	/**
+	 * Override rendering of the label to include the dropdown indicator
+	 */
+	protected override updateLabel(): void {
+		if (this.label) {
+			// Reset the label element with the current model name and a dropdown indicator
+			dom.reset(this.label,
+				dom.$('span.chat-model-label', undefined, this.action.label),
+				...renderLabelWithIcons(`$(${Codicon.chevronDown.id})`)
+			);
+		}
+	}
+
+	/**
+	 * Override rendering to add CSS classes and initialize the widget
+	 */
+	override render(container: HTMLElement): void {
+		super.render(container);
+
+		// Add classes for styling this element
+		container.classList.add('chat-modelPicker-item');
+
+		// Create the model picker widget that will be shown when clicked
+		this.widget = this.instantiationService.createInstance(
+			ModelPickerWidget,
+			this.currentModel,
+			() => this.delegate.getModels(),
+			(model) => this.delegate.setModel(model)
+		);
+
+		// Register event handlers
+		this._register(this.widget.onDidChangeModel(model => {
+			this.action.label = model.metadata.name;
+			this.updateLabel();
+		}));
+	}
+
+	/**
+	 * Override the onClick to show our picker widget
+	 */
+	override onClick(event: MouseEvent): void {
+		if (!this.widget) {
+			return;
+		}
+
+		// Show the model picker at the current position
+		this.widget.showAt({
+			x: event.clientX,
+			y: event.clientY
+		});
+
+		event.stopPropagation();
+		event.preventDefault();
+	}
+
+	/**
+	 * Set aria label attributes on the element
+	 */
+	protected setAriaLabelAttributes(element: HTMLElement): void {
+		element.setAttribute('aria-label', localize('chatModelPicker', "Chat Model: {0}", this.action.label));
+		element.setAttribute('aria-haspopup', 'true');
+		element.setAttribute('role', 'button');
+	}
+}

--- a/src/vs/workbench/contrib/chat/browser/modelPicker/modelPickerWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/modelPicker/modelPickerWidget.ts
@@ -1,0 +1,146 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IAction } from '../../../../../base/common/actions.js';
+import { Disposable } from '../../../../../base/common/lifecycle.js';
+import { IAnchor } from '../../../../../base/browser/ui/contextview/contextview.js';
+import { Emitter } from '../../../../../base/common/event.js';
+import { ILanguageModelChatMetadataAndIdentifier } from '../../common/languageModels.js';
+import { IActionWidgetService } from '../../../../../platform/actionWidget/browser/actionWidget.js';
+import { localize } from '../../../../../nls.js';
+import { MenuId, IMenuService } from '../../../../../platform/actions/common/actions.js';
+import { IContextKeyService } from '../../../../../platform/contextkey/common/contextkey.js';
+import { ICommandService } from '../../../../../platform/commands/common/commands.js';
+import { IChatEntitlementService, ChatEntitlement } from '../../common/chatEntitlementService.js';
+import { getFlatActionBarActions } from '../../../../../platform/actions/browser/menuEntryActionViewItem.js';
+import { ActionListItemKind, IActionListItem } from '../../../../../platform/actionWidget/browser/actionList.js';
+import { ThemeIcon } from '../../../../../base/common/themables.js';
+import { Codicon } from '../../../../../base/common/codicons.js';
+
+interface IModelPickerActionItem {
+	model: ILanguageModelChatMetadataAndIdentifier;
+	isCurrent: boolean;
+}
+
+/**
+ * Widget for picking a language model for chat.
+ */
+export class ModelPickerWidget extends Disposable {
+	private readonly _onDidChangeModel = this._register(new Emitter<ILanguageModelChatMetadataAndIdentifier>());
+	readonly onDidChangeModel = this._onDidChangeModel.event;
+
+	constructor(
+		private currentModel: ILanguageModelChatMetadataAndIdentifier,
+		private readonly getModels: () => ILanguageModelChatMetadataAndIdentifier[],
+		private readonly setModel: (model: ILanguageModelChatMetadataAndIdentifier) => void,
+		@IActionWidgetService private readonly actionWidgetService: IActionWidgetService,
+		@IMenuService private readonly menuService: IMenuService,
+		@IContextKeyService private readonly contextKeyService: IContextKeyService,
+		@IChatEntitlementService private readonly chatEntitlementService: IChatEntitlementService,
+		@ICommandService private readonly commandService: ICommandService,
+	) {
+		super();
+	}
+
+	/**
+	 * Get the label to display in the button that shows the current model
+	 */
+	get buttonLabel(): string {
+		return this.currentModel.metadata.name;
+	}
+
+	/**
+	 * Convert available models to action items for display
+	 */
+	private getActionItems(): IModelPickerActionItem[] {
+		const items: IModelPickerActionItem[] = this.getModels().map(model => ({
+			model,
+			isCurrent: model.identifier === this.currentModel.identifier
+		}));
+
+		return items;
+	}
+
+	/**
+	 * Get any additional actions to add to the picker menu
+	 */
+	private getAdditionalActions(): IAction[] {
+		const menuActions = this.menuService.createMenu(MenuId.ChatModelPicker, this.contextKeyService);
+		const menuContributions = getFlatActionBarActions(menuActions.getActions());
+		menuActions.dispose();
+
+		const additionalActions: IAction[] = [];
+
+		// Add menu contributions from extensions
+		if (menuContributions.length > 0) {
+			additionalActions.push(...menuContributions);
+		}
+
+		// Add upgrade option if entitlement is limited
+		if (this.chatEntitlementService.entitlement === ChatEntitlement.Limited) {
+			additionalActions.push({
+				id: 'moreModels',
+				label: localize('chat.moreModels', "Add Premium Models"),
+				enabled: true,
+				tooltip: localize('chat.moreModels.tooltip', "Add premium models"),
+				class: undefined,
+				run: () => {
+					const commandId = 'workbench.action.chat.upgradePlan';
+					this.commandService.executeCommand(commandId);
+				}
+			});
+		}
+
+		return additionalActions;
+	}
+
+	/**
+	 * Shows the picker at the specified anchor
+	 */
+	showAt(anchor: IAnchor, container?: HTMLElement): void {
+		const items: IActionListItem<ILanguageModelChatMetadataAndIdentifier>[] = this.getActionItems().map(item => ({
+			item: item.model,
+			kind: ActionListItemKind.Action,
+			canPreview: false,
+			group: { title: '', icon: ThemeIcon.fromId(item.isCurrent ? Codicon.check.id : Codicon.blank.id) },
+			disabled: false,
+			hideIcon: false,
+			label: item.model.metadata.name,
+		} satisfies IActionListItem<ILanguageModelChatMetadataAndIdentifier>));
+
+		const delegate = {
+			onSelect: (item: ILanguageModelChatMetadataAndIdentifier) => {
+				if (item.identifier !== this.currentModel.identifier) {
+					this.setModel(item);
+					this.currentModel = item;
+					this._onDidChangeModel.fire(item);
+				}
+				this.actionWidgetService.hide(false);
+				return true;
+			},
+			onHide: () => { },
+			getWidgetAriaLabel: () => localize('modelPicker', "Model Picker")
+		};
+
+		// Get additional actions to show in the picker
+		const additionalActions = this.getAdditionalActions();
+		let buttonBar: IAction[] = [];
+
+		// If we have additional actions, add them to the button bar
+		if (additionalActions.length > 0) {
+			buttonBar = additionalActions;
+		}
+
+		this.actionWidgetService.show(
+			'modelPicker',
+			false,
+			items,
+			delegate,
+			anchor,
+			container,
+			buttonBar
+		);
+	}
+}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
This switches the model picker to be powered by the action widget rather than a native dropdown menu. Opening the door for us to do more complex things

![image](https://github.com/user-attachments/assets/fc04b2fc-09ea-4d9a-9bb8-26efa456b9c1)



TODO:
- Add descriptions
- Tooltip rendering
- Maybe not links for manage models
