### PR TITLE
mcp: refine extension API

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadMcp.ts
+++ b/src/vs/workbench/api/browser/mainThreadMcp.ts
@@ -9,11 +9,12 @@ import { Disposable, DisposableMap } from '../../../base/common/lifecycle.js';
 import { ISettableObservable, observableValue } from '../../../base/common/observable.js';
 import { LogLevel } from '../../../platform/log/common/log.js';
 import { IMcpMessageTransport, IMcpRegistry } from '../../contrib/mcp/common/mcpRegistryTypes.js';
-import { McpCollectionDefinition, McpConnectionState, McpServerDefinition, McpServerTransportType } from '../../contrib/mcp/common/mcpTypes.js';
+import { McpCollectionDefinition, McpConnectionState, McpServerDefinition, McpServerLaunch, McpServerTransportType } from '../../contrib/mcp/common/mcpTypes.js';
 import { MCP } from '../../contrib/mcp/common/modelContextProtocol.js';
 import { ExtensionHostKind, extensionHostKindToString } from '../../services/extensions/common/extensionHostKind.js';
 import { IExtHostContext, extHostNamedCustomer } from '../../services/extensions/common/extHostCustomers.js';
-import { ExtHostContext, MainContext, MainThreadMcpShape } from '../common/extHost.protocol.js';
+import { Proxied } from '../../services/extensions/common/proxyIdentifier.js';
+import { ExtHostContext, ExtHostMcpShape, MainContext, MainThreadMcpShape } from '../common/extHost.protocol.js';
 
 @extHostNamedCustomer(MainContext.MainThreadMcp)
 export class MainThreadMcp extends Disposable implements MainThreadMcpShape {
@@ -21,6 +22,7 @@ export class MainThreadMcp extends Disposable implements MainThreadMcpShape {
 	private _serverIdCounter = 0;
 
 	private readonly _servers = new Map<number, ExtHostMcpServerLaunch>();
+	private readonly _proxy: Proxied<ExtHostMcpShape>;
 	private readonly _collectionDefinitions = this._register(new DisposableMap<string, {
 		fromExtHost: McpCollectionDefinition.FromExtHost;
 		servers: ISettableObservable<readonly McpServerDefinition[]>;
@@ -32,7 +34,7 @@ export class MainThreadMcp extends Disposable implements MainThreadMcpShape {
 		@IMcpRegistry private readonly _mcpRegistry: IMcpRegistry,
 	) {
 		super();
-		const proxy = _extHostContext.getProxy(ExtHostContext.ExtHostMcp);
+		const proxy = this._proxy = _extHostContext.getProxy(ExtHostContext.ExtHostMcp);
 		this._register(this._mcpRegistry.registerDelegate({
 			// Prefer Node.js extension hosts when they're available. No CORS issues etc.
 			priority: _extHostContext.extensionHostKind === ExtensionHostKind.LocalWebWorker ? 0 : 1,
@@ -73,6 +75,10 @@ export class MainThreadMcp extends Disposable implements MainThreadMcpShape {
 			const serverDefinitions = observableValue<readonly McpServerDefinition[]>('mcpServers', servers);
 			const handle = this._mcpRegistry.registerCollection({
 				...collection,
+				resolveServerLanch: collection.canResolveLaunch ? (async def => {
+					const r = await this._proxy.$resolveMcpLaunch(collection.id, def.label);
+					return r ? McpServerLaunch.fromSerialized(r) : undefined;
+				}) : undefined,
 				remoteAuthority: this._extHostContext.remoteAuthority,
 				serverDefinitions,
 			});

--- a/src/vs/workbench/api/common/extHost.api.impl.ts
+++ b/src/vs/workbench/api/common/extHost.api.impl.ts
@@ -1830,7 +1830,7 @@ export function createApiFactoryAndRegisterActors(accessor: ServicesAccessor): I
 			AISearchKeyword: AISearchKeyword,
 			TextSearchCompleteMessageTypeNew: TextSearchCompleteMessageType,
 			ChatErrorLevel: extHostTypes.ChatErrorLevel,
-			McpSSEServerDefinition: extHostTypes.McpSSEServerDefinition,
+			McpHttpServerDefinition: extHostTypes.McpHttpServerDefinition,
 			McpStdioServerDefinition: extHostTypes.McpStdioServerDefinition,
 		};
 	};

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -2977,6 +2977,7 @@ export interface ExtHostTestingShape {
 }
 
 export interface ExtHostMcpShape {
+	$resolveMcpLaunch(collectionId: string, label: string): Promise<McpServerLaunch.Serialized | undefined>;
 	$startMcp(id: number, launch: McpServerLaunch.Serialized): void;
 	$stopMcp(id: number): void;
 	$sendMessage(id: number, message: string): void;
@@ -2987,7 +2988,7 @@ export interface MainThreadMcpShape {
 	$onDidChangeState(id: number, state: McpConnectionState): void;
 	$onDidPublishLog(id: number, level: LogLevel, log: string): void;
 	$onDidReceiveMessage(id: number, message: string): void;
-	$upsertMcpCollection(collection: McpCollectionDefinition.FromExtHost, servers: Dto<McpServerDefinition>[]): void;
+	$upsertMcpCollection(collection: McpCollectionDefinition.FromExtHost, servers: McpServerDefinition.Serialized[]): void;
 	$deleteMcpCollection(collectionId: string): void;
 }
 

--- a/src/vs/workbench/api/common/extHostTypeConverters.ts
+++ b/src/vs/workbench/api/common/extHostTypeConverters.ts
@@ -63,6 +63,7 @@ import { getPrivateApiFor } from './extHostTestingPrivateApi.js';
 import * as types from './extHostTypes.js';
 import { LanguageModelPromptTsxPart, LanguageModelTextPart } from './extHostTypes.js';
 import { ChatAgentLocation } from '../../contrib/chat/common/constants.js';
+import { McpServerLaunch, McpServerTransportType } from '../../contrib/mcp/common/mcpTypes.js';
 
 export namespace Command {
 
@@ -3254,5 +3255,30 @@ export namespace LanguageModelToolResult {
 export namespace IconPath {
 	export function fromThemeIcon(iconPath: vscode.ThemeIcon): languages.IconPath {
 		return iconPath;
+	}
+}
+
+export namespace McpServerDefinition {
+	function isHttpConfig(candidate: vscode.McpServerDefinition): candidate is vscode.McpHttpServerDefinition {
+		return !!(candidate as vscode.McpHttpServerDefinition).uri;
+	}
+
+	export function from(item: vscode.McpServerDefinition): McpServerLaunch.Serialized {
+		return McpServerLaunch.toSerialized(
+			isHttpConfig(item)
+				? {
+					type: McpServerTransportType.HTTP,
+					uri: item.uri,
+					headers: Object.entries(item.headers),
+				}
+				: {
+					type: McpServerTransportType.Stdio,
+					cwd: item.cwd,
+					args: item.args,
+					command: item.command,
+					env: item.env,
+					envFile: undefined,
+				}
+		);
 	}
 }

--- a/src/vs/workbench/api/common/extHostTypes.ts
+++ b/src/vs/workbench/api/common/extHostTypes.ts
@@ -5158,11 +5158,11 @@ export class McpStdioServerDefinition implements vscode.McpStdioServerDefinition
 	) { }
 }
 
-export class McpSSEServerDefinition implements vscode.McpSSEServerDefinition {
-	headers: [string, string][] = [];
+export class McpHttpServerDefinition implements vscode.McpHttpServerDefinition {
 	constructor(
 		public label: string,
-		public uri: URI
+		public uri: URI,
+		public headers: Record<string, string> = {},
 	) { }
 }
 //#endregion

--- a/src/vs/workbench/contrib/mcp/common/mcpTypes.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpTypes.ts
@@ -44,6 +44,9 @@ export interface McpCollectionDefinition {
 	/** Scope where associated collection info should be stored. */
 	readonly scope: StorageScope;
 
+	/** Resolves a server definition. If present, always called before a server starts. */
+	resolveServerLanch?(definition: McpServerDefinition): Promise<McpServerLaunch | undefined>;
+
 	/** For lazy-loaded collections only: */
 	readonly lazy?: {
 		/** True if `serverDefinitions` were loaded from the cache */
@@ -78,6 +81,8 @@ export namespace McpCollectionDefinition {
 		readonly label: string;
 		readonly isTrustedByDefault: boolean;
 		readonly scope: StorageScope;
+		readonly canResolveLaunch: boolean;
+		readonly extensionId: string;
 	}
 
 	export function equals(a: McpCollectionDefinition, b: McpCollectionDefinition): boolean {

--- a/src/vscode-dts/vscode.proposed.mcpConfigurationProvider.d.ts
+++ b/src/vscode-dts/vscode.proposed.mcpConfigurationProvider.d.ts
@@ -6,37 +6,110 @@ declare module 'vscode' {
 
 	// https://github.com/microsoft/vscode/issues/243522
 
+	/**
+	 * McpStdioServerDefinition represents an MCP server available by running
+	 * a local process and listening to its stdin and stdout streams.
+	 */
 	export class McpStdioServerDefinition {
-
+		/**
+		 * The human-readable name of the server.
+		 */
 		label: string;
 
+		/**
+		 * The working directory used to start the server.
+		 */
 		cwd?: Uri;
+
+		/**
+		 * The command used to start the server. Node.js-based servers may use
+		 * `process.execPath` to use the editor's version of Node.js to run the script.
+		 */
 		command: string;
-		args: readonly string[];
+		/**
+		 * Additional command-line arguments passed to the server.
+		 */
+		args: string[];
+
+		/**
+		 * Optional additional environment information for the server. Variables
+		 * in this environment will overwrite or remove (if null) the default
+		 * environment variables.
+		 */
 		env: Record<string, string | number | null>;
 
-		constructor(label: string, command: string, args: string[], env: { [key: string]: string });
+		constructor(label: string, command: string, args?: string[], env?: Record<string, string | number | null>);
 	}
 
-	export class McpSSEServerDefinition {
-
+	/**
+	 * McpHttpServerDefinition represents an MCP server available using the
+	 * Streamable HTTP transport.
+	 */
+	export class McpHttpServerDefinition {
+		/**
+		 * The human-readable name of the server.
+		 */
 		label: string;
 
+		/**
+		 * The URI of the server. The editor will make a POST request to this URI
+		 * to begin each session.
+		 */
 		uri: Uri;
 
-		headers: [string, string][];
+		/**
+		 * Optional additional heads included with each request to the server.
+		 */
+		headers: Record<string, string>;
 
-		constructor(label: string, uri: Uri);
+		/**
+		 * @param label The human-readable name of the server.
+		 * @param uri The URI of the server.
+		 * @param headers Optional additional heads included with each request to the server.
+		 */
+		constructor(label: string, uri: Uri, headers?: Record<string, string>);
 	}
 
-	export type McpServerDefinition = McpStdioServerDefinition | McpSSEServerDefinition;
+	export type McpServerDefinition = McpStdioServerDefinition | McpHttpServerDefinition;
 
-	export interface McpConfigurationProvider {
-
+	/**
+	 * A type that can provide server configurations. This may only be used in
+	 * conjunction with `contributes.modelContextServerCollections` in the
+	 * extension's package.json.
+	 *
+	 * To allow the editor to cache available servers, extensions should register
+	 * this before `activate()` resolves.
+	 */
+	export interface McpConfigurationProvider<T extends McpServerDefinition = McpServerDefinition> {
+		/**
+		 * Optional event fired to signal that the set of available servers has changed.
+		 */
 		onDidChange?: Event<void>;
 
-		provideMcpServerDefinitions(token: CancellationToken): ProviderResult<McpServerDefinition[]>;
+		/**
+		 * Provides available MCP servers. The editor will call this method eagerly
+		 * to ensure the availability of servers for the language model, and so
+		 * extensions should not take actions which would require user
+		 * interaction, such as authentication.
+		 *
+		 * @param token A cancellation token.
+		 * @returns An array of MCP available MCP servers
+		 */
+		provideMcpServerDefinitions(token: CancellationToken): ProviderResult<T[]>;
 
+		/**
+		 * This function will be called when the editor needs to start MCP server.
+		 * At this point, the extension may take any actions which may require user
+		 * interaction, such as authentication.
+		 *
+		 * The extension may return undefined on error to indicate that the server
+		 * should not be started.
+		 *
+		 * @param server The MCP server to resolve
+		 * @param token A cancellation token.
+		 * @returns The given, resolved server or thenable that resolves to such.
+		 */
+		resolveMcpServerDefinition?(server: T, token: CancellationToken): ProviderResult<T>;
 	}
 
 	namespace lm {


### PR DESCRIPTION
- Replace SSE with HTTP in the API (although this still supports the
  same SSE fallback we otherwise have, this is not documented)
- Add a new `resolveMcpServerDefinition` step that is only run before
  the MCP server is started -- both from a cache or from a running
  extension. This lets extensions do user interaction is a more correct way.
- Add appropriate docs and such.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
