### PR TITLE
Add `getAnyConfig` to git `Repository` API

### DIFF
--- a/extensions/git/src/api/api1.ts
+++ b/extensions/git/src/api/api1.ts
@@ -116,6 +116,10 @@ export class ApiRepository implements Repository {
 		return this.#repository.unsetConfig(key);
 	}
 
+	getAnyConfig(key: string): Promise<string> {
+		return this.#repository.getAnyConfig(key);
+	}
+
 	getGlobalConfig(key: string): Promise<string> {
 		return this.#repository.getGlobalConfig(key);
 	}

--- a/extensions/git/src/api/git.d.ts
+++ b/extensions/git/src/api/git.d.ts
@@ -207,6 +207,7 @@ export interface Repository {
 	getConfig(key: string): Promise<string>;
 	setConfig(key: string, value: string): Promise<string>;
 	unsetConfig(key: string): Promise<string>;
+	getAnyConfig(key: string): Promise<string>;
 	getGlobalConfig(key: string): Promise<string>;
 
 	getObjectDetails(treeish: string, path: string): Promise<{ mode: string, object: string, size: number }>;

--- a/extensions/git/src/repository.ts
+++ b/extensions/git/src/repository.ts
@@ -1088,6 +1088,10 @@ export class Repository implements Disposable {
 		return this.run(Operation.Config(true), () => this.repository.config('get', 'local', key));
 	}
 
+	getAnyConfig(key: string): Promise<string> {
+		return this.run(Operation.Config(true), () => this.repository.config('get', '', key));
+	}
+
 	getGlobalConfig(key: string): Promise<string> {
 		return this.run(Operation.Config(true), () => this.repository.config('get', 'global', key));
 	}


### PR DESCRIPTION
This allows extensions to get configuration for any scope. This should prevent confusion when configuration can be excluded when requesting a specific scope.

See https://github.com/microsoft/vscode-pull-request-github/pull/6797