### PR TITLE
feat: markdown-basics snippets: quote all lines

### DIFF
--- a/extensions/markdown-basics/snippets/markdown.code-snippets
+++ b/extensions/markdown-basics/snippets/markdown.code-snippets
@@ -11,7 +11,7 @@
 	},
 	"Insert quoted text": {
 		"prefix": "quote",
-		"body": "> ${1:${TM_SELECTED_TEXT}}",
+		"body": "${1:${TM_SELECTED_TEXT/^/> /gm}}",
 		"description": "Insert quoted text"
 	},
 	"Insert inline code": {


### PR DESCRIPTION
Previously, this snippet just inserted `> ` before the selected text, which is not very useful; particularly, when multiple paragraphs are selected, this will only quote the first one:

```markdown
> This is a paragraph.

This is another paragraph, which was supposed to be quoted but wasn't.
```

Instead, we now prefix every line in the selection with `> `, so that it will all be quoted regardless of how many paragraphs are taken.

```markdown
> This is a paragraph.
> 
> This is another paragraph, which was supposed to be quoted and now is.
```

This does also change the behavior in the case of no selected text slightly; previously it would insert `> []` (where `[]` indicates the selection; that is, it would put the insertion point after the quote marker). It now inserts `[> ]` instead (that is, the same text but it's all selected) so if you start typing you'll wind up removing the quote marker. Since using this snippet without a selection is just a roundabout way of typing <kbd>&gt;</kbd><kbd>&nbsp;</kbd> this seems like an acceptable tradeoff.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Closes #247150.