### PR TITLE
track tasks with dependencies in active tasks, enabling them to be used as a `preLaunchTask`

### DIFF
--- a/src/vs/workbench/contrib/tasks/browser/terminalTaskSystem.ts
+++ b/src/vs/workbench/contrib/tasks/browser/terminalTaskSystem.ts
@@ -290,7 +290,7 @@ export class TerminalTaskSystem extends Disposable implements ITaskSystem {
 			if (task.configurationProperties.dependsOn) {
 				// Track the parent task #244744
 				const mapKey = task.getMapKey();
-				this._activeTasks[mapKey] = this._activeTasks[mapKey] || { task, promise: executeResult.promise, count: { count: 0 } };
+				this._activeTasks[mapKey] = { task, promise: executeResult.promise, count: { count: 0 } };
 			}
 			executeResult.promise.then(summary => {
 				this._lastTask = this._currentTask;
@@ -578,7 +578,6 @@ export class TerminalTaskSystem extends Disposable implements ITaskSystem {
 			});
 		}).finally(() => {
 			delete this._activeTasks[mapKey];
-			delete this._activeTasks[task.getMapKey()];
 		});
 		const lastInstance = this._getInstances(task).pop();
 		const count = lastInstance?.count ?? { count: 0 };

--- a/src/vs/workbench/contrib/tasks/browser/terminalTaskSystem.ts
+++ b/src/vs/workbench/contrib/tasks/browser/terminalTaskSystem.ts
@@ -287,11 +287,17 @@ export class TerminalTaskSystem extends Disposable implements ITaskSystem {
 
 		try {
 			const executeResult = { kind: TaskExecuteKind.Started, task, started: {}, promise: this._executeTask(task, resolver, trigger, new Set(), new Map(), undefined) };
+			if (task.configurationProperties.dependsOn) {
+				// Track the parent task #244744
+				const mapKey = task.getMapKey();
+				this._activeTasks[mapKey] = this._activeTasks[mapKey] || { task, promise: executeResult.promise, count: { count: 0 } };
+			}
 			executeResult.promise.then(summary => {
 				this._lastTask = this._currentTask;
 			});
 			return executeResult;
 		} catch (error) {
+			this._removeFromActiveTasks(task);
 			if (error instanceof TaskError) {
 				throw error;
 			} else if (error instanceof Error) {
@@ -528,6 +534,8 @@ export class TerminalTaskSystem extends Disposable implements ITaskSystem {
 							if (!taskResult) {
 								const activeTask = this._activeTasks[dependencyTask.getMapKey()] ?? this._getInstances(dependencyTask).pop();
 								taskResult = activeTask && this._getDependencyPromise(activeTask);
+								this._activeTasks[mapKey].terminal = activeTask?.terminal;
+								this._activeTasks[mapKey].count = { count: task.configurationProperties.dependsOn.length };
 							}
 						}
 						if (!taskResult) {
@@ -570,6 +578,7 @@ export class TerminalTaskSystem extends Disposable implements ITaskSystem {
 			});
 		}).finally(() => {
 			delete this._activeTasks[mapKey];
+			delete this._activeTasks[task.getMapKey()];
 		});
 		const lastInstance = this._getInstances(task).pop();
 		const count = lastInstance?.count ?? { count: 0 };


### PR DESCRIPTION
fix #244744

Easy repro:

- in `vscode-copilot` repo, use this launch config . Before, it would hang and debugging wouldn't launch. 

![Image](https://github.com/user-attachments/assets/41f9de9f-a21c-4451-b8ba-a8a320b19be8)