### PR TITLE
[prompts]: run a saved prompt file

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/actions/chatContextActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatContextActions.ts
@@ -66,7 +66,7 @@ import { convertBufferToScreenshotVariable, ScreenshotVariableId } from '../cont
 import { resizeImage } from '../imageUtils.js';
 import { INSTRUCTIONS_COMMAND_ID } from '../promptSyntax/contributions/attachInstructionsCommand.js';
 import { CHAT_CATEGORY } from './chatActions.js';
-import { runAttachInstructionsAction } from './promptActions/index.js';
+import { runAttachInstructionsAction, registerPromptActions } from './promptActions/index.js';
 
 export function registerChatContextActions() {
 	registerAction2(AttachContextAction);
@@ -949,7 +949,6 @@ export class AttachContextAction extends Action2 {
 	}
 }
 
-
 async function createMarkersQuickPick(accessor: ServicesAccessor, onBackgroundAccept?: (item: IDiagnosticVariableEntryFilterData[]) => void): Promise<IDiagnosticVariableEntryFilterData | undefined> {
 	const quickInputService = accessor.get(IQuickInputService);
 	const markerService = accessor.get(IMarkerService);
@@ -1001,7 +1000,6 @@ async function createMarkersQuickPick(accessor: ServicesAccessor, onBackgroundAc
 		quickPick.show();
 	}).finally(() => store.dispose());
 }
-
 
 async function showToolsPick(accessor: ServicesAccessor, widget: IChatWidget): Promise<IToolQuickPickItem | undefined> {
 
@@ -1068,3 +1066,8 @@ async function showToolsPick(accessor: ServicesAccessor, widget: IChatWidget): P
 
 	return result;
 }
+
+/**
+ * Register all actions related to reusable prompt files.
+ */
+registerPromptActions();

--- a/src/vs/workbench/contrib/chat/browser/actions/promptActions/dialogs/askToSelectPrompt/utils/runPrompt.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/promptActions/dialogs/askToSelectPrompt/utils/runPrompt.ts
@@ -45,15 +45,6 @@ export const runPromptFile = async (
 
 	const widget = await getChatWidgetObject(options);
 
-	// const { attachmentModel, input } = widget;
-	// const { promptInstructions } = attachmentModel;
-
-	// const { toolsMetadata } = (await promptInstructions.allSettled());
-	// if ((toolsMetadata !== null) && (toolsMetadata.length > 0)) {
-	// 	input.selectedToolsModel
-	// 		.selectOnly(toolsMetadata);
-	// }
-
 	widget.setInput(`/${basename(file)}`);
 	// submit the prompt immediately
 	await widget.acceptInput();

--- a/src/vs/workbench/contrib/chat/browser/actions/promptActions/dialogs/askToSelectPrompt/utils/runPrompt.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/promptActions/dialogs/askToSelectPrompt/utils/runPrompt.ts
@@ -45,10 +45,19 @@ export const runPromptFile = async (
 
 	const widget = await getChatWidgetObject(options);
 
-	await widget.setInput(`/${basename(file)}`);
+	// const { attachmentModel, input } = widget;
+	// const { promptInstructions } = attachmentModel;
+
+	// const { toolsMetadata } = (await promptInstructions.allSettled());
+	// if ((toolsMetadata !== null) && (toolsMetadata.length > 0)) {
+	// 	input.selectedToolsModel
+	// 		.selectOnly(toolsMetadata);
+	// }
+
+	widget.setInput(`/${basename(file)}`);
 	// submit the prompt immediately
 	await widget.acceptInput();
 
+
 	return { widget };
 };
-

--- a/src/vs/workbench/contrib/chat/browser/actions/promptActions/index.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/promptActions/index.ts
@@ -6,6 +6,7 @@
 import { registerRunPromptActions } from './chatRunPromptAction.js';
 import { registerSaveToPromptActions } from './chatSaveToPromptAction.js';
 import { registerAttachPromptActions } from './chatAttachInstructionsAction.js';
+export { runAttachInstructionsAction } from './chatAttachInstructionsAction.js';
 
 /**
  * Helper to register all actions related to reusable prompt files.
@@ -15,5 +16,3 @@ export const registerPromptActions = () => {
 	registerAttachPromptActions();
 	registerSaveToPromptActions();
 };
-
-export { runAttachInstructionsAction } from './chatAttachInstructionsAction.js';

--- a/src/vs/workbench/contrib/chat/browser/attachments/promptInstructions/promptInstructionsCollectionWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/attachments/promptInstructions/promptInstructionsCollectionWidget.ts
@@ -63,6 +63,20 @@ export class PromptInstructionsAttachmentsCollectionWidget extends Disposable {
 	}
 
 	/**
+	 * TODO: @legomushroom
+	 */
+	public allSettled() {
+		return this.model.allSettled();
+	}
+
+	/**
+	 * TODO: @legomushroom
+	 */
+	public get toolsMetadata() {
+		return this.model.toolsMetadata;
+	}
+
+	/**
 	 * Check if child widget list is empty (no attachments present).
 	 */
 	public get empty(): boolean {

--- a/src/vs/workbench/contrib/chat/browser/attachments/promptInstructions/promptInstructionsCollectionWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/attachments/promptInstructions/promptInstructionsCollectionWidget.ts
@@ -63,17 +63,11 @@ export class PromptInstructionsAttachmentsCollectionWidget extends Disposable {
 	}
 
 	/**
-	 * TODO: @legomushroom
+	 * Get a promise that resolves when parsing/resolving processes
+	 * are fully completed, including all possible nested child references.
 	 */
 	public allSettled() {
 		return this.model.allSettled();
-	}
-
-	/**
-	 * TODO: @legomushroom
-	 */
-	public get toolsMetadata() {
-		return this.model.toolsMetadata;
 	}
 
 	/**

--- a/src/vs/workbench/contrib/chat/browser/chatAttachmentModel/chatPromptAttachmentModel.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatAttachmentModel/chatPromptAttachmentModel.ts
@@ -61,8 +61,13 @@ export class ChatPromptAttachmentModel extends Disposable {
 
 	/**
 	 * Get list of all tools associated with the prompt.
+	 *
+	 * Note! This property returns pont-in-time state of the tools metadata
+	 *       and does not take into account if the prompt or its nested child
+	 *       references are still being resolved. Please use the {@link settled}
+	 *       or {@link allSettled} properties if you need to retrieve the final
+	 *       list of the tools available.
 	 */
-	// TODO: @legomushroom - note about `allSettled`
 	public get toolsMetadata(): readonly string[] | null {
 		return this.reference.allToolsMetadata;
 	}

--- a/src/vs/workbench/contrib/chat/browser/chatAttachmentModel/chatPromptAttachmentModel.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatAttachmentModel/chatPromptAttachmentModel.ts
@@ -43,7 +43,7 @@ export class ChatPromptAttachmentModel extends Disposable {
 	 */
 	public get references(): readonly URI[] {
 		const { reference } = this;
-		const { errorCondition } = this.reference;
+		const { errorCondition } = reference;
 
 		// return no references if the attachment is disabled
 		// or if this object itself has an error
@@ -57,6 +57,14 @@ export class ChatPromptAttachmentModel extends Disposable {
 			...reference.allValidReferencesUris,
 			reference.uri,
 		];
+	}
+
+	/**
+	 * Get list of all tools associated with the prompt.
+	 */
+	// TODO: @legomushroom - note about `allSettled`
+	public get toolsMetadata(): readonly string[] | null {
+		return this.reference.allToolsMetadata;
 	}
 
 	/**
@@ -115,14 +123,15 @@ export class ChatPromptAttachmentModel extends Disposable {
 	) {
 		super();
 
-		this._onUpdate.fire = this._onUpdate.fire.bind(this._onUpdate);
 		this._reference = this._register(this.initService.createInstance(
 			BasePromptParser,
 			this.getContentsProvider(uri),
 			[],
 		));
 
-		this._reference.onUpdate(this._onUpdate.fire);
+		this._reference.onUpdate(
+			this._onUpdate.fire.bind(this._onUpdate),
+		);
 	}
 
 	/**

--- a/src/vs/workbench/contrib/chat/browser/chatAttachmentModel/chatPromptAttachmentsCollection.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatAttachmentModel/chatPromptAttachmentsCollection.ts
@@ -15,7 +15,7 @@ import { IConfigurationService } from '../../../../../platform/configuration/com
 import { IChatRequestVariableEntry, IPromptVariableEntry, isChatRequestFileEntry } from '../../common/chatModel.js';
 
 /**
- * TODO: @legomushroom
+ * Prefix for all prompt instruction variable IDs.
  */
 const PROMPT_VARIABLE_ID_PREFIX = 'vscode.prompt.instructions';
 
@@ -88,7 +88,7 @@ export const toChatVariable = (
 };
 
 /**
- * TODO: @legomushroom
+ * Checks of a provided chat variable is a `prompt file` variable.
  */
 export function isPromptFileChatVariable(
 	variable: IChatRequestVariableEntry,

--- a/src/vs/workbench/contrib/chat/browser/chatAttachmentModel/chatPromptAttachmentsCollection.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatAttachmentModel/chatPromptAttachmentsCollection.ts
@@ -87,6 +87,9 @@ export const toChatVariable = (
 	};
 };
 
+/**
+ * TODO: @legomushroom
+ */
 export function isPromptFileChatVariable(
 	variable: IChatRequestVariableEntry,
 ): variable is IPromptVariableEntry {

--- a/src/vs/workbench/contrib/chat/browser/chatAttachmentModel/chatPromptAttachmentsCollection.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatAttachmentModel/chatPromptAttachmentsCollection.ts
@@ -6,13 +6,18 @@
 import { URI } from '../../../../../base/common/uri.js';
 import { Emitter } from '../../../../../base/common/event.js';
 import { basename } from '../../../../../base/common/resources.js';
-import { IChatRequestVariableEntry, isChatRequestFileEntry } from '../../common/chatModel.js';
 import { ChatPromptAttachmentModel } from './chatPromptAttachmentModel.js';
 import { PromptsConfig } from '../../../../../platform/prompts/common/config.js';
 import { IPromptFileReference } from '../../common/promptSyntax/parsers/types.js';
 import { Disposable, DisposableMap } from '../../../../../base/common/lifecycle.js';
 import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
+import { IChatRequestVariableEntry, IPromptVariableEntry, isChatRequestFileEntry } from '../../common/chatModel.js';
+
+/**
+ * TODO: @legomushroom
+ */
+const PROMPT_VARIABLE_ID_PREFIX = 'vscode.prompt.instructions';
 
 /**
  * Prompt IDs start with a well-defined prefix that is used by
@@ -27,7 +32,7 @@ export const createPromptVariableId = (
 	isRoot: boolean,
 ): string => {
 	// the default prefix that is used for all prompt files
-	let prefix = 'vscode.prompt.instructions';
+	let prefix = PROMPT_VARIABLE_ID_PREFIX;
 	// if the reference is the root object, add the `.root` suffix
 	if (isRoot) {
 		prefix += '.root';
@@ -53,7 +58,7 @@ export const createPromptVariableId = (
 export const toChatVariable = (
 	reference: Pick<IPromptFileReference, 'uri' | 'isPromptFile'>,
 	isRoot: boolean,
-): IChatRequestVariableEntry => {
+): IPromptVariableEntry => {
 	const { uri, isPromptFile } = reference;
 
 	// default `id` is the stringified `URI`
@@ -78,11 +83,15 @@ export const toChatVariable = (
 		value: uri,
 		kind: 'file',
 		modelDescription,
+		isRoot,
 	};
 };
 
-export function isPromptFileChatVariable(variable: IChatRequestVariableEntry): boolean {
-	return isChatRequestFileEntry(variable) && variable.name.startsWith('prompt:');
+export function isPromptFileChatVariable(
+	variable: IChatRequestVariableEntry,
+): variable is IPromptVariableEntry {
+	return isChatRequestFileEntry(variable)
+		&& variable.id.startsWith(PROMPT_VARIABLE_ID_PREFIX);
 }
 
 /**

--- a/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
@@ -160,7 +160,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 
 	readonly selectedToolsModel: ChatSelectedTools;
 
-	public getAttachedAndImplicitContext(sessionId: string): IChatRequestVariableEntry[] {
+	public async getAttachedAndImplicitContext(sessionId: string): Promise<IChatRequestVariableEntry[]> {
 		const contextArr = [...this.attachmentModel.attachments];
 		if (this.implicitContext?.enabled && this.implicitContext.value) {
 			contextArr.push(this.implicitContext.toBaseEntry());
@@ -181,6 +181,9 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 				}),
 			);
 		}
+
+		// wait for all prompt files resolve precesses to settle
+		await this.promptInstructionsAttachmentsPart.allSettled();
 
 		contextArr
 			.push(...this.promptInstructionsAttachmentsPart.chatAttachments);

--- a/src/vs/workbench/contrib/chat/browser/chatSelectedTools.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSelectedTools.ts
@@ -3,7 +3,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-
 import { reset } from '../../../../base/browser/dom.js';
 import { IActionViewItemProvider } from '../../../../base/browser/ui/actionbar/actionbar.js';
 import { IActionViewItemOptions } from '../../../../base/browser/ui/actionbar/actionViewItems.js';
@@ -43,6 +42,8 @@ export class ChatSelectedTools extends Disposable {
 
 	readonly toolsActionItemViewItemProvider: IActionViewItemProvider & { onDidRender: Event<void> };
 
+	private allTools: IObservable<Readonly<IToolData>[]>;
+
 	constructor(
 		@ILanguageModelToolsService toolsService: ILanguageModelToolsService,
 		@IInstantiationService instaService: IInstantiationService,
@@ -52,7 +53,7 @@ export class ChatSelectedTools extends Disposable {
 
 		this._selectedTools = this._register(storedTools(StorageScope.WORKSPACE, StorageTarget.MACHINE, storageService));
 
-		const allTools = observableFromEvent(
+		this.allTools = observableFromEvent(
 			toolsService.onDidChangeTools,
 			() => Array.from(toolsService.getTools()).filter(t => t.supportsToolPicker)
 		);
@@ -66,7 +67,7 @@ export class ChatSelectedTools extends Disposable {
 
 		this.tools = derived(r => {
 			const disabled = disabledData.read(r);
-			const tools = allTools.read(r);
+			const tools = this.allTools.read(r);
 			if (!disabled) {
 				return tools;
 			}
@@ -77,7 +78,7 @@ export class ChatSelectedTools extends Disposable {
 		});
 
 		const toolsCount = derived(r => {
-			const count = allTools.read(r).length;
+			const count = this.allTools.read(r).length;
 			const enabled = this.tools.read(r).length;
 			return { count, enabled };
 		});
@@ -123,6 +124,23 @@ export class ChatSelectedTools extends Disposable {
 			},
 			{ onDidRender: onDidRender.event }
 		);
+	}
+
+	/**
+	 * Select only the provided tools unselecting the rest.
+	 *
+	 * @param tools Set of tool IDs to select.
+	 */
+	public selectOnly(
+		tools: Set<string>,
+	): void {
+		const allTools = this.allTools.get();
+
+		const disabledTools = allTools.filter((tool) => {
+			return (tools.has(tool.id) === false);
+		});
+
+		this.update([], disabledTools);
 	}
 
 	update(disableBuckets: readonly ToolDataSource[], disableTools: readonly IToolData[]): void {

--- a/src/vs/workbench/contrib/chat/browser/chatSelectedTools.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSelectedTools.ts
@@ -132,12 +132,13 @@ export class ChatSelectedTools extends Disposable {
 	 * @param tools Set of tool IDs to select.
 	 */
 	public selectOnly(
-		tools: Set<string>,
+		tools: readonly string[],
 	): void {
 		const allTools = this.allTools.get();
+		const uniqueTools = new Set(tools);
 
 		const disabledTools = allTools.filter((tool) => {
-			return (tools.has(tool.id) === false);
+			return (uniqueTools.has(tool.id) === false);
 		});
 
 		this.update([], disabledTools);

--- a/src/vs/workbench/contrib/chat/common/chatModel.ts
+++ b/src/vs/workbench/contrib/chat/common/chatModel.ts
@@ -127,6 +127,12 @@ export interface IDiagnosticVariableEntryFilterData {
 	readonly filterRange?: IRange;
 }
 
+export interface IPromptVariableEntry extends IBaseChatRequestVariableEntry {
+	readonly kind: 'file';
+	readonly value: URI | Location;
+	readonly isRoot: boolean;
+}
+
 export namespace IDiagnosticVariableEntryFilterData {
 	export const icon = Codicon.error;
 

--- a/src/vs/workbench/contrib/chat/common/chatModel.ts
+++ b/src/vs/workbench/contrib/chat/common/chatModel.ts
@@ -127,6 +127,9 @@ export interface IDiagnosticVariableEntryFilterData {
 	readonly filterRange?: IRange;
 }
 
+/**
+ * Chat variable that represents an attached prompt file.
+ */
 export interface IPromptVariableEntry extends IBaseChatRequestVariableEntry {
 	readonly kind: 'file';
 	readonly value: URI | Location;

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/contentProviders/promptContentsProviderBase.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/contentProviders/promptContentsProviderBase.ts
@@ -59,8 +59,6 @@ export abstract class PromptContentsProviderBase<
 		super();
 		// ensure that the `onChangeEmitter` always fires with the correct context
 		this.onChangeEmitter.fire = this.onChangeEmitter.fire.bind(this.onChangeEmitter);
-		// subscribe to the change event emitted by an extending class
-		this._register(this.onChangeEmitter.event(this.onContentsChanged, this));
 	}
 
 	/**
@@ -129,6 +127,10 @@ export abstract class PromptContentsProviderBase<
 
 		// `'full'` means "everything has changed"
 		this.onContentsChanged('full');
+
+		// TODO: @legomushroom
+		// subscribe to the change event emitted by an extending class
+		this._register(this.onChangeEmitter.event(this.onContentsChanged, this));
 
 		return this;
 	}

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/contentProviders/promptContentsProviderBase.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/contentProviders/promptContentsProviderBase.ts
@@ -128,8 +128,8 @@ export abstract class PromptContentsProviderBase<
 		// `'full'` means "everything has changed"
 		this.onContentsChanged('full');
 
-		// TODO: @legomushroom
-		// subscribe to the change event emitted by an extending class
+		// TODO: @legomushroom - test this?
+		// subscribe to the change event emitted by a child class
 		this._register(this.onChangeEmitter.event(this.onContentsChanged, this));
 
 		return this;

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/contentProviders/promptContentsProviderBase.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/contentProviders/promptContentsProviderBase.ts
@@ -128,7 +128,6 @@ export abstract class PromptContentsProviderBase<
 		// `'full'` means "everything has changed"
 		this.onContentsChanged('full');
 
-		// TODO: @legomushroom - test this?
 		// subscribe to the change event emitted by a child class
 		this._register(this.onChangeEmitter.event(this.onContentsChanged, this));
 

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/languageFeatures/providers/decorationsProvider/decorations/frontMatterDecoration.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/languageFeatures/providers/decorationsProvider/decorations/frontMatterDecoration.ts
@@ -3,8 +3,8 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { CssClassModifiers } from '../types.js';
 import { localize } from '../../../../../../../../../nls.js';
-import { CssClassModifiers } from '../../../../service/types.js';
 import { FrontMatterMarkerDecoration } from './frontMatterMarkerDecoration.js';
 import { Position } from '../../../../../../../../../editor/common/core/position.js';
 import { BaseToken } from '../../../../../../../../../editor/common/codecs/baseToken.js';

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/languageFeatures/providers/decorationsProvider/decorations/frontMatterDecoration.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/languageFeatures/providers/decorationsProvider/decorations/frontMatterDecoration.ts
@@ -19,8 +19,8 @@ import { FrontMatterHeader } from '../../../../../../../../../editor/common/code
 export enum CssClassNames {
 	main = '.prompt-front-matter-decoration',
 	inline = '.prompt-front-matter-decoration-inline',
-	mainInactive = `${CssClassNames.main}${CssClassModifiers.Inactive}`,
-	inlineInactive = `${CssClassNames.inline}${CssClassModifiers.Inactive}`,
+	mainInactive = `${CssClassNames.main}${CssClassModifiers.inactive}`,
+	inlineInactive = `${CssClassNames.inline}${CssClassModifiers.inactive}`,
 }
 
 /**

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/languageFeatures/providers/decorationsProvider/decorations/frontMatterMarkerDecoration.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/languageFeatures/providers/decorationsProvider/decorations/frontMatterMarkerDecoration.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { CssClassModifiers } from '../../../../service/types.js';
+import { CssClassModifiers } from '../types.js';
 import { TDecorationStyles, ReactiveDecorationBase } from './utils/index.js';
 import { FrontMatterMarker } from '../../../../../../../../../editor/common/codecs/markdownExtensionsCodec/tokens/frontMatterMarker.js';
 

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/languageFeatures/providers/decorationsProvider/decorations/frontMatterMarkerDecoration.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/languageFeatures/providers/decorationsProvider/decorations/frontMatterMarkerDecoration.ts
@@ -13,8 +13,8 @@ import { FrontMatterMarker } from '../../../../../../../../../editor/common/code
 export enum CssClassNames {
 	main = '.prompt-front-matter-decoration-marker',
 	inline = '.prompt-front-matter-decoration-marker-inline',
-	mainInactive = `${CssClassNames.main}${CssClassModifiers.Inactive}`,
-	inlineInactive = `${CssClassNames.inline}${CssClassModifiers.Inactive}`,
+	mainInactive = `${CssClassNames.main}${CssClassModifiers.inactive}`,
+	inlineInactive = `${CssClassNames.inline}${CssClassModifiers.inactive}`,
 }
 
 /**

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/languageFeatures/providers/decorationsProvider/types.d.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/languageFeatures/providers/decorationsProvider/types.d.ts
@@ -35,3 +35,10 @@ export enum DecorationClassNames {
 	 */
 	fileReference = DecorationClassNames.default,
 }
+
+/**
+ * Decoration CSS class modifiers.
+ */
+export enum CssClassModifiers {
+	Inactive = '.prompt-decoration-inactive',
+}

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/languageFeatures/providers/decorationsProvider/types.d.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/languageFeatures/providers/decorationsProvider/types.d.ts
@@ -40,5 +40,9 @@ export enum DecorationClassNames {
  * Decoration CSS class modifiers.
  */
 export enum CssClassModifiers {
+	/**
+	 * CSS class modifier for `active` state of
+	 * a `reactive` prompt syntax decoration.
+	 */
 	Inactive = '.prompt-decoration-inactive',
 }

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/languageFeatures/providers/decorationsProvider/types.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/languageFeatures/providers/decorationsProvider/types.ts
@@ -3,8 +3,8 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { IRange } from '../../../../../../../../editor/common/core/range.ts';
-import { ModelDecorationOptions } from '../../../../../../../../editor/common/model/textModel.ts';
+import { IRange } from '../../../../../../../../editor/common/core/range.js';
+import { ModelDecorationOptions } from '../../../../../../../../editor/common/model/textModel.js';
 
 /**
  * Decoration object.
@@ -44,5 +44,5 @@ export enum CssClassModifiers {
 	 * CSS class modifier for `active` state of
 	 * a `reactive` prompt syntax decoration.
 	 */
-	Inactive = '.prompt-decoration-inactive',
+	inactive = '.prompt-decoration-inactive',
 }

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/basePromptParser.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/basePromptParser.ts
@@ -139,7 +139,12 @@ export class BasePromptParser<TContentsProvider extends IPromptContentsProvider>
 			return this;
 		}
 
-		// TODO: @legomushroom - what to do if the stream is not defined?
+		// by the time when the `firstParseResult` promise is resolved,
+		// this object may have been already disposed, hence noop
+		if (this.disposed) {
+			return this;
+		}
+
 		assertDefined(
 			this.stream,
 			'No stream reference found.',

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/basePromptParser.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/basePromptParser.ts
@@ -21,10 +21,10 @@ import { IRange, Range } from '../../../../../../editor/common/core/range.js';
 import { assert, assertNever } from '../../../../../../base/common/assert.js';
 import { BaseToken } from '../../../../../../editor/common/codecs/baseToken.js';
 import { VSBufferReadableStream } from '../../../../../../base/common/buffer.js';
-import { isPromptOrInstructionsFile } from '../../../../../../platform/prompts/common/constants.js';
 import { basename, dirname, extUri } from '../../../../../../base/common/resources.js';
 import { ObservableDisposable } from '../../../../../../base/common/observableDisposable.js';
 import { IWorkspaceContextService } from '../../../../../../platform/workspace/common/workspace.js';
+import { isPromptOrInstructionsFile } from '../../../../../../platform/prompts/common/constants.js';
 import { IInstantiationService } from '../../../../../../platform/instantiation/common/instantiation.js';
 import { MarkdownLink } from '../../../../../../editor/common/codecs/markdownCodec/tokens/markdownLink.js';
 import { MarkdownToken } from '../../../../../../editor/common/codecs/markdownCodec/tokens/markdownToken.js';
@@ -486,6 +486,55 @@ export class BasePromptParser<TContentsProvider extends IPromptContentsProvider>
 	}
 
 	/**
+	 * TODO: @legomushroom
+	 */
+	// TODO: @legomushroom - add unit tests?
+	public get toolsMetadata(): readonly string[] | null {
+		if (this.header === undefined) {
+			return null;
+		}
+
+		const { tools } = this.header.metadata;
+		if (tools === undefined) {
+			return null;
+		}
+
+		return tools.toolNames;
+	}
+
+	/**
+	 * TODO: @legomushroom
+	 */
+	// TODO: @legomushroom - add unit tests?
+	public get allToolsMetadata(): readonly string[] | null {
+		let hasTools = false;
+		const result: string[] = [];
+
+		if (this.toolsMetadata !== null) {
+			result.push(...this.toolsMetadata);
+			hasTools = true;
+		}
+
+		for (const reference of this.references) {
+			const { allToolsMetadata } = reference;
+
+			if (allToolsMetadata === null) {
+				continue;
+			}
+
+			result.push(...allToolsMetadata);
+			hasTools = true;
+		}
+
+		if (hasTools === false) {
+			return null;
+		}
+
+		// return unique list of tools
+		return [...new Set(result)];
+	}
+
+	/**
 	 * Get list of errors for the direct links of the current reference.
 	 */
 	public get errors(): readonly ResolveError[] {
@@ -763,6 +812,14 @@ export class PromptReference extends ObservableDisposable implements IPromptRefe
 
 	public get allReferences(): readonly IPromptReference[] {
 		return this.parser.allReferences;
+	}
+
+	public get toolsMetadata(): readonly string[] | null {
+		return this.parser.toolsMetadata;
+	}
+
+	public get allToolsMetadata(): readonly string[] | null {
+		return this.parser.allToolsMetadata;
 	}
 
 	public get allValidReferences(): readonly IPromptReference[] {

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/basePromptParser.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/basePromptParser.ts
@@ -488,7 +488,6 @@ export class BasePromptParser<TContentsProvider extends IPromptContentsProvider>
 	/**
 	 * Associated `tools` metadata for the current reference.
 	 */
-	// TODO: @legomushroom - add unit tests?
 	public get toolsMetadata(): readonly string[] | null {
 		if (this.header === undefined) {
 			return null;
@@ -506,7 +505,6 @@ export class BasePromptParser<TContentsProvider extends IPromptContentsProvider>
 	 * Entire associated `tools` metadata for this reference and
 	 * all possible nested child references.
 	 */
-	// TODO: @legomushroom - add unit tests?
 	public get allToolsMetadata(): readonly string[] | null {
 		let hasTools = false;
 		const result: string[] = [];

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/basePromptParser.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/basePromptParser.ts
@@ -486,7 +486,7 @@ export class BasePromptParser<TContentsProvider extends IPromptContentsProvider>
 	}
 
 	/**
-	 * TODO: @legomushroom
+	 * Associated `tools` metadata for the current reference.
 	 */
 	// TODO: @legomushroom - add unit tests?
 	public get toolsMetadata(): readonly string[] | null {
@@ -503,7 +503,8 @@ export class BasePromptParser<TContentsProvider extends IPromptContentsProvider>
 	}
 
 	/**
-	 * TODO: @legomushroom
+	 * Entire associated `tools` metadata for this reference and
+	 * all possible nested child references.
 	 */
 	// TODO: @legomushroom - add unit tests?
 	public get allToolsMetadata(): readonly string[] | null {

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/basePromptParser.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/basePromptParser.ts
@@ -139,6 +139,7 @@ export class BasePromptParser<TContentsProvider extends IPromptContentsProvider>
 			return this;
 		}
 
+		// TODO: @legomushroom - what to do if the stream is not defined?
 		assertDefined(
 			this.stream,
 			'No stream reference found.',

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/promptHeader/header.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/promptHeader/header.ts
@@ -14,9 +14,14 @@ import { FrontMatterRecord } from '../../../../../../../editor/common/codecs/fro
 import { FrontMatterDecoder, TFrontMatterToken } from '../../../../../../../editor/common/codecs/frontMatterCodec/frontMatterDecoder.js';
 
 /**
- * Type of all known metadata records inside the prompt header.
+ * Metadata associated with the prompt header.
  */
-type TMetadataRecord = PromptToolsMetadata;
+interface IHeaderMetadata {
+	/**
+	 * Metadata for `tools` record in the header.
+	 */
+	tools?: PromptToolsMetadata;
+}
 
 /**
  * Prompt header holds all metadata records for a prompt.
@@ -28,17 +33,14 @@ export class PromptHeader extends Disposable {
 	private readonly stream: FrontMatterDecoder;
 
 	/**
-	 * List of all unique well-known metadata records
-	 * inside the prompt header.
+	 * Metadata records associated with the header.
 	 */
-	private readonly records: TMetadataRecord[];
-
+	private readonly meta: IHeaderMetadata;
 	/**
-	 * List of all unique well-known metadata records
-	 * inside the prompt header.
+	 * Metadata records associated with the header.
 	 */
-	public get metadata(): readonly TMetadataRecord[] {
-		return this.records;
+	public get metadata(): Readonly<IHeaderMetadata> {
+		return this.meta;
 	}
 
 	/**
@@ -65,7 +67,7 @@ export class PromptHeader extends Disposable {
 		super();
 
 		this.issues = [];
-		this.records = [];
+		this.meta = {};
 		this.recordNames = new Set<string>();
 
 		this.stream = this._register(
@@ -131,7 +133,7 @@ export class PromptHeader extends Disposable {
 			const { diagnostics } = toolsMetadata;
 
 			this.issues.push(...diagnostics);
-			this.records.push(toolsMetadata);
+			this.meta.tools = toolsMetadata;
 			this.recordNames.add(recordName);
 
 			return;

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/types.d.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/types.d.ts
@@ -132,13 +132,13 @@ interface IPromptReferenceBase extends IDisposable {
 	/**
 	 * Direct references of the current reference.
 	 */
-	references: readonly IPromptReference[];
+	readonly references: readonly IPromptReference[];
 
 	/**
 	 * All references that the current reference may have,
 	 * including all possible nested child references.
 	 */
-	allReferences: readonly IPromptReference[];
+	readonly allReferences: readonly IPromptReference[];
 
 	/**
 	 * All *valid* references that the current reference may have,
@@ -148,16 +148,16 @@ interface IPromptReferenceBase extends IDisposable {
 	 * without creating a circular reference loop or having any other
 	 * issues that would make the reference resolve logic to fail.
 	 */
-	// TODO: @legomushroom - add `readonly` to all fields
-	allValidReferences: readonly IPromptReference[];
+	readonly allValidReferences: readonly IPromptReference[];
 
 	/**
-	 * TODO: @legomushroom
+	 * Associated `tools` metadata for the current reference.
 	 */
 	readonly toolsMetadata?: readonly string[] | null;
 
 	/**
-	 * TODO: @legomushroom
+	 * Entire associated `tools` metadata for this reference and
+	 * all possible nested child references.
 	 */
 	readonly allToolsMetadata: readonly string[] | null;
 

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/types.d.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/types.d.ts
@@ -148,7 +148,18 @@ interface IPromptReferenceBase extends IDisposable {
 	 * without creating a circular reference loop or having any other
 	 * issues that would make the reference resolve logic to fail.
 	 */
+	// TODO: @legomushroom - add `readonly` to all fields
 	allValidReferences: readonly IPromptReference[];
+
+	/**
+	 * TODO: @legomushroom
+	 */
+	readonly toolsMetadata?: readonly string[] | null;
+
+	/**
+	 * TODO: @legomushroom
+	 */
+	readonly allToolsMetadata: readonly string[] | null;
 
 	/**
 	 * Returns a promise that resolves when the reference contents

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/service/types.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/service/types.ts
@@ -45,7 +45,6 @@ export interface IPromptPath {
 	readonly type: TPromptsType;
 }
 
-
 /**
  * Provides prompt services.
  */
@@ -76,7 +75,7 @@ export interface IPromptsService extends IDisposable {
 	getPromptSlashData(name: string): IChatPromptSlashData | undefined;
 
 	/**
-	 * Searches for the prompt file for the slash command
+	 * Searches for the prompt file for the slash command.
 	 */
 	resolvePromptSlashData(data: IChatPromptSlashData): Promise<IPromptPath | undefined>;
 
@@ -90,6 +89,7 @@ export interface IChatPromptSlashData {
 /**
  * Decoration CSS class modifiers.
  */
+// TODO: @legomushroom - move out
 export enum CssClassModifiers {
 	Inactive = '.prompt-decoration-inactive',
 }

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/service/types.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/service/types.ts
@@ -85,11 +85,3 @@ export interface IChatPromptSlashData {
 	readonly command: string;
 	readonly detail: string;
 }
-
-/**
- * Decoration CSS class modifiers.
- */
-// TODO: @legomushroom - move out
-export enum CssClassModifiers {
-	Inactive = '.prompt-decoration-inactive',
-}

--- a/src/vs/workbench/contrib/chat/test/common/promptSyntax/parsers/textModelPromptParser.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/promptSyntax/parsers/textModelPromptParser.test.ts
@@ -22,7 +22,6 @@ import { ExpectedDiagnosticWarning, TExpectedDiagnostic } from '../testUtils/exp
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../../base/test/common/utils.js';
 import { TextModelPromptParser } from '../../../../common/promptSyntax/parsers/textModelPromptParser.js';
 import { IInstantiationService } from '../../../../../../../platform/instantiation/common/instantiation.js';
-import { PromptToolsMetadata } from '../../../../common/promptSyntax/parsers/promptHeader/metadata/tools.js';
 import { InMemoryFileSystemProvider } from '../../../../../../../platform/files/common/inMemoryFilesystemProvider.js';
 import { TestInstantiationService } from '../../../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
 
@@ -303,32 +302,25 @@ suite('TextModelPromptParser', () => {
 				}),
 			]);
 
-			const { header } = test.parser;
+			const { header, toolsMetadata } = test.parser;
 			assertDefined(
 				header,
 				'Prompt header must be defined.',
 			);
 
-			assert.strictEqual(
-				header.metadata.length,
-				1,
-				'Prompt header must have 1 metadata record.',
-			);
-
-			const tools = header.metadata[0];
-			assert(
-				tools instanceof PromptToolsMetadata,
-				`Prompt header must have tools metadata record, got '${tools}'.`,
+			assertDefined(
+				toolsMetadata,
+				'Tools metadata must be present.',
 			);
 
 			assert.strictEqual(
-				tools.toolNames.length,
+				toolsMetadata.length,
 				2,
-				`Prompt header tools metadata must have 2 tool names, got '[${tools.toolNames.join(', ')}]'.`,
+				`Prompt header tools metadata must have 2 tool names, got '[${toolsMetadata.join(', ')}]'.`,
 			);
 
 			assert.deepStrictEqual(
-				tools.toolNames,
+				toolsMetadata,
 				['tool_name1', 'tool_name2'],
 				`Prompt header must have correct tools metadata.`,
 			);
@@ -364,22 +356,15 @@ suite('TextModelPromptParser', () => {
 				}),
 			]);
 
-			const { header } = test.parser;
+			const { header, toolsMetadata } = test.parser;
 			assertDefined(
 				header,
 				'Prompt header must be defined.',
 			);
 
-			assert.strictEqual(
-				header.metadata.length,
-				1,
-				'Prompt header must have 1 metadata record.',
-			);
-
-			const tools = header.metadata[0];
-			assert(
-				tools instanceof PromptToolsMetadata,
-				`Prompt header must have tools metadata record, got '${tools}'.`,
+			assertDefined(
+				toolsMetadata,
+				'Tools metadata must be defined.',
 			);
 
 			await test.validateHeaderDiagnostics([

--- a/src/vs/workbench/contrib/chat/test/common/promptSyntax/promptFileReference.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/promptSyntax/promptFileReference.test.ts
@@ -185,7 +185,7 @@ class TestPromptFileReference extends Disposable {
 			[
 				`\nExpected(${this.expectedReferences.length}): [\n ${this.expectedReferences.join('\n ')}\n]`,
 				`Received(${resolvedReferences.length}): [\n ${resolvedReferences.join('\n ')}\n]`,
-			].join('\n')
+			].join('\n'),
 		);
 
 		return rootReference;
@@ -724,7 +724,7 @@ suite('PromptFileReference (Unix)', function () {
 								'## Some Header',
 								'some contents',
 								' ',
-							].join('\n'),
+							],
 						},
 						{
 							name: 'file2.prompt.md',
@@ -736,7 +736,7 @@ suite('PromptFileReference (Unix)', function () {
 								'\t- this file #file:folder1/file3.prompt.md ',
 								'\t- also this [file4.prompt.md](./folder1/some-other-folder/file4.prompt.md) please!',
 								' ',
-							].join('\n'), // TODO: @legomushroom - allow for `string[]` content natively
+							],
 						},
 						{
 							name: 'folder1',
@@ -751,7 +751,7 @@ suite('PromptFileReference (Unix)', function () {
 										'[](./some-other-folder/non-existing-folder)',
 										`\t- some seemingly random #file:${rootFolder}/folder1/some-other-folder/yetAnotherFolder🤭/another-file.prompt.md contents`,
 										' some more\t content',
-									].join('\n'),
+									],
 								},
 								{
 									name: 'some-other-folder',
@@ -768,7 +768,7 @@ suite('PromptFileReference (Unix)', function () {
 												'',
 												'and some',
 												' non-prompt #file:./some-non-prompt-file.md\t\t \t[](../../folder1/)\t',
-											].join('\n'),
+											],
 										},
 										{
 											name: 'file.txt',
@@ -785,7 +785,7 @@ suite('PromptFileReference (Unix)', function () {
 														'---',
 														`[](${rootFolder}/folder1/some-other-folder)`,
 														'another-file.prompt.md contents\t [#file:file.txt](../file.txt)',
-													].join('\n'),
+													],
 												},
 												{
 													name: 'one_more_file_just_in_case.prompt.md',

--- a/src/vs/workbench/contrib/chat/test/common/promptSyntax/testUtils/mockFilesystem.ts
+++ b/src/vs/workbench/contrib/chat/test/common/promptSyntax/testUtils/mockFilesystem.ts
@@ -19,7 +19,7 @@ interface IMockFilesystemNode {
  * Represents a `file` node.
  */
 export interface IMockFile extends IMockFilesystemNode {
-	contents: string;
+	contents: string | readonly string[];
 }
 
 /**
@@ -90,7 +90,11 @@ export class MockFilesystem {
 					`File '${folderUri.path}' already exists.`,
 				);
 
-				await this.fileService.writeFile(childUri, VSBuffer.fromString(child.contents));
+				const contents: string = (typeof child.contents === 'string')
+					? child.contents
+					: child.contents.join('\n');
+
+				await this.fileService.writeFile(childUri, VSBuffer.fromString(contents));
 
 				resolvedChildren.push({
 					...child,


### PR DESCRIPTION
Adds the ability to run previously saved prompt files with specified tools metadata.

Part of https://github.com/microsoft/vscode-copilot/issues/15596, https://github.com/microsoft/vscode-copilot/issues/15420 and https://github.com/microsoft/vscode-copilot/issues/12203