### PR TITLE
config: allow asking for input even in an empty workspace

### DIFF
--- a/src/vs/workbench/services/configurationResolver/browser/baseConfigurationResolverService.ts
+++ b/src/vs/workbench/services/configurationResolver/browser/baseConfigurationResolverService.ts
@@ -198,7 +198,7 @@ export abstract class BaseConfigurationResolverService extends AbstractVariableR
 	}
 
 	private async resolveInputs(folder: IWorkspaceFolderData | undefined, section: string, target?: ConfigurationTarget): Promise<ConfiguredInput[] | undefined> {
-		if (this.workspaceContextService.getWorkbenchState() === WorkbenchState.EMPTY || !section) {
+		if (!section) {
 			return undefined;
 		}
 

--- a/src/vs/workbench/services/configurationResolver/browser/baseConfigurationResolverService.ts
+++ b/src/vs/workbench/services/configurationResolver/browser/baseConfigurationResolverService.ts
@@ -17,7 +17,7 @@ import { ConfigurationTarget, IConfigurationOverrides, IConfigurationService } f
 import { ILabelService } from '../../../../platform/label/common/label.js';
 import { IInputOptions, IPickOptions, IQuickInputService, IQuickPickItem } from '../../../../platform/quickinput/common/quickInput.js';
 import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
-import { IWorkspaceContextService, IWorkspaceFolderData, WorkbenchState } from '../../../../platform/workspace/common/workspace.js';
+import { IWorkspaceContextService, IWorkspaceFolderData } from '../../../../platform/workspace/common/workspace.js';
 import { EditorResourceAccessor, SideBySideEditor } from '../../../common/editor.js';
 import { IEditorService } from '../../editor/common/editorService.js';
 import { IExtensionService } from '../../extensions/common/extensions.js';
@@ -44,7 +44,7 @@ export abstract class BaseConfigurationResolverService extends AbstractVariableR
 		editorService: IEditorService,
 		private readonly configurationService: IConfigurationService,
 		private readonly commandService: ICommandService,
-		private readonly workspaceContextService: IWorkspaceContextService,
+		workspaceContextService: IWorkspaceContextService,
 		private readonly quickInputService: IQuickInputService,
 		private readonly labelService: ILabelService,
 		private readonly pathService: IPathService,


### PR DESCRIPTION
This behavior dates from when inputs were first added (#63910). I don't
think this does much anymore -- if a config is not found in the
requested section, undefined is returned anyway, and aborting
early doesn't get us much.

Fixes #245707

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
