### PR TITLE
fix: color of placeholder text does not respect setting

### DIFF
--- a/src/vs/editor/contrib/placeholderText/browser/placeholderText.contribution.ts
+++ b/src/vs/editor/contrib/placeholderText/browser/placeholderText.contribution.ts
@@ -13,4 +13,4 @@ import { wrapInReloadableClass1 } from '../../../../platform/observable/common/w
 
 registerEditorContribution(PlaceholderTextContribution.ID, wrapInReloadableClass1(() => PlaceholderTextContribution), EditorContributionInstantiation.Eager);
 
-registerColor('editor.placeholder.foreground', ghostTextForeground, localize('placeholderForeground', 'Foreground color of the placeholder text in the editor.'));
+export const placeholderForeground = registerColor('editor.placeholder.foreground', ghostTextForeground, localize('placeholderForeground', 'Foreground color of the placeholder text in the editor.'));

--- a/src/vs/editor/contrib/placeholderText/browser/placeholderText.css
+++ b/src/vs/editor/contrib/placeholderText/browser/placeholderText.css
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 .monaco-editor {
-	--vscode-editor-placeholder-foreground: var(--vscode-editorGhostText-foreground);
 
 	.editorPlaceholder {
 		top: 0px;


### PR DESCRIPTION
fix #230056. See bug description for how to test.

Root cause is `--vscode-editor-placeholder-foreground: var(--vscode-editorGhostText-foreground);`.
This forces the placeholder foreground to be the color of ghost text. Since this is on the CSS level, setting would not be respected.
The addition of `export const placeholderForeground` is not strictly necessary. Just in case the color is used as default for another color in the future.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
