### PR TITLE
refactor(nls): use then for JSON parsing

### DIFF
--- a/src/vs/base/node/nls.ts
+++ b/src/vs/base/node/nls.ts
@@ -123,9 +123,9 @@ export async function resolveNLSConfiguration({ userLocale, osLocale, userDataPa
 			//               ^moduleId ^nlsKeys                               ^moduleId      ^nlsKey ^nlsValue
 			= await Promise.all([
 				fs.promises.mkdir(commitLanguagePackCachePath, { recursive: true }),
-				JSON.parse(await fs.promises.readFile(path.join(nlsMetadataPath, 'nls.keys.json'), 'utf-8')),
-				JSON.parse(await fs.promises.readFile(path.join(nlsMetadataPath, 'nls.messages.json'), 'utf-8')),
-				JSON.parse(await fs.promises.readFile(mainLanguagePackPath, 'utf-8'))
+				fs.promises.readFile(path.join(nlsMetadataPath, 'nls.keys.json'), 'utf-8').then(content => JSON.parse(content)),
+				fs.promises.readFile(path.join(nlsMetadataPath, 'nls.messages.json'), 'utf-8').then(content => JSON.parse(content)),
+				fs.promises.readFile(mainLanguagePackPath, 'utf-8').then(content => JSON.parse(content)),
 			]);
 
 		const nlsResult: string[] = [];


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

In the original code, using `await` inside each `readFile` call within `Promise.all` made them execute sequentially, negating the parallel execution benefit of `Promise.all`. The refactored version uses `.then` to parse JSON after `readFile` promises resolve, enabling all operations in `Promise.all` to run truly in parallel.