### PR TITLE
fix: correct filename sort by importing pre-existing function

### DIFF
--- a/src/vs/workbench/contrib/testing/browser/testingExplorerView.ts
+++ b/src/vs/workbench/contrib/testing/browser/testingExplorerView.ts
@@ -82,6 +82,7 @@ import './media/testing.css';
 import { DebugLastRun, ReRunLastRun } from './testExplorerActions.js';
 import { TestingExplorerFilter } from './testingExplorerFilter.js';
 import { CountSummary, collectTestStateCounts, getTestProgressText } from './testingProgressUiService.js';
+import { compareFileNames } from '../../../../base/common/comparers.js';
 
 const enum LastFocusState {
 	Input,
@@ -1351,7 +1352,10 @@ class TreeSorter implements ITreeSorter<TestExplorerTreeElement> {
 		const sb = b.test.item.sortText;
 		// If tests are in the same location and there's no preferred sortText,
 		// keep the extension's insertion order (#163449).
-		return inSameLocation && !sa && !sb ? 0 : (sa || a.test.item.label).localeCompare(sb || b.test.item.label);
+
+		// will sort the files considering numeric order
+		return compareFileNames(sa || a.test.item.label, sb || b.test.item.label);
+
 	}
 }
 


### PR DESCRIPTION
Issue #245624: Testing workbench sorts filenames differently to explorer.
The issue suggested to use an existing function {compareFileNames} from comparers for more intuitive + consistent sorting of test cases. I imported the function and replaced it with the original line of code that used a string comparison which made it mix up numerical sorting. The changed code can be tested by creating files with names of the problematic naming (test1, test10, test2 etc) and ensure it gives the expected order (test1, test2, test10) instead of the issue (test1, test10, test2). 

(first time submitting a pull request and unsure if this pull request is formatted correctly + issue was open when I last checked the issue). Thank you for reviewing.