### PR TITLE
[prompts]: add 'description' prompt header metadata support

### DIFF
--- a/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/promptHeader/header.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/promptHeader/header.ts
@@ -5,6 +5,7 @@
 
 import { localize } from '../../../../../../../nls.js';
 import { PromptToolsMetadata } from './metadata/tools.js';
+import { PromptDescriptionMetadata } from './metadata/description.js';
 import { Disposable } from '../../../../../../../base/common/lifecycle.js';
 import { Text } from '../../../../../../../editor/common/codecs/baseToken.js';
 import { PromptMetadataError, PromptMetadataWarning, TDiagnostic } from './diagnostics.js';
@@ -21,6 +22,11 @@ interface IHeaderMetadata {
 	 * Metadata for `tools` record in the header.
 	 */
 	tools?: PromptToolsMetadata;
+
+	/**
+	 * Metadata for `description` record in the header.
+	 */
+	description?: PromptDescriptionMetadata;
 }
 
 /**

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/promptHeader/header.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/promptHeader/header.ts
@@ -15,16 +15,16 @@ import { FrontMatterRecord } from '../../../../../../../editor/common/codecs/fro
 import { FrontMatterDecoder, TFrontMatterToken } from '../../../../../../../editor/common/codecs/frontMatterCodec/frontMatterDecoder.js';
 
 /**
- * Metadata associated with the prompt header.
+ * Metadata defined in the prompt header.
  */
-interface IHeaderMetadata {
+export interface IHeaderMetadata {
 	/**
-	 * Metadata for `tools` record in the header.
+	 * Tools metadata in the prompt header.
 	 */
 	tools?: PromptToolsMetadata;
 
 	/**
-	 * Metadata for `description` record in the header.
+	 * Description metadata in the prompt header.
 	 */
 	description?: PromptDescriptionMetadata;
 }
@@ -39,11 +39,11 @@ export class PromptHeader extends Disposable {
 	private readonly stream: FrontMatterDecoder;
 
 	/**
-	 * Metadata records associated with the header.
+	 * Metadata records.
 	 */
 	private readonly meta: IHeaderMetadata;
 	/**
-	 * Metadata records associated with the header.
+	 * Metadata records.
 	 */
 	public get metadata(): Readonly<IHeaderMetadata> {
 		return this.meta;

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/promptHeader/header.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/promptHeader/header.ts
@@ -145,6 +145,18 @@ export class PromptHeader extends Disposable {
 			return;
 		}
 
+		// if the record might be a "description" metadata
+		// add it to the list of parsed metadata records
+		if (PromptDescriptionMetadata.isDescriptionRecord(token)) {
+			const descriptionMetadata = new PromptDescriptionMetadata(token);
+			const { diagnostics } = descriptionMetadata;
+
+			this.issues.push(...diagnostics);
+			this.meta.description = descriptionMetadata;
+			this.recordNames.add(recordName);
+			return;
+		}
+
 		// all other records are currently not supported
 		this.issues.push(
 			new PromptMetadataWarning(

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/promptHeader/metadata/description.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/promptHeader/metadata/description.ts
@@ -32,12 +32,12 @@ export class PromptDescriptionMetadata extends PromptMetadataRecord {
 	}
 
 	/**
-	 * TODO: @legomushroom
+	 * Value token reference of the record.
 	 */
 	private valueToken: FrontMatterString | undefined;
 
 	/**
-	 * TODO: @legomushroom
+	 * Clean text value of the record.
 	 */
 	public get text(): string | null {
 		const { valueToken } = this;

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/promptHeader/metadata/description.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/promptHeader/metadata/description.ts
@@ -1,0 +1,112 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { PromptMetadataRecord } from './record.js';
+import { localize } from '../../../../../../../../nls.js';
+import { assert } from '../../../../../../../../base/common/assert.js';
+import { PromptMetadataDiagnostic, PromptMetadataError } from '../diagnostics.js';
+import { FrontMatterRecord, FrontMatterString, FrontMatterToken } from '../../../../../../../../editor/common/codecs/frontMatterCodec/tokens/index.js';
+
+/**
+ * Name of the `description` metadata record in the prompt header.
+ */
+const RECORD_NAME = 'description';
+
+/**
+ * Prompt `description` metadata record inside the prompt header.
+ */
+export class PromptDescriptionMetadata extends PromptMetadataRecord {
+	/**
+	 * Private field for tracking all diagnostic issues
+	 * related to this metadata record.
+	 */
+	private readonly issues: PromptMetadataDiagnostic[];
+
+	/**
+	 * List of all diagnostic issues related to this metadata record.
+	 */
+	public get diagnostics(): readonly PromptMetadataDiagnostic[] {
+		return this.issues;
+	}
+
+	/**
+	 * TODO: @legomushroom
+	 */
+	private valueToken: FrontMatterString | undefined;
+
+	/**
+	 * TODO: @legomushroom
+	 */
+	public get text(): string | null {
+		const { valueToken } = this;
+
+		if (valueToken === undefined) {
+			return null;
+		}
+
+		return valueToken.cleanText;
+	}
+
+	constructor(
+		private readonly recordToken: FrontMatterRecord,
+	) {
+		// sanity check on the name of the record
+		assert(
+			PromptDescriptionMetadata.isDescriptionRecord(recordToken),
+			`Record token must be 'description', got '${recordToken.nameToken.text}'.`,
+		);
+
+		super(recordToken.range);
+
+		this.issues = [];
+		this.collectDiagnostics();
+	}
+
+	/**
+	 * Validate the metadata record and collect all issues
+	 * related to its content.
+	 */
+	private collectDiagnostics(): void {
+		const { valueToken } = this.recordToken;
+
+		// validate that the record value is a string
+		if ((valueToken instanceof FrontMatterString) === false) {
+			this.issues.push(
+				new PromptMetadataError(
+					valueToken.range,
+					localize(
+						'prompt.header.metadata.description.diagnostics.invalid-value-type',
+						"Value of the '{0}' metadata must be '{1}', got '{2}.",
+						RECORD_NAME,
+						'string',
+						valueToken.valueTypeName,
+					),
+				),
+			);
+
+			return;
+		}
+
+		this.valueToken = valueToken;
+	}
+
+	/**
+	 * Check if a provided front matter token is a metadata record
+	 * with name equal to `description`.
+	 */
+	public static isDescriptionRecord(
+		token: FrontMatterToken,
+	): boolean {
+		if ((token instanceof FrontMatterRecord) === false) {
+			return false;
+		}
+
+		if (token.nameToken.text === RECORD_NAME) {
+			return true;
+		}
+
+		return false;
+	}
+}

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/types.d.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/types.d.ts
@@ -7,6 +7,7 @@ import { URI } from '../../../../../../base/common/uri.js';
 import { ResolveError } from '../../promptFileReferenceErrors.js';
 import { IDisposable } from '../../../../../../base/common/lifecycle.js';
 import { IRange, Range } from '../../../../../../editor/common/core/range.js';
+import { IHeaderMetadata } from './promptHeader/header.ts';
 
 /**
  * A resolve error with a parent prompt URI, if any.
@@ -46,6 +47,21 @@ export interface ITopError extends IResolveError {
 	 * Localized error message.
 	 */
 	readonly localizedMessage: string;
+}
+
+/**
+ * Metadata defined in the prompt header.
+ */
+export interface IPromptMetadata {
+	/**
+	 * Tools metadata in the prompt header.
+	 */
+	tools?: readonly string[];
+
+	/**
+	 * Description metadata in the prompt header.
+	 */
+	description?: string;
 }
 
 /**
@@ -151,15 +167,15 @@ interface IPromptReferenceBase extends IDisposable {
 	readonly allValidReferences: readonly IPromptReference[];
 
 	/**
-	 * Associated `tools` metadata for the current reference.
-	 */
-	readonly toolsMetadata?: readonly string[] | null;
-
-	/**
 	 * Entire associated `tools` metadata for this reference and
 	 * all possible nested child references.
 	 */
 	readonly allToolsMetadata: readonly string[] | null;
+
+	/**
+	 * Metadata defined in the prompt header.
+	 */
+	readonly metadata: IPromptMetadata;
 
 	/**
 	 * Returns a promise that resolves when the reference contents

--- a/src/vs/workbench/contrib/chat/test/common/promptSyntax/parsers/textModelPromptParser.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/promptSyntax/parsers/textModelPromptParser.test.ts
@@ -302,25 +302,26 @@ suite('TextModelPromptParser', () => {
 				}),
 			]);
 
-			const { header, toolsMetadata } = test.parser;
+			const { header, metadata } = test.parser;
 			assertDefined(
 				header,
 				'Prompt header must be defined.',
 			);
 
+			const { tools } = metadata;
 			assertDefined(
-				toolsMetadata,
+				tools,
 				'Tools metadata must be present.',
 			);
 
 			assert.strictEqual(
-				toolsMetadata.length,
+				tools.length,
 				2,
-				`Prompt header tools metadata must have 2 tool names, got '[${toolsMetadata.join(', ')}]'.`,
+				`Prompt header tools metadata must have 2 tool names, got '[${tools.join(', ')}]'.`,
 			);
 
 			assert.deepStrictEqual(
-				toolsMetadata,
+				tools,
 				['tool_name1', 'tool_name2'],
 				`Prompt header must have correct tools metadata.`,
 			);
@@ -356,14 +357,15 @@ suite('TextModelPromptParser', () => {
 				}),
 			]);
 
-			const { header, toolsMetadata } = test.parser;
+			const { header, metadata } = test.parser;
 			assertDefined(
 				header,
 				'Prompt header must be defined.',
 			);
 
+			const { tools } = metadata;
 			assertDefined(
-				toolsMetadata,
+				tools,
 				'Tools metadata must be defined.',
 			);
 

--- a/src/vs/workbench/contrib/chat/test/common/promptSyntax/promptFileReference.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/promptSyntax/promptFileReference.test.ts
@@ -730,6 +730,7 @@ suite('PromptFileReference (Unix)', function () {
 							name: 'file2.prompt.md',
 							contents: [
 								'---',
+								'description: \'Root prompt description.\'',
 								'tools: [\'my-tool1\']',
 								'---',
 								'## Files',
@@ -809,7 +810,7 @@ suite('PromptFileReference (Unix)', function () {
 				[
 					new ExpectedReference(
 						rootUri,
-						createTestFileReference('folder1/file3.prompt.md', 5, 14),
+						createTestFileReference('folder1/file3.prompt.md', 6, 14),
 					),
 					new ExpectedReference(
 						URI.joinPath(rootUri, './folder1'),
@@ -855,7 +856,7 @@ suite('PromptFileReference (Unix)', function () {
 					new ExpectedReference(
 						rootUri,
 						new MarkdownLink(
-							6, 14,
+							7, 14,
 							'[file4.prompt.md]', '(./folder1/some-other-folder/file4.prompt.md)',
 						),
 					),
@@ -891,16 +892,19 @@ suite('PromptFileReference (Unix)', function () {
 
 			const rootReference = await test.run();
 
-			const { toolsMetadata, allToolsMetadata } = rootReference;
+			const { metadata, allToolsMetadata } = rootReference;
+			const { tools, description } = metadata;
 
-			assertDefined(
-				toolsMetadata,
-				'Tools metadata must to be defined.',
-			);
 			assert.deepStrictEqual(
-				toolsMetadata,
+				tools,
 				['my-tool1'],
 				'Must have correct tools metadata',
+			);
+
+			assert.deepStrictEqual(
+				description,
+				'Root prompt description.',
+				'Must have correct description metadata',
 			);
 
 			assertDefined(


### PR DESCRIPTION
Adds 'description' prompt header metadata support.

Part of https://github.com/microsoft/vscode-copilot/issues/15596, https://github.com/microsoft/vscode-copilot/issues/15420 and https://github.com/microsoft/vscode-copilot/issues/12203