### PR TITLE
[prompts]: add support for 'mode' header metadata

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
@@ -182,8 +182,16 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 			);
 		}
 
+		// prompt files may have nested child references to other prompt
+		// files that are resolved asynchronously, hence we need to wait
+		// for the entire prompt instruction tree to be processed
+		const instructionsStarted = performance.now();
+
 		// wait for all prompt files resolve precesses to settle
 		await this.promptInstructionsAttachmentsPart.allSettled();
+
+		// allow-any-unicode-next-line
+		this.logService.trace(`[⏱] instructions tree resolved in ${performance.now() - instructionsStarted}ms`);
 
 		contextArr
 			.push(...this.promptInstructionsAttachmentsPart.chatAttachments);

--- a/src/vs/workbench/contrib/chat/browser/contrib/chatImplicitContext.ts
+++ b/src/vs/workbench/contrib/chat/browser/contrib/chatImplicitContext.ts
@@ -20,7 +20,7 @@ import { EditorsOrder } from '../../../../common/editor.js';
 import { IEditorService } from '../../../../services/editor/common/editorService.js';
 import { getNotebookEditorFromEditorPane, INotebookEditor } from '../../../notebook/browser/notebookBrowser.js';
 import { IChatEditingService } from '../../common/chatEditingService.js';
-import { IChatRequestFileEntry, IChatRequestImplicitVariableEntry } from '../../common/chatModel.js';
+import { IChatRequestFileEntry, IChatRequestImplicitVariableEntry, IPromptVariableEntry } from '../../common/chatModel.js';
 import { IChatService } from '../../common/chatService.js';
 import { ChatAgentLocation } from '../../common/constants.js';
 import { ILanguageModelIgnoredFilesService } from '../../common/ignoredFiles.js';
@@ -340,13 +340,22 @@ export class ChatImplicitContext extends Disposable implements IChatRequestImpli
 		this._onDidChangeValue.fire();
 	}
 
-	toBaseEntry(): IChatRequestFileEntry {
-		return {
+	toBaseEntry(): IChatRequestFileEntry | IPromptVariableEntry {
+		const result: IChatRequestFileEntry = {
 			kind: 'file',
 			id: this.id,
 			name: this.name,
 			value: this.value,
-			modelDescription: this.modelDescription
+			modelDescription: this.modelDescription,
+		};
+
+		if (this.isPromptFile === false) {
+			return result;
+		}
+
+		return {
+			...result,
+			isRoot: true,
 		};
 	}
 }

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/basePromptParser.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/basePromptParser.ts
@@ -497,27 +497,38 @@ export class BasePromptParser<TContentsProvider extends IPromptContentsProvider>
 	 */
 	public get metadata(): IPromptMetadata {
 		if (this.header === undefined) {
-			return {};
+			return {
+				mode: ChatMode.Ask,
+			};
 		}
 
 		const { metadata } = this.header;
 		if (metadata === undefined) {
-			return {};
+			return {
+				mode: ChatMode.Ask,
+			};
 		}
 
-		const result: IPromptMetadata = {};
 
 		const { tools, mode, description } = metadata;
-		if (tools !== undefined) {
-			result.tools = tools.toolNames;
-		}
 
-		if (mode !== undefined) {
-			result.mode = mode.chatMode;
-		}
+		// compute resulting mode based on presence
+		// of `tools` metadata in the prompt header
+		const resultingMode = (tools !== undefined)
+			? ChatMode.Agent
+			: mode?.chatMode;
+
+		// fallback to `ask` mode if no mode is defined
+		const result: IPromptMetadata = {
+			mode: resultingMode ?? ChatMode.Ask,
+		};
 
 		if (description !== undefined) {
 			result.description = description.text ?? undefined;
+		}
+
+		if (tools !== undefined) {
+			result.tools = tools.toolNames;
 		}
 
 		return result;

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/basePromptParser.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/basePromptParser.ts
@@ -499,7 +499,7 @@ export class BasePromptParser<TContentsProvider extends IPromptContentsProvider>
 			return {};
 		}
 
-		const { metadata, toolsAndModeCompatible } = this.header;
+		const { metadata } = this.header;
 		if (metadata === undefined) {
 			return {};
 		}
@@ -509,13 +509,10 @@ export class BasePromptParser<TContentsProvider extends IPromptContentsProvider>
 		const { tools, mode, description } = metadata;
 		if (tools !== undefined) {
 			result.tools = tools.toolNames;
+		}
 
-			// copy over the `mode` metadata value only if
-			// the `tools` and `mode` metadata are compatible,
-			// otherwise ignore the `mode` metadata completely
-			if (toolsAndModeCompatible === true) {
-				result.mode = mode?.chatMode;
-			}
+		if (mode !== undefined) {
+			result.mode = mode.chatMode;
 		}
 
 		if (description !== undefined) {

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/basePromptParser.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/basePromptParser.ts
@@ -492,23 +492,30 @@ export class BasePromptParser<TContentsProvider extends IPromptContentsProvider>
 	}
 
 	/**
-	 * Metadata defined in the prompt header.
+	 * Valid metadata records defined in the prompt header.
 	 */
 	public get metadata(): IPromptMetadata {
 		if (this.header === undefined) {
 			return {};
 		}
 
-		const { metadata } = this.header;
+		const { metadata, toolsAndModeCompatible } = this.header;
 		if (metadata === undefined) {
 			return {};
 		}
 
 		const result: IPromptMetadata = {};
 
-		const { tools, description } = metadata;
+		const { tools, mode, description } = metadata;
 		if (tools !== undefined) {
 			result.tools = tools.toolNames;
+
+			// copy over the `mode` metadata value only if
+			// the `tools` and `mode` metadata are compatible,
+			// otherwise ignore the `mode` metadata completely
+			if (toolsAndModeCompatible === true) {
+				result.mode = mode?.chatMode;
+			}
 		}
 
 		if (description !== undefined) {

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/promptHeader/header.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/promptHeader/header.ts
@@ -53,7 +53,15 @@ export class PromptHeader extends Disposable {
 	 * Metadata records.
 	 */
 	public get metadata(): Readonly<IHeaderMetadata> {
-		return this.meta;
+		const result = { ...this.meta };
+
+		// if the `tools` and `mode` metadata are compatible,
+		// then drop the `mode` metadata from the result
+		if (this.toolsAndModeCompatible === false) {
+			delete result.mode;
+		}
+
+		return result;
 	}
 
 	/**
@@ -193,7 +201,7 @@ export class PromptHeader extends Disposable {
 	/**
 	 * TODO: @legomushroom
 	 */
-	public get toolsAndModeCompatible(): boolean {
+	private get toolsAndModeCompatible(): boolean {
 		const { tools, mode } = this.meta;
 
 		// if `mode` is not set or equal to `agent` mode,
@@ -223,7 +231,7 @@ export class PromptHeader extends Disposable {
 
 		const { tools, mode } = this.meta;
 
-		// sanity checks on the behavior of the `toolsAndModeCompatible` method
+		// sanity checks on the behavior of the `toolsAndModeCompatible` getter
 		assertDefined(
 			tools,
 			'Tools metadata must have been present.',

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/promptHeader/header.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/promptHeader/header.ts
@@ -169,7 +169,7 @@ export class PromptHeader extends Disposable {
 			this.meta.tools = toolsMetadata;
 			this.recordNames.add(recordName);
 
-			return this.checkToolsAndModeCompatibility();
+			return this.validateToolsAndModeCompatibility();
 		}
 
 		// if the record might be a "mode" metadata
@@ -182,7 +182,7 @@ export class PromptHeader extends Disposable {
 			this.meta.mode = modeMetadata;
 			this.recordNames.add(recordName);
 
-			return this.checkToolsAndModeCompatibility();
+			return this.validateToolsAndModeCompatibility();
 		}
 
 		// all other records are currently not supported
@@ -199,7 +199,8 @@ export class PromptHeader extends Disposable {
 	}
 
 	/**
-	 * TODO: @legomushroom
+	 * Check if value of `tools` and `mode` metadata
+	 * are compatible with each other.
 	 */
 	private get toolsAndModeCompatible(): boolean {
 		const { tools, mode } = this.meta;
@@ -222,9 +223,10 @@ export class PromptHeader extends Disposable {
 	}
 
 	/**
-	 * TODO: @legomushroom
+	 * Validate that the `tools` and `mode` metadata are compatible
+	 * with each other. If not, add a warning diagnostic.
 	 */
-	private checkToolsAndModeCompatibility(): void {
+	private validateToolsAndModeCompatibility(): void {
 		if (this.toolsAndModeCompatible === true) {
 			return;
 		}
@@ -250,7 +252,7 @@ export class PromptHeader extends Disposable {
 				mode.range,
 				localize(
 					'prompt.header.metadata.mode.diagnostics.incompatible-with-tools',
-					"Unknown metadata record '{0}' can only have the '{1}' value if '{2}' record is present so it will be ignored.",
+					"Record '{0}' is implied to have the '{1}' value if '{2}' record is present so the specified value will be ignored.",
 					mode.recordName,
 					ChatMode.Agent,
 					tools.recordName,

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/promptHeader/header.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/promptHeader/header.ts
@@ -3,7 +3,10 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { ChatMode } from '../../../constants.js';
 import { localize } from '../../../../../../../nls.js';
+import { assert } from '../../../../../../../base/common/assert.js';
+import { assertDefined } from '../../../../../../../base/common/types.js';
 import { Disposable } from '../../../../../../../base/common/lifecycle.js';
 import { Text } from '../../../../../../../editor/common/codecs/baseToken.js';
 import { PromptMetadataError, PromptMetadataWarning, TDiagnostic } from './diagnostics.js';
@@ -12,9 +15,6 @@ import { SimpleToken } from '../../../../../../../editor/common/codecs/simpleCod
 import { PromptToolsMetadata, PromptModeMetadata, PromptDescriptionMetadata } from './metadata/index.js';
 import { FrontMatterRecord } from '../../../../../../../editor/common/codecs/frontMatterCodec/tokens/index.js';
 import { FrontMatterDecoder, TFrontMatterToken } from '../../../../../../../editor/common/codecs/frontMatterCodec/frontMatterDecoder.js';
-import { ChatMode } from '../../../constants.js';
-import { assertDefined } from '../../../../../../../base/common/types.js';
-import { assert } from '../../../../../../../base/common/assert.js';
 
 /**
  * Metadata defined in the prompt header.
@@ -53,15 +53,9 @@ export class PromptHeader extends Disposable {
 	 * Metadata records.
 	 */
 	public get metadata(): Readonly<IHeaderMetadata> {
-		const result = { ...this.meta };
-
-		// if the `tools` and `mode` metadata are compatible,
-		// then drop the `mode` metadata from the result
-		if (this.toolsAndModeCompatible === false) {
-			delete result.mode;
-		}
-
-		return result;
+		return Object.freeze({
+			...this.meta,
+		});
 	}
 
 	/**

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/promptHeader/header.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/promptHeader/header.ts
@@ -161,6 +161,18 @@ export class PromptHeader extends Disposable {
 			return;
 		}
 
+		// if the record might be a "mode" metadata
+		// add it to the list of parsed metadata records
+		if (PromptModeMetadata.isModeRecord(token)) {
+			const modeMetadata = new PromptModeMetadata(token);
+			const { diagnostics } = modeMetadata;
+
+			this.issues.push(...diagnostics);
+			this.meta.mode = modeMetadata;
+			this.recordNames.add(recordName);
+			return;
+		}
+
 		// all other records are currently not supported
 		this.issues.push(
 			new PromptMetadataWarning(

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/promptHeader/header.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/promptHeader/header.ts
@@ -193,7 +193,7 @@ export class PromptHeader extends Disposable {
 	/**
 	 * TODO: @legomushroom
 	 */
-	private toolsAndModeCompatible(): boolean {
+	public get toolsAndModeCompatible(): boolean {
 		const { tools, mode } = this.meta;
 
 		// if `mode` is not set or equal to `agent` mode,
@@ -217,7 +217,7 @@ export class PromptHeader extends Disposable {
 	 * TODO: @legomushroom
 	 */
 	private checkToolsAndModeCompatibility(): void {
-		if (this.toolsAndModeCompatible() === true) {
+		if (this.toolsAndModeCompatible === true) {
 			return;
 		}
 

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/promptHeader/header.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/promptHeader/header.ts
@@ -4,13 +4,12 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { localize } from '../../../../../../../nls.js';
-import { PromptToolsMetadata } from './metadata/tools.js';
-import { PromptDescriptionMetadata } from './metadata/description.js';
 import { Disposable } from '../../../../../../../base/common/lifecycle.js';
 import { Text } from '../../../../../../../editor/common/codecs/baseToken.js';
 import { PromptMetadataError, PromptMetadataWarning, TDiagnostic } from './diagnostics.js';
 import { TokenStream } from '../../../../../../../editor/common/codecs/utils/tokenStream.js';
 import { SimpleToken } from '../../../../../../../editor/common/codecs/simpleCodec/tokens/index.js';
+import { PromptToolsMetadata, PromptModeMetadata, PromptDescriptionMetadata } from './metadata/index.js';
 import { FrontMatterRecord } from '../../../../../../../editor/common/codecs/frontMatterCodec/tokens/index.js';
 import { FrontMatterDecoder, TFrontMatterToken } from '../../../../../../../editor/common/codecs/frontMatterCodec/frontMatterDecoder.js';
 
@@ -27,6 +26,11 @@ export interface IHeaderMetadata {
 	 * Description metadata in the prompt header.
 	 */
 	description?: PromptDescriptionMetadata;
+
+	/**
+	 * Chat mode metadata in the prompt header.
+	 */
+	mode?: PromptModeMetadata;
 }
 
 /**

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/promptHeader/metadata/description.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/promptHeader/metadata/description.ts
@@ -10,7 +10,7 @@ import { PromptMetadataDiagnostic, PromptMetadataError } from '../diagnostics.js
 import { FrontMatterRecord, FrontMatterString, FrontMatterToken } from '../../../../../../../../editor/common/codecs/frontMatterCodec/tokens/index.js';
 
 /**
- * Name of the `description` metadata record in the prompt header.
+ * Name of the metadata record in the prompt header.
  */
 const RECORD_NAME = 'description';
 
@@ -18,6 +18,10 @@ const RECORD_NAME = 'description';
  * Prompt `description` metadata record inside the prompt header.
  */
 export class PromptDescriptionMetadata extends PromptMetadataRecord {
+	public override get recordName(): string {
+		return RECORD_NAME;
+	}
+
 	/**
 	 * Private field for tracking all diagnostic issues
 	 * related to this metadata record.

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/promptHeader/metadata/description.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/promptHeader/metadata/description.ts
@@ -82,7 +82,7 @@ export class PromptDescriptionMetadata extends PromptMetadataRecord {
 					valueToken.range,
 					localize(
 						'prompt.header.metadata.description.diagnostics.invalid-value-type',
-						"Value of the '{0}' metadata must be '{1}', got '{2}.",
+						"Value of the '{0}' metadata must be '{1}', got '{2}'.",
 						RECORD_NAME,
 						'string',
 						valueToken.valueTypeName,

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/promptHeader/metadata/index.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/promptHeader/metadata/index.ts
@@ -1,0 +1,8 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+export { PromptModeMetadata } from './mode.js';
+export { PromptToolsMetadata } from './tools.js';
+export { PromptDescriptionMetadata } from './description.js';

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/promptHeader/metadata/mode.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/promptHeader/metadata/mode.ts
@@ -28,6 +28,10 @@ const VALID_MODES = Object.freeze([
  * Prompt `mode` metadata record inside the prompt header.
  */
 export class PromptModeMetadata extends PromptMetadataRecord {
+	public override get recordName(): string {
+		return RECORD_NAME;
+	}
+
 	/**
 	 * Private field for tracking all diagnostic issues
 	 * related to this metadata record.
@@ -44,12 +48,12 @@ export class PromptModeMetadata extends PromptMetadataRecord {
 	/**
 	 * Private field for tracking the chat mode value.
 	 */
-	private modeValue: ChatMode | undefined;
+	private value: ChatMode | undefined;
 	/**
 	 * Chat mode value of the metadata record.
 	 */
-	public get mode(): ChatMode | undefined {
-		return this.modeValue;
+	public get chatMode(): ChatMode | undefined {
+		return this.value;
 	}
 
 	constructor(
@@ -98,7 +102,7 @@ export class PromptModeMetadata extends PromptMetadataRecord {
 		const validModes: string[] = [...VALID_MODES];
 		const index = validModes.indexOf(cleanText);
 		if (index !== -1) {
-			this.modeValue = VALID_MODES[index];
+			this.value = VALID_MODES[index];
 			return;
 		}
 

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/promptHeader/metadata/mode.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/promptHeader/metadata/mode.ts
@@ -85,7 +85,7 @@ export class PromptModeMetadata extends PromptMetadataRecord {
 					valueToken.range,
 					localize(
 						'prompt.header.metadata.mode.diagnostics.invalid-value-type',
-						"Value of the '{0}' metadata must be '{1}', got '{2}.",
+						"Value of the '{0}' metadata must be '{1}', got '{2}'.",
 						RECORD_NAME,
 						'string',
 						valueToken.valueTypeName,

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/promptHeader/metadata/mode.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/promptHeader/metadata/mode.ts
@@ -1,0 +1,140 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { PromptMetadataRecord } from './record.js';
+import { ChatMode } from '../../../../constants.js';
+import { localize } from '../../../../../../../../nls.js';
+import { assert } from '../../../../../../../../base/common/assert.js';
+import { PromptMetadataDiagnostic, PromptMetadataError } from '../diagnostics.js';
+import { FrontMatterRecord, FrontMatterString, FrontMatterToken } from '../../../../../../../../editor/common/codecs/frontMatterCodec/tokens/index.js';
+
+/**
+ * Name of the metadata record in the prompt header.
+ */
+const RECORD_NAME = 'mode';
+
+/**
+ * Valid chat mode values.
+ */
+const VALID_MODES = Object.freeze([
+	ChatMode.Ask,
+	ChatMode.Edit,
+	ChatMode.Agent,
+]);
+
+/**
+ * Prompt `mode` metadata record inside the prompt header.
+ */
+export class PromptModeMetadata extends PromptMetadataRecord {
+	/**
+	 * Private field for tracking all diagnostic issues
+	 * related to this metadata record.
+	 */
+	private readonly issues: PromptMetadataDiagnostic[];
+
+	/**
+	 * List of all diagnostic issues related to this metadata record.
+	 */
+	public get diagnostics(): readonly PromptMetadataDiagnostic[] {
+		return this.issues;
+	}
+
+	/**
+	 * Private field for tracking the chat mode value.
+	 */
+	private modeValue: ChatMode | undefined;
+	/**
+	 * Chat mode value of the metadata record.
+	 */
+	public get mode(): ChatMode | undefined {
+		return this.modeValue;
+	}
+
+	constructor(
+		private readonly recordToken: FrontMatterRecord,
+	) {
+		// sanity check on the name of the record
+		assert(
+			PromptModeMetadata.isModeRecord(recordToken),
+			`Record token must be 'mode', got '${recordToken.nameToken.text}'.`,
+		);
+
+		super(recordToken.range);
+
+		this.issues = [];
+		this.collectDiagnostics();
+	}
+
+	/**
+	 * Validate the metadata record and collect all issues
+	 * related to its content.
+	 */
+	private collectDiagnostics(): void {
+		const { valueToken } = this.recordToken;
+
+		// validate that the record value is a string
+		if ((valueToken instanceof FrontMatterString) === false) {
+			this.issues.push(
+				new PromptMetadataError(
+					valueToken.range,
+					localize(
+						'prompt.header.metadata.mode.diagnostics.invalid-value-type',
+						"Value of the '{0}' metadata must be '{1}', got '{2}.",
+						RECORD_NAME,
+						'string',
+						valueToken.valueTypeName,
+					),
+				),
+			);
+
+			return;
+		}
+
+		const { cleanText } = valueToken;
+
+		// validate that text value is one of the valid modes
+		const validModes: string[] = [...VALID_MODES];
+		const index = validModes.indexOf(cleanText);
+		if (index !== -1) {
+			this.modeValue = VALID_MODES[index];
+			return;
+		}
+
+		// if not valid mode value, add an appropriate diagnostic
+		this.issues.push(
+			new PromptMetadataError(
+				valueToken.range,
+				localize(
+					'prompt.header.metadata.mode.diagnostics.invalid-value',
+					"Value of the '{0}' metadata must be one of ({1}), got '{2}'.",
+					RECORD_NAME,
+					VALID_MODES
+						.map((modeName) => {
+							return `'${modeName}'`;
+						}).join(', '),
+					cleanText,
+				),
+			),
+		);
+	}
+
+	/**
+	 * Check if a provided front matter token is a metadata record
+	 * with name equal to `mode`.
+	 */
+	public static isModeRecord(
+		token: FrontMatterToken,
+	): boolean {
+		if ((token instanceof FrontMatterRecord) === false) {
+			return false;
+		}
+
+		if (token.nameToken.text === RECORD_NAME) {
+			return true;
+		}
+
+		return false;
+	}
+}

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/promptHeader/metadata/record.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/promptHeader/metadata/record.ts
@@ -23,7 +23,7 @@ export abstract class PromptMetadataRecord {
 	) { }
 
 	/**
-	 * TODO: @legomushroom
+	 * Name of the metadata record.
 	 */
 	public abstract get recordName(): string;
 

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/promptHeader/metadata/record.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/promptHeader/metadata/record.ts
@@ -23,6 +23,11 @@ export abstract class PromptMetadataRecord {
 	) { }
 
 	/**
+	 * TODO: @legomushroom
+	 */
+	public abstract get recordName(): string;
+
+	/**
 	 * List of all `error` issue diagnostics.
 	 */
 	public get errorDiagnostics(): readonly PromptMetadataError[] {

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/promptHeader/metadata/tools.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/promptHeader/metadata/tools.ts
@@ -10,14 +10,18 @@ import { PromptMetadataDiagnostic, PromptMetadataError, PromptMetadataWarning } 
 import { FrontMatterArray, FrontMatterRecord, FrontMatterString, FrontMatterToken, FrontMatterValueToken } from '../../../../../../../../editor/common/codecs/frontMatterCodec/tokens/index.js';
 
 /**
- * Name of the `tools` metadata record in the prompt header.
+ * Name of the metadata record in the prompt header.
  */
-const TOOLS_NAME = 'tools';
+const RECORD_NAME = 'tools';
 
 /**
  * Prompt `tools` metadata record inside the prompt header.
  */
 export class PromptToolsMetadata extends PromptMetadataRecord {
+	public override get recordName(): string {
+		return RECORD_NAME;
+	}
+
 	/**
 	 * Private field for tracking all diagnostic issues
 	 * related to this metadata record.
@@ -76,7 +80,7 @@ export class PromptToolsMetadata extends PromptMetadataRecord {
 					localize(
 						'prompt.header.metadata.tools.diagnostics.invalid-value-type',
 						"Value of the '{0}' metadata must be '{1}', got '{2}.",
-						TOOLS_NAME,
+						RECORD_NAME,
 						'array',
 						valueToken.valueTypeName,
 					),
@@ -165,7 +169,7 @@ export class PromptToolsMetadata extends PromptMetadataRecord {
 			return false;
 		}
 
-		if (token.nameToken.text === TOOLS_NAME) {
+		if (token.nameToken.text === RECORD_NAME) {
 			return true;
 		}
 

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/promptHeader/metadata/tools.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/promptHeader/metadata/tools.ts
@@ -79,7 +79,7 @@ export class PromptToolsMetadata extends PromptMetadataRecord {
 					valueToken.range,
 					localize(
 						'prompt.header.metadata.tools.diagnostics.invalid-value-type',
-						"Value of the '{0}' metadata must be '{1}', got '{2}.",
+						"Value of the '{0}' metadata must be '{1}', got '{2}'.",
 						RECORD_NAME,
 						'array',
 						valueToken.valueTypeName,

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/types.d.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/types.d.ts
@@ -3,11 +3,11 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { ChatMode } from '../../constants.ts';
 import { URI } from '../../../../../../base/common/uri.js';
 import { ResolveError } from '../../promptFileReferenceErrors.js';
 import { IDisposable } from '../../../../../../base/common/lifecycle.js';
 import { IRange, Range } from '../../../../../../editor/common/core/range.js';
-import { IHeaderMetadata } from './promptHeader/header.ts';
 
 /**
  * A resolve error with a parent prompt URI, if any.
@@ -49,19 +49,26 @@ export interface ITopError extends IResolveError {
 	readonly localizedMessage: string;
 }
 
+// TODO: @legomushroom - remove the `.d.ts` of the file name?
+
 /**
  * Metadata defined in the prompt header.
  */
 export interface IPromptMetadata {
+	/**
+	 * Description metadata in the prompt header.
+	 */
+	description?: string;
+
 	/**
 	 * Tools metadata in the prompt header.
 	 */
 	tools?: readonly string[];
 
 	/**
-	 * Description metadata in the prompt header.
+	 * Chat mode metadata in the prompt header.
 	 */
-	description?: string;
+	mode?: ChatMode;
 }
 
 /**

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/types.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/types.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ChatMode } from '../../constants.ts';
+import { ChatMode } from '../../constants.js';
 import { URI } from '../../../../../../base/common/uri.js';
 import { ResolveError } from '../../promptFileReferenceErrors.js';
 import { IDisposable } from '../../../../../../base/common/lifecycle.js';
@@ -48,8 +48,6 @@ export interface ITopError extends IResolveError {
 	 */
 	readonly localizedMessage: string;
 }
-
-// TODO: @legomushroom - remove the `.d.ts` of the file name?
 
 /**
  * Metadata defined in the prompt header.

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/types.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/types.ts
@@ -66,7 +66,7 @@ export interface IPromptMetadata {
 	/**
 	 * Chat mode metadata in the prompt header.
 	 */
-	mode?: ChatMode;
+	mode: ChatMode;
 }
 
 /**

--- a/src/vs/workbench/contrib/chat/test/common/promptSyntax/parsers/textModelPromptParser.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/promptSyntax/parsers/textModelPromptParser.test.ts
@@ -463,7 +463,7 @@ suite('TextModelPromptParser', () => {
 
 						assert.strictEqual(
 							mode,
-							undefined,
+							ChatMode.Agent,
 							'Mode metadata must have correct value.',
 						);
 
@@ -503,7 +503,7 @@ suite('TextModelPromptParser', () => {
 
 						assert.strictEqual(
 							mode,
-							undefined,
+							ChatMode.Agent,
 							'Mode metadata must have correct value.',
 						);
 
@@ -577,7 +577,7 @@ suite('TextModelPromptParser', () => {
 
 						assert.strictEqual(
 							mode,
-							undefined,
+							ChatMode.Agent,
 							'Mode metadata must have correct value.',
 						);
 
@@ -743,7 +743,7 @@ suite('TextModelPromptParser', () => {
 
 						assert.strictEqual(
 							mode,
-							undefined,
+							ChatMode.Ask,
 							'Mode metadata must have correct value.',
 						);
 

--- a/src/vs/workbench/contrib/chat/test/common/promptSyntax/promptFileReference.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/promptSyntax/promptFileReference.test.ts
@@ -732,6 +732,7 @@ suite('PromptFileReference (Unix)', function () {
 								'---',
 								'description: \'Root prompt description.\'',
 								'tools: [\'my-tool1\']',
+								'mode: "agent" ',
 								'---',
 								'## Files',
 								'\t- this file #file:folder1/file3.prompt.md ',
@@ -763,6 +764,7 @@ suite('PromptFileReference (Unix)', function () {
 												'---',
 												'tools: [\'my-tool1\', "my-tool2", true, , ]',
 												'something: true',
+												'mode: \'ask\'\t',
 												'---',
 												'this file has a non-existing #file:./some-non-existing/file.prompt.md\t\treference',
 												'',
@@ -810,7 +812,7 @@ suite('PromptFileReference (Unix)', function () {
 				[
 					new ExpectedReference(
 						rootUri,
-						createTestFileReference('folder1/file3.prompt.md', 6, 14),
+						createTestFileReference('folder1/file3.prompt.md', 7, 14),
 					),
 					new ExpectedReference(
 						URI.joinPath(rootUri, './folder1'),
@@ -827,8 +829,7 @@ suite('PromptFileReference (Unix)', function () {
 						URI.joinPath(rootUri, './folder1'),
 						createTestFileReference(
 							`/${rootFolderName}/folder1/some-other-folder/yetAnotherFolder🤭/another-file.prompt.md`,
-							6,
-							26,
+							6, 26,
 						),
 					),
 					new ExpectedReference(
@@ -856,13 +857,13 @@ suite('PromptFileReference (Unix)', function () {
 					new ExpectedReference(
 						rootUri,
 						new MarkdownLink(
-							7, 14,
+							8, 14,
 							'[file4.prompt.md]', '(./folder1/some-other-folder/file4.prompt.md)',
 						),
 					),
 					new ExpectedReference(
 						URI.joinPath(rootUri, './folder1/some-other-folder'),
-						createTestFileReference('./some-non-existing/file.prompt.md', 5, 30),
+						createTestFileReference('./some-non-existing/file.prompt.md', 6, 30),
 						new OpenFailed(
 							URI.joinPath(rootUri, './folder1/some-other-folder/some-non-existing/file.prompt.md'),
 							'Failed to open non-existing prompt snippets file',
@@ -870,7 +871,7 @@ suite('PromptFileReference (Unix)', function () {
 					),
 					new ExpectedReference(
 						URI.joinPath(rootUri, './folder1/some-other-folder'),
-						createTestFileReference('./some-non-prompt-file.md', 9, 13),
+						createTestFileReference('./some-non-prompt-file.md', 10, 13),
 						new OpenFailed(
 							URI.joinPath(rootUri, './folder1/some-other-folder/some-non-prompt-file.md'),
 							'Oh no!',
@@ -879,7 +880,7 @@ suite('PromptFileReference (Unix)', function () {
 					new ExpectedReference(
 						URI.joinPath(rootUri, './some-other-folder/folder1'),
 						new MarkdownLink(
-							9, 48,
+							10, 48,
 							'[]', '(../../folder1/)',
 						),
 						new FolderReference(

--- a/src/vs/workbench/contrib/chat/test/common/promptSyntax/promptFileReference.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/promptSyntax/promptFileReference.test.ts
@@ -4,11 +4,13 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
+import { ChatMode } from '../../../common/constants.js';
 import { URI } from '../../../../../../base/common/uri.js';
 import { Schemas } from '../../../../../../base/common/network.js';
 import { extUri } from '../../../../../../base/common/resources.js';
 import { isWindows } from '../../../../../../base/common/platform.js';
 import { Range } from '../../../../../../editor/common/core/range.js';
+import { assertDefined } from '../../../../../../base/common/types.js';
 import { Disposable } from '../../../../../../base/common/lifecycle.js';
 import { IMockFolder, MockFilesystem } from './testUtils/mockFilesystem.js';
 import { IFileService } from '../../../../../../platform/files/common/files.js';
@@ -29,7 +31,6 @@ import { InMemoryFileSystemProvider } from '../../../../../../platform/files/com
 import { IFileContentsProviderOptions } from '../../../common/promptSyntax/contentProviders/filePromptContentsProvider.js';
 import { TestInstantiationService } from '../../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
 import { NotPromptFile, RecursiveReference, OpenFailed, FolderReference } from '../../../common/promptFileReferenceErrors.js';
-import { assertDefined } from '../../../../../../base/common/types.js';
 
 /**
  * Represents a file reference with an expected
@@ -899,13 +900,13 @@ suite('PromptFileReference (Unix)', function () {
 			assert.deepStrictEqual(
 				tools,
 				['my-tool1'],
-				'Must have correct tools metadata',
+				'Must have correct tools metadata.',
 			);
 
 			assert.deepStrictEqual(
 				description,
 				'Root prompt description.',
-				'Must have correct description metadata',
+				'Must have correct description metadata.',
 			);
 
 			assertDefined(
@@ -915,8 +916,512 @@ suite('PromptFileReference (Unix)', function () {
 			assert.deepStrictEqual(
 				allToolsMetadata,
 				['my-tool1', 'my-tool3', 'my-tool2'],
-				'Must have correct all tools metadata',
+				'Must have correct all tools metadata.',
 			);
+		});
+
+		suite('• tools and mode compatibility', () => {
+			test('• tools are ignored if root prompt in the ask mode', async function () {
+				if (isWindows) {
+					this.skip();
+				}
+
+				const rootFolderName = 'resolves-nested-file-references';
+				const rootFolder = `/${rootFolderName}`;
+				const rootUri = URI.file(rootFolder);
+
+				const test = testDisposables.add(instantiationService.createInstance(TestPromptFileReference,
+					/**
+					 * The file structure to be created on the disk for the test.
+					 */
+					[{
+						name: rootFolderName,
+						children: [
+							{
+								name: 'file1.prompt.md',
+								contents: [
+									'## Some Header',
+									'some contents',
+									' ',
+								],
+							},
+							{
+								name: 'file2.prompt.md',
+								contents: [
+									'---',
+									'description: \'Description of my prompt.\'',
+									'mode: "ask" ',
+									'---',
+									'## Files',
+									'\t- this file #file:folder1/file3.prompt.md ',
+									'\t- also this [file4.prompt.md](./folder1/some-other-folder/file4.prompt.md) please!',
+									' ',
+								],
+							},
+							{
+								name: 'folder1',
+								children: [
+									{
+										name: 'file3.prompt.md',
+										contents: [
+											'---',
+											'tools: [ false, \'my-tool1\' , ]',
+											'mode: \'agent\'\t',
+											'---',
+											' some more\t content',
+										],
+									},
+									{
+										name: 'some-other-folder',
+										children: [
+											{
+												name: 'file4.prompt.md',
+												contents: [
+													'---',
+													'tools: [\'my-tool1\', "my-tool2", true, , ]',
+													'something: true',
+													'mode: \'ask\'\t',
+													'---',
+													'',
+													'',
+													'and some more content',
+												],
+											},
+										],
+									},
+								],
+							},
+						],
+					}],
+					/**
+					 * The root file path to start the resolve process from.
+					 */
+					URI.file(`/${rootFolderName}/file2.prompt.md`),
+					/**
+					 * The expected references to be resolved.
+					 */
+					[
+						new ExpectedReference(
+							rootUri,
+							createTestFileReference('folder1/file3.prompt.md', 6, 14),
+						),
+						new ExpectedReference(
+							rootUri,
+							new MarkdownLink(
+								7, 14,
+								'[file4.prompt.md]', '(./folder1/some-other-folder/file4.prompt.md)',
+							),
+						),
+					]
+				));
+
+				const rootReference = await test.run();
+
+				const { metadata, allToolsMetadata } = rootReference;
+				const { tools, mode, description } = metadata;
+
+				assert.deepStrictEqual(
+					tools,
+					undefined,
+					'Must have correct tools metadata.',
+				);
+
+				assert.deepStrictEqual(
+					mode,
+					ChatMode.Ask,
+					'Must have correct tools metadata.',
+				);
+
+				assert.deepStrictEqual(
+					description,
+					'Description of my prompt.',
+					'Must have correct description metadata.',
+				);
+
+				assert.deepStrictEqual(
+					allToolsMetadata,
+					null,
+					'Must have correct all tools metadata.',
+				);
+			});
+
+			test('• tools are ignored if root prompt in the edit mode', async function () {
+				if (isWindows) {
+					this.skip();
+				}
+
+				const rootFolderName = 'resolves-nested-file-references';
+				const rootFolder = `/${rootFolderName}`;
+				const rootUri = URI.file(rootFolder);
+
+				const test = testDisposables.add(instantiationService.createInstance(TestPromptFileReference,
+					/**
+					 * The file structure to be created on the disk for the test.
+					 */
+					[{
+						name: rootFolderName,
+						children: [
+							{
+								name: 'file1.prompt.md',
+								contents: [
+									'## Some Header',
+									'some contents',
+									' ',
+								],
+							},
+							{
+								name: 'file2.prompt.md',
+								contents: [
+									'---',
+									'description: \'Description of my prompt.\'',
+									'mode:\t\t"edit"\t\t',
+									'---',
+									'## Files',
+									'\t- this file #file:folder1/file3.prompt.md ',
+									'\t- also this [file4.prompt.md](./folder1/some-other-folder/file4.prompt.md) please!',
+									' ',
+								],
+							},
+							{
+								name: 'folder1',
+								children: [
+									{
+										name: 'file3.prompt.md',
+										contents: [
+											'---',
+											'tools: [ false, \'my-tool1\' , ]',
+											'---',
+											' some more\t content',
+										],
+									},
+									{
+										name: 'some-other-folder',
+										children: [
+											{
+												name: 'file4.prompt.md',
+												contents: [
+													'---',
+													'tools: [\'my-tool1\', "my-tool2", true, , ]',
+													'something: true',
+													'mode: \'agent\'\t',
+													'---',
+													'',
+													'',
+													'and some more content',
+												],
+											},
+										],
+									},
+								],
+							},
+						],
+					}],
+					/**
+					 * The root file path to start the resolve process from.
+					 */
+					URI.file(`/${rootFolderName}/file2.prompt.md`),
+					/**
+					 * The expected references to be resolved.
+					 */
+					[
+						new ExpectedReference(
+							rootUri,
+							createTestFileReference('folder1/file3.prompt.md', 6, 14),
+						),
+						new ExpectedReference(
+							rootUri,
+							new MarkdownLink(
+								7, 14,
+								'[file4.prompt.md]', '(./folder1/some-other-folder/file4.prompt.md)',
+							),
+						),
+					]
+				));
+
+				const rootReference = await test.run();
+
+				const { metadata, allToolsMetadata } = rootReference;
+				const { tools, mode, description } = metadata;
+
+				assert.deepStrictEqual(
+					tools,
+					undefined,
+					'Must have correct tools metadata.',
+				);
+
+				assert.deepStrictEqual(
+					mode,
+					ChatMode.Edit,
+					'Must have correct tools metadata.',
+				);
+
+				assert.deepStrictEqual(
+					description,
+					'Description of my prompt.',
+					'Must have correct description metadata.',
+				);
+
+				assert.deepStrictEqual(
+					allToolsMetadata,
+					null,
+					'Must have correct all tools metadata.',
+				);
+			});
+
+			test('• tools are not ignored if root prompt in the agent mode', async function () {
+				if (isWindows) {
+					this.skip();
+				}
+
+				const rootFolderName = 'resolves-nested-file-references';
+				const rootFolder = `/${rootFolderName}`;
+				const rootUri = URI.file(rootFolder);
+
+				const test = testDisposables.add(instantiationService.createInstance(TestPromptFileReference,
+					/**
+					 * The file structure to be created on the disk for the test.
+					 */
+					[{
+						name: rootFolderName,
+						children: [
+							{
+								name: 'file1.prompt.md',
+								contents: [
+									'## Some Header',
+									'some contents',
+									' ',
+								],
+							},
+							{
+								name: 'file2.prompt.md',
+								contents: [
+									'---',
+									'description: \'Description of my prompt.\'',
+									'mode: \t\t "agent" \t\t ',
+									'---',
+									'## Files',
+									'\t- this file #file:folder1/file3.prompt.md ',
+									'\t- also this [file4.prompt.md](./folder1/some-other-folder/file4.prompt.md) please!',
+									' ',
+								],
+							},
+							{
+								name: 'folder1',
+								children: [
+									{
+										name: 'file3.prompt.md',
+										contents: [
+											'---',
+											'tools: [ false, \'my-tool1\' , ]',
+											'---',
+											' some more\t content',
+										],
+									},
+									{
+										name: 'some-other-folder',
+										children: [
+											{
+												name: 'file4.prompt.md',
+												contents: [
+													'---',
+													'tools: [\'my-tool1\', "my-tool2", true, , \'my-tool3\' , ]',
+													'something: true',
+													'mode: \'agent\'\t',
+													'---',
+													'',
+													'',
+													'and some more content',
+												],
+											},
+										],
+									},
+								],
+							},
+						],
+					}],
+					/**
+					 * The root file path to start the resolve process from.
+					 */
+					URI.file(`/${rootFolderName}/file2.prompt.md`),
+					/**
+					 * The expected references to be resolved.
+					 */
+					[
+						new ExpectedReference(
+							rootUri,
+							createTestFileReference('folder1/file3.prompt.md', 6, 14),
+						),
+						new ExpectedReference(
+							rootUri,
+							new MarkdownLink(
+								7, 14,
+								'[file4.prompt.md]', '(./folder1/some-other-folder/file4.prompt.md)',
+							),
+						),
+					]
+				));
+
+				const rootReference = await test.run();
+
+				const { metadata, allToolsMetadata } = rootReference;
+				const { tools, mode, description } = metadata;
+
+				assert.deepStrictEqual(
+					tools,
+					undefined,
+					'Must have correct tools metadata.',
+				);
+
+				assert.deepStrictEqual(
+					mode,
+					ChatMode.Agent,
+					'Must have correct tools metadata.',
+				);
+
+				assert.deepStrictEqual(
+					description,
+					'Description of my prompt.',
+					'Must have correct description metadata.',
+				);
+
+				assert.deepStrictEqual(
+					allToolsMetadata,
+					[
+						'my-tool1',
+						'my-tool2',
+						'my-tool3',
+					],
+					'Must have correct all tools metadata.',
+				);
+			});
+
+			test('• tools are not ignored if root prompt implicitly in the agent mode', async function () {
+				if (isWindows) {
+					this.skip();
+				}
+
+				const rootFolderName = 'resolves-nested-file-references';
+				const rootFolder = `/${rootFolderName}`;
+				const rootUri = URI.file(rootFolder);
+
+				const test = testDisposables.add(instantiationService.createInstance(TestPromptFileReference,
+					/**
+					 * The file structure to be created on the disk for the test.
+					 */
+					[{
+						name: rootFolderName,
+						children: [
+							{
+								name: 'file1.prompt.md',
+								contents: [
+									'## Some Header',
+									'some contents',
+									' ',
+								],
+							},
+							{
+								name: 'file2.prompt.md',
+								contents: [
+									'---',
+									'tools: [ false, \'my-tool12\' , ]',
+									'description: \'Description of my prompt.\'',
+									'---',
+									'## Files',
+									'\t- this file #file:folder1/file3.prompt.md ',
+									'\t- also this [file4.prompt.md](./folder1/some-other-folder/file4.prompt.md) please!',
+									' ',
+								],
+							},
+							{
+								name: 'folder1',
+								children: [
+									{
+										name: 'file3.prompt.md',
+										contents: [
+											'---',
+											'tools: [ false, \'my-tool1\' , ]',
+											'---',
+											' some more\t content',
+										],
+									},
+									{
+										name: 'some-other-folder',
+										children: [
+											{
+												name: 'file4.prompt.md',
+												contents: [
+													'---',
+													'tools: [\'my-tool1\', "my-tool2", true, , \'my-tool3\' , ]',
+													'something: true',
+													'mode: \'agent\'\t',
+													'---',
+													'',
+													'',
+													'and some more content',
+												],
+											},
+										],
+									},
+								],
+							},
+						],
+					}],
+					/**
+					 * The root file path to start the resolve process from.
+					 */
+					URI.file(`/${rootFolderName}/file2.prompt.md`),
+					/**
+					 * The expected references to be resolved.
+					 */
+					[
+						new ExpectedReference(
+							rootUri,
+							createTestFileReference('folder1/file3.prompt.md', 6, 14),
+						),
+						new ExpectedReference(
+							rootUri,
+							new MarkdownLink(
+								7, 14,
+								'[file4.prompt.md]', '(./folder1/some-other-folder/file4.prompt.md)',
+							),
+						),
+					]
+				));
+
+				const rootReference = await test.run();
+
+				const { metadata, allToolsMetadata } = rootReference;
+				const { tools, mode, description } = metadata;
+
+				assert.deepStrictEqual(
+					tools,
+					['my-tool12'],
+					'Must have correct tools metadata.',
+				);
+
+				assert.deepStrictEqual(
+					mode,
+					undefined,
+					'Must have correct tools metadata.',
+				);
+
+				assert.deepStrictEqual(
+					description,
+					'Description of my prompt.',
+					'Must have correct description metadata.',
+				);
+
+				assert.deepStrictEqual(
+					allToolsMetadata,
+					[
+						'my-tool12',
+						'my-tool1',
+						'my-tool2',
+						'my-tool3',
+					],
+					'Must have correct all tools metadata.',
+				);
+			});
 		});
 	});
 });

--- a/src/vs/workbench/contrib/chat/test/common/promptSyntax/promptFileReference.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/promptSyntax/promptFileReference.test.ts
@@ -1401,7 +1401,7 @@ suite('PromptFileReference (Unix)', function () {
 
 				assert.deepStrictEqual(
 					mode,
-					undefined,
+					ChatMode.Agent,
 					'Must have correct tools metadata.',
 				);
 


### PR DESCRIPTION
Adds support for the `mode` header metadata that defines what chat mode to use when a prompt in run in the chat widget. Currently:

- `mode` can be one of 3 string values: `'ask'`, `'edit'`, or `'agent'`
- if `tools` metadata is defined then `mode` is assumed to be `agent` and any other configured value is ignored and is highlighted with appropriate warning marker in the editor
- likewise, if a prompt file references for other prompt files, the top level prompt file defines overall `chat mode` value for the entire prompt tree; this has couple of consequences:
  - if a nested prompt file defines a different mode, it gets ignored
  - if a top-level prompt file does not use `agent` mode, while some nested prompt defines `tools`, the tools metadata gets ignored
- furthermore, if multiple prompts are attached at the same time, the overall `chat mode` and `tools` metadata is computed across all of them; for instance, if there are multiple prompt files attached and each of them define it's own `mode`, we compute the safest possible mode that will satisfy all of them, where the `Ask` mode is the safest while `Agent` is the least safest
- as for the overall `tools`, those are computed as a union of all `tools` that the prompt files define

Part of https://github.com/microsoft/vscode-copilot/issues/15596, https://github.com/microsoft/vscode-copilot/issues/15420 and https://github.com/microsoft/vscode-copilot/issues/12203