### PR TITLE
Support categories in model picker

### DIFF
--- a/src/vs/platform/actionWidget/browser/actionList.ts
+++ b/src/vs/platform/actionWidget/browser/actionList.ts
@@ -75,7 +75,7 @@ class HeaderRenderer<T> implements IListRenderer<IActionListItem<T>, IHeaderTemp
 	}
 
 	renderElement(element: IActionListItem<T>, _index: number, templateData: IHeaderTemplateData): void {
-		templateData.text.textContent = element.group?.title ?? '';
+		templateData.text.textContent = element.group?.title ?? element.label ?? '';
 	}
 
 	disposeTemplate(_templateData: IHeaderTemplateData): void {

--- a/src/vs/workbench/api/common/extHostLanguageModels.ts
+++ b/src/vs/workbench/api/common/extHostLanguageModels.ts
@@ -25,6 +25,7 @@ import { IExtHostRpcService } from './extHostRpcService.js';
 import * as typeConvert from './extHostTypeConverters.js';
 import * as extHostTypes from './extHostTypes.js';
 import { SerializableObjectWithBuffers } from '../../services/extensions/common/proxyIdentifier.js';
+import { DEFAULT_MODEL_PICKER_CATEGORY } from '../../contrib/chat/common/modelPicker/chatModelCategoryService.js';
 
 export interface IExtHostLanguageModels extends ExtHostLanguageModels { }
 
@@ -181,6 +182,7 @@ export class ExtHostLanguageModels implements ExtHostLanguageModelsShape {
 			targetExtensions: metadata.extensions,
 			isDefault: metadata.isDefault,
 			isUserSelectable: metadata.isUserSelectable,
+			modelPickerCategory: metadata.categoryId ?? DEFAULT_MODEL_PICKER_CATEGORY,
 			capabilities: metadata.capabilities,
 		});
 

--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -106,6 +106,7 @@ import './promptSyntax/contributions/attachInstructionsCommand.js';
 import { ChatViewsWelcomeHandler } from './viewsWelcome/chatViewsWelcomeHandler.js';
 import { runSaveToPromptAction, SAVE_TO_PROMPT_SLASH_COMMAND_NAME } from './actions/promptActions/chatSaveToPromptAction.js';
 import { assertDefined } from '../../../../base/common/types.js';
+import { ChatModelPickerCategoryHandler } from '../common/modelPicker/chatModelPickerCategory.contribution.js';
 
 // Register configuration
 const configurationRegistry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration);
@@ -614,6 +615,7 @@ registerWorkbenchContribution2(ChatEditingEditorAccessibility.ID, ChatEditingEdi
 registerWorkbenchContribution2(ChatEditingEditorOverlay.ID, ChatEditingEditorOverlay, WorkbenchPhase.AfterRestored);
 registerWorkbenchContribution2(ChatEditingEditorContextKeys.ID, ChatEditingEditorContextKeys, WorkbenchPhase.AfterRestored);
 registerWorkbenchContribution2(ChatTransferContribution.ID, ChatTransferContribution, WorkbenchPhase.BlockRestore);
+registerWorkbenchContribution2(ChatModelPickerCategoryHandler.ID, ChatModelPickerCategoryHandler, WorkbenchPhase.Eventually);
 
 registerChatActions();
 registerChatCopyActions();

--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -48,6 +48,7 @@ import { ILanguageModelIgnoredFilesService, LanguageModelIgnoredFilesService } f
 import { ILanguageModelsService, LanguageModelsService } from '../common/languageModels.js';
 import { ILanguageModelStatsService, LanguageModelStatsService } from '../common/languageModelStats.js';
 import { ILanguageModelToolsService } from '../common/languageModelToolsService.js';
+import { ChatModelCategoryService, IChatModelCategoryService } from '../common/modelPicker/chatModelCategoryService.js';
 import { PROMPT_DOCUMENTATION_URL } from '../common/promptSyntax/constants.js';
 import { registerReusablePromptLanguageFeatures } from '../common/promptSyntax/languageFeatures/providers/index.js';
 import { PromptsService } from '../common/promptSyntax/service/promptsService.js';
@@ -654,6 +655,7 @@ registerSingleton(IChatMarkdownAnchorService, ChatMarkdownAnchorService, Instant
 registerSingleton(ILanguageModelIgnoredFilesService, LanguageModelIgnoredFilesService, InstantiationType.Delayed);
 registerSingleton(IChatEntitlementService, ChatEntitlementService, InstantiationType.Delayed);
 registerSingleton(IPromptsService, PromptsService, InstantiationType.Delayed);
+registerSingleton(IChatModelCategoryService, ChatModelCategoryService, InstantiationType.Delayed);
 
 registerWorkbenchContribution2(ChatEditingNotebookFileSystemProviderContrib.ID, ChatEditingNotebookFileSystemProviderContrib, WorkbenchPhase.BlockStartup);
 

--- a/src/vs/workbench/contrib/chat/common/languageModels.ts
+++ b/src/vs/workbench/contrib/chat/common/languageModels.ts
@@ -127,6 +127,7 @@ export interface ILanguageModelChatMetadata {
 
 	readonly isDefault?: boolean;
 	readonly isUserSelectable?: boolean;
+	readonly modelPickerCategory: string;
 	readonly auth?: {
 		readonly providerLabel: string;
 		readonly accountLabel?: string;

--- a/src/vs/workbench/contrib/chat/common/modelPicker/chatModelCategoryService.ts
+++ b/src/vs/workbench/contrib/chat/common/modelPicker/chatModelCategoryService.ts
@@ -1,0 +1,100 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Emitter, Event } from '../../../../../base/common/event.js';
+import { Disposable, IDisposable } from '../../../../../base/common/lifecycle.js';
+import { localize } from '../../../../../nls.js';
+import { createDecorator } from '../../../../../platform/instantiation/common/instantiation.js';
+
+export interface IChatModelCategory {
+	/**
+	 * The unique identifier for this category
+	 */
+	id: string;
+
+	/**
+	 * The user-facing name of this category
+	 */
+	name: string;
+}
+
+export interface IChatModelCategoryService {
+	readonly _serviceBrand: undefined;
+
+	/**
+	 * An event that fires when the registered categories change
+	 */
+	readonly onDidChangeCategories: Event<void>;
+
+	/**
+	 * Register a model category
+	 * @param category The category to register
+	 * @returns A disposable that will unregister the category
+	 */
+	registerCategory(category: IChatModelCategory): IDisposable;
+
+	/**
+	 * Get all registered categories
+	 * @returns An array of registered categories
+	 */
+	getCategories(): IChatModelCategory[];
+
+	/**
+	 * Get a category by its ID
+	 * @param id The ID of the category to retrieve
+	 * @returns The category with the given ID, or undefined if not found
+	 */
+	getCategoryById(id: string): IChatModelCategory | undefined;
+}
+
+export const IChatModelCategoryService = createDecorator<IChatModelCategoryService>('chatModelCategoryService');
+
+export const DEFAULT_MODEL_PICKER_CATEGORY = 'other';
+
+export class ChatModelCategoryService extends Disposable implements IChatModelCategoryService {
+	_serviceBrand: undefined;
+
+	private readonly _onDidChangeCategories = this._register(new Emitter<void>());
+	readonly onDidChangeCategories = this._onDidChangeCategories.event;
+
+	private readonly _categories = new Map<string, IChatModelCategory>();
+	private readonly _modelCategories = new Map<string, string>();
+
+	constructor() {
+		super();
+		this._register(this.registerCategory({ id: DEFAULT_MODEL_PICKER_CATEGORY, name: localize('chat.modelPicker.other', "Other Models") }));
+	}
+
+	registerCategory(category: IChatModelCategory) {
+		if (this._categories.has(category.id)) {
+			throw new Error(`Model category with ID '${category.id}' is already registered`);
+		}
+
+		this._categories.set(category.id, category);
+		this._onDidChangeCategories.fire();
+
+		return {
+			dispose: () => {
+				if (this._categories.delete(category.id)) {
+					this._onDidChangeCategories.fire();
+				}
+			}
+		};
+	}
+
+	getCategories(): IChatModelCategory[] {
+		return Array.from(this._categories.values()).sort((a, b) => {
+			return a.name.localeCompare(b.name);
+		});
+	}
+
+	getCategoryById(id: string): IChatModelCategory | undefined {
+		return this._categories.get(id);
+	}
+
+	getCategoryForModel(modelId: string): string | undefined {
+		return this._modelCategories.get(modelId);
+	}
+}

--- a/src/vs/workbench/contrib/chat/common/modelPicker/chatModelPickerCategory.contribution.ts
+++ b/src/vs/workbench/contrib/chat/common/modelPicker/chatModelPickerCategory.contribution.ts
@@ -1,0 +1,101 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { DisposableMap, DisposableStore } from '../../../../../base/common/lifecycle.js';
+import { localize } from '../../../../../nls.js';
+import { ExtensionIdentifier } from '../../../../../platform/extensions/common/extensions.js';
+import { ILogService } from '../../../../../platform/log/common/log.js';
+import { IWorkbenchContribution } from '../../../../common/contributions.js';
+import * as extensionsRegistry from '../../../../services/extensions/common/extensionsRegistry.js';
+import { IChatModelCategoryService } from './chatModelCategoryService.js';
+
+export interface IRawChatModelPickerCategoryContribution {
+	/**
+	 * The id of the category
+	 */
+	id: string;
+
+	/**
+	 * User-facing name of the category
+	 */
+	name: string;
+}
+
+const chatModelPickerCategoriesExtensionPoint = extensionsRegistry.ExtensionsRegistry.registerExtensionPoint<IRawChatModelPickerCategoryContribution[]>({
+	extensionPoint: 'chatModelPickerCategories',
+	jsonSchema: {
+		description: localize('vscode.extension.contributes.chatModelPickerCategories', 'Contributes categories for organizing models in the chat model picker'),
+		type: 'array',
+		items: {
+			additionalProperties: false,
+			type: 'object',
+			defaultSnippets: [{ body: { id: '', name: '' } }],
+			required: ['id', 'name'],
+			properties: {
+				id: {
+					description: localize('chatModelPickerCategoryId', "A unique identifier for this category."),
+					type: 'string'
+				},
+				name: {
+					description: localize('chatModelPickerCategoryName', "User-facing name for this category."),
+					type: 'string'
+				}
+			}
+		}
+	},
+	activationEventsGenerator: (contributions: IRawChatModelPickerCategoryContribution[], result: { push(item: string): void }) => {
+		for (const contrib of contributions) {
+			result.push(`onChatModelPickerCategory:${contrib.id}`);
+		}
+	},
+});
+
+export class ChatModelPickerCategoryHandler implements IWorkbenchContribution {
+
+	static readonly ID = 'workbench.contrib.chatModelPickerCategoryHandler';
+
+	private _categoryRegistrationDisposables = new DisposableMap<string>();
+
+	constructor(
+		@IChatModelCategoryService private readonly modelCategoryService: IChatModelCategoryService,
+		@ILogService private readonly logService: ILogService
+	) {
+		this.handleAndRegisterModelCategories();
+	}
+
+	private handleAndRegisterModelCategories(): void {
+		chatModelPickerCategoriesExtensionPoint.setHandler((extensions, delta) => {
+			for (const extension of delta.added) {
+				for (const categoryDescriptor of extension.value) {
+					try {
+						const store = new DisposableStore();
+						store.add(this.modelCategoryService.registerCategory({
+							id: categoryDescriptor.id,
+							name: categoryDescriptor.name
+						}));
+
+						// Store the registration under a key that combines extension ID and category ID
+						this._categoryRegistrationDisposables.set(
+							getCategoryKey(extension.description.identifier, categoryDescriptor.id),
+							store
+						);
+					} catch (e) {
+						this.logService.error(`Failed to register model picker category ${categoryDescriptor.id}: ${e}`);
+					}
+				}
+			}
+
+			for (const extension of delta.removed) {
+				for (const categoryDescriptor of extension.value) {
+					this._categoryRegistrationDisposables.deleteAndDispose(getCategoryKey(extension.description.identifier, categoryDescriptor.id));
+				}
+			}
+		});
+	}
+}
+
+function getCategoryKey(extensionId: ExtensionIdentifier, categoryId: string): string {
+	return `${extensionId.value}_${categoryId}`;
+}

--- a/src/vs/workbench/contrib/chat/test/common/languageModels.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/languageModels.test.ts
@@ -14,6 +14,7 @@ import { ChatMessageRole, IChatResponseFragment, languageModelExtensionPoint, La
 import { IExtensionService, nullExtensionDescription } from '../../../../services/extensions/common/extensions.js';
 import { ExtensionsRegistry } from '../../../../services/extensions/common/extensionsRegistry.js';
 import { MockContextKeyService } from '../../../../../platform/keybinding/test/common/mockKeybindingService.js';
+import { DEFAULT_MODEL_PICKER_CATEGORY } from '../../common/modelPicker/chatModelCategoryService.js';
 
 suite('LanguageModels', function () {
 
@@ -50,6 +51,7 @@ suite('LanguageModels', function () {
 				name: 'Pretty Name',
 				vendor: 'test-vendor',
 				family: 'test-family',
+				modelPickerCategory: DEFAULT_MODEL_PICKER_CATEGORY,
 				version: 'test-version',
 				id: 'test-id',
 				maxInputTokens: 100,
@@ -70,6 +72,7 @@ suite('LanguageModels', function () {
 				vendor: 'test-vendor',
 				family: 'test2-family',
 				version: 'test2-version',
+				modelPickerCategory: DEFAULT_MODEL_PICKER_CATEGORY,
 				id: 'test-id',
 				maxInputTokens: 100,
 				maxOutputTokens: 100,
@@ -119,6 +122,7 @@ suite('LanguageModels', function () {
 				id: 'actual-lm',
 				maxInputTokens: 100,
 				maxOutputTokens: 100,
+				modelPickerCategory: DEFAULT_MODEL_PICKER_CATEGORY,
 			},
 			sendChatRequest: async (messages, _from, _options, token) => {
 				// const message = messages.at(-1);

--- a/src/vscode-dts/vscode.proposed.chatProvider.d.ts
+++ b/src/vscode-dts/vscode.proposed.chatProvider.d.ts
@@ -70,6 +70,13 @@ declare module 'vscode' {
 			readonly toolCalling?: boolean;
 			readonly agentMode?: boolean;
 		};
+
+		/**
+		 * Optional ID of the category this model belongs to.
+		 * Categories are contributed via the `chatModelPickerCategories` extension point.
+		 * If not specified, the model will appear in the "Other Models" category.
+		 */
+		readonly categoryId?: string;
 	}
 
 	export interface ChatResponseProviderMetadata {


### PR DESCRIPTION
Introduces a contribution point which allows contributing categories to the model picker. Models can then register to a category to be grouped in a logical way.