### PR TITLE
make merge editor more accessible

### DIFF
--- a/src/vs/workbench/contrib/mergeEditor/browser/commands/commands.ts
+++ b/src/vs/workbench/contrib/mergeEditor/browser/commands/commands.ts
@@ -661,3 +661,34 @@ export class AcceptMerge extends MergeEditorAction2 {
 		};
 	}
 }
+
+export class ToggleBetweenInputs extends MergeEditorAction2 {
+	constructor() {
+		super({
+			id: 'mergeEditor.toggleBetweenInputs',
+			category: mergeEditorCategory,
+			title: localize2('mergeEditor.toggleBetweenInputs', "Toggle Between Merge Editor Inputs"),
+			f1: true,
+			precondition: ctxIsMergeEditor,
+			keybinding: [
+				{
+					primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KeyT,
+					// Override reopen closed editor
+					weight: KeybindingWeight.WorkbenchContrib + 10,
+					when: ctxIsMergeEditor,
+				}
+			]
+		});
+	}
+
+	override runWithMergeEditor({ viewModel }: MergeEditorAction2Args, accessor: ServicesAccessor) {
+		const input1IsFocused = viewModel.inputCodeEditorView1.editor.hasWidgetFocus();
+
+		// Toggle focus between inputs
+		if (input1IsFocused) {
+			viewModel.inputCodeEditorView2.editor.focus();
+		} else {
+			viewModel.inputCodeEditorView1.editor.focus();
+		}
+	}
+}

--- a/src/vs/workbench/contrib/mergeEditor/browser/commands/commands.ts
+++ b/src/vs/workbench/contrib/mergeEditor/browser/commands/commands.ts
@@ -515,7 +515,7 @@ export class AcceptAllInput1 extends MergeEditorAction {
 		super({
 			id: 'merge.acceptAllInput1',
 			category: mergeEditorCategory,
-			title: localize2('merge.acceptAllInput1', "Accept All Changes from Left"),
+			title: localize2('merge.acceptAllInput1', "Accept All Incoming Changes from Left"),
 			f1: true,
 			precondition: ctxIsMergeEditor,
 			menu: { id: MenuId.MergeInput1Toolbar, group: 'primary' },
@@ -533,7 +533,7 @@ export class AcceptAllInput2 extends MergeEditorAction {
 		super({
 			id: 'merge.acceptAllInput2',
 			category: mergeEditorCategory,
-			title: localize2('merge.acceptAllInput2', "Accept All Changes from Right"),
+			title: localize2('merge.acceptAllInput2', "Accept All Current Changes from Right"),
 			f1: true,
 			precondition: ctxIsMergeEditor,
 			menu: { id: MenuId.MergeInput2Toolbar, group: 'primary' },

--- a/src/vs/workbench/contrib/mergeEditor/browser/commands/commands.ts
+++ b/src/vs/workbench/contrib/mergeEditor/browser/commands/commands.ts
@@ -24,6 +24,8 @@ import { ctxIsMergeEditor, ctxMergeEditorLayout, ctxMergeEditorShowBase, ctxMerg
 import { IEditorService } from '../../../../services/editor/common/editorService.js';
 import { transaction } from '../../../../../base/common/observable.js';
 import { ModifiedBaseRangeStateKind } from '../model/modifiedBaseRange.js';
+import { KeyCode, KeyMod } from '../../../../../base/common/keyCodes.js';
+import { KeybindingWeight } from '../../../../../platform/keybinding/common/keybindingsRegistry.js';
 
 abstract class MergeEditorAction extends Action2 {
 	constructor(desc: Readonly<IAction2Options>) {
@@ -621,8 +623,15 @@ export class AcceptMerge extends MergeEditorAction2 {
 			id: 'mergeEditor.acceptMerge',
 			category: mergeEditorCategory,
 			title: localize2('mergeEditor.acceptMerge', "Complete Merge"),
-			f1: false,
-			precondition: ctxIsMergeEditor
+			f1: true,
+			precondition: ctxIsMergeEditor,
+			keybinding: [
+				{
+					primary: KeyMod.CtrlCmd | KeyCode.Enter,
+					weight: KeybindingWeight.EditorContrib,
+					when: ctxIsMergeEditor,
+				}
+			]
 		});
 	}
 

--- a/src/vs/workbench/contrib/mergeEditor/browser/mergeEditor.contribution.ts
+++ b/src/vs/workbench/contrib/mergeEditor/browser/mergeEditor.contribution.ts
@@ -16,7 +16,7 @@ import {
 	CompareInput2WithBaseCommand, GoToNextUnhandledConflict, GoToPreviousUnhandledConflict, OpenBaseFile, OpenMergeEditor,
 	OpenResultResource, ResetToBaseAndAutoMergeCommand, SetColumnLayout, SetMixedLayout, ShowHideTopBase, ShowHideCenterBase, ShowHideBase,
 	ShowNonConflictingChanges, ToggleActiveConflictInput1, ToggleActiveConflictInput2, ResetCloseWithConflictsChoice,
-	AcceptAllCombination
+	AcceptAllCombination, ToggleBetweenInputs
 } from './commands/commands.js';
 import { MergeEditorCopyContentsToJSON, MergeEditorLoadContentsFromFolder, MergeEditorSaveContentsToFolder } from './commands/devCommands.js';
 import { MergeEditorInput } from './mergeEditorInput.js';
@@ -88,6 +88,8 @@ registerAction2(ResetToBaseAndAutoMergeCommand);
 registerAction2(AcceptMerge);
 registerAction2(ResetCloseWithConflictsChoice);
 registerAction2(AcceptAllCombination);
+
+registerAction2(ToggleBetweenInputs);
 
 // Dev Commands
 registerAction2(MergeEditorCopyContentsToJSON);

--- a/src/vs/workbench/contrib/mergeEditor/browser/mergeEditorAccessibilityHelp.ts
+++ b/src/vs/workbench/contrib/mergeEditor/browser/mergeEditorAccessibilityHelp.ts
@@ -30,6 +30,7 @@ export class MergeEditorAccessibilityHelpProvider implements IAccessibleViewImpl
 			localize('msg2', "Navigate between merge conflicts using the commands Go to Next Unhandled Conflict{0} and Go to Previous Unhandled Conflict{1}.", '<keybinding:merge.goToNextUnhandledConflict>', '<keybinding:merge.goToPreviousUnhandledConflict>'),
 			localize('msg3', "Run the command Merge Editor: Accept All Incoming Changes from the Left{0} and Merge Editor: Accept All Current Changes from the Right{1}", '<keybinding:merge.acceptAllInput1>', '<keybinding:merge.acceptAllInput2>'),
 			localize('msg4', "Complete the Merge{0}.", '<keybinding:mergeEditor.acceptMerge>'),
+			localize('msg5', "Toggle between merge editor inputs, incoming and current changes {0}.", '<keybinding:mergeEditor.toggleBetweenInputs>'),
 		];
 
 		return new AccessibleContentProvider(

--- a/src/vs/workbench/contrib/mergeEditor/browser/mergeEditorAccessibilityHelp.ts
+++ b/src/vs/workbench/contrib/mergeEditor/browser/mergeEditorAccessibilityHelp.ts
@@ -29,6 +29,7 @@ export class MergeEditorAccessibilityHelpProvider implements IAccessibleViewImpl
 			localize('msg1', "You are in a merge editor."),
 			localize('msg2', "Navigate between merge conflicts using the commands Go to Next Unhandled Conflict{0} and Go to Previous Unhandled Conflict{1}.", '<keybinding:merge.goToNextUnhandledConflict>', '<keybinding:merge.goToPreviousUnhandledConflict>'),
 			localize('msg3', "Run the command Merge Editor: Accept All Incoming Changes from the Left{0} and Merge Editor: Accept All Current Changes from the Right{1}", '<keybinding:merge.acceptAllInput1>', '<keybinding:merge.acceptAllInput2>'),
+			localize('msg4', "Complete the Merge{0}.", '<keybinding:mergeEditor.acceptMerge>'),
 		];
 
 		return new AccessibleContentProvider(

--- a/src/vs/workbench/contrib/mergeEditor/browser/mergeEditorAccessibilityHelp.ts
+++ b/src/vs/workbench/contrib/mergeEditor/browser/mergeEditorAccessibilityHelp.ts
@@ -28,7 +28,7 @@ export class MergeEditorAccessibilityHelpProvider implements IAccessibleViewImpl
 		const content = [
 			localize('msg1', "You are in a merge editor."),
 			localize('msg2', "Navigate between merge conflicts using the commands Go to Next Unhandled Conflict{0} and Go to Previous Unhandled Conflict{1}.", '<keybinding:merge.goToNextUnhandledConflict>', '<keybinding:merge.goToPreviousUnhandledConflict>'),
-			localize('msg3', "Run the command Merge Editor: Accept All Changes from the Left{0} and Merge Editor: Accept All Changes from the Right{1}", '<keybinding:merge.acceptAllInput1>', '<keybinding:merge.acceptAllInput2>'),
+			localize('msg3', "Run the command Merge Editor: Accept All Incoming Changes from the Left{0} and Merge Editor: Accept All Current Changes from the Right{1}", '<keybinding:merge.acceptAllInput1>', '<keybinding:merge.acceptAllInput2>'),
 		];
 
 		return new AccessibleContentProvider(

--- a/src/vs/workbench/contrib/mergeEditor/browser/mergeEditorInput.ts
+++ b/src/vs/workbench/contrib/mergeEditor/browser/mergeEditorInput.ts
@@ -204,7 +204,7 @@ function alertFocusedEditor(editor: MergeEditorType) {
 			alert(localize('mergeEditor.input2', "Right Input"));
 			break;
 		case 'result':
-			alert(localize('mergeEditor.result', "Result"));
+			alert(localize('mergeEditor.result', "Merge Result"));
 			break;
 	}
 }

--- a/src/vs/workbench/contrib/mergeEditor/browser/mergeEditorInput.ts
+++ b/src/vs/workbench/contrib/mergeEditor/browser/mergeEditorInput.ts
@@ -23,6 +23,8 @@ import { MergeEditorTelemetry } from './telemetry.js';
 import { IEditorService } from '../../../services/editor/common/editorService.js';
 import { IFilesConfigurationService } from '../../../services/filesConfiguration/common/filesConfigurationService.js';
 import { ILanguageSupport, ITextFileSaveOptions, ITextFileService } from '../../../services/textfile/common/textfiles.js';
+import { alert } from '../../../../base/browser/ui/aria/aria.js';
+import { MergeEditorType } from './view/viewModel.js';
 
 export class MergeEditorInputData {
 	constructor(
@@ -37,6 +39,8 @@ export class MergeEditorInput extends AbstractTextResourceEditorInput implements
 	static readonly ID = 'mergeEditor.Input';
 
 	private _inputModel?: IMergeEditorInputModel;
+
+	private _focusedEditor: MergeEditorType = 'result';
 
 	override closeHandler: IEditorCloseHandler = {
 		showConfirm: () => this._inputModel?.shouldConfirmClose() ?? false,
@@ -178,5 +182,29 @@ export class MergeEditorInput extends AbstractTextResourceEditorInput implements
 		this._inputModel?.model.setLanguageId(languageId, source);
 	}
 
+	/**
+	 * Updates the focused editor and triggers a name change event
+	 */
+	public updateFocusedEditor(editor: MergeEditorType): void {
+		if (this._focusedEditor !== editor) {
+			this._focusedEditor = editor;
+			alertFocusedEditor(editor);
+		}
+	}
+
 	// implement get/set encoding
+}
+
+function alertFocusedEditor(editor: MergeEditorType) {
+	switch (editor) {
+		case 'input1':
+			alert(localize('mergeEditor.input1', "Left Input"));
+			break;
+		case 'input2':
+			alert(localize('mergeEditor.input2', "Right Input"));
+			break;
+		case 'result':
+			alert(localize('mergeEditor.result', "Result"));
+			break;
+	}
 }

--- a/src/vs/workbench/contrib/mergeEditor/browser/mergeEditorInput.ts
+++ b/src/vs/workbench/contrib/mergeEditor/browser/mergeEditorInput.ts
@@ -198,10 +198,10 @@ export class MergeEditorInput extends AbstractTextResourceEditorInput implements
 function alertFocusedEditor(editor: MergeEditorType) {
 	switch (editor) {
 		case 'input1':
-			alert(localize('mergeEditor.input1', "Left Input"));
+			alert(localize('mergeEditor.input1', "Incoming, Left Input"));
 			break;
 		case 'input2':
-			alert(localize('mergeEditor.input2', "Right Input"));
+			alert(localize('mergeEditor.input2', "Current, Right Input"));
 			break;
 		case 'result':
 			alert(localize('mergeEditor.result', "Merge Result"));

--- a/src/vs/workbench/contrib/mergeEditor/browser/view/mergeEditor.ts
+++ b/src/vs/workbench/contrib/mergeEditor/browser/view/mergeEditor.ts
@@ -218,6 +218,18 @@ export class MergeEditor extends AbstractTextEditor<IMergeEditorViewState> {
 		});
 		this._sessionDisposables.add(viewModel);
 
+		// Track focus changes to update the editor name
+		this._sessionDisposables.add(autorun(reader => {
+			/** @description Update focused editor name based on focus */
+			const focusedType = viewModel.focusedEditorType.read(reader);
+
+			if (!(input instanceof MergeEditorInput)) {
+				return;
+			}
+
+			input.updateFocusedEditor(focusedType || 'result');
+		}));
+
 		// Set/unset context keys based on input
 		this._ctxResultUri.set(inputModel.resultUri.toString());
 		this._ctxBaseUri.set(model.base.uri.toString());

--- a/src/vs/workbench/contrib/mergeEditor/browser/view/viewModel.ts
+++ b/src/vs/workbench/contrib/mergeEditor/browser/view/viewModel.ts
@@ -116,6 +116,29 @@ export class MergeEditorViewModel extends Disposable {
 		return undefined;
 	});
 
+	/**
+	 * Returns an observable that tracks which editor type is currently focused
+	 */
+	public readonly focusedEditorType = derived<MergeEditorType | undefined>(this, reader => {
+		const lastFocusedEditor = this.lastFocusedEditor.read(reader);
+
+		if (!lastFocusedEditor.view) {
+			return undefined;
+		}
+
+		if (lastFocusedEditor.view === this.inputCodeEditorView1) {
+			return 'input1';
+		} else if (lastFocusedEditor.view === this.inputCodeEditorView2) {
+			return 'input2';
+		} else if (lastFocusedEditor.view === this.resultCodeEditorView) {
+			return 'result';
+		} else if (lastFocusedEditor.view === this.baseCodeEditorView.read(reader)) {
+			return 'base';
+		}
+
+		return undefined;
+	});
+
 	public readonly selectionInBase = derived(this, reader => {
 		const sourceEditor = this.lastFocusedEditor.read(reader).view;
 		if (!sourceEditor) {
@@ -343,3 +366,5 @@ interface IAttachedHistoryElement {
 	undo(): void;
 	redo(): void;
 }
+
+export type MergeEditorType = 'input1' | 'input2' | 'result' | 'base';


### PR DESCRIPTION
fixes #227843
fixes #227842
fixes #202877
fixes #227841

- Added alerts when switching between editors in the merge editor so users know which they’re currently in

https://github.com/user-attachments/assets/c882a6b2-6bef-46b3-bc81-4d747eb27540

- Added a new command to toggle between the "Current" and "Incoming" change editor inputs via keyboard

https://github.com/user-attachments/assets/385c550a-e997-4f41-ac34-49eef1eee293

- Added a `ctrlCmd+Enter` keybinding for Complete Merge action to align with other execute/complete actions
- Introduced more descriptive names for Accept All Changes actions
- Updated the accessibility help dialogs to reflect these changes



