### PR TITLE
Fixup: Update relative path resolver logic to handle ${workspaceFolder} variable

### DIFF
--- a/extensions/typescript-language-features/src/utils/relativePathResolver.ts
+++ b/extensions/typescript-language-features/src/utils/relativePathResolver.ts
@@ -7,6 +7,18 @@ import * as vscode from 'vscode';
 
 export class RelativeWorkspacePathResolver {
 	public static asAbsoluteWorkspacePath(relativePath: string): string | undefined {
+		// Handle ${workspaceFolder} variable
+		const workspaceFolderVar = '${workspaceFolder}';
+		if (relativePath.startsWith(workspaceFolderVar) && vscode.workspace.workspaceFolders?.[0]) {
+			const remainingPath = relativePath.substring(workspaceFolderVar.length);
+			return path.join(
+				vscode.workspace.workspaceFolders[0].uri.fsPath,
+				// Remove leading slash/backslash if present
+				remainingPath.replace(/^[/\\]/, '')
+			);
+		}
+
+		// Handle the original path formats
 		for (const root of vscode.workspace.workspaceFolders || []) {
 			const rootPrefixes = [`./${root.name}/`, `${root.name}/`, `.\\${root.name}\\`, `${root.name}\\`];
 			for (const rootPrefix of rootPrefixes) {


### PR DESCRIPTION
In the case that a path starts with the ${workspaceFolder} variable, we need to resolve it to the actual workspace folder path. This is important for ensuring that the path is correctly interpreted in the context of the workspace.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
