### PR TITLE
Disable AutoUpdate log for disabled extensions fixes #245795

### DIFF
--- a/src/vs/workbench/contrib/extensions/browser/extensionsWorkbenchService.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionsWorkbenchService.ts
@@ -1971,7 +1971,7 @@ export class ExtensionsWorkbenchService extends Disposable implements IExtension
 		}
 		await Promise.allSettled(extensions.map(extensions => extensions.syncInstalledExtensionsWithGallery(gallery, this.getProductVersion())));
 		if (this.outdated.length) {
-			this.logService.info(`Auto updating outdated extensions.`, this.outdated.map(e => e.identifier.id).join(', '));
+			this.logService.info(`Auto updating outdated extensions.`, this.outdated.filter(e => this.extensionEnablementService.isEnabledEnablementState(e.enablementState)).map(e => e.identifier.id).join(', '));
 			this.eventuallyAutoUpdateExtensions();
 		}
 	}
@@ -2027,7 +2027,9 @@ export class ExtensionsWorkbenchService extends Disposable implements IExtension
 		const toUpdate: IExtension[] = [];
 		for (const extension of this.outdated) {
 			if (!this.shouldAutoUpdateExtension(extension)) {
-				this.logService.info('Auto update disabled for extension', extension.identifier.id);
+				if (this.extensionEnablementService.isEnabledEnablementState(extension.enablementState)) {
+					this.logService.info('Auto update disabled for extension', extension.identifier.id);
+				}
 				continue;
 			}
 			if (await this.shouldRequireConsentToUpdate(extension)) {


### PR DESCRIPTION
fixes #245795

Filters the AutoUpdate console log messages to enabled extensions only
reducing the enormous amount of useless INFO messages

```js
INFO Auto update disabled for extension publisher.name     workbench.desktop.main.js:sourcemap:35
INFO Auto updating outdated extensions.                    workbench.desktop.main.js:sourcemap:35
```

before:

https://github.com/user-attachments/assets/beb9e9ab-5706-4522-b71c-c34978e48a6a