### PR TITLE
Provide parsed links for text after brackets

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/links/browser/terminalLinkParsing.ts
+++ b/src/vs/workbench/contrib/terminalContrib/links/browser/terminalLinkParsing.ts
@@ -314,6 +314,23 @@ function detectLinksViaSuffix(line: string): IParsedLink[] {
 				prefix,
 				suffix
 			});
+
+			// If the path contains an opening bracket, provide the path starting immediately after
+			// the opening bracket as an additional result
+			const openingBracketMatch = path.matchAll(/(?<bracket>[\[\(])(?![\]\)])/g);
+			for (const match of openingBracketMatch) {
+				const bracket = match.groups?.bracket;
+				if (bracket) {
+					results.push({
+						path: {
+							index: linkStartIndex + (prefix?.text.length || 0) + match.index + 1,
+							text: path.substring(match.index + bracket.length)
+						},
+						prefix,
+						suffix
+					});
+				}
+			}
 		}
 	}
 

--- a/src/vs/workbench/contrib/terminalContrib/links/test/browser/terminalLinkParsing.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/links/test/browser/terminalLinkParsing.test.ts
@@ -322,6 +322,48 @@ suite('TerminalLinkParsing', () => {
 			);
 		});
 
+		test('should detect multiple links when opening brackets are in the text', () => {
+			deepStrictEqual(
+				detectLinks('notlink[foo:45]', OperatingSystem.Linux),
+				[
+					{
+						path: {
+							index: 0,
+							text: 'notlink[foo'
+						},
+						prefix: undefined,
+						suffix: {
+							col: undefined,
+							row: 45,
+							rowEnd: undefined,
+							colEnd: undefined,
+							suffix: {
+								index: 11,
+								text: ':45'
+							}
+						}
+					},
+					{
+						path: {
+							index: 8,
+							text: 'foo'
+						},
+						prefix: undefined,
+						suffix: {
+							col: undefined,
+							row: 45,
+							rowEnd: undefined,
+							colEnd: undefined,
+							suffix: {
+								index: 11,
+								text: ':45'
+							}
+						}
+					},
+				] as IParsedLink[]
+			);
+		});
+
 		test('should extract the link prefix', () => {
 			deepStrictEqual(
 				detectLinks('"foo", line 5, col 6', OperatingSystem.Linux),

--- a/src/vs/workbench/contrib/terminalContrib/links/test/browser/terminalLocalLinkDetector.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/links/test/browser/terminalLocalLinkDetector.test.ts
@@ -251,6 +251,13 @@ suite('Workbench - TerminalLocalLinkDetector', () => {
 				{ range: [[1, 1], [16, 1]], uri: URI.file('/parent/cwd/foo') }
 			]);
 		});
+
+		test('should support finding links after brackets', async () => {
+			validResources = [URI.file('/parent/cwd/foo')];
+			await assertLinks(TerminalBuiltinLinkType.LocalFile, 'bar[foo:5', [
+				{ range: [[5, 1], [9, 1]], uri: URI.file('/parent/cwd/foo') }
+			]);
+		});
 	});
 
 	suite('macOS/Linux', () => {


### PR DESCRIPTION
Fixes #231998

<img width="637" alt="Screenshot 2025-04-23 at 6 52 18 am" src="https://github.com/user-attachments/assets/f6314609-67d5-4e19-9e0f-937192fc5e2d" />
