### PR TITLE
allow skipping kernel selection if already selected

### DIFF
--- a/src/vs/workbench/api/common/extHostNotebookKernels.ts
+++ b/src/vs/workbench/api/common/extHostNotebookKernels.ts
@@ -84,6 +84,9 @@ export class ExtHostNotebookKernels implements ExtHostNotebookKernelsShape {
 						if (notebookEditorId === undefined) {
 							throw new Error(`Cannot invoke 'notebook.selectKernel' for unrecognized notebook editor ${v.notebookEditor.notebook.uri.toString()}`);
 						}
+						if ('skipIfAlreadySelected' in v) {
+							return { notebookEditorId, skipIfAlreadySelected: v.skipIfAlreadySelected };
+						}
 						return { notebookEditorId };
 					}
 					return v;

--- a/src/vs/workbench/contrib/notebook/browser/viewParts/notebookKernelQuickPickStrategy.ts
+++ b/src/vs/workbench/contrib/notebook/browser/viewParts/notebookKernelQuickPickStrategy.ts
@@ -72,8 +72,7 @@ export type KernelQuickPickContext =
 	{ id: string; extension: string } |
 	{ notebookEditorId: string } |
 	{ id: string; extension: string; notebookEditorId: string } |
-	{ ui?: boolean; notebookEditor?: NotebookEditorWidget } |
-	{ notebookUri?: URI; skipIfAlreadySelected?: boolean };
+	{ ui?: boolean; notebookEditor?: NotebookEditorWidget; skipIfAlreadySelected?: boolean };
 
 export interface IKernelPickerStrategy {
 	showQuickPick(editor: IActiveNotebookEditor, wantedKernelId?: string): Promise<boolean>;

--- a/src/vs/workbench/contrib/notebook/browser/viewParts/notebookKernelQuickPickStrategy.ts
+++ b/src/vs/workbench/contrib/notebook/browser/viewParts/notebookKernelQuickPickStrategy.ts
@@ -72,7 +72,8 @@ export type KernelQuickPickContext =
 	{ id: string; extension: string } |
 	{ notebookEditorId: string } |
 	{ id: string; extension: string; notebookEditorId: string } |
-	{ ui?: boolean; notebookEditor?: NotebookEditorWidget };
+	{ ui?: boolean; notebookEditor?: NotebookEditorWidget } |
+	{ notebookUri?: URI; skipIfAlreadySelected?: boolean };
 
 export interface IKernelPickerStrategy {
 	showQuickPick(editor: IActiveNotebookEditor, wantedKernelId?: string): Promise<boolean>;

--- a/src/vs/workbench/contrib/notebook/browser/viewParts/notebookKernelView.ts
+++ b/src/vs/workbench/contrib/notebook/browser/viewParts/notebookKernelView.ts
@@ -32,11 +32,6 @@ function getEditorFromContext(editorService: IEditorService, context?: KernelQui
 		editor = getNotebookEditorFromEditorPane(matchingEditor);
 	} else if (context !== undefined && 'notebookEditor' in context) {
 		editor = context?.notebookEditor;
-	} else if (context !== undefined && 'notebookUri' in context) {
-		const matchingEditor = editorService.visibleEditorPanes.find((editor) => {
-			return editor.input.resource?.toString() === context.notebookUri?.toString();
-		});
-		editor = getNotebookEditorFromEditorPane(matchingEditor);
 	} else {
 		editor = getNotebookEditorFromEditorPane(editorService.activeEditorPane);
 	}

--- a/src/vs/workbench/contrib/notebook/browser/viewParts/notebookKernelView.ts
+++ b/src/vs/workbench/contrib/notebook/browser/viewParts/notebookKernelView.ts
@@ -47,6 +47,7 @@ function shouldSkip(
 
 	return !!(selected && (
 		(context && 'skipIfAlreadySelected' in context && context.skipIfAlreadySelected) ||
+		// target kernel is already selected
 		(controllerId && selected.id === controllerId && ExtensionIdentifier.equals(selected.extension, extensionId))
 	));
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
https://github.com/microsoft/vscode-copilot/issues/16271

just re-use an existing command that will open the kernel picker if no args are provided, but allow skipping if the kernel is already selected.