### PR TITLE
Fix terminal quick fix bugs

### DIFF
--- a/src/vs/platform/terminal/common/capabilities/commandDetectionCapability.ts
+++ b/src/vs/platform/terminal/common/capabilities/commandDetectionCapability.ts
@@ -540,27 +540,7 @@ class UnixPtyHeuristics extends Disposable {
 			return;
 		}
 
-		// Calculate the command
-		currentCommand.command = this._hooks.isCommandStorageDisabled ? '' : this._terminal.buffer.active.getLine(currentCommand.commandStartMarker.line)?.translateToString(false, currentCommand.commandStartX, currentCommand.commandRightPromptStartX);
-		let y = currentCommand.commandStartMarker.line + 1;
-		const commandExecutedLine = currentCommand.commandExecutedMarker.line;
-		for (; y < commandExecutedLine; y++) {
-			const line = this._terminal.buffer.active.getLine(y);
-			if (line) {
-				const continuation = currentCommand.continuations?.find(e => e.marker.line === y);
-				if (continuation) {
-					currentCommand.command += '\n';
-				}
-				const startColumn = continuation?.end ?? 0;
-				currentCommand.command += line.translateToString(true, startColumn);
-			}
-		}
-		if (y === commandExecutedLine) {
-			currentCommand.command += this._terminal.buffer.active.getLine(commandExecutedLine)?.translateToString(true, undefined, currentCommand.commandExecutedX) || '';
-		}
-		if (currentCommand.command) {
-			currentCommand.command = currentCommand.command.trim();
-		}
+		currentCommand.command = this._capability.promptInputModel.ghostTextIndex > -1 ? this._capability.promptInputModel.value.substring(0, this._capability.promptInputModel.ghostTextIndex) : this._capability.promptInputModel.value;
 		this._hooks.onCommandExecutedEmitter.fire(currentCommand as ITerminalCommand);
 	}
 }

--- a/src/vs/platform/terminal/common/capabilities/commandDetectionCapability.ts
+++ b/src/vs/platform/terminal/common/capabilities/commandDetectionCapability.ts
@@ -541,7 +541,7 @@ class UnixPtyHeuristics extends Disposable {
 		}
 
 		// Calculate the command
-		currentCommand.command = this._hooks.isCommandStorageDisabled ? '' : this._terminal.buffer.active.getLine(currentCommand.commandStartMarker.line)?.translateToString(true, currentCommand.commandStartX, currentCommand.commandRightPromptStartX).trim();
+		currentCommand.command = this._hooks.isCommandStorageDisabled ? '' : this._terminal.buffer.active.getLine(currentCommand.commandStartMarker.line)?.translateToString(false, currentCommand.commandStartX, currentCommand.commandRightPromptStartX);
 		let y = currentCommand.commandStartMarker.line + 1;
 		const commandExecutedLine = currentCommand.commandExecutedMarker.line;
 		for (; y < commandExecutedLine; y++) {
@@ -557,6 +557,9 @@ class UnixPtyHeuristics extends Disposable {
 		}
 		if (y === commandExecutedLine) {
 			currentCommand.command += this._terminal.buffer.active.getLine(commandExecutedLine)?.translateToString(true, undefined, currentCommand.commandExecutedX) || '';
+		}
+		if (currentCommand.command) {
+			currentCommand.command = currentCommand.command.trim();
 		}
 		this._hooks.onCommandExecutedEmitter.fire(currentCommand as ITerminalCommand);
 	}


### PR DESCRIPTION
fixes #211857

Previously, both the **Create PR** and **Push Upstream** terminal quick fixes required the command line to match a specific regex:

https://github.com/microsoft/vscode/blob/7de10c33ba1ff24e9787e3f80bf3fc3e211ef766/src/vs/workbench/contrib/terminalContrib/quickFix/browser/terminalQuickFixBuiltinActions.ts#L12

However, in certain cases, the captured `commandLine` was incorrectly set to `gitpush` instead of `git push`. This occurred when the user entered `git` and `push` on separate lines — such as when a command wrapped due to line length.

![Wrapped command](https://github.com/user-attachments/assets/2f1ff5ad-2c7b-4c02-a43d-0fba96816fce)

During the `execute` phase, the command was correctly recognized. But by the `finished` phase, the space had been lost, breaking the match:

![Incorrect by finished](https://github.com/user-attachments/assets/f4a12f54-d04b-4391-8c19-31485c2e2717)

The issue was caused by trimming whitespace **before** combining wrapped lines — which removed the space between command parts. 

Daniel suggested instead of changing that logic, we replace it and use the `promptInputModel.value` instead which does not have this issue. 

![Working case](https://github.com/user-attachments/assets/13e6ec84-0c6a-4983-b260-205f0d046a65)

