### PR TITLE
[prompts]: fix prompt decoration providers for disposed text model

### DIFF
--- a/src/vs/workbench/contrib/chat/common/promptSyntax/languageFeatures/providers/decorationsProvider/promptDecorationsProvider.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/languageFeatures/providers/decorationsProvider/promptDecorationsProvider.ts
@@ -48,6 +48,12 @@ export class PromptDecorator extends ProviderInstanceBase {
 	protected override async onPromptParserUpdate(): Promise<this> {
 		await this.parser.allSettled();
 
+		// by the time the promise above completes, either this object
+		// or the text model might be already has been disposed
+		if (this.disposed || this.model.isDisposed()) {
+			return this;
+		}
+
 		this.removeAllDecorations();
 		this.addDecorations();
 
@@ -100,7 +106,7 @@ export class PromptDecorator extends ProviderInstanceBase {
 	}
 
 	/**
-	 *
+	 * Update existing decorations.
 	 */
 	private changeModelDecorations(
 		decorations: readonly TChangedDecorator[],
@@ -115,7 +121,7 @@ export class PromptDecorator extends ProviderInstanceBase {
 	}
 
 	/**
-	 * Add a decorations for all prompt tokens.
+	 * Add decorations for all prompt tokens.
 	 */
 	private addDecorations(): this {
 		this.model.changeDecorations((accessor) => {
@@ -162,6 +168,10 @@ export class PromptDecorator extends ProviderInstanceBase {
 	}
 
 	public override dispose(): void {
+		if (this.disposed) {
+			return;
+		}
+
 		this.removeAllDecorations();
 
 		super.dispose();

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/languageFeatures/providers/providerInstanceManagerBase.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/languageFeatures/providers/providerInstanceManagerBase.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { ProviderInstanceBase } from './providerInstanceBase.js';
+import { assert } from '../../../../../../../base/common/assert.js';
 import { ITextModel } from '../../../../../../../editor/common/model.js';
 import { assertDefined } from '../../../../../../../base/common/types.js';
 import { Disposable } from '../../../../../../../base/common/lifecycle.js';
@@ -49,6 +50,11 @@ export abstract class ProviderInstanceManagerBase<TInstance extends ProviderInst
 		// cache of managed instances
 		this.instances = this._register(
 			new ObjectCache((model: ITextModel) => {
+				assert(
+					model.isDisposed() === false,
+					'Text model must not be disposed.',
+				);
+
 				// sanity check - the new TS/JS discrepancies regarding fields initialization
 				// logic mean that this can be `undefined` during runtime while defined in TS
 				assertDefined(

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/basePromptParser.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/basePromptParser.ts
@@ -695,8 +695,6 @@ export class BasePromptParser<TContentsProvider extends IPromptContentsProvider>
 		this.promptHeader?.dispose();
 		delete this.promptHeader;
 
-		this._onUpdate.fire();
-
 		super.dispose();
 	}
 }

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsService.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsService.ts
@@ -56,6 +56,11 @@ export class PromptsService extends Disposable implements IPromptsService {
 		// for the provided model, if no active non-disposed parser exists
 		this.cache = this._register(
 			new ObjectCache((model) => {
+				assert(
+					model.isDisposed() === false,
+					'Text model must not be disposed.',
+				);
+
 				/**
 				 * Note! When/if shared with "file" prompts, the `seenReferences` array below must be taken into account.
 				 * Otherwise consumers will either see incorrect failing or incorrect successful results, based on their
@@ -65,9 +70,7 @@ export class PromptsService extends Disposable implements IPromptsService {
 					TextModelPromptParser,
 					model,
 					[],
-				);
-
-				parser.start();
+				).start();
 
 				// this is a sanity check and the contract of the object cache,
 				// we must return a non-disposed object from this factory function

--- a/src/vs/workbench/contrib/chat/test/common/promptSyntax/service/promptsService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/promptSyntax/service/promptsService.test.ts
@@ -527,7 +527,7 @@ suite('PromptsService', () => {
 			);
 		});
 
-		test('• throws if disposed model provided', async function () {
+		test('• throws if a disposed model provided', async function () {
 			const model = disposables.add(createTextModel(
 				'test1\ntest2\n\ntest3\t\n',
 				'barLang',


### PR DESCRIPTION
Ensures that prompt decoration providers not access possible disposed text models.

Part of https://github.com/microsoft/vscode-copilot/issues/15596.