### PR TITLE
fix: render IPython.display.Latex as math output

### DIFF
--- a/extensions/notebook-renderers/src/index.ts
+++ b/extensions/notebook-renderers/src/index.ts
@@ -592,6 +592,14 @@ export const activate: ActivationFunction<void> = (ctx) => {
 						disposables.set(outputInfo.id, disposable);
 					}
 					break;
+				case 'text/latex': {
+					if (!ctx.workspace.isTrusted) {
+						return;
+					}
+					disposables.get(outputInfo.id)?.dispose();
+					await renderHTML(outputInfo, element, signal!, htmlHooks);
+					break;
+				}
 				case 'text/plain':
 					{
 						disposables.get(outputInfo.id)?.dispose();

--- a/src/vs/workbench/contrib/notebook/browser/viewModel/cellOutputTextHelper.ts
+++ b/src/vs/workbench/contrib/notebook/browser/viewModel/cellOutputTextHelper.ts
@@ -80,11 +80,22 @@ export function getOutputStreamText(output: ICellOutputViewModel): { text: strin
 
 const decoder = new TextDecoder();
 
+function ensureMathWrapped(latex: string): string {
+	console.log('[DEBUG] ensureMathWrapped called with:', latex);  // Add this
+	if (!latex.trim().startsWith('$')) {
+		return `$${latex}$`;
+	}
+	return latex;
+}
+
 export function getOutputText(mimeType: string, buffer: IOutputItemDto, shortError: boolean = false): string {
 	let text = `${mimeType}`; // default in case we can't get the text value for some reason.
 
 	const charLimit = 100000;
 	text = decoder.decode(buffer.data.slice(0, charLimit).buffer);
+	if (mimeType === 'text/latex') {
+		text = ensureMathWrapped(text);
+	}
 
 	if (buffer.data.byteLength > charLimit) {
 		text = text + '...(truncated)';


### PR DESCRIPTION
This patch ensures that IPython.display.Latex outputs are rendered the same way as IPython.display.Math outputs in Jupyter notebooks.

Problem:
Previously, unwrapped LaTeX strings passed to display(Latex(...)) were not rendered properly unless manually wrapped with $...$. This behavior differed from Colab and classic Jupyter Notebook behavior.

Fix:

Added ensureMathWrapped() in cellOutputTextHelper.ts to automatically wrap LaTeX strings with $...$ if not already present.

Handled the text/latex MIME type in extensions/notebook-renderers/src/index.ts to trigger the MathJax rendering path used by Math().

Result:
This change improves consistency and user experience when using display(Latex(...)) in notebooks, eliminating the need for manual wrapping and matching the behavior of other platforms like Colab.