### PR TITLE
Introduce Notebook Output Preview editor

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/controller/cellOutputActions.ts
+++ b/src/vs/workbench/contrib/notebook/browser/controller/cellOutputActions.ts
@@ -182,16 +182,16 @@ registerAction2(class OpenCellOutputInEditorAction extends Action2 {
 	}
 });
 
-export const OPEN_OUTPUT_IN_NOTEBOOK_OUTPUT_EDITOR_COMMAND_ID = 'notebook.cellOutput.openInNotebookOutputEditor';
+export const OPEN_OUTPUT_IN_OUTPUT_PREVIEW_COMMAND_ID = 'notebook.cellOutput.openInOutputPreview';
 
 registerAction2(class OpenCellOutputInNotebookOutputEditorAction extends Action2 {
 	constructor() {
 		super({
-			id: OPEN_OUTPUT_IN_NOTEBOOK_OUTPUT_EDITOR_COMMAND_ID,
-			title: localize('notebookActions.openOutputInNotebookOutputEditor', "Open Cell Output in Notebook Output Editor"),
+			id: OPEN_OUTPUT_IN_OUTPUT_PREVIEW_COMMAND_ID,
+			title: localize('notebookActions.openOutputInNotebookOutputEditor', "Open in Output Preview"),
 			menu: {
 				id: MenuId.NotebookOutputToolbar,
-				when: NOTEBOOK_CELL_HAS_OUTPUTS
+				when: ContextKeyExpr.and(NOTEBOOK_CELL_HAS_OUTPUTS, ContextKeyExpr.equals('config.notebook.openOutputInPreviewEditor.enabled', true))
 			},
 			f1: false,
 			category: NOTEBOOK_ACTIONS_CATEGORY,

--- a/src/vs/workbench/contrib/notebook/browser/controller/cellOutputActions.ts
+++ b/src/vs/workbench/contrib/notebook/browser/controller/cellOutputActions.ts
@@ -191,7 +191,7 @@ registerAction2(class OpenCellOutputInNotebookOutputEditorAction extends Action2
 			title: localize('notebookActions.openOutputInNotebookOutputEditor', "Open in Output Preview"),
 			menu: {
 				id: MenuId.NotebookOutputToolbar,
-				when: ContextKeyExpr.and(NOTEBOOK_CELL_HAS_OUTPUTS, ContextKeyExpr.equals('config.notebook.openOutputInPreviewEditor.enabled', true))
+				when: ContextKeyExpr.and(NOTEBOOK_CELL_HAS_OUTPUTS, ContextKeyExpr.equals('config.notebook.output.openInPreviewEditor.enabled', true))
 			},
 			f1: false,
 			category: NOTEBOOK_ACTIONS_CATEGORY,

--- a/src/vs/workbench/contrib/notebook/browser/notebook.contribution.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebook.contribution.ts
@@ -132,6 +132,8 @@ import { NotebookMultiDiffEditorInput } from './diff/notebookMultiDiffEditorInpu
 import { getFormattedMetadataJSON } from '../common/model/notebookCellTextModel.js';
 import { INotebookOutlineEntryFactory, NotebookOutlineEntryFactory } from './viewModel/notebookOutlineEntryFactory.js';
 import { getFormattedNotebookMetadataJSON } from '../common/model/notebookMetadataTextModel.js';
+import { NotebookOutputEditor } from './outputEditor/notebookOutputEditor.js';
+import { NotebookOutputEditorInput } from './outputEditor/notebookOutputEditorInput.js';
 
 /*--------------------------------------------------------------------------------------------- */
 
@@ -154,6 +156,17 @@ Registry.as<IEditorPaneRegistry>(EditorExtensions.EditorPane).registerEditorPane
 	),
 	[
 		new SyncDescriptor(NotebookDiffEditorInput)
+	]
+);
+
+Registry.as<IEditorPaneRegistry>(EditorExtensions.EditorPane).registerEditorPane(
+	EditorPaneDescriptor.create(
+		NotebookOutputEditor,
+		NotebookOutputEditor.ID,
+		'Notebook Output Editor'
+	),
+	[
+		new SyncDescriptor(NotebookOutputEditorInput)
 	]
 );
 
@@ -239,6 +252,18 @@ class NotebookEditorSerializer implements IEditorSerializer {
 	}
 }
 
+class NotebookOutputEditorSerializer implements IEditorSerializer {
+	canSerialize(editor: EditorInput): boolean {
+		return editor.typeId === NotebookOutputEditorInput.ID;
+	}
+	serialize(editor: EditorInput): string | undefined {
+		return undefined;
+	}
+	deserialize(instantiationService: IInstantiationService, serializedEditor: string): EditorInput | undefined {
+		return undefined;
+	}
+}
+
 Registry.as<IEditorFactoryRegistry>(EditorExtensions.EditorFactory).registerEditorSerializer(
 	NotebookEditorInput.ID,
 	NotebookEditorSerializer
@@ -247,6 +272,11 @@ Registry.as<IEditorFactoryRegistry>(EditorExtensions.EditorFactory).registerEdit
 Registry.as<IEditorFactoryRegistry>(EditorExtensions.EditorFactory).registerEditorSerializer(
 	NotebookDiffEditorInput.ID,
 	NotebookDiffEditorSerializer
+);
+
+Registry.as<IEditorFactoryRegistry>(EditorExtensions.EditorFactory).registerEditorSerializer(
+	NotebookOutputEditorInput.ID,
+	NotebookOutputEditorSerializer
 );
 
 export class NotebookContribution extends Disposable implements IWorkbenchContribution {

--- a/src/vs/workbench/contrib/notebook/browser/notebook.contribution.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebook.contribution.ts
@@ -166,8 +166,7 @@ Registry.as<IEditorPaneRegistry>(EditorExtensions.EditorPane).registerEditorPane
 		'Notebook Output Editor'
 	),
 	[
-		new SyncDescriptor(NotebookOutputEditorInput),
-		// new SyncDescriptor(NotebookOutputViewerInput)
+		new SyncDescriptor(NotebookOutputEditorInput)
 	]
 );
 
@@ -1092,7 +1091,7 @@ configurationRegistry.registerConfiguration({
 			tags: ['notebookLayout']
 		},
 		[NotebookSetting.openOutputInPreviewEditor]: {
-			description: nls.localize('notebook.openOutputInPreviewEditor.description', "Controls whether or not the action to open a cell output in a preview editor is enabled. This action can be used via the cell output menu."),
+			description: nls.localize('notebook.output.openInPreviewEditor.description', "Controls whether or not the action to open a cell output in a preview editor is enabled. This action can be used via the cell output menu."),
 			type: 'boolean',
 			default: false,
 			tags: ['preview']

--- a/src/vs/workbench/contrib/notebook/browser/notebook.contribution.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebook.contribution.ts
@@ -261,7 +261,7 @@ class NotebookOutputEditorSerializer implements IEditorSerializer {
 	serialize(input: EditorInput): string | undefined {
 		assertType(input instanceof NotebookOutputEditorInput);
 
-		const data = input.getSerializedData(); // in case of cell movement etc get latest indexes
+		const data = input.getSerializedData(); // in case of cell movement etc get latest indices
 		if (!data) {
 			return undefined;
 		}
@@ -274,7 +274,7 @@ class NotebookOutputEditorSerializer implements IEditorSerializer {
 			return undefined;
 		}
 
-		const input = instantiationService.createInstance(NotebookOutputEditorInput, data.notebookUri, undefined, data.cellIndex, undefined, data.outputIndex);
+		const input = instantiationService.createInstance(NotebookOutputEditorInput, data.notebookUri, data.cellIndex, undefined, data.outputIndex);
 		return input;
 	}
 }
@@ -1090,6 +1090,12 @@ configurationRegistry.registerConfiguration({
 			type: 'boolean',
 			default: true,
 			tags: ['notebookLayout']
+		},
+		[NotebookSetting.openOutputInPreviewEditor]: {
+			description: nls.localize('notebook.openOutputInPreviewEditor.description', "Controls whether or not the action to open a cell output in a preview editor is enabled. This action can be used via the cell output menu."),
+			type: 'boolean',
+			default: false,
+			tags: ['preview']
 		},
 		[NotebookSetting.showFoldingControls]: {
 			description: nls.localize('notebook.showFoldingControls.description', "Controls when the Markdown header folding arrow is shown."),

--- a/src/vs/workbench/contrib/notebook/browser/outputEditor/notebookOutputEditor.ts
+++ b/src/vs/workbench/contrib/notebook/browser/outputEditor/notebookOutputEditor.ts
@@ -362,15 +362,12 @@ export class NotebookOutputEditorContribution implements IWorkbenchContribution 
 			{
 				createEditorInput: async ({ resource, options }) => {
 					const outputUriData = CellUri.parseCellOutputUri(resource);
-					if (!outputUriData || !outputUriData.notebook || outputUriData.cellIndex === undefined || outputUriData.outputIndex === undefined || !outputUriData.cellId || !outputUriData.outputId) {
+					if (!outputUriData || !outputUriData.notebook || outputUriData.cellIndex === undefined || outputUriData.outputIndex === undefined || !outputUriData.outputId) {
 						throw new Error('Invalid output uri for notebook output editor');
 					}
 
-
 					const notebookUri = this.uriIdentityService.asCanonicalUri(outputUriData.notebook);
-
 					const cellIndex = outputUriData.cellIndex;
-
 					const outputId = outputUriData.outputId;
 					const outputIndex = outputUriData.outputIndex;
 

--- a/src/vs/workbench/contrib/notebook/browser/outputEditor/notebookOutputEditor.ts
+++ b/src/vs/workbench/contrib/notebook/browser/outputEditor/notebookOutputEditor.ts
@@ -1,0 +1,323 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as DOM from '../../../../../base/browser/dom.js';
+import * as nls from '../../../../../nls.js';
+
+import { getDefaultNotebookCreationOptions } from '../notebookEditorWidget.js';
+import { EditorPane } from '../../../../browser/parts/editor/editorPane.js';
+import { BackLayerWebView, INotebookDelegateForWebview } from '../view/renderers/backLayerWebView.js';
+import { CellEditState, ICellOutputViewModel, ICommonCellInfo, IGenericCellViewModel, IInsetRenderOutput, INotebookEditorCreationOptions, RenderOutputType } from '../notebookBrowser.js';
+import { CellUri, NOTEBOOK_OUTPUT_EDITOR_ID } from '../../common/notebookCommon.js';
+import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
+import { IStorageService } from '../../../../../platform/storage/common/storage.js';
+import { ITelemetryService } from '../../../../../platform/telemetry/common/telemetry.js';
+import { IThemeService } from '../../../../../platform/theme/common/themeService.js';
+import { IEditorGroup } from '../../../../services/editor/common/editorGroupsService.js';
+import { NotebookTextDiffEditor } from '../diff/notebookDiffEditor.js';
+import { NotebookOptions } from '../notebookOptions.js';
+import { IWorkbenchContribution, registerWorkbenchContribution2, WorkbenchPhase } from '../../../../common/contributions.js';
+import { IEditorResolverService, RegisteredEditorPriority } from '../../../../services/editor/common/editorResolverService.js';
+import { INotebookEditorModelResolverService } from '../../common/notebookEditorModelResolverService.js';
+import { INotebookService } from '../../common/notebookService.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { Schemas } from '../../../../../base/common/network.js';
+import { NotebookOutputEditorInput } from './notebookOutputEditorInput.js';
+import { IEditorOpenContext } from '../../../../common/editor.js';
+import { CancellationToken } from '../../../../../base/common/cancellation.js';
+import { IEditorOptions } from '../../../../../platform/editor/common/editor.js';
+import { generateUuid } from '../../../../../base/common/uuid.js';
+import { IUriIdentityService } from '../../../../../platform/uriIdentity/common/uriIdentity.js';
+import { IEditorService } from '../../../../services/editor/common/editorService.js';
+import { INotebookEditorService } from '../services/notebookEditorService.js';
+
+
+export class NotebookOutputEditor extends EditorPane implements INotebookDelegateForWebview {
+
+	static readonly ID: string = NOTEBOOK_OUTPUT_EDITOR_ID;
+
+
+	creationOptions: INotebookEditorCreationOptions = getDefaultNotebookCreationOptions();
+
+	private _rootElement!: HTMLElement;
+	// private _dimension: DOM.Dimension | undefined = undefined;
+	private _outputWebview: BackLayerWebView<ICommonCellInfo> | null = null;
+
+
+	private readonly _notebookOptions: NotebookOptions;
+	get notebookOptions() {
+		return this._notebookOptions;
+	}
+
+	private _isDisposed: boolean = false;
+	get isDisposed() {
+		return this._isDisposed;
+	}
+
+	constructor(
+		group: IEditorGroup,
+		@IInstantiationService private readonly instantiationService: IInstantiationService,
+		@IThemeService themeService: IThemeService,
+		@ITelemetryService telemetryService: ITelemetryService,
+		@IStorageService storageService: IStorageService,
+		@IEditorService editorService: IEditorService,
+		@INotebookEditorService private readonly notebookEditorService: INotebookEditorService,
+		@INotebookService private readonly notebookService: INotebookService,
+	) {
+		super(NotebookTextDiffEditor.ID, group, telemetryService, themeService, storageService);
+		this._notebookOptions = this.instantiationService.createInstance(NotebookOptions, this.window, false, undefined);
+		this._register(this._notebookOptions);
+	}
+
+	createEditor(parent: HTMLElement): void {
+		this._rootElement = DOM.append(parent, DOM.$('.notebook-output-editor'));
+	}
+
+	private async _createOriginalWebview(id: string, viewType: string, resource: URI): Promise<void> {
+		this._outputWebview?.dispose();
+
+		this._outputWebview = this.instantiationService.createInstance(BackLayerWebView, this, id, viewType, resource, {
+			...this._notebookOptions.computeDiffWebviewOptions(),
+			fontFamily: this._generateFontFamily()
+		}, undefined) as BackLayerWebView<ICommonCellInfo>;
+
+		// attach the webview container to the DOM tree first
+		DOM.append(this._rootElement, this._outputWebview.element);
+
+		this._outputWebview.createWebview(this.window);
+		this._outputWebview.element.style.width = `calc(100% - 16px)`;
+		this._outputWebview.element.style.left = `16px`;
+
+	}
+
+	_generateFontFamily(): string {
+		return `"SF Mono", Monaco, Menlo, Consolas, "Ubuntu Mono", "Liberation Mono", "DejaVu Sans Mono", "Courier New", monospace`;
+	}
+
+
+	override async setInput(input: NotebookOutputEditorInput, options: IEditorOptions | undefined, context: IEditorOpenContext, token: CancellationToken): Promise<void> {
+		await this._createOriginalWebview(generateUuid(), input.notebookViewType, URI.from({ scheme: Schemas.vscodeNotebookCellOutput, path: '', query: 'openIn=notebookOutputEditor' }));
+
+		const resolvedNotebookModel = input.getNotebookRef().object;
+		const notebookTextModel = resolvedNotebookModel.notebook;
+
+		const outputUriData = CellUri.parseCellOutputUri(input.outputDataUri);
+		if (!outputUriData || !outputUriData.notebook || !outputUriData.cellId) {
+			throw new Error('Invalid output uri for notebook output editor');
+		}
+
+		const cellTextModel = notebookTextModel.cells.find(cellTextModel => cellTextModel.outputs.some(output => output.outputId === outputUriData.outputId)); // || output.alternativeOutputId === outputId));
+		if (!cellTextModel) {
+			throw new Error('Invalid cell output uri, no matching cell');
+		}
+
+
+		const cellInfo: ICommonCellInfo = {
+			cellId: outputUriData.cellId,
+			cellHandle: cellTextModel.handle,
+			cellUri: cellTextModel.uri,
+		};
+
+
+		const notebookEditor = this.notebookEditorService.retrieveExistingWidgetFromURI(input.notebookUri)?.value;
+		if (!notebookEditor) {
+			throw new Error('Invalid notebook editor, no matching notebook editor');
+		}
+
+		const cellOutputViewModel = notebookEditor.getCellByInfo(cellInfo).outputsViewModels.find(outputViewModel => outputViewModel.model.outputId === outputUriData.outputId);
+		if (!cellOutputViewModel) {
+			throw new Error('Invalid NotebookOutputEditorInput, no matching cell output view model');
+		}
+
+		let result: IInsetRenderOutput | undefined = undefined;
+
+		const [mimeTypes, pick] = cellOutputViewModel.resolveMimeTypes(notebookTextModel, undefined);
+		const pickedMimeTypeRenderer = cellOutputViewModel.pickedMimeType || mimeTypes[pick];
+
+		if (mimeTypes.length !== 0) {
+			const renderer = this.notebookService.getRendererInfo(pickedMimeTypeRenderer.rendererId);
+			result = renderer
+				? { type: RenderOutputType.Extension, renderer, source: cellOutputViewModel, mimeType: pickedMimeTypeRenderer.mimeType }
+				: this._renderMissingRenderer(cellOutputViewModel, pickedMimeTypeRenderer.mimeType);
+
+		}
+
+		if (!result) {
+			throw new Error('No InsetRenderInfo for output');
+		}
+
+		this._outputWebview?.createOutput(cellInfo, result, 0, 0);
+	}
+
+	private _renderMissingRenderer(viewModel: ICellOutputViewModel, preferredMimeType: string | undefined): IInsetRenderOutput {
+		if (!viewModel.model.outputs.length) {
+			return this._renderMessage(viewModel, nls.localize('empty', "Cell has no output"));
+		}
+
+		if (!preferredMimeType) {
+			const mimeTypes = viewModel.model.outputs.map(op => op.mime);
+			const mimeTypesMessage = mimeTypes.join(', ');
+			return this._renderMessage(viewModel, nls.localize('noRenderer.2', "No renderer could be found for output. It has the following mimetypes: {0}", mimeTypesMessage));
+		}
+
+		return this._renderSearchForMimetype(viewModel, preferredMimeType);
+	}
+
+	private _renderMessage(viewModel: ICellOutputViewModel, message: string): IInsetRenderOutput {
+		const el = DOM.$('p', undefined, message);
+		return { type: RenderOutputType.Html, source: viewModel, htmlContent: el.outerHTML };
+	}
+
+	private _renderSearchForMimetype(viewModel: ICellOutputViewModel, mimeType: string): IInsetRenderOutput {
+		const query = `@tag:notebookRenderer ${mimeType}`;
+
+		const p = DOM.$('p', undefined, `No renderer could be found for mimetype "${mimeType}", but one might be available on the Marketplace.`);
+		const a = DOM.$('a', { href: `command:workbench.extensions.search?%22${query}%22`, class: 'monaco-button monaco-text-button', tabindex: 0, role: 'button', style: 'padding: 8px; text-decoration: none; color: rgb(255, 255, 255); background-color: rgb(14, 99, 156); max-width: 200px;' }, `Search Marketplace`);
+
+		return {
+			type: RenderOutputType.Html,
+			source: viewModel,
+			htmlContent: p.outerHTML + a.outerHTML,
+		};
+	}
+
+	async focusNotebookCell(cell: IGenericCellViewModel, focus: 'output' | 'editor' | 'container'): Promise<void> {
+
+	}
+
+	async focusNextNotebookCell(cell: IGenericCellViewModel, focus: 'output' | 'editor' | 'container'): Promise<void> {
+
+	}
+
+	toggleNotebookCellSelection(cell: IGenericCellViewModel) {
+		throw new Error('Not implemented.');
+	}
+
+	getCellById(cellId: string): IGenericCellViewModel | undefined {
+		throw new Error('Not implemented');
+	}
+
+	getCellByInfo(cellInfo: ICommonCellInfo): IGenericCellViewModel {
+		throw new Error('Not implemented');
+	}
+
+	layout(dimension: DOM.Dimension, position: DOM.IDomPosition): void {
+
+	}
+
+	setScrollTop(scrollTop: number): void {
+
+	}
+
+	triggerScroll(event: any): void {
+
+	}
+
+	getOutputRenderer(): any {
+
+	}
+
+	updateOutputHeight(cellInfo: ICommonCellInfo, output: ICellOutputViewModel, height: number, isInit: boolean, source?: string): void {
+
+	}
+
+	scheduleOutputHeightAck(cellInfo: ICommonCellInfo, outputId: string, height: number): void {
+
+	}
+
+	updateMarkupCellHeight(cellId: string, height: number, isInit: boolean): void {
+
+	}
+
+	setMarkupCellEditState(cellId: string, editState: CellEditState): void {
+
+	}
+
+	didResizeOutput(cellId: string): void {
+
+	}
+
+	didStartDragMarkupCell(cellId: string, event: { dragOffsetY: number }): void {
+
+	}
+
+	didDragMarkupCell(cellId: string, event: { dragOffsetY: number }): void {
+
+	}
+
+	didDropMarkupCell(cellId: string, event: { dragOffsetY: number; ctrlKey: boolean; altKey: boolean }): void {
+
+	}
+
+	didEndDragMarkupCell(cellId: string): void {
+
+	}
+
+	updatePerformanceMetadata(cellId: string, executionId: string, duration: number, rendererId: string): void {
+
+	}
+
+	didFocusOutputInputChange(inputFocused: boolean): void {
+
+	}
+
+	override dispose() {
+		this._isDisposed = true;
+		super.dispose();
+	}
+}
+
+export class NotebookOutputEditorContribution implements IWorkbenchContribution {
+
+	static readonly ID = 'workbench.contribution.notebookOutputEditorContribution';
+
+	constructor(
+		@INotebookService notebookService: INotebookService,
+		@IEditorResolverService editorResolverService: IEditorResolverService,
+		@IInstantiationService private readonly instantiationService: IInstantiationService,
+		@IUriIdentityService private readonly uriIdentityService: IUriIdentityService,
+		@INotebookEditorModelResolverService private readonly notebookEditorModelResolverService: INotebookEditorModelResolverService,
+	) {
+		editorResolverService.registerEditor(
+			`${Schemas.vscodeNotebookCellOutput}:/**`,
+			{
+				id: 'notebookOutputEditor',
+				label: 'Notebook Output Editor',
+				priority: RegisteredEditorPriority.exclusive
+			},
+			{
+				// We want to support all notebook types which could have any file extension,
+				// so we just check if the resource corresponds to a notebook
+				canSupportResource: (resource: URI) => {
+					if (resource.scheme === Schemas.vscodeNotebookCellOutput) {
+						const params = new URLSearchParams(resource.query);
+						return params.get('openIn') === 'notebookOutputEditor';
+					}
+					return false;
+				}
+			},
+			{
+				createEditorInput: async ({ resource, options }) => {
+					const outputUriData = CellUri.parseCellOutputUri(resource);
+					if (!outputUriData || !outputUriData.notebook || !outputUriData.cellId) {
+						throw new Error('Invalid output uri for notebook output editor');
+					}
+
+
+					const notebookUri = this.uriIdentityService.asCanonicalUri(outputUriData.notebook);
+					const notebook = await this.notebookEditorModelResolverService.resolve(notebookUri);
+
+					const editorInput = this.instantiationService.createInstance(NotebookOutputEditorInput, notebook, resource);
+					return {
+						editor: editorInput,
+						options: options
+					};
+				}
+			}
+		);
+	}
+}
+
+registerWorkbenchContribution2(NotebookOutputEditorContribution.ID, NotebookOutputEditorContribution, WorkbenchPhase.BlockRestore);

--- a/src/vs/workbench/contrib/notebook/browser/outputEditor/notebookOutputEditor.ts
+++ b/src/vs/workbench/contrib/notebook/browser/outputEditor/notebookOutputEditor.ts
@@ -270,7 +270,7 @@ export class NotebookOutputEditor extends EditorPane implements INotebookDelegat
 	}
 
 	getCellByInfo(cellInfo: ICommonCellInfo): IGenericCellViewModel {
-		throw new Error('Not implemented');
+		return this._notebookViewModel?.getCellByHandle(cellInfo.cellHandle) as IGenericCellViewModel;
 	}
 
 	layout(dimension: DOM.Dimension, position: DOM.IDomPosition): void {

--- a/src/vs/workbench/contrib/notebook/browser/outputEditor/notebookOutputEditorInput.ts
+++ b/src/vs/workbench/contrib/notebook/browser/outputEditor/notebookOutputEditorInput.ts
@@ -3,59 +3,159 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { IReference } from '../../../../../base/common/lifecycle.js';
+import * as nls from '../../../../../nls.js';
+import { Event } from '../../../../../base/common/event.js';
+import { IDisposable, IReference } from '../../../../../base/common/lifecycle.js';
 import { URI } from '../../../../../base/common/uri.js';
+import { EditorInputCapabilities } from '../../../../common/editor.js';
 import { EditorInput } from '../../../../common/editor/editorInput.js';
 import { IResolvedNotebookEditorModel } from '../../common/notebookCommon.js';
+import { INotebookEditorModelResolverService } from '../../common/notebookEditorModelResolverService.js';
+import { NotebookEditorWidget } from '../notebookEditorWidget.js';
+import { INotebookEditorService } from '../services/notebookEditorService.js';
 
 
-export class NotebookOutputEditorInput extends EditorInput {
+class ResolvedNotebookOutputEditorInputModel implements IDisposable {
+	constructor(
+		readonly notebookRef: IReference<IResolvedNotebookEditorModel>,
+		readonly notebookUri: URI,
+		readonly cellId: string,
+		readonly outputId: string,
+	) { }
+
+	dispose(): void {
+		this.notebookRef.dispose();
+	}
+}
+
+// export class NotebookOutputViewerInput extends EditorInput { // for viewing static outputs, encode mime + data
+// 	static readonly ID: string = 'workbench.input.notebookOutputViewerInput';
+// }
+
+export class NotebookOutputEditorInput extends EditorInput { // for viewing dynamic outputs w execution refreshing
 	static readonly ID: string = 'workbench.input.notebookOutputEditorInput';
 
-	private notebookRef: IReference<IResolvedNotebookEditorModel>;
+	private _notebookRef: IReference<IResolvedNotebookEditorModel> | undefined;
+	private readonly _notebookUri: URI;
 
-	getNotebookRef(): IReference<IResolvedNotebookEditorModel> {
-		return this.notebookRef;
-	}
+	readonly cellIndex: number;
 
-	private _notebookViewType: string;
-	get notebookViewType(): string {
-		return this._notebookViewType;
-	}
+	public cellId: string | undefined;
 
-	private _notebookUri: URI;
-	get notebookUri(): URI {
-		return this._notebookUri;
-	}
-
-	private _outputDataUri: URI; // has outputId, cellId
-	get outputDataUri(): URI {
-		return this._outputDataUri;
-	}
+	readonly outputIndex: number;
+	private outputId: string | undefined;
 
 	constructor(
-		notebookRef: IReference<IResolvedNotebookEditorModel>,
-		outputDataUri: URI,
+		notebookUri: URI,
+		cellId: string | undefined,
+		cellIndex: number,
+		outputId: string | undefined,
+		outputIndex: number,
+		@INotebookEditorService private readonly notebookEditorService: INotebookEditorService,
+		@INotebookEditorModelResolverService private readonly notebookEditorModelResolverService: INotebookEditorModelResolverService,
 	) {
 		super();
-		this.notebookRef = notebookRef;
+		this._notebookUri = notebookUri;
 
-		this._notebookViewType = notebookRef.object.viewType;
-		this._notebookUri = notebookRef.object.resource;
-		this._outputDataUri = outputDataUri;
+		this.cellId = cellId;
+		this.cellIndex = cellIndex;
+
+		this.outputId = outputId;
+		this.outputIndex = outputIndex;
 	}
 
 	override get typeId(): string {
 		return NotebookOutputEditorInput.ID;
 	}
 
+	override async resolve(): Promise<ResolvedNotebookOutputEditorInputModel> {
+		if (!this._notebookRef) {
+			this._notebookRef = await this.notebookEditorModelResolverService.resolve(this._notebookUri);
+		}
+
+		const notebookEditor = this.notebookEditorService.retrieveExistingWidgetFromURI(this._notebookUri)?.value;
+		if (!notebookEditor) {
+			throw new Error('Notebook editor not found');
+		}
+
+		if (!notebookEditor.viewModel) {
+			// Wait for the viewModel to be attached before proceeding if it hasn't attached
+			await getEditorViewModelAttachedPromise(notebookEditor);
+		}
+
+		const cell = notebookEditor.cellAt(this.cellIndex);
+		if (!cell) {
+			throw new Error('Cell not found');
+		}
+		if (!this.cellId) {
+			this.cellId = cell.id;
+		}
+
+		const oId = this._notebookRef.object.notebook.cells.find(c => c.handle === cell.handle)?.outputs[this.outputIndex];
+		if (!oId) {
+			throw new Error('Output not found');
+		}
+		if (!this.outputId) {
+			this.outputId = oId.outputId;
+		}
+
+		return new ResolvedNotebookOutputEditorInputModel(
+			this._notebookRef,
+			this._notebookUri,
+			this.cellId,
+			this.outputId,
+		);
+	}
+
+	public getSerializedData(): { notebookUri: URI; cellIndex: number; outputIndex: number } | undefined {
+		// need to translate from ids -> current indexes
+		// ids aren't deterministic across reloads, so indexes are best option
+
+		const notebookEditor = this.notebookEditorService.retrieveExistingWidgetFromURI(this._notebookUri)?.value;
+		if (!notebookEditor) {
+			return;
+		}
+
+		const cellIndex = notebookEditor.viewModel?.viewCells.findIndex(c => c.id === this.cellId);
+		if (cellIndex === undefined || cellIndex === -1) {
+			return;
+		}
+
+		const outputIndex = notebookEditor.cellAt(cellIndex)?.outputsViewModels.findIndex(o => o.model.outputId === this.outputId);
+		if (outputIndex === undefined || outputIndex === -1) {
+			return;
+		}
+
+		return {
+			notebookUri: this._notebookUri,
+			cellIndex: cellIndex,
+			outputIndex: outputIndex,
+		};
+	}
+
+	override getName(): string {
+		return nls.localize('notebookOutputEditorInput', "Notebook Output Preview");
+	}
+
+	override get editorId(): string {
+		return 'notebookOutputEditor';
+	}
+
 	override get resource(): URI | undefined {
-		return undefined;
+		return;
+	}
+
+	override get capabilities() {
+		return EditorInputCapabilities.Readonly;
 	}
 
 	override dispose(): void {
-		this.notebookRef.dispose();
 		super.dispose();
 	}
+}
 
+function getEditorViewModelAttachedPromise(editor: NotebookEditorWidget) {
+	return new Promise<void>((resolve, reject) => {
+		Event.once(editor.onDidAttachViewModel)(() => editor.viewModel ? resolve() : reject());
+	});
 }

--- a/src/vs/workbench/contrib/notebook/browser/outputEditor/notebookOutputEditorInput.ts
+++ b/src/vs/workbench/contrib/notebook/browser/outputEditor/notebookOutputEditorInput.ts
@@ -1,0 +1,61 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IReference } from '../../../../../base/common/lifecycle.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { EditorInput } from '../../../../common/editor/editorInput.js';
+import { IResolvedNotebookEditorModel } from '../../common/notebookCommon.js';
+
+
+export class NotebookOutputEditorInput extends EditorInput {
+	static readonly ID: string = 'workbench.input.notebookOutputEditorInput';
+
+	private notebookRef: IReference<IResolvedNotebookEditorModel>;
+
+	getNotebookRef(): IReference<IResolvedNotebookEditorModel> {
+		return this.notebookRef;
+	}
+
+	private _notebookViewType: string;
+	get notebookViewType(): string {
+		return this._notebookViewType;
+	}
+
+	private _notebookUri: URI;
+	get notebookUri(): URI {
+		return this._notebookUri;
+	}
+
+	private _outputDataUri: URI; // has outputId, cellId
+	get outputDataUri(): URI {
+		return this._outputDataUri;
+	}
+
+	constructor(
+		notebookRef: IReference<IResolvedNotebookEditorModel>,
+		outputDataUri: URI,
+	) {
+		super();
+		this.notebookRef = notebookRef;
+
+		this._notebookViewType = notebookRef.object.viewType;
+		this._notebookUri = notebookRef.object.resource;
+		this._outputDataUri = outputDataUri;
+	}
+
+	override get typeId(): string {
+		return NotebookOutputEditorInput.ID;
+	}
+
+	override get resource(): URI | undefined {
+		return undefined;
+	}
+
+	override dispose(): void {
+		this.notebookRef.dispose();
+		super.dispose();
+	}
+
+}

--- a/src/vs/workbench/contrib/notebook/common/notebookCommon.ts
+++ b/src/vs/workbench/contrib/notebook/common/notebookCommon.ts
@@ -653,7 +653,6 @@ export namespace CellUri {
 			query: new URLSearchParams({
 				openIn: 'notebookOutputEditor',
 				notebook: notebook.toString(),
-				cellId: cellId,
 				cellIndex: String(cellIndex),
 				outputId: outputId,
 				outputIndex: String(outputIndex),
@@ -661,7 +660,7 @@ export namespace CellUri {
 		});
 	}
 
-	export function parseCellOutputUri(uri: URI): { notebook: URI; openIn: string; outputId?: string; cellFragment?: string; outputIndex?: number; cellHandle?: number; cellId?: string; cellIndex?: number } | undefined {
+	export function parseCellOutputUri(uri: URI): { notebook: URI; openIn: string; outputId?: string; cellFragment?: string; outputIndex?: number; cellHandle?: number; cellIndex?: number } | undefined {
 		return extractCellOutputDetails(uri);
 	}
 
@@ -1017,7 +1016,7 @@ export const NotebookSetting = {
 	stickyScrollMode: 'notebook.stickyScroll.mode',
 	undoRedoPerCell: 'notebook.undoRedoPerCell',
 	consolidatedOutputButton: 'notebook.consolidatedOutputButton',
-	openOutputInPreviewEditor: 'notebook.openOutputInPreviewEditor.enabled',
+	openOutputInPreviewEditor: 'notebook.output.openInPreviewEditor.enabled',
 	showFoldingControls: 'notebook.showFoldingControls',
 	dragAndDropEnabled: 'notebook.dragAndDropEnabled',
 	cellEditorOptionsCustomizations: 'notebook.editorOptionsCustomizations',

--- a/src/vs/workbench/contrib/notebook/common/notebookCommon.ts
+++ b/src/vs/workbench/contrib/notebook/common/notebookCommon.ts
@@ -42,6 +42,7 @@ export const NOTEBOOK_DIFF_EDITOR_ID = 'workbench.editor.notebookTextDiffEditor'
 export const NOTEBOOK_MULTI_DIFF_EDITOR_ID = 'workbench.editor.notebookMultiTextDiffEditor';
 export const INTERACTIVE_WINDOW_EDITOR_ID = 'workbench.editor.interactive';
 export const REPL_EDITOR_ID = 'workbench.editor.repl';
+export const NOTEBOOK_OUTPUT_EDITOR_ID = 'workbench.editor.notebookOutputEditor';
 
 export const EXECUTE_REPL_COMMAND_ID = 'replNotebook.input.execute';
 
@@ -646,7 +647,18 @@ export namespace CellUri {
 		});
 	}
 
-	export function parseCellOutputUri(uri: URI): { notebook: URI; openIn: string; outputId?: string; cellFragment?: string; outputIndex?: number; cellHandle?: number } | undefined {
+	export function generateOutputEditorCellOutputUriWithId(notebook: URI, outputId: string, cellId: string): URI {
+		return notebook.with({
+			scheme: Schemas.vscodeNotebookCellOutput,
+			query: new URLSearchParams({
+				openIn: 'notebookOutputEditor',
+				outputId: outputId,
+				cellId: cellId,
+			}).toString()
+		});
+	}
+
+	export function parseCellOutputUri(uri: URI): { notebook: URI; openIn: string; outputId?: string; cellFragment?: string; outputIndex?: number; cellHandle?: number; cellId?: string} | undefined {
 		return extractCellOutputDetails(uri);
 	}
 

--- a/src/vs/workbench/contrib/notebook/common/notebookCommon.ts
+++ b/src/vs/workbench/contrib/notebook/common/notebookCommon.ts
@@ -647,18 +647,21 @@ export namespace CellUri {
 		});
 	}
 
-	export function generateOutputEditorCellOutputUriWithId(notebook: URI, outputId: string, cellId: string): URI {
+	export function generateOutputEditorUri(notebook: URI, cellId: string, cellIndex: number, outputId: string, outputIndex: number): URI {
 		return notebook.with({
 			scheme: Schemas.vscodeNotebookCellOutput,
 			query: new URLSearchParams({
 				openIn: 'notebookOutputEditor',
-				outputId: outputId,
+				notebook: notebook.toString(),
 				cellId: cellId,
+				cellIndex: String(cellIndex),
+				outputId: outputId,
+				outputIndex: String(outputIndex),
 			}).toString()
 		});
 	}
 
-	export function parseCellOutputUri(uri: URI): { notebook: URI; openIn: string; outputId?: string; cellFragment?: string; outputIndex?: number; cellHandle?: number; cellId?: string} | undefined {
+	export function parseCellOutputUri(uri: URI): { notebook: URI; openIn: string; outputId?: string; cellFragment?: string; outputIndex?: number; cellHandle?: number; cellId?: string; cellIndex?: number } | undefined {
 		return extractCellOutputDetails(uri);
 	}
 

--- a/src/vs/workbench/contrib/notebook/common/notebookCommon.ts
+++ b/src/vs/workbench/contrib/notebook/common/notebookCommon.ts
@@ -1017,6 +1017,7 @@ export const NotebookSetting = {
 	stickyScrollMode: 'notebook.stickyScroll.mode',
 	undoRedoPerCell: 'notebook.undoRedoPerCell',
 	consolidatedOutputButton: 'notebook.consolidatedOutputButton',
+	openOutputInPreviewEditor: 'notebook.openOutputInPreviewEditor.enabled',
 	showFoldingControls: 'notebook.showFoldingControls',
 	dragAndDropEnabled: 'notebook.dragAndDropEnabled',
 	cellEditorOptionsCustomizations: 'notebook.editorOptionsCustomizations',

--- a/src/vs/workbench/services/notebook/common/notebookDocumentService.ts
+++ b/src/vs/workbench/services/notebook/common/notebookDocumentService.ts
@@ -66,7 +66,7 @@ export function generateMetadataUri(notebook: URI): URI {
 	return notebook.with({ scheme: Schemas.vscodeNotebookMetadata, fragment });
 }
 
-export function extractCellOutputDetails(uri: URI): { notebook: URI; openIn: string; outputId?: string; cellFragment?: string; outputIndex?: number; cellHandle?: number; cellId?: string; cellIndex?: number } | undefined {
+export function extractCellOutputDetails(uri: URI): { notebook: URI; openIn: string; outputId?: string; cellFragment?: string; outputIndex?: number; cellHandle?: number; cellIndex?: number } | undefined {
 	if (uri.scheme !== Schemas.vscodeNotebookCellOutput) {
 		return;
 	}
@@ -84,7 +84,6 @@ export function extractCellOutputDetails(uri: URI): { notebook: URI; openIn: str
 		fragment: null,
 		query: null,
 	});
-	const cellid = params.get('cellId') || undefined;
 	const cellIndex = params.get('cellIndex') ? parseInt(params.get('cellIndex') || '', 10) : undefined;
 
 	return {
@@ -94,7 +93,6 @@ export function extractCellOutputDetails(uri: URI): { notebook: URI; openIn: str
 		outputIndex: outputIndex,
 		cellHandle: parsedCell?.handle,
 		cellFragment: uri.fragment,
-		cellId: cellid,
 		cellIndex: cellIndex,
 	};
 }

--- a/src/vs/workbench/services/notebook/common/notebookDocumentService.ts
+++ b/src/vs/workbench/services/notebook/common/notebookDocumentService.ts
@@ -66,7 +66,7 @@ export function generateMetadataUri(notebook: URI): URI {
 	return notebook.with({ scheme: Schemas.vscodeNotebookMetadata, fragment });
 }
 
-export function extractCellOutputDetails(uri: URI): { notebook: URI; openIn: string; outputId?: string; cellFragment?: string; outputIndex?: number; cellHandle?: number } | undefined {
+export function extractCellOutputDetails(uri: URI): { notebook: URI; openIn: string; outputId?: string; cellFragment?: string; outputIndex?: number; cellHandle?: number; cellId?: string } | undefined {
 	if (uri.scheme !== Schemas.vscodeNotebookCellOutput) {
 		return;
 	}
@@ -84,6 +84,7 @@ export function extractCellOutputDetails(uri: URI): { notebook: URI; openIn: str
 		fragment: null,
 		query: null,
 	});
+	const cellid = params.get('cellId') || undefined;
 
 	return {
 		notebook: notebookUri,
@@ -92,6 +93,7 @@ export function extractCellOutputDetails(uri: URI): { notebook: URI; openIn: str
 		outputIndex: outputIndex,
 		cellHandle: parsedCell?.handle,
 		cellFragment: uri.fragment,
+		cellId: cellid,
 	};
 }
 

--- a/src/vs/workbench/services/notebook/common/notebookDocumentService.ts
+++ b/src/vs/workbench/services/notebook/common/notebookDocumentService.ts
@@ -66,7 +66,7 @@ export function generateMetadataUri(notebook: URI): URI {
 	return notebook.with({ scheme: Schemas.vscodeNotebookMetadata, fragment });
 }
 
-export function extractCellOutputDetails(uri: URI): { notebook: URI; openIn: string; outputId?: string; cellFragment?: string; outputIndex?: number; cellHandle?: number; cellId?: string } | undefined {
+export function extractCellOutputDetails(uri: URI): { notebook: URI; openIn: string; outputId?: string; cellFragment?: string; outputIndex?: number; cellHandle?: number; cellId?: string; cellIndex?: number } | undefined {
 	if (uri.scheme !== Schemas.vscodeNotebookCellOutput) {
 		return;
 	}
@@ -85,6 +85,7 @@ export function extractCellOutputDetails(uri: URI): { notebook: URI; openIn: str
 		query: null,
 	});
 	const cellid = params.get('cellId') || undefined;
+	const cellIndex = params.get('cellIndex') ? parseInt(params.get('cellIndex') || '', 10) : undefined;
 
 	return {
 		notebook: notebookUri,
@@ -94,6 +95,7 @@ export function extractCellOutputDetails(uri: URI): { notebook: URI; openIn: str
 		cellHandle: parsedCell?.handle,
 		cellFragment: uri.fragment,
 		cellId: cellid,
+		cellIndex: cellIndex,
 	};
 }
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Re: #143244

PR provides initial support for opening outputs in a separate editor. User needs to enable `notebook.openOutputInPreviewEditor.enabled` and then the action can be reached from within the notebook cell output toolbar. More polish is planned