### PR TITLE
fix: handle cancellation errors inside edit session identity provider

### DIFF
--- a/extensions/git/src/editSessionIdentityProvider.ts
+++ b/extensions/git/src/editSessionIdentityProvider.ts
@@ -16,7 +16,13 @@ export class GitEditSessionIdentityProvider implements vscode.EditSessionIdentit
 		this.providerRegistration = vscode.Disposable.from(
 			vscode.workspace.registerEditSessionIdentityProvider('file', this),
 			vscode.workspace.onWillCreateEditSessionIdentity((e) => {
-				e.waitUntil(this._onWillCreateEditSessionIdentity(e.workspaceFolder));
+				e.waitUntil(
+					this._onWillCreateEditSessionIdentity(e.workspaceFolder).catch(err => {
+						if (err instanceof vscode.CancellationError) {
+							throw err;
+						}
+					})
+				);
 			})
 		);
 	}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Fix #247449

Fix ensures that a cancellation error thrown from `this._onWillCreateEditSessionIdentity` are bubbled up.