### PR TITLE
[prompts]: rename 'include' metadata into 'applyTo'

### DIFF
--- a/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/basePromptParser.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/basePromptParser.ts
@@ -542,7 +542,7 @@ export class BasePromptParser<TContentsProvider extends IPromptContentsProvider>
 			return {};
 		}
 
-		const { tools, mode, description, include } = metadata;
+		const { tools, mode, description, applyTo } = metadata;
 
 		// compute resulting mode based on presence
 		// of `tools` metadata in the prompt header
@@ -554,7 +554,7 @@ export class BasePromptParser<TContentsProvider extends IPromptContentsProvider>
 			mode: resultingMode,
 			description: description?.text,
 			tools: tools?.toolNames,
-			include: include?.text,
+			applyTo: applyTo?.text,
 		};
 	}
 

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/promptHeader/header.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/promptHeader/header.ts
@@ -5,7 +5,7 @@
 
 import { ChatMode } from '../../../constants.js';
 import { localize } from '../../../../../../../nls.js';
-import { PromptIncludeMetadata } from './metadata/include.js';
+import { PromptApplyToMetadata } from './metadata/applyTo.js';
 import { assert } from '../../../../../../../base/common/assert.js';
 import { assertDefined } from '../../../../../../../base/common/types.js';
 import { Disposable } from '../../../../../../../base/common/lifecycle.js';
@@ -37,9 +37,9 @@ export interface IHeaderMetadata {
 	mode?: PromptModeMetadata;
 
 	/**
-	 * Chat include metadata in the prompt header.
+	 * Chat 'applyTo' metadata in the prompt header.
 	 */
-	include?: PromptIncludeMetadata;
+	applyTo?: PromptApplyToMetadata;
 }
 
 /**
@@ -186,14 +186,14 @@ export class PromptHeader extends Disposable {
 			return this.validateToolsAndModeCompatibility();
 		}
 
-		// if the record might be a "include" metadata
+		// if the record might be a "applyTo" metadata
 		// add it to the list of parsed metadata records
-		if (PromptIncludeMetadata.isIncludeRecord(token)) {
-			const includeMetadata = new PromptIncludeMetadata(token, this.languageId);
-			const { diagnostics } = includeMetadata;
+		if (PromptApplyToMetadata.isApplyToRecord(token)) {
+			const applyToMetadata = new PromptApplyToMetadata(token, this.languageId);
+			const { diagnostics } = applyToMetadata;
 
 			this.issues.push(...diagnostics);
-			this.meta.include = includeMetadata;
+			this.meta.applyTo = applyToMetadata;
 			this.recordNames.add(recordName);
 
 			return;

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/promptHeader/metadata/applyTo.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/promptHeader/metadata/applyTo.ts
@@ -13,12 +13,12 @@ import { FrontMatterRecord, FrontMatterToken } from '../../../../../../../../edi
 /**
  * Name of the metadata record in the prompt header.
  */
-const RECORD_NAME = 'include';
+const RECORD_NAME = 'applyTo';
 
 /**
- * Prompt `include` metadata record inside the prompt header.
+ * Prompt `applyTo` metadata record inside the prompt header.
  */
-export class PromptIncludeMetadata extends PromptStringMetadata {
+export class PromptApplyToMetadata extends PromptStringMetadata {
 	constructor(
 		recordToken: FrontMatterRecord,
 		languageId: string,
@@ -41,7 +41,7 @@ export class PromptIncludeMetadata extends PromptStringMetadata {
 			return result;
 		}
 
-		// the include metadata makes sense only for 'instruction' prompts
+		// the applyTo metadata makes sense only for 'instruction' prompts
 		if (this.languageId !== INSTRUCTIONS_LANGUAGE_ID) {
 			result.push(
 				new PromptMetadataError(
@@ -66,7 +66,7 @@ export class PromptIncludeMetadata extends PromptStringMetadata {
 				new PromptMetadataWarning(
 					this.valueToken.range,
 					localize(
-						'prompt.header.metadata.include.diagnostics.non-valid-glob',
+						'prompt.header.metadata.applyTo.diagnostics.non-valid-glob',
 						"Invalid glob pattern '{0}'.",
 						cleanText,
 					),
@@ -100,9 +100,9 @@ export class PromptIncludeMetadata extends PromptStringMetadata {
 
 	/**
 	 * Check if a provided front matter token is a metadata record
-	 * with name equal to `include`.
+	 * with name equal to `applyTo`.
 	 */
-	public static isIncludeRecord(
+	public static isApplyToRecord(
 		token: FrontMatterToken,
 	): boolean {
 		if ((token instanceof FrontMatterRecord) === false) {

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/types.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/types.ts
@@ -69,9 +69,9 @@ export interface IPromptMetadata {
 	mode?: ChatMode;
 
 	/**
-	 * Chat 'include' metadata in the prompt header.
+	 * Chat 'applyTo' metadata in the prompt header.
 	 */
-	include?: string;
+	applyTo?: string;
 }
 
 /**

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsService.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsService.ts
@@ -184,15 +184,15 @@ export class PromptsService extends Disposable implements IPromptsService {
 
 		for (const instruction of instructions.flatMap(flatten)) {
 			const { metadata, uri } = instruction;
-			const { include } = metadata;
+			const { applyTo } = metadata;
 
-			if (include === undefined) {
+			if (applyTo === undefined) {
 				continue;
 			}
 
 			// if glob pattern is one of the special wildcard values,
 			// add the instructions file event if no files are attached
-			if ((include === '**') || (include === '**/*')) {
+			if ((applyTo === '**') || (applyTo === '**/*')) {
 				result.push(uri);
 
 				continue;
@@ -201,7 +201,7 @@ export class PromptsService extends Disposable implements IPromptsService {
 			// match each attached file with each glob pattern and
 			// add the instructions file its rule matches the file
 			for (const file of files) {
-				if (match(include, file.fsPath)) {
+				if (match(applyTo, file.fsPath)) {
 					result.push(uri);
 
 					continue;

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/service/types.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/service/types.ts
@@ -158,7 +158,7 @@ export interface IPromptsService extends IDisposable {
 
 	/**
 	 * Find all instruction files which have a glob pattern in their
-	 * 'include' metadata record that match the provided list of files.
+	 * 'applyTo' metadata record that match the provided list of files.
 	 */
 	findInstructionFilesFor(
 		fileUris: readonly URI[],

--- a/src/vs/workbench/contrib/chat/test/common/promptSyntax/parsers/textModelPromptParser.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/promptSyntax/parsers/textModelPromptParser.test.ts
@@ -330,7 +330,7 @@ suite('TextModelPromptParser', () => {
 					'Prompt header must be defined.',
 				);
 
-				const { tools, mode, description, include } = metadata;
+				const { tools, mode, description, applyTo: include } = metadata;
 				assert.deepStrictEqual(
 					tools,
 					['tool_name1', 'tool_name2'],
@@ -396,7 +396,7 @@ suite('TextModelPromptParser', () => {
 					'Prompt header must be defined.',
 				);
 
-				const { tools, mode, description, include } = metadata;
+				const { tools, mode, description, applyTo: include } = metadata;
 				assert.deepStrictEqual(
 					tools,
 					['tool_name1', 'tool_name2'],
@@ -535,7 +535,7 @@ suite('TextModelPromptParser', () => {
 							'Prompt header must be defined.',
 						);
 
-						const { include, mode } = metadata;
+						const { applyTo: include, mode } = metadata;
 						assert.strictEqual(
 							mode,
 							ChatMode.Ask,
@@ -576,7 +576,7 @@ suite('TextModelPromptParser', () => {
 							'Prompt header must be defined.',
 						);
 
-						const { include, mode } = metadata;
+						const { applyTo: include, mode } = metadata;
 						assert.strictEqual(
 							mode,
 							ChatMode.Edit,
@@ -615,7 +615,7 @@ suite('TextModelPromptParser', () => {
 					'Prompt header must be defined.',
 				);
 
-				const { include, mode } = metadata;
+				const { applyTo: include, mode } = metadata;
 				assert.strictEqual(
 					mode,
 					ChatMode.Agent,

--- a/src/vs/workbench/contrib/chat/test/common/promptSyntax/parsers/textModelPromptParser.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/promptSyntax/parsers/textModelPromptParser.test.ts
@@ -302,7 +302,7 @@ suite('TextModelPromptParser', () => {
 					/* 05 */"	tools: [ 'tool_name3', \"tool_name4\" ]", /* duplicate `tools` record is ignored */
 					/* 06 */"	tools: 'tool_name5'", /* duplicate `tools` record with invalid value is ignored */
 					/* 07 */"	mode: 'agent'",
-					/* 07 */"	include: 'frontend/**/*spec.ts'",
+					/* 07 */"	applyTo: 'frontend/**/*spec.ts'",
 					/* 08 */"---",
 					/* 09 */"The cactus on my desk has a thriving Instagram account.",
 					/* 10 */"Midnight snacks are the secret to eternal [text](./foo-bar-baz/another-file.ts) happiness.",
@@ -330,7 +330,7 @@ suite('TextModelPromptParser', () => {
 					'Prompt header must be defined.',
 				);
 
-				const { tools, mode, description, applyTo: include } = metadata;
+				const { tools, mode, description, applyTo } = metadata;
 				assert.deepStrictEqual(
 					tools,
 					['tool_name1', 'tool_name2'],
@@ -350,9 +350,9 @@ suite('TextModelPromptParser', () => {
 				);
 
 				assert.strictEqual(
-					include,
+					applyTo,
 					undefined,
-					`Prompt header must have no 'include' metadata.`,
+					`Prompt header must have no 'applyTo' metadata.`,
 				);
 			});
 
@@ -367,7 +367,7 @@ suite('TextModelPromptParser', () => {
 					/* 05 */"	tools: [ 'tool_name3', \"tool_name4\" ]", /* duplicate `tools` record is ignored */
 					/* 06 */"	tools: 'tool_name5'", /* duplicate `tools` record with invalid value is ignored */
 					/* 07 */"	mode: 'agent'",
-					/* 07 */"	include: 'frontend/**/*spec.ts'",
+					/* 07 */"	applyTo: 'frontend/**/*spec.ts'",
 					/* 08 */"---",
 					/* 09 */"The cactus on my desk has a thriving Instagram account.",
 					/* 10 */"Midnight snacks are the secret to eternal [text](./foo-bar-baz/another-file.ts) happiness.",
@@ -396,7 +396,7 @@ suite('TextModelPromptParser', () => {
 					'Prompt header must be defined.',
 				);
 
-				const { tools, mode, description, applyTo: include } = metadata;
+				const { tools, mode, description, applyTo } = metadata;
 				assert.deepStrictEqual(
 					tools,
 					['tool_name1', 'tool_name2'],
@@ -416,9 +416,9 @@ suite('TextModelPromptParser', () => {
 				);
 
 				assert.strictEqual(
-					include,
+					applyTo,
 					'frontend/**/*spec.ts',
-					`Prompt header must have no 'include' metadata.`,
+					`Prompt header must have no 'applyTo' metadata.`,
 				);
 			});
 		});
@@ -512,14 +512,14 @@ suite('TextModelPromptParser', () => {
 				]);
 			});
 
-			suite('• include metadata', () => {
+			suite('• applyTo metadata', () => {
 				suite('• language', () => {
 					test('• prompt', async () => {
 						const test = createTest(
 							createURI('/absolute/folder/and/a/my.prompt.md'),
 							[
 					/* 01 */"---",
-					/* 02 */"include: '**/*'",
+					/* 02 */"applyTo: '**/*'",
 					/* 03 */"mode: \"ask\"",
 					/* 04 */"---",
 					/* 05 */"The cactus on my desk has a thriving Instagram account.",
@@ -535,7 +535,7 @@ suite('TextModelPromptParser', () => {
 							'Prompt header must be defined.',
 						);
 
-						const { applyTo: include, mode } = metadata;
+						const { applyTo, mode } = metadata;
 						assert.strictEqual(
 							mode,
 							ChatMode.Ask,
@@ -543,14 +543,14 @@ suite('TextModelPromptParser', () => {
 						);
 
 						assert(
-							include === undefined,
-							'Include metadata must not be defined.',
+							applyTo === undefined,
+							'ApplyTo metadata must not be defined.',
 						);
 
 						await test.validateHeaderDiagnostics([
 							new ExpectedDiagnosticError(
 								new Range(2, 1, 2, 1 + 15),
-								'The \'include\' metadata record is only valid in instruction files.',
+								'The \'applyTo\' metadata record is only valid in instruction files.',
 							),
 						]);
 					});
@@ -560,7 +560,7 @@ suite('TextModelPromptParser', () => {
 							createURI('/absolute/folder/and/a/my.prompt.md'),
 							[
 					/* 01 */"---",
-					/* 02 */"include: '**/*'",
+					/* 02 */"applyTo: '**/*'",
 					/* 03 */"mode: \"edit\"",
 					/* 04 */"---",
 					/* 05 */"The cactus on my desk has a thriving Instagram account.",
@@ -576,7 +576,7 @@ suite('TextModelPromptParser', () => {
 							'Prompt header must be defined.',
 						);
 
-						const { applyTo: include, mode } = metadata;
+						const { applyTo, mode } = metadata;
 						assert.strictEqual(
 							mode,
 							ChatMode.Edit,
@@ -584,9 +584,9 @@ suite('TextModelPromptParser', () => {
 						);
 
 						assert.strictEqual(
-							include,
+							applyTo,
 							'**/*',
-							'Include metadata must have correct value.',
+							'ApplyTo metadata must have correct value.',
 						);
 
 						await test.validateHeaderDiagnostics([]);
@@ -600,7 +600,7 @@ suite('TextModelPromptParser', () => {
 					[
 					/* 01 */"---",
 					/* 02 */"mode: \"agent\"",
-					/* 03 */"include: ''",
+					/* 03 */"applyTo: ''",
 					/* 04 */"---",
 					/* 05 */"The cactus on my desk has a thriving Instagram account.",
 					],
@@ -615,7 +615,7 @@ suite('TextModelPromptParser', () => {
 					'Prompt header must be defined.',
 				);
 
-				const { applyTo: include, mode } = metadata;
+				const { applyTo, mode } = metadata;
 				assert.strictEqual(
 					mode,
 					ChatMode.Agent,
@@ -623,9 +623,9 @@ suite('TextModelPromptParser', () => {
 				);
 
 				assert.strictEqual(
-					include,
+					applyTo,
 					undefined,
-					'Include metadata must not be defined.',
+					'ApplyTo metadata must not be defined.',
 				);
 
 				await test.validateHeaderDiagnostics([

--- a/src/vs/workbench/contrib/chat/test/common/promptSyntax/promptFileReference.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/promptSyntax/promptFileReference.test.ts
@@ -932,7 +932,7 @@ suite('PromptFileReference (Unix)', function () {
 			);
 		});
 
-		suite('• include', () => {
+		suite('• applyTo', () => {
 			test('• prompt language', async function () {
 				if (isWindows) {
 					this.skip();
@@ -961,7 +961,7 @@ suite('PromptFileReference (Unix)', function () {
 								name: 'file2.prompt.md',
 								contents: [
 									'---',
-									'include: \'**/*\'',
+									'applyTo: \'**/*\'',
 									'tools: [ false, \'my-tool12\' , ]',
 									'description: \'Description of my prompt.\'',
 									'---',
@@ -1030,7 +1030,7 @@ suite('PromptFileReference (Unix)', function () {
 				const rootReference = await test.run();
 
 				const { metadata, allToolsMetadata } = rootReference;
-				const { tools, mode, description, applyTo: include } = metadata;
+				const { tools, mode, description, applyTo } = metadata;
 
 				assert.deepStrictEqual(
 					tools,
@@ -1062,9 +1062,9 @@ suite('PromptFileReference (Unix)', function () {
 				);
 
 				assert.strictEqual(
-					include,
+					applyTo,
 					undefined,
-					'Must have no \'include\' metadata.',
+					'Must have no \'applyTo\' metadata.',
 				);
 			});
 
@@ -1097,7 +1097,7 @@ suite('PromptFileReference (Unix)', function () {
 								name: 'file2.instructions.md',
 								contents: [
 									'---',
-									'include: \'**/*\'',
+									'applyTo: \'**/*\'',
 									'tools: [ false, \'my-tool12\' , ]',
 									'description: \'Description of my prompt.\'',
 									'---',
@@ -1166,7 +1166,7 @@ suite('PromptFileReference (Unix)', function () {
 				const rootReference = await test.run();
 
 				const { metadata, allToolsMetadata } = rootReference;
-				const { tools, mode, description, applyTo: include } = metadata;
+				const { tools, mode, description, applyTo } = metadata;
 
 				assert.deepStrictEqual(
 					tools,
@@ -1198,9 +1198,9 @@ suite('PromptFileReference (Unix)', function () {
 				);
 
 				assert.strictEqual(
-					include,
+					applyTo,
 					'**/*',
-					'Must have no \'include\' metadata.',
+					'Must have no \'applyTo\' metadata.',
 				);
 			});
 		});

--- a/src/vs/workbench/contrib/chat/test/common/promptSyntax/promptFileReference.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/promptSyntax/promptFileReference.test.ts
@@ -1030,7 +1030,7 @@ suite('PromptFileReference (Unix)', function () {
 				const rootReference = await test.run();
 
 				const { metadata, allToolsMetadata } = rootReference;
-				const { tools, mode, description, include } = metadata;
+				const { tools, mode, description, applyTo: include } = metadata;
 
 				assert.deepStrictEqual(
 					tools,
@@ -1166,7 +1166,7 @@ suite('PromptFileReference (Unix)', function () {
 				const rootReference = await test.run();
 
 				const { metadata, allToolsMetadata } = rootReference;
-				const { tools, mode, description, include } = metadata;
+				const { tools, mode, description, applyTo: include } = metadata;
 
 				assert.deepStrictEqual(
 					tools,

--- a/src/vs/workbench/contrib/chat/test/common/promptSyntax/service/promptsService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/promptSyntax/service/promptsService.test.ts
@@ -1801,7 +1801,7 @@ suite('PromptsService', () => {
 														'---',
 														'description: "Another file description."',
 														'tools: [\'my-tool3\', false, "my-tool2" ]',
-														'include: "**/*.tsx"',
+														'applyTo: "**/*.tsx"',
 														'---',
 														`[](${rootFolder}/folder1/some-other-folder)`,
 														'another-file.instructions.md contents\t [#file:file.txt](../file.txt)',
@@ -1831,14 +1831,14 @@ suite('PromptsService', () => {
 						description: 'Root prompt description.',
 						tools: ['my-tool1'],
 						mode: 'agent',
-						include: undefined,
+						applyTo: undefined,
 					},
 					children: [
 						{
 							uri: URI.joinPath(rootFolderUri, 'folder1/file3.prompt.md'),
 							metadata: {
 								description: undefined,
-								include: undefined,
+								applyTo: undefined,
 								tools: ['my-tool1'],
 								mode: 'agent',
 							},
@@ -1849,7 +1849,7 @@ suite('PromptsService', () => {
 										description: 'Another file description.',
 										tools: ['my-tool3', 'my-tool2'],
 										mode: 'agent',
-										include: '**/*.tsx',
+										applyTo: '**/*.tsx',
 									},
 									children: undefined,
 								},
@@ -1860,7 +1860,7 @@ suite('PromptsService', () => {
 							metadata: {
 								tools: ['my-tool1', 'my-tool2'],
 								description: 'File 4 splendid description.',
-								include: undefined,
+								applyTo: undefined,
 								mode: 'agent',
 							},
 							children: undefined,
@@ -1941,7 +1941,7 @@ suite('PromptsService', () => {
 									contents: [
 										'---',
 										'description: \'Instructions file 1.\'',
-										'include: "**/*.tsx"',
+										'applyTo: "**/*.tsx"',
 										'---',
 										'Some instructions 1 contents.',
 									],
@@ -1951,7 +1951,7 @@ suite('PromptsService', () => {
 									contents: [
 										'---',
 										'description: \'Instructions file 2.\'',
-										'include: "**/folder1/*.tsx"',
+										'applyTo: "**/folder1/*.tsx"',
 										'---',
 										'Some instructions 2 contents.',
 									],
@@ -1961,7 +1961,7 @@ suite('PromptsService', () => {
 									contents: [
 										'---',
 										'description: \'Instructions file 3.\'',
-										'include: "**/folder2/*.tsx"',
+										'applyTo: "**/folder2/*.tsx"',
 										'---',
 										'Some instructions 3 contents.',
 									],
@@ -1971,7 +1971,7 @@ suite('PromptsService', () => {
 									contents: [
 										'---',
 										'description: \'Instructions file 4.\'',
-										'include: "src/build/*.tsx"',
+										'applyTo: "src/build/*.tsx"',
 										'---',
 										'Some instructions 4 contents.',
 									],
@@ -2009,7 +2009,7 @@ suite('PromptsService', () => {
 							contents: [
 								'---',
 								'description: \'Instructions file 10.\'',
-								'include: "**/folder1/*.tsx"',
+								'applyTo: "**/folder1/*.tsx"',
 								'---',
 								'Some instructions 10 contents.',
 							],
@@ -2019,7 +2019,7 @@ suite('PromptsService', () => {
 							contents: [
 								'---',
 								'description: \'Instructions file 11.\'',
-								'include: "**/folder1/*.py"',
+								'applyTo: "**/folder1/*.py"',
 								'---',
 								'Some instructions 11 contents.',
 							],


### PR DESCRIPTION
Renames 'include' metadata into 'applyTo'.

Part of https://github.com/microsoft/vscode-copilot/issues/15596.

> Fun fact - the old and the new names have the same character count, soo.. 🤗 
> 👉 <img width="122" alt="image" src="https://github.com/user-attachments/assets/d2efd373-fffc-4b3d-9712-905097e5110e" /> 👈 
