### PR TITLE
ChatRequest.tools should only include tools that are in the tool picker

### DIFF
--- a/src/vs/workbench/api/common/extHostChatAgents2.ts
+++ b/src/vs/workbench/api/common/extHostChatAgents2.ts
@@ -567,7 +567,9 @@ export class ExtHostChatAgents2 extends Disposable implements ExtHostChatAgentsS
 		}
 		const result = new Map<string, boolean>();
 		for (const tool of this._tools.getTools(extension)) {
-			result.set(tool.name, request.userSelectedTools2[tool.name] ?? false);
+			if (typeof request.userSelectedTools2[tool.name] === 'boolean') {
+				result.set(tool.name, request.userSelectedTools2[tool.name]);
+			}
 		}
 		return result;
 	}

--- a/src/vs/workbench/contrib/chat/browser/chatSelectedTools.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSelectedTools.ts
@@ -142,7 +142,9 @@ export class ChatSelectedTools extends Disposable {
 		const result = new Map<IToolData, boolean>();
 		const enabledTools = new Set(this.tools.get().map(t => t.id));
 		for (const tool of this._allTools.get()) {
-			result.set(tool, enabledTools.has(tool.id));
+			if (tool.supportsToolPicker) {
+				result.set(tool, enabledTools.has(tool.id));
+			}
 		}
 		return result;
 	}


### PR DESCRIPTION
Otherwise it includes tools that aren't supposed to be enabled for agent mode

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
