### PR TITLE
#188711 - Walkthrough Focus-Visible Outline

### DIFF
--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/media/gettingStarted.css
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/media/gettingStarted.css
@@ -272,7 +272,7 @@
 	font-size: 13px;
 	box-sizing: border-box;
 	line-height: normal;
-	margin: 8px 8px 8px 0;
+	margin: 8px 8px 8px 1px;
 	padding: 3px 6px 6px;
 	text-align: left;
 }
@@ -694,7 +694,7 @@
 
 .monaco-workbench .part.editor > .content .gettingStartedContainer button:focus-visible {
 	outline: 1px solid var(--vscode-focusBorder);
-	outline-offset: -1px;
+	outline-offset: 0;
 }
 
 .monaco-workbench .part.editor > .content .gettingStartedContainer .prev-button.button-link {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
Addresses: https://github.com/microsoft/vscode/issues/188711

The focus-visible outline on Walkthrough buttons was being cut off due to the absolute positioning of the progress bar. This PR resolves the issue, ensuring that buttons without progress bars remain unaffected.


Each screenshot is of the keyboard focus on a default theme provided by VS Code:


Default Light Modern:
![image](https://github.com/user-attachments/assets/4ee49d11-e717-4531-9d73-e083a445a8ad)

Default Dark Modern:
![image](https://github.com/user-attachments/assets/79bc48bc-4c12-4f8a-86a6-94fc3afe7c7e)

Default High Contrast:
![image](https://github.com/user-attachments/assets/293e60a2-9af2-452f-b212-d9d35afea4b2)




Note: A margin already exists that attempts to provide room for the focus-visible border of all buttons under the `gettingStartedContainer` div [here](https://github.com/microsoft/vscode/blob/2b9486161abaca59b5132ce3c59544f3cc7000f6/src/vs/workbench/contrib/welcomeGettingStarted/browser/media/gettingStarted.css#L681). However, this CSS does not take precedence over other selectors using the `getting-started-category` class. Not sure if there is a cleanup opportunity there, but wanted to call it out since it influenced my changes.

