### PR TITLE
listeners for notebook replace input element

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/contrib/find/notebookFindReplaceWidget.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/find/notebookFindReplaceWidget.ts
@@ -427,18 +427,13 @@ export abstract class SimpleFindReplaceWidget extends Widget {
 			}
 		));
 
-		// Find/Replace History with update delayer
+		// Find History with update delayer
 		this._updateFindHistoryDelayer = new Delayer<void>(500);
-		this._updateReplaceHistoryDelayer = new Delayer<void>(500);
 
 		this.oninput(this._findInput.domNode, (e) => {
 			this.foundMatch = this.onInputChanged();
 			this.updateButtons(this.foundMatch);
 			this._delayedUpdateFindHistory();
-		});
-
-		this.oninput(this._replaceInput.domNode, (e) => {
-			this._delayedUpdateReplaceHistory();
 		});
 
 		this._register(this._findInput.inputBox.onDidChange(() => {
@@ -590,6 +585,13 @@ export abstract class SimpleFindReplaceWidget extends Widget {
 		this._replaceInputFocusTracker = this._register(dom.trackFocus(this._replaceInput.domNode));
 		this._register(this._replaceInputFocusTracker.onDidFocus(this.onReplaceInputFocusTrackerFocus.bind(this)));
 		this._register(this._replaceInputFocusTracker.onDidBlur(this.onReplaceInputFocusTrackerBlur.bind(this)));
+
+		// Replace History with update delayer
+		this._updateReplaceHistoryDelayer = new Delayer<void>(500);
+
+		this.oninput(this._replaceInput.domNode, (e) => {
+			this._delayedUpdateReplaceHistory();
+		});
 
 		this._register(this._replaceInput.inputBox.onDidChange(() => {
 			this._state.change({ replaceString: this._replaceInput.getValue() }, true);

--- a/src/vs/workbench/contrib/notebook/browser/contrib/find/notebookFindReplaceWidget.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/find/notebookFindReplaceWidget.ts
@@ -292,7 +292,7 @@ export abstract class SimpleFindReplaceWidget extends Widget {
 	private readonly _innerFindDomNode: HTMLElement;
 	private readonly _focusTracker: dom.IFocusTracker;
 	private readonly _findInputFocusTracker: dom.IFocusTracker;
-	private readonly _updateHistoryDelayer: Delayer<void>;
+	private readonly _updateFindHistoryDelayer: Delayer<void>;
 	protected readonly _matchesCount!: HTMLElement;
 	private readonly prevBtn: SimpleButton;
 	private readonly nextBtn: SimpleButton;
@@ -301,6 +301,7 @@ export abstract class SimpleFindReplaceWidget extends Widget {
 	private readonly _innerReplaceDomNode!: HTMLElement;
 	private _toggleReplaceBtn!: SimpleButton;
 	private readonly _replaceInputFocusTracker!: dom.IFocusTracker;
+	private readonly _updateReplaceHistoryDelayer: Delayer<void>;
 	protected _replaceBtn!: SimpleButton;
 	protected _replaceAllBtn!: SimpleButton;
 
@@ -426,13 +427,18 @@ export abstract class SimpleFindReplaceWidget extends Widget {
 			}
 		));
 
-		// Find History with update delayer
-		this._updateHistoryDelayer = new Delayer<void>(500);
+		// Find/Replace History with update delayer
+		this._updateFindHistoryDelayer = new Delayer<void>(500);
+		this._updateReplaceHistoryDelayer = new Delayer<void>(500);
 
 		this.oninput(this._findInput.domNode, (e) => {
 			this.foundMatch = this.onInputChanged();
 			this.updateButtons(this.foundMatch);
-			this._delayedUpdateHistory();
+			this._delayedUpdateFindHistory();
+		});
+
+		this.oninput(this._replaceInput.domNode, (e) => {
+			this._delayedUpdateReplaceHistory();
 		});
 
 		this._register(this._findInput.inputBox.onDidChange(() => {
@@ -875,12 +881,20 @@ export abstract class SimpleFindReplaceWidget extends Widget {
 		}
 	}
 
-	protected _delayedUpdateHistory() {
-		this._updateHistoryDelayer.trigger(this._updateHistory.bind(this));
+	protected _delayedUpdateFindHistory() {
+		this._updateFindHistoryDelayer.trigger(this._updateFindHistory.bind(this));
 	}
 
-	protected _updateHistory() {
+	protected _updateFindHistory() {
 		this._findInput.inputBox.addToHistory();
+	}
+
+	protected _delayedUpdateReplaceHistory() {
+		this._updateReplaceHistoryDelayer.trigger(this._updateReplaceHistory.bind(this));
+	}
+
+	protected _updateReplaceHistory() {
+		this._replaceInput.inputBox.addToHistory();
 	}
 
 	protected _getRegexValue(): boolean {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Fixes: #247635
Unblocks: #247459

An oversight during initial implementation. Made the assumption that there was already a local history for the replace input box, allowing you to navigate through history. There never was, so any time you typed in the replace box, it would never get added to the history set, even the local set that wasn't persistent. 

Missed it in the initial test because there was history always coming from the standard editor find widget once the storage was set up which was always navigable. Had to set both settings to never which would effectively flush the storage, and reveal the issue in notebooks. 

Anyways this just adds the listeners.



