### PR TITLE
Fix Settings search not working in Chinese

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/preferencesSearch.ts
+++ b/src/vs/workbench/contrib/preferences/browser/preferencesSearch.ts
@@ -170,7 +170,7 @@ export class SettingMatches {
 	}
 
 	private _toAlphaNumeric(s: string): string {
-		return s.replace(/[^A-Za-z0-9]+/g, '');
+		return s.replace(/[^\p{L}\p{N}]+/gu, '');
 	}
 
 	private _doFindMatchesInSetting(searchString: string, setting: ISetting): IRange[] {


### PR DESCRIPTION
Fixes #246269
Fixes #247537

This is what happens when you only think of ASCII.
