### PR TITLE
[prompts]: allow front matter header to end at the end of a file

### DIFF
--- a/src/vs/editor/common/codecs/markdownExtensionsCodec/tokens/frontMatterMarker.ts
+++ b/src/vs/editor/common/codecs/markdownExtensionsCodec/tokens/frontMatterMarker.ts
@@ -7,7 +7,6 @@ import { Range } from '../../../core/range.js';
 import { BaseToken } from '../../baseToken.js';
 import { Dash } from '../../simpleCodec/tokens/dash.js';
 import { NewLine } from '../../linesCodec/tokens/newLine.js';
-import { assert } from '../../../../../base/common/assert.js';
 import { MarkdownExtensionsToken } from './markdownExtensionsToken.js';
 import { CarriageReturn } from '../../linesCodec/tokens/carriageReturn.js';
 
@@ -39,13 +38,6 @@ export class FrontMatterMarker extends MarkdownExtensionsToken {
 		range: Range,
 		public readonly tokens: readonly TMarkerToken[],
 	) {
-		const lastToken = tokens[tokens.length - 1];
-
-		assert(
-			lastToken instanceof NewLine,
-			`Front Matter marker must end with a new line token, got '${lastToken}'.`,
-		);
-
 		super(range);
 	}
 

--- a/src/vs/editor/test/common/utils/testDecoder.ts
+++ b/src/vs/editor/test/common/utils/testDecoder.ts
@@ -221,7 +221,7 @@ export class TestDecoder<T extends BaseToken, D extends BaseDecoder<T>> extends 
 
 			assert(
 				receivedToken.equals(expectedToken),
-				`Expected token '${i}' to be '${expectedToken}', got '${receivedToken}'.`,
+				`\nExpected token '${i}' to be:\n\n${expectedToken.text}\n(${expectedToken.range})\n\ngot:\n\n${receivedToken.text}\n(${receivedToken.range})\n`,
 			);
 		}
 


### PR DESCRIPTION
Currently we require the end marker of Front Matter header to end with a new line for the header to be valid. This PR removes that restriction so that the header can end at the end of the file. This mainly improves syntax highlighting and other language features when user actively editing a prompt.

For https://github.com/microsoft/vscode-copilot/issues/16557, part of https://github.com/microsoft/vscode-copilot/issues/15596.