### PR TITLE
add 'type: module' to the package.json of vscode-web

### DIFF
--- a/build/gulpfile.vscode.web.js
+++ b/build/gulpfile.vscode.web.js
@@ -167,7 +167,7 @@ function packageTask(sourceFolderName, destinationFolderName) {
 
 		const name = product.nameShort;
 		const packageJsonStream = gulp.src(['remote/web/package.json'], { base: 'remote/web' })
-			.pipe(json({ name, version }));
+			.pipe(json({ name, version, type: 'module' }));
 
 		const license = gulp.src(['remote/LICENSE'], { base: 'remote', allowEmpty: true });
 


### PR DESCRIPTION
This is used in test-web to know that this build supports loading with ESM