### PR TITLE
Make quick input padding consistent

### DIFF
--- a/src/vs/platform/quickinput/browser/media/quickInput.css
+++ b/src/vs/platform/quickinput/browser/media/quickInput.css
@@ -72,7 +72,7 @@
 .quick-input-header {
 	cursor: grab;
 	display: flex;
-	padding: 8px 6px 2px 6px;
+	padding: 6px 6px 2px 6px;
 }
 
 .quick-input-widget.hidden-input .quick-input-header {
@@ -179,7 +179,7 @@
 }
 
 .quick-input-list .monaco-scrollable-element {
-	padding: 0px 5px;
+	padding: 0px 6px;
 }
 
 .quick-input-list .quick-input-list-entry {


### PR DESCRIPTION
Fixes #247649

After:

<img width="621" alt="Screenshot 2025-04-30 at 8 32 53 am" src="https://github.com/user-attachments/assets/d954f784-95b3-4ddc-9748-affce528ccb0" />

<img width="726" alt="Screenshot 2025-04-30 at 8 33 35 am" src="https://github.com/user-attachments/assets/da9059fa-3564-47bf-ab8d-a11615955d82" />
