### PR TITLE
[prompts]: fix attach instructions file picker dialog multi-select logic

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/actions/chatClearActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatClearActions.ts
@@ -43,6 +43,11 @@ export interface INewEditSessionActionContext {
 	 * Whether the inputValue is partial and should wait for further user input. If false or not set, the prompt is sent immediately.
 	 */
 	isPartialQuery?: boolean;
+
+	/**
+	 * TODO: @legomushroom
+	 */
+	dontFocus?: boolean;
 }
 
 export function registerNewChatActions() {
@@ -115,7 +120,11 @@ export function registerNewChatActions() {
 			await widget.waitForReady();
 			widget.attachmentModel.clear(true);
 			widget.input.relatedFiles?.clear();
-			widget.focusInput();
+
+			// TODO: @legomushroom
+			if (!context?.dontFocus) {
+				widget.focusInput();
+			}
 
 			if (!context) {
 				return;

--- a/src/vs/workbench/contrib/chat/browser/actions/chatClearActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatClearActions.ts
@@ -45,7 +45,9 @@ export interface INewEditSessionActionContext {
 	isPartialQuery?: boolean;
 
 	/**
-	 * TODO: @legomushroom
+	 * Don't focus the chat input of the newly created chat session.
+	 * Useful, for instance, to allow the multi-select 'attach file' picker
+	 * flows which also use a key modifier to attach to a new chat session.
 	 */
 	dontFocus?: boolean;
 }
@@ -121,7 +123,6 @@ export function registerNewChatActions() {
 			widget.attachmentModel.clear(true);
 			widget.input.relatedFiles?.clear();
 
-			// TODO: @legomushroom
 			if (!context?.dontFocus) {
 				widget.focusInput();
 			}

--- a/src/vs/workbench/contrib/chat/browser/actions/promptActions/chatAttachInstructionsAction.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/promptActions/chatAttachInstructionsAction.ts
@@ -103,14 +103,14 @@ class AttachInstructionsAction extends Action2 {
 		}
 
 		// find all prompt files in the user workspace
-		const instructionFiles = await promptsService.listPromptFiles('instructions');
+		const promptFiles = await promptsService.listPromptFiles('instructions');
 		const placeholder = localize(
 			'commands.instructions.select-dialog.placeholder',
 			'Select instructions files to attach',
 		);
 
 		// TODO: @legomushroom - use the options.widget reference?
-		await pickers.selectInstructionsFiles({ promptFiles: instructionFiles, placeholder });
+		await pickers.selectInstructionsFiles({ promptFiles, placeholder });
 	}
 }
 

--- a/src/vs/workbench/contrib/chat/browser/actions/promptActions/chatAttachInstructionsAction.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/promptActions/chatAttachInstructionsAction.ts
@@ -98,7 +98,6 @@ class AttachInstructionsAction extends Action2 {
 			);
 
 			widget.focusInput();
-
 			return;
 		}
 
@@ -109,8 +108,11 @@ class AttachInstructionsAction extends Action2 {
 			'Select instructions files to attach',
 		);
 
-		// TODO: @legomushroom - use the options.widget reference?
-		await pickers.selectInstructionsFiles({ promptFiles, placeholder });
+		await pickers.selectInstructionsFiles({
+			promptFiles,
+			placeholder,
+			widget: options.widget,
+		});
 	}
 }
 

--- a/src/vs/workbench/contrib/chat/browser/actions/promptActions/chatAttachInstructionsAction.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/promptActions/chatAttachInstructionsAction.ts
@@ -103,21 +103,14 @@ class AttachInstructionsAction extends Action2 {
 		}
 
 		// find all prompt files in the user workspace
-		const promptFiles = await promptsService.listPromptFiles('instructions');
+		const instructionFiles = await promptsService.listPromptFiles('instructions');
 		const placeholder = localize(
 			'commands.instructions.select-dialog.placeholder',
 			'Select instructions files to attach',
 		);
 
-		const instructions = await pickers.selectInstructionsFiles({ promptFiles, placeholder });
-
-		if (instructions !== undefined) {
-			const widget = await attachInstructionsFiles(
-				instructions,
-				attachOptions,
-			);
-			widget.focusInput();
-		}
+		// TODO: @legomushroom - use the options.widget reference?
+		await pickers.selectInstructionsFiles({ promptFiles: instructionFiles, placeholder });
 	}
 }
 

--- a/src/vs/workbench/contrib/chat/browser/actions/promptActions/chatAttachInstructionsAction.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/promptActions/chatAttachInstructionsAction.ts
@@ -110,6 +110,7 @@ class AttachInstructionsAction extends Action2 {
 
 		await pickers.selectInstructionsFiles({
 			promptFiles,
+			resource,
 			placeholder,
 			widget: options.widget,
 		});

--- a/src/vs/workbench/contrib/chat/browser/actions/promptActions/chatRunPromptAction.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/promptActions/chatRunPromptAction.ts
@@ -235,7 +235,6 @@ class RunSelectedPromptAction extends Action2 {
 	}
 }
 
-
 /**
  * Gets `URI` of a prompt file open in an active editor instance, if any.
  */

--- a/src/vs/workbench/contrib/chat/browser/actions/promptActions/dialogs/askToSelectPrompt/promptFilePickers.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/promptActions/dialogs/askToSelectPrompt/promptFilePickers.ts
@@ -192,6 +192,7 @@ export class PromptFilePickers {
 						inNewChat: keyMods.ctrlCmd,
 						viewsService: this.viewsService,
 						commandService: this.commandService,
+						widget: options.widget,
 					},
 				);
 				lastActiveWidget = widget;

--- a/src/vs/workbench/contrib/chat/browser/actions/promptActions/dialogs/askToSelectPrompt/promptFilePickers.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/promptActions/dialogs/askToSelectPrompt/promptFilePickers.ts
@@ -143,7 +143,6 @@ export class PromptFilePickers {
 	 * the resource pre-selected in the prompts list.
 	 */
 	public async selectInstructionsFiles(options: ISelectOptions): Promise<undefined> {
-
 		const fileOptions = this._createPromptPickItems(options);
 		fileOptions.splice(0, 0, NEW_INSTRUCTIONS_FILE_OPTION);
 
@@ -217,9 +216,8 @@ export class PromptFilePickers {
 	 * If {@link ISelectOptions.resource resource} is provided, the dialog will have
 	 * the resource pre-selected in the prompts list.
 	 */
-	// TODO: @legomushroom - fix this one?
+	// TODO: @legomushroom - use the same logic for this one?
 	public async selectPromptFile(options: ISelectOptions): Promise<ISelectPromptResult | undefined> {
-
 		const fileOptions = this._createPromptPickItems(options);
 		fileOptions.splice(0, 0, NEW_PROMPT_FILE_OPTION);
 

--- a/src/vs/workbench/contrib/chat/browser/actions/promptActions/dialogs/askToSelectPrompt/promptFilePickers.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/promptActions/dialogs/askToSelectPrompt/promptFilePickers.ts
@@ -147,15 +147,17 @@ export class PromptFilePickers {
 	 * the resource pre-selected in the prompts list.
 	 */
 	public async selectInstructionsFiles(options: ISelectOptions): Promise<null> {
-		const fileOptions = this.createPromptPickItems(options);
+		const [fileOptions, activeItem] = this.createPromptPickItems(options);
 		fileOptions.splice(0, 0, NEW_INSTRUCTIONS_FILE_OPTION);
 
 		const quickPick = this.quickInputService.createQuickPick<WithUriValue<IQuickPickItem>>();
-		quickPick.activeItems = fileOptions.length ? [fileOptions[0]] : [];
 		quickPick.placeholder = options.placeholder;
 		quickPick.canAcceptInBackground = true;
 		quickPick.matchOnDescription = true;
 		quickPick.items = fileOptions;
+		quickPick.activeItems = (activeItem !== undefined)
+			? [activeItem]
+			: [fileOptions[0]];
 
 		return new Promise((resolve) => {
 			const disposables = new DisposableStore();
@@ -221,15 +223,17 @@ export class PromptFilePickers {
 	 * the resource pre-selected in the prompts list.
 	 */
 	public async selectPromptFile(options: ISelectOptions): Promise<ISelectPromptResult | undefined> {
-		const fileOptions = this.createPromptPickItems(options);
+		const [fileOptions, activeItem] = this.createPromptPickItems(options);
 		fileOptions.splice(0, 0, NEW_PROMPT_FILE_OPTION);
 
 		const quickPick = this.quickInputService.createQuickPick<WithUriValue<IQuickPickItem>>();
-		quickPick.activeItems = fileOptions.length ? [fileOptions[0]] : [];
 		quickPick.placeholder = options.placeholder;
 		quickPick.canAcceptInBackground = true;
 		quickPick.matchOnDescription = true;
 		quickPick.items = fileOptions;
+		quickPick.activeItems = (activeItem !== undefined)
+			? [activeItem]
+			: [fileOptions[0]];
 
 		return new Promise<ISelectPromptResult | undefined>(resolve => {
 			const disposables = new DisposableStore();
@@ -285,7 +289,7 @@ export class PromptFilePickers {
 		});
 	}
 
-	private createPromptPickItems(options: ISelectOptions): WithUriValue<IQuickPickItem>[] {
+	private createPromptPickItems(options: ISelectOptions): [WithUriValue<IQuickPickItem>[], WithUriValue<IQuickPickItem> | undefined] {
 		const { promptFiles, resource } = options;
 
 		const fileOptions = promptFiles.map((promptFile) => {
@@ -327,7 +331,7 @@ export class PromptFilePickers {
 				return 0;
 			});
 		}
-		return fileOptions;
+		return [fileOptions, activeItem];
 	}
 
 	private createPromptPickItem(promptFile: IPromptPath): WithUriValue<IQuickPickItem> {

--- a/src/vs/workbench/contrib/chat/browser/actions/promptActions/dialogs/askToSelectPrompt/promptFilePickers.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/promptActions/dialogs/askToSelectPrompt/promptFilePickers.ts
@@ -3,11 +3,13 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-// TODO: @legomushroom
+import { IChatWidget } from '../../../../chat.js';
 import { localize } from '../../../../../../../../nls.js';
 import { URI } from '../../../../../../../../base/common/uri.js';
 import { OS } from '../../../../../../../../base/common/platform.js';
+import { pick } from '../../../../../../../../base/common/arrays.js';
 import { assert } from '../../../../../../../../base/common/assert.js';
+import { attachInstructionsFiles } from './utils/attachInstructions.js';
 import { Codicon } from '../../../../../../../../base/common/codicons.js';
 import { WithUriValue } from '../../../../../../../../base/common/types.js';
 import { ThemeIcon } from '../../../../../../../../base/common/themables.js';
@@ -18,16 +20,13 @@ import { IFileService } from '../../../../../../../../platform/files/common/file
 import { ILabelService } from '../../../../../../../../platform/label/common/label.js';
 import { IOpenerService } from '../../../../../../../../platform/opener/common/opener.js';
 import { UILabelProvider } from '../../../../../../../../base/common/keybindingLabels.js';
+import { IViewsService } from '../../../../../../../services/views/common/viewsService.js';
 import { IDialogService } from '../../../../../../../../platform/dialogs/common/dialogs.js';
 import { ICommandService } from '../../../../../../../../platform/commands/common/commands.js';
 import { getCleanPromptName } from '../../../../../../../../platform/prompts/common/constants.js';
 import { INSTRUCTIONS_DOCUMENTATION_URL, PROMPT_DOCUMENTATION_URL } from '../../../../../common/promptSyntax/constants.js';
 import { NEW_PROMPT_COMMAND_ID, NEW_INSTRUCTIONS_COMMAND_ID } from '../../../../promptSyntax/contributions/createPromptCommand/createPromptCommand.js';
 import { IKeyMods, IQuickInputButton, IQuickInputService, IQuickPick, IQuickPickItem, IQuickPickItemButtonEvent } from '../../../../../../../../platform/quickinput/common/quickInput.js';
-import { attachInstructionsFiles } from './utils/attachInstructions.js';
-import { IChatWidget } from '../../../../chat.js';
-import { IViewsService } from '../../../../../../../services/views/common/viewsService.js';
-import { pick } from '../../../../../../../../base/common/arrays.js';
 
 /**
  * Options for the {@link askToSelectInstructions} function.
@@ -50,6 +49,11 @@ export interface ISelectOptions {
 	 * List of prompt files to show in the selection dialog.
 	 */
 	readonly promptFiles: readonly IPromptPath[];
+
+	/**
+	 * Optional chat widget reference to attach files to.
+	 */
+	readonly widget?: IChatWidget;
 }
 
 export interface ISelectPromptResult {
@@ -126,7 +130,6 @@ const DELETE_BUTTON: IQuickInputButton = Object.freeze({
 
 export class PromptFilePickers {
 	constructor(
-		// TODO: @legomushroom - cleanup the names
 		@ILabelService private readonly _labelService: ILabelService,
 		@IQuickInputService private readonly _quickInputService: IQuickInputService,
 		@IOpenerService private readonly _openerService: IOpenerService,
@@ -216,7 +219,6 @@ export class PromptFilePickers {
 	 * If {@link ISelectOptions.resource resource} is provided, the dialog will have
 	 * the resource pre-selected in the prompts list.
 	 */
-	// TODO: @legomushroom - use the same logic for this one?
 	public async selectPromptFile(options: ISelectOptions): Promise<ISelectPromptResult | undefined> {
 		const fileOptions = this._createPromptPickItems(options);
 		fileOptions.splice(0, 0, NEW_PROMPT_FILE_OPTION);
@@ -261,7 +263,6 @@ export class PromptFilePickers {
 					isResolved = true;
 				}
 
-				// TODO: @legomushroom
 				// if user submitted their selection, close the dialog
 				if (!event.inBackground) {
 					disposables.dispose();

--- a/src/vs/workbench/contrib/chat/browser/actions/promptActions/dialogs/askToSelectPrompt/utils/attachInstructions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/promptActions/dialogs/askToSelectPrompt/utils/attachInstructions.ts
@@ -5,7 +5,7 @@
 
 import { IChatWidget, showChatView } from '../../../../../chat.js';
 import { URI } from '../../../../../../../../../base/common/uri.js';
-import { ACTION_ID_NEW_CHAT } from '../../../../chatClearActions.js';
+import { ACTION_ID_NEW_CHAT, INewEditSessionActionContext } from '../../../../chatClearActions.js';
 import { assertDefined } from '../../../../../../../../../base/common/types.js';
 import { IAttachInstructionsActionOptions } from '../../../chatAttachInstructionsAction.js';
 import { IViewsService } from '../../../../../../../../services/views/common/viewsService.js';
@@ -77,8 +77,11 @@ const showChat = async (
 	const { commandService, viewsService } = options;
 
 	if (createNew === true) {
-		// TODO: @legomushroom - prevent focus somehow?
-		await commandService.executeCommand(ACTION_ID_NEW_CHAT);
+		// TODO: @legomushroom
+		await commandService.executeCommand(
+			ACTION_ID_NEW_CHAT,
+			{ dontFocus: true } satisfies INewEditSessionActionContext,
+		);
 	}
 
 	const widget = await showChatView(viewsService);

--- a/src/vs/workbench/contrib/chat/browser/actions/promptActions/dialogs/askToSelectPrompt/utils/attachInstructions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/promptActions/dialogs/askToSelectPrompt/utils/attachInstructions.ts
@@ -77,9 +77,13 @@ const showChat = async (
 	const { commandService, viewsService } = options;
 
 	if (createNew === true) {
-		// TODO: @legomushroom
 		await commandService.executeCommand(
 			ACTION_ID_NEW_CHAT,
+			/**
+			 * We need to skip the chat input focus on new chat instance
+			 * creation to allow for the files picker dialog to be kept
+			 * open so users can select multiple files.
+			 */
 			{ dontFocus: true } satisfies INewEditSessionActionContext,
 		);
 	}

--- a/src/vs/workbench/contrib/chat/browser/actions/promptActions/dialogs/askToSelectPrompt/utils/attachInstructions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/promptActions/dialogs/askToSelectPrompt/utils/attachInstructions.ts
@@ -77,6 +77,7 @@ const showChat = async (
 	const { commandService, viewsService } = options;
 
 	if (createNew === true) {
+		// TODO: @legomushroom - prevent focus somehow?
 		await commandService.executeCommand(ACTION_ID_NEW_CHAT);
 	}
 

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/contributions/languageFeatures/providers/providerInstanceBase.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/contributions/languageFeatures/providers/providerInstanceBase.ts
@@ -42,6 +42,6 @@ export abstract class ProviderInstanceBase extends ObservableDisposable {
 			.start();
 
 		// initialize an update
-		this.onPromptSettled(undefined);
+		setTimeout(this.onPromptSettled.bind(this));
 	}
 }


### PR DESCRIPTION
Fixes the attach instructions file picker dialog multi-select select logic.

For https://github.com/microsoft/vscode-copilot/issues/16788, part of https://github.com/microsoft/vscode-copilot/issues/15596