### PR TITLE
Issue #210694 added hover color change on Activity Bar elements

### DIFF
--- a/scripts/package-lock.json
+++ b/scripts/package-lock.json
@@ -1,0 +1,6 @@
+{
+	"name": "scripts",
+	"lockfileVersion": 3,
+	"requires": true,
+	"packages": {}
+}

--- a/src/vs/workbench/browser/parts/activitybar/activitybarPart.ts
+++ b/src/vs/workbench/browser/parts/activitybar/activitybarPart.ts
@@ -13,7 +13,7 @@ import { IInstantiationService, ServicesAccessor } from '../../../../platform/in
 import { DisposableStore, MutableDisposable } from '../../../../base/common/lifecycle.js';
 import { ToggleSidebarPositionAction, ToggleSidebarVisibilityAction } from '../../actions/layoutActions.js';
 import { IThemeService, IColorTheme, registerThemingParticipant } from '../../../../platform/theme/common/themeService.js';
-import { ACTIVITY_BAR_BACKGROUND, ACTIVITY_BAR_BORDER, ACTIVITY_BAR_FOREGROUND, ACTIVITY_BAR_ACTIVE_BORDER, ACTIVITY_BAR_BADGE_BACKGROUND, ACTIVITY_BAR_BADGE_FOREGROUND, ACTIVITY_BAR_INACTIVE_FOREGROUND, ACTIVITY_BAR_ACTIVE_BACKGROUND, ACTIVITY_BAR_DRAG_AND_DROP_BORDER, ACTIVITY_BAR_ACTIVE_FOCUS_BORDER } from '../../../common/theme.js';
+import { ACTIVITY_BAR_BACKGROUND, ACTIVITY_BAR_BORDER, ACTIVITY_BAR_FOREGROUND, ACTIVITY_BAR_ACTIVE_BORDER, ACTIVITY_BAR_BADGE_BACKGROUND, ACTIVITY_BAR_BADGE_FOREGROUND, ACTIVITY_BAR_INACTIVE_FOREGROUND, ACTIVITY_BAR_ACTIVE_BACKGROUND, ACTIVITY_BAR_DRAG_AND_DROP_BORDER, ACTIVITY_BAR_ACTIVE_FOCUS_BORDER, ACTIVITY_BAR_HOVER_FOREGROUND, ACTIVITY_BAR_HOVER_BACKGROUND, ACTIVITY_BAR_TOP_HOVER_FOREGROUND, ACTIVITY_BAR_TOP_HOVER_BACKGROUND } from '../../../common/theme.js';
 import { activeContrastBorder, contrastBorder, focusBorder } from '../../../../platform/theme/common/colorRegistry.js';
 import { addDisposableListener, append, EventType, isAncestor, $, clearNode } from '../../../../base/browser/dom.js';
 import { assertIsDefined } from '../../../../base/common/types.js';
@@ -576,6 +576,42 @@ registerThemingParticipant((theme, collector) => {
 			.monaco-workbench .activitybar > .content :not(.monaco-menu) > .monaco-action-bar .action-item.checked .active-item-indicator {
 				z-index: 0;
 				background-color: ${activityBarActiveBackgroundColor};
+			}
+		`);
+	}
+
+	const activeBarHoverForeground = theme.getColor(ACTIVITY_BAR_HOVER_FOREGROUND);
+	if (activeBarHoverForeground) {
+		collector.addRule(`
+			.monaco-workbench .activitybar > .content :not(.monaco-menu) > .monaco-action-bar .action-item:hover .action-label {
+				color: ${activeBarHoverForeground};
+			}
+		`);
+	}
+
+	const activeBarHoverBackground = theme.getColor(ACTIVITY_BAR_HOVER_BACKGROUND);
+	if (activeBarHoverBackground) {
+		collector.addRule(`
+			.monaco-workbench .activitybar > .content :not(.monaco-menu) > .monaco-action-bar .action-item:hover {
+				background-color: ${activeBarHoverForeground};
+			}
+		`);
+	}
+
+	const activeBarTopHoverForeground = theme.getColor(ACTIVITY_BAR_TOP_HOVER_FOREGROUND);
+	if (activeBarTopHoverForeground) {
+		collector.addRule(`
+			.monaco-workbench .activitybar > .top :not(.monaco-menu) > .monaco-action-bar .action-item:hover .action-label {
+				color: ${activeBarTopHoverForeground};
+			}
+		`);
+	}
+
+	const activeBarTopHoverBackground = theme.getColor(ACTIVITY_BAR_TOP_HOVER_BACKGROUND);
+	if (activeBarTopHoverBackground) {
+		collector.addRule(`
+			.monaco-workbench .activitybar > .top :not(.monaco-menu) > .monaco-action-bar .action-item:hover {
+				background-color: ${activeBarTopHoverForeground};
 			}
 		`);
 	}

--- a/src/vs/workbench/common/theme.ts
+++ b/src/vs/workbench/common/theme.ts
@@ -401,6 +401,20 @@ export const ACTIVITY_BAR_FOREGROUND = registerColor('activityBar.foreground', {
 	hcLight: editorForeground
 }, localize('activityBarForeground', "Activity bar item foreground color when it is active. The activity bar is showing on the far left or right and allows to switch between views of the side bar."));
 
+export const ACTIVITY_BAR_HOVER_FOREGROUND = registerColor('activityBar.hoverForeground', {
+	dark: '#00a0df',
+	light: '#00a0df',
+	hcDark: '#00a0df',
+	hcLight: '#00a0df'
+}, localize('activityBarHoverForeground', "Activity bar item foreground color when it is hovered over."));
+
+export const ACTIVITY_BAR_HOVER_BACKGROUND = registerColor('activityBar.hoverBackground', {
+	dark: '#a4dcf3',
+	light: '#a4dcf3',
+	hcDark: '#a4dcf3',
+	hcLight: '#a4dcf3'
+}, localize('activityBarHoverBackground', "Activity bar item background color when it is hovered over."));
+
 export const ACTIVITY_BAR_INACTIVE_FOREGROUND = registerColor('activityBar.inactiveForeground', {
 	dark: transparent(ACTIVITY_BAR_FOREGROUND, 0.4),
 	light: transparent(ACTIVITY_BAR_FOREGROUND, 0.4),
@@ -453,6 +467,20 @@ export const ACTIVITY_BAR_TOP_FOREGROUND = registerColor('activityBarTop.foregro
 	hcDark: Color.white,
 	hcLight: editorForeground
 }, localize('activityBarTop', "Active foreground color of the item in the Activity bar when it is on top / bottom. The activity allows to switch between views of the side bar."));
+
+export const ACTIVITY_BAR_TOP_HOVER_FOREGROUND = registerColor('activityBarTop.hoverForeground', {
+	dark: '#00a0df',
+	light: '#00a0df',
+	hcDark: '#00a0df',
+	hcLight: '#00a0df'
+}, localize('activityBarTopHoverForeground', "Top activity bar item foreground color when it is hovered over."));
+
+export const ACTIVITY_BAR_TOP_HOVER_BACKGROUND = registerColor('activityBarTop.hoverBackground', {
+	dark: '#a4dcf3',
+	light: '#a4dcf3',
+	hcDark: '#a4dcf3',
+	hcLight: '#a4dcf3'
+}, localize('activityBarTopHoverBackground', "Top activity bar item background color when it is hovered over."));
 
 export const ACTIVITY_BAR_TOP_ACTIVE_BORDER = registerColor('activityBarTop.activeBorder', {
 	dark: ACTIVITY_BAR_TOP_FOREGROUND,


### PR DESCRIPTION
The code in this pull request was made to solve Issue #210694. As a part of this solution, icons on the activityBar and activityBarTop will highlight with a blue color when hovered over to more easily communicate which icon is selected at a given moment. 

To test, build, and hover the mouse cursor over elements on the activityBar bar. 