### PR TITLE
Fix cancellation logic in Picker onDidChangeValue handler (fixes #247945)

### DIFF
--- a/src/vs/platform/quickinput/browser/pickerQuickAccess.ts
+++ b/src/vs/platform/quickinput/browser/pickerQuickAccess.ts
@@ -146,11 +146,12 @@ export abstract class PickerQuickAccessProvider<T extends IPickerQuickAccessItem
 		let picksCts: CancellationTokenSource | undefined = undefined;
 		const picksDisposable = disposables.add(new MutableDisposable());
 		const updatePickerItems = async () => {
-			const picksDisposables = picksDisposable.value = new DisposableStore();
-
 			// Cancel any previous ask for picks and busy
 			picksCts?.dispose(true);
 			picker.busy = false;
+
+			// Setting the .value will call dispose() on the previous value, so we need to do this AFTER cancelling with dispose(true).
+			const picksDisposables = picksDisposable.value = new DisposableStore();
 
 			// Create new cancellation source for this run
 			picksCts = picksDisposables.add(new CancellationTokenSource(token));


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
The onDidChangeValue in the quick access picker has logic to cancel the previous search as the user is typing.

However this logic was never actually called because the `value` setter on `DisposableStore` called `dispose()` on the previous value. The problem is that calling `dispose()` without `cancel()` just removes all the listeners without triggering their cancellation handlers. So the `dispose(true)` runs but it's a no-op; there's nothing left to cancel.

This PR fixes the issue by running the cancellation first, then updating the `DisposableStore` value.

I observe a 2-10x faster experience when typing in a fairly large workspace, depending on the exact search term.

Resolves #247945