### PR TITLE
Add "Installed" filter to Extensions view

### DIFF
--- a/src/vs/workbench/contrib/extensions/browser/extensionsViewlet.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionsViewlet.ts
@@ -120,6 +120,9 @@ export class ExtensionsViewletViewsContribution extends Disposable implements IW
 		/* Recommendations views */
 		viewDescriptors.push(...this.createRecommendedExtensionsViewDescriptors());
 
+		/* Installed extensions view */
+		viewDescriptors.push(...this.createInstalledExtensionsViewDescriptors());
+
 		/* Built-in extensions views */
 		viewDescriptors.push(...this.createBuiltinExtensionsViewDescriptors());
 
@@ -396,6 +399,21 @@ export class ExtensionsViewletViewsContribution extends Disposable implements IW
 
 		return viewDescriptors;
 	}
+
+	private createInstalledExtensionsViewDescriptors(): IViewDescriptor[] {
+		const viewDescriptors: IViewDescriptor[] = [];
+
+		viewDescriptors.push({
+			id: 'workbench.views.extensions.installed',
+			name: localize2('installedExtensions', "Installed"),
+			ctorDescriptor: new SyncDescriptor(StaticQueryExtensionsView, [{ query: '@installed' }]),
+			when: ContextKeyExpr.has('installedExtensions'),
+			order: 3
+		});
+
+		return viewDescriptors;
+	}
+
 
 	private createBuiltinExtensionsViewDescriptors(): IViewDescriptor[] {
 		const viewDescriptors: IViewDescriptor[] = [];


### PR DESCRIPTION
This PR adds a new "Installed" filter to the Extensions viewlet.

It introduces a new view descriptor via `createInstalledExtensionsViewDescriptors()` that registers a view with the query `@installed`. This makes it easier for users to quickly locate all currently installed extensions.

This change aligns with the structure used for other filters like `@builtin` and `@recommended`, and reuses the `StaticQueryExtensionsView` for implementation consistency.

I’m submitting this as part of a class project and welcome any feedback. Thank you!
