### PR TITLE
Use international number formatter to display quota percentage

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatStatus.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatStatus.ts
@@ -505,13 +505,15 @@ class ChatStatusDashboard extends Disposable {
 			} else {
 				usedPercentage = Math.max(0, 100 - quota.percentRemaining);
 			}
+			// Use intl number format to format the used percentage to 1 decimal place
+			const percentUsedFormatter = new Intl.NumberFormat(undefined, { maximumFractionDigits: 1, minimumFractionDigits: 0 });
 
 			if (quota.unlimited) {
 				quotaValue.textContent = localize('quotaUnlimited', "Included");
 			} else if (quota.overageCount) {
 				quotaValue.textContent = localize('quotaDisplayWithOverage', "+{0} requests", quota.overageCount);
 			} else {
-				quotaValue.textContent = localize('quotaDisplay', "{0}%", usedPercentage);
+				quotaValue.textContent = localize('quotaDisplay', "{0}%", percentUsedFormatter.format(usedPercentage));
 			}
 
 			quotaBit.style.width = `${usedPercentage}%`;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Shows the number format according to the locale

cc @connor4312

We don't do this in many of the places we show numbers. I'm wondering if we should be and if so if there should be a utility that respects the user's VS code locale settings? Is it weird to do this just in one place?
