### PR TITLE
Added Installed filter to the extensions view.

### DIFF
--- a/src/vs/workbench/contrib/extensions/browser/extensions.contribution.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensions.contribution.ts
@@ -1156,6 +1156,21 @@ class ExtensionsContributions extends Disposable implements IWorkbenchContributi
 			run: () => this.extensionsWorkbenchService.openSearch('@disabled ')
 		});
 
+		this.registerExtensionAction({
+			id: 'workbench.extensions.action.showInstalledExtensions',
+			title: localize('showInstalledExtensions', "Show Installed Extensions"),
+			category: ExtensionsLocalizedLabel,
+			menu: [
+				{ id: MenuId.CommandPalette, when: ContextKeyExpr.or(CONTEXT_HAS_LOCAL_SERVER, CONTEXT_HAS_REMOTE_SERVER, CONTEXT_HAS_WEB_SERVER) },
+				{ id: extensionsFilterSubMenu, group: '3_installed', order: 2 }
+			],
+			menuTitles: {
+				[extensionsFilterSubMenu.id]: localize('installed filter', "Installed")
+			},
+			run: () => this.extensionsWorkbenchService.openSearch('@installed ')
+		});
+
+
 		const extensionsSortSubMenu = new MenuId('extensionsSortSubMenu');
 		MenuRegistry.appendMenuItem(extensionsFilterSubMenu, {
 			submenu: extensionsSortSubMenu,


### PR DESCRIPTION
Previously the Installed filter was intentionally omitted to avoid clutter, but for Issue 246971 this was asked to be re-added as a usability improvement. The filter is now available in the view menu and can be used to show only installed extensions.
This can be tested locally through running VSCode from the terminal with:

yarn
yarn run watch
yarn run vscode

Then checking if the Installed filter properly appears in the menu.

This PR was created for https://github.com/microsoft/vscode/issues/246971
