### PR TITLE
When Copilot sign in is going to use enterprise, it should say so (fix microsoft/vscode-copilot#16915)

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatSetup.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSetup.ts
@@ -693,6 +693,10 @@ class ChatSetup {
 
 	private getPrimaryButton(): string {
 		if (this.context.state.entitlement === ChatEntitlement.Unknown) {
+			if (ChatEntitlementRequests.providerId(this.configurationService) === defaultChat.enterpriseProviderId) {
+				return localize('setupWithProviderShort', "Sign in with {0}", defaultChat.enterpriseProviderName);
+			}
+
 			return localize('signInButton', "Sign in");
 		}
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
