### PR TITLE
Also detect ChromeOS as Linux

### DIFF
--- a/src/vs/base/common/platform.ts
+++ b/src/vs/base/common/platform.ts
@@ -100,7 +100,7 @@ else if (typeof navigator === 'object' && !isElectronRenderer) {
 	_isWindows = _userAgent.indexOf('Windows') >= 0;
 	_isMacintosh = _userAgent.indexOf('Macintosh') >= 0;
 	_isIOS = (_userAgent.indexOf('Macintosh') >= 0 || _userAgent.indexOf('iPad') >= 0 || _userAgent.indexOf('iPhone') >= 0) && !!navigator.maxTouchPoints && navigator.maxTouchPoints > 0;
-	_isLinux = _userAgent.indexOf('Linux') >= 0;
+	_isLinux = _userAgent.indexOf('Linux') >= 0 || _userAgent.indexOf('CrOS') >= 0;
 	_isMobile = _userAgent?.indexOf('Mobi') >= 0;
 	_isWeb = true;
 	_language = nls.getNLSLanguage() || LANGUAGE_DEFAULT;


### PR DESCRIPTION
This also fixes https://github.com/microsoft/vscode/issues/247766

Currently we detect Linux by searching the user agent string for Linux, but this does not match ChromeOS. This adds a secondary check for CrOS.