### PR TITLE
[prompts][debt]: refactor token equals method

### DIFF
--- a/src/vs/editor/common/codecs/baseToken.ts
+++ b/src/vs/editor/common/codecs/baseToken.ts
@@ -8,16 +8,19 @@ import { assert } from '../../../base/common/assert.js';
 import { IRange, Range } from '../../../editor/common/core/range.js';
 
 /**
- * Base class for all tokens with a `range` that
- * reflects token position in the original data.
+ * Base class for all tokens with a `range` that reflects
+ * token position in the original text.
  */
 export abstract class BaseToken {
 	constructor(
-		private _range: Range,
+		private tokenRange: Range,
 	) { }
 
+	/**
+	 * Range of the token in the original text.
+	 */
 	public get range(): Range {
-		return this._range;
+		return this.tokenRange;
 	}
 
 	/**
@@ -60,12 +63,22 @@ export abstract class BaseToken {
 	 * Change `range` of the token with provided range components.
 	 */
 	public withRange(components: Partial<IRange>): this {
-		this._range = new Range(
+		this.tokenRange = new Range(
 			components.startLineNumber ?? this.range.startLineNumber,
 			components.startColumn ?? this.range.startColumn,
 			components.endLineNumber ?? this.range.endLineNumber,
 			components.endColumn ?? this.range.endColumn,
 		);
+
+		return this;
+	}
+
+	/**
+	 * Collapse range of the token to its start position.
+	 * See {@link Range.collapseToStart} for more details.
+	 */
+	public collapseRangeToStart(): this {
+		this.tokenRange = this.tokenRange.collapseToStart();
 
 		return this;
 	}

--- a/src/vs/editor/common/codecs/baseToken.ts
+++ b/src/vs/editor/common/codecs/baseToken.ts
@@ -40,8 +40,16 @@ export abstract class BaseToken {
 	/**
 	 * Check if this token is equal to another one.
 	 */
-	public equals<T extends BaseToken>(other: T): boolean {
-		if (!(other instanceof this.constructor)) {
+	public equals(other: BaseToken): other is typeof this {
+		if (other.constructor !== this.constructor) {
+			return false;
+		}
+
+		if (this.text.length !== other.text.length) {
+			return false;
+		}
+
+		if (this.text !== other.text) {
 			return false;
 		}
 

--- a/src/vs/editor/common/codecs/linesCodec/tokens/line.ts
+++ b/src/vs/editor/common/codecs/linesCodec/tokens/line.ts
@@ -40,21 +40,6 @@ export class Line extends BaseToken {
 	}
 
 	/**
-	 * Check if this token is equal to another one.
-	 */
-	public override equals<T extends BaseToken>(other: T): boolean {
-		if (!super.equals(other)) {
-			return false;
-		}
-
-		if (!(other instanceof Line)) {
-			return false;
-		}
-
-		return this.text === other.text;
-	}
-
-	/**
 	 * Returns a string representation of the token.
 	 */
 	public override toString(): string {

--- a/src/vs/editor/common/codecs/markdownCodec/tokens/markdownComment.ts
+++ b/src/vs/editor/common/codecs/markdownCodec/tokens/markdownComment.ts
@@ -3,7 +3,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { BaseToken } from '../../baseToken.js';
 import { Range } from '../../../core/range.js';
 import { MarkdownToken } from './markdownToken.js';
 import { assert } from '../../../../../base/common/assert.js';
@@ -30,21 +29,6 @@ export class MarkdownComment extends MarkdownToken {
 	 */
 	public get hasEndMarker(): boolean {
 		return this.text.endsWith('-->');
-	}
-
-	/**
-	 * Check if this token is equal to another one.
-	 */
-	public override equals<T extends BaseToken>(other: T): boolean {
-		if (!super.sameRange(other.range)) {
-			return false;
-		}
-
-		if (!(other instanceof MarkdownComment)) {
-			return false;
-		}
-
-		return this.text === other.text;
 	}
 
 	/**

--- a/src/vs/editor/common/codecs/markdownCodec/tokens/markdownImage.ts
+++ b/src/vs/editor/common/codecs/markdownCodec/tokens/markdownImage.ts
@@ -3,7 +3,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { BaseToken } from '../../baseToken.js';
 import { MarkdownToken } from './markdownToken.js';
 import { IRange, Range } from '../../../core/range.js';
 import { assert } from '../../../../../base/common/assert.js';
@@ -93,21 +92,6 @@ export class MarkdownImage extends MarkdownToken {
 	 */
 	public get path(): string {
 		return this.reference.slice(1, this.reference.length - 1);
-	}
-
-	/**
-	 * Check if this token is equal to another one.
-	 */
-	public override equals<T extends BaseToken>(other: T): boolean {
-		if (!super.sameRange(other.range)) {
-			return false;
-		}
-
-		if (!(other instanceof MarkdownImage)) {
-			return false;
-		}
-
-		return this.text === other.text;
 	}
 
 	/**

--- a/src/vs/editor/common/codecs/markdownCodec/tokens/markdownLink.ts
+++ b/src/vs/editor/common/codecs/markdownCodec/tokens/markdownLink.ts
@@ -3,7 +3,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { BaseToken } from '../../baseToken.js';
 import { MarkdownToken } from './markdownToken.js';
 import { IRange, Range } from '../../../core/range.js';
 import { assert } from '../../../../../base/common/assert.js';
@@ -88,21 +87,6 @@ export class MarkdownLink extends MarkdownToken {
 	 */
 	public get path(): string {
 		return this.reference.slice(1, this.reference.length - 1);
-	}
-
-	/**
-	 * Check if this token is equal to another one.
-	 */
-	public override equals<T extends BaseToken>(other: T): boolean {
-		if (!super.sameRange(other.range)) {
-			return false;
-		}
-
-		if (!(other instanceof MarkdownLink)) {
-			return false;
-		}
-
-		return this.text === other.text;
 	}
 
 	/**

--- a/src/vs/editor/common/codecs/markdownExtensionsCodec/tokens/frontMatterHeader.ts
+++ b/src/vs/editor/common/codecs/markdownExtensionsCodec/tokens/frontMatterHeader.ts
@@ -50,25 +50,6 @@ export class FrontMatterHeader extends MarkdownExtensionsToken {
 	}
 
 	/**
-	 * Check if this token is equal to another one.
-	 */
-	public override equals<T extends BaseToken>(other: T): boolean {
-		if (!super.sameRange(other.range)) {
-			return false;
-		}
-
-		if (!(other instanceof FrontMatterHeader)) {
-			return false;
-		}
-
-		if (this.text.length !== other.text.length) {
-			return false;
-		}
-
-		return (this.text === other.text);
-	}
-
-	/**
 	 * Create new instance of the token from the given tokens.
 	 */
 	public static fromTokens(

--- a/src/vs/editor/common/codecs/simpleCodec/tokens/word.ts
+++ b/src/vs/editor/common/codecs/simpleCodec/tokens/word.ts
@@ -49,21 +49,6 @@ export class Word extends BaseToken {
 	}
 
 	/**
-	 * Check if this token is equal to another one.
-	 */
-	public override equals<T extends BaseToken>(other: T): boolean {
-		if (!super.equals(other)) {
-			return false;
-		}
-
-		if (!(other instanceof Word)) {
-			return false;
-		}
-
-		return this.text === other.text;
-	}
-
-	/**
 	 * Returns a string representation of the token.
 	 */
 	public override toString(): string {

--- a/src/vs/editor/test/common/codecs/baseToken.test.ts
+++ b/src/vs/editor/test/common/codecs/baseToken.test.ts
@@ -202,4 +202,148 @@ suite('BaseToken', () => {
 			});
 		});
 	});
+
+	suite('• equals()', () => {
+		suite('• false', () => {
+			test('• different constructor', () => {
+				test('• same base class', () => {
+					class TestToken1 extends BaseToken {
+						public override get text(): string {
+							throw new Error('Method not implemented.');
+						}
+
+						public override toString(): string {
+							throw new Error('Method not implemented.');
+						}
+					}
+
+					class TestToken2 extends BaseToken {
+						public override get text(): string {
+							throw new Error('Method not implemented.');
+						}
+
+						public override toString(): string {
+							throw new Error('Method not implemented.');
+						}
+					}
+
+					const range = randomRange();
+					const token1 = new TestToken1(range);
+					const token2 = new TestToken2(range);
+
+					assert.strictEqual(
+						token1.equals(token2),
+						false,
+						`Token of type '${token1.constructor.name}' must not be equal to token of type '${token2.constructor.name}'.`,
+					);
+
+					assert.strictEqual(
+						token2.equals(token1),
+						false,
+						`Token of type '${token2.constructor.name}' must not be equal to token of type '${token1.constructor.name}'.`,
+					);
+				});
+			});
+
+			test('• child', () => {
+				class TestToken1 extends BaseToken {
+					public override get text(): string {
+						throw new Error('Method not implemented.');
+					}
+
+					public override toString(): string {
+						throw new Error('Method not implemented.');
+					}
+				}
+
+				class TestToken2 extends TestToken1 {
+					constructor(
+						range: Range,
+					) {
+						super(range);
+					}
+				}
+
+				const range = randomRange();
+				const token1 = new TestToken1(range);
+				const token2 = new TestToken2(range);
+
+				assert.strictEqual(
+					token1.equals(token2),
+					false,
+					`Token of type '${token1.constructor.name}' must not be equal to token of type '${token2.constructor.name}'.`,
+				);
+
+				assert.strictEqual(
+					token2.equals(token1),
+					false,
+					`Token of type '${token2.constructor.name}' must not be equal to token of type '${token1.constructor.name}'.`,
+				);
+			});
+
+			test('• different text', () => {
+				class TestToken extends BaseToken {
+					constructor(
+						private readonly value: string,
+					) {
+						super(new Range(1, 1, 1, 1 + value.length));
+					}
+
+					public override get text(): string {
+						return this.value;
+					}
+
+					public override toString(): string {
+						throw new Error('Method not implemented.');
+					}
+				}
+
+				const token1 = new TestToken('text1');
+				const token2 = new TestToken('text2');
+
+				assert.strictEqual(
+					token1.equals(token2),
+					false,
+					`Token of type '${token1.constructor.name}' must not be equal to token of type '${token2.constructor.name}'.`,
+				);
+
+				assert.strictEqual(
+					token2.equals(token1),
+					false,
+					`Token of type '${token2.constructor.name}' must not be equal to token of type '${token1.constructor.name}'.`,
+				);
+			});
+
+			test('• different range', () => {
+				class TestToken extends BaseToken {
+					public override get text(): string {
+						return 'some text value';
+					}
+
+					public override toString(): string {
+						throw new Error('Method not implemented.');
+					}
+				}
+
+				const range1 = randomRange();
+				const token1 = new TestToken(range1);
+
+				// TODO: @legomushroom - generate range different from the one of token1
+				const range2 = randomRange();
+				const token2 = new TestToken(range2);
+
+				assert.strictEqual(
+					token1.equals(token2),
+					false,
+					`Token of type '${token1.constructor.name}' must not be equal to token of type '${token2.constructor.name}'.`,
+				);
+
+				assert.strictEqual(
+					token2.equals(token1),
+					false,
+					`Token of type '${token2.constructor.name}' must not be equal to token of type '${token1.constructor.name}'.`,
+				);
+			});
+		});
+	});
 });

--- a/src/vs/editor/test/common/codecs/tokens/baseToken.test.ts
+++ b/src/vs/editor/test/common/codecs/tokens/baseToken.test.ts
@@ -1,0 +1,534 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { Range } from '../../../../common/core/range.js';
+import { randomInt } from '../../../../../base/common/numbers.js';
+import { BaseToken } from '../../../../common/codecs/baseToken.js';
+import { assertDefined } from '../../../../../base/common/types.js';
+import { randomBoolean } from '../../../../../base/test/common/testUtils.js';
+import { NewLine } from '../../../../common/codecs/linesCodec/tokens/newLine.js';
+import { CarriageReturn } from '../../../../common/codecs/linesCodec/tokens/carriageReturn.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { TSimpleToken, WELL_KNOWN_TOKENS } from '../../../../common/codecs/simpleCodec/simpleDecoder.js';
+import { ISimpleTokenClass, SimpleToken } from '../../../../common/codecs/simpleCodec/tokens/simpleToken.js';
+import { At, Colon, DollarSign, ExclamationMark, Hash, LeftAngleBracket, LeftBracket, LeftCurlyBrace, RightAngleBracket, RightBracket, RightCurlyBrace, Slash, Space, Word } from '../../../../common/codecs/simpleCodec/tokens/index.js';
+
+/**
+ * Generates a random {@link Range} object.
+ *
+ * @throws if {@link maxNumber} argument is less than `2`,
+ *         is equal to `NaN` or is `infinite`.
+ */
+const randomRange = (
+	maxNumber: number = 1_000,
+): Range => {
+	assert(
+		maxNumber > 1,
+		`Max number must be greater than 1, got '${maxNumber}'.`,
+	);
+
+	const startLineNumber = randomInt(maxNumber, 1);
+	const endLineNumber = (randomBoolean() === true)
+		? startLineNumber
+		: randomInt(2 * maxNumber, startLineNumber);
+
+	const startColumnNumber = randomInt(maxNumber, 1);
+	const endColumnNumber = (randomBoolean() === true)
+		? startColumnNumber + 1
+		: randomInt(2 * maxNumber, startColumnNumber + 1);
+
+	return new Range(
+		startLineNumber,
+		startColumnNumber,
+		endLineNumber,
+		endColumnNumber,
+	);
+};
+
+/**
+ * Generates a random {@link Range} object that is different
+ * from the provided one.
+ */
+const randomRangeNotEqualTo = (
+	differentFrom: Range,
+	maxTries: number = 10,
+): Range => {
+	let retriesLeft = maxTries;
+
+	while (retriesLeft-- > 0) {
+		const range = randomRange();
+		if (range.equalsRange(differentFrom) === false) {
+			return range;
+		}
+	}
+
+	throw new Error(
+		`Failed to generate a random range different from '${differentFrom}' in ${maxTries} tries.`,
+	);
+};
+
+/**
+ * List of simple tokens to randomly select from
+ * in the {@link randomSimpleToken} utility.
+ */
+const TOKENS: readonly ISimpleTokenClass<TSimpleToken>[] = Object.freeze([
+	...WELL_KNOWN_TOKENS,
+	CarriageReturn,
+	NewLine,
+]);
+
+/**
+ * Generates a random {@link SimpleToken} instance.
+ */
+const randomSimpleToken = (): TSimpleToken => {
+	const index = randomInt(TOKENS.length - 1);
+
+	const Constructor = TOKENS[index];
+	assertDefined(
+		Constructor,
+		`Cannot find a constructor object for a well-known token at index '${index}'.`,
+	);
+
+	return new Constructor(randomRange());
+};
+
+suite('BaseToken', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	suite('• render()', () => {
+		/**
+		 * Note! Range of tokens is ignored by the render method, hence
+		 *       we generate random ranges for each token in this test.
+		 */
+		test('• a list of tokens', () => {
+			const tests: readonly [string, BaseToken[]][] = [
+				['/textoftheword$#', [
+					new Slash(randomRange()),
+					new Word(randomRange(), 'textoftheword'),
+					new DollarSign(randomRange()),
+					new Hash(randomRange()),
+				]],
+				['<:👋helou👋:>', [
+					new LeftAngleBracket(randomRange()),
+					new Colon(randomRange()),
+					new Word(randomRange(), '👋helou👋'),
+					new Colon(randomRange()),
+					new RightAngleBracket(randomRange()),
+				]],
+				[' {$#[ !@! ]#$} ', [
+					new Space(randomRange()),
+					new LeftCurlyBrace(randomRange()),
+					new DollarSign(randomRange()),
+					new Hash(randomRange()),
+					new LeftBracket(randomRange()),
+					new Space(randomRange()),
+					new ExclamationMark(randomRange()),
+					new At(randomRange()),
+					new ExclamationMark(randomRange()),
+					new Space(randomRange()),
+					new RightBracket(randomRange()),
+					new Hash(randomRange()),
+					new DollarSign(randomRange()),
+					new RightCurlyBrace(randomRange()),
+					new Space(randomRange()),
+				]],
+			];
+
+			for (const test of tests) {
+				const [expectedText, tokens] = test;
+
+				assert.strictEqual(
+					expectedText,
+					BaseToken.render(tokens),
+				);
+			}
+		});
+
+		test('• an empty list of tokens', () => {
+			assert.strictEqual(
+				'',
+				BaseToken.render([]),
+				`Must correctly render and empty list of tokens.`,
+			);
+		});
+	});
+
+	suite('• fullRange()', () => {
+		suite('• throws', () => {
+			test('• if empty list provided', () => {
+				assert.throws(() => {
+					BaseToken.fullRange([]);
+				});
+			});
+
+			test('• if start line number of the first token is greater than one of the last token', () => {
+				assert.throws(() => {
+					const lastToken = randomSimpleToken();
+
+					// generate a first token with starting line number that is
+					// greater than the start line number of the last token
+					const startLineNumber = lastToken.range.startLineNumber + randomInt(10, 1);
+					const firstToken = new Colon(
+						new Range(
+							startLineNumber,
+							lastToken.range.startColumn,
+							startLineNumber,
+							lastToken.range.startColumn + 1,
+						),
+					);
+
+					BaseToken.fullRange([
+						firstToken,
+						// tokens in the middle are ignored, so we
+						// generate random ones to fill the gap
+						randomSimpleToken(),
+						randomSimpleToken(),
+						randomSimpleToken(),
+						randomSimpleToken(),
+						randomSimpleToken(),
+						// -
+						lastToken,
+					]);
+				});
+			});
+
+			test('• if start line numbers are equal and end of the first token is greater than the start of the last token', () => {
+				assert.throws(() => {
+					const firstToken = randomSimpleToken();
+
+					const lastToken = new Hash(
+						new Range(
+							firstToken.range.startLineNumber,
+							firstToken.range.endColumn - 1,
+							firstToken.range.startLineNumber + randomInt(10),
+							firstToken.range.endColumn,
+						),
+					);
+
+					BaseToken.fullRange([
+						firstToken,
+						// tokens in the middle are ignored, so we
+						// generate random ones to fill the gap
+						randomSimpleToken(),
+						randomSimpleToken(),
+						randomSimpleToken(),
+						randomSimpleToken(),
+						randomSimpleToken(),
+						// -
+						lastToken,
+					]);
+				});
+			});
+		});
+	});
+
+	suite('• withRange()', () => {
+		test('• updates token range', () => {
+			class TestToken extends BaseToken {
+				public override get text(): string {
+					throw new Error('Method not implemented.');
+				}
+				public override toString(): string {
+					throw new Error('Method not implemented.');
+				}
+			}
+
+			const rangeBefore = randomRange();
+			const token = new TestToken(rangeBefore);
+
+			assert(
+				token.range.equalsRange(rangeBefore),
+				'Token range must be unchanged before updating.',
+			);
+
+			const rangeAfter = randomRangeNotEqualTo(rangeBefore);
+			token.withRange(rangeAfter);
+
+			assert(
+				token.range.equalsRange(rangeAfter),
+				`Token range must be to the new '${rangeAfter}' one.`,
+			);
+		});
+	});
+
+	suite('• equals()', () => {
+		test('• true', () => {
+			class TestToken extends BaseToken {
+				constructor(
+					range: Range,
+					private readonly value: string,
+				) {
+					super(range);
+				}
+				public override get text(): string {
+					return this.value;
+				}
+
+				public override toString(): string {
+					throw new Error('Method not implemented.');
+				}
+			}
+			const text = 'contents';
+
+			const startLineNumber = randomInt(100, 1);
+			const startColumnNumber = randomInt(100, 1);
+			const range = new Range(
+				startLineNumber,
+				startColumnNumber,
+				startLineNumber,
+				startColumnNumber + text.length,
+			);
+
+			const token1 = new TestToken(range, text);
+			const token2 = new TestToken(range, text);
+
+			assert(
+				token1.equals(token2),
+				`Token of type '${token1.constructor.name}' must be equal to token of type '${token2.constructor.name}'.`,
+			);
+
+			assert(
+				token2.equals(token1),
+				`Token of type '${token2.constructor.name}' must be equal to token of type '${token1.constructor.name}'.`,
+			);
+		});
+
+		suite('• false', () => {
+			suite('• different constructor', () => {
+				test('• same base class', () => {
+					class TestToken1 extends BaseToken {
+						public override get text(): string {
+							throw new Error('Method not implemented.');
+						}
+
+						public override toString(): string {
+							throw new Error('Method not implemented.');
+						}
+					}
+
+					class TestToken2 extends BaseToken {
+						public override get text(): string {
+							throw new Error('Method not implemented.');
+						}
+
+						public override toString(): string {
+							throw new Error('Method not implemented.');
+						}
+					}
+
+					const range = randomRange();
+					const token1 = new TestToken1(range);
+					const token2 = new TestToken2(range);
+
+					assert.strictEqual(
+						token1.equals(token2),
+						false,
+						`Token of type '${token1.constructor.name}' must not be equal to token of type '${token2.constructor.name}'.`,
+					);
+
+					assert.strictEqual(
+						token2.equals(token1),
+						false,
+						`Token of type '${token2.constructor.name}' must not be equal to token of type '${token1.constructor.name}'.`,
+					);
+				});
+
+				test('• child', () => {
+					class TestToken1 extends BaseToken {
+						public override get text(): string {
+							throw new Error('Method not implemented.');
+						}
+
+						public override toString(): string {
+							throw new Error('Method not implemented.');
+						}
+					}
+
+					class TestToken2 extends TestToken1 { }
+
+					const range = randomRange();
+					const token1 = new TestToken1(range);
+					const token2 = new TestToken2(range);
+
+					assert.strictEqual(
+						token1.equals(token2),
+						false,
+						`Token of type '${token1.constructor.name}' must not be equal to token of type '${token2.constructor.name}'.`,
+					);
+
+					assert.strictEqual(
+						token2.equals(token1),
+						false,
+						`Token of type '${token2.constructor.name}' must not be equal to token of type '${token1.constructor.name}'.`,
+					);
+				});
+
+				test('• different direct ancestor', () => {
+					class TestToken1 extends BaseToken {
+						public override get text(): string {
+							throw new Error('Method not implemented.');
+						}
+
+						public override toString(): string {
+							throw new Error('Method not implemented.');
+						}
+					}
+
+					class TestToken3 extends BaseToken {
+						public override get text(): string {
+							throw new Error('Method not implemented.');
+						}
+
+						public override toString(): string {
+							throw new Error('Method not implemented.');
+						}
+					}
+
+					class TestToken2 extends TestToken3 { }
+
+					const range = randomRange();
+					const token1 = new TestToken1(range);
+					const token2 = new TestToken2(range);
+
+					assert.strictEqual(
+						token1.equals(token2),
+						false,
+						`Token of type '${token1.constructor.name}' must not be equal to token of type '${token2.constructor.name}'.`,
+					);
+
+					assert.strictEqual(
+						token2.equals(token1),
+						false,
+						`Token of type '${token2.constructor.name}' must not be equal to token of type '${token1.constructor.name}'.`,
+					);
+				});
+			});
+
+			test('• different text', () => {
+				class TestToken extends BaseToken {
+					constructor(
+						private readonly value: string,
+					) {
+						super(new Range(1, 1, 1, 1 + value.length));
+					}
+
+					public override get text(): string {
+						return this.value;
+					}
+
+					public override toString(): string {
+						throw new Error('Method not implemented.');
+					}
+				}
+
+				const token1 = new TestToken('text1');
+				const token2 = new TestToken('text2');
+
+				assert.strictEqual(
+					token1.equals(token2),
+					false,
+					`Token of type '${token1.constructor.name}' must not be equal to token of type '${token2.constructor.name}'.`,
+				);
+
+				assert.strictEqual(
+					token2.equals(token1),
+					false,
+					`Token of type '${token2.constructor.name}' must not be equal to token of type '${token1.constructor.name}'.`,
+				);
+			});
+
+			test('• different range', () => {
+				class TestToken extends BaseToken {
+					public override get text(): string {
+						return 'some text value';
+					}
+
+					public override toString(): string {
+						throw new Error('Method not implemented.');
+					}
+				}
+
+				const range1 = randomRange();
+				const token1 = new TestToken(range1);
+
+				const range2 = randomRangeNotEqualTo(range1);
+				const token2 = new TestToken(range2);
+
+				assert.strictEqual(
+					token1.equals(token2),
+					false,
+					`Token of type '${token1.constructor.name}' must not be equal to token of type '${token2.constructor.name}'.`,
+				);
+
+				assert.strictEqual(
+					token2.equals(token1),
+					false,
+					`Token of type '${token2.constructor.name}' must not be equal to token of type '${token1.constructor.name}'.`,
+				);
+			});
+		});
+	});
+
+	suite('• collapseRangeToStart()', () => {
+		test('• collapses token range to the start position', () => {
+			class TestToken extends BaseToken {
+				public override get text(): string {
+					throw new Error('Method not implemented.');
+				}
+				public override toString(): string {
+					throw new Error('Method not implemented.');
+				}
+			}
+
+			const startLineNumber = randomInt(10, 1);
+			const startColumnNumber = randomInt(10, 1);
+			const range = new Range(
+				startLineNumber,
+				startColumnNumber,
+				startLineNumber + randomInt(10, 1),
+				startColumnNumber + randomInt(10, 1),
+			);
+
+			const token = new TestToken(range);
+
+			assert(
+				token.range.isEmpty() === false,
+				'Token range must not be empty before collapsing.',
+			);
+
+			token.collapseRangeToStart();
+
+			assert(
+				token.range.isEmpty(),
+				'Token range must be empty after collapsing.',
+			);
+
+			assert.strictEqual(
+				token.range.startLineNumber,
+				startLineNumber,
+				'Token range start line number must not change.',
+			);
+
+			assert.strictEqual(
+				token.range.startColumn,
+				startColumnNumber,
+				'Token range start column number must not change.',
+			);
+
+			assert.strictEqual(
+				token.range.endLineNumber,
+				startLineNumber,
+				'Token range end line number must be equal to line start number.',
+			);
+
+			assert.strictEqual(
+				token.range.endColumn,
+				startColumnNumber,
+				'Token range end column number must be equal to column start number.',
+			);
+		});
+	});
+});

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/codecs/tokens/fileReference.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/codecs/tokens/fileReference.ts
@@ -7,7 +7,6 @@
 import { PromptVariableWithData } from './promptVariable.js';
 import { assert } from '../../../../../../../base/common/assert.js';
 import { IRange, Range } from '../../../../../../../editor/common/core/range.js';
-import { BaseToken } from '../../../../../../../editor/common/codecs/baseToken.js';
 
 /**
  * Name of the variable.
@@ -39,17 +38,6 @@ export class FileReference extends PromptVariableWithData {
 			variable.range,
 			variable.data,
 		);
-	}
-
-	/**
-	 * Check if this token is equal to another one.
-	 */
-	public override equals<T extends BaseToken>(other: T): boolean {
-		if ((other instanceof FileReference) === false) {
-			return false;
-		}
-
-		return super.equals(other);
 	}
 
 	/**

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/codecs/tokens/promptAtMention.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/codecs/tokens/promptAtMention.ts
@@ -6,7 +6,6 @@
 import { PromptToken } from './promptToken.js';
 import { assert } from '../../../../../../../base/common/assert.js';
 import { Range } from '../../../../../../../editor/common/core/range.js';
-import { BaseToken } from '../../../../../../../editor/common/codecs/baseToken.js';
 import { INVALID_NAME_CHARACTERS, STOP_CHARACTERS } from '../parsers/promptVariableParser.js';
 
 /**
@@ -42,25 +41,6 @@ export class PromptAtMention extends PromptToken {
 	 */
 	public get text(): string {
 		return `${START_CHARACTER}${this.name}`;
-	}
-
-	/**
-	 * Check if this token is equal to another one.
-	 */
-	public override equals<T extends BaseToken>(other: T): boolean {
-		if (!super.sameRange(other.range)) {
-			return false;
-		}
-
-		if ((other instanceof PromptAtMention) === false) {
-			return false;
-		}
-
-		if (this.text.length !== other.text.length) {
-			return false;
-		}
-
-		return this.text === other.text;
 	}
 
 	/**

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/codecs/tokens/promptSlashCommand.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/codecs/tokens/promptSlashCommand.ts
@@ -6,7 +6,6 @@
 import { PromptToken } from './promptToken.js';
 import { assert } from '../../../../../../../base/common/assert.js';
 import { Range } from '../../../../../../../editor/common/core/range.js';
-import { BaseToken } from '../../../../../../../editor/common/codecs/baseToken.js';
 import { INVALID_NAME_CHARACTERS, STOP_CHARACTERS } from '../parsers/promptSlashCommandParser.js';
 
 /**
@@ -42,25 +41,6 @@ export class PromptSlashCommand extends PromptToken {
 	 */
 	public get text(): string {
 		return `${START_CHARACTER}${this.name}`;
-	}
-
-	/**
-	 * Check if this token is equal to another one.
-	 */
-	public override equals<T extends BaseToken>(other: T): boolean {
-		if (!super.sameRange(other.range)) {
-			return false;
-		}
-
-		if ((other instanceof PromptSlashCommand) === false) {
-			return false;
-		}
-
-		if (this.text.length !== other.text.length) {
-			return false;
-		}
-
-		return this.text === other.text;
 	}
 
 	/**

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/codecs/tokens/promptTemplateVariable.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/codecs/tokens/promptTemplateVariable.ts
@@ -5,7 +5,6 @@
 
 import { PromptToken } from './promptToken.js';
 import { Range } from '../../../../../../../editor/common/core/range.js';
-import { BaseToken } from '../../../../../../../editor/common/codecs/baseToken.js';
 import { DollarSign } from '../../../../../../../editor/common/codecs/simpleCodec/tokens/dollarSign.js';
 import { LeftCurlyBrace, RightCurlyBrace } from '../../../../../../../editor/common/codecs/simpleCodec/tokens/curlyBraces.js';
 
@@ -34,25 +33,6 @@ export class PromptTemplateVariable extends PromptToken {
 			this.contents,
 			RightCurlyBrace.symbol,
 		].join('');
-	}
-
-	/**
-	 * Check if this token is equal to another one.
-	 */
-	public override equals<T extends BaseToken>(other: T): boolean {
-		if (!super.sameRange(other.range)) {
-			return false;
-		}
-
-		if ((other instanceof PromptTemplateVariable) === false) {
-			return false;
-		}
-
-		if (this.text.length !== other.text.length) {
-			return false;
-		}
-
-		return this.text === other.text;
 	}
 
 	/**

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/codecs/tokens/promptVariable.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/codecs/tokens/promptVariable.ts
@@ -6,7 +6,6 @@
 import { PromptToken } from './promptToken.js';
 import { assert } from '../../../../../../../base/common/assert.js';
 import { IRange, Range } from '../../../../../../../editor/common/core/range.js';
-import { BaseToken } from '../../../../../../../editor/common/codecs/baseToken.js';
 import { INVALID_NAME_CHARACTERS, STOP_CHARACTERS } from '../parsers/promptVariableParser.js';
 
 /**
@@ -50,25 +49,6 @@ export class PromptVariable extends PromptToken {
 	}
 
 	/**
-	 * Check if this token is equal to another one.
-	 */
-	public override equals<T extends BaseToken>(other: T): boolean {
-		if (!super.sameRange(other.range)) {
-			return false;
-		}
-
-		if ((other instanceof PromptVariable) === false) {
-			return false;
-		}
-
-		if (this.text.length !== other.text.length) {
-			return false;
-		}
-
-		return this.text === other.text;
-	}
-
-	/**
 	 * Return a string representation of the token.
 	 */
 	public override toString(): string {
@@ -109,17 +89,6 @@ export class PromptVariableWithData extends PromptVariable {
 	 */
 	public override get text(): string {
 		return `${START_CHARACTER}${this.name}${DATA_SEPARATOR}${this.data}`;
-	}
-
-	/**
-	 * Check if this token is equal to another one.
-	 */
-	public override equals<T extends BaseToken>(other: T): boolean {
-		if ((other instanceof PromptVariableWithData) === false) {
-			return false;
-		}
-
-		return super.equals(other);
 	}
 
 	/**

--- a/src/vs/workbench/contrib/chat/test/common/promptSyntax/codecs/chatPromptCodec.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/promptSyntax/codecs/chatPromptCodec.test.ts
@@ -8,9 +8,9 @@ import { Range } from '../../../../../../../editor/common/core/range.js';
 import { newWriteableStream } from '../../../../../../../base/common/stream.js';
 import { TestDecoder } from '../../../../../../../editor/test/common/utils/testDecoder.js';
 import { ChatPromptCodec } from '../../../../common/promptSyntax/codecs/chatPromptCodec.js';
-import { FileReference } from '../../../../common/promptSyntax/codecs/tokens/fileReference.js';
 import { NewLine } from '../../../../../../../editor/common/codecs/linesCodec/tokens/newLine.js';
 import { Space, Tab, Word } from '../../../../../../../editor/common/codecs/simpleCodec/tokens/index.js';
+import { PromptVariableWithData } from '../../../../common/promptSyntax/codecs/tokens/promptVariable.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../../base/test/common/utils.js';
 import { ChatPromptDecoder, TChatPromptToken } from '../../../../common/promptSyntax/codecs/chatPromptDecoder.js';
 
@@ -28,8 +28,9 @@ import { ChatPromptDecoder, TChatPromptToken } from '../../../../common/promptSy
  * await test.run(
  *   ' hello #file:./some-file.md world\n',
  *   [
- *     new FileReference(
+ *     new PromptVariableWithData(
  *       new Range(1, 8, 1, 28),
+ *       'file',
  *       './some-file.md',
  *     ),
  *   ]
@@ -54,8 +55,9 @@ suite('ChatPromptCodec', () => {
 			'#file:/etc/hosts some text\t\n  for #file:./README.md\t testing\n ✔ purposes\n#file:LICENSE.md ✌ \t#file:.gitignore\n\n\n\t   #file:/Users/legomushroom/repos/vscode   \n\nsomething #file:\tsomewhere\n',
 			[
 				// reference
-				new FileReference(
+				new PromptVariableWithData(
 					new Range(1, 1, 1, 1 + 16),
+					'file',
 					'/etc/hosts',
 				),
 				new Space(new Range(1, 17, 1, 17 + 1)),
@@ -69,8 +71,9 @@ suite('ChatPromptCodec', () => {
 				new Word(new Range(2, 3, 2, 3 + 3), 'for'),
 				new Space(new Range(2, 6, 2, 6 + 1)),
 				// reference
-				new FileReference(
+				new PromptVariableWithData(
 					new Range(2, 7, 2, 7 + 17),
+					'file',
 					'./README.md',
 				),
 				new Tab(new Range(2, 24, 2, 24 + 1)),
@@ -83,8 +86,9 @@ suite('ChatPromptCodec', () => {
 				new Word(new Range(3, 4, 3, 4 + 8), 'purposes'),
 				new NewLine(new Range(3, 12, 3, 12 + 1)),
 				// reference
-				new FileReference(
+				new PromptVariableWithData(
 					new Range(4, 1, 4, 1 + 16),
+					'file',
 					'LICENSE.md',
 				),
 				new Space(new Range(4, 17, 4, 17 + 1)),
@@ -92,8 +96,9 @@ suite('ChatPromptCodec', () => {
 				new Space(new Range(4, 19, 4, 19 + 1)),
 				new Tab(new Range(4, 20, 4, 20 + 1)),
 				// reference
-				new FileReference(
+				new PromptVariableWithData(
 					new Range(4, 21, 4, 21 + 16),
+					'file',
 					'.gitignore',
 				),
 				new NewLine(new Range(4, 37, 4, 37 + 1)),
@@ -104,8 +109,9 @@ suite('ChatPromptCodec', () => {
 				new Space(new Range(7, 3, 7, 3 + 1)),
 				new Space(new Range(7, 4, 7, 4 + 1)),
 				// reference
-				new FileReference(
+				new PromptVariableWithData(
 					new Range(7, 5, 7, 5 + 38),
+					'file',
 					'/Users/legomushroom/repos/vscode',
 				),
 				new Space(new Range(7, 43, 7, 43 + 1)),
@@ -116,8 +122,9 @@ suite('ChatPromptCodec', () => {
 				new Word(new Range(9, 1, 9, 1 + 9), 'something'),
 				new Space(new Range(9, 10, 9, 10 + 1)),
 				// reference
-				new FileReference(
+				new PromptVariableWithData(
 					new Range(9, 11, 9, 11 + 6),
+					'file',
 					'',
 				),
 				new Tab(new Range(9, 17, 9, 17 + 1)),

--- a/src/vs/workbench/contrib/chat/test/common/promptSyntax/codecs/chatPromptDecoder.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/promptSyntax/codecs/chatPromptDecoder.test.ts
@@ -7,7 +7,6 @@ import { VSBuffer } from '../../../../../../../base/common/buffer.js';
 import { Range } from '../../../../../../../editor/common/core/range.js';
 import { newWriteableStream } from '../../../../../../../base/common/stream.js';
 import { TestDecoder } from '../../../../../../../editor/test/common/utils/testDecoder.js';
-import { FileReference } from '../../../../common/promptSyntax/codecs/tokens/fileReference.js';
 import { NewLine } from '../../../../../../../editor/common/codecs/linesCodec/tokens/newLine.js';
 import { PromptAtMention } from '../../../../common/promptSyntax/codecs/tokens/promptAtMention.js';
 import { PromptSlashCommand } from '../../../../common/promptSyntax/codecs/tokens/promptSlashCommand.js';
@@ -32,8 +31,9 @@ import { At, Dash, ExclamationMark, FormFeed, Hash, Space, Tab, VerticalTab, Wor
  * await test.run(
  *   ' hello #file:./some-file.md world\n',
  *   [
- *     new FileReference(
+ *     new PromptVariableWithData(
  *       new Range(1, 8, 1, 28),
+ *       'file',
  *       './some-file.md',
  *     ),
  *   ]
@@ -91,8 +91,9 @@ suite('ChatPromptDecoder', () => {
 				new Space(new Range(3, 12, 3, 13)),
 				new Word(new Range(3, 13, 3, 20), 'message'),
 				new Space(new Range(3, 20, 3, 21)),
-				new FileReference(
+				new PromptVariableWithData(
 					new Range(3, 21, 3, 21 + 24),
+					'file',
 					'./path/to/file1.md',
 				),
 				new NewLine(new Range(3, 45, 3, 46)),
@@ -110,15 +111,17 @@ suite('ChatPromptDecoder', () => {
 				// sixth line
 				new Space(new Range(6, 1, 6, 2)),
 				new Tab(new Range(6, 2, 6, 3)),
-				new FileReference(
+				new PromptVariableWithData(
 					new Range(6, 3, 6, 3 + 24),
+					'file',
 					'a/b/c/filename2.md',
 				),
 				new Tab(new Range(6, 27, 6, 28)),
 				new Word(new Range(6, 28, 6, 30), '🖖'),
 				new Tab(new Range(6, 30, 6, 31)),
-				new FileReference(
+				new PromptVariableWithData(
 					new Range(6, 31, 6, 31 + 19),
+					'file',
 					'other-file.md',
 				),
 				new NewLine(new Range(6, 50, 6, 51)),
@@ -134,8 +137,9 @@ suite('ChatPromptDecoder', () => {
 				new Space(new Range(7, 42, 7, 43)),
 				new Word(new Range(7, 43, 7, 43 + 4), 'text'),
 				new Space(new Range(7, 47, 7, 48)),
-				new FileReference(
+				new PromptVariableWithData(
 					new Range(7, 48, 7, 48 + 38),
+					'file',
 					'/some/file/with/absolute/path.md',
 				),
 				new NewLine(new Range(7, 86, 7, 87)),
@@ -149,8 +153,9 @@ suite('ChatPromptDecoder', () => {
 				new Space(new Range(8, 10, 8, 11)),
 				new Word(new Range(8, 11, 8, 11 + 4), 'text'),
 				new Space(new Range(8, 15, 8, 16)),
-				new FileReference(
+				new PromptVariableWithData(
 					new Range(8, 16, 8, 16 + 6),
+					'file',
 					'',
 				),
 				new Space(new Range(8, 22, 8, 23)),


### PR DESCRIPTION
Refactors the `equals()` method on all token classes, adds appropriate test coverage.