### PR TITLE
[prompts][debt]: make unit test less flaky

### DIFF
--- a/src/vs/workbench/contrib/chat/test/common/promptSyntax/contentProviders/filePromptContentsProvider.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/promptSyntax/contentProviders/filePromptContentsProvider.test.ts
@@ -25,6 +25,11 @@ import { InMemoryFileSystemProvider } from '../../../../../../../platform/files/
 import { FilePromptContentProvider } from '../../../../common/promptSyntax/contentProviders/filePromptContentsProvider.js';
 import { TestInstantiationService } from '../../../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
 
+/**
+ * Timeout to wait for the content changed event to be emitted.
+ */
+const CONTENT_CHANGED_TIMEOUT = 50;
+
 suite('FilePromptContentsProvider', () => {
 	const testDisposables = ensureNoDisposablesAreLeakedInTestSuite();
 
@@ -73,7 +78,7 @@ suite('FilePromptContentsProvider', () => {
 		}));
 		contentsProvider.start();
 
-		await wait(25);
+		await wait(CONTENT_CHANGED_TIMEOUT);
 
 		assertDefined(
 			streamOrError,
@@ -131,7 +136,7 @@ suite('FilePromptContentsProvider', () => {
 				}));
 				contentsProvider.start();
 
-				await wait(25);
+				await wait(CONTENT_CHANGED_TIMEOUT);
 
 				assertDefined(
 					streamOrError,
@@ -187,7 +192,7 @@ suite('FilePromptContentsProvider', () => {
 				}));
 				contentsProvider.start();
 
-				await wait(25);
+				await wait(CONTENT_CHANGED_TIMEOUT);
 
 				assertDefined(
 					streamOrError,
@@ -227,7 +232,7 @@ suite('FilePromptContentsProvider', () => {
 				}));
 				contentsProvider.start();
 
-				await wait(25);
+				await wait(CONTENT_CHANGED_TIMEOUT);
 
 				assertDefined(
 					streamOrError,


### PR DESCRIPTION
Bumps up the timeout to wait for the content changed event to be emitted to reduce unit test flakiness.

Related build: https://dev.azure.com/monacotools/Monaco/_build/results?buildId=335710&view=logs&j=2a81633e-e3f5-564c-d9b7-29d4c6c01530&t=1c35f05c-d451-522f-7181-861f09ccaca9&s=859b8d9a-8fd6-5a5c-6f5e-f84f1990894e