### PR TITLE
Git - disable "unstage selected ranges" and "unstage changes" commands in the editor/peek view

### DIFF
--- a/extensions/git/package.json
+++ b/extensions/git/package.json
@@ -977,7 +977,7 @@
         "command": "git.unstageSelectedRanges",
         "key": "ctrl+k ctrl+n",
         "mac": "cmd+k cmd+n",
-        "when": "editorTextFocus && isInDiffEditor && isInDiffRightEditor && (resourceScheme == file || resourceScheme == git)"
+        "when": "editorTextFocus && isInDiffEditor && isInDiffRightEditor && resourceScheme == git"
       },
       {
         "command": "git.revertSelectedRanges",
@@ -1082,7 +1082,7 @@
         },
         {
           "command": "git.unstageSelectedRanges",
-          "when": "config.git.enabled && !git.missing && gitOpenRepositoryCount != 0 && (resourceScheme == file || resourceScheme == git)"
+          "when": "config.git.enabled && !git.missing && gitOpenRepositoryCount != 0 && resourceScheme == git"
         },
         {
           "command": "git.unstageChange",

--- a/extensions/git/package.json
+++ b/extensions/git/package.json
@@ -2238,7 +2238,7 @@
         },
         {
           "command": "git.unstageChange",
-          "when": "config.git.enabled && !git.missing && originalResource =~ /^git\\:.*%22ref%22%3A%22HEAD%22%7D$/"
+          "when": "false"
         }
       ],
       "timeline/item/context": [


### PR DESCRIPTION
Related #248197