### PR TITLE
fix flaky unit test

### DIFF
--- a/src/vs/editor/test/common/codecs/tokens/compositeToken.test.ts
+++ b/src/vs/editor/test/common/codecs/tokens/compositeToken.test.ts
@@ -228,12 +228,12 @@ suite('CompositeToken', () => {
 				// ensure there is at least one composite token
 				const lastToken = tokens[tokens.length - 1];
 				const compositeToken1 = new TestToken(randomTokens(
-					randomInt(5, 2),
+					randomInt(3, 1),
 					lastToken.range.endLineNumber,
 					lastToken.range.endColumn,
 				));
 				const compositeToken2 = new TestToken(randomTokens(
-					randomInt(5, 2),
+					randomInt(6, 4),
 					lastToken.range.endLineNumber,
 					lastToken.range.endColumn,
 				));


### PR DESCRIPTION
Ensures that randomly generated composite tokens are always different in the unit test.

For https://github.com/microsoft/vscode/issues/248214