### PR TITLE
ESM improvements for hybrid extensions

### DIFF
--- a/src/vs/workbench/api/common/extHostExtensionService.ts
+++ b/src/vs/workbench/api/common/extHostExtensionService.ts
@@ -1087,7 +1087,7 @@ export abstract class AbstractExtHostExtensionService extends Disposable impleme
 	}
 
 	protected _isESM(extensionDescription: IExtensionDescription | undefined, modulePath?: string): boolean {
-		modulePath ??= extensionDescription?.main;
+		modulePath ??= extensionDescription ? this._getEntryPoint(extensionDescription) : modulePath;
 		return modulePath?.endsWith('.mjs') || (extensionDescription?.type === 'module' && !modulePath?.endsWith('.cjs'));
 	}
 

--- a/src/vs/workbench/api/worker/extHostExtensionService.ts
+++ b/src/vs/workbench/api/worker/extHostExtensionService.ts
@@ -12,6 +12,7 @@ import { IExtensionDescription } from '../../../platform/extensions/common/exten
 import { ExtensionRuntime } from '../common/extHostTypes.js';
 import { timeout } from '../../../base/common/async.js';
 import { ExtHostConsoleForwarder } from './extHostConsoleForwarder.js';
+import { extname } from '../../../base/common/path.js';
 
 class WorkerRequireInterceptor extends RequireInterceptor {
 
@@ -147,5 +148,6 @@ export class ExtHostExtensionService extends AbstractExtHostExtensionService {
 }
 
 function ensureSuffix(path: string, suffix: string): string {
-	return path.endsWith(suffix) ? path : path + suffix;
+	const extName = extname(path);
+	return extName ? path : path + suffix;
 }


### PR DESCRIPTION
This PR makes it possible to have an extension that uses ESM for the NodeJS EH and CJS for the web worker EH.

A sample is the GH issue notebooks extension: https://github.com/microsoft/vscode-github-issue-notebooks/pull/185

re https://github.com/microsoft/vscode/issues/130367