### PR TITLE
Tidy up postinst script

### DIFF
--- a/resources/linux/debian/postinst.template
+++ b/resources/linux/debian/postinst.template
@@ -105,6 +105,9 @@ Components: main
 Architectures: amd64,arm64,armhf
 Signed-By: $CODE_TRUSTED_PART
 EOF
+			if [ -f "$CODE_SOURCE_PART" ]; then
+				rm -f "$CODE_SOURCE_PART"
+			fi
 		else
 			echo "### THIS FILE IS AUTOMATICALLY CONFIGURED ###
 # You may comment out this entry, but any other modifications may be lost.

--- a/resources/linux/debian/postinst.template
+++ b/resources/linux/debian/postinst.template
@@ -48,23 +48,17 @@ if [ "@@NAME@@" != "code-oss" ]; then
 	if [ "$RET" = 'false' ]; then
 		# The user specified in debconf not to add the Microsoft repository
 		WRITE_SOURCE='no'
-	elif [ -f "$CODE_SOURCE_PART_DEB822" ] && [ -f "$CODE_TRUSTED_PART" ]; then
-		# The user has migrated themselves to the DEB822 format
-		WRITE_SOURCE='no'
-	elif [ -f "$CODE_SOURCE_PART" ] && (grep -q "http://packages.microsoft.com/repos/vscode" $CODE_SOURCE_PART); then
-		# Migrate from old repository
+	elif [ -f "$CODE_SOURCE_PART" ]; then
+		# The user is not on the new DEB822 format
 		WRITE_SOURCE='yes'
-	elif [ -f "$CODE_SOURCE_PART" ] && (grep -q "http://packages.microsoft.com/repos/code" $CODE_SOURCE_PART); then
-		# Migrate from old repository
+	elif [ -f "$CODE_SOURCE_PART_DEB822" ]; then
+		# The user is on the new DEB822 format, but refresh the file contents
 		WRITE_SOURCE='yes'
-	elif apt-cache policy | grep -q "https://packages.microsoft.com/repos/code"; then
-		# The user is already on the new repository
+	elif [ -f /etc/rpi-issue ]; then
+		# Do not write on Raspberry Pi OS
+		# https://github.com/microsoft/vscode/issues/118825
 		WRITE_SOURCE='no'
-	elif [ ! -f $CODE_SOURCE_PART ] && [ ! -f /etc/rpi-issue ]; then
-		# Source list does not exist and we're not running on Raspberry Pi OS
-		WRITE_SOURCE='ask'
-	elif grep -q "# disabled on upgrade to" $CODE_SOURCE_PART; then
-		# Source list was disabled by OS upgrade
+	else
 		WRITE_SOURCE='ask'
 	fi
 


### PR DESCRIPTION
Ref https://github.com/microsoft/vscode/issues/238697

This PR simplifies the WRITE_SOURCE if-elseif block and adds another check to remove the old sources file after migrating to the new one.

Verification build: https://dev.azure.com/monacotools/Monaco/_build/results?buildId=336644&view=results.