### PR TITLE
Add casts to silence breaks due to updated DOM types

### DIFF
--- a/extensions/notebook-renderers/src/index.ts
+++ b/extensions/notebook-renderers/src/index.ts
@@ -16,7 +16,7 @@ function clearContainer(container: HTMLElement) {
 }
 
 function renderImage(outputInfo: OutputItem, element: HTMLElement): IDisposable {
-	const blob = new Blob([outputInfo.data()], { type: outputInfo.mime });
+	const blob = new Blob([outputInfo.data() as Uint8Array<ArrayBuffer>], { type: outputInfo.mime });
 	const src = URL.createObjectURL(blob);
 	const disposable = {
 		dispose: () => {

--- a/src/vs/base/browser/dom.ts
+++ b/src/vs/base/browser/dom.ts
@@ -1544,7 +1544,7 @@ export function triggerDownload(dataOrUri: Uint8Array | URI, name: string): void
 	if (URI.isUri(dataOrUri)) {
 		url = dataOrUri.toString(true);
 	} else {
-		const blob = new Blob([dataOrUri]);
+		const blob = new Blob([dataOrUri as Uint8Array<ArrayBuffer>]);
 		url = URL.createObjectURL(blob);
 
 		// Ensure to free the data from DOM eventually

--- a/src/vs/base/common/hash.ts
+++ b/src/vs/base/common/hash.ts
@@ -93,7 +93,7 @@ export const hashAsync = (input: string | ArrayBufferView | VSBuffer) => {
 		buff = input;
 	}
 
-	return crypto.subtle.digest('sha-1', buff).then(toHexString);
+	return crypto.subtle.digest('sha-1', buff as ArrayBufferView<ArrayBuffer>).then(toHexString);
 };
 
 const enum SHA1Constant {

--- a/src/vs/code/browser/workbench/workbench.ts
+++ b/src/vs/code/browser/workbench/workbench.ts
@@ -109,9 +109,9 @@ class ServerKeyedAESCrypto implements ISecretStorageCrypto {
 		// Do the decryption and parse the result as JSON
 		const key = await this.getKey(clientKey.buffer);
 		const decrypted = await mainWindow.crypto.subtle.decrypt(
-			{ name: AESConstants.ALGORITHM as const, iv: iv.buffer },
+			{ name: AESConstants.ALGORITHM as const, iv: iv.buffer as Uint8Array<ArrayBuffer> },
 			key,
-			cipherText.buffer
+			cipherText.buffer as Uint8Array<ArrayBuffer>
 		);
 
 		return new TextDecoder().decode(new Uint8Array(decrypted));

--- a/src/vs/editor/browser/gpu/gpuDisposable.ts
+++ b/src/vs/editor/browser/gpu/gpuDisposable.ts
@@ -28,7 +28,7 @@ export namespace GPULifecycle {
 	export function createBuffer(device: GPUDevice, descriptor: GPUBufferDescriptor, initialValues?: Float32Array | (() => Float32Array)): IReference<GPUBuffer> {
 		const buffer = device.createBuffer(descriptor);
 		if (initialValues) {
-			device.queue.writeBuffer(buffer, 0, isFunction(initialValues) ? initialValues() : initialValues);
+			device.queue.writeBuffer(buffer, 0, (isFunction(initialValues) ? initialValues() : initialValues) as Float32Array<ArrayBuffer>);
 		}
 		return wrapDestroyableInDisposable(buffer);
 	}

--- a/src/vs/editor/browser/gpu/rectangleRenderer.ts
+++ b/src/vs/editor/browser/gpu/rectangleRenderer.ts
@@ -251,7 +251,7 @@ export class RectangleRenderer extends ViewEventHandler {
 			const dpr = getActiveWindow().devicePixelRatio;
 			this._scrollOffsetValueBuffer[0] = this._context.viewLayout.getCurrentScrollLeft() * dpr;
 			this._scrollOffsetValueBuffer[1] = this._context.viewLayout.getCurrentScrollTop() * dpr;
-			this._device.queue.writeBuffer(this._scrollOffsetBindBuffer, 0, this._scrollOffsetValueBuffer);
+			this._device.queue.writeBuffer(this._scrollOffsetBindBuffer, 0, this._scrollOffsetValueBuffer as Float32Array<ArrayBuffer>);
 		}
 		return true;
 	}

--- a/src/vs/editor/browser/gpu/renderStrategy/fullFileRenderStrategy.ts
+++ b/src/vs/editor/browser/gpu/renderStrategy/fullFileRenderStrategy.ts
@@ -174,7 +174,7 @@ export class FullFileRenderStrategy extends BaseRenderStrategy {
 		const dpr = getActiveWindow().devicePixelRatio;
 		this._scrollOffsetValueBuffer[0] = (e?.scrollLeft ?? this._context.viewLayout.getCurrentScrollLeft()) * dpr;
 		this._scrollOffsetValueBuffer[1] = (e?.scrollTop ?? this._context.viewLayout.getCurrentScrollTop()) * dpr;
-		this._device.queue.writeBuffer(this._scrollOffsetBindBuffer, 0, this._scrollOffsetValueBuffer);
+		this._device.queue.writeBuffer(this._scrollOffsetBindBuffer, 0, this._scrollOffsetValueBuffer as Float32Array<ArrayBuffer>);
 		return true;
 	}
 

--- a/src/vs/editor/browser/gpu/renderStrategy/viewportRenderStrategy.ts
+++ b/src/vs/editor/browser/gpu/renderStrategy/viewportRenderStrategy.ts
@@ -157,7 +157,7 @@ export class ViewportRenderStrategy extends BaseRenderStrategy {
 		const dpr = getActiveWindow().devicePixelRatio;
 		this._scrollOffsetValueBuffer[0] = (e?.scrollLeft ?? this._context.viewLayout.getCurrentScrollLeft()) * dpr;
 		this._scrollOffsetValueBuffer[1] = (e?.scrollTop ?? this._context.viewLayout.getCurrentScrollTop()) * dpr;
-		this._device.queue.writeBuffer(this._scrollOffsetBindBuffer, 0, this._scrollOffsetValueBuffer);
+		this._device.queue.writeBuffer(this._scrollOffsetBindBuffer, 0, this._scrollOffsetValueBuffer as Float32Array<ArrayBuffer>);
 		return true;
 	}
 

--- a/src/vs/platform/files/browser/htmlFileSystemProvider.ts
+++ b/src/vs/platform/files/browser/htmlFileSystemProvider.ts
@@ -221,7 +221,7 @@ export class HTMLFileSystemProvider extends Disposable implements IFileSystemPro
 
 			// Write to target overwriting any existing contents
 			const writable = await handle.createWritable();
-			await writable.write(content);
+			await writable.write(content as Uint8Array<ArrayBuffer>);
 			await writable.close();
 		} catch (error) {
 			throw this.toFileSystemProviderError(error);

--- a/src/vs/workbench/contrib/chat/browser/chatAttachmentWidgets.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatAttachmentWidgets.ts
@@ -325,7 +325,7 @@ function createImageElements(resource: URI | undefined, name: string, fullName: 
 		disposable.add(hoverService.setupDelayedHover(element, { content: hoverElement, appearance: { showPointer: true } }));
 
 
-		const blob = new Blob([buffer], { type: 'image/png' });
+		const blob = new Blob([buffer as Uint8Array<ArrayBuffer>], { type: 'image/png' });
 		const url = URL.createObjectURL(blob);
 		const pillImg = dom.$('img.chat-attached-context-pill-image', { src: url, alt: '' });
 		const pill = dom.$('div.chat-attached-context-pill', {}, pillImg);

--- a/src/vs/workbench/contrib/chat/browser/imageUtils.ts
+++ b/src/vs/workbench/contrib/chat/browser/imageUtils.ts
@@ -24,7 +24,7 @@ export async function resizeImage(data: Uint8Array | string, mimeType?: string):
 	}
 
 	return new Promise((resolve, reject) => {
-		const blob = new Blob([data], { type: mimeType });
+		const blob = new Blob([data as Uint8Array<ArrayBuffer>], { type: mimeType });
 		const img = new Image();
 		const url = URL.createObjectURL(blob);
 		img.src = url;

--- a/src/vs/workbench/contrib/files/browser/fileImportExport.ts
+++ b/src/vs/workbench/contrib/files/browser/fileImportExport.ts
@@ -718,7 +718,7 @@ export class FileDownload {
 
 			listenStream(sourceStream, {
 				onData: data => {
-					target.write(data.buffer);
+					target.write(data.buffer as Uint8Array<ArrayBuffer>);
 					this.reportProgress(contents.name, contents.size, data.byteLength, operation);
 				},
 				onError: error => {
@@ -736,7 +736,7 @@ export class FileDownload {
 	private async downloadFileUnbufferedBrowser(resource: URI, target: FileSystemWritableFileStream, operation: IDownloadOperation, token: CancellationToken): Promise<void> {
 		const contents = await this.fileService.readFile(resource, undefined, token);
 		if (!token.isCancellationRequested) {
-			target.write(contents.value.buffer);
+			target.write(contents.value.buffer as Uint8Array<ArrayBuffer>);
 			this.reportProgress(contents.name, contents.size, contents.value.byteLength, operation);
 		}
 

--- a/src/vs/workbench/contrib/mcp/common/mcpRegistryInputStorage.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpRegistryInputStorage.ts
@@ -163,9 +163,9 @@ export class McpRegistryInputStorage extends Disposable {
 			const encrypted = decodeBase64(this._record.value.secrets.value);
 
 			const decrypted = await crypto.subtle.decrypt(
-				{ name: MCP_ENCRYPTION_KEY_ALGORITHM, iv: iv.buffer },
+				{ name: MCP_ENCRYPTION_KEY_ALGORITHM, iv: iv.buffer as Uint8Array<ArrayBuffer> },
 				key,
-				encrypted.buffer,
+				encrypted.buffer as Uint8Array<ArrayBuffer>,
 			);
 
 			const unsealedSecrets = JSON.parse(new TextDecoder().decode(decrypted));

--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewPreloads.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewPreloads.ts
@@ -1070,7 +1070,7 @@ async function webviewPreloads(ctx: PreloadContext) {
 				},
 
 				blob(): Blob {
-					return new Blob([valueBytes], { type: this.mime });
+					return new Blob([valueBytes as Uint8Array<ArrayBuffer>], { type: this.mime });
 				},
 
 				get _allOutputItems() {
@@ -2520,7 +2520,7 @@ async function webviewPreloads(ctx: PreloadContext) {
 				},
 
 				blob(): Blob {
-					return new Blob([this.data()], { type: this.mime });
+					return new Blob([this.data() as Uint8Array<ArrayBuffer>], { type: this.mime });
 				},
 
 				_allOutputItems: [{

--- a/src/vs/workbench/contrib/webview/browser/pre/service-worker.ts
+++ b/src/vs/workbench/contrib/webview/browser/pre/service-worker.ts
@@ -308,7 +308,7 @@ async function processResourceRequest(
 			headers['Cross-Origin-Opener-Policy'] = 'same-origin';
 		}
 
-		const response = new Response(entry.data, {
+		const response = new Response(entry.data as Uint8Array<ArrayBuffer>, {
 			status: 200,
 			headers
 		});


### PR DESCRIPTION
This addresses [build errors](https://github.com/microsoft/TypeScript/pull/61647#issuecomment-2852829581) with TS5.9 and the updated DOM types from https://github.com/microsoft/TypeScript/pull/61647.

This fixes are currently handled via casts so as to avoid any runtime changes or significant changes to the types. In some cases, the casts address deficiencies in the types from external packages.

Some of the breaks could be fixed by modifying `VSBuffer` to only accept `Buffer<ArrayBuffer>`, but this required significantly more casts in other locations. I leave it up to the discretion of the VSCode team as to whether more extensive changes are necessary.