### PR TITLE
Fix Notebook Cell Output uri conflict issues -- conflict message + incorrect editor choice

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/outputEditor/notebookOutputEditor.ts
+++ b/src/vs/workbench/contrib/notebook/browser/outputEditor/notebookOutputEditor.ts
@@ -348,7 +348,7 @@ export class NotebookOutputEditorContribution implements IWorkbenchContribution 
 			{
 				id: 'notebookOutputEditor',
 				label: 'Notebook Output Editor',
-				priority: RegisteredEditorPriority.option
+				priority: RegisteredEditorPriority.default
 			},
 			{
 				canSupportResource: (resource: URI) => {

--- a/src/vs/workbench/services/editor/browser/editorResolverService.ts
+++ b/src/vs/workbench/services/editor/browser/editorResolverService.ts
@@ -427,8 +427,7 @@ export class EditorResolverService extends Disposable implements IEditorResolver
 				conflictingDefault: false
 			};
 		}
-		// If the editor is exclusive we use that, else use the user setting, else use the built-in+ editor
-		// If using the built-in+ editor, we need to check canSupportResource, else take the first possible editor
+		// If the editor is exclusive we use that, else use the user setting, else we check canSupportResource, else take the viewtype of first possible editor
 		const selectedViewType = possibleEditors[0].editorInfo.priority === RegisteredEditorPriority.exclusive ?
 			possibleEditors[0].editorInfo.id :
 			associationsFromSetting[0]?.viewType ||
@@ -438,7 +437,7 @@ export class EditorResolverService extends Disposable implements IEditorResolver
 		let conflictingDefault = false;
 
 		// Filter out exclusive before we check for conflicts as exclusive editors cannot be manually chosen
-		// same as above, need to check canSupportResource, else take the first possible editor
+		// similar to above, need to check canSupportResource if nothing is exclusive
 		possibleEditors = possibleEditors
 			.filter(editor => editor.editorInfo.priority !== RegisteredEditorPriority.exclusive)
 			.filter(editor => !editor.options?.canSupportResource || editor.options.canSupportResource(resource));

--- a/src/vs/workbench/services/editor/browser/editorResolverService.ts
+++ b/src/vs/workbench/services/editor/browser/editorResolverService.ts
@@ -428,14 +428,19 @@ export class EditorResolverService extends Disposable implements IEditorResolver
 			};
 		}
 		// If the editor is exclusive we use that, else use the user setting, else use the built-in+ editor
+		// If using the built-in+ editor, we need to check canSupportResource, else take the first possible editor
 		const selectedViewType = possibleEditors[0].editorInfo.priority === RegisteredEditorPriority.exclusive ?
 			possibleEditors[0].editorInfo.id :
-			associationsFromSetting[0]?.viewType || possibleEditors[0].editorInfo.id;
+			associationsFromSetting[0]?.viewType ||
+			(possibleEditors.find(editor => (!editor.options?.canSupportResource || editor.options.canSupportResource(resource)))?.editorInfo.id || possibleEditors[0].editorInfo.id);
 
 		let conflictingDefault = false;
 
 		// Filter out exclusive before we check for conflicts as exclusive editors cannot be manually chosen
-		possibleEditors = possibleEditors.filter(editor => editor.editorInfo.priority !== RegisteredEditorPriority.exclusive);
+		// same as above, need to check canSupportResource, else take the first possible editor
+		possibleEditors = possibleEditors
+			.filter(editor => editor.editorInfo.priority !== RegisteredEditorPriority.exclusive)
+			.filter(editor => !editor.options?.canSupportResource || editor.options.canSupportResource(resource));
 		if (associationsFromSetting.length === 0 && possibleEditors.length > 1) {
 			conflictingDefault = true;
 		}

--- a/src/vs/workbench/services/editor/browser/editorResolverService.ts
+++ b/src/vs/workbench/services/editor/browser/editorResolverService.ts
@@ -432,7 +432,8 @@ export class EditorResolverService extends Disposable implements IEditorResolver
 		const selectedViewType = possibleEditors[0].editorInfo.priority === RegisteredEditorPriority.exclusive ?
 			possibleEditors[0].editorInfo.id :
 			associationsFromSetting[0]?.viewType ||
-			(possibleEditors.find(editor => (!editor.options?.canSupportResource || editor.options.canSupportResource(resource)))?.editorInfo.id || possibleEditors[0].editorInfo.id);
+			(possibleEditors.find(editor => (!editor.options?.canSupportResource || editor.options.canSupportResource(resource)))?.editorInfo.id) ||
+			possibleEditors[0].editorInfo.id;
 
 		let conflictingDefault = false;
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Almost identical issue from years ago: https://github.com/microsoft/vscode/issues/134153. This was because we had multiple ways of handling cell uris, and now this PR addresses the multiple ways we have to handle cell output uris.

During April endgame we opted to make the nb output editor setting private, as the feature still needed more polish, and to avoid breaking existing cell output actions the editor priority was set to `option`. To ensure that the feature can still be dogfooded by team members with the private setting enabled, the priority needs to be raised to `default`. 

This causes some problems though. 
- context: 
  - the uri schema `vscode-notebook-cell-output` is supported based on glob patterns by BOTH the base notebook editor and the notebook output editor (new feature I'm working on). 
  - Both editors have a `canSupportResource()` function defined in their options, and we use the query portion of the uri to specify an `openIn` arg that specifies either `notebook` or `notebookOutputEditor`
- if using the cell output action `Open in Output Preview`, you will see the error for multiple default editors. This is because the notebook editor itself technically can open a cell output uri scheme. This is a relatively small issue.
--- 
Bigger problem is now opening a cell output uri attachment in chat. This _should_ resolve to the notebook editor. However:
- example output uri from chat: `"vscode-notebook-cell-output:/c%3A/Users/milively/Documents/_dev_work/playground-0/_notebooks/rich%20notebooks/example_notebook.ipynb?openIn%3Dnotebook%26outputIndex%3D0#W0sZmlsZQ%3D%3D"`
  - note the scheme, and `openIn%3Dnotebook`
- if clicking the cell output attachment in chat, you see an error `Unable to resolve text model content for resource <...>`. This is because the logic in `getEditor()` would resolve to the basic Text Editor, rather than the notebook editor.
--- 
Detailed issue:
- This is because of the prior logic for `selectedViewType` would arrive at the viewtype `notebookOutputEditor` because it was in the first slot of `possibleEditors[]` (this array contained: `[notebookOutputEditor, jupyter-notebook]`).
```
const selectedViewType = possibleEditors[0].editorInfo.priority === RegisteredEditorPriority.exclusive ?
	possibleEditors[0].editorInfo.id :
	associationsFromSetting[0]?.viewType || possibleEditors[0].editorInfo.id;
```
- all of this led to the final stage of `getEditor` where a `findMatchingEditor()` search was executed to find the correct editor, and it was fed the viewType `notebookOutputEditor` and editors `[Notebook Output Editor, Jupyter Notebook, Text Editor]`.
- In the implementation of `findMatchingEditor()` we do check `canSupportResource`, and this is causing the issue, since this is the only place here that it was being used. This search for an editor will always return nothing, since the only time the viewtype matches the editor is for the Notebook Output Editor, and the `canSupportResource` check will always fail in this case due to the openIn arg in the uri query not matching. 
--- 
TLDR: This PR adds the following:
- extra filter on selectedViewType: this ensures we check resource support before falling back to the viewtype of the first possible editor
- extra filter on possibleEditors: ensuring we have a smaller subset of possible editors (only those that support a given resource)