### PR TITLE
[prompts][debt]: refactor the find instructions method of the prompts service

### DIFF
--- a/src/vs/base/common/codecs/baseDecoder.ts
+++ b/src/vs/base/common/codecs/baseDecoder.ts
@@ -3,11 +3,11 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { assert, assertNever } from '../assert.js';
 import { Emitter } from '../event.js';
 import { ReadableStream } from '../stream.js';
 import { DeferredPromise } from '../async.js';
 import { AsyncDecoder } from './asyncDecoder.js';
+import { assert, assertNever } from '../assert.js';
 import { DisposableMap, IDisposable } from '../lifecycle.js';
 import { ObservableDisposable } from '../observableDisposable.js';
 

--- a/src/vs/base/common/codecs/baseDecoder.ts
+++ b/src/vs/base/common/codecs/baseDecoder.ts
@@ -109,7 +109,7 @@ export abstract class BaseDecoder<
 			'Cannot start stream that has already ended.',
 		);
 		assert(
-			!this.disposed,
+			this.isDisposed === false,
 			'Cannot start stream that has already disposed.',
 		);
 

--- a/src/vs/base/common/objectCache.ts
+++ b/src/vs/base/common/objectCache.ts
@@ -83,7 +83,7 @@ export class ObjectCache<
 		this._register(new DisposableMap());
 
 	constructor(
-		private readonly factory: (key: TKey) => TValue & { disposed: false },
+		private readonly factory: (key: TKey) => TValue & { isDisposed: false },
 	) {
 		super();
 	}
@@ -96,11 +96,11 @@ export class ObjectCache<
 	 * @throws if {@linkcode factory} callback returns a disposed object.
 	 * @param key - ID of the object in the cache
 	 */
-	public get(key: TKey): TValue & { disposed: false } {
+	public get(key: TKey): TValue & { isDisposed: false } {
 		let object = this.cache.get(key);
 
 		// if object is already disposed, remove it from the cache
-		if (object?.disposed) {
+		if (object?.isDisposed) {
 			this.cache.deleteAndLeak(key);
 			object = undefined;
 		}

--- a/src/vs/base/common/objectCache.ts
+++ b/src/vs/base/common/objectCache.ts
@@ -126,7 +126,7 @@ export class ObjectCache<
 		);
 
 		// remove it from the cache automatically on dispose
-		object.addDisposable(
+		object.addDisposables(
 			object.onDispose(() => {
 				this.cache.deleteAndLeak(key);
 			}));

--- a/src/vs/base/common/observableDisposable.ts
+++ b/src/vs/base/common/observableDisposable.ts
@@ -6,7 +6,7 @@
 import { Disposable, DisposableStore, IDisposable, toDisposable } from './lifecycle.js';
 
 /**
- * Disposable object that tracks its {@linkcode disposed} state
+ * Disposable object that tracks its {@linkcode isDisposed} state
  * as a public attribute and provides the {@linkcode onDispose}
  * event to subscribe to.
  */
@@ -17,9 +17,9 @@ export abstract class ObservableDisposable extends Disposable {
 	private readonly store = this._register(new DisposableStore());
 
 	/**
-	 * Gets current 'disposed' state of this object.
+	 * Check if the current object is already has been disposed.
 	 */
-	public get disposed(): boolean {
+	public get isDisposed(): boolean {
 		return this.store.isDisposed;
 	}
 
@@ -31,7 +31,7 @@ export abstract class ObservableDisposable extends Disposable {
 	 */
 	public onDispose(callback: () => void): IDisposable {
 		// if already disposed, execute the callback immediately
-		if (this.disposed) {
+		if (this.isDisposed) {
 			const timeoutHandle = setTimeout(callback);
 
 			return toDisposable(() => {
@@ -70,7 +70,7 @@ export abstract class ObservableDisposable extends Disposable {
 /**
  * Type for a non-disposed object `TObject`.
  */
-type TNotDisposed<TObject extends { disposed: boolean }> = TObject & { disposed: false };
+type TNotDisposed<TObject extends { isDisposed: boolean }> = TObject & { isDisposed: false };
 
 /**
  * Asserts that a provided `object` is not `disposed` yet,
@@ -79,11 +79,11 @@ type TNotDisposed<TObject extends { disposed: boolean }> = TObject & { disposed:
  * @throws if the provided `object.disposed` equal to `false`.
  * @param error Error message or error object to throw if assertion fails.
  */
-export function assertNotDisposed<TObject extends { disposed: boolean }>(
+export function assertNotDisposed<TObject extends { isDisposed: boolean }>(
 	object: TObject,
 	error: string | Error,
 ): asserts object is TNotDisposed<TObject> {
-	if (!object.disposed) {
+	if (!object.isDisposed) {
 		return;
 	}
 

--- a/src/vs/base/test/common/objectCache.test.ts
+++ b/src/vs/base/test/common/objectCache.test.ts
@@ -237,10 +237,10 @@ suite('ObjectCache', function () {
 
 			cache.remove(key2, disposeOnRemove);
 
-			const object2Disposed = obj2.disposed;
+			const object2Disposed = obj2.isDisposed;
 
 			// ensure we don't leak undisposed object in the tests
-			if (!obj2.disposed) {
+			if (obj2.isDisposed === false) {
 				obj2.dispose();
 			}
 
@@ -256,7 +256,7 @@ suite('ObjectCache', function () {
 			 */
 
 			assert(
-				!obj1.disposed,
+				obj1.isDisposed === false,
 				'[obj1] Object must not be disposed.',
 			);
 
@@ -315,7 +315,7 @@ suite('ObjectCache', function () {
 			}
 
 			// caution! explicit type casting below!
-			return result as TestObject<string> & { disposed: false };
+			return result as TestObject<string> & { isDisposed: false };
 		};
 
 		// ObjectCache<TestObject>

--- a/src/vs/base/test/common/observableDisposable.test.ts
+++ b/src/vs/base/test/common/observableDisposable.test.ts
@@ -54,7 +54,7 @@ suite('ObservableDisposable', () => {
 				'Object must not be disposed yet.',
 			);
 
-			const onDisposeSpy = spy(() => { });
+			const onDisposeSpy = spy();
 			disposables.add(object.onDispose(onDisposeSpy));
 
 			assert(
@@ -185,7 +185,7 @@ suite('ObservableDisposable', () => {
 				);
 			}
 
-			object.addDisposable(...disposableObjects);
+			object.addDisposables(...disposableObjects);
 
 			// a sanity check after the 'addDisposable' call
 			for (const disposable of disposableObjects) {
@@ -228,7 +228,7 @@ suite('ObservableDisposable', () => {
 					const disposableObject = new TestDisposable();
 					allDisposables.push(disposableObject);
 					if (parent !== null) {
-						parent.addDisposable(disposableObject);
+						parent.addDisposables(disposableObject);
 					}
 
 					// generate child disposable objects recursively

--- a/src/vs/base/test/common/observableDisposable.test.ts
+++ b/src/vs/base/test/common/observableDisposable.test.ts
@@ -30,14 +30,14 @@ suite('ObservableDisposable', () => {
 		);
 
 		assert(
-			object.disposed === false,
+			object.isDisposed === false,
 			'Object must not be disposed yet.',
 		);
 
 		object.dispose();
 
 		assert(
-			object.disposed,
+			object.isDisposed,
 			'Object must be disposed.',
 		);
 	});
@@ -50,7 +50,7 @@ suite('ObservableDisposable', () => {
 			disposables.add(object);
 
 			assert(
-				object.disposed === false,
+				object.isDisposed === false,
 				'Object must not be disposed yet.',
 			);
 
@@ -78,7 +78,7 @@ suite('ObservableDisposable', () => {
 			 */
 
 			assert(
-				object.disposed,
+				object.isDisposed,
 				'Object must be disposed.',
 			);
 
@@ -102,7 +102,7 @@ suite('ObservableDisposable', () => {
 			);
 
 			assert(
-				object.disposed,
+				object.isDisposed,
 				'Object must be disposed.',
 			);
 		});
@@ -168,7 +168,7 @@ suite('ObservableDisposable', () => {
 			disposables.add(object);
 
 			assert(
-				object.disposed === false,
+				object.isDisposed === false,
 				'Object must not be disposed yet.',
 			);
 
@@ -256,7 +256,7 @@ suite('ObservableDisposable', () => {
 			disposables.add(object);
 
 			assert(
-				object.disposed === false,
+				object.isDisposed === false,
 				'Object must not be disposed yet.',
 			);
 
@@ -271,7 +271,7 @@ suite('ObservableDisposable', () => {
 			// a sanity check for the initial state of the objects
 			for (const disposable of allDisposableObjects) {
 				assert(
-					disposable.disposed === false,
+					disposable.isDisposed === false,
 					'Disposable object must not be disposed yet.',
 				);
 			}
@@ -280,7 +280,7 @@ suite('ObservableDisposable', () => {
 
 			// finally validate that all objects are disposed
 			const allDisposed = allDisposableObjects.reduce((acc, disposable) => {
-				return acc && disposable.disposed;
+				return acc && disposable.isDisposed;
 			}, true);
 
 			assert(

--- a/src/vs/workbench/contrib/chat/browser/attachments/promptInstructions/promptInstructionsCollectionWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/attachments/promptInstructions/promptInstructionsCollectionWidget.ts
@@ -6,11 +6,11 @@
 import { URI } from '../../../../../../base/common/uri.js';
 import { Emitter } from '../../../../../../base/common/event.js';
 import { ResourceLabels } from '../../../../../browser/labels.js';
+import { Disposable } from '../../../../../../base/common/lifecycle.js';
 import { ILogService } from '../../../../../../platform/log/common/log.js';
 import { InstructionsAttachmentWidget } from './promptInstructionsWidget.js';
 import { IModelService } from '../../../../../../editor/common/services/model.js';
 import { INSTRUCTIONS_LANGUAGE_ID } from '../../../common/promptSyntax/constants.js';
-import { Disposable, IDisposable } from '../../../../../../base/common/lifecycle.js';
 import { ILanguageService } from '../../../../../../editor/common/languages/language.js';
 import { IInstantiationService } from '../../../../../../platform/instantiation/common/instantiation.js';
 import { ChatPromptAttachmentsCollection } from '../../chatAttachmentModel/chatPromptAttachmentsCollection.js';
@@ -32,12 +32,9 @@ export class PromptInstructionsAttachmentsCollectionWidget extends Disposable {
 	 */
 	private _onAttachmentsChange = this._register(new Emitter<void>());
 	/**
-	 * Subscribe to the `onAttachmentsChange` event.
-	 * @param callback Function to invoke when number of attachments change.
+	 * Subscribe to the event that fires when number of attachments change.
 	 */
-	public onAttachmentsChange(callback: () => unknown): IDisposable {
-		return this._onAttachmentsChange.event(callback);
-	}
+	public readonly onAttachmentsChange = this._onAttachmentsChange.event;
 
 	/**
 	 * The parent DOM node this widget was rendered into.

--- a/src/vs/workbench/contrib/chat/browser/chatAttachmentModel/chatPromptAttachmentModel.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatAttachmentModel/chatPromptAttachmentModel.ts
@@ -6,7 +6,6 @@
 import { URI } from '../../../../../base/common/uri.js';
 import { pick } from '../../../../../base/common/arrays.js';
 import { Emitter } from '../../../../../base/common/event.js';
-import { IDisposable } from '../../../../../base/common/lifecycle.js';
 import { PromptParser } from '../../common/promptSyntax/parsers/promptParser.js';
 import { BasePromptParser } from '../../common/promptSyntax/parsers/basePromptParser.js';
 import { ObservableDisposable } from '../../../../../base/common/observableDisposable.js';
@@ -94,12 +93,11 @@ export class ChatPromptAttachmentModel extends ObservableDisposable {
 	 */
 	protected _onUpdate = this._register(new Emitter<void>());
 	/**
-	 * Subscribe to the `onUpdate` event.
-	 * @param callback Function to invoke on update.
+	 * Subscribe to the event that fires when the underlying prompt
+	 * reference instance is updated.
+	 * See {@link BasePromptParser.onUpdate}.
 	 */
-	public onUpdate(callback: () => unknown): IDisposable {
-		return this._onUpdate.event(callback);
-	}
+	public readonly onUpdate = this._onUpdate.event;
 
 	constructor(
 		public readonly uri: URI,

--- a/src/vs/workbench/contrib/chat/browser/chatAttachmentModel/chatPromptAttachmentModel.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatAttachmentModel/chatPromptAttachmentModel.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { URI } from '../../../../../base/common/uri.js';
+import { pick } from '../../../../../base/common/arrays.js';
 import { Emitter } from '../../../../../base/common/event.js';
 import { IDisposable } from '../../../../../base/common/lifecycle.js';
 import { PromptParser } from '../../common/promptSyntax/parsers/promptParser.js';
@@ -51,7 +52,7 @@ export class ChatPromptAttachmentModel extends ObservableDisposable {
 		// otherwise return `URI` for the main reference and
 		// all valid child `URI` references it may contain
 		return [
-			...reference.allValidReferencesUris,
+			...reference.allValidReferences.map(pick('uri')),
 			reference.uri,
 		];
 	}

--- a/src/vs/workbench/contrib/chat/browser/chatAttachmentModel/chatPromptAttachmentsCollection.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatAttachmentModel/chatPromptAttachmentsCollection.ts
@@ -251,7 +251,7 @@ export class ChatPromptAttachmentsCollection extends Disposable {
 			}
 
 			const instruction = this.initService.createInstance(ChatPromptAttachmentModel, uri);
-			instruction.addDisposable(
+			instruction.addDisposables(
 				instruction.onDispose(() => {
 					// note! we have to use `deleteAndLeak` here, because the `*AndDispose`
 					//       alternative results in an infinite loop of calling this callback

--- a/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingModifiedNotebookEntry.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingModifiedNotebookEntry.ts
@@ -475,7 +475,7 @@ export class ChatEditingModifiedNotebookEntry extends AbstractChatEditingModifie
 
 	protected override _resetEditsState(tx: ITransaction): void {
 		super._resetEditsState(tx);
-		this.cellEntryMap.forEach(entry => !entry.disposed && entry.clearCurrentEditLineDecoration());
+		this.cellEntryMap.forEach(entry => !entry.isDisposed && entry.clearCurrentEditLineDecoration());
 	}
 
 	protected override _createUndoRedoElement(response: IChatResponseModel): IUndoRedoElement | undefined {

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/contentProviders/filePromptContentsProvider.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/contentProviders/filePromptContentsProvider.ts
@@ -123,7 +123,7 @@ export class FilePromptContentProvider extends PromptContentsProviderBase<FileCh
 			// after the promise above complete, this object can be already disposed or
 			// the cancellation could be requested, in that case destroy the stream and
 			// throw cancellation error
-			if (this.disposed || cancellationToken?.isCancellationRequested) {
+			if (this.isDisposed || cancellationToken?.isCancellationRequested) {
 				fileStream.value.destroy();
 				throw new CancellationError();
 			}

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/contentProviders/promptContentsProviderBase.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/contentProviders/promptContentsProviderBase.ts
@@ -128,7 +128,7 @@ export abstract class PromptContentsProviderBase<
 
 		promise
 			.then((stream) => {
-				if (cancellationToken?.isCancellationRequested || this.disposed) {
+				if (cancellationToken?.isCancellationRequested || this.isDisposed) {
 					stream.destroy();
 					throw new CancellationError();
 				}
@@ -155,7 +155,7 @@ export abstract class PromptContentsProviderBase<
 	 */
 	public start(): this {
 		assert(
-			!this.disposed,
+			!this.isDisposed,
 			'Cannot start contents provider that was already disposed.',
 		);
 

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/contributions/languageFeatures/providers/decorationsProvider/promptDecorationsProvider.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/contributions/languageFeatures/providers/decorationsProvider/promptDecorationsProvider.ts
@@ -50,7 +50,7 @@ export class PromptDecorator extends ProviderInstanceBase {
 	): this {
 		// by the time the promise above completes, either this object
 		// or the text model might be already has been disposed
-		if (this.disposed || this.model.isDisposed()) {
+		if (this.isDisposed || this.model.isDisposed()) {
 			return this;
 		}
 
@@ -167,7 +167,7 @@ export class PromptDecorator extends ProviderInstanceBase {
 	}
 
 	public override dispose(): void {
-		if (this.disposed) {
+		if (this.isDisposed) {
 			return;
 		}
 

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/contributions/languageFeatures/providers/promptLinkProvider.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/contributions/languageFeatures/providers/promptLinkProvider.ts
@@ -42,7 +42,7 @@ export class PromptLinkProvider extends Disposable implements LinkProvider {
 
 		const parser = this.promptsService.getSyntaxParserFor(model);
 		assert(
-			!parser.disposed,
+			parser.disposed === false,
 			'Prompt parser must not be disposed.',
 		);
 

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/contributions/languageFeatures/providers/promptLinkProvider.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/contributions/languageFeatures/providers/promptLinkProvider.ts
@@ -42,7 +42,7 @@ export class PromptLinkProvider extends Disposable implements LinkProvider {
 
 		const parser = this.promptsService.getSyntaxParserFor(model);
 		assert(
-			parser.disposed === false,
+			parser.isDisposed === false,
 			'Prompt parser must not be disposed.',
 		);
 

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/contributions/languageFeatures/providers/promptPathAutocompletion.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/contributions/languageFeatures/providers/promptPathAutocompletion.ts
@@ -135,7 +135,7 @@ export class PromptPathAutocompletion extends Disposable implements CompletionIt
 
 		const parser = this.promptsService.getSyntaxParserFor(model);
 		assert(
-			parser.disposed === false,
+			parser.isDisposed === false,
 			'Prompt parser must not be disposed.',
 		);
 

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/contributions/languageFeatures/providers/promptPathAutocompletion.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/contributions/languageFeatures/providers/promptPathAutocompletion.ts
@@ -135,7 +135,7 @@ export class PromptPathAutocompletion extends Disposable implements CompletionIt
 
 		const parser = this.promptsService.getSyntaxParserFor(model);
 		assert(
-			!parser.disposed,
+			parser.disposed === false,
 			'Prompt parser must not be disposed.',
 		);
 

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/basePromptParser.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/basePromptParser.ts
@@ -399,7 +399,7 @@ export class BasePromptParser<TContentsProvider extends IPromptContentsProvider>
 
 		this._references.push(reference);
 
-		reference.addDisposable(
+		reference.addDisposables(
 			// the content provider is exclusively owned by the reference
 			// hence dispose it when the reference is disposed
 			reference.onDispose(contentProvider.dispose.bind(contentProvider)),

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/basePromptParser.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/basePromptParser.ts
@@ -562,14 +562,6 @@ export class BasePromptParser<TContentsProvider extends IPromptContentsProvider>
 	}
 
 	/**
-	 * Get list of all valid child references as URIs.
-	 */
-	public get allValidReferencesUris(): readonly URI[] {
-		return this.allValidReferences
-			.map(child => child.uri);
-	}
-
-	/**
 	 * Valid metadata records defined in the prompt header.
 	 */
 	public get metadata(): IPromptMetadata {

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/basePromptParser.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/basePromptParser.ts
@@ -123,7 +123,7 @@ export class BasePromptParser<TContentsProvider extends IPromptContentsProvider>
 		callback: (error?: Error) => void,
 	): IDisposable {
 		const disposable = this._onSettled.event(callback);
-		const streamEnded = (this.stream?.ended && (this.stream.disposed === false));
+		const streamEnded = (this.stream?.ended && (this.stream.isDisposed === false));
 
 		// if already in the error state or stream has already ended,
 		// invoke the callback immediately but asynchronously
@@ -191,7 +191,7 @@ export class BasePromptParser<TContentsProvider extends IPromptContentsProvider>
 
 		// by the time when the `firstParseResult` promise is resolved,
 		// this object may have been already disposed, hence noop
-		if (this.disposed) {
+		if (this.isDisposed) {
 			return this;
 		}
 
@@ -367,7 +367,7 @@ export class BasePromptParser<TContentsProvider extends IPromptContentsProvider>
 		});
 
 		// calling `start` on a disposed stream throws, so we warn and return instead
-		if (this.stream.disposed) {
+		if (this.stream.isDisposed) {
 			this.logService.warn(
 				`[prompt parser][${basename(this.uri)}] cannot start stream that has been already disposed, aborting`,
 			);
@@ -426,7 +426,7 @@ export class BasePromptParser<TContentsProvider extends IPromptContentsProvider>
 		// decoders can fire the 'end' event also when they are get disposed,
 		// but because we dispose them when a new stream is received, we can
 		// safely ignore the event in this case
-		if (stream.disposed === true) {
+		if (stream.isDisposed === true) {
 			return this;
 		}
 
@@ -746,7 +746,7 @@ export class BasePromptParser<TContentsProvider extends IPromptContentsProvider>
 	 * @inheritdoc
 	 */
 	public override dispose(): void {
-		if (this.disposed) {
+		if (this.isDisposed) {
 			return;
 		}
 

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsService.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsService.ts
@@ -183,17 +183,16 @@ export class PromptsService extends Disposable implements IPromptsService {
 	public async findInstructionFilesFor(
 		files: readonly URI[],
 	): Promise<readonly URI[]> {
-		const result: URI[] = [];
-
 		const instructionFiles = await this.listPromptFiles('instructions');
 		if (instructionFiles.length === 0) {
-			return result;
+			return [];
 		}
 
 		const instructions = await this.getAllMetadata(
 			instructionFiles.map(pick('uri')),
 		);
 
+		const foundFiles = new ResourceSet();
 		for (const instruction of instructions.flatMap(flatten)) {
 			const { metadata, uri } = instruction;
 			const { applyTo } = metadata;
@@ -205,7 +204,7 @@ export class PromptsService extends Disposable implements IPromptsService {
 			// if glob pattern is one of the special wildcard values,
 			// add the instructions file event if no files are attached
 			if ((applyTo === '**') || (applyTo === '**/*')) {
-				result.push(uri);
+				foundFiles.add(uri);
 
 				continue;
 			}
@@ -214,12 +213,12 @@ export class PromptsService extends Disposable implements IPromptsService {
 			// add the instructions file if its rule matches the file
 			for (const file of files) {
 				if (match(applyTo, file.fsPath)) {
-					result.push(uri);
+					foundFiles.add(uri);
 				}
 			}
 		}
 
-		return [...new ResourceSet(result)];
+		return [...foundFiles];
 	}
 
 	@logTime()

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsService.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsService.ts
@@ -102,7 +102,7 @@ export class PromptsService extends Disposable implements IPromptsService {
 	 */
 	public getSyntaxParserFor(
 		model: ITextModel,
-	): TextModelPromptParser & { disposed: false } {
+	): TextModelPromptParser & { isDisposed: false } {
 		assert(
 			model.isDisposed() === false,
 			'Cannot create a prompt syntax parser for a disposed model.',

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/service/types.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/service/types.ts
@@ -128,7 +128,7 @@ export interface IPromptsService extends IDisposable {
 	 */
 	getSyntaxParserFor(
 		model: ITextModel,
-	): TSharedPrompt & { disposed: false };
+	): TSharedPrompt & { isDisposed: false };
 
 	/**
 	 * List all available prompt files.

--- a/src/vs/workbench/contrib/chat/test/common/mockPromptsService.ts
+++ b/src/vs/workbench/contrib/chat/test/common/mockPromptsService.ts
@@ -10,20 +10,21 @@ import { TextModelPromptParser } from '../../common/promptSyntax/parsers/textMod
 import { IChatPromptSlashCommand, IMetadata, IPromptPath, IPromptsService, TCombinedToolsMetadata, TPromptsType } from '../../common/promptSyntax/service/types.js';
 
 export class MockPromptsService implements IPromptsService {
+	_serviceBrand: undefined;
+
 	getCombinedToolsMetadata(files: readonly URI[]): Promise<TCombinedToolsMetadata> {
 		throw new Error('Method not implemented.');
 	}
-	getAllMetadata(files: readonly URI[]): Promise<readonly IMetadata[]> {
+	getAllMetadata(_files: readonly URI[]): Promise<readonly IMetadata[]> {
 		throw new Error('Method not implemented.');
 	}
-	_serviceBrand: undefined;
-	getSyntaxParserFor(model: ITextModel): TextModelPromptParser & { disposed: false } {
+	getSyntaxParserFor(_model: ITextModel): TextModelPromptParser & { isDisposed: false } {
 		throw new Error('Method not implemented.');
 	}
-	listPromptFiles(type: TPromptsType): Promise<readonly IPromptPath[]> {
+	listPromptFiles(_type: TPromptsType): Promise<readonly IPromptPath[]> {
 		throw new Error('Method not implemented.');
 	}
-	getSourceFolders(type: TPromptsType): readonly IPromptPath[] {
+	getSourceFolders(_type: TPromptsType): readonly IPromptPath[] {
 		throw new Error('Method not implemented.');
 	}
 	public asPromptSlashCommand(name: string): IChatPromptSlashCommand | undefined {
@@ -35,13 +36,13 @@ export class MockPromptsService implements IPromptsService {
 		}
 		return undefined;
 	}
-	resolvePromptSlashCommand(data: IChatPromptSlashCommand): Promise<IPromptPath | undefined> {
+	resolvePromptSlashCommand(_data: IChatPromptSlashCommand): Promise<IPromptPath | undefined> {
 		throw new Error('Method not implemented.');
 	}
 	findPromptSlashCommands(): Promise<IChatPromptSlashCommand[]> {
 		throw new Error('Method not implemented.');
 	}
-	findInstructionFilesFor(files: readonly URI[]): Promise<readonly URI[]> {
+	findInstructionFilesFor(_files: readonly URI[]): Promise<readonly URI[]> {
 		throw new Error('Method not implemented.');
 	}
 	dispose(): void { }

--- a/src/vs/workbench/contrib/chat/test/common/promptSyntax/parsers/textModelPromptParser.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/promptSyntax/parsers/textModelPromptParser.test.ts
@@ -972,7 +972,7 @@ suite('TextModelPromptParser', () => {
 		test.model.dispose();
 
 		assert(
-			test.parser.disposed,
+			test.parser.isDisposed,
 			'The parser should be disposed with its model.',
 		);
 	});

--- a/src/vs/workbench/contrib/chat/test/common/promptSyntax/service/promptsService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/promptSyntax/service/promptsService.test.ts
@@ -158,7 +158,7 @@ suite('PromptsService', () => {
 			);
 
 			assert(
-				!parser1.disposed,
+				!parser1.isDisposed,
 				'Parser1 must not be disposed.',
 			);
 
@@ -233,7 +233,7 @@ suite('PromptsService', () => {
 			);
 
 			assert(
-				!parser2.disposed,
+				!parser2.isDisposed,
 				'Parser2 must not be disposed.',
 			);
 
@@ -243,17 +243,17 @@ suite('PromptsService', () => {
 			);
 
 			assert(
-				!parser2.disposed,
+				!parser2.isDisposed,
 				'Parser2 must not be disposed.',
 			);
 
 			assert(
-				!parser1.disposed,
+				!parser1.isDisposed,
 				'Parser1 must not be disposed.',
 			);
 
 			assert(
-				!parser1_1.disposed,
+				!parser1_1.isDisposed,
 				'Parser1_1 must not be disposed.',
 			);
 
@@ -314,17 +314,17 @@ suite('PromptsService', () => {
 			parser1.dispose();
 
 			assert(
-				parser1.disposed,
+				parser1.isDisposed,
 				'Parser1 must be disposed.',
 			);
 
 			assert(
-				parser1_1.disposed,
+				parser1_1.isDisposed,
 				'Parser1_1 must be disposed.',
 			);
 
 			assert(
-				!parser2.disposed,
+				!parser2.isDisposed,
 				'Parser2 must not be disposed.',
 			);
 
@@ -337,7 +337,7 @@ suite('PromptsService', () => {
 			const parser1_2 = service.getSyntaxParserFor(model1);
 
 			assert(
-				!parser1_2.disposed,
+				!parser1_2.isDisposed,
 				'Parser1_2 must not be disposed.',
 			);
 
@@ -390,13 +390,13 @@ suite('PromptsService', () => {
 
 			// assert that the parser is also disposed
 			assert(
-				parser2.disposed,
+				parser2.isDisposed,
 				'Parser2 must be disposed.',
 			);
 
 			// sanity check that the other parser is not affected
 			assert(
-				!parser1_2.disposed,
+				!parser1_2.isDisposed,
 				'Parser1_2 must not be disposed.',
 			);
 
@@ -416,7 +416,7 @@ suite('PromptsService', () => {
 			const parser2_1 = service.getSyntaxParserFor(model2_1);
 
 			assert(
-				!parser2_1.disposed,
+				!parser2_1.isDisposed,
 				'Parser2_1 must not be disposed.',
 			);
 
@@ -472,7 +472,7 @@ suite('PromptsService', () => {
 
 			// sanity checks
 			assert(
-				!parser.disposed,
+				!parser.isDisposed,
 				'Parser must not be disposed.',
 			);
 			assert(


### PR DESCRIPTION
 - refactors the find instructions method of the prompts service to eliminate unnecessary temporary found URI duplicates
 - removes redundant 'allValidReferencesUris' method on the parsers
 - refactors observable disposable class to reuse more functionality of the disposable store class and renames its 'disposed' getter to align with other components in the code base
 - cleanups the `on*` methods left over in https://github.com/microsoft/vscode/pull/248265#discussion_r2078499575