### PR TITLE
Fix property initialization order in Henning Dieterichs' files

### DIFF
--- a/src/vs/editor/browser/observableCodeEditor.ts
+++ b/src/vs/editor/browser/observableCodeEditor.ts
@@ -47,8 +47,8 @@ export class ObservableCodeEditor extends Disposable {
 		return result;
 	}
 
-	private _updateCounter = 0;
-	private _currentTransaction: TransactionImpl | undefined = undefined;
+	private _updateCounter;
+	private _currentTransaction: TransactionImpl | undefined;
 
 	private _beginUpdate(): void {
 		this._updateCounter++;
@@ -70,6 +70,84 @@ export class ObservableCodeEditor extends Disposable {
 
 	private constructor(public readonly editor: ICodeEditor) {
 		super();
+		this._updateCounter = 0;
+		this._currentTransaction = undefined;
+		this._model = observableValue(this, this.editor.getModel());
+		this.model = this._model;
+		this.isReadonly = observableFromEvent(this, this.editor.onDidChangeConfiguration, () => this.editor.getOption(EditorOption.readOnly));
+		this._versionId = observableValueOpts<number | null, IModelContentChangedEvent | undefined>({ owner: this, lazy: true }, this.editor.getModel()?.getVersionId() ?? null);
+		this.versionId = this._versionId;
+		this._selections = observableValueOpts<Selection[] | null, ICursorSelectionChangedEvent | undefined>(
+			{ owner: this, equalsFn: equalsIfDefined(itemsEquals(Selection.selectionsEqual)), lazy: true },
+			this.editor.getSelections() ?? null
+		);
+		this.selections = this._selections;
+		this.positions = derivedOpts<readonly Position[] | null>(
+			{ owner: this, equalsFn: equalsIfDefined(itemsEquals(Position.equals)) },
+			reader => this.selections.read(reader)?.map(s => s.getStartPosition()) ?? null
+		);
+		this.isFocused = observableFromEvent(this, e => {
+			const d1 = this.editor.onDidFocusEditorWidget(e);
+			const d2 = this.editor.onDidBlurEditorWidget(e);
+			return {
+				dispose() {
+					d1.dispose();
+					d2.dispose();
+				}
+			};
+		}, () => this.editor.hasWidgetFocus());
+		this.isTextFocused = observableFromEvent(this, e => {
+			const d1 = this.editor.onDidFocusEditorText(e);
+			const d2 = this.editor.onDidBlurEditorText(e);
+			return {
+				dispose() {
+					d1.dispose();
+					d2.dispose();
+				}
+			};
+		}, () => this.editor.hasTextFocus());
+		this.inComposition = observableFromEvent(this, e => {
+			const d1 = this.editor.onDidCompositionStart(() => {
+				e(undefined);
+			});
+			const d2 = this.editor.onDidCompositionEnd(() => {
+				e(undefined);
+			});
+			return {
+				dispose() {
+					d1.dispose();
+					d2.dispose();
+				}
+			};
+		}, () => this.editor.inComposition);
+		this.value = derivedWithSetter(this,
+			reader => { this.versionId.read(reader); return this.model.read(reader)?.getValue() ?? ''; },
+			(value, tx) => {
+				const model = this.model.get();
+				if (model !== null) {
+					if (value !== model.getValue()) {
+						model.setValue(value);
+					}
+				}
+			}
+		);
+		this.valueIsEmpty = derived(this, reader => { this.versionId.read(reader); return this.editor.getModel()?.getValueLength() === 0; });
+		this.cursorSelection = derivedOpts({ owner: this, equalsFn: equalsIfDefined(Selection.selectionsEqual) }, reader => this.selections.read(reader)?.[0] ?? null);
+		this.cursorPosition = derivedOpts({ owner: this, equalsFn: Position.equals }, reader => this.selections.read(reader)?.[0]?.getPosition() ?? null);
+		this.cursorLineNumber = derived<number | null>(this, reader => this.cursorPosition.read(reader)?.lineNumber ?? null);
+		this.onDidType = observableSignal<string>(this);
+		this.onDidPaste = observableSignal<IPasteEvent>(this);
+		this.scrollTop = observableFromEvent(this.editor.onDidScrollChange, () => this.editor.getScrollTop());
+		this.scrollLeft = observableFromEvent(this.editor.onDidScrollChange, () => this.editor.getScrollLeft());
+		this.layoutInfo = observableFromEvent(this.editor.onDidLayoutChange, () => this.editor.getLayoutInfo());
+		this.layoutInfoContentLeft = this.layoutInfo.map(l => l.contentLeft);
+		this.layoutInfoDecorationsLeft = this.layoutInfo.map(l => l.decorationsLeft);
+		this.layoutInfoWidth = this.layoutInfo.map(l => l.width);
+		this.layoutInfoMinimap = this.layoutInfo.map(l => l.minimap);
+		this.layoutInfoVerticalScrollbarWidth = this.layoutInfo.map(l => l.verticalScrollbarWidth);
+		this.contentWidth = observableFromEvent(this.editor.onDidContentSizeChange, () => this.editor.getContentWidth());
+		this._widgetCounter = 0;
+		this.openedPeekWidgets = observableValue(this, 0);
 
 		this._register(this.editor.onBeginUpdate(() => this._beginUpdate()));
 		this._register(this.editor.onEndUpdate(() => this._endUpdate()));
@@ -149,93 +227,46 @@ export class ObservableCodeEditor extends Disposable {
 		}
 	}
 
-	private readonly _model = observableValue(this, this.editor.getModel());
-	public readonly model: IObservable<ITextModel | null> = this._model;
+	private readonly _model;
+	public readonly model: IObservable<ITextModel | null>;
 
-	public readonly isReadonly = observableFromEvent(this, this.editor.onDidChangeConfiguration, () => this.editor.getOption(EditorOption.readOnly));
+	public readonly isReadonly;
 
-	private readonly _versionId = observableValueOpts<number | null, IModelContentChangedEvent | undefined>({ owner: this, lazy: true }, this.editor.getModel()?.getVersionId() ?? null);
-	public readonly versionId: IObservableWithChange<number | null, IModelContentChangedEvent | undefined> = this._versionId;
+	private readonly _versionId;
+	public readonly versionId: IObservableWithChange<number | null, IModelContentChangedEvent | undefined>;
 
-	private readonly _selections = observableValueOpts<Selection[] | null, ICursorSelectionChangedEvent | undefined>(
-		{ owner: this, equalsFn: equalsIfDefined(itemsEquals(Selection.selectionsEqual)), lazy: true },
-		this.editor.getSelections() ?? null
-	);
-	public readonly selections: IObservableWithChange<Selection[] | null, ICursorSelectionChangedEvent | undefined> = this._selections;
+	private readonly _selections;
+	public readonly selections: IObservableWithChange<Selection[] | null, ICursorSelectionChangedEvent | undefined>;
 
 
-	public readonly positions = derivedOpts<readonly Position[] | null>(
-		{ owner: this, equalsFn: equalsIfDefined(itemsEquals(Position.equals)) },
-		reader => this.selections.read(reader)?.map(s => s.getStartPosition()) ?? null
-	);
+	public readonly positions;
 
-	public readonly isFocused = observableFromEvent(this, e => {
-		const d1 = this.editor.onDidFocusEditorWidget(e);
-		const d2 = this.editor.onDidBlurEditorWidget(e);
-		return {
-			dispose() {
-				d1.dispose();
-				d2.dispose();
-			}
-		};
-	}, () => this.editor.hasWidgetFocus());
+	public readonly isFocused;
 
-	public readonly isTextFocused = observableFromEvent(this, e => {
-		const d1 = this.editor.onDidFocusEditorText(e);
-		const d2 = this.editor.onDidBlurEditorText(e);
-		return {
-			dispose() {
-				d1.dispose();
-				d2.dispose();
-			}
-		};
-	}, () => this.editor.hasTextFocus());
+	public readonly isTextFocused;
 
-	public readonly inComposition = observableFromEvent(this, e => {
-		const d1 = this.editor.onDidCompositionStart(() => {
-			e(undefined);
-		});
-		const d2 = this.editor.onDidCompositionEnd(() => {
-			e(undefined);
-		});
-		return {
-			dispose() {
-				d1.dispose();
-				d2.dispose();
-			}
-		};
-	}, () => this.editor.inComposition);
+	public readonly inComposition;
 
-	public readonly value = derivedWithSetter(this,
-		reader => { this.versionId.read(reader); return this.model.read(reader)?.getValue() ?? ''; },
-		(value, tx) => {
-			const model = this.model.get();
-			if (model !== null) {
-				if (value !== model.getValue()) {
-					model.setValue(value);
-				}
-			}
-		}
-	);
-	public readonly valueIsEmpty = derived(this, reader => { this.versionId.read(reader); return this.editor.getModel()?.getValueLength() === 0; });
-	public readonly cursorSelection = derivedOpts({ owner: this, equalsFn: equalsIfDefined(Selection.selectionsEqual) }, reader => this.selections.read(reader)?.[0] ?? null);
-	public readonly cursorPosition = derivedOpts({ owner: this, equalsFn: Position.equals }, reader => this.selections.read(reader)?.[0]?.getPosition() ?? null);
-	public readonly cursorLineNumber = derived<number | null>(this, reader => this.cursorPosition.read(reader)?.lineNumber ?? null);
+	public readonly value;
+	public readonly valueIsEmpty;
+	public readonly cursorSelection;
+	public readonly cursorPosition;
+	public readonly cursorLineNumber;
 
-	public readonly onDidType = observableSignal<string>(this);
-	public readonly onDidPaste = observableSignal<IPasteEvent>(this);
+	public readonly onDidType;
+	public readonly onDidPaste;
 
-	public readonly scrollTop = observableFromEvent(this.editor.onDidScrollChange, () => this.editor.getScrollTop());
-	public readonly scrollLeft = observableFromEvent(this.editor.onDidScrollChange, () => this.editor.getScrollLeft());
+	public readonly scrollTop;
+	public readonly scrollLeft;
 
-	public readonly layoutInfo = observableFromEvent(this.editor.onDidLayoutChange, () => this.editor.getLayoutInfo());
-	public readonly layoutInfoContentLeft = this.layoutInfo.map(l => l.contentLeft);
-	public readonly layoutInfoDecorationsLeft = this.layoutInfo.map(l => l.decorationsLeft);
-	public readonly layoutInfoWidth = this.layoutInfo.map(l => l.width);
-	public readonly layoutInfoMinimap = this.layoutInfo.map(l => l.minimap);
-	public readonly layoutInfoVerticalScrollbarWidth = this.layoutInfo.map(l => l.verticalScrollbarWidth);
+	public readonly layoutInfo;
+	public readonly layoutInfoContentLeft;
+	public readonly layoutInfoDecorationsLeft;
+	public readonly layoutInfoWidth;
+	public readonly layoutInfoMinimap;
+	public readonly layoutInfoVerticalScrollbarWidth;
 
-	public readonly contentWidth = observableFromEvent(this.editor.onDidContentSizeChange, () => this.editor.getContentWidth());
+	public readonly contentWidth;
 
 	public getOption<T extends EditorOption>(id: T): IObservable<FindComputedEditorOptionValueById<T>> {
 		return observableFromEvent(this, cb => this.editor.onDidChangeConfiguration(e => {
@@ -258,7 +289,7 @@ export class ObservableCodeEditor extends Disposable {
 		return d;
 	}
 
-	private _widgetCounter = 0;
+	private _widgetCounter;
 
 	public createOverlayWidget(widget: IObservableOverlayWidget): IDisposable {
 		const overlayWidgetId = 'observableOverlayWidget' + (this._widgetCounter++);
@@ -354,7 +385,7 @@ export class ObservableCodeEditor extends Disposable {
 		return result;
 	}
 
-	public readonly openedPeekWidgets = observableValue(this, 0);
+	public readonly openedPeekWidgets;
 
 	isTargetHovered(predicate: (target: IEditorMouseEvent) => boolean, store: DisposableStore): IObservable<boolean> {
 		const isHovered = observableValue('isInjectedTextHovered', false);

--- a/src/vs/editor/browser/widget/diffEditor/components/diffEditorEditors.ts
+++ b/src/vs/editor/browser/widget/diffEditor/components/diffEditorEditors.ts
@@ -22,29 +22,29 @@ import { DiffEditorOptions } from '../diffEditorOptions.js';
 import { IContextKeyService } from '../../../../../platform/contextkey/common/contextkey.js';
 
 export class DiffEditorEditors extends Disposable {
-	public readonly original = this._register(this._createLeftHandSideEditor(this._options.editorOptions.get(), this._argCodeEditorWidgetOptions.originalEditor || {}));
-	public readonly modified = this._register(this._createRightHandSideEditor(this._options.editorOptions.get(), this._argCodeEditorWidgetOptions.modifiedEditor || {}));
+	public readonly original;
+	public readonly modified;
 
-	private readonly _onDidContentSizeChange = this._register(new Emitter<IContentSizeChangedEvent>());
+	private readonly _onDidContentSizeChange;
 	public get onDidContentSizeChange() { return this._onDidContentSizeChange.event; }
 
-	public readonly modifiedScrollTop = observableFromEvent(this, this.modified.onDidScrollChange, () => /** @description modified.getScrollTop */ this.modified.getScrollTop());
-	public readonly modifiedScrollHeight = observableFromEvent(this, this.modified.onDidScrollChange, () => /** @description modified.getScrollHeight */ this.modified.getScrollHeight());
+	public readonly modifiedScrollTop;
+	public readonly modifiedScrollHeight;
 
-	public readonly modifiedObs = observableCodeEditor(this.modified);
-	public readonly originalObs = observableCodeEditor(this.original);
+	public readonly modifiedObs;
+	public readonly originalObs;
 
-	public readonly modifiedModel = this.modifiedObs.model;
+	public readonly modifiedModel;
 
-	public readonly modifiedSelections = observableFromEvent(this, this.modified.onDidChangeCursorSelection, () => this.modified.getSelections() ?? []);
-	public readonly modifiedCursor = derivedOpts({ owner: this, equalsFn: Position.equals }, reader => this.modifiedSelections.read(reader)[0]?.getPosition() ?? new Position(1, 1));
+	public readonly modifiedSelections;
+	public readonly modifiedCursor;
 
-	public readonly originalCursor = observableFromEvent(this, this.original.onDidChangeCursorPosition, () => this.original.getPosition() ?? new Position(1, 1));
+	public readonly originalCursor;
 
-	public readonly isOriginalFocused = observableCodeEditor(this.original).isFocused;
-	public readonly isModifiedFocused = observableCodeEditor(this.modified).isFocused;
+	public readonly isOriginalFocused;
+	public readonly isModifiedFocused;
 
-	public readonly isFocused = derived(this, reader => this.isOriginalFocused.read(reader) || this.isModifiedFocused.read(reader));
+	public readonly isFocused;
 
 	constructor(
 		private readonly originalEditorElement: HTMLElement,
@@ -57,6 +57,20 @@ export class DiffEditorEditors extends Disposable {
 		@IKeybindingService private readonly _keybindingService: IKeybindingService
 	) {
 		super();
+		this.original = this._register(this._createLeftHandSideEditor(this._options.editorOptions.get(), this._argCodeEditorWidgetOptions.originalEditor || {}));
+		this.modified = this._register(this._createRightHandSideEditor(this._options.editorOptions.get(), this._argCodeEditorWidgetOptions.modifiedEditor || {}));
+		this._onDidContentSizeChange = this._register(new Emitter<IContentSizeChangedEvent>());
+		this.modifiedScrollTop = observableFromEvent(this, this.modified.onDidScrollChange, () => /** @description modified.getScrollTop */ this.modified.getScrollTop());
+		this.modifiedScrollHeight = observableFromEvent(this, this.modified.onDidScrollChange, () => /** @description modified.getScrollHeight */ this.modified.getScrollHeight());
+		this.modifiedObs = observableCodeEditor(this.modified);
+		this.originalObs = observableCodeEditor(this.original);
+		this.modifiedModel = this.modifiedObs.model;
+		this.modifiedSelections = observableFromEvent(this, this.modified.onDidChangeCursorSelection, () => this.modified.getSelections() ?? []);
+		this.modifiedCursor = derivedOpts({ owner: this, equalsFn: Position.equals }, reader => this.modifiedSelections.read(reader)[0]?.getPosition() ?? new Position(1, 1));
+		this.originalCursor = observableFromEvent(this, this.original.onDidChangeCursorPosition, () => this.original.getPosition() ?? new Position(1, 1));
+		this.isOriginalFocused = observableCodeEditor(this.original).isFocused;
+		this.isModifiedFocused = observableCodeEditor(this.modified).isFocused;
+		this.isFocused = derived(this, reader => this.isOriginalFocused.read(reader) || this.isModifiedFocused.read(reader));
 
 		this._argCodeEditorWidgetOptions = null as any;
 

--- a/src/vs/editor/browser/widget/diffEditor/components/diffEditorSash.ts
+++ b/src/vs/editor/browser/widget/diffEditor/components/diffEditorSash.ts
@@ -50,13 +50,9 @@ export class SashLayout {
 }
 
 export class DiffEditorSash extends Disposable {
-	private readonly _sash = this._register(new Sash(this._domNode, {
-		getVerticalSashTop: (_sash: Sash): number => 0,
-		getVerticalSashLeft: (_sash: Sash): number => this.sashLeft.get(),
-		getVerticalSashHeight: (_sash: Sash): number => this._dimensions.height.get(),
-	}, { orientation: Orientation.VERTICAL }));
+	private readonly _sash;
 
-	private _startSashPosition: number | undefined = undefined;
+	private _startSashPosition: number | undefined;
 
 	constructor(
 		private readonly _domNode: HTMLElement,
@@ -67,6 +63,12 @@ export class DiffEditorSash extends Disposable {
 		private readonly _resetSash: () => void,
 	) {
 		super();
+		this._sash = this._register(new Sash(this._domNode, {
+			getVerticalSashTop: (_sash: Sash): number => 0,
+			getVerticalSashLeft: (_sash: Sash): number => this.sashLeft.get(),
+			getVerticalSashHeight: (_sash: Sash): number => this._dimensions.height.get(),
+		}, { orientation: Orientation.VERTICAL }));
+		this._startSashPosition = undefined;
 
 		this._register(this._sash.onDidStart(() => {
 			this._startSashPosition = this.sashLeft.get();

--- a/src/vs/editor/browser/widget/diffEditor/components/diffEditorViewZones/diffEditorViewZones.ts
+++ b/src/vs/editor/browser/widget/diffEditor/components/diffEditorViewZones/diffEditorViewZones.ts
@@ -40,15 +40,15 @@ import { Range } from '../../../../../common/core/range.js';
  * Make sure to add the view zones!
  */
 export class DiffEditorViewZones extends Disposable {
-	private readonly _originalTopPadding = observableValue(this, 0);
+	private readonly _originalTopPadding;
 	private readonly _originalScrollTop: IObservable<number>;
-	private readonly _originalScrollOffset = observableValue<number, boolean>(this, 0);
-	private readonly _originalScrollOffsetAnimated = animatedObservable(this._targetWindow, this._originalScrollOffset, this._store);
+	private readonly _originalScrollOffset;
+	private readonly _originalScrollOffsetAnimated;
 
-	private readonly _modifiedTopPadding = observableValue(this, 0);
+	private readonly _modifiedTopPadding;
 	private readonly _modifiedScrollTop: IObservable<number>;
-	private readonly _modifiedScrollOffset = observableValue<number, boolean>(this, 0);
-	private readonly _modifiedScrollOffsetAnimated = animatedObservable(this._targetWindow, this._modifiedScrollOffset, this._store);
+	private readonly _modifiedScrollOffset;
+	private readonly _modifiedScrollOffsetAnimated;
 
 	public readonly viewZones: IObservable<{ orig: IObservableViewZone[]; mod: IObservableViewZone[] }>;
 
@@ -65,6 +65,12 @@ export class DiffEditorViewZones extends Disposable {
 		@IContextMenuService private readonly _contextMenuService: IContextMenuService,
 	) {
 		super();
+		this._originalTopPadding = observableValue(this, 0);
+		this._originalScrollOffset = observableValue<number, boolean>(this, 0);
+		this._originalScrollOffsetAnimated = animatedObservable(this._targetWindow, this._originalScrollOffset, this._store);
+		this._modifiedTopPadding = observableValue(this, 0);
+		this._modifiedScrollOffset = observableValue<number, boolean>(this, 0);
+		this._modifiedScrollOffsetAnimated = animatedObservable(this._targetWindow, this._modifiedScrollOffset, this._store);
 
 		const state = observableValue('invalidateAlignmentsState', 0);
 

--- a/src/vs/editor/browser/widget/diffEditor/diffEditorOptions.ts
+++ b/src/vs/editor/browser/widget/diffEditor/diffEditorOptions.ts
@@ -17,71 +17,109 @@ export class DiffEditorOptions {
 
 	public get editorOptions(): IObservableWithChange<IEditorOptions, { changedOptions: IEditorOptions }> { return this._options; }
 
-	private readonly _diffEditorWidth = observableValue<number>(this, 0);
+	private readonly _diffEditorWidth;
 
-	private readonly _screenReaderMode = observableFromEvent(this, this._accessibilityService.onDidChangeScreenReaderOptimized, () => this._accessibilityService.isScreenReaderOptimized());
+	private readonly _screenReaderMode;
 
 	constructor(
 		options: Readonly<IDiffEditorOptions>,
 		@IAccessibilityService private readonly _accessibilityService: IAccessibilityService,
 	) {
+		this._diffEditorWidth = observableValue<number>(this, 0);
+		this._screenReaderMode = observableFromEvent(this, this._accessibilityService.onDidChangeScreenReaderOptimized, () => this._accessibilityService.isScreenReaderOptimized());
+		this.couldShowInlineViewBecauseOfSize = derived(this, reader =>
+			this._options.read(reader).renderSideBySide && this._diffEditorWidth.read(reader) <= this._options.read(reader).renderSideBySideInlineBreakpoint
+		);
+		this.renderOverviewRuler = derived(this, reader => this._options.read(reader).renderOverviewRuler);
+		this.renderSideBySide = derived(this, reader => {
+			if (this.compactMode.read(reader)) {
+				if (this.shouldRenderInlineViewInSmartMode.read(reader)) {
+					return false;
+				}
+			}
+
+			return this._options.read(reader).renderSideBySide
+				&& !(this._options.read(reader).useInlineViewWhenSpaceIsLimited && this.couldShowInlineViewBecauseOfSize.read(reader) && !this._screenReaderMode.read(reader));
+		});
+		this.readOnly = derived(this, reader => this._options.read(reader).readOnly);
+		this.shouldRenderOldRevertArrows = derived(this, reader => {
+			if (!this._options.read(reader).renderMarginRevertIcon) { return false; }
+			if (!this.renderSideBySide.read(reader)) { return false; }
+			if (this.readOnly.read(reader)) { return false; }
+			if (this.shouldRenderGutterMenu.read(reader)) { return false; }
+			return true;
+		});
+		this.shouldRenderGutterMenu = derived(this, reader => this._options.read(reader).renderGutterMenu);
+		this.renderIndicators = derived(this, reader => this._options.read(reader).renderIndicators);
+		this.enableSplitViewResizing = derived(this, reader => this._options.read(reader).enableSplitViewResizing);
+		this.splitViewDefaultRatio = derived(this, reader => this._options.read(reader).splitViewDefaultRatio);
+		this.ignoreTrimWhitespace = derived(this, reader => this._options.read(reader).ignoreTrimWhitespace);
+		this.maxComputationTimeMs = derived(this, reader => this._options.read(reader).maxComputationTime);
+		this.showMoves = derived(this, reader => this._options.read(reader).experimental.showMoves! && this.renderSideBySide.read(reader));
+		this.isInEmbeddedEditor = derived(this, reader => this._options.read(reader).isInEmbeddedEditor);
+		this.diffWordWrap = derived(this, reader => this._options.read(reader).diffWordWrap);
+		this.originalEditable = derived(this, reader => this._options.read(reader).originalEditable);
+		this.diffCodeLens = derived(this, reader => this._options.read(reader).diffCodeLens);
+		this.accessibilityVerbose = derived(this, reader => this._options.read(reader).accessibilityVerbose);
+		this.diffAlgorithm = derived(this, reader => this._options.read(reader).diffAlgorithm);
+		this.showEmptyDecorations = derived(this, reader => this._options.read(reader).experimental.showEmptyDecorations!);
+		this.onlyShowAccessibleDiffViewer = derived(this, reader => this._options.read(reader).onlyShowAccessibleDiffViewer);
+		this.compactMode = derived(this, reader => this._options.read(reader).compactMode);
+		this.trueInlineDiffRenderingEnabled = derived(this, reader =>
+			this._options.read(reader).experimental.useTrueInlineView!
+		);
+		this.useTrueInlineDiffRendering = derived(this, reader =>
+			!this.renderSideBySide.read(reader) && this.trueInlineDiffRenderingEnabled.read(reader)
+		);
+		this.hideUnchangedRegions = derived(this, reader => this._options.read(reader).hideUnchangedRegions.enabled!);
+		this.hideUnchangedRegionsRevealLineCount = derived(this, reader => this._options.read(reader).hideUnchangedRegions.revealLineCount!);
+		this.hideUnchangedRegionsContextLineCount = derived(this, reader => this._options.read(reader).hideUnchangedRegions.contextLineCount!);
+		this.hideUnchangedRegionsMinimumLineCount = derived(this, reader => this._options.read(reader).hideUnchangedRegions.minimumLineCount!);
+		this._model = observableValue<DiffEditorViewModel | undefined>(this, undefined);
+		this.shouldRenderInlineViewInSmartMode = this._model
+			.map(this, model => derivedConstOnceDefined(this, reader => {
+				const diffs = model?.diff.read(reader);
+				return diffs ? isSimpleDiff(diffs, this.trueInlineDiffRenderingEnabled.read(reader)) : undefined;
+			}))
+			.flatten()
+			.map(this, v => !!v);
+		this.inlineViewHideOriginalLineNumbers = this.compactMode;
 		const optionsCopy = { ...options, ...validateDiffEditorOptions(options, diffEditorDefaultOptions) };
 		this._options = observableValue(this, optionsCopy);
 	}
 
-	public readonly couldShowInlineViewBecauseOfSize = derived(this, reader =>
-		this._options.read(reader).renderSideBySide && this._diffEditorWidth.read(reader) <= this._options.read(reader).renderSideBySideInlineBreakpoint
-	);
+	public readonly couldShowInlineViewBecauseOfSize;
 
-	public readonly renderOverviewRuler = derived(this, reader => this._options.read(reader).renderOverviewRuler);
-	public readonly renderSideBySide = derived(this, reader => {
-		if (this.compactMode.read(reader)) {
-			if (this.shouldRenderInlineViewInSmartMode.read(reader)) {
-				return false;
-			}
-		}
+	public readonly renderOverviewRuler;
+	public readonly renderSideBySide;
+	public readonly readOnly;
 
-		return this._options.read(reader).renderSideBySide
-			&& !(this._options.read(reader).useInlineViewWhenSpaceIsLimited && this.couldShowInlineViewBecauseOfSize.read(reader) && !this._screenReaderMode.read(reader));
-	});
-	public readonly readOnly = derived(this, reader => this._options.read(reader).readOnly);
+	public readonly shouldRenderOldRevertArrows;
 
-	public readonly shouldRenderOldRevertArrows = derived(this, reader => {
-		if (!this._options.read(reader).renderMarginRevertIcon) { return false; }
-		if (!this.renderSideBySide.read(reader)) { return false; }
-		if (this.readOnly.read(reader)) { return false; }
-		if (this.shouldRenderGutterMenu.read(reader)) { return false; }
-		return true;
-	});
+	public readonly shouldRenderGutterMenu;
+	public readonly renderIndicators;
+	public readonly enableSplitViewResizing;
+	public readonly splitViewDefaultRatio;
+	public readonly ignoreTrimWhitespace;
+	public readonly maxComputationTimeMs;
+	public readonly showMoves;
+	public readonly isInEmbeddedEditor;
+	public readonly diffWordWrap;
+	public readonly originalEditable;
+	public readonly diffCodeLens;
+	public readonly accessibilityVerbose;
+	public readonly diffAlgorithm;
+	public readonly showEmptyDecorations;
+	public readonly onlyShowAccessibleDiffViewer;
+	public readonly compactMode;
+	private readonly trueInlineDiffRenderingEnabled: IObservable<boolean>;
 
-	public readonly shouldRenderGutterMenu = derived(this, reader => this._options.read(reader).renderGutterMenu);
-	public readonly renderIndicators = derived(this, reader => this._options.read(reader).renderIndicators);
-	public readonly enableSplitViewResizing = derived(this, reader => this._options.read(reader).enableSplitViewResizing);
-	public readonly splitViewDefaultRatio = derived(this, reader => this._options.read(reader).splitViewDefaultRatio);
-	public readonly ignoreTrimWhitespace = derived(this, reader => this._options.read(reader).ignoreTrimWhitespace);
-	public readonly maxComputationTimeMs = derived(this, reader => this._options.read(reader).maxComputationTime);
-	public readonly showMoves = derived(this, reader => this._options.read(reader).experimental.showMoves! && this.renderSideBySide.read(reader));
-	public readonly isInEmbeddedEditor = derived(this, reader => this._options.read(reader).isInEmbeddedEditor);
-	public readonly diffWordWrap = derived(this, reader => this._options.read(reader).diffWordWrap);
-	public readonly originalEditable = derived(this, reader => this._options.read(reader).originalEditable);
-	public readonly diffCodeLens = derived(this, reader => this._options.read(reader).diffCodeLens);
-	public readonly accessibilityVerbose = derived(this, reader => this._options.read(reader).accessibilityVerbose);
-	public readonly diffAlgorithm = derived(this, reader => this._options.read(reader).diffAlgorithm);
-	public readonly showEmptyDecorations = derived(this, reader => this._options.read(reader).experimental.showEmptyDecorations!);
-	public readonly onlyShowAccessibleDiffViewer = derived(this, reader => this._options.read(reader).onlyShowAccessibleDiffViewer);
-	public readonly compactMode = derived(this, reader => this._options.read(reader).compactMode);
-	private readonly trueInlineDiffRenderingEnabled: IObservable<boolean> = derived(this, reader =>
-		this._options.read(reader).experimental.useTrueInlineView!
-	);
+	public readonly useTrueInlineDiffRendering: IObservable<boolean>;
 
-	public readonly useTrueInlineDiffRendering: IObservable<boolean> = derived(this, reader =>
-		!this.renderSideBySide.read(reader) && this.trueInlineDiffRenderingEnabled.read(reader)
-	);
-
-	public readonly hideUnchangedRegions = derived(this, reader => this._options.read(reader).hideUnchangedRegions.enabled!);
-	public readonly hideUnchangedRegionsRevealLineCount = derived(this, reader => this._options.read(reader).hideUnchangedRegions.revealLineCount!);
-	public readonly hideUnchangedRegionsContextLineCount = derived(this, reader => this._options.read(reader).hideUnchangedRegions.contextLineCount!);
-	public readonly hideUnchangedRegionsMinimumLineCount = derived(this, reader => this._options.read(reader).hideUnchangedRegions.minimumLineCount!);
+	public readonly hideUnchangedRegions;
+	public readonly hideUnchangedRegionsRevealLineCount;
+	public readonly hideUnchangedRegionsContextLineCount;
+	public readonly hideUnchangedRegionsMinimumLineCount;
 
 	public updateOptions(changedOptions: IDiffEditorOptions): void {
 		const newDiffEditorOptions = validateDiffEditorOptions(changedOptions, this._options.get());
@@ -93,21 +131,15 @@ export class DiffEditorOptions {
 		this._diffEditorWidth.set(width, undefined);
 	}
 
-	private readonly _model = observableValue<DiffEditorViewModel | undefined>(this, undefined);
+	private readonly _model;
 
 	public setModel(model: DiffEditorViewModel | undefined) {
 		this._model.set(model, undefined);
 	}
 
-	private readonly shouldRenderInlineViewInSmartMode = this._model
-		.map(this, model => derivedConstOnceDefined(this, reader => {
-			const diffs = model?.diff.read(reader);
-			return diffs ? isSimpleDiff(diffs, this.trueInlineDiffRenderingEnabled.read(reader)) : undefined;
-		}))
-		.flatten()
-		.map(this, v => !!v);
+	private readonly shouldRenderInlineViewInSmartMode;
 
-	public readonly inlineViewHideOriginalLineNumbers = this.compactMode;
+	public readonly inlineViewHideOriginalLineNumbers;
 }
 
 function isSimpleDiff(diff: DiffState, supportsTrueDiffRendering: boolean): boolean {

--- a/src/vs/editor/browser/widget/diffEditor/diffEditorWidget.ts
+++ b/src/vs/editor/browser/widget/diffEditor/diffEditorWidget.ts
@@ -56,40 +56,30 @@ export interface IDiffCodeEditorWidgetOptions {
 export class DiffEditorWidget extends DelegatingEditor implements IDiffEditor {
 	public static ENTIRE_DIFF_OVERVIEW_WIDTH = OverviewRulerFeature.ENTIRE_DIFF_OVERVIEW_WIDTH;
 
-	private readonly elements = h('div.monaco-diff-editor.side-by-side', { style: { position: 'relative', height: '100%' } }, [
-		h('div.editor.original@original', { style: { position: 'absolute', height: '100%', } }),
-		h('div.editor.modified@modified', { style: { position: 'absolute', height: '100%', } }),
-		h('div.accessibleDiffViewer@accessibleDiffViewer', { style: { position: 'absolute', height: '100%' } }),
-	]);
-	private readonly _diffModelSrc = this._register(disposableObservableValue<RefCounted<DiffEditorViewModel> | undefined>(this, undefined));
-	private readonly _diffModel = derived<DiffEditorViewModel | undefined>(this, reader => this._diffModelSrc.read(reader)?.object);
-	public readonly onDidChangeModel = Event.fromObservableLight(this._diffModel);
+	private readonly elements;
+	private readonly _diffModelSrc;
+	private readonly _diffModel;
+	public readonly onDidChangeModel;
 
 	public get onDidContentSizeChange() { return this._editors.onDidContentSizeChange; }
 
-	private readonly _contextKeyService = this._register(this._parentContextKeyService.createScoped(this._domElement));
-	private readonly _instantiationService = this._register(this._parentInstantiationService.createChild(
-		new ServiceCollection([IContextKeyService, this._contextKeyService])
-	));
+	private readonly _contextKeyService;
+	private readonly _instantiationService;
 	private readonly _rootSizeObserver: ObservableElementSizeObserver;
 
 
 	private readonly _sashLayout: SashLayout;
 	private readonly _sash: IObservable<DiffEditorSash | undefined>;
-	private readonly _boundarySashes = observableValue<IBoundarySashes | undefined>(this, undefined);
+	private readonly _boundarySashes;
 
-	private _accessibleDiffViewerShouldBeVisible = observableValue(this, false);
-	private _accessibleDiffViewerVisible = derived(this, reader =>
-		this._options.onlyShowAccessibleDiffViewer.read(reader)
-			? true
-			: this._accessibleDiffViewerShouldBeVisible.read(reader)
-	);
+	private _accessibleDiffViewerShouldBeVisible;
+	private _accessibleDiffViewerVisible;
 	private readonly _accessibleDiffViewer: IObservable<AccessibleDiffViewer>;
 	private readonly _options: DiffEditorOptions;
 	private readonly _editors: DiffEditorEditors;
 
 	private readonly _overviewRulerPart: IObservable<OverviewRulerFeature | undefined>;
-	private readonly _movedBlocksLinesPart = observableValue<MovedBlocksLinesFeature | undefined>(this, undefined);
+	private readonly _movedBlocksLinesPart;
 
 	private readonly _gutter: IObservable<DiffEditorGutter | undefined>;
 
@@ -106,6 +96,89 @@ export class DiffEditorWidget extends DelegatingEditor implements IDiffEditor {
 		@IEditorProgressService private readonly _editorProgressService: IEditorProgressService,
 	) {
 		super();
+		this.elements = h('div.monaco-diff-editor.side-by-side', { style: { position: 'relative', height: '100%' } }, [
+			h('div.editor.original@original', { style: { position: 'absolute', height: '100%', } }),
+			h('div.editor.modified@modified', { style: { position: 'absolute', height: '100%', } }),
+			h('div.accessibleDiffViewer@accessibleDiffViewer', { style: { position: 'absolute', height: '100%' } }),
+		]);
+		this._diffModelSrc = this._register(disposableObservableValue<RefCounted<DiffEditorViewModel> | undefined>(this, undefined));
+		this._diffModel = derived<DiffEditorViewModel | undefined>(this, reader => this._diffModelSrc.read(reader)?.object);
+		this.onDidChangeModel = Event.fromObservableLight(this._diffModel);
+		this._contextKeyService = this._register(this._parentContextKeyService.createScoped(this._domElement));
+		this._instantiationService = this._register(this._parentInstantiationService.createChild(
+			new ServiceCollection([IContextKeyService, this._contextKeyService])
+		));
+		this._boundarySashes = observableValue<IBoundarySashes | undefined>(this, undefined);
+		this._accessibleDiffViewerShouldBeVisible = observableValue(this, false);
+		this._accessibleDiffViewerVisible = derived(this, reader =>
+			this._options.onlyShowAccessibleDiffViewer.read(reader)
+				? true
+				: this._accessibleDiffViewerShouldBeVisible.read(reader)
+		);
+		this._movedBlocksLinesPart = observableValue<MovedBlocksLinesFeature | undefined>(this, undefined);
+		this._layoutInfo = derived(this, reader => {
+			const fullWidth = this._rootSizeObserver.width.read(reader);
+			const fullHeight = this._rootSizeObserver.height.read(reader);
+
+			if (this._rootSizeObserver.automaticLayout) {
+				this.elements.root.style.height = '100%';
+			} else {
+				this.elements.root.style.height = fullHeight + 'px';
+			}
+
+			const sash = this._sash.read(reader);
+
+			const gutter = this._gutter.read(reader);
+			const gutterWidth = gutter?.width.read(reader) ?? 0;
+
+			const overviewRulerPartWidth = this._overviewRulerPart.read(reader)?.width ?? 0;
+
+			let originalLeft: number, originalWidth: number, modifiedLeft: number, modifiedWidth: number, gutterLeft: number;
+
+			const sideBySide = !!sash;
+			if (sideBySide) {
+				const sashLeft = sash.sashLeft.read(reader);
+				const movedBlocksLinesWidth = this._movedBlocksLinesPart.read(reader)?.width.read(reader) ?? 0;
+
+				originalLeft = 0;
+				originalWidth = sashLeft - gutterWidth - movedBlocksLinesWidth;
+
+				gutterLeft = sashLeft - gutterWidth;
+
+				modifiedLeft = sashLeft;
+				modifiedWidth = fullWidth - modifiedLeft - overviewRulerPartWidth;
+			} else {
+				gutterLeft = 0;
+
+				const shouldHideOriginalLineNumbers = this._options.inlineViewHideOriginalLineNumbers.read(reader);
+				originalLeft = gutterWidth;
+				if (shouldHideOriginalLineNumbers) {
+					originalWidth = 0;
+				} else {
+					originalWidth = Math.max(5, this._editors.originalObs.layoutInfoDecorationsLeft.read(reader));
+				}
+
+				modifiedLeft = gutterWidth + originalWidth;
+				modifiedWidth = fullWidth - modifiedLeft - overviewRulerPartWidth;
+			}
+
+			this.elements.original.style.left = originalLeft + 'px';
+			this.elements.original.style.width = originalWidth + 'px';
+			this._editors.original.layout({ width: originalWidth, height: fullHeight }, true);
+
+			gutter?.layout(gutterLeft);
+
+			this.elements.modified.style.left = modifiedLeft + 'px';
+			this.elements.modified.style.width = modifiedWidth + 'px';
+			this._editors.modified.layout({ width: modifiedWidth, height: fullHeight }, true);
+
+			return {
+				modifiedEditor: this._editors.modified.getLayoutInfo(),
+				originalEditor: this._editors.original.getLayoutInfo(),
+			};
+		});
+		this._diffValue = this._diffModel.map((m, r) => m?.diff.read(r));
+		this.onDidUpdateDiff = Event.fromObservableLight(this._diffValue);
 		codeEditorService.willCreateDiffEditor();
 
 		this._contextKeyService.createKey('isInDiffEditor', true);
@@ -350,67 +423,7 @@ export class DiffEditorWidget extends DelegatingEditor implements IDiffEditor {
 		return editor;
 	}
 
-	private readonly _layoutInfo = derived(this, reader => {
-		const fullWidth = this._rootSizeObserver.width.read(reader);
-		const fullHeight = this._rootSizeObserver.height.read(reader);
-
-		if (this._rootSizeObserver.automaticLayout) {
-			this.elements.root.style.height = '100%';
-		} else {
-			this.elements.root.style.height = fullHeight + 'px';
-		}
-
-		const sash = this._sash.read(reader);
-
-		const gutter = this._gutter.read(reader);
-		const gutterWidth = gutter?.width.read(reader) ?? 0;
-
-		const overviewRulerPartWidth = this._overviewRulerPart.read(reader)?.width ?? 0;
-
-		let originalLeft: number, originalWidth: number, modifiedLeft: number, modifiedWidth: number, gutterLeft: number;
-
-		const sideBySide = !!sash;
-		if (sideBySide) {
-			const sashLeft = sash.sashLeft.read(reader);
-			const movedBlocksLinesWidth = this._movedBlocksLinesPart.read(reader)?.width.read(reader) ?? 0;
-
-			originalLeft = 0;
-			originalWidth = sashLeft - gutterWidth - movedBlocksLinesWidth;
-
-			gutterLeft = sashLeft - gutterWidth;
-
-			modifiedLeft = sashLeft;
-			modifiedWidth = fullWidth - modifiedLeft - overviewRulerPartWidth;
-		} else {
-			gutterLeft = 0;
-
-			const shouldHideOriginalLineNumbers = this._options.inlineViewHideOriginalLineNumbers.read(reader);
-			originalLeft = gutterWidth;
-			if (shouldHideOriginalLineNumbers) {
-				originalWidth = 0;
-			} else {
-				originalWidth = Math.max(5, this._editors.originalObs.layoutInfoDecorationsLeft.read(reader));
-			}
-
-			modifiedLeft = gutterWidth + originalWidth;
-			modifiedWidth = fullWidth - modifiedLeft - overviewRulerPartWidth;
-		}
-
-		this.elements.original.style.left = originalLeft + 'px';
-		this.elements.original.style.width = originalWidth + 'px';
-		this._editors.original.layout({ width: originalWidth, height: fullHeight }, true);
-
-		gutter?.layout(gutterLeft);
-
-		this.elements.modified.style.left = modifiedLeft + 'px';
-		this.elements.modified.style.width = modifiedWidth + 'px';
-		this._editors.modified.layout({ width: modifiedWidth, height: fullHeight }, true);
-
-		return {
-			modifiedEditor: this._editors.modified.getLayoutInfo(),
-			originalEditor: this._editors.original.getLayoutInfo(),
-		};
-	});
+	private readonly _layoutInfo;
 
 	private _createDiffEditorContributions() {
 		const contributions: IDiffEditorContributionDescription[] = EditorExtensionsRegistry.getDiffEditorContributions();
@@ -526,8 +539,8 @@ export class DiffEditorWidget extends DelegatingEditor implements IDiffEditor {
 		this._boundarySashes.set(sashes, undefined);
 	}
 
-	private readonly _diffValue = this._diffModel.map((m, r) => m?.diff.read(r));
-	readonly onDidUpdateDiff: Event<void> = Event.fromObservableLight(this._diffValue);
+	private readonly _diffValue;
+	readonly onDidUpdateDiff: Event<void>;
 
 	get ignoreTrimWhitespace(): boolean { return this._options.ignoreTrimWhitespace.get(); }
 

--- a/src/vs/editor/browser/widget/diffEditor/features/gutterFeature.ts
+++ b/src/vs/editor/browser/widget/diffEditor/features/gutterFeature.ts
@@ -35,14 +35,14 @@ const emptyArr: never[] = [];
 const width = 35;
 
 export class DiffEditorGutter extends Disposable {
-	private readonly _menu = this._register(this._menuService.createMenu(MenuId.DiffEditorHunkToolbar, this._contextKeyService));
-	private readonly _actions = observableFromEvent(this, this._menu.onDidChange, () => this._menu.getActions());
-	private readonly _hasActions = this._actions.map(a => a.length > 0);
-	private readonly _showSash = derived(this, reader => this._options.renderSideBySide.read(reader) && this._hasActions.read(reader));
+	private readonly _menu;
+	private readonly _actions;
+	private readonly _hasActions;
+	private readonly _showSash;
 
-	public readonly width = derived(this, reader => this._hasActions.read(reader) ? width : 0);
+	public readonly width;
 
-	private readonly elements = h('div.gutter@gutter', { style: { position: 'absolute', height: '100%', width: width + 'px' } }, []);
+	private readonly elements;
 
 	constructor(
 		diffEditorRoot: HTMLDivElement,
@@ -56,6 +56,48 @@ export class DiffEditorGutter extends Disposable {
 		@IMenuService private readonly _menuService: IMenuService,
 	) {
 		super();
+		this._menu = this._register(this._menuService.createMenu(MenuId.DiffEditorHunkToolbar, this._contextKeyService));
+		this._actions = observableFromEvent(this, this._menu.onDidChange, () => this._menu.getActions());
+		this._hasActions = this._actions.map(a => a.length > 0);
+		this._showSash = derived(this, reader => this._options.renderSideBySide.read(reader) && this._hasActions.read(reader));
+		this.width = derived(this, reader => this._hasActions.read(reader) ? width : 0);
+		this.elements = h('div.gutter@gutter', { style: { position: 'absolute', height: '100%', width: width + 'px' } }, []);
+		this._currentDiff = derived(this, (reader) => {
+			const model = this._diffModel.read(reader);
+			if (!model) {
+				return undefined;
+			}
+			const mappings = model.diff.read(reader)?.mappings;
+
+			const cursorPosition = this._editors.modifiedCursor.read(reader);
+			if (!cursorPosition) { return undefined; }
+
+			return mappings?.find(m => m.lineRangeMapping.modified.contains(cursorPosition.lineNumber));
+		});
+		this._selectedDiffs = derived(this, (reader) => {
+			/** @description selectedDiffs */
+			const model = this._diffModel.read(reader);
+			const diff = model?.diff.read(reader);
+			// Return `emptyArr` because it is a constant. [] is always a new array and would trigger a change.
+			if (!diff) { return emptyArr; }
+
+			const selections = this._editors.modifiedSelections.read(reader);
+			if (selections.every(s => s.isEmpty())) { return emptyArr; }
+
+			const selectedLineNumbers = new LineRangeSet(selections.map(s => LineRange.fromRangeInclusive(s)));
+
+			const selectedMappings = diff.mappings.filter(m =>
+				m.lineRangeMapping.innerChanges && selectedLineNumbers.intersects(m.lineRangeMapping.modified)
+			);
+			const result = selectedMappings.map(mapping => ({
+				mapping,
+				rangeMappings: mapping.lineRangeMapping.innerChanges!.filter(
+					c => selections.some(s => Range.areIntersecting(c.modifiedRange, s))
+				)
+			}));
+			if (result.length === 0 || result.every(r => r.rangeMappings.length === 0)) { return emptyArr; }
+			return result;
+		});
 
 		this._register(prependRemoveOnDispose(diffEditorRoot, this.elements.root));
 
@@ -138,43 +180,9 @@ export class DiffEditorGutter extends Disposable {
 		return value;
 	}
 
-	private readonly _currentDiff = derived(this, (reader) => {
-		const model = this._diffModel.read(reader);
-		if (!model) {
-			return undefined;
-		}
-		const mappings = model.diff.read(reader)?.mappings;
+	private readonly _currentDiff;
 
-		const cursorPosition = this._editors.modifiedCursor.read(reader);
-		if (!cursorPosition) { return undefined; }
-
-		return mappings?.find(m => m.lineRangeMapping.modified.contains(cursorPosition.lineNumber));
-	});
-
-	private readonly _selectedDiffs = derived(this, (reader) => {
-		/** @description selectedDiffs */
-		const model = this._diffModel.read(reader);
-		const diff = model?.diff.read(reader);
-		// Return `emptyArr` because it is a constant. [] is always a new array and would trigger a change.
-		if (!diff) { return emptyArr; }
-
-		const selections = this._editors.modifiedSelections.read(reader);
-		if (selections.every(s => s.isEmpty())) { return emptyArr; }
-
-		const selectedLineNumbers = new LineRangeSet(selections.map(s => LineRange.fromRangeInclusive(s)));
-
-		const selectedMappings = diff.mappings.filter(m =>
-			m.lineRangeMapping.innerChanges && selectedLineNumbers.intersects(m.lineRangeMapping.modified)
-		);
-		const result = selectedMappings.map(mapping => ({
-			mapping,
-			rangeMappings: mapping.lineRangeMapping.innerChanges!.filter(
-				c => selections.some(s => Range.areIntersecting(c.modifiedRange, s))
-			)
-		}));
-		if (result.length === 0 || result.every(r => r.rangeMappings.length === 0)) { return emptyArr; }
-		return result;
-	});
+	private readonly _selectedDiffs;
 
 	layout(left: number) {
 		this.elements.gutter.style.left = left + 'px';
@@ -197,15 +205,12 @@ class DiffGutterItem implements IGutterItemInfo {
 
 
 class DiffToolBar extends Disposable implements IGutterItemView {
-	private readonly _elements = h('div.gutterItem', { style: { height: '20px', width: '34px' } }, [
-		h('div.background@background', {}, []),
-		h('div.buttons@buttons', {}, []),
-	]);
+	private readonly _elements;
 
-	private readonly _showAlways = this._item.map(this, item => item.showAlways);
-	private readonly _menuId = this._item.map(this, item => item.menuId);
+	private readonly _showAlways;
+	private readonly _menuId;
 
-	private readonly _isSmall = observableValue(this, false);
+	private readonly _isSmall;
 
 	constructor(
 		private readonly _item: IObservable<DiffGutterItem>,
@@ -214,6 +219,15 @@ class DiffToolBar extends Disposable implements IGutterItemView {
 		@IInstantiationService instantiationService: IInstantiationService
 	) {
 		super();
+		this._elements = h('div.gutterItem', { style: { height: '20px', width: '34px' } }, [
+			h('div.background@background', {}, []),
+			h('div.buttons@buttons', {}, []),
+		]);
+		this._showAlways = this._item.map(this, item => item.showAlways);
+		this._menuId = this._item.map(this, item => item.menuId);
+		this._isSmall = observableValue(this, false);
+		this._lastItemRange = undefined;
+		this._lastViewRange = undefined;
 
 		const hoverDelegate = this._register(instantiationService.createInstance(
 			WorkbenchHoverDelegate,
@@ -267,8 +281,8 @@ class DiffToolBar extends Disposable implements IGutterItemView {
 		}));
 	}
 
-	private _lastItemRange: OffsetRange | undefined = undefined;
-	private _lastViewRange: OffsetRange | undefined = undefined;
+	private _lastItemRange: OffsetRange | undefined;
+	private _lastViewRange: OffsetRange | undefined;
 
 	layout(itemRange: OffsetRange, viewRange: OffsetRange): void {
 		this._lastItemRange = itemRange;

--- a/src/vs/editor/browser/widget/diffEditor/features/movedBlocksLinesFeature.ts
+++ b/src/vs/editor/browser/widget/diffEditor/features/movedBlocksLinesFeature.ts
@@ -26,11 +26,11 @@ export class MovedBlocksLinesFeature extends Disposable {
 	public static readonly movedCodeBlockPadding = 4;
 
 	private readonly _element: SVGElement;
-	private readonly _originalScrollTop = observableFromEvent(this, this._editors.original.onDidScrollChange, () => this._editors.original.getScrollTop());
-	private readonly _modifiedScrollTop = observableFromEvent(this, this._editors.modified.onDidScrollChange, () => this._editors.modified.getScrollTop());
-	private readonly _viewZonesChanged = observableSignalFromEvent('onDidChangeViewZones', this._editors.modified.onDidChangeViewZones);
+	private readonly _originalScrollTop;
+	private readonly _modifiedScrollTop;
+	private readonly _viewZonesChanged;
 
-	public readonly width = observableValue(this, 0);
+	public readonly width;
 
 	constructor(
 		private readonly _rootElement: HTMLElement,
@@ -40,6 +40,122 @@ export class MovedBlocksLinesFeature extends Disposable {
 		private readonly _editors: DiffEditorEditors,
 	) {
 		super();
+		this._originalScrollTop = observableFromEvent(this, this._editors.original.onDidScrollChange, () => this._editors.original.getScrollTop());
+		this._modifiedScrollTop = observableFromEvent(this, this._editors.modified.onDidScrollChange, () => this._editors.modified.getScrollTop());
+		this._viewZonesChanged = observableSignalFromEvent('onDidChangeViewZones', this._editors.modified.onDidChangeViewZones);
+		this.width = observableValue(this, 0);
+		this._modifiedViewZonesChangedSignal = observableSignalFromEvent('modified.onDidChangeViewZones', this._editors.modified.onDidChangeViewZones);
+		this._originalViewZonesChangedSignal = observableSignalFromEvent('original.onDidChangeViewZones', this._editors.original.onDidChangeViewZones);
+		this._state = derivedWithStore(this, (reader, store) => {
+			/** @description state */
+
+			this._element.replaceChildren();
+			const model = this._diffModel.read(reader);
+			const moves = model?.diff.read(reader)?.movedTexts;
+			if (!moves || moves.length === 0) {
+				this.width.set(0, undefined);
+				return;
+			}
+
+			this._viewZonesChanged.read(reader);
+
+			const infoOrig = this._originalEditorLayoutInfo.read(reader);
+			const infoMod = this._modifiedEditorLayoutInfo.read(reader);
+			if (!infoOrig || !infoMod) {
+				this.width.set(0, undefined);
+				return;
+			}
+
+			this._modifiedViewZonesChangedSignal.read(reader);
+			this._originalViewZonesChangedSignal.read(reader);
+
+			const lines = moves.map((move) => {
+				function computeLineStart(range: LineRange, editor: ICodeEditor) {
+					const t1 = editor.getTopForLineNumber(range.startLineNumber, true);
+					const t2 = editor.getTopForLineNumber(range.endLineNumberExclusive, true);
+					return (t1 + t2) / 2;
+				}
+
+				const start = computeLineStart(move.lineRangeMapping.original, this._editors.original);
+				const startOffset = this._originalScrollTop.read(reader);
+				const end = computeLineStart(move.lineRangeMapping.modified, this._editors.modified);
+				const endOffset = this._modifiedScrollTop.read(reader);
+
+				const from = start - startOffset;
+				const to = end - endOffset;
+
+				const top = Math.min(start, end);
+				const bottom = Math.max(start, end);
+
+				return { range: new OffsetRange(top, bottom), from, to, fromWithoutScroll: start, toWithoutScroll: end, move };
+			});
+
+			lines.sort(tieBreakComparators(
+				compareBy(l => l.fromWithoutScroll > l.toWithoutScroll, booleanComparator),
+				compareBy(l => l.fromWithoutScroll > l.toWithoutScroll ? l.fromWithoutScroll : -l.toWithoutScroll, numberComparator)
+			));
+
+			const layout = LinesLayout.compute(lines.map(l => l.range));
+
+			const padding = 10;
+			const lineAreaLeft = infoOrig.verticalScrollbarWidth;
+			const lineAreaWidth = (layout.getTrackCount() - 1) * 10 + padding * 2;
+			const width = lineAreaLeft + lineAreaWidth + (infoMod.contentLeft - MovedBlocksLinesFeature.movedCodeBlockPadding);
+
+			let idx = 0;
+			for (const line of lines) {
+				const track = layout.getTrack(idx);
+				const verticalY = lineAreaLeft + padding + track * 10;
+
+				const arrowHeight = 15;
+				const arrowWidth = 15;
+				const right = width;
+
+				const rectWidth = infoMod.glyphMarginWidth + infoMod.lineNumbersWidth;
+				const rectHeight = 18;
+				const rect = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
+				rect.classList.add('arrow-rectangle');
+				rect.setAttribute('x', `${right - rectWidth}`);
+				rect.setAttribute('y', `${line.to - rectHeight / 2}`);
+				rect.setAttribute('width', `${rectWidth}`);
+				rect.setAttribute('height', `${rectHeight}`);
+				this._element.appendChild(rect);
+
+				const g = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+
+				const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+
+				path.setAttribute('d', `M ${0} ${line.from} L ${verticalY} ${line.from} L ${verticalY} ${line.to} L ${right - arrowWidth} ${line.to}`);
+				path.setAttribute('fill', 'none');
+				g.appendChild(path);
+
+				const arrowRight = document.createElementNS('http://www.w3.org/2000/svg', 'polygon');
+				arrowRight.classList.add('arrow');
+
+				store.add(autorun(reader => {
+					path.classList.toggle('currentMove', line.move === model.activeMovedText.read(reader));
+					arrowRight.classList.toggle('currentMove', line.move === model.activeMovedText.read(reader));
+				}));
+
+				arrowRight.setAttribute('points', `${right - arrowWidth},${line.to - arrowHeight / 2} ${right},${line.to} ${right - arrowWidth},${line.to + arrowHeight / 2}`);
+				g.appendChild(arrowRight);
+
+				this._element.appendChild(g);
+
+				/*
+				TODO@hediet
+				path.addEventListener('mouseenter', () => {
+					model.setHoveredMovedText(line.move);
+				});
+				path.addEventListener('mouseleave', () => {
+					model.setHoveredMovedText(undefined);
+				});*/
+
+				idx++;
+			}
+
+			this.width.set(lineAreaWidth, undefined);
+		});
 
 		this._element = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
 		this._element.setAttribute('class', 'moved-blocks-lines');
@@ -135,119 +251,10 @@ export class MovedBlocksLinesFeature extends Disposable {
 		}));
 	}
 
-	private readonly _modifiedViewZonesChangedSignal = observableSignalFromEvent('modified.onDidChangeViewZones', this._editors.modified.onDidChangeViewZones);
-	private readonly _originalViewZonesChangedSignal = observableSignalFromEvent('original.onDidChangeViewZones', this._editors.original.onDidChangeViewZones);
+	private readonly _modifiedViewZonesChangedSignal;
+	private readonly _originalViewZonesChangedSignal;
 
-	private readonly _state = derivedWithStore(this, (reader, store) => {
-		/** @description state */
-
-		this._element.replaceChildren();
-		const model = this._diffModel.read(reader);
-		const moves = model?.diff.read(reader)?.movedTexts;
-		if (!moves || moves.length === 0) {
-			this.width.set(0, undefined);
-			return;
-		}
-
-		this._viewZonesChanged.read(reader);
-
-		const infoOrig = this._originalEditorLayoutInfo.read(reader);
-		const infoMod = this._modifiedEditorLayoutInfo.read(reader);
-		if (!infoOrig || !infoMod) {
-			this.width.set(0, undefined);
-			return;
-		}
-
-		this._modifiedViewZonesChangedSignal.read(reader);
-		this._originalViewZonesChangedSignal.read(reader);
-
-		const lines = moves.map((move) => {
-			function computeLineStart(range: LineRange, editor: ICodeEditor) {
-				const t1 = editor.getTopForLineNumber(range.startLineNumber, true);
-				const t2 = editor.getTopForLineNumber(range.endLineNumberExclusive, true);
-				return (t1 + t2) / 2;
-			}
-
-			const start = computeLineStart(move.lineRangeMapping.original, this._editors.original);
-			const startOffset = this._originalScrollTop.read(reader);
-			const end = computeLineStart(move.lineRangeMapping.modified, this._editors.modified);
-			const endOffset = this._modifiedScrollTop.read(reader);
-
-			const from = start - startOffset;
-			const to = end - endOffset;
-
-			const top = Math.min(start, end);
-			const bottom = Math.max(start, end);
-
-			return { range: new OffsetRange(top, bottom), from, to, fromWithoutScroll: start, toWithoutScroll: end, move };
-		});
-
-		lines.sort(tieBreakComparators(
-			compareBy(l => l.fromWithoutScroll > l.toWithoutScroll, booleanComparator),
-			compareBy(l => l.fromWithoutScroll > l.toWithoutScroll ? l.fromWithoutScroll : -l.toWithoutScroll, numberComparator)
-		));
-
-		const layout = LinesLayout.compute(lines.map(l => l.range));
-
-		const padding = 10;
-		const lineAreaLeft = infoOrig.verticalScrollbarWidth;
-		const lineAreaWidth = (layout.getTrackCount() - 1) * 10 + padding * 2;
-		const width = lineAreaLeft + lineAreaWidth + (infoMod.contentLeft - MovedBlocksLinesFeature.movedCodeBlockPadding);
-
-		let idx = 0;
-		for (const line of lines) {
-			const track = layout.getTrack(idx);
-			const verticalY = lineAreaLeft + padding + track * 10;
-
-			const arrowHeight = 15;
-			const arrowWidth = 15;
-			const right = width;
-
-			const rectWidth = infoMod.glyphMarginWidth + infoMod.lineNumbersWidth;
-			const rectHeight = 18;
-			const rect = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
-			rect.classList.add('arrow-rectangle');
-			rect.setAttribute('x', `${right - rectWidth}`);
-			rect.setAttribute('y', `${line.to - rectHeight / 2}`);
-			rect.setAttribute('width', `${rectWidth}`);
-			rect.setAttribute('height', `${rectHeight}`);
-			this._element.appendChild(rect);
-
-			const g = document.createElementNS('http://www.w3.org/2000/svg', 'g');
-
-			const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
-
-			path.setAttribute('d', `M ${0} ${line.from} L ${verticalY} ${line.from} L ${verticalY} ${line.to} L ${right - arrowWidth} ${line.to}`);
-			path.setAttribute('fill', 'none');
-			g.appendChild(path);
-
-			const arrowRight = document.createElementNS('http://www.w3.org/2000/svg', 'polygon');
-			arrowRight.classList.add('arrow');
-
-			store.add(autorun(reader => {
-				path.classList.toggle('currentMove', line.move === model.activeMovedText.read(reader));
-				arrowRight.classList.toggle('currentMove', line.move === model.activeMovedText.read(reader));
-			}));
-
-			arrowRight.setAttribute('points', `${right - arrowWidth},${line.to - arrowHeight / 2} ${right},${line.to} ${right - arrowWidth},${line.to + arrowHeight / 2}`);
-			g.appendChild(arrowRight);
-
-			this._element.appendChild(g);
-
-			/*
-			TODO@hediet
-			path.addEventListener('mouseenter', () => {
-				model.setHoveredMovedText(line.move);
-			});
-			path.addEventListener('mouseleave', () => {
-				model.setHoveredMovedText(undefined);
-			});*/
-
-			idx++;
-		}
-
-		this.width.set(lineAreaWidth, undefined);
-	});
+	private readonly _state;
 }
 
 class LinesLayout {

--- a/src/vs/editor/browser/widget/diffEditor/features/revertButtonsFeature.ts
+++ b/src/vs/editor/browser/widget/diffEditor/features/revertButtonsFeature.ts
@@ -107,17 +107,11 @@ export class RevertButtonsFeature extends Disposable {
 export class RevertButton extends Disposable implements IGlyphMarginWidget {
 	public static counter = 0;
 
-	private readonly _id: string = `revertButton${RevertButton.counter++}`;
+	private readonly _id: string;
 
 	getId(): string { return this._id; }
 
-	private readonly _domNode = h('div.revertButton', {
-		title: this._revertSelection
-			? localize('revertSelectedChanges', 'Revert Selected Changes')
-			: localize('revertChange', 'Revert Change')
-	},
-		[renderIcon(Codicon.arrowRight)]
-	).root;
+	private readonly _domNode;
 
 	constructor(
 		private readonly _lineNumber: number,
@@ -126,6 +120,14 @@ export class RevertButton extends Disposable implements IGlyphMarginWidget {
 		private readonly _revertSelection: boolean,
 	) {
 		super();
+		this._id = `revertButton${RevertButton.counter++}`;
+		this._domNode = h('div.revertButton', {
+			title: this._revertSelection
+				? localize('revertSelectedChanges', 'Revert Selected Changes')
+				: localize('revertChange', 'Revert Change')
+		},
+			[renderIcon(Codicon.arrowRight)]
+		).root;
 
 
 		this._register(addDisposableListener(this._domNode, EventType.MOUSE_DOWN, e => {

--- a/src/vs/editor/browser/widget/diffEditor/utils.ts
+++ b/src/vs/editor/browser/widget/diffEditor/utils.ts
@@ -221,33 +221,42 @@ export interface IObservableViewZone extends IViewZone {
 }
 
 export class PlaceholderViewZone implements IObservableViewZone {
-	public readonly domNode = document.createElement('div');
+	public readonly domNode;
 
-	private readonly _actualTop = observableValue<number | undefined>(this, undefined);
-	private readonly _actualHeight = observableValue<number | undefined>(this, undefined);
+	private readonly _actualTop;
+	private readonly _actualHeight;
 
-	public readonly actualTop: IObservable<number | undefined> = this._actualTop;
-	public readonly actualHeight: IObservable<number | undefined> = this._actualHeight;
+	public readonly actualTop: IObservable<number | undefined>;
+	public readonly actualHeight: IObservable<number | undefined>;
 
-	public readonly showInHiddenAreas = true;
+	public readonly showInHiddenAreas;
 
 	public get afterLineNumber(): number { return this._afterLineNumber.get(); }
 
-	public readonly onChange?: IObservable<unknown> = this._afterLineNumber;
+	public readonly onChange?: IObservable<unknown>;
 
 	constructor(
 		private readonly _afterLineNumber: IObservable<number>,
 		public readonly heightInPx: number,
 	) {
+		this.domNode = document.createElement('div');
+		this._actualTop = observableValue<number | undefined>(this, undefined);
+		this._actualHeight = observableValue<number | undefined>(this, undefined);
+		this.actualTop = this._actualTop;
+		this.actualHeight = this._actualHeight;
+		this.showInHiddenAreas = true;
+		this.onChange = this._afterLineNumber;
+		this.onDomNodeTop = (top: number) => {
+			this._actualTop.set(top, undefined);
+		};
+		this.onComputedHeight = (height: number) => {
+			this._actualHeight.set(height, undefined);
+		};
 	}
 
-	onDomNodeTop = (top: number) => {
-		this._actualTop.set(top, undefined);
-	};
+	onDomNodeTop;
 
-	onComputedHeight = (height: number) => {
-		this._actualHeight.set(height, undefined);
-	};
+	onComputedHeight;
 }
 
 

--- a/src/vs/editor/browser/widget/diffEditor/utils/editorGutter.ts
+++ b/src/vs/editor/browser/widget/diffEditor/utils/editorGutter.ts
@@ -11,19 +11,13 @@ import { LineRange } from '../../../../common/core/ranges/lineRange.js';
 import { OffsetRange } from '../../../../common/core/offsetRange.js';
 
 export class EditorGutter<T extends IGutterItemInfo = IGutterItemInfo> extends Disposable {
-	private readonly scrollTop = observableFromEvent(this,
-		this._editor.onDidScrollChange,
-		(e) => /** @description editor.onDidScrollChange */ this._editor.getScrollTop()
-	);
-	private readonly isScrollTopZero = this.scrollTop.map((scrollTop) => /** @description isScrollTopZero */ scrollTop === 0);
-	private readonly modelAttached = observableFromEvent(this,
-		this._editor.onDidChangeModel,
-		(e) => /** @description editor.onDidChangeModel */ this._editor.hasModel()
-	);
+	private readonly scrollTop;
+	private readonly isScrollTopZero;
+	private readonly modelAttached;
 
-	private readonly editorOnDidChangeViewZones = observableSignalFromEvent('onDidChangeViewZones', this._editor.onDidChangeViewZones);
-	private readonly editorOnDidContentSizeChange = observableSignalFromEvent('onDidContentSizeChange', this._editor.onDidContentSizeChange);
-	private readonly domNodeSizeChanged = observableSignal('domNodeSizeChanged');
+	private readonly editorOnDidChangeViewZones;
+	private readonly editorOnDidContentSizeChange;
+	private readonly domNodeSizeChanged;
 
 	constructor(
 		private readonly _editor: CodeEditorWidget,
@@ -31,6 +25,19 @@ export class EditorGutter<T extends IGutterItemInfo = IGutterItemInfo> extends D
 		private readonly itemProvider: IGutterItemProvider<T>
 	) {
 		super();
+		this.scrollTop = observableFromEvent(this,
+			this._editor.onDidScrollChange,
+			(e) => /** @description editor.onDidScrollChange */ this._editor.getScrollTop()
+		);
+		this.isScrollTopZero = this.scrollTop.map((scrollTop) => /** @description isScrollTopZero */ scrollTop === 0);
+		this.modelAttached = observableFromEvent(this,
+			this._editor.onDidChangeModel,
+			(e) => /** @description editor.onDidChangeModel */ this._editor.hasModel()
+		);
+		this.editorOnDidChangeViewZones = observableSignalFromEvent('onDidChangeViewZones', this._editor.onDidChangeViewZones);
+		this.editorOnDidContentSizeChange = observableSignalFromEvent('onDidContentSizeChange', this._editor.onDidContentSizeChange);
+		this.domNodeSizeChanged = observableSignal('domNodeSizeChanged');
+		this.views = new Map<string, ManagedGutterItemView>();
 		this._domNode.className = 'gutter monaco-editor';
 		const scrollDecoration = this._domNode.appendChild(
 			h('div.scroll-decoration', { role: 'presentation', ariaHidden: 'true', style: { width: '100%' } })
@@ -60,7 +67,7 @@ export class EditorGutter<T extends IGutterItemInfo = IGutterItemInfo> extends D
 		reset(this._domNode);
 	}
 
-	private readonly views = new Map<string, ManagedGutterItemView>();
+	private readonly views;
 
 	private render(reader: IReader): void {
 		if (!this.modelAttached.read(reader)) {

--- a/src/vs/editor/browser/widget/multiDiffEditor/diffEditorItemTemplate.ts
+++ b/src/vs/editor/browser/widget/multiDiffEditor/diffEditorItemTemplate.ts
@@ -35,64 +35,31 @@ export class TemplateData implements IObjectData {
 }
 
 export class DiffEditorItemTemplate extends Disposable implements IPooledObject<TemplateData> {
-	private readonly _viewModel = observableValue<DocumentDiffItemViewModel | undefined>(this, undefined);
+	private readonly _viewModel;
 
-	private readonly _collapsed = derived(this, reader => this._viewModel.read(reader)?.collapsed.read(reader));
+	private readonly _collapsed;
 
-	private readonly _editorContentHeight = observableValue<number>(this, 500);
-	public readonly contentHeight = derived(this, reader => {
-		const h = this._collapsed.read(reader) ? 0 : this._editorContentHeight.read(reader);
-		return h + this._outerEditorHeight;
-	});
+	private readonly _editorContentHeight;
+	public readonly contentHeight;
 
-	private readonly _modifiedContentWidth = observableValue<number>(this, 0);
-	private readonly _modifiedWidth = observableValue<number>(this, 0);
-	private readonly _originalContentWidth = observableValue<number>(this, 0);
-	private readonly _originalWidth = observableValue<number>(this, 0);
+	private readonly _modifiedContentWidth;
+	private readonly _modifiedWidth;
+	private readonly _originalContentWidth;
+	private readonly _originalWidth;
 
-	public readonly maxScroll = derived(this, reader => {
-		const scroll1 = this._modifiedContentWidth.read(reader) - this._modifiedWidth.read(reader);
-		const scroll2 = this._originalContentWidth.read(reader) - this._originalWidth.read(reader);
-		if (scroll1 > scroll2) {
-			return { maxScroll: scroll1, width: this._modifiedWidth.read(reader) };
-		} else {
-			return { maxScroll: scroll2, width: this._originalWidth.read(reader) };
-		}
-	});
+	public readonly maxScroll;
 
-	private readonly _elements = h('div.multiDiffEntry', [
-		h('div.header@header', [
-			h('div.header-content', [
-				h('div.collapse-button@collapseButton'),
-				h('div.file-path', [
-					h('div.title.modified.show-file-icons@primaryPath', [] as any),
-					h('div.status.deleted@status', ['R']),
-					h('div.title.original.show-file-icons@secondaryPath', [] as any),
-				]),
-				h('div.actions@actions'),
-			]),
-		]),
+	private readonly _elements;
 
-		h('div.editorParent', [
-			h('div.editorContainer@editor'),
-		])
-	]) as Record<string, HTMLElement>;
+	public readonly editor;
 
-	public readonly editor = this._register(this._instantiationService.createInstance(DiffEditorWidget, this._elements.editor, {
-		overflowWidgetsDomNode: this._overflowWidgetsDomNode,
-	}, {}));
+	private readonly isModifedFocused;
+	private readonly isOriginalFocused;
+	public readonly isFocused;
 
-	private readonly isModifedFocused = observableCodeEditor(this.editor.getModifiedEditor()).isFocused;
-	private readonly isOriginalFocused = observableCodeEditor(this.editor.getOriginalEditor()).isFocused;
-	public readonly isFocused = derived(this, reader => this.isModifedFocused.read(reader) || this.isOriginalFocused.read(reader));
+	private readonly _resourceLabel;
 
-	private readonly _resourceLabel = this._workbenchUIElementFactory.createResourceLabel
-		? this._register(this._workbenchUIElementFactory.createResourceLabel(this._elements.primaryPath))
-		: undefined;
-
-	private readonly _resourceLabel2 = this._workbenchUIElementFactory.createResourceLabel
-		? this._register(this._workbenchUIElementFactory.createResourceLabel(this._elements.secondaryPath))
-		: undefined;
+	private readonly _resourceLabel2;
 
 	private readonly _outerEditorHeight: number;
 	private readonly _contextKeyService: IScopedContextKeyService;
@@ -105,6 +72,59 @@ export class DiffEditorItemTemplate extends Disposable implements IPooledObject<
 		@IContextKeyService _parentContextKeyService: IContextKeyService,
 	) {
 		super();
+		this._viewModel = observableValue<DocumentDiffItemViewModel | undefined>(this, undefined);
+		this._collapsed = derived(this, reader => this._viewModel.read(reader)?.collapsed.read(reader));
+		this._editorContentHeight = observableValue<number>(this, 500);
+		this.contentHeight = derived(this, reader => {
+			const h = this._collapsed.read(reader) ? 0 : this._editorContentHeight.read(reader);
+			return h + this._outerEditorHeight;
+		});
+		this._modifiedContentWidth = observableValue<number>(this, 0);
+		this._modifiedWidth = observableValue<number>(this, 0);
+		this._originalContentWidth = observableValue<number>(this, 0);
+		this._originalWidth = observableValue<number>(this, 0);
+		this.maxScroll = derived(this, reader => {
+			const scroll1 = this._modifiedContentWidth.read(reader) - this._modifiedWidth.read(reader);
+			const scroll2 = this._originalContentWidth.read(reader) - this._originalWidth.read(reader);
+			if (scroll1 > scroll2) {
+				return { maxScroll: scroll1, width: this._modifiedWidth.read(reader) };
+			} else {
+				return { maxScroll: scroll2, width: this._originalWidth.read(reader) };
+			}
+		});
+		this._elements = h('div.multiDiffEntry', [
+			h('div.header@header', [
+				h('div.header-content', [
+					h('div.collapse-button@collapseButton'),
+					h('div.file-path', [
+						h('div.title.modified.show-file-icons@primaryPath', [] as any),
+						h('div.status.deleted@status', ['R']),
+						h('div.title.original.show-file-icons@secondaryPath', [] as any),
+					]),
+					h('div.actions@actions'),
+				]),
+			]),
+
+			h('div.editorParent', [
+				h('div.editorContainer@editor'),
+			])
+		]) as Record<string, HTMLElement>;
+		this.editor = this._register(this._instantiationService.createInstance(DiffEditorWidget, this._elements.editor, {
+			overflowWidgetsDomNode: this._overflowWidgetsDomNode,
+		}, {}));
+		this.isModifedFocused = observableCodeEditor(this.editor.getModifiedEditor()).isFocused;
+		this.isOriginalFocused = observableCodeEditor(this.editor.getOriginalEditor()).isFocused;
+		this.isFocused = derived(this, reader => this.isModifedFocused.read(reader) || this.isOriginalFocused.read(reader));
+		this._resourceLabel = this._workbenchUIElementFactory.createResourceLabel
+			? this._register(this._workbenchUIElementFactory.createResourceLabel(this._elements.primaryPath))
+			: undefined;
+		this._resourceLabel2 = this._workbenchUIElementFactory.createResourceLabel
+			? this._register(this._workbenchUIElementFactory.createResourceLabel(this._elements.secondaryPath))
+			: undefined;
+		this._dataStore = this._register(new DisposableStore());
+		this._headerHeight = 40;
+		this._lastScrollTop = -1;
+		this._isSettingScrollTop = false;
 
 		const btn = new Button(this._elements.collapseButton, {});
 
@@ -178,7 +198,7 @@ export class DiffEditorItemTemplate extends Disposable implements IPooledObject<
 		}
 	}
 
-	private readonly _dataStore = this._register(new DisposableStore());
+	private readonly _dataStore;
 
 	private _data: TemplateData | undefined;
 
@@ -261,10 +281,10 @@ export class DiffEditorItemTemplate extends Disposable implements IPooledObject<
 		}
 	}
 
-	private readonly _headerHeight = /*this._elements.header.clientHeight*/ 40;
+	private readonly _headerHeight;
 
-	private _lastScrollTop = -1;
-	private _isSettingScrollTop = false;
+	private _lastScrollTop;
+	private _isSettingScrollTop;
 
 	public render(verticalRange: OffsetRange, width: number, editorScroll: number, viewPort: OffsetRange): void {
 		this._elements.root.style.visibility = 'visible';

--- a/src/vs/editor/browser/widget/multiDiffEditor/multiDiffEditorWidgetImpl.ts
+++ b/src/vs/editor/browser/widget/multiDiffEditor/multiDiffEditorWidgetImpl.ts
@@ -33,90 +33,32 @@ import './style.css';
 import { IWorkbenchUIElementFactory } from './workbenchUIElementFactory.js';
 
 export class MultiDiffEditorWidgetImpl extends Disposable {
-	private readonly _scrollableElements = h('div.scrollContent', [
-		h('div@content', {
-			style: {
-				overflow: 'hidden',
-			}
-		}),
-		h('div.monaco-editor@overflowWidgetsDomNode', {
-		}),
-	]);
+	private readonly _scrollableElements;
 
-	private readonly _scrollable = this._register(new Scrollable({
-		forceIntegerValues: false,
-		scheduleAtNextAnimationFrame: (cb) => scheduleAtNextAnimationFrame(getWindow(this._element), cb),
-		smoothScrollDuration: 100,
-	}));
+	private readonly _scrollable;
 
-	private readonly _scrollableElement = this._register(new SmoothScrollableElement(this._scrollableElements.root, {
-		vertical: ScrollbarVisibility.Auto,
-		horizontal: ScrollbarVisibility.Auto,
-		useShadows: false,
-	}, this._scrollable));
+	private readonly _scrollableElement;
 
-	private readonly _elements = h('div.monaco-component.multiDiffEditor', {}, [
-		h('div', {}, [this._scrollableElement.getDomNode()]),
-		h('div.placeholder@placeholder', {}, [h('div')]),
-	]);
+	private readonly _elements;
 
-	private readonly _sizeObserver = this._register(new ObservableElementSizeObserver(this._element, undefined));
+	private readonly _sizeObserver;
 
-	private readonly _objectPool = this._register(new ObjectPool<TemplateData, DiffEditorItemTemplate>((data) => {
-		const template = this._instantiationService.createInstance(
-			DiffEditorItemTemplate,
-			this._scrollableElements.content,
-			this._scrollableElements.overflowWidgetsDomNode,
-			this._workbenchUIElementFactory
-		);
-		template.setData(data);
-		return template;
-	}));
+	private readonly _objectPool;
 
-	public readonly scrollTop = observableFromEvent(this, this._scrollableElement.onScroll, () => /** @description scrollTop */ this._scrollableElement.getScrollPosition().scrollTop);
-	public readonly scrollLeft = observableFromEvent(this, this._scrollableElement.onScroll, () => /** @description scrollLeft */ this._scrollableElement.getScrollPosition().scrollLeft);
+	public readonly scrollTop;
+	public readonly scrollLeft;
 
-	private readonly _viewItemsInfo = derivedWithStore<{ items: readonly VirtualizedViewItem[]; getItem: (viewModel: DocumentDiffItemViewModel) => VirtualizedViewItem }>(this,
-		(reader, store) => {
-			const vm = this._viewModel.read(reader);
-			if (!vm) {
-				return { items: [], getItem: _d => { throw new BugIndicatingError(); } };
-			}
-			const viewModels = vm.items.read(reader);
-			const map = new Map<DocumentDiffItemViewModel, VirtualizedViewItem>();
-			const items = viewModels.map(d => {
-				const item = store.add(new VirtualizedViewItem(d, this._objectPool, this.scrollLeft, delta => {
-					this._scrollableElement.setScrollPosition({ scrollTop: this._scrollableElement.getScrollPosition().scrollTop + delta });
-				}));
-				const data = this._lastDocStates?.[item.getKey()];
-				if (data) {
-					transaction(tx => {
-						item.setViewState(data, tx);
-					});
-				}
-				map.set(d, item);
-				return item;
-			});
-			return { items, getItem: d => map.get(d)! };
-		}
-	);
+	private readonly _viewItemsInfo;
 
-	private readonly _viewItems = this._viewItemsInfo.map(this, items => items.items);
+	private readonly _viewItems;
 
-	private readonly _spaceBetweenPx = 0;
+	private readonly _spaceBetweenPx;
 
-	private readonly _totalHeight = this._viewItems.map(this, (items, reader) => items.reduce((r, i) => r + i.contentHeight.read(reader) + this._spaceBetweenPx, 0));
-	public readonly activeControl = derived(this, reader => {
-		const activeDiffItem = this._viewModel.read(reader)?.activeDiffItem.read(reader);
-		if (!activeDiffItem) { return undefined; }
-		const viewItem = this._viewItemsInfo.read(reader).getItem(activeDiffItem);
-		return viewItem.template.read(reader)?.editor;
-	});
+	private readonly _totalHeight;
+	public readonly activeControl;
 
-	private readonly _contextKeyService = this._register(this._parentContextKeyService.createScoped(this._element));
-	private readonly _instantiationService = this._register(this._parentInstantiationService.createChild(
-		new ServiceCollection([IContextKeyService, this._contextKeyService])
-	));
+	private readonly _contextKeyService;
+	private readonly _instantiationService;
 
 	constructor(
 		private readonly _element: HTMLElement,
@@ -127,6 +69,80 @@ export class MultiDiffEditorWidgetImpl extends Disposable {
 		@IInstantiationService private readonly _parentInstantiationService: IInstantiationService,
 	) {
 		super();
+		this._scrollableElements = h('div.scrollContent', [
+			h('div@content', {
+				style: {
+					overflow: 'hidden',
+				}
+			}),
+			h('div.monaco-editor@overflowWidgetsDomNode', {
+			}),
+		]);
+		this._scrollable = this._register(new Scrollable({
+			forceIntegerValues: false,
+			scheduleAtNextAnimationFrame: (cb) => scheduleAtNextAnimationFrame(getWindow(this._element), cb),
+			smoothScrollDuration: 100,
+		}));
+		this._scrollableElement = this._register(new SmoothScrollableElement(this._scrollableElements.root, {
+			vertical: ScrollbarVisibility.Auto,
+			horizontal: ScrollbarVisibility.Auto,
+			useShadows: false,
+		}, this._scrollable));
+		this._elements = h('div.monaco-component.multiDiffEditor', {}, [
+			h('div', {}, [this._scrollableElement.getDomNode()]),
+			h('div.placeholder@placeholder', {}, [h('div')]),
+		]);
+		this._sizeObserver = this._register(new ObservableElementSizeObserver(this._element, undefined));
+		this._objectPool = this._register(new ObjectPool<TemplateData, DiffEditorItemTemplate>((data) => {
+			const template = this._instantiationService.createInstance(
+				DiffEditorItemTemplate,
+				this._scrollableElements.content,
+				this._scrollableElements.overflowWidgetsDomNode,
+				this._workbenchUIElementFactory
+			);
+			template.setData(data);
+			return template;
+		}));
+		this.scrollTop = observableFromEvent(this, this._scrollableElement.onScroll, () => /** @description scrollTop */ this._scrollableElement.getScrollPosition().scrollTop);
+		this.scrollLeft = observableFromEvent(this, this._scrollableElement.onScroll, () => /** @description scrollLeft */ this._scrollableElement.getScrollPosition().scrollLeft);
+		this._viewItemsInfo = derivedWithStore<{ items: readonly VirtualizedViewItem[]; getItem: (viewModel: DocumentDiffItemViewModel) => VirtualizedViewItem }>(this,
+			(reader, store) => {
+				const vm = this._viewModel.read(reader);
+				if (!vm) {
+					return { items: [], getItem: _d => { throw new BugIndicatingError(); } };
+				}
+				const viewModels = vm.items.read(reader);
+				const map = new Map<DocumentDiffItemViewModel, VirtualizedViewItem>();
+				const items = viewModels.map(d => {
+					const item = store.add(new VirtualizedViewItem(d, this._objectPool, this.scrollLeft, delta => {
+						this._scrollableElement.setScrollPosition({ scrollTop: this._scrollableElement.getScrollPosition().scrollTop + delta });
+					}));
+					const data = this._lastDocStates?.[item.getKey()];
+					if (data) {
+						transaction(tx => {
+							item.setViewState(data, tx);
+						});
+					}
+					map.set(d, item);
+					return item;
+				});
+				return { items, getItem: d => map.get(d)! };
+			}
+		);
+		this._viewItems = this._viewItemsInfo.map(this, items => items.items);
+		this._spaceBetweenPx = 0;
+		this._totalHeight = this._viewItems.map(this, (items, reader) => items.reduce((r, i) => r + i.contentHeight.read(reader) + this._spaceBetweenPx, 0));
+		this.activeControl = derived(this, reader => {
+			const activeDiffItem = this._viewModel.read(reader)?.activeDiffItem.read(reader);
+			if (!activeDiffItem) { return undefined; }
+			const viewItem = this._viewItemsInfo.read(reader).getItem(activeDiffItem);
+			return viewItem.template.read(reader)?.editor;
+		});
+		this._contextKeyService = this._register(this._parentContextKeyService.createScoped(this._element));
+		this._instantiationService = this._register(this._parentInstantiationService.createChild(
+			new ServiceCollection([IContextKeyService, this._contextKeyService])
+		));
+		this._lastDocStates = {};
 
 		this._register(autorunWithStore((reader, store) => {
 			const viewModel = this._viewModel.read(reader);
@@ -251,7 +267,7 @@ export class MultiDiffEditorWidgetImpl extends Disposable {
 	}
 
 	/** This accounts for documents that are not loaded yet. */
-	private _lastDocStates: IMultiDiffEditorViewState['docStates'] = {};
+	private _lastDocStates: IMultiDiffEditorViewState['docStates'];
 
 	public setViewState(viewState: IMultiDiffEditorViewState): void {
 		this.setScrollState(viewState.scrollState);

--- a/src/vs/editor/common/model/bracketPairsTextModelPart/bracketPairsTree/bracketPairsTree.ts
+++ b/src/vs/editor/common/model/bracketPairsTextModelPart/bracketPairsTree/bracketPairsTree.ts
@@ -25,7 +25,7 @@ import { combineTextEditInfos } from './combineTextEditInfos.js';
 import { ClosingBracketKind, OpeningBracketKind } from '../../../languages/supports/languageBracketsConfiguration.js';
 
 export class BracketPairsTree extends Disposable {
-	private readonly didChangeEmitter = new Emitter<void>();
+	private readonly didChangeEmitter;
 
 	/*
 		There are two trees:
@@ -39,22 +39,28 @@ export class BracketPairsTree extends Disposable {
 	private initialAstWithoutTokens: AstNode | undefined;
 	private astWithTokens: AstNode | undefined;
 
-	private readonly denseKeyProvider = new DenseKeyProvider<string>();
-	private readonly brackets = new LanguageAgnosticBracketTokens(this.denseKeyProvider, this.getLanguageConfiguration);
+	private readonly denseKeyProvider;
+	private readonly brackets;
 
 	public didLanguageChange(languageId: string): boolean {
 		return this.brackets.didLanguageChange(languageId);
 	}
 
-	public readonly onDidChange = this.didChangeEmitter.event;
-	private queuedTextEditsForInitialAstWithoutTokens: TextEditInfo[] = [];
-	private queuedTextEdits: TextEditInfo[] = [];
+	public readonly onDidChange;
+	private queuedTextEditsForInitialAstWithoutTokens: TextEditInfo[];
+	private queuedTextEdits: TextEditInfo[];
 
 	public constructor(
 		private readonly textModel: TextModel,
 		private readonly getLanguageConfiguration: (languageId: string) => ResolvedLanguageConfiguration
 	) {
 		super();
+		this.didChangeEmitter = new Emitter<void>();
+		this.denseKeyProvider = new DenseKeyProvider<string>();
+		this.brackets = new LanguageAgnosticBracketTokens(this.denseKeyProvider, this.getLanguageConfiguration);
+		this.onDidChange = this.didChangeEmitter.event;
+		this.queuedTextEditsForInitialAstWithoutTokens = [];
+		this.queuedTextEdits = [];
 
 		if (!textModel.tokenization.hasTokens) {
 			const brackets = this.brackets.getSingleLanguageBracketTokens(this.textModel.getLanguageId());

--- a/src/vs/editor/common/model/bracketPairsTextModelPart/bracketPairsTree/tokenizer.ts
+++ b/src/vs/editor/common/model/bracketPairsTextModelPart/bracketPairsTree/tokenizer.ts
@@ -64,17 +64,21 @@ export class TextBufferTokenizer implements Tokenizer {
 	private readonly textBufferLineCount: number;
 	private readonly textBufferLastLineLength: number;
 
-	private readonly reader = new NonPeekableTextBufferTokenizer(this.textModel, this.bracketTokens);
+	private readonly reader;
 
 	constructor(
 		private readonly textModel: ITokenizerSource,
 		private readonly bracketTokens: LanguageAgnosticBracketTokens
 	) {
+		this.reader = new NonPeekableTextBufferTokenizer(this.textModel, this.bracketTokens);
+		this._offset = lengthZero;
+		this.didPeek = false;
+		this.peeked = null;
 		this.textBufferLineCount = textModel.getLineCount();
 		this.textBufferLastLineLength = textModel.getLineLength(this.textBufferLineCount);
 	}
 
-	private _offset: Length = lengthZero;
+	private _offset: Length;
 
 	get offset() {
 		return this._offset;
@@ -95,8 +99,8 @@ export class TextBufferTokenizer implements Tokenizer {
 		this.reader.setPosition(obj.lineCount, obj.columnCount);
 	}
 
-	private didPeek = false;
-	private peeked: Token | null = null;
+	private didPeek;
+	private peeked: Token | null;
 
 	read(): Token | null {
 		let token: Token | null;

--- a/src/vs/editor/common/model/textModelTokens.ts
+++ b/src/vs/editor/common/model/textModelTokens.ts
@@ -25,7 +25,7 @@ const enum Constants {
 }
 
 export class TokenizerWithStateStore<TState extends IState = IState> {
-	private readonly initialState = this.tokenizationSupport.getInitialState() as TState;
+	private readonly initialState;
 
 	public readonly store: TrackingTokenizationStateStore<TState>;
 
@@ -33,6 +33,7 @@ export class TokenizerWithStateStore<TState extends IState = IState> {
 		lineCount: number,
 		public readonly tokenizationSupport: ITokenizationSupport
 	) {
+		this.initialState = this.tokenizationSupport.getInitialState() as TState;
 		this.store = new TrackingTokenizationStateStore<TState>(lineCount);
 	}
 

--- a/src/vs/editor/common/model/tokenizationTextModelPart.ts
+++ b/src/vs/editor/common/model/tokenizationTextModelPart.ts
@@ -34,19 +34,19 @@ import { SparseTokensStore } from '../tokens/sparseTokensStore.js';
 import { IInstantiationService } from '../../../platform/instantiation/common/instantiation.js';
 
 export class TokenizationTextModelPart extends TextModelPart implements ITokenizationTextModelPart {
-	private readonly _semanticTokens: SparseTokensStore = new SparseTokensStore(this._languageService.languageIdCodec);
+	private readonly _semanticTokens: SparseTokensStore;
 
-	private readonly _onDidChangeLanguage: Emitter<IModelLanguageChangedEvent> = this._register(new Emitter<IModelLanguageChangedEvent>());
-	public readonly onDidChangeLanguage: Event<IModelLanguageChangedEvent> = this._onDidChangeLanguage.event;
+	private readonly _onDidChangeLanguage: Emitter<IModelLanguageChangedEvent>;
+	public readonly onDidChangeLanguage: Event<IModelLanguageChangedEvent>;
 
-	private readonly _onDidChangeLanguageConfiguration: Emitter<IModelLanguageConfigurationChangedEvent> = this._register(new Emitter<IModelLanguageConfigurationChangedEvent>());
-	public readonly onDidChangeLanguageConfiguration: Event<IModelLanguageConfigurationChangedEvent> = this._onDidChangeLanguageConfiguration.event;
+	private readonly _onDidChangeLanguageConfiguration: Emitter<IModelLanguageConfigurationChangedEvent>;
+	public readonly onDidChangeLanguageConfiguration: Event<IModelLanguageConfigurationChangedEvent>;
 
-	private readonly _onDidChangeTokens: Emitter<IModelTokensChangedEvent> = this._register(new Emitter<IModelTokensChangedEvent>());
-	public readonly onDidChangeTokens: Event<IModelTokensChangedEvent> = this._onDidChangeTokens.event;
+	private readonly _onDidChangeTokens: Emitter<IModelTokensChangedEvent>;
+	public readonly onDidChangeTokens: Event<IModelTokensChangedEvent>;
 
 	private _tokens!: AbstractTokens;
-	private readonly _tokensDisposables: DisposableStore = this._register(new DisposableStore());
+	private readonly _tokensDisposables: DisposableStore;
 
 	constructor(
 		private readonly _textModel: TextModel,
@@ -58,6 +58,14 @@ export class TokenizationTextModelPart extends TextModelPart implements ITokeniz
 		@IInstantiationService private readonly _instantiationService: IInstantiationService
 	) {
 		super();
+		this._semanticTokens = new SparseTokensStore(this._languageService.languageIdCodec);
+		this._onDidChangeLanguage = this._register(new Emitter<IModelLanguageChangedEvent>());
+		this.onDidChangeLanguage = this._onDidChangeLanguage.event;
+		this._onDidChangeLanguageConfiguration = this._register(new Emitter<IModelLanguageConfigurationChangedEvent>());
+		this.onDidChangeLanguageConfiguration = this._onDidChangeLanguageConfiguration.event;
+		this._onDidChangeTokens = this._register(new Emitter<IModelTokensChangedEvent>());
+		this.onDidChangeTokens = this._onDidChangeTokens.event;
+		this._tokensDisposables = this._register(new DisposableStore());
 
 		// We just look at registry changes to determine whether to use tree sitter.
 		// This means that removing a language from the setting will not cause a switch to textmate and will require a reload.

--- a/src/vs/editor/contrib/inlineCompletions/browser/hintsWidget/inlineCompletionsHintsWidget.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/hintsWidget/inlineCompletionsHintsWidget.ts
@@ -37,27 +37,11 @@ import { InlineCompletionsModel } from '../model/inlineCompletionsModel.js';
 import './inlineCompletionsHintsWidget.css';
 
 export class InlineCompletionsHintsWidget extends Disposable {
-	private readonly alwaysShowToolbar = observableFromEvent(this, this.editor.onDidChangeConfiguration, () => this.editor.getOption(EditorOption.inlineSuggest).showToolbar === 'always');
+	private readonly alwaysShowToolbar;
 
-	private sessionPosition: Position | undefined = undefined;
+	private sessionPosition: Position | undefined;
 
-	private readonly position = derived(this, reader => {
-		const ghostText = this.model.read(reader)?.primaryGhostText.read(reader);
-
-		if (!this.alwaysShowToolbar.read(reader) || !ghostText || ghostText.parts.length === 0) {
-			this.sessionPosition = undefined;
-			return null;
-		}
-
-		const firstColumn = ghostText.parts[0].column;
-		if (this.sessionPosition && this.sessionPosition.lineNumber !== ghostText.lineNumber) {
-			this.sessionPosition = undefined;
-		}
-
-		const position = new Position(ghostText.lineNumber, Math.min(firstColumn, this.sessionPosition?.column ?? Number.MAX_SAFE_INTEGER));
-		this.sessionPosition = position;
-		return position;
-	});
+	private readonly position;
 
 	constructor(
 		private readonly editor: ICodeEditor,
@@ -65,6 +49,25 @@ export class InlineCompletionsHintsWidget extends Disposable {
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
 	) {
 		super();
+		this.alwaysShowToolbar = observableFromEvent(this, this.editor.onDidChangeConfiguration, () => this.editor.getOption(EditorOption.inlineSuggest).showToolbar === 'always');
+		this.sessionPosition = undefined;
+		this.position = derived(this, reader => {
+			const ghostText = this.model.read(reader)?.primaryGhostText.read(reader);
+
+			if (!this.alwaysShowToolbar.read(reader) || !ghostText || ghostText.parts.length === 0) {
+				this.sessionPosition = undefined;
+				return null;
+			}
+
+			const firstColumn = ghostText.parts[0].column;
+			if (this.sessionPosition && this.sessionPosition.lineNumber !== ghostText.lineNumber) {
+				this.sessionPosition = undefined;
+			}
+
+			const position = new Position(ghostText.lineNumber, Math.min(firstColumn, this.sessionPosition?.column ?? Number.MAX_SAFE_INTEGER));
+			this.sessionPosition = position;
+			return position;
+		});
 
 		this._register(autorunWithStore((reader, store) => {
 			/** @description setup content widget */
@@ -122,38 +125,15 @@ export class InlineSuggestionHintsContentWidget extends Disposable implements IC
 
 	private static id = 0;
 
-	private readonly id = `InlineSuggestionHintsContentWidget${InlineSuggestionHintsContentWidget.id++}`;
-	public readonly allowEditorOverflow = true;
-	public readonly suppressMouseDown = false;
+	private readonly id;
+	public readonly allowEditorOverflow;
+	public readonly suppressMouseDown;
 
-	private readonly _warningMessageContentNode = derivedWithStore((reader, store) => {
-		const warning = this._warning.read(reader);
-		if (!warning) {
-			return undefined;
-		}
-		if (typeof warning.message === 'string') {
-			return warning.message;
-		}
-		const markdownElement = store.add(renderMarkdown(warning.message));
-		return markdownElement.element;
-	});
+	private readonly _warningMessageContentNode;
 
-	private readonly _warningMessageNode = n.div({
-		class: 'warningMessage',
-		style: {
-			maxWidth: 400,
-			margin: 4,
-			marginBottom: 4,
-			display: derived(reader => this._warning.read(reader) ? 'block' : 'none'),
-		}
-	}, [
-		this._warningMessageContentNode,
-	]).keepUpdated(this._store);
+	private readonly _warningMessageNode;
 
-	private readonly nodes = h('div.inlineSuggestionsHints', { className: this.withBorder ? 'monaco-hover monaco-hover-content' : '' }, [
-		this._warningMessageNode.element,
-		h('div@toolBar'),
-	]);
+	private readonly nodes;
 
 	private createCommandAction(commandId: string, label: string, iconClassName: string): Action {
 		const action = new Action(
@@ -172,25 +152,18 @@ export class InlineSuggestionHintsContentWidget extends Disposable implements IC
 		return action;
 	}
 
-	private readonly previousAction = this._register(this.createCommandAction(showPreviousInlineSuggestionActionId, localize('previous', 'Previous'), ThemeIcon.asClassName(inlineSuggestionHintsPreviousIcon)));
-	private readonly availableSuggestionCountAction = this._register(new Action('inlineSuggestionHints.availableSuggestionCount', '', undefined, false));
-	private readonly nextAction = this._register(this.createCommandAction(showNextInlineSuggestionActionId, localize('next', 'Next'), ThemeIcon.asClassName(inlineSuggestionHintsNextIcon)));
+	private readonly previousAction;
+	private readonly availableSuggestionCountAction;
+	private readonly nextAction;
 
 	private readonly toolBar: CustomizedMenuWorkbenchToolBar;
 
 	// TODO@hediet: deprecate MenuId.InlineCompletionsActions
-	private readonly inlineCompletionsActionsMenus = this._register(this._menuService.createMenu(
-		MenuId.InlineCompletionsActions,
-		this._contextKeyService
-	));
+	private readonly inlineCompletionsActionsMenus;
 
-	private readonly clearAvailableSuggestionCountLabelDebounced = this._register(new RunOnceScheduler(() => {
-		this.availableSuggestionCountAction.label = '';
-	}, 100));
+	private readonly clearAvailableSuggestionCountLabelDebounced;
 
-	private readonly disableButtonsDebounced = this._register(new RunOnceScheduler(() => {
-		this.previousAction.enabled = this.nextAction.enabled = false;
-	}, 100));
+	private readonly disableButtonsDebounced;
 
 	constructor(
 		private readonly editor: ICodeEditor,
@@ -208,6 +181,48 @@ export class InlineSuggestionHintsContentWidget extends Disposable implements IC
 		@IMenuService private readonly _menuService: IMenuService,
 	) {
 		super();
+		this.id = `InlineSuggestionHintsContentWidget${InlineSuggestionHintsContentWidget.id++}`;
+		this.allowEditorOverflow = true;
+		this.suppressMouseDown = false;
+		this._warningMessageContentNode = derivedWithStore((reader, store) => {
+			const warning = this._warning.read(reader);
+			if (!warning) {
+				return undefined;
+			}
+			if (typeof warning.message === 'string') {
+				return warning.message;
+			}
+			const markdownElement = store.add(renderMarkdown(warning.message));
+			return markdownElement.element;
+		});
+		this._warningMessageNode = n.div({
+			class: 'warningMessage',
+			style: {
+				maxWidth: 400,
+				margin: 4,
+				marginBottom: 4,
+				display: derived(reader => this._warning.read(reader) ? 'block' : 'none'),
+			}
+		}, [
+			this._warningMessageContentNode,
+		]).keepUpdated(this._store);
+		this.nodes = h('div.inlineSuggestionsHints', { className: this.withBorder ? 'monaco-hover monaco-hover-content' : '' }, [
+			this._warningMessageNode.element,
+			h('div@toolBar'),
+		]);
+		this.previousAction = this._register(this.createCommandAction(showPreviousInlineSuggestionActionId, localize('previous', 'Previous'), ThemeIcon.asClassName(inlineSuggestionHintsPreviousIcon)));
+		this.availableSuggestionCountAction = this._register(new Action('inlineSuggestionHints.availableSuggestionCount', '', undefined, false));
+		this.nextAction = this._register(this.createCommandAction(showNextInlineSuggestionActionId, localize('next', 'Next'), ThemeIcon.asClassName(inlineSuggestionHintsNextIcon)));
+		this.inlineCompletionsActionsMenus = this._register(this._menuService.createMenu(
+			MenuId.InlineCompletionsActions,
+			this._contextKeyService
+		));
+		this.clearAvailableSuggestionCountLabelDebounced = this._register(new RunOnceScheduler(() => {
+			this.availableSuggestionCountAction.label = '';
+		}, 100));
+		this.disableButtonsDebounced = this._register(new RunOnceScheduler(() => {
+			this.previousAction.enabled = this.nextAction.enabled = false;
+		}, 100));
 
 		this._register(autorun(reader => {
 			this._warningMessageContentNode.read(reader);
@@ -356,10 +371,10 @@ class StatusBarViewItem extends MenuEntryActionViewItem {
 }
 
 export class CustomizedMenuWorkbenchToolBar extends WorkbenchToolBar {
-	private readonly menu = this._store.add(this.menuService.createMenu(this.menuId, this.contextKeyService, { emitEventsForSubmenuChanges: true }));
-	private additionalActions: IAction[] = [];
-	private prependedPrimaryActions: IAction[] = [];
-	private additionalPrimaryActions: IAction[] = [];
+	private readonly menu;
+	private additionalActions: IAction[];
+	private prependedPrimaryActions: IAction[];
+	private additionalPrimaryActions: IAction[];
 
 	constructor(
 		container: HTMLElement,
@@ -373,6 +388,10 @@ export class CustomizedMenuWorkbenchToolBar extends WorkbenchToolBar {
 		@ITelemetryService telemetryService: ITelemetryService,
 	) {
 		super(container, { resetMenu: menuId, ...options2 }, menuService, contextKeyService, contextMenuService, keybindingService, commandService, telemetryService);
+		this.menu = this._store.add(this.menuService.createMenu(this.menuId, this.contextKeyService, { emitEventsForSubmenuChanges: true }));
+		this.additionalActions = [];
+		this.prependedPrimaryActions = [];
+		this.additionalPrimaryActions = [];
 
 		this._store.add(this.menu.onDidChange(() => this.updateToolbar()));
 		this.updateToolbar();

--- a/src/vs/editor/contrib/inlineCompletions/browser/model/changeRecorder.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/model/changeRecorder.ts
@@ -43,15 +43,16 @@ export class TextModelChangeRecorder extends Disposable {
 		return result;
 	}
 
-	private readonly _structuredLogger = this._register(this._instantiationService.createInstance(StructuredLogger.cast<IRecordableEditorLogEntry & IDocumentEventDataSetChangeReason>(),
-		'editor.inlineSuggest.logChangeReason.commandId'
-	));
+	private readonly _structuredLogger;
 
 	constructor(
 		private readonly _editor: ICodeEditor,
 		@IInstantiationService private readonly _instantiationService: IInstantiationService,
 	) {
 		super();
+		this._structuredLogger = this._register(this._instantiationService.createInstance(StructuredLogger.cast<IRecordableEditorLogEntry & IDocumentEventDataSetChangeReason>(),
+			'editor.inlineSuggest.logChangeReason.commandId'
+		));
 		this._register(autorunWithStore((reader, store) => {
 			if (!(this._editor instanceof CodeEditorWidget)) { return; }
 			if (!this._structuredLogger.isEnabled.read(reader)) { return; }

--- a/src/vs/editor/contrib/inlineCompletions/browser/model/inlineCompletionsModel.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/model/inlineCompletionsModel.ts
@@ -47,31 +47,31 @@ import { singleTextEditAugments, singleTextRemoveCommonPrefix } from './singleTe
 import { SuggestItemInfo } from './suggestWidgetAdapter.js';
 
 export class InlineCompletionsModel extends Disposable {
-	private readonly _source = this._register(this._instantiationService.createInstance(InlineCompletionsSource, this.textModel, this._textModelVersionId, this._debounceValue));
-	private readonly _isActive = observableValue<boolean>(this, false);
-	private readonly _onlyRequestInlineEditsSignal = observableSignal(this);
-	private readonly _forceUpdateExplicitlySignal = observableSignal(this);
-	private readonly _noDelaySignal = observableSignal(this);
+	private readonly _source;
+	private readonly _isActive;
+	private readonly _onlyRequestInlineEditsSignal;
+	private readonly _forceUpdateExplicitlySignal;
+	private readonly _noDelaySignal;
 
-	private readonly _fetchSpecificProviderSignal = observableSignal<InlineCompletionsProvider | undefined>(this);
+	private readonly _fetchSpecificProviderSignal;
 
 	// We use a semantic id to keep the same inline completion selected even if the provider reorders the completions.
-	private readonly _selectedInlineCompletionId = observableValue<string | undefined>(this, undefined);
-	public readonly primaryPosition = derived(this, reader => this._positions.read(reader)[0] ?? new Position(1, 1));
+	private readonly _selectedInlineCompletionId;
+	public readonly primaryPosition;
 
-	private _isAcceptingPartially = false;
+	private _isAcceptingPartially;
 	public get isAcceptingPartially() { return this._isAcceptingPartially; }
 
-	private readonly _onDidAccept = new Emitter<void>();
-	public readonly onDidAccept = this._onDidAccept.event;
+	private readonly _onDidAccept;
+	public readonly onDidAccept;
 
-	private readonly _editorObs = observableCodeEditor(this._editor);
+	private readonly _editorObs;
 
-	private readonly _suggestPreviewEnabled = this._editorObs.getOption(EditorOption.suggest).map(v => v.preview);
-	private readonly _suggestPreviewMode = this._editorObs.getOption(EditorOption.suggest).map(v => v.previewMode);
-	private readonly _inlineSuggestMode = this._editorObs.getOption(EditorOption.inlineSuggest).map(v => v.mode);
-	private readonly _inlineEditsEnabled = this._editorObs.getOption(EditorOption.inlineSuggest).map(v => !!v.edits.enabled);
-	private readonly _inlineEditsShowCollapsedEnabled = this._editorObs.getOption(EditorOption.inlineSuggest).map(s => s.edits.showCollapsed);
+	private readonly _suggestPreviewEnabled;
+	private readonly _suggestPreviewMode;
+	private readonly _inlineSuggestMode;
+	private readonly _inlineEditsEnabled;
+	private readonly _inlineEditsShowCollapsedEnabled;
 
 	constructor(
 		public readonly textModel: ITextModel,
@@ -88,6 +88,409 @@ export class InlineCompletionsModel extends Disposable {
 		@ILanguageFeaturesService private readonly _languageFeaturesService: ILanguageFeaturesService,
 	) {
 		super();
+		this._source = this._register(this._instantiationService.createInstance(InlineCompletionsSource, this.textModel, this._textModelVersionId, this._debounceValue));
+		this._isActive = observableValue<boolean>(this, false);
+		this._onlyRequestInlineEditsSignal = observableSignal(this);
+		this._forceUpdateExplicitlySignal = observableSignal(this);
+		this._noDelaySignal = observableSignal(this);
+		this._fetchSpecificProviderSignal = observableSignal<InlineCompletionsProvider | undefined>(this);
+		this._selectedInlineCompletionId = observableValue<string | undefined>(this, undefined);
+		this.primaryPosition = derived(this, reader => this._positions.read(reader)[0] ?? new Position(1, 1));
+		this._isAcceptingPartially = false;
+		this._onDidAccept = new Emitter<void>();
+		this.onDidAccept = this._onDidAccept.event;
+		this._editorObs = observableCodeEditor(this._editor);
+		this._suggestPreviewEnabled = this._editorObs.getOption(EditorOption.suggest).map(v => v.preview);
+		this._suggestPreviewMode = this._editorObs.getOption(EditorOption.suggest).map(v => v.previewMode);
+		this._inlineSuggestMode = this._editorObs.getOption(EditorOption.inlineSuggest).map(v => v.mode);
+		this._inlineEditsEnabled = this._editorObs.getOption(EditorOption.inlineSuggest).map(v => !!v.edits.enabled);
+		this._inlineEditsShowCollapsedEnabled = this._editorObs.getOption(EditorOption.inlineSuggest).map(s => s.edits.showCollapsed);
+		this._lastShownInlineCompletionInfo = undefined;
+		this._lastAcceptedInlineCompletionInfo = undefined;
+		this._didUndoInlineEdits = derivedHandleChanges({
+			owner: this,
+			changeTracker: {
+				createChangeSummary: () => ({ didUndo: false }),
+				handleChange: (ctx, changeSummary) => {
+					changeSummary.didUndo = ctx.didChange(this._textModelVersionId) && !!ctx.change?.isUndoing;
+					return true;
+				}
+			}
+		}, (reader, changeSummary) => {
+			const versionId = this._textModelVersionId.read(reader);
+			if (versionId !== null
+				&& this._lastAcceptedInlineCompletionInfo
+				&& this._lastAcceptedInlineCompletionInfo.textModelVersionIdAfter === versionId - 1
+				&& this._lastAcceptedInlineCompletionInfo.inlineCompletion.isInlineEdit
+				&& changeSummary.didUndo
+			) {
+				this._lastAcceptedInlineCompletionInfo = undefined;
+				return true;
+			}
+			return false;
+		});
+		this._preserveCurrentCompletionReasons = new Set([
+			VersionIdChangeReason.Redo,
+			VersionIdChangeReason.Undo,
+			VersionIdChangeReason.AcceptWord,
+		]);
+		this.dontRefetchSignal = observableSignal(this);
+		this._fetchInlineCompletionsPromise = derivedHandleChanges({
+			owner: this,
+			changeTracker: {
+				createChangeSummary: () => ({
+					dontRefetch: false,
+					preserveCurrentCompletion: false,
+					inlineCompletionTriggerKind: InlineCompletionTriggerKind.Automatic,
+					onlyRequestInlineEdits: false,
+					shouldDebounce: true,
+					provider: undefined as InlineCompletionsProvider | undefined,
+				}),
+				handleChange: (ctx, changeSummary) => {
+					/** @description fetch inline completions */
+					if (ctx.didChange(this._textModelVersionId) && this._preserveCurrentCompletionReasons.has(this._getReason(ctx.change))) {
+						changeSummary.preserveCurrentCompletion = true;
+					} else if (ctx.didChange(this._forceUpdateExplicitlySignal)) {
+						changeSummary.inlineCompletionTriggerKind = InlineCompletionTriggerKind.Explicit;
+					} else if (ctx.didChange(this.dontRefetchSignal)) {
+						changeSummary.dontRefetch = true;
+					} else if (ctx.didChange(this._onlyRequestInlineEditsSignal)) {
+						changeSummary.onlyRequestInlineEdits = true;
+					} else if (ctx.didChange(this._fetchSpecificProviderSignal)) {
+						changeSummary.provider = ctx.change;
+					}
+					return true;
+				},
+			},
+		}, (reader, changeSummary) => {
+			this._source.clearOperationOnTextModelChange.read(reader); // Make sure the clear operation runs before the fetch operation
+			this._noDelaySignal.read(reader);
+			this.dontRefetchSignal.read(reader);
+			this._onlyRequestInlineEditsSignal.read(reader);
+			this._forceUpdateExplicitlySignal.read(reader);
+			this._fetchSpecificProviderSignal.read(reader);
+			const shouldUpdate = (this._enabled.read(reader) && this._selectedSuggestItem.read(reader)) || this._isActive.read(reader);
+			if (!shouldUpdate) {
+				this._source.cancelUpdate();
+				return undefined;
+			}
+
+			this._textModelVersionId.read(reader); // Refetch on text change
+
+			const suggestWidgetInlineCompletions = this._source.suggestWidgetInlineCompletions.get();
+			const suggestItem = this._selectedSuggestItem.read(reader);
+			if (suggestWidgetInlineCompletions && !suggestItem) {
+				this._source.seedInlineCompletionsWithSuggestWidget();
+			}
+
+			const cursorPosition = this.primaryPosition.get();
+			if (changeSummary.dontRefetch) {
+				return Promise.resolve(true);
+			}
+
+			if (this._didUndoInlineEdits.read(reader) && changeSummary.inlineCompletionTriggerKind !== InlineCompletionTriggerKind.Explicit) {
+				transaction(tx => {
+					this._source.clear(tx);
+				});
+				return undefined;
+			}
+
+			let context: InlineCompletionContextWithoutUuid = {
+				triggerKind: changeSummary.inlineCompletionTriggerKind,
+				selectedSuggestionInfo: suggestItem?.toSelectedSuggestionInfo(),
+				includeInlineCompletions: !changeSummary.onlyRequestInlineEdits,
+				includeInlineEdits: this._inlineEditsEnabled.read(reader),
+			};
+
+			if (context.triggerKind === InlineCompletionTriggerKind.Automatic) {
+				if (this.textModel.getAlternativeVersionId() === this._lastShownInlineCompletionInfo?.alternateTextModelVersionId) {
+					// When undoing back to a version where an inline edit/completion was shown,
+					// we want to show an inline edit (or completion) again if it was originally an inline edit (or completion).
+					context = {
+						...context,
+						includeInlineCompletions: !this._lastShownInlineCompletionInfo.inlineCompletion.isInlineEdit,
+						includeInlineEdits: this._lastShownInlineCompletionInfo.inlineCompletion.isInlineEdit,
+					};
+				}
+			}
+
+			const itemToPreserveCandidate = this.selectedInlineCompletion.get() ?? this._inlineCompletionItems.get()?.inlineEdit;
+			const itemToPreserve = changeSummary.preserveCurrentCompletion || itemToPreserveCandidate?.forwardStable
+				? itemToPreserveCandidate : undefined;
+			const userJumpedToActiveCompletion = this._jumpedToId.map(jumpedTo => !!jumpedTo && jumpedTo === this._inlineCompletionItems.get()?.inlineEdit?.semanticId);
+
+			const providers = changeSummary.provider ? [changeSummary.provider] : this._languageFeaturesService.inlineCompletionsProvider.all(this.textModel);
+
+			return this._source.fetch(providers, cursorPosition, context, itemToPreserve?.identity, changeSummary.shouldDebounce, userJumpedToActiveCompletion, !!changeSummary.provider);
+		});
+		this._inlineCompletionItems = derivedOpts({ owner: this }, reader => {
+			const c = this._source.inlineCompletions.read(reader);
+			if (!c) { return undefined; }
+			const cursorPosition = this.primaryPosition.read(reader);
+			let inlineEdit: InlineEditItem | undefined = undefined;
+			const visibleCompletions: InlineCompletionItem[] = [];
+			for (const completion of c.inlineCompletions) {
+				if (!completion.isInlineEdit) {
+					if (completion.isVisible(this.textModel, cursorPosition)) {
+						visibleCompletions.push(completion);
+					}
+				} else {
+					inlineEdit = completion;
+				}
+			}
+
+			if (visibleCompletions.length !== 0) {
+				// Don't show the inline edit if there is a visible completion
+				inlineEdit = undefined;
+			}
+
+			return {
+				inlineCompletions: visibleCompletions,
+				inlineEdit,
+			};
+		});
+		this._filteredInlineCompletionItems = derivedOpts({ owner: this, equalsFn: itemsEquals() }, reader => {
+			const c = this._inlineCompletionItems.read(reader);
+			return c?.inlineCompletions ?? [];
+		});
+		this.selectedInlineCompletionIndex = derived<number>(this, (reader) => {
+			const selectedInlineCompletionId = this._selectedInlineCompletionId.read(reader);
+			const filteredCompletions = this._filteredInlineCompletionItems.read(reader);
+			const idx = this._selectedInlineCompletionId === undefined ? -1
+				: filteredCompletions.findIndex(v => v.semanticId === selectedInlineCompletionId);
+			if (idx === -1) {
+				// Reset the selection so that the selection does not jump back when it appears again
+				this._selectedInlineCompletionId.set(undefined, undefined);
+				return 0;
+			}
+			return idx;
+		});
+		this.selectedInlineCompletion = derived<InlineCompletionItem | undefined>(this, (reader) => {
+			const filteredCompletions = this._filteredInlineCompletionItems.read(reader);
+			const idx = this.selectedInlineCompletionIndex.read(reader);
+			return filteredCompletions[idx];
+		});
+		this.activeCommands = derivedOpts<Command[]>({ owner: this, equalsFn: itemsEquals() },
+			r => this.selectedInlineCompletion.read(r)?.source.inlineSuggestions.commands ?? []
+		);
+		this.lastTriggerKind = this._source.inlineCompletions.map(this, v => v?.request?.context.triggerKind);
+		this.inlineCompletionsCount = derived<number | undefined>(this, reader => {
+			if (this.lastTriggerKind.read(reader) === InlineCompletionTriggerKind.Explicit) {
+				return this._filteredInlineCompletionItems.read(reader).length;
+			} else {
+				return undefined;
+			}
+		});
+		this._hasVisiblePeekWidgets = derived(this, reader => this._editorObs.openedPeekWidgets.read(reader) > 0);
+		this.state = derivedOpts<{
+			kind: 'ghostText';
+			edits: readonly SingleTextEdit[];
+			primaryGhostText: GhostTextOrReplacement;
+			ghostTexts: readonly GhostTextOrReplacement[];
+			suggestItem: SuggestItemInfo | undefined;
+			inlineCompletion: InlineCompletionItem | undefined;
+		} | {
+			kind: 'inlineEdit';
+			edits: readonly SingleTextEdit[];
+			inlineEdit: InlineEdit;
+			inlineCompletion: InlineEditItem;
+			cursorAtInlineEdit: IObservable<boolean>;
+		} | undefined>({
+			owner: this,
+			equalsFn: (a, b) => {
+				if (!a || !b) { return a === b; }
+
+				if (a.kind === 'ghostText' && b.kind === 'ghostText') {
+					return ghostTextsOrReplacementsEqual(a.ghostTexts, b.ghostTexts)
+						&& a.inlineCompletion === b.inlineCompletion
+						&& a.suggestItem === b.suggestItem;
+				} else if (a.kind === 'inlineEdit' && b.kind === 'inlineEdit') {
+					return a.inlineEdit.equals(b.inlineEdit);
+				}
+				return false;
+			}
+		}, (reader) => {
+			const model = this.textModel;
+
+			const item = this._inlineCompletionItems.read(reader);
+			const inlineEditResult = item?.inlineEdit;
+			if (inlineEditResult) {
+				if (this._hasVisiblePeekWidgets.read(reader)) {
+					return undefined;
+				}
+				let edit = inlineEditResult.getSingleTextEdit();
+				edit = singleTextRemoveCommonPrefix(edit, model);
+
+				const cursorAtInlineEdit = this.primaryPosition.map(cursorPos => LineRange.fromRangeInclusive(inlineEditResult.targetRange).addMargin(1, 1).contains(cursorPos.lineNumber));
+
+				const commands = inlineEditResult.source.inlineSuggestions.commands;
+				const inlineEdit = new InlineEdit(edit, commands ?? [], inlineEditResult);
+
+				const edits = inlineEditResult.updatedEdit;
+				const e = edits ? TextEdit.fromOffsetEdit(edits, new TextModelText(this.textModel)).edits : [edit];
+
+				return { kind: 'inlineEdit', inlineEdit, inlineCompletion: inlineEditResult, edits: e, cursorAtInlineEdit };
+			}
+
+			const suggestItem = this._selectedSuggestItem.read(reader);
+			if (suggestItem) {
+				const suggestCompletionEdit = singleTextRemoveCommonPrefix(suggestItem.getSingleTextEdit(), model);
+				const augmentation = this._computeAugmentation(suggestCompletionEdit, reader);
+
+				const isSuggestionPreviewEnabled = this._suggestPreviewEnabled.read(reader);
+				if (!isSuggestionPreviewEnabled && !augmentation) { return undefined; }
+
+				const fullEdit = augmentation?.edit ?? suggestCompletionEdit;
+				const fullEditPreviewLength = augmentation ? augmentation.edit.text.length - suggestCompletionEdit.text.length : 0;
+
+				const mode = this._suggestPreviewMode.read(reader);
+				const positions = this._positions.read(reader);
+				const edits = [fullEdit, ...getSecondaryEdits(this.textModel, positions, fullEdit)];
+				const ghostTexts = edits
+					.map((edit, idx) => computeGhostText(edit, model, mode, positions[idx], fullEditPreviewLength))
+					.filter(isDefined);
+				const primaryGhostText = ghostTexts[0] ?? new GhostText(fullEdit.range.endLineNumber, []);
+				return { kind: 'ghostText', edits, primaryGhostText, ghostTexts, inlineCompletion: augmentation?.completion, suggestItem };
+			} else {
+				if (!this._isActive.read(reader)) { return undefined; }
+				const inlineCompletion = this.selectedInlineCompletion.read(reader);
+				if (!inlineCompletion) { return undefined; }
+
+				const replacement = inlineCompletion.getSingleTextEdit();
+				const mode = this._inlineSuggestMode.read(reader);
+				const positions = this._positions.read(reader);
+				const edits = [replacement, ...getSecondaryEdits(this.textModel, positions, replacement)];
+				const ghostTexts = edits
+					.map((edit, idx) => computeGhostText(edit, model, mode, positions[idx], 0))
+					.filter(isDefined);
+				if (!ghostTexts[0]) { return undefined; }
+				return { kind: 'ghostText', edits, primaryGhostText: ghostTexts[0], ghostTexts, inlineCompletion, suggestItem: undefined };
+			}
+		});
+		this.status = derived(this, reader => {
+			if (this._source.loading.read(reader)) { return 'loading'; }
+			const s = this.state.read(reader);
+			if (s?.kind === 'ghostText') { return 'ghostText'; }
+			if (s?.kind === 'inlineEdit') { return 'inlineEdit'; }
+			return 'noSuggestion';
+		});
+		this.inlineCompletionState = derived(this, reader => {
+			const s = this.state.read(reader);
+			if (!s || s.kind !== 'ghostText') {
+				return undefined;
+			}
+			if (this._editorObs.inComposition.read(reader)) {
+				return undefined;
+			}
+			return s;
+		});
+		this.inlineEditState = derived(this, reader => {
+			const s = this.state.read(reader);
+			if (!s || s.kind !== 'inlineEdit') {
+				return undefined;
+			}
+			return s;
+		});
+		this.inlineEditAvailable = derived(this, reader => {
+			const s = this.inlineEditState.read(reader);
+			return !!s;
+		});
+		this.warning = derived(this, reader => {
+			return this.inlineCompletionState.read(reader)?.inlineCompletion?.warning;
+		});
+		this.ghostTexts = derivedOpts({ owner: this, equalsFn: ghostTextsOrReplacementsEqual }, reader => {
+			const v = this.inlineCompletionState.read(reader);
+			if (!v) {
+				return undefined;
+			}
+			return v.ghostTexts;
+		});
+		this.primaryGhostText = derivedOpts({ owner: this, equalsFn: ghostTextOrReplacementEquals }, reader => {
+			const v = this.inlineCompletionState.read(reader);
+			if (!v) {
+				return undefined;
+			}
+			return v?.primaryGhostText;
+		});
+		this.showCollapsed = derived<boolean>(this, reader => {
+			const state = this.state.read(reader);
+			if (!state || state.kind !== 'inlineEdit') {
+				return false;
+			}
+
+			if (state.inlineCompletion.displayLocation) {
+				return false;
+			}
+
+			const isCurrentModelVersion = state.inlineCompletion.updatedEditModelVersion === this._textModelVersionId.read(reader);
+			return (this._inlineEditsShowCollapsedEnabled.read(reader) || !isCurrentModelVersion)
+				&& this._jumpedToId.read(reader) !== state.inlineCompletion.semanticId
+				&& !this._inAcceptFlow.read(reader);
+		});
+		this._tabShouldIndent = derived(this, reader => {
+			if (this._inAcceptFlow.read(reader)) {
+				return false;
+			}
+
+			function isMultiLine(range: Range): boolean {
+				return range.startLineNumber !== range.endLineNumber;
+			}
+
+			function getNonIndentationRange(model: ITextModel, lineNumber: number): Range {
+				const columnStart = model.getLineIndentColumn(lineNumber);
+				const lastNonWsColumn = model.getLineLastNonWhitespaceColumn(lineNumber);
+				const columnEnd = Math.max(lastNonWsColumn, columnStart);
+				return new Range(lineNumber, columnStart, lineNumber, columnEnd);
+			}
+
+			const selections = this._editorObs.selections.read(reader);
+			return selections?.some(s => {
+				if (s.isEmpty()) {
+					return this.textModel.getLineLength(s.startLineNumber) === 0;
+				} else {
+					return isMultiLine(s) || s.containsRange(getNonIndentationRange(this.textModel, s.startLineNumber));
+				}
+			});
+		});
+		this.tabShouldJumpToInlineEdit = derived(this, reader => {
+			if (this._tabShouldIndent.read(reader)) {
+				return false;
+			}
+
+			const s = this.inlineEditState.read(reader);
+			if (!s) {
+				return false;
+			}
+
+			if (this.showCollapsed.read(reader)) {
+				return true;
+			}
+
+			return !s.cursorAtInlineEdit.read(reader);
+		});
+		this.tabShouldAcceptInlineEdit = derived(this, reader => {
+			const s = this.inlineEditState.read(reader);
+			if (!s) {
+				return false;
+			}
+			if (this.showCollapsed.read(reader)) {
+				return false;
+			}
+			if (s.inlineCompletion.targetRange.startLineNumber === this._editorObs.cursorLineNumber.read(reader)) {
+				return true;
+			}
+			if (this._jumpedToId.read(reader) === s.inlineCompletion.semanticId) {
+				return true;
+			}
+			if (this._tabShouldIndent.read(reader)) {
+				return false;
+			}
+
+			return s.cursorAtInlineEdit.read(reader);
+		});
+		this._jumpedToId = observableValue<undefined | string>(this, undefined);
+		this._inAcceptFlow = observableValue(this, false);
+		this.inAcceptFlow = this._inAcceptFlow;
 
 		this._register(recomputeInitiallyAndOnChange(this._fetchInlineCompletionsPromise));
 
@@ -156,30 +559,9 @@ export class InlineCompletionsModel extends Disposable {
 		this._didUndoInlineEdits.recomputeInitiallyAndOnChange(this._store);
 	}
 
-	private _lastShownInlineCompletionInfo: { alternateTextModelVersionId: number; /* already freed! */ inlineCompletion: InlineSuggestionItem } | undefined = undefined;
-	private _lastAcceptedInlineCompletionInfo: { textModelVersionIdAfter: number; /* already freed! */ inlineCompletion: InlineSuggestionItem } | undefined = undefined;
-	private readonly _didUndoInlineEdits = derivedHandleChanges({
-		owner: this,
-		changeTracker: {
-			createChangeSummary: () => ({ didUndo: false }),
-			handleChange: (ctx, changeSummary) => {
-				changeSummary.didUndo = ctx.didChange(this._textModelVersionId) && !!ctx.change?.isUndoing;
-				return true;
-			}
-		}
-	}, (reader, changeSummary) => {
-		const versionId = this._textModelVersionId.read(reader);
-		if (versionId !== null
-			&& this._lastAcceptedInlineCompletionInfo
-			&& this._lastAcceptedInlineCompletionInfo.textModelVersionIdAfter === versionId - 1
-			&& this._lastAcceptedInlineCompletionInfo.inlineCompletion.isInlineEdit
-			&& changeSummary.didUndo
-		) {
-			this._lastAcceptedInlineCompletionInfo = undefined;
-			return true;
-		}
-		return false;
-	});
+	private _lastShownInlineCompletionInfo: { alternateTextModelVersionId: number; /* already freed! */ inlineCompletion: InlineSuggestionItem } | undefined;
+	private _lastAcceptedInlineCompletionInfo: { textModelVersionIdAfter: number; /* already freed! */ inlineCompletion: InlineSuggestionItem } | undefined;
+	private readonly _didUndoInlineEdits;
 
 	public debugGetSelectedSuggestItem(): IObservable<SuggestItemInfo | undefined> {
 		return this._selectedSuggestItem;
@@ -215,11 +597,7 @@ export class InlineCompletionsModel extends Disposable {
 		};
 	}
 
-	private readonly _preserveCurrentCompletionReasons = new Set([
-		VersionIdChangeReason.Redo,
-		VersionIdChangeReason.Undo,
-		VersionIdChangeReason.AcceptWord,
-	]);
+	private readonly _preserveCurrentCompletionReasons;
 
 	private _getReason(e: IModelContentChangedEvent | undefined): VersionIdChangeReason {
 		if (e?.isUndoing) { return VersionIdChangeReason.Undo; }
@@ -228,96 +606,9 @@ export class InlineCompletionsModel extends Disposable {
 		return VersionIdChangeReason.Other;
 	}
 
-	public readonly dontRefetchSignal = observableSignal(this);
+	public readonly dontRefetchSignal;
 
-	private readonly _fetchInlineCompletionsPromise = derivedHandleChanges({
-		owner: this,
-		changeTracker: {
-			createChangeSummary: () => ({
-				dontRefetch: false,
-				preserveCurrentCompletion: false,
-				inlineCompletionTriggerKind: InlineCompletionTriggerKind.Automatic,
-				onlyRequestInlineEdits: false,
-				shouldDebounce: true,
-				provider: undefined as InlineCompletionsProvider | undefined,
-			}),
-			handleChange: (ctx, changeSummary) => {
-				/** @description fetch inline completions */
-				if (ctx.didChange(this._textModelVersionId) && this._preserveCurrentCompletionReasons.has(this._getReason(ctx.change))) {
-					changeSummary.preserveCurrentCompletion = true;
-				} else if (ctx.didChange(this._forceUpdateExplicitlySignal)) {
-					changeSummary.inlineCompletionTriggerKind = InlineCompletionTriggerKind.Explicit;
-				} else if (ctx.didChange(this.dontRefetchSignal)) {
-					changeSummary.dontRefetch = true;
-				} else if (ctx.didChange(this._onlyRequestInlineEditsSignal)) {
-					changeSummary.onlyRequestInlineEdits = true;
-				} else if (ctx.didChange(this._fetchSpecificProviderSignal)) {
-					changeSummary.provider = ctx.change;
-				}
-				return true;
-			},
-		},
-	}, (reader, changeSummary) => {
-		this._source.clearOperationOnTextModelChange.read(reader); // Make sure the clear operation runs before the fetch operation
-		this._noDelaySignal.read(reader);
-		this.dontRefetchSignal.read(reader);
-		this._onlyRequestInlineEditsSignal.read(reader);
-		this._forceUpdateExplicitlySignal.read(reader);
-		this._fetchSpecificProviderSignal.read(reader);
-		const shouldUpdate = (this._enabled.read(reader) && this._selectedSuggestItem.read(reader)) || this._isActive.read(reader);
-		if (!shouldUpdate) {
-			this._source.cancelUpdate();
-			return undefined;
-		}
-
-		this._textModelVersionId.read(reader); // Refetch on text change
-
-		const suggestWidgetInlineCompletions = this._source.suggestWidgetInlineCompletions.get();
-		const suggestItem = this._selectedSuggestItem.read(reader);
-		if (suggestWidgetInlineCompletions && !suggestItem) {
-			this._source.seedInlineCompletionsWithSuggestWidget();
-		}
-
-		const cursorPosition = this.primaryPosition.get();
-		if (changeSummary.dontRefetch) {
-			return Promise.resolve(true);
-		}
-
-		if (this._didUndoInlineEdits.read(reader) && changeSummary.inlineCompletionTriggerKind !== InlineCompletionTriggerKind.Explicit) {
-			transaction(tx => {
-				this._source.clear(tx);
-			});
-			return undefined;
-		}
-
-		let context: InlineCompletionContextWithoutUuid = {
-			triggerKind: changeSummary.inlineCompletionTriggerKind,
-			selectedSuggestionInfo: suggestItem?.toSelectedSuggestionInfo(),
-			includeInlineCompletions: !changeSummary.onlyRequestInlineEdits,
-			includeInlineEdits: this._inlineEditsEnabled.read(reader),
-		};
-
-		if (context.triggerKind === InlineCompletionTriggerKind.Automatic) {
-			if (this.textModel.getAlternativeVersionId() === this._lastShownInlineCompletionInfo?.alternateTextModelVersionId) {
-				// When undoing back to a version where an inline edit/completion was shown,
-				// we want to show an inline edit (or completion) again if it was originally an inline edit (or completion).
-				context = {
-					...context,
-					includeInlineCompletions: !this._lastShownInlineCompletionInfo.inlineCompletion.isInlineEdit,
-					includeInlineEdits: this._lastShownInlineCompletionInfo.inlineCompletion.isInlineEdit,
-				};
-			}
-		}
-
-		const itemToPreserveCandidate = this.selectedInlineCompletion.get() ?? this._inlineCompletionItems.get()?.inlineEdit;
-		const itemToPreserve = changeSummary.preserveCurrentCompletion || itemToPreserveCandidate?.forwardStable
-			? itemToPreserveCandidate : undefined;
-		const userJumpedToActiveCompletion = this._jumpedToId.map(jumpedTo => !!jumpedTo && jumpedTo === this._inlineCompletionItems.get()?.inlineEdit?.semanticId);
-
-		const providers = changeSummary.provider ? [changeSummary.provider] : this._languageFeaturesService.inlineCompletionsProvider.all(this.textModel);
-
-		return this._source.fetch(providers, cursorPosition, context, itemToPreserve?.identity, changeSummary.shouldDebounce, userJumpedToActiveCompletion, !!changeSummary.provider);
-	});
+	private readonly _fetchInlineCompletionsPromise;
 
 	public async trigger(tx?: ITransaction, options?: { onlyFetchInlineEdits?: boolean; noDelay?: boolean }): Promise<void> {
 		subtransaction(tx, tx => {
@@ -358,191 +649,32 @@ export class InlineCompletionsModel extends Disposable {
 		});
 	}
 
-	private readonly _inlineCompletionItems = derivedOpts({ owner: this }, reader => {
-		const c = this._source.inlineCompletions.read(reader);
-		if (!c) { return undefined; }
-		const cursorPosition = this.primaryPosition.read(reader);
-		let inlineEdit: InlineEditItem | undefined = undefined;
-		const visibleCompletions: InlineCompletionItem[] = [];
-		for (const completion of c.inlineCompletions) {
-			if (!completion.isInlineEdit) {
-				if (completion.isVisible(this.textModel, cursorPosition)) {
-					visibleCompletions.push(completion);
-				}
-			} else {
-				inlineEdit = completion;
-			}
-		}
+	private readonly _inlineCompletionItems;
 
-		if (visibleCompletions.length !== 0) {
-			// Don't show the inline edit if there is a visible completion
-			inlineEdit = undefined;
-		}
+	private readonly _filteredInlineCompletionItems;
 
-		return {
-			inlineCompletions: visibleCompletions,
-			inlineEdit,
-		};
-	});
+	public readonly selectedInlineCompletionIndex;
 
-	private readonly _filteredInlineCompletionItems = derivedOpts({ owner: this, equalsFn: itemsEquals() }, reader => {
-		const c = this._inlineCompletionItems.read(reader);
-		return c?.inlineCompletions ?? [];
-	});
+	public readonly selectedInlineCompletion;
 
-	public readonly selectedInlineCompletionIndex = derived<number>(this, (reader) => {
-		const selectedInlineCompletionId = this._selectedInlineCompletionId.read(reader);
-		const filteredCompletions = this._filteredInlineCompletionItems.read(reader);
-		const idx = this._selectedInlineCompletionId === undefined ? -1
-			: filteredCompletions.findIndex(v => v.semanticId === selectedInlineCompletionId);
-		if (idx === -1) {
-			// Reset the selection so that the selection does not jump back when it appears again
-			this._selectedInlineCompletionId.set(undefined, undefined);
-			return 0;
-		}
-		return idx;
-	});
-
-	public readonly selectedInlineCompletion = derived<InlineCompletionItem | undefined>(this, (reader) => {
-		const filteredCompletions = this._filteredInlineCompletionItems.read(reader);
-		const idx = this.selectedInlineCompletionIndex.read(reader);
-		return filteredCompletions[idx];
-	});
-
-	public readonly activeCommands = derivedOpts<Command[]>({ owner: this, equalsFn: itemsEquals() },
-		r => this.selectedInlineCompletion.read(r)?.source.inlineSuggestions.commands ?? []
-	);
+	public readonly activeCommands;
 
 	public readonly lastTriggerKind: IObservable<InlineCompletionTriggerKind | undefined>
-		= this._source.inlineCompletions.map(this, v => v?.request?.context.triggerKind);
+		;
 
-	public readonly inlineCompletionsCount = derived<number | undefined>(this, reader => {
-		if (this.lastTriggerKind.read(reader) === InlineCompletionTriggerKind.Explicit) {
-			return this._filteredInlineCompletionItems.read(reader).length;
-		} else {
-			return undefined;
-		}
-	});
+	public readonly inlineCompletionsCount;
 
-	private readonly _hasVisiblePeekWidgets = derived(this, reader => this._editorObs.openedPeekWidgets.read(reader) > 0);
+	private readonly _hasVisiblePeekWidgets;
 
-	public readonly state = derivedOpts<{
-		kind: 'ghostText';
-		edits: readonly SingleTextEdit[];
-		primaryGhostText: GhostTextOrReplacement;
-		ghostTexts: readonly GhostTextOrReplacement[];
-		suggestItem: SuggestItemInfo | undefined;
-		inlineCompletion: InlineCompletionItem | undefined;
-	} | {
-		kind: 'inlineEdit';
-		edits: readonly SingleTextEdit[];
-		inlineEdit: InlineEdit;
-		inlineCompletion: InlineEditItem;
-		cursorAtInlineEdit: IObservable<boolean>;
-	} | undefined>({
-		owner: this,
-		equalsFn: (a, b) => {
-			if (!a || !b) { return a === b; }
+	public readonly state;
 
-			if (a.kind === 'ghostText' && b.kind === 'ghostText') {
-				return ghostTextsOrReplacementsEqual(a.ghostTexts, b.ghostTexts)
-					&& a.inlineCompletion === b.inlineCompletion
-					&& a.suggestItem === b.suggestItem;
-			} else if (a.kind === 'inlineEdit' && b.kind === 'inlineEdit') {
-				return a.inlineEdit.equals(b.inlineEdit);
-			}
-			return false;
-		}
-	}, (reader) => {
-		const model = this.textModel;
+	public readonly status;
 
-		const item = this._inlineCompletionItems.read(reader);
-		const inlineEditResult = item?.inlineEdit;
-		if (inlineEditResult) {
-			if (this._hasVisiblePeekWidgets.read(reader)) {
-				return undefined;
-			}
-			let edit = inlineEditResult.getSingleTextEdit();
-			edit = singleTextRemoveCommonPrefix(edit, model);
+	public readonly inlineCompletionState;
 
-			const cursorAtInlineEdit = this.primaryPosition.map(cursorPos => LineRange.fromRangeInclusive(inlineEditResult.targetRange).addMargin(1, 1).contains(cursorPos.lineNumber));
+	public readonly inlineEditState;
 
-			const commands = inlineEditResult.source.inlineSuggestions.commands;
-			const inlineEdit = new InlineEdit(edit, commands ?? [], inlineEditResult);
-
-			const edits = inlineEditResult.updatedEdit;
-			const e = edits ? TextEdit.fromOffsetEdit(edits, new TextModelText(this.textModel)).edits : [edit];
-
-			return { kind: 'inlineEdit', inlineEdit, inlineCompletion: inlineEditResult, edits: e, cursorAtInlineEdit };
-		}
-
-		const suggestItem = this._selectedSuggestItem.read(reader);
-		if (suggestItem) {
-			const suggestCompletionEdit = singleTextRemoveCommonPrefix(suggestItem.getSingleTextEdit(), model);
-			const augmentation = this._computeAugmentation(suggestCompletionEdit, reader);
-
-			const isSuggestionPreviewEnabled = this._suggestPreviewEnabled.read(reader);
-			if (!isSuggestionPreviewEnabled && !augmentation) { return undefined; }
-
-			const fullEdit = augmentation?.edit ?? suggestCompletionEdit;
-			const fullEditPreviewLength = augmentation ? augmentation.edit.text.length - suggestCompletionEdit.text.length : 0;
-
-			const mode = this._suggestPreviewMode.read(reader);
-			const positions = this._positions.read(reader);
-			const edits = [fullEdit, ...getSecondaryEdits(this.textModel, positions, fullEdit)];
-			const ghostTexts = edits
-				.map((edit, idx) => computeGhostText(edit, model, mode, positions[idx], fullEditPreviewLength))
-				.filter(isDefined);
-			const primaryGhostText = ghostTexts[0] ?? new GhostText(fullEdit.range.endLineNumber, []);
-			return { kind: 'ghostText', edits, primaryGhostText, ghostTexts, inlineCompletion: augmentation?.completion, suggestItem };
-		} else {
-			if (!this._isActive.read(reader)) { return undefined; }
-			const inlineCompletion = this.selectedInlineCompletion.read(reader);
-			if (!inlineCompletion) { return undefined; }
-
-			const replacement = inlineCompletion.getSingleTextEdit();
-			const mode = this._inlineSuggestMode.read(reader);
-			const positions = this._positions.read(reader);
-			const edits = [replacement, ...getSecondaryEdits(this.textModel, positions, replacement)];
-			const ghostTexts = edits
-				.map((edit, idx) => computeGhostText(edit, model, mode, positions[idx], 0))
-				.filter(isDefined);
-			if (!ghostTexts[0]) { return undefined; }
-			return { kind: 'ghostText', edits, primaryGhostText: ghostTexts[0], ghostTexts, inlineCompletion, suggestItem: undefined };
-		}
-	});
-
-	public readonly status = derived(this, reader => {
-		if (this._source.loading.read(reader)) { return 'loading'; }
-		const s = this.state.read(reader);
-		if (s?.kind === 'ghostText') { return 'ghostText'; }
-		if (s?.kind === 'inlineEdit') { return 'inlineEdit'; }
-		return 'noSuggestion';
-	});
-
-	public readonly inlineCompletionState = derived(this, reader => {
-		const s = this.state.read(reader);
-		if (!s || s.kind !== 'ghostText') {
-			return undefined;
-		}
-		if (this._editorObs.inComposition.read(reader)) {
-			return undefined;
-		}
-		return s;
-	});
-
-	public readonly inlineEditState = derived(this, reader => {
-		const s = this.state.read(reader);
-		if (!s || s.kind !== 'inlineEdit') {
-			return undefined;
-		}
-		return s;
-	});
-
-	public readonly inlineEditAvailable = derived(this, reader => {
-		const s = this.inlineEditState.read(reader);
-		return !!s;
-	});
+	public readonly inlineEditAvailable;
 
 	private _computeAugmentation(suggestCompletion: SingleTextEdit, reader: IReader | undefined) {
 		const model = this.textModel;
@@ -564,105 +696,19 @@ export class InlineCompletionsModel extends Disposable {
 		return augmentedCompletion;
 	}
 
-	public readonly warning = derived(this, reader => {
-		return this.inlineCompletionState.read(reader)?.inlineCompletion?.warning;
-	});
+	public readonly warning;
 
-	public readonly ghostTexts = derivedOpts({ owner: this, equalsFn: ghostTextsOrReplacementsEqual }, reader => {
-		const v = this.inlineCompletionState.read(reader);
-		if (!v) {
-			return undefined;
-		}
-		return v.ghostTexts;
-	});
+	public readonly ghostTexts;
 
-	public readonly primaryGhostText = derivedOpts({ owner: this, equalsFn: ghostTextOrReplacementEquals }, reader => {
-		const v = this.inlineCompletionState.read(reader);
-		if (!v) {
-			return undefined;
-		}
-		return v?.primaryGhostText;
-	});
+	public readonly primaryGhostText;
 
-	public readonly showCollapsed = derived<boolean>(this, reader => {
-		const state = this.state.read(reader);
-		if (!state || state.kind !== 'inlineEdit') {
-			return false;
-		}
+	public readonly showCollapsed;
 
-		if (state.inlineCompletion.displayLocation) {
-			return false;
-		}
+	private readonly _tabShouldIndent;
 
-		const isCurrentModelVersion = state.inlineCompletion.updatedEditModelVersion === this._textModelVersionId.read(reader);
-		return (this._inlineEditsShowCollapsedEnabled.read(reader) || !isCurrentModelVersion)
-			&& this._jumpedToId.read(reader) !== state.inlineCompletion.semanticId
-			&& !this._inAcceptFlow.read(reader);
-	});
+	public readonly tabShouldJumpToInlineEdit;
 
-	private readonly _tabShouldIndent = derived(this, reader => {
-		if (this._inAcceptFlow.read(reader)) {
-			return false;
-		}
-
-		function isMultiLine(range: Range): boolean {
-			return range.startLineNumber !== range.endLineNumber;
-		}
-
-		function getNonIndentationRange(model: ITextModel, lineNumber: number): Range {
-			const columnStart = model.getLineIndentColumn(lineNumber);
-			const lastNonWsColumn = model.getLineLastNonWhitespaceColumn(lineNumber);
-			const columnEnd = Math.max(lastNonWsColumn, columnStart);
-			return new Range(lineNumber, columnStart, lineNumber, columnEnd);
-		}
-
-		const selections = this._editorObs.selections.read(reader);
-		return selections?.some(s => {
-			if (s.isEmpty()) {
-				return this.textModel.getLineLength(s.startLineNumber) === 0;
-			} else {
-				return isMultiLine(s) || s.containsRange(getNonIndentationRange(this.textModel, s.startLineNumber));
-			}
-		});
-	});
-
-	public readonly tabShouldJumpToInlineEdit = derived(this, reader => {
-		if (this._tabShouldIndent.read(reader)) {
-			return false;
-		}
-
-		const s = this.inlineEditState.read(reader);
-		if (!s) {
-			return false;
-		}
-
-		if (this.showCollapsed.read(reader)) {
-			return true;
-		}
-
-		return !s.cursorAtInlineEdit.read(reader);
-	});
-
-	public readonly tabShouldAcceptInlineEdit = derived(this, reader => {
-		const s = this.inlineEditState.read(reader);
-		if (!s) {
-			return false;
-		}
-		if (this.showCollapsed.read(reader)) {
-			return false;
-		}
-		if (s.inlineCompletion.targetRange.startLineNumber === this._editorObs.cursorLineNumber.read(reader)) {
-			return true;
-		}
-		if (this._jumpedToId.read(reader) === s.inlineCompletion.semanticId) {
-			return true;
-		}
-		if (this._tabShouldIndent.read(reader)) {
-			return false;
-		}
-
-		return s.cursorAtInlineEdit.read(reader);
-	});
+	public readonly tabShouldAcceptInlineEdit;
 
 	private async _deltaSelectedInlineCompletionIndex(delta: 1 | -1): Promise<void> {
 		await this.triggerExplicitly();
@@ -892,9 +938,9 @@ export class InlineCompletionsModel extends Disposable {
 		};
 	}
 
-	private readonly _jumpedToId = observableValue<undefined | string>(this, undefined);
-	private readonly _inAcceptFlow = observableValue(this, false);
-	public readonly inAcceptFlow: IObservable<boolean> = this._inAcceptFlow;
+	private readonly _jumpedToId;
+	private readonly _inAcceptFlow;
+	public readonly inAcceptFlow: IObservable<boolean>;
 
 	public jump(): void {
 		const s = this.inlineEditState.get();

--- a/src/vs/editor/contrib/inlineCompletions/browser/model/suggestWidgetAdapter.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/model/suggestWidgetAdapter.ts
@@ -240,21 +240,9 @@ function suggestItemInfoEquals(a: SuggestItemInfo | undefined, b: SuggestItemInf
 }
 
 export class ObservableSuggestWidgetAdapter extends Disposable {
-	private readonly _suggestWidgetAdaptor = this._register(new SuggestWidgetAdaptor(
-		this._editorObs.editor,
-		() => {
-			this._editorObs.forceUpdate();
-			return this._suggestControllerPreselector();
-		},
-		(item) => this._editorObs.forceUpdate(_tx => {
-			/** @description InlineCompletionsController.handleSuggestAccepted */
-			this._handleSuggestAccepted(item);
-		})
-	));
+	private readonly _suggestWidgetAdaptor;
 
-	public readonly selectedItem = observableFromEvent(this, cb => this._suggestWidgetAdaptor.onDidSelectedItemChange(() => {
-		this._editorObs.forceUpdate(_tx => cb(undefined));
-	}), () => this._suggestWidgetAdaptor.selectedItem);
+	public readonly selectedItem;
 
 	constructor(
 		private readonly _editorObs: ObservableCodeEditor,
@@ -263,6 +251,20 @@ export class ObservableSuggestWidgetAdapter extends Disposable {
 		private readonly _suggestControllerPreselector: () => SingleTextEdit | undefined,
 	) {
 		super();
+		this._suggestWidgetAdaptor = this._register(new SuggestWidgetAdaptor(
+			this._editorObs.editor,
+			() => {
+				this._editorObs.forceUpdate();
+				return this._suggestControllerPreselector();
+			},
+			(item) => this._editorObs.forceUpdate(_tx => {
+				/** @description InlineCompletionsController.handleSuggestAccepted */
+				this._handleSuggestAccepted(item);
+			})
+		));
+		this.selectedItem = observableFromEvent(this, cb => this._suggestWidgetAdaptor.onDidSelectedItemChange(() => {
+			this._editorObs.forceUpdate(_tx => cb(undefined));
+		}), () => this._suggestWidgetAdaptor.selectedItem);
 	}
 
 	public stopForceRenderingAbove(): void {

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/ghostText/ghostTextView.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/ghostText/ghostTextView.ts
@@ -46,20 +46,14 @@ const USE_SQUIGGLES_FOR_WARNING = true;
 const GHOST_TEXT_CLASS_NAME = 'ghost-text';
 
 export class GhostTextView extends Disposable {
-	private readonly _isDisposed = observableValue(this, false);
-	private readonly _editorObs = observableCodeEditor(this._editor);
+	private readonly _isDisposed;
+	private readonly _editorObs;
 	public static hot = createHotClass(GhostTextView);
 
-	private _warningState = derived(reader => {
-		const gt = this._model.ghostText.read(reader);
-		if (!gt) { return undefined; }
-		const warning = this._model.warning.read(reader);
-		if (!warning) { return undefined; }
-		return { lineNumber: gt.lineNumber, position: new Position(gt.lineNumber, gt.parts[0].column), icon: warning.icon };
-	});
+	private _warningState;
 
-	private readonly _onDidClick = this._register(new Emitter<IMouseEvent>());
-	public readonly onDidClick = this._onDidClick.event;
+	private readonly _onDidClick;
+	public readonly onDidClick;
 
 	constructor(
 		private readonly _editor: ICodeEditor,
@@ -73,6 +67,147 @@ export class GhostTextView extends Disposable {
 		@ILanguageService private readonly _languageService: ILanguageService,
 	) {
 		super();
+		this._isDisposed = observableValue(this, false);
+		this._editorObs = observableCodeEditor(this._editor);
+		this._warningState = derived(reader => {
+			const gt = this._model.ghostText.read(reader);
+			if (!gt) { return undefined; }
+			const warning = this._model.warning.read(reader);
+			if (!warning) { return undefined; }
+			return { lineNumber: gt.lineNumber, position: new Position(gt.lineNumber, gt.parts[0].column), icon: warning.icon };
+		});
+		this._onDidClick = this._register(new Emitter<IMouseEvent>());
+		this.onDidClick = this._onDidClick.event;
+		this._useSyntaxHighlighting = this._options.map(o => o.syntaxHighlightingEnabled);
+		this._extraClassNames = derived(this, reader => {
+			const extraClasses = [...this._options.read(reader).extraClasses ?? []];
+			if (this._useSyntaxHighlighting.read(reader)) {
+				extraClasses.push('syntax-highlighted');
+			}
+			if (USE_SQUIGGLES_FOR_WARNING && this._warningState.read(reader)) {
+				extraClasses.push('warning');
+			}
+			const extraClassNames = extraClasses.map(c => ` ${c}`).join('');
+			return extraClassNames;
+		});
+		this.uiState = derived(this, reader => {
+			if (this._isDisposed.read(reader)) { return undefined; }
+			const textModel = this._editorObs.model.read(reader);
+			if (textModel !== this._model.targetTextModel.read(reader)) { return undefined; }
+			const ghostText = this._model.ghostText.read(reader);
+			if (!ghostText) { return undefined; }
+
+			const replacedRange = ghostText instanceof GhostTextReplacement ? ghostText.columnRange : undefined;
+
+			const syntaxHighlightingEnabled = this._useSyntaxHighlighting.read(reader);
+			const extraClassNames = this._extraClassNames.read(reader);
+			const { inlineTexts, additionalLines, hiddenRange, additionalLinesOriginalSuffix } = computeGhostTextViewData(ghostText, textModel, GHOST_TEXT_CLASS_NAME + extraClassNames);
+
+			const currentLine = textModel.getLineContent(ghostText.lineNumber);
+			const edit = new OffsetEdit(inlineTexts.map(t => SingleOffsetEdit.insert(t.column - 1, t.text)));
+			const tokens = syntaxHighlightingEnabled ? textModel.tokenization.tokenizeLinesAt(ghostText.lineNumber, [edit.apply(currentLine), ...additionalLines.map(l => l.content)]) : undefined;
+			const newRanges = edit.getNewTextRanges();
+			const inlineTextsWithTokens = inlineTexts.map((t, idx) => ({ ...t, tokens: tokens?.[0]?.getTokensInRange(newRanges[idx]) }));
+
+			const tokenizedAdditionalLines: LineData[] = additionalLines.map((l, idx) => {
+				let content = tokens?.[idx + 1] ?? LineTokens.createEmpty(l.content, this._languageService.languageIdCodec);
+				if (idx === additionalLines.length - 1 && additionalLinesOriginalSuffix) {
+					const t = TokenWithTextArray.fromLineTokens(textModel.tokenization.getLineTokens(additionalLinesOriginalSuffix.lineNumber));
+					const existingContent = t.slice(additionalLinesOriginalSuffix.columnRange.toZeroBasedOffsetRange());
+					content = TokenWithTextArray.fromLineTokens(content).append(existingContent).toLineTokens(content.languageIdCodec);
+				}
+				return {
+					content,
+					decorations: l.decorations,
+				};
+			});
+
+			return {
+				replacedRange,
+				inlineTexts: inlineTextsWithTokens,
+				additionalLines: tokenizedAdditionalLines,
+				hiddenRange,
+				lineNumber: ghostText.lineNumber,
+				additionalReservedLineCount: this._model.minReservedLineCount.read(reader),
+				targetTextModel: textModel,
+				syntaxHighlightingEnabled,
+			};
+		});
+		this.decorations = derived(this, reader => {
+			const uiState = this.uiState.read(reader);
+			if (!uiState) { return []; }
+
+			const decorations: IModelDeltaDecoration[] = [];
+
+			const extraClassNames = this._extraClassNames.read(reader);
+
+			if (uiState.replacedRange) {
+				decorations.push({
+					range: uiState.replacedRange.toRange(uiState.lineNumber),
+					options: { inlineClassName: 'inline-completion-text-to-replace' + extraClassNames, description: 'GhostTextReplacement' }
+				});
+			}
+
+			if (uiState.hiddenRange) {
+				decorations.push({
+					range: uiState.hiddenRange.toRange(uiState.lineNumber),
+					options: { inlineClassName: 'ghost-text-hidden', description: 'ghost-text-hidden', }
+				});
+			}
+
+			for (const p of uiState.inlineTexts) {
+				decorations.push({
+					range: Range.fromPositions(new Position(uiState.lineNumber, p.column)),
+					options: {
+						description: 'ghost-text-decoration',
+						after: {
+							content: p.text,
+							tokens: p.tokens,
+							inlineClassName: (p.preview ? 'ghost-text-decoration-preview' : 'ghost-text-decoration')
+								+ (this._isClickable ? ' clickable' : '')
+								+ extraClassNames
+								+ p.lineDecorations.map(d => ' ' + d.className).join(' '), // TODO: take the ranges into account for line decorations
+							cursorStops: InjectedTextCursorStops.Left,
+							attachedData: new GhostTextAttachedData(this),
+						},
+						showIfCollapsed: true,
+					}
+				});
+			}
+
+			return decorations;
+		});
+		this._additionalLinesWidget = this._register(
+			new AdditionalLinesWidget(
+				this._editor,
+				derived(reader => {
+					/** @description lines */
+					const uiState = this.uiState.read(reader);
+					return uiState ? {
+						lineNumber: uiState.lineNumber,
+						additionalLines: uiState.additionalLines,
+						minReservedLineCount: uiState.additionalReservedLineCount,
+						targetTextModel: uiState.targetTextModel,
+					} : undefined;
+				}),
+				this._shouldKeepCursorStable,
+				this._isClickable
+			)
+		);
+		this._isInlineTextHovered = this._editorObs.isTargetHovered(
+			p => p.target.type === MouseTargetType.CONTENT_TEXT &&
+				p.target.detail.injectedText?.options.attachedData instanceof GhostTextAttachedData &&
+				p.target.detail.injectedText.options.attachedData.owner === this,
+			this._store
+		);
+		this.isHovered = derived(this, reader => {
+			if (this._isDisposed.read(reader)) { return false; }
+			return this._isInlineTextHovered.read(reader) || this._additionalLinesWidget.isHovered.read(reader);
+		});
+		this.height = derived(this, reader => {
+			const lineHeight = this._editorObs.getOption(EditorOption.lineHeight).read(reader);
+			return lineHeight + (this._additionalLinesWidget.viewZoneHeight.read(reader) ?? 0);
+		});
 
 		this._register(toDisposable(() => { this._isDisposed.set(true, undefined); }));
 		this._register(this._editorObs.setDecorations(this.decorations));
@@ -147,143 +282,21 @@ export class GhostTextView extends Disposable {
 		return undefined;
 	}
 
-	private readonly _useSyntaxHighlighting = this._options.map(o => o.syntaxHighlightingEnabled);
+	private readonly _useSyntaxHighlighting;
 
-	private readonly _extraClassNames = derived(this, reader => {
-		const extraClasses = [...this._options.read(reader).extraClasses ?? []];
-		if (this._useSyntaxHighlighting.read(reader)) {
-			extraClasses.push('syntax-highlighted');
-		}
-		if (USE_SQUIGGLES_FOR_WARNING && this._warningState.read(reader)) {
-			extraClasses.push('warning');
-		}
-		const extraClassNames = extraClasses.map(c => ` ${c}`).join('');
-		return extraClassNames;
-	});
+	private readonly _extraClassNames;
 
-	private readonly uiState = derived(this, reader => {
-		if (this._isDisposed.read(reader)) { return undefined; }
-		const textModel = this._editorObs.model.read(reader);
-		if (textModel !== this._model.targetTextModel.read(reader)) { return undefined; }
-		const ghostText = this._model.ghostText.read(reader);
-		if (!ghostText) { return undefined; }
+	private readonly uiState;
 
-		const replacedRange = ghostText instanceof GhostTextReplacement ? ghostText.columnRange : undefined;
+	private readonly decorations;
 
-		const syntaxHighlightingEnabled = this._useSyntaxHighlighting.read(reader);
-		const extraClassNames = this._extraClassNames.read(reader);
-		const { inlineTexts, additionalLines, hiddenRange, additionalLinesOriginalSuffix } = computeGhostTextViewData(ghostText, textModel, GHOST_TEXT_CLASS_NAME + extraClassNames);
+	private readonly _additionalLinesWidget;
 
-		const currentLine = textModel.getLineContent(ghostText.lineNumber);
-		const edit = new OffsetEdit(inlineTexts.map(t => SingleOffsetEdit.insert(t.column - 1, t.text)));
-		const tokens = syntaxHighlightingEnabled ? textModel.tokenization.tokenizeLinesAt(ghostText.lineNumber, [edit.apply(currentLine), ...additionalLines.map(l => l.content)]) : undefined;
-		const newRanges = edit.getNewTextRanges();
-		const inlineTextsWithTokens = inlineTexts.map((t, idx) => ({ ...t, tokens: tokens?.[0]?.getTokensInRange(newRanges[idx]) }));
+	private readonly _isInlineTextHovered;
 
-		const tokenizedAdditionalLines: LineData[] = additionalLines.map((l, idx) => {
-			let content = tokens?.[idx + 1] ?? LineTokens.createEmpty(l.content, this._languageService.languageIdCodec);
-			if (idx === additionalLines.length - 1 && additionalLinesOriginalSuffix) {
-				const t = TokenWithTextArray.fromLineTokens(textModel.tokenization.getLineTokens(additionalLinesOriginalSuffix.lineNumber));
-				const existingContent = t.slice(additionalLinesOriginalSuffix.columnRange.toZeroBasedOffsetRange());
-				content = TokenWithTextArray.fromLineTokens(content).append(existingContent).toLineTokens(content.languageIdCodec);
-			}
-			return {
-				content,
-				decorations: l.decorations,
-			};
-		});
+	public readonly isHovered;
 
-		return {
-			replacedRange,
-			inlineTexts: inlineTextsWithTokens,
-			additionalLines: tokenizedAdditionalLines,
-			hiddenRange,
-			lineNumber: ghostText.lineNumber,
-			additionalReservedLineCount: this._model.minReservedLineCount.read(reader),
-			targetTextModel: textModel,
-			syntaxHighlightingEnabled,
-		};
-	});
-
-	private readonly decorations = derived(this, reader => {
-		const uiState = this.uiState.read(reader);
-		if (!uiState) { return []; }
-
-		const decorations: IModelDeltaDecoration[] = [];
-
-		const extraClassNames = this._extraClassNames.read(reader);
-
-		if (uiState.replacedRange) {
-			decorations.push({
-				range: uiState.replacedRange.toRange(uiState.lineNumber),
-				options: { inlineClassName: 'inline-completion-text-to-replace' + extraClassNames, description: 'GhostTextReplacement' }
-			});
-		}
-
-		if (uiState.hiddenRange) {
-			decorations.push({
-				range: uiState.hiddenRange.toRange(uiState.lineNumber),
-				options: { inlineClassName: 'ghost-text-hidden', description: 'ghost-text-hidden', }
-			});
-		}
-
-		for (const p of uiState.inlineTexts) {
-			decorations.push({
-				range: Range.fromPositions(new Position(uiState.lineNumber, p.column)),
-				options: {
-					description: 'ghost-text-decoration',
-					after: {
-						content: p.text,
-						tokens: p.tokens,
-						inlineClassName: (p.preview ? 'ghost-text-decoration-preview' : 'ghost-text-decoration')
-							+ (this._isClickable ? ' clickable' : '')
-							+ extraClassNames
-							+ p.lineDecorations.map(d => ' ' + d.className).join(' '), // TODO: take the ranges into account for line decorations
-						cursorStops: InjectedTextCursorStops.Left,
-						attachedData: new GhostTextAttachedData(this),
-					},
-					showIfCollapsed: true,
-				}
-			});
-		}
-
-		return decorations;
-	});
-
-	private readonly _additionalLinesWidget = this._register(
-		new AdditionalLinesWidget(
-			this._editor,
-			derived(reader => {
-				/** @description lines */
-				const uiState = this.uiState.read(reader);
-				return uiState ? {
-					lineNumber: uiState.lineNumber,
-					additionalLines: uiState.additionalLines,
-					minReservedLineCount: uiState.additionalReservedLineCount,
-					targetTextModel: uiState.targetTextModel,
-				} : undefined;
-			}),
-			this._shouldKeepCursorStable,
-			this._isClickable
-		)
-	);
-
-	private readonly _isInlineTextHovered = this._editorObs.isTargetHovered(
-		p => p.target.type === MouseTargetType.CONTENT_TEXT &&
-			p.target.detail.injectedText?.options.attachedData instanceof GhostTextAttachedData &&
-			p.target.detail.injectedText.options.attachedData.owner === this,
-		this._store
-	);
-
-	public readonly isHovered = derived(this, reader => {
-		if (this._isDisposed.read(reader)) { return false; }
-		return this._isInlineTextHovered.read(reader) || this._additionalLinesWidget.isHovered.read(reader);
-	});
-
-	public readonly height = derived(this, reader => {
-		const lineHeight = this._editorObs.getOption(EditorOption.lineHeight).read(reader);
-		return lineHeight + (this._additionalLinesWidget.viewZoneHeight.read(reader) ?? 0);
-	});
+	public readonly height;
 
 	public ownsViewZone(viewZoneId: string): boolean {
 		return this._additionalLinesWidget.viewZoneId === viewZoneId;
@@ -373,31 +386,19 @@ export class AdditionalLinesWidget extends Disposable {
 	private _viewZoneInfo: { viewZoneId: string; heightInLines: number; lineNumber: number } | undefined;
 	public get viewZoneId(): string | undefined { return this._viewZoneInfo?.viewZoneId; }
 
-	private _viewZoneHeight = observableValue<undefined | number>('viewZoneHeight', undefined);
+	private _viewZoneHeight;
 	public get viewZoneHeight(): IObservable<number | undefined> { return this._viewZoneHeight; }
 
-	private readonly editorOptionsChanged = observableSignalFromEvent('editorOptionChanged', Event.filter(
-		this._editor.onDidChangeConfiguration,
-		e => e.hasChanged(EditorOption.disableMonospaceOptimizations)
-			|| e.hasChanged(EditorOption.stopRenderingLineAfter)
-			|| e.hasChanged(EditorOption.renderWhitespace)
-			|| e.hasChanged(EditorOption.renderControlCharacters)
-			|| e.hasChanged(EditorOption.fontLigatures)
-			|| e.hasChanged(EditorOption.fontInfo)
-			|| e.hasChanged(EditorOption.lineHeight)
-	));
+	private readonly editorOptionsChanged;
 
-	private readonly _onDidClick = this._register(new Emitter<IMouseEvent>());
-	public readonly onDidClick = this._onDidClick.event;
+	private readonly _onDidClick;
+	public readonly onDidClick;
 
-	private readonly _viewZoneListener = this._register(new MutableDisposable());
+	private readonly _viewZoneListener;
 
-	readonly isHovered = observableCodeEditor(this._editor).isTargetHovered(
-		p => isTargetGhostText(p.target.element),
-		this._store
-	);
+	readonly isHovered;
 
-	private hasBeenAccepted = false;
+	private hasBeenAccepted;
 
 	constructor(
 		private readonly _editor: ICodeEditor,
@@ -411,6 +412,25 @@ export class AdditionalLinesWidget extends Disposable {
 		private readonly _isClickable: boolean,
 	) {
 		super();
+		this._viewZoneHeight = observableValue<undefined | number>('viewZoneHeight', undefined);
+		this.editorOptionsChanged = observableSignalFromEvent('editorOptionChanged', Event.filter(
+			this._editor.onDidChangeConfiguration,
+			e => e.hasChanged(EditorOption.disableMonospaceOptimizations)
+				|| e.hasChanged(EditorOption.stopRenderingLineAfter)
+				|| e.hasChanged(EditorOption.renderWhitespace)
+				|| e.hasChanged(EditorOption.renderControlCharacters)
+				|| e.hasChanged(EditorOption.fontLigatures)
+				|| e.hasChanged(EditorOption.fontInfo)
+				|| e.hasChanged(EditorOption.lineHeight)
+		));
+		this._onDidClick = this._register(new Emitter<IMouseEvent>());
+		this.onDidClick = this._onDidClick.event;
+		this._viewZoneListener = this._register(new MutableDisposable());
+		this.isHovered = observableCodeEditor(this._editor).isTargetHovered(
+			p => isTargetGhostText(p.target.element),
+			this._store
+		);
+		this.hasBeenAccepted = false;
 
 		if (this._editor instanceof CodeEditorWidget && this._shouldKeepCursorStable) {
 			this._register(this._editor.onBeforeExecuteEdit(e => this.hasBeenAccepted = e.source === 'inlineSuggestion.accept'));

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineCompletionsView.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineCompletionsView.ts
@@ -17,44 +17,18 @@ import { GhostTextView } from './ghostText/ghostTextView.js';
 import { InlineEditsViewAndDiffProducer } from './inlineEdits/inlineEditsViewProducer.js';
 
 export class InlineCompletionsView extends Disposable {
-	private readonly _ghostTexts = derived(this, (reader) => {
-		const model = this._model.read(reader);
-		return model?.ghostTexts.read(reader) ?? [];
-	});
+	private readonly _ghostTexts;
 
-	private readonly _stablizedGhostTexts = convertItemsToStableObservables(this._ghostTexts, this._store);
-	private readonly _editorObs = observableCodeEditor(this._editor);
+	private readonly _stablizedGhostTexts;
+	private readonly _editorObs;
 
-	private readonly _ghostTextWidgets = mapObservableArrayCached(this, this._stablizedGhostTexts, (ghostText, store) => derivedDisposable((reader) => this._instantiationService.createInstance(
-		GhostTextView.hot.read(reader),
-		this._editor,
-		{
-			ghostText: ghostText,
-			warning: this._model.map((m, reader) => {
-				const warning = m?.warning?.read(reader);
-				return warning ? { icon: warning.icon } : undefined;
-			}),
-			minReservedLineCount: constObservable(0),
-			targetTextModel: this._model.map(v => v?.textModel),
-		},
-		this._editorObs.getOption(EditorOption.inlineSuggest).map(v => ({ syntaxHighlightingEnabled: v.syntaxHighlightingEnabled })),
-		false,
-		false
-	)
-	).recomputeInitiallyAndOnChange(store)
-	).recomputeInitiallyAndOnChange(this._store);
+	private readonly _ghostTextWidgets;
 
-	private readonly _inlineEdit = derived(this, reader => this._model.read(reader)?.inlineEditState.read(reader)?.inlineEdit);
-	private readonly _everHadInlineEdit = derivedObservableWithCache<boolean>(this, (reader, last) => last || !!this._inlineEdit.read(reader) || !!this._model.read(reader)?.inlineCompletionState.read(reader)?.inlineCompletion?.showInlineEditMenu);
-	protected readonly _inlineEditWidget = derivedDisposable(reader => {
-		if (!this._everHadInlineEdit.read(reader)) {
-			return undefined;
-		}
-		return this._instantiationService.createInstance(InlineEditsViewAndDiffProducer.hot.read(reader), this._editor, this._inlineEdit, this._model, this._focusIsInMenu);
-	})
-		.recomputeInitiallyAndOnChange(this._store);
+	private readonly _inlineEdit;
+	private readonly _everHadInlineEdit;
+	protected readonly _inlineEditWidget;
 
-	private readonly _fontFamily = this._editorObs.getOption(EditorOption.inlineSuggest).map(val => val.fontFamily);
+	private readonly _fontFamily;
 
 	constructor(
 		private readonly _editor: ICodeEditor,
@@ -63,6 +37,40 @@ export class InlineCompletionsView extends Disposable {
 		@IInstantiationService private readonly _instantiationService: IInstantiationService,
 	) {
 		super();
+		this._ghostTexts = derived(this, (reader) => {
+			const model = this._model.read(reader);
+			return model?.ghostTexts.read(reader) ?? [];
+		});
+		this._stablizedGhostTexts = convertItemsToStableObservables(this._ghostTexts, this._store);
+		this._editorObs = observableCodeEditor(this._editor);
+		this._ghostTextWidgets = mapObservableArrayCached(this, this._stablizedGhostTexts, (ghostText, store) => derivedDisposable((reader) => this._instantiationService.createInstance(
+			GhostTextView.hot.read(reader),
+			this._editor,
+			{
+				ghostText: ghostText,
+				warning: this._model.map((m, reader) => {
+					const warning = m?.warning?.read(reader);
+					return warning ? { icon: warning.icon } : undefined;
+				}),
+				minReservedLineCount: constObservable(0),
+				targetTextModel: this._model.map(v => v?.textModel),
+			},
+			this._editorObs.getOption(EditorOption.inlineSuggest).map(v => ({ syntaxHighlightingEnabled: v.syntaxHighlightingEnabled })),
+			false,
+			false
+		)
+		).recomputeInitiallyAndOnChange(store)
+		).recomputeInitiallyAndOnChange(this._store);
+		this._inlineEdit = derived(this, reader => this._model.read(reader)?.inlineEditState.read(reader)?.inlineEdit);
+		this._everHadInlineEdit = derivedObservableWithCache<boolean>(this, (reader, last) => last || !!this._inlineEdit.read(reader) || !!this._model.read(reader)?.inlineCompletionState.read(reader)?.inlineCompletion?.showInlineEditMenu);
+		this._inlineEditWidget = derivedDisposable(reader => {
+			if (!this._everHadInlineEdit.read(reader)) {
+				return undefined;
+			}
+			return this._instantiationService.createInstance(InlineEditsViewAndDiffProducer.hot.read(reader), this._editor, this._inlineEdit, this._model, this._focusIsInMenu);
+		})
+			.recomputeInitiallyAndOnChange(this._store);
+		this._fontFamily = this._editorObs.getOption(EditorOption.inlineSuggest).map(val => val.fontFamily);
 
 		this._register(createStyleSheetFromObservable(derived(reader => {
 			const fontFamily = this._fontFamily.read(reader);

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/inlineEditsLineReplacementView.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/inlineEditsLineReplacementView.ts
@@ -32,238 +32,24 @@ import { getPrefixTrim, mapOutFalsy, rectToProps } from '../utils/utils.js';
 
 export class InlineEditsLineReplacementView extends Disposable implements IInlineEditsView {
 
-	private readonly _onDidClick = this._register(new Emitter<IMouseEvent>());
-	readonly onDidClick = this._onDidClick.event;
+	private readonly _onDidClick;
+	readonly onDidClick;
 
-	private readonly _originalBubblesDecorationCollection = this._editor.editor.createDecorationsCollection();
-	private readonly _originalBubblesDecorationOptions: IModelDecorationOptions = {
-		description: 'inlineCompletions-original-bubble',
-		className: 'inlineCompletions-original-bubble',
-		stickiness: TrackedRangeStickiness.NeverGrowsWhenTypingAtEdges
-	};
+	private readonly _originalBubblesDecorationCollection;
+	private readonly _originalBubblesDecorationOptions: IModelDecorationOptions;
 
-	private readonly _maxPrefixTrim = this._edit.map(e => e ? getPrefixTrim(e.replacements.flatMap(r => [r.originalRange, r.modifiedRange]), e.originalRange, e.modifiedLines, this._editor.editor) : undefined);
+	private readonly _maxPrefixTrim;
 
-	private readonly _modifiedLineElements = derived(reader => {
-		const lines = [];
-		let requiredWidth = 0;
-
-		const prefixTrim = this._maxPrefixTrim.read(reader);
-		const edit = this._edit.read(reader);
-		if (!edit || !prefixTrim) {
-			return undefined;
-		}
-
-		const maxPrefixTrim = prefixTrim.prefixTrim;
-		const modifiedBubbles = rangesToBubbleRanges(edit.replacements.map(r => r.modifiedRange)).map(r => new Range(r.startLineNumber, r.startColumn - maxPrefixTrim, r.endLineNumber, r.endColumn - maxPrefixTrim));
-
-		const textModel = this._editor.model.get()!;
-		const startLineNumber = edit.modifiedRange.startLineNumber;
-		for (let i = 0; i < edit.modifiedRange.length; i++) {
-			const line = document.createElement('div');
-			const lineNumber = startLineNumber + i;
-			const modLine = edit.modifiedLines[i].slice(maxPrefixTrim);
-
-			const t = textModel.tokenization.tokenizeLinesAt(lineNumber, [modLine])?.[0];
-			let tokens: LineTokens;
-			if (t) {
-				tokens = TokenArray.fromLineTokens(t).toLineTokens(modLine, this._languageService.languageIdCodec);
-			} else {
-				tokens = LineTokens.createEmpty(modLine, this._languageService.languageIdCodec);
-			}
-
-			// Inline decorations are broken down into individual spans. To be able to render rounded corners, we need to set the start and end decorations separately.
-			const decorations = [];
-			for (const modified of modifiedBubbles.filter(b => b.startLineNumber === lineNumber)) {
-				const validatedEndColumn = Math.min(modified.endColumn, modLine.length + 1);
-				decorations.push(new InlineDecoration(new Range(1, modified.startColumn, 1, validatedEndColumn), 'inlineCompletions-modified-bubble', InlineDecorationType.Regular));
-				decorations.push(new InlineDecoration(new Range(1, modified.startColumn, 1, modified.startColumn + 1), 'start', InlineDecorationType.Regular));
-				decorations.push(new InlineDecoration(new Range(1, validatedEndColumn - 1, 1, validatedEndColumn), 'end', InlineDecorationType.Regular));
-			}
-
-			// TODO: All lines should be rendered at once for one dom element
-			const result = renderLines(new LineSource([tokens]), RenderOptions.fromEditor(this._editor.editor).withSetWidth(false).withScrollBeyondLastColumn(0), decorations, line, true);
-			this._editor.getOption(EditorOption.fontInfo).read(reader); // update when font info changes
-
-			requiredWidth = Math.max(requiredWidth, result.minWidthInPx);
-
-			lines.push(line);
-		}
-
-		return { lines, requiredWidth: requiredWidth };
-	});
+	private readonly _modifiedLineElements;
 
 
-	private readonly _layout = derived(this, reader => {
-		const modifiedLines = this._modifiedLineElements.read(reader);
-		const maxPrefixTrim = this._maxPrefixTrim.read(reader);
-		const edit = this._edit.read(reader);
-		if (!modifiedLines || !maxPrefixTrim || !edit) {
-			return undefined;
-		}
+	private readonly _layout;
 
-		const { prefixLeftOffset } = maxPrefixTrim;
-		const { requiredWidth } = modifiedLines;
+	private readonly _viewZoneInfo;
 
-		const lineHeight = this._editor.getOption(EditorOption.lineHeight).read(reader);
-		const contentLeft = this._editor.layoutInfoContentLeft.read(reader);
-		const verticalScrollbarWidth = this._editor.layoutInfoVerticalScrollbarWidth.read(reader);
-		const scrollLeft = this._editor.scrollLeft.read(reader);
-		const scrollTop = this._editor.scrollTop.read(reader);
-		const editorLeftOffset = contentLeft - scrollLeft;
+	private readonly _div;
 
-		const textModel = this._editor.editor.getModel()!;
-
-		const originalLineWidths = edit.originalRange.mapToLineArray(line => this._editor.editor.getOffsetForColumn(line, textModel.getLineMaxColumn(line)) - prefixLeftOffset);
-		const maxLineWidth = Math.max(...originalLineWidths, requiredWidth);
-
-		const startLineNumber = edit.originalRange.startLineNumber;
-		const endLineNumber = edit.originalRange.endLineNumberExclusive - 1;
-		const topOfOriginalLines = this._editor.editor.getTopForLineNumber(startLineNumber) - scrollTop;
-		const bottomOfOriginalLines = this._editor.editor.getBottomForLineNumber(endLineNumber) - scrollTop;
-
-		// Box Widget positioning
-		const originalLinesOverlay = Rect.fromLeftTopWidthHeight(
-			editorLeftOffset + prefixLeftOffset,
-			topOfOriginalLines,
-			maxLineWidth,
-			bottomOfOriginalLines - topOfOriginalLines
-		);
-		const modifiedLinesOverlay = Rect.fromLeftTopWidthHeight(
-			originalLinesOverlay.left,
-			originalLinesOverlay.bottom,
-			originalLinesOverlay.width,
-			edit.modifiedRange.length * lineHeight
-		);
-		const background = Rect.hull([originalLinesOverlay, modifiedLinesOverlay]);
-
-		const lowerBackground = background.intersectVertical(new OffsetRange(originalLinesOverlay.bottom, Number.MAX_SAFE_INTEGER));
-		const lowerText = new Rect(lowerBackground.left, lowerBackground.top, lowerBackground.right, lowerBackground.bottom);
-
-		return {
-			originalLinesOverlay,
-			modifiedLinesOverlay,
-			background,
-			lowerBackground,
-			lowerText,
-			minContentWidthRequired: prefixLeftOffset + maxLineWidth + verticalScrollbarWidth,
-		};
-	});
-
-	private readonly _viewZoneInfo = derived<{ height: number; lineNumber: number } | undefined>(reader => {
-		const shouldShowViewZone = this._editor.getOption(EditorOption.inlineSuggest).map(o => o.edits.allowCodeShifting === 'always').read(reader);
-		if (!shouldShowViewZone) {
-			return undefined;
-		}
-
-		const layout = this._layout.read(reader);
-		const edit = this._edit.read(reader);
-		if (!layout || !edit) {
-			return undefined;
-		}
-
-		const viewZoneHeight = layout.lowerBackground.height;
-		const viewZoneLineNumber = edit.originalRange.endLineNumberExclusive;
-		return { height: viewZoneHeight, lineNumber: viewZoneLineNumber };
-	});
-
-	private readonly _div = n.div({
-		class: 'line-replacement',
-	}, [
-		derived(reader => {
-			const layout = mapOutFalsy(this._layout).read(reader);
-			const modifiedLineElements = this._modifiedLineElements.read(reader);
-			if (!layout || !modifiedLineElements) {
-				return [];
-			}
-
-			const layoutProps = layout.read(reader);
-			const contentLeft = this._editor.layoutInfoContentLeft.read(reader);
-			const contentWidth = this._editor.contentWidth.read(reader);
-			const contentHeight = this._editor.editor.getContentHeight();
-
-			const lineHeight = this._editor.getOption(EditorOption.lineHeight).read(reader);
-			modifiedLineElements.lines.forEach(l => {
-				l.style.width = `${layoutProps.lowerText.width}px`;
-				l.style.height = `${lineHeight}px`;
-				l.style.position = 'relative';
-			});
-
-			const modifiedBorderColor = getModifiedBorderColor(this._tabAction).read(reader);
-			const originalBorderColor = getOriginalBorderColor(this._tabAction).read(reader);
-
-			return [
-				n.div({
-					style: {
-						position: 'absolute',
-						top: 0,
-						left: contentLeft,
-						width: contentWidth,
-						height: contentHeight,
-						overflow: 'hidden',
-						pointerEvents: 'none',
-					}
-				}, [
-					n.div({
-						class: 'originalOverlayLineReplacement',
-						style: {
-							position: 'absolute',
-							...rectToProps(reader => layout.read(reader).background.translateX(-contentLeft)),
-							borderRadius: '4px',
-
-							border: getEditorBlendedColor(originalBorderColor, this._themeService).map(c => `1px solid ${c.toString()}`),
-							pointerEvents: 'none',
-							boxSizing: 'border-box',
-							background: asCssVariable(originalBackgroundColor),
-						}
-					}),
-					n.div({
-						class: 'modifiedOverlayLineReplacement',
-						style: {
-							position: 'absolute',
-							...rectToProps(reader => layout.read(reader).lowerBackground.translateX(-contentLeft)),
-							borderRadius: '0 0 4px 4px',
-							background: asCssVariable(editorBackground),
-							boxShadow: `${asCssVariable(scrollbarShadow)} 0 6px 6px -6px`,
-							border: `1px solid ${asCssVariable(modifiedBorderColor)}`,
-							boxSizing: 'border-box',
-							overflow: 'hidden',
-							cursor: 'pointer',
-							pointerEvents: 'auto',
-						},
-						onmousedown: e => {
-							e.preventDefault(); // This prevents that the editor loses focus
-						},
-						onclick: (e) => this._onDidClick.fire(new StandardMouseEvent(getWindow(e), e)),
-					}, [
-						n.div({
-							style: {
-								position: 'absolute', top: 0, left: 0, width: '100%', height: '100%',
-								background: asCssVariable(modifiedChangedLineBackgroundColor),
-							},
-						})
-					]),
-					n.div({
-						class: 'modifiedLinesLineReplacement',
-						style: {
-							position: 'absolute',
-							boxSizing: 'border-box',
-							...rectToProps(reader => layout.read(reader).lowerText.translateX(-contentLeft)),
-							fontFamily: this._editor.getOption(EditorOption.fontFamily),
-							fontSize: this._editor.getOption(EditorOption.fontSize),
-							fontWeight: this._editor.getOption(EditorOption.fontWeight),
-							pointerEvents: 'none',
-							whiteSpace: 'nowrap',
-							borderRadius: '0 0 4px 4px',
-							overflow: 'hidden',
-						}
-					}, [...modifiedLineElements.lines]),
-				])
-			];
-		})
-	]).keepUpdated(this._store);
-
-	readonly isHovered = this._editor.isTargetHovered((e) => this._isMouseOverWidget(e), this._store);
+	readonly isHovered;
 
 	constructor(
 		private readonly _editor: ObservableCodeEditor,
@@ -278,6 +64,231 @@ export class InlineEditsLineReplacementView extends Disposable implements IInlin
 		@IThemeService private readonly _themeService: IThemeService,
 	) {
 		super();
+		this._onDidClick = this._register(new Emitter<IMouseEvent>());
+		this.onDidClick = this._onDidClick.event;
+		this._originalBubblesDecorationCollection = this._editor.editor.createDecorationsCollection();
+		this._originalBubblesDecorationOptions = {
+			description: 'inlineCompletions-original-bubble',
+			className: 'inlineCompletions-original-bubble',
+			stickiness: TrackedRangeStickiness.NeverGrowsWhenTypingAtEdges
+		};
+		this._maxPrefixTrim = this._edit.map(e => e ? getPrefixTrim(e.replacements.flatMap(r => [r.originalRange, r.modifiedRange]), e.originalRange, e.modifiedLines, this._editor.editor) : undefined);
+		this._modifiedLineElements = derived(reader => {
+			const lines = [];
+			let requiredWidth = 0;
+
+			const prefixTrim = this._maxPrefixTrim.read(reader);
+			const edit = this._edit.read(reader);
+			if (!edit || !prefixTrim) {
+				return undefined;
+			}
+
+			const maxPrefixTrim = prefixTrim.prefixTrim;
+			const modifiedBubbles = rangesToBubbleRanges(edit.replacements.map(r => r.modifiedRange)).map(r => new Range(r.startLineNumber, r.startColumn - maxPrefixTrim, r.endLineNumber, r.endColumn - maxPrefixTrim));
+
+			const textModel = this._editor.model.get()!;
+			const startLineNumber = edit.modifiedRange.startLineNumber;
+			for (let i = 0; i < edit.modifiedRange.length; i++) {
+				const line = document.createElement('div');
+				const lineNumber = startLineNumber + i;
+				const modLine = edit.modifiedLines[i].slice(maxPrefixTrim);
+
+				const t = textModel.tokenization.tokenizeLinesAt(lineNumber, [modLine])?.[0];
+				let tokens: LineTokens;
+				if (t) {
+					tokens = TokenArray.fromLineTokens(t).toLineTokens(modLine, this._languageService.languageIdCodec);
+				} else {
+					tokens = LineTokens.createEmpty(modLine, this._languageService.languageIdCodec);
+				}
+
+				// Inline decorations are broken down into individual spans. To be able to render rounded corners, we need to set the start and end decorations separately.
+				const decorations = [];
+				for (const modified of modifiedBubbles.filter(b => b.startLineNumber === lineNumber)) {
+					const validatedEndColumn = Math.min(modified.endColumn, modLine.length + 1);
+					decorations.push(new InlineDecoration(new Range(1, modified.startColumn, 1, validatedEndColumn), 'inlineCompletions-modified-bubble', InlineDecorationType.Regular));
+					decorations.push(new InlineDecoration(new Range(1, modified.startColumn, 1, modified.startColumn + 1), 'start', InlineDecorationType.Regular));
+					decorations.push(new InlineDecoration(new Range(1, validatedEndColumn - 1, 1, validatedEndColumn), 'end', InlineDecorationType.Regular));
+				}
+
+				// TODO: All lines should be rendered at once for one dom element
+				const result = renderLines(new LineSource([tokens]), RenderOptions.fromEditor(this._editor.editor).withSetWidth(false).withScrollBeyondLastColumn(0), decorations, line, true);
+				this._editor.getOption(EditorOption.fontInfo).read(reader); // update when font info changes
+
+				requiredWidth = Math.max(requiredWidth, result.minWidthInPx);
+
+				lines.push(line);
+			}
+
+			return { lines, requiredWidth: requiredWidth };
+		});
+		this._layout = derived(this, reader => {
+			const modifiedLines = this._modifiedLineElements.read(reader);
+			const maxPrefixTrim = this._maxPrefixTrim.read(reader);
+			const edit = this._edit.read(reader);
+			if (!modifiedLines || !maxPrefixTrim || !edit) {
+				return undefined;
+			}
+
+			const { prefixLeftOffset } = maxPrefixTrim;
+			const { requiredWidth } = modifiedLines;
+
+			const lineHeight = this._editor.getOption(EditorOption.lineHeight).read(reader);
+			const contentLeft = this._editor.layoutInfoContentLeft.read(reader);
+			const verticalScrollbarWidth = this._editor.layoutInfoVerticalScrollbarWidth.read(reader);
+			const scrollLeft = this._editor.scrollLeft.read(reader);
+			const scrollTop = this._editor.scrollTop.read(reader);
+			const editorLeftOffset = contentLeft - scrollLeft;
+
+			const textModel = this._editor.editor.getModel()!;
+
+			const originalLineWidths = edit.originalRange.mapToLineArray(line => this._editor.editor.getOffsetForColumn(line, textModel.getLineMaxColumn(line)) - prefixLeftOffset);
+			const maxLineWidth = Math.max(...originalLineWidths, requiredWidth);
+
+			const startLineNumber = edit.originalRange.startLineNumber;
+			const endLineNumber = edit.originalRange.endLineNumberExclusive - 1;
+			const topOfOriginalLines = this._editor.editor.getTopForLineNumber(startLineNumber) - scrollTop;
+			const bottomOfOriginalLines = this._editor.editor.getBottomForLineNumber(endLineNumber) - scrollTop;
+
+			// Box Widget positioning
+			const originalLinesOverlay = Rect.fromLeftTopWidthHeight(
+				editorLeftOffset + prefixLeftOffset,
+				topOfOriginalLines,
+				maxLineWidth,
+				bottomOfOriginalLines - topOfOriginalLines
+			);
+			const modifiedLinesOverlay = Rect.fromLeftTopWidthHeight(
+				originalLinesOverlay.left,
+				originalLinesOverlay.bottom,
+				originalLinesOverlay.width,
+				edit.modifiedRange.length * lineHeight
+			);
+			const background = Rect.hull([originalLinesOverlay, modifiedLinesOverlay]);
+
+			const lowerBackground = background.intersectVertical(new OffsetRange(originalLinesOverlay.bottom, Number.MAX_SAFE_INTEGER));
+			const lowerText = new Rect(lowerBackground.left, lowerBackground.top, lowerBackground.right, lowerBackground.bottom);
+
+			return {
+				originalLinesOverlay,
+				modifiedLinesOverlay,
+				background,
+				lowerBackground,
+				lowerText,
+				minContentWidthRequired: prefixLeftOffset + maxLineWidth + verticalScrollbarWidth,
+			};
+		});
+		this._viewZoneInfo = derived<{ height: number; lineNumber: number } | undefined>(reader => {
+			const shouldShowViewZone = this._editor.getOption(EditorOption.inlineSuggest).map(o => o.edits.allowCodeShifting === 'always').read(reader);
+			if (!shouldShowViewZone) {
+				return undefined;
+			}
+
+			const layout = this._layout.read(reader);
+			const edit = this._edit.read(reader);
+			if (!layout || !edit) {
+				return undefined;
+			}
+
+			const viewZoneHeight = layout.lowerBackground.height;
+			const viewZoneLineNumber = edit.originalRange.endLineNumberExclusive;
+			return { height: viewZoneHeight, lineNumber: viewZoneLineNumber };
+		});
+		this._div = n.div({
+			class: 'line-replacement',
+		}, [
+			derived(reader => {
+				const layout = mapOutFalsy(this._layout).read(reader);
+				const modifiedLineElements = this._modifiedLineElements.read(reader);
+				if (!layout || !modifiedLineElements) {
+					return [];
+				}
+
+				const layoutProps = layout.read(reader);
+				const contentLeft = this._editor.layoutInfoContentLeft.read(reader);
+				const contentWidth = this._editor.contentWidth.read(reader);
+				const contentHeight = this._editor.editor.getContentHeight();
+
+				const lineHeight = this._editor.getOption(EditorOption.lineHeight).read(reader);
+				modifiedLineElements.lines.forEach(l => {
+					l.style.width = `${layoutProps.lowerText.width}px`;
+					l.style.height = `${lineHeight}px`;
+					l.style.position = 'relative';
+				});
+
+				const modifiedBorderColor = getModifiedBorderColor(this._tabAction).read(reader);
+				const originalBorderColor = getOriginalBorderColor(this._tabAction).read(reader);
+
+				return [
+					n.div({
+						style: {
+							position: 'absolute',
+							top: 0,
+							left: contentLeft,
+							width: contentWidth,
+							height: contentHeight,
+							overflow: 'hidden',
+							pointerEvents: 'none',
+						}
+					}, [
+						n.div({
+							class: 'originalOverlayLineReplacement',
+							style: {
+								position: 'absolute',
+								...rectToProps(reader => layout.read(reader).background.translateX(-contentLeft)),
+								borderRadius: '4px',
+
+								border: getEditorBlendedColor(originalBorderColor, this._themeService).map(c => `1px solid ${c.toString()}`),
+								pointerEvents: 'none',
+								boxSizing: 'border-box',
+								background: asCssVariable(originalBackgroundColor),
+							}
+						}),
+						n.div({
+							class: 'modifiedOverlayLineReplacement',
+							style: {
+								position: 'absolute',
+								...rectToProps(reader => layout.read(reader).lowerBackground.translateX(-contentLeft)),
+								borderRadius: '0 0 4px 4px',
+								background: asCssVariable(editorBackground),
+								boxShadow: `${asCssVariable(scrollbarShadow)} 0 6px 6px -6px`,
+								border: `1px solid ${asCssVariable(modifiedBorderColor)}`,
+								boxSizing: 'border-box',
+								overflow: 'hidden',
+								cursor: 'pointer',
+								pointerEvents: 'auto',
+							},
+							onmousedown: e => {
+								e.preventDefault(); // This prevents that the editor loses focus
+							},
+							onclick: (e) => this._onDidClick.fire(new StandardMouseEvent(getWindow(e), e)),
+						}, [
+							n.div({
+								style: {
+									position: 'absolute', top: 0, left: 0, width: '100%', height: '100%',
+									background: asCssVariable(modifiedChangedLineBackgroundColor),
+								},
+							})
+						]),
+						n.div({
+							class: 'modifiedLinesLineReplacement',
+							style: {
+								position: 'absolute',
+								boxSizing: 'border-box',
+								...rectToProps(reader => layout.read(reader).lowerText.translateX(-contentLeft)),
+								fontFamily: this._editor.getOption(EditorOption.fontFamily),
+								fontSize: this._editor.getOption(EditorOption.fontSize),
+								fontWeight: this._editor.getOption(EditorOption.fontWeight),
+								pointerEvents: 'none',
+								whiteSpace: 'nowrap',
+								borderRadius: '0 0 4px 4px',
+								overflow: 'hidden',
+							}
+						}, [...modifiedLineElements.lines]),
+					])
+				];
+			})
+		]).keepUpdated(this._store);
+		this.isHovered = this._editor.isTargetHovered((e) => this._isMouseOverWidget(e), this._store);
+		this._previousViewZoneInfo = undefined;
 
 		this._register(toDisposable(() => this._originalBubblesDecorationCollection.clear()));
 		this._register(toDisposable(() => this._editor.editor.changeViewZones(accessor => this.removePreviousViewZone(accessor))));
@@ -322,7 +333,7 @@ export class InlineEditsLineReplacementView extends Disposable implements IInlin
 	}
 
 	// View Zones
-	private _previousViewZoneInfo: { height: number; lineNumber: number; id: string } | undefined = undefined;
+	private _previousViewZoneInfo: { height: number; lineNumber: number; id: string } | undefined;
 
 	private removePreviousViewZone(changeAccessor: IViewZoneChangeAccessor) {
 		if (!this._previousViewZoneInfo) {

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/inlineEditsSideBySideView.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/inlineEditsSideBySideView.ts
@@ -56,10 +56,10 @@ export class InlineEditsSideBySideView extends Disposable implements IInlineEdit
 		return maxOriginalContent + maxModifiedContent + originalPadding + modifiedPadding < editorWidth - editorContentLeft - editorVerticalScrollbar - minimapWidth;
 	}
 
-	private readonly _editorObs = observableCodeEditor(this._editor);
+	private readonly _editorObs;
 
-	private readonly _onDidClick = this._register(new Emitter<IMouseEvent>());
-	readonly onDidClick = this._onDidClick.event;
+	private readonly _onDidClick;
+	readonly onDidClick;
 
 	constructor(
 		private readonly _editor: ICodeEditor,
@@ -73,6 +73,463 @@ export class InlineEditsSideBySideView extends Disposable implements IInlineEdit
 		@IThemeService private readonly _themeService: IThemeService,
 	) {
 		super();
+		this._editorObs = observableCodeEditor(this._editor);
+		this._onDidClick = this._register(new Emitter<IMouseEvent>());
+		this.onDidClick = this._onDidClick.event;
+		this._display = derived(this, reader => !!this._uiState.read(reader) ? 'block' : 'none');
+		this.previewRef = n.ref<HTMLDivElement>();
+		this._editorContainer = n.div({
+			class: ['editorContainer'],
+			style: { position: 'absolute', overflow: 'hidden', cursor: 'pointer' },
+			onmousedown: e => {
+				e.preventDefault(); // This prevents that the editor loses focus
+			},
+			onclick: (e) => {
+				this._onDidClick.fire(new StandardMouseEvent(getWindow(e), e));
+			}
+		}, [
+			n.div({ class: 'preview', style: { pointerEvents: 'none' }, ref: this.previewRef }),
+		]).keepUpdated(this._store);
+		this.isHovered = this._editorContainer.didMouseMoveDuringHover;
+		this.previewEditor = this._register(this._instantiationService.createInstance(
+			EmbeddedCodeEditorWidget,
+			this.previewRef.element,
+			{
+				glyphMargin: false,
+				lineNumbers: 'off',
+				minimap: { enabled: false },
+				guides: {
+					indentation: false,
+					bracketPairs: false,
+					bracketPairsHorizontal: false,
+					highlightActiveIndentation: false,
+				},
+				rulers: [],
+				padding: { top: 0, bottom: 0 },
+				folding: false,
+				selectOnLineNumbers: false,
+				selectionHighlight: false,
+				columnSelection: false,
+				overviewRulerBorder: false,
+				overviewRulerLanes: 0,
+				lineDecorationsWidth: 0,
+				lineNumbersMinChars: 0,
+				revealHorizontalRightPadding: 0,
+				bracketPairColorization: { enabled: true, independentColorPoolPerBracketType: false },
+				scrollBeyondLastLine: false,
+				scrollbar: {
+					vertical: 'hidden',
+					horizontal: 'hidden',
+					handleMouseWheel: false,
+				},
+				readOnly: true,
+				wordWrap: 'off',
+				wordWrapOverride1: 'off',
+				wordWrapOverride2: 'off',
+			},
+			{
+				contextKeyValues: {
+					[InlineCompletionContextKeys.inInlineEditsPreviewEditor.key]: true,
+				},
+				contributions: [],
+			},
+			this._editor
+		));
+		this._previewEditorObs = observableCodeEditor(this.previewEditor);
+		this._activeViewZones = [];
+		this._updatePreviewEditor = derived(reader => {
+			this._editorContainer.readEffect(reader);
+			this._previewEditorObs.model.read(reader); // update when the model is set
+
+			// Setting this here explicitly to make sure that the preview editor is
+			// visible when needed, we're also checking that these fields are defined
+			// because of the auto run initial
+			// Before removing these, verify with a non-monospace font family
+			this._display.read(reader);
+			if (this._nonOverflowView) {
+				this._nonOverflowView.element.style.display = this._display.read(reader);
+			}
+
+			const uiState = this._uiState.read(reader);
+			const edit = this._edit.read(reader);
+			if (!uiState || !edit) {
+				return;
+			}
+
+			const range = edit.originalLineRange;
+
+			const hiddenAreas: Range[] = [];
+			if (range.startLineNumber > 1) {
+				hiddenAreas.push(new Range(1, 1, range.startLineNumber - 1, 1));
+			}
+			if (range.startLineNumber + uiState.newTextLineCount < this._previewTextModel.getLineCount() + 1) {
+				hiddenAreas.push(new Range(range.startLineNumber + uiState.newTextLineCount, 1, this._previewTextModel.getLineCount() + 1, 1));
+			}
+
+			this.previewEditor.setHiddenAreas(hiddenAreas, undefined, true);
+
+			// TODO: is this the proper way to handle viewzones?
+			const previousViewZones = [...this._activeViewZones];
+			this._activeViewZones = [];
+
+			const reducedLinesCount = (range.endLineNumberExclusive - range.startLineNumber) - uiState.newTextLineCount;
+			this.previewEditor.changeViewZones((changeAccessor) => {
+				previousViewZones.forEach(id => changeAccessor.removeZone(id));
+
+				if (reducedLinesCount > 0) {
+					this._activeViewZones.push(changeAccessor.addZone({
+						afterLineNumber: range.startLineNumber + uiState.newTextLineCount - 1,
+						heightInLines: reducedLinesCount,
+						showInHiddenAreas: true,
+						domNode: $('div.diagonal-fill.inline-edits-view-zone'),
+					}));
+				}
+			});
+		});
+		this._previewEditorWidth = derived(this, reader => {
+			const edit = this._edit.read(reader);
+			if (!edit) { return 0; }
+			this._updatePreviewEditor.read(reader);
+
+			return maxContentWidthInRange(this._previewEditorObs, edit.modifiedLineRange, reader);
+		});
+		this._cursorPosIfTouchesEdit = derived(this, reader => {
+			const cursorPos = this._editorObs.cursorPosition.read(reader);
+			const edit = this._edit.read(reader);
+			if (!edit || !cursorPos) { return undefined; }
+			return edit.modifiedLineRange.contains(cursorPos.lineNumber) ? cursorPos : undefined;
+		});
+		this._originalStartPosition = derived(this, (reader) => {
+			const inlineEdit = this._edit.read(reader);
+			return inlineEdit ? new Position(inlineEdit.originalLineRange.startLineNumber, 1) : null;
+		});
+		this._originalEndPosition = derived(this, (reader) => {
+			const inlineEdit = this._edit.read(reader);
+			return inlineEdit ? new Position(inlineEdit.originalLineRange.endLineNumberExclusive, 1) : null;
+		});
+		this._originalVerticalStartPosition = this._editorObs.observePosition(this._originalStartPosition, this._store).map(p => p?.y);
+		this._originalVerticalEndPosition = this._editorObs.observePosition(this._originalEndPosition, this._store).map(p => p?.y);
+		this._originalDisplayRange = this._edit.map(e => e?.displayRange);
+		this._editorMaxContentWidthInRange = derived(this, reader => {
+			const originalDisplayRange = this._originalDisplayRange.read(reader);
+			if (!originalDisplayRange) {
+				return constObservable(0);
+			}
+			this._editorObs.versionId.read(reader);
+
+			// Take the max value that we observed.
+			// Reset when either the edit changes or the editor text version.
+			return derivedObservableWithCache<number>(this, (reader, lastValue) => {
+				const maxWidth = maxContentWidthInRange(this._editorObs, originalDisplayRange, reader);
+				return Math.max(maxWidth, lastValue ?? 0);
+			});
+		}).map((v, r) => v.read(r));
+		this._previewEditorLayoutInfo = derived(this, (reader) => {
+			const inlineEdit = this._edit.read(reader);
+			if (!inlineEdit) {
+				return null;
+			}
+			const state = this._uiState.read(reader);
+			if (!state) {
+				return null;
+			}
+
+			const range = inlineEdit.originalLineRange;
+
+			const horizontalScrollOffset = this._editorObs.scrollLeft.read(reader);
+
+			const editorContentMaxWidthInRange = this._editorMaxContentWidthInRange.read(reader);
+			const editorLayout = this._editorObs.layoutInfo.read(reader);
+			const previewContentWidth = this._previewEditorWidth.read(reader);
+			const editorContentAreaWidth = editorLayout.contentWidth - editorLayout.verticalScrollbarWidth;
+			const editorBoundingClientRect = this._editor.getContainerDomNode().getBoundingClientRect();
+			const clientContentAreaRight = editorLayout.contentLeft + editorLayout.contentWidth + editorBoundingClientRect.left;
+			const remainingWidthRightOfContent = getWindow(this._editor.getContainerDomNode()).innerWidth - clientContentAreaRight;
+			const remainingWidthRightOfEditor = getWindow(this._editor.getContainerDomNode()).innerWidth - editorBoundingClientRect.right;
+			const desiredMinimumWidth = Math.min(editorLayout.contentWidth * 0.3, previewContentWidth, 100);
+			const IN_EDITOR_DISPLACEMENT = 0;
+			const maximumAvailableWidth = IN_EDITOR_DISPLACEMENT + remainingWidthRightOfContent;
+
+			const cursorPos = this._cursorPosIfTouchesEdit.read(reader);
+
+			const maxPreviewEditorLeft = Math.max(
+				// We're starting from the content area right and moving it left by IN_EDITOR_DISPLACEMENT and also by an amount to ensure some minimum desired width
+				editorContentAreaWidth + horizontalScrollOffset - IN_EDITOR_DISPLACEMENT - Math.max(0, desiredMinimumWidth - maximumAvailableWidth),
+				// But we don't want that the moving left ends up covering the cursor, so this will push it to the right again
+				Math.min(
+					cursorPos ? getOffsetForPos(this._editorObs, cursorPos, reader) + 50 : 0,
+					editorContentAreaWidth + horizontalScrollOffset
+				)
+			);
+			const previewEditorLeftInTextArea = Math.min(editorContentMaxWidthInRange + ORIGINAL_END_PADDING, maxPreviewEditorLeft);
+
+			const maxContentWidth = editorContentMaxWidthInRange + ORIGINAL_END_PADDING + previewContentWidth + 70;
+
+			const dist = maxPreviewEditorLeft - previewEditorLeftInTextArea;
+
+			let desiredPreviewEditorScrollLeft;
+			let codeRight;
+			if (previewEditorLeftInTextArea > horizontalScrollOffset) {
+				desiredPreviewEditorScrollLeft = 0;
+				codeRight = editorLayout.contentLeft + previewEditorLeftInTextArea - horizontalScrollOffset;
+			} else {
+				desiredPreviewEditorScrollLeft = horizontalScrollOffset - previewEditorLeftInTextArea;
+				codeRight = editorLayout.contentLeft;
+			}
+
+			const selectionTop = this._originalVerticalStartPosition.read(reader) ?? this._editor.getTopForLineNumber(range.startLineNumber) - this._editorObs.scrollTop.read(reader);
+			const selectionBottom = this._originalVerticalEndPosition.read(reader) ?? this._editor.getBottomForLineNumber(range.endLineNumberExclusive - 1) - this._editorObs.scrollTop.read(reader);
+
+			// TODO: const { prefixLeftOffset } = getPrefixTrim(inlineEdit.edit.edits.map(e => e.range), inlineEdit.originalLineRange, [], this._editor);
+			const codeLeft = editorLayout.contentLeft - horizontalScrollOffset;
+
+			let codeRect = Rect.fromLeftTopRightBottom(codeLeft, selectionTop, codeRight, selectionBottom);
+			const isInsertion = codeRect.height === 0;
+			if (!isInsertion) {
+				codeRect = codeRect.withMargin(VERTICAL_PADDING, HORIZONTAL_PADDING);
+			}
+
+			const editHeight = this._editor.getOption(EditorOption.lineHeight) * inlineEdit.modifiedLineRange.length;
+			const codeHeight = selectionBottom - selectionTop;
+			const previewEditorHeight = Math.max(codeHeight, editHeight);
+
+			const clipped = dist === 0;
+			const codeEditDist = 0;
+			const previewEditorWidth = Math.min(previewContentWidth + MODIFIED_END_PADDING, remainingWidthRightOfEditor + editorLayout.width - editorLayout.contentLeft - codeEditDist);
+
+			let editRect = Rect.fromLeftTopWidthHeight(codeRect.right + codeEditDist, selectionTop, previewEditorWidth, previewEditorHeight);
+			if (!isInsertion) {
+				editRect = editRect.withMargin(VERTICAL_PADDING, HORIZONTAL_PADDING).translateX(HORIZONTAL_PADDING + BORDER_WIDTH);
+			} else {
+				// Align top of edit with insertion line
+				editRect = editRect.withMargin(VERTICAL_PADDING, HORIZONTAL_PADDING).translateY(VERTICAL_PADDING);
+			}
+
+			// debugView(debugLogRects({ codeRect, editRect }, this._editor.getDomNode()!), reader);
+
+			return {
+				codeRect,
+				editRect,
+				codeScrollLeft: horizontalScrollOffset,
+				contentLeft: editorLayout.contentLeft,
+
+				isInsertion,
+				maxContentWidth,
+				shouldShowShadow: clipped,
+				desiredPreviewEditorScrollLeft,
+				previewEditorWidth,
+			};
+		});
+		this._stickyScrollController = StickyScrollController.get(this._editorObs.editor);
+		this._stickyScrollHeight = this._stickyScrollController ? observableFromEvent(this._stickyScrollController.onDidChangeStickyScrollHeight, () => this._stickyScrollController!.stickyScrollWidgetHeight) : constObservable(0);
+		this._shouldOverflow = derived(reader => {
+			if (!ENABLE_OVERFLOW) {
+				return false;
+			}
+			const range = this._edit.read(reader)?.originalLineRange;
+			if (!range) {
+				return false;
+			}
+			const stickyScrollHeight = this._stickyScrollHeight.read(reader);
+			const top = this._editor.getTopForLineNumber(range.startLineNumber) - this._editorObs.scrollTop.read(reader);
+			if (top <= stickyScrollHeight) {
+				return false;
+			}
+			const bottom = this._editor.getTopForLineNumber(range.endLineNumberExclusive) - this._editorObs.scrollTop.read(reader);
+			if (bottom >= this._editorObs.layoutInfo.read(reader).height) {
+				return false;
+			}
+			return true;
+		});
+		this._originalBackgroundColor = observableFromEvent(this, this._themeService.onDidColorThemeChange, () => {
+			return this._themeService.getColorTheme().getColor(originalBackgroundColor) ?? Color.transparent;
+		});
+		this._backgroundSvg = n.svg({
+			transform: 'translate(-0.5 -0.5)',
+			style: { overflow: 'visible', pointerEvents: 'none', position: 'absolute' },
+		}, [
+			n.svgElem('path', {
+				class: 'rightOfModifiedBackgroundCoverUp',
+				d: derived(reader => {
+					const layoutInfo = this._previewEditorLayoutInfo.read(reader);
+					if (!layoutInfo) {
+						return undefined;
+					}
+					const originalBackgroundColor = this._originalBackgroundColor.read(reader);
+					if (originalBackgroundColor.isTransparent()) {
+						return undefined;
+					}
+
+					return new PathBuilder()
+						.moveTo(layoutInfo.codeRect.getRightTop())
+						.lineTo(layoutInfo.codeRect.getRightTop().deltaX(1000))
+						.lineTo(layoutInfo.codeRect.getRightBottom().deltaX(1000))
+						.lineTo(layoutInfo.codeRect.getRightBottom())
+						.build();
+				}),
+				style: {
+					fill: asCssVariableWithDefault(editorBackground, 'transparent'),
+				}
+			}),
+		]).keepUpdated(this._store);
+		this._originalOverlay = n.div({
+			style: { pointerEvents: 'none', display: this._previewEditorLayoutInfo.map(layoutInfo => layoutInfo?.isInsertion ? 'none' : 'block') },
+		}, derived(reader => {
+			const layoutInfoObs = mapOutFalsy(this._previewEditorLayoutInfo).read(reader);
+			if (!layoutInfoObs) { return undefined; }
+
+			const borderStyling = getOriginalBorderColor(this._tabAction).map(bc => `${BORDER_WIDTH}px solid ${asCssVariable(bc)}`);
+			const borderStylingSeparator = `${BORDER_WIDTH + WIDGET_SEPARATOR_WIDTH}px solid ${asCssVariable(editorBackground)}`;
+
+			const hasBorderLeft = layoutInfoObs.read(reader).codeScrollLeft !== 0;
+			const isModifiedLower = layoutInfoObs.map(layoutInfo => layoutInfo.codeRect.bottom < layoutInfo.editRect.bottom);
+			const transitionRectSize = BORDER_RADIUS * 2 + BORDER_WIDTH * 2;
+
+			// Create an overlay which hides the left hand side of the original overlay when it overflows to the left
+			// such that there is a smooth transition at the edge of content left
+			const overlayHider = layoutInfoObs.map(layoutInfo => Rect.fromLeftTopRightBottom(
+				layoutInfo.contentLeft - BORDER_RADIUS - BORDER_WIDTH,
+				layoutInfo.codeRect.top,
+				layoutInfo.contentLeft,
+				layoutInfo.codeRect.bottom + transitionRectSize
+			)).read(reader);
+
+			const intersectionLine = new OffsetRange(overlayHider.left, Number.MAX_SAFE_INTEGER);
+			const overlayRect = layoutInfoObs.map(layoutInfo => layoutInfo.codeRect.intersectHorizontal(intersectionLine));
+			const separatorRect = overlayRect.map(overlayRect => overlayRect.withMargin(WIDGET_SEPARATOR_WIDTH, 0, WIDGET_SEPARATOR_WIDTH, WIDGET_SEPARATOR_WIDTH).intersectHorizontal(intersectionLine));
+
+			const transitionRect = overlayRect.map(overlayRect => Rect.fromLeftTopWidthHeight(overlayRect.right - transitionRectSize + BORDER_WIDTH, overlayRect.bottom - BORDER_WIDTH, transitionRectSize, transitionRectSize).intersectHorizontal(intersectionLine));
+
+			return [
+				n.div({
+					class: 'originalSeparatorSideBySide',
+					style: {
+						...separatorRect.read(reader).toStyles(),
+						boxSizing: 'border-box',
+						borderRadius: `${BORDER_RADIUS}px 0 0 ${BORDER_RADIUS}px`,
+						borderTop: borderStylingSeparator,
+						borderBottom: borderStylingSeparator,
+						borderLeft: hasBorderLeft ? 'none' : borderStylingSeparator,
+					}
+				}),
+
+				n.div({
+					class: 'originalOverlaySideBySide',
+					style: {
+						...overlayRect.read(reader).toStyles(),
+						boxSizing: 'border-box',
+						borderRadius: `${BORDER_RADIUS}px 0 0 ${BORDER_RADIUS}px`,
+						borderTop: borderStyling,
+						borderBottom: borderStyling,
+						borderLeft: hasBorderLeft ? 'none' : borderStyling,
+						backgroundColor: asCssVariable(originalBackgroundColor),
+					}
+				}),
+
+				n.div({
+					class: 'originalCornerCutoutSideBySide',
+					style: {
+						pointerEvents: 'none',
+						display: isModifiedLower.map(isLower => isLower ? 'block' : 'none'),
+						...transitionRect.read(reader).toStyles(),
+					}
+				}, [
+					n.div({
+						class: 'originalCornerCutoutBackground',
+						style: {
+							position: 'absolute', top: '0px', left: '0px', width: '100%', height: '100%',
+							backgroundColor: getEditorBlendedColor(originalBackgroundColor, this._themeService).map(c => c.toString()),
+						}
+					}),
+					n.div({
+						class: 'originalCornerCutoutBorder',
+						style: {
+							position: 'absolute', top: '0px', left: '0px', width: '100%', height: '100%',
+							boxSizing: 'border-box',
+							borderTop: borderStyling,
+							borderRight: borderStyling,
+							borderRadius: `0 100% 0 0`,
+							backgroundColor: asCssVariable(editorBackground)
+						}
+					})
+				]),
+				n.div({
+					class: 'originalOverlaySideBySideHider',
+					style: {
+						...overlayHider.toStyles(),
+						backgroundColor: asCssVariable(editorBackground),
+					}
+				}),
+			];
+		})).keepUpdated(this._store);
+		this._modifiedOverlay = n.div({
+			style: { pointerEvents: 'none', }
+		}, derived(reader => {
+			const layoutInfoObs = mapOutFalsy(this._previewEditorLayoutInfo).read(reader);
+			if (!layoutInfoObs) { return undefined; }
+
+			const isModifiedLower = layoutInfoObs.map(layoutInfo => layoutInfo.codeRect.bottom < layoutInfo.editRect.bottom);
+
+			const borderRadius = isModifiedLower.map(isLower => `0 ${BORDER_RADIUS}px ${BORDER_RADIUS}px ${isLower ? BORDER_RADIUS : 0}px`);
+			const borderStyling = getEditorBlendedColor(getModifiedBorderColor(this._tabAction), this._themeService).map(c => `1px solid ${c.toString()}`);
+			const borderStylingSeparator = `${BORDER_WIDTH + WIDGET_SEPARATOR_WIDTH}px solid ${asCssVariable(editorBackground)}`;
+
+			const overlayRect = layoutInfoObs.map(layoutInfo => layoutInfo.editRect.withMargin(0, BORDER_WIDTH));
+			const separatorRect = overlayRect.map(overlayRect => overlayRect.withMargin(WIDGET_SEPARATOR_WIDTH, WIDGET_SEPARATOR_WIDTH, WIDGET_SEPARATOR_WIDTH, 0));
+
+			const insertionRect = derived(reader => {
+				const overlay = overlayRect.read(reader);
+				const layoutinfo = layoutInfoObs.read(reader);
+				if (!layoutinfo.isInsertion || layoutinfo.contentLeft >= overlay.left) {
+					return Rect.fromLeftTopWidthHeight(overlay.left, overlay.top, 0, 0);
+				}
+				return new Rect(layoutinfo.contentLeft, overlay.top, overlay.left, overlay.top + BORDER_WIDTH * 2);
+			});
+
+			return [
+				n.div({
+					class: 'modifiedInsertionSideBySide',
+					style: {
+						...insertionRect.read(reader).toStyles(),
+						backgroundColor: getModifiedBorderColor(this._tabAction).map(c => asCssVariable(c)),
+					}
+				}),
+				n.div({
+					class: 'modifiedSeparatorSideBySide',
+					style: {
+						...separatorRect.read(reader).toStyles(),
+						borderRadius,
+						borderTop: borderStylingSeparator,
+						borderBottom: borderStylingSeparator,
+						borderRight: borderStylingSeparator,
+						boxSizing: 'border-box',
+					}
+				}),
+				n.div({
+					class: 'modifiedOverlaySideBySide',
+					style: {
+						...overlayRect.read(reader).toStyles(),
+						borderRadius,
+						border: borderStyling,
+						boxSizing: 'border-box',
+						backgroundColor: asCssVariable(modifiedBackgroundColor),
+					}
+				})
+			];
+		})).keepUpdated(this._store);
+		this._nonOverflowView = n.div({
+			class: 'inline-edits-view',
+			style: {
+				position: 'absolute',
+				overflow: 'visible',
+				top: '0px',
+				left: '0px',
+				display: this._display,
+			},
+		}, [
+			this._backgroundSvg,
+			derived(this, reader => this._shouldOverflow.read(reader) ? [] : [this._editorContainer, this._originalOverlay, this._modifiedOverlay]),
+		]).keepUpdated(this._store);
 
 		this._register(this._editorObs.createOverlayWidget({
 			domNode: this._nonOverflowView.element,
@@ -113,478 +570,49 @@ export class InlineEditsSideBySideView extends Disposable implements IInlineEdit
 		this._updatePreviewEditor.recomputeInitiallyAndOnChange(this._store);
 	}
 
-	private readonly _display = derived(this, reader => !!this._uiState.read(reader) ? 'block' : 'none');
+	private readonly _display;
 
-	private readonly previewRef = n.ref<HTMLDivElement>();
+	private readonly previewRef;
 
-	private readonly _editorContainer = n.div({
-		class: ['editorContainer'],
-		style: { position: 'absolute', overflow: 'hidden', cursor: 'pointer' },
-		onmousedown: e => {
-			e.preventDefault(); // This prevents that the editor loses focus
-		},
-		onclick: (e) => {
-			this._onDidClick.fire(new StandardMouseEvent(getWindow(e), e));
-		}
-	}, [
-		n.div({ class: 'preview', style: { pointerEvents: 'none' }, ref: this.previewRef }),
-	]).keepUpdated(this._store);
+	private readonly _editorContainer;
 
-	public readonly isHovered = this._editorContainer.didMouseMoveDuringHover;
+	public readonly isHovered;
 
-	public readonly previewEditor = this._register(this._instantiationService.createInstance(
-		EmbeddedCodeEditorWidget,
-		this.previewRef.element,
-		{
-			glyphMargin: false,
-			lineNumbers: 'off',
-			minimap: { enabled: false },
-			guides: {
-				indentation: false,
-				bracketPairs: false,
-				bracketPairsHorizontal: false,
-				highlightActiveIndentation: false,
-			},
-			rulers: [],
-			padding: { top: 0, bottom: 0 },
-			folding: false,
-			selectOnLineNumbers: false,
-			selectionHighlight: false,
-			columnSelection: false,
-			overviewRulerBorder: false,
-			overviewRulerLanes: 0,
-			lineDecorationsWidth: 0,
-			lineNumbersMinChars: 0,
-			revealHorizontalRightPadding: 0,
-			bracketPairColorization: { enabled: true, independentColorPoolPerBracketType: false },
-			scrollBeyondLastLine: false,
-			scrollbar: {
-				vertical: 'hidden',
-				horizontal: 'hidden',
-				handleMouseWheel: false,
-			},
-			readOnly: true,
-			wordWrap: 'off',
-			wordWrapOverride1: 'off',
-			wordWrapOverride2: 'off',
-		},
-		{
-			contextKeyValues: {
-				[InlineCompletionContextKeys.inInlineEditsPreviewEditor.key]: true,
-			},
-			contributions: [],
-		},
-		this._editor
-	));
+	public readonly previewEditor;
 
-	private readonly _previewEditorObs = observableCodeEditor(this.previewEditor);
+	private readonly _previewEditorObs;
 
-	private _activeViewZones: string[] = [];
-	private readonly _updatePreviewEditor = derived(reader => {
-		this._editorContainer.readEffect(reader);
-		this._previewEditorObs.model.read(reader); // update when the model is set
+	private _activeViewZones: string[];
+	private readonly _updatePreviewEditor;
 
-		// Setting this here explicitly to make sure that the preview editor is
-		// visible when needed, we're also checking that these fields are defined
-		// because of the auto run initial
-		// Before removing these, verify with a non-monospace font family
-		this._display.read(reader);
-		if (this._nonOverflowView) {
-			this._nonOverflowView.element.style.display = this._display.read(reader);
-		}
+	private readonly _previewEditorWidth;
 
-		const uiState = this._uiState.read(reader);
-		const edit = this._edit.read(reader);
-		if (!uiState || !edit) {
-			return;
-		}
+	private readonly _cursorPosIfTouchesEdit;
 
-		const range = edit.originalLineRange;
+	private readonly _originalStartPosition;
 
-		const hiddenAreas: Range[] = [];
-		if (range.startLineNumber > 1) {
-			hiddenAreas.push(new Range(1, 1, range.startLineNumber - 1, 1));
-		}
-		if (range.startLineNumber + uiState.newTextLineCount < this._previewTextModel.getLineCount() + 1) {
-			hiddenAreas.push(new Range(range.startLineNumber + uiState.newTextLineCount, 1, this._previewTextModel.getLineCount() + 1, 1));
-		}
+	private readonly _originalEndPosition;
 
-		this.previewEditor.setHiddenAreas(hiddenAreas, undefined, true);
+	private readonly _originalVerticalStartPosition;
+	private readonly _originalVerticalEndPosition;
 
-		// TODO: is this the proper way to handle viewzones?
-		const previousViewZones = [...this._activeViewZones];
-		this._activeViewZones = [];
+	private readonly _originalDisplayRange;
+	private readonly _editorMaxContentWidthInRange;
 
-		const reducedLinesCount = (range.endLineNumberExclusive - range.startLineNumber) - uiState.newTextLineCount;
-		this.previewEditor.changeViewZones((changeAccessor) => {
-			previousViewZones.forEach(id => changeAccessor.removeZone(id));
+	private readonly _previewEditorLayoutInfo;
 
-			if (reducedLinesCount > 0) {
-				this._activeViewZones.push(changeAccessor.addZone({
-					afterLineNumber: range.startLineNumber + uiState.newTextLineCount - 1,
-					heightInLines: reducedLinesCount,
-					showInHiddenAreas: true,
-					domNode: $('div.diagonal-fill.inline-edits-view-zone'),
-				}));
-			}
-		});
-	});
+	private _stickyScrollController;
+	private readonly _stickyScrollHeight;
 
-	private readonly _previewEditorWidth = derived(this, reader => {
-		const edit = this._edit.read(reader);
-		if (!edit) { return 0; }
-		this._updatePreviewEditor.read(reader);
+	private readonly _shouldOverflow;
 
-		return maxContentWidthInRange(this._previewEditorObs, edit.modifiedLineRange, reader);
-	});
+	private readonly _originalBackgroundColor;
 
-	private readonly _cursorPosIfTouchesEdit = derived(this, reader => {
-		const cursorPos = this._editorObs.cursorPosition.read(reader);
-		const edit = this._edit.read(reader);
-		if (!edit || !cursorPos) { return undefined; }
-		return edit.modifiedLineRange.contains(cursorPos.lineNumber) ? cursorPos : undefined;
-	});
+	private readonly _backgroundSvg;
 
-	private readonly _originalStartPosition = derived(this, (reader) => {
-		const inlineEdit = this._edit.read(reader);
-		return inlineEdit ? new Position(inlineEdit.originalLineRange.startLineNumber, 1) : null;
-	});
+	private readonly _originalOverlay;
 
-	private readonly _originalEndPosition = derived(this, (reader) => {
-		const inlineEdit = this._edit.read(reader);
-		return inlineEdit ? new Position(inlineEdit.originalLineRange.endLineNumberExclusive, 1) : null;
-	});
+	private readonly _modifiedOverlay;
 
-	private readonly _originalVerticalStartPosition = this._editorObs.observePosition(this._originalStartPosition, this._store).map(p => p?.y);
-	private readonly _originalVerticalEndPosition = this._editorObs.observePosition(this._originalEndPosition, this._store).map(p => p?.y);
-
-	private readonly _originalDisplayRange = this._edit.map(e => e?.displayRange);
-	private readonly _editorMaxContentWidthInRange = derived(this, reader => {
-		const originalDisplayRange = this._originalDisplayRange.read(reader);
-		if (!originalDisplayRange) {
-			return constObservable(0);
-		}
-		this._editorObs.versionId.read(reader);
-
-		// Take the max value that we observed.
-		// Reset when either the edit changes or the editor text version.
-		return derivedObservableWithCache<number>(this, (reader, lastValue) => {
-			const maxWidth = maxContentWidthInRange(this._editorObs, originalDisplayRange, reader);
-			return Math.max(maxWidth, lastValue ?? 0);
-		});
-	}).map((v, r) => v.read(r));
-
-	private readonly _previewEditorLayoutInfo = derived(this, (reader) => {
-		const inlineEdit = this._edit.read(reader);
-		if (!inlineEdit) {
-			return null;
-		}
-		const state = this._uiState.read(reader);
-		if (!state) {
-			return null;
-		}
-
-		const range = inlineEdit.originalLineRange;
-
-		const horizontalScrollOffset = this._editorObs.scrollLeft.read(reader);
-
-		const editorContentMaxWidthInRange = this._editorMaxContentWidthInRange.read(reader);
-		const editorLayout = this._editorObs.layoutInfo.read(reader);
-		const previewContentWidth = this._previewEditorWidth.read(reader);
-		const editorContentAreaWidth = editorLayout.contentWidth - editorLayout.verticalScrollbarWidth;
-		const editorBoundingClientRect = this._editor.getContainerDomNode().getBoundingClientRect();
-		const clientContentAreaRight = editorLayout.contentLeft + editorLayout.contentWidth + editorBoundingClientRect.left;
-		const remainingWidthRightOfContent = getWindow(this._editor.getContainerDomNode()).innerWidth - clientContentAreaRight;
-		const remainingWidthRightOfEditor = getWindow(this._editor.getContainerDomNode()).innerWidth - editorBoundingClientRect.right;
-		const desiredMinimumWidth = Math.min(editorLayout.contentWidth * 0.3, previewContentWidth, 100);
-		const IN_EDITOR_DISPLACEMENT = 0;
-		const maximumAvailableWidth = IN_EDITOR_DISPLACEMENT + remainingWidthRightOfContent;
-
-		const cursorPos = this._cursorPosIfTouchesEdit.read(reader);
-
-		const maxPreviewEditorLeft = Math.max(
-			// We're starting from the content area right and moving it left by IN_EDITOR_DISPLACEMENT and also by an amount to ensure some minimum desired width
-			editorContentAreaWidth + horizontalScrollOffset - IN_EDITOR_DISPLACEMENT - Math.max(0, desiredMinimumWidth - maximumAvailableWidth),
-			// But we don't want that the moving left ends up covering the cursor, so this will push it to the right again
-			Math.min(
-				cursorPos ? getOffsetForPos(this._editorObs, cursorPos, reader) + 50 : 0,
-				editorContentAreaWidth + horizontalScrollOffset
-			)
-		);
-		const previewEditorLeftInTextArea = Math.min(editorContentMaxWidthInRange + ORIGINAL_END_PADDING, maxPreviewEditorLeft);
-
-		const maxContentWidth = editorContentMaxWidthInRange + ORIGINAL_END_PADDING + previewContentWidth + 70;
-
-		const dist = maxPreviewEditorLeft - previewEditorLeftInTextArea;
-
-		let desiredPreviewEditorScrollLeft;
-		let codeRight;
-		if (previewEditorLeftInTextArea > horizontalScrollOffset) {
-			desiredPreviewEditorScrollLeft = 0;
-			codeRight = editorLayout.contentLeft + previewEditorLeftInTextArea - horizontalScrollOffset;
-		} else {
-			desiredPreviewEditorScrollLeft = horizontalScrollOffset - previewEditorLeftInTextArea;
-			codeRight = editorLayout.contentLeft;
-		}
-
-		const selectionTop = this._originalVerticalStartPosition.read(reader) ?? this._editor.getTopForLineNumber(range.startLineNumber) - this._editorObs.scrollTop.read(reader);
-		const selectionBottom = this._originalVerticalEndPosition.read(reader) ?? this._editor.getBottomForLineNumber(range.endLineNumberExclusive - 1) - this._editorObs.scrollTop.read(reader);
-
-		// TODO: const { prefixLeftOffset } = getPrefixTrim(inlineEdit.edit.edits.map(e => e.range), inlineEdit.originalLineRange, [], this._editor);
-		const codeLeft = editorLayout.contentLeft - horizontalScrollOffset;
-
-		let codeRect = Rect.fromLeftTopRightBottom(codeLeft, selectionTop, codeRight, selectionBottom);
-		const isInsertion = codeRect.height === 0;
-		if (!isInsertion) {
-			codeRect = codeRect.withMargin(VERTICAL_PADDING, HORIZONTAL_PADDING);
-		}
-
-		const editHeight = this._editor.getOption(EditorOption.lineHeight) * inlineEdit.modifiedLineRange.length;
-		const codeHeight = selectionBottom - selectionTop;
-		const previewEditorHeight = Math.max(codeHeight, editHeight);
-
-		const clipped = dist === 0;
-		const codeEditDist = 0;
-		const previewEditorWidth = Math.min(previewContentWidth + MODIFIED_END_PADDING, remainingWidthRightOfEditor + editorLayout.width - editorLayout.contentLeft - codeEditDist);
-
-		let editRect = Rect.fromLeftTopWidthHeight(codeRect.right + codeEditDist, selectionTop, previewEditorWidth, previewEditorHeight);
-		if (!isInsertion) {
-			editRect = editRect.withMargin(VERTICAL_PADDING, HORIZONTAL_PADDING).translateX(HORIZONTAL_PADDING + BORDER_WIDTH);
-		} else {
-			// Align top of edit with insertion line
-			editRect = editRect.withMargin(VERTICAL_PADDING, HORIZONTAL_PADDING).translateY(VERTICAL_PADDING);
-		}
-
-		// debugView(debugLogRects({ codeRect, editRect }, this._editor.getDomNode()!), reader);
-
-		return {
-			codeRect,
-			editRect,
-			codeScrollLeft: horizontalScrollOffset,
-			contentLeft: editorLayout.contentLeft,
-
-			isInsertion,
-			maxContentWidth,
-			shouldShowShadow: clipped,
-			desiredPreviewEditorScrollLeft,
-			previewEditorWidth,
-		};
-	});
-
-	private _stickyScrollController = StickyScrollController.get(this._editorObs.editor);
-	private readonly _stickyScrollHeight = this._stickyScrollController ? observableFromEvent(this._stickyScrollController.onDidChangeStickyScrollHeight, () => this._stickyScrollController!.stickyScrollWidgetHeight) : constObservable(0);
-
-	private readonly _shouldOverflow = derived(reader => {
-		if (!ENABLE_OVERFLOW) {
-			return false;
-		}
-		const range = this._edit.read(reader)?.originalLineRange;
-		if (!range) {
-			return false;
-		}
-		const stickyScrollHeight = this._stickyScrollHeight.read(reader);
-		const top = this._editor.getTopForLineNumber(range.startLineNumber) - this._editorObs.scrollTop.read(reader);
-		if (top <= stickyScrollHeight) {
-			return false;
-		}
-		const bottom = this._editor.getTopForLineNumber(range.endLineNumberExclusive) - this._editorObs.scrollTop.read(reader);
-		if (bottom >= this._editorObs.layoutInfo.read(reader).height) {
-			return false;
-		}
-		return true;
-	});
-
-	private readonly _originalBackgroundColor = observableFromEvent(this, this._themeService.onDidColorThemeChange, () => {
-		return this._themeService.getColorTheme().getColor(originalBackgroundColor) ?? Color.transparent;
-	});
-
-	private readonly _backgroundSvg = n.svg({
-		transform: 'translate(-0.5 -0.5)',
-		style: { overflow: 'visible', pointerEvents: 'none', position: 'absolute' },
-	}, [
-		n.svgElem('path', {
-			class: 'rightOfModifiedBackgroundCoverUp',
-			d: derived(reader => {
-				const layoutInfo = this._previewEditorLayoutInfo.read(reader);
-				if (!layoutInfo) {
-					return undefined;
-				}
-				const originalBackgroundColor = this._originalBackgroundColor.read(reader);
-				if (originalBackgroundColor.isTransparent()) {
-					return undefined;
-				}
-
-				return new PathBuilder()
-					.moveTo(layoutInfo.codeRect.getRightTop())
-					.lineTo(layoutInfo.codeRect.getRightTop().deltaX(1000))
-					.lineTo(layoutInfo.codeRect.getRightBottom().deltaX(1000))
-					.lineTo(layoutInfo.codeRect.getRightBottom())
-					.build();
-			}),
-			style: {
-				fill: asCssVariableWithDefault(editorBackground, 'transparent'),
-			}
-		}),
-	]).keepUpdated(this._store);
-
-	private readonly _originalOverlay = n.div({
-		style: { pointerEvents: 'none', display: this._previewEditorLayoutInfo.map(layoutInfo => layoutInfo?.isInsertion ? 'none' : 'block') },
-	}, derived(reader => {
-		const layoutInfoObs = mapOutFalsy(this._previewEditorLayoutInfo).read(reader);
-		if (!layoutInfoObs) { return undefined; }
-
-		const borderStyling = getOriginalBorderColor(this._tabAction).map(bc => `${BORDER_WIDTH}px solid ${asCssVariable(bc)}`);
-		const borderStylingSeparator = `${BORDER_WIDTH + WIDGET_SEPARATOR_WIDTH}px solid ${asCssVariable(editorBackground)}`;
-
-		const hasBorderLeft = layoutInfoObs.read(reader).codeScrollLeft !== 0;
-		const isModifiedLower = layoutInfoObs.map(layoutInfo => layoutInfo.codeRect.bottom < layoutInfo.editRect.bottom);
-		const transitionRectSize = BORDER_RADIUS * 2 + BORDER_WIDTH * 2;
-
-		// Create an overlay which hides the left hand side of the original overlay when it overflows to the left
-		// such that there is a smooth transition at the edge of content left
-		const overlayHider = layoutInfoObs.map(layoutInfo => Rect.fromLeftTopRightBottom(
-			layoutInfo.contentLeft - BORDER_RADIUS - BORDER_WIDTH,
-			layoutInfo.codeRect.top,
-			layoutInfo.contentLeft,
-			layoutInfo.codeRect.bottom + transitionRectSize
-		)).read(reader);
-
-		const intersectionLine = new OffsetRange(overlayHider.left, Number.MAX_SAFE_INTEGER);
-		const overlayRect = layoutInfoObs.map(layoutInfo => layoutInfo.codeRect.intersectHorizontal(intersectionLine));
-		const separatorRect = overlayRect.map(overlayRect => overlayRect.withMargin(WIDGET_SEPARATOR_WIDTH, 0, WIDGET_SEPARATOR_WIDTH, WIDGET_SEPARATOR_WIDTH).intersectHorizontal(intersectionLine));
-
-		const transitionRect = overlayRect.map(overlayRect => Rect.fromLeftTopWidthHeight(overlayRect.right - transitionRectSize + BORDER_WIDTH, overlayRect.bottom - BORDER_WIDTH, transitionRectSize, transitionRectSize).intersectHorizontal(intersectionLine));
-
-		return [
-			n.div({
-				class: 'originalSeparatorSideBySide',
-				style: {
-					...separatorRect.read(reader).toStyles(),
-					boxSizing: 'border-box',
-					borderRadius: `${BORDER_RADIUS}px 0 0 ${BORDER_RADIUS}px`,
-					borderTop: borderStylingSeparator,
-					borderBottom: borderStylingSeparator,
-					borderLeft: hasBorderLeft ? 'none' : borderStylingSeparator,
-				}
-			}),
-
-			n.div({
-				class: 'originalOverlaySideBySide',
-				style: {
-					...overlayRect.read(reader).toStyles(),
-					boxSizing: 'border-box',
-					borderRadius: `${BORDER_RADIUS}px 0 0 ${BORDER_RADIUS}px`,
-					borderTop: borderStyling,
-					borderBottom: borderStyling,
-					borderLeft: hasBorderLeft ? 'none' : borderStyling,
-					backgroundColor: asCssVariable(originalBackgroundColor),
-				}
-			}),
-
-			n.div({
-				class: 'originalCornerCutoutSideBySide',
-				style: {
-					pointerEvents: 'none',
-					display: isModifiedLower.map(isLower => isLower ? 'block' : 'none'),
-					...transitionRect.read(reader).toStyles(),
-				}
-			}, [
-				n.div({
-					class: 'originalCornerCutoutBackground',
-					style: {
-						position: 'absolute', top: '0px', left: '0px', width: '100%', height: '100%',
-						backgroundColor: getEditorBlendedColor(originalBackgroundColor, this._themeService).map(c => c.toString()),
-					}
-				}),
-				n.div({
-					class: 'originalCornerCutoutBorder',
-					style: {
-						position: 'absolute', top: '0px', left: '0px', width: '100%', height: '100%',
-						boxSizing: 'border-box',
-						borderTop: borderStyling,
-						borderRight: borderStyling,
-						borderRadius: `0 100% 0 0`,
-						backgroundColor: asCssVariable(editorBackground)
-					}
-				})
-			]),
-			n.div({
-				class: 'originalOverlaySideBySideHider',
-				style: {
-					...overlayHider.toStyles(),
-					backgroundColor: asCssVariable(editorBackground),
-				}
-			}),
-		];
-	})).keepUpdated(this._store);
-
-	private readonly _modifiedOverlay = n.div({
-		style: { pointerEvents: 'none', }
-	}, derived(reader => {
-		const layoutInfoObs = mapOutFalsy(this._previewEditorLayoutInfo).read(reader);
-		if (!layoutInfoObs) { return undefined; }
-
-		const isModifiedLower = layoutInfoObs.map(layoutInfo => layoutInfo.codeRect.bottom < layoutInfo.editRect.bottom);
-
-		const borderRadius = isModifiedLower.map(isLower => `0 ${BORDER_RADIUS}px ${BORDER_RADIUS}px ${isLower ? BORDER_RADIUS : 0}px`);
-		const borderStyling = getEditorBlendedColor(getModifiedBorderColor(this._tabAction), this._themeService).map(c => `1px solid ${c.toString()}`);
-		const borderStylingSeparator = `${BORDER_WIDTH + WIDGET_SEPARATOR_WIDTH}px solid ${asCssVariable(editorBackground)}`;
-
-		const overlayRect = layoutInfoObs.map(layoutInfo => layoutInfo.editRect.withMargin(0, BORDER_WIDTH));
-		const separatorRect = overlayRect.map(overlayRect => overlayRect.withMargin(WIDGET_SEPARATOR_WIDTH, WIDGET_SEPARATOR_WIDTH, WIDGET_SEPARATOR_WIDTH, 0));
-
-		const insertionRect = derived(reader => {
-			const overlay = overlayRect.read(reader);
-			const layoutinfo = layoutInfoObs.read(reader);
-			if (!layoutinfo.isInsertion || layoutinfo.contentLeft >= overlay.left) {
-				return Rect.fromLeftTopWidthHeight(overlay.left, overlay.top, 0, 0);
-			}
-			return new Rect(layoutinfo.contentLeft, overlay.top, overlay.left, overlay.top + BORDER_WIDTH * 2);
-		});
-
-		return [
-			n.div({
-				class: 'modifiedInsertionSideBySide',
-				style: {
-					...insertionRect.read(reader).toStyles(),
-					backgroundColor: getModifiedBorderColor(this._tabAction).map(c => asCssVariable(c)),
-				}
-			}),
-			n.div({
-				class: 'modifiedSeparatorSideBySide',
-				style: {
-					...separatorRect.read(reader).toStyles(),
-					borderRadius,
-					borderTop: borderStylingSeparator,
-					borderBottom: borderStylingSeparator,
-					borderRight: borderStylingSeparator,
-					boxSizing: 'border-box',
-				}
-			}),
-			n.div({
-				class: 'modifiedOverlaySideBySide',
-				style: {
-					...overlayRect.read(reader).toStyles(),
-					borderRadius,
-					border: borderStyling,
-					boxSizing: 'border-box',
-					backgroundColor: asCssVariable(modifiedBackgroundColor),
-				}
-			})
-		];
-	})).keepUpdated(this._store);
-
-	private readonly _nonOverflowView = n.div({
-		class: 'inline-edits-view',
-		style: {
-			position: 'absolute',
-			overflow: 'visible',
-			top: '0px',
-			left: '0px',
-			display: this._display,
-		},
-	}, [
-		this._backgroundSvg,
-		derived(this, reader => this._shouldOverflow.read(reader) ? [] : [this._editorContainer, this._originalOverlay, this._modifiedOverlay]),
-	]).keepUpdated(this._store);
+	private readonly _nonOverflowView;
 }

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/inlineEditsWordInsertView.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/inlineEditsWordInsertView.ts
@@ -21,102 +21,16 @@ import { mapOutFalsy, rectToProps } from '../utils/utils.js';
 
 export class InlineEditsWordInsertView extends Disposable implements IInlineEditsView {
 
-	private readonly _onDidClick = this._register(new Emitter<IMouseEvent>());
-	readonly onDidClick = this._onDidClick.event;
+	private readonly _onDidClick;
+	readonly onDidClick;
 
-	private readonly _start = this._editor.observePosition(constObservable(this._edit.range.getStartPosition()), this._store);
+	private readonly _start;
 
-	private readonly _layout = derived(this, reader => {
-		const start = this._start.read(reader);
-		if (!start) {
-			return undefined;
-		}
-		const contentLeft = this._editor.layoutInfoContentLeft.read(reader);
-		const lineHeight = this._editor.getOption(EditorOption.lineHeight).read(reader);
+	private readonly _layout;
 
-		const w = this._editor.getOption(EditorOption.fontInfo).read(reader).typicalHalfwidthCharacterWidth;
-		const width = this._edit.text.length * w + 5;
+	private readonly _div;
 
-		const center = new Point(contentLeft + start.x + w / 2 - this._editor.scrollLeft.read(reader), start.y);
-
-		const modified = Rect.fromLeftTopWidthHeight(center.x - width / 2, center.y + lineHeight + 5, width, lineHeight);
-		const background = Rect.hull([Rect.fromPoint(center), modified]).withMargin(4);
-
-		return {
-			modified,
-			center,
-			background,
-			lowerBackground: background.intersectVertical(new OffsetRange(modified.top - 2, Number.MAX_SAFE_INTEGER)),
-		};
-	});
-
-	private readonly _div = n.div({
-		class: 'word-insert',
-	}, [
-		derived(reader => {
-			const layout = mapOutFalsy(this._layout).read(reader);
-			if (!layout) {
-				return [];
-			}
-
-			const modifiedBorderColor = asCssVariable(getModifiedBorderColor(this._tabAction).read(reader));
-
-			return [
-				n.div({
-					style: {
-						position: 'absolute',
-						...rectToProps(reader => layout.read(reader).lowerBackground),
-						borderRadius: '4px',
-						background: 'var(--vscode-editor-background)'
-					}
-				}, []),
-				n.div({
-					style: {
-						position: 'absolute',
-						...rectToProps(reader => layout.read(reader).modified),
-						borderRadius: '4px',
-						padding: '0px',
-						textAlign: 'center',
-						background: 'var(--vscode-inlineEdit-modifiedChangedTextBackground)',
-						fontFamily: this._editor.getOption(EditorOption.fontFamily),
-						fontSize: this._editor.getOption(EditorOption.fontSize),
-						fontWeight: this._editor.getOption(EditorOption.fontWeight),
-					}
-				}, [
-					this._edit.text,
-				]),
-				n.div({
-					style: {
-						position: 'absolute',
-						...rectToProps(reader => layout.read(reader).background),
-						borderRadius: '4px',
-						border: `1px solid ${modifiedBorderColor}`,
-						//background: 'rgba(122, 122, 122, 0.12)', looks better
-						background: 'var(--vscode-inlineEdit-wordReplacementView-background)',
-					}
-				}, []),
-				n.svg({
-					viewBox: '0 0 12 18',
-					width: 12,
-					height: 18,
-					fill: 'none',
-					style: {
-						position: 'absolute',
-						left: derived(reader => layout.read(reader).center.x - 9),
-						top: derived(reader => layout.read(reader).center.y + 4),
-						transform: 'scale(1.4, 1.4)',
-					}
-				}, [
-					n.svgElem('path', {
-						d: 'M5.06445 0H7.35759C7.35759 0 7.35759 8.47059 7.35759 11.1176C7.35759 13.7647 9.4552 18 13.4674 18C17.4795 18 -2.58445 18 0.281373 18C3.14719 18 5.06477 14.2941 5.06477 11.1176C5.06477 7.94118 5.06445 0 5.06445 0Z',
-						fill: 'var(--vscode-inlineEdit-modifiedChangedTextBackground)',
-					})
-				])
-			];
-		})
-	]).keepUpdated(this._store);
-
-	readonly isHovered = constObservable(false);
+	readonly isHovered;
 
 	constructor(
 		private readonly _editor: ObservableCodeEditor,
@@ -125,6 +39,98 @@ export class InlineEditsWordInsertView extends Disposable implements IInlineEdit
 		private readonly _tabAction: IObservable<InlineEditTabAction>
 	) {
 		super();
+		this._onDidClick = this._register(new Emitter<IMouseEvent>());
+		this.onDidClick = this._onDidClick.event;
+		this._start = this._editor.observePosition(constObservable(this._edit.range.getStartPosition()), this._store);
+		this._layout = derived(this, reader => {
+			const start = this._start.read(reader);
+			if (!start) {
+				return undefined;
+			}
+			const contentLeft = this._editor.layoutInfoContentLeft.read(reader);
+			const lineHeight = this._editor.getOption(EditorOption.lineHeight).read(reader);
+
+			const w = this._editor.getOption(EditorOption.fontInfo).read(reader).typicalHalfwidthCharacterWidth;
+			const width = this._edit.text.length * w + 5;
+
+			const center = new Point(contentLeft + start.x + w / 2 - this._editor.scrollLeft.read(reader), start.y);
+
+			const modified = Rect.fromLeftTopWidthHeight(center.x - width / 2, center.y + lineHeight + 5, width, lineHeight);
+			const background = Rect.hull([Rect.fromPoint(center), modified]).withMargin(4);
+
+			return {
+				modified,
+				center,
+				background,
+				lowerBackground: background.intersectVertical(new OffsetRange(modified.top - 2, Number.MAX_SAFE_INTEGER)),
+			};
+		});
+		this._div = n.div({
+			class: 'word-insert',
+		}, [
+			derived(reader => {
+				const layout = mapOutFalsy(this._layout).read(reader);
+				if (!layout) {
+					return [];
+				}
+
+				const modifiedBorderColor = asCssVariable(getModifiedBorderColor(this._tabAction).read(reader));
+
+				return [
+					n.div({
+						style: {
+							position: 'absolute',
+							...rectToProps(reader => layout.read(reader).lowerBackground),
+							borderRadius: '4px',
+							background: 'var(--vscode-editor-background)'
+						}
+					}, []),
+					n.div({
+						style: {
+							position: 'absolute',
+							...rectToProps(reader => layout.read(reader).modified),
+							borderRadius: '4px',
+							padding: '0px',
+							textAlign: 'center',
+							background: 'var(--vscode-inlineEdit-modifiedChangedTextBackground)',
+							fontFamily: this._editor.getOption(EditorOption.fontFamily),
+							fontSize: this._editor.getOption(EditorOption.fontSize),
+							fontWeight: this._editor.getOption(EditorOption.fontWeight),
+						}
+					}, [
+						this._edit.text,
+					]),
+					n.div({
+						style: {
+							position: 'absolute',
+							...rectToProps(reader => layout.read(reader).background),
+							borderRadius: '4px',
+							border: `1px solid ${modifiedBorderColor}`,
+							//background: 'rgba(122, 122, 122, 0.12)', looks better
+							background: 'var(--vscode-inlineEdit-wordReplacementView-background)',
+						}
+					}, []),
+					n.svg({
+						viewBox: '0 0 12 18',
+						width: 12,
+						height: 18,
+						fill: 'none',
+						style: {
+							position: 'absolute',
+							left: derived(reader => layout.read(reader).center.x - 9),
+							top: derived(reader => layout.read(reader).center.y + 4),
+							transform: 'scale(1.4, 1.4)',
+						}
+					}, [
+						n.svgElem('path', {
+							d: 'M5.06445 0H7.35759C7.35759 0 7.35759 8.47059 7.35759 11.1176C7.35759 13.7647 9.4552 18 13.4674 18C17.4795 18 -2.58445 18 0.281373 18C3.14719 18 5.06477 14.2941 5.06477 11.1176C5.06477 7.94118 5.06445 0 5.06445 0Z',
+							fill: 'var(--vscode-inlineEdit-modifiedChangedTextBackground)',
+						})
+					])
+				];
+			})
+		]).keepUpdated(this._store);
+		this.isHovered = constObservable(false);
 
 		this._register(this._editor.createOverlayWidget({
 			domNode: this._div.element,

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/inlineEditsWordReplacementView.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/inlineEditsWordReplacementView.ts
@@ -29,17 +29,17 @@ export class InlineEditsWordReplacementView extends Disposable implements IInlin
 
 	public static MAX_LENGTH = 100;
 
-	private readonly _onDidClick = this._register(new Emitter<IMouseEvent>());
-	readonly onDidClick = this._onDidClick.event;
+	private readonly _onDidClick;
+	readonly onDidClick;
 
-	private readonly _start = this._editor.observePosition(constObservable(this._edit.range.getStartPosition()), this._store);
-	private readonly _end = this._editor.observePosition(constObservable(this._edit.range.getEndPosition()), this._store);
+	private readonly _start;
+	private readonly _end;
 
-	private readonly _line = document.createElement('div');
+	private readonly _line;
 
-	private readonly _hoverableElement = observableValue<ObserverNodeWithElement | null>(this, null);
+	private readonly _hoverableElement;
 
-	readonly isHovered = this._hoverableElement.map((e, reader) => e?.didMouseMoveDuringHover.read(reader) ?? false);
+	readonly isHovered;
 
 	constructor(
 		private readonly _editor: ObservableCodeEditor,
@@ -49,6 +49,163 @@ export class InlineEditsWordReplacementView extends Disposable implements IInlin
 		@ILanguageService private readonly _languageService: ILanguageService,
 	) {
 		super();
+		this._onDidClick = this._register(new Emitter<IMouseEvent>());
+		this.onDidClick = this._onDidClick.event;
+		this._start = this._editor.observePosition(constObservable(this._edit.range.getStartPosition()), this._store);
+		this._end = this._editor.observePosition(constObservable(this._edit.range.getEndPosition()), this._store);
+		this._line = document.createElement('div');
+		this._hoverableElement = observableValue<ObserverNodeWithElement | null>(this, null);
+		this.isHovered = this._hoverableElement.map((e, reader) => e?.didMouseMoveDuringHover.read(reader) ?? false);
+		this._renderTextEffect = derived(_reader => {
+			const tm = this._editor.model.get()!;
+			const origLine = tm.getLineContent(this._edit.range.startLineNumber);
+
+			const edit = SingleOffsetEdit.replace(new OffsetRange(this._edit.range.startColumn - 1, this._edit.range.endColumn - 1), this._edit.text);
+			const lineToTokenize = edit.apply(origLine);
+			const t = tm.tokenization.tokenizeLinesAt(this._edit.range.startLineNumber, [lineToTokenize])?.[0];
+			let tokens: LineTokens;
+			if (t) {
+				tokens = TokenArray.fromLineTokens(t).slice(edit.getRangeAfterApply()).toLineTokens(this._edit.text, this._languageService.languageIdCodec);
+			} else {
+				tokens = LineTokens.createEmpty(this._edit.text, this._languageService.languageIdCodec);
+			}
+			const res = renderLines(new LineSource([tokens]), RenderOptions.fromEditor(this._editor.editor).withSetWidth(false).withScrollBeyondLastColumn(0), [], this._line, true);
+			this._line.style.width = `${res.minWidthInPx}px`;
+		});
+		this._layout = derived(this, reader => {
+			this._renderTextEffect.read(reader);
+			const widgetStart = this._start.read(reader);
+			const widgetEnd = this._end.read(reader);
+
+			// TODO@hediet better about widgetStart and widgetEnd in a single transaction!
+			if (!widgetStart || !widgetEnd || widgetStart.x > widgetEnd.x || widgetStart.y > widgetEnd.y) {
+				return undefined;
+			}
+
+			const lineHeight = this._editor.getOption(EditorOption.lineHeight).read(reader);
+			const scrollLeft = this._editor.scrollLeft.read(reader);
+			const w = this._editor.getOption(EditorOption.fontInfo).read(reader).typicalHalfwidthCharacterWidth;
+
+			const modifiedLeftOffset = 3 * w;
+			const modifiedTopOffset = 4;
+			const modifiedOffset = new Point(modifiedLeftOffset, modifiedTopOffset);
+
+			const originalLine = Rect.fromPoints(widgetStart, widgetEnd).withHeight(lineHeight).translateX(-scrollLeft);
+			const modifiedLine = Rect.fromPointSize(originalLine.getLeftBottom().add(modifiedOffset), new Point(this._edit.text.length * w, originalLine.height));
+
+			const lowerBackground = modifiedLine.withLeft(originalLine.left);
+
+			// debugView(debugLogRects({ lowerBackground }, this._editor.editor.getContainerDomNode()), reader);
+
+			return {
+				originalLine,
+				modifiedLine,
+				lowerBackground,
+				lineHeight,
+			};
+		});
+		this._root = n.div({
+			class: 'word-replacement',
+		}, [
+			derived(reader => {
+				const layout = mapOutFalsy(this._layout).read(reader);
+				if (!layout) {
+					return [];
+				}
+
+				const contentLeft = this._editor.layoutInfoContentLeft.read(reader);
+				const borderWidth = 1;
+
+				const originalBorderColor = getOriginalBorderColor(this._tabAction).map(c => asCssVariable(c)).read(reader);
+				const modifiedBorderColor = getModifiedBorderColor(this._tabAction).map(c => asCssVariable(c)).read(reader);
+
+				return [
+					n.div({
+						style: {
+							position: 'absolute',
+							top: 0,
+							left: contentLeft,
+							width: this._editor.contentWidth,
+							height: this._editor.editor.getContentHeight(),
+							overflow: 'hidden',
+							pointerEvents: 'none',
+						}
+					}, [
+						n.div({
+							style: {
+								position: 'absolute',
+								...rectToProps(reader => layout.read(reader).lowerBackground.withMargin(borderWidth, 2 * borderWidth, borderWidth, 0)),
+								background: asCssVariable(editorBackground),
+								//boxShadow: `${asCssVariable(scrollbarShadow)} 0 6px 6px -6px`,
+								cursor: 'pointer',
+								pointerEvents: 'auto',
+							},
+							onmousedown: e => {
+								e.preventDefault(); // This prevents that the editor loses focus
+							},
+							onmouseup: (e) => this._onDidClick.fire(new StandardMouseEvent(getWindow(e), e)),
+							obsRef: (elem) => {
+								this._hoverableElement.set(elem, undefined);
+							}
+						}),
+						n.div({
+							style: {
+								position: 'absolute',
+								...rectToProps(reader => layout.read(reader).modifiedLine.withMargin(1, 2)),
+								fontFamily: this._editor.getOption(EditorOption.fontFamily),
+								fontSize: this._editor.getOption(EditorOption.fontSize),
+								fontWeight: this._editor.getOption(EditorOption.fontWeight),
+
+								pointerEvents: 'none',
+								boxSizing: 'border-box',
+								borderRadius: '4px',
+								border: `${borderWidth}px solid ${modifiedBorderColor}`,
+
+								background: asCssVariable(modifiedChangedTextOverlayColor),
+								display: 'flex',
+								justifyContent: 'center',
+								alignItems: 'center',
+
+								outline: `2px solid ${asCssVariable(editorBackground)}`,
+							}
+						}, [this._line]),
+						n.div({
+							style: {
+								position: 'absolute',
+								...rectToProps(reader => layout.read(reader).originalLine.withMargin(1)),
+								boxSizing: 'border-box',
+								borderRadius: '4px',
+								border: `${borderWidth}px solid ${originalBorderColor}`,
+								background: asCssVariable(originalChangedTextOverlayColor),
+								pointerEvents: 'none',
+							}
+						}, []),
+
+						n.svg({
+							width: 11,
+							height: 14,
+							viewBox: '0 0 11 14',
+							fill: 'none',
+							style: {
+								position: 'absolute',
+								left: layout.map(l => l.modifiedLine.left - 16),
+								top: layout.map(l => l.modifiedLine.top + Math.round((l.lineHeight - 14 - 5) / 2)),
+							}
+						}, [
+							n.svgElem('path', {
+								d: 'M1 0C1 2.98966 1 5.92087 1 8.49952C1 9.60409 1.89543 10.5 3 10.5H10.5',
+								stroke: asCssVariable(editorHoverForeground),
+							}),
+							n.svgElem('path', {
+								d: 'M6 7.5L9.99999 10.49998L6 13.5',
+								stroke: asCssVariable(editorHoverForeground),
+							})
+						]),
+
+					])
+				];
+			})
+		]).keepUpdated(this._store);
 
 		this._register(this._editor.createOverlayWidget({
 			domNode: this._root.element,
@@ -58,156 +215,9 @@ export class InlineEditsWordReplacementView extends Disposable implements IInlin
 		}));
 	}
 
-	private readonly _renderTextEffect = derived(_reader => {
-		const tm = this._editor.model.get()!;
-		const origLine = tm.getLineContent(this._edit.range.startLineNumber);
+	private readonly _renderTextEffect;
 
-		const edit = SingleOffsetEdit.replace(new OffsetRange(this._edit.range.startColumn - 1, this._edit.range.endColumn - 1), this._edit.text);
-		const lineToTokenize = edit.apply(origLine);
-		const t = tm.tokenization.tokenizeLinesAt(this._edit.range.startLineNumber, [lineToTokenize])?.[0];
-		let tokens: LineTokens;
-		if (t) {
-			tokens = TokenArray.fromLineTokens(t).slice(edit.getRangeAfterApply()).toLineTokens(this._edit.text, this._languageService.languageIdCodec);
-		} else {
-			tokens = LineTokens.createEmpty(this._edit.text, this._languageService.languageIdCodec);
-		}
-		const res = renderLines(new LineSource([tokens]), RenderOptions.fromEditor(this._editor.editor).withSetWidth(false).withScrollBeyondLastColumn(0), [], this._line, true);
-		this._line.style.width = `${res.minWidthInPx}px`;
-	});
+	private readonly _layout;
 
-	private readonly _layout = derived(this, reader => {
-		this._renderTextEffect.read(reader);
-		const widgetStart = this._start.read(reader);
-		const widgetEnd = this._end.read(reader);
-
-		// TODO@hediet better about widgetStart and widgetEnd in a single transaction!
-		if (!widgetStart || !widgetEnd || widgetStart.x > widgetEnd.x || widgetStart.y > widgetEnd.y) {
-			return undefined;
-		}
-
-		const lineHeight = this._editor.getOption(EditorOption.lineHeight).read(reader);
-		const scrollLeft = this._editor.scrollLeft.read(reader);
-		const w = this._editor.getOption(EditorOption.fontInfo).read(reader).typicalHalfwidthCharacterWidth;
-
-		const modifiedLeftOffset = 3 * w;
-		const modifiedTopOffset = 4;
-		const modifiedOffset = new Point(modifiedLeftOffset, modifiedTopOffset);
-
-		const originalLine = Rect.fromPoints(widgetStart, widgetEnd).withHeight(lineHeight).translateX(-scrollLeft);
-		const modifiedLine = Rect.fromPointSize(originalLine.getLeftBottom().add(modifiedOffset), new Point(this._edit.text.length * w, originalLine.height));
-
-		const lowerBackground = modifiedLine.withLeft(originalLine.left);
-
-		// debugView(debugLogRects({ lowerBackground }, this._editor.editor.getContainerDomNode()), reader);
-
-		return {
-			originalLine,
-			modifiedLine,
-			lowerBackground,
-			lineHeight,
-		};
-	});
-
-	private readonly _root = n.div({
-		class: 'word-replacement',
-	}, [
-		derived(reader => {
-			const layout = mapOutFalsy(this._layout).read(reader);
-			if (!layout) {
-				return [];
-			}
-
-			const contentLeft = this._editor.layoutInfoContentLeft.read(reader);
-			const borderWidth = 1;
-
-			const originalBorderColor = getOriginalBorderColor(this._tabAction).map(c => asCssVariable(c)).read(reader);
-			const modifiedBorderColor = getModifiedBorderColor(this._tabAction).map(c => asCssVariable(c)).read(reader);
-
-			return [
-				n.div({
-					style: {
-						position: 'absolute',
-						top: 0,
-						left: contentLeft,
-						width: this._editor.contentWidth,
-						height: this._editor.editor.getContentHeight(),
-						overflow: 'hidden',
-						pointerEvents: 'none',
-					}
-				}, [
-					n.div({
-						style: {
-							position: 'absolute',
-							...rectToProps(reader => layout.read(reader).lowerBackground.withMargin(borderWidth, 2 * borderWidth, borderWidth, 0)),
-							background: asCssVariable(editorBackground),
-							//boxShadow: `${asCssVariable(scrollbarShadow)} 0 6px 6px -6px`,
-							cursor: 'pointer',
-							pointerEvents: 'auto',
-						},
-						onmousedown: e => {
-							e.preventDefault(); // This prevents that the editor loses focus
-						},
-						onmouseup: (e) => this._onDidClick.fire(new StandardMouseEvent(getWindow(e), e)),
-						obsRef: (elem) => {
-							this._hoverableElement.set(elem, undefined);
-						}
-					}),
-					n.div({
-						style: {
-							position: 'absolute',
-							...rectToProps(reader => layout.read(reader).modifiedLine.withMargin(1, 2)),
-							fontFamily: this._editor.getOption(EditorOption.fontFamily),
-							fontSize: this._editor.getOption(EditorOption.fontSize),
-							fontWeight: this._editor.getOption(EditorOption.fontWeight),
-
-							pointerEvents: 'none',
-							boxSizing: 'border-box',
-							borderRadius: '4px',
-							border: `${borderWidth}px solid ${modifiedBorderColor}`,
-
-							background: asCssVariable(modifiedChangedTextOverlayColor),
-							display: 'flex',
-							justifyContent: 'center',
-							alignItems: 'center',
-
-							outline: `2px solid ${asCssVariable(editorBackground)}`,
-						}
-					}, [this._line]),
-					n.div({
-						style: {
-							position: 'absolute',
-							...rectToProps(reader => layout.read(reader).originalLine.withMargin(1)),
-							boxSizing: 'border-box',
-							borderRadius: '4px',
-							border: `${borderWidth}px solid ${originalBorderColor}`,
-							background: asCssVariable(originalChangedTextOverlayColor),
-							pointerEvents: 'none',
-						}
-					}, []),
-
-					n.svg({
-						width: 11,
-						height: 14,
-						viewBox: '0 0 11 14',
-						fill: 'none',
-						style: {
-							position: 'absolute',
-							left: layout.map(l => l.modifiedLine.left - 16),
-							top: layout.map(l => l.modifiedLine.top + Math.round((l.lineHeight - 14 - 5) / 2)),
-						}
-					}, [
-						n.svgElem('path', {
-							d: 'M1 0C1 2.98966 1 5.92087 1 8.49952C1 9.60409 1.89543 10.5 3 10.5H10.5',
-							stroke: asCssVariable(editorHoverForeground),
-						}),
-						n.svgElem('path', {
-							d: 'M6 7.5L9.99999 10.49998L6 13.5',
-							stroke: asCssVariable(editorHoverForeground),
-						})
-					]),
-
-				])
-			];
-		})
-	]).keepUpdated(this._store);
+	private readonly _root;
 }

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/originalEditorInlineDiffView.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/originalEditorInlineDiffView.ts
@@ -32,17 +32,12 @@ export class OriginalEditorInlineDiffView extends Disposable implements IInlineE
 		return allowsTrueInlineDiffRendering(mapping);
 	}
 
-	private readonly _onDidClick = this._register(new Emitter<IMouseEvent>());
-	readonly onDidClick = this._onDidClick.event;
+	private readonly _onDidClick;
+	readonly onDidClick;
 
-	readonly isHovered = observableCodeEditor(this._originalEditor).isTargetHovered(
-		p => p.target.type === MouseTargetType.CONTENT_TEXT &&
-			p.target.detail.injectedText?.options.attachedData instanceof InlineEditAttachedData &&
-			p.target.detail.injectedText.options.attachedData.owner === this,
-		this._store
-	);
+	readonly isHovered;
 
-	private readonly _tokenizationFinished = modelTokenizationFinished(this._modifiedTextModel);
+	private readonly _tokenizationFinished;
 
 	constructor(
 		private readonly _originalEditor: ICodeEditor,
@@ -50,6 +45,165 @@ export class OriginalEditorInlineDiffView extends Disposable implements IInlineE
 		private readonly _modifiedTextModel: ITextModel,
 	) {
 		super();
+		this._onDidClick = this._register(new Emitter<IMouseEvent>());
+		this.onDidClick = this._onDidClick.event;
+		this.isHovered = observableCodeEditor(this._originalEditor).isTargetHovered(
+			p => p.target.type === MouseTargetType.CONTENT_TEXT &&
+				p.target.detail.injectedText?.options.attachedData instanceof InlineEditAttachedData &&
+				p.target.detail.injectedText.options.attachedData.owner === this,
+			this._store
+		);
+		this._tokenizationFinished = modelTokenizationFinished(this._modifiedTextModel);
+		this._decorations = derived(this, reader => {
+			const diff = this._state.read(reader);
+			if (!diff) { return undefined; }
+
+			const modified = diff.modifiedText;
+			const showInline = diff.mode === 'insertionInline';
+			const hasOneInnerChange = diff.diff.length === 1 && diff.diff[0].innerChanges?.length === 1;
+
+			const showEmptyDecorations = true;
+
+			const originalDecorations: IModelDeltaDecoration[] = [];
+			const modifiedDecorations: IModelDeltaDecoration[] = [];
+
+			const diffLineAddDecorationBackground = ModelDecorationOptions.register({
+				className: 'inlineCompletions-line-insert',
+				description: 'line-insert',
+				isWholeLine: true,
+				marginClassName: 'gutter-insert',
+			});
+
+			const diffLineDeleteDecorationBackground = ModelDecorationOptions.register({
+				className: 'inlineCompletions-line-delete',
+				description: 'line-delete',
+				isWholeLine: true,
+				marginClassName: 'gutter-delete',
+			});
+
+			const diffWholeLineDeleteDecoration = ModelDecorationOptions.register({
+				className: 'inlineCompletions-char-delete',
+				description: 'char-delete',
+				isWholeLine: false,
+			});
+
+			const diffWholeLineAddDecoration = ModelDecorationOptions.register({
+				className: 'inlineCompletions-char-insert',
+				description: 'char-insert',
+				isWholeLine: true,
+			});
+
+			const diffAddDecoration = ModelDecorationOptions.register({
+				className: 'inlineCompletions-char-insert',
+				description: 'char-insert',
+				shouldFillLineOnLineBreak: true,
+			});
+
+			const diffAddDecorationEmpty = ModelDecorationOptions.register({
+				className: 'inlineCompletions-char-insert diff-range-empty',
+				description: 'char-insert diff-range-empty',
+			});
+
+			for (const m of diff.diff) {
+				const showFullLineDecorations = diff.mode !== 'sideBySide' && diff.mode !== 'deletion' && diff.mode !== 'insertionInline';
+				if (showFullLineDecorations) {
+					if (!m.original.isEmpty) {
+						originalDecorations.push({
+							range: m.original.toInclusiveRange()!,
+							options: diffLineDeleteDecorationBackground,
+						});
+					}
+					if (!m.modified.isEmpty) {
+						modifiedDecorations.push({
+							range: m.modified.toInclusiveRange()!,
+							options: diffLineAddDecorationBackground,
+						});
+					}
+				}
+
+				if (m.modified.isEmpty || m.original.isEmpty) {
+					if (!m.original.isEmpty) {
+						originalDecorations.push({ range: m.original.toInclusiveRange()!, options: diffWholeLineDeleteDecoration });
+					}
+					if (!m.modified.isEmpty) {
+						modifiedDecorations.push({ range: m.modified.toInclusiveRange()!, options: diffWholeLineAddDecoration });
+					}
+				} else {
+					const useInlineDiff = showInline && allowsTrueInlineDiffRendering(m);
+					for (const i of m.innerChanges || []) {
+						// Don't show empty markers outside the line range
+						if (m.original.contains(i.originalRange.startLineNumber)) {
+							const replacedText = this._originalEditor.getModel()?.getValueInRange(i.originalRange, EndOfLinePreference.LF);
+							originalDecorations.push({
+								range: i.originalRange,
+								options: {
+									description: 'char-delete',
+									shouldFillLineOnLineBreak: false,
+									className: classNames(
+										'inlineCompletions-char-delete',
+										i.originalRange.isSingleLine() && diff.mode === 'insertionInline' && 'single-line-inline',
+										i.originalRange.isEmpty() && 'empty',
+										((i.originalRange.isEmpty() && hasOneInnerChange || diff.mode === 'deletion' && replacedText === '\n') && showEmptyDecorations && !useInlineDiff) && 'diff-range-empty'
+									),
+									inlineClassName: useInlineDiff ? classNames('strike-through', 'inlineCompletions') : null,
+									zIndex: 1
+								}
+							});
+						}
+						if (m.modified.contains(i.modifiedRange.startLineNumber)) {
+							modifiedDecorations.push({
+								range: i.modifiedRange,
+								options: (i.modifiedRange.isEmpty() && showEmptyDecorations && !useInlineDiff && hasOneInnerChange)
+									? diffAddDecorationEmpty
+									: diffAddDecoration
+							});
+						}
+						if (useInlineDiff) {
+							const insertedText = modified.getValueOfRange(i.modifiedRange);
+							// when the injected text becomes long, the editor will split it into multiple spans
+							// to be able to get the border around the start and end of the text, we need to split it into multiple segments
+							const textSegments = insertedText.length > 3 ?
+								[
+									{ text: insertedText.slice(0, 1), extraClasses: ['start'], offsetRange: new OffsetRange(i.modifiedRange.startColumn - 1, i.modifiedRange.startColumn) },
+									{ text: insertedText.slice(1, -1), extraClasses: [], offsetRange: new OffsetRange(i.modifiedRange.startColumn, i.modifiedRange.endColumn - 2) },
+									{ text: insertedText.slice(-1), extraClasses: ['end'], offsetRange: new OffsetRange(i.modifiedRange.endColumn - 2, i.modifiedRange.endColumn - 1) }
+								] :
+								[
+									{ text: insertedText, extraClasses: ['start', 'end'], offsetRange: new OffsetRange(i.modifiedRange.startColumn - 1, i.modifiedRange.endColumn) }
+								];
+
+							// Tokenization
+							this._tokenizationFinished.read(reader); // reconsider when tokenization is finished
+							const lineTokens = this._modifiedTextModel.tokenization.getLineTokens(i.modifiedRange.startLineNumber);
+
+							for (const { text, extraClasses, offsetRange } of textSegments) {
+								originalDecorations.push({
+									range: Range.fromPositions(i.originalRange.getEndPosition()),
+									options: {
+										description: 'inserted-text',
+										before: {
+											tokens: lineTokens.getTokensInRange(offsetRange),
+											content: text,
+											inlineClassName: classNames(
+												'inlineCompletions-char-insert',
+												i.modifiedRange.isSingleLine() && diff.mode === 'insertionInline' && 'single-line-inline',
+												...extraClasses // include extraClasses for additional styling if provided
+											),
+											cursorStops: InjectedTextCursorStops.None,
+											attachedData: new InlineEditAttachedData(this),
+										},
+										zIndex: 2,
+										showIfCollapsed: true,
+									}
+								});
+							}
+						}
+					}
+				}
+			}
+
+			return { originalDecorations, modifiedDecorations };
+		});
 
 		this._register(observableCodeEditor(this._originalEditor).setDecorations(this._decorations.map(d => d?.originalDecorations ?? [])));
 
@@ -72,156 +226,7 @@ export class OriginalEditorInlineDiffView extends Disposable implements IInlineE
 		}));
 	}
 
-	private readonly _decorations = derived(this, reader => {
-		const diff = this._state.read(reader);
-		if (!diff) { return undefined; }
-
-		const modified = diff.modifiedText;
-		const showInline = diff.mode === 'insertionInline';
-		const hasOneInnerChange = diff.diff.length === 1 && diff.diff[0].innerChanges?.length === 1;
-
-		const showEmptyDecorations = true;
-
-		const originalDecorations: IModelDeltaDecoration[] = [];
-		const modifiedDecorations: IModelDeltaDecoration[] = [];
-
-		const diffLineAddDecorationBackground = ModelDecorationOptions.register({
-			className: 'inlineCompletions-line-insert',
-			description: 'line-insert',
-			isWholeLine: true,
-			marginClassName: 'gutter-insert',
-		});
-
-		const diffLineDeleteDecorationBackground = ModelDecorationOptions.register({
-			className: 'inlineCompletions-line-delete',
-			description: 'line-delete',
-			isWholeLine: true,
-			marginClassName: 'gutter-delete',
-		});
-
-		const diffWholeLineDeleteDecoration = ModelDecorationOptions.register({
-			className: 'inlineCompletions-char-delete',
-			description: 'char-delete',
-			isWholeLine: false,
-		});
-
-		const diffWholeLineAddDecoration = ModelDecorationOptions.register({
-			className: 'inlineCompletions-char-insert',
-			description: 'char-insert',
-			isWholeLine: true,
-		});
-
-		const diffAddDecoration = ModelDecorationOptions.register({
-			className: 'inlineCompletions-char-insert',
-			description: 'char-insert',
-			shouldFillLineOnLineBreak: true,
-		});
-
-		const diffAddDecorationEmpty = ModelDecorationOptions.register({
-			className: 'inlineCompletions-char-insert diff-range-empty',
-			description: 'char-insert diff-range-empty',
-		});
-
-		for (const m of diff.diff) {
-			const showFullLineDecorations = diff.mode !== 'sideBySide' && diff.mode !== 'deletion' && diff.mode !== 'insertionInline';
-			if (showFullLineDecorations) {
-				if (!m.original.isEmpty) {
-					originalDecorations.push({
-						range: m.original.toInclusiveRange()!,
-						options: diffLineDeleteDecorationBackground,
-					});
-				}
-				if (!m.modified.isEmpty) {
-					modifiedDecorations.push({
-						range: m.modified.toInclusiveRange()!,
-						options: diffLineAddDecorationBackground,
-					});
-				}
-			}
-
-			if (m.modified.isEmpty || m.original.isEmpty) {
-				if (!m.original.isEmpty) {
-					originalDecorations.push({ range: m.original.toInclusiveRange()!, options: diffWholeLineDeleteDecoration });
-				}
-				if (!m.modified.isEmpty) {
-					modifiedDecorations.push({ range: m.modified.toInclusiveRange()!, options: diffWholeLineAddDecoration });
-				}
-			} else {
-				const useInlineDiff = showInline && allowsTrueInlineDiffRendering(m);
-				for (const i of m.innerChanges || []) {
-					// Don't show empty markers outside the line range
-					if (m.original.contains(i.originalRange.startLineNumber)) {
-						const replacedText = this._originalEditor.getModel()?.getValueInRange(i.originalRange, EndOfLinePreference.LF);
-						originalDecorations.push({
-							range: i.originalRange,
-							options: {
-								description: 'char-delete',
-								shouldFillLineOnLineBreak: false,
-								className: classNames(
-									'inlineCompletions-char-delete',
-									i.originalRange.isSingleLine() && diff.mode === 'insertionInline' && 'single-line-inline',
-									i.originalRange.isEmpty() && 'empty',
-									((i.originalRange.isEmpty() && hasOneInnerChange || diff.mode === 'deletion' && replacedText === '\n') && showEmptyDecorations && !useInlineDiff) && 'diff-range-empty'
-								),
-								inlineClassName: useInlineDiff ? classNames('strike-through', 'inlineCompletions') : null,
-								zIndex: 1
-							}
-						});
-					}
-					if (m.modified.contains(i.modifiedRange.startLineNumber)) {
-						modifiedDecorations.push({
-							range: i.modifiedRange,
-							options: (i.modifiedRange.isEmpty() && showEmptyDecorations && !useInlineDiff && hasOneInnerChange)
-								? diffAddDecorationEmpty
-								: diffAddDecoration
-						});
-					}
-					if (useInlineDiff) {
-						const insertedText = modified.getValueOfRange(i.modifiedRange);
-						// when the injected text becomes long, the editor will split it into multiple spans
-						// to be able to get the border around the start and end of the text, we need to split it into multiple segments
-						const textSegments = insertedText.length > 3 ?
-							[
-								{ text: insertedText.slice(0, 1), extraClasses: ['start'], offsetRange: new OffsetRange(i.modifiedRange.startColumn - 1, i.modifiedRange.startColumn) },
-								{ text: insertedText.slice(1, -1), extraClasses: [], offsetRange: new OffsetRange(i.modifiedRange.startColumn, i.modifiedRange.endColumn - 2) },
-								{ text: insertedText.slice(-1), extraClasses: ['end'], offsetRange: new OffsetRange(i.modifiedRange.endColumn - 2, i.modifiedRange.endColumn - 1) }
-							] :
-							[
-								{ text: insertedText, extraClasses: ['start', 'end'], offsetRange: new OffsetRange(i.modifiedRange.startColumn - 1, i.modifiedRange.endColumn) }
-							];
-
-						// Tokenization
-						this._tokenizationFinished.read(reader); // reconsider when tokenization is finished
-						const lineTokens = this._modifiedTextModel.tokenization.getLineTokens(i.modifiedRange.startLineNumber);
-
-						for (const { text, extraClasses, offsetRange } of textSegments) {
-							originalDecorations.push({
-								range: Range.fromPositions(i.originalRange.getEndPosition()),
-								options: {
-									description: 'inserted-text',
-									before: {
-										tokens: lineTokens.getTokensInRange(offsetRange),
-										content: text,
-										inlineClassName: classNames(
-											'inlineCompletions-char-insert',
-											i.modifiedRange.isSingleLine() && diff.mode === 'insertionInline' && 'single-line-inline',
-											...extraClasses // include extraClasses for additional styling if provided
-										),
-										cursorStops: InjectedTextCursorStops.None,
-										attachedData: new InlineEditAttachedData(this),
-									},
-									zIndex: 2,
-									showIfCollapsed: true,
-								}
-							});
-						}
-					}
-				}
-			}
-		}
-
-		return { originalDecorations, modifiedDecorations };
-	});
+	private readonly _decorations;
 }
 
 class InlineEditAttachedData {

--- a/src/vs/editor/contrib/placeholderText/browser/placeholderTextContribution.ts
+++ b/src/vs/editor/contrib/placeholderText/browser/placeholderTextContribution.ts
@@ -21,53 +21,58 @@ export class PlaceholderTextContribution extends Disposable implements IEditorCo
 	}
 
 	public static readonly ID = 'editor.contrib.placeholderText';
-	private readonly _editorObs = observableCodeEditor(this._editor);
+	private readonly _editorObs;
 
-	private readonly _placeholderText = this._editorObs.getOption(EditorOption.placeholder);
+	private readonly _placeholderText;
 
-	private readonly _state = derivedOpts<{ placeholder: string } | undefined>({ owner: this, equalsFn: structuralEquals }, reader => {
-		const p = this._placeholderText.read(reader);
-		if (!p) { return undefined; }
-		if (!this._editorObs.valueIsEmpty.read(reader)) { return undefined; }
-		return { placeholder: p };
-	});
+	private readonly _state;
 
-	private readonly _shouldViewBeAlive = isOrWasTrue(this, reader => this._state.read(reader)?.placeholder !== undefined);
+	private readonly _shouldViewBeAlive;
 
-	private readonly _view = derivedWithStore((reader, store) => {
-		if (!this._shouldViewBeAlive.read(reader)) { return; }
-
-		const element = h('div.editorPlaceholder');
-
-		store.add(autorun(reader => {
-			const data = this._state.read(reader);
-			const shouldBeVisibile = data?.placeholder !== undefined;
-			element.root.style.display = shouldBeVisibile ? 'block' : 'none';
-			element.root.innerText = data?.placeholder ?? '';
-		}));
-		store.add(autorun(reader => {
-			const info = this._editorObs.layoutInfo.read(reader);
-			element.root.style.left = `${info.contentLeft}px`;
-			element.root.style.width = (info.contentWidth - info.verticalScrollbarWidth) + 'px';
-			element.root.style.top = `${this._editor.getTopForLineNumber(0)}px`;
-		}));
-		store.add(autorun(reader => {
-			element.root.style.fontFamily = this._editorObs.getOption(EditorOption.fontFamily).read(reader);
-			element.root.style.fontSize = this._editorObs.getOption(EditorOption.fontSize).read(reader) + 'px';
-			element.root.style.lineHeight = this._editorObs.getOption(EditorOption.lineHeight).read(reader) + 'px';
-		}));
-		store.add(this._editorObs.createOverlayWidget({
-			allowEditorOverflow: false,
-			minContentWidthInPx: constObservable(0),
-			position: constObservable(null),
-			domNode: element.root,
-		}));
-	});
+	private readonly _view;
 
 	constructor(
 		private readonly _editor: ICodeEditor,
 	) {
 		super();
+		this._editorObs = observableCodeEditor(this._editor);
+		this._placeholderText = this._editorObs.getOption(EditorOption.placeholder);
+		this._state = derivedOpts<{ placeholder: string } | undefined>({ owner: this, equalsFn: structuralEquals }, reader => {
+			const p = this._placeholderText.read(reader);
+			if (!p) { return undefined; }
+			if (!this._editorObs.valueIsEmpty.read(reader)) { return undefined; }
+			return { placeholder: p };
+		});
+		this._shouldViewBeAlive = isOrWasTrue(this, reader => this._state.read(reader)?.placeholder !== undefined);
+		this._view = derivedWithStore((reader, store) => {
+			if (!this._shouldViewBeAlive.read(reader)) { return; }
+
+			const element = h('div.editorPlaceholder');
+
+			store.add(autorun(reader => {
+				const data = this._state.read(reader);
+				const shouldBeVisibile = data?.placeholder !== undefined;
+				element.root.style.display = shouldBeVisibile ? 'block' : 'none';
+				element.root.innerText = data?.placeholder ?? '';
+			}));
+			store.add(autorun(reader => {
+				const info = this._editorObs.layoutInfo.read(reader);
+				element.root.style.left = `${info.contentLeft}px`;
+				element.root.style.width = (info.contentWidth - info.verticalScrollbarWidth) + 'px';
+				element.root.style.top = `${this._editor.getTopForLineNumber(0)}px`;
+			}));
+			store.add(autorun(reader => {
+				element.root.style.fontFamily = this._editorObs.getOption(EditorOption.fontFamily).read(reader);
+				element.root.style.fontSize = this._editorObs.getOption(EditorOption.fontSize).read(reader) + 'px';
+				element.root.style.lineHeight = this._editorObs.getOption(EditorOption.lineHeight).read(reader) + 'px';
+			}));
+			store.add(this._editorObs.createOverlayWidget({
+				allowEditorOverflow: false,
+				minContentWidthInPx: constObservable(0),
+				position: constObservable(null),
+				domNode: element.root,
+			}));
+		});
 		this._view.recomputeInitiallyAndOnChange(this._store);
 	}
 }

--- a/src/vs/editor/contrib/unicodeHighlighter/browser/unicodeHighlighter.ts
+++ b/src/vs/editor/contrib/unicodeHighlighter/browser/unicodeHighlighter.ts
@@ -214,9 +214,9 @@ function resolveOptions(trusted: boolean, options: InternalUnicodeHighlightOptio
 }
 
 class DocumentUnicodeHighlighter extends Disposable {
-	private readonly _model: ITextModel = this._editor.getModel();
+	private readonly _model: ITextModel;
 	private readonly _updateSoon: RunOnceScheduler;
-	private _decorations = this._editor.createDecorationsCollection();
+	private _decorations;
 
 	constructor(
 		private readonly _editor: IActiveCodeEditor,
@@ -225,6 +225,8 @@ class DocumentUnicodeHighlighter extends Disposable {
 		@IEditorWorkerService private readonly _editorWorkerService: IEditorWorkerService,
 	) {
 		super();
+		this._model = this._editor.getModel();
+		this._decorations = this._editor.createDecorationsCollection();
 		this._updateSoon = this._register(new RunOnceScheduler(() => this._update(), 250));
 
 		this._register(this._editor.onDidChangeModelContent(() => {
@@ -298,9 +300,9 @@ class DocumentUnicodeHighlighter extends Disposable {
 
 class ViewportUnicodeHighlighter extends Disposable {
 
-	private readonly _model: ITextModel = this._editor.getModel();
+	private readonly _model: ITextModel;
 	private readonly _updateSoon: RunOnceScheduler;
-	private readonly _decorations = this._editor.createDecorationsCollection();
+	private readonly _decorations;
 
 	constructor(
 		private readonly _editor: IActiveCodeEditor,
@@ -308,6 +310,8 @@ class ViewportUnicodeHighlighter extends Disposable {
 		private readonly _updateState: (state: IUnicodeHighlightsResult | null) => void,
 	) {
 		super();
+		this._model = this._editor.getModel();
+		this._decorations = this._editor.createDecorationsCollection();
 
 		this._updateSoon = this._register(new RunOnceScheduler(() => this._update(), 250));
 

--- a/src/vs/workbench/contrib/mergeEditor/browser/mergeEditorInput.ts
+++ b/src/vs/workbench/contrib/mergeEditor/browser/mergeEditorInput.ts
@@ -41,16 +41,9 @@ export class MergeEditorInput extends AbstractTextResourceEditorInput implements
 
 	private _inputModel?: IMergeEditorInputModel;
 
-	private _focusedEditor: MergeEditorType = 'result';
+	private _focusedEditor: MergeEditorType;
 
-	override closeHandler: IEditorCloseHandler = {
-		showConfirm: () => this._inputModel?.shouldConfirmClose() ?? false,
-		confirm: async (editors) => {
-			assertFn(() => editors.every(e => e.editor instanceof MergeEditorInput));
-			const inputModels = editors.map(e => (e.editor as MergeEditorInput)._inputModel).filter(isDefined);
-			return await this._inputModel!.confirmClose(inputModels);
-		},
-	};
+	override closeHandler: IEditorCloseHandler;
 
 	private get useWorkingCopy() {
 		return this.configurationService.getValue('mergeEditor.useWorkingCopy') ?? false;
@@ -73,6 +66,21 @@ export class MergeEditorInput extends AbstractTextResourceEditorInput implements
 		@ILogService private readonly logService: ILogService,
 	) {
 		super(result, undefined, editorService, textFileService, labelService, fileService, filesConfigurationService, textResourceConfigurationService, customEditorLabelService);
+		this._focusedEditor = 'result';
+		this.closeHandler = {
+			showConfirm: () => this._inputModel?.shouldConfirmClose() ?? false,
+			confirm: async (editors) => {
+				assertFn(() => editors.every(e => e.editor instanceof MergeEditorInput));
+				const inputModels = editors.map(e => (e.editor as MergeEditorInput)._inputModel).filter(isDefined);
+				return await this._inputModel!.confirmClose(inputModels);
+			},
+		};
+		this.mergeEditorModeFactory = this._instaService.createInstance(
+			this.useWorkingCopy
+				? TempFileMergeEditorModeFactory
+				: WorkspaceMergeEditorModeFactory,
+			this._instaService.createInstance(MergeEditorTelemetry),
+		);
 	}
 
 	override dispose(): void {
@@ -99,12 +107,7 @@ export class MergeEditorInput extends AbstractTextResourceEditorInput implements
 		return localize('name', "Merging: {0}", super.getName());
 	}
 
-	private readonly mergeEditorModeFactory = this._instaService.createInstance(
-		this.useWorkingCopy
-			? TempFileMergeEditorModeFactory
-			: WorkspaceMergeEditorModeFactory,
-		this._instaService.createInstance(MergeEditorTelemetry),
-	);
+	private readonly mergeEditorModeFactory;
 
 	override async resolve(): Promise<IMergeEditorInputModel> {
 		if (!this._inputModel) {

--- a/src/vs/workbench/contrib/mergeEditor/browser/mergeEditorInputModel.ts
+++ b/src/vs/workbench/contrib/mergeEditor/browser/mergeEditorInputModel.ts
@@ -127,16 +127,12 @@ export class TempFileMergeEditorModeFactory implements IMergeEditorInputModelFac
 }
 
 class TempFileMergeEditorInputModel extends EditorModel implements IMergeEditorInputModel {
-	private readonly savedAltVersionId = observableValue(this, this.model.resultTextModel.getAlternativeVersionId());
-	private readonly altVersionId = observableFromEvent(this,
-		e => this.model.resultTextModel.onDidChangeContent(e),
-		() =>
-			/** @description getAlternativeVersionId */ this.model.resultTextModel.getAlternativeVersionId()
-	);
+	private readonly savedAltVersionId;
+	private readonly altVersionId;
 
-	public readonly isDirty = derived(this, (reader) => this.altVersionId.read(reader) !== this.savedAltVersionId.read(reader));
+	public readonly isDirty;
 
-	private finished = false;
+	private finished;
 
 	constructor(
 		public readonly model: MergeEditorModel,
@@ -148,6 +144,13 @@ class TempFileMergeEditorInputModel extends EditorModel implements IMergeEditorI
 		@IEditorService private readonly editorService: IEditorService,
 	) {
 		super();
+		this.savedAltVersionId = observableValue(this, this.model.resultTextModel.getAlternativeVersionId());
+		this.altVersionId = observableFromEvent(this,
+			e => this.model.resultTextModel.onDidChangeContent(e),
+			() => /** @description getAlternativeVersionId */ this.model.resultTextModel.getAlternativeVersionId()
+		);
+		this.isDirty = derived(this, (reader) => this.altVersionId.read(reader) !== this.savedAltVersionId.read(reader));
+		this.finished = false;
 	}
 
 	override dispose(): void {
@@ -359,13 +362,10 @@ export class WorkspaceMergeEditorModeFactory implements IMergeEditorInputModelFa
 }
 
 class WorkspaceMergeEditorInputModel extends EditorModel implements IMergeEditorInputModel {
-	public readonly isDirty = observableFromEvent(this,
-		Event.any(this.resultTextFileModel.onDidChangeDirty, this.resultTextFileModel.onDidSaveError),
-		() => /** @description isDirty */ this.resultTextFileModel.isDirty()
-	);
+	public readonly isDirty;
 
-	private reported = false;
-	private readonly dateTimeOpened = new Date();
+	private reported;
+	private readonly dateTimeOpened;
 
 	constructor(
 		public readonly model: MergeEditorModel,
@@ -376,6 +376,12 @@ class WorkspaceMergeEditorInputModel extends EditorModel implements IMergeEditor
 		@IStorageService private readonly _storageService: IStorageService,
 	) {
 		super();
+		this.isDirty = observableFromEvent(this,
+			Event.any(this.resultTextFileModel.onDidChangeDirty, this.resultTextFileModel.onDidSaveError),
+			() => /** @description isDirty */ this.resultTextFileModel.isDirty()
+		);
+		this.reported = false;
+		this.dateTimeOpened = new Date();
 	}
 
 	public override dispose(): void {

--- a/src/vs/workbench/contrib/mergeEditor/browser/model/diffComputer.ts
+++ b/src/vs/workbench/contrib/mergeEditor/browser/model/diffComputer.ts
@@ -23,14 +23,15 @@ export interface IMergeDiffComputerResult {
 }
 
 export class MergeDiffComputer implements IMergeDiffComputer {
-	private readonly mergeAlgorithm = observableConfigValue<'smart' | 'experimental' | 'legacy' | 'advanced'>(
-		'mergeEditor.diffAlgorithm', 'advanced', this.configurationService)
-		.map(v => v === 'smart' ? 'legacy' : v === 'experimental' ? 'advanced' : v);
+	private readonly mergeAlgorithm;
 
 	constructor(
 		@IEditorWorkerService private readonly editorWorkerService: IEditorWorkerService,
 		@IConfigurationService private readonly configurationService: IConfigurationService,
 	) {
+		this.mergeAlgorithm = observableConfigValue<'smart' | 'experimental' | 'legacy' | 'advanced'>(
+			'mergeEditor.diffAlgorithm', 'advanced', this.configurationService)
+			.map(v => v === 'smart' ? 'legacy' : v === 'experimental' ? 'advanced' : v);
 	}
 
 	async computeDiff(textModel1: ITextModel, textModel2: ITextModel, reader: IReader): Promise<IMergeDiffComputerResult> {

--- a/src/vs/workbench/contrib/mergeEditor/browser/model/mergeEditorModel.ts
+++ b/src/vs/workbench/contrib/mergeEditor/browser/model/mergeEditorModel.ts
@@ -29,25 +29,14 @@ export interface InputData {
 }
 
 export class MergeEditorModel extends EditorModel {
-	private readonly input1TextModelDiffs = this._register(new TextModelDiffs(this.base, this.input1.textModel, this.diffComputer));
-	private readonly input2TextModelDiffs = this._register(new TextModelDiffs(this.base, this.input2.textModel, this.diffComputer));
-	private readonly resultTextModelDiffs = this._register(new TextModelDiffs(this.base, this.resultTextModel, this.diffComputer));
-	public readonly modifiedBaseRanges = derived<ModifiedBaseRange[]>(this, (reader) => {
-		const input1Diffs = this.input1TextModelDiffs.diffs.read(reader);
-		const input2Diffs = this.input2TextModelDiffs.diffs.read(reader);
-		return ModifiedBaseRange.fromDiffs(input1Diffs, input2Diffs, this.base, this.input1.textModel, this.input2.textModel);
-	});
+	private readonly input1TextModelDiffs;
+	private readonly input2TextModelDiffs;
+	private readonly resultTextModelDiffs;
+	public readonly modifiedBaseRanges;
 
-	private readonly modifiedBaseRangeResultStates = derived(this, reader => {
-		const map = new Map<ModifiedBaseRange, ModifiedBaseRangeData>(
-			this.modifiedBaseRanges.read(reader).map<[ModifiedBaseRange, ModifiedBaseRangeData]>((s) => [
-				s, new ModifiedBaseRangeData(s)
-			])
-		);
-		return map;
-	});
+	private readonly modifiedBaseRangeResultStates;
 
-	private readonly resultSnapshot = this.resultTextModel.createSnapshot();
+	private readonly resultSnapshot;
 
 	constructor(
 		readonly base: ITextModel,
@@ -61,6 +50,101 @@ export class MergeEditorModel extends EditorModel {
 		@IUndoRedoService private readonly undoRedoService: IUndoRedoService,
 	) {
 		super();
+		this.input1TextModelDiffs = this._register(new TextModelDiffs(this.base, this.input1.textModel, this.diffComputer));
+		this.input2TextModelDiffs = this._register(new TextModelDiffs(this.base, this.input2.textModel, this.diffComputer));
+		this.resultTextModelDiffs = this._register(new TextModelDiffs(this.base, this.resultTextModel, this.diffComputer));
+		this.modifiedBaseRanges = derived<ModifiedBaseRange[]>(this, (reader) => {
+			const input1Diffs = this.input1TextModelDiffs.diffs.read(reader);
+			const input2Diffs = this.input2TextModelDiffs.diffs.read(reader);
+			return ModifiedBaseRange.fromDiffs(input1Diffs, input2Diffs, this.base, this.input1.textModel, this.input2.textModel);
+		});
+		this.modifiedBaseRangeResultStates = derived(this, reader => {
+			const map = new Map<ModifiedBaseRange, ModifiedBaseRangeData>(
+				this.modifiedBaseRanges.read(reader).map<[ModifiedBaseRange, ModifiedBaseRangeData]>((s) => [
+					s, new ModifiedBaseRangeData(s)
+				])
+			);
+			return map;
+		});
+		this.resultSnapshot = this.resultTextModel.createSnapshot();
+		this.baseInput1Diffs = this.input1TextModelDiffs.diffs;
+		this.baseInput2Diffs = this.input2TextModelDiffs.diffs;
+		this.baseResultDiffs = this.resultTextModelDiffs.diffs;
+		this.input1ResultMapping = derived(this, reader => {
+			return this.getInputResultMapping(
+				this.baseInput1Diffs.read(reader),
+				this.baseResultDiffs.read(reader),
+				this.input1.textModel.getLineCount(),
+			);
+		});
+		this.resultInput1Mapping = derived(this, reader => this.input1ResultMapping.read(reader).reverse());
+		this.input2ResultMapping = derived(this, reader => {
+			return this.getInputResultMapping(
+				this.baseInput2Diffs.read(reader),
+				this.baseResultDiffs.read(reader),
+				this.input2.textModel.getLineCount(),
+			);
+		});
+		this.resultInput2Mapping = derived(this, reader => this.input2ResultMapping.read(reader).reverse());
+		this.baseResultMapping = derived(this, reader => {
+			const map = new DocumentLineRangeMap(this.baseResultDiffs.read(reader), -1);
+			return new DocumentLineRangeMap(
+				map.lineRangeMappings.map((m) =>
+					m.inputRange.isEmpty || m.outputRange.isEmpty
+						? new LineRangeMapping(
+							// We can do this because two adjacent diffs have one line in between.
+							m.inputRange.deltaStart(-1),
+							m.outputRange.deltaStart(-1)
+						)
+						: m
+				),
+				map.inputLineCount
+			);
+		});
+		this.resultBaseMapping = derived(this, reader => this.baseResultMapping.read(reader).reverse());
+		this.diffComputingState = derived(this, reader => {
+			const states = [
+				this.input1TextModelDiffs,
+				this.input2TextModelDiffs,
+				this.resultTextModelDiffs,
+			].map((s) => s.state.read(reader));
+
+			if (states.some((s) => s === TextModelDiffState.initializing)) {
+				return MergeEditorModelState.initializing;
+			}
+			if (states.some((s) => s === TextModelDiffState.updating)) {
+				return MergeEditorModelState.updating;
+			}
+			return MergeEditorModelState.upToDate;
+		});
+		this.inputDiffComputingState = derived(this, reader => {
+			const states = [
+				this.input1TextModelDiffs,
+				this.input2TextModelDiffs,
+			].map((s) => s.state.read(reader));
+
+			if (states.some((s) => s === TextModelDiffState.initializing)) {
+				return MergeEditorModelState.initializing;
+			}
+			if (states.some((s) => s === TextModelDiffState.updating)) {
+				return MergeEditorModelState.updating;
+			}
+			return MergeEditorModelState.upToDate;
+		});
+		this.isUpToDate = derived(this, reader => this.diffComputingState.read(reader) === MergeEditorModelState.upToDate);
+		this.onInitialized = waitForState(this.diffComputingState, state => state === MergeEditorModelState.upToDate).then(() => { });
+		this.firstRun = true;
+		this.unhandledConflictsCount = derived(this, reader => {
+			const map = this.modifiedBaseRangeResultStates.read(reader);
+			let unhandledCount = 0;
+			for (const [_key, value] of map) {
+				if (!value.handled.read(reader)) {
+					unhandledCount++;
+				}
+			}
+			return unhandledCount;
+		});
+		this.hasUnhandledConflicts = this.unhandledConflictsCount.map(value => /** @description hasUnhandledConflicts */ value > 0);
 
 		this._register(keepObserved(this.modifiedBaseRangeResultStates));
 		this._register(keepObserved(this.input1ResultMapping));
@@ -202,30 +286,18 @@ export class MergeEditorModel extends EditorModel {
 		return this.modifiedBaseRangeResultStates.get().has(baseRange);
 	}
 
-	public readonly baseInput1Diffs = this.input1TextModelDiffs.diffs;
+	public readonly baseInput1Diffs;
 
-	public readonly baseInput2Diffs = this.input2TextModelDiffs.diffs;
-	public readonly baseResultDiffs = this.resultTextModelDiffs.diffs;
+	public readonly baseInput2Diffs;
+	public readonly baseResultDiffs;
 	public get isApplyingEditInResult(): boolean { return this.resultTextModelDiffs.isApplyingChange; }
-	public readonly input1ResultMapping = derived(this, reader => {
-		return this.getInputResultMapping(
-			this.baseInput1Diffs.read(reader),
-			this.baseResultDiffs.read(reader),
-			this.input1.textModel.getLineCount(),
-		);
-	});
+	public readonly input1ResultMapping;
 
-	public readonly resultInput1Mapping = derived(this, reader => this.input1ResultMapping.read(reader).reverse());
+	public readonly resultInput1Mapping;
 
-	public readonly input2ResultMapping = derived(this, reader => {
-		return this.getInputResultMapping(
-			this.baseInput2Diffs.read(reader),
-			this.baseResultDiffs.read(reader),
-			this.input2.textModel.getLineCount(),
-		);
-	});
+	public readonly input2ResultMapping;
 
-	public readonly resultInput2Mapping = derived(this, reader => this.input2ResultMapping.read(reader).reverse());
+	public readonly resultInput2Mapping;
 
 	private getInputResultMapping(inputLinesDiffs: DetailedLineRangeMapping[], resultDiffs: DetailedLineRangeMapping[], inputLineCount: number) {
 		const map = DocumentLineRangeMap.betweenOutputs(inputLinesDiffs, resultDiffs, inputLineCount);
@@ -243,23 +315,9 @@ export class MergeEditorModel extends EditorModel {
 		);
 	}
 
-	public readonly baseResultMapping = derived(this, reader => {
-		const map = new DocumentLineRangeMap(this.baseResultDiffs.read(reader), -1);
-		return new DocumentLineRangeMap(
-			map.lineRangeMappings.map((m) =>
-				m.inputRange.isEmpty || m.outputRange.isEmpty
-					? new LineRangeMapping(
-						// We can do this because two adjacent diffs have one line in between.
-						m.inputRange.deltaStart(-1),
-						m.outputRange.deltaStart(-1)
-					)
-					: m
-			),
-			map.inputLineCount
-		);
-	});
+	public readonly baseResultMapping;
 
-	public readonly resultBaseMapping = derived(this, reader => this.baseResultMapping.read(reader).reverse());
+	public readonly resultBaseMapping;
 
 	public translateInputRangeToBase(input: 1 | 2, range: Range): Range {
 		const baseInputDiffs = input === 1 ? this.baseInput1Diffs.get() : this.baseInput2Diffs.get();
@@ -292,42 +350,15 @@ export class MergeEditorModel extends EditorModel {
 		return this.modifiedBaseRanges.get().filter(r => r.baseRange.intersectsOrTouches(rangeInBase));
 	}
 
-	public readonly diffComputingState = derived(this, reader => {
-		const states = [
-			this.input1TextModelDiffs,
-			this.input2TextModelDiffs,
-			this.resultTextModelDiffs,
-		].map((s) => s.state.read(reader));
+	public readonly diffComputingState;
 
-		if (states.some((s) => s === TextModelDiffState.initializing)) {
-			return MergeEditorModelState.initializing;
-		}
-		if (states.some((s) => s === TextModelDiffState.updating)) {
-			return MergeEditorModelState.updating;
-		}
-		return MergeEditorModelState.upToDate;
-	});
+	public readonly inputDiffComputingState;
 
-	public readonly inputDiffComputingState = derived(this, reader => {
-		const states = [
-			this.input1TextModelDiffs,
-			this.input2TextModelDiffs,
-		].map((s) => s.state.read(reader));
+	public readonly isUpToDate;
 
-		if (states.some((s) => s === TextModelDiffState.initializing)) {
-			return MergeEditorModelState.initializing;
-		}
-		if (states.some((s) => s === TextModelDiffState.updating)) {
-			return MergeEditorModelState.updating;
-		}
-		return MergeEditorModelState.upToDate;
-	});
+	public readonly onInitialized;
 
-	public readonly isUpToDate = derived(this, reader => this.diffComputingState.read(reader) === MergeEditorModelState.upToDate);
-
-	public readonly onInitialized = waitForState(this.diffComputingState, state => state === MergeEditorModelState.upToDate).then(() => { });
-
-	private firstRun = true;
+	private firstRun;
 	private updateBaseRangeAcceptedState(resultDiffs: DetailedLineRangeMapping[], states: Map<ModifiedBaseRange, ModifiedBaseRangeData>, tx: ITransaction): void {
 		const baseRangeWithStoreAndTouchingDiffs = leftJoin(
 			states,
@@ -543,18 +574,9 @@ export class MergeEditorModel extends EditorModel {
 		state.handledInput2.set(handled, tx);
 	}
 
-	public readonly unhandledConflictsCount = derived(this, reader => {
-		const map = this.modifiedBaseRangeResultStates.read(reader);
-		let unhandledCount = 0;
-		for (const [_key, value] of map) {
-			if (!value.handled.read(reader)) {
-				unhandledCount++;
-			}
-		}
-		return unhandledCount;
-	});
+	public readonly unhandledConflictsCount;
 
-	public readonly hasUnhandledConflicts = this.unhandledConflictsCount.map(value => /** @description hasUnhandledConflicts */ value > 0);
+	public readonly hasUnhandledConflicts;
 
 	public setLanguageId(languageId: string, source?: string): void {
 		const language = this.languageService.createById(languageId);
@@ -758,16 +780,23 @@ function arrayCount<T>(array: Iterable<T>, predicate: (value: T) => boolean): nu
 }
 
 class ModifiedBaseRangeData {
-	constructor(private readonly baseRange: ModifiedBaseRange) { }
+	constructor(private readonly baseRange: ModifiedBaseRange) {
+		this.accepted = observableValue(`BaseRangeState${this.baseRange.baseRange}`, ModifiedBaseRangeState.base);
+		this.handledInput1 = observableValue(`BaseRangeHandledState${this.baseRange.baseRange}.Input1`, false);
+		this.handledInput2 = observableValue(`BaseRangeHandledState${this.baseRange.baseRange}.Input2`, false);
+		this.computedFromDiffing = false;
+		this.previousNonDiffingState = undefined;
+		this.handled = derived(this, reader => this.handledInput1.read(reader) && this.handledInput2.read(reader));
+	}
 
-	public accepted: ISettableObservable<ModifiedBaseRangeState> = observableValue(`BaseRangeState${this.baseRange.baseRange}`, ModifiedBaseRangeState.base);
-	public handledInput1: ISettableObservable<boolean> = observableValue(`BaseRangeHandledState${this.baseRange.baseRange}.Input1`, false);
-	public handledInput2: ISettableObservable<boolean> = observableValue(`BaseRangeHandledState${this.baseRange.baseRange}.Input2`, false);
+	public accepted: ISettableObservable<ModifiedBaseRangeState>;
+	public handledInput1: ISettableObservable<boolean>;
+	public handledInput2: ISettableObservable<boolean>;
 
-	public computedFromDiffing = false;
-	public previousNonDiffingState: ModifiedBaseRangeState | undefined = undefined;
+	public computedFromDiffing;
+	public previousNonDiffingState: ModifiedBaseRangeState | undefined;
 
-	public readonly handled = derived(this, reader => this.handledInput1.read(reader) && this.handledInput2.read(reader));
+	public readonly handled;
 }
 
 export const enum MergeEditorModelState {

--- a/src/vs/workbench/contrib/mergeEditor/browser/model/mergeEditorModel.ts
+++ b/src/vs/workbench/contrib/mergeEditor/browser/model/mergeEditorModel.ts
@@ -132,7 +132,7 @@ export class MergeEditorModel extends EditorModel {
 			return MergeEditorModelState.upToDate;
 		});
 		this.isUpToDate = derived(this, reader => this.diffComputingState.read(reader) === MergeEditorModelState.upToDate);
-		this.onInitialized = waitForState(this.diffComputingState, state => state === MergeEditorModelState.upToDate).then(() => { });
+
 		this.firstRun = true;
 		this.unhandledConflictsCount = derived(this, reader => {
 			const map = this.modifiedBaseRangeResultStates.read(reader);
@@ -152,7 +152,7 @@ export class MergeEditorModel extends EditorModel {
 
 		const initializePromise = this.initialize();
 
-		this.onInitialized = this.onInitialized.then(async () => {
+		this.onInitialized = waitForState(this.diffComputingState, state => state === MergeEditorModelState.upToDate).then(async () => {
 			await initializePromise;
 		});
 

--- a/src/vs/workbench/contrib/mergeEditor/browser/model/modifiedBaseRange.ts
+++ b/src/vs/workbench/contrib/mergeEditor/browser/model/modifiedBaseRange.ts
@@ -44,9 +44,9 @@ export class ModifiedBaseRange {
 		);
 	}
 
-	public readonly input1CombinedDiff = DetailedLineRangeMapping.join(this.input1Diffs);
-	public readonly input2CombinedDiff = DetailedLineRangeMapping.join(this.input2Diffs);
-	public readonly isEqualChange = equals(this.input1Diffs, this.input2Diffs, (a, b) => a.getLineEdit().equals(b.getLineEdit()));
+	public readonly input1CombinedDiff;
+	public readonly input2CombinedDiff;
+	public readonly isEqualChange;
 
 	constructor(
 		public readonly baseRange: MergeEditorLineRange,
@@ -66,6 +66,13 @@ export class ModifiedBaseRange {
 		*/
 		public readonly input2Diffs: readonly DetailedLineRangeMapping[]
 	) {
+		this.input1CombinedDiff = DetailedLineRangeMapping.join(this.input1Diffs);
+		this.input2CombinedDiff = DetailedLineRangeMapping.join(this.input2Diffs);
+		this.isEqualChange = equals(this.input1Diffs, this.input2Diffs, (a, b) => a.getLineEdit().equals(b.getLineEdit()));
+		this.smartInput1LineRangeEdit = null;
+		this.smartInput2LineRangeEdit = null;
+		this.dumbInput1LineRangeEdit = null;
+		this.dumbInput2LineRangeEdit = null;
 		if (this.input1Diffs.length === 0 && this.input2Diffs.length === 0) {
 			throw new BugIndicatingError('must have at least one diff');
 		}
@@ -135,8 +142,8 @@ export class ModifiedBaseRange {
 		};
 	}
 
-	private smartInput1LineRangeEdit: LineRangeEdit | undefined | null = null;
-	private smartInput2LineRangeEdit: LineRangeEdit | undefined | null = null;
+	private smartInput1LineRangeEdit: LineRangeEdit | undefined | null;
+	private smartInput2LineRangeEdit: LineRangeEdit | undefined | null;
 
 	private smartCombineInputs(firstInput: 1 | 2): LineRangeEdit | undefined {
 		if (firstInput === 1 && this.smartInput1LineRangeEdit !== null) {
@@ -173,8 +180,8 @@ export class ModifiedBaseRange {
 		return result;
 	}
 
-	private dumbInput1LineRangeEdit: LineRangeEdit | undefined | null = null;
-	private dumbInput2LineRangeEdit: LineRangeEdit | undefined | null = null;
+	private dumbInput1LineRangeEdit: LineRangeEdit | undefined | null;
+	private dumbInput2LineRangeEdit: LineRangeEdit | undefined | null;
 
 	private dumbCombineInputs(firstInput: 1 | 2): LineRangeEdit | undefined {
 		if (firstInput === 1 && this.dumbInput1LineRangeEdit !== null) {

--- a/src/vs/workbench/contrib/mergeEditor/browser/view/editorGutter.ts
+++ b/src/vs/workbench/contrib/mergeEditor/browser/view/editorGutter.ts
@@ -10,19 +10,13 @@ import { CodeEditorWidget } from '../../../../../editor/browser/widget/codeEdito
 import { MergeEditorLineRange } from '../model/lineRange.js';
 
 export class EditorGutter<T extends IGutterItemInfo = IGutterItemInfo> extends Disposable {
-	private readonly scrollTop = observableFromEvent(this,
-		this._editor.onDidScrollChange,
-		(e) => /** @description editor.onDidScrollChange */ this._editor.getScrollTop()
-	);
-	private readonly isScrollTopZero = this.scrollTop.map((scrollTop) => /** @description isScrollTopZero */ scrollTop === 0);
-	private readonly modelAttached = observableFromEvent(this,
-		this._editor.onDidChangeModel,
-		(e) => /** @description editor.onDidChangeModel */ this._editor.hasModel()
-	);
+	private readonly scrollTop;
+	private readonly isScrollTopZero;
+	private readonly modelAttached;
 
-	private readonly editorOnDidChangeViewZones = observableSignalFromEvent('onDidChangeViewZones', this._editor.onDidChangeViewZones);
-	private readonly editorOnDidContentSizeChange = observableSignalFromEvent('onDidContentSizeChange', this._editor.onDidContentSizeChange);
-	private readonly domNodeSizeChanged = observableSignal('domNodeSizeChanged');
+	private readonly editorOnDidChangeViewZones;
+	private readonly editorOnDidContentSizeChange;
+	private readonly domNodeSizeChanged;
 
 	constructor(
 		private readonly _editor: CodeEditorWidget,
@@ -30,6 +24,19 @@ export class EditorGutter<T extends IGutterItemInfo = IGutterItemInfo> extends D
 		private readonly itemProvider: IGutterItemProvider<T>
 	) {
 		super();
+		this.scrollTop = observableFromEvent(this,
+			this._editor.onDidScrollChange,
+			(e) => /** @description editor.onDidScrollChange */ this._editor.getScrollTop()
+		);
+		this.isScrollTopZero = this.scrollTop.map((scrollTop) => /** @description isScrollTopZero */ scrollTop === 0);
+		this.modelAttached = observableFromEvent(this,
+			this._editor.onDidChangeModel,
+			(e) => /** @description editor.onDidChangeModel */ this._editor.hasModel()
+		);
+		this.editorOnDidChangeViewZones = observableSignalFromEvent('onDidChangeViewZones', this._editor.onDidChangeViewZones);
+		this.editorOnDidContentSizeChange = observableSignalFromEvent('onDidContentSizeChange', this._editor.onDidContentSizeChange);
+		this.domNodeSizeChanged = observableSignal('domNodeSizeChanged');
+		this.views = new Map<string, ManagedGutterItemView>();
 		this._domNode.className = 'gutter monaco-editor';
 		const scrollDecoration = this._domNode.appendChild(
 			h('div.scroll-decoration', { role: 'presentation', ariaHidden: 'true', style: { width: '100%' } })
@@ -59,7 +66,7 @@ export class EditorGutter<T extends IGutterItemInfo = IGutterItemInfo> extends D
 		reset(this._domNode);
 	}
 
-	private readonly views = new Map<string, ManagedGutterItemView>();
+	private readonly views;
 
 	private render(reader: IReader): void {
 		if (!this.modelAttached.read(reader)) {

--- a/src/vs/workbench/contrib/mergeEditor/browser/view/editors/codeEditorView.ts
+++ b/src/vs/workbench/contrib/mergeEditor/browser/view/editors/codeEditorView.ts
@@ -25,76 +25,31 @@ import { observableConfigValue } from '../../../../../../platform/observable/com
 import { MergeEditorViewModel } from '../viewModel.js';
 
 export abstract class CodeEditorView extends Disposable {
-	readonly model = this.viewModel.map(m => /** @description model */ m?.model);
+	readonly model;
 
-	protected readonly htmlElements = h('div.code-view', [
-		h('div.header@header', [
-			h('span.title@title'),
-			h('span.description@description'),
-			h('span.detail@detail'),
-			h('span.toolbar@toolbar'),
-		]),
-		h('div.container', [
-			h('div.gutter@gutterDiv'),
-			h('div@editor'),
-		]),
-	]);
+	protected readonly htmlElements;
 
-	private readonly _onDidViewChange = new Emitter<IViewSize | undefined>();
+	private readonly _onDidViewChange;
 
-	public readonly view: IView = {
-		element: this.htmlElements.root,
-		minimumWidth: DEFAULT_EDITOR_MIN_DIMENSIONS.width,
-		maximumWidth: DEFAULT_EDITOR_MAX_DIMENSIONS.width,
-		minimumHeight: DEFAULT_EDITOR_MIN_DIMENSIONS.height,
-		maximumHeight: DEFAULT_EDITOR_MAX_DIMENSIONS.height,
-		onDidChange: this._onDidViewChange.event,
-		layout: (width: number, height: number, top: number, left: number) => {
-			setStyle(this.htmlElements.root, { width, height, top, left });
-			this.editor.layout({
-				width: width - this.htmlElements.gutterDiv.clientWidth,
-				height: height - this.htmlElements.header.clientHeight,
-			});
-		}
-		// preferredWidth?: number | undefined;
-		// preferredHeight?: number | undefined;
-		// priority?: LayoutPriority | undefined;
-		// snap?: boolean | undefined;
-	};
+	public readonly view: IView;
 
-	protected readonly checkboxesVisible = observableConfigValue<boolean>('mergeEditor.showCheckboxes', false, this.configurationService);
-	protected readonly showDeletionMarkers = observableConfigValue<boolean>('mergeEditor.showDeletionMarkers', true, this.configurationService);
-	protected readonly useSimplifiedDecorations = observableConfigValue<boolean>('mergeEditor.useSimplifiedDecorations', false, this.configurationService);
+	protected readonly checkboxesVisible;
+	protected readonly showDeletionMarkers;
+	protected readonly useSimplifiedDecorations;
 
-	public readonly editor = this.instantiationService.createInstance(
-		CodeEditorWidget,
-		this.htmlElements.editor,
-		{},
-		{
-			contributions: this.getEditorContributions(),
-		}
-	);
+	public readonly editor;
 
 	public updateOptions(newOptions: Readonly<IEditorOptions>): void {
 		this.editor.updateOptions(newOptions);
 	}
 
-	public readonly isFocused = observableFromEvent(this,
-		Event.any(this.editor.onDidBlurEditorWidget, this.editor.onDidFocusEditorWidget),
-		() => /** @description editor.hasWidgetFocus */ this.editor.hasWidgetFocus()
-	);
+	public readonly isFocused;
 
-	public readonly cursorPosition = observableFromEvent(this,
-		this.editor.onDidChangeCursorPosition,
-		() => /** @description editor.getPosition */ this.editor.getPosition()
-	);
+	public readonly cursorPosition;
 
-	public readonly selection = observableFromEvent(this,
-		this.editor.onDidChangeCursorSelection,
-		() => /** @description editor.getSelections */ this.editor.getSelections()
-	);
+	public readonly selection;
 
-	public readonly cursorLineNumber = this.cursorPosition.map(p => /** @description cursorPosition.lineNumber */ p?.lineNumber);
+	public readonly cursorLineNumber;
 
 	constructor(
 		private readonly instantiationService: IInstantiationService,
@@ -102,6 +57,63 @@ export abstract class CodeEditorView extends Disposable {
 		private readonly configurationService: IConfigurationService,
 	) {
 		super();
+		this.model = this.viewModel.map(m => /** @description model */ m?.model);
+		this.htmlElements = h('div.code-view', [
+			h('div.header@header', [
+				h('span.title@title'),
+				h('span.description@description'),
+				h('span.detail@detail'),
+				h('span.toolbar@toolbar'),
+			]),
+			h('div.container', [
+				h('div.gutter@gutterDiv'),
+				h('div@editor'),
+			]),
+		]);
+		this._onDidViewChange = new Emitter<IViewSize | undefined>();
+		this.view = {
+			element: this.htmlElements.root,
+			minimumWidth: DEFAULT_EDITOR_MIN_DIMENSIONS.width,
+			maximumWidth: DEFAULT_EDITOR_MAX_DIMENSIONS.width,
+			minimumHeight: DEFAULT_EDITOR_MIN_DIMENSIONS.height,
+			maximumHeight: DEFAULT_EDITOR_MAX_DIMENSIONS.height,
+			onDidChange: this._onDidViewChange.event,
+			layout: (width: number, height: number, top: number, left: number) => {
+				setStyle(this.htmlElements.root, { width, height, top, left });
+				this.editor.layout({
+					width: width - this.htmlElements.gutterDiv.clientWidth,
+					height: height - this.htmlElements.header.clientHeight,
+				});
+			}
+			// preferredWidth?: number | undefined;
+			// preferredHeight?: number | undefined;
+			// priority?: LayoutPriority | undefined;
+			// snap?: boolean | undefined;
+		};
+		this.checkboxesVisible = observableConfigValue<boolean>('mergeEditor.showCheckboxes', false, this.configurationService);
+		this.showDeletionMarkers = observableConfigValue<boolean>('mergeEditor.showDeletionMarkers', true, this.configurationService);
+		this.useSimplifiedDecorations = observableConfigValue<boolean>('mergeEditor.useSimplifiedDecorations', false, this.configurationService);
+		this.editor = this.instantiationService.createInstance(
+			CodeEditorWidget,
+			this.htmlElements.editor,
+			{},
+			{
+				contributions: this.getEditorContributions(),
+			}
+		);
+		this.isFocused = observableFromEvent(this,
+			Event.any(this.editor.onDidBlurEditorWidget, this.editor.onDidFocusEditorWidget),
+			() => /** @description editor.hasWidgetFocus */ this.editor.hasWidgetFocus()
+		);
+		this.cursorPosition = observableFromEvent(this,
+			this.editor.onDidChangeCursorPosition,
+			() => /** @description editor.getPosition */ this.editor.getPosition()
+		);
+		this.selection = observableFromEvent(this,
+			this.editor.onDidChangeCursorSelection,
+			() => /** @description editor.getSelections */ this.editor.getSelections()
+		);
+		this.cursorLineNumber = this.cursorPosition.map(p => /** @description cursorPosition.lineNumber */ p?.lineNumber);
 
 	}
 

--- a/src/vs/workbench/contrib/mergeEditor/browser/view/viewModel.ts
+++ b/src/vs/workbench/contrib/mergeEditor/browser/view/viewModel.ts
@@ -22,11 +22,9 @@ import { InputCodeEditorView } from './editors/inputCodeEditorView.js';
 import { ResultCodeEditorView } from './editors/resultCodeEditorView.js';
 
 export class MergeEditorViewModel extends Disposable {
-	private readonly manuallySetActiveModifiedBaseRange = observableValue<
-		{ range: ModifiedBaseRange | undefined; counter: number }
-	>(this, { range: undefined, counter: 0 });
+	private readonly manuallySetActiveModifiedBaseRange;
 
-	private readonly attachedHistory = this._register(new AttachedHistory(this.model.resultTextModel));
+	private readonly attachedHistory;
 
 	constructor(
 		public readonly model: MergeEditorModel,
@@ -39,6 +37,108 @@ export class MergeEditorViewModel extends Disposable {
 		@INotificationService private readonly notificationService: INotificationService,
 	) {
 		super();
+		this.manuallySetActiveModifiedBaseRange = observableValue<
+			{ range: ModifiedBaseRange | undefined; counter: number }
+		>(this, { range: undefined, counter: 0 });
+		this.attachedHistory = this._register(new AttachedHistory(this.model.resultTextModel));
+		this.shouldUseAppendInsteadOfAccept = observableConfigValue<boolean>(
+			'mergeEditor.shouldUseAppendInsteadOfAccept',
+			false,
+			this.configurationService,
+		);
+		this.counter = 0;
+		this.lastFocusedEditor = derivedObservableWithWritableCache<
+			{ view: CodeEditorView | undefined; counter: number }
+		>(this, (reader, lastValue) => {
+			const editors = [
+				this.inputCodeEditorView1,
+				this.inputCodeEditorView2,
+				this.resultCodeEditorView,
+				this.baseCodeEditorView.read(reader),
+			];
+			const view = editors.find((e) => e && e.isFocused.read(reader));
+			return view ? { view, counter: this.counter++ } : lastValue || { view: undefined, counter: this.counter++ };
+		});
+		this.baseShowDiffAgainst = derived<1 | 2 | undefined>(this, reader => {
+			const lastFocusedEditor = this.lastFocusedEditor.read(reader);
+			if (lastFocusedEditor.view === this.inputCodeEditorView1) {
+				return 1;
+			} else if (lastFocusedEditor.view === this.inputCodeEditorView2) {
+				return 2;
+			}
+			return undefined;
+		});
+		this.focusedEditorType = derived<MergeEditorType | undefined>(this, reader => {
+			const lastFocusedEditor = this.lastFocusedEditor.read(reader);
+
+			if (!lastFocusedEditor.view) {
+				return undefined;
+			}
+
+			if (lastFocusedEditor.view === this.inputCodeEditorView1) {
+				return 'input1';
+			} else if (lastFocusedEditor.view === this.inputCodeEditorView2) {
+				return 'input2';
+			} else if (lastFocusedEditor.view === this.resultCodeEditorView) {
+				return 'result';
+			} else if (lastFocusedEditor.view === this.baseCodeEditorView.read(reader)) {
+				return 'base';
+			}
+
+			return undefined;
+		});
+		this.selectionInBase = derived(this, reader => {
+			const sourceEditor = this.lastFocusedEditor.read(reader).view;
+			if (!sourceEditor) {
+				return undefined;
+			}
+			const selections = sourceEditor.selection.read(reader) || [];
+
+			const rangesInBase = selections.map((selection) => {
+				if (sourceEditor === this.inputCodeEditorView1) {
+					return this.model.translateInputRangeToBase(1, selection);
+				} else if (sourceEditor === this.inputCodeEditorView2) {
+					return this.model.translateInputRangeToBase(2, selection);
+				} else if (sourceEditor === this.resultCodeEditorView) {
+					return this.model.translateResultRangeToBase(selection);
+				} else if (sourceEditor === this.baseCodeEditorView.read(reader)) {
+					return selection;
+				} else {
+					return selection;
+				}
+			});
+
+			return {
+				rangesInBase,
+				sourceEditor
+			};
+		});
+		this.activeModifiedBaseRange = derived(this,
+			(reader) => {
+				/** @description activeModifiedBaseRange */
+				const focusedEditor = this.lastFocusedEditor.read(reader);
+				const manualRange = this.manuallySetActiveModifiedBaseRange.read(reader);
+				if (manualRange.counter > focusedEditor.counter) {
+					return manualRange.range;
+				}
+
+				if (!focusedEditor.view) {
+					return;
+				}
+				const cursorLineNumber = focusedEditor.view.cursorLineNumber.read(reader);
+				if (!cursorLineNumber) {
+					return undefined;
+				}
+
+				const modifiedBaseRanges = this.model.modifiedBaseRanges.read(reader);
+				return modifiedBaseRanges.find((r) => {
+					const range = this.getRangeOfModifiedBaseRange(focusedEditor.view!, r, reader);
+					return range.isEmpty
+						? range.startLineNumber === cursorLineNumber
+						: range.contains(cursorLineNumber);
+				});
+			}
+		);
 
 		this._register(resultCodeEditorView.editor.onDidChangeModelContent(e => {
 			if (this.model.isApplyingEditInResult || e.isRedoing || e.isUndoing) {
@@ -86,85 +186,19 @@ export class MergeEditorViewModel extends Disposable {
 		}));
 	}
 
-	public readonly shouldUseAppendInsteadOfAccept = observableConfigValue<boolean>(
-		'mergeEditor.shouldUseAppendInsteadOfAccept',
-		false,
-		this.configurationService,
-	);
+	public readonly shouldUseAppendInsteadOfAccept;
 
-	private counter = 0;
-	private readonly lastFocusedEditor = derivedObservableWithWritableCache<
-		{ view: CodeEditorView | undefined; counter: number }
-	>(this, (reader, lastValue) => {
-		const editors = [
-			this.inputCodeEditorView1,
-			this.inputCodeEditorView2,
-			this.resultCodeEditorView,
-			this.baseCodeEditorView.read(reader),
-		];
-		const view = editors.find((e) => e && e.isFocused.read(reader));
-		return view ? { view, counter: this.counter++ } : lastValue || { view: undefined, counter: this.counter++ };
-	});
+	private counter;
+	private readonly lastFocusedEditor;
 
-	public readonly baseShowDiffAgainst = derived<1 | 2 | undefined>(this, reader => {
-		const lastFocusedEditor = this.lastFocusedEditor.read(reader);
-		if (lastFocusedEditor.view === this.inputCodeEditorView1) {
-			return 1;
-		} else if (lastFocusedEditor.view === this.inputCodeEditorView2) {
-			return 2;
-		}
-		return undefined;
-	});
+	public readonly baseShowDiffAgainst;
 
 	/**
 	 * Returns an observable that tracks which editor type is currently focused
 	 */
-	public readonly focusedEditorType = derived<MergeEditorType | undefined>(this, reader => {
-		const lastFocusedEditor = this.lastFocusedEditor.read(reader);
+	public readonly focusedEditorType;
 
-		if (!lastFocusedEditor.view) {
-			return undefined;
-		}
-
-		if (lastFocusedEditor.view === this.inputCodeEditorView1) {
-			return 'input1';
-		} else if (lastFocusedEditor.view === this.inputCodeEditorView2) {
-			return 'input2';
-		} else if (lastFocusedEditor.view === this.resultCodeEditorView) {
-			return 'result';
-		} else if (lastFocusedEditor.view === this.baseCodeEditorView.read(reader)) {
-			return 'base';
-		}
-
-		return undefined;
-	});
-
-	public readonly selectionInBase = derived(this, reader => {
-		const sourceEditor = this.lastFocusedEditor.read(reader).view;
-		if (!sourceEditor) {
-			return undefined;
-		}
-		const selections = sourceEditor.selection.read(reader) || [];
-
-		const rangesInBase = selections.map((selection) => {
-			if (sourceEditor === this.inputCodeEditorView1) {
-				return this.model.translateInputRangeToBase(1, selection);
-			} else if (sourceEditor === this.inputCodeEditorView2) {
-				return this.model.translateInputRangeToBase(2, selection);
-			} else if (sourceEditor === this.resultCodeEditorView) {
-				return this.model.translateResultRangeToBase(selection);
-			} else if (sourceEditor === this.baseCodeEditorView.read(reader)) {
-				return selection;
-			} else {
-				return selection;
-			}
-		});
-
-		return {
-			rangesInBase,
-			sourceEditor
-		};
-	});
+	public readonly selectionInBase;
 
 	private getRangeOfModifiedBaseRange(editor: CodeEditorView, modifiedBaseRange: ModifiedBaseRange, reader: IReader | undefined): MergeEditorLineRange {
 		if (editor === this.resultCodeEditorView) {
@@ -177,32 +211,7 @@ export class MergeEditorViewModel extends Disposable {
 		}
 	}
 
-	public readonly activeModifiedBaseRange = derived(this,
-		(reader) => {
-			/** @description activeModifiedBaseRange */
-			const focusedEditor = this.lastFocusedEditor.read(reader);
-			const manualRange = this.manuallySetActiveModifiedBaseRange.read(reader);
-			if (manualRange.counter > focusedEditor.counter) {
-				return manualRange.range;
-			}
-
-			if (!focusedEditor.view) {
-				return;
-			}
-			const cursorLineNumber = focusedEditor.view.cursorLineNumber.read(reader);
-			if (!cursorLineNumber) {
-				return undefined;
-			}
-
-			const modifiedBaseRanges = this.model.modifiedBaseRanges.read(reader);
-			return modifiedBaseRanges.find((r) => {
-				const range = this.getRangeOfModifiedBaseRange(focusedEditor.view!, r, reader);
-				return range.isEmpty
-					? range.startLineNumber === cursorLineNumber
-					: range.contains(cursorLineNumber);
-			});
-		}
-	);
+	public readonly activeModifiedBaseRange;
 
 	public setActiveModifiedBaseRange(range: ModifiedBaseRange | undefined, tx: ITransaction): void {
 		this.manuallySetActiveModifiedBaseRange.set({ range, counter: this.counter++ }, tx);
@@ -315,11 +324,13 @@ export class MergeEditorViewModel extends Disposable {
 }
 
 class AttachedHistory extends Disposable {
-	private readonly attachedHistory: { element: IAttachedHistoryElement; altId: number }[] = [];
-	private previousAltId: number = this.model.getAlternativeVersionId();
+	private readonly attachedHistory: { element: IAttachedHistoryElement; altId: number }[];
+	private previousAltId: number;
 
 	constructor(private readonly model: ITextModel) {
 		super();
+		this.attachedHistory = [];
+		this.previousAltId = this.model.getAlternativeVersionId();
 
 		this._register(model.onDidChangeContent((e) => {
 			const currentAltId = model.getAlternativeVersionId();

--- a/src/vs/workbench/contrib/mergeEditor/browser/view/viewZones.ts
+++ b/src/vs/workbench/contrib/mergeEditor/browser/view/viewZones.ts
@@ -17,15 +17,19 @@ import { getAlignments } from './lineAlignment.js';
 import { MergeEditorViewModel } from './viewModel.js';
 
 export class ViewZoneComputer {
-	private readonly conflictActionsFactoryInput1 = new ConflictActionsFactory(this.input1Editor);
-	private readonly conflictActionsFactoryInput2 = new ConflictActionsFactory(this.input2Editor);
-	private readonly conflictActionsFactoryResult = new ConflictActionsFactory(this.resultEditor);
+	private readonly conflictActionsFactoryInput1;
+	private readonly conflictActionsFactoryInput2;
+	private readonly conflictActionsFactoryResult;
 
 	constructor(
 		private readonly input1Editor: ICodeEditor,
 		private readonly input2Editor: ICodeEditor,
 		private readonly resultEditor: ICodeEditor,
-	) { }
+	) {
+		this.conflictActionsFactoryInput1 = new ConflictActionsFactory(this.input1Editor);
+		this.conflictActionsFactoryInput2 = new ConflictActionsFactory(this.input2Editor);
+		this.conflictActionsFactoryResult = new ConflictActionsFactory(this.resultEditor);
+	}
 
 	public computeViewZones(
 		reader: IReader,

--- a/src/vs/workbench/contrib/multiDiffEditor/browser/multiDiffEditorInput.ts
+++ b/src/vs/workbench/contrib/multiDiffEditor/browser/multiDiffEditorInput.ts
@@ -74,7 +74,7 @@ export class MultiDiffEditorInput extends EditorInput implements ILanguageSuppor
 	override get capabilities(): EditorInputCapabilities { return EditorInputCapabilities.Readonly; }
 	override get typeId(): string { return MultiDiffEditorInput.ID; }
 
-	private _name: string = '';
+	private _name: string;
 	override getName(): string { return this._name; }
 
 	override get editorId(): string { return DEFAULT_EDITOR_ASSOCIATION.id; }
@@ -92,6 +92,51 @@ export class MultiDiffEditorInput extends EditorInput implements ILanguageSuppor
 		@ITextFileService private readonly _textFileService: ITextFileService,
 	) {
 		super();
+		this._name = '';
+		this._viewModel = new LazyStatefulPromise(async () => {
+			const model = await this._createModel();
+			this._register(model);
+			const vm = new MultiDiffEditorViewModel(model, this._instantiationService);
+			this._register(vm);
+			await raceTimeout(vm.waitForDiffs(), 1000);
+			return vm;
+		});
+		this._resolvedSource = new ObservableLazyPromise(async () => {
+			const source: IResolvedMultiDiffSource | undefined = this.initialResources
+				? { resources: ValueWithChangeEvent.const(this.initialResources) }
+				: await this._multiDiffSourceResolverService.resolve(this.multiDiffSource);
+			return {
+				source,
+				resources: source ? observableFromValueWithChangeEvent(this, source.resources) : constObservable([]),
+			};
+		});
+		this.resources = derived(this, reader => this._resolvedSource.cachedPromiseResult.read(reader)?.data?.resources.read(reader));
+		this.textFileServiceOnDidChange = new FastEventDispatcher<ITextFileEditorModel, URI>(
+			this._textFileService.files.onDidChangeDirty,
+			item => item.resource.toString(),
+			uri => uri.toString()
+		);
+		this._isDirtyObservables = mapObservableArrayCached(this, this.resources.map(r => r ?? []), res => {
+			const isModifiedDirty = res.modifiedUri ? isUriDirty(this.textFileServiceOnDidChange, this._textFileService, res.modifiedUri) : constObservable(false);
+			const isOriginalDirty = res.originalUri ? isUriDirty(this.textFileServiceOnDidChange, this._textFileService, res.originalUri) : constObservable(false);
+			return derived(reader => /** @description modifiedDirty||originalDirty */ isModifiedDirty.read(reader) || isOriginalDirty.read(reader));
+		}, i => i.getKey());
+		this._isDirtyObservable = derived(this, reader => this._isDirtyObservables.read(reader).some(isDirty => isDirty.read(reader)))
+			.keepObserved(this._store);
+		this.onDidChangeDirty = Event.fromObservableLight(this._isDirtyObservable);
+		this.closeHandler = {
+
+			// This is a workaround for not having a better way
+			// to figure out if the editors this input wraps
+			// around are opened or not
+
+			async confirm() {
+				return ConfirmResult.DONT_SAVE;
+			},
+			showConfirm() {
+				return false;
+			}
+		};
 
 		this._register(autorun((reader) => {
 			/** @description Updates name */
@@ -133,14 +178,7 @@ export class MultiDiffEditorInput extends EditorInput implements ILanguageSuppor
 		return this._viewModel.getPromise();
 	}
 
-	private readonly _viewModel = new LazyStatefulPromise(async () => {
-		const model = await this._createModel();
-		this._register(model);
-		const vm = new MultiDiffEditorViewModel(model, this._instantiationService);
-		this._register(vm);
-		await raceTimeout(vm.waitForDiffs(), 1000);
-		return vm;
-	});
+	private readonly _viewModel;
 
 	private async _createModel(): Promise<IMultiDiffEditorModel & IDisposable> {
 		const source = await this._resolvedSource.getPromise();
@@ -209,15 +247,7 @@ export class MultiDiffEditorInput extends EditorInput implements ILanguageSuppor
 		return result;
 	}
 
-	private readonly _resolvedSource = new ObservableLazyPromise(async () => {
-		const source: IResolvedMultiDiffSource | undefined = this.initialResources
-			? { resources: ValueWithChangeEvent.const(this.initialResources) }
-			: await this._multiDiffSourceResolverService.resolve(this.multiDiffSource);
-		return {
-			source,
-			resources: source ? observableFromValueWithChangeEvent(this, source.resources) : constObservable([]),
-		};
-	});
+	private readonly _resolvedSource;
 
 	override matches(otherInput: EditorInput | IUntypedEditorInput): boolean {
 		if (super.matches(otherInput)) {
@@ -231,23 +261,14 @@ export class MultiDiffEditorInput extends EditorInput implements ILanguageSuppor
 		return false;
 	}
 
-	public readonly resources = derived(this, reader => this._resolvedSource.cachedPromiseResult.read(reader)?.data?.resources.read(reader));
+	public readonly resources;
 
-	private readonly textFileServiceOnDidChange = new FastEventDispatcher<ITextFileEditorModel, URI>(
-		this._textFileService.files.onDidChangeDirty,
-		item => item.resource.toString(),
-		uri => uri.toString()
-	);
+	private readonly textFileServiceOnDidChange;
 
-	private readonly _isDirtyObservables = mapObservableArrayCached(this, this.resources.map(r => r ?? []), res => {
-		const isModifiedDirty = res.modifiedUri ? isUriDirty(this.textFileServiceOnDidChange, this._textFileService, res.modifiedUri) : constObservable(false);
-		const isOriginalDirty = res.originalUri ? isUriDirty(this.textFileServiceOnDidChange, this._textFileService, res.originalUri) : constObservable(false);
-		return derived(reader => /** @description modifiedDirty||originalDirty */ isModifiedDirty.read(reader) || isOriginalDirty.read(reader));
-	}, i => i.getKey());
-	private readonly _isDirtyObservable = derived(this, reader => this._isDirtyObservables.read(reader).some(isDirty => isDirty.read(reader)))
-		.keepObserved(this._store);
+	private readonly _isDirtyObservables;
+	private readonly _isDirtyObservable;
 
-	override readonly onDidChangeDirty = Event.fromObservableLight(this._isDirtyObservable);
+	override readonly onDidChangeDirty;
 	override isDirty() { return this._isDirtyObservable.get(); }
 
 	override async save(group: number, options?: ISaveOptions | undefined): Promise<EditorInput> {
@@ -277,19 +298,7 @@ export class MultiDiffEditorInput extends EditorInput implements ILanguageSuppor
 		return undefined;
 	}
 
-	override readonly closeHandler: IEditorCloseHandler = {
-
-		// This is a workaround for not having a better way
-		// to figure out if the editors this input wraps
-		// around are opened or not
-
-		async confirm() {
-			return ConfirmResult.DONT_SAVE;
-		},
-		showConfirm() {
-			return false;
-		}
-	};
+	override readonly closeHandler: IEditorCloseHandler;
 }
 
 export interface IDocumentDiffItemWithMultiDiffEditorItem extends IDocumentDiffItem {

--- a/src/vs/workbench/contrib/multiDiffEditor/browser/scmMultiDiffSourceResolver.ts
+++ b/src/vs/workbench/contrib/multiDiffEditor/browser/scmMultiDiffSourceResolver.ts
@@ -84,21 +84,25 @@ export class ScmMultiDiffSourceResolver implements IMultiDiffSourceResolver {
 }
 
 class ScmResolvedMultiDiffSource implements IResolvedMultiDiffSource {
-	private readonly _resources = observableFromEvent<MultiDiffEditorItem[]>(
-		this._group.onDidChangeResources,
-		() => /** @description resources */ this._group.resources.map(e => new MultiDiffEditorItem(e.multiDiffEditorOriginalUri, e.multiDiffEditorModifiedUri, e.sourceUri))
-	);
-	readonly resources = new ValueWithChangeEventFromObservable(this._resources);
+	private readonly _resources;
+	readonly resources;
 
-	public readonly contextKeys: Record<string, ContextKeyValue> = {
-		scmResourceGroup: this._group.id,
-		scmProvider: this._repository.provider.contextValue,
-	};
+	public readonly contextKeys: Record<string, ContextKeyValue>;
 
 	constructor(
 		private readonly _group: ISCMResourceGroup,
 		private readonly _repository: ISCMRepository,
-	) { }
+	) {
+		this._resources = observableFromEvent<MultiDiffEditorItem[]>(
+			this._group.onDidChangeResources,
+			() => /** @description resources */ this._group.resources.map(e => new MultiDiffEditorItem(e.multiDiffEditorOriginalUri, e.multiDiffEditorModifiedUri, e.sourceUri))
+		);
+		this.resources = new ValueWithChangeEventFromObservable(this._resources);
+		this.contextKeys = {
+			scmResourceGroup: this._group.id,
+			scmProvider: this._repository.provider.contextValue,
+		};
+	}
 }
 
 interface UriFields {

--- a/src/vs/workbench/services/textMate/browser/backgroundTokenization/textMateWorkerTokenizerController.ts
+++ b/src/vs/workbench/services/textMate/browser/backgroundTokenization/textMateWorkerTokenizerController.ts
@@ -24,16 +24,16 @@ import type { applyStateStackDiff, StateStack } from 'vscode-textmate';
 export class TextMateWorkerTokenizerController extends Disposable {
 	private static _id = 0;
 
-	public readonly controllerId = TextMateWorkerTokenizerController._id++;
-	private readonly _pendingChanges: IModelContentChangedEvent[] = [];
+	public readonly controllerId;
+	private readonly _pendingChanges: IModelContentChangedEvent[];
 
 	/**
 	 * These states will eventually equal the worker states.
 	 * _states[i] stores the state at the end of line number i+1.
 	 */
-	private readonly _states = new TokenizationStateStore<StateStack>();
+	private readonly _states;
 
-	private readonly _loggingEnabled = observableConfigValue('editor.experimental.asyncTokenizationLogging', false, this._configurationService);
+	private readonly _loggingEnabled;
 
 	private _applyStateStackDiffFn?: typeof applyStateStackDiff;
 	private _initialState?: StateStack;
@@ -47,6 +47,10 @@ export class TextMateWorkerTokenizerController extends Disposable {
 		private readonly _maxTokenizationLineLength: IObservable<number>,
 	) {
 		super();
+		this.controllerId = TextMateWorkerTokenizerController._id++;
+		this._pendingChanges = [];
+		this._states = new TokenizationStateStore<StateStack>();
+		this._loggingEnabled = observableConfigValue('editor.experimental.asyncTokenizationLogging', false, this._configurationService);
 
 		this._register(keepObserved(this._loggingEnabled));
 

--- a/src/vs/workbench/services/textMate/browser/textMateTokenizationFeatureImpl.ts
+++ b/src/vs/workbench/services/textMate/browser/textMateTokenizationFeatureImpl.ts
@@ -44,22 +44,18 @@ export class TextMateTokenizationFeature extends Disposable implements ITextMate
 	public _serviceBrand: undefined;
 
 	private readonly _styleElement: HTMLStyleElement;
-	private readonly _createdModes: string[] = [];
-	private readonly _encounteredLanguages: boolean[] = [];
+	private readonly _createdModes: string[];
+	private readonly _encounteredLanguages: boolean[];
 
-	private _debugMode: boolean = false;
-	private _debugModePrintFunc: (str: string) => void = () => { };
+	private _debugMode: boolean;
+	private _debugModePrintFunc: (str: string) => void;
 
-	private _grammarDefinitions: IValidGrammarDefinition[] | null = null;
-	private _grammarFactory: TMGrammarFactory | null = null;
-	private readonly _tokenizersRegistrations = this._register(new DisposableStore());
-	private _currentTheme: IRawTheme | null = null;
-	private _currentTokenColorMap: string[] | null = null;
-	private readonly _threadedBackgroundTokenizerFactory = this._instantiationService.createInstance(
-		ThreadedBackgroundTokenizerFactory,
-		(timeMs, languageId, sourceExtensionId, lineLength, isRandomSample) => this._reportTokenizationTime(timeMs, languageId, sourceExtensionId, lineLength, true, isRandomSample),
-		() => this.getAsyncTokenizationEnabled(),
-	);
+	private _grammarDefinitions: IValidGrammarDefinition[] | null;
+	private _grammarFactory: TMGrammarFactory | null;
+	private readonly _tokenizersRegistrations;
+	private _currentTheme: IRawTheme | null;
+	private _currentTokenColorMap: string[] | null;
+	private readonly _threadedBackgroundTokenizerFactory;
 
 	constructor(
 		@ILanguageService private readonly _languageService: ILanguageService,
@@ -74,6 +70,21 @@ export class TextMateTokenizationFeature extends Disposable implements ITextMate
 		@ITelemetryService private readonly _telemetryService: ITelemetryService,
 	) {
 		super();
+		this._createdModes = [];
+		this._encounteredLanguages = [];
+		this._debugMode = false;
+		this._debugModePrintFunc = () => { };
+		this._grammarDefinitions = null;
+		this._grammarFactory = null;
+		this._tokenizersRegistrations = this._register(new DisposableStore());
+		this._currentTheme = null;
+		this._currentTokenColorMap = null;
+		this._threadedBackgroundTokenizerFactory = this._instantiationService.createInstance(
+			ThreadedBackgroundTokenizerFactory,
+			(timeMs, languageId, sourceExtensionId, lineLength, isRandomSample) => this._reportTokenizationTime(timeMs, languageId, sourceExtensionId, lineLength, true, isRandomSample),
+			() => this.getAsyncTokenizationEnabled(),
+		);
+		this._vscodeOniguruma = null;
 
 		this._styleElement = domStylesheets.createStyleSheet();
 		this._styleElement.className = 'vscode-tokens-styles';
@@ -354,7 +365,7 @@ export class TextMateTokenizationFeature extends Disposable implements ITextMate
 		return grammar;
 	}
 
-	private _vscodeOniguruma: Promise<typeof import('vscode-oniguruma')> | null = null;
+	private _vscodeOniguruma: Promise<typeof import('vscode-oniguruma')> | null;
 	private _getVSCodeOniguruma(): Promise<typeof import('vscode-oniguruma')> {
 		if (!this._vscodeOniguruma) {
 			this._vscodeOniguruma = (async () => {


### PR DESCRIPTION
Prepare for property initialisation order changes. Fixes #243049

The changes were produced by an automated refactoring tool and the PR was created by an AI. @hediet verified that the js in the out folder before and after this change stays the same (only some comments in the outputted JS disappeared).