### PR TITLE
Fix property initialization order in Alex Dima's files

### DIFF
--- a/src/vs/editor/browser/view/viewLayer.ts
+++ b/src/vs/editor/browser/view/viewLayer.ts
@@ -252,13 +252,15 @@ export class RenderedLinesCollection<T extends ILine> {
 
 export class VisibleLinesCollection<T extends IVisibleLine> {
 
-	public readonly domNode: FastDomNode<HTMLElement> = this._createDomNode();
-	private readonly _linesCollection: RenderedLinesCollection<T> = new RenderedLinesCollection<T>(this._lineFactory);
+	public readonly domNode: FastDomNode<HTMLElement>;
+	private readonly _linesCollection: RenderedLinesCollection<T>;
 
 	constructor(
 		private readonly _viewContext: ViewContext,
 		private readonly _lineFactory: ILineFactory<T>,
 	) {
+		this.domNode = this._createDomNode();
+		this._linesCollection = new RenderedLinesCollection<T>(this._lineFactory);
 	}
 
 	private _createDomNode(): FastDomNode<HTMLElement> {


### PR DESCRIPTION
Prepare for property initialisation order changes. Fixes #243049

The changes were produced by an automated refactoring tool and the PR was created by an AI. @hediet verified that the js in the out folder before and after this change stays the same (only some comments in the outputted JS disappeared).