### PR TITLE
Fix property initialization order in meganrogge's files

### DIFF
--- a/src/vs/platform/accessibilitySignal/browser/accessibilitySignalService.ts
+++ b/src/vs/platform/accessibilitySignal/browser/accessibilitySignalService.ts
@@ -65,12 +65,9 @@ export interface IAccessbilitySignalOptions {
 
 export class AccessibilitySignalService extends Disposable implements IAccessibilitySignalService {
 	readonly _serviceBrand: undefined;
-	private readonly sounds: Map<string, HTMLAudioElement> = new Map();
-	private readonly screenReaderAttached = observableFromEvent(this,
-		this.accessibilityService.onDidChangeScreenReaderOptimized,
-		() => /** @description accessibilityService.onDidChangeScreenReaderOptimized */ this.accessibilityService.isScreenReaderOptimized()
-	);
-	private readonly sentTelemetry = new Set<string>();
+	private readonly sounds: Map<string, HTMLAudioElement>;
+	private readonly screenReaderAttached;
+	private readonly sentTelemetry;
 
 	constructor(
 		@IConfigurationService private readonly configurationService: IConfigurationService,
@@ -78,6 +75,38 @@ export class AccessibilitySignalService extends Disposable implements IAccessibi
 		@ITelemetryService private readonly telemetryService: ITelemetryService,
 	) {
 		super();
+		this.sounds = new Map();
+		this.screenReaderAttached = observableFromEvent(this,
+			this.accessibilityService.onDidChangeScreenReaderOptimized,
+			() => /** @description accessibilityService.onDidChangeScreenReaderOptimized */ this.accessibilityService.isScreenReaderOptimized()
+		);
+		this.sentTelemetry = new Set<string>();
+		this.playingSounds = new Set<Sound>();
+		this._signalConfigValue = new CachedFunction((signal: AccessibilitySignal) => observableConfigValue<{
+			sound: EnabledState;
+			announcement: EnabledState;
+		}>(signal.settingsKey, { sound: 'off', announcement: 'off' }, this.configurationService));
+		this._signalEnabledState = new CachedFunction(
+			{ getCacheKey: getStructuralKey },
+			(arg: { signal: AccessibilitySignal; userGesture: boolean; modality?: AccessibilityModality | undefined }) => {
+				return derived(reader => {
+					/** @description sound enabled */
+					const setting = this._signalConfigValue.get(arg.signal).read(reader);
+
+					if (arg.modality === 'sound' || arg.modality === undefined) {
+						if (checkEnabledState(setting.sound, () => this.screenReaderAttached.read(reader), arg.userGesture)) {
+							return true;
+						}
+					}
+					if (arg.modality === 'announcement' || arg.modality === undefined) {
+						if (checkEnabledState(setting.announcement, () => this.screenReaderAttached.read(reader), arg.userGesture)) {
+							return true;
+						}
+					}
+					return false;
+				}).recomputeInitiallyAndOnChange(this._store);
+			}
+		);
 	}
 
 	public getEnabledState(signal: AccessibilitySignal, userGesture: boolean, modality?: AccessibilityModality | undefined): IValueWithChangeEvent<boolean> {
@@ -152,7 +181,7 @@ export class AccessibilitySignalService extends Disposable implements IAccessibi
 		return Math.max(Math.min(volume, 100), 0);
 	}
 
-	private readonly playingSounds = new Set<Sound>();
+	private readonly playingSounds;
 
 	public async playSound(sound: Sound, allowManyInParallel = false): Promise<void> {
 		if (!allowManyInParallel && this.playingSounds.has(sound)) {
@@ -198,32 +227,9 @@ export class AccessibilitySignalService extends Disposable implements IAccessibi
 		return toDisposable(() => playing = false);
 	}
 
-	private readonly _signalConfigValue = new CachedFunction((signal: AccessibilitySignal) => observableConfigValue<{
-		sound: EnabledState;
-		announcement: EnabledState;
-	}>(signal.settingsKey, { sound: 'off', announcement: 'off' }, this.configurationService));
+	private readonly _signalConfigValue;
 
-	private readonly _signalEnabledState = new CachedFunction(
-		{ getCacheKey: getStructuralKey },
-		(arg: { signal: AccessibilitySignal; userGesture: boolean; modality?: AccessibilityModality | undefined }) => {
-			return derived(reader => {
-				/** @description sound enabled */
-				const setting = this._signalConfigValue.get(arg.signal).read(reader);
-
-				if (arg.modality === 'sound' || arg.modality === undefined) {
-					if (checkEnabledState(setting.sound, () => this.screenReaderAttached.read(reader), arg.userGesture)) {
-						return true;
-					}
-				}
-				if (arg.modality === 'announcement' || arg.modality === undefined) {
-					if (checkEnabledState(setting.announcement, () => this.screenReaderAttached.read(reader), arg.userGesture)) {
-						return true;
-					}
-				}
-				return false;
-			}).recomputeInitiallyAndOnChange(this._store);
-		}
-	);
+	private readonly _signalEnabledState;
 
 	public isAnnouncementEnabled(signal: AccessibilitySignal, userGesture?: boolean): boolean {
 		if (!signal.announcementMessage) {


### PR DESCRIPTION
Prepare for property initialisation order changes. Fixes #243049

The changes were produced by an automated refactoring tool and the PR was created by an AI. @hediet verified that the js in the out folder before and after this change stays the same (only some comments in the outputted JS disappeared).