### PR TITLE
fix suggestions for git bash

### DIFF
--- a/extensions/terminal-suggest/src/env/pathExecutableCache.ts
+++ b/extensions/terminal-suggest/src/env/pathExecutableCache.ts
@@ -101,11 +101,6 @@ export class PathExecutableCache implements vscode.Disposable {
 
 	private async _getFilesInPath(path: string, pathSeparator: string, labels: Set<string>): Promise<Set<ICompletionResource> | undefined> {
 		try {
-			const stat = await fs.stat(path);
-			if (!stat.isDirectory()) {
-				return undefined;
-			}
-
 			const result = new Set<ICompletionResource>();
 			const fileResource = vscode.Uri.file(path);
 			const files = await vscode.workspace.fs.readDirectory(fileResource);

--- a/extensions/terminal-suggest/src/env/pathExecutableCache.ts
+++ b/extensions/terminal-suggest/src/env/pathExecutableCache.ts
@@ -62,7 +62,7 @@ export class PathExecutableCache implements vscode.Disposable {
 		}
 
 		// Check cache
-		if (this._cachedExes && this._cachedPathValue === pathValue) {
+		if (this._cachedExes && this._cachedPathValue === pathValue && this._cachedExes.labels?.size) {
 			return this._cachedExes;
 		}
 

--- a/extensions/terminal-suggest/src/terminalSuggestMain.ts
+++ b/extensions/terminal-suggest/src/terminalSuggestMain.ts
@@ -105,7 +105,7 @@ export async function activate(context: vscode.ExtensionContext) {
 				return;
 			}
 
-			const commandsInPath = await pathExecutableCache.getExecutablesInPath(terminal.shellIntegration?.env?.value);
+			const commandsInPath = await pathExecutableCache.getExecutablesInPath(terminal.shellIntegration?.env?.value, terminalShellType);
 			const shellGlobals = await getShellGlobals(terminalShellType, commandsInPath?.labels) ?? [];
 			if (!commandsInPath?.completionResources) {
 				console.debug('#terminalCompletions No commands found in path');
@@ -114,7 +114,7 @@ export async function activate(context: vscode.ExtensionContext) {
 			// Order is important here, add shell globals first so they are prioritized over path commands
 			const commands = [...shellGlobals, ...commandsInPath.completionResources];
 			const prefix = getPrefix(terminalContext.commandLine, terminalContext.cursorPosition);
-			const pathSeparator = isWindows ? '\\' : '/';
+			const pathSeparator = isWindows && terminalShellType !== TerminalShellType.GitBash ? '\\' : '/';
 			const tokenType = getTokenType(terminalContext, terminalShellType);
 			const result = await Promise.race([
 				getCompletionItemsFromSpecs(


### PR DESCRIPTION
fixes #245843

When we started using the new shell API #245843, we were passing `gitbash` as the `shell` to `exec` and that's not a valid shell.


Additionally, the `PATH` for Git Bash uses `/` and `:` and we were trying to parse paths from it using `\` and `;`. It's unclear to me how that was ever working before, but was in 1.98 somehow. 

Also, we were calling `fs.stat`, which I've learned is bad as it can block the extension host. That was a redundant check anyway as we already try to resolve the directory from the provided path for the workspace and it was causing issues.

Lastly, we were not checking the size of the `_cachedExes` before, so this was returning the empty result after I made this fix.

<img width="764" alt="{1ECB17A9-0D70-49B2-BB61-6CCBDEACDADA}" src="https://github.com/user-attachments/assets/accb733e-062d-4582-afd7-2dd5aa713ce2" />

