### PR TITLE
Fix property initialization order in isidor's files

### DIFF
--- a/src/vs/workbench/contrib/files/browser/views/openEditorsView.ts
+++ b/src/vs/workbench/contrib/files/browser/views/openEditorsView.ts
@@ -638,8 +638,8 @@ class EditorGroupRenderer implements IListRenderer<IEditorGroup, IEditorGroupTem
 class OpenEditorRenderer implements IListRenderer<OpenEditor, IOpenEditorTemplateData> {
 	static readonly ID = 'openeditor';
 
-	private readonly closeEditorAction = this.instantiationService.createInstance(CloseEditorAction, CloseEditorAction.ID, CloseEditorAction.LABEL);
-	private readonly unpinEditorAction = this.instantiationService.createInstance(UnpinEditorAction, UnpinEditorAction.ID, UnpinEditorAction.LABEL);
+	private readonly closeEditorAction;
+	private readonly unpinEditorAction;
 
 	constructor(
 		private labels: ResourceLabels,
@@ -647,6 +647,8 @@ class OpenEditorRenderer implements IListRenderer<OpenEditor, IOpenEditorTemplat
 		private keybindingService: IKeybindingService,
 		private configurationService: IConfigurationService
 	) {
+		this.closeEditorAction = this.instantiationService.createInstance(CloseEditorAction, CloseEditorAction.ID, CloseEditorAction.LABEL);
+		this.unpinEditorAction = this.instantiationService.createInstance(UnpinEditorAction, UnpinEditorAction.ID, UnpinEditorAction.LABEL);
 		// noop
 	}
 


### PR DESCRIPTION
Prepare for property initialisation order changes. Fixes #243049

The changes were produced by an automated refactoring tool and the PR was created by an AI. @hediet verified that the js in the out folder before and after this change stays the same (only some comments in the outputted JS disappeared).