### PR TITLE
Fix property initialization order in rebornix's files

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/services/notebookServiceImpl.ts
+++ b/src/vs/workbench/contrib/notebook/browser/services/notebookServiceImpl.ts
@@ -524,8 +524,8 @@ export class NotebookService extends Disposable implements INotebookService {
 	private readonly _memento: Memento;
 	private readonly _viewTypeCache: MementoObject;
 
-	private readonly _notebookProviders = new Map<string, SimpleNotebookProviderInfo>();
-	private _notebookProviderInfoStore: NotebookProviderInfoStore | undefined = undefined;
+	private readonly _notebookProviders;
+	private _notebookProviderInfoStore: NotebookProviderInfoStore | undefined;
 	private get notebookProviderInfoStore(): NotebookProviderInfoStore {
 		if (!this._notebookProviderInfoStore) {
 			this._notebookProviderInfoStore = this._register(this._instantiationService.createInstance(NotebookProviderInfoStore));
@@ -533,35 +533,35 @@ export class NotebookService extends Disposable implements INotebookService {
 
 		return this._notebookProviderInfoStore;
 	}
-	private readonly _notebookRenderersInfoStore = this._instantiationService.createInstance(NotebookOutputRendererInfoStore);
-	private readonly _onDidChangeOutputRenderers = this._register(new Emitter<void>());
-	readonly onDidChangeOutputRenderers = this._onDidChangeOutputRenderers.event;
+	private readonly _notebookRenderersInfoStore;
+	private readonly _onDidChangeOutputRenderers;
+	readonly onDidChangeOutputRenderers;
 
-	private readonly _notebookStaticPreloadInfoStore = new Set<NotebookStaticPreloadInfo>();
+	private readonly _notebookStaticPreloadInfoStore;
 
-	private readonly _models = new ResourceMap<ModelData>();
+	private readonly _models;
 
-	private readonly _onWillAddNotebookDocument = this._register(new Emitter<NotebookTextModel>());
-	private readonly _onDidAddNotebookDocument = this._register(new Emitter<NotebookTextModel>());
-	private readonly _onWillRemoveNotebookDocument = this._register(new Emitter<NotebookTextModel>());
-	private readonly _onDidRemoveNotebookDocument = this._register(new Emitter<NotebookTextModel>());
+	private readonly _onWillAddNotebookDocument;
+	private readonly _onDidAddNotebookDocument;
+	private readonly _onWillRemoveNotebookDocument;
+	private readonly _onDidRemoveNotebookDocument;
 
-	readonly onWillAddNotebookDocument = this._onWillAddNotebookDocument.event;
-	readonly onDidAddNotebookDocument = this._onDidAddNotebookDocument.event;
-	readonly onDidRemoveNotebookDocument = this._onDidRemoveNotebookDocument.event;
-	readonly onWillRemoveNotebookDocument = this._onWillRemoveNotebookDocument.event;
+	readonly onWillAddNotebookDocument;
+	readonly onDidAddNotebookDocument;
+	readonly onDidRemoveNotebookDocument;
+	readonly onWillRemoveNotebookDocument;
 
-	private readonly _onAddViewType = this._register(new Emitter<string>());
-	readonly onAddViewType = this._onAddViewType.event;
+	private readonly _onAddViewType;
+	readonly onAddViewType;
 
-	private readonly _onWillRemoveViewType = this._register(new Emitter<string>());
-	readonly onWillRemoveViewType = this._onWillRemoveViewType.event;
+	private readonly _onWillRemoveViewType;
+	readonly onWillRemoveViewType;
 
-	private readonly _onDidChangeEditorTypes = this._register(new Emitter<void>());
-	onDidChangeEditorTypes: Event<void> = this._onDidChangeEditorTypes.event;
+	private readonly _onDidChangeEditorTypes;
+	onDidChangeEditorTypes: Event<void>;
 
 	private _cutItems: NotebookCellTextModel[] | undefined;
-	private _lastClipboardIsCopy: boolean = true;
+	private _lastClipboardIsCopy: boolean;
 
 	private _displayOrder!: MimeTypeDisplayOrder;
 
@@ -574,6 +574,28 @@ export class NotebookService extends Disposable implements INotebookService {
 		@INotebookDocumentService private readonly _notebookDocumentService: INotebookDocumentService
 	) {
 		super();
+		this._notebookProviders = new Map<string, SimpleNotebookProviderInfo>();
+		this._notebookProviderInfoStore = undefined;
+		this._notebookRenderersInfoStore = this._instantiationService.createInstance(NotebookOutputRendererInfoStore);
+		this._onDidChangeOutputRenderers = this._register(new Emitter<void>());
+		this.onDidChangeOutputRenderers = this._onDidChangeOutputRenderers.event;
+		this._notebookStaticPreloadInfoStore = new Set<NotebookStaticPreloadInfo>();
+		this._models = new ResourceMap<ModelData>();
+		this._onWillAddNotebookDocument = this._register(new Emitter<NotebookTextModel>());
+		this._onDidAddNotebookDocument = this._register(new Emitter<NotebookTextModel>());
+		this._onWillRemoveNotebookDocument = this._register(new Emitter<NotebookTextModel>());
+		this._onDidRemoveNotebookDocument = this._register(new Emitter<NotebookTextModel>());
+		this.onWillAddNotebookDocument = this._onWillAddNotebookDocument.event;
+		this.onDidAddNotebookDocument = this._onDidAddNotebookDocument.event;
+		this.onDidRemoveNotebookDocument = this._onDidRemoveNotebookDocument.event;
+		this.onWillRemoveNotebookDocument = this._onWillRemoveNotebookDocument.event;
+		this._onAddViewType = this._register(new Emitter<string>());
+		this.onAddViewType = this._onAddViewType.event;
+		this._onWillRemoveViewType = this._register(new Emitter<string>());
+		this.onWillRemoveViewType = this._onWillRemoveViewType.event;
+		this._onDidChangeEditorTypes = this._register(new Emitter<void>());
+		this.onDidChangeEditorTypes = this._onDidChangeEditorTypes.event;
+		this._lastClipboardIsCopy = true;
 
 		notebookRendererExtensionPoint.setHandler((renderers) => {
 			this._notebookRenderersInfoStore.clear();


### PR DESCRIPTION
Prepare for property initialisation order changes. Fixes #243049

The changes were produced by an automated refactoring tool and the PR was created by an AI. @hediet verified that the js in the out folder before and after this change stays the same (only some comments in the outputted JS disappeared).