### PR TITLE
Fix property initialization order in Benjamin Pasero's files

### DIFF
--- a/src/vs/workbench/contrib/search/common/cacheState.ts
+++ b/src/vs/workbench/contrib/search/common/cacheState.ts
@@ -17,7 +17,7 @@ enum LoadingPhase {
 
 export class FileQueryCacheState {
 
-	private readonly _cacheKey = defaultGenerator.nextId();
+	private readonly _cacheKey;
 	get cacheKey(): string {
 		if (this.loadingPhase === LoadingPhase.Loaded || !this.previousCacheState) {
 			return this._cacheKey;
@@ -38,9 +38,9 @@ export class FileQueryCacheState {
 		return isUpdating || !this.previousCacheState ? isUpdating : this.previousCacheState.isUpdating;
 	}
 
-	private readonly query = this.cacheQuery(this._cacheKey);
+	private readonly query;
 
-	private loadingPhase = LoadingPhase.Created;
+	private loadingPhase;
 	private loadPromise: Promise<void> | undefined;
 
 	constructor(
@@ -49,6 +49,9 @@ export class FileQueryCacheState {
 		private disposeFn: (cacheKey: string) => Promise<void>,
 		private previousCacheState: FileQueryCacheState | undefined
 	) {
+		this._cacheKey = defaultGenerator.nextId();
+		this.query = this.cacheQuery(this._cacheKey);
+		this.loadingPhase = LoadingPhase.Created;
 		if (this.previousCacheState) {
 			const current = Object.assign({}, this.query, { cacheKey: null });
 			const previous = Object.assign({}, this.previousCacheState.query, { cacheKey: null });


### PR DESCRIPTION
Prepare for property initialisation order changes. Fixes #243049

The changes were produced by an automated refactoring tool and the PR was created by an AI. @hediet verified that the js in the out folder before and after this change stays the same (only some comments in the outputted JS disappeared).