### PR TITLE
Fix property initialization order in Andrea Mah's files

### DIFF
--- a/src/vs/workbench/api/common/extHostSearch.ts
+++ b/src/vs/workbench/api/common/extHostSearch.ts
@@ -31,25 +31,35 @@ export const IExtHostSearch = createDecorator<IExtHostSearch>('IExtHostSearch');
 
 export class ExtHostSearch implements IExtHostSearch {
 
-	protected readonly _proxy: MainThreadSearchShape = this.extHostRpc.getProxy(MainContext.MainThreadSearch);
-	protected _handlePool: number = 0;
+	protected readonly _proxy: MainThreadSearchShape;
+	protected _handlePool: number;
 
-	private readonly _textSearchProvider = new Map<number, vscode.TextSearchProvider2>();
-	private readonly _textSearchUsedSchemes = new Set<string>();
+	private readonly _textSearchProvider;
+	private readonly _textSearchUsedSchemes;
 
-	private readonly _aiTextSearchProvider = new Map<number, vscode.AITextSearchProvider>();
-	private readonly _aiTextSearchUsedSchemes = new Set<string>();
+	private readonly _aiTextSearchProvider;
+	private readonly _aiTextSearchUsedSchemes;
 
-	private readonly _fileSearchProvider = new Map<number, vscode.FileSearchProvider2>();
-	private readonly _fileSearchUsedSchemes = new Set<string>();
+	private readonly _fileSearchProvider;
+	private readonly _fileSearchUsedSchemes;
 
-	private readonly _fileSearchManager = new FileSearchManager();
+	private readonly _fileSearchManager;
 
 	constructor(
 		@IExtHostRpcService private extHostRpc: IExtHostRpcService,
 		@IURITransformerService protected _uriTransformer: IURITransformerService,
 		@ILogService protected _logService: ILogService,
-	) { }
+	) {
+		this._proxy = this.extHostRpc.getProxy(MainContext.MainThreadSearch);
+		this._handlePool = 0;
+		this._textSearchProvider = new Map<number, vscode.TextSearchProvider2>();
+		this._textSearchUsedSchemes = new Set<string>();
+		this._aiTextSearchProvider = new Map<number, vscode.AITextSearchProvider>();
+		this._aiTextSearchUsedSchemes = new Set<string>();
+		this._fileSearchProvider = new Map<number, vscode.FileSearchProvider2>();
+		this._fileSearchUsedSchemes = new Set<string>();
+		this._fileSearchManager = new FileSearchManager();
+	}
 
 	protected _transformScheme(scheme: string): string {
 		return this._uriTransformer.transformOutgoingScheme(scheme);

--- a/src/vs/workbench/api/common/extHostSearch.ts
+++ b/src/vs/workbench/api/common/extHostSearch.ts
@@ -34,16 +34,16 @@ export class ExtHostSearch implements IExtHostSearch {
 	protected readonly _proxy: MainThreadSearchShape;
 	protected _handlePool: number;
 
-	private readonly _textSearchProvider;
-	private readonly _textSearchUsedSchemes;
+	private readonly _textSearchProvider: Map<number, vscode.TextSearchProvider2>;
+	private readonly _textSearchUsedSchemes: Set<string>;
 
-	private readonly _aiTextSearchProvider;
-	private readonly _aiTextSearchUsedSchemes;
+	private readonly _aiTextSearchProvider: Map<number, vscode.AITextSearchProvider>;
+	private readonly _aiTextSearchUsedSchemes: Set<string>;
 
-	private readonly _fileSearchProvider;
-	private readonly _fileSearchUsedSchemes;
+	private readonly _fileSearchProvider: Map<number, vscode.FileSearchProvider2>;
+	private readonly _fileSearchUsedSchemes: Set<string>;
 
-	private readonly _fileSearchManager;
+	private readonly _fileSearchManager: FileSearchManager;
 
 	constructor(
 		@IExtHostRpcService private extHostRpc: IExtHostRpcService,
@@ -229,4 +229,3 @@ export function reviveQuery<U extends IRawQuery>(rawQuery: U): U extends IRawTex
 function reviveFolderQuery(rawFolderQuery: IFolderQuery<UriComponents>): IFolderQuery<URI> {
 	return revive(rawFolderQuery);
 }
-


### PR DESCRIPTION
Prepare for property initialisation order changes. Fixes #243049

The changes were produced by an automated refactoring tool and the PR was created by an AI. @hediet verified that the js in the out folder before and after this change stays the same (only some comments in the outputted JS disappeared).