### PR TITLE
debt - introduce `IChatContextPickService` to drive the "Add Context..." picker

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/actions/chatContext.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatContext.ts
@@ -1,0 +1,289 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import { CancellationToken } from '../../../../../base/common/cancellation.js';
+import { Codicon } from '../../../../../base/common/codicons.js';
+import { Disposable } from '../../../../../base/common/lifecycle.js';
+import { isElectron } from '../../../../../base/common/platform.js';
+import { dirname } from '../../../../../base/common/resources.js';
+import { ThemeIcon } from '../../../../../base/common/themables.js';
+import { localize } from '../../../../../nls.js';
+import { IClipboardService } from '../../../../../platform/clipboard/common/clipboardService.js';
+import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
+import { ILabelService } from '../../../../../platform/label/common/label.js';
+import { IQuickPickSeparator } from '../../../../../platform/quickinput/common/quickInput.js';
+import { IWorkbenchContribution } from '../../../../common/contributions.js';
+import { EditorResourceAccessor, SideBySideEditor } from '../../../../common/editor.js';
+import { DiffEditorInput } from '../../../../common/editor/diffEditorInput.js';
+import { IEditorService } from '../../../../services/editor/common/editorService.js';
+import { IHostService } from '../../../../services/host/browser/host.js';
+import { UntitledTextEditorInput } from '../../../../services/untitled/common/untitledTextEditorInput.js';
+import { FileEditorInput } from '../../../files/browser/editors/fileEditorInput.js';
+import { NotebookEditorInput } from '../../../notebook/common/notebookEditorInput.js';
+import { IChatContextPickService, IChatContextValueItem, IChatContextPickerItem, IChatContextPickerPickItem } from '../chatContextPickService.js';
+import { IChatEditingService } from '../../common/chatEditingService.js';
+import { IChatRequestToolEntry, IChatRequestVariableEntry, IImageVariableEntry, OmittedState } from '../../common/chatModel.js';
+import { IToolData } from '../../common/languageModelToolsService.js';
+import { IChatWidget } from '../chat.js';
+import { imageToHash, isImage } from '../chatPasteProviders.js';
+import { convertBufferToScreenshotVariable } from '../contrib/screenshot.js';
+import { ChatInstructionsPickerPick } from './promptActions/chatAttachInstructionsAction.js';
+
+
+export class ChatContextContributions extends Disposable implements IWorkbenchContribution {
+
+	static readonly ID = 'chat.contextContributions';
+
+	constructor(
+		@IInstantiationService instantiationService: IInstantiationService,
+		@IChatContextPickService contextPickService: IChatContextPickService,
+	) {
+		super();
+
+		// ###############################################################################################
+		//
+		// Default context picks/values which are "native" to chat. This is NOT the complete list
+		// and feature area specific context, like for notebooks, problems, etc, should be contributed
+		// by the feature area.
+		//
+		// ###############################################################################################
+
+		this._store.add(contextPickService.registerChatContextItem(instantiationService.createInstance(ToolsContextPickerPick)));
+		this._store.add(contextPickService.registerChatContextItem(instantiationService.createInstance(ChatInstructionsPickerPick)));
+		this._store.add(contextPickService.registerChatContextItem(instantiationService.createInstance(OpenEditorContextValuePick)));
+		this._store.add(contextPickService.registerChatContextItem(instantiationService.createInstance(RelatedFilesContextPickerPick)));
+		this._store.add(contextPickService.registerChatContextItem(instantiationService.createInstance(ClipboardImageContextValuePick)));
+		this._store.add(contextPickService.registerChatContextItem(instantiationService.createInstance(ScreenshotContextValuePick)));
+	}
+}
+
+class ToolsContextPickerPick implements IChatContextPickerItem {
+
+	readonly type = 'pickerPick';
+	readonly label: string = localize('chatContext.tools', 'Tools...');
+	readonly icon: ThemeIcon = Codicon.tools;
+	readonly ordinal = -500;
+
+	asPicker(widget: IChatWidget): {
+		readonly placeholder: string;
+		readonly picks: Promise<(IChatContextPickerPickItem | IQuickPickSeparator)[]>;
+	} {
+
+		type Pick = IChatContextPickerPickItem & { ordinal: number; groupLabel: string };
+		const items: Pick[] = [];
+
+		for (const tool of widget.input.selectedToolsModel.tools.get()) {
+			if (!tool.canBeReferencedInPrompt) {
+				continue;
+			}
+			const item: Pick = {
+				...this._classify(tool),
+				label: tool.toolReferenceName ?? tool.id,
+				description: (tool.toolReferenceName ?? tool.id) !== tool.displayName ? tool.displayName : undefined,
+				asAttachment: (): IChatRequestToolEntry => {
+					return {
+						kind: 'tool',
+						id: tool.id,
+						name: tool.displayName,
+						fullName: tool.displayName,
+						value: undefined,
+					};
+				}
+			};
+
+			items.push(item);
+		}
+
+		items.sort((a, b) => {
+			let res = a.ordinal - b.ordinal;
+			if (res === 0) {
+				res = a.label.localeCompare(b.label);
+			}
+			return res;
+		});
+
+		let lastGroupLabel: string | undefined;
+		const picks: (IQuickPickSeparator | Pick)[] = [];
+
+
+		for (const item of items) {
+			if (lastGroupLabel !== item.groupLabel) {
+				picks.push({ type: 'separator', label: item.groupLabel });
+				lastGroupLabel = item.groupLabel;
+			}
+			picks.push(item);
+		}
+
+		return {
+			placeholder: localize('chatContext.tools.placeholder', 'Select a tool'),
+			picks: Promise.resolve(picks)
+		};
+
+	}
+
+	private _classify(tool: IToolData) {
+		if (tool.source.type === 'internal' || tool.source.type === 'extension' && !tool.source.isExternalTool) {
+			return { ordinal: 1, groupLabel: localize('chatContext.tools.internal', 'Built-In') };
+		} else if (tool.source.type === 'mcp') {
+			return { ordinal: 2, groupLabel: localize('chatContext.tools.mcp', 'MCP Servers') };
+		} else {
+			return { ordinal: 3, groupLabel: localize('chatContext.tools.extension', 'Extensions') };
+		}
+	}
+}
+
+
+
+class OpenEditorContextValuePick implements IChatContextValueItem {
+
+	readonly type = 'valuePick';
+	readonly label: string = localize('chatContext.editors', 'Open Editors');
+	readonly icon: ThemeIcon = Codicon.file;
+	readonly ordinal = 800;
+
+	constructor(
+		@IEditorService private _editorService: IEditorService,
+		@ILabelService private _labelService: ILabelService,
+	) { }
+
+	isEnabled(): Promise<boolean> | boolean {
+		return this._editorService.editors.filter(e => e instanceof FileEditorInput || e instanceof DiffEditorInput || e instanceof UntitledTextEditorInput).length > 0;
+	}
+
+	async asAttachment(): Promise<IChatRequestVariableEntry[]> {
+		const result: IChatRequestVariableEntry[] = [];
+		for (const editor of this._editorService.editors) {
+			if (!(editor instanceof FileEditorInput || editor instanceof DiffEditorInput || editor instanceof UntitledTextEditorInput || editor instanceof NotebookEditorInput)) {
+				continue;
+			}
+			const uri = EditorResourceAccessor.getOriginalUri(editor, { supportSideBySide: SideBySideEditor.PRIMARY });
+			if (!uri) {
+				continue;
+			}
+			result.push({
+				kind: 'file',
+				id: uri.toString(),
+				value: uri,
+				name: this._labelService.getUriBasenameLabel(uri),
+			});
+		}
+		return result;
+	}
+
+}
+
+class RelatedFilesContextPickerPick implements IChatContextPickerItem {
+
+	readonly type = 'pickerPick';
+
+	readonly label: string = localize('chatContext.relatedFiles', 'Related Files');
+	readonly icon: ThemeIcon = Codicon.sparkle;
+	readonly ordinal = 300;
+
+	constructor(
+		@IChatEditingService private readonly _chatEditingService: IChatEditingService,
+		@ILabelService private readonly _labelService: ILabelService,
+	) { }
+
+	isEnabled(widget: IChatWidget): boolean {
+		return this._chatEditingService.hasRelatedFilesProviders() && (Boolean(widget.getInput()) || widget.attachmentModel.fileAttachments.length > 0);
+	}
+
+	asPicker(widget: IChatWidget): {
+		readonly placeholder: string;
+		readonly picks: Promise<(IChatContextPickerPickItem | IQuickPickSeparator)[]>;
+	} {
+
+		const picks = (async () => {
+			const chatSessionId = widget.viewModel?.sessionId;
+			if (!chatSessionId) {
+				return [];
+			}
+			const relatedFiles = await this._chatEditingService.getRelatedFiles(chatSessionId, widget.getInput(), widget.attachmentModel.fileAttachments, CancellationToken.None);
+			if (!relatedFiles) {
+				return [];
+			}
+			const attachments = widget.attachmentModel.getAttachmentIDs();
+			return this._chatEditingService.getRelatedFiles(chatSessionId, widget.getInput(), widget.attachmentModel.fileAttachments, CancellationToken.None)
+				.then((files) => (files ?? []).reduce<(IChatContextPickerPickItem | IQuickPickSeparator)[]>((acc, cur) => {
+					acc.push({ type: 'separator', label: cur.group });
+					for (const file of cur.files) {
+						const label = this._labelService.getUriBasenameLabel(file.uri);
+						acc.push({
+							label: label,
+							description: this._labelService.getUriLabel(dirname(file.uri), { relative: true }),
+							disabled: attachments.has(file.uri.toString()),
+							asAttachment: () => {
+								return {
+									kind: 'file',
+									id: file.uri.toString(),
+									value: file.uri,
+									name: label,
+									omittedState: OmittedState.NotOmitted
+								};
+							}
+						});
+					}
+					return acc;
+				}, []));
+		})();
+
+		return {
+			placeholder: localize('relatedFiles', 'Add related files to your working set'),
+			picks,
+		};
+	}
+}
+
+
+class ClipboardImageContextValuePick implements IChatContextValueItem {
+	readonly type = 'valuePick';
+	readonly label = localize('imageFromClipboard', 'Image from Clipboard');
+	readonly icon = Codicon.fileMedia;
+
+	constructor(
+		@IClipboardService private readonly _clipboardService: IClipboardService,
+	) { }
+
+	async isEnabled(widget: IChatWidget) {
+		if (!widget.input.selectedLanguageModel?.metadata.capabilities?.vision) {
+			return false;
+		}
+		const imageData = await this._clipboardService.readImage();
+		return isImage(imageData);
+	}
+
+	async asAttachment(): Promise<IImageVariableEntry> {
+		const fileBuffer = await this._clipboardService.readImage();
+		return {
+			id: await imageToHash(fileBuffer),
+			name: localize('pastedImage', 'Pasted Image'),
+			fullName: localize('pastedImage', 'Pasted Image'),
+			value: fileBuffer,
+			kind: 'image',
+		};
+	}
+}
+
+class ScreenshotContextValuePick implements IChatContextValueItem {
+
+	readonly type = 'valuePick';
+	readonly icon = Codicon.deviceCamera;
+	readonly label = (isElectron
+		? localize('chatContext.attachScreenshot.labelElectron.Window', 'Screenshot Window')
+		: localize('chatContext.attachScreenshot.labelWeb', 'Screenshot'));
+
+	constructor(
+		@IHostService private readonly _hostService: IHostService,
+	) { }
+
+	async isEnabled(widget: IChatWidget) {
+		return !!widget.input.selectedLanguageModel?.metadata.capabilities?.vision;
+	}
+
+	async asAttachment(): Promise<IChatRequestVariableEntry | undefined> {
+		const blob = await this._hostService.getScreenshot();
+		return blob && convertBufferToScreenshotVariable(blob);
+	}
+}

--- a/src/vs/workbench/contrib/chat/browser/actions/chatContextActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatContextActions.ts
@@ -3,69 +3,47 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { groupBy } from '../../../../../base/common/arrays.js';
-import { CancellationToken } from '../../../../../base/common/cancellation.js';
+import { DeferredPromise, isThenable, raceCancellationError } from '../../../../../base/common/async.js';
+import { CancellationTokenSource } from '../../../../../base/common/cancellation.js';
 import { Codicon } from '../../../../../base/common/codicons.js';
-import { ResolvedKeybinding } from '../../../../../base/common/keybindings.js';
 import { KeyCode, KeyMod } from '../../../../../base/common/keyCodes.js';
 import { DisposableStore } from '../../../../../base/common/lifecycle.js';
 import { Schemas } from '../../../../../base/common/network.js';
-import { isElectron } from '../../../../../base/common/platform.js';
-import { basename, dirname, extUri } from '../../../../../base/common/resources.js';
 import { ThemeIcon } from '../../../../../base/common/themables.js';
-import { WithUriValue } from '../../../../../base/common/types.js';
+import { assertType, isObject } from '../../../../../base/common/types.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { ServicesAccessor } from '../../../../../editor/browser/editorExtensions.js';
-import { IRange, Range } from '../../../../../editor/common/core/range.js';
-import { Command, SymbolKinds } from '../../../../../editor/common/languages.js';
+import { Range } from '../../../../../editor/common/core/range.js';
 import { ITextModelService } from '../../../../../editor/common/services/resolverService.js';
 import { AbstractGotoSymbolQuickAccessProvider, IGotoSymbolQuickPickItem } from '../../../../../editor/contrib/quickAccess/browser/gotoSymbolQuickAccess.js';
 import { localize, localize2 } from '../../../../../nls.js';
 import { Action2, MenuId, registerAction2 } from '../../../../../platform/actions/common/actions.js';
-import { IClipboardService } from '../../../../../platform/clipboard/common/clipboardService.js';
-import { ICommandService } from '../../../../../platform/commands/common/commands.js';
 import { ContextKeyExpr, IContextKeyService } from '../../../../../platform/contextkey/common/contextkey.js';
 import { IFileService } from '../../../../../platform/files/common/files.js';
 import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
 import { IKeybindingService } from '../../../../../platform/keybinding/common/keybinding.js';
 import { KeybindingWeight } from '../../../../../platform/keybinding/common/keybindingsRegistry.js';
-import { ILabelService } from '../../../../../platform/label/common/label.js';
 import { ILogService } from '../../../../../platform/log/common/log.js';
-import { IMarkerService, MarkerSeverity } from '../../../../../platform/markers/common/markers.js';
 import { AnythingQuickAccessProviderRunOptions } from '../../../../../platform/quickinput/common/quickAccess.js';
-import { IQuickInputService, IQuickPickItem, IQuickPickItemWithResource, IQuickPickSeparator, QuickPickItem } from '../../../../../platform/quickinput/common/quickInput.js';
+import { IQuickInputService, IQuickPickItem, IQuickPickItemWithResource, QuickPickItem } from '../../../../../platform/quickinput/common/quickInput.js';
 import { ActiveEditorContext, TextCompareEditorActiveContext } from '../../../../common/contextkeys.js';
 import { EditorResourceAccessor, SideBySideEditor } from '../../../../common/editor.js';
-import { DiffEditorInput } from '../../../../common/editor/diffEditorInput.js';
 import { IEditorService } from '../../../../services/editor/common/editorService.js';
-import { IHostService } from '../../../../services/host/browser/host.js';
-import { VIEW_ID as SEARCH_VIEW_ID } from '../../../../services/search/common/search.js';
-import { UntitledTextEditorInput } from '../../../../services/untitled/common/untitledTextEditorInput.js';
 import { IViewsService } from '../../../../services/views/common/viewsService.js';
-import { FileEditorInput } from '../../../files/browser/editors/fileEditorInput.js';
 import { TEXT_FILE_EDITOR_ID } from '../../../files/common/files.js';
-import { NotebookEditorInput } from '../../../notebook/common/notebookEditorInput.js';
 import { AnythingQuickAccessProvider } from '../../../search/browser/anythingQuickAccess.js';
 import { isSearchTreeFileMatch, isSearchTreeMatch } from '../../../search/browser/searchTreeModel/searchTreeCommon.js';
-import { SearchView } from '../../../search/browser/searchView.js';
 import { ISymbolQuickPickItem, SymbolsQuickAccessProvider } from '../../../search/browser/symbolsQuickAccess.js';
 import { SearchContext } from '../../../search/common/constants.js';
-import { IChatAgentService } from '../../common/chatAgents.js';
 import { ChatContextKeys } from '../../common/chatContextKeys.js';
-import { IChatEditingService } from '../../common/chatEditingService.js';
-import { IChatRequestVariableEntry, IDiagnosticVariableEntryFilterData, OmittedState } from '../../common/chatModel.js';
-import { ChatRequestAgentPart } from '../../common/chatParserTypes.js';
+import { IChatRequestVariableEntry, OmittedState } from '../../common/chatModel.js';
 import { ChatAgentLocation } from '../../common/constants.js';
-import { IToolData } from '../../common/languageModelToolsService.js';
 import { IChatWidget, IChatWidgetService, IQuickChatService, showChatView } from '../chat.js';
-import { imageToHash, isImage } from '../chatPasteProviders.js';
 import { isQuickChat } from '../chatWidget.js';
-import { createFilesAndFolderQuickPick } from '../contrib/chatDynamicVariables.js';
-import { convertBufferToScreenshotVariable, ScreenshotVariableId } from '../contrib/screenshot.js';
 import { resizeImage } from '../imageUtils.js';
-import { INSTRUCTIONS_COMMAND_ID } from '../promptSyntax/contributions/attachInstructionsCommand.js';
 import { CHAT_CATEGORY } from './chatActions.js';
-import { runAttachInstructionsAction, registerPromptActions } from './promptActions/index.js';
+import { IChatContextValueItem, IChatContextPickService, IChatContextPickerItem, isChatContextPickerPickItem } from '../chatContextPickService.js';
+import { registerPromptActions } from './promptActions/index.js';
 
 export function registerChatContextActions() {
 	registerAction2(AttachContextAction);
@@ -73,170 +51,7 @@ export function registerChatContextActions() {
 	registerAction2(AttachFolderToChatAction);
 	registerAction2(AttachSelectionToChatAction);
 	registerAction2(AttachSearchResultAction);
-}
-
-/**
- * We fill the quickpick with these types, and enable some quick access providers
- */
-type IAttachmentQuickPickItem = ICommandVariableQuickPickItem | IWorkspaceSymbolsQuickPickItem
-	| IToolsQuickPickItem | IToolQuickPickItem
-	| IImageQuickPickItem | IOpenEditorsQuickPickItem | ISearchResultsQuickPickItem
-	| IScreenShotQuickPickItem | IRelatedFilesQuickPickItem | IInstructionsQuickPickItem
-	| IFolderQuickPickItem | IFolderResultQuickPickItem
-	| IDiagnosticsQuickPickItem | IDiagnosticsQuickPickItemWithFilter;
-
-function isIAttachmentQuickPickItem(obj: unknown): obj is IAttachmentQuickPickItem {
-	return (
-		typeof obj === 'object'
-		&& obj !== null
-		&& typeof (<IAttachmentQuickPickItem>obj).kind === 'string'
-	);
-}
-
-const attachmentsOrdinals: (IAttachmentQuickPickItem['kind'])[] = [
-	// bottom-most
-	'tools',
-	'command',
-	'screenshot',
-	'image',
-	'workspaceSymbol',
-	'diagnostic',
-	'instructions',
-	'related-files',
-	'folder',
-	'open-editors',
-	// top-most
-];
-
-/**
- * These are the types that we can get out of the quick pick
- */
-type IChatContextQuickPickItem = IAttachmentQuickPickItem | IGotoSymbolQuickPickItem | ISymbolQuickPickItem | IQuickPickItemWithResource;
-
-function isIGotoSymbolQuickPickItem(obj: unknown): obj is IGotoSymbolQuickPickItem {
-	return (
-		typeof obj === 'object'
-		&& typeof (obj as IGotoSymbolQuickPickItem).symbolName === 'string'
-		&& !!(obj as IGotoSymbolQuickPickItem).uri
-		&& !!(obj as IGotoSymbolQuickPickItem).range);
-}
-
-function isISymbolQuickPickItem(obj: unknown): obj is ISymbolQuickPickItem {
-	return (
-		typeof obj === 'object'
-		&& typeof (obj as ISymbolQuickPickItem).symbol === 'object'
-		&& !!(obj as ISymbolQuickPickItem).symbol);
-}
-
-function isIQuickPickItemWithResource(obj: unknown): obj is IQuickPickItemWithResource {
-	return (
-		typeof obj === 'object'
-		&& typeof (obj as IQuickPickItemWithResource).resource === 'object'
-		&& URI.isUri((obj as IQuickPickItemWithResource).resource));
-}
-
-
-interface IToolsQuickPickItem extends IQuickPickItem {
-	kind: 'tools';
-	id: string;
-	label: string;
-}
-
-interface IRelatedFilesQuickPickItem extends IQuickPickItem {
-	kind: 'related-files';
-	id: string;
-	label: string;
-}
-
-interface IFolderQuickPickItem extends IQuickPickItem {
-	kind: 'folder';
-	id: string;
-	label: string;
-}
-
-interface IFolderResultQuickPickItem extends IQuickPickItem {
-	kind: 'folder-search-result';
-	id: string;
-	resource: URI;
-}
-
-interface IImageQuickPickItem extends IQuickPickItem {
-	kind: 'image';
-	id: string;
-}
-
-interface ICommandVariableQuickPickItem extends IQuickPickItem {
-	kind: 'command';
-	id: string;
-	command: Command;
-	name?: string;
-	value: unknown;
-	icon?: ThemeIcon;
-}
-
-interface IToolQuickPickItem extends IQuickPickItem {
-	kind: 'tool';
-	id: string;
-	name?: string;
-	icon?: ThemeIcon;
-	tool: IToolData;
-}
-
-interface IWorkspaceSymbolsQuickPickItem extends IQuickPickItem {
-	kind: 'workspaceSymbol';
-	id: string;
-}
-
-interface IOpenEditorsQuickPickItem extends IQuickPickItem {
-	kind: 'open-editors';
-	id: 'open-editors';
-	icon?: ThemeIcon;
-}
-
-interface ISearchResultsQuickPickItem extends IQuickPickItem {
-	kind: 'search-results';
-	id: string;
-	icon?: ThemeIcon;
-}
-
-interface IScreenShotQuickPickItem extends IQuickPickItem {
-	kind: 'screenshot';
-	id: string;
-	icon?: ThemeIcon;
-}
-
-interface IDiagnosticsQuickPickItem extends IQuickPickItem {
-	kind: 'diagnostic';
-	id: string;
-	icon?: ThemeIcon;
-}
-
-interface IDiagnosticsQuickPickItemWithFilter extends IQuickPickItem {
-	kind: 'diagnostic-filter';
-	id: string;
-	filter: IDiagnosticVariableEntryFilterData;
-	icon?: ThemeIcon;
-}
-
-/**
- * Quick pick item for instructions attachment.
- */
-const INSTRUCTION_PICK_ID = 'instructions';
-interface IInstructionsQuickPickItem extends IQuickPickItem {
-	/**
-	 * The ID of the quick pick item.
-	 */
-	id: typeof INSTRUCTION_PICK_ID;
-
-	/**
-	 * Unique kind identifier of the instructions attachment.
-	 */
-	kind: typeof INSTRUCTION_PICK_ID;
-
-	/**
-	 * Keybinding of the command.
-	 */
-	keybinding?: ResolvedKeybinding;
+	registerPromptActions();
 }
 
 abstract class AttachResourceAction extends Action2 {
@@ -444,6 +259,38 @@ export class AttachSearchResultAction extends Action2 {
 	}
 }
 
+/** This is our type */
+interface IContextPickItemItem extends IQuickPickItem {
+	kind: 'contextPick';
+	item: IChatContextValueItem | IChatContextPickerItem;
+}
+
+/** These are the types we get from "platform QP" */
+type IQuickPickServicePickItem = IGotoSymbolQuickPickItem | ISymbolQuickPickItem | IQuickPickItemWithResource;
+
+function isIContextPickItemItem(obj: unknown): obj is IContextPickItemItem {
+	return (
+		isObject(obj)
+		&& typeof (<IContextPickItemItem>obj).kind === 'string'
+		&& (<IContextPickItemItem>obj).kind === 'contextPick'
+	);
+}
+
+function isIGotoSymbolQuickPickItem(obj: unknown): obj is IGotoSymbolQuickPickItem {
+	return (
+		isObject(obj)
+		&& typeof (obj as IGotoSymbolQuickPickItem).symbolName === 'string'
+		&& !!(obj as IGotoSymbolQuickPickItem).uri
+		&& !!(obj as IGotoSymbolQuickPickItem).range);
+}
+
+function isIQuickPickItemWithResource(obj: unknown): obj is IQuickPickItemWithResource {
+	return (
+		isObject(obj)
+		&& URI.isUri((obj as IQuickPickItemWithResource).resource));
+}
+
+
 export class AttachContextAction extends Action2 {
 
 	constructor() {
@@ -466,216 +313,13 @@ export class AttachContextAction extends Action2 {
 		});
 	}
 
-	private _getFileContextId(item: { resource: URI } | { uri: URI; range: IRange }) {
-		if ('resource' in item) {
-			return item.resource.toString();
-		}
-
-		return item.uri.toString() + (item.range.startLineNumber !== item.range.endLineNumber ?
-			`:${item.range.startLineNumber}-${item.range.endLineNumber}` :
-			`:${item.range.startLineNumber}`);
-	}
-
-	private async _attachContext(accessor: ServicesAccessor, widget: IChatWidget, isInBackground?: boolean, ...picks: IChatContextQuickPickItem[]) {
-		const commandService = accessor.get(ICommandService);
-		const clipboardService = accessor.get(IClipboardService);
-		const editorService = accessor.get(IEditorService);
-		const labelService = accessor.get(ILabelService);
-		const viewsService = accessor.get(IViewsService);
-		const chatEditingService = accessor.get(IChatEditingService);
-		const hostService = accessor.get(IHostService);
-		const fileService = accessor.get(IFileService);
-		const textModelService = accessor.get(ITextModelService);
-		const quickInputService = accessor.get(IQuickInputService);
-		const toAttach: IChatRequestVariableEntry[] = [];
-		for (const pick of picks) {
-
-			if (isIAttachmentQuickPickItem(pick)) {
-				if (pick.kind === 'folder-search-result') {
-					toAttach.push({
-						kind: 'directory',
-						id: pick.id,
-						value: pick.resource,
-						name: basename(pick.resource),
-					});
-				} else if (pick.kind === 'diagnostic-filter') {
-					toAttach.push({
-						id: pick.id,
-						name: pick.label,
-						value: pick.filter,
-						kind: 'diagnostic',
-						icon: pick.icon,
-						...pick.filter,
-					});
-
-				} else if (pick.kind === 'open-editors') {
-					for (const editor of editorService.editors.filter(e => e instanceof FileEditorInput || e instanceof DiffEditorInput || e instanceof UntitledTextEditorInput || e instanceof NotebookEditorInput)) {
-						const uri = editor instanceof DiffEditorInput ? editor.modified.resource : editor.resource;
-						if (uri) {
-							toAttach.push({
-								kind: 'file',
-								id: this._getFileContextId({ resource: uri }),
-								value: uri,
-								name: labelService.getUriBasenameLabel(uri),
-							});
-						}
-					}
-				} else if (pick.kind === 'search-results') {
-					const searchView = viewsService.getViewWithId(SEARCH_VIEW_ID) as SearchView;
-					for (const result of searchView.model.searchResult.matches()) {
-						toAttach.push({
-							kind: 'file',
-							id: this._getFileContextId({ resource: result.resource }),
-							value: result.resource,
-							name: labelService.getUriBasenameLabel(result.resource),
-						});
-					}
-				} else if (pick.kind === 'related-files') {
-					// Get all provider results and show them in a second tier picker
-					const chatSessionId = widget.viewModel?.sessionId;
-					if (!chatSessionId || !chatEditingService) {
-						continue;
-					}
-					const relatedFiles = await chatEditingService.getRelatedFiles(chatSessionId, widget.getInput(), widget.attachmentModel.fileAttachments, CancellationToken.None);
-					if (!relatedFiles) {
-						continue;
-					}
-					const attachments = widget.attachmentModel.getAttachmentIDs();
-					const itemsPromise = chatEditingService.getRelatedFiles(chatSessionId, widget.getInput(), widget.attachmentModel.fileAttachments, CancellationToken.None)
-						.then((files) => (files ?? []).reduce<(WithUriValue<IQuickPickItem> | IQuickPickSeparator)[]>((acc, cur) => {
-							acc.push({ type: 'separator', label: cur.group });
-							for (const file of cur.files) {
-								acc.push({
-									type: 'item',
-									label: labelService.getUriBasenameLabel(file.uri),
-									description: labelService.getUriLabel(dirname(file.uri), { relative: true }),
-									value: file.uri,
-									disabled: attachments.has(this._getFileContextId({ resource: file.uri })),
-									picked: true
-								});
-							}
-							return acc;
-						}, []));
-					const selectedFile = await quickInputService.pick(itemsPromise, { placeHolder: localize('relatedFiles', 'Add related files to your working set') });
-					if (selectedFile) {
-						toAttach.push({
-							kind: 'file',
-							id: this._getFileContextId({ resource: selectedFile.value }),
-							value: selectedFile.value,
-							name: selectedFile.label,
-							omittedState: OmittedState.NotOmitted
-						});
-					}
-				} else if (pick.kind === 'screenshot') {
-					const blob = await hostService.getScreenshot();
-					if (blob) {
-						toAttach.push(convertBufferToScreenshotVariable(blob));
-					}
-				} else if (pick.kind === 'command') {
-					// Dynamic variable with a followup command
-					const selection = await commandService.executeCommand(pick.command.id, ...(pick.command.arguments ?? []));
-					if (!selection) {
-						// User made no selection, skip this variable
-						continue;
-					}
-					toAttach.push({
-						...pick,
-						value: pick.value,
-						name: `${typeof pick.value === 'string' && pick.value.startsWith('#') ? pick.value.slice(1) : ''}${selection}`,
-						// Apply the original icon with the new name
-						fullName: selection
-					});
-				} else if (pick.kind === 'tool') {
-					toAttach.push({
-						id: pick.id,
-						name: pick.tool.displayName,
-						fullName: pick.tool.displayName,
-						value: undefined,
-						icon: pick.icon,
-						kind: 'tool'
-					});
-				} else if (pick.kind === 'image') {
-					const fileBuffer = await clipboardService.readImage();
-					toAttach.push({
-						id: await imageToHash(fileBuffer),
-						name: localize('pastedImage', 'Pasted Image'),
-						fullName: localize('pastedImage', 'Pasted Image'),
-						value: fileBuffer,
-						kind: 'image',
-					});
-				}
-			} else if (isISymbolQuickPickItem(pick) && pick.symbol) {
-				// Workspace symbol
-				toAttach.push({
-					kind: 'symbol',
-					id: this._getFileContextId(pick.symbol.location),
-					value: pick.symbol.location,
-					symbolKind: pick.symbol.kind,
-					icon: SymbolKinds.toIcon(pick.symbol.kind),
-					fullName: pick.label,
-					name: pick.symbol.name,
-				});
-			} else if (isIQuickPickItemWithResource(pick) && pick.resource) {
-				if (/\.(png|jpg|jpeg|bmp|gif|tiff)$/i.test(pick.resource.path)) {
-					// checks if the file is an image
-					if (URI.isUri(pick.resource)) {
-						// read the image and attach a new file context.
-						const readFile = await fileService.readFile(pick.resource);
-						const resizedImage = await resizeImage(readFile.value.buffer);
-						toAttach.push({
-							id: pick.resource.toString(),
-							name: pick.label,
-							fullName: pick.label,
-							value: resizedImage,
-							kind: 'image',
-							references: [{ reference: pick.resource, kind: 'reference' }]
-						});
-					}
-				} else {
-					let omittedState = OmittedState.NotOmitted;
-					try {
-						const createdModel = await textModelService.createModelReference(pick.resource);
-						createdModel.dispose();
-					} catch {
-						omittedState = OmittedState.Full;
-					}
-
-					toAttach.push({
-						kind: 'file',
-						id: this._getFileContextId({ resource: pick.resource }),
-						value: pick.resource,
-						name: pick.label,
-						omittedState
-					});
-				}
-			} else if (isIGotoSymbolQuickPickItem(pick) && pick.uri && pick.range) {
-				toAttach.push({
-					kind: 'generic',
-					id: this._getFileContextId({ uri: pick.uri, range: pick.range.decoration }),
-					value: { uri: pick.uri, range: pick.range.decoration },
-					fullName: pick.label,
-					name: pick.symbolName!,
-				});
-			}
-		}
-
-		widget.attachmentModel.addContext(...toAttach);
-		if (!isInBackground) {
-			// Set focus back into the input once the user is done attaching items
-			// so that the user can start typing their message
-			widget.focusInput();
-		}
-	}
-
 	override async run(accessor: ServicesAccessor, ...args: any[]): Promise<void> {
-		const chatAgentService = accessor.get(IChatAgentService);
-		const widgetService = accessor.get(IChatWidgetService);
-		const clipboardService = accessor.get(IClipboardService);
-		const editorService = accessor.get(IEditorService);
-		const contextKeyService = accessor.get(IContextKeyService);
+
 		const instantiationService = accessor.get(IInstantiationService);
+		const widgetService = accessor.get(IChatWidgetService);
+		const contextKeyService = accessor.get(IContextKeyService);
 		const keybindingService = accessor.get(IKeybindingService);
-		const chatEditingService = accessor.get(IChatEditingService);
+		const contextPickService = accessor.get(IChatContextPickService);
 
 		const context: { widget?: IChatWidget; placeholder?: string } | undefined = args[0];
 		const widget = context?.widget ?? widgetService.lastFocusedWidget;
@@ -683,245 +327,62 @@ export class AttachContextAction extends Action2 {
 			return;
 		}
 
-		const quickPickItems: IAttachmentQuickPickItem[] = [];
-		if (widget.input.selectedLanguageModel?.metadata.capabilities?.vision) {
-			const imageData = await clipboardService.readImage();
-			if (isImage(imageData)) {
-				quickPickItems.push({
-					kind: 'image',
-					id: await imageToHash(imageData),
-					label: localize('imageFromClipboard', 'Image from Clipboard'),
-					iconClass: ThemeIcon.asClassName(Codicon.fileMedia),
-				});
+		const quickPickItems: IContextPickItemItem[] = [];
+
+		for (const item of contextPickService.items) {
+
+			if (item.isEnabled && !await item.isEnabled(widget)) {
+				continue;
 			}
 
 			quickPickItems.push({
-				kind: 'screenshot',
-				id: ScreenshotVariableId,
-				icon: ThemeIcon.fromId(Codicon.deviceCamera.id),
-				iconClass: ThemeIcon.asClassName(Codicon.deviceCamera),
-				label: (isElectron
-					? localize('chatContext.attachScreenshot.labelElectron.Window', 'Screenshot Window')
-					: localize('chatContext.attachScreenshot.labelWeb', 'Screenshot')),
+				kind: 'contextPick',
+				item,
+				label: item.label,
+				iconClass: ThemeIcon.asClassName(item.icon),
+				keybinding: item.commandId ? keybindingService.lookupKeybinding(item.commandId, contextKeyService) : undefined,
 			});
 		}
 
-		if (widget.viewModel?.sessionId) {
-			const agentPart = widget.parsedInput.parts.find((part): part is ChatRequestAgentPart => part instanceof ChatRequestAgentPart);
-			if (agentPart) {
-				const completions = await chatAgentService.getAgentCompletionItems(agentPart.agent.id, '', CancellationToken.None);
-				for (const variable of completions) {
-					if (variable.fullName && variable.command) {
-						quickPickItems.push({
-							kind: 'command',
-							label: variable.fullName,
-							id: variable.id,
-							command: variable.command,
-							icon: variable.icon,
-							iconClass: variable.icon ? ThemeIcon.asClassName(variable.icon) : undefined,
-							value: variable.value,
-							name: variable.name
-						});
-					} else {
-						// Currently there's nothing that falls into this category
-					}
-				}
-			}
-		}
-
-		quickPickItems.push({
-			kind: 'tools',
-			label: localize('chatContext.tools', 'Tools...'),
-			iconClass: ThemeIcon.asClassName(Codicon.tools),
-			id: 'tools',
-		});
-
-		quickPickItems.push({
-			kind: 'workspaceSymbol',
-			label: localize('chatContext.symbol', 'Symbols...'),
-			iconClass: ThemeIcon.asClassName(Codicon.symbolField),
-			id: 'symbol'
-		});
-
-		quickPickItems.push({
-			kind: 'folder',
-			label: localize('chatContext.folder', 'Files & Folders...'),
-			iconClass: ThemeIcon.asClassName(Codicon.folder),
-			id: 'folder',
-		});
-
-		quickPickItems.push({
-			kind: 'diagnostic',
-			label: localize('chatContext.diagnstic', 'Problems...'),
-			iconClass: ThemeIcon.asClassName(Codicon.error),
-			id: 'diagnostic'
-		});
-
-		if (widget.location === ChatAgentLocation.Notebook) {
-			quickPickItems.push({
-				kind: 'command',
-				id: 'chatContext.notebook.kernelVariable',
-				icon: ThemeIcon.fromId(Codicon.serverEnvironment.id),
-				iconClass: ThemeIcon.asClassName(Codicon.serverEnvironment),
-				value: 'kernelVariable',
-				label: localize('chatContext.notebook.kernelVariable', 'Kernel Variable...'),
-				command: {
-					id: 'notebook.chat.selectAndInsertKernelVariable',
-					title: localize('chatContext.notebook.selectkernelVariable', 'Select and Insert Kernel Variable'),
-					arguments: [{ widget, range: undefined }]
-				}
-			});
-		}
-
-		if (chatEditingService?.hasRelatedFilesProviders() && (widget.getInput() || widget.attachmentModel.fileAttachments.length > 0)) {
-			quickPickItems.push({
-				kind: 'related-files',
-				id: 'related-files',
-				label: localize('chatContext.relatedFiles', 'Related Files'),
-				iconClass: ThemeIcon.asClassName(Codicon.sparkle),
-			});
-		}
-		if (editorService.editors.filter(e => e instanceof FileEditorInput || e instanceof DiffEditorInput || e instanceof UntitledTextEditorInput).length > 0) {
-			quickPickItems.push({
-				kind: 'open-editors',
-				id: 'open-editors',
-				label: localize('chatContext.editors', 'Open Editors'),
-				iconClass: ThemeIcon.asClassName(Codicon.files),
-			});
-		}
-		if (SearchContext.HasSearchResults.getValue(contextKeyService)) {
-			quickPickItems.push({
-				kind: 'search-results',
-				id: 'search-results',
-				label: localize('chatContext.searchResults', 'Search Results'),
-				iconClass: ThemeIcon.asClassName(Codicon.search),
-			});
-		}
-
-		// if the `reusable prompts` feature is enabled, add
-		// the appropriate attachment type to the list
-		if (widget.attachmentModel.promptInstructions.featureEnabled) {
-			const keybinding = keybindingService.lookupKeybinding(INSTRUCTIONS_COMMAND_ID, contextKeyService);
-
-			quickPickItems.push({
-				id: INSTRUCTION_PICK_ID,
-				kind: INSTRUCTION_PICK_ID,
-				label: localize('chatContext.attach.instructions.label', 'Instructions...'),
-				iconClass: ThemeIcon.asClassName(Codicon.bookmark),
-				keybinding,
-			});
-		}
-
-		quickPickItems.sort((a, b) => {
-			let result = attachmentsOrdinals.indexOf(b.kind) - attachmentsOrdinals.indexOf(a.kind);
-			if (result === 0) {
-				result = a.label.localeCompare(b.label);
-			}
-			return result;
-		});
-
-		instantiationService.invokeFunction(this._show.bind(this), widget, quickPickItems, '', context?.placeholder);
+		instantiationService.invokeFunction(this._show.bind(this), widget, quickPickItems, context?.placeholder);
 	}
 
-	private async _showDiagnosticsPick(instantiationService: IInstantiationService, onBackgroundAccept: (item: IChatContextQuickPickItem[]) => void): Promise<IDiagnosticsQuickPickItemWithFilter | undefined> {
-		const convert = (item: IDiagnosticVariableEntryFilterData): IDiagnosticsQuickPickItemWithFilter => ({
-			kind: 'diagnostic-filter',
-			id: IDiagnosticVariableEntryFilterData.id(item),
-			label: IDiagnosticVariableEntryFilterData.label(item),
-			icon: IDiagnosticVariableEntryFilterData.icon,
-			filter: item,
-		});
-
-		const filter = await instantiationService.invokeFunction(createMarkersQuickPick, items => onBackgroundAccept(items.map(convert)));
-		return filter && convert(filter);
-	}
-
-	private _show(accessor: ServicesAccessor, widget: IChatWidget, quickPickItems: (IChatContextQuickPickItem | QuickPickItem)[] | undefined, query: string = '', placeholder?: string) {
+	private _show(accessor: ServicesAccessor, widget: IChatWidget, additionPicks: IContextPickItemItem[] | undefined, placeholder?: string) {
 		const quickInputService = accessor.get(IQuickInputService);
 		const quickChatService = accessor.get(IQuickChatService);
-		const editorService = accessor.get(IEditorService);
-		const commandService = accessor.get(ICommandService);
 		const instantiationService = accessor.get(IInstantiationService);
 
-		const attach = (isBackgroundAccept: boolean, ...items: IChatContextQuickPickItem[]) => {
-			instantiationService.invokeFunction(this._attachContext.bind(this), widget, isBackgroundAccept, ...items);
-		};
 
 		const providerOptions: AnythingQuickAccessProviderRunOptions = {
-			additionPicks: quickPickItems,
-			handleAccept: async (inputItem: IChatContextQuickPickItem, isBackgroundAccept: boolean) => {
-				let item: IChatContextQuickPickItem | undefined = inputItem;
+			additionPicks,
+			handleAccept: async (item: IQuickPickServicePickItem | IContextPickItemItem, isBackgroundAccept: boolean) => {
 
-				if (isIAttachmentQuickPickItem(item)) {
+				if (isIContextPickItemItem(item)) {
 
-					if (item.kind === 'workspaceSymbol') {
-						instantiationService.invokeFunction(this._show.bind(this), widget, quickPickItems, SymbolsQuickAccessProvider.PREFIX, placeholder);
-						return;
-					} else if (item.kind === 'instructions') {
-						runAttachInstructionsAction(commandService, { widget });
-						return;
+					let isDone = true;
+					if (item.item.type === 'valuePick') {
+						this._handleContextPick(item.item, widget);
+
+					} else if (item.item.type === 'pickerPick') {
+						isDone = await this._handleContextPickerItem(quickInputService, item.item, widget);
 					}
 
-					if (item.kind === 'folder') {
-						item = await this._showFolders(instantiationService);
-					} else if (item.kind === 'diagnostic') {
-						item = await this._showDiagnosticsPick(instantiationService, i => attach(true, ...i));
-					} else if (item.kind === 'tools') {
-						item = await instantiationService.invokeFunction(showToolsPick, widget);
-					}
-					if (!item) {
+					if (!isDone) {
 						// restart picker when sub-picker didn't return anything
-						instantiationService.invokeFunction(this._show.bind(this), widget, quickPickItems, '', placeholder);
+						instantiationService.invokeFunction(this._show.bind(this), widget, additionPicks, placeholder);
 						return;
 					}
 
+				} else {
+					instantiationService.invokeFunction(this._handleQPPick.bind(this), widget, isBackgroundAccept, item);
 				}
-				attach(isBackgroundAccept, item);
 				if (isQuickChat(widget)) {
 					quickChatService.open();
 				}
-
-			},
-			filter: (item: IChatContextQuickPickItem | IQuickPickSeparator) => {
-				// Avoid attaching the same context twice
-				const attachedContext = widget.attachmentModel.getAttachmentIDs();
-
-				if (isIAttachmentQuickPickItem(item) && item.kind === 'open-editors') {
-					for (const editor of editorService.editors.filter(e => e instanceof FileEditorInput || e instanceof DiffEditorInput || e instanceof UntitledTextEditorInput)) {
-						// There is an open editor that hasn't yet been attached to the chat
-						if (editor.resource && !attachedContext.has(this._getFileContextId({ resource: editor.resource }))) {
-							return true;
-						}
-					}
-					return false;
-				}
-
-				if ('kind' in item && item.kind === 'image') {
-					return !attachedContext.has(item.id);
-				}
-
-				if ('symbol' in item && item.symbol) {
-					return !attachedContext.has(this._getFileContextId(item.symbol.location));
-				}
-
-				if (item && typeof item === 'object' && 'resource' in item && URI.isUri(item.resource)) {
-					return [Schemas.file, Schemas.vscodeRemote, Schemas.untitled].includes(item.resource.scheme)
-						&& !attachedContext.has(this._getFileContextId({ resource: item.resource })); // Hack because Typescript doesn't narrow this type correctly
-				}
-
-				if (item && typeof item === 'object' && 'uri' in item && item.uri && item.range) {
-					return !attachedContext.has(this._getFileContextId({ uri: item.uri, range: item.range.decoration }));
-				}
-
-				if (!('command' in item) && item.id) {
-					return !attachedContext.has(item.id);
-				}
-
-				// Don't filter out dynamic variables which show secondary data (temporary)
-				return true;
 			}
 		};
-		quickInputService.quickAccess.show(query, {
+
+		quickInputService.quickAccess.show('', {
 			enabledProviderPrefixes: [
 				AnythingQuickAccessProvider.PREFIX,
 				SymbolsQuickAccessProvider.PREFIX,
@@ -932,140 +393,153 @@ export class AttachContextAction extends Action2 {
 		});
 	}
 
-	private async _showFolders(instantiationService: IInstantiationService): Promise<IFolderResultQuickPickItem | undefined> {
-		const folder = await instantiationService.invokeFunction(createFilesAndFolderQuickPick);
-		if (!folder) {
-			return undefined;
-		}
+	private async _handleQPPick(accessor: ServicesAccessor, widget: IChatWidget, isInBackground: boolean, pick: IQuickPickServicePickItem) {
+		const fileService = accessor.get(IFileService);
+		const textModelService = accessor.get(ITextModelService);
 
-		return {
-			kind: 'folder-search-result',
-			id: folder.toString(),
-			label: basename(folder),
-			resource: folder,
-		};
-	}
-}
 
-async function createMarkersQuickPick(accessor: ServicesAccessor, onBackgroundAccept?: (item: IDiagnosticVariableEntryFilterData[]) => void): Promise<IDiagnosticVariableEntryFilterData | undefined> {
-	const quickInputService = accessor.get(IQuickInputService);
-	const markerService = accessor.get(IMarkerService);
-	const labelService = accessor.get(ILabelService);
+		const toAttach: IChatRequestVariableEntry[] = [];
 
-	const markers = markerService.read({ severities: MarkerSeverity.Error | MarkerSeverity.Warning | MarkerSeverity.Info });
-	const grouped = groupBy(markers, (a, b) => extUri.compare(a.resource, b.resource));
+		if (isIQuickPickItemWithResource(pick) && pick.resource) {
+			if (/\.(png|jpg|jpeg|bmp|gif|tiff)$/i.test(pick.resource.path)) {
+				// checks if the file is an image
+				if (URI.isUri(pick.resource)) {
+					// read the image and attach a new file context.
+					const readFile = await fileService.readFile(pick.resource);
+					const resizedImage = await resizeImage(readFile.value.buffer);
+					toAttach.push({
+						id: pick.resource.toString(),
+						name: pick.label,
+						fullName: pick.label,
+						value: resizedImage,
+						kind: 'image',
+						references: [{ reference: pick.resource, kind: 'reference' }]
+					});
+				}
+			} else {
+				let omittedState = OmittedState.NotOmitted;
+				try {
+					const createdModel = await textModelService.createModelReference(pick.resource);
+					createdModel.dispose();
+				} catch {
+					omittedState = OmittedState.Full;
+				}
 
-	const severities = new Set<MarkerSeverity>();
-	type MarkerPickItem = IQuickPickItem & { resource?: URI; entry: IDiagnosticVariableEntryFilterData };
-	const items: (MarkerPickItem | IQuickPickSeparator)[] = [];
-
-	let pickCount = 0;
-	for (const group of grouped) {
-		const resource = group[0].resource;
-
-		items.push({ type: 'separator', label: labelService.getUriLabel(resource, { relative: true }) });
-		for (const marker of group) {
-			pickCount++;
-			severities.add(marker.severity);
-			items.push({
-				type: 'item',
-				resource: marker.resource,
-				label: marker.message,
-				description: localize('markers.panel.at.ln.col.number', "[Ln {0}, Col {1}]", '' + marker.startLineNumber, '' + marker.startColumn),
-				entry: IDiagnosticVariableEntryFilterData.fromMarker(marker),
+				toAttach.push({
+					kind: 'file',
+					id: pick.resource.toString(),
+					value: pick.resource,
+					name: pick.label,
+					omittedState
+				});
+			}
+		} else if (isIGotoSymbolQuickPickItem(pick) && pick.uri && pick.range) {
+			toAttach.push({
+				kind: 'generic',
+				id: JSON.stringify({ uri: pick.uri, range: pick.range.decoration }),
+				value: { uri: pick.uri, range: pick.range.decoration },
+				fullName: pick.label,
+				name: pick.symbolName!,
 			});
 		}
+
+
+		widget.attachmentModel.addContext(...toAttach);
+
+		if (!isInBackground) {
+			// Set focus back into the input once the user is done attaching items
+			// so that the user can start typing their message
+			widget.focusInput();
+		}
 	}
 
-	items.unshift({ type: 'item', label: localize('markers.panel.allErrors', 'All Problems'), entry: { filterSeverity: MarkerSeverity.Info } });
+	private async _handleContextPick(item: IChatContextValueItem, widget: IChatWidget) {
 
-	const store = new DisposableStore();
-	const quickPick = store.add(quickInputService.createQuickPick<MarkerPickItem>({ useSeparators: true }));
-	quickPick.canAcceptInBackground = !onBackgroundAccept;
-	quickPick.placeholder = localize('pickAProblem', 'Select a problem to attach');
-	quickPick.items = items;
+		const value = await item.asAttachment(widget);
+		if (Array.isArray(value)) {
+			widget.attachmentModel.addContext(...value);
+		} else if (value) {
+			widget.attachmentModel.addContext(value);
+		}
+	}
 
-	return new Promise<IDiagnosticVariableEntryFilterData | undefined>(resolve => {
-		store.add(quickPick.onDidHide(() => resolve(undefined)));
-		store.add(quickPick.onDidAccept(ev => {
-			if (ev.inBackground) {
-				onBackgroundAccept?.(quickPick.selectedItems.map(i => i.entry));
-			} else {
-				resolve(quickPick.selectedItems[0]?.entry);
-				quickPick.dispose();
+	private async _handleContextPickerItem(quickInputService: IQuickInputService, item: IChatContextPickerItem, widget: IChatWidget): Promise<boolean> {
+
+		const pickerConfig = item.asPicker(widget);
+
+		const store = new DisposableStore();
+
+		const goBackItem: IQuickPickItem = {
+			label: localize('goBack', 'Go back ↩'),
+			alwaysShow: true
+		};
+		const extraPicks: QuickPickItem[] = [{ type: 'separator' }, goBackItem];
+
+		const qp = store.add(quickInputService.createQuickPick({ useSeparators: true }));
+
+		qp.placeholder = pickerConfig.placeholder;
+		qp.matchOnDescription = true;
+		// qp.ignoreFocusOut = true;
+		qp.canAcceptInBackground = true;
+		qp.busy = true;
+		qp.show();
+
+		if (isThenable(pickerConfig.picks)) {
+			const items = await (pickerConfig.picks.then(value => {
+				return ([] as QuickPickItem[]).concat(value, extraPicks);
+			}));
+
+			qp.items = items;
+			qp.busy = false;
+		} else {
+
+			let cts: CancellationTokenSource | undefined;
+
+			const update = async () => {
+				assertType(typeof pickerConfig.picks === 'function');
+
+				if (cts) {
+					cts.cancel();
+					store.delete(cts);
+				}
+				cts = store.add(new CancellationTokenSource());
+
+				try {
+					qp.busy = true;
+					const items = await raceCancellationError(pickerConfig.picks(qp.value, cts.token), cts.token);
+					qp.items = ([] as QuickPickItem[]).concat(items, extraPicks);
+				} finally {
+					qp.busy = false;
+				}
+			};
+
+			store.add(qp.onDidChangeValue(update));
+			update();
+		}
+
+		const defer = new DeferredPromise<boolean>();
+
+		store.add(qp.onDidAccept(e => {
+			const [selected] = qp.selectedItems;
+			if (isChatContextPickerPickItem(selected)) {
+				widget.attachmentModel.addContext(selected.asAttachment());
+			}
+			if (selected === goBackItem) {
+				defer.complete(false);
+			}
+			if (!e.inBackground) {
+				defer.complete(true);
 			}
 		}));
-		quickPick.show();
-	}).finally(() => store.dispose());
+
+		store.add(qp.onDidHide(() => {
+			defer.complete(true);
+		}));
+
+		try {
+			return await defer.p;
+		} finally {
+			store.dispose();
+		}
+	}
 }
-
-async function showToolsPick(accessor: ServicesAccessor, widget: IChatWidget): Promise<IToolQuickPickItem | undefined> {
-
-	const quickPickService = accessor.get(IQuickInputService);
-
-
-	function classify(tool: IToolData) {
-		if (tool.source.type === 'internal' || tool.source.type === 'extension' && !tool.source.isExternalTool) {
-			return { ordinal: 1, groupLabel: localize('chatContext.tools.internal', 'Built-In') };
-		} else if (tool.source.type === 'mcp') {
-			return { ordinal: 2, groupLabel: localize('chatContext.tools.mcp', 'MCP Servers') };
-		} else {
-			return { ordinal: 3, groupLabel: localize('chatContext.tools.extension', 'Extensions') };
-		}
-	}
-
-	type Pick = IToolQuickPickItem & { ordinal: number; groupLabel: string };
-	const items: Pick[] = [];
-
-	for (const tool of widget.input.selectedToolsModel.tools.get()) {
-		if (!tool.canBeReferencedInPrompt) {
-			continue;
-		}
-		const item: Pick = {
-			tool,
-			...classify(tool),
-			kind: 'tool',
-			label: tool.toolReferenceName ?? tool.id,
-			description: (tool.toolReferenceName ?? tool.id) !== tool.displayName ? tool.displayName : undefined,
-			id: tool.id,
-		};
-		// if (ThemeIcon.isThemeIcon(tool.icon)) {
-		// 	item.iconClass = ThemeIcon.asClassName(tool.icon);
-		// } else if (tool.icon) {
-		// 	item.iconPath = tool.icon;
-		// }
-		items.push(item);
-	}
-
-	items.sort((a, b) => {
-		let res = a.ordinal - b.ordinal;
-		if (res === 0) {
-			res = a.label.localeCompare(b.label);
-		}
-		return res;
-	});
-
-	let lastGroupLabel: string | undefined;
-	const picks: (IQuickPickSeparator | Pick)[] = [];
-
-
-	for (const item of items) {
-		if (lastGroupLabel !== item.groupLabel) {
-			picks.push({ type: 'separator', label: item.groupLabel });
-			lastGroupLabel = item.groupLabel;
-		}
-		picks.push(item);
-	}
-
-	const result = await quickPickService.pick(picks, {
-		placeHolder: localize('chatContext.tools.placeholder', 'Select a tool'),
-		canPickMany: false
-	});
-
-	return result;
-}
-
-/**
- * Register all actions related to reusable prompt files.
- */
-registerPromptActions();

--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -57,6 +57,7 @@ import { AgentChatAccessibilityHelp, EditsChatAccessibilityHelp, PanelChatAccess
 import { CopilotTitleBarMenuRendering, registerChatActions, ACTION_ID_NEW_CHAT } from './actions/chatActions.js';
 import { registerNewChatActions } from './actions/chatClearActions.js';
 import { CodeBlockActionRendering, registerChatCodeBlockActions, registerChatCodeCompareBlockActions } from './actions/chatCodeblockActions.js';
+import { ChatContextContributions } from './actions/chatContext.js';
 import { registerChatContextActions } from './actions/chatContextActions.js';
 import { registerChatCopyActions } from './actions/chatCopyActions.js';
 import { registerChatDeveloperActions } from './actions/chatDeveloperActions.js';
@@ -74,6 +75,7 @@ import { IChatAccessibilityService, IChatCodeBlockContextProviderService, IChatW
 import { ChatAccessibilityService } from './chatAccessibilityService.js';
 import './chatAttachmentModel.js';
 import { ChatMarkdownAnchorService, IChatMarkdownAnchorService } from './chatContentParts/chatMarkdownAnchorService.js';
+import { ChatContextPickService, IChatContextPickService } from './chatContextPickService.js';
 import { ChatInputBoxContentProvider } from './chatEdinputInputContentProvider.js';
 import { ChatEditingEditorAccessibility } from './chatEditing/chatEditingEditorAccessibility.js';
 import { registerChatEditorActions } from './chatEditing/chatEditingEditorActions.js';
@@ -617,6 +619,7 @@ registerWorkbenchContribution2(ChatEditingEditorOverlay.ID, ChatEditingEditorOve
 registerWorkbenchContribution2(SimpleBrowserOverlay.ID, SimpleBrowserOverlay, WorkbenchPhase.AfterRestored);
 registerWorkbenchContribution2(ChatEditingEditorContextKeys.ID, ChatEditingEditorContextKeys, WorkbenchPhase.AfterRestored);
 registerWorkbenchContribution2(ChatTransferContribution.ID, ChatTransferContribution, WorkbenchPhase.BlockRestore);
+registerWorkbenchContribution2(ChatContextContributions.ID, ChatContextContributions, WorkbenchPhase.AfterRestored);
 
 registerChatActions();
 registerChatCopyActions();
@@ -658,6 +661,7 @@ registerSingleton(IChatMarkdownAnchorService, ChatMarkdownAnchorService, Instant
 registerSingleton(ILanguageModelIgnoredFilesService, LanguageModelIgnoredFilesService, InstantiationType.Delayed);
 registerSingleton(IChatEntitlementService, ChatEntitlementService, InstantiationType.Delayed);
 registerSingleton(IPromptsService, PromptsService, InstantiationType.Delayed);
+registerSingleton(IChatContextPickService, ChatContextPickService, InstantiationType.Delayed);
 
 registerWorkbenchContribution2(ChatEditingNotebookFileSystemProviderContrib.ID, ChatEditingNotebookFileSystemProviderContrib, WorkbenchPhase.BlockStartup);
 

--- a/src/vs/workbench/contrib/chat/browser/chatContextPickService.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContextPickService.ts
@@ -1,0 +1,96 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import { CancellationToken } from '../../../../base/common/cancellation.js';
+import { IDisposable, toDisposable } from '../../../../base/common/lifecycle.js';
+import { ThemeIcon } from '../../../../base/common/themables.js';
+import { isObject } from '../../../../base/common/types.js';
+import { createDecorator } from '../../../../platform/instantiation/common/instantiation.js';
+import { IQuickPickSeparator } from '../../../../platform/quickinput/common/quickInput.js';
+import { IChatWidget } from './chat.js';
+import { IChatRequestVariableEntry } from '../common/chatModel.js';
+import { compare } from '../../../../base/common/strings.js';
+
+
+export interface IChatContextPickerPickItem {
+	label: string;
+	iconClass?: string;
+	description?: string;
+	disabled?: boolean;
+	asAttachment(): IChatRequestVariableEntry;
+}
+
+export function isChatContextPickerPickItem(item: unknown): item is IChatContextPickerPickItem {
+	return isObject(item) && typeof (item as IChatContextPickerPickItem).asAttachment === 'function';
+}
+
+interface IChatContextItem {
+	readonly label: string;
+	readonly icon: ThemeIcon;
+	readonly commandId?: string;
+	readonly ordinal?: number;
+	isEnabled?(widget: IChatWidget): Promise<boolean> | boolean;
+}
+
+export interface IChatContextValueItem extends IChatContextItem {
+	readonly type: 'valuePick';
+
+	asAttachment(widget: IChatWidget): Promise<IChatRequestVariableEntry | IChatRequestVariableEntry[] | undefined>;
+}
+
+export interface IChatContextPickerItem extends IChatContextItem {
+	readonly type: 'pickerPick';
+
+	asPicker(widget: IChatWidget): {
+		readonly placeholder: string;
+		readonly picks: Promise<(IChatContextPickerPickItem | IQuickPickSeparator)[]> | ((query: string, token: CancellationToken) => Promise<(IChatContextPickerPickItem | IQuickPickSeparator)[]>);
+	};
+}
+
+export interface IChatContextPickService {
+	_serviceBrand: undefined;
+
+	items: Iterable<IChatContextValueItem | IChatContextPickerItem>;
+
+	/**
+	 * Register a value or  picker to the "Add Context" flow. A value directly resolved to a
+	 * chat attachment and a picker first shows a list of items to pick from and then
+	 * resolves the selected item to a chat attachment.
+	 */
+	registerChatContextItem(item: IChatContextValueItem | IChatContextPickerItem): IDisposable;
+}
+
+export const IChatContextPickService = createDecorator<IChatContextPickService>('IContextPickService');
+
+export class ChatContextPickService implements IChatContextPickService {
+
+	declare _serviceBrand: undefined;
+
+	private readonly _picks: IChatContextValueItem[] = [];
+
+	readonly items: Iterable<IChatContextValueItem> = this._picks;
+
+	registerChatContextItem(pick: IChatContextValueItem): IDisposable {
+		this._picks.push(pick);
+
+		this._picks.sort((a, b) => {
+			const valueA = a.ordinal ?? 0;
+			const valueB = b.ordinal ?? 0;
+			if (valueA === valueB) {
+				return compare(a.label, b.label);
+			} else if (valueA < valueB) {
+				return 1;
+			} else {
+				return -1;
+			}
+		});
+
+		return toDisposable(() => {
+			const index = this._picks.indexOf(pick);
+			if (index >= 0) {
+				this._picks.splice(index, 1);
+			}
+		});
+	}
+}

--- a/src/vs/workbench/contrib/chat/browser/contrib/chatDynamicVariables.ts
+++ b/src/vs/workbench/contrib/chat/browser/contrib/chatDynamicVariables.ts
@@ -4,33 +4,18 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { coalesce } from '../../../../../base/common/arrays.js';
-import { CancellationToken } from '../../../../../base/common/cancellation.js';
-import { Codicon } from '../../../../../base/common/codicons.js';
-import { isCancellationError } from '../../../../../base/common/errors.js';
-import * as glob from '../../../../../base/common/glob.js';
 import { IMarkdownString, MarkdownString } from '../../../../../base/common/htmlContent.js';
-import { Disposable, DisposableStore, dispose, isDisposable } from '../../../../../base/common/lifecycle.js';
-import { ResourceSet } from '../../../../../base/common/map.js';
-import { basename, dirname, extUri, joinPath, relativePath } from '../../../../../base/common/resources.js';
-import { ThemeIcon } from '../../../../../base/common/themables.js';
+import { Disposable, dispose, isDisposable } from '../../../../../base/common/lifecycle.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { IRange, Range } from '../../../../../editor/common/core/range.js';
 import { IDecorationOptions } from '../../../../../editor/common/editorCommon.js';
 import { Command, isLocation } from '../../../../../editor/common/languages.js';
-import { ILanguageService } from '../../../../../editor/common/languages/language.js';
-import { getIconClasses } from '../../../../../editor/common/services/getIconClasses.js';
-import { IModelService } from '../../../../../editor/common/services/model.js';
 import { Action2, registerAction2 } from '../../../../../platform/actions/common/actions.js';
 import { ICommandService } from '../../../../../platform/commands/common/commands.js';
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
-import { FileKind, FileType, IFileService } from '../../../../../platform/files/common/files.js';
 import { IInstantiationService, ServicesAccessor } from '../../../../../platform/instantiation/common/instantiation.js';
 import { ILabelService } from '../../../../../platform/label/common/label.js';
 import { PromptsConfig } from '../../../../../platform/prompts/common/config.js';
-import { IQuickInputService, IQuickPickItem } from '../../../../../platform/quickinput/common/quickInput.js';
-import { IWorkspaceContextService } from '../../../../../platform/workspace/common/workspace.js';
-import { IHistoryService } from '../../../../services/history/common/history.js';
-import { getExcludes, IFileQuery, ISearchComplete, ISearchConfiguration, ISearchService, QueryType } from '../../../../services/search/common/search.js';
 import { IChatRequestVariableValue, IDynamicVariable } from '../../common/chatVariables.js';
 import { IChatWidget } from '../chat.js';
 import { ChatWidget, IChatWidgetContrib } from '../chatWidget.js';
@@ -239,216 +224,6 @@ function isDynamicVariable(obj: any): obj is IDynamicVariable {
 ChatWidget.CONTRIBS.push(ChatDynamicVariableModel);
 
 
-export async function createFilesAndFolderQuickPick(accessor: ServicesAccessor): Promise<URI | undefined> {
-	const quickInputService = accessor.get(IQuickInputService);
-	const searchService = accessor.get(ISearchService);
-	const configurationService = accessor.get(IConfigurationService);
-	const workspaceService = accessor.get(IWorkspaceContextService);
-	const fileService = accessor.get(IFileService);
-	const labelService = accessor.get(ILabelService);
-	const modelService = accessor.get(IModelService);
-	const languageService = accessor.get(ILanguageService);
-	const historyService = accessor.get(IHistoryService);
-
-	type ResourcePick = IQuickPickItem & { resource: URI; kind: FileKind };
-
-	const workspaces = workspaceService.getWorkspace().folders.map(folder => folder.uri);
-
-	const defaultItems: ResourcePick[] = [];
-	(await getTopLevelFolders(workspaces, fileService)).forEach(uri => defaultItems.push(createQuickPickItem(uri, FileKind.FOLDER)));
-	historyService.getHistory().filter(a => a.resource).slice(0, 30).forEach(uri => defaultItems.push(createQuickPickItem(uri.resource!, FileKind.FILE)));
-	defaultItems.sort((a, b) => extUri.compare(a.resource, b.resource));
-
-	const quickPick = quickInputService.createQuickPick<ResourcePick>();
-	quickPick.placeholder = 'Search file or folder by name';
-	quickPick.items = defaultItems;
-
-	return await new Promise<URI | undefined>(_resolve => {
-
-		const disposables = new DisposableStore();
-		const resolve = (res: URI | undefined) => {
-			_resolve(res);
-			disposables.dispose();
-			quickPick.dispose();
-		};
-
-		disposables.add(quickPick.onDidChangeValue(async value => {
-			if (value === '') {
-				quickPick.items = defaultItems;
-				return;
-			}
-
-			const picks: ResourcePick[] = [];
-
-			await Promise.all(workspaces.map(async workspace => {
-				const result = await searchFilesAndFolders(
-					workspace,
-					value,
-					true,
-					undefined,
-					undefined,
-					configurationService,
-					searchService
-				);
-
-				for (const folder of result.folders) {
-					picks.push(createQuickPickItem(folder, FileKind.FOLDER));
-				}
-				for (const file of result.files) {
-					picks.push(createQuickPickItem(file, FileKind.FILE));
-				}
-			}));
-
-			quickPick.items = picks.sort((a, b) => extUri.compare(a.resource, b.resource));
-		}));
-
-		disposables.add(quickPick.onDidAccept((e) => {
-			const value = (quickPick.selectedItems[0] as any)?.resource;
-			resolve(value);
-		}));
-
-		disposables.add(quickPick.onDidHide(() => {
-			resolve(undefined);
-		}));
-
-		quickPick.show();
-	});
-
-	function createQuickPickItem(resource: URI, kind: FileKind): ResourcePick {
-		return {
-			resource,
-			kind,
-			id: resource.toString(),
-			alwaysShow: true,
-			label: basename(resource),
-			description: labelService.getUriLabel(dirname(resource), { relative: true }),
-			iconClasses: kind === FileKind.FILE ? getIconClasses(modelService, languageService, resource, FileKind.FILE) : undefined,
-			iconClass: kind === FileKind.FOLDER ? ThemeIcon.asClassName(Codicon.folder) : undefined
-		};
-	}
-}
-
-export async function getTopLevelFolders(workspaces: URI[], fileService: IFileService): Promise<URI[]> {
-	const folders: URI[] = [];
-	for (const workspace of workspaces) {
-		const fileSystemProvider = fileService.getProvider(workspace.scheme);
-		if (!fileSystemProvider) {
-			continue;
-		}
-
-		const entries = await fileSystemProvider.readdir(workspace);
-		for (const [name, type] of entries) {
-			const entryResource = joinPath(workspace, name);
-			if (type === FileType.Directory) {
-				folders.push(entryResource);
-			}
-		}
-	}
-
-	return folders;
-}
-
-export async function searchFilesAndFolders(
-	workspace: URI,
-	pattern: string,
-	fuzzyMatch: boolean,
-	token: CancellationToken | undefined,
-	cacheKey: string | undefined,
-	configurationService: IConfigurationService,
-	searchService: ISearchService
-): Promise<{ folders: URI[]; files: URI[] }> {
-	const segmentMatchPattern = caseInsensitiveGlobPattern(fuzzyMatch ? fuzzyMatchingGlobPattern(pattern) : continousMatchingGlobPattern(pattern));
-
-	const searchExcludePattern = getExcludes(configurationService.getValue<ISearchConfiguration>({ resource: workspace })) || {};
-	const searchOptions: IFileQuery = {
-		folderQueries: [{
-			folder: workspace,
-			disregardIgnoreFiles: configurationService.getValue<boolean>('explorer.excludeGitIgnore'),
-		}],
-		type: QueryType.File,
-		shouldGlobMatchFilePattern: true,
-		cacheKey,
-		excludePattern: searchExcludePattern,
-		sortByScore: true,
-	};
-
-	let searchResult: ISearchComplete | undefined;
-	try {
-		searchResult = await searchService.fileSearch({ ...searchOptions, filePattern: `{**/${segmentMatchPattern}/**,${pattern}}` }, token);
-	} catch (e) {
-		if (!isCancellationError(e)) {
-			throw e;
-		}
-	}
-
-	if (!searchResult || token?.isCancellationRequested) {
-		return { files: [], folders: [] };
-	}
-
-	const fileResources = searchResult.results.map(result => result.resource);
-	const folderResources = getMatchingFoldersFromFiles(fileResources, workspace, segmentMatchPattern);
-
-	return { folders: folderResources, files: fileResources };
-}
-
-function fuzzyMatchingGlobPattern(pattern: string): string {
-	if (!pattern) {
-		return '*';
-	}
-	return '*' + pattern.split('').join('*') + '*';
-}
-
-function continousMatchingGlobPattern(pattern: string): string {
-	if (!pattern) {
-		return '*';
-	}
-	return '*' + pattern + '*';
-}
-
-function caseInsensitiveGlobPattern(pattern: string): string {
-	let caseInsensitiveFilePattern = '';
-	for (let i = 0; i < pattern.length; i++) {
-		const char = pattern[i];
-		if (/[a-zA-Z]/.test(char)) {
-			caseInsensitiveFilePattern += `[${char.toLowerCase()}${char.toUpperCase()}]`;
-		} else {
-			caseInsensitiveFilePattern += char;
-		}
-	}
-	return caseInsensitiveFilePattern;
-}
-
-
-// TODO: remove this and have support from the search service
-function getMatchingFoldersFromFiles(resources: URI[], workspace: URI, segmentMatchPattern: string): URI[] {
-	const uniqueFolders = new ResourceSet();
-	for (const resource of resources) {
-		const relativePathToRoot = relativePath(workspace, resource);
-		if (!relativePathToRoot) {
-			throw new Error('Resource is not a child of the workspace');
-		}
-
-		let dirResource = workspace;
-		const stats = relativePathToRoot.split('/').slice(0, -1);
-		for (const stat of stats) {
-			dirResource = dirResource.with({ path: `${dirResource.path}/${stat}` });
-			uniqueFolders.add(dirResource);
-		}
-	}
-
-	const matchingFolders: URI[] = [];
-	for (const folderResource of uniqueFolders) {
-		const stats = folderResource.path.split('/');
-		const dirStat = stats[stats.length - 1];
-		if (!dirStat || !glob.match(segmentMatchPattern, dirStat)) {
-			continue;
-		}
-
-		matchingFolders.push(folderResource);
-	}
-
-	return matchingFolders;
-}
 
 
 export interface IAddDynamicVariableContext {

--- a/src/vs/workbench/contrib/chat/browser/contrib/chatInputCompletions.ts
+++ b/src/vs/workbench/contrib/chat/browser/contrib/chatInputCompletions.ts
@@ -43,7 +43,8 @@ import { IPromptsService } from '../../common/promptSyntax/service/types.js';
 import { ChatSubmitAction } from '../actions/chatExecuteActions.js';
 import { IChatWidget, IChatWidgetService } from '../chat.js';
 import { ChatInputPart } from '../chatInputPart.js';
-import { ChatDynamicVariableModel, searchFilesAndFolders } from './chatDynamicVariables.js';
+import { ChatDynamicVariableModel } from './chatDynamicVariables.js';
+import { searchFilesAndFolders } from '../../../search/browser/chatContributions.js';
 
 class SlashCommandCompletions extends Disposable {
 	constructor(

--- a/src/vs/workbench/contrib/chat/common/chatModel.ts
+++ b/src/vs/workbench/contrib/chat/common/chatModel.ts
@@ -200,9 +200,14 @@ export interface IElementVariableEntry extends IBaseChatRequestVariableEntry {
 	readonly kind: 'element';
 }
 
+export interface IPromptFileVariableEntry extends IBaseChatRequestVariableEntry {
+	readonly kind: 'promptFile';
+}
+
 export type IChatRequestVariableEntry = IGenericChatRequestVariableEntry | IChatRequestImplicitVariableEntry | IChatRequestPasteVariableEntry
 	| ISymbolVariableEntry | ICommandResultVariableEntry | IDiagnosticVariableEntry | IImageVariableEntry | IChatRequestToolEntry
-	| IChatRequestDirectoryEntry | IChatRequestFileEntry | INotebookOutputVariableEntry | IElementVariableEntry;
+	| IChatRequestDirectoryEntry | IChatRequestFileEntry | INotebookOutputVariableEntry | IElementVariableEntry
+	| IPromptFileVariableEntry;
 
 export function isImplicitVariableEntry(obj: IChatRequestVariableEntry): obj is IChatRequestImplicitVariableEntry {
 	return obj.kind === 'implicit';

--- a/src/vs/workbench/contrib/markers/browser/markers.contribution.ts
+++ b/src/vs/workbench/contrib/markers/browser/markers.contribution.ts
@@ -16,7 +16,7 @@ import { MenuId, registerAction2, Action2 } from '../../../../platform/actions/c
 import { Registry } from '../../../../platform/registry/common/platform.js';
 import { MarkersViewMode, Markers, MarkersContextKeys } from '../common/markers.js';
 import Messages from './messages.js';
-import { IWorkbenchContributionsRegistry, Extensions as WorkbenchExtensions, IWorkbenchContribution } from '../../../common/contributions.js';
+import { IWorkbenchContributionsRegistry, Extensions as WorkbenchExtensions, IWorkbenchContribution, registerWorkbenchContribution2, WorkbenchPhase } from '../../../common/contributions.js';
 import { IMarkersView } from './markers.js';
 import { LifecyclePhase } from '../../../services/lifecycle/common/lifecycle.js';
 import { IClipboardService } from '../../../../platform/clipboard/common/clipboardService.js';
@@ -36,6 +36,7 @@ import { IActivityService, NumberBadge } from '../../../services/activity/common
 import { viewFilterSubmenu } from '../../../browser/parts/views/viewFilter.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { problemsConfigurationNodeBase } from '../../../common/configuration.js';
+import { MarkerChatContextContribution } from './markersChatContext.js';
 
 KeybindingsRegistry.registerCommandAndKeybindingRule({
 	id: Markers.MARKER_OPEN_ACTION_ID,
@@ -685,6 +686,8 @@ class MarkersStatusBarContributions extends Disposable implements IWorkbenchCont
 }
 
 workbenchRegistry.registerWorkbenchContribution(MarkersStatusBarContributions, LifecyclePhase.Restored);
+
+registerWorkbenchContribution2(MarkerChatContextContribution.ID, MarkerChatContextContribution, WorkbenchPhase.AfterRestored);
 
 class ActivityUpdater extends Disposable implements IWorkbenchContribution {
 

--- a/src/vs/workbench/contrib/markers/browser/markersChatContext.ts
+++ b/src/vs/workbench/contrib/markers/browser/markersChatContext.ts
@@ -1,0 +1,88 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+
+import { groupBy } from '../../../../base/common/arrays.js';
+import { Codicon } from '../../../../base/common/codicons.js';
+import { Disposable } from '../../../../base/common/lifecycle.js';
+import { extUri } from '../../../../base/common/resources.js';
+import { localize } from '../../../../nls.js';
+import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
+import { ILabelService } from '../../../../platform/label/common/label.js';
+import { IMarkerService, MarkerSeverity } from '../../../../platform/markers/common/markers.js';
+import { IQuickPickSeparator } from '../../../../platform/quickinput/common/quickInput.js';
+import { IWorkbenchContribution } from '../../../common/contributions.js';
+import { IChatContextPickerItem, IChatContextPickerPickItem, IChatContextPickService } from '../../chat/browser/chatContextPickService.js';
+import { IDiagnosticVariableEntryFilterData } from '../../chat/common/chatModel.js';
+
+class MarkerChatContextPick implements IChatContextPickerItem {
+
+	readonly type = 'pickerPick';
+	readonly label = localize('chatContext.diagnstic', 'Problems...');
+	readonly icon = Codicon.error;
+	readonly ordinal = -100;
+
+	constructor(
+		@IMarkerService private readonly _markerService: IMarkerService,
+		@ILabelService private readonly _labelService: ILabelService,
+	) { }
+
+	asPicker(): { readonly placeholder: string; readonly picks: Promise<(IChatContextPickerPickItem | IQuickPickSeparator)[]> } {
+
+		const markers = this._markerService.read({ severities: MarkerSeverity.Error | MarkerSeverity.Warning | MarkerSeverity.Info });
+		const grouped = groupBy(markers, (a, b) => extUri.compare(a.resource, b.resource));
+
+		const severities = new Set<MarkerSeverity>();
+		const items: (IChatContextPickerPickItem | IQuickPickSeparator)[] = [];
+
+		let pickCount = 0;
+		for (const group of grouped) {
+			const resource = group[0].resource;
+
+			items.push({ type: 'separator', label: this._labelService.getUriLabel(resource, { relative: true }) });
+			for (const marker of group) {
+				pickCount++;
+				severities.add(marker.severity);
+
+				items.push({
+					label: marker.message,
+					description: localize('markers.panel.at.ln.col.number', "[Ln {0}, Col {1}]", '' + marker.startLineNumber, '' + marker.startColumn),
+					asAttachment() {
+						return IDiagnosticVariableEntryFilterData.toEntry(IDiagnosticVariableEntryFilterData.fromMarker(marker));
+					}
+				});
+			}
+		}
+
+		items.unshift({
+			label: localize('markers.panel.allErrors', 'All Problems'),
+			asAttachment() {
+				return IDiagnosticVariableEntryFilterData.toEntry({
+					filterSeverity: MarkerSeverity.Info
+				});
+			},
+		});
+
+
+		return {
+			placeholder: localize('chatContext.diagnstic.placeholder', 'Select a problem to attach'),
+			picks: Promise.resolve(items)
+		};
+	}
+}
+
+
+export class MarkerChatContextContribution extends Disposable implements IWorkbenchContribution {
+
+	static readonly ID = 'workbench.contrib.chat.markerChatContextContribution';
+
+	constructor(
+		@IChatContextPickService contextPickService: IChatContextPickService,
+		@IInstantiationService instantiationService: IInstantiationService,
+	) {
+		super();
+		this._store.add(contextPickService.registerChatContextItem(instantiationService.createInstance(MarkerChatContextPick)));
+	}
+}

--- a/src/vs/workbench/contrib/notebook/browser/controller/chat/notebook.chat.contribution.ts
+++ b/src/vs/workbench/contrib/notebook/browser/controller/chat/notebook.chat.contribution.ts
@@ -16,7 +16,7 @@ import { localize } from '../../../../../../nls.js';
 import { Action2, MenuId, registerAction2 } from '../../../../../../platform/actions/common/actions.js';
 import { ContextKeyExpr, IContextKey, IContextKeyService } from '../../../../../../platform/contextkey/common/contextkey.js';
 import { ServicesAccessor } from '../../../../../../platform/instantiation/common/instantiation.js';
-import { IQuickInputService, IQuickPickItem } from '../../../../../../platform/quickinput/common/quickInput.js';
+import { IQuickInputService, IQuickPickItem, IQuickPickSeparator } from '../../../../../../platform/quickinput/common/quickInput.js';
 import { IWorkbenchContribution, registerWorkbenchContribution2, WorkbenchPhase } from '../../../../../common/contributions.js';
 import { IEditorService } from '../../../../../services/editor/common/editorService.js';
 import { IChatWidget, IChatWidgetService, showChatView } from '../../../../chat/browser/chat.js';
@@ -37,6 +37,8 @@ import './cellChatActions.js';
 import { CTX_NOTEBOOK_CHAT_HAS_AGENT } from './notebookChatContext.js';
 import { IViewsService } from '../../../../../services/views/common/viewsService.js';
 import { createNotebookOutputVariableEntry, NOTEBOOK_CELL_OUTPUT_MIME_TYPE_LIST_FOR_CHAT_CONST } from '../../contrib/chat/notebookChatUtils.js';
+import { IChatContextPickerItem, IChatContextPickerPickItem, IChatContextPickService } from '../../../../chat/browser/chatContextPickService.js';
+import { Codicon } from '../../../../../../base/common/codicons.js';
 
 const NotebookKernelVariableKey = 'kernelVariable';
 
@@ -52,8 +54,11 @@ class NotebookChatContribution extends Disposable implements IWorkbenchContribut
 		@IChatWidgetService private readonly chatWidgetService: IChatWidgetService,
 		@INotebookKernelService private readonly notebookKernelService: INotebookKernelService,
 		@ILanguageFeaturesService private readonly languageFeaturesService: ILanguageFeaturesService,
+		@IChatContextPickService chatContextPickService: IChatContextPickService
 	) {
 		super();
+
+		this._register(chatContextPickService.registerChatContextItem(new KernelVariableContextPicker(this.editorService, this.notebookKernelService)));
 
 		this._ctxHasProvider = CTX_NOTEBOOK_CHAT_HAS_AGENT.bindTo(contextKeyService);
 
@@ -237,6 +242,67 @@ export class SelectAndInsertKernelVariableAction extends Action2 {
 				kind: 'generic'
 			});
 		}
+	}
+}
+
+class KernelVariableContextPicker implements IChatContextPickerItem {
+
+	readonly type = 'pickerPick';
+	readonly label = localize('chatContext.notebook.kernelVariable', 'Kernel Variable...');
+	readonly icon = Codicon.serverEnvironment;
+
+	constructor(
+		@IEditorService private readonly editorService: IEditorService,
+		@INotebookKernelService private readonly notebookKernelService: INotebookKernelService,
+	) { }
+
+	isEnabled(widget: IChatWidget): Promise<boolean> | boolean {
+		return widget.location === ChatAgentLocation.Notebook && Boolean(getNotebookEditorFromEditorPane(this.editorService.activeEditorPane)?.getViewModel()?.notebookDocument);
+	}
+
+	asPicker(): { readonly placeholder: string; readonly picks: Promise<(IChatContextPickerPickItem | IQuickPickSeparator)[]> } {
+
+		const picks = (async () => {
+
+			const notebook = getNotebookEditorFromEditorPane(this.editorService.activeEditorPane)?.getViewModel()?.notebookDocument;
+
+			if (!notebook) {
+				return [];
+			}
+
+			const selectedKernel = this.notebookKernelService.getMatchingKernel(notebook).selected;
+			const hasVariableProvider = selectedKernel?.hasVariableProvider;
+
+			if (!hasVariableProvider) {
+				return [];
+			}
+
+			const variables = selectedKernel.provideVariables(notebook.uri, undefined, 'named', 0, CancellationToken.None);
+
+			const result: IChatContextPickerPickItem[] = [];
+			for await (const variable of variables) {
+				result.push({
+					label: variable.name,
+					description: variable.value,
+					asAttachment: () => {
+						return {
+							kind: 'generic',
+							id: 'vscode.notebook.variable',
+							name: variable.name,
+							value: variable.value,
+							icon: codiconsLibrary.variable,
+						};
+					},
+				});
+			}
+
+			return result;
+		})();
+
+		return {
+			placeholder: localize('chatContext.notebook.kernelVariable.placeholder', 'Select a kernel variable'),
+			picks
+		};
 	}
 }
 

--- a/src/vs/workbench/contrib/search/browser/chatContributions.ts
+++ b/src/vs/workbench/contrib/search/browser/chatContributions.ts
@@ -1,0 +1,348 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Codicon } from '../../../../base/common/codicons.js';
+import { Disposable } from '../../../../base/common/lifecycle.js';
+import { ThemeIcon } from '../../../../base/common/themables.js';
+import { localize } from '../../../../nls.js';
+import { IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
+import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
+import { ILabelService } from '../../../../platform/label/common/label.js';
+import { IWorkbenchContribution } from '../../../common/contributions.js';
+import { getExcludes, IFileQuery, ISearchComplete, ISearchConfiguration, ISearchService, QueryType, VIEW_ID } from '../../../services/search/common/search.js';
+import { IViewsService } from '../../../services/views/common/viewsService.js';
+import { IChatContextPickerItem, IChatContextPickerPickItem, IChatContextPickService, IChatContextValueItem } from '../../chat/browser/chatContextPickService.js';
+import { IChatRequestVariableEntry, ISymbolVariableEntry } from '../../chat/common/chatModel.js';
+import { SearchContext } from '../common/constants.js';
+import { SearchView } from './searchView.js';
+import { CancellationToken } from '../../../../base/common/cancellation.js';
+import { basename, dirname, joinPath, relativePath } from '../../../../base/common/resources.js';
+import { compare } from '../../../../base/common/strings.js';
+import { URI } from '../../../../base/common/uri.js';
+import { ILanguageService } from '../../../../editor/common/languages/language.js';
+import { getIconClasses } from '../../../../editor/common/services/getIconClasses.js';
+import { IModelService } from '../../../../editor/common/services/model.js';
+import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
+import { FileKind, FileType, IFileService } from '../../../../platform/files/common/files.js';
+import { IWorkspaceContextService } from '../../../../platform/workspace/common/workspace.js';
+import { IHistoryService } from '../../../services/history/common/history.js';
+import { isCancellationError } from '../../../../base/common/errors.js';
+import * as glob from '../../../../base/common/glob.js';
+import { ResourceSet } from '../../../../base/common/map.js';
+import { SymbolsQuickAccessProvider } from './symbolsQuickAccess.js';
+import { SymbolKinds } from '../../../../editor/common/languages.js';
+
+export class SearchChatContextContribution extends Disposable implements IWorkbenchContribution {
+
+	static readonly ID = 'workbench.contributions.searchChatContextContribution';
+
+	constructor(
+		@IInstantiationService instantiationService: IInstantiationService,
+		@IChatContextPickService chatContextPickService: IChatContextPickService
+	) {
+		super();
+		this._store.add(chatContextPickService.registerChatContextItem(instantiationService.createInstance(SearchViewResultChatContextPick)));
+		this._store.add(chatContextPickService.registerChatContextItem(instantiationService.createInstance(FilesAndFoldersPickerPick)));
+		this._store.add(chatContextPickService.registerChatContextItem(this._store.add(instantiationService.createInstance(SymbolsContextPickerPick))));
+	}
+}
+
+class SearchViewResultChatContextPick implements IChatContextValueItem {
+
+	readonly type = 'valuePick';
+	readonly label: string = localize('chatContext.searchResults', 'Search Results');
+	readonly icon: ThemeIcon = Codicon.search;
+	readonly ordinal = 500;
+
+	constructor(
+		@IContextKeyService private readonly _contextKeyService: IContextKeyService,
+		@IViewsService private readonly _viewsService: IViewsService,
+		@ILabelService private readonly _labelService: ILabelService,
+	) { }
+
+	isEnabled(): Promise<boolean> | boolean {
+		return !!SearchContext.HasSearchResults.getValue(this._contextKeyService);
+	}
+
+	async asAttachment(): Promise<IChatRequestVariableEntry[]> {
+		const searchView = this._viewsService.getViewWithId(VIEW_ID);
+		if (!(searchView instanceof SearchView)) {
+			return [];
+		}
+
+		return searchView.model.searchResult.matches().map(result => ({
+			kind: 'file',
+			id: result.resource.toString(),
+			value: result.resource,
+			name: this._labelService.getUriBasenameLabel(result.resource),
+		}));
+	}
+}
+
+class SymbolsContextPickerPick implements IChatContextPickerItem {
+
+	readonly type = 'pickerPick';
+
+	readonly label: string = localize('symbols', 'Symbols...');
+	readonly icon: ThemeIcon = Codicon.symbolField;
+	readonly ordinal = -200;
+
+	private _provider: SymbolsQuickAccessProvider | undefined;
+
+	constructor(
+		@IInstantiationService private readonly _instantiationService: IInstantiationService,
+	) { }
+
+	dispose(): void {
+		this._provider?.dispose();
+	}
+
+	asPicker(): {
+		readonly placeholder: string;
+		readonly picks: (query: string, token: CancellationToken) => Promise<IChatContextPickerPickItem[]>;
+	} {
+
+		return {
+			placeholder: localize('select.symb', "Select a symbol"),
+			picks: async (query: string, token: CancellationToken) => {
+
+				this._provider ??= this._instantiationService.createInstance(SymbolsQuickAccessProvider);
+
+				return this._provider.getSymbolPicks(query, undefined, token).then(symbolItems => {
+					const result: IChatContextPickerPickItem[] = [];
+					for (const item of symbolItems) {
+						if (!item.symbol) {
+							continue;
+						}
+
+						const attachment: ISymbolVariableEntry = {
+							kind: 'symbol',
+							id: JSON.stringify(item.symbol.location),
+							value: item.symbol.location,
+							symbolKind: item.symbol.kind,
+							icon: SymbolKinds.toIcon(item.symbol.kind),
+							fullName: item.label,
+							name: item.symbol.name,
+						};
+
+						result.push({
+							label: item.symbol.name,
+							iconClass: ThemeIcon.asClassName(SymbolKinds.toIcon(item.symbol.kind)),
+							asAttachment() {
+								return attachment;
+							}
+						});
+					}
+					return result;
+				});
+			}
+		};
+	}
+}
+
+class FilesAndFoldersPickerPick implements IChatContextPickerItem {
+
+	readonly type = 'pickerPick';
+	readonly label = localize('chatContext.folder', 'Files & Folders...');
+	readonly icon = Codicon.folder;
+	readonly ordinal = 600;
+
+	constructor(
+		@ISearchService private readonly _searchService: ISearchService,
+		@ILabelService private readonly _labelService: ILabelService,
+		@IModelService private readonly _modelService: IModelService,
+		@ILanguageService private readonly _languageService: ILanguageService,
+		@IConfigurationService private readonly _configurationService: IConfigurationService,
+		@IWorkspaceContextService private readonly _workspaceService: IWorkspaceContextService,
+		@IFileService private readonly _fileService: IFileService,
+		@IHistoryService private readonly _historyService: IHistoryService,
+	) { }
+
+	asPicker(): {
+		readonly placeholder: string;
+		readonly picks: (query: string, token: CancellationToken) => Promise<IChatContextPickerPickItem[]>;
+	} {
+
+		return {
+			placeholder: localize('chatContext.attach.files.placeholder', "Search file or folder by name"),
+			picks: async (value, token) => {
+
+				const workspaces = this._workspaceService.getWorkspace().folders.map(folder => folder.uri);
+
+				const defaultItems: IChatContextPickerPickItem[] = [];
+				(await getTopLevelFolders(workspaces, this._fileService)).forEach(uri => defaultItems.push(this._createPickItem(uri, FileKind.FOLDER)));
+				this._historyService.getHistory().filter(a => a.resource).slice(0, 30).forEach(uri => defaultItems.push(this._createPickItem(uri.resource!, FileKind.FILE)));
+
+				if (value === '') {
+					return defaultItems;
+				}
+
+				const result: IChatContextPickerPickItem[] = [];
+
+				await Promise.all(workspaces.map(async workspace => {
+					const { folders, files } = await searchFilesAndFolders(
+						workspace,
+						value,
+						true,
+						token,
+						undefined,
+						this._configurationService,
+						this._searchService
+					);
+
+					for (const folder of folders) {
+						result.push(this._createPickItem(folder, FileKind.FOLDER));
+					}
+					for (const file of files) {
+						result.push(this._createPickItem(file, FileKind.FILE));
+					}
+				}));
+
+				result.sort((a, b) => compare(a.label, b.label));
+
+				return result;
+			},
+		};
+	}
+
+	private _createPickItem(resource: URI, kind: FileKind): IChatContextPickerPickItem {
+		return {
+			label: basename(resource),
+			description: this._labelService.getUriLabel(dirname(resource), { relative: true }),
+			iconClass: kind === FileKind.FILE
+				? getIconClasses(this._modelService, this._languageService, resource, FileKind.FILE).join(' ')
+				: ThemeIcon.asClassName(Codicon.folder),
+			asAttachment: () => {
+				return {
+					kind: kind === FileKind.FILE ? 'file' : 'directory',
+					id: resource.toString(),
+					value: resource,
+					name: basename(resource),
+				};
+			}
+		};
+	}
+
+}
+export async function searchFilesAndFolders(
+	workspace: URI,
+	pattern: string,
+	fuzzyMatch: boolean,
+	token: CancellationToken | undefined,
+	cacheKey: string | undefined,
+	configurationService: IConfigurationService,
+	searchService: ISearchService
+): Promise<{ folders: URI[]; files: URI[] }> {
+	const segmentMatchPattern = caseInsensitiveGlobPattern(fuzzyMatch ? fuzzyMatchingGlobPattern(pattern) : continousMatchingGlobPattern(pattern));
+
+	const searchExcludePattern = getExcludes(configurationService.getValue<ISearchConfiguration>({ resource: workspace })) || {};
+	const searchOptions: IFileQuery = {
+		folderQueries: [{
+			folder: workspace,
+			disregardIgnoreFiles: configurationService.getValue<boolean>('explorer.excludeGitIgnore'),
+		}],
+		type: QueryType.File,
+		shouldGlobMatchFilePattern: true,
+		cacheKey,
+		excludePattern: searchExcludePattern,
+		sortByScore: true,
+	};
+
+	let searchResult: ISearchComplete | undefined;
+	try {
+		searchResult = await searchService.fileSearch({ ...searchOptions, filePattern: `{**/${segmentMatchPattern}/**,${pattern}}` }, token);
+	} catch (e) {
+		if (!isCancellationError(e)) {
+			throw e;
+		}
+	}
+
+	if (!searchResult || token?.isCancellationRequested) {
+		return { files: [], folders: [] };
+	}
+
+	const fileResources = searchResult.results.map(result => result.resource);
+	const folderResources = getMatchingFoldersFromFiles(fileResources, workspace, segmentMatchPattern);
+
+	return { folders: folderResources, files: fileResources };
+}
+
+function fuzzyMatchingGlobPattern(pattern: string): string {
+	if (!pattern) {
+		return '*';
+	}
+	return '*' + pattern.split('').join('*') + '*';
+}
+
+function continousMatchingGlobPattern(pattern: string): string {
+	if (!pattern) {
+		return '*';
+	}
+	return '*' + pattern + '*';
+}
+
+function caseInsensitiveGlobPattern(pattern: string): string {
+	let caseInsensitiveFilePattern = '';
+	for (let i = 0; i < pattern.length; i++) {
+		const char = pattern[i];
+		if (/[a-zA-Z]/.test(char)) {
+			caseInsensitiveFilePattern += `[${char.toLowerCase()}${char.toUpperCase()}]`;
+		} else {
+			caseInsensitiveFilePattern += char;
+		}
+	}
+	return caseInsensitiveFilePattern;
+}
+
+// TODO: remove this and have support from the search service
+function getMatchingFoldersFromFiles(resources: URI[], workspace: URI, segmentMatchPattern: string): URI[] {
+	const uniqueFolders = new ResourceSet();
+	for (const resource of resources) {
+		const relativePathToRoot = relativePath(workspace, resource);
+		if (!relativePathToRoot) {
+			throw new Error('Resource is not a child of the workspace');
+		}
+
+		let dirResource = workspace;
+		const stats = relativePathToRoot.split('/').slice(0, -1);
+		for (const stat of stats) {
+			dirResource = dirResource.with({ path: `${dirResource.path}/${stat}` });
+			uniqueFolders.add(dirResource);
+		}
+	}
+
+	const matchingFolders: URI[] = [];
+	for (const folderResource of uniqueFolders) {
+		const stats = folderResource.path.split('/');
+		const dirStat = stats[stats.length - 1];
+		if (!dirStat || !glob.match(segmentMatchPattern, dirStat)) {
+			continue;
+		}
+
+		matchingFolders.push(folderResource);
+	}
+
+	return matchingFolders;
+}
+
+export async function getTopLevelFolders(workspaces: URI[], fileService: IFileService): Promise<URI[]> {
+	const folders: URI[] = [];
+	for (const workspace of workspaces) {
+		const fileSystemProvider = fileService.getProvider(workspace.scheme);
+		if (!fileSystemProvider) {
+			continue;
+		}
+
+		const entries = await fileSystemProvider.readdir(workspace);
+		for (const [name, type] of entries) {
+			const entryResource = joinPath(workspace, name);
+			if (type === FileType.Directory) {
+				folders.push(entryResource);
+			}
+		}
+	}
+
+	return folders;
+}

--- a/src/vs/workbench/contrib/search/browser/search.contribution.ts
+++ b/src/vs/workbench/contrib/search/browser/search.contribution.ts
@@ -32,6 +32,7 @@ import { CommandsRegistry } from '../../../../platform/commands/common/commands.
 import { assertType } from '../../../../base/common/types.js';
 import { getWorkspaceSymbols, IWorkspaceSymbol } from '../common/search.js';
 import * as Constants from '../common/constants.js';
+import { SearchChatContextContribution } from './chatContributions.js';
 
 import './searchActionsCopy.js';
 import './searchActionsFind.js';
@@ -42,6 +43,7 @@ import './searchActionsTopBar.js';
 import './searchActionsTextQuickAccess.js';
 import { TEXT_SEARCH_QUICK_ACCESS_PREFIX, TextSearchQuickAccess } from './quickTextSearch/textSearchQuickAccess.js';
 import { Extensions, IConfigurationMigrationRegistry } from '../../../common/configuration.js';
+import { registerWorkbenchContribution2, WorkbenchPhase } from '../../../common/contributions.js';
 
 registerSingleton(ISearchViewModelWorkbenchService, SearchViewModelWorkbenchService, InstantiationType.Delayed);
 registerSingleton(ISearchHistoryService, SearchHistoryService, InstantiationType.Delayed);
@@ -49,6 +51,8 @@ registerSingleton(ISearchHistoryService, SearchHistoryService, InstantiationType
 replaceContributions();
 notebookSearchContributions();
 searchWidgetContributions();
+
+registerWorkbenchContribution2(SearchChatContextContribution.ID, SearchChatContextContribution, WorkbenchPhase.AfterRestored);
 
 const SEARCH_MODE_CONFIG = 'search.mode';
 


### PR DESCRIPTION
This PR cleans up `AttachContextAction` by moving individual attachment types out into contributes types (`IChatContextPickService` and `IChatContextItem`). Some types remain within the chat-feature but other move into their respective layer, e.g notebooks, search, or marker.

Also, the `IChatContextItem` encapsulates all logic into one type, e.g presentation (label, icon) and how it transform into an attachment (directly or via a nested pick)