### PR TITLE
[prompts]: fix window freeze issue when a prompt with empty header is executed

### DIFF
--- a/src/vs/base/common/codecs/baseDecoder.ts
+++ b/src/vs/base/common/codecs/baseDecoder.ts
@@ -105,7 +105,7 @@ export abstract class BaseDecoder<
 	 */
 	public start(): this {
 		assert(
-			!this._ended,
+			this._ended === false,
 			'Cannot start stream that has already ended.',
 		);
 		assert(
@@ -119,9 +119,15 @@ export abstract class BaseDecoder<
 		}
 		this.started = true;
 
-		this.stream.on('data', this.tryOnStreamData);
-		this.stream.on('error', this.onStreamError);
+		/**
+		 * !NOTE! The order of event subscriptions is critical here because
+		 *        the `data` event is also starts the stream, hence changing
+		 *        the order of event subscriptions can lead to race conditions.
+		 *        See {@link ReadableStreamEvents} for more info.
+		 */
 		this.stream.on('end', this.onStreamEnd);
+		this.stream.on('error', this.onStreamError);
+		this.stream.on('data', this.tryOnStreamData);
 
 		// this allows to compose decoders together, - if a decoder
 		// instance is passed as a readable stream to this decoder,
@@ -244,7 +250,7 @@ export abstract class BaseDecoder<
 	 */
 	public resume(): void {
 		assert(
-			!this.ended,
+			this.ended === false,
 			'Cannot resume the stream because it has already ended.',
 		);
 

--- a/src/vs/editor/test/common/codecs/frontMatterDecoder.test.ts
+++ b/src/vs/editor/test/common/codecs/frontMatterDecoder.test.ts
@@ -114,4 +114,12 @@ suite('FrontMatterDecoder', () => {
 				new Space(new Range(3, 27, 3, 28)),
 			]);
 	});
+
+	test('• empty', async () => {
+		const test = disposables.add(
+			new TestFrontMatterDecoder(),
+		);
+
+		await test.run('', []);
+	});
 });

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/basePromptParser.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/basePromptParser.ts
@@ -328,6 +328,13 @@ export class BasePromptParser<TContentsProvider extends IPromptContentsProvider>
 		// decode the byte stream to a stream of prompt tokens
 		this.stream = ChatPromptCodec.decode(streamOrError);
 
+		/**
+		 * !NOTE! The order of event subscriptions below is critical here because
+		 *        the `data` event is also starts the stream, hence changing
+		 *        the order of event subscriptions can lead to race conditions.
+		 *        See {@link ReadableStreamEvents} for more info.
+		 */
+
 		// on error or stream end, dispose the stream and fire the update event
 		this.stream.on('error', this.onStreamEnd.bind(this, this.stream));
 		this.stream.on('end', this.onStreamEnd.bind(this, this.stream));

--- a/src/vs/workbench/contrib/chat/test/common/promptSyntax/parsers/textModelPromptParser.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/promptSyntax/parsers/textModelPromptParser.test.ts
@@ -290,6 +290,51 @@ suite('TextModelPromptParser', () => {
 
 	suite('• header', () => {
 		suite(' • metadata', () => {
+			test(`• empty header`, async () => {
+				const test = createTest(
+					URI.file('/absolute/folder/and/a/filename.txt'),
+					[
+					/* 01 */"---",
+					/* 02 */"",
+					/* 03 */"---",
+					/* 04 */"The cactus on my desk has a thriving Instagram account.",
+					/* 05 */"Midnight snacks are the secret to eternal [text](./foo-bar-baz/another-file.ts) happiness.",
+					/* 06 */"In an alternate universe, pigeons deliver sushi by drone.",
+					/* 07 */"Lunar rainbows only appear when you sing in falsetto.",
+					/* 08 */"Carrots have secret telepathic abilities, but only on Tuesdays.",
+					],
+				);
+
+				await test.validateReferences([
+					new ExpectedReference({
+						uri: URI.file('/absolute/folder/and/a/foo-bar-baz/another-file.ts'),
+						text: '[text](./foo-bar-baz/another-file.ts)',
+						path: './foo-bar-baz/another-file.ts',
+						startLine: 5,
+						startColumn: 43,
+						pathStartColumn: 50,
+						childrenOrError: new OpenFailed(URI.file('/absolute/folder/and/a/foo-bar-baz/another-file.ts'), 'File not found.'),
+					}),
+				]);
+
+				const { header, metadata } = test.parser;
+				assertDefined(
+					header,
+					'Prompt header must be defined.',
+				);
+
+				assert.deepStrictEqual(
+					metadata,
+					{
+						applyTo: undefined,
+						description: undefined,
+						mode: undefined,
+						tools: undefined,
+					},
+					'Must have empty metadata.',
+				);
+			});
+
 			test(`• has correct 'prompt' metadata`, async () => {
 				const test = createTest(
 					URI.file('/absolute/folder/and/a/filename.txt'),


### PR DESCRIPTION
The issue is caused by a race condition due to improper order of stream event subscriptions. 

For https://github.com/microsoft/vscode/issues/248509