### PR TITLE
fix git bash suggestions

### DIFF
--- a/extensions/terminal-suggest/src/env/pathExecutableCache.ts
+++ b/extensions/terminal-suggest/src/env/pathExecutableCache.ts
@@ -12,6 +12,7 @@ import { getFriendlyResourcePath } from '../helpers/uri';
 import { SettingsIds } from '../constants';
 import * as filesystem from 'fs';
 import * as path from 'path';
+import { TerminalShellType } from '../terminalSuggestMain';
 
 const isWindows = osIsWindows();
 
@@ -45,10 +46,14 @@ export class PathExecutableCache implements vscode.Disposable {
 		this._cachedPathValue = undefined;
 	}
 
-	async getExecutablesInPath(env: ITerminalEnvironment = process.env): Promise<{ completionResources: Set<ICompletionResource> | undefined; labels: Set<string> | undefined } | undefined> {
+	async getExecutablesInPath(env: ITerminalEnvironment = process.env, shellType?: TerminalShellType): Promise<{ completionResources: Set<ICompletionResource> | undefined; labels: Set<string> | undefined } | undefined> {
 		// Create cache key
 		let pathValue: string | undefined;
-		if (isWindows) {
+		if (shellType === TerminalShellType.GitBash) {
+			// TODO: figure out why shellIntegration.env.PATH
+			// regressed from using \ to / (correct)
+			pathValue = process.env.PATH;
+		} else if (isWindows) {
 			const caseSensitivePathKey = Object.keys(env).find(key => key.toLowerCase() === 'path');
 			if (caseSensitivePathKey) {
 				pathValue = env[caseSensitivePathKey];

--- a/extensions/terminal-suggest/src/terminalSuggestMain.ts
+++ b/extensions/terminal-suggest/src/terminalSuggestMain.ts
@@ -105,7 +105,7 @@ export async function activate(context: vscode.ExtensionContext) {
 				return;
 			}
 
-			const commandsInPath = await pathExecutableCache.getExecutablesInPath(terminal.shellIntegration?.env?.value);
+			const commandsInPath = await pathExecutableCache.getExecutablesInPath(terminal.shellIntegration?.env?.value, terminalShellType);
 			const shellGlobals = await getShellGlobals(terminalShellType, commandsInPath?.labels) ?? [];
 			if (!commandsInPath?.completionResources) {
 				console.debug('#terminalCompletions No commands found in path');
@@ -143,7 +143,7 @@ export async function activate(context: vscode.ExtensionContext) {
 			}
 
 			if (terminal.shellIntegration?.cwd && (result.filesRequested || result.foldersRequested)) {
-				return new vscode.TerminalCompletionList(result.items, { filesRequested: result.filesRequested, foldersRequested: result.foldersRequested, fileExtensions: result.fileExtensions, cwd: result.cwd ?? terminal.shellIntegration.cwd, env: terminal.shellIntegration?.env?.value });
+				return new vscode.TerminalCompletionList(result.items, { filesRequested: result.filesRequested, foldersRequested: result.foldersRequested, fileExtensions: result.fileExtensions, cwd: result.cwd ?? terminal.shellIntegration.cwd, env: terminal.shellIntegration?.env?.value, });
 			}
 			return result.items;
 		}


### PR DESCRIPTION
fixes #245843

Initial investigation that led me to `shellIntegration.env` as the cause:
https://github.com/microsoft/vscode/pull/248424#issuecomment-2864285888

From there, @anthonykim1 and I went back and forth on this to figure out the solution:

`shellIntegration.env.value.PATH` used to report the path using `\` correctly (in 1.98). Now, it uses `/`, so we are deferring to `process.env` to fix this, as that uses `\` and allows us to reolve the executables.

Follow-up items, discovered during this lengthy debugging 😅 :
- https://github.com/microsoft/vscode/issues/248558 (me)
- https://github.com/microsoft/vscode/issues/248559 (me)
- https://github.com/microsoft/vscode/issues/248561 (@anthonykim1)