### PR TITLE
Ignore error when deleting last search result

### DIFF
--- a/src/vs/workbench/contrib/search/browser/searchActionsRemoveReplace.ts
+++ b/src/vs/workbench/contrib/search/browser/searchActionsRemoveReplace.ts
@@ -129,7 +129,8 @@ registerAction2(class RemoveAction extends Action2 {
 
 		if (focusElement && shouldRefocusMatch) {
 			if (!nextFocusElement) {
-				nextFocusElement = await getLastNodeFromSameType(viewer, focusElement);
+				// Ignore error if there are no elements left
+				nextFocusElement = await getLastNodeFromSameType(viewer, focusElement).catch(() => { });
 			}
 
 			if (nextFocusElement && !arrayContainsElementOrParent(nextFocusElement, elementsToRemove)) {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Fixes: https://github.com/microsoft/vscode/issues/245643

Ignore error from finding the next element to focus on after deleting the last result entry.

This is only for deletions that happen with delete keys since doing it through the UI seems to have some fallback
