### PR TITLE
Migrate built-in php extension off of CompletionItem.textEdit

### DIFF
--- a/extensions/php-language-features/src/features/completionItemProvider.ts
+++ b/extensions/php-language-features/src/features/completionItemProvider.ts
@@ -3,9 +3,9 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { CompletionItemProvider, CompletionItem, CompletionItemKind, CancellationToken, TextDocument, Position, Range, TextEdit, workspace, CompletionContext } from 'vscode';
-import * as phpGlobals from './phpGlobals';
+import { CancellationToken, CompletionContext, CompletionItem, CompletionItemKind, CompletionItemProvider, Position, Range, TextDocument, workspace } from 'vscode';
 import * as phpGlobalFunctions from './phpGlobalFunctions';
+import * as phpGlobals from './phpGlobals';
 
 export default class PHPCompletionItemProvider implements CompletionItemProvider {
 
@@ -56,7 +56,8 @@ export default class PHPCompletionItemProvider implements CompletionItemProvider
 
 			if (beforeWord === '<?') {
 				const proposal = createNewProposal(CompletionItemKind.Class, '<?php', null);
-				proposal.textEdit = new TextEdit(new Range(twoBeforePosition, position), '<?php');
+				proposal.insertText = '<?php';
+				proposal.range = new Range(twoBeforePosition, position);
 				result.push(proposal);
 				return Promise.resolve(result);
 			}


### PR DESCRIPTION
Fix #237860

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
