### PR TITLE
aux windows - do not show actions toggled

### DIFF
--- a/src/vs/workbench/browser/parts/editor/auxiliaryEditorPart.ts
+++ b/src/vs/workbench/browser/parts/editor/auxiliaryEditorPart.ts
@@ -89,7 +89,6 @@ registerAction2(class extends Action2 {
 			id: 'workbench.action.disableCompactAuxiliaryWindow',
 			title: localize('disableCompactAuxiliaryWindow', "Unset Compact Mode"),
 			icon: Codicon.screenNormal,
-			toggled: ContextKeyExpr.and(IsAuxiliaryTitleBarContext, IsCompactTitleBarContext),
 			menu: {
 				id: MenuId.LayoutControlMenu,
 				when: ContextKeyExpr.and(IsAuxiliaryTitleBarContext, IsCompactTitleBarContext),

--- a/src/vs/workbench/electron-sandbox/actions/windowActions.ts
+++ b/src/vs/workbench/electron-sandbox/actions/windowActions.ts
@@ -484,8 +484,7 @@ export class DisableWindowAlwaysOnTopAction extends Action2 {
 		super({
 			id: DisableWindowAlwaysOnTopAction.ID,
 			title: localize('disableWindowAlwaysOnTop', "Unset Always on Top"),
-			icon: Codicon.pin,
-			toggled: { condition: IsWindowAlwaysOnTopContext, icon: Codicon.pinned },
+			icon: Codicon.pinned,
 			menu: {
 				id: MenuId.LayoutControlMenu,
 				when: ContextKeyExpr.and(IsWindowAlwaysOnTopContext, IsAuxiliaryTitleBarContext),


### PR DESCRIPTION
Since some windows open toggled by default, this results in a more calm UI.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
