### PR TITLE
Fix PowerShell shell integration when strict mode is enabled.

### DIFF
--- a/src/vs/workbench/contrib/terminal/common/scripts/shellIntegration.ps1
+++ b/src/vs/workbench/contrib/terminal/common/scripts/shellIntegration.ps1
@@ -139,7 +139,7 @@ if ($env:STARSHIP_SESSION_KEY) {
 elseif ($env:POSH_SESSION_ID) {
 	[Console]::Write("$([char]0x1b)]633;P;PromptType=oh-my-posh`a")
 }
-elseif ($Global:GitPromptSettings) {
+elseif ((Test-Path variable:global:GitPromptSettings) -and $Global:GitPromptSettings) {
 	[Console]::Write("$([char]0x1b)]633;P;PromptType=posh-git`a")
 }
 


### PR DESCRIPTION
Check if variable exists before accessing it to prevent script failures in strict mode.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
