### PR TITLE
Add `runOptions.instancePolicy` for tasks

### DIFF
--- a/src/vs/workbench/contrib/tasks/browser/terminalTaskSystem.ts
+++ b/src/vs/workbench/contrib/tasks/browser/terminalTaskSystem.ts
@@ -399,6 +399,16 @@ export class TerminalTaskSystem extends Disposable implements ITaskSystem {
 			(value) => recentKey && recentKey === value.task.getKey())?.task;
 	}
 
+	public getFirstInstance(task: Task): Task | undefined {
+		const recentKey = task.getKey();
+		for (const task of this.getActiveTasks()) {
+			if (recentKey && recentKey === task.getKey()) {
+				return task;
+			}
+		}
+		return undefined;
+	}
+
 	public getBusyTasks(): Task[] {
 		return Object.keys(this._busyTasks).map(key => this._busyTasks[key]);
 	}

--- a/src/vs/workbench/contrib/tasks/common/jsonSchema_v2.ts
+++ b/src/vs/workbench/contrib/tasks/common/jsonSchema_v2.ts
@@ -378,6 +378,19 @@ const runOptions: IJSONSchema = {
 			description: nls.localize('JsonSchema.tasks.instanceLimit', 'The number of instances of the task that are allowed to run simultaneously.'),
 			default: 1
 		},
+		instancePolicy: {
+			type: 'string',
+			enum: ['terminateNewest', 'terminateOldest', 'prompt', 'warn', 'silent'],
+			enumDescriptions: [
+				nls.localize('JsonSchema.tasks.instancePolicy.terminateNewest', 'Terminates the newest instance.'),
+				nls.localize('JsonSchema.tasks.instancePolicy.terminateOldest', 'Terminates the oldest instance.'),
+				nls.localize('JsonSchema.tasks.instancePolicy.prompt', 'Asks which instance to terminate.'),
+				nls.localize('JsonSchema.tasks.instancePolicy.warn', 'Does nothing but warns that the instance limit has been reached.'),
+				nls.localize('JsonSchema.tasks.instancePolicy.silent', 'Does nothing.'),
+			],
+			description: nls.localize('JsonSchema.tasks.instancePolicy', 'Policy to apply when instance limit is reached.'),
+			default: 'prompt'
+		}
 	},
 	description: nls.localize('JsonSchema.tasks.runOptions', 'The task\'s run related options')
 };

--- a/src/vs/workbench/contrib/tasks/common/taskConfiguration.ts
+++ b/src/vs/workbench/contrib/tasks/common/taskConfiguration.ts
@@ -142,6 +142,7 @@ export interface IRunOptionsConfig {
 	reevaluateOnRerun?: boolean;
 	runOn?: string;
 	instanceLimit?: number;
+	instancePolicy?: Tasks.InstancePolicy;
 }
 
 export interface ITaskIdentifier {
@@ -708,12 +709,13 @@ export namespace RunOnOptions {
 }
 
 export namespace RunOptions {
-	const properties: IMetaData<Tasks.IRunOptions, void>[] = [{ property: 'reevaluateOnRerun' }, { property: 'runOn' }, { property: 'instanceLimit' }];
+	const properties: IMetaData<Tasks.IRunOptions, void>[] = [{ property: 'reevaluateOnRerun' }, { property: 'runOn' }, { property: 'instanceLimit' }, { property: 'instancePolicy' }];
 	export function fromConfiguration(value: IRunOptionsConfig | undefined): Tasks.IRunOptions {
 		return {
 			reevaluateOnRerun: value ? value.reevaluateOnRerun : true,
 			runOn: value ? RunOnOptions.fromString(value.runOn) : Tasks.RunOnOptions.default,
-			instanceLimit: value ? value.instanceLimit : 1
+			instanceLimit: value ? value.instanceLimit : 1,
+			instancePolicy: value ? InstancePolicy.fromString(value.instancePolicy) : Tasks.InstancePolicy.prompt
 		};
 	}
 
@@ -723,6 +725,27 @@ export namespace RunOptions {
 
 	export function fillProperties(target: Tasks.IRunOptions, source: Tasks.IRunOptions | undefined): Tasks.IRunOptions {
 		return _fillProperties(target, source, properties)!;
+	}
+}
+
+export namespace InstancePolicy {
+	export function fromString(value: string | undefined): Tasks.InstancePolicy {
+		if (!value) {
+			return Tasks.InstancePolicy.prompt;
+		}
+		switch (value.toLowerCase()) {
+			case 'terminatenewest':
+				return Tasks.InstancePolicy.terminateNewest;
+			case 'terminateoldest':
+				return Tasks.InstancePolicy.terminateOldest;
+			case 'warn':
+				return Tasks.InstancePolicy.warn;
+			case 'silent':
+				return Tasks.InstancePolicy.silent;
+			case 'prompt':
+			default:
+				return Tasks.InstancePolicy.prompt;
+		}
 	}
 }
 

--- a/src/vs/workbench/contrib/tasks/common/taskSystem.ts
+++ b/src/vs/workbench/contrib/tasks/common/taskSystem.ts
@@ -117,4 +117,5 @@ export interface ITaskSystem {
 	customExecutionComplete(task: Task, result: number): Promise<void>;
 	isTaskVisible(task: Task): boolean;
 	getTaskForTerminal(instanceId: number): Task | undefined;
+	getFirstInstance(task: Task): Task | undefined;
 }

--- a/src/vs/workbench/contrib/tasks/common/tasks.ts
+++ b/src/vs/workbench/contrib/tasks/common/tasks.ts
@@ -565,14 +565,23 @@ export enum RunOnOptions {
 	folderOpen = 2
 }
 
+export const enum InstancePolicy {
+	terminateNewest = 'terminateNewest',
+	terminateOldest = 'terminateOldest',
+	prompt = 'prompt',
+	warn = 'warn',
+	silent = 'silent'
+}
+
 export interface IRunOptions {
 	reevaluateOnRerun?: boolean;
 	runOn?: RunOnOptions;
 	instanceLimit?: number;
+	instancePolicy?: InstancePolicy;
 }
 
 export namespace RunOptions {
-	export const defaults: IRunOptions = { reevaluateOnRerun: true, runOn: RunOnOptions.default, instanceLimit: 1 };
+	export const defaults: IRunOptions = { reevaluateOnRerun: true, runOn: RunOnOptions.default, instanceLimit: 1, instancePolicy: InstancePolicy.prompt };
 }
 
 export abstract class CommonTask {


### PR DESCRIPTION
Fixes #90125

Carries over changes from #117129 to a new branch to avoid conflicts. Also polishes a few things.

Note when verifying: after changing the `instancePolicy`, one must kill all instances of that task for it to take effect - that's by design as it's reusing the `instancePolicy` that was set for the prior task terminals.

Discovered this bug https://github.com/microsoft/vscode/issues/248733 in the process of testing

