### PR TITLE
Chat request removes words that start with / 

### DIFF
--- a/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsService.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsService.ts
@@ -134,7 +134,7 @@ export class PromptsService extends Disposable implements IPromptsService {
 	}
 
 	public asPromptSlashCommand(command: string): IChatPromptSlashCommand | undefined {
-		if (command.match(/^[\w_\-\.]+/)) {
+		if (command.match(/^[\w_\-\.]+$/)) {
 			return { command, detail: localize('prompt.file.detail', 'Prompt file: {0}', command) };
 		}
 		return undefined;

--- a/src/vs/workbench/contrib/chat/test/common/__snapshots__/ChatRequestParser_prompt_slash_command.0.snap
+++ b/src/vs/workbench/contrib/chat/test/common/__snapshots__/ChatRequestParser_prompt_slash_command.0.snap
@@ -1,0 +1,33 @@
+{
+  parts: [
+    {
+      range: {
+        start: 0,
+        endExclusive: 4
+      },
+      editorRange: {
+        startLineNumber: 1,
+        startColumn: 1,
+        endLineNumber: 1,
+        endColumn: 5
+      },
+      text: "    ",
+      kind: "text"
+    },
+    {
+      range: {
+        start: 4,
+        endExclusive: 11
+      },
+      editorRange: {
+        startLineNumber: 1,
+        startColumn: 5,
+        endLineNumber: 1,
+        endColumn: 12
+      },
+      slashPromptCommand: { command: "prompt" },
+      kind: "prompt"
+    }
+  ],
+  text: "    /prompt"
+}

--- a/src/vs/workbench/contrib/chat/test/common/__snapshots__/ChatRequestParser_prompt_slash_command_after_slash.0.snap
+++ b/src/vs/workbench/contrib/chat/test/common/__snapshots__/ChatRequestParser_prompt_slash_command_after_slash.0.snap
@@ -1,0 +1,19 @@
+{
+  parts: [
+    {
+      range: {
+        start: 0,
+        endExclusive: 41
+      },
+      editorRange: {
+        startLineNumber: 1,
+        startColumn: 1,
+        endLineNumber: 1,
+        endColumn: 42
+      },
+      text: "/ route and the request of /search-option",
+      kind: "text"
+    }
+  ],
+  text: "/ route and the request of /search-option"
+}

--- a/src/vs/workbench/contrib/chat/test/common/__snapshots__/ChatRequestParser_prompt_slash_command_after_text.0.snap
+++ b/src/vs/workbench/contrib/chat/test/common/__snapshots__/ChatRequestParser_prompt_slash_command_after_text.0.snap
@@ -1,0 +1,19 @@
+{
+  parts: [
+    {
+      range: {
+        start: 0,
+        endExclusive: 52
+      },
+      editorRange: {
+        startLineNumber: 1,
+        startColumn: 1,
+        endLineNumber: 1,
+        endColumn: 53
+      },
+      text: "handle the / route and the request of /search-option",
+      kind: "text"
+    }
+  ],
+  text: "handle the / route and the request of /search-option"
+}

--- a/src/vs/workbench/contrib/chat/test/common/__snapshots__/ChatRequestParser_slash_command_after_whitespace.0.snap
+++ b/src/vs/workbench/contrib/chat/test/common/__snapshots__/ChatRequestParser_slash_command_after_whitespace.0.snap
@@ -1,0 +1,33 @@
+{
+  parts: [
+    {
+      range: {
+        start: 0,
+        endExclusive: 4
+      },
+      editorRange: {
+        startLineNumber: 1,
+        startColumn: 1,
+        endLineNumber: 1,
+        endColumn: 5
+      },
+      text: "    ",
+      kind: "text"
+    },
+    {
+      range: {
+        start: 4,
+        endExclusive: 8
+      },
+      editorRange: {
+        startLineNumber: 1,
+        startColumn: 5,
+        endLineNumber: 1,
+        endColumn: 9
+      },
+      slashCommand: { command: "fix" },
+      kind: "slash"
+    }
+  ],
+  text: "    /fix"
+}

--- a/src/vs/workbench/contrib/chat/test/common/__snapshots__/ChatRequestParser_slash_command_not_first.0.snap
+++ b/src/vs/workbench/contrib/chat/test/common/__snapshots__/ChatRequestParser_slash_command_not_first.0.snap
@@ -1,0 +1,19 @@
+{
+  parts: [
+    {
+      range: {
+        start: 0,
+        endExclusive: 10
+      },
+      editorRange: {
+        startLineNumber: 1,
+        startColumn: 1,
+        endLineNumber: 1,
+        endColumn: 11
+      },
+      text: "Hello /fix",
+      kind: "text"
+    }
+  ],
+  text: "Hello /fix"
+}

--- a/src/vs/workbench/contrib/chat/test/common/__snapshots__/ChatRequestParser_slash_in_text.0.snap
+++ b/src/vs/workbench/contrib/chat/test/common/__snapshots__/ChatRequestParser_slash_in_text.0.snap
@@ -1,0 +1,19 @@
+{
+  parts: [
+    {
+      range: {
+        start: 0,
+        endExclusive: 65
+      },
+      editorRange: {
+        startLineNumber: 1,
+        startColumn: 1,
+        endLineNumber: 1,
+        endColumn: 66
+      },
+      text: "can we add a new file for an Express router to handle the / route",
+      kind: "text"
+    }
+  ],
+  text: "can we add a new file for an Express router to handle the / route"
+}

--- a/src/vs/workbench/contrib/chat/test/common/chatRequestParser.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/chatRequestParser.test.ts
@@ -61,6 +61,13 @@ suite('ChatRequestParser', () => {
 		await assertSnapshot(result);
 	});
 
+	test('slash in text', async () => {
+		parser = instantiationService.createInstance(ChatRequestParser);
+		const text = 'can we add a new file for an Express router to handle the / route';
+		const result = parser.parseChatRequest('1', text);
+		await assertSnapshot(result);
+	});
+
 	test('slash command', async () => {
 		const slashCommandService = mockObject<IChatSlashCommandService>()({});
 		slashCommandService.getCommands.returns([{ command: 'fix' }]);
@@ -93,6 +100,89 @@ suite('ChatRequestParser', () => {
 		const result = parser.parseChatRequest('1', text);
 		await assertSnapshot(result);
 	});
+
+	test('slash command not first', async () => {
+		const slashCommandService = mockObject<IChatSlashCommandService>()({});
+		slashCommandService.getCommands.returns([{ command: 'fix' }]);
+		instantiationService.stub(IChatSlashCommandService, slashCommandService as any);
+
+		parser = instantiationService.createInstance(ChatRequestParser);
+		const text = 'Hello /fix';
+		const result = parser.parseChatRequest('1', text);
+		await assertSnapshot(result);
+	});
+
+	test('slash command after whitespace', async () => {
+		const slashCommandService = mockObject<IChatSlashCommandService>()({});
+		slashCommandService.getCommands.returns([{ command: 'fix' }]);
+		instantiationService.stub(IChatSlashCommandService, slashCommandService as any);
+
+		parser = instantiationService.createInstance(ChatRequestParser);
+		const text = '    /fix';
+		const result = parser.parseChatRequest('1', text);
+		await assertSnapshot(result);
+	});
+
+	test('prompt slash command', async () => {
+		const slashCommandService = mockObject<IChatSlashCommandService>()({});
+		slashCommandService.getCommands.returns([{ command: 'fix' }]);
+		instantiationService.stub(IChatSlashCommandService, slashCommandService as any);
+
+		const promptSlashCommandService = mockObject<IPromptsService>()({});
+		promptSlashCommandService.asPromptSlashCommand.callsFake((command: string) => {
+			if (command.match(/^[\w_\-\.]+$/)) {
+				return { command };
+			}
+			return undefined;
+		});
+		instantiationService.stub(IPromptsService, promptSlashCommandService as any);
+
+		parser = instantiationService.createInstance(ChatRequestParser);
+		const text = '    /prompt';
+		const result = parser.parseChatRequest('1', text);
+		await assertSnapshot(result);
+	});
+
+	test('prompt slash command after text', async () => {
+		const slashCommandService = mockObject<IChatSlashCommandService>()({});
+		slashCommandService.getCommands.returns([{ command: 'fix' }]);
+		instantiationService.stub(IChatSlashCommandService, slashCommandService as any);
+
+		const promptSlashCommandService = mockObject<IPromptsService>()({});
+		promptSlashCommandService.asPromptSlashCommand.callsFake((command: string) => {
+			if (command.match(/^[\w_\-\.]+$/)) {
+				return { command };
+			}
+			return undefined;
+		});
+		instantiationService.stub(IPromptsService, promptSlashCommandService as any);
+
+		parser = instantiationService.createInstance(ChatRequestParser);
+		const text = 'handle the / route and the request of /search-option';
+		const result = parser.parseChatRequest('1', text);
+		await assertSnapshot(result);
+	});
+
+	test('prompt slash command after slash', async () => {
+		const slashCommandService = mockObject<IChatSlashCommandService>()({});
+		slashCommandService.getCommands.returns([{ command: 'fix' }]);
+		instantiationService.stub(IChatSlashCommandService, slashCommandService as any);
+
+		const promptSlashCommandService = mockObject<IPromptsService>()({});
+		promptSlashCommandService.asPromptSlashCommand.callsFake((command: string) => {
+			if (command.match(/^[\w_\-\.]+$/)) {
+				return { command };
+			}
+			return undefined;
+		});
+		instantiationService.stub(IPromptsService, promptSlashCommandService as any);
+
+		parser = instantiationService.createInstance(ChatRequestParser);
+		const text = '/ route and the request of /search-option';
+		const result = parser.parseChatRequest('1', text);
+		await assertSnapshot(result);
+	});
+
 
 	// test('variables', async () => {
 	// 	varService.hasVariable.returns(true);

--- a/src/vs/workbench/contrib/chat/test/common/mockPromptsService.ts
+++ b/src/vs/workbench/contrib/chat/test/common/mockPromptsService.ts
@@ -5,7 +5,6 @@
 
 import { URI } from '../../../../../base/common/uri.js';
 import { ITextModel } from '../../../../../editor/common/model.js';
-import { PROMPT_FILE_EXTENSION } from '../../../../../platform/prompts/common/constants.js';
 import { TextModelPromptParser } from '../../common/promptSyntax/parsers/textModelPromptParser.js';
 import { IChatPromptSlashCommand, IMetadata, IPromptPath, IPromptsService, TCombinedToolsMetadata, TPromptsType } from '../../common/promptSyntax/service/types.js';
 
@@ -26,13 +25,7 @@ export class MockPromptsService implements IPromptsService {
 	getSourceFolders(type: TPromptsType): readonly IPromptPath[] {
 		throw new Error('Method not implemented.');
 	}
-	public asPromptSlashCommand(name: string): IChatPromptSlashCommand | undefined {
-		if (name.endsWith(PROMPT_FILE_EXTENSION)) {
-			const command = `prompt:${name.substring(0, -PROMPT_FILE_EXTENSION.length)}`;
-			return {
-				command, detail: name,
-			};
-		}
+	public asPromptSlashCommand(command: string): IChatPromptSlashCommand | undefined {
 		return undefined;
 	}
 	resolvePromptSlashCommand(data: IChatPromptSlashCommand): Promise<IPromptPath | undefined> {


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/248721

@roblourens Can you have a look?
Is my assumption correct that slash command are only valid at the beginning of the chat input?

For April I added 'Prompt Chat commands' they represent a prompt.
Because the parser is sync, I can't find out at parse time if the prompt really exists, so I assume it's one if it has valid characters.

This however brings up the issue that we don't test if a slash command is at the beginning of the chat input.

