### PR TITLE
fix: add max height on dialog message (#248731)

### DIFF
--- a/src/vs/base/browser/ui/dialog/dialog.css
+++ b/src/vs/base/browser/ui/dialog/dialog.css
@@ -92,6 +92,7 @@
 .monaco-dialog-box .dialog-message-row .dialog-message-container .dialog-message-detail {
 	line-height: 22px;
 	flex: 1; /* let the message always grow */
+	max-height: 75vh;
 }
 
 .monaco-dialog-box .dialog-message-row .dialog-message-container .dialog-message a:focus {


### PR DESCRIPTION
Fixes: #248731

Added max-height to prevent text overflow when there is too much content.