### PR TITLE
Handle globs in Trusted Domains by part & no longer depend on it for Chat features

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatMarkdownRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatMarkdownRenderer.ts
@@ -16,7 +16,6 @@ import { IFileService } from '../../../../platform/files/common/files.js';
 import { IHoverService } from '../../../../platform/hover/browser/hover.js';
 import { IOpenerService } from '../../../../platform/opener/common/opener.js';
 import { REVEAL_IN_EXPLORER_COMMAND_ID } from '../../files/browser/fileConstants.js';
-import { ITrustedDomainService } from '../../url/browser/trustedDomainService.js';
 
 const allowedHtmlTags = [
 	'b',
@@ -63,7 +62,6 @@ export class ChatMarkdownRenderer extends MarkdownRenderer {
 		options: IMarkdownRendererOptions | undefined,
 		@ILanguageService languageService: ILanguageService,
 		@IOpenerService openerService: IOpenerService,
-		@ITrustedDomainService private readonly trustedDomainService: ITrustedDomainService,
 		@IHoverService private readonly hoverService: IHoverService,
 		@IFileService private readonly fileService: IFileService,
 		@ICommandService private readonly commandService: ICommandService,
@@ -74,7 +72,7 @@ export class ChatMarkdownRenderer extends MarkdownRenderer {
 	override render(markdown: IMarkdownString | undefined, options?: MarkdownRenderOptions, markedOptions?: MarkedOptions): IMarkdownRenderResult {
 		options = {
 			...options,
-			remoteImageIsAllowed: (uri) => this.trustedDomainService.isValid(uri),
+			remoteImageIsAllowed: (_uri) => false,
 			sanitizerOptions: {
 				replaceWithPlaintext: true,
 				allowedTags: allowedHtmlTags,

--- a/src/vs/workbench/contrib/chat/test/browser/__snapshots__/ChatMarkdownRenderer_remote_images.0.snap
+++ b/src/vs/workbench/contrib/chat/test/browser/__snapshots__/ChatMarkdownRenderer_remote_images.0.snap
@@ -1,1 +1,0 @@
-<div class="rendered-markdown"><p><img src="http://allowed.com/image.jpg"> </p><div>&lt;img src="http://disallowed.com/image.jpg"&gt;</div><p></p></div>

--- a/src/vs/workbench/contrib/chat/test/browser/__snapshots__/ChatMarkdownRenderer_remote_images_are_disallowed.0.snap
+++ b/src/vs/workbench/contrib/chat/test/browser/__snapshots__/ChatMarkdownRenderer_remote_images_are_disallowed.0.snap
@@ -1,0 +1,1 @@
+<div class="rendered-markdown"><p></p><div>&lt;img src="http://disallowed.com/image.jpg"&gt;</div><p></p></div>

--- a/src/vs/workbench/contrib/chat/test/browser/chatMarkdownRenderer.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/chatMarkdownRenderer.test.ts
@@ -7,8 +7,6 @@ import { MarkdownString } from '../../../../../base/common/htmlContent.js';
 import { assertSnapshot } from '../../../../../base/test/common/snapshot.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { ChatMarkdownRenderer } from '../../browser/chatMarkdownRenderer.js';
-import { ITrustedDomainService } from '../../../url/browser/trustedDomainService.js';
-import { MockTrustedDomainService } from '../../../url/test/browser/mockTrustedDomainService.js';
 import { workbenchInstantiationService } from '../../../../test/browser/workbenchTestServices.js';
 
 suite('ChatMarkdownRenderer', () => {
@@ -17,7 +15,6 @@ suite('ChatMarkdownRenderer', () => {
 	let testRenderer: ChatMarkdownRenderer;
 	setup(() => {
 		const instantiationService = store.add(workbenchInstantiationService(undefined, store));
-		instantiationService.stub(ITrustedDomainService, new MockTrustedDomainService(['http://allowed.com']));
 		testRenderer = instantiationService.createInstance(ChatMarkdownRenderer, {});
 	});
 
@@ -102,8 +99,8 @@ suite('ChatMarkdownRenderer', () => {
 		await assertSnapshot(result.element.outerHTML);
 	});
 
-	test('remote images', async () => {
-		const md = new MarkdownString('<img src="http://allowed.com/image.jpg"> <img src="http://disallowed.com/image.jpg">');
+	test('remote images are disallowed', async () => {
+		const md = new MarkdownString('<img src="http://disallowed.com/image.jpg">');
 		md.supportHtml = true;
 		const result = store.add(testRenderer.render(md));
 		await assertSnapshot(result.element.outerHTML);

--- a/src/vs/workbench/contrib/url/common/urlGlob.ts
+++ b/src/vs/workbench/contrib/url/common/urlGlob.ts
@@ -5,89 +5,154 @@
 
 import { URI } from '../../../../base/common/uri.js';
 
-// TODO: rewrite this to use URIs directly and validate each part individually
-// instead of relying on memoization of the stringified URI.
-export const testUrlMatchesGlob = (uri: URI, globUrl: string): boolean => {
-	let url = uri.with({ query: null, fragment: null }).toString(true);
-	const normalize = (url: string) => url.replace(/\/+$/, '');
-	globUrl = normalize(globUrl);
-	url = normalize(url);
+/**
+ * Normalizes a URL by removing trailing slashes and query/fragment components.
+ * @param url The URL to normalize.
+ * @returns URI - The normalized URI object.
+ */
+function normalizeURL(url: string | URI): URI {
+	const uri = typeof url === 'string' ? URI.parse(url) : url;
+	return uri.with({
+		// Remove trailing slashes
+		path: uri.path.replace(/\/+$/, ''),
+		// Remove query and fragment
+		query: null,
+		fragment: null,
+	});
+}
 
-	const memo = Array.from({ length: url.length + 1 }).map(() =>
-		Array.from({ length: globUrl.length + 1 }).map(() => undefined),
+/**
+ * Checks if a given URL matches a glob URL pattern.
+ * The glob URL pattern can contain wildcards (*) and subdomain matching (*.)
+ * @param uri The URL to check.
+ * @param globUrl The glob URL pattern to match against.
+ * @returns boolean - True if the URL matches the glob URL pattern, false otherwise.
+ */
+export function testUrlMatchesGlob(uri: string | URI, globUrl: string): boolean {
+	const normalizedUrl = normalizeURL(uri);
+	let normalizedGlobUrl = normalizeURL(globUrl);
+
+	const globHasScheme = /^[^./:]*:\/\//.test(globUrl);
+	// if the glob does not have a scheme we assume the scheme is http or https
+	// so if the url doesn't have a scheme of http or https we return false
+	if (!globHasScheme) {
+		if (normalizedUrl.scheme !== 'http' && normalizedUrl.scheme !== 'https') {
+			return false;
+		}
+		normalizedGlobUrl = normalizeURL(`${normalizedUrl.scheme}://${globUrl}`);
+	}
+
+	return (
+		doMemoUrlMatch(normalizedUrl.scheme, normalizedGlobUrl.scheme) &&
+		// The authority is the only thing that should do port logic.
+		doMemoUrlMatch(normalizedUrl.authority, normalizedGlobUrl.authority, true) &&
+		(
+			//
+			normalizedGlobUrl.path === '/' ||
+			doMemoUrlMatch(normalizedUrl.path, normalizedGlobUrl.path)
+		)
+	);
+}
+
+/**
+ * @param normalizedUrlPart The normalized URL part to match.
+ * @param normalizedGlobUrlPart The normalized glob URL part to match against.
+ * @param includePortLogic Whether to include port logic in the matching process.
+ * @returns boolean - True if the URL part matches the glob URL part, false otherwise.
+ */
+function doMemoUrlMatch(
+	normalizedUrlPart: string,
+	normalizedGlobUrlPart: string,
+	includePortLogic: boolean = false,
+) {
+	const memo = Array.from({ length: normalizedUrlPart.length + 1 }).map(() =>
+		Array.from({ length: normalizedGlobUrlPart.length + 1 }).map(() => undefined),
 	);
 
-	if (/^[^./:]*:\/\//.test(globUrl)) {
-		return doUrlMatch(memo, url, globUrl, 0, 0);
-	}
+	return doUrlPartMatch(memo, includePortLogic, normalizedUrlPart, normalizedGlobUrlPart, 0, 0);
+}
 
-	const scheme = /^(https?):\/\//.exec(url)?.[1];
-	if (scheme) {
-		return doUrlMatch(memo, url, `${scheme}://${globUrl}`, 0, 0);
-	}
-
-	return false;
-};
-
-const doUrlMatch = (
+/**
+ * Recursively checks if a URL part matches a glob URL part.
+ * This function uses memoization to avoid recomputing results for the same inputs.
+ * It handles various cases such as exact matches, wildcard matches, and port logic.
+ * @param memo A memoization table to avoid recomputing results for the same inputs.
+ * @param includePortLogic Whether to include port logic in the matching process.
+ * @param urlPart The URL part to match with.
+ * @param globUrlPart The glob URL part to match against.
+ * @param urlOffset The current offset in the URL part.
+ * @param globUrlOffset The current offset in the glob URL part.
+ * @returns boolean - True if the URL part matches the glob URL part, false otherwise.
+ */
+function doUrlPartMatch(
 	memo: (boolean | undefined)[][],
-	url: string,
-	globUrl: string,
+	includePortLogic: boolean,
+	urlPart: string,
+	globUrlPart: string,
 	urlOffset: number,
-	globUrlOffset: number,
-): boolean => {
+	globUrlOffset: number
+): boolean {
 	if (memo[urlOffset]?.[globUrlOffset] !== undefined) {
 		return memo[urlOffset][globUrlOffset]!;
 	}
 
 	const options = [];
 
-	// Endgame.
-	// Fully exact match
-	if (urlOffset === url.length) {
-		return globUrlOffset === globUrl.length;
+	// We've reached the end of the url.
+	if (urlOffset === urlPart.length) {
+		// We're also at the end of the glob url as well so we have an exact match.
+		if (globUrlOffset === globUrlPart.length) {
+			return true;
+		}
+
+		if (includePortLogic && globUrlPart[globUrlOffset] + globUrlPart[globUrlOffset + 1] === ':*') {
+			// any port match. Consume a port if it exists otherwise nothing. Always consume the base.
+			return globUrlOffset + 2 === globUrlPart.length;
+		}
+
+		return false;
 	}
 
 	// Some path remaining in url
-	if (globUrlOffset === globUrl.length) {
-		const remaining = url.slice(urlOffset);
+	if (globUrlOffset === globUrlPart.length) {
+		const remaining = urlPart.slice(urlOffset);
 		return remaining[0] === '/';
 	}
 
-	if (url[urlOffset] === globUrl[globUrlOffset]) {
+	if (urlPart[urlOffset] === globUrlPart[globUrlOffset]) {
 		// Exact match.
-		options.push(doUrlMatch(memo, url, globUrl, urlOffset + 1, globUrlOffset + 1));
+		options.push(doUrlPartMatch(memo, includePortLogic, urlPart, globUrlPart, urlOffset + 1, globUrlOffset + 1));
 	}
 
-	if (globUrl[globUrlOffset] + globUrl[globUrlOffset + 1] === '*.') {
+	if (globUrlPart[globUrlOffset] + globUrlPart[globUrlOffset + 1] === '*.') {
 		// Any subdomain match. Either consume one thing that's not a / or : and don't advance base or consume nothing and do.
-		if (!['/', ':'].includes(url[urlOffset])) {
-			options.push(doUrlMatch(memo, url, globUrl, urlOffset + 1, globUrlOffset));
+		if (!['/', ':'].includes(urlPart[urlOffset])) {
+			options.push(doUrlPartMatch(memo, includePortLogic, urlPart, globUrlPart, urlOffset + 1, globUrlOffset));
 		}
-		options.push(doUrlMatch(memo, url, globUrl, urlOffset, globUrlOffset + 2));
+		options.push(doUrlPartMatch(memo, includePortLogic, urlPart, globUrlPart, urlOffset, globUrlOffset + 2));
 	}
 
-	if (globUrl[globUrlOffset] === '*') {
+	if (globUrlPart[globUrlOffset] === '*') {
 		// Any match. Either consume one thing and don't advance base or consume nothing and do.
-		if (urlOffset + 1 === url.length) {
+		if (urlOffset + 1 === urlPart.length) {
 			// If we're at the end of the input url consume one from both.
-			options.push(doUrlMatch(memo, url, globUrl, urlOffset + 1, globUrlOffset + 1));
+			options.push(doUrlPartMatch(memo, includePortLogic, urlPart, globUrlPart, urlOffset + 1, globUrlOffset + 1));
 		} else {
-			options.push(doUrlMatch(memo, url, globUrl, urlOffset + 1, globUrlOffset));
+			options.push(doUrlPartMatch(memo, includePortLogic, urlPart, globUrlPart, urlOffset + 1, globUrlOffset));
 		}
-		options.push(doUrlMatch(memo, url, globUrl, urlOffset, globUrlOffset + 1));
+		options.push(doUrlPartMatch(memo, includePortLogic, urlPart, globUrlPart, urlOffset, globUrlOffset + 1));
 	}
 
-	if (globUrl[globUrlOffset] + globUrl[globUrlOffset + 1] === ':*') {
-		// any port match. Consume a port if it exists otherwise nothing. Always comsume the base.
-		if (url[urlOffset] === ':') {
+	if (includePortLogic && globUrlPart[globUrlOffset] + globUrlPart[globUrlOffset + 1] === ':*') {
+		// any port match. Consume a port if it exists otherwise nothing. Always consume the base.
+		if (urlPart[urlOffset] === ':') {
 			let endPortIndex = urlOffset + 1;
-			do { endPortIndex++; } while (/[0-9]/.test(url[endPortIndex]));
-			options.push(doUrlMatch(memo, url, globUrl, endPortIndex, globUrlOffset + 2));
+			do { endPortIndex++; } while (/[0-9]/.test(urlPart[endPortIndex]));
+			options.push(doUrlPartMatch(memo, includePortLogic, urlPart, globUrlPart, endPortIndex, globUrlOffset + 2));
 		} else {
-			options.push(doUrlMatch(memo, url, globUrl, urlOffset, globUrlOffset + 2));
+			options.push(doUrlPartMatch(memo, includePortLogic, urlPart, globUrlPart, urlOffset, globUrlOffset + 2));
 		}
 	}
 
 	return (memo[urlOffset][globUrlOffset] = options.some(a => a === true));
-};
+}

--- a/src/vs/workbench/contrib/url/test/browser/trustedDomains.test.ts
+++ b/src/vs/workbench/contrib/url/test/browser/trustedDomains.test.ts
@@ -113,4 +113,9 @@ suite('Link protection domain matching', () => {
 		linkAllowedByRules('https://github.com/login/oauth/authorize?foo=4', ['https://github.com/login/oauth/authorize']);
 		linkAllowedByRules('https://github.com/login/oauth/authorize#foo', ['https://github.com/login/oauth/authorize']);
 	});
+
+	test('ensure individual parts of url are compared and wildcard does not leak out', () => {
+		linkNotAllowedByRules('https://x.org/github.com', ['https://*.github.com']);
+		linkNotAllowedByRules('https://x.org/y.github.com', ['https://*.github.com']);
+	});
 });


### PR DESCRIPTION
This commit includes 2 fixes related to Trusted Domains:
1. The Trusted Domain service would match things like `https://a.com/github.com` for glob pattern `https://*.github.com`. This change fixes that by handling parts of URLs (scheme, authority, path) separately and evaluating them
2. Chat Markdown rendering and fetch tool no longer depend on Trusted Domain Service

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
