### PR TITLE
SCM - fix quick diff vertical scrolling issue

### DIFF
--- a/src/vs/editor/contrib/peekView/browser/peekView.ts
+++ b/src/vs/editor/contrib/peekView/browser/peekView.ts
@@ -255,7 +255,7 @@ export abstract class PeekViewWidget extends ZoneWidget {
 		}
 
 		const headHeight = Math.ceil(this.editor.getOption(EditorOption.lineHeight) * 1.2);
-		const bodyHeight = Math.round(heightInPixel - (headHeight + 2 /* the border-top/bottom width*/));
+		const bodyHeight = Math.round(heightInPixel - (headHeight + 1 /* the border-top width */));
 
 		this._doLayoutHead(headHeight, widthInPixel);
 		this._doLayoutBody(bodyHeight, widthInPixel);

--- a/src/vs/workbench/contrib/scm/browser/quickDiffWidget.ts
+++ b/src/vs/workbench/contrib/scm/browser/quickDiffWidget.ts
@@ -229,7 +229,9 @@ class QuickDiffWidget extends PeekViewWidget {
 		const lineHeight = this.editor.getOption(EditorOption.lineHeight);
 		const editorHeight = this.editor.getLayoutInfo().height;
 		const editorHeightInLines = Math.floor(editorHeight / lineHeight);
-		const height = Math.min(getChangeHeight(change) + /* padding */ 8, Math.floor(editorHeightInLines / 3));
+		const height = Math.min(
+			getChangeHeight(change) + 2 /* arrow, frame, header */ + 6 /* 3 lines above/below the change */,
+			Math.floor(editorHeightInLines / 3));
 
 		this.renderTitle();
 		this.updateDropdown();
@@ -250,7 +252,10 @@ class QuickDiffWidget extends PeekViewWidget {
 		}
 		this._actionbarWidget!.context = [diffEditorModel.modified.uri, providerSpecificChanges, contextIndex];
 		if (usePosition) {
-			this.show(position, height);
+			// In order to account for the 1px border-top of the content element we
+			// have to add 1px. The pixel value needs to be expressed as a fraction
+			// of the line height.
+			this.show(position, height + (1 / lineHeight));
 			this.editor.setPosition(position);
 			this.editor.focus();
 		}


### PR DESCRIPTION
These changes fix an issue where the content height of the peek widget is `2px` smaller than the diff editor causing the vertical scrollbar to appear.

Screenshot with the changes from this PR:
<img width="966" alt="image" src="https://github.com/user-attachments/assets/65978cca-8d4a-4818-ae65-8b659fb8fe8c" />