### PR TITLE
Register a NullAuthProvider for github-enterprise when there is no setting set

### DIFF
--- a/extensions/github-authentication/src/extension.ts
+++ b/extensions/github-authentication/src/extension.ts
@@ -6,10 +6,42 @@
 import * as vscode from 'vscode';
 import { GitHubAuthenticationProvider, UriEventHandler } from './github';
 
-function initGHES(context: vscode.ExtensionContext, uriHandler: UriEventHandler) {
+const settingNotSent = '"github-enterprise.uri" not set';
+const settingInvalid = '"github-enterprise.uri" invalid';
+
+class NullAuthProvider implements vscode.AuthenticationProvider {
+	private _onDidChangeSessions = new vscode.EventEmitter<vscode.AuthenticationProviderAuthenticationSessionsChangeEvent>();
+	onDidChangeSessions = this._onDidChangeSessions.event;
+
+	private readonly _disposable: vscode.Disposable;
+
+	constructor(private readonly _errorMessage: string) {
+		this._disposable = vscode.authentication.registerAuthenticationProvider('github-enterprise', 'GitHub Enterprise', this);
+	}
+
+	createSession(): Thenable<vscode.AuthenticationSession> {
+		throw new Error(this._errorMessage);
+	}
+
+	getSessions(): Thenable<vscode.AuthenticationSession[]> {
+		return Promise.resolve([]);
+	}
+	removeSession(): Thenable<void> {
+		throw new Error(this._errorMessage);
+	}
+
+	dispose() {
+		this._onDidChangeSessions.dispose();
+		this._disposable.dispose();
+	}
+}
+
+function initGHES(context: vscode.ExtensionContext, uriHandler: UriEventHandler): vscode.Disposable {
 	const settingValue = vscode.workspace.getConfiguration().get<string>('github-enterprise.uri');
 	if (!settingValue) {
-		return undefined;
+		const provider = new NullAuthProvider(settingNotSent);
+		context.subscriptions.push(provider);
+		return provider;
 	}
 
 	// validate user value
@@ -18,7 +50,9 @@ function initGHES(context: vscode.ExtensionContext, uriHandler: UriEventHandler)
 		uri = vscode.Uri.parse(settingValue, true);
 	} catch (e) {
 		vscode.window.showErrorMessage(vscode.l10n.t('GitHub Enterprise Server URI is not a valid URI: {0}', e.message ?? e));
-		return;
+		const provider = new NullAuthProvider(settingInvalid);
+		context.subscriptions.push(provider);
+		return provider;
 	}
 
 	const githubEnterpriseAuthProvider = new GitHubAuthenticationProvider(context, uriHandler, uri);
@@ -33,12 +67,14 @@ export function activate(context: vscode.ExtensionContext) {
 
 	context.subscriptions.push(new GitHubAuthenticationProvider(context, uriHandler));
 
-	let githubEnterpriseAuthProvider: GitHubAuthenticationProvider | undefined = initGHES(context, uriHandler);
-
+	let before = vscode.workspace.getConfiguration().get<string>('github-enterprise.uri');
+	let githubEnterpriseAuthProvider = initGHES(context, uriHandler);
 	context.subscriptions.push(vscode.workspace.onDidChangeConfiguration(async e => {
 		if (e.affectsConfiguration('github-enterprise.uri')) {
-			if (vscode.workspace.getConfiguration().get<string>('github-enterprise.uri')) {
+			const after = vscode.workspace.getConfiguration().get<string>('github-enterprise.uri');
+			if (before !== after) {
 				githubEnterpriseAuthProvider?.dispose();
+				before = after;
 				githubEnterpriseAuthProvider = initGHES(context, uriHandler);
 			}
 		}


### PR DESCRIPTION
This should help in some cases where extensions call getSession to get github-enterprise and end up waiting 5 seconds for it to time out because it use to only be registered when there was a setting set.

Before (5s long):
```
> await vscode.authentication.getSession('github-enterprise', ['read:user'], { createIfNone: true })
Uncaught 'Timed out waiting for authentication provider to register'
```
after (instant):
```
> await vscode.authentication.getSession('github-enterprise', ['read:user'], { createIfNone: true })
Uncaught Error: "github-enterprise.uri" not set
```

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
