### PR TITLE
add opt-in setting to gracefully kill terminal processes

### DIFF
--- a/src/vs/platform/terminal/common/terminal.ts
+++ b/src/vs/platform/terminal/common/terminal.ts
@@ -121,6 +121,7 @@ export const enum TerminalSettingId {
 	FontLigaturesEnabled = 'terminal.integrated.fontLigatures.enabled',
 	FontLigaturesFeatureSettings = 'terminal.integrated.fontLigatures.featureSettings',
 	FontLigaturesFallbackLigatures = 'terminal.integrated.fontLigatures.fallbackLigatures',
+	KillGracefully = 'terminal.integrated.killGracefully',
 
 	// Debug settings that are hidden from user
 
@@ -649,6 +650,10 @@ export interface IShellLaunchConfig {
 	 * Report terminal's shell environment variables to VS Code and extensions
 	 */
 	shellIntegrationEnvironmentReporting?: boolean;
+	/**
+	 * Whether the process should be killed gracefully
+	 */
+	killGracefully?: boolean;
 }
 
 export interface ITerminalTabAction {

--- a/src/vs/platform/terminal/node/terminalProcess.ts
+++ b/src/vs/platform/terminal/node/terminalProcess.ts
@@ -377,13 +377,33 @@ export class TerminalProcess extends Disposable implements ITerminalChildProcess
 			if (this._ptyProcess) {
 				await this._throttleKillSpawn();
 				this._logService.trace('node-pty.IPty#kill');
-				this._ptyProcess.kill();
+				if (this.shellLaunchConfig.killGracefully) {
+					this._killGracefully(this._ptyProcess);
+				} else {
+					this._ptyProcess.kill();
+				}
 			}
 		} catch (ex) {
 			// Swallow, the pty has already been killed
 		}
 		this._onProcessExit.fire(this._exitCode || 0);
 		this.dispose();
+	}
+
+	private async _killGracefully(ptyProcess: IPty): Promise<void> {
+		if (!isWindows) {
+			ptyProcess.kill('SIGTERM');
+		} else if (isWindows && process.platform === 'win32') {
+			const windir = process.env['WINDIR'] || 'C:\\Windows';
+			const TASK_KILL = path.join(windir, 'System32', 'taskkill.exe');
+			try {
+				await exec(`${TASK_KILL} /T /PID ${ptyProcess.pid}`);
+			} catch (err) {
+				ptyProcess.kill();
+			}
+		} else {
+			ptyProcess.kill();
+		}
 	}
 
 	private async _throttleKillSpawn(): Promise<void> {
@@ -452,7 +472,11 @@ export class TerminalProcess extends Disposable implements ITerminalChildProcess
 				setTimeout(() => {
 					if (this._closeTimeout && !this._store.isDisposed) {
 						this._closeTimeout = undefined;
-						this._kill();
+						if (this._ptyProcess && this.shellLaunchConfig.killGracefully) {
+							this._killGracefully(this._ptyProcess);
+						} else {
+							this._kill();
+						}
 					}
 				}, ShutdownConstants.MaximumShutdownTime);
 			}

--- a/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
@@ -566,6 +566,9 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 			if (e.affectsConfiguration(AccessibilityVerbositySettingId.Terminal)) {
 				this._setAriaLabel(this.xterm?.raw, this._instanceId, this.title);
 			}
+			if (e.affectsConfiguration(TerminalSettingId.KillGracefully)) {
+				this.shellLaunchConfig.killGracefully = this._configurationService.getValue(TerminalSettingId.KillGracefully);
+			}
 			if (e.affectsConfiguration('terminal.integrated')) {
 				this.updateConfig();
 				this.setVisible(this._isVisible);
@@ -1506,7 +1509,7 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 				message: nls.localize('workspaceNotTrustedCreateTerminalCwd', "Cannot launch a terminal process in an untrusted workspace with cwd {0} and userHome {1}", this._cwd, this._userHome)
 			});
 		}
-
+		this.shellLaunchConfig.killGracefully = this._configurationService.getValue(TerminalSettingId.KillGracefully);
 		// Re-evaluate dimensions if the container has been set since the xterm instance was created
 		if (this._container && this._cols === 0 && this._rows === 0) {
 			this._initDimensions();

--- a/src/vs/workbench/contrib/terminal/common/terminalConfiguration.ts
+++ b/src/vs/workbench/contrib/terminal/common/terminalConfiguration.ts
@@ -640,6 +640,14 @@ const terminalConfiguration: IConfigurationNode = {
 				localize('terminal.integrated.focusAfterRun.none', "Do nothing."),
 			]
 		},
+		[TerminalSettingId.KillGracefully]: {
+			type: 'boolean',
+			default: false,
+			markdownDescription: localize(
+				'terminal.integrated.killGracefully',
+				'Controls how terminal processes are terminated. When enabled, attempts a graceful shutdown of the process tree. On POSIX, this will send \`SIGTERM\`. On Windows, it uses \`taskkill.exe\` without the \`/F\` (force) flag. Note that this may allow misbehaving processes to remain running. When disabled (default), processes are terminated with: \`SIGHUP\`.'
+			),
+		},
 		...terminalContribConfiguration,
 	}
 };


### PR DESCRIPTION
fix #206607

Tested on macOS and Windows.

cc @Tyriar 

Before:

https://github.com/user-attachments/assets/bd41bad6-4ba5-45f3-b7ea-35b9878d5411

After (works when killing via trash can or after closing and reopening the window):

https://github.com/user-attachments/assets/08ee1f52-ccf8-46ab-95e1-71124b477e5f

