### PR TITLE
Introduce Issuer handling in the Authentication stack

### DIFF
--- a/extensions/github-authentication/package.json
+++ b/extensions/github-authentication/package.json
@@ -17,6 +17,9 @@
     "ui",
     "workspace"
   ],
+  "enabledApiProposals": [
+    "authIssuers"
+  ],
   "activationEvents": [],
   "capabilities": {
     "virtualWorkspaces": true,
@@ -31,11 +34,17 @@
     "authentication": [
       {
         "label": "GitHub",
-        "id": "github"
+        "id": "github",
+        "issuerGlobs": [
+          "https://github.com/login/oauth"
+        ]
       },
       {
         "label": "GitHub Enterprise Server",
-        "id": "github-enterprise"
+        "id": "github-enterprise",
+        "issuerGlobs": [
+          "*"
+        ]
       }
     ],
     "configuration": [{

--- a/extensions/github-authentication/src/github.ts
+++ b/extensions/github-authentication/src/github.ts
@@ -137,7 +137,17 @@ export class GitHubAuthenticationProvider implements vscode.AuthenticationProvid
 
 		this._disposable = vscode.Disposable.from(
 			this._telemetryReporter,
-			vscode.authentication.registerAuthenticationProvider(type, this._githubServer.friendlyName, this, { supportsMultipleAccounts: true }),
+			vscode.authentication.registerAuthenticationProvider(
+				type,
+				this._githubServer.friendlyName,
+				this,
+				{
+					supportsMultipleAccounts: true,
+					supportedIssuers: [
+						ghesUri ?? vscode.Uri.parse('https://github.com/login/oauth')
+					]
+				}
+			),
 			this.context.secrets.onDidChange(() => this.checkForUpdates())
 		);
 	}

--- a/extensions/github-authentication/tsconfig.json
+++ b/extensions/github-authentication/tsconfig.json
@@ -12,6 +12,7 @@
 	},
 	"include": [
 		"src/**/*",
-		"../../src/vscode-dts/vscode.d.ts"
+		"../../src/vscode-dts/vscode.d.ts",
+		"../../src/vscode-dts/vscode.proposed.authIssuers.d.ts"
 	]
 }

--- a/extensions/microsoft-authentication/package.json
+++ b/extensions/microsoft-authentication/package.json
@@ -15,7 +15,8 @@
   "activationEvents": [],
   "enabledApiProposals": [
     "idToken",
-    "nativeWindowHandle"
+    "nativeWindowHandle",
+    "authIssuers"
   ],
   "capabilities": {
     "virtualWorkspaces": true,
@@ -31,7 +32,10 @@
     "authentication": [
       {
         "label": "Microsoft",
-        "id": "microsoft"
+        "id": "microsoft",
+        "issuerGlobs": [
+          "https://login.microsoftonline.com/*/v2.0"
+        ]
       },
       {
         "label": "Microsoft Sovereign Cloud",

--- a/extensions/microsoft-authentication/src/AADHelper.ts
+++ b/extensions/microsoft-authentication/src/AADHelper.ts
@@ -203,7 +203,7 @@ export class AzureActiveDirectoryService {
 		return this._sessionChangeEmitter.event;
 	}
 
-	public getSessions(scopes?: string[], account?: vscode.AuthenticationSessionAccountInformation): Promise<vscode.AuthenticationSession[]> {
+	public getSessions(scopes: string[] | undefined, { account, issuer }: vscode.AuthenticationProviderSessionOptions = {}): Promise<vscode.AuthenticationSession[]> {
 		if (!scopes) {
 			this._logger.info('Getting sessions for all scopes...');
 			const sessions = this._tokens
@@ -226,6 +226,12 @@ export class AzureActiveDirectoryService {
 		if (!modifiedScopes.includes('offline_access')) {
 			modifiedScopes.push('offline_access');
 		}
+		if (issuer) {
+			const tenant = issuer.path.split('/')[1];
+			if (tenant) {
+				modifiedScopes.push(`VSCODE_TENANT:${tenant}`);
+			}
+		}
 		modifiedScopes = modifiedScopes.sort();
 
 		const modifiedScopesStr = modifiedScopes.join(' ');
@@ -237,7 +243,7 @@ export class AzureActiveDirectoryService {
 			scopeStr: modifiedScopesStr,
 			// filter our special scopes
 			scopesToSend: modifiedScopes.filter(s => !s.startsWith('VSCODE_')).join(' '),
-			tenant: this.getTenantId(scopes),
+			tenant: this.getTenantId(modifiedScopes),
 		};
 
 		this._logger.trace(`[${scopeData.scopeStr}] Queued getting sessions` + account ? ` for ${account?.label}` : '');
@@ -297,7 +303,7 @@ export class AzureActiveDirectoryService {
 			.map(result => (result as PromiseFulfilledResult<vscode.AuthenticationSession>).value);
 	}
 
-	public createSession(scopes: string[], account?: vscode.AuthenticationSessionAccountInformation): Promise<vscode.AuthenticationSession> {
+	public createSession(scopes: string[], { account, issuer }: vscode.AuthenticationProviderSessionOptions = {}): Promise<vscode.AuthenticationSession> {
 		let modifiedScopes = [...scopes];
 		if (!modifiedScopes.includes('openid')) {
 			modifiedScopes.push('openid');
@@ -311,6 +317,12 @@ export class AzureActiveDirectoryService {
 		if (!modifiedScopes.includes('offline_access')) {
 			modifiedScopes.push('offline_access');
 		}
+		if (issuer) {
+			const tenant = issuer.path.split('/')[1];
+			if (tenant) {
+				modifiedScopes.push(`VSCODE_TENANT:${tenant}`);
+			}
+		}
 		modifiedScopes = modifiedScopes.sort();
 		const scopeData: IScopeData = {
 			originalScopes: scopes,
@@ -319,7 +331,7 @@ export class AzureActiveDirectoryService {
 			// filter our special scopes
 			scopesToSend: modifiedScopes.filter(s => !s.startsWith('VSCODE_')).join(' '),
 			clientId: this.getClientId(scopes),
-			tenant: this.getTenantId(scopes),
+			tenant: this.getTenantId(modifiedScopes),
 		};
 
 		this._logger.trace(`[${scopeData.scopeStr}] Queued creating session`);

--- a/extensions/microsoft-authentication/src/extensionV2.ts
+++ b/extensions/microsoft-authentication/src/extensionV2.ts
@@ -7,7 +7,7 @@ import { Environment, EnvironmentParameters } from '@azure/ms-rest-azure-env';
 import Logger from './logger';
 import { MsalAuthProvider } from './node/authProvider';
 import { UriEventHandler } from './UriEventHandler';
-import { authentication, commands, ExtensionContext, l10n, window, workspace, Disposable } from 'vscode';
+import { authentication, commands, ExtensionContext, l10n, window, workspace, Disposable, Uri } from 'vscode';
 import { MicrosoftAuthenticationTelemetryReporter, MicrosoftSovereignCloudAuthenticationTelemetryReporter } from './common/telemetryReporter';
 
 async function initMicrosoftSovereignCloudAuthProvider(
@@ -79,7 +79,12 @@ export async function activate(context: ExtensionContext, mainTelemetryReporter:
 		'microsoft',
 		'Microsoft',
 		authProvider,
-		{ supportsMultipleAccounts: true }
+		{
+			supportsMultipleAccounts: true,
+			supportedIssuers: [
+				Uri.parse('https://login.microsoftonline.com/*/v2.0')
+			]
+		}
 	));
 
 	let microsoftSovereignCloudAuthProviderDisposable = await initMicrosoftSovereignCloudAuthProvider(context, uriHandler);

--- a/extensions/microsoft-authentication/src/node/authProvider.ts
+++ b/extensions/microsoft-authentication/src/node/authProvider.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 import { AccountInfo, AuthenticationResult, ClientAuthError, ClientAuthErrorCodes, ServerError } from '@azure/msal-node';
-import { AuthenticationGetSessionOptions, AuthenticationProvider, AuthenticationProviderAuthenticationSessionsChangeEvent, AuthenticationProviderSessionOptions, AuthenticationSession, AuthenticationSessionAccountInformation, CancellationError, EventEmitter, ExtensionContext, ExtensionKind, l10n, LogOutputChannel, window } from 'vscode';
+import { AuthenticationGetSessionOptions, AuthenticationProvider, AuthenticationProviderAuthenticationSessionsChangeEvent, AuthenticationProviderSessionOptions, AuthenticationSession, AuthenticationSessionAccountInformation, CancellationError, EventEmitter, ExtensionContext, ExtensionKind, l10n, LogOutputChannel, Uri, window } from 'vscode';
 import { Environment } from '@azure/ms-rest-azure-env';
 import { CachedPublicClientApplicationManager } from './publicClientCache';
 import { UriEventHandler } from '../UriEventHandler';
@@ -154,9 +154,9 @@ export class MsalAuthProvider implements AuthenticationProvider {
 
 	//#region AuthenticationProvider methods
 
-	async getSessions(scopes: string[] | undefined, options?: AuthenticationGetSessionOptions): Promise<AuthenticationSession[]> {
+	async getSessions(scopes: string[] | undefined, options: AuthenticationGetSessionOptions = {}): Promise<AuthenticationSession[]> {
 		const askingForAll = scopes === undefined;
-		const scopeData = new ScopeData(scopes);
+		const scopeData = new ScopeData(scopes, options?.issuer);
 		// Do NOT use `scopes` beyond this place in the code. Use `scopeData` instead.
 		this._logger.info('[getSessions]', askingForAll ? '[all]' : `[${scopeData.scopeStr}]`, 'starting');
 
@@ -186,7 +186,7 @@ export class MsalAuthProvider implements AuthenticationProvider {
 	}
 
 	async createSession(scopes: readonly string[], options: AuthenticationProviderSessionOptions): Promise<AuthenticationSession> {
-		const scopeData = new ScopeData(scopes);
+		const scopeData = new ScopeData(scopes, options.issuer);
 		// Do NOT use `scopes` beyond this place in the code. Use `scopeData` instead.
 
 		this._logger.info('[createSession]', `[${scopeData.scopeStr}]`, 'starting');

--- a/extensions/microsoft-authentication/tsconfig.json
+++ b/extensions/microsoft-authentication/tsconfig.json
@@ -23,6 +23,7 @@
 		"src/**/*",
 		"../../src/vscode-dts/vscode.d.ts",
 		"../../src/vscode-dts/vscode.proposed.idToken.d.ts",
-		"../../src/vscode-dts/vscode.proposed.nativeWindowHandle.d.ts"
+		"../../src/vscode-dts/vscode.proposed.nativeWindowHandle.d.ts",
+		"../../src/vscode-dts/vscode.proposed.authIssuers.d.ts"
 	]
 }

--- a/src/vs/platform/extensions/common/extensions.ts
+++ b/src/vs/platform/extensions/common/extensions.ts
@@ -104,6 +104,7 @@ export interface ICodeActionContribution {
 export interface IAuthenticationContribution {
 	readonly id: string;
 	readonly label: string;
+	readonly issuerGlobs?: string[];
 }
 
 export interface IWalkthroughStep {

--- a/src/vs/platform/extensions/common/extensionsApiProposals.ts
+++ b/src/vs/platform/extensions/common/extensionsApiProposals.ts
@@ -19,6 +19,9 @@ const _allApiProposals = {
 		proposal: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.aiTextSearchProvider.d.ts',
 		version: 2
 	},
+	authIssuers: {
+		proposal: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.authIssuers.d.ts',
+	},
 	authLearnMore: {
 		proposal: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.authLearnMore.d.ts',
 	},

--- a/src/vs/workbench/api/common/extHost.api.impl.ts
+++ b/src/vs/workbench/api/common/extHost.api.impl.ts
@@ -298,6 +298,9 @@ export function createApiFactoryAndRegisterActors(accessor: ServicesAccessor): I
 				) {
 					checkProposedApiEnabled(extension, 'authLearnMore');
 				}
+				if (options?.issuer) {
+					checkProposedApiEnabled(extension, 'authIssuers');
+				}
 				return extHostAuthentication.getSession(extension, providerId, scopes, options as any);
 			},
 			getAccounts(providerId: string) {
@@ -312,6 +315,9 @@ export function createApiFactoryAndRegisterActors(accessor: ServicesAccessor): I
 				return _asExtensionEvent(extHostAuthentication.getExtensionScopedSessionsEvent(extension.identifier.value));
 			},
 			registerAuthenticationProvider(id: string, label: string, provider: vscode.AuthenticationProvider, options?: vscode.AuthenticationProviderOptions): vscode.Disposable {
+				if (options?.supportedIssuers) {
+					checkProposedApiEnabled(extension, 'authIssuers');
+				}
 				return extHostAuthentication.registerAuthenticationProvider(id, label, provider, options);
 			}
 		};

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -180,7 +180,7 @@ export interface AuthenticationGetSessionOptions {
 }
 
 export interface MainThreadAuthenticationShape extends IDisposable {
-	$registerAuthenticationProvider(id: string, label: string, supportsMultipleAccounts: boolean): void;
+	$registerAuthenticationProvider(id: string, label: string, supportsMultipleAccounts: boolean, supportedIssuers?: UriComponents[]): void;
 	$unregisterAuthenticationProvider(id: string): void;
 	$ensureProvider(id: string): Promise<void>;
 	$sendDidChangeSessions(providerId: string, event: AuthenticationSessionsChangeEvent): void;

--- a/src/vs/workbench/contrib/authentication/browser/authentication.contribution.ts
+++ b/src/vs/workbench/contrib/authentication/browser/authentication.contribution.ts
@@ -42,6 +42,7 @@ class AuthenticationDataRenderer extends Disposable implements IExtensionFeature
 		const headers = [
 			localize('authenticationlabel', "Label"),
 			localize('authenticationid', "ID"),
+			localize('authenticationMcpAuthorizationServers', "MCP Authorization Servers")
 		];
 
 		const rows: IRowData[][] = authentication
@@ -50,6 +51,7 @@ class AuthenticationDataRenderer extends Disposable implements IExtensionFeature
 				return [
 					auth.label,
 					auth.id,
+					(auth.issuerGlobs ?? []).join(',\n')
 				];
 			});
 

--- a/src/vs/workbench/services/authentication/test/browser/authenticationService.test.ts
+++ b/src/vs/workbench/services/authentication/test/browser/authenticationService.test.ts
@@ -6,6 +6,7 @@
 import assert from 'assert';
 import { Emitter, Event } from '../../../../../base/common/event.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { URI } from '../../../../../base/common/uri.js';
 import { AuthenticationAccessService } from '../../browser/authenticationAccessService.js';
 import { AuthenticationService } from '../../browser/authenticationService.js';
 import { AuthenticationProviderInformation, AuthenticationSessionsChangeEvent, IAuthenticationProvider } from '../../common/authentication.js';
@@ -127,10 +128,104 @@ suite('AuthenticationService', () => {
 			// Assert that the retrieved provider is the same as the registered provider
 			assert.deepEqual(retrievedProvider, provider);
 		});
+
+		test('getOrActivateProviderIdForIssuer - should return undefined when no provider matches the issuer', async () => {
+			const issuer = URI.parse('https://example.com');
+			const result = await authenticationService.getOrActivateProviderIdForIssuer(issuer);
+			assert.strictEqual(result, undefined);
+		});
+
+		test('getOrActivateProviderIdForIssuer - should return provider id if issuerGlobs matches and issuers match', async () => {
+			// Register a declared provider with an issuer glob
+			const provider: AuthenticationProviderInformation = {
+				id: 'github',
+				label: 'GitHub',
+				issuerGlobs: ['https://github.com/*']
+			};
+			authenticationService.registerDeclaredAuthenticationProvider(provider);
+
+			// Register an authentication provider with matching issuers
+			const authProvider = createProvider({
+				id: 'github',
+				label: 'GitHub',
+				issuers: [URI.parse('https://github.com/login')]
+			});
+			authenticationService.registerAuthenticationProvider('github', authProvider);
+
+			// Test with a matching URI
+			const issuer = URI.parse('https://github.com/login');
+			const result = await authenticationService.getOrActivateProviderIdForIssuer(issuer);
+
+			// Verify the result
+			assert.strictEqual(result, 'github');
+		});
+
+		test('getOrActivateProviderIdForIssuer - should return undefined if issuerGlobs match but issuers do not match', async () => {
+			// Register a declared provider with an issuer glob
+			const provider: AuthenticationProviderInformation = {
+				id: 'github',
+				label: 'GitHub',
+				issuerGlobs: ['https://github.com/*']
+			};
+			authenticationService.registerDeclaredAuthenticationProvider(provider);
+
+			// Register an authentication provider with non-matching issuers
+			const authProvider = createProvider({
+				id: 'github',
+				label: 'GitHub',
+				issuers: [URI.parse('https://github.com/different')]
+			});
+			authenticationService.registerAuthenticationProvider('github', authProvider);
+
+			// Test with a non-matching URI
+			const issuer = URI.parse('https://github.com/login');
+			const result = await authenticationService.getOrActivateProviderIdForIssuer(issuer);
+
+			// Verify the result
+			assert.strictEqual(result, undefined);
+		});
+
+		test('getOrActivateProviderIdForIssuer - should check multiple providers and return the first match', async () => {
+			// Register two declared providers with issuer globs
+			const provider1: AuthenticationProviderInformation = {
+				id: 'github',
+				label: 'GitHub',
+				issuerGlobs: ['https://github.com/*']
+			};
+			const provider2: AuthenticationProviderInformation = {
+				id: 'microsoft',
+				label: 'Microsoft',
+				issuerGlobs: ['https://login.microsoftonline.com/*']
+			};
+			authenticationService.registerDeclaredAuthenticationProvider(provider1);
+			authenticationService.registerDeclaredAuthenticationProvider(provider2);
+
+			// Register authentication providers
+			const githubProvider = createProvider({
+				id: 'github',
+				label: 'GitHub',
+				issuers: [URI.parse('https://github.com/different')]
+			});
+			authenticationService.registerAuthenticationProvider('github', githubProvider);
+
+			const microsoftProvider = createProvider({
+				id: 'microsoft',
+				label: 'Microsoft',
+				issuers: [URI.parse('https://login.microsoftonline.com/common')]
+			});
+			authenticationService.registerAuthenticationProvider('microsoft', microsoftProvider);
+
+			// Test with a URI that should match the second provider
+			const issuer = URI.parse('https://login.microsoftonline.com/common');
+			const result = await authenticationService.getOrActivateProviderIdForIssuer(issuer);
+
+			// Verify the result
+			assert.strictEqual(result, 'microsoft');
+		});
 	});
 
 	suite('authenticationSessions', () => {
-		test('getSessions', async () => {
+		test('getSessions - base case', async () => {
 			let isCalled = false;
 			const provider = createProvider({
 				getSessions: async () => {
@@ -143,6 +238,19 @@ suite('AuthenticationService', () => {
 
 			assert.equal(sessions.length, 1);
 			assert.ok(isCalled);
+		});
+
+		test('getSessions - issuer is not registered', async () => {
+			let isCalled = false;
+			const provider = createProvider({
+				getSessions: async () => {
+					isCalled = true;
+					return [createSession()];
+				},
+			});
+			authenticationService.registerAuthenticationProvider(provider.id, provider);
+			assert.rejects(() => authenticationService.getSessions(provider.id, [], undefined, undefined, URI.parse('https://example.com')));
+			assert.ok(!isCalled);
 		});
 
 		test('createSession', async () => {

--- a/src/vscode-dts/vscode.proposed.authIssuers.d.ts
+++ b/src/vscode-dts/vscode.proposed.authIssuers.d.ts
@@ -1,0 +1,30 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+declare module 'vscode' {
+	export interface AuthenticationProviderOptions {
+		/**
+		 * When specified, this provider will be associated with these issuers. They can still contain globs
+		 * just like their extension contribution counterparts.
+		 */
+		readonly supportedIssuers?: Uri[];
+	}
+
+	export interface AuthenticationProviderSessionOptions {
+		/**
+		 * When specified, the authentication provider will use the provided issuer URL to
+		 * authenticate the user. This is only used when a provider `supportsIssuerOverride` is set to true
+		 */
+		issuer?: Uri;
+	}
+
+	export interface AuthenticationGetSessionOptions {
+		/**
+		 * When specified, the authentication provider will use the provided issuer URL to
+		 * authenticate the user. This is only used when a provider `supportsIssuerOverride` is set to true
+		 */
+		issuer?: Uri;
+	}
+}


### PR DESCRIPTION
Mostly plumbing... this enables:
```
vscode.authentication.getSession('microsoft', scopes, { issuer: "https://login.microsoftonline.com/common/v2.0" });
```
And the respective API for an auth providers to handle it being passed in.

This props up work in MCP land which needs a way to map an issuer to an auth provider... but I certainly see utility outside of that space.

Fixes https://github.com/microsoft/vscode/issues/248775#issuecomment-2876711396

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
