### PR TITLE
Fix for auto search on empty

### DIFF
--- a/src/vs/workbench/contrib/search/browser/searchView.ts
+++ b/src/vs/workbench/contrib/search/browser/searchView.ts
@@ -1838,6 +1838,7 @@ export class SearchView extends ViewPane {
 	}
 
 	public clearAIResults() {
+		this.model.searchResult.aiTextSearchResult.hidden = true;
 		this._cachedResults = undefined;
 		this.model.cancelAISearch(true);
 		this.model.clearAiSearchResults();


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Fix for auto search on empty results.
We need to hide the AI text results tree as part of the clearing of the results so that the tree doesn't re-render automatically on any search