### PR TITLE
Adjust chat editing UX 

### DIFF
--- a/src/vs/editor/common/languages.ts
+++ b/src/vs/editor/common/languages.ts
@@ -1598,7 +1598,10 @@ export interface TextEdit {
 /** @internal */
 export abstract class TextEdit {
 	static asEditOperation(edit: TextEdit): ISingleEditOperation {
-		return EditOperation.replace(Range.lift(edit.range), edit.text);
+		const range = Range.lift(edit.range);
+		return range.isEmpty()
+			? EditOperation.insert(range.getStartPosition(), edit.text) // moves marker
+			: EditOperation.replace(range, edit.text);
 	}
 	static isTextEdit(thing: any): thing is TextEdit {
 		const possibleTextEdit = thing as TextEdit;

--- a/src/vs/workbench/api/browser/mainThreadChatAgents2.ts
+++ b/src/vs/workbench/api/browser/mainThreadChatAgents2.ts
@@ -93,10 +93,9 @@ export class MainThreadChatAgents2 extends Disposable implements MainThreadChatA
 
 	private readonly _chatRelatedFilesProviders = this._register(new DisposableMap<number, IDisposable>());
 
-	private readonly _pendingProgress = new Map<string, (part: IChatProgress) => void>();
+	private readonly _pendingProgress = new Map<string, (parts: IChatProgress[]) => void>();
 	private readonly _proxy: ExtHostChatAgentsShape2;
 
-	private _responsePartHandlePool = 0;
 	private readonly _activeTasks = new Map<string, IChatTask>();
 
 	private readonly _unresolvedAnchors = new Map</* requestId */string, Map</* id */ string, IChatContentInlineReference>>();
@@ -233,54 +232,65 @@ export class MainThreadChatAgents2 extends Disposable implements MainThreadChatA
 		this._chatAgentService.updateAgent(data.id, revive(metadataUpdate));
 	}
 
-	async $handleProgressChunk(requestId: string, progress: IChatProgressDto, responsePartHandle?: number): Promise<number | void> {
+	async $handleProgressChunk(requestId: string, chunks: (IChatProgressDto | [IChatProgressDto, number])[]): Promise<void> {
 
-		const revivedProgress = progress.kind === 'notebookEdit'
-			? ChatNotebookEdit.fromChatEdit(revive(progress))
-			: revive(progress) as IChatProgress;
+		const chatProgressParts: IChatProgress[] = [];
 
-		if (revivedProgress.kind === 'notebookEdit'
-			|| revivedProgress.kind === 'textEdit'
-			|| revivedProgress.kind === 'codeblockUri'
-		) {
-			// make sure to use the canonical uri
-			revivedProgress.uri = this._uriIdentityService.asCanonicalUri(revivedProgress.uri);
-		}
+		chunks.forEach(item => {
+			const [progress, responsePartHandle] = Array.isArray(item) ? item : [item];
 
-		if (revivedProgress.kind === 'progressTask') {
-			const handle = ++this._responsePartHandlePool;
-			const responsePartId = `${requestId}_${handle}`;
-			const task = new MainThreadChatTask(revivedProgress.content);
-			this._activeTasks.set(responsePartId, task);
-			this._pendingProgress.get(requestId)?.(task);
-			return handle;
-		} else if (responsePartHandle !== undefined) {
-			const responsePartId = `${requestId}_${responsePartHandle}`;
-			const task = this._activeTasks.get(responsePartId);
-			switch (revivedProgress.kind) {
-				case 'progressTaskResult':
-					if (task && revivedProgress.content) {
-						task.complete(revivedProgress.content.value);
-						this._activeTasks.delete(responsePartId);
-					} else {
-						task?.complete(undefined);
+			const revivedProgress = progress.kind === 'notebookEdit'
+				? ChatNotebookEdit.fromChatEdit(revive(progress))
+				: revive(progress) as IChatProgress;
+
+			if (revivedProgress.kind === 'notebookEdit'
+				|| revivedProgress.kind === 'textEdit'
+				|| revivedProgress.kind === 'codeblockUri'
+			) {
+				// make sure to use the canonical uri
+				revivedProgress.uri = this._uriIdentityService.asCanonicalUri(revivedProgress.uri);
+			}
+
+			if (responsePartHandle !== undefined) {
+
+				if (revivedProgress.kind === 'progressTask') {
+					const handle = responsePartHandle;
+					const responsePartId = `${requestId}_${handle}`;
+					const task = new MainThreadChatTask(revivedProgress.content);
+					this._activeTasks.set(responsePartId, task);
+					chatProgressParts.push(task);
+
+				} else if (responsePartHandle !== undefined) {
+					const responsePartId = `${requestId}_${responsePartHandle}`;
+					const task = this._activeTasks.get(responsePartId);
+					switch (revivedProgress.kind) {
+						case 'progressTaskResult':
+							if (task && revivedProgress.content) {
+								task.complete(revivedProgress.content.value);
+								this._activeTasks.delete(responsePartId);
+							} else {
+								task?.complete(undefined);
+							}
+							return;
+						case 'warning':
+						case 'reference':
+							task?.add(revivedProgress);
+							return;
 					}
-					return responsePartHandle;
-				case 'warning':
-				case 'reference':
-					task?.add(revivedProgress);
-					return;
+				}
 			}
-		}
 
-		if (revivedProgress.kind === 'inlineReference' && revivedProgress.resolveId) {
-			if (!this._unresolvedAnchors.has(requestId)) {
-				this._unresolvedAnchors.set(requestId, new Map());
+			if (revivedProgress.kind === 'inlineReference' && revivedProgress.resolveId) {
+				if (!this._unresolvedAnchors.has(requestId)) {
+					this._unresolvedAnchors.set(requestId, new Map());
+				}
+				this._unresolvedAnchors.get(requestId)?.set(revivedProgress.resolveId, revivedProgress);
 			}
-			this._unresolvedAnchors.get(requestId)?.set(revivedProgress.resolveId, revivedProgress);
-		}
 
-		this._pendingProgress.get(requestId)?.(revivedProgress);
+			chatProgressParts.push(revivedProgress);
+		});
+
+		this._pendingProgress.get(requestId)?.(chatProgressParts);
 	}
 
 	$handleAnchorResolve(requestId: string, handle: string, resolveAnchor: Dto<IChatContentInlineReference> | undefined): void {

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -1307,7 +1307,7 @@ export interface MainThreadChatAgentsShape2 extends IDisposable {
 	$unregisterAgentCompletionsProvider(handle: number, id: string): void;
 	$updateAgent(handle: number, metadataUpdate: IExtensionChatAgentMetadata): void;
 	$unregisterAgent(handle: number): void;
-	$handleProgressChunk(requestId: string, chunk: IChatProgressDto, handle?: number): Promise<number | void>;
+	$handleProgressChunk(requestId: string, chunks: (IChatProgressDto | [IChatProgressDto, number])[]): Promise<void>;
 	$handleAnchorResolve(requestId: string, handle: string, anchor: Dto<IChatContentInlineReference>): void;
 
 

--- a/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingEditorOverlay.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingEditorOverlay.ts
@@ -56,10 +56,13 @@ class ChatEditorOverlayWidget extends Disposable {
 		this._domNode.classList.add('chat-editor-overlay-widget');
 
 		this._isBusy = derived(r => {
-			const session = this._session.read(r);
-			const chatModel = session && _chatService.getSession(session?.chatSessionId);
 
-			return chatModel?.requestInProgressObs.read(r) ?? false;
+			const entry = this._entry.read(r);
+			return entry?.waitsForLastEdits.read(r) ?? false;
+
+			// const session = this._session.read(r);
+			// const chatModel = session && _chatService.getSession(session?.chatSessionId);
+			// return chatModel?.requestInProgressObs.read(r) ?? false;
 		});
 
 		const requestMessage = derived(r => {

--- a/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingModifiedFileEntry.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingModifiedFileEntry.ts
@@ -54,6 +54,9 @@ export abstract class AbstractChatEditingModifiedFileEntry extends Disposable im
 	protected readonly _stateObs = observableValue<ModifiedFileEntryState>(this, ModifiedFileEntryState.Modified);
 	readonly state: IObservable<ModifiedFileEntryState> = this._stateObs;
 
+	protected readonly _waitsForLastEdits = observableValue<boolean>(this, false);
+	readonly waitsForLastEdits: IObservable<boolean> = this._waitsForLastEdits;
+
 	protected readonly _isCurrentlyBeingModifiedByObs = observableValue<IChatResponseModel | undefined>(this, undefined);
 	readonly isCurrentlyBeingModifiedBy: IObservable<IChatResponseModel | undefined> = this._isCurrentlyBeingModifiedByObs;
 
@@ -133,7 +136,7 @@ export abstract class AbstractChatEditingModifiedFileEntry extends Disposable im
 
 		const autoSaveOff = this._store.add(new MutableDisposable());
 		this._store.add(autorun(r => {
-			if (this._lastModifyingResponseInProgressObs.read(r)) {
+			if (this._waitsForLastEdits.read(r)) {
 				autoSaveOff.value = _fileConfigService.disableAutoSave(this.modifiedURI);
 			} else {
 				autoSaveOff.clear();
@@ -294,6 +297,7 @@ export abstract class AbstractChatEditingModifiedFileEntry extends Disposable im
 	protected _resetEditsState(tx: ITransaction): void {
 		this._isCurrentlyBeingModifiedByObs.set(undefined, tx);
 		this._rewriteRatioObs.set(0, tx);
+		this._waitsForLastEdits.set(false, tx);
 	}
 
 	// --- snapshot

--- a/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingModifiedNotebookEntry.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingModifiedNotebookEntry.ts
@@ -564,7 +564,8 @@ export class ChatEditingModifiedNotebookEntry extends AbstractChatEditingModifie
 		};
 
 		this._applyEditsSync(async () => {
-			edits.map(edit => {
+			edits.map((edit, idx) => {
+				const last = isLastEdits && idx === edits.length - 1;
 				if (TextEdit.isTextEdit(edit)) {
 					// Possible we're getting the raw content for the notebook.
 					if (isEqual(resource, this.modifiedModel.uri)) {
@@ -577,7 +578,7 @@ export class ChatEditingModifiedNotebookEntry extends AbstractChatEditingModifie
 							finishPreviousCells();
 							this.editedCells.add(resource);
 						}
-						cellEntry?.acceptAgentEdits([edit], isLastEdits, responseModel);
+						cellEntry?.acceptAgentEdits([edit], last, responseModel);
 					}
 				} else {
 					// If we notebook edits, its impossible to get text edits for the notebook uri.

--- a/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingServiceImpl.ts
@@ -292,18 +292,19 @@ export class ChatEditingService extends Disposable implements IChatEditingServic
 
 				if (newEdits.length > 0 || isFirst) {
 					if (part.kind === 'notebookEditGroup') {
-						newEdits.forEach(edit => {
+						newEdits.forEach((edit, idx) => {
+							const done = part.done ? idx === newEdits.length - 1 : false;
 							if (TextEdit.isTextEdit(edit)) {
 								// Not possible, as Notebooks would have a different type.
 								return;
 							} else if (isCellTextEditOperation(edit)) {
-								entry.streaming.pushNotebookCellText(edit.uri, [edit.edit]);
+								entry.streaming.pushNotebookCellText(edit.uri, [edit.edit], done);
 							} else {
-								entry.streaming.pushNotebook([edit]);
+								entry.streaming.pushNotebook([edit], done);
 							}
 						});
 					} else if (part.kind === 'textEditGroup') {
-						entry.streaming.pushText(newEdits as TextEdit[]);
+						entry.streaming.pushText(newEdits as TextEdit[], part.done ?? false);
 					}
 				}
 

--- a/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingSession.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingSession.ts
@@ -707,6 +707,7 @@ export class ChatEditingSession extends Disposable implements IChatEditingSessio
 				didComplete = true;
 				sequencer.queue(async () => {
 					if (!this.isDisposed) {
+						await this._acceptEdits(resource, [], true, responseModel);
 						await this._resolve(responseModel.requestId, inUndoStop, resource);
 						completePromise.complete();
 					}

--- a/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingSession.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingSession.ts
@@ -678,24 +678,24 @@ export class ChatEditingSession extends Disposable implements IChatEditingSessio
 		let didComplete = false;
 
 		return {
-			pushText: (edits) => {
+			pushText: (edits, isLastEdits) => {
 				sequencer.queue(async () => {
 					if (!this.isDisposed) {
-						await this._acceptEdits(resource, edits, false, responseModel);
+						await this._acceptEdits(resource, edits, isLastEdits, responseModel);
 					}
 				});
 			},
-			pushNotebookCellText: (cell, edits) => {
+			pushNotebookCellText: (cell, edits, isLastEdits) => {
 				sequencer.queue(async () => {
 					if (!this.isDisposed) {
-						await this._acceptEdits(cell, edits, false, responseModel);
+						await this._acceptEdits(cell, edits, isLastEdits, responseModel);
 					}
 				});
 			},
-			pushNotebook: edits => {
+			pushNotebook: (edits, isLastEdits) => {
 				sequencer.queue(async () => {
 					if (!this.isDisposed) {
-						await this._acceptEdits(resource, edits, false, responseModel);
+						await this._acceptEdits(resource, edits, isLastEdits, responseModel);
 					}
 				});
 			},
@@ -707,7 +707,6 @@ export class ChatEditingSession extends Disposable implements IChatEditingSessio
 				didComplete = true;
 				sequencer.queue(async () => {
 					if (!this.isDisposed) {
-						await this._acceptEdits(resource, [], true, responseModel);
 						await this._resolve(responseModel.requestId, inUndoStop, resource);
 						completePromise.complete();
 					}

--- a/src/vs/workbench/contrib/chat/browser/chatSetup.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSetup.ts
@@ -207,7 +207,7 @@ class SetupAgent extends Disposable implements IChatAgentImplementation {
 		super();
 	}
 
-	async invoke(request: IChatAgentRequest, progress: (part: IChatProgress) => void): Promise<IChatAgentResult> {
+	async invoke(request: IChatAgentRequest, progress: (parts: IChatProgress[]) => void): Promise<IChatAgentResult> {
 		return this.instantiationService.invokeFunction(async accessor /* using accessor for lazy loading */ => {
 			const chatService = accessor.get(IChatService);
 			const languageModelsService = accessor.get(ILanguageModelsService);
@@ -215,7 +215,7 @@ class SetupAgent extends Disposable implements IChatAgentImplementation {
 			const chatAgentService = accessor.get(IChatAgentService);
 			const languageModelToolsService = accessor.get(ILanguageModelToolsService);
 
-			return this.doInvoke(request, progress, chatService, languageModelsService, chatWidgetService, chatAgentService, languageModelToolsService);
+			return this.doInvoke(request, part => progress([part]), chatService, languageModelsService, chatWidgetService, chatAgentService, languageModelToolsService);
 		});
 	}
 

--- a/src/vs/workbench/contrib/chat/common/chatAgents.ts
+++ b/src/vs/workbench/contrib/chat/common/chatAgents.ts
@@ -69,7 +69,7 @@ export interface IChatWelcomeMessageContent {
 }
 
 export interface IChatAgentImplementation {
-	invoke(request: IChatAgentRequest, progress: (part: IChatProgress) => void, history: IChatAgentHistoryEntry[], token: CancellationToken): Promise<IChatAgentResult>;
+	invoke(request: IChatAgentRequest, progress: (parts: IChatProgress[]) => void, history: IChatAgentHistoryEntry[], token: CancellationToken): Promise<IChatAgentResult>;
 	setRequestPaused?(requestId: string, isPaused: boolean): void;
 	provideFollowups?(request: IChatAgentRequest, result: IChatAgentResult, history: IChatAgentHistoryEntry[], token: CancellationToken): Promise<IChatFollowup[]>;
 	provideChatTitle?: (history: IChatAgentHistoryEntry[], token: CancellationToken) => Promise<string | undefined>;
@@ -192,7 +192,7 @@ export interface IChatAgentService {
 	registerChatParticipantDetectionProvider(handle: number, provider: IChatParticipantDetectionProvider): IDisposable;
 	detectAgentOrCommand(request: IChatAgentRequest, history: IChatAgentHistoryEntry[], options: { location: ChatAgentLocation }, token: CancellationToken): Promise<{ agent: IChatAgentData; command?: IChatAgentCommand } | undefined>;
 	hasChatParticipantDetectionProviders(): boolean;
-	invokeAgent(agent: string, request: IChatAgentRequest, progress: (part: IChatProgress) => void, history: IChatAgentHistoryEntry[], token: CancellationToken): Promise<IChatAgentResult>;
+	invokeAgent(agent: string, request: IChatAgentRequest, progress: (parts: IChatProgress[]) => void, history: IChatAgentHistoryEntry[], token: CancellationToken): Promise<IChatAgentResult>;
 	setRequestPaused(agent: string, requestId: string, isPaused: boolean): void;
 	getFollowups(id: string, request: IChatAgentRequest, result: IChatAgentResult, history: IChatAgentHistoryEntry[], token: CancellationToken): Promise<IChatFollowup[]>;
 	getChatTitle(id: string, history: IChatAgentHistoryEntry[], token: CancellationToken): Promise<string | undefined>;
@@ -467,7 +467,7 @@ export class ChatAgentService extends Disposable implements IChatAgentService {
 			.filter(a => a.extensionId.value !== agent.extensionId.value).length > 0;
 	}
 
-	async invokeAgent(id: string, request: IChatAgentRequest, progress: (part: IChatProgress) => void, history: IChatAgentHistoryEntry[], token: CancellationToken): Promise<IChatAgentResult> {
+	async invokeAgent(id: string, request: IChatAgentRequest, progress: (parts: IChatProgress[]) => void, history: IChatAgentHistoryEntry[], token: CancellationToken): Promise<IChatAgentResult> {
 		const data = this._agents.get(id);
 		if (!data?.impl) {
 			throw new Error(`No activated agent with id "${id}"`);
@@ -581,7 +581,7 @@ export class MergedChatAgent implements IChatAgent {
 	get modes(): ChatMode[] { return this.data.modes; }
 	get disambiguation(): { category: string; description: string; examples: string[] }[] { return this.data.disambiguation; }
 
-	async invoke(request: IChatAgentRequest, progress: (part: IChatProgress) => void, history: IChatAgentHistoryEntry[], token: CancellationToken): Promise<IChatAgentResult> {
+	async invoke(request: IChatAgentRequest, progress: (parts: IChatProgress[]) => void, history: IChatAgentHistoryEntry[], token: CancellationToken): Promise<IChatAgentResult> {
 		return this.impl.invoke(request, progress, history, token);
 	}
 

--- a/src/vs/workbench/contrib/chat/common/chatEditingService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatEditingService.ts
@@ -215,6 +215,8 @@ export interface IModifiedFileEntry {
 	readonly lastModifyingResponse: IObservable<IChatResponseModel | undefined>;
 	readonly rewriteRatio: IObservable<number>;
 
+	readonly waitsForLastEdits: IObservable<boolean>;
+
 	accept(transaction: ITransaction | undefined): Promise<void>;
 	reject(transaction: ITransaction | undefined): Promise<void>;
 

--- a/src/vs/workbench/contrib/chat/common/chatEditingService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatEditingService.ts
@@ -70,9 +70,9 @@ export interface WorkingSetDisplayMetadata {
 }
 
 export interface IStreamingEdits {
-	pushText(edits: TextEdit[]): void;
-	pushNotebookCellText(cell: URI, edits: TextEdit[]): void;
-	pushNotebook(edits: ICellEditOperation[]): void;
+	pushText(edits: TextEdit[], isLastEdits: boolean): void;
+	pushNotebookCellText(cell: URI, edits: TextEdit[], isLastEdits: boolean): void;
+	pushNotebook(edits: ICellEditOperation[], isLastEdits: boolean): void;
 	/** Marks edits as done, idempotent */
 	complete(): void;
 }

--- a/src/vs/workbench/contrib/chat/test/common/chatService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/chatService.test.ts
@@ -55,7 +55,7 @@ const chatAgentWithUsedContext: IChatAgent = {
 	slashCommands: [],
 	disambiguation: [],
 	async invoke(request, progress, history, token) {
-		progress({
+		progress([{
 			documents: [
 				{
 					uri: URI.file('/test/path/to/file'),
@@ -66,7 +66,7 @@ const chatAgentWithUsedContext: IChatAgent = {
 				}
 			],
 			kind: 'usedContext'
-		});
+		}]);
 
 		return { metadata: { metadataKey: 'value' } };
 	},
@@ -89,7 +89,7 @@ const chatAgentWithMarkdown: IChatAgent = {
 	slashCommands: [],
 	disambiguation: [],
 	async invoke(request, progress, history, token) {
-		progress({ kind: 'markdownContent', content: new MarkdownString('test') });
+		progress([{ kind: 'markdownContent', content: new MarkdownString('test') }]);
 		return { metadata: { metadataKey: 'value' } };
 	},
 	async provideFollowups(sessionId, token) {

--- a/src/vs/workbench/contrib/chat/test/common/voiceChatService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/voiceChatService.test.ts
@@ -46,7 +46,7 @@ suite('VoiceChat', () => {
 		provideFollowups?(request: IChatAgentRequest, result: IChatAgentResult, history: IChatAgentHistoryEntry[], token: CancellationToken): Promise<IChatFollowup[]> {
 			throw new Error('Method not implemented.');
 		}
-		invoke(request: IChatAgentRequest, progress: (part: IChatProgress) => void, history: IChatAgentHistoryEntry[], token: CancellationToken): Promise<IChatAgentResult> { throw new Error('Method not implemented.'); }
+		invoke(request: IChatAgentRequest, progress: (part: IChatProgress[]) => void, history: IChatAgentHistoryEntry[], token: CancellationToken): Promise<IChatAgentResult> { throw new Error('Method not implemented.'); }
 		metadata = {};
 	}
 
@@ -65,7 +65,7 @@ suite('VoiceChat', () => {
 		readonly onDidChangeAgents = Event.None;
 		registerAgentImplementation(id: string, agent: IChatAgentImplementation): IDisposable { throw new Error(); }
 		registerDynamicAgent(data: IChatAgentData, agentImpl: IChatAgentImplementation): IDisposable { throw new Error('Method not implemented.'); }
-		invokeAgent(id: string, request: IChatAgentRequest, progress: (part: IChatProgress) => void, history: IChatAgentHistoryEntry[], token: CancellationToken): Promise<IChatAgentResult> { throw new Error(); }
+		invokeAgent(id: string, request: IChatAgentRequest, progress: (part: IChatProgress[]) => void, history: IChatAgentHistoryEntry[], token: CancellationToken): Promise<IChatAgentResult> { throw new Error(); }
 		setRequestPaused(agent: string, requestId: string, isPaused: boolean): void { throw new Error('not implemented'); }
 		getFollowups(id: string, request: IChatAgentRequest, result: IChatAgentResult, history: IChatAgentHistoryEntry[], token: CancellationToken): Promise<IChatFollowup[]> { throw new Error(); }
 		getActivatedAgents(): IChatAgent[] { return agents; }

--- a/src/vs/workbench/contrib/inlineChat/test/browser/inlineChatController.test.ts
+++ b/src/vs/workbench/contrib/inlineChat/test/browser/inlineChatController.test.ts
@@ -228,14 +228,14 @@ suite('InlineChatController', function () {
 
 		store.add(chatAgentService.registerDynamicAgent({ id: 'testEditorAgent', ...agentData, }, {
 			async invoke(request, progress, history, token) {
-				progress({
+				progress([{
 					kind: 'textEdit',
 					uri: model.uri,
 					edits: [{
 						range: new Range(1, 1, 1, 1),
 						text: request.message
 					}]
-				});
+				}]);
 				return {};
 			},
 		}));
@@ -314,14 +314,14 @@ suite('InlineChatController', function () {
 			...agentData
 		}, {
 			async invoke(request, progress, history, token) {
-				progress({
+				progress([{
 					kind: 'textEdit',
 					uri: editor.getModel().uri,
 					edits: [{
 						range: new Range(1, 1, 1, 1), // EDIT happens outside of whole range
 						text: `${request.message}\n${request.message}`
 					}]
-				});
+				}]);
 
 				return {};
 			},
@@ -379,9 +379,9 @@ suite('InlineChatController', function () {
 		}, {
 			async invoke(request, progress, history, token) {
 
-				progress({ kind: 'textEdit', uri: model.uri, edits: [{ range: new Range(1, 1, 1, 1), text: 'hEllo1\n' }] });
-				progress({ kind: 'textEdit', uri: model.uri, edits: [{ range: new Range(2, 1, 2, 1), text: 'hEllo2\n' }] });
-				progress({ kind: 'textEdit', uri: model.uri, edits: [{ range: new Range(1, 1, 1000, 1), text: 'Hello1\nHello2\n' }] });
+				progress([{ kind: 'textEdit', uri: model.uri, edits: [{ range: new Range(1, 1, 1, 1), text: 'hEllo1\n' }] }]);
+				progress([{ kind: 'textEdit', uri: model.uri, edits: [{ range: new Range(2, 1, 2, 1), text: 'hEllo2\n' }] }]);
+				progress([{ kind: 'textEdit', uri: model.uri, edits: [{ range: new Range(1, 1, 1000, 1), text: 'Hello1\nHello2\n' }] }]);
 
 				return {};
 			},
@@ -418,10 +418,10 @@ suite('InlineChatController', function () {
 					const text = '${CSI}#a\n${CSI}#b\n${CSI}#c\n';
 
 					await timeout(10);
-					progress({ kind: 'textEdit', uri: model.uri, edits: [{ range: new Range(1, 1, 1, 1), text: text }] });
+					progress([{ kind: 'textEdit', uri: model.uri, edits: [{ range: new Range(1, 1, 1, 1), text: text }] }]);
 
 					await timeout(10);
-					progress({ kind: 'textEdit', uri: model.uri, edits: [{ range: new Range(1, 1, 1, 1), text: text.repeat(1000) + 'DONE' }] });
+					progress([{ kind: 'textEdit', uri: model.uri, edits: [{ range: new Range(1, 1, 1, 1), text: text.repeat(1000) + 'DONE' }] }]);
 
 					throw new Error('Too long');
 				},
@@ -494,7 +494,7 @@ suite('InlineChatController', function () {
 			...agentData
 		}, {
 			async invoke(request, progress, history, token) {
-				progress({ kind: 'textEdit', uri: model.uri, edits: [{ range: new Range(1, 1, 1, 1), text: request.message + (count++) }] });
+				progress([{ kind: 'textEdit', uri: model.uri, edits: [{ range: new Range(1, 1, 1, 1), text: request.message + (count++) }] }]);
 				return {};
 			},
 		}));
@@ -534,7 +534,7 @@ suite('InlineChatController', function () {
 			...agentData
 		}, {
 			async invoke(request, progress, history, token) {
-				progress({ kind: 'textEdit', uri: model.uri, edits: [{ range: new Range(1, 1, 1, 1), text: text.shift() ?? '' }] });
+				progress([{ kind: 'textEdit', uri: model.uri, edits: [{ range: new Range(1, 1, 1, 1), text: text.shift() ?? '' }] }]);
 				return {};
 			},
 		}));
@@ -582,7 +582,7 @@ suite('InlineChatController', function () {
 			...agentData
 		}, {
 			async invoke(request, progress, history, token) {
-				progress({ kind: 'textEdit', uri: model.uri, edits: [{ range: new Range(1, 1, 1, 1), text: text.shift() ?? '' }] });
+				progress([{ kind: 'textEdit', uri: model.uri, edits: [{ range: new Range(1, 1, 1, 1), text: text.shift() ?? '' }] }]);
 				return {};
 			},
 		}));
@@ -622,7 +622,7 @@ suite('InlineChatController', function () {
 			...agentData
 		}, {
 			async invoke(request, progress, history, token) {
-				progress({ kind: 'textEdit', uri: model.uri, edits: [{ range: new Range(1, 1, 1, 1), text: text.shift() ?? '' }] });
+				progress([{ kind: 'textEdit', uri: model.uri, edits: [{ range: new Range(1, 1, 1, 1), text: text.shift() ?? '' }] }]);
 				return {};
 			},
 		}));
@@ -677,7 +677,7 @@ suite('InlineChatController', function () {
 			async invoke(request, progress, history, token) {
 				queueMicrotask(() => onDidInvoke.fire());
 				commandDetection.push(request.enableCommandDetection);
-				progress({ kind: 'textEdit', uri: model.uri, edits: [{ range: new Range(1, 1, 1, 1), text: request.message + (count++) }] });
+				progress([{ kind: 'textEdit', uri: model.uri, edits: [{ range: new Range(1, 1, 1, 1), text: request.message + (count++) }] }]);
 
 				if (count === 1) {
 					// FIRST call waits for cancellation
@@ -727,7 +727,7 @@ suite('InlineChatController', function () {
 		}, {
 			async invoke(request, progress, history, token) {
 				commandDetection.push(request.enableCommandDetection);
-				progress({ kind: 'textEdit', uri: model.uri, edits: [{ range: new Range(1, 1, 1, 1), text: request.message + (count++) }] });
+				progress([{ kind: 'textEdit', uri: model.uri, edits: [{ range: new Range(1, 1, 1, 1), text: request.message + (count++) }] }]);
 				return {};
 			},
 		}));
@@ -767,7 +767,7 @@ suite('InlineChatController', function () {
 
 				attempts.push(request.attempt);
 
-				progress({ kind: 'textEdit', uri: model.uri, edits: [{ range: new Range(1, 1, 1, 1), text: `TRY:${request.attempt}\n` }] });
+				progress([{ kind: 'textEdit', uri: model.uri, edits: [{ range: new Range(1, 1, 1, 1), text: `TRY:${request.attempt}\n` }] }]);
 				await raceCancellation(deferred.p, token);
 				deferred.complete();
 				await timeout(10);
@@ -801,7 +801,7 @@ suite('InlineChatController', function () {
 		model.setValue('World');
 
 		const deferred = new DeferredPromise<void>();
-		let progress: ((part: IChatProgress) => void) | undefined;
+		let progress: ((parts: IChatProgress[]) => void) | undefined;
 
 		store.add(chatAgentService.registerDynamicAgent({
 			id: 'testEditorAgent2',
@@ -827,7 +827,7 @@ suite('InlineChatController', function () {
 
 		const modelChange = new Promise<void>(resolve => model.onDidChangeContent(() => resolve()));
 
-		progress({ kind: 'textEdit', uri: model.uri, edits: [{ range: new Range(1, 1, 1, 1), text: 'Hello-Hello' }] });
+		progress([{ kind: 'textEdit', uri: model.uri, edits: [{ range: new Range(1, 1, 1, 1), text: 'Hello-Hello' }] }]);
 
 		await modelChange;
 		assert.strictEqual(model.getValue(), 'HelloWorld'); // first word has been streamed
@@ -884,14 +884,14 @@ suite('InlineChatController', function () {
 			store.add(chatAgentService.registerDynamicAgent({ id: 'testEditorAgent', ...agentData, }, {
 				async invoke(request, progress, history, token) {
 
-					progress({
+					progress([{
 						kind: 'textEdit',
 						uri: model.uri,
 						edits: [{
 							range: new Range(1, 1, 1, 1),
 							text: request.message
 						}]
-					});
+					}]);
 
 					if (request.message === 'two') {
 						await timeout(100); // give edit a chance
@@ -938,7 +938,7 @@ suite('InlineChatController', function () {
 		}, {
 			async invoke(request, progress, history, token) {
 
-				progress({ kind: 'textEdit', uri: model.uri, edits: [{ range: new Range(1, 1, 1, 1), text: 'Hello-Hello' }] });
+				progress([{ kind: 'textEdit', uri: model.uri, edits: [{ range: new Range(1, 1, 1, 1), text: 'Hello-Hello' }] }]);
 				await deferred.p;
 				return {};
 			},
@@ -975,11 +975,11 @@ suite('InlineChatController', function () {
 			}, {
 				async invoke(request, progress, history, token) {
 
-					progress({ kind: 'textEdit', uri: model.uri, edits: [{ range: new Range(1, 1, 1, 1), text: 'Hello1' }] });
+					progress([{ kind: 'textEdit', uri: model.uri, edits: [{ range: new Range(1, 1, 1, 1), text: 'Hello1' }] }]);
 					await timeout(100);
-					progress({ kind: 'textEdit', uri: model.uri, edits: [{ range: new Range(1, 1, 1, 1), text: 'Hello2' }] });
+					progress([{ kind: 'textEdit', uri: model.uri, edits: [{ range: new Range(1, 1, 1, 1), text: 'Hello2' }] }]);
 					await timeout(100);
-					progress({ kind: 'textEdit', uri: model.uri, edits: [{ range: new Range(1, 1, 1, 1), text: 'Hello3' }] });
+					progress([{ kind: 'textEdit', uri: model.uri, edits: [{ range: new Range(1, 1, 1, 1), text: 'Hello3' }] }]);
 					await timeout(100);
 
 					return {


### PR DESCRIPTION
Enhancements to the chat editing experience allow for better handling of different editing strategies, particularly for replace edits. The IPC protocol now supports multiple response chunks, and the editing operations are more aware of their context. 

Also: Breakpoints in agent mode will maybe now correctly follow the lines of code they are set on

Fixes microsoft/vscode#249083 and microsoft/vscode-copilot#16964