### PR TITLE
Bring back container focus for autoreveal cell execution w/ AI

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/controller/executeActions.ts
+++ b/src/vs/workbench/contrib/notebook/browser/controller/executeActions.ts
@@ -117,7 +117,6 @@ function handleSmartAutoReveal(cell: ICellViewModel, notebookEditor: IActiveNote
 	if (revealPercent !== undefined && revealThreshold !== undefined) { // "smart" reveal, only if both settings are set (for AI execution tracking primarily)
 		let elementScrollTop: number;
 
-		// omitted focusing the cell container, can potentially consider bringing it back
 		const cellEditorHeight = cell.layoutInfo.editorHeight;
 		const viewportHeight = notebookEditor.getLayoutInfo().height;
 
@@ -134,6 +133,7 @@ function handleSmartAutoReveal(cell: ICellViewModel, notebookEditor: IActiveNote
 			elementScrollTop = cellTop + cellEditorHeight - revealHeight;
 		}
 
+		notebookEditor.focusNotebookCell(cell, 'container', { skipReveal: true });
 		notebookEditor.setScrollTop(elementScrollTop - SMART_VIEWPORT_REVEAL_PADDING);
 		return true;
 	} else {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Found myself getting a bit lost sometimes. the container focus indicator is a nice bit of context for 'whats happening' as the agent executes various cells. 

skipReveal because we immediately set the scrolltop