### PR TITLE
eng - fix layer checker

### DIFF
--- a/build/lib/layersChecker.js
+++ b/build/lib/layersChecker.js
@@ -73,13 +73,15 @@ const CORE_TYPES = [
     'Request',
     'Response',
     'Body',
-    '__type',
-    '__global',
+    'any',
+    'timeout',
     'Performance',
     'PerformanceMark',
     'PerformanceObserver',
     'ImportMeta',
     'structuredClone',
+    'stackTraceLimit',
+    'captureStackTrace',
     // webcrypto has been available since Node.js 19, but still live in dom.d.ts
     'Crypto',
     'SubtleCrypto',
@@ -93,7 +95,6 @@ const CORE_TYPES = [
     'value',
     'done',
     'DOMException',
-    'localStorage',
     'WebSocket',
 ];
 // Types that are defined in a common layer but are known to be only
@@ -113,20 +114,6 @@ const RULES = [
     {
         target: '**/vs/**/test/**',
         skip: true // -> skip all test files
-    },
-    // Common: vs/base/common/platform.ts
-    {
-        target: '**/vs/base/common/platform.ts',
-        allowedTypes: [
-            ...CORE_TYPES,
-            // Safe access to postMessage() and friends
-            'MessageEvent',
-        ],
-        disallowedTypes: NATIVE_TYPES,
-        disallowedDefinitions: [
-            'lib.dom.d.ts', // no DOM
-            '@types/node' // no node.js
-        ]
     },
     // Common: vs/base/common/async.ts
     {
@@ -159,59 +146,16 @@ const RULES = [
             '@types/node' // no node.js
         ]
     },
-    // Common: vs/platform/environment/common/*
+    // Common: vs/platform services that can access native types
     {
-        target: '**/vs/platform/environment/common/*.ts',
-        allowedTypes: CORE_TYPES,
-        disallowedTypes: [ /* Ignore native types that are defined from here */],
-        disallowedDefinitions: [
-            'lib.dom.d.ts', // no DOM
-            '@types/node' // no node.js
-        ]
-    },
-    // Common: vs/platform/window/common/window.ts
-    {
-        target: '**/vs/platform/window/common/window.ts',
-        allowedTypes: CORE_TYPES,
-        disallowedTypes: [ /* Ignore native types that are defined from here */],
-        disallowedDefinitions: [
-            'lib.dom.d.ts', // no DOM
-            '@types/node' // no node.js
-        ]
-    },
-    // Common: vs/platform/browserElements/common/browserElements.ts
-    {
-        target: '**/vs/platform/browserElements/common/browserElements.ts',
-        allowedTypes: CORE_TYPES,
-        disallowedTypes: [ /* Ignore native types that are defined from here */],
-        disallowedDefinitions: [
-            'lib.dom.d.ts', // no DOM
-            '@types/node' // no node.js
-        ]
-    },
-    // Common: vs/platform/browserElements/common/nativeBrowserElementsService.ts
-    {
-        target: '**/vs/platform/browserElements/common/nativeBrowserElementsService.ts',
-        allowedTypes: CORE_TYPES,
-        disallowedTypes: [ /* Ignore native types that are defined from here */],
-        disallowedDefinitions: [
-            'lib.dom.d.ts', // no DOM
-            '@types/node' // no node.js
-        ]
-    },
-    // Common: vs/platform/native/common/native.ts
-    {
-        target: '**/vs/platform/native/common/native.ts',
-        allowedTypes: CORE_TYPES,
-        disallowedTypes: [ /* Ignore native types that are defined from here */],
-        disallowedDefinitions: [
-            'lib.dom.d.ts', // no DOM
-            '@types/node' // no node.js
-        ]
-    },
-    // Common: vs/platform/native/common/nativeHostService.ts
-    {
-        target: '**/vs/platform/native/common/nativeHostService.ts',
+        target: `**/vs/platform/{${[
+            'environment/common/*.ts',
+            'window/common/window.ts',
+            'native/common/native.ts',
+            'native/common/nativeHostService.ts',
+            'browserElements/common/browserElements.ts',
+            'browserElements/common/nativeBrowserElementsService.ts'
+        ].join(',')}}`,
         allowedTypes: CORE_TYPES,
         disallowedTypes: [ /* Ignore native types that are defined from here */],
         disallowedDefinitions: [
@@ -233,14 +177,15 @@ const RULES = [
             '@types/node' // no node.js
         ]
     },
-    // Common: vs/base/parts/sandbox/electron-sandbox/preload.ts
+    // Common: vs/base/parts/sandbox/electron-sandbox/preload{,-aux}.ts
     {
-        target: '**/vs/base/parts/sandbox/electron-sandbox/preload.ts',
+        target: '**/vs/base/parts/sandbox/electron-sandbox/preload{,-aux}.ts',
         allowedTypes: [
             ...CORE_TYPES,
             // Safe access to a very small subset of node.js
             'process',
-            'NodeJS'
+            'NodeJS',
+            '__global'
         ],
         disallowedTypes: NATIVE_TYPES,
         disallowedDefinitions: [
@@ -260,11 +205,11 @@ const RULES = [
     // Browser
     {
         target: '**/vs/**/browser/**',
-        allowedTypes: CORE_TYPES,
-        disallowedTypes: NATIVE_TYPES,
-        allowedDefinitions: [
-            '@types/node/stream/consumers.d.ts' // node.js started to duplicate types from lib.dom.d.ts so we have to account for that
+        allowedTypes: [
+            ...CORE_TYPES,
+            'localStorage'
         ],
+        disallowedTypes: NATIVE_TYPES,
         disallowedDefinitions: [
             '@types/node' // no node.js
         ]
@@ -294,31 +239,10 @@ const RULES = [
             '@types/node' // no node.js
         ]
     },
-    // Electron (utility)
+    // Electron (main, utility)
     {
-        target: '**/vs/**/electron-utility/**',
-        allowedTypes: [
-            ...CORE_TYPES,
-            // --> types from electron.d.ts that duplicate from lib.dom.d.ts
-            'Event',
-            'Request'
-        ],
-        disallowedTypes: [
-            'ipcMain' // not allowed, use validatedIpcMain instead
-        ],
-        disallowedDefinitions: [
-            'lib.dom.d.ts' // no DOM
-        ]
-    },
-    // Electron (main)
-    {
-        target: '**/vs/**/electron-main/**',
-        allowedTypes: [
-            ...CORE_TYPES,
-            // --> types from electron.d.ts that duplicate from lib.dom.d.ts
-            'Event',
-            'Request'
-        ],
+        target: '**/vs/**/{electron-main,electron-utility}/**',
+        allowedTypes: CORE_TYPES,
         disallowedTypes: [
             'ipcMain' // not allowed, use validatedIpcMain instead
         ],
@@ -340,12 +264,16 @@ function checkFile(program, sourceFile, rule) {
         if (!symbol) {
             return;
         }
+        let text = symbol.getName();
+        if (rule.allowedTypes?.some(allowed => allowed === text)) {
+            return; // override
+        }
         let _parentSymbol = symbol;
         while (_parentSymbol.parent) {
             _parentSymbol = _parentSymbol.parent;
         }
         const parentSymbol = _parentSymbol;
-        const text = parentSymbol.getName();
+        text = parentSymbol.getName();
         if (rule.allowedTypes?.some(allowed => allowed === text)) {
             return; // override
         }

--- a/build/lib/layersChecker.ts
+++ b/build/lib/layersChecker.ts
@@ -71,13 +71,15 @@ const CORE_TYPES = [
 	'Request',
 	'Response',
 	'Body',
-	'__type',
-	'__global',
+	'any',
+	'timeout',
 	'Performance',
 	'PerformanceMark',
 	'PerformanceObserver',
 	'ImportMeta',
 	'structuredClone',
+	'stackTraceLimit',
+	'captureStackTrace',
 
 	// webcrypto has been available since Node.js 19, but still live in dom.d.ts
 	'Crypto',
@@ -93,7 +95,6 @@ const CORE_TYPES = [
 	'value',
 	'done',
 	'DOMException',
-	'localStorage',
 	'WebSocket',
 ];
 
@@ -116,22 +117,6 @@ const RULES: IRule[] = [
 	{
 		target: '**/vs/**/test/**',
 		skip: true // -> skip all test files
-	},
-
-	// Common: vs/base/common/platform.ts
-	{
-		target: '**/vs/base/common/platform.ts',
-		allowedTypes: [
-			...CORE_TYPES,
-
-			// Safe access to postMessage() and friends
-			'MessageEvent',
-		],
-		disallowedTypes: NATIVE_TYPES,
-		disallowedDefinitions: [
-			'lib.dom.d.ts', // no DOM
-			'@types/node'	// no node.js
-		]
 	},
 
 	// Common: vs/base/common/async.ts
@@ -169,64 +154,16 @@ const RULES: IRule[] = [
 		]
 	},
 
-	// Common: vs/platform/environment/common/*
+	// Common: vs/platform services that can access native types
 	{
-		target: '**/vs/platform/environment/common/*.ts',
-		allowedTypes: CORE_TYPES,
-		disallowedTypes: [/* Ignore native types that are defined from here */],
-		disallowedDefinitions: [
-			'lib.dom.d.ts', // no DOM
-			'@types/node'	// no node.js
-		]
-	},
-
-	// Common: vs/platform/window/common/window.ts
-	{
-		target: '**/vs/platform/window/common/window.ts',
-		allowedTypes: CORE_TYPES,
-		disallowedTypes: [/* Ignore native types that are defined from here */],
-		disallowedDefinitions: [
-			'lib.dom.d.ts', // no DOM
-			'@types/node'	// no node.js
-		]
-	},
-
-	// Common: vs/platform/browserElements/common/browserElements.ts
-	{
-		target: '**/vs/platform/browserElements/common/browserElements.ts',
-		allowedTypes: CORE_TYPES,
-		disallowedTypes: [/* Ignore native types that are defined from here */],
-		disallowedDefinitions: [
-			'lib.dom.d.ts', // no DOM
-			'@types/node'	// no node.js
-		]
-	},
-
-	// Common: vs/platform/browserElements/common/nativeBrowserElementsService.ts
-	{
-		target: '**/vs/platform/browserElements/common/nativeBrowserElementsService.ts',
-		allowedTypes: CORE_TYPES,
-		disallowedTypes: [/* Ignore native types that are defined from here */],
-		disallowedDefinitions: [
-			'lib.dom.d.ts', // no DOM
-			'@types/node'	// no node.js
-		]
-	},
-
-	// Common: vs/platform/native/common/native.ts
-	{
-		target: '**/vs/platform/native/common/native.ts',
-		allowedTypes: CORE_TYPES,
-		disallowedTypes: [/* Ignore native types that are defined from here */],
-		disallowedDefinitions: [
-			'lib.dom.d.ts', // no DOM
-			'@types/node'	// no node.js
-		]
-	},
-
-	// Common: vs/platform/native/common/nativeHostService.ts
-	{
-		target: '**/vs/platform/native/common/nativeHostService.ts',
+		target: `**/vs/platform/{${[
+			'environment/common/*.ts',
+			'window/common/window.ts',
+			'native/common/native.ts',
+			'native/common/nativeHostService.ts',
+			'browserElements/common/browserElements.ts',
+			'browserElements/common/nativeBrowserElementsService.ts'
+		].join(',')}}`,
 		allowedTypes: CORE_TYPES,
 		disallowedTypes: [/* Ignore native types that are defined from here */],
 		disallowedDefinitions: [
@@ -251,15 +188,16 @@ const RULES: IRule[] = [
 		]
 	},
 
-	// Common: vs/base/parts/sandbox/electron-sandbox/preload.ts
+	// Common: vs/base/parts/sandbox/electron-sandbox/preload{,-aux}.ts
 	{
-		target: '**/vs/base/parts/sandbox/electron-sandbox/preload.ts',
+		target: '**/vs/base/parts/sandbox/electron-sandbox/preload{,-aux}.ts',
 		allowedTypes: [
 			...CORE_TYPES,
 
 			// Safe access to a very small subset of node.js
 			'process',
-			'NodeJS'
+			'NodeJS',
+			'__global'
 		],
 		disallowedTypes: NATIVE_TYPES,
 		disallowedDefinitions: [
@@ -281,11 +219,11 @@ const RULES: IRule[] = [
 	// Browser
 	{
 		target: '**/vs/**/browser/**',
-		allowedTypes: CORE_TYPES,
-		disallowedTypes: NATIVE_TYPES,
-		allowedDefinitions: [
-			'@types/node/stream/consumers.d.ts' // node.js started to duplicate types from lib.dom.d.ts so we have to account for that
+		allowedTypes: [
+			...CORE_TYPES,
+			'localStorage'
 		],
+		disallowedTypes: NATIVE_TYPES,
 		disallowedDefinitions: [
 			'@types/node'	// no node.js
 		]
@@ -319,34 +257,10 @@ const RULES: IRule[] = [
 		]
 	},
 
-	// Electron (utility)
+	// Electron (main, utility)
 	{
-		target: '**/vs/**/electron-utility/**',
-		allowedTypes: [
-			...CORE_TYPES,
-
-			// --> types from electron.d.ts that duplicate from lib.dom.d.ts
-			'Event',
-			'Request'
-		],
-		disallowedTypes: [
-			'ipcMain' // not allowed, use validatedIpcMain instead
-		],
-		disallowedDefinitions: [
-			'lib.dom.d.ts'	// no DOM
-		]
-	},
-
-	// Electron (main)
-	{
-		target: '**/vs/**/electron-main/**',
-		allowedTypes: [
-			...CORE_TYPES,
-
-			// --> types from electron.d.ts that duplicate from lib.dom.d.ts
-			'Event',
-			'Request'
-		],
+		target: '**/vs/**/{electron-main,electron-utility}/**',
+		allowedTypes: CORE_TYPES,
 		disallowedTypes: [
 			'ipcMain' // not allowed, use validatedIpcMain instead
 		],
@@ -384,6 +298,11 @@ function checkFile(program: ts.Program, sourceFile: ts.SourceFile, rule: IRule) 
 			return;
 		}
 
+		let text = symbol.getName();
+		if (rule.allowedTypes?.some(allowed => allowed === text)) {
+			return; // override
+		}
+
 		let _parentSymbol: any = symbol;
 
 		while (_parentSymbol.parent) {
@@ -391,7 +310,7 @@ function checkFile(program: ts.Program, sourceFile: ts.SourceFile, rule: IRule) 
 		}
 
 		const parentSymbol = _parentSymbol as ts.Symbol;
-		const text = parentSymbol.getName();
+		text = parentSymbol.getName();
 
 		if (rule.allowedTypes?.some(allowed => allowed === text)) {
 			return; // override


### PR DESCRIPTION
Adding __global to CORE_TYPES allows node.js types in all layers.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
