### PR TITLE
feat(quickinput): improve dnd drag areas UX

### DIFF
--- a/src/vs/base/browser/ui/hover/hover.ts
+++ b/src/vs/base/browser/ui/hover/hover.ts
@@ -107,6 +107,11 @@ export interface IHoverDelegate2 {
 	hideHover(force?: boolean): void;
 
 	/**
+	 * Enable or disable the hover service. This will force hide any currently visible hover
+	 */
+	enableHover(enabled: boolean): void;
+
+	/**
 	 * This should only be used until we have the ability to show multiple context views
 	 * simultaneously. #188822
 	 */

--- a/src/vs/base/browser/ui/hover/hoverDelegate2.ts
+++ b/src/vs/base/browser/ui/hover/hoverDelegate2.ts
@@ -12,6 +12,7 @@ let baseHoverDelegate: IHoverDelegate2 = {
 	setupDelayedHover: () => Disposable.None,
 	setupDelayedHoverAtMouse: () => Disposable.None,
 	hideHover: () => undefined,
+	enableHover: () => undefined,
 	showAndFocusLastHover: () => undefined,
 	setupManagedHover: () => ({
 		dispose: () => undefined,

--- a/src/vs/editor/browser/services/hoverService/hoverService.ts
+++ b/src/vs/editor/browser/services/hoverService/hoverService.ts
@@ -42,6 +42,8 @@ export class HoverService extends Disposable implements IHoverService {
 	private _currentDelayedHoverGroupId: number | string | undefined;
 	private _lastHoverOptions: IHoverOptions | undefined;
 
+	private _enabled = true;
+
 	private _lastFocusedElementBeforeOpen: HTMLElement | undefined;
 
 	private readonly _delayedHovers = new Map<HTMLElement, { show: (focus: boolean) => void }>();
@@ -67,6 +69,10 @@ export class HoverService extends Disposable implements IHoverService {
 			primary: KeyChord(KeyMod.CtrlCmd | KeyCode.KeyK, KeyMod.CtrlCmd | KeyCode.KeyI),
 			handler: () => { this._showAndFocusHoverForActiveElement(); },
 		}));
+	}
+
+	get enable() {
+		return this._enabled;
 	}
 
 	showInstantHover(options: IHoverOptions, focus?: boolean, skipLastFocusedUpdate?: boolean, dontShow?: boolean): IHoverWidget | undefined {
@@ -289,11 +295,20 @@ export class HoverService extends Disposable implements IHoverService {
 		return hover;
 	}
 
+	enableHover(enabled: boolean) {
+		this._enabled = enabled;
+		if (!enabled) {
+			this.hideHover(true);
+		}
+	}
+
 	private _showHover(hover: HoverWidget, options: IHoverOptions, focus?: boolean) {
-		this._contextViewHandler.showContextView(
-			new HoverContextViewDelegate(hover, focus),
-			options.container
-		);
+		if (this.enable) {
+			this._contextViewHandler.showContextView(
+				new HoverContextViewDelegate(hover, focus),
+				options.container
+			);
+		}
 	}
 
 	hideHover(force?: boolean): void {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

# Intro
- Update dnd drag areas when input's value is empty
- Disabled tooltip when inpuBox is moving

# Related
fixed #248391