### PR TITLE
add custom aria labels for chat tool confirmation codeblocks

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatTerminalToolSubPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatTerminalToolSubPart.ts
@@ -81,7 +81,8 @@ export class TerminalConfirmationWidgetSubPart extends BaseChatToolInvocationSub
 			editorOptions: {
 				wordWrap: 'on',
 				readOnly: false,
-				tabFocusMode: true
+				tabFocusMode: true,
+				ariaLabel: title
 			}
 		};
 		const langId = this.languageService.getLanguageIdByLanguageName(terminalData.language ?? 'sh') ?? 'shellscript';

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatToolConfirmationSubPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatToolConfirmationSubPart.ts
@@ -119,8 +119,9 @@ export class ToolConfirmationSubPart extends BaseChatToolInvocationSubPart {
 				verticalPadding: 5,
 				editorOptions: {
 					wordWrap: 'on',
-					tabFocusMode: true
-				}
+					tabFocusMode: true,
+					ariaLabel: title
+				},
 			};
 
 			const elements = dom.h('div', [
@@ -139,7 +140,8 @@ export class ToolConfirmationSubPart extends BaseChatToolInvocationSubPart {
 					verticalPadding: 5,
 					editorOptions: {
 						wordWrap: 'off',
-						readOnly: false
+						readOnly: false,
+						ariaLabel: toolInvocation.confirmationMessages.title
 					}
 				};
 

--- a/src/vs/workbench/contrib/chat/browser/codeBlockPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/codeBlockPart.ts
@@ -412,8 +412,13 @@ export class CodeBlockPart extends Disposable {
 
 		this.editor.updateOptions({
 			...this.getEditorOptionsFromConfig(),
-			ariaLabel: localize('chat.codeBlockLabel', "Code block {0}", data.codeBlockIndex + 1),
 		});
+		if (!this.editor.getOption(EditorOption.ariaLabel)) {
+			// Don't override the ariaLabel if it was set by the editor options
+			this.editor.updateOptions({
+				ariaLabel: localize('chat.codeBlockLabel', "Code block {0}", data.codeBlockIndex + 1),
+			});
+		}
 		this.layout(width);
 		this.toolbar.setAriaLabel(localize('chat.codeBlockToolbarLabel', "Code block {0}", data.codeBlockIndex + 1));
 		if (data.renderOptions?.hideToolbar) {


### PR DESCRIPTION
fix #249279

Before:

https://github.com/user-attachments/assets/502094dd-6d83-4c65-b080-b885993f0868

https://github.com/user-attachments/assets/186c8d81-92b0-48bc-9ab4-fc58bbf030f1

After:

https://github.com/user-attachments/assets/f26a2aa5-363d-4e96-973a-1671ed4f0502

https://github.com/user-attachments/assets/24e36647-263b-45ce-ab9a-650f9e9b3e4c

