### PR TITLE
feat: offer to move into Applications folder on macOS

### DIFF
--- a/src/vs/platform/environment/common/argv.ts
+++ b/src/vs/platform/environment/common/argv.ts
@@ -125,6 +125,7 @@ export interface NativeParsedArgs {
 	'unresponsive-sample-interval'?: string;
 	'unresponsive-sample-period'?: string;
 	'enable-rdp-display-tracking'?: boolean;
+	'disable-app-install-dir-detection'?: boolean;
 
 	// chromium command line args: https://electronjs.org/docs/all#supported-chrome-command-line-switches
 	'no-proxy-server'?: boolean;

--- a/src/vs/platform/environment/electron-main/environmentMainService.ts
+++ b/src/vs/platform/environment/electron-main/environmentMainService.ts
@@ -36,6 +36,8 @@ export interface IEnvironmentMainService extends INativeEnvironmentService {
 	// TODO@deepak1556 TODO@bpasero temporary until a real fix lands upstream
 	readonly enableRDPDisplayTracking: boolean;
 
+	readonly disableAppInstallDirDetection: boolean;
+
 	unsetSnapExportedVariables(): void;
 	restoreSnapExportedVariables(): void;
 }
@@ -67,6 +69,9 @@ export class EnvironmentMainService extends NativeEnvironmentService implements 
 
 	@memoize
 	get useCodeCache(): boolean { return !!this.codeCachePath; }
+
+	@memoize
+	get disableAppInstallDirDetection(): boolean { return !!this.args['disable-app-install-dir-detection']; }
 
 	unsetSnapExportedVariables() {
 		if (!isLinux) {

--- a/src/vs/platform/environment/node/argv.ts
+++ b/src/vs/platform/environment/node/argv.ts
@@ -186,6 +186,7 @@ export const OPTIONS: OptionDescriptions<Required<NativeParsedArgs>> = {
 	'unresponsive-sample-interval': { type: 'string' },
 	'unresponsive-sample-period': { type: 'string' },
 	'enable-rdp-display-tracking': { type: 'boolean' },
+	'disable-app-install-dir-detection': { type: 'boolean' },
 
 	// chromium flags
 	'no-proxy-server': { type: 'boolean' },

--- a/src/vs/platform/native/common/native.ts
+++ b/src/vs/platform/native/common/native.ts
@@ -197,6 +197,9 @@ export interface ICommonNativeHostService {
 	installShellCommand(): Promise<void>;
 	uninstallShellCommand(): Promise<void>;
 
+	// macOS application mover
+	moveToApplicationsFolder(): Promise<void>;
+
 	// Lifecycle
 	notifyReady(): Promise<void>;
 	relaunch(options?: { addArgs?: string[]; removeArgs?: string[] }): Promise<void>;

--- a/src/vs/workbench/electron-sandbox/window.ts
+++ b/src/vs/workbench/electron-sandbox/window.ts
@@ -680,6 +680,11 @@ export class NativeWindow extends BaseWindow {
 		// Touchbar menu (if enabled)
 		this.updateTouchbarMenu();
 
+		// macOS: move to Applications folder (if needed)
+		if (isMacintosh) {
+			this.nativeHostService.moveToApplicationsFolder();
+		}
+
 		// Smoke Test Driver
 		if (this.environmentService.enableSmokeTestDriver) {
 			registerWindowDriver(this.instantiationService);

--- a/src/vs/workbench/test/electron-sandbox/workbenchTestServices.ts
+++ b/src/vs/workbench/test/electron-sandbox/workbenchTestServices.ts
@@ -141,6 +141,7 @@ export class TestNativeHostService implements INativeHostService {
 	async toggleWindowTabsBar(): Promise<void> { }
 	async installShellCommand(): Promise<void> { }
 	async uninstallShellCommand(): Promise<void> { }
+	async moveToApplicationsFolder(): Promise<void> { }
 	async notifyReady(): Promise<void> { }
 	async relaunch(options?: { addArgs?: string[] | undefined; removeArgs?: string[] | undefined } | undefined): Promise<void> { }
 	async reload(): Promise<void> { }


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/213909

Detect when application on macOS is installed outside the Applications folder and offer choice to move. The detection will bail early under the following cases,

1) Application is launched from the cli (CI or perf environments). Additionally the relauncher on the runtime side cannot forward cli args so we should skip this case
2) Application is installed in portable mode

There are 3 cases this path should cover,

1) There are no versions of the app already present under the Applications folder

In this case, once user confirms the choice to move `app.moveToApplicationsFolder` will quit the current instance (which follows app.quit path in the runtime so all shutdown veto paths will be respected), copy the app to destination, trash the source app, wait for the application to exit and relaunch from the destination

2) There is an existing version of the app in the Applications folder but is not running `conflictType === exists`

In this case, once user confirms the choice to move `app.moveToApplicationsFolder` delete the version under Applications folder and follow the same order of steps as 1)

3) There is an existing version of the app in the Applications folder and is currently running `conflictType === existsAndRunning`

In this case, due to our singleton logic any new instance sharing the same user-data-dir will merge to the running instance and hence no action is needed. When using different user-data-dir the launch would happen from cli in which case the detection will bail early as mentioned before.

**Question:**

1) Do we need a setting for explicit opt-out in case there are cases we haven't covered ?