### PR TITLE
mcp: initial wiring for resources

### DIFF
--- a/src/vs/base/common/iterator.ts
+++ b/src/vs/base/common/iterator.ts
@@ -171,6 +171,14 @@ export namespace Iterable {
 		for await (const item of iterable) {
 			result.push(item);
 		}
-		return Promise.resolve(result);
+		return result;
+	}
+
+	export async function asyncToArrayFlat<T>(iterable: AsyncIterable<T[]>): Promise<T[]> {
+		let result: T[] = [];
+		for await (const item of iterable) {
+			result = result.concat(item);
+		}
+		return result;
 	}
 }

--- a/src/vs/workbench/contrib/mcp/browser/mcp.contribution.ts
+++ b/src/vs/workbench/contrib/mcp/browser/mcp.contribution.ts
@@ -28,6 +28,7 @@ import { McpContextKeysController } from '../common/mcpContextKeys.js';
 import { IMcpDevModeDebugging, McpDevModeDebugging } from '../common/mcpDevMode.js';
 import { McpRegistry } from '../common/mcpRegistry.js';
 import { IMcpRegistry } from '../common/mcpRegistryTypes.js';
+import { McpResourceFilesystem } from '../common/mcpResourceFilesystem.js';
 import { McpService } from '../common/mcpService.js';
 import { HasInstalledMcpServersContext, IMcpService, IMcpWorkbenchService, InstalledMcpServersViewId, McpServersGalleryEnabledContext } from '../common/mcpTypes.js';
 import { AddConfigurationAction, EditStoredInput, InstallFromActivation, ListMcpServerCommand, McpBrowseCommand, MCPServerActionRendering, McpServerOptionsCommand, RemoveStoredInput, ResetMcpCachedTools, ResetMcpTrustCommand, RestartServer, ShowConfiguration, ShowOutput, StartServer, StopServer } from './mcpCommands.js';
@@ -45,7 +46,6 @@ registerSingleton(IMcpWorkbenchService, McpWorkbenchService, InstantiationType.E
 registerSingleton(IMcpConfigPathsService, McpConfigPathsService, InstantiationType.Delayed);
 registerSingleton(IMcpDevModeDebugging, McpDevModeDebugging, InstantiationType.Delayed);
 
-
 mcpDiscoveryRegistry.register(new SyncDescriptor(RemoteNativeMpcDiscovery));
 mcpDiscoveryRegistry.register(new SyncDescriptor(ConfigMcpDiscovery));
 mcpDiscoveryRegistry.register(new SyncDescriptor(ExtensionMcpDiscovery));
@@ -55,6 +55,7 @@ registerWorkbenchContribution2('mcpDiscovery', McpDiscovery, WorkbenchPhase.Afte
 registerWorkbenchContribution2('mcpContextKeys', McpContextKeysController, WorkbenchPhase.BlockRestore);
 registerWorkbenchContribution2('mcpLanguageFeatures', McpLanguageFeatures, WorkbenchPhase.Eventually);
 registerWorkbenchContribution2('mcpUrlHandler', McpUrlHandler, WorkbenchPhase.BlockRestore);
+registerWorkbenchContribution2('mcpResourceFilesystem', McpResourceFilesystem, WorkbenchPhase.BlockRestore);
 
 registerAction2(ListMcpServerCommand);
 registerAction2(McpServerOptionsCommand);

--- a/src/vs/workbench/contrib/mcp/common/mcpResourceFilesystem.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpResourceFilesystem.ts
@@ -1,0 +1,250 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { sumBy } from '../../../../base/common/arrays.js';
+import { decodeBase64, VSBuffer } from '../../../../base/common/buffer.js';
+import { CancellationToken, CancellationTokenSource } from '../../../../base/common/cancellation.js';
+import { Emitter, Event } from '../../../../base/common/event.js';
+import { Lazy } from '../../../../base/common/lazy.js';
+import { Disposable, DisposableStore, IDisposable, MutableDisposable } from '../../../../base/common/lifecycle.js';
+import { autorun } from '../../../../base/common/observable.js';
+import { newWriteableStream, ReadableStreamEvents } from '../../../../base/common/stream.js';
+import { equalsIgnoreCase } from '../../../../base/common/strings.js';
+import { URI } from '../../../../base/common/uri.js';
+import { createFileSystemProviderError, FileChangeType, FileSystemProviderCapabilities, FileSystemProviderErrorCode, FileType, IFileChange, IFileDeleteOptions, IFileOverwriteOptions, IFileReadStreamOptions, IFileService, IFileSystemProviderWithFileAtomicReadCapability, IFileSystemProviderWithFileReadStreamCapability, IFileSystemProviderWithFileReadWriteCapability, IFileWriteOptions, IStat, IWatchOptions } from '../../../../platform/files/common/files.js';
+import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
+import { IWorkbenchContribution } from '../../../common/contributions.js';
+import { McpServer } from './mcpServer.js';
+import { McpServerRequestHandler } from './mcpServerRequestHandler.js';
+import { IMcpService, McpResourceURI } from './mcpTypes.js';
+import { MCP } from './modelContextProtocol.js';
+
+export class McpResourceFilesystem extends Disposable implements IWorkbenchContribution,
+	IFileSystemProviderWithFileReadWriteCapability,
+	IFileSystemProviderWithFileAtomicReadCapability,
+	IFileSystemProviderWithFileReadStreamCapability {
+	/** Defer getting the MCP service since this is a BlockRestore and no need to make it unnecessarily. */
+	private readonly _mcpServiceLazy = new Lazy(() => this._instantiationService.invokeFunction(a => a.get(IMcpService)));
+
+	private get _mcpService() {
+		return this._mcpServiceLazy.value;
+	}
+
+	public readonly onDidChangeCapabilities = Event.None;
+
+	private readonly _onDidChangeFile = this._register(new Emitter<readonly IFileChange[]>());
+	public readonly onDidChangeFile = this._onDidChangeFile.event;
+
+	public readonly capabilities: FileSystemProviderCapabilities = FileSystemProviderCapabilities.None
+		| FileSystemProviderCapabilities.Readonly
+		| FileSystemProviderCapabilities.PathCaseSensitive
+		| FileSystemProviderCapabilities.FileReadStream
+		| FileSystemProviderCapabilities.FileAtomicRead;
+
+	constructor(
+		@IInstantiationService private readonly _instantiationService: IInstantiationService,
+		@IFileService private readonly _fileService: IFileService,
+	) {
+		super();
+		this._register(this._fileService.registerProvider(McpResourceURI.scheme, this));
+	}
+
+	//#region Filesystem API
+
+	public async readFile(resource: URI): Promise<Uint8Array> {
+		return this._readFile(resource);
+	}
+
+	public readFileStream(resource: URI, opts: IFileReadStreamOptions, token: CancellationToken): ReadableStreamEvents<Uint8Array> {
+		const stream = newWriteableStream<Uint8Array>(data => VSBuffer.concat(data.map(data => VSBuffer.wrap(data))).buffer);
+
+		this._readFile(resource, token).then(
+			data => {
+				if (opts.position) {
+					data = data.slice(opts.position);
+				}
+
+				if (opts.length) {
+					data = data.slice(0, opts.length);
+				}
+
+				stream.end(data);
+			},
+			err => stream.error(err),
+		);
+
+		return stream;
+	}
+
+	public watch(uri: URI, _opts: IWatchOptions): IDisposable {
+		const { resourceURI, server } = this._decodeURI(uri);
+
+		server.start();
+
+		const store = new DisposableStore();
+		let watchedOnHandler: McpServerRequestHandler | undefined;
+		const watchListener = store.add(new MutableDisposable());
+		const callCts = store.add(new MutableDisposable<CancellationTokenSource>());
+		store.add(autorun(reader => {
+			const connection = server.connection.read(reader);
+			if (!connection) {
+				return;
+			}
+
+			const handler = connection.handler.read(reader);
+			if (!handler || watchedOnHandler === handler) {
+				return;
+			}
+
+			callCts.value?.dispose(true);
+			callCts.value = new CancellationTokenSource();
+			watchedOnHandler = handler;
+
+			const token = callCts.value.token;
+			handler.subscribe({ uri: resourceURI.toString(true) }, token).then(
+				() => {
+					if (!token.isCancellationRequested) {
+						watchListener.value = handler.onDidUpdateResource(e => {
+							if (equalsUriPath(e.params.uri, resourceURI)) {
+								this._onDidChangeFile.fire([{ resource: uri, type: FileChangeType.UPDATED }]);
+							}
+						});
+					}
+				}, err => {
+					handler.logger.warn(`Failed to subscribe to resource changes for ${resourceURI}: ${err}`);
+					watchedOnHandler = undefined;
+				},
+			);
+		}));
+
+		return store;
+	}
+
+	public async stat(resource: URI): Promise<IStat> {
+		const { forSameURI, contents } = await this._readURI(resource);
+		if (!contents.length) {
+			throw createFileSystemProviderError(`File not found`, FileSystemProviderErrorCode.FileNotFound);
+		}
+
+		return {
+			ctime: 0,
+			mtime: 0,
+			size: sumBy(contents, c => contentToBuffer(c).byteLength),
+			type: forSameURI.length ? FileType.File : FileType.Directory,
+		};
+	}
+
+	public async readdir(resource: URI): Promise<[string, FileType][]> {
+		const { forSameURI, contents, resourceURI } = await this._readURI(resource);
+		if (forSameURI.length > 0) {
+			throw createFileSystemProviderError(`File is not a directory`, FileSystemProviderErrorCode.FileNotADirectory);
+		}
+
+		const resourcePathParts = resourceURI.path.split('/');
+
+		const output = new Map<string, FileType>();
+		for (const content of contents) {
+			const contentURI = URI.parse(content.uri);
+			const contentPathParts = contentURI.path.split('/');
+
+			// Skip contents that are not in the same directory
+			if (contentPathParts.length <= resourcePathParts.length || !resourcePathParts.every((part, index) => equalsIgnoreCase(part, contentPathParts[index]))) {
+				continue;
+			}
+
+			// nested resource in a directory, just emit a directory to output
+			else if (contentPathParts.length > resourcePathParts.length + 1) {
+				output.set(contentPathParts[resourcePathParts.length], FileType.Directory);
+			}
+
+			else {
+				// resource in the same directory, emit the file
+				const name = contentPathParts[contentPathParts.length - 1];
+				output.set(name, contentToBuffer(content).byteLength > 0 ? FileType.File : FileType.Directory);
+			}
+		}
+
+		return [...output];
+	}
+
+	public mkdir(resource: URI): Promise<void> {
+		throw createFileSystemProviderError('write is not supported', FileSystemProviderErrorCode.NoPermissions);
+	}
+	public writeFile(resource: URI, content: Uint8Array, opts: IFileWriteOptions): Promise<void> {
+		throw createFileSystemProviderError('write is not supported', FileSystemProviderErrorCode.NoPermissions);
+	}
+	public delete(resource: URI, opts: IFileDeleteOptions): Promise<void> {
+		throw createFileSystemProviderError('delete is not supported', FileSystemProviderErrorCode.NoPermissions);
+	}
+	public rename(from: URI, to: URI, opts: IFileOverwriteOptions): Promise<void> {
+		throw createFileSystemProviderError('rename is not supported', FileSystemProviderErrorCode.NoPermissions);
+	}
+
+	//#endregion
+
+	private async _readFile(resource: URI, token?: CancellationToken): Promise<Uint8Array> {
+		const { forSameURI, contents } = await this._readURI(resource);
+
+		// MCP does not distinguish between files and directories, and says that
+		// servers should just return multiple when 'reading' a directory.
+		if (!forSameURI.length) {
+			if (!contents.length) {
+				throw createFileSystemProviderError(`File not found`, FileSystemProviderErrorCode.FileNotFound);
+			} else {
+				throw createFileSystemProviderError(`File is a directory`, FileSystemProviderErrorCode.FileIsADirectory);
+			}
+		}
+
+		return contentToBuffer(forSameURI[0]);
+	}
+
+	private _decodeURI(uri: URI) {
+		let definitionId: string;
+		let resourceURI: URI;
+		try {
+			({ definitionId, resourceURI } = McpResourceURI.toServer(uri));
+		} catch (e) {
+			throw createFileSystemProviderError(String(e), FileSystemProviderErrorCode.FileNotFound);
+		}
+
+		if (resourceURI.path.endsWith('/')) {
+			resourceURI = resourceURI.with({ path: resourceURI.path.slice(0, -1) });
+		}
+
+		const server = this._mcpService.servers.get().find(s => s.definition.id === definitionId);
+		if (!server) {
+			throw createFileSystemProviderError(`MCP server with definition ID ${definitionId} not found`, FileSystemProviderErrorCode.FileNotFound);
+		}
+
+		return { definitionId, resourceURI, server };
+	}
+
+	private async _readURI(uri: URI, token?: CancellationToken) {
+		const { resourceURI, server } = this._decodeURI(uri);
+		const res = await McpServer.callOn(server, r => r.readResource({ uri: resourceURI.toString(true) }, token), token);
+
+		return {
+			contents: res.contents,
+			resourceURI,
+			forSameURI: res.contents.filter(c => equalsUriPath(c.uri, resourceURI)),
+		};
+	}
+}
+
+function equalsUriPath(a: string, b: URI): boolean {
+	// MCP doesn't specify either way, but underlying systems may can be case-sensitive.
+	// It's better to treat case-sensitive paths as case-insensitive than vise-versa.
+	return equalsIgnoreCase(URI.parse(a).path, b.path);
+}
+
+function contentToBuffer(content: MCP.TextResourceContents | MCP.BlobResourceContents): Uint8Array {
+	if ('text' in content) {
+		return VSBuffer.fromString(content.text).buffer;
+	} else if ('blob' in content) {
+		return decodeBase64(content.blob).buffer;
+	} else {
+		throw createFileSystemProviderError('Unknown content type', FileSystemProviderErrorCode.Unknown);
+	}
+}

--- a/src/vs/workbench/contrib/mcp/common/mcpService.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpService.ts
@@ -52,7 +52,7 @@ export class McpService extends Disposable implements IMcpService {
 		this.userCache = this._register(_instantiationService.createInstance(McpServerMetadataCache, StorageScope.PROFILE));
 		this.workspaceCache = this._register(_instantiationService.createInstance(McpServerMetadataCache, StorageScope.WORKSPACE));
 
-		const updateThrottle = this._store.add(new RunOnceScheduler(() => this._updateCollectedServers(), 500));
+		const updateThrottle = this._store.add(new RunOnceScheduler(() => this.updateCollectedServers(), 500));
 
 		// Throttle changes so that if a collection is changed, or a server is
 		// unregistered/registered, we don't stop servers unnecessarily.
@@ -73,7 +73,7 @@ export class McpService extends Disposable implements IMcpService {
 		const collections = await this._mcpRegistry.discoverCollections();
 		const collectionIds = new Set(collections.map(c => c.id));
 
-		this._updateCollectedServers();
+		this.updateCollectedServers();
 
 		// Discover any newly-collected servers with unknown tools
 		const todo: Promise<unknown>[] = [];
@@ -150,7 +150,7 @@ export class McpService extends Disposable implements IMcpService {
 		}));
 	}
 
-	private _updateCollectedServers() {
+	public updateCollectedServers() {
 		const definitions = this._mcpRegistry.collections.get().flatMap(collectionDefinition =>
 			collectionDefinition.serverDefinitions.get().map(serverDefinition => ({
 				serverDefinition,

--- a/src/vs/workbench/contrib/mcp/test/common/mcpRegistryTypes.ts
+++ b/src/vs/workbench/contrib/mcp/test/common/mcpRegistryTypes.ts
@@ -81,7 +81,7 @@ export class TestMcpMessageTransport extends Disposable implements IMcpMessageTr
 			if (responder) {
 				const response = responder(message);
 				if (response) {
-					setImmediate(() => this.simulateReceiveMessage(response));
+					setTimeout(() => this.simulateReceiveMessage(response));
 				}
 			}
 		}

--- a/src/vs/workbench/contrib/mcp/test/common/mcpRegistryTypes.ts
+++ b/src/vs/workbench/contrib/mcp/test/common/mcpRegistryTypes.ts
@@ -3,12 +3,18 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Emitter } from '../../../../../base/common/event.js';
-import { Disposable } from '../../../../../base/common/lifecycle.js';
-import { observableValue } from '../../../../../base/common/observable.js';
-import { LogLevel } from '../../../../../platform/log/common/log.js';
-import { IMcpMessageTransport } from '../../common/mcpRegistryTypes.js';
-import { McpConnectionState } from '../../common/mcpTypes.js';
+import { Emitter, Event } from '../../../../../base/common/event.js';
+import { Disposable, IDisposable } from '../../../../../base/common/lifecycle.js';
+import { IObservable, observableValue } from '../../../../../base/common/observable.js';
+import { ConfigurationTarget } from '../../../../../platform/configuration/common/configuration.js';
+import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
+import { LogLevel, NullLogger } from '../../../../../platform/log/common/log.js';
+import { StorageScope } from '../../../../../platform/storage/common/storage.js';
+import { IWorkspaceFolderData } from '../../../../../platform/workspace/common/workspace.js';
+import { IResolvedValue } from '../../../../services/configurationResolver/common/configurationResolverExpression.js';
+import { IMcpHostDelegate, IMcpMessageTransport, IMcpRegistry, IMcpResolveConnectionOptions } from '../../common/mcpRegistryTypes.js';
+import { McpServerConnection } from '../../common/mcpServerConnection.js';
+import { IMcpServerConnection, LazyCollectionState, McpCollectionDefinition, McpCollectionReference, McpConnectionState, McpDefinitionReference, McpServerDefinition, McpServerTransportType } from '../../common/mcpTypes.js';
 import { MCP } from '../../common/modelContextProtocol.js';
 
 /**
@@ -29,13 +35,56 @@ export class TestMcpMessageTransport extends Disposable implements IMcpMessageTr
 
 	constructor() {
 		super();
+
+		this.setResponder('initialize', () => ({
+			jsonrpc: MCP.JSONRPC_VERSION,
+			id: 1, // The handler uses 1 for the first request
+			result: {
+				protocolVersion: MCP.LATEST_PROTOCOL_VERSION,
+				serverInfo: {
+					name: 'Test MCP Server',
+					version: '1.0.0',
+				},
+				capabilities: {
+					resources: {
+						supportedTypes: ['text/plain'],
+					},
+					tools: {
+						supportsCancellation: true,
+					}
+				}
+			}
+		}));
 	}
+
+	/**
+	 * Set a responder function for a specific method.
+	 * The responder receives the sent message and should return a response object,
+	 * which will be simulated as a server response.
+	 */
+	public setResponder(method: string, responder: (message: any) => MCP.JSONRPCMessage | undefined): void {
+		if (!this._responders) {
+			this._responders = new Map();
+		}
+		this._responders.set(method, responder);
+	}
+
+	private _responders?: Map<string, (message: MCP.JSONRPCMessage) => MCP.JSONRPCMessage | undefined>;
 
 	/**
 	 * Send a message through the transport.
 	 */
 	public send(message: MCP.JSONRPCMessage): void {
 		this._sentMessages.push(message);
+		if (this._responders && 'method' in message && typeof message.method === 'string') {
+			const responder = this._responders.get(message.method);
+			if (responder) {
+				const response = responder(message);
+				if (response) {
+					setImmediate(() => this.simulateReceiveMessage(response));
+				}
+			}
+		}
 	}
 
 	/**
@@ -104,5 +153,90 @@ export class TestMcpMessageTransport extends Disposable implements IMcpMessageTr
 	 */
 	public clearSentMessages(): void {
 		this._sentMessages.length = 0;
+	}
+}
+
+export class TestMcpRegistry implements IMcpRegistry {
+	public makeTestTransport = () => new TestMcpMessageTransport();
+
+	constructor(@IInstantiationService private readonly _instantiationService: IInstantiationService) { }
+
+	_serviceBrand: undefined;
+	onDidChangeInputs = Event.None;
+	collections = observableValue<readonly McpCollectionDefinition[]>(this, [{
+		id: 'test-collection',
+		remoteAuthority: null,
+		label: 'Test Collection',
+		serverDefinitions: observableValue(this, [{
+			id: 'test-server',
+			label: 'Test Server',
+			launch: { type: McpServerTransportType.Stdio, command: 'echo', args: ['Hello MCP'], env: {}, envFile: undefined, cwd: undefined },
+		} satisfies McpServerDefinition]),
+		isTrustedByDefault: true,
+		scope: StorageScope.APPLICATION,
+	}]);
+	delegates = observableValue<readonly IMcpHostDelegate[]>(this, [{
+		priority: 0,
+		canStart: () => true,
+		start: () => {
+			const t = this.makeTestTransport();
+			setTimeout(() => t.setConnectionState({ state: McpConnectionState.Kind.Running }));
+			return t;
+		},
+		waitForInitialProviderPromises: () => Promise.resolve(),
+	}]);
+	lazyCollectionState = observableValue<LazyCollectionState>(this, LazyCollectionState.AllKnown);
+	collectionToolPrefix(collection: McpCollectionReference): IObservable<string> {
+		return observableValue<string>(this, `mcp-${collection.id}-`);
+	}
+	getServerDefinition(collectionRef: McpDefinitionReference, definitionRef: McpDefinitionReference): IObservable<{ server: McpServerDefinition | undefined; collection: McpCollectionDefinition | undefined }> {
+		const collectionObs = this.collections.map(cols => cols.find(c => c.id === collectionRef.id));
+		return collectionObs.map((collection, reader) => {
+			const server = collection?.serverDefinitions.read(reader).find(s => s.id === definitionRef.id);
+			return { collection, server };
+		});
+	}
+	discoverCollections(): Promise<McpCollectionDefinition[]> {
+		throw new Error('Method not implemented.');
+	}
+	registerDelegate(delegate: IMcpHostDelegate): IDisposable {
+		throw new Error('Method not implemented.');
+	}
+	registerCollection(collection: McpCollectionDefinition): IDisposable {
+		throw new Error('Method not implemented.');
+	}
+	resetTrust(): void {
+		throw new Error('Method not implemented.');
+	}
+	getTrust(collection: McpCollectionReference): IObservable<boolean | undefined> {
+		throw new Error('Method not implemented.');
+	}
+	clearSavedInputs(scope: StorageScope, inputId?: string): Promise<void> {
+		throw new Error('Method not implemented.');
+	}
+	editSavedInput(inputId: string, folderData: IWorkspaceFolderData | undefined, configSection: string, target: ConfigurationTarget): Promise<void> {
+		throw new Error('Method not implemented.');
+	}
+	setSavedInput(inputId: string, target: ConfigurationTarget, value: string): Promise<void> {
+		throw new Error('Method not implemented.');
+	}
+	getSavedInputs(scope: StorageScope): Promise<{ [id: string]: IResolvedValue }> {
+		throw new Error('Method not implemented.');
+	}
+	resolveConnection(options: IMcpResolveConnectionOptions): Promise<IMcpServerConnection | undefined> {
+		const collection = this.collections.get().find(c => c.id === options.collectionRef.id);
+		const definition = collection?.serverDefinitions.get().find(d => d.id === options.definitionRef.id);
+		if (!collection || !definition) {
+			throw new Error(`Collection or definition not found: ${options.collectionRef.id}, ${options.definitionRef.id}`);
+		}
+		const del = this.delegates.get()[0];
+		return Promise.resolve(new McpServerConnection(
+			collection,
+			definition,
+			del,
+			definition.launch,
+			new NullLogger(),
+			this._instantiationService,
+		));
 	}
 }

--- a/src/vs/workbench/contrib/mcp/test/common/mcpResourceFilesystem.test.ts
+++ b/src/vs/workbench/contrib/mcp/test/common/mcpResourceFilesystem.test.ts
@@ -1,0 +1,281 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { Disposable } from '../../../../../base/common/lifecycle.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { FileChangeType, FileSystemProviderErrorCode, FileType, IFileChange, IFileService } from '../../../../../platform/files/common/files.js';
+import { ServiceCollection } from '../../../../../platform/instantiation/common/serviceCollection.js';
+import { TestInstantiationService } from '../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
+import { ILoggerService, NullLogService } from '../../../../../platform/log/common/log.js';
+import { IStorageService } from '../../../../../platform/storage/common/storage.js';
+import { ITelemetryService } from '../../../../../platform/telemetry/common/telemetry.js';
+import { NullTelemetryService } from '../../../../../platform/telemetry/common/telemetryUtils.js';
+import { IWorkspaceContextService } from '../../../../../platform/workspace/common/workspace.js';
+import { TestContextService, TestLoggerService, TestProductService, TestStorageService } from '../../../../test/common/workbenchTestServices.js';
+import { IMcpRegistry } from '../../common/mcpRegistryTypes.js';
+import { McpResourceFilesystem } from '../../common/mcpResourceFilesystem.js';
+import { McpService } from '../../common/mcpService.js';
+import { IMcpService } from '../../common/mcpTypes.js';
+import { MCP } from '../../common/modelContextProtocol.js';
+import { TestMcpMessageTransport, TestMcpRegistry } from './mcpRegistryTypes.js';
+import { IProductService } from '../../../../../platform/product/common/productService.js';
+import { Barrier, timeout } from '../../../../../base/common/async.js';
+
+
+suite('Workbench - MCP - ResourceFilesystem', () => {
+
+	const ds = ensureNoDisposablesAreLeakedInTestSuite();
+
+	let transport: TestMcpMessageTransport;
+	let fs: McpResourceFilesystem;
+
+	setup(() => {
+		const services = new ServiceCollection(
+			[IFileService, { registerProvider: () => { } }],
+			[IStorageService, ds.add(new TestStorageService())],
+			[ILoggerService, ds.add(new TestLoggerService())],
+			[IWorkspaceContextService, new TestContextService()],
+			[ITelemetryService, NullTelemetryService],
+			[IProductService, TestProductService],
+		);
+
+		const parentInsta1 = ds.add(new TestInstantiationService(services));
+		const registry = new TestMcpRegistry(parentInsta1);
+
+		const parentInsta2 = ds.add(parentInsta1.createChild(new ServiceCollection([IMcpRegistry, registry])));
+		const mcpService = ds.add(new McpService(parentInsta2, registry, { registerToolData: () => Disposable.None, registerToolImplementation: () => Disposable.None } as any, new NullLogService()));
+		mcpService.updateCollectedServers();
+
+		const instaService = ds.add(parentInsta2.createChild(new ServiceCollection(
+			[IMcpRegistry, registry],
+			[IMcpService, mcpService],
+		)));
+
+		fs = ds.add(instaService.createInstance(McpResourceFilesystem));
+
+		transport = ds.add(new TestMcpMessageTransport());
+		registry.makeTestTransport = () => transport;
+	});
+
+	test('reads a basic file', async () => {
+		transport.setResponder('resources/read', msg => {
+			assert.strictEqual(msg.params.uri, 'custom://hello/world.txt');
+			return {
+				id: msg.id,
+				jsonrpc: '2.0',
+				result: {
+					contents: [{ uri: msg.params.uri, text: 'Hello World' }],
+				} satisfies MCP.ReadResourceResult
+			};
+		});
+
+		const response = await fs.readFile(URI.parse('mcp-resource://dGVzdC1zZXJ2ZXI/custom/hello/world.txt'));
+		assert.strictEqual(new TextDecoder().decode(response), 'Hello World');
+	});
+
+	test('stat returns file information', async () => {
+		transport.setResponder('resources/read', msg => {
+			assert.strictEqual(msg.params.uri, 'custom://hello/world.txt');
+			return {
+				id: msg.id,
+				jsonrpc: '2.0',
+				result: {
+					contents: [{ uri: msg.params.uri, text: 'Hello World' }],
+				} satisfies MCP.ReadResourceResult
+			};
+		});
+
+		const fileStats = await fs.stat(URI.parse('mcp-resource://dGVzdC1zZXJ2ZXI/custom/hello/world.txt'));
+		assert.strictEqual(fileStats.type, FileType.File);
+		assert.strictEqual(fileStats.size, 'Hello World'.length);
+	});
+
+	test('stat returns directory information', async () => {
+		transport.setResponder('resources/read', msg => {
+			assert.strictEqual(msg.params.uri, 'custom://hello');
+			return {
+				id: msg.id,
+				jsonrpc: '2.0',
+				result: {
+					contents: [
+						{ uri: 'custom://hello/file1.txt', text: 'File 1' },
+						{ uri: 'custom://hello/file2.txt', text: 'File 2' },
+					],
+				} satisfies MCP.ReadResourceResult
+			};
+		});
+
+		const dirStats = await fs.stat(URI.parse('mcp-resource://dGVzdC1zZXJ2ZXI/custom/hello/'));
+		assert.strictEqual(dirStats.type, FileType.Directory);
+		// Size should be sum of all file contents in the directory
+		assert.strictEqual(dirStats.size, 'File 1'.length + 'File 2'.length);
+	});
+
+	test('stat throws FileNotFound for nonexistent resources', async () => {
+		transport.setResponder('resources/read', msg => {
+			return {
+				id: msg.id,
+				jsonrpc: '2.0',
+				result: {
+					contents: [],
+				} satisfies MCP.ReadResourceResult
+			};
+		});
+
+		await assert.rejects(
+			() => fs.stat(URI.parse('mcp-resource://dGVzdC1zZXJ2ZXI/custom/nonexistent.txt')),
+			(err: any) => err.code === FileSystemProviderErrorCode.FileNotFound
+		);
+	});
+
+	test('readdir returns directory contents', async () => {
+		transport.setResponder('resources/read', msg => {
+			assert.strictEqual(msg.params.uri, 'custom://hello/dir');
+			return {
+				id: msg.id,
+				jsonrpc: '2.0',
+				result: {
+					contents: [
+						{ uri: 'custom://hello/dir/file1.txt', text: 'File 1' },
+						{ uri: 'custom://hello/dir/file2.txt', text: 'File 2' },
+						{ uri: 'custom://hello/dir/subdir/file3.txt', text: 'File 3' },
+					],
+				} satisfies MCP.ReadResourceResult
+			};
+		});
+
+		const dirEntries = await fs.readdir(URI.parse('mcp-resource://dGVzdC1zZXJ2ZXI/custom/hello/dir/'));
+		assert.deepStrictEqual(dirEntries, [
+			['file1.txt', FileType.File],
+			['file2.txt', FileType.File],
+			['subdir', FileType.Directory],
+		]);
+	});
+
+	test('readdir throws when reading a file as directory', async () => {
+		transport.setResponder('resources/read', msg => {
+			return {
+				id: msg.id,
+				jsonrpc: '2.0',
+				result: {
+					contents: [{ uri: msg.params.uri, text: 'This is a file' }],
+				} satisfies MCP.ReadResourceResult
+			};
+		});
+
+		await assert.rejects(
+			() => fs.readdir(URI.parse('mcp-resource://dGVzdC1zZXJ2ZXI/custom/hello/file.txt')),
+			(err: any) => err.code === FileSystemProviderErrorCode.FileNotADirectory
+		);
+	});
+
+	test('watch file emits change events', async () => {
+		// Set up the responder for resource reading
+		transport.setResponder('resources/read', msg => {
+			return {
+				id: msg.id,
+				jsonrpc: '2.0',
+				result: {
+					contents: [{ uri: msg.params.uri, text: 'File content' }],
+				} satisfies MCP.ReadResourceResult
+			};
+		});
+
+		const didSubscribe = new Barrier();
+
+		// Set up the responder for resource subscription
+		transport.setResponder('resources/subscribe', msg => {
+			didSubscribe.open();
+			return {
+				id: msg.id,
+				jsonrpc: '2.0',
+				result: {},
+			};
+		});
+
+		const uri = URI.parse('mcp-resource://dGVzdC1zZXJ2ZXI/custom/hello/file.txt');
+		const fileChanges: IFileChange[] = [];
+
+		// Create a listener for file change events
+		const disposable = fs.onDidChangeFile(events => {
+			fileChanges.push(...events);
+		});
+
+		// Start watching the file
+		const watchDisposable = fs.watch(uri, { excludes: [], recursive: false });
+
+		// Simulate a file update notification from the server
+		await didSubscribe.wait();
+		await timeout(10); // wait for listeners to attach
+
+		transport.simulateReceiveMessage({
+			jsonrpc: '2.0',
+			method: 'notifications/resources/updated',
+			params: {
+				uri: 'custom://hello/file.txt',
+			},
+		});
+		transport.simulateReceiveMessage({
+			jsonrpc: '2.0',
+			method: 'notifications/resources/updated',
+			params: {
+				uri: 'custom://hello/unrelated.txt',
+			},
+		});
+
+		// Check that we received a file change event
+		assert.strictEqual(fileChanges.length, 1);
+		assert.strictEqual(fileChanges[0].type, FileChangeType.UPDATED);
+		assert.strictEqual(fileChanges[0].resource.toString(), uri.toString());
+
+		// Clean up
+		disposable.dispose();
+		watchDisposable.dispose();
+	});
+
+	test('read blob resource', async () => {
+		const blobBase64 = 'SGVsbG8gV29ybGQgYXMgQmxvYg=='; // "Hello World as Blob" in base64
+
+		transport.setResponder('resources/read', msg => {
+			assert.strictEqual(msg.params.uri, 'custom://hello/blob.bin');
+			return {
+				id: msg.id,
+				jsonrpc: '2.0',
+				result: {
+					contents: [{ uri: msg.params.uri, blob: blobBase64 }],
+				} satisfies MCP.ReadResourceResult
+			};
+		});
+
+		const response = await fs.readFile(URI.parse('mcp-resource://dGVzdC1zZXJ2ZXI/custom/hello/blob.bin'));
+		assert.strictEqual(new TextDecoder().decode(response), 'Hello World as Blob');
+	});
+
+	test('throws error for write operations', async () => {
+		const uri = URI.parse('mcp-resource://dGVzdC1zZXJ2ZXI/custom/hello/file.txt');
+
+		await assert.rejects(
+			async () => fs.writeFile(uri, new Uint8Array(), { create: true, overwrite: true, atomic: false, unlock: false }),
+			(err: any) => err.code === FileSystemProviderErrorCode.NoPermissions
+		);
+
+		await assert.rejects(
+			async () => fs.delete(uri, { recursive: false, useTrash: false, atomic: false }),
+			(err: any) => err.code === FileSystemProviderErrorCode.NoPermissions
+		);
+
+		await assert.rejects(
+			async () => fs.mkdir(uri),
+			(err: any) => err.code === FileSystemProviderErrorCode.NoPermissions
+		);
+
+		await assert.rejects(
+			async () => fs.rename(uri, URI.parse('mcp-resource://dGVzdC1zZXJ2ZXI/custom/hello/newfile.txt'), { overwrite: false }),
+			(err: any) => err.code === FileSystemProviderErrorCode.NoPermissions
+		);
+	});
+});

--- a/src/vs/workbench/contrib/mcp/test/common/mcpServerRequestHandler.test.ts
+++ b/src/vs/workbench/contrib/mcp/test/common/mcpServerRequestHandler.test.ts
@@ -81,28 +81,6 @@ suite('Workbench - MCP - ServerRequestHandler', () => {
 		// Start the handler creation
 		const handlerPromise = McpServerRequestHandler.create(instantiationService, transport, logger, undefined, cts.token);
 
-		// Simulate successful initialization
-		// We need to respond to the initialize request that the handler will make
-		transport.simulateReceiveMessage({
-			jsonrpc: MCP.JSONRPC_VERSION,
-			id: 1, // The handler uses 1 for the first request
-			result: {
-				protocolVersion: MCP.LATEST_PROTOCOL_VERSION,
-				serverInfo: {
-					name: 'Test MCP Server',
-					version: '1.0.0',
-				},
-				capabilities: {
-					resources: {
-						supportedTypes: ['text/plain'],
-					},
-					tools: {
-						supportsCancellation: true,
-					}
-				}
-			}
-		});
-
 		handler = await handlerPromise;
 		store.add(handler);
 	});


### PR DESCRIPTION
- MCP resources are scoped under the `mcp-resource` scheme to a specific server.
- Implements a fileystem provider for `mcp-resource` and commands to list
  MCP resources on the server.
- Supports attaching MCP resources to requests when received from prompts.

Refs #244159

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
