### PR TITLE
Moves getPositionOffsetTransformerFromTextModel into its own file

### DIFF
--- a/src/vs/editor/common/core/text/getPositionOffsetTransformerFromTextModel.ts
+++ b/src/vs/editor/common/core/text/getPositionOffsetTransformerFromTextModel.ts
@@ -1,0 +1,26 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { ITextModel } from '../../model.js';
+import { Position } from '../position.js';
+import { PositionOffsetTransformerBase } from './positionToOffset.js';
+
+export function getPositionOffsetTransformerFromTextModel(textModel: ITextModel): PositionOffsetTransformerBase {
+	return new PositionOffsetTransformerWithTextModel(textModel);
+}
+
+class PositionOffsetTransformerWithTextModel extends PositionOffsetTransformerBase {
+	constructor(private readonly _textModel: ITextModel) {
+		super();
+	}
+
+	override getOffset(position: Position): number {
+		return this._textModel.getOffsetAt(position);
+	}
+
+	override getPosition(offset: number): Position {
+		return this._textModel.getPositionAt(offset);
+	}
+}

--- a/src/vs/editor/common/core/text/positionToOffset.ts
+++ b/src/vs/editor/common/core/text/positionToOffset.ts
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { findLastIdxMonotonous } from '../../../../base/common/arraysFind.js';
-import { ITextModel } from '../../model.js';
 import { StringEdit, StringReplacement } from '../edits/stringEdit.js';
 import { OffsetRange } from '../ranges/offsetRange.js';
 import { Position } from '../position.js';
@@ -116,23 +115,5 @@ export class PositionOffsetTransformer extends PositionOffsetTransformerBase {
 
 	getLineLength(lineNumber: number): number {
 		return this.lineEndOffsetByLineIdx[lineNumber - 1] - this.lineStartOffsetByLineIdx[lineNumber - 1];
-	}
-}
-
-export function getPositionOffsetTransformerFromTextModel(textModel: ITextModel): PositionOffsetTransformerBase {
-	return new PositionOffsetTransformerWithTextModel(textModel);
-}
-
-class PositionOffsetTransformerWithTextModel extends PositionOffsetTransformerBase {
-	constructor(private readonly _textModel: ITextModel) {
-		super();
-	}
-
-	override getOffset(position: Position): number {
-		return this._textModel.getOffsetAt(position);
-	}
-
-	override getPosition(offset: number): Position {
-		return this._textModel.getPositionAt(offset);
 	}
 }

--- a/src/vs/editor/contrib/inlineCompletions/browser/model/inlineSuggestionItem.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/model/inlineSuggestionItem.ts
@@ -12,7 +12,7 @@ import { ISingleEditOperation } from '../../../../common/core/editOperation.js';
 import { applyEditsToRanges, StringEdit, StringReplacement } from '../../../../common/core/edits/stringEdit.js';
 import { OffsetRange } from '../../../../common/core/ranges/offsetRange.js';
 import { Position } from '../../../../common/core/position.js';
-import { getPositionOffsetTransformerFromTextModel, PositionOffsetTransformerBase } from '../../../../common/core/text/positionToOffset.js';
+import { PositionOffsetTransformerBase } from '../../../../common/core/text/positionToOffset.js';
 import { Range } from '../../../../common/core/range.js';
 import { TextReplacement, TextEdit } from '../../../../common/core/edits/textEdit.js';
 import { StringText } from '../../../../common/core/text/abstractText.js';
@@ -23,6 +23,7 @@ import { ITextModel, EndOfLinePreference } from '../../../../common/model.js';
 import { TextModelText } from '../../../../common/model/textModelText.js';
 import { IDisplayLocation, InlineSuggestData, InlineSuggestionList, SnippetInfo } from './provideInlineCompletions.js';
 import { singleTextRemoveCommonPrefix } from './singleTextEditHelpers.js';
+import { getPositionOffsetTransformerFromTextModel } from '../../../../common/core/text/getPositionOffsetTransformerFromTextModel.js';
 
 export type InlineSuggestionItem = InlineEditItem | InlineCompletionItem;
 


### PR DESCRIPTION
...to avoid core data structure files depending on ITextModel.