### PR TITLE
Removes ITextModel dependency from objectStream.ts

### DIFF
--- a/src/vs/editor/common/codecs/utils/objectStream.ts
+++ b/src/vs/editor/common/codecs/utils/objectStream.ts
@@ -3,8 +3,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ITextModel } from '../../model.js';
-import { VSBuffer } from '../../../../base/common/buffer.js';
 import { assertNever } from '../../../../base/common/assert.js';
 import { CancellationToken } from '../../../../base/common/cancellation.js';
 import { ObservableDisposable } from '../../../../base/common/observableDisposable.js';
@@ -211,16 +209,6 @@ export class ObjectStream<T extends object> extends ObservableDisposable impleme
 	): ObjectStream<T> {
 		return new ObjectStream(arrayToGenerator(array), cancellationToken);
 	}
-
-	/**
-	 * Create new instance of the stream from a provided text model.
-	 */
-	public static fromTextModel(
-		model: ITextModel,
-		cancellationToken?: CancellationToken,
-	): ObjectStream<VSBuffer> {
-		return new ObjectStream(modelToGenerator(model), cancellationToken);
-	}
 }
 
 /**
@@ -230,33 +218,6 @@ export const arrayToGenerator = <T extends NonNullable<unknown>>(array: T[]): Ge
 	return (function* (): Generator<T, undefined> {
 		for (const item of array) {
 			yield item;
-		}
-	})();
-};
-
-/**
- * Create a generator out of a provided text model.
- */
-export const modelToGenerator = (model: ITextModel): Generator<VSBuffer, undefined> => {
-	return (function* (): Generator<VSBuffer, undefined> {
-		const totalLines = model.getLineCount();
-		let currentLine = 1;
-
-		while (currentLine <= totalLines) {
-			if (model.isDisposed()) {
-				return undefined;
-			}
-
-			yield VSBuffer.fromString(
-				model.getLineContent(currentLine),
-			);
-			if (currentLine !== totalLines) {
-				yield VSBuffer.fromString(
-					model.getEOL(),
-				);
-			}
-
-			currentLine++;
 		}
 	})();
 };

--- a/src/vs/editor/common/codecs/utils/objectStreamFromTextModel.ts
+++ b/src/vs/editor/common/codecs/utils/objectStreamFromTextModel.ts
@@ -1,0 +1,46 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { VSBuffer } from '../../../../base/common/buffer.js';
+import { CancellationToken } from '../../../../base/common/cancellation.js';
+import { ITextModel } from '../../model.js';
+import { ObjectStream } from './objectStream.js';
+
+/**
+ * Create new instance of the stream from a provided text model.
+ */
+export function objectStreamFromTextModel(
+	model: ITextModel,
+	cancellationToken?: CancellationToken,
+): ObjectStream<VSBuffer> {
+	return new ObjectStream(modelToGenerator(model), cancellationToken);
+}
+
+/**
+ * Create a generator out of a provided text model.
+ */
+export const modelToGenerator = (model: ITextModel): Generator<VSBuffer, undefined> => {
+	return (function* (): Generator<VSBuffer, undefined> {
+		const totalLines = model.getLineCount();
+		let currentLine = 1;
+
+		while (currentLine <= totalLines) {
+			if (model.isDisposed()) {
+				return undefined;
+			}
+
+			yield VSBuffer.fromString(
+				model.getLineContent(currentLine),
+			);
+			if (currentLine !== totalLines) {
+				yield VSBuffer.fromString(
+					model.getEOL(),
+				);
+			}
+
+			currentLine++;
+		}
+	})();
+};

--- a/src/vs/editor/test/common/codecs/simpleDecoder.test.ts
+++ b/src/vs/editor/test/common/codecs/simpleDecoder.test.ts
@@ -37,6 +37,15 @@ import {
 	Comma,
 } from '../../../common/codecs/simpleCodec/tokens/index.js';
 
+
+class Test {
+
+}
+
+
+const t = new Test();
+
+
 /**
  * A reusable test utility that asserts that a `SimpleDecoder` instance
  * correctly decodes `inputData` into a stream of `TSimpleToken` tokens.

--- a/src/vs/editor/test/common/codecs/simpleDecoder.test.ts
+++ b/src/vs/editor/test/common/codecs/simpleDecoder.test.ts
@@ -37,15 +37,6 @@ import {
 	Comma,
 } from '../../../common/codecs/simpleCodec/tokens/index.js';
 
-
-class Test {
-
-}
-
-
-const t = new Test();
-
-
 /**
  * A reusable test utility that asserts that a `SimpleDecoder` instance
  * correctly decodes `inputData` into a stream of `TSimpleToken` tokens.

--- a/src/vs/editor/test/common/codecs/utils/objectStream.test.ts
+++ b/src/vs/editor/test/common/codecs/utils/objectStream.test.ts
@@ -14,6 +14,7 @@ import { randomBoolean } from '../../../../../base/test/common/testUtils.js';
 import { CancellationTokenSource } from '../../../../../base/common/cancellation.js';
 import { arrayToGenerator, ObjectStream } from '../../../../common/codecs/utils/objectStream.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { objectStreamFromTextModel } from '../../../../common/codecs/utils/objectStreamFromTextModel.js';
 
 suite('ObjectStream', () => {
 	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
@@ -49,7 +50,7 @@ suite('ObjectStream', () => {
 					URI.file('/foo.js'),
 				),
 			);
-			const stream = disposables.add(ObjectStream.fromTextModel(model));
+			const stream = disposables.add(objectStreamFromTextModel(model));
 
 			const receivedData = await consume(stream);
 
@@ -102,7 +103,7 @@ suite('ObjectStream', () => {
 			};
 
 			const stream = disposables.add(
-				ObjectStream.fromTextModel(model, cancellation.token),
+				objectStreamFromTextModel(model, cancellation.token),
 			);
 
 			const receivedData = await consume(stream);

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/contentProviders/textModelContentsProvider.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/contentProviders/textModelContentsProvider.ts
@@ -11,10 +11,10 @@ import { ReadableStream } from '../../../../../../base/common/stream.js';
 import { FilePromptContentProvider } from './filePromptContentsProvider.js';
 import { TextModel } from '../../../../../../editor/common/model/textModel.js';
 import { CancellationToken } from '../../../../../../base/common/cancellation.js';
-import { ObjectStream } from '../../../../../../editor/common/codecs/utils/objectStream.js';
 import { IModelContentChangedEvent } from '../../../../../../editor/common/textModelEvents.js';
 import { IInstantiationService } from '../../../../../../platform/instantiation/common/instantiation.js';
 import { IPromptContentsProviderOptions, PromptContentsProviderBase } from './promptContentsProviderBase.js';
+import { objectStreamFromTextModel } from '../../../../../../editor/common/codecs/utils/objectStreamFromTextModel.js';
 
 /**
  * Prompt contents provider for a {@link ITextModel} instance.
@@ -63,7 +63,7 @@ export class TextModelContentsProvider extends PromptContentsProviderBase<IModel
 		_event: IModelContentChangedEvent | 'full',
 		cancellationToken?: CancellationToken,
 	): Promise<ReadableStream<VSBuffer>> {
-		return ObjectStream.fromTextModel(this.model, cancellationToken);
+		return objectStreamFromTextModel(this.model, cancellationToken);
 	}
 
 	public override createNew(


### PR DESCRIPTION
This unblocks the copilot copy sources, which also copies over all transitive dependencies.