### PR TITLE
Rename "Next Edit Suggestions" to "Next edit suggestions" and "Code Completion" to "Code completion"

### DIFF
--- a/src/vs/editor/contrib/inlineCompletions/browser/controller/commands.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/controller/commands.ts
@@ -85,7 +85,7 @@ export class ExplicitTriggerInlineEditAction extends EditorAction {
 	constructor() {
 		super({
 			id: 'editor.action.inlineSuggest.triggerInlineEditExplicit',
-			label: nls.localize2('action.inlineSuggest.trigger.explicitInlineEdit', "Trigger Next Edit Suggestion"),
+			label: nls.localize2('action.inlineSuggest.trigger.explicitInlineEdit', "Trigger next edit suggestion"),
 			precondition: EditorContextKeys.writable,
 		});
 	}

--- a/src/vs/platform/accessibilitySignal/browser/accessibilitySignalService.ts
+++ b/src/vs/platform/accessibilitySignal/browser/accessibilitySignalService.ts
@@ -453,11 +453,11 @@ export class AccessibilitySignal {
 		settingsKey: 'accessibility.signals.lineHasInlineSuggestion',
 	});
 	public static readonly nextEditSuggestion = AccessibilitySignal.register({
-		name: localize('accessibilitySignals.nextEditSuggestion.name', 'Next Edit Suggestion on Line'),
+		name: localize('accessibilitySignals.nextEditSuggestion.name', 'Next edit suggestion on Line'),
 		sound: Sound.nextEditSuggestion,
 		legacySoundSettingsKey: 'audioCues.nextEditSuggestion',
 		settingsKey: 'accessibility.signals.nextEditSuggestion',
-		announcementMessage: localize('accessibility.signals.nextEditSuggestion', 'Next Edit Suggestion'),
+		announcementMessage: localize('accessibility.signals.nextEditSuggestion', 'Next edit suggestion'),
 	});
 	public static readonly terminalQuickFix = AccessibilitySignal.register({
 		name: localize('accessibilitySignals.terminalQuickFix.name', 'Terminal Quick Fix'),

--- a/src/vs/workbench/contrib/chat/browser/actions/chatActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatActions.ts
@@ -699,7 +699,7 @@ export function registerChatActions() {
 		constructor() {
 			super({
 				id: 'workbench.action.chat.configureCodeCompletions',
-				title: localize2('configureCompletions', "Configure Code Completions..."),
+				title: localize2('configureCompletions', "Configure code completions..."),
 				precondition: ContextKeyExpr.and(
 					ChatContextKeys.Setup.installed,
 					ChatContextKeys.Setup.disabled.negate()

--- a/src/vs/workbench/contrib/chat/browser/chatStatus.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatStatus.ts
@@ -209,7 +209,7 @@ export class ChatStatusBarEntry extends Disposable implements IWorkbenchContribu
 			// Completions Disabled
 			else if (this.editorService.activeTextEditorLanguageId && !isCompletionsEnabled(this.configurationService, this.editorService.activeTextEditorLanguageId)) {
 				text = `$(copilot-unavailable)`;
-				ariaLabel = localize('completionsDisabledStatus', "Code Completions Disabled");
+				ariaLabel = localize('completionsDisabledStatus', "Code completions Disabled");
 			}
 		}
 
@@ -572,21 +572,21 @@ class ChatStatusDashboard extends Disposable {
 		const modeId = this.editorService.activeTextEditorLanguageId;
 		const settings = container.appendChild($('div.settings'));
 
-		// --- Code Completions
+		// --- Code completions
 		{
 			const globalSetting = append(settings, $('div.setting'));
-			this.createCodeCompletionsSetting(globalSetting, localize('settings.codeCompletions', "Code Completions (all files)"), '*', disposables);
+			this.createCodeCompletionsSetting(globalSetting, localize('settings.codeCompletions', "Code completions (all files)"), '*', disposables);
 
 			if (modeId) {
 				const languageSetting = append(settings, $('div.setting'));
-				this.createCodeCompletionsSetting(languageSetting, localize('settings.codeCompletionsLanguage', "Code Completions ({0})", this.languageService.getLanguageName(modeId) ?? modeId), modeId, disposables);
+				this.createCodeCompletionsSetting(languageSetting, localize('settings.codeCompletionsLanguage', "Code completions ({0})", this.languageService.getLanguageName(modeId) ?? modeId), modeId, disposables);
 			}
 		}
 
-		// --- Next Edit Suggestions
+		// --- Next edit suggestions
 		{
 			const setting = append(settings, $('div.setting'));
-			this.createNextEditSuggestionsSetting(setting, localize('settings.nextEditSuggestions', "Next Edit Suggestions"), this.getCompletionsSettingAccessor(modeId), disposables);
+			this.createNextEditSuggestionsSetting(setting, localize('settings.nextEditSuggestions', "Next edit suggestions"), this.getCompletionsSettingAccessor(modeId), disposables);
 		}
 
 		return settings;

--- a/src/vs/workbench/contrib/welcomeGettingStarted/common/gettingStartedContent.ts
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/common/gettingStartedContent.ts
@@ -691,10 +691,10 @@ export const walkthroughs: GettingStartedWalkthroughContent = [
 				},
 				{
 					id: 'copilotSetup.inline',
-					title: localize('gettingStarted.nes.title', "Next Edit Suggestions"),
+					title: localize('gettingStarted.nes.title', "Next edit suggestions"),
 					description: localize('gettingStarted.nes.description', "Get code suggestions that predict your next edit."),
 					media: {
-						type: 'svg', altText: 'Next Edit Suggestions', path: 'ai-powered-suggestions.svg'
+						type: 'svg', altText: 'Next edit suggestions', path: 'ai-powered-suggestions.svg'
 					},
 				},
 				{


### PR DESCRIPTION
```Copilot Generated Description:``` Standardize the casing of "Next Edit Suggestions" to "Next edit suggestions" across various labels and settings.

https://github.com/microsoft/vscode-copilot/issues/16768