### PR TITLE
fix: missing translations of remote built-in extensions

### DIFF
--- a/build/gulpfile.reh.js
+++ b/build/gulpfile.reh.js
@@ -58,6 +58,7 @@ const serverResourceIncludes = [
 
 	// NLS
 	'out-build/nls.messages.json',
+	'out-build/nls.keys.json',
 
 	// Process monitor
 	'out-build/vs/base/node/cpuUsage.sh',

--- a/src/vs/base/node/nls.ts
+++ b/src/vs/base/node/nls.ts
@@ -108,26 +108,26 @@ export async function resolveNLSConfiguration({ userLocale, osLocale, userDataPa
 			_corruptedFile: languagePackCorruptMarkerFile
 		};
 
-		if (await Promises.exists(commitLanguagePackCachePath)) {
+		if (await Promises.exists(languagePackMessagesFile)) {
 			touch(commitLanguagePackCachePath).catch(() => { }); // We don't wait for this. No big harm if we can't touch
 			mark('code/didGenerateNls');
 			return result;
 		}
 
 		const [
-			,
 			nlsDefaultKeys,
 			nlsDefaultMessages,
 			nlsPackdata
 		]:
-			[unknown, Array<[string, string[]]>, string[], { contents: Record<string, Record<string, string>> }]
-			//               ^moduleId ^nlsKeys                               ^moduleId      ^nlsKey ^nlsValue
+			[Array<[string, string[]]>, string[], { contents: Record<string, Record<string, string>> }]
+			//      ^moduleId ^nlsKeys                               ^moduleId      ^nlsKey ^nlsValue
 			= await Promise.all([
-				promises.mkdir(commitLanguagePackCachePath, { recursive: true }),
 				promises.readFile(join(nlsMetadataPath, 'nls.keys.json'), 'utf-8').then(content => JSON.parse(content)),
 				promises.readFile(join(nlsMetadataPath, 'nls.messages.json'), 'utf-8').then(content => JSON.parse(content)),
 				promises.readFile(mainLanguagePackPath, 'utf-8').then(content => JSON.parse(content)),
 			]);
+
+		await promises.mkdir(commitLanguagePackCachePath, { recursive: true });
 
 		const nlsResult: string[] = [];
 

--- a/src/vs/base/node/nls.ts
+++ b/src/vs/base/node/nls.ts
@@ -127,8 +127,6 @@ export async function resolveNLSConfiguration({ userLocale, osLocale, userDataPa
 				promises.readFile(mainLanguagePackPath, 'utf-8').then(content => JSON.parse(content)),
 			]);
 
-		await promises.mkdir(commitLanguagePackCachePath, { recursive: true });
-
 		const nlsResult: string[] = [];
 
 		// We expect NLS messages to be in a flat array in sorted order as they
@@ -144,6 +142,8 @@ export async function resolveNLSConfiguration({ userLocale, osLocale, userDataPa
 				nlsIndex++;
 			}
 		}
+
+		await promises.mkdir(commitLanguagePackCachePath, { recursive: true });
 
 		await Promise.all([
 			promises.writeFile(languagePackMessagesFile, JSON.stringify(nlsResult), 'utf-8'),

--- a/src/vs/platform/extensionManagement/common/extensionManagement.ts
+++ b/src/vs/platform/extensionManagement/common/extensionManagement.ts
@@ -616,7 +616,7 @@ export interface IExtensionManagementService {
 	uninstall(extension: ILocalExtension, options?: UninstallOptions): Promise<void>;
 	uninstallExtensions(extensions: UninstallExtensionInfo[]): Promise<void>;
 	toggleApplicationScope(extension: ILocalExtension, fromProfileLocation: URI): Promise<ILocalExtension>;
-	getInstalled(type?: ExtensionType, profileLocation?: URI, productVersion?: IProductVersion): Promise<ILocalExtension[]>;
+	getInstalled(type?: ExtensionType, profileLocation?: URI, productVersion?: IProductVersion, language?: string): Promise<ILocalExtension[]>;
 	getExtensionsControlManifest(): Promise<IExtensionsControlManifest>;
 	copyExtensions(fromProfileLocation: URI, toProfileLocation: URI): Promise<void>;
 	updateMetadata(local: ILocalExtension, metadata: Partial<Metadata>, profileLocation: URI): Promise<ILocalExtension>;

--- a/src/vs/platform/extensionManagement/common/extensionManagementIpc.ts
+++ b/src/vs/platform/extensionManagement/common/extensionManagementIpc.ts
@@ -17,6 +17,7 @@ import {
 import { ExtensionType, IExtensionManifest, TargetPlatform } from '../../extensions/common/extensions.js';
 import { IProductService } from '../../product/common/productService.js';
 import { CommontExtensionManagementService } from './abstractExtensionManagementService.js';
+import { language } from '../../../base/common/platform.js';
 
 function transformIncomingURI(uri: UriComponents, transformer: IURITransformer | null): URI;
 function transformIncomingURI(uri: UriComponents | undefined, transformer: IURITransformer | null): URI | undefined;
@@ -145,7 +146,7 @@ export class ExtensionManagementChannel implements IServerChannel {
 				return this.service.uninstallExtensions(arg.map(({ extension, options }) => ({ extension: transformIncomingExtension(extension, uriTransformer), options: transformIncomingOptions(options, uriTransformer) })));
 			}
 			case 'getInstalled': {
-				const extensions = await this.service.getInstalled(args[0], transformIncomingURI(args[1], uriTransformer), args[2]);
+				const extensions = await this.service.getInstalled(args[0], transformIncomingURI(args[1], uriTransformer), args[2], args[3]);
 				return extensions.map(e => transformOutgoingExtension(e, uriTransformer));
 			}
 			case 'toggleApplicationScope': {
@@ -297,7 +298,7 @@ export class ExtensionManagementChannelClient extends CommontExtensionManagement
 	}
 
 	getInstalled(type: ExtensionType | null = null, extensionsProfileResource?: URI, productVersion?: IProductVersion): Promise<ILocalExtension[]> {
-		return Promise.resolve(this.channel.call<ILocalExtension[]>('getInstalled', [type, extensionsProfileResource, productVersion]))
+		return Promise.resolve(this.channel.call<ILocalExtension[]>('getInstalled', [type, extensionsProfileResource, productVersion, language]))
 			.then(extensions => extensions.map(extension => transformIncomingExtension(extension, null)));
 	}
 

--- a/src/vs/platform/extensionManagement/node/extensionManagementService.ts
+++ b/src/vs/platform/extensionManagement/node/extensionManagementService.ts
@@ -130,8 +130,8 @@ export class ExtensionManagementService extends AbstractExtensionManagementServi
 		}
 	}
 
-	getInstalled(type?: ExtensionType, profileLocation: URI = this.userDataProfilesService.defaultProfile.extensionsResource, productVersion: IProductVersion = { version: this.productService.version, date: this.productService.date }): Promise<ILocalExtension[]> {
-		return this.extensionsScanner.scanExtensions(type ?? null, profileLocation, productVersion);
+	getInstalled(type?: ExtensionType, profileLocation: URI = this.userDataProfilesService.defaultProfile.extensionsResource, productVersion: IProductVersion = { version: this.productService.version, date: this.productService.date }, language?: string): Promise<ILocalExtension[]> {
+		return this.extensionsScanner.scanExtensions(type ?? null, profileLocation, productVersion, language);
 	}
 
 	scanAllUserInstalledExtensions(): Promise<ILocalExtension[]> {
@@ -562,14 +562,14 @@ export class ExtensionsScanner extends Disposable {
 		await this.initializeExtensionSize();
 	}
 
-	async scanExtensions(type: ExtensionType | null, profileLocation: URI, productVersion: IProductVersion): Promise<ILocalExtension[]> {
+	async scanExtensions(type: ExtensionType | null, profileLocation: URI, productVersion: IProductVersion, language?: string): Promise<ILocalExtension[]> {
 		try {
 			const userScanOptions: UserExtensionsScanOptions = { includeInvalid: true, profileLocation, productVersion };
 			let scannedExtensions: IScannedExtension[] = [];
 			if (type === null || type === ExtensionType.System) {
 				let scanAllExtensionsPromise = this.scanAllExtensionPromise.get(profileLocation);
 				if (!scanAllExtensionsPromise) {
-					scanAllExtensionsPromise = this.extensionsScannerService.scanAllExtensions({}, userScanOptions)
+					scanAllExtensionsPromise = this.extensionsScannerService.scanAllExtensions({ language }, userScanOptions)
 						.finally(() => this.scanAllExtensionPromise.delete(profileLocation));
 					this.scanAllExtensionPromise.set(profileLocation, scanAllExtensionsPromise);
 				}

--- a/src/vs/platform/extensionManagement/node/extensionManagementService.ts
+++ b/src/vs/platform/extensionManagement/node/extensionManagementService.ts
@@ -564,23 +564,23 @@ export class ExtensionsScanner extends Disposable {
 
 	async scanExtensions(type: ExtensionType | null, profileLocation: URI, productVersion: IProductVersion, language?: string): Promise<ILocalExtension[]> {
 		try {
-			const userScanOptions: UserExtensionsScanOptions = { includeInvalid: true, profileLocation, productVersion };
+			const cacheKey: URI = profileLocation.with({ query: language });
+			const userScanOptions: UserExtensionsScanOptions = { includeInvalid: true, profileLocation, productVersion, language };
 			let scannedExtensions: IScannedExtension[] = [];
 			if (type === null || type === ExtensionType.System) {
-				const key: URI = profileLocation.with({ query: language });
-				let scanAllExtensionsPromise = this.scanAllExtensionPromise.get(key);
+				let scanAllExtensionsPromise = this.scanAllExtensionPromise.get(cacheKey);
 				if (!scanAllExtensionsPromise) {
 					scanAllExtensionsPromise = this.extensionsScannerService.scanAllExtensions({ language }, userScanOptions)
-						.finally(() => this.scanAllExtensionPromise.delete(key));
-					this.scanAllExtensionPromise.set(key, scanAllExtensionsPromise);
+						.finally(() => this.scanAllExtensionPromise.delete(cacheKey));
+					this.scanAllExtensionPromise.set(cacheKey, scanAllExtensionsPromise);
 				}
 				scannedExtensions.push(...await scanAllExtensionsPromise);
 			} else if (type === ExtensionType.User) {
-				let scanUserExtensionsPromise = this.scanUserExtensionsPromise.get(profileLocation);
+				let scanUserExtensionsPromise = this.scanUserExtensionsPromise.get(cacheKey);
 				if (!scanUserExtensionsPromise) {
 					scanUserExtensionsPromise = this.extensionsScannerService.scanUserExtensions(userScanOptions)
-						.finally(() => this.scanUserExtensionsPromise.delete(profileLocation));
-					this.scanUserExtensionsPromise.set(profileLocation, scanUserExtensionsPromise);
+						.finally(() => this.scanUserExtensionsPromise.delete(cacheKey));
+					this.scanUserExtensionsPromise.set(cacheKey, scanUserExtensionsPromise);
 				}
 				scannedExtensions.push(...await scanUserExtensionsPromise);
 			}

--- a/src/vs/platform/extensionManagement/node/extensionManagementService.ts
+++ b/src/vs/platform/extensionManagement/node/extensionManagementService.ts
@@ -567,11 +567,12 @@ export class ExtensionsScanner extends Disposable {
 			const userScanOptions: UserExtensionsScanOptions = { includeInvalid: true, profileLocation, productVersion };
 			let scannedExtensions: IScannedExtension[] = [];
 			if (type === null || type === ExtensionType.System) {
-				let scanAllExtensionsPromise = this.scanAllExtensionPromise.get(profileLocation);
+				const key: URI = profileLocation.with({ query: language });
+				let scanAllExtensionsPromise = this.scanAllExtensionPromise.get(key);
 				if (!scanAllExtensionsPromise) {
 					scanAllExtensionsPromise = this.extensionsScannerService.scanAllExtensions({ language }, userScanOptions)
-						.finally(() => this.scanAllExtensionPromise.delete(profileLocation));
-					this.scanAllExtensionPromise.set(profileLocation, scanAllExtensionsPromise);
+						.finally(() => this.scanAllExtensionPromise.delete(key));
+					this.scanAllExtensionPromise.set(key, scanAllExtensionsPromise);
 				}
 				scannedExtensions.push(...await scanAllExtensionsPromise);
 			} else if (type === ExtensionType.User) {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

@BlackHole1 noticed that some translations are missing when develop in remote mode. After digging a bit, we found that only built-in extensions' NLS messages are missing. For example, the Source Control view (contributed by the built-in 'Git' extension) and built-in extensions' configurations are in English.

Despite that the remote server will download and install the corresponding language pack extension, it does not pick the language pack up because of 2 problems:

1. There's no `nls.keys.json` in the server build, causing `clp/{hash}.{lang}/*` failed to generate.
2. When scanning built-in extensions, the UI language was not passed correctly to the backend.

This PR fixes the 2 problems.

Note about problem 1: The original code `Promise.all([mkdir, read keys, read messages])` will fail when the keys file is missing, but the mkdir task would succeed and leave an empty folder which prevents it regenerate in the next calling. So I changed the testing logic from the folder to the file in it.

Fixes #250579