### PR TITLE
rm setting ref in chat user action required signal setting

### DIFF
--- a/src/vs/workbench/contrib/accessibility/browser/accessibilityConfiguration.ts
+++ b/src/vs/workbench/contrib/accessibility/browser/accessibilityConfiguration.ts
@@ -753,7 +753,7 @@ const configuration: IConfigurationNode = {
 		},
 		'accessibility.signals.chatUserActionRequired': {
 			...signalFeatureBase,
-			'markdownDescription': localize('accessibility.signals.chatUserActionRequired', "Plays a signal - sound (audio cue) and/or announcement (alert) - when user action is required in the chat. Note that {0} will impact the `auto` behavior of this setting.", '`#chat.focusWindowOnConfirmation#`'),
+			'markdownDescription': localize('accessibility.signals.chatUserActionRequired', "Plays a signal - sound (audio cue) and/or announcement (alert) - when user action is required in the chat."),
 			'properties': {
 				'sound': {
 					'description': localize('accessibility.signals.chatUserActionRequired.sound', "Plays a sound when user action is required in the chat."),


### PR DESCRIPTION
The setting name is misleading - it doesn't actually focus the window 

cc @roblourens 
