### PR TITLE
`dom.ts#getFocusedWindow()` has a weird redundant check (fix #249416)

### DIFF
--- a/src/vs/base/browser/dom.ts
+++ b/src/vs/base/browser/dom.ts
@@ -942,15 +942,6 @@ export function getActiveWindow(): CodeWindow {
 	return (document.defaultView?.window ?? mainWindow) as CodeWindow;
 }
 
-export function getFocusedWindow(): CodeWindow | undefined {
-	const document = getActiveDocument();
-	// This check is needed to ensure the window has focus
-	if (document.defaultView?.window.document.hasFocus()) {
-		return (document.defaultView?.window) as CodeWindow;
-	}
-	return;
-}
-
 interface IMutationObserver {
 	users: number;
 	readonly observer: MutationObserver;

--- a/src/vs/workbench/contrib/chat/browser/languageModelToolsService.ts
+++ b/src/vs/workbench/contrib/chat/browser/languageModelToolsService.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { getFocusedWindow } from '../../../../base/browser/dom.js';
+import { getActiveDocument } from '../../../../base/browser/dom.js';
 import { renderStringAsPlaintext } from '../../../../base/browser/markdownRenderer.js';
 import { assertNever } from '../../../../base/common/assert.js';
 import { RunOnceScheduler } from '../../../../base/common/async.js';
@@ -375,7 +375,7 @@ export class LanguageModelToolsService extends Disposable implements ILanguageMo
 	}
 
 	private playAccessibilitySignal(toolInvocations: ChatToolInvocation[]): void {
-		const hasFocusedWindow = getFocusedWindow();
+		const hasFocusedWindow = getActiveDocument().hasFocus();
 		const autoApproved = this._configurationService.getValue('chat.tools.autoApprove');
 		if (autoApproved) {
 			return;


### PR DESCRIPTION
I would like to restore just 1 group of methods that talk about an active window or document and then `hasFocus()` can be used selectively.