### PR TITLE
Fix cut-off edit suggestions in the editor and rendering after minimap

### DIFF
--- a/src/vs/editor/browser/observableCodeEditor.ts
+++ b/src/vs/editor/browser/observableCodeEditor.ts
@@ -143,9 +143,11 @@ export class ObservableCodeEditor extends Disposable {
 		this.layoutInfoContentLeft = this.layoutInfo.map(l => l.contentLeft);
 		this.layoutInfoDecorationsLeft = this.layoutInfo.map(l => l.decorationsLeft);
 		this.layoutInfoWidth = this.layoutInfo.map(l => l.width);
+		this.layoutInfoHeight = this.layoutInfo.map(l => l.height);
 		this.layoutInfoMinimap = this.layoutInfo.map(l => l.minimap);
 		this.layoutInfoVerticalScrollbarWidth = this.layoutInfo.map(l => l.verticalScrollbarWidth);
 		this.contentWidth = observableFromEvent(this.editor.onDidContentSizeChange, () => this.editor.getContentWidth());
+		this.contentHeight = observableFromEvent(this.editor.onDidContentSizeChange, () => this.editor.getContentHeight());
 		this._widgetCounter = 0;
 		this.openedPeekWidgets = observableValue(this, 0);
 
@@ -263,10 +265,12 @@ export class ObservableCodeEditor extends Disposable {
 	public readonly layoutInfoContentLeft;
 	public readonly layoutInfoDecorationsLeft;
 	public readonly layoutInfoWidth;
+	public readonly layoutInfoHeight;
 	public readonly layoutInfoMinimap;
 	public readonly layoutInfoVerticalScrollbarWidth;
 
 	public readonly contentWidth;
+	public readonly contentHeight;
 
 	public getOption<T extends EditorOption>(id: T): IObservable<FindComputedEditorOptionValueById<T>> {
 		return observableFromEvent(this, cb => this.editor.onDidChangeConfiguration(e => {

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/inlineEditsCollapsedView.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/inlineEditsCollapsedView.ts
@@ -16,7 +16,7 @@ import { singleTextRemoveCommonPrefix } from '../../../model/singleTextEditHelpe
 import { IInlineEditsView } from '../inlineEditsViewInterface.js';
 import { InlineEditWithChanges } from '../inlineEditWithChanges.js';
 import { inlineEditIndicatorPrimaryBorder } from '../theme.js';
-import { PathBuilder } from '../utils/utils.js';
+import { getEditorValidOverlayRect, PathBuilder, rectToProps } from '../utils/utils.js';
 
 export class InlineEditsCollapsedView extends Disposable implements IInlineEditsView {
 
@@ -102,10 +102,7 @@ export class InlineEditsCollapsedView extends Disposable implements IInlineEdits
 			ref: this._iconRef,
 			style: {
 				position: 'absolute',
-				top: 0,
-				left: contentLeft,
-				width: this._editorObs.contentWidth,
-				height: this._editorObs.editor.getContentHeight(),
+				...rectToProps((r) => getEditorValidOverlayRect(this._editorObs).read(r)),
 				overflow: 'hidden',
 				pointerEvents: 'none',
 			}

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/inlineEditsLineReplacementView.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/inlineEditsLineReplacementView.ts
@@ -28,7 +28,7 @@ import { TokenArray } from '../../../../../../common/tokens/tokenArray.js';
 import { InlineDecoration, InlineDecorationType } from '../../../../../../common/viewModel.js';
 import { IInlineEditsView, InlineEditTabAction } from '../inlineEditsViewInterface.js';
 import { getEditorBlendedColor, getModifiedBorderColor, getOriginalBorderColor, modifiedChangedLineBackgroundColor, originalBackgroundColor } from '../theme.js';
-import { getPrefixTrim, mapOutFalsy, rectToProps } from '../utils/utils.js';
+import { getEditorValidOverlayRect, getPrefixTrim, mapOutFalsy, rectToProps } from '../utils/utils.js';
 
 export class InlineEditsLineReplacementView extends Disposable implements IInlineEditsView {
 
@@ -204,8 +204,6 @@ export class InlineEditsLineReplacementView extends Disposable implements IInlin
 
 				const layoutProps = layout.read(reader);
 				const contentLeft = this._editor.layoutInfoContentLeft.read(reader);
-				const contentWidth = this._editor.contentWidth.read(reader);
-				const contentHeight = this._editor.editor.getContentHeight();
 
 				const lineHeight = this._editor.getOption(EditorOption.lineHeight).read(reader);
 				modifiedLineElements.lines.forEach(l => {
@@ -221,10 +219,7 @@ export class InlineEditsLineReplacementView extends Disposable implements IInlin
 					n.div({
 						style: {
 							position: 'absolute',
-							top: 0,
-							left: contentLeft,
-							width: contentWidth,
-							height: contentHeight,
+							...rectToProps((r) => getEditorValidOverlayRect(this._editor).read(r)),
 							overflow: 'hidden',
 							pointerEvents: 'none',
 						}

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/inlineEditsWordReplacementView.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/inlineEditsWordReplacementView.ts
@@ -23,7 +23,7 @@ import { LineTokens } from '../../../../../../common/tokens/lineTokens.js';
 import { TokenArray } from '../../../../../../common/tokens/tokenArray.js';
 import { IInlineEditsView, InlineEditTabAction } from '../inlineEditsViewInterface.js';
 import { getModifiedBorderColor, getOriginalBorderColor, modifiedChangedTextOverlayColor, originalChangedTextOverlayColor } from '../theme.js';
-import { mapOutFalsy, rectToProps } from '../utils/utils.js';
+import { getEditorValidOverlayRect, mapOutFalsy, rectToProps } from '../utils/utils.js';
 
 export class InlineEditsWordReplacementView extends Disposable implements IInlineEditsView {
 
@@ -113,7 +113,6 @@ export class InlineEditsWordReplacementView extends Disposable implements IInlin
 					return [];
 				}
 
-				const contentLeft = this._editor.layoutInfoContentLeft.read(reader);
 				const borderWidth = 1;
 
 				const originalBorderColor = getOriginalBorderColor(this._tabAction).map(c => asCssVariable(c)).read(reader);
@@ -123,10 +122,7 @@ export class InlineEditsWordReplacementView extends Disposable implements IInlin
 					n.div({
 						style: {
 							position: 'absolute',
-							top: 0,
-							left: contentLeft,
-							width: this._editor.contentWidth,
-							height: this._editor.editor.getContentHeight(),
+							...rectToProps((r) => getEditorValidOverlayRect(this._editor).read(r)),
 							overflow: 'hidden',
 							pointerEvents: 'none',
 						}

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/utils/utils.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/utils/utils.ts
@@ -104,6 +104,26 @@ export function getContentRenderWidth(content: string, editor: ICodeEditor, text
 	return numNoneTabs * w + numTabs * tabSize;
 }
 
+export function getEditorValidOverlayRect(editor: ObservableCodeEditor): IObservable<Rect> {
+	const contentLeft = editor.layoutInfoContentLeft;
+
+	const width = derived(r => {
+		const hasMinimapOnTheRight = editor.layoutInfoMinimap.read(r).minimapLeft !== 0;
+		const editorWidth = editor.layoutInfoWidth.read(r) - contentLeft.read(r);
+
+		if (hasMinimapOnTheRight) {
+			const minimapAndScrollbarWidth = editor.layoutInfoMinimap.read(r).minimapWidth + editor.layoutInfoVerticalScrollbarWidth.read(r);
+			return editorWidth - minimapAndScrollbarWidth;
+		}
+
+		return editorWidth;
+	});
+
+	const height = derived(r => editor.layoutInfoHeight.read(r) + editor.contentHeight.read(r));
+
+	return derived(r => Rect.fromLeftTopWidthHeight(contentLeft.read(r), 0, width.read(r), height.read(r)));
+}
+
 export class StatusBarViewItem extends MenuEntryActionViewItem {
 	protected readonly _updateLabelListener = this._register(this._contextKeyService.onDidChangeContext(() => {
 		this.updateLabel();


### PR DESCRIPTION
```Copilot Generated Description:``` Adjust the editor's layout calculations to ensure that edit suggestions are fully visible, even at the end of a file or when they are long. This includes adding height calculations and updating the overlay rectangle logic.

Fixes microsoft/vscode-copilot-release#9892
fixes https://github.com/microsoft/vscode-copilot/issues/16356
fixes https://github.com/microsoft/vscode-copilot/issues/15966