### PR TITLE
Cursor moves to the end of the edit after inline completion

### DIFF
--- a/src/vs/editor/contrib/inlineCompletions/browser/utils.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/utils.ts
@@ -13,6 +13,8 @@ import { Position } from '../../../common/core/position.js';
 import { PositionOffsetTransformer } from '../../../common/core/text/positionToOffset.js';
 import { Range } from '../../../common/core/range.js';
 import { TextReplacement, TextEdit } from '../../../common/core/edits/textEdit.js';
+import { getPositionOffsetTransformerFromTextModel } from '../../../common/core/text/getPositionOffsetTransformerFromTextModel.js';
+import { ITextModel } from '../../../common/model.js';
 
 const array: ReadonlyArray<any> = [];
 export function getReadonlyEmptyArray<T>(): readonly T[] {
@@ -43,6 +45,14 @@ export function getModifiedRangesAfterApplying(edits: readonly TextReplacement[]
 	const edit = new TextEdit(sortPerm.apply(edits));
 	const sortedNewRanges = edit.getNewRanges();
 	return sortPerm.inverse().apply(sortedNewRanges);
+}
+
+export function removeTextReplacementCommonSuffixPrefix(edits: readonly TextReplacement[], textModel: ITextModel): TextReplacement[] {
+	const transformer = getPositionOffsetTransformerFromTextModel(textModel);
+	const text = textModel.getValue();
+	const stringReplacements = edits.map(edit => transformer.getStringReplacement(edit));
+	const minimalStringReplacements = stringReplacements.map(replacement => replacement.removeCommonSuffixPrefix(text));
+	return minimalStringReplacements.map(replacement => transformer.getSingleTextEdit(replacement));
 }
 
 export function convertItemsToStableObservables<T>(items: IObservable<readonly T[]>, store: DisposableStore): IObservable<IObservable<T>[]> {


### PR DESCRIPTION
```Copilot Generated Description:``` Adjust the cursor position to move to the end of the edit instead of the end of the provided range during inline completions. Introduce a utility function to remove common suffixes and prefixes from text replacements.

fixes https://github.com/microsoft/vscode-copilot/issues/17187