### PR TITLE
add manage custom chat modes command

### DIFF
--- a/extensions/prompt-basics/package.json
+++ b/extensions/prompt-basics/package.json
@@ -34,6 +34,17 @@
           "copilot-instructions.md"
         ],
         "configuration": "./language-configuration.json"
+      },
+      {
+        "id": "chatmode",
+        "aliases": [
+          "Chat Mode",
+          "chat mode"
+        ],
+        "extensions": [
+          ".chatmode.md"
+        ],
+        "configuration": "./language-configuration.json"
       }
     ],
     "grammars": [
@@ -54,6 +65,15 @@
           "markup.underline.link.markdown",
           "punctuation.definition.list.begin.markdown"
         ]
+      },
+      {
+        "language": "chatmode",
+        "path": "./syntaxes/prompt.tmLanguage.json",
+        "scopeName": "text.html.markdown.prompt",
+        "unbalancedBracketScopes": [
+          "markup.underline.link.markdown",
+          "punctuation.definition.list.begin.markdown"
+        ]
       }
     ],
     "configurationDefaults": {
@@ -63,6 +83,11 @@
         "diffEditor.ignoreTrimWhitespace": false
       },
       "[instructions]": {
+        "editor.unicodeHighlight.ambiguousCharacters": false,
+        "editor.unicodeHighlight.invisibleCharacters": false,
+        "diffEditor.ignoreTrimWhitespace": false
+      },
+      "[chatmode]": {
         "editor.unicodeHighlight.ambiguousCharacters": false,
         "editor.unicodeHighlight.invisibleCharacters": false,
         "diffEditor.ignoreTrimWhitespace": false
@@ -76,6 +101,10 @@
       {
         "language": "instructions",
         "path": "./snippets/instructions.code-snippets"
+      },
+      {
+        "language": "chatmode",
+        "path": "./snippets/chatmode.code-snippets"
       }
     ]
   },

--- a/extensions/prompt-basics/snippets/chatmode.code-snippets
+++ b/extensions/prompt-basics/snippets/chatmode.code-snippets
@@ -1,0 +1,13 @@
+{
+	"fileTemplate": {
+		"prefix": "Custom Chat Mode",
+		"body": [
+			"---",
+			"description: '${1:Description of the custom chat mode.}'",
+			"tools: [ '${2:tool1}', '${3:tool2}' ]",
+			"---",
+		],
+		"description": "Custom chat modes can define a specific behavior for the chat",
+		"isFileTemplate": true,
+	}
+}

--- a/src/vs/platform/prompts/common/config.ts
+++ b/src/vs/platform/prompts/common/config.ts
@@ -5,11 +5,11 @@
 
 import { ContextKeyExpr } from '../../contextkey/common/contextkey.js';
 import type { IConfigurationService } from '../../configuration/common/configuration.js';
-import { CONFIG_KEY, PROMPT_DEFAULT_SOURCE_FOLDER, INSTRUCTIONS_LOCATIONS_CONFIG_KEY, PROMPT_LOCATIONS_CONFIG_KEY, INSTRUCTIONS_DEFAULT_SOURCE_FOLDER } from './constants.js';
+import { CONFIG_KEY, PROMPT_DEFAULT_SOURCE_FOLDER, INSTRUCTIONS_LOCATIONS_CONFIG_KEY, PROMPT_LOCATIONS_CONFIG_KEY, INSTRUCTIONS_DEFAULT_SOURCE_FOLDER, PromptsType, getPromptFileDefaultLocation, MODE_LOCATIONS_CONFIG_KEY, getPromptFileLocationsConfigKey } from './prompts.js';
 
 /**
  * Configuration helper for the `reusable prompts` feature.
- * @see {@link CONFIG_KEY},  {@link PROMPT_LOCATIONS_CONFIG_KEY} and {@link INSTRUCTIONS_LOCATIONS_CONFIG_KEY}.
+ * @see {@link CONFIG_KEY}, {@link PROMPT_LOCATIONS_CONFIG_KEY}, {@link INSTRUCTIONS_LOCATIONS_CONFIG_KEY} or {@link MODE_LOCATIONS_CONFIG_KEY}.
  *
  * ### Functions
  *
@@ -31,6 +31,7 @@ export namespace PromptsConfig {
 	export const KEY = CONFIG_KEY;
 	export const PROMPT_LOCATIONS_KEY = PROMPT_LOCATIONS_CONFIG_KEY;
 	export const INSTRUCTIONS_LOCATION_KEY = INSTRUCTIONS_LOCATIONS_CONFIG_KEY;
+	export const MODE_LOCATION_KEY = MODE_LOCATIONS_CONFIG_KEY;
 
 	/**
 	 * Checks if the feature is enabled.
@@ -51,13 +52,13 @@ export namespace PromptsConfig {
 
 	/**
 	 * Get value of the `reusable prompt locations` configuration setting.
-	 * @see {@link PROMPT_LOCATIONS_CONFIG_KEY} or  {@link INSTRUCTIONS_LOCATIONS_CONFIG_KEY}.
+	 * @see {@link PROMPT_LOCATIONS_CONFIG_KEY}, {@link INSTRUCTIONS_LOCATIONS_CONFIG_KEY}, {@link MODE_LOCATIONS_CONFIG_KEY}.
 	 */
 	export const getLocationsValue = (
 		configService: IConfigurationService,
-		type: 'instructions' | 'prompt'
+		type: PromptsType
 	): Record<string, boolean> | undefined => {
-		const key = type === 'instructions' ? INSTRUCTIONS_LOCATIONS_CONFIG_KEY : PROMPT_LOCATIONS_CONFIG_KEY;
+		const key = getPromptFileLocationsConfigKey(type);
 		const configValue = configService.getValue(key);
 
 		if (configValue === undefined || configValue === null || Array.isArray(configValue)) {
@@ -88,14 +89,14 @@ export namespace PromptsConfig {
 
 	/**
 	 * Gets list of source folders for prompt files.
-	 * Defaults to {@link PROMPT_DEFAULT_SOURCE_FOLDER} or {@link INSTRUCTIONS_DEFAULT_SOURCE_FOLDER}.
+	 * Defaults to {@link PROMPT_DEFAULT_SOURCE_FOLDER}, {@link INSTRUCTIONS_DEFAULT_SOURCE_FOLDER} or {@link MODE_DEFAULT_SOURCE_FOLDER}.
 	 */
 	export const promptSourceFolders = (
 		configService: IConfigurationService,
-		type: 'instructions' | 'prompt'
+		type: PromptsType
 	): string[] => {
 		const value = getLocationsValue(configService, type);
-		const defaultSourceFolder = type === 'instructions' ? INSTRUCTIONS_DEFAULT_SOURCE_FOLDER : PROMPT_DEFAULT_SOURCE_FOLDER;
+		const defaultSourceFolder = getPromptFileDefaultLocation(type);
 
 		// note! the `value &&` part handles the `undefined`, `null`, and `false` cases
 		if (value && (typeof value === 'object')) {

--- a/src/vs/platform/prompts/test/common/config.test.ts
+++ b/src/vs/platform/prompts/test/common/config.test.ts
@@ -9,6 +9,7 @@ import { PromptsConfig } from '../../common/config.js';
 import { randomInt } from '../../../../base/common/numbers.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
 import { IConfigurationOverrides, IConfigurationService } from '../../../configuration/common/configuration.js';
+import { PromptsType } from '../../common/prompts.js';
 
 /**
  * Mocked instance of {@link IConfigurationService}.
@@ -22,7 +23,7 @@ const createMock = <T>(value: T): IConfigurationService => {
 			);
 
 			assert(
-				[PromptsConfig.KEY, PromptsConfig.PROMPT_LOCATIONS_KEY, PromptsConfig.INSTRUCTIONS_LOCATION_KEY].includes(key),
+				[PromptsConfig.KEY, PromptsConfig.PROMPT_LOCATIONS_KEY, PromptsConfig.INSTRUCTIONS_LOCATION_KEY, PromptsConfig.MODE_LOCATION_KEY].includes(key),
 				`Unsupported configuration key '${key}'.`,
 			);
 
@@ -164,7 +165,7 @@ suite('PromptsConfig', () => {
 			const configService = createMock(undefined);
 
 			assert.strictEqual(
-				PromptsConfig.getLocationsValue(configService, 'prompt'),
+				PromptsConfig.getLocationsValue(configService, PromptsType.prompt),
 				undefined,
 				'Must read correct value.',
 			);
@@ -174,7 +175,7 @@ suite('PromptsConfig', () => {
 			const configService = createMock(null);
 
 			assert.strictEqual(
-				PromptsConfig.getLocationsValue(configService, 'prompt'),
+				PromptsConfig.getLocationsValue(configService, PromptsType.prompt),
 				undefined,
 				'Must read correct value.',
 			);
@@ -183,7 +184,7 @@ suite('PromptsConfig', () => {
 		suite('• object', () => {
 			test('• empty', () => {
 				assert.deepStrictEqual(
-					PromptsConfig.getLocationsValue(createMock({}), 'prompt'),
+					PromptsConfig.getLocationsValue(createMock({}), PromptsType.prompt),
 					{},
 					'Must read correct value.',
 				);
@@ -204,7 +205,7 @@ suite('PromptsConfig', () => {
 						'some/folder.with.dots/another.file': true,
 						'/var/logs/app.01.05.error': true,
 						'./.tempfile': true,
-					}), 'prompt'),
+					}), PromptsType.prompt),
 					{
 						'/root/.bashrc': true,
 						'../../folder/.hidden-folder/config.xml': true,
@@ -248,7 +249,7 @@ suite('PromptsConfig', () => {
 						'\f\f': true,
 						'../lib/some_library.v1.0.1.so': '\r\n',
 						'/dev/shm/.shared_resource': randomInt(Number.MAX_SAFE_INTEGER, Number.MIN_SAFE_INTEGER),
-					}), 'prompt'),
+					}), PromptsType.prompt),
 					{
 						'../assets/img/logo.v2.png': true,
 						'/mnt/storage/video.archive/episode.01.mkv': false,
@@ -275,7 +276,7 @@ suite('PromptsConfig', () => {
 						'/var/data/datafile.2025-02-05.json': '\n',
 						'../lib/some_library.v1.0.1.so': '\r\n',
 						'/dev/shm/.shared_resource': randomInt(Number.MAX_SAFE_INTEGER, Number.MIN_SAFE_INTEGER),
-					}), 'prompt'),
+					}), PromptsType.prompt),
 					{
 						'/mnt/storage/video.archive/episode.01.mkv': false,
 					},
@@ -290,7 +291,7 @@ suite('PromptsConfig', () => {
 			const configService = createMock(undefined);
 
 			assert.deepStrictEqual(
-				PromptsConfig.promptSourceFolders(configService, 'prompt'),
+				PromptsConfig.promptSourceFolders(configService, PromptsType.prompt),
 				[],
 				'Must read correct value.',
 			);
@@ -300,7 +301,7 @@ suite('PromptsConfig', () => {
 			const configService = createMock(null);
 
 			assert.deepStrictEqual(
-				PromptsConfig.promptSourceFolders(configService, 'prompt'),
+				PromptsConfig.promptSourceFolders(configService, PromptsType.prompt),
 				[],
 				'Must read correct value.',
 			);
@@ -309,7 +310,7 @@ suite('PromptsConfig', () => {
 		suite('object', () => {
 			test('empty', () => {
 				assert.deepStrictEqual(
-					PromptsConfig.promptSourceFolders(createMock({}), 'prompt'),
+					PromptsConfig.promptSourceFolders(createMock({}), PromptsType.prompt),
 					['.github/prompts'],
 					'Must read correct value.',
 				);
@@ -331,7 +332,7 @@ suite('PromptsConfig', () => {
 						'/var/logs/app.01.05.error': true,
 						'.GitHub/prompts': true,
 						'./.tempfile': true,
-					}), 'prompt'),
+					}), PromptsType.prompt),
 					[
 						'.github/prompts',
 						'/root/.bashrc',
@@ -379,7 +380,7 @@ suite('PromptsConfig', () => {
 						'\f\f': true,
 						'../lib/some_library.v1.0.1.so': '\r\n',
 						'/dev/shm/.shared_resource': randomInt(Number.MAX_SAFE_INTEGER, Number.MIN_SAFE_INTEGER),
-					}), 'prompt'),
+					}), PromptsType.prompt),
 					[
 						'.github/prompts',
 						'../assets/img/logo.v2.png',
@@ -407,7 +408,7 @@ suite('PromptsConfig', () => {
 						'/var/data/datafile.2025-02-05.json': '\n',
 						'../lib/some_library.v1.0.1.so': '\r\n',
 						'/dev/shm/.shared_resource': randomInt(Number.MAX_SAFE_INTEGER, Number.MIN_SAFE_INTEGER),
-					}), 'prompt'),
+					}), PromptsType.prompt),
 					[
 						'.github/prompts',
 					],
@@ -442,7 +443,7 @@ suite('PromptsConfig', () => {
 						'\f\f': true,
 						'../lib/some_library.v1.0.1.so': '\r\n',
 						'/dev/shm/.shared_resource': randomInt(Number.MAX_SAFE_INTEGER, Number.MIN_SAFE_INTEGER),
-					}), 'prompt'),
+					}), PromptsType.prompt),
 					[
 						'../assets/img/logo.v2.png',
 						'../.local/bin/script.sh',

--- a/src/vs/platform/prompts/test/common/constants.test.ts
+++ b/src/vs/platform/prompts/test/common/constants.test.ts
@@ -6,7 +6,7 @@
 import assert from 'assert';
 import { URI } from '../../../../base/common/uri.js';
 import { randomInt } from '../../../../base/common/numbers.js';
-import { getCleanPromptName, isPromptOrInstructionsFile } from '../../common/constants.js';
+import { getCleanPromptName, isPromptOrInstructionsFile } from '../../common/prompts.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
 
 

--- a/src/vs/platform/userDataSync/common/promptsSync/promptsSync.ts
+++ b/src/vs/platform/userDataSync/common/promptsSync/promptsSync.ts
@@ -13,7 +13,7 @@ import { IStringDictionary } from '../../../../base/common/collections.js';
 import { CancellationToken } from '../../../../base/common/cancellation.js';
 import { IUriIdentityService } from '../../../uriIdentity/common/uriIdentity.js';
 import { IEnvironmentService } from '../../../environment/common/environment.js';
-import { isPromptOrInstructionsFile } from '../../../prompts/common/constants.js';
+import { isPromptOrInstructionsFile } from '../../../prompts/common/prompts.js';
 import { IUserDataProfile } from '../../../userDataProfile/common/userDataProfile.js';
 import { IConfigurationService } from '../../../configuration/common/configuration.js';
 import { areSame, IMergeResult as IPromptsMergeResult, merge } from './promptsMerge.js';

--- a/src/vs/workbench/contrib/chat/browser/actions/promptActions/chatAttachInstructionsAction.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/promptActions/chatAttachInstructionsAction.ts
@@ -23,7 +23,7 @@ import { IChatContextPickerItem, IChatContextPickerPickItem } from '../../chatCo
 import { CancellationToken } from '../../../../../../base/common/cancellation.js';
 import { IQuickPickSeparator } from '../../../../../../platform/quickinput/common/quickInput.js';
 import { Codicon } from '../../../../../../base/common/codicons.js';
-import { getCleanPromptName } from '../../../../../../platform/prompts/common/constants.js';
+import { getCleanPromptName, PromptsType } from '../../../../../../platform/prompts/common/prompts.js';
 import { compare } from '../../../../../../base/common/strings.js';
 import { ILabelService } from '../../../../../../platform/label/common/label.js';
 import { dirname } from '../../../../../../base/common/resources.js';
@@ -131,17 +131,17 @@ class AttachInstructionsAction extends Action2 {
 		}
 
 		// find all prompt files in the user workspace
-		const promptFiles = await promptsService.listPromptFiles('instructions');
+		const promptFiles = await promptsService.listPromptFiles(PromptsType.instructions);
 		const placeholder = localize(
 			'commands.instructions.select-dialog.placeholder',
 			'Select instructions files to attach',
 		);
 
-		const instructions = await pickers.selectInstructionsFiles({ promptFiles, resource, placeholder });
+		const result = await pickers.selectPromptFile({ promptFiles, resource, placeholder, type: PromptsType.instructions });
 
-		if (instructions !== undefined) {
+		if (result !== undefined) {
 			const widget = await attachInstructionsFiles(
-				instructions,
+				[result.promptFile],
 				attachOptions,
 			);
 			widget.focusInput();
@@ -203,7 +203,7 @@ export class ChatInstructionsPickerPick implements IChatContextPickerItem {
 
 	asPicker(): { readonly placeholder: string; readonly picks: Promise<(IChatContextPickerPickItem | IQuickPickSeparator)[]> | ((query: string, token: CancellationToken) => Promise<(IChatContextPickerPickItem | IQuickPickSeparator)[]>) } {
 
-		const picks = this.promptsService.listPromptFiles('instructions').then(value => {
+		const picks = this.promptsService.listPromptFiles(PromptsType.instructions).then(value => {
 
 			const result: (IChatContextPickerPickItem | IQuickPickSeparator)[] = [];
 

--- a/src/vs/workbench/contrib/chat/browser/actions/promptActions/chatModeActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/promptActions/chatModeActions.ts
@@ -1,0 +1,69 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { CHAT_CATEGORY } from '../chatActions.js';
+import { Codicon } from '../../../../../../base/common/codicons.js';
+import { ChatContextKeys } from '../../../common/chatContextKeys.js';
+import { IPromptsService } from '../../../common/promptSyntax/service/types.js';
+import { localize, localize2 } from '../../../../../../nls.js';
+import { PromptsConfig } from '../../../../../../platform/prompts/common/config.js';
+import { PromptFilePickers } from './dialogs/askToSelectPrompt/promptFilePickers.js';
+import { ServicesAccessor } from '../../../../../../editor/browser/editorExtensions.js';
+import { ContextKeyExpr } from '../../../../../../platform/contextkey/common/contextkey.js';
+import { Action2, registerAction2 } from '../../../../../../platform/actions/common/actions.js';
+import { IInstantiationService } from '../../../../../../platform/instantiation/common/instantiation.js';
+import { PromptsType } from '../../../../../../platform/prompts/common/prompts.js';
+import { IOpenerService } from '../../../../../../platform/opener/common/opener.js';
+
+/**
+ * Action ID for the `Manage Custom Chat Mode` action.
+ */
+const MANAGE_CUSTOM_MODE_ACTION_ID = 'workbench.action.chat.manage.mode';
+
+class ManageModeAction extends Action2 {
+	constructor() {
+		super({
+			id: MANAGE_CUSTOM_MODE_ACTION_ID,
+			title: localize2('manage-mode.capitalized', "Manage Custom Chat Modes..."),
+			icon: Codicon.bookmark,
+			f1: true,
+			precondition: ContextKeyExpr.and(PromptsConfig.enabledCtx, ChatContextKeys.enabled),
+			category: CHAT_CATEGORY,
+		});
+	}
+
+	public override async run(
+		accessor: ServicesAccessor,
+	): Promise<void> {
+		const promptsService = accessor.get(IPromptsService);
+		const openerService = accessor.get(IOpenerService);
+		const instaService = accessor.get(IInstantiationService);
+
+		const pickers = instaService.createInstance(PromptFilePickers);
+
+		// find all prompt files in the user workspace
+		const promptFiles = await promptsService.listPromptFiles(PromptsType.mode);
+		const placeholder = localize(
+			'commands.mode.select-dialog.placeholder',
+			'Select the custom chat mode to edit'
+		);
+
+		const result = await pickers.selectPromptFile({ promptFiles, placeholder, type: PromptsType.mode, optionEdit: false });
+
+		if (result === undefined) {
+			return;
+		}
+		openerService.open(result.promptFile);
+	}
+}
+
+
+
+/**
+ * Helper to register all the `Run Current Prompt` actions.
+ */
+export const registerChatModeActions = () => {
+	registerAction2(ManageModeAction);
+};

--- a/src/vs/workbench/contrib/chat/browser/actions/promptActions/chatRunPromptAction.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/promptActions/chatRunPromptAction.ts
@@ -30,6 +30,7 @@ import { ICodeEditorService } from '../../../../../../editor/browser/services/co
 import { KeybindingWeight } from '../../../../../../platform/keybinding/common/keybindingsRegistry.js';
 import { Action2, MenuId, registerAction2 } from '../../../../../../platform/actions/common/actions.js';
 import { IInstantiationService } from '../../../../../../platform/instantiation/common/instantiation.js';
+import { PromptsType } from '../../../../../../platform/prompts/common/prompts.js';
 
 /**
  * Condition for the `Run Current Prompt` action.
@@ -208,14 +209,14 @@ class RunSelectedPromptAction extends Action2 {
 		const pickers = instaService.createInstance(PromptFilePickers);
 
 		// find all prompt files in the user workspace
-		const promptFiles = await promptsService.listPromptFiles('prompt');
+		const promptFiles = await promptsService.listPromptFiles(PromptsType.prompt);
 		const placeholder = localize(
 			'commands.prompt.select-dialog.placeholder',
 			'Select the prompt file to run (hold {0}-key to use in new chat)',
 			UILabelProvider.modifierLabels[OS].ctrlKey
 		);
 
-		const result = await pickers.selectPromptFile({ promptFiles, placeholder });
+		const result = await pickers.selectPromptFile({ promptFiles, placeholder, type: PromptsType.prompt });
 
 		if (result === undefined) {
 			return;

--- a/src/vs/workbench/contrib/chat/browser/actions/promptActions/index.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/promptActions/index.ts
@@ -6,6 +6,7 @@
 import { registerRunPromptActions } from './chatRunPromptAction.js';
 import { registerSaveToPromptActions } from './chatSaveToPromptAction.js';
 import { registerAttachPromptActions } from './chatAttachInstructionsAction.js';
+import { registerChatModeActions } from './chatModeActions.js';
 
 /**
  * Helper to register all actions related to reusable prompt files.
@@ -14,4 +15,5 @@ export const registerPromptActions = () => {
 	registerRunPromptActions();
 	registerAttachPromptActions();
 	registerSaveToPromptActions();
+	registerChatModeActions();
 };

--- a/src/vs/workbench/contrib/chat/browser/attachments/promptInstructions/promptInstructionsWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/attachments/promptInstructions/promptInstructionsWidget.ts
@@ -20,7 +20,7 @@ import { IHoverService } from '../../../../../../platform/hover/browser/hover.js
 import { ILanguageService } from '../../../../../../editor/common/languages/language.js';
 import { FileKind, IFileService } from '../../../../../../platform/files/common/files.js';
 import { IMenuService, MenuId } from '../../../../../../platform/actions/common/actions.js';
-import { getCleanPromptName } from '../../../../../../platform/prompts/common/constants.js';
+import { getCleanPromptName } from '../../../../../../platform/prompts/common/prompts.js';
 import { ObservableDisposable } from '../../../../../../base/common/observableDisposable.js';
 import { IContextKeyService } from '../../../../../../platform/contextkey/common/contextkey.js';
 import { ChatPromptAttachmentModel } from '../../chatAttachmentModel/chatPromptAttachmentModel.js';

--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -20,7 +20,7 @@ import { InstantiationType, registerSingleton } from '../../../../platform/insta
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { mcpGalleryServiceUrlConfig } from '../../../../platform/mcp/common/mcpManagement.js';
 import { PromptsConfig } from '../../../../platform/prompts/common/config.js';
-import { INSTRUCTIONS_DEFAULT_SOURCE_FOLDER, INSTRUCTION_FILE_EXTENSION, PROMPT_DEFAULT_SOURCE_FOLDER, PROMPT_FILE_EXTENSION } from '../../../../platform/prompts/common/constants.js';
+import { INSTRUCTIONS_DEFAULT_SOURCE_FOLDER, INSTRUCTION_FILE_EXTENSION, MODE_DEFAULT_SOURCE_FOLDER, MODE_FILE_EXTENSION, PROMPT_DEFAULT_SOURCE_FOLDER, PROMPT_FILE_EXTENSION } from '../../../../platform/prompts/common/prompts.js';
 import { Registry } from '../../../../platform/registry/common/platform.js';
 import { EditorPaneDescriptor, IEditorPaneRegistry } from '../../../browser/editor.js';
 import { Extensions, IConfigurationMigrationRegistry } from '../../../common/configuration.js';
@@ -47,7 +47,7 @@ import { ILanguageModelIgnoredFilesService, LanguageModelIgnoredFilesService } f
 import { ILanguageModelsService, LanguageModelsService } from '../common/languageModels.js';
 import { ILanguageModelStatsService, LanguageModelStatsService } from '../common/languageModelStats.js';
 import { ILanguageModelToolsService } from '../common/languageModelToolsService.js';
-import { INSTRUCTIONS_DOCUMENTATION_URL, PROMPT_DOCUMENTATION_URL } from '../common/promptSyntax/constants.js';
+import { INSTRUCTIONS_DOCUMENTATION_URL, MODE_DOCUMENTATION_URL, PROMPT_DOCUMENTATION_URL } from '../common/promptSyntax/constants.js';
 import { registerPromptFileContributions } from '../common/promptSyntax/contributions/index.js';
 import { PromptsService } from '../common/promptSyntax/service/promptsService.js';
 import { IPromptsService } from '../common/promptSyntax/service/types.js';
@@ -398,6 +398,35 @@ configurationRegistry.registerConfiguration({
 				{
 					[PROMPT_DEFAULT_SOURCE_FOLDER]: true,
 					'/Users/vscode/repos/prompts': true,
+				},
+			],
+		},
+		[PromptsConfig.MODE_LOCATION_KEY]: {
+			type: 'object',
+			title: nls.localize(
+				'chat.mode.config.locations.title',
+				"Mode File Locations",
+			),
+			markdownDescription: nls.localize(
+				'chat.mode.config.locations.description',
+				"Specify location(s) of custom chat mode files (`*{0}`). [Learn More]({1}).\n\nRelative paths are resolved from the root folder(s) of your workspace.",
+				MODE_FILE_EXTENSION,
+				MODE_DOCUMENTATION_URL,
+			),
+			default: {
+				[MODE_DEFAULT_SOURCE_FOLDER]: true,
+			},
+			additionalProperties: { type: 'boolean' },
+			unevaluatedProperties: { type: 'boolean' },
+			restricted: true,
+			tags: ['experimental', 'prompts', 'reusable prompts', 'prompt snippets', 'instructions'],
+			examples: [
+				{
+					[MODE_DEFAULT_SOURCE_FOLDER]: true,
+				},
+				{
+					[MODE_DEFAULT_SOURCE_FOLDER]: true,
+					'/Users/vscode/repos/chatmodes': true,
 				},
 			],
 		},

--- a/src/vs/workbench/contrib/chat/browser/promptSyntax/contributions/createPromptCommand/dialogs/askForPromptName.ts
+++ b/src/vs/workbench/contrib/chat/browser/promptSyntax/contributions/createPromptCommand/dialogs/askForPromptName.ts
@@ -4,8 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { localize } from '../../../../../../../../nls.js';
-import { TPromptsType } from '../../../../../common/promptSyntax/service/types.js';
-import { getPromptFileExtension } from '../../../../../../../../platform/prompts/common/constants.js';
+import { getPromptFileExtension, PromptsType } from '../../../../../../../../platform/prompts/common/prompts.js';
 import { IQuickInputService } from '../../../../../../../../platform/quickinput/common/quickInput.js';
 import { URI } from '../../../../../../../../base/common/uri.js';
 import { IFileService } from '../../../../../../../../platform/files/common/files.js';
@@ -18,16 +17,11 @@ import { ServicesAccessor } from '../../../../../../../../editor/browser/editorE
  */
 export async function askForPromptFileName(
 	accessor: ServicesAccessor,
-	type: TPromptsType,
+	type: PromptsType,
 	selectedFolder: URI
 ): Promise<string | undefined> {
 	const quickInputService = accessor.get(IQuickInputService);
 	const fileService = accessor.get(IFileService);
-
-	const placeHolder = (type === 'instructions')
-		? localize('askForInstructionsFileName.placeholder', "Enter the name of the instructions file")
-		: localize('askForPromptFileName.placeholder', "Enter the name of the prompt file");
-
 
 	const sanitizeInput = (input: string) => {
 		const trimmedName = input.trim();
@@ -68,10 +62,24 @@ export async function askForPromptFileName(
 		return undefined;
 	};
 
-	const result = await quickInputService.input({ placeHolder, validateInput });
+	const result = await quickInputService.input({ placeHolder: getPlaceholderString(type), validateInput });
 	if (!result) {
 		return undefined;
 	}
 
 	return sanitizeInput(result);
 }
+
+function getPlaceholderString(type: PromptsType): string {
+	switch (type) {
+		case PromptsType.instructions:
+			return localize('askForInstructionsFileName.placeholder', "Enter the name of the instructions file");
+		case PromptsType.prompt:
+			return localize('askForPromptFileName.placeholder', "Enter the name of the prompt file");
+		case PromptsType.mode:
+			return localize('askForModeFileName.placeholder', "Enter the name of the custom chat mode file");
+		default:
+			throw new Error('Unknown prompt type');
+	}
+}
+

--- a/src/vs/workbench/contrib/chat/browser/promptSyntax/contributions/createPromptCommand/dialogs/askForPromptSourceFolder.ts
+++ b/src/vs/workbench/contrib/chat/browser/promptSyntax/contributions/createPromptCommand/dialogs/askForPromptSourceFolder.ts
@@ -11,9 +11,10 @@ import { ILabelService } from '../../../../../../../../platform/label/common/lab
 import { IOpenerService } from '../../../../../../../../platform/opener/common/opener.js';
 import { PROMPT_DOCUMENTATION_URL } from '../../../../../common/promptSyntax/constants.js';
 import { IWorkspaceContextService } from '../../../../../../../../platform/workspace/common/workspace.js';
-import { IPromptPath, IPromptsService, TPromptsType } from '../../../../../common/promptSyntax/service/types.js';
+import { IPromptPath, IPromptsService } from '../../../../../common/promptSyntax/service/types.js';
 import { IPickOptions, IQuickInputService, IQuickPickItem } from '../../../../../../../../platform/quickinput/common/quickInput.js';
 import { ServicesAccessor } from '../../../../../../../../platform/instantiation/common/instantiation.js';
+import { PromptsType } from '../../../../../../../../platform/prompts/common/prompts.js';
 
 interface IFolderQuickPickItem extends IQuickPickItem {
 	readonly folder: IPromptPath;
@@ -25,8 +26,7 @@ interface IFolderQuickPickItem extends IQuickPickItem {
  */
 export async function askForPromptSourceFolder(
 	accessor: ServicesAccessor,
-	type: TPromptsType,
-	placeHolder: string
+	type: PromptsType
 ): Promise<IPromptPath | undefined> {
 	const quickInputService = accessor.get(IQuickInputService);
 	const promptsService = accessor.get(IPromptsService);
@@ -40,7 +40,7 @@ export async function askForPromptSourceFolder(
 	// note! this is a temporary solution and must be replaced with a dialog to select
 	//       a custom folder path, or switch to a different prompt type
 	if (folders.length === 0) {
-		await showNoFoldersDialog(accessor);
+		await showNoFoldersDialog(accessor, type);
 		return;
 	}
 
@@ -51,7 +51,7 @@ export async function askForPromptSourceFolder(
 	}
 
 	const pickOptions: IPickOptions<IFolderQuickPickItem> = {
-		placeHolder,
+		placeHolder: getPlaceholderString(type),
 		canPickMany: false,
 		matchOnDescription: true,
 	};
@@ -112,22 +112,32 @@ export async function askForPromptSourceFolder(
 	return answer.folder;
 }
 
+function getPlaceholderString(type: PromptsType): string {
+	switch (type) {
+		case PromptsType.instructions:
+			return localize('workbench.command.instructions.create.location.placeholder', "Select a location to create the instructions file in...");
+		case PromptsType.prompt:
+			return localize('workbench.command.prompt.create.location.placeholder', "Select a location to create the prompt file in...");
+		case PromptsType.mode:
+			return localize('workbench.command.mode.create.location.placeholder', "Select a location to create the mode file in...");
+		default:
+			throw new Error('Unknown prompt type');
+	}
+}
+
 /**
  * Shows a dialog to the user when no prompt source folders are found.
  *
  * Note! this is a temporary solution and must be replaced with a dialog to select
  *       a custom folder path, or switch to a different prompt type
  */
-async function showNoFoldersDialog(accessor: ServicesAccessor): Promise<void> {
+async function showNoFoldersDialog(accessor: ServicesAccessor, type: PromptsType): Promise<void> {
 	const quickInputService = accessor.get(IQuickInputService);
 	const openerService = accessor.get(IOpenerService);
 
 	const docsQuickPick: WithUriValue<IQuickPickItem> = {
 		type: 'item',
-		label: localize(
-			'commands.prompts.create.ask-folder.empty.docs-label',
-			'Learn how to configure reusable prompts',
-		),
+		label: getLearnLabel(type),
 		description: PROMPT_DOCUMENTATION_URL,
 		tooltip: PROMPT_DOCUMENTATION_URL,
 		value: URI.parse(PROMPT_DOCUMENTATION_URL),
@@ -136,14 +146,37 @@ async function showNoFoldersDialog(accessor: ServicesAccessor): Promise<void> {
 	const result = await quickInputService.pick(
 		[docsQuickPick],
 		{
-			placeHolder: localize(
-				'commands.prompts.create.ask-folder.empty.placeholder',
-				'No prompt source folders found.',
-			),
+			placeHolder: getMissingSourceFolderString(type),
 			canPickMany: false,
 		});
 
 	if (result) {
 		await openerService.open(result.value);
+	}
+}
+
+function getLearnLabel(type: PromptsType): string {
+	switch (type) {
+		case PromptsType.prompt:
+			return localize('commands.prompts.create.ask-folder.empty.docs-label', 'Learn how to configure reusable prompts');
+		case PromptsType.instructions:
+			return localize('commands.instructions.create.ask-folder.empty.docs-label', 'Learn how to configure reusable instructions');
+		case PromptsType.mode:
+			return localize('commands.mode.create.ask-folder.empty.docs-label', 'Learn how to configure custom chat modes');
+		default:
+			throw new Error('Unknown prompt type');
+	}
+}
+
+function getMissingSourceFolderString(type: PromptsType): string {
+	switch (type) {
+		case PromptsType.instructions:
+			return localize('commands.instructions.create.ask-folder.empty.placeholder', 'No instruction source folders found.');
+		case PromptsType.prompt:
+			return localize('commands.prompts.create.ask-folder.empty.placeholder', 'No prompt source folders found.');
+		case PromptsType.mode:
+			return localize('commands.mode.create.ask-folder.empty.placeholder', 'No custom chat mode source folders found.');
+		default:
+			throw new Error('Unknown prompt type');
 	}
 }

--- a/src/vs/workbench/contrib/chat/browser/promptSyntax/contributions/createPromptCommand/utils/createPromptFile.ts
+++ b/src/vs/workbench/contrib/chat/browser/promptSyntax/contributions/createPromptCommand/utils/createPromptFile.ts
@@ -9,7 +9,7 @@ import { assert } from '../../../../../../../../base/common/assert.js';
 import { VSBuffer } from '../../../../../../../../base/common/buffer.js';
 import { dirname } from '../../../../../../../../base/common/resources.js';
 import { IFileService } from '../../../../../../../../platform/files/common/files.js';
-import { isPromptOrInstructionsFile, PROMPT_FILE_EXTENSION } from '../../../../../../../../platform/prompts/common/constants.js';
+import { isPromptOrInstructionsFile, PROMPT_FILE_EXTENSION } from '../../../../../../../../platform/prompts/common/prompts.js';
 
 /**
  * Options for the {@link createPromptFile} utility.

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/constants.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/constants.ts
@@ -4,12 +4,14 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { LanguageSelector } from '../../../../../editor/common/languageSelector.js';
+import { PromptsType } from '../../../../../platform/prompts/common/prompts.js';
 
 /**
  * Documentation link for the reusable prompts feature.
  */
 export const PROMPT_DOCUMENTATION_URL = 'https://aka.ms/vscode-ghcp-prompt-snippets';
 export const INSTRUCTIONS_DOCUMENTATION_URL = 'https://aka.ms/vscode-ghcp-custom-instructions';
+export const MODE_DOCUMENTATION_URL = 'https://aka.ms/vscode-ghcp-custom-chat-modes'; // todo
 
 /**
  * Language ID for the reusable prompt syntax.
@@ -22,6 +24,27 @@ export const PROMPT_LANGUAGE_ID = 'prompt';
 export const INSTRUCTIONS_LANGUAGE_ID = 'instructions';
 
 /**
+ * Language ID for modes syntax.
+ */
+export const MODE_LANGUAGE_ID = 'chatmode';
+
+/**
  * Prompt and instructions files language selector.
  */
-export const PROMPT_AND_INSTRUCTIONS_LANGUAGE_SELECTOR: LanguageSelector = [PROMPT_LANGUAGE_ID, INSTRUCTIONS_LANGUAGE_ID];
+export const ALL_PROMPTS_LANGUAGE_SELECTOR: LanguageSelector = [PROMPT_LANGUAGE_ID, INSTRUCTIONS_LANGUAGE_ID, MODE_LANGUAGE_ID];
+
+/**
+ * The language id for for a prompts type.
+ */
+export function getLanguageIdForPromptsType(type: PromptsType): string {
+	switch (type) {
+		case PromptsType.prompt:
+			return PROMPT_LANGUAGE_ID;
+		case PromptsType.instructions:
+			return INSTRUCTIONS_LANGUAGE_ID;
+		case PromptsType.mode:
+			return MODE_LANGUAGE_ID;
+		default:
+			throw new Error(`Unknown prompt type: ${type}`);
+	}
+}

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/contentProviders/filePromptContentsProvider.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/contentProviders/filePromptContentsProvider.ts
@@ -13,7 +13,7 @@ import { CancellationToken } from '../../../../../../base/common/cancellation.js
 import { IModelService } from '../../../../../../editor/common/services/model.js';
 import { ILanguageService } from '../../../../../../editor/common/languages/language.js';
 import { IPromptContentsProviderOptions, PromptContentsProviderBase } from './promptContentsProviderBase.js';
-import { isPromptOrInstructionsFile } from '../../../../../../platform/prompts/common/constants.js';
+import { isPromptOrInstructionsFile } from '../../../../../../platform/prompts/common/prompts.js';
 import { OpenFailed, NotPromptFile, ResolveError, FolderReference } from '../../promptFileReferenceErrors.js';
 import { FileChangesEvent, FileChangeType, IFileService } from '../../../../../../platform/files/common/files.js';
 

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/contributions/configMigration.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/contributions/configMigration.ts
@@ -8,7 +8,7 @@ import { ILogService } from '../../../../../../platform/log/common/log.js';
 import { asBoolean } from '../../../../../../platform/prompts/common/config.js';
 import { IWorkbenchContribution } from '../../../../../common/contributions.js';
 import { IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
-import { CONFIG_KEY, PROMPT_LOCATIONS_CONFIG_KEY } from '../../../../../../platform/prompts/common/constants.js';
+import { CONFIG_KEY, PROMPT_LOCATIONS_CONFIG_KEY } from '../../../../../../platform/prompts/common/prompts.js';
 
 /**
  * Contribution that migrates the old config setting value to a new one.

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/contributions/languageFeatures/providers/promptLinkProvider.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/contributions/languageFeatures/providers/promptLinkProvider.ts
@@ -9,7 +9,7 @@ import { ITextModel } from '../../../../../../../../editor/common/model.js';
 import { assertDefined } from '../../../../../../../../base/common/types.js';
 import { Disposable } from '../../../../../../../../base/common/lifecycle.js';
 import { CancellationError } from '../../../../../../../../base/common/errors.js';
-import { PROMPT_AND_INSTRUCTIONS_LANGUAGE_SELECTOR } from '../../../constants.js';
+import { ALL_PROMPTS_LANGUAGE_SELECTOR } from '../../../constants.js';
 import { CancellationToken } from '../../../../../../../../base/common/cancellation.js';
 import { FolderReference, NotPromptFile } from '../../../../promptFileReferenceErrors.js';
 import { ILink, ILinksList, LinkProvider } from '../../../../../../../../editor/common/languages.js';
@@ -25,7 +25,7 @@ export class PromptLinkProvider extends Disposable implements LinkProvider {
 	) {
 		super();
 
-		this._register(this.languageService.linkProvider.register(PROMPT_AND_INSTRUCTIONS_LANGUAGE_SELECTOR, this));
+		this._register(this.languageService.linkProvider.register(ALL_PROMPTS_LANGUAGE_SELECTOR, this));
 	}
 
 	/**

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/contributions/languageFeatures/providers/promptPathAutocompletion.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/contributions/languageFeatures/providers/promptPathAutocompletion.ts
@@ -21,7 +21,7 @@ import { extUri } from '../../../../../../../../base/common/resources.js';
 import { ITextModel } from '../../../../../../../../editor/common/model.js';
 import { Disposable } from '../../../../../../../../base/common/lifecycle.js';
 import { CancellationError } from '../../../../../../../../base/common/errors.js';
-import { PROMPT_AND_INSTRUCTIONS_LANGUAGE_SELECTOR } from '../../../constants.js';
+import { ALL_PROMPTS_LANGUAGE_SELECTOR } from '../../../constants.js';
 import { Position } from '../../../../../../../../editor/common/core/position.js';
 import { IPromptFileReference, TPromptReference } from '../../../parsers/types.js';
 import { assert, assertNever } from '../../../../../../../../base/common/assert.js';
@@ -102,7 +102,7 @@ export class PromptPathAutocompletion extends Disposable implements CompletionIt
 	) {
 		super();
 
-		this._register(this.languageService.completionProvider.register(PROMPT_AND_INSTRUCTIONS_LANGUAGE_SELECTOR, this));
+		this._register(this.languageService.completionProvider.register(ALL_PROMPTS_LANGUAGE_SELECTOR, this));
 	}
 
 	/**

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/basePromptParser.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/basePromptParser.ts
@@ -27,7 +27,7 @@ import { VSBufferReadableStream } from '../../../../../../base/common/buffer.js'
 import { ObservableDisposable } from '../../../../../../base/common/observableDisposable.js';
 import type { IPromptMetadata, TPromptReference, IResolveError, ITopError } from './types.js';
 import { IWorkspaceContextService } from '../../../../../../platform/workspace/common/workspace.js';
-import { isPromptOrInstructionsFile } from '../../../../../../platform/prompts/common/constants.js';
+import { isPromptOrInstructionsFile } from '../../../../../../platform/prompts/common/prompts.js';
 import { IInstantiationService } from '../../../../../../platform/instantiation/common/instantiation.js';
 import { MarkdownLink } from '../../../../../../editor/common/codecs/markdownCodec/tokens/markdownLink.js';
 import { MarkdownToken } from '../../../../../../editor/common/codecs/markdownCodec/tokens/markdownToken.js';

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/promptParser.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/promptParser.ts
@@ -9,7 +9,7 @@ import { IPromptContentsProvider } from '../contentProviders/types.js';
 import { ILogService } from '../../../../../../platform/log/common/log.js';
 import { BasePromptParser, IPromptParserOptions } from './basePromptParser.js';
 import { IModelService } from '../../../../../../editor/common/services/model.js';
-import { isUntitled } from '../../../../../../platform/prompts/common/constants.js';
+import { isUntitled } from '../../../../../../platform/prompts/common/prompts.js';
 import { TextModelContentsProvider } from '../contentProviders/textModelContentsProvider.js';
 import { FilePromptContentProvider } from '../contentProviders/filePromptContentsProvider.js';
 import { IWorkspaceContextService } from '../../../../../../platform/workspace/common/workspace.js';

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/service/types.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/service/types.ts
@@ -11,6 +11,8 @@ import { ITextModel } from '../../../../../../editor/common/model.js';
 import { IDisposable } from '../../../../../../base/common/lifecycle.js';
 import { TextModelPromptParser } from '../parsers/textModelPromptParser.js';
 import { createDecorator } from '../../../../../../platform/instantiation/common/instantiation.js';
+import { PromptsType } from '../../../../../../platform/prompts/common/prompts.js';
+import { Event } from '../../../../../../base/common/event.js';
 
 /**
  * Provides prompt services.
@@ -21,11 +23,6 @@ export const IPromptsService = createDecorator<IPromptsService>('IPromptsService
  * Where the prompt is stored.
  */
 export type TPromptsStorage = 'local' | 'user';
-
-/**
- * What the prompt is used for.
- */
-export type TPromptsType = 'instructions' | 'prompt';
 
 /**
  * Represents a prompt path with its type.
@@ -45,7 +42,7 @@ export interface IPromptPath {
 	/**
 	 * Type of the prompt (e.g. 'prompt' or 'instructions').
 	 */
-	readonly type: TPromptsType;
+	readonly type: PromptsType;
 }
 
 /**
@@ -74,6 +71,28 @@ export interface IMetadata {
 	 */
 	readonly children?: readonly TTree<IMetadata>[];
 }
+
+export interface ICustomChatMode {
+	/**
+	 * URI of a custom chat mode file.
+	 */
+	readonly uri: URI;
+
+	/**
+	 * Name of the custom chat mode.
+	 */
+	readonly name: string;
+	/**
+	 * Description of the mode
+	 */
+	readonly description?: string;
+
+	/**
+	 * Tools metadata in the prompt header.
+	 */
+	readonly tools?: readonly string[];
+}
+
 
 /**
  * Type of combined tools metadata for the case
@@ -133,12 +152,12 @@ export interface IPromptsService extends IDisposable {
 	/**
 	 * List all available prompt files.
 	 */
-	listPromptFiles(type: TPromptsType): Promise<readonly IPromptPath[]>;
+	listPromptFiles(type: PromptsType): Promise<readonly IPromptPath[]>;
 
 	/**
 	 * Get a list of prompt source folders based on the provided prompt type.
 	 */
-	getSourceFolders(type: TPromptsType): readonly IPromptPath[];
+	getSourceFolders(type: PromptsType): readonly IPromptPath[];
 
 	/**
 	 * Returns a prompt command if the command name.
@@ -163,6 +182,16 @@ export interface IPromptsService extends IDisposable {
 	findInstructionFilesFor(
 		fileUris: readonly URI[],
 	): Promise<readonly URI[]>;
+
+	/**
+	 * Event that is triggered when the list of custom chat modes changes.
+	 */
+	readonly onDidChangeCustomChatModes: Event<void>;
+
+	/**
+	 * Finds all available custom chat modes
+	 */
+	getCustomChatModes(): Promise<readonly ICustomChatMode[]>;
 
 	/**
 	 * Gets the metadata for the given prompt file uri.

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/utils/promptFilesLocator.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/utils/promptFilesLocator.ts
@@ -3,7 +3,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { TPromptsType } from '../service/types.js';
 import { URI } from '../../../../../../base/common/uri.js';
 import { match } from '../../../../../../base/common/glob.js';
 import { assert } from '../../../../../../base/common/assert.js';
@@ -14,12 +13,13 @@ import { PromptsConfig } from '../../../../../../platform/prompts/common/config.
 import { basename, dirname, extUri } from '../../../../../../base/common/resources.js';
 import { IWorkspaceContextService } from '../../../../../../platform/workspace/common/workspace.js';
 import { IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
-import { getPromptFileType, PROMPT_FILE_EXTENSION } from '../../../../../../platform/prompts/common/constants.js';
+import { getPromptFileType, PROMPT_FILE_EXTENSION, PromptsType } from '../../../../../../platform/prompts/common/prompts.js';
 
 /**
  * Utility class to locate prompt files.
  */
 export class PromptFilesLocator {
+
 	constructor(
 		@IFileService private readonly fileService: IFileService,
 		@IConfigurationService private readonly configService: IConfigurationService,
@@ -31,7 +31,7 @@ export class PromptFilesLocator {
 	 *
 	 * @returns List of prompt files found in the workspace.
 	 */
-	public async listFiles(type: TPromptsType): Promise<readonly URI[]> {
+	public async listFiles(type: PromptsType): Promise<readonly URI[]> {
 		const configuredLocations = PromptsConfig.promptSourceFolders(this.configService, type);
 		const absoluteLocations = toAbsoluteLocations(configuredLocations, this.workspaceService);
 
@@ -48,7 +48,7 @@ export class PromptFilesLocator {
 	 */
 	public async listFilesIn(
 		folders: readonly URI[],
-		type: TPromptsType,
+		type: PromptsType,
 	): Promise<readonly URI[]> {
 		return await this.findFilesInLocations(folders, type);
 	}
@@ -65,7 +65,7 @@ export class PromptFilesLocator {
 	 *
 	 * @returns List of possible unambiguous prompt file folders.
 	 */
-	public getConfigBasedSourceFolders(type: TPromptsType): readonly URI[] {
+	public getConfigBasedSourceFolders(type: PromptsType): readonly URI[] {
 		const configuredLocations = PromptsConfig.promptSourceFolders(this.configService, type);
 		const absoluteLocations = toAbsoluteLocations(configuredLocations, this.workspaceService);
 
@@ -116,7 +116,7 @@ export class PromptFilesLocator {
 	 */
 	private async findFilesInLocations(
 		absoluteLocations: readonly URI[],
-		type: TPromptsType,
+		type: PromptsType,
 	): Promise<readonly URI[]> {
 
 		// find all prompt files in the provided locations, then match
@@ -279,7 +279,7 @@ export const firstNonGlobParent = (
  */
 const findFilesInLocation = async (
 	location: URI,
-	type: TPromptsType,
+	type: PromptsType,
 	fileService: IFileService,
 ): Promise<readonly URI[]> => {
 	const result: URI[] = [];

--- a/src/vs/workbench/contrib/chat/test/common/mockPromptsService.ts
+++ b/src/vs/workbench/contrib/chat/test/common/mockPromptsService.ts
@@ -3,12 +3,15 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { Event } from '../../../../../base/common/event.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { ITextModel } from '../../../../../editor/common/model.js';
+import { PromptsType } from '../../../../../platform/prompts/common/prompts.js';
 import { TextModelPromptParser } from '../../common/promptSyntax/parsers/textModelPromptParser.js';
-import { IChatPromptSlashCommand, IMetadata, IPromptPath, IPromptsService, TPromptsType } from '../../common/promptSyntax/service/types.js';
+import { IChatPromptSlashCommand, ICustomChatMode, IMetadata, IPromptPath, IPromptsService } from '../../common/promptSyntax/service/types.js';
 
 export class MockPromptsService implements IPromptsService {
+
 	_serviceBrand: undefined;
 
 	getAllMetadata(_files: readonly URI[]): Promise<readonly IMetadata[]> {
@@ -20,13 +23,13 @@ export class MockPromptsService implements IPromptsService {
 	getSyntaxParserFor(_model: ITextModel): TextModelPromptParser & { isDisposed: false } {
 		throw new Error('Method not implemented.');
 	}
-	listPromptFiles(_type: TPromptsType): Promise<readonly IPromptPath[]> {
+	listPromptFiles(_type: PromptsType): Promise<readonly IPromptPath[]> {
 		throw new Error('Method not implemented.');
 	}
-	getSourceFolders(_type: TPromptsType): readonly IPromptPath[] {
+	getSourceFolders(_type: PromptsType): readonly IPromptPath[] {
 		throw new Error('Method not implemented.');
 	}
-	public asPromptSlashCommand(command: string): IChatPromptSlashCommand | undefined {
+	asPromptSlashCommand(command: string): IChatPromptSlashCommand | undefined {
 		return undefined;
 	}
 	resolvePromptSlashCommand(_data: IChatPromptSlashCommand): Promise<IMetadata | undefined> {
@@ -36,6 +39,10 @@ export class MockPromptsService implements IPromptsService {
 		throw new Error('Method not implemented.');
 	}
 	findInstructionFilesFor(_files: readonly URI[]): Promise<readonly URI[]> {
+		throw new Error('Method not implemented.');
+	}
+	onDidChangeCustomChatModes: Event<void> = Event.None;
+	getCustomChatModes(): Promise<readonly ICustomChatMode[]> {
 		throw new Error('Method not implemented.');
 	}
 	dispose(): void { }

--- a/src/vs/workbench/contrib/chat/test/common/promptSyntax/promptFileReference.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/promptSyntax/promptFileReference.test.ts
@@ -24,12 +24,11 @@ import { waitRandom, randomBoolean } from '../../../../../../base/test/common/te
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
 import { IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
 import { IInstantiationService } from '../../../../../../platform/instantiation/common/instantiation.js';
-import { INSTRUCTIONS_LANGUAGE_ID, PROMPT_LANGUAGE_ID } from '../../../common/promptSyntax/constants.js';
 import { MarkdownLink } from '../../../../../../editor/common/codecs/markdownCodec/tokens/markdownLink.js';
 import { ConfigurationService } from '../../../../../../platform/configuration/common/configurationService.js';
 import { IPromptParserOptions, TErrorCondition } from '../../../common/promptSyntax/parsers/basePromptParser.js';
 import { InMemoryFileSystemProvider } from '../../../../../../platform/files/common/inMemoryFilesystemProvider.js';
-import { INSTRUCTION_FILE_EXTENSION, PROMPT_FILE_EXTENSION } from '../../../../../../platform/prompts/common/constants.js';
+import { getPromptFileType } from '../../../../../../platform/prompts/common/prompts.js';
 import { TestInstantiationService } from '../../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
 import { NotPromptFile, RecursiveReference, OpenFailed, FolderReference } from '../../../common/promptFileReferenceErrors.js';
 
@@ -237,15 +236,7 @@ suite('PromptFileReference', function () {
 		instantiationService.stub(IModelService, { getModel() { return null; } });
 		instantiationService.stub(ILanguageService, {
 			guessLanguageIdByFilepathOrFirstLine(uri: URI) {
-				if (uri.path.endsWith(PROMPT_FILE_EXTENSION)) {
-					return PROMPT_LANGUAGE_ID;
-				}
-
-				if (uri.path.endsWith(INSTRUCTION_FILE_EXTENSION)) {
-					return INSTRUCTIONS_LANGUAGE_ID;
-				}
-
-				return null;
+				return getPromptFileType(uri) ?? null;
 			}
 		});
 	});

--- a/src/vs/workbench/contrib/chat/test/common/promptSyntax/service/promptsService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/promptSyntax/service/promptsService.test.ts
@@ -26,7 +26,7 @@ import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../../ba
 import { IConfigurationService } from '../../../../../../../platform/configuration/common/configuration.js';
 import { INSTRUCTIONS_LANGUAGE_ID, PROMPT_LANGUAGE_ID } from '../../../../common/promptSyntax/constants.js';
 import { InMemoryFileSystemProvider } from '../../../../../../../platform/files/common/inMemoryFilesystemProvider.js';
-import { INSTRUCTION_FILE_EXTENSION, PROMPT_FILE_EXTENSION } from '../../../../../../../platform/prompts/common/constants.js';
+import { INSTRUCTION_FILE_EXTENSION, PROMPT_FILE_EXTENSION, PromptsType } from '../../../../../../../platform/prompts/common/prompts.js';
 import { TestInstantiationService } from '../../../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
 import { TestConfigurationService } from '../../../../../../../platform/configuration/test/common/testConfigurationService.js';
 
@@ -721,33 +721,33 @@ suite('PromptsService', () => {
 					{
 						uri: URI.joinPath(rootFolderUri, '.github/prompts/file1.instructions.md'),
 						storage: 'local',
-						type: 'instructions',
+						type: PromptsType.instructions,
 					},
 					{
 						uri: URI.joinPath(rootFolderUri, '.github/prompts/file2.instructions.md'),
 						storage: 'local',
-						type: 'instructions',
+						type: PromptsType.instructions,
 					},
 					{
 						uri: URI.joinPath(rootFolderUri, '.github/prompts/file3.instructions.md'),
 						storage: 'local',
-						type: 'instructions',
+						type: PromptsType.instructions,
 					},
 					{
 						uri: URI.joinPath(rootFolderUri, '.github/prompts/file4.instructions.md'),
 						storage: 'local',
-						type: 'instructions',
+						type: PromptsType.instructions,
 					},
 					// user instructions
 					{
 						uri: URI.joinPath(userPromptsFolderUri, 'file10.instructions.md'),
 						storage: 'user',
-						type: 'instructions',
+						type: PromptsType.instructions,
 					},
 					{
 						uri: URI.joinPath(userPromptsFolderUri, 'file11.instructions.md'),
 						storage: 'user',
-						type: 'instructions',
+						type: PromptsType.instructions,
 					},
 				]));
 
@@ -900,33 +900,33 @@ suite('PromptsService', () => {
 					{
 						uri: URI.joinPath(rootFolderUri, '.github/prompts/file1.instructions.md'),
 						storage: 'local',
-						type: 'instructions',
+						type: PromptsType.instructions,
 					},
 					{
 						uri: URI.joinPath(rootFolderUri, '.github/prompts/file2.instructions.md'),
 						storage: 'local',
-						type: 'instructions',
+						type: PromptsType.instructions,
 					},
 					{
 						uri: URI.joinPath(rootFolderUri, '.github/prompts/file3.instructions.md'),
 						storage: 'local',
-						type: 'instructions',
+						type: PromptsType.instructions,
 					},
 					{
 						uri: URI.joinPath(rootFolderUri, '.github/prompts/file4.instructions.md'),
 						storage: 'local',
-						type: 'instructions',
+						type: PromptsType.instructions,
 					},
 					// user instructions
 					{
 						uri: URI.joinPath(userPromptsFolderUri, 'file10.instructions.md'),
 						storage: 'user',
-						type: 'instructions',
+						type: PromptsType.instructions,
 					},
 					{
 						uri: URI.joinPath(userPromptsFolderUri, 'file11.instructions.md'),
 						storage: 'user',
-						type: 'instructions',
+						type: PromptsType.instructions,
 					},
 				]));
 

--- a/src/vs/workbench/contrib/chat/test/common/promptSyntax/utils/promptFilesLocator.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/promptSyntax/utils/promptFilesLocator.test.ts
@@ -21,6 +21,7 @@ import { InMemoryFileSystemProvider } from '../../../../../../../platform/files/
 import { TestInstantiationService } from '../../../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
 import { IConfigurationOverrides, IConfigurationService } from '../../../../../../../platform/configuration/common/configuration.js';
 import { IWorkspace, IWorkspaceContextService, IWorkspaceFolder } from '../../../../../../../platform/workspace/common/workspace.js';
+import { PromptsType } from '../../../../../../../platform/prompts/common/prompts.js';
 
 /**
  * Mocked instance of {@link IConfigurationService}.
@@ -34,7 +35,7 @@ const mockConfigService = <T>(value: T): IConfigurationService => {
 			);
 
 			assert(
-				[PromptsConfig.KEY, PromptsConfig.PROMPT_LOCATIONS_KEY].includes(key),
+				[PromptsConfig.KEY, PromptsConfig.PROMPT_LOCATIONS_KEY, PromptsConfig.INSTRUCTIONS_LOCATION_KEY, PromptsConfig.MODE_LOCATION_KEY].includes(key),
 				`Unsupported configuration key '${key}'.`,
 			);
 
@@ -110,7 +111,7 @@ suite('PromptFilesLocator', () => {
 				const locator = await createPromptsLocator(undefined, EMPTY_WORKSPACE, []);
 
 				assert.deepStrictEqual(
-					(await locator.listFiles('prompt'))
+					(await locator.listFiles(PromptsType.prompt))
 						.map((file) => file.fsPath),
 					[],
 					'No prompts must be found.',
@@ -124,7 +125,7 @@ suite('PromptFilesLocator', () => {
 				}, EMPTY_WORKSPACE, []);
 
 				assert.deepStrictEqual(
-					await locator.listFiles('prompt'),
+					await locator.listFiles(PromptsType.prompt),
 					[],
 					'No prompts must be found.',
 				);
@@ -137,7 +138,7 @@ suite('PromptFilesLocator', () => {
 				], EMPTY_WORKSPACE, []);
 
 				assert.deepStrictEqual(
-					await locator.listFiles('prompt'),
+					await locator.listFiles(PromptsType.prompt),
 					[],
 					'No prompts must be found.',
 				);
@@ -147,7 +148,7 @@ suite('PromptFilesLocator', () => {
 				const locator = await createPromptsLocator(null, EMPTY_WORKSPACE, []);
 
 				assert.deepStrictEqual(
-					(await locator.listFiles('prompt'))
+					(await locator.listFiles(PromptsType.prompt))
 						.map((file) => file.fsPath),
 					[],
 					'No prompts must be found.',
@@ -158,7 +159,7 @@ suite('PromptFilesLocator', () => {
 				const locator = await createPromptsLocator('/etc/hosts/prompts', EMPTY_WORKSPACE, []);
 
 				assert.deepStrictEqual(
-					(await locator.listFiles('prompt'))
+					(await locator.listFiles(PromptsType.prompt))
 						.map((file) => file.fsPath),
 					[],
 					'No prompts must be found.',
@@ -211,7 +212,7 @@ suite('PromptFilesLocator', () => {
 					]);
 
 				assert.deepStrictEqual(
-					(await locator.listFiles('prompt'))
+					(await locator.listFiles(PromptsType.prompt))
 						.map((file) => file.fsPath),
 					[
 						createURI('/Users/legomushroom/repos/prompts/test.prompt.md').path,
@@ -288,7 +289,7 @@ suite('PromptFilesLocator', () => {
 							);
 
 							assert.deepStrictEqual(
-								(await locator.listFiles('prompt'))
+								(await locator.listFiles(PromptsType.prompt))
 									.map((file) => file.fsPath),
 								[
 									createURI('/Users/legomushroom/repos/vscode/deps/text/my.prompt.md').fsPath,
@@ -448,7 +449,7 @@ suite('PromptFilesLocator', () => {
 							);
 
 							assert.deepStrictEqual(
-								(await locator.listFiles('prompt'))
+								(await locator.listFiles(PromptsType.prompt))
 									.map((file) => file.fsPath),
 								[
 									createURI('/Users/legomushroom/repos/vscode/deps/text/nested/specific.prompt.md').fsPath,
@@ -532,7 +533,7 @@ suite('PromptFilesLocator', () => {
 							);
 
 							assert.deepStrictEqual(
-								(await locator.listFiles('prompt'))
+								(await locator.listFiles(PromptsType.prompt))
 									.map((file) => file.fsPath),
 								[
 									createURI('/Users/legomushroom/repos/vscode/deps/text/my.prompt.md').fsPath,
@@ -692,7 +693,7 @@ suite('PromptFilesLocator', () => {
 							);
 
 							assert.deepStrictEqual(
-								(await locator.listFiles('prompt'))
+								(await locator.listFiles(PromptsType.prompt))
 									.map((file) => file.fsPath),
 								[
 									createURI('/Users/legomushroom/repos/vscode/deps/text/nested/specific.prompt.md').fsPath,
@@ -772,7 +773,7 @@ suite('PromptFilesLocator', () => {
 							);
 
 							assert.deepStrictEqual(
-								(await locator.listFiles('prompt'))
+								(await locator.listFiles(PromptsType.prompt))
 									.map((file) => file.fsPath),
 								[
 									createURI('/Users/legomushroom/repos/vscode/deps/text/my.prompt.md').fsPath,
@@ -932,7 +933,7 @@ suite('PromptFilesLocator', () => {
 							);
 
 							assert.deepStrictEqual(
-								(await locator.listFiles('prompt'))
+								(await locator.listFiles(PromptsType.prompt))
 									.map((file) => file.fsPath),
 								[
 									createURI('/Users/legomushroom/repos/vscode/deps/text/nested/specific.prompt.md').fsPath,
@@ -1017,7 +1018,7 @@ suite('PromptFilesLocator', () => {
 			]);
 
 		assert.deepStrictEqual(
-			(await locator.listFiles('prompt'))
+			(await locator.listFiles(PromptsType.prompt))
 				.map((file) => file.fsPath),
 			[
 				createURI('/Users/legomushroom/repos/vscode/.github/prompts/my.prompt.md').fsPath,
@@ -1104,7 +1105,7 @@ suite('PromptFilesLocator', () => {
 			]);
 
 		assert.deepStrictEqual(
-			(await locator.listFiles('prompt'))
+			(await locator.listFiles(PromptsType.prompt))
 				.map((file) => file.fsPath),
 			[
 				createURI('/Users/legomushroom/repos/prompts/test.prompt.md').path,
@@ -1225,7 +1226,7 @@ suite('PromptFilesLocator', () => {
 					]);
 
 				assert.deepStrictEqual(
-					(await locator.listFiles('prompt'))
+					(await locator.listFiles(PromptsType.prompt))
 						.map((file) => file.fsPath),
 					[
 						createURI('/Users/legomushroom/repos/vscode/.github/prompts/default.prompt.md').path,
@@ -1346,7 +1347,7 @@ suite('PromptFilesLocator', () => {
 					]);
 
 				assert.deepStrictEqual(
-					(await locator.listFiles('prompt'))
+					(await locator.listFiles(PromptsType.prompt))
 						.map((file) => file.fsPath),
 					[
 						createURI('/Users/legomushroom/repos/vscode/.github/prompts/default.prompt.md').fsPath,
@@ -1470,7 +1471,7 @@ suite('PromptFilesLocator', () => {
 					]);
 
 				assert.deepStrictEqual(
-					(await locator.listFiles('prompt'))
+					(await locator.listFiles(PromptsType.prompt))
 						.map((file) => file.fsPath),
 					[
 						createURI('/Users/legomushroom/repos/prompts/test.prompt.md').path,
@@ -1593,7 +1594,7 @@ suite('PromptFilesLocator', () => {
 					]);
 
 				assert.deepStrictEqual(
-					(await locator.listFiles('prompt'))
+					(await locator.listFiles(PromptsType.prompt))
 						.map((file) => file.fsPath),
 					[
 						// all of these are due to the `.github/prompts` setting
@@ -1708,7 +1709,7 @@ suite('PromptFilesLocator', () => {
 							);
 
 							assert.deepStrictEqual(
-								(await locator.listFiles('prompt'))
+								(await locator.listFiles(PromptsType.prompt))
 									.map((file) => file.fsPath),
 								[
 									createURI('/Users/legomushroom/repos/vscode/gen/text/my.prompt.md').fsPath,
@@ -1914,7 +1915,7 @@ suite('PromptFilesLocator', () => {
 							);
 
 							assert.deepStrictEqual(
-								(await locator.listFiles('prompt'))
+								(await locator.listFiles(PromptsType.prompt))
 									.map((file) => file.fsPath),
 								[
 									createURI('/Users/legomushroom/repos/vscode/gen/text/my.prompt.md').fsPath,
@@ -2039,7 +2040,7 @@ suite('PromptFilesLocator', () => {
 							);
 
 							assert.deepStrictEqual(
-								(await locator.listFiles('prompt'))
+								(await locator.listFiles(PromptsType.prompt))
 									.map((file) => file.fsPath),
 								[
 									createURI('/Users/legomushroom/repos/vscode/gen/text/my.prompt.md').fsPath,
@@ -2275,7 +2276,7 @@ suite('PromptFilesLocator', () => {
 							);
 
 							assert.deepStrictEqual(
-								(await locator.listFiles('prompt'))
+								(await locator.listFiles(PromptsType.prompt))
 									.map((file) => file.fsPath),
 								[
 									createURI('/Users/legomushroom/repos/vscode/gen/text/my.prompt.md').fsPath,
@@ -2391,7 +2392,7 @@ suite('PromptFilesLocator', () => {
 			);
 
 			assert.deepStrictEqual(
-				locator.getConfigBasedSourceFolders('prompt')
+				locator.getConfigBasedSourceFolders(PromptsType.prompt)
 					.map((file) => file.fsPath),
 				[
 					createURI('/Users/legomushroom/repos/vscode/.github/prompts').fsPath,

--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChatCurrentLine.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChatCurrentLine.ts
@@ -41,6 +41,7 @@ import { observableConfigValue } from '../../../../platform/observable/common/pl
 import { Emitter } from '../../../../base/common/event.js';
 import { ChatAgentLocation } from '../../chat/common/constants.js';
 import { INSTRUCTIONS_LANGUAGE_ID, PROMPT_LANGUAGE_ID } from '../../chat/common/promptSyntax/constants.js';
+import { MODE_FILE_EXTENSION } from '../../../../platform/prompts/common/prompts.js';
 
 /**
  * Set of language IDs where inline chat hints should not be shown.
@@ -51,6 +52,7 @@ const IGNORED_LANGUAGE_IDS = new Set([
 	'search-result',
 	INSTRUCTIONS_LANGUAGE_ID,
 	PROMPT_LANGUAGE_ID,
+	MODE_FILE_EXTENSION
 ]);
 
 export const CTX_INLINE_CHAT_SHOWING_HINT = new RawContextKey<boolean>('inlineChatShowingHint', false, localize('inlineChatShowingHint', "Whether inline chat shows a contextual hint"));


### PR DESCRIPTION
FYI @roblourens @legomushroom @digitarald

This adds new commands 
- New Custom Chat Mode
- Manage Custom Chat Modes

Based on my thinking that prompt files and mode files are not exactly the same (see https://github.com/microsoft/vscode-copilot/issues/17638#issuecomment-2900355023), I decided to start with a new file extension `.chatmode.md`.

- A prompt file represents a chat request and consists of a user query, tool selection and context (files, rules (aka instructions, The prompt file body consists of the user query that also lists context (via # and md-links). 
- A mode file has selected tools and contexts but no user query. 
The prompt file body defines additional context via # and md-links. 

Using separate file extensions has the following advantages:
- allows the user to place prompt files and mode files in the same folder
- customize editing support for prompt files and mode files
- looking at the file name is enough to know what the file was designed for

I'm happy to discuss this and change this. 

There's also a new setting 'chat.modeFilesLocations'.

For @roblourens there API to access modes:

`IPromptsService.getCustomChatModes` and `IPromptsService.onDidChangeCustomChatModes`


Still TODO:
- Make labels consistent, Right now it mostly uses 'Custom Change Mode', but not everywhere
- onDidChangeCustomChatModes not implemented
- editor is not yet aware of the new mode. No mode specific validation, code assist, etc.

