### PR TITLE
Implement sticky cell execution status

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/media/notebook.css
+++ b/src/vs/workbench/contrib/notebook/browser/media/notebook.css
@@ -263,6 +263,10 @@
 	line-height: 15px;
 }
 
+.monaco-workbench .notebookOverlay > .cell-list-container > .monaco-list > .monaco-scrollable-element > .monaco-list-rows > .monaco-list-row .execution-count-label .codicon {
+	font-size: 14px;
+}
+
 .monaco-workbench .notebookOverlay .cell .cell-editor-part {
 	position: relative;
 }

--- a/src/vs/workbench/contrib/notebook/browser/view/cellParts/cellExecution.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/cellParts/cellExecution.ts
@@ -7,17 +7,20 @@ import * as DOM from '../../../../../../base/browser/dom.js';
 import { disposableTimeout } from '../../../../../../base/common/async.js';
 import { DisposableStore } from '../../../../../../base/common/lifecycle.js';
 import { clamp } from '../../../../../../base/common/numbers.js';
+import { ThemeIcon } from '../../../../../../base/common/themables.js';
 import { ICellViewModel, INotebookEditorDelegate } from '../../notebookBrowser.js';
-import { CellViewModelStateChangeEvent } from '../../notebookViewEvents.js';
 import { CellContentPart } from '../cellPart.js';
 import { CodeCellViewModel } from '../../viewModel/codeCellViewModel.js';
 import { NotebookCellInternalMetadata } from '../../../common/notebookCommon.js';
 import { INotebookExecutionStateService } from '../../../common/notebookExecutionStateService.js';
+import { executingStateIcon } from '../../notebookIcons.js';
+import { renderLabelWithIcons } from '../../../../../../base/browser/ui/iconLabel/iconLabels.js';
 
 const UPDATE_EXECUTION_ORDER_GRACE_PERIOD = 200;
 
 export class CellExecutionPart extends CellContentPart {
 	private readonly kernelDisposables = this._register(new DisposableStore());
+	private readonly _executionOrderContent: HTMLElement;
 
 	constructor(
 		private readonly _notebookEditor: INotebookEditorDelegate,
@@ -25,6 +28,19 @@ export class CellExecutionPart extends CellContentPart {
 		@INotebookExecutionStateService private readonly _notebookExecutionStateService: INotebookExecutionStateService
 	) {
 		super();
+
+		// Add class to the outer container for styling
+		this._executionOrderLabel.classList.add('cell-execution-order');
+
+		// Create nested div for content
+		this._executionOrderContent = DOM.append(this._executionOrderLabel, DOM.$('div'));
+
+		// Add a method to watch for cell execution state changes
+		this._register(this._notebookExecutionStateService.onDidChangeExecution(e => {
+			if (this.currentCell && 'affectsCell' in e && e.affectsCell(this.currentCell.uri)) {
+				this._updatePosition();
+			}
+		}));
 
 		this._register(this._notebookEditor.onDidChangeActiveKernel(() => {
 			if (this.currentCell) {
@@ -59,6 +75,7 @@ export class CellExecutionPart extends CellContentPart {
 				disposableTimeout(() => {
 					if (this.currentCell === renderingCell) {
 						this.updateExecutionOrder(this.currentCell!.internalMetadata, true);
+						this._updatePosition();
 					}
 				}, UPDATE_EXECUTION_ORDER_GRACE_PERIOD, this.cellDisposables);
 				return;
@@ -67,15 +84,12 @@ export class CellExecutionPart extends CellContentPart {
 			const executionOrderLabel = typeof internalMetadata.executionOrder === 'number' ?
 				`[${internalMetadata.executionOrder}]` :
 				'[ ]';
-			this._executionOrderLabel.innerText = executionOrderLabel;
-		} else {
-			this._executionOrderLabel.innerText = '';
-		}
-	}
+			this._executionOrderContent.innerText = executionOrderLabel;
 
-	override updateState(element: ICellViewModel, e: CellViewModelStateChangeEvent): void {
-		if (e.internalMetadataChanged) {
-			this.updateExecutionOrder(element.internalMetadata);
+			// Call _updatePosition to refresh sticky status
+			this._updatePosition();
+		} else {
+			this._executionOrderContent.innerText = '';
 		}
 	}
 
@@ -84,34 +98,84 @@ export class CellExecutionPart extends CellContentPart {
 	}
 
 	private _updatePosition() {
-		if (this.currentCell) {
-			if (this.currentCell.isInputCollapsed) {
-				DOM.hide(this._executionOrderLabel);
-			} else {
-				DOM.show(this._executionOrderLabel);
-				let top = this.currentCell.layoutInfo.editorHeight - 22 + this.currentCell.layoutInfo.statusBarHeight;
+		if (!this.currentCell) {
+			return;
+		}
 
-				if (this.currentCell instanceof CodeCellViewModel) {
-					const elementTop = this._notebookEditor.getAbsoluteTopOfElement(this.currentCell);
-					const editorBottom = elementTop + this.currentCell.layoutInfo.outputContainerOffset;
-					// another approach to avoid the flicker caused by sticky scroll is manually calculate the scrollBottom:
-					// const scrollBottom = this._notebookEditor.scrollTop + this._notebookEditor.getLayoutInfo().height - 26 - this._notebookEditor.getLayoutInfo().stickyHeight;
-					const scrollBottom = this._notebookEditor.scrollBottom;
+		if (this.currentCell.isInputCollapsed) {
+			DOM.hide(this._executionOrderLabel);
+			return;
+		}
 
-					const lineHeight = 22;
-					if (scrollBottom <= editorBottom) {
-						const offset = editorBottom - scrollBottom;
-						top -= offset;
-						top = clamp(
-							top,
-							lineHeight + 12, // line height + padding for single line
-							this.currentCell.layoutInfo.editorHeight - lineHeight + this.currentCell.layoutInfo.statusBarHeight
-						);
-					}
+		// Only show the execution order label when the cell is running
+		const cellIsRunning = !!this._notebookExecutionStateService.getCellExecution(this.currentCell.uri);
+
+		if (!cellIsRunning) {
+			// Keep showing the execution order label but remove sticky class
+			this._executionOrderLabel.classList.remove('sticky');
+		}
+
+		DOM.show(this._executionOrderLabel);
+		let top = this.currentCell.layoutInfo.editorHeight - 22 + this.currentCell.layoutInfo.statusBarHeight;
+
+		if (this.currentCell instanceof CodeCellViewModel) {
+			const elementTop = this._notebookEditor.getAbsoluteTopOfElement(this.currentCell);
+			const editorBottom = elementTop + this.currentCell.layoutInfo.outputContainerOffset;
+			const scrollBottom = this._notebookEditor.scrollBottom;
+			const lineHeight = 22;
+
+			const statusBarVisible = this.currentCell.layoutInfo.statusBarHeight > 0;
+
+			// Sticky mode: cell is running and editor is not fully visible
+			if (scrollBottom <= editorBottom && cellIsRunning) {
+				const offset = editorBottom - scrollBottom;
+				top -= offset;
+				top = clamp(
+					top,
+					lineHeight + 12, // line height + padding for single line
+					this.currentCell.layoutInfo.editorHeight - lineHeight + this.currentCell.layoutInfo.statusBarHeight
+				);
+
+				const isAlreadySticky = this._executionOrderLabel.classList.contains('sticky');
+				// Add a class when it's in sticky mode for special styling
+				if (!isAlreadySticky) {
+					this._executionOrderLabel.classList.add('sticky');
+					// Only recreate the content if we're newly becoming sticky
+					DOM.clearNode(this._executionOrderContent);
+					const icon = ThemeIcon.modify(executingStateIcon, 'spin');
+					DOM.append(this._executionOrderContent, ...renderLabelWithIcons(`$(${icon.id})`));
 				}
+				// When already sticky, we don't need to recreate the content
+			} else if (!statusBarVisible && cellIsRunning) {
+				// Status bar is hidden but cell is running: show execution order label at the bottom of the editor area
+				const wasSticky = this._executionOrderLabel.classList.contains('sticky');
+				this._executionOrderLabel.classList.remove('sticky');
+				top = this.currentCell.layoutInfo.editorHeight - lineHeight; // Place at the bottom of the editor
+				// Only update content if we were previously sticky or content is not correct
+				const iconIsPresent = this._executionOrderContent.querySelector('.codicon') !== null;
+				if (wasSticky || iconIsPresent) {
+					const executionOrder = this.currentCell.internalMetadata.executionOrder;
+					const executionOrderLabel = typeof executionOrder === 'number' ?
+						`[${executionOrder}]` :
+						'[ ]';
+					this._executionOrderContent.innerText = executionOrderLabel;
+				}
+			} else {
+				// Only update if the current state is sticky
+				const wasSticky = this._executionOrderLabel.classList.contains('sticky');
+				this._executionOrderLabel.classList.remove('sticky');
 
-				this._executionOrderLabel.style.top = `${top}px`;
+				// When transitioning from sticky to non-sticky, restore the proper content
+				if (wasSticky) {
+					const executionOrder = this.currentCell.internalMetadata.executionOrder;
+					const executionOrderLabel = typeof executionOrder === 'number' ?
+						`[${executionOrder}]` :
+						'[ ]';
+					this._executionOrderContent.innerText = executionOrderLabel;
+				}
 			}
 		}
+
+		this._executionOrderLabel.style.top = `${top}px`;
 	}
 }


### PR DESCRIPTION
Enhance the notebook's cell execution display by making the execution order label sticky when the cell is running and not fully visible. This improves visibility and user experience during code execution.