### PR TITLE
Tasks with maxSeverity equal to warning should be set to warning >= c…

### DIFF
--- a/src/vs/workbench/contrib/tasks/browser/taskTerminalStatus.ts
+++ b/src/vs/workbench/contrib/tasks/browser/taskTerminalStatus.ts
@@ -103,7 +103,7 @@ export class TaskTerminalStatus extends Disposable {
 			} else {
 				terminalData.terminal.statusList.add(SUCCEEDED_TASK_STATUS);
 			}
-		} else if (event.exitCode || (terminalData.problemMatcher.maxMarkerSeverity !== undefined && terminalData.problemMatcher.maxMarkerSeverity >= MarkerSeverity.Warning)) {
+		} else if (event.exitCode || (terminalData.problemMatcher.maxMarkerSeverity !== undefined && terminalData.problemMatcher.maxMarkerSeverity > MarkerSeverity.Warning)) {
 			this._accessibilitySignalService.playSignal(AccessibilitySignal.taskFailed);
 			terminalData.terminal.statusList.add(FAILED_TASK_STATUS);
 		} else if (terminalData.problemMatcher.maxMarkerSeverity === MarkerSeverity.Warning) {


### PR DESCRIPTION
…auses them to be marked as failed

This check was recently changed and now tasks that have warnings are marked as failed.

Fixes https://github.com/microsoft/vscode/issues/249584

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
