### PR TITLE
Support extentions providing code snippets via registered text document content providers (fix #248407)

### DIFF
--- a/src/vs/workbench/contrib/snippets/test/browser/snippetFile.test.ts
+++ b/src/vs/workbench/contrib/snippets/test/browser/snippetFile.test.ts
@@ -16,7 +16,7 @@ suite('Snippets', function () {
 
 	class TestSnippetFile extends SnippetFile {
 		constructor(filepath: URI, snippets: Snippet[]) {
-			super(SnippetSource.Extension, filepath, undefined, undefined, undefined!, undefined!);
+			super(SnippetSource.Extension, filepath, undefined, undefined, undefined!, undefined!, undefined!);
 			this.data.push(...snippets);
 		}
 	}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
Hi,
this PR implements what was suggested in this [issue ](https://github.com/microsoft/vscode/issues/248407), which is adding support for extensions defining the path to the snippet file as a custom scheme. e.g. 

```json
"contributes": {
    "snippets": [
      {
        "language": "html",
        "path": "my-scheme:/snippets.json"
      }
    ],
  ```

Regarding testing, I have created a simple extension based on [contentprovider-sample](https://github.com/microsoft/vscode-extension-samples/tree/main/contentprovider-sample), which you can find it here: 
https://github.com/mbehzad/snippet-extension-test
It can be run via its launch.json or installing its vsix package that is also in the repo [here](https://github.com/mbehzad/snippet-extension-test/tree/main/releases) in the vscode from this PR.

Cheers,
Mehran

