### PR TITLE
Fix capitalization for next edit suggestion labels

### DIFF
--- a/src/vs/editor/contrib/inlineCompletions/browser/controller/commands.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/controller/commands.ts
@@ -85,7 +85,7 @@ export class ExplicitTriggerInlineEditAction extends EditorAction {
 	constructor() {
 		super({
 			id: 'editor.action.inlineSuggest.triggerInlineEditExplicit',
-			label: nls.localize2('action.inlineSuggest.trigger.explicitInlineEdit', "Trigger next edit suggestion"),
+			label: nls.localize2('action.inlineSuggest.trigger.explicitInlineEdit', "Trigger Next Edit Suggestion"),
 			precondition: EditorContextKeys.writable,
 		});
 	}

--- a/src/vs/platform/accessibilitySignal/browser/accessibilitySignalService.ts
+++ b/src/vs/platform/accessibilitySignal/browser/accessibilitySignalService.ts
@@ -455,11 +455,11 @@ export class AccessibilitySignal {
 		settingsKey: 'accessibility.signals.lineHasInlineSuggestion',
 	});
 	public static readonly nextEditSuggestion = AccessibilitySignal.register({
-		name: localize('accessibilitySignals.nextEditSuggestion.name', 'Next edit suggestion on Line'),
+		name: localize('accessibilitySignals.nextEditSuggestion.name', 'Next Edit Suggestion on Line'),
 		sound: Sound.nextEditSuggestion,
 		legacySoundSettingsKey: 'audioCues.nextEditSuggestion',
 		settingsKey: 'accessibility.signals.nextEditSuggestion',
-		announcementMessage: localize('accessibility.signals.nextEditSuggestion', 'Next edit suggestion'),
+		announcementMessage: localize('accessibility.signals.nextEditSuggestion', 'Next Edit Suggestion'),
 	});
 	public static readonly terminalQuickFix = AccessibilitySignal.register({
 		name: localize('accessibilitySignals.terminalQuickFix.name', 'Terminal Quick Fix'),


### PR DESCRIPTION
```Copilot Generated Description:``` Update labels and announcement messages for the next edit suggestion to use consistent capitalization.