### PR TITLE
chat: fix code block pills/undo's not working correctly

### DIFF
--- a/src/vs/workbench/contrib/chat/common/tools/editFileTool.ts
+++ b/src/vs/workbench/contrib/chat/common/tools/editFileTool.ts
@@ -8,7 +8,6 @@ import { MarkdownString } from '../../../../../base/common/htmlContent.js';
 import { IDisposable } from '../../../../../base/common/lifecycle.js';
 import { autorun } from '../../../../../base/common/observable.js';
 import { URI, UriComponents } from '../../../../../base/common/uri.js';
-import { generateUuid } from '../../../../../base/common/uuid.js';
 import { CellUri } from '../../../notebook/common/notebookCommon.js';
 import { INotebookService } from '../../../notebook/common/notebookService.js';
 import { ICodeMapperService } from '../../common/chatCodeMapperService.js';
@@ -50,16 +49,6 @@ export class EditTool implements IToolImpl {
 
 		const model = this.chatService.getSession(invocation.context?.sessionId) as ChatModel;
 		const request = model.getRequests().at(-1)!;
-
-		// Undo stops mark groups of response data in the output. Operations, such
-		// as text edits, that happen between undo stops are all done or undone together.
-		if (request.response?.response.getMarkdown().length) {
-			// slightly hacky way to avoid an extra 'no-op' undo stop at the start of responses that are just edits
-			model.acceptResponseProgress(request, {
-				kind: 'undoStop',
-				id: generateUuid(),
-			});
-		}
 
 		model.acceptResponseProgress(request, {
 			kind: 'markdownContent',


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-copilot/issues/17016

Implicitly insert undo stops when a codeBlockUri for edits comes in, fixes us not having undo stops for new insert/patch edit tools.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
