### PR TITLE
feat: add Setting ID filter for reference

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/settingsSearchMenu.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsSearchMenu.ts
@@ -144,8 +144,8 @@ export class SettingsSearchFilterDropdownMenuActionViewItem extends DropdownMenu
 			),
 			this.createAction(
 				'idSettingsSearch',
-				localize('idSettingsSearch', "Settings ID"),
-				localize('idSettingsSearchTooltip', "Add Settings ID filter"),
+				localize('idSettingsSearch', "Setting ID"),
+				localize('idSettingsSearchTooltip', "Add Setting ID filter"),
 				`@${ID_SETTING_TAG}`,
 				false
 			)

--- a/src/vs/workbench/contrib/preferences/browser/settingsSearchMenu.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsSearchMenu.ts
@@ -11,7 +11,7 @@ import { SuggestController } from '../../../../editor/contrib/suggest/browser/su
 import { localize } from '../../../../nls.js';
 import { IContextMenuService } from '../../../../platform/contextview/browser/contextView.js';
 import { SuggestEnabledInput } from '../../codeEditor/browser/suggestEnabledInput/suggestEnabledInput.js';
-import { EXTENSION_SETTING_TAG, FEATURE_SETTING_TAG, GENERAL_TAG_SETTING_TAG, LANGUAGE_SETTING_TAG, MODIFIED_SETTING_TAG, POLICY_SETTING_TAG } from '../common/preferences.js';
+import { EXTENSION_SETTING_TAG, FEATURE_SETTING_TAG, GENERAL_TAG_SETTING_TAG, ID_SETTING_TAG, LANGUAGE_SETTING_TAG, MODIFIED_SETTING_TAG, POLICY_SETTING_TAG } from '../common/preferences.js';
 
 export class SettingsSearchFilterDropdownMenuActionViewItem extends DropdownMenuActionViewItem {
 	private readonly suggestController: SuggestController | null;
@@ -141,6 +141,13 @@ export class SettingsSearchFilterDropdownMenuActionViewItem extends DropdownMenu
 				localize('policySettingsSearch', "Policy services"),
 				localize('policySettingsSearchTooltip', "Show settings for policy services"),
 				`@${POLICY_SETTING_TAG}`
+			),
+			this.createAction(
+				'idSettingsSearch',
+				localize('idSettingsSearch', "Settings ID"),
+				localize('idSettingsSearchTooltip', "Add Settings ID filter"),
+				`@${ID_SETTING_TAG}`,
+				false
 			)
 		];
 	}


### PR DESCRIPTION
Closes #242336.

This PR adds a "Setting ID" filter as an item under the funnel button dropdown in the Settings editor search box. With this PR, the dropdown items match more closely with the suggestions that a user sees when typing `@` in the settings search box, allowing for more discoverability.