### PR TITLE
debt: finish adopting ensureNoDisposablesAreLeakedInTestSuite

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -223,20 +223,7 @@ export default tseslint.config(
 				{
 					// Files should (only) be removed from the list they adopt the leak detector
 					'exclude': [
-						'src/vs/platform/configuration/test/common/configuration.test.ts',
-						'src/vs/platform/opener/test/common/opener.test.ts',
-						'src/vs/platform/registry/test/common/platform.test.ts',
-						'src/vs/platform/workspace/test/common/workspace.test.ts',
-						'src/vs/platform/workspaces/test/electron-main/workspaces.test.ts',
-						'src/vs/workbench/contrib/bulkEdit/test/browser/bulkCellEdits.test.ts',
-						'src/vs/workbench/contrib/chat/test/common/chatWordCounter.test.ts',
-						'src/vs/workbench/contrib/extensions/test/common/extensionQuery.test.ts',
-						'src/vs/workbench/contrib/notebook/test/browser/notebookExecutionService.test.ts',
-						'src/vs/workbench/contrib/notebook/test/browser/notebookExecutionStateService.test.ts',
-						'src/vs/workbench/contrib/tasks/test/common/problemMatcher.test.ts',
-						'src/vs/workbench/services/commands/test/common/commandService.test.ts',
 						'src/vs/workbench/services/userActivity/test/browser/domActivityTracker.test.ts',
-						'src/vs/workbench/test/browser/quickAccess.test.ts'
 					]
 				}
 			]

--- a/src/vs/base/common/event.ts
+++ b/src/vs/base/common/event.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { CancelablePromise } from './async.js';
 import { CancellationToken } from './cancellation.js';
 import { diffSets } from './collections.js';
 import { onUnexpectedError } from './errors.js';
@@ -598,8 +599,16 @@ export namespace Event {
 	/**
 	 * Creates a promise out of an event, using the {@link Event.once} helper.
 	 */
-	export function toPromise<T>(event: Event<T>, disposables?: IDisposable[] | DisposableStore): Promise<T> {
-		return new Promise(resolve => once(event)(resolve, null, disposables));
+	export function toPromise<T>(event: Event<T>, disposables?: IDisposable[] | DisposableStore): CancelablePromise<T> {
+		let cancelRef: () => void;
+		const promise = new Promise((resolve, reject) => {
+			const listener = once(event)(resolve, null, disposables);
+			// not resolved, matching the behavior of a normal disposal
+			cancelRef = () => listener.dispose();
+		}) as CancelablePromise<T>;
+		promise.cancel = cancelRef!;
+
+		return promise;
 	}
 
 	/**

--- a/src/vs/platform/configuration/test/common/configuration.test.ts
+++ b/src/vs/platform/configuration/test/common/configuration.test.ts
@@ -5,8 +5,11 @@
 import assert from 'assert';
 import { merge, removeFromValueTree } from '../../common/configuration.js';
 import { mergeChanges } from '../../common/configurationModels.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
 
 suite('Configuration', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
 
 	test('simple merge', () => {
 		let base = { 'a': 1, 'b': 2 };
@@ -120,6 +123,8 @@ suite('Configuration', () => {
 });
 
 suite('Configuration Changes: Merge', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
 
 	test('merge only keys', () => {
 		const actual = mergeChanges({ keys: ['a', 'b'], overrides: [] }, { keys: ['c', 'd'], overrides: [] });

--- a/src/vs/platform/opener/test/common/opener.test.ts
+++ b/src/vs/platform/opener/test/common/opener.test.ts
@@ -6,8 +6,11 @@
 import assert from 'assert';
 import { URI } from '../../../../base/common/uri.js';
 import { extractSelection, withSelection } from '../../common/opener.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
 
 suite('extractSelection', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
 
 	test('extractSelection with only startLineNumber', async () => {
 		const uri = URI.parse('file:///some/file.js#73');

--- a/src/vs/platform/quickinput/browser/quickAccess.ts
+++ b/src/vs/platform/quickinput/browser/quickAccess.ts
@@ -6,7 +6,7 @@
 import { DeferredPromise } from '../../../base/common/async.js';
 import { CancellationTokenSource } from '../../../base/common/cancellation.js';
 import { Event } from '../../../base/common/event.js';
-import { Disposable, DisposableStore, IDisposable, toDisposable } from '../../../base/common/lifecycle.js';
+import { Disposable, DisposableStore, IDisposable, isDisposable, toDisposable } from '../../../base/common/lifecycle.js';
 import { IInstantiationService } from '../../instantiation/common/instantiation.js';
 import { DefaultQuickAccessFilterValue, Extensions, IQuickAccessController, IQuickAccessOptions, IQuickAccessProvider, IQuickAccessProviderDescriptor, IQuickAccessRegistry } from '../common/quickAccess.js';
 import { IQuickInputService, IQuickPick, IQuickPickItem, ItemActivation } from '../common/quickInput.js';
@@ -30,6 +30,15 @@ export class QuickAccessController extends Disposable implements IQuickAccessCon
 		@IInstantiationService private readonly instantiationService: IInstantiationService
 	) {
 		super();
+		this._register(toDisposable(() => {
+			for (const provider of this.mapProviderToDescriptor.values()) {
+				if (isDisposable(provider)) {
+					provider.dispose();
+				}
+			}
+
+			this.visibleQuickAccess?.picker.dispose();
+		}));
 	}
 
 	pick(value = '', options?: IQuickAccessOptions): Promise<IQuickPickItem[] | undefined> {

--- a/src/vs/platform/registry/test/common/platform.test.ts
+++ b/src/vs/platform/registry/test/common/platform.test.ts
@@ -6,8 +6,11 @@
 import assert from 'assert';
 import { isFunction } from '../../../../base/common/types.js';
 import { Registry } from '../../common/platform.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
 
 suite('Platform / Registry', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
 
 	test('registry - api', function () {
 		assert.ok(isFunction(Registry.add));

--- a/src/vs/platform/workspace/test/common/workspace.test.ts
+++ b/src/vs/platform/workspace/test/common/workspace.test.ts
@@ -10,8 +10,11 @@ import { extUriBiasedIgnorePathCase } from '../../../../base/common/resources.js
 import { URI } from '../../../../base/common/uri.js';
 import { IRawFileWorkspaceFolder, Workspace, WorkspaceFolder } from '../../common/workspace.js';
 import { toWorkspaceFolders } from '../../../workspaces/common/workspaces.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
 
 suite('Workspace', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
 
 	const fileFolder = isWindows ? 'c:\\src' : '/src';
 	const abcFolder = isWindows ? 'c:\\abc' : '/abc';

--- a/src/vs/workbench/contrib/extensions/test/common/extensionQuery.test.ts
+++ b/src/vs/workbench/contrib/extensions/test/common/extensionQuery.test.ts
@@ -5,8 +5,11 @@
 
 import assert from 'assert';
 import { Query } from '../../common/extensionQuery.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 
 suite('Extension query', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+
 	test('parse', () => {
 		let query = Query.parse('');
 		assert.strictEqual(query.value, '');

--- a/src/vs/workbench/contrib/tasks/test/common/problemMatcher.test.ts
+++ b/src/vs/workbench/contrib/tasks/test/common/problemMatcher.test.ts
@@ -6,6 +6,7 @@ import * as matchers from '../../common/problemMatcher.js';
 
 import assert from 'assert';
 import { ValidationState, IProblemReporter, ValidationStatus } from '../../../../../base/common/parsers.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 
 class ProblemReporter implements IProblemReporter {
 	private _validationStatus: ValidationStatus;
@@ -59,6 +60,8 @@ suite('ProblemPatternParser', () => {
 	let reporter: ProblemReporter;
 	let parser: matchers.ProblemPatternParser;
 	const testRegexp = new RegExp('test');
+
+	ensureNoDisposablesAreLeakedInTestSuite();
 
 	setup(() => {
 		reporter = new ProblemReporter();

--- a/src/vs/workbench/services/history/test/browser/historyService.test.ts
+++ b/src/vs/workbench/services/history/test/browser/historyService.test.ts
@@ -838,7 +838,7 @@ suite('HistoryService', function () {
 		const input4 = disposables.add(new TestFileEditorInput(URI.parse('foo://bar4'), TEST_EDITOR_INPUT_ID));
 		const input5 = disposables.add(new TestFileEditorInput(URI.parse('foo://bar5'), TEST_EDITOR_INPUT_ID));
 
-		let editorChangePromise = Event.toPromise(editorService.onDidActiveEditorChange);
+		let editorChangePromise: Promise<void> = Event.toPromise(editorService.onDidActiveEditorChange);
 		await part.activeGroup.openEditor(input1, { pinned: true });
 		assert.strictEqual(part.activeGroup.activeEditor, input1);
 		await editorChangePromise;

--- a/src/vs/workbench/services/userActivity/test/browser/domActivityTracker.test.ts
+++ b/src/vs/workbench/services/userActivity/test/browser/domActivityTracker.test.ts
@@ -3,31 +3,29 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import assert from 'assert';
+import * as sinon from 'sinon';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { TestInstantiationService } from '../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
 import { DomActivityTracker } from '../../browser/domActivityTracker.js';
 import { UserActivityService } from '../../common/userActivityService.js';
-import * as sinon from 'sinon';
-import assert from 'assert';
 
 suite('DomActivityTracker', () => {
 	let uas: UserActivityService;
-	let dom: DomActivityTracker;
 	let insta: TestInstantiationService;
 	let clock: sinon.SinonFakeTimers;
 	const maxTimeToBecomeIdle = 3 * 30_000; // (MIN_INTERVALS_WITHOUT_ACTIVITY + 1) * CHECK_INTERVAL;
+	const store = ensureNoDisposablesAreLeakedInTestSuite();
 
 	setup(() => {
 		clock = sinon.useFakeTimers();
-		insta = new TestInstantiationService();
-		uas = new UserActivityService(insta);
-		dom = new DomActivityTracker(uas);
+		insta = store.add(new TestInstantiationService());
+		uas = store.add(new UserActivityService(insta));
+		store.add(new DomActivityTracker(uas));
 	});
 
 	teardown(() => {
-		dom.dispose();
-		uas.dispose();
 		clock.restore();
-		insta.dispose();
 	});
 
 


### PR DESCRIPTION
Closes #200091

Notably makes `raceCancellablePromises` itself be cancellable to allow
for composition, and make `Event.toPromise` cancellable too.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
