### PR TITLE
feat: conditionallyExecuteCommand API proposal

### DIFF
--- a/extensions/vscode-api-tests/package.json
+++ b/extensions/vscode-api-tests/package.json
@@ -9,6 +9,7 @@
     "authSession",
     "chatParticipantPrivate",
     "chatProvider",
+    "conditionallyExecuteCommand",
     "contribStatusBarItems",
     "contribViewsRemote",
     "customEditorMove",

--- a/extensions/vscode-api-tests/src/singlefolder-tests/commands.test.ts
+++ b/extensions/vscode-api-tests/src/singlefolder-tests/commands.test.ts
@@ -164,4 +164,63 @@ suite('vscode API - commands', () => {
 
 		return closeAllEditors();
 	});
+
+	test('conditional: no condition', async function () {
+		let args: IArguments;
+		const registration = commands.registerCommand('t1', function () {
+			args = arguments;
+		});
+
+		const result = await commands.conditionallyExecuteCommand('', 't1', 'start');
+		assert.ok(result.executed);
+		registration.dispose();
+		assert.ok(args!);
+		assert.strictEqual(args!.length, 1);
+		assert.strictEqual(args![0], 'start');
+	});
+
+	test('conditional: true condition', async function () {
+		let args: IArguments;
+		const registration = commands.registerCommand('t1', function () {
+			args = arguments;
+		});
+
+		const result = await commands.conditionallyExecuteCommand('true', 't1', 'start');
+		assert.ok(result.executed);
+		registration.dispose();
+		assert.ok(args!);
+		assert.strictEqual(args!.length, 1);
+		assert.strictEqual(args![0], 'start');
+	});
+
+	test('conditional: false condition', async function () {
+		let args: IArguments;
+		const registration = commands.registerCommand('t1', function () {
+			args = arguments;
+		});
+
+		const result = await commands.conditionallyExecuteCommand('false', 't1', 'start');
+		assert.strictEqual(result.executed, false);
+		registration.dispose();
+		assert.strictEqual(args!, undefined);
+	});
+
+	test('conditional: sidebarVisible', async function () {
+		const registration = commands.registerCommand('t1', function () {
+			return true;
+		});
+
+		let result = await commands.conditionallyExecuteCommand('sideBarVisible', 't1');
+		assert.ok(result.executed);
+		assert.ok(result.result);
+
+		commands.executeCommand('workbench.action.closeSidebar');
+
+		result = await commands.conditionallyExecuteCommand('sideBarVisible', 't1');
+		assert.strictEqual(result.executed, false);
+		assert.strictEqual(result.result, undefined);
+
+		registration.dispose();
+
+	});
 });

--- a/src/vs/platform/extensions/common/extensionsApiProposals.ts
+++ b/src/vs/platform/extensions/common/extensionsApiProposals.ts
@@ -80,6 +80,9 @@ const _allApiProposals = {
 	commentsDraftState: {
 		proposal: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.commentsDraftState.d.ts',
 	},
+	conditionallyExecuteCommand: {
+		proposal: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.conditionallyExecuteCommand.d.ts',
+	},
 	contribAccessibilityHelpContent: {
 		proposal: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.contribAccessibilityHelpContent.d.ts',
 	},

--- a/src/vs/workbench/api/common/extHost.api.impl.ts
+++ b/src/vs/workbench/api/common/extHost.api.impl.ts
@@ -366,7 +366,11 @@ export function createApiFactoryAndRegisterActors(accessor: ServicesAccessor): I
 			},
 			getCommands(filterInternal: boolean = false): Thenable<string[]> {
 				return extHostCommands.getCommands(filterInternal);
-			}
+			},
+			conditionallyExecuteCommand<T>(when: string, id: string, ...args: any[]): Thenable<{ executed: boolean; result: T | undefined }> {
+				checkProposedApiEnabled(extension, 'conditionallyExecuteCommand');
+				return extHostCommands.conditionallyExecuteCommand<T>(when, id, ...args);
+			},
 		};
 
 		// namespace: env

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -116,6 +116,8 @@ export interface MainThreadCommandsShape extends IDisposable {
 	$unregisterCommand(id: string): void;
 	$fireCommandActivationEvent(id: string): void;
 	$executeCommand(id: string, args: any[] | SerializableObjectWithBuffers<any[]>, retry: boolean): Promise<unknown | undefined>;
+	$conditionallyExecuteCommand(when: string, id: string, args: any[] | SerializableObjectWithBuffers<any[]>, retry: boolean): Promise<unknown | undefined>;
+	$checkCondition(when: string): Promise<boolean>;
 	$getCommands(): Promise<string[]>;
 }
 

--- a/src/vs/workbench/api/common/extHostCommands.ts
+++ b/src/vs/workbench/api/common/extHostCommands.ts
@@ -176,7 +176,15 @@ export class ExtHostCommands implements ExtHostCommandsShape {
 		return this._doExecuteCommand(id, args, true);
 	}
 
-	private async _doExecuteCommand<T>(id: string, args: any[], retry: boolean): Promise<T> {
+	async conditionallyExecuteCommand<T>(when: string, id: string, ...args: any[]): Promise<{ executed: boolean; result: T | undefined }> {
+		this._logService.trace('ExtHostCommands#conditionallyExecuteCommand', id);
+		if (!when || await this.#proxy.$checkCondition(when)) {
+			return { executed: true, result: await this._doExecuteCommand(id, args, true, when) };
+		}
+		return { executed: false, result: undefined };
+	}
+
+	private async _doExecuteCommand<T>(id: string, args: any[], retry: boolean, when?: string): Promise<T> {
 
 		if (this._commands.has(id)) {
 			// - We stay inside the extension host and support

--- a/src/vs/workbench/api/test/browser/mainThreadCommands.test.ts
+++ b/src/vs/workbench/api/test/browser/mainThreadCommands.test.ts
@@ -10,6 +10,7 @@ import { SingleProxyRPCProtocol } from '../common/testRPCProtocol.js';
 import { IExtensionService } from '../../../services/extensions/common/extensions.js';
 import { mock } from '../../../../base/test/common/mock.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+import { IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
 
 suite('MainThreadCommands', function () {
 
@@ -17,7 +18,7 @@ suite('MainThreadCommands', function () {
 
 	test('dispose on unregister', function () {
 
-		const commands = new MainThreadCommands(SingleProxyRPCProtocol(null), undefined!, new class extends mock<IExtensionService>() { });
+		const commands = new MainThreadCommands(SingleProxyRPCProtocol(null), undefined!, new class extends mock<IExtensionService>() { }, new class extends mock<IContextKeyService>() { });
 		assert.strictEqual(CommandsRegistry.getCommand('foo'), undefined);
 
 		// register
@@ -34,7 +35,7 @@ suite('MainThreadCommands', function () {
 
 	test('unregister all on dispose', function () {
 
-		const commands = new MainThreadCommands(SingleProxyRPCProtocol(null), undefined!, new class extends mock<IExtensionService>() { });
+		const commands = new MainThreadCommands(SingleProxyRPCProtocol(null), undefined!, new class extends mock<IExtensionService>() { }, new class extends mock<IContextKeyService>() { });
 		assert.strictEqual(CommandsRegistry.getCommand('foo'), undefined);
 
 		commands.$registerCommand('foo');
@@ -67,7 +68,8 @@ suite('MainThreadCommands', function () {
 					activations.push(id);
 					return Promise.resolve();
 				}
-			}
+			},
+			new class extends mock<IContextKeyService>() { }
 		);
 
 		// case 1: arguments and retry

--- a/src/vscode-dts/vscode.proposed.conditionallyExecuteCommand.d.ts
+++ b/src/vscode-dts/vscode.proposed.conditionallyExecuteCommand.d.ts
@@ -1,0 +1,14 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+declare module 'vscode' {
+	export namespace commands {
+
+		/**
+		 * TODO
+		 */
+		export function conditionallyExecuteCommand<T>(when: string, id: string, ...args: string[]): Thenable<{ executed: boolean; result: T | undefined }>;
+	}
+}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR is based on @jrieken comment for allowing access to context through the API:
> You should not be reading and evaluating context keys. Instead you should be more like an "event source" and we should own the tuple [event, when-clause, command] - just like we do it for keybindings. Something like this
>
> 1. extension registers event source
> 2. vscode allows to bind events to commands using when-clauses
> 3. extension fires event -> vscode evaluates the binding (using the focused/active element) and invokes the command

To implement this, I've added a new function to the `commands` API that allows conditional execution of commands based on the context of the active element. This could be a separate functionality from commands, but I figured it was better to add on to the existing commands implementation rather than creating an entirely new event registration system. 

Tests implemented in:
* `extensions/vscode-api-tests/src/singlefolder-tests/commands.test.ts`
* `src/vs/workbench/api/test/browser/mainThreadCommands.test.ts`

Closes #249741

Addresses common requests in #10471