### PR TITLE
Disassembly View: don't display invalid memory instructions

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/disassemblyView.ts
+++ b/src/vs/workbench/contrib/debug/browser/disassemblyView.ts
@@ -511,6 +511,11 @@ export class DisassemblyView extends EditorPane {
 					continue;
 				}
 
+				if (address === -1n) {
+					// Ignore invalid instructions returned by the adapter.
+					continue;
+				}
+
 				const entry: IDisassembledInstructionEntry = {
 					allowBreakpoint: true,
 					isBreakpointSet: false,


### PR DESCRIPTION
Ignore instructions returned by the debug adapter that have invalid memory (-1).  

This can happen when VSCode tries to disassemble unmapped memory, for example, when scrolling past a module address range.

Fix #249782
