### PR TITLE
fix: throttle the collection write requests

### DIFF
--- a/src/vs/platform/userDataSync/common/userDataProfilesManifestSync.ts
+++ b/src/vs/platform/userDataSync/common/userDataProfilesManifestSync.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { timeout } from '../../../base/common/async.js';
 import { CancellationToken } from '../../../base/common/cancellation.js';
 import { toFormattedString } from '../../../base/common/jsonFormatter.js';
 import { URI } from '../../../base/common/uri.js';
@@ -216,6 +217,7 @@ export class UserDataProfilesManifestSynchroniser extends AbstractSynchroniser i
 					this.logService.trace(`${this.syncResourceLogLabel}: Created collection "${collection}" for "${profile.name}".`);
 					addedCollections.push(collection);
 					remoteProfiles.push({ id: profile.id, name: profile.name, collection, icon: profile.icon, useDefaultFlags: profile.useDefaultFlags });
+					await this.throttleUpdate();
 				}
 			} else {
 				this.logService.info(`${this.syncResourceLogLabel}: Could not create remote profiles as there are too many profiles.`);
@@ -238,6 +240,7 @@ export class UserDataProfilesManifestSynchroniser extends AbstractSynchroniser i
 					this.logService.info(`${this.syncResourceLogLabel}: Failed to update remote profiles. Cleaning up added collections...`);
 					for (const collection of addedCollections) {
 						await this.userDataSyncStoreService.deleteCollection(collection, this.syncHeaders);
+						await this.throttleUpdate();
 					}
 				}
 				throw error;
@@ -245,6 +248,7 @@ export class UserDataProfilesManifestSynchroniser extends AbstractSynchroniser i
 
 			for (const profile of remote?.removed || []) {
 				await this.userDataSyncStoreService.deleteCollection(profile.collection, this.syncHeaders);
+				await this.throttleUpdate();
 			}
 		}
 
@@ -254,6 +258,16 @@ export class UserDataProfilesManifestSynchroniser extends AbstractSynchroniser i
 			await this.updateLastSyncUserData(remoteUserData);
 			this.logService.info(`${this.syncResourceLogLabel}: Updated last synchronized profiles.`);
 		}
+	}
+
+	/**
+	 * This is a helper function to avoid write conflicts in Cosmos DB.
+	 * Session tokens in Cosmos DB seem to include a timestamp in seconds.
+	 * Writing multiple collections under the same timestamp results in a case where only the last collection seems to be written successfully.
+	 * This function acts as a throttle by forcing the client to wait for around a second.
+	 */
+	private async throttleUpdate(): Promise<void> {
+		await timeout(1000);
 	}
 
 	async updateRemoteProfiles(profiles: ISyncUserDataProfile[], ref: string | null): Promise<IRemoteUserData> {

--- a/src/vs/platform/userDataSync/common/userDataSyncStoreService.ts
+++ b/src/vs/platform/userDataSync/common/userDataSyncStoreService.ts
@@ -283,7 +283,7 @@ export class UserDataSyncStoreClient extends Disposable {
 	 * This is a helper function to avoid write conflicts in Cosmos DB.
 	 * Session tokens in Cosmos DB seem to include a timestamp in seconds.
 	 * Writing multiple collections under the same timestamp results in a case where only the last collection seems to be written successfully.
-	 * This function acts as a throttle by forcing the client to wait for around a second.
+	 * This function acts as a throttle by forcing the client to wait for around a second before continuing.
 	 */
 	private async throttleUpdate(): Promise<void> {
 		await timeout(1000);


### PR DESCRIPTION
This PR adds a throttle to POST and DELETE collection calls so that the settings sync server can ingest the incoming data without conflicts.

I originally read up on [session consistency](https://learn.microsoft.com/en-us/azure/cosmos-db/consistency-levels#session-consistency) and thought that we needed to implement session tokens, but I noticed that even after using session tokens, writing two collections at nearly the same time still resulted in a last-writer-wins scenario that matches with the documentation on [managing conflicts](https://learn.microsoft.com/en-us/azure/cosmos-db/nosql/how-to-manage-conflicts?tabs=dotnetv2%2Capi-async%2Casync%2Cv4async). Even adding retry logic did not fix that case.

As a result of my experiences above, I added throttling instead, which seemed to significantly reduce the rate of 405 errors upon creating or deleting profiles. The downside is that users must wait several seconds for bulk additions/deletions, but I do not expect most users to tweak their profiles very frequently.