### PR TITLE
mcp: initial sampling implementation

### DIFF
--- a/src/vs/workbench/api/common/extHostMcp.ts
+++ b/src/vs/workbench/api/common/extHostMcp.ts
@@ -20,6 +20,8 @@ import { AUTH_SERVER_METADATA_DISCOVERY_PATH, getDefaultMetadataForUrl, getMetad
 import { URI } from '../../../base/common/uri.js';
 import { MCP } from '../../contrib/mcp/common/modelContextProtocol.js';
 import { CancellationError } from '../../../base/common/errors.js';
+import { ConfigurationTarget } from '../../../platform/configuration/common/configuration.js';
+import { IExtHostInitDataService } from './extHostInitDataService.js';
 
 export const IExtHostMpcService = createDecorator<IExtHostMpcService>('IExtHostMpcService');
 
@@ -38,6 +40,7 @@ export class ExtHostMcpService extends Disposable implements IExtHostMpcService 
 
 	constructor(
 		@IExtHostRpcService extHostRpc: IExtHostRpcService,
+		@IExtHostInitDataService private readonly _extHostInitData: IExtHostInitDataService
 	) {
 		super();
 		this._proxy = extHostRpc.getProxy(MainContext.MainThreadMcp);
@@ -105,6 +108,7 @@ export class ExtHostMcpService extends Disposable implements IExtHostMpcService 
 			scope: StorageScope.WORKSPACE,
 			canResolveLaunch: typeof provider.resolveMcpServerDefinition === 'function',
 			extensionId: extension.identifier.value,
+			configTarget: this._extHostInitData.remote.isRemote ? ConfigurationTarget.USER_REMOTE : ConfigurationTarget.USER,
 		};
 
 		const update = async () => {
@@ -124,7 +128,7 @@ export class ExtHostMcpService extends Disposable implements IExtHostMpcService 
 					id,
 					label: item.label,
 					cacheNonce: item.version,
-					launch: Convert.McpServerDefinition.from(item)
+					launch: Convert.McpServerDefinition.from(item),
 				});
 			}
 

--- a/src/vs/workbench/api/node/extHostMcpNode.ts
+++ b/src/vs/workbench/api/node/extHostMcpNode.ts
@@ -15,12 +15,14 @@ import { McpConnectionState, McpServerLaunch, McpServerTransportStdio, McpServer
 import { ExtHostMcpService } from '../common/extHostMcp.js';
 import { IExtHostRpcService } from '../common/extHostRpcService.js';
 import * as path from '../../../base/common/path.js';
+import { IExtHostInitDataService } from '../common/extHostInitDataService.js';
 
 export class NodeExtHostMpcService extends ExtHostMcpService {
 	constructor(
 		@IExtHostRpcService extHostRpc: IExtHostRpcService,
+		@IExtHostInitDataService initDataService: IExtHostInitDataService,
 	) {
-		super(extHostRpc);
+		super(extHostRpc, initDataService);
 	}
 
 	private nodeServers = new Map<number, {

--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -29,7 +29,7 @@ import { EditorExtensions, IEditorFactoryRegistry } from '../../../common/editor
 import { IWorkbenchAssignmentService } from '../../../services/assignment/common/assignmentService.js';
 import { mcpSchemaId } from '../../../services/configuration/common/configuration.js';
 import { IEditorResolverService, RegisteredEditorPriority } from '../../../services/editor/common/editorResolverService.js';
-import { allDiscoverySources, discoverySourceLabel, mcpConfigurationSection, mcpDiscoverySection, mcpEnabledSection, mcpSchemaExampleServers } from '../../mcp/common/mcpConfiguration.js';
+import { allDiscoverySources, discoverySourceLabel, mcpConfigurationSection, mcpDiscoverySection, mcpEnabledSection, mcpSchemaExampleServers, mcpServerSamplingSection } from '../../mcp/common/mcpConfiguration.js';
 import { ChatAgentNameService, ChatAgentService, IChatAgentNameService, IChatAgentService } from '../common/chatAgents.js';
 import { CodeMapperService, ICodeMapperService } from '../common/chatCodeMapperService.js';
 import '../common/chatColors.js';
@@ -248,6 +248,32 @@ configurationRegistry.registerConfiguration({
 				previewFeature: true,
 				defaultValue: false
 			}
+		},
+		[mcpServerSamplingSection]: {
+			type: 'object',
+			description: nls.localize('chat.mcp.serverSampling', "Configures which models are exposed to MCP servers for sampling (making model requests in the background). This setting can be edited in a graphical way under the `{0}` command.", 'MCP: ' + nls.localize('mcp.list', 'List Servers')),
+			additionalProperties: {
+				type: 'object',
+				properties: {
+					allowedDuringChat: {
+						type: 'boolean',
+						description: nls.localize('chat.mcp.serverSampling.allowedDuringChat', "Whether this server is make sampling requests during its tool calls in a chat session."),
+						default: true,
+					},
+					allowedOutsideChat: {
+						type: 'boolean',
+						description: nls.localize('chat.mcp.serverSampling.allowedOutsideChat', "Whether this server is allowed to make sampling requests outside of a chat session."),
+						default: false,
+					},
+					allowedModels: {
+						type: 'array',
+						items: {
+							type: 'string',
+							description: nls.localize('chat.mcp.serverSampling.model', "A model the MCP server has access to."),
+						},
+					}
+				}
+			},
 		},
 		[mcpConfigurationSection]: {
 			type: 'object',

--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -253,6 +253,7 @@ configurationRegistry.registerConfiguration({
 		[mcpServerSamplingSection]: {
 			type: 'object',
 			description: nls.localize('chat.mcp.serverSampling', "Configures which models are exposed to MCP servers for sampling (making model requests in the background). This setting can be edited in a graphical way under the `{0}` command.", 'MCP: ' + nls.localize('mcp.list', 'List Servers')),
+			scope: ConfigurationScope.RESOURCE,
 			additionalProperties: {
 				type: 'object',
 				properties: {

--- a/src/vs/workbench/contrib/mcp/browser/mcp.contribution.ts
+++ b/src/vs/workbench/contrib/mcp/browser/mcp.contribution.ts
@@ -31,10 +31,11 @@ import { IMcpDevModeDebugging, McpDevModeDebugging } from '../common/mcpDevMode.
 import { McpRegistry } from '../common/mcpRegistry.js';
 import { IMcpRegistry } from '../common/mcpRegistryTypes.js';
 import { McpResourceFilesystem } from '../common/mcpResourceFilesystem.js';
+import { McpSamplingService } from '../common/mcpSamplingService.js';
 import { McpService } from '../common/mcpService.js';
-import { HasInstalledMcpServersContext, IMcpService, IMcpWorkbenchService, InstalledMcpServersViewId, McpServersGalleryEnabledContext } from '../common/mcpTypes.js';
+import { HasInstalledMcpServersContext, IMcpSamplingService, IMcpService, IMcpWorkbenchService, InstalledMcpServersViewId, McpServersGalleryEnabledContext } from '../common/mcpTypes.js';
 import { McpAddContextContribution } from './mcpAddContextContribution.js';
-import { AddConfigurationAction, EditStoredInput, InstallFromActivation, ListMcpServerCommand, McpBrowseCommand, McpBrowseResourcesCommand, MCPServerActionRendering, McpServerOptionsCommand, RemoveStoredInput, ResetMcpCachedTools, ResetMcpTrustCommand, RestartServer, ShowConfiguration, ShowOutput, StartServer, StopServer } from './mcpCommands.js';
+import { AddConfigurationAction, EditStoredInput, InstallFromActivation, ListMcpServerCommand, McpBrowseCommand, McpBrowseResourcesCommand, McpConfigureSamplingModels, MCPServerActionRendering, McpServerOptionsCommand, RemoveStoredInput, ResetMcpCachedTools, ResetMcpTrustCommand, RestartServer, ShowConfiguration, ShowOutput, StartServer, StopServer } from './mcpCommands.js';
 import { McpDiscovery } from './mcpDiscovery.js';
 import { McpLanguageFeatures } from './mcpLanguageFeatures.js';
 import { McpResourceQuickAccess } from './mcpResourceQuickAccess.js';
@@ -49,6 +50,7 @@ registerSingleton(IMcpService, McpService, InstantiationType.Delayed);
 registerSingleton(IMcpWorkbenchService, McpWorkbenchService, InstantiationType.Eager);
 registerSingleton(IMcpConfigPathsService, McpConfigPathsService, InstantiationType.Delayed);
 registerSingleton(IMcpDevModeDebugging, McpDevModeDebugging, InstantiationType.Delayed);
+registerSingleton(IMcpSamplingService, McpSamplingService, InstantiationType.Delayed);
 
 mcpDiscoveryRegistry.register(new SyncDescriptor(RemoteNativeMpcDiscovery));
 mcpDiscoveryRegistry.register(new SyncDescriptor(ConfigMcpDiscovery));
@@ -76,6 +78,7 @@ registerAction2(RestartServer);
 registerAction2(ShowConfiguration);
 registerAction2(McpBrowseCommand);
 registerAction2(McpBrowseResourcesCommand);
+registerAction2(McpConfigureSamplingModels);
 
 registerWorkbenchContribution2('mcpActionRendering', MCPServerActionRendering, WorkbenchPhase.BlockRestore);
 registerWorkbenchContribution2('mcpAddContext', McpAddContextContribution, WorkbenchPhase.Eventually);

--- a/src/vs/workbench/contrib/mcp/browser/mcpCommands.ts
+++ b/src/vs/workbench/contrib/mcp/browser/mcpCommands.ts
@@ -11,6 +11,7 @@ import { Event } from '../../../../base/common/event.js';
 import { Disposable, DisposableStore } from '../../../../base/common/lifecycle.js';
 import { autorun, derived } from '../../../../base/common/observable.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
+import { isDefined } from '../../../../base/common/types.js';
 import { URI } from '../../../../base/common/uri.js';
 import { ILocalizedString, localize, localize2 } from '../../../../nls.js';
 import { IActionViewItemService } from '../../../../platform/actions/browser/actionViewItemService.js';
@@ -32,14 +33,15 @@ import { IEditorService } from '../../../services/editor/common/editorService.js
 import { IViewsService } from '../../../services/views/common/viewsService.js';
 import { ChatContextKeys } from '../../chat/common/chatContextKeys.js';
 import { ChatMode } from '../../chat/common/constants.js';
+import { ILanguageModelsService } from '../../chat/common/languageModels.js';
 import { extensionsFilterSubMenu, IExtensionsWorkbenchService } from '../../extensions/common/extensions.js';
 import { TEXT_FILE_EDITOR_ID } from '../../files/common/files.js';
 import { McpCommandIds } from '../common/mcpCommandIds.js';
 import { McpContextKeys } from '../common/mcpContextKeys.js';
 import { IMcpRegistry } from '../common/mcpRegistryTypes.js';
-import { McpResourceQuickAccess } from './mcpResourceQuickAccess.js';
-import { IMcpServer, IMcpServerStartOpts, IMcpService, IMcpWorkbenchService, InstalledMcpServersViewId, LazyCollectionState, McpConnectionState, McpServersGalleryEnabledContext, McpServerCacheState } from '../common/mcpTypes.js';
+import { IMcpSamplingService, IMcpServer, IMcpServerStartOpts, IMcpService, IMcpWorkbenchService, InstalledMcpServersViewId, LazyCollectionState, McpConnectionState, McpServerCacheState, McpServersGalleryEnabledContext } from '../common/mcpTypes.js';
 import { McpAddConfigurationCommand } from './mcpCommandsAddConfiguration.js';
+import { McpResourceQuickAccess } from './mcpResourceQuickAccess.js';
 import { McpUrlHandler } from './mcpUrlHandler.js';
 
 // acroynms do not get localized
@@ -152,17 +154,17 @@ export class McpServerOptionsCommand extends Action2 {
 		const quickInputService = accessor.get(IQuickInputService);
 		const mcpRegistry = accessor.get(IMcpRegistry);
 		const editorService = accessor.get(IEditorService);
+		const commandService = accessor.get(ICommandService);
 		const server = mcpService.servers.get().find(s => s.definition.id === id);
 		if (!server) {
 			return;
 		}
 
-
 		const collection = mcpRegistry.collections.get().find(c => c.id === server.collection.id);
 		const serverDefinition = collection?.serverDefinitions.get().find(s => s.id === server.definition.id);
 
 		interface ActionItem extends IQuickPickItem {
-			action: 'start' | 'stop' | 'restart' | 'showOutput' | 'config';
+			action: 'start' | 'stop' | 'restart' | 'showOutput' | 'config' | 'configSampling';
 		}
 
 		const items: ActionItem[] = [];
@@ -188,6 +190,10 @@ export class McpServerOptionsCommand extends Action2 {
 		items.push({
 			label: localize('mcp.showOutput', 'Show Output'),
 			action: 'showOutput'
+		}, {
+			label: localize('mcp.configAccess', 'Configure Model Access'),
+			description: localize('mcp.showOutput.description', 'Set the models the server can use via MCP sampling'),
+			action: 'configSampling'
 		});
 
 		const configTarget = serverDefinition?.presentation?.origin || collection?.presentation?.origin;
@@ -228,6 +234,8 @@ export class McpServerOptionsCommand extends Action2 {
 					options: { selection: URI.isUri(configTarget) ? undefined : configTarget!.range }
 				});
 				break;
+			case 'configSampling':
+				return commandService.executeCommand(McpCommandIds.ConfigureSamplingModels, server);
 			default:
 				assertNever(pick.action);
 		}
@@ -618,5 +626,42 @@ export class McpBrowseResourcesCommand extends Action2 {
 
 	run(accessor: ServicesAccessor): void {
 		accessor.get(IQuickInputService).quickAccess.show(McpResourceQuickAccess.PREFIX);
+	}
+}
+
+
+export class McpConfigureSamplingModels extends Action2 {
+	constructor() {
+		super({
+			id: McpCommandIds.ConfigureSamplingModels,
+			title: localize2('mcp.configureSamplingModels', "Configure SamplingModel"),
+			category,
+		});
+	}
+
+	async run(accessor: ServicesAccessor, server: IMcpServer): Promise<number> {
+		const quickInputService = accessor.get(IQuickInputService);
+		const lmService = accessor.get(ILanguageModelsService);
+		const mcpSampling = accessor.get(IMcpSamplingService);
+
+		const existingIds = new Set(mcpSampling.getConfig(server).allowedModels);
+		const allItems: IQuickPickItem[] = lmService.getLanguageModelIds().map(id => {
+			const model = lmService.lookupLanguageModel(id)!;
+			return model.isUserSelectable ? ({ label: model.name, description: model.description, id, picked: existingIds.has(id) }) : undefined;
+		}).filter(isDefined);
+
+		allItems.sort((a, b) => (b.picked ? 1 : 0) - (a.picked ? 1 : 0) || a.label.localeCompare(b.label));
+
+		// do the quickpick selection
+		const picked = await quickInputService.pick(allItems, {
+			placeHolder: localize('mcp.configureSamplingModels.ph', 'Pick the models {0} can access via MCP sampling', server.definition.label),
+			canPickMany: true,
+		});
+
+		if (picked) {
+			await mcpSampling.updateConfig(server, c => c.allowedModels = picked.map(p => p.id!));
+		}
+
+		return picked?.length || 0;
 	}
 }

--- a/src/vs/workbench/contrib/mcp/common/discovery/configMcpDiscovery.ts
+++ b/src/vs/workbench/contrib/mcp/common/discovery/configMcpDiscovery.ts
@@ -164,6 +164,7 @@ export class ConfigMcpDiscovery extends Disposable implements IMcpDiscovery {
 					remoteAuthority: src.path.remoteAuthority || null,
 					serverDefinitions: src.serverDefinitions,
 					isTrustedByDefault: true,
+					configTarget: src.path.target,
 					scope: src.path.scope,
 				});
 			}

--- a/src/vs/workbench/contrib/mcp/common/discovery/extensionMcpDiscovery.ts
+++ b/src/vs/workbench/contrib/mcp/common/discovery/extensionMcpDiscovery.ts
@@ -7,6 +7,7 @@ import { Disposable, DisposableMap } from '../../../../../base/common/lifecycle.
 import { observableValue } from '../../../../../base/common/observable.js';
 import { isFalsyOrWhitespace } from '../../../../../base/common/strings.js';
 import { localize } from '../../../../../nls.js';
+import { ConfigurationTarget } from '../../../../../platform/configuration/common/configuration.js';
 import { IMcpCollectionContribution } from '../../../../../platform/extensions/common/extensions.js';
 import { IStorageService, StorageScope, StorageTarget } from '../../../../../platform/storage/common/storage.js';
 import { IExtensionService } from '../../../../services/extensions/common/extensions.js';
@@ -85,6 +86,7 @@ export class ExtensionMcpDiscovery extends Disposable implements IMcpDiscovery {
 						remoteAuthority: null,
 						isTrustedByDefault: true,
 						scope: StorageScope.WORKSPACE,
+						configTarget: ConfigurationTarget.USER,
 						serverDefinitions: observableValue<McpServerDefinition[]>(this, serverDefs?.map(McpServerDefinition.fromSerialized) || []),
 						lazy: {
 							isCached: !!serverDefs,

--- a/src/vs/workbench/contrib/mcp/common/discovery/nativeMcpDiscoveryAbstract.ts
+++ b/src/vs/workbench/contrib/mcp/common/discovery/nativeMcpDiscoveryAbstract.ts
@@ -10,7 +10,7 @@ import { Schemas } from '../../../../../base/common/network.js';
 import { autorunWithStore, IObservable, IReader, ISettableObservable, observableValue } from '../../../../../base/common/observable.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { localize } from '../../../../../nls.js';
-import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
+import { ConfigurationTarget, IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 import { IFileService } from '../../../../../platform/files/common/files.js';
 import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
 import { ILabelService } from '../../../../../platform/label/common/label.js';
@@ -144,6 +144,7 @@ export abstract class NativeFilesystemMcpDiscovery extends FilesystemMcpDiscover
 				id: adapter.id,
 				label: discoverySourceLabel[adapter.discoverySource] + this.suffix,
 				remoteAuthority: adapter.remoteAuthority,
+				configTarget: ConfigurationTarget.USER,
 				scope: StorageScope.PROFILE,
 				isTrustedByDefault: false,
 				serverDefinitions: observableValue<readonly McpServerDefinition[]>(this, []),

--- a/src/vs/workbench/contrib/mcp/common/discovery/workspaceMcpDiscoveryAdapter.ts
+++ b/src/vs/workbench/contrib/mcp/common/discovery/workspaceMcpDiscoveryAdapter.ts
@@ -7,7 +7,7 @@ import { DisposableMap, IDisposable } from '../../../../../base/common/lifecycle
 import { observableValue } from '../../../../../base/common/observable.js';
 import { joinPath } from '../../../../../base/common/resources.js';
 import { URI } from '../../../../../base/common/uri.js';
-import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
+import { ConfigurationTarget, IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 import { IFileService } from '../../../../../platform/files/common/files.js';
 import { StorageScope } from '../../../../../platform/storage/common/storage.js';
 import { IWorkspaceContextService, IWorkspaceFolder } from '../../../../../platform/workspace/common/workspace.js';
@@ -56,6 +56,7 @@ export class CursorWorkspaceMcpDiscoveryAdapter extends FilesystemMcpDiscovery i
 			scope: StorageScope.WORKSPACE,
 			isTrustedByDefault: false,
 			serverDefinitions: observableValue(this, []),
+			configTarget: ConfigurationTarget.WORKSPACE_FOLDER,
 			presentation: {
 				origin: configFile,
 				order: McpCollectionSortOrder.WorkspaceFolder + 1,

--- a/src/vs/workbench/contrib/mcp/common/mcpCommandIds.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpCommandIds.ts
@@ -7,19 +7,20 @@
  * Contains all MCP command IDs used in the workbench.
  */
 export const enum McpCommandIds {
-	ListServer = 'workbench.mcp.listServer',
-	ServerOptions = 'workbench.mcp.serverOptions',
-	ResetTrust = 'workbench.mcp.resetTrust',
-	ResetCachedTools = 'workbench.mcp.resetCachedTools',
 	AddConfiguration = 'workbench.mcp.addConfiguration',
-	RemoveStoredInput = 'workbench.mcp.removeStoredInput',
-	EditStoredInput = 'workbench.mcp.editStoredInput',
+	Browse = 'workbench.mcp.browseServers',
 	BrowseResources = 'workbench.mcp.browseResources',
+	ConfigureSamplingModels = 'workbench.mcp.configureSamplingModels',
+	EditStoredInput = 'workbench.mcp.editStoredInput',
+	InstallFromActivation = 'workbench.mcp.installFromActivation',
+	ListServer = 'workbench.mcp.listServer',
+	RemoveStoredInput = 'workbench.mcp.removeStoredInput',
+	ResetCachedTools = 'workbench.mcp.resetCachedTools',
+	ResetTrust = 'workbench.mcp.resetTrust',
+	RestartServer = 'workbench.mcp.restartServer',
+	ServerOptions = 'workbench.mcp.serverOptions',
 	ShowConfiguration = 'workbench.mcp.showConfiguration',
 	ShowOutput = 'workbench.mcp.showOutput',
-	RestartServer = 'workbench.mcp.restartServer',
 	StartServer = 'workbench.mcp.startServer',
 	StopServer = 'workbench.mcp.stopServer',
-	InstallFromActivation = 'workbench.mcp.installFromActivation',
-	Browse = 'workbench.mcp.browseServers'
 }

--- a/src/vs/workbench/contrib/mcp/common/mcpConfiguration.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpConfiguration.ts
@@ -45,6 +45,13 @@ export const discoverySourceLabel: Record<DiscoverySource, string> = {
 export const mcpConfigurationSection = 'mcp';
 export const mcpDiscoverySection = 'chat.mcp.discovery.enabled';
 export const mcpEnabledSection = 'chat.mcp.enabled';
+export const mcpServerSamplingSection = 'chat.mcp.serverSampling';
+
+export interface IMcpServerSamplingConfiguration {
+	allowedDuringChat?: boolean;
+	allowedOutsideChat?: boolean;
+	allowedModels?: string[];
+}
 
 export const mcpSchemaExampleServers = {
 	'mcp-server-time': {

--- a/src/vs/workbench/contrib/mcp/common/mcpSamplingService.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpSamplingService.ts
@@ -1,0 +1,247 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { mapFindFirst } from '../../../../base/common/arraysFind.js';
+import { decodeBase64 } from '../../../../base/common/buffer.js';
+import { CancellationToken } from '../../../../base/common/cancellation.js';
+import { Event } from '../../../../base/common/event.js';
+import { isDefined } from '../../../../base/common/types.js';
+import { localize } from '../../../../nls.js';
+import { ICommandService } from '../../../../platform/commands/common/commands.js';
+import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
+import { IDialogService } from '../../../../platform/dialogs/common/dialogs.js';
+import { ExtensionIdentifier } from '../../../../platform/extensions/common/extensions.js';
+import { INotificationService, Severity } from '../../../../platform/notification/common/notification.js';
+import { ChatImageMimeType, ChatMessageRole, IChatMessage, IChatMessagePart, ILanguageModelsService } from '../../chat/common/languageModels.js';
+import { McpCommandIds } from './mcpCommandIds.js';
+import { IMcpServerSamplingConfiguration, mcpServerSamplingSection } from './mcpConfiguration.js';
+import { IMcpSamplingService, IMcpServer, ISamplingOptions, ISamplingResult, McpError } from './mcpTypes.js';
+import { MCP } from './modelContextProtocol.js';
+
+const enum ModelMatch {
+	UnsureAllowedDuringChat,
+	UnsureAllowedOutsideChat,
+	NotAllowed,
+	NoMatchingModel,
+}
+
+
+export class McpSamplingService implements IMcpSamplingService {
+	declare readonly _serviceBrand: undefined;
+
+	private readonly _sessionSets = {
+		allowedDuringChat: new Map<string, boolean>(),
+		allowedOutsideChat: new Map<string, boolean>(),
+	};
+
+	constructor(
+		@ILanguageModelsService private readonly _languageModelsService: ILanguageModelsService,
+		@IConfigurationService private readonly _configurationService: IConfigurationService,
+		@IDialogService private readonly _dialogService: IDialogService,
+		@INotificationService private readonly _notificationService: INotificationService,
+		@ICommandService private readonly _commandService: ICommandService,
+	) {
+		// Initialize the service with the language models service
+	}
+
+	async sample(opts: ISamplingOptions, token = CancellationToken.None): Promise<ISamplingResult> {
+		const messages = opts.params.messages.map((message): IChatMessage | undefined => {
+			const content: IChatMessagePart | undefined = message.content.type === 'text'
+				? { type: 'text', value: message.content.text }
+				: message.content.type === 'image' || message.content.type === 'audio'
+					? { type: 'image_url', value: { mimeType: message.content.mimeType as ChatImageMimeType, data: decodeBase64(message.content.data) } }
+					: undefined;
+			if (!content) {
+				return undefined;
+			}
+			return {
+				role: message.role === 'assistant' ? ChatMessageRole.Assistant : ChatMessageRole.User,
+				content: [content]
+			};
+		}).filter(isDefined);
+
+		const model = await this._getMatchingModel(opts);
+		// todo@connor4312: nullExtensionDescription.identifier -> undefined with API update
+		const response = await this._languageModelsService.sendChatRequest(model, new ExtensionIdentifier('Github.copilot-chat'), messages, {}, token);
+
+		let responseText = '';
+
+		// MCP doesn't have a notion of a multi-part sampling response, so we only preserve text
+		// Ref https://github.com/modelcontextprotocol/modelcontextprotocol/issues/91
+		const streaming = (async () => {
+			for await (const part of response.stream) {
+				if (Array.isArray(part)) {
+					for (const p of part) {
+						if (p.part.type === 'text') {
+							responseText += p.part.value;
+						}
+					}
+				} else if (part.part.type === 'text') {
+					responseText += part.part.value;
+				}
+			}
+		})();
+
+		try {
+			await Promise.all([response.result, streaming]);
+			return {
+				sample: {
+					model,
+					content: { type: 'text', text: responseText },
+					role: 'assistant', // it came from the model!
+				},
+			};
+		} catch (err) {
+			throw McpError.unknown(err);
+		}
+	}
+
+	private async _getMatchingModel(opts: ISamplingOptions): Promise<string> {
+		const model = await this._getMatchingModelInner(opts.server, opts.isDuringToolCall, opts.params.modelPreferences);
+
+		if (model === ModelMatch.UnsureAllowedDuringChat) {
+			const retry = await this._showContextual(
+				opts.isDuringToolCall,
+				localize('mcp.sampling.allowDuringChat.title', 'Allow MCP tools from "{0}" to make LLM requests?', opts.server.definition.label),
+				localize('mcp.sampling.allowDuringChat.desc', 'The MCP server "{0}" has issued a request to make an language model call. Do you want to allow it to make requests during chat?', opts.server.definition.label),
+				this.allowButtons(opts.server, 'allowedDuringChat')
+			);
+			if (retry) {
+				return this._getMatchingModel(opts);
+			}
+			throw McpError.notAllowed();
+		} else if (model === ModelMatch.UnsureAllowedOutsideChat) {
+			const retry = await this._showContextual(
+				opts.isDuringToolCall,
+				localize('mcp.sampling.allowOutsideChat.title', 'Allow MCP server "{0}" to make LLM requests?', opts.server.definition.label),
+				localize('mcp.sampling.allowOutsideChat.desc', 'The MCP server "{0}" has issued a request to make an language model call. Do you want to allow it to make requests, outside of tool calls during chat?', opts.server.definition.label),
+				this.allowButtons(opts.server, 'allowedOutsideChat')
+			);
+			if (retry) {
+				return this._getMatchingModel(opts);
+			}
+			throw McpError.notAllowed();
+		} else if (model === ModelMatch.NotAllowed) {
+			throw McpError.notAllowed();
+		} else if (model === ModelMatch.NoMatchingModel) {
+			const newlyPickedModels = opts.isDuringToolCall
+				? await this._commandService.executeCommand<number>(McpCommandIds.ConfigureSamplingModels, opts.server)
+				: await this._notify(
+					localize('mcp.sampling.needsModels', 'MCP server "{0}" triggered a language model request, but it has no allowlisted models.', opts.server.definition.label),
+					{
+						[localize('configure', 'Configure')]: () => this._commandService.executeCommand<number>(McpCommandIds.ConfigureSamplingModels, opts.server),
+						[localize('cancel', 'Cancel')]: () => Promise.resolve(undefined),
+					}
+				);
+			if (newlyPickedModels) {
+				return this._getMatchingModel(opts);
+			}
+			throw McpError.notAllowed();
+		}
+
+		return model;
+	}
+
+	private allowButtons(server: IMcpServer, key: 'allowedDuringChat' | 'allowedOutsideChat') {
+		return {
+			[localize('mcp.sampling.allow.inSession', 'Allow in this Session')]: async () => {
+				this._sessionSets[key].set(server.definition.id, true);
+				return true;
+			},
+			[localize('mcp.sampling.allow.always', 'Always')]: async () => {
+				await this.updateConfig(server, c => c[key] = true);
+				return true;
+			},
+			[localize('mcp.sampling.allow.notNow', 'Now Now')]: async () => {
+				this._sessionSets[key].set(server.definition.id, false);
+				return false;
+			},
+			[localize('mcp.sampling.allow.never', 'Never')]: async () => {
+				await this.updateConfig(server, c => c[key] = false);
+				return false;
+			},
+		};
+	}
+
+	private async _showContextual<T>(isDuringToolCall: boolean, title: string, message: string, buttons: Record<string, () => T>): Promise<Awaited<T> | undefined> {
+		if (isDuringToolCall) {
+			const result = await this._dialogService.prompt({
+				type: 'question',
+				title: title,
+				message,
+				buttons: Object.entries(buttons).map(([label, run]) => ({ label, run })),
+			});
+			return await result.result;
+		} else {
+			return await this._notify(message, buttons);
+		}
+	}
+
+	private async _notify<T>(message: string, buttons: Record<string, () => T>): Promise<Awaited<T> | undefined> {
+		return await new Promise<T | undefined>(resolve => {
+			const handle = this._notificationService.prompt(
+				Severity.Info,
+				message,
+				Object.entries(buttons).map(([label, action]) => ({
+					label,
+					run: () => resolve(action()),
+				}))
+			);
+			Event.once(handle.onDidClose)(() => resolve(undefined));
+		});
+	}
+
+	/**
+	 * Gets the matching model for the MCP server in this context, or
+	 * a reason why no model could be selected.
+	 */
+	private async _getMatchingModelInner(server: IMcpServer, isDuringToolCall: boolean, preferences: MCP.ModelPreferences | undefined): Promise<ModelMatch | string> {
+		const config = this.getConfig(server);
+		// 1. Ensure the server is allowed to sample in this context
+		if (isDuringToolCall && !config.allowedDuringChat && !this._sessionSets.allowedDuringChat.has(server.definition.id)) {
+			return config.allowedDuringChat === undefined ? ModelMatch.UnsureAllowedDuringChat : ModelMatch.NotAllowed;
+		} else if (!isDuringToolCall && !config.allowedOutsideChat && !this._sessionSets.allowedOutsideChat.has(server.definition.id)) {
+			return config.allowedOutsideChat === undefined ? ModelMatch.UnsureAllowedOutsideChat : ModelMatch.NotAllowed;
+		}
+
+		// 2. Get the configured models, or the default model(s)
+		const foundModelIdsDeep = config.allowedModels?.filter(m => !!this._languageModelsService.lookupLanguageModel(m)) || this._languageModelsService.getLanguageModelIds().filter(m => this._languageModelsService.lookupLanguageModel(m)?.isDefault);
+
+		const foundModelIds = foundModelIdsDeep.flat().sort((a, b) => b.length - a.length); // Sort by length to prefer most specific
+
+		if (!foundModelIds.length) {
+			return ModelMatch.NoMatchingModel;
+		}
+
+		// 3. If preferences are provided, try to match them from the allowed models
+		if (preferences?.hints) {
+			const found = mapFindFirst(preferences.hints, hint => foundModelIds.find(model => model.toLowerCase().includes(hint.name!.toLowerCase())));
+			if (found) {
+				return found;
+			}
+		}
+
+		return foundModelIds[0]; // Return the first matching model
+	}
+
+	public getConfig(server: IMcpServer): IMcpServerSamplingConfiguration {
+		const mapping = this._configurationService.getValue<Record<string, IMcpServerSamplingConfiguration>>(mcpServerSamplingSection);
+		return mapping[server.definition.id] || {};
+	}
+
+	public async updateConfig(server: IMcpServer, mutate: (r: IMcpServerSamplingConfiguration) => unknown) {
+		const def = server.readDefinitions().get();
+		const mapping = this._configurationService.getValue<Record<string, IMcpServerSamplingConfiguration>>(mcpServerSamplingSection, { resource: def.collection?.presentation?.origin });
+
+		const newConfig = { ...mapping[server.definition.id] };
+		mutate(newConfig);
+
+		await this._configurationService.updateValue(
+			mcpServerSamplingSection,
+			{ ...mapping, [server.definition.id]: newConfig },
+		);
+		return newConfig;
+	}
+}

--- a/src/vs/workbench/contrib/mcp/common/mcpServerRequestHandler.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpServerRequestHandler.ts
@@ -15,7 +15,7 @@ import { IInstantiationService } from '../../../../platform/instantiation/common
 import { canLog, ILogger, log, LogLevel } from '../../../../platform/log/common/log.js';
 import { IProductService } from '../../../../platform/product/common/productService.js';
 import { IMcpMessageTransport } from './mcpRegistryTypes.js';
-import { McpConnectionState, MpcResponseError } from './mcpTypes.js';
+import { IMcpClientMethods, McpConnectionState, McpError, MpcResponseError } from './mcpTypes.js';
 import { MCP } from './modelContextProtocol.js';
 
 /**
@@ -28,6 +28,15 @@ interface PendingRequest {
 export interface McpRoot {
 	uri: string;
 	name?: string;
+}
+
+export interface IMcpServerRequestHandlerOptions extends IMcpClientMethods {
+	/** MCP message transport */
+	launch: IMcpMessageTransport;
+	/** Logger instance. */
+	logger: ILogger;
+	/** Log level MCP messages is logged at */
+	requestLogLevel?: LogLevel;
 }
 
 /**
@@ -85,13 +94,13 @@ export class McpServerRequestHandler extends Disposable {
 	 * Connects to the MCP server and does the initialization handshake.
 	 * @throws MpcResponseError if the server fails to initialize.
 	 */
-	public static async create(instaService: IInstantiationService, launch: IMcpMessageTransport, logger: ILogger, requestLogLevel = LogLevel.Debug, token?: CancellationToken) {
-		const mcp = new McpServerRequestHandler(launch, logger, requestLogLevel);
+	public static async create(instaService: IInstantiationService, opts: IMcpServerRequestHandlerOptions, token?: CancellationToken) {
+		const mcp = new McpServerRequestHandler(opts);
 		const store = new DisposableStore();
 		try {
 			const timer = store.add(new IntervalTimer());
 			timer.cancelAndSet(() => {
-				logger.info('Waiting for server to respond to `initialize` request...');
+				opts.logger.info('Waiting for server to respond to `initialize` request...');
 			}, 5000);
 
 			await instaService.invokeFunction(async accessor => {
@@ -102,6 +111,7 @@ export class McpServerRequestHandler extends Disposable {
 						protocolVersion: MCP.LATEST_PROTOCOL_VERSION,
 						capabilities: {
 							roots: { listChanged: true },
+							sampling: opts.createMessageRequestHandler ? {} : undefined,
 						},
 						clientInfo: {
 							name: productService.nameLong,
@@ -126,12 +136,23 @@ export class McpServerRequestHandler extends Disposable {
 		}
 	}
 
-	protected constructor(
-		private readonly launch: IMcpMessageTransport,
-		public readonly logger: ILogger,
-		private readonly requestLogLevel: LogLevel,
-	) {
+	public readonly logger: ILogger;
+	private readonly _launch: IMcpMessageTransport;
+	private readonly _requestLogLevel: LogLevel;
+	private readonly _createMessageRequestHandler: IMcpServerRequestHandlerOptions['createMessageRequestHandler'];
+
+	protected constructor({
+		launch,
+		logger,
+		createMessageRequestHandler,
+		requestLogLevel = LogLevel.Debug,
+	}: IMcpServerRequestHandlerOptions) {
 		super();
+		this._launch = launch;
+		this.logger = logger;
+		this._requestLogLevel = requestLogLevel;
+		this._createMessageRequestHandler = createMessageRequestHandler;
+
 		this._register(launch.onDidReceiveMessage(message => this.handleMessage(message)));
 		this._register(autorun(reader => {
 			const state = launch.state.read(reader).state;
@@ -192,11 +213,11 @@ export class McpServerRequestHandler extends Disposable {
 	}
 
 	private send(mcp: MCP.JSONRPCMessage) {
-		if (canLog(this.logger.getLevel(), this.requestLogLevel)) { // avoid building the string if we don't need to
-			log(this.logger, this.requestLogLevel, `[editor -> server] ${JSON.stringify(mcp)}`);
+		if (canLog(this.logger.getLevel(), this._requestLogLevel)) { // avoid building the string if we don't need to
+			log(this.logger, this._requestLogLevel, `[editor -> server] ${JSON.stringify(mcp)}`);
 		}
 
-		this.launch.send(mcp);
+		this._launch.send(mcp);
 	}
 
 	/**
@@ -231,8 +252,8 @@ export class McpServerRequestHandler extends Disposable {
 	 * Handle incoming messages from the server
 	 */
 	private handleMessage(message: MCP.JSONRPCMessage): void {
-		if (canLog(this.logger.getLevel(), this.requestLogLevel)) { // avoid building the string if we don't need to
-			log(this.logger, this.requestLogLevel, `[server -> editor] ${JSON.stringify(message)}`);
+		if (canLog(this.logger.getLevel(), this._requestLogLevel)) { // avoid building the string if we don't need to
+			log(this.logger, this._requestLogLevel, `[server -> editor] ${JSON.stringify(message)}`);
 		}
 
 		// Handle responses to our requests
@@ -279,25 +300,36 @@ export class McpServerRequestHandler extends Disposable {
 	/**
 	 * Handle incoming server requests
 	 */
-	private handleServerRequest(request: MCP.JSONRPCRequest & MCP.ServerRequest): void {
-		switch (request.method) {
-			case 'ping':
-				return this.respondToRequest(request, this.handlePing(request));
-			case 'roots/list':
-				return this.respondToRequest(request, this.handleRootsList(request));
-
-			default: {
-				const errorResponse: MCP.JSONRPCError = {
-					jsonrpc: MCP.JSONRPC_VERSION,
-					id: request.id,
-					error: {
-						code: MCP.METHOD_NOT_FOUND,
-						message: `Method not found: ${request.method}`
-					}
-				};
-				this.send(errorResponse);
-				break;
+	private async handleServerRequest(request: MCP.JSONRPCRequest & MCP.ServerRequest): Promise<void> {
+		try {
+			let response: MCP.Result | undefined;
+			if (request.method === 'ping') {
+				response = this.handlePing(request);
+			} else if (request.method === 'roots/list') {
+				response = this.handleRootsList(request);
+			} else if (request.method === 'sampling/createMessage' && this._createMessageRequestHandler) {
+				response = await this._createMessageRequestHandler(request.params as MCP.CreateMessageRequest['params']);
+			} else {
+				throw McpError.methodNotFound(request.method);
 			}
+			this.respondToRequest(request, response);
+		} catch (e) {
+			if (!(e instanceof McpError)) {
+				this.logger.error(`Error handling request ${request.method}:`, e);
+				e = McpError.unknown(e);
+			}
+
+			const errorResponse: MCP.JSONRPCError = {
+				jsonrpc: MCP.JSONRPC_VERSION,
+				id: request.id,
+				error: {
+					code: e.code,
+					message: e.message,
+					data: e.data,
+				}
+			};
+
+			this.send(errorResponse);
 		}
 	}
 	/**

--- a/src/vs/workbench/contrib/mcp/common/mcpTypes.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpTypes.ts
@@ -54,6 +54,8 @@ export interface McpCollectionDefinition {
 	readonly isTrustedByDefault: boolean;
 	/** Scope where associated collection info should be stored. */
 	readonly scope: StorageScope;
+	/** Configuration target where configuration related to this server should be stored. */
+	readonly configTarget: ConfigurationTarget;
 
 	/** Resolves a server definition. If present, always called before a server starts. */
 	resolveServerLanch?(definition: McpServerDefinition): Promise<McpServerLaunch | undefined>;
@@ -94,6 +96,7 @@ export namespace McpCollectionDefinition {
 		readonly scope: StorageScope;
 		readonly canResolveLaunch: boolean;
 		readonly extensionId: string;
+		readonly configTarget: ConfigurationTarget;
 	}
 
 	export function equals(a: McpCollectionDefinition, b: McpCollectionDefinition): boolean {

--- a/src/vs/workbench/contrib/mcp/test/common/mcpRegistry.test.ts
+++ b/src/vs/workbench/contrib/mcp/test/common/mcpRegistry.test.ts
@@ -155,7 +155,8 @@ suite('Workbench - MCP - Registry', () => {
 			remoteAuthority: null,
 			serverDefinitions: observableValue('serverDefs', []),
 			isTrustedByDefault: true,
-			scope: StorageScope.APPLICATION
+			scope: StorageScope.APPLICATION,
+			configTarget: ConfigurationTarget.USER,
 		};
 
 		// Create base definition that can be reused

--- a/src/vs/workbench/contrib/mcp/test/common/mcpRegistryTypes.ts
+++ b/src/vs/workbench/contrib/mcp/test/common/mcpRegistryTypes.ts
@@ -167,6 +167,7 @@ export class TestMcpRegistry implements IMcpRegistry {
 		id: 'test-collection',
 		remoteAuthority: null,
 		label: 'Test Collection',
+		configTarget: ConfigurationTarget.USER,
 		serverDefinitions: observableValue(this, [{
 			id: 'test-server',
 			label: 'Test Server',

--- a/src/vs/workbench/contrib/mcp/test/common/mcpServerConnection.test.ts
+++ b/src/vs/workbench/contrib/mcp/test/common/mcpServerConnection.test.ts
@@ -20,6 +20,7 @@ import { IMcpHostDelegate, IMcpMessageTransport } from '../../common/mcpRegistry
 import { McpServerConnection } from '../../common/mcpServerConnection.js';
 import { McpCollectionDefinition, McpConnectionState, McpServerDefinition, McpServerTransportType } from '../../common/mcpTypes.js';
 import { TestMcpMessageTransport } from './mcpRegistryTypes.js';
+import { ConfigurationTarget } from '../../../../../platform/configuration/common/configuration.js';
 
 class TestMcpHostDelegate extends Disposable implements IMcpHostDelegate {
 	private readonly _transport: TestMcpMessageTransport;
@@ -86,7 +87,8 @@ suite('Workbench - MCP - ServerConnection', () => {
 			remoteAuthority: null,
 			serverDefinitions: observableValue('serverDefs', []),
 			isTrustedByDefault: true,
-			scope: StorageScope.APPLICATION
+			scope: StorageScope.APPLICATION,
+			configTarget: ConfigurationTarget.USER,
 		};
 
 		// Create server definition

--- a/src/vs/workbench/contrib/mcp/test/common/mcpServerConnection.test.ts
+++ b/src/vs/workbench/contrib/mcp/test/common/mcpServerConnection.test.ts
@@ -135,7 +135,7 @@ suite('Workbench - MCP - ServerConnection', () => {
 		store.add(connection);
 
 		// Start the connection
-		const startPromise = connection.start();
+		const startPromise = connection.start({});
 
 		// Simulate successful connection
 		transport.setConnectionState({ state: McpConnectionState.Kind.Running });
@@ -163,7 +163,7 @@ suite('Workbench - MCP - ServerConnection', () => {
 		store.add(connection);
 
 		// Start the connection
-		const state = await connection.start();
+		const state = await connection.start({});
 
 		assert.strictEqual(state.state, McpConnectionState.Kind.Error);
 		assert.ok(state.message);
@@ -182,7 +182,7 @@ suite('Workbench - MCP - ServerConnection', () => {
 		store.add(connection);
 
 		// Start the connection
-		const startPromise = connection.start();
+		const startPromise = connection.start({});
 
 		// Simulate error in transport
 		transport.setConnectionState({
@@ -208,7 +208,7 @@ suite('Workbench - MCP - ServerConnection', () => {
 		store.add(connection);
 
 		// Start the connection
-		const startPromise = connection.start();
+		const startPromise = connection.start({});
 		transport.setConnectionState({ state: McpConnectionState.Kind.Running });
 		await startPromise;
 
@@ -232,10 +232,10 @@ suite('Workbench - MCP - ServerConnection', () => {
 		store.add(connection);
 
 		// Start the connection
-		const startPromise1 = connection.start();
+		const startPromise1 = connection.start({});
 
 		// Try to start again while starting
-		const startPromise2 = connection.start();
+		const startPromise2 = connection.start({});
 
 		// Simulate successful connection
 		transport.setConnectionState({ state: McpConnectionState.Kind.Running });
@@ -265,7 +265,7 @@ suite('Workbench - MCP - ServerConnection', () => {
 		);
 
 		// Start the connection
-		const startPromise = connection.start();
+		const startPromise = connection.start({});
 		transport.setConnectionState({ state: McpConnectionState.Kind.Running });
 		await startPromise;
 
@@ -298,7 +298,7 @@ suite('Workbench - MCP - ServerConnection', () => {
 		store.add(connection);
 
 		// Start the connection
-		const startPromise = connection.start();
+		const startPromise = connection.start({});
 
 		// Simulate log message from transport
 		transport.simulateLog('Test log message');
@@ -327,7 +327,7 @@ suite('Workbench - MCP - ServerConnection', () => {
 		store.add(connection);
 
 		// Start the connection
-		const startPromise = connection.start();
+		const startPromise = connection.start({});
 
 		// Transition to error state
 		const errorState: McpConnectionState = {
@@ -343,7 +343,7 @@ suite('Workbench - MCP - ServerConnection', () => {
 		transport.setConnectionState({ state: McpConnectionState.Kind.Stopped });
 
 		// Transition back to running state
-		const startPromise2 = connection.start();
+		const startPromise2 = connection.start({});
 		transport.setConnectionState({ state: McpConnectionState.Kind.Running });
 		state = await startPromise2;
 		assert.deepStrictEqual(state, { state: McpConnectionState.Kind.Running });
@@ -365,7 +365,7 @@ suite('Workbench - MCP - ServerConnection', () => {
 		store.add(connection);
 
 		// First cycle
-		let startPromise = connection.start();
+		let startPromise = connection.start({});
 		transport.setConnectionState({ state: McpConnectionState.Kind.Running });
 		await startPromise;
 
@@ -373,7 +373,7 @@ suite('Workbench - MCP - ServerConnection', () => {
 		assert.deepStrictEqual(connection.state.get(), { state: McpConnectionState.Kind.Stopped });
 
 		// Second cycle
-		startPromise = connection.start();
+		startPromise = connection.start({});
 		transport.setConnectionState({ state: McpConnectionState.Kind.Running });
 		await startPromise;
 

--- a/src/vs/workbench/contrib/mcp/test/common/mcpServerRequestHandler.test.ts
+++ b/src/vs/workbench/contrib/mcp/test/common/mcpServerRequestHandler.test.ts
@@ -79,7 +79,7 @@ suite('Workbench - MCP - ServerRequestHandler', () => {
 			.createLogger('mcpServerTest', { hidden: true, name: 'MCP Test' }));
 
 		// Start the handler creation
-		const handlerPromise = McpServerRequestHandler.create(instantiationService, transport, logger, undefined, cts.token);
+		const handlerPromise = McpServerRequestHandler.create(instantiationService, { logger, launch: transport }, cts.token);
 
 		handler = await handlerPromise;
 		store.add(handler);


### PR DESCRIPTION
- MCP servers get a prompt when they ask for sampling. Usage in tool
  calls (i.e. a sampling request within a concurrent tool request) is a
  separate prompt from 'ambient' usage. Sampling is 'just' a request to
  the client and can technically happen at any time.
- By default MCP servers will get the default model in chat. But that is
  configurable by users. Multiple models can be configured and if they
  are then the model will be picked based on the rough 'model hints' we
  get from the server.
- Not sure where the config should live. I have it in user settings in
  this demo. Having it in mcp.json would be a natural place to put it,
  but that doesn't work for extension-provided servers or servers from
  other config files (e.g. claude desktop configs) so that could not
  be the only place.
- There are some limitations from MCP such as https://github.com/modelcontextprotocol/modelcontextprotocol/issues/91

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
