### PR TITLE
Add `editor.inlineSuggest.experimental.suppressInlineSuggestions`

### DIFF
--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -1357,6 +1357,13 @@ class EditorEnumOption<K extends EditorOption, T extends string, V> extends Base
 	}
 }
 
+function stringArray(value: any, defaultValue: string[]): string[] {
+	if (!Array.isArray(value)) {
+		return defaultValue;
+	}
+	return value.map(item => String(item));
+}
+
 //#endregion
 
 //#region autoIndent
@@ -4274,6 +4281,16 @@ export interface IInlineSuggestOptions {
 		*/
 		useMultiLineGhostText?: boolean;
 	};
+
+	/**
+	* @internal
+	*/
+	experimental?: {
+		/**
+		* @internal
+		*/
+		suppressInlineSuggestions?: string[];
+	};
 }
 
 type RequiredRecursive<T> = {
@@ -4305,6 +4322,9 @@ class InlineEditorSuggest extends BaseEditorOption<EditorOption.inlineSuggest, I
 				allowCodeShifting: 'always',
 				useMultiLineGhostText: true
 			},
+			experimental: {
+				suppressInlineSuggestions: [],
+			},
 		};
 
 		super(
@@ -4335,6 +4355,12 @@ class InlineEditorSuggest extends BaseEditorOption<EditorOption.inlineSuggest, I
 					type: 'boolean',
 					default: defaults.suppressSuggestions,
 					description: nls.localize('inlineSuggest.suppressSuggestions', "Controls how inline suggestions interact with the suggest widget. If enabled, the suggest widget is not shown automatically when inline suggestions are available.")
+				},
+				'editor.inlineSuggest.experimental.suppressInlineSuggestions': {
+					type: 'array',
+					tags: ['experimental', 'onExp'],
+					items: { type: 'string' },
+					description: nls.localize('inlineSuggest.suppressInlineSuggestions', "Suppresses inline completions for specified extension IDs.")
 				},
 				'editor.inlineSuggest.fontFamily': {
 					type: 'string',
@@ -4388,6 +4414,9 @@ class InlineEditorSuggest extends BaseEditorOption<EditorOption.inlineSuggest, I
 				allowCodeShifting: stringSet(input.edits?.allowCodeShifting, this.defaultValue.edits.allowCodeShifting, ['always', 'horizontal', 'never']),
 				renderSideBySide: stringSet(input.edits?.renderSideBySide, this.defaultValue.edits.renderSideBySide, ['never', 'auto']),
 				useMultiLineGhostText: boolean(input.edits?.useMultiLineGhostText, this.defaultValue.edits.useMultiLineGhostText),
+			},
+			experimental: {
+				suppressInlineSuggestions: stringArray(input.experimental?.suppressInlineSuggestions, this.defaultValue.experimental.suppressInlineSuggestions),
 			},
 		};
 	}


### PR DESCRIPTION
```Copilot Generated Description:``` Introduce a new experimental option to suppress inline suggestions for specified extension IDs. This change includes updates to the editor options and the inline completions model to accommodate the new functionality.

related https://github.com/microsoft/vscode-copilot/issues/14337