### PR TITLE
feat: Add support for preferred light/dark file icon themes 

### DIFF
--- a/src/vs/platform/theme/common/theme.ts
+++ b/src/vs/platform/theme/common/theme.ts
@@ -13,13 +13,20 @@ export enum ColorScheme {
 	HIGH_CONTRAST_LIGHT = 'hcLight'
 }
 
+/**
+ * File icon scheme used by the OS and by color themes.
+ */
+export enum FileIconScheme {
+	DARK = 'dark',
+	LIGHT = 'light',
+}
+
 export enum ThemeTypeSelector {
 	VS = 'vs',
 	VS_DARK = 'vs-dark',
 	HC_BLACK = 'hc-black',
 	HC_LIGHT = 'hc-light'
 }
-
 
 export function isHighContrast(scheme: ColorScheme): boolean {
 	return scheme === ColorScheme.HIGH_CONTRAST_DARK || scheme === ColorScheme.HIGH_CONTRAST_LIGHT;

--- a/src/vs/workbench/contrib/themes/browser/themes.contribution.ts
+++ b/src/vs/workbench/contrib/themes/browser/themes.contribution.ts
@@ -726,19 +726,19 @@ registerAction2(class extends Action2 {
 		}
 
 		const currentTheme = themeService.getColorTheme();
-		let newSettingsId: string = ThemeSettings.PREFERRED_DARK_THEME;
+		let newSettingsId: string = ThemeSettings.PREFERRED_DARK_COLOR_THEME;
 		switch (currentTheme.type) {
 			case ColorScheme.LIGHT:
-				newSettingsId = ThemeSettings.PREFERRED_DARK_THEME;
+				newSettingsId = ThemeSettings.PREFERRED_DARK_COLOR_THEME;
 				break;
 			case ColorScheme.DARK:
-				newSettingsId = ThemeSettings.PREFERRED_LIGHT_THEME;
+				newSettingsId = ThemeSettings.PREFERRED_LIGHT_COLOR_THEME;
 				break;
 			case ColorScheme.HIGH_CONTRAST_LIGHT:
-				newSettingsId = ThemeSettings.PREFERRED_HC_DARK_THEME;
+				newSettingsId = ThemeSettings.PREFERRED_HC_DARK_COLOR_THEME;
 				break;
 			case ColorScheme.HIGH_CONTRAST_DARK:
-				newSettingsId = ThemeSettings.PREFERRED_HC_LIGHT_THEME;
+				newSettingsId = ThemeSettings.PREFERRED_HC_LIGHT_COLOR_THEME;
 				break;
 		}
 

--- a/src/vs/workbench/services/themes/browser/workbenchThemeService.ts
+++ b/src/vs/workbench/services/themes/browser/workbenchThemeService.ts
@@ -34,7 +34,7 @@ import { ProductIconThemeData, DEFAULT_PRODUCT_ICON_THEME_ID } from './productIc
 import { registerProductIconThemeSchemas } from '../common/productIconThemeSchema.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
 import { isWeb } from '../../../../base/common/platform.js';
-import { ColorScheme, ThemeTypeSelector } from '../../../../platform/theme/common/theme.js';
+import { ColorScheme, FileIconScheme, ThemeTypeSelector } from '../../../../platform/theme/common/theme.js';
 import { IHostColorSchemeService } from '../common/hostColorSchemeService.js';
 import { RunOnceScheduler, Sequencer } from '../../../../base/common/async.js';
 import { IUserDataInitializationService } from '../../userData/browser/userDataInit.js';
@@ -255,7 +255,12 @@ export class WorkbenchThemeService extends Disposable implements IWorkbenchTheme
 			) {
 				this.restoreColorTheme();
 			}
-			if (e.affectsConfiguration(ThemeSettings.FILE_ICON_THEME)) {
+			if (e.affectsConfiguration(ThemeSettings.FILE_ICON_THEME)
+				|| e.affectsConfiguration(ThemeSettings.PREFERRED_LIGHT_FILE_ICON_THEME)
+				|| e.affectsConfiguration(ThemeSettings.PREFERRED_DARK_FILE_ICON_THEME)
+				|| e.affectsConfiguration(ThemeSettings.DETECT_COLOR_SCHEME)
+				|| e.affectsConfiguration(ThemeSettings.SYSTEM_COLOR_THEME)
+			) {
 				this.restoreFileIconTheme();
 			}
 			if (e.affectsConfiguration(ThemeSettings.PRODUCT_ICON_THEME)) {
@@ -358,6 +363,7 @@ export class WorkbenchThemeService extends Disposable implements IWorkbenchTheme
 		this._register(this.hostColorService.onDidChangeColorScheme(() => {
 			if (this.settings.isDetectingColorScheme()) {
 				this.restoreColorTheme();
+				this.restoreFileIconTheme();
 			}
 		}));
 	}
@@ -550,12 +556,16 @@ export class WorkbenchThemeService extends Disposable implements IWorkbenchTheme
 		}
 	}
 
+	public getFileIconTheme(): IWorkbenchFileIconTheme {
+		return this.currentFileIconTheme;
+	}
+
 	public async getFileIconThemes(): Promise<IWorkbenchFileIconTheme[]> {
 		return this.fileIconThemeRegistry.getThemes();
 	}
 
-	public getFileIconTheme() {
-		return this.currentFileIconTheme;
+	public getPreferredFileIconScheme(): FileIconScheme | undefined {
+		return this.settings.getPreferredFileIconScheme();
 	}
 
 	public get onDidFileIconThemeChange(): Event<IWorkbenchFileIconTheme> {

--- a/src/vs/workbench/services/themes/browser/workbenchThemeService.ts
+++ b/src/vs/workbench/services/themes/browser/workbenchThemeService.ts
@@ -245,10 +245,10 @@ export class WorkbenchThemeService extends Disposable implements IWorkbenchTheme
 	private installConfigurationListener() {
 		this._register(this.configurationService.onDidChangeConfiguration(e => {
 			if (e.affectsConfiguration(ThemeSettings.COLOR_THEME)
-				|| e.affectsConfiguration(ThemeSettings.PREFERRED_DARK_THEME)
-				|| e.affectsConfiguration(ThemeSettings.PREFERRED_LIGHT_THEME)
-				|| e.affectsConfiguration(ThemeSettings.PREFERRED_HC_DARK_THEME)
-				|| e.affectsConfiguration(ThemeSettings.PREFERRED_HC_LIGHT_THEME)
+				|| e.affectsConfiguration(ThemeSettings.PREFERRED_DARK_COLOR_THEME)
+				|| e.affectsConfiguration(ThemeSettings.PREFERRED_LIGHT_COLOR_THEME)
+				|| e.affectsConfiguration(ThemeSettings.PREFERRED_HC_DARK_COLOR_THEME)
+				|| e.affectsConfiguration(ThemeSettings.PREFERRED_HC_LIGHT_COLOR_THEME)
 				|| e.affectsConfiguration(ThemeSettings.DETECT_COLOR_SCHEME)
 				|| e.affectsConfiguration(ThemeSettings.DETECT_HC)
 				|| e.affectsConfiguration(ThemeSettings.SYSTEM_COLOR_THEME)

--- a/src/vs/workbench/services/themes/common/themeConfiguration.ts
+++ b/src/vs/workbench/services/themes/common/themeConfiguration.ts
@@ -41,7 +41,7 @@ const colorThemeSettingSchema: IConfigurationPropertySchema = {
 	enumItemLabels: colorThemeSettingEnumItemLabels,
 	errorMessage: nls.localize('colorThemeError', "Theme is unknown or not installed."),
 };
-const preferredDarkThemeSettingSchema: IConfigurationPropertySchema = {
+const preferredDarkColorThemeSettingSchema: IConfigurationPropertySchema = {
 	type: 'string', //
 	markdownDescription: nls.localize({ key: 'preferredDarkColorTheme', comment: ['{0} will become a link to another setting.'] }, 'Specifies the color theme when system color mode is dark and {0} is enabled.', formatSettingAsLink(ThemeSettings.DETECT_COLOR_SCHEME)),
 	default: ThemeSettingDefaults.COLOR_THEME_DARK,
@@ -51,7 +51,7 @@ const preferredDarkThemeSettingSchema: IConfigurationPropertySchema = {
 	enumItemLabels: colorThemeSettingEnumItemLabels,
 	errorMessage: nls.localize('colorThemeError', "Theme is unknown or not installed."),
 };
-const preferredLightThemeSettingSchema: IConfigurationPropertySchema = {
+const preferredLightColorThemeSettingSchema: IConfigurationPropertySchema = {
 	type: 'string',
 	markdownDescription: nls.localize({ key: 'preferredLightColorTheme', comment: ['{0} will become a link to another setting.'] }, 'Specifies the color theme when system color mode is light and {0} is enabled.', formatSettingAsLink(ThemeSettings.DETECT_COLOR_SCHEME)),
 	default: ThemeSettingDefaults.COLOR_THEME_LIGHT,
@@ -61,7 +61,7 @@ const preferredLightThemeSettingSchema: IConfigurationPropertySchema = {
 	enumItemLabels: colorThemeSettingEnumItemLabels,
 	errorMessage: nls.localize('colorThemeError', "Theme is unknown or not installed."),
 };
-const preferredHCDarkThemeSettingSchema: IConfigurationPropertySchema = {
+const preferredHCDarkColorThemeSettingSchema: IConfigurationPropertySchema = {
 	type: 'string',
 	markdownDescription: nls.localize({ key: 'preferredHCDarkColorTheme', comment: ['{0} will become a link to another setting.'] }, 'Specifies the color theme when in high contrast dark mode and {0} is enabled.', formatSettingAsLink(ThemeSettings.DETECT_HC)),
 	default: ThemeSettingDefaults.COLOR_THEME_HC_DARK,
@@ -71,7 +71,7 @@ const preferredHCDarkThemeSettingSchema: IConfigurationPropertySchema = {
 	enumItemLabels: colorThemeSettingEnumItemLabels,
 	errorMessage: nls.localize('colorThemeError', "Theme is unknown or not installed."),
 };
-const preferredHCLightThemeSettingSchema: IConfigurationPropertySchema = {
+const preferredHCLightColorThemeSettingSchema: IConfigurationPropertySchema = {
 	type: 'string',
 	markdownDescription: nls.localize({ key: 'preferredHCLightColorTheme', comment: ['{0} will become a link to another setting.'] }, 'Specifies the color theme when in high contrast light mode and {0} is enabled.', formatSettingAsLink(ThemeSettings.DETECT_HC)),
 	default: ThemeSettingDefaults.COLOR_THEME_HC_LIGHT,
@@ -81,23 +81,21 @@ const preferredHCLightThemeSettingSchema: IConfigurationPropertySchema = {
 	enumItemLabels: colorThemeSettingEnumItemLabels,
 	errorMessage: nls.localize('colorThemeError', "Theme is unknown or not installed."),
 };
+
 const detectColorSchemeSettingSchema: IConfigurationPropertySchema = {
 	type: 'boolean',
-	markdownDescription: nls.localize({ key: 'detectColorScheme', comment: ['{0} and {1} will become links to other settings.'] }, 'If enabled, will automatically select a color theme based on the system color mode. If the system color mode is dark, {0} is used, else {1}.', formatSettingAsLink(ThemeSettings.PREFERRED_DARK_THEME), formatSettingAsLink(ThemeSettings.PREFERRED_LIGHT_THEME)),
+	markdownDescription: nls.localize({ key: 'detectColorScheme', comment: ['{0} and {1} will become links to other settings.'] }, 'If enabled, will automatically select a color theme based on the system color mode. If the system color mode is dark, {0} is used, else {1}.', formatSettingAsLink(ThemeSettings.PREFERRED_DARK_COLOR_THEME), formatSettingAsLink(ThemeSettings.PREFERRED_LIGHT_COLOR_THEME)),
 	default: false,
 	tags: [COLOR_THEME_CONFIGURATION_SETTINGS_TAG],
 };
-
-const colorCustomizationsSchema: IConfigurationPropertySchema = {
-	type: 'object',
-	description: nls.localize('workbenchColors', "Overrides colors from the currently selected color theme."),
-	allOf: [{ $ref: workbenchColorsSchemaId }],
-	default: {},
-	defaultSnippets: [{
-		body: {
-		}
-	}]
+const detectHCSchemeSettingSchema: IConfigurationPropertySchema = {
+	type: 'boolean',
+	default: true,
+	markdownDescription: nls.localize({ key: 'autoDetectHighContrast', comment: ['{0} and {1} will become links to other settings.'] }, "If enabled, will automatically change to high contrast theme if the OS is using a high contrast theme. The high contrast theme to use is specified by {0} and {1}.", formatSettingAsLink(ThemeSettings.PREFERRED_HC_DARK_COLOR_THEME), formatSettingAsLink(ThemeSettings.PREFERRED_HC_LIGHT_COLOR_THEME)),
+	scope: ConfigurationScope.APPLICATION,
+	tags: [COLOR_THEME_CONFIGURATION_SETTINGS_TAG],
 };
+
 const fileIconThemeSettingSchema: IConfigurationPropertySchema = {
 	type: ['string', 'null'],
 	default: ThemeSettingDefaults.FILE_ICON_THEME,
@@ -117,12 +115,15 @@ const productIconThemeSettingSchema: IConfigurationPropertySchema = {
 	errorMessage: nls.localize('productIconThemeError', "Product icon theme is unknown or not installed.")
 };
 
-const detectHCSchemeSettingSchema: IConfigurationPropertySchema = {
-	type: 'boolean',
-	default: true,
-	markdownDescription: nls.localize({ key: 'autoDetectHighContrast', comment: ['{0} and {1} will become links to other settings.'] }, "If enabled, will automatically change to high contrast theme if the OS is using a high contrast theme. The high contrast theme to use is specified by {0} and {1}.", formatSettingAsLink(ThemeSettings.PREFERRED_HC_DARK_THEME), formatSettingAsLink(ThemeSettings.PREFERRED_HC_LIGHT_THEME)),
-	scope: ConfigurationScope.APPLICATION,
-	tags: [COLOR_THEME_CONFIGURATION_SETTINGS_TAG],
+const colorCustomizationsSchema: IConfigurationPropertySchema = {
+	type: 'object',
+	description: nls.localize('workbenchColors', "Overrides colors from the currently selected color theme."),
+	allOf: [{ $ref: workbenchColorsSchemaId }],
+	default: {},
+	defaultSnippets: [{
+		body: {
+		}
+	}]
 };
 
 const themeSettingsConfiguration: IConfigurationNode = {
@@ -131,13 +132,13 @@ const themeSettingsConfiguration: IConfigurationNode = {
 	type: 'object',
 	properties: {
 		[ThemeSettings.COLOR_THEME]: colorThemeSettingSchema,
-		[ThemeSettings.PREFERRED_DARK_THEME]: preferredDarkThemeSettingSchema,
-		[ThemeSettings.PREFERRED_LIGHT_THEME]: preferredLightThemeSettingSchema,
-		[ThemeSettings.PREFERRED_HC_DARK_THEME]: preferredHCDarkThemeSettingSchema,
-		[ThemeSettings.PREFERRED_HC_LIGHT_THEME]: preferredHCLightThemeSettingSchema,
+		[ThemeSettings.PREFERRED_DARK_COLOR_THEME]: preferredDarkColorThemeSettingSchema,
+		[ThemeSettings.PREFERRED_LIGHT_COLOR_THEME]: preferredLightColorThemeSettingSchema,
+		[ThemeSettings.PREFERRED_HC_DARK_COLOR_THEME]: preferredHCDarkColorThemeSettingSchema,
+		[ThemeSettings.PREFERRED_HC_LIGHT_COLOR_THEME]: preferredHCLightColorThemeSettingSchema,
 		[ThemeSettings.FILE_ICON_THEME]: fileIconThemeSettingSchema,
+		[ThemeSettings.PRODUCT_ICON_THEME]: productIconThemeSettingSchema,
 		[ThemeSettings.COLOR_CUSTOMIZATIONS]: colorCustomizationsSchema,
-		[ThemeSettings.PRODUCT_ICON_THEME]: productIconThemeSettingSchema
 	}
 };
 configurationRegistry.registerConfiguration(themeSettingsConfiguration);
@@ -275,10 +276,10 @@ export function updateProductIconThemeConfigurationSchemas(themes: IWorkbenchPro
 }
 
 const colorSchemeToPreferred = {
-	[ColorScheme.DARK]: ThemeSettings.PREFERRED_DARK_THEME,
-	[ColorScheme.LIGHT]: ThemeSettings.PREFERRED_LIGHT_THEME,
-	[ColorScheme.HIGH_CONTRAST_DARK]: ThemeSettings.PREFERRED_HC_DARK_THEME,
-	[ColorScheme.HIGH_CONTRAST_LIGHT]: ThemeSettings.PREFERRED_HC_LIGHT_THEME
+	[ColorScheme.DARK]: ThemeSettings.PREFERRED_DARK_COLOR_THEME,
+	[ColorScheme.LIGHT]: ThemeSettings.PREFERRED_LIGHT_COLOR_THEME,
+	[ColorScheme.HIGH_CONTRAST_DARK]: ThemeSettings.PREFERRED_HC_DARK_COLOR_THEME,
+	[ColorScheme.HIGH_CONTRAST_LIGHT]: ThemeSettings.PREFERRED_HC_LIGHT_COLOR_THEME
 };
 
 export class ThemeConfiguration {

--- a/src/vs/workbench/services/themes/common/workbenchThemeService.ts
+++ b/src/vs/workbench/services/themes/common/workbenchThemeService.ts
@@ -10,7 +10,7 @@ import { IColorTheme, IThemeService, IFileIconTheme, IProductIconTheme } from '.
 import { ConfigurationTarget } from '../../../../platform/configuration/common/configuration.js';
 import { isBoolean, isString } from '../../../../base/common/types.js';
 import { IconContribution, IconDefinition } from '../../../../platform/theme/common/iconRegistry.js';
-import { ColorScheme, ThemeTypeSelector } from '../../../../platform/theme/common/theme.js';
+import { ColorScheme, FileIconScheme, ThemeTypeSelector } from '../../../../platform/theme/common/theme.js';
 
 export const IWorkbenchThemeService = refineServiceDecorator<IThemeService, IWorkbenchThemeService>(IThemeService);
 
@@ -32,6 +32,9 @@ export enum ThemeSettings {
 	PREFERRED_LIGHT_COLOR_THEME = 'workbench.preferredLightColorTheme',
 	PREFERRED_HC_DARK_COLOR_THEME = 'workbench.preferredHighContrastColorTheme', /* id kept for compatibility reasons */
 	PREFERRED_HC_LIGHT_COLOR_THEME = 'workbench.preferredHighContrastLightColorTheme',
+
+	PREFERRED_DARK_FILE_ICON_THEME = 'workbench.preferredDarkFileIconTheme',
+	PREFERRED_LIGHT_FILE_ICON_THEME = 'workbench.preferredLightFileIconTheme',
 
 	DETECT_COLOR_SCHEME = 'window.autoDetectColorScheme',
 	DETECT_HC = 'window.autoDetectHighContrast',
@@ -150,6 +153,8 @@ export interface IWorkbenchThemeService extends IThemeService {
 	getFileIconThemes(): Promise<IWorkbenchFileIconTheme[]>;
 	getMarketplaceFileIconThemes(publisher: string, name: string, version: string): Promise<IWorkbenchFileIconTheme[]>;
 	onDidFileIconThemeChange: Event<IWorkbenchFileIconTheme>;
+
+	getPreferredFileIconScheme(): FileIconScheme | undefined;
 
 	setProductIconTheme(iconThemeId: string | undefined | IWorkbenchProductIconTheme, settingsTarget: ThemeSettingTarget): Promise<IWorkbenchProductIconTheme>;
 	getProductIconTheme(): IWorkbenchProductIconTheme;

--- a/src/vs/workbench/services/themes/common/workbenchThemeService.ts
+++ b/src/vs/workbench/services/themes/common/workbenchThemeService.ts
@@ -28,10 +28,11 @@ export enum ThemeSettings {
 	TOKEN_COLOR_CUSTOMIZATIONS = 'editor.tokenColorCustomizations',
 	SEMANTIC_TOKEN_COLOR_CUSTOMIZATIONS = 'editor.semanticTokenColorCustomizations',
 
-	PREFERRED_DARK_THEME = 'workbench.preferredDarkColorTheme',
-	PREFERRED_LIGHT_THEME = 'workbench.preferredLightColorTheme',
-	PREFERRED_HC_DARK_THEME = 'workbench.preferredHighContrastColorTheme', /* id kept for compatibility reasons */
-	PREFERRED_HC_LIGHT_THEME = 'workbench.preferredHighContrastLightColorTheme',
+	PREFERRED_DARK_COLOR_THEME = 'workbench.preferredDarkColorTheme',
+	PREFERRED_LIGHT_COLOR_THEME = 'workbench.preferredLightColorTheme',
+	PREFERRED_HC_DARK_COLOR_THEME = 'workbench.preferredHighContrastColorTheme', /* id kept for compatibility reasons */
+	PREFERRED_HC_LIGHT_COLOR_THEME = 'workbench.preferredHighContrastLightColorTheme',
+
 	DETECT_COLOR_SCHEME = 'window.autoDetectColorScheme',
 	DETECT_HC = 'window.autoDetectHighContrast',
 


### PR DESCRIPTION
This change introduces the ability to specify different file icon themes
for light and dark modes when `window.autoDetectColorScheme` is enabled.

Needed because [catpuccin](https://github.com/catppuccin/vscode-icons) provides both light and dark file icons.

I think I got it working, but I might have some issues with testing it. Would appreciate it if other people could test it.