### PR TITLE
fix: correct codicon name from `extensionLarge` to `extensionsLarge`

### DIFF
--- a/src/vs/base/common/codiconsLibrary.ts
+++ b/src/vs/base/common/codiconsLibrary.ts
@@ -598,5 +598,5 @@ export const codiconsLibrary = {
 	keyboardTabBelow: register('keyboard-tab-below', 0xec45),
 	gitPullRequestDone: register('git-pull-request-done', 0xec46),
 	mcp: register('mcp', 0xec47),
-	extensionLarge: register('extension-large', 0xec48),
+	extensionsLarge: register('extensions-large', 0xec48),
 } as const;


### PR DESCRIPTION
This pull request includes a minor update to the `codiconsLibrary` in `src/vs/base/common/codiconsLibrary.ts`. The change corrects the name of the `extensionLarge` icon to `extensionsLarge` for consistency.