### PR TITLE
mcp: respect cwd in configs, allow proper variable resolution

### DIFF
--- a/src/vs/platform/mcp/common/mcpPlatformTypes.ts
+++ b/src/vs/platform/mcp/common/mcpPlatformTypes.ts
@@ -32,6 +32,7 @@ export interface IMcpConfigurationStdio extends IMcpConfigurationCommon {
 	args?: readonly string[];
 	env?: Record<string, string | number | null>;
 	envFile?: string;
+	cwd?: string;
 }
 
 export interface IMcpConfigurationHTTP extends IMcpConfigurationCommon {

--- a/src/vs/workbench/api/common/extHostTypeConverters.ts
+++ b/src/vs/workbench/api/common/extHostTypeConverters.ts
@@ -3406,7 +3406,7 @@ export namespace McpServerDefinition {
 				}
 				: {
 					type: McpServerTransportType.Stdio,
-					cwd: item.cwd,
+					cwd: item.cwd?.fsPath,
 					args: item.args,
 					command: item.command,
 					env: item.env,

--- a/src/vs/workbench/api/node/extHostMcpNode.ts
+++ b/src/vs/workbench/api/node/extHostMcpNode.ts
@@ -7,14 +7,14 @@ import { ChildProcessWithoutNullStreams, spawn } from 'child_process';
 import { readFile } from 'fs/promises';
 import { homedir } from 'os';
 import { parseEnvFile } from '../../../base/common/envfile.js';
-import { URI } from '../../../base/common/uri.js';
+import { untildify } from '../../../base/common/labels.js';
 import { StreamSplitter } from '../../../base/node/nodeStreams.js';
+import { findExecutable } from '../../../base/node/processes.js';
 import { LogLevel } from '../../../platform/log/common/log.js';
 import { McpConnectionState, McpServerLaunch, McpServerTransportStdio, McpServerTransportType } from '../../contrib/mcp/common/mcpTypes.js';
 import { ExtHostMcpService } from '../common/extHostMcp.js';
 import { IExtHostRpcService } from '../common/extHostRpcService.js';
-import { findExecutable } from '../../../base/node/processes.js';
-import { untildify } from '../../../base/common/labels.js';
+import * as path from '../../../base/common/path.js';
 
 export class NodeExtHostMpcService extends ExtHostMcpService {
 	constructor(
@@ -83,7 +83,11 @@ export class NodeExtHostMpcService extends ExtHostMcpService {
 		let child: ChildProcessWithoutNullStreams;
 		try {
 			const home = homedir();
-			const cwd = launch.cwd ? URI.revive(launch.cwd).fsPath : home;
+			let cwd = launch.cwd ? untildify(launch.cwd, home) : home;
+			if (!path.isAbsolute(cwd)) {
+				cwd = path.join(home, cwd);
+			}
+
 			const { executable, args, shell } = await formatSubprocessArguments(
 				untildify(launch.command, home),
 				launch.args.map(a => untildify(a, home)),
@@ -94,7 +98,7 @@ export class NodeExtHostMpcService extends ExtHostMcpService {
 			this._proxy.$onDidPublishLog(id, LogLevel.Debug, `Server command line: ${executable} ${args.join(' ')}`);
 			child = spawn(executable, args, {
 				stdio: 'pipe',
-				cwd: launch.cwd ? URI.revive(launch.cwd).fsPath : homedir(),
+				cwd,
 				signal: abortCtrl.signal,
 				env,
 				shell,

--- a/src/vs/workbench/contrib/mcp/common/discovery/configMcpDiscovery.ts
+++ b/src/vs/workbench/contrib/mcp/common/discovery/configMcpDiscovery.ts
@@ -7,6 +7,7 @@ import { equals as arrayEquals } from '../../../../../base/common/arrays.js';
 import { Throttler } from '../../../../../base/common/async.js';
 import { Disposable, DisposableStore, IDisposable, MutableDisposable } from '../../../../../base/common/lifecycle.js';
 import { autorunDelta, ISettableObservable, observableValue } from '../../../../../base/common/observable.js';
+import { isAbsolute, join } from '../../../../../base/common/path.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { Location } from '../../../../../editor/common/languages.js';
 import { ITextModelService } from '../../../../../editor/common/services/resolverService.js';
@@ -128,7 +129,11 @@ export class ConfigMcpDiscovery extends Disposable implements IMcpDiscovery {
 					command: value.command,
 					env: value.env || {},
 					envFile: value.envFile,
-					cwd: src.path.workspaceFolder?.uri,
+					cwd: value.cwd
+						// if the cwd is defined in a workspace folder but not absolute (and not
+						// a variable or tilde-expansion) then resolve it in the workspace folder
+						? (!isAbsolute(value.cwd) && !value.cwd.startsWith('~') && !value.cwd.startsWith('${') && src.path.workspaceFolder ? join(src.path.workspaceFolder.uri.fsPath, value.cwd) : value.cwd)
+						: src.path.workspaceFolder?.uri.fsPath,
 				},
 				roots: src.path.workspaceFolder ? [src.path.workspaceFolder.uri] : [],
 				variableReplacement: {

--- a/src/vs/workbench/contrib/mcp/common/discovery/nativeMcpDiscoveryAdapters.ts
+++ b/src/vs/workbench/contrib/mcp/common/discovery/nativeMcpDiscoveryAdapters.ts
@@ -51,7 +51,7 @@ export function claudeConfigToServerDefinition(idPrefix: string, contents: VSBuf
 				command: server.command,
 				env: server.env || {},
 				envFile: undefined,
-				cwd,
+				cwd: cwd?.fsPath,
 			}
 		};
 	});

--- a/src/vs/workbench/contrib/mcp/common/mcpTypes.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpTypes.ts
@@ -365,7 +365,7 @@ export const enum McpServerTransportType {
  */
 export interface McpServerTransportStdio {
 	readonly type: McpServerTransportType.Stdio;
-	readonly cwd: URI | undefined;
+	readonly cwd: string | undefined;
 	readonly command: string;
 	readonly args: readonly string[];
 	readonly env: Record<string, string | number | null>;
@@ -390,7 +390,7 @@ export type McpServerLaunch =
 export namespace McpServerLaunch {
 	export type Serialized =
 		| { type: McpServerTransportType.HTTP; uri: UriComponents; headers: [string, string][] }
-		| { type: McpServerTransportType.Stdio; cwd: UriComponents | undefined; command: string; args: readonly string[]; env: Record<string, string | number | null>; envFile: string | undefined };
+		| { type: McpServerTransportType.Stdio; cwd: string | undefined; command: string; args: readonly string[]; env: Record<string, string | number | null>; envFile: string | undefined };
 
 	export function toSerialized(launch: McpServerLaunch): McpServerLaunch.Serialized {
 		return launch;
@@ -403,7 +403,7 @@ export namespace McpServerLaunch {
 			case McpServerTransportType.Stdio:
 				return {
 					type: launch.type,
-					cwd: launch.cwd ? URI.revive(launch.cwd) : undefined,
+					cwd: launch.cwd,
 					command: launch.command,
 					args: launch.args,
 					env: launch.env,

--- a/src/vs/workbench/contrib/mcp/test/common/mcpRegistry.test.ts
+++ b/src/vs/workbench/contrib/mcp/test/common/mcpRegistry.test.ts
@@ -8,7 +8,6 @@ import * as sinon from 'sinon';
 import { timeout } from '../../../../../base/common/async.js';
 import { ISettableObservable, observableValue } from '../../../../../base/common/observable.js';
 import { upcast } from '../../../../../base/common/types.js';
-import { URI } from '../../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { ConfigurationTarget, IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
@@ -169,7 +168,7 @@ suite('Workbench - MCP - Registry', () => {
 				args: [],
 				env: {},
 				envFile: undefined,
-				cwd: URI.parse('file:///test')
+				cwd: '/test',
 			}
 		};
 	});
@@ -223,7 +222,7 @@ suite('Workbench - MCP - Registry', () => {
 					PATH: '${input:testInteractive}'
 				},
 				envFile: undefined,
-				cwd: URI.parse('file:///test')
+				cwd: '/test',
 			},
 			variableReplacement: {
 				section: 'mcp',

--- a/src/vs/workbench/contrib/mcp/test/common/mcpServerConnection.test.ts
+++ b/src/vs/workbench/contrib/mcp/test/common/mcpServerConnection.test.ts
@@ -8,7 +8,6 @@ import { timeout } from '../../../../../base/common/async.js';
 import { Disposable } from '../../../../../base/common/lifecycle.js';
 import { autorun, observableValue } from '../../../../../base/common/observable.js';
 import { upcast } from '../../../../../base/common/types.js';
-import { URI } from '../../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { ServiceCollection } from '../../../../../platform/instantiation/common/serviceCollection.js';
 import { TestInstantiationService } from '../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
@@ -100,7 +99,7 @@ suite('Workbench - MCP - ServerConnection', () => {
 				args: [],
 				env: {},
 				envFile: undefined,
-				cwd: URI.parse('file:///test')
+				cwd: '/test'
 			}
 		};
 	});


### PR DESCRIPTION
Keeps it as a string, rather than forcing it into a URI, so that variables can be resolved.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
