### PR TITLE
mcp: respect annotations on tool results

### DIFF
--- a/src/vs/workbench/contrib/chat/common/languageModelToolsService.ts
+++ b/src/vs/workbench/contrib/chat/common/languageModelToolsService.ts
@@ -45,8 +45,8 @@ export interface IToolData {
 
 export interface IToolProgressStep {
 	readonly message: string | IMarkdownString | undefined;
-	readonly increment: number | undefined;
-	readonly total: number | undefined;
+	readonly increment?: number;
+	readonly total?: number;
 }
 
 export type ToolProgress = IProgress<IToolProgressStep>;

--- a/src/vs/workbench/contrib/mcp/common/mcpService.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpService.ts
@@ -280,18 +280,30 @@ class McpToolImplementation implements IToolImpl {
 		};
 
 		for (const item of callResult.content) {
+			const audience = item.annotations?.audience || ['assistant'];
+			if (audience.includes('user')) {
+				if (item.type === 'text') {
+					progress.report({ message: item.text });
+				}
+			}
+
+			const isForModel = audience.includes('assistant');
 			if (item.type === 'text') {
 				details.output.push({ type: 'text', value: item.text });
-				result.content.push({
-					kind: 'text',
-					value: item.text
-				});
+				if (isForModel) {
+					result.content.push({
+						kind: 'text',
+						value: item.text
+					});
+				}
 			} else if (item.type === 'image' || item.type === 'audio') {
 				details.output.push({ type: 'data', mimeType: item.mimeType, value64: item.data });
-				result.content.push({
-					kind: 'data',
-					value: { mimeType: item.mimeType, data: decodeBase64(item.data) }
-				});
+				if (isForModel) {
+					result.content.push({
+						kind: 'data',
+						value: { mimeType: item.mimeType, data: decodeBase64(item.data) }
+					});
+				}
 			} else {
 				// unsupported for now.
 			}


### PR DESCRIPTION
We still show everything to the user so the model can't do sneaky things, but user-only messages are now omitted from the tool result data and we show the user text as progress.

Fixes #248437

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
