### PR TITLE
Fix custom titlebar visibility when native title bar is enabled on macos

### DIFF
--- a/src/vs/workbench/services/layout/browser/layoutService.ts
+++ b/src/vs/workbench/services/layout/browser/layoutService.ts
@@ -352,7 +352,7 @@ export function shouldShowCustomTitleBar(configurationService: IConfigurationSer
 	}
 
 	// Hide custom title bar when native title bar enabled and custom title bar is empty
-	if (hasNativeMenu(configurationService)) {
+	if (nativeTitleBarEnabled && hasNativeMenu(configurationService)) {
 		return false;
 	}
 


### PR DESCRIPTION
```Copilot Generated Description:``` Update the logic to hide the custom title bar only when the native title bar is enabled and the custom title bar is empty.

Fixes microsoft/vscode#249564