### PR TITLE
[prompts]: disable front matter header decorations provider

### DIFF
--- a/src/vs/workbench/contrib/chat/common/promptSyntax/contributions/languageFeatures/index.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/contributions/languageFeatures/index.ts
@@ -9,7 +9,6 @@ import { isWindows } from '../../../../../../../base/common/platform.js';
 import { PromptPathAutocompletion } from './providers/promptPathAutocompletion.js';
 import { PromptLinkDiagnosticsInstanceManager } from './providers/promptLinkDiagnosticsProvider.js';
 import { PromptHeaderDiagnosticsInstanceManager } from './providers/promptHeaderDiagnosticsProvider.js';
-import { PromptDecorationsProviderInstanceManager } from './providers/decorationsProvider/promptDecorationsProvider.js';
 
 /**
  * Base list of language feature contributions.
@@ -18,7 +17,12 @@ const CONTRIBUTIONS: TContribution[] = [
 	PromptLinkProvider,
 	PromptLinkDiagnosticsInstanceManager,
 	PromptHeaderDiagnosticsInstanceManager,
-	PromptDecorationsProviderInstanceManager,
+	/**
+	 * PromptDecorationsProviderInstanceManager is currently disabled because the only currently
+	 * available decoration is the Front Matter header, which we decided to disable for now.
+	 * Add it back when more decorations are needed.
+	 */
+	// PromptDecorationsProviderInstanceManager,
 ];
 
 /**


### PR DESCRIPTION

<img width="1840" alt="image" src="https://github.com/user-attachments/assets/d1e0c815-2e2c-4528-b258-97f326b0de86" />

Disables Front Matter decorations provider for the time being.