### PR TITLE
[prompts]: allow for non-quoted string values inside front matter arrays

### DIFF
--- a/src/vs/editor/common/codecs/frontMatterCodec/parsers/frontMatterArray.ts
+++ b/src/vs/editor/common/codecs/frontMatterCodec/parsers/frontMatterArray.ts
@@ -3,16 +3,16 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { VALID_INTER_RECORD_SPACING_TOKENS } from '../constants.js';
 import { assert } from '../../../../../base/common/assert.js';
 import { PartialFrontMatterValue } from './frontMatterValue.js';
 import { FrontMatterArray } from '../tokens/frontMatterArray.js';
 import { assertDefined } from '../../../../../base/common/types.js';
+import { VALID_INTER_RECORD_SPACING_TOKENS } from '../constants.js';
 import { FrontMatterValueToken } from '../tokens/frontMatterToken.js';
+import { FrontMatterSequence } from '../tokens/frontMatterSequence.js';
 import { TSimpleDecoderToken } from '../../simpleCodec/simpleDecoder.js';
 import { Comma, LeftBracket, RightBracket } from '../../simpleCodec/tokens/index.js';
 import { assertNotConsumed, ParserBase, TAcceptTokenResult } from '../../simpleCodec/parserBase.js';
-import { FrontMatterSequence } from '../tokens/frontMatterSequence.js';
 
 /**
  * List of tokens that can go in-between array items
@@ -162,7 +162,7 @@ export class PartialFrontMatterArray extends ParserBase<TSimpleDecoderToken, Par
 
 		assertDefined(
 			endToken,
-			`No tokens found.`,
+			'No tokens found.',
 		);
 
 		assert(

--- a/src/vs/editor/common/codecs/frontMatterCodec/parsers/frontMatterValue.ts
+++ b/src/vs/editor/common/codecs/frontMatterCodec/parsers/frontMatterValue.ts
@@ -6,7 +6,7 @@
 import { BaseToken } from '../../baseToken.js';
 import { PartialFrontMatterArray } from './frontMatterArray.js';
 import { PartialFrontMatterString } from './frontMatterString.js';
-import { FrontMatterBoolean } from '../tokens/frontMatterBoolean.js';
+import { asBoolean, FrontMatterBoolean } from '../tokens/frontMatterBoolean.js';
 import { FrontMatterValueToken } from '../tokens/frontMatterToken.js';
 import { PartialFrontMatterSequence } from './frontMatterSequence.js';
 import { FrontMatterSequence } from '../tokens/frontMatterSequence.js';
@@ -154,10 +154,8 @@ export class PartialFrontMatterValue extends ParserBase<TSimpleDecoderToken, Par
 			}
 		}
 
-		if (token instanceof Word) {
-			return ['true', 'false'].includes(
-				token.text.toLowerCase(),
-			);
+		if ((token instanceof Word) && (asBoolean(token) !== null)) {
+			return true;
 		}
 
 		return false;

--- a/src/vs/editor/common/codecs/frontMatterCodec/tokens/frontMatterBoolean.ts
+++ b/src/vs/editor/common/codecs/frontMatterCodec/tokens/frontMatterBoolean.ts
@@ -73,9 +73,9 @@ export class FrontMatterBoolean extends FrontMatterValueToken<'boolean', readonl
 /**
  * Try to convert a {@link Word} token to a `boolean` value.
  */
-const asBoolean = (
+export function asBoolean(
 	token: Word,
-): boolean | null => {
+): boolean | null {
 	if (token.text.toLowerCase() === 'true') {
 		return true;
 	}
@@ -85,4 +85,4 @@ const asBoolean = (
 	}
 
 	return null;
-};
+}

--- a/src/vs/editor/test/common/codecs/frontMatterDecoder/frontMatterDecoder.test.ts
+++ b/src/vs/editor/test/common/codecs/frontMatterDecoder/frontMatterDecoder.test.ts
@@ -358,7 +358,6 @@ suite('FrontMatterDecoder', () => {
 						]);
 				});
 
-
 				test('• redundant commas', async () => {
 					const test = disposables.add(new TestFrontMatterDecoder());
 

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/promptHeader/metadata/tools.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/promptHeader/metadata/tools.ts
@@ -6,6 +6,7 @@
 import { PromptMetadataRecord } from './base/record.js';
 import { localize } from '../../../../../../../../nls.js';
 import { PromptMetadataDiagnostic, PromptMetadataError, PromptMetadataWarning } from '../diagnostics.js';
+import { FrontMatterSequence } from '../../../../../../../../editor/common/codecs/frontMatterCodec/tokens/frontMatterSequence.js';
 import { FrontMatterArray, FrontMatterRecord, FrontMatterString, FrontMatterToken, FrontMatterValueToken } from '../../../../../../../../editor/common/codecs/frontMatterCodec/tokens/index.js';
 
 /**
@@ -99,8 +100,11 @@ export class PromptToolsMetadata extends PromptMetadataRecord {
 	): readonly PromptMetadataDiagnostic[] {
 		const issues: PromptMetadataDiagnostic[] = [];
 
-		// tool name must be a string
-		if ((valueToken instanceof FrontMatterString) === false) {
+		// tool name must be a quoted or an unquoted 'string'
+		if (
+			(valueToken instanceof FrontMatterString) === false &&
+			(valueToken instanceof FrontMatterSequence) === false
+		) {
 			issues.push(
 				new PromptMetadataWarning(
 					valueToken.range,

--- a/src/vs/workbench/contrib/chat/test/common/promptSyntax/parsers/textModelPromptParser.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/promptSyntax/parsers/textModelPromptParser.test.ts
@@ -556,6 +556,38 @@ suite('TextModelPromptParser', () => {
 				]);
 			});
 
+			suite('• tools metadata', () => {
+				test('• tool names can be quoted and non-quoted string', async () => {
+					const test = createTest(
+						URI.file('/absolute/folder/and/a/my.prompt.md'),
+						[
+					/* 01 */"---",
+					/* 02 */"tools: [tool1, 'tool2', \"tool3\", tool-4]",
+					/* 03 */"---",
+					/* 04 */"The cactus on my desk has a thriving Instagram account.",
+						],
+						PROMPT_LANGUAGE_ID,
+					);
+
+					await test.allSettled();
+
+					const { header, metadata } = test.parser;
+					assertDefined(
+						header,
+						'Prompt header must be defined.',
+					);
+
+					const { tools } = metadata;
+					assert.deepStrictEqual(
+						tools,
+						['tool1', 'tool2', 'tool3', 'tool-4'],
+						'Mode metadata must have correct value.',
+					);
+
+					await test.validateHeaderDiagnostics([]);
+				});
+			});
+
 			suite('• applyTo metadata', () => {
 				suite('• language', () => {
 					test('• prompt', async () => {


### PR DESCRIPTION
<img width="1840" alt="image" src="https://github.com/user-attachments/assets/047c2328-8208-4a77-aeff-e1a5add1a7c8" />

Makes changes to allow for non-quoted string values inside front matter arrays.