### PR TITLE
disasembly view: handle negative line height returned by debug adapter

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/disassemblyView.ts
+++ b/src/vs/workbench/contrib/debug/browser/disassemblyView.ts
@@ -210,7 +210,7 @@ export class DisassemblyView extends EditorPane {
 				if (thisOM.isSourceCodeRender && row.showSourceLocation && row.instruction.location?.path && row.instruction.line) {
 					// instruction line + source lines
 					if (row.instruction.endLine) {
-						return lineHeight * (row.instruction.endLine - row.instruction.line + 2);
+						return lineHeight * Math.max(2, (row.instruction.endLine - row.instruction.line + 2));
 					} else {
 						// source is only a single line.
 						return lineHeight * 2;


### PR DESCRIPTION
Handle gracefully instructions returned by the debug adapter with `endLine` smaller than `line`, Otherwise `getHeight` can return a negative number which can mess up the view.

Fixes #250174. After the fix:

[Screencast From 2025-05-31 09-07-14.webm](https://github.com/user-attachments/assets/dcb23f3d-75e7-4628-9230-25479e247500)

