### PR TITLE
mcp: display and allow saving resources generated by tool calls

### DIFF
--- a/src/vs/platform/actions/common/actions.ts
+++ b/src/vs/platform/actions/common/actions.ts
@@ -251,6 +251,8 @@ export class MenuId {
 	static readonly ChatEditingCodeBlockContext = new MenuId('ChatEditingCodeBlockContext');
 	static readonly ChatTitleBarMenu = new MenuId('ChatTitleBarMenu');
 	static readonly ChatAttachmentsContext = new MenuId('ChatAttachmentsContext');
+	static readonly ChatToolOutputResourceToolbar = new MenuId('ChatToolOutputResourceToolbar');
+	static readonly ChatToolOutputResourceContext = new MenuId('ChatToolOutputResourceContext');
 	static readonly AccessibleView = new MenuId('AccessibleView');
 	static readonly MultiDiffEditorFileToolbar = new MenuId('MultiDiffEditorFileToolbar');
 	static readonly DiffEditorHunkToolbar = new MenuId('DiffEditorHunkToolbar');

--- a/src/vs/workbench/contrib/chat/browser/chatAttachmentResolve.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatAttachmentResolve.ts
@@ -24,7 +24,7 @@ import { UntitledTextEditorInput } from '../../../services/untitled/common/untit
 import { createNotebookOutputVariableEntry, NOTEBOOK_CELL_OUTPUT_MIME_TYPE_LIST_FOR_CHAT_CONST } from '../../notebook/browser/contrib/chat/notebookChatUtils.js';
 import { getOutputViewModelFromId } from '../../notebook/browser/controller/cellOutputActions.js';
 import { getNotebookEditorFromEditorPane } from '../../notebook/browser/notebookBrowser.js';
-import { IChatRequestVariableEntry, IDiagnosticVariableEntry, IDiagnosticVariableEntryFilterData, ISymbolVariableEntry, OmittedState } from '../common/chatModel.js';
+import { CHAT_ATTACHABLE_IMAGE_MIME_TYPES, getAttachableImageExtension, IChatRequestVariableEntry, IDiagnosticVariableEntry, IDiagnosticVariableEntryFilterData, ISymbolVariableEntry, OmittedState } from '../common/chatModel.js';
 import { imageToHash } from './chatPasteProviders.js';
 import { resizeImage } from './imageUtils.js';
 
@@ -114,7 +114,12 @@ export type ImageTransferData = {
 	mimeType?: string;
 	omittedState?: OmittedState;
 };
-const SUPPORTED_IMAGE_EXTENSIONS_REGEX = /\.(png|jpg|jpeg|gif|webp)$/i;
+const SUPPORTED_IMAGE_EXTENSIONS_REGEX = new RegExp(`\\.(${Object.keys(CHAT_ATTACHABLE_IMAGE_MIME_TYPES).join('|')})$`, 'i');
+
+function getMimeTypeFromPath(match: RegExpExecArray): string | undefined {
+	const ext = match[1].toLowerCase();
+	return CHAT_ATTACHABLE_IMAGE_MIME_TYPES[ext];
+}
 
 export async function resolveImageEditorAttachContext(fileService: IFileService, dialogService: IDialogService, resource: URI, data?: VSBuffer, mimeType?: string): Promise<IChatRequestVariableEntry | undefined> {
 	if (!resource) {
@@ -184,23 +189,6 @@ export async function resolveImageAttachContext(images: ImageTransferData[]): Pr
 		omittedState: image.omittedState || OmittedState.NotOmitted,
 		references: image.resource ? [{ reference: image.resource, kind: 'reference' }] : []
 	})));
-}
-
-const MIME_TYPES: Record<string, string> = {
-	png: 'image/png',
-	jpg: 'image/jpeg',
-	jpeg: 'image/jpeg',
-	gif: 'image/gif',
-	webp: 'image/webp',
-};
-
-function getMimeTypeFromPath(match: RegExpExecArray): string | undefined {
-	const ext = match[1].toLowerCase();
-	return MIME_TYPES[ext];
-}
-
-export function getAttachableImageExtension(mimeType: string): string | undefined {
-	return Object.entries(MIME_TYPES).find(([_, value]) => value === mimeType)?.[0];
 }
 
 // --- MARKERS ---

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/chatAttachmentsContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/chatAttachmentsContentPart.ts
@@ -27,6 +27,8 @@ export class ChatAttachmentsContentPart extends Disposable {
 	private readonly _onDidChangeVisibility = this._register(new Emitter<boolean>());
 	private readonly _contextResourceLabels: ResourceLabels;
 
+	public contextMenuHandler?: (attachment: IChatRequestVariableEntry, event: MouseEvent) => void;
+
 	constructor(
 		private readonly variables: IChatRequestVariableEntry[],
 		private readonly contentReferences: ReadonlyArray<IChatContentReference> = [],
@@ -89,6 +91,8 @@ export class ChatAttachmentsContentPart extends Disposable {
 					}
 				}
 			}
+
+			this._register(dom.addDisposableListener(widget.element, 'contextmenu', e => this.contextMenuHandler?.(attachment, e)));
 
 			if (this.attachedContextDisposables.isDisposed) {
 				widget.dispose();

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/media/chatConfirmationWidget.css
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/media/chatConfirmationWidget.css
@@ -138,3 +138,19 @@
 .chat-confirmation-widget.hideButtons .chat-buttons-container {
 	display: none;
 }
+
+.chat-collapsible-io-resource-group {
+	display: flex;
+	gap: 8px;
+	align-items: center;
+	margin-bottom: 8px !important;
+
+	.chat-collapsible-io-resource-items {
+		display: flex;
+		align-items: center;
+
+		.chat-attached-context {
+			margin-bottom: 0 !important;
+		}
+	}
+}

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatInputOutputMarkdownProgressPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatInputOutputMarkdownProgressPart.ts
@@ -12,13 +12,13 @@ import { ILanguageService } from '../../../../../../editor/common/languages/lang
 import { IModelService } from '../../../../../../editor/common/services/model.js';
 import { localize } from '../../../../../../nls.js';
 import { IInstantiationService } from '../../../../../../platform/instantiation/common/instantiation.js';
+import { getAttachableImageExtension } from '../../../common/chatModel.js';
 import { IChatToolInvocation, IChatToolInvocationSerialized } from '../../../common/chatService.js';
 import { IToolResultInputOutputDetails } from '../../../common/languageModelToolsService.js';
 import { IChatCodeBlockInfo } from '../../chat.js';
-import { getAttachableImageExtension } from '../../chatAttachmentResolve.js';
 import { IChatContentPartRenderContext } from '../chatContentParts.js';
 import { EditorPool } from '../chatMarkdownContentPart.js';
-import { ChatCollapsibleInputOutputContentPart, IChatCollapsibleIOCodePart, IChatCollapsibleIODataPart } from '../chatToolInputOutputContentPart.js';
+import { ChatCollapsibleInputOutputContentPart, ChatCollapsibleIOPart, IChatCollapsibleIOCodePart } from '../chatToolInputOutputContentPart.js';
 import { BaseChatToolInvocationSubPart } from './chatToolInvocationSubPart.js';
 
 export class ChatInputOutputMarkdownProgressPart extends BaseChatToolInvocationSubPart {
@@ -97,7 +97,7 @@ export class ChatInputOutputMarkdownProgressPart extends BaseChatToolInvocationS
 			editorPool,
 			toCodePart(input),
 			processedOutput && {
-				parts: processedOutput.map((o): IChatCollapsibleIODataPart | IChatCollapsibleIOCodePart => {
+				parts: processedOutput.map((o): ChatCollapsibleIOPart => {
 					if (o.type === 'data') {
 						const decoded = decodeBase64(o.value64).buffer;
 						if (getAttachableImageExtension(o.mimeType)) {
@@ -107,6 +107,8 @@ export class ChatInputOutputMarkdownProgressPart extends BaseChatToolInvocationS
 						}
 					} else if (o.type === 'text') {
 						return toCodePart(o.value);
+					} else if (o.type === 'resource') {
+						return { kind: 'resource', uri: o.uri };
 					} else {
 						assertNever(o);
 					}

--- a/src/vs/workbench/contrib/chat/browser/contrib/chatInputCompletions.ts
+++ b/src/vs/workbench/contrib/chat/browser/contrib/chatInputCompletions.ts
@@ -46,7 +46,7 @@ import { IMcpPrompt, IMcpPromptMessage, IMcpServer, IMcpService, McpResourceURI 
 import { searchFilesAndFolders } from '../../../search/browser/chatContributions.js';
 import { IChatAgentData, IChatAgentNameService, IChatAgentService, getFullyQualifiedId } from '../../common/chatAgents.js';
 import { IChatEditingService } from '../../common/chatEditingService.js';
-import { IChatRequestVariableEntry } from '../../common/chatModel.js';
+import { getAttachableImageExtension, IChatRequestVariableEntry } from '../../common/chatModel.js';
 import { ChatRequestAgentPart, ChatRequestAgentSubcommandPart, ChatRequestSlashPromptPart, ChatRequestTextPart, ChatRequestToolPart, ChatRequestToolSetPart, chatAgentLeader, chatSubcommandLeader, chatVariableLeader } from '../../common/chatParserTypes.js';
 import { IChatSlashCommandService } from '../../common/chatSlashCommands.js';
 import { IDynamicVariable } from '../../common/chatVariables.js';
@@ -55,7 +55,6 @@ import { ToolSet } from '../../common/languageModelToolsService.js';
 import { IPromptsService } from '../../common/promptSyntax/service/types.js';
 import { ChatSubmitAction } from '../actions/chatExecuteActions.js';
 import { IChatWidget, IChatWidgetService } from '../chat.js';
-import { getAttachableImageExtension } from '../chatAttachmentResolve.js';
 import { ChatInputPart } from '../chatInputPart.js';
 import { ChatDynamicVariableModel } from './chatDynamicVariables.js';
 

--- a/src/vs/workbench/contrib/chat/common/chatModel.ts
+++ b/src/vs/workbench/contrib/chat/common/chatModel.ts
@@ -277,6 +277,19 @@ export function isSCMHistoryItemVariableEntry(obj: IChatRequestVariableEntry): o
 	return obj.kind === 'scmHistoryItem';
 }
 
+
+export const CHAT_ATTACHABLE_IMAGE_MIME_TYPES: Record<string, string> = {
+	png: 'image/png',
+	jpg: 'image/jpeg',
+	jpeg: 'image/jpeg',
+	gif: 'image/gif',
+	webp: 'image/webp',
+};
+
+export function getAttachableImageExtension(mimeType: string): string | undefined {
+	return Object.entries(CHAT_ATTACHABLE_IMAGE_MIME_TYPES).find(([_, value]) => value === mimeType)?.[0];
+}
+
 export interface IChatRequestVariableData {
 	variables: IChatRequestVariableEntry[];
 }

--- a/src/vs/workbench/contrib/chat/common/languageModelToolsService.ts
+++ b/src/vs/workbench/contrib/chat/common/languageModelToolsService.ts
@@ -125,7 +125,7 @@ export function isToolInvocationContext(obj: any): obj is IToolInvocationContext
 
 export interface IToolResultInputOutputDetails {
 	readonly input: string;
-	readonly output: ({ type: 'text'; value: string } | { type: 'data'; mimeType: string; value64: string })[];
+	readonly output: ({ type: 'text'; value: string } | { type: 'data'; mimeType: string; value64: string } | { type: 'resource'; uri: URI })[];
 	readonly isError?: boolean;
 }
 


### PR DESCRIPTION
We don't have a way to attach these resources from the tool call, so the model when we encounter these I put in a tool result message telling the model to read the resource from its URI, which it can do using the read_file tool.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
