### PR TITLE
fix: show local results mid-search if available

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
@@ -1793,9 +1793,12 @@ export class SettingsEditor2 extends EditorPane {
 			}
 			this.searchResultModel.showAiResults = false;
 
-			// Show the results because the embeddings might take a while,
-			// and because the remote results are always appended to the end.
-			this.onDidFinishSearch(expandResults, undefined);
+			if (localResults && localResults.filterMatches.length > 0) {
+				// The remote results might take a while and
+				// are always appended to the end anyway, so
+				// show some results now.
+				this.onDidFinishSearch(expandResults, undefined);
+			}
 
 			if (!localResults || !localResults.exactMatch) {
 				await this.doRemoteSearch(query, searchInProgress.token);

--- a/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
@@ -1792,6 +1792,11 @@ export class SettingsEditor2 extends EditorPane {
 				return;
 			}
 			this.searchResultModel.showAiResults = false;
+
+			// Show the results because the embeddings might take a while,
+			// and because the remote results are always appended to the end.
+			this.onDidFinishSearch(expandResults, undefined);
+
 			if (!localResults || !localResults.exactMatch) {
 				await this.doRemoteSearch(query, searchInProgress.token);
 			}
@@ -1799,13 +1804,11 @@ export class SettingsEditor2 extends EditorPane {
 				return;
 			}
 
-			// Update UI only after all the search results are in
-			// ref https://github.com/microsoft/vscode/issues/224946
 			this.onDidFinishSearch(expandResults, progressRunner);
 		});
 	}
 
-	private onDidFinishSearch(expandResults: boolean, progressRunner: IProgressRunner) {
+	private onDidFinishSearch(expandResults: boolean, progressRunner: IProgressRunner | undefined) {
 		this.tocTreeModel.currentSearchModel = this.searchResultModel;
 		if (expandResults) {
 			this.tocTree.setFocus([]);
@@ -1815,7 +1818,7 @@ export class SettingsEditor2 extends EditorPane {
 		}
 		this.refreshTOCTree();
 		this.renderTree(undefined, true);
-		progressRunner.done();
+		progressRunner?.done();
 	}
 
 	private doLocalSearch(query: string, token: CancellationToken): Promise<ISearchResult | null> {

--- a/src/vs/workbench/contrib/preferences/browser/settingsTreeModels.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsTreeModels.ts
@@ -1097,6 +1097,12 @@ export class SearchResultModel extends SettingsTreeModel {
 		this.cachedUniqueSearchResults.clear();
 		this.newExtensionSearchResults = null;
 
+		if (this.rawSearchResults && order === SearchResultIdx.Local) {
+			// To prevent the Settings editor from showing
+			// stale remote results mid-search.
+			delete this.rawSearchResults[SearchResultIdx.Remote];
+		}
+
 		this.rawSearchResults ??= [];
 		if (!result) {
 			delete this.rawSearchResults[order];


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
This PR partially reverts #225296, but it only renders mid-search local results if there are any to prevent showing flashes of "No settings found".