### PR TITLE
Ensure no repeat categories in ADMX/ADML

### DIFF
--- a/build/lib/policies.js
+++ b/build/lib/policies.js
@@ -720,7 +720,7 @@ function renderGP(policies, translations) {
     const appName = product.nameLong;
     const regKey = product.win32RegValueName;
     const versions = [...new Set(policies.map(p => p.minimumVersion)).values()].sort();
-    const categories = [...new Set(policies.map(p => p.category))];
+    const categories = [...Object.values(policies.reduce((acc, p) => ({ ...acc, [p.category.name.nlsKey]: p.category }), {}))];
     return {
         admx: renderADMX(regKey, versions, categories, policies),
         adml: [

--- a/build/lib/policies.ts
+++ b/build/lib/policies.ts
@@ -936,7 +936,7 @@ function renderGP(policies: Policy[], translations: Translations) {
 	const regKey = product.win32RegValueName;
 
 	const versions = [...new Set(policies.map(p => p.minimumVersion)).values()].sort();
-	const categories = [...new Set(policies.map(p => p.category))];
+	const categories = [...Object.values(policies.reduce((acc, p) => ({ ...acc, [p.category.name.nlsKey]: p.category }), {}))] as Category[];
 
 	return {
 		admx: renderADMX(regKey, versions, categories, policies),


### PR DESCRIPTION
closes https://github.com/microsoft/vscode/issues/248917

Below illustrates the existing value of `categories`.  Note that two objects share the same `nlsKey` and `value`.

This change keeps just one of the two duplicates below, using `nlsKey` as the check for uniqueness.

```json
[
  {
    "moduleName": "vs/platform/telemetry/common/telemetryService",
    "name": {
      "value": "Telemetry",
      "nlsKey": "telemetryConfigurationTitle"
    }
  },
  // Duplicate 1
  {
    "moduleName": "vs/platform/extensionManagement/common/extensionManagement",
    "name": {
      "value": "Extensions",
      "nlsKey": "extensionsConfigurationTitle"
    }
  },
  {
    "moduleName": "vs/platform/update/common/update.config.contribution",
    "name": {
      "value": "Update",
      "nlsKey": "updateConfigurationTitle"
    }
  },
  // Duplicate 2
  {
    "moduleName": "vs/workbench/contrib/extensions/browser/extensions.contribution",
    "name": {
      "value": "Extensions",
      "nlsKey": "extensionsConfigurationTitle"
    }
  },
  {
    "moduleName": "vs/workbench/contrib/chat/browser/chat.contribution",
    "name": {
      "value": "Chat",
      "nlsKey": "interactiveSessionConfigurationTitle"
    }
  }
]
```

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

cc/ @sandy081 @joaomoreno 
