### PR TITLE
Debugger disassembly: reload disassembly around current instruction

### DIFF
--- a/src/vs/base/browser/ui/list/listWidget.ts
+++ b/src/vs/base/browser/ui/list/listWidget.ts
@@ -1854,7 +1854,7 @@ export class List<T> implements ISpliceable<T>, IDisposable {
 		}
 	}
 
-	private findNextIndex(index: number, loop = false, filter?: (element: T) => boolean): number {
+	findNextIndex(index: number, loop = false, filter?: (element: T) => boolean): number {
 		for (let i = 0; i < this.length; i++) {
 			if (index >= this.length && !loop) {
 				return -1;

--- a/src/vs/base/browser/ui/table/tableWidget.ts
+++ b/src/vs/base/browser/ui/table/tableWidget.ts
@@ -366,6 +366,10 @@ export class Table<TRow> implements ISpliceable<TRow>, IDisposable {
 		this.list.reveal(index, relativeTop);
 	}
 
+	findNextIndex(index: number, loop = false, filter?: (element: TRow) => boolean) {
+		return this.list.findNextIndex(index, loop, filter);
+	}
+
 	dispose(): void {
 		this.disposables.dispose();
 	}

--- a/src/vs/workbench/contrib/debug/browser/disassemblyView.ts
+++ b/src/vs/workbench/contrib/debug/browser/disassemblyView.ts
@@ -638,9 +638,19 @@ export class DisassemblyView extends EditorPane {
 		this.clear();
 		this._instructionBpList = this._debugService.getModel().getInstructionBreakpoints();
 		this.loadDisassembledInstructions(instructionReference, offset, -DisassemblyView.NUM_INSTRUCTIONS_TO_LOAD * 4, DisassemblyView.NUM_INSTRUCTIONS_TO_LOAD * 8).then(() => {
-			// on load, set the target instruction in the middle of the page.
+			// on load, set the target instruction as the current instructionReference.
 			if (this._disassembledInstructions!.length > 0) {
-				const targetIndex = Math.floor(this._disassembledInstructions!.length / 2);
+				let targetIndex: number | undefined = undefined;
+				const refBaseAddress = this._referenceToMemoryAddress.get(instructionReference);
+				if (refBaseAddress !== undefined) {
+					targetIndex = this._disassembledInstructions!.findNextIndex(0, false, entry => entry.address === refBaseAddress);
+				}
+
+				// If didn't find the instructonReference, set the target instruction in the middle of the page.
+				if (targetIndex === undefined) {
+					targetIndex = Math.floor(this._disassembledInstructions!.length / 2);
+				}
+
 				this._disassembledInstructions!.reveal(targetIndex, 0.5);
 
 				// Always focus the target address on reload, or arrow key navigation would look terrible


### PR DESCRIPTION
Reload disassembly around current instruction instead of the middle of the page.

Fixes #250178. After the fix:


[Screencast From 2025-05-31 09-00-36.webm](https://github.com/user-attachments/assets/1e512cb7-c160-4a6c-aa65-93c36ce0464e)
