### PR TITLE
Context key `availableEditorIds` for diff editors

### DIFF
--- a/src/vs/workbench/common/contextkeys.ts
+++ b/src/vs/workbench/common/contextkeys.ts
@@ -15,6 +15,7 @@ import { Schemas } from '../../base/common/network.js';
 import { EditorInput } from './editor/editorInput.js';
 import { IEditorResolverService } from '../services/editor/common/editorResolverService.js';
 import { DEFAULT_EDITOR_ASSOCIATION } from './editor.js';
+import { DiffEditorInput } from './editor/diffEditorInput.js';
 
 //#region < --- Workbench --- >
 
@@ -302,13 +303,30 @@ export function applyAvailableEditorIds(contextKey: IContextKey<string>, editor:
 		return;
 	}
 
-	const editorResource = editor.resource;
-	if (editorResource?.scheme === Schemas.untitled && editor.editorId !== DEFAULT_EDITOR_ASSOCIATION.id) {
-		// Non text editor untitled files cannot be easily serialized between extensions
-		// so instead we disable this context key to prevent common commands that act on the active editor
-		contextKey.set('');
-	} else {
-		const editors = editorResource ? editorResolverService.getEditors(editorResource).map(editor => editor.id) : [];
-		contextKey.set(editors.join(','));
+	const editors = getAvailableEditorIds(editor, editorResolverService);
+	contextKey.set(editors.join(','));
+}
+
+function getAvailableEditorIds(editor: EditorInput, editorResolverService: IEditorResolverService): string[] {
+	// Non text editor untitled files cannot be easily serialized between
+	// extensions so instead we disable this context key to prevent common
+	// commands that act on the active editor.
+	if (editor.resource?.scheme === Schemas.untitled && editor.editorId !== DEFAULT_EDITOR_ASSOCIATION.id) {
+		return [];
 	}
+
+	// Diff editors. The original and modified resources of a diff editor
+	// *should* be the same, but calculate the set intersection just to be safe.
+	if (editor instanceof DiffEditorInput) {
+		const original = getAvailableEditorIds(editor.original, editorResolverService);
+		const modified = new Set(getAvailableEditorIds(editor.modified, editorResolverService));
+		return original.filter(editor => modified.has(editor));
+	}
+
+	// Normal editors.
+	if (editor.resource) {
+		return editorResolverService.getEditors(editor.resource).map(editor => editor.id);
+	}
+
+	return [];
 }


### PR DESCRIPTION
Closes #247028. Updates the context key `availableEditorIds` to also work for diff editors, which allows commands like "Reopen with editor..." to work.