### PR TITLE
Bring back MCP tool set but keep its tools

### DIFF
--- a/src/vs/base/common/iterator.ts
+++ b/src/vs/base/common/iterator.ts
@@ -56,6 +56,16 @@ export namespace Iterable {
 		return false;
 	}
 
+	export function every<T>(iterable: Iterable<T>, predicate: (t: T, i: number) => unknown): boolean {
+		let i = 0;
+		for (const element of iterable) {
+			if (!predicate(element, i++)) {
+				return false;
+			}
+		}
+		return true;
+	}
+
 	export function find<T, R extends T>(iterable: Iterable<T>, predicate: (t: T) => t is R): R | undefined;
 	export function find<T>(iterable: Iterable<T>, predicate: (t: T) => boolean): T | undefined;
 	export function find<T>(iterable: Iterable<T>, predicate: (t: T) => boolean): T | undefined {

--- a/src/vs/base/test/common/iterator.test.ts
+++ b/src/vs/base/test/common/iterator.test.ts
@@ -32,4 +32,43 @@ suite('Iterable', function () {
 		assert.deepStrictEqual([...Iterable.wrap(1)], [1]);
 		assert.deepStrictEqual([...Iterable.wrap([1, 2, 3])], [1, 2, 3]);
 	});
+
+	test('every', function () {
+		// Empty iterable should return true (vacuous truth)
+		assert.strictEqual(Iterable.every([], () => false), true);
+
+		// All elements match predicate
+		assert.strictEqual(Iterable.every([2, 4, 6, 8], x => x % 2 === 0), true);
+		assert.strictEqual(Iterable.every([1, 2, 3], x => x > 0), true);
+
+		// Not all elements match predicate
+		assert.strictEqual(Iterable.every([1, 2, 3, 4], x => x % 2 === 0), false);
+		assert.strictEqual(Iterable.every([1, 2, 3], x => x > 2), false);
+
+		// Single element - matches
+		assert.strictEqual(Iterable.every([5], x => x === 5), true);
+
+		// Single element - doesn't match
+		assert.strictEqual(Iterable.every([5], x => x === 6), false);
+
+		// Test index parameter in predicate
+		const numbers = [10, 11, 12, 13];
+		assert.strictEqual(Iterable.every(numbers, (x, i) => x === 10 + i), true);
+		assert.strictEqual(Iterable.every(numbers, (x, i) => i < 2), false);
+
+		// Test early termination - predicate should not be called for all elements
+		let callCount = 0;
+		const result = Iterable.every([1, 2, 3, 4, 5], x => {
+			callCount++;
+			return x < 3;
+		});
+		assert.strictEqual(result, false);
+		assert.strictEqual(callCount, 3); // Should stop at the third element
+
+		// Test with truthy/falsy values
+		assert.strictEqual(Iterable.every([1, 2, 3], x => x), true);
+		assert.strictEqual(Iterable.every([1, 0, 3], x => x), false);
+		assert.strictEqual(Iterable.every(['a', 'b', 'c'], x => x), true);
+		assert.strictEqual(Iterable.every(['a', '', 'c'], x => x), false);
+	});
 });

--- a/src/vs/workbench/contrib/chat/browser/actions/chatToolPicker.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatToolPicker.ts
@@ -6,6 +6,7 @@ import { assertNever } from '../../../../../base/common/assert.js';
 import { Codicon } from '../../../../../base/common/codicons.js';
 import { diffSets } from '../../../../../base/common/collections.js';
 import { Event } from '../../../../../base/common/event.js';
+import { Iterable } from '../../../../../base/common/iterator.js';
 import { DisposableStore } from '../../../../../base/common/lifecycle.js';
 import { ThemeIcon } from '../../../../../base/common/themables.js';
 import { assertType } from '../../../../../base/common/types.js';
@@ -187,17 +188,19 @@ export async function showToolsPicker(
 		}
 
 		if (toolSetOrTool instanceof ToolSet) {
-			bucket.children.push({
-				parent: bucket,
-				type: 'item',
-				picked,
-				toolset: toolSetOrTool,
-				label: toolSetOrTool.toolReferenceName,
-				description: toolSetOrTool.description,
-				indented: true,
-				buttons
+			if (toolSetOrTool.source.type !== 'mcp') { // don't show the MCP toolset
+				bucket.children.push({
+					parent: bucket,
+					type: 'item',
+					picked,
+					toolset: toolSetOrTool,
+					label: toolSetOrTool.toolReferenceName,
+					description: toolSetOrTool.description,
+					indented: true,
+					buttons
+				});
+			}
 
-			});
 		} else if (toolSetOrTool.canBeReferencedInPrompt) {
 			bucket.children.push({
 				parent: bucket,
@@ -373,6 +376,23 @@ export async function showToolsPicker(
 	await Promise.race([Event.toPromise(Event.any(picker.onDidAccept, picker.onDidHide))]);
 
 	store.dispose();
+
+	const mcpToolSets = new Set<ToolSet>();
+
+	for (const item of toolsService.toolSets.get()) {
+		if (item.source.type === 'mcp') {
+			mcpToolSets.add(item);
+
+			if (Iterable.every(item.getTools(), tool => result.get(tool))) {
+				// ALL tools from the MCP tool set are here, replace them with just the toolset
+				// but only when computing the final result
+				for (const tool of item.getTools()) {
+					result.delete(tool);
+				}
+				result.set(item, true);
+			}
+		}
+	}
 
 	return didAccept ? result : undefined;
 }


### PR DESCRIPTION
* Iterator#every
* register tool set for MCP serer
* don't show MCP toolset in tools picker (because they are a bucket already)
* remove the filtering of homogenous tool sets