### PR TITLE
fix(editor): handle minimap offset in content width

### DIFF
--- a/src/vs/editor/browser/viewParts/editorScrollbar/editorScrollbar.ts
+++ b/src/vs/editor/browser/viewParts/editorScrollbar/editorScrollbar.ts
@@ -114,12 +114,11 @@ export class EditorScrollbar extends ViewPart {
 		this.scrollbarDomNode.setLeft(layoutInfo.contentLeft);
 
 		const minimap = options.get(EditorOption.minimap);
-		const side = minimap.side;
-		if (side === 'right') {
-			this.scrollbarDomNode.setWidth(layoutInfo.contentWidth + layoutInfo.minimap.minimapWidth);
-		} else {
-			this.scrollbarDomNode.setWidth(layoutInfo.contentWidth);
-		}
+
+		const minimapExtraWidth = minimap.enabled && minimap.side === 'right'
+			? layoutInfo.minimap.minimapWidth + layoutInfo.verticalScrollbarWidth : 0;
+
+		this.scrollbarDomNode.setWidth(layoutInfo.contentWidth + minimapExtraWidth);
 		this.scrollbarDomNode.setHeight(layoutInfo.height);
 	}
 

--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -2798,10 +2798,13 @@ export class EditorLayoutInfoComputer extends ComputedEditorOption<EditorOption.
 			decorationsLeft += minimapLayout.minimapWidth;
 			contentLeft += minimapLayout.minimapWidth;
 		}
-		const contentWidth = remainingWidth - minimapLayout.minimapWidth;
+
+		const minimapOffset = minimap.enabled && minimap.side === 'right' ? verticalScrollbarWidth : 0;
+		const contentWidth = remainingWidth - minimapLayout.minimapWidth - minimapOffset;
 
 		// (leaving 2px for the cursor to have space after the last character)
-		const viewportColumn = Math.max(1, Math.floor((contentWidth - verticalScrollbarWidth - 2) / typicalHalfwidthCharacterWidth));
+		const scrollbarCompensation = !minimap.enabled || minimap.side === 'left' ? verticalScrollbarWidth : 0;
+		const viewportColumn = Math.max(1, Math.floor((contentWidth - scrollbarCompensation - 2) / typicalHalfwidthCharacterWidth));
 
 		const verticalArrowSize = (verticalScrollbarHasArrows ? scrollbarArrowSize : 0);
 

--- a/src/vs/editor/test/browser/config/editorLayoutProvider.test.ts
+++ b/src/vs/editor/test/browser/config/editorLayoutProvider.test.ts
@@ -1396,7 +1396,7 @@ suite('Editor ViewLayout - EditorLayoutProvider', () => {
 			decorationsWidth: 26,
 
 			contentLeft: 92,
-			contentWidth: 1018,
+			contentWidth: 1004,
 
 			minimap: {
 				renderMinimap: RenderMinimap.Text,


### PR DESCRIPTION
Account for the minimap offset from the viewport edge when calculating the content width, so the minimap does not overlap the content.

Closes: #250072

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
