### PR TITLE
Highlight debug console important message correctly

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/debugSession.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugSession.ts
@@ -1153,7 +1153,8 @@ export class DebugSession implements IDebugSession {
 
 		const outputQueue = new Queue<void>();
 		this.rawListeners.add(this.raw.onDidOutput(async event => {
-			const outputSeverity = event.body.category === 'stderr' ? Severity.Error : event.body.category === 'console' ? Severity.Warning : Severity.Info;
+			const outputSeverity = event.body.category === 'stderr' ? Severity.Error :
+				(event.body.category === 'console' || event.body.category === 'important') ? Severity.Warning : Severity.Info;
 
 			// When a variables event is received, execute immediately to obtain the variables value #126967
 			if (event.body.variablesReference) {


### PR DESCRIPTION
The current colour of a debug important message is the same as an output from the debuggee, use the same colour as a normal message from the debugger.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
