### PR TITLE
set an empty selection so that get selection does not return undefined

### DIFF
--- a/src/vs/workbench/api/common/extHostNotebookEditor.ts
+++ b/src/vs/workbench/api/common/extHostNotebookEditor.ts
@@ -36,7 +36,7 @@ export class ExtHostNotebookEditor {
 					return that.notebookData.apiNotebook;
 				},
 				get selection() {
-					return that._selections[0];
+					return that._selections[0] ?? new vscode.NotebookRange(0, 0);
 				},
 				set selection(selection: vscode.NotebookRange) {
 					this.selections = [selection];
@@ -93,7 +93,7 @@ export class ExtHostNotebookEditor {
 	}
 
 	_acceptSelections(selections: vscode.NotebookRange[]): void {
-		this._selections = selections.length > 0 ? selections : [new vscode.NotebookRange(0, 0)];
+		this._selections = selections;
 	}
 
 	private _trySetSelections(value: vscode.NotebookRange[]): void {

--- a/src/vs/workbench/api/common/extHostNotebookEditor.ts
+++ b/src/vs/workbench/api/common/extHostNotebookEditor.ts
@@ -36,7 +36,7 @@ export class ExtHostNotebookEditor {
 					return that.notebookData.apiNotebook;
 				},
 				get selection() {
-					return that._selections[0] ?? new vscode.NotebookRange(0, 0);
+					return that._selections[0];
 				},
 				set selection(selection: vscode.NotebookRange) {
 					this.selections = [selection];
@@ -48,8 +48,8 @@ export class ExtHostNotebookEditor {
 					if (!Array.isArray(value) || !value.every(extHostTypes.NotebookRange.isNotebookRange)) {
 						throw illegalArgument('selections');
 					}
-					that._selections = value;
-					that._trySetSelections(value);
+					that._selections = value.length === 0 ? [new vscode.NotebookRange(0, 0)] : value;
+					that._trySetSelections(that._selections);
 				},
 				get visibleRanges() {
 					return that._visibleRanges;
@@ -93,7 +93,7 @@ export class ExtHostNotebookEditor {
 	}
 
 	_acceptSelections(selections: vscode.NotebookRange[]): void {
-		this._selections = selections;
+		this._selections = selections.length === 0 ? [new vscode.NotebookRange(0, 0)] : selections;
 	}
 
 	private _trySetSelections(value: vscode.NotebookRange[]): void {

--- a/src/vs/workbench/api/common/extHostNotebookEditor.ts
+++ b/src/vs/workbench/api/common/extHostNotebookEditor.ts
@@ -93,7 +93,7 @@ export class ExtHostNotebookEditor {
 	}
 
 	_acceptSelections(selections: vscode.NotebookRange[]): void {
-		this._selections = selections;
+		this._selections = selections.length > 0 ? selections : [new vscode.NotebookRange(0, 0)];
 	}
 
 	private _trySetSelections(value: vscode.NotebookRange[]): void {

--- a/src/vs/workbench/api/common/extHostNotebookEditor.ts
+++ b/src/vs/workbench/api/common/extHostNotebookEditor.ts
@@ -9,6 +9,7 @@ import * as extHostConverter from './extHostTypeConverters.js';
 import * as extHostTypes from './extHostTypes.js';
 import * as vscode from 'vscode';
 import { ExtHostNotebookDocument } from './extHostNotebookDocument.js';
+import { NotebookRange } from './extHostTypes.js';
 
 export class ExtHostNotebookEditor {
 
@@ -48,7 +49,7 @@ export class ExtHostNotebookEditor {
 					if (!Array.isArray(value) || !value.every(extHostTypes.NotebookRange.isNotebookRange)) {
 						throw illegalArgument('selections');
 					}
-					that._selections = value.length === 0 ? [new vscode.NotebookRange(0, 0)] : value;
+					that._selections = value.length === 0 ? [new NotebookRange(0, 0)] : value;
 					that._trySetSelections(that._selections);
 				},
 				get visibleRanges() {
@@ -93,7 +94,7 @@ export class ExtHostNotebookEditor {
 	}
 
 	_acceptSelections(selections: vscode.NotebookRange[]): void {
-		this._selections = selections.length === 0 ? [new vscode.NotebookRange(0, 0)] : selections;
+		this._selections = selections.length === 0 ? [new NotebookRange(0, 0)] : selections;
 	}
 
 	private _trySetSelections(value: vscode.NotebookRange[]): void {


### PR DESCRIPTION
fix https://github.com/microsoft/vscode-copilot/issues/17909

This will make the value match the type in the API.
I think having an undefined selection is specific to the way we recover snapshots - deleting all cells for instance will have some fixup to set the selection to an empty selection

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
