### PR TITLE
mcp: use tool embedded resource data for 'permalinks'

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -110,6 +110,7 @@ import { ChatViewsWelcomeHandler } from './viewsWelcome/chatViewsWelcomeHandler.
 import { registerAction2 } from '../../../../platform/actions/common/actions.js';
 import product from '../../../../platform/product/common/product.js';
 import { ChatModeService, IChatModeService } from '../common/chatModes.js';
+import { ChatResponseResourceFileSystemProvider } from '../common/chatResponseResourceFileSystemProvider.js';
 
 // Register configuration
 const configurationRegistry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration);
@@ -708,6 +709,7 @@ registerWorkbenchContribution2(SimpleBrowserOverlay.ID, SimpleBrowserOverlay, Wo
 registerWorkbenchContribution2(ChatEditingEditorContextKeys.ID, ChatEditingEditorContextKeys, WorkbenchPhase.AfterRestored);
 registerWorkbenchContribution2(ChatTransferContribution.ID, ChatTransferContribution, WorkbenchPhase.BlockRestore);
 registerWorkbenchContribution2(ChatContextContributions.ID, ChatContextContributions, WorkbenchPhase.AfterRestored);
+registerWorkbenchContribution2(ChatResponseResourceFileSystemProvider.ID, ChatResponseResourceFileSystemProvider, WorkbenchPhase.AfterRestored);
 
 registerChatActions();
 registerChatCopyActions();

--- a/src/vs/workbench/contrib/chat/browser/chatAttachmentWidgets.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatAttachmentWidgets.ts
@@ -247,6 +247,7 @@ export class ImageAttachmentWidget extends AbstractChatAttachmentWidget {
 		@IHoverService private readonly hoverService: IHoverService,
 		@ILanguageModelsService private readonly languageModelsService: ILanguageModelsService,
 		@ITelemetryService private readonly telemetryService: ITelemetryService,
+		@IInstantiationService instantiationService: IInstantiationService,
 	) {
 		super(attachment, options, container, contextResourceLabels, hoverDelegate, currentLanguageModel, commandService, openerService);
 
@@ -290,6 +291,9 @@ export class ImageAttachmentWidget extends AbstractChatAttachmentWidget {
 
 		if (resource) {
 			this.addResourceOpenHandlers(resource, undefined);
+			instantiationService.invokeFunction(accessor => {
+				this._register(hookUpResourceAttachmentDragAndContextMenu(accessor, this.element, resource));
+			});
 		}
 
 		this.attachClearButton();

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/chatAttachmentsContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/chatAttachmentsContentPart.ts
@@ -28,7 +28,6 @@ export class ChatAttachmentsContentPart extends Disposable {
 	private readonly _contextResourceLabels: ResourceLabels;
 
 	public contextMenuHandler?: (attachment: IChatRequestVariableEntry, event: MouseEvent) => void;
-	public dragStartHandler?: (attachment: IChatRequestVariableEntry, event: DragEvent, element: HTMLElement) => void;
 
 	constructor(
 		private readonly variables: IChatRequestVariableEntry[],
@@ -94,7 +93,6 @@ export class ChatAttachmentsContentPart extends Disposable {
 			}
 
 			this._register(dom.addDisposableListener(widget.element, 'contextmenu', e => this.contextMenuHandler?.(attachment, e)));
-			this._register(dom.addDisposableListener(widget.element, 'dragstart', e => this.dragStartHandler?.(attachment, e, widget.element)));
 
 			if (this.attachedContextDisposables.isDisposed) {
 				widget.dispose();

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatInputOutputMarkdownProgressPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatInputOutputMarkdownProgressPart.ts
@@ -3,17 +3,18 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { assertNever } from '../../../../../../base/common/assert.js';
 import { decodeBase64 } from '../../../../../../base/common/buffer.js';
 import { IMarkdownString } from '../../../../../../base/common/htmlContent.js';
 import { toDisposable } from '../../../../../../base/common/lifecycle.js';
+import { getExtensionForMimeType } from '../../../../../../base/common/mime.js';
 import { autorun } from '../../../../../../base/common/observable.js';
+import { basename } from '../../../../../../base/common/resources.js';
 import { ILanguageService } from '../../../../../../editor/common/languages/language.js';
 import { IModelService } from '../../../../../../editor/common/services/model.js';
-import { localize } from '../../../../../../nls.js';
 import { IInstantiationService } from '../../../../../../platform/instantiation/common/instantiation.js';
-import { getAttachableImageExtension } from '../../../common/chatModel.js';
+import { ChatResponseResource } from '../../../common/chatModel.js';
 import { IChatToolInvocation, IChatToolInvocationSerialized } from '../../../common/chatService.js';
+import { isResponseVM } from '../../../common/chatViewModel.js';
 import { IToolResultInputOutputDetails } from '../../../common/languageModelToolsService.js';
 import { IChatCodeBlockInfo } from '../../chat.js';
 import { IChatContentPartRenderContext } from '../chatContentParts.js';
@@ -87,9 +88,10 @@ export class ChatInputOutputMarkdownProgressPart extends BaseChatToolInvocationS
 
 		let processedOutput = output;
 		if (typeof output === 'string') { // back compat with older stored versions
-			processedOutput = [{ type: 'text', value: output }];
+			processedOutput = [{ value: output, isText: true }];
 		}
 
+		const requestId = isResponseVM(context.element) ? context.element.requestId : context.element.id;
 		const collapsibleListPart = this._register(instantiationService.createInstance(
 			ChatCollapsibleInputOutputContentPart,
 			message,
@@ -98,20 +100,29 @@ export class ChatInputOutputMarkdownProgressPart extends BaseChatToolInvocationS
 			editorPool,
 			toCodePart(input),
 			processedOutput && {
-				parts: processedOutput.map((o): ChatCollapsibleIOPart => {
-					if (o.type === 'data') {
-						const decoded = decodeBase64(o.value64).buffer;
-						if (getAttachableImageExtension(o.mimeType)) {
-							return { kind: 'data', value: decoded, mimeType: o.mimeType, uri: o.uri };
-						} else {
-							return toCodePart(localize('toolResultData', "Data of type {0} ({1} bytes)", o.mimeType, decoded.byteLength));
-						}
-					} else if (o.type === 'text') {
+				parts: processedOutput.map((o, i): ChatCollapsibleIOPart => {
+					const permalinkBasename = o.uri
+						? basename(o.uri)
+						: o.mimeType && getExtensionForMimeType(o.mimeType)
+							? `file${getExtensionForMimeType(o.mimeType)}`
+							: 'file' + (o.isText ? '.txt' : '.bin');
+
+					const permalinkUri = ChatResponseResource.createUri(context.element.sessionId, requestId, toolInvocation.toolCallId, i, permalinkBasename);
+
+					if (o.isText && !o.asResource) {
 						return toCodePart(o.value);
-					} else if (o.type === 'resource') {
-						return { kind: 'resource', uri: o.uri };
 					} else {
-						assertNever(o);
+						let decoded: Uint8Array | undefined;
+						try {
+							if (!o.isText) {
+								decoded = decodeBase64(o.value).buffer;
+							}
+						} catch {
+							// ignored
+						}
+
+						// Fall back to text if it's not valid base64
+						return { kind: 'data', value: decoded || new TextEncoder().encode(o.value), mimeType: o.mimeType, uri: permalinkUri };
 					}
 				}),
 			},

--- a/src/vs/workbench/contrib/chat/browser/languageModelToolsService.ts
+++ b/src/vs/workbench/contrib/chat/browser/languageModelToolsService.ts
@@ -340,7 +340,7 @@ export class LanguageModelToolsService extends Disposable implements ILanguageMo
 			toolResult ??= { content: [] };
 			toolResult.toolResultError = err instanceof Error ? err.message : String(err);
 			if (tool.data.alwaysDisplayInputOutput) {
-				toolResult.toolResultDetails = { input: this.formatToolInput(dto), output: [{ type: 'text', value: String(err) }], isError: true };
+				toolResult.toolResultDetails = { input: this.formatToolInput(dto), output: [{ isText: true, value: String(err) }], isError: true };
 			}
 
 			throw err;
@@ -402,11 +402,11 @@ export class LanguageModelToolsService extends Disposable implements ILanguageMo
 	private toolResultToIO(toolResult: IToolResult): IToolResultInputOutputDetails['output'] {
 		return toolResult.content.map(part => {
 			if (part.kind === 'text') {
-				return { type: 'text', value: part.value };
+				return { isText: true, value: part.value };
 			} else if (part.kind === 'promptTsx') {
-				return { type: 'text', value: stringifyPromptTsxPart(part) };
+				return { isText: true, value: stringifyPromptTsxPart(part) };
 			} else if (part.kind === 'data') {
-				return { type: 'data', value64: encodeBase64(part.value.data), mimeType: part.value.mimeType };
+				return { value: encodeBase64(part.value.data), mimeType: part.value.mimeType };
 			} else {
 				assertNever(part);
 			}

--- a/src/vs/workbench/contrib/chat/common/chatModel.ts
+++ b/src/vs/workbench/contrib/chat/common/chatModel.ts
@@ -1946,3 +1946,39 @@ export interface IChatAgentEditedFileEvent {
 	readonly uri: URI;
 	readonly eventKind: ChatRequestEditedFileEventKind;
 }
+
+/** URI for a resource embedded in a chat request/response */
+export namespace ChatResponseResource {
+	export const scheme = 'vscode-chat-response-resource';
+
+	export function createUri(sessionId: string, requestId: string, toolCallId: string, index: number, basename?: string): URI {
+		return URI.from({
+			scheme: ChatResponseResource.scheme,
+			authority: sessionId,
+			path: `/tool/${requestId}/${toolCallId}/${index}` + (basename ? `/${basename}` : ''),
+		});
+	}
+
+	export function parseUri(uri: URI): undefined | { sessionId: string; requestId: string; toolCallId: string; index: number } {
+		if (uri.scheme !== ChatResponseResource.scheme) {
+			return undefined;
+		}
+
+		const parts = uri.path.split('/');
+		if (parts.length < 5) {
+			return undefined;
+		}
+
+		const [, kind, requestId, toolCallId, index] = parts;
+		if (kind !== 'tool') {
+			return undefined;
+		}
+
+		return {
+			sessionId: uri.authority,
+			requestId: requestId,
+			toolCallId: toolCallId,
+			index: Number(index),
+		};
+	}
+}

--- a/src/vs/workbench/contrib/chat/common/chatResponseResourceFileSystemProvider.ts
+++ b/src/vs/workbench/contrib/chat/common/chatResponseResourceFileSystemProvider.ts
@@ -1,0 +1,114 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { decodeBase64, VSBuffer } from '../../../../base/common/buffer.js';
+import { Event } from '../../../../base/common/event.js';
+import { Disposable, IDisposable } from '../../../../base/common/lifecycle.js';
+import { newWriteableStream, ReadableStreamEvents } from '../../../../base/common/stream.js';
+import { URI } from '../../../../base/common/uri.js';
+import { createFileSystemProviderError, FileSystemProviderCapabilities, FileSystemProviderErrorCode, FileType, IFileService, IFileSystemProviderWithFileAtomicReadCapability, IFileSystemProviderWithFileReadStreamCapability, IFileSystemProviderWithFileReadWriteCapability, IStat } from '../../../../platform/files/common/files.js';
+import { IWorkbenchContribution } from '../../../common/contributions.js';
+import { ChatResponseResource } from './chatModel.js';
+import { IChatService, IChatToolInvocation, IChatToolInvocationSerialized } from './chatService.js';
+import { isToolResultInputOutputDetails } from './languageModelToolsService.js';
+
+export class ChatResponseResourceFileSystemProvider extends Disposable implements
+	IWorkbenchContribution,
+	IFileSystemProviderWithFileReadWriteCapability,
+	IFileSystemProviderWithFileAtomicReadCapability,
+	IFileSystemProviderWithFileReadStreamCapability {
+
+	public static readonly ID = 'workbench.contrib.chatResponseResourceFileSystemProvider';
+
+	public readonly onDidChangeCapabilities = Event.None;
+	public readonly onDidChangeFile = Event.None;
+
+	public readonly capabilities: FileSystemProviderCapabilities = FileSystemProviderCapabilities.None
+		| FileSystemProviderCapabilities.Readonly
+		| FileSystemProviderCapabilities.PathCaseSensitive
+		| FileSystemProviderCapabilities.FileReadStream
+		| FileSystemProviderCapabilities.FileAtomicRead
+		| FileSystemProviderCapabilities.FileReadWrite;
+
+	constructor(
+		@IChatService private readonly chatService: IChatService,
+		@IFileService private readonly _fileService: IFileService
+	) {
+		super();
+		this._register(this._fileService.registerProvider(ChatResponseResource.scheme, this));
+	}
+
+	readFile(resource: URI): Promise<Uint8Array> {
+		return Promise.resolve(this.lookupURI(resource));
+	}
+
+	readFileStream(resource: URI): ReadableStreamEvents<Uint8Array> {
+		const stream = newWriteableStream<Uint8Array>(data => VSBuffer.concat(data.map(data => VSBuffer.wrap(data))).buffer);
+		stream.end(this.lookupURI(resource));
+		return stream;
+	}
+
+	stat(resource: URI): Promise<IStat> {
+		const r = this.lookupURI(resource);
+		return Promise.resolve({
+			type: FileType.File,
+			ctime: 0,
+			mtime: 0,
+			size: r.length,
+		});
+	}
+
+	delete(): Promise<void> {
+		throw createFileSystemProviderError('fs is readonly', FileSystemProviderErrorCode.NoPermissions);
+	}
+
+	watch(): IDisposable {
+		return Disposable.None;
+	}
+
+	mkdir(): Promise<void> {
+		throw createFileSystemProviderError('fs is readonly', FileSystemProviderErrorCode.NoPermissions);
+	}
+
+	readdir(): Promise<[string, FileType][]> {
+		return Promise.resolve([]);
+	}
+
+	rename(): Promise<void> {
+		throw createFileSystemProviderError('fs is readonly', FileSystemProviderErrorCode.NoPermissions);
+	}
+
+	writeFile(): Promise<void> {
+		throw createFileSystemProviderError('fs is readonly', FileSystemProviderErrorCode.NoPermissions);
+	}
+
+	private lookupURI(uri: URI): Uint8Array {
+		const parsed = ChatResponseResource.parseUri(uri);
+		if (!parsed) {
+			throw createFileSystemProviderError(`File not found`, FileSystemProviderErrorCode.FileNotFound);
+		}
+		const { sessionId, requestId, toolCallId } = parsed;
+		const result = this.chatService.getSession(sessionId)
+			?.getRequests()
+			.find(r => r.id === requestId)
+			?.response?.entireResponse.value
+			.find((r): r is IChatToolInvocation | IChatToolInvocationSerialized => (r.kind === 'toolInvocation' || r.kind === 'toolInvocationSerialized') && r.toolCallId === toolCallId);
+
+		if (!result) {
+			throw createFileSystemProviderError(`File not found`, FileSystemProviderErrorCode.FileNotFound);
+		}
+
+		if (!isToolResultInputOutputDetails(result.resultDetails)) {
+			throw createFileSystemProviderError(`Tool does not have I/O`, FileSystemProviderErrorCode.FileNotFound);
+		}
+
+		const part = result.resultDetails.output.at(parsed.index);
+		if (!part) {
+			throw createFileSystemProviderError(`Tool does not have part`, FileSystemProviderErrorCode.FileNotFound);
+		}
+
+		return part.isText ? new TextEncoder().encode(part.value) : decodeBase64(part.value).buffer;
+	}
+}

--- a/src/vs/workbench/contrib/chat/common/languageModelToolsService.ts
+++ b/src/vs/workbench/contrib/chat/common/languageModelToolsService.ts
@@ -125,7 +125,17 @@ export function isToolInvocationContext(obj: any): obj is IToolInvocationContext
 
 export interface IToolResultInputOutputDetails {
 	readonly input: string;
-	readonly output: ({ type: 'text'; value: string } | { type: 'data'; mimeType: string; value64: string; uri?: URI } | { type: 'resource'; uri: URI })[];
+	readonly output: ({
+		value: string;
+		/** If true, value is text. If false or not given, value is base64 */
+		isText?: boolean;
+		/** Mimetype of the value, optional */
+		mimeType?: string;
+		/** URI of the resource on the MCP server. */
+		uri?: URI;
+		/** If true, this part came in as a resource reference rather than direct data. */
+		asResource?: boolean;
+	})[];
 	readonly isError?: boolean;
 }
 

--- a/src/vs/workbench/contrib/extensions/common/searchExtensionsTool.ts
+++ b/src/vs/workbench/contrib/extensions/common/searchExtensionsTool.ts
@@ -143,7 +143,7 @@ export class SearchExtensionsTool implements IToolImpl {
 			}],
 			toolResultDetails: {
 				input: JSON.stringify(params),
-				output: [{ type: 'text', value: JSON.stringify(result.map(extension => extension.id)) }]
+				output: [{ isText: true, value: JSON.stringify(result.map(extension => extension.id)) }]
 			}
 		};
 	}

--- a/src/vs/workbench/contrib/mcp/common/mcpService.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpService.ts
@@ -11,13 +11,14 @@ import { markdownCommandLink, MarkdownString } from '../../../../base/common/htm
 import { Disposable, DisposableStore, IReference, toDisposable } from '../../../../base/common/lifecycle.js';
 import { equals } from '../../../../base/common/objects.js';
 import { autorun, IObservable, observableValue, transaction } from '../../../../base/common/observable.js';
+import { basename } from '../../../../base/common/resources.js';
 import { URI } from '../../../../base/common/uri.js';
 import { localize } from '../../../../nls.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
 import { IProductService } from '../../../../platform/product/common/productService.js';
 import { StorageScope } from '../../../../platform/storage/common/storage.js';
-import { getAttachableImageExtension } from '../../chat/common/chatModel.js';
+import { ChatResponseResource, getAttachableImageExtension } from '../../chat/common/chatModel.js';
 import { CountTokensCallback, ILanguageModelToolsService, IPreparedToolInvocation, IToolData, IToolImpl, IToolInvocation, IToolResult, IToolResultInputOutputDetails, ToolDataSource, ToolProgress, ToolSet } from '../../chat/common/languageModelToolsService.js';
 import { McpCommandIds } from './mcpCommandIds.js';
 import { IMcpRegistry } from './mcpRegistryTypes.js';
@@ -301,19 +302,19 @@ class McpToolImplementation implements IToolImpl {
 			}
 
 			// Rewrite image rsources to images so they are inlined nicely
-			const addAsInlineData = (mimeType: string, value64: string, uri?: URI) => {
-				details.output.push({ type: 'data', mimeType, value64, uri });
+			const addAsInlineData = (mimeType: string, value: string, uri?: URI) => {
+				details.output.push({ mimeType, value, uri });
 				if (isForModel) {
 					result.content.push({
 						kind: 'data',
-						value: { mimeType, data: decodeBase64(value64) }
+						value: { mimeType, data: decodeBase64(value) }
 					});
 				}
 			};
 
 			const isForModel = audience.includes('assistant');
 			if (item.type === 'text') {
-				details.output.push({ type: 'text', value: item.text });
+				details.output.push({ isText: true, value: item.text });
 				if (isForModel) {
 					result.content.push({
 						kind: 'text',
@@ -321,17 +322,27 @@ class McpToolImplementation implements IToolImpl {
 					});
 				}
 			} else if (item.type === 'image' || item.type === 'audio') {
-				addAsInlineData(item.mimeType, item.data);
+				// default to some image type if not given to hint
+				addAsInlineData(item.mimeType || 'image/png', item.data);
 			} else if (item.type === 'resource') {
 				const uri = McpResourceURI.fromServer(this._server.definition, item.resource.uri);
 				if (item.resource.mimeType && getAttachableImageExtension(item.resource.mimeType) && 'blob' in item.resource) {
 					addAsInlineData(item.resource.mimeType, item.resource.blob, uri);
 				} else {
-					details.output.push({ type: 'resource', uri });
+					details.output.push({
+						uri,
+						isText: 'text' in item.resource,
+						mimeType: item.resource.mimeType,
+						value: 'blob' in item.resource ? item.resource.blob : item.resource.text,
+						asResource: true,
+					});
+
 					if (isForModel) {
+						const permalink = invocation.chatRequestId && invocation.context && ChatResponseResource.createUri(invocation.context.sessionId, invocation.chatRequestId, invocation.callId, result.content.length, basename(uri));
+
 						result.content.push({
 							kind: 'text',
-							value: 'text' in item.resource ? item.resource.text : `The tool returns a resource which can be read from the URI ${uri}`,
+							value: 'text' in item.resource ? item.resource.text : `The tool returns a resource which can be read from the URI ${permalink || uri}`,
 						});
 					}
 				}


### PR DESCRIPTION
Previously we kind of normalized on MCP resource URIs in tool responses.
This means we basically ignored the embedded content and _required_
servers implement resources to make it work.

In this PR, I register a read-only filesystem that serves contents from
the chat tool response. This avoids extra resources calls and might be
more predictable as well.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
