### PR TITLE
Eli/new welcome command palette step

### DIFF
--- a/src/vs/workbench/contrib/quickaccess/browser/commandsQuickAccess.ts
+++ b/src/vs/workbench/contrib/quickaccess/browser/commandsQuickAccess.ts
@@ -40,6 +40,7 @@ import { IEditorService } from '../../../services/editor/common/editorService.js
 import { IExtensionService } from '../../../services/extensions/common/extensions.js';
 import { createKeybindingCommandQuery } from '../../../services/preferences/browser/keybindingsEditorModel.js';
 import { IPreferencesService } from '../../../services/preferences/common/preferences.js';
+import { HelpQuickAccessProvider } from '../../../../platform/quickinput/browser/helpQuickAccess.js';
 
 export class CommandsQuickAccessProvider extends AbstractEditorCommandsQuickAccessProvider {
 
@@ -278,6 +279,23 @@ export class ShowAllCommandsAction extends Action2 {
 
 	async run(accessor: ServicesAccessor): Promise<void> {
 		accessor.get(IQuickInputService).quickAccess.show(CommandsQuickAccessProvider.PREFIX);
+	}
+}
+
+export class ShowAllCommandsHelpAction extends Action2 {
+
+	static readonly ID = 'workbench.action.showCommandsHelp';
+
+	constructor() {
+		super({
+			id: ShowAllCommandsHelpAction.ID,
+			title: localize2('showCommandsHelp', 'Show All Commands Help'),
+			f1: true
+		});
+	}
+
+	async run(accessor: ServicesAccessor): Promise<void> {
+		accessor.get(IQuickInputService).quickAccess.show(HelpQuickAccessProvider.PREFIX);
 	}
 }
 

--- a/src/vs/workbench/contrib/quickaccess/browser/quickAccess.contribution.ts
+++ b/src/vs/workbench/contrib/quickaccess/browser/quickAccess.contribution.ts
@@ -8,7 +8,7 @@ import { IQuickAccessRegistry, Extensions } from '../../../../platform/quickinpu
 import { Registry } from '../../../../platform/registry/common/platform.js';
 import { HelpQuickAccessProvider } from '../../../../platform/quickinput/browser/helpQuickAccess.js';
 import { ViewQuickAccessProvider, OpenViewPickerAction, QuickAccessViewPickerAction } from './viewQuickAccess.js';
-import { CommandsQuickAccessProvider, ShowAllCommandsAction, ClearCommandHistoryAction } from './commandsQuickAccess.js';
+import { CommandsQuickAccessProvider, ShowAllCommandsAction, ShowAllCommandsHelpAction, ClearCommandHistoryAction } from './commandsQuickAccess.js';
 import { MenuRegistry, MenuId, registerAction2 } from '../../../../platform/actions/common/actions.js';
 import { KeyMod } from '../../../../base/common/keyCodes.js';
 import { ContextKeyExpr } from '../../../../platform/contextkey/common/contextkey.js';
@@ -114,6 +114,7 @@ MenuRegistry.appendMenuItem(MenuId.EditorContext, {
 
 registerAction2(ClearCommandHistoryAction);
 registerAction2(ShowAllCommandsAction);
+registerAction2(ShowAllCommandsHelpAction);
 registerAction2(OpenViewPickerAction);
 registerAction2(QuickAccessViewPickerAction);
 

--- a/src/vs/workbench/contrib/welcomeGettingStarted/common/gettingStartedContent.ts
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/common/gettingStartedContent.ts
@@ -14,9 +14,17 @@ import { NotebookSetting } from '../../notebook/common/notebookCommon.js';
 import { CONTEXT_ACCESSIBILITY_MODE_ENABLED } from '../../../../platform/accessibility/common/accessibility.js';
 import { URI } from '../../../../base/common/uri.js';
 import product from '../../../../platform/product/common/product.js';
+import { isMacintosh } from '../../../../base/common/platform.js';
 
 interface IGettingStartedContentProvider {
 	(): string;
+}
+
+/**
+ * Gets the platform-specific keyboard shortcut for opening Command Palette
+ */
+function getCommandPaletteShortcut(): string {
+	return isMacintosh ? '⇧⌘P' : 'Ctrl+Shift+P';
 }
 
 export const copilotSettingsMessage = localize({ key: 'settings', comment: ['{Locked="["}', '{Locked="]({0})"}', '{Locked="]({1})"}'] }, "{0} Copilot Free, Pro and Pro+ may show [public code]({1}) suggestions and we may use your data for product improvement. You can change these [settings]({2}) at any time.", product.defaultChatAgent?.providerName, product.defaultChatAgent?.publicCodeMatchesUrl, product.defaultChatAgent?.manageSettingsUrl);
@@ -314,7 +322,7 @@ export const walkthroughs: GettingStartedWalkthroughContent = [
 				{
 					id: 'commandPaletteTask',
 					title: localize('gettingStarted.commandPalette.title', "Unlock productivity with the Command Palette "),
-					description: localize('gettingStarted.commandPalette.description.interpolated', "Run commands without reaching for your mouse to accomplish any task in VS Code.\n{0}", Button(localize('commandPalette', "Open Command Palette"), 'command:workbench.action.showCommandsHelp')),
+					description: localize('gettingStarted.commandPalette.description.dynamic', "Run commands without reaching for your mouse to accomplish any task in VS Code. Press {0} to open the Command Palette and type ? to discover all available commands.\n{1}", getCommandPaletteShortcut(), Button(localize('commandPalette', "Open Command Palette"), 'command:workbench.action.showCommandsHelp')),
 					media: { type: 'svg', altText: 'Command Palette overlay for searching and executing commands.', path: 'commandPalette.svg' },
 				},
 				// Hidden in favor of copilot entry (to be revisited when copilot entry moves, if at all)
@@ -421,7 +429,7 @@ export const walkthroughs: GettingStartedWalkthroughContent = [
 				{
 					id: 'commandPaletteTaskWeb',
 					title: localize('gettingStarted.commandPalette.title', "Unlock productivity with the Command Palette "),
-					description: localize('gettingStarted.commandPalette.description.interpolated', "Run commands without reaching for your mouse to accomplish any task in VS Code.\n{0}", Button(localize('commandPalette', "Open Command Palette"), 'command:workbench.action.showCommandsHelp')),
+					description: localize('gettingStarted.commandPalette.description.dynamic', "Run commands without reaching for your mouse to accomplish any task in VS Code. Press {0} to open the Command Palette and type ? to discover all available commands.\n{1}", getCommandPaletteShortcut(), Button(localize('commandPalette', "Open Command Palette"), 'command:workbench.action.showCommandsHelp')),
 					media: { type: 'svg', altText: 'Command Palette overlay for searching and executing commands.', path: 'commandPalette.svg' },
 				},
 				// Hidden in favor of copilot entry
@@ -485,7 +493,7 @@ export const walkthroughs: GettingStartedWalkthroughContent = [
 				{
 					id: 'commandPaletteTaskAccessibility',
 					title: localize('gettingStarted.commandPaletteAccessibility.title', "Unlock productivity with the Command Palette "),
-					description: localize('gettingStarted.commandPaletteAccessibility.description.interpolated', "Run commands without reaching for your mouse to accomplish any task in VS Code.\n{0}", Button(localize('commandPalette', "Open Command Palette"), 'command:workbench.action.showCommandsHelp')),
+					description: localize('gettingStarted.commandPalette.description.dynamic', "Run commands without reaching for your mouse to accomplish any task in VS Code. Press {0} to open the Command Palette and type ? to discover all available commands.\n{1}", getCommandPaletteShortcut(), Button(localize('commandPalette', "Open Command Palette"), 'command:workbench.action.showCommandsHelp')),
 					media: { type: 'markdown', path: 'empty' },
 				},
 				{
@@ -713,7 +721,7 @@ export const walkthroughs: GettingStartedWalkthroughContent = [
 				{
 					id: 'newCommandPaletteTask',
 					title: localize('newgettingStarted.commandPalette.title', "All commands within reach"),
-					description: localize('gettingStarted.commandPalette.description.interpolated', "Run commands without reaching for your mouse to accomplish any task in VS Code.\n{0}", Button(localize('commandPalette', "Open Command Palette"), 'command:workbench.action.showCommandsHelp')),
+					description: localize('gettingStarted.commandPalette.description.dynamic', "Run commands without reaching for your mouse to accomplish any task in VS Code. Press {0} to open the Command Palette and type ? to discover all available commands.\n{1}", getCommandPaletteShortcut(), Button(localize('commandPalette', "Open Command Palette"), 'command:workbench.action.showCommandsHelp')),
 					media: { type: 'svg', altText: 'Command Palette overlay for searching and executing commands.', path: 'commandPalette.svg' },
 				},
 				{

--- a/src/vs/workbench/contrib/welcomeGettingStarted/common/gettingStartedContent.ts
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/common/gettingStartedContent.ts
@@ -314,7 +314,7 @@ export const walkthroughs: GettingStartedWalkthroughContent = [
 				{
 					id: 'commandPaletteTask',
 					title: localize('gettingStarted.commandPalette.title', "Unlock productivity with the Command Palette "),
-					description: localize('gettingStarted.commandPalette.description.interpolated', "Run commands without reaching for your mouse to accomplish any task in VS Code.\n{0}", Button(localize('commandPalette', "Open Command Palette"), 'command:workbench.action.showCommands')),
+					description: localize('gettingStarted.commandPalette.description.interpolated', "Run commands without reaching for your mouse to accomplish any task in VS Code.\n{0}", Button(localize('commandPalette', "Open Command Palette"), 'command:workbench.action.showCommandsHelp')),
 					media: { type: 'svg', altText: 'Command Palette overlay for searching and executing commands.', path: 'commandPalette.svg' },
 				},
 				// Hidden in favor of copilot entry (to be revisited when copilot entry moves, if at all)
@@ -421,7 +421,7 @@ export const walkthroughs: GettingStartedWalkthroughContent = [
 				{
 					id: 'commandPaletteTaskWeb',
 					title: localize('gettingStarted.commandPalette.title', "Unlock productivity with the Command Palette "),
-					description: localize('gettingStarted.commandPalette.description.interpolated', "Run commands without reaching for your mouse to accomplish any task in VS Code.\n{0}", Button(localize('commandPalette', "Open Command Palette"), 'command:workbench.action.showCommands')),
+					description: localize('gettingStarted.commandPalette.description.interpolated', "Run commands without reaching for your mouse to accomplish any task in VS Code.\n{0}", Button(localize('commandPalette', "Open Command Palette"), 'command:workbench.action.showCommandsHelp')),
 					media: { type: 'svg', altText: 'Command Palette overlay for searching and executing commands.', path: 'commandPalette.svg' },
 				},
 				// Hidden in favor of copilot entry
@@ -485,7 +485,7 @@ export const walkthroughs: GettingStartedWalkthroughContent = [
 				{
 					id: 'commandPaletteTaskAccessibility',
 					title: localize('gettingStarted.commandPaletteAccessibility.title', "Unlock productivity with the Command Palette "),
-					description: localize('gettingStarted.commandPaletteAccessibility.description.interpolated', "Run commands without reaching for your mouse to accomplish any task in VS Code.\n{0}", Button(localize('commandPalette', "Open Command Palette"), 'command:workbench.action.showCommands')),
+					description: localize('gettingStarted.commandPaletteAccessibility.description.interpolated', "Run commands without reaching for your mouse to accomplish any task in VS Code.\n{0}", Button(localize('commandPalette', "Open Command Palette"), 'command:workbench.action.showCommandsHelp')),
 					media: { type: 'markdown', path: 'empty' },
 				},
 				{
@@ -713,7 +713,7 @@ export const walkthroughs: GettingStartedWalkthroughContent = [
 				{
 					id: 'newCommandPaletteTask',
 					title: localize('newgettingStarted.commandPalette.title', "All commands within reach"),
-					description: localize('gettingStarted.commandPalette.description.interpolated', "Run commands without reaching for your mouse to accomplish any task in VS Code.\n{0}", Button(localize('commandPalette', "Open Command Palette"), 'command:workbench.action.showCommands')),
+					description: localize('gettingStarted.commandPalette.description.interpolated', "Run commands without reaching for your mouse to accomplish any task in VS Code.\n{0}", Button(localize('commandPalette', "Open Command Palette"), 'command:workbench.action.showCommandsHelp')),
 					media: { type: 'svg', altText: 'Command Palette overlay for searching and executing commands.', path: 'commandPalette.svg' },
 				},
 				{


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
Added platform specific keyboard shortcuts in Command Palette step of new welcome experience. '?' opens by default when user clicks 'open command palette'. Addressing https://github.com/microsoft/vscode-copilot/issues/17927