### PR TITLE
Engineering - test-documentation.sh|bat uses main instead of vnext

### DIFF
--- a/src/vs/workbench/contrib/themes/test/node/colorRegistry.releaseTest.ts
+++ b/src/vs/workbench/contrib/themes/test/node/colorRegistry.releaseTest.ts
@@ -89,7 +89,7 @@ suite('Color Registry', function () {
 		// avoid importing the TestEnvironmentService as it brings in a duplicate registration of the file editor input factory.
 		const environmentService = new class extends mock<INativeEnvironmentService>() { override args = { _: [] }; };
 
-		const docUrl = 'https://raw.githubusercontent.com/microsoft/vscode-docs/main/api/references/theme-color.md';
+		const docUrl = 'https://raw.githubusercontent.com/microsoft/vscode-docs/vnext/api/references/theme-color.md';
 
 		const reqContext = await new RequestService('local', new TestConfigurationService(), environmentService, new NullLogService()).request({ url: docUrl }, CancellationToken.None);
 		const content = (await asTextOrError(reqContext))!;


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-internalbacklog/issues/5487