### PR TITLE
Feature: Unfold all block comments command (Fixes #85783)

### DIFF
--- a/src/vs/editor/contrib/folding/browser/folding.ts
+++ b/src/vs/editor/contrib/folding/browser/folding.ts
@@ -883,6 +883,39 @@ class FoldAllBlockCommentsAction extends FoldingAction<void> {
 	}
 }
 
+
+class UnfoldAllBlockCommentsAction extends FoldingAction<void> {
+
+	constructor() {
+		super({
+			id: 'editor.unfoldAllBlockComments',
+			label: nls.localize2('unfoldAllBlockComments.label', "Unfold All Block Comments"),
+			precondition: CONTEXT_FOLDING_ENABLED,
+			kbOpts: {
+				kbExpr: EditorContextKeys.editorTextFocus,
+				primary: KeyChord(KeyMod.CtrlCmd | KeyCode.KeyK, KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.Slash),
+				weight: KeybindingWeight.EditorContrib
+			}
+		});
+	}
+
+	invoke(_foldingController: FoldingController, foldingModel: FoldingModel, editor: ICodeEditor, args: void, languageConfigurationService: ILanguageConfigurationService): void {
+		if (foldingModel.regions.hasTypes()) {
+			setCollapseStateForType(foldingModel, FoldingRangeKind.Comment.value, false);
+		} else {
+			const editorModel = editor.getModel();
+			if (!editorModel) {
+				return;
+			}
+			const comments = languageConfigurationService.getLanguageConfiguration(editorModel.getLanguageId()).comments;
+			if (comments && comments.blockCommentStartToken) {
+				const regExp = new RegExp('^\\s*' + escapeRegExpCharacters(comments.blockCommentStartToken));
+				setCollapseStateForMatchingLines(foldingModel, regExp, false);
+			}
+		}
+	}
+}
+
 class FoldAllRegionsAction extends FoldingAction<void> {
 
 	constructor() {
@@ -1251,6 +1284,7 @@ registerEditorAction(ToggleFoldRecursivelyAction);
 registerEditorAction(FoldAllAction);
 registerEditorAction(UnfoldAllAction);
 registerEditorAction(FoldAllBlockCommentsAction);
+registerEditorAction(UnfoldAllBlockCommentsAction);
 registerEditorAction(FoldAllRegionsAction);
 registerEditorAction(UnfoldAllRegionsAction);
 registerEditorAction(FoldAllExceptAction);


### PR DESCRIPTION
This pull request addresses a long-requested feature by extending the editor's folding functionality. Previously, while the editor’s folding supported various regions, only folding (not unfolding) was available for block comment sections. With this update, users can now unfold all block comment sections at once as well. (Fixes #85783)

Specifically, this adds the "Unfold All Block Comments" command, with the key binding 'Ctrl+K Ctrl+Shift+/', complementing the existing "Fold All Block Comments" command ('Ctrl+K Ctrl+/').

This new command enables users to quickly unfold all block comments in the editor without affecting other folded regions. Additionally, folding and unfolding tests have been added to verify the functionality.

Co-Authored by @Barros1902