### PR TITLE
fix(devcontainer): bump rust feature to fix container build

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -6,9 +6,9 @@
       "integrity": "sha256:e7dc4d37ab9e3d6e7ebb221bac741f5bfe07dae47025399d038b17af2ed8ddb7"
     },
     "ghcr.io/devcontainers/features/rust:1": {
-      "version": "1.1.3",
-      "resolved": "ghcr.io/devcontainers/features/rust@sha256:aba6f47303b197976902bf544c786b5efecc03c238ff593583e5e74dfa9c7ccb",
-      "integrity": "sha256:aba6f47303b197976902bf544c786b5efecc03c238ff593583e5e74dfa9c7ccb"
+      "version": "1.3.3",
+      "resolved": "ghcr.io/devcontainers/features/rust@sha256:2521a8eeb4911bfcb22557c8394870ea22eb790d8e52219ddc5182f62d388995",
+      "integrity": "sha256:2521a8eeb4911bfcb22557c8394870ea22eb790d8e52219ddc5182f62d388995"
     }
   }
 }


### PR DESCRIPTION
Rust 1.87.0 removed the RLS and rust-analysis components, which led to an error when building the 'rust' devcontainer feature.

This commit bumps the feature version to 1.3.3, where those components have been removed from the build script, resolving the issue.

Closes: #250420

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
