### PR TITLE
mcp: Tool picker names should not show mcp_{server}_ prefix

### DIFF
--- a/src/vs/workbench/contrib/mcp/common/mcpServer.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpServer.ts
@@ -708,6 +708,7 @@ function encodeCapabilities(cap: MCP.ServerCapabilities): McpCapability {
 export class McpTool implements IMcpTool {
 
 	readonly id: string;
+	readonly referenceName: string;
 
 	public get definition(): MCP.Tool { return this._definition; }
 
@@ -716,6 +717,7 @@ export class McpTool implements IMcpTool {
 		idPrefix: string,
 		private readonly _definition: IValidatedMcpTool,
 	) {
+		this.referenceName = _definition.name.replaceAll('.', '_');
 		this.id = (idPrefix + _definition.name).replaceAll('.', '_').slice(0, McpToolName.MaxLength);
 	}
 

--- a/src/vs/workbench/contrib/mcp/common/mcpService.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpService.ts
@@ -115,7 +115,7 @@ export class McpService extends Disposable implements IMcpService {
 					source,
 					icon: Codicon.tools,
 					displayName: tool.definition.annotations?.title || tool.definition.name,
-					toolReferenceName: tool.id,
+					toolReferenceName: tool.referenceName,
 					modelDescription: tool.definition.description ?? '',
 					userDescription: tool.definition.description ?? '',
 					inputSchema: tool.definition.inputSchema,

--- a/src/vs/workbench/contrib/mcp/common/mcpTypes.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpTypes.ts
@@ -345,6 +345,8 @@ export interface IMcpPromptMessage extends MCP.PromptMessage { }
 export interface IMcpTool {
 
 	readonly id: string;
+	/** Name for #referencing in chat */
+	readonly referenceName: string;
 
 	readonly definition: MCP.Tool;
 


### PR DESCRIPTION
Fixes #250021

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
