### PR TITLE
mcp: fix codelens action is not showing all prompts

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/contrib/chatInputCompletions.ts
+++ b/src/vs/workbench/contrib/chat/browser/contrib/chatInputCompletions.ts
@@ -213,7 +213,8 @@ class SlashCommandCompletions extends Disposable {
 					return null;
 				}
 
-				const range = computeCompletionRanges(model, position, /\/[\w.]*/g);
+				// regex is the opposite of `mcpPromptReplaceSpecialChars` found in `mcpTypes.ts`
+				const range = computeCompletionRanges(model, position, /\/[a-z0-9_.-]*/g);
 				if (!range) {
 					return null;
 				}


### PR DESCRIPTION
...when the server name contains dashes or underscores

Fixes #250475

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
