### PR TITLE
Improve scope handling in MCP auth providers

### DIFF
--- a/src/vs/workbench/api/common/extHostAuthentication.ts
+++ b/src/vs/workbench/api/common/extHostAuthentication.ts
@@ -300,8 +300,9 @@ export class DynamicAuthProvider implements vscode.AuthenticationProvider {
 		if (!scopes) {
 			return this._tokenStore.sessions;
 		}
-		let sessions = this._tokenStore.sessions.filter(session => session.scopes.join(' ') === scopes.join(' '));
-		this._logger.info(`Found ${sessions.length} sessions for scopes: ${scopes.join(' ')}`);
+		const scopeStr = scopes.join(' ');
+		let sessions = this._tokenStore.sessions.filter(session => session.scopes.join(' ') === scopeStr);
+		this._logger.info(`Found ${sessions.length} sessions for scopes: ${scopeStr}`);
 		if (sessions.length) {
 			const newTokens: IAuthorizationToken[] = [];
 			const removedTokens: IAuthorizationToken[] = [];
@@ -322,6 +323,10 @@ export class DynamicAuthProvider implements vscode.AuthenticationProvider {
 						}
 						try {
 							const newToken = await this.exchangeRefreshTokenForToken(token.refresh_token);
+							if (newToken.scope !== scopeStr) {
+								this._logger.warn(`Token scopes '${newToken.scope}' do not match requested scopes '${scopeStr}'. Overwriting token with what was requested...`);
+								newToken.scope = scopeStr;
+							}
 							this._logger.info(`Successfully created a new token for scopes ${session.scopes.join(' ')}.`);
 							newTokens.push(newToken);
 						} catch (err) {
@@ -335,9 +340,9 @@ export class DynamicAuthProvider implements vscode.AuthenticationProvider {
 				this._tokenStore.update({ added: newTokens, removed: removedTokens });
 				// Since we updated the tokens, we need to re-filter the sessions
 				// to get the latest state
-				sessions = this._tokenStore.sessions.filter(session => session.scopes.join(' ') === scopes.join(' '));
+				sessions = this._tokenStore.sessions.filter(session => session.scopes.join(' ') === scopeStr);
 			}
-			this._logger.info(`Found ${sessions.length} sessions for scopes: ${scopes.join(' ')}`);
+			this._logger.info(`Found ${sessions.length} sessions for scopes: ${scopeStr}`);
 			return sessions;
 		}
 		return [];
@@ -379,11 +384,15 @@ export class DynamicAuthProvider implements vscode.AuthenticationProvider {
 		if (!token) {
 			throw new Error('Failed to create authentication token');
 		}
+		if (token.scope !== scopes.join(' ')) {
+			this._logger.warn(`Token scopes '${token.scope}' do not match requested scopes '${scopes.join(' ')}'. Overwriting token with what was requested...`);
+			token.scope = scopes.join(' ');
+		}
 
 		// Store session for later retrieval
 		this._tokenStore.update({ added: [{ ...token, created_at: Date.now() }], removed: [] });
 		const session = this._tokenStore.sessions.find(t => t.accessToken === token.access_token)!;
-		this._logger.info(`Created session for scopes: ${scopes.join(' ')}`);
+		this._logger.info(`Created session for scopes: ${token.scope}`);
 		return session;
 	}
 


### PR DESCRIPTION
Basically if the scopes returned do not match what was requested, warn and overwrite.

Also, order doesn't matter so fix that in these dynamic auth providers for now (do core later)

Fixes https://github.com/microsoft/vscode/issues/250548

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
