### PR TITLE
client_name isn't actually required

### DIFF
--- a/src/vs/base/common/oauth.ts
+++ b/src/vs/base/common/oauth.ts
@@ -228,9 +228,9 @@ export interface IAuthorizationDynamicClientRegistrationResponse {
 	client_secret_expires_at?: number;
 
 	/**
-	 * REQUIRED. Client name as provided during registration.
+	 * OPTIONAL. Client name as provided during registration.
 	 */
-	client_name: string;
+	client_name?: string;
 
 	/**
 	 * OPTIONAL. Client URI as provided during registration.
@@ -579,7 +579,7 @@ export function isAuthorizationDynamicClientRegistrationResponse(obj: unknown): 
 		return false;
 	}
 	const response = obj as IAuthorizationDynamicClientRegistrationResponse;
-	return response.client_id !== undefined && response.client_name !== undefined;
+	return response.client_id !== undefined;
 }
 
 export function isAuthorizationAuthorizeResponse(obj: unknown): obj is IAuthorizationAuthorizeResponse {
@@ -596,14 +596,6 @@ export function isAuthorizationTokenResponse(obj: unknown): obj is IAuthorizatio
 	}
 	const response = obj as IAuthorizationTokenResponse;
 	return response.access_token !== undefined && response.token_type !== undefined;
-}
-
-export function isDynamicClientRegistrationResponse(obj: unknown): obj is IAuthorizationDynamicClientRegistrationResponse {
-	if (typeof obj !== 'object' || obj === null) {
-		return false;
-	}
-	const response = obj as IAuthorizationDynamicClientRegistrationResponse;
-	return response.client_id !== undefined && response.client_name !== undefined;
 }
 
 export function isAuthorizationDeviceResponse(obj: unknown): obj is IAuthorizationDeviceResponse {

--- a/src/vs/base/test/common/oauth.test.ts
+++ b/src/vs/base/test/common/oauth.test.ts
@@ -16,7 +16,6 @@ import {
 	isAuthorizationProtectedResourceMetadata,
 	isAuthorizationServerMetadata,
 	isAuthorizationTokenResponse,
-	isDynamicClientRegistrationResponse,
 	parseWWWAuthenticateHeader,
 	fetchDynamicRegistration,
 	IAuthorizationJWTClaims,
@@ -66,7 +65,7 @@ suite('OAuth', () => {
 			assert.strictEqual(isAuthorizationDynamicClientRegistrationResponse(null), false);
 			assert.strictEqual(isAuthorizationDynamicClientRegistrationResponse(undefined), false);
 			assert.strictEqual(isAuthorizationDynamicClientRegistrationResponse({}), false);
-			assert.strictEqual(isAuthorizationDynamicClientRegistrationResponse({ client_id: 'missing-name' }), false);
+			assert.strictEqual(isAuthorizationDynamicClientRegistrationResponse({ client_id: 'just-id' }), true);
 			assert.strictEqual(isAuthorizationDynamicClientRegistrationResponse({ client_name: 'missing-id' }), false);
 			assert.strictEqual(isAuthorizationDynamicClientRegistrationResponse('not an object'), false);
 		});
@@ -101,22 +100,6 @@ suite('OAuth', () => {
 			assert.strictEqual(isAuthorizationTokenResponse({ access_token: 'missing-type' }), false);
 			assert.strictEqual(isAuthorizationTokenResponse({ token_type: 'missing-token' }), false);
 			assert.strictEqual(isAuthorizationTokenResponse('not an object'), false);
-		});
-
-		test('isDynamicClientRegistrationResponse should correctly identify client registration response', () => {
-			// Valid response
-			assert.strictEqual(isDynamicClientRegistrationResponse({
-				client_id: 'client-123',
-				client_name: 'Test Client'
-			}), true);
-
-			// Invalid cases
-			assert.strictEqual(isDynamicClientRegistrationResponse(null), false);
-			assert.strictEqual(isDynamicClientRegistrationResponse(undefined), false);
-			assert.strictEqual(isDynamicClientRegistrationResponse({}), false);
-			assert.strictEqual(isDynamicClientRegistrationResponse({ client_id: 'missing-name' }), false);
-			assert.strictEqual(isDynamicClientRegistrationResponse({ client_name: 'missing-id' }), false);
-			assert.strictEqual(isDynamicClientRegistrationResponse('not an object'), false);
 		});
 
 		test('isAuthorizationDeviceResponse should correctly identify device authorization response', () => {


### PR DESCRIPTION
https://datatracker.ietf.org/doc/html/rfc7591#section-3.2

> Additionally, the authorization server MUST return all registered
metadata about this client, including any fields provisioned by the
authorization server itself.

I interpret this as... since we always include the `client_name` it should always be in the response... but this isn't true in practice.... which is fine. We aren't using this property anywhere anyway.

Fixes https://github.com/microsoft/vscode/issues/250537

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
