### PR TITLE
Tiny changes to input hover bar ('x' button) to match code block toolbar

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/media/chat.css
@@ -1932,21 +1932,21 @@ have to be updated for changes to the rules above, or to support more deeply nes
 		z-index: 10000;
 		background-color: var(--vscode-interactive-result-editor-background-color, var(--vscode-editor-background));
 		border: 1px solid var(--vscode-chat-requestBorder);
-		top: -8px;
+		top: -13px;
 		right: 20px;
 		border-radius: 3px;
 	}
 
 	.request-hover .actions-container {
-		width: 24px;
-		height: 24px;
+		width: 26px;
+		height: 26px;
 	}
 
 	.request-hover .actions-container .action-label.codicon-x {
-		width: 24px;
-		height: 24px;
+		width: 26px;
+		height: 26px;
 		padding-top: 4px;
-		padding-left: 4px;
+		padding-left: 5px;
 	}
 
 	.request-hover.has-no-actions {
@@ -1959,11 +1959,11 @@ have to be updated for changes to the rules above, or to support more deeply nes
 
 	div[data-index="0"] .monaco-tl-contents {
 		.interactive-item-container.interactive-request {
-			padding-top: 15px;
+			padding-top: 19px;
 		}
 
 		.request-hover {
-			top: 2px;
+			top: 0px;
 		}
 	}
 


### PR DESCRIPTION
Addressing [feedback from Rob (#250219)](https://github.com/microsoft/vscode/issues/250219) that the 'x' button on hover looks inconsistent with the code block toolbar. 

Here's what I updated to help with the styling: 
- Container to be 26x26 instead of 24x24
- Moved up the placement to -13px to be centered on the top border of the prompt
- Adjusted the padding for the first input to make sure there's enough room

Demo:
https://github.com/user-attachments/assets/3dd3c082-1793-4b39-acac-c861d8fd49b6


