### PR TITLE
Don't show title in custom title bar if shown in native title bar

### DIFF
--- a/src/vs/workbench/browser/parts/titlebar/titlebarPart.ts
+++ b/src/vs/workbench/browser/parts/titlebar/titlebarPart.ts
@@ -556,15 +556,19 @@ export class BrowserTitlebarPart extends Part implements ITitlebarPart {
 	private createTitle(): void {
 		this.titleDisposables.clear();
 
+		const isShowingTitleInNativeTitlebar = hasNativeTitlebar(this.configurationService, this.titleBarStyle);
+
 		// Text Title
 		if (!this.isCommandCenterVisible) {
-			this.title.innerText = this.windowTitle.value;
-			this.titleDisposables.add(this.windowTitle.onDidChange(() => {
+			if (!isShowingTitleInNativeTitlebar) {
 				this.title.innerText = this.windowTitle.value;
-				if (this.lastLayoutDimensions) {
-					this.updateLayout(this.lastLayoutDimensions); // layout menubar and other renderings in the titlebar
-				}
-			}));
+				this.titleDisposables.add(this.windowTitle.onDidChange(() => {
+					this.title.innerText = this.windowTitle.value;
+					if (this.lastLayoutDimensions) {
+						this.updateLayout(this.lastLayoutDimensions); // layout menubar and other renderings in the titlebar
+					}
+				}));
+			}
 		}
 
 		// Menu Title


### PR DESCRIPTION
```Copilot Generated Description:``` Prevent the title from displaying in the custom title bar when it is already shown in the native title bar.

closes https://github.com/microsoft/vscode/issues/249746