### PR TITLE
Improve gutter menu rendering when no line numbers

### DIFF
--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/components/gutterIndicatorView.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/components/gutterIndicatorView.ts
@@ -240,7 +240,14 @@ export class InlineEditsGutterIndicator extends Disposable {
 
 			if (pillIsFullyDocked) {
 				const pillRect = pillFullyDockedRect;
-				const lineNumberWidth = Math.max(layout.lineNumbersLeft + layout.lineNumbersWidth - gutterViewPortWithStickyScroll.left, 0);
+
+				let lineNumberWidth;
+				if (layout.lineNumbersWidth === 0) {
+					lineNumberWidth = Math.min(Math.max(layout.lineNumbersLeft - gutterViewPortWithStickyScroll.left, 0), pillRect.width - idealIconWidth);
+				} else {
+					lineNumberWidth = Math.max(layout.lineNumbersLeft + layout.lineNumbersWidth - gutterViewPortWithStickyScroll.left, 0);
+				}
+
 				const lineNumberRect = pillRect.withWidth(lineNumberWidth);
 				const iconWidth = Math.max(Math.min(layout.decorationsWidth, idealIconWidth), minimalIconWidth);
 				const iconRect = pillRect.withWidth(iconWidth).translateX(lineNumberWidth);


### PR DESCRIPTION
```Copilot Generated Description:``` Enhance the rendering of the gutter menu to handle cases where line numbers are not present. Adjustments ensure proper width calculations for the gutter elements.

closes https://github.com/microsoft/vscode-copilot/issues/17983