### PR TITLE
only apply graceful kill setting to linux/macOS

### DIFF
--- a/src/vs/platform/terminal/node/terminalProcess.ts
+++ b/src/vs/platform/terminal/node/terminalProcess.ts
@@ -377,8 +377,7 @@ export class TerminalProcess extends Disposable implements ITerminalChildProcess
 			if (this._ptyProcess) {
 				await this._throttleKillSpawn();
 				this._logService.trace('node-pty.IPty#kill');
-				// For windows, we already attempt to gracefully kill the process
-				if (!isWindows && this.shellLaunchConfig.killGracefully) {
+				if (this.shellLaunchConfig.killGracefully) {
 					this._killGracefully(this._ptyProcess);
 				} else {
 					this._ptyProcess.kill();

--- a/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
@@ -567,7 +567,8 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 				this._setAriaLabel(this.xterm?.raw, this._instanceId, this.title);
 			}
 			if (e.affectsConfiguration(TerminalSettingId.KillGracefully)) {
-				this.shellLaunchConfig.killGracefully = this._configurationService.getValue(TerminalSettingId.KillGracefully);
+				// For windows, we already attempt to gracefully kill the process
+				this.shellLaunchConfig.killGracefully = !isWindows && this._configurationService.getValue(TerminalSettingId.KillGracefully);
 			}
 			if (e.affectsConfiguration('terminal.integrated')) {
 				this.updateConfig();
@@ -1509,7 +1510,8 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 				message: nls.localize('workspaceNotTrustedCreateTerminalCwd', "Cannot launch a terminal process in an untrusted workspace with cwd {0} and userHome {1}", this._cwd, this._userHome)
 			});
 		}
-		this.shellLaunchConfig.killGracefully = this._configurationService.getValue(TerminalSettingId.KillGracefully);
+		// For windows, we already attempt to gracefully kill the process
+		this.shellLaunchConfig.killGracefully = !isWindows && this._configurationService.getValue(TerminalSettingId.KillGracefully);
 		// Re-evaluate dimensions if the container has been set since the xterm instance was created
 		if (this._container && this._cols === 0 && this._rows === 0) {
 			this._initDimensions();

--- a/src/vs/workbench/contrib/terminal/common/terminalConfiguration.ts
+++ b/src/vs/workbench/contrib/terminal/common/terminalConfiguration.ts
@@ -645,7 +645,7 @@ const terminalConfiguration: IConfigurationNode = {
 			default: false,
 			markdownDescription: localize(
 				'terminal.integrated.killGracefully',
-				'Controls how terminal processes are terminated. When enabled, attempts a graceful shutdown of the process tree. On POSIX, this will send \`SIGTERM\`. On Windows, it uses \`taskkill.exe\` without the \`/F\` (force) flag. Note that this may allow misbehaving processes to remain running. When disabled (default), processes are terminated with: \`SIGHUP\`.'
+				'Controls how terminal processes are terminated on macOS and Linux. When enabled, attempts a graceful shutdown of the process tree. This will send \`SIGTERM\`. When disabled (default), processes are terminated with: \`SIGHUP\`.'
 			),
 		},
 		...terminalContribConfiguration,


### PR DESCRIPTION
fix #250523

Testing revealed that graceful shutdown already happens for Windows.