### PR TITLE
commands: fix for startup command in vscode.dev/edu route

### DIFF
--- a/src/vs/base/common/async.ts
+++ b/src/vs/base/common/async.ts
@@ -117,6 +117,17 @@ export function raceCancellationError<T>(promise: Promise<T>, token: Cancellatio
 }
 
 /**
+ * Wraps a cancellable promise such that it is no cancellable. Can be used to
+ * avoid issues with shared promises that would normally be returned as
+ * cancellable to consumers.
+ */
+export function notCancellablePromise<T>(promise: CancelablePromise<T>): Promise<T> {
+	return new Promise<T>((resolve, reject) => {
+		promise.then(resolve, reject);
+	});
+}
+
+/**
  * Returns as soon as one of the promises resolves or rejects and cancels remaining promises
  */
 export function raceCancellablePromises<T>(cancellablePromises: (CancelablePromise<T> | Promise<T>)[]): CancelablePromise<T> {

--- a/src/vs/workbench/services/commands/common/commandService.ts
+++ b/src/vs/workbench/services/commands/common/commandService.ts
@@ -37,14 +37,15 @@ export class CommandService extends Disposable implements ICommandService {
 
 	private _activateStar(): Promise<void> {
 		if (!this._starActivation) {
-			// wait for * activation, limited to at most 30s. This is wrapped with
-			// notCancellablePromise so it doesn't get cancelled early because it is
-			// shared between consumers.
+			// wait for * activation, limited to at most 30s.
 			this._starActivation = raceCancellablePromises([
 				this._extensionService.activateByEvent(`*`),
 				timeout(30000)
 			]);
 		}
+
+		// This is wrapped with notCancellablePromise so it doesn't get cancelled
+		// early because it is shared between consumers.
 		return notCancellablePromise(this._starActivation);
 	}
 

--- a/src/vs/workbench/services/commands/common/commandService.ts
+++ b/src/vs/workbench/services/commands/common/commandService.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { raceCancellablePromises, timeout } from '../../../../base/common/async.js';
+import { CancelablePromise, notCancellablePromise, raceCancellablePromises, timeout } from '../../../../base/common/async.js';
 import { Emitter, Event } from '../../../../base/common/event.js';
 import { Disposable } from '../../../../base/common/lifecycle.js';
 import { CommandsRegistry, ICommandEvent, ICommandService } from '../../../../platform/commands/common/commands.js';
@@ -17,7 +17,7 @@ export class CommandService extends Disposable implements ICommandService {
 	declare readonly _serviceBrand: undefined;
 
 	private _extensionHostIsReady: boolean = false;
-	private _starActivation: Promise<void> | null;
+	private _starActivation: CancelablePromise<void> | null;
 
 	private readonly _onWillExecuteCommand: Emitter<ICommandEvent> = this._register(new Emitter<ICommandEvent>());
 	public readonly onWillExecuteCommand: Event<ICommandEvent> = this._onWillExecuteCommand.event;
@@ -38,14 +38,14 @@ export class CommandService extends Disposable implements ICommandService {
 	private _activateStar(): Promise<void> {
 		if (!this._starActivation) {
 			// wait for * activation, limited to at most 30s. This is wrapped with
-			// Promise.resolve() so it doesn't get cancelled early because it is
+			// notCancellablePromise so it doesn't get cancelled early because it is
 			// shared between consumers.
-			this._starActivation = Promise.resolve(raceCancellablePromises([
+			this._starActivation = raceCancellablePromises([
 				this._extensionService.activateByEvent(`*`),
 				timeout(30000)
-			]));
+			]);
 		}
-		return this._starActivation;
+		return notCancellablePromise(this._starActivation);
 	}
 
 	async executeCommand<T>(id: string, ...args: any[]): Promise<T> {
@@ -101,6 +101,11 @@ export class CommandService extends Disposable implements ICommandService {
 		} catch (err) {
 			return Promise.reject(err);
 		}
+	}
+
+	public override dispose(): void {
+		super.dispose();
+		this._starActivation?.cancel();
 	}
 }
 


### PR DESCRIPTION
Closes https://github.com/microsoft/vscode-dev/issues/1290 properly.
I didn't realize that, if given a promise, `Promise.resolve` just
returns that same promise, so my attempt to hide the `cancel` method
didn't work.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
