### PR TITLE
Fix duplication of IDs in ADMX/ADML Group Policy

### DIFF
--- a/build/lib/policies.js
+++ b/build/lib/policies.js
@@ -44,7 +44,7 @@ function renderADMLString(prefix, moduleName, nlsString, translations) {
     if (!value) {
         value = nlsString.value;
     }
-    return `<string id="${prefix}_${nlsString.nlsKey.replace(/\./g, '_')}">${value}</string>`;
+    return `<string id="${moduleName.replace(/[\.\/]/g, '_')}_${prefix}_${nlsString.nlsKey.replace(/\./g, '_')}">${value}</string>`;
 }
 function renderProfileString(_prefix, moduleName, nlsString, translations) {
     let value;
@@ -79,8 +79,8 @@ class BasePolicy {
     }
     renderADMX(regKey) {
         return [
-            `<policy name="${this.name}" class="Both" displayName="$(string.${this.name})" explainText="$(string.${this.name}_${this.description.nlsKey.replace(/\./g, '_')})" key="Software\\Policies\\Microsoft\\${regKey}" presentation="$(presentation.${this.name})">`,
-            `	<parentCategory ref="${this.category.name.nlsKey}" />`,
+            `<policy name="${this.moduleName.replace(/[\.\/]/g, '_')}_${this.name}" class="Both" displayName="$(string.${this.moduleName.replace(/[\.\/]/g, '_')}_${this.name})" explainText="$(string.${this.moduleName.replace(/[\.\/]/g, '_')}_${this.name}_${this.description.nlsKey.replace(/\./g, '_')})" key="Software\/Policies\/Microsoft\/${regKey}" presentation="$(presentation.${this.moduleName.replace(/[\.\/]/g, '_')}_${this.name})">`,
+            `	<parentCategory ref="${this.moduleName.replace(/[\.\/]/g, '_')}_${this.category.name.nlsKey}" />`,
             `	<supportedOn ref="Supported_${this.minimumVersion.replace(/\./g, '_')}" />`,
             `	<elements>`,
             ...this.renderADMXElements(),
@@ -90,12 +90,12 @@ class BasePolicy {
     }
     renderADMLStrings(translations) {
         return [
-            `<string id="${this.name}">${this.name}</string>`,
+            `<string id="${this.moduleName.replace(/[\.\/]/g, '_')}_${this.name}">${this.name}</string>`,
             this.renderADMLString(this.description, translations)
         ];
     }
     renderADMLPresentation() {
-        return `<presentation id="${this.name}">${this.renderADMLPresentationContents()}</presentation>`;
+        return `<presentation id="${this.moduleName.replace(/[\.\/]/g, '_')}_${this.name}">${this.renderADMLPresentationContents()}</presentation>`;
     }
     renderProfile() {
         return [`<key>${this.name}</key>`, this.renderProfileValue()];
@@ -119,13 +119,13 @@ class BooleanPolicy extends BasePolicy {
     }
     renderADMXElements() {
         return [
-            `<boolean id="${this.name}" valueName="${this.name}">`,
+            `<boolean id="${this.moduleName.replace(/[\.\/]/g, '_')}_${this.name}" valueName="${this.name}">`,
             `	<trueValue><decimal value="1" /></trueValue><falseValue><decimal value="0" /></falseValue>`,
             `</boolean>`
         ];
     }
     renderADMLPresentationContents() {
-        return `<checkBox refId="${this.name}">${this.name}</checkBox>`;
+        return `<checkBox refId="${this.moduleName.replace(/[\.\/]/g, '_')}_${this.name}">${this.name}</checkBox>`;
     }
     renderProfileValue() {
         return `<false/>`;
@@ -167,12 +167,12 @@ class NumberPolicy extends BasePolicy {
     }
     renderADMXElements() {
         return [
-            `<decimal id="${this.name}" valueName="${this.name}" />`
+            `<decimal id="${this.moduleName.replace(/[\.\/]/g, '_')}_${this.name}" valueName="${this.name}" />`
             // `<decimal id="Quarantine_PurgeItemsAfterDelay" valueName="PurgeItemsAfterDelay" minValue="0" maxValue="10000000" />`
         ];
     }
     renderADMLPresentationContents() {
-        return `<decimalTextBox refId="${this.name}" defaultValue="${this.defaultValue}">${this.name}</decimalTextBox>`;
+        return `<decimalTextBox refId="${this.moduleName.replace(/[\.\/]/g, '_')}_${this.name}" defaultValue="${this.defaultValue}">${this.name}</decimalTextBox>`;
     }
     renderProfileValue() {
         return `<integer>${this.defaultValue}</integer>`;
@@ -202,10 +202,10 @@ class StringPolicy extends BasePolicy {
         super(PolicyType.String, name, category, minimumVersion, description, moduleName);
     }
     renderADMXElements() {
-        return [`<text id="${this.name}" valueName="${this.name}" required="true" />`];
+        return [`<text id="${this.moduleName.replace(/[\.\/]/g, '_')}_${this.name}" valueName="${this.name}" required="true" />`];
     }
     renderADMLPresentationContents() {
-        return `<textBox refId="${this.name}"><label>${this.name}:</label></textBox>`;
+        return `<textBox refId="${this.moduleName.replace(/[\.\/]/g, '_')}_${this.name}"><label>${this.name}:</label></textBox>`;
     }
     renderProfileValue() {
         return `<string></string>`;
@@ -235,10 +235,10 @@ class ObjectPolicy extends BasePolicy {
         super(PolicyType.Object, name, category, minimumVersion, description, moduleName);
     }
     renderADMXElements() {
-        return [`<multiText id="${this.name}" valueName="${this.name}" required="true" />`];
+        return [`<multiText id="${this.moduleName.replace(/[\.\/]/g, '_')}_${this.name}" valueName="${this.name}" required="true" />`];
     }
     renderADMLPresentationContents() {
-        return `<multiTextBox refId="${this.name}" />`;
+        return `<multiTextBox refId="${this.moduleName.replace(/[\.\/]/g, '_')}_${this.name}" />`;
     }
     renderProfileValue() {
         return `<string></string>`;
@@ -288,8 +288,8 @@ class StringEnumPolicy extends BasePolicy {
     }
     renderADMXElements() {
         return [
-            `<enum id="${this.name}" valueName="${this.name}">`,
-            ...this.enum_.map((value, index) => `	<item displayName="$(string.${this.name}_${this.enumDescriptions[index].nlsKey})"><value><string>${value}</string></value></item>`),
+            `<enum id="${this.moduleName.replace(/[\.\/]/g, '_')}_${this.name}" valueName="${this.name}">`,
+            ...this.enum_.map((value, index) => `	<item displayName="$(string.${this.moduleName.replace(/[\.\/]/g, '_')}_${this.name}_${this.enumDescriptions[index].nlsKey})"><value><string>${value}</string></value></item>`),
             `</enum>`
         ];
     }
@@ -300,7 +300,7 @@ class StringEnumPolicy extends BasePolicy {
         ];
     }
     renderADMLPresentationContents() {
-        return `<dropdownList refId="${this.name}" />`;
+        return `<dropdownList refId="${this.moduleName.replace(/[\.\/]/g, '_')}_${this.name}" />`;
     }
     renderProfileValue() {
         return `<string>${this.enum_[0]}</string>`;
@@ -509,7 +509,7 @@ function renderADMX(regKey, versions, categories, policies) {
 	</supportedOn>
 	<categories>
 		<category displayName="$(string.Application)" name="Application" />
-		${categories.map(c => `<category displayName="$(string.Category_${c.name.nlsKey})" name="${c.name.nlsKey}"><parentCategory ref="Application" /></category>`).join(`\n		`)}
+		${categories.map(c => `<category displayName="$(string.${c.moduleName.replace(/[\.\/]/g, '_')}_Category_${c.name.nlsKey})" name="${c.moduleName.replace(/[\.\/]/g, '_')}_${c.name.nlsKey}"><parentCategory ref="Application" /></category>`).join(`\n		`)}
 	</categories>
 	<policies>
 		${policies.map(p => p.renderADMX(regKey)).flat().join(`\n		`)}

--- a/build/lib/policies.ts
+++ b/build/lib/policies.ts
@@ -68,7 +68,7 @@ function renderADMLString(prefix: string, moduleName: string, nlsString: NlsStri
 		value = nlsString.value;
 	}
 
-	return `<string id="${prefix}_${nlsString.nlsKey.replace(/\./g, '_')}">${value}</string>`;
+	return `<string id="${moduleName.replace(/[\.\/]/g, '_')}_${prefix}_${nlsString.nlsKey.replace(/\./g, '_')}">${value}</string>`;
 }
 
 function renderProfileString(_prefix: string, moduleName: string, nlsString: NlsString, translations?: LanguageTranslations): string {
@@ -105,8 +105,8 @@ abstract class BasePolicy implements Policy {
 
 	renderADMX(regKey: string) {
 		return [
-			`<policy name="${this.name}" class="Both" displayName="$(string.${this.name})" explainText="$(string.${this.name}_${this.description.nlsKey.replace(/\./g, '_')})" key="Software\\Policies\\Microsoft\\${regKey}" presentation="$(presentation.${this.name})">`,
-			`	<parentCategory ref="${this.category.name.nlsKey}" />`,
+			`<policy name="${this.moduleName.replace(/[\.\/]/g, '_')}_${this.name}" class="Both" displayName="$(string.${this.moduleName.replace(/[\.\/]/g, '_')}_${this.name})" explainText="$(string.${this.moduleName.replace(/[\.\/]/g, '_')}_${this.name}_${this.description.nlsKey.replace(/\./g, '_')})" key="Software\/Policies\/Microsoft\/${regKey}" presentation="$(presentation.${this.moduleName.replace(/[\.\/]/g, '_')}_${this.name})">`,
+			`	<parentCategory ref="${this.moduleName.replace(/[\.\/]/g, '_')}_${this.category.name.nlsKey}" />`,
 			`	<supportedOn ref="Supported_${this.minimumVersion.replace(/\./g, '_')}" />`,
 			`	<elements>`,
 			...this.renderADMXElements(),
@@ -119,13 +119,13 @@ abstract class BasePolicy implements Policy {
 
 	renderADMLStrings(translations?: LanguageTranslations) {
 		return [
-			`<string id="${this.name}">${this.name}</string>`,
+			`<string id="${this.moduleName.replace(/[\.\/]/g, '_')}_${this.name}">${this.name}</string>`,
 			this.renderADMLString(this.description, translations)
 		];
 	}
 
 	renderADMLPresentation(): string {
-		return `<presentation id="${this.name}">${this.renderADMLPresentationContents()}</presentation>`;
+		return `<presentation id="${this.moduleName.replace(/[\.\/]/g, '_')}_${this.name}">${this.renderADMLPresentationContents()}</presentation>`;
 	}
 
 	protected abstract renderADMLPresentationContents(): string;
@@ -175,14 +175,14 @@ class BooleanPolicy extends BasePolicy {
 
 	protected renderADMXElements(): string[] {
 		return [
-			`<boolean id="${this.name}" valueName="${this.name}">`,
+			`<boolean id="${this.moduleName.replace(/[\.\/]/g, '_')}_${this.name}" valueName="${this.name}">`,
 			`	<trueValue><decimal value="1" /></trueValue><falseValue><decimal value="0" /></falseValue>`,
 			`</boolean>`
 		];
 	}
 
 	renderADMLPresentationContents() {
-		return `<checkBox refId="${this.name}">${this.name}</checkBox>`;
+		return `<checkBox refId="${this.moduleName.replace(/[\.\/]/g, '_')}_${this.name}">${this.name}</checkBox>`;
 	}
 
 	renderProfileValue(): string {
@@ -247,13 +247,13 @@ class NumberPolicy extends BasePolicy {
 
 	protected renderADMXElements(): string[] {
 		return [
-			`<decimal id="${this.name}" valueName="${this.name}" />`
+			`<decimal id="${this.moduleName.replace(/[\.\/]/g, '_')}_${this.name}" valueName="${this.name}" />`
 			// `<decimal id="Quarantine_PurgeItemsAfterDelay" valueName="PurgeItemsAfterDelay" minValue="0" maxValue="10000000" />`
 		];
 	}
 
 	renderADMLPresentationContents() {
-		return `<decimalTextBox refId="${this.name}" defaultValue="${this.defaultValue}">${this.name}</decimalTextBox>`;
+		return `<decimalTextBox refId="${this.moduleName.replace(/[\.\/]/g, '_')}_${this.name}" defaultValue="${this.defaultValue}">${this.name}</decimalTextBox>`;
 	}
 
 	renderProfileValue() {
@@ -304,11 +304,11 @@ class StringPolicy extends BasePolicy {
 	}
 
 	protected renderADMXElements(): string[] {
-		return [`<text id="${this.name}" valueName="${this.name}" required="true" />`];
+		return [`<text id="${this.moduleName.replace(/[\.\/]/g, '_')}_${this.name}" valueName="${this.name}" required="true" />`];
 	}
 
 	renderADMLPresentationContents() {
-		return `<textBox refId="${this.name}"><label>${this.name}:</label></textBox>`;
+		return `<textBox refId="${this.moduleName.replace(/[\.\/]/g, '_')}_${this.name}"><label>${this.name}:</label></textBox>`;
 	}
 
 	renderProfileValue(): string {
@@ -359,11 +359,11 @@ class ObjectPolicy extends BasePolicy {
 	}
 
 	protected renderADMXElements(): string[] {
-		return [`<multiText id="${this.name}" valueName="${this.name}" required="true" />`];
+		return [`<multiText id="${this.moduleName.replace(/[\.\/]/g, '_')}_${this.name}" valueName="${this.name}" required="true" />`];
 	}
 
 	renderADMLPresentationContents() {
-		return `<multiTextBox refId="${this.name}" />`;
+		return `<multiTextBox refId="${this.moduleName.replace(/[\.\/]/g, '_')}_${this.name}" />`;
 	}
 
 	renderProfileValue(): string {
@@ -436,8 +436,8 @@ class StringEnumPolicy extends BasePolicy {
 
 	protected renderADMXElements(): string[] {
 		return [
-			`<enum id="${this.name}" valueName="${this.name}">`,
-			...this.enum_.map((value, index) => `	<item displayName="$(string.${this.name}_${this.enumDescriptions[index].nlsKey})"><value><string>${value}</string></value></item>`),
+			`<enum id="${this.moduleName.replace(/[\.\/]/g, '_')}_${this.name}" valueName="${this.name}">`,
+			...this.enum_.map((value, index) => `	<item displayName="$(string.${this.moduleName.replace(/[\.\/]/g, '_')}_${this.name}_${this.enumDescriptions[index].nlsKey})"><value><string>${value}</string></value></item>`),
 			`</enum>`
 		];
 	}
@@ -450,7 +450,7 @@ class StringEnumPolicy extends BasePolicy {
 	}
 
 	renderADMLPresentationContents() {
-		return `<dropdownList refId="${this.name}" />`;
+		return `<dropdownList refId="${this.moduleName.replace(/[\.\/]/g, '_')}_${this.name}" />`;
 	}
 
 	renderProfileValue() {
@@ -711,7 +711,7 @@ function renderADMX(regKey: string, versions: string[], categories: Category[], 
 	</supportedOn>
 	<categories>
 		<category displayName="$(string.Application)" name="Application" />
-		${categories.map(c => `<category displayName="$(string.Category_${c.name.nlsKey})" name="${c.name.nlsKey}"><parentCategory ref="Application" /></category>`).join(`\n		`)}
+		${categories.map(c => `<category displayName="$(string.${c.moduleName.replace(/[\.\/]/g, '_')}_Category_${c.name.nlsKey})" name="${c.moduleName.replace(/[\.\/]/g, '_')}_${c.name.nlsKey}"><parentCategory ref="Application" /></category>`).join(`\n		`)}
 	</categories>
 	<policies>
 		${policies.map(p => p.renderADMX(regKey)).flat().join(`\n		`)}


### PR DESCRIPTION
The current generation of Group Policy ADMX/ADML files does not deduplicate IDs which come from different modules. As a result, when loading these definitions, the Group Policy Editor throws an error and doesn't load the templates:
![image](https://github.com/user-attachments/assets/6a507f8d-8884-499a-9cfc-e7d4428c30e9)

The cause of this issue is that extensionsConfigurationTitle is registered by two different modules when the policy is generated, and they are then created in the XML with conflicting IDs.

This affects both Microsoft VSCode and VSCode OSS.

After applying this change, the files generated load correctly into Group Policy editor.
![image](https://github.com/user-attachments/assets/38ec4a8c-d4f8-4041-a486-1a5c6b96e503)

Because of the original issue of duplicated keys, the Extensions category does appear twice in this solution. It would be possible to deduplicate if the nlsString and the category name are the same, but I didn't want to necessarily assume that would always be true for all languages, assuming it's true in English, as these are separate translation items.
Group Policy is perfectly happy to have categories etc. with the same display name, but like all XML, gets upset if IDs are duplicated.

At the risk of going on a tangent, the way that the policy files are being generated in policy.ts look to be unstable - with string substitutions being used to generate XML. Should a new policy be introduced with any special characters, it would likely break these policy files. It may be worth looking at rebuilding this to either manipulate DOM or appropriately escape the substitutions.

I wasn't able to find any appropriate tests against this generation process (and I'm not familiar with Node so no idea how to go about creating some), but if there exist any, I'm happy to add tests in relation to these errors.