### PR TITLE
When revealing/navigation hunks, reveal the line one above so that the deleted-view-zone and its hunk actions are fully visible

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingCodeEditorIntegration.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingCodeEditorIntegration.ts
@@ -552,7 +552,7 @@ export class ChatEditingCodeEditorIntegration implements IModifiedFileEntryEdito
 		const targetRange = decorations[newIndex];
 		const targetPosition = next ? targetRange.getStartPosition() : targetRange.getEndPosition();
 		this._editor.setPosition(targetPosition);
-		this._editor.revealPositionInCenter(targetPosition);
+		this._editor.revealPositionInCenter(targetRange.getStartPosition().delta(-1));
 		this._editor.focus();
 
 		return true;


### PR DESCRIPTION
fixes https://github.com/microsoft/vscode/issues/247374