### PR TITLE
Fix #250737,  Match count result overflow in Notebook findWidget

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/contrib/find/notebookFindWidget.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/find/notebookFindWidget.ts
@@ -364,7 +364,7 @@ class NotebookFindWidget extends SimpleFindReplaceWidget implements INotebookEdi
 			return;
 		}
 
-		this._matchesCount.style.width = MAX_MATCHES_COUNT_WIDTH + 'px';
+		this._matchesCount.style.minWidth = MAX_MATCHES_COUNT_WIDTH + 'px';
 		this._matchesCount.title = '';
 
 		// remove previous content


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
Before fix:
![image](https://github.com/user-attachments/assets/1d340023-9bf4-4a12-b7e6-246343e43fe1)

After fix:
![image](https://github.com/user-attachments/assets/eff1a7a3-dbea-4f26-be9c-7448962114b2)

I saw that the `minWidth` here was modified in this https://github.com/microsoft/vscode/issues/147398 . Now after revising back to the `minWidth`, it seems that there won't be any problems now either.