### PR TITLE
Add restructuredtext support in markdown code block

### DIFF
--- a/extensions/markdown-basics/package.json
+++ b/extensions/markdown-basics/package.json
@@ -75,6 +75,7 @@
           "meta.embedded.block.perl6": "perl6",
           "meta.embedded.block.powershell": "powershell",
           "meta.embedded.block.python": "python",
+          "meta.embedded.block.restructuredtext": "restructuredtext",
           "meta.embedded.block.rust": "rust",
           "meta.embedded.block.scala": "scala",
           "meta.embedded.block.shellscript": "shellscript",

--- a/extensions/markdown-basics/syntaxes/markdown.tmLanguage.json
+++ b/extensions/markdown-basics/syntaxes/markdown.tmLanguage.json
@@ -1388,6 +1388,39 @@
 				}
 			]
 		},
+		"fenced_code_block_restructuredtext": {
+			"begin": "(^|\\G)(\\s*)(`{3,}|~{3,})\\s*(?i:(restructuredtext|rst)((\\s+|:|,|\\{|\\?)[^`]*)?$)",
+			"name": "markup.fenced_code.block.markdown",
+			"end": "(^|\\G)(\\2|\\s{0,3})(\\3)\\s*$",
+			"beginCaptures": {
+				"3": {
+					"name": "punctuation.definition.markdown"
+				},
+				"4": {
+					"name": "fenced_code.block.language.markdown"
+				},
+				"5": {
+					"name": "fenced_code.block.language.attributes.markdown"
+				}
+			},
+			"endCaptures": {
+				"3": {
+					"name": "punctuation.definition.markdown"
+				}
+			},
+			"patterns": [
+				{
+					"begin": "(^|\\G)(\\s*)(.*)",
+					"while": "(^|\\G)(?!\\s*([`~]{3,})\\s*$)",
+					"contentName": "meta.embedded.block.restructuredtext",
+					"patterns": [
+						{
+							"include": "source.rst"
+						}
+					]
+				}
+			]
+		},
 		"fenced_code_block_rust": {
 			"begin": "(^|\\G)(\\s*)(`{3,}|~{3,})\\s*(?i:(rust|rs|\\{\\.rust.+?\\})((\\s+|:|,|\\{|\\?)[^`]*)?$)",
 			"name": "markup.fenced_code.block.markdown",
@@ -2037,6 +2070,9 @@
 				},
 				{
 					"include": "#fenced_code_block_regexp_python"
+				},
+				{
+					"include": "#fenced_code_block_restructuredtext"
 				},
 				{
 					"include": "#fenced_code_block_rust"


### PR DESCRIPTION
https://github.com/microsoft/vscode/pull/144680 added built-in support for `reStructuredText` grammar. This MR extends the usage for within markdown code block by using either `restructuredtext` or `rst`.

Demo from the MR build:

![image](https://github.com/user-attachments/assets/71a14c4e-10cd-4e89-b2f0-ee6680fb6ac8)
