### PR TITLE
Fixes #242059

### DIFF
--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChatCurrentLine.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChatCurrentLine.ts
@@ -38,7 +38,6 @@ import { PLAINTEXT_LANGUAGE_ID } from '../../../../editor/common/languages/modes
 import { createStyleSheet2 } from '../../../../base/browser/domStylesheets.js';
 import { stringValue } from '../../../../base/browser/cssValue.js';
 import { observableConfigValue } from '../../../../platform/observable/common/platformObservableUtils.js';
-import { Emitter } from '../../../../base/common/event.js';
 import { ChatAgentLocation } from '../../chat/common/constants.js';
 import { INSTRUCTIONS_LANGUAGE_ID, PROMPT_LANGUAGE_ID } from '../../chat/common/promptSyntax/constants.js';
 import { MODE_FILE_EXTENSION } from '../../../../platform/prompts/common/prompts.js';
@@ -242,7 +241,7 @@ export class InlineChatHintsController extends Disposable implements IEditorCont
 			const ghostState = ghostCtrl?.model.read(r)?.state.read(r);
 
 			const textFocus = editorObs.isTextFocused.read(r);
-			let position = editorObs.cursorPosition.read(r);
+			const position = editorObs.cursorPosition.read(r);
 			const model = editorObs.model.read(r);
 
 			const kb = keyObs.read(r);
@@ -255,14 +254,7 @@ export class InlineChatHintsController extends Disposable implements IEditorCont
 				return undefined;
 			}
 
-			// DEBT - I cannot use `model.onDidChangeContent` directly here
-			// https://github.com/microsoft/vscode/issues/242059
-			const emitter = r.store.add(new Emitter<void>());
-			r.store.add(model.onDidChangeContent(() => emitter.fire()));
-			observableFromEvent(emitter.event, () => model.getVersionId()).read(r);
-
-			// position can be wrong
-			position = model.validatePosition(position);
+			editorObs.versionId.read(r);
 
 			const visible = this._visibilityObs.read(r);
 			const isEol = model.getLineMaxColumn(position.lineNumber) === position.column;


### PR DESCRIPTION
Fixes #242059 FYI @jrieken

The position cannot be wrong now anymore, as only "well behaving" observables are read. "Well behaving" observables ensure that dependencies always see globally consistent state.

The observableFromEvent was not well-behaving, as the text model change event fires (immediately triggering reactions) before other objects can update their data. This could cause the autorun to see inconsistent state.

`editorObs.versionId` uses editor transactions to avoid this problem.