### PR TITLE
read clipboard in the last keyboard event for safari

### DIFF
--- a/src/vs/workbench/services/clipboard/browser/clipboardService.ts
+++ b/src/vs/workbench/services/clipboard/browser/clipboardService.ts
@@ -15,6 +15,10 @@ import { IWorkbenchEnvironmentService } from '../../environment/common/environme
 import { ILogService } from '../../../../platform/log/common/log.js';
 import { ILayoutService } from '../../../../platform/layout/browser/layoutService.js';
 import { getActiveWindow } from '../../../../base/browser/dom.js';
+import { isSafari } from '../../../../base/browser/browser.js';
+import { promiseWithResolvers, timeout } from '../../../../base/common/async.js';
+
+const READ_TEXT_FROM_SAFARI_CLIPBOARD_TIMEOUT = 200;
 
 export class BrowserClipboardService extends BaseBrowserClipboardService {
 
@@ -26,6 +30,11 @@ export class BrowserClipboardService extends BaseBrowserClipboardService {
 		@ILayoutService layoutService: ILayoutService
 	) {
 		super(layoutService, logService);
+		if (isSafari) {
+			// Webkit browsers (Safari) require a user gesture to read from the clipboard.
+			// https://webkit.org/blog/10855/async-clipboard-api/
+			window.addEventListener('keydown', () => this.resolveReadTextPromise())
+		}
 	}
 
 	override async writeText(text: string, type?: string): Promise<void> {
@@ -34,6 +43,36 @@ export class BrowserClipboardService extends BaseBrowserClipboardService {
 		}
 
 		return super.writeText(text, type);
+	}
+
+	private async resolveReadTextPromise() {
+		// try to wait readText request for 3 times with 20ms timeout each
+		for (let i = 0; i < 3; i++) {
+			await timeout(20);
+			const reader = this.readTextPromise
+			this.readTextPromise = undefined
+			if (reader) {
+				const text = await getActiveWindow().navigator.clipboard.readText()
+				reader.resolve(text);
+				return
+			}
+		}
+	}
+
+	private readTextPromise?: ReturnType<typeof promiseWithResolvers<string | undefined>>
+
+	private async readTextByLastUserEvent(): Promise<string | undefined> {
+		if (!this.readTextPromise) {
+			const resolvers = promiseWithResolvers<string | undefined>();
+			const timer = setTimeout(() => resolvers.resolve(undefined), READ_TEXT_FROM_SAFARI_CLIPBOARD_TIMEOUT);
+			resolvers.promise.finally(() => clearTimeout(timer))
+
+			this.readTextPromise = resolvers
+		}
+
+		const text = await this.readTextPromise.promise
+		this.readTextPromise = undefined;
+		return text
 	}
 
 	override async readText(type?: string): Promise<string> {
@@ -46,6 +85,12 @@ export class BrowserClipboardService extends BaseBrowserClipboardService {
 		}
 
 		try {
+			// Try to read clipboard text from the last user event in for webkit browsers (Safari).
+			if (isSafari) {
+				const text = await this.readTextByLastUserEvent();
+				if (text !== undefined) return text;
+			}
+
 			return await getActiveWindow().navigator.clipboard.readText();
 		} catch (error) {
 			return new Promise<string>(resolve => {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

- browser: Safari (webkit)
- install VIM extension & enable `"vim.useSystemClipboard": true`
- press key `p` in VIM normal mode will produce an error about "can not read clipboard" permission error. It's the limitation of webkit <https://webkit.org/blog/10855/async-clipboard-api/>: must use clipboard api in the user gesture event handler