### PR TITLE
Kkbrooks/iconlabel fix

### DIFF
--- a/src/vs/base/browser/ui/iconLabel/iconlabel.css
+++ b/src/vs/base/browser/ui/iconLabel/iconlabel.css
@@ -60,12 +60,12 @@
 }
 
 .monaco-icon-label > .monaco-icon-label-container > .monaco-icon-suffix-container > .label-suffix {
-	color: var(--vscode-peekViewTitleDescription-foreground);
+	opacity: .7;
 	white-space: pre;
 }
 
 .monaco-icon-label > .monaco-icon-label-container > .monaco-icon-description-container > .label-description {
-	color: var(--vscode-peekViewTitleDescription-foreground);
+	opacity: .7;
 	margin-left: 0.5em;
 	font-size: 0.9em;
 	white-space: pre; /* enable to show labels that include multiple whitespaces */

--- a/src/vs/workbench/contrib/chat/browser/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/media/chat.css
@@ -1182,6 +1182,11 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	border-color: var(--vscode-focusBorder);
 }
 
+.chat-attached-context-attachment .monaco-icon-label > .monaco-icon-label-container > .monaco-icon-suffix-container > .label-suffix {
+	color: var(--vscode-peekViewTitleDescription-foreground);
+	opacity: 1;
+}
+
 .chat-notification-widget .chat-warning-codicon .codicon-warning,
 .chat-quota-error-widget .codicon-warning {
 	color: var(--vscode-notificationsWarningIcon-foreground) !important; /* Have to override default styles which apply to all lists */


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

### Changes to label styles:

* [`src/vs/base/browser/ui/iconLabel/iconlabel.css`](diffhunk://#diff-93ac308d9370d907e287adb9c39b7ed81f8cc28502bf5a060cf4c4bcbe1dfffeL63-R68): Updated the `.label-suffix` and `.label-description` elements to use `opacity: .7` instead of the `--vscode-peekViewTitleDescription-foreground` color variable, ensuring a consistent semi-transparent appearance.

* [`src/vs/workbench/contrib/chat/browser/media/chat.css`](diffhunk://#diff-d9537b4703002189d5579da7ffbdd4c0d457f8cebea706f8c0e56cf4861dac44R1185-R1188): Added a new style for `.chat-attached-context-attachment .label-suffix` to explicitly set the color to `--vscode-peekViewTitleDescription-foreground`, ensuring it passes accessibility in this specific context.

The accessibility due date for this fix is June 16.

Related to: #250882, #250829 
