### PR TITLE
mcp: fix resource picker sometimes is empty

### DIFF
--- a/src/vs/workbench/contrib/mcp/browser/mcpResourceQuickAccess.ts
+++ b/src/vs/workbench/contrib/mcp/browser/mcpResourceQuickAccess.ts
@@ -329,6 +329,7 @@ export class McpResourcePickHelper {
 				rec.templates.complete([]);
 				rec.resources.complete([]);
 			}
+			publish();
 		})).finally(() => {
 			store.dispose();
 		});


### PR DESCRIPTION
We didn't trigger a 'change' after the promise resolved, so if we resolve rec.templates and rec.resources synchronously (for a server with no mcp resources) then we could end before publishing everything

Fixes #250890

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
