### PR TITLE
mcp: fix authority-less MCP resources cannot be read by VS Code

### DIFF
--- a/src/vs/workbench/contrib/mcp/common/mcpTypes.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpTypes.ts
@@ -609,6 +609,10 @@ export const mcpServerIcon = registerIcon('mcp-server', Codicon.mcp, localize('m
 export namespace McpResourceURI {
 	export const scheme = 'mcp-resource';
 
+	// Random placeholder for empty authorities, otherwise they're represente as
+	// `scheme//path/here` in the URI which would get normalized to `scheme/path/here`.
+	const emptyAuthorityPlaceholder = 'dylo78gyp'; // chosen by a fair dice roll. Guaranteed to be random.
+
 	export function fromServer(def: McpDefinitionReference, resourceURI: URI | string): URI {
 		if (typeof resourceURI === 'string') {
 			resourceURI = URI.parse(resourceURI);
@@ -616,7 +620,7 @@ export namespace McpResourceURI {
 		return resourceURI.with({
 			scheme,
 			authority: encodeHex(VSBuffer.fromString(def.id)),
-			path: ['', resourceURI.scheme, resourceURI.authority].join('/') + resourceURI.path,
+			path: ['', resourceURI.scheme, resourceURI.authority || emptyAuthorityPlaceholder].join('/') + resourceURI.path,
 		});
 	}
 
@@ -636,8 +640,8 @@ export namespace McpResourceURI {
 			definitionId: decodeHex(uri.authority).toString(),
 			resourceURI: uri.with({
 				scheme: serverScheme,
-				authority,
-				path: '/' + path.join('/'),
+				authority: authority.toLowerCase() === emptyAuthorityPlaceholder ? '' : authority,
+				path: path.length ? ('/' + path.join('/')) : '',
 			}),
 		};
 	}

--- a/src/vs/workbench/contrib/mcp/test/common/mcpTypes.test.ts
+++ b/src/vs/workbench/contrib/mcp/test/common/mcpTypes.test.ts
@@ -1,0 +1,27 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { McpResourceURI } from '../../common/mcpTypes.js';
+import * as assert from 'assert';
+
+suite('MCP Types', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('McpResourceURI - round trips', () => {
+		const roundTrip = (uri: string) => {
+			const from = McpResourceURI.fromServer({ label: '', id: 'my-id' }, uri);
+			const to = McpResourceURI.toServer(from);
+			assert.strictEqual(to.definitionId, 'my-id');
+			assert.strictEqual(to.resourceURI.toString(true), uri, `expected to round trip ${uri}`);
+		};
+
+		roundTrip('file:///path/to/file.txt');
+		roundTrip('custom-scheme://my-path/to/resource.txt');
+		roundTrip('custom-scheme://my-path');
+		roundTrip('custom-scheme://my-path/');
+		roundTrip('custom-scheme://my-path/?with=query&params=here');
+	});
+});


### PR DESCRIPTION
Fixes #250905

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
