### PR TITLE
add multi-command support for terminal suggest

### DIFF
--- a/extensions/terminal-suggest/src/fig/figInterface.ts
+++ b/extensions/terminal-suggest/src/fig/figInterface.ts
@@ -31,7 +31,7 @@ export async function getFigSuggestions(
 	specs: Fig.Spec[],
 	terminalContext: { commandLine: string; cursorPosition: number },
 	availableCommands: ICompletionResource[],
-	prefix: string,
+	currentCommandAndArgString: string,
 	tokenType: TokenType,
 	shellIntegrationCwd: vscode.Uri | undefined,
 	env: Record<string, string>,
@@ -45,7 +45,7 @@ export async function getFigSuggestions(
 		hasCurrentArg: false,
 		items: [],
 	};
-	const currentCommand = prefix.split(' ')[0];
+	const currentCommand = currentCommandAndArgString.split(' ')[0];
 	for (const spec of specs) {
 		const specLabels = getFigSuggestionLabel(spec);
 
@@ -66,7 +66,7 @@ export async function getFigSuggestions(
 					const description = getFixSuggestionDescription(spec);
 					result.items.push(createCompletionItem(
 						terminalContext.cursorPosition,
-						prefix,
+						currentCommandAndArgString,
 						{
 							label: { label: specLabel, description },
 							kind: vscode.TerminalCompletionItemKind.Method
@@ -93,7 +93,7 @@ export async function getFigSuggestions(
 			if (!actualSpec) {
 				continue;
 			}
-			const completionItemResult = await getFigSpecSuggestions(actualSpec, terminalContext, prefix, shellIntegrationCwd, env, name, executeExternals, token);
+			const completionItemResult = await getFigSpecSuggestions(actualSpec, terminalContext, currentCommandAndArgString, shellIntegrationCwd, env, name, executeExternals, token);
 			result.hasCurrentArg ||= !!completionItemResult?.hasCurrentArg;
 			if (completionItemResult) {
 				result.filesRequested ||= completionItemResult.filesRequested;

--- a/extensions/terminal-suggest/src/fig/figInterface.ts
+++ b/extensions/terminal-suggest/src/fig/figInterface.ts
@@ -45,6 +45,7 @@ export async function getFigSuggestions(
 		hasCurrentArg: false,
 		items: [],
 	};
+	const currentCommand = prefix.split(' ')[0];
 	for (const spec of specs) {
 		const specLabels = getFigSuggestionLabel(spec);
 
@@ -82,8 +83,8 @@ export async function getFigSuggestions(
 				: availableCommands.filter(command => specLabel === (command.definitionCommand ?? (typeof command.label === 'string' ? command.label : command.label.label))));
 			if (
 				!(osIsWindows()
-					? commandAndAliases.some(e => prefix.startsWith(`${removeAnyFileExtension((typeof e.label === 'string' ? e.label : e.label.label))} `))
-					: commandAndAliases.some(e => prefix.startsWith(`${typeof e.label === 'string' ? e.label : e.label.label} `)))
+					? commandAndAliases.some(e => currentCommand.startsWith(`${removeAnyFileExtension((typeof e.label === 'string' ? e.label : e.label.label))} `))
+					: commandAndAliases.some(e => currentCommand.startsWith(typeof e.label === 'string' ? e.label : e.label.label)))
 			) {
 				continue;
 			}

--- a/extensions/terminal-suggest/src/fig/figInterface.ts
+++ b/extensions/terminal-suggest/src/fig/figInterface.ts
@@ -36,7 +36,6 @@ export async function getFigSuggestions(
 	shellIntegrationCwd: vscode.Uri | undefined,
 	env: Record<string, string>,
 	name: string,
-	precedingText: string,
 	executeExternals: IFigExecuteExternals,
 	token?: vscode.CancellationToken,
 ): Promise<IFigSpecSuggestionsResult> {
@@ -83,8 +82,8 @@ export async function getFigSuggestions(
 				: availableCommands.filter(command => specLabel === (command.definitionCommand ?? (typeof command.label === 'string' ? command.label : command.label.label))));
 			if (
 				!(osIsWindows()
-					? commandAndAliases.some(e => precedingText.startsWith(`${removeAnyFileExtension((typeof e.label === 'string' ? e.label : e.label.label))} `))
-					: commandAndAliases.some(e => precedingText.startsWith(`${typeof e.label === 'string' ? e.label : e.label.label} `)))
+					? commandAndAliases.some(e => prefix.startsWith(`${removeAnyFileExtension((typeof e.label === 'string' ? e.label : e.label.label))} `))
+					: commandAndAliases.some(e => prefix.startsWith(`${typeof e.label === 'string' ? e.label : e.label.label} `)))
 			) {
 				continue;
 			}

--- a/extensions/terminal-suggest/src/fig/figInterface.ts
+++ b/extensions/terminal-suggest/src/fig/figInterface.ts
@@ -83,7 +83,7 @@ export async function getFigSuggestions(
 				: availableCommands.filter(command => specLabel === (command.definitionCommand ?? (typeof command.label === 'string' ? command.label : command.label.label))));
 			if (
 				!(osIsWindows()
-					? commandAndAliases.some(e => currentCommand.startsWith(`${removeAnyFileExtension((typeof e.label === 'string' ? e.label : e.label.label))} `))
+					? commandAndAliases.some(e => currentCommand.startsWith(removeAnyFileExtension((typeof e.label === 'string' ? e.label : e.label.label))))
 					: commandAndAliases.some(e => currentCommand.startsWith(typeof e.label === 'string' ? e.label : e.label.label)))
 			) {
 				continue;

--- a/extensions/terminal-suggest/src/helpers/completionItem.ts
+++ b/extensions/terminal-suggest/src/helpers/completionItem.ts
@@ -6,9 +6,9 @@
 import * as vscode from 'vscode';
 import type { ICompletionResource } from '../types';
 
-export function createCompletionItem(cursorPosition: number, prefix: string, commandResource: ICompletionResource, detail?: string, documentation?: string | vscode.MarkdownString, kind?: vscode.TerminalCompletionItemKind): vscode.TerminalCompletionItem {
-	const endsWithSpace = prefix.endsWith(' ');
-	const lastWord = endsWithSpace ? '' : prefix.split(' ').at(-1) ?? '';
+export function createCompletionItem(cursorPosition: number, currentCommandString: string, commandResource: ICompletionResource, detail?: string, documentation?: string | vscode.MarkdownString, kind?: vscode.TerminalCompletionItemKind): vscode.TerminalCompletionItem {
+	const endsWithSpace = currentCommandString.endsWith(' ');
+	const lastWord = endsWithSpace ? '' : currentCommandString.split(' ').at(-1) ?? '';
 	return {
 		label: commandResource.label,
 		detail: detail ?? commandResource.detail ?? '',

--- a/extensions/terminal-suggest/src/terminalSuggestMain.ts
+++ b/extensions/terminal-suggest/src/terminalSuggestMain.ts
@@ -152,14 +152,13 @@ export async function activate(context: vscode.ExtensionContext) {
 }
 
 /**
- * Adjusts the current working directory based on a given prefix if it is a folder.
+ * Adjusts the current working directory based on a given current command string if it is a folder.
  * @param currentCommandString - The current command string, which might contain a folder path prefix.
  * @param currentCwd - The current working directory.
  * @returns The new working directory.
  */
 export async function resolveCwdFromCurrentCommandString(currentCommandString: string, currentCwd?: vscode.Uri): Promise<vscode.Uri | undefined> {
-	// Set prefix to the last word of the original prefix
-	currentCommandString = currentCommandString.split(/\s+/).pop()?.trim() ?? '';
+	const prefix = currentCommandString.split(/\s+/).pop()?.trim() ?? '';
 
 	if (!currentCwd) {
 		return;
@@ -172,14 +171,14 @@ export async function resolveCwdFromCurrentCommandString(currentCommandString: s
 			// TODO: This support is very basic, ideally the slashes supported would depend upon the
 			//       shell type. For example git bash under Windows does not allow using \ as a path
 			//       separator.
-			lastSlashIndex = currentCommandString.lastIndexOf('\\');
+			lastSlashIndex = prefix.lastIndexOf('\\');
 			if (lastSlashIndex === -1) {
-				lastSlashIndex = currentCommandString.lastIndexOf('/');
+				lastSlashIndex = prefix.lastIndexOf('/');
 			}
 		} else {
-			lastSlashIndex = currentCommandString.lastIndexOf('/');
+			lastSlashIndex = prefix.lastIndexOf('/');
 		}
-		const relativeFolder = lastSlashIndex === -1 ? '' : currentCommandString.slice(0, lastSlashIndex);
+		const relativeFolder = lastSlashIndex === -1 ? '' : prefix.slice(0, lastSlashIndex);
 
 		// Resolve the absolute path of the prefix
 		const resolvedPath = path.resolve(currentCwd?.fsPath, relativeFolder);
@@ -225,11 +224,11 @@ export function getCurrentCommandAndArgs(commandLine: string, cursorPosition: nu
 		}
 	}
 
-	// The start of the prefix is after the last reset char (plus one for the char itself)
-	const prefixStart = lastResetIndex + 1;
-	const prefix = beforeCursor.slice(prefixStart).replace(/^\s+/, '');
+	// The start of the current command string is after the last reset char (plus one for the char itself)
+	const currentCommandStart = lastResetIndex + 1;
+	const currentCommandString = beforeCursor.slice(currentCommandStart).replace(/^\s+/, '');
 
-	return prefix;
+	return currentCommandString;
 }
 
 export function asArray<T>(x: T | T[]): T[];

--- a/extensions/terminal-suggest/src/terminalSuggestMain.ts
+++ b/extensions/terminal-suggest/src/terminalSuggestMain.ts
@@ -196,7 +196,6 @@ export async function resolveCwdFromPrefix(prefix: string, currentCwd?: vscode.U
 }
 
 function getPrefix(commandLine: string, cursorPosition: number, shellType: TerminalShellType | undefined): string {
-	// Use resetChars imported from tokens.ts
 
 	// Return an empty string if the command line is empty after trimming
 	if (commandLine.trim() === '') {

--- a/extensions/terminal-suggest/src/terminalSuggestMain.ts
+++ b/extensions/terminal-suggest/src/terminalSuggestMain.ts
@@ -20,7 +20,7 @@ import { getBashGlobals } from './shell/bash';
 import { getFishGlobals } from './shell/fish';
 import { getPwshGlobals } from './shell/pwsh';
 import { getZshGlobals } from './shell/zsh';
-import { getTokenType, TokenType } from './tokens';
+import { getTokenType, TokenType, shellTypeResetChars, defaultShellTypeResetChars } from './tokens';
 import type { ICompletionResource } from './types';
 import { createCompletionItem } from './helpers/completionItem';
 import { getFigSuggestions } from './fig/figInterface';
@@ -113,7 +113,7 @@ export async function activate(context: vscode.ExtensionContext) {
 			}
 			// Order is important here, add shell globals first so they are prioritized over path commands
 			const commands = [...shellGlobals, ...commandsInPath.completionResources];
-			const prefix = getPrefix(terminalContext.commandLine, terminalContext.cursorPosition);
+			const prefix = getPrefix(terminalContext.commandLine, terminalContext.cursorPosition, terminalShellType);
 			const pathSeparator = isWindows ? '\\' : '/';
 			const tokenType = getTokenType(terminalContext, terminalShellType);
 			const result = await Promise.race([
@@ -195,7 +195,9 @@ export async function resolveCwdFromPrefix(prefix: string, currentCwd?: vscode.U
 	return undefined;
 }
 
-function getPrefix(commandLine: string, cursorPosition: number): string {
+function getPrefix(commandLine: string, cursorPosition: number, shellType: TerminalShellType | undefined): string {
+	// Use resetChars imported from tokens.ts
+
 	// Return an empty string if the command line is empty after trimming
 	if (commandLine.trim() === '') {
 		return '';
@@ -209,11 +211,21 @@ function getPrefix(commandLine: string, cursorPosition: number): string {
 	// Extract the part of the line up to the cursor position
 	const beforeCursor = commandLine.slice(0, cursorPosition);
 
-	// Find the last sequence of non-whitespace characters before the cursor
-	const match = beforeCursor.match(/(\S+)\s*$/);
+	const resetChars = shellType ? shellTypeResetChars.get(shellType) ?? defaultShellTypeResetChars : defaultShellTypeResetChars;
+	// Find the last reset character before the cursor
+	let lastResetIndex = -1;
+	for (const char of resetChars) {
+		const idx = beforeCursor.lastIndexOf(char);
+		if (idx > lastResetIndex) {
+			lastResetIndex = idx;
+		}
+	}
 
-	// Return the match if found, otherwise undefined
-	return match ? match[0] : '';
+	// The start of the prefix is after the last reset char (plus one for the char itself)
+	const prefixStart = lastResetIndex + 1;
+	const prefix = beforeCursor.slice(prefixStart).replace(/^\s+/, '');
+
+	return prefix;
 }
 
 export function asArray<T>(x: T | T[]): T[];
@@ -240,17 +252,17 @@ export async function getCompletionItemsFromSpecs(
 	let hasCurrentArg = false;
 	let fileExtensions: string[] | undefined;
 
-	let precedingText = terminalContext.commandLine.slice(0, terminalContext.cursorPosition + 1);
+	// let precedingText = terminalContext.commandLine.slice(0, terminalContext.cursorPosition + 1);
 	if (isWindows) {
-		const spaceIndex = precedingText.indexOf(' ');
-		const commandEndIndex = spaceIndex === -1 ? precedingText.length : spaceIndex;
-		const lastDotIndex = precedingText.lastIndexOf('.', commandEndIndex);
+		const spaceIndex = prefix.indexOf(' ');
+		const commandEndIndex = spaceIndex === -1 ? prefix.length : spaceIndex;
+		const lastDotIndex = prefix.lastIndexOf('.', commandEndIndex);
 		if (lastDotIndex > 0) { // Don't treat dotfiles as extensions
-			precedingText = precedingText.substring(0, lastDotIndex) + precedingText.substring(spaceIndex);
+			prefix = prefix.substring(0, lastDotIndex) + prefix.substring(spaceIndex);
 		}
 	}
 
-	const result = await getFigSuggestions(specs, terminalContext, availableCommands, prefix, tokenType, shellIntegrationCwd, env, name, precedingText, executeExternals ?? { executeCommand, executeCommandTimeout }, token);
+	const result = await getFigSuggestions(specs, terminalContext, availableCommands, prefix, tokenType, shellIntegrationCwd, env, name, executeExternals ?? { executeCommand, executeCommandTimeout }, token);
 	if (result) {
 		hasCurrentArg ||= result.hasCurrentArg;
 		filesRequested ||= result.filesRequested;
@@ -361,3 +373,4 @@ export function sanitizeProcessEnvironment(env: Record<string, string>, ...prese
 			}
 		});
 }
+

--- a/extensions/terminal-suggest/src/terminalSuggestMain.ts
+++ b/extensions/terminal-suggest/src/terminalSuggestMain.ts
@@ -252,7 +252,6 @@ export async function getCompletionItemsFromSpecs(
 	let hasCurrentArg = false;
 	let fileExtensions: string[] | undefined;
 
-	// let precedingText = terminalContext.commandLine.slice(0, terminalContext.cursorPosition + 1);
 	if (isWindows) {
 		const spaceIndex = prefix.indexOf(' ');
 		const commandEndIndex = spaceIndex === -1 ? prefix.length : spaceIndex;

--- a/extensions/terminal-suggest/src/terminalSuggestMain.ts
+++ b/extensions/terminal-suggest/src/terminalSuggestMain.ts
@@ -158,6 +158,9 @@ export async function activate(context: vscode.ExtensionContext) {
  * @returns The new working directory.
  */
 export async function resolveCwdFromPrefix(prefix: string, currentCwd?: vscode.Uri): Promise<vscode.Uri | undefined> {
+	// Set prefix to the last word of the original prefix
+	prefix = prefix.split(/\s+/).pop()?.trim() ?? '';
+
 	if (!currentCwd) {
 		return;
 	}

--- a/extensions/terminal-suggest/src/terminalSuggestMain.ts
+++ b/extensions/terminal-suggest/src/terminalSuggestMain.ts
@@ -195,7 +195,7 @@ export async function resolveCwdFromPrefix(prefix: string, currentCwd?: vscode.U
 	return undefined;
 }
 
-function getPrefix(commandLine: string, cursorPosition: number, shellType: TerminalShellType | undefined): string {
+export function getPrefix(commandLine: string, cursorPosition: number, shellType: TerminalShellType | undefined): string {
 
 	// Return an empty string if the command line is empty after trimming
 	if (commandLine.trim() === '') {

--- a/extensions/terminal-suggest/src/test/terminalSuggestMain.test.ts
+++ b/extensions/terminal-suggest/src/test/terminalSuggestMain.test.ts
@@ -6,7 +6,7 @@
 import { deepStrictEqual, strictEqual } from 'assert';
 import 'mocha';
 import { basename } from 'path';
-import { asArray, getCompletionItemsFromSpecs, getPrefix } from '../terminalSuggestMain';
+import { asArray, getCompletionItemsFromSpecs, getCurrentCommandAndArgs } from '../terminalSuggestMain';
 import { getTokenType } from '../tokens';
 import { cdTestSuiteSpec as cdTestSuite } from './completions/cd.test';
 import { codeSpecOptionsAndSubcommands, codeTestSuite, codeTunnelTestSuite } from './completions/code.test';
@@ -92,7 +92,7 @@ suite('Terminal Suggest', () => {
 				test(`'${testSpec.input}' -> ${expectedString}`, async () => {
 					const commandLine = testSpec.input.split('|')[0];
 					const cursorPosition = testSpec.input.indexOf('|');
-					const prefix = getPrefix(commandLine, cursorPosition, undefined);
+					const currentCommandString = getCurrentCommandAndArgs(commandLine, cursorPosition, undefined);
 					const filesRequested = testSpec.expectedResourceRequests?.type === 'files' || testSpec.expectedResourceRequests?.type === 'both';
 					const foldersRequested = testSpec.expectedResourceRequests?.type === 'folders' || testSpec.expectedResourceRequests?.type === 'both';
 					const terminalContext = { commandLine, cursorPosition, allowFallbackCompletions: true };
@@ -100,7 +100,7 @@ suite('Terminal Suggest', () => {
 						completionSpecs,
 						terminalContext,
 						availableCommands.map(c => { return { label: c }; }),
-						prefix,
+						currentCommandString,
 						getTokenType(terminalContext, undefined),
 						testPaths.cwd,
 						{},

--- a/extensions/terminal-suggest/src/test/terminalSuggestMain.test.ts
+++ b/extensions/terminal-suggest/src/test/terminalSuggestMain.test.ts
@@ -6,7 +6,7 @@
 import { deepStrictEqual, strictEqual } from 'assert';
 import 'mocha';
 import { basename } from 'path';
-import { asArray, getCompletionItemsFromSpecs } from '../terminalSuggestMain';
+import { asArray, getCompletionItemsFromSpecs, getPrefix } from '../terminalSuggestMain';
 import { getTokenType } from '../tokens';
 import { cdTestSuiteSpec as cdTestSuite } from './completions/cd.test';
 import { codeSpecOptionsAndSubcommands, codeTestSuite, codeTunnelTestSuite } from './completions/code.test';
@@ -92,7 +92,7 @@ suite('Terminal Suggest', () => {
 				test(`'${testSpec.input}' -> ${expectedString}`, async () => {
 					const commandLine = testSpec.input.split('|')[0];
 					const cursorPosition = testSpec.input.indexOf('|');
-					const prefix = commandLine.slice(0, cursorPosition).split(' ').at(-1) || '';
+					const prefix = getPrefix(commandLine, cursorPosition, undefined);
 					const filesRequested = testSpec.expectedResourceRequests?.type === 'files' || testSpec.expectedResourceRequests?.type === 'both';
 					const foldersRequested = testSpec.expectedResourceRequests?.type === 'folders' || testSpec.expectedResourceRequests?.type === 'both';
 					const terminalContext = { commandLine, cursorPosition, allowFallbackCompletions: true };

--- a/extensions/terminal-suggest/src/test/tokens.test.ts
+++ b/extensions/terminal-suggest/src/test/tokens.test.ts
@@ -54,15 +54,47 @@ suite('Terminal Suggest', () => {
 		suite('multiple commands on the line', () => {
 			test('multiple commands, cursor at end', () => {
 				strictEqual(getTokenType({ commandLine: 'echo hello && echo world', cursorPosition: 'echo hello && ech'.length }, undefined), TokenType.Command);
+				// Bash
+				strictEqual(getTokenType({ commandLine: 'echo hello && echo world', cursorPosition: 'echo hello && ech'.length }, TerminalShellType.Bash), TokenType.Command);
+				// Zsh
+				strictEqual(getTokenType({ commandLine: 'echo hello && echo world', cursorPosition: 'echo hello && ech'.length }, TerminalShellType.Zsh), TokenType.Command);
+				// Fish (use ';' as separator)
+				strictEqual(getTokenType({ commandLine: 'echo hello; echo world', cursorPosition: 'echo hello; ech'.length }, TerminalShellType.Fish), TokenType.Command);
+				// PowerShell (use ';' as separator)
+				strictEqual(getTokenType({ commandLine: 'echo hello; echo world', cursorPosition: 'echo hello; ech'.length }, TerminalShellType.PowerShell), TokenType.Command);
 			});
 			test('multiple commands, cursor mid text', () => {
 				strictEqual(getTokenType({ commandLine: 'echo hello && echo world', cursorPosition: 'echo hello && echo w'.length }, undefined), TokenType.Argument);
+				// Bash
+				strictEqual(getTokenType({ commandLine: 'echo hello && echo world', cursorPosition: 'echo hello && echo w'.length }, TerminalShellType.Bash), TokenType.Argument);
+				// Zsh
+				strictEqual(getTokenType({ commandLine: 'echo hello && echo world', cursorPosition: 'echo hello && echo w'.length }, TerminalShellType.Zsh), TokenType.Argument);
+				// Fish (use ';' as separator)
+				strictEqual(getTokenType({ commandLine: 'echo hello; echo world', cursorPosition: 'echo hello; echo w'.length }, TerminalShellType.Fish), TokenType.Argument);
+				// PowerShell (use ';' as separator)
+				strictEqual(getTokenType({ commandLine: 'echo hello; echo world', cursorPosition: 'echo hello; echo w'.length }, TerminalShellType.PowerShell), TokenType.Argument);
 			});
 			test('multiple commands, cursor at end with reset char', () => {
 				strictEqual(getTokenType({ commandLine: 'echo hello && echo world; ', cursorPosition: 'echo hello && echo world; '.length }, undefined), TokenType.Command);
+				// Bash
+				strictEqual(getTokenType({ commandLine: 'echo hello && echo world; ', cursorPosition: 'echo hello && echo world; '.length }, TerminalShellType.Bash), TokenType.Command);
+				// Zsh
+				strictEqual(getTokenType({ commandLine: 'echo hello && echo world; ', cursorPosition: 'echo hello && echo world; '.length }, TerminalShellType.Zsh), TokenType.Command);
+				// Fish (use ';' as separator)
+				strictEqual(getTokenType({ commandLine: 'echo hello; echo world; ', cursorPosition: 'echo hello; echo world; '.length }, TerminalShellType.Fish), TokenType.Command);
+				// PowerShell (use ';' as separator)
+				strictEqual(getTokenType({ commandLine: 'echo hello; echo world; ', cursorPosition: 'echo hello; echo world; '.length }, TerminalShellType.PowerShell), TokenType.Command);
 			});
 			test('multiple commands, cursor mid text with reset char', () => {
 				strictEqual(getTokenType({ commandLine: 'echo hello && echo world; ', cursorPosition: 'echo hello && echo worl'.length }, undefined), TokenType.Argument);
+				// Bash
+				strictEqual(getTokenType({ commandLine: 'echo hello && echo world; ', cursorPosition: 'echo hello && echo worl'.length }, TerminalShellType.Bash), TokenType.Argument);
+				// Zsh
+				strictEqual(getTokenType({ commandLine: 'echo hello && echo world; ', cursorPosition: 'echo hello && echo worl'.length }, TerminalShellType.Zsh), TokenType.Argument);
+				// Fish (use ';' as separator)
+				strictEqual(getTokenType({ commandLine: 'echo hello; echo world; ', cursorPosition: 'echo hello; echo worl'.length }, TerminalShellType.Fish), TokenType.Argument);
+				// PowerShell (use ';' as separator)
+				strictEqual(getTokenType({ commandLine: 'echo hello; echo world; ', cursorPosition: 'echo hello; echo worl'.length }, TerminalShellType.PowerShell), TokenType.Argument);
 			});
 		});
 	});

--- a/extensions/terminal-suggest/src/test/tokens.test.ts
+++ b/extensions/terminal-suggest/src/test/tokens.test.ts
@@ -48,5 +48,22 @@ suite('Terminal Suggest', () => {
 		test('arguments after reset char', () => {
 			strictEqual(getTokenType({ commandLine: `Write-Host hello -and $true `, cursorPosition: `Write-Host hello -and $true `.length }, TerminalShellType.PowerShell), TokenType.Argument);
 		});
+		test('; reset char', () => {
+			strictEqual(getTokenType({ commandLine: `Write-Host hello; `, cursorPosition: `Write-Host hello; `.length }, TerminalShellType.PowerShell), TokenType.Command);
+		});
+		suite('multiple commands on the line', () => {
+			test('multiple commands, cursor at end', () => {
+				strictEqual(getTokenType({ commandLine: 'echo hello && echo world', cursorPosition: 'echo hello && ech'.length }, undefined), TokenType.Command);
+			});
+			test('multiple commands, cursor mid text', () => {
+				strictEqual(getTokenType({ commandLine: 'echo hello && echo world', cursorPosition: 'echo hello && echo w'.length }, undefined), TokenType.Argument);
+			});
+			test('multiple commands, cursor at end with reset char', () => {
+				strictEqual(getTokenType({ commandLine: 'echo hello && echo world; ', cursorPosition: 'echo hello && echo world; '.length }, undefined), TokenType.Command);
+			});
+			test('multiple commands, cursor mid text with reset char', () => {
+				strictEqual(getTokenType({ commandLine: 'echo hello && echo world; ', cursorPosition: 'echo hello && echo worl'.length }, undefined), TokenType.Argument);
+			});
+		});
 	});
 });

--- a/extensions/terminal-suggest/src/tokens.ts
+++ b/extensions/terminal-suggest/src/tokens.ts
@@ -14,18 +14,35 @@ export const enum TokenType {
 const shellTypeResetChars = new Map<TerminalShellType, string[]>([
 	[TerminalShellType.Bash, ['>', '>>', '<', '2>', '2>>', '&>', '&>>', '|', '|&', '&&', '||', '&', ';', '(', '{', '<<']],
 	[TerminalShellType.Zsh, ['>', '>>', '<', '2>', '2>>', '&>', '&>>', '<>', '|', '|&', '&&', '||', '&', ';', '(', '{', '<<', '<<<', '<(']],
-	[TerminalShellType.PowerShell, ['>', '>>', '<', '2>', '2>>', '*>', '*>>', '|', '-and', '-or', '-not', '!', '&', '-eq', '-ne', '-gt', '-lt', '-ge', '-le', '-like', '-notlike', '-match', '-notmatch', '-contains', '-notcontains', '-in', '-notin']]
+	[TerminalShellType.PowerShell, ['>', '>>', '<', '2>', '2>>', '*>', '*>>', '|', ';', '-and', '-or', '-not', '!', '&', '-eq', '-ne', '-gt', '-lt', '-ge', '-le', '-like', '-notlike', '-match', '-notmatch', '-contains', '-notcontains', '-in', '-notin']]
 ]);
 
 const defaultShellTypeResetChars = shellTypeResetChars.get(TerminalShellType.Bash)!;
 
 export function getTokenType(ctx: { commandLine: string; cursorPosition: number }, shellType: TerminalShellType | undefined): TokenType {
-	const spaceIndex = ctx.commandLine.substring(0, ctx.cursorPosition).lastIndexOf(' ');
+	const commandLine = ctx.commandLine;
+	const cursorPosition = ctx.cursorPosition;
+	const commandResetChars = shellType === undefined ? defaultShellTypeResetChars : shellTypeResetChars.get(shellType) ?? defaultShellTypeResetChars;
+
+	// Check for reset char before the current word
+	const beforeCursor = commandLine.substring(0, cursorPosition);
+	const wordStart = beforeCursor.lastIndexOf(' ') + 1;
+	const beforeWord = commandLine.substring(0, wordStart);
+
+	// Look for " <reset char> " before the word
+	for (const resetChar of commandResetChars) {
+		const pattern = ` ${resetChar} `;
+		if (beforeWord.endsWith(pattern)) {
+			return TokenType.Command;
+		}
+	}
+
+	// Fallback to original logic for the very first command
+	const spaceIndex = beforeCursor.lastIndexOf(' ');
 	if (spaceIndex === -1) {
 		return TokenType.Command;
 	}
-	const previousTokens = ctx.commandLine.substring(0, spaceIndex + 1).trim();
-	const commandResetChars = shellType === undefined ? defaultShellTypeResetChars : shellTypeResetChars.get(shellType) ?? defaultShellTypeResetChars;
+	const previousTokens = beforeCursor.substring(0, spaceIndex + 1).trim();
 	if (commandResetChars.some(e => previousTokens.endsWith(e))) {
 		return TokenType.Command;
 	}

--- a/extensions/terminal-suggest/src/tokens.ts
+++ b/extensions/terminal-suggest/src/tokens.ts
@@ -11,13 +11,13 @@ export const enum TokenType {
 	Argument,
 }
 
-const shellTypeResetChars = new Map<TerminalShellType, string[]>([
+export const shellTypeResetChars = new Map<TerminalShellType, string[]>([
 	[TerminalShellType.Bash, ['>', '>>', '<', '2>', '2>>', '&>', '&>>', '|', '|&', '&&', '||', '&', ';', '(', '{', '<<']],
 	[TerminalShellType.Zsh, ['>', '>>', '<', '2>', '2>>', '&>', '&>>', '<>', '|', '|&', '&&', '||', '&', ';', '(', '{', '<<', '<<<', '<(']],
 	[TerminalShellType.PowerShell, ['>', '>>', '<', '2>', '2>>', '*>', '*>>', '|', ';', '-and', '-or', '-not', '!', '&', '-eq', '-ne', '-gt', '-lt', '-ge', '-le', '-like', '-notlike', '-match', '-notmatch', '-contains', '-notcontains', '-in', '-notin']]
 ]);
 
-const defaultShellTypeResetChars = shellTypeResetChars.get(TerminalShellType.Bash)!;
+export const defaultShellTypeResetChars = shellTypeResetChars.get(TerminalShellType.Bash)!;
 
 export function getTokenType(ctx: { commandLine: string; cursorPosition: number }, shellType: TerminalShellType | undefined): TokenType {
 	const commandLine = ctx.commandLine;


### PR DESCRIPTION
fix #241993

This  introduces significant changes to improve terminal command suggestion functionality. The primary focus is on replacing the `prefix` parameter with `currentCommandString` across various functions, enhancing the accuracy of command and argument parsing. Additionally, the update refines the logic for identifying commands and arguments based on shell-specific reset characters, and extends test coverage to validate these improvements.

also adds `;` as a reset char for `pwsh`

<img width="701" alt="Screenshot 2025-06-06 at 7 35 41 PM" src="https://github.com/user-attachments/assets/76e257ed-f8a8-498f-b78f-1f1fbe1247f8" />



