### PR TITLE
Disable variable line heights in notebook cells

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/diff/diffComponents.ts
+++ b/src/vs/workbench/contrib/notebook/browser/diff/diffComponents.ts
@@ -860,7 +860,8 @@ abstract class AbstractElementRenderer extends Disposable {
 					height: this.cell.layoutInfo.metadataHeight
 				},
 				overflowWidgetsDomNode: this.notebookEditor.getOverflowContainerDomNode(),
-				readOnly: false
+				readOnly: false,
+				allowVariableLineHeights: false
 			}, {});
 			this.layout({ metadataHeight: true });
 			this._metadataEditorDisposeStore.add(this._metadataEditor);
@@ -956,7 +957,8 @@ abstract class AbstractElementRenderer extends Disposable {
 				width: Math.min(OUTPUT_EDITOR_HEIGHT_MAGIC, this.cell.getComputedCellContainerWidth(this.notebookEditor.getLayoutInfo(), false, this.cell.type === 'unchanged' || this.cell.type === 'modified') - 32),
 				height: this.cell.layoutInfo.rawOutputHeight
 			},
-			overflowWidgetsDomNode: this.notebookEditor.getOverflowContainerDomNode()
+			overflowWidgetsDomNode: this.notebookEditor.getOverflowContainerDomNode(),
+			allowVariableLineHeights: false
 		}, {});
 		this._outputEditorDisposeStore.add(this._outputEditor);
 

--- a/src/vs/workbench/contrib/notebook/browser/diff/notebookDiffList.ts
+++ b/src/vs/workbench/contrib/notebook/browser/diff/notebookDiffList.ts
@@ -621,6 +621,7 @@ function buildSourceEditor(instantiationService: IInstantiationService, notebook
 		},
 		automaticLayout: false,
 		overflowWidgetsDomNode: notebookEditor.getOverflowContainerDomNode(),
+		allowVariableLineHeights: false,
 		readOnly: true,
 	}, {
 		contributions: EditorExtensionsRegistry.getEditorContributions().filter(c => skipContributions.indexOf(c.id) === -1)

--- a/src/vs/workbench/contrib/notebook/browser/view/cellParts/markupCell.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/cellParts/markupCell.ts
@@ -331,6 +331,7 @@ export class MarkupCell extends Disposable {
 					width: width,
 					height: editorHeight
 				},
+				allowVariableLineHeights: false,
 				// overflowWidgetsDomNode: this.notebookEditor.getOverflowContainerDomNode()
 			}, {
 				contributions: this.notebookEditor.creationOptions.cellEditorContributions

--- a/src/vs/workbench/contrib/notebook/browser/view/notebookCellEditorPool.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/notebookCellEditorPool.ts
@@ -61,6 +61,7 @@ export class NotebookCellEditorPool extends Disposable {
 				handleMouseWheel: false,
 				useShadows: false,
 			},
+			allowVariableLineHeights: false,
 		}, {
 			contributions: this.notebookEditor.creationOptions.cellEditorContributions
 		}));

--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/cellRenderer.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/cellRenderer.ts
@@ -286,6 +286,7 @@ export class CodeCellRenderer extends AbstractCellRenderer implements IListRende
 
 		const editor = editorInstaService.createInstance(CodeEditorWidget, editorContainer, {
 			...this.editorOptions.getDefaultValue(),
+			allowVariableLineHeights: false,
 			dimension: {
 				width: 0,
 				height: 0


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
For https://github.com/microsoft/vscode/issues/248794#issuecomment-2956584072

Disable variable line heights as we need to pre-calculate cell heights to avoid ui flickering

@amunger @rebornix @Yoyokrazy 
Disabling as this will require a lot of work to get this working, easier to first disable this than have things broken and UI flicking/poor ux... we can enable/resolve later if and when we decide to enable this for notebooks.
I have had a look and getting support for notebooks will not be easy