### PR TITLE
(Reland) fix: smoke tests for stable with editcontext enabled

### DIFF
--- a/test/automation/src/debug.ts
+++ b/test/automation/src/debug.ts
@@ -9,7 +9,6 @@ import { Code, findElement } from './code';
 import { Editors } from './editors';
 import { Editor } from './editor';
 import { IElement } from './driver';
-import { Quality } from './application';
 
 const VIEWLET = 'div[id="workbench.view.debug"]';
 const DEBUG_VIEW = `${VIEWLET}`;
@@ -133,7 +132,7 @@ export class Debug extends Viewlet {
 
 	async waitForReplCommand(text: string, accept: (result: string) => boolean): Promise<void> {
 		await this.commands.runCommand('Debug: Focus on Debug Console View');
-		const selector = this.code.quality === Quality.Stable ? REPL_FOCUSED_TEXTAREA : REPL_FOCUSED_NATIVE_EDIT_CONTEXT;
+		const selector = !this.code.editContextEnabled ? REPL_FOCUSED_TEXTAREA : REPL_FOCUSED_NATIVE_EDIT_CONTEXT;
 		await this.code.waitForActiveElement(selector);
 		await this.code.waitForSetValue(selector, text);
 

--- a/test/automation/src/editor.ts
+++ b/test/automation/src/editor.ts
@@ -6,7 +6,6 @@
 import { References } from './peek';
 import { Commands } from './workbench';
 import { Code } from './code';
-import { Quality } from './application';
 
 const RENAME_BOX = '.monaco-editor .monaco-editor.rename-box';
 const RENAME_INPUT = `${RENAME_BOX} .rename-input`;
@@ -107,7 +106,7 @@ export class Editor {
 	}
 
 	private _editContextSelector() {
-		return this.code.quality === Quality.Stable ? 'textarea' : '.native-edit-context';
+		return !this.code.editContextEnabled ? 'textarea' : '.native-edit-context';
 	}
 
 	async waitForEditorContents(filename: string, accept: (contents: string) => boolean, selectorPrefix = ''): Promise<any> {

--- a/test/automation/src/editors.ts
+++ b/test/automation/src/editors.ts
@@ -3,7 +3,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Quality } from './application';
 import { Code } from './code';
 
 export class Editors {
@@ -53,7 +52,7 @@ export class Editors {
 	}
 
 	async waitForActiveEditor(fileName: string, retryCount?: number): Promise<any> {
-		const selector = `.editor-instance .monaco-editor[data-uri$="${fileName}"] ${this.code.quality === Quality.Stable ? 'textarea' : '.native-edit-context'}`;
+		const selector = `.editor-instance .monaco-editor[data-uri$="${fileName}"] ${!this.code.editContextEnabled ? 'textarea' : '.native-edit-context'}`;
 		return this.code.waitForActiveElement(selector, retryCount);
 	}
 

--- a/test/automation/src/extensions.ts
+++ b/test/automation/src/extensions.ts
@@ -8,7 +8,6 @@ import { Code } from './code';
 import { ncp } from 'ncp';
 import { promisify } from 'util';
 import { Commands } from './workbench';
-import { Quality } from './application';
 import path = require('path');
 import fs = require('fs');
 
@@ -21,7 +20,7 @@ export class Extensions extends Viewlet {
 
 	async searchForExtension(id: string): Promise<any> {
 		await this.commands.runCommand('Extensions: Focus on Extensions View', { exactLabelMatch: true });
-		await this.code.waitForTypeInEditor(`div.extensions-viewlet[id="workbench.view.extensions"] .monaco-editor ${this.code.quality === Quality.Stable ? 'textarea' : '.native-edit-context'}`, `@id:${id}`);
+		await this.code.waitForTypeInEditor(`div.extensions-viewlet[id="workbench.view.extensions"] .monaco-editor ${!this.code.editContextEnabled ? 'textarea' : '.native-edit-context'}`, `@id:${id}`);
 		await this.code.waitForTextContent(`div.part.sidebar div.composite.title h2`, 'Extensions: Marketplace');
 
 		let retrials = 1;

--- a/test/automation/src/notebook.ts
+++ b/test/automation/src/notebook.ts
@@ -3,7 +3,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Quality } from './application';
 import { Code } from './code';
 import { QuickAccess } from './quickaccess';
 import { QuickInput } from './quickinput';
@@ -47,7 +46,7 @@ export class Notebook {
 
 		await this.code.waitForElement(editor);
 
-		const editContext = `${editor} ${this.code.quality === Quality.Stable ? 'textarea' : '.native-edit-context'}`;
+		const editContext = `${editor} ${!this.code.editContextEnabled ? 'textarea' : '.native-edit-context'}`;
 		await this.code.waitForActiveElement(editContext);
 
 		await this.code.waitForTypeInEditor(editContext, text);

--- a/test/automation/src/scm.ts
+++ b/test/automation/src/scm.ts
@@ -6,7 +6,6 @@
 import { Viewlet } from './viewlet';
 import { IElement } from './driver';
 import { findElement, findElements, Code } from './code';
-import { Quality } from './application';
 
 const VIEWLET = 'div[id="workbench.view.scm"]';
 const SCM_INPUT_NATIVE_EDIT_CONTEXT = `${VIEWLET} .scm-editor .native-edit-context`;
@@ -79,6 +78,6 @@ export class SCM extends Viewlet {
 	}
 
 	private _editContextSelector(): string {
-		return this.code.quality === Quality.Stable ? SCM_INPUT_TEXTAREA : SCM_INPUT_NATIVE_EDIT_CONTEXT;
+		return !this.code.editContextEnabled ? SCM_INPUT_TEXTAREA : SCM_INPUT_NATIVE_EDIT_CONTEXT;
 	}
 }

--- a/test/automation/src/settings.ts
+++ b/test/automation/src/settings.ts
@@ -7,7 +7,6 @@ import { Editor } from './editor';
 import { Editors } from './editors';
 import { Code } from './code';
 import { QuickAccess } from './quickaccess';
-import { Quality } from './application';
 
 const SEARCH_BOX_NATIVE_EDIT_CONTEXT = '.settings-editor .suggest-input-container .monaco-editor .native-edit-context';
 const SEARCH_BOX_TEXTAREA = '.settings-editor .suggest-input-container .monaco-editor textarea';
@@ -26,7 +25,7 @@ export class SettingsEditor {
 
 		await this.editors.selectTab('settings.json');
 		await this.code.sendKeybinding('right', () =>
-			this.editor.waitForEditorSelection('settings.json', (s) => this._acceptEditorSelection(this.code.quality, s)));
+			this.editor.waitForEditorSelection('settings.json', (s) => this._acceptEditorSelection(this.code.editContextEnabled, s)));
 		await this.editor.waitForTypeInEditor('settings.json', `"${setting}": ${value},`);
 		await this.editors.saveOpenedFile();
 	}
@@ -42,7 +41,7 @@ export class SettingsEditor {
 
 		await this.editors.selectTab('settings.json');
 		await this.code.sendKeybinding('right', () =>
-			this.editor.waitForEditorSelection('settings.json', (s) => this._acceptEditorSelection(this.code.quality, s)));
+			this.editor.waitForEditorSelection('settings.json', (s) => this._acceptEditorSelection(this.code.editContextEnabled, s)));
 		await this.editor.waitForTypeInEditor('settings.json', settings.map(v => `"${v[0]}": ${v[1]},`).join(''));
 		await this.editors.saveOpenedFile();
 	}
@@ -85,11 +84,11 @@ export class SettingsEditor {
 	}
 
 	private _editContextSelector() {
-		return this.code.quality === Quality.Stable ? SEARCH_BOX_TEXTAREA : SEARCH_BOX_NATIVE_EDIT_CONTEXT;
+		return !this.code.editContextEnabled ? SEARCH_BOX_TEXTAREA : SEARCH_BOX_NATIVE_EDIT_CONTEXT;
 	}
 
-	private _acceptEditorSelection(quality: Quality, s: { selectionStart: number; selectionEnd: number }): boolean {
-		if (quality === Quality.Stable) {
+	private _acceptEditorSelection(editContextEnabled: boolean, s: { selectionStart: number; selectionEnd: number }): boolean {
+		if (!editContextEnabled) {
 			return true;
 		}
 		return s.selectionStart === 1 && s.selectionEnd === 1;

--- a/test/smoke/src/areas/workbench/data-loss.test.ts
+++ b/test/smoke/src/areas/workbench/data-loss.test.ts
@@ -7,7 +7,7 @@ import { join } from 'path';
 import { Application, ApplicationOptions, Logger, Quality } from '../../../../automation';
 import { createApp, timeout, installDiagnosticsHandler, installAppAfterHandler, getRandomUserDataDir, suiteLogsPath, suiteCrashPath } from '../../utils';
 
-export function setup(ensureStableCode: () => string | undefined, logger: Logger) {
+export function setup(ensureStableCode: () => { stableCodePath: string | undefined; stableCodeVersion: { major: number; minor: number; patch: number } | undefined }, logger: Logger) {
 	describe('Data Loss (insiders -> insiders)', function () {
 
 		// Double the timeout since these tests involve 2 startups
@@ -146,7 +146,7 @@ export function setup(ensureStableCode: () => string | undefined, logger: Logger
 		installAppAfterHandler(() => insidersApp ?? stableApp, async () => stableApp?.stop());
 
 		it('verifies opened editors are restored', async function () {
-			const stableCodePath = ensureStableCode();
+			const { stableCodePath, stableCodeVersion } = ensureStableCode();
 			if (!stableCodePath) {
 				this.skip();
 			}
@@ -170,6 +170,7 @@ export function setup(ensureStableCode: () => string | undefined, logger: Logger
 			stableOptions.quality = Quality.Stable;
 			stableOptions.logsPath = logsPath;
 			stableOptions.crashesPath = crashesPath;
+			stableOptions.version = stableCodeVersion ?? { major: 0, minor: 0, patch: 0 };
 
 			stableApp = new Application(stableOptions);
 			await stableApp.start();
@@ -210,7 +211,7 @@ export function setup(ensureStableCode: () => string | undefined, logger: Logger
 		});
 
 		async function testHotExit(this: import('mocha').Context, title: string, restartDelay: number | undefined) {
-			const stableCodePath = ensureStableCode();
+			const { stableCodePath, stableCodeVersion } = ensureStableCode();
 			if (!stableCodePath) {
 				this.skip();
 			}
@@ -225,6 +226,7 @@ export function setup(ensureStableCode: () => string | undefined, logger: Logger
 			stableOptions.quality = Quality.Stable;
 			stableOptions.logsPath = logsPath;
 			stableOptions.crashesPath = crashesPath;
+			stableOptions.version = stableCodeVersion ?? { major: 0, minor: 0, patch: 0 };
 
 			stableApp = new Application(stableOptions);
 			await stableApp.start();

--- a/test/smoke/src/main.ts
+++ b/test/smoke/src/main.ts
@@ -322,6 +322,8 @@ async function ensureStableCode(): Promise<void> {
 			// VSCode/Code.exe (Windows) | VSCode/code (Linux)
 			stableCodePath = path.dirname(stableCodeExecutable);
 		}
+
+		opts['stable-version'] = parseVersion(stableVersion);
 	}
 
 	if (!fs.existsSync(stableCodePath)) {
@@ -352,6 +354,7 @@ before(async function () {
 
 	this.defaultOptions = {
 		quality,
+		version: parseVersion(version ?? '0.0.0'),
 		codePath: opts.build,
 		workspacePath,
 		userDataDir,
@@ -396,7 +399,7 @@ after(async function () {
 });
 
 describe(`VSCode Smoke Tests (${opts.web ? 'Web' : 'Electron'})`, () => {
-	if (!opts.web) { setupDataLossTests(() => opts['stable-build'] /* Do not change, deferred for a reason! */, logger); }
+	if (!opts.web) { setupDataLossTests(() => { return { stableCodePath: opts['stable-build'], stableCodeVersion: opts['stable-version'] } /* Do not change, deferred for a reason! */; }, logger); }
 	setupPreferencesTests(logger);
 	setupSearchTests(logger);
 	if (!opts.web) { setupNotebookTests(logger); }


### PR DESCRIPTION
For https://github.com/microsoft/vscode/issues/251022

Stable `<= 1.100` don't have editcontext enabled, so `Data Loss (stable -> insiders)` smoke tests when run on older stable needs to use the non editcontext path however there isn't a public way to get info on whether editcontext is enabled for a product without reading its settings but reading the settings from the automation has to deal with obtaining the editor element https://github.com/microsoft/vscode/blob/433220e98a439b35185da25b89976115a274b014/test/automation/src/settings.ts#L87-L89, **see the recursive problem here**. As a stop-gap solution I decided to do a hard coded checks based on version number in this PR, ideas welcome for better fixes.

/cc @aiday-mar @bpasero 