### PR TITLE
Revert "fix: smoke tests for stable with editcontext enabled (#251055)"

### DIFF
--- a/test/automation/src/editor.ts
+++ b/test/automation/src/editor.ts
@@ -6,6 +6,7 @@
 import { References } from './peek';
 import { Commands } from './workbench';
 import { Code } from './code';
+import { Quality } from './application';
 
 const RENAME_BOX = '.monaco-editor .monaco-editor.rename-box';
 const RENAME_INPUT = `${RENAME_BOX} .rename-input`;
@@ -106,7 +107,7 @@ export class Editor {
 	}
 
 	private _editContextSelector() {
-		return '.native-edit-context';
+		return this.code.quality === Quality.Stable ? 'textarea' : '.native-edit-context';
 	}
 
 	async waitForEditorContents(filename: string, accept: (contents: string) => boolean, selectorPrefix = ''): Promise<any> {

--- a/test/automation/src/editors.ts
+++ b/test/automation/src/editors.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { Quality } from './application';
 import { Code } from './code';
 
 export class Editors {
@@ -52,7 +53,7 @@ export class Editors {
 	}
 
 	async waitForActiveEditor(fileName: string, retryCount?: number): Promise<any> {
-		const selector = `.editor-instance .monaco-editor[data-uri$="${fileName}"] .native-edit-context`;
+		const selector = `.editor-instance .monaco-editor[data-uri$="${fileName}"] ${this.code.quality === Quality.Stable ? 'textarea' : '.native-edit-context'}`;
 		return this.code.waitForActiveElement(selector, retryCount);
 	}
 

--- a/test/automation/src/extensions.ts
+++ b/test/automation/src/extensions.ts
@@ -8,6 +8,7 @@ import { Code } from './code';
 import { ncp } from 'ncp';
 import { promisify } from 'util';
 import { Commands } from './workbench';
+import { Quality } from './application';
 import path = require('path');
 import fs = require('fs');
 
@@ -20,7 +21,7 @@ export class Extensions extends Viewlet {
 
 	async searchForExtension(id: string): Promise<any> {
 		await this.commands.runCommand('Extensions: Focus on Extensions View', { exactLabelMatch: true });
-		await this.code.waitForTypeInEditor(`div.extensions-viewlet[id="workbench.view.extensions"] .monaco-editor .native-edit-context`, `@id:${id}`);
+		await this.code.waitForTypeInEditor(`div.extensions-viewlet[id="workbench.view.extensions"] .monaco-editor ${this.code.quality === Quality.Stable ? 'textarea' : '.native-edit-context'}`, `@id:${id}`);
 		await this.code.waitForTextContent(`div.part.sidebar div.composite.title h2`, 'Extensions: Marketplace');
 
 		let retrials = 1;

--- a/test/automation/src/notebook.ts
+++ b/test/automation/src/notebook.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { Quality } from './application';
 import { Code } from './code';
 import { QuickAccess } from './quickaccess';
 import { QuickInput } from './quickinput';
@@ -46,7 +47,7 @@ export class Notebook {
 
 		await this.code.waitForElement(editor);
 
-		const editContext = `${editor} .native-edit-context`;
+		const editContext = `${editor} ${this.code.quality === Quality.Stable ? 'textarea' : '.native-edit-context'}`;
 		await this.code.waitForActiveElement(editContext);
 
 		await this.code.waitForTypeInEditor(editContext, text);


### PR DESCRIPTION
This reverts commit 433220e98a439b35185da25b89976115a274b014.

For https://dev.azure.com/monacotools/Monaco/_build/results?buildId=342070&view=results

Reland follow-up in https://github.com/microsoft/vscode/pull/251074
