### PR TITLE
Allow menu bar to get more space when there is no window title

### DIFF
--- a/src/vs/workbench/browser/parts/titlebar/media/titlebarpart.css
+++ b/src/vs/workbench/browser/parts/titlebar/media/titlebarpart.css
@@ -71,14 +71,14 @@
 	align-items: center;
 }
 
-.monaco-workbench .part.titlebar > .titlebar-container > .titlebar-left {
+.monaco-workbench .part.titlebar > .titlebar-container.has-center > .titlebar-left {
 	order: 0;
 	width: 20%;
 	flex-grow: 2;
 	justify-content: flex-start;
 }
 
-.monaco-workbench .part.titlebar > .titlebar-container > .titlebar-center {
+.monaco-workbench .part.titlebar > .titlebar-container.has-center > .titlebar-center {
 	order: 1;
 	width: 60%;
 	max-width: fit-content;
@@ -88,7 +88,7 @@
 	justify-content: center;
 }
 
-.monaco-workbench .part.titlebar > .titlebar-container > .titlebar-right {
+.monaco-workbench .part.titlebar > .titlebar-container.has-center > .titlebar-right {
 	order: 2;
 	width: 20%;
 	min-width: min-content;
@@ -96,7 +96,19 @@
 	justify-content: flex-end;
 }
 
+.monaco-workbench .part.titlebar > .titlebar-container:not(.has-center) > .titlebar-left {
+	flex: 1 1 0%;
+	min-width: 0;
+}
 
+.monaco-workbench .part.titlebar > .titlebar-container:not(.has-center) > .titlebar-center {
+	display: none;
+}
+
+.monaco-workbench .part.titlebar > .titlebar-container:not(.has-center) > .titlebar-right {
+	flex: 0 0 auto;
+	padding-left: 16px; /* ensure there is some space between title and controls */
+}
 
 /* Window title text */
 .monaco-workbench .part.titlebar > .titlebar-container > .titlebar-center > .window-title {

--- a/src/vs/workbench/browser/parts/titlebar/titlebarPart.ts
+++ b/src/vs/workbench/browser/parts/titlebar/titlebarPart.ts
@@ -568,6 +568,8 @@ export class BrowserTitlebarPart extends Part implements ITitlebarPart {
 						this.updateLayout(this.lastLayoutDimensions); // layout menubar and other renderings in the titlebar
 					}
 				}));
+			} else {
+				reset(this.title);
 			}
 		}
 
@@ -849,17 +851,22 @@ export class BrowserTitlebarPart extends Part implements ITitlebarPart {
 	private updateLayout(dimension: Dimension): void {
 		this.lastLayoutDimensions = dimension;
 
-		if (hasCustomTitlebar(this.configurationService, this.titleBarStyle)) {
-			const zoomFactor = getZoomFactor(getWindow(this.element));
-
-			this.element.style.setProperty('--zoom-factor', zoomFactor.toString());
-			this.rootContainer.classList.toggle('counter-zoom', this.preventZoom);
-
-			if (this.customMenubar.value) {
-				const menubarDimension = new Dimension(0, dimension.height);
-				this.customMenubar.value.layout(menubarDimension);
-			}
+		if (!hasCustomTitlebar(this.configurationService, this.titleBarStyle)) {
+			return;
 		}
+
+		const zoomFactor = getZoomFactor(getWindow(this.element));
+
+		this.element.style.setProperty('--zoom-factor', zoomFactor.toString());
+		this.rootContainer.classList.toggle('counter-zoom', this.preventZoom);
+
+		if (this.customMenubar.value) {
+			const menubarDimension = new Dimension(0, dimension.height);
+			this.customMenubar.value.layout(menubarDimension);
+		}
+
+		const hasCenter = this.isCommandCenterVisible || this.title.innerText !== '';
+		this.rootContainer.classList.toggle('has-center', hasCenter);
 	}
 
 	focus(): void {


### PR DESCRIPTION
```Copilot Generated Description:``` Adjust the layout of the title bar to provide more space for the menu bar when there is no window title, enhancing the overall user interface.

closes https://github.com/microsoft/vscode/issues/250832