### PR TITLE
support resource completions for `Git Bash`

### DIFF
--- a/extensions/terminal-suggest/src/terminalSuggestMain.ts
+++ b/extensions/terminal-suggest/src/terminalSuggestMain.ts
@@ -143,7 +143,6 @@ export async function activate(context: vscode.ExtensionContext) {
 			}
 
 			if (terminal.shellIntegration?.cwd && (result.filesRequested || result.foldersRequested)) {
-
 				return new vscode.TerminalCompletionList(result.items, { filesRequested: result.filesRequested, foldersRequested: result.foldersRequested, fileExtensions: result.fileExtensions, cwd: result.cwd ?? terminal.shellIntegration.cwd, env: terminal.shellIntegration?.env?.value, });
 			}
 			return result.items;

--- a/extensions/terminal-suggest/src/terminalSuggestMain.ts
+++ b/extensions/terminal-suggest/src/terminalSuggestMain.ts
@@ -143,7 +143,6 @@ export async function activate(context: vscode.ExtensionContext) {
 			}
 
 			if (terminal.shellIntegration?.cwd && (result.filesRequested || result.foldersRequested)) {
-				// vscode.env.remoteName
 
 				return new vscode.TerminalCompletionList(result.items, { filesRequested: result.filesRequested, foldersRequested: result.foldersRequested, fileExtensions: result.fileExtensions, cwd: result.cwd ?? terminal.shellIntegration.cwd, env: terminal.shellIntegration?.env?.value, });
 			}

--- a/extensions/terminal-suggest/src/terminalSuggestMain.ts
+++ b/extensions/terminal-suggest/src/terminalSuggestMain.ts
@@ -143,6 +143,8 @@ export async function activate(context: vscode.ExtensionContext) {
 			}
 
 			if (terminal.shellIntegration?.cwd && (result.filesRequested || result.foldersRequested)) {
+				// vscode.env.remoteName
+
 				return new vscode.TerminalCompletionList(result.items, { filesRequested: result.filesRequested, foldersRequested: result.foldersRequested, fileExtensions: result.fileExtensions, cwd: result.cwd ?? terminal.shellIntegration.cwd, env: terminal.shellIntegration?.env?.value, });
 			}
 			return result.items;

--- a/src/vs/workbench/api/common/extHostTerminalService.ts
+++ b/src/vs/workbench/api/common/extHostTerminalService.ts
@@ -18,7 +18,7 @@ import { serializeEnvironmentDescriptionMap, serializeEnvironmentVariableCollect
 import { CancellationTokenSource } from '../../../base/common/cancellation.js';
 import { generateUuid } from '../../../base/common/uuid.js';
 import { IEnvironmentVariableCollectionDescription, IEnvironmentVariableMutator, ISerializableEnvironmentVariableCollection } from '../../../platform/terminal/common/environmentVariable.js';
-import { ICreateContributedTerminalProfileOptions, IProcessReadyEvent, IShellLaunchConfigDto, ITerminalChildProcess, ITerminalLaunchError, ITerminalProfile, TerminalIcon, TerminalLocation, IProcessProperty, ProcessPropertyType, IProcessPropertyMap, TerminalShellType } from '../../../platform/terminal/common/terminal.js';
+import { ICreateContributedTerminalProfileOptions, IProcessReadyEvent, IShellLaunchConfigDto, ITerminalChildProcess, ITerminalLaunchError, ITerminalProfile, TerminalIcon, TerminalLocation, IProcessProperty, ProcessPropertyType, IProcessPropertyMap, TerminalShellType, WindowsShellType } from '../../../platform/terminal/common/terminal.js';
 import { TerminalDataBufferer } from '../../../platform/terminal/common/terminalDataBuffering.js';
 import { ThemeColor } from '../../../base/common/themables.js';
 import { Promises } from '../../../base/common/async.js';
@@ -27,6 +27,7 @@ import { TerminalCompletionList, TerminalQuickFix, ViewColumn } from './extHostT
 import { IExtHostCommands } from './extHostCommands.js';
 import { MarshalledId } from '../../../base/common/marshallingIds.js';
 import { ISerializedTerminalInstanceContext } from '../../contrib/terminal/common/terminal.js';
+import { isWindows } from '../../../base/common/platform.js';
 
 export interface IExtHostTerminalService extends ExtHostTerminalServiceShape, IDisposable {
 
@@ -776,7 +777,8 @@ export abstract class BaseExtHostTerminalService extends Disposable implements I
 		if (completions === null || completions === undefined) {
 			return undefined;
 		}
-		return TerminalCompletionList.from(completions);
+		const pathSeparator = !isWindows || this.activeTerminal.state?.shell === WindowsShellType.GitBash ? '/' : '\\';
+		return TerminalCompletionList.from(completions, pathSeparator);
 	}
 
 	public $acceptTerminalShellType(id: number, shellType: TerminalShellType | undefined): void {

--- a/src/vs/workbench/api/common/extHostTypeConverters.ts
+++ b/src/vs/workbench/api/common/extHostTypeConverters.ts
@@ -3204,7 +3204,7 @@ export namespace TerminalResourceRequestConfig {
 	export function from(resourceRequestConfig: vscode.TerminalResourceRequestConfig, pathSeparator: string): extHostProtocol.TerminalResourceRequestConfigDto {
 		return {
 			...resourceRequestConfig,
-			pathSeparator: pathSeparator,
+			pathSeparator,
 			cwd: resourceRequestConfig.cwd ? URI.revive(resourceRequestConfig.cwd) : undefined,
 		};
 	}

--- a/src/vs/workbench/api/common/extHostTypeConverters.ts
+++ b/src/vs/workbench/api/common/extHostTypeConverters.ts
@@ -16,7 +16,6 @@ import { parse, revive } from '../../../base/common/marshalling.js';
 import { MarshalledId } from '../../../base/common/marshallingIds.js';
 import { Mimes } from '../../../base/common/mime.js';
 import { cloneAndChange } from '../../../base/common/objects.js';
-import { isWindows } from '../../../base/common/platform.js';
 import { IPrefixTreeNode, WellDefinedPrefixTree } from '../../../base/common/prefixTree.js';
 import { basename } from '../../../base/common/resources.js';
 import { ThemeIcon } from '../../../base/common/themables.js';
@@ -3188,7 +3187,7 @@ export namespace TerminalCompletionItemDto {
 }
 
 export namespace TerminalCompletionList {
-	export function from(completions: vscode.TerminalCompletionList | vscode.TerminalCompletionItem[]): extHostProtocol.TerminalCompletionListDto {
+	export function from(completions: vscode.TerminalCompletionList | vscode.TerminalCompletionItem[], pathSeparator: string): extHostProtocol.TerminalCompletionListDto {
 		if (Array.isArray(completions)) {
 			return {
 				items: completions.map(i => TerminalCompletionItemDto.from(i)),
@@ -3196,16 +3195,16 @@ export namespace TerminalCompletionList {
 		}
 		return {
 			items: completions.items.map(i => TerminalCompletionItemDto.from(i)),
-			resourceRequestConfig: completions.resourceRequestConfig ? TerminalResourceRequestConfig.from(completions.resourceRequestConfig) : undefined,
+			resourceRequestConfig: completions.resourceRequestConfig ? TerminalResourceRequestConfig.from(completions.resourceRequestConfig, pathSeparator) : undefined,
 		};
 	}
 }
 
 export namespace TerminalResourceRequestConfig {
-	export function from(resourceRequestConfig: vscode.TerminalResourceRequestConfig): extHostProtocol.TerminalResourceRequestConfigDto {
+	export function from(resourceRequestConfig: vscode.TerminalResourceRequestConfig, pathSeparator: string): extHostProtocol.TerminalResourceRequestConfigDto {
 		return {
 			...resourceRequestConfig,
-			pathSeparator: isWindows ? '\\' : '/',
+			pathSeparator: pathSeparator,
 			cwd: resourceRequestConfig.cwd ? URI.revive(resourceRequestConfig.cwd) : undefined,
 		};
 	}

--- a/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalCompletionService.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalCompletionService.ts
@@ -248,7 +248,7 @@ export class TerminalCompletionService extends Disposable implements ITerminalCo
 		}
 
 		// The _complete_ folder of the last word. For example if the last word is `./src/file`,
-		// this will be `./src/`. this also always ends in the path separator if it is not the empty
+		// this will be `./src/`. This also always ends in the path separator if it is not the empty
 		// string and path separators are normalized on Windows.
 		let lastWordFolder = lastSlashIndex === -1 ? '' : lastWord.slice(0, lastSlashIndex + 1);
 		if (useWindowsStylePath) {

--- a/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalCompletionService.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalCompletionService.ts
@@ -282,7 +282,7 @@ export class TerminalCompletionService extends Disposable implements ITerminalCo
 			}
 			case 'absolute': {
 				if (shellType === WindowsShellType.GitBash) {
-					lastWordFolderResource = URI.file(gitBashPathToWindows(lastWordFolder));
+					lastWordFolderResource = URI.file(gitBashPathToWindows(lastWordFolder, this._processEnv.SystemDrive));
 				} else {
 					lastWordFolderResource = URI.file(lastWordFolder.replaceAll('\\ ', ' '));
 				}

--- a/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalCompletionService.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalCompletionService.ts
@@ -506,13 +506,13 @@ export class TerminalCompletionService extends Disposable implements ITerminalCo
 
 function getFriendlyPath(uri: URI, pathSeparator: string, kind: TerminalCompletionItemKind, shellType?: TerminalShellType): string {
 	let path = uri.fsPath;
-	pathSeparator = shellType === WindowsShellType.GitBash ? '\\' : pathSeparator;
+	const sep = shellType === WindowsShellType.GitBash ? '\\' : pathSeparator;
 	// Ensure folders end with the path separator to differentiate presentation from files
-	if (kind === TerminalCompletionItemKind.Folder && !path.endsWith(pathSeparator)) {
-		path += pathSeparator;
+	if (kind === TerminalCompletionItemKind.Folder && !path.endsWith(sep)) {
+		path += sep;
 	}
 	// Ensure drive is capitalized on Windows
-	if (pathSeparator === '\\' && path.match(/^[a-zA-Z]:\\/)) {
+	if (sep === '\\' && path.match(/^[a-zA-Z]:\\/)) {
 		path = `${path[0].toUpperCase()}:${path.slice(2)}`;
 	}
 	return path;

--- a/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalCompletionService.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalCompletionService.ts
@@ -538,9 +538,11 @@ function addPathRelativePrefix(text: string, resourceRequestConfig: Pick<Termina
  *   "/d/bar" => "D:\\bar"
  */
 export function gitBashPathToWindows(path: string): string {
+	// Dynamically determine the system drive (default to 'C:' if not set)
+	const systemDrive = (process.env.SystemDrive || 'C:').toUpperCase();
 	// Handle root "/"
 	if (path === '/') {
-		return 'C:\\';
+		return `${systemDrive}\\`;
 	}
 	const match = path.match(/^\/([a-zA-Z])(\/.*)?$/);
 	if (match) {

--- a/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalCompletionService.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalCompletionService.ts
@@ -17,6 +17,7 @@ import { TerminalCompletionItemKind, type ITerminalCompletion } from './terminal
 import { env as processEnv } from '../../../../../base/common/process.js';
 import type { IProcessEnvironment } from '../../../../../base/common/platform.js';
 import { timeout } from '../../../../../base/common/async.js';
+import { gitBashPathToWindows } from './terminalGitBashHelpers.js';
 
 export const ITerminalCompletionService = createDecorator<ITerminalCompletionService>('terminalCompletionService');
 
@@ -527,42 +528,4 @@ function addPathRelativePrefix(text: string, resourceRequestConfig: Pick<Termina
 		return `.${resourceRequestConfig.pathSeparator}${text}`;
 	}
 	return text;
-}
-
-/**
- * Converts a Git Bash absolute path to a Windows absolute path.
- * Examples:
- *   "/"      => "C:\\"
- *   "/c/"    => "C:\\"
- *   "/c/Users/foo" => "C:\\Users\\foo"
- *   "/d/bar" => "D:\\bar"
- */
-export function gitBashPathToWindows(path: string): string {
-	// Dynamically determine the system drive (default to 'C:' if not set)
-	const systemDrive = (process.env.SystemDrive || 'C:').toUpperCase();
-	// Handle root "/"
-	if (path === '/') {
-		return `${systemDrive}\\`;
-	}
-	const match = path.match(/^\/([a-zA-Z])(\/.*)?$/);
-	if (match) {
-		const drive = match[1].toUpperCase();
-		const rest = match[2] ? match[2].replace(/\//g, '\\') : '\\';
-		return `${drive}:${rest}`;
-	}
-	// Fallback: just replace slashes
-	return path.replace(/\//g, '\\');
-}
-
-/**
- *
- * @param path A Windows-style absolute path (e.g., "C:\Users\foo").
- * Converts it to a Git Bash-style absolute path (e.g., "/c/Users/foo").
- * @returns The Git Bash-style absolute path.
- */
-export function windowsToGitBashPath(path: string): string {
-	// Convert Windows path (e.g. C:\Users\foo) to Git Bash path (e.g. /c/Users/foo)
-	return path
-		.replace(/^[a-zA-Z]:\\/, match => `/${match[0].toLowerCase()}/`)
-		.replace(/\\/g, '/');
 }

--- a/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalGitBashHelpers.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalGitBashHelpers.ts
@@ -1,0 +1,42 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Converts a Git Bash absolute path to a Windows absolute path.
+ * Examples:
+ *   "/"      => "C:\\"
+ *   "/c/"    => "C:\\"
+ *   "/c/Users/foo" => "C:\\Users\\foo"
+ *   "/d/bar" => "D:\\bar"
+ */
+export function gitBashPathToWindows(path: string): string {
+	// Dynamically determine the system drive (default to 'C:' if not set)
+	const systemDrive = (process.env.SystemDrive || 'C:').toUpperCase();
+	// Handle root "/"
+	if (path === '/') {
+		return `${systemDrive}\\`;
+	}
+	const match = path.match(/^\/([a-zA-Z])(\/.*)?$/);
+	if (match) {
+		const drive = match[1].toUpperCase();
+		const rest = match[2] ? match[2].replace(/\//g, '\\') : '\\';
+		return `${drive}:${rest}`;
+	}
+	// Fallback: just replace slashes
+	return path.replace(/\//g, '\\');
+}
+
+/**
+ *
+ * @param path A Windows-style absolute path (e.g., "C:\Users\foo").
+ * Converts it to a Git Bash-style absolute path (e.g., "/c/Users/foo").
+ * @returns The Git Bash-style absolute path.
+ */
+export function windowsToGitBashPath(path: string): string {
+	// Convert Windows path (e.g. C:\Users\foo) to Git Bash path (e.g. /c/Users/foo)
+	return path
+		.replace(/^[a-zA-Z]:\\/, match => `/${match[0].toLowerCase()}/`)
+		.replace(/\\/g, '/');
+}

--- a/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalGitBashHelpers.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalGitBashHelpers.ts
@@ -11,9 +11,9 @@
  *   "/c/Users/foo" => "C:\\Users\\foo"
  *   "/d/bar" => "D:\\bar"
  */
-export function gitBashPathToWindows(path: string): string {
+export function gitBashPathToWindows(path: string, driveLetter?: string): string {
 	// Dynamically determine the system drive (default to 'C:' if not set)
-	const systemDrive = (process.env.SystemDrive || 'C:').toUpperCase();
+	const systemDrive = (driveLetter || 'C:').toUpperCase();
 	// Handle root "/"
 	if (path === '/') {
 		return `${systemDrive}\\`;

--- a/src/vs/workbench/contrib/terminalContrib/suggest/test/browser/terminalCompletionService.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/test/browser/terminalCompletionService.test.ts
@@ -36,7 +36,8 @@ interface IAssertionCommandLineConfig {
 /**
  * Assert the set of completions exist exactly, including their order.
  */
-function assertCompletions(actual: ITerminalCompletion[] | undefined, expected: IAssertionTerminalCompletion[], expectedConfig: IAssertionCommandLineConfig, noAlterations?: boolean) {
+function assertCompletions(actual: ITerminalCompletion[] | undefined, expected: IAssertionTerminalCompletion[], expectedConfig: IAssertionCommandLineConfig, pathSep?: string) {
+	const sep = pathSep ?? pathSeparator;
 	assert.deepStrictEqual(
 		actual?.map(e => ({
 			label: e.label,
@@ -45,8 +46,8 @@ function assertCompletions(actual: ITerminalCompletion[] | undefined, expected: 
 			replacementIndex: e.replacementIndex,
 			replacementLength: e.replacementLength,
 		})), expected.map(e => ({
-			label: noAlterations ? e.label : e.label.replaceAll('/', pathSeparator),
-			detail: noAlterations ? e.detail : e.detail ? e.detail.replaceAll('/', pathSeparator) : '',
+			label: e.label.replaceAll('/', sep),
+			detail: e.detail ? e.detail.replaceAll('/', sep) : '',
 			kind: e.kind ?? TerminalCompletionItemKind.Folder,
 			replacementIndex: expectedConfig.replacementIndex,
 			replacementLength: expectedConfig.replacementLength,
@@ -646,7 +647,7 @@ suite('TerminalCompletionService', () => {
 				{ label: './bar/', detail: 'C:\\Users\\foo\\bar\\' },
 				{ label: './baz.txt', detail: 'C:\\Users\\foo\\baz.txt', kind: TerminalCompletionItemKind.File },
 				{ label: './../', detail: 'C:\\Users\\' }
-			], { replacementIndex: 0, replacementLength: 2 }, true);
+			], { replacementIndex: 0, replacementLength: 2 }, '/');
 		});
 
 		test('resolveResources with cwd as Windows path (absolute)', async () => {
@@ -670,7 +671,7 @@ suite('TerminalCompletionService', () => {
 				{ label: '/c/Users/foo/', detail: 'C:\\Users\\foo\\' },
 				{ label: '/c/Users/foo/bar/', detail: 'C:\\Users\\foo\\bar\\' },
 				{ label: '/c/Users/foo/baz.txt', detail: 'C:\\Users\\foo\\baz.txt', kind: TerminalCompletionItemKind.File },
-			], { replacementIndex: 0, replacementLength: 13 }, true);
+			], { replacementIndex: 0, replacementLength: 13 }, '/');
 		});
 	});
 });

--- a/src/vs/workbench/contrib/terminalContrib/suggest/test/browser/terminalCompletionService.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/test/browser/terminalCompletionService.test.ts
@@ -5,7 +5,7 @@
 
 import { URI } from '../../../../../../base/common/uri.js';
 import { IFileService, IFileStatWithMetadata, IResolveMetadataFileOptions } from '../../../../../../platform/files/common/files.js';
-import { gitBashPathToWindows, TerminalCompletionService, TerminalResourceRequestConfig, windowsToGitBashPath } from '../../browser/terminalCompletionService.js';
+import { TerminalCompletionService, TerminalResourceRequestConfig } from '../../browser/terminalCompletionService.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
 import assert, { fail } from 'assert';
 import { isWindows, type IProcessEnvironment } from '../../../../../../base/common/platform.js';
@@ -19,6 +19,7 @@ import { TerminalCapability } from '../../../../../../platform/terminal/common/c
 import { ITerminalCompletion, TerminalCompletionItemKind } from '../../browser/terminalCompletionItem.js';
 import { count } from '../../../../../../base/common/strings.js';
 import { WindowsShellType } from '../../../../../../platform/terminal/common/terminal.js';
+import { gitBashPathToWindows, windowsToGitBashPath } from '../../browser/terminalGitBashHelpers.js';
 
 const pathSeparator = isWindows ? '\\' : '/';
 

--- a/src/vs/workbench/contrib/terminalContrib/suggest/test/browser/terminalCompletionService.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/test/browser/terminalCompletionService.test.ts
@@ -611,67 +611,69 @@ suite('TerminalCompletionService', () => {
 		});
 	});
 
-	suite('gitbash', () => {
-		test('should convert Git Bash absolute path to Windows absolute path', () => {
-			assert.strictEqual(gitBashPathToWindows('/'), 'C:\\');
-			assert.strictEqual(gitBashPathToWindows('/c/'), 'C:\\');
-			assert.strictEqual(gitBashPathToWindows('/c/Users/foo'), 'C:\\Users\\foo');
-			assert.strictEqual(gitBashPathToWindows('/d/bar'), 'D:\\bar');
-		});
+	if (isWindows) {
+		suite('gitbash', () => {
+			test('should convert Git Bash absolute path to Windows absolute path', () => {
+				assert.strictEqual(gitBashPathToWindows('/'), 'C:\\');
+				assert.strictEqual(gitBashPathToWindows('/c/'), 'C:\\');
+				assert.strictEqual(gitBashPathToWindows('/c/Users/foo'), 'C:\\Users\\foo');
+				assert.strictEqual(gitBashPathToWindows('/d/bar'), 'D:\\bar');
+			});
 
-		test('should convert Windows absolute path to Git Bash absolute path', () => {
-			assert.strictEqual(windowsToGitBashPath('C:\\'), '/c/');
-			assert.strictEqual(windowsToGitBashPath('C:\\Users\\foo'), '/c/Users/foo');
-			assert.strictEqual(windowsToGitBashPath('D:\\bar'), '/d/bar');
-			assert.strictEqual(windowsToGitBashPath('E:\\some\\path'), '/e/some/path');
-		});
-		test('resolveResources with cwd as Windows path (relative)', async () => {
-			const resourceRequestConfig: TerminalResourceRequestConfig = {
-				cwd: URI.file('C:\\Users\\foo'),
-				foldersRequested: true,
-				filesRequested: true,
-				pathSeparator: '/'
-			};
-			validResources = [
-				URI.file('C:\\Users\\foo'),
-				URI.file('C:\\Users\\foo\\bar'),
-				URI.file('C:\\Users\\foo\\baz.txt')
-			];
-			childResources = [
-				{ resource: URI.file('C:\\Users\\foo\\bar'), isDirectory: true },
-				{ resource: URI.file('C:\\Users\\foo\\baz.txt'), isFile: true }
-			];
-			const result = await terminalCompletionService.resolveResources(resourceRequestConfig, './', 2, provider, capabilities, WindowsShellType.GitBash);
-			assertCompletions(result, [
-				{ label: './', detail: 'C:\\Users\\foo\\' },
-				{ label: './bar/', detail: 'C:\\Users\\foo\\bar\\' },
-				{ label: './baz.txt', detail: 'C:\\Users\\foo\\baz.txt', kind: TerminalCompletionItemKind.File },
-				{ label: './../', detail: 'C:\\Users\\' }
-			], { replacementIndex: 0, replacementLength: 2 }, '/');
-		});
+			test('should convert Windows absolute path to Git Bash absolute path', () => {
+				assert.strictEqual(windowsToGitBashPath('C:\\'), '/c/');
+				assert.strictEqual(windowsToGitBashPath('C:\\Users\\foo'), '/c/Users/foo');
+				assert.strictEqual(windowsToGitBashPath('D:\\bar'), '/d/bar');
+				assert.strictEqual(windowsToGitBashPath('E:\\some\\path'), '/e/some/path');
+			});
+			test('resolveResources with cwd as Windows path (relative)', async () => {
+				const resourceRequestConfig: TerminalResourceRequestConfig = {
+					cwd: URI.file('C:\\Users\\foo'),
+					foldersRequested: true,
+					filesRequested: true,
+					pathSeparator: '/'
+				};
+				validResources = [
+					URI.file('C:\\Users\\foo'),
+					URI.file('C:\\Users\\foo\\bar'),
+					URI.file('C:\\Users\\foo\\baz.txt')
+				];
+				childResources = [
+					{ resource: URI.file('C:\\Users\\foo\\bar'), isDirectory: true },
+					{ resource: URI.file('C:\\Users\\foo\\baz.txt'), isFile: true }
+				];
+				const result = await terminalCompletionService.resolveResources(resourceRequestConfig, './', 2, provider, capabilities, WindowsShellType.GitBash);
+				assertCompletions(result, [
+					{ label: './', detail: 'C:\\Users\\foo\\' },
+					{ label: './bar/', detail: 'C:\\Users\\foo\\bar\\' },
+					{ label: './baz.txt', detail: 'C:\\Users\\foo\\baz.txt', kind: TerminalCompletionItemKind.File },
+					{ label: './../', detail: 'C:\\Users\\' }
+				], { replacementIndex: 0, replacementLength: 2 }, '/');
+			});
 
-		test('resolveResources with cwd as Windows path (absolute)', async () => {
-			const resourceRequestConfig: TerminalResourceRequestConfig = {
-				cwd: URI.file('C:\\Users\\foo'),
-				foldersRequested: true,
-				filesRequested: true,
-				pathSeparator: '/'
-			};
-			validResources = [
-				URI.file('C:\\Users\\foo'),
-				URI.file('C:\\Users\\foo\\bar'),
-				URI.file('C:\\Users\\foo\\baz.txt')
-			];
-			childResources = [
-				{ resource: URI.file('C:\\Users\\foo\\bar'), isDirectory: true },
-				{ resource: URI.file('C:\\Users\\foo\\baz.txt'), isFile: true }
-			];
-			const result = await terminalCompletionService.resolveResources(resourceRequestConfig, '/c/Users/foo/', 13, provider, capabilities, WindowsShellType.GitBash);
-			assertCompletions(result, [
-				{ label: '/c/Users/foo/', detail: 'C:\\Users\\foo\\' },
-				{ label: '/c/Users/foo/bar/', detail: 'C:\\Users\\foo\\bar\\' },
-				{ label: '/c/Users/foo/baz.txt', detail: 'C:\\Users\\foo\\baz.txt', kind: TerminalCompletionItemKind.File },
-			], { replacementIndex: 0, replacementLength: 13 }, '/');
+			test('resolveResources with cwd as Windows path (absolute)', async () => {
+				const resourceRequestConfig: TerminalResourceRequestConfig = {
+					cwd: URI.file('C:\\Users\\foo'),
+					foldersRequested: true,
+					filesRequested: true,
+					pathSeparator: '/'
+				};
+				validResources = [
+					URI.file('C:\\Users\\foo'),
+					URI.file('C:\\Users\\foo\\bar'),
+					URI.file('C:\\Users\\foo\\baz.txt')
+				];
+				childResources = [
+					{ resource: URI.file('C:\\Users\\foo\\bar'), isDirectory: true },
+					{ resource: URI.file('C:\\Users\\foo\\baz.txt'), isFile: true }
+				];
+				const result = await terminalCompletionService.resolveResources(resourceRequestConfig, '/c/Users/foo/', 13, provider, capabilities, WindowsShellType.GitBash);
+				assertCompletions(result, [
+					{ label: '/c/Users/foo/', detail: 'C:\\Users\\foo\\' },
+					{ label: '/c/Users/foo/bar/', detail: 'C:\\Users\\foo\\bar\\' },
+					{ label: '/c/Users/foo/baz.txt', detail: 'C:\\Users\\foo\\baz.txt', kind: TerminalCompletionItemKind.File },
+				], { replacementIndex: 0, replacementLength: 13 }, '/');
+			});
 		});
-	});
+	}
 });


### PR DESCRIPTION
fixes #248559 

This pull request introduces support for handling Git Bash paths in the terminal completion service for relative and absolute paths. Key changes include the addition of path conversion utilities, updates to the terminal completion logic, and new test cases for Git Bash path handling and completions.

We convert from git bash style path to window style path to resolve the folders/files on the filesystem and convert to git bash style paths for labels of the completion items, providing the file system path as a detail.

<img width="766" alt="{2CADF100-5829-4EE9-9FF8-59E87EB78C31}" src="https://github.com/user-attachments/assets/dfff4f65-f3c7-40ba-bb56-712171d6b9c6" />
