### PR TITLE
more certainty for resuming the paused emitter

### DIFF
--- a/extensions/ipynb/src/test/clearOutputs.test.ts
+++ b/extensions/ipynb/src/test/clearOutputs.test.ts
@@ -25,7 +25,7 @@ suite(`ipynb Clear Outputs`, () => {
 		await vscode.commands.executeCommand('workbench.action.closeAllEditors');
 	});
 
-	test.skip('Clear outputs after opening Notebook', async () => {
+	test('Clear outputs after opening Notebook', async () => {
 		const cells: nbformat.ICell[] = [
 			{
 				cell_type: 'code',

--- a/src/vs/workbench/api/common/extHostNotebook.ts
+++ b/src/vs/workbench/api/common/extHostNotebook.ts
@@ -327,7 +327,7 @@ export class ExtHostNotebookController implements ExtHostNotebookShape {
 		}
 
 		if (document.versionId !== versionId) {
-			throw new Error('Document version mismatch');
+			throw new Error('Document version mismatch, expected: ' + versionId + ', actual: ' + document.versionId);
 		}
 
 		if (!this._extHostFileSystem.value.isWritableFileSystem(uri.scheme)) {


### PR DESCRIPTION
fix https://github.com/microsoft/vscode/issues/244288

The only way I can see this happening is if we pause the emitter and then throw before getting into the try, or while in the finally before resuming. 
This change just adds another try/finally that is solely responsible for resuming the emitter.
 
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
