### PR TITLE
de-dupe terminal suggest commands for which there are specs

### DIFF
--- a/extensions/terminal-suggest/src/terminalSuggestMain.ts
+++ b/extensions/terminal-suggest/src/terminalSuggestMain.ts
@@ -266,7 +266,9 @@ export async function getCompletionItemsFromSpecs(
 		const labels = new Set(items.map((i) => typeof i.label === 'string' ? i.label : i.label.label));
 		for (const command of availableCommands) {
 			const commandTextLabel = typeof command.label === 'string' ? command.label : command.label.label;
-			if (!labels.has(commandTextLabel)) {
+			// Remove any file extension for matching on Windows
+			const labelWithoutExtension = isWindows ? commandTextLabel.replace(/\.[^ ]+$/, '') : commandTextLabel;
+			if (!labels.has(labelWithoutExtension)) {
 				items.push(createCompletionItem(
 					terminalContext.cursorPosition,
 					prefix,


### PR DESCRIPTION
fix #244918

Before:

<img width="417" alt="{AC140EB7-9F3B-406A-B3A0-291FC73EE93B}" src="https://github.com/user-attachments/assets/c5e0ddc9-1c7c-47ed-adf9-074ccdcc4d22" />

After:

![{7772E996-A48F-4D0B-AD91-30EEC9CB4D40}](https://github.com/user-attachments/assets/f499e195-a4e1-49c3-ae19-b08d360bb092)

cc @tyriar