### PR TITLE
support builtin commands for git bash

### DIFF
--- a/extensions/terminal-suggest/src/terminalSuggestMain.ts
+++ b/extensions/terminal-suggest/src/terminalSuggestMain.ts
@@ -58,6 +58,7 @@ for (const spec of upstreamSpecs) {
 const getShellSpecificGlobals: Map<TerminalShellType, (options: ExecOptionsWithStringEncoding, existingCommands?: Set<string>) => Promise<(string | ICompletionResource)[]>> = new Map([
 	[TerminalShellType.Bash, getBashGlobals],
 	[TerminalShellType.Zsh, getZshGlobals],
+	[TerminalShellType.GitBash, getBashGlobals], // Git Bash is a bash shell
 	// TODO: Ghost text in the command line prevents completions from working ATM for fish
 	[TerminalShellType.Fish, getFishGlobals],
 	[TerminalShellType.PowerShell, getPwshGlobals],
@@ -72,7 +73,11 @@ async function getShellGlobals(shellType: TerminalShellType, existingCommands?: 
 		if (!shellType) {
 			return;
 		}
-		const options: ExecOptionsWithStringEncoding = { encoding: 'utf-8', shell: shellType };
+		let execShellType = shellType;
+		if (shellType === TerminalShellType.GitBash) {
+			execShellType = TerminalShellType.Bash; // Git Bash is a bash shell
+		}
+		const options: ExecOptionsWithStringEncoding = { encoding: 'utf-8', shell: execShellType, windowsHide: true };
 		const mixedCommands: (string | ICompletionResource)[] | undefined = await getShellSpecificGlobals.get(shellType)?.(options, existingCommands);
 		const normalizedCommands = mixedCommands?.map(command => typeof command === 'string' ? ({ label: command }) : command);
 		cachedGlobals.set(shellType, normalizedCommands);


### PR DESCRIPTION
fix #248558

The issue was we were passing in `gitbash` as the `shell` to `exec`. The fix is to pass in `bash` in that case.

<img width="939" alt="{38A9C12E-8DA9-4EDF-86DF-A4CBD1AB4FC7}" src="https://github.com/user-attachments/assets/18f88125-91d6-4dbb-aa46-c48705121bb2" />

cc @tyriar