### PR TITLE
don't add `\` if path already starts with that on pwsh for suggestions

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalCompletionService.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalCompletionService.ts
@@ -525,6 +525,9 @@ function getFriendlyPath(uri: URI, pathSeparator: string, kind: TerminalCompleti
  */
 function addPathRelativePrefix(text: string, resourceRequestConfig: Pick<TerminalResourceRequestConfig, 'pathSeparator'>, lastWordFolderHasDotPrefix: boolean): string {
 	if (!lastWordFolderHasDotPrefix) {
+		if (text.startsWith(resourceRequestConfig.pathSeparator)) {
+			return `.${text}`;
+		}
 		return `.${resourceRequestConfig.pathSeparator}${text}`;
 	}
 	return text;


### PR DESCRIPTION
fix #251217

Before:

<img width="541" alt="{D2C08262-A5EB-45FE-A0FF-016757AEDD83}" src="https://github.com/user-attachments/assets/62205233-c090-4219-9cca-601d6cce2af2" />

After:

<img width="699" alt="{CADAD28E-B210-46D7-8114-ED2CDDD94627}" src="https://github.com/user-attachments/assets/eda809ec-04ae-4303-893d-f6d2fdbd069e" />

cc @Tyriar 