### PR TITLE
Fix markdown preview scroll crawls at EOF (fix #249278)

### DIFF
--- a/extensions/markdown-language-features/preview-src/scroll-sync.ts
+++ b/extensions/markdown-language-features/preview-src/scroll-sync.ts
@@ -156,7 +156,6 @@ export function scrollToRevealSourceLine(line: number, documentVersion: number, 
 		const progressInElement = line - Math.floor(line);
 		scrollTo = previousTop + (rect.height * progressInElement);
 	}
-	scrollTo = Math.abs(scrollTo) < 1 ? Math.sign(scrollTo) : scrollTo;
 	window.scroll(window.scrollX, Math.max(1, window.scrollY + scrollTo));
 }
 


### PR DESCRIPTION
Fix scrolling of markdown preview at EOF. This PR fixes #249278.

* Remove logic that causes scroll errors.

### Cause
* At EOF, scroll synchronization is performed every time a character is typed.
* At EOF, the calculated `scrollTo` is very small, less than 1, but the postprocessing scrolls more than necessary.
  This causes errors again, and to reduce this error, `scrollTo` is set in the opposite direction again.
* This eventually repeats with every typing, occurs a "crawls" issue.

### Resolve
1. First, I removed the logic that causes errors.

2. I checked the history at the time by finding the PR and Issue where the code was written. (457acf8, #111094)
  The code was originally written intentionally to fix an old another scrolling issue.
  However, I tested it myself, and the issue that was there before is no longer occurring.

### Test
I have tested this PR with the document referenced by previous contributors https://github.com/jlelong/LaTeX-Workshop-wiki/blob/master/Hover.md.

#### Before
![before](https://github.com/user-attachments/assets/1e81af21-8599-44d5-b056-bf75af4adce1)

#### After
![after](https://github.com/user-attachments/assets/82e5f7cb-d3de-4b03-bc29-44a1f1cf14ed)

#### Test previous issue
![test-old-issue](https://github.com/user-attachments/assets/f416d72e-5d85-4553-965e-721b484f9360)
