### PR TITLE
Misc MCP Auth fixes

### DIFF
--- a/src/vs/base/test/common/oauth.test.ts
+++ b/src/vs/base/test/common/oauth.test.ts
@@ -11,7 +11,7 @@ import {
 	getMetadataWithDefaultValues,
 	isAuthorizationAuthorizeResponse,
 	isAuthorizationDeviceResponse,
-	isAuthorizationDeviceTokenErrorResponse,
+	isAuthorizationErrorResponse,
 	isAuthorizationDynamicClientRegistrationResponse,
 	isAuthorizationProtectedResourceMetadata,
 	isAuthorizationServerMetadata,
@@ -138,43 +138,42 @@ suite('OAuth', () => {
 			assert.strictEqual(isAuthorizationDeviceResponse('not an object'), false);
 		});
 
-		test('isAuthorizationDeviceTokenErrorResponse should correctly identify device token error response', () => {
+		test('isAuthorizationErrorResponse should correctly identify error response', () => {
 			// Valid error response
-			assert.strictEqual(isAuthorizationDeviceTokenErrorResponse({
+			assert.strictEqual(isAuthorizationErrorResponse({
 				error: 'authorization_pending',
 				error_description: 'The authorization request is still pending'
 			}), true);
 
 			// Valid error response with different error codes
-			assert.strictEqual(isAuthorizationDeviceTokenErrorResponse({
+			assert.strictEqual(isAuthorizationErrorResponse({
 				error: 'slow_down',
 				error_description: 'Polling too fast'
 			}), true);
 
-			assert.strictEqual(isAuthorizationDeviceTokenErrorResponse({
+			assert.strictEqual(isAuthorizationErrorResponse({
 				error: 'access_denied',
 				error_description: 'The user denied the request'
 			}), true);
 
-			assert.strictEqual(isAuthorizationDeviceTokenErrorResponse({
+			assert.strictEqual(isAuthorizationErrorResponse({
 				error: 'expired_token',
 				error_description: 'The device code has expired'
 			}), true);
 
 			// Valid response with optional error_uri
-			assert.strictEqual(isAuthorizationDeviceTokenErrorResponse({
+			assert.strictEqual(isAuthorizationErrorResponse({
 				error: 'invalid_request',
 				error_description: 'The request is missing a required parameter',
 				error_uri: 'https://example.com/error'
 			}), true);
 
 			// Invalid cases
-			assert.strictEqual(isAuthorizationDeviceTokenErrorResponse(null), false);
-			assert.strictEqual(isAuthorizationDeviceTokenErrorResponse(undefined), false);
-			assert.strictEqual(isAuthorizationDeviceTokenErrorResponse({}), false);
-			assert.strictEqual(isAuthorizationDeviceTokenErrorResponse({ error: 'missing-description' }), false);
-			assert.strictEqual(isAuthorizationDeviceTokenErrorResponse({ error_description: 'missing-error' }), false);
-			assert.strictEqual(isAuthorizationDeviceTokenErrorResponse('not an object'), false);
+			assert.strictEqual(isAuthorizationErrorResponse(null), false);
+			assert.strictEqual(isAuthorizationErrorResponse(undefined), false);
+			assert.strictEqual(isAuthorizationErrorResponse({}), false);
+			assert.strictEqual(isAuthorizationErrorResponse({ error_description: 'missing-error' }), false);
+			assert.strictEqual(isAuthorizationErrorResponse('not an object'), false);
 		});
 	});
 

--- a/src/vs/workbench/api/common/extHostAuthentication.ts
+++ b/src/vs/workbench/api/common/extHostAuthentication.ts
@@ -186,7 +186,7 @@ export class ExtHostAuthentication implements ExtHostAuthenticationShape {
 				throw new Error('Server does not support dynamic registration');
 			}
 			try {
-				const registration = await fetchDynamicRegistration(serverMetadata.registration_endpoint, this._initData.environment.appName);
+				const registration = await fetchDynamicRegistration(serverMetadata.registration_endpoint, this._initData.environment.appName, resourceMetadata?.scopes_supported);
 				clientId = registration.client_id;
 			} catch (err) {
 				throw new Error(`Dynamic registration failed: ${err.message}`);

--- a/src/vs/workbench/api/node/extHostAuthentication.ts
+++ b/src/vs/workbench/api/node/extHostAuthentication.ts
@@ -73,7 +73,7 @@ class LoopbackAuthServer implements ILoopbackServer {
 					const state = reqUrl.searchParams.get('state') ?? undefined;
 					const error = reqUrl.searchParams.get('error') ?? undefined;
 					if (error) {
-						res.writeHead(302, { location: `/?error=${reqUrl.searchParams.get('error_description')}` });
+						res.writeHead(302, { location: `/done?error=${reqUrl.searchParams.get('error_description') || error}` });
 						res.end();
 						deferredPromise.error(new Error(error));
 						break;
@@ -84,19 +84,19 @@ class LoopbackAuthServer implements ILoopbackServer {
 						break;
 					}
 					if (this.state !== state) {
-						res.writeHead(302, { location: `/?error=${encodeURIComponent('State does not match.')}` });
+						res.writeHead(302, { location: `/done?error=${encodeURIComponent('State does not match.')}` });
 						res.end();
 						deferredPromise.error(new Error('State does not match.'));
 						break;
 					}
 					deferredPromise.complete({ code, state });
-					res.writeHead(302, { location: '/success' });
+					res.writeHead(302, { location: '/done' });
 					res.end();
 					break;
 				}
 				// Serve the static files
-				case '/success':
-					this._sendSuccessPage(res);
+				case '/done':
+					this._sendPage(res);
 					break;
 				default:
 					res.writeHead(404);
@@ -114,7 +114,7 @@ class LoopbackAuthServer implements ILoopbackServer {
 		return `http://127.0.0.1:${this._port}/`;
 	}
 
-	private _sendSuccessPage(res: http.ServerResponse): void {
+	private _sendPage(res: http.ServerResponse): void {
 		const html = getHtml(this._appUri);
 		res.writeHead(200, {
 			'Content-Type': 'text/html',
@@ -147,11 +147,8 @@ class LoopbackAuthServer implements ILoopbackServer {
 		this._server.on('error', err => {
 			if ('code' in err && err.code === 'EADDRINUSE') {
 				this._logger.error('Address in use, retrying with a different port...');
-				setTimeout(() => {
-					this._server.close();
-					// Best effort to use a specific port, but fallback to a random one if it is in use
-					this._server.listen(0, '127.0.0.1');
-				}, 1000);
+				// Best effort to use a specific port, but fallback to a random one if it is in use
+				this._server.listen(0, '127.0.0.1');
 				return;
 			}
 			clearTimeout(portTimeout);
@@ -232,11 +229,13 @@ export class NodeDynamicAuthProvider extends DynamicAuthProvider {
 			});
 		}
 
-		// Add device code flow support (works in all environments)
-		this._createFlows.push({
-			label: nls.localize('device code', "Device Code"),
-			handler: (scopes, progress, token) => this._createWithDeviceCode(scopes, progress, token)
-		});
+		// Add device code flow to the end since it's not as streamlined
+		if (serverMetadata.device_authorization_endpoint) {
+			this._createFlows.push({
+				label: nls.localize('device code', "Device Code"),
+				handler: (scopes, progress, token) => this._createWithDeviceCode(scopes, progress, token)
+			});
+		}
 	}
 
 	private async _createWithLoopbackServer(scopes: string[], progress: vscode.Progress<IProgressStep>, token: vscode.CancellationToken): Promise<IAuthorizationTokenResponse> {


### PR DESCRIPTION
1. only do device code flow if the server supports it
2. fix route in loopback server where error cases were going to `/` which was a typo
3. fix port listening in loopback when default port is taken
4. some servers require registration to have scopes, so passed that through
5. some types clean up

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
