### PR TITLE
Don't revive URI before sending from ext to main

### DIFF
--- a/extensions/terminal-suggest/src/terminalSuggestMain.ts
+++ b/extensions/terminal-suggest/src/terminalSuggestMain.ts
@@ -148,13 +148,13 @@ export async function activate(context: vscode.ExtensionContext) {
 			}
 
 			if (terminal.shellIntegration?.cwd && (result.filesRequested || result.foldersRequested)) {
-				let cwd;
-				if (vscode.env.remoteName) {
-					cwd = vscode.Uri.file((result.cwd ?? terminal.shellIntegration.cwd).path).with({ authority: vscode.env.remoteName, scheme: 'vscode-remote' });
-				} else {
-					cwd = vscode.Uri.file((result.cwd ?? terminal.shellIntegration.cwd).fsPath);
-				}
-				return new vscode.TerminalCompletionList(result.items, { filesRequested: result.filesRequested, foldersRequested: result.foldersRequested, fileExtensions: result.fileExtensions, cwd, env: terminal.shellIntegration?.env?.value, });
+				return new vscode.TerminalCompletionList(result.items, {
+					filesRequested: result.filesRequested,
+					foldersRequested: result.foldersRequested,
+					fileExtensions: result.fileExtensions,
+					cwd: result.cwd ?? terminal.shellIntegration.cwd,
+					env: terminal.shellIntegration?.env?.value,
+				});
 			}
 			return result.items;
 		}

--- a/src/vs/workbench/api/common/extHostTypeConverters.ts
+++ b/src/vs/workbench/api/common/extHostTypeConverters.ts
@@ -3205,7 +3205,7 @@ export namespace TerminalResourceRequestConfig {
 		return {
 			...resourceRequestConfig,
 			pathSeparator,
-			cwd: resourceRequestConfig.cwd ? URI.revive(resourceRequestConfig.cwd) : undefined,
+			cwd: resourceRequestConfig.cwd,
 		};
 	}
 }


### PR DESCRIPTION
Fixes #235331

Tested on TestResolver and is converted from vscode-local to file, so I think it should work for wsl.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

cc @aeschli 