### PR TITLE
add `resolveSymlinkTarget` option to `fileService.resolve` to support resolving the realpath for terminal completions

### DIFF
--- a/src/vs/platform/files/common/fileService.ts
+++ b/src/vs/platform/files/common/fileService.ts
@@ -249,7 +249,7 @@ export class FileService extends Disposable implements IFileService {
 	private async toFileStat(provider: IFileSystemProvider, resource: URI, stat: IStat | { type: FileType } & Partial<IStat>, siblings: number | undefined, resolveMetadata: boolean, resolveSymlinkTarget: boolean, recurse: (stat: IFileStat, siblings?: number) => boolean): Promise<IFileStat> {
 		const { providerExtUri } = this.getExtUri(provider);
 
-		if (resource.path && resolveSymlinkTarget && (stat.type & FileType.SymbolicLink) === 0) {
+		if (resource.path && resolveSymlinkTarget && (stat.type & FileType.SymbolicLink) !== 0) {
 			try {
 				const resolvedSymlinkStat = await provider.realpath?.(resource);
 				if (resolvedSymlinkStat) {

--- a/src/vs/platform/files/common/fileService.ts
+++ b/src/vs/platform/files/common/fileService.ts
@@ -251,7 +251,7 @@ export class FileService extends Disposable implements IFileService {
 
 		if (resource.path && resolveSymlinkTarget && (stat.type & FileType.SymbolicLink) !== 0) {
 			try {
-				const resolvedSymlinkStat = await provider.realpath?.(resource);
+				const resolvedSymlinkStat = await provider.stat?.(resource);
 				if (resolvedSymlinkStat) {
 					stat = resolvedSymlinkStat;
 				}

--- a/src/vs/platform/files/common/files.ts
+++ b/src/vs/platform/files/common/files.ts
@@ -657,6 +657,7 @@ export interface IFileSystemProvider {
 
 	readFile?(resource: URI): Promise<Uint8Array>;
 	writeFile?(resource: URI, content: Uint8Array, opts: IFileWriteOptions): Promise<void>;
+	realpath?(resource: URI): Promise<IStat>;
 
 	readFileStream?(resource: URI, opts: IFileReadStreamOptions, token: CancellationToken): ReadableStreamEvents<Uint8Array>;
 
@@ -1373,6 +1374,11 @@ export interface IResolveFileOptions {
 	 * on performance and thus should only be used when these values are required.
 	 */
 	readonly resolveMetadata?: boolean;
+
+	/**
+	 * Will resolve the target of symbolic links if enabled.
+	 */
+	readonly resolveSymlinkTarget?: boolean;
 }
 
 export interface IResolveMetadataFileOptions extends IResolveFileOptions {

--- a/src/vs/platform/files/common/files.ts
+++ b/src/vs/platform/files/common/files.ts
@@ -494,6 +494,11 @@ export interface IStat {
 	 * The file permissions.
 	 */
 	readonly permissions?: FilePermission;
+
+	/**
+	 * The symbolic link target if the file is a symbolic link.
+	 */
+	readonly symbolicLinkTarget?: string;
 }
 
 export interface IWatchOptionsWithoutCorrelation {
@@ -1267,6 +1272,7 @@ export interface IFileStatWithMetadata extends IFileStat, IBaseFileStatWithMetad
 	readonly size: number;
 	readonly readonly: boolean;
 	readonly locked: boolean;
+	readonly symbolicLinkTarget?: string;
 	readonly children: IFileStatWithMetadata[] | undefined;
 }
 

--- a/src/vs/platform/files/node/diskFileSystemProvider.ts
+++ b/src/vs/platform/files/node/diskFileSystemProvider.ts
@@ -503,7 +503,7 @@ export class DiskFileSystemProvider extends AbstractDiskFileSystemProvider imple
 		} finally {
 			if (lockForHandle) {
 				if (this.mapHandleToLock.get(fd) === lockForHandle) {
-					this.traceLock(`[DiskFileSystemProvider]: close() - resource lock removed from handle-lock map ${fd}`);
+					this.traceLock(`[Disk FileSystemProvider]: close() - resource lock removed from handle-lock map ${fd}`);
 					this.mapHandleToLock.delete(fd); // only delete from map if this is still our lock!
 				}
 

--- a/src/vs/platform/files/node/diskFileSystemProvider.ts
+++ b/src/vs/platform/files/node/diskFileSystemProvider.ts
@@ -461,7 +461,7 @@ export class DiskFileSystemProvider extends AbstractDiskFileSystemProvider imple
 			// wise we end up in a deadlock situation
 			// https://github.com/microsoft/vscode/issues/142462
 			if (previousLock) {
-				this.traceLock(`[DiskFileSystemProvider]: open() - disposing a previous lock that was still stored on same handle ${fd} (${filePath})`);
+				this.traceLock(`[Disk FileSystemProvider]: open() - disposing a previous lock that was still stored on same handle ${fd} (${filePath})`);
 				previousLock.dispose();
 			}
 		}

--- a/src/vs/platform/files/node/diskFileSystemProvider.ts
+++ b/src/vs/platform/files/node/diskFileSystemProvider.ts
@@ -507,7 +507,7 @@ export class DiskFileSystemProvider extends AbstractDiskFileSystemProvider imple
 					this.mapHandleToLock.delete(fd); // only delete from map if this is still our lock!
 				}
 
-				this.traceLock(`[DiskFileSystemProvider]: close() - disposing lock for handle ${fd}`);
+				this.traceLock(`[Disk FileSystemProvider]: close() - disposing lock for handle ${fd}`);
 				lockForHandle.dispose();
 			}
 		}

--- a/src/vs/platform/files/node/diskFileSystemProvider.ts
+++ b/src/vs/platform/files/node/diskFileSystemProvider.ts
@@ -25,7 +25,6 @@ import { ILogService } from '../../log/common/log.js';
 import { AbstractDiskFileSystemProvider, IDiskFileSystemProviderOptions } from '../common/diskFileSystemProvider.js';
 import { UniversalWatcherClient } from './watcher/watcherClient.js';
 import { NodeJSWatcherClient } from './watcher/nodejs/nodejsClient.js';
-import { realpath } from '../../../base/node/extpath.js';
 
 export class DiskFileSystemProvider extends AbstractDiskFileSystemProvider implements
 	IFileSystemProviderWithFileReadWriteCapability,
@@ -210,17 +209,6 @@ export class DiskFileSystemProvider extends AbstractDiskFileSystemProvider imple
 		} finally {
 			lock?.dispose();
 		}
-	}
-
-	/**
-	 *
-	 * @param resource the resource to resolve the real path for
-	 * @returns a promise that resolves to the stat of the resolved path
-	 */
-	async realpath(resource: URI): Promise<IStat> {
-		const resolvedPath = await realpath(resource.path);
-		const stat = await this.stat(URI.file(resolvedPath));
-		return stat;
 	}
 
 	private traceLock(msg: string): void {

--- a/src/vs/platform/files/test/node/fixtures/service/symlink/realpath.txt
+++ b/src/vs/platform/files/test/node/fixtures/service/symlink/realpath.txt
@@ -1,0 +1,1 @@
+This is the real target file for symlink realpath testing.

--- a/src/vs/platform/files/test/node/fixtures/service/symlink/symlink.txt
+++ b/src/vs/platform/files/test/node/fixtures/service/symlink/symlink.txt
@@ -1,0 +1,1 @@
+realpath.txt

--- a/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalCompletionService.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalCompletionService.ts
@@ -313,7 +313,7 @@ export class TerminalCompletionService extends Disposable implements ITerminalCo
 			return resourceCompletions;
 		}
 
-		const stat = await this._fileService.resolve(lastWordFolderResource, { resolveSingleChildDescendants: true });
+		const stat = await this._fileService.resolve(lastWordFolderResource, { resolveSingleChildDescendants: true, resolveSymlinkTarget: true });
 		if (!stat?.children) {
 			return;
 		}
@@ -417,7 +417,7 @@ export class TerminalCompletionService extends Disposable implements ITerminalCo
 						const cdPathEntries = cdPath.split(useWindowsStylePath ? ';' : ':');
 						for (const cdPathEntry of cdPathEntries) {
 							try {
-								const fileStat = await this._fileService.resolve(URI.file(cdPathEntry), { resolveSingleChildDescendants: true });
+								const fileStat = await this._fileService.resolve(URI.file(cdPathEntry), { resolveSingleChildDescendants: true, resolveSymlinkTarget: true });
 								if (fileStat?.children) {
 									for (const child of fileStat.children) {
 										if (!child.isDirectory) {


### PR DESCRIPTION
fix #239409

