### PR TITLE
feat: add keybindings to toggle settings UI

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/preferences.contribution.ts
+++ b/src/vs/workbench/contrib/preferences/browser/preferences.contribution.ts
@@ -1316,6 +1316,11 @@ class SettingsEditorTitleContribution extends Disposable implements IWorkbenchCo
 						id: '_workbench.openUserSettingsEditor',
 						title: OPEN_USER_SETTINGS_UI_TITLE,
 						icon: preferencesOpenSettingsIcon,
+						keybinding: {
+							weight: KeybindingWeight.WorkbenchContrib + 1,
+							when: openUserSettingsEditorWhen,
+							primary: KeyMod.CtrlCmd | KeyCode.Comma,
+						},
 						menu: [{
 							id: MenuId.EditorTitle,
 							when: openUserSettingsEditorWhen,
@@ -1338,13 +1343,18 @@ class SettingsEditorTitleContribution extends Disposable implements IWorkbenchCo
 			registerOpenUserSettingsEditorFromJsonAction();
 		}));
 
-		const openSettingsJsonWhen = ContextKeyExpr.and(CONTEXT_SETTINGS_JSON_EDITOR.toNegated(), CONTEXT_SETTINGS_EDITOR);
+		const openSettingsJsonWhen = CONTEXT_SETTINGS_EDITOR;
 		this._register(registerAction2(class extends Action2 {
 			constructor() {
 				super({
 					id: SETTINGS_EDITOR_COMMAND_SWITCH_TO_JSON,
 					title: nls.localize2('openSettingsJson', "Open Settings (JSON)"),
 					icon: preferencesOpenSettingsIcon,
+					keybinding: {
+						weight: KeybindingWeight.WorkbenchContrib + 1,
+						when: openSettingsJsonWhen,
+						primary: KeyMod.CtrlCmd | KeyCode.Comma,
+					},
 					menu: [{
 						id: MenuId.EditorTitle,
 						when: openSettingsJsonWhen,
@@ -1417,7 +1427,7 @@ function getEditorGroupFromArguments(accessor: ServicesAccessor, args: unknown[]
 
 registerWorkbenchContribution2(PreferencesActionsContribution.ID, PreferencesActionsContribution, WorkbenchPhase.BlockStartup);
 registerWorkbenchContribution2(PreferencesContribution.ID, PreferencesContribution, WorkbenchPhase.BlockStartup);
-registerWorkbenchContribution2(SettingsEditorTitleContribution.ID, SettingsEditorTitleContribution, WorkbenchPhase.AfterRestored);
+registerWorkbenchContribution2(SettingsEditorTitleContribution.ID, SettingsEditorTitleContribution, WorkbenchPhase.BlockStartup);
 
 registerEditorContribution(SettingsEditorContribution.ID, SettingsEditorContribution, EditorContributionInstantiation.AfterFirstRender);
 


### PR DESCRIPTION
This PR adds keybindings to toggle between the Settings editor and settings.json file.

I see a few issues with this PR and wanted to request some feedback.

1. I couldn't get the keybindings to appear in the keybindings editor until I changed SettingsEditorTitleContribution to block startup. This issue is similar to https://github.com/microsoft/vscode/issues/159875.

2. CONTEXT_SETTINGS_JSON_EDITOR isn't actually set anywhere. Instead, I currently use a much longer context key expression, openUserSettingsEditorWhen, around line 1306. I'd like to double-check whether that large context key could cause perf issues, and if so, get the JSON editor context key working properly, first.

3. I had to set the new keybinding weights to be +1 to prevent SETTINGS_COMMAND_OPEN_SETTINGS, which has no when clause, from always stealing the keybinds. I'm thinking that fixing up CONTEXT_SETTINGS_JSON_EDITOR and using it would be a better solution, but is there something else I should try?
