### PR TITLE
Fix terminal icon picker issues

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminalIconPicker.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalIconPicker.ts
@@ -11,6 +11,7 @@ import { Disposable } from '../../../../base/common/lifecycle.js';
 import type { ThemeIcon } from '../../../../base/common/themables.js';
 import { IHoverService } from '../../../../platform/hover/browser/hover.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
+import { ILayoutService } from '../../../../platform/layout/browser/layoutService.js';
 import { defaultInputBoxStyles } from '../../../../platform/theme/browser/defaultStyles.js';
 import { getIconRegistry, IconContribution } from '../../../../platform/theme/common/iconRegistry.js';
 import { WorkbenchIconSelectBox } from '../../../services/userDataProfile/browser/iconSelectBox.js';
@@ -39,7 +40,8 @@ export class TerminalIconPicker extends Disposable {
 
 	constructor(
 		@IInstantiationService instantiationService: IInstantiationService,
-		@IHoverService private readonly _hoverService: IHoverService
+		@IHoverService private readonly _hoverService: IHoverService,
+		@ILayoutService private readonly _layoutService: ILayoutService,
 	) {
 		super();
 
@@ -64,7 +66,7 @@ export class TerminalIconPicker extends Disposable {
 				target: {
 					targetElements: [body],
 					x: bodyRect.left + (bodyRect.width - dimension.width) / 2,
-					y: bodyRect.top
+					y: bodyRect.top + this._layoutService.activeContainerOffset.quickPickTop - 2
 				},
 				position: {
 					hoverPosition: HoverPosition.BELOW,

--- a/src/vs/workbench/contrib/terminal/browser/terminalIconPicker.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalIconPicker.ts
@@ -45,8 +45,7 @@ export class TerminalIconPicker extends Disposable {
 
 		this._iconSelectBox = instantiationService.createInstance(WorkbenchIconSelectBox, {
 			icons: icons.value,
-			inputBoxStyles: defaultInputBoxStyles,
-			showIconInfo: true
+			inputBoxStyles: defaultInputBoxStyles
 		});
 	}
 
@@ -58,18 +57,21 @@ export class TerminalIconPicker extends Disposable {
 				this._iconSelectBox.dispose();
 			}));
 			this._iconSelectBox.clearInput();
+			const body = getActiveDocument().body;
+			const bodyRect = body.getBoundingClientRect();
 			const hoverWidget = this._hoverService.showInstantHover({
 				content: this._iconSelectBox.domNode,
-				target: getActiveDocument().body,
+				target: {
+					targetElements: [body],
+					x: bodyRect.left + (bodyRect.width - dimension.width) / 2,
+					y: bodyRect.top
+				},
 				position: {
 					hoverPosition: HoverPosition.BELOW,
 				},
 				persistence: {
 					sticky: true,
 				},
-				appearance: {
-					showPointer: true
-				}
 			}, true);
 			if (hoverWidget) {
 				this._register(hoverWidget);


### PR DESCRIPTION
Fixes #251428

![image](https://github.com/user-attachments/assets/9ebaee64-a2db-4b4c-9aed-a384ff31312c)


@sandy081 I still think `showIconInfo` adds value as it's the only way to know what you're filtering on, but I'm removing to align with profiles. It was the only use.