### PR TITLE
Make sure command finished event is fired when chat agent runs a command

### DIFF
--- a/src/vs/platform/terminal/common/capabilities/partialCommandDetectionCapability.ts
+++ b/src/vs/platform/terminal/common/capabilities/partialCommandDetectionCapability.ts
@@ -33,6 +33,14 @@ export class PartialCommandDetectionCapability extends DisposableStore implement
 		private readonly _terminal: Terminal,
 	) {
 		super();
+		this.add(this._terminal.onWriteParsed(e => {
+			if (
+				// Cursor has reset after the write
+				this._terminal.buffer.active.cursorX === 0
+			) {
+				this._onEnter();
+			}
+		}));
 		this.add(this._terminal.onData(e => this._onData(e)));
 		this.add(this._terminal.parser.registerCsiHandler({ final: 'J' }, params => {
 			if (params.length >= 1 && (params[0] === 2 || params[0] === 3)) {

--- a/src/vs/platform/terminal/common/capabilities/partialCommandDetectionCapability.ts
+++ b/src/vs/platform/terminal/common/capabilities/partialCommandDetectionCapability.ts
@@ -33,14 +33,6 @@ export class PartialCommandDetectionCapability extends DisposableStore implement
 		private readonly _terminal: Terminal,
 	) {
 		super();
-		this.add(this._terminal.onWriteParsed(e => {
-			if (
-				// Cursor has reset after the write
-				this._terminal.buffer.active.cursorX === 0
-			) {
-				this._onEnter();
-			}
-		}));
 		this.add(this._terminal.onData(e => this._onData(e)));
 		this.add(this._terminal.parser.registerCsiHandler({ final: 'J' }, params => {
 			if (params.length >= 1 && (params[0] === 2 || params[0] === 3)) {
@@ -52,7 +44,7 @@ export class PartialCommandDetectionCapability extends DisposableStore implement
 	}
 
 	private _onData(data: string): void {
-		if (data === '\x0d') {
+		if (data.includes('\x0d')) {
 			this._onEnter();
 		}
 	}


### PR DESCRIPTION
When the `Basic` shell integration strategy is chosen due to either a screen reader being present when using pwsh (which lacks PSReadline support) or some other clashing configuration, `partialCommandDetectionCapability` vs `CommandDetectionCapability` is used. 

`RunInTerminalTool` relies on `onDidEndTerminalShellExecution` firing in order to consider the terminal command running step completed. If that does not occur, the tool will continue to hang and wait for a `done` event that never comes. 

`onDidEndTerminalShellExecution` waits for `onCommandFinished` to be fired from its capability. In the case of the `partialCommandDetectionCapability`, that happens only `onEnter` IE when enter is sent to the terminal. That **does not occur** when the chat agent sends the command, so no `onCommandFinished` gets fired and thus chat hangs and never believes the command has completed even though it has. 

The fix is to also listen to `onWriteParsed` and check for if the `cursorX === 0`, IE the cursor has reset after a write has happened, thus the command has finished.

Repro I used to verify:
Enable NVDA on windows and screen reader mode. Set the default terminal profile to pwsh. Instruct chat agent to run `ls` in the terminal. Watch it hang and never complete. Same steps using this PR allows it to complete, see screenshot below. Also verified this PR doesn't cause issues when not in screen reader mode. I believe this will fix other peoples' reports too, captured in other issues.

![image](https://github.com/user-attachments/assets/912ad6e2-d7c4-402f-8965-6eab41940ad7)

fix #251436