### PR TITLE
fix: PowerShell not working with username having Unicode

### DIFF
--- a/src/vs/platform/shell/node/shellEnv.ts
+++ b/src/vs/platform/shell/node/shellEnv.ts
@@ -139,7 +139,7 @@ async function doResolveShellEnv(logService: ILogService, token: CancellationTok
 		// Older versions of PowerShell removes double quotes sometimes
 		// so we use "double single quotes" which is how you escape single
 		// quotes inside of a single quoted string.
-		command = `Write-Output '${mark}'; [System.Environment]::GetEnvironmentVariables() | ConvertTo-Json -Compress; Write-Output '${mark}'`;
+		command = `chcp 65001; Write-Output '${mark}'; [System.Environment]::GetEnvironmentVariables() | ConvertTo-Json -Compress; Write-Output '${mark}'`;
 
 		// -Login is not a supported argument on PowerShell 5, which is a version of
 		// powershell that is exclusive to Windows. Providing it would error. Also,


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
Fixes #251478
On some computers, the default encoding of PowerShell is not utf8, which will cause the Unicode characters in the obtained environment variables to become garbled. Here we first set the encoding to utf8 to fix this issue.