### PR TITLE
Don't render text when the view is hidden

### DIFF
--- a/src/vs/editor/browser/view.ts
+++ b/src/vs/editor/browser/view.ts
@@ -568,7 +568,7 @@ export class View extends ViewEventHandler {
 				inputLatency.onRenderStart();
 			},
 			renderText: (): [ViewPart[], RenderingContext] | null => {
-				if (!this.domNode.domNode.isConnected) {
+				if (!this.domNode.domNode.isConnected || !this.domNode.domNode.offsetParent) {
 					return null;
 				}
 				let viewPartsToRender = this._getViewPartsToRender();


### PR DESCRIPTION
Currently, there is a check in [view.ts](https://github.com/microsoft/vscode/blob/a1d87f0f27f8bd53900e7cbcc2c22d42909b6a2e/src/vs/editor/browser/view.ts#L571) that avoids rendering text when the view node is not connected. This PR proposes to add another simple check that would avoid rendering text when the view node is hidden.

It would be useful for Monaco adopters such as Eclipse Theia, which have an editor lifecycle that differs from the editor lifecycle in the VS Code workbench. As such, it should make Monaco more reusable outside VS Code.

Please see https://github.com/eclipse-theia/theia/pull/15500#issuecomment-2931415910 for some background.

Thank you!