### PR TITLE
remove special dot character from prompt test names

### DIFF
--- a/src/vs/workbench/contrib/chat/test/common/promptSyntax/codecs/base/markdownDecoder.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/promptSyntax/codecs/base/markdownDecoder.test.ts
@@ -242,7 +242,7 @@ suite('MarkdownDecoder', () => {
 						'The "characterName" must be set, got "empty line".',
 					);
 
-					test(`• stop character - "${characterName}"`, async () => {
+					test(`stop character - "${characterName}"`, async () => {
 						const test = testDisposables.add(
 							new TestMarkdownDecoder(),
 						);
@@ -334,7 +334,7 @@ suite('MarkdownDecoder', () => {
 						'The "characterName" must be set, got "empty line".',
 					);
 
-					test(`• stop character - "${characterName}"`, async () => {
+					test(`stop character - "${characterName}"`, async () => {
 						const test = testDisposables.add(
 							new TestMarkdownDecoder(),
 						);
@@ -583,7 +583,7 @@ suite('MarkdownDecoder', () => {
 						'The "characterName" must be set, got "empty line".',
 					);
 
-					test(`• stop character - "${characterName}"`, async () => {
+					test(`stop character - "${characterName}"`, async () => {
 						const test = testDisposables.add(
 							new TestMarkdownDecoder(),
 						);
@@ -678,7 +678,7 @@ suite('MarkdownDecoder', () => {
 						'The "characterName" must be set, got "empty line".',
 					);
 
-					test(`• stop character - "${characterName}"`, async () => {
+					test(`stop character - "${characterName}"`, async () => {
 						const test = testDisposables.add(
 							new TestMarkdownDecoder(),
 						);

--- a/src/vs/workbench/contrib/chat/test/common/promptSyntax/parsers/textModelPromptParser.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/promptSyntax/parsers/textModelPromptParser.test.ts
@@ -290,9 +290,9 @@ suite('TextModelPromptParser', () => {
 	});
 
 	suite('header', () => {
-		suite(' • metadata', () => {
-			suite(' • instructions', () => {
-				test(`• empty header`, async () => {
+		suite('metadata', () => {
+			suite('instructions', () => {
+				test(`empty header`, async () => {
 					const test = createTest(
 						URI.file('/absolute/folder/and/a/filename.txt'),
 						[
@@ -335,7 +335,7 @@ suite('TextModelPromptParser', () => {
 					);
 				});
 
-				test(`• has correct 'instructions' metadata`, async () => {
+				test(`has correct 'instructions' metadata`, async () => {
 					const test = createTest(
 						URI.file('/absolute/folder/and/a/filename.instructions.md'),
 						[
@@ -392,8 +392,8 @@ suite('TextModelPromptParser', () => {
 				});
 			});
 
-			suite(' • prompts', () => {
-				test(`• empty header`, async () => {
+			suite('prompts', () => {
+				test(`empty header`, async () => {
 					const test = createTest(
 						URI.file('/absolute/folder/and/a/filename.txt'),
 						[
@@ -436,7 +436,7 @@ suite('TextModelPromptParser', () => {
 					);
 				});
 
-				test(`• has correct 'prompt' metadata`, async () => {
+				test(`has correct 'prompt' metadata`, async () => {
 					const test = createTest(
 						URI.file('/absolute/folder/and/a/filename.txt'),
 						[
@@ -494,8 +494,8 @@ suite('TextModelPromptParser', () => {
 				});
 			});
 
-			suite(' • modes', () => {
-				test(`• empty header`, async () => {
+			suite('modes', () => {
+				test(`empty header`, async () => {
 					const test = createTest(
 						URI.file('/absolute/folder/and/a/filename.txt'),
 						[
@@ -538,7 +538,7 @@ suite('TextModelPromptParser', () => {
 					);
 				});
 
-				test(`• has correct metadata`, async () => {
+				test(`has correct metadata`, async () => {
 					const test = createTest(
 						URI.file('/absolute/folder/and/a/filename.txt'),
 						[

--- a/src/vs/workbench/contrib/chat/test/common/promptSyntax/utils/promptFilesLocator.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/promptSyntax/utils/promptFilesLocator.test.ts
@@ -292,7 +292,7 @@ suite('PromptFilesLocator', () => {
 					];
 
 					for (const setting of settings) {
-						test(`• '${setting}'`, async () => {
+						test(`'${setting}'`, async () => {
 							const locator = await createPromptsLocator(
 								{ [setting]: true },
 								EMPTY_WORKSPACE,
@@ -350,7 +350,7 @@ suite('PromptFilesLocator', () => {
 					}
 				});
 
-				suite(`• specific`, () => {
+				suite(`specific`, () => {
 					const testSettings = [
 						[
 							'/Users/legomushroom/repos/vscode/**/*specific*',
@@ -443,7 +443,7 @@ suite('PromptFilesLocator', () => {
 					];
 
 					for (const settings of testSettings) {
-						test(`• '${JSON.stringify(settings)}'`, async () => {
+						test(`'${JSON.stringify(settings)}'`, async () => {
 							const vscodeSettings: Record<string, boolean> = {};
 							for (const setting of settings) {
 								vscodeSettings[setting] = true;
@@ -536,7 +536,7 @@ suite('PromptFilesLocator', () => {
 					];
 
 					for (const setting of testSettings) {
-						test(`• '${setting}'`, async () => {
+						test(`'${setting}'`, async () => {
 							const locator = await createPromptsLocator(
 								{ [setting]: true },
 								['/Users/legomushroom/repos/vscode'],
@@ -594,7 +594,7 @@ suite('PromptFilesLocator', () => {
 					}
 				});
 
-				suite(`• specific`, () => {
+				suite(`specific`, () => {
 					const testSettings = [
 						[
 							'**/*specific*',
@@ -687,7 +687,7 @@ suite('PromptFilesLocator', () => {
 					];
 
 					for (const settings of testSettings) {
-						test(`• '${JSON.stringify(settings)}'`, async () => {
+						test(`'${JSON.stringify(settings)}'`, async () => {
 							const vscodeSettings: Record<string, boolean> = {};
 							for (const setting of settings) {
 								vscodeSettings[setting] = true;
@@ -776,7 +776,7 @@ suite('PromptFilesLocator', () => {
 					];
 
 					for (const setting of settings) {
-						test(`• '${setting}'`, async () => {
+						test(`'${setting}'`, async () => {
 							const locator = await createPromptsLocator(
 								{ [setting]: true },
 								['/Users/legomushroom/repos/vscode'],
@@ -834,7 +834,7 @@ suite('PromptFilesLocator', () => {
 					}
 				});
 
-				suite(`• specific`, () => {
+				suite(`specific`, () => {
 					const testSettings = [
 						[
 							'/Users/legomushroom/repos/vscode/**/*specific*',
@@ -927,7 +927,7 @@ suite('PromptFilesLocator', () => {
 					];
 
 					for (const settings of testSettings) {
-						test(`• '${JSON.stringify(settings)}'`, async () => {
+						test(`'${JSON.stringify(settings)}'`, async () => {
 							const vscodeSettings: Record<string, boolean> = {};
 							for (const setting of settings) {
 								vscodeSettings[setting] = true;
@@ -1687,7 +1687,7 @@ suite('PromptFilesLocator', () => {
 					];
 
 					for (const setting of testSettings) {
-						test(`• '${setting}'`, async () => {
+						test(`'${setting}'`, async () => {
 							const locator = await createPromptsLocator(
 								{ [setting]: true },
 								[
@@ -1773,7 +1773,7 @@ suite('PromptFilesLocator', () => {
 					}
 				});
 
-				suite(`• specific`, () => {
+				suite(`specific`, () => {
 					const testSettings = [
 						[
 							'**/my.prompt.md',
@@ -1888,7 +1888,7 @@ suite('PromptFilesLocator', () => {
 					];
 
 					for (const settings of testSettings) {
-						test(`• '${JSON.stringify(settings)}'`, async () => {
+						test(`'${JSON.stringify(settings)}'`, async () => {
 							const vscodeSettings: Record<string, boolean> = {};
 							for (const setting of settings) {
 								vscodeSettings[setting] = true;
@@ -2018,7 +2018,7 @@ suite('PromptFilesLocator', () => {
 					];
 
 					for (const setting of testSettings) {
-						test(`• '${setting}'`, async () => {
+						test(`'${setting}'`, async () => {
 							const locator = await createPromptsLocator(
 								{ [setting]: true },
 								[
@@ -2104,7 +2104,7 @@ suite('PromptFilesLocator', () => {
 					}
 				});
 
-				suite(`• specific`, () => {
+				suite(`specific`, () => {
 					const testSettings = [
 						[
 							'/Users/legomushroom/repos/**/my.prompt.md',
@@ -2249,7 +2249,7 @@ suite('PromptFilesLocator', () => {
 					];
 
 					for (const settings of testSettings) {
-						test(`• '${JSON.stringify(settings)}'`, async () => {
+						test(`'${JSON.stringify(settings)}'`, async () => {
 							const vscodeSettings: Record<string, boolean> = {};
 							for (const setting of settings) {
 								vscodeSettings[setting] = true;


### PR DESCRIPTION
Looks strange on Windows:
![image](https://github.com/user-attachments/assets/933a70d1-6a13-4e83-b816-45b6e1db1014)

