### PR TITLE
Support icons with commands for inline suggestions

### DIFF
--- a/src/vs/editor/common/languages.ts
+++ b/src/vs/editor/common/languages.ts
@@ -852,7 +852,7 @@ export interface InlineCompletions<TItem extends InlineCompletion = InlineComple
 	/**
 	 * A list of commands associated with the inline completions of this list.
 	 */
-	readonly commands?: Command[];
+	readonly commands?: InlineCompletionCommand[];
 
 	readonly suppressSuggestions?: boolean | undefined;
 
@@ -861,6 +861,8 @@ export interface InlineCompletions<TItem extends InlineCompletion = InlineComple
 	 */
 	readonly enableForwardStability?: boolean | undefined;
 }
+
+export type InlineCompletionCommand = { command: Command; icon?: ThemeIcon };
 
 export type InlineCompletionProviderGroupId = string;
 

--- a/src/vs/editor/contrib/inlineCompletions/browser/hintsWidget/inlineCompletionsHintsWidget.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/hintsWidget/inlineCompletionsHintsWidget.ts
@@ -30,7 +30,7 @@ import { registerIcon } from '../../../../../platform/theme/common/iconRegistry.
 import { ContentWidgetPositionPreference, ICodeEditor, IContentWidget, IContentWidgetPosition } from '../../../../browser/editorBrowser.js';
 import { EditorOption } from '../../../../common/config/editorOptions.js';
 import { Position } from '../../../../common/core/position.js';
-import { Command, InlineCompletionTriggerKind, InlineCompletionWarning } from '../../../../common/languages.js';
+import { InlineCompletionCommand, InlineCompletionTriggerKind, InlineCompletionWarning } from '../../../../common/languages.js';
 import { PositionAffinity } from '../../../../common/model.js';
 import { showNextInlineSuggestionActionId, showPreviousInlineSuggestionActionId } from '../controller/commandIds.js';
 import { InlineCompletionsModel } from '../model/inlineCompletionsModel.js';
@@ -171,7 +171,7 @@ export class InlineSuggestionHintsContentWidget extends Disposable implements IC
 		private readonly _position: IObservable<Position | null>,
 		private readonly _currentSuggestionIdx: IObservable<number>,
 		private readonly _suggestionCount: IObservable<number | undefined>,
-		private readonly _extraCommands: IObservable<Command[]>,
+		private readonly _extraCommands: IObservable<InlineCompletionCommand[]>,
 		private readonly _warning: IObservable<InlineCompletionWarning | undefined>,
 		private readonly _relayout: () => void,
 		@ICommandService private readonly _commandService: ICommandService,
@@ -289,12 +289,12 @@ export class InlineSuggestionHintsContentWidget extends Disposable implements IC
 			const extraCommands = this._extraCommands.read(reader);
 			const extraActions = extraCommands.map<IAction>(c => ({
 				class: undefined,
-				id: c.id,
+				id: c.command.id,
 				enabled: true,
-				tooltip: c.tooltip || '',
-				label: c.title,
+				tooltip: c.command.tooltip || '',
+				label: c.command.title,
 				run: (event) => {
-					return this._commandService.executeCommand(c.id);
+					return this._commandService.executeCommand(c.command.id);
 				},
 			}));
 

--- a/src/vs/editor/contrib/inlineCompletions/browser/model/inlineCompletionsModel.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/model/inlineCompletionsModel.ts
@@ -26,7 +26,7 @@ import { Selection } from '../../../../common/core/selection.js';
 import { TextReplacement, TextEdit } from '../../../../common/core/edits/textEdit.js';
 import { TextLength } from '../../../../common/core/text/textLength.js';
 import { ScrollType } from '../../../../common/editorCommon.js';
-import { Command, InlineCompletionEndOfLifeReasonKind, InlineCompletion, InlineCompletionTriggerKind, PartialAcceptTriggerKind, InlineCompletionsProvider } from '../../../../common/languages.js';
+import { InlineCompletionEndOfLifeReasonKind, InlineCompletion, InlineCompletionTriggerKind, PartialAcceptTriggerKind, InlineCompletionsProvider, InlineCompletionCommand } from '../../../../common/languages.js';
 import { ILanguageConfigurationService } from '../../../../common/languages/languageConfigurationRegistry.js';
 import { EndOfLinePreference, IModelDeltaDecoration, ITextModel } from '../../../../common/model.js';
 import { TextModelText } from '../../../../common/model/textModelText.js';
@@ -274,7 +274,7 @@ export class InlineCompletionsModel extends Disposable {
 			const idx = this.selectedInlineCompletionIndex.read(reader);
 			return filteredCompletions[idx];
 		});
-		this.activeCommands = derivedOpts<Command[]>({ owner: this, equalsFn: itemsEquals() },
+		this.activeCommands = derivedOpts<InlineCompletionCommand[]>({ owner: this, equalsFn: itemsEquals() },
 			r => this.selectedInlineCompletion.read(r)?.source.inlineSuggestions.commands ?? []
 		);
 		this.lastTriggerKind = this._source.inlineCompletions.map(this, v => v?.request?.context.triggerKind);

--- a/src/vs/editor/contrib/inlineCompletions/browser/model/inlineEdit.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/model/inlineEdit.ts
@@ -4,13 +4,13 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { TextReplacement } from '../../../../common/core/edits/textEdit.js';
-import { Command } from '../../../../common/languages.js';
+import { InlineCompletionCommand } from '../../../../common/languages.js';
 import { InlineSuggestionItem } from './inlineSuggestionItem.js';
 
 export class InlineEdit {
 	constructor(
 		public readonly edit: TextReplacement,
-		public readonly commands: readonly Command[],
+		public readonly commands: readonly InlineCompletionCommand[],
 		public readonly inlineCompletion: InlineSuggestionItem,
 	) { }
 

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/components/gutterIndicatorMenu.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/components/gutterIndicatorMenu.ts
@@ -78,7 +78,13 @@ export class GutterIndicatorMenuContent {
 			commandId: hideInlineCompletionId
 		}));
 
-		const extensionCommands = this._model.extensionCommands.map((c, idx) => option(createOptionArgs({ id: c.id + '_' + idx, title: c.title, icon: Codicon.symbolEvent, commandId: c.id, commandArgs: c.arguments })));
+		const extensionCommands = this._model.extensionCommands.map((c, idx) => option(createOptionArgs({
+			id: c.command.id + '_' + idx,
+			title: c.command.title,
+			icon: c.icon ?? Codicon.symbolEvent,
+			commandId: c.command.id,
+			commandArgs: c.command.arguments
+		})));
 
 		const toggleCollapsedMode = this._inlineEditsShowCollapsed.map(showCollapsed => showCollapsed ?
 			option(createOptionArgs({

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditWithChanges.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditWithChanges.ts
@@ -8,7 +8,7 @@ import { LineRange } from '../../../../../common/core/ranges/lineRange.js';
 import { Position } from '../../../../../common/core/position.js';
 import { TextEdit } from '../../../../../common/core/edits/textEdit.js';
 import { AbstractText } from '../../../../../common/core/text/abstractText.js';
-import { Command } from '../../../../../common/languages.js';
+import { InlineCompletionCommand } from '../../../../../common/languages.js';
 import { InlineSuggestionItem } from '../../model/inlineSuggestionItem.js';
 
 export class InlineEditWithChanges {
@@ -31,7 +31,7 @@ export class InlineEditWithChanges {
 		public readonly originalText: AbstractText,
 		public readonly edit: TextEdit,
 		public readonly cursorPosition: Position,
-		public readonly commands: readonly Command[],
+		public readonly commands: readonly InlineCompletionCommand[],
 		public readonly inlineCompletion: InlineSuggestionItem
 	) {
 	}

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsModel.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsModel.ts
@@ -11,7 +11,7 @@ import { observableCodeEditor } from '../../../../../browser/observableCodeEdito
 import { LineRange } from '../../../../../common/core/ranges/lineRange.js';
 import { TextEdit } from '../../../../../common/core/edits/textEdit.js';
 import { StringText } from '../../../../../common/core/text/abstractText.js';
-import { Command, InlineCompletionDisplayLocation } from '../../../../../common/languages.js';
+import { Command, InlineCompletionCommand, InlineCompletionDisplayLocation } from '../../../../../common/languages.js';
 import { InlineCompletionsModel } from '../../model/inlineCompletionsModel.js';
 import { InlineCompletionItem } from '../../model/inlineSuggestionItem.js';
 import { IInlineEditHost, IInlineEditModel, InlineEditTabAction } from './inlineEditsViewInterface.js';
@@ -21,7 +21,7 @@ export class InlineEditModel implements IInlineEditModel {
 
 	readonly action: Command | undefined;
 	readonly displayName: string;
-	readonly extensionCommands: Command[];
+	readonly extensionCommands: InlineCompletionCommand[];
 
 	readonly displayLocation: InlineCompletionDisplayLocation | undefined;
 	readonly showCollapsed: IObservable<boolean>;

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViewInterface.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViewInterface.ts
@@ -6,7 +6,7 @@
 import { IMouseEvent } from '../../../../../../base/browser/mouseEvent.js';
 import { Event } from '../../../../../../base/common/event.js';
 import { IObservable } from '../../../../../../base/common/observable.js';
-import { Command, InlineCompletionDisplayLocation } from '../../../../../common/languages.js';
+import { Command, InlineCompletionCommand, InlineCompletionDisplayLocation } from '../../../../../common/languages.js';
 import { InlineEditWithChanges } from './inlineEditWithChanges.js';
 
 export enum InlineEditTabAction {
@@ -28,7 +28,7 @@ export interface IInlineEditHost {
 export interface IInlineEditModel {
 	displayName: string;
 	action: Command | undefined;
-	extensionCommands: Command[];
+	extensionCommands: InlineCompletionCommand[];
 	inlineEdit: InlineEditWithChanges;
 	tabAction: IObservable<InlineEditTabAction>;
 	showCollapsed: IObservable<boolean>;

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -7387,13 +7387,18 @@ declare namespace monaco.languages {
 		/**
 		 * A list of commands associated with the inline completions of this list.
 		 */
-		readonly commands?: Command[];
+		readonly commands?: InlineCompletionCommand[];
 		readonly suppressSuggestions?: boolean | undefined;
 		/**
 		 * When set and the user types a suggestion without derivating from it, the inline suggestion is not updated.
 		 */
 		readonly enableForwardStability?: boolean | undefined;
 	}
+
+	export type InlineCompletionCommand = {
+		command: Command;
+		icon?: editor.ThemeIcon;
+	};
 
 	export type InlineCompletionProviderGroupId = string;
 

--- a/src/vs/workbench/api/common/extHostLanguageFeatures.ts
+++ b/src/vs/workbench/api/common/extHostLanguageFeatures.ts
@@ -1444,7 +1444,7 @@ class InlineCompletionAdapter {
 				if (!disposableStore) {
 					disposableStore = new DisposableStore();
 				}
-				return this._commands.toInternal(c, disposableStore);
+				return typeConvert.CompletionCommand.from(c, this._commands, disposableStore);
 			}),
 			suppressSuggestions: false,
 			enableForwardStability,
@@ -1530,7 +1530,7 @@ class InlineCompletionAdapter {
 				if (!disposableStore) {
 					disposableStore = new DisposableStore();
 				}
-				return this._commands.toInternal(c, disposableStore);
+				return typeConvert.CompletionCommand.from(c, this._commands, disposableStore);
 			}),
 			suppressSuggestions: false,
 			enableForwardStability,

--- a/src/vs/workbench/api/common/extHostTypeConverters.ts
+++ b/src/vs/workbench/api/common/extHostTypeConverters.ts
@@ -1117,6 +1117,18 @@ export namespace CompletionItemTag {
 	}
 }
 
+export namespace CompletionCommand {
+	export function from(c: vscode.Command | { command: vscode.Command; icon: vscode.ThemeIcon }, converter: CommandsConverter, disposables: DisposableStore): { command: extHostProtocol.ICommandDto; icon?: languages.IconPath } {
+		if ('icon' in c && 'command' in c) {
+			return {
+				command: converter.toInternal(c.command, disposables),
+				icon: IconPath.fromThemeIcon(c.icon)
+			};
+		}
+		return { command: converter.toInternal(c, disposables) };
+	}
+}
+
 export namespace CompletionItemKind {
 
 	const _from = new Map<types.CompletionItemKind, languages.CompletionItemKind>([

--- a/src/vs/workbench/api/common/extHostTypes.ts
+++ b/src/vs/workbench/api/common/extHostTypes.ts
@@ -1879,7 +1879,7 @@ export class InlineSuggestion implements vscode.InlineCompletionItem {
 export class InlineSuggestionList implements vscode.InlineCompletionList {
 	items: vscode.InlineCompletionItem[];
 
-	commands: vscode.Command[] | undefined = undefined;
+	commands: (vscode.Command | { command: vscode.Command; icon: vscode.ThemeIcon })[] | undefined = undefined;
 
 	suppressSuggestions: boolean | undefined = undefined;
 

--- a/src/vscode-dts/vscode.proposed.inlineCompletionsAdditions.d.ts
+++ b/src/vscode-dts/vscode.proposed.inlineCompletionsAdditions.d.ts
@@ -159,7 +159,7 @@ declare module 'vscode' {
 		/**
 		 * A list of commands associated with the inline completions of this list.
 		 */
-		commands?: Command[];
+		commands?: Array<Command | { command: Command; icon: ThemeIcon }>;
 
 		/**
 		 * When set and the user types a suggestion without deviating from it, the inline suggestion is not updated.


### PR DESCRIPTION
```Copilot Generated Description:``` Introduce a new type for inline completion commands that includes an optional icon, allowing commands associated with inline completions to have icons. Update relevant interfaces and classes to utilize this new type.

relevant: https://github.com/microsoft/vscode-copilot/issues/18392