### PR TITLE
Set chat input aria label based on mode

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
@@ -431,7 +431,12 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 
 		this.initSelectedModel();
 
-		this._register(this.onDidChangeCurrentChatMode(() => this.accessibilityService.alert(this._currentMode.kind)));
+		this._register(this.onDidChangeCurrentChatMode(() => {
+			this.accessibilityService.alert(this._currentMode.kind);
+			if (this._inputEditor) {
+				this._inputEditor.updateOptions({ ariaLabel: this._getAriaLabel() });
+			}
+		}));
 		this._register(this._onDidChangeCurrentLanguageModel.event(() => {
 			if (this._currentLanguageModel?.metadata.name) {
 				this.accessibilityService.alert(this._currentLanguageModel.metadata.name);
@@ -604,7 +609,22 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 		const verbose = this.configurationService.getValue<boolean>(AccessibilityVerbositySettingId.Chat);
 		if (verbose) {
 			const kbLabel = this.keybindingService.lookupKeybinding(AccessibilityCommandId.OpenAccessibilityHelp)?.getLabel();
-			return kbLabel ? localize('actions.chat.accessibiltyHelp', "Chat Input,  Type to ask questions or type / for topics, press enter to send out the request. Use {0} for Chat Accessibility Help.", kbLabel) : localize('chatInput.accessibilityHelpNoKb', "Chat Input,  Type code here and press Enter to run. Use the Chat Accessibility Help command for more information.");
+			let modeLabel = '';
+			switch (this.currentMode) {
+				case ChatMode.Agent:
+					modeLabel = localize('chatInput.mode.agent', "(Agent Mode), edit files in your workspace.");
+					break;
+				case ChatMode.Edit:
+					modeLabel = localize('chatInput.mode.edit', "(Edit Mode), edit files in your workspace.");
+					break;
+				case ChatMode.Ask:
+				default:
+					modeLabel = localize('chatInput.mode.ask', "(Ask Mode), ask questions or type / for topics.");
+					break;
+			}
+			return kbLabel
+				? localize('actions.chat.accessibiltyHelp', "Chat Input {0} Press Enter to send out the request. Use {1} for Chat Accessibility Help.", modeLabel, kbLabel)
+				: localize('chatInput.accessibilityHelpNoKb', "Chat Input {0} Press Enter to send out the request. Use the Chat Accessibility Help command for more information.", modeLabel);
 		}
 		return localize('chatInput', "Chat Input");
 	}


### PR DESCRIPTION


cc @roblourens 

Before, regardless of mode:
<img width="1091" alt="Screenshot 2025-06-17 at 3 09 20 PM" src="https://github.com/user-attachments/assets/36de8136-df91-4636-bd9b-6c6889e16c39" />


After:
<img width="640" alt="Screenshot 2025-06-17 at 3 05 23 PM" src="https://github.com/user-attachments/assets/716e9cde-cce8-4b00-92f0-b0824aa99d29" />
<img width="638" alt="Screenshot 2025-06-17 at 3 05 07 PM" src="https://github.com/user-attachments/assets/f200c113-baca-4dd6-b223-cb7a0cf852cb" />
<img width="610" alt="Screenshot 2025-06-17 at 3 04 59 PM" src="https://github.com/user-attachments/assets/0684a4e9-7847-463f-b449-95177c83cac1" />


