### PR TITLE
fix a11y issues w chat diff buttons

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/chatMarkdownContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/chatMarkdownContentPart.ts
@@ -338,16 +338,13 @@ class CollapsedCodeBlock extends Disposable {
 	) {
 		super();
 		this.element = $('.chat-codeblock-pill-widget');
+		this.element.tabIndex = 0;
 		this.element.classList.add('show-file-icons');
-		this._register(dom.addDisposableListener(this.element, 'click', async () => {
-			if (this._currentDiff) {
-				this.editorService.openEditor({
-					original: { resource: this._currentDiff.originalURI },
-					modified: { resource: this._currentDiff.modifiedURI },
-					options: { transient: true },
-				});
-			} else if (this.uri) {
-				this.editorService.openEditor({ resource: this.uri });
+		this.element.role = 'button';
+		this._register(dom.addDisposableListener(this.element, 'click', () => this._showDiff()));
+		this._register(dom.addDisposableListener(this.element, 'keydown', (e) => {
+			if (e.key === 'Enter' || e.key === ' ') {
+				this._showDiff();
 			}
 		}));
 		this._register(dom.addDisposableListener(this.element, dom.EventType.CONTEXT_MENU, domEvent => {
@@ -363,6 +360,18 @@ class CollapsedCodeBlock extends Disposable {
 				},
 			});
 		}));
+	}
+
+	private _showDiff(): void {
+		if (this._currentDiff) {
+			this.editorService.openEditor({
+				original: { resource: this._currentDiff.originalURI },
+				modified: { resource: this._currentDiff.modifiedURI },
+				options: { transient: true },
+			});
+		} else if (this.uri) {
+			this.editorService.openEditor({ resource: this.uri });
+		}
 	}
 
 	render(uri: URI, isStreaming?: boolean): void {


### PR DESCRIPTION
1. Make them keyboard focusable
2. When focused, allow `space` or `enter` to open the file diff
3. Set the proper role, `button`

fixes #250397
fixes [#17563](https://github.com/microsoft/vscode-copilot/issues/17563)

https://github.com/user-attachments/assets/ed680563-3b05-49b5-8f78-fb0aa2d453c4


