### PR TITLE
Improve inline edit support in diff editor

### DIFF
--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -4299,10 +4299,6 @@ export interface IInlineSuggestOptions {
 		* @internal
 		*/
 		enabled?: boolean;
-		/**
-		* @internal
-		*/
-		useMultiLineGhostText?: boolean;
 	};
 
 	/**
@@ -4343,7 +4339,6 @@ class InlineEditorSuggest extends BaseEditorOption<EditorOption.inlineSuggest, I
 				showCollapsed: false,
 				renderSideBySide: 'auto',
 				allowCodeShifting: 'always',
-				useMultiLineGhostText: true
 			},
 			experimental: {
 				suppressInlineSuggestions: [],
@@ -4436,7 +4431,6 @@ class InlineEditorSuggest extends BaseEditorOption<EditorOption.inlineSuggest, I
 				showCollapsed: boolean(input.edits?.showCollapsed, this.defaultValue.edits.showCollapsed),
 				allowCodeShifting: stringSet(input.edits?.allowCodeShifting, this.defaultValue.edits.allowCodeShifting, ['always', 'horizontal', 'never']),
 				renderSideBySide: stringSet(input.edits?.renderSideBySide, this.defaultValue.edits.renderSideBySide, ['never', 'auto']),
-				useMultiLineGhostText: boolean(input.edits?.useMultiLineGhostText, this.defaultValue.edits.useMultiLineGhostText),
 			},
 			experimental: {
 				suppressInlineSuggestions: stringArray(input.experimental?.suppressInlineSuggestions, this.defaultValue.experimental.suppressInlineSuggestions),

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsModel.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsModel.ts
@@ -22,6 +22,7 @@ export class InlineEditModel implements IInlineEditModel {
 	readonly action: Command | undefined;
 	readonly displayName: string;
 	readonly extensionCommands: InlineCompletionCommand[];
+	readonly isInDiffEditor: boolean;
 
 	readonly displayLocation: InlineCompletionDisplayLocation | undefined;
 	readonly showCollapsed: IObservable<boolean>;
@@ -34,6 +35,7 @@ export class InlineEditModel implements IInlineEditModel {
 		this.action = this.inlineEdit.inlineCompletion.action;
 		this.displayName = this.inlineEdit.inlineCompletion.source.provider.displayName ?? localize('inlineEdit', "Inline Edit");
 		this.extensionCommands = this.inlineEdit.inlineCompletion.source.inlineSuggestions.commands ?? [];
+		this.isInDiffEditor = this._model.isInDiffEditor;
 
 		this.displayLocation = this.inlineEdit.inlineCompletion.displayLocation;
 		this.showCollapsed = this._model.showCollapsed;

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViewInterface.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViewInterface.ts
@@ -29,6 +29,7 @@ export interface IInlineEditModel {
 	displayName: string;
 	action: Command | undefined;
 	extensionCommands: InlineCompletionCommand[];
+	isInDiffEditor: boolean;
 	inlineEdit: InlineEditWithChanges;
 	tabAction: IObservable<InlineEditTabAction>;
 	showCollapsed: IObservable<boolean>;

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/inlineEditsDeletionView.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/inlineEditsDeletionView.ts
@@ -26,6 +26,7 @@ const HORIZONTAL_PADDING = 0;
 const VERTICAL_PADDING = 0;
 const BORDER_WIDTH = 1;
 const WIDGET_SEPARATOR_WIDTH = 1;
+const WIDGET_SEPARATOR_DIFF_EDITOR_WIDTH = 3;
 const BORDER_RADIUS = 4;
 
 export class InlineEditsDeletionView extends Disposable implements IInlineEditsView {
@@ -46,6 +47,7 @@ export class InlineEditsDeletionView extends Disposable implements IInlineEditsV
 		private readonly _uiState: IObservable<{
 			originalRange: LineRange;
 			deletions: Range[];
+			inDiffEditor: boolean;
 		} | undefined>,
 		private readonly _tabAction: IObservable<InlineEditTabAction>,
 	) {
@@ -159,7 +161,8 @@ export class InlineEditsDeletionView extends Disposable implements IInlineEditsV
 			return rect.intersectHorizontal(new OffsetRange(overlayHider.left, Number.MAX_SAFE_INTEGER));
 		});
 
-		const separatorRect = overlayRect.map(rect => rect.withMargin(WIDGET_SEPARATOR_WIDTH, WIDGET_SEPARATOR_WIDTH));
+		const separatorWidth = this._uiState.map(s => s?.inDiffEditor ? WIDGET_SEPARATOR_DIFF_EDITOR_WIDTH : WIDGET_SEPARATOR_WIDTH).read(reader);
+		const separatorRect = overlayRect.map(rect => rect.withMargin(separatorWidth, separatorWidth));
 
 		return [
 			n.div({
@@ -167,7 +170,7 @@ export class InlineEditsDeletionView extends Disposable implements IInlineEditsV
 				style: {
 					...separatorRect.read(reader).toStyles(),
 					borderRadius: `${BORDER_RADIUS}px`,
-					border: `${BORDER_WIDTH + WIDGET_SEPARATOR_WIDTH}px solid ${asCssVariable(editorBackground)}`,
+					border: `${BORDER_WIDTH + separatorWidth}px solid ${asCssVariable(editorBackground)}`,
 					boxSizing: 'border-box',
 				}
 			}),

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/inlineEditsInsertionView.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/inlineEditsInsertionView.ts
@@ -29,6 +29,7 @@ import { getPrefixTrim, mapOutFalsy } from '../utils/utils.js';
 
 const BORDER_WIDTH = 1;
 const WIDGET_SEPARATOR_WIDTH = 1;
+const WIDGET_SEPARATOR_DIFF_EDITOR_WIDTH = 3;
 const BORDER_RADIUS = 4;
 
 export class InlineEditsInsertionView extends Disposable implements IInlineEditsView {
@@ -126,6 +127,7 @@ export class InlineEditsInsertionView extends Disposable implements IInlineEdits
 			lineNumber: number;
 			startColumn: number;
 			text: string;
+			inDiffEditor: boolean;
 		} | undefined>,
 		private readonly _tabAction: IObservable<InlineEditTabAction>,
 		@IInstantiationService instantiationService: IInstantiationService,
@@ -261,8 +263,9 @@ export class InlineEditsInsertionView extends Disposable implements IInlineEdits
 			layoutInfo.overlay.bottom
 		)).read(reader);
 
+		const separatorWidth = this._input.map(i => i?.inDiffEditor ? WIDGET_SEPARATOR_DIFF_EDITOR_WIDTH : WIDGET_SEPARATOR_WIDTH).read(reader);
 		const overlayRect = overlayLayoutObs.map(l => l.overlay.withMargin(0, BORDER_WIDTH, 0, l.startsAtContentLeft ? 0 : BORDER_WIDTH).intersectHorizontal(new OffsetRange(overlayHider.left, Number.MAX_SAFE_INTEGER)));
-		const underlayRect = overlayRect.map(rect => rect.withMargin(WIDGET_SEPARATOR_WIDTH, WIDGET_SEPARATOR_WIDTH));
+		const underlayRect = overlayRect.map(rect => rect.withMargin(separatorWidth, separatorWidth));
 
 		return [
 			n.div({
@@ -270,7 +273,7 @@ export class InlineEditsInsertionView extends Disposable implements IInlineEdits
 				style: {
 					...underlayRect.read(reader).toStyles(),
 					borderRadius: BORDER_RADIUS,
-					border: `${BORDER_WIDTH + WIDGET_SEPARATOR_WIDTH}px solid ${asCssVariable(editorBackground)}`,
+					border: `${BORDER_WIDTH + separatorWidth}px solid ${asCssVariable(editorBackground)}`,
 					boxSizing: 'border-box',
 				}
 			}),

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/inlineEditsLineReplacementView.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/inlineEditsLineReplacementView.ts
@@ -7,7 +7,7 @@ import { $, getWindow, n } from '../../../../../../../base/browser/dom.js';
 import { IMouseEvent, StandardMouseEvent } from '../../../../../../../base/browser/mouseEvent.js';
 import { Emitter } from '../../../../../../../base/common/event.js';
 import { Disposable, toDisposable } from '../../../../../../../base/common/lifecycle.js';
-import { autorun, autorunDelta, constObservable, derived, IObservable } from '../../../../../../../base/common/observable.js';
+import { autorunDelta, constObservable, derived, IObservable } from '../../../../../../../base/common/observable.js';
 import { editorBackground, scrollbarShadow } from '../../../../../../../platform/theme/common/colorRegistry.js';
 import { asCssVariable } from '../../../../../../../platform/theme/common/colorUtils.js';
 import { IThemeService } from '../../../../../../../platform/theme/common/themeService.js';
@@ -22,7 +22,6 @@ import { Range } from '../../../../../../common/core/range.js';
 import { LineRange } from '../../../../../../common/core/ranges/lineRange.js';
 import { OffsetRange } from '../../../../../../common/core/ranges/offsetRange.js';
 import { ILanguageService } from '../../../../../../common/languages/language.js';
-import { IModelDecorationOptions, TrackedRangeStickiness } from '../../../../../../common/model.js';
 import { LineTokens, TokenArray } from '../../../../../../common/tokens/lineTokens.js';
 import { InlineDecoration, InlineDecorationType } from '../../../../../../common/viewModel.js';
 import { IInlineEditsView, InlineEditTabAction } from '../inlineEditsViewInterface.js';
@@ -33,9 +32,6 @@ export class InlineEditsLineReplacementView extends Disposable implements IInlin
 
 	private readonly _onDidClick;
 	readonly onDidClick;
-
-	private readonly _originalBubblesDecorationCollection;
-	private readonly _originalBubblesDecorationOptions: IModelDecorationOptions;
 
 	private readonly _maxPrefixTrim;
 
@@ -58,6 +54,7 @@ export class InlineEditsLineReplacementView extends Disposable implements IInlin
 			modifiedLines: string[];
 			replacements: Replacement[];
 		} | undefined>,
+		private readonly _isInDiffEditor: IObservable<boolean>,
 		private readonly _tabAction: IObservable<InlineEditTabAction>,
 		@ILanguageService private readonly _languageService: ILanguageService,
 		@IThemeService private readonly _themeService: IThemeService,
@@ -65,12 +62,6 @@ export class InlineEditsLineReplacementView extends Disposable implements IInlin
 		super();
 		this._onDidClick = this._register(new Emitter<IMouseEvent>());
 		this.onDidClick = this._onDidClick.event;
-		this._originalBubblesDecorationCollection = this._editor.editor.createDecorationsCollection();
-		this._originalBubblesDecorationOptions = {
-			description: 'inlineCompletions-original-bubble',
-			className: 'inlineCompletions-original-bubble',
-			stickiness: TrackedRangeStickiness.NeverGrowsWhenTypingAtEdges
-		};
 		this._maxPrefixTrim = this._edit.map(e => e ? getPrefixTrim(e.replacements.flatMap(r => [r.originalRange, r.modifiedRange]), e.originalRange, e.modifiedLines, this._editor.editor) : undefined);
 		this._modifiedLineElements = derived(reader => {
 			const lines = [];
@@ -100,13 +91,10 @@ export class InlineEditsLineReplacementView extends Disposable implements IInlin
 					tokens = LineTokens.createEmpty(modLine, this._languageService.languageIdCodec);
 				}
 
-				// Inline decorations are broken down into individual spans. To be able to render rounded corners, we need to set the start and end decorations separately.
 				const decorations = [];
 				for (const modified of modifiedBubbles.filter(b => b.startLineNumber === lineNumber)) {
 					const validatedEndColumn = Math.min(modified.endColumn, modLine.length + 1);
 					decorations.push(new InlineDecoration(new Range(1, modified.startColumn, 1, validatedEndColumn), 'inlineCompletions-modified-bubble', InlineDecorationType.Regular));
-					decorations.push(new InlineDecoration(new Range(1, modified.startColumn, 1, modified.startColumn + 1), 'start', InlineDecorationType.Regular));
-					decorations.push(new InlineDecoration(new Range(1, validatedEndColumn - 1, 1, validatedEndColumn), 'end', InlineDecorationType.Regular));
 				}
 
 				// TODO: All lines should be rendered at once for one dom element
@@ -213,6 +201,8 @@ export class InlineEditsLineReplacementView extends Disposable implements IInlin
 				const layoutProps = layout.read(reader);
 				const contentLeft = this._editor.layoutInfoContentLeft.read(reader);
 
+				const separatorWidth = this._isInDiffEditor.read(reader) ? 3 : 1;
+
 				modifiedLineElements.lines.forEach((l, i) => {
 					l.style.width = `${layoutProps.lowerText.width}px`;
 					l.style.height = `${layoutProps.modifiedLineHeights[i]}px`;
@@ -231,6 +221,18 @@ export class InlineEditsLineReplacementView extends Disposable implements IInlin
 							pointerEvents: 'none',
 						}
 					}, [
+						n.div({
+							class: 'borderAroundLineReplacement',
+							style: {
+								position: 'absolute',
+								...rectToProps(reader => layout.read(reader).background.translateX(-contentLeft).withMargin(separatorWidth)),
+								borderRadius: '4px',
+
+								border: `${separatorWidth + 1}px solid ${asCssVariable(editorBackground)}`,
+								boxSizing: 'border-box',
+								pointerEvents: 'none',
+							}
+						}),
 						n.div({
 							class: 'originalOverlayLineReplacement',
 							style: {
@@ -292,7 +294,6 @@ export class InlineEditsLineReplacementView extends Disposable implements IInlin
 		this.isHovered = this._editor.isTargetHovered((e) => this._isMouseOverWidget(e), this._store);
 		this._previousViewZoneInfo = undefined;
 
-		this._register(toDisposable(() => this._originalBubblesDecorationCollection.clear()));
 		this._register(toDisposable(() => this._editor.editor.changeViewZones(accessor => this.removePreviousViewZone(accessor))));
 
 		this._register(autorunDelta(this._viewZoneInfo, ({ lastValue, newValue }) => {
@@ -304,15 +305,6 @@ export class InlineEditsLineReplacementView extends Disposable implements IInlin
 				if (!newValue) { return; }
 				this.addViewZone(newValue, changeAccessor);
 			});
-		}));
-
-		this._register(autorun(reader => {
-			const edit = this._edit.read(reader);
-			const originalBubbles = [];
-			if (edit) {
-				originalBubbles.push(...rangesToBubbleRanges(edit.replacements.map(r => r.originalRange)));
-			}
-			this._originalBubblesDecorationCollection.set(originalBubbles.map(r => ({ range: r, options: this._originalBubblesDecorationOptions })));
 		}));
 
 		this._register(this._editor.createOverlayWidget({

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/view.css
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/view.css
@@ -14,9 +14,9 @@
 		z-index: 34; /* Below the find widget */
 		height: 20px;
 
-		color: var(--vscode-inlineEdit-indicator-foreground);
-		background-color: var(--vscode-inlineEdit-indicator-background);
-		border: 1px solid var(--vscode-inlineEdit-indicator-border);
+		color: var(--vscode-inlineEdit-gutterIndicator-primaryForeground);
+		background-color: var(--vscode-inlineEdit-gutterIndicator-background);
+		border: 1px solid var(--vscode-inlineEdit-gutterIndicator-primaryBorder);
 		border-radius: 3px;
 
 		align-items: center;
@@ -63,7 +63,7 @@
 			transform: none;
 			transition: transform 0.2s ease-in-out;
 			.codicon {
-				color: var(--vscode-inlineEdit-indicator-foreground);
+				color: var(--vscode-inlineEdit-gutterIndicator-primaryForeground);
 			}
 		}
 
@@ -153,11 +153,11 @@
 
 	/* line replacement bubbles */
 
-	.inlineCompletions-modified-bubble{
+	.inlineCompletions-modified-bubble {
 		background: var(--vscode-inlineEdit-modifiedChangedTextBackground);
 	}
 
-	.inlineCompletions-original-bubble{
+	.inlineCompletions-original-bubble {
 		background: var(--vscode-inlineEdit-originalChangedTextBackground);
 	}
 
@@ -180,9 +180,13 @@
 	.inline-edit.modified-background.ghost-text,
 	.inline-edit.modified-background.ghost-text-decoration,
 	.inline-edit.modified-background.ghost-text-decoration-preview,
-	.inline-edit.modified-background.suggest-preview-text .ghost-text{
+	.inline-edit.modified-background.suggest-preview-text .ghost-text {
 		background: var(--vscode-inlineEdit-modifiedChangedTextBackground) !important;
 		display: inline-block !important;
+	}
+
+	.inlineCompletions-original-lines {
+		background: var(--vscode-editor-background);
 	}
 }
 


### PR DESCRIPTION
```Copilot Generated Description:``` Enhance the inline edit model to include a flag for diff editor context and adjust the rendering logic accordingly. Update styles and decorations to better support inline edits within diff views.

closes https://github.com/microsoft/vscode-copilot/issues/11853