### PR TITLE
Move pwsh shell integration from .psm1 back to .ps1

### DIFF
--- a/build/azure-pipelines/win32/codesign.js
+++ b/build/azure-pipelines/win32/codesign.js
@@ -17,7 +17,7 @@ async function main() {
     // 2. Codesign Powershell scripts
     // 3. Codesign context menu appx package (insiders only)
     const codesignTask1 = (0, codesign_1.spawnCodesignProcess)(esrpCliDLLPath, 'sign-windows', codeSigningFolderPath, '*.dll,*.exe,*.node');
-    const codesignTask2 = (0, codesign_1.spawnCodesignProcess)(esrpCliDLLPath, 'sign-windows-appx', codeSigningFolderPath, '*.ps1,*.psm1');
+    const codesignTask2 = (0, codesign_1.spawnCodesignProcess)(esrpCliDLLPath, 'sign-windows-appx', codeSigningFolderPath, '*.ps1');
     const codesignTask3 = process.env['VSCODE_QUALITY'] === 'insider'
         ? (0, codesign_1.spawnCodesignProcess)(esrpCliDLLPath, 'sign-windows-appx', codeSigningFolderPath, '*.appx')
         : undefined;

--- a/build/azure-pipelines/win32/codesign.ts
+++ b/build/azure-pipelines/win32/codesign.ts
@@ -19,7 +19,7 @@ async function main() {
 	// 2. Codesign Powershell scripts
 	// 3. Codesign context menu appx package (insiders only)
 	const codesignTask1 = spawnCodesignProcess(esrpCliDLLPath, 'sign-windows', codeSigningFolderPath, '*.dll,*.exe,*.node');
-	const codesignTask2 = spawnCodesignProcess(esrpCliDLLPath, 'sign-windows-appx', codeSigningFolderPath, '*.ps1,*.psm1');
+	const codesignTask2 = spawnCodesignProcess(esrpCliDLLPath, 'sign-windows-appx', codeSigningFolderPath, '*.ps1');
 	const codesignTask3 = process.env['VSCODE_QUALITY'] === 'insider'
 		? spawnCodesignProcess(esrpCliDLLPath, 'sign-windows-appx', codeSigningFolderPath, '*.appx')
 		: undefined;

--- a/build/gulpfile.reh.js
+++ b/build/gulpfile.reh.js
@@ -67,7 +67,9 @@ const serverResourceIncludes = [
 	'out-build/vs/workbench/contrib/externalTerminal/**/*.scpt',
 
 	// Terminal shell integration
-	'out-build/vs/workbench/contrib/terminal/common/scripts/shellIntegration.psm1',
+	'out-build/vs/workbench/contrib/terminal/common/scripts/shellIntegration.ps1',
+	'out-build/vs/workbench/contrib/terminal/common/scripts/CodeTabExpansion.psm1',
+	'out-build/vs/workbench/contrib/terminal/common/scripts/GitTabExpansion.psm1',
 	'out-build/vs/workbench/contrib/terminal/common/scripts/shellIntegration-bash.sh',
 	'out-build/vs/workbench/contrib/terminal/common/scripts/shellIntegration-env.zsh',
 	'out-build/vs/workbench/contrib/terminal/common/scripts/shellIntegration-profile.zsh',

--- a/build/gulpfile.vscode.js
+++ b/build/gulpfile.vscode.js
@@ -75,6 +75,7 @@ const vscodeResourceIncludes = [
 
 	// Terminal shell integration
 	'out-build/vs/workbench/contrib/terminal/common/scripts/*.fish',
+	'out-build/vs/workbench/contrib/terminal/common/scripts/*.ps1',
 	'out-build/vs/workbench/contrib/terminal/common/scripts/*.psm1',
 	'out-build/vs/workbench/contrib/terminal/common/scripts/*.sh',
 	'out-build/vs/workbench/contrib/terminal/common/scripts/*.zsh',

--- a/src/vs/platform/terminal/node/terminalEnvironment.ts
+++ b/src/vs/platform/terminal/node/terminalEnvironment.ts
@@ -338,10 +338,10 @@ enum ShellIntegrationExecutable {
 
 const shellIntegrationArgs: Map<ShellIntegrationExecutable, string[]> = new Map();
 // The try catch swallows execution policy errors in the case of the archive distributable
-shellIntegrationArgs.set(ShellIntegrationExecutable.WindowsPwsh, ['-noexit', '-command', 'try { Import-Module \"{0}\\out\\vs\\workbench\\contrib\\terminal\\common\\scripts\\shellIntegration.psm1\" } catch {}{1}']);
-shellIntegrationArgs.set(ShellIntegrationExecutable.WindowsPwshLogin, ['-l', '-noexit', '-command', 'try { Import-Module \"{0}\\out\\vs\\workbench\\contrib\\terminal\\common\\scripts\\shellIntegration.psm1\" } catch {}{1}']);
-shellIntegrationArgs.set(ShellIntegrationExecutable.Pwsh, ['-noexit', '-command', 'Import-Module "{0}/out/vs/workbench/contrib/terminal/common/scripts/shellIntegration.psm1"{1}']);
-shellIntegrationArgs.set(ShellIntegrationExecutable.PwshLogin, ['-l', '-noexit', '-command', 'Import-Module "{0}/out/vs/workbench/contrib/terminal/common/scripts/shellIntegration.psm1"']);
+shellIntegrationArgs.set(ShellIntegrationExecutable.WindowsPwsh, ['-noexit', '-command', 'try { . \"{0}\\out\\vs\\workbench\\contrib\\terminal\\common\\scripts\\shellIntegration.ps1\" } catch {}{1}']);
+shellIntegrationArgs.set(ShellIntegrationExecutable.WindowsPwshLogin, ['-l', '-noexit', '-command', 'try { . \"{0}\\out\\vs\\workbench\\contrib\\terminal\\common\\scripts\\shellIntegration.ps1\" } catch {}{1}']);
+shellIntegrationArgs.set(ShellIntegrationExecutable.Pwsh, ['-noexit', '-command', '. "{0}/out/vs/workbench/contrib/terminal/common/scripts/shellIntegration.ps1"{1}']);
+shellIntegrationArgs.set(ShellIntegrationExecutable.PwshLogin, ['-l', '-noexit', '-command', '. "{0}/out/vs/workbench/contrib/terminal/common/scripts/shellIntegration.ps1"']);
 shellIntegrationArgs.set(ShellIntegrationExecutable.Zsh, ['-i']);
 shellIntegrationArgs.set(ShellIntegrationExecutable.ZshLogin, ['-il']);
 shellIntegrationArgs.set(ShellIntegrationExecutable.Bash, ['--init-file', '{0}/out/vs/workbench/contrib/terminal/common/scripts/shellIntegration-bash.sh']);

--- a/src/vs/platform/terminal/test/node/terminalEnvironment.test.ts
+++ b/src/vs/platform/terminal/test/node/terminalEnvironment.test.ts
@@ -48,8 +48,8 @@ suite('platform - terminalEnvironment', async () => {
 		// These tests are only expected to work on Windows 10 build 18309 and above
 		(getWindowsBuildNumber() < 18309 ? suite.skip : suite)('pwsh', async () => {
 			const expectedPs1 = process.platform === 'win32'
-				? `try { Import-Module "${repoRoot}\\out\\vs\\workbench\\contrib\\terminal\\common\\scripts\\shellIntegration.psm1" } catch {}`
-				: `Import-Module "${repoRoot}/out/vs/workbench/contrib/terminal/common/scripts/shellIntegration.psm1"`;
+				? `try { . "${repoRoot}\\out\\vs\\workbench\\contrib\\terminal\\common\\scripts\\shellIntegration.ps1" } catch {}`
+				: `. "${repoRoot}/out/vs/workbench/contrib/terminal/common/scripts/shellIntegration.ps1"`;
 			suite('should override args', async () => {
 				const enabledExpectedResult = Object.freeze<IShellIntegrationConfigInjection>({
 					type: 'injection',

--- a/src/vs/workbench/contrib/terminal/common/scripts/shellIntegration.ps1
+++ b/src/vs/workbench/contrib/terminal/common/scripts/shellIntegration.ps1
@@ -23,7 +23,9 @@ $Global:__VSCodeState = @{
 	IsWindows10 = $false
 }
 
-# Store the nonce in script scope and unset the global
+# Store the nonce in a regular variable and unset the environment variable. It's by design that
+# anything that can execute PowerShell code can read the nonce, as it's basically impossible to hide
+# in PowerShell. The most important thing is getting it out of the environment.
 $Global:__VSCodeState.Nonce = $env:VSCODE_NONCE
 $env:VSCODE_NONCE = $null
 

--- a/src/vs/workbench/contrib/terminal/common/scripts/shellIntegration.ps1
+++ b/src/vs/workbench/contrib/terminal/common/scripts/shellIntegration.ps1
@@ -4,7 +4,7 @@
 # ---------------------------------------------------------------------------------------------
 
 # Prevent installing more than once per session
-if (Test-Path variable:Script:__VSCodeState.OriginalPrompt) {
+if (Test-Path variable:global:__VSCodeState.OriginalPrompt) {
 	return;
 }
 
@@ -13,7 +13,7 @@ if ($ExecutionContext.SessionState.LanguageMode -ne "FullLanguage") {
 	return;
 }
 
-$Script:__VSCodeState = @{
+$Global:__VSCodeState = @{
 	OriginalPrompt = $function:Prompt
 	LastHistoryId = -1
 	IsInExecution = $false
@@ -24,21 +24,21 @@ $Script:__VSCodeState = @{
 }
 
 # Store the nonce in script scope and unset the global
-$Script:__VSCodeState.Nonce = $env:VSCODE_NONCE
+$Global:__VSCodeState.Nonce = $env:VSCODE_NONCE
 $env:VSCODE_NONCE = $null
 
-$Script:__VSCodeState.IsStable = $env:VSCODE_STABLE
+$Global:__VSCodeState.IsStable = $env:VSCODE_STABLE
 $env:VSCODE_STABLE = $null
 
 $__vscode_shell_env_reporting = $env:VSCODE_SHELL_ENV_REPORTING
 $env:VSCODE_SHELL_ENV_REPORTING = $null
 if ($__vscode_shell_env_reporting) {
-	$Script:__VSCodeState.EnvVarsToReport = $__vscode_shell_env_reporting.Split(',')
+	$Global:__VSCodeState.EnvVarsToReport = $__vscode_shell_env_reporting.Split(',')
 }
 Remove-Variable -Name __vscode_shell_env_reporting -ErrorAction SilentlyContinue
 
 $osVersion = [System.Environment]::OSVersion.Version
-$Script:__VSCodeState.IsWindows10 = $IsWindows -and $osVersion.Major -eq 10 -and $osVersion.Minor -eq 0 -and $osVersion.Build -lt 22000
+$Global:__VSCodeState.IsWindows10 = $IsWindows -and $osVersion.Major -eq 10 -and $osVersion.Minor -eq 0 -and $osVersion.Build -lt 22000
 Remove-Variable -Name osVersion -ErrorAction SilentlyContinue
 
 if ($env:VSCODE_ENV_REPLACE) {
@@ -86,9 +86,9 @@ function Global:Prompt() {
 	$Result = ""
 	# Skip finishing the command if the first command has not yet started or an execution has not
 	# yet begun
-	if ($Script:__VSCodeState.LastHistoryId -ne -1 -and $Script:__VSCodeState.IsInExecution -eq $true) {
-		$Script:__VSCodeState.IsInExecution = $false
-		if ($LastHistoryEntry.Id -eq $Script:__VSCodeState.LastHistoryId) {
+	if ($Global:__VSCodeState.LastHistoryId -ne -1 -and $Global:__VSCodeState.IsInExecution -eq $true) {
+		$Global:__VSCodeState.IsInExecution = $false
+		if ($LastHistoryEntry.Id -eq $Global:__VSCodeState.LastHistoryId) {
 			# Don't provide a command line or exit code if there was no history entry (eg. ctrl+c, enter on no command)
 			$Result += "$([char]0x1b)]633;D`a"
 		}
@@ -107,15 +107,15 @@ function Global:Prompt() {
 
 	# Send current environment variables as JSON
 	# OSC 633 ; EnvJson ; <Environment> ; <Nonce>
-	if ($Script:__VSCodeState.EnvVarsToReport.Count -gt 0) {
+	if ($Global:__VSCodeState.EnvVarsToReport.Count -gt 0) {
 		$envMap = @{}
-        foreach ($varName in $Script:__VSCodeState.EnvVarsToReport) {
+        foreach ($varName in $Global:__VSCodeState.EnvVarsToReport) {
             if (Test-Path "env:$varName") {
                 $envMap[$varName] = (Get-Item "env:$varName").Value
             }
         }
         $envJson = $envMap | ConvertTo-Json -Compress
-        $Result += "$([char]0x1b)]633;EnvJson;$(__VSCode-Escape-Value $envJson);$($Script:__VSCodeState.Nonce)`a"
+        $Result += "$([char]0x1b)]633;EnvJson;$(__VSCode-Escape-Value $envJson);$($Global:__VSCodeState.Nonce)`a"
 	}
 
 	# Before running the original prompt, put $? back to what it was:
@@ -123,18 +123,18 @@ function Global:Prompt() {
 		Write-Error "failure" -ea ignore
 	}
 	# Run the original prompt
-	$OriginalPrompt += $Script:__VSCodeState.OriginalPrompt.Invoke()
+	$OriginalPrompt += $Global:__VSCodeState.OriginalPrompt.Invoke()
 	$Result += $OriginalPrompt
 
 	# Prompt
 	# OSC 633 ; <Property>=<Value> ST
-	if ($Script:__VSCodeState.IsStable -eq "0") {
+	if ($Global:__VSCodeState.IsStable -eq "0") {
 		$Result += "$([char]0x1b)]633;P;Prompt=$(__VSCode-Escape-Value $OriginalPrompt)`a"
 	}
 
 	# Write command started
 	$Result += "$([char]0x1b)]633;B`a"
-	$Script:__VSCodeState.LastHistoryId = $LastHistoryEntry.Id
+	$Global:__VSCodeState.LastHistoryId = $LastHistoryEntry.Id
 	return $Result
 }
 
@@ -154,10 +154,10 @@ elseif ((Test-Path variable:global:GitPromptSettings) -and $Global:GitPromptSett
 if (Get-Module -Name PSReadLine) {
 	[Console]::Write("$([char]0x1b)]633;P;HasRichCommandDetection=True`a")
 
-	$Script:__VSCodeState.OriginalPSConsoleHostReadLine = $function:PSConsoleHostReadLine
+	$Global:__VSCodeState.OriginalPSConsoleHostReadLine = $function:PSConsoleHostReadLine
 	function Global:PSConsoleHostReadLine {
-		$CommandLine = $Script:__VSCodeState.OriginalPSConsoleHostReadLine.Invoke()
-		$Script:__VSCodeState.IsInExecution = $true
+		$CommandLine = $Global:__VSCodeState.OriginalPSConsoleHostReadLine.Invoke()
+		$Global:__VSCodeState.IsInExecution = $true
 
 		# Command line
 		# OSC 633 ; E [; <CommandLine> [; <Nonce>]] ST
@@ -165,8 +165,8 @@ if (Get-Module -Name PSReadLine) {
 		$Result += $(__VSCode-Escape-Value $CommandLine)
 		# Only send the nonce if the OS is not Windows 10 as it seems to echo to the terminal
 		# sometimes
-		if ($Script:__VSCodeState.IsWindows10 -eq $false) {
-			$Result += ";$($Script:__VSCodeState.Nonce)"
+		if ($Global:__VSCodeState.IsWindows10 -eq $false) {
+			$Result += ";$($Global:__VSCodeState.Nonce)"
 		}
 		$Result += "`a"
 
@@ -181,9 +181,9 @@ if (Get-Module -Name PSReadLine) {
 	}
 
 	# Set ContinuationPrompt property
-	$Script:__VSCodeState.ContinuationPrompt = (Get-PSReadLineOption).ContinuationPrompt
-	if ($Script:__VSCodeState.ContinuationPrompt) {
-		[Console]::Write("$([char]0x1b)]633;P;ContinuationPrompt=$(__VSCode-Escape-Value $Script:__VSCodeState.ContinuationPrompt)`a")
+	$Global:__VSCodeState.ContinuationPrompt = (Get-PSReadLineOption).ContinuationPrompt
+	if ($Global:__VSCodeState.ContinuationPrompt) {
+		[Console]::Write("$([char]0x1b)]633;P;ContinuationPrompt=$(__VSCode-Escape-Value $Global:__VSCodeState.ContinuationPrompt)`a")
 	}
 }
 


### PR DESCRIPTION
This reverts commit dd48c7f264782fc16486381e8792f79a3f7a19fa, reversing changes made to 80f28ae4edb1a60b0e328ab51df213608e03caa4.

This breaks the pwsh extension and only added isolation of the single state variable we use so it's not worth it.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
