### PR TITLE
feat: implement prefetching for AI settings search

### DIFF
--- a/src/vs/workbench/browser/workbench.contribution.ts
+++ b/src/vs/workbench/browser/workbench.contribution.ts
@@ -623,7 +623,7 @@ const registry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Con
 			'workbench.settings.showAISearchToggle': {
 				'type': 'boolean',
 				'default': product.quality !== 'stable',
-				'description': localize('settings.showAISearchToggle', "Controls whether the AI search toggle is shown in the search bar in the Settings editor."),
+				'description': localize('settings.showAISearchToggle', "Controls whether the AI search results toggle is shown in the search bar in the Settings editor after doing a search and once AI search results are available."),
 				'tags': ['experimental', 'onExP']
 			},
 			'workbench.hover.delay': {

--- a/src/vs/workbench/contrib/preferences/browser/preferencesSearch.ts
+++ b/src/vs/workbench/contrib/preferences/browser/preferencesSearch.ts
@@ -555,21 +555,16 @@ class TfIdfSearchProvider implements IRemoteSearchProvider {
 }
 
 class RemoteSearchProvider implements IRemoteSearchProvider {
-	private _embeddingsSearchProvider: EmbeddingsSearchProvider;
 	private _tfIdfSearchProvider: TfIdfSearchProvider;
 	private _filter: string = '';
 
-	constructor(
-		@IAiSettingsSearchService private readonly aiSettingsSearchService: IAiSettingsSearchService
-	) {
-		this._embeddingsSearchProvider = new EmbeddingsSearchProvider(this.aiSettingsSearchService, true);
+	constructor() {
 		this._tfIdfSearchProvider = new TfIdfSearchProvider();
 	}
 
 	setFilter(filter: string): void {
 		this._filter = filter;
 		this._tfIdfSearchProvider.setFilter(filter);
-		this._embeddingsSearchProvider.setFilter(filter);
 	}
 
 	async searchModel(preferencesModel: ISettingsEditorModel, token: CancellationToken): Promise<ISearchResult | null> {
@@ -577,21 +572,8 @@ class RemoteSearchProvider implements IRemoteSearchProvider {
 			return null;
 		}
 
-		if (!this.aiSettingsSearchService.isEnabled()) {
-			return this._tfIdfSearchProvider.searchModel(preferencesModel, token);
-		}
-
-		let results = await this._embeddingsSearchProvider.searchModel(preferencesModel, token);
-		if (results?.filterMatches.length) {
-			return results;
-		}
-		if (!token.isCancellationRequested) {
-			results = await this._tfIdfSearchProvider.searchModel(preferencesModel, token);
-			if (results?.filterMatches.length) {
-				return results;
-			}
-		}
-		return null;
+		const results = await this._tfIdfSearchProvider.searchModel(preferencesModel, token);
+		return results;
 	}
 }
 

--- a/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
@@ -349,6 +349,7 @@ export class SettingsEditor2 extends EditorPane {
 		} else if (alreadyVisible) {
 			this.searchInputActionBar.pull(0);
 			this.searchContainer.classList.remove('with-ai-toggle');
+			this.showAiResultsAction.checked = false;
 		}
 	}
 

--- a/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
@@ -1850,7 +1850,14 @@ export class SettingsEditor2 extends EditorPane {
 		if (!embeddingsResults || token.isCancellationRequested) {
 			return null;
 		}
-		return await this.getLLMRankedResults(query, token);
+		const llmResults = await this.getLLMRankedResults(query, token);
+		if (!llmResults) {
+			return null;
+		}
+		return {
+			filterMatches: embeddingsResults.filterMatches.concat(llmResults.filterMatches),
+			exactMatch: false
+		};
 	}
 
 	private async getLLMRankedResults(query: string, token: CancellationToken): Promise<ISearchResult | null> {

--- a/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
@@ -13,7 +13,7 @@ import { ToggleActionViewItem } from '../../../../base/browser/ui/toggle/toggle.
 import { ITreeElement } from '../../../../base/browser/ui/tree/tree.js';
 import { CodeWindow } from '../../../../base/browser/window.js';
 import { Action } from '../../../../base/common/actions.js';
-import { Delayer, raceTimeout } from '../../../../base/common/async.js';
+import { CancelablePromise, createCancelablePromise, Delayer, raceTimeout } from '../../../../base/common/async.js';
 import { CancellationToken, CancellationTokenSource } from '../../../../base/common/cancellation.js';
 import { Color } from '../../../../base/common/color.js';
 import { fromNow } from '../../../../base/common/date.js';
@@ -49,7 +49,6 @@ import { IWorkspaceTrustManagementService } from '../../../../platform/workspace
 import { registerNavigableContainer } from '../../../browser/actions/widgetNavigationCommands.js';
 import { EditorPane } from '../../../browser/parts/editor/editorPane.js';
 import { IEditorMemento, IEditorOpenContext, IEditorPane } from '../../../common/editor.js';
-import { IAiSettingsSearchService } from '../../../services/aiSettingsSearch/common/aiSettingsSearch.js';
 import { APPLICATION_SCOPES, IWorkbenchConfigurationService } from '../../../services/configuration/common/configuration.js';
 import { IEditorGroup, IEditorGroupsService } from '../../../services/editor/common/editorGroupsService.js';
 import { IExtensionService } from '../../../services/extensions/common/extensions.js';
@@ -185,8 +184,8 @@ export class SettingsEditor2 extends EditorPane {
 	private tocTree!: TOCTree;
 
 	private searchDelayer: Delayer<void>;
-	private aiSearchDelayer: Delayer<void>;
 	private searchInProgress: CancellationTokenSource | null = null;
+	private aiSearchPromise: CancelablePromise<void> | null = null;
 
 	private showAiResultsAction: Action | null = null;
 
@@ -256,11 +255,9 @@ export class SettingsEditor2 extends EditorPane {
 		@IExtensionGalleryService private readonly extensionGalleryService: IExtensionGalleryService,
 		@IEditorProgressService private readonly editorProgressService: IEditorProgressService,
 		@IUserDataProfileService userDataProfileService: IUserDataProfileService,
-		@IAiSettingsSearchService private readonly aiSettingsSearchService: IAiSettingsSearchService
 	) {
 		super(SettingsEditor2.ID, group, telemetryService, themeService, storageService);
-		this.searchDelayer = new Delayer(300);
-		this.aiSearchDelayer = new Delayer(2000);
+		this.searchDelayer = new Delayer(200);
 		this.viewState = { settingsTarget: ConfigurationTarget.USER_LOCAL };
 
 		this.settingFastUpdateDelayer = new Delayer<void>(SettingsEditor2.SETTING_UPDATE_FAST_DEBOUNCE);
@@ -285,7 +282,7 @@ export class SettingsEditor2 extends EditorPane {
 		this._register(configurationService.onDidChangeConfiguration(e => {
 			if (e.affectedKeys.has(WorkbenchSettingsEditorSettings.ShowAISearchToggle)) {
 				const isToggleVisible = this.configurationService.getValue<boolean>(WorkbenchSettingsEditorSettings.ShowAISearchToggle);
-				this.updateAISearchToggleVisibility(isToggleVisible);
+				this.updateAiSearchToggleVisibility(isToggleVisible);
 			}
 			if (e.source !== ConfigurationTarget.DEFAULT) {
 				this.onConfigUpdate(e.affectedKeys);
@@ -335,20 +332,22 @@ export class SettingsEditor2 extends EditorPane {
 		});
 	}
 
-	private updateAISearchToggleVisibility(isVisible: boolean): void {
+	private updateAiSearchToggleVisibility(showToggle: boolean): void {
 		if (!this.searchContainer || !this.showAiResultsAction || !this.searchInputActionBar) {
 			return;
 		}
 
-		if (isVisible) {
+		const chatSetupHidden = this.contextKeyService.getContextKeyValue<boolean>('chatSetupHidden');
+		const alreadyVisible = this.searchInputActionBar.hasAction(this.showAiResultsAction);
+		if (!alreadyVisible && showToggle && !chatSetupHidden) {
 			this.searchInputActionBar.push(this.showAiResultsAction, {
-				index: 1,
+				index: 0,
 				label: false,
 				icon: true
 			});
 			this.searchContainer.classList.add('with-ai-toggle');
-		} else if (this.searchInputActionBar.hasAction(this.showAiResultsAction)) {
-			this.searchInputActionBar.pull(1);
+		} else if (alreadyVisible) {
+			this.searchInputActionBar.pull(0);
 			this.searchContainer.classList.remove('with-ai-toggle');
 		}
 	}
@@ -614,6 +613,7 @@ export class SettingsEditor2 extends EditorPane {
 	}
 
 	clearSearchResults(): void {
+		this.updateAiSearchToggleVisibility(false);
 		this.searchWidget.setValue('');
 		this.focusSearch();
 	}
@@ -654,22 +654,11 @@ export class SettingsEditor2 extends EditorPane {
 		));
 
 		const showAiResultActionClassNames = ['action-label', ThemeIcon.asClassName(preferencesAiResultsIcon)];
-		const searchServiceEnabled = this.aiSettingsSearchService.isEnabled();
-
 		this.showAiResultsAction = this._register(new Action(SETTINGS_EDITOR_COMMAND_SHOW_AI_RESULTS,
-			searchServiceEnabled
-				? localize('showAiResultsDescription', "Search settings with AI")
-				: localize('showAiResultsNotReady', "AI search functionality loading..."),
-			showAiResultActionClassNames.join(' '), searchServiceEnabled
+			localize('showAiResults', "Show AI-recommended results"), showAiResultActionClassNames.join(' '), true
 		));
-		this._register(this.aiSettingsSearchService.onProviderRegistered(() => {
-			if (this.showAiResultsAction) {
-				this.showAiResultsAction.label = localize('showAiResultsDescription', "Search settings with AI");
-				this.showAiResultsAction.enabled = true;
-			}
-		}));
-		this._register(this.showAiResultsAction.onDidChange(() => {
-			this.onSearchInputChanged(true);
+		this._register(this.showAiResultsAction.onDidChange(async () => {
+			await this.toggleAiSearch();
 		}));
 
 		const filterAction = this._register(new Action(SETTINGS_EDITOR_COMMAND_SUGGEST_FILTERS,
@@ -759,15 +748,12 @@ export class SettingsEditor2 extends EditorPane {
 
 		const actionsToPush = [clearInputAction, filterAction];
 		this.searchInputActionBar.push(actionsToPush, { label: false, icon: true });
-
-		const setupHidden = this.contextKeyService.getContextKeyValue<boolean>('chatSetupHidden');
-		const showSuggestions = this.configurationService.getValue<boolean>(WorkbenchSettingsEditorSettings.ShowAISearchToggle);
-		this.updateAISearchToggleVisibility(!setupHidden && showSuggestions);
 	}
 
-	toggleAiSearch(): void {
-		if (this.showAiResultsAction && this.showAiResultsAction.enabled) {
-			this.showAiResultsAction.checked = !this.showAiResultsAction.checked;
+	async toggleAiSearch(): Promise<void> {
+		if (this.searchResultModel && this.showAiResultsAction) {
+			this.searchResultModel.showAiResults = this.showAiResultsAction.checked ?? false;
+			this.onDidFinishSearch(true, undefined);
 		}
 	}
 
@@ -1711,7 +1697,6 @@ export class SettingsEditor2 extends EditorPane {
 			}
 
 			this.searchDelayer.cancel();
-			this.aiSearchDelayer.cancel();
 			if (this.searchInProgress) {
 				this.searchInProgress.dispose(true);
 				this.searchInProgress = null;
@@ -1781,37 +1766,11 @@ export class SettingsEditor2 extends EditorPane {
 		}
 
 		const searchInProgress = this.searchInProgress = new CancellationTokenSource();
-
-		if (this.showAiResultsAction?.checked) {
-			return this.searchDelayer.trigger(async () => {
-				// Use both embeddings and LLM results from the AI search.
-				if (searchInProgress.token.isCancellationRequested) {
-					return;
-				}
-				const embeddingsResults = await this.doAiSearch(query, searchInProgress.token);
-				if (!this.searchResultModel || searchInProgress.token.isCancellationRequested) {
-					return;
-				}
-				this.searchResultModel.showAiResults = true;
-				if (embeddingsResults?.filterMatches.length) {
-					this.aiSearchDelayer.trigger(async () => {
-						await this.getLLMRankedResults(query, searchInProgress.token);
-						if (searchInProgress.token.isCancellationRequested) {
-							return;
-						}
-						this.onDidFinishSearch(expandResults, progressRunner);
-					});
-				} else {
-					this.onDidFinishSearch(expandResults, progressRunner);
-				}
-			});
-		}
-
-		// Use the local search algorithm and only the embeddings from the AI search.
 		return this.searchDelayer.trigger(async () => {
 			if (searchInProgress.token.isCancellationRequested) {
 				return;
 			}
+			this.updateAiSearchToggleVisibility(false);
 			const localResults = await this.doLocalSearch(query, searchInProgress.token);
 			if (!this.searchResultModel || searchInProgress.token.isCancellationRequested) {
 				return;
@@ -1832,11 +1791,27 @@ export class SettingsEditor2 extends EditorPane {
 				return;
 			}
 
+			// Kick off an AI search in the background. We purposely do not await it.
+			if (this.aiSearchPromise) {
+				this.aiSearchPromise.cancel();
+			}
+			this.aiSearchPromise = createCancelablePromise(token => {
+				return this.doAiSearch(query, token).then((results) => {
+					if (results) {
+						this.updateAiSearchToggleVisibility(true);
+					}
+				}).catch(e => {
+					if (!isCancellationError(e)) {
+						this.logService.trace('Error during AI settings search:', e);
+					}
+				});
+			});
+
 			this.onDidFinishSearch(expandResults, progressRunner);
 		});
 	}
 
-	private onDidFinishSearch(expandResults: boolean, progressRunner: IProgressRunner | undefined) {
+	private onDidFinishSearch(expandResults: boolean, progressRunner: IProgressRunner | undefined): void {
 		this.tocTreeModel.currentSearchModel = this.searchResultModel;
 		if (expandResults) {
 			this.tocTree.setFocus([]);
@@ -1862,15 +1837,21 @@ export class SettingsEditor2 extends EditorPane {
 		return this.searchWithProvider(SearchResultIdx.Remote, remoteSearchProvider, token);
 	}
 
-	private doAiSearch(query: string, token: CancellationToken): Promise<ISearchResult | null> {
+	private async doAiSearch(query: string, token: CancellationToken): Promise<ISearchResult | null> {
 		const aiSearchProvider = this.preferencesSearchService.getAiSearchProvider(query);
-		return this.searchWithProvider(SearchResultIdx.Embeddings, aiSearchProvider, token);
+		const embeddingsResults = await this.searchWithProvider(SearchResultIdx.Embeddings, aiSearchProvider, token);
+		if (!embeddingsResults || token.isCancellationRequested) {
+			return null;
+		}
+		return await this.getLLMRankedResults(query, token);
 	}
 
 	private async getLLMRankedResults(query: string, token: CancellationToken): Promise<ISearchResult | null> {
 		const aiSearchProvider = this.preferencesSearchService.getAiSearchProvider(query);
 		const result = await aiSearchProvider.getLLMRankedResults(token);
-		// This function has to be called after doAiSearch is called and done.
+		if (!result || token.isCancellationRequested) {
+			return null;
+		}
 		this.searchResultModel!.setResult(SearchResultIdx.AiSelected, result);
 		return result;
 	}

--- a/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
@@ -659,7 +659,7 @@ export class SettingsEditor2 extends EditorPane {
 			localize('showAiResults', "Show AI-recommended results"), showAiResultActionClassNames.join(' '), true
 		));
 		this._register(this.showAiResultsAction.onDidChange(async () => {
-			await this.toggleAiSearch();
+			await this.onDidToggleAiSearch();
 		}));
 
 		const filterAction = this._register(new Action(SETTINGS_EDITOR_COMMAND_SUGGEST_FILTERS,
@@ -751,7 +751,13 @@ export class SettingsEditor2 extends EditorPane {
 		this.searchInputActionBar.push(actionsToPush, { label: false, icon: true });
 	}
 
-	async toggleAiSearch(): Promise<void> {
+	toggleAiSearch(): void {
+		if (this.showAiResultsAction) {
+			this.showAiResultsAction.checked = !this.showAiResultsAction.checked;
+		}
+	}
+
+	private async onDidToggleAiSearch(): Promise<void> {
 		if (this.searchResultModel && this.showAiResultsAction) {
 			this.searchResultModel.showAiResults = this.showAiResultsAction.checked ?? false;
 			this.onDidFinishSearch(true, undefined);

--- a/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
@@ -1851,11 +1851,11 @@ export class SettingsEditor2 extends EditorPane {
 			return null;
 		}
 		const llmResults = await this.getLLMRankedResults(query, token);
-		if (!llmResults) {
+		if (token.isCancellationRequested) {
 			return null;
 		}
 		return {
-			filterMatches: embeddingsResults.filterMatches.concat(llmResults.filterMatches),
+			filterMatches: embeddingsResults.filterMatches.concat(llmResults?.filterMatches ?? []),
 			exactMatch: false
 		};
 	}


### PR DESCRIPTION
This PR changes the behaviour of AI settings search in the Settings editor in the following ways

- The Settings editor will only search and show results from the more performant algorithms, i.e. string-matching and TF-IDF. Previously, it was fetching embeddings results as well for users with Copilot enabled.
- The Settings editor will start an AI search in the background after those searches are complete. The search uses free models and will only apply to users with Copilot enabled.
- The sparkle is now hidden until there are AI search results available. Clicking on the toggle now immediately flips the Settings editor search results between the non-AI ones and the AI ones.

