### PR TITLE
add 2 states for `selectionMode` for the terminal

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalSuggestAddon.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalSuggestAddon.ts
@@ -681,7 +681,8 @@ export class SuggestAddon extends Disposable implements ITerminalAddon, ISuggest
 				this._instantiationService.createInstance(PersistedWidgetSize),
 				{
 					statusBarMenuId: MenuId.MenubarTerminalSuggestStatusMenu,
-					showStatusBarSettingId: TerminalSuggestSettingId.ShowStatusBar
+					showStatusBarSettingId: TerminalSuggestSettingId.ShowStatusBar,
+					selectionModeSettingId: TerminalSuggestSettingId.SelectionMode,
 				},
 				this._getFontInfo.bind(this),
 				this._onDidFontConfigurationChange.event.bind(this),

--- a/src/vs/workbench/contrib/terminalContrib/suggest/common/terminalSuggestConfiguration.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/common/terminalSuggestConfiguration.ts
@@ -19,6 +19,7 @@ export const enum TerminalSuggestSettingId {
 	CdPath = 'terminal.integrated.suggest.cdPath',
 	InlineSuggestion = 'terminal.integrated.suggest.inlineSuggestion',
 	UpArrowNavigatesHistory = 'terminal.integrated.suggest.upArrowNavigatesHistory',
+	SelectionMode = 'terminal.integrated.suggest.selectionMode',
 }
 
 export const windowsDefaultExecutableExtensions: string[] = [
@@ -121,13 +122,23 @@ export const terminalSuggestConfiguration: IStringDictionary<IConfigurationPrope
 		markdownDescription: localize('suggest.runOnEnter', "Controls whether suggestions should run immediately when `Enter` (not `Tab`) is used to accept the result."),
 		enum: ['ignore', 'never', 'exactMatch', 'exactMatchIgnoreExtension', 'always'],
 		markdownEnumDescriptions: [
-			localize('runOnEnter.ignore', "Ignore suggestions and send the enter directly to the shell without completing. This is used as the default value so the suggest widget is as unobtrusive as possible."),
 			localize('runOnEnter.never', "Never run on `Enter`."),
 			localize('runOnEnter.exactMatch', "Run on `Enter` when the suggestion is typed in its entirety."),
 			localize('runOnEnter.exactMatchIgnoreExtension', "Run on `Enter` when the suggestion is typed in its entirety or when a file is typed without its extension included."),
 			localize('runOnEnter.always', "Always run on `Enter`.")
 		],
-		default: 'ignore',
+		default: 'never',
+		tags: ['preview']
+	},
+	[TerminalSuggestSettingId.SelectionMode]: {
+		markdownDescription: localize('terminal.integrated.selectionMode', "Controls how suggestion selection works in the integrated terminal."),
+		type: 'string',
+		enum: ['always', 'never'],
+		enumDescriptions: [
+			localize('terminal.integrated.selectionMode.always', "Always select."),
+			localize('terminal.integrated.selectionMode.never', "No selection will occur until the user explicitly navigates the suggestions."),
+		],
+		default: 'always',
 		tags: ['preview']
 	},
 	[TerminalSuggestSettingId.WindowsExecutableExtensions]: {
@@ -179,6 +190,7 @@ export const terminalSuggestConfiguration: IStringDictionary<IConfigurationPrope
 		default: true,
 		tags: ['preview']
 	},
+
 };
 
 

--- a/src/vs/workbench/services/suggest/browser/simpleSuggestWidget.ts
+++ b/src/vs/workbench/services/suggest/browser/simpleSuggestWidget.ts
@@ -71,6 +71,25 @@ export interface IWorkbenchSuggestWidgetOptions {
 	 * The setting for showing the status bar.
 	 */
 	showStatusBarSettingId?: string;
+
+	/**
+	 * The setting for selection mode.
+	 */
+	selectionModeSettingId?: string;
+}
+
+/**
+ * Controls how suggest selection works
+*/
+export const enum SuggestSelectionMode {
+	/**
+	 * Always select, what enter does depends on runOnEnter.
+	 */
+	Always = 'always',
+	/**
+	 * User needs to press down to select.
+	 */
+	Never = 'never'
 }
 
 export class SimpleSuggestWidget<TModel extends SimpleCompletionModel<TItem>, TItem extends SimpleCompletionItem> extends Disposable {
@@ -421,7 +440,8 @@ export class SimpleSuggestWidget<TModel extends SimpleCompletionModel<TItem>, TI
 			this._setState(isFrozen ? State.Frozen : State.Open);
 			this._list.reveal(selectionIndex, 0);
 			this._list.setFocus([selectionIndex]);
-			// this._list.setFocus(noFocus ? [] : [selectionIndex]);
+			const noFocus = this._options?.selectionModeSettingId ? this._configurationService.getValue<SuggestSelectionMode>(this._options.selectionModeSettingId) === SuggestSelectionMode.Never : false;
+			this._list.setFocus(noFocus ? [] : [selectionIndex]);
 		} finally {
 			// this._onDidFocus.resume();
 			// this._onDidSelect.resume();


### PR DESCRIPTION
part of #243887

Also removes `ignore` as the default option for `runOnEnter` in favor of `none`.

https://github.com/user-attachments/assets/c99e6d80-b89a-4fa8-b512-4825e0d0226d

