### PR TITLE
prompts: allow loading instructions on demand

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/chatAttachmentsContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/chatAttachmentsContentPart.ts
@@ -12,7 +12,7 @@ import { URI } from '../../../../../base/common/uri.js';
 import { Range } from '../../../../../editor/common/core/range.js';
 import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
 import { ResourceLabels } from '../../../../browser/labels.js';
-import { IChatRequestVariableEntry, isElementVariableEntry, isImageVariableEntry, isNotebookOutputVariableEntry, isPasteVariableEntry, isPromptFileVariableEntry, isSCMHistoryItemVariableEntry, OmittedState } from '../../common/chatVariableEntries.js';
+import { IChatRequestVariableEntry, isElementVariableEntry, isImageVariableEntry, isNotebookOutputVariableEntry, isPasteVariableEntry, isPromptFileVariableEntry, isPromptTextVariableEntry, isSCMHistoryItemVariableEntry, OmittedState } from '../../common/chatVariableEntries.js';
 import { ChatResponseReferencePartStatusKind, IChatContentReference } from '../../common/chatService.js';
 import { DefaultChatAttachmentWidget, ElementChatAttachmentWidget, FileAttachmentWidget, ImageAttachmentWidget, NotebookCellOutputChatAttachmentWidget, PasteAttachmentWidget, PromptFileAttachmentWidget, SCMHistoryItemAttachmentWidget, ToolSetOrToolItemAttachmentWidget } from '../chatAttachmentWidgets.js';
 
@@ -60,7 +60,10 @@ export class ChatAttachmentsContentPart extends Disposable {
 				attachment.omittedState = isAttachmentPartialOrOmitted ? OmittedState.Full : attachment.omittedState;
 				widget = this.instantiationService.createInstance(ImageAttachmentWidget, resource, attachment, undefined, { shouldFocusClearButton: false, supportsDeletion: false }, container, this._contextResourceLabels, hoverDelegate);
 			} else if (resource && isPromptFileVariableEntry(attachment)) {
-				widget = this.instantiationService.createInstance(PromptFileAttachmentWidget, resource, attachment, undefined, { shouldFocusClearButton: false, supportsDeletion: false }, container, this._contextResourceLabels, hoverDelegate);
+				widget = this.instantiationService.createInstance(PromptFileAttachmentWidget, attachment, undefined, { shouldFocusClearButton: false, supportsDeletion: false }, container, this._contextResourceLabels, hoverDelegate);
+			} else if (isPromptTextVariableEntry(attachment)) {
+				continue; // do not show for now, work in progress @aeschli)
+				//widget = this.instantiationService.createInstance(PromptTextAttachmentWidget, attachment, undefined, { shouldFocusClearButton: false, supportsDeletion: false }, container, this._contextResourceLabels, hoverDelegate);
 			} else if (resource && (attachment.kind === 'file' || attachment.kind === 'directory')) {
 				widget = this.instantiationService.createInstance(FileAttachmentWidget, resource, range, attachment, correspondingContentReference, undefined, { shouldFocusClearButton: false, supportsDeletion: false }, container, this._contextResourceLabels, hoverDelegate);
 			} else if (isPasteVariableEntry(attachment)) {

--- a/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
@@ -76,7 +76,7 @@ import { IChatAgentService } from '../common/chatAgents.js';
 import { ChatContextKeys } from '../common/chatContextKeys.js';
 import { IChatEditingSession } from '../common/chatEditingService.js';
 import { ChatEntitlement, IChatEntitlementService } from '../common/chatEntitlementService.js';
-import { IChatRequestVariableEntry, ChatRequestVariableSet, isPromptFileVariableEntry, isElementVariableEntry, isImageVariableEntry, isNotebookOutputVariableEntry, isPasteVariableEntry, isSCMHistoryItemVariableEntry } from '../common/chatVariableEntries.js';
+import { IChatRequestVariableEntry, ChatRequestVariableSet, isPromptFileVariableEntry, isElementVariableEntry, isImageVariableEntry, isNotebookOutputVariableEntry, isPasteVariableEntry, isSCMHistoryItemVariableEntry, isPromptTextVariableEntry } from '../common/chatVariableEntries.js';
 import { ChatMode2, IChatMode, IChatModeService, isBuiltinChatMode, validateChatMode2 } from '../common/chatModes.js';
 import { IChatFollowup } from '../common/chatService.js';
 import { IChatResponseViewModel } from '../common/chatViewModel.js';
@@ -87,7 +87,7 @@ import { CancelAction, ChatEditingSessionSubmitAction, ChatOpenModelPickerAction
 import { ImplicitContextAttachmentWidget } from './attachments/implicitContextAttachment.js';
 import { IChatWidget } from './chat.js';
 import { ChatAttachmentModel } from './chatAttachmentModel.js';
-import { DefaultChatAttachmentWidget, ElementChatAttachmentWidget, FileAttachmentWidget, ImageAttachmentWidget, NotebookCellOutputChatAttachmentWidget, PasteAttachmentWidget, PromptFileAttachmentWidget, SCMHistoryItemAttachmentWidget, ToolSetOrToolItemAttachmentWidget } from './chatAttachmentWidgets.js';
+import { DefaultChatAttachmentWidget, ElementChatAttachmentWidget, FileAttachmentWidget, ImageAttachmentWidget, NotebookCellOutputChatAttachmentWidget, PasteAttachmentWidget, PromptFileAttachmentWidget, PromptTextAttachmentWidget, SCMHistoryItemAttachmentWidget, ToolSetOrToolItemAttachmentWidget } from './chatAttachmentWidgets.js';
 import { IDisposableReference } from './chatContentParts/chatCollections.js';
 import { CollapsibleListPool, IChatCollapsibleListItem } from './chatContentParts/chatReferencesContentPart.js';
 import { ChatDragAndDrop } from './chatDragAndDrop.js';
@@ -1267,8 +1267,10 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 				attachmentWidget = this.instantiationService.createInstance(ToolSetOrToolItemAttachmentWidget, attachment, this._currentLanguageModel, options, container, this._contextResourceLabels, hoverDelegate);
 			} else if (resource && isNotebookOutputVariableEntry(attachment)) {
 				attachmentWidget = this.instantiationService.createInstance(NotebookCellOutputChatAttachmentWidget, resource, attachment, this._currentLanguageModel, options, container, this._contextResourceLabels, hoverDelegate);
-			} else if (resource && isPromptFileVariableEntry(attachment)) {
-				attachmentWidget = this.instantiationService.createInstance(PromptFileAttachmentWidget, resource, attachment, this._currentLanguageModel, options, container, this._contextResourceLabels, hoverDelegate);
+			} else if (isPromptFileVariableEntry(attachment)) {
+				attachmentWidget = this.instantiationService.createInstance(PromptFileAttachmentWidget, attachment, this._currentLanguageModel, options, container, this._contextResourceLabels, hoverDelegate);
+			} else if (isPromptTextVariableEntry(attachment)) {
+				attachmentWidget = this.instantiationService.createInstance(PromptTextAttachmentWidget, attachment, undefined, options, container, this._contextResourceLabels, hoverDelegate);
 			} else if (resource && (attachment.kind === 'file' || attachment.kind === 'directory')) {
 				attachmentWidget = this.instantiationService.createInstance(FileAttachmentWidget, resource, range, attachment, undefined, this._currentLanguageModel, options, container, this._contextResourceLabels, hoverDelegate);
 			} else if (isImageVariableEntry(attachment)) {

--- a/src/vs/workbench/contrib/chat/browser/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatWidget.ts
@@ -1635,6 +1635,10 @@ export class ChatWidget extends Disposable implements IChatWidget {
 	 * such instructions to the context.
 	 */
 	private async _autoAttachInstructions(attachedContext: ChatRequestVariableSet): Promise<void> {
+		const copilotInstructions = await this.promptsService.findCopilotInstructions();
+		if (copilotInstructions.length) {
+			attachedContext.add(...copilotInstructions.map(instruction => toPromptFileVariableEntry(instruction, true)));
+		}
 		const existingInstructions = new ResourceSet();
 		const fileInContext = [];
 
@@ -1650,13 +1654,16 @@ export class ChatWidget extends Disposable implements IChatWidget {
 		}
 
 		const automaticInstructions = await this.promptsService.findInstructionFilesFor(fileInContext, existingInstructions);
-		const promptVariableEntries = automaticInstructions.map(instruction => toPromptFileVariableEntry(instruction.uri, true, instruction.reason));
+		if (automaticInstructions.length) {
+			const promptVariableEntries = automaticInstructions.map(instruction => toPromptFileVariableEntry(instruction.uri, true, instruction.reason));
 
-		// add instructions to the final context list
-		attachedContext.add(...promptVariableEntries);
+			// add instructions to the final context list
+			attachedContext.add(...promptVariableEntries);
 
-		// add to attached list to make the instructions sticky
-		this.inputPart.attachmentModel.addContext(...promptVariableEntries);
+			// add to attached list to make the instructions sticky
+			this.inputPart.attachmentModel.addContext(...promptVariableEntries);
+		}
+
 	}
 }
 

--- a/src/vs/workbench/contrib/chat/browser/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatWidget.ts
@@ -70,6 +70,7 @@ import { MicrotaskDelay } from '../../../../base/common/symbols.js';
 import { IChatRequestVariableEntry, ChatRequestVariableSet as ChatRequestVariableSet, isPromptFileVariableEntry, toPromptFileVariableEntry } from '../common/chatVariableEntries.js';
 import { PromptsConfig } from '../common/promptSyntax/config/config.js';
 import { CancellationToken } from '../../../../base/common/cancellation.js';
+import { ComputeAutomaticInstructions } from '../common/promptSyntax/computeAutomaticInstructions.js';
 
 const $ = dom.$;
 
@@ -1209,7 +1210,7 @@ export class ChatWidget extends Disposable implements IChatWidget {
 	private _findPromptFileInContext(attachedContext: ChatRequestVariableSet): URI | undefined {
 		for (const item of attachedContext.asArray()) {
 			if (isPromptFileVariableEntry(item) && item.isRoot && this.promptsService.getPromptFileType(item.value) === PromptsType.prompt) {
-				return IChatRequestVariableEntry.toUri(item);
+				return item.value;
 			}
 		}
 		return undefined;
@@ -1288,7 +1289,6 @@ export class ChatWidget extends Disposable implements IChatWidget {
 				// process the prompt command
 				await this._applyPromptFileIfSet(requestInputs);
 				await this._autoAttachInstructions(requestInputs.attachedContext);
-				await this._collectReferencedInstructions(requestInputs.attachedContext);
 			}
 
 			if (this.viewOptions.enableWorkingSet !== undefined && this.input.currentMode === ChatMode.Edit && !this.chatService.edits2Enabled) {
@@ -1617,57 +1617,20 @@ export class ChatWidget extends Disposable implements IChatWidget {
 		this.inputPart.selectedToolsModel.enable(enabledToolSets, enabledTools, true);
 	}
 
-	private async _collectReferencedInstructions(attachedContext: ChatRequestVariableSet): Promise<void> {
-		for (const variable of attachedContext.asArray()) {
-			if (isPromptFileVariableEntry(variable)) {
-				const result = await this.promptsService.parse(variable.value, CancellationToken.None);
-				for (const ref of result.allValidReferences) {
-					const reason = localize('instruction.file.reason.referenced', 'Referenced by {0}', basename(variable.value));
-					attachedContext.add(toPromptFileVariableEntry(ref, true, reason));
-				}
-			}
-		}
-	}
-
 	/**
-	 * Resolves instructions that have `applyTo` metadata that can
-	 * match file references in the attached context and then attaches
-	 * such instructions to the context.
+	 * Adds additional instructions to the context
+	 * - instructions that have a 'applyTo' pattern that matches the current input
+	 * - instructions referenced in the copilot settings 'copilot-instructions*
+	 * - instructions referenced in an already included instruction file
 	 */
 	private async _autoAttachInstructions(attachedContext: ChatRequestVariableSet): Promise<void> {
-		const copilotInstructions = await this.promptsService.findCopilotInstructions();
-		if (copilotInstructions.length) {
-			attachedContext.add(...copilotInstructions.map(instruction => toPromptFileVariableEntry(instruction, true)));
-		}
-		const existingInstructions = new ResourceSet();
-		const fileInContext = [];
+		const computer = this.instantiationService.createInstance(ComputeAutomaticInstructions);
+		await computer.collect(attachedContext, true, CancellationToken.None);
 
-		for (const variable of attachedContext.asArray()) {
-			if (isPromptFileVariableEntry(variable)) {
-				existingInstructions.add(variable.value);
-			} else {
-				const uri = IChatRequestVariableEntry.toUri(variable);
-				if (uri) {
-					fileInContext.push(uri);
-				}
-			}
-		}
-
-		const automaticInstructions = await this.promptsService.findInstructionFilesFor(fileInContext, existingInstructions);
-		if (automaticInstructions.length) {
-			const promptVariableEntries = automaticInstructions.map(instruction => toPromptFileVariableEntry(instruction.uri, true, instruction.reason));
-
-			// add instructions to the final context list
-			attachedContext.add(...promptVariableEntries);
-
-			// add to attached list to make the instructions sticky
-			this.inputPart.attachmentModel.addContext(...promptVariableEntries);
-		}
-
+		// add to attached list to make the instructions sticky
+		//this.inputPart.attachmentModel.addContext(...computer.autoAddedInstructions);
 	}
 }
-
-
 
 export class ChatWidgetService extends Disposable implements IChatWidgetService {
 

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/computeAutomaticInstructions.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/computeAutomaticInstructions.ts
@@ -1,0 +1,281 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { CancellationToken } from '../../../../../base/common/cancellation.js';
+import { match, splitGlobAware } from '../../../../../base/common/glob.js';
+import { ResourceMap, ResourceSet } from '../../../../../base/common/map.js';
+import { Schemas } from '../../../../../base/common/network.js';
+import { basename, joinPath } from '../../../../../base/common/resources.js';
+import { isObject, isString } from '../../../../../base/common/types.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { localize } from '../../../../../nls.js';
+import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
+import { IFileService } from '../../../../../platform/files/common/files.js';
+import { ILabelService } from '../../../../../platform/label/common/label.js';
+import { ILogService } from '../../../../../platform/log/common/log.js';
+import { IWorkspaceContextService } from '../../../../../platform/workspace/common/workspace.js';
+import { ChatRequestVariableSet, IChatRequestVariableEntry, IPromptFileVariableEntry, isPromptFileVariableEntry, toPromptFileVariableEntry, toPromptTextVariableEntry } from '../chatVariableEntries.js';
+import { PromptsConfig } from './config/config.js';
+import { COPILOT_CUSTOM_INSTRUCTIONS_FILENAME } from './config/promptFileLocations.js';
+import { PromptsType } from './promptTypes.js';
+import { IPromptParserResult, IPromptPath, IPromptsService } from './service/promptsService.js';
+
+export class ComputeAutomaticInstructions {
+
+	private _parseResults: ResourceMap<IPromptParserResult> = new ResourceMap();
+
+	private _autoAddedInstructions: IPromptFileVariableEntry[] = [];
+
+	constructor(
+		@IPromptsService private readonly _promptsService: IPromptsService,
+		@ILogService public readonly _logService: ILogService,
+		@ILabelService private readonly _labelService: ILabelService,
+		@IConfigurationService private readonly _configurationService: IConfigurationService,
+		@IWorkspaceContextService private readonly _workspaceService: IWorkspaceContextService,
+		@IFileService private readonly _fileService: IFileService,
+	) {
+	}
+
+	get autoAddedInstructions(): readonly IPromptFileVariableEntry[] {
+		return this._autoAddedInstructions;
+	}
+
+	private async _parsePromptFile(uri: URI, token: CancellationToken): Promise<IPromptParserResult> {
+		if (this._parseResults.has(uri)) {
+			return this._parseResults.get(uri)!;
+		}
+		const result = await this._promptsService.parse(uri, token);
+		this._parseResults.set(uri, result);
+		return result;
+	}
+
+	public async collect(variables: ChatRequestVariableSet, addInstructionsSummary: boolean, token: CancellationToken): Promise<void> {
+		const instructionFiles = await this._promptsService.listPromptFiles(PromptsType.instructions, token);
+
+		this._logService.trace(`[InstructionsContextComputer] ${instructionFiles.length} instruction files available.`);
+
+		// find instructions where the `applyTo` matches the attached context
+
+		const context = this._getContext(variables);
+		const autoAddedInstructions = await this.findInstructionFilesFor(instructionFiles, context, token);
+
+		variables.add(...autoAddedInstructions);
+		this._autoAddedInstructions.push(...autoAddedInstructions);
+
+		// get copilot instructions
+		const copilotInstructions = await this._getCopilotInstructions();
+		for (const file of copilotInstructions.files) {
+			variables.add(toPromptFileVariableEntry(file, true));
+		}
+		this._logService.trace(`[InstructionsContextComputer]  ${copilotInstructions.files.size} Copilot instructions files added.`);
+
+		const copilotInstructionsFromSettings = this._getCopilotTextInstructions(copilotInstructions.instructionMessages);
+		const instructionsWithPatternsList = addInstructionsSummary ? await this._getInstructionsWithPatternsList(instructionFiles, variables, token) : [];
+
+		if (copilotInstructionsFromSettings.length + instructionsWithPatternsList.length > 0) {
+			const text = `${copilotInstructionsFromSettings.join('\n')}\n\n${instructionsWithPatternsList.join('\n')}`;
+			const settingId = copilotInstructionsFromSettings.length > 0 ? PromptsConfig.COPILOT_INSTRUCTIONS : undefined;
+			variables.add(toPromptTextVariableEntry(text, settingId));
+		}
+		// add all instructions for all instruction files that are in the context
+		this._addReferencedInstructions(variables, token);
+
+	}
+
+	/** public for testing */
+	public async findInstructionFilesFor(instructionFiles: readonly IPromptPath[], context: { files: ResourceSet; instructions: ResourceSet }, token: CancellationToken): Promise<IPromptFileVariableEntry[]> {
+
+		const autoAddedInstructions: IPromptFileVariableEntry[] = [];
+		for (const instructionFile of instructionFiles) {
+			const { metadata, uri } = await this._parsePromptFile(instructionFile.uri, token);
+
+			if (metadata?.promptType !== PromptsType.instructions) {
+				this._logService.trace(`[InstructionsContextComputer] Not an instruction file: ${uri}`);
+				continue;
+			}
+			const applyTo = metadata?.applyTo;
+
+			if (!applyTo) {
+				this._logService.trace(`[InstructionsContextComputer] No 'applyTo' found: ${uri}`);
+				continue;
+			}
+
+			if (context.instructions.has(uri)) {
+				// the instruction file is already part of the input or has already been processed
+				this._logService.trace(`[InstructionsContextComputer] Skipping already processed instruction file: ${uri}`);
+				continue;
+			}
+
+			const match = this._matches(context.files, applyTo);
+			if (match) {
+				this._logService.trace(`[InstructionsContextComputer] Match for ${uri} with ${match.pattern}${match.file ? ` for file ${match.file}` : ''}`);
+
+				const reason = !match.file ?
+					localize('instruction.file.reason.allFiles', 'Automatically attached as pattern is **') :
+					localize('instruction.file.reason.specificFile', 'Automatically attached as pattern {0} matches {1}', applyTo, this._labelService.getUriLabel(match.file, { relative: true }));
+
+
+				autoAddedInstructions.push(toPromptFileVariableEntry(uri, true, reason));
+			} else {
+				this._logService.trace(`[InstructionsContextComputer] No match for ${uri} with ${applyTo}`);
+			}
+		}
+		return autoAddedInstructions;
+	}
+
+	private _getContext(attachedContext: ChatRequestVariableSet): { files: ResourceSet; instructions: ResourceSet } {
+		const files = new ResourceSet();
+		const instructions = new ResourceSet();
+		for (const variable of attachedContext.asArray()) {
+			if (isPromptFileVariableEntry(variable)) {
+				instructions.add(variable.value);
+			} else {
+				const uri = IChatRequestVariableEntry.toUri(variable);
+				if (uri) {
+					files.add(uri);
+				}
+			}
+		}
+
+		return { files, instructions };
+	}
+
+	private async _getCopilotInstructions(): Promise<{ files: ResourceSet; instructionMessages: Set<string> }> {
+		const instructionMessages = new Set<string>();
+		const instructionFiles = new Set<string>();
+
+		const useCopilotInstructionsFiles = this._configurationService.getValue(PromptsConfig.USE_COPILOT_INSTRUCTION_FILES);
+		if (useCopilotInstructionsFiles) {
+			instructionFiles.add(`.github/` + COPILOT_CUSTOM_INSTRUCTIONS_FILENAME);
+		}
+
+		const config = this._configurationService.inspect(PromptsConfig.COPILOT_INSTRUCTIONS);
+
+		[config.workspaceFolderValue, config.workspaceValue, config.userValue].forEach((value: any) => {
+			if (Array.isArray(value)) {
+				for (const item of value) {
+					if (isString(item)) {
+						instructionMessages.add(item);
+					} else if (item && isObject(item)) {
+						if (isString(item.text)) {
+							instructionMessages.add(item.text);
+						} else if (isString(item.file)) {
+							instructionFiles.add(item.file);
+						}
+					}
+				}
+			}
+		});
+
+		const { folders } = this._workspaceService.getWorkspace();
+		const files = new ResourceSet();
+		for (const folder of folders) {
+			for (const instructionFilePath of instructionFiles) {
+				const file = joinPath(folder.uri, instructionFilePath);
+				if (await this._fileService.exists(file)) {
+					files.add(file);
+				}
+			}
+		}
+		return { files, instructionMessages };
+	}
+
+	private _matches(files: ResourceSet, applyToPattern: string): { pattern: string; file?: URI } | undefined {
+		const patterns = splitGlobAware(applyToPattern, ',');
+		const patterMatches = (pattern: string): { pattern: string; file?: URI } | undefined => {
+			pattern = pattern.trim();
+			if (pattern.length === 0) {
+				// if glob pattern is empty, skip it
+				return undefined;
+			}
+			if (pattern === '**' || pattern === '**/*' || pattern === '*') {
+				// if glob pattern is one of the special wildcard values,
+				// add the instructions file event if no files are attached
+				return { pattern };
+			}
+			if (!pattern.startsWith('/') && !pattern.startsWith('**/')) {
+				// support relative glob patterns, e.g. `src/**/*.js`
+				pattern = '**/' + pattern;
+			}
+
+			// match each attached file with each glob pattern and
+			// add the instructions file if its rule matches the file
+			for (const file of files) {
+				// if the file is not a valid URI, skip it
+				if (match(pattern, file.path)) {
+					return { pattern, file }; // return the matched pattern and file URI
+				}
+			}
+			return undefined;
+		};
+		for (const pattern of patterns) {
+			const matchResult = patterMatches(pattern);
+			if (matchResult) {
+				return matchResult; // return the first matched pattern and file URI
+			}
+		}
+		return undefined;
+	}
+
+	private async _getInstructionsWithPatternsList(instructionFiles: readonly IPromptPath[], _existingVariables: ChatRequestVariableSet, token: CancellationToken): Promise<string[]> {
+		const entries: string[] = [];
+		for (const instructionFile of instructionFiles) {
+			const { metadata, uri } = await this._parsePromptFile(instructionFile.uri, token);
+			if (metadata?.promptType !== PromptsType.instructions) {
+				continue;
+			}
+			const applyTo = metadata?.applyTo;
+
+
+			if (applyTo && applyTo !== '**' && applyTo !== '**/*' && applyTo !== '*') {
+				entries.push(`Instruction file '${getFilePath(uri)}' contains important rules for all files matching ${metadata.applyTo}.`);
+			}
+		}
+		if (entries.length === 0) {
+			return entries;
+		}
+		return [
+			'The user has provided a list of custopm instruction files that contain rules that need to be followed when modifying or creating new code.',
+			'Each file comes with a glob pattern that specifies which files the instructions apply to.',
+			'It is important to follow these instructions when working with the codebase. If the file is not already available as attachment, use the `read_file` tool to acquire it.',
+		].concat(entries);
+	}
+
+	private _getCopilotTextInstructions(iterable: Iterable<string>): string[] {
+		const entries: string[] = [];
+		for (const result of iterable) {
+			const message = result.trim();
+			if (message.length !== 0) {
+				entries.push(result);
+				entries.push();
+			}
+		}
+		if (entries.length === 0) {
+			return [];
+		}
+		return ['The user has provided the following instructions that you want to follow.'].concat(entries);
+	}
+
+	private async _addReferencedInstructions(attachedContext: ChatRequestVariableSet, token: CancellationToken): Promise<void> {
+		for (const variable of attachedContext.asArray()) {
+			if (isPromptFileVariableEntry(variable)) {
+				const result = await this._parsePromptFile(variable.value, token);
+				for (const ref of result.allValidReferences) {
+					if (await this._fileService.exists(ref)) {
+						const reason = localize('instruction.file.reason.referenced', 'Referenced by {0}', basename(variable.value));
+						attachedContext.add(toPromptFileVariableEntry(ref, true, reason));
+					}
+				}
+			}
+		}
+	}
+}
+
+function getFilePath(uri: URI): string {
+	if (uri.scheme === Schemas.file || uri.scheme === Schemas.vscodeRemote) {
+		return uri.fsPath;
+	}
+	return uri.toString();
+}

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/config/config.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/config/config.ts
@@ -50,6 +50,16 @@ export namespace PromptsConfig {
 	export const MODE_LOCATION_KEY = 'chat.modeFilesLocations';
 
 	/**
+	 * Configuration key for use of the copilot instructions file.
+	 */
+	export const USE_COPILOT_INSTRUCTION_FILES = 'github.copilot.chat.codeGeneration.useInstructionFiles';
+
+	/**
+	 * Configuration key for the copilot instruction setting.
+	 */
+	export const COPILOT_INSTRUCTIONS = 'github.copilot.chat.codeGeneration.instructions';
+
+	/**
 	 * Checks if the feature is enabled.
 	 * @see {@link PromptsConfig.KEY}.
 	 */

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/config/promptFileLocations.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/config/promptFileLocations.ts
@@ -34,7 +34,7 @@ export const COPILOT_CUSTOM_INSTRUCTIONS_FILENAME = 'copilot-instructions.md';
 export const PROMPT_DEFAULT_SOURCE_FOLDER = '.github/prompts';
 
 /**
- * Default reusable prompt files source folder.
+ * Default reusable instructions files source folder.
  */
 export const INSTRUCTIONS_DEFAULT_SOURCE_FOLDER = '.github/instructions';
 

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsService.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsService.ts
@@ -14,7 +14,6 @@ import { CancellationToken } from '../../../../../../base/common/cancellation.js
 import { PromptsType } from '../promptTypes.js';
 import { createDecorator } from '../../../../../../platform/instantiation/common/instantiation.js';
 import { ITopError } from '../parsers/types.js';
-import { ResourceSet } from '../../../../../../base/common/map.js';
 
 /**
  * Provides prompt services.
@@ -179,17 +178,6 @@ export interface IPromptsService extends IDisposable {
 	 * Returns a prompt command if the command name is valid.
 	 */
 	findPromptSlashCommands(): Promise<IChatPromptSlashCommand[]>;
-
-	/**
-	 * Find all instruction files which have a glob pattern in their
-	 * 'applyTo' metadata record that match the provided list of files.
-	 */
-	findInstructionFilesFor(fileUris: readonly URI[], ignoreInstructions?: ResourceSet): Promise<readonly { uri: URI; reason: string }[]>;
-
-	/**
-	 * Looks in the workspace for the copilot instructions files.
-	 */
-	findCopilotInstructions(): Promise<readonly URI[]>;
 
 	/**
 	 * Event that is triggered when the list of custom chat modes changes.

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsService.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsService.ts
@@ -187,6 +187,11 @@ export interface IPromptsService extends IDisposable {
 	findInstructionFilesFor(fileUris: readonly URI[], ignoreInstructions?: ResourceSet): Promise<readonly { uri: URI; reason: string }[]>;
 
 	/**
+	 * Looks in the workspace for the copilot instructions files.
+	 */
+	findCopilotInstructions(): Promise<readonly URI[]>;
+
+	/**
 	 * Event that is triggered when the list of custom chat modes changes.
 	 */
 	readonly onDidChangeCustomChatModes: Event<void>;

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsServiceImpl.ts
@@ -6,12 +6,10 @@
 import { localize } from '../../../../../../nls.js';
 import { getPromptsTypeForLanguageId, PROMPT_LANGUAGE_ID, PromptsType } from '../promptTypes.js';
 import { PromptParser } from '../parsers/promptParser.js';
-import { match, splitGlobAware } from '../../../../../../base/common/glob.js';
 import { type URI } from '../../../../../../base/common/uri.js';
 import { type IPromptFileReference } from '../parsers/types.js';
 import { assert } from '../../../../../../base/common/assert.js';
 import { basename } from '../../../../../../base/common/path.js';
-import { ResourceSet } from '../../../../../../base/common/map.js';
 import { PromptFilesLocator } from '../utils/promptFilesLocator.js';
 import { Disposable } from '../../../../../../base/common/lifecycle.js';
 import { Event } from '../../../../../../base/common/event.js';
@@ -25,11 +23,10 @@ import { CancellationToken } from '../../../../../../base/common/cancellation.js
 import { IInstantiationService } from '../../../../../../platform/instantiation/common/instantiation.js';
 import { IUserDataProfileService } from '../../../../../services/userDataProfile/common/userDataProfile.js';
 import type { IChatPromptSlashCommand, ICustomChatMode, IMetadata, IPromptParserResult, IPromptPath, IPromptsService, TPromptsStorage } from './promptsService.js';
-import { COPILOT_CUSTOM_INSTRUCTIONS_FILENAME, getCleanPromptName, PROMPT_FILE_EXTENSION } from '../config/promptFileLocations.js';
+import { getCleanPromptName, PROMPT_FILE_EXTENSION } from '../config/promptFileLocations.js';
 import { ILanguageService } from '../../../../../../editor/common/languages/language.js';
 import { PromptsConfig } from '../config/config.js';
 import { IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
-import { isObject, isString } from '../../../../../../base/common/types.js';
 
 /**
  * Provides prompt services.
@@ -262,118 +259,6 @@ export class PromptsService extends Disposable implements IPromptsService {
 		}
 	}
 
-
-	public async findInstructionFilesFor(files: readonly URI[], ignoreInstructions?: ResourceSet): Promise<readonly { uri: URI; reason: string }[]> {
-		const instructionFiles = await this.listPromptFiles(PromptsType.instructions, CancellationToken.None);
-		if (instructionFiles.length === 0) {
-			this.logger.trace('[PromptsService#findInstructionFilesFor] No instruction files available.');
-			return [];
-		}
-		this.logger.trace(`[PromptsService#findInstructionFilesFor] ${files.length} input files provided. ${files.map(file => file.toString()).join(', ')}`);
-		this.logger.trace(`[PromptsService#findInstructionFilesFor] ${instructionFiles.length} instruction files available.`);
-
-		const result: { uri: URI; reason: string }[] = [];
-		const foundFiles = new ResourceSet();
-		for (const instructionFile of instructionFiles) {
-			const { metadata, uri } = await this.parse(instructionFile.uri, CancellationToken.None);
-
-			if (metadata?.promptType !== PromptsType.instructions) {
-				this.logger.trace(`[PromptsService#findInstructionFilesFor] Not an instruction file: ${uri}`);
-				continue;
-			}
-
-			if (ignoreInstructions?.has(uri) || foundFiles.has(uri)) {
-				// the instruction file is already part of the input or has already been processed
-				this.logger.trace(`[PromptsService#findInstructionFilesFor] Skipping already processed instruction file: ${uri}`);
-				continue;
-			}
-
-
-			const { applyTo } = metadata;
-			if (applyTo === undefined) {
-				continue;
-			}
-
-			const patterns = splitGlobAware(applyTo, ',');
-			const patterMatches = (pattern: string): URI | true | false => {
-				pattern = pattern.trim();
-				if (pattern.length === 0) {
-					// if glob pattern is empty, skip it
-					return false;
-				}
-				if (pattern === '**' || pattern === '**/*' || pattern === '*') {
-					// if glob pattern is one of the special wildcard values,
-					// add the instructions file event if no files are attached
-					return true;
-				}
-				if (!pattern.startsWith('/') && !pattern.startsWith('**/')) {
-					// support relative glob patterns, e.g. `src/**/*.js`
-					pattern = '**/' + pattern;
-				}
-
-				// match each attached file with each glob pattern and
-				// add the instructions file if its rule matches the file
-				for (const file of files) {
-					// if the file is not a valid URI, skip it
-					if (match(pattern, file.path)) {
-						return file;
-					}
-				}
-				return false;
-			};
-
-
-			let matches = false;
-			for (const pattern of patterns) {
-				const matchResult = patterMatches(pattern);
-				if (matchResult !== false) {
-					const reason = matchResult === true ?
-						localize('instruction.file.reason.allFiles', 'Automatically attached as pattern is **') :
-						localize('instruction.file.reason.specificFile', 'Automatically attached as pattern {0} matches {1}', applyTo, this.labelService.getUriLabel(matchResult, { relative: true }));
-
-					result.push({ uri, reason });
-					foundFiles.add(uri);
-					this.logger.trace(`[PromptsService#findInstructionFilesFor] ${uri} selected: ${reason}`);
-					matches = true;
-					break;
-				}
-			}
-			if (!matches) {
-				this.logger.trace(`[PromptsService#findInstructionFilesFor]  ${uri} no match: pattern: ${applyTo}`);
-			}
-		}
-		return result;
-	}
-
-	public async findCopilotInstructions(): Promise<readonly URI[]> {
-		const instructionMessages: string[] = [];
-		const instructionFiles = new Set<string>();
-
-		const useCopilotInstructionsFiles = this.configurationService.getValue(PromptsConfig.USE_COPILOT_INSTRUCTION_FILES);
-		if (useCopilotInstructionsFiles) {
-			instructionFiles.add(`.github/` + COPILOT_CUSTOM_INSTRUCTIONS_FILENAME);
-		}
-
-		const config = this.configurationService.inspect(PromptsConfig.COPILOT_INSTRUCTIONS);
-
-		[config.workspaceFolderValue, config.workspaceValue, config.userValue].forEach((value: any) => {
-			if (Array.isArray(value)) {
-				for (const item of value) {
-					if (isString(item)) {
-						instructionMessages.push(item);
-					} else if (item && isObject(item)) {
-						if (isString(item.text)) {
-							instructionMessages.push(item.text);
-						} else if (isString(item.file)) {
-							instructionFiles.add(item.file);
-						}
-					}
-				}
-			}
-		});
-
-		return this.fileLocator.getCopilotInstructionsFiles(instructionFiles);
-	}
 
 	public async getAllMetadata(promptUris: readonly URI[]): Promise<IMetadata[]> {
 		const metadata = await Promise.all(

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/utils/promptFilesLocator.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/utils/promptFilesLocator.ts
@@ -58,6 +58,20 @@ export class PromptFilesLocator extends Disposable {
 		return files.filter(file => getPromptFileType(file) === type);
 	}
 
+	public async getCopilotInstructionsFiles(instructionFilePaths: Iterable<string>): Promise<URI[]> {
+		const { folders } = this.workspaceService.getWorkspace();
+		const result: URI[] = [];
+		for (const folder of folders) {
+			for (const instructionFilePath of instructionFilePaths) {
+				const file = joinPath(folder.uri, instructionFilePath);
+				if (await this.fileService.exists(file)) {
+					result.push(file);
+				}
+			}
+		}
+		return result;
+	}
+
 	public createFilesUpdatedEvent(type: PromptsType): { readonly event: Event<void>; dispose: () => void } {
 		const disposables = new DisposableStore();
 		const eventEmitter = disposables.add(new Emitter<void>());

--- a/src/vs/workbench/contrib/chat/test/common/mockPromptsService.ts
+++ b/src/vs/workbench/contrib/chat/test/common/mockPromptsService.ts
@@ -36,12 +36,6 @@ export class MockPromptsService implements IPromptsService {
 	findPromptSlashCommands(): Promise<IChatPromptSlashCommand[]> {
 		throw new Error('Method not implemented.');
 	}
-	findInstructionFilesFor(_files: readonly URI[]): Promise<readonly { uri: URI; reason: string }[]> {
-		throw new Error('Method not implemented.');
-	}
-	findCopilotInstructions(): Promise<readonly URI[]> {
-		throw new Error('Method not implemented.');
-	}
 	onDidChangeCustomChatModes: Event<void> = Event.None;
 	getCustomChatModes(token: CancellationToken): Promise<readonly ICustomChatMode[]> {
 		throw new Error('Method not implemented.');

--- a/src/vs/workbench/contrib/chat/test/common/mockPromptsService.ts
+++ b/src/vs/workbench/contrib/chat/test/common/mockPromptsService.ts
@@ -39,6 +39,9 @@ export class MockPromptsService implements IPromptsService {
 	findInstructionFilesFor(_files: readonly URI[]): Promise<readonly { uri: URI; reason: string }[]> {
 		throw new Error('Method not implemented.');
 	}
+	findCopilotInstructions(): Promise<readonly URI[]> {
+		throw new Error('Method not implemented.');
+	}
 	onDidChangeCustomChatModes: Event<void> = Event.None;
 	getCustomChatModes(token: CancellationToken): Promise<readonly ICustomChatMode[]> {
 		throw new Error('Method not implemented.');

--- a/src/vs/workbench/contrib/inlineChat/test/browser/inlineChatController.test.ts
+++ b/src/vs/workbench/contrib/inlineChat/test/browser/inlineChatController.test.ts
@@ -11,7 +11,6 @@ import { Emitter, Event } from '../../../../../base/common/event.js';
 import { DisposableStore } from '../../../../../base/common/lifecycle.js';
 import { constObservable, IObservable } from '../../../../../base/common/observable.js';
 import { assertType } from '../../../../../base/common/types.js';
-import { URI } from '../../../../../base/common/uri.js';
 import { mock } from '../../../../../base/test/common/mock.js';
 import { runWithFakedTimers } from '../../../../../base/test/common/timeTravelScheduler.js';
 import { IActiveCodeEditor } from '../../../../../editor/browser/editorBrowser.js';
@@ -67,7 +66,7 @@ import { ChatWidgetHistoryService, IChatWidgetHistoryService } from '../../../ch
 import { ChatAgentLocation, ChatMode } from '../../../chat/common/constants.js';
 import { ILanguageModelsService, LanguageModelsService } from '../../../chat/common/languageModels.js';
 import { ILanguageModelToolsService } from '../../../chat/common/languageModelToolsService.js';
-import { IPromptsService } from '../../../chat/common/promptSyntax/service/promptsService.js';
+import { IPromptPath, IPromptsService } from '../../../chat/common/promptSyntax/service/promptsService.js';
 import { MockChatModeService } from '../../../chat/test/common/mockChatModeService.js';
 import { MockLanguageModelToolsService } from '../../../chat/test/common/mockLanguageModelToolsService.js';
 import { INotebookEditorService } from '../../../notebook/browser/services/notebookEditorService.js';
@@ -77,6 +76,7 @@ import { IInlineChatSessionService } from '../../browser/inlineChatSessionServic
 import { InlineChatSessionServiceImpl } from '../../browser/inlineChatSessionServiceImpl.js';
 import { CTX_INLINE_CHAT_RESPONSE_TYPE, InlineChatConfigKeys, InlineChatResponseType } from '../../common/inlineChat.js';
 import { TestWorkerService } from './testWorkerService.js';
+import { PromptsType } from '../../../chat/common/promptSyntax/promptTypes.js';
 
 suite('InlineChatController', function () {
 
@@ -202,7 +202,7 @@ suite('InlineChatController', function () {
 			[ITextModelService, new SyncDescriptor(TextModelResolverService)],
 			[ILanguageModelToolsService, new SyncDescriptor(MockLanguageModelToolsService)],
 			[IPromptsService, new class extends mock<IPromptsService>() {
-				override async findInstructionFilesFor(_file: readonly URI[]): Promise<readonly { uri: URI; reason: string }[]> {
+				override async listPromptFiles(type: PromptsType, token: CancellationToken): Promise<readonly IPromptPath[]> {
 					return [];
 				}
 			}],


### PR DESCRIPTION
Introduce functionality to load copilot instructions on demand, enhancing the agent mode with a list of available instructions. 

For https://github.com/microsoft/vscode-copilot/issues/17214