### PR TITLE
Improve organization of auth state for MCP servers

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadAuthentication.ts
+++ b/src/vs/workbench/api/browser/mainThreadAuthentication.ts
@@ -225,7 +225,7 @@ export class MainThreadAuthentication extends Disposable implements MainThreadAu
 	}
 
 	async $registerDynamicAuthenticationProvider(id: string, label: string, authorizationServer: UriComponents, clientId: string): Promise<void> {
-		await this.$registerAuthenticationProvider(id, label, false, [authorizationServer]);
+		await this.$registerAuthenticationProvider(id, label, true, [authorizationServer]);
 		this.dynamicAuthProviderStorageService.storeClientId(id, URI.revive(authorizationServer).toString(true), clientId, label);
 	}
 

--- a/src/vs/workbench/api/browser/mainThreadMcp.ts
+++ b/src/vs/workbench/api/browser/mainThreadMcp.ts
@@ -165,10 +165,12 @@ export class MainThreadMcp extends Disposable implements MainThreadMcpShape {
 		if (sessions.length) {
 			// If we have an existing session preference, use that. If not, we'll return any valid session at the end of this function.
 			if (matchingAccountPreferenceSession && this.authenticationMCPServerAccessService.isAccessAllowed(providerId, matchingAccountPreferenceSession.account.label, server.id)) {
+				this._mcpRegistry.setAuthenticationUsage(server.id, providerId);
 				return matchingAccountPreferenceSession.accessToken;
 			}
 			// If we only have one account for a single auth provider, lets just check if it's allowed and return it if it is.
 			if (!provider.supportsMultipleAccounts && this.authenticationMCPServerAccessService.isAccessAllowed(providerId, sessions[0].account.label, server.id)) {
+				this._mcpRegistry.setAuthenticationUsage(server.id, providerId);
 				return sessions[0].accessToken;
 			}
 		}
@@ -201,6 +203,7 @@ export class MainThreadMcp extends Disposable implements MainThreadMcpShape {
 			);
 		}
 
+		this._mcpRegistry.setAuthenticationUsage(server.id, providerId);
 		this.authenticationMCPServerAccessService.updateAllowedMcpServers(providerId, session.account.label, [{ id: server.id, name: server.label, allowed: true }]);
 		this.authenticationMcpServersService.updateAccountPreference(server.id, providerId, session.account);
 		this.authenticationMCPServerUsageService.addAccountUsage(providerId, session.account.label, scopesSupported, server.id, server.label);

--- a/src/vs/workbench/contrib/mcp/common/mcpRegistry.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpRegistry.ts
@@ -50,6 +50,9 @@ export class McpRegistry extends Disposable implements IMcpRegistry {
 		return this._collections.read(reader);
 	});
 
+	// We don't need anything fancy here since the callers are all on-demand (not wanting to listen to changes)
+	private readonly _serverIdAuthUsage = new Map<string, string>();
+
 	private readonly _workspaceStorage = new Lazy(() => this._register(this._instantiationService.createInstance(McpRegistryInputStorage, StorageScope.WORKSPACE, StorageTarget.USER)));
 	private readonly _profileStorage = new Lazy(() => this._register(this._instantiationService.createInstance(McpRegistryInputStorage, StorageScope.PROFILE, StorageTarget.USER)));
 
@@ -121,6 +124,14 @@ export class McpRegistry extends Disposable implements IMcpRegistry {
 				this._collections.set(currentCollections.filter(c => c !== collection), undefined);
 			}
 		};
+	}
+
+	public getAuthenticationUsage(mcpServerId: string): string | undefined {
+		return this._serverIdAuthUsage.get(mcpServerId);
+	}
+
+	public setAuthenticationUsage(mcpServerId: string, providerId: string): void {
+		this._serverIdAuthUsage.set(mcpServerId, providerId);
 	}
 
 	public getServerDefinition(collectionRef: McpDefinitionReference, definitionRef: McpDefinitionReference): IObservable<{ server: McpServerDefinition | undefined; collection: McpCollectionDefinition | undefined }> {

--- a/src/vs/workbench/contrib/mcp/common/mcpRegistryTypes.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpRegistryTypes.ts
@@ -64,6 +64,9 @@ export interface IMcpRegistry {
 	registerDelegate(delegate: IMcpHostDelegate): IDisposable;
 	registerCollection(collection: McpCollectionDefinition): IDisposable;
 
+	getAuthenticationUsage(mcpServerId: string): string | undefined;
+	setAuthenticationUsage(mcpServerId: string, providerId: string): void;
+
 	/** Resets the trust state of all collections. */
 	resetTrust(): void;
 

--- a/src/vs/workbench/contrib/mcp/test/common/mcpRegistryTypes.ts
+++ b/src/vs/workbench/contrib/mcp/test/common/mcpRegistryTypes.ts
@@ -212,6 +212,12 @@ export class TestMcpRegistry implements IMcpRegistry {
 	getTrust(collection: McpCollectionReference): IObservable<boolean | undefined> {
 		throw new Error('Method not implemented.');
 	}
+	getAuthenticationUsage(mcpServerId: string): string | undefined {
+		throw new Error('Method not implemented.');
+	}
+	setAuthenticationUsage(mcpServerId: string, providerId: string): void {
+		throw new Error('Method not implemented.');
+	}
 	clearSavedInputs(scope: StorageScope, inputId?: string): Promise<void> {
 		throw new Error('Method not implemented.');
 	}

--- a/src/vs/workbench/services/authentication/common/authentication.ts
+++ b/src/vs/workbench/services/authentication/common/authentication.ts
@@ -153,6 +153,12 @@ export interface IAuthenticationService {
 	isAuthenticationProviderRegistered(id: string): boolean;
 
 	/**
+	 * Checks if an authentication provider is dynamic
+	 * @param id The id of the provider to check
+	 */
+	isDynamicAuthenticationProvider(id: string): boolean;
+
+	/**
 	 * Registers an authentication provider
 	 * @param id The id of the provider
 	 * @param provider The implementation of the provider


### PR DESCRIPTION
Now they will show in the their own section in the Account Menu

<img width="444" alt="image" src="https://github.com/user-attachments/assets/59e71369-a099-4e47-8674-093881168145" />


 AND have an option to Disconnect or Sign out in the MCP Server menu depending on if the account is used by other things.

<img width="762" alt="image" src="https://github.com/user-attachments/assets/8119380e-4156-4f06-94f7-cc165bd62780" />

<img width="790" alt="image" src="https://github.com/user-attachments/assets/470dd18c-0149-4d5f-b605-08c393a5dac4" />


<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
Fixes https://github.com/microsoft/vscode/issues/251802