### PR TITLE
mcp: add support for elicitations

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/chatConfirmationWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/chatConfirmationWidget.ts
@@ -186,24 +186,31 @@ abstract class BaseChatConfirmationWidget extends Disposable {
 }
 
 export class ChatConfirmationWidget extends BaseChatConfirmationWidget {
+	private _renderedMessage: HTMLElement | undefined;
+
 	constructor(
 		title: string | IMarkdownString,
 		subtitle: string | IMarkdownString | undefined,
-		private readonly message: string | IMarkdownString,
+		message: string | IMarkdownString,
 		buttons: IChatConfirmationButton[],
-		container: HTMLElement,
+		private readonly _container: HTMLElement,
 		@IInstantiationService instantiationService: IInstantiationService,
 		@IContextMenuService contextMenuService: IContextMenuService,
 		@IConfigurationService configurationService: IConfigurationService,
 		@IHostService hostService: IHostService,
 	) {
 		super(title, subtitle, buttons, instantiationService, contextMenuService, configurationService, hostService);
+		this.updateMessage(message);
+	}
 
+	public updateMessage(message: string | IMarkdownString): void {
+		this._renderedMessage?.remove();
 		const renderedMessage = this._register(this.markdownRenderer.render(
-			typeof this.message === 'string' ? new MarkdownString(this.message) : this.message,
+			typeof message === 'string' ? new MarkdownString(message) : message,
 			{ asyncRenderCallback: () => this._onDidChangeHeight.fire() }
 		));
-		this.renderMessage(renderedMessage.element, container);
+		this.renderMessage(renderedMessage.element, this._container);
+		this._renderedMessage = renderedMessage.element;
 	}
 }
 

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/chatConfirmationWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/chatConfirmationWidget.ts
@@ -103,6 +103,10 @@ abstract class BaseChatConfirmationWidget extends Disposable {
 		return this._domNode;
 	}
 
+	private get showingButtons() {
+		return !this.domNode.classList.contains('hideButtons');
+	}
+
 	setShowButtons(showButton: boolean): void {
 		this.domNode.classList.toggle('hideButtons', !showButton);
 	}
@@ -176,7 +180,7 @@ abstract class BaseChatConfirmationWidget extends Disposable {
 	protected renderMessage(element: HTMLElement, listContainer: HTMLElement): void {
 		this.messageElement.append(element);
 
-		if (this._configurationService.getValue<boolean>('chat.notifyWindowOnConfirmation')) {
+		if (this.showingButtons && this._configurationService.getValue<boolean>('chat.notifyWindowOnConfirmation')) {
 			const targetWindow = dom.getWindow(listContainer);
 			if (!targetWindow.document.hasFocus()) {
 				this._hostService.focus(targetWindow, { mode: FocusMode.Notify });

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/chatElicitationContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/chatElicitationContentPart.ts
@@ -1,0 +1,66 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Emitter } from '../../../../../base/common/event.js';
+import { isMarkdownString, MarkdownString } from '../../../../../base/common/htmlContent.js';
+import { Disposable, IDisposable } from '../../../../../base/common/lifecycle.js';
+import { localize } from '../../../../../nls.js';
+import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
+import { IChatProgressRenderableResponseContent } from '../../common/chatModel.js';
+import { IChatElicitationRequest } from '../../common/chatService.js';
+import { ChatConfirmationWidget } from './chatConfirmationWidget.js';
+import { IChatContentPart, IChatContentPartRenderContext } from './chatContentParts.js';
+
+export class ChatElicitationContentPart extends Disposable implements IChatContentPart {
+	public readonly domNode: HTMLElement;
+
+	private readonly _onDidChangeHeight = this._register(new Emitter<void>());
+	public readonly onDidChangeHeight = this._onDidChangeHeight.event;
+
+	constructor(
+		elicitation: IChatElicitationRequest,
+		context: IChatContentPartRenderContext,
+		@IInstantiationService private readonly instantiationService: IInstantiationService,
+	) {
+		super();
+
+		const buttons = [
+			{ label: localize('accept', "Respond"), data: true },
+			{ label: localize('dismiss', "Cancel"), data: false, isSecondary: true },
+		];
+		const confirmationWidget = this._register(this.instantiationService.createInstance(ChatConfirmationWidget, elicitation.title, elicitation.originMessage, elicitation.message, buttons, context.container));
+		confirmationWidget.setShowButtons(elicitation.state === 'pending');
+
+		this._register(confirmationWidget.onDidChangeHeight(() => this._onDidChangeHeight.fire()));
+
+		this._register(confirmationWidget.onDidClick(async e => {
+			if (e.data) {
+				await elicitation.accept();
+			} else {
+				await elicitation.reject();
+			}
+
+			confirmationWidget.setShowButtons(false);
+			if (elicitation.acceptedResult) {
+				const messageMd = isMarkdownString(elicitation.message) ? MarkdownString.lift(elicitation.message) : new MarkdownString(elicitation.message);
+				messageMd.appendCodeblock('json', JSON.stringify(elicitation.acceptedResult, null, 2));
+				confirmationWidget.updateMessage(messageMd);
+			}
+
+			this._onDidChangeHeight.fire();
+		}));
+
+		this.domNode = confirmationWidget.domNode;
+	}
+
+	hasSameContent(other: IChatProgressRenderableResponseContent): boolean {
+		// No other change allowed for this content type
+		return other.kind === 'elicitation';
+	}
+
+	addDisposable(disposable: IDisposable): void {
+		this._register(disposable);
+	}
+}

--- a/src/vs/workbench/contrib/chat/browser/chatListRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatListRenderer.ts
@@ -49,7 +49,7 @@ import { IChatAgentMetadata } from '../common/chatAgents.js';
 import { ChatContextKeys } from '../common/chatContextKeys.js';
 import { IChatTextEditGroup } from '../common/chatModel.js';
 import { chatSubcommandLeader } from '../common/chatParserTypes.js';
-import { ChatAgentVoteDirection, ChatAgentVoteDownReason, ChatErrorLevel, IChatConfirmation, IChatContentReference, IChatExtensionsContent, IChatFollowup, IChatMarkdownContent, IChatTask, IChatTaskSerialized, IChatToolInvocation, IChatToolInvocationSerialized, IChatTreeData, IChatUndoStop } from '../common/chatService.js';
+import { ChatAgentVoteDirection, ChatAgentVoteDownReason, ChatErrorLevel, IChatConfirmation, IChatContentReference, IChatElicitationRequest, IChatExtensionsContent, IChatFollowup, IChatMarkdownContent, IChatTask, IChatTaskSerialized, IChatToolInvocation, IChatToolInvocationSerialized, IChatTreeData, IChatUndoStop } from '../common/chatService.js';
 import { IChatCodeCitations, IChatErrorDetailsPart, IChatReferences, IChatRendererContent, IChatRequestViewModel, IChatResponseViewModel, IChatWorkingProgress, isRequestVM, isResponseVM } from '../common/chatViewModel.js';
 import { getNWords } from '../common/chatWordCounter.js';
 import { CodeBlockModelCollection } from '../common/codeBlockModelCollection.js';
@@ -80,6 +80,7 @@ import { ChatEditorOptions } from './chatOptions.js';
 import { ChatCodeBlockContentProvider, CodeBlockPart } from './codeBlockPart.js';
 import { canceledName } from '../../../../base/common/errors.js';
 import { IChatRequestVariableEntry } from '../common/chatVariableEntries.js';
+import { ChatElicitationContentPart } from './chatContentParts/chatElicitationContentPart.js';
 
 const $ = dom.$;
 
@@ -963,6 +964,8 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 				return this.renderUndoStop(content);
 			} else if (content.kind === 'errorDetails') {
 				return this.renderChatErrorDetails(context, content, templateData);
+			} else if (content.kind === 'elicitation') {
+				return this.renderElicitation(context, content, templateData);
 			}
 
 			return this.renderNoContent(other => content.kind === other.kind);
@@ -1132,6 +1135,12 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 
 	private renderConfirmation(context: IChatContentPartRenderContext, confirmation: IChatConfirmation, templateData: IChatListItemTemplate): IChatContentPart {
 		const part = this.instantiationService.createInstance(ChatConfirmationContentPart, confirmation, context);
+		part.addDisposable(part.onDidChangeHeight(() => this.updateItemHeight(templateData)));
+		return part;
+	}
+
+	private renderElicitation(context: IChatContentPartRenderContext, elicitation: IChatElicitationRequest, templateData: IChatListItemTemplate): IChatContentPart {
+		const part = this.instantiationService.createInstance(ChatElicitationContentPart, elicitation, context);
 		part.addDisposable(part.onDidChangeHeight(() => this.updateItemHeight(templateData)));
 		return part;
 	}

--- a/src/vs/workbench/contrib/chat/common/chatModel.ts
+++ b/src/vs/workbench/contrib/chat/common/chatModel.ts
@@ -25,7 +25,7 @@ import { CellUri, ICellEditOperation } from '../../notebook/common/notebookCommo
 import { IChatAgentCommand, IChatAgentData, IChatAgentResult, IChatAgentService, reviveSerializedAgent } from './chatAgents.js';
 import { IChatEditingService, IChatEditingSession } from './chatEditingService.js';
 import { ChatRequestTextPart, IParsedChatRequest, reviveParsedChatRequest } from './chatParserTypes.js';
-import { ChatAgentVoteDirection, ChatAgentVoteDownReason, IChatAgentMarkdownContentWithVulnerability, IChatCodeCitation, IChatCommandButton, IChatConfirmation, IChatContentInlineReference, IChatContentReference, IChatEditingSessionAction, IChatExtensionsContent, IChatFollowup, IChatLocationData, IChatMarkdownContent, IChatNotebookEdit, IChatPrepareToolInvocationPart, IChatProgress, IChatProgressMessage, IChatResponseCodeblockUriPart, IChatResponseProgressFileTreeData, IChatTask, IChatTaskSerialized, IChatTextEdit, IChatToolInvocation, IChatToolInvocationSerialized, IChatTreeData, IChatUndoStop, IChatUsedContext, IChatWarningMessage, isIUsedContext } from './chatService.js';
+import { ChatAgentVoteDirection, ChatAgentVoteDownReason, IChatAgentMarkdownContentWithVulnerability, IChatCodeCitation, IChatCommandButton, IChatConfirmation, IChatContentInlineReference, IChatContentReference, IChatEditingSessionAction, IChatElicitationRequest, IChatExtensionsContent, IChatFollowup, IChatLocationData, IChatMarkdownContent, IChatNotebookEdit, IChatPrepareToolInvocationPart, IChatProgress, IChatProgressMessage, IChatResponseCodeblockUriPart, IChatResponseProgressFileTreeData, IChatTask, IChatTaskSerialized, IChatTextEdit, IChatToolInvocation, IChatToolInvocationSerialized, IChatTreeData, IChatUndoStop, IChatUsedContext, IChatWarningMessage, isIUsedContext } from './chatService.js';
 import { IChatRequestVariableEntry } from './chatVariableEntries.js';
 import { ChatAgentLocation, ChatMode } from './constants.js';
 
@@ -123,7 +123,8 @@ export type IChatProgressResponseContent =
 	| IChatToolInvocation
 	| IChatToolInvocationSerialized
 	| IChatUndoStop
-	| IChatPrepareToolInvocationPart;
+	| IChatPrepareToolInvocationPart
+	| IChatElicitationRequest;
 
 const nonHistoryKinds = new Set(['toolInvocation', 'toolInvocationSerialized', 'undoStop', 'prepareToolInvocation']);
 function isChatProgressHistoryResponseContent(content: IChatProgressResponseContent): content is IChatProgressHistoryResponseContent {
@@ -349,6 +350,7 @@ class AbstractResponse implements IResponse {
 				case 'extensions':
 				case 'undoStop':
 				case 'prepareToolInvocation':
+				case 'elicitation':
 					// Ignore
 					continue;
 				case 'inlineReference':

--- a/src/vs/workbench/contrib/chat/common/chatService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService.ts
@@ -227,6 +227,17 @@ export interface IChatConfirmation {
 	kind: 'confirmation';
 }
 
+export interface IChatElicitationRequest {
+	kind: 'elicitation';
+	title: string | IMarkdownString;
+	message: string | IMarkdownString;
+	originMessage?: string | IMarkdownString;
+	state: 'pending' | 'accepted' | 'rejected';
+	acceptedResult?: Record<string, unknown>;
+	accept(): Promise<void>;
+	reject(): Promise<void>;
+}
+
 export interface IChatTerminalToolInvocationData {
 	kind: 'terminal';
 	command: string;
@@ -310,7 +321,8 @@ export type IChatProgress =
 	| IChatExtensionsContent
 	| IChatUndoStop
 	| IChatPrepareToolInvocationPart
-	| IChatTaskSerialized;
+	| IChatTaskSerialized
+	| IChatElicitationRequest;
 
 export interface IChatFollowup {
 	kind: 'reply';

--- a/src/vs/workbench/contrib/mcp/browser/mcp.contribution.ts
+++ b/src/vs/workbench/contrib/mcp/browser/mcp.contribution.ts
@@ -33,10 +33,11 @@ import { IMcpRegistry } from '../common/mcpRegistryTypes.js';
 import { McpResourceFilesystem } from '../common/mcpResourceFilesystem.js';
 import { McpSamplingService } from '../common/mcpSamplingService.js';
 import { McpService } from '../common/mcpService.js';
-import { HasInstalledMcpServersContext, IMcpSamplingService, IMcpService, IMcpWorkbenchService, InstalledMcpServersViewId, McpServersGalleryEnabledContext } from '../common/mcpTypes.js';
+import { HasInstalledMcpServersContext, IMcpElicitationService, IMcpSamplingService, IMcpService, IMcpWorkbenchService, InstalledMcpServersViewId, McpServersGalleryEnabledContext } from '../common/mcpTypes.js';
 import { McpAddContextContribution } from './mcpAddContextContribution.js';
 import { AddConfigurationAction, EditStoredInput, InstallFromActivation, ListMcpServerCommand, McpBrowseCommand, McpBrowseResourcesCommand, McpConfigureSamplingModels, MCPServerActionRendering, McpServerOptionsCommand, McpStartPromptingServerCommand, RemoveStoredInput, ResetMcpCachedTools, ResetMcpTrustCommand, RestartServer, ShowConfiguration, ShowOutput, StartServer, StopServer } from './mcpCommands.js';
 import { McpDiscovery } from './mcpDiscovery.js';
+import { McpElicitationService } from './mcpElicitationService.js';
 import { McpLanguageFeatures } from './mcpLanguageFeatures.js';
 import { McpResourceQuickAccess } from './mcpResourceQuickAccess.js';
 import { McpServerEditor } from './mcpServerEditor.js';
@@ -51,6 +52,7 @@ registerSingleton(IMcpWorkbenchService, McpWorkbenchService, InstantiationType.E
 registerSingleton(IMcpConfigPathsService, McpConfigPathsService, InstantiationType.Delayed);
 registerSingleton(IMcpDevModeDebugging, McpDevModeDebugging, InstantiationType.Delayed);
 registerSingleton(IMcpSamplingService, McpSamplingService, InstantiationType.Delayed);
+registerSingleton(IMcpElicitationService, McpElicitationService, InstantiationType.Delayed);
 
 mcpDiscoveryRegistry.register(new SyncDescriptor(RemoteNativeMpcDiscovery));
 mcpDiscoveryRegistry.register(new SyncDescriptor(ConfigMcpDiscovery));

--- a/src/vs/workbench/contrib/mcp/browser/mcpElicitationService.ts
+++ b/src/vs/workbench/contrib/mcp/browser/mcpElicitationService.ts
@@ -1,0 +1,280 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Action } from '../../../../base/common/actions.js';
+import { assertNever } from '../../../../base/common/assert.js';
+import { CancellationToken } from '../../../../base/common/cancellation.js';
+import { DisposableStore } from '../../../../base/common/lifecycle.js';
+import { localize } from '../../../../nls.js';
+import { INotificationService, Severity } from '../../../../platform/notification/common/notification.js';
+import { IQuickInputService, IQuickPick, IQuickPickItem } from '../../../../platform/quickinput/common/quickInput.js';
+import { IMcpElicitationService, IMcpServer, IMcpToolCallContext } from '../common/mcpTypes.js';
+import { MCP } from '../common/modelContextProtocol.js';
+
+const noneItem: IQuickPickItem = { id: undefined, label: localize('mcp.elicit.enum.none', 'None'), description: localize('mcp.elicit.enum.none.description', 'No selection'), alwaysShow: true };
+
+export class McpElicitationService implements IMcpElicitationService {
+	declare readonly _serviceBrand: undefined;
+
+	constructor(
+		@INotificationService private readonly _notificationService: INotificationService,
+		@IQuickInputService private readonly _quickInputService: IQuickInputService,
+	) { }
+
+	public elicit(server: IMcpServer, context: IMcpToolCallContext | undefined, elicitation: MCP.ElicitRequest['params'], token: CancellationToken): Promise<MCP.ElicitResult> {
+		const store = new DisposableStore();
+		return new Promise<MCP.ElicitResult>(resolve => {
+			const handle = this._notificationService.notify({
+				message: elicitation.message,
+				source: localize('mcp.elicit.source', 'MCP Server ({0})', server.definition.label),
+				severity: Severity.Info,
+				actions: {
+					primary: [store.add(new Action('mcp.elicit.give', localize('mcp.elicit.give', 'Respond'), undefined, true, () => resolve(this._doElicit(elicitation, token))))],
+					secondary: [store.add(new Action('mcp.elicit.cancel', localize('mcp.elicit.cancel', 'Cancel'), undefined, true, () => resolve({ action: 'decline' })))],
+				}
+			});
+			store.add(handle.onDidClose(() => resolve({ action: 'cancel' })));
+			store.add(token.onCancellationRequested(() => resolve({ action: 'cancel' })));
+		}).finally(() => store.dispose());
+	}
+
+	private async _doElicit(elicitation: MCP.ElicitRequest['params'], token: CancellationToken): Promise<MCP.ElicitResult> {
+		const quickPick = this._quickInputService.createQuickPick<IQuickPickItem>();
+		const store = new DisposableStore();
+
+		try {
+			const properties = Object.entries(elicitation.requestedSchema.properties);
+			const requiredFields = new Set(elicitation.requestedSchema.required || []);
+			const results: Record<string, string | number | boolean> = {};
+			const backSnapshots: { value: string; validationMessage?: string }[] = [];
+
+			quickPick.title = elicitation.message;
+			quickPick.totalSteps = properties.length;
+			quickPick.ignoreFocusOut = true;
+
+			for (let i = 0; i < properties.length; i++) {
+				const [propertyName, schema] = properties[i];
+				const isRequired = requiredFields.has(propertyName);
+				const restore = backSnapshots.at(i);
+
+				store.clear();
+				quickPick.step = i + 1;
+				quickPick.title = schema.title || propertyName;
+				quickPick.placeholder = this._getFieldPlaceholder(schema, isRequired);
+				quickPick.value = restore?.value ?? '';
+				quickPick.validationMessage = '';
+				quickPick.buttons = i > 0 ? [this._quickInputService.backButton] : [];
+
+				let result: { type: 'value'; value: string | number | boolean | undefined } | { type: 'back' } | { type: 'cancel' };
+				if (schema.type === 'boolean') {
+					result = await this._handleEnumField(quickPick, { ...schema, type: 'string', enum: ['true', 'false'] }, isRequired, store, token);
+					if (result.type === 'value') { result.value = result.value === 'true' ? true : false; }
+				} else if (schema.type === 'string' && 'enum' in schema) {
+					result = await this._handleEnumField(quickPick, schema, isRequired, store, token);
+				} else {
+					result = await this._handleInputField(quickPick, schema, isRequired, store, token);
+					if (result.type === 'value' && (schema.type === 'number' || schema.type === 'integer')) {
+						result.value = Number(result.value);
+					}
+				}
+
+				if (result.type === 'back') {
+					i -= 2;
+					continue;
+				}
+				if (result.type === 'cancel') {
+					return { action: 'cancel' };
+				}
+
+				backSnapshots[i] = { value: quickPick.value };
+
+				if (result.value === undefined) {
+					delete results[propertyName];
+				} else {
+					results[propertyName] = result.value;
+				}
+			}
+
+			return {
+				action: 'accept',
+				content: results,
+			};
+		} finally {
+			store.dispose();
+			quickPick.dispose();
+		}
+	}
+
+	private _getFieldPlaceholder(schema: MCP.PrimitiveSchemaDefinition, required: boolean): string {
+		let placeholder = schema.description || '';
+		if (!required) {
+			placeholder = placeholder ? `${placeholder} (${localize('optional', 'Optional')})` : localize('optional', 'Optional');
+		}
+		return placeholder;
+	}
+
+	private async _handleEnumField(
+		quickPick: IQuickPick<IQuickPickItem>,
+		schema: MCP.EnumSchema,
+		required: boolean,
+		store: DisposableStore,
+		token: CancellationToken
+	) {
+		const items: IQuickPickItem[] = schema.enum.map((value, index) => ({
+			id: value,
+			label: value,
+			description: schema.enumNames?.[index],
+		}));
+
+		if (!required) {
+			items.push(noneItem);
+		}
+
+		quickPick.items = items;
+		quickPick.canSelectMany = false;
+
+		return new Promise<{ type: 'value'; value: string | undefined } | { type: 'back' } | { type: 'cancel' }>(resolve => {
+			store.add(token.onCancellationRequested(() => resolve({ type: 'cancel' })));
+			store.add(quickPick.onDidAccept(() => {
+				const selected = quickPick.selectedItems[0];
+				if (selected) {
+					resolve({ type: 'value', value: selected.id });
+				}
+			}));
+			store.add(quickPick.onDidTriggerButton(() => resolve({ type: 'back' })));
+			store.add(quickPick.onDidHide(() => resolve({ type: 'cancel' })));
+
+			quickPick.show();
+		});
+	}
+
+	private async _handleInputField(
+		quickPick: IQuickPick<IQuickPickItem>,
+		schema: MCP.NumberSchema | MCP.StringSchema,
+		required: boolean,
+		store: DisposableStore,
+		token: CancellationToken
+	) {
+		quickPick.canSelectMany = false;
+
+		const updateItems = () => {
+			const items: IQuickPickItem[] = [];
+			if (quickPick.value) {
+				const validation = this._validateInput(quickPick.value, schema);
+				quickPick.validationMessage = validation.message;
+				if (validation.isValid) {
+					items.push({ id: '$current', label: `➤ ${quickPick.value}` });
+				}
+			} else {
+				quickPick.validationMessage = '';
+			}
+			if (!required) {
+				items.push(noneItem);
+			}
+			quickPick.items = items;
+		};
+
+		updateItems();
+
+		return new Promise<{ type: 'value'; value: string | undefined } | { type: 'back' } | { type: 'cancel' }>(resolve => {
+			if (token.isCancellationRequested) {
+				resolve({ type: 'cancel' });
+				return;
+			}
+
+			store.add(token.onCancellationRequested(() => resolve({ type: 'cancel' })));
+			store.add(quickPick.onDidChangeValue(updateItems));
+			store.add(quickPick.onDidAccept(() => {
+				if (!quickPick.selectedItems[0].id) {
+					resolve({ type: 'value', value: undefined });
+				} else if (!quickPick.validationMessage) {
+					resolve({ type: 'value', value: quickPick.value });
+				}
+			}));
+			store.add(quickPick.onDidTriggerButton(() => resolve({ type: 'back' })));
+			store.add(quickPick.onDidHide(() => resolve({ type: 'cancel' })));
+
+			quickPick.show();
+		});
+	}
+
+	private _validateInput(value: string, schema: MCP.NumberSchema | MCP.StringSchema): { isValid: boolean; message?: string } {
+		switch (schema.type) {
+			case 'string':
+				return this._validateString(value, schema);
+			case 'number':
+			case 'integer':
+				return this._validateNumber(value, schema);
+			default:
+				assertNever(schema);
+		}
+	}
+
+	private _validateString(value: string, schema: MCP.StringSchema): { isValid: boolean; parsedValue?: string; message?: string } {
+		if (schema.minLength && value.length < schema.minLength) {
+			return { isValid: false, message: localize('mcp.elicit.validation.minLength', 'Minimum length is {0}', schema.minLength) };
+		}
+		if (schema.maxLength && value.length > schema.maxLength) {
+			return { isValid: false, message: localize('mcp.elicit.validation.maxLength', 'Maximum length is {0}', schema.maxLength) };
+		}
+		if (schema.format) {
+			const formatValid = this._validateStringFormat(value, schema.format);
+			if (!formatValid.isValid) {
+				return formatValid;
+			}
+		}
+		return { isValid: true, parsedValue: value };
+	}
+
+	private _validateStringFormat(value: string, format: string): { isValid: boolean; message?: string } {
+		switch (format) {
+			case 'email':
+				return !value.includes('@')
+					? { isValid: true }
+					: { isValid: false, message: localize('mcp.elicit.validation.email', 'Please enter a valid email address') };
+			case 'uri':
+				if (URL.canParse(value)) {
+					return { isValid: true };
+				} else {
+					return { isValid: false, message: localize('mcp.elicit.validation.uri', 'Please enter a valid URI') };
+				}
+			case 'date': {
+				const dateRegex = /^\d{4}-\d{2}-\d{2}$/;
+				if (!dateRegex.test(value)) {
+					return { isValid: false, message: localize('mcp.elicit.validation.date', 'Please enter a valid date (YYYY-MM-DD)') };
+				}
+				const date = new Date(value);
+				return !isNaN(date.getTime())
+					? { isValid: true }
+					: { isValid: false, message: localize('mcp.elicit.validation.date', 'Please enter a valid date (YYYY-MM-DD)') };
+			}
+			case 'date-time': {
+				const dateTime = new Date(value);
+				return !isNaN(dateTime.getTime())
+					? { isValid: true }
+					: { isValid: false, message: localize('mcp.elicit.validation.dateTime', 'Please enter a valid date-time') };
+			}
+			default:
+				return { isValid: true };
+		}
+	}
+
+	private _validateNumber(value: string, schema: MCP.NumberSchema): { isValid: boolean; parsedValue?: number; message?: string } {
+		const parsed = schema.type === 'integer' ? parseInt(value, 10) : parseFloat(value);
+		if (isNaN(parsed)) {
+			return { isValid: false, message: localize('mcp.elicit.validation.number', 'Please enter a valid number') };
+		}
+		if (schema.type === 'integer' && !Number.isInteger(parsed)) {
+			return { isValid: false, message: localize('mcp.elicit.validation.integer', 'Please enter a valid integer') };
+		}
+		if (schema.minimum !== undefined && parsed < schema.minimum) {
+			return { isValid: false, message: localize('mcp.elicit.validation.minimum', 'Minimum value is {0}', schema.minimum) };
+		}
+		if (schema.maximum !== undefined && parsed > schema.maximum) {
+			return { isValid: false, message: localize('mcp.elicit.validation.maximum', 'Maximum value is {0}', schema.maximum) };
+		}
+		return { isValid: true, parsedValue: parsed };
+	}
+}

--- a/src/vs/workbench/contrib/mcp/common/mcpServerRequestHandler.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpServerRequestHandler.ts
@@ -112,6 +112,7 @@ export class McpServerRequestHandler extends Disposable {
 						capabilities: {
 							roots: { listChanged: true },
 							sampling: opts.createMessageRequestHandler ? {} : undefined,
+							elicitation: opts.elicitationRequestHandler ? {} : undefined,
 						},
 						clientInfo: {
 							name: productService.nameLong,
@@ -140,11 +141,13 @@ export class McpServerRequestHandler extends Disposable {
 	private readonly _launch: IMcpMessageTransport;
 	private readonly _requestLogLevel: LogLevel;
 	private readonly _createMessageRequestHandler: IMcpServerRequestHandlerOptions['createMessageRequestHandler'];
+	private readonly _elicitationRequestHandler: IMcpServerRequestHandlerOptions['elicitationRequestHandler'];
 
 	protected constructor({
 		launch,
 		logger,
 		createMessageRequestHandler,
+		elicitationRequestHandler,
 		requestLogLevel = LogLevel.Debug,
 	}: IMcpServerRequestHandlerOptions) {
 		super();
@@ -152,6 +155,7 @@ export class McpServerRequestHandler extends Disposable {
 		this.logger = logger;
 		this._requestLogLevel = requestLogLevel;
 		this._createMessageRequestHandler = createMessageRequestHandler;
+		this._elicitationRequestHandler = elicitationRequestHandler;
 
 		this._register(launch.onDidReceiveMessage(message => this.handleMessage(message)));
 		this._register(autorun(reader => {
@@ -309,6 +313,8 @@ export class McpServerRequestHandler extends Disposable {
 				response = this.handleRootsList(request);
 			} else if (request.method === 'sampling/createMessage' && this._createMessageRequestHandler) {
 				response = await this._createMessageRequestHandler(request.params as MCP.CreateMessageRequest['params']);
+			} else if (request.method === 'elicitation/create' && this._elicitationRequestHandler) {
+				response = await this._elicitationRequestHandler(request.params as MCP.ElicitRequest['params']);
 			} else {
 				throw McpError.methodNotFound(request.method);
 			}

--- a/src/vs/workbench/contrib/mcp/common/mcpService.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpService.ts
@@ -286,7 +286,7 @@ class McpToolImplementation implements IToolImpl {
 			content: []
 		};
 
-		const callResult = await this._tool.callWithProgress(invocation.parameters as Record<string, any>, progress, token);
+		const callResult = await this._tool.callWithProgress(invocation.parameters as Record<string, any>, progress, { chatRequestId: invocation.chatRequestId, chatSessionId: invocation.context?.sessionId }, token);
 		const details: IToolResultInputOutputDetails = {
 			input: JSON.stringify(invocation.parameters, undefined, 2),
 			output: [],

--- a/src/vs/workbench/contrib/mcp/common/modelContextProtocol.ts
+++ b/src/vs/workbench/contrib/mcp/common/modelContextProtocol.ts
@@ -247,6 +247,10 @@ export namespace MCP {
 		 * Present if the client supports sampling from an LLM.
 		 */
 		sampling?: object;
+		/**
+		 * Present if the client supports elicitation from the server.
+		 */
+		elicitation?: object;
 	}
 
 	/**
@@ -1245,6 +1249,91 @@ export namespace MCP {
 		method: "notifications/roots/list_changed";
 	}
 
+	/**
+ * A request from the server to elicit additional information from the user via the client.
+ */
+	export interface ElicitRequest extends Request {
+		method: "elicitation/create";
+		params: {
+			/**
+			 * The message to present to the user.
+			 */
+			message: string;
+			/**
+			 * A restricted subset of JSON Schema.
+			 * Only top-level properties are allowed, without nesting.
+			 */
+			requestedSchema: {
+				type: "object";
+				properties: {
+					[key: string]: PrimitiveSchemaDefinition;
+				};
+				required?: string[];
+			};
+		};
+	}
+
+	/**
+	 * Restricted schema definitions that only allow primitive types
+	 * without nested objects or arrays.
+	 */
+	export type PrimitiveSchemaDefinition =
+		| StringSchema
+		| NumberSchema
+		| BooleanSchema
+		| EnumSchema;
+
+	export interface StringSchema {
+		type: "string";
+		title?: string;
+		description?: string;
+		minLength?: number;
+		maxLength?: number;
+		format?: "email" | "uri" | "date" | "date-time";
+	}
+
+	export interface NumberSchema {
+		type: "number" | "integer";
+		title?: string;
+		description?: string;
+		minimum?: number;
+		maximum?: number;
+	}
+
+	export interface BooleanSchema {
+		type: "boolean";
+		title?: string;
+		description?: string;
+		default?: boolean;
+	}
+
+	export interface EnumSchema {
+		type: "string";
+		title?: string;
+		description?: string;
+		enum: string[];
+		enumNames?: string[]; // Display names for enum values
+	}
+
+	/**
+	 * The client's response to an elicitation request.
+	 */
+	export interface ElicitResult extends Result {
+		/**
+		 * The user action in response to the elicitation.
+		 * - "accept": User submitted the form/confirmed the action
+		 * - "decline": User explicitly declined the action
+		 * - "cancel": User dismissed without making an explicit choice
+		 */
+		action: "accept" | "decline" | "cancel";
+
+		/**
+		 * The submitted form data, only present when action is "accept".
+		 * Contains values matching the requested schema.
+		 */
+		content?: { [key: string]: string | number | boolean };
+	}
+
 	/* Client messages */
 	export type ClientRequest =
 		| PingRequest
@@ -1267,13 +1356,14 @@ export namespace MCP {
 		| InitializedNotification
 		| RootsListChangedNotification;
 
-	export type ClientResult = EmptyResult | CreateMessageResult | ListRootsResult;
+	export type ClientResult = EmptyResult | CreateMessageResult | ListRootsResult | ElicitResult;
 
 	/* Server messages */
 	export type ServerRequest =
 		| PingRequest
 		| CreateMessageRequest
-		| ListRootsRequest;
+		| ListRootsRequest
+		| ElicitRequest;
 
 	export type ServerNotification =
 		| CancelledNotification


### PR DESCRIPTION
Prompts inline in chat if associated with a tool call, and prompts via notification otherwise. Input is given via quickpick. Validation is done appropriately.

Refs https://github.com/microsoft/vscode/issues/248418

https://github.com/user-attachments/assets/0c0241ec-8a11-40b8-b036-819fefe0f21a


