### PR TITLE
Add telemetry for inline edit views

### DIFF
--- a/src/vs/editor/common/languages.ts
+++ b/src/vs/editor/common/languages.ts
@@ -890,7 +890,7 @@ export interface InlineCompletionsProvider<T extends InlineCompletions = InlineC
 	 * Is called when an inline completion item is no longer being used.
 	 * Provides a reason of why it is not used anymore.
 	*/
-	handleEndOfLifetime?(completions: T, item: T['items'][number], reason: InlineCompletionEndOfLifeReason<T['items'][number]>): void;
+	handleEndOfLifetime?(completions: T, item: T['items'][number], reason: InlineCompletionEndOfLifeReason<T['items'][number]>, lifetimeSummary: LifetimeSummary): void;
 
 	/**
 	 * Will be called when a completions list is no longer in use and can be garbage-collected.
@@ -934,6 +934,14 @@ export type InlineCompletionEndOfLifeReason<TInlineCompletion = InlineCompletion
 	kind: InlineCompletionEndOfLifeReasonKind.Ignored;
 	supersededBy?: TInlineCompletion;
 	userTypingDisagreed: boolean;
+};
+
+export type LifetimeSummary = {
+	requestUuid: string;
+	shown: boolean;
+	editorType: string;
+	viewKind: string | undefined;
+	error: string | undefined;
 };
 
 export interface CodeAction {

--- a/src/vs/editor/contrib/inlineCompletions/browser/model/inlineCompletionsModel.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/model/inlineCompletionsModel.ts
@@ -227,7 +227,7 @@ export class InlineCompletionsModel extends Disposable {
 			const suppressedProviderGroupIds = this._suppressedInlineCompletionGroupIds.get();
 			const availableProviders = providers.filter(provider => !(provider.groupId && suppressedProviderGroupIds.has(provider.groupId)));
 
-			return this._source.fetch(availableProviders, cursorPosition, context, itemToPreserve?.identity, changeSummary.shouldDebounce, userJumpedToActiveCompletion, !!changeSummary.provider);
+			return this._source.fetch(availableProviders, cursorPosition, context, itemToPreserve?.identity, changeSummary.shouldDebounce, userJumpedToActiveCompletion, !!changeSummary.provider, this.editorType);
 		});
 		this._inlineCompletionItems = derivedOpts({ owner: this }, reader => {
 			const c = this._source.inlineCompletions.read(reader);
@@ -529,6 +529,7 @@ export class InlineCompletionsModel extends Disposable {
 				d.getOriginalEditor().getId() === this._editor.getId() ||
 				d.getModifiedEditor().getId() === this._editor.getId());
 
+		this.editorType = !!diffEditor ? 'diffEditor' : 'textEditor';
 		this.isInDiffEditor = !!diffEditor;
 
 		this._register(recomputeInitiallyAndOnChange(this._fetchInlineCompletionsPromise));
@@ -538,7 +539,7 @@ export class InlineCompletionsModel extends Disposable {
 			const item = this.inlineCompletionState.read(reader);
 			const completion = item?.inlineCompletion;
 			if (completion) {
-				this.handleInlineSuggestionShown(completion);
+				this.handleInlineSuggestionShown(completion, 'ghostText');
 			}
 		}));
 
@@ -750,6 +751,8 @@ export class InlineCompletionsModel extends Disposable {
 	public readonly tabShouldAcceptInlineEdit;
 
 	public readonly isInDiffEditor;
+
+	public readonly editorType: 'textEditor' | 'diffEditor';
 
 	private async _deltaSelectedInlineCompletionIndex(delta: 1 | -1): Promise<void> {
 		await this.triggerExplicitly();
@@ -1016,8 +1019,8 @@ export class InlineCompletionsModel extends Disposable {
 		});
 	}
 
-	public async handleInlineSuggestionShown(inlineCompletion: InlineSuggestionItem): Promise<void> {
-		await inlineCompletion.reportInlineEditShown(this._commandService);
+	public async handleInlineSuggestionShown(inlineCompletion: InlineSuggestionItem, viewKind: string): Promise<void> {
+		await inlineCompletion.reportInlineEditShown(this._commandService, viewKind);
 	}
 }
 

--- a/src/vs/editor/contrib/inlineCompletions/browser/model/inlineCompletionsSource.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/model/inlineCompletionsSource.ts
@@ -116,7 +116,7 @@ export class InlineCompletionsSource extends Disposable {
 	private readonly _loadingCount;
 	public readonly loading;
 
-	public fetch(providers: InlineCompletionsProvider[], position: Position, context: InlineCompletionContextWithoutUuid, activeInlineCompletion: InlineSuggestionIdentity | undefined, withDebounce: boolean, userJumpedToActiveCompletion: IObservable<boolean>, providerhasChangedCompletion: boolean): Promise<boolean> {
+	public fetch(providers: InlineCompletionsProvider[], position: Position, context: InlineCompletionContextWithoutUuid, activeInlineCompletion: InlineSuggestionIdentity | undefined, withDebounce: boolean, userJumpedToActiveCompletion: IObservable<boolean>, providerhasChangedCompletion: boolean, editorType: string): Promise<boolean> {
 		const request = new UpdateRequest(position, context, this._textModel.getVersionId());
 
 		const target = context.selectedSuggestionInfo ? this.suggestWidgetInlineCompletions.get() : this.inlineCompletions.get();
@@ -166,6 +166,7 @@ export class InlineCompletionsSource extends Disposable {
 						position,
 						this._textModel,
 						context,
+						editorType,
 						source.token,
 						this._languageConfigurationService
 					);

--- a/src/vs/editor/contrib/inlineCompletions/browser/model/inlineSuggestionItem.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/model/inlineSuggestionItem.ts
@@ -99,8 +99,8 @@ abstract class InlineSuggestionItemBase {
 		this.source.removeRef();
 	}
 
-	public reportInlineEditShown(commandService: ICommandService) {
-		this._data.reportInlineEditShown(commandService, this.insertText);
+	public reportInlineEditShown(commandService: ICommandService, viewKind: string) {
+		this._data.reportInlineEditShown(commandService, this.insertText, viewKind);
 	}
 
 	public reportPartialAccept(acceptedCharacters: number, info: PartialAcceptInfo) {
@@ -113,6 +113,10 @@ abstract class InlineSuggestionItemBase {
 
 	public setEndOfLifeReason(reason: InlineCompletionEndOfLifeReason): void {
 		this._data.setEndOfLifeReason(reason);
+	}
+
+	public reportInlineEditError(reason: string): void {
+		this._data.reportInlineEditError(reason);
 	}
 
 	/**

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsModel.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsModel.ts
@@ -50,12 +50,13 @@ export class InlineEditModel implements IInlineEditModel {
 	}
 
 	abort(reason: string) {
-		console.error(reason); // TODO: add logs/telemetry
+		console.error(reason);
+		this.inlineEdit.inlineCompletion.reportInlineEditError(reason);
 		this._model.stop();
 	}
 
-	handleInlineEditShown() {
-		this._model.handleInlineSuggestionShown(this.inlineEdit.inlineCompletion);
+	handleInlineEditShown(viewKind: string) {
+		this._model.handleInlineSuggestionShown(this.inlineEdit.inlineCompletion, viewKind);
 	}
 }
 

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsView.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsView.ts
@@ -76,8 +76,6 @@ export class InlineEditsView extends Disposable {
 				return undefined;
 			}
 
-			model.handleInlineEditShown();
-
 			const inlineEdit = model.inlineEdit;
 			let mappings = RangeMapping.fromEdit(inlineEdit.edit);
 			let newText = inlineEdit.edit.apply(inlineEdit.originalText);
@@ -88,6 +86,8 @@ export class InlineEditsView extends Disposable {
 				model.abort(`unable to determine view: tried to render ${this._previousView?.view}`);
 				return undefined;
 			}
+
+			model.handleInlineEditShown(state.kind);
 
 			if (state.kind === 'sideBySide') {
 				const indentationAdjustmentEdit = createReindentEdit(newText, inlineEdit.modifiedLineRange);

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViewInterface.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViewInterface.ts
@@ -35,7 +35,7 @@ export interface IInlineEditModel {
 	showCollapsed: IObservable<boolean>;
 	displayLocation: InlineCompletionDisplayLocation | undefined;
 
-	handleInlineEditShown(): void;
+	handleInlineEditShown(viewKind: string): void;
 	accept(): void;
 	jump(): void;
 	abort(reason: string): void;

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -7422,7 +7422,7 @@ declare namespace monaco.languages {
 		 * Is called when an inline completion item is no longer being used.
 		 * Provides a reason of why it is not used anymore.
 		*/
-		handleEndOfLifetime?(completions: T, item: T['items'][number], reason: InlineCompletionEndOfLifeReason<T['items'][number]>): void;
+		handleEndOfLifetime?(completions: T, item: T['items'][number], reason: InlineCompletionEndOfLifeReason<T['items'][number]>, lifetimeSummary: LifetimeSummary): void;
 		/**
 		 * Will be called when a completions list is no longer in use and can be garbage-collected.
 		*/
@@ -7461,6 +7461,14 @@ declare namespace monaco.languages {
 		kind: InlineCompletionEndOfLifeReasonKind.Ignored;
 		supersededBy?: TInlineCompletion;
 		userTypingDisagreed: boolean;
+	};
+
+	export type LifetimeSummary = {
+		requestUuid: string;
+		shown: boolean;
+		editorType: string;
+		viewKind: string | undefined;
+		error: string | undefined;
 	};
 
 	export interface CodeAction {

--- a/src/vs/workbench/api/browser/mainThreadLanguageFeatures.ts
+++ b/src/vs/workbench/api/browser/mainThreadLanguageFeatures.ts
@@ -34,6 +34,8 @@ import * as search from '../../contrib/search/common/search.js';
 import * as typeh from '../../contrib/typeHierarchy/common/typeHierarchy.js';
 import { extHostNamedCustomer, IExtHostContext } from '../../services/extensions/common/extHostCustomers.js';
 import { ExtHostContext, ExtHostLanguageFeaturesShape, HoverWithId, ICallHierarchyItemDto, ICodeActionDto, ICodeActionProviderMetadataDto, IdentifiableInlineCompletion, IdentifiableInlineCompletions, IDocumentDropEditDto, IDocumentDropEditProviderMetadata, IDocumentFilterDto, IIndentationRuleDto, IInlayHintDto, ILanguageConfigurationDto, ILanguageWordDefinitionDto, ILinkDto, ILocationDto, ILocationLinkDto, IOnEnterRuleDto, IPasteEditDto, IPasteEditProviderMetadataDto, IRegExpDto, ISignatureHelpProviderMetadataDto, ISuggestDataDto, ISuggestDataDtoField, ISuggestResultDtoField, ITypeHierarchyItemDto, IWorkspaceSymbolDto, MainContext, MainThreadLanguageFeaturesShape } from '../common/extHost.protocol.js';
+import { ITelemetryService } from '../../../platform/telemetry/common/telemetry.js';
+import { InlineCompletionEndOfLifeReasonKind } from '../common/extHostTypes.js';
 
 @extHostNamedCustomer(MainContext.MainThreadLanguageFeatures)
 export class MainThreadLanguageFeatures extends Disposable implements MainThreadLanguageFeaturesShape {
@@ -46,7 +48,8 @@ export class MainThreadLanguageFeatures extends Disposable implements MainThread
 		@ILanguageService private readonly _languageService: ILanguageService,
 		@ILanguageConfigurationService private readonly _languageConfigurationService: ILanguageConfigurationService,
 		@ILanguageFeaturesService private readonly _languageFeaturesService: ILanguageFeaturesService,
-		@IUriIdentityService private readonly _uriIdentService: IUriIdentityService
+		@IUriIdentityService private readonly _uriIdentService: IUriIdentityService,
+		@ITelemetryService private readonly _telemetryService: ITelemetryService,
 	) {
 		super();
 
@@ -629,7 +632,7 @@ export class MainThreadLanguageFeatures extends Disposable implements MainThread
 					await this._proxy.$handleInlineCompletionPartialAccept(handle, completions.pid, item.idx, acceptedCharacters, info);
 				}
 			},
-			handleEndOfLifetime: async (completions, item, reason) => {
+			handleEndOfLifetime: async (completions, item, reason, lifetimeSummary) => {
 
 				function mapReason<T1, T2>(reason: languages.InlineCompletionEndOfLifeReason<T1>, f: (reason: T1) => T2): languages.InlineCompletionEndOfLifeReason<T2> {
 					if (reason.kind === languages.InlineCompletionEndOfLifeReasonKind.Ignored) {
@@ -644,6 +647,20 @@ export class MainThreadLanguageFeatures extends Disposable implements MainThread
 				if (supportsHandleEvents) {
 					await this._proxy.$handleInlineCompletionEndOfLifetime(handle, completions.pid, item.idx, mapReason(reason, i => ({ pid: completions.pid, idx: i.idx })));
 				}
+
+				const endOfLifeSummary: InlineCompletionEndOfLifeEvent = {
+					id: lifetimeSummary.requestUuid,
+					shown: lifetimeSummary.shown,
+					editorType: lifetimeSummary.editorType,
+					viewKind: lifetimeSummary.viewKind,
+					error: lifetimeSummary.error,
+					superseded: reason.kind === InlineCompletionEndOfLifeReasonKind.Ignored && !!reason.supersededBy,
+					reason: reason.kind === InlineCompletionEndOfLifeReasonKind.Accepted ? 'accepted'
+						: reason.kind === InlineCompletionEndOfLifeReasonKind.Rejected ? 'rejected'
+							: 'ignored'
+				};
+
+				this._telemetryService.publicLog2<InlineCompletionEndOfLifeEvent, InlineCompletionsEndOfLifeClassification>('inlineCompletion.endOfLife', endOfLifeSummary);
 			},
 			disposeInlineCompletions: (completions: IdentifiableInlineCompletions, reason: languages.InlineCompletionsDisposeReason): void => {
 				this._proxy.$freeInlineCompletionsList(handle, completions.pid, reason);
@@ -1265,3 +1282,24 @@ export class MainThreadDocumentRangeSemanticTokensProvider implements languages.
 	}
 }
 
+type InlineCompletionEndOfLifeEvent = {
+	id: string;
+	shown: boolean;
+	reason: 'accepted' | 'rejected' | 'ignored';
+	error: string | undefined;
+	superseded: boolean;
+	editorType: string;
+	viewKind: string | undefined;
+};
+
+type InlineCompletionsEndOfLifeClassification = {
+	owner: 'benibenj';
+	comment: 'Inline completions ended';
+	id: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The identifier for the inline completion request' };
+	shown: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Whether the inline completion was shown to the user' };
+	reason: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The reason for the inline completion ending' };
+	error: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The error message if the inline completion failed' };
+	superseded: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Whether the inline completion was superseded by another one' };
+	editorType: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The type of the editor where the inline completion was shown' };
+	viewKind: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The kind of the view where the inline completion was shown' };
+};


### PR DESCRIPTION
This will help us evaluate which views have a low acceptance rate. This might indicate that some representations of inlin edits views are hard to understand/read. Based on that information we can focus on improving these