### PR TITLE
Add shown duration to inline completions

### DIFF
--- a/src/vs/editor/common/languages.ts
+++ b/src/vs/editor/common/languages.ts
@@ -939,6 +939,8 @@ export type InlineCompletionEndOfLifeReason<TInlineCompletion = InlineCompletion
 export type LifetimeSummary = {
 	requestUuid: string;
 	shown: boolean;
+	shownDuration: number;
+	shownDurationUncollapsed: number;
 	editorType: string;
 	viewKind: string | undefined;
 	error: string | undefined;

--- a/src/vs/editor/contrib/inlineCompletions/browser/model/inlineCompletionsSource.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/model/inlineCompletionsSource.ts
@@ -27,7 +27,7 @@ import { IModelContentChangedEvent } from '../../../../common/textModelEvents.js
 import { formatRecordableLogEntry, IRecordableEditorLogEntry, IRecordableLogEntry, StructuredLogger } from '../structuredLogger.js';
 import { wait } from '../utils.js';
 import { InlineSuggestionIdentity, InlineSuggestionItem } from './inlineSuggestionItem.js';
-import { InlineCompletionContextWithoutUuid, InlineCompletionProviderResult, provideInlineCompletions } from './provideInlineCompletions.js';
+import { InlineCompletionContextWithoutUuid, InlineCompletionEditorType, InlineCompletionProviderResult, provideInlineCompletions } from './provideInlineCompletions.js';
 
 export class InlineCompletionsSource extends Disposable {
 	private static _requestId = 0;
@@ -116,7 +116,7 @@ export class InlineCompletionsSource extends Disposable {
 	private readonly _loadingCount;
 	public readonly loading;
 
-	public fetch(providers: InlineCompletionsProvider[], position: Position, context: InlineCompletionContextWithoutUuid, activeInlineCompletion: InlineSuggestionIdentity | undefined, withDebounce: boolean, userJumpedToActiveCompletion: IObservable<boolean>, providerhasChangedCompletion: boolean, editorType: string): Promise<boolean> {
+	public fetch(providers: InlineCompletionsProvider[], position: Position, context: InlineCompletionContextWithoutUuid, activeInlineCompletion: InlineSuggestionIdentity | undefined, withDebounce: boolean, userJumpedToActiveCompletion: IObservable<boolean>, providerhasChangedCompletion: boolean, editorType: InlineCompletionEditorType): Promise<boolean> {
 		const request = new UpdateRequest(position, context, this._textModel.getVersionId());
 
 		const target = context.selectedSuggestionInfo ? this.suggestWidgetInlineCompletions.get() : this.inlineCompletions.get();

--- a/src/vs/editor/contrib/inlineCompletions/browser/model/inlineSuggestionItem.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/model/inlineSuggestionItem.ts
@@ -24,6 +24,7 @@ import { TextModelText } from '../../../../common/model/textModelText.js';
 import { IDisplayLocation, InlineSuggestData, InlineSuggestionList, SnippetInfo } from './provideInlineCompletions.js';
 import { singleTextRemoveCommonPrefix } from './singleTextEditHelpers.js';
 import { getPositionOffsetTransformerFromTextModel } from '../../../../common/core/text/getPositionOffsetTransformerFromTextModel.js';
+import { InlineCompletionViewKind } from '../view/inlineEdits/inlineEditsViewInterface.js';
 
 export type InlineSuggestionItem = InlineEditItem | InlineCompletionItem;
 
@@ -99,7 +100,7 @@ abstract class InlineSuggestionItemBase {
 		this.source.removeRef();
 	}
 
-	public reportInlineEditShown(commandService: ICommandService, viewKind: string) {
+	public reportInlineEditShown(commandService: ICommandService, viewKind: InlineCompletionViewKind) {
 		this._data.reportInlineEditShown(commandService, this.insertText, viewKind);
 	}
 

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsModel.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsModel.ts
@@ -14,7 +14,7 @@ import { StringText } from '../../../../../common/core/text/abstractText.js';
 import { Command, InlineCompletionCommand, InlineCompletionDisplayLocation } from '../../../../../common/languages.js';
 import { InlineCompletionsModel } from '../../model/inlineCompletionsModel.js';
 import { InlineCompletionItem } from '../../model/inlineSuggestionItem.js';
-import { IInlineEditHost, IInlineEditModel, InlineEditTabAction } from './inlineEditsViewInterface.js';
+import { IInlineEditHost, IInlineEditModel, InlineCompletionViewKind, InlineEditTabAction } from './inlineEditsViewInterface.js';
 import { InlineEditWithChanges } from './inlineEditWithChanges.js';
 
 export class InlineEditModel implements IInlineEditModel {
@@ -55,7 +55,7 @@ export class InlineEditModel implements IInlineEditModel {
 		this._model.stop();
 	}
 
-	handleInlineEditShown(viewKind: string) {
+	handleInlineEditShown(viewKind: InlineCompletionViewKind) {
 		this._model.handleInlineSuggestionShown(this.inlineEdit.inlineCompletion, viewKind);
 	}
 }

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViewInterface.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViewInterface.ts
@@ -40,3 +40,15 @@ export interface IInlineEditModel {
 	jump(): void;
 	abort(reason: string): void;
 }
+
+export enum InlineCompletionViewKind {
+	GhostText = 'ghostText',
+	Custom = 'custom',
+	SideBySide = 'sideBySide',
+	Deletion = 'deletion',
+	InsertionInline = 'insertionInline',
+	InsertionMultiLine = 'insertionMultiLine',
+	WordReplacements = 'wordReplacements',
+	LineReplacement = 'lineReplacement',
+	Collapsed = 'collapsed'
+}

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -7466,6 +7466,8 @@ declare namespace monaco.languages {
 	export type LifetimeSummary = {
 		requestUuid: string;
 		shown: boolean;
+		shownDuration: number;
+		shownDurationUncollapsed: number;
 		editorType: string;
 		viewKind: string | undefined;
 		error: string | undefined;

--- a/src/vs/workbench/api/browser/mainThreadLanguageFeatures.ts
+++ b/src/vs/workbench/api/browser/mainThreadLanguageFeatures.ts
@@ -651,15 +651,18 @@ export class MainThreadLanguageFeatures extends Disposable implements MainThread
 				const endOfLifeSummary: InlineCompletionEndOfLifeEvent = {
 					id: lifetimeSummary.requestUuid,
 					shown: lifetimeSummary.shown,
+					shownDuration: lifetimeSummary.shownDuration,
+					shownDurationUncollapsed: lifetimeSummary.shownDurationUncollapsed,
 					editorType: lifetimeSummary.editorType,
 					viewKind: lifetimeSummary.viewKind,
 					error: lifetimeSummary.error,
+					extensionId,
 					superseded: reason.kind === InlineCompletionEndOfLifeReasonKind.Ignored && !!reason.supersededBy,
 					reason: reason.kind === InlineCompletionEndOfLifeReasonKind.Accepted ? 'accepted'
 						: reason.kind === InlineCompletionEndOfLifeReasonKind.Rejected ? 'rejected'
 							: 'ignored'
 				};
-
+				console.log('Inline completion end of life:', endOfLifeSummary);
 				this._telemetryService.publicLog2<InlineCompletionEndOfLifeEvent, InlineCompletionsEndOfLifeClassification>('inlineCompletion.endOfLife', endOfLifeSummary);
 			},
 			disposeInlineCompletions: (completions: IdentifiableInlineCompletions, reason: languages.InlineCompletionsDisposeReason): void => {
@@ -1284,7 +1287,10 @@ export class MainThreadDocumentRangeSemanticTokensProvider implements languages.
 
 type InlineCompletionEndOfLifeEvent = {
 	id: string;
+	extensionId: string;
 	shown: boolean;
+	shownDuration: number;
+	shownDurationUncollapsed: number;
 	reason: 'accepted' | 'rejected' | 'ignored';
 	error: string | undefined;
 	superseded: boolean;
@@ -1296,7 +1302,10 @@ type InlineCompletionsEndOfLifeClassification = {
 	owner: 'benibenj';
 	comment: 'Inline completions ended';
 	id: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The identifier for the inline completion request' };
+	extensionId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The identifier for the extension that contributed the inline completion' };
 	shown: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Whether the inline completion was shown to the user' };
+	shownDuration: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The duration for which the inline completion was shown' };
+	shownDurationUncollapsed: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The duration for which the inline completion was shown without collapsing' };
 	reason: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The reason for the inline completion ending' };
 	error: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The error message if the inline completion failed' };
 	superseded: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Whether the inline completion was superseded by another one' };


### PR DESCRIPTION
```Copilot Generated Description:``` Introduce properties for shown duration and shown duration uncollapsed in the inline completion lifecycle. Update related types and methods to accommodate these new properties.