### PR TITLE
Don't count codeblocks as words in chat rendering calculation

### DIFF
--- a/src/vs/workbench/contrib/chat/common/chatViewModel.ts
+++ b/src/vs/workbench/contrib/chat/common/chatViewModel.ts
@@ -606,7 +606,7 @@ export class ChatResponseViewModel extends Disposable implements IChatResponseVi
 						this._contentUpdateTimings.lastUpdateTime = now;
 					}
 
-					const timeDiff = Math.min(now - this._contentUpdateTimings.lastUpdateTime, 1000);
+					const timeDiff = Math.min(now - this._contentUpdateTimings.lastUpdateTime, 500);
 					const newTotalTime = Math.max(this._contentUpdateTimings.totalTime + timeDiff, 250);
 					const impliedWordLoadRate = wordCount / (newTotalTime / 1000);
 					this.trace('onDidChange', `Update- got ${wordCount} words over last ${newTotalTime}ms = ${impliedWordLoadRate} words/s`);

--- a/src/vs/workbench/contrib/chat/common/chatWordCounter.ts
+++ b/src/vs/workbench/contrib/chat/common/chatWordCounter.ts
@@ -46,7 +46,8 @@ export function getNWords(str: string, numWordsToCount: number): IWordCountResul
 	// One chinese character
 	// One or more + - =, handled so that code like "a=1+2-3" is broken up better
 	// One or more characters that aren't whitepace or any of the above
-	const allWordMatches = Array.from(str.matchAll(new RegExp(linkPattern + r`|\p{sc=Han}|=+|\++|-+|[^\s\|\p{sc=Han}|=|\+|\-]+`, 'gu')));
+	const backtick = '`';
+	const allWordMatches = Array.from(str.matchAll(new RegExp(linkPattern + r`|\p{sc=Han}|=+|\++|-+|[^\s\|\p{sc=Han}|=|\+|\-|${backtick}]+`, 'gu')));
 
 	const targetWords = allWordMatches.slice(0, numWordsToCount);
 

--- a/src/vs/workbench/contrib/chat/test/common/chatWordCounter.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/chatWordCounter.test.ts
@@ -87,6 +87,14 @@ suite('ChatWordCounter', () => {
 			cases.forEach(([str, nWords, result]) => doTest(str, nWords, result));
 		});
 
+		test('codeblocks', () => {
+			const cases: [string, number, string][] = [
+				['hello\n\n```\n```\n\nworld foo', 2, 'hello\n\n```\n```\n\nworld'],
+			];
+
+			cases.forEach(([str, nWords, result]) => doTest(str, nWords, result));
+		});
+
 		test('chinese characters', () => {
 			const cases: [string, number, string][] = [
 				['我喜欢中国菜', 3, '我喜欢'],


### PR DESCRIPTION
This was causing rendering to slow down when editing files because edit tools emit empty codeblocks just to trigger the codeblock pill render