### PR TITLE
Add support for FreeBSD

### DIFF
--- a/build/lib/propertyInitOrderChecker.ts
+++ b/build/lib/propertyInitOrderChecker.ts
@@ -36,7 +36,7 @@ let errorCount = 0;
 function createProgram(tsconfigPath: string): ts.Program {
 	const tsConfig = ts.readConfigFile(tsconfigPath, ts.sys.readFile);
 
-	const configHostParser: ts.ParseConfigHost = { fileExists: fs.existsSync, readDirectory: ts.sys.readDirectory, readFile: file => fs.readFileSync(file, 'utf8'), useCaseSensitiveFileNames: process.platform === 'linux' };
+	const configHostParser: ts.ParseConfigHost = { fileExists: fs.existsSync, readDirectory: ts.sys.readDirectory, readFile: file => fs.readFileSync(file, 'utf8'), useCaseSensitiveFileNames: (process.platform === 'linux' || process.platform === 'freebsd') };
 	const tsConfigParsed = ts.parseJsonConfigFileContent(tsConfig.config, configHostParser, path.resolve(path.dirname(tsconfigPath)), { noEmit: true });
 
 	const compilerHost = ts.createCompilerHost(tsConfigParsed.options, true);

--- a/build/lib/snapshotLoader.ts
+++ b/build/lib/snapshotLoader.ts
@@ -26,6 +26,7 @@ export namespace snaps {
 
 		case 'win32':
 		case 'linux':
+		case 'freebsd':
 			loaderFilepath = `VSCode-${process.platform}-${arch}/resources/app/out/vs/loader.js`;
 			startupBlobFilepath = `VSCode-${process.platform}-${arch}/snapshot_blob.bin`;
 			break;

--- a/extensions/emmet/src/test/testUtils.ts
+++ b/extensions/emmet/src/test/testUtils.ts
@@ -31,7 +31,7 @@ export function createRandomFile(contents = '', fileExtension = 'txt'): Thenable
 }
 
 export function pathEquals(path1: string, path2: string): boolean {
-	if (process.platform !== 'linux') {
+	if (process.platform !== 'linux' && process.platform !== 'freebsd') {
 		path1 = path1.toLowerCase();
 		path2 = path2.toLowerCase();
 	}

--- a/extensions/vscode-api-tests/src/utils.ts
+++ b/extensions/vscode-api-tests/src/utils.ts
@@ -38,7 +38,7 @@ export async function deleteFile(file: vscode.Uri): Promise<boolean> {
 }
 
 export function pathEquals(path1: string, path2: string): boolean {
-	if (process.platform !== 'linux') {
+	if (process.platform !== 'linux' && process.platform !== 'freebsd') {
 		path1 = path1.toLowerCase();
 		path2 = path2.toLowerCase();
 	}

--- a/extensions/vscode-test-resolver/src/util/processes.ts
+++ b/extensions/vscode-test-resolver/src/util/processes.ts
@@ -20,7 +20,7 @@ export function terminateProcess(p: cp.ChildProcess, extensionPath: string): Ter
 		} catch (err) {
 			return { success: false, error: err };
 		}
-	} else if (process.platform === 'darwin' || process.platform === 'linux') {
+	} else if (process.platform === 'darwin' || process.platform === 'linux' || process.platform === 'freebsd') {
 		try {
 			const cmd = path.join(extensionPath, 'scripts', 'terminateProcess.sh');
 			const result = cp.spawnSync(cmd, [p.pid!.toString()]);

--- a/resources/linux/bin/code.sh
+++ b/resources/linux/bin/code.sh
@@ -13,7 +13,7 @@ if [ -n "$VSCODE_IPC_HOOK_CLI" ]; then
 fi
 
 # test that VSCode wasn't installed inside WSL
-if grep -qi Microsoft /proc/version && [ -z "$DONT_PROMPT_WSL_INSTALL" ]; then
+if grep -qi Microsoft /proc/version 2> /dev/null && [ -z "$DONT_PROMPT_WSL_INSTALL" ]; then
 	echo "To use @@PRODNAME@@ with the Windows Subsystem for Linux, please install @@PRODNAME@@ in Windows and uninstall the Linux version in WSL. You can then use the \`@@APPNAME@@\` command in a WSL terminal just as you would in a normal command prompt." 1>&2
 	printf "Do you want to continue anyway? [y/N] " 1>&2
 	read -r YN

--- a/resources/server/bin/helpers/check-requirements-linux.sh
+++ b/resources/server/bin/helpers/check-requirements-linux.sh
@@ -34,6 +34,9 @@ if [ -f /etc/os-release ]; then
     if [ "$OS_ID" = "nixos" ]; then
         echo "Warning: NixOS detected, skipping GLIBC check"
         exit 0
+    elif [ "$OS_ID" = "freebsd" ]; then
+        echo "Warning: FreeBSD detected, skipping GLIBC check"
+        exit 0
     fi
 fi
 

--- a/src/bootstrap-node.ts
+++ b/src/bootstrap-node.ts
@@ -152,7 +152,7 @@ export function configurePortable(product: Partial<IProductConfiguration>): { po
 			return process.env['VSCODE_PORTABLE'];
 		}
 
-		if (process.platform === 'win32' || process.platform === 'linux') {
+		if (process.platform === 'win32' || process.platform === 'linux' || process.platform === 'freebsd') {
 			return path.join(getApplicationPath(), 'data');
 		}
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -141,7 +141,7 @@ if (userLocale) {
 // Pseudo Language Language Pack is being used.
 // In that case, use `en` as the Electron locale.
 
-if (process.platform === 'win32' || process.platform === 'linux') {
+if (process.platform === 'win32' || process.platform === 'linux' || process.platform === 'freebsd') {
 	const electronLocale = (!userLocale || userLocale === 'qps-ploc') ? 'en' : userLocale;
 	app.commandLine.appendSwitch('lang', electronLocale);
 }
@@ -231,7 +231,7 @@ function configureCommandlineSwitchesSync(cliArgs: NativeParsedArgs) {
 		'proxy-bypass-list'
 	];
 
-	if (process.platform === 'linux') {
+	if (process.platform === 'linux' || process.platform === 'freebsd') {
 
 		// Force enable screen readers on Linux via this flag
 		SUPPORTED_ELECTRON_SWITCHES.push('force-renderer-accessibility');

--- a/src/vs/base/common/platform.ts
+++ b/src/vs/base/common/platform.ts
@@ -74,7 +74,7 @@ declare const navigator: INavigator;
 if (typeof nodeProcess === 'object') {
 	_isWindows = (nodeProcess.platform === 'win32');
 	_isMacintosh = (nodeProcess.platform === 'darwin');
-	_isLinux = (nodeProcess.platform === 'linux');
+	_isLinux = (nodeProcess.platform === 'linux' || nodeProcess.platform === 'freebsd');
 	_isLinuxSnap = _isLinux && !!nodeProcess.env['SNAP'] && !!nodeProcess.env['SNAP_REVISION'];
 	_isElectron = isElectronProcess;
 	_isCI = !!nodeProcess.env['CI'] || !!nodeProcess.env['BUILD_ARTIFACTSTAGINGDIRECTORY'];
@@ -100,7 +100,7 @@ else if (typeof navigator === 'object' && !isElectronRenderer) {
 	_isWindows = _userAgent.indexOf('Windows') >= 0;
 	_isMacintosh = _userAgent.indexOf('Macintosh') >= 0;
 	_isIOS = (_userAgent.indexOf('Macintosh') >= 0 || _userAgent.indexOf('iPad') >= 0 || _userAgent.indexOf('iPhone') >= 0) && !!navigator.maxTouchPoints && navigator.maxTouchPoints > 0;
-	_isLinux = _userAgent.indexOf('Linux') >= 0;
+	_isLinux = (_userAgent.indexOf('Linux') >= 0 || _userAgent.indexOf('FreeBSD') >= 0);
 	_isMobile = _userAgent?.indexOf('Mobi') >= 0;
 	_isWeb = true;
 	_language = nls.getNLSLanguage() || LANGUAGE_DEFAULT;

--- a/src/vs/base/node/ps.ts
+++ b/src/vs/base/node/ps.ts
@@ -225,7 +225,7 @@ export function listProcesses(rootPid: number): Promise<ProcessItem> {
 					}
 				} else {
 					const ps = stdout.toString().trim();
-					const args = '-ax -o pid=,ppid=,pcpu=,pmem=,command=';
+					const args = '-ax -o pid= -o ppid= -o pcpu= -o pmem= -o command=';
 
 					// Set numeric locale to ensure '.' is used as the decimal separator
 					exec(`${ps} ${args}`, { maxBuffer: 1000 * 1024, env: { LC_NUMERIC: 'en_US.UTF-8' } }, (err, stdout, stderr) => {

--- a/src/vs/code/electron-main/app.ts
+++ b/src/vs/code/electron-main/app.ts
@@ -990,6 +990,7 @@ export class CodeApplication extends Disposable {
 				break;
 
 			case 'linux':
+			case 'freebsd':
 				if (isLinuxSnap) {
 					services.set(IUpdateService, new SyncDescriptor(SnapUpdateService, [process.env['SNAP'], process.env['SNAP_REVISION']]));
 				} else {

--- a/src/vs/platform/environment/node/userDataPath.ts
+++ b/src/vs/platform/environment/node/userDataPath.ts
@@ -87,6 +87,7 @@ function doGetUserDataPath(cliArgs: NativeParsedArgs, productName: string): stri
 			appDataPath = join(homedir(), 'Library', 'Application Support');
 			break;
 		case 'linux':
+		case 'freebsd':
 			appDataPath = process.env['XDG_CONFIG_HOME'] || join(homedir(), '.config');
 			break;
 		default:

--- a/src/vs/workbench/api/browser/mainThreadTask.ts
+++ b/src/vs/workbench/api/browser/mainThreadTask.ts
@@ -727,6 +727,7 @@ export class MainThreadTask extends Disposable implements MainThreadTaskShape {
 				platform = Platform.Platform.Mac;
 				break;
 			case 'linux':
+			case 'freebsd':
 				platform = Platform.Platform.Linux;
 				break;
 			default:

--- a/src/vs/workbench/services/actions/common/menusExtensionPoint.ts
+++ b/src/vs/workbench/services/actions/common/menusExtensionPoint.ts
@@ -1174,7 +1174,10 @@ class CommandsTableRenderer extends Disposable implements IExtensionFeatureTable
 
 		switch (platform) {
 			case 'win32': key = rawKeyBinding.win; break;
-			case 'linux': key = rawKeyBinding.linux; break;
+			case 'linux':
+			case 'freebsd':
+				key = rawKeyBinding.linux;
+				break;
 			case 'darwin': key = rawKeyBinding.mac; break;
 		}
 

--- a/test/automation/src/electron.ts
+++ b/test/automation/src/electron.ts
@@ -85,6 +85,7 @@ export function getDevElectronPath(): string {
 		case 'darwin':
 			return join(buildPath, 'electron', `${product.nameLong}.app`, 'Contents', 'MacOS', 'Electron');
 		case 'linux':
+		case 'freebsd':
 			return join(buildPath, 'electron', `${product.applicationName}`);
 		case 'win32':
 			return join(buildPath, 'electron', `${product.nameShort}.exe`);
@@ -97,7 +98,8 @@ export function getBuildElectronPath(root: string): string {
 	switch (process.platform) {
 		case 'darwin':
 			return join(root, 'Contents', 'MacOS', 'Electron');
-		case 'linux': {
+		case 'linux':
+		case 'freebsd': {
 			const product = require(join(root, 'resources', 'app', 'product.json'));
 			return join(root, product.applicationName);
 		}

--- a/test/smoke/src/areas/task/task.test.ts
+++ b/test/smoke/src/areas/task/task.test.ts
@@ -19,6 +19,6 @@ export function setup(logger: Logger) {
 		// Refs https://github.com/microsoft/vscode/issues/225250
 		// Pty spawning fails with invalid fd error in product CI while development CI
 		// works fine, we need additional logging to investigate.
-		setupTaskQuickPickTests({ skipSuite: process.platform === 'linux' });
+		setupTaskQuickPickTests({ skipSuite: (process.platform === 'linux' || process.platform === 'freebsd') });
 	});
 }

--- a/test/smoke/src/areas/terminal/terminal.test.ts
+++ b/test/smoke/src/areas/terminal/terminal.test.ts
@@ -39,15 +39,15 @@ export function setup(logger: Logger) {
 		// https://github.com/microsoft/vscode/issues/216564
 		// The pty host can crash on Linux in smoke tests for an unknown reason. We need more user
 		// reports to investigate
-		setupTerminalEditorsTests({ skipSuite: process.platform === 'linux' });
-		setupTerminalInputTests({ skipSuite: process.platform === 'linux' });
-		setupTerminalPersistenceTests({ skipSuite: process.platform === 'linux' });
-		setupTerminalProfileTests({ skipSuite: process.platform === 'linux' });
-		setupTerminalTabsTests({ skipSuite: process.platform === 'linux' });
-		setupTerminalShellIntegrationTests({ skipSuite: process.platform === 'linux' });
-		setupTerminalStickyScrollTests({ skipSuite: process.platform === 'linux' });
+		setupTerminalEditorsTests({ skipSuite: (process.platform === 'linux' || process.platform === 'freebsd') });
+		setupTerminalInputTests({ skipSuite: (process.platform === 'linux' || process.platform === 'freebsd') });
+		setupTerminalPersistenceTests({ skipSuite: (process.platform === 'linux' || process.platform === 'freebsd') });
+		setupTerminalProfileTests({ skipSuite: (process.platform === 'linux' || process.platform === 'freebsd') });
+		setupTerminalTabsTests({ skipSuite: (process.platform === 'linux' || process.platform === 'freebsd') });
+		setupTerminalShellIntegrationTests({ skipSuite: (process.platform === 'linux' || process.platform === 'freebsd') });
+		setupTerminalStickyScrollTests({ skipSuite: (process.platform === 'linux' || process.platform === 'freebsd') });
 		// https://github.com/microsoft/vscode/pull/141974
 		// Windows is skipped here as well as it was never enabled from the start
-		setupTerminalSplitCwdTests({ skipSuite: process.platform === 'linux' || process.platform === 'win32' });
+		setupTerminalSplitCwdTests({ skipSuite: (process.platform === 'linux' || process.platform === 'freebsd' || process.platform === 'win32') });
 	});
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR contains a set of changes for adding support for FreeBSD.

Basically, FreeBSD can be treated as if it is Linux. So the changes are mainly adding `process.platform === 'freebsd'`, `process.platform !== 'freebsd'`, or `case 'freebsd'`: to wherever it checks the OS is Linux with a few exceptions where the check is for really Linux-specific.

I would much appreciate it if this PR is considered for merging.

Relate PR: https://github.com/microsoft/vscode-deviceid/pull/25
Related Issues: #1359, #30046, #32409, #74857, #129928