### PR TITLE
add session ID to terminal, send with suggest, quickfix, and creation events

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminal.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminal.ts
@@ -675,6 +675,11 @@ export interface ITerminalInstance extends IBaseTerminalInstance {
 	readonly hasFocus: boolean;
 
 	/**
+	 * The ID of the session that this terminal is connected to
+	 */
+	readonly sessionId: string;
+
+	/**
 	 * Get or set the behavior of the terminal when it closes. This was indented only to be called
 	 * after reconnecting to a terminal.
 	 */

--- a/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
@@ -91,6 +91,7 @@ import { IContextMenuService } from '../../../../platform/contextview/browser/co
 import { TerminalContribCommandId } from '../terminalContribExports.js';
 import type { IProgressState } from '@xterm/addon-progress';
 import { refreshShellIntegrationInfoStatus } from './terminalTooltip.js';
+import { generateUuid } from '../../../../base/common/uuid.js';
 
 const enum Constants {
 	/**
@@ -360,6 +361,8 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 		onDidAddFirstListener: async () => (this.xterm ?? await this._xtermReadyPromise)?.raw.loadAddon(this._lineDataEventAddon!)
 	}));
 	readonly onLineData = this._onLineData.event;
+
+	readonly sessionId = generateUuid();
 
 	constructor(
 		private readonly _terminalShellTypeContextKey: IContextKey<string>,

--- a/src/vs/workbench/contrib/terminal/browser/terminalTelemetry.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalTelemetry.ts
@@ -61,6 +61,8 @@ export class TerminalTelemetryContribution extends Disposable implements IWorkbe
 			shellIntegrationQuality: number;
 			shellIntegrationInjected: boolean;
 			shellIntegrationInjectionFailureReason: ShellIntegrationInjectionFailureReason | undefined;
+
+			sessionId: string;
 		};
 		type TerminalCreationTelemetryClassification = {
 			owner: 'tyriar';
@@ -77,6 +79,8 @@ export class TerminalTelemetryContribution extends Disposable implements IWorkbe
 			shellIntegrationQuality: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The shell integration quality (rich=2, basic=1 or none=0).' };
 			shellIntegrationInjected: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Whether the shell integration script was injected.' };
 			shellIntegrationInjectionFailureReason: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Info about shell integration injection.' };
+
+			sessionId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The session ID of the terminal instance.' };
 		};
 		this._telemetryService.publicLog2<TerminalCreationTelemetryData, TerminalCreationTelemetryClassification>('terminal/createInstance', {
 			shellType: getSanitizedShellType(slc),
@@ -90,6 +94,7 @@ export class TerminalTelemetryContribution extends Disposable implements IWorkbe
 			shellIntegrationQuality: commandDetection?.hasRichCommandDetection ? 2 : commandDetection ? 1 : 0,
 			shellIntegrationInjected: instance.usedShellIntegrationInjection,
 			shellIntegrationInjectionFailureReason: instance.shellIntegrationInjectionFailureReason,
+			sessionId: instance.sessionId,
 		});
 	}
 }

--- a/src/vs/workbench/contrib/terminalContrib/quickFix/browser/quickFixAddon.ts
+++ b/src/vs/workbench/contrib/terminalContrib/quickFix/browser/quickFixAddon.ts
@@ -81,6 +81,7 @@ export class TerminalQuickFixAddon extends Disposable implements ITerminalAddon,
 	readonly onDidUpdateQuickFixes = this._onDidUpdateQuickFixes.event;
 
 	constructor(
+		private readonly _sessionId: string,
 		private readonly _aliases: string[][] | undefined,
 		private readonly _capabilities: ITerminalCapabilityStore,
 		@IAccessibilitySignalService private readonly _accessibilitySignalService: IAccessibilitySignalService,
@@ -224,16 +225,19 @@ export class TerminalQuickFixAddon extends Disposable implements ITerminalAddon,
 		type QuickFixResultTelemetryEvent = {
 			quickFixId: string;
 			ranQuickFix: boolean;
+			sessionId: string;
 		};
 		type QuickFixClassification = {
 			owner: 'meganrogge';
 			quickFixId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The quick fix ID' };
 			ranQuickFix: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Whether the quick fix was run' };
+			sessionId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The terminal session ID' };
 			comment: 'Terminal quick fixes';
 		};
 		this._telemetryService?.publicLog2<QuickFixResultTelemetryEvent, QuickFixClassification>('terminal/quick-fix', {
 			quickFixId: id,
-			ranQuickFix: this._didRun
+			ranQuickFix: this._didRun,
+			sessionId: this._sessionId
 		});
 		this._decoration.clear();
 		this._decorationDisposables.clear();

--- a/src/vs/workbench/contrib/terminalContrib/quickFix/browser/terminal.quickFix.contribution.ts
+++ b/src/vs/workbench/contrib/terminalContrib/quickFix/browser/terminal.quickFix.contribution.ts
@@ -49,7 +49,7 @@ class TerminalQuickFixContribution extends DisposableStore implements ITerminalC
 
 	xtermReady(xterm: IXtermTerminal & { raw: RawXtermTerminal }): void {
 		// Create addon
-		this._addon = this._instantiationService.createInstance(TerminalQuickFixAddon, undefined, this._ctx.instance.capabilities);
+		this._addon = this._instantiationService.createInstance(TerminalQuickFixAddon, this._ctx.instance.sessionId, undefined, this._ctx.instance.capabilities);
 		xterm.raw.loadAddon(this._addon);
 
 		// Hook up listeners

--- a/src/vs/workbench/contrib/terminalContrib/quickFix/test/browser/quickFixAddon.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/quickFix/test/browser/quickFixAddon.test.ts
@@ -29,6 +29,7 @@ import { ITerminalQuickFixService } from '../../browser/quickFix.js';
 import { getQuickFixesForCommand, TerminalQuickFixAddon } from '../../browser/quickFixAddon.js';
 import { freePort, FreePortOutputRegex, gitCreatePr, GitCreatePrOutputRegex, gitFastForwardPull, GitFastForwardPullOutputRegex, GitPushOutputRegex, gitPushSetUpstream, gitSimilar, GitSimilarOutputRegex, gitTwoDashes, GitTwoDashesRegex, pwshGeneralError, PwshGeneralErrorOutputRegex, pwshUnixCommandNotFoundError, PwshUnixCommandNotFoundErrorOutputRegex } from '../../browser/terminalQuickFixBuiltinActions.js';
 import { TestStorageService } from '../../../../../test/common/workbenchTestServices.js';
+import { generateUuid } from '../../../../../../base/common/uuid.js';
 
 suite('QuickFixAddon', () => {
 	const store = ensureNoDisposablesAreLeakedInTestSuite();
@@ -66,7 +67,7 @@ suite('QuickFixAddon', () => {
 		openerService = instantiationService.stub(IOpenerService, {} as Partial<IOpenerService>);
 		commandService = new TestCommandService(instantiationService);
 
-		quickFixAddon = instantiationService.createInstance(TerminalQuickFixAddon, [], capabilities);
+		quickFixAddon = instantiationService.createInstance(TerminalQuickFixAddon, generateUuid(), [], capabilities);
 		terminal.loadAddon(quickFixAddon);
 	});
 

--- a/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminal.suggest.contribution.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminal.suggest.contribution.ts
@@ -208,7 +208,7 @@ class TerminalSuggestContribution extends DisposableStore implements ITerminalCo
 			return;
 		}
 
-		const addon = this._addon.value = this._instantiationService.createInstance(SuggestAddon, this._ctx.instance.shellType, this._ctx.instance.capabilities, this._terminalSuggestWidgetVisibleContextKey);
+		const addon = this._addon.value = this._instantiationService.createInstance(SuggestAddon, this._ctx.instance.sessionId, this._ctx.instance.shellType, this._ctx.instance.capabilities, this._terminalSuggestWidgetVisibleContextKey);
 		xterm.loadAddon(addon);
 		this._loadPwshCompletionAddon(xterm);
 		this._loadLspCompletionAddon(xterm);

--- a/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalSuggestAddon.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalSuggestAddon.ts
@@ -136,6 +136,7 @@ export class SuggestAddon extends Disposable implements ITerminalAddon, ISuggest
 	private _suggestTelemetry: TerminalSuggestTelemetry | undefined;
 
 	constructor(
+		private readonly _sessionId: string,
 		shellType: TerminalShellType | undefined,
 		private readonly _capabilities: ITerminalCapabilityStore,
 		private readonly _terminalSuggestWidgetVisibleContextKey: IContextKey<boolean>,
@@ -753,7 +754,7 @@ export class SuggestAddon extends Disposable implements ITerminalAddon, ISuggest
 		}
 		const initialPromptInputState = this._mostRecentPromptInputState;
 		if (!suggestion || !initialPromptInputState || this._leadingLineContent === undefined || !this._model) {
-			this._suggestTelemetry?.acceptCompletion(undefined, this._mostRecentPromptInputState?.value);
+			this._suggestTelemetry?.acceptCompletion(this._sessionId, undefined, this._mostRecentPromptInputState?.value);
 			return;
 		}
 		SuggestAddon.lastAcceptedCompletionTimestamp = Date.now();
@@ -839,7 +840,7 @@ export class SuggestAddon extends Disposable implements ITerminalAddon, ISuggest
 
 		// Send the completion
 		this._onAcceptedCompletion.fire(resultSequence);
-		this._suggestTelemetry?.acceptCompletion(completion, this._mostRecentPromptInputState?.value);
+		this._suggestTelemetry?.acceptCompletion(this._sessionId, completion, this._mostRecentPromptInputState?.value);
 		this.hideSuggestWidget(true);
 	}
 


### PR DESCRIPTION
Will enable us to look at completion outcomes for each shell type 