### PR TITLE
track latency from request -> showing terminal completions, indicate first shown for shell type and for window

### DIFF
--- a/src/vs/workbench/contrib/terminal/common/terminalStorageKeys.ts
+++ b/src/vs/workbench/contrib/terminal/common/terminalStorageKeys.ts
@@ -13,5 +13,6 @@ export const enum TerminalStorageKeys {
 	TerminalBufferState = 'terminal.integrated.bufferState',
 	TerminalLayoutInfo = 'terminal.integrated.layoutInfo',
 	PinnedRecentCommandsPrefix = 'terminal.pinnedRecentCommands',
-	TerminalSuggestSize = 'terminal.integrated.suggestSize'
+	TerminalSuggestSize = 'terminal.integrated.suggestSize',
+	HasShownCompletions = 'terminal.integrated.hasShownCompletions',
 }

--- a/src/vs/workbench/contrib/terminal/common/terminalStorageKeys.ts
+++ b/src/vs/workbench/contrib/terminal/common/terminalStorageKeys.ts
@@ -14,5 +14,4 @@ export const enum TerminalStorageKeys {
 	TerminalLayoutInfo = 'terminal.integrated.layoutInfo',
 	PinnedRecentCommandsPrefix = 'terminal.pinnedRecentCommands',
 	TerminalSuggestSize = 'terminal.integrated.suggestSize',
-	FirstShown = 'terminal.integrated.firstShown',
 }

--- a/src/vs/workbench/contrib/terminal/common/terminalStorageKeys.ts
+++ b/src/vs/workbench/contrib/terminal/common/terminalStorageKeys.ts
@@ -14,5 +14,5 @@ export const enum TerminalStorageKeys {
 	TerminalLayoutInfo = 'terminal.integrated.layoutInfo',
 	PinnedRecentCommandsPrefix = 'terminal.pinnedRecentCommands',
 	TerminalSuggestSize = 'terminal.integrated.suggestSize',
-	FirstShown = 'terminal.integrated.firstShownCompletions',
+	FirstShown = 'terminal.integrated.firstShown',
 }

--- a/src/vs/workbench/contrib/terminal/common/terminalStorageKeys.ts
+++ b/src/vs/workbench/contrib/terminal/common/terminalStorageKeys.ts
@@ -14,5 +14,5 @@ export const enum TerminalStorageKeys {
 	TerminalLayoutInfo = 'terminal.integrated.layoutInfo',
 	PinnedRecentCommandsPrefix = 'terminal.pinnedRecentCommands',
 	TerminalSuggestSize = 'terminal.integrated.suggestSize',
-	HasShownCompletions = 'terminal.integrated.hasShownCompletions',
+	FirstShown = 'terminal.integrated.firstShownCompletions',
 }

--- a/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalSuggestAddon.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalSuggestAddon.ts
@@ -881,8 +881,7 @@ export class SuggestAddon extends Disposable implements ITerminalAddon, ISuggest
 	}
 
 	getFirstShown(shellType: TerminalShellType): { window: boolean; shell: boolean } {
-		const raw = firstShownTracker;
-		if (!raw) {
+		if (!firstShownTracker) {
 			firstShownTracker = {
 				window: true,
 				shell: {
@@ -893,8 +892,8 @@ export class SuggestAddon extends Disposable implements ITerminalAddon, ISuggest
 		}
 
 		try {
-			const isFirstForWindow = raw.window;
-			const isFirstForShell = raw.shell[shellType] === undefined;
+			const isFirstForWindow = firstShownTracker.window;
+			const isFirstForShell = firstShownTracker.shell[shellType] === undefined;
 
 			if (isFirstForWindow || isFirstForShell) {
 				this.updateShown();

--- a/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalSuggestAddon.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalSuggestAddon.ts
@@ -885,13 +885,13 @@ export class SuggestAddon extends Disposable implements ITerminalAddon, ISuggest
 		if (!firstShownTracker) {
 			firstShownTracker = {
 				window: true,
-				shell: { [shellType]: true }
+				shell: new Map([[shellType, true]])
 			};
 			return { window: true, shell: true };
 		}
 
 		const isFirstForWindow = firstShownTracker.window;
-		const isFirstForShell = firstShownTracker.shell[shellType] === undefined;
+		const isFirstForShell = !firstShownTracker.shell.has(shellType);
 
 		if (isFirstForWindow || isFirstForShell) {
 			this.updateShown();

--- a/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalSuggestAddon.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalSuggestAddon.ts
@@ -342,7 +342,6 @@ export class SuggestAddon extends Disposable implements ITerminalAddon, ISuggest
 			lineContext
 		);
 		if (token.isCancellationRequested) {
-			// If cancelled, reset the tracker
 			this._completionRequestTimestamp = undefined;
 			return;
 		}

--- a/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalSuggestAddon.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalSuggestAddon.ts
@@ -885,13 +885,13 @@ export class SuggestAddon extends Disposable implements ITerminalAddon, ISuggest
 		if (!firstShownTracker) {
 			firstShownTracker = {
 				window: true,
-				shell: new Map([[shellType, true]])
+				shell: { [shellType]: true }
 			};
 			return { window: true, shell: true };
 		}
 
 		const isFirstForWindow = firstShownTracker.window;
-		const isFirstForShell = !firstShownTracker.shell.has(shellType);
+		const isFirstForShell = !firstShownTracker.shell[shellType];
 
 		if (isFirstForWindow || isFirstForShell) {
 			this.updateShown();

--- a/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalSuggestAddon.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalSuggestAddon.ts
@@ -219,6 +219,7 @@ export class SuggestAddon extends Disposable implements ITerminalAddon, ISuggest
 				this._model?.forceRefilterAll();
 			}
 		}));
+		this._register(this._extensionService.onWillStop(() => firstShownTracker = undefined));
 	}
 
 	activate(xterm: Terminal): void {

--- a/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalSuggestAddon.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalSuggestAddon.ts
@@ -885,29 +885,22 @@ export class SuggestAddon extends Disposable implements ITerminalAddon, ISuggest
 		if (!firstShownTracker) {
 			firstShownTracker = {
 				window: true,
-				shell: {
-					[shellType]: true
-				}
+				shell: { [shellType]: true }
 			};
 			return { window: true, shell: true };
 		}
 
-		try {
-			const isFirstForWindow = firstShownTracker.window;
-			const isFirstForShell = firstShownTracker.shell[shellType] === undefined;
+		const isFirstForWindow = firstShownTracker.window;
+		const isFirstForShell = firstShownTracker.shell[shellType] === undefined;
 
-			if (isFirstForWindow || isFirstForShell) {
-				this.updateShown();
-			}
-
-			return {
-				window: isFirstForWindow,
-				shell: isFirstForShell
-			};
-
-		} catch {
-			return { window: false, shell: false };
+		if (isFirstForWindow || isFirstForShell) {
+			this.updateShown();
 		}
+
+		return {
+			window: isFirstForWindow,
+			shell: isFirstForShell
+		};
 	}
 
 	updateShown(): void {

--- a/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalSuggestAddon.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalSuggestAddon.ts
@@ -706,7 +706,6 @@ export class SuggestAddon extends Disposable implements ITerminalAddon, ISuggest
 			if (this._suggestTelemetry && this.shellType) {
 				const firstShown = this.getFirstShown(this.shellType);
 				this.updateShown();
-				console.log(`Completions shown for ${this.shellType} after ${completionLatency}ms first shown for shell: ${firstShown.shell} first shown for window: ${firstShown.window}`);
 				this._suggestTelemetry.logCompletionLatency(this._sessionId, completionLatency, firstShown);
 			}
 			this._completionRequestTimestamp = undefined;

--- a/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalSuggestAddon.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalSuggestAddon.ts
@@ -46,7 +46,7 @@ export interface ISuggestController {
 	hideSuggestWidget(cancelAnyRequests: boolean, wasClosedByUser?: boolean): void;
 }
 
-let firstShownObj: { shell: Partial<Record<TerminalShellType, boolean>>; window: boolean } | undefined = undefined;
+let firstShownTracker: { shell: Partial<Record<TerminalShellType, boolean>>; window: boolean } | undefined = undefined;
 
 export class SuggestAddon extends Disposable implements ITerminalAddon, ISuggestController {
 	private _terminal?: Terminal;
@@ -882,9 +882,9 @@ export class SuggestAddon extends Disposable implements ITerminalAddon, ISuggest
 	}
 
 	getFirstShown(shellType: TerminalShellType): { window: boolean; shell: boolean } {
-		const raw = firstShownObj;
+		const raw = firstShownTracker;
 		if (!raw) {
-			firstShownObj = {
+			firstShownTracker = {
 				window: true,
 				shell: {
 					[shellType]: true
@@ -912,12 +912,12 @@ export class SuggestAddon extends Disposable implements ITerminalAddon, ISuggest
 	}
 
 	updateShown(): void {
-		if (!this.shellType || !firstShownObj) {
+		if (!this.shellType || !firstShownTracker) {
 			return;
 		}
 
-		firstShownObj.window = false;
-		firstShownObj.shell[this.shellType] = false;
+		firstShownTracker.window = false;
+		firstShownTracker.shell[this.shellType] = false;
 	}
 }
 

--- a/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalSuggestAddon.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalSuggestAddon.ts
@@ -217,6 +217,13 @@ export class SuggestAddon extends Disposable implements ITerminalAddon, ISuggest
 				this._model?.forceRefilterAll();
 			}
 		}));
+
+		const activeWindow = dom.getActiveWindow();
+		if (typeof activeWindow !== 'undefined' && typeof activeWindow.addEventListener === 'function') {
+			activeWindow.addEventListener('beforeunload', () => {
+				this.setHasShownCompletions(false);
+			});
+		}
 	}
 
 	activate(xterm: Terminal): void {

--- a/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalSuggestAddon.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalSuggestAddon.ts
@@ -35,7 +35,6 @@ import { IntervalTimer, TimeoutTimer } from '../../../../../base/common/async.js
 import { localize } from '../../../../../nls.js';
 import { TerminalSuggestTelemetry } from './terminalSuggestTelemetry.js';
 import { terminalSymbolAliasIcon, terminalSymbolArgumentIcon, terminalSymbolEnumMember, terminalSymbolFileIcon, terminalSymbolFlagIcon, terminalSymbolInlineSuggestionIcon, terminalSymbolMethodIcon, terminalSymbolOptionIcon, terminalSymbolFolderIcon, terminalSymbolSymbolicLinkFileIcon, terminalSymbolSymbolicLinkFolderIcon } from './terminalSymbolIcons.js';
-import { ILifecycleService } from '../../../../services/lifecycle/common/lifecycle.js';
 
 export interface ISuggestController {
 	isPasting: boolean;

--- a/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalSuggestAddon.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalSuggestAddon.ts
@@ -701,7 +701,6 @@ export class SuggestAddon extends Disposable implements ITerminalAddon, ISuggest
 			const completionLatency = Date.now() - this._completionRequestTimestamp;
 			if (this._suggestTelemetry && this.shellType) {
 				const firstShown = this.getFirstShown(this.shellType);
-				console.log('first shown ', firstShown.shell, firstShown.window);
 				this.updateShown();
 				this._suggestTelemetry.logCompletionLatency(this._sessionId, completionLatency, firstShown);
 			}

--- a/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalSuggestAddon.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalSuggestAddon.ts
@@ -701,7 +701,6 @@ export class SuggestAddon extends Disposable implements ITerminalAddon, ISuggest
 			if (this._suggestTelemetry && this.shellType) {
 				const firstShown = this.getFirstShown(this.shellType);
 				this.updateShown();
-				console.log(`Completions shown for ${this.shellType} after ${completionLatency}ms first shown for shell: ${firstShown.shell} first shown for window: ${firstShown.window}`);
 				this._suggestTelemetry.logCompletionLatency(this._sessionId, completionLatency, firstShown);
 			}
 			this._completionRequestTimestamp = undefined;

--- a/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalSuggestAddon.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalSuggestAddon.ts
@@ -47,7 +47,7 @@ export interface ISuggestController {
 }
 
 
-let firstShownTracker: { shell: Partial<Record<TerminalShellType, boolean>>; window: boolean } | undefined = undefined;
+let firstShownTracker: { shell: Set<TerminalShellType>; window: boolean } | undefined = undefined;
 export class SuggestAddon extends Disposable implements ITerminalAddon, ISuggestController {
 	private _terminal?: Terminal;
 
@@ -885,13 +885,13 @@ export class SuggestAddon extends Disposable implements ITerminalAddon, ISuggest
 		if (!firstShownTracker) {
 			firstShownTracker = {
 				window: true,
-				shell: { [shellType]: true }
+				shell: new Set([shellType])
 			};
 			return { window: true, shell: true };
 		}
 
 		const isFirstForWindow = firstShownTracker.window;
-		const isFirstForShell = firstShownTracker.shell[shellType] ?? true;
+		const isFirstForShell = !firstShownTracker.shell.has(shellType);
 
 		if (isFirstForWindow || isFirstForShell) {
 			this.updateShown();
@@ -909,7 +909,7 @@ export class SuggestAddon extends Disposable implements ITerminalAddon, ISuggest
 		}
 
 		firstShownTracker.window = false;
-		firstShownTracker.shell[this.shellType] = false;
+		firstShownTracker.shell.add(this.shellType);
 	}
 }
 

--- a/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalSuggestTelemetry.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalSuggestTelemetry.ts
@@ -48,6 +48,44 @@ export class TerminalSuggestTelemetry extends Disposable {
 		this._acceptedCompletions = this._acceptedCompletions || [];
 		this._acceptedCompletions.push({ label: typeof completion.label === 'string' ? completion.label : completion.label.label, kind: this._kindMap.get(completion.kind!), sessionId });
 	}
+
+	/**
+	 * Logs the latency (ms) from completion request to completions shown.
+	 * @param sessionId The terminal session ID
+	 * @param latency The measured latency in ms
+	 * @param first Whether this is the first ever showing of completions in the session
+	 */
+	logCompletionLatency(sessionId: string, latency: number, first: boolean): void {
+		this._telemetryService.publicLog2<{
+			sessionId: string;
+			latency: number;
+			first: boolean;
+		}, {
+			owner: 'meganrogge';
+			comment: 'Latency in ms from terminal completion request to completions shown.';
+			sessionId: {
+				classification: 'SystemMetaData';
+				purpose: 'FeatureInsight';
+				comment: 'The session ID of the terminal session.';
+			};
+			latency: {
+				classification: 'SystemMetaData';
+				purpose: 'PerformanceAndHealth';
+				comment: 'The latency in milliseconds.';
+			};
+			first: {
+				classification: 'SystemMetaData';
+				purpose: 'FeatureInsight';
+				comment: 'Whether this is the first ever showing of completions in the session.';
+			};
+		}>('terminal.suggest.completionLatency', {
+			sessionId,
+			latency,
+			first
+		});
+	}
+
+
 	private _sendTelemetryInfo(fromInterrupt?: boolean, exitCode?: number): void {
 		const commandLine = this._promptInputModel?.value;
 		for (const completion of this._acceptedCompletions || []) {

--- a/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalSuggestTelemetry.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalSuggestTelemetry.ts
@@ -53,13 +53,14 @@ export class TerminalSuggestTelemetry extends Disposable {
 	 * Logs the latency (ms) from completion request to completions shown.
 	 * @param sessionId The terminal session ID
 	 * @param latency The measured latency in ms
-	 * @param first Whether this is the first ever showing of completions in the session
+	 * @param firstShownFor Object indicating if completions have been shown for window/shell
 	 */
-	logCompletionLatency(sessionId: string, latency: number, first: boolean): void {
+	logCompletionLatency(sessionId: string, latency: number, firstShownFor: { window: boolean; shell: boolean }): void {
 		this._telemetryService.publicLog2<{
 			sessionId: string;
 			latency: number;
-			first: boolean;
+			firstWindow: boolean;
+			firstShell: boolean;
 		}, {
 			owner: 'meganrogge';
 			comment: 'Latency in ms from terminal completion request to completions shown.';
@@ -73,15 +74,21 @@ export class TerminalSuggestTelemetry extends Disposable {
 				purpose: 'PerformanceAndHealth';
 				comment: 'The latency in milliseconds.';
 			};
-			first: {
+			firstWindow: {
 				classification: 'SystemMetaData';
 				purpose: 'FeatureInsight';
-				comment: 'Whether this is the first ever showing of completions in the session.';
+				comment: 'Whether this is the first ever showing of completions in the window.';
+			};
+			firstShell: {
+				classification: 'SystemMetaData';
+				purpose: 'FeatureInsight';
+				comment: 'Whether this is the first ever showing of completions in the shell.';
 			};
 		}>('terminal.suggest.completionLatency', {
 			sessionId,
 			latency,
-			first
+			firstWindow: firstShownFor.window,
+			firstShell: firstShownFor.shell
 		});
 	}
 


### PR DESCRIPTION
part of #251994

<img width="547" alt="Screenshot 2025-06-20 at 4 09 34 PM" src="https://github.com/user-attachments/assets/de3e6caa-e559-4667-a3fb-7907b0bb2c9a" />
