### PR TITLE
[engineering] run `npm i` during postinstall in parallel

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -5,4 +5,4 @@ runtime="electron"
 build_from_source="true"
 legacy-peer-deps="true"
 timeout=180000
-npm_config_node_gyp="node build/npm/gyp/node_modules/node-gyp/bin/node-gyp.js"
+node_gyp="node build/npm/gyp/node_modules/node-gyp/bin/node-gyp.js"

--- a/build/npm/postinstall.js
+++ b/build/npm/postinstall.js
@@ -76,13 +76,13 @@ async function npmInstall(dir, opts) {
 	};
 
 	// Use our bundled node-gyp version
-	env['npm_config_node_gyp'] =
+	opts.env['npm_config_node_gyp'] =
 		process.platform === 'win32'
 			? path.join(__dirname, 'gyp', 'node_modules', '.bin', 'node-gyp.cmd')
 			: path.join(__dirname, 'gyp', 'node_modules', '.bin', 'node-gyp');
 
 	// Scripts may call `node-gyp rebuild` directly, so ensure our version is used.
-	env['PATH'] = path.join(__dirname, 'gyp', 'node_modules', '.bin') + path.delimiter + env['PATH'];
+	opts.env['PATH'] = path.join(__dirname, 'gyp', 'node_modules', '.bin') + path.delimiter + opts.env['PATH'];
 
 	const start = Date.now();
 	const command = process.env['npm_command'] || 'install';

--- a/build/npm/postinstall.js
+++ b/build/npm/postinstall.js
@@ -11,6 +11,32 @@ const { dirs } = require('./dirs');
 const npm = process.platform === 'win32' ? 'npm.cmd' : 'npm';
 const root = path.dirname(path.dirname(__dirname));
 
+function async_spawn(dir, command, args, opts) {
+	const child = cp.spawn(command, args, { ...opts, stdio: 'pipe' })
+
+	if (child.stdout) {
+		child.stdout.on('data', data => {
+			data.toString().split("\n").map(line => log(dir, line))
+		})
+	}
+
+	if (child.stderr) {
+		child.stderr.on('data', data => {
+			data.toString().split("\n").map(line => log(dir, line))
+		})
+	}
+
+	const promise = new Promise((resolve, reject) => {
+		child.on('error', reject)
+
+		child.on('close', code => {
+			resolve({ status: code })
+		})
+	})
+
+	return promise
+}
+
 function log(dir, message) {
 	if (process.stdout.isTTY) {
 		console.log(`\x1b[34m[${dir}]\x1b[0m`, message);
@@ -19,16 +45,19 @@ function log(dir, message) {
 	}
 }
 
-function run(command, args, opts) {
-	log(opts.cwd || '.', '$ ' + command + ' ' + args.join(' '));
+async function run(command, args, { dir, ...opts }) {
+	dir = dir || opts.cwd || '.';
+	log(dir, '$ ' + command + ' ' + args.join(' '));
 
-	const result = cp.spawnSync(command, args, opts);
+	const result = process.env.NPM_POSTINSTALL_PARALLEL === 'false'
+		? cp.spawnSync(command, args, opts)
+		: await async_spawn(dir, command, args, opts);
 
 	if (result.error) {
-		console.error(`ERR Failed to spawn process: ${result.error}`);
+		console.error(`ERR [${dir} ${command}] Failed to spawn process: ${result.error}`);
 		process.exit(1);
 	} else if (result.status !== 0) {
-		console.error(`ERR Process exited with code: ${result.status}`);
+		console.error(`ERR [${dir} ${command}] Process exited with code: ${result.status}`);
 		process.exit(result.status);
 	}
 }
@@ -37,7 +66,7 @@ function run(command, args, opts) {
  * @param {string} dir
  * @param {*} [opts]
  */
-function npmInstall(dir, opts) {
+async function npmInstall(dir, opts) {
 	opts = {
 		env: { ...process.env },
 		...(opts ?? {}),
@@ -46,23 +75,25 @@ function npmInstall(dir, opts) {
 		shell: true
 	};
 
+	const start = Date.now();
 	const command = process.env['npm_command'] || 'install';
 
 	if (process.env['VSCODE_REMOTE_DEPENDENCIES_CONTAINER_NAME'] && /^(.build\/distro\/npm\/)?remote$/.test(dir)) {
 		const userinfo = os.userInfo();
 		log(dir, `Installing dependencies inside container ${process.env['VSCODE_REMOTE_DEPENDENCIES_CONTAINER_NAME']}...`);
 
+		opts.dir = dir;
 		opts.cwd = root;
 		if (process.env['npm_config_arch'] === 'arm64') {
-			run('sudo', ['docker', 'run', '--rm', '--privileged', 'multiarch/qemu-user-static', '--reset', '-p', 'yes'], opts);
+			await run('sudo', ['docker', 'run', '--rm', '--privileged', 'multiarch/qemu-user-static', '--reset', '-p', 'yes'], opts);
 		}
-		run('sudo', ['docker', 'run', '-e', 'GITHUB_TOKEN', '-v', `${process.env['VSCODE_HOST_MOUNT']}:/root/vscode`, '-v', `${process.env['VSCODE_HOST_MOUNT']}/.build/.netrc:/root/.netrc`, '-w', path.resolve('/root/vscode', dir), process.env['VSCODE_REMOTE_DEPENDENCIES_CONTAINER_NAME'], 'sh', '-c', `\"chown -R root:root ${path.resolve('/root/vscode', dir)} && npm i -g node-gyp-build && npm ci\"`], opts);
-		run('sudo', ['chown', '-R', `${userinfo.uid}:${userinfo.gid}`, `${path.resolve(root, dir)}`], opts);
+		await run('sudo', ['docker', 'run', '-e', 'GITHUB_TOKEN', '-v', `${process.env['VSCODE_HOST_MOUNT']}:/root/vscode`, '-v', `${process.env['VSCODE_HOST_MOUNT']}/.build/.netrc:/root/.netrc`, '-w', path.resolve('/root/vscode', dir), process.env['VSCODE_REMOTE_DEPENDENCIES_CONTAINER_NAME'], 'sh', '-c', `\"chown -R root:root ${path.resolve('/root/vscode', dir)} && npm i -g node-gyp-build && npm ci\"`], opts);
+		await run('sudo', ['chown', '-R', `${userinfo.uid}:${userinfo.gid}`, `${path.resolve(root, dir)}`], opts);
 	} else {
-		log(dir, 'Installing dependencies...');
-		run(npm, command.split(' '), opts);
+		await run(npm, command.split(' '), opts);
 	}
 	removeParcelWatcherPrebuild(dir);
+	log(dir, "Done in " + (Date.now() - start) + "ms");
 }
 
 function setNpmrcConfig(dir, env) {

--- a/build/npm/postinstall.js
+++ b/build/npm/postinstall.js
@@ -82,7 +82,8 @@ async function npmInstall(dir, opts) {
 			: path.join(__dirname, 'gyp', 'node_modules', '.bin', 'node-gyp');
 
 	// Scripts may call `node-gyp rebuild` directly, so ensure our version is used.
-	opts.env['PATH'] = path.join(__dirname, 'gyp', 'node_modules', '.bin') + path.delimiter + opts.env['PATH'];
+	const pathVar = process.platform === 'win32' ? 'Path' : 'PATH';
+	opts.env[pathVar] = path.join(__dirname, 'gyp', 'node_modules', '.bin') + path.delimiter + opts.env[pathVar];
 
 	const start = Date.now();
 	const command = process.env['npm_command'] || 'install';

--- a/build/npm/postinstall.js
+++ b/build/npm/postinstall.js
@@ -114,6 +114,9 @@ function setNpmrcConfig(dir, env) {
 			? path.join(__dirname, 'gyp', 'node_modules', '.bin', 'node-gyp.cmd')
 			: path.join(__dirname, 'gyp', 'node_modules', '.bin', 'node-gyp');
 
+	// Scripts may call `node-gyp rebuild` directly, so ensure our version is used.
+	env['PATH'] = path.join(__dirname, 'gyp', 'node_modules', '.bin') + path.delimiter + env['PATH'];
+
 	// Force node-gyp to use process.config on macOS
 	// which defines clang variable as expected. Otherwise we
 	// run into compilation errors due to incorrect compiler

--- a/build/npm/postinstall.js
+++ b/build/npm/postinstall.js
@@ -75,6 +75,15 @@ async function npmInstall(dir, opts) {
 		shell: true
 	};
 
+	// Use our bundled node-gyp version
+	env['npm_config_node_gyp'] =
+		process.platform === 'win32'
+			? path.join(__dirname, 'gyp', 'node_modules', '.bin', 'node-gyp.cmd')
+			: path.join(__dirname, 'gyp', 'node_modules', '.bin', 'node-gyp');
+
+	// Scripts may call `node-gyp rebuild` directly, so ensure our version is used.
+	env['PATH'] = path.join(__dirname, 'gyp', 'node_modules', '.bin') + path.delimiter + env['PATH'];
+
 	const start = Date.now();
 	const command = process.env['npm_command'] || 'install';
 
@@ -107,15 +116,6 @@ function setNpmrcConfig(dir, env) {
 			env[`npm_config_${key}`] = value.replace(/^"(.*)"$/, '$1');
 		}
 	}
-
-	// Use our bundled node-gyp version
-	env['npm_config_node_gyp'] =
-		process.platform === 'win32'
-			? path.join(__dirname, 'gyp', 'node_modules', '.bin', 'node-gyp.cmd')
-			: path.join(__dirname, 'gyp', 'node_modules', '.bin', 'node-gyp');
-
-	// Scripts may call `node-gyp rebuild` directly, so ensure our version is used.
-	env['PATH'] = path.join(__dirname, 'gyp', 'node_modules', '.bin') + path.delimiter + env['PATH'];
 
 	// Force node-gyp to use process.config on macOS
 	// which defines clang variable as expected. Otherwise we

--- a/build/npm/preinstall.js
+++ b/build/npm/preinstall.js
@@ -30,8 +30,11 @@ if (process.platform === 'win32') {
 		console.error('\x1b[1;31m*** Invalid C/C++ Compiler Toolchain. Please check https://github.com/microsoft/vscode/wiki/How-to-Contribute#prerequisites.\x1b[0;0m');
 		throw new Error();
 	}
-	installHeaders();
 }
+
+// Install headers on all platforms, to avoid parallel `npm i` during postinstall.js causing corruption.
+// https://github.com/nodejs/node-gyp/pull/3170
+installHeaders();
 
 if (process.arch !== os.arch()) {
 	console.error(`\x1b[1;31m*** ARCHITECTURE MISMATCH: The node.js process is ${process.arch}, but your OS architecture is ${os.arch()}. ***\x1b[0;0m`);
@@ -76,7 +79,8 @@ function hasSupportedVisualStudioVersion() {
 }
 
 function installHeaders() {
-	cp.execSync(`npm.cmd ${process.env['npm_command'] || 'ci'}`, {
+	const exeSuffix = process.platform === 'win32' ? '.cmd' : '';
+	cp.execSync(`npm${exeSuffix} ${process.env['npm_command'] || 'ci'}`, {
 		env: process.env,
 		cwd: path.join(__dirname, 'gyp'),
 		stdio: 'inherit'
@@ -85,7 +89,7 @@ function installHeaders() {
 	// The node gyp package got installed using the above npm command using the gyp/package.json
 	// file checked into our repository. So from that point it is save to construct the path
 	// to that executable
-	const node_gyp = path.join(__dirname, 'gyp', 'node_modules', '.bin', 'node-gyp.cmd');
+	const node_gyp = path.join(__dirname, 'gyp', 'node_modules', '.bin', 'node-gyp' + exeSuffix);
 	const result = cp.execFileSync(node_gyp, ['list'], { encoding: 'utf8', shell: true });
 	const versions = new Set(result.split(/\n/g).filter(line => !line.startsWith('gyp info')).map(value => value));
 


### PR DESCRIPTION
this speeds up `npm i` considerably on all platforms

i have been using this for a few months so all the bugs should be worked out

one major issue was running node-gyp in parallel can cause random corruption https://github.com/nodejs/node-gyp/issues/3165

cc @deepak1556 #250554 https://github.com/microsoft/vscode/pull/250981