### PR TITLE
Inform screen reader users when there's a rendering error in chat, make keyboard navigable

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatAccessibilityService.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatAccessibilityService.ts
@@ -42,7 +42,7 @@ export class ChatAccessibilityService extends Disposable implements IChatAccessi
 		const isPanelChat = typeof response !== 'string';
 		const responseContent = typeof response === 'string' ? response : response?.response.toString();
 		this._accessibilitySignalService.playSignal(AccessibilitySignal.chatResponseReceived, { allowManyInParallel: true });
-		if (!response || !responseContent) {
+		if (!response) {
 			return;
 		}
 		const errorDetails = isPanelChat && response.errorDetails ? ` ${response.errorDetails.message}` : '';

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/chatErrorConfirmationPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/chatErrorConfirmationPart.ts
@@ -9,6 +9,7 @@ import { Emitter } from '../../../../../base/common/event.js';
 import { IMarkdownString } from '../../../../../base/common/htmlContent.js';
 import { Disposable, IDisposable } from '../../../../../base/common/lifecycle.js';
 import { MarkdownRenderer } from '../../../../../editor/browser/widget/markdownRenderer/browser/markdownRenderer.js';
+import { IAccessibilityService } from '../../../../../platform/accessibility/common/accessibility.js';
 import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
 import { defaultButtonStyles } from '../../../../../platform/theme/browser/defaultStyles.js';
 import { ChatErrorLevel, IChatResponseErrorDetailsConfirmationButton, IChatSendRequestOptions, IChatService } from '../../common/chatService.js';
@@ -35,6 +36,7 @@ export class ChatErrorConfirmationContentPart extends Disposable implements ICha
 		@IInstantiationService instantiationService: IInstantiationService,
 		@IChatWidgetService chatWidgetService: IChatWidgetService,
 		@IChatService chatService: IChatService,
+		@IAccessibilityService private readonly _accessibilityService: IAccessibilityService
 	) {
 		super();
 
@@ -42,7 +44,7 @@ export class ChatErrorConfirmationContentPart extends Disposable implements ICha
 		assertIsResponseVM(element);
 
 		this.domNode = $('.chat-error-confirmation');
-		this.domNode.append(this._register(new ChatErrorWidget(kind, content, renderer)).domNode);
+		this.domNode.append(this._register(new ChatErrorWidget(kind, content, renderer, this._accessibilityService)).domNode);
 
 		const buttonOptions: IButtonOptions = { ...defaultButtonStyles };
 

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/chatErrorConfirmationPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/chatErrorConfirmationPart.ts
@@ -9,7 +9,6 @@ import { Emitter } from '../../../../../base/common/event.js';
 import { IMarkdownString } from '../../../../../base/common/htmlContent.js';
 import { Disposable, IDisposable } from '../../../../../base/common/lifecycle.js';
 import { MarkdownRenderer } from '../../../../../editor/browser/widget/markdownRenderer/browser/markdownRenderer.js';
-import { IAccessibilityService } from '../../../../../platform/accessibility/common/accessibility.js';
 import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
 import { defaultButtonStyles } from '../../../../../platform/theme/browser/defaultStyles.js';
 import { ChatErrorLevel, IChatResponseErrorDetailsConfirmationButton, IChatSendRequestOptions, IChatService } from '../../common/chatService.js';
@@ -35,8 +34,7 @@ export class ChatErrorConfirmationContentPart extends Disposable implements ICha
 		context: IChatContentPartRenderContext,
 		@IInstantiationService instantiationService: IInstantiationService,
 		@IChatWidgetService chatWidgetService: IChatWidgetService,
-		@IChatService chatService: IChatService,
-		@IAccessibilityService private readonly _accessibilityService: IAccessibilityService
+		@IChatService chatService: IChatService
 	) {
 		super();
 
@@ -44,7 +42,7 @@ export class ChatErrorConfirmationContentPart extends Disposable implements ICha
 		assertIsResponseVM(element);
 
 		this.domNode = $('.chat-error-confirmation');
-		this.domNode.append(this._register(new ChatErrorWidget(kind, content, renderer, this._accessibilityService)).domNode);
+		this.domNode.append(this._register(new ChatErrorWidget(kind, content, renderer)).domNode);
 
 		const buttonOptions: IButtonOptions = { ...defaultButtonStyles };
 

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/chatErrorConfirmationPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/chatErrorConfirmationPart.ts
@@ -34,7 +34,7 @@ export class ChatErrorConfirmationContentPart extends Disposable implements ICha
 		context: IChatContentPartRenderContext,
 		@IInstantiationService instantiationService: IInstantiationService,
 		@IChatWidgetService chatWidgetService: IChatWidgetService,
-		@IChatService chatService: IChatService
+		@IChatService chatService: IChatService,
 	) {
 		super();
 

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/chatErrorContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/chatErrorContentPart.ts
@@ -12,7 +12,6 @@ import { MarkdownRenderer } from '../../../../../editor/browser/widget/markdownR
 import { ChatErrorLevel } from '../../common/chatService.js';
 import { IChatRendererContent } from '../../common/chatViewModel.js';
 import { IChatContentPart } from './chatContentParts.js';
-import { IAccessibilityService } from '../../../../../platform/accessibility/common/accessibility.js';
 
 const $ = dom.$;
 
@@ -24,11 +23,10 @@ export class ChatErrorContentPart extends Disposable implements IChatContentPart
 		content: IMarkdownString,
 		private readonly errorDetails: IChatRendererContent,
 		renderer: MarkdownRenderer,
-		@IAccessibilityService private readonly _accessibilityService: IAccessibilityService
 	) {
 		super();
 
-		this.domNode = this._register(new ChatErrorWidget(kind, content, renderer, this._accessibilityService)).domNode;
+		this.domNode = this._register(new ChatErrorWidget(kind, content, renderer)).domNode;
 	}
 
 	hasSameContent(other: IChatRendererContent): boolean {
@@ -42,14 +40,12 @@ export class ChatErrorWidget extends Disposable {
 	constructor(
 		kind: ChatErrorLevel,
 		content: IMarkdownString,
-		renderer: MarkdownRenderer,
-		@IAccessibilityService private readonly _accessibilityService: IAccessibilityService
+		renderer: MarkdownRenderer
 	) {
 		super();
 
 		this.domNode = $('.chat-notification-widget');
 		this.domNode.tabIndex = 0;
-		this._accessibilityService.alert(`Chat error: ${content.value}`);
 		let icon;
 		let iconClass;
 		switch (kind) {

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/chatErrorContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/chatErrorContentPart.ts
@@ -40,7 +40,7 @@ export class ChatErrorWidget extends Disposable {
 	constructor(
 		kind: ChatErrorLevel,
 		content: IMarkdownString,
-		renderer: MarkdownRenderer
+		renderer: MarkdownRenderer,
 	) {
 		super();
 

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/chatErrorContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/chatErrorContentPart.ts
@@ -12,6 +12,7 @@ import { MarkdownRenderer } from '../../../../../editor/browser/widget/markdownR
 import { ChatErrorLevel } from '../../common/chatService.js';
 import { IChatRendererContent } from '../../common/chatViewModel.js';
 import { IChatContentPart } from './chatContentParts.js';
+import { IAccessibilityService } from '../../../../../platform/accessibility/common/accessibility.js';
 
 const $ = dom.$;
 
@@ -23,10 +24,11 @@ export class ChatErrorContentPart extends Disposable implements IChatContentPart
 		content: IMarkdownString,
 		private readonly errorDetails: IChatRendererContent,
 		renderer: MarkdownRenderer,
+		@IAccessibilityService private readonly _accessibilityService: IAccessibilityService
 	) {
 		super();
 
-		this.domNode = this._register(new ChatErrorWidget(kind, content, renderer)).domNode;
+		this.domNode = this._register(new ChatErrorWidget(kind, content, renderer, this._accessibilityService)).domNode;
 	}
 
 	hasSameContent(other: IChatRendererContent): boolean {
@@ -41,10 +43,13 @@ export class ChatErrorWidget extends Disposable {
 		kind: ChatErrorLevel,
 		content: IMarkdownString,
 		renderer: MarkdownRenderer,
+		@IAccessibilityService private readonly _accessibilityService: IAccessibilityService
 	) {
 		super();
 
 		this.domNode = $('.chat-notification-widget');
+		this.domNode.tabIndex = 0;
+		this._accessibilityService.alert(`Chat error: ${content.value}`);
 		let icon;
 		let iconClass;
 		switch (kind) {

--- a/src/vs/workbench/contrib/chat/browser/chatListRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatListRenderer.ts
@@ -81,6 +81,7 @@ import { ChatCodeBlockContentProvider, CodeBlockPart } from './codeBlockPart.js'
 import { canceledName } from '../../../../base/common/errors.js';
 import { IChatRequestVariableEntry } from '../common/chatVariableEntries.js';
 import { ChatElicitationContentPart } from './chatContentParts/chatElicitationContentPart.js';
+import { alert } from '../../../../base/browser/ui/aria/aria.js';
 
 const $ = dom.$;
 
@@ -964,6 +965,7 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 
 			return this.renderNoContent(other => content.kind === other.kind);
 		} catch (err) {
+			alert(`Chat error: ${toErrorMessage(err, false)}`);
 			this.logService.error('ChatListItemRenderer#renderChatContentPart: error rendering content', toErrorMessage(err, true));
 			const errorPart = this.instantiationService.createInstance(ChatErrorContentPart, ChatErrorLevel.Error, new MarkdownString(localize('renderFailMsg', "Failed to render content") + `: ${toErrorMessage(err, false)}`), content, this.renderer);
 			return {


### PR DESCRIPTION
Before, screen reader users were not given an indication that there were rendering errors in the chat response. They were also not keyboard focusable. 

We now alert the error so screen reader users are aware of it ASAP and make error messages keyboard focusable so they can be reviewed.

fixes #252191