### PR TITLE
Use correct contrast color for partial selection, clear state on all nav

### DIFF
--- a/src/vs/editor/contrib/suggest/browser/suggestWidget.ts
+++ b/src/vs/editor/contrib/suggest/browser/suggestWidget.ts
@@ -43,7 +43,7 @@ import { isWindows } from '../../../../base/common/platform.js';
  */
 registerColor('editorSuggestWidget.background', editorWidgetBackground, nls.localize('editorSuggestWidgetBackground', 'Background color of the suggest widget.'));
 registerColor('editorSuggestWidget.border', editorWidgetBorder, nls.localize('editorSuggestWidgetBorder', 'Border color of the suggest widget.'));
-const editorSuggestWidgetForeground = registerColor('editorSuggestWidget.foreground', editorForeground, nls.localize('editorSuggestWidgetForeground', 'Foreground color of the suggest widget.'));
+export const editorSuggestWidgetForeground = registerColor('editorSuggestWidget.foreground', editorForeground, nls.localize('editorSuggestWidgetForeground', 'Foreground color of the suggest widget.'));
 registerColor('editorSuggestWidget.selectedForeground', quickInputListFocusForeground, nls.localize('editorSuggestWidgetSelectedForeground', 'Foreground color of the selected entry in the suggest widget.'));
 registerColor('editorSuggestWidget.selectedIconForeground', quickInputListFocusIconForeground, nls.localize('editorSuggestWidgetSelectedIconForeground', 'Icon foreground color of the selected entry in the suggest widget.'));
 export const editorSuggestWidgetSelectedBackground = registerColor('editorSuggestWidget.selectedBackground', quickInputListFocusBackground, nls.localize('editorSuggestWidgetSelectedBackground', 'Background color of the selected entry in the suggest widget.'));

--- a/src/vs/workbench/services/suggest/browser/media/suggest.css
+++ b/src/vs/workbench/services/suggest/browser/media/suggest.css
@@ -157,7 +157,7 @@
 	color: var(--vscode-editorSuggestWidget-highlightForeground);
 }
 
-.workbench-suggest-widget .monaco-list .monaco-list-row.focused > .contents > .main .monaco-highlighted-label .highlight {
+.workbench-suggest-widget:not(.partial-selection) .monaco-list .monaco-list-row.focused > .contents > .main .monaco-highlighted-label .highlight {
 	color: var(--vscode-editorSuggestWidget-focusHighlightForeground);
 }
 


### PR DESCRIPTION
Fixes #252200
Fixes #252208

---

Light+

![image](https://github.com/user-attachments/assets/a4ce5c89-f157-4fc9-a7f5-55150ea73524)
![image](https://github.com/user-attachments/assets/6c5d2aa0-8fa4-4dca-a6aa-e8e339ad20d2)

Dark Modern

![image](https://github.com/user-attachments/assets/90ef2fb6-87f1-448c-b3c8-745ee876d473)
![image](https://github.com/user-attachments/assets/cdc29969-982d-400f-88a7-671e4b26d652)
