### PR TITLE
improve git bash absolute path support

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalCompletionService.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalCompletionService.ts
@@ -269,9 +269,7 @@ export class TerminalCompletionService extends Disposable implements ITerminalCo
 		let lastWordFolderResource: URI | string | undefined;
 		const lastWordFolderHasDotPrefix = !!lastWordFolder.match(/^\.\.?[\\\/]/);
 		const lastWordFolderHasTildePrefix = !!lastWordFolder.match(/^~[\\\/]?/);
-		const isAbsolutePath = useWindowsStylePath
-			? /^[a-zA-Z]:[\\\/]/.test(lastWord)
-			: lastWord.startsWith(resourceRequestConfig.pathSeparator);
+		const isAbsolutePath = getIsAbsolutePath(shellType, resourceRequestConfig.pathSeparator, lastWordFolder, useWindowsStylePath);
 		const type = lastWordFolderHasTildePrefix ? 'tilde' : isAbsolutePath ? 'absolute' : 'relative';
 		switch (type) {
 			case 'tilde': {
@@ -559,4 +557,11 @@ function addPathRelativePrefix(text: string, resourceRequestConfig: Pick<Termina
 		return `.${resourceRequestConfig.pathSeparator}${text}`;
 	}
 	return text;
+}
+
+function getIsAbsolutePath(shellType: TerminalShellType | undefined, pathSeparator: string, lastWord: string, useWindowsStylePath: boolean): boolean {
+	if (shellType === WindowsShellType.GitBash) {
+		return lastWord.startsWith(pathSeparator) || /^[a-zA-Z]:\//.test(lastWord);
+	}
+	return useWindowsStylePath ? /^[a-zA-Z]:[\\\/]/.test(lastWord) : lastWord.startsWith(pathSeparator);
 }

--- a/src/vs/workbench/contrib/terminalContrib/suggest/test/browser/terminalCompletionService.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/test/browser/terminalCompletionService.test.ts
@@ -635,6 +635,30 @@ suite('TerminalCompletionService', () => {
 				assert.strictEqual(windowsToGitBashPath('D:\\bar'), '/d/bar');
 				assert.strictEqual(windowsToGitBashPath('E:\\some\\path'), '/e/some/path');
 			});
+
+			test('resolveResources with c:/ style absolute path for Git Bash', async () => {
+				const resourceRequestConfig: TerminalResourceRequestConfig = {
+					cwd: URI.file('C:\\Users\\foo'),
+					foldersRequested: true,
+					filesRequested: true,
+					pathSeparator: '/'
+				};
+				validResources = [
+					URI.file('C:\\Users\\foo'),
+					URI.file('C:\\Users\\foo\\bar'),
+					URI.file('C:\\Users\\foo\\baz.txt')
+				];
+				childResources = [
+					{ resource: URI.file('C:\\Users\\foo\\bar'), isDirectory: true, isFile: false },
+					{ resource: URI.file('C:\\Users\\foo\\baz.txt'), isFile: true }
+				];
+				const result = await terminalCompletionService.resolveResources(resourceRequestConfig, 'C:/Users/foo/', 13, provider, capabilities, WindowsShellType.GitBash);
+				assertCompletions(result, [
+					{ label: 'C:/Users/foo/', detail: 'C:\\Users\\foo\\' },
+					{ label: 'C:/Users/foo/bar/', detail: 'C:\\Users\\foo\\bar\\' },
+					{ label: 'C:/Users/foo/baz.txt', detail: 'C:\\Users\\foo\\baz.txt', kind: TerminalCompletionItemKind.File },
+				], { replacementIndex: 0, replacementLength: 13 }, '/');
+			});
 			test('resolveResources with cwd as Windows path (relative)', async () => {
 				const resourceRequestConfig: TerminalResourceRequestConfig = {
 					cwd: URI.file('C:\\Users\\foo'),


### PR DESCRIPTION
fix #251993

Also added a test

Before:

![image](https://github.com/user-attachments/assets/9f0fe8a2-66bc-4dcc-bfea-e3ad0127a416)

After:

![{72DD8321-0FB2-4954-B655-ECA3760233C9}](https://github.com/user-attachments/assets/5145201c-bea3-4568-aa3d-06431719cd13)

