### PR TITLE
Updating edit context only on line change and selection change and using previous edit context selection to determine type input

### DIFF
--- a/src/vs/editor/browser/controller/editContext/native/nativeEditContext.ts
+++ b/src/vs/editor/browser/controller/editContext/native/nativeEditContext.ts
@@ -283,7 +283,6 @@ export class NativeEditContext extends AbstractEditContext {
 	}
 
 	private _updateEditContextOnLineChange(fromLineNumber: number, toLineNumber: number): void {
-		console.log('_updateEditContextOnLineChange', fromLineNumber, toLineNumber);
 		if (this._editContextPrimarySelection.endLineNumber < fromLineNumber || this._editContextPrimarySelection.startLineNumber > toLineNumber) {
 			return;
 		}
@@ -363,7 +362,6 @@ export class NativeEditContext extends AbstractEditContext {
 		if (!editContextState) {
 			return;
 		}
-		console.log('_updateEditContext', editContextState);
 		this._editContext.updateText(0, Number.MAX_SAFE_INTEGER, editContextState.text ?? ' ');
 		this._editContext.updateSelection(editContextState.selectionStartOffset, editContextState.selectionEndOffset);
 		this._editContextPrimarySelection = editContextState.editContextPrimarySelection;
@@ -372,9 +370,6 @@ export class NativeEditContext extends AbstractEditContext {
 
 	private _emitTypeEvent(viewController: ViewController, e: ITextUpdateEvent): void {
 		if (!this._editContext) {
-			return;
-		}
-		if (!this._editContextPrimarySelection.equalsSelection(this._primarySelection)) {
 			return;
 		}
 		const selectionEndOffset = this._previousEditContextSelection.endExclusive;
@@ -407,7 +402,6 @@ export class NativeEditContext extends AbstractEditContext {
 			replaceNextCharCnt,
 			positionDelta
 		};
-		console.log('typeInput : ', typeInput);
 		this._onType(viewController, typeInput);
 	}
 

--- a/src/vs/editor/browser/controller/editContext/native/nativeEditContext.ts
+++ b/src/vs/editor/browser/controller/editContext/native/nativeEditContext.ts
@@ -32,6 +32,7 @@ import { NativeEditContextRegistry } from './nativeEditContextRegistry.js';
 import { IEditorAriaOptions } from '../../../editorBrowser.js';
 import { isHighSurrogate, isLowSurrogate } from '../../../../../base/common/strings.js';
 import { IME } from '../../../../../base/common/ime.js';
+import { OffsetRange } from '../../../../common/core/ranges/offsetRange.js';
 
 // Corresponds to classes in nativeEditContext.css
 enum CompositionClassName {
@@ -55,6 +56,7 @@ export class NativeEditContext extends AbstractEditContext {
 	private readonly _imeTextArea: FastDomNode<HTMLTextAreaElement>;
 	private readonly _editContext: EditContext;
 	private readonly _screenReaderSupport: ScreenReaderSupport;
+	private _previousEditContextSelection: OffsetRange = new OffsetRange(0, 0);
 	private _editContextPrimarySelection: Selection = new Selection(1, 1, 1, 1);
 
 	// Overflow guard container
@@ -236,7 +238,6 @@ export class NativeEditContext extends AbstractEditContext {
 
 	public prepareRender(ctx: RenderingContext): void {
 		this._screenReaderSupport.prepareRender(ctx);
-		this._updateEditContext();
 		this._updateSelectionAndControlBounds(ctx);
 	}
 
@@ -267,15 +268,26 @@ export class NativeEditContext extends AbstractEditContext {
 	}
 
 	public override onLinesChanged(e: ViewLinesChangedEvent): boolean {
+		this._updateEditContextOnLineChange(e.fromLineNumber, e.fromLineNumber + e.count - 1);
 		return true;
 	}
 
 	public override onLinesDeleted(e: ViewLinesDeletedEvent): boolean {
+		this._updateEditContextOnLineChange(e.fromLineNumber, e.toLineNumber);
 		return true;
 	}
 
 	public override onLinesInserted(e: ViewLinesInsertedEvent): boolean {
+		this._updateEditContextOnLineChange(e.fromLineNumber, e.toLineNumber);
 		return true;
+	}
+
+	private _updateEditContextOnLineChange(fromLineNumber: number, toLineNumber: number): void {
+		console.log('_updateEditContextOnLineChange', fromLineNumber, toLineNumber);
+		if (this._editContextPrimarySelection.endLineNumber < fromLineNumber || this._editContextPrimarySelection.startLineNumber > toLineNumber) {
+			return;
+		}
+		this._updateEditContext();
 	}
 
 	public override onScrollChanged(e: ViewScrollChangedEvent): boolean {
@@ -351,9 +363,11 @@ export class NativeEditContext extends AbstractEditContext {
 		if (!editContextState) {
 			return;
 		}
+		console.log('_updateEditContext', editContextState);
 		this._editContext.updateText(0, Number.MAX_SAFE_INTEGER, editContextState.text ?? ' ');
 		this._editContext.updateSelection(editContextState.selectionStartOffset, editContextState.selectionEndOffset);
 		this._editContextPrimarySelection = editContextState.editContextPrimarySelection;
+		this._previousEditContextSelection = new OffsetRange(editContextState.selectionStartOffset, editContextState.selectionEndOffset);
 	}
 
 	private _emitTypeEvent(viewController: ViewController, e: ITextUpdateEvent): void {
@@ -363,13 +377,9 @@ export class NativeEditContext extends AbstractEditContext {
 		if (!this._editContextPrimarySelection.equalsSelection(this._primarySelection)) {
 			return;
 		}
-		const model = this._context.viewModel.model;
-		const startPositionOfEditContext = this._editContextStartPosition();
-		const offsetOfStartOfText = model.getOffsetAt(startPositionOfEditContext);
-		const offsetOfSelectionEnd = model.getOffsetAt(this._primarySelection.getEndPosition());
-		const offsetOfSelectionStart = model.getOffsetAt(this._primarySelection.getStartPosition());
-		const selectionEndOffset = offsetOfSelectionEnd - offsetOfStartOfText;
-		const selectionStartOffset = offsetOfSelectionStart - offsetOfStartOfText;
+		const selectionEndOffset = this._previousEditContextSelection.endExclusive;
+		const selectionStartOffset = this._previousEditContextSelection.start;
+		this._previousEditContextSelection = new OffsetRange(e.selectionStart, e.selectionEnd);
 
 		let replaceNextCharCnt = 0;
 		let replacePrevCharCnt = 0;
@@ -397,12 +407,8 @@ export class NativeEditContext extends AbstractEditContext {
 			replaceNextCharCnt,
 			positionDelta
 		};
+		console.log('typeInput : ', typeInput);
 		this._onType(viewController, typeInput);
-
-		// It could be that the typed letter does not produce a change in the editor text,
-		// for example if an extension registers a custom typing command, and the typing operation does something else like scrolling
-		// Need to update the edit context to reflect this
-		this._updateEditContext();
 	}
 
 	private _onType(viewController: ViewController, typeInput: ITypeData): void {


### PR DESCRIPTION
fixes https://github.com/microsoft/vscode/issues/252129
fixes https://github.com/microsoft/vscode/issues/251608
fixes https://github.com/microsoft/vscode/issues/251809