### PR TITLE
feat: always show the sparkle for enrolled users

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/preferencesSearch.ts
+++ b/src/vs/workbench/contrib/preferences/browser/preferencesSearch.ts
@@ -72,7 +72,11 @@ export class PreferencesSearchService extends Disposable implements IPreferences
 		return this._remoteSearchProvider;
 	}
 
-	getAiSearchProvider(filter: string): IAiSearchProvider {
+	getAiSearchProvider(filter: string): IAiSearchProvider | undefined {
+		if (!this.remoteSearchAllowed) {
+			return undefined;
+		}
+
 		this._aiSearchProvider ??= this.instantiationService.createInstance(AiSearchProvider);
 		this._aiSearchProvider.setFilter(filter);
 		return this._aiSearchProvider;

--- a/src/vs/workbench/contrib/preferences/common/preferences.ts
+++ b/src/vs/workbench/contrib/preferences/common/preferences.ts
@@ -40,7 +40,7 @@ export interface IPreferencesSearchService {
 
 	getLocalSearchProvider(filter: string): ISearchProvider;
 	getRemoteSearchProvider(filter: string, newExtensionsOnly?: boolean): ISearchProvider | undefined;
-	getAiSearchProvider(filter: string): IAiSearchProvider;
+	getAiSearchProvider(filter: string): IAiSearchProvider | undefined;
 }
 
 export interface ISearchProvider {
@@ -112,6 +112,7 @@ export const EXTENSION_FETCH_TIMEOUT_MS = 1000;
 
 export enum WorkbenchSettingsEditorSettings {
 	ShowAISearchToggle = 'workbench.settings.showAISearchToggle',
+	EnableNaturalLanguageSearch = 'workbench.settings.enableNaturalLanguageSearch',
 }
 
 export type ExtensionToggleData = {


### PR DESCRIPTION
This PR also restricts calling into the LLM for users who have workbench.settings.enableNaturalLanguageSearch set to false.
