### PR TITLE
Tool picker doesn't show custom mode selections

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/actions/chatToolActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatToolActions.ts
@@ -18,6 +18,7 @@ import { isResponseVM } from '../../common/chatViewModel.js';
 import { ChatMode } from '../../common/constants.js';
 import { IToolData, ToolSet } from '../../common/languageModelToolsService.js';
 import { IChatWidget, IChatWidgetService } from '../chat.js';
+import { ToolsScope } from '../chatSelectedTools.js';
 import { CHAT_CATEGORY } from './chatActions.js';
 import { showToolsPicker } from './chatToolPicker.js';
 
@@ -110,7 +111,25 @@ class ConfigureToolsAction extends Action2 {
 			return;
 		}
 
-		await instaService.invokeFunction(showToolsPicker, localize('placeholder', "Select tools that are available to chat"), widget.input.selectedToolsModel.entriesMap, newEntriesMap => {
+		let placeholder;
+		let description;
+		const { entriesScope, entriesMap } = widget.input.selectedToolsModel;
+		switch (entriesScope) {
+			case ToolsScope.Session:
+				placeholder = localize('chat.tools.placeholder.session', "Select tools for this chat session");
+				description = localize('chat.tools.description.session', "The selected tools were configured by a prompt command and only apply to this chat session.");
+				break;
+			case ToolsScope.Mode:
+				placeholder = localize('chat.tools.placeholder.mode', "Select tools for this chat mode");
+				description = localize('chat.tools.description.mode', "The selected tools are configured by the '{0}' chat mode.", widget.input.currentMode2.name);
+				break;
+			case ToolsScope.Global:
+				placeholder = localize('chat.tools.placeholder.global', "Select tools that are available to chat");
+				description = undefined;
+				break;
+		}
+
+		const result = await instaService.invokeFunction(showToolsPicker, placeholder, description, entriesMap.get(), newEntriesMap => {
 			const disableToolSets: ToolSet[] = [];
 			const disableTools: IToolData[] = [];
 			for (const [item, enabled] of newEntriesMap) {
@@ -122,11 +141,13 @@ class ConfigureToolsAction extends Action2 {
 					}
 				}
 			}
-			widget.input.selectedToolsModel.disable(disableToolSets, disableTools, false);
 		});
+		if (result) {
+			widget.input.selectedToolsModel.set(result, false);
+		}
 
 		telemetryService.publicLog2<SelectedToolData, SelectedToolClassification>('chat/selectedTools', {
-			total: widget.input.selectedToolsModel.entriesMap.size,
+			total: widget.input.selectedToolsModel.entriesMap.get().size,
 			enabled: widget.input.selectedToolsModel.entries.get().size,
 		});
 	}

--- a/src/vs/workbench/contrib/chat/browser/actions/chatToolPicker.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatToolPicker.ts
@@ -51,6 +51,7 @@ function isActionableButton(obj: IQuickInputButton): obj is ActionableButton {
 export async function showToolsPicker(
 	accessor: ServicesAccessor,
 	placeHolder: string,
+	description?: string,
 	toolsEntries?: ReadonlyMap<ToolSet | IToolData, boolean>,
 	onUpdate?: (toolsEntries: ReadonlyMap<ToolSet | IToolData, boolean>) => void
 ): Promise<ReadonlyMap<ToolSet | IToolData, boolean> | undefined> {
@@ -243,6 +244,7 @@ export async function showToolsPicker(
 
 	const picker = store.add(quickPickService.createQuickPick<MyPick>({ useSeparators: true }));
 	picker.placeholder = placeHolder;
+	picker.description = description;
 	picker.canSelectMany = true;
 	picker.keepScrollPosition = true;
 	picker.sortByLabel = false;

--- a/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
@@ -406,7 +406,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 		}));
 
 		this._attachmentModel = this._register(this.instantiationService.createInstance(ChatAttachmentModel));
-		this.selectedToolsModel = this._register(this.instantiationService.createInstance(ChatSelectedTools, observableFromEvent(this, this.onDidChangeCurrentChatMode, () => this.currentMode)));
+		this.selectedToolsModel = this._register(this.instantiationService.createInstance(ChatSelectedTools, observableFromEvent(this, this.onDidChangeCurrentChatMode, () => this.currentMode2)));
 		this.dnd = this._register(this.instantiationService.createInstance(ChatDragAndDrop, this._attachmentModel, styles));
 
 		this.getInputState = (): IChatInputState => {

--- a/src/vs/workbench/contrib/chat/browser/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatWidget.ts
@@ -52,7 +52,7 @@ import { ChatViewModel, IChatRequestViewModel, IChatResponseViewModel, isRequest
 import { IChatInputState } from '../common/chatWidgetHistoryService.js';
 import { CodeBlockModelCollection } from '../common/codeBlockModelCollection.js';
 import { ChatAgentLocation, ChatMode } from '../common/constants.js';
-import { ILanguageModelToolsService, IToolData, ToolSet } from '../common/languageModelToolsService.js';
+import { ILanguageModelToolsService, ToolSet } from '../common/languageModelToolsService.js';
 import { type TPromptMetadata } from '../common/promptSyntax/parsers/promptHeader/promptHeader.js';
 import { IPromptParserResult, IPromptsService } from '../common/promptSyntax/service/promptsService.js';
 import { handleModeSwitch } from './actions/chatActions.js';
@@ -1559,18 +1559,11 @@ export class ChatWidget extends Disposable implements IChatWidget {
 	}
 
 	getUserSelectedTools(): Record<string, boolean> | undefined {
-		if (this.input.currentMode2.customTools) {
-			const customTools = new Set<string>(this.input.currentMode2.customTools);
-			return this.toolsService.toToolEnablementMap(customTools);
-		} else if (this.input.currentMode === ChatMode.Agent) {
-			const userSelectedTools: Record<string, boolean> = {};
-			for (const [tool, enablement] of this.input.selectedToolsModel.asEnablementMap()) {
-				userSelectedTools[tool.id] = enablement;
-			}
-			return userSelectedTools;
+		const userSelectedTools: Record<string, boolean> = {};
+		for (const [tool, enablement] of this.input.selectedToolsModel.asEnablementMap()) {
+			userSelectedTools[tool.id] = enablement;
 		}
-
-		return undefined;
+		return userSelectedTools;
 	}
 
 	getModeRequestOptions(): Partial<IChatSendRequestOptions> {
@@ -1799,28 +1792,14 @@ export class ChatWidget extends Disposable implements IChatWidget {
 		// if we have some tools present, the mode must have been equal to `agent`
 		assert(this.input.currentMode === ChatMode.Agent, `Chat mode must be 'agent' when there are 'tools' defined, got ${this.input.currentMode}.`);
 
-		// convert names to tools or tool sets
-		const enabledTools: IToolData[] = [];
-		const enabledToolSets: ToolSet[] = [];
-		for (const name of tools) {
-			const tool = this.toolsService.getToolByName(name);
-			if (tool) {
-				enabledTools.push(tool);
-				continue;
-			}
-			const toolset = this.toolsService.getToolSetByName(name);
-			if (toolset) {
-				enabledToolSets.push(toolset);
-				continue;
-			}
-		}
-		this.input.selectedToolsModel.enable(enabledToolSets, enabledTools, true);
+		const enablementMap = this.toolsService.toToolAndToolSetEnablementMap(new Set(tools));
+		this.input.selectedToolsModel.set(enablementMap, true);
 	}
 
 	/**
 	 * Adds additional instructions to the context
 	 * - instructions that have a 'applyTo' pattern that matches the current input
-	 * - instructions referenced in the copilot settings 'copilot-instructions*
+	 * - instructions referenced in the copilot settings 'copilot-instructions'
 	 * - instructions referenced in an already included instruction file
 	 */
 	private async _autoAttachInstructions({ attachedContext }: IChatRequestInputOptions): Promise<void> {

--- a/src/vs/workbench/contrib/chat/browser/languageModelToolsService.ts
+++ b/src/vs/workbench/contrib/chat/browser/languageModelToolsService.ts
@@ -481,9 +481,29 @@ export class LanguageModelToolsService extends Disposable implements ILanguageMo
 		return result;
 	}
 
+	toToolAndToolSetEnablementMap(toolOrToolSetNames: Set<string>): Map<ToolSet | IToolData, boolean> {
+		const result = new Map<ToolSet | IToolData, boolean>();
+		for (const tool of this._tools.values()) {
+			result.set(tool.data, tool.data.toolReferenceName !== undefined && toolOrToolSetNames.has(tool.data.toolReferenceName));
+		}
+		for (const toolSet of this._toolSets) {
+			result.set(toolSet, toolOrToolSetNames.has(toolSet.referenceName));
+		}
+		return result;
+	}
+
 	private readonly _toolSets = new ObservableSet<ToolSet>();
 
 	readonly toolSets: IObservable<Iterable<ToolSet>> = this._toolSets.observable;
+
+	getToolSet(id: string): ToolSet | undefined {
+		for (const toolSet of this._toolSets) {
+			if (toolSet.id === id) {
+				return toolSet;
+			}
+		}
+		return undefined;
+	}
 
 	getToolSetByName(name: string): ToolSet | undefined {
 		for (const toolSet of this._toolSets) {

--- a/src/vs/workbench/contrib/chat/browser/promptSyntax/promptFileRewriter.ts
+++ b/src/vs/workbench/contrib/chat/browser/promptSyntax/promptFileRewriter.ts
@@ -1,0 +1,73 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { CancellationToken } from '../../../../../base/common/cancellation.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { ICodeEditorService } from '../../../../../editor/browser/services/codeEditorService.js';
+import { EditOperation } from '../../../../../editor/common/core/editOperation.js';
+import { Range } from '../../../../../editor/common/core/range.js';
+import { ITextModel } from '../../../../../editor/common/model.js';
+import { IToolAndToolSetEnablementMap, ToolSet } from '../../common/languageModelToolsService.js';
+import { IPromptsService } from '../../common/promptSyntax/service/promptsService.js';
+
+export class PromptFileRewriter {
+	constructor(
+		@ICodeEditorService private readonly _codeEditorService: ICodeEditorService,
+		@IPromptsService private readonly _promptsService: IPromptsService
+	) {
+	}
+
+	public async openAndRewriteTools(uri: URI, newTools: IToolAndToolSetEnablementMap | undefined, token: CancellationToken): Promise<void> {
+		const editor = await this._codeEditorService.openCodeEditor({ resource: uri }, this._codeEditorService.getFocusedCodeEditor());
+		if (!editor || !editor.hasModel()) {
+			return;
+		}
+		const model = editor.getModel();
+
+		const parser = this._promptsService.getSyntaxParserFor(model);
+		const { header } = await parser.start(token).settled();
+
+		if ((header === undefined) || token.isCancellationRequested) {
+			return undefined;
+		}
+
+		if (('tools' in header.metadataUtility) === false) {
+			return undefined;
+		}
+		const { tools } = header.metadataUtility;
+		if (tools === undefined) {
+			return undefined;
+		}
+		editor.setSelection(tools.range);
+		await this.rewriteTools(model, newTools, tools.range);
+	}
+
+
+	public rewriteTools(model: ITextModel, newTools: IToolAndToolSetEnablementMap | undefined, range: Range): void {
+
+		const newToolNames: string[] = [];
+		if (newTools === undefined) {
+			model.pushStackElement();
+			model.pushEditOperations(null, [EditOperation.replaceMove(range, '')], () => null);
+			model.pushStackElement();
+			return;
+		}
+		for (const [item, picked] of newTools) {
+			if (picked) {
+				if (item instanceof ToolSet) {
+					newToolNames.push(item.referenceName);
+				} else {
+					newToolNames.push(item.toolReferenceName ?? item.displayName);
+				}
+			}
+		}
+
+		model.pushStackElement();
+		model.pushEditOperations(null, [EditOperation.replaceMove(range, `tools: [${newToolNames.map(s => `'${s}'`).join(', ')}]`)], () => null);
+		model.pushStackElement();
+	}
+}
+
+

--- a/src/vs/workbench/contrib/chat/browser/promptSyntax/promptToolsCodeLensProvider.ts
+++ b/src/vs/workbench/contrib/chat/browser/promptSyntax/promptToolsCodeLensProvider.ts
@@ -6,7 +6,6 @@
 import { CancellationToken } from '../../../../../base/common/cancellation.js';
 import { Disposable } from '../../../../../base/common/lifecycle.js';
 import { generateUuid } from '../../../../../base/common/uuid.js';
-import { EditOperation } from '../../../../../editor/common/core/editOperation.js';
 import { CodeLens, CodeLensList, CodeLensProvider } from '../../../../../editor/common/languages.js';
 import { isITextModel, ITextModel } from '../../../../../editor/common/model.js';
 import { ILanguageFeaturesService } from '../../../../../editor/common/services/languageFeatures.js';
@@ -14,11 +13,12 @@ import { localize } from '../../../../../nls.js';
 import { CommandsRegistry } from '../../../../../platform/commands/common/commands.js';
 import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
 import { showToolsPicker } from '../actions/chatToolPicker.js';
-import { ILanguageModelToolsService, IToolData, ToolSet } from '../../common/languageModelToolsService.js';
+import { ILanguageModelToolsService } from '../../common/languageModelToolsService.js';
 import { ALL_PROMPTS_LANGUAGE_SELECTOR } from '../../common/promptSyntax/promptTypes.js';
 import { PromptToolsMetadata } from '../../common/promptSyntax/parsers/promptHeader/metadata/tools.js';
 import { IPromptsService } from '../../common/promptSyntax/service/promptsService.js';
 import { registerEditorFeature } from '../../../../../editor/common/editorFeatures.js';
+import { PromptFileRewriter } from './promptFileRewriter.js';
 
 class PromptToolsCodeLensProvider extends Disposable implements CodeLensProvider {
 
@@ -78,35 +78,12 @@ class PromptToolsCodeLensProvider extends Disposable implements CodeLensProvider
 
 	private async updateTools(model: ITextModel, tools: PromptToolsMetadata) {
 
-		const toolNames = new Set(tools.value);
-		const selectedToolsNow = new Map<ToolSet | IToolData, boolean>();
-
-		for (const tool of this.languageModelToolsService.getTools()) {
-			selectedToolsNow.set(tool, toolNames.has(tool.toolReferenceName ?? tool.displayName));
-		}
-		for (const toolSet of this.languageModelToolsService.toolSets.get()) {
-			selectedToolsNow.set(toolSet, toolNames.has(toolSet.referenceName));
-		}
-
-		const newSelectedAfter = await this.instantiationService.invokeFunction(showToolsPicker, localize('placeholder', "Select tools"), selectedToolsNow);
+		const selectedToolsNow = tools.value ? this.languageModelToolsService.toToolAndToolSetEnablementMap(new Set(tools.value)) : new Map();
+		const newSelectedAfter = await this.instantiationService.invokeFunction(showToolsPicker, localize('placeholder', "Select tools"), undefined, selectedToolsNow);
 		if (!newSelectedAfter) {
 			return;
 		}
-
-		const newToolNames: string[] = [];
-		for (const [item, picked] of newSelectedAfter) {
-			if (picked) {
-				if (item instanceof ToolSet) {
-					newToolNames.push(item.referenceName);
-				} else {
-					newToolNames.push(item.toolReferenceName ?? item.displayName);
-				}
-			}
-		}
-
-		model.pushStackElement();
-		model.pushEditOperations(null, [EditOperation.replaceMove(tools.range, `tools: [${newToolNames.map(s => `'${s}'`).join(', ')}]`)], () => null);
-		model.pushStackElement();
+		await this.instantiationService.createInstance(PromptFileRewriter).rewriteTools(model, newSelectedAfter, tools.range);
 	}
 }
 

--- a/src/vs/workbench/contrib/chat/common/chatModes.ts
+++ b/src/vs/workbench/contrib/chat/common/chatModes.ts
@@ -6,6 +6,7 @@
 import { CancellationToken } from '../../../../base/common/cancellation.js';
 import { Emitter, Event } from '../../../../base/common/event.js';
 import { Disposable } from '../../../../base/common/lifecycle.js';
+import { URI } from '../../../../base/common/uri.js';
 import { localize } from '../../../../nls.js';
 import { IContextKey, IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
 import { createDecorator } from '../../../../platform/instantiation/common/instantiation.js';
@@ -37,7 +38,7 @@ export class ChatModeService extends Disposable implements IChatModeService {
 		@IPromptsService private readonly promptsService: IPromptsService,
 		@IChatAgentService private readonly chatAgentService: IChatAgentService,
 		@IContextKeyService contextKeyService: IContextKeyService,
-		@ILogService private readonly logService: ILogService
+		@ILogService private readonly logService: ILogService,
 	) {
 		super();
 
@@ -95,6 +96,7 @@ export interface IChatMode {
 	readonly kind: ChatMode;
 	readonly customTools?: readonly string[];
 	readonly body?: string;
+	readonly uri?: URI;
 }
 
 export function isIChatMode(mode: unknown): mode is IChatMode {
@@ -126,6 +128,10 @@ export class CustomChatMode implements IChatMode {
 
 	get body(): string {
 		return this.customChatMode.body;
+	}
+
+	get uri(): URI {
+		return this.customChatMode.uri;
 	}
 
 	public readonly kind = ChatMode.Agent;

--- a/src/vs/workbench/contrib/chat/common/languageModelToolsService.ts
+++ b/src/vs/workbench/contrib/chat/common/languageModelToolsService.ts
@@ -198,6 +198,8 @@ export interface IToolImpl {
 	prepareToolInvocation?(parameters: any, token: CancellationToken): Promise<IPreparedToolInvocation | undefined>;
 }
 
+export type IToolAndToolSetEnablementMap = ReadonlyMap<IToolData | ToolSet, boolean>;
+
 export class ToolSet {
 
 	protected readonly _tools = new ObservableSet<IToolData>();
@@ -266,8 +268,10 @@ export interface ILanguageModelToolsService {
 	resetToolAutoConfirmation(): void;
 	cancelToolCallsForRequest(requestId: string): void;
 	toToolEnablementMap(toolOrToolSetNames: Set<string>): Record<string, boolean>;
+	toToolAndToolSetEnablementMap(toolOrToolSetNames: Set<string>): IToolAndToolSetEnablementMap;
 
 	readonly toolSets: IObservable<Iterable<ToolSet>>;
+	getToolSet(id: string): ToolSet | undefined;
 	getToolSetByName(name: string): ToolSet | undefined;
 	createToolSet(source: ToolDataSource, id: string, referenceName: string, options?: { icon?: ThemeIcon; description?: string }): ToolSet & IDisposable;
 }

--- a/src/vs/workbench/contrib/chat/test/browser/chatSelectedTools.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/chatSelectedTools.test.ts
@@ -9,17 +9,17 @@ import { ContextKeyService } from '../../../../../platform/contextkey/browser/co
 import { workbenchInstantiationService } from '../../../../test/browser/workbenchTestServices.js';
 import { LanguageModelToolsService } from '../../browser/languageModelToolsService.js';
 import { IChatService } from '../../common/chatService.js';
-import { ILanguageModelToolsService, IToolData, ToolDataSource } from '../../common/languageModelToolsService.js';
+import { ILanguageModelToolsService, IToolData, ToolDataSource, ToolSet } from '../../common/languageModelToolsService.js';
 import { MockChatService } from '../common/mockChatService.js';
 import { ChatSelectedTools } from '../../browser/chatSelectedTools.js';
 import { constObservable } from '../../../../../base/common/observable.js';
-import { ChatMode } from '../../common/constants.js';
 import { Iterable } from '../../../../../base/common/iterator.js';
 import { DisposableStore } from '../../../../../base/common/lifecycle.js';
 import { runWithFakedTimers } from '../../../../../base/test/common/timeTravelScheduler.js';
 import { timeout } from '../../../../../base/common/async.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { URI } from '../../../../../base/common/uri.js';
+import { ChatMode2 } from '../../common/chatModes.js';
 
 suite('ChatSelectedTools', () => {
 
@@ -40,7 +40,7 @@ suite('ChatSelectedTools', () => {
 
 		store.add(instaService);
 		toolsService = instaService.get(ILanguageModelToolsService);
-		selectedTools = store.add(instaService.createInstance(ChatSelectedTools, constObservable(ChatMode.Agent)));
+		selectedTools = store.add(instaService.createInstance(ChatSelectedTools, constObservable(ChatMode2.Agent)));
 	});
 
 	teardown(function () {
@@ -102,9 +102,10 @@ suite('ChatSelectedTools', () => {
 
 			await timeout(1000); // UGLY the tools service updates its state sync but emits the event async (750ms) delay. This affects the observable that depends on the event
 
-			assert.strictEqual(selectedTools.entriesMap.size, 4); // 1 toolset, 3 tools
+			assert.strictEqual(selectedTools.entriesMap.get().size, 4); // 1 toolset, 3 tools
 
-			selectedTools.disable([], [toolData2, toolData3], false);
+			const toSet = new Map<IToolData | ToolSet, boolean>([[toolData1, true], [toolData2, false], [toolData3, false], [toolset, true]]);
+			selectedTools.set(toSet, false);
 
 			const map = selectedTools.asEnablementMap();
 			assert.strictEqual(map.size, 3); // 3 tools
@@ -165,10 +166,11 @@ suite('ChatSelectedTools', () => {
 
 			await timeout(1000); // UGLY the tools service updates its state sync but emits the event async (750ms) delay. This affects the observable that depends on the event
 
-			assert.strictEqual(selectedTools.entriesMap.size, 4); // 1 toolset, 3 tools
+			assert.strictEqual(selectedTools.entriesMap.get().size, 4); // 1 toolset, 3 tools
 
 			// Toolset is checked, tools 2 and 3 are unchecked
-			selectedTools.disable([], [toolData2, toolData3], false);
+			const toSet = new Map<IToolData | ToolSet, boolean>([[toolData1, true], [toolData2, false], [toolData3, false], [toolset, true]]);
+			selectedTools.set(toSet, false);
 
 			const map = selectedTools.asEnablementMap();
 			assert.strictEqual(map.size, 3); // 3 tools

--- a/src/vs/workbench/contrib/chat/test/common/mockLanguageModelToolsService.ts
+++ b/src/vs/workbench/contrib/chat/test/common/mockLanguageModelToolsService.ts
@@ -64,11 +64,19 @@ export class MockLanguageModelToolsService implements ILanguageModelToolsService
 		return undefined;
 	}
 
+	getToolSet(id: string): ToolSet | undefined {
+		return undefined;
+	}
+
 	createToolSet(): ToolSet & IDisposable {
 		throw new Error('Method not implemented.');
 	}
 
 	toToolEnablementMap(toolOrToolSetNames: Set<string>): Record<string, boolean> {
+		throw new Error('Method not implemented.');
+	}
+
+	toToolAndToolSetEnablementMap(toolOrToolSetNames: Set<string>): Map<ToolSet | IToolData, boolean> {
 		throw new Error('Method not implemented.');
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-copilot/issues/18165

The tools picker is now aware of the custom chat modes
* If a custom chat mode is selected that has tools configured, the picker shows these tools. Changes are applied to the mode file.
* If a prompt file was ran that has tools selected, the tools picker shows the current tools selection and explains
* in all other cases we show the currently globally selected tools and changes will make changes for all chats that do not have custom tools configured
