### PR TITLE
Authentication polish around account access

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadMcp.ts
+++ b/src/vs/workbench/api/browser/mainThreadMcp.ts
@@ -165,13 +165,11 @@ export class MainThreadMcp extends Disposable implements MainThreadMcpShape {
 		if (sessions.length) {
 			// If we have an existing session preference, use that. If not, we'll return any valid session at the end of this function.
 			if (matchingAccountPreferenceSession && this.authenticationMCPServerAccessService.isAccessAllowed(providerId, matchingAccountPreferenceSession.account.label, server.id)) {
-				this._mcpRegistry.setAuthenticationUsage(server.id, providerId);
 				this.authenticationMCPServerUsageService.addAccountUsage(providerId, matchingAccountPreferenceSession.account.label, scopesSupported, server.id, server.label);
 				return matchingAccountPreferenceSession.accessToken;
 			}
 			// If we only have one account for a single auth provider, lets just check if it's allowed and return it if it is.
 			if (!provider.supportsMultipleAccounts && this.authenticationMCPServerAccessService.isAccessAllowed(providerId, sessions[0].account.label, server.id)) {
-				this._mcpRegistry.setAuthenticationUsage(server.id, providerId);
 				this.authenticationMCPServerUsageService.addAccountUsage(providerId, sessions[0].account.label, scopesSupported, server.id, server.label);
 				return sessions[0].accessToken;
 			}
@@ -205,7 +203,6 @@ export class MainThreadMcp extends Disposable implements MainThreadMcpShape {
 			);
 		}
 
-		this._mcpRegistry.setAuthenticationUsage(server.id, providerId);
 		this.authenticationMCPServerAccessService.updateAllowedMcpServers(providerId, session.account.label, [{ id: server.id, name: server.label, allowed: true }]);
 		this.authenticationMcpServersService.updateAccountPreference(server.id, providerId, session.account);
 		this.authenticationMCPServerUsageService.addAccountUsage(providerId, session.account.label, scopesSupported, server.id, server.label);

--- a/src/vs/workbench/contrib/authentication/browser/authentication.contribution.ts
+++ b/src/vs/workbench/contrib/authentication/browser/authentication.contribution.ts
@@ -7,7 +7,7 @@ import { Disposable } from '../../../../base/common/lifecycle.js';
 import { localize } from '../../../../nls.js';
 import { registerAction2 } from '../../../../platform/actions/common/actions.js';
 import { CommandsRegistry } from '../../../../platform/commands/common/commands.js';
-import { IExtensionManifest } from '../../../../platform/extensions/common/extensions.js';
+import { IExtensionManifest, IExtensionDescription } from '../../../../platform/extensions/common/extensions.js';
 import { SyncDescriptor } from '../../../../platform/instantiation/common/descriptors.js';
 import { Registry } from '../../../../platform/registry/common/platform.js';
 import { IWorkbenchContribution, WorkbenchPhase, registerWorkbenchContribution2 } from '../../../common/contributions.js';
@@ -20,6 +20,12 @@ import { IAuthenticationUsageService } from '../../../services/authentication/br
 import { ManageAccountPreferencesForMcpServerAction } from './actions/manageAccountPreferencesForMcpServerAction.js';
 import { ManageTrustedMcpServersForAccountAction } from './actions/manageTrustedMcpServersForAccountAction.js';
 import { RemoveDynamicAuthenticationProvidersAction } from './actions/manageDynamicAuthenticationProvidersAction.js';
+import { IExtensionService } from '../../../services/extensions/common/extensions.js';
+import { IAuthenticationQueryService } from '../../../services/authentication/common/authenticationQuery.js';
+import { IMcpRegistry } from '../../mcp/common/mcpRegistryTypes.js';
+import { autorun } from '../../../../base/common/observable.js';
+import { IAuthenticationService } from '../../../services/authentication/common/authentication.js';
+import { Event } from '../../../../base/common/event.js';
 
 const codeExchangeProxyCommand = CommandsRegistry.registerCommand('workbench.getCodeExchangeProxyEndpoints', function (accessor, _) {
 	const environmentService = accessor.get(IBrowserWorkbenchEnvironmentService);
@@ -110,5 +116,105 @@ class AuthenticationUsageContribution implements IWorkbenchContribution {
 	}
 }
 
+class AuthenticationExtensionsContribution extends Disposable implements IWorkbenchContribution {
+	static ID = 'workbench.contrib.authenticationExtensions';
+
+	constructor(
+		@IExtensionService private readonly _extensionService: IExtensionService,
+		@IAuthenticationQueryService private readonly _authenticationQueryService: IAuthenticationQueryService,
+		@IAuthenticationService private readonly _authenticationService: IAuthenticationService
+	) {
+		super();
+		void this.run();
+		this._register(this._extensionService.onDidChangeExtensions(this._onDidChangeExtensions, this));
+		this._register(
+			Event.any(
+				this._authenticationService.onDidChangeDeclaredProviders,
+				this._authenticationService.onDidRegisterAuthenticationProvider
+			)(() => this._cleanupRemovedExtensions())
+		);
+	}
+
+	async run(): Promise<void> {
+		await this._extensionService.whenInstalledExtensionsRegistered();
+		this._cleanupRemovedExtensions();
+	}
+
+	private _onDidChangeExtensions(delta: { readonly added: readonly IExtensionDescription[]; readonly removed: readonly IExtensionDescription[] }): void {
+		if (delta.removed.length > 0) {
+			this._cleanupRemovedExtensions(delta.removed);
+		}
+	}
+
+	private _cleanupRemovedExtensions(removedExtensions?: readonly IExtensionDescription[]): void {
+		const extensionIdsToRemove = removedExtensions
+			? new Set(removedExtensions.map(e => e.identifier.value))
+			: new Set(this._extensionService.extensions.map(e => e.identifier.value));
+
+		// If we are cleaning up specific removed extensions, we only remove those.
+		const isTargetedCleanup = !!removedExtensions;
+
+		const providerIds = this._authenticationQueryService.getProviderIds();
+		for (const providerId of providerIds) {
+			this._authenticationQueryService.provider(providerId).forEachAccount(account => {
+				account.extensions().forEach(extension => {
+					const shouldRemove = isTargetedCleanup
+						? extensionIdsToRemove.has(extension.extensionId)
+						: !extensionIdsToRemove.has(extension.extensionId);
+
+					if (shouldRemove) {
+						extension.removeUsage();
+						extension.setAccessAllowed(false);
+					}
+				});
+			});
+		}
+	}
+}
+
+class AuthenticationMcpContribution extends Disposable implements IWorkbenchContribution {
+	static ID = 'workbench.contrib.authenticationMcp';
+
+	constructor(
+		@IMcpRegistry private readonly _mcpRegistry: IMcpRegistry,
+		@IAuthenticationQueryService private readonly _authenticationQueryService: IAuthenticationQueryService,
+		@IAuthenticationService private readonly _authenticationService: IAuthenticationService
+	) {
+		super();
+		this._cleanupRemovedMcpServers();
+
+		// Listen for MCP collections changes using autorun with observables
+		this._register(autorun(reader => {
+			// Read the collections observable to register dependency
+			this._mcpRegistry.collections.read(reader);
+			// Schedule cleanup for next tick to avoid running during observable updates
+			queueMicrotask(() => this._cleanupRemovedMcpServers());
+		}));
+		this._register(
+			Event.any(
+				this._authenticationService.onDidChangeDeclaredProviders,
+				this._authenticationService.onDidRegisterAuthenticationProvider
+			)(() => this._cleanupRemovedMcpServers())
+		);
+	}
+
+	private _cleanupRemovedMcpServers(): void {
+		const currentServerIds = new Set(this._mcpRegistry.collections.get().flatMap(c => c.serverDefinitions.get()).map(s => s.id));
+		const providerIds = this._authenticationQueryService.getProviderIds();
+		for (const providerId of providerIds) {
+			this._authenticationQueryService.provider(providerId).forEachAccount(account => {
+				account.mcpServers().forEach(server => {
+					if (!currentServerIds.has(server.mcpServerId)) {
+						server.removeUsage();
+						server.setAccessAllowed(false);
+					}
+				});
+			});
+		}
+	}
+}
+
 registerWorkbenchContribution2(AuthenticationContribution.ID, AuthenticationContribution, WorkbenchPhase.AfterRestored);
 registerWorkbenchContribution2(AuthenticationUsageContribution.ID, AuthenticationUsageContribution, WorkbenchPhase.Eventually);
+registerWorkbenchContribution2(AuthenticationExtensionsContribution.ID, AuthenticationExtensionsContribution, WorkbenchPhase.Eventually);
+registerWorkbenchContribution2(AuthenticationMcpContribution.ID, AuthenticationMcpContribution, WorkbenchPhase.Eventually);

--- a/src/vs/workbench/contrib/mcp/browser/mcpCommands.ts
+++ b/src/vs/workbench/contrib/mcp/browser/mcpCommands.ts
@@ -23,16 +23,13 @@ import { ICommandService } from '../../../../platform/commands/common/commands.j
 import { ConfigurationTarget } from '../../../../platform/configuration/common/configuration.js';
 import { ContextKeyExpr } from '../../../../platform/contextkey/common/contextkey.js';
 import { IInstantiationService, ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
-import { IProductService } from '../../../../platform/product/common/productService.js';
 import { IQuickInputService, IQuickPickItem, IQuickPickSeparator } from '../../../../platform/quickinput/common/quickInput.js';
 import { StorageScope } from '../../../../platform/storage/common/storage.js';
 import { spinningLoading } from '../../../../platform/theme/common/iconRegistry.js';
 import { IWorkspaceContextService } from '../../../../platform/workspace/common/workspace.js';
 import { ActiveEditorContext, ResourceContextKey } from '../../../common/contextkeys.js';
 import { IWorkbenchContribution } from '../../../common/contributions.js';
-import { IAuthenticationAccessService } from '../../../services/authentication/browser/authenticationAccessService.js';
-import { IAuthenticationMcpAccessService } from '../../../services/authentication/browser/authenticationMcpAccessService.js';
-import { IAuthenticationMcpService } from '../../../services/authentication/browser/authenticationMcpService.js';
+import { IAccountQuery, IAuthenticationQueryService } from '../../../services/authentication/common/authenticationQuery.js';
 import { IAuthenticationService } from '../../../services/authentication/common/authentication.js';
 import { IEditorService } from '../../../services/editor/common/editorService.js';
 import { IViewsService } from '../../../services/views/common/viewsService.js';
@@ -45,7 +42,7 @@ import { TEXT_FILE_EDITOR_ID } from '../../files/common/files.js';
 import { McpCommandIds } from '../common/mcpCommandIds.js';
 import { McpContextKeys } from '../common/mcpContextKeys.js';
 import { IMcpRegistry } from '../common/mcpRegistryTypes.js';
-import { HasInstalledMcpServersContext, IMcpSamplingService, IMcpServer, IMcpServerStartOpts, IMcpService, InstalledMcpServersViewId, LazyCollectionState, McpCapability, McpConnectionState, mcpPromptPrefix, McpServerCacheState } from '../common/mcpTypes.js';
+import { HasInstalledMcpServersContext, IMcpSamplingService, IMcpServer, IMcpServerStartOpts, IMcpService, InstalledMcpServersViewId, LazyCollectionState, McpCapability, McpConnectionState, McpDefinitionReference, mcpPromptPrefix, McpServerCacheState } from '../common/mcpTypes.js';
 import { McpAddConfigurationCommand } from './mcpCommandsAddConfiguration.js';
 import { McpResourceQuickAccess, McpResourceQuickPick } from './mcpResourceQuickAccess.js';
 import { openPanelChatAndGetWidget } from './openPanelChatAndGetWidget.js';
@@ -133,7 +130,12 @@ export class ListMcpServerCommand extends Action2 {
 }
 
 interface ActionItem extends IQuickPickItem {
-	action: 'start' | 'stop' | 'restart' | 'disconnect' | 'signout' | 'showOutput' | 'config' | 'configSampling' | 'samplingLog' | 'resources';
+	action: 'start' | 'stop' | 'restart' | 'showOutput' | 'config' | 'configSampling' | 'samplingLog' | 'resources';
+}
+
+interface AuthActionItem extends IQuickPickItem {
+	action: 'disconnect' | 'signout';
+	accountQuery: IAccountQuery;
 }
 
 export class McpServerOptionsCommand extends Action2 {
@@ -153,11 +155,8 @@ export class McpServerOptionsCommand extends Action2 {
 		const editorService = accessor.get(IEditorService);
 		const commandService = accessor.get(ICommandService);
 		const samplingService = accessor.get(IMcpSamplingService);
-		const authenticationMcpService = accessor.get(IAuthenticationMcpService);
-		const authenticationMcpAccessService = accessor.get(IAuthenticationMcpAccessService);
-		const authenticationExtensionAccessService = accessor.get(IAuthenticationAccessService);
+		const authenticationQueryService = accessor.get(IAuthenticationQueryService);
 		const authenticationService = accessor.get(IAuthenticationService);
-		const productService = accessor.get(IProductService);
 		const server = mcpService.servers.get().find(s => s.definition.id === id);
 		if (!server) {
 			return;
@@ -166,7 +165,7 @@ export class McpServerOptionsCommand extends Action2 {
 		const collection = mcpRegistry.collections.get().find(c => c.id === server.collection.id);
 		const serverDefinition = collection?.serverDefinitions.get().find(s => s.id === server.definition.id);
 
-		const items: (ActionItem | IQuickPickSeparator)[] = [];
+		const items: (ActionItem | AuthActionItem | IQuickPickSeparator)[] = [];
 		const serverState = server.connectionState.get();
 
 		items.push({ type: 'separator', label: localize('mcp.actions.status', 'Status') });
@@ -188,17 +187,7 @@ export class McpServerOptionsCommand extends Action2 {
 			});
 		}
 
-		const item = this._getAuthAction(
-			mcpRegistry,
-			authenticationMcpService,
-			authenticationMcpAccessService,
-			authenticationExtensionAccessService,
-			productService,
-			server.definition.id
-		);
-		if (item) {
-			items.push(item);
-		}
+		items.push(...this._getAuthActions(authenticationQueryService, server.definition.id));
 
 		const configTarget = serverDefinition?.presentation?.origin || collection?.presentation?.origin;
 		if (configTarget) {
@@ -261,24 +250,12 @@ export class McpServerOptionsCommand extends Action2 {
 				await server.start({ isFromInteraction: true });
 				break;
 			case 'disconnect':
-				await this._handleAuth(
-					mcpRegistry,
-					authenticationMcpService,
-					authenticationMcpAccessService,
-					authenticationService,
-					server,
-					false
-				);
+				await server.stop();
+				await this._handleAuth(authenticationService, pick.accountQuery, server.definition, false);
 				break;
 			case 'signout':
-				await this._handleAuth(
-					mcpRegistry,
-					authenticationMcpService,
-					authenticationMcpAccessService,
-					authenticationService,
-					server,
-					true
-				);
+				await server.stop();
+				await this._handleAuth(authenticationService, pick.accountQuery, server.definition, true);
 				break;
 			case 'showOutput':
 				server.showOutput();
@@ -301,102 +278,54 @@ export class McpServerOptionsCommand extends Action2 {
 				});
 				break;
 			default:
-				assertNever(pick.action);
+				assertNever(pick);
 		}
 	}
 
-	private _getAuthAction(
-		mcpRegistry: IMcpRegistry,
-		authenticationMcpService: IAuthenticationMcpService,
-		authenticationMcpAccessService: IAuthenticationMcpAccessService,
-		authenticationAccessService: IAuthenticationAccessService,
-		productService: IProductService,
+	private _getAuthActions(
+		authenticationQueryService: IAuthenticationQueryService,
 		serverId: string
-	): ActionItem | undefined {
-		const providerId = mcpRegistry.getAuthenticationUsage(serverId);
-		if (!providerId) {
-			return undefined;
-		}
-		const preference = authenticationMcpService.getAccountPreference(serverId, providerId);
-		if (!preference) {
-			return undefined;
-		}
-		if (!authenticationMcpAccessService.isAccessAllowed(providerId, preference, serverId)) {
-			return undefined;
-		}
-		const allowedServers = this._getAllAllowedItems(
-			authenticationMcpAccessService,
-			authenticationAccessService,
-			productService,
-			providerId,
-			preference
-		);
+	): AuthActionItem[] {
+		const result: AuthActionItem[] = [];
+		// Really, this should only ever have one entry.
+		for (const [providerId, accountName] of authenticationQueryService.mcpServer(serverId).getAllAccountPreferences()) {
 
-		// If there are multiple allowed servers/extensions, other things are using this provider
-		// so we show a disconnect action, otherwise we show a sign out action.
-		if (allowedServers.length > 1) {
-			return {
-				action: 'disconnect',
-				label: localize('mcp.disconnect', 'Disconnect Account'),
-				description: `(${preference})`,
-			};
+			const accountQuery = authenticationQueryService.provider(providerId).account(accountName);
+			if (!accountQuery.mcpServer(serverId).isAccessAllowed()) {
+				continue; // skip accounts that are not allowed
+			}
+			// If there are multiple allowed servers/extensions, other things are using this provider
+			// so we show a disconnect action, otherwise we show a sign out action.
+			if (accountQuery.entities().getEntityCount().total > 1) {
+				result.push({
+					action: 'disconnect',
+					label: localize('mcp.disconnect', 'Disconnect Account'),
+					description: `(${accountName})`,
+					accountQuery
+				});
+			} else {
+				result.push({
+					action: 'signout',
+					label: localize('mcp.signOut', 'Sign Out'),
+					description: `(${accountName})`,
+					accountQuery
+				});
+			}
 		}
-		return {
-			action: 'signout',
-			label: localize('mcp.signOut', 'Sign Out'),
-			description: `(${preference})`
-		};
-	}
-
-	// TODO@TylerLeonhardt: The fact that this function exists means that these classes could really use some refactoring...
-	private _getAllAllowedItems(
-		authenticationMcpAccessService: IAuthenticationMcpAccessService,
-		authenticationAccessService: IAuthenticationAccessService,
-		productService: IProductService,
-		providerId: string,
-		preference: string
-	) {
-		const trustedExtensionAuth = Array.isArray(productService.trustedExtensionAuthAccess) || !productService.trustedExtensionAuthAccess
-			? []
-			: productService.trustedExtensionAuthAccess[providerId] ?? [];
-		const trustedMcpAuth = Array.isArray(productService.trustedMcpAuthAccess) || !productService.trustedMcpAuthAccess
-			? []
-			: productService.trustedMcpAuthAccess[providerId] ?? [];
-
-		return [
-			...authenticationMcpAccessService.readAllowedMcpServers(providerId, preference).filter(s => !s.trusted),
-			...authenticationAccessService.readAllowedExtensions(providerId, preference).filter(e => !e.trusted),
-			...trustedExtensionAuth,
-			...trustedMcpAuth
-		];
+		return result;
 	}
 
 	private async _handleAuth(
-		mcpRegistry: IMcpRegistry,
-		authenticationMcpService: IAuthenticationMcpService,
-		authenticationMcpAccessService: IAuthenticationMcpAccessService,
 		authenticationService: IAuthenticationService,
-		server: IMcpServer,
+		accountQuery: IAccountQuery,
+		definition: McpDefinitionReference,
 		signOut: boolean
 	) {
-		const providerId = mcpRegistry.getAuthenticationUsage(server.definition.id);
-		if (!providerId) {
-			return;
-		}
-		const preference = authenticationMcpService.getAccountPreference(server.definition.id, providerId);
-		if (!preference) {
-			return;
-		}
-		authenticationMcpAccessService.updateAllowedMcpServers(providerId, preference, [
-			{
-				id: server.definition.id,
-				name: server.definition.label,
-				allowed: false
-			}
-		]);
+		const { providerId, accountName } = accountQuery;
+		accountQuery.mcpServer(definition.id).setAccessAllowed(false, definition.label);
 		if (signOut) {
 			const accounts = await authenticationService.getAccounts(providerId);
-			const account = accounts.find(a => a.label === preference);
+			const account = accounts.find(a => a.label === accountName);
 			if (account) {
 				const sessions = await authenticationService.getSessions(providerId, undefined, { account });
 				for (const session of sessions) {

--- a/src/vs/workbench/contrib/mcp/common/mcpRegistry.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpRegistry.ts
@@ -50,9 +50,6 @@ export class McpRegistry extends Disposable implements IMcpRegistry {
 		return this._collections.read(reader);
 	});
 
-	// We don't need anything fancy here since the callers are all on-demand (not wanting to listen to changes)
-	private readonly _serverIdAuthUsage = new Map<string, string>();
-
 	private readonly _workspaceStorage = new Lazy(() => this._register(this._instantiationService.createInstance(McpRegistryInputStorage, StorageScope.WORKSPACE, StorageTarget.USER)));
 	private readonly _profileStorage = new Lazy(() => this._register(this._instantiationService.createInstance(McpRegistryInputStorage, StorageScope.PROFILE, StorageTarget.USER)));
 
@@ -124,14 +121,6 @@ export class McpRegistry extends Disposable implements IMcpRegistry {
 				this._collections.set(currentCollections.filter(c => c !== collection), undefined);
 			}
 		};
-	}
-
-	public getAuthenticationUsage(mcpServerId: string): string | undefined {
-		return this._serverIdAuthUsage.get(mcpServerId);
-	}
-
-	public setAuthenticationUsage(mcpServerId: string, providerId: string): void {
-		this._serverIdAuthUsage.set(mcpServerId, providerId);
 	}
 
 	public getServerDefinition(collectionRef: McpDefinitionReference, definitionRef: McpDefinitionReference): IObservable<{ server: McpServerDefinition | undefined; collection: McpCollectionDefinition | undefined }> {

--- a/src/vs/workbench/contrib/mcp/common/mcpRegistryTypes.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpRegistryTypes.ts
@@ -64,9 +64,6 @@ export interface IMcpRegistry {
 	registerDelegate(delegate: IMcpHostDelegate): IDisposable;
 	registerCollection(collection: McpCollectionDefinition): IDisposable;
 
-	getAuthenticationUsage(mcpServerId: string): string | undefined;
-	setAuthenticationUsage(mcpServerId: string, providerId: string): void;
-
 	/** Resets the trust state of all collections. */
 	resetTrust(): void;
 

--- a/src/vs/workbench/contrib/mcp/test/common/mcpRegistryTypes.ts
+++ b/src/vs/workbench/contrib/mcp/test/common/mcpRegistryTypes.ts
@@ -212,12 +212,6 @@ export class TestMcpRegistry implements IMcpRegistry {
 	getTrust(collection: McpCollectionReference): IObservable<boolean | undefined> {
 		throw new Error('Method not implemented.');
 	}
-	getAuthenticationUsage(mcpServerId: string): string | undefined {
-		throw new Error('Method not implemented.');
-	}
-	setAuthenticationUsage(mcpServerId: string, providerId: string): void {
-		throw new Error('Method not implemented.');
-	}
 	clearSavedInputs(scope: StorageScope, inputId?: string): Promise<void> {
 		throw new Error('Method not implemented.');
 	}

--- a/src/vs/workbench/services/authentication/browser/authenticationMcpAccessService.ts
+++ b/src/vs/workbench/services/authentication/browser/authenticationMcpAccessService.ts
@@ -44,6 +44,7 @@ export interface IAuthenticationMcpAccessService {
 	removeAllowedMcpServers(providerId: string, accountName: string): void;
 }
 
+// TODO@TylerLeonhardt: Should this class only keep track of allowed things and throw away disallowed ones?
 export class AuthenticationMcpAccessService extends Disposable implements IAuthenticationMcpAccessService {
 	_serviceBrand: undefined;
 

--- a/src/vs/workbench/services/authentication/common/authenticationQuery.ts
+++ b/src/vs/workbench/services/authentication/common/authenticationQuery.ts
@@ -68,6 +68,12 @@ export interface IAccountQuery extends IBaseQuery {
 	mcpServers(): IAccountMcpServersQuery;
 
 	/**
+	 * Get operations for all entities (extensions and MCP servers) on this account
+	 * @returns An account-entities query interface for type-agnostic operations
+	 */
+	entities(): IAccountEntitiesQuery;
+
+	/**
 	 * Remove all authentication data for this account
 	 */
 	remove(): void;
@@ -125,6 +131,12 @@ export interface IAccountExtensionQuery extends IBaseQuery {
 	 * Check if this account is the preferred account for this extension
 	 */
 	isPreferred(): boolean;
+
+	/**
+	 * Check if this extension is trusted (defined in product.json)
+	 * @returns True if the extension is trusted, false otherwise
+	 */
+	isTrusted(): boolean;
 }
 
 /**
@@ -194,10 +206,10 @@ export interface IAccountExtensionsQuery extends IBaseQuery {
 	readonly accountName: string;
 
 	/**
-	 * Get all extension IDs that have access to this account
-	 * @returns Array of extension IDs
+	 * Get all extensions that have access to this account with their trusted state
+	 * @returns Array of objects containing extension data including trusted state
 	 */
-	getAllowedExtensionIds(): string[];
+	getAllowedExtensions(): { id: string; name: string; allowed?: boolean; lastUsed?: number; trusted?: boolean }[];
 
 	/**
 	 * Grant access to this account for all specified extensions
@@ -250,16 +262,40 @@ export interface IAccountMcpServersQuery extends IBaseQuery {
 }
 
 /**
+ * Query interface for type-agnostic operations on all entities (extensions and MCP servers) within a specific account
+ */
+export interface IAccountEntitiesQuery extends IBaseQuery {
+	readonly accountName: string;
+
+	/**
+	 * Check if this account has been used by any entity (extension or MCP server)
+	 * @returns True if the account has been used, false otherwise
+	 */
+	hasAnyUsage(): boolean;
+
+	/**
+	 * Get the total count of entities that have used this account
+	 * @returns Object with counts for extensions and MCP servers
+	 */
+	getEntityCount(): { extensions: number; mcpServers: number; total: number };
+
+	/**
+	 * Remove access to this account for all entities (extensions and MCP servers)
+	 */
+	removeAllAccess(): void;
+
+	/**
+	 * Execute a callback for each entity that has used this account
+	 * @param callback Function to execute for each entity
+	 */
+	forEach(callback: (entityId: string, entityType: 'extension' | 'mcpServer') => void): void;
+}
+
+/**
  * Query interface for operations on a specific extension within a provider
  */
 export interface IProviderExtensionQuery extends IBaseQuery {
 	readonly extensionId: string;
-
-	/**
-	 * Get the last used account for this extension within this provider
-	 * @returns The account name, or undefined if no preference is set
-	 */
-	getLastUsedAccount(): Promise<string | undefined>;
 
 	/**
 	 * Get the preferred account for this extension within this provider
@@ -277,12 +313,6 @@ export interface IProviderExtensionQuery extends IBaseQuery {
 	 * Remove the account preference for this extension within this provider
 	 */
 	removeAccountPreference(): void;
-
-	/**
-	 * Get all accounts that this extension has used within this provider
-	 * @returns Array of account names
-	 */
-	getUsedAccounts(): Promise<string[]>;
 }
 
 /**

--- a/src/vs/workbench/services/authentication/test/browser/authenticationAccessService.test.ts
+++ b/src/vs/workbench/services/authentication/test/browser/authenticationAccessService.test.ts
@@ -1,0 +1,481 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { TestInstantiationService } from '../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
+import { IStorageService, StorageScope, StorageTarget } from '../../../../../platform/storage/common/storage.js';
+import { IProductService } from '../../../../../platform/product/common/productService.js';
+import { TestStorageService, TestProductService } from '../../../../test/common/workbenchTestServices.js';
+import { AuthenticationAccessService, IAuthenticationAccessService } from '../../browser/authenticationAccessService.js';
+import { AllowedExtension } from '../../common/authentication.js';
+
+suite('AuthenticationAccessService', () => {
+	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
+
+	let instantiationService: TestInstantiationService;
+	let storageService: TestStorageService;
+	let productService: IProductService & { trustedExtensionAuthAccess?: string[] | Record<string, string[]> };
+	let authenticationAccessService: IAuthenticationAccessService;
+
+	setup(() => {
+		instantiationService = disposables.add(new TestInstantiationService());
+
+		// Set up storage service
+		storageService = disposables.add(new TestStorageService());
+		instantiationService.stub(IStorageService, storageService);
+
+		// Set up product service with no trusted extensions by default
+		productService = { ...TestProductService, trustedExtensionAuthAccess: undefined };
+		instantiationService.stub(IProductService, productService);
+
+		// Create the service instance
+		authenticationAccessService = disposables.add(instantiationService.createInstance(AuthenticationAccessService));
+	});
+
+	teardown(() => {
+		// Reset product service configuration to prevent test interference
+		if (productService) {
+			productService.trustedExtensionAuthAccess = undefined;
+		}
+	});
+
+	suite('isAccessAllowed', () => {
+		test('returns undefined for unknown extension with no product configuration', () => {
+			const result = authenticationAccessService.isAccessAllowed('github', 'user@example.com', 'unknown-extension');
+			assert.strictEqual(result, undefined);
+		});
+
+		test('returns true for trusted extension from product.json (array format)', () => {
+			productService.trustedExtensionAuthAccess = ['trusted-extension-1', 'trusted-extension-2'];
+
+			const result = authenticationAccessService.isAccessAllowed('github', 'user@example.com', 'trusted-extension-1');
+			assert.strictEqual(result, true);
+		});
+
+		test('returns true for trusted extension from product.json (object format)', () => {
+			productService.trustedExtensionAuthAccess = {
+				'github': ['github-extension'],
+				'microsoft': ['microsoft-extension']
+			};
+
+			const result1 = authenticationAccessService.isAccessAllowed('github', 'user@example.com', 'github-extension');
+			assert.strictEqual(result1, true);
+
+			const result2 = authenticationAccessService.isAccessAllowed('microsoft', 'user@microsoft.com', 'microsoft-extension');
+			assert.strictEqual(result2, true);
+		});
+
+		test('returns undefined for extension not in trusted list', () => {
+			productService.trustedExtensionAuthAccess = ['trusted-extension'];
+
+			const result = authenticationAccessService.isAccessAllowed('github', 'user@example.com', 'untrusted-extension');
+			assert.strictEqual(result, undefined);
+		});
+
+		test('returns stored allowed state when extension is in storage', () => {
+			// Add extension to storage
+			authenticationAccessService.updateAllowedExtensions('github', 'user@example.com', [{
+				id: 'stored-extension',
+				name: 'Stored Extension',
+				allowed: false
+			}]);
+
+			const result = authenticationAccessService.isAccessAllowed('github', 'user@example.com', 'stored-extension');
+			assert.strictEqual(result, false);
+		});
+
+		test('returns true for extension in storage with allowed=true', () => {
+			authenticationAccessService.updateAllowedExtensions('github', 'user@example.com', [{
+				id: 'allowed-extension',
+				name: 'Allowed Extension',
+				allowed: true
+			}]);
+
+			const result = authenticationAccessService.isAccessAllowed('github', 'user@example.com', 'allowed-extension');
+			assert.strictEqual(result, true);
+		});
+
+		test('returns true for extension in storage with undefined allowed property (legacy behavior)', () => {
+			// Simulate legacy data where allowed property didn't exist
+			const legacyExtension: AllowedExtension = {
+				id: 'legacy-extension',
+				name: 'Legacy Extension'
+				// allowed property is undefined
+			};
+
+			authenticationAccessService.updateAllowedExtensions('github', 'user@example.com', [legacyExtension]);
+
+			const result = authenticationAccessService.isAccessAllowed('github', 'user@example.com', 'legacy-extension');
+			assert.strictEqual(result, true);
+		});
+
+		test('product.json trusted extensions take precedence over storage', () => {
+			productService.trustedExtensionAuthAccess = ['product-trusted-extension'];
+
+			// Try to store the same extension as not allowed
+			authenticationAccessService.updateAllowedExtensions('github', 'user@example.com', [{
+				id: 'product-trusted-extension',
+				name: 'Product Trusted Extension',
+				allowed: false
+			}]);
+
+			// Product.json should take precedence
+			const result = authenticationAccessService.isAccessAllowed('github', 'user@example.com', 'product-trusted-extension');
+			assert.strictEqual(result, true);
+		});
+	});
+
+	suite('readAllowedExtensions', () => {
+		test('returns empty array when no data exists', () => {
+			const result = authenticationAccessService.readAllowedExtensions('github', 'user@example.com');
+			assert.strictEqual(result.length, 0);
+		});
+
+		test('returns stored extensions', () => {
+			const extensions: AllowedExtension[] = [
+				{ id: 'extension1', name: 'Extension 1', allowed: true },
+				{ id: 'extension2', name: 'Extension 2', allowed: false }
+			];
+
+			authenticationAccessService.updateAllowedExtensions('github', 'user@example.com', extensions);
+
+			const result = authenticationAccessService.readAllowedExtensions('github', 'user@example.com');
+			assert.strictEqual(result.length, 2);
+			assert.strictEqual(result[0].id, 'extension1');
+			assert.strictEqual(result[0].allowed, true);
+			assert.strictEqual(result[1].id, 'extension2');
+			assert.strictEqual(result[1].allowed, false);
+		});
+
+		test('includes trusted extensions from product.json (array format)', () => {
+			productService.trustedExtensionAuthAccess = ['trusted-extension-1', 'trusted-extension-2'];
+
+			const result = authenticationAccessService.readAllowedExtensions('github', 'user@example.com');
+			assert.strictEqual(result.length, 2);
+
+			const trustedExtension1 = result.find(e => e.id === 'trusted-extension-1');
+			assert.ok(trustedExtension1);
+			assert.strictEqual(trustedExtension1.allowed, true);
+			assert.strictEqual(trustedExtension1.trusted, true);
+			assert.strictEqual(trustedExtension1.name, 'trusted-extension-1'); // Should default to ID
+
+			const trustedExtension2 = result.find(e => e.id === 'trusted-extension-2');
+			assert.ok(trustedExtension2);
+			assert.strictEqual(trustedExtension2.allowed, true);
+			assert.strictEqual(trustedExtension2.trusted, true);
+		});
+
+		test('includes trusted extensions from product.json (object format)', () => {
+			productService.trustedExtensionAuthAccess = {
+				'github': ['github-extension'],
+				'microsoft': ['microsoft-extension']
+			};
+
+			const githubResult = authenticationAccessService.readAllowedExtensions('github', 'user@example.com');
+			assert.strictEqual(githubResult.length, 1);
+			assert.strictEqual(githubResult[0].id, 'github-extension');
+			assert.strictEqual(githubResult[0].trusted, true);
+
+			const microsoftResult = authenticationAccessService.readAllowedExtensions('microsoft', 'user@microsoft.com');
+			assert.strictEqual(microsoftResult.length, 1);
+			assert.strictEqual(microsoftResult[0].id, 'microsoft-extension');
+			assert.strictEqual(microsoftResult[0].trusted, true);
+
+			// Provider not in trusted list should return empty (no stored extensions)
+			const unknownResult = authenticationAccessService.readAllowedExtensions('unknown', 'user@unknown.com');
+			assert.strictEqual(unknownResult.length, 0);
+		});
+
+		test('merges stored extensions with trusted extensions from product.json', () => {
+			productService.trustedExtensionAuthAccess = ['trusted-extension'];
+
+			// Add some stored extensions
+			authenticationAccessService.updateAllowedExtensions('github', 'user@example.com', [
+				{ id: 'stored-extension', name: 'Stored Extension', allowed: false }
+			]);
+
+			const result = authenticationAccessService.readAllowedExtensions('github', 'user@example.com');
+			assert.strictEqual(result.length, 2);
+
+			const trustedExtension = result.find(e => e.id === 'trusted-extension');
+			assert.ok(trustedExtension);
+			assert.strictEqual(trustedExtension.trusted, true);
+			assert.strictEqual(trustedExtension.allowed, true);
+
+			const storedExtension = result.find(e => e.id === 'stored-extension');
+			assert.ok(storedExtension);
+			assert.strictEqual(storedExtension.trusted, undefined);
+			assert.strictEqual(storedExtension.allowed, false);
+		});
+
+		test('updates existing stored extension to trusted when found in product.json', () => {
+			// First add an extension to storage
+			authenticationAccessService.updateAllowedExtensions('github', 'user@example.com', [
+				{ id: 'extension1', name: 'Extension 1', allowed: false }
+			]);
+
+			// Then add it to trusted list
+			productService.trustedExtensionAuthAccess = ['extension1'];
+
+			const result = authenticationAccessService.readAllowedExtensions('github', 'user@example.com');
+			assert.strictEqual(result.length, 1);
+			assert.strictEqual(result[0].id, 'extension1');
+			assert.strictEqual(result[0].trusted, true);
+			assert.strictEqual(result[0].allowed, true); // Should be marked as allowed due to being trusted
+		});
+
+		test('handles malformed storage data gracefully', () => {
+			// Directly store malformed data in storage
+			storageService.store('github-user@example.com', 'invalid-json', StorageScope.APPLICATION, StorageTarget.USER);
+
+			const result = authenticationAccessService.readAllowedExtensions('github', 'user@example.com');
+			assert.strictEqual(result.length, 0); // Should return empty array instead of throwing
+		});
+	});
+
+	suite('updateAllowedExtensions', () => {
+		test('adds new extensions to storage', () => {
+			const extensions: AllowedExtension[] = [
+				{ id: 'extension1', name: 'Extension 1', allowed: true },
+				{ id: 'extension2', name: 'Extension 2', allowed: false }
+			];
+
+			authenticationAccessService.updateAllowedExtensions('github', 'user@example.com', extensions);
+
+			const result = authenticationAccessService.readAllowedExtensions('github', 'user@example.com');
+			assert.strictEqual(result.length, 2);
+			assert.strictEqual(result[0].id, 'extension1');
+			assert.strictEqual(result[1].id, 'extension2');
+		});
+
+		test('updates existing extension allowed status', () => {
+			// First add an extension
+			authenticationAccessService.updateAllowedExtensions('github', 'user@example.com', [
+				{ id: 'extension1', name: 'Extension 1', allowed: true }
+			]);
+
+			// Then update its allowed status
+			authenticationAccessService.updateAllowedExtensions('github', 'user@example.com', [
+				{ id: 'extension1', name: 'Extension 1', allowed: false }
+			]);
+
+			const result = authenticationAccessService.readAllowedExtensions('github', 'user@example.com');
+			assert.strictEqual(result.length, 1);
+			assert.strictEqual(result[0].allowed, false);
+		});
+
+		test('updates existing extension name when new name is provided', () => {
+			// First add an extension with default name
+			authenticationAccessService.updateAllowedExtensions('github', 'user@example.com', [
+				{ id: 'extension1', name: 'extension1', allowed: true }
+			]);
+
+			// Then update with a proper name
+			authenticationAccessService.updateAllowedExtensions('github', 'user@example.com', [
+				{ id: 'extension1', name: 'My Extension', allowed: true }
+			]);
+
+			const result = authenticationAccessService.readAllowedExtensions('github', 'user@example.com');
+			assert.strictEqual(result.length, 1);
+			assert.strictEqual(result[0].name, 'My Extension');
+		});
+
+		test('does not update name when new name is same as ID', () => {
+			// First add an extension with a proper name
+			authenticationAccessService.updateAllowedExtensions('github', 'user@example.com', [
+				{ id: 'extension1', name: 'My Extension', allowed: true }
+			]);
+
+			// Then try to update with ID as name (should keep existing name)
+			authenticationAccessService.updateAllowedExtensions('github', 'user@example.com', [
+				{ id: 'extension1', name: 'extension1', allowed: false }
+			]);
+
+			const result = authenticationAccessService.readAllowedExtensions('github', 'user@example.com');
+			assert.strictEqual(result.length, 1);
+			assert.strictEqual(result[0].name, 'My Extension'); // Should keep the original name
+			assert.strictEqual(result[0].allowed, false); // But update the allowed status
+		});
+
+		test('does not store trusted extensions - they should only come from product.json', () => {
+			productService.trustedExtensionAuthAccess = ['trusted-extension'];
+
+			// Try to store a trusted extension along with regular extensions
+			authenticationAccessService.updateAllowedExtensions('github', 'user@example.com', [
+				{ id: 'regular-extension', name: 'Regular Extension', allowed: true },
+				{ id: 'trusted-extension', name: 'Trusted Extension', allowed: false }
+			]);
+
+			// Check what's actually stored in storage (should only be the regular extension)
+			const storedData = storageService.get('github-user@example.com', StorageScope.APPLICATION);
+			assert.ok(storedData);
+			const parsedData = JSON.parse(storedData);
+			assert.strictEqual(parsedData.length, 1);
+			assert.strictEqual(parsedData[0].id, 'regular-extension');
+
+			// But when we read, we should get both (trusted from product.json + stored)
+			const result = authenticationAccessService.readAllowedExtensions('github', 'user@example.com');
+			assert.strictEqual(result.length, 2);
+
+			const trustedExt = result.find(e => e.id === 'trusted-extension');
+			assert.ok(trustedExt);
+			assert.strictEqual(trustedExt.trusted, true);
+			assert.strictEqual(trustedExt.allowed, true); // Should be true from product.json, not false from storage
+
+			const regularExt = result.find(e => e.id === 'regular-extension');
+			assert.ok(regularExt);
+			assert.strictEqual(regularExt.trusted, undefined);
+			assert.strictEqual(regularExt.allowed, true);
+		});
+
+		test('filters out trusted extensions before storing', () => {
+			productService.trustedExtensionAuthAccess = ['trusted-ext-1', 'trusted-ext-2'];
+
+			// Add both trusted and regular extensions
+			const extensions: AllowedExtension[] = [
+				{ id: 'regular-ext', name: 'Regular Extension', allowed: true },
+				{ id: 'trusted-ext-1', name: 'Trusted Extension 1', allowed: false },
+				{ id: 'another-regular-ext', name: 'Another Regular Extension', allowed: false },
+				{ id: 'trusted-ext-2', name: 'Trusted Extension 2', allowed: true }
+			];
+
+			authenticationAccessService.updateAllowedExtensions('github', 'user@example.com', extensions);
+
+			// Check storage - should only contain regular extensions
+			const storedData = storageService.get('github-user@example.com', StorageScope.APPLICATION);
+			assert.ok(storedData);
+			const parsedData = JSON.parse(storedData);
+			assert.strictEqual(parsedData.length, 2);
+			assert.ok(parsedData.find((e: AllowedExtension) => e.id === 'regular-ext'));
+			assert.ok(parsedData.find((e: AllowedExtension) => e.id === 'another-regular-ext'));
+			assert.ok(!parsedData.find((e: AllowedExtension) => e.id === 'trusted-ext-1'));
+			assert.ok(!parsedData.find((e: AllowedExtension) => e.id === 'trusted-ext-2'));
+		});
+
+		test('fires onDidChangeExtensionSessionAccess event', () => {
+			let eventFired = false;
+			let eventData: { providerId: string; accountName: string } | undefined;
+
+			const subscription = authenticationAccessService.onDidChangeExtensionSessionAccess(e => {
+				eventFired = true;
+				eventData = e;
+			});
+			disposables.add(subscription);
+
+			authenticationAccessService.updateAllowedExtensions('github', 'user@example.com', [
+				{ id: 'extension1', name: 'Extension 1', allowed: true }
+			]);
+
+			assert.strictEqual(eventFired, true);
+			assert.ok(eventData);
+			assert.strictEqual(eventData.providerId, 'github');
+			assert.strictEqual(eventData.accountName, 'user@example.com');
+		});
+	});
+
+	suite('removeAllowedExtensions', () => {
+		test('removes all extensions from storage', () => {
+			// First add some extensions
+			authenticationAccessService.updateAllowedExtensions('github', 'user@example.com', [
+				{ id: 'extension1', name: 'Extension 1', allowed: true },
+				{ id: 'extension2', name: 'Extension 2', allowed: false }
+			]);
+
+			// Verify they exist
+			const result = authenticationAccessService.readAllowedExtensions('github', 'user@example.com');
+			assert.ok(result.length > 0);
+
+			// Remove them
+			authenticationAccessService.removeAllowedExtensions('github', 'user@example.com');
+
+			// Verify storage is empty (but trusted extensions from product.json might still be there)
+			const storedData = storageService.get('github-user@example.com', StorageScope.APPLICATION);
+			assert.strictEqual(storedData, undefined);
+		});
+
+		test('fires onDidChangeExtensionSessionAccess event', () => {
+			let eventFired = false;
+			let eventData: { providerId: string; accountName: string } | undefined;
+
+			// First add an extension
+			authenticationAccessService.updateAllowedExtensions('github', 'user@example.com', [
+				{ id: 'extension1', name: 'Extension 1', allowed: true }
+			]);
+
+			// Then listen for the remove event
+			const subscription = authenticationAccessService.onDidChangeExtensionSessionAccess(e => {
+				eventFired = true;
+				eventData = e;
+			});
+			disposables.add(subscription);
+
+			authenticationAccessService.removeAllowedExtensions('github', 'user@example.com');
+
+			assert.strictEqual(eventFired, true);
+			assert.ok(eventData);
+			assert.strictEqual(eventData.providerId, 'github');
+			assert.strictEqual(eventData.accountName, 'user@example.com');
+		});
+
+		test('does not affect trusted extensions from product.json', () => {
+			productService.trustedExtensionAuthAccess = ['trusted-extension'];
+
+			// Add some regular extensions and verify both trusted and regular exist
+			authenticationAccessService.updateAllowedExtensions('github', 'user@example.com', [
+				{ id: 'regular-extension', name: 'Regular Extension', allowed: true }
+			]);
+
+			let result = authenticationAccessService.readAllowedExtensions('github', 'user@example.com');
+			assert.strictEqual(result.length, 2); // 1 trusted + 1 regular
+
+			// Remove stored extensions
+			authenticationAccessService.removeAllowedExtensions('github', 'user@example.com');
+
+			// Trusted extension should still be there
+			result = authenticationAccessService.readAllowedExtensions('github', 'user@example.com');
+			assert.strictEqual(result.length, 1);
+			assert.strictEqual(result[0].id, 'trusted-extension');
+			assert.strictEqual(result[0].trusted, true);
+		});
+	});
+
+	suite('integration with product.json configurations', () => {
+		test('handles switching between array and object format', () => {
+			// Start with array format
+			productService.trustedExtensionAuthAccess = ['ext1', 'ext2'];
+			let result = authenticationAccessService.readAllowedExtensions('github', 'user@example.com');
+			assert.strictEqual(result.length, 2);
+
+			// Switch to object format
+			productService.trustedExtensionAuthAccess = {
+				'github': ['ext1', 'ext3'],
+				'microsoft': ['ext4']
+			};
+			result = authenticationAccessService.readAllowedExtensions('github', 'user@example.com');
+			assert.strictEqual(result.length, 2); // ext1 and ext3 for github
+			assert.ok(result.find(e => e.id === 'ext1'));
+			assert.ok(result.find(e => e.id === 'ext3'));
+			assert.ok(!result.find(e => e.id === 'ext2')); // Should not be there anymore
+		});
+
+		test('handles empty trusted extension configurations', () => {
+			// Test undefined
+			productService.trustedExtensionAuthAccess = undefined;
+			let result = authenticationAccessService.readAllowedExtensions('github', 'user@example.com');
+			assert.strictEqual(result.length, 0);
+
+			// Test empty array
+			productService.trustedExtensionAuthAccess = [];
+			result = authenticationAccessService.readAllowedExtensions('github', 'user@example.com');
+			assert.strictEqual(result.length, 0);
+
+			// Test empty object
+			productService.trustedExtensionAuthAccess = {};
+			result = authenticationAccessService.readAllowedExtensions('github', 'user@example.com');
+			assert.strictEqual(result.length, 0);
+		});
+	});
+});


### PR DESCRIPTION
This adopts the AuthenticationQueryService in:
1. Manage Trusted Extensions quick pick
2. An MCP server's Quick Pick (shows Sign Out or Disconnect account)
3. An MCP server's view (shows Sign Out or Disconnect account)
4. Depend on this service instead of some sily map in the MCP Registry
5. Have the `AuthenticationAccessService` own looking at the product.json so that implementers don't need to know about it

This also contains a number of squashed bugs...

1. We were not cleaning up storage state when an extension or mcp server was uninstalled
2. The Extension Access service wasn't using `ExtensionIdentifier.toKey`

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

![image](https://github.com/user-attachments/assets/6131090f-8015-49b4-9e7b-8adb0e1e76a5)
![image](https://github.com/user-attachments/assets/e8f3a8a8-0922-4102-af0e-e36b9fdfdfb5)
