### PR TITLE
Remove chat agent all models logic

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
@@ -558,10 +558,6 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 	private modelSupportedForDefaultAgent(model: ILanguageModelChatMetadataAndIdentifier): boolean {
 		// Probably this logic could live in configuration on the agent, or somewhere else, if it gets more complex
 		if (this.currentMode === ChatMode.Agent || (this.currentMode === ChatMode.Edit && this.configurationService.getValue(ChatConfiguration.Edits2Enabled))) {
-			if (this.configurationService.getValue('chat.agent.allModels')) {
-				return true;
-			}
-
 			const supportsToolsAgent = typeof model.metadata.capabilities?.agentMode === 'undefined' || model.metadata.capabilities.agentMode;
 
 			// Filter out models that don't support tool calling, and models that don't support enough context to have a good experience with the tools agent


### PR DESCRIPTION
This PR removes or refactors logic related to supporting all models for the chat agent. See `chatInputPart.ts` for details on the changes.