### PR TITLE
Fix: Add restart button to Running Extensions view (#250201)

### DIFF
--- a/src/vs/workbench/contrib/extensions/browser/abstractRuntimeExtensionsEditor.ts
+++ b/src/vs/workbench/contrib/extensions/browser/abstractRuntimeExtensionsEditor.ts
@@ -294,7 +294,7 @@ export abstract class AbstractRuntimeExtensionsEditor extends EditorPane {
 				}
 
 				data.actionbar.clear();
-				
+
 				// Add restart action if needed
 				if (element.marketplaceInfo) {
 					const restartAction = this._instantiationService.createInstance(ExtensionRuntimeStateAction);
@@ -304,7 +304,7 @@ export abstract class AbstractRuntimeExtensionsEditor extends EditorPane {
 						data.elementDisposables.push(restartAction);
 					}
 				}
-				
+
 				const slowExtensionAction = this._createSlowExtensionAction(element);
 				if (slowExtensionAction) {
 					data.actionbar.push(slowExtensionAction, { icon: false, label: true });

--- a/src/vs/workbench/contrib/extensions/browser/abstractRuntimeExtensionsEditor.ts
+++ b/src/vs/workbench/contrib/extensions/browser/abstractRuntimeExtensionsEditor.ts
@@ -46,6 +46,7 @@ import { RuntimeExtensionsInput } from '../common/runtimeExtensionsInput.js';
 import { errorIcon, warningIcon } from './extensionsIcons.js';
 import { ExtensionIconWidget } from './extensionsWidgets.js';
 import './media/runtimeExtensionsEditor.css';
+import { ExtensionRuntimeStateAction } from './extensionsActions.js';
 
 interface IExtensionProfileInformation {
 	/**
@@ -293,6 +294,17 @@ export abstract class AbstractRuntimeExtensionsEditor extends EditorPane {
 				}
 
 				data.actionbar.clear();
+				
+				// Add restart action if needed
+				if (element.marketplaceInfo) {
+					const restartAction = this._instantiationService.createInstance(ExtensionRuntimeStateAction);
+					restartAction.extension = element.marketplaceInfo;
+					if (restartAction.enabled) {
+						data.actionbar.push(restartAction, { icon: false, label: true });
+						data.elementDisposables.push(restartAction);
+					}
+				}
+				
 				const slowExtensionAction = this._createSlowExtensionAction(element);
 				if (slowExtensionAction) {
 					data.actionbar.push(slowExtensionAction, { icon: false, label: true });


### PR DESCRIPTION
**Fixes #250201**

## Summary
This PR adds the restart button functionality to the Running Extensions view, ensuring consistency with the main Extensions view behavior when disabling extensions.

## Problem
When extensions are disabled from the Running Extensions view (View → Extensions → Show Running Extensions), no restart button appears to notify users that extensions need to be restarted. This is inconsistent with the main Extensions view which properly shows a "Restart Extensions" button.

## Solution
- Import `ExtensionRuntimeStateAction` in `abstractRuntimeExtensionsEditor.ts`
- Add restart action to the actionbar in the `renderElement` method
- Ensure the action is only added when `element.marketplaceInfo` exists and the action is enabled
- Properly dispose of the action with `elementDisposables` to prevent memory leaks

## Changes Made
- **File**: `src/vs/workbench/contrib/extensions/browser/abstractRuntimeExtensionsEditor.ts`
  - Added import for `ExtensionRuntimeStateAction`
  - Modified `renderElement` method to include restart action in actionbar
  - Added proper disposal management

## Testing Steps
1. Open VSCode
2. Install and enable some extensions
3. Go to **View → Extensions → Show Running Extensions**
4. Right-click on a running extension and select **Disable**
5. ✅ **Verify**: A restart button now appears (previously this was missing)
6. ✅ **Verify**: Clicking the restart button properly restarts extensions
7. ✅ **Verify**: Behavior matches the main Extensions view

## Checklist
- [x] Code is up-to-date with the `main` branch
- [x] Associated with issue #250201
- [x] Follows existing code patterns and conventions
- [x] Maintains backward compatibility
- [x] Includes proper resource disposal
