### PR TITLE
Open URL command: remember the last URL

### DIFF
--- a/src/vs/workbench/contrib/url/browser/url.contribution.ts
+++ b/src/vs/workbench/contrib/url/browser/url.contribution.ts
@@ -22,8 +22,11 @@ import { ConfigurationScope, Extensions as ConfigurationExtensions, IConfigurati
 import { workbenchConfigurationNodeBase } from '../../../common/configuration.js';
 import { ITrustedDomainService, TrustedDomainService } from './trustedDomainService.js';
 import { registerSingleton, InstantiationType } from '../../../../platform/instantiation/common/extensions.js';
+import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
 
 class OpenUrlAction extends Action2 {
+
+	static readonly STORAGE_KEY = 'workbench.action.url.openUrl.lastInput';
 
 	constructor() {
 		super({
@@ -37,11 +40,15 @@ class OpenUrlAction extends Action2 {
 	async run(accessor: ServicesAccessor): Promise<void> {
 		const quickInputService = accessor.get(IQuickInputService);
 		const urlService = accessor.get(IURLService);
+		const storageService = accessor.get(IStorageService);
 
-		return quickInputService.input({ prompt: localize('urlToOpen', "URL to open") }).then(input => {
+		const value = storageService.get(OpenUrlAction.STORAGE_KEY, StorageScope.WORKSPACE, '');
+
+		return quickInputService.input({ prompt: localize('urlToOpen', "URL to open"), value }).then(input => {
 			if (input) {
 				const uri = URI.parse(input);
 				urlService.open(uri, { originalUrl: input });
+				storageService.store(OpenUrlAction.STORAGE_KEY, input, StorageScope.WORKSPACE, StorageTarget.MACHINE);
 			}
 		});
 	}


### PR DESCRIPTION
`Developer: Open URL` is a developer command to test URL handlers.

This PR populates the inpt dialog with the previous input to speed up testing URL handlers