### PR TITLE
linux: fallback to xdg-portal-required-version 3 for COSMIC

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -20,6 +20,7 @@ import { resolveNLSConfiguration } from './vs/base/node/nls.js';
 import { getUNCHost, addUNCHostToAllowlist } from './vs/base/node/unc.js';
 import { INLSConfiguration } from './vs/nls.js';
 import { NativeParsedArgs } from './vs/platform/environment/common/argv.js';
+import { getDesktopEnvironment } from './vs/base/common/desktopEnvironmentInfo.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -350,7 +351,9 @@ function configureCommandlineSwitchesSync(cliArgs: NativeParsedArgs) {
 	// Use portal version 4 that supports current_folder option
 	// to address https://github.com/microsoft/vscode/issues/213780
 	// Runtime sets the default version to 3, refs https://github.com/electron/electron/pull/44426
-	app.commandLine.appendSwitch('xdg-portal-required-version', '4');
+	if (process.platform === 'linux' && getDesktopEnvironment() !== 'COSMIC') {
+		app.commandLine.appendSwitch('xdg-portal-required-version', '4');
+	}
 
 	return argvConfig;
 }

--- a/src/vs/base/common/desktopEnvironmentInfo.ts
+++ b/src/vs/base/common/desktopEnvironmentInfo.ts
@@ -9,6 +9,7 @@ import { env } from './process.js';
 enum DesktopEnvironment {
 	UNKNOWN = 'UNKNOWN',
 	CINNAMON = 'CINNAMON',
+	COSMIC = 'COSMIC',
 	DEEPIN = 'DEEPIN',
 	GNOME = 'GNOME',
 	KDE3 = 'KDE3',
@@ -59,6 +60,8 @@ export function getDesktopEnvironment(): DesktopEnvironment {
 					return DesktopEnvironment.UKUI;
 				case 'LXQt':
 					return DesktopEnvironment.LXQT;
+				case 'COSMIC':
+					return DesktopEnvironment.COSMIC;
 			}
 		}
 	}


### PR DESCRIPTION
This fixes #252497 

This PR does a few small things:
- Add a definition for COSMIC to `desktopEnvironmentInfo.js`
- Use that in `src/main.ts` to optionally ignore the `xdg-portal-required-version` change for COSMIC 