### PR TITLE
Revert "Use Code OSS GitHub client id"

### DIFF
--- a/extensions/github-authentication/src/config.ts
+++ b/extensions/github-authentication/src/config.ts
@@ -15,5 +15,5 @@ export interface IConfig {
 // not really a secret... so we allow the client secret in code. It is brought in before we publish VS Code. Reference:
 // https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/best-practices-for-creating-an-oauth-app#client-secrets
 export const Config: IConfig = {
-	gitHubClientId: 'a5d3c261b032765a78de'
+	gitHubClientId: '01ab8ac9400c4e429b23'
 };


### PR DESCRIPTION
Reverts microsoft/vscode#252426

There's some weird issue with Copilot's https://api.github.com/copilot_internal/user API returns:

```json
{
	"access_type_sku": "copilot_enterprise_seat_multi_quota",
	"analytics_tracking_id": "bc403bb7a21415ccbf0abc7e1b9be4b2",
	"assigned_date": null,
	"can_signup_for_limited": false,
	"chat_enabled": false,
	"copilot_plan": "individual",
	"organization_login_list": [],
	"organization_list": [],
	"quota_reset_date": "2025-07-01",
	"quota_snapshots": {
		"chat": {
			"entitlement": 1000,
			"overage_count": 0,
			"overage_permitted": true,
			"percent_remaining": 100.0,
			"quota_id": "chat",
			"quota_remaining": 0.0,
			"remaining": 1000,
			"unlimited": true
		},
		"completions": {
			"entitlement": 1000,
			"overage_count": 0,
			"overage_permitted": true,
			"percent_remaining": 100.0,
			"quota_id": "completions",
			"quota_remaining": 0.0,
			"remaining": 1000,
			"unlimited": true
		},
		"premium_interactions": {
			"entitlement": 1000,
			"overage_count": 0,
			"overage_permitted": true,
			"percent_remaining": 100.0,
			"quota_id": "premium_interactions",
			"quota_remaining": 0.0,
			"remaining": 1000,
			"unlimited": true
		}
	}
}
```
Instead of:
```json
{
	"access_type_sku": "copilot_enterprise_seat_multi_quota",
	"analytics_tracking_id": "bc403bb7a21415ccbf0abc7e1b9be4b2",
	"assigned_date": "2024-01-06T14:10:35-08:00",
	"can_signup_for_limited": false,
	"chat_enabled": true,
	"copilot_plan": "enterprise",
	"organization_login_list": [
		"github",
		"microsoft"
	],
	"organization_list": [
		{
			"login": "github",
			"name": "GitHub"
		},
		{
			"login": "microsoft",
			"name": "Microsoft"
		}
	],
	"quota_reset_date": "2025-07-01",
	"quota_snapshots": {
		"chat": {
			"entitlement": 1000,
			"overage_count": 0,
			"overage_permitted": true,
			"percent_remaining": 100.0,
			"quota_id": "chat",
			"quota_remaining": 0.0,
			"remaining": 1000,
			"unlimited": true
		},
		"completions": {
			"entitlement": 1000,
			"overage_count": 0,
			"overage_permitted": true,
			"percent_remaining": 100.0,
			"quota_id": "completions",
			"quota_remaining": 0.0,
			"remaining": 1000,
			"unlimited": true
		},
		"premium_interactions": {
			"entitlement": 1000,
			"overage_count": 0,
			"overage_permitted": true,
			"percent_remaining": 100.0,
			"quota_id": "premium_interactions",
			"quota_remaining": 0.0,
			"remaining": 1000,
			"unlimited": true
		}
	}
}
```

The difference:
* `chat_enabled`
* `organization_list` & `organization_login_list`
* `copilot_plan`
* `assigned_date`

Why? Not sure. GitHub will have to investigate. We can't move back to this until this is resolved.