### PR TITLE
feat: add core experimentation service for startup experiments

### DIFF
--- a/src/vs/workbench/services/coreExperimentation/common/coreExperimentationService.ts
+++ b/src/vs/workbench/services/coreExperimentation/common/coreExperimentationService.ts
@@ -1,0 +1,178 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Disposable } from '../../../../base/common/lifecycle.js';
+import { InstantiationType, registerSingleton } from '../../../../platform/instantiation/common/extensions.js';
+import { IProductService } from '../../../../platform/product/common/productService.js';
+import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
+import { firstSessionDateStorageKey, ITelemetryService } from '../../../../platform/telemetry/common/telemetry.js';
+import { createDecorator } from '../../../../platform/instantiation/common/instantiation.js';
+import { IContextKeyService, RawContextKey } from '../../../../platform/contextkey/common/contextkey.js';
+
+export const ICoreExperimentationService = createDecorator<ICoreExperimentationService>('coreExperimentationService');
+export const startupExpContext = new RawContextKey<string>('coreExperimentation.startupExpGroup', '');
+
+interface IExperiment {
+	cohort: number;
+	subCohort: number; // Optional for future use
+	experimentGroup: string;
+	iteration: number;
+	isInExperiment: boolean;
+}
+
+export interface ICoreExperimentationService {
+	readonly _serviceBrand: undefined;
+	getExperiment(experimentName: string): IExperiment | undefined;
+}
+
+interface IExperimentDefinition {
+	name: string;
+	targetPercentage: number;
+	treatments: { name: string; percentage: number }[];
+	iteration: number;
+}
+
+export class CoreExperimentationService extends Disposable implements ICoreExperimentationService {
+	declare readonly _serviceBrand: undefined;
+
+	private readonly experiments = new Map<string, IExperiment>();
+
+	constructor(
+		@IStorageService private readonly storageService: IStorageService,
+		@ITelemetryService private readonly telemetryService: ITelemetryService,
+		@IProductService private readonly productService: IProductService,
+		@IContextKeyService private readonly contextKeyService: IContextKeyService
+	) {
+		super();
+		this.initializeExperiments();
+	}
+
+	private initializeExperiments(): void {
+
+		const firstSessionDateString = this.storageService.get(firstSessionDateStorageKey, StorageScope.APPLICATION) || new Date().toUTCString();
+		const daysSinceFirstSession = ((+new Date()) - (+new Date(firstSessionDateString))) / 1000 / 60 / 60 / 24;
+		if (daysSinceFirstSession > 1) {
+			// not a startup exp candidate.
+			return;
+		}
+
+		const expName = 'startupExp';
+		// also check storage to see if this user has already seen the startup experience
+		const storageKey = `coreExperimentation.${expName}`;
+		const storedExperiment = this.storageService.get(storageKey, StorageScope.APPLICATION);
+		if (storedExperiment) {
+			return;
+		}
+
+		// check that this is a new launch scenario.
+		const startupLayoutExperiment: IExperimentDefinition = {
+			name: expName,
+			targetPercentage: this.getTargetPercentage(),
+			treatments: [
+				{ name: 'control', percentage: 25 },
+				{ name: 'maximizedChat', percentage: 25 },
+				{ name: 'splitEmptyEditorChat', percentage: 25 },
+				{ name: 'splitWelcomeChat', percentage: 25 }
+			],
+			iteration: 1
+		};
+
+		const experiment = this.createExperiment(startupLayoutExperiment, storageKey);
+		if (experiment) {
+			this.experiments.set(startupLayoutExperiment.name, experiment);
+			this.sendExperimentTelemetry(startupLayoutExperiment.name, experiment);
+			startupExpContext.bindTo(this.contextKeyService).set(experiment.experimentGroup);
+		}
+	}
+
+	private getTargetPercentage(): number {
+		const quality = this.productService.quality;
+		if (quality === 'stable') {
+			return 20;
+		} else if (quality === 'insider') {
+			return 20;
+		}
+		return 100;
+	}
+
+	private createExperiment(definition: IExperimentDefinition, storageKey: string): IExperiment | undefined {
+		const newExperiment = this.createNewExperiment(definition);
+		if (newExperiment) {
+			this.storageService.store(
+				storageKey,
+				JSON.stringify(newExperiment),
+				StorageScope.APPLICATION,
+				StorageTarget.MACHINE
+			);
+		}
+		return newExperiment;
+	}
+
+	private createNewExperiment(definition: IExperimentDefinition): IExperiment | undefined {
+		const cohort = Math.random();
+
+		if (cohort >= definition.targetPercentage / 100) {
+			return undefined;
+		}
+
+		// Normalize the cohort to the experiment range [0, targetPercentage/100]
+		const normalizedCohort = cohort / (definition.targetPercentage / 100);
+
+		let cumulativePercentage = 0;
+		for (const treatment of definition.treatments) {
+			cumulativePercentage += treatment.percentage;
+			if (normalizedCohort * 100 <= cumulativePercentage) {
+				return {
+					cohort,
+					subCohort: normalizedCohort,
+					experimentGroup: treatment.name,
+					iteration: definition.iteration,
+					isInExperiment: true
+				};
+			}
+		}
+		return undefined;
+	}
+
+	private sendExperimentTelemetry(experimentName: string, experiment: IExperiment): void {
+		type ExperimentCohortClassification = {
+			owner: 'bhavyaus';
+			comment: 'Records which experiment cohort the user is in for core experiments';
+			experimentName: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The name of the experiment' };
+			cohort: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The exact cohort number for the user' };
+			subCohort: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The exact sub-cohort number for the user in the experiment cohort' };
+			experimentGroup: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The experiment group the user is in' };
+			iteration: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The iteration number for the experiment' };
+			isInExperiment: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Whether the user is in the experiment' };
+		};
+
+		type ExperimentCohortEvent = {
+			experimentName: string;
+			cohort: number;
+			subCohort: number;
+			experimentGroup: string;
+			iteration: number;
+			isInExperiment: boolean;
+		};
+
+		this.telemetryService.publicLog2<ExperimentCohortEvent, ExperimentCohortClassification>(
+			`coreExperimentation.experimentCohort`,
+			{
+				experimentName,
+				cohort: experiment.cohort,
+				subCohort: experiment.subCohort,
+				experimentGroup: experiment.experimentGroup,
+				iteration: experiment.iteration,
+				isInExperiment: experiment.isInExperiment
+			}
+		);
+	}
+
+	getExperiment(experimentName: string): IExperiment | undefined {
+		return this.experiments.get(experimentName);
+	}
+}
+
+registerSingleton(ICoreExperimentationService, CoreExperimentationService, InstantiationType.Delayed);

--- a/src/vs/workbench/services/coreExperimentation/common/coreExperimentationService.ts
+++ b/src/vs/workbench/services/coreExperimentation/common/coreExperimentationService.ts
@@ -17,7 +17,7 @@ export const startupExpContext = new RawContextKey<string>('coreExperimentation.
 interface IExperiment {
 	cohort: number;
 	subCohort: number; // Optional for future use
-	experimentGroup: string;
+	experimentGroup: StartupExperimentGroup;
 	iteration: number;
 	isInExperiment: boolean;
 }
@@ -28,7 +28,7 @@ export interface ICoreExperimentationService {
 }
 
 interface ExperimentGroupDefinition {
-	name: string;
+	name: StartupExperimentGroup;
 	min: number;
 	max: number;
 	iteration: number;
@@ -40,7 +40,7 @@ interface ExperimentConfiguration {
 	groups: ExperimentGroupDefinition[];
 }
 
-enum StartupExperimentGroup {
+export enum StartupExperimentGroup {
 	Control = 'control',
 	MaximizedChat = 'maximizedChat',
 	SplitEmptyEditorChat = 'splitEmptyEditorChat',

--- a/src/vs/workbench/services/coreExperimentation/common/coreExperimentationService.ts
+++ b/src/vs/workbench/services/coreExperimentation/common/coreExperimentationService.ts
@@ -66,7 +66,6 @@ export class CoreExperimentationService extends Disposable implements ICoreExper
 			return;
 		}
 
-		// check that this is a new launch scenario.
 		const startupLayoutExperiment: IExperimentDefinition = {
 			name: expName,
 			targetPercentage: this.getTargetPercentage(),
@@ -79,11 +78,17 @@ export class CoreExperimentationService extends Disposable implements ICoreExper
 			iteration: 1
 		};
 
-		const experiment = this.createExperiment(startupLayoutExperiment, storageKey);
+		const experiment = this.createNewExperiment(startupLayoutExperiment);
 		if (experiment) {
 			this.experiments.set(startupLayoutExperiment.name, experiment);
 			this.sendExperimentTelemetry(startupLayoutExperiment.name, experiment);
 			startupExpContext.bindTo(this.contextKeyService).set(experiment.experimentGroup);
+			this.storageService.store(
+				storageKey,
+				JSON.stringify(experiment),
+				StorageScope.APPLICATION,
+				StorageTarget.MACHINE
+			);
 		}
 	}
 
@@ -94,20 +99,7 @@ export class CoreExperimentationService extends Disposable implements ICoreExper
 		} else if (quality === 'insider') {
 			return 20;
 		}
-		return 100;
-	}
-
-	private createExperiment(definition: IExperimentDefinition, storageKey: string): IExperiment | undefined {
-		const newExperiment = this.createNewExperiment(definition);
-		if (newExperiment) {
-			this.storageService.store(
-				storageKey,
-				JSON.stringify(newExperiment),
-				StorageScope.APPLICATION,
-				StorageTarget.MACHINE
-			);
-		}
-		return newExperiment;
+		return 0;
 	}
 
 	private createNewExperiment(definition: IExperimentDefinition): IExperiment | undefined {

--- a/src/vs/workbench/services/coreExperimentation/test/browser/coreExperimentationService.test.ts
+++ b/src/vs/workbench/services/coreExperimentation/test/browser/coreExperimentationService.test.ts
@@ -1,0 +1,326 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { MockContextKeyService } from '../../../../../platform/keybinding/test/common/mockKeybindingService.js';
+import { CoreExperimentationService, startupExpContext } from '../../common/coreExperimentationService.js';
+import { firstSessionDateStorageKey, ITelemetryService, ITelemetryData, TelemetryLevel } from '../../../../../platform/telemetry/common/telemetry.js';
+import { StorageScope, StorageTarget } from '../../../../../platform/storage/common/storage.js';
+import { TestStorageService } from '../../../../test/common/workbenchTestServices.js';
+import { IProductService } from '../../../../../platform/product/common/productService.js';
+
+interface ITelemetryEvent {
+	eventName: string;
+	data: ITelemetryData;
+}
+
+class MockTelemetryService implements ITelemetryService {
+	declare readonly _serviceBrand: undefined;
+
+	public events: ITelemetryEvent[] = [];
+	public readonly telemetryLevel = TelemetryLevel.USAGE;
+	public readonly sessionId = 'test-session';
+	public readonly machineId = 'test-machine';
+	public readonly sqmId = 'test-sqm';
+	public readonly devDeviceId = 'test-device';
+	public readonly firstSessionDate = 'test-date';
+	public readonly sendErrorTelemetry = true;
+
+	publicLog2<E, T>(eventName: string, data?: E): void {
+		this.events.push({ eventName, data: (data as ITelemetryData) || {} });
+	}
+
+	publicLog(eventName: string, data?: ITelemetryData): void {
+		this.events.push({ eventName, data: data || {} });
+	}
+
+	publicLogError(eventName: string, data?: ITelemetryData): void {
+		this.events.push({ eventName, data: data || {} });
+	}
+
+	publicLogError2<E, T>(eventName: string, data?: E): void {
+		this.events.push({ eventName, data: (data as ITelemetryData) || {} });
+	}
+
+	setExperimentProperty(): void { }
+}
+
+class MockProductService implements IProductService {
+	declare readonly _serviceBrand: undefined;
+
+	public quality: string = 'stable';
+
+	get version() { return '1.0.0'; }
+	get commit() { return 'test-commit'; }
+	get nameLong() { return 'Test VSCode'; }
+	get nameShort() { return 'VSCode'; }
+	get applicationName() { return 'test-vscode'; }
+	get serverApplicationName() { return 'test-server'; }
+	get dataFolderName() { return '.test-vscode'; }
+	get urlProtocol() { return 'test-vscode'; }
+	get extensionAllowedProposedApi() { return []; }
+	get extensionProperties() { return {}; }
+}
+
+suite('CoreExperimentationService', () => {
+	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
+
+	let storageService: TestStorageService;
+	let telemetryService: MockTelemetryService;
+	let productService: MockProductService;
+	let contextKeyService: MockContextKeyService;
+
+	setup(() => {
+		storageService = disposables.add(new TestStorageService());
+		telemetryService = new MockTelemetryService();
+		productService = new MockProductService();
+		contextKeyService = new MockContextKeyService();
+	});
+
+	test('should not initialize experiment if user has already seen startup experience (found in storage)', () => {
+		storageService.store(firstSessionDateStorageKey, new Date().toUTCString(), StorageScope.APPLICATION, StorageTarget.MACHINE);
+
+		// Set that user has already seen the experiment
+		const existingExperiment = {
+			cohort: 0.5,
+			subCohort: 0.5,
+			experimentGroup: 'control',
+			iteration: 1,
+			isInExperiment: true
+		};
+		storageService.store('coreExperimentation.startup', JSON.stringify(existingExperiment), StorageScope.APPLICATION, StorageTarget.MACHINE);
+
+		const service = disposables.add(new CoreExperimentationService(
+			storageService,
+			telemetryService,
+			productService,
+			contextKeyService
+		));
+
+		// Should not return experiment again
+		assert.strictEqual(service.getExperiment(), undefined);
+
+		// No telemetry should be sent for new experiment
+		assert.strictEqual(telemetryService.events.length, 0);
+	});
+
+	test('should initialize experiment for new user in first session and set context key', () => {
+		// Set first session date to today
+		storageService.store(firstSessionDateStorageKey, new Date().toUTCString(), StorageScope.APPLICATION, StorageTarget.MACHINE);
+
+		// Mock Math.random to return a value that puts user in experiment
+		const originalMathRandom = Math.random;
+		Math.random = () => 0.1; // 10% - should be in experiment for all quality levels
+
+		try {
+			const service = disposables.add(new CoreExperimentationService(
+				storageService,
+				telemetryService,
+				productService,
+				contextKeyService
+			));
+
+			// Should create experiment
+			const experiment = service.getExperiment();
+			assert(experiment, 'Experiment should be defined');
+			assert.strictEqual(experiment.isInExperiment, true);
+			assert.strictEqual(experiment.iteration, 1);
+			assert(experiment.cohort >= 0 && experiment.cohort < 1, 'Cohort should be between 0 and 1');
+			assert(['control', 'maximizedChat', 'splitEmptyEditorChat', 'splitWelcomeChat'].includes(experiment.experimentGroup),
+				'Experiment group should be one of the defined treatments');
+
+			// Context key should be set to experiment group
+			const contextValue = startupExpContext.getValue(contextKeyService);
+			assert.strictEqual(contextValue, experiment.experimentGroup,
+				'Context key should be set to experiment group');
+		} finally {
+			Math.random = originalMathRandom;
+		}
+	});
+
+	test('should emit telemetry when experiment is created', () => {
+		// Set first session date to today
+		storageService.store(firstSessionDateStorageKey, new Date().toUTCString(), StorageScope.APPLICATION, StorageTarget.MACHINE);
+
+		// Mock Math.random to return a value that puts user in experiment
+		const originalMathRandom = Math.random;
+		Math.random = () => 0.1; // 10% - should be in experiment
+
+		try {
+			const service = disposables.add(new CoreExperimentationService(
+				storageService,
+				telemetryService,
+				productService,
+				contextKeyService
+			));
+
+			const experiment = service.getExperiment();
+			assert(experiment, 'Experiment should be defined');
+
+			// Check that telemetry was sent
+			assert.strictEqual(telemetryService.events.length, 1);
+			const telemetryEvent = telemetryService.events[0];
+			assert.strictEqual(telemetryEvent.eventName, 'coreExperimentation.experimentCohort');
+			// Verify telemetry data
+			const data = telemetryEvent.data as any;
+			assert.strictEqual(data.experimentName, 'startup');
+			assert.strictEqual(data.cohort, experiment.cohort);
+			assert.strictEqual(data.subCohort, experiment.subCohort);
+			assert.strictEqual(data.experimentGroup, experiment.experimentGroup);
+			assert.strictEqual(data.iteration, experiment.iteration);
+			assert.strictEqual(data.isInExperiment, experiment.isInExperiment);
+		} finally {
+			Math.random = originalMathRandom;
+		}
+	});
+
+	test('should not include user in experiment if random value exceeds target percentage', () => {
+		// Set first session date to today
+		storageService.store(firstSessionDateStorageKey, new Date().toUTCString(), StorageScope.APPLICATION, StorageTarget.MACHINE);
+		productService.quality = 'stable'; // 20% target
+
+		// Mock Math.random to return a value outside experiment range
+		const originalMathRandom = Math.random;
+		Math.random = () => 0.25; // 25% - should be outside 20% target for stable
+
+		try {
+			const service = disposables.add(new CoreExperimentationService(
+				storageService,
+				telemetryService,
+				productService,
+				contextKeyService
+			));
+
+			// Should not create experiment
+			const experiment = service.getExperiment();
+			assert.strictEqual(experiment, undefined);
+
+			// No telemetry should be sent
+			assert.strictEqual(telemetryService.events.length, 0);
+		} finally {
+			Math.random = originalMathRandom;
+		}
+	});
+
+	test('should assign correct experiment group based on cohort normalization', () => {
+		// Set first session date to today
+		storageService.store(firstSessionDateStorageKey, new Date().toUTCString(), StorageScope.APPLICATION, StorageTarget.MACHINE);
+		productService.quality = 'stable'; // 20% target
+
+		const testCases = [
+			{ random: 0.02, expectedGroup: 'control' }, // 2% -> 10% normalized -> first 25% of experiment
+			{ random: 0.07, expectedGroup: 'maximizedChat' }, // 7% -> 35% normalized -> second 25% of experiment
+			{ random: 0.12, expectedGroup: 'splitEmptyEditorChat' }, // 12% -> 60% normalized -> third 25% of experiment
+			{ random: 0.17, expectedGroup: 'splitWelcomeChat' } // 17% -> 85% normalized -> fourth 25% of experiment
+		];
+
+		const originalMathRandom = Math.random;
+
+		try {
+			for (const testCase of testCases) {
+				Math.random = () => testCase.random;
+				storageService.remove('coreExperimentation.startup', StorageScope.APPLICATION);
+				telemetryService.events = []; // Reset telemetry events
+
+				const service = disposables.add(new CoreExperimentationService(
+					storageService,
+					telemetryService,
+					productService,
+					contextKeyService
+				));
+
+				const experiment = service.getExperiment();
+				assert(experiment, `Experiment should be defined for random ${testCase.random}`);
+				assert.strictEqual(experiment.experimentGroup, testCase.expectedGroup,
+					`Expected group ${testCase.expectedGroup} for random ${testCase.random}, got ${experiment.experimentGroup}`);
+			}
+		} finally {
+			Math.random = originalMathRandom;
+		}
+	});
+
+	test('should store experiment in storage when created', () => {
+		// Set first session date to today
+		storageService.store(firstSessionDateStorageKey, new Date().toUTCString(), StorageScope.APPLICATION, StorageTarget.MACHINE);
+
+		const originalMathRandom = Math.random;
+		Math.random = () => 0.1; // Ensure user is in experiment
+
+		try {
+			const service = disposables.add(new CoreExperimentationService(
+				storageService,
+				telemetryService,
+				productService,
+				contextKeyService
+			));
+
+			const experiment = service.getExperiment();
+			assert(experiment, 'Experiment should be defined');
+
+			// Check that experiment was stored
+			const storedValue = storageService.get('coreExperimentation.startup', StorageScope.APPLICATION);
+			assert(storedValue, 'Experiment should be stored');
+
+			const storedExperiment = JSON.parse(storedValue);
+			assert.strictEqual(storedExperiment.experimentGroup, experiment.experimentGroup);
+			assert.strictEqual(storedExperiment.iteration, experiment.iteration);
+			assert.strictEqual(storedExperiment.isInExperiment, experiment.isInExperiment);
+			assert.strictEqual(storedExperiment.cohort, experiment.cohort);
+			assert.strictEqual(storedExperiment.subCohort, experiment.subCohort);
+		} finally {
+			Math.random = originalMathRandom;
+		}
+	});
+
+	test('should handle missing first session date by using current date', () => {
+		// Don't set first session date - service should use current date
+		const originalMathRandom = Math.random;
+		Math.random = () => 0.1; // Ensure user would be in experiment
+
+		try {
+			const service = disposables.add(new CoreExperimentationService(
+				storageService,
+				telemetryService,
+				productService,
+				contextKeyService
+			));
+
+			const experiment = service.getExperiment();
+			assert(experiment, 'Experiment should be defined when first session date is missing');
+			assert.strictEqual(telemetryService.events.length, 1);
+		} finally {
+			Math.random = originalMathRandom;
+		}
+	});
+
+	test('should handle sub-cohort calculation correctly', () => {
+		// Set first session date to today
+		storageService.store(firstSessionDateStorageKey, new Date().toUTCString(), StorageScope.APPLICATION, StorageTarget.MACHINE);
+		productService.quality = 'stable'; // 20% target
+
+		const originalMathRandom = Math.random;
+		Math.random = () => 0.1; // 10% cohort -> 50% normalized sub-cohort
+
+		try {
+			const service = disposables.add(new CoreExperimentationService(
+				storageService,
+				telemetryService,
+				productService,
+				contextKeyService
+			));
+
+			const experiment = service.getExperiment();
+			assert(experiment, 'Experiment should be defined');
+
+			// Verify sub-cohort calculation
+			const expectedSubCohort = 0.1 / (20 / 100); // 0.1 / 0.2 = 0.5
+			assert.strictEqual(experiment.subCohort, expectedSubCohort,
+				'Sub-cohort should be correctly normalized');
+		} finally {
+			Math.random = originalMathRandom;
+		}
+	});
+});

--- a/src/vs/workbench/workbench.common.main.ts
+++ b/src/vs/workbench/workbench.common.main.ts
@@ -130,6 +130,7 @@ import './services/userActivity/common/userActivityService.js';
 import './services/userActivity/browser/userActivityBrowser.js';
 import './services/editor/browser/editorPaneService.js';
 import './services/editor/common/customEditorLabelService.js';
+import './services/coreExperimentation/common/coreExperimentationService.js';
 
 import { InstantiationType, registerSingleton } from '../platform/instantiation/common/extensions.js';
 import { GlobalExtensionEnablementService } from '../platform/extensionManagement/common/extensionEnablementService.js';


### PR DESCRIPTION
## Core Experimentation Service for Startup Layout Experiments

This PR introduces a new `CoreExperimentationService` to manage A/B testing experiments for VS Code startup experiences.

### How the Service Works (Pseudocode)

```
1. On service initialization:
   IF user's first session was more than 1 day ago:
     RETURN (not eligible for startup experiments)
   
   IF experiment already exists in storage:
     RETURN (user already participated)
   
   2. Generate random cohort (0-1)
   
   3. Check if user falls within target percentage:
      - Stable builds: 20% participation  
      - Insider builds: 20% participation
   
   4. IF user is selected:
      - Normalize cohort to experiment range
      - Assign to experiment group based on normalized value:
        * [0-25%): Control group
        * [25-50%): Maximized Chat
        * [50-75%): Split Empty Editor Chat  
        * [75-100%): Split Welcome Chat
      
      - Store experiment data in application storage
      - Set context key for UI consumption
      - Send telemetry event
```

#### Service  Usage
```typescript

// Get current user's experiment (returns undefined if not in experiment)
const exp:IExperiment = this.coreExperimentationService.getExperiment();

if (exp?.experimentGroup) {
// Valid values (see StartupExperimentGroup enum): 'control', 'maximizedChat', 'splitEmptyEditorChat', 'splitWelcomeChat'
}
```

#### Context Key Usage
The service sets a context key:

```typescript
// Context key: 'coreExperimentation.startupExpGroup'
// Valid values (see StartupExperimentGroup enum): 'control', 'maximizedChat', 'splitEmptyEditorChat', 'splitWelcomeChat'
```

### Experiment Configuration

- **Stable builds**: 20% participation, 4 equal groups (25% each)
- **Insider builds**: 20% participation, 4 equal groups (25% each)