### PR TITLE
Push coding agent button closer to send button

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/actions/chatExecuteActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatExecuteActions.ts
@@ -483,7 +483,7 @@ export class CreateRemoteAgentJobAction extends Action2 {
 			menu: {
 				id: MenuId.ChatExecute,
 				group: 'navigation',
-				order: 0,
+				order: 3.9,
 				when: ChatContextKeys.hasRemoteCodingAgent
 			}
 		});


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

`3.9` was Copilot's idea...but it's pretty genius.  With integer values the cloud button gets shifted around. In my testing the cloud button is always directly left of the send/dispatch menu.