### PR TITLE
[engineering] transpiled desktop bundle?

### DIFF
--- a/build/gulpfile.vscode.js
+++ b/build/gulpfile.vscode.js
@@ -488,7 +488,7 @@ BUILD_TARGETS.forEach(buildTarget => {
 		gulp.task(vscodeTaskCI);
 
 		const vscodeTask = task.define(`vscode${dashed(platform)}${dashed(arch)}${dashed(minified)}`, task.series(
-			minified ? compileBuildWithManglingTask : compileBuildWithoutManglingTask,
+			/*minified ? compileBuildWithManglingTask : */compileBuildWithoutManglingTask,
 			cleanExtensionsBuildTask,
 			compileNonNativeExtensionsBuildTask,
 			compileExtensionMediaBuildTask,

--- a/build/lib/compilation.js
+++ b/build/lib/compilation.js
@@ -103,6 +103,7 @@ function createCompile(src, { build, emitError, transpileOnly, preserveEnglish }
             .pipe(tsFilter)
             .pipe(util.loadSourcemaps())
             .pipe(compilation(token))
+            .pipe(util.$if(!!transpileOnly, util.loadSourcemaps()))
             .pipe(noDeclarationsFilter)
             .pipe(util.$if(build, nls.nls({ preserveEnglish })))
             .pipe(noDeclarationsFilter.restore)
@@ -137,7 +138,7 @@ function compileTask(src, out, build, options = {}) {
         if (os_1.default.totalmem() < 4_000_000_000) {
             throw new Error('compilation requires 4GB of RAM');
         }
-        const compile = createCompile(src, { build, emitError: true, transpileOnly: false, preserveEnglish: !!options.preserveEnglish });
+        const compile = createCompile(src, { build, emitError: true, transpileOnly: process.env.VSCODE_FORCE_TRANSPILE ? { esbuild: true } : false, preserveEnglish: !!options.preserveEnglish });
         const srcPipe = gulp_1.default.src(`${src}/**`, { base: `${src}` });
         const generator = new MonacoGenerator(false);
         if (src === 'src') {

--- a/build/lib/compilation.ts
+++ b/build/lib/compilation.ts
@@ -80,6 +80,7 @@ export function createCompile(src: string, { build, emitError, transpileOnly, pr
 			.pipe(tsFilter)
 			.pipe(util.loadSourcemaps())
 			.pipe(compilation(token))
+			.pipe(util.$if(!!transpileOnly, util.loadSourcemaps()))
 			.pipe(noDeclarationsFilter)
 			.pipe(util.$if(build, nls.nls({ preserveEnglish })))
 			.pipe(noDeclarationsFilter.restore)
@@ -124,7 +125,7 @@ export function compileTask(src: string, out: string, build: boolean, options: {
 			throw new Error('compilation requires 4GB of RAM');
 		}
 
-		const compile = createCompile(src, { build, emitError: true, transpileOnly: false, preserveEnglish: !!options.preserveEnglish });
+		const compile = createCompile(src, { build, emitError: true, transpileOnly: process.env.VSCODE_FORCE_TRANSPILE ? { esbuild: true } : false, preserveEnglish: !!options.preserveEnglish });
 		const srcPipe = gulp.src(`${src}/**`, { base: `${src}` });
 		const generator = new MonacoGenerator(false);
 		if (src === 'src') {

--- a/build/lib/util.js
+++ b/build/lib/util.js
@@ -188,6 +188,14 @@ function loadSourcemaps() {
             return;
         }
         f.contents = Buffer.from(contents.replace(/\/\/# sourceMappingURL=(.*)$/g, ''), 'utf8');
+        if (lastMatch[1].startsWith('data:application/json')) {
+            const parts = lastMatch[1].split('base64,');
+            if (parts.length > 1) {
+                f.sourceMap = JSON.parse(Buffer.from(parts[1], 'base64').toString('utf8'));
+            }
+            cb(undefined, f);
+            return;
+        }
         fs_1.default.readFile(path_1.default.join(path_1.default.dirname(f.path), lastMatch[1]), 'utf8', (err, contents) => {
             if (err) {
                 return cb(err);

--- a/build/lib/util.ts
+++ b/build/lib/util.ts
@@ -229,6 +229,15 @@ export function loadSourcemaps(): NodeJS.ReadWriteStream {
 
 			f.contents = Buffer.from(contents.replace(/\/\/# sourceMappingURL=(.*)$/g, ''), 'utf8');
 
+			if (lastMatch[1].startsWith('data:application/json')) {
+				const parts = lastMatch[1].split('base64,');
+				if (parts.length > 1) {
+					f.sourceMap = JSON.parse(Buffer.from(parts[1], 'base64').toString('utf8'));
+				}
+				cb(undefined, f);
+				return;
+			}
+
 			fs.readFile(path.join(path.dirname(f.path), lastMatch[1]), 'utf8', (err, contents) => {
 				if (err) { return cb(err); }
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

I'm experimenting with ways to build vscode as fast as possible. The obvious:

- mangling is slow = disable it
- tsb/tsc are slow = transpile with esbuild instead

I'm wondering if anyone has tried transpile + minify + bundle before?

This PR shows the issue I'm experiencing:

```
❯ VSCODE_FORCE_TRANSPILE=true node --max-old-space-size=8192 ./node_modules/gulp/bin/gulp.js vscode-darwin-arm64-migh
[22:19:55] Starting bundle-vscode ...
...
[22:19:55] Bundled entry point: cli...
[22:19:55] Bundled entry point: bootstrap-fork...
✘ [ERROR] "IProfileAnalysisWorkerService" is not declared in this file

    out-build/vs/platform/profiling/electron-browser/profileAnalysisWorkerService.js:71:2:
      71 │   IProfileAnalysisWorkerService,
         ╵   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

✘ [ERROR] "ProfilingOutput" is not declared in this file

    out-build/vs/platform/profiling/electron-browser/profileAnalysisWorkerService.js:72:2:
      72 │   ProfilingOutput
         ╵   ~~~~~~~~~~~~~~~
```

These errors span across many types of constants across many files.

Is this a configuration issue? An esbuild bug?

Includes #252590 

cc @bpasero @isidorn @joaomoreno 