### PR TITLE
[engineering] make boilerplate stripper differentiate between tsc and esbuild

### DIFF
--- a/build/lib/bundle.js
+++ b/build/lib/bundle.js
@@ -13,7 +13,7 @@ function removeAllTSBoilerplate(source) {
 const BOILERPLATE = [
     { start: /^var __extends/, end: /^}\)\(\);$/ },
     { start: /^var __assign/, end: /^};$/ },
-    { start: /^var __decorate/, end: /^};$/ },
+    { start: /^var __decorate\b/, end: /^};$/ },
     { start: /^var __metadata/, end: /^};$/ },
     { start: /^var __param/, end: /^};$/ },
     { start: /^var __awaiter/, end: /^};$/ },

--- a/build/lib/bundle.ts
+++ b/build/lib/bundle.ts
@@ -18,7 +18,7 @@ export function removeAllTSBoilerplate(source: string) {
 const BOILERPLATE = [
 	{ start: /^var __extends/, end: /^}\)\(\);$/ },
 	{ start: /^var __assign/, end: /^};$/ },
-	{ start: /^var __decorate/, end: /^};$/ },
+	{ start: /^var __decorate\b/, end: /^};$/ },
 	{ start: /^var __metadata/, end: /^};$/ },
 	{ start: /^var __param/, end: /^};$/ },
 	{ start: /^var __awaiter/, end: /^};$/ },


### PR DESCRIPTION
typescript compiler emits a method named `__decorate` [1]
esbuild emits a different method named `__decorateClass` [2]

ensure the regex differentiates the two and does not clobber esbuild outputs

[1] https://github.com/microsoft/TypeScript/blob/02672d281c26e561708127da1d8d1a6cae45fee2/src/compiler/factory/emitHelpers.ts#L730-L742
[2] https://github.com/evanw/esbuild/blob/f4159a7b823cd5fe2217da2c30e8873d2f319667/internal/runtime/runtime.go#L550-L561

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
