### PR TITLE
PromptParser: set language as input

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatWidget.ts
@@ -1422,7 +1422,7 @@ export class ChatWidget extends Disposable implements IChatWidget {
 			// if not, check if the context contains a prompt file: This is the old workflow that we still support for legacy reasons
 			const uri = this._findPromptFileInContext(requestInput.attachedContext);
 			if (uri) {
-				parseResult = await this.promptsService.parse(uri, CancellationToken.None);
+				parseResult = await this.promptsService.parse(uri, PromptsType.prompt, CancellationToken.None);
 			}
 		}
 

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/contentProviders/filePromptContentsProvider.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/contentProviders/filePromptContentsProvider.ts
@@ -27,6 +27,10 @@ export class FilePromptContentProvider extends PromptContentsProviderBase<FileCh
 	}
 
 	public override get languageId(): string {
+		if (this.options.languageId) {
+			return this.options.languageId;
+		}
+
 		const model = this.modelService.getModel(this.uri);
 
 		if (model !== null) {
@@ -46,7 +50,7 @@ export class FilePromptContentProvider extends PromptContentsProviderBase<FileCh
 
 	constructor(
 		public readonly uri: URI,
-		options: Partial<IPromptContentsProviderOptions>,
+		options: IPromptContentsProviderOptions,
 		@IFileService private readonly fileService: IFileService,
 		@IModelService private readonly modelService: IModelService,
 		@ILanguageService private readonly languageService: ILanguageService,
@@ -140,7 +144,7 @@ export class FilePromptContentProvider extends PromptContentsProviderBase<FileCh
 
 	public override createNew(
 		promptContentsSource: { uri: URI },
-		options: Partial<IPromptContentsProviderOptions> = {},
+		options: IPromptContentsProviderOptions,
 	): IPromptContentsProvider {
 		return new FilePromptContentProvider(
 			promptContentsSource.uri,

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/contentProviders/promptContentsProviderBase.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/contentProviders/promptContentsProviderBase.ts
@@ -24,14 +24,13 @@ export interface IPromptContentsProviderOptions {
 	 * file extension to be treated as a prompt file.
 	 */
 	readonly allowNonPromptFiles: boolean;
+
+	/**
+	 * Language ID to use for the prompt contents. If not set, the language ID will be inferred from the file.
+	 */
+	readonly languageId: string | undefined;
 }
 
-/**
- * Default {@link IPromptContentsProviderOptions} options.
- */
-export const DEFAULT_OPTIONS: IPromptContentsProviderOptions = {
-	allowNonPromptFiles: false,
-};
 
 /**
  * Base class for prompt contents providers. Classes that extend this one are responsible to:
@@ -51,7 +50,7 @@ export abstract class PromptContentsProviderBase<
 	TChangeEvent extends NonNullable<unknown>,
 > extends ObservableDisposable implements IPromptContentsProvider {
 	public abstract readonly uri: URI;
-	public abstract createNew(promptContentsSource: { uri: URI }): IPromptContentsProvider;
+	public abstract createNew(promptContentsSource: { uri: URI }, options: IPromptContentsProviderOptions): IPromptContentsProvider;
 	public abstract override toString(): string;
 	public abstract get languageId(): string;
 	public abstract get sourceName(): string;
@@ -105,20 +104,16 @@ export abstract class PromptContentsProviderBase<
 	protected readonly onChangeEmitter = this._register(new Emitter<TChangeEvent | 'full'>());
 
 	/**
-	 * Options passed to the constructor, extended with
-	 * value defaults from {@link DEFAULT_OPTIONS}.
+	 * Options passed to the constructor
 	 */
 	protected readonly options: IPromptContentsProviderOptions;
 
 	constructor(
-		options: Partial<IPromptContentsProviderOptions>,
+		options: IPromptContentsProviderOptions,
 	) {
 		super();
 
-		this.options = {
-			...DEFAULT_OPTIONS,
-			...options,
-		};
+		this.options = options;
 	}
 
 	/**

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/contentProviders/textModelContentsProvider.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/contentProviders/textModelContentsProvider.ts
@@ -36,7 +36,7 @@ export class TextModelContentsProvider extends PromptContentsProviderBase<IModel
 
 	constructor(
 		private readonly model: ITextModel,
-		options: Partial<IPromptContentsProviderOptions>,
+		options: IPromptContentsProviderOptions,
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
 	) {
 		super(options);
@@ -67,7 +67,7 @@ export class TextModelContentsProvider extends PromptContentsProviderBase<IModel
 
 	public override createNew(
 		promptContentsSource: TextModel | { uri: URI },
-		options: Partial<IPromptContentsProviderOptions> = {},
+		options: IPromptContentsProviderOptions,
 	): IPromptContentsProvider {
 		if (promptContentsSource instanceof TextModel) {
 			return this.instantiationService.createInstance(

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/contentProviders/types.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/contentProviders/types.ts
@@ -10,6 +10,7 @@ import { IDisposable } from '../../../../../../base/common/lifecycle.js';
 import { VSBufferReadableStream } from '../../../../../../base/common/buffer.js';
 import { PromptsType } from '../promptTypes.js';
 import { CancellationToken } from '../../../../../../base/common/cancellation.js';
+import { IPromptContentsProviderOptions } from './promptContentsProviderBase.js';
 
 /**
  * Interface for a prompt contents provider. Prompt contents providers are
@@ -64,5 +65,6 @@ export interface IPromptContentsProvider extends IDisposable {
 	 */
 	createNew(
 		promptContentsSource: { uri: URI },
+		options: IPromptContentsProviderOptions,
 	): IPromptContentsProvider;
 }

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/filePromptParser.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/filePromptParser.ts
@@ -17,7 +17,7 @@ import { IInstantiationService } from '../../../../../../platform/instantiation/
 export class FilePromptParser extends BasePromptParser<FilePromptContentProvider> {
 	constructor(
 		uri: URI,
-		options: Partial<IPromptParserOptions>,
+		options: IPromptParserOptions,
 		@IInstantiationService instantiationService: IInstantiationService,
 		@IWorkspaceContextService workspaceService: IWorkspaceContextService,
 		@ILogService logService: ILogService,

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/promptParser.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/promptParser.ts
@@ -14,13 +14,14 @@ import { FilePromptContentProvider } from '../contentProviders/filePromptContent
 import { IWorkspaceContextService } from '../../../../../../platform/workspace/common/workspace.js';
 import { IInstantiationService } from '../../../../../../platform/instantiation/common/instantiation.js';
 import { Schemas } from '../../../../../../base/common/network.js';
+import { IPromptContentsProviderOptions } from '../contentProviders/promptContentsProviderBase.js';
 
 /**
  * Get prompt contents provider object based on the prompt type.
  */
 function getContentsProvider(
 	uri: URI,
-	options: Partial<IPromptParserOptions>,
+	options: IPromptContentsProviderOptions,
 	modelService: IModelService,
 	instaService: IInstantiationService
 ): IPromptContentsProvider {
@@ -53,7 +54,7 @@ export class PromptParser extends BasePromptParser<IPromptContentsProvider> {
 
 	constructor(
 		uri: URI,
-		options: Partial<IPromptParserOptions>,
+		options: IPromptParserOptions,
 		@ILogService logService: ILogService,
 		@IModelService modelService: IModelService,
 		@IInstantiationService instaService: IInstantiationService,

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/textModelPromptParser.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/parsers/textModelPromptParser.ts
@@ -17,7 +17,7 @@ import { IInstantiationService } from '../../../../../../platform/instantiation/
 export class TextModelPromptParser extends BasePromptParser<TextModelContentsProvider> {
 	constructor(
 		model: ITextModel,
-		options: Partial<IPromptParserOptions>,
+		options: IPromptParserOptions,
 		@IInstantiationService instantiationService: IInstantiationService,
 		@IWorkspaceContextService workspaceService: IWorkspaceContextService,
 		@ILogService logService: ILogService,

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsService.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsService.ts
@@ -203,7 +203,7 @@ export interface IPromptsService extends IDisposable {
 	 * Parses the provided URI
 	 * @param uris
 	 */
-	parse(uri: URI, token: CancellationToken): Promise<IPromptParserResult>;
+	parse(uri: URI, type: PromptsType, token: CancellationToken): Promise<IPromptParserResult>;
 
 	/**
 	 * Returns the prompt file type for the given URI.

--- a/src/vs/workbench/contrib/chat/test/common/mockPromptsService.ts
+++ b/src/vs/workbench/contrib/chat/test/common/mockPromptsService.ts
@@ -40,7 +40,7 @@ export class MockPromptsService implements IPromptsService {
 	getCustomChatModes(token: CancellationToken): Promise<readonly ICustomChatMode[]> {
 		throw new Error('Method not implemented.');
 	}
-	parse(uri: URI, token: CancellationToken): Promise<IPromptParserResult> {
+	parse(uri: URI, type: PromptsType, token: CancellationToken): Promise<IPromptParserResult> {
 		throw new Error('Method not implemented.');
 	}
 	getPromptFileType(resource: URI): PromptsType | undefined {

--- a/src/vs/workbench/contrib/chat/test/common/promptSyntax/contentProviders/filePromptContentsProvider.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/promptSyntax/contentProviders/filePromptContentsProvider.test.ts
@@ -70,7 +70,7 @@ suite('FilePromptContentsProvider', () => {
 		const contentsProvider = testDisposables.add(instantiationService.createInstance(
 			FilePromptContentProvider,
 			fileUri,
-			{},
+			{ allowNonPromptFiles: true, languageId: undefined },
 		));
 
 		let streamOrError: ReadableStream<VSBuffer> | Error | undefined;
@@ -128,7 +128,7 @@ suite('FilePromptContentsProvider', () => {
 				const contentsProvider = testDisposables.add(instantiationService.createInstance(
 					FilePromptContentProvider,
 					fileUri,
-					{ allowNonPromptFiles: true },
+					{ allowNonPromptFiles: true, languageId: undefined },
 				));
 
 				let streamOrError: ReadableStream<VSBuffer> | Error | undefined;
@@ -184,47 +184,7 @@ suite('FilePromptContentsProvider', () => {
 				const contentsProvider = testDisposables.add(instantiationService.createInstance(
 					FilePromptContentProvider,
 					fileUri,
-					{ allowNonPromptFiles: false },
-				));
-
-				let streamOrError: ReadableStream<VSBuffer> | Error | undefined;
-				testDisposables.add(contentsProvider.onContentChanged((event) => {
-					streamOrError = event;
-				}));
-				contentsProvider.start();
-
-				await timeout(CONTENT_CHANGED_TIMEOUT);
-
-				assertDefined(
-					streamOrError,
-					'The `streamOrError` must be defined.',
-				);
-
-				assert(
-					streamOrError instanceof NotPromptFile,
-					`Provider must produce an 'NotPromptFile' error, got '${streamOrError}'.`,
-				);
-			});
-
-			test('undefined', async () => {
-				const fileService = instantiationService.get(IFileService);
-
-				const fileName = (randomBoolean() === true)
-					? `file-${randomInt(10_000)}.md`
-					: `file-${randomInt(10_000)}.txt`;
-
-				const fileUri = URI.file(`/${fileName}`);
-
-				if (await fileService.exists(fileUri)) {
-					await fileService.del(fileUri);
-				}
-				await fileService.writeFile(fileUri, VSBuffer.fromString('Hello, world!'));
-				await timeout(5);
-
-				const contentsProvider = testDisposables.add(instantiationService.createInstance(
-					FilePromptContentProvider,
-					fileUri,
-					{},
+					{ allowNonPromptFiles: false, languageId: undefined },
 				));
 
 				let streamOrError: ReadableStream<VSBuffer> | Error | undefined;

--- a/src/vs/workbench/contrib/chat/test/common/promptSyntax/parsers/textModelPromptParser.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/promptSyntax/parsers/textModelPromptParser.test.ts
@@ -70,7 +70,7 @@ class TextModelPromptParserTest extends Disposable {
 
 		// create the parser instance
 		this.parser = this._register(
-			instantiationService.createInstance(TextModelPromptParser, this.model, {}),
+			instantiationService.createInstance(TextModelPromptParser, this.model, { seenReferences: [], allowNonPromptFiles: true, languageId: undefined }),
 		).start();
 	}
 

--- a/src/vs/workbench/contrib/chat/test/common/promptSyntax/promptFileReference.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/promptSyntax/promptFileReference.test.ts
@@ -29,7 +29,7 @@ import { MarkdownLink } from '../../../common/promptSyntax/codecs/base/markdownC
 import { FileReference } from '../../../common/promptSyntax/codecs/tokens/fileReference.js';
 import { getPromptFileType } from '../../../common/promptSyntax/config/promptFileLocations.js';
 import { PromptsType } from '../../../common/promptSyntax/promptTypes.js';
-import { IPromptParserOptions, type TErrorCondition } from '../../../common/promptSyntax/parsers/basePromptParser.js';
+import { type TErrorCondition } from '../../../common/promptSyntax/parsers/basePromptParser.js';
 import { FilePromptParser } from '../../../common/promptSyntax/parsers/filePromptParser.js';
 import { type TPromptReference } from '../../../common/promptSyntax/parsers/types.js';
 import { IMockFolder, MockFilesystem } from './testUtils/mockFilesystem.js';
@@ -91,7 +91,6 @@ class TestPromptFileReference extends Disposable {
 	 * Run the test.
 	 */
 	public async run(
-		options: Partial<IPromptParserOptions> = {},
 	): Promise<FilePromptParser> {
 		// create the files structure on the disk
 		await (this.instantiationService.createInstance(MockFilesystem, this.fileStructure)).mock();
@@ -107,7 +106,7 @@ class TestPromptFileReference extends Disposable {
 			this.instantiationService.createInstance(
 				FilePromptParser,
 				this.rootFileUri,
-				options,
+				{ seenReferences: [], allowNonPromptFiles: true, languageId: undefined },
 			),
 		).start();
 
@@ -690,7 +689,7 @@ suite('PromptFileReference', function () {
 				]
 			));
 
-			await test.run({ allowNonPromptFiles: true });
+			await test.run();
 		});
 	});
 


### PR DESCRIPTION
The parser would not parse a header if the language was not set on the underlying text model. But on window reload it takes a while until the textModel gets the correct language id, as the language contributions come from extension that need to be loaded first.
As we know what we parse, we pass in the language when starting the parser

Fixes https://github.com/microsoft/vscode-copilot/issues/17988
Fixes https://github.com/microsoft/vscode/issues/249294