### PR TITLE
Allow the internal fetch tool to return `IToolResultDataPart` for images

### DIFF
--- a/src/vs/workbench/contrib/chat/test/electron-browser/fetchPageTool.test.ts
+++ b/src/vs/workbench/contrib/chat/test/electron-browser/fetchPageTool.test.ts
@@ -196,7 +196,7 @@ suite('FetchWebPageTool', () => {
 		const binaryBuffer = VSBuffer.wrap(binaryContent);
 
 		const fileContentMap = new ResourceMap<string | VSBuffer>([
-			[URI.parse('file:///path/to/image.png'), binaryBuffer],
+			[URI.parse('file:///path/to/binary.dat'), binaryBuffer],
 			[URI.parse('file:///path/to/text.txt'), 'This is text content']
 		]);
 
@@ -209,7 +209,7 @@ suite('FetchWebPageTool', () => {
 			{
 				callId: 'test-call-binary',
 				toolId: 'fetch-page',
-				parameters: { urls: ['file:///path/to/image.png', 'file:///path/to/text.txt'] },
+				parameters: { urls: ['file:///path/to/binary.dat', 'file:///path/to/text.txt'] },
 				context: undefined
 			},
 			() => Promise.resolve(0),
@@ -234,6 +234,44 @@ suite('FetchWebPageTool', () => {
 
 		// Both files should be in toolResultDetails since they were successfully fetched
 		assert.strictEqual(Array.isArray(result.toolResultDetails) ? result.toolResultDetails.length : 0, 2, 'Should have 2 valid URLs in toolResultDetails');
+	});
+
+	test('PNG files are now supported as image data parts (regression test)', async () => {
+		// This test ensures that PNG files that previously returned "not supported"
+		// messages now return proper image data parts
+		const binaryContent = new Uint8Array([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x0D]);
+		const binaryBuffer = VSBuffer.wrap(binaryContent);
+
+		const fileContentMap = new ResourceMap<string | VSBuffer>([
+			[URI.parse('file:///path/to/image.png'), binaryBuffer]
+		]);
+
+		const tool = new FetchWebPageTool(
+			new TestWebContentExtractorService(new ResourceMap<string>()),
+			new ExtendedTestFileService(fileContentMap)
+		);
+
+		const result = await tool.invoke(
+			{
+				callId: 'test-png-support',
+				toolId: 'fetch-page',
+				parameters: { urls: ['file:///path/to/image.png'] },
+				context: undefined
+			},
+			() => Promise.resolve(0),
+			{ report: () => { } },
+			CancellationToken.None
+		);
+
+		// Should have 1 result
+		assert.strictEqual(result.content.length, 1, 'Should have 1 result');
+
+		// PNG file should now be returned as a data part, not a "not supported" message
+		assert.strictEqual(result.content[0].kind, 'data', 'PNG file should return data part');
+		if (result.content[0].kind === 'data') {
+			assert.strictEqual(result.content[0].value.mimeType, 'image/png', 'Should have PNG MIME type');
+			assert.strictEqual(result.content[0].value.data, binaryBuffer, 'Should have correct binary data');
+		}
 	});
 
 	test('should correctly distinguish between binary and text content', async () => {
@@ -275,5 +313,423 @@ suite('FetchWebPageTool', () => {
 		if (result.content[1].kind === 'text') {
 			assert.strictEqual(result.content[1].value, 'Binary files are not supported at the moment.', 'Should return not supported message');
 		}
+	});
+
+	test('Supported image files are returned as data parts', async () => {
+		// Test data for different supported image formats
+		const pngData = VSBuffer.fromString('fake PNG data');
+		const jpegData = VSBuffer.fromString('fake JPEG data');
+		const gifData = VSBuffer.fromString('fake GIF data');
+		const webpData = VSBuffer.fromString('fake WebP data');
+		const bmpData = VSBuffer.fromString('fake BMP data');
+
+		const fileContentMap = new ResourceMap<string | VSBuffer>();
+		fileContentMap.set(URI.parse('file:///image.png'), pngData);
+		fileContentMap.set(URI.parse('file:///photo.jpg'), jpegData);
+		fileContentMap.set(URI.parse('file:///animation.gif'), gifData);
+		fileContentMap.set(URI.parse('file:///modern.webp'), webpData);
+		fileContentMap.set(URI.parse('file:///bitmap.bmp'), bmpData);
+
+		const tool = new FetchWebPageTool(
+			new TestWebContentExtractorService(new ResourceMap<string>()),
+			new ExtendedTestFileService(fileContentMap)
+		);
+
+		const result = await tool.invoke(
+			{
+				callId: 'test-images',
+				toolId: 'fetch-page',
+				parameters: { urls: ['file:///image.png', 'file:///photo.jpg', 'file:///animation.gif', 'file:///modern.webp', 'file:///bitmap.bmp'] },
+				context: undefined
+			},
+			() => Promise.resolve(0),
+			{ report: () => { } },
+			CancellationToken.None
+		);
+
+		// All images should be returned as data parts
+		assert.strictEqual(result.content.length, 5, 'Should have 5 results');
+
+		// Check PNG
+		assert.strictEqual(result.content[0].kind, 'data', 'PNG should be data part');
+		if (result.content[0].kind === 'data') {
+			assert.strictEqual(result.content[0].value.mimeType, 'image/png', 'PNG should have correct MIME type');
+			assert.strictEqual(result.content[0].value.data, pngData, 'PNG should have correct data');
+		}
+
+		// Check JPEG
+		assert.strictEqual(result.content[1].kind, 'data', 'JPEG should be data part');
+		if (result.content[1].kind === 'data') {
+			assert.strictEqual(result.content[1].value.mimeType, 'image/jpeg', 'JPEG should have correct MIME type');
+			assert.strictEqual(result.content[1].value.data, jpegData, 'JPEG should have correct data');
+		}
+
+		// Check GIF
+		assert.strictEqual(result.content[2].kind, 'data', 'GIF should be data part');
+		if (result.content[2].kind === 'data') {
+			assert.strictEqual(result.content[2].value.mimeType, 'image/gif', 'GIF should have correct MIME type');
+			assert.strictEqual(result.content[2].value.data, gifData, 'GIF should have correct data');
+		}
+
+		// Check WebP
+		assert.strictEqual(result.content[3].kind, 'data', 'WebP should be data part');
+		if (result.content[3].kind === 'data') {
+			assert.strictEqual(result.content[3].value.mimeType, 'image/webp', 'WebP should have correct MIME type');
+			assert.strictEqual(result.content[3].value.data, webpData, 'WebP should have correct data');
+		}
+
+		// Check BMP
+		assert.strictEqual(result.content[4].kind, 'data', 'BMP should be data part');
+		if (result.content[4].kind === 'data') {
+			assert.strictEqual(result.content[4].value.mimeType, 'image/bmp', 'BMP should have correct MIME type');
+			assert.strictEqual(result.content[4].value.data, bmpData, 'BMP should have correct data');
+		}
+	});
+
+	test('Mixed image and text files work correctly', async () => {
+		const textData = 'This is some text content';
+		const imageData = VSBuffer.fromString('fake image data');
+
+		const fileContentMap = new ResourceMap<string | VSBuffer>();
+		fileContentMap.set(URI.parse('file:///text.txt'), textData);
+		fileContentMap.set(URI.parse('file:///image.png'), imageData);
+
+		const tool = new FetchWebPageTool(
+			new TestWebContentExtractorService(new ResourceMap<string>()),
+			new ExtendedTestFileService(fileContentMap)
+		);
+
+		const result = await tool.invoke(
+			{
+				callId: 'test-mixed',
+				toolId: 'fetch-page',
+				parameters: { urls: ['file:///text.txt', 'file:///image.png'] },
+				context: undefined
+			},
+			() => Promise.resolve(0),
+			{ report: () => { } },
+			CancellationToken.None
+		);
+
+		// Text should be returned as text part
+		assert.strictEqual(result.content[0].kind, 'text', 'Text file should be text part');
+		if (result.content[0].kind === 'text') {
+			assert.strictEqual(result.content[0].value, textData, 'Text should have correct content');
+		}
+
+		// Image should be returned as data part
+		assert.strictEqual(result.content[1].kind, 'data', 'Image file should be data part');
+		if (result.content[1].kind === 'data') {
+			assert.strictEqual(result.content[1].value.mimeType, 'image/png', 'Image should have correct MIME type');
+			assert.strictEqual(result.content[1].value.data, imageData, 'Image should have correct data');
+		}
+	});
+
+	test('Case insensitive image extensions work', async () => {
+		const imageData = VSBuffer.fromString('fake image data');
+
+		const fileContentMap = new ResourceMap<string | VSBuffer>();
+		fileContentMap.set(URI.parse('file:///image.PNG'), imageData);
+		fileContentMap.set(URI.parse('file:///photo.JPEG'), imageData);
+
+		const tool = new FetchWebPageTool(
+			new TestWebContentExtractorService(new ResourceMap<string>()),
+			new ExtendedTestFileService(fileContentMap)
+		);
+
+		const result = await tool.invoke(
+			{
+				callId: 'test-case',
+				toolId: 'fetch-page',
+				parameters: { urls: ['file:///image.PNG', 'file:///photo.JPEG'] },
+				context: undefined
+			},
+			() => Promise.resolve(0),
+			{ report: () => { } },
+			CancellationToken.None
+		);
+
+		// Both should be returned as data parts despite uppercase extensions
+		assert.strictEqual(result.content[0].kind, 'data', 'PNG with uppercase extension should be data part');
+		if (result.content[0].kind === 'data') {
+			assert.strictEqual(result.content[0].value.mimeType, 'image/png', 'Should have correct MIME type');
+		}
+
+		assert.strictEqual(result.content[1].kind, 'data', 'JPEG with uppercase extension should be data part');
+		if (result.content[1].kind === 'data') {
+			assert.strictEqual(result.content[1].value.mimeType, 'image/jpeg', 'Should have correct MIME type');
+		}
+	});
+
+	// Comprehensive tests for toolResultDetails
+	suite('toolResultDetails', () => {
+		test('should include only successfully fetched URIs in correct order', async () => {
+			const webContentMap = new ResourceMap<string>([
+				[URI.parse('https://success1.com'), 'Content 1'],
+				[URI.parse('https://success2.com'), 'Content 2']
+			]);
+
+			const fileContentMap = new ResourceMap<string | VSBuffer>([
+				[URI.parse('file:///success.txt'), 'File content'],
+				[URI.parse('mcp-resource://server/file.txt'), 'MCP content']
+			]);
+
+			const tool = new FetchWebPageTool(
+				new TestWebContentExtractorService(webContentMap),
+				new ExtendedTestFileService(fileContentMap)
+			);
+
+			const testUrls = [
+				'https://success1.com',       // index 0 - should be in toolResultDetails
+				'invalid-url',                // index 1 - should NOT be in toolResultDetails
+				'file:///success.txt',        // index 2 - should be in toolResultDetails
+				'https://success2.com',       // index 3 - should be in toolResultDetails
+				'file:///nonexistent.txt',    // index 4 - should NOT be in toolResultDetails
+				'mcp-resource://server/file.txt' // index 5 - should be in toolResultDetails
+			];
+
+			const result = await tool.invoke(
+				{ callId: 'test-details', toolId: 'fetch-page', parameters: { urls: testUrls }, context: undefined },
+				() => Promise.resolve(0),
+				{ report: () => { } },
+				CancellationToken.None
+			);
+
+			// Verify toolResultDetails contains exactly the successful URIs
+			assert.ok(Array.isArray(result.toolResultDetails), 'toolResultDetails should be an array');
+			assert.strictEqual(result.toolResultDetails.length, 4, 'Should have 4 successful URIs');
+
+			// Check that all entries are URI objects
+			const uriDetails = result.toolResultDetails as URI[];
+			assert.ok(uriDetails.every(uri => uri instanceof URI), 'All toolResultDetails entries should be URI objects');
+
+			// Check specific URIs are included (web URIs first, then successful file URIs)
+			const expectedUris = [
+				'https://success1.com/',
+				'https://success2.com/',
+				'file:///success.txt',
+				'mcp-resource://server/file.txt'
+			];
+
+			const actualUriStrings = uriDetails.map(uri => uri.toString());
+			assert.deepStrictEqual(actualUriStrings.sort(), expectedUris.sort(), 'Should contain exactly the expected successful URIs');
+
+			// Verify content array matches input order (including failures)
+			assert.strictEqual(result.content.length, 6, 'Content should have result for each input URL');
+			assert.strictEqual(result.content[0].value, 'Content 1', 'First web URI content');
+			assert.strictEqual(result.content[1].value, 'Invalid URL', 'Invalid URL marked as invalid');
+			assert.strictEqual(result.content[2].value, 'File content', 'File URI content');
+			assert.strictEqual(result.content[3].value, 'Content 2', 'Second web URI content');
+			assert.strictEqual(result.content[4].value, 'Invalid URL', 'Nonexistent file marked as invalid');
+			assert.strictEqual(result.content[5].value, 'MCP content', 'MCP resource content');
+		});
+
+		test('should exclude failed web requests from toolResultDetails', async () => {
+			// Set up web content extractor that will throw for some URIs
+			const webContentMap = new ResourceMap<string>([
+				[URI.parse('https://success.com'), 'Success content']
+				// https://failure.com not in map - will throw error
+			]);
+
+			const tool = new FetchWebPageTool(
+				new TestWebContentExtractorService(webContentMap),
+				new ExtendedTestFileService(new ResourceMap<string | VSBuffer>())
+			);
+
+			const testUrls = [
+				'https://success.com',  // Should succeed
+				'https://failure.com'   // Should fail (not in content map)
+			];
+
+			try {
+				await tool.invoke(
+					{ callId: 'test-web-failure', toolId: 'fetch-page', parameters: { urls: testUrls }, context: undefined },
+					() => Promise.resolve(0),
+					{ report: () => { } },
+					CancellationToken.None
+				);
+
+				// If the web extractor throws, it should be handled gracefully
+				// But in this test setup, the TestWebContentExtractorService throws for missing content
+				assert.fail('Expected test web content extractor to throw for missing URI');
+			} catch (error) {
+				// This is expected behavior with the current test setup
+				// The TestWebContentExtractorService throws when content is not found
+				assert.ok(error.message.includes('No content configured for URI'), 'Should throw for unconfigured URI');
+			}
+		});
+
+		test('should exclude failed file reads from toolResultDetails', async () => {
+			const fileContentMap = new ResourceMap<string | VSBuffer>([
+				[URI.parse('file:///existing.txt'), 'File exists']
+				// file:///missing.txt not in map - will throw error
+			]);
+
+			const tool = new FetchWebPageTool(
+				new TestWebContentExtractorService(new ResourceMap<string>()),
+				new ExtendedTestFileService(fileContentMap)
+			);
+
+			const testUrls = [
+				'file:///existing.txt',  // Should succeed
+				'file:///missing.txt'    // Should fail (not in file map)
+			];
+
+			const result = await tool.invoke(
+				{ callId: 'test-file-failure', toolId: 'fetch-page', parameters: { urls: testUrls }, context: undefined },
+				() => Promise.resolve(0),
+				{ report: () => { } },
+				CancellationToken.None
+			);
+
+			// Verify only successful file URI is in toolResultDetails
+			assert.ok(Array.isArray(result.toolResultDetails), 'toolResultDetails should be an array');
+			assert.strictEqual(result.toolResultDetails.length, 1, 'Should have only 1 successful URI');
+
+			const uriDetails = result.toolResultDetails as URI[];
+			assert.strictEqual(uriDetails[0].toString(), 'file:///existing.txt', 'Should contain only the successful file URI');
+
+			// Verify content reflects both attempts
+			assert.strictEqual(result.content.length, 2, 'Should have results for both input URLs');
+			assert.strictEqual(result.content[0].value, 'File exists', 'First file should have content');
+			assert.strictEqual(result.content[1].value, 'Invalid URL', 'Second file should be marked invalid');
+		});
+
+		test('should handle mixed success and failure scenarios', async () => {
+			const webContentMap = new ResourceMap<string>([
+				[URI.parse('https://web-success.com'), 'Web success']
+			]);
+
+			const fileContentMap = new ResourceMap<string | VSBuffer>([
+				[URI.parse('file:///file-success.txt'), 'File success'],
+				[URI.parse('mcp-resource://good/file.txt'), VSBuffer.fromString('MCP binary content')]
+			]);
+
+			const tool = new FetchWebPageTool(
+				new TestWebContentExtractorService(webContentMap),
+				new ExtendedTestFileService(fileContentMap)
+			);
+
+			const testUrls = [
+				'invalid-scheme://bad',      // Invalid URI
+				'https://web-success.com',   // Web success
+				'file:///file-missing.txt',  // File failure
+				'file:///file-success.txt',  // File success
+				'completely-invalid-url',    // Invalid URL format
+				'mcp-resource://good/file.txt' // MCP success
+			];
+
+			const result = await tool.invoke(
+				{ callId: 'test-mixed', toolId: 'fetch-page', parameters: { urls: testUrls }, context: undefined },
+				() => Promise.resolve(0),
+				{ report: () => { } },
+				CancellationToken.None
+			);
+
+			// Should have 3 successful URIs: web-success, file-success, mcp-success
+			assert.ok(Array.isArray(result.toolResultDetails), 'toolResultDetails should be an array');
+			assert.strictEqual((result.toolResultDetails as URI[]).length, 3, 'Should have 3 successful URIs');
+
+			const uriDetails = result.toolResultDetails as URI[];
+			const actualUriStrings = uriDetails.map(uri => uri.toString());
+			const expectedSuccessful = [
+				'https://web-success.com/',
+				'file:///file-success.txt',
+				'mcp-resource://good/file.txt'
+			];
+
+			assert.deepStrictEqual(actualUriStrings.sort(), expectedSuccessful.sort(), 'Should contain exactly the successful URIs');
+
+			// Verify content array reflects all inputs in original order
+			assert.strictEqual(result.content.length, 6, 'Should have results for all input URLs');
+			assert.strictEqual(result.content[0].value, 'Invalid URL', 'Invalid scheme marked as invalid');
+			assert.strictEqual(result.content[1].value, 'Web success', 'Web success content');
+			assert.strictEqual(result.content[2].value, 'Invalid URL', 'Missing file marked as invalid');
+			assert.strictEqual(result.content[3].value, 'File success', 'File success content');
+			assert.strictEqual(result.content[4].value, 'Invalid URL', 'Invalid URL marked as invalid');
+			assert.strictEqual(result.content[5].value, 'MCP binary content', 'MCP success content');
+		});
+
+		test('should return empty toolResultDetails when all requests fail', async () => {
+			const tool = new FetchWebPageTool(
+				new TestWebContentExtractorService(new ResourceMap<string>()), // Empty - all web requests fail
+				new ExtendedTestFileService(new ResourceMap<string | VSBuffer>()) // Empty - all file requests fail
+			);
+
+			const testUrls = [
+				'https://nonexistent.com',
+				'file:///missing.txt',
+				'invalid-url',
+				'bad://scheme'
+			];
+
+			try {
+				const result = await tool.invoke(
+					{ callId: 'test-all-fail', toolId: 'fetch-page', parameters: { urls: testUrls }, context: undefined },
+					() => Promise.resolve(0),
+					{ report: () => { } },
+					CancellationToken.None
+				);
+
+				// If web extractor doesn't throw, check the results
+				assert.ok(Array.isArray(result.toolResultDetails), 'toolResultDetails should be an array');
+				assert.strictEqual((result.toolResultDetails as URI[]).length, 0, 'Should have no successful URIs');
+				assert.strictEqual(result.content.length, 4, 'Should have results for all input URLs');
+				assert.ok(result.content.every(content => content.value === 'Invalid URL'), 'All content should be marked as invalid');
+			} catch (error) {
+				// Expected with TestWebContentExtractorService when no content is configured
+				assert.ok(error.message.includes('No content configured for URI'), 'Should throw for unconfigured URI');
+			}
+		});
+
+		test('should handle empty URL array', async () => {
+			const tool = new FetchWebPageTool(
+				new TestWebContentExtractorService(new ResourceMap<string>()),
+				new ExtendedTestFileService(new ResourceMap<string | VSBuffer>())
+			);
+
+			const result = await tool.invoke(
+				{ callId: 'test-empty', toolId: 'fetch-page', parameters: { urls: [] }, context: undefined },
+				() => Promise.resolve(0),
+				{ report: () => { } },
+				CancellationToken.None
+			);
+
+			assert.strictEqual(result.content.length, 1, 'Should have one content item for empty URLs');
+			assert.strictEqual(result.content[0].value, 'No valid URLs provided.', 'Should indicate no valid URLs');
+			assert.ok(!result.toolResultDetails, 'toolResultDetails should not be present for empty URLs');
+		});
+
+		test('should handle image files in toolResultDetails', async () => {
+			const imageBuffer = VSBuffer.fromString('fake-png-data');
+			const fileContentMap = new ResourceMap<string | VSBuffer>([
+				[URI.parse('file:///image.png'), imageBuffer],
+				[URI.parse('file:///document.txt'), 'Text content']
+			]);
+
+			const tool = new FetchWebPageTool(
+				new TestWebContentExtractorService(new ResourceMap<string>()),
+				new ExtendedTestFileService(fileContentMap)
+			);
+
+			const result = await tool.invoke(
+				{ callId: 'test-images', toolId: 'fetch-page', parameters: { urls: ['file:///image.png', 'file:///document.txt'] }, context: undefined },
+				() => Promise.resolve(0),
+				{ report: () => { } },
+				CancellationToken.None
+			);
+
+			// Both files should be successful and in toolResultDetails
+			assert.ok(Array.isArray(result.toolResultDetails), 'toolResultDetails should be an array');
+			assert.strictEqual((result.toolResultDetails as URI[]).length, 2, 'Should have 2 successful file URIs');
+
+			const uriDetails = result.toolResultDetails as URI[];
+			assert.strictEqual(uriDetails[0].toString(), 'file:///image.png', 'Should include image file');
+			assert.strictEqual(uriDetails[1].toString(), 'file:///document.txt', 'Should include text file');
+
+			// Check content types
+			assert.strictEqual(result.content[0].kind, 'data', 'Image should be data part');
+			assert.strictEqual(result.content[1].kind, 'text', 'Text file should be text part');
+		});
 	});
 });


### PR DESCRIPTION
Needs https://github.com/microsoft/vscode-copilot-chat/pull/27 to be live for like a day just in case... so I'll merge it tomorrow.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

ref https://github.com/microsoft/vscode/issues/250495