### PR TITLE
Add snooze button for completions / NES

### DIFF
--- a/src/vs/base/browser/ui/button/button.ts
+++ b/src/vs/base/browser/ui/button/button.ts
@@ -333,7 +333,9 @@ export class Button extends Disposable implements IButton {
 	}
 
 	setTitle(title: string) {
-		if (!this._hover && title !== '') {
+		if (this.options.hoverDelegate?.showNativeHover) {
+			this._element.title = title;
+		} else if (!this._hover && title !== '') {
 			this._hover = this._register(getBaseLayerHoverDelegate().setupManagedHover(this.options.hoverDelegate ?? getDefaultHoverDelegate('element'), this._element, title));
 		} else if (this._hover) {
 			this._hover.update(title);

--- a/src/vs/base/browser/ui/toggle/toggle.ts
+++ b/src/vs/base/browser/ui/toggle/toggle.ts
@@ -40,6 +40,7 @@ export interface ICheckboxStyles {
 	readonly checkboxDisabledBackground: string | undefined;
 	readonly checkboxDisabledForeground: string | undefined;
 	readonly size?: number;
+	readonly hoverDelegate?: IHoverDelegate;
 }
 
 export const unthemedToggleStyles = {
@@ -272,7 +273,7 @@ export class Checkbox extends Widget {
 	constructor(private title: string, private isChecked: boolean, styles: ICheckboxStyles) {
 		super();
 
-		this.checkbox = this._register(new Toggle({ title: this.title, isChecked: this.isChecked, icon: Codicon.check, actionClassName: Checkbox.CLASS_NAME, ...unthemedToggleStyles }));
+		this.checkbox = this._register(new Toggle({ title: this.title, isChecked: this.isChecked, icon: Codicon.check, actionClassName: Checkbox.CLASS_NAME, hoverDelegate: styles.hoverDelegate, ...unthemedToggleStyles }));
 
 		this.domNode = this.checkbox.domNode;
 

--- a/src/vs/editor/browser/services/inlineCompletionsService.ts
+++ b/src/vs/editor/browser/services/inlineCompletionsService.ts
@@ -3,19 +3,18 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { WindowIntervalTimer } from '../../../../../base/browser/dom.js';
-import { BugIndicatingError } from '../../../../../base/common/errors.js';
-import { Emitter, Event } from '../../../../../base/common/event.js';
-import { Disposable } from '../../../../../base/common/lifecycle.js';
-import { localize, localize2 } from '../../../../../nls.js';
-import { Action2 } from '../../../../../platform/actions/common/actions.js';
-import { ContextKeyExpr, IContextKeyService, RawContextKey } from '../../../../../platform/contextkey/common/contextkey.js';
-import { InstantiationType, registerSingleton } from '../../../../../platform/instantiation/common/extensions.js';
-import { createDecorator } from '../../../../../platform/instantiation/common/instantiation.js';
-import { IQuickInputService, IQuickPickItem } from '../../../../../platform/quickinput/common/quickInput.js';
-import { ServicesAccessor } from '../../../../browser/editorExtensions.js';
+import { WindowIntervalTimer } from '../../../base/browser/dom.js';
+import { BugIndicatingError } from '../../../base/common/errors.js';
+import { Emitter, Event } from '../../../base/common/event.js';
+import { Disposable } from '../../../base/common/lifecycle.js';
+import { localize, localize2 } from '../../../nls.js';
+import { Action2 } from '../../../platform/actions/common/actions.js';
+import { ContextKeyExpr, IContextKeyService, RawContextKey } from '../../../platform/contextkey/common/contextkey.js';
+import { InstantiationType, registerSingleton } from '../../../platform/instantiation/common/extensions.js';
+import { createDecorator, ServicesAccessor } from '../../../platform/instantiation/common/instantiation.js';
+import { IQuickInputService, IQuickPickItem } from '../../../platform/quickinput/common/quickInput.js';
 
-export const IInlineCompletionsService = createDecorator<IInlineCompletionsService>('inlineCompletionsService');
+export const IInlineCompletionsService = createDecorator<IInlineCompletionsService>('IInlineCompletionsService');
 
 export interface IInlineCompletionsService {
 	readonly _serviceBrand: undefined;

--- a/src/vs/editor/contrib/inlineCompletions/browser/controller/inlineCompletionsController.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/controller/inlineCompletionsController.ts
@@ -37,7 +37,7 @@ import { ObservableContextKeyService } from '../utils.js';
 import { InlineCompletionsView } from '../view/inlineCompletionsView.js';
 import { inlineSuggestCommitId } from './commandIds.js';
 import { InlineCompletionContextKeys } from './inlineCompletionContextKeys.js';
-import { IInlineCompletionsService } from '../services/inlineCompletionsService.js';
+import { IInlineCompletionsService } from '../../../../browser/services/inlineCompletionsService.js';
 
 export class InlineCompletionsController extends Disposable {
 	private static readonly _instances = new Set<InlineCompletionsController>();

--- a/src/vs/editor/contrib/inlineCompletions/browser/controller/inlineCompletionsController.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/controller/inlineCompletionsController.ts
@@ -37,6 +37,7 @@ import { ObservableContextKeyService } from '../utils.js';
 import { InlineCompletionsView } from '../view/inlineCompletionsView.js';
 import { inlineSuggestCommitId } from './commandIds.js';
 import { InlineCompletionContextKeys } from './inlineCompletionContextKeys.js';
+import { IInlineCompletionsService } from '../services/inlineCompletionsService.js';
 
 export class InlineCompletionsController extends Disposable {
 	private static readonly _instances = new Set<InlineCompletionsController>();
@@ -95,6 +96,7 @@ export class InlineCompletionsController extends Disposable {
 		@IAccessibilitySignalService private readonly _accessibilitySignalService: IAccessibilitySignalService,
 		@IKeybindingService private readonly _keybindingService: IKeybindingService,
 		@IAccessibilityService private readonly _accessibilityService: IAccessibilityService,
+		@IInlineCompletionsService private readonly _inlineCompletionsService: IInlineCompletionsService,
 	) {
 		super();
 		this._editorObs = observableCodeEditor(this.editor);
@@ -110,7 +112,8 @@ export class InlineCompletionsController extends Disposable {
 			this._contextKeyService.onDidChangeContext,
 			() => this._contextKeyService.getContext(this.editor.getDomNode()).getValue('editorDictation.inProgress') === true
 		);
-		this._enabled = derived(this, reader => this._enabledInConfig.read(reader) && (!this._isScreenReaderEnabled.read(reader) || !this._editorDictationInProgress.read(reader)));
+		const isSnoozing = observableFromEvent(this, this._inlineCompletionsService.onDidChangeIsSnoozing, () => this._inlineCompletionsService.isSnoozing());
+		this._enabled = derived(this, reader => this._enabledInConfig.read(reader) && !isSnoozing.read(reader) && (!this._isScreenReaderEnabled.read(reader) || !this._editorDictationInProgress.read(reader)));
 		this._debounceValue = this._debounceService.for(
 			this._languageFeaturesService.inlineCompletionsProvider,
 			'InlineCompletionsDebounce',

--- a/src/vs/editor/contrib/inlineCompletions/browser/inlineCompletions.contribution.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/inlineCompletions.contribution.ts
@@ -12,7 +12,7 @@ import { AcceptInlineCompletion, AcceptNextLineOfInlineCompletion, AcceptNextWor
 import { InlineCompletionsController } from './controller/inlineCompletionsController.js';
 import { InlineCompletionsHoverParticipant } from './hintsWidget/hoverParticipant.js';
 import { InlineCompletionsAccessibleView } from './inlineCompletionsAccessibleView.js';
-import { CancelSnoozeInlineCompletion, SnoozeInlineCompletion } from './services/inlineCompletionsService.js';
+import { CancelSnoozeInlineCompletion, SnoozeInlineCompletion } from '../../../browser/services/inlineCompletionsService.js';
 
 registerEditorContribution(InlineCompletionsController.ID, wrapInHotClass1(InlineCompletionsController.hot), EditorContributionInstantiation.Eventually);
 

--- a/src/vs/editor/contrib/inlineCompletions/browser/inlineCompletions.contribution.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/inlineCompletions.contribution.ts
@@ -12,6 +12,7 @@ import { AcceptInlineCompletion, AcceptNextLineOfInlineCompletion, AcceptNextWor
 import { InlineCompletionsController } from './controller/inlineCompletionsController.js';
 import { InlineCompletionsHoverParticipant } from './hintsWidget/hoverParticipant.js';
 import { InlineCompletionsAccessibleView } from './inlineCompletionsAccessibleView.js';
+import { CancelSnoozeInlineCompletion, SnoozeInlineCompletion } from './services/inlineCompletionsService.js';
 
 registerEditorContribution(InlineCompletionsController.ID, wrapInHotClass1(InlineCompletionsController.hot), EditorContributionInstantiation.Eventually);
 
@@ -28,6 +29,8 @@ registerEditorAction(HideInlineCompletion);
 registerEditorAction(JumpToNextInlineEdit);
 registerAction2(ToggleAlwaysShowInlineSuggestionToolbar);
 registerEditorAction(DevExtractReproSample);
+registerAction2(SnoozeInlineCompletion);
+registerAction2(CancelSnoozeInlineCompletion);
 
 HoverParticipantRegistry.register(InlineCompletionsHoverParticipant);
 AccessibleViewRegistry.register(new InlineCompletionsAccessibleView());

--- a/src/vs/editor/contrib/inlineCompletions/browser/services/inlineCompletionsService.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/services/inlineCompletionsService.ts
@@ -1,0 +1,182 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { WindowIntervalTimer } from '../../../../../base/browser/dom.js';
+import { BugIndicatingError } from '../../../../../base/common/errors.js';
+import { Emitter, Event } from '../../../../../base/common/event.js';
+import { Disposable } from '../../../../../base/common/lifecycle.js';
+import { localize, localize2 } from '../../../../../nls.js';
+import { Action2 } from '../../../../../platform/actions/common/actions.js';
+import { ContextKeyExpr, IContextKeyService, RawContextKey } from '../../../../../platform/contextkey/common/contextkey.js';
+import { InstantiationType, registerSingleton } from '../../../../../platform/instantiation/common/extensions.js';
+import { createDecorator } from '../../../../../platform/instantiation/common/instantiation.js';
+import { IQuickInputService, IQuickPickItem } from '../../../../../platform/quickinput/common/quickInput.js';
+import { ServicesAccessor } from '../../../../browser/editorExtensions.js';
+
+export const IInlineCompletionsService = createDecorator<IInlineCompletionsService>('inlineCompletionsService');
+
+export interface IInlineCompletionsService {
+	readonly _serviceBrand: undefined;
+
+	onDidChangeIsSnoozing: Event<boolean>;
+
+	/**
+	 * Get the remaining time (in ms) for which inline completions should be snoozed,
+	 * or 0 if not snoozed.
+	 */
+	readonly snoozeTimeLeft: number;
+
+	/**
+	 * Snooze inline completions for the specified duration. If already snoozed, extend the snooze time.
+	 */
+	snooze(durationMs?: number): void;
+
+	/**
+	 * Snooze inline completions for the specified duration. If already snoozed, overwrite the existing snooze time.
+	 */
+	setSnoozeDuration(durationMs: number): void;
+
+	/**
+	 * Check if inline completions are currently snoozed.
+	 */
+	isSnoozing(): boolean;
+
+	/**
+	 * Cancel the current snooze.
+	 */
+	cancelSnooze(): void;
+}
+
+const InlineCompletionsSnoozing = new RawContextKey<boolean>('inlineCompletions.snoozed', false, localize('inlineCompletions.snoozed', "Whether inline completions are currently snoozed"));
+
+export class InlineCompletionsService extends Disposable implements IInlineCompletionsService {
+	declare readonly _serviceBrand: undefined;
+
+	private _onDidChangeIsSnoozing = this._register(new Emitter<boolean>());
+	readonly onDidChangeIsSnoozing: Event<boolean> = this._onDidChangeIsSnoozing.event;
+
+	private static readonly SNOOZE_DURATION = 300_000; // 5 minutes
+
+	private _snoozeTimeEnd: undefined | number = undefined;
+	get snoozeTimeLeft(): number {
+		if (this._snoozeTimeEnd === undefined) {
+			return 0;
+		}
+		return Math.max(0, this._snoozeTimeEnd - Date.now());
+	}
+
+	private _timer: WindowIntervalTimer;
+
+	constructor(@IContextKeyService private _contextKeyService: IContextKeyService) {
+		super();
+
+		this._timer = this._register(new WindowIntervalTimer());
+
+		const inlineCompletionsSnoozing = InlineCompletionsSnoozing.bindTo(this._contextKeyService);
+		this._register(this.onDidChangeIsSnoozing(() => inlineCompletionsSnoozing.set(this.isSnoozing())));
+	}
+
+	snooze(durationMs: number = InlineCompletionsService.SNOOZE_DURATION): void {
+		this.setSnoozeDuration(durationMs + this.snoozeTimeLeft);
+	}
+
+	setSnoozeDuration(durationMs: number): void {
+		const wasSnoozing = this.isSnoozing();
+
+		if (this._snoozeTimeEnd === undefined) {
+			this._snoozeTimeEnd = Date.now() + durationMs;
+		} else if (this.snoozeTimeLeft > 0) {
+			this._snoozeTimeEnd += durationMs;
+		} else {
+			this._snoozeTimeEnd = Date.now() + durationMs;
+		}
+
+		const isSnoozing = this.isSnoozing();
+		if (wasSnoozing !== isSnoozing) {
+			this._onDidChangeIsSnoozing.fire(isSnoozing);
+		}
+
+		if (isSnoozing) {
+			this._timer.cancelAndSet(
+				() => {
+					if (!this.isSnoozing()) {
+						this._onDidChangeIsSnoozing.fire(false);
+					} else {
+						throw new BugIndicatingError('Snooze timer did not fire as expected');
+					}
+				},
+				this.snoozeTimeLeft + 1,
+			);
+		}
+	}
+
+	isSnoozing(): boolean {
+		return this.snoozeTimeLeft > 0;
+	}
+
+	cancelSnooze(): void {
+		if (this.isSnoozing()) {
+			this._snoozeTimeEnd = undefined;
+			this._timer.cancel();
+			this._onDidChangeIsSnoozing.fire(false);
+		}
+	}
+}
+
+registerSingleton(IInlineCompletionsService, InlineCompletionsService, InstantiationType.Delayed);
+
+const snoozeInlineSuggestId = 'editor.action.inlineSuggest.snooze';
+const cancelSnoozeInlineSuggestId = 'editor.action.inlineSuggest.cancelSnooze';
+
+export class SnoozeInlineCompletion extends Action2 {
+	public static ID = snoozeInlineSuggestId;
+	constructor() {
+		super({
+			id: SnoozeInlineCompletion.ID,
+			title: localize2('action.inlineSuggest.snooze', "Snooze Inline Suggestions"),
+			precondition: ContextKeyExpr.true(),
+			f1: true,
+		});
+	}
+
+	public async run(accessor: ServicesAccessor): Promise<void> {
+		const quickInputService = accessor.get(IQuickInputService);
+		const inlineCompletionsService = accessor.get(IInlineCompletionsService);
+
+		const items: IQuickPickItem[] = [
+			{ label: '5 minutes', id: '5', picked: true },
+			{ label: '10 minutes', id: '10' },
+			{ label: '15 minutes', id: '15' },
+			{ label: '30 minutes', id: '30' },
+			{ label: '60 minutes', id: '60' }
+		];
+
+		const picked = await quickInputService.pick(items, {
+			placeHolder: localize('snooze.placeholder', "Select snooze duration")
+		});
+
+		if (picked) {
+			const minutes = parseInt(picked.id!, 10);
+			const durationMs = minutes * 60 * 1000;
+			inlineCompletionsService.setSnoozeDuration(durationMs);
+		}
+	}
+}
+
+export class CancelSnoozeInlineCompletion extends Action2 {
+	public static ID = cancelSnoozeInlineSuggestId;
+	constructor() {
+		super({
+			id: CancelSnoozeInlineCompletion.ID,
+			title: localize2('action.inlineSuggest.cancelSnooze', "Cancel Snooze Inline Suggestions"),
+			precondition: InlineCompletionsSnoozing,
+			f1: true,
+		});
+	}
+
+	public async run(accessor: ServicesAccessor): Promise<void> {
+		accessor.get(IInlineCompletionsService).cancelSnooze();
+	}
+}

--- a/src/vs/editor/standalone/browser/standaloneServices.ts
+++ b/src/vs/editor/standalone/browser/standaloneServices.ts
@@ -10,6 +10,7 @@ import '../../common/services/languageFeatureDebounce.js';
 import '../../common/services/semanticTokensStylingService.js';
 import '../../common/services/languageFeaturesService.js';
 import '../../browser/services/hoverService/hoverService.js';
+import '../../contrib/inlineCompletions/browser/services/inlineCompletionsService.js';
 
 import * as strings from '../../../base/common/strings.js';
 import * as dom from '../../../base/browser/dom.js';

--- a/src/vs/editor/standalone/browser/standaloneServices.ts
+++ b/src/vs/editor/standalone/browser/standaloneServices.ts
@@ -10,7 +10,7 @@ import '../../common/services/languageFeatureDebounce.js';
 import '../../common/services/semanticTokensStylingService.js';
 import '../../common/services/languageFeaturesService.js';
 import '../../browser/services/hoverService/hoverService.js';
-import '../../contrib/inlineCompletions/browser/services/inlineCompletionsService.js';
+import '../../browser/services/inlineCompletionsService.js';
 
 import * as strings from '../../../base/common/strings.js';
 import * as dom from '../../../base/browser/dom.js';

--- a/src/vs/editor/test/browser/testCodeEditor.ts
+++ b/src/vs/editor/test/browser/testCodeEditor.ts
@@ -61,6 +61,7 @@ import { IUndoRedoService } from '../../../platform/undoRedo/common/undoRedo.js'
 import { UndoRedoService } from '../../../platform/undoRedo/common/undoRedoService.js';
 import { ITreeSitterLibraryService } from '../../common/services/treeSitter/treeSitterLibraryService.js';
 import { TestTreeSitterLibraryService } from '../common/services/testTreeSitterLibraryService.js';
+import { IInlineCompletionsService, InlineCompletionsService } from '../../browser/services/inlineCompletionsService.js';
 
 export interface ITestCodeEditor extends IActiveCodeEditor {
 	getViewModel(): ViewModel | undefined;
@@ -222,6 +223,7 @@ export function createCodeEditorServices(disposables: Pick<DisposableStore, 'add
 	define(ILanguageFeatureDebounceService, LanguageFeatureDebounceService);
 	define(ILanguageFeaturesService, LanguageFeaturesService);
 	define(ITreeSitterLibraryService, TestTreeSitterLibraryService);
+	define(IInlineCompletionsService, InlineCompletionsService);
 
 	const instantiationService = disposables.add(new TestInstantiationService(services, true));
 	disposables.add(toDisposable(() => {

--- a/src/vs/workbench/contrib/chat/browser/chatStatus.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatStatus.ts
@@ -42,7 +42,7 @@ import { ActionBar } from '../../../../base/browser/ui/actionbar/actionbar.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
 import { Codicon } from '../../../../base/common/codicons.js';
 import { URI } from '../../../../base/common/uri.js';
-import { IInlineCompletionsService } from '../../../../editor/contrib/inlineCompletions/browser/services/inlineCompletionsService.js';
+import { IInlineCompletionsService } from '../../../../editor/browser/services/inlineCompletionsService.js';
 
 const gaugeBackground = registerColor('gauge.background', {
 	dark: inputValidationInfoBorder,

--- a/src/vs/workbench/contrib/chat/browser/chatStatus.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatStatus.ts
@@ -10,7 +10,7 @@ import { language } from '../../../../base/common/platform.js';
 import { localize } from '../../../../nls.js';
 import { IWorkbenchContribution } from '../../../common/contributions.js';
 import { IStatusbarEntry, IStatusbarEntryAccessor, IStatusbarService, ShowTooltipCommand, StatusbarAlignment, StatusbarEntryKind } from '../../../services/statusbar/browser/statusbar.js';
-import { $, addDisposableListener, append, clearNode, EventHelper, EventType } from '../../../../base/browser/dom.js';
+import { $, addDisposableListener, append, clearNode, disposableWindowInterval, EventHelper, EventType, getWindow } from '../../../../base/browser/dom.js';
 import { ChatEntitlement, ChatEntitlementService, IChatEntitlementService, IQuotaSnapshot, isProUser } from '../common/chatEntitlementService.js';
 import { CancellationToken } from '../../../../base/common/cancellation.js';
 import { defaultButtonStyles, defaultCheckboxStyles } from '../../../../platform/theme/browser/defaultStyles.js';
@@ -42,6 +42,7 @@ import { ActionBar } from '../../../../base/browser/ui/actionbar/actionbar.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
 import { Codicon } from '../../../../base/common/codicons.js';
 import { URI } from '../../../../base/common/uri.js';
+import { IInlineCompletionsService } from '../../../../editor/contrib/inlineCompletions/browser/services/inlineCompletionsService.js';
 
 const gaugeBackground = registerColor('gauge.background', {
 	dark: inputValidationInfoBorder,
@@ -315,6 +316,7 @@ class ChatStatusDashboard extends Disposable {
 		@IOpenerService private readonly openerService: IOpenerService,
 		@ITelemetryService private readonly telemetryService: ITelemetryService,
 		@ITextResourceConfigurationService private readonly textResourceConfigurationService: ITextResourceConfigurationService,
+		@IInlineCompletionsService private readonly inlineCompletionsService: IInlineCompletionsService,
 	) {
 		super();
 	}
@@ -359,7 +361,7 @@ class ChatStatusDashboard extends Disposable {
 			}
 
 			if (this.chatEntitlementService.entitlement === ChatEntitlement.Free && (Number(chatQuota?.percentRemaining) <= 25 || Number(completionsQuota?.percentRemaining) <= 25)) {
-				const upgradeProButton = disposables.add(new Button(this.element, { ...defaultButtonStyles, secondary: canUseCopilot(this.chatEntitlementService) /* use secondary color when copilot can still be used */ }));
+				const upgradeProButton = disposables.add(new Button(this.element, { ...defaultButtonStyles, hoverDelegate: nativeHoverDelegate, secondary: canUseCopilot(this.chatEntitlementService) /* use secondary color when copilot can still be used */ }));
 				upgradeProButton.label = localize('upgradeToCopilotPro', "Upgrade to Copilot Pro");
 				disposables.add(upgradeProButton.onDidClick(() => this.runCommandAndClose('workbench.action.chat.upgradePlan')));
 			}
@@ -410,7 +412,7 @@ class ChatStatusDashboard extends Disposable {
 		// Settings
 		{
 			const chatSentiment = this.chatEntitlementService.sentiment;
-			addSeparator(localize('settingsTitle', "Settings"), chatSentiment.installed && !chatSentiment.disabled && !chatSentiment.untrusted ? toAction({
+			addSeparator(localize('completionsAndNES', "Completions / NES"), chatSentiment.installed && !chatSentiment.disabled && !chatSentiment.untrusted ? toAction({
 				id: 'workbench.action.openChatSettings',
 				label: localize('settingsLabel', "Settings"),
 				tooltip: localize('settingsTooltip', "Open Settings"),
@@ -419,6 +421,12 @@ class ChatStatusDashboard extends Disposable {
 			}) : undefined);
 
 			this.createSettings(this.element, disposables);
+		}
+
+		// Completions Snooze
+		if (canUseCopilot(this.chatEntitlementService)) {
+			const snooze = append(this.element, $('div.snooze-completions'));
+			this.createCompletionsSnooze(snooze, localize('settings.snooze', "Snooze"), disposables);
 		}
 
 		// New to Copilot / Signed out
@@ -449,7 +457,7 @@ class ChatStatusDashboard extends Disposable {
 
 				this.element.appendChild($('div.description', undefined, descriptionText));
 
-				const button = disposables.add(new Button(this.element, { ...defaultButtonStyles }));
+				const button = disposables.add(new Button(this.element, { ...defaultButtonStyles, hoverDelegate: nativeHoverDelegate }));
 				button.label = buttonLabel;
 				disposables.add(button.onDidClick(() => this.runCommandAndClose('workbench.action.chat.triggerSetup')));
 			}
@@ -536,7 +544,7 @@ class ChatStatusDashboard extends Disposable {
 		));
 
 		if (supportsOverage && (this.chatEntitlementService.entitlement === ChatEntitlement.Pro || this.chatEntitlementService.entitlement === ChatEntitlement.ProPlus)) {
-			const manageOverageButton = disposables.add(new Button(quotaIndicator, { ...defaultButtonStyles, secondary: true }));
+			const manageOverageButton = disposables.add(new Button(quotaIndicator, { ...defaultButtonStyles, secondary: true, hoverDelegate: nativeHoverDelegate }));
 			manageOverageButton.label = localize('enableAdditionalUsage', "Manage paid premium requests");
 			disposables.add(manageOverageButton.onDidClick(() => this.runCommandAndClose(() => this.openerService.open(URI.parse(defaultChat.manageOverageUrl)))));
 		}
@@ -609,7 +617,7 @@ class ChatStatusDashboard extends Disposable {
 	}
 
 	private createSetting(container: HTMLElement, settingIdsToReEvaluate: string[], label: string, accessor: ISettingsAccessor, disposables: DisposableStore): Checkbox {
-		const checkbox = disposables.add(new Checkbox(label, Boolean(accessor.readSetting()), defaultCheckboxStyles));
+		const checkbox = disposables.add(new Checkbox(label, Boolean(accessor.readSetting()), { ...defaultCheckboxStyles, hoverDelegate: nativeHoverDelegate }));
 		container.appendChild(checkbox.domNode);
 
 		const settingLabel = append(container, $('span.setting-label', undefined, label));
@@ -706,6 +714,85 @@ class ChatStatusDashboard extends Disposable {
 					container.classList.add('disabled');
 				}
 			}
+		}));
+	}
+
+	private createCompletionsSnooze(container: HTMLElement, label: string, disposables: DisposableStore): void {
+		const isEnabled = () => {
+			const completionsEnabled = isCompletionsEnabled(this.configurationService);
+			const completionsEnabledActiveLanguage = isCompletionsEnabled(this.configurationService, this.editorService.activeTextEditorLanguageId);
+			return completionsEnabled || completionsEnabledActiveLanguage;
+		};
+
+		const button = disposables.add(new Button(container, { disabled: !isEnabled(), ...defaultButtonStyles, hoverDelegate: nativeHoverDelegate, secondary: true }));
+
+		const timerDisplay = container.appendChild($('span.snooze-label'));
+
+		const actionBar = container.appendChild($('div.snooze-action-bar'));
+		const toolbar = disposables.add(new ActionBar(actionBar, { hoverDelegate: nativeHoverDelegate }));
+		const cancelAction = toAction({
+			id: 'workbench.action.cancelSnoozeStatusBarLink',
+			label: 'Cancel Snooze',
+			run: () => this.inlineCompletionsService.cancelSnooze(),
+			class: ThemeIcon.asClassName(Codicon.stopCircle)
+		});
+
+		const update = (isEnabled: boolean) => {
+			container.classList.toggle('disabled', !isEnabled);
+			toolbar.clear();
+
+			const timeLeftMs = this.inlineCompletionsService.snoozeTimeLeft;
+			if (!isEnabled || timeLeftMs <= 0) {
+				timerDisplay.textContent = localize('settings.mute5minutes', "Mute for 5 mins");
+				button.label = label;
+				button.setTitle(localize('settings.snooze5minutes', "Snooze completions and NES for 5 mins"));
+				return true;
+			}
+
+			const timeLeftSeconds = Math.ceil(timeLeftMs / 1000);
+			const minutes = Math.floor(timeLeftSeconds / 60);
+			const seconds = timeLeftSeconds % 60;
+
+			timerDisplay.textContent = `${minutes}:${seconds < 10 ? '0' : ''}${seconds} remaining`;
+			button.label = localize('settings.plus5mins', "+5 mins");
+			button.setTitle(localize('settings.snoozeAdditional5minutes', "Snooze additional 5 mins"));
+			toolbar.push([cancelAction], { icon: true, label: false });
+
+			return false;
+		};
+
+		// Update every second if there's time remaining
+		const timerDisposables = disposables.add(new DisposableStore());
+		function updateIntervalTimer() {
+			timerDisposables.clear();
+			const enabled = isEnabled();
+
+			if (update(enabled)) {
+				return;
+			}
+
+			timerDisposables.add(disposableWindowInterval(
+				getWindow(container),
+				() => update(enabled),
+				1_000,
+			));
+		}
+		updateIntervalTimer();
+
+		disposables.add(button.onDidClick(() => {
+			this.inlineCompletionsService.snooze();
+			update(isEnabled());
+		}));
+
+		disposables.add(this.configurationService.onDidChangeConfiguration(e => {
+			if (e.affectsConfiguration(defaultChat.completionsEnablementSetting)) {
+				button.enabled = isEnabled();
+			}
+			updateIntervalTimer();
+		}));
+
+		disposables.add(this.inlineCompletionsService.onDidChangeIsSnoozing(e => {
+			updateIntervalTimer();
 		}));
 	}
 }

--- a/src/vs/workbench/contrib/chat/browser/media/chatStatus.css
+++ b/src/vs/workbench/contrib/chat/browser/media/chatStatus.css
@@ -121,6 +121,42 @@
 	color: var(--vscode-disabledForeground);
 }
 
+/* Snoozing */
+
+.chat-status-bar-entry-tooltip .snooze-completions {
+	margin-top: 6px;
+	display: flex;
+	flex-direction: row;
+	flex-wrap: nowrap;
+	align-items: center;
+	gap: 6px;
+}
+
+.chat-status-bar-entry-tooltip .snooze-completions .monaco-button {
+	width: fit-content;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	text-wrap: nowrap;
+	padding: 2px 8px;
+}
+
+.chat-status-bar-entry-tooltip .snooze-completions .snooze-label {
+	flex: 1;
+	padding-left: 2px;
+	color: var(--vscode-descriptionForeground);
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.chat-status-bar-entry-tooltip .snooze-completions.disabled .snooze-label {
+	color: var(--vscode-disabledForeground);
+}
+
+.chat-status-bar-entry-tooltip .snooze-completions .snooze-action-bar {
+	margin-left: auto;
+}
+
 /* Contributions */
 
 .chat-status-bar-entry-tooltip .contribution .body {


### PR DESCRIPTION
```Copilot Generated Description:``` Introduce a snooze feature for inline completions, allowing users to temporarily disable suggestions for a specified duration. This includes the implementation of the snooze and cancel actions, along with the necessary service and UI updates.