### PR TITLE
debug: fix taskkill warning when stopping debugging of a C# app

### DIFF
--- a/src/vs/workbench/contrib/debug/node/debugAdapter.ts
+++ b/src/vs/workbench/contrib/debug/node/debugAdapter.ts
@@ -289,7 +289,9 @@ export class ExecutableDebugAdapter extends StreamDebugAdapter {
 		// processes. Therefore we use TASKKILL.EXE
 		await this.cancelPendingRequests();
 		if (platform.isWindows) {
-			return killTree(this.serverProcess!.pid!, true);
+			return killTree(this.serverProcess!.pid!, true).catch(() => {
+				this.serverProcess?.kill();
+			});
 		} else {
 			this.serverProcess.kill('SIGTERM');
 			return Promise.resolve(undefined);


### PR DESCRIPTION
We didn't warn about this previously, and I accidentally made some changes that avoided the implicit 'catch' we had here.

Fixes #253026

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
