### PR TITLE
Onboarding prompt after MCP server install

### DIFF
--- a/src/vs/workbench/contrib/mcp/browser/mcpWorkbenchService.ts
+++ b/src/vs/workbench/contrib/mcp/browser/mcpWorkbenchService.ts
@@ -34,9 +34,6 @@ import { IRemoteAgentService } from '../../../services/remote/common/remoteAgent
 import { mcpConfigurationSection } from '../common/mcpConfiguration.js';
 import { HasInstalledMcpServersContext, IMcpConfigPath, IMcpWorkbenchService, IWorkbenchMcpServer, McpCollectionSortOrder, McpServersGalleryEnabledContext } from '../common/mcpTypes.js';
 import { McpServerEditorInput } from './mcpServerEditorInput.js';
-import { ICommandService } from '../../../../platform/commands/common/commands.js';
-import { CHAT_OPEN_ACTION_ID, IChatViewOpenOptions } from '../../chat/browser/actions/chatActions.js';
-import { ChatModeKind } from '../../chat/common/constants.js';
 
 class McpWorkbenchServer implements IWorkbenchMcpServer {
 
@@ -154,7 +151,6 @@ export class McpWorkbenchService extends Disposable implements IMcpWorkbenchServ
 		@IProductService private readonly productService: IProductService,
 		@IRemoteAgentService private readonly remoteAgentService: IRemoteAgentService,
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
-		@ICommandService private readonly commandService: ICommandService,
 		@IURLService urlService: IURLService,
 	) {
 		super();
@@ -249,35 +245,6 @@ export class McpWorkbenchService extends Disposable implements IMcpWorkbenchServ
 			await this.mcpManagementService.installFromGallery(server.gallery, { packageType: server.gallery.packageTypes[0] });
 		} else {
 			throw new Error('No installable server found');
-		}
-
-		// After successful installation, check if the server has a readme and prompt
-		await this.queryLocal(); // Refresh local servers to get the updated state
-		const installedServer = this._local.find(s => s.name === server.name);
-
-		if (installedServer) {
-			try {
-				// Open chat with prompt about the installed server
-				let query: string;
-				if (installedServer.local?.readmeUrl) {
-					// If readme exists, reference it
-					query = `Suggest interesting developer workflows I could run with MCP tools from ${installedServer.local.readmeUrl.toString()}`;
-				} else {
-					// Fallback: use the server name
-					const serverName = installedServer.label || installedServer.name;
-					query = `Suggest interesting developer workflows I could run with the ${serverName} MCP tools`;
-				}
-
-				const options: IChatViewOpenOptions = {
-					query,
-					isPartialQuery: true,
-					mode: ChatModeKind.Agent
-				};
-				await this.commandService.executeCommand(CHAT_OPEN_ACTION_ID, options);
-			} catch (error) {
-				// If we can't open the chat, just skip
-				console.debug('Could not open chat for MCP server:', error);
-			}
 		}
 	}
 

--- a/src/vs/workbench/contrib/mcp/browser/mcpWorkbenchService.ts
+++ b/src/vs/workbench/contrib/mcp/browser/mcpWorkbenchService.ts
@@ -255,11 +255,21 @@ export class McpWorkbenchService extends Disposable implements IMcpWorkbenchServ
 		await this.queryLocal(); // Refresh local servers to get the updated state
 		const installedServer = this._local.find(s => s.name === server.name);
 
-		if (installedServer?.local?.readmeUrl) {
+		if (installedServer) {
 			try {
 				// Open chat with prompt about the installed server
+				let query: string;
+				if (installedServer.local?.readmeUrl) {
+					// If readme exists, reference it
+					query = `Suggest interesting developer workflows I could run with MCP tools from ${installedServer.local.readmeUrl.toString()}`;
+				} else {
+					// Fallback: use the server name
+					const serverName = installedServer.label || installedServer.name;
+					query = `Suggest interesting developer workflows I could run with the ${serverName} MCP tools`;
+				}
+
 				const options: IChatViewOpenOptions = {
-					query: `Suggest interesting developer workflows I could run with MCP tools from ${installedServer.local.readmeUrl.toString()}`,
+					query,
 					isPartialQuery: true,
 					mode: ChatModeKind.Agent
 				};

--- a/src/vs/workbench/contrib/mcp/browser/mcpWorkbenchService.ts
+++ b/src/vs/workbench/contrib/mcp/browser/mcpWorkbenchService.ts
@@ -241,11 +241,15 @@ export class McpWorkbenchService extends Disposable implements IMcpWorkbenchServ
 	async install(server: IWorkbenchMcpServer): Promise<void> {
 		if (server.installable) {
 			await this.mcpManagementService.install(server.installable);
-		} else if (server.gallery) {
-			await this.mcpManagementService.installFromGallery(server.gallery, { packageType: server.gallery.packageTypes[0] });
-		} else {
-			throw new Error('No installable server found');
+			return;
 		}
+
+		if (server.gallery) {
+			await this.mcpManagementService.installFromGallery(server.gallery, { packageType: server.gallery.packageTypes[0] });
+			return;
+		}
+
+		throw new Error('No installable server found');
 	}
 
 	async uninstall(server: IWorkbenchMcpServer): Promise<void> {


### PR DESCRIPTION
Light onboarding after installing MCP servers, suggesting a prompt based on the server readme or, as fallback, tool names.