### PR TITLE
build: update preinstall check for node@22.15.1

### DIFF
--- a/build/npm/preinstall.js
+++ b/build/npm/preinstall.js
@@ -9,8 +9,8 @@ const minorNodeVersion = parseInt(nodeVersion[2]);
 const patchNodeVersion = parseInt(nodeVersion[3]);
 
 if (!process.env['VSCODE_SKIP_NODE_VERSION_CHECK']) {
-	if (majorNodeVersion < 20 || (majorNodeVersion === 20 && minorNodeVersion < 18) || (majorNodeVersion === 20 && minorNodeVersion === 18 && patchNodeVersion < 1)) {
-		console.error('\x1b[1;31m*** Please use Node.js v20.18.1 or later for development.\x1b[0;0m');
+	if (majorNodeVersion < 22 || (majorNodeVersion === 22 && minorNodeVersion < 15) || (majorNodeVersion === 22 && minorNodeVersion === 15 && patchNodeVersion < 1)) {
+		console.error('\x1b[1;31m*** Please use Node.js v22.15.1 or later for development.\x1b[0;0m');
 		throw new Error();
 	}
 }


### PR DESCRIPTION
One of our dependencies needs sync esm which breaks compilation when using Node.js v20.18.1 without `--experimental-require-module` flag passed explicitly. Bump node version checks to what our current `.nvmrc` states and additionally with this version the flag is enabled by default.

```
demohan@Deepaks-MacBook-Pro vscode % npm run compile

> code-oss-dev@1.102.0 compile
> node ./node_modules/gulp/bin/gulp.js compile

Error [ERR_REQUIRE_ESM]: require() of ES Module /Users/demohan/github/vscode/node_modules/@vscode/gulp-electron/node_modules/@electron/get/dist/index.js from /Users/demohan/github/vscode/node_modules/@vscode/gulp-electron/src/download.js not supported.
Instead change the require of index.js in /Users/demohan/github/vscode/node_modules/@vscode/gulp-electron/src/download.js to a dynamic import() which is available in all CommonJS modules.
    at Object.<anonymous> (/Users/demohan/github/vscode/node_modules/@vscode/gulp-electron/src/download.js:4:30) {
  code: 'ERR_REQUIRE_ESM'
}
```