### PR TITLE
Fix for canceling search on query triggered

### DIFF
--- a/src/vs/workbench/contrib/search/browser/searchView.ts
+++ b/src/vs/workbench/contrib/search/browser/searchView.ts
@@ -1656,6 +1656,7 @@ export class SearchView extends ViewPane {
 			this.inputPatternIncludes.onSearchSubmit();
 		});
 
+		this.viewModel.cancelSearch(true);
 		if (!shouldKeepAIResults) {
 			this.clearAIResults();
 		}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This fixes a regression where we were not canceling the previous searches on query changed.
The reason is that we changed a couple function calls into a helper function but left one behind.

![Screenshot 2025-07-01 at 1 36 01 PM](https://github.com/user-attachments/assets/bc90570c-12a8-41d4-b06b-12543256d277)
