### PR TITLE
Restore experiment from storage if exists

### DIFF
--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.ts
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.ts
@@ -962,7 +962,6 @@ export class GettingStartedPage extends EditorPane {
 			const startupExpValue = startupExpContext.getValue(this.contextService);
 
 			if (fistContentBehaviour === 'openToFirstCategory' && ((!startupExpValue || startupExpValue === '' || startupExpValue === StartupExperimentGroup.Control))) {
-				startupExpContext.bindTo(this.contextService).reset();
 				const first = this.gettingStartedCategories.filter(c => !c.when || this.contextService.contextMatchesRules(c.when))[0];
 				if (first) {
 					this.hasScrolledToFirstCategory = true;

--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/startupPage.ts
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/startupPage.ts
@@ -148,7 +148,6 @@ export class StartupPageRunnerContribution extends Disposable implements IWorkbe
 					if (this.storageService.isNew(StorageScope.APPLICATION)) {
 						const startupExpValue = startupExpContext.getValue(this.contextKeyService);
 						if (startupExpValue === StartupExperimentGroup.MaximizedChat || startupExpValue === StartupExperimentGroup.SplitEmptyEditorChat) {
-							startupExpContext.bindTo(this.contextKeyService).reset();
 							return;
 						}
 					}

--- a/src/vs/workbench/services/coreExperimentation/common/coreExperimentationService.ts
+++ b/src/vs/workbench/services/coreExperimentation/common/coreExperimentationService.ts
@@ -107,7 +107,15 @@ export class CoreExperimentationService extends Disposable implements ICoreExper
 		const storageKey = `coreExperimentation.${experimentConfig.experimentName}`;
 		const storedExperiment = this.storageService.get(storageKey, StorageScope.APPLICATION);
 		if (storedExperiment) {
-			return;
+			try {
+				const parsedExperiment: IExperiment = JSON.parse(storedExperiment);
+				this.experiments.set(experimentConfig.experimentName, parsedExperiment);
+				startupExpContext.bindTo(this.contextKeyService).set(parsedExperiment.experimentGroup);
+				return;
+			} catch (e) {
+				this.storageService.remove(storageKey, StorageScope.APPLICATION);
+				return;
+			}
 		}
 
 		const experiment = this.createStartupExperiment(experimentConfig.experimentName, experimentConfig);
@@ -196,4 +204,4 @@ export class CoreExperimentationService extends Disposable implements ICoreExper
 	}
 }
 
-registerSingleton(ICoreExperimentationService, CoreExperimentationService, InstantiationType.Delayed);
+registerSingleton(ICoreExperimentationService, CoreExperimentationService, InstantiationType.Eager);

--- a/src/vs/workbench/services/coreExperimentation/test/browser/coreExperimentationService.test.ts
+++ b/src/vs/workbench/services/coreExperimentation/test/browser/coreExperimentationService.test.ts
@@ -80,7 +80,7 @@ suite('CoreExperimentationService', () => {
 		contextKeyService = new MockContextKeyService();
 	});
 
-	test('should not initialize experiment if user has already seen startup experience (found in storage)', () => {
+	test('should return experiment from storage if it exists', () => {
 		storageService.store(firstSessionDateStorageKey, new Date().toUTCString(), StorageScope.APPLICATION, StorageTarget.MACHINE);
 
 		// Set that user has already seen the experiment
@@ -101,7 +101,7 @@ suite('CoreExperimentationService', () => {
 		));
 
 		// Should not return experiment again
-		assert.strictEqual(service.getExperiment(), undefined);
+		assert.deepStrictEqual(service.getExperiment(), existingExperiment);
 
 		// No telemetry should be sent for new experiment
 		assert.strictEqual(telemetryService.events.length, 0);


### PR DESCRIPTION
Core exp service is only doing local compute for generating exp buckets and is ok to be initialized  eagerly.