### PR TITLE
don't add `inlineCompletionItem` to model unless it's supported

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalSuggestAddon.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalSuggestAddon.ts
@@ -342,11 +342,13 @@ export class SuggestAddon extends Disposable implements ITerminalAddon, ISuggest
 		}
 
 		const lineContext = new LineContext(normalizedLeadingLineContent, this._cursorIndexDelta);
+		const items = completions.filter(c => !!c.label).map(c => new TerminalCompletionItem(c));
+		if (isInlineCompletionSupported(this.shellType)) {
+			items.push(this._inlineCompletionItem);
+		}
+
 		const model = new TerminalCompletionModel(
-			[
-				...completions.filter(c => !!c.label).map(c => new TerminalCompletionItem(c)),
-				this._inlineCompletionItem,
-			],
+			items,
 			lineContext
 		);
 		if (token.isCancellationRequested) {


### PR DESCRIPTION
fix #252367

<img width="1192" alt="Screenshot 2025-07-03 at 8 53 19 AM" src="https://github.com/user-attachments/assets/91bd62f0-fdff-4bb8-bdf5-8625608332b3" />
