### PR TITLE
prefer `Tab` kb over `Enter` so it shows in terminal suggest status bar

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminal.suggest.contribution.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminal.suggest.contribution.ts
@@ -441,7 +441,7 @@ registerActiveInstanceAction({
 	keybinding: [{
 		primary: KeyCode.Tab,
 		// Tab is bound to other workbench keybindings that this needs to beat
-		weight: KeybindingWeight.WorkbenchContrib + 1
+		weight: KeybindingWeight.WorkbenchContrib + 2
 	},
 	{
 		primary: KeyCode.Enter,


### PR DESCRIPTION
fix #253068