### PR TITLE
[release/1.102] Fixes https://github.com/microsoft/vscode-internalbacklog/issues/5602

### DIFF
--- a/src/vs/editor/contrib/inlineCompletions/browser/model/inlineCompletionsModel.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/model/inlineCompletionsModel.ts
@@ -172,6 +172,7 @@ export class InlineCompletionsModel extends Disposable {
 						changeSummary.changeReason = detailedReasons.length > 0 ? detailedReasons[0].getType() : '';
 						changeSummary.textChange = true;
 					} else if (ctx.didChange(this._forceUpdateExplicitlySignal)) {
+						changeSummary.preserveCurrentCompletion = true;
 						changeSummary.inlineCompletionTriggerKind = InlineCompletionTriggerKind.Explicit;
 					} else if (ctx.didChange(this.dontRefetchSignal)) {
 						changeSummary.dontRefetch = true;

--- a/src/vs/editor/contrib/inlineCompletions/test/browser/inlineCompletions.test.ts
+++ b/src/vs/editor/contrib/inlineCompletions/test/browser/inlineCompletions.test.ts
@@ -340,6 +340,7 @@ suite('Inline Completions', () => {
 
 		test('when accepting word by word', async function () {
 			// The user types the text as suggested and the provider reports a different suggestion.
+			// Even when triggering explicitly, we want to keep the suggestion.
 
 			const provider = new MockInlineCompletionsProvider();
 			await withAsyncTestCodeEditorAndInlineCompletionsModel('',
@@ -356,7 +357,7 @@ suite('Inline Completions', () => {
 
 					await ctx.model.triggerExplicitly(); // reset to provider truth
 					await timeout(10000);
-					assert.deepStrictEqual(ctx.context.getAndClearViewStates(), (["foo[ baz]"]));
+					assert.deepStrictEqual(ctx.context.getAndClearViewStates(), ([]));
 				}
 			);
 		});


### PR DESCRIPTION
Cherry-pick of commit 6db0578b2ae from main branch.

Fixes https://github.com/microsoft/vscode-internalbacklog/issues/5602

This fix ensures that when forcing an explicit update of inline completions, the current completion is preserved by setting \changeSummary.preserveCurrentCompletion = true\.

**Changes:**
- Added \changeSummary.preserveCurrentCompletion = true;\ in the explicit trigger path of InlineCompletionsModel

**Cherry-picked from:** #254099