### PR TITLE
[release/1.102] Fixes https://github.com/microsoft/vscode/issues/254153

### DIFF
--- a/src/vs/workbench/api/common/extHostCommands.ts
+++ b/src/vs/workbench/api/common/extHostCommands.ts
@@ -287,6 +287,10 @@ export class ExtHostCommands implements ExtHostCommandsShape {
 		if (!command.extension) {
 			return;
 		}
+		if (id.startsWith('code.copilot.logStructured')) {
+			// This command is very active. See https://github.com/microsoft/vscode/issues/254153.
+			return;
+		}
 		type ExtensionActionTelemetry = {
 			extensionId: string;
 			id: TelemetryTrustedValue<string>;


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/254153

Cherry-pick of https://github.com/microsoft/vscode/pull/254159 to release/1.102

This commit prevents excessive telemetry from the `code.copilot.logStructured` command which was causing performance issues.