### PR TITLE
Add *.tsbuildinfo to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,4 +20,5 @@ vscode.db
 /cli/openssl
 product.overrides.json
 *.snap.actual
+*.tsbuildinfo
 .vscode-test


### PR DESCRIPTION
The `.tsbuildinfo` file is generated by TypeScript when using certain compiler options or running `tsc --build`.