### PR TITLE
feat: allow programatic export of copilot chat logs #228144

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/actions/chatImportExport.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatImportExport.ts
@@ -18,6 +18,7 @@ import { ChatContextKeys } from '../../common/chatContextKeys.js';
 import { isExportableSessionData } from '../../common/chatModel.js';
 import { IChatService } from '../../common/chatService.js';
 import { IEditorService } from '../../../../services/editor/common/editorService.js';
+import { URI } from '../../../../../base/common/uri.js';
 
 const defaultFileName = 'chat.json';
 const filters = [{ name: localize('chat.file.label', "Chat Session"), extensions: ['json'] }];
@@ -44,14 +45,18 @@ export function registerChatExportActions() {
 				return;
 			}
 
-			const defaultUri = joinPath(await fileDialogService.defaultFilePath(), defaultFileName);
-			const result = await fileDialogService.showSaveDialog({
-				defaultUri,
-				filters
-			});
-			if (!result) {
-				return;
+			const dest = args.length > 0 ? args[0] : undefined;
+
+			// If destination is passed, use it and avoid the fileDialogService
+			// Otherwise, use the fileDialogService
+			let target: URI | undefined;
+			if (dest) {
+				target = typeof dest === 'string' ? URI.file(dest) : dest;
+			} else {
+				const defaultUri = joinPath(await fileDialogService.defaultFilePath(), defaultFileName);
+				target = await fileDialogService.showSaveDialog({ defaultUri, filters });
 			}
+			if (!target) { return; }
 
 			const model = chatService.getSession(widget.viewModel.sessionId);
 			if (!model) {
@@ -60,7 +65,10 @@ export function registerChatExportActions() {
 
 			// Using toJSON on the model
 			const content = VSBuffer.fromString(JSON.stringify(model.toExport(), undefined, 2));
-			await fileService.writeFile(result, content);
+			await fileService.writeFile(target, content, {
+				// Using atomic for better reliability
+				atomic: { postfix: '.vsctmp' }
+			});
 		}
 	});
 

--- a/src/vs/workbench/contrib/chat/browser/actions/chatImportExport.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatImportExport.ts
@@ -50,8 +50,8 @@ export function registerChatExportActions() {
 			// If destination is passed, use it and avoid the fileDialogService
 			// Otherwise, use the fileDialogService
 			let target: URI | undefined;
-			if (dest) {
-				target = typeof dest === 'string' ? URI.file(dest) : dest;
+			if (URI.isUri(dest)) {
+				target = dest;
 			} else {
 				const defaultUri = joinPath(await fileDialogService.defaultFilePath(), defaultFileName);
 				target = await fileDialogService.showSaveDialog({ defaultUri, filters });


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
closes: #228144 
Proposed changes:
- The [workbench.action.chat.export](https://github.com/microsoft/vscode/blob/38ae3ed024e8282b012027ac01e1458595fe2c19/src/vs/workbench/contrib/chat/browser/actions/chatImportExport.ts#L28) can now be passed a dest argument via the args parameter. If provided and a valid URI, this will be used to save the chat log, bypassing the manual fileSystemDialog.
- The intent of the above is to automate the ability to save copilot chat logs.

Testing these changes:
- Call the workbench.action.chat.export api and provide dest in args like this:
```ts
await vscode.commands.executeCommand('workbench.action.chat.export', [".github/chatlogs/export.json"]);
```