### PR TITLE
Correct capitalization of 'JetBrains' and 'ReSharper' in settings UI

### DIFF
--- a/src/vs/workbench/contrib/preferences/common/preferences.ts
+++ b/src/vs/workbench/contrib/preferences/common/preferences.ts
@@ -224,6 +224,10 @@ knownTermMappings.set('powershell', 'PowerShell');
 knownTermMappings.set('javascript', 'JavaScript');
 knownTermMappings.set('typescript', 'TypeScript');
 knownTermMappings.set('github', 'GitHub');
+knownTermMappings.set('jet brains', 'JetBrains');
+knownTermMappings.set('jetbrains', 'JetBrains');
+knownTermMappings.set('re sharper', 'ReSharper');
+knownTermMappings.set('resharper', 'ReSharper');
 
 export function wordifyKey(key: string): string {
 	key = key


### PR DESCRIPTION
This PR updates the display names for JetBrains and ReSharper in the VSCode settings UI to preserve their correct branding and capitalization.

Previously, the default camelCase word-splitting logic rendered ReSharper as "re sharper", which is incorrect. These terms are now explicitly set to display as JetBrains and ReSharper, respecting their proper casing and names.