### PR TITLE
NES in collapsed code fix

### DIFF
--- a/src/vs/editor/contrib/folding/browser/folding.ts
+++ b/src/vs/editor/contrib/folding/browser/folding.ts
@@ -511,6 +511,26 @@ export class FoldingController extends Disposable implements IEditorContribution
 	public reveal(position: IPosition): void {
 		this.editor.revealPositionInCenterIfOutsideViewport(position, ScrollType.Smooth);
 	}
+
+	public revealFoldedRegionsInRange(range: IRange): void {
+		const foldingModelPromise = this.getFoldingModel();
+		if (!foldingModelPromise) {
+			return;
+		}
+		foldingModelPromise.then(foldingModel => {
+			if (foldingModel && this.hiddenRangeModel) {
+				const toToggle: FoldingRegion[] = [];
+				for (let lineNumber = range.startLineNumber; lineNumber <= range.endLineNumber; lineNumber++) {
+					if (this.hiddenRangeModel.isHidden(lineNumber)) {
+						toToggle.push(...foldingModel.getAllRegionsAtLine(lineNumber, r => r.isCollapsed && lineNumber > r.startLineNumber));
+					}
+				}
+				if (toToggle.length) {
+					foldingModel.toggleCollapseState(toToggle);
+				}
+			}
+		}).then(undefined, onUnexpectedError);
+	}
 }
 
 export class RangesLimitReporter extends Disposable implements FoldingLimitReporter {

--- a/src/vs/editor/contrib/inlineCompletions/browser/model/inlineCompletionsModel.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/model/inlineCompletionsModel.ts
@@ -47,6 +47,7 @@ import { TextModelEditReason, EditReasons } from '../../../../common/textModelEd
 import { ICodeEditorService } from '../../../../browser/services/codeEditorService.js';
 import { InlineCompletionViewData, InlineCompletionViewKind } from '../view/inlineEdits/inlineEditsViewInterface.js';
 import { IInlineCompletionsService } from '../../../../browser/services/inlineCompletionsService.js';
+import { FoldingController } from '../../../folding/browser/folding.js';
 
 export class InlineCompletionsModel extends Disposable {
 	private readonly _source;
@@ -83,6 +84,8 @@ export class InlineCompletionsModel extends Disposable {
 	public readonly onDidAccept = this._onDidAccept.event;
 
 	private readonly _editorObs;
+
+	private readonly _foldingController;
 
 	private readonly _suggestPreviewEnabled;
 	private readonly _suggestPreviewMode;
@@ -163,6 +166,8 @@ export class InlineCompletionsModel extends Disposable {
 				};
 			}
 		}));
+
+		this._foldingController = FoldingController.get(this._editor);
 
 		const inlineCompletionProviders = observableFromEvent(this._languageFeaturesService.inlineCompletionsProvider.onDidChange, () => this._languageFeaturesService.inlineCompletionsProvider.all(textModel));
 		mapObservableArrayCached(this, inlineCompletionProviders, (provider, store) => {
@@ -661,10 +666,26 @@ export class InlineCompletionsModel extends Disposable {
 		return v?.primaryGhostText;
 	});
 
+	private readonly _visibleRanges = observableFromEvent(this._editor.onDidChangeHiddenAreas, () => this._editor.getVisibleRanges());
+
+	public readonly isInHiddenArea = derived(this, reader => {
+		const state = this.state.read(reader);
+		if (!state || state.kind !== 'inlineEdit') {
+			return false;
+		}
+
+		const completionRange = state.inlineCompletion.targetRange;
+		return !this._visibleRanges.read(reader).some(visibleRange => visibleRange.containsRange(completionRange));
+	});
+
 	public readonly showCollapsed = derived<boolean>(this, reader => {
 		const state = this.state.read(reader);
 		if (!state || state.kind !== 'inlineEdit') {
 			return false;
+		}
+
+		if (this.isInHiddenArea.read(reader)) {
+			return true;
 		}
 
 		if (state.inlineCompletion.displayLocation) {
@@ -1003,6 +1024,8 @@ export class InlineCompletionsModel extends Disposable {
 			this.dontRefetchSignal.trigger(tx);
 			const targetRange = s.inlineCompletion.targetRange;
 			const targetPosition = targetRange.getStartPosition();
+
+			this._foldingController?.revealFoldedRegionsInRange(targetRange);
 			this._editor.setPosition(targetPosition, 'inlineCompletions.jump');
 
 			// TODO: consider using view information to reveal it

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/components/gutterIndicatorView.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/components/gutterIndicatorView.ts
@@ -212,10 +212,10 @@ export class InlineEditsGutterIndicator extends Disposable {
 			const gutterEditArea = Rect.fromRanges(OffsetRange.fromTo(gutterViewPortWithoutStickyScroll.left, gutterViewPortWithoutStickyScroll.right), verticalEditRange);
 
 			// The gutter view container (pill)
-			const pillHeight = lineHeight;
+			const pillHeight = lineHeight > 0 ? lineHeight : 19; // Todo: find the height of the line
 			const pillOffset = this._verticalOffset.read(reader);
 			const pillFullyDockedRect = gutterEditArea.withHeight(pillHeight).translateY(pillOffset);
-			const pillIsFullyDocked = gutterViewPortWithoutStickyScrollWithoutPaddingTop.containsRect(pillFullyDockedRect);
+			const pillIsFullyDocked = gutterViewPortWithoutStickyScrollWithoutPaddingTop.containsRect(pillFullyDockedRect) && lineHeight > 0;
 
 			// The icon which will be rendered in the pill
 			const iconNoneDocked = this._tabAction.map(action => action === InlineEditTabAction.Accept ? Codicon.keyboardTab : Codicon.arrowRight);


### PR DESCRIPTION
```Copilot Generated Description:``` Implement a method to reveal folded regions within a specified range in the FoldingController, and integrate this functionality into the InlineCompletionsModel to enhance inline edit visibility.

fixes https://github.com/microsoft/vscode/issues/253575