### PR TITLE
[release branch] add non-markdown description back for chat.tools.autoApprove

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -213,7 +213,9 @@ configurationRegistry.registerConfiguration({
 		},
 		'chat.tools.autoApprove': {
 			default: false,
-			markdownDescription: nls.localize('chat.tools.autoApprove', "Controls whether tool use should be automatically approved.\n\nAllows _all_ tools to run automatically without user confirmation, overriding any tool-specific settings such as terminal auto-approval.\n\nUse with caution: carefully review selected tools and be extra wary of possible sources of prompt injection!"),
+			// Description is added in for policy parser. See https://github.com/microsoft/vscode/issues/254526
+			description: nls.localize('chat.tools.autoApprove.description', "Controls whether tool use should be automatically approved. Allow all tools to run automatically without user confirmation, overriding any tool-specific settings such as terminal auto-approval. Use with caution: carefully review selected tools and be extra wary of possible sources of prompt injection!"),
+			markdownDescription: nls.localize('chat.tools.autoApprove.markdownDescription', "Controls whether tool use should be automatically approved.\n\nAllows _all_ tools to run automatically without user confirmation, overriding any tool-specific settings such as terminal auto-approval.\n\nUse with caution: carefully review selected tools and be extra wary of possible sources of prompt injection!"),
 			type: 'boolean',
 			tags: ['experimental'],
 			policy: {


### PR DESCRIPTION
main branch PR: https://github.com/microsoft/vscode/pull/254529
related: https://github.com/microsoft/vscode/issues/254526

unblocks https://dev.azure.com/monacotools/Monaco/_build/results?buildId=347931&view=logs&j=3792f238-f35e-5f82-0dbc-272432d9a0fb&t=19ca2b82-e9ec-5437-eb2e-505cf4e28552

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
