### PR TITLE
reset input in welcome view on context change for experimental mode

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatWidget.ts
@@ -461,6 +461,21 @@ export class ChatWidget extends Disposable implements IChatWidget {
 		}));
 
 		this._register(this.onDidChangeParsedInput(() => this.updateChatInputContext()));
+
+		this._register(this.contextKeyService.onDidChangeContext(e => {
+			if (e.affectsSome(new Set([
+				ChatContextKeys.Setup.installed.key,
+				ChatContextKeys.Entitlement.canSignUp.key
+			]))) {
+				// reset the input in welcome view if it was rendered in experimental mode
+				if (this.container.classList.contains('experimental-welcome-view')) {
+					this.container.classList.remove('experimental-welcome-view');
+					const renderFollowups = this.viewOptions.renderFollowups ?? false;
+					const renderStyle = this.viewOptions.renderStyle;
+					this.createInput(this.container, { renderFollowups, renderStyle });
+				}
+			}
+		}));
 	}
 
 	private _lastSelectedAgent: IChatAgentData | undefined;


### PR DESCRIPTION
For:
https://github.com/microsoft/vscode/issues/254594

cc: @bpasero 


Tested chat input location changes for the below scenarios assuming that user is opted into the experiment:
| Scenario | Before | Action | After |
|----------|--------|--------|-------|
| **1** | New Welcome View (chat input in the middle) | Install extension from the extension viewlet | Chat input moves to the bottom |
| **2** | New Welcome View (chat input in the middle) | Install extension via chat-setup (`triggerSetup` and `triggerSetupWithoutDialog` commands in walkthrough, chat panel) | Chat input moves to the bottom |
| **3** | Extension installed and signed in (chat input at the bottom) | Uninstall extension | New Welcome View shows, chat input moves to the middle |
| **4** | New Welcome View shows (Extension installed but not signed up) | Sign up |  Chat input moves to the bottom |