### PR TITLE
Updated references to schemastore.org

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -83,7 +83,7 @@
 			"fileMatch": [
 				"cgmanifest.json"
 			],
-			"url": "https://json.schemastore.org/component-detection-manifest.json",
+			"url": "https://www.schemastore.org/component-detection-manifest.json",
 		},
 		{
 			"fileMatch": [

--- a/extensions/json-language-features/client/src/node/jsonClientMain.ts
+++ b/extensions/json-language-features/client/src/node/jsonClientMain.ts
@@ -158,7 +158,7 @@ async function getSchemaRequestService(context: ExtensionContext, log: LogOutput
 
 	return {
 		getContent: async (uri: string) => {
-			if (cache && /^https?:\/\/json\.schemastore\.org\//.test(uri)) {
+			if (cache && /^https?:\/\/(json|www)\.schemastore\.org\//.test(uri)) {
 				const content = await cache.getSchemaIfUpdatedSince(uri, retryTimeoutInHours);
 				if (content) {
 					if (log.logLevel === LogLevel.Trace) {

--- a/extensions/json-language-features/server/README.md
+++ b/extensions/json-language-features/server/README.md
@@ -90,7 +90,7 @@ The server supports the following settings:
                         "foo.json",
                         "*.superfoo.json"
                     ],
-                    "url": "http://json.schemastore.org/foo",
+                    "url": "http://www.schemastore.org/foo",
                     "schema": {
                         "type": "array"
                     }

--- a/extensions/npm/package.json
+++ b/extensions/npm/package.json
@@ -336,11 +336,11 @@
     "jsonValidation": [
       {
         "fileMatch": "package.json",
-        "url": "https://json.schemastore.org/package"
+        "url": "https://www.schemastore.org/package"
       },
       {
         "fileMatch": "bower.json",
-        "url": "https://json.schemastore.org/bower"
+        "url": "https://www.schemastore.org/bower"
       }
     ],
     "taskDefinitions": [

--- a/extensions/typescript-language-features/package.json
+++ b/extensions/typescript-language-features/package.json
@@ -81,7 +81,7 @@
       },
       {
         "fileMatch": "tsconfig.json",
-        "url": "https://json.schemastore.org/tsconfig"
+        "url": "https://www.schemastore.org/tsconfig"
       },
       {
         "fileMatch": "tsconfig.json",
@@ -89,7 +89,7 @@
       },
       {
         "fileMatch": "tsconfig.*.json",
-        "url": "https://json.schemastore.org/tsconfig"
+        "url": "https://www.schemastore.org/tsconfig"
       },
       {
         "fileMatch": "tsconfig-*.json",
@@ -97,7 +97,7 @@
       },
       {
         "fileMatch": "tsconfig-*.json",
-        "url": "https://json.schemastore.org/tsconfig"
+        "url": "https://www.schemastore.org/tsconfig"
       },
       {
         "fileMatch": "tsconfig.*.json",
@@ -105,27 +105,27 @@
       },
       {
         "fileMatch": "typings.json",
-        "url": "https://json.schemastore.org/typings"
+        "url": "https://www.schemastore.org/typings"
       },
       {
         "fileMatch": ".bowerrc",
-        "url": "https://json.schemastore.org/bowerrc"
+        "url": "https://www.schemastore.org/bowerrc"
       },
       {
         "fileMatch": ".babelrc",
-        "url": "https://json.schemastore.org/babelrc"
+        "url": "https://www.schemastore.org/babelrc"
       },
       {
         "fileMatch": ".babelrc.json",
-        "url": "https://json.schemastore.org/babelrc"
+        "url": "https://www.schemastore.org/babelrc"
       },
       {
         "fileMatch": "babel.config.json",
-        "url": "https://json.schemastore.org/babelrc"
+        "url": "https://www.schemastore.org/babelrc"
       },
       {
         "fileMatch": "jsconfig.json",
-        "url": "https://json.schemastore.org/jsconfig"
+        "url": "https://www.schemastore.org/jsconfig"
       },
       {
         "fileMatch": "jsconfig.json",
@@ -133,7 +133,7 @@
       },
       {
         "fileMatch": "jsconfig.*.json",
-        "url": "https://json.schemastore.org/jsconfig"
+        "url": "https://www.schemastore.org/jsconfig"
       },
       {
         "fileMatch": "jsconfig.*.json",

--- a/test/.mocharc.json
+++ b/test/.mocharc.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://json.schemastore.org/mocharc",
+	"$schema": "https://www.schemastore.org/mocharc",
 	"ui": "tdd",
 	"timeout": 10000
 }

--- a/test/monaco/.mocharc.json
+++ b/test/monaco/.mocharc.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://json.schemastore.org/mocharc",
+	"$schema": "https://www.schemastore.org/mocharc",
 	"ui": "bdd",
 	"timeout": 10000
 }


### PR DESCRIPTION
Fixes #254689

This PR replaces the use of the `json.schemastore.org` subdomain with `www.schemastore.org`. We're deprecating the `json` subdomain and standardizing on `www`.

Without this change, VS Code won't be able to download the schema files once the deprecation is done (no time schedule for that yet, but we need to start the process now).