### PR TITLE
Revert "terminal: default 'terminal.integrated.inheritEnv' to false on Windows (#252325)

### DIFF
--- a/src/vs/platform/terminal/common/terminalPlatformConfiguration.ts
+++ b/src/vs/platform/terminal/common/terminalPlatformConfiguration.ts
@@ -5,7 +5,7 @@
 
 import { getAllCodicons } from '../../../base/common/codicons.js';
 import { IJSONSchema, IJSONSchemaMap } from '../../../base/common/jsonSchema.js';
-import { isWindows, OperatingSystem, Platform, PlatformToString } from '../../../base/common/platform.js';
+import { OperatingSystem, Platform, PlatformToString } from '../../../base/common/platform.js';
 import { localize } from '../../../nls.js';
 import { ConfigurationScope, Extensions, IConfigurationNode, IConfigurationRegistry } from '../../configuration/common/configurationRegistry.js';
 import { Registry } from '../../registry/common/platform.js';
@@ -336,10 +336,9 @@ const terminalPlatformConfiguration: IConfigurationNode = {
 		},
 		[TerminalSettingId.InheritEnv]: {
 			scope: ConfigurationScope.APPLICATION,
-			description: localize('terminal.integrated.inheritEnv', "Whether new shells should inherit their environment from VS Code, which may source a login shell to ensure $PATH and other development variables are initialized."),
+			description: localize('terminal.integrated.inheritEnv', "Whether new shells should inherit their environment from VS Code, which may source a login shell to ensure $PATH and other development variables are initialized. This has no effect on Windows."),
 			type: 'boolean',
-			// False by default on Windows to prevent powershell inheritance issues (#251446)
-			default: isWindows ? false : true,
+			default: true
 		},
 		[TerminalSettingId.PersistentSessionScrollback]: {
 			scope: ConfigurationScope.APPLICATION,


### PR DESCRIPTION
This reverts commit ae6080018a4b9bd5987ac1afd47532e84c07170e.

Fixes #252689

This was part of the Windows shell environment change that we didn't end up reverting with the rest. This ended up causing problems for Windows host connecting to non-Windows remotes having the wrong `inheritEnv` value, breaking the correct environment users are used to having.

cc @connor4312 

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
