### PR TITLE
chat: refactor out chatEditingTimeline, tests, bugs

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingSession.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingSession.ts
@@ -3,31 +3,26 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { equals as arraysEqual, binarySearch2 } from '../../../../../base/common/arrays.js';
-import { findLast } from '../../../../../base/common/arraysFind.js';
 import { DeferredPromise, ITask, Sequencer, SequencerByKey, timeout } from '../../../../../base/common/async.js';
 import { CancellationToken } from '../../../../../base/common/cancellation.js';
 import { BugIndicatingError } from '../../../../../base/common/errors.js';
 import { Emitter } from '../../../../../base/common/event.js';
 import { Iterable } from '../../../../../base/common/iterator.js';
-import { Disposable, DisposableStore, dispose } from '../../../../../base/common/lifecycle.js';
+import { Disposable, dispose } from '../../../../../base/common/lifecycle.js';
 import { ResourceMap } from '../../../../../base/common/map.js';
-import { autorun, derived, derivedOpts, IObservable, IReader, ITransaction, ObservablePromise, observableValue, transaction } from '../../../../../base/common/observable.js';
+import { autorun, IObservable, IReader, ITransaction, observableValue, transaction } from '../../../../../base/common/observable.js';
 import { isEqual } from '../../../../../base/common/resources.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { IBulkEditService } from '../../../../../editor/browser/services/bulkEditService.js';
 import { TextEdit } from '../../../../../editor/common/languages.js';
 import { ILanguageService } from '../../../../../editor/common/languages/language.js';
 import { ITextModel } from '../../../../../editor/common/model.js';
-import { IEditorWorkerService } from '../../../../../editor/common/services/editorWorker.js';
 import { IModelService } from '../../../../../editor/common/services/model.js';
 import { ITextModelService } from '../../../../../editor/common/services/resolverService.js';
 import { localize } from '../../../../../nls.js';
 import { AccessibilitySignal, IAccessibilitySignalService } from '../../../../../platform/accessibilitySignal/browser/accessibilitySignalService.js';
-import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 import { EditorActivation } from '../../../../../platform/editor/common/editor.js';
 import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
-import { observableConfigValue } from '../../../../../platform/observable/common/platformObservableUtils.js';
 import { DiffEditorInput } from '../../../../common/editor/diffEditorInput.js';
 import { IEditorGroupsService } from '../../../../services/editor/common/editorGroupsService.js';
 import { IEditorService } from '../../../../services/editor/common/editorService.js';
@@ -35,17 +30,15 @@ import { MultiDiffEditor } from '../../../multiDiffEditor/browser/multiDiffEdito
 import { MultiDiffEditorInput } from '../../../multiDiffEditor/browser/multiDiffEditorInput.js';
 import { CellUri, ICellEditOperation } from '../../../notebook/common/notebookCommon.js';
 import { INotebookService } from '../../../notebook/common/notebookService.js';
-import { ChatEditingSessionState, ChatEditKind, getMultiDiffSourceUri, IChatEditingSession, IEditSessionEntryDiff, IModifiedEntryTelemetryInfo, IModifiedFileEntry, ISnapshotEntry, IStreamingEdits, ModifiedFileEntryState } from '../../common/chatEditingService.js';
-import { IChatRequestDisablement, IChatResponseModel } from '../../common/chatModel.js';
+import { ChatEditingSessionState, ChatEditKind, getMultiDiffSourceUri, IChatEditingSession, IModifiedEntryTelemetryInfo, IModifiedFileEntry, ISnapshotEntry, IStreamingEdits, ModifiedFileEntryState } from '../../common/chatEditingService.js';
+import { IChatResponseModel } from '../../common/chatModel.js';
 import { IChatService } from '../../common/chatService.js';
 import { ChatEditingModifiedDocumentEntry } from './chatEditingModifiedDocumentEntry.js';
 import { AbstractChatEditingModifiedFileEntry } from './chatEditingModifiedFileEntry.js';
 import { ChatEditingModifiedNotebookEntry } from './chatEditingModifiedNotebookEntry.js';
 import { ChatEditingSessionStorage, IChatEditingSessionSnapshot, IChatEditingSessionStop, StoredSessionState } from './chatEditingSessionStorage.js';
 import { ChatEditingTextModelContentProvider } from './chatEditingTextModelContentProviders.js';
-import { ChatEditingModifiedNotebookDiff } from './notebook/chatEditingModifiedNotebookDiff.js';
-
-const POST_EDIT_STOP_ID = 'd19944f6-f46c-4e17-911b-79a8e843c7c0'; // randomly generated
+import { ChatEditingTimeline } from './chatEditingTimeline.js';
 
 class ThrottledSequencer extends Sequencer {
 
@@ -81,19 +74,6 @@ class ThrottledSequencer extends Sequencer {
 	}
 }
 
-function getMaxHistoryIndex(history: readonly IChatEditingSessionSnapshot[]) {
-	const lastHistory = history.at(-1);
-	return lastHistory ? lastHistory.startIndex + lastHistory.stops.length : 0;
-}
-
-function snapshotsEqualForDiff(a: ISnapshotEntry | undefined, b: ISnapshotEntry | undefined) {
-	if (!a || !b) {
-		return a === b;
-	}
-
-	return isEqual(a.snapshotUri, b.snapshotUri) && a.current === b.current;
-}
-
 function getCurrentAndNextStop(requestId: string, stopId: string | undefined, history: readonly IChatEditingSessionSnapshot[]) {
 	const snapshotIndex = history.findIndex(s => s.requestId === requestId);
 	if (snapshotIndex === -1) { return undefined; }
@@ -114,43 +94,9 @@ function getCurrentAndNextStop(requestId: string, stopId: string | undefined, hi
 	return { current, next };
 }
 
-function getFirstAndLastStop(uri: URI, history: readonly IChatEditingSessionSnapshot[]): { current: ResourceMap<ISnapshotEntry>; next: ResourceMap<ISnapshotEntry> } | undefined {
-	let firstStopWithUri: IChatEditingSessionStop | undefined;
-	for (const snapshot of history) {
-		const stop = snapshot.stops.find(s => s.entries.has(uri));
-		if (stop) {
-			firstStopWithUri = stop;
-			break;
-		}
-	}
-
-	let lastStopWithUri: ResourceMap<ISnapshotEntry> | undefined;
-	for (let i = history.length - 1; i >= 0; i--) {
-		const snapshot = history[i];
-		if (snapshot.postEdit?.has(uri)) {
-			lastStopWithUri = snapshot.postEdit;
-			break;
-		}
-
-		const stop = findLast(snapshot.stops, s => s.entries.has(uri));
-		if (stop) {
-			lastStopWithUri = stop.entries;
-			break;
-		}
-	}
-
-	if (!firstStopWithUri || !lastStopWithUri) {
-		return undefined;
-	}
-
-	return { current: firstStopWithUri.entries, next: lastStopWithUri };
-}
-
 export class ChatEditingSession extends Disposable implements IChatEditingSession {
-
 	private readonly _state = observableValue<ChatEditingSessionState>(this, ChatEditingSessionState.Initial);
-	private readonly _linearHistory = observableValue<readonly IChatEditingSessionSnapshot[]>(this, []);
-	private readonly _linearHistoryIndex = observableValue<number>(this, 0);
+	private readonly _timeline: ChatEditingTimeline;
 
 	/**
 	 * Contains the contents of a file when the AI first began doing edits to it.
@@ -169,27 +115,8 @@ export class ChatEditingSession extends Disposable implements IChatEditingSessio
 		return this._state;
 	}
 
-	public readonly canUndo = derived<boolean>((r) => {
-		if (this.state.read(r) !== ChatEditingSessionState.Idle) {
-			return false;
-		}
-		const linearHistoryIndex = this._linearHistoryIndex.read(r);
-		return linearHistoryIndex > 0;
-	});
-
-	public readonly canRedo = derived<boolean>((r) => {
-		if (this.state.read(r) !== ChatEditingSessionState.Idle) {
-			return false;
-		}
-		const linearHistoryIndex = this._linearHistoryIndex.read(r);
-		return linearHistoryIndex < getMaxHistoryIndex(this._linearHistory.read(r));
-	});
-
-	// public hiddenRequestIds = derived<string[]>((r) => {
-	// 	const linearHistory = this._linearHistory.read(r);
-	// 	const linearHistoryIndex = this._linearHistoryIndex.read(r);
-	// 	return linearHistory.slice(linearHistoryIndex).map(s => s.requestId).filter((r): r is string => !!r);
-	// });
+	public readonly canUndo: IObservable<boolean>;
+	public readonly canRedo: IObservable<boolean>;
 
 	private readonly _onDidDispose = new Emitter<void>();
 	get onDidDispose() {
@@ -210,12 +137,14 @@ export class ChatEditingSession extends Disposable implements IChatEditingSessio
 		@IEditorService private readonly _editorService: IEditorService,
 		@IChatService private readonly _chatService: IChatService,
 		@INotebookService private readonly _notebookService: INotebookService,
-		@IEditorWorkerService private readonly _editorWorkerService: IEditorWorkerService,
-		@IConfigurationService private readonly _configurationService: IConfigurationService,
 		@IAccessibilitySignalService private readonly _accessibilitySignalService: IAccessibilitySignalService,
 	) {
 		super();
-		this._ignoreTrimWhitespaceObservable = observableConfigValue('diffEditor.ignoreTrimWhitespace', true, this._configurationService);
+		this._timeline = _instantiationService.createInstance(ChatEditingTimeline);
+		this.canRedo = this._timeline.canRedo.map((hasHistory, reader) =>
+			hasHistory && this._state.read(reader) === ChatEditingSessionState.Idle);
+		this.canUndo = this._timeline.canUndo.map((hasHistory, reader) =>
+			hasHistory && this._state.read(reader) === ChatEditingSessionState.Idle);
 	}
 
 	public async init(): Promise<void> {
@@ -224,11 +153,10 @@ export class ChatEditingSession extends Disposable implements IChatEditingSessio
 			for (const [uri, content] of restoredSessionState.initialFileContents) {
 				this._initialFileContents.set(uri, content);
 			}
-			this._pendingSnapshot = restoredSessionState.pendingSnapshot;
 			await this._restoreSnapshot(restoredSessionState.recentSnapshot, false);
-			transaction(async tx => {
-				this._linearHistory.set(restoredSessionState.linearHistory, tx);
-				this._linearHistoryIndex.set(restoredSessionState.linearHistoryIndex, tx);
+			transaction(tx => {
+				this._pendingSnapshot.set(restoredSessionState.pendingSnapshot, tx);
+				this._timeline.restoreFromState({ history: restoredSessionState.linearHistory, index: restoredSessionState.linearHistoryIndex }, tx);
 				this._state.set(ChatEditingSessionState.Idle, tx);
 			});
 		} else {
@@ -259,222 +187,55 @@ export class ChatEditingSession extends Disposable implements IChatEditingSessio
 
 	public storeState(): Promise<void> {
 		const storage = this._instantiationService.createInstance(ChatEditingSessionStorage, this.chatSessionId);
+		const timelineState = this._timeline.getStateForPersistence();
 		const state: StoredSessionState = {
 			initialFileContents: this._initialFileContents,
-			pendingSnapshot: this._pendingSnapshot,
+			pendingSnapshot: this._pendingSnapshot.get(),
 			recentSnapshot: this._createSnapshot(undefined, undefined),
-			linearHistoryIndex: this._linearHistoryIndex.get(),
-			linearHistory: this._linearHistory.get(),
+			linearHistoryIndex: timelineState.index,
+			linearHistory: timelineState.history,
 		};
 		return storage.storeState(state);
 	}
 
-	private _findSnapshot(requestId: string): IChatEditingSessionSnapshot | undefined {
-		return this._linearHistory.get().find(s => s.requestId === requestId);
-	}
-
-	private _findEditStop(requestId: string, undoStop: string | undefined) {
-		const snapshot = this._findSnapshot(requestId);
-		if (!snapshot) {
-			return undefined;
-		}
-		const idx = snapshot.stops.findIndex(s => s.stopId === undoStop);
-		return idx === -1 ? undefined : { stop: snapshot.stops[idx], snapshot, historyIndex: snapshot.startIndex + idx };
-	}
-
 	private _ensurePendingSnapshot() {
-		this._pendingSnapshot ??= this._createSnapshot(undefined, undefined);
-	}
-
-	private _diffsBetweenStops = new Map<string, IObservable<IEditSessionEntryDiff | undefined>>();
-	private _fullDiffs = new Map<string, IObservable<IEditSessionEntryDiff | undefined>>();
-
-	private readonly _ignoreTrimWhitespaceObservable: IObservable<boolean>;
-
-	/**
-	 * Gets diff for text entries between stops.
-	 * @param entriesContent Observable that observes either snapshot entry
-	 * @param modelUrisObservable Observable that observes only the snapshot URIs.
-	 */
-	private _entryDiffBetweenTextStops(
-		entriesContent: IObservable<{ before: ISnapshotEntry; after: ISnapshotEntry } | undefined>,
-		modelUrisObservable: IObservable<[URI, URI] | undefined>,
-	): IObservable<ObservablePromise<IEditSessionEntryDiff> | undefined> {
-		const modelRefsPromise = derived(this, (reader) => {
-			const modelUris = modelUrisObservable.read(reader);
-			if (!modelUris) { return undefined; }
-
-			const store = reader.store.add(new DisposableStore());
-			const promise = Promise.all(modelUris.map(u => this._textModelService.createModelReference(u))).then(refs => {
-				if (store.isDisposed) {
-					refs.forEach(r => r.dispose());
-				} else {
-					refs.forEach(r => store.add(r));
-				}
-
-				return refs;
-			});
-
-			return new ObservablePromise(promise);
-		});
-
-		return derived((reader): ObservablePromise<IEditSessionEntryDiff> | undefined => {
-			const refs2 = modelRefsPromise.read(reader)?.promiseResult.read(reader);
-			const refs = refs2?.data;
-			if (!refs) {
-				return;
-			}
-
-			const entries = entriesContent.read(reader); // trigger re-diffing when contents change
-
-			if (entries?.before && ChatEditingModifiedNotebookEntry.canHandleSnapshot(entries.before)) {
-				const diffService = this._instantiationService.createInstance(ChatEditingModifiedNotebookDiff, entries.before, entries.after);
-				return new ObservablePromise(diffService.computeDiff());
-
-			}
-			const ignoreTrimWhitespace = this._ignoreTrimWhitespaceObservable.read(reader);
-			const promise = this._editorWorkerService.computeDiff(
-				refs[0].object.textEditorModel.uri,
-				refs[1].object.textEditorModel.uri,
-				{ ignoreTrimWhitespace, computeMoves: false, maxComputationTimeMs: 3000 },
-				'advanced'
-			).then((diff): IEditSessionEntryDiff => {
-				const entryDiff: IEditSessionEntryDiff = {
-					originalURI: refs[0].object.textEditorModel.uri,
-					modifiedURI: refs[1].object.textEditorModel.uri,
-					identical: !!diff?.identical,
-					quitEarly: !diff || diff.quitEarly,
-					added: 0,
-					removed: 0,
-				};
-				if (diff) {
-					for (const change of diff.changes) {
-						entryDiff.removed += change.original.endLineNumberExclusive - change.original.startLineNumber;
-						entryDiff.added += change.modified.endLineNumberExclusive - change.modified.startLineNumber;
-					}
-				}
-
-				return entryDiff;
-			});
-
-			return new ObservablePromise(promise);
-		});
-	}
-
-	private _createDiffBetweenStopsObservable(uri: URI, requestId: string | undefined, stopId: string | undefined): IObservable<IEditSessionEntryDiff | undefined> {
-		const entries = derivedOpts<undefined | { before: ISnapshotEntry; after: ISnapshotEntry }>(
-			{
-				equalsFn: (a, b) => snapshotsEqualForDiff(a?.before, b?.before) && snapshotsEqualForDiff(a?.after, b?.after),
-			},
-			reader => {
-				const stops = requestId ?
-					getCurrentAndNextStop(requestId, stopId, this._linearHistory.read(reader)) :
-					getFirstAndLastStop(uri, this._linearHistory.read(reader));
-				if (!stops) { return undefined; }
-				const before = stops.current.get(uri);
-				const after = stops.next.get(uri);
-				if (!before || !after) { return undefined; }
-				return { before, after };
-			},
-		);
-
-		// Separate observable for model refs to avoid unnecessary disposal
-		const modelUrisObservable = derivedOpts<[URI, URI] | undefined>({ equalsFn: (a, b) => arraysEqual(a, b, isEqual) }, reader => {
-			const entriesValue = entries.read(reader);
-			if (!entriesValue) { return undefined; }
-			return [entriesValue.before.snapshotUri, entriesValue.after.snapshotUri];
-		});
-
-		const diff = this._entryDiffBetweenTextStops(entries, modelUrisObservable);
-
-		return derived(reader => {
-			return diff.read(reader)?.promiseResult.read(reader)?.data || undefined;
-		});
+		const prev = this._pendingSnapshot.get();
+		if (!prev) {
+			this._pendingSnapshot.set(this._createSnapshot(undefined, undefined), undefined);
+		}
 	}
 
 	public getEntryDiffBetweenStops(uri: URI, requestId: string | undefined, stopId: string | undefined) {
-		if (requestId) {
-			const key = `${uri}\0${requestId}\0${stopId}`;
-			let observable = this._diffsBetweenStops.get(key);
-			if (!observable) {
-				observable = this._createDiffBetweenStopsObservable(uri, requestId, stopId);
-				this._diffsBetweenStops.set(key, observable);
-			}
-
-			return observable;
-		} else {
-			const key = uri.toString();
-			let observable = this._fullDiffs.get(key);
-			if (!observable) {
-				observable = this._createDiffBetweenStopsObservable(uri, requestId, stopId);
-				this._fullDiffs.set(key, observable);
-			}
-
-			return observable;
-		}
+		return this._timeline.getEntryDiffBetweenStops(uri, requestId, stopId);
 	}
 
 	public createSnapshot(requestId: string, undoStop: string | undefined, makeEmpty = undoStop !== undefined): void {
-		const snapshot = makeEmpty ? this._createEmptySnapshot(undoStop) : this._createSnapshot(requestId, undoStop);
-
-		const linearHistoryPtr = this._linearHistoryIndex.get();
-		const newLinearHistory: IChatEditingSessionSnapshot[] = [];
-		for (const entry of this._linearHistory.get()) {
-			if (entry.startIndex >= linearHistoryPtr) {
-				// all further entries are being dropped
-				break;
-			} else if (linearHistoryPtr - entry.startIndex < entry.stops.length) {
-				newLinearHistory.push({ requestId: entry.requestId, stops: entry.stops.slice(0, linearHistoryPtr - entry.startIndex), startIndex: entry.startIndex, postEdit: undefined });
-			} else {
-				newLinearHistory.push(entry);
-			}
-		}
-
-		const lastEntry = newLinearHistory.at(-1);
-		if (requestId && lastEntry?.requestId === requestId) {
-			// mirror over the saved postEdit modifications
-			if (lastEntry.postEdit && undoStop) {
-				const rebaseUri = (uri: URI) => URI.parse(uri.toString().replaceAll(POST_EDIT_STOP_ID, undoStop));
-				for (const [uri, prev] of lastEntry.postEdit.entries()) {
-					snapshot.entries.set(uri, { ...prev, snapshotUri: rebaseUri(prev.snapshotUri), resource: rebaseUri(prev.resource) });
-				}
-			}
-
-			newLinearHistory[newLinearHistory.length - 1] = { ...lastEntry, stops: [...lastEntry.stops, snapshot], postEdit: undefined };
-		} else {
-			newLinearHistory.push({ requestId, startIndex: lastEntry ? lastEntry.startIndex + lastEntry.stops.length : 0, stops: [snapshot], postEdit: undefined });
-		}
-
-		transaction((tx) => {
-			const last = newLinearHistory[newLinearHistory.length - 1];
-			this._linearHistory.set(newLinearHistory, tx);
-			this._linearHistoryIndex.set(last.startIndex + last.stops.length, tx);
-		});
+		this._timeline.pushSnapshot(
+			requestId,
+			undoStop,
+			makeEmpty ? ChatEditingTimeline.createEmptySnapshot(undoStop) : this._createSnapshot(requestId, undoStop),
+		);
 	}
 
-	private _createEmptySnapshot(undoStop: string | undefined): IChatEditingSessionStop {
-		return {
-			stopId: undoStop,
-			entries: new ResourceMap(),
-		};
-	}
-
-	private _createSnapshot(requestId: string | undefined, undoStop: string | undefined): IChatEditingSessionStop {
+	private _createSnapshot(requestId: string | undefined, stopId: string | undefined): IChatEditingSessionStop {
 		const entries = new ResourceMap<ISnapshotEntry>();
 		for (const entry of this._entriesObs.get()) {
-			entries.set(entry.modifiedURI, entry.createSnapshot(requestId, undoStop));
+			entries.set(entry.modifiedURI, entry.createSnapshot(requestId, stopId));
 		}
-
-		return {
-			stopId: undoStop,
-			entries,
-		};
+		return { stopId, entries };
 	}
 
 	public getSnapshot(requestId: string, undoStop: string | undefined, snapshotUri: URI): ISnapshotEntry | undefined {
-		const entries = undoStop === POST_EDIT_STOP_ID
-			? this._findSnapshot(requestId)?.postEdit
-			: this._findEditStop(requestId, undoStop)?.stop.entries;
+		let entries: ResourceMap<ISnapshotEntry> | undefined;
+		if (undoStop === ChatEditingTimeline.POST_EDIT_STOP_ID) {
+			// If postEdit, get from timeline state
+			const timelineState = this._timeline.getStateForPersistence();
+			const snap = timelineState.history.find(s => s.requestId === requestId);
+			entries = snap?.postEdit;
+		} else {
+			const stopRef = this._timeline.getSnapshotForRestore(requestId, undoStop);
+			entries = stopRef?.stop.entries;
+		}
 		return entries && [...entries.values()].find((e) => isEqual(e.snapshotUri, snapshotUri));
 	}
 
@@ -488,29 +249,33 @@ export class ChatEditingSession extends Disposable implements IChatEditingSessio
 	}
 
 	public getSnapshotUri(requestId: string, uri: URI, stopId: string | undefined): URI | undefined {
-		const stops = getCurrentAndNextStop(requestId, stopId, this._linearHistory.get());
+		// This should be encapsulated in the timeline, but for now, fallback to legacy logic if needed.
+		// TODO: Move this logic into a timeline method if required by the design.
+		const timelineState = this._timeline.getStateForPersistence();
+		const stops = getCurrentAndNextStop(requestId, stopId, timelineState.history);
 		return stops?.next.get(uri)?.snapshotUri;
 	}
 
 	/**
 	 * A snapshot representing the state of the working set before a new request has been sent
 	 */
-	private _pendingSnapshot: IChatEditingSessionStop | undefined;
+	private _pendingSnapshot = observableValue<IChatEditingSessionStop | undefined>(this, undefined);
+
 	public async restoreSnapshot(requestId: string | undefined, stopId: string | undefined): Promise<void> {
 		if (requestId !== undefined) {
-			const stopRef = this._findEditStop(requestId, stopId);
+			const stopRef = this._timeline.getSnapshotForRestore(requestId, stopId);
 			if (stopRef) {
 				this._ensurePendingSnapshot();
-				this._linearHistoryIndex.set(stopRef.historyIndex, undefined);
 				await this._restoreSnapshot(stopRef.stop);
+				stopRef.apply();
 				this._updateRequestHiddenState();
 			}
 		} else {
-			const pendingSnapshot = this._pendingSnapshot;
+			const pendingSnapshot = this._pendingSnapshot.get();
 			if (!pendingSnapshot) {
 				return; // We don't have a pending snapshot that we can restore
 			}
-			this._pendingSnapshot = undefined;
+			this._pendingSnapshot.set(undefined, undefined);
 			await this._restoreSnapshot(pendingSnapshot, undefined);
 		}
 	}
@@ -697,66 +462,34 @@ export class ChatEditingSession extends Disposable implements IChatEditingSessio
 		};
 	}
 
-	private _getHistoryEntryByLinearIndex(index: number) {
-		const history = this._linearHistory.get();
-		const searchedIndex = binarySearch2(history.length, (e) => history[e].startIndex - index);
-		const entry = history[searchedIndex < 0 ? (~searchedIndex) - 1 : searchedIndex];
-		if (!entry || index - entry.startIndex >= entry.stops.length) {
-			return undefined;
-		}
-
-		return {
-			entry,
-			stop: entry.stops[index - entry.startIndex]
-		};
-	}
-
 	async undoInteraction(): Promise<void> {
-		const newIndex = this._linearHistoryIndex.get() - 1;
-		const previousSnapshot = this._getHistoryEntryByLinearIndex(newIndex);
-		if (!previousSnapshot) {
+		const undo = this._timeline.getUndoSnapshot();
+		if (!undo) {
 			return;
 		}
-
 		this._ensurePendingSnapshot();
-		await this._restoreSnapshot(previousSnapshot.stop);
-		this._linearHistoryIndex.set(newIndex, undefined);
+		await this._restoreSnapshot(undo.stop);
+		undo.apply();
 		this._updateRequestHiddenState();
 	}
 
 	async redoInteraction(): Promise<void> {
-		const maxIndex = getMaxHistoryIndex(this._linearHistory.get());
-		const newIndex = this._linearHistoryIndex.get() + 1;
-		if (newIndex > maxIndex) {
-			return;
-		}
-
-		const nextSnapshot = newIndex === maxIndex ? this._pendingSnapshot : this._getHistoryEntryByLinearIndex(newIndex)?.stop;
+		const redo = this._timeline.getRedoSnapshot();
+		const nextSnapshot = redo?.stop || this._pendingSnapshot.get();
 		if (!nextSnapshot) {
 			return;
 		}
 		await this._restoreSnapshot(nextSnapshot);
-		this._linearHistoryIndex.set(newIndex, undefined);
+		if (redo) {
+			redo.apply();
+		} else {
+			this._pendingSnapshot.set(undefined, undefined);
+		}
 		this._updateRequestHiddenState();
 	}
 
-
 	private _updateRequestHiddenState() {
-		const history = this._linearHistory.get();
-		const index = this._linearHistoryIndex.get();
-
-		const undoRequests: IChatRequestDisablement[] = [];
-		for (const entry of history) {
-			if (!entry.requestId) {
-				// ignored
-			} else if (entry.startIndex >= index) {
-				undoRequests.push({ requestId: entry.requestId });
-			} else if (entry.startIndex + entry.stops.length > index) {
-				undoRequests.push({ requestId: entry.requestId, afterUndoStop: entry.stops[index - entry.startIndex].stopId });
-			}
-		}
-
-		this._chatService.getSession(this.chatSessionId)?.setDisabledRequests(undoRequests);
+		this._chatService.getSession(this.chatSessionId)?.setDisabledRequests(this._timeline.getRequestDisablement());
 	}
 
 	private async _acceptStreamingEditsStart(responseModel: IChatResponseModel, undoStop: string | undefined, resource: URI) {
@@ -764,74 +497,11 @@ export class ChatEditingSession extends Disposable implements IChatEditingSessio
 		transaction((tx) => {
 			this._state.set(ChatEditingSessionState.StreamingEdits, tx);
 			entry.acceptStreamingEditsStart(responseModel, tx);
-			this.ensureEditInUndoStopMatches(responseModel.requestId, undoStop, entry, false, tx);
+			this._timeline.ensureEditInUndoStopMatches(responseModel.requestId, undoStop, entry, false, tx);
 		});
 	}
 
-	/**
-	 * Ensures the state of the file in the given snapshot matches the current
-	 * state of the {@param entry}. This is used to handle concurrent file edits.
-	 *
-	 * Given the case of two different edits, we will place and undo stop right
-	 * before we `textEditGroup` in the underlying markdown stream, but at the
-	 * time those are added the edits haven't been made yet, so both files will
-	 * simply have the unmodified state.
-	 *
-	 * This method is called after each edit, so after the first file finishes
-	 * being edits, it will update its content in the second undo snapshot such
-	 * that it can be undone successfully.
-	 *
-	 * We ensure that the same file is not concurrently edited via the
-	 * {@link _streamingEditLocks}, avoiding race conditions.
-	 *
-	 * @param next If true, this will edit the snapshot _after_ the undo stop
-	 */
-	private ensureEditInUndoStopMatches(requestId: string, undoStop: string | undefined, entry: AbstractChatEditingModifiedFileEntry, next: boolean, tx: ITransaction | undefined) {
-		const history = this._linearHistory.get();
-		const snapIndex = history.findIndex(s => s.requestId === requestId);
-		if (snapIndex === -1) {
-			return;
-		}
-
-		const snap = history[snapIndex];
-		let stopIndex = snap.stops.findIndex(s => s.stopId === undoStop);
-		if (stopIndex === -1) {
-			return;
-		}
-
-		// special case: put the last change in the pendingSnapshot as needed
-		if (next) {
-			if (stopIndex === snap.stops.length - 1) {
-				const postEdit = new ResourceMap(snap.postEdit || this._createEmptySnapshot(undefined).entries);
-				if (!snap.postEdit || !entry.equalsSnapshot(postEdit.get(entry.modifiedURI))) {
-					postEdit.set(entry.modifiedURI, entry.createSnapshot(requestId, POST_EDIT_STOP_ID));
-					const newHistory = history.slice();
-					newHistory[snapIndex] = { ...snap, postEdit };
-					this._linearHistory.set(newHistory, tx);
-				}
-				return;
-			}
-			stopIndex++;
-		}
-
-		const stop = snap.stops[stopIndex];
-		if (entry.equalsSnapshot(stop.entries.get(entry.modifiedURI))) {
-			return;
-		}
-
-		const newMap = new ResourceMap(stop.entries);
-		newMap.set(entry.modifiedURI, entry.createSnapshot(requestId, stop.stopId));
-
-		const newStop = snap.stops.slice();
-		newStop[stopIndex] = { ...stop, entries: newMap };
-
-		const newHistory = history.slice();
-		newHistory[snapIndex] = { ...snap, stops: newStop };
-		this._linearHistory.set(newHistory, tx);
-	}
-
 	private async _acceptEdits(resource: URI, textEdits: (TextEdit | ICellEditOperation)[], isLastEdits: boolean, responseModel: IChatResponseModel): Promise<void> {
-		this._fullDiffs.delete(resource.toString());
 		const entry = await this._getOrCreateModifiedFileEntry(resource, this._getTelemetryInfoForModel(responseModel));
 		await entry.acceptAgentEdits(resource, textEdits, isLastEdits, responseModel);
 	}
@@ -848,7 +518,6 @@ export class ChatEditingSession extends Disposable implements IChatEditingSessio
 	}
 
 	private async _resolve(requestId: string, undoStop: string | undefined, resource: URI): Promise<void> {
-
 		const hasOtherTasks = Iterable.some(this._streamingEditLocks.keys(), k => k !== resource.toString());
 		if (!hasOtherTasks) {
 			this._state.set(ChatEditingSessionState.Idle, undefined);
@@ -859,7 +528,7 @@ export class ChatEditingSession extends Disposable implements IChatEditingSessio
 			return;
 		}
 
-		this.ensureEditInUndoStopMatches(requestId, undoStop, entry, /* next= */ true, undefined);
+		this._timeline.ensureEditInUndoStopMatches(requestId, undoStop, entry, /* next= */ true, undefined);
 		return entry.acceptStreamingEditsEnd();
 
 	}

--- a/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingTimeline.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingTimeline.ts
@@ -1,0 +1,461 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+
+
+import { equals as arraysEqual, binarySearch2 } from '../../../../../base/common/arrays.js';
+import { findLast } from '../../../../../base/common/arraysFind.js';
+import { DisposableStore } from '../../../../../base/common/lifecycle.js';
+import { ResourceMap } from '../../../../../base/common/map.js';
+import { derived, derivedOpts, IObservable, ITransaction, ObservablePromise, observableValue, transaction } from '../../../../../base/common/observable.js';
+import { isEqual } from '../../../../../base/common/resources.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { IEditorWorkerService } from '../../../../../editor/common/services/editorWorker.js';
+import { ITextModelService } from '../../../../../editor/common/services/resolverService.js';
+import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
+import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
+import { observableConfigValue } from '../../../../../platform/observable/common/platformObservableUtils.js';
+import { IEditSessionEntryDiff, ISnapshotEntry } from '../../common/chatEditingService.js';
+import { IChatRequestDisablement } from '../../common/chatModel.js';
+import { AbstractChatEditingModifiedFileEntry } from './chatEditingModifiedFileEntry.js';
+import { ChatEditingModifiedNotebookEntry } from './chatEditingModifiedNotebookEntry.js';
+import { IChatEditingSessionSnapshot, IChatEditingSessionStop } from './chatEditingSessionStorage.js';
+import { ChatEditingModifiedNotebookDiff } from './notebook/chatEditingModifiedNotebookDiff.js';
+
+/**
+ * Timeline/undo-redo stack for ChatEditingSession.
+ */
+export class ChatEditingTimeline {
+	public static readonly POST_EDIT_STOP_ID = 'd19944f6-f46c-4e17-911b-79a8e843c7c0'; // randomly generated
+	public static createEmptySnapshot(undoStop: string | undefined): IChatEditingSessionStop {
+		return {
+			stopId: undoStop,
+			entries: new ResourceMap(),
+		};
+	}
+
+	private readonly _linearHistory = observableValue<readonly IChatEditingSessionSnapshot[]>(this, []);
+	private readonly _linearHistoryIndex = observableValue<number>(this, 0);
+
+	private readonly _diffsBetweenStops = new Map<string, IObservable<IEditSessionEntryDiff | undefined>>();
+	private readonly _fullDiffs = new Map<string, IObservable<IEditSessionEntryDiff | undefined>>();
+	private readonly _ignoreTrimWhitespaceObservable: IObservable<boolean>;
+
+	public readonly canUndo: IObservable<boolean>;
+	public readonly canRedo: IObservable<boolean>;
+
+	constructor(
+		@IEditorWorkerService private readonly _editorWorkerService: IEditorWorkerService,
+		@IInstantiationService private readonly _instantiationService: IInstantiationService,
+		@IConfigurationService configurationService: IConfigurationService,
+		@ITextModelService private readonly _textModelService: ITextModelService,
+	) {
+		this._ignoreTrimWhitespaceObservable = observableConfigValue('diffEditor.ignoreTrimWhitespace', true, configurationService);
+
+		this.canUndo = derived(r => {
+			const linearHistoryIndex = this._linearHistoryIndex.read(r);
+			return linearHistoryIndex > 1;
+		});
+		this.canRedo = derived(r => {
+			const linearHistoryIndex = this._linearHistoryIndex.read(r);
+			return linearHistoryIndex < getMaxHistoryIndex(this._linearHistory.read(r));
+		});
+	}
+
+	/**
+	 * Restore the timeline from a saved state (history array and index).
+	 */
+	public restoreFromState(state: { history: readonly IChatEditingSessionSnapshot[]; index: number }, tx: ITransaction): void {
+		this._linearHistory.set(state.history, tx);
+		this._linearHistoryIndex.set(state.index, tx);
+	}
+
+	/**
+	 * Get the snapshot and history index for restoring, given requestId and stopId.
+	 * If requestId is undefined, returns undefined (pending snapshot is managed by session).
+	 */
+	public getSnapshotForRestore(requestId: string | undefined, stopId: string | undefined): { stop: IChatEditingSessionStop; historyIndex: number; apply(): void } | undefined {
+		if (requestId === undefined) {
+			return undefined;
+		}
+		const stopRef = this.findEditStop(requestId, stopId);
+		if (!stopRef) {
+			return undefined;
+		}
+
+		return { stop: stopRef.stop, historyIndex: stopRef.historyIndex, apply: () => this._linearHistoryIndex.set(stopRef.historyIndex + 1, undefined) };
+	}
+
+	/**
+	 * Ensures the state of the file in the given snapshot matches the current
+	 * state of the {@param entry}. This is used to handle concurrent file edits.
+	 *
+	 * Given the case of two different edits, we will place and undo stop right
+	 * before we `textEditGroup` in the underlying markdown stream, but at the
+	 * time those are added the edits haven't been made yet, so both files will
+	 * simply have the unmodified state.
+	 *
+	 * This method is called after each edit, so after the first file finishes
+	 * being edits, it will update its content in the second undo snapshot such
+	 * that it can be undone successfully.
+	 *
+	 * We ensure that the same file is not concurrently edited via the
+	 * {@link _streamingEditLocks}, avoiding race conditions.
+	 *
+	 * @param next If true, this will edit the snapshot _after_ the undo stop
+	 */
+	public ensureEditInUndoStopMatches(
+		requestId: string,
+		undoStop: string | undefined,
+		entry: Pick<AbstractChatEditingModifiedFileEntry, 'modifiedURI' | 'createSnapshot' | 'equalsSnapshot'>,
+		next: boolean,
+		tx: ITransaction | undefined
+	) {
+		const history = this._linearHistory.get();
+		const snapIndex = history.findIndex((s) => s.requestId === requestId);
+		if (snapIndex === -1) {
+			return;
+		}
+
+		const snap = history[snapIndex];
+		let stopIndex = snap.stops.findIndex((s) => s.stopId === undoStop);
+		if (stopIndex === -1) {
+			return;
+		}
+
+		if (next) {
+			if (stopIndex === snap.stops.length - 1) {
+				const postEdit = new ResourceMap(snap.postEdit || ChatEditingTimeline.createEmptySnapshot(undefined).entries);
+				if (!snap.postEdit || !entry.equalsSnapshot(postEdit.get(entry.modifiedURI) as ISnapshotEntry | undefined)) {
+					postEdit.set(entry.modifiedURI, entry.createSnapshot(requestId, ChatEditingTimeline.POST_EDIT_STOP_ID));
+					const newHistory = history.slice();
+					newHistory[snapIndex] = { ...snap, postEdit };
+					this._linearHistory.set(newHistory, tx);
+				}
+				return;
+			}
+			stopIndex++;
+		}
+
+		const stop = snap.stops[stopIndex];
+		if (entry.equalsSnapshot(stop.entries.get(entry.modifiedURI))) {
+			return;
+		}
+
+		const newMap = new ResourceMap(stop.entries);
+		newMap.set(entry.modifiedURI, entry.createSnapshot(requestId, stop.stopId));
+
+		const newStop = snap.stops.slice();
+		newStop[stopIndex] = { ...stop, entries: newMap };
+
+		const newHistory = history.slice();
+		newHistory[snapIndex] = { ...snap, stops: newStop };
+		this._linearHistory.set(newHistory, tx);
+	}
+
+	/**
+	 * Get the undo snapshot (previous in history), or undefined if at start.
+	 * If the timeline is at the end of the history, it will return the last stop
+	 * pushed into the history.
+	 */
+	public getUndoSnapshot(): { stop: IChatEditingSessionStop; apply(): void } | undefined {
+		const idx = this._linearHistoryIndex.get() - 2;
+		const entry = this.getHistoryEntryByLinearIndex(idx);
+		if (entry) {
+			return { stop: entry.stop, apply: () => this._linearHistoryIndex.set(idx + 1, undefined) };
+		}
+		return undefined;
+	}
+
+	/**
+	 * Get the redo snapshot (next in history), or undefined if at end.
+	 */
+	public getRedoSnapshot(): { stop: IChatEditingSessionStop; apply(): void } | undefined {
+		const idx = this._linearHistoryIndex.get();
+		const entry = this.getHistoryEntryByLinearIndex(idx);
+		if (entry) {
+			return { stop: entry.stop, apply: () => this._linearHistoryIndex.set(idx + 1, undefined) };
+		}
+		return undefined;
+	}
+
+	/**
+	 * Get the state for persistence (history and index).
+	 */
+	public getStateForPersistence(): { history: readonly IChatEditingSessionSnapshot[]; index: number } {
+		return { history: this._linearHistory.get(), index: this._linearHistoryIndex.get() };
+	}
+
+	private findSnapshot(requestId: string): IChatEditingSessionSnapshot | undefined {
+		return this._linearHistory.get().find((s) => s.requestId === requestId);
+	}
+
+	private findEditStop(requestId: string, undoStop: string | undefined) {
+		const snapshot = this.findSnapshot(requestId);
+		if (!snapshot) {
+			return undefined;
+		}
+		const idx = snapshot.stops.findIndex((s) => s.stopId === undoStop);
+		return idx === -1 ? undefined : { stop: snapshot.stops[idx], snapshot, historyIndex: snapshot.startIndex + idx };
+	}
+
+	private getHistoryEntryByLinearIndex(index: number) {
+		const history = this._linearHistory.get();
+		const searchedIndex = binarySearch2(history.length, (e) => history[e].startIndex - index);
+		const entry = history[searchedIndex < 0 ? (~searchedIndex) - 1 : searchedIndex];
+		if (!entry || index - entry.startIndex >= entry.stops.length) {
+			return undefined;
+		}
+		return {
+			entry,
+			stop: entry.stops[index - entry.startIndex]
+		};
+	}
+
+	public pushSnapshot(requestId: string, undoStop: string | undefined, snapshot: IChatEditingSessionStop) {
+		const linearHistoryPtr = this._linearHistoryIndex.get();
+		const newLinearHistory: IChatEditingSessionSnapshot[] = [];
+		for (const entry of this._linearHistory.get()) {
+			if (entry.startIndex >= linearHistoryPtr) {
+				break;
+			} else if (linearHistoryPtr - entry.startIndex < entry.stops.length) {
+				newLinearHistory.push({ requestId: entry.requestId, stops: entry.stops.slice(0, linearHistoryPtr - entry.startIndex), startIndex: entry.startIndex, postEdit: undefined });
+			} else {
+				newLinearHistory.push(entry);
+			}
+		}
+
+		const lastEntry = newLinearHistory.at(-1);
+		if (requestId && lastEntry?.requestId === requestId) {
+			if (lastEntry.postEdit && undoStop) {
+				const rebaseUri = (uri: URI) => uri.with({ query: uri.query.replace(ChatEditingTimeline.POST_EDIT_STOP_ID, undoStop) });
+				for (const [uri, prev] of lastEntry.postEdit.entries()) {
+					snapshot.entries.set(uri, { ...prev, snapshotUri: rebaseUri(prev.snapshotUri), resource: rebaseUri(prev.resource) });
+				}
+			}
+			newLinearHistory[newLinearHistory.length - 1] = { ...lastEntry, stops: [...lastEntry.stops, snapshot], postEdit: undefined };
+		} else {
+			newLinearHistory.push({ requestId, startIndex: lastEntry ? lastEntry.startIndex + lastEntry.stops.length : 0, stops: [snapshot], postEdit: undefined });
+		}
+
+		transaction((tx) => {
+			const last = newLinearHistory[newLinearHistory.length - 1];
+			this._linearHistory.set(newLinearHistory, tx);
+			this._linearHistoryIndex.set(last.startIndex + last.stops.length, tx);
+		});
+	}
+
+	/**
+	 * Gets chat disablement entries for the current timeline state.
+	 */
+	public getRequestDisablement() {
+		const history = this._linearHistory.get();
+		const index = this._linearHistoryIndex.get();
+		const undoRequests: IChatRequestDisablement[] = [];
+		for (const entry of history) {
+			if (!entry.requestId) {
+				// ignored
+			} else if (entry.startIndex >= index) {
+				undoRequests.push({ requestId: entry.requestId });
+			} else if (entry.startIndex + entry.stops.length > index) {
+				undoRequests.push({ requestId: entry.requestId, afterUndoStop: entry.stops[index - entry.startIndex].stopId });
+			}
+		}
+		return undoRequests;
+	}
+
+	/**
+	 * Gets diff for text entries between stops.
+	 * @param entriesContent Observable that observes either snapshot entry
+	 * @param modelUrisObservable Observable that observes only the snapshot URIs.
+	 */
+	private _entryDiffBetweenTextStops(
+		entriesContent: IObservable<{ before: ISnapshotEntry; after: ISnapshotEntry } | undefined>,
+		modelUrisObservable: IObservable<[URI, URI] | undefined>,
+	): IObservable<ObservablePromise<IEditSessionEntryDiff> | undefined> {
+		const modelRefsPromise = derived(this, (reader) => {
+			const modelUris = modelUrisObservable.read(reader);
+			if (!modelUris) { return undefined; }
+
+			const store = reader.store.add(new DisposableStore());
+			const promise = Promise.all(modelUris.map(u => this._textModelService.createModelReference(u))).then(refs => {
+				if (store.isDisposed) {
+					refs.forEach(r => r.dispose());
+				} else {
+					refs.forEach(r => store.add(r));
+				}
+
+				return refs;
+			});
+
+			return new ObservablePromise(promise);
+		});
+
+		return derived((reader): ObservablePromise<IEditSessionEntryDiff> | undefined => {
+			const refs2 = modelRefsPromise.read(reader)?.promiseResult.read(reader);
+			const refs = refs2?.data;
+			if (!refs) {
+				return;
+			}
+
+			const entries = entriesContent.read(reader); // trigger re-diffing when contents change
+
+			if (entries?.before && ChatEditingModifiedNotebookEntry.canHandleSnapshot(entries.before)) {
+				const diffService = this._instantiationService.createInstance(ChatEditingModifiedNotebookDiff, entries.before, entries.after);
+				return new ObservablePromise(diffService.computeDiff());
+
+			}
+			const ignoreTrimWhitespace = this._ignoreTrimWhitespaceObservable.read(reader);
+			const promise = this._editorWorkerService.computeDiff(
+				refs[0].object.textEditorModel.uri,
+				refs[1].object.textEditorModel.uri,
+				{ ignoreTrimWhitespace, computeMoves: false, maxComputationTimeMs: 3000 },
+				'advanced'
+			).then((diff): IEditSessionEntryDiff => {
+				const entryDiff: IEditSessionEntryDiff = {
+					originalURI: refs[0].object.textEditorModel.uri,
+					modifiedURI: refs[1].object.textEditorModel.uri,
+					identical: !!diff?.identical,
+					quitEarly: !diff || diff.quitEarly,
+					added: 0,
+					removed: 0,
+				};
+				if (diff) {
+					for (const change of diff.changes) {
+						entryDiff.removed += change.original.endLineNumberExclusive - change.original.startLineNumber;
+						entryDiff.added += change.modified.endLineNumberExclusive - change.modified.startLineNumber;
+					}
+				}
+
+				return entryDiff;
+			});
+
+			return new ObservablePromise(promise);
+		});
+	}
+
+	private _createDiffBetweenStopsObservable(uri: URI, requestId: string | undefined, stopId: string | undefined): IObservable<IEditSessionEntryDiff | undefined> {
+		const entries = derivedOpts<undefined | { before: ISnapshotEntry; after: ISnapshotEntry }>(
+			{
+				equalsFn: (a, b) => snapshotsEqualForDiff(a?.before, b?.before) && snapshotsEqualForDiff(a?.after, b?.after),
+			},
+			reader => {
+				const stops = requestId ?
+					getCurrentAndNextStop(requestId, stopId, this._linearHistory.read(reader)) :
+					getFirstAndLastStop(uri, this._linearHistory.read(reader));
+				if (!stops) { return undefined; }
+				const before = stops.current.get(uri);
+				const after = stops.next.get(uri);
+				if (!before || !after) { return undefined; }
+				return { before, after };
+			},
+		);
+
+		// Separate observable for model refs to avoid unnecessary disposal
+		const modelUrisObservable = derivedOpts<[URI, URI] | undefined>({ equalsFn: (a, b) => arraysEqual(a, b, isEqual) }, reader => {
+			const entriesValue = entries.read(reader);
+			if (!entriesValue) { return undefined; }
+			return [entriesValue.before.snapshotUri, entriesValue.after.snapshotUri];
+		});
+
+		const diff = this._entryDiffBetweenTextStops(entries, modelUrisObservable);
+
+		return derived(reader => {
+			return diff.read(reader)?.promiseResult.read(reader)?.data || undefined;
+		});
+	}
+
+	public getEntryDiffBetweenStops(uri: URI, requestId: string | undefined, stopId: string | undefined) {
+		if (requestId) {
+			const key = `${uri}\0${requestId}\0${stopId}`;
+			let observable = this._diffsBetweenStops.get(key);
+			if (!observable) {
+				observable = this._createDiffBetweenStopsObservable(uri, requestId, stopId);
+				this._diffsBetweenStops.set(key, observable);
+			}
+
+			return observable;
+		} else {
+			const key = uri.toString();
+			let observable = this._fullDiffs.get(key);
+			if (!observable) {
+				observable = this._createDiffBetweenStopsObservable(uri, requestId, stopId);
+				this._fullDiffs.set(key, observable);
+			}
+
+			return observable;
+		}
+	}
+}
+
+function getMaxHistoryIndex(history: readonly IChatEditingSessionSnapshot[]) {
+	const lastHistory = history.at(-1);
+	return lastHistory ? lastHistory.startIndex + lastHistory.stops.length : 0;
+}
+
+function snapshotsEqualForDiff(a: ISnapshotEntry | undefined, b: ISnapshotEntry | undefined) {
+	if (!a || !b) {
+		return a === b;
+	}
+
+	return isEqual(a.snapshotUri, b.snapshotUri) && a.current === b.current;
+}
+
+function getCurrentAndNextStop(requestId: string, stopId: string | undefined, history: readonly IChatEditingSessionSnapshot[]) {
+	const snapshotIndex = history.findIndex(s => s.requestId === requestId);
+	if (snapshotIndex === -1) { return undefined; }
+	const snapshot = history[snapshotIndex];
+	const stopIndex = snapshot.stops.findIndex(s => s.stopId === stopId);
+	if (stopIndex === -1) { return undefined; }
+
+	const currentStop = snapshot.stops[stopIndex];
+	const current = currentStop.entries;
+	const nextStop = stopIndex < snapshot.stops.length - 1
+		? snapshot.stops[stopIndex + 1]
+		: undefined;
+	const next = nextStop?.entries || snapshot.postEdit;
+
+
+	if (!next) {
+		return undefined;
+	}
+
+	return { current, currentStopId: currentStop.stopId, next, nextStopId: nextStop?.stopId || ChatEditingTimeline.POST_EDIT_STOP_ID };
+}
+
+function getFirstAndLastStop(uri: URI, history: readonly IChatEditingSessionSnapshot[]) {
+	let firstStopWithUri: IChatEditingSessionStop | undefined;
+	for (const snapshot of history) {
+		const stop = snapshot.stops.find(s => s.entries.has(uri));
+		if (stop) {
+			firstStopWithUri = stop;
+			break;
+		}
+	}
+
+	let lastStopWithUri: ResourceMap<ISnapshotEntry> | undefined;
+	let lastStopWithUriId: string | undefined;
+	for (let i = history.length - 1; i >= 0; i--) {
+		const snapshot = history[i];
+		if (snapshot.postEdit?.has(uri)) {
+			lastStopWithUri = snapshot.postEdit;
+			lastStopWithUriId = ChatEditingTimeline.POST_EDIT_STOP_ID;
+			break;
+		}
+
+		const stop = findLast(snapshot.stops, s => s.entries.has(uri));
+		if (stop) {
+			lastStopWithUri = stop.entries;
+			lastStopWithUriId = stop.stopId;
+			break;
+		}
+	}
+
+	if (!firstStopWithUri || !lastStopWithUri) {
+		return undefined;
+	}
+
+	return { current: firstStopWithUri.entries, currentStopId: firstStopWithUri.stopId, next: lastStopWithUri, nextStopId: lastStopWithUriId! };
+}

--- a/src/vs/workbench/contrib/chat/test/browser/chatEditingTimeline.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/chatEditingTimeline.test.ts
@@ -1,0 +1,466 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { workbenchInstantiationService } from '../../../../test/browser/workbenchTestServices.js';
+import { ChatEditingTimeline } from '../../browser/chatEditing/chatEditingTimeline.js';
+import { IChatEditingSessionStop } from '../../browser/chatEditing/chatEditingSessionStorage.js';
+import { transaction } from '../../../../../base/common/observable.js';
+
+suite('ChatEditingTimeline', () => {
+	const ds = ensureNoDisposablesAreLeakedInTestSuite();
+	let timeline: ChatEditingTimeline;
+
+	setup(() => {
+		const instaService = workbenchInstantiationService(undefined, ds);
+		timeline = instaService.createInstance(ChatEditingTimeline);
+	});
+
+	suite('undo/redo', () => {
+		test('undo/redo with empty history', () => {
+			assert.strictEqual(timeline.getUndoSnapshot(), undefined);
+			assert.strictEqual(timeline.getRedoSnapshot(), undefined);
+			assert.strictEqual(timeline.canRedo.get(), false);
+			assert.strictEqual(timeline.canUndo.get(), false);
+		});
+	});
+
+	function createSnapshot(stopId = 'stop', entries?: any): IChatEditingSessionStop {
+		return {
+			stopId,
+			entries: entries || new Map(),
+		};
+	}
+
+	suite('Basic functionality', () => {
+		test('pushSnapshot and undo/redo navigation', () => {
+			// Push two snapshots
+			timeline.pushSnapshot('req1', 'stop1', createSnapshot('stop1'));
+			timeline.pushSnapshot('req1', 'stop2', createSnapshot('stop2'));
+
+			// After two pushes, canUndo should be true, canRedo false
+			assert.strictEqual(timeline.canUndo.get(), true);
+			assert.strictEqual(timeline.canRedo.get(), false);
+
+			// Undo should move back to stop1
+			const undoSnap = timeline.getUndoSnapshot();
+			assert.ok(undoSnap);
+			assert.strictEqual(undoSnap.stop.stopId, 'stop1');
+			undoSnap.apply();
+			assert.strictEqual(timeline.canUndo.get(), false);
+			assert.strictEqual(timeline.canRedo.get(), true);
+
+			// Redo should move forward to stop2
+			const redoSnap = timeline.getRedoSnapshot();
+			assert.ok(redoSnap);
+			assert.strictEqual(redoSnap.stop.stopId, 'stop2');
+			redoSnap.apply();
+			assert.strictEqual(timeline.canUndo.get(), true);
+			assert.strictEqual(timeline.canRedo.get(), false);
+		});
+
+		test('restoreFromState restores history and index', () => {
+			timeline.pushSnapshot('req1', 'stop1', createSnapshot('stop1'));
+			timeline.pushSnapshot('req1', 'stop2', createSnapshot('stop2'));
+			const state = timeline.getStateForPersistence();
+
+			// Move back
+			timeline.getUndoSnapshot()?.apply();
+
+			// Restore state
+			transaction(tx => timeline.restoreFromState(state, tx));
+			assert.strictEqual(timeline.canUndo.get(), true);
+			assert.strictEqual(timeline.canRedo.get(), false);
+		});
+
+		test('getSnapshotForRestore returns correct snapshot', () => {
+			timeline.pushSnapshot('req1', 'stop1', createSnapshot('stop1'));
+			timeline.pushSnapshot('req1', 'stop2', createSnapshot('stop2'));
+
+			const snap = timeline.getSnapshotForRestore('req1', 'stop1');
+			assert.ok(snap);
+			assert.strictEqual(snap.stop.stopId, 'stop1');
+			snap.apply();
+
+			assert.strictEqual(timeline.canRedo.get(), true);
+			assert.strictEqual(timeline.canUndo.get(), false);
+
+			const snap2 = timeline.getSnapshotForRestore('req1', 'stop2');
+			assert.ok(snap2);
+			assert.strictEqual(snap2.stop.stopId, 'stop2');
+			snap2.apply();
+
+			assert.strictEqual(timeline.canRedo.get(), false);
+			assert.strictEqual(timeline.canUndo.get(), true);
+		});
+
+		test('getRequestDisablement returns correct requests', () => {
+			timeline.pushSnapshot('req1', 'stop1', createSnapshot('stop1'));
+			timeline.pushSnapshot('req2', 'stop2', createSnapshot('stop2'));
+
+			// Move back to first
+			timeline.getUndoSnapshot()?.apply();
+
+			const disables = timeline.getRequestDisablement();
+			assert.ok(Array.isArray(disables));
+			assert.ok(disables.some(d => d.requestId === 'req2'));
+		});
+	});
+
+	suite('Multiple requests', () => {
+		test('handles multiple requests with separate snapshots', () => {
+			timeline.pushSnapshot('req1', 'stop1', createSnapshot('stop1'));
+			timeline.pushSnapshot('req2', 'stop2', createSnapshot('stop2'));
+			timeline.pushSnapshot('req3', 'stop3', createSnapshot('stop3'));
+
+			assert.strictEqual(timeline.canUndo.get(), true);
+			assert.strictEqual(timeline.canRedo.get(), false);
+
+			// Undo should go back through requests
+			let undoSnap = timeline.getUndoSnapshot();
+			assert.ok(undoSnap);
+			assert.strictEqual(undoSnap.stop.stopId, 'stop2');
+			undoSnap.apply();
+
+			undoSnap = timeline.getUndoSnapshot();
+			assert.ok(undoSnap);
+			assert.strictEqual(undoSnap.stop.stopId, 'stop1');
+		});
+
+		test('handles same request with multiple stops', () => {
+			timeline.pushSnapshot('req1', 'stop1', createSnapshot('stop1'));
+			timeline.pushSnapshot('req1', 'stop2', createSnapshot('stop2'));
+			timeline.pushSnapshot('req1', 'stop3', createSnapshot('stop3'));
+
+			const state = timeline.getStateForPersistence();
+			assert.strictEqual(state.history.length, 1);
+			assert.strictEqual(state.history[0].stops.length, 3);
+			assert.strictEqual(state.history[0].requestId, 'req1');
+		});
+
+		test('mixed requests and stops', () => {
+			timeline.pushSnapshot('req1', 'stop1', createSnapshot('stop1'));
+			timeline.pushSnapshot('req1', 'stop2', createSnapshot('stop2'));
+			timeline.pushSnapshot('req2', 'stop3', createSnapshot('stop3'));
+			timeline.pushSnapshot('req2', 'stop4', createSnapshot('stop4'));
+
+			const state = timeline.getStateForPersistence();
+			assert.strictEqual(state.history.length, 2);
+			assert.strictEqual(state.history[0].stops.length, 2);
+			assert.strictEqual(state.history[1].stops.length, 2);
+		});
+	});
+
+	suite('Edge cases', () => {
+		test('getSnapshotForRestore with non-existent request', () => {
+			timeline.pushSnapshot('req1', 'stop1', createSnapshot('stop1'));
+
+			const snap = timeline.getSnapshotForRestore('nonexistent', 'stop1');
+			assert.strictEqual(snap, undefined);
+		});
+
+		test('getSnapshotForRestore with non-existent stop', () => {
+			timeline.pushSnapshot('req1', 'stop1', createSnapshot('stop1'));
+
+			const snap = timeline.getSnapshotForRestore('req1', 'nonexistent');
+			assert.strictEqual(snap, undefined);
+		});
+	});
+
+	suite('History manipulation', () => {
+		test('pushing snapshots after undo truncates future history', () => {
+			timeline.pushSnapshot('req1', 'stop1', createSnapshot('stop1'));
+			timeline.pushSnapshot('req1', 'stop2', createSnapshot('stop2'));
+			timeline.pushSnapshot('req1', 'stop3', createSnapshot('stop3'));
+
+			// Undo twice
+			timeline.getUndoSnapshot()?.apply();
+			timeline.getUndoSnapshot()?.apply();
+
+			// Push new snapshot - should truncate stop3
+			timeline.pushSnapshot('req1', 'new_stop', createSnapshot('new_stop'));
+
+			const state = timeline.getStateForPersistence();
+			assert.strictEqual(state.history[0].stops.length, 2); // stop1 + new_stop
+			assert.strictEqual(state.history[0].stops[1].stopId, 'new_stop');
+		});
+
+		test('branching from middle of history creates new branch', () => {
+			timeline.pushSnapshot('req1', 'stop1', createSnapshot('stop1'));
+			timeline.pushSnapshot('req2', 'stop2', createSnapshot('stop2'));
+			timeline.pushSnapshot('req3', 'stop3', createSnapshot('stop3'));
+
+			// Undo to middle
+			timeline.getUndoSnapshot()?.apply();
+
+			// Push new request
+			timeline.pushSnapshot('req4', 'stop4', createSnapshot('stop4'));
+
+			const state = timeline.getStateForPersistence();
+			assert.strictEqual(state.history.length, 3); // req1, req2, req4
+			assert.strictEqual(state.history[2].requestId, 'req4');
+		});
+	});
+
+	suite('State persistence', () => {
+		test('getStateForPersistence returns complete state', () => {
+			timeline.pushSnapshot('req1', 'stop1', createSnapshot('stop1'));
+			timeline.pushSnapshot('req2', 'stop2', createSnapshot('stop2'));
+
+			const state = timeline.getStateForPersistence();
+			assert.ok(state.history);
+			assert.ok(typeof state.index === 'number');
+			assert.strictEqual(state.history.length, 2);
+			assert.strictEqual(state.index, 2);
+		});
+
+		test('restoreFromState handles empty history', () => {
+			const emptyState = { history: [], index: 0 };
+
+			transaction(tx => timeline.restoreFromState(emptyState, tx));
+
+			assert.strictEqual(timeline.canUndo.get(), false);
+			assert.strictEqual(timeline.canRedo.get(), false);
+		});
+
+		test('restoreFromState with complex history', () => {
+			// Create complex state
+			timeline.pushSnapshot('req1', 'stop1', createSnapshot('stop1'));
+			timeline.pushSnapshot('req1', 'stop2', createSnapshot('stop2'));
+			timeline.pushSnapshot('req2', 'stop3', createSnapshot('stop3'));
+
+			const originalState = timeline.getStateForPersistence();
+
+			// Create new timeline and restore
+			const instaService = workbenchInstantiationService(undefined, ds);
+			const newTimeline = instaService.createInstance(ChatEditingTimeline);
+			transaction(tx => newTimeline.restoreFromState(originalState, tx));
+
+			const restoredState = newTimeline.getStateForPersistence();
+			assert.deepStrictEqual(restoredState.index, originalState.index);
+			assert.strictEqual(restoredState.history.length, originalState.history.length);
+		});
+	});
+
+	suite('Request disablement', () => {
+		test('getRequestDisablement at various positions', () => {
+			timeline.pushSnapshot('req1', 'stop1', createSnapshot('stop1'));
+			timeline.pushSnapshot('req2', 'stop2', createSnapshot('stop2'));
+			timeline.pushSnapshot('req3', 'stop3', createSnapshot('stop3'));
+
+			// At end - no disabled requests
+			let disables = timeline.getRequestDisablement();
+			assert.strictEqual(disables.length, 0);
+
+			// Move back one
+			timeline.getUndoSnapshot()?.apply();
+			disables = timeline.getRequestDisablement();
+			assert.strictEqual(disables.length, 1);
+			assert.strictEqual(disables[0].requestId, 'req3');
+
+			// Move back to beginning
+			timeline.getUndoSnapshot()?.apply();
+			timeline.getUndoSnapshot()?.apply();
+			disables = timeline.getRequestDisablement();
+			assert.strictEqual(disables.length, 2);
+		});
+
+		test('getRequestDisablement with mixed request/stop structure', () => {
+			timeline.pushSnapshot('req1', 'stop1', createSnapshot('stop1'));
+			timeline.pushSnapshot('req1', 'stop2', createSnapshot('stop2'));
+			timeline.pushSnapshot('req2', 'stop3', createSnapshot('stop3'));
+
+			// Move to middle of req1
+			timeline.getUndoSnapshot()?.apply();
+			timeline.getUndoSnapshot()?.apply();
+
+			const disables = timeline.getRequestDisablement();
+			assert.strictEqual(disables.length, 2);
+
+			// Should have partial disable for req1 and full disable for req2
+			const req1Disable = disables.find(d => d.requestId === 'req1');
+			const req2Disable = disables.find(d => d.requestId === 'req2');
+
+			assert.ok(req1Disable);
+			assert.ok(req2Disable);
+			assert.ok(req1Disable.afterUndoStop);
+			assert.strictEqual(req2Disable.afterUndoStop, undefined);
+		});
+	});
+
+	suite('Boundary conditions', () => {
+		test('undo/redo at boundaries', () => {
+			// Empty timeline
+			assert.strictEqual(timeline.getUndoSnapshot(), undefined);
+			assert.strictEqual(timeline.getRedoSnapshot(), undefined);
+
+			// Single snapshot
+			timeline.pushSnapshot('req1', 'stop2', createSnapshot('stop2'));
+			timeline.pushSnapshot('req1', 'stop2', createSnapshot('stop2'));
+			assert.ok(timeline.getUndoSnapshot());
+			assert.strictEqual(timeline.getRedoSnapshot(), undefined);
+
+			// At beginning after undo
+			timeline.getUndoSnapshot()?.apply();
+			assert.strictEqual(timeline.getUndoSnapshot(), undefined);
+			assert.ok(timeline.getRedoSnapshot());
+		});
+
+		test('multiple undos and redos', () => {
+			timeline.pushSnapshot('req1', 'stop1', createSnapshot('stop1'));
+			timeline.pushSnapshot('req2', 'stop2', createSnapshot('stop2'));
+			timeline.pushSnapshot('req3', 'stop3', createSnapshot('stop3'));
+
+			// Undo all
+			const stops: string[] = [];
+			let undoSnap = timeline.getUndoSnapshot();
+			while (undoSnap) {
+				stops.push(undoSnap.stop.stopId!);
+				undoSnap.apply();
+				undoSnap = timeline.getUndoSnapshot();
+			}
+			assert.deepStrictEqual(stops, ['stop2', 'stop1']);
+
+			// Redo all
+			const redoStops: string[] = [];
+			let redoSnap = timeline.getRedoSnapshot();
+			while (redoSnap) {
+				redoStops.push(redoSnap.stop.stopId!);
+				redoSnap.apply();
+				redoSnap = timeline.getRedoSnapshot();
+			}
+			assert.deepStrictEqual(redoStops, ['stop2', 'stop3']);
+		});
+	});
+
+	suite('Static methods', () => {
+		test('createEmptySnapshot creates valid snapshot', () => {
+			const snapshot = ChatEditingTimeline.createEmptySnapshot('test-stop');
+			assert.strictEqual(snapshot.stopId, 'test-stop');
+			assert.ok(snapshot.entries);
+			assert.strictEqual(snapshot.entries.size, 0);
+		});
+
+		test('createEmptySnapshot with undefined stopId', () => {
+			const snapshot = ChatEditingTimeline.createEmptySnapshot(undefined);
+			assert.strictEqual(snapshot.stopId, undefined);
+			assert.ok(snapshot.entries);
+		});
+
+		test('POST_EDIT_STOP_ID is consistent', () => {
+			assert.strictEqual(typeof ChatEditingTimeline.POST_EDIT_STOP_ID, 'string');
+			assert.ok(ChatEditingTimeline.POST_EDIT_STOP_ID.length > 0);
+		});
+	});
+
+	suite('Observable behavior', () => {
+		test('canUndo observable updates correctly', () => {
+			assert.strictEqual(timeline.canUndo.get(), false);
+
+			timeline.pushSnapshot('req1', 'stop1', createSnapshot('stop1'));
+			timeline.pushSnapshot('req1', 'stop2', createSnapshot('stop2'));
+			assert.strictEqual(timeline.canUndo.get(), true);
+
+			timeline.getUndoSnapshot()?.apply();
+			assert.strictEqual(timeline.canUndo.get(), false);
+		});
+
+		test('canRedo observable updates correctly', () => {
+			timeline.pushSnapshot('req1', 'stop1', createSnapshot('stop1'));
+			timeline.pushSnapshot('req1', 'stop2', createSnapshot('stop2'));
+			assert.strictEqual(timeline.canRedo.get(), false);
+
+			timeline.getUndoSnapshot()?.apply();
+			assert.strictEqual(timeline.canRedo.get(), true);
+
+			timeline.getRedoSnapshot()?.apply();
+			assert.strictEqual(timeline.canRedo.get(), false);
+		});
+	});
+
+	suite('Complex scenarios', () => {
+		test('interleaved requests and undos', () => {
+			timeline.pushSnapshot('req1', 'stop1', createSnapshot('stop1'));
+			timeline.pushSnapshot('req2', 'stop2', createSnapshot('stop2'));
+
+			// Undo req2
+			timeline.getUndoSnapshot()?.apply();
+
+			// Add req3 (should branch from req1)
+			timeline.pushSnapshot('req3', 'stop3', createSnapshot('stop3'));
+
+			const state = timeline.getStateForPersistence();
+			assert.strictEqual(state.history.length, 2); // req1, req3
+			assert.strictEqual(state.history[1].requestId, 'req3');
+		});
+
+		test('large number of snapshots', () => {
+			// Push 100 snapshots
+			for (let i = 1; i <= 100; i++) {
+				timeline.pushSnapshot(`req${i}`, `stop${i}`, createSnapshot(`stop${i}`));
+			}
+
+			assert.strictEqual(timeline.canUndo.get(), true);
+			assert.strictEqual(timeline.canRedo.get(), false);
+
+			const state = timeline.getStateForPersistence();
+			assert.strictEqual(state.history.length, 100);
+			assert.strictEqual(state.index, 100);
+		});
+
+		test('alternating single and multi-stop requests', () => {
+			// Single stop request
+			timeline.pushSnapshot('req1', 'stop1', createSnapshot('stop1'));
+
+			// Multi-stop request
+			timeline.pushSnapshot('req2', 'stop2a', createSnapshot('stop2a'));
+			timeline.pushSnapshot('req2', 'stop2b', createSnapshot('stop2b'));
+			timeline.pushSnapshot('req2', 'stop2c', createSnapshot('stop2c'));
+
+			// Single stop request
+			timeline.pushSnapshot('req3', 'stop3', createSnapshot('stop3'));
+
+			const state = timeline.getStateForPersistence();
+			assert.strictEqual(state.history.length, 3);
+			assert.strictEqual(state.history[0].stops.length, 1);
+			assert.strictEqual(state.history[1].stops.length, 3);
+			assert.strictEqual(state.history[2].stops.length, 1);
+		});
+	});
+
+	suite('Error resilience', () => {
+		test('handles invalid apply calls gracefully', () => {
+			timeline.pushSnapshot('req1', 'stop1', createSnapshot('stop1'));
+			timeline.pushSnapshot('req1', 'stop2', createSnapshot('stop2'));
+
+			const undoSnap = timeline.getUndoSnapshot();
+			assert.ok(undoSnap);
+
+			// Apply twice - second should be safe
+			undoSnap.apply();
+			undoSnap.apply(); // Should not throw
+
+			assert.strictEqual(timeline.canUndo.get(), false);
+		});
+
+		test('getSnapshotForRestore with malformed stopId', () => {
+			timeline.pushSnapshot('req1', 'stop1', createSnapshot('stop1'));
+
+			const snap = timeline.getSnapshotForRestore('req1', '');
+			assert.strictEqual(snap, undefined);
+		});
+
+		test('handles restoration edge cases', () => {
+			const emptyState = { history: [], index: 0 };
+			transaction(tx => timeline.restoreFromState(emptyState, tx));
+
+			// Should be safe to call methods on empty timeline
+			assert.strictEqual(timeline.getUndoSnapshot(), undefined);
+			assert.strictEqual(timeline.getRedoSnapshot(), undefined);
+			assert.deepStrictEqual(timeline.getRequestDisablement(), []);
+		});
+	});
+});


### PR DESCRIPTION
- Refactor out the ChatEditingTimeline into its own class.
- Add some base unit tests for it.
- Fix some off-by-1 errors and a logic error that caused diffs to not
  show on some edit pills.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
