### PR TITLE
debt - global view container toolbar misses telemetry source

### DIFF
--- a/src/vs/workbench/browser/parts/compositePart.ts
+++ b/src/vs/workbench/browser/parts/compositePart.ts
@@ -89,7 +89,7 @@ export abstract class CompositePart<T extends Composite> extends Part {
 		protected readonly registry: CompositeRegistry<T>,
 		private readonly activeCompositeSettingsKey: string,
 		private readonly defaultCompositeId: string,
-		private readonly nameForTelemetry: string,
+		protected readonly nameForTelemetry: string,
 		private readonly compositeCSSClass: string,
 		private readonly titleForegroundColor: string | undefined,
 		private readonly titleBorderColor: string | undefined,

--- a/src/vs/workbench/browser/parts/paneCompositePart.ts
+++ b/src/vs/workbench/browser/parts/paneCompositePart.ts
@@ -365,7 +365,8 @@ export abstract class AbstractPaneCompositePart extends CompositePart<PaneCompos
 				toggleMenuTitle: localize('moreActions', "More Actions..."),
 				hoverDelegate: this.toolbarHoverDelegate,
 				hiddenItemStrategy: HiddenItemStrategy.NoHide,
-				highlightToggledItems: true
+				highlightToggledItems: true,
+				telemetrySource: this.nameForTelemetry
 			}
 		));
 


### PR DESCRIPTION
@sandy081 @benibenj fyi, this made global actions in composite parts never report telemetry, such as these:

<img width="119" alt="image" src="https://github.com/user-attachments/assets/b897b1ca-bf59-4581-8367-b3111bb39cf5" />

//cc @cwebster-99 