### PR TITLE
managed hover handles native hover implementation

### DIFF
--- a/src/vs/base/browser/ui/actionbar/actionViewItems.ts
+++ b/src/vs/base/browser/ui/actionbar/actionViewItems.ts
@@ -228,16 +228,11 @@ export class BaseActionViewItem extends Disposable implements IActionViewItem {
 		const title = this.getTooltip() ?? '';
 		this.updateAriaLabel();
 
-		if (this.options.hoverDelegate?.showNativeHover) {
-			/* While custom hover is not inside custom hover */
-			this.element.title = title;
-		} else {
-			if (!this.customHover && title !== '') {
-				const hoverDelegate = this.options.hoverDelegate ?? getDefaultHoverDelegate('element');
-				this.customHover = this._store.add(getBaseLayerHoverDelegate().setupManagedHover(hoverDelegate, this.element, title));
-			} else if (this.customHover) {
-				this.customHover.update(title);
-			}
+		if (!this.customHover && title !== '') {
+			const hoverDelegate = this.options.hoverDelegate ?? getDefaultHoverDelegate('element');
+			this.customHover = this._store.add(getBaseLayerHoverDelegate().setupManagedHover(hoverDelegate, this.element, title));
+		} else if (this.customHover) {
+			this.customHover.update(title);
 		}
 	}
 

--- a/src/vs/base/browser/ui/button/button.ts
+++ b/src/vs/base/browser/ui/button/button.ts
@@ -333,9 +333,7 @@ export class Button extends Disposable implements IButton {
 	}
 
 	setTitle(title: string) {
-		if (this.options.hoverDelegate?.showNativeHover) {
-			this._element.title = title;
-		} else if (!this._hover && title !== '') {
+		if (!this._hover && title !== '') {
 			this._hover = this._register(getBaseLayerHoverDelegate().setupManagedHover(this.options.hoverDelegate ?? getDefaultHoverDelegate('element'), this._element, title));
 		} else if (this._hover) {
 			this._hover.update(title);

--- a/src/vs/base/browser/ui/highlightedlabel/highlightedLabel.ts
+++ b/src/vs/base/browser/ui/highlightedlabel/highlightedLabel.ts
@@ -135,16 +135,11 @@ export class HighlightedLabel extends Disposable {
 
 		dom.reset(this.domNode, ...children);
 
-		if (this.options?.hoverDelegate?.showNativeHover) {
-			/* While custom hover is not inside custom hover */
-			this.domNode.title = this.title;
-		} else {
-			if (!this.customHover && this.title !== '') {
-				const hoverDelegate = this.options?.hoverDelegate ?? getDefaultHoverDelegate('mouse');
-				this.customHover = this._register(getBaseLayerHoverDelegate().setupManagedHover(hoverDelegate, this.domNode, this.title));
-			} else if (this.customHover) {
-				this.customHover.update(this.title);
-			}
+		if (!this.customHover && this.title !== '') {
+			const hoverDelegate = this.options?.hoverDelegate ?? getDefaultHoverDelegate('mouse');
+			this.customHover = this._register(getBaseLayerHoverDelegate().setupManagedHover(hoverDelegate, this.domNode, this.title));
+		} else if (this.customHover) {
+			this.customHover.update(this.title);
 		}
 
 		this.didEverRender = true;

--- a/src/vs/base/browser/ui/iconLabel/iconLabel.ts
+++ b/src/vs/base/browser/ui/iconLabel/iconLabel.ts
@@ -15,8 +15,6 @@ import { Range } from '../../../common/range.js';
 import { getDefaultHoverDelegate } from '../hover/hoverDelegateFactory.js';
 import type { IManagedHoverTooltipMarkdownString } from '../hover/hover.js';
 import { getBaseLayerHoverDelegate } from '../hover/hoverDelegate2.js';
-import { isString } from '../../../common/types.js';
-import { stripIcons } from '../../../common/iconLabels.js';
 import { URI } from '../../../common/uri.js';
 
 export interface IIconLabelCreationOptions {
@@ -222,23 +220,9 @@ export class IconLabel extends Disposable {
 			hoverTarget = this.creationOptions.hoverTargetOverride;
 		}
 
-		if (this.hoverDelegate.showNativeHover) {
-			function setupNativeHover(htmlElement: HTMLElement, tooltip: string | IManagedHoverTooltipMarkdownString | undefined): void {
-				if (isString(tooltip)) {
-					// Icons don't render in the native hover so we strip them out
-					htmlElement.title = stripIcons(tooltip);
-				} else if (tooltip?.markdownNotSupportedFallback) {
-					htmlElement.title = tooltip.markdownNotSupportedFallback;
-				} else {
-					htmlElement.removeAttribute('title');
-				}
-			}
-			setupNativeHover(hoverTarget, tooltip);
-		} else {
-			const hoverDisposable = getBaseLayerHoverDelegate().setupManagedHover(this.hoverDelegate, hoverTarget, tooltip);
-			if (hoverDisposable) {
-				this.customHovers.set(htmlElement, hoverDisposable);
-			}
+		const hoverDisposable = getBaseLayerHoverDelegate().setupManagedHover(this.hoverDelegate, hoverTarget, tooltip);
+		if (hoverDisposable) {
+			this.customHovers.set(htmlElement, hoverDisposable);
 		}
 	}
 

--- a/src/vs/base/browser/ui/toggle/toggle.ts
+++ b/src/vs/base/browser/ui/toggle/toggle.ts
@@ -132,7 +132,7 @@ export class Toggle extends Widget {
 	readonly domNode: HTMLElement;
 
 	private _checked: boolean;
-	private _hover?: IManagedHover;
+	private _hover: IManagedHover;
 
 	constructor(opts: IToggleOpts) {
 		super();
@@ -153,11 +153,7 @@ export class Toggle extends Widget {
 		}
 
 		this.domNode = document.createElement('div');
-		if (this._opts.hoverDelegate?.showNativeHover) {
-			this.domNode.title = this._opts.title;
-		} else {
-			this._hover = this._register(getBaseLayerHoverDelegate().setupManagedHover(opts.hoverDelegate ?? getDefaultHoverDelegate('mouse'), this.domNode, this._opts.title));
-		}
+		this._hover = this._register(getBaseLayerHoverDelegate().setupManagedHover(opts.hoverDelegate ?? getDefaultHoverDelegate('mouse'), this.domNode, this._opts.title));
 		this.domNode.classList.add(...classes);
 		if (!this._opts.notFocusable) {
 			this.domNode.tabIndex = 0;
@@ -249,11 +245,7 @@ export class Toggle extends Widget {
 	}
 
 	setTitle(newTitle: string): void {
-		if (this._hover) {
-			this._hover.update(newTitle);
-		} else {
-			this.domNode.title = newTitle;
-		}
+		this._hover.update(newTitle);
 		this.domNode.setAttribute('aria-label', newTitle);
 	}
 

--- a/src/vs/editor/browser/services/hoverService/hoverService.ts
+++ b/src/vs/editor/browser/services/hoverService/hoverService.ts
@@ -20,16 +20,17 @@ import { IAccessibilityService } from '../../../../platform/accessibility/common
 import { ILayoutService } from '../../../../platform/layout/browser/layoutService.js';
 import { mainWindow } from '../../../../base/browser/window.js';
 import { ContextViewHandler } from '../../../../platform/contextview/browser/contextViewService.js';
-import type { IHoverLifecycleOptions, IHoverOptions, IHoverWidget, IManagedHover, IManagedHoverContentOrFactory, IManagedHoverOptions } from '../../../../base/browser/ui/hover/hover.js';
+import { isManagedHoverTooltipMarkdownString, type IHoverLifecycleOptions, type IHoverOptions, type IHoverWidget, type IManagedHover, type IManagedHoverContentOrFactory, type IManagedHoverOptions } from '../../../../base/browser/ui/hover/hover.js';
 import type { IHoverDelegate, IHoverDelegateTarget } from '../../../../base/browser/ui/hover/hoverDelegate.js';
 import { ManagedHoverWidget } from './updatableHoverWidget.js';
 import { timeout, TimeoutTimer } from '../../../../base/common/async.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
-import { isNumber } from '../../../../base/common/types.js';
+import { isNumber, isString } from '../../../../base/common/types.js';
 import { KeyChord, KeyCode, KeyMod } from '../../../../base/common/keyCodes.js';
 import { KeybindingsRegistry, KeybindingWeight } from '../../../../platform/keybinding/common/keybindingsRegistry.js';
 import { EditorContextKeys } from '../../../common/editorContextKeys.js';
 import { IMarkdownString } from '../../../../base/common/htmlContent.js';
+import { stripIcons } from '../../../../base/common/iconLabels.js';
 
 export class HoverService extends Disposable implements IHoverService {
 	declare readonly _serviceBrand: undefined;
@@ -370,6 +371,10 @@ export class HoverService extends Disposable implements IHoverService {
 	setupManagedHover(hoverDelegate: IHoverDelegate, targetElement: HTMLElement, content: IManagedHoverContentOrFactory, options?: IManagedHoverOptions | undefined): IManagedHover {
 		targetElement.setAttribute('custom-hover', 'true');
 
+		if (hoverDelegate.showNativeHover) {
+			return setupNativeHover(targetElement, content);
+		}
+
 		if (targetElement.title !== '') {
 			console.warn('HTML element already has a title attribute, which will conflict with the custom hover. Please remove the title attribute.');
 			console.trace('Stack trace:', targetElement.title);
@@ -518,6 +523,36 @@ function getHoverIdFromContent(content: string | HTMLElement | IMarkdownString):
 		return content.toString();
 	}
 	return content.value;
+}
+
+function getStringContent(contentOrFactory: IManagedHoverContentOrFactory): string | undefined {
+	const content = typeof contentOrFactory === 'function' ? contentOrFactory() : contentOrFactory;
+	if (isString(content)) {
+		// Icons don't render in the native hover so we strip them out
+		return stripIcons(content);
+	}
+	if (isManagedHoverTooltipMarkdownString(content)) {
+		return content.markdownNotSupportedFallback;
+	}
+	return undefined;
+}
+
+function setupNativeHover(targetElement: HTMLElement, content: IManagedHoverContentOrFactory): IManagedHover {
+	function updateTitle(title: string | undefined) {
+		if (title) {
+			targetElement.setAttribute('title', title);
+		} else {
+			targetElement.removeAttribute('title');
+		}
+	}
+
+	updateTitle(getStringContent(content));
+	return {
+		update: (content) => updateTitle(getStringContent(content)),
+		show: () => { },
+		hide: () => { },
+		dispose: () => updateTitle(undefined),
+	};
 }
 
 class HoverContextViewDelegate implements IDelegate {

--- a/src/vs/editor/browser/services/hoverService/hoverService.ts
+++ b/src/vs/editor/browser/services/hoverService/hoverService.ts
@@ -369,11 +369,11 @@ export class HoverService extends Disposable implements IHoverService {
 	// TODO: Investigate performance of this function. There seems to be a lot of content created
 	//       and thrown away on start up
 	setupManagedHover(hoverDelegate: IHoverDelegate, targetElement: HTMLElement, content: IManagedHoverContentOrFactory, options?: IManagedHoverOptions | undefined): IManagedHover {
-		targetElement.setAttribute('custom-hover', 'true');
-
 		if (hoverDelegate.showNativeHover) {
 			return setupNativeHover(targetElement, content);
 		}
+
+		targetElement.setAttribute('custom-hover', 'true');
 
 		if (targetElement.title !== '') {
 			console.warn('HTML element already has a title attribute, which will conflict with the custom hover. Please remove the title attribute.');

--- a/src/vs/platform/opener/browser/link.ts
+++ b/src/vs/platform/opener/browser/link.ts
@@ -128,9 +128,7 @@ export class Link extends Disposable {
 	}
 
 	private setTooltip(title: string | undefined): void {
-		if (this.hoverDelegate.showNativeHover) {
-			this.el.title = title ?? '';
-		} else if (!this.hover && title) {
+		if (!this.hover && title) {
 			this.hover = this._register(this._hoverService.setupManagedHover(this.hoverDelegate, this.el, title));
 		} else if (this.hover) {
 			this.hover.update(title);


### PR DESCRIPTION
The deprecated `setupManagedHover` is being used by many base widgets. These base widgets sometimes appear inside a workbench hover. In that case we need to use a native hover instead of a custom one. Due to this, the `showNativeHover` property exists on the hover delegate. Currently each widget implements the logic of checking if a hover is native or not which adds unneccesary complexity to each widget. Also, there have been multiple times when a widget was used in a custom hover which did not implement the `showNativeHover` logic which lead to issues.

I moved the simple logic into `setupManagedHover` and cleaned up all the widgets which used the `showNativeHover` property. We'll need to come up with a nicer solution for `setupDelayedHover`. Maybe move up the dom tree and check if there is some ancesstor which is a hover.

closes https://github.com/microsoft/vscode/issues/253736

// cc @Tyriar 