### PR TITLE
Properly quote potential Markdown in "author" fields from SCM/vscode.git

### DIFF
--- a/extensions/git/src/blame.ts
+++ b/extensions/git/src/blame.ts
@@ -5,7 +5,7 @@
 
 import { DecorationOptions, l10n, Position, Range, TextEditor, TextEditorChange, TextEditorDecorationType, TextEditorChangeKind, ThemeColor, Uri, window, workspace, EventEmitter, ConfigurationChangeEvent, StatusBarItem, StatusBarAlignment, Command, MarkdownString, languages, HoverProvider, CancellationToken, Hover, TextDocument } from 'vscode';
 import { Model } from './model';
-import { dispose, fromNow, getCommitShortHash, IDisposable, truncate } from './util';
+import { dispose, escapeDoubleQuotes, escapeMarkdownSyntaxTokens, fromNow, getCommitShortHash, IDisposable, truncate } from './util';
 import { Repository } from './repository';
 import { throttle } from './decorators';
 import { BlameInformation, Commit } from './git';
@@ -252,14 +252,14 @@ export class GitBlameController {
 		const authorEmail = commitInformation?.authorEmail ?? blameInformation.authorEmail;
 		const authorDate = commitInformation?.authorDate ?? blameInformation.authorDate;
 		const avatar = commitAvatar ? `![${authorName}](${commitAvatar}|width=${AVATAR_SIZE},height=${AVATAR_SIZE})` : '$(account)';
-
+		const escapedAuthorName = authorName ? escapeMarkdownSyntaxTokens(escapeDoubleQuotes(authorName)) : authorName;
 
 		if (authorName) {
 			if (authorEmail) {
 				const emailTitle = l10n.t('Email');
-				markdownString.appendMarkdown(`${avatar} [**${authorName}**](mailto:${authorEmail} "${emailTitle} ${authorName}")`);
+				markdownString.appendMarkdown(`${avatar} [**${escapedAuthorName}**](mailto:${authorEmail} "${emailTitle} ${escapedAuthorName}")`);
 			} else {
-				markdownString.appendMarkdown(`${avatar} **${authorName}**`);
+				markdownString.appendMarkdown(`${avatar} **${escapedAuthorName}**`);
 			}
 
 			if (authorDate) {

--- a/extensions/git/src/timelineProvider.ts
+++ b/extensions/git/src/timelineProvider.ts
@@ -10,7 +10,7 @@ import { debounce } from './decorators';
 import { emojify, ensureEmojis } from './emoji';
 import { CommandCenter } from './commands';
 import { OperationKind, OperationResult } from './operation';
-import { truncate } from './util';
+import { escapeDoubleQuotes, escapeMarkdownSyntaxTokens, truncate } from './util';
 import { CommitShortStat } from './git';
 import { provideSourceControlHistoryItemAvatar, provideSourceControlHistoryItemHoverCommands, provideSourceControlHistoryItemMessageLinks } from './historyItemDetailsProvider';
 import { AvatarQuery, AvatarQueryCommit } from './api/git';
@@ -58,15 +58,17 @@ export class GitTimelineItem extends TimelineItem {
 		this.tooltip = new MarkdownString('', true);
 		this.tooltip.isTrusted = true;
 
+		const escapedAuthor = escapeMarkdownSyntaxTokens(escapeDoubleQuotes(author));
+
 		const avatarMarkdown = avatar
-			? `![${author}](${avatar}|width=${AVATAR_SIZE},height=${AVATAR_SIZE})`
+			? `![${escapedAuthor}](${avatar}|width=${AVATAR_SIZE},height=${AVATAR_SIZE})`
 			: '$(account)';
 
 		if (email) {
 			const emailTitle = l10n.t('Email');
-			this.tooltip.appendMarkdown(`${avatarMarkdown} [**${author}**](mailto:${email} "${emailTitle} ${author}")`);
+			this.tooltip.appendMarkdown(`${avatarMarkdown} [**${escapedAuthor}**](mailto:${email} "${emailTitle} ${escapedAuthor}")`);
 		} else {
-			this.tooltip.appendMarkdown(`${avatarMarkdown} **${author}**`);
+			this.tooltip.appendMarkdown(`${avatarMarkdown} **${escapedAuthor}**`);
 		}
 
 		this.tooltip.appendMarkdown(`, $(history) ${date}\n\n`);

--- a/extensions/git/src/util.ts
+++ b/extensions/git/src/util.ts
@@ -822,3 +822,14 @@ export function extractFilePathFromArgs(argv: string[], startIndex: number): str
 	// leading quote and return the path as-is
 	return path.slice(1);
 }
+
+// From src/vs/base/common/htmlContent.ts
+export function escapeMarkdownSyntaxTokens(text: string): string {
+	// escape markdown syntax tokens: http://daringfireball.net/projects/markdown/syntax#backslash
+	return text.replace(/[\\`*_{}[\]()#+\-!~]/g, '\\$&'); // CodeQL [SM02383] Backslash is escaped in the character class
+}
+
+// From src/vs/base/common/htmlContent.ts
+export function escapeDoubleQuotes(input: string) {
+	return input.replace(/"/g, '&quot;');
+}

--- a/src/vs/workbench/contrib/scm/browser/util.ts
+++ b/src/vs/workbench/contrib/scm/browser/util.ts
@@ -22,7 +22,7 @@ import { IInstantiationService } from '../../../../platform/instantiation/common
 import { IResourceNode, ResourceTree } from '../../../../base/common/resourceTree.js';
 import { IThemeService } from '../../../../platform/theme/common/themeService.js';
 import { IManagedHoverTooltipMarkdownString } from '../../../../base/browser/ui/hover/hover.js';
-import { MarkdownString } from '../../../../base/common/htmlContent.js';
+import { escapeDoubleQuotes, escapeMarkdownSyntaxTokens, MarkdownString } from '../../../../base/common/htmlContent.js';
 import { URI } from '../../../../base/common/uri.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
 import { fromNow, safeIntl } from '../../../../base/common/date.js';
@@ -165,17 +165,19 @@ export function getHistoryItemHoverContent(themeService: IThemeService, historyI
 	const markdown = new MarkdownString('', { isTrusted: true, supportThemeIcons: true });
 
 	if (historyItem.author) {
+		const escapedAuthor = escapeMarkdownSyntaxTokens(escapeDoubleQuotes(historyItem.author));
+
 		const icon = URI.isUri(historyItem.authorIcon)
-			? `![${historyItem.author}](${historyItem.authorIcon.toString()}|width=20,height=20)`
+			? `![${escapedAuthor}](${historyItem.authorIcon.toString()}|width=20,height=20)`
 			: ThemeIcon.isThemeIcon(historyItem.authorIcon)
 				? `$(${historyItem.authorIcon.id})`
 				: '$(account)';
 
 		if (historyItem.authorEmail) {
 			const emailTitle = localize('emailLinkTitle', "Email");
-			markdown.appendMarkdown(`${icon} [**${historyItem.author}**](mailto:${historyItem.authorEmail} "${emailTitle} ${historyItem.author}")`);
+			markdown.appendMarkdown(`${icon} [**${escapedAuthor}**](mailto:${historyItem.authorEmail} "${emailTitle} ${escapedAuthor}")`);
 		} else {
-			markdown.appendMarkdown(`${icon} **${historyItem.author}**`);
+			markdown.appendMarkdown(`${icon} **${escapedAuthor}**`);
 		}
 
 		if (historyItem.timestamp) {


### PR DESCRIPTION
Fixes #255009.

This fix can be reproduced and verified as described in #255009. After this patch lands, the "author" fields containing special characters and Markdown would be properly displayed.

If necessary, please feel free to provide me with pointers on how to add unit testing cases for this fix.

**Preferred merging strategy:** Merge or rebase.

## Post-patching screenshots

### Timeline view

![image 1](https://github.com/user-attachments/assets/85692c0e-8ac2-4cea-9b39-0d7aa059ec9b)

![image 2](https://github.com/user-attachments/assets/566aea06-90f8-43a6-a7f5-0cd922037f71)

### SCM history view

![image 4](https://github.com/user-attachments/assets/eed5d30b-8526-40f4-9246-3406daec5666)

![image 3](https://github.com/user-attachments/assets/184fbbb8-7b7f-4bdf-9f94-1203aa213c33)

### Blame view

![image 5](https://github.com/user-attachments/assets/979aa11f-ef93-4923-ba53-3137a05c0dd5)