### PR TITLE
Use open and show notebook instead of executeCommand in tests

### DIFF
--- a/extensions/vscode-api-tests/src/singlefolder-tests/notebook.api.test.ts
+++ b/extensions/vscode-api-tests/src/singlefolder-tests/notebook.api.test.ts
@@ -244,7 +244,7 @@ const apiTestSerializer: vscode.NotebookSerializer = {
 		// no kernel -> no default language
 		assert.strictEqual(getFocusedCell(editor)?.document.languageId, 'typescript');
 
-		await vscode.commands.executeCommand('vscode.openWith', notebook.uri, 'default');
+		await vscode.window.showNotebookDocument(await vscode.workspace.openNotebookDocument(notebook.uri));
 		assert.strictEqual(vscode.window.activeTextEditor?.document.uri.path, notebook.uri.path);
 	});
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
Fixes https://github.com/microsoft/vscode/issues/125369