### PR TITLE
Eliminate some flakiness when not verifying files save

### DIFF
--- a/test/automation/src/editors.ts
+++ b/test/automation/src/editors.ts
@@ -15,6 +15,7 @@ export class Editors {
 		} else {
 			await this.code.sendKeybinding('ctrl+s');
 		}
+		await this.code.waitForElements('.tab.active.dirty', false, results => results.length === 0);
 	}
 
 	async selectTab(fileName: string): Promise<void> {


### PR DESCRIPTION
This test was flaking because before the suite runs a bunch of settings are added which are critical to making the test reliable. Inside the settings part it opens the editor, edits it and saves the file via ctrl/cmd+s. This is all fine, but it doesn't verify anything so the editor may end up closing before ctrl/cmd+s actually gets handled. We disable the modal in smoke tests since it needs to run headlessly, so it's difficult to see that the file never actually saves and a dirty file is closed and discarded.

The fix is to verify settings.json actually does save by changing the shared Editors.saveOpenedFile mechanism to ensure the dirty indicator isn't present on the active tab.

Fixes #254893
Part of #246731

FYI @aiday-mar 

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
