### PR TITLE
TypeError thrown in instanceof DocumentSymbol

### DIFF
--- a/src/vs/workbench/api/common/extHostTypes.ts
+++ b/src/vs/workbench/api/common/extHostTypes.ts
@@ -1422,9 +1422,6 @@ export class DocumentSymbol extends AbstractDocumentSymbol {
 	}
 
 	static override[Symbol.hasInstance](candidate: unknown): boolean {
-		if (!isObject(candidate)) {
-			throw new TypeError();
-		}
 		return candidate instanceof AbstractDocumentSymbol
 			|| candidate instanceof SymbolInformationAndDocumentSymbol;
 	}


### PR DESCRIPTION
For https://github.com/microsoft/vscode/issues/253842

The bug causes `x instanceof DocumentSymbol` to fail with an expection if x is undefined or a number or anything else that is not an 'object;

The correct behaviour is to return `false`.

<img width="368" height="176" alt="image" src="https://github.com/user-attachments/assets/2c915156-b056-4238-80ea-4fe11ad9b2c5" />

