### PR TITLE
check if thisArgs are defined

### DIFF
--- a/src/vs/workbench/api/common/extHost.api.impl.ts
+++ b/src/vs/workbench/api/common/extHost.api.impl.ts
@@ -1359,7 +1359,9 @@ export function createApiFactoryAndRegisterActors(accessor: ServicesAccessor): I
 			},
 			onDidStartTask: (listeners, thisArgs?, disposables?) => {
 				if (!isProposedApiEnabled(extension, 'taskExecutionTerminal')) {
-					thisArgs.terminal = undefined;
+					if (thisArgs) {
+						thisArgs.terminal = undefined;
+					}
 				}
 				return _asExtensionEvent(extHostTask.onDidStartTask)(listeners, thisArgs, disposables);
 			},


### PR DESCRIPTION
This can fire with `taskExecution` undefined

https://github.com/microsoft/vscode/blob/9caaf5db4d6651ea15f3cf7c0ea4d8d2ef234547/src/vs/workbench/api/common/extHostTask.ts#L515-L517

https://github.com/microsoft/vscode/blob/bb4137c2b0c90fa5aa9f793d8423aec8fbed7c1b/src/vs/workbench/api/common/extHostTask.ts#L496

So we could be trying to set `terminal` on `undefined`

https://github.com/microsoft/vscode/blob/bb4137c2b0c90fa5aa9f793d8423aec8fbed7c1b/src/vs/workbench/api/common/extHost.api.impl.ts#L1360-L1365

fixes #255209