### PR TITLE
modify the right arg

### DIFF
--- a/src/vs/workbench/api/common/extHost.api.impl.ts
+++ b/src/vs/workbench/api/common/extHost.api.impl.ts
@@ -1357,13 +1357,20 @@ export function createApiFactoryAndRegisterActors(accessor: ServicesAccessor): I
 			get taskExecutions(): vscode.TaskExecution[] {
 				return extHostTask.taskExecutions;
 			},
-			onDidStartTask: (listeners, thisArgs?, disposables?) => {
-				if (!isProposedApiEnabled(extension, 'taskExecutionTerminal')) {
-					if (thisArgs) {
-						thisArgs.terminal = undefined;
+			onDidStartTask: (listener: (e: vscode.TaskStartEvent) => any, thisArgs?: any, disposables?) => {
+				const wrappedListener = (event: vscode.TaskStartEvent) => {
+					if (!isProposedApiEnabled(extension, 'taskExecutionTerminal')) {
+						if (event?.execution?.terminal !== undefined) {
+							event.execution.terminal = undefined;
+						}
 					}
-				}
-				return _asExtensionEvent(extHostTask.onDidStartTask)(listeners, thisArgs, disposables);
+					const eventWithExecution = {
+						...event,
+						execution: event.execution
+					};
+					return listener.call(thisArgs, eventWithExecution);
+				};
+				return _asExtensionEvent(extHostTask.onDidStartTask)(wrappedListener, thisArgs, disposables);
 			},
 			onDidEndTask: (listeners, thisArgs?, disposables?) => {
 				return _asExtensionEvent(extHostTask.onDidEndTask)(listeners, thisArgs, disposables);

--- a/src/vscode-dts/vscode.proposed.taskExecutionTerminal.d.ts
+++ b/src/vscode-dts/vscode.proposed.taskExecutionTerminal.d.ts
@@ -10,6 +10,6 @@ declare module 'vscode' {
 		/**
 		 * The terminal associated with this task execution, if any.
 		 */
-		readonly terminal?: Terminal;
+		terminal?: Terminal;
 	}
 }


### PR DESCRIPTION
LMK if you can find a better way to accomplish this - we don't have access to the `isProposedApiEnabled` check in the place where we initially assign the `terminal`, wish we did