### PR TITLE
Dev Containers fails to start on VS Code 1.102.0 with TypeError: Cannot read properties of null (reading 'filesToOpen') (fix #255254)

### DIFF
--- a/src/vs/workbench/browser/actions/workspaceCommands.ts
+++ b/src/vs/workbench/browser/actions/workspaceCommands.ts
@@ -199,7 +199,7 @@ CommandsRegistry.registerCommand({
 		};
 
 		const workspaceToOpen: IWorkspaceToOpen | IFolderToOpen = (hasWorkspaceFileExtension(uri) || uri.scheme === Schemas.untitled) ? { workspaceUri: uri } : { folderUri: uri };
-		const filesToOpen: IFileToOpen[] = typeof arg === 'object' ? arg.filesToOpen?.map(file => ({ fileUri: URI.from(file, true) })) ?? [] : [];
+		const filesToOpen: IFileToOpen[] = arg?.filesToOpen?.map(file => ({ fileUri: URI.from(file, true) })) ?? [];
 		return commandService.executeCommand('_files.windowOpen', [workspaceToOpen, ...filesToOpen], options);
 	},
 	metadata: {


### PR DESCRIPTION
**TIL**:  passing in `undefined` as parameter to `commands.executeCommand` ends up as `null` in the workbench renderer:
* ExtHost: `vscode.commands.executeCommand('vscode.openFolder', vscode.Uri.file('/path/to/folder'), undefined)`
* Renderer: `handler: (, uriComponents?: UriComponents, arg?: boolean | IOpenFolderAPICommandOptions)`
* :bug: `arg` is `null`