### PR TITLE
fix: prevent duplicate 'Disable' button in extension view (fix #244138)

### DIFF
--- a/src/vs/workbench/contrib/extensions/browser/extensionsActions.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionsActions.ts
@@ -1752,7 +1752,7 @@ export class DisableGloballyAction extends ExtensionAction {
 		this.enabled = false;
 		if (this.extension && this.extension.local && !this.extension.isWorkspaceScoped && this.extensionService.extensions.some(e => areSameExtensions({ id: e.identifier.value, uuid: e.uuid }, this.extension!.identifier))) {
 			this.enabled = this.extension.state === ExtensionState.Installed
-				&& (this.extension.enablementState === EnablementState.EnabledGlobally || this.extension.enablementState === EnablementState.EnabledWorkspace)
+				&& !this.extensionEnablementService.isDisabledGlobally(this.extension.local)
 				&& this.extensionEnablementService.canChangeEnablement(this.extension.local);
 		}
 	}


### PR DESCRIPTION
This PR fixes issue #244138 by ensuring that the “Disable” and “Disable (Workspace)” buttons are not shown at the same time when an extension is enabled only in the workspace.

- The visibility of the global “Disable” button is controlled by DisableGloballyAction.
- To avoid showing this button when the extension is already disabled globally, we now use the isDisabledGlobally method from extensionEnablementService, which accurately reflects the global disabled state.

Please let me know if any further changes are needed.