### PR TITLE
Chatmode without tools should use global tools

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatSelectedTools.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSelectedTools.ts
@@ -83,8 +83,9 @@ export class ChatSelectedTools extends Disposable {
 			const currentMode = this._mode.read(r);
 
 			let currentMap = this._sessionStates.get(currentMode.id);
-			if (!currentMap && currentMode.kind === ChatModeKind.Agent && currentMode.customTools) {
-				currentMap = this._toolsService.toToolAndToolSetEnablementMap(currentMode.customTools.read(r));
+			const modeTools = currentMode.customTools?.read(r);
+			if (!currentMap && currentMode.kind === ChatModeKind.Agent && modeTools) {
+				currentMap = this._toolsService.toToolAndToolSetEnablementMap(modeTools);
 			}
 			if (currentMap) {
 				for (const tool of this._allTools.read(r)) {
@@ -118,7 +119,7 @@ export class ChatSelectedTools extends Disposable {
 		if (this._sessionStates.has(mode.id)) {
 			return ToolsScope.Session;
 		}
-		if (mode.kind === ChatModeKind.Agent && mode.customTools && mode.uri) {
+		if (mode.kind === ChatModeKind.Agent && mode.customTools?.get() && mode.uri) {
 			return ToolsScope.Mode;
 		}
 		return ToolsScope.Global;
@@ -143,7 +144,7 @@ export class ChatSelectedTools extends Disposable {
 			this._sessionStates.set(mode.id, enablementMap);
 			return;
 		}
-		if (mode.kind === ChatModeKind.Agent && mode.customTools && mode.uri) {
+		if (mode.kind === ChatModeKind.Agent && mode.customTools?.get() && mode.uri) {
 			// apply directly to mode file.
 			this.updateCustomModeTools(mode.uri.get(), enablementMap);
 			return;


### PR DESCRIPTION
Fixes #254753

This got caused by a refactoring of an API:
Initially we had this API:
```
export interface IChatMode {
	...
	readonly customTools?: readonly string[];

}
```
Commit https://github.com/microsoft/vscode/commit/267e6d1922e7ae5e00aa9a2c4cfc27b98e37b44c from Rob changed it to 

```
export interface IChatMode {
	...
	readonly customTools?: IObservable<readonly string[] | undefined>;
	...
}
```

This broke the code 
```
	if (!currentMap && currentMode.kind === ChatModeKind.Agent && currentMode.customTools) {
		...	
        }
```
`currentMode.customTools` is now only undefined for built-in modes. For custom mode its now an observable that returns undefined or a set of tools

The fix is to change `currentMode.customTools` to `currentMode.customTools?.read()`