### PR TITLE
Add support for changing color space of syntax highlighting colors

### DIFF
--- a/build/monaco/monaco.d.ts.recipe
+++ b/build/monaco/monaco.d.ts.recipe
@@ -75,6 +75,7 @@ declare namespace monaco {
 
 #include(vs/platform/markers/common/markers): MarkerTag, MarkerSeverity
 #include(vs/base/common/cancellation): CancellationTokenSource, CancellationToken
+#include(vs/base/common/color): RGBColorSpace
 #include(vs/base/common/uri): URI, UriComponents
 #include(vs/base/common/keyCodes): KeyCode
 #include(vs/editor/common/services/editorBaseApi): KeyMod

--- a/src/vs/base/common/color.ts
+++ b/src/vs/base/common/color.ts
@@ -10,6 +10,8 @@ function roundFloat(number: number, decimalPoints: number): number {
 	return Math.round(number * decimal) / decimal;
 }
 
+export type RGBColorSpace = 'srgb' | 'display-p3' | 'a98-rgb' | 'prophoto-rgb' | 'rec2020';
+
 export class RGBA {
 	_rgbaBrand: void = undefined;
 
@@ -552,6 +554,23 @@ export class Color {
 			this._toString = Color.Format.CSS.format(this);
 		}
 		return this._toString;
+	}
+
+	/**
+	 * Returns a CSS color(<color-space> ...) string for this color.
+	 */
+	toColorSpaceString(space: RGBColorSpace): string {
+		if (space === 'srgb') {
+			return this.toString();
+		}
+
+		const r = +(this.rgba.r / 255).toFixed(3);
+		const g = +(this.rgba.g / 255).toFixed(3);
+		const b = +(this.rgba.b / 255).toFixed(3);
+		const a = this.rgba.a;
+		const alpha = a === 1 ? '' : ` / ${+a.toFixed(3)}`;
+
+		return `color(${space} ${r} ${g} ${b}${alpha})`;
 	}
 
 	private _toNumber32Bit?: number;

--- a/src/vs/base/common/color.ts
+++ b/src/vs/base/common/color.ts
@@ -10,7 +10,7 @@ function roundFloat(number: number, decimalPoints: number): number {
 	return Math.round(number * decimal) / decimal;
 }
 
-export type RGBColorSpace = 'srgb' | 'display-p3' | 'a98-rgb' | 'prophoto-rgb' | 'rec2020';
+export type RGBColorSpace = null | 'srgb' | 'display-p3' | 'a98-rgb' | 'prophoto-rgb' | 'rec2020';
 
 export class RGBA {
 	_rgbaBrand: void = undefined;
@@ -560,7 +560,7 @@ export class Color {
 	 * Returns a CSS color(<color-space> ...) string for this color.
 	 */
 	toColorSpaceString(space: RGBColorSpace): string {
-		if (space === 'srgb') {
+		if (!space || space === 'srgb') {
 			return this.toString();
 		}
 

--- a/src/vs/base/test/common/color.test.ts
+++ b/src/vs/base/test/common/color.test.ts
@@ -709,4 +709,57 @@ suite('Color', () => {
 			assertContrastRatio(0xffffffff, 0x606060ff, 21, 0x000000ff);
 		});
 	});
+
+	suite('toColorSpaceString', () => {
+		test('outputs correct CSS for all supported color spaces', () => {
+			const color = new Color(new RGBA(10, 20, 30, 0.5));
+			assert.strictEqual(color.toColorSpaceString('srgb'), 'rgba(10, 20, 30, 0.5)');
+			assert.strictEqual(color.toColorSpaceString('display-p3'), 'color(display-p3 0.039 0.078 0.118 / 0.5)');
+			assert.strictEqual(color.toColorSpaceString('a98-rgb'), 'color(a98-rgb 0.039 0.078 0.118 / 0.5)');
+			assert.strictEqual(color.toColorSpaceString('prophoto-rgb'), 'color(prophoto-rgb 0.039 0.078 0.118 / 0.5)');
+			assert.strictEqual(color.toColorSpaceString('rec2020'), 'color(rec2020 0.039 0.078 0.118 / 0.5)');
+
+			const colorOpaque = new Color(new RGBA(10, 20, 30, 1));
+			assert.strictEqual(colorOpaque.toColorSpaceString('srgb'), '#0a141e');
+			assert.strictEqual(colorOpaque.toColorSpaceString('display-p3'), 'color(display-p3 0.039 0.078 0.118)');
+			assert.strictEqual(colorOpaque.toColorSpaceString('a98-rgb'), 'color(a98-rgb 0.039 0.078 0.118)');
+			assert.strictEqual(colorOpaque.toColorSpaceString('prophoto-rgb'), 'color(prophoto-rgb 0.039 0.078 0.118)');
+			assert.strictEqual(colorOpaque.toColorSpaceString('rec2020'), 'color(rec2020 0.039 0.078 0.118)');
+		});
+
+		test('outputs correct CSS for extreme color values', () => {
+			const black = new Color(new RGBA(0, 0, 0, 1));
+			const white = new Color(new RGBA(255, 255, 255, 1));
+			const blackAlpha = new Color(new RGBA(0, 0, 0, 0.5));
+			const whiteAlpha = new Color(new RGBA(255, 255, 255, 0.5));
+
+			// Black, opaque
+			assert.strictEqual(black.toColorSpaceString('srgb'), '#000000');
+			assert.strictEqual(black.toColorSpaceString('display-p3'), 'color(display-p3 0 0 0)');
+			assert.strictEqual(black.toColorSpaceString('a98-rgb'), 'color(a98-rgb 0 0 0)');
+			assert.strictEqual(black.toColorSpaceString('prophoto-rgb'), 'color(prophoto-rgb 0 0 0)');
+			assert.strictEqual(black.toColorSpaceString('rec2020'), 'color(rec2020 0 0 0)');
+
+			// Black, alpha
+			assert.strictEqual(blackAlpha.toColorSpaceString('srgb'), 'rgba(0, 0, 0, 0.5)');
+			assert.strictEqual(blackAlpha.toColorSpaceString('display-p3'), 'color(display-p3 0 0 0 / 0.5)');
+			assert.strictEqual(blackAlpha.toColorSpaceString('a98-rgb'), 'color(a98-rgb 0 0 0 / 0.5)');
+			assert.strictEqual(blackAlpha.toColorSpaceString('prophoto-rgb'), 'color(prophoto-rgb 0 0 0 / 0.5)');
+			assert.strictEqual(blackAlpha.toColorSpaceString('rec2020'), 'color(rec2020 0 0 0 / 0.5)');
+
+			// White, opaque
+			assert.strictEqual(white.toColorSpaceString('srgb'), '#ffffff');
+			assert.strictEqual(white.toColorSpaceString('display-p3'), 'color(display-p3 1 1 1)');
+			assert.strictEqual(white.toColorSpaceString('a98-rgb'), 'color(a98-rgb 1 1 1)');
+			assert.strictEqual(white.toColorSpaceString('prophoto-rgb'), 'color(prophoto-rgb 1 1 1)');
+			assert.strictEqual(white.toColorSpaceString('rec2020'), 'color(rec2020 1 1 1)');
+
+			// White, alpha
+			assert.strictEqual(whiteAlpha.toColorSpaceString('srgb'), 'rgba(255, 255, 255, 0.5)');
+			assert.strictEqual(whiteAlpha.toColorSpaceString('display-p3'), 'color(display-p3 1 1 1 / 0.5)');
+			assert.strictEqual(whiteAlpha.toColorSpaceString('a98-rgb'), 'color(a98-rgb 1 1 1 / 0.5)');
+			assert.strictEqual(whiteAlpha.toColorSpaceString('prophoto-rgb'), 'color(prophoto-rgb 1 1 1 / 0.5)');
+			assert.strictEqual(whiteAlpha.toColorSpaceString('rec2020'), 'color(rec2020 1 1 1 / 0.5)');
+		});
+	});
 });

--- a/src/vs/base/test/common/color.test.ts
+++ b/src/vs/base/test/common/color.test.ts
@@ -713,6 +713,7 @@ suite('Color', () => {
 	suite('toColorSpaceString', () => {
 		test('outputs correct CSS for all supported color spaces', () => {
 			const color = new Color(new RGBA(10, 20, 30, 0.5));
+			assert.strictEqual(color.toColorSpaceString(null), 'rgba(10, 20, 30, 0.5)');
 			assert.strictEqual(color.toColorSpaceString('srgb'), 'rgba(10, 20, 30, 0.5)');
 			assert.strictEqual(color.toColorSpaceString('display-p3'), 'color(display-p3 0.039 0.078 0.118 / 0.5)');
 			assert.strictEqual(color.toColorSpaceString('a98-rgb'), 'color(a98-rgb 0.039 0.078 0.118 / 0.5)');
@@ -720,6 +721,7 @@ suite('Color', () => {
 			assert.strictEqual(color.toColorSpaceString('rec2020'), 'color(rec2020 0.039 0.078 0.118 / 0.5)');
 
 			const colorOpaque = new Color(new RGBA(10, 20, 30, 1));
+			assert.strictEqual(colorOpaque.toColorSpaceString(null), '#0a141e');
 			assert.strictEqual(colorOpaque.toColorSpaceString('srgb'), '#0a141e');
 			assert.strictEqual(colorOpaque.toColorSpaceString('display-p3'), 'color(display-p3 0.039 0.078 0.118)');
 			assert.strictEqual(colorOpaque.toColorSpaceString('a98-rgb'), 'color(a98-rgb 0.039 0.078 0.118)');
@@ -734,6 +736,7 @@ suite('Color', () => {
 			const whiteAlpha = new Color(new RGBA(255, 255, 255, 0.5));
 
 			// Black, opaque
+			assert.strictEqual(black.toColorSpaceString(null), '#000000');
 			assert.strictEqual(black.toColorSpaceString('srgb'), '#000000');
 			assert.strictEqual(black.toColorSpaceString('display-p3'), 'color(display-p3 0 0 0)');
 			assert.strictEqual(black.toColorSpaceString('a98-rgb'), 'color(a98-rgb 0 0 0)');
@@ -741,6 +744,7 @@ suite('Color', () => {
 			assert.strictEqual(black.toColorSpaceString('rec2020'), 'color(rec2020 0 0 0)');
 
 			// Black, alpha
+			assert.strictEqual(blackAlpha.toColorSpaceString(null), 'rgba(0, 0, 0, 0.5)');
 			assert.strictEqual(blackAlpha.toColorSpaceString('srgb'), 'rgba(0, 0, 0, 0.5)');
 			assert.strictEqual(blackAlpha.toColorSpaceString('display-p3'), 'color(display-p3 0 0 0 / 0.5)');
 			assert.strictEqual(blackAlpha.toColorSpaceString('a98-rgb'), 'color(a98-rgb 0 0 0 / 0.5)');
@@ -748,6 +752,7 @@ suite('Color', () => {
 			assert.strictEqual(blackAlpha.toColorSpaceString('rec2020'), 'color(rec2020 0 0 0 / 0.5)');
 
 			// White, opaque
+			assert.strictEqual(white.toColorSpaceString(null), '#ffffff');
 			assert.strictEqual(white.toColorSpaceString('srgb'), '#ffffff');
 			assert.strictEqual(white.toColorSpaceString('display-p3'), 'color(display-p3 1 1 1)');
 			assert.strictEqual(white.toColorSpaceString('a98-rgb'), 'color(a98-rgb 1 1 1)');
@@ -755,6 +760,7 @@ suite('Color', () => {
 			assert.strictEqual(white.toColorSpaceString('rec2020'), 'color(rec2020 1 1 1)');
 
 			// White, alpha
+			assert.strictEqual(whiteAlpha.toColorSpaceString(null), 'rgba(255, 255, 255, 0.5)');
 			assert.strictEqual(whiteAlpha.toColorSpaceString('srgb'), 'rgba(255, 255, 255, 0.5)');
 			assert.strictEqual(whiteAlpha.toColorSpaceString('display-p3'), 'color(display-p3 1 1 1 / 0.5)');
 			assert.strictEqual(whiteAlpha.toColorSpaceString('a98-rgb'), 'color(a98-rgb 1 1 1 / 0.5)');

--- a/src/vs/editor/browser/viewParts/viewLinesGpu/viewLinesGpu.ts
+++ b/src/vs/editor/browser/viewParts/viewLinesGpu/viewLinesGpu.ts
@@ -30,6 +30,7 @@ import { FullFileRenderStrategy } from '../../gpu/renderStrategy/fullFileRenderS
 import { MutableDisposable } from '../../../../base/common/lifecycle.js';
 import type { ViewLineRenderingData } from '../../../common/viewModel.js';
 import { GlyphRasterizer } from '../../gpu/raster/glyphRasterizer.js';
+import { TokenizationRegistry } from '../../../common/languages.js';
 
 const enum GlyphStorageBufferInfo {
 	FloatsPerEntry = 2 + 2 + 2,
@@ -115,11 +116,24 @@ export class ViewLinesGpu extends ViewPart implements IViewLines {
 		}));
 
 		const presentationFormat = navigator.gpu.getPreferredCanvasFormat();
-		this._viewGpuContext.ctx.configure({
-			device: this._device,
-			format: presentationFormat,
-			alphaMode: 'premultiplied',
-		});
+		const configureCanvas = () => {
+			const highlightingColorSpace = TokenizationRegistry.getHighlightingColorSpace();
+
+			// WebGPU currently supports only 'srgb' and 'display-p3'. Fall back to 'display-p3' if a non srgb color space is configured, which should be closer to the theme's preference.
+			const gpuColorSpace: PredefinedColorSpace = highlightingColorSpace === 'srgb' || !highlightingColorSpace ? 'srgb' : 'display-p3';
+			this._viewGpuContext.ctx.configure({
+				device: this._device,
+				format: presentationFormat,
+				colorSpace: gpuColorSpace,
+				alphaMode: 'premultiplied',
+			});
+		};
+		configureCanvas();
+		this._register(TokenizationRegistry.onDidChange(e => {
+			if (e.changedHighlightingColorSpace) {
+				configureCanvas();
+			}
+		}));
 
 		this._renderPassColorAttachment = {
 			view: null!, // Will be filled at render time

--- a/src/vs/editor/common/languages.ts
+++ b/src/vs/editor/common/languages.ts
@@ -6,7 +6,7 @@
 import { VSBuffer } from '../../base/common/buffer.js';
 import { CancellationToken } from '../../base/common/cancellation.js';
 import { Codicon } from '../../base/common/codicons.js';
-import { Color } from '../../base/common/color.js';
+import { Color, RGBColorSpace } from '../../base/common/color.js';
 import { IReadonlyVSDataTransfer } from '../../base/common/dataTransfer.js';
 import { Event } from '../../base/common/event.js';
 import { HierarchicalKind } from '../../base/common/hierarchicalKind.js';
@@ -2367,6 +2367,7 @@ export interface DocumentRangeSemanticTokensProvider {
 export interface ITokenizationSupportChangedEvent {
 	changedLanguages: string[];
 	changedColorMap: boolean;
+	changedHighlightingColorSpace: boolean;
 }
 
 /**
@@ -2456,6 +2457,16 @@ export interface ITokenizationRegistry<TSupport> {
 	getColorMap(): Color[] | null;
 
 	getDefaultBackground(): Color | null;
+
+	/**
+	 * Gets the color space used for syntax highlighting CSS. Defaults to 'srgb'.
+	 */
+	getHighlightingColorSpace(): RGBColorSpace;
+
+	/**
+	 * Sets the color space used for syntax highlighting CSS.
+	 */
+	setHighlightingColorSpace(space: RGBColorSpace): void;
 }
 
 /**

--- a/src/vs/editor/common/languages/supports/tokenization.ts
+++ b/src/vs/editor/common/languages/supports/tokenization.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Color } from '../../../../base/common/color.js';
+import { Color, RGBColorSpace } from '../../../../base/common/color.js';
 import { LanguageId, FontStyle, ColorId, StandardTokenType, MetadataConsts } from '../../encodedTokenAttributes.js';
 
 export interface ITokenThemeRule {
@@ -409,11 +409,12 @@ export class ThemeTrieElement {
 	}
 }
 
-export function generateTokensCSSForColorMap(colorMap: readonly Color[]): string {
+export function generateTokensCSSForColorMap(colorMap: readonly Color[], highlightingColorSpace: RGBColorSpace): string {
 	const rules: string[] = [];
 	for (let i = 1, len = colorMap.length; i < len; i++) {
 		const color = colorMap[i];
-		rules[i] = `.mtk${i} { color: ${color}; }`;
+		const colorStr = color.toColorSpaceString(highlightingColorSpace);
+		rules[i] = `.mtk${i} { color: ${colorStr}; }`;
 	}
 	rules.push('.mtki { font-style: italic; }');
 	rules.push('.mtkb { font-weight: bold; }');

--- a/src/vs/editor/common/tokenizationRegistry.ts
+++ b/src/vs/editor/common/tokenizationRegistry.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Color } from '../../base/common/color.js';
+import { Color, RGBColorSpace } from '../../base/common/color.js';
 import { Emitter, Event } from '../../base/common/event.js';
 import { Disposable, IDisposable, toDisposable } from '../../base/common/lifecycle.js';
 import { ITokenizationRegistry, ITokenizationSupportChangedEvent, ILazyTokenizationSupport } from './languages.js';
@@ -18,6 +18,7 @@ export class TokenizationRegistry<TSupport> implements ITokenizationRegistry<TSu
 	public readonly onDidChange: Event<ITokenizationSupportChangedEvent> = this._onDidChange.event;
 
 	private _colorMap: Color[] | null;
+	private _highlightingColorSpace: RGBColorSpace = 'srgb';
 
 	constructor() {
 		this._colorMap = null;
@@ -26,7 +27,8 @@ export class TokenizationRegistry<TSupport> implements ITokenizationRegistry<TSu
 	public handleChange(languageIds: string[]): void {
 		this._onDidChange.fire({
 			changedLanguages: languageIds,
-			changedColorMap: false
+			changedColorMap: false,
+			changedHighlightingColorSpace: false
 		});
 	}
 
@@ -96,12 +98,30 @@ export class TokenizationRegistry<TSupport> implements ITokenizationRegistry<TSu
 		this._colorMap = colorMap;
 		this._onDidChange.fire({
 			changedLanguages: Array.from(this._tokenizationSupports.keys()),
-			changedColorMap: true
+			changedColorMap: true,
+			changedHighlightingColorSpace: false
 		});
 	}
 
 	public getColorMap(): Color[] | null {
 		return this._colorMap;
+	}
+
+	public getHighlightingColorSpace(): RGBColorSpace {
+		return this._highlightingColorSpace;
+	}
+
+	public setHighlightingColorSpace(space: RGBColorSpace): void {
+		if (this._highlightingColorSpace === space) {
+			return;
+		}
+
+		this._highlightingColorSpace = space;
+		this._onDidChange.fire({
+			changedLanguages: Array.from(this._tokenizationSupports.keys()),
+			changedColorMap: false,
+			changedHighlightingColorSpace: true
+		});
 	}
 
 	public getDefaultBackground(): Color | null {

--- a/src/vs/editor/common/tokenizationRegistry.ts
+++ b/src/vs/editor/common/tokenizationRegistry.ts
@@ -18,7 +18,7 @@ export class TokenizationRegistry<TSupport> implements ITokenizationRegistry<TSu
 	public readonly onDidChange: Event<ITokenizationSupportChangedEvent> = this._onDidChange.event;
 
 	private _colorMap: Color[] | null;
-	private _highlightingColorSpace: RGBColorSpace = 'srgb';
+	private _highlightingColorSpace: RGBColorSpace = null;
 
 	constructor() {
 		this._colorMap = null;

--- a/src/vs/editor/standalone/browser/standaloneCodeEditor.ts
+++ b/src/vs/editor/standalone/browser/standaloneCodeEditor.ts
@@ -474,7 +474,12 @@ export class StandaloneEditor extends StandaloneCodeEditor implements IStandalon
 	}
 
 	private getHighlightingColorSpace(): RGBColorSpace {
-		return this._configurationService.getValue<RGBColorSpace>('workbench.highlightingColorSpace') ?? 'srgb';
+		const space = this._configurationService.getValue<RGBColorSpace | 'default'>('workbench.highlightingColorSpace');
+		if (space !== 'default') {
+			return space;
+		}
+
+		return null;
 	}
 
 	public override dispose(): void {
@@ -555,7 +560,12 @@ export class StandaloneDiffEditor2 extends DiffEditorWidget implements IStandalo
 	}
 
 	private getHighlightingColorSpace(): RGBColorSpace {
-		return this._configurationService.getValue<RGBColorSpace>('workbench.highlightingColorSpace') ?? 'srgb';
+		const space = this._configurationService.getValue<RGBColorSpace | 'default'>('workbench.highlightingColorSpace');
+		if (space !== 'default') {
+			return space;
+		}
+
+		return null;
 	}
 
 	public override dispose(): void {

--- a/src/vs/editor/standalone/browser/standaloneCodeEditor.ts
+++ b/src/vs/editor/standalone/browser/standaloneCodeEditor.ts
@@ -442,11 +442,11 @@ export class StandaloneEditor extends StandaloneCodeEditor implements IStandalon
 		delete options.model;
 		super(domElement, options, instantiationService, codeEditorService, commandService, contextKeyService, hoverService, keybindingService, themeService, notificationService, accessibilityService, languageConfigurationService, languageFeaturesService);
 
-		themeService.setHighlightingColorSpace(this.getHighlightingColorSpace());
-
 		this._configurationService = configurationService;
 		this._standaloneThemeService = themeService;
 		this._register(themeDomRegistration);
+
+		themeService.setHighlightingColorSpace(this.getHighlightingColorSpace());
 		this._register(configurationService.onDidChangeConfiguration((event: IConfigurationChangeEvent) => {
 			if (event.affectsConfiguration('workbench.highlightingColorSpace')) {
 				themeService.setHighlightingColorSpace(this.getHighlightingColorSpace());
@@ -546,12 +546,12 @@ export class StandaloneDiffEditor2 extends DiffEditorWidget implements IStandalo
 			editorProgressService,
 		);
 
-		themeService.setHighlightingColorSpace(this.getHighlightingColorSpace());
-
 		this._configurationService = configurationService;
 		this._standaloneThemeService = themeService;
 
 		this._register(themeDomRegistration);
+
+		themeService.setHighlightingColorSpace(this.getHighlightingColorSpace());
 		this._register(configurationService.onDidChangeConfiguration((event: IConfigurationChangeEvent) => {
 			if (event.affectsConfiguration('workbench.highlightingColorSpace')) {
 				themeService.setHighlightingColorSpace(this.getHighlightingColorSpace());

--- a/src/vs/editor/standalone/browser/standaloneThemeService.ts
+++ b/src/vs/editor/standalone/browser/standaloneThemeService.ts
@@ -34,6 +34,7 @@ class StandaloneTheme implements IStandaloneTheme {
 
 	public readonly id: string;
 	public readonly themeName: string;
+	public highlightingColorSpace: RGBColorSpace;
 
 	private readonly themeData: IStandaloneThemeData;
 	private colors: Map<string, Color> | null;
@@ -57,6 +58,7 @@ class StandaloneTheme implements IStandaloneTheme {
 		this.colors = null;
 		this.defaultColors = Object.create(null);
 		this._tokenTheme = null;
+		this.highlightingColorSpace = standaloneThemeData.highlightingColorSpace;
 	}
 
 	public get label(): string {
@@ -232,7 +234,7 @@ export class StandaloneThemeService extends Disposable implements IStandaloneThe
 	private _styleElements: HTMLStyleElement[];
 	private _colorMapOverride: Color[] | null;
 	private _theme!: IStandaloneTheme;
-	private _highlightingColorSpace: RGBColorSpace = 'srgb';
+	private _highlightingColorSpace: RGBColorSpace = null;
 
 	private _builtInProductIconTheme = new UnthemedProductIconTheme();
 
@@ -406,7 +408,7 @@ export class StandaloneThemeService extends Disposable implements IStandaloneThe
 		ruleCollector.addRule(`.monaco-editor, .monaco-diff-editor, .monaco-component { ${colorVariables.join('\n')} }`);
 
 		const colorMap = this._colorMapOverride || this._theme.tokenTheme.getColorMap();
-		ruleCollector.addRule(generateTokensCSSForColorMap(colorMap, this._highlightingColorSpace));
+		ruleCollector.addRule(generateTokensCSSForColorMap(colorMap, this._highlightingColorSpace || this._theme.highlightingColorSpace));
 
 		this._themeCSS = cssRules.join('\n');
 		this._updateCSS();

--- a/src/vs/editor/standalone/browser/standaloneThemeService.ts
+++ b/src/vs/editor/standalone/browser/standaloneThemeService.ts
@@ -6,7 +6,7 @@
 import * as dom from '../../../base/browser/dom.js';
 import * as domStylesheetsJs from '../../../base/browser/domStylesheets.js';
 import { addMatchMediaChangeListener } from '../../../base/browser/browser.js';
-import { Color } from '../../../base/common/color.js';
+import { Color, RGBColorSpace } from '../../../base/common/color.js';
 import { Emitter } from '../../../base/common/event.js';
 import { TokenizationRegistry } from '../../common/languages.js';
 import { FontStyle, TokenMetadata } from '../../common/encodedTokenAttributes.js';
@@ -232,6 +232,7 @@ export class StandaloneThemeService extends Disposable implements IStandaloneThe
 	private _styleElements: HTMLStyleElement[];
 	private _colorMapOverride: Color[] | null;
 	private _theme!: IStandaloneTheme;
+	private _highlightingColorSpace: RGBColorSpace = 'srgb';
 
 	private _builtInProductIconTheme = new UnthemedProductIconTheme();
 
@@ -374,6 +375,14 @@ export class StandaloneThemeService extends Disposable implements IStandaloneThe
 		this._onOSSchemeChanged();
 	}
 
+	public setHighlightingColorSpace(highlightingColorSpace: RGBColorSpace): void {
+		if (this._highlightingColorSpace === highlightingColorSpace) {
+			return;
+		}
+		this._highlightingColorSpace = highlightingColorSpace;
+		this._updateThemeOrColorMap();
+	}
+
 	private _updateThemeOrColorMap(): void {
 		const cssRules: string[] = [];
 		const hasRule: { [rule: string]: boolean } = {};
@@ -397,7 +406,7 @@ export class StandaloneThemeService extends Disposable implements IStandaloneThe
 		ruleCollector.addRule(`.monaco-editor, .monaco-diff-editor, .monaco-component { ${colorVariables.join('\n')} }`);
 
 		const colorMap = this._colorMapOverride || this._theme.tokenTheme.getColorMap();
-		ruleCollector.addRule(generateTokensCSSForColorMap(colorMap));
+		ruleCollector.addRule(generateTokensCSSForColorMap(colorMap, this._highlightingColorSpace));
 
 		this._themeCSS = cssRules.join('\n');
 		this._updateCSS();

--- a/src/vs/editor/standalone/common/standaloneTheme.ts
+++ b/src/vs/editor/standalone/common/standaloneTheme.ts
@@ -19,6 +19,7 @@ export interface IStandaloneThemeData {
 	rules: ITokenThemeRule[];
 	encodedTokensColors?: string[];
 	colors: IColors;
+	highlightingColorSpace: RGBColorSpace;
 }
 
 export interface IStandaloneTheme extends IColorTheme {

--- a/src/vs/editor/standalone/common/standaloneTheme.ts
+++ b/src/vs/editor/standalone/common/standaloneTheme.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Color } from '../../../base/common/color.js';
+import { Color, RGBColorSpace } from '../../../base/common/color.js';
 import { ITokenThemeRule, TokenTheme } from '../../common/languages/supports/tokenization.js';
 import { createDecorator } from '../../../platform/instantiation/common/instantiation.js';
 import { IColorTheme, IThemeService } from '../../../platform/theme/common/themeService.js';
@@ -38,5 +38,7 @@ export interface IStandaloneThemeService extends IThemeService {
 	getColorTheme(): IStandaloneTheme;
 
 	setColorMapOverride(colorMapOverride: Color[] | null): void;
+
+	setHighlightingColorSpace(highlightingColorSpace: RGBColorSpace): void;
 
 }

--- a/src/vs/editor/standalone/common/themes.ts
+++ b/src/vs/editor/standalone/common/themes.ts
@@ -11,6 +11,7 @@ import { editorBackground, editorForeground, editorInactiveSelection, editorSele
 export const vs: IStandaloneThemeData = {
 	base: 'vs',
 	inherit: false,
+	highlightingColorSpace: null,
 	rules: [
 		{ token: '', foreground: '000000', background: 'fffffe' },
 		{ token: 'invalid', foreground: 'cd3131' },
@@ -83,6 +84,7 @@ export const vs: IStandaloneThemeData = {
 export const vs_dark: IStandaloneThemeData = {
 	base: 'vs-dark',
 	inherit: false,
+	highlightingColorSpace: null,
 	rules: [
 		{ token: '', foreground: 'D4D4D4', background: '1E1E1E' },
 		{ token: 'invalid', foreground: 'f44747' },
@@ -155,6 +157,7 @@ export const vs_dark: IStandaloneThemeData = {
 export const hc_black: IStandaloneThemeData = {
 	base: 'hc-black',
 	inherit: false,
+	highlightingColorSpace: null,
 	rules: [
 		{ token: '', foreground: 'FFFFFF', background: '000000' },
 		{ token: 'invalid', foreground: 'f44747' },
@@ -214,6 +217,7 @@ export const hc_black: IStandaloneThemeData = {
 export const hc_light: IStandaloneThemeData = {
 	base: 'hc-light',
 	inherit: false,
+	highlightingColorSpace: null,
 	rules: [
 		{ token: '', foreground: '292929', background: 'FFFFFF' },
 		{ token: 'invalid', foreground: 'B5200D' },

--- a/src/vs/editor/standalone/test/browser/standaloneLanguages.test.ts
+++ b/src/vs/editor/standalone/test/browser/standaloneLanguages.test.ts
@@ -74,7 +74,9 @@ suite('TokenizationSupport2Adapter', () => {
 
 				semanticHighlighting: false,
 
-				tokenColorMap: []
+				tokenColorMap: [],
+
+				highlightingColorSpace: null,
 			};
 		}
 		setColorMapOverride(colorMapOverride: Color[] | null): void {

--- a/src/vs/editor/standalone/test/browser/standaloneLanguages.test.ts
+++ b/src/vs/editor/standalone/test/browser/standaloneLanguages.test.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
-import { Color } from '../../../../base/common/color.js';
+import { Color, RGBColorSpace } from '../../../../base/common/color.js';
 import { Emitter } from '../../../../base/common/event.js';
 import { DisposableStore } from '../../../../base/common/lifecycle.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
@@ -78,6 +78,8 @@ suite('TokenizationSupport2Adapter', () => {
 			};
 		}
 		setColorMapOverride(colorMapOverride: Color[] | null): void {
+		}
+		setHighlightingColorSpace(highlightingColorSpace: RGBColorSpace): void {
 		}
 		public getFileIconTheme(): IFileIconTheme {
 			return {

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -108,6 +108,7 @@ declare namespace monaco {
 		 */
 		readonly onCancellationRequested: (listener: (e: any) => any, thisArgs?: any, disposables?: IDisposable[]) => IDisposable;
 	}
+	export type RGBColorSpace = null | 'srgb' | 'display-p3' | 'a98-rgb' | 'prophoto-rgb' | 'rec2020';
 	/**
 	 * Uniform Resource Identifier (Uri) http://tools.ietf.org/html/rfc3986.
 	 * This class is a simple parser which creates the basic component parts
@@ -1187,6 +1188,7 @@ declare namespace monaco.editor {
 		rules: ITokenThemeRule[];
 		encodedTokensColors?: string[];
 		colors: IColors;
+		highlightingColorSpace: RGBColorSpace;
 	}
 
 	export type IColors = {

--- a/src/vs/platform/theme/common/themeService.ts
+++ b/src/vs/platform/theme/common/themeService.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Codicon } from '../../../base/common/codicons.js';
-import { Color } from '../../../base/common/color.js';
+import { Color, RGBColorSpace } from '../../../base/common/color.js';
 import { Emitter, Event } from '../../../base/common/event.js';
 import { Disposable, IDisposable, toDisposable } from '../../../base/common/lifecycle.js';
 import { IEnvironmentService } from '../../environment/common/environment.js';
@@ -74,6 +74,11 @@ export interface IColorTheme {
 	 * Defines whether semantic highlighting should be enabled for the theme.
 	 */
 	readonly semanticHighlighting: boolean;
+
+	/**
+	 * Preferred RGB color space to use for syntax highlighting when this theme is active.
+	 */
+	readonly highlightingColorSpace: RGBColorSpace;
 }
 
 export interface IFileIconTheme {

--- a/src/vs/platform/theme/test/common/testThemeService.ts
+++ b/src/vs/platform/theme/test/common/testThemeService.ts
@@ -38,6 +38,8 @@ export class TestColorTheme implements IColorTheme {
 	get tokenColorMap(): string[] {
 		return [];
 	}
+
+	public readonly highlightingColorSpace = null;
 }
 
 class TestFileIconTheme implements IFileIconTheme {

--- a/src/vs/workbench/browser/workbench.contribution.ts
+++ b/src/vs/workbench/browser/workbench.contribution.ts
@@ -678,6 +678,19 @@ const registry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Con
 				'default': true,
 				'description': localize('tips.enabled', "When enabled, will show the watermark tips when no editor is open.")
 			},
+			'workbench.highlightingColorSpace': {
+				type: 'string',
+				enum: ['srgb', 'display-p3', 'a98-rgb', 'prophoto-rgb', 'rec2020'],
+				enumDescriptions: [
+					localize('highlightingColorSpace.srgb', "Use sRGB color space for syntax highlighting."),
+					localize('highlightingColorSpace.display-p3', "Use Display P3 color space for syntax highlighting."),
+					localize('highlightingColorSpace.a98-rgb', "Use Adobe RGB (1998) color space for syntax highlighting."),
+					localize('highlightingColorSpace.prophoto-rgb', "Use ProPhoto RGB color space for syntax highlighting."),
+					localize('highlightingColorSpace.rec2020', "Use Rec. 2020 color space for syntax highlighting.")
+				],
+				default: 'srgb',
+				description: localize('workbench.highlightingColorSpace', "Controls the color space used for syntax highlighting.")
+			},
 		}
 	});
 

--- a/src/vs/workbench/browser/workbench.contribution.ts
+++ b/src/vs/workbench/browser/workbench.contribution.ts
@@ -680,15 +680,16 @@ const registry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Con
 			},
 			'workbench.highlightingColorSpace': {
 				type: 'string',
-				enum: ['srgb', 'display-p3', 'a98-rgb', 'prophoto-rgb', 'rec2020'],
+				enum: ['default', 'srgb', 'display-p3', 'a98-rgb', 'prophoto-rgb', 'rec2020'],
 				enumDescriptions: [
+					localize('highlightingColorSpace.default', "Use the theme's color space for syntax highlighting."),
 					localize('highlightingColorSpace.srgb', "Use sRGB color space for syntax highlighting."),
 					localize('highlightingColorSpace.display-p3', "Use Display P3 color space for syntax highlighting."),
 					localize('highlightingColorSpace.a98-rgb', "Use Adobe RGB (1998) color space for syntax highlighting."),
 					localize('highlightingColorSpace.prophoto-rgb', "Use ProPhoto RGB color space for syntax highlighting."),
 					localize('highlightingColorSpace.rec2020', "Use Rec. 2020 color space for syntax highlighting.")
 				],
-				default: 'srgb',
+				default: 'default',
 				description: localize('workbench.highlightingColorSpace', "Controls the color space used for syntax highlighting.")
 			},
 		}

--- a/src/vs/workbench/contrib/extensions/browser/extensionEditor.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionEditor.ts
@@ -761,7 +761,8 @@ export class ExtensionEditor extends EditorPane {
 	private renderBody(body: string): string {
 		const nonce = generateUuid();
 		const colorMap = TokenizationRegistry.getColorMap();
-		const css = colorMap ? generateTokensCSSForColorMap(colorMap) : '';
+		const highlightingColorSpace = TokenizationRegistry.getHighlightingColorSpace();
+		const css = colorMap ? generateTokensCSSForColorMap(colorMap, highlightingColorSpace) : '';
 		return `<!DOCTYPE html>
 		<html>
 			<head>

--- a/src/vs/workbench/contrib/mcp/browser/mcpServerEditor.ts
+++ b/src/vs/workbench/contrib/mcp/browser/mcpServerEditor.ts
@@ -522,7 +522,8 @@ export class McpServerEditor extends EditorPane {
 	private renderBody(body: string): string {
 		const nonce = generateUuid();
 		const colorMap = TokenizationRegistry.getColorMap();
-		const css = colorMap ? generateTokensCSSForColorMap(colorMap) : '';
+		const highlightingColorSpace = TokenizationRegistry.getHighlightingColorSpace();
+		const css = colorMap ? generateTokensCSSForColorMap(colorMap, highlightingColorSpace) : '';
 		return `<!DOCTYPE html>
 		<html>
 			<head>

--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView.ts
@@ -1998,7 +1998,8 @@ function copyBufferIfNeeded(buffer: Uint8Array, transfer: ArrayBuffer[]): Uint8A
 
 function getTokenizationCss() {
 	const colorMap = TokenizationRegistry.getColorMap();
-	const tokenizationCss = colorMap ? generateTokensCSSForColorMap(colorMap) : '';
+	const highlightingColorSpace = TokenizationRegistry.getHighlightingColorSpace();
+	const tokenizationCss = colorMap ? generateTokensCSSForColorMap(colorMap, highlightingColorSpace) : '';
 	return tokenizationCss;
 }
 

--- a/src/vs/workbench/contrib/terminal/test/common/terminalColorRegistry.test.ts
+++ b/src/vs/workbench/contrib/terminal/test/common/terminalColorRegistry.test.ts
@@ -8,7 +8,7 @@ import { Extensions as ThemeingExtensions, IColorRegistry, ColorIdentifier } fro
 import { Registry } from '../../../../../platform/registry/common/platform.js';
 import { ansiColorIdentifiers, registerColors } from '../../common/terminalColorRegistry.js';
 import { IColorTheme } from '../../../../../platform/theme/common/themeService.js';
-import { Color } from '../../../../../base/common/color.js';
+import { Color, RGBColorSpace } from '../../../../../base/common/color.js';
 import { ColorScheme } from '../../../../../platform/theme/common/theme.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 
@@ -24,7 +24,8 @@ function getMockTheme(type: ColorScheme): IColorTheme {
 		defines: () => true,
 		getTokenStyleMetadata: () => undefined,
 		tokenColorMap: [],
-		semanticHighlighting: false
+		semanticHighlighting: false,
+		highlightingColorSpace: null as RGBColorSpace
 	};
 	return theme;
 }

--- a/src/vs/workbench/contrib/update/browser/releaseNotesEditor.ts
+++ b/src/vs/workbench/contrib/update/browser/releaseNotesEditor.ts
@@ -273,7 +273,8 @@ export class ReleaseNotesManager {
 			}]
 		});
 		const colorMap = TokenizationRegistry.getColorMap();
-		const css = colorMap ? generateTokensCSSForColorMap(colorMap) : '';
+		const highlightingColorSpace = TokenizationRegistry.getHighlightingColorSpace();
+		const css = colorMap ? generateTokensCSSForColorMap(colorMap, highlightingColorSpace) : '';
 		const showReleaseNotes = Boolean(this._configurationService.getValue<boolean>('update.showReleaseNotes'));
 
 		return `<!DOCTYPE html>

--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStartedDetailsRenderer.ts
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStartedDetailsRenderer.ts
@@ -35,8 +35,9 @@ export class GettingStartedDetailsRenderer {
 		const content = await this.readAndCacheStepMarkdown(path, base);
 		const nonce = generateUuid();
 		const colorMap = TokenizationRegistry.getColorMap();
+		const highlightingColorSpace = TokenizationRegistry.getHighlightingColorSpace();
 
-		const css = colorMap ? generateTokensCSSForColorMap(colorMap) : '';
+		const css = colorMap ? generateTokensCSSForColorMap(colorMap, highlightingColorSpace) : '';
 
 		const inDev = document.location.protocol === 'http:';
 		const imgSrcCsp = inDev ? 'img-src https: data: http:' : 'img-src https: data:';
@@ -173,8 +174,9 @@ export class GettingStartedDetailsRenderer {
 		const content = await this.readAndCacheSVGFile(path);
 		const nonce = generateUuid();
 		const colorMap = TokenizationRegistry.getColorMap();
+		const highlightingColorSpace = TokenizationRegistry.getHighlightingColorSpace();
 
-		const css = colorMap ? generateTokensCSSForColorMap(colorMap) : '';
+		const css = colorMap ? generateTokensCSSForColorMap(colorMap, highlightingColorSpace) : '';
 		return `<!DOCTYPE html>
 		<html>
 			<head>

--- a/src/vs/workbench/services/textMate/browser/textMateTokenizationFeatureImpl.ts
+++ b/src/vs/workbench/services/textMate/browser/textMateTokenizationFeatureImpl.ts
@@ -115,8 +115,13 @@ export class TextMateTokenizationFeature extends Disposable implements ITextMate
 		return !!this._configurationService.getValue<boolean>('editor.experimental.asyncTokenizationVerification');
 	}
 
-	private getHighlightingColorSpace(): RGBColorSpace {
-		return this._configurationService.getValue<RGBColorSpace>('workbench.highlightingColorSpace') ?? 'srgb';
+	private getHighlightingColorSpace(theme: IWorkbenchColorTheme): RGBColorSpace {
+		const space = this._configurationService.getValue<RGBColorSpace | 'default'>('workbench.highlightingColorSpace');
+		if (space !== 'default') {
+			return space;
+		}
+
+		return theme.highlightingColorSpace;
 	}
 
 	private _handleGrammarsExtPoint(extensions: readonly IExtensionPointUser<ITMSyntaxExtensionPoint[]>[]): void {
@@ -353,7 +358,7 @@ export class TextMateTokenizationFeature extends Disposable implements ITextMate
 
 		this._grammarFactory?.setTheme(this._currentTheme, this._currentTokenColorMap);
 		const colorMap = toColorMap(this._currentTokenColorMap);
-		const highlightingColorSpace = this.getHighlightingColorSpace();
+		const highlightingColorSpace = this.getHighlightingColorSpace(colorTheme);
 		const cssRules = generateTokensCSSForColorMap(colorMap, highlightingColorSpace);
 		this._styleElement.textContent = cssRules;
 


### PR DESCRIPTION
Fixes #161028

Adds an option to change the color space of syntax highlighting colors. This allows more vibrant colors than the default sRGB color space which is narrow and can't encode vibrant colors.

See screenshot below uses Display P3 color space to the left and the unpatched version to the right (sRGB).

To test this you will need a display that supports a wider gamut, otherwise you will not see a difference. It's easiest to see with fully red (#ff0000) or fully green colors (#00ff00). All recent mac displays will support Display P3 colors.

<img width="1279" height="1615" alt="DisplayP3Highlighting" src="https://github.com/user-attachments/assets/6bc85d63-188c-41c2-872b-b74d43a89aa5" />
