### PR TITLE
Make sure we still allow other attrs in chat markdown

### DIFF
--- a/src/vs/base/browser/dom.ts
+++ b/src/vs/base/browser/dom.ts
@@ -1846,9 +1846,11 @@ export const trustedMathMlTags = Object.freeze([
 ]);
 
 
+export const defaultAllowedAttrs = Object.freeze(['href', 'data-href', 'data-command', 'target', 'title', 'name', 'src', 'alt', 'class', 'id', 'role', 'tabindex', 'style', 'data-code', 'width', 'height', 'align', 'x-dispatch', 'required', 'checked', 'placeholder', 'type', 'start']);
+
 const defaultDomPurifyConfig = Object.freeze<dompurify.Config & { RETURN_TRUSTED_TYPE: true }>({
 	ALLOWED_TAGS: ['a', 'button', 'blockquote', 'code', 'div', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'hr', 'input', 'label', 'li', 'p', 'pre', 'select', 'small', 'span', 'strong', 'textarea', 'ul', 'ol'],
-	ALLOWED_ATTR: ['href', 'data-href', 'data-command', 'target', 'title', 'name', 'src', 'alt', 'class', 'id', 'role', 'tabindex', 'style', 'data-code', 'width', 'height', 'align', 'x-dispatch', 'required', 'checked', 'placeholder', 'type', 'start'],
+	ALLOWED_ATTR: [...defaultAllowedAttrs],
 	RETURN_DOM: false,
 	RETURN_DOM_FRAGMENT: false,
 	RETURN_TRUSTED_TYPE: true

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/chatMarkdownContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/chatMarkdownContentPart.ts
@@ -100,7 +100,7 @@ export class ChatMarkdownContentPart extends Disposable implements IChatContentP
 		let thisPartCodeBlockIndexStart = 0;
 
 		this.domNode = document.createElement('div');
-		this.domNode.classList.add('chat-markdown-part');
+		this.domNode.classList.add('chat-markdown-part', 'rendered-markdown');
 
 		const enableMath = configurationService.getValue<boolean>(ChatConfiguration.EnableMath);
 

--- a/src/vs/workbench/contrib/markdown/browser/markedKatexSupport.ts
+++ b/src/vs/workbench/contrib/markdown/browser/markedKatexSupport.ts
@@ -25,7 +25,7 @@ export class MarkedKatexSupport {
 					return this.sanitizeKatexStyles(attrValue);
 				}
 
-				return false;
+				return dom.defaultAllowedAttrs.includes(attrName);
 			},
 		};
 	}


### PR DESCRIPTION
This makes sure we still allow our normal list of attributes in addition to the filtered `style`/`class`

Also fixes a class to correct some styling rules

