### PR TITLE
Fix terminal events squatting on common props

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminalTelemetry.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalTelemetry.ts
@@ -62,7 +62,7 @@ export class TerminalTelemetryContribution extends Disposable implements IWorkbe
 			shellIntegrationInjected: boolean;
 			shellIntegrationInjectionFailureReason: ShellIntegrationInjectionFailureReason | undefined;
 
-			sessionId: string;
+			terminalSessionId: string;
 		};
 		type TerminalCreationTelemetryClassification = {
 			owner: 'tyriar';
@@ -80,7 +80,7 @@ export class TerminalTelemetryContribution extends Disposable implements IWorkbe
 			shellIntegrationInjected: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Whether the shell integration script was injected.' };
 			shellIntegrationInjectionFailureReason: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Info about shell integration injection.' };
 
-			sessionId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The session ID of the terminal instance.' };
+			terminalSessionId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The session ID of the terminal instance.' };
 		};
 		this._telemetryService.publicLog2<TerminalCreationTelemetryData, TerminalCreationTelemetryClassification>('terminal/createInstance', {
 			shellType: getSanitizedShellType(slc),
@@ -94,7 +94,7 @@ export class TerminalTelemetryContribution extends Disposable implements IWorkbe
 			shellIntegrationQuality: commandDetection?.hasRichCommandDetection ? 2 : commandDetection ? 1 : 0,
 			shellIntegrationInjected: instance.usedShellIntegrationInjection,
 			shellIntegrationInjectionFailureReason: instance.shellIntegrationInjectionFailureReason,
-			sessionId: instance.sessionId,
+			terminalSessionId: instance.sessionId,
 		});
 	}
 }

--- a/src/vs/workbench/contrib/terminalContrib/quickFix/browser/quickFixAddon.ts
+++ b/src/vs/workbench/contrib/terminalContrib/quickFix/browser/quickFixAddon.ts
@@ -225,19 +225,19 @@ export class TerminalQuickFixAddon extends Disposable implements ITerminalAddon,
 		type QuickFixResultTelemetryEvent = {
 			quickFixId: string;
 			ranQuickFix: boolean;
-			sessionId: string;
+			terminalSessionId: string;
 		};
 		type QuickFixClassification = {
 			owner: 'meganrogge';
 			quickFixId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The quick fix ID' };
 			ranQuickFix: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Whether the quick fix was run' };
-			sessionId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The terminal session ID' };
+			terminalSessionId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The terminal session ID' };
 			comment: 'Terminal quick fixes';
 		};
 		this._telemetryService?.publicLog2<QuickFixResultTelemetryEvent, QuickFixClassification>('terminal/quick-fix', {
 			quickFixId: id,
 			ranQuickFix: this._didRun,
-			sessionId: this._sessionId
+			terminalSessionId: this._sessionId
 		});
 		this._decoration.clear();
 		this._decorationDisposables.clear();

--- a/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalSuggestTelemetry.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalSuggestTelemetry.ts
@@ -57,14 +57,14 @@ export class TerminalSuggestTelemetry extends Disposable {
 	 */
 	logCompletionLatency(sessionId: string, latency: number, firstShownFor: { window: boolean; shell: boolean }): void {
 		this._telemetryService.publicLog2<{
-			sessionId: string;
+			terminalSessionId: string;
 			latency: number;
 			firstWindow: boolean;
 			firstShell: boolean;
 		}, {
 			owner: 'meganrogge';
 			comment: 'Latency in ms from terminal completion request to completions shown.';
-			sessionId: {
+			terminalSessionId: {
 				classification: 'SystemMetaData';
 				purpose: 'FeatureInsight';
 				comment: 'The session ID of the terminal session.';
@@ -85,7 +85,7 @@ export class TerminalSuggestTelemetry extends Disposable {
 				comment: 'Whether this is the first ever showing of completions in the shell.';
 			};
 		}>('terminal.suggest.completionLatency', {
-			sessionId,
+			terminalSessionId: sessionId,
 			latency,
 			firstWindow: firstShownFor.window,
 			firstShell: firstShownFor.shell
@@ -118,7 +118,7 @@ export class TerminalSuggestTelemetry extends Disposable {
 				kind: string | undefined;
 				outcome: string;
 				exitCode: number | undefined;
-				sessionId: string;
+				terminalSessionId: string;
 				provider: string | undefined;
 			}, {
 				owner: 'meganrogge';
@@ -138,7 +138,7 @@ export class TerminalSuggestTelemetry extends Disposable {
 					purpose: 'FeatureInsight';
 					comment: 'The exit code from the command';
 				};
-				sessionId: {
+				terminalSessionId: {
 					classification: 'SystemMetaData';
 					purpose: 'FeatureInsight';
 					comment: 'The session ID of the terminal session where the completion was accepted';
@@ -152,7 +152,7 @@ export class TerminalSuggestTelemetry extends Disposable {
 				kind,
 				outcome,
 				exitCode,
-				sessionId: completion.sessionId,
+				terminalSessionId: completion.sessionId,
 				provider
 			});
 		}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
`sessionid` is a VS code common property which indicates the VS code session. We cannot send this property twice otherwise it gets overriden. Here we correct to terminalSessionId.

FYI @meganrogge
