### PR TITLE
Revert "refactor: remove redundant actionRunner override in ChatEditorOverlayWidget"

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingEditorOverlay.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingEditorOverlay.ts
@@ -275,6 +275,10 @@ class ChatEditorOverlayWidget extends Disposable {
 							});
 						}
 
+						override get actionRunner(): IActionRunner {
+							return super.actionRunner;
+						}
+
 						protected override getTooltip(): string | undefined {
 							const value = super.getTooltip();
 							if (!value) {


### PR DESCRIPTION
Reverts microsoft/vscode#254797
fix: https://github.com/microsoft/vscode/issues/255438

The following methods were used to verify this

1. open /Applications/Visual Studio Code - Insiders.app/Contents/Resources/app/out/vs/workbench/workbench.desktop.main.js
2. Edit and insert `get actionRunner(){return super.actionRunner;}` on line 2074 Col 18701