### PR TITLE
add layover to new cells correctly and dispose of listeners as cells are removed

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/contrib/troubleshoot/layout.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/troubleshoot/layout.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Disposable, DisposableStore, dispose, IDisposable } from '../../../../../../base/common/lifecycle.js';
+import { Disposable, DisposableStore, dispose, IDisposable, toDisposable } from '../../../../../../base/common/lifecycle.js';
 import { localize2 } from '../../../../../../nls.js';
 import { Categories } from '../../../../../../platform/action/common/actionCommonCategories.js';
 import { Action2, registerAction2 } from '../../../../../../platform/actions/common/actions.js';
@@ -20,7 +20,7 @@ export class TroubleshootController extends Disposable implements INotebookEdito
 	static id: string = 'workbench.notebook.troubleshoot';
 
 	private readonly _localStore = this._register(new DisposableStore());
-	private _cellStateListeners: IDisposable[] = [];
+	private _cellDisposables: DisposableStore[] = [];
 	private _enabled: boolean = false;
 	private _cellStatusItems: string[] = [];
 	private _cellOverlayIds: string[] = [];
@@ -43,7 +43,8 @@ export class TroubleshootController extends Disposable implements INotebookEdito
 
 	private _update() {
 		this._localStore.clear();
-		this._cellStateListeners.forEach(listener => listener.dispose());
+		this._cellDisposables.forEach(listener => listener.dispose());
+		this._cellDisposables = [];
 		this._removeCellOverlays();
 		this._removeNotebookOverlay();
 
@@ -184,8 +185,11 @@ export class TroubleshootController extends Disposable implements INotebookEdito
 
 		const getLayoutInfo = () => {
 			const eol = cell.textBuffer.getEOL() === '\n' ? 'LF' : 'CRLF';
-			const scrollTop = this._notebookEditor.getAbsoluteTopOfElement(cell);
-			return `cell #${index} (handle: ${cell.handle}) | AbsoluteTopOfElement: ${scrollTop}px | EOL: ${eol}`;
+			let scrollTop = '';
+			if (cell.layoutInfo.layoutState > 0) {
+				scrollTop = `| AbsoluteTopOfElement: ${this._notebookEditor.getAbsoluteTopOfElement(cell)}px`;
+			}
+			return `cell #${index} (handle: ${cell.handle}) ${scrollTop} | EOL: ${eol}`;
 		};
 		const label = document.createElement('div');
 		label.textContent = getLayoutInfo();
@@ -227,19 +231,27 @@ export class TroubleshootController extends Disposable implements INotebookEdito
 				}
 			};
 
-			this._localStore.add(cell.onDidChangeLayout((e) => {
+			const disposables = this._cellDisposables[index];
+			disposables.add(cell.onDidChangeLayout((e) => {
 				updateLayout();
 			}));
-			this._localStore.add(cell.textBuffer.onDidChangeContent(() => {
+			disposables.add(cell.textBuffer.onDidChangeContent(() => {
 				updateLayout();
 			}));
 			if (cell.textModel) {
-				this._localStore.add(cell.textModel.onDidChangeContent(() => {
+				disposables.add(cell.textModel.onDidChangeContent(() => {
 					updateLayout();
 				}));
 			}
-			this._localStore.add(this._notebookEditor.onDidChangeLayout(() => {
+			disposables.add(this._notebookEditor.onDidChangeLayout(() => {
 				updateLayout();
+			}));
+			disposables.add(toDisposable(() => {
+				this._notebookEditor.changeCellOverlays((accessor) => {
+					if (overlayId) {
+						accessor.removeOverlay(overlayId);
+					}
+				});
 			}));
 		}
 
@@ -271,7 +283,9 @@ export class TroubleshootController extends Disposable implements INotebookEdito
 		for (let i = 0; i < this._notebookEditor.getLength(); i++) {
 			const cell = this._notebookEditor.cellAt(i);
 
-			this._cellStateListeners.push(cell.onDidChangeLayout(e => {
+			const disposableStore = new DisposableStore();
+			this._cellDisposables.push(disposableStore);
+			disposableStore.add(cell.onDidChangeLayout(e => {
 				this._log(cell, e);
 			}));
 		}
@@ -279,14 +293,25 @@ export class TroubleshootController extends Disposable implements INotebookEdito
 		this._localStore.add(this._notebookEditor.onDidChangeViewCells(e => {
 			[...e.splices].reverse().forEach(splice => {
 				const [start, deleted, newCells] = splice;
-				const deletedCells = this._cellStateListeners.splice(start, deleted, ...newCells.map(cell => {
-					return cell.onDidChangeLayout((e: ICommonCellViewModelLayoutChangeInfo) => {
+				const deletedCells = this._cellDisposables.splice(start, deleted, ...newCells.map(cell => {
+					const disposableStore = new DisposableStore();
+					disposableStore.add(cell.onDidChangeLayout(e => {
 						this._log(cell, e);
-					});
+					}));
+					return disposableStore;
 				}));
 
 				dispose(deletedCells);
 			});
+
+			// Add the overlays
+			const addedCells = e.splices.reduce((acc, [, , newCells]) => [...acc, ...newCells], [] as ICellViewModel[]);
+			for (let i = 0; i < addedCells.length; i++) {
+				const cellIndex = this._notebookEditor.getCellIndex(addedCells[i]);
+				if (cellIndex !== undefined) {
+					this._createCellOverlay(addedCells[i], cellIndex);
+				}
+			}
 		}));
 
 		const vm = this._notebookEditor.getViewModel();
@@ -297,6 +322,7 @@ export class TroubleshootController extends Disposable implements INotebookEdito
 		}
 
 		this._cellStatusItems = vm.deltaCellStatusBarItems(this._cellStatusItems, items);
+
 	}
 
 	private _getItemsForCells(): INotebookDeltaCellStatusBarItems[] {
@@ -318,7 +344,7 @@ export class TroubleshootController extends Disposable implements INotebookEdito
 	}
 
 	override dispose() {
-		dispose(this._cellStateListeners);
+		dispose(this._cellDisposables);
 		this._removeCellOverlays();
 		this._removeNotebookOverlay();
 		this._localStore.clear();

--- a/src/vs/workbench/contrib/notebook/browser/contrib/troubleshoot/layout.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/troubleshoot/layout.ts
@@ -3,12 +3,12 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Disposable, DisposableStore, dispose, IDisposable, toDisposable } from '../../../../../../base/common/lifecycle.js';
+import { Disposable, DisposableStore, dispose, toDisposable } from '../../../../../../base/common/lifecycle.js';
 import { localize2 } from '../../../../../../nls.js';
 import { Categories } from '../../../../../../platform/action/common/actionCommonCategories.js';
 import { Action2, registerAction2 } from '../../../../../../platform/actions/common/actions.js';
 import { ServicesAccessor } from '../../../../../../platform/instantiation/common/instantiation.js';
-import { getNotebookEditorFromEditorPane, ICellViewModel, ICommonCellViewModelLayoutChangeInfo, INotebookDeltaCellStatusBarItems, INotebookEditor, INotebookEditorContribution } from '../../notebookBrowser.js';
+import { getNotebookEditorFromEditorPane, ICellViewModel, INotebookDeltaCellStatusBarItems, INotebookEditor, INotebookEditorContribution } from '../../notebookBrowser.js';
 import { registerNotebookContribution } from '../../notebookEditorExtensions.js';
 import { NotebookEditorWidget } from '../../notebookEditorWidget.js';
 import { CellStatusbarAlignment, INotebookCellStatusBarItem } from '../../../common/notebookCommon.js';
@@ -23,7 +23,6 @@ export class TroubleshootController extends Disposable implements INotebookEdito
 	private _cellDisposables: DisposableStore[] = [];
 	private _enabled: boolean = false;
 	private _cellStatusItems: string[] = [];
-	private _cellOverlayIds: string[] = [];
 	private _notebookOverlayDomNode: HTMLElement | undefined;
 
 	constructor(private readonly _notebookEditor: INotebookEditor) {
@@ -43,9 +42,8 @@ export class TroubleshootController extends Disposable implements INotebookEdito
 
 	private _update() {
 		this._localStore.clear();
-		this._cellDisposables.forEach(listener => listener.dispose());
+		this._cellDisposables.forEach(d => d.dispose());
 		this._cellDisposables = [];
-		this._removeCellOverlays();
 		this._removeNotebookOverlay();
 
 		if (!this._notebookEditor.hasModel()) {
@@ -216,7 +214,6 @@ export class TroubleshootController extends Disposable implements INotebookEdito
 		});
 
 		if (overlayId) {
-			this._cellOverlayIds.push(overlayId);
 
 			// Update overlay when layout changes
 			const updateLayout = () => {
@@ -255,17 +252,6 @@ export class TroubleshootController extends Disposable implements INotebookEdito
 			}));
 		}
 
-	}
-
-	private _removeCellOverlays() {
-		if (this._cellOverlayIds.length > 0) {
-			this._notebookEditor.changeCellOverlays((accessor) => {
-				for (const id of this._cellOverlayIds) {
-					accessor.removeOverlay(id);
-				}
-			});
-			this._cellOverlayIds = [];
-		}
 	}
 
 	private _removeNotebookOverlay() {
@@ -345,7 +331,6 @@ export class TroubleshootController extends Disposable implements INotebookEdito
 
 	override dispose() {
 		dispose(this._cellDisposables);
-		this._removeCellOverlays();
 		this._removeNotebookOverlay();
 		this._localStore.clear();
 		super.dispose();


### PR DESCRIPTION
found while looking for a cause of https://github.com/microsoft/vscode/issues/251601.
One issue was straight forward, we didn't stop updating the overlay for a cell after it was removed from the notebook.

The other is a little sneakier - if you add a handler to the viewModel's `onDidChangeViewCells`, it is called before the listView's handler, which means you can work with cells that were just added to the viewModel, but haven't yet been added to the ListView, which can causes an Invalid index error in `NotebookCellList.getCellViewScrollTop`.
Checking `cell.layoutInfo.layoutState > 0` seems to work fine to guard against this.