### PR TITLE
Add commit_id option to ServeWebArgs for specific client version

### DIFF
--- a/cli/src/commands/args.rs
+++ b/cli/src/commands/args.rs
@@ -216,6 +216,9 @@ pub struct ServeWebArgs {
 	/// Specifies the directory that server data is kept in.
 	#[clap(long)]
 	pub server_data_dir: Option<String>,
+	/// Use a specific commit SHA for the client.
+	#[clap(long)]
+	pub commit_id: Option<String>,
 }
 
 #[derive(Args, Debug, Clone)]

--- a/cli/src/commands/serve_web.rs
+++ b/cli/src/commands/serve_web.rs
@@ -629,6 +629,22 @@ impl ConnectionManager {
 				Quality::try_from(q).map_err(|_| CodeError::UpdatesNotConfigured("unknown quality"))
 			})?;
 
+		if let Some(commit) = &self.args.commit_id {
+			let release = Release {
+				name: commit.to_string(),
+				commit: commit.to_string(),
+				platform: self.platform,
+				target: target_kind,
+				quality,
+			};
+			debug!(
+				self.log,
+				"using provided commit instead of latest release: {}", release
+			);
+			*latest = Some((now, release.clone()));
+			return Ok(release);
+		}
+
 		let release = self
 			.update_service
 			.get_latest_commit(self.platform, target_kind, quality)

--- a/cli/src/commands/serve_web.rs
+++ b/cli/src/commands/serve_web.rs
@@ -88,8 +88,10 @@ pub async fn serve_web(ctx: CommandContext, mut args: ServeWebArgs) -> Result<i3
 
 	let cm: Arc<ConnectionManager> = ConnectionManager::new(&ctx, platform, args.clone());
 	let update_check_interval = 3600;
-	cm.clone()
-		.start_update_checker(Duration::from_secs(update_check_interval));
+	if args.commit_id.is_none() {
+		cm.clone()
+			.start_update_checker(Duration::from_secs(update_check_interval));
+	}
 
 	let key = get_server_key_half(&ctx.paths);
 	let make_svc = move || {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
Closes #255218

I opened that issue and it hasn't received its requisite 20 community upvotes, but it seems like a lightweight change. This is intended to avoid scenarios where `code serve-web` is unusable due to problems with the latest release client.