### PR TITLE
fix: Code CLI script fails with "Unable to determine app path from symlink" with bash 5.3 

### DIFF
--- a/resources/darwin/bin/code.sh
+++ b/resources/darwin/bin/code.sh
@@ -20,7 +20,7 @@ function app_realpath() {
 		[[ $SOURCE != /* ]] && SOURCE=$DIR/$SOURCE
 	done
 	SOURCE_DIR="$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
-	echo "${SOURCE_DIR%%${SOURCE_DIR#*.app}}"
+	echo "$SOURCE_DIR" | grep -o '.*\.app'
 }
 
 APP_PATH="$(app_realpath "${BASH_SOURCE[0]}")"


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Solve #254824

