### PR TITLE
Change cmd+. to open mode picker instead of toggle model

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/actions/chatExecuteActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatExecuteActions.ts
@@ -207,13 +207,6 @@ class ToggleChatModeAction extends Action2 {
 				ChatContextKeys.enabled,
 				ChatContextKeys.requestInProgress.negate()),
 			tooltip: localize('setChatMode', "Set Mode"),
-			keybinding: {
-				when: ContextKeyExpr.and(
-					ChatContextKeys.inChatInput,
-					ChatContextKeys.location.isEqualTo(ChatAgentLocation.Panel)),
-				primary: KeyMod.CtrlCmd | KeyCode.Period,
-				weight: KeybindingWeight.EditorContrib
-			},
 			menu: [
 				{
 					id: MenuId.ChatInput,
@@ -387,6 +380,13 @@ class OpenModePickerAction extends Action2 {
 			category: CHAT_CATEGORY,
 			f1: false,
 			precondition: ChatContextKeys.enabled,
+			keybinding: {
+				when: ContextKeyExpr.and(
+					ChatContextKeys.inChatInput,
+					ChatContextKeys.location.isEqualTo(ChatAgentLocation.Panel)),
+				primary: KeyMod.CtrlCmd | KeyCode.Period,
+				weight: KeybindingWeight.EditorContrib
+			},
 		});
 	}
 


### PR DESCRIPTION
Fix microsoft/vscode-copilot#16625

Anyone can rebind `workbench.action.chat.toggleAgentMode` to get the previous behavior back