### PR TITLE
Fix typos in comments, string literals, and class names across multip…

### DIFF
--- a/build/lib/mangle/index.js
+++ b/build/lib/mangle/index.js
@@ -139,7 +139,7 @@ class ClassData {
     }
     static makeImplicitPublicActuallyPublic(data, reportViolation) {
         // TS-HACK
-        // A subtype can make an inherited protected field public. To prevent accidential
+        // A subtype can make an inherited protected field public. To prevent accidental
         // mangling of public fields we mark the original (protected) fields as public...
         for (const [name, info] of data.fields) {
             if (info.type !== 0 /* FieldType.Public */) {

--- a/build/lib/mangle/index.ts
+++ b/build/lib/mangle/index.ts
@@ -150,7 +150,7 @@ class ClassData {
 
 	static makeImplicitPublicActuallyPublic(data: ClassData, reportViolation: (name: string, what: string, why: string) => void): void {
 		// TS-HACK
-		// A subtype can make an inherited protected field public. To prevent accidential
+		// A subtype can make an inherited protected field public. To prevent accidental
 		// mangling of public fields we mark the original (protected) fields as public...
 		for (const [name, info] of data.fields) {
 			if (info.type !== FieldType.Public) {

--- a/build/lib/nls.js
+++ b/build/lib/nls.js
@@ -331,7 +331,7 @@ var _nls;
     }
     function parseLocalizeKeyOrValue(sourceExpression) {
         // sourceValue can be "foo", 'foo', `foo` or { .... }
-        // in its evalulated form
+        // in its evaluated form
         // we want to return either the string or the object
         // eslint-disable-next-line no-eval
         return eval(`(${sourceExpression})`);

--- a/build/lib/nls.ts
+++ b/build/lib/nls.ts
@@ -429,7 +429,7 @@ module _nls {
 
 	function parseLocalizeKeyOrValue(sourceExpression: string) {
 		// sourceValue can be "foo", 'foo', `foo` or { .... }
-		// in its evalulated form
+		// in its evaluated form
 		// we want to return either the string or the object
 		// eslint-disable-next-line no-eval
 		return eval(`(${sourceExpression})`);

--- a/build/lib/stylelint/validateVariableNames.ts
+++ b/build/lib/stylelint/validateVariableNames.ts
@@ -26,7 +26,7 @@ export interface IValidator {
 
 export function getVariableNameValidator(): IValidator {
 	const allVariables = getKnownVariableNames();
-	return (value: string, report: (unknwnVariable: string) => void) => {
+	return (value: string, report: (unknownVariable: string) => void) => {
 		RE_VAR_PROP.lastIndex = 0; // reset lastIndex just to be sure
 		let match;
 		while (match = RE_VAR_PROP.exec(value)) {

--- a/build/lib/tsb/builder.js
+++ b/build/lib/tsb/builder.js
@@ -71,7 +71,7 @@ function createTypeScriptBuilder(config, projectFile, cmd) {
     let oldErrors = Object.create(null);
     let headUsed = process.memoryUsage().heapUsed;
     let emitSourceMapsInStream = true;
-    // always emit declaraction files
+    // always emit declaration files
     host.getCompilationSettings().declaration = true;
     function file(file) {
         // support gulp-sourcemaps
@@ -285,7 +285,7 @@ function createTypeScriptBuilder(config, projectFile, cmd) {
                         }
                         // remember when this was build
                         newLastBuildVersion.set(fileName, host.getScriptVersion(fileName));
-                        // remeber the signature
+                        // remember the signature
                         if (value.signature && lastDtsHash[fileName] !== value.signature) {
                             lastDtsHash[fileName] = value.signature;
                             filesWithChangedSignature.push(fileName);
@@ -508,7 +508,7 @@ class LanguageServiceHost {
         if (result) {
             return result.getVersion();
         }
-        return 'UNKNWON_FILE_' + Math.random().toString(16).slice(2);
+        return 'UNKNOWN_FILE_' + Math.random().toString(16).slice(2);
     }
     getScriptSnapshot(filename, resolve = true) {
         filename = normalize(filename);

--- a/build/lib/tsb/builder.ts
+++ b/build/lib/tsb/builder.ts
@@ -54,7 +54,7 @@ export function createTypeScriptBuilder(config: IConfiguration, projectFile: str
 	let headUsed = process.memoryUsage().heapUsed;
 	let emitSourceMapsInStream = true;
 
-	// always emit declaraction files
+	// always emit declaration files
 	host.getCompilationSettings().declaration = true;
 
 	function file(file: Vinyl): void {
@@ -305,7 +305,7 @@ export function createTypeScriptBuilder(config: IConfiguration, projectFile: str
 						// remember when this was build
 						newLastBuildVersion.set(fileName, host.getScriptVersion(fileName));
 
-						// remeber the signature
+						// remember the signature
 						if (value.signature && lastDtsHash[fileName] !== value.signature) {
 							lastDtsHash[fileName] = value.signature;
 							filesWithChangedSignature.push(fileName);
@@ -576,7 +576,7 @@ class LanguageServiceHost implements ts.LanguageServiceHost {
 		if (result) {
 			return result.getVersion();
 		}
-		return 'UNKNWON_FILE_' + Math.random().toString(16).slice(2);
+		return 'UNKNOWN_FILE_' + Math.random().toString(16).slice(2);
 	}
 
 	getScriptSnapshot(filename: string, resolve: boolean = true): ScriptSnapshot {

--- a/build/lib/tsb/transpiler.js
+++ b/build/lib/tsb/transpiler.js
@@ -163,7 +163,7 @@ class TscTranspiler {
         this._outputFileNames = new OutputFileNameOracle(_cmdLine, configFilePath);
     }
     async join() {
-        // wait for all penindg jobs
+        // wait for all pending jobs
         this._consumeQueue();
         await Promise.allSettled(this._allJobs);
         this._allJobs.length = 0;

--- a/build/lib/tsb/transpiler.ts
+++ b/build/lib/tsb/transpiler.ts
@@ -213,7 +213,7 @@ export class TscTranspiler implements ITranspiler {
 	}
 
 	async join() {
-		// wait for all penindg jobs
+		// wait for all pending jobs
 		this._consumeQueue();
 		await Promise.allSettled(this._allJobs);
 		this._allJobs.length = 0;

--- a/src/vs/workbench/services/extensions/common/abstractExtensionService.ts
+++ b/src/vs/workbench/services/extensions/common/abstractExtensionService.ts
@@ -1501,7 +1501,7 @@ export class ImplicitActivationAwareReader implements IActivationEventsReader {
 	}
 }
 
-class ActivationFeatureMarkdowneRenderer extends Disposable implements IExtensionFeatureMarkdownRenderer {
+class ActivationFeatureMarkdownRenderer extends Disposable implements IExtensionFeatureMarkdownRenderer {
 
 	readonly type = 'markdown';
 
@@ -1530,5 +1530,5 @@ Registry.as<IExtensionFeaturesRegistry>(ExtensionFeaturesExtensions.ExtensionFea
 	access: {
 		canToggle: false
 	},
-	renderer: new SyncDescriptor(ActivationFeatureMarkdowneRenderer),
+	renderer: new SyncDescriptor(ActivationFeatureMarkdownRenderer),
 });

--- a/src/vs/workbench/services/extensions/common/extensionsProposedApi.ts
+++ b/src/vs/workbench/services/extensions/common/extensionsProposedApi.ts
@@ -115,7 +115,7 @@ export class ExtensionsProposedApi {
 	}
 }
 
-class ApiProposalsMarkdowneRenderer extends Disposable implements IExtensionFeatureMarkdownRenderer {
+class ApiProposalsMarkdownRenderer extends Disposable implements IExtensionFeatureMarkdownRenderer {
 
 	readonly type = 'markdown';
 
@@ -144,5 +144,5 @@ Registry.as<IExtensionFeaturesRegistry>(Extensions.ExtensionFeaturesRegistry).re
 	access: {
 		canToggle: false
 	},
-	renderer: new SyncDescriptor(ApiProposalsMarkdowneRenderer),
+	renderer: new SyncDescriptor(ApiProposalsMarkdownRenderer),
 });


### PR DESCRIPTION
This PR fixes multiple typos across 11 files in the codebase.
In total, 17 lines were updated to correct spelling mistakes in comments, string literals, and class names.
No functional changes were made.
