### PR TITLE
fix enablement of mcp tool sets and tools

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/promptSyntax/promptFileRewriter.ts
+++ b/src/vs/workbench/contrib/chat/browser/promptSyntax/promptFileRewriter.ts
@@ -9,7 +9,7 @@ import { ICodeEditorService } from '../../../../../editor/browser/services/codeE
 import { EditOperation } from '../../../../../editor/common/core/editOperation.js';
 import { Range } from '../../../../../editor/common/core/range.js';
 import { ITextModel } from '../../../../../editor/common/model.js';
-import { IToolAndToolSetEnablementMap, ToolSet } from '../../common/languageModelToolsService.js';
+import { IToolAndToolSetEnablementMap, IToolData, ToolSet } from '../../common/languageModelToolsService.js';
 import { IPromptsService } from '../../common/promptSyntax/service/promptsService.js';
 
 export class PromptFileRewriter {
@@ -59,11 +59,19 @@ export class PromptFileRewriter {
 			model.pushStackElement();
 			return;
 		}
+		const toolsCoveredBySets = new Set<IToolData>();
+		for (const [item, picked] of newTools) {
+			if (picked && item instanceof ToolSet) {
+				for (const tool of item.getTools()) {
+					toolsCoveredBySets.add(tool);
+				}
+			}
+		}
 		for (const [item, picked] of newTools) {
 			if (picked) {
 				if (item instanceof ToolSet) {
 					newToolNames.push(item.referenceName);
-				} else {
+				} else if (!toolsCoveredBySets.has(item)) {
 					newToolNames.push(item.toolReferenceName ?? item.displayName);
 				}
 			}


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/253824

In the tools picker, parent node are shown checked if at least one child is checked.
However, in our model, a tool set nodes are only checked if all children are checked.

