### PR TITLE
Tools in the chat mode are not correctly applied after a window reload

### DIFF
--- a/src/vs/workbench/contrib/chat/common/chatModes.ts
+++ b/src/vs/workbench/contrib/chat/common/chatModes.ts
@@ -149,14 +149,13 @@ export class ChatModeService extends Disposable implements IChatModeService {
 			}
 
 			this.hasCustomModes.set(this._customModeInstances.size > 0);
-
-			if (fireChangeEvent) {
-				this._onDidChangeChatModes.fire();
-			}
 		} catch (error) {
 			this.logService.error(error, 'Failed to load custom chat modes');
 			this._customModeInstances.clear();
 			this.hasCustomModes.set(false);
+		}
+		if (fireChangeEvent) {
+			this._onDidChangeChatModes.fire();
 		}
 	}
 

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/contentProviders/textModelContentsProvider.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/contentProviders/textModelContentsProvider.ts
@@ -31,7 +31,7 @@ export class TextModelContentsProvider extends PromptContentsProviderBase<IModel
 	}
 
 	public override get languageId(): string {
-		return this.model.getLanguageId();
+		return this.options.languageId ?? this.model.getLanguageId();
 	}
 
 	constructor(

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsServiceImpl.ts
@@ -26,7 +26,6 @@ import { getCleanPromptName, PROMPT_FILE_EXTENSION } from '../config/promptFileL
 import { ILanguageService } from '../../../../../../editor/common/languages/language.js';
 import { PromptsConfig } from '../config/config.js';
 import { IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
-import { TModeMetadata } from '../parsers/promptHeader/modeHeader.js';
 
 /**
  * Provides prompt services.
@@ -240,10 +239,15 @@ export class PromptsService extends Disposable implements IPromptsService {
 						throw new Error(localize('promptParser.notCompleted', "Prompt parser for {0} did not complete.", uri.toString()));
 					}
 
-					const { description, model, tools } = parser.metadata as TModeMetadata;
 					const body = await parser.getBody();
 					const name = getCleanPromptName(uri);
-					return { uri: uri, name, description, tools, model, body };
+
+					const metadata = parser.metadata;
+					if (metadata?.promptType !== PromptsType.mode) {
+						return { uri, name, body };
+					}
+					const { description, model, tools } = metadata;
+					return { uri, name, description, model, tools, body };
 				} finally {
 					parser?.dispose();
 				}


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/255752

- on reload, the text model in the editor is first initialized with language id: `plaintext`.
- that confuses the prompt parser and it does not parse the header
- that throws an error in the code that loads all custom modes
- that error prevents the change notification to be sent. The current mode is stale 