### PR TITLE
Revert "fix - update constraint for command options validation"

### DIFF
--- a/src/vs/workbench/browser/actions/workspaceCommands.ts
+++ b/src/vs/workbench/browser/actions/workspaceCommands.ts
@@ -220,7 +220,7 @@ CommandsRegistry.registerCommand({
 					'`forceTempProfile`: Whether to use a temporary profile when opening the folder/workspace. Defaults to false. ' +
 					'`filesToOpen`: An array of files to open in the new window. Defaults to an empty array. ' +
 					'Note, for backward compatibility, options can also be of type boolean, representing the `forceNewWindow` setting.',
-				constraint: (value: any) => value === undefined || (typeof value === 'object' && value !== null) || typeof value === 'boolean'
+				constraint: (value: any) => value === undefined || typeof value === 'object' || typeof value === 'boolean'
 			}
 		]
 	}


### PR DESCRIPTION
Reverts microsoft/vscode#255339

Otherwise extensions that pass in `undefined` will wrongly be treated as this type ends up as `null`.