### PR TITLE
chore: enable verbose logs for windows electron smoketests

### DIFF
--- a/build/azure-pipelines/win32/product-build-win32-test.yml
+++ b/build/azure-pipelines/win32/product-build-win32-test.yml
@@ -164,7 +164,7 @@ steps:
   - ${{ if ne(parameters.VSCODE_QUALITY, 'oss') }}:
     - ${{ if eq(parameters.VSCODE_RUN_ELECTRON_TESTS, true) }}:
       # Additional "--" needed to workaround https://github.com/npm/cli/issues/7375
-      - powershell: npm run smoketest-no-compile -- -- --tracing --build "$(agent.builddirectory)\VSCode-win32-$(VSCODE_ARCH)"
+      - powershell: npm run smoketest-no-compile -- -- --verbose --tracing --build "$(agent.builddirectory)\VSCode-win32-$(VSCODE_ARCH)"
         displayName: 🧪 Run smoke tests (Electron)
         timeoutInMinutes: 20
 


### PR DESCRIPTION
For https://github.com/microsoft/vscode/issues/227367