### PR TITLE
fs - workaround failure to read a folder that is a subst drive (#252361)

### DIFF
--- a/src/vs/base/node/pfs.ts
+++ b/src/vs/base/node/pfs.ts
@@ -107,6 +107,8 @@ async function readdir(path: string, options?: { withFileTypes: true }): Promise
 	try {
 		return await doReaddir(path, options);
 	} catch (error) {
+		// TODO@bpasero workaround for #252361 that should be removed
+		// once the upstream issue in node.js is resolved
 		if (error.code === 'ENOENT' && isWindows && isRootOrDriveLetter(path)) {
 			try {
 				return await doReaddir(path.slice(0, -1), options);

--- a/src/vs/base/node/pfs.ts
+++ b/src/vs/base/node/pfs.ts
@@ -104,6 +104,21 @@ export interface IDirent {
 async function readdir(path: string): Promise<string[]>;
 async function readdir(path: string, options: { withFileTypes: true }): Promise<IDirent[]>;
 async function readdir(path: string, options?: { withFileTypes: true }): Promise<(string | IDirent)[]> {
+	try {
+		return await doReaddir(path, options);
+	} catch (error) {
+		if (error.code === 'ENOENT' && isWindows && isRootOrDriveLetter(path)) {
+			try {
+				return await doReaddir(path.slice(0, -1), options);
+			} catch (e) {
+				// ignore
+			}
+		}
+		throw error;
+	}
+}
+
+async function doReaddir(path: string, options?: { withFileTypes: true }): Promise<(string | IDirent)[]> {
 	return handleDirectoryChildren(await (options ? safeReaddirWithFileTypes(path) : fs.promises.readdir(path)));
 }
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
