### PR TITLE
fail early when too deep in recursion

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/notebookCellLayoutManager.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebookCellLayoutManager.ts
@@ -26,9 +26,8 @@ export class NotebookCellLayoutManager extends Disposable {
 
 	private checkStackDepth() {
 		if (this._layoutStack.length > 30) {
-			this.loggingService.error('cell layout', `NotebookCellLayoutManager: layout stack is too deep`);
-			this.loggingService.error('cell layout', this._layoutStack.join(' -> '));
-			throw new Error('NotebookCellLayoutManager: layout stack is too deep, check logs for more info');
+			const layoutTrace = this._layoutStack.join(' -> ');
+			throw new Error('NotebookCellLayoutManager: layout stack is too deep: ' + layoutTrace);
 		}
 	}
 

--- a/src/vs/workbench/contrib/notebook/browser/notebookCellLayoutManager.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebookCellLayoutManager.ts
@@ -5,7 +5,7 @@
 
 import { DeferredPromise } from '../../../../base/common/async.js';
 import { Disposable, IDisposable, toDisposable } from '../../../../base/common/lifecycle.js';
-import { ICellViewModel, CellLayoutContext } from './notebookBrowser.js';
+import { ICellViewModel } from './notebookBrowser.js';
 import { NotebookEditorWidget } from './notebookEditorWidget.js';
 import { INotebookCellList } from './view/notebookRenderingCommon.js';
 import * as DOM from '../../../../base/browser/dom.js';
@@ -14,6 +14,7 @@ import { INotebookLoggingService } from '../common/notebookLoggingService.js';
 export class NotebookCellLayoutManager extends Disposable {
 	private _pendingLayouts: WeakMap<ICellViewModel, IDisposable> | null = new WeakMap<ICellViewModel, IDisposable>();
 	private _layoutDisposables: Set<IDisposable> = new Set<IDisposable>();
+	private readonly _layoutStack: string[] = [];
 	private _isDisposed = false;
 	constructor(
 		private notebookWidget: NotebookEditorWidget,
@@ -23,8 +24,17 @@ export class NotebookCellLayoutManager extends Disposable {
 		super();
 	}
 
-	async layoutNotebookCell(cell: ICellViewModel, height: number, context?: CellLayoutContext): Promise<void> {
-		this.loggingService.debug('cell layout', `cell:${cell.handle}, height:${height}`);
+	private checkStackDepth() {
+		if (this._layoutStack.length > 30) {
+			this.loggingService.error('cell layout', `NotebookCellLayoutManager: layout stack is too deep`);
+			this.loggingService.error('cell layout', this._layoutStack.join(' -> '));
+			throw new Error('NotebookCellLayoutManager: layout stack is too deep, check logs for more info');
+		}
+	}
+
+	async layoutNotebookCell(cell: ICellViewModel, height: number): Promise<void> {
+		const layoutTag = `cell:${cell.handle}, height:${height}`;
+		this.loggingService.debug('cell layout', layoutTag);
 		const viewIndex = this._list.getViewIndex(cell);
 		if (viewIndex === undefined) {
 			// the cell is hidden
@@ -40,6 +50,7 @@ export class NotebookCellLayoutManager extends Disposable {
 			const pendingLayout = this._pendingLayouts?.get(cell);
 			this._pendingLayouts?.delete(cell);
 
+			this._layoutStack.push(layoutTag);
 			try {
 				if (this._isDisposed) {
 					return;
@@ -59,6 +70,7 @@ export class NotebookCellLayoutManager extends Disposable {
 					return;
 				}
 
+				this.checkStackDepth();
 
 				if (!this.notebookWidget.hasEditorFocus()) {
 					// Do not scroll inactive notebook
@@ -76,6 +88,7 @@ export class NotebookCellLayoutManager extends Disposable {
 
 				this._list.updateElementHeight2(cell, height);
 			} finally {
+				this._layoutStack.pop();
 				deferred.complete(undefined);
 				if (pendingLayout) {
 					pendingLayout.dispose();

--- a/src/vs/workbench/contrib/notebook/browser/notebookEditorWidget.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebookEditorWidget.ts
@@ -2368,7 +2368,7 @@ export class NotebookEditorWidget extends Disposable implements INotebookEditorD
 	//#endregion
 
 	async layoutNotebookCell(cell: ICellViewModel, height: number, context?: CellLayoutContext): Promise<void> {
-		return this._cellLayoutManager?.layoutNotebookCell(cell, height, context);
+		return this._cellLayoutManager?.layoutNotebookCell(cell, height);
 	}
 
 	getActiveCell() {


### PR DESCRIPTION
fix https://github.com/microsoft/vscode/issues/248835

this won't actually fix the stack overflow error, but it will change where it is thrown so the error site entry will change.
Also adds more diagnostic info to the error message so that we can see what this recursive layout loop looks like.
Not intended to change behavior from the user's perspective.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
