### PR TITLE
Revert "debt - make `vscode.executeDocumentSymbolProvider` very correct wrt what it returns (#251190)"

### DIFF
--- a/src/vs/workbench/api/common/extHostApiCommands.ts
+++ b/src/vs/workbench/api/common/extHostApiCommands.ts
@@ -41,21 +41,28 @@ const newCommands: ApiCommand[] = [
 			if (isFalsyOrEmpty(value)) {
 				return undefined;
 			}
+			class MergedInfo extends types.SymbolInformation implements vscode.DocumentSymbol {
+				static to(symbol: languages.DocumentSymbol): MergedInfo {
+					const res = new MergedInfo(
+						symbol.name,
+						typeConverters.SymbolKind.to(symbol.kind),
+						symbol.containerName || '',
+						new types.Location(apiArgs[0], typeConverters.Range.to(symbol.range))
+					);
+					res.detail = symbol.detail;
+					res.range = res.location.range;
+					res.selectionRange = typeConverters.Range.to(symbol.selectionRange);
+					res.children = symbol.children ? symbol.children.map(MergedInfo.to) : [];
+					return res;
+				}
 
-			function wrap(symbol: languages.DocumentSymbol): types.SymbolInformationAndDocumentSymbol {
-				return new types.SymbolInformationAndDocumentSymbol(
-					symbol.name,
-					typeConverters.SymbolKind.to(symbol.kind),
-					symbol.detail,
-					symbol.containerName || '',
-					apiArgs[0],
-					typeConverters.Range.to(symbol.range),
-					typeConverters.Range.to(symbol.selectionRange),
-					symbol.children ? symbol.children.map(wrap) : []
-				);
+				detail!: string;
+				range!: vscode.Range;
+				selectionRange!: vscode.Range;
+				children!: vscode.DocumentSymbol[];
+				override containerName: string = '';
 			}
-
-			return value.map(wrap);
+			return value.map(MergedInfo.to);
 
 		})
 	),

--- a/src/vs/workbench/api/common/extHostTypes.ts
+++ b/src/vs/workbench/api/common/extHostTypes.ts
@@ -1383,8 +1383,19 @@ export class SymbolInformation {
 	}
 }
 
+@es5ClassCompat
+export class DocumentSymbol {
 
-abstract class AbstractDocumentSymbol {
+	static validate(candidate: DocumentSymbol): void {
+		if (!candidate.name) {
+			throw new Error('name must not be falsy');
+		}
+		if (!candidate.range.contains(candidate.selectionRange)) {
+			throw new Error('selectionRange must be contained in fullRange');
+		}
+		candidate.children?.forEach(DocumentSymbol.validate);
+	}
+
 	name: string;
 	detail: string;
 	kind: SymbolKind;
@@ -1400,53 +1411,11 @@ abstract class AbstractDocumentSymbol {
 		this.range = range;
 		this.selectionRange = selectionRange;
 		this.children = [];
-	}
-}
 
-@es5ClassCompat
-export class DocumentSymbol extends AbstractDocumentSymbol {
-
-	static validate(candidate: DocumentSymbol): void {
-		if (!candidate.name) {
-			throw new Error('name must not be falsy');
-		}
-		if (!candidate.range.contains(candidate.selectionRange)) {
-			throw new Error('selectionRange must be contained in fullRange');
-		}
-		candidate.children?.forEach(DocumentSymbol.validate);
-	}
-
-	constructor(name: string, detail: string, kind: SymbolKind, range: Range, selectionRange: Range) {
-		super(name, detail, kind, range, selectionRange);
 		DocumentSymbol.validate(this);
 	}
-
-	static override[Symbol.hasInstance](candidate: unknown): boolean {
-		return candidate instanceof AbstractDocumentSymbol
-			|| candidate instanceof SymbolInformationAndDocumentSymbol;
-	}
 }
 
-// This is a special type that's used from the `vscode.executeDocumentSymbolProvider` API
-// command which implements both shapes, vscode.SymbolInformation _and_ vscode.DocumentSymbol
-export class SymbolInformationAndDocumentSymbol extends SymbolInformation implements vscode.DocumentSymbol {
-
-	detail: string;
-	range: vscode.Range;
-	selectionRange: vscode.Range;
-	children: vscode.DocumentSymbol[];
-	override containerName: string;
-
-	constructor(name: string, kind: vscode.SymbolKind, detail: string, containerName: string, uri: URI, range: Range, selectionRange: Range, children?: SymbolInformationAndDocumentSymbol[]) {
-		super(name, kind, containerName, new Location(uri, range));
-
-		this.containerName = containerName;
-		this.detail = detail;
-		this.range = range;
-		this.selectionRange = selectionRange;
-		this.children = children ?? [];
-	}
-}
 
 export enum CodeActionTriggerKind {
 	Invoke = 1,

--- a/src/vs/workbench/api/test/browser/extHostApiCommands.test.ts
+++ b/src/vs/workbench/api/test/browser/extHostApiCommands.test.ts
@@ -774,9 +774,8 @@ suite('ExtHostLanguageFeatureCommands', function () {
 				assert.strictEqual(values.length, 2);
 				const [first, second] = values;
 				assert.strictEqual(first instanceof types.SymbolInformation, true);
-				assert.strictEqual(first instanceof types.DocumentSymbol, true);
+				assert.strictEqual(first instanceof types.DocumentSymbol, false);
 				assert.strictEqual(second instanceof types.SymbolInformation, true);
-				assert.strictEqual(second instanceof types.DocumentSymbol, true);
 				assert.strictEqual(first.name, 'DocumentSymbol');
 				assert.strictEqual(first.children.length, 1);
 				assert.strictEqual(second.name, 'SymbolInformation');


### PR DESCRIPTION

For #253842

This reverts commit f91d77fc7c53659a5666d6f10979697942983071.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
