### PR TITLE
add editor a11y playwright tests

### DIFF
--- a/src/vs/editor/browser/controller/editContext/native/nativeEditContext.ts
+++ b/src/vs/editor/browser/controller/editContext/native/nativeEditContext.ts
@@ -90,6 +90,7 @@ export class NativeEditContext extends AbstractEditContext {
 		this._imeTextArea.setClassName(`ime-text-area`);
 		this._imeTextArea.setAttribute('readonly', 'true');
 		this._imeTextArea.setAttribute('tabindex', '-1');
+		this._imeTextArea.setAttribute('aria-hidden', 'true');
 		this.domNode.setAttribute('autocorrect', 'off');
 		this.domNode.setAttribute('autocapitalize', 'off');
 		this.domNode.setAttribute('autocomplete', 'off');

--- a/test/monaco/monaco.test.ts
+++ b/test/monaco/monaco.test.ts
@@ -157,10 +157,10 @@ describe('API Integration Tests', function (): void {
 			let violationCount = 0;
 			const checkedElements = new Set<string>();
 			const customReporter = {
-				async report(violations: Result[]) {
+				report(violations: Result[]) {
 					// Log failed elements
 					violations.forEach(v => {
-						v.nodes.forEach(node => {
+						v.nodes.forEach((node) => {
 							const selector = node.target?.join(' ');
 							if (selector) {
 								checkedElements.add(selector);
@@ -173,8 +173,8 @@ describe('API Integration Tests', function (): void {
 			};
 
 			// Run axe and get all results (passes and violations)
-			const axeResults = await page.evaluate(async () => {
-				return await window.axe.run(document, {
+			const axeResults = await page.evaluate(() => {
+				return window.axe.run(document, {
 					runOnly: {
 						type: 'tag',
 						values: ['wcag2a']
@@ -204,7 +204,7 @@ describe('API Integration Tests', function (): void {
 				includedImpacts: ['critical', 'serious'],
 				detailedReport: true,
 				detailedReportOptions: { html: true }
-			}, false, customReporter);
+			}, false);
 			playwright.expect(violationCount).toBe(0);
 		});
 		it('Monaco editor container should have an ARIA role', async () => {

--- a/test/monaco/monaco.test.ts
+++ b/test/monaco/monaco.test.ts
@@ -177,7 +177,7 @@ describe('API Integration Tests', function (): void {
 						console.log(`${emoji} FAIL: ${selector} - ${v.id} - ${v.description}`);
 					}
 				});
-				violationCount += 1;
+				violationCount += isCritical ? 1 : 0;
 			});
 
 

--- a/test/monaco/monaco.test.ts
+++ b/test/monaco/monaco.test.ts
@@ -5,7 +5,7 @@
 
 import * as playwright from '@playwright/test';
 import { assert } from 'chai';
-import { checkA11y } from 'axe-playwright';
+import { checkA11y, injectAxe } from 'axe-playwright';
 import type { Result } from 'axe-core';
 
 const PORT = 8563;
@@ -140,6 +140,7 @@ describe('API Integration Tests', function (): void {
 	describe('Accessibility', function (): void {
 		beforeEach(async () => {
 			await page.goto(APP);
+			await injectAxe(page);
 		});
 
 		it('Should not have critical accessibility violations', async () => {
@@ -193,7 +194,7 @@ describe('API Integration Tests', function (): void {
 			});
 
 			// Now run the actual checkA11y for test assertion and violation logging
-			await checkA11y(page, undefined, {
+			await checkA11y(page, document, {
 				axeOptions: {
 					runOnly: {
 						type: 'tag',

--- a/test/monaco/monaco.test.ts
+++ b/test/monaco/monaco.test.ts
@@ -174,10 +174,10 @@ describe('API Integration Tests', function (): void {
 			// Log failed elements
 			axeResults.violations.forEach((v: any) => {
 				const isCritical = v.impact === 'critical';
-				const emoji = isCritical ? '❌' : '⚠️ ';
+				const emoji = isCritical ? '❌' : undefined;
 				v.nodes.forEach((node: any) => {
 					const selector = node.target?.join(' ');
-					if (selector) {
+					if (selector && emoji) {
 						checkedElements.add(selector);
 						console.log(`${emoji} FAIL: ${selector} - ${v.id} - ${v.description}`);
 					}
@@ -191,7 +191,6 @@ describe('API Integration Tests', function (): void {
 					const selector = node.target?.join(' ');
 					if (selector && !checkedElements.has(selector)) {
 						checkedElements.add(selector);
-						console.log(`✅ PASS: ${selector} - ${pass.id} - ${pass.description}`);
 					}
 				});
 			});
@@ -214,10 +213,10 @@ describe('API Integration Tests', function (): void {
 
 			axeResults.violations.forEach((v: any) => {
 				const isCritical = v.impact === 'critical';
-				const emoji = isCritical ? '❌' : '⚠️ ';
+				const emoji = isCritical ? '❌' : undefined;
 				v.nodes.forEach((node: any) => {
 					const selector = node.target?.join(' ');
-					if (selector) {
+					if (selector && emoji) {
 						checkedElements.add(selector);
 						console.log(`${emoji} FAIL: ${selector} - ${v.id} - ${v.description}`);
 					}
@@ -230,7 +229,6 @@ describe('API Integration Tests', function (): void {
 					const selector = node.target?.join(' ');
 					if (selector && !checkedElements.has(selector)) {
 						checkedElements.add(selector);
-						console.log(`✅ PASS: ${selector} - ${pass.id} - ${pass.description}`);
 					}
 				});
 			});

--- a/test/monaco/monaco.test.ts
+++ b/test/monaco/monaco.test.ts
@@ -171,7 +171,6 @@ describe('API Integration Tests', function (): void {
 				});
 			});
 
-			// Log failed elements
 			axeResults.violations.forEach((v: any) => {
 				const isCritical = v.impact === 'critical';
 				const emoji = isCritical ? '❌' : undefined;
@@ -185,7 +184,6 @@ describe('API Integration Tests', function (): void {
 				violationCount += isCritical ? 1 : 0;
 			});
 
-			// Log passed elements
 			axeResults.passes.forEach((pass: any) => {
 				pass.nodes.forEach((node: any) => {
 					const selector = node.target?.join(' ');

--- a/test/monaco/monaco.test.ts
+++ b/test/monaco/monaco.test.ts
@@ -180,7 +180,7 @@ describe('API Integration Tests', function (): void {
 						values: ['wcag2a']
 					}
 				});
-			});
+			}, customReporter);
 
 			// Log passed elements
 			axeResults.passes.forEach((pass: any) => {

--- a/test/monaco/monaco.test.ts
+++ b/test/monaco/monaco.test.ts
@@ -140,18 +140,18 @@ describe('API Integration Tests', function (): void {
 		beforeEach(async () => {
 			await page.goto(APP);
 			await injectAxe(page);
+			await page.evaluate(`
+			(function () {
+				instance.focus();
+				instance.trigger('keyboard', 'cursorHome');
+				instance.trigger('keyboard', 'type', {
+					text: 'a'
+				});
+			})()
+			`);
 		});
 
 		it('Editor should not have critical accessibility violations', async () => {
-			await page.evaluate(`
-		(function () {
-			instance.focus();
-			instance.trigger('keyboard', 'cursorHome');
-			instance.trigger('keyboard', 'type', {
-				text: 'a'
-			});
-		})()
-		`);
 
 			let violationCount = 0;
 			const checkedElements = new Set<string>();
@@ -208,15 +208,6 @@ describe('API Integration Tests', function (): void {
 			playwright.expect(violationCount).toBe(0);
 		});
 		it('Monaco editor container should have an ARIA role', async () => {
-			await page.evaluate(`
-		(function () {
-			instance.focus();
-			instance.trigger('keyboard', 'cursorHome');
-			instance.trigger('keyboard', 'type', {
-				text: 'a'
-			});
-		})()
-		`);
 			const role = await page.evaluate(() => {
 				const container = document.querySelector('.monaco-editor');
 				return container?.getAttribute('role');
@@ -225,15 +216,6 @@ describe('API Integration Tests', function (): void {
 		});
 
 		it('Monaco editor should have an ARIA label', async () => {
-			await page.evaluate(`
-		(function () {
-			instance.focus();
-			instance.trigger('keyboard', 'cursorHome');
-			instance.trigger('keyboard', 'type', {
-				text: 'a'
-			});
-		})()
-		`);
 			const ariaLabel = await page.evaluate(() => {
 				const container = document.querySelector('.monaco-editor');
 				return container?.getAttribute('aria-label');
@@ -242,15 +224,6 @@ describe('API Integration Tests', function (): void {
 		});
 
 		it('All toolbar buttons should have accessible names', async () => {
-			await page.evaluate(`
-		(function () {
-			instance.focus();
-			instance.trigger('keyboard', 'cursorHome');
-			instance.trigger('keyboard', 'type', {
-				text: 'a'
-			});
-		})()
-		`);
 			const buttonsWithoutLabel = await page.evaluate(() => {
 				return Array.from(document.querySelectorAll('button')).filter(btn => {
 					const label = btn.getAttribute('aria-label') || btn.textContent?.trim();

--- a/test/monaco/package-lock.json
+++ b/test/monaco/package-lock.json
@@ -8,6 +8,9 @@
       "name": "test-monaco",
       "version": "1.0.0",
       "license": "MIT",
+      "dependencies": {
+        "axe-playwright": "^2.1.0"
+      },
       "devDependencies": {
         "@types/chai": "^4.2.14",
         "chai": "^4.2.0",
@@ -20,6 +23,12 @@
       "integrity": "sha512-G+ITQPXkwTrslfG5L/BksmbLUA0M1iybEsmCWPqzSxsRRhJZimBKJkoMi8fr/CPygPTj4zO5pJH7I2/cm9M7SQ==",
       "dev": true
     },
+    "node_modules/@types/junit-report-builder": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/junit-report-builder/-/junit-report-builder-3.0.2.tgz",
+      "integrity": "sha512-R5M+SYhMbwBeQcNXYWNCZkl09vkVfAtcPIaCGdzIkkbeaTrVbGQ7HVgi4s+EmM/M1K4ZuWQH0jGcvMvNePfxYA==",
+      "license": "MIT"
+    },
     "node_modules/assertion-error": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
@@ -27,6 +36,46 @@
       "dev": true,
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.10.3",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.10.3.tgz",
+      "integrity": "sha512-Xm7bpRXnDSX2YE2YFfBk2FnF0ep6tmG7xPh8iHee8MIcrgq762Nkce856dYtJYLkuIoYZvGfTs/PbZhideTcEg==",
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/axe-html-reporter": {
+      "version": "2.2.11",
+      "resolved": "https://registry.npmjs.org/axe-html-reporter/-/axe-html-reporter-2.2.11.tgz",
+      "integrity": "sha512-WlF+xlNVgNVWiM6IdVrsh+N0Cw7qupe5HT9N6Uyi+aN7f6SSi92RDomiP1noW8OWIV85V6x404m5oKMeqRV3tQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mustache": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=8.9.0"
+      },
+      "peerDependencies": {
+        "axe-core": ">=3"
+      }
+    },
+    "node_modules/axe-playwright": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/axe-playwright/-/axe-playwright-2.1.0.tgz",
+      "integrity": "sha512-tY48SX56XaAp16oHPyD4DXpybz8Jxdz9P7exTjF/4AV70EGUavk+1fUPWirM0OYBR+YyDx6hUeDvuHVA6fB9YA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/junit-report-builder": "^3.0.2",
+        "axe-core": "^4.10.1",
+        "axe-html-reporter": "2.2.11",
+        "junit-report-builder": "^5.1.1",
+        "picocolors": "^1.1.1"
+      },
+      "peerDependencies": {
+        "playwright": ">1.0.0"
       }
     },
     "node_modules/chai": {
@@ -77,6 +126,50 @@
         "node": "*"
       }
     },
+    "node_modules/junit-report-builder": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/junit-report-builder/-/junit-report-builder-5.1.1.tgz",
+      "integrity": "sha512-ZNOIIGMzqCGcHQEA2Q4rIQQ3Df6gSIfne+X9Rly9Bc2y55KxAZu8iGv+n2pP0bLf0XAOctJZgeloC54hWzCahQ==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.21",
+        "make-dir": "^3.1.0",
+        "xmlbuilder": "^15.1.1"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
+    },
+    "node_modules/make-dir": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mustache": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
+      "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
+      "license": "MIT",
+      "bin": {
+        "mustache": "bin/mustache"
+      }
+    },
     "node_modules/pathval": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
@@ -84,6 +177,21 @@
       "dev": true,
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
       }
     },
     "node_modules/type-detect": {
@@ -102,6 +210,15 @@
       "dev": true,
       "peerDependencies": {
         "webpack": "^2.2.0-rc || ^3 || ^4 || ^5"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "15.1.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
+      "integrity": "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0"
       }
     }
   }

--- a/test/monaco/package-lock.json
+++ b/test/monaco/package-lock.json
@@ -8,11 +8,9 @@
       "name": "test-monaco",
       "version": "1.0.0",
       "license": "MIT",
-      "dependencies": {
-        "axe-playwright": "^2.1.0"
-      },
       "devDependencies": {
         "@types/chai": "^4.2.14",
+        "axe-playwright": "^2.1.0",
         "chai": "^4.2.0",
         "warnings-to-errors-webpack-plugin": "^2.3.0"
       }
@@ -27,6 +25,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@types/junit-report-builder/-/junit-report-builder-3.0.2.tgz",
       "integrity": "sha512-R5M+SYhMbwBeQcNXYWNCZkl09vkVfAtcPIaCGdzIkkbeaTrVbGQ7HVgi4s+EmM/M1K4ZuWQH0jGcvMvNePfxYA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/assertion-error": {
@@ -42,6 +41,7 @@
       "version": "4.10.3",
       "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.10.3.tgz",
       "integrity": "sha512-Xm7bpRXnDSX2YE2YFfBk2FnF0ep6tmG7xPh8iHee8MIcrgq762Nkce856dYtJYLkuIoYZvGfTs/PbZhideTcEg==",
+      "dev": true,
       "license": "MPL-2.0",
       "engines": {
         "node": ">=4"
@@ -51,6 +51,7 @@
       "version": "2.2.11",
       "resolved": "https://registry.npmjs.org/axe-html-reporter/-/axe-html-reporter-2.2.11.tgz",
       "integrity": "sha512-WlF+xlNVgNVWiM6IdVrsh+N0Cw7qupe5HT9N6Uyi+aN7f6SSi92RDomiP1noW8OWIV85V6x404m5oKMeqRV3tQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mustache": "^4.0.1"
@@ -66,6 +67,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/axe-playwright/-/axe-playwright-2.1.0.tgz",
       "integrity": "sha512-tY48SX56XaAp16oHPyD4DXpybz8Jxdz9P7exTjF/4AV70EGUavk+1fUPWirM0OYBR+YyDx6hUeDvuHVA6fB9YA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/junit-report-builder": "^3.0.2",
@@ -130,6 +132,7 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/junit-report-builder/-/junit-report-builder-5.1.1.tgz",
       "integrity": "sha512-ZNOIIGMzqCGcHQEA2Q4rIQQ3Df6gSIfne+X9Rly9Bc2y55KxAZu8iGv+n2pP0bLf0XAOctJZgeloC54hWzCahQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.21",
@@ -144,12 +147,14 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/make-dir": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
       "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "semver": "^6.0.0"
@@ -165,6 +170,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
       "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "mustache": "bin/mustache"
@@ -183,12 +189,14 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/semver": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -216,6 +224,7 @@
       "version": "15.1.1",
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
       "integrity": "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.0"

--- a/test/monaco/package.json
+++ b/test/monaco/package.json
@@ -14,5 +14,8 @@
     "@types/chai": "^4.2.14",
     "chai": "^4.2.0",
     "warnings-to-errors-webpack-plugin": "^2.3.0"
+  },
+  "dependencies": {
+    "axe-playwright": "^2.1.0"
   }
 }

--- a/test/monaco/package.json
+++ b/test/monaco/package.json
@@ -12,10 +12,8 @@
   },
   "devDependencies": {
     "@types/chai": "^4.2.14",
+    "axe-playwright": "^2.1.0",
     "chai": "^4.2.0",
     "warnings-to-errors-webpack-plugin": "^2.3.0"
-  },
-  "dependencies": {
-    "axe-playwright": "^2.1.0"
   }
 }


### PR DESCRIPTION
Fixes #250767 

Uses https://www.npmjs.com/package/axe-playwright to verify that our editor elements are a11y compliant.

https://github.com/microsoft/vscode/blob/64bce31db1f63ef79df41b3fbdb3cccc03a1b605/test/monaco/monaco.test.ts#L159-L172

Also checks for color contrast:
https://github.com/microsoft/vscode/blob/64bce31db1f63ef79df41b3fbdb3cccc03a1b605/test/monaco/monaco.test.ts#L205-L213

For example, the checks showed that our `ime-text-area`, which is not meant to be discoverable to screen reader users, was missing a label. That actually needed `aria-hidden: true`, which I fixed.

<img width="1038" height="679" alt="Screenshot 2025-07-14 at 7 13 20 PM" src="https://github.com/user-attachments/assets/c3bcab9f-22e1-4500-b56b-eae8353195f8" />

Checks all of these things, verifying that none of the violations are `critical`. Note that I removed the ✅ and ⚠️ logs. It'll only log if there are `critical` violations ❌ .

<img width="1138" height="912" alt="Screenshot 2025-07-14 at 8 51 45 PM" src="https://github.com/user-attachments/assets/86d35e40-c839-4fee-8043-e718dcd9dafd" />
<img width="1147" height="442" alt="Screenshot 2025-07-14 at 8 52 00 PM" src="https://github.com/user-attachments/assets/02aeb8ce-73a4-4199-b159-e012cd4edb08" />

