### PR TITLE
only add listeners when enabled

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/contrib/troubleshoot/layout.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/troubleshoot/layout.ts
@@ -50,9 +50,8 @@ export class TroubleshootController extends Disposable implements INotebookEdito
 			return;
 		}
 
-		this._updateListener();
-
 		if (this._enabled) {
+			this._updateListener();
 			this._createNotebookOverlay();
 			this._createCellOverlays();
 		}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
Just add the listeners when enabled - everything is torn down and re-added when toggling the troubleshooter anyway.
My previous change made it so the overlay was being added for new cells when disabled.