### PR TITLE
Skip "breakpoints are available before accessing debug extension API"

### DIFF
--- a/extensions/vscode-api-tests/src/singlefolder-tests/debug.test.ts
+++ b/extensions/vscode-api-tests/src/singlefolder-tests/debug.test.ts
@@ -15,7 +15,7 @@ suite('vscode API - debug', function () {
 		await closeAllEditors();
 	});
 
-	test('breakpoints are available before accessing debug extension API', async () => {
+	test.skip('breakpoints are available before accessing debug extension API', async () => {
 		const file = await createRandomFile(undefined, undefined, '.js');
 		const doc = await workspace.openTextDocument(file);
 		await window.showTextDocument(doc);


### PR DESCRIPTION
See https://github.com/microsoft/vscode/issues/254039