### PR TITLE
Tighten up dom sanitizing rules

### DIFF
--- a/src/vs/base/browser/markdownRenderer.ts
+++ b/src/vs/base/browser/markdownRenderer.ts
@@ -419,8 +419,6 @@ export const allowedMarkdownHtmlAttributes = [
 	'class',
 	'colspan',
 	'controls',
-	'data-code',
-	'data-href',
 	'disabled',
 	'draggable',
 	'height',
@@ -437,17 +435,20 @@ export const allowedMarkdownHtmlAttributes = [
 	'width',
 	'start',
 
+	// Custom markdown attributes
+	'data-code',
+	'data-href',
+
 	// These attributes are sanitized in the hooks
 	'style',
 	'class',
 ];
 
 function getSanitizerOptions(options: IInternalSanitizerOptions): domSanitize.SanitizeOptions {
-	const allowedSchemes = [
+	const allowedLinkSchemes = [
 		Schemas.http,
 		Schemas.https,
 		Schemas.mailto,
-		Schemas.data,
 		Schemas.file,
 		Schemas.vscodeFileResource,
 		Schemas.vscodeRemote,
@@ -456,11 +457,11 @@ function getSanitizerOptions(options: IInternalSanitizerOptions): domSanitize.Sa
 	];
 
 	if (options.isTrusted) {
-		allowedSchemes.push(Schemas.command);
+		allowedLinkSchemes.push(Schemas.command);
 	}
 
 	if (options.allowedProductProtocols) {
-		allowedSchemes.push(...options.allowedProductProtocols);
+		allowedLinkSchemes.push(...options.allowedProductProtocols);
 	}
 
 	return {
@@ -468,9 +469,26 @@ function getSanitizerOptions(options: IInternalSanitizerOptions): domSanitize.Sa
 		// Since we have our own sanitize function for marked, it's possible we missed some tag so let dompurify make sure.
 		// HTML tags that can result from markdown are from reading https://spec.commonmark.org/0.29/
 		// HTML table tags that can result from markdown are from https://github.github.com/gfm/#tables-extension-
-		overrideAllowedTags: options.allowedTags ?? domSanitize.basicMarkupHtmlTags,
-		overrideAllowedAttributes: allowedMarkdownHtmlAttributes,
-		overrideAllowedProtocols: allowedSchemes,
+		allowedTags: {
+			override: options.allowedTags ?? domSanitize.basicMarkupHtmlTags
+		},
+		allowedAttributes: {
+			override: allowedMarkdownHtmlAttributes,
+		},
+		allowedLinkProtocols: {
+			override: allowedLinkSchemes,
+		},
+		allowedMediaProtocols: {
+			override: [
+				Schemas.http,
+				Schemas.https,
+				Schemas.data,
+				Schemas.file,
+				Schemas.vscodeFileResource,
+				Schemas.vscodeRemote,
+				Schemas.vscodeRemoteResource,
+			]
+		},
 		hooks: {
 			uponSanitizeAttribute: (element, e) => {
 				if (options.customAttrSanitizer) {

--- a/src/vs/base/test/browser/domSanitize.test.ts
+++ b/src/vs/base/test/browser/domSanitize.test.ts
@@ -6,6 +6,7 @@
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../common/utils.js';
 import { sanitizeHtml } from '../../browser/domSanitize.js';
 import * as assert from 'assert';
+import { Schemas } from '../../common/network.js';
 
 suite('DomSanitize', () => {
 
@@ -34,19 +35,26 @@ suite('DomSanitize', () => {
 	});
 
 	test('allows custom tags via config', () => {
-		const html = '<custom-tag>hello</custom-tag>';
-		const result = sanitizeHtml(html, {
-			overrideAllowedTags: ['custom-tag']
-		});
-		const str = result.toString();
-
-		assert.ok(str.includes('<custom-tag>hello</custom-tag>'));
+		{
+			const html = '<div>removed</div><custom-tag>hello</custom-tag>';
+			const result = sanitizeHtml(html, {
+				allowedTags: { override: ['custom-tag'] }
+			});
+			assert.strictEqual(result.toString(), 'removed<custom-tag>hello</custom-tag>');
+		}
+		{
+			const html = '<div>kept</div><augmented-tag>world</augmented-tag>';
+			const result = sanitizeHtml(html, {
+				allowedTags: { augment: ['augmented-tag'] }
+			});
+			assert.strictEqual(result.toString(), '<div>kept</div><augmented-tag>world</augmented-tag>');
+		}
 	});
 
 	test('allows custom attributes via config', () => {
 		const html = '<div custom-attr="value">content</div>';
 		const result = sanitizeHtml(html, {
-			overrideAllowedAttributes: ['custom-attr']
+			allowedAttributes: { override: ['custom-attr'] }
 		});
 		const str = result.toString();
 
@@ -98,7 +106,9 @@ suite('DomSanitize', () => {
 
 	test('allows data images when enabled', () => {
 		const html = '<img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==">';
-		const result = sanitizeHtml(html, { allowDataImages: true });
+		const result = sanitizeHtml(html, {
+			allowedMediaProtocols: { override: [Schemas.data] }
+		});
 		const str = result.toString();
 
 		assert.ok(str.includes('src="data:image/png;base64,'));

--- a/src/vs/workbench/contrib/issue/browser/issueFormService.ts
+++ b/src/vs/workbench/contrib/issue/browser/issueFormService.ts
@@ -93,7 +93,23 @@ export class IssueFormService implements IIssueFormService {
 			// removes preset monaco-workbench
 			auxiliaryWindow.container.remove();
 			auxiliaryWindow.window.document.body.appendChild(div);
-			safeInnerHtml(div, BaseHtml());
+			safeInnerHtml(div, BaseHtml(), {
+				// Also allow input elements
+				allowedTags: {
+					augment: [
+						'input',
+						'select',
+						'checkbox',
+					]
+				},
+				allowedAttributes: {
+					augment: [
+						'id',
+						'class',
+						'style',
+					]
+				}
+			});
 
 			this.issueReporterWindow = auxiliaryWindow.window;
 		} else {

--- a/src/vs/workbench/contrib/markdown/browser/markdownDocumentRenderer.ts
+++ b/src/vs/workbench/contrib/markdown/browser/markdownDocumentRenderer.ts
@@ -163,20 +163,28 @@ const allowedProtocols = [
 ];
 
 function sanitize(documentContent: string, allowAllProtocols = false): TrustedHTML {
+	// TODO: Move most of these options to the callers
 	return sanitizeHtml(documentContent, {
-		overrideAllowedProtocols: allowAllProtocols ? '*' : allowedProtocols,
-		overrideAllowedTags: [
-			...basicMarkupHtmlTags,
-			'input',
-			'checkbox',
-			'checklist',
-		],
-		overrideAllowedAttributes: [
-			...allowedMarkdownHtmlAttributes,
-			'data-command', 'name', 'id', 'role', 'tabindex',
-			'x-dispatch',
-			'required', 'checked', 'placeholder', 'when-checked', 'checked-on',
-		],
+		allowedLinkProtocols: {
+			override: allowAllProtocols ? '*' : allowedProtocols,
+		},
+		allowedTags: {
+			override: [
+				...basicMarkupHtmlTags,
+				'input',
+				'select',
+				'checkbox',
+				'checklist',
+			],
+		},
+		allowedAttributes: {
+			override: [
+				...allowedMarkdownHtmlAttributes,
+				'data-command', 'name', 'id', 'role', 'tabindex',
+				'x-dispatch',
+				'required', 'checked', 'placeholder', 'when-checked', 'checked-on',
+			],
+		}
 	});
 }
 

--- a/src/vs/workbench/contrib/welcomeWalkthrough/browser/walkThroughPart.ts
+++ b/src/vs/workbench/contrib/welcomeWalkthrough/browser/walkThroughPart.ts
@@ -33,7 +33,7 @@ import { OS, OperatingSystem } from '../../../../base/common/platform.js';
 import { deepClone } from '../../../../base/common/objects.js';
 import { INotificationService } from '../../../../platform/notification/common/notification.js';
 import { addDisposableListener, Dimension, isHTMLAnchorElement, isHTMLButtonElement, isHTMLElement, size } from '../../../../base/browser/dom.js';
-import { safeInnerHtml } from '../../../../base/browser/domSanitize.js';
+import * as domSanitize from '../../../../base/browser/domSanitize.js';
 import { IEditorGroup, IEditorGroupsService } from '../../../services/editor/common/editorGroupsService.js';
 import { CancellationToken } from '../../../../base/common/cancellation.js';
 import { IExtensionService } from '../../../services/extensions/common/extensions.js';
@@ -288,7 +288,7 @@ export class WalkThroughPart extends EditorPane {
 
 				const content = model.main;
 				if (!input.resource.path.endsWith('.md')) {
-					safeInnerHtml(this.content, content);
+					this.safeSetInnerHtml(this.content, content);
 
 					this.updateSizeClasses();
 					this.decorateContent();
@@ -303,7 +303,7 @@ export class WalkThroughPart extends EditorPane {
 				const innerContent = document.createElement('div');
 				innerContent.classList.add('walkThroughContent'); // only for markdown files
 				const markdown = this.expandMacros(content);
-				safeInnerHtml(innerContent, markdown);
+				this.safeSetInnerHtml(innerContent, markdown);
 				this.content.appendChild(innerContent);
 
 				model.snippets.forEach((snippet, i) => {
@@ -378,6 +378,20 @@ export class WalkThroughPart extends EditorPane {
 				this.contentDisposables.push(Gesture.addTarget(innerContent));
 				this.contentDisposables.push(addDisposableListener(innerContent, TouchEventType.Change, e => this.onTouchChange(e as GestureEvent)));
 			});
+	}
+
+	private safeSetInnerHtml(node: HTMLElement, content: string) {
+		domSanitize.safeInnerHtml(node, content, {
+			allowedAttributes: {
+				augment: [
+					'id',
+					'class',
+					'style',
+					'data-command',
+					'data-href',
+				]
+			}
+		});
 	}
 
 	private getEditorOptions(language: string): ICodeEditorOptions {


### PR DESCRIPTION
This change adds restrictions to our dom sanitizer rules. The goal is to make the core set of rules more restrictive and require callers to opt into more permissive options

Main changes:

- Remove input tags being allowed by default
- Remove id, class, and style attrs being allowed by default
- Remove some markdown specific / custom attributes from the default list
- Split up link/media allowed commands
- Restructure api to make it more clear how you can override or augment tags/attrs


