### PR TITLE
Simplify api for rendered markdown

### DIFF
--- a/src/vs/base/browser/formattedTextRenderer.ts
+++ b/src/vs/base/browser/formattedTextRenderer.ts
@@ -14,30 +14,20 @@ export interface IContentActionHandler {
 }
 
 export interface FormattedTextRenderOptions {
-	readonly className?: string;
-	readonly inline?: boolean;
 	readonly actionHandler?: IContentActionHandler;
 	readonly renderCodeSegments?: boolean;
 }
 
-export function renderText(text: string, options: FormattedTextRenderOptions = {}): HTMLElement {
-	const element = createElement(options);
+export function renderText(text: string, _options?: FormattedTextRenderOptions, target?: HTMLElement): HTMLElement {
+	const element = target ?? document.createElement('div');
 	element.textContent = text;
 	return element;
 }
 
-export function renderFormattedText(formattedText: string, options: FormattedTextRenderOptions = {}): HTMLElement {
-	const element = createElement(options);
-	_renderFormattedText(element, parseFormattedText(formattedText, !!options.renderCodeSegments), options.actionHandler, options.renderCodeSegments);
-	return element;
-}
-
-export function createElement(options: FormattedTextRenderOptions): HTMLElement {
-	const tagName = options.inline ? 'span' : 'div';
-	const element = document.createElement(tagName);
-	if (options.className) {
-		element.className = options.className;
-	}
+export function renderFormattedText(formattedText: string, options?: FormattedTextRenderOptions, target?: HTMLElement): HTMLElement {
+	const element = target ?? document.createElement('div');
+	element.textContent = '';
+	_renderFormattedText(element, parseFormattedText(formattedText, !!options?.renderCodeSegments), options?.actionHandler, options?.renderCodeSegments);
 	return element;
 }
 

--- a/src/vs/base/browser/ui/button/button.ts
+++ b/src/vs/base/browser/ui/button/button.ts
@@ -237,7 +237,7 @@ export class Button extends Disposable implements IButton {
 		const labelElement = this.options.supportShortLabel ? this._labelElement! : this._element;
 
 		if (isMarkdownString(value)) {
-			const rendered = renderMarkdown(value, { inline: true });
+			const rendered = renderMarkdown(value, undefined, document.createElement('span'));
 			rendered.dispose();
 
 			// Don't include outer `<p>`
@@ -641,7 +641,7 @@ export class ButtonWithIcon extends Button {
 
 		this._element.classList.add('monaco-text-button');
 		if (isMarkdownString(value)) {
-			const rendered = renderMarkdown(value, { inline: true });
+			const rendered = renderMarkdown(value, undefined, document.createElement('span'));
 			rendered.dispose();
 
 			const root = rendered.element.querySelector('p')?.innerHTML;

--- a/src/vs/base/browser/ui/inputbox/inputBox.ts
+++ b/src/vs/base/browser/ui/inputbox/inputBox.ts
@@ -8,7 +8,6 @@ import * as cssJs from '../../cssValue.js';
 import { DomEmitter } from '../../event.js';
 import { renderFormattedText, renderText } from '../../formattedTextRenderer.js';
 import { IHistoryNavigationWidget } from '../../history.js';
-import { MarkdownRenderOptions } from '../../markdownRenderer.js';
 import { ActionBar } from '../actionbar/actionbar.js';
 import * as aria from '../aria/aria.js';
 import { AnchorAlignment, IContextViewProvider } from '../contextview/contextview.js';
@@ -485,14 +484,14 @@ export class InputBox extends Widget {
 				div = dom.append(container, $('.monaco-inputbox-container'));
 				layout();
 
-				const renderOptions: MarkdownRenderOptions = {
-					inline: true,
-					className: 'monaco-inputbox-message'
-				};
 
-				const spanElement = (this.message.formatContent
-					? renderFormattedText(this.message.content!, renderOptions)
-					: renderText(this.message.content!, renderOptions));
+				const spanElement = $('span.monaco-inputbox-message');
+				if (this.message.formatContent) {
+					renderFormattedText(this.message.content!, undefined, spanElement);
+				} else {
+					renderText(this.message.content!, undefined, spanElement);
+				}
+
 				spanElement.classList.add(this.classForType(this.message.type));
 
 				const styles = this.stylesForType(this.message.type);

--- a/src/vs/base/test/browser/formattedTextRenderer.test.ts
+++ b/src/vs/base/test/browser/formattedTextRenderer.test.ts
@@ -7,6 +7,7 @@ import assert from 'assert';
 import { renderFormattedText, renderText } from '../../browser/formattedTextRenderer.js';
 import { DisposableStore } from '../../common/lifecycle.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../common/utils.js';
+import { $ } from '../../browser/dom.js';
 
 suite('FormattedTextRenderer', () => {
 	const store = new DisposableStore();
@@ -27,11 +28,11 @@ suite('FormattedTextRenderer', () => {
 		assert.strictEqual(result.tagName, 'DIV');
 	});
 
-	test('render element with class', () => {
-		const result: HTMLElement = renderText('testing', {
-			className: 'testClass'
-		});
+	test('render element with target', () => {
+		const target = $('div.testClass');
+		const result = renderText('testing', {}, target);
 		assert.strictEqual(result.nodeType, document.ELEMENT_NODE);
+		assert.strictEqual(result, target);
 		assert.strictEqual(result.className, 'testClass');
 	});
 

--- a/src/vs/editor/browser/widget/markdownRenderer/browser/markdownRenderer.ts
+++ b/src/vs/editor/browser/widget/markdownRenderer/browser/markdownRenderer.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { MarkdownRenderOptions, MarkedOptions, renderMarkdown } from '../../../../../base/browser/markdownRenderer.js';
+import { MarkdownRenderOptions, renderMarkdown } from '../../../../../base/browser/markdownRenderer.js';
 import { createTrustedTypesPolicy } from '../../../../../base/browser/trustedTypes.js';
 import { onUnexpectedError } from '../../../../../base/common/errors.js';
 import { IMarkdownString, MarkdownStringTrustedOptions } from '../../../../../base/common/htmlContent.js';
@@ -45,14 +45,14 @@ export class MarkdownRenderer {
 		@IOpenerService private readonly _openerService: IOpenerService,
 	) { }
 
-	render(markdown: IMarkdownString | undefined, options?: MarkdownRenderOptions, markedOptions?: MarkedOptions, outElement?: HTMLElement): IMarkdownRenderResult {
+	render(markdown: IMarkdownString | undefined, options?: MarkdownRenderOptions, outElement?: HTMLElement): IMarkdownRenderResult {
 		if (!markdown) {
 			const element = outElement ?? document.createElement('span');
 			return { element, dispose: () => { } };
 		}
 
 		const disposables = new DisposableStore();
-		const rendered = disposables.add(renderMarkdown(markdown, { ...this._getRenderOptions(markdown, disposables), ...options }, markedOptions, outElement));
+		const rendered = disposables.add(renderMarkdown(markdown, { ...this._getRenderOptions(markdown, disposables), ...options }, outElement));
 		rendered.element.classList.add('rendered-markdown');
 		return {
 			element: rendered.element,

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/chatMarkdownContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/chatMarkdownContentPart.ts
@@ -234,7 +234,8 @@ export class ChatMarkdownContentPart extends Disposable implements IChatContentP
 					}
 				},
 				asyncRenderCallback: () => this._onDidChangeHeight.fire(),
-			}, markedOpts, this.domNode));
+				markedOptions: markedOpts,
+			}, this.domNode));
 
 			const markdownDecorationsRenderer = instantiationService.createInstance(ChatMarkdownDecorationsRenderer);
 			this._register(markdownDecorationsRenderer.walkTreeAndAnnotateReferenceLinks(markdown, result.element));

--- a/src/vs/workbench/contrib/chat/browser/chatListRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatListRenderer.ts
@@ -612,15 +612,13 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 		if (element.agentOrSlashCommandDetected) {
 			const msg = element.slashCommand ? localize('usedAgentSlashCommand', "used {0} [[(rerun without)]]", `${chatSubcommandLeader}${element.slashCommand.name}`) : localize('usedAgent', "[[(rerun without)]]");
 			dom.reset(templateData.detail, renderFormattedText(msg, {
-				className: 'agentOrSlashCommandDetected',
-				inline: true,
 				actionHandler: {
 					disposables: templateData.elementDisposables,
 					callback: (content) => {
 						this._onDidClickRerunWithAgentOrCommandDetection.fire(element);
 					},
 				}
-			}));
+			}, $('span.agentOrSlashCommandDetected')));
 
 		} else if (this.rendererOptions.renderStyle !== 'minimal' && !element.isComplete && !checkModeOption(this.delegate.currentChatMode(), this.rendererOptions.progressMessageAtBottomOfResponse)) {
 			if (element.model.isPaused.get()) {

--- a/src/vs/workbench/contrib/chat/browser/chatMarkdownRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatMarkdownRenderer.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { $ } from '../../../../base/browser/dom.js';
-import { MarkdownRenderOptions, MarkedOptions } from '../../../../base/browser/markdownRenderer.js';
+import { MarkdownRenderOptions } from '../../../../base/browser/markdownRenderer.js';
 import { getDefaultHoverDelegate } from '../../../../base/browser/ui/hover/hoverDelegateFactory.js';
 import { IMarkdownString } from '../../../../base/common/htmlContent.js';
 import { DisposableStore } from '../../../../base/common/lifecycle.js';
@@ -70,7 +70,7 @@ export class ChatMarkdownRenderer extends MarkdownRenderer {
 		super(options ?? {}, languageService, openerService);
 	}
 
-	override render(markdown: IMarkdownString | undefined, options?: MarkdownRenderOptions, markedOptions?: MarkedOptions, outElement?: HTMLElement): IMarkdownRenderResult {
+	override render(markdown: IMarkdownString | undefined, options?: MarkdownRenderOptions, outElement?: HTMLElement): IMarkdownRenderResult {
 		options = {
 			...options,
 			remoteImageIsAllowed: (_uri) => false,
@@ -91,7 +91,7 @@ export class ChatMarkdownRenderer extends MarkdownRenderer {
 				value: `<body>\n\n${markdown.value}</body>`,
 			}
 			: markdown;
-		const result = super.render(mdWithBody, options, markedOptions, outElement);
+		const result = super.render(mdWithBody, options, outElement);
 
 		// In some cases, the renderer can return text that is not inside a <p>,
 		// but our CSS expects text to be in a <p> for margin to be applied properly.

--- a/src/vs/workbench/contrib/comments/browser/commentsTreeViewer.ts
+++ b/src/vs/workbench/contrib/comments/browser/commentsTreeViewer.ts
@@ -248,12 +248,11 @@ export class CommentNodeRenderer implements IListRenderer<ITreeNode<CommentNode>
 
 	private getRenderedComment(commentBody: IMarkdownString, disposables: DisposableStore) {
 		const renderedComment = renderMarkdown(commentBody, {
-			inline: true,
 			actionHandler: {
 				callback: (link) => openLinkFromMarkdown(this.openerService, link, commentBody.isTrusted),
 				disposables: disposables
 			}
-		});
+		}, document.createElement('span'));
 		const images = renderedComment.element.getElementsByTagName('img');
 		for (let i = 0; i < images.length; i++) {
 			const image = images[i];

--- a/src/vs/workbench/contrib/markdown/test/browser/markdownKatexSupport.test.ts
+++ b/src/vs/workbench/contrib/markdown/test/browser/markdownKatexSupport.test.ts
@@ -20,9 +20,10 @@ suite('Markdown Katex Support Test', () => {
 			sanitizerOptions: MarkedKatexSupport.getSanitizerOptions({
 				allowedTags: basicMarkupHtmlTags,
 				allowedAttributes: defaultAllowedAttrs,
-			})
-		}, {
-			markedExtensions: [katex],
+			}),
+			markedOptions: {
+				markedExtensions: [katex],
+			}
 		}));
 		return rendered;
 	}

--- a/src/vs/workbench/contrib/testing/browser/testingExplorerView.ts
+++ b/src/vs/workbench/contrib/testing/browser/testingExplorerView.ts
@@ -1475,7 +1475,7 @@ class ErrorRenderer implements ITreeRenderer<TestTreeErrorMessage, FuzzyScore, I
 		if (typeof element.message === 'string') {
 			data.label.innerText = element.message;
 		} else {
-			const result = this.renderer.render(element.message, { inline: true });
+			const result = this.renderer.render(element.message, undefined, document.createElement('span'));
 			data.label.appendChild(result.element);
 		}
 		data.disposable.add(this.hoverService.setupManagedHover(getDefaultHoverDelegate('mouse'), data.label, element.description));

--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.ts
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.ts
@@ -1394,7 +1394,7 @@ export class GettingStartedPage extends EditorPane {
 						const labelWithIcon = renderLabelWithIcons(node);
 						for (const element of labelWithIcon) {
 							if (typeof element === 'string') {
-								p.appendChild(renderFormattedText(element, { inline: true, renderCodeSegments: true }));
+								p.appendChild(renderFormattedText(element, { renderCodeSegments: true }, $('span')));
 							} else {
 								p.appendChild(element);
 							}


### PR DESCRIPTION
- Replace `inline/className` with optional `target` node. This lets callers avoid creating extra hierarchy and have more control over where the md is rendered

- Move marked options into main options bag

