### PR TITLE
Support the locale argument of TypeScript language server on the web version (#256252)

### DIFF
--- a/extensions/typescript-language-features/web/src/pathMapper.ts
+++ b/extensions/typescript-language-features/web/src/pathMapper.ts
@@ -16,7 +16,7 @@ export class PathMapper {
 	 * Copied from toResource in typescriptServiceClient.ts
 	 */
 	toResource(filepath: string): URI {
-		if (looksLikeLibDtsPath(filepath)) {
+		if (looksLikeLibDtsPath(filepath) || looksLikeLocaleResourcePath(filepath)) {
 			return URI.from({
 				scheme: this.extensionUri.scheme,
 				authority: this.extensionUri.authority,
@@ -81,6 +81,10 @@ export function fromResource(extensionUri: URI, uri: URI) {
 
 export function looksLikeLibDtsPath(filepath: string) {
 	return filepath.startsWith('/lib.') && filepath.endsWith('.d.ts');
+}
+
+export function looksLikeLocaleResourcePath(filepath: string) {
+	return !!filepath.match(/^\/[a-zA-Z]+(-[a-zA-Z]+)?\/diagnosticMessages\.generated\.json$/);
 }
 
 export function looksLikeNodeModules(filepath: string) {

--- a/extensions/typescript-language-features/web/src/webServer.ts
+++ b/extensions/typescript-language-features/web/src/webServer.ts
@@ -41,6 +41,12 @@ async function initializeSession(
 		removeEventListener('message', listener);
 	});
 	setSys(sys);
+
+	const localeStr = findArgument(args, '--locale');
+	if (localeStr) {
+		ts.validateLocaleAndSetLanguage(localeStr, sys);
+	}
+
 	startWorkerSession(ts, sys, fs, sessionOptions, ports.tsserver, pathMapper, logger);
 }
 


### PR DESCRIPTION
This PR fixes #256252 by mimicing the [process of applying the locale](https://github.com/microsoft/TypeScript/blob/65cb4bd2d52cd882f2c3a503681479eb2ed291ca/src/tsserver/nodeServer.ts#L280-L283) in the Node.js version of tsserver. Moreover, the locale-dependent JSON files happen to share similar mapped path with `.d.ts` files in tsdk, so I added a pedantic path check to allowing remapping the path.
