### PR TITLE
tools: update tools of a chat request when they change

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadChatAgents2.ts
+++ b/src/vs/workbench/api/browser/mainThreadChatAgents2.ts
@@ -174,6 +174,9 @@ export class MainThreadChatAgents2 extends Disposable implements MainThreadChatA
 					this._pendingProgress.delete(request.requestId);
 				}
 			},
+			setRequestTools: (requestId, tools) => {
+				this._proxy.$setRequestTools(requestId, tools);
+			},
 			setRequestPaused: (requestId, isPaused) => {
 				this._proxy.$setRequestPaused(handle, requestId, isPaused);
 			},

--- a/src/vs/workbench/api/common/extHost.api.impl.ts
+++ b/src/vs/workbench/api/common/extHost.api.impl.ts
@@ -1551,6 +1551,10 @@ export function createApiFactoryAndRegisterActors(accessor: ServicesAccessor): I
 			},
 			registerMcpServerDefinitionProvider(id, provider) {
 				return extHostMcp.registerMcpConfigurationProvider(extension, id, provider);
+			},
+			onDidChangeChatRequestTools(...args) {
+				checkProposedApiEnabled(extension, 'chatParticipantAdditions');
+				return _asExtensionEvent(extHostChatAgents2.onDidChangeChatRequestTools)(...args);
 			}
 		};
 

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -1371,6 +1371,7 @@ export interface ExtHostChatAgentsShape2 {
 	$releaseSession(sessionId: string): void;
 	$detectChatParticipant(handle: number, request: Dto<IChatAgentRequest>, context: { history: IChatAgentHistoryEntryDto[] }, options: { participants: IChatParticipantMetadata[]; location: ChatAgentLocation }, token: CancellationToken): Promise<IChatParticipantDetectionResult | null | undefined>;
 	$provideRelatedFiles(handle: number, request: Dto<IChatRequestDraft>, token: CancellationToken): Promise<Dto<IChatRelatedFile>[] | undefined>;
+	$setRequestTools(requestId: string, tools: Pick<IChatAgentRequest, 'userSelectedTools'>): void;
 }
 export interface IChatParticipantMetadata {
 	participant: string;

--- a/src/vs/workbench/contrib/chat/browser/chatSelectedTools.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSelectedTools.ts
@@ -166,9 +166,8 @@ export class ChatSelectedTools extends Disposable {
 		await this._instantiationService.createInstance(PromptFileRewriter).openAndRewriteTools(uri, enablementMap, CancellationToken.None);
 	}
 
-	asEnablementMap(): Map<IToolData, boolean> {
+	public readonly enablementMap: IObservable<ReadonlyMap<IToolData, boolean>> = this.entriesMap.map((map, r) => {
 		const result = new Map<IToolData, boolean>();
-		const map = this.entriesMap.get();
 
 		const _set = (tool: IToolData, enabled: boolean) => {
 			// ONLY disable a tool that isn't enabled yet
@@ -180,7 +179,7 @@ export class ChatSelectedTools extends Disposable {
 
 		for (const [item, enabled] of map) {
 			if (item instanceof ToolSet) {
-				for (const tool of item.getTools()) {
+				for (const tool of item.getTools(r)) {
 					// Tools from an mcp tool set are explicitly enabled/disabled under the tool set.
 					// Other toolsets don't show individual tools under the tool set and enablement just follows the toolset.
 					const toolEnabled = item.source.type === 'mcp' ?
@@ -195,5 +194,5 @@ export class ChatSelectedTools extends Disposable {
 			}
 		}
 		return result;
-	}
+	});
 }

--- a/src/vs/workbench/contrib/chat/browser/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatWidget.ts
@@ -1748,18 +1748,16 @@ export class ChatWidget extends Disposable implements IChatWidget {
 		return undefined;
 	}
 
-	getUserSelectedTools(): Record<string, boolean> | undefined {
-		const userSelectedTools: Record<string, boolean> = {};
-		for (const [tool, enablement] of this.input.selectedToolsModel.asEnablementMap()) {
-			userSelectedTools[tool.id] = enablement;
-		}
-		return userSelectedTools;
-	}
-
 	getModeRequestOptions(): Partial<IChatSendRequestOptions> {
 		return {
 			modeInstructions: this.input.currentModeObs.get().body?.get(),
-			userSelectedTools: this.getUserSelectedTools(),
+			userSelectedTools: this.input.selectedToolsModel.enablementMap.map(map => {
+				const userSelectedTools: Record<string, boolean> = {};
+				for (const [tool, enablement] of map) {
+					userSelectedTools[tool.id] = enablement;
+				}
+				return userSelectedTools;
+			}),
 			mode: this.input.currentModeKind,
 		};
 	}
@@ -1998,7 +1996,8 @@ export class ChatWidget extends Disposable implements IChatWidget {
 	 */
 	private async _autoAttachInstructions({ attachedContext }: IChatRequestInputOptions): Promise<void> {
 		let readFileTool = this.toolsService.getToolByName('readFile');
-		if (readFileTool && this.getUserSelectedTools()?.[readFileTool.id] === false) {
+		const enablementMap = this.input.selectedToolsModel.enablementMap.get();
+		if (readFileTool && Iterable.some(enablementMap, ([tool, enabled]) => tool.id === readFileTool!.id && enabled === false)) {
 			readFileTool = undefined;
 		}
 

--- a/src/vs/workbench/contrib/chat/common/chatService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService.ts
@@ -510,7 +510,7 @@ export type IChatLocationData = IChatEditorLocationData | IChatNotebookLocationD
 export interface IChatSendRequestOptions {
 	mode?: ChatModeKind;
 	userSelectedModelId?: string;
-	userSelectedTools?: Record<string, boolean>;
+	userSelectedTools?: IObservable<Record<string, boolean>>;
 	modeInstructions?: string;
 	location?: ChatAgentLocation;
 	locationData?: IChatLocationData;

--- a/src/vs/workbench/contrib/chat/test/browser/chatSelectedTools.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/chatSelectedTools.test.ts
@@ -107,7 +107,7 @@ suite('ChatSelectedTools', () => {
 			const toSet = new Map<IToolData | ToolSet, boolean>([[toolData1, true], [toolData2, false], [toolData3, false], [toolset, true]]);
 			selectedTools.set(toSet, false);
 
-			const map = selectedTools.asEnablementMap();
+			const map = selectedTools.enablementMap.get();
 			assert.strictEqual(map.size, 3); // 3 tools
 
 			assert.strictEqual(map.get(toolData1), true);
@@ -172,7 +172,7 @@ suite('ChatSelectedTools', () => {
 			const toSet = new Map<IToolData | ToolSet, boolean>([[toolData1, true], [toolData2, false], [toolData3, false], [toolset, true]]);
 			selectedTools.set(toSet, false);
 
-			const map = selectedTools.asEnablementMap();
+			const map = selectedTools.enablementMap.get();
 			assert.strictEqual(map.size, 3); // 3 tools
 
 			// User toolset is enabled - all tools are enabled

--- a/src/vs/workbench/contrib/chat/test/common/voiceChatService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/voiceChatService.test.ts
@@ -46,6 +46,8 @@ suite('VoiceChat', () => {
 		provideFollowups?(request: IChatAgentRequest, result: IChatAgentResult, history: IChatAgentHistoryEntry[], token: CancellationToken): Promise<IChatFollowup[]> {
 			throw new Error('Method not implemented.');
 		}
+		setRequestTools(requestId: string, tools: Pick<IChatAgentRequest, 'userSelectedTools'>): void {
+		}
 		invoke(request: IChatAgentRequest, progress: (part: IChatProgress[]) => void, history: IChatAgentHistoryEntry[], token: CancellationToken): Promise<IChatAgentResult> { throw new Error('Method not implemented.'); }
 		metadata = {};
 	}
@@ -66,6 +68,7 @@ suite('VoiceChat', () => {
 		registerAgentImplementation(id: string, agent: IChatAgentImplementation): IDisposable { throw new Error(); }
 		registerDynamicAgent(data: IChatAgentData, agentImpl: IChatAgentImplementation): IDisposable { throw new Error('Method not implemented.'); }
 		invokeAgent(id: string, request: IChatAgentRequest, progress: (part: IChatProgress[]) => void, history: IChatAgentHistoryEntry[], token: CancellationToken): Promise<IChatAgentResult> { throw new Error(); }
+		setRequestTools(agent: string, requestId: string, tools: Pick<IChatAgentRequest, 'userSelectedTools'>): void { }
 		setRequestPaused(agent: string, requestId: string, isPaused: boolean): void { throw new Error('not implemented'); }
 		getFollowups(id: string, request: IChatAgentRequest, result: IChatAgentResult, history: IChatAgentHistoryEntry[], token: CancellationToken): Promise<IChatFollowup[]> { throw new Error(); }
 		getActivatedAgents(): IChatAgent[] { return agents; }

--- a/src/vs/workbench/contrib/mcp/node/mcpStdioStateHandler.ts
+++ b/src/vs/workbench/contrib/mcp/node/mcpStdioStateHandler.ts
@@ -46,13 +46,16 @@ export class McpStdioStateHandler implements IDisposable {
 	 */
 	public stop(): void {
 		if (this._procState === McpProcessState.Running) {
+			let graceTime = this._graceTimeMs;
 			try {
 				this._child.stdin.end();
 			} catch (error) {
 				// If stdin.end() fails, continue with termination sequence
 				// This can happen if the stream is already in an error state
+				graceTime = 1;
 			}
-			this._nextTimeout = new TimeoutTimer(() => this.killPolite(), this._graceTimeMs);
+			this._procState = McpProcessState.StdinEnded;
+			this._nextTimeout = new TimeoutTimer(() => this.killPolite(), graceTime);
 		} else {
 			this._nextTimeout?.dispose();
 			this.killForceful();

--- a/src/vscode-dts/vscode.proposed.chatParticipantAdditions.d.ts
+++ b/src/vscode-dts/vscode.proposed.chatParticipantAdditions.d.ts
@@ -258,6 +258,13 @@ declare module 'vscode' {
 		readonly tools: Map<string, boolean>;
 	}
 
+	export namespace lm {
+		/**
+		 * Fired when the set of tools on a chat request changes.
+		 */
+		export const onDidChangeChatRequestTools: Event<ChatRequest>;
+	}
+
 	// TODO@API fit this into the stream
 	export interface ChatUsedContext {
 		documents: ChatDocumentContext[];


### PR DESCRIPTION
Makes the `userSelectedTools` passed into the chat agent service
observable such that the tools of the ongoing request update as new
tools come in. The benefit of this versus other (previous) approaches
is that it reflects the enablement/disablement state of the picker
(which is likely to get additional controls in the future) and works
without special tagging.

@roblourens / @DonJayamanne I think with this we can get rid of

https://github.com/microsoft/vscode-copilot-chat/blob/0d6f5516d2fef455340228fd7bc34a4f501725d3/src/extension/tools/vscode-node/toolsService.ts#L118-L122

which was added for Jupyter iirc.

Closes #254684

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
