### PR TITLE
`copilot-instructions.md` not added when `chat.promptFiles` is disabled

### DIFF
--- a/src/vs/workbench/contrib/chat/common/promptSyntax/computeAutomaticInstructions.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/computeAutomaticInstructions.ts
@@ -81,6 +81,17 @@ export class ComputeAutomaticInstructions {
 
 	}
 
+	public async collectCopilotInstructionsOnly(variables: ChatRequestVariableSet, token: CancellationToken): Promise<void> {
+		const copilotInstructions = await this._getCopilotInstructions();
+		for (const entry of copilotInstructions) {
+			variables.add(entry);
+		}
+		this._logService.trace(`[InstructionsContextComputer]  ${copilotInstructions.length} Copilot instructions files added.`);
+		// add all instructions for all instruction files that are in the context
+		await this._addReferencedInstructions(variables, token);
+		return;
+	}
+
 	/** public for testing */
 	public async findInstructionFilesFor(instructionFiles: readonly IPromptPath[], context: { files: ResourceSet; instructions: ResourceSet }, token: CancellationToken): Promise<IPromptFileVariableEntry[]> {
 


### PR DESCRIPTION
There's been a change in 1.102 in that github.copilot.chat.codeGeneration.useInstructionFiles is only used if also chat.promptFiles is set.
That causes that many users that are in an organization that turned on the ChatPromptFiles  policy no longer get the .github/copilot-instructions.md files
Fix is coming for 1.102.2

Fixes https://github.com/microsoft/vscode/issues/255742