### PR TITLE
Prefix all provider IDs with core/ext/lsp

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadTerminalService.ts
+++ b/src/vs/workbench/api/browser/mainThreadTerminalService.ts
@@ -279,7 +279,10 @@ export class MainThreadTerminalService implements MainThreadTerminalServiceShape
 			provideCompletions: async (commandLine, cursorPosition, allowFallbackCompletions, token) => {
 				const completions = await this._proxy.$provideTerminalCompletions(id, { commandLine, cursorPosition, allowFallbackCompletions }, token);
 				return {
-					items: completions?.items.map(c => ({ ...c, provider: id })),
+					items: completions?.items.map(c => ({
+						provider: `ext:${id}`,
+						...c,
+					})),
 					resourceRequestConfig: completions?.resourceRequestConfig
 				};
 			}

--- a/src/vs/workbench/contrib/terminalContrib/suggest/browser/pwshCompletionProviderAddon.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/browser/pwshCompletionProviderAddon.ts
@@ -46,7 +46,7 @@ const enum RequestCompletionsSequence {
 
 export class PwshCompletionProviderAddon extends Disposable implements ITerminalAddon, ITerminalCompletionProvider {
 
-	static readonly ID = 'pwsh-shell-integration';
+	static readonly ID = 'core:pwsh-shell-integration';
 
 	id: string = PwshCompletionProviderAddon.ID;
 	triggerCharacters?: string[] | undefined;

--- a/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalCompletionService.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalCompletionService.ts
@@ -217,7 +217,7 @@ export class TerminalCompletionService extends Disposable implements ITerminalCo
 				return completionItems;
 			}
 			if (completions.resourceRequestConfig) {
-				const resourceCompletions = await this.resolveResources(completions.resourceRequestConfig, promptValue, cursorPosition, provider.id, capabilities, shellType);
+				const resourceCompletions = await this.resolveResources(completions.resourceRequestConfig, promptValue, cursorPosition, `core:path:ext:${provider.id}`, capabilities, shellType);
 				if (resourceCompletions) {
 					for (const item of resourceCompletions) {
 						const labels = new Set(completionItems.map(c => c.label));

--- a/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalSuggestAddon.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalSuggestAddon.ts
@@ -139,7 +139,7 @@ export class SuggestAddon extends Disposable implements ITerminalAddon, ISuggest
 		inputData: '\x1b[C',
 		replacementIndex: 0,
 		replacementLength: 0,
-		provider: 'core',
+		provider: 'core:inlineSuggestion',
 		detail: 'Inline suggestion',
 		kind: TerminalCompletionItemKind.InlineSuggestion,
 		kindLabel: 'Inline suggestion',


### PR DESCRIPTION
This will make the inline suggestion event in particular easier to understand, but also make everything more consistent.