### PR TITLE
tools: surface tool source in chat additions api

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadLanguageModelTools.ts
+++ b/src/vs/workbench/api/browser/mainThreadLanguageModelTools.ts
@@ -41,6 +41,7 @@ export class MainThreadLanguageModelTools extends Disposable implements MainThre
 				userDescription: tool.userDescription,
 				modelDescription: tool.modelDescription,
 				inputSchema: tool.inputSchema,
+				source: tool.source,
 			} satisfies IToolDataDto));
 	}
 

--- a/src/vs/workbench/api/common/extHost.api.impl.ts
+++ b/src/vs/workbench/api/common/extHost.api.impl.ts
@@ -1855,6 +1855,8 @@ export function createApiFactoryAndRegisterActors(accessor: ServicesAccessor): I
 			LanguageModelToolResult: extHostTypes.LanguageModelToolResult,
 			LanguageModelToolResult2: extHostTypes.LanguageModelToolResult2,
 			LanguageModelDataPart: extHostTypes.LanguageModelDataPart,
+			LanguageModelToolExtensionSource: extHostTypes.LanguageModelToolExtensionSource,
+			LanguageModelToolMCPSource: extHostTypes.LanguageModelToolMCPSource,
 			ExtendedLanguageModelToolResult: extHostTypes.ExtendedLanguageModelToolResult,
 			PreparedTerminalToolInvocation: extHostTypes.PreparedTerminalToolInvocation,
 			LanguageModelChatToolMode: extHostTypes.LanguageModelChatToolMode,

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -61,7 +61,7 @@ import { IChatContentInlineReference, IChatFollowup, IChatNotebookEdit, IChatPro
 import { IChatRequestVariableValue } from '../../contrib/chat/common/chatVariables.js';
 import { ChatAgentLocation } from '../../contrib/chat/common/constants.js';
 import { IChatMessage, IChatResponseFragment, ILanguageModelChatMetadata, ILanguageModelChatSelector, ILanguageModelsChangeEvent } from '../../contrib/chat/common/languageModels.js';
-import { IPreparedToolInvocation, IToolInvocation, IToolInvocationPreparationContext, IToolProgressStep, IToolResult } from '../../contrib/chat/common/languageModelToolsService.js';
+import { IPreparedToolInvocation, IToolInvocation, IToolInvocationPreparationContext, IToolProgressStep, IToolResult, ToolDataSource } from '../../contrib/chat/common/languageModelToolsService.js';
 import { DebugConfigurationProviderTriggerKind, IAdapterDescriptor, IConfig, IDebugSessionReplMode, IDebugTestRunReference, IDebugVisualization, IDebugVisualizationContext, IDebugVisualizationTreeItem, MainThreadDebugVisualization } from '../../contrib/debug/common/debug.js';
 import { McpCollectionDefinition, McpConnectionState, McpServerDefinition, McpServerLaunch } from '../../contrib/mcp/common/mcpTypes.js';
 import * as notebookCommon from '../../contrib/notebook/common/notebookCommon.js';
@@ -1391,6 +1391,7 @@ export interface IToolDataDto {
 	displayName: string;
 	userDescription?: string;
 	modelDescription: string;
+	source: Dto<ToolDataSource>;
 	inputSchema?: IJSONSchema;
 }
 

--- a/src/vs/workbench/api/common/extHostTypeConverters.ts
+++ b/src/vs/workbench/api/common/extHostTypeConverters.ts
@@ -42,7 +42,7 @@ import { IChatAgentRequest, IChatAgentResult } from '../../contrib/chat/common/c
 import { IChatRequestDraft } from '../../contrib/chat/common/chatEditingService.js';
 import { IChatRequestVariableEntry, isImageVariableEntry } from '../../contrib/chat/common/chatVariableEntries.js';
 import { IChatAgentMarkdownContentWithVulnerability, IChatCodeCitation, IChatCommandButton, IChatConfirmation, IChatContentInlineReference, IChatContentReference, IChatExtensionsContent, IChatFollowup, IChatMarkdownContent, IChatMoveMessage, IChatPrepareToolInvocationPart, IChatProgressMessage, IChatResponseCodeblockUriPart, IChatTaskDto, IChatTaskResult, IChatTextEdit, IChatTreeData, IChatUserActionEvent, IChatWarningMessage } from '../../contrib/chat/common/chatService.js';
-import { IToolData, IToolResult } from '../../contrib/chat/common/languageModelToolsService.js';
+import { IToolResult, ToolDataSource } from '../../contrib/chat/common/languageModelToolsService.js';
 import * as chatProvider from '../../contrib/chat/common/languageModels.js';
 import { IChatMessageDataPart, IChatResponseDataPart, IChatResponsePromptTsxPart, IChatResponseTextPart } from '../../contrib/chat/common/languageModels.js';
 import { DebugTreeItemCollapsibleState, IDebugVisualizationTreeItem } from '../../contrib/debug/common/debug.js';
@@ -3279,15 +3279,15 @@ export namespace DebugTreeItem {
 	}
 }
 
-export namespace LanguageModelToolDescription {
-	export function to(item: IToolData): vscode.LanguageModelToolInformation {
-		return {
-			// Note- the reason this is a unique 'name' is just to avoid confusion with the toolCallId
-			name: item.id,
-			description: item.modelDescription,
-			inputSchema: item.inputSchema,
-			tags: item.tags ?? [],
-		};
+export namespace LanguageModelToolSource {
+	export function to(source: Dto<ToolDataSource>): vscode.LanguageModelToolInformation['source'] {
+		if (source.type === 'mcp') {
+			return new types.LanguageModelToolMCPSource(source.label, source.serverLabel || source.label, source.instructions);
+		} else if (source.type === 'extension') {
+			return new types.LanguageModelToolExtensionSource(source.extensionId.value, source.label);
+		} else {
+			return undefined;
+		}
 	}
 }
 

--- a/src/vs/workbench/api/common/extHostTypes.ts
+++ b/src/vs/workbench/api/common/extHostTypes.ts
@@ -5133,6 +5133,14 @@ export enum LanguageModelChatToolMode {
 	Required = 2
 }
 
+export class LanguageModelToolExtensionSource implements vscode.LanguageModelToolExtensionSource {
+	constructor(public readonly id: string, public readonly label: string) { }
+}
+
+export class LanguageModelToolMCPSource implements vscode.LanguageModelToolMCPSource {
+	constructor(public readonly label: string, public readonly name: string, public readonly instructions: string | undefined) { }
+}
+
 //#endregion
 
 //#region ai
@@ -5175,7 +5183,7 @@ export enum KeywordRecognitionStatus {
 
 //#endregion
 
-//#region MC
+//#region MCP
 export class McpStdioServerDefinition implements vscode.McpStdioServerDefinition {
 	cwd?: URI;
 

--- a/src/vs/workbench/contrib/chat/common/languageModelToolsService.ts
+++ b/src/vs/workbench/contrib/chat/common/languageModelToolsService.ts
@@ -60,6 +60,8 @@ export type ToolDataSource =
 	| {
 		type: 'mcp';
 		label: string;
+		serverLabel: string | undefined;
+		instructions: string | undefined;
 		collectionId: string;
 		definitionId: string;
 	}

--- a/src/vs/workbench/contrib/chat/test/browser/chatSelectedTools.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/chatSelectedTools.test.ts
@@ -49,7 +49,7 @@ suite('ChatSelectedTools', () => {
 
 	ensureNoDisposablesAreLeakedInTestSuite();
 
-	const mcpSource: ToolDataSource = { type: 'mcp', label: 'MCP', collectionId: '', definitionId: '' };
+	const mcpSource: ToolDataSource = { type: 'mcp', label: 'MCP', collectionId: '', definitionId: '', instructions: '', serverLabel: '' };
 	test('Can\'t enable/disable MCP tools directly #18161', () => {
 
 		return runWithFakedTimers({}, async () => {

--- a/src/vs/workbench/contrib/mcp/common/mcpServerRequestHandler.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpServerRequestHandler.ts
@@ -72,6 +72,10 @@ export class McpServerRequestHandler extends Disposable {
 		return this._serverInit.serverInfo;
 	}
 
+	public get serverInstructions(): string | undefined {
+		return this._serverInit.instructions;
+	}
+
 	// Event emitters for server notifications
 	private readonly _onDidReceiveCancelledNotification = this._register(new Emitter<MCP.CancelledNotification>());
 	readonly onDidReceiveCancelledNotification = this._onDidReceiveCancelledNotification.event;

--- a/src/vscode-dts/vscode.proposed.chatParticipantAdditions.d.ts
+++ b/src/vscode-dts/vscode.proposed.chatParticipantAdditions.d.ts
@@ -265,6 +265,43 @@ declare module 'vscode' {
 		export const onDidChangeChatRequestTools: Event<ChatRequest>;
 	}
 
+	export class LanguageModelToolExtensionSource {
+		/**
+		 * ID of the extension that published the tool.
+		 */
+		readonly id: string;
+
+		/**
+		 * Label of the extension that published the tool.
+		 */
+		readonly label: string;
+
+		private constructor(id: string, label: string);
+	}
+
+	export class LanguageModelToolMCPSource {
+		/**
+		 * Editor-configured label of the MCP server that published the tool.
+		 */
+		readonly label: string;
+
+		/**
+		 * Server-defined name of the MCP server.
+		 */
+		readonly name: string;
+
+		/**
+		 * Server-defined instructions for MCP tool use.
+		 */
+		readonly instructions?: string;
+
+		private constructor(label: string, name: string, instructions?: string);
+	}
+
+	export interface LanguageModelToolInformation {
+		source: LanguageModelToolExtensionSource | LanguageModelToolMCPSource | undefined;
+	}
+
 	// TODO@API fit this into the stream
 	export interface ChatUsedContext {
 		documents: ChatDocumentContext[];


### PR DESCRIPTION
For MCP I can already kind of get this from the tool name, but for
extension tools we previously had no way to know which extension
provided the tool, and I need this for virtual tools.

This PR adds a `LanguageModelToolInformation.source` containing details
about where the tool came from. I also use this to include the MCP
server instructions which is needed for #250017.

cc @aeschli @roblourens

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
