### PR TITLE
Always show warning about untrusted content from fetch tool

### DIFF
--- a/src/vs/workbench/contrib/chat/electron-browser/tools/fetchPageTool.ts
+++ b/src/vs/workbench/contrib/chat/electron-browser/tools/fetchPageTool.ts
@@ -203,19 +203,22 @@ export class FetchWebPageTool implements IToolImpl {
 			if (urlsNeedingConfirmation.length === 1) {
 				confirmationTitle = localize('fetchWebPage.confirmationTitle.singular', 'Fetch web page?');
 				confirmationMessage = new MarkdownString(
-					urlsNeedingConfirmation[0].toString() + '\n\n$(info) ' +
-					localize('fetchWebPage.confirmationMessage.singular', 'Web content may contain malicious code or attempt prompt injection attacks.'),
+					urlsNeedingConfirmation[0].toString(),
 					{ supportThemeIcons: true }
 				);
 			} else {
 				confirmationTitle = localize('fetchWebPage.confirmationTitle.plural', 'Fetch web pages?');
 				confirmationMessage = new MarkdownString(
-					urlsNeedingConfirmation.map(uri => `- ${uri.toString()}`).join('\n') + '\n\n$(info) ' +
-					localize('fetchWebPage.confirmationMessage.plural', 'Web content may contain malicious code or attempt prompt injection attacks.'),
+					urlsNeedingConfirmation.map(uri => `- ${uri.toString()}`).join('\n'),
 					{ supportThemeIcons: true }
 				);
 			}
-			result.confirmationMessages = { title: confirmationTitle, message: confirmationMessage, allowAutoConfirm: true };
+			result.confirmationMessages = {
+				title: confirmationTitle,
+				message: confirmationMessage,
+				allowAutoConfirm: true,
+				disclaimer: new MarkdownString('$(info) ' + localize('fetchWebPage.confirmationMessage.plural', 'Web content may contain malicious code or attempt prompt injection attacks.'), { supportThemeIcons: true })
+			};
 		}
 		return result;
 	}


### PR DESCRIPTION
Port #254727 to main
* Always show warning about untrusted content from fetch tool
For #254654

* Put info icon back

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
