### PR TITLE
Adds support for proper localhost loopback on RFC 6761

### DIFF
--- a/src/vs/workbench/contrib/url/common/trustedDomains.ts
+++ b/src/vs/workbench/contrib/url/common/trustedDomains.ts
@@ -51,9 +51,10 @@ export function normalizeURL(url: string | URI): string {
 	} catch { return url.toString(); }
 }
 const rLocalhost = /^localhost(:\d+)?$/i;
+const rLocalhostTld = /^(.+\.)?localhost(:\d+)?$/i;
 const r127 = /^127.0.0.1(:\d+)?$/;
 
 export function isLocalhostAuthority(authority: string) {
-	return rLocalhost.test(authority) || r127.test(authority);
+	return rLocalhost.test(authority) || rLocalhostTld.test(authority) || r127.test(authority);
 }
 

--- a/src/vs/workbench/contrib/url/common/trustedDomains.ts
+++ b/src/vs/workbench/contrib/url/common/trustedDomains.ts
@@ -50,11 +50,10 @@ export function normalizeURL(url: string | URI): string {
 		}
 	} catch { return url.toString(); }
 }
-const rLocalhost = /^localhost(:\d+)?$/i;
-const rLocalhostTld = /^(.+\.)?localhost(:\d+)?$/i;
+const rLocalhost = /^(.+\.)?localhost(:\d+)?$/i;
 const r127 = /^127.0.0.1(:\d+)?$/;
 
 export function isLocalhostAuthority(authority: string) {
-	return rLocalhost.test(authority) || rLocalhostTld.test(authority) || r127.test(authority);
+	return rLocalhost.test(authority) || r127.test(authority);
 }
 

--- a/src/vs/workbench/contrib/url/test/browser/trustedDomains.test.ts
+++ b/src/vs/workbench/contrib/url/test/browser/trustedDomains.test.ts
@@ -37,6 +37,11 @@ suite('Link protection domain matching', () => {
 		linkAllowedByRules('https://127.0.0.1:3000', []);
 		linkAllowedByRules('https://localhost', []);
 		linkAllowedByRules('https://localhost:3000', []);
+		linkAllowedByRules('https://dev.localhost', []);
+		linkAllowedByRules('https://dev.localhost:3000', []);
+		linkAllowedByRules('https://app.localhost', []);
+		linkAllowedByRules('https://api.localhost:8080', []);
+		linkAllowedByRules('https://myapp.dev.localhost:8080', []);
 	});
 
 	test('* star', () => {


### PR DESCRIPTION
Fixes #256611 

- 🔍 Added TLD matching for localhost variations
- ✅ Updated tests to cover new localhost cases

The solution follows RFC 6761 standards where .localhost is a special-use top-level domain reserved for loopback purposes. The regex pattern ^(.+\.)?localhost(:\d+)?$ matches:

localhost (the base domain)
*.localhost (any subdomain of localhost)
Optional port numbers (e.g., :3000, :8080)
Case-insensitive matching

Now when you encounter links ending with dev.localhost or any other *.localhost subdomain, VS Code will automatically trust them and won't prompt you to configure trusted domains or ask if you want to open the external website. This provides the same seamless experience as localhost itself, which aligns with the RFC 6761 specification that treats the entire .localhost TLD as reserved for local loopback testing.
