### PR TITLE
elicitation custom labels

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/chatElicitationContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/chatElicitationContentPart.ts
@@ -25,10 +25,10 @@ export class ChatElicitationContentPart extends Disposable implements IChatConte
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
 	) {
 		super();
-
+		const { acceptButtonLabel, rejectButtonLabel } = elicitation;
 		const buttons = [
-			{ label: localize('accept', "Respond"), data: true },
-			{ label: localize('dismiss', "Cancel"), data: false, isSecondary: true },
+			{ label: acceptButtonLabel ?? localize('accept', "Respond"), data: true },
+			{ label: rejectButtonLabel ?? localize('dismiss', "Cancel"), data: false, isSecondary: true },
 		];
 		const confirmationWidget = this._register(this.instantiationService.createInstance(ChatConfirmationWidget, elicitation.title, elicitation.originMessage, this.getMessageToRender(elicitation), buttons, context.container));
 		confirmationWidget.setShowButtons(elicitation.state === 'pending');

--- a/src/vs/workbench/contrib/chat/common/chatService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService.ts
@@ -234,6 +234,8 @@ export interface IChatElicitationRequest {
 	originMessage?: string | IMarkdownString;
 	state: 'pending' | 'accepted' | 'rejected';
 	acceptedResult?: Record<string, unknown>;
+	acceptButtonLabel?: string;
+	rejectButtonLabel?: string;
 	accept(): Promise<void>;
 	reject(): Promise<void>;
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Make the elicitationRequestChatPart more generic by allowing the caller to set custom labels on the buttons

Each button is hooked up to a callback, which is generally useful beyond mcp elicitations.

### Buttons
<img width="920" height="281" alt="image" src="https://github.com/user-attachments/assets/4095ee8e-f3a4-4766-9d81-258bbd6bbf67" />

### First button selected
<img width="845" height="158" alt="image" src="https://github.com/user-attachments/assets/7a247f47-0d26-4708-b67c-d20a71cb32b6" />

### Second button selected
<img width="884" height="159" alt="image" src="https://github.com/user-attachments/assets/b132932b-5374-4264-b056-615982584a72" />
