### PR TITLE
Set run in terminal icon to chat and remove Copilot name

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
@@ -531,16 +531,10 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 				const defaultProfile = (await this._terminalProfileResolverService.getDefaultProfile({ remoteAuthority: this.remoteAuthority, os }));
 				this.shellLaunchConfig.executable = defaultProfile.path;
 				this.shellLaunchConfig.args = defaultProfile.args;
-				if (this.shellLaunchConfig.isExtensionOwnedTerminal) {
-					// Only use default icon and color and env if they are undefined in the SLC
-					this.shellLaunchConfig.icon ??= defaultProfile.icon;
-					this.shellLaunchConfig.color ??= defaultProfile.color;
-					this.shellLaunchConfig.env ??= defaultProfile.env;
-				} else {
-					this.shellLaunchConfig.icon = defaultProfile.icon;
-					this.shellLaunchConfig.color = defaultProfile.color;
-					this.shellLaunchConfig.env = defaultProfile.env;
-				}
+				// Only use default icon and color and env if they are undefined in the SLC
+				this.shellLaunchConfig.icon ??= defaultProfile.icon;
+				this.shellLaunchConfig.color ??= defaultProfile.color;
+				this.shellLaunchConfig.env ??= defaultProfile.env;
 			}
 
 			// Resolve the shell type ahead of time to allow features that depend upon it to work

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/toolTerminalCreator.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/toolTerminalCreator.ts
@@ -5,6 +5,7 @@
 
 import { DeferredPromise, disposableTimeout, timeout } from '../../../../../base/common/async.js';
 import type { CancellationToken } from '../../../../../base/common/cancellation.js';
+import { Codicon } from '../../../../../base/common/codicons.js';
 import { CancellationError } from '../../../../../base/common/errors.js';
 import { DisposableStore } from '../../../../../base/common/lifecycle.js';
 import { ThemeIcon } from '../../../../../base/common/themables.js';
@@ -70,8 +71,7 @@ export class ToolTerminalCreator {
 	private _createCopilotTerminal() {
 		return this._terminalService.createTerminal({
 			config: {
-				name: 'Copilot',
-				icon: ThemeIcon.fromId('copilot'),
+				icon: ThemeIcon.fromId(Codicon.chatSparkle.id),
 				hideFromUser: true,
 				env: {
 					GIT_PAGER: 'cat', // avoid making `git diff` interactive when called from copilot


### PR DESCRIPTION
Fixes #256768
Fixes #256765

<img width="359" height="135" alt="image" src="https://github.com/user-attachments/assets/e7aa780c-d31e-4f6d-baaa-e3d83f0b2234" />

It's not clear why that condition was there to begin with. Looked at https://github.com/microsoft/vscode/pull/183121 where it was done but still not sure.