### PR TITLE
Add internal API for getting a webview's content size

### DIFF
--- a/src/vs/workbench/contrib/webview/browser/pre/index.html
+++ b/src/vs/workbench/contrib/webview/browser/pre/index.html
@@ -5,7 +5,7 @@
 	<meta charset="UTF-8">
 
 	<meta http-equiv="Content-Security-Policy"
-		content="default-src 'none'; script-src 'sha256-l9e7E37hgQqoIAqcFRgQ5/0NqMMW93mQmYAsUcDUyZ4=' 'self'; frame-src 'self'; style-src 'unsafe-inline';">
+		content="default-src 'none'; script-src 'sha256-kvB8+4EUtyEDThMIgb61H4fMe04EqjRhttNuYd028mo=' 'self'; frame-src 'self'; style-src 'unsafe-inline';">
 
 	<!-- Disable pinch zooming -->
 	<meta name="viewport"
@@ -1120,6 +1120,21 @@
 
 						if (wasFocused) {
 							contentWindow.focus();
+						}
+
+						// Get body size
+						const docEl = contentDocument.documentElement;
+						if (docEl) {
+							const postSize = () => {
+								hostMessaging.postMessage('updated-intrinsic-content-size', {
+									width: docEl.scrollWidth,
+									height: docEl.scrollHeight
+								});
+							};
+
+							const resizeObserver = new ResizeObserver(postSize);
+							resizeObserver.observe(docEl);
+							postSize();
 						}
 
 						pendingMessages.forEach((message) => {

--- a/src/vs/workbench/contrib/webview/browser/webview.ts
+++ b/src/vs/workbench/contrib/webview/browser/webview.ts
@@ -9,6 +9,7 @@ import { CodeWindow } from '../../../../base/browser/window.js';
 import { equals } from '../../../../base/common/arrays.js';
 import { Event } from '../../../../base/common/event.js';
 import { IDisposable } from '../../../../base/common/lifecycle.js';
+import { IObservable } from '../../../../base/common/observable.js';
 import { isEqual } from '../../../../base/common/resources.js';
 import { URI } from '../../../../base/common/uri.js';
 import { generateUuid } from '../../../../base/common/uuid.js';
@@ -233,7 +234,13 @@ export interface IWebview extends IDisposable {
 	readonly onDidWheel: Event<IMouseWheelEvent>;
 
 	readonly onDidUpdateState: Event<string | undefined>;
-	readonly onDidReload: Event<void>;
+
+	/**
+	 * The natural size of the content inside the webview.
+	 *
+	 * This is computed by looking at the size of the webview's the document element.
+	 */
+	readonly intrinsicContentSize: IObservable<{ readonly width: number; readonly height: number } | undefined>;
 
 	/**
 	 * Fired when the webview cannot be loaded or is now in a non-functional state.

--- a/src/vs/workbench/contrib/webview/browser/webviewMessages.d.ts
+++ b/src/vs/workbench/contrib/webview/browser/webviewMessages.d.ts
@@ -40,7 +40,8 @@ export type FromWebviewMessage = {
 	'did-keyup': KeyEvent;
 	'did-context-menu': { clientX: number; clientY: number; context: { [key: string]: unknown } };
 	'drag-start': void;
-	'drag': WebViewDragEvent
+	'drag': WebViewDragEvent;
+	'updated-intrinsic-content-size': { width: number; height: number };
 };
 
 interface UpdateContentEvent {


### PR DESCRIPTION
Needed for #255000. This will allow us to adjust the size of rendered outputs to better fit the content

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
