### PR TITLE
docs(strings): improve clarity of escapeRegExpCharacters and count fu…

### DIFF
--- a/src/vs/base/common/strings.ts
+++ b/src/vs/base/common/strings.ts
@@ -83,14 +83,20 @@ export function escape(html: string): string {
 }
 
 /**
- * Escapes regular expression characters in a given string
+ * Escapes characters that have special meaning in regular expressions.
+ * For example, "." becomes "\." so it’s treated literally.
+ * @param value The string to escape
+ * @returns The escaped string safe for RegExp use
  */
 export function escapeRegExpCharacters(value: string): string {
 	return value.replace(/[\\\{\}\*\+\?\|\^\$\.\[\]\(\)]/g, '\\$&');
 }
 
 /**
- * Counts how often `substr` occurs inside `value`.
+ * Counts the number of non-overlapping occurrences of `substr` in `value`.
+ * @param value The full string to search in
+ * @param substr The substring to count
+ * @returns The number of times `substr` appears
  */
 export function count(value: string, substr: string): number {
 	let result = 0;


### PR DESCRIPTION

This small documentation update clarifies the purpose and behavior of the `escapeRegExpCharacters` and `count` functions in `strings.ts`.

- `escapeRegExpCharacters`: improved wording to emphasize RegExp safety
- `count`: clarified that the function counts **non-overlapping** occurrences

These edits aim to improve readability and reduce ambiguity for future contributors.

No functional code changes were made.

