### PR TITLE
fix: memory leak in extension features tab

### DIFF
--- a/src/vs/workbench/contrib/extensions/browser/extensionFeaturesTab.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionFeaturesTab.ts
@@ -736,7 +736,7 @@ class ExtensionFeatureView extends Disposable {
 	}
 
 	private renderElementData(container: HTMLElement, renderer: IExtensionFeatureElementRenderer): void {
-		const elementData = renderer.render(this.manifest);
+		const elementData = this._register(renderer.render(this.manifest));
 		if (elementData.onDidChange) {
 			this._register(elementData.onDidChange(data => {
 				clearNode(container);


### PR DESCRIPTION
Fix an event listener leak in the extensions editor features tab. 


## Event listeners (before)

One [end-to-end test](https://github.com/SimonSiefke/vscode-memory-leak-finder/blob/068a2116ab72ed9a2668e0f7537818f3874bfdac/packages/e2e/src/extension.detail-view-open-settings.js) showed an `auxclick` and `keydown` event listener leak from `markdownRenderer.ts`. 

```json
{
  "eventListenersWithStackTrace": [
    {
      "type": "auxclick",
      "description": "n=>this.a.fire(n)",
      "objectId": "-6737128020740298089.4.35825",
      "stack": [
        "listener (file:///workspace/vscode-memory-leak-finder/.vscode-test/vscode-linux-x64-1.102.0/resources/app/out/vs/workbench/workbench.desktop.main.js:69:53100)",
        "Object.onWillAddFirstListener (vscode-file://vscode-app/workspace/vscode-memory-leak-finder/.vscode-test/vscode-linux-x64-1.102.0/resources/app/out/vs/workbench/workbench.desktop.main.js:70:53162)",
        "u (vscode-file://vscode-app/workspace/vscode-memory-leak-finder/.vscode-test/vscode-linux-x64-1.102.0/resources/app/out/vs/workbench/workbench.desktop.main.js:29:1565)",
        "vscode-file://vscode-app/workspace/vscode-memory-leak-finder/.vscode-test/vscode-linux-x64-1.102.0/resources/app/out/vs/workbench/workbench.desktop.main.js:27:6613",
        "Array.map (<anonymous>)",
        "vscode-file://vscode-app/workspace/vscode-memory-leak-finder/.vscode-test/vscode-linux-x64-1.102.0/resources/app/out/vs/workbench/workbench.desktop.main.js:27:6605",
        "b0 (vscode-file://vscode-app/workspace/vscode-memory-leak-finder/.vscode-test/vscode-linux-x64-1.102.0/resources/app/out/vs/workbench/workbench.desktop.main.js:384:2706)",
        "Yxe.r (vscode-file://vscode-app/workspace/vscode-memory-leak-finder/.vscode-test/vscode-linux-x64-1.102.0/resources/app/out/vs/workbench/workbench.desktop.main.js:2126:72)",
        "Yxe.n (vscode-file://vscode-app/workspace/vscode-memory-leak-finder/.vscode-test/vscode-linux-x64-1.102.0/resources/app/out/vs/workbench/workbench.desktop.main.js:2111:336)"
      ],
      "count": 194,
      "originalStack": [
        "file:/Users/cloudtest/vss/_work/1/s/src/vs/base/browser/event.ts:40:14"
      ],
      "originalName": "e"
    },
    {
      "type": "keydown",
      "description": "b=>{const v=new yi(b);!v.equals(10)&&!v.equals(3)||K$t(i,e,v)}",
      "objectId": "-6737128020740298089.4.35827",
      "stack": [
        "listener (file:///workspace/vscode-memory-leak-finder/.vscode-test/vscode-linux-x64-1.102.0/resources/app/out/vs/workbench/workbench.desktop.main.js:383:2826)",
        "new N5i (vscode-file://vscode-app/workspace/vscode-memory-leak-finder/.vscode-test/vscode-linux-x64-1.102.0/resources/app/out/vs/workbench/workbench.desktop.main.js:32:8619)",
        "K (vscode-file://vscode-app/workspace/vscode-memory-leak-finder/.vscode-test/vscode-linux-x64-1.102.0/resources/app/out/vs/workbench/workbench.desktop.main.js:32:8780)",
        "b0 (vscode-file://vscode-app/workspace/vscode-memory-leak-finder/.vscode-test/vscode-linux-x64-1.102.0/resources/app/out/vs/workbench/workbench.desktop.main.js:384:2813)",
        "Yxe.r (vscode-file://vscode-app/workspace/vscode-memory-leak-finder/.vscode-test/vscode-linux-x64-1.102.0/resources/app/out/vs/workbench/workbench.desktop.main.js:2126:72)",
        "Yxe.n (vscode-file://vscode-app/workspace/vscode-memory-leak-finder/.vscode-test/vscode-linux-x64-1.102.0/resources/app/out/vs/workbench/workbench.desktop.main.js:2111:336)",
        "Yxe.render (vscode-file://vscode-app/workspace/vscode-memory-leak-finder/.vscode-test/vscode-linux-x64-1.102.0/resources/app/out/vs/workbench/workbench.desktop.main.js:2109:24451)",
        "Cat.H (vscode-file://vscode-app/workspace/vscode-memory-leak-finder/.vscode-test/vscode-linux-x64-1.102.0/resources/app/out/vs/workbench/workbench.desktop.main.js:2126:9844)",
        "Cat.t (vscode-file://vscode-app/workspace/vscode-memory-leak-finder/.vscode-test/vscode-linux-x64-1.102.0/resources/app/out/vs/workbench/workbench.desktop.main.js:2126:8377)"
      ],
      "count": 97,
      "originalStack": [
        "file:/Users/cloudtest/vss/_work/1/s/src/vs/base/browser/markdownRenderer.ts:189:87"
      ],
      "originalName": "e"
    }
  ],
  "isLeak": true
}
```

After checking where the `markdownRenderer` connects to the `extensionFeatures` module, one suspicious disposable from below was discovered. The change registers `renderer.render(this.manifest)` as a disposable so that it can be properly disposed.

## Event listeners (after)

Running the same test again with the fix in place shows no more leaking event listeners

```json
{
  "eventListeners": [],
  "isLeak": false
}

```