### PR TITLE
fix: memory leak in editor edit context

### DIFF
--- a/src/vs/editor/browser/controller/editContext/native/nativeEditContext.ts
+++ b/src/vs/editor/browser/controller/editContext/native/nativeEditContext.ts
@@ -106,7 +106,7 @@ export class NativeEditContext extends AbstractEditContext {
 		this._editContext = EditContext.create(window);
 		this.setEditContextOnDomNode();
 
-		this._screenReaderSupport = instantiationService.createInstance(ScreenReaderSupport, this.domNode, context, this._viewController);
+		this._screenReaderSupport = this._register(instantiationService.createInstance(ScreenReaderSupport, this.domNode, context, this._viewController));
 
 		this._register(addDisposableListener(this.domNode.domNode, 'copy', (e) => this._ensureClipboardGetsEditorSelection(e)));
 		this._register(addDisposableListener(this.domNode.domNode, 'cut', (e) => {


### PR DESCRIPTION
Register the `screenReaderSupport` as a disposable.