### PR TITLE
fix: set edit context to undefined in dispose

### DIFF
--- a/src/vs/editor/browser/controller/editContext/native/nativeEditContext.ts
+++ b/src/vs/editor/browser/controller/editContext/native/nativeEditContext.ts
@@ -210,6 +210,7 @@ export class NativeEditContext extends AbstractEditContext {
 
 	public override dispose(): void {
 		// Force blue the dom node so can write in pane with no native edit context after disposal
+		this.domNode.domNode.editContext = undefined;
 		this.domNode.domNode.blur();
 		this.domNode.domNode.remove();
 		this._imeTextArea.domNode.remove();


### PR DESCRIPTION
This fixes a memory leak related to edit context. 

When opening and closing a text editor, the number of `EditContexts` seems to increase each time. Setting the `editContext` property to `undefined` in the `dispose` function seems to solve this issue.

## Test Script

```sh
git clone git@github.com:SimonSiefke/vscode-memory-leak-finder.git &&
cd vscode-memory-leak-finder &&
git checkout v5.88.0 &&
npm ci &&
node packages/cli/bin/test.js --cwd packages/e2e  --check-leaks --measure-after --measure edit-context-count --only ^editor.open --runs 97 &&
cat ./.vscode-memory-leak-finder-results/edit-context-count/editor.open.json 
```

## Before

The number of edit contexts when opening and closing a text editor 97 times grows from 2 to 99:


![before](https://github.com/user-attachments/assets/fe2bd653-81c5-415f-a6d0-937826486edc)





## After



The number of edit contexts when opening and closing a text editor 97 times stays constant: 

![after](https://github.com/user-attachments/assets/1f09b880-08d6-4999-830f-1b502cf3ea7a)



