### PR TITLE
Reverse lines: apply to whole document when selection is single line

### DIFF
--- a/src/vs/editor/common/core/range.ts
+++ b/src/vs/editor/common/core/range.ts
@@ -364,6 +364,9 @@ export class Range {
 		return new Range(this.startLineNumber + lineCount, this.startColumn, this.endLineNumber + lineCount, this.endColumn);
 	}
 
+	/**
+	 * Test if this range starts and ends on the same line.
+	 */
 	public isSingleLine(): boolean {
 		return this.startLineNumber === this.endLineNumber;
 	}

--- a/src/vs/editor/contrib/linesOperations/browser/linesOperations.ts
+++ b/src/vs/editor/contrib/linesOperations/browser/linesOperations.ts
@@ -251,7 +251,7 @@ export abstract class AbstractSortLinesAction extends EditorAction {
 
 		const model = editor.getModel();
 		let selections = editor.getSelections();
-		if (selections.length === 1 && selections[0].isEmpty()) {
+		if (selections.length === 1 && selections[0].isSingleLine()) {
 			// Apply to whole document.
 			selections = [new Selection(1, 1, model.getLineCount(), model.getLineMaxColumn(model.getLineCount()))];
 		}
@@ -322,7 +322,7 @@ export class DeleteDuplicateLinesAction extends EditorAction {
 		let updateSelection = true;
 
 		let selections = editor.getSelections();
-		if (selections.length === 1 && selections[0].isEmpty()) {
+		if (selections.length === 1 && selections[0].isSingleLine()) {
 			// Apply to whole document.
 			selections = [new Selection(1, 1, model.getLineCount(), model.getLineMaxColumn(model.getLineCount()))];
 			updateSelection = false;
@@ -389,7 +389,7 @@ export class ReverseLinesAction extends EditorAction {
 		const model: ITextModel = editor.getModel();
 		const originalSelections = editor.getSelections();
 		let selections = originalSelections;
-		if (selections.length === 1 && selections[0].isEmpty()) {
+		if (selections.length === 1 && selections[0].isSingleLine()) {
 			// Apply to whole document.
 			selections = [new Selection(1, 1, model.getLineCount(), model.getLineMaxColumn(model.getLineCount()))];
 		}

--- a/src/vs/editor/contrib/linesOperations/test/browser/linesOperations.test.ts
+++ b/src/vs/editor/contrib/linesOperations/test/browser/linesOperations.test.ts
@@ -106,6 +106,26 @@ suite('Editor Contrib - Line Operations', () => {
 					});
 				});
 		});
+
+		test('applies to whole document when selection is single line', function () {
+			withTestCodeEditor(
+				[
+					'omicron',
+					'beta',
+					'alpha'
+				], {}, (editor) => {
+					const model = editor.getModel()!;
+					const sortLinesAscendingAction = new SortLinesAscendingAction();
+
+					editor.setSelection(new Selection(2, 1, 2, 4));
+					executeAction(sortLinesAscendingAction, editor);
+					assert.deepStrictEqual(model.getLinesContent(), [
+						'alpha',
+						'beta',
+						'omicron'
+					]);
+				});
+		});
 	});
 
 	suite('SortLinesDescendingAction', () => {
@@ -246,6 +266,23 @@ suite('Editor Contrib - Line Operations', () => {
 					editor.getSelections()!.forEach((actualSelection, index) => {
 						assert.deepStrictEqual(actualSelection.toString(), expectedSelections[index].toString());
 					});
+				});
+		});
+
+		test('applies to whole document when selection is single line', function () {
+			withTestCodeEditor(
+				[
+					'alpha',
+					'beta',
+					'alpha',
+					'omicron'
+				], {}, (editor) => {
+					const model = editor.getModel()!;
+					const deleteDuplicateLinesAction = new DeleteDuplicateLinesAction();
+
+					editor.setSelection(new Selection(2, 1, 2, 2));
+					executeAction(deleteDuplicateLinesAction, editor);
+					assert.deepStrictEqual(model.getLinesContent(), ['alpha', 'beta', 'omicron']);
 				});
 		});
 	});
@@ -729,7 +766,7 @@ suite('Editor Contrib - Line Operations', () => {
 				});
 		});
 
-		test('handles single line selection', function () {
+		test('applies to whole document when selection is single line', function () {
 			withTestCodeEditor(
 				[
 					'line1',
@@ -742,8 +779,7 @@ suite('Editor Contrib - Line Operations', () => {
 					// Select only line 2
 					editor.setSelection(new Selection(2, 1, 2, 6));
 					executeAction(reverseLinesAction, editor);
-					// Single line should remain unchanged
-					assert.deepStrictEqual(model.getLinesContent(), ['line1', 'line2', 'line3']);
+					assert.deepStrictEqual(model.getLinesContent(), ['line3', 'line2', 'line1']);
 				});
 		});
 
@@ -763,6 +799,26 @@ suite('Editor Contrib - Line Operations', () => {
 					editor.setSelection(new Selection(2, 1, 4, 1));
 					executeAction(reverseLinesAction, editor);
 					assert.deepStrictEqual(model.getLinesContent(), ['line1', 'line3', 'line2', 'line4', 'line5']);
+				});
+		});
+
+		test('applies to whole document when selection is single line', function () {
+			withTestCodeEditor(
+				[
+					'omicron',
+					'beta',
+					'alpha'
+				], {}, (editor) => {
+					const model = editor.getModel()!;
+					const reverseLinesAction = new ReverseLinesAction();
+
+					editor.setSelection(new Selection(2, 1, 2, 4));
+					executeAction(reverseLinesAction, editor);
+					assert.deepStrictEqual(model.getLinesContent(), [
+						'alpha',
+						'beta',
+						'omicron'
+					]);
 				});
 		});
 	});

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -771,6 +771,9 @@ declare namespace monaco {
 		 * Moves the range by the given amount of lines.
 		 */
 		delta(lineCount: number): Range;
+		/**
+		 * Test if this range starts and ends on the same line.
+		 */
 		isSingleLine(): boolean;
 		static fromPositions(start: IPosition, end?: IPosition): Range;
 		/**


### PR DESCRIPTION
Previously, actions 'reverse lines', 'sort lines' and 'delete duplicate lines' did nothing when the selection starts and ends on the same line. This could be confusing if the user was trying to sort the document and nothing happened.

Instead, apply the action to the whole document. This is more useful.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
