### PR TITLE
ci: remove install build dependencies step on linux

### DIFF
--- a/.github/workflows/pr-linux-test.yml
+++ b/.github/workflows/pr-linux-test.yml
@@ -64,23 +64,6 @@ jobs:
         if: steps.cache-node-modules.outputs.cache-hit == 'true'
         run: tar -xzf .build/node_modules_cache/cache.tgz
 
-      - name: Install build dependencies
-        if: steps.cache-node-modules.outputs.cache-hit != 'true'
-        working-directory: build
-        run: |
-          set -e
-
-          for i in {1..5}; do # try 5 times
-            npm ci && break
-            if [ $i -eq 5 ]; then
-              echo "Npm install failed too many times" >&2
-              exit 1
-            fi
-            echo "Npm install failed $i, trying again..."
-          done
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Install dependencies
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
         run: |

--- a/.github/workflows/pr-node-modules.yml
+++ b/.github/workflows/pr-node-modules.yml
@@ -113,23 +113,6 @@ jobs:
           path: .build/node_modules_cache
           key: "node_modules-linux-${{ hashFiles('.build/packagelockhash') }}"
 
-      - name: Install build dependencies
-        if: steps.cache-node-modules.outputs.cache-hit != 'true'
-        working-directory: build
-        run: |
-          set -e
-
-          for i in {1..5}; do # try 5 times
-            npm ci && break
-            if [ $i -eq 5 ]; then
-              echo "Npm install failed too many times" >&2
-              exit 1
-            fi
-            echo "Npm install failed $i, trying again..."
-          done
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Install dependencies
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
         run: |

--- a/build/azure-pipelines/linux/product-build-linux.yml
+++ b/build/azure-pipelines/linux/product-build-linux.yml
@@ -100,23 +100,6 @@ steps:
     condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'), ne(variables['NPM_REGISTRY'], 'none'))
     displayName: Setup NPM Authentication
 
-  - script: |
-      set -e
-
-      for i in {1..5}; do # try 5 times
-        npm ci && break
-        if [ $i -eq 5 ]; then
-          echo "Npm install failed too many times" >&2
-          exit 1
-        fi
-        echo "Npm install failed $i, trying again..."
-      done
-    workingDirectory: build
-    env:
-      GITHUB_TOKEN: "$(github-distro-mixin-password)"
-    displayName: Install build dependencies
-    condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'))
-
   # Step will be used by both verify glibcxx version for remote server and building rpm package,
   # hence avoid adding it behind NODE_MODULES_RESTORED condition.
   - script: |

--- a/build/linux/debian/install-sysroot.js
+++ b/build/linux/debian/install-sysroot.js
@@ -15,7 +15,6 @@ const fs_1 = __importDefault(require("fs"));
 const https_1 = __importDefault(require("https"));
 const path_1 = __importDefault(require("path"));
 const crypto_1 = require("crypto");
-const ansi_colors_1 = __importDefault(require("ansi-colors"));
 // Based on https://source.chromium.org/chromium/chromium/src/+/main:build/linux/sysroot_scripts/install-sysroot.py.
 const URL_PREFIX = 'https://msftelectronbuild.z5.web.core.windows.net';
 const URL_PATH = 'sysroots/toolchain';
@@ -89,22 +88,22 @@ async function fetchUrl(options, retries = 10, retryDelay = 1000) {
                 });
                 if (assetResponse.ok && (assetResponse.status >= 200 && assetResponse.status < 300)) {
                     const assetContents = Buffer.from(await assetResponse.arrayBuffer());
-                    console.log(`Fetched response body buffer: ${ansi_colors_1.default.magenta(`${assetContents.byteLength} bytes`)}`);
+                    console.log(`Fetched response body buffer: ${assetContents.byteLength} bytes`);
                     if (options.checksumSha256) {
                         const actualSHA256Checksum = (0, crypto_1.createHash)('sha256').update(assetContents).digest('hex');
                         if (actualSHA256Checksum !== options.checksumSha256) {
-                            throw new Error(`Checksum mismatch for ${ansi_colors_1.default.cyan(asset.url)} (expected ${options.checksumSha256}, actual ${actualSHA256Checksum}))`);
+                            throw new Error(`Checksum mismatch for ${asset.url} (expected ${options.checksumSha256}, actual ${actualSHA256Checksum}))`);
                         }
                     }
-                    console.log(`Verified SHA256 checksums match for ${ansi_colors_1.default.cyan(asset.url)}`);
+                    console.log(`Verified SHA256 checksums match for ${asset.url}`);
                     const tarCommand = `tar -xz -C ${options.dest}`;
                     (0, child_process_1.execSync)(tarCommand, { input: assetContents });
                     console.log(`Fetch complete!`);
                     return;
                 }
-                throw new Error(`Request ${ansi_colors_1.default.magenta(asset.url)} failed with status code: ${assetResponse.status}`);
+                throw new Error(`Request ${asset.url} failed with status code: ${assetResponse.status}`);
             }
-            throw new Error(`Request ${ansi_colors_1.default.magenta('https://api.github.com')} failed with status code: ${response.status}`);
+            throw new Error(`Request https://api.github.com failed with status code: ${response.status}`);
         }
         finally {
             clearTimeout(timeout);

--- a/build/linux/debian/install-sysroot.ts
+++ b/build/linux/debian/install-sysroot.ts
@@ -10,7 +10,6 @@ import https from 'https';
 import path from 'path';
 import { createHash } from 'crypto';
 import { DebianArchString } from './types';
-import ansiColors from 'ansi-colors';
 
 // Based on https://source.chromium.org/chromium/chromium/src/+/main:build/linux/sysroot_scripts/install-sysroot.py.
 const URL_PREFIX = 'https://msftelectronbuild.z5.web.core.windows.net';
@@ -98,22 +97,22 @@ async function fetchUrl(options: IFetchOptions, retries = 10, retryDelay = 1000)
 				});
 				if (assetResponse.ok && (assetResponse.status >= 200 && assetResponse.status < 300)) {
 					const assetContents = Buffer.from(await assetResponse.arrayBuffer());
-					console.log(`Fetched response body buffer: ${ansiColors.magenta(`${(assetContents as Buffer).byteLength} bytes`)}`);
+					console.log(`Fetched response body buffer: ${(assetContents as Buffer).byteLength} bytes`);
 					if (options.checksumSha256) {
 						const actualSHA256Checksum = createHash('sha256').update(assetContents).digest('hex');
 						if (actualSHA256Checksum !== options.checksumSha256) {
-							throw new Error(`Checksum mismatch for ${ansiColors.cyan(asset.url)} (expected ${options.checksumSha256}, actual ${actualSHA256Checksum}))`);
+							throw new Error(`Checksum mismatch for ${asset.url} (expected ${options.checksumSha256}, actual ${actualSHA256Checksum}))`);
 						}
 					}
-					console.log(`Verified SHA256 checksums match for ${ansiColors.cyan(asset.url)}`);
+					console.log(`Verified SHA256 checksums match for ${asset.url}`);
 					const tarCommand = `tar -xz -C ${options.dest}`;
 					execSync(tarCommand, { input: assetContents });
 					console.log(`Fetch complete!`);
 					return;
 				}
-				throw new Error(`Request ${ansiColors.magenta(asset.url)} failed with status code: ${assetResponse.status}`);
+				throw new Error(`Request ${asset.url} failed with status code: ${assetResponse.status}`);
 			}
-			throw new Error(`Request ${ansiColors.magenta('https://api.github.com')} failed with status code: ${response.status}`);
+			throw new Error(`Request https://api.github.com failed with status code: ${response.status}`);
 		} finally {
 			clearTimeout(timeout);
 		}


### PR DESCRIPTION
Step was needed for running `install-sysroot` due to its build/ dev dependency `ansi-colors` which is trivial one for logging, lets remove it and simplify the ci config for linux.