### PR TITLE
Don't set `aria-activedescendant` if input box does not have focus.

### DIFF
--- a/src/vs/platform/quickinput/browser/quickInputController.ts
+++ b/src/vs/platform/quickinput/browser/quickInputController.ts
@@ -213,7 +213,9 @@ export class QuickInputController extends Disposable {
 		const list = this._register(this.instantiationService.createInstance(QuickInputTree, container, this.options.hoverDelegate, this.options.linkOpenerDelegate, listId));
 		inputBox.setAttribute('aria-controls', listId);
 		this._register(list.onDidChangeFocus(() => {
-			inputBox.setAttribute('aria-activedescendant', list.getActiveDescendant() ?? '');
+			if (inputBox.hasFocus()) {
+				inputBox.setAttribute('aria-activedescendant', list.getActiveDescendant() ?? '');
+			}
 		}));
 		this._register(list.onChangedAllVisibleChecked(checked => {
 			checkAll.checked = checked;


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/251068

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
