### PR TITLE
Bring back runCommands tool set

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/terminal.chatAgentTools.contribution.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/terminal.chatAgentTools.contribution.ts
@@ -3,11 +3,14 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { Codicon } from '../../../../../base/common/codicons.js';
 import { Disposable } from '../../../../../base/common/lifecycle.js';
+import { ThemeIcon } from '../../../../../base/common/themables.js';
+import { localize } from '../../../../../nls.js';
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
 import { registerWorkbenchContribution2, WorkbenchPhase, type IWorkbenchContribution } from '../../../../common/contributions.js';
-import { ILanguageModelToolsService } from '../../../chat/common/languageModelToolsService.js';
+import { ILanguageModelToolsService, ToolDataSource } from '../../../chat/common/languageModelToolsService.js';
 import { GetTerminalOutputTool, GetTerminalOutputToolData } from './getTerminalOutputTool.js';
 import { RunInTerminalTool, RunInTerminalToolData } from './runInTerminalTool.js';
 
@@ -31,6 +34,13 @@ class ChatAgentToolsContribution extends Disposable implements IWorkbenchContrib
 		const getTerminalOutputTool = instantiationService.createInstance(GetTerminalOutputTool);
 		this._register(toolsService.registerToolData(GetTerminalOutputToolData));
 		this._register(toolsService.registerToolImplementation(GetTerminalOutputToolData.id, getTerminalOutputTool));
+
+		const toolSet = this._register(toolsService.createToolSet(ToolDataSource.Internal, 'runCommands', 'runCommands', {
+			icon: ThemeIcon.fromId(Codicon.terminal.id),
+			description: localize('toolset.runCommands', 'Runs commands in the terminal')
+		}));
+		toolSet.addTool(RunInTerminalToolData);
+		toolSet.addTool(GetTerminalOutputToolData);
 	}
 }
 registerWorkbenchContribution2(ChatAgentToolsContribution.ID, ChatAgentToolsContribution, WorkbenchPhase.AfterRestored);


### PR DESCRIPTION
Fixes #257145

Not sure how to validate this other than checking the tools list that it's there:

<img width="966" height="306" alt="image" src="https://github.com/user-attachments/assets/c45574de-4a1b-4b12-9c6b-07c7480a7007" />
