### PR TITLE
Reshape chat session api

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadChatSessions.ts
+++ b/src/vs/workbench/api/browser/mainThreadChatSessions.ts
@@ -7,7 +7,7 @@ import { CancellationToken } from '../../../base/common/cancellation.js';
 import { Disposable, DisposableMap } from '../../../base/common/lifecycle.js';
 import { URI, UriComponents } from '../../../base/common/uri.js';
 import { ILogService } from '../../../platform/log/common/log.js';
-import { IChatSessionDefinition, IChatSessionDefinitionProvider, IChatSessionsService } from '../../contrib/chat/common/chatSessionsService.js';
+import { IChatSessionItem, IChatSessionItemProvider, IChatSessionsService } from '../../contrib/chat/common/chatSessionsService.js';
 import { extHostNamedCustomer, IExtHostContext } from '../../services/extensions/common/extHostCustomers.js';
 import { ExtHostContext, MainContext, MainThreadChatSessionsShape } from '../common/extHost.protocol.js';
 
@@ -25,14 +25,14 @@ export class MainThreadChatSessions extends Disposable implements MainThreadChat
 
 	$registerChatSessionItemProvider(handle: number, chatSessionType: string): void {
 		// Register the provider handle - this tracks that a provider exists
-		const provider: IChatSessionDefinitionProvider = {
+		const provider: IChatSessionItemProvider = {
 			chatSessionType,
-			provideChatSessionDefinitions: (token) => this._provideChatSessionsInformation(handle, token)
+			provideChatSessionItems: (token) => this._provideChatSessionItems(handle, token)
 		};
-		this._registrations.set(handle, this._chatSessionsService.registerChatSessionDefinitionProvider(handle, provider));
+		this._registrations.set(handle, this._chatSessionsService.registerChatSessionItemProvider(handle, provider));
 	}
 
-	private async _provideChatSessionsInformation(handle: number, token: CancellationToken): Promise<IChatSessionDefinition[]> {
+	private async _provideChatSessionItems(handle: number, token: CancellationToken): Promise<IChatSessionItem[]> {
 		const proxy = this._extHostContext.getProxy(ExtHostContext.ExtHostChatSessions);
 
 		try {
@@ -56,7 +56,7 @@ export class MainThreadChatSessions extends Disposable implements MainThreadChat
 
 	private _reviveIconPath(
 		iconPath: UriComponents | { light: UriComponents; dark: UriComponents } | { id: string; color?: { id: string } | undefined })
-		: IChatSessionDefinition['iconPath'] {
+		: IChatSessionItem['iconPath'] {
 		if (!iconPath) {
 			return undefined;
 		}

--- a/src/vs/workbench/api/browser/mainThreadChatSessions.ts
+++ b/src/vs/workbench/api/browser/mainThreadChatSessions.ts
@@ -7,7 +7,7 @@ import { CancellationToken } from '../../../base/common/cancellation.js';
 import { Disposable, DisposableMap } from '../../../base/common/lifecycle.js';
 import { URI, UriComponents } from '../../../base/common/uri.js';
 import { ILogService } from '../../../platform/log/common/log.js';
-import { IChatSessionContent, IChatSessionsProvider, IChatSessionsService } from '../../contrib/chat/common/chatSessionsService.js';
+import { IChatSessionDefinition, IChatSessionDefinitionProvider, IChatSessionsService } from '../../contrib/chat/common/chatSessionsService.js';
 import { extHostNamedCustomer, IExtHostContext } from '../../services/extensions/common/extHostCustomers.js';
 import { ExtHostContext, MainContext, MainThreadChatSessionsShape } from '../common/extHost.protocol.js';
 
@@ -23,24 +23,24 @@ export class MainThreadChatSessions extends Disposable implements MainThreadChat
 		super();
 	}
 
-	$registerChatSessionsProvider(handle: number, chatSessionType: string): void {
+	$registerChatSessionItemProvider(handle: number, chatSessionType: string): void {
 		// Register the provider handle - this tracks that a provider exists
-		const provider: IChatSessionsProvider = {
+		const provider: IChatSessionDefinitionProvider = {
 			chatSessionType,
-			provideChatSessions: (token) => this._provideChatSessionsInformation(handle, token)
+			provideChatSessionDefinitions: (token) => this._provideChatSessionsInformation(handle, token)
 		};
-		this._registrations.set(handle, this._chatSessionsService.registerChatSessionsProvider(handle, provider));
+		this._registrations.set(handle, this._chatSessionsService.registerChatSessionDefinitionProvider(handle, provider));
 	}
 
-	private async _provideChatSessionsInformation(handle: number, token: CancellationToken): Promise<IChatSessionContent[]> {
+	private async _provideChatSessionsInformation(handle: number, token: CancellationToken): Promise<IChatSessionDefinition[]> {
 		const proxy = this._extHostContext.getProxy(ExtHostContext.ExtHostChatSessions);
 
 		try {
 			// Get all results as an array from the RPC call
-			const sessions = await proxy.$provideChatSessions(handle, token);
+			const sessions = await proxy.$provideChatSessionItems(handle, token);
 			return sessions.map(session => ({
 				...session,
-				uri: URI.revive(session.uri),
+				id: session.id,
 				iconPath: session.iconPath ? this._reviveIconPath(session.iconPath) : undefined
 			}));
 		} catch (error) {
@@ -49,14 +49,14 @@ export class MainThreadChatSessions extends Disposable implements MainThreadChat
 		return [];
 	}
 
-	$unregisterChatSessionsProvider(handle: number): void {
+	$unregisterChatSessionItemProvider(handle: number): void {
 		this._registrations.deleteAndDispose(handle);
 	}
 
 
 	private _reviveIconPath(
 		iconPath: UriComponents | { light: UriComponents; dark: UriComponents } | { id: string; color?: { id: string } | undefined })
-		: IChatSessionContent['iconPath'] {
+		: IChatSessionDefinition['iconPath'] {
 		if (!iconPath) {
 			return undefined;
 		}

--- a/src/vs/workbench/api/common/extHost.api.impl.ts
+++ b/src/vs/workbench/api/common/extHost.api.impl.ts
@@ -1505,9 +1505,9 @@ export function createApiFactoryAndRegisterActors(accessor: ServicesAccessor): I
 				checkProposedApiEnabled(extension, 'chatParticipantPrivate');
 				return _asExtensionEvent(extHostChatAgents2.onDidDisposeChatSession)(listeners, thisArgs, disposables);
 			},
-			registerChatSessionsProvider(provider: vscode.ChatSessionsProvider) {
+			registerChatSessionItemProvider(chatSessionType: string, provider: vscode.ChatSessionItemProvider) {
 				checkProposedApiEnabled(extension, 'chatSessionsProvider');
-				return extHostChatSessions.registerChatSessionsProvider(provider);
+				return extHostChatSessions.registerChatSessionItemProvider(chatSessionType, provider);
 			},
 		};
 

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -58,7 +58,7 @@ import { ICodeMapperRequest, ICodeMapperResult } from '../../contrib/chat/common
 import { IChatRelatedFile, IChatRelatedFileProviderMetadata as IChatRelatedFilesProviderMetadata, IChatRequestDraft } from '../../contrib/chat/common/chatEditingService.js';
 import { IChatProgressHistoryResponseContent } from '../../contrib/chat/common/chatModel.js';
 import { IChatContentInlineReference, IChatFollowup, IChatNotebookEdit, IChatProgress, IChatTask, IChatTaskDto, IChatUserActionEvent, IChatVoteAction } from '../../contrib/chat/common/chatService.js';
-import { IChatSessionContent } from '../../contrib/chat/common/chatSessionsService.js';
+import { IChatSessionDefinition as IChatSessionDefinition } from '../../contrib/chat/common/chatSessionsService.js';
 import { IChatRequestVariableValue } from '../../contrib/chat/common/chatVariables.js';
 import { ChatAgentLocation } from '../../contrib/chat/common/constants.js';
 import { IChatMessage, IChatResponseFragment, ILanguageModelChatMetadataAndIdentifier, ILanguageModelChatSelector } from '../../contrib/chat/common/languageModels.js';
@@ -3102,12 +3102,12 @@ export interface MainThreadChatStatusShape {
 }
 
 export interface MainThreadChatSessionsShape extends IDisposable {
-	$registerChatSessionsProvider(handle: number, chatSessionType: string): void;
-	$unregisterChatSessionsProvider(handle: number): void;
+	$registerChatSessionItemProvider(handle: number, chatSessionType: string): void;
+	$unregisterChatSessionItemProvider(handle: number): void;
 }
 
 export interface ExtHostChatSessionsShape {
-	$provideChatSessions(handle: number, token: CancellationToken): Promise<IChatSessionContent[]>;
+	$provideChatSessionItems(handle: number, token: CancellationToken): Promise<IChatSessionDefinition[]>;
 }
 
 // --- proxy identifiers

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -58,7 +58,7 @@ import { ICodeMapperRequest, ICodeMapperResult } from '../../contrib/chat/common
 import { IChatRelatedFile, IChatRelatedFileProviderMetadata as IChatRelatedFilesProviderMetadata, IChatRequestDraft } from '../../contrib/chat/common/chatEditingService.js';
 import { IChatProgressHistoryResponseContent } from '../../contrib/chat/common/chatModel.js';
 import { IChatContentInlineReference, IChatFollowup, IChatNotebookEdit, IChatProgress, IChatTask, IChatTaskDto, IChatUserActionEvent, IChatVoteAction } from '../../contrib/chat/common/chatService.js';
-import { IChatSessionDefinition as IChatSessionDefinition } from '../../contrib/chat/common/chatSessionsService.js';
+import { IChatSessionItem } from '../../contrib/chat/common/chatSessionsService.js';
 import { IChatRequestVariableValue } from '../../contrib/chat/common/chatVariables.js';
 import { ChatAgentLocation } from '../../contrib/chat/common/constants.js';
 import { IChatMessage, IChatResponseFragment, ILanguageModelChatMetadataAndIdentifier, ILanguageModelChatSelector } from '../../contrib/chat/common/languageModels.js';
@@ -3107,7 +3107,7 @@ export interface MainThreadChatSessionsShape extends IDisposable {
 }
 
 export interface ExtHostChatSessionsShape {
-	$provideChatSessionItems(handle: number, token: CancellationToken): Promise<IChatSessionDefinition[]>;
+	$provideChatSessionItems(handle: number, token: CancellationToken): Promise<IChatSessionItem[]>;
 }
 
 // --- proxy identifiers

--- a/src/vs/workbench/api/common/extHostChatSessions.ts
+++ b/src/vs/workbench/api/common/extHostChatSessions.ts
@@ -11,7 +11,7 @@ import { Proxied } from '../../services/extensions/common/proxyIdentifier.js';
 import { ExtHostChatSessionsShape, MainContext, MainThreadChatSessionsShape } from './extHost.protocol.js';
 import { ExtHostCommands } from './extHostCommands.js';
 import { IExtHostRpcService } from './extHostRpcService.js';
-import { IChatSessionDefinition as IChatSessionItem } from '../../contrib/chat/common/chatSessionsService.js';
+import { IChatSessionItem } from '../../contrib/chat/common/chatSessionsService.js';
 
 export class ExtHostChatSessions extends Disposable implements ExtHostChatSessionsShape {
 

--- a/src/vs/workbench/api/common/extHostChatSessions.ts
+++ b/src/vs/workbench/api/common/extHostChatSessions.ts
@@ -3,30 +3,23 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Disposable, DisposableStore } from '../../../base/common/lifecycle.js';
-import { createDecorator } from '../../../platform/instantiation/common/instantiation.js';
-import { IExtHostRpcService } from './extHostRpcService.js';
-import { ExtHostChatSessionsShape, MainContext, MainThreadChatSessionsShape } from './extHost.protocol.js';
 import type * as vscode from 'vscode';
-import { ILogService } from '../../../platform/log/common/log.js';
-import { Proxied } from '../../services/extensions/common/proxyIdentifier.js';
-import { ExtHostCommands } from './extHostCommands.js';
+import { Disposable, DisposableStore } from '../../../base/common/lifecycle.js';
 import { MarshalledId } from '../../../base/common/marshallingIds.js';
 import { URI } from '../../../base/common/uri.js';
+import { ILogService } from '../../../platform/log/common/log.js';
+import { Proxied } from '../../services/extensions/common/proxyIdentifier.js';
+import { ExtHostChatSessionsShape, MainContext, MainThreadChatSessionsShape } from './extHost.protocol.js';
+import { ExtHostCommands } from './extHostCommands.js';
+import { IExtHostRpcService } from './extHostRpcService.js';
+import { IChatSessionContent } from '../../contrib/chat/common/chatSessionsService.js';
 
-export interface IExtHostChatSessions extends ExtHostChatSessionsShape {
-	registerChatSessionsProvider(provider: vscode.ChatSessionsProvider): vscode.Disposable;
-	$provideChatSessions(handle: number, token: vscode.CancellationToken): Promise<vscode.ChatSessionContent[]>;
-}
-export const IExtHostChatSessions = createDecorator<IExtHostChatSessions>('IExtHostChatSessions');
-
-export class ExtHostChatSessions extends Disposable implements IExtHostChatSessions {
-	declare _serviceBrand: undefined;
+export class ExtHostChatSessions extends Disposable implements ExtHostChatSessionsShape {
 
 	private readonly _proxy: Proxied<MainThreadChatSessionsShape>;
-	private readonly _statusProviders = new Map<number, { provider: vscode.ChatSessionsProvider; disposable: DisposableStore }>();
+	private readonly _statusProviders = new Map<number, { provider: vscode.ChatSessionItemProvider; disposable: DisposableStore }>();
 	private _nextHandle = 0;
-	private _sessionMap: Map<string, vscode.ChatSessionContent> = new Map();
+	private _sessionMap: Map<string, vscode.ChatSessionItem> = new Map();
 
 	constructor(
 		commands: ExtHostCommands,
@@ -54,32 +47,35 @@ export class ExtHostChatSessions extends Disposable implements IExtHostChatSessi
 		});
 	}
 
-	registerChatSessionsProvider(provider: vscode.ChatSessionsProvider): vscode.Disposable {
+	registerChatSessionItemProvider(chatSessionType: string, provider: vscode.ChatSessionItemProvider): vscode.Disposable {
 		const handle = this._nextHandle++;
 		const disposables = new DisposableStore();
 
 		this._statusProviders.set(handle, { provider, disposable: disposables });
-		this._proxy.$registerChatSessionsProvider(handle, provider.chatSessionType);
+		this._proxy.$registerChatSessionsProvider(handle, chatSessionType);
 
 		return {
 			dispose: () => {
 				this._statusProviders.delete(handle);
 				disposables.dispose();
-				provider.dispose();
 				this._proxy.$unregisterChatSessionsProvider(handle);
 			}
 		};
 	}
 
-	async $provideChatSessions(handle: number, token: vscode.CancellationToken): Promise<vscode.ChatSessionContent[]> {
+	async $provideChatSessions(handle: number, token: vscode.CancellationToken): Promise<IChatSessionContent[]> {
 		const entry = this._statusProviders.get(handle);
 		if (!entry) {
 			this._logService.error(`No provider registered for handle ${handle}`);
 			return [];
 		}
 
-		const sessions = await entry.provider.provideChatSessions(token);
-		const response: vscode.ChatSessionContent[] = [];
+		const sessions = await entry.provider.provideChatSessionItems(token);
+		if (!sessions) {
+			return [];
+		}
+
+		const response: IChatSessionContent[] = [];
 		for (const sessionContent of sessions) {
 			if (sessionContent.uri) {
 				this._sessionMap.set(

--- a/src/vs/workbench/contrib/chat/browser/actions/chatActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatActions.ts
@@ -565,7 +565,7 @@ export function registerChatActions() {
 						const cancellationToken = new CancellationTokenSource();
 
 						try {
-							const sessions = await chatSessionsService.provideChatSessionDefinitions(cancellationToken.token);
+							const sessions = await chatSessionsService.provideChatSessionItems(cancellationToken.token);
 
 							for (const session of sessions) {
 								const sessionContent = session.session;
@@ -845,7 +845,7 @@ export function registerChatActions() {
 			}
 
 			const showAgentSessionsMenuConfig = configurationService.getValue<string>(ChatConfiguration.AgentSessionsViewLocation);
-			if (showAgentSessionsMenuConfig === 'showChatsMenu' && chatSessionsService.hasChatSessionDefinitionProviders) {
+			if (showAgentSessionsMenuConfig === 'showChatsMenu' && chatSessionsService.hasChatSessionItemProviders) {
 				await this.showIntegratedPicker(
 					chatService,
 					quickInputService,

--- a/src/vs/workbench/contrib/chat/browser/actions/chatActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatActions.ts
@@ -565,7 +565,7 @@ export function registerChatActions() {
 						const cancellationToken = new CancellationTokenSource();
 
 						try {
-							const sessions = await chatSessionsService.provideChatSessions(cancellationToken.token);
+							const sessions = await chatSessionsService.provideChatSessionDefinitions(cancellationToken.token);
 
 							for (const session of sessions) {
 								const sessionContent = session.session;
@@ -588,17 +588,17 @@ export function registerChatActions() {
 									label: sessionContent.label,
 									description: '',
 									chat: {
-										sessionId: sessionContent.uri.toString(),
+										sessionId: sessionContent.id,
 										title: sessionContent.label,
 										isActive: false,
 										lastMessageDate: 0,
 									},
 									buttons,
-									uri: sessionContent.uri
+									id: sessionContent.id
 								};
 
 								// Check if this agent already exists (update existing or add new)
-								const existingIndex = agentPicks.findIndex(pick => pick.chat.sessionId === sessionContent.uri.path);
+								const existingIndex = agentPicks.findIndex(pick => pick.chat.sessionId === sessionContent.id);
 								if (existingIndex >= 0) {
 									agentPicks[existingIndex] = agentPick;
 								} else {
@@ -845,7 +845,7 @@ export function registerChatActions() {
 			}
 
 			const showAgentSessionsMenuConfig = configurationService.getValue<string>(ChatConfiguration.AgentSessionsViewLocation);
-			if (showAgentSessionsMenuConfig === 'showChatsMenu' && chatSessionsService.hasChatSessionsProviders) {
+			if (showAgentSessionsMenuConfig === 'showChatsMenu' && chatSessionsService.hasChatSessionDefinitionProviders) {
 				await this.showIntegratedPicker(
 					chatService,
 					quickInputService,

--- a/src/vs/workbench/contrib/chat/browser/actions/chatActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatActions.ts
@@ -746,7 +746,7 @@ export function registerChatActions() {
 					if (buttonItem.id) {
 						const contextItem = context.item as ICodingAgentPickerItem;
 						commandService.executeCommand(buttonItem.id, {
-							uri: contextItem.uri,
+							id: contextItem.id,
 							$mid: MarshalledId.ChatSessionContext
 						});
 					}
@@ -790,13 +790,13 @@ export function registerChatActions() {
 							true
 						);
 						return;
-					} else if ((item as ICodingAgentPickerItem).uri !== undefined) {
+					} else if ((item as ICodingAgentPickerItem).id !== undefined) {
 						// TODO: This is a temporary change that will be replaced by opening a new chat instance
 						if (item.buttons && item.buttons.length > 0) {
 							const pickedItem = (item.buttons[0] as ICodingAgentPickerItem);
 							if (pickedItem.id) {
 								commandService.executeCommand(pickedItem.id, {
-									uri: (item as ICodingAgentPickerItem).uri,
+									id: (item as ICodingAgentPickerItem).id,
 									$mid: MarshalledId.ChatSessionContext
 								});
 							}

--- a/src/vs/workbench/contrib/chat/common/chatSessionsService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatSessionsService.ts
@@ -11,8 +11,8 @@ import { InstantiationType, registerSingleton } from '../../../../platform/insta
 import { URI } from '../../../../base/common/uri.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
 
-export interface IChatSessionContent {
-	uri: URI;
+export interface IChatSessionDefinition {
+	id: string;
 	label: string;
 	iconPath?: URI | {
 		light: URI;
@@ -20,23 +20,23 @@ export interface IChatSessionContent {
 	} | ThemeIcon;
 }
 
-export interface IChatSessionsProvider {
+export interface IChatSessionDefinitionProvider {
 	readonly chatSessionType: string;
-	provideChatSessions(token: CancellationToken): Promise<IChatSessionContent[]>;
+	provideChatSessionDefinitions(token: CancellationToken): Promise<IChatSessionDefinition[]>;
 }
 
 export interface IChatSessionsService {
 	readonly _serviceBrand: undefined;
-	registerChatSessionsProvider(handle: number, provider: IChatSessionsProvider): IDisposable;
-	hasChatSessionsProviders: boolean;
-	provideChatSessions(token: CancellationToken): Promise<{ provider: IChatSessionsProvider; session: IChatSessionContent }[]>;
+	registerChatSessionDefinitionProvider(handle: number, provider: IChatSessionDefinitionProvider): IDisposable;
+	hasChatSessionDefinitionProviders: boolean;
+	provideChatSessionDefinitions(token: CancellationToken): Promise<{ provider: IChatSessionDefinitionProvider; session: IChatSessionDefinition }[]>;
 }
 
 export const IChatSessionsService = createDecorator<IChatSessionsService>('chatSessionsService');
 
 export class ChatSessionsService extends Disposable implements IChatSessionsService {
 	readonly _serviceBrand: undefined;
-	private _providers: Map<number, IChatSessionsProvider> = new Map();
+	private _providers: Map<number, IChatSessionDefinitionProvider> = new Map();
 
 	constructor(
 		@ILogService private readonly _logService: ILogService,
@@ -44,14 +44,14 @@ export class ChatSessionsService extends Disposable implements IChatSessionsServ
 		super();
 	}
 
-	public async provideChatSessions(token: CancellationToken): Promise<{ provider: IChatSessionsProvider; session: IChatSessionContent }[]> {
-		const results: { provider: IChatSessionsProvider; session: IChatSessionContent }[] = [];
+	public async provideChatSessionDefinitions(token: CancellationToken): Promise<{ provider: IChatSessionDefinitionProvider; session: IChatSessionDefinition }[]> {
+		const results: { provider: IChatSessionDefinitionProvider; session: IChatSessionDefinition }[] = [];
 
 		// Iterate through all registered providers and collect their results
 		for (const [handle, provider] of this._providers) {
 			try {
-				if (provider.provideChatSessions) {
-					const sessions = await provider.provideChatSessions(token);
+				if (provider.provideChatSessionDefinitions) {
+					const sessions = await provider.provideChatSessionDefinitions(token);
 					results.push(...sessions.map(session => ({ provider, session })));
 				}
 			} catch (error) {
@@ -65,7 +65,7 @@ export class ChatSessionsService extends Disposable implements IChatSessionsServ
 		return results;
 	}
 
-	public registerChatSessionsProvider(handle: number, provider: IChatSessionsProvider): IDisposable {
+	public registerChatSessionDefinitionProvider(handle: number, provider: IChatSessionDefinitionProvider): IDisposable {
 		this._providers.set(handle, provider);
 		return {
 			dispose: () => {
@@ -74,7 +74,7 @@ export class ChatSessionsService extends Disposable implements IChatSessionsServ
 		};
 	}
 
-	public get hasChatSessionsProviders(): boolean {
+	public get hasChatSessionDefinitionProviders(): boolean {
 		return this._providers.size > 0;
 	}
 }

--- a/src/vs/workbench/contrib/chat/common/chatSessionsService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatSessionsService.ts
@@ -11,7 +11,7 @@ import { InstantiationType, registerSingleton } from '../../../../platform/insta
 import { URI } from '../../../../base/common/uri.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
 
-export interface IChatSessionDefinition {
+export interface IChatSessionItem {
 	id: string;
 	label: string;
 	iconPath?: URI | {
@@ -20,23 +20,23 @@ export interface IChatSessionDefinition {
 	} | ThemeIcon;
 }
 
-export interface IChatSessionDefinitionProvider {
+export interface IChatSessionItemProvider {
 	readonly chatSessionType: string;
-	provideChatSessionDefinitions(token: CancellationToken): Promise<IChatSessionDefinition[]>;
+	provideChatSessionItems(token: CancellationToken): Promise<IChatSessionItem[]>;
 }
 
 export interface IChatSessionsService {
 	readonly _serviceBrand: undefined;
-	registerChatSessionDefinitionProvider(handle: number, provider: IChatSessionDefinitionProvider): IDisposable;
-	hasChatSessionDefinitionProviders: boolean;
-	provideChatSessionDefinitions(token: CancellationToken): Promise<{ provider: IChatSessionDefinitionProvider; session: IChatSessionDefinition }[]>;
+	registerChatSessionItemProvider(handle: number, provider: IChatSessionItemProvider): IDisposable;
+	hasChatSessionItemProviders: boolean;
+	provideChatSessionItems(token: CancellationToken): Promise<{ provider: IChatSessionItemProvider; session: IChatSessionItem }[]>;
 }
 
 export const IChatSessionsService = createDecorator<IChatSessionsService>('chatSessionsService');
 
 export class ChatSessionsService extends Disposable implements IChatSessionsService {
 	readonly _serviceBrand: undefined;
-	private _providers: Map<number, IChatSessionDefinitionProvider> = new Map();
+	private _providers: Map<number, IChatSessionItemProvider> = new Map();
 
 	constructor(
 		@ILogService private readonly _logService: ILogService,
@@ -44,14 +44,14 @@ export class ChatSessionsService extends Disposable implements IChatSessionsServ
 		super();
 	}
 
-	public async provideChatSessionDefinitions(token: CancellationToken): Promise<{ provider: IChatSessionDefinitionProvider; session: IChatSessionDefinition }[]> {
-		const results: { provider: IChatSessionDefinitionProvider; session: IChatSessionDefinition }[] = [];
+	public async provideChatSessionItems(token: CancellationToken): Promise<{ provider: IChatSessionItemProvider; session: IChatSessionItem }[]> {
+		const results: { provider: IChatSessionItemProvider; session: IChatSessionItem }[] = [];
 
 		// Iterate through all registered providers and collect their results
 		for (const [handle, provider] of this._providers) {
 			try {
-				if (provider.provideChatSessionDefinitions) {
-					const sessions = await provider.provideChatSessionDefinitions(token);
+				if (provider.provideChatSessionItems) {
+					const sessions = await provider.provideChatSessionItems(token);
 					results.push(...sessions.map(session => ({ provider, session })));
 				}
 			} catch (error) {
@@ -65,7 +65,7 @@ export class ChatSessionsService extends Disposable implements IChatSessionsServ
 		return results;
 	}
 
-	public registerChatSessionDefinitionProvider(handle: number, provider: IChatSessionDefinitionProvider): IDisposable {
+	public registerChatSessionItemProvider(handle: number, provider: IChatSessionItemProvider): IDisposable {
 		this._providers.set(handle, provider);
 		return {
 			dispose: () => {
@@ -74,7 +74,7 @@ export class ChatSessionsService extends Disposable implements IChatSessionsServ
 		};
 	}
 
-	public get hasChatSessionDefinitionProviders(): boolean {
+	public get hasChatSessionItemProviders(): boolean {
 		return this._providers.size > 0;
 	}
 }

--- a/src/vscode-dts/vscode.proposed.chatSessionsProvider.d.ts
+++ b/src/vscode-dts/vscode.proposed.chatSessionsProvider.d.ts
@@ -9,6 +9,11 @@ declare module 'vscode' {
 	 */
 	export interface ChatSessionItemProvider {
 		/**
+		 * Label of the extension that registers the provider.
+		 */
+		readonly label: string;
+
+		/**
 		 * Event that the provider can fire to signal that chat sessions have changed.
 		 */
 		readonly onDidChangeChatSessionItems: Event<void>;

--- a/src/vscode-dts/vscode.proposed.chatSessionsProvider.d.ts
+++ b/src/vscode-dts/vscode.proposed.chatSessionsProvider.d.ts
@@ -5,30 +5,25 @@
 
 declare module 'vscode' {
 	/**
-	 * Provides a list of chat sessions
+	 * Provides a list of information about chat sessions.
 	 */
-	export interface ChatSessionsProvider extends Disposable {
+	export interface ChatSessionItemProvider {
 		/**
-		 * Type to identify providers.
+		 * Event that the provider can fire to signal that chat sessions have changed.
 		 */
-		readonly chatSessionType: string;
+		readonly onDidChangeChatSessionItems: Event<void>;
 
 		/**
-		 * Fired when chat sessions change.
+		 * Provides a list of chat sessions.
 		 */
-		readonly onDidChangeChatSessionContent: Event<void>;
-
-		/**
-		 * Provide a list of chat sessions.
-		 * */
-		provideChatSessions(token: CancellationToken): Thenable<ChatSessionContent[]>;
+		provideChatSessionItems(token: CancellationToken): ProviderResult<ChatSessionItem[]>;
 	}
 
-	export interface ChatSessionContent {
+	export interface ChatSessionItem {
 		/**
-		 * Identifies the session
-		 *		 */
-		uri: Uri;
+		 * Unique identifier for the chat session.
+		 */
+		id: string;
 
 		/**
 		 * Human readable name of the session shown in the UI
@@ -42,6 +37,6 @@ declare module 'vscode' {
 	}
 
 	export namespace chat {
-		export function registerChatSessionsProvider(provider: ChatSessionsProvider): Disposable;
+		export function registerChatSessionItemProvider(chatSessionType: string, provider: ChatSessionItemProvider): Disposable;
 	}
 }


### PR DESCRIPTION
Name and shape cleanup

@osortega Can you take over this pr to finish hooking it up. The big change is from uri -> id. We can still use a uri internally if we want but I think externally in the APIs we should just use `sessionType` and `sessionId` as a pair to identify sessions 