### PR TITLE
Error handling of create worktree and fix create worktree... command from command palette 

### DIFF
--- a/extensions/git/src/api/git.d.ts
+++ b/extensions/git/src/api/git.d.ts
@@ -441,5 +441,6 @@ export const enum GitErrorCodes {
 	TagConflict = 'TagConflict',
 	CherryPickEmpty = 'CherryPickEmpty',
 	CherryPickConflict = 'CherryPickConflict',
-	WorktreeContainsChanges = 'WorktreeContainsChanges'
+	WorktreeContainsChanges = 'WorktreeContainsChanges',
+	WorktreeAlreadyExists = 'WorktreeAlreadyExists'
 }

--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -3395,6 +3395,10 @@ export class CommandCenter {
 		dispose(disposables);
 		inputBox.dispose();
 
+		if (!worktreeName) {
+			return;
+		}
+
 		// Default to view parent directory of repository root
 		const defaultUri = Uri.file(path.dirname(repository.root));
 

--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -3351,9 +3351,17 @@ export class CommandCenter {
 		}
 	}
 
-	@command('git.createWorktree', { repository: true })
-	async createWorktree(repository: Repository): Promise<void> {
-		await this._createWorktree(repository, undefined, undefined);
+	@command('git.createWorktree')
+	async createWorktree(): Promise<void> {
+		const mainRepository = this.model.repositories.find(repo =>
+			!repo.dotGit.commonPath
+		);
+
+		if (!mainRepository) {
+			return;
+		}
+
+		await this._createWorktree(mainRepository, undefined, undefined);
 	}
 
 	private async _createWorktree(repository: Repository, worktreePath?: string, name?: string): Promise<void> {
@@ -3420,10 +3428,7 @@ export class CommandCenter {
 
 		worktreePath = path.join(uris[0].fsPath, worktreeName);
 
-		await repository.worktree({
-			name: name,
-			path: worktreePath,
-		});
+		await repository.worktree({ name: name, path: worktreePath });
 	}
 
 	@command('git.deleteWorktree', { repository: true })

--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -3351,17 +3351,9 @@ export class CommandCenter {
 		}
 	}
 
-	@command('git.createWorktree')
-	async createWorktree(): Promise<void> {
-		const mainRepository = this.model.repositories.find(repo =>
-			!repo.dotGit.commonPath
-		);
-
-		if (!mainRepository) {
-			return;
-		}
-
-		await this._createWorktree(mainRepository, undefined, undefined);
+	@command('git.createWorktree', { repository: true })
+	async createWorktree(repository: Repository): Promise<void> {
+		await this._createWorktree(repository, undefined, undefined);
 	}
 
 	private async _createWorktree(repository: Repository, worktreePath?: string, name?: string): Promise<void> {

--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -351,6 +351,8 @@ function getGitErrorCode(stderr: string): string | undefined {
 		return GitErrorCodes.NotASafeGitRepository;
 	} else if (/contains modified or untracked files|use --force to delete it/.test(stderr)) {
 		return GitErrorCodes.WorktreeContainsChanges;
+	} else if (/is already used by worktree at|already exists/.test(stderr)) {
+		return GitErrorCodes.WorktreeAlreadyExists;
 	}
 
 	return undefined;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
This PR resolves 3 things:

- Exits creation of worktree when user escapes worktree name input box
- Chooses the main repo as context when creating a worktree from command palette (gets rid of repo picker)
- Handles errors when creating worktree with dialog 

https://github.com/user-attachments/assets/67bca871-db7a-44aa-80b0-cc70b13923ae


