### PR TITLE
Move off of AsyncIterableObject

### DIFF
--- a/src/tsconfig.base.json
+++ b/src/tsconfig.base.json
@@ -19,7 +19,8 @@
 			"ES2022",
 			"DOM",
 			"DOM.Iterable",
-			"WebWorker.ImportScripts"
+			"WebWorker.ImportScripts",
+			"ESNext.Array"
 		],
 		"allowSyntheticDefaultImports": true
 	}

--- a/src/tsconfig.base.json
+++ b/src/tsconfig.base.json
@@ -19,8 +19,7 @@
 			"ES2022",
 			"DOM",
 			"DOM.Iterable",
-			"WebWorker.ImportScripts",
-			"ESNext.Array"
+			"WebWorker.ImportScripts"
 		],
 		"allowSyntheticDefaultImports": true
 	}

--- a/src/vs/editor/contrib/hover/browser/getHover.ts
+++ b/src/vs/editor/contrib/hover/browser/getHover.ts
@@ -40,10 +40,12 @@ export function getHoverProviderResultsAsAsyncIterable(registry: LanguageFeature
 	return AsyncIterableObject.fromPromisesResolveOrder(promises).coalesce();
 }
 
-export function getHoversPromise(registry: LanguageFeatureRegistry<HoverProvider>, model: ITextModel, position: Position, token: CancellationToken, recursive = false): Promise<Hover[]> {
-	return Array.fromAsync(
-		getHoverProviderResultsAsAsyncIterable(registry, model, position, token, recursive),
-		item => item.hover);
+export async function getHoversPromise(registry: LanguageFeatureRegistry<HoverProvider>, model: ITextModel, position: Position, token: CancellationToken, recursive = false): Promise<Hover[]> {
+	const out: Hover[] = [];
+	for await (const item of getHoverProviderResultsAsAsyncIterable(registry, model, position, token, recursive)) {
+		out.push(item.hover);
+	}
+	return out;
 }
 
 registerModelAndPositionCommand('_executeHoverProvider', (accessor, model, position): Promise<Hover[]> => {

--- a/src/vs/editor/contrib/hover/browser/getHover.ts
+++ b/src/vs/editor/contrib/hover/browser/getHover.ts
@@ -34,14 +34,16 @@ async function executeProvider(provider: HoverProvider, ordinal: number, model: 
 	return new HoverProviderResult(provider, result, ordinal);
 }
 
-export function getHoverProviderResultsAsAsyncIterable(registry: LanguageFeatureRegistry<HoverProvider>, model: ITextModel, position: Position, token: CancellationToken, recursive = false): AsyncIterableObject<HoverProviderResult> {
+export function getHoverProviderResultsAsAsyncIterable(registry: LanguageFeatureRegistry<HoverProvider>, model: ITextModel, position: Position, token: CancellationToken, recursive = false): AsyncIterable<HoverProviderResult> {
 	const providers = registry.ordered(model, recursive);
 	const promises = providers.map((provider, index) => executeProvider(provider, index, model, position, token));
 	return AsyncIterableObject.fromPromisesResolveOrder(promises).coalesce();
 }
 
 export function getHoversPromise(registry: LanguageFeatureRegistry<HoverProvider>, model: ITextModel, position: Position, token: CancellationToken, recursive = false): Promise<Hover[]> {
-	return getHoverProviderResultsAsAsyncIterable(registry, model, position, token, recursive).map(item => item.hover).toPromise();
+	return Array.fromAsync(
+		getHoverProviderResultsAsAsyncIterable(registry, model, position, token, recursive),
+		item => item.hover);
 }
 
 registerModelAndPositionCommand('_executeHoverProvider', (accessor, model, position): Promise<Hover[]> => {

--- a/src/vs/editor/contrib/hover/browser/hoverTypes.ts
+++ b/src/vs/editor/contrib/hover/browser/hoverTypes.ts
@@ -4,16 +4,15 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Dimension } from '../../../../base/browser/dom.js';
-import { AsyncIterableObject } from '../../../../base/common/async.js';
 import { CancellationToken } from '../../../../base/common/cancellation.js';
 import { IDisposable } from '../../../../base/common/lifecycle.js';
+import { ScrollEvent } from '../../../../base/common/scrollable.js';
+import { BrandedService, IConstructorSignature } from '../../../../platform/instantiation/common/instantiation.js';
 import { ICodeEditor, IEditorMouseEvent } from '../../../browser/editorBrowser.js';
 import { Position } from '../../../common/core/position.js';
 import { Range } from '../../../common/core/range.js';
 import { IModelDecoration } from '../../../common/model.js';
-import { BrandedService, IConstructorSignature } from '../../../../platform/instantiation/common/instantiation.js';
 import { HoverStartSource } from './hoverOperation.js';
-import { ScrollEvent } from '../../../../base/common/scrollable.js';
 
 export interface IHoverPart {
 	/**
@@ -163,7 +162,7 @@ export interface IEditorHoverParticipant<T extends IHoverPart = IHoverPart> {
 	readonly hoverOrdinal: number;
 	suggestHoverAnchor?(mouseEvent: IEditorMouseEvent): HoverAnchor | null;
 	computeSync(anchor: HoverAnchor, lineDecorations: IModelDecoration[], source: HoverStartSource): T[];
-	computeAsync?(anchor: HoverAnchor, lineDecorations: IModelDecoration[], source: HoverStartSource, token: CancellationToken): AsyncIterableObject<T>;
+	computeAsync?(anchor: HoverAnchor, lineDecorations: IModelDecoration[], source: HoverStartSource, token: CancellationToken): AsyncIterable<T>;
 	createLoadingMessage?(anchor: HoverAnchor): T | null;
 	renderHoverParts(context: IEditorHoverRenderContext, hoverParts: T[]): IRenderedHoverParts<T>;
 	getAccessibleContent(hoverPart: T): string;


### PR DESCRIPTION
For #256854

Replaces with async generator usage and the new `Array.fromAsync` helper
