### PR TITLE
Store client id and secret in DynamicAuthProvider ctor

### DIFF
--- a/src/vs/workbench/api/common/extHostAuthentication.ts
+++ b/src/vs/workbench/api/common/extHostAuthentication.ts
@@ -320,6 +320,8 @@ export class DynamicAuthProvider implements vscode.AuthenticationProvider {
 			: stringifiedServer;
 		// Auth Provider label is just the resource name if provided, otherwise the authority of the authorization server.
 		this.label = _resourceMetadata?.resource_name ?? this.authorizationServer.authority;
+		this._clientId = _clientId;
+		this._clientSecret = _clientSecret;
 
 		this._logger = loggerService.createLogger(this.id, { name: this.label });
 		this._disposable = new DisposableStore();


### PR DESCRIPTION
Hi! I'm debugging why `client_secret` is omitted from calls to my oauth token endpoint when testing locally. Neither the `Authorization` header or `client_secret` field are set. The oauth flow works fine with both the MCP inspector and Claude Code, fwiw. I'm unfortunately not able to find any useful trace logs in vscode. When I try to restart the server to test the flow, after one initial failure, the `MCP: *` logs spin with `Waiting for server to respond to `initialize` request...`. This prevents me from switching the MCP: * logs to trace early enough in the flow.

As best as I can tell, the call to [exchangeCodeForToken](https://github.com/microsoft/vscode/blob/3d2a04de2ae305e05a592665b6d3b52ec1a63386/src/vs/workbench/api/common/extHostAuthentication.ts#L608) is omitting the client_secret field which implies the [_clientSecret](https://github.com/microsoft/vscode/blob/3d2a04de2ae305e05a592665b6d3b52ec1a63386/src/vs/workbench/api/common/extHostAuthentication.ts#L312) field on DynamicAuthProvider is unset when called in [registerDynamicAuthProvider](https://github.com/microsoft/vscode/blob/3d2a04de2ae305e05a592665b6d3b52ec1a63386/src/vs/workbench/api/common/extHostAuthentication.ts#L184C9-L184C36) or [_createWithLoopbackServer](https://github.com/microsoft/vscode/blob/3d2a04de2ae305e05a592665b6d3b52ec1a63386/src/vs/workbench/api/node/extHostAuthentication.ts#L161). The latter seems likely since my testing is all local (edit: I tried with a non-local server and client_secret is still omitted from the token request).

This PR goes ahead and sets _clientSecret and _clientId in the constructor. Though, I suspect this is naive and incorrect! I don't pretend to understand the codebase!

It might be nice to respect the [token_endpoint_auth_method](https://github.com/microsoft/vscode/blob/16c5a9ac8d71cd49ec56247adf236a71df732a3a/src/vs/base/common/oauth.ts#L199) returned in authorization server metadata. Currently, it's always passed as `none` when [registering](https://github.com/microsoft/vscode/blob/16c5a9ac8d71cd49ec56247adf236a71df732a3a/src/vs/base/common/oauth.ts#L749) a client: 


Here are some details from the flow. I see authorization server metadata like:

```
{
  authorization_endpoint: "http://localhost:3000/oauth/authorize",
  token_endpoint: "http://localhost:3000/oauth/token",
  token_endpoint_auth_methods_supported: ["client_secret_basic"],
  registration_endpoint: "http://localhost:3000/oauth/register",
  issuer: "http://localhost:3000",
  scopes_supported: ["read_write"],
  grant_types_supported: ["authorization_code"],
  response_types_supported: ["code"],
  code_challenge_methods_supported: ["S256"]
}
```

Client registration is successful, I see the client in the `Authentication` command.  The response looks like:

```
{
  client_id: "...",
  client_name: "Visual Studio Code",
  scope: "read_write",
  token_endpoint_auth_method: "client_secret_basic",
  redirect_uris: ["https://insiders.vscode.dev/redirect", "https://vscode.dev/redirect", "http://localhost/", "http://127.0.0.1/", "http://localhost:33418/", "http://127.0.0.1:33418/"],
  grant_types: ["authorization_code", "refresh_token"],
  response_types: ["code"],
  client_secret_expires_at: 1755746519,
  client_secret: "..." }
```

The Authorization request and redirect are successful, but the token endpoint rejects the token call because no authorization header (I logged all headers to confirm) or client_secret parameter are set. The request looks like:

```
{
  grant_type: "authorization_code",
  client_id: "...",
  redirect_uri: "http://127.0.0.1:33418/",
  code: "...",
  code_verifier: "...")
}
```

vscode logs show: `Error getting token from server metadata: Error: Failed to create authentication token`

