### PR TITLE
Add the ability to clear a ChatResponseStream, passing in a reason which results in a warning being displayed

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadChatAgents2.ts
+++ b/src/vs/workbench/api/browser/mainThreadChatAgents2.ts
@@ -245,6 +245,11 @@ export class MainThreadChatAgents2 extends Disposable implements MainThreadChatA
 		chunks.forEach(item => {
 			const [progress, responsePartHandle] = Array.isArray(item) ? item : [item];
 
+			if (progress.kind === 'clear') {
+				chatProgressParts.push({ kind: 'clear', reason: progress.reason });
+				return;
+			}
+
 			const revivedProgress = progress.kind === 'notebookEdit'
 				? ChatNotebookEdit.fromChatEdit(progress)
 				: revive(progress) as IChatProgress;

--- a/src/vs/workbench/api/browser/mainThreadChatAgents2.ts
+++ b/src/vs/workbench/api/browser/mainThreadChatAgents2.ts
@@ -245,8 +245,8 @@ export class MainThreadChatAgents2 extends Disposable implements MainThreadChatA
 		chunks.forEach(item => {
 			const [progress, responsePartHandle] = Array.isArray(item) ? item : [item];
 
-			if (progress.kind === 'clear') {
-				chatProgressParts.push({ kind: 'clear', reason: progress.reason });
+			if (progress.kind === 'clearToPreviousToolInvocation') {
+				chatProgressParts.push({ kind: 'clearToPreviousToolInvocation', reason: progress.reason });
 				return;
 			}
 

--- a/src/vs/workbench/api/browser/mainThreadChatAgents2.ts
+++ b/src/vs/workbench/api/browser/mainThreadChatAgents2.ts
@@ -245,11 +245,6 @@ export class MainThreadChatAgents2 extends Disposable implements MainThreadChatA
 		chunks.forEach(item => {
 			const [progress, responsePartHandle] = Array.isArray(item) ? item : [item];
 
-			if (progress.kind === 'clearToPreviousToolInvocation') {
-				chatProgressParts.push({ kind: 'clearToPreviousToolInvocation', reason: progress.reason });
-				return;
-			}
-
 			const revivedProgress = progress.kind === 'notebookEdit'
 				? ChatNotebookEdit.fromChatEdit(progress)
 				: revive(progress) as IChatProgress;

--- a/src/vs/workbench/api/common/extHost.api.impl.ts
+++ b/src/vs/workbench/api/common/extHost.api.impl.ts
@@ -1859,6 +1859,7 @@ export function createApiFactoryAndRegisterActors(accessor: ServicesAccessor): I
 			ChatPrepareToolInvocationPart: extHostTypes.ChatPrepareToolInvocationPart,
 			ChatResponseMultiDiffPart: extHostTypes.ChatResponseMultiDiffPart,
 			ChatResponseReferencePartStatusKind: extHostTypes.ChatResponseReferencePartStatusKind,
+			ChatResponseClearReason: extHostTypes.ChatResponseClearReason,
 			ChatRequestTurn: extHostTypes.ChatRequestTurn,
 			ChatRequestTurn2: extHostTypes.ChatRequestTurn,
 			ChatResponseTurn: extHostTypes.ChatResponseTurn,

--- a/src/vs/workbench/api/common/extHost.api.impl.ts
+++ b/src/vs/workbench/api/common/extHost.api.impl.ts
@@ -1859,7 +1859,7 @@ export function createApiFactoryAndRegisterActors(accessor: ServicesAccessor): I
 			ChatPrepareToolInvocationPart: extHostTypes.ChatPrepareToolInvocationPart,
 			ChatResponseMultiDiffPart: extHostTypes.ChatResponseMultiDiffPart,
 			ChatResponseReferencePartStatusKind: extHostTypes.ChatResponseReferencePartStatusKind,
-			ChatResponseClearReason: extHostTypes.ChatResponseClearReason,
+			ChatResponseClearToPreviousToolInvocationReason: extHostTypes.ChatResponseClearToPreviousToolInvocationReason,
 			ChatRequestTurn: extHostTypes.ChatRequestTurn,
 			ChatRequestTurn2: extHostTypes.ChatRequestTurn,
 			ChatResponseTurn: extHostTypes.ChatResponseTurn,

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -57,7 +57,7 @@ import { IChatAgentMetadata, IChatAgentRequest, IChatAgentResult } from '../../c
 import { ICodeMapperRequest, ICodeMapperResult } from '../../contrib/chat/common/chatCodeMapperService.js';
 import { IChatRelatedFile, IChatRelatedFileProviderMetadata as IChatRelatedFilesProviderMetadata, IChatRequestDraft } from '../../contrib/chat/common/chatEditingService.js';
 import { IChatProgressHistoryResponseContent } from '../../contrib/chat/common/chatModel.js';
-import { IChatContentInlineReference, IChatFollowup, IChatNotebookEdit, IChatProgress, IChatTask, IChatTaskDto, IChatUserActionEvent, IChatVoteAction } from '../../contrib/chat/common/chatService.js';
+import { IChatContentInlineReference, IChatFollowup, IChatNotebookEdit, IChatProgress, IChatTask, IChatTaskDto, IChatUserActionEvent, IChatVoteAction, ChatResponseClearReason } from '../../contrib/chat/common/chatService.js';
 import { IChatSessionItem } from '../../contrib/chat/common/chatSessionsService.js';
 import { IChatRequestVariableValue } from '../../contrib/chat/common/chatVariables.js';
 import { ChatAgentLocation } from '../../contrib/chat/common/constants.js';
@@ -1438,7 +1438,8 @@ export type IDocumentContextDto = {
 export type IChatProgressDto =
 	| Dto<Exclude<IChatProgress, IChatTask | IChatNotebookEdit>>
 	| IChatTaskDto
-	| IChatNotebookEditDto;
+	| IChatNotebookEditDto
+	| IChatResponseClearDto;
 
 export interface ExtHostUrlsShape {
 	$handleExternalUri(handle: number, uri: UriComponents): Promise<void>;
@@ -2191,6 +2192,11 @@ export interface IChatNotebookEditDto {
 	edits: ICellEditOperationDto[];
 	kind: 'notebookEdit';
 	done?: boolean;
+}
+
+export interface IChatResponseClearDto {
+	kind: 'clear';
+	reason: ChatResponseClearReason;
 }
 
 export type ICellEditOperationDto =

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -57,7 +57,7 @@ import { IChatAgentMetadata, IChatAgentRequest, IChatAgentResult } from '../../c
 import { ICodeMapperRequest, ICodeMapperResult } from '../../contrib/chat/common/chatCodeMapperService.js';
 import { IChatRelatedFile, IChatRelatedFileProviderMetadata as IChatRelatedFilesProviderMetadata, IChatRequestDraft } from '../../contrib/chat/common/chatEditingService.js';
 import { IChatProgressHistoryResponseContent } from '../../contrib/chat/common/chatModel.js';
-import { IChatContentInlineReference, IChatFollowup, IChatNotebookEdit, IChatProgress, IChatTask, IChatTaskDto, IChatUserActionEvent, IChatVoteAction, ChatResponseClearReason } from '../../contrib/chat/common/chatService.js';
+import { IChatContentInlineReference, IChatFollowup, IChatNotebookEdit, IChatProgress, IChatTask, IChatTaskDto, IChatUserActionEvent, IChatVoteAction, ChatResponseClearToPreviousToolInvocationReason } from '../../contrib/chat/common/chatService.js';
 import { IChatSessionItem } from '../../contrib/chat/common/chatSessionsService.js';
 import { IChatRequestVariableValue } from '../../contrib/chat/common/chatVariables.js';
 import { ChatAgentLocation } from '../../contrib/chat/common/constants.js';
@@ -1439,7 +1439,7 @@ export type IChatProgressDto =
 	| Dto<Exclude<IChatProgress, IChatTask | IChatNotebookEdit>>
 	| IChatTaskDto
 	| IChatNotebookEditDto
-	| IChatResponseClearDto;
+	| IChatResponseClearToPreviousToolInvocationDto;
 
 export interface ExtHostUrlsShape {
 	$handleExternalUri(handle: number, uri: UriComponents): Promise<void>;
@@ -2194,9 +2194,9 @@ export interface IChatNotebookEditDto {
 	done?: boolean;
 }
 
-export interface IChatResponseClearDto {
-	kind: 'clear';
-	reason: ChatResponseClearReason;
+export interface IChatResponseClearToPreviousToolInvocationDto {
+	kind: 'clearToPreviousToolInvocation';
+	reason: ChatResponseClearToPreviousToolInvocationReason;
 }
 
 export type ICellEditOperationDto =

--- a/src/vs/workbench/api/common/extHostChatAgents2.ts
+++ b/src/vs/workbench/api/common/extHostChatAgents2.ts
@@ -135,9 +135,9 @@ export class ChatAgentResponseStream {
 			};
 
 			this._apiObject = Object.freeze<vscode.ChatResponseStream>({
-				clear(reason) {
+				clearToPreviousToolInvocation(reason) {
 					throwIfDone(this.markdown);
-					send({ kind: 'clear', reason: reason });
+					send({ kind: 'clearToPreviousToolInvocation', reason: reason });
 					return this;
 				},
 				markdown(value) {

--- a/src/vs/workbench/api/common/extHostChatAgents2.ts
+++ b/src/vs/workbench/api/common/extHostChatAgents2.ts
@@ -135,6 +135,11 @@ export class ChatAgentResponseStream {
 			};
 
 			this._apiObject = Object.freeze<vscode.ChatResponseStream>({
+				clear(reason) {
+					throwIfDone(this.markdown);
+					send({ kind: 'clear', reason: reason });
+					return this;
+				},
 				markdown(value) {
 					throwIfDone(this.markdown);
 					const part = new extHostTypes.ChatResponseMarkdownPart(value);

--- a/src/vs/workbench/api/common/extHostTypes.ts
+++ b/src/vs/workbench/api/common/extHostTypes.ts
@@ -4848,7 +4848,7 @@ export enum ChatResponseReferencePartStatusKind {
 	Omitted = 3
 }
 
-export enum ChatResponseClearReason {
+export enum ChatResponseClearToPreviousToolInvocationReason {
 	NoReason = 0,
 	FilteredContentRetry = 1,
 	CopyrightContentRetry = 2,

--- a/src/vs/workbench/api/common/extHostTypes.ts
+++ b/src/vs/workbench/api/common/extHostTypes.ts
@@ -4848,6 +4848,12 @@ export enum ChatResponseReferencePartStatusKind {
 	Omitted = 3
 }
 
+export enum ChatResponseClearReason {
+	NoReason = 0,
+	FilteredContentRetry = 1,
+	CopyrightContentRetry = 2,
+}
+
 export class ChatRequestEditorData implements vscode.ChatRequestEditorData {
 	constructor(
 		readonly document: vscode.TextDocument,

--- a/src/vs/workbench/contrib/chat/common/chatService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService.ts
@@ -102,7 +102,7 @@ export enum ChatResponseReferencePartStatusKind {
 	Omitted = 3
 }
 
-export enum ChatResponseClearReason {
+export enum ChatResponseClearToPreviousToolInvocationReason {
 	NoReason = 0,
 	FilteredContentRetry = 1,
 	CopyrightContentRetry = 2,
@@ -235,9 +235,9 @@ export interface IChatTextEdit {
 	done?: boolean;
 }
 
-export interface IChatClear {
-	kind: 'clear';
-	reason: ChatResponseClearReason;
+export interface IChatClearToPreviousToolInvocation {
+	kind: 'clearToPreviousToolInvocation';
+	reason: ChatResponseClearToPreviousToolInvocationReason;
 }
 
 export interface IChatNotebookEdit {
@@ -381,7 +381,7 @@ export type IChatProgress =
 	| IChatMoveMessage
 	| IChatResponseCodeblockUriPart
 	| IChatConfirmation
-	| IChatClear
+	| IChatClearToPreviousToolInvocation
 	| IChatToolInvocation
 	| IChatToolInvocationSerialized
 	| IChatExtensionsContent

--- a/src/vs/workbench/contrib/chat/common/chatService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService.ts
@@ -102,6 +102,12 @@ export enum ChatResponseReferencePartStatusKind {
 	Omitted = 3
 }
 
+export enum ChatResponseClearReason {
+	NoReason = 0,
+	FilteredContentRetry = 1,
+	CopyrightContentRetry = 2,
+}
+
 export interface IChatContentReference {
 	reference: URI | Location | IChatContentVariableReference | string;
 	iconPath?: ThemeIcon | { light: URI; dark?: URI };
@@ -227,6 +233,11 @@ export interface IChatTextEdit {
 	edits: TextEdit[];
 	kind: 'textEdit';
 	done?: boolean;
+}
+
+export interface IChatClear {
+	kind: 'clear';
+	reason: ChatResponseClearReason;
 }
 
 export interface IChatNotebookEdit {
@@ -370,6 +381,7 @@ export type IChatProgress =
 	| IChatMoveMessage
 	| IChatResponseCodeblockUriPart
 	| IChatConfirmation
+	| IChatClear
 	| IChatToolInvocation
 	| IChatToolInvocationSerialized
 	| IChatExtensionsContent

--- a/src/vscode-dts/vscode.proposed.chatParticipantAdditions.d.ts
+++ b/src/vscode-dts/vscode.proposed.chatParticipantAdditions.d.ts
@@ -298,6 +298,8 @@ declare module 'vscode' {
 		prepareToolInvocation(toolName: string): void;
 
 		push(part: ExtendedChatResponsePart): void;
+
+		clear(reason: ChatResponseClearReason): void;
 	}
 
 	export enum ChatResponseReferencePartStatusKind {
@@ -306,6 +308,11 @@ declare module 'vscode' {
 		Omitted = 3
 	}
 
+	export enum ChatResponseClearReason {
+		NoReason = 0,
+		FilteredContentRetry = 1,
+		CopyrightContentRetry = 2,
+	}
 
 	/**
 	 * Does this piggy-back on the existing ChatRequest, or is it a different type of request entirely?

--- a/src/vscode-dts/vscode.proposed.chatParticipantAdditions.d.ts
+++ b/src/vscode-dts/vscode.proposed.chatParticipantAdditions.d.ts
@@ -299,7 +299,7 @@ declare module 'vscode' {
 
 		push(part: ExtendedChatResponsePart): void;
 
-		clear(reason: ChatResponseClearReason): void;
+		clearToPreviousToolInvocation(reason: ChatResponseClearToPreviousToolInvocationReason): void;
 	}
 
 	export enum ChatResponseReferencePartStatusKind {
@@ -308,7 +308,7 @@ declare module 'vscode' {
 		Omitted = 3
 	}
 
-	export enum ChatResponseClearReason {
+	export enum ChatResponseClearToPreviousToolInvocationReason {
 		NoReason = 0,
 		FilteredContentRetry = 1,
 		CopyrightContentRetry = 2,


### PR DESCRIPTION
Add the ability to clear a ChatResponseStream, passing in a reason which results in a warning being displayed.

The corresponding issue is #257434  