### PR TITLE
fix(terminal): getBufferReverseIterator bug after scrollback limit reached

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/xterm/xtermTerminal.ts
+++ b/src/vs/workbench/contrib/terminal/browser/xterm/xtermTerminal.ts
@@ -327,7 +327,7 @@ export class XtermTerminal extends Disposable implements IXtermTerminal, IDetach
 	}
 
 	*getBufferReverseIterator(): IterableIterator<string> {
-		for (let i = this.raw.buffer.active.length; i >= 0; i--) {
+		for (let i = this.raw.buffer.active.length - 1; i >= 0; i--) {
 			const { lineData, lineIndex } = getFullBufferLineAsString(i, this.raw.buffer.active);
 			if (lineData) {
 				i = lineIndex;


### PR DESCRIPTION
fix terminal getBufferReverseIterator issue, related to: https://github.com/xtermjs/xterm.js/issues/5378
