### PR TITLE
fix some issues

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/bufferOutputPolling.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/bufferOutputPolling.ts
@@ -94,7 +94,7 @@ export async function pollForOutputAndIdle(
 			}
 			terminalExecutionIdleBeforeTimeout = true;
 			const modelOutputEvalResponse =
-				await assessOutputForFinishedState(buffer, token, languageModelsService);
+				await assessOutputForErrors(buffer, token, languageModelsService);
 			return { modelOutputEvalResponse, terminalExecutionIdleBeforeTimeout, output: buffer, pollDurationMs: Date.now() - pollStartTime + (extendedPolling ? PollingConsts.FirstPollingMaxDuration : 0) };
 		}
 	}
@@ -128,13 +128,13 @@ export async function promptForMorePolling(command: string, context: IToolInvoca
 	return false; // Fallback to not waiting if we can't prompt the user
 }
 
-export async function assessOutputForFinishedState(buffer: string, token: CancellationToken, languageModelsService: ILanguageModelsService): Promise<string> {
+export async function assessOutputForErrors(buffer: string, token: CancellationToken, languageModelsService: ILanguageModelsService): Promise<string> {
 	const models = await languageModelsService.selectLanguageModels({ vendor: 'copilot', family: 'gpt-4o-mini' });
 	if (!models.length) {
 		return 'No models available';
 	}
 
-	const response = await languageModelsService.sendChatRequest(models[0], new ExtensionIdentifier('Github.copilot-chat'), [{ role: ChatMessageRole.Assistant, content: [{ type: 'text', value: `Evaluate this terminal output to determine if the command is finished for now or still in process: ${buffer}. Return the word true if finished for now and false if still in process.` }] }], {}, token);
+	const response = await languageModelsService.sendChatRequest(models[0], new ExtensionIdentifier('Github.copilot-chat'), [{ role: ChatMessageRole.Assistant, content: [{ type: 'text', value: `Evaluate this terminal output to determine if there were errors or if the command ran successfully: ${buffer}.` }] }], {}, token);
 
 	let responseText = '';
 

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/bufferOutputPolling.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/bufferOutputPolling.ts
@@ -90,9 +90,9 @@ export async function pollForOutputAndIdle(
 
 		if (noNewDataCount >= PollingConsts.MinNoDataEvents) {
 			if (execution.isActive && ((await execution.isActive()) === true)) {
-				noNewDataCount = 0; // Reset if the execution is still active
-				lastBufferLength = currentBufferLength; // Update lastBufferLength to the current length
-				continue; // If the execution is still active, we don't consider it idle
+				noNewDataCount = 0;
+				lastBufferLength = currentBufferLength;
+				continue;
 			}
 			terminalExecutionIdleBeforeTimeout = true;
 			const modelOutputEvalResponse =

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/bufferOutputPolling.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/bufferOutputPolling.ts
@@ -95,8 +95,7 @@ export async function pollForOutputAndIdle(
 				continue;
 			}
 			terminalExecutionIdleBeforeTimeout = true;
-			const modelOutputEvalResponse =
-				await assessOutputForErrors(buffer, token, languageModelsService);
+			const modelOutputEvalResponse = await assessOutputForErrors(buffer, token, languageModelsService);
 			return { modelOutputEvalResponse, terminalExecutionIdleBeforeTimeout, output: buffer, pollDurationMs: Date.now() - pollStartTime + (extendedPolling ? PollingConsts.FirstPollingMaxDuration : 0) };
 		}
 	}

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/bufferOutputPolling.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/bufferOutputPolling.ts
@@ -44,7 +44,7 @@ export async function pollForOutputAndIdle(
 	extendedPolling: boolean,
 	token: CancellationToken,
 	languageModelsService: ILanguageModelsService,
-): Promise<{ terminalExecutionIdleBeforeTimeout: boolean; output: string; pollDurationMs?: number }> {
+): Promise<{ terminalExecutionIdleBeforeTimeout: boolean; output: string; pollDurationMs?: number; modelOutputEvalResponse?: string }> {
 	const maxWaitMs = extendedPolling ? PollingConsts.ExtendedPollingMaxDuration : PollingConsts.FirstPollingMaxDuration;
 	const maxInterval = PollingConsts.MaxPollingIntervalDuration;
 	let currentInterval = PollingConsts.MinPollingDuration;
@@ -89,16 +89,18 @@ export async function pollForOutputAndIdle(
 		}
 
 		if (noNewDataCount >= PollingConsts.MinNoDataEvents) {
-			terminalExecutionIdleBeforeTimeout = await assessOutputForFinishedState(buffer, execution, token, languageModelsService);
-			if (terminalExecutionIdleBeforeTimeout) {
-				return { terminalExecutionIdleBeforeTimeout, output: buffer, pollDurationMs: Date.now() - pollStartTime + (extendedPolling ? PollingConsts.FirstPollingMaxDuration : 0) };
+			terminalExecutionIdleBeforeTimeout = true;
+			if (execution.isActive && ((await execution.isActive()) === true)) {
+				continue; // If the execution is still active, we don't consider it idle
 			}
+			const modelOutputEvalResponse = await assessOutputForFinishedState(buffer, token, languageModelsService);
+			return { modelOutputEvalResponse, terminalExecutionIdleBeforeTimeout, output: buffer, pollDurationMs: Date.now() - pollStartTime + (extendedPolling ? PollingConsts.FirstPollingMaxDuration : 0) };
 		}
 	}
-	return { terminalExecutionIdleBeforeTimeout, output: buffer, pollDurationMs: Date.now() - pollStartTime + (extendedPolling ? PollingConsts.FirstPollingMaxDuration : 0) };
+	return { terminalExecutionIdleBeforeTimeout: false, output: buffer, pollDurationMs: Date.now() - pollStartTime + (extendedPolling ? PollingConsts.FirstPollingMaxDuration : 0) };
 }
 
-export async function promptForMorePolling(command: string, context: IToolInvocationContext, chatService: IChatService): Promise<boolean> {
+export async function promptForMorePolling(command: string, context: IToolInvocationContext, chatService: IChatService, token: CancellationToken): Promise<boolean> {
 	const chatModel = chatService.getSession(context.sessionId);
 	if (chatModel instanceof ChatModel) {
 		const request = chatModel.getRequests().at(-1);
@@ -125,16 +127,13 @@ export async function promptForMorePolling(command: string, context: IToolInvoca
 	return false; // Fallback to not waiting if we can't prompt the user
 }
 
-export async function assessOutputForFinishedState(buffer: string, execution: { getOutput: () => string; isActive?: () => Promise<boolean> }, token: CancellationToken, languageModelsService: ILanguageModelsService): Promise<boolean> {
-	if (execution.isActive && ((await execution.isActive()) === false)) {
-		return true;
-	}
+export async function assessOutputForFinishedState(buffer: string, token: CancellationToken, languageModelsService: ILanguageModelsService): Promise<string> {
 	const models = await languageModelsService.selectLanguageModels({ vendor: 'copilot', family: 'gpt-4o-mini' });
 	if (!models.length) {
-		return false;
+		return 'No models available';
 	}
 
-	const response = await languageModelsService.sendChatRequest(models[0], new ExtensionIdentifier('Github.copilot-chat'), [{ role: ChatMessageRole.Assistant, content: [{ type: 'text', value: `Evaluate this terminal output to determine if the command is finished or still in process: ${buffer}. Return the word true if finished and false if still in process.` }] }], {}, token);
+	const response = await languageModelsService.sendChatRequest(models[0], new ExtensionIdentifier('Github.copilot-chat'), [{ role: ChatMessageRole.Assistant, content: [{ type: 'text', value: `Evaluate this terminal output to determine if the command is finished for now or still in process: ${buffer}. Return the word true if finished for now and false if still in process.` }] }], {}, token);
 
 	let responseText = '';
 
@@ -154,8 +153,8 @@ export async function assessOutputForFinishedState(buffer: string, execution: { 
 
 	try {
 		await Promise.all([response.result, streaming]);
-		return responseText.includes('true');
+		return response.result;
 	} catch (err) {
-		return false;
+		return 'Error occurred ' + err;
 	}
 }

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/bufferOutputPolling.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/bufferOutputPolling.ts
@@ -89,18 +89,19 @@ export async function pollForOutputAndIdle(
 		}
 
 		if (noNewDataCount >= PollingConsts.MinNoDataEvents) {
-			terminalExecutionIdleBeforeTimeout = true;
 			if (execution.isActive && ((await execution.isActive()) === true)) {
 				continue; // If the execution is still active, we don't consider it idle
 			}
-			const modelOutputEvalResponse = await assessOutputForFinishedState(buffer, token, languageModelsService);
+			terminalExecutionIdleBeforeTimeout = true;
+			const modelOutputEvalResponse =
+				await assessOutputForFinishedState(buffer, token, languageModelsService);
 			return { modelOutputEvalResponse, terminalExecutionIdleBeforeTimeout, output: buffer, pollDurationMs: Date.now() - pollStartTime + (extendedPolling ? PollingConsts.FirstPollingMaxDuration : 0) };
 		}
 	}
 	return { terminalExecutionIdleBeforeTimeout: false, output: buffer, pollDurationMs: Date.now() - pollStartTime + (extendedPolling ? PollingConsts.FirstPollingMaxDuration : 0) };
 }
 
-export async function promptForMorePolling(command: string, context: IToolInvocationContext, chatService: IChatService, token: CancellationToken): Promise<boolean> {
+export async function promptForMorePolling(command: string, context: IToolInvocationContext, chatService: IChatService): Promise<boolean> {
 	const chatModel = chatService.getSession(context.sessionId);
 	if (chatModel instanceof ChatModel) {
 		const request = chatModel.getRequests().at(-1);

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/bufferOutputPolling.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/bufferOutputPolling.ts
@@ -90,6 +90,8 @@ export async function pollForOutputAndIdle(
 
 		if (noNewDataCount >= PollingConsts.MinNoDataEvents) {
 			if (execution.isActive && ((await execution.isActive()) === true)) {
+				noNewDataCount = 0; // Reset if the execution is still active
+				lastBufferLength = currentBufferLength; // Update lastBufferLength to the current length
 				continue; // If the execution is still active, we don't consider it idle
 			}
 			terminalExecutionIdleBeforeTimeout = true;

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/runInTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/runInTerminalTool.ts
@@ -281,7 +281,7 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 		const termId = generateUuid();
 
 		if (args.isBackground) {
-			let outputAndIdle: { terminalExecutionIdleBeforeTimeout: boolean; output: string; pollDurationMs?: number } | undefined = undefined;
+			let outputAndIdle: { terminalExecutionIdleBeforeTimeout: boolean; output: string; pollDurationMs?: number; modelOutputEvalResponse?: string } | undefined = undefined;
 
 			this._logService.debug(`RunInTerminalTool: Creating background terminal with ID=${termId}`);
 			const toolTerminal = await this._instantiationService.createInstance(ToolTerminalCreator).createTerminal(token);
@@ -306,7 +306,7 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 
 				outputAndIdle = await pollForOutputAndIdle(execution, false, token, this._languageModelsService);
 				if (!outputAndIdle.terminalExecutionIdleBeforeTimeout) {
-					const extendPolling = await promptForMorePolling(command, invocation.context, this._chatService);
+					const extendPolling = await promptForMorePolling(command, invocation.context, this._chatService, token);
 					if (extendPolling) {
 						outputAndIdle = await pollForOutputAndIdle(execution, true, token, this._languageModelsService);
 					}
@@ -318,7 +318,7 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 							? `Note: The tool simplified the command to \`${command}\`, and that command is now running in terminal with ID=${termId}`
 							: `Command is running in terminal with ID=${termId}`
 				);
-				resultText += outputAndIdle.terminalExecutionIdleBeforeTimeout ? `\n\ The command became idle with output:\n${outputAndIdle.output}` : `\n\ The command is still running, with output:\n${outputAndIdle.output}`;
+				resultText += outputAndIdle.modelOutputEvalResponse ? `\n\ The command became idle with output:\n${outputAndIdle.modelOutputEvalResponse}` : `\n\ The command is still running, with output:\n${outputAndIdle.output}`;
 				return {
 					content: [{
 						kind: 'text',

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/runInTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/runInTerminalTool.ts
@@ -306,7 +306,7 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 
 				outputAndIdle = await pollForOutputAndIdle(execution, false, token, this._languageModelsService);
 				if (!outputAndIdle.terminalExecutionIdleBeforeTimeout) {
-					const extendPolling = await promptForMorePolling(command, invocation.context, this._chatService, token);
+					const extendPolling = await promptForMorePolling(command, invocation.context, this._chatService);
 					if (extendPolling) {
 						outputAndIdle = await pollForOutputAndIdle(execution, true, token, this._languageModelsService);
 					}

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/task/getTaskOutputTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/task/getTaskOutputTool.ts
@@ -77,18 +77,18 @@ export class GetTaskOutputTool extends Disposable implements IToolImpl {
 		const taskDefinition = getTaskDefinition(args.id);
 		const task = await getTaskForTool(args.id, taskDefinition, args.workspaceFolder, this._configurationService, this._tasksService);
 		if (!task) {
-			return { content: [{ kind: 'text', value: localize('copilotChat.taskNotFound', 'Task not found: `{0}`', args.id) }], toolResultMessage: new MarkdownString(localize('copilotChat.taskNotFound', 'Task not found: `{0}`', args.id)) };
+			return { content: [{ kind: 'text', value: `Task not found: ${args.id}` }], toolResultMessage: new MarkdownString(localize('copilotChat.taskNotFound', 'Task not found: `{0}`', args.id)) };
 		}
 
 		const resource = this._tasksService.getTerminalForTask(task);
 		const terminal = this._terminalService.instances.find(t => t.resource.path === resource?.path && t.resource.scheme === resource.scheme);
 		if (!terminal) {
-			return { content: [{ kind: 'text', value: localize('copilotChat.terminalNotFound', 'Terminal not found for task `{0}`', taskDefinition?.taskLabel) }], toolResultMessage: new MarkdownString(localize('copilotChat.terminalNotFound', 'Terminal not found for task `{0}`', taskDefinition?.taskLabel)) };
+			return { content: [{ kind: 'text', value: `Terminal not found for task ${taskDefinition?.taskLabel}` }], toolResultMessage: new MarkdownString(localize('copilotChat.terminalNotFound', 'Terminal not found for task `{0}`', taskDefinition?.taskLabel)) };
 		}
 		return {
 			content: [{
 				kind: 'text',
-				value: localize('copilotChat.taskOutput', 'Output of task `{0}`:\n{1}', taskDefinition.taskLabel, getOutput(terminal))
+				value: `Output of task ${taskDefinition.taskLabel}: ${getOutput(terminal)}`
 			}]
 		};
 	}

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/task/runTaskTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/task/runTaskTool.ts
@@ -59,12 +59,12 @@ export class RunTaskTool implements IToolImpl {
 		const task = await getTaskForTool(args.id, taskDefinition, args.workspaceFolder, this._configurationService, this._tasksService);
 
 		if (!task) {
-			return { content: [{ kind: 'text', value: localize('copilotChat.taskNotFound', 'Task not found: `{0}`', args.id) }], toolResultMessage: new MarkdownString(localize('copilotChat.taskNotFound', 'Task not found: `{0}`', args.id)) };
+			return { content: [{ kind: 'text', value: `Task not found: ${args.id}` }], toolResultMessage: new MarkdownString(localize('copilotChat.taskNotFound', 'Task not found: `{0}`', args.id)) };
 		}
 
 		const activeTasks = await this._tasksService.getActiveTasks();
 		if (activeTasks.includes(task)) {
-			return { content: [{ kind: 'text', value: localize('copilotChat.taskAlreadyRunning', 'The task `{0}` is already running.', taskDefinition.taskLabel) }], toolResultMessage: new MarkdownString(localize('copilotChat.taskAlreadyRunning', 'The task `{0}` is already running.', taskDefinition.taskLabel)) };
+			return { content: [{ kind: 'text', value: `The task ${taskDefinition.taskLabel} is already running.` }], toolResultMessage: new MarkdownString(localize('copilotChat.taskAlreadyRunning', 'The task `{0}` is already running.', taskDefinition.taskLabel)) };
 		}
 
 		const raceResult = await Promise.race([this._tasksService.run(task), timeout(3000)]);
@@ -73,14 +73,14 @@ export class RunTaskTool implements IToolImpl {
 		const resource = this._tasksService.getTerminalForTask(task);
 		const terminal = this._terminalService.instances.find(t => t.resource.path === resource?.path && t.resource.scheme === resource.scheme);
 		if (!terminal) {
-			return { content: [{ kind: 'text', value: localize('copilotChat.noTerminal', 'Task started but no terminal was found for: `{0}`', taskDefinition.taskLabel) }], toolResultMessage: new MarkdownString(localize('copilotChat.noTerminal', 'Task started but no terminal was found for: `{0}`', taskDefinition.taskLabel)) };
+			return { content: [{ kind: 'text', value: `Task started but no terminal was found for: ${taskDefinition.taskLabel}` }], toolResultMessage: new MarkdownString(localize('copilotChat.noTerminal', 'Task started but no terminal was found for: `{0}`', taskDefinition.taskLabel)) };
 		}
 
 		_progress.report({ message: new MarkdownString(localize('copilotChat.checkingOutput', 'Checking output for `{0}`', taskDefinition.taskLabel)) });
 
 		let outputAndIdle = await pollForOutputAndIdle({ getOutput: () => getOutput(terminal), isActive: () => this._isTaskActive(task) }, false, token, this._languageModelsService);
 		if (!outputAndIdle.terminalExecutionIdleBeforeTimeout) {
-			const extendPolling = await promptForMorePolling(taskDefinition.taskLabel, invocation.context, this._chatService);
+			const extendPolling = await promptForMorePolling(taskDefinition.taskLabel, invocation.context, this._chatService, token);
 			if (extendPolling) {
 				_progress.report({ message: new MarkdownString(`Checking output for \`${taskDefinition.taskLabel}\``) });
 				outputAndIdle = await pollForOutputAndIdle({ getOutput: () => getOutput(terminal), isActive: () => this._isTaskActive(task) }, true, token, this._languageModelsService);

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/task/runTaskTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/task/runTaskTool.ts
@@ -80,7 +80,7 @@ export class RunTaskTool implements IToolImpl {
 
 		let outputAndIdle = await pollForOutputAndIdle({ getOutput: () => getOutput(terminal), isActive: () => this._isTaskActive(task) }, false, token, this._languageModelsService);
 		if (!outputAndIdle.terminalExecutionIdleBeforeTimeout) {
-			const extendPolling = await promptForMorePolling(taskDefinition.taskLabel, invocation.context, this._chatService, token);
+			const extendPolling = await promptForMorePolling(taskDefinition.taskLabel, invocation.context, this._chatService);
 			if (extendPolling) {
 				_progress.report({ message: new MarkdownString(`Checking output for \`${taskDefinition.taskLabel}\``) });
 				outputAndIdle = await pollForOutputAndIdle({ getOutput: () => getOutput(terminal), isActive: () => this._isTaskActive(task) }, true, token, this._languageModelsService);


### PR DESCRIPTION
Undoes localization of strings for the model.

When idle, returns the LLM response so that for background terminal long running executions, we don't wait forever. Before, the LLM was saying the terminal was still active even though it wasn't 

Also, if a task is active still, continues polling.

Finally, the LLM now evaluates the output for errors vs checking if it's finished.