### PR TITLE
fix: changed the node js version for devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/devcontainers/typescript-node:20-bookworm
+FROM mcr.microsoft.com/devcontainers/typescript-node:22-bookworm
 
 ADD install-vscode.sh /root/
 RUN /root/install-vscode.sh


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

As per #257193 the dev containers were having issues with node js version 20. I have updated the DockerFile to allow it for v22 as well. 

Old :

<img width="1298" height="595" alt="image" src="https://github.com/user-attachments/assets/e48aae05-ba92-415b-9a12-66088485e429" />


New:

<img width="1393" height="609" alt="image" src="https://github.com/user-attachments/assets/8ed958de-dfd7-48c1-ac57-558b8e80b49d" />

