### PR TITLE
Add experiment flag around NuGet MCP assisted config

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -326,6 +326,9 @@ configurationRegistry.registerConfiguration({
 			description: nls.localize('chat.mcp.assisted.nuget.enabled.description', "Enables NuGet packages for AI-assisted MCP server installation. Used to install MCP servers by name from the central registry for .NET packages (NuGet.org)."),
 			default: false,
 			tags: ['experimental'],
+			experiment: {
+				mode: 'startup'
+			}
 		},
 		[ChatConfiguration.UseFileStorage]: {
 			type: 'boolean',

--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -116,6 +116,7 @@ import { registerLanguageModelActions } from './actions/chatLanguageModelActions
 import { PromptUrlHandler } from './promptSyntax/promptUrlHandler.js';
 import { ChatTaskServiceImpl, IChatTasksService } from '../common/chatTasksService.js';
 import { ChatOutputRendererService, IChatOutputRendererService } from './chatOutputItemRenderer.js';
+import { AssistedTypes, AddConfigurationType } from '../../mcp/browser/mcpCommandsAddConfiguration.js';
 
 // Register configuration
 const configurationRegistry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration);
@@ -319,6 +320,12 @@ configurationRegistry.registerConfiguration({
 					}
 				}
 			},
+		},
+		[AssistedTypes[AddConfigurationType.NuGetPackage].enabledConfigKey]: {
+			type: 'boolean',
+			description: nls.localize('chat.mcp.assisted.nuget.enabled.description', "Enables NuGet packages for AI-assisted MCP server installation. Used to install MCP servers by name from NuGet packages from the central registry for .NET packages."),
+			default: false,
+			tags: ['experimental'],
 		},
 		[ChatConfiguration.UseFileStorage]: {
 			type: 'boolean',

--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -323,7 +323,7 @@ configurationRegistry.registerConfiguration({
 		},
 		[AssistedTypes[AddConfigurationType.NuGetPackage].enabledConfigKey]: {
 			type: 'boolean',
-			description: nls.localize('chat.mcp.assisted.nuget.enabled.description', "Enables NuGet packages for AI-assisted MCP server installation. Used to install MCP servers by name from NuGet packages from the central registry for .NET packages."),
+			description: nls.localize('chat.mcp.assisted.nuget.enabled.description', "Enables NuGet packages for AI-assisted MCP server installation. Used to install MCP servers by name from the central registry for .NET packages (NuGet.org)."),
 			default: false,
 			tags: ['experimental'],
 		},

--- a/src/vs/workbench/contrib/mcp/browser/mcpCommandsAddConfiguration.ts
+++ b/src/vs/workbench/contrib/mcp/browser/mcpCommandsAddConfiguration.ts
@@ -15,7 +15,7 @@ import { URI } from '../../../../base/common/uri.js';
 import { generateUuid } from '../../../../base/common/uuid.js';
 import { localize } from '../../../../nls.js';
 import { ICommandService } from '../../../../platform/commands/common/commands.js';
-import { ConfigurationTarget } from '../../../../platform/configuration/common/configuration.js';
+import { ConfigurationTarget, IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { IFileService } from '../../../../platform/files/common/files.js';
 import { ILabelService } from '../../../../platform/label/common/label.js';
 import { IMcpRemoteServerConfiguration, IMcpServerConfiguration, IMcpServerVariable, IMcpStdioServerConfiguration, McpServerType } from '../../../../platform/mcp/common/mcpPlatformTypes.js';
@@ -23,7 +23,6 @@ import { INotificationService } from '../../../../platform/notification/common/n
 import { IQuickInputService, IQuickPickItem, QuickPickInput } from '../../../../platform/quickinput/common/quickInput.js';
 import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry.js';
 import { isWorkspaceFolder, IWorkspaceContextService, IWorkspaceFolder, WorkbenchState } from '../../../../platform/workspace/common/workspace.js';
-import { IWorkbenchAssignmentService } from '../../../services/assignment/common/assignmentService.js';
 import { IEditorService } from '../../../services/editor/common/editorService.js';
 import { IWorkbenchEnvironmentService } from '../../../services/environment/common/environmentService.js';
 import { IWorkbenchMcpManagementService } from '../../../services/mcp/common/mcpWorkbenchManagementService.js';
@@ -32,7 +31,7 @@ import { mcpStdioServerSchema } from '../common/mcpConfiguration.js';
 import { IMcpRegistry } from '../common/mcpRegistryTypes.js';
 import { IMcpService, McpConnectionState } from '../common/mcpTypes.js';
 
-const enum AddConfigurationType {
+export const enum AddConfigurationType {
 	Stdio,
 	HTTP,
 
@@ -44,34 +43,34 @@ const enum AddConfigurationType {
 
 type AssistedConfigurationType = AddConfigurationType.NpmPackage | AddConfigurationType.PipPackage | AddConfigurationType.NuGetPackage | AddConfigurationType.DockerImage;
 
-const assistedTypes = {
+export const AssistedTypes = {
 	[AddConfigurationType.NpmPackage]: {
 		title: localize('mcp.npm.title', "Enter NPM Package Name"),
 		placeholder: localize('mcp.npm.placeholder', "Package name (e.g., @org/package)"),
 		pickLabel: localize('mcp.serverType.npm', "NPM Package"),
 		pickDescription: localize('mcp.serverType.npm.description', "Install from an NPM package name"),
-		experimentName: null,
+		enabledConfigKey: null, // always enabled
 	},
 	[AddConfigurationType.PipPackage]: {
 		title: localize('mcp.pip.title', "Enter Pip Package Name"),
 		placeholder: localize('mcp.pip.placeholder', "Package name (e.g., package-name)"),
 		pickLabel: localize('mcp.serverType.pip', "Pip Package"),
 		pickDescription: localize('mcp.serverType.pip.description', "Install from a Pip package name"),
-		experimentName: null,
+		enabledConfigKey: null, // always enabled
 	},
 	[AddConfigurationType.NuGetPackage]: {
 		title: localize('mcp.nuget.title', "Enter NuGet Package Name"),
 		placeholder: localize('mcp.nuget.placeholder', "Package name (e.g., Package.Name)"),
 		pickLabel: localize('mcp.serverType.nuget', "NuGet Package"),
 		pickDescription: localize('mcp.serverType.nuget.description', "Install from a NuGet package name"),
-		experimentName: 'mcp.assistedConfiguration.nuget',
+		enabledConfigKey: 'chat.mcp.assisted.nuget.enabled',
 	},
 	[AddConfigurationType.DockerImage]: {
 		title: localize('mcp.docker.title', "Enter Docker Image Name"),
 		placeholder: localize('mcp.docker.placeholder', "Image name (e.g., mcp/imagename)"),
 		pickLabel: localize('mcp.serverType.docker', "Docker Image"),
 		pickDescription: localize('mcp.serverType.docker.description', "Install from a Docker image"),
-		experimentName: null,
+		enabledConfigKey: null, // always enabled
 	},
 };
 
@@ -125,7 +124,7 @@ export class McpAddConfigurationCommand {
 		@ITelemetryService private readonly _telemetryService: ITelemetryService,
 		@IMcpService private readonly _mcpService: IMcpService,
 		@ILabelService private readonly _label: ILabelService,
-		@IWorkbenchAssignmentService private readonly _assignmentService: IWorkbenchAssignmentService,
+		@IConfigurationService private readonly _configurationService: IConfigurationService,
 	) { }
 
 	private async getServerType(): Promise<AddConfigurationType | undefined> {
@@ -144,9 +143,9 @@ export class McpAddConfigurationCommand {
 		if (aiSupported) {
 			items.unshift({ type: 'separator', label: localize('mcp.serverType.manual', "Manual Install") });
 
-			const elligableTypes = await Promise.all(Object.entries(assistedTypes).map(async ([type, { pickLabel, pickDescription, experimentName }]) => {
-				if (experimentName) {
-					const enabled = await this._assignmentService?.getTreatment<boolean>(experimentName) ?? false;
+			const elligableTypes = Object.entries(AssistedTypes).map(([type, { pickLabel, pickDescription, enabledConfigKey }]) => {
+				if (enabledConfigKey) {
+					const enabled = this._configurationService.getValue<boolean>(enabledConfigKey) ?? false;
 					if (!enabled) {
 						return;
 					}
@@ -156,11 +155,11 @@ export class McpAddConfigurationCommand {
 					label: pickLabel,
 					description: pickDescription,
 				};
-			}));
+			}).filter(x => !!x);
 
 			items.push(
 				{ type: 'separator', label: localize('mcp.serverType.copilot', "Model-Assisted") },
-				...elligableTypes.filter(x => !!x)
+				...elligableTypes
 			);
 		}
 
@@ -272,8 +271,8 @@ export class McpAddConfigurationCommand {
 	private async getAssistedConfig(type: AssistedConfigurationType): Promise<{ name: string; server: Omit<IMcpStdioServerConfiguration, 'type'>; inputs?: IMcpServerVariable[]; inputValues?: Record<string, string> } | undefined> {
 		const packageName = await this._quickInputService.input({
 			ignoreFocusLost: true,
-			title: assistedTypes[type].title,
-			placeHolder: assistedTypes[type].placeholder,
+			title: AssistedTypes[type].title,
+			placeHolder: AssistedTypes[type].placeholder,
 		});
 
 		if (!packageName) {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This continues PR https://github.com/microsoft/vscode/pull/254678 and is progress on  https://github.com/microsoft/vscode-copilot/issues/15329.

I have tried the flow on several packages and I see the model assisted loop halt "randomly" and this needs more investigation. Let's put this behind a feature flag for now until there is more discussion. 

I tested it using our internal experimentation framework as well as enabling it explicitly in config.

<img width="1711" height="673" alt="image" src="https://github.com/user-attachments/assets/19c5ad86-65b2-446d-a6a1-f0fb8ec723bc" />
