### PR TITLE
Remove stale decoration when running watch activities

### DIFF
--- a/src/vs/platform/terminal/common/capabilities/commandDetectionCapability.ts
+++ b/src/vs/platform/terminal/common/capabilities/commandDetectionCapability.ts
@@ -172,7 +172,6 @@ export class CommandDetectionCapability extends Disposable implements ICommandDe
 			if (this._terminal.buffer.active.baseY + this._terminal.buffer.active.cursorY < this._currentCommand.commandStartMarker.line) {
 				this._clearCommandsInViewport();
 				this._currentCommand.isInvalid = true;
-				this._clearDecorationsInViewport();
 				this._onCurrentCommandInvalidated.fire({ reason: CommandInvalidationReason.Windows });
 			}
 		}
@@ -191,6 +190,7 @@ export class CommandDetectionCapability extends Disposable implements ICommandDe
 		// Remove them
 		if (count > 0) {
 			this._onCommandInvalidated.fire(this._commands.splice(this._commands.length - count, count));
+			this._onCurrentCommandInvalidated.fire({ reason: CommandInvalidationReason.NoProblemsReported });
 		}
 	}
 
@@ -198,33 +198,6 @@ export class CommandDetectionCapability extends Disposable implements ICommandDe
 		this._promptInputModel.setContinuationPrompt(value);
 	}
 
-	private _clearDecorationsInViewport(): void {
-		// Reset the current command's decorations by disposing markers
-		this._currentCommand.commandStartMarker?.dispose();
-		this._currentCommand.commandStartMarker = undefined;
-
-		// Above two line was enough to remove stale decorations.
-		// Should we still be disposing other "related"
-		this._currentCommand.commandExecutedMarker?.dispose();
-		this._currentCommand.commandExecutedMarker = undefined;
-
-		this._currentCommand.promptStartMarker?.dispose();
-		this._currentCommand.promptStartMarker = undefined;
-
-		this._currentCommand.currentContinuationMarker?.dispose();
-		this._currentCommand.currentContinuationMarker = undefined;
-
-		this._currentCommand.commandFinishedMarker?.dispose();
-		this._currentCommand.commandFinishedMarker = undefined;
-
-		// the lists goes on with commandLines..commandRightPromptStartX and commandRightPromptEndX... etc
-
-		// Should we be removing all markets in commandMarkers?
-		for (const marker of this._commandMarkers) {
-			marker.dispose();
-		}
-		this._commandMarkers.length = 0;
-	}
 
 	// TODO: Simplify this, can everything work off the last line?
 	setPromptTerminator(promptTerminator: string, lastPromptLine: string) {

--- a/src/vs/platform/terminal/common/capabilities/commandDetectionCapability.ts
+++ b/src/vs/platform/terminal/common/capabilities/commandDetectionCapability.ts
@@ -190,14 +190,13 @@ export class CommandDetectionCapability extends Disposable implements ICommandDe
 		// Remove them
 		if (count > 0) {
 			this._onCommandInvalidated.fire(this._commands.splice(this._commands.length - count, count));
-			this._onCurrentCommandInvalidated.fire({ reason: CommandInvalidationReason.NoProblemsReported });
+			// this._onCurrentCommandInvalidated.fire({ reason: CommandInvalidationReason.NoProblemsReported });
 		}
 	}
 
 	setContinuationPrompt(value: string): void {
 		this._promptInputModel.setContinuationPrompt(value);
 	}
-
 
 	// TODO: Simplify this, can everything work off the last line?
 	setPromptTerminator(promptTerminator: string, lastPromptLine: string) {

--- a/src/vs/platform/terminal/common/capabilities/commandDetectionCapability.ts
+++ b/src/vs/platform/terminal/common/capabilities/commandDetectionCapability.ts
@@ -172,6 +172,7 @@ export class CommandDetectionCapability extends Disposable implements ICommandDe
 			if (this._terminal.buffer.active.baseY + this._terminal.buffer.active.cursorY < this._currentCommand.commandStartMarker.line) {
 				this._clearCommandsInViewport();
 				this._currentCommand.isInvalid = true;
+				this._clearDecorationsInViewport();
 				this._onCurrentCommandInvalidated.fire({ reason: CommandInvalidationReason.Windows });
 			}
 		}
@@ -195,6 +196,34 @@ export class CommandDetectionCapability extends Disposable implements ICommandDe
 
 	setContinuationPrompt(value: string): void {
 		this._promptInputModel.setContinuationPrompt(value);
+	}
+
+	private _clearDecorationsInViewport(): void {
+		// Reset the current command's decorations by disposing markers
+		this._currentCommand.commandStartMarker?.dispose();
+		this._currentCommand.commandStartMarker = undefined;
+
+		// Above two line was enough to remove stale decorations.
+		// Should we still be disposing other "related"
+		this._currentCommand.commandExecutedMarker?.dispose();
+		this._currentCommand.commandExecutedMarker = undefined;
+
+		this._currentCommand.promptStartMarker?.dispose();
+		this._currentCommand.promptStartMarker = undefined;
+
+		this._currentCommand.currentContinuationMarker?.dispose();
+		this._currentCommand.currentContinuationMarker = undefined;
+
+		this._currentCommand.commandFinishedMarker?.dispose();
+		this._currentCommand.commandFinishedMarker = undefined;
+
+		// the lists goes on with commandLines..commandRightPromptStartX and commandRightPromptEndX... etc
+
+		// Should we be removing all markets in commandMarkers?
+		for (const marker of this._commandMarkers) {
+			marker.dispose();
+		}
+		this._commandMarkers.length = 0;
 	}
 
 	// TODO: Simplify this, can everything work off the last line?

--- a/src/vs/platform/terminal/common/capabilities/commandDetectionCapability.ts
+++ b/src/vs/platform/terminal/common/capabilities/commandDetectionCapability.ts
@@ -190,7 +190,6 @@ export class CommandDetectionCapability extends Disposable implements ICommandDe
 		// Remove them
 		if (count > 0) {
 			this._onCommandInvalidated.fire(this._commands.splice(this._commands.length - count, count));
-			// this._onCurrentCommandInvalidated.fire({ reason: CommandInvalidationReason.NoProblemsReported });
 		}
 	}
 

--- a/src/vs/workbench/contrib/terminal/browser/xterm/decorationAddon.ts
+++ b/src/vs/workbench/contrib/terminal/browser/xterm/decorationAddon.ts
@@ -229,7 +229,7 @@ export class DecorationAddon extends Disposable implements ITerminalAddon, IDeco
 			if (command.exitCode !== undefined && buffer && marker) {
 				// Only register if cursor is at or below the command start marker
 				// This prevents misplaced decorations when watch commands clear previous output
-				if (buffer.cursorY >= marker.line) {
+				if (buffer.baseY + buffer.cursorY >= marker.line) {
 					this.registerCommandDecoration(command);
 				}
 			} else {

--- a/src/vs/workbench/contrib/terminal/browser/xterm/decorationAddon.ts
+++ b/src/vs/workbench/contrib/terminal/browser/xterm/decorationAddon.ts
@@ -222,7 +222,7 @@ export class DecorationAddon extends Disposable implements ITerminalAddon, IDeco
 		}
 		commandDetectionListeners.push(capability.onCommandFinished(command => {
 			const buffer = this._terminal?.buffer?.active;
-			const marker = command.promptStartMarker;
+			const marker = command.marker;
 
 			// Only apply cursor check for commands with exit codes (completed commands)
 			// Skip the check for incomplete commands (no exitCode) to allow placeholders

--- a/src/vs/workbench/contrib/terminal/browser/xterm/decorationAddon.ts
+++ b/src/vs/workbench/contrib/terminal/browser/xterm/decorationAddon.ts
@@ -224,9 +224,16 @@ export class DecorationAddon extends Disposable implements ITerminalAddon, IDeco
 			const buffer = this._terminal?.buffer?.active;
 			const marker = command.promptStartMarker;
 
-			// Only register if cursor is at or below the command start marker
-			// This prevents misplaced decorations when watch commands clear previous output
-			if (buffer && marker && buffer.cursorY >= marker.line) {
+			// Only apply cursor check for commands with exit codes (completed commands)
+			// Skip the check for incomplete commands (no exitCode) to allow placeholders
+			if (command.exitCode !== undefined && buffer && marker) {
+				// Only register if cursor is at or below the command start marker
+				// This prevents misplaced decorations when watch commands clear previous output
+				if (buffer.cursorY >= marker.line) {
+					this.registerCommandDecoration(command);
+				}
+			} else {
+				// No exit code means incomplete command - always register placeholder
 				this.registerCommandDecoration(command);
 			}
 

--- a/src/vs/workbench/contrib/terminal/browser/xterm/decorationAddon.ts
+++ b/src/vs/workbench/contrib/terminal/browser/xterm/decorationAddon.ts
@@ -222,7 +222,7 @@ export class DecorationAddon extends Disposable implements ITerminalAddon, IDeco
 		}
 		commandDetectionListeners.push(capability.onCommandFinished(command => {
 			if (command.exitCode !== 130) {
-				// Don't show decoration when exiting out via ctrl+c
+				// Don't re-register decoration when watch activity (e.g. `npm run compile`) are exited with ctrl+c.
 				this.registerCommandDecoration(command);
 			}
 			if (command.exitCode) {

--- a/src/vs/workbench/contrib/terminal/browser/xterm/decorationAddon.ts
+++ b/src/vs/workbench/contrib/terminal/browser/xterm/decorationAddon.ts
@@ -221,10 +221,15 @@ export class DecorationAddon extends Disposable implements ITerminalAddon, IDeco
 			this.registerCommandDecoration(command);
 		}
 		commandDetectionListeners.push(capability.onCommandFinished(command => {
-			if (command.exitCode !== 130) {
-				// Don't re-register decoration when watch activity (e.g. `npm run compile`) are exited with ctrl+c.
+			const buffer = this._terminal?.buffer?.active;
+			const marker = command.promptStartMarker;
+
+			// Only register if cursor is at or below the command start marker
+			// This prevents misplaced decorations when watch commands clear previous output
+			if (buffer && marker && buffer.cursorY >= marker.line) {
 				this.registerCommandDecoration(command);
 			}
+
 			if (command.exitCode) {
 				this._accessibilitySignalService.playSignal(AccessibilitySignal.terminalCommandFailed);
 			} else {

--- a/src/vs/workbench/contrib/terminal/browser/xterm/decorationAddon.ts
+++ b/src/vs/workbench/contrib/terminal/browser/xterm/decorationAddon.ts
@@ -224,7 +224,7 @@ export class DecorationAddon extends Disposable implements ITerminalAddon, IDeco
 			const buffer = this._terminal?.buffer?.active;
 			const marker = command.promptStartMarker;
 
-			// Edge case: Handle case where tsc watch commands clears buffer, but decoration that tsc command re-appears
+			// Edge case: Handle case where tsc watch commands clears buffer, but decoration of that tsc command re-appears
 			const shouldRegisterDecoration = (
 				command.exitCode === undefined ||
 				// Only register decoration if the cursor is at or below the promptStart marker.

--- a/src/vs/workbench/contrib/terminal/browser/xterm/decorationAddon.ts
+++ b/src/vs/workbench/contrib/terminal/browser/xterm/decorationAddon.ts
@@ -221,7 +221,10 @@ export class DecorationAddon extends Disposable implements ITerminalAddon, IDeco
 			this.registerCommandDecoration(command);
 		}
 		commandDetectionListeners.push(capability.onCommandFinished(command => {
-			this.registerCommandDecoration(command);
+			if (command.exitCode !== 130) {
+				// Don't show decoration when exiting out via ctrl+c
+				this.registerCommandDecoration(command);
+			}
 			if (command.exitCode) {
 				this._accessibilitySignalService.playSignal(AccessibilitySignal.terminalCommandFailed);
 			} else {


### PR DESCRIPTION
Resolves: https://github.com/microsoft/vscode/issues/166864
This would remove the "stale" decoration from showing when manually running "npm run compile" in terminal.