### PR TITLE
race prompt response and terminal/task idle, hide prompt part when terminal/task becomes idle or prompt is replied to

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/chatElicitationContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/chatElicitationContentPart.ts
@@ -32,6 +32,8 @@ export class ChatElicitationContentPart extends Disposable implements IChatConte
 		const confirmationWidget = this._register(this.instantiationService.createInstance(ChatConfirmationWidget, elicitation.title, elicitation.originMessage, this.getMessageToRender(elicitation), buttons, context.container));
 		confirmationWidget.setShowButtons(elicitation.state === 'pending');
 
+		this._register(elicitation.onDidRequestRemovePart(() => this.domNode.remove()));
+
 		this._register(confirmationWidget.onDidChangeHeight(() => this._onDidChangeHeight.fire()));
 
 		this._register(confirmationWidget.onDidClick(async e => {

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/chatElicitationContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/chatElicitationContentPart.ts
@@ -32,7 +32,7 @@ export class ChatElicitationContentPart extends Disposable implements IChatConte
 		const confirmationWidget = this._register(this.instantiationService.createInstance(ChatConfirmationWidget, elicitation.title, elicitation.originMessage, this.getMessageToRender(elicitation), buttons, context.container));
 		confirmationWidget.setShowButtons(elicitation.state === 'pending');
 
-		this._register(elicitation.onDidRequestRemovePart(() => this.domNode.remove()));
+		this._register(elicitation.onDidRequestHide(() => this.domNode.remove()));
 
 		this._register(confirmationWidget.onDidChangeHeight(() => this._onDidChangeHeight.fire()));
 

--- a/src/vs/workbench/contrib/chat/browser/chatElicitationRequestPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatElicitationRequestPart.ts
@@ -13,8 +13,8 @@ export class ChatElicitationRequestPart extends Disposable implements IChatElici
 	public state: 'pending' | 'accepted' | 'rejected' = 'pending';
 	public acceptedResult?: Record<string, unknown>;
 
-	private _onDidRequestRemovePart = this._register(new Emitter<void>());
-	public readonly onDidRequestRemovePart = this._onDidRequestRemovePart.event;
+	private _onDidRequestHide = this._register(new Emitter<void>());
+	public readonly onDidRequestHide = this._onDidRequestHide.event;
 
 	constructor(
 		public readonly title: string | IMarkdownString,
@@ -29,7 +29,7 @@ export class ChatElicitationRequestPart extends Disposable implements IChatElici
 	}
 
 	removePart(): void {
-		this._onDidRequestRemovePart.fire();
+		this._onDidRequestHide.fire();
 	}
 
 	public toJSON() {

--- a/src/vs/workbench/contrib/chat/browser/chatElicitationRequestPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatElicitationRequestPart.ts
@@ -28,7 +28,7 @@ export class ChatElicitationRequestPart extends Disposable implements IChatElici
 		super();
 	}
 
-	removePart(): void {
+	hide(): void {
 		this._onDidRequestHide.fire();
 	}
 

--- a/src/vs/workbench/contrib/chat/browser/chatElicitationRequestPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatElicitationRequestPart.ts
@@ -3,13 +3,18 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { Emitter } from '../../../../base/common/event.js';
 import { IMarkdownString } from '../../../../base/common/htmlContent.js';
+import { Disposable } from '../../../../base/common/lifecycle.js';
 import { IChatElicitationRequest } from '../common/chatService.js';
 
-export class ChatElicitationRequestPart implements IChatElicitationRequest {
+export class ChatElicitationRequestPart extends Disposable implements IChatElicitationRequest {
 	public readonly kind = 'elicitation';
 	public state: 'pending' | 'accepted' | 'rejected' = 'pending';
 	public acceptedResult?: Record<string, unknown>;
+
+	private _onDidRequestRemovePart = this._register(new Emitter<void>());
+	public readonly onDidRequestRemovePart = this._onDidRequestRemovePart.event;
 
 	constructor(
 		public readonly title: string | IMarkdownString,
@@ -19,7 +24,13 @@ export class ChatElicitationRequestPart implements IChatElicitationRequest {
 		public readonly rejectButtonLabel: string,
 		public readonly accept: () => Promise<void>,
 		public readonly reject: () => Promise<void>,
-	) { }
+	) {
+		super();
+	}
+
+	removePart(): void {
+		this._onDidRequestRemovePart.fire();
+	}
 
 	public toJSON() {
 		return {

--- a/src/vs/workbench/contrib/chat/common/chatService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService.ts
@@ -238,7 +238,7 @@ export interface IChatElicitationRequest {
 	acceptedResult?: Record<string, unknown>;
 	accept(): Promise<void>;
 	reject(): Promise<void>;
-	onDidRequestRemovePart: Event<void>;
+	onDidRequestHide: Event<void>;
 }
 
 export interface IChatTerminalToolInvocationData {

--- a/src/vs/workbench/contrib/chat/common/chatService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService.ts
@@ -238,6 +238,7 @@ export interface IChatElicitationRequest {
 	acceptedResult?: Record<string, unknown>;
 	accept(): Promise<void>;
 	reject(): Promise<void>;
+	onDidRequestRemovePart: Event<void>;
 }
 
 export interface IChatTerminalToolInvocationData {

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/bufferOutputPolling.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/bufferOutputPolling.ts
@@ -16,7 +16,7 @@ import { IToolInvocationContext } from '../../../chat/common/languageModelToolsS
 import { ITerminalInstance } from '../../../terminal/browser/terminal.js';
 import type { IMarker as IXtermMarker } from '@xterm/xterm';
 
-const enum PollingConsts {
+export const enum PollingConsts {
 	MinNoDataEvents = 2, // Minimum number of no data checks before considering the terminal idle
 	MinPollingDuration = 500,
 	FirstPollingMaxDuration = 20000, // 20 seconds
@@ -31,7 +31,7 @@ const enum PollingConsts {
  */
 export async function racePollingOrPrompt(
 	pollFn: () => Promise<{ terminalExecutionIdleBeforeTimeout: boolean; output: string; pollDurationMs?: number; modelOutputEvalResponse?: string }>,
-	promptFn: () => { promise: Promise<boolean>; part?: ChatElicitationRequestPart },
+	promptFn: () => { promise: Promise<boolean>; part?: Pick<ChatElicitationRequestPart, 'hide' | 'onDidRequestHide'> },
 	originalResult: { terminalExecutionIdleBeforeTimeout: boolean; output: string; pollDurationMs?: number; modelOutputEvalResponse?: string },
 	token: CancellationToken,
 	languageModelsService: ILanguageModelsService,

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/bufferOutputPolling.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/bufferOutputPolling.ts
@@ -156,18 +156,18 @@ export function promptForMorePolling(command: string, context: IToolInvocationCo
 		if (request) {
 			let part: ChatElicitationRequestPart | undefined = undefined;
 			const promise = new Promise<boolean>(resolve => {
-				part = new ChatElicitationRequestPart(
+				const thePart = part = new ChatElicitationRequestPart(
 					new MarkdownString(localize('poll.terminal.waiting', "Continue waiting for `{0}` to finish?", command)),
 					new MarkdownString(localize('poll.terminal.polling', "Copilot will continue to poll for output to determine when the terminal becomes idle for up to 2 minutes.")),
 					'',
 					localize('poll.terminal.accept', 'Yes'),
 					localize('poll.terminal.reject', 'No'),
 					async () => {
-						part!.state = 'accepted';
+						thePart.state = 'accepted';
 						resolve(true);
 					},
 					async () => {
-						part!.state = 'rejected';
+						thePart.state = 'rejected';
 						resolve(false);
 					}
 				);

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/bufferOutputPolling.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/bufferOutputPolling.ts
@@ -32,6 +32,7 @@ const enum PollingConsts {
 export async function racePollingOrPrompt(
 	pollFn: () => Promise<{ terminalExecutionIdleBeforeTimeout: boolean; output: string; pollDurationMs?: number; modelOutputEvalResponse?: string }>,
 	promptFn: () => { promise: Promise<boolean>; part?: ChatElicitationRequestPart },
+	originalResult: { terminalExecutionIdleBeforeTimeout: boolean; output: string; pollDurationMs?: number; modelOutputEvalResponse?: string },
 	token: CancellationToken,
 	languageModelsService: ILanguageModelsService,
 	execution: { getOutput: () => string; isActive?: () => Promise<boolean> }
@@ -64,6 +65,8 @@ export async function racePollingOrPrompt(
 		if (promptResult) {
 			// User accepted, poll again (extended)
 			return await pollForOutputAndIdle(execution, true, token, languageModelsService);
+		} else {
+			return originalResult; // User rejected, return the original result
 		}
 	}
 	// If prompt was rejected or something else, return the result of the first poll

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/bufferOutputPolling.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/bufferOutputPolling.ts
@@ -42,6 +42,7 @@ export async function racePollingOrPrompt(
 
 	const pollPromiseWrapped = pollPromise.then(async result => {
 		if (!promptResolved && part) {
+			// The terminal polling is finished, no need to show the prompt
 			part.removePart();
 		}
 		return { type: 'poll', result };

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/bufferOutputPolling.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/bufferOutputPolling.ts
@@ -43,7 +43,7 @@ export async function racePollingOrPrompt(
 	const pollPromiseWrapped = pollPromise.then(async result => {
 		if (!promptResolved && part) {
 			// The terminal polling is finished, no need to show the prompt
-			part.removePart();
+			part.hide();
 		}
 		return { type: 'poll', result };
 	});
@@ -164,14 +164,16 @@ export function promptForMorePolling(command: string, context: IToolInvocationCo
 					localize('poll.terminal.reject', 'No'),
 					async () => {
 						thePart.state = 'accepted';
+						thePart.hide();
 						resolve(true);
 					},
 					async () => {
 						thePart.state = 'rejected';
+						thePart.hide();
 						resolve(false);
 					}
 				);
-				chatModel.acceptResponseProgress(request, part);
+				chatModel.acceptResponseProgress(request, thePart);
 			});
 			return { promise, part };
 		}

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/runInTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/runInTerminalTool.ts
@@ -319,7 +319,6 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 					]);
 					if (raceResult.type === 'poll') {
 						outputAndIdle = raceResult.result as typeof outputAndIdle;
-						await part?.removePart();
 					} else if (raceResult.type === 'prompt') {
 						const promptResult = raceResult.result as boolean;
 						if (promptResult) {

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/runInTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/runInTerminalTool.ts
@@ -298,6 +298,7 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 					outputAndIdle = await racePollingOrPrompt(
 						() => pollForOutputAndIdle(execution, true, token, this._languageModelsService),
 						() => promptForMorePolling(command, invocation.context!, this._chatService),
+						outputAndIdle,
 						token,
 						this._languageModelsService,
 						execution

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/task/runTaskTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/task/runTaskTool.ts
@@ -103,7 +103,6 @@ export class RunTaskTool implements IToolImpl {
 			]);
 			if (raceResult.type === 'poll') {
 				outputAndIdle = raceResult.result as typeof outputAndIdle;
-				await part?.removePart();
 			} else if (raceResult.type === 'prompt') {
 				const promptResult = raceResult.result as boolean;
 				if (promptResult) {

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/task/runTaskTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/task/runTaskTool.ts
@@ -82,6 +82,7 @@ export class RunTaskTool implements IToolImpl {
 			outputAndIdle = await racePollingOrPrompt(
 				() => pollForOutputAndIdle({ getOutput: () => getOutput(terminal), isActive: () => this._isTaskActive(task) }, true, token, this._languageModelsService),
 				() => promptForMorePolling(taskDefinition.taskLabel, invocation.context!, this._chatService),
+				outputAndIdle,
 				token,
 				this._languageModelsService,
 				{ getOutput: () => getOutput(terminal), isActive: () => this._isTaskActive(task) }

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/bufferOutputPolling.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/bufferOutputPolling.test.ts
@@ -12,94 +12,106 @@ import { Emitter } from '../../../../../../base/common/event.js';
 
 suite('racePollingOrPrompt', () => {
 	ensureNoDisposablesAreLeakedInTestSuite();
+
+	const defaultOriginalResult = { terminalExecutionIdleBeforeTimeout: false, output: '', pollDurationMs: PollingConsts.FirstPollingMaxDuration };
+	const defaultToken = CancellationToken.None;
+	const defaultLanguageModelsService = {} as any;
+	const defaultExecution = { getOutput: () => 'output' };
+
+	/**
+	 * Returns a set of arguments for racePollingOrPrompt, allowing overrides for testing.
+	 */
+	function getArgs(overrides?: {
+		pollFn?: () => Promise<ReturnType<typeof racePollingOrPrompt> extends Promise<infer R> ? R : any>;
+		promptFn?: () => { promise: Promise<boolean>; part?: Pick<ChatElicitationRequestPart, 'hide' | 'onDidRequestHide'> | undefined };
+		originalResult?: Parameters<typeof racePollingOrPrompt>[2];
+		token?: CancellationToken;
+		languageModelsService?: typeof defaultLanguageModelsService;
+		execution?: typeof defaultExecution;
+	}) {
+		return {
+			pollFn: overrides?.pollFn ?? (async () => ({ terminalExecutionIdleBeforeTimeout: true, output: 'output', pollDurationMs: 100 })),
+			promptFn: overrides?.promptFn ?? (() => ({ promise: new Promise<boolean>(() => { }), part: undefined })),
+			originalResult: overrides?.originalResult ?? defaultOriginalResult,
+			token: overrides?.token ?? defaultToken,
+			languageModelsService: overrides?.languageModelsService ?? defaultLanguageModelsService,
+			execution: overrides?.execution ?? defaultExecution
+		};
+	}
+
 	test('should resolve with poll result if polling finishes first', async () => {
 		let pollResolved = false;
-		const pollFn = async () => {
-			pollResolved = true;
-			return { terminalExecutionIdleBeforeTimeout: true, output: 'output', pollDurationMs: 100 };
-		};
-		const promptFn = () => ({ promise: new Promise<boolean>(() => { }), part: undefined });
-		const originalResult = { terminalExecutionIdleBeforeTimeout: false, output: '', pollDurationMs: PollingConsts.FirstPollingMaxDuration };
-		const token = CancellationToken.None;
-		const languageModelsService = {} as any;
-		const execution = { getOutput: () => 'output' };
-
-		const result = await racePollingOrPrompt(pollFn, promptFn, originalResult, token, languageModelsService, execution);
+		const args = getArgs({
+			pollFn: async () => {
+				pollResolved = true;
+				return { terminalExecutionIdleBeforeTimeout: true, output: 'output', pollDurationMs: 100 };
+			}
+		});
+		const result = await racePollingOrPrompt(args.pollFn, args.promptFn, args.originalResult, args.token, args.languageModelsService, args.execution);
 		assert.ok(pollResolved);
 		assert.deepEqual(result, { terminalExecutionIdleBeforeTimeout: true, output: 'output', pollDurationMs: 100 });
 	});
 
 	test('should resolve with poll result if prompt is rejected', async () => {
-		const pollFn = async () => {
-			return { terminalExecutionIdleBeforeTimeout: false, output: 'output', pollDurationMs: 100 };
-		};
-		const promptFn = () => ({ promise: Promise.resolve(false), part: undefined });
-		const originalResult = { terminalExecutionIdleBeforeTimeout: false, output: 'original', pollDurationMs: PollingConsts.FirstPollingMaxDuration };
-		const token = CancellationToken.None;
-		const languageModelsService = {} as any;
-		const execution = { getOutput: () => 'output' };
-
-		const result = await racePollingOrPrompt(pollFn, promptFn, originalResult, token, languageModelsService, execution);
-		assert.deepEqual(result, originalResult);
+		const args = getArgs({
+			pollFn: async () => ({ terminalExecutionIdleBeforeTimeout: false, output: 'output', pollDurationMs: 100 }),
+			promptFn: () => ({ promise: Promise.resolve(false), part: undefined }),
+			originalResult: { terminalExecutionIdleBeforeTimeout: false, output: 'original', pollDurationMs: PollingConsts.FirstPollingMaxDuration }
+		});
+		const result = await racePollingOrPrompt(args.pollFn, args.promptFn, args.originalResult, args.token, args.languageModelsService, args.execution);
+		assert.deepEqual(result, args.originalResult);
 	});
 
 	test('should poll again if prompt is accepted', async () => {
 		let extraPollCount = 0;
-		const pollFn = async () => {
-			extraPollCount++;
-			return { terminalExecutionIdleBeforeTimeout: false, output: 'output', pollDurationMs: 100 };
-		};
-		const promptFn = () => ({ promise: Promise.resolve(true), part: undefined });
-		const originalResult = { terminalExecutionIdleBeforeTimeout: false, output: 'original', pollDurationMs: PollingConsts.FirstPollingMaxDuration };
-		const token = CancellationToken.None;
-		const languageModelsService = {
-			selectLanguageModels: async () => [],
-			sendChatRequest: async () => ({ result: '', stream: [] })
-		} as any;
-		const execution = { getOutput: () => 'output' };
-
-		const result = await racePollingOrPrompt(pollFn, promptFn, originalResult, token, languageModelsService, execution);
+		const args = getArgs({
+			pollFn: async () => {
+				extraPollCount++;
+				return { terminalExecutionIdleBeforeTimeout: false, output: 'output', pollDurationMs: 100 };
+			},
+			promptFn: () => ({ promise: Promise.resolve(true), part: undefined }),
+			originalResult: { terminalExecutionIdleBeforeTimeout: false, output: 'original', pollDurationMs: PollingConsts.FirstPollingMaxDuration },
+			languageModelsService: {
+				selectLanguageModels: async () => [],
+				sendChatRequest: async () => ({ result: '', stream: [] })
+			}
+		});
+		const result = await racePollingOrPrompt(args.pollFn, args.promptFn, args.originalResult, args.token, args.languageModelsService, args.execution);
 		assert.ok(extraPollCount === 1);
-		assert(result?.pollDurationMs && result.pollDurationMs > originalResult.pollDurationMs);
+		assert(result?.pollDurationMs && args.originalResult.pollDurationMs && result.pollDurationMs > args.originalResult.pollDurationMs);
 	});
+
 	test('should call part.hide() if polling finishes before prompt resolves', async () => {
 		let hideCalled = false;
 		const part: Pick<ChatElicitationRequestPart, 'hide' | 'onDidRequestHide'> = { hide: () => { hideCalled = true; }, onDidRequestHide: () => new Emitter() };
-		const pollFn = async () => {
-			return { terminalExecutionIdleBeforeTimeout: true, output: 'output', pollDurationMs: 100 };
-		};
-		let promptResolve: (v: boolean) => void;
-		const promptFn = () => ({
-			promise: new Promise<boolean>(resolve => { promptResolve = resolve; }),
-			part
+		const args = getArgs({
+			pollFn: async () => ({ terminalExecutionIdleBeforeTimeout: true, output: 'output', pollDurationMs: 100 }),
+			promptFn: () => ({
+				promise: new Promise<boolean>(() => { }),
+				part
+			})
 		});
-		const originalResult = { terminalExecutionIdleBeforeTimeout: false, output: '', pollDurationMs: PollingConsts.FirstPollingMaxDuration };
-		const token = CancellationToken.None;
-		const languageModelsService = {} as any;
-		const execution = { getOutput: () => 'output' };
-
-		const result = await racePollingOrPrompt(pollFn, promptFn, originalResult, token, languageModelsService, execution);
+		const result = await racePollingOrPrompt(args.pollFn, args.promptFn, args.originalResult, args.token, args.languageModelsService, args.execution);
 		assert.strictEqual(hideCalled, true);
 		assert.deepEqual(result, { terminalExecutionIdleBeforeTimeout: true, output: 'output', pollDurationMs: 100 });
 	});
 
 	test('should return promptly if cancellation is requested', async () => {
 		let pollCalled = false;
-		const pollFn = async () => {
-			pollCalled = true;
-			return { terminalExecutionIdleBeforeTimeout: false, output: 'output', pollDurationMs: 100 };
-		};
-		const promptFn = () => ({
-			promise: new Promise<boolean>(() => { }),
-			part: undefined
+		const args = getArgs({
+			pollFn: async () => {
+				pollCalled = true;
+				return { terminalExecutionIdleBeforeTimeout: false, output: 'output', pollDurationMs: 100 };
+			},
+			promptFn: () => ({
+				promise: new Promise<boolean>(() => { }),
+				part: undefined
+			}),
+			originalResult: { terminalExecutionIdleBeforeTimeout: false, output: 'original', pollDurationMs: PollingConsts.FirstPollingMaxDuration },
+			token: { isCancellationRequested: true } as CancellationToken
 		});
-		const originalResult = { terminalExecutionIdleBeforeTimeout: false, output: 'original', pollDurationMs: PollingConsts.FirstPollingMaxDuration };
-		const token = { isCancellationRequested: true } as CancellationToken;
-		const languageModelsService = {} as any;
-		const execution = { getOutput: () => 'output' };
-
-		const result = await racePollingOrPrompt(pollFn, promptFn, originalResult, token, languageModelsService, execution);
+		const result = await racePollingOrPrompt(args.pollFn, args.promptFn, args.originalResult, args.token, args.languageModelsService, args.execution);
 		assert.ok(pollCalled);
-		assert.deepEqual(result, await pollFn());
+		assert.deepEqual(result, await args.pollFn());
 	});
 });

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/bufferOutputPolling.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/bufferOutputPolling.test.ts
@@ -1,0 +1,105 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { strict as assert } from 'assert';
+import { CancellationToken } from '../../../../../../base/common/cancellation.js';
+import { PollingConsts, racePollingOrPrompt } from '../../browser/bufferOutputPolling.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
+import { ChatElicitationRequestPart } from '../../../../chat/browser/chatElicitationRequestPart.js';
+import { Emitter } from '../../../../../../base/common/event.js';
+
+suite('racePollingOrPrompt', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+	test('should resolve with poll result if polling finishes first', async () => {
+		let pollResolved = false;
+		const pollFn = async () => {
+			pollResolved = true;
+			return { terminalExecutionIdleBeforeTimeout: true, output: 'output', pollDurationMs: 100 };
+		};
+		const promptFn = () => ({ promise: new Promise<boolean>(() => { }), part: undefined });
+		const originalResult = { terminalExecutionIdleBeforeTimeout: false, output: '', pollDurationMs: PollingConsts.FirstPollingMaxDuration };
+		const token = CancellationToken.None;
+		const languageModelsService = {} as any;
+		const execution = { getOutput: () => 'output' };
+
+		const result = await racePollingOrPrompt(pollFn, promptFn, originalResult, token, languageModelsService, execution);
+		assert.ok(pollResolved);
+		assert.deepEqual(result, { terminalExecutionIdleBeforeTimeout: true, output: 'output', pollDurationMs: 100 });
+	});
+
+	test('should resolve with poll result if prompt is rejected', async () => {
+		const pollFn = async () => {
+			return { terminalExecutionIdleBeforeTimeout: false, output: 'output', pollDurationMs: 100 };
+		};
+		const promptFn = () => ({ promise: Promise.resolve(false), part: undefined });
+		const originalResult = { terminalExecutionIdleBeforeTimeout: false, output: 'original', pollDurationMs: PollingConsts.FirstPollingMaxDuration };
+		const token = CancellationToken.None;
+		const languageModelsService = {} as any;
+		const execution = { getOutput: () => 'output' };
+
+		const result = await racePollingOrPrompt(pollFn, promptFn, originalResult, token, languageModelsService, execution);
+		assert.deepEqual(result, originalResult);
+	});
+
+	test('should poll again if prompt is accepted', async () => {
+		let extraPollCount = 0;
+		const pollFn = async () => {
+			extraPollCount++;
+			return { terminalExecutionIdleBeforeTimeout: false, output: 'output', pollDurationMs: 100 };
+		};
+		const promptFn = () => ({ promise: Promise.resolve(true), part: undefined });
+		const originalResult = { terminalExecutionIdleBeforeTimeout: false, output: 'original', pollDurationMs: PollingConsts.FirstPollingMaxDuration };
+		const token = CancellationToken.None;
+		const languageModelsService = {
+			selectLanguageModels: async () => [],
+			sendChatRequest: async () => ({ result: '', stream: [] })
+		} as any;
+		const execution = { getOutput: () => 'output' };
+
+		const result = await racePollingOrPrompt(pollFn, promptFn, originalResult, token, languageModelsService, execution);
+		assert.ok(extraPollCount === 1);
+		assert(result?.pollDurationMs && result.pollDurationMs > originalResult.pollDurationMs);
+	});
+	test('should call part.hide() if polling finishes before prompt resolves', async () => {
+		let hideCalled = false;
+		const part: Pick<ChatElicitationRequestPart, 'hide' | 'onDidRequestHide'> = { hide: () => { hideCalled = true; }, onDidRequestHide: () => new Emitter() };
+		const pollFn = async () => {
+			return { terminalExecutionIdleBeforeTimeout: true, output: 'output', pollDurationMs: 100 };
+		};
+		let promptResolve: (v: boolean) => void;
+		const promptFn = () => ({
+			promise: new Promise<boolean>(resolve => { promptResolve = resolve; }),
+			part
+		});
+		const originalResult = { terminalExecutionIdleBeforeTimeout: false, output: '', pollDurationMs: PollingConsts.FirstPollingMaxDuration };
+		const token = CancellationToken.None;
+		const languageModelsService = {} as any;
+		const execution = { getOutput: () => 'output' };
+
+		const result = await racePollingOrPrompt(pollFn, promptFn, originalResult, token, languageModelsService, execution);
+		assert.strictEqual(hideCalled, true);
+		assert.deepEqual(result, { terminalExecutionIdleBeforeTimeout: true, output: 'output', pollDurationMs: 100 });
+	});
+
+	test('should return promptly if cancellation is requested', async () => {
+		let pollCalled = false;
+		const pollFn = async () => {
+			pollCalled = true;
+			return { terminalExecutionIdleBeforeTimeout: false, output: 'output', pollDurationMs: 100 };
+		};
+		const promptFn = () => ({
+			promise: new Promise<boolean>(() => { }),
+			part: undefined
+		});
+		const originalResult = { terminalExecutionIdleBeforeTimeout: false, output: 'original', pollDurationMs: PollingConsts.FirstPollingMaxDuration };
+		const token = { isCancellationRequested: true } as CancellationToken;
+		const languageModelsService = {} as any;
+		const execution = { getOutput: () => 'output' };
+
+		const result = await racePollingOrPrompt(pollFn, promptFn, originalResult, token, languageModelsService, execution);
+		assert.ok(pollCalled);
+		assert.deepEqual(result, await pollFn());
+	});
+});

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/bufferOutputPolling.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/bufferOutputPolling.test.ts
@@ -30,7 +30,7 @@ suite('racePollingOrPrompt', () => {
 		execution?: typeof defaultExecution;
 	}) {
 		return {
-			pollFn: overrides?.pollFn ?? (async () => ({ terminalExecutionIdleBeforeTimeout: true, output: 'output', pollDurationMs: 100 })),
+			pollFn: overrides?.pollFn ?? (async () => ({ terminalExecutionIdleBeforeTimeout: true, output: 'output', pollDurationMs: 0 })),
 			promptFn: overrides?.promptFn ?? (() => ({ promise: new Promise<boolean>(() => { }), part: undefined })),
 			originalResult: overrides?.originalResult ?? defaultOriginalResult,
 			token: overrides?.token ?? defaultToken,
@@ -44,17 +44,17 @@ suite('racePollingOrPrompt', () => {
 		const args = getArgs({
 			pollFn: async () => {
 				pollResolved = true;
-				return { terminalExecutionIdleBeforeTimeout: true, output: 'output', pollDurationMs: 100 };
+				return { terminalExecutionIdleBeforeTimeout: true, output: 'output', pollDurationMs: 0 };
 			}
 		});
 		const result = await racePollingOrPrompt(args.pollFn, args.promptFn, args.originalResult, args.token, args.languageModelsService, args.execution);
 		assert.ok(pollResolved);
-		assert.deepEqual(result, { terminalExecutionIdleBeforeTimeout: true, output: 'output', pollDurationMs: 100 });
+		assert.deepEqual(result, { terminalExecutionIdleBeforeTimeout: true, output: 'output', pollDurationMs: 0 });
 	});
 
 	test('should resolve with poll result if prompt is rejected', async () => {
 		const args = getArgs({
-			pollFn: async () => ({ terminalExecutionIdleBeforeTimeout: false, output: 'output', pollDurationMs: 100 }),
+			pollFn: async () => ({ terminalExecutionIdleBeforeTimeout: false, output: 'output', pollDurationMs: 0 }),
 			promptFn: () => ({ promise: Promise.resolve(false), part: undefined }),
 			originalResult: { terminalExecutionIdleBeforeTimeout: false, output: 'original', pollDurationMs: PollingConsts.FirstPollingMaxDuration }
 		});
@@ -67,7 +67,7 @@ suite('racePollingOrPrompt', () => {
 		const args = getArgs({
 			pollFn: async () => {
 				extraPollCount++;
-				return { terminalExecutionIdleBeforeTimeout: false, output: 'output', pollDurationMs: 100 };
+				return { terminalExecutionIdleBeforeTimeout: false, output: 'output', pollDurationMs: 0 };
 			},
 			promptFn: () => ({ promise: Promise.resolve(true), part: undefined }),
 			originalResult: { terminalExecutionIdleBeforeTimeout: false, output: 'original', pollDurationMs: PollingConsts.FirstPollingMaxDuration },
@@ -85,7 +85,7 @@ suite('racePollingOrPrompt', () => {
 		let hideCalled = false;
 		const part: Pick<ChatElicitationRequestPart, 'hide' | 'onDidRequestHide'> = { hide: () => { hideCalled = true; }, onDidRequestHide: () => new Emitter() };
 		const args = getArgs({
-			pollFn: async () => ({ terminalExecutionIdleBeforeTimeout: true, output: 'output', pollDurationMs: 100 }),
+			pollFn: async () => ({ terminalExecutionIdleBeforeTimeout: true, output: 'output', pollDurationMs: 0 }),
 			promptFn: () => ({
 				promise: new Promise<boolean>(() => { }),
 				part
@@ -93,7 +93,7 @@ suite('racePollingOrPrompt', () => {
 		});
 		const result = await racePollingOrPrompt(args.pollFn, args.promptFn, args.originalResult, args.token, args.languageModelsService, args.execution);
 		assert.strictEqual(hideCalled, true);
-		assert.deepEqual(result, { terminalExecutionIdleBeforeTimeout: true, output: 'output', pollDurationMs: 100 });
+		assert.deepEqual(result, { terminalExecutionIdleBeforeTimeout: true, output: 'output', pollDurationMs: 0 });
 	});
 
 	test('should return promptly if cancellation is requested', async () => {
@@ -101,7 +101,7 @@ suite('racePollingOrPrompt', () => {
 		const args = getArgs({
 			pollFn: async () => {
 				pollCalled = true;
-				return { terminalExecutionIdleBeforeTimeout: false, output: 'output', pollDurationMs: 100 };
+				return { terminalExecutionIdleBeforeTimeout: false, output: 'output', pollDurationMs: 0 };
 			},
 			promptFn: () => ({
 				promise: new Promise<boolean>(() => { }),


### PR DESCRIPTION
When the terminal or task becomes idle, we want to hide the prompt if it hasn't been replied to by then. This PR accomplishes that.

It adds `hide` and `onDidRequestHide` to `ChatElicitationRequestPart` so that we can hide the prompt if it has not been replied to by the time the terminal or task has become idle or when the prompt is replied to since it's no longer relevant. cc @connor4312 

It also hides the prompt once the user has taken either action.

https://github.com/user-attachments/assets/e06a3967-95dd-4888-8955-391dd24ea5dc

