### PR TITLE
mcp: implement autorun, rework trust

### DIFF
--- a/src/vs/platform/mcp/common/mcpManagement.ts
+++ b/src/vs/platform/mcp/common/mcpManagement.ts
@@ -208,3 +208,10 @@ export interface IAllowedMcpServersService {
 
 export const mcpEnabledConfig = 'chat.mcp.enabled';
 export const mcpGalleryServiceUrlConfig = 'chat.mcp.gallery.serviceUrl';
+export const mcpAutoStartConfig = 'chat.mcp.autostart';
+
+export const enum McpAutoStartValue {
+	Never = 'never',
+	OnlyNew = 'onlyNew',
+	NewAndOutdated = 'newAndOutdated',
+}

--- a/src/vs/workbench/api/browser/mainThreadMcp.ts
+++ b/src/vs/workbench/api/browser/mainThreadMcp.ts
@@ -16,7 +16,7 @@ import { IDialogService, IPromptButton } from '../../../platform/dialogs/common/
 import { ExtensionIdentifier } from '../../../platform/extensions/common/extensions.js';
 import { LogLevel } from '../../../platform/log/common/log.js';
 import { IMcpMessageTransport, IMcpRegistry } from '../../contrib/mcp/common/mcpRegistryTypes.js';
-import { McpCollectionDefinition, McpConnectionState, McpServerDefinition, McpServerLaunch, McpServerTransportType } from '../../contrib/mcp/common/mcpTypes.js';
+import { McpCollectionDefinition, McpConnectionState, McpServerDefinition, McpServerLaunch, McpServerTransportType, McpServerTrust } from '../../contrib/mcp/common/mcpTypes.js';
 import { MCP } from '../../contrib/mcp/common/modelContextProtocol.js';
 import { IAuthenticationMcpAccessService } from '../../services/authentication/browser/authenticationMcpAccessService.js';
 import { IAuthenticationMcpService } from '../../services/authentication/browser/authenticationMcpService.js';
@@ -97,6 +97,7 @@ export class MainThreadMcp extends Disposable implements MainThreadMcpShape {
 					const r = await this._proxy.$resolveMcpLaunch(collection.id, def.label);
 					return r ? McpServerLaunch.fromSerialized(r) : undefined;
 				}) : undefined,
+				trustBehavior: collection.isTrustedByDefault ? McpServerTrust.Kind.Trusted : McpServerTrust.Kind.TrustedOnNonce,
 				remoteAuthority: this._extHostContext.remoteAuthority,
 				serverDefinitions,
 			});

--- a/src/vs/workbench/api/common/extHostMcp.ts
+++ b/src/vs/workbench/api/common/extHostMcp.ts
@@ -128,7 +128,7 @@ export class ExtHostMcpService extends Disposable implements IExtHostMpcService 
 				servers.push({
 					id,
 					label: item.label,
-					cacheNonce: item.version,
+					cacheNonce: item.version || '$$NONE',
 					launch: Convert.McpServerDefinition.from(item),
 				});
 			}

--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -21,7 +21,7 @@ import { Extensions as ConfigurationExtensions, ConfigurationScope, IConfigurati
 import { SyncDescriptor } from '../../../../platform/instantiation/common/descriptors.js';
 import { InstantiationType, registerSingleton } from '../../../../platform/instantiation/common/extensions.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
-import { mcpEnabledConfig, mcpGalleryServiceUrlConfig } from '../../../../platform/mcp/common/mcpManagement.js';
+import { mcpAutoStartConfig, McpAutoStartValue, mcpEnabledConfig, mcpGalleryServiceUrlConfig } from '../../../../platform/mcp/common/mcpManagement.js';
 import { PromptsConfig } from '../common/promptSyntax/config/config.js';
 import { INSTRUCTIONS_DEFAULT_SOURCE_FOLDER, INSTRUCTION_FILE_EXTENSION, MODE_DEFAULT_SOURCE_FOLDER, MODE_FILE_EXTENSION, PROMPT_DEFAULT_SOURCE_FOLDER, PROMPT_FILE_EXTENSION } from '../common/promptSyntax/config/promptFileLocations.js';
 import { Registry } from '../../../../platform/registry/common/platform.js';
@@ -292,6 +292,21 @@ configurationRegistry.registerConfiguration({
 				minimumVersion: '1.99',
 				tags: [PolicyTag.Account, PolicyTag.MCP]
 			}
+		},
+		[mcpAutoStartConfig]: {
+			type: 'string',
+			description: nls.localize('chat.mcp.autostart', "Controls whether MCP servers should be automatically started when the chat messages are submitted."),
+			default: McpAutoStartValue.NewAndOutdated,
+			enum: [
+				McpAutoStartValue.Never,
+				McpAutoStartValue.OnlyNew,
+				McpAutoStartValue.NewAndOutdated
+			],
+			enumDescriptions: [
+				nls.localize('chat.mcp.autostart.never', "Never automatically start MCP servers."),
+				nls.localize('chat.mcp.autostart.onlyNew', "Only automatically start new MCP servers that have never been run."),
+				nls.localize('chat.mcp.autostart.newAndOutdated', "Automatically start new and outdated MCP servers that are not yet running.")
+			]
 		},
 		[mcpServerSamplingSection]: {
 			type: 'object',

--- a/src/vs/workbench/contrib/chat/browser/contrib/chatInputCompletions.ts
+++ b/src/vs/workbench/contrib/chat/browser/contrib/chatInputCompletions.ts
@@ -598,7 +598,7 @@ class StartParameterizedPromptAction extends Action2 {
 		try {
 			// start the server if not already running so that it's ready to resolve
 			// the prompt instantly when the user finishes picking arguments.
-			server.start();
+			await server.start();
 
 			const args = await pick.createArgs();
 			if (!args) {

--- a/src/vs/workbench/contrib/chat/browser/languageModelToolsService.ts
+++ b/src/vs/workbench/contrib/chat/browser/languageModelToolsService.ts
@@ -143,6 +143,11 @@ export class LanguageModelToolsService extends Disposable implements ILanguageMo
 		}
 	}
 
+	flushToolChanges(): void {
+		this._onDidChangeToolsScheduler.cancel();
+		this._onDidChangeTools.fire();
+	}
+
 	registerToolImplementation(id: string, tool: IToolImpl): IDisposable {
 		const entry = this._tools.get(id);
 		if (!entry) {

--- a/src/vs/workbench/contrib/chat/common/languageModelToolsService.ts
+++ b/src/vs/workbench/contrib/chat/common/languageModelToolsService.ts
@@ -284,6 +284,7 @@ export interface ILanguageModelToolsService {
 	onDidChangeTools: Event<void>;
 	registerToolData(toolData: IToolData): IDisposable;
 	registerToolImplementation(id: string, tool: IToolImpl): IDisposable;
+	flushToolChanges(): void;
 	getTools(): Iterable<Readonly<IToolData>>;
 	getTool(id: string): IToolData | undefined;
 	getToolByName(name: string, includeDisabled?: boolean): IToolData | undefined;

--- a/src/vs/workbench/contrib/chat/test/browser/chatEditingService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/chatEditingService.test.ts
@@ -42,6 +42,8 @@ import { EditOperation } from '../../../../../editor/common/core/editOperation.j
 import { Position } from '../../../../../editor/common/core/position.js';
 import { ChatModel } from '../../common/chatModel.js';
 import { TextEdit } from '../../../../../editor/common/languages.js';
+import { IMcpService } from '../../../mcp/common/mcpTypes.js';
+import { TestMcpService } from '../../../mcp/test/common/testMcpService.js';
 
 function getAgentData(id: string): IChatAgentData {
 	return {
@@ -76,6 +78,7 @@ suite('ChatEditingService', function () {
 		collection.set(IChatEditingService, new SyncDescriptor(ChatEditingService));
 		collection.set(IEditorWorkerService, new SyncDescriptor(TestWorkerService));
 		collection.set(IChatService, new SyncDescriptor(ChatService));
+		collection.set(IMcpService, new TestMcpService());
 		collection.set(ILanguageModelsService, new SyncDescriptor(NullLanguageModelsService));
 		collection.set(IMultiDiffSourceResolverService, new class extends mock<IMultiDiffSourceResolverService>() {
 			override registerResolver(_resolver: IMultiDiffSourceResolver): IDisposable {

--- a/src/vs/workbench/contrib/chat/test/common/chatService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/chatService.test.ts
@@ -40,6 +40,8 @@ import { IChatVariablesService } from '../../common/chatVariables.js';
 import { ChatAgentLocation, ChatModeKind } from '../../common/constants.js';
 import { MockChatService } from './mockChatService.js';
 import { MockChatVariablesService } from './mockChatVariables.js';
+import { IMcpService } from '../../../mcp/common/mcpTypes.js';
+import { TestMcpService } from '../../../mcp/test/common/testMcpService.js';
 
 const chatAgentWithUsedContextId = 'ChatProviderWithUsedContext';
 const chatAgentWithUsedContext: IChatAgent = {
@@ -124,7 +126,8 @@ suite('ChatService', () => {
 	setup(async () => {
 		instantiationService = testDisposables.add(new TestInstantiationService(new ServiceCollection(
 			[IChatVariablesService, new MockChatVariablesService()],
-			[IWorkbenchAssignmentService, new NullWorkbenchAssignmentService()]
+			[IWorkbenchAssignmentService, new NullWorkbenchAssignmentService()],
+			[IMcpService, new TestMcpService()],
 		)));
 		instantiationService.stub(IStorageService, storageService = testDisposables.add(new TestStorageService()));
 		instantiationService.stub(ILogService, new NullLogService());

--- a/src/vs/workbench/contrib/chat/test/common/mockLanguageModelToolsService.ts
+++ b/src/vs/workbench/contrib/chat/test/common/mockLanguageModelToolsService.ts
@@ -20,6 +20,10 @@ export class MockLanguageModelToolsService implements ILanguageModelToolsService
 
 	onDidChangeTools: Event<void> = Event.None;
 
+	flushToolChanges(): void {
+
+	}
+
 	registerToolData(toolData: IToolData): IDisposable {
 		return Disposable.None;
 	}

--- a/src/vs/workbench/contrib/inlineChat/test/browser/inlineChatController.test.ts
+++ b/src/vs/workbench/contrib/inlineChat/test/browser/inlineChatController.test.ts
@@ -78,6 +78,8 @@ import { CTX_INLINE_CHAT_RESPONSE_TYPE, InlineChatConfigKeys, InlineChatResponse
 import { TestWorkerService } from './testWorkerService.js';
 import { PromptsType } from '../../../chat/common/promptSyntax/promptTypes.js';
 import { ChatTransferService, IChatTransferService } from '../../../chat/common/chatTransferService.js';
+import { IMcpService } from '../../../mcp/common/mcpTypes.js';
+import { TestMcpService } from '../../../mcp/test/common/testMcpService.js';
 
 suite('InlineChatController', function () {
 
@@ -160,6 +162,7 @@ suite('InlineChatController', function () {
 			[IChatSlashCommandService, new SyncDescriptor(ChatSlashCommandService)],
 			[IChatTransferService, new SyncDescriptor(ChatTransferService)],
 			[IChatService, new SyncDescriptor(ChatService)],
+			[IMcpService, new TestMcpService()],
 			[IChatAgentNameService, new class extends mock<IChatAgentNameService>() {
 				override getAgentNameRestriction(chatAgentData: IChatAgentData): boolean {
 					return false;

--- a/src/vs/workbench/contrib/inlineChat/test/browser/inlineChatSession.test.ts
+++ b/src/vs/workbench/contrib/inlineChat/test/browser/inlineChatSession.test.ts
@@ -66,6 +66,8 @@ import { ChatAgentLocation, ChatModeKind } from '../../../chat/common/constants.
 import { ChatTransferService, IChatTransferService } from '../../../chat/common/chatTransferService.js';
 import { NullLanguageModelsService } from '../../../chat/test/common/languageModels.js';
 import { ILanguageModelsService } from '../../../chat/common/languageModels.js';
+import { IMcpService } from '../../../mcp/common/mcpTypes.js';
+import { TestMcpService } from '../../../mcp/test/common/testMcpService.js';
 
 suite('InlineChatSession', function () {
 
@@ -102,6 +104,7 @@ suite('InlineChatSession', function () {
 			[IInlineChatSessionService, new SyncDescriptor(InlineChatSessionServiceImpl)],
 			[ICommandService, new SyncDescriptor(TestCommandService)],
 			[ILanguageModelToolsService, new MockLanguageModelToolsService()],
+			[IMcpService, new TestMcpService()],
 			[IEditorProgressService, new class extends mock<IEditorProgressService>() {
 				override show(total: unknown, delay?: unknown): IProgressRunner {
 					return {

--- a/src/vs/workbench/contrib/mcp/browser/mcp.contribution.ts
+++ b/src/vs/workbench/contrib/mcp/browser/mcp.contribution.ts
@@ -23,6 +23,7 @@ import { McpCommandIds } from '../common/mcpCommandIds.js';
 import { mcpServerSchema } from '../common/mcpConfiguration.js';
 import { McpContextKeysController } from '../common/mcpContextKeys.js';
 import { IMcpDevModeDebugging, McpDevModeDebugging } from '../common/mcpDevMode.js';
+import { McpLanguageModelToolContribution } from '../common/mcpLanguageModelToolContribution.js';
 import { McpRegistry } from '../common/mcpRegistry.js';
 import { IMcpRegistry } from '../common/mcpRegistryTypes.js';
 import { McpResourceFilesystem } from '../common/mcpResourceFilesystem.js';
@@ -57,6 +58,7 @@ registerWorkbenchContribution2('mcpDiscovery', McpDiscovery, WorkbenchPhase.Afte
 registerWorkbenchContribution2('mcpContextKeys', McpContextKeysController, WorkbenchPhase.BlockRestore);
 registerWorkbenchContribution2('mcpLanguageFeatures', McpLanguageFeatures, WorkbenchPhase.Eventually);
 registerWorkbenchContribution2('mcpResourceFilesystem', McpResourceFilesystem, WorkbenchPhase.BlockRestore);
+registerWorkbenchContribution2(McpLanguageModelToolContribution.ID, McpLanguageModelToolContribution, WorkbenchPhase.AfterRestored);
 
 registerAction2(ListMcpServerCommand);
 registerAction2(McpServerOptionsCommand);

--- a/src/vs/workbench/contrib/mcp/browser/mcpCommands.ts
+++ b/src/vs/workbench/contrib/mcp/browser/mcpCommands.ts
@@ -5,6 +5,7 @@
 
 import { h } from '../../../../base/browser/dom.js';
 import { assertNever } from '../../../../base/common/assert.js';
+import { VSBuffer } from '../../../../base/common/buffer.js';
 import { Codicon } from '../../../../base/common/codicons.js';
 import { groupBy } from '../../../../base/common/collections.js';
 import { Event } from '../../../../base/common/event.js';
@@ -20,42 +21,43 @@ import { IActionViewItemService } from '../../../../platform/actions/browser/act
 import { MenuEntryActionViewItem } from '../../../../platform/actions/browser/menuEntryActionViewItem.js';
 import { Action2, MenuId, MenuItemAction, MenuRegistry } from '../../../../platform/actions/common/actions.js';
 import { ICommandService } from '../../../../platform/commands/common/commands.js';
-import { ConfigurationTarget } from '../../../../platform/configuration/common/configuration.js';
+import { ConfigurationTarget, IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { ContextKeyExpr } from '../../../../platform/contextkey/common/contextkey.js';
+import { IFileService } from '../../../../platform/files/common/files.js';
 import { IInstantiationService, ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
+import { mcpAutoStartConfig, McpAutoStartValue } from '../../../../platform/mcp/common/mcpManagement.js';
+import { observableConfigValue } from '../../../../platform/observable/common/platformObservableUtils.js';
+import { IOpenerService } from '../../../../platform/opener/common/opener.js';
+import { IProductService } from '../../../../platform/product/common/productService.js';
 import { IQuickInputService, IQuickPickItem, IQuickPickSeparator } from '../../../../platform/quickinput/common/quickInput.js';
 import { StorageScope } from '../../../../platform/storage/common/storage.js';
 import { spinningLoading } from '../../../../platform/theme/common/iconRegistry.js';
 import { IWorkspaceContextService, IWorkspaceFolder } from '../../../../platform/workspace/common/workspace.js';
+import { PICK_WORKSPACE_FOLDER_COMMAND_ID } from '../../../browser/actions/workspaceCommands.js';
 import { ActiveEditorContext, RemoteNameContext, ResourceContextKey, WorkbenchStateContext, WorkspaceFolderCountContext } from '../../../common/contextkeys.js';
 import { IWorkbenchContribution } from '../../../common/contributions.js';
-import { IAccountQuery, IAuthenticationQueryService } from '../../../services/authentication/common/authenticationQuery.js';
 import { IAuthenticationService } from '../../../services/authentication/common/authentication.js';
+import { IAccountQuery, IAuthenticationQueryService } from '../../../services/authentication/common/authenticationQuery.js';
+import { MCP_CONFIGURATION_KEY, WORKSPACE_STANDALONE_CONFIGURATIONS } from '../../../services/configuration/common/configuration.js';
 import { IEditorService } from '../../../services/editor/common/editorService.js';
+import { IRemoteUserDataProfilesService } from '../../../services/userDataProfile/common/remoteUserDataProfiles.js';
+import { IUserDataProfileService } from '../../../services/userDataProfile/common/userDataProfile.js';
 import { IViewsService } from '../../../services/views/common/viewsService.js';
+import { CHAT_CONFIG_MENU_ID } from '../../chat/browser/actions/chatActions.js';
 import { ChatViewId, IChatWidgetService } from '../../chat/browser/chat.js';
 import { ChatContextKeys } from '../../chat/common/chatContextKeys.js';
 import { ChatModeKind } from '../../chat/common/constants.js';
 import { ILanguageModelsService } from '../../chat/common/languageModels.js';
+import { VIEW_CONTAINER } from '../../extensions/browser/extensions.contribution.js';
 import { extensionsFilterSubMenu, IExtensionsWorkbenchService } from '../../extensions/common/extensions.js';
 import { TEXT_FILE_EDITOR_ID } from '../../files/common/files.js';
 import { McpCommandIds } from '../common/mcpCommandIds.js';
 import { McpContextKeys } from '../common/mcpContextKeys.js';
 import { IMcpRegistry } from '../common/mcpRegistryTypes.js';
-import { HasInstalledMcpServersContext, IMcpSamplingService, IMcpServer, IMcpServerStartOpts, IMcpService, InstalledMcpServersViewId, LazyCollectionState, McpCapability, McpConnectionState, McpDefinitionReference, mcpPromptPrefix, McpServerCacheState } from '../common/mcpTypes.js';
+import { HasInstalledMcpServersContext, IMcpSamplingService, IMcpServer, IMcpServerStartOpts, IMcpService, InstalledMcpServersViewId, LazyCollectionState, McpCapability, McpConnectionState, McpDefinitionReference, mcpPromptPrefix, McpServerCacheState, McpStartServerInteraction } from '../common/mcpTypes.js';
 import { McpAddConfigurationCommand } from './mcpCommandsAddConfiguration.js';
 import { McpResourceQuickAccess, McpResourceQuickPick } from './mcpResourceQuickAccess.js';
 import { openPanelChatAndGetWidget } from './openPanelChatAndGetWidget.js';
-import { IUserDataProfileService } from '../../../services/userDataProfile/common/userDataProfile.js';
-import { IRemoteUserDataProfilesService } from '../../../services/userDataProfile/common/remoteUserDataProfiles.js';
-import { PICK_WORKSPACE_FOLDER_COMMAND_ID } from '../../../browser/actions/workspaceCommands.js';
-import { MCP_CONFIGURATION_KEY, WORKSPACE_STANDALONE_CONFIGURATIONS } from '../../../services/configuration/common/configuration.js';
-import { IFileService } from '../../../../platform/files/common/files.js';
-import { VSBuffer } from '../../../../base/common/buffer.js';
-import { IProductService } from '../../../../platform/product/common/productService.js';
-import { IOpenerService } from '../../../../platform/opener/common/opener.js';
-import { CHAT_CONFIG_MENU_ID } from '../../chat/browser/actions/chatActions.js';
-import { VIEW_CONTAINER } from '../../extensions/browser/extensions.contribution.js';
 
 // acroynms do not get localized
 const category: ILocalizedString = {
@@ -249,7 +251,7 @@ export class McpServerOptionsCommand extends Action2 {
 
 		switch (pick.action) {
 			case 'start':
-				await server.start({ isFromInteraction: true });
+				await server.start({ promptType: 'all-untrusted' });
 				server.showOutput();
 				break;
 			case 'stop':
@@ -257,7 +259,7 @@ export class McpServerOptionsCommand extends Action2 {
 				break;
 			case 'restart':
 				await server.stop();
-				await server.start({ isFromInteraction: true });
+				await server.start({ promptType: 'all-untrusted' });
 				break;
 			case 'disconnect':
 				await server.stop();
@@ -352,8 +354,11 @@ export class MCPServerActionRendering extends Disposable implements IWorkbenchCo
 		@IMcpService mcpService: IMcpService,
 		@IInstantiationService instaService: IInstantiationService,
 		@ICommandService commandService: ICommandService,
+		@IConfigurationService configurationService: IConfigurationService,
 	) {
 		super();
+
+		const config = observableConfigValue(mcpAutoStartConfig, McpAutoStartValue.NewAndOutdated, configurationService);
 
 		const enum DisplayedState {
 			None,
@@ -370,11 +375,7 @@ export class MCPServerActionRendering extends Disposable implements IWorkbenchCo
 				switch (server.cacheState.read(reader)) {
 					case McpServerCacheState.Unknown:
 					case McpServerCacheState.Outdated:
-						if (server.trusted.read(reader) === false) {
-							thisState = DisplayedState.None;
-						} else {
-							thisState = server.connectionState.read(reader).state === McpConnectionState.Kind.Error ? DisplayedState.Error : DisplayedState.NewTools;
-						}
+						thisState = server.connectionState.read(reader).state === McpConnectionState.Kind.Error ? DisplayedState.Error : DisplayedState.NewTools;
 						break;
 					case McpServerCacheState.RefreshingFromUnknown:
 						thisState = DisplayedState.Refreshing;
@@ -395,7 +396,11 @@ export class MCPServerActionRendering extends Disposable implements IWorkbenchCo
 				serversPerState[DisplayedState.NewTools] ??= [];
 			}
 
-			const maxState = (serversPerState.length - 1) as DisplayedState;
+			let maxState = (serversPerState.length - 1) as DisplayedState;
+			if (maxState === DisplayedState.NewTools && config.read(reader) !== McpAutoStartValue.Never) {
+				maxState = DisplayedState.None;
+			}
+
 			return { state: maxState, servers: serversPerState[maxState] || [] };
 		});
 
@@ -447,7 +452,8 @@ export class MCPServerActionRendering extends Disposable implements IWorkbenchCo
 
 					const { state, servers } = displayedState.get();
 					if (state === DisplayedState.NewTools) {
-						servers.forEach(server => server.stop().then(() => server.start()));
+						const interaction = new McpStartServerInteraction();
+						servers.forEach(server => server.stop().then(() => server.start({ interaction })));
 						mcpService.activateCollections();
 					} else if (state === DisplayedState.Refreshing) {
 						servers.at(-1)?.showOutput();
@@ -496,7 +502,7 @@ export class ResetMcpTrustCommand extends Action2 {
 	}
 
 	run(accessor: ServicesAccessor): void {
-		const mcpService = accessor.get(IMcpRegistry);
+		const mcpService = accessor.get(IMcpService);
 		mcpService.resetTrust();
 	}
 }
@@ -639,7 +645,7 @@ export class RestartServer extends Action2 {
 		const s = accessor.get(IMcpService).servers.get().find(s => s.definition.id === serverId);
 		s?.showOutput();
 		await s?.stop();
-		await s?.start({ isFromInteraction: true, ...opts });
+		await s?.start({ promptType: 'all-untrusted', ...opts });
 	}
 }
 
@@ -655,7 +661,7 @@ export class StartServer extends Action2 {
 
 	async run(accessor: ServicesAccessor, serverId: string, opts?: IMcpServerStartOpts) {
 		const s = accessor.get(IMcpService).servers.get().find(s => s.definition.id === serverId);
-		await s?.start({ isFromInteraction: true, ...opts });
+		await s?.start({ promptType: 'all-untrusted', ...opts });
 	}
 }
 

--- a/src/vs/workbench/contrib/mcp/browser/mcpCommandsAddConfiguration.ts
+++ b/src/vs/workbench/contrib/mcp/browser/mcpCommandsAddConfiguration.ts
@@ -361,7 +361,7 @@ export class McpAddConfigurationCommand {
 					this._commandService.executeCommand(McpCommandIds.ServerOptions, name);
 				}
 
-				server.start({ isFromInteraction: true }).then(state => {
+				server.start({ promptType: 'all-untrusted' }).then(state => {
 					if (state.state === McpConnectionState.Kind.Error) {
 						server.showOutput();
 					}

--- a/src/vs/workbench/contrib/mcp/browser/mcpLanguageFeatures.ts
+++ b/src/vs/workbench/contrib/mcp/browser/mcpLanguageFeatures.ts
@@ -22,7 +22,7 @@ import { ConfigurationResolverExpression, IResolvedValue } from '../../../servic
 import { McpCommandIds } from '../common/mcpCommandIds.js';
 import { mcpConfigurationSection } from '../common/mcpConfiguration.js';
 import { IMcpRegistry } from '../common/mcpRegistryTypes.js';
-import { IMcpConfigPath, IMcpService, IMcpWorkbenchService, McpConnectionState } from '../common/mcpTypes.js';
+import { IMcpConfigPath, IMcpServerStartOpts, IMcpService, IMcpWorkbenchService, McpConnectionState } from '../common/mcpTypes.js';
 
 const diagnosticOwner = 'vscode.mcp';
 
@@ -191,7 +191,7 @@ export class McpLanguageFeatures extends Disposable implements IWorkbenchContrib
 						command: {
 							id: McpCommandIds.RestartServer,
 							title: localize('mcp.restart', "Restart"),
-							arguments: [server.definition.id],
+							arguments: [server.definition.id, { autoTrustChanges: true } satisfies IMcpServerStartOpts],
 						},
 					});
 					if (canDebug) {
@@ -200,7 +200,7 @@ export class McpLanguageFeatures extends Disposable implements IWorkbenchContrib
 							command: {
 								id: McpCommandIds.RestartServer,
 								title: localize('mcp.debug', "Debug"),
-								arguments: [server.definition.id, { debug: true }],
+								arguments: [server.definition.id, { debug: true, autoTrustChanges: true } satisfies IMcpServerStartOpts],
 							},
 						});
 					}
@@ -242,7 +242,7 @@ export class McpLanguageFeatures extends Disposable implements IWorkbenchContrib
 						command: {
 							id: McpCommandIds.RestartServer,
 							title: localize('mcp.restart', "Restart"),
-							arguments: [server.definition.id],
+							arguments: [server.definition.id, { autoTrustChanges: true } satisfies IMcpServerStartOpts],
 						},
 					});
 					if (canDebug) {
@@ -251,7 +251,7 @@ export class McpLanguageFeatures extends Disposable implements IWorkbenchContrib
 							command: {
 								id: McpCommandIds.RestartServer,
 								title: localize('mcp.debug', "Debug"),
-								arguments: [server.definition.id, { debug: true }],
+								arguments: [server.definition.id, { autoTrustChanges: true, debug: true } satisfies IMcpServerStartOpts],
 							},
 						});
 					}
@@ -262,7 +262,7 @@ export class McpLanguageFeatures extends Disposable implements IWorkbenchContrib
 						command: {
 							id: McpCommandIds.StartServer,
 							title: '$(debug-start) ' + localize('mcp.start', "Start"),
-							arguments: [server.definition.id],
+							arguments: [server.definition.id, { autoTrustChanges: true } satisfies IMcpServerStartOpts],
 						},
 					});
 					if (canDebug) {
@@ -271,7 +271,7 @@ export class McpLanguageFeatures extends Disposable implements IWorkbenchContrib
 							command: {
 								id: McpCommandIds.StartServer,
 								title: localize('mcp.debug', "Debug"),
-								arguments: [server.definition.id, { debug: true }],
+								arguments: [server.definition.id, { autoTrustChanges: true, debug: true } satisfies IMcpServerStartOpts],
 							},
 						});
 					}

--- a/src/vs/workbench/contrib/mcp/browser/mcpServerActions.ts
+++ b/src/vs/workbench/contrib/mcp/browser/mcpServerActions.ts
@@ -3,26 +3,26 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { getDomNodePagePosition } from '../../../../base/browser/dom.js';
 import { ActionViewItem, IActionViewItemOptions } from '../../../../base/browser/ui/actionbar/actionViewItems.js';
+import { alert } from '../../../../base/browser/ui/aria/aria.js';
 import { Action, IAction, Separator } from '../../../../base/common/actions.js';
+import { Emitter } from '../../../../base/common/event.js';
+import { IMarkdownString, MarkdownString } from '../../../../base/common/htmlContent.js';
 import { disposeIfDisposable } from '../../../../base/common/lifecycle.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
 import { localize } from '../../../../nls.js';
+import { ICommandService } from '../../../../platform/commands/common/commands.js';
 import { IContextMenuService } from '../../../../platform/contextview/browser/contextView.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
-import { errorIcon, infoIcon, manageExtensionIcon, trustIcon, warningIcon } from '../../extensions/browser/extensionsIcons.js';
-import { getDomNodePagePosition } from '../../../../base/browser/dom.js';
-import { IMcpSamplingService, IMcpServer, IMcpServerContainer, IMcpService, IMcpWorkbenchService, IWorkbenchMcpServer, McpCapability, McpConnectionState, McpServerEditorTab, McpServerInstallState } from '../common/mcpTypes.js';
-import { IEditorService } from '../../../services/editor/common/editorService.js';
-import { ICommandService } from '../../../../platform/commands/common/commands.js';
-import { McpCommandIds } from '../common/mcpCommandIds.js';
-import { IAccountQuery, IAuthenticationQueryService } from '../../../services/authentication/common/authenticationQuery.js';
-import { IAuthenticationService } from '../../../services/authentication/common/authentication.js';
-import { alert } from '../../../../base/browser/ui/aria/aria.js';
-import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry.js';
-import { IMarkdownString, MarkdownString } from '../../../../base/common/htmlContent.js';
-import { Emitter } from '../../../../base/common/event.js';
 import { IAllowedMcpServersService } from '../../../../platform/mcp/common/mcpManagement.js';
+import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry.js';
+import { IAuthenticationService } from '../../../services/authentication/common/authentication.js';
+import { IAccountQuery, IAuthenticationQueryService } from '../../../services/authentication/common/authenticationQuery.js';
+import { IEditorService } from '../../../services/editor/common/editorService.js';
+import { errorIcon, infoIcon, manageExtensionIcon, trustIcon, warningIcon } from '../../extensions/browser/extensionsIcons.js';
+import { McpCommandIds } from '../common/mcpCommandIds.js';
+import { IMcpSamplingService, IMcpServer, IMcpServerContainer, IMcpService, IMcpWorkbenchService, IWorkbenchMcpServer, McpCapability, McpConnectionState, McpServerEditorTab, McpServerInstallState } from '../common/mcpTypes.js';
 
 export abstract class McpServerAction extends Action implements IMcpServerContainer {
 
@@ -303,7 +303,7 @@ export class StartServerAction extends McpServerAction {
 		if (!server) {
 			return;
 		}
-		await server.start({ isFromInteraction: true });
+		await server.start({ promptType: 'all-untrusted' });
 		server.showOutput();
 	}
 
@@ -399,7 +399,7 @@ export class RestartServerAction extends McpServerAction {
 			return;
 		}
 		await server.stop();
-		await server.start({ isFromInteraction: true });
+		await server.start({ promptType: 'all-untrusted' });
 		server.showOutput();
 	}
 

--- a/src/vs/workbench/contrib/mcp/common/discovery/extensionMcpDiscovery.ts
+++ b/src/vs/workbench/contrib/mcp/common/discovery/extensionMcpDiscovery.ts
@@ -14,7 +14,7 @@ import { IExtensionService } from '../../../../services/extensions/common/extens
 import * as extensionsRegistry from '../../../../services/extensions/common/extensionsRegistry.js';
 import { mcpActivationEvent, mcpContributionPoint } from '../mcpConfiguration.js';
 import { IMcpRegistry } from '../mcpRegistryTypes.js';
-import { extensionPrefixedIdentifier, McpServerDefinition } from '../mcpTypes.js';
+import { extensionPrefixedIdentifier, McpServerDefinition, McpServerTrust } from '../mcpTypes.js';
 import { IMcpDiscovery } from './mcpDiscovery.js';
 
 const cacheKey = 'mcp.extCachedServers';
@@ -84,7 +84,7 @@ export class ExtensionMcpDiscovery extends Disposable implements IMcpDiscovery {
 						id,
 						label: coll.label,
 						remoteAuthority: null,
-						isTrustedByDefault: true,
+						trustBehavior: McpServerTrust.Kind.TrustedOnNonce,
 						scope: StorageScope.WORKSPACE,
 						configTarget: ConfigurationTarget.USER,
 						serverDefinitions: observableValue<McpServerDefinition[]>(this, serverDefs?.map(McpServerDefinition.fromSerialized) || []),

--- a/src/vs/workbench/contrib/mcp/common/discovery/nativeMcpDiscoveryAbstract.ts
+++ b/src/vs/workbench/contrib/mcp/common/discovery/nativeMcpDiscoveryAbstract.ts
@@ -20,7 +20,7 @@ import { StorageScope } from '../../../../../platform/storage/common/storage.js'
 import { Dto } from '../../../../services/extensions/common/proxyIdentifier.js';
 import { DiscoverySource, discoverySourceLabel, mcpDiscoverySection } from '../mcpConfiguration.js';
 import { IMcpRegistry } from '../mcpRegistryTypes.js';
-import { McpCollectionDefinition, McpCollectionSortOrder, McpServerDefinition } from '../mcpTypes.js';
+import { McpCollectionDefinition, McpCollectionSortOrder, McpServerDefinition, McpServerTrust } from '../mcpTypes.js';
 import { IMcpDiscovery } from './mcpDiscovery.js';
 import { ClaudeDesktopMpcDiscoveryAdapter, CursorDesktopMpcDiscoveryAdapter, NativeMpcDiscoveryAdapter, WindsurfDesktopMpcDiscoveryAdapter } from './nativeMcpDiscoveryAdapters.js';
 
@@ -54,7 +54,7 @@ export abstract class FilesystemMcpDiscovery extends Disposable {
 		file: URI,
 		collection: WritableMcpCollectionDefinition,
 		discoverySource: DiscoverySource | undefined,
-		adaptFile: (contents: VSBuffer) => McpServerDefinition[] | undefined,
+		adaptFile: (contents: VSBuffer) => Promise<McpServerDefinition[] | undefined>,
 	): IDisposable {
 		const store = new DisposableStore();
 		const collectionRegistration = store.add(new MutableDisposable());
@@ -62,7 +62,7 @@ export abstract class FilesystemMcpDiscovery extends Disposable {
 			let definitions: McpServerDefinition[] = [];
 			try {
 				const contents = await this._fileService.readFile(file);
-				definitions = adaptFile(contents.value) || [];
+				definitions = await adaptFile(contents.value) || [];
 			} catch {
 				// ignored
 			}
@@ -146,7 +146,7 @@ export abstract class NativeFilesystemMcpDiscovery extends FilesystemMcpDiscover
 				remoteAuthority: adapter.remoteAuthority,
 				configTarget: ConfigurationTarget.USER,
 				scope: StorageScope.PROFILE,
-				isTrustedByDefault: false,
+				trustBehavior: McpServerTrust.Kind.TrustedOnNonce,
 				serverDefinitions: observableValue<readonly McpServerDefinition[]>(this, []),
 				presentation: {
 					origin: file,

--- a/src/vs/workbench/contrib/mcp/common/discovery/workspaceMcpDiscoveryAdapter.ts
+++ b/src/vs/workbench/contrib/mcp/common/discovery/workspaceMcpDiscoveryAdapter.ts
@@ -14,7 +14,7 @@ import { IWorkspaceContextService, IWorkspaceFolder } from '../../../../../platf
 import { IRemoteAgentService } from '../../../../services/remote/common/remoteAgentService.js';
 import { DiscoverySource } from '../mcpConfiguration.js';
 import { IMcpRegistry } from '../mcpRegistryTypes.js';
-import { McpCollectionSortOrder } from '../mcpTypes.js';
+import { McpCollectionSortOrder, McpServerTrust } from '../mcpTypes.js';
 import { IMcpDiscovery } from './mcpDiscovery.js';
 import { FilesystemMcpDiscovery, WritableMcpCollectionDefinition } from './nativeMcpDiscoveryAbstract.js';
 import { claudeConfigToServerDefinition } from './nativeMcpDiscoveryAdapters.js';
@@ -54,7 +54,7 @@ export class CursorWorkspaceMcpDiscoveryAdapter extends FilesystemMcpDiscovery i
 			label: `${folder.name}/.cursor/mcp.json`,
 			remoteAuthority: this._remoteAgentService.getConnection()?.remoteAuthority || null,
 			scope: StorageScope.WORKSPACE,
-			isTrustedByDefault: false,
+			trustBehavior: McpServerTrust.Kind.TrustedOnNonce,
 			serverDefinitions: observableValue(this, []),
 			configTarget: ConfigurationTarget.WORKSPACE_FOLDER,
 			presentation: {
@@ -67,8 +67,8 @@ export class CursorWorkspaceMcpDiscoveryAdapter extends FilesystemMcpDiscovery i
 			URI.joinPath(folder.uri, '.cursor', 'mcp.json'),
 			collection,
 			DiscoverySource.CursorWorkspace,
-			contents => {
-				const defs = claudeConfigToServerDefinition(collection.id, contents, folder.uri);
+			async contents => {
+				const defs = await claudeConfigToServerDefinition(collection.id, contents, folder.uri);
 				defs?.forEach(d => d.roots = [folder.uri]);
 				return defs;
 			}

--- a/src/vs/workbench/contrib/mcp/common/mcpContextKeys.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpContextKeys.ts
@@ -51,10 +51,6 @@ export class McpContextKeysController extends Disposable implements IWorkbenchCo
 			ctxServerCount.set(servers.length);
 			ctxToolsCount.set(serverTools.reduce((count, tools) => count + tools.length, 0));
 			ctxHasUnknownTools.set(mcpService.lazyCollectionState.read(r) !== LazyCollectionState.AllKnown || servers.some(s => {
-				if (s.trusted.read(r) === false) {
-					return false;
-				}
-
 				const toolState = s.cacheState.read(r);
 				return toolState === McpServerCacheState.Unknown || toolState === McpServerCacheState.Outdated || toolState === McpServerCacheState.RefreshingFromUnknown;
 			}));

--- a/src/vs/workbench/contrib/mcp/common/mcpDevMode.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpDevMode.ts
@@ -37,7 +37,7 @@ export class McpDevModeServerAttache extends Disposable {
 		const restart = async () => {
 			const lastDebugged = fwdRef.lastModeDebugged;
 			await server.stop();
-			await server.start({ isFromInteraction: false, debug: lastDebugged });
+			await server.start({ debug: lastDebugged });
 		};
 
 		// 1. Auto-start the server, restart if entering debug mode

--- a/src/vs/workbench/contrib/mcp/common/mcpLanguageModelToolContribution.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpLanguageModelToolContribution.ts
@@ -1,0 +1,308 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { decodeBase64, VSBuffer } from '../../../../base/common/buffer.js';
+import { CancellationToken } from '../../../../base/common/cancellation.js';
+import { Codicon } from '../../../../base/common/codicons.js';
+import { markdownCommandLink, MarkdownString } from '../../../../base/common/htmlContent.js';
+import { Lazy } from '../../../../base/common/lazy.js';
+import { Disposable, DisposableMap, DisposableStore, toDisposable } from '../../../../base/common/lifecycle.js';
+import { equals } from '../../../../base/common/objects.js';
+import { autorun } from '../../../../base/common/observable.js';
+import { basename } from '../../../../base/common/resources.js';
+import { URI } from '../../../../base/common/uri.js';
+import { localize } from '../../../../nls.js';
+import { IFileService } from '../../../../platform/files/common/files.js';
+import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
+import { IProductService } from '../../../../platform/product/common/productService.js';
+import { StorageScope } from '../../../../platform/storage/common/storage.js';
+import { IWorkbenchContribution } from '../../../common/contributions.js';
+import { ChatResponseResource, getAttachableImageExtension } from '../../chat/common/chatModel.js';
+import { CountTokensCallback, ILanguageModelToolsService, IPreparedToolInvocation, IToolData, IToolImpl, IToolInvocation, IToolInvocationPreparationContext, IToolResult, IToolResultInputOutputDetails, ToolDataSource, ToolProgress, ToolSet } from '../../chat/common/languageModelToolsService.js';
+import { McpCommandIds } from './mcpCommandIds.js';
+import { IMcpRegistry } from './mcpRegistryTypes.js';
+import { IMcpServer, IMcpService, IMcpTool, McpResourceURI } from './mcpTypes.js';
+
+interface ISyncedToolData {
+	toolData: IToolData;
+	store: DisposableStore;
+}
+
+export class McpLanguageModelToolContribution extends Disposable implements IWorkbenchContribution {
+
+	public static readonly ID = 'workbench.contrib.mcp.languageModelTools';
+
+	constructor(
+		@ILanguageModelToolsService private readonly _toolsService: ILanguageModelToolsService,
+		@IMcpService mcpService: IMcpService,
+		@IInstantiationService private readonly _instantiationService: IInstantiationService,
+		@IMcpRegistry private readonly _mcpRegistry: IMcpRegistry,
+	) {
+		super();
+
+		const previous = this._register(new DisposableMap<IMcpServer, DisposableStore>());
+		this._register(autorun(reader => {
+			const servers = mcpService.servers.read(reader);
+
+			const toDelete = new Set(previous.keys());
+			for (const server of servers) {
+				if (previous.has(server)) {
+					toDelete.delete(server);
+					continue;
+				}
+
+				const store = new DisposableStore();
+				const toolSet = new Lazy(() => {
+					const metadata = server.serverMetadata.get();
+					const source: ToolDataSource = {
+						type: 'mcp',
+						serverLabel: metadata?.serverName,
+						instructions: metadata?.serverInstructions,
+						label: server.definition.label,
+						collectionId: server.collection.id,
+						definitionId: server.definition.id
+					};
+					const toolSet = store.add(this._toolsService.createToolSet(
+						source,
+						server.definition.id, server.definition.label,
+						{
+							icon: Codicon.mcp,
+							description: localize('mcp.toolset', "{0}: All Tools", server.definition.label)
+						}
+					));
+
+					return { toolSet, source };
+				});
+
+				this._syncTools(server, toolSet, store);
+				previous.set(server, store);
+			}
+
+			for (const key of toDelete) {
+				previous.deleteAndDispose(key);
+			}
+		}));
+	}
+
+	private _syncTools(server: IMcpServer, collectionData: Lazy<{ toolSet: ToolSet; source: ToolDataSource }>, store: DisposableStore) {
+		const tools = new Map</* tool ID */string, ISyncedToolData>();
+
+		store.add(autorun(reader => {
+			const toDelete = new Set(tools.keys());
+
+			// toRegister is deferred until deleting tools that moving a tool between
+			// servers (or deleting one instance of a multi-instance server) doesn't cause an error.
+			const toRegister: (() => void)[] = [];
+			const registerTool = (tool: IMcpTool, toolData: IToolData, store: DisposableStore) => {
+				store.add(this._toolsService.registerToolData(toolData));
+				store.add(this._toolsService.registerToolImplementation(tool.id, this._instantiationService.createInstance(McpToolImplementation, tool, server)));
+				store.add(collectionData.value.toolSet.addTool(toolData));
+			};
+
+			for (const tool of server.tools.read(reader)) {
+				const existing = tools.get(tool.id);
+				const collection = this._mcpRegistry.collections.get().find(c => c.id === server.collection.id);
+				const toolData: IToolData = {
+					id: tool.id,
+					source: collectionData.value.source,
+					icon: Codicon.tools,
+					// duplicative: https://github.com/modelcontextprotocol/modelcontextprotocol/pull/813
+					displayName: tool.definition.annotations?.title || tool.definition.title || tool.definition.name,
+					toolReferenceName: tool.referenceName,
+					modelDescription: tool.definition.description ?? '',
+					userDescription: tool.definition.description ?? '',
+					inputSchema: tool.definition.inputSchema,
+					canBeReferencedInPrompt: true,
+					alwaysDisplayInputOutput: true,
+					runsInWorkspace: collection?.scope === StorageScope.WORKSPACE || !!collection?.remoteAuthority,
+					tags: ['mcp'],
+				};
+
+				if (existing) {
+					if (!equals(existing.toolData, toolData)) {
+						existing.toolData = toolData;
+						existing.store.clear();
+						// We need to re-register both the data and implementation, as the
+						// implementation is discarded when the data is removed (#245921)
+						registerTool(tool, toolData, store);
+					}
+					toDelete.delete(tool.id);
+				} else {
+					const store = new DisposableStore();
+					toRegister.push(() => registerTool(tool, toolData, store));
+					tools.set(tool.id, { toolData, store });
+				}
+			}
+
+			for (const id of toDelete) {
+				const tool = tools.get(id);
+				if (tool) {
+					tool.store.dispose();
+					tools.delete(id);
+				}
+			}
+
+			for (const fn of toRegister) {
+				fn();
+			}
+		}));
+
+		store.add(toDisposable(() => {
+			for (const tool of tools.values()) {
+				tool.store.dispose();
+			}
+		}));
+	}
+}
+
+class McpToolImplementation implements IToolImpl {
+	constructor(
+		private readonly _tool: IMcpTool,
+		private readonly _server: IMcpServer,
+		@IProductService private readonly _productService: IProductService,
+		@IFileService private readonly _fileService: IFileService,
+	) { }
+
+	async prepareToolInvocation(context: IToolInvocationPreparationContext): Promise<IPreparedToolInvocation> {
+		const tool = this._tool;
+		const server = this._server;
+
+		const mcpToolWarning = localize(
+			'mcp.tool.warning',
+			"Note that MCP servers or malicious conversation content may attempt to misuse '{0}' through tools.",
+			this._productService.nameShort
+		);
+
+		const needsConfirmation = !tool.definition.annotations?.readOnlyHint;
+		// duplicative: https://github.com/modelcontextprotocol/modelcontextprotocol/pull/813
+		const title = tool.definition.annotations?.title || tool.definition.title || ('`' + tool.definition.name + '`');
+		const subtitle = localize('msg.subtitle', "{0} (MCP Server)", server.definition.label);
+
+		return {
+			confirmationMessages: needsConfirmation ? {
+				title: new MarkdownString(localize('msg.title', "Run {0}", title)),
+				message: new MarkdownString(tool.definition.description, { supportThemeIcons: true }),
+				disclaimer: mcpToolWarning,
+				allowAutoConfirm: true,
+			} : undefined,
+			invocationMessage: new MarkdownString(localize('msg.run', "Running {0}", title)),
+			pastTenseMessage: new MarkdownString(localize('msg.ran', "Ran {0} ", title)),
+			originMessage: new MarkdownString(markdownCommandLink({
+				id: McpCommandIds.ShowConfiguration,
+				title: subtitle,
+				arguments: [server.collection.id, server.definition.id],
+			}), { isTrusted: true }),
+			toolSpecificData: {
+				kind: 'input',
+				rawInput: context.parameters
+			}
+		};
+	}
+
+	async invoke(invocation: IToolInvocation, _countTokens: CountTokensCallback, progress: ToolProgress, token: CancellationToken) {
+
+		const result: IToolResult = {
+			content: []
+		};
+
+		const callResult = await this._tool.callWithProgress(invocation.parameters as Record<string, any>, progress, { chatRequestId: invocation.chatRequestId, chatSessionId: invocation.context?.sessionId }, token);
+		const details: IToolResultInputOutputDetails = {
+			input: JSON.stringify(invocation.parameters, undefined, 2),
+			output: [],
+			isError: callResult.isError === true,
+		};
+
+		for (const item of callResult.content) {
+			const audience = item.annotations?.audience || ['assistant'];
+			if (audience.includes('user')) {
+				if (item.type === 'text') {
+					progress.report({ message: item.text });
+				}
+			}
+
+			// Rewrite image rsources to images so they are inlined nicely
+			const addAsInlineData = (mimeType: string, value: string, uri?: URI) => {
+				details.output.push({ type: 'embed', mimeType, value, uri });
+				if (isForModel) {
+					result.content.push({
+						kind: 'data',
+						value: { mimeType, data: decodeBase64(value) }
+					});
+				}
+			};
+
+			const isForModel = audience.includes('assistant');
+			if (item.type === 'text') {
+				details.output.push({ type: 'embed', isText: true, value: item.text });
+				// structured content 'represents the result of the tool call', so take
+				// that in place of any textual description when present.
+				if (isForModel && !callResult.structuredContent) {
+					result.content.push({
+						kind: 'text',
+						value: item.text
+					});
+				}
+			} else if (item.type === 'image' || item.type === 'audio') {
+				// default to some image type if not given to hint
+				addAsInlineData(item.mimeType || 'image/png', item.data);
+			} else if (item.type === 'resource_link') {
+				const uri = McpResourceURI.fromServer(this._server.definition, item.uri);
+				details.output.push({
+					type: 'ref',
+					uri,
+					mimeType: item.mimeType,
+				});
+
+				if (isForModel) {
+					if (item.mimeType && getAttachableImageExtension(item.mimeType)) {
+						result.content.push({
+							kind: 'data',
+							value: {
+								mimeType: item.mimeType,
+								data: await this._fileService.readFile(uri).then(f => f.value).catch(() => VSBuffer.alloc(0)),
+							}
+						});
+					} else {
+						result.content.push({
+							kind: 'text',
+							value: `The tool returns a resource which can be read from the URI ${uri}\n`,
+						});
+					}
+				}
+			} else if (item.type === 'resource') {
+				const uri = McpResourceURI.fromServer(this._server.definition, item.resource.uri);
+				if (item.resource.mimeType && getAttachableImageExtension(item.resource.mimeType) && 'blob' in item.resource) {
+					addAsInlineData(item.resource.mimeType, item.resource.blob, uri);
+				} else {
+					details.output.push({
+						type: 'embed',
+						uri,
+						isText: 'text' in item.resource,
+						mimeType: item.resource.mimeType,
+						value: 'blob' in item.resource ? item.resource.blob : item.resource.text,
+						asResource: true,
+					});
+
+					if (isForModel) {
+						const permalink = invocation.chatRequestId && invocation.context && ChatResponseResource.createUri(invocation.context.sessionId, invocation.chatRequestId, invocation.callId, result.content.length, basename(uri));
+
+						result.content.push({
+							kind: 'text',
+							value: 'text' in item.resource ? item.resource.text : `The tool returns a resource which can be read from the URI ${permalink || uri}\n`,
+						});
+					}
+				}
+			}
+		}
+
+		if (callResult.structuredContent) {
+			details.output.push({ type: 'embed', isText: true, value: JSON.stringify(callResult.structuredContent, null, 2) });
+			result.content.push({ kind: 'text', value: JSON.stringify(callResult.structuredContent) });
+		}
+
+		result.toolResultDetails = details;
+		return result;
+	}
+}

--- a/src/vs/workbench/contrib/mcp/common/mcpRegistry.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpRegistry.ts
@@ -287,7 +287,12 @@ export class McpRegistry extends Disposable implements IMcpRegistry {
 		return !!trustedDefinitionIds?.includes(definition.id);
 	}
 
-	private async _promptForTrustOpenDialog(definitions: { definition: McpServerDefinition; collection: McpCollectionDefinition }[]): Promise<string[] | undefined> {
+	/**
+	 * Confirms with the user which of the provided definitions should be trusted.
+	 * Returns undefined if the user cancelled the flow, or the list of trusted
+	 * definition IDs otherwise.
+	 */
+	protected async _promptForTrustOpenDialog(definitions: { definition: McpServerDefinition; collection: McpCollectionDefinition }[]): Promise<string[] | undefined> {
 		function labelFor(r: { definition: McpServerDefinition; collection: McpCollectionDefinition }) {
 			const originURI = r.definition.presentation?.origin?.uri || r.collection.presentation?.origin;
 			let labelWithOrigin = originURI ? `[\`${r.definition.label}\`](${originURI})` : '`' + r.definition.label + '`';

--- a/src/vs/workbench/contrib/mcp/common/mcpRegistry.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpRegistry.ts
@@ -238,8 +238,12 @@ export class McpRegistry extends Disposable implements IMcpRegistry {
 				return false;
 			}
 
-			if (await this._promptForTrust(definition, collection, interaction, trustNonceBearer)) {
+			const didTrust = await this._promptForTrust(definition, collection, interaction, trustNonceBearer);
+			if (didTrust) {
 				return true;
+			}
+			if (didTrust === undefined) {
+				return undefined;
 			}
 
 			trustNonceBearer.trustedAtNonce = notTrustedNonce;

--- a/src/vs/workbench/contrib/mcp/common/mcpRegistry.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpRegistry.ts
@@ -3,23 +3,28 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { assertNever } from '../../../../base/common/assert.js';
 import { Codicon } from '../../../../base/common/codicons.js';
 import { Emitter } from '../../../../base/common/event.js';
 import { MarkdownString } from '../../../../base/common/htmlContent.js';
+import { Iterable } from '../../../../base/common/iterator.js';
 import { Lazy } from '../../../../base/common/lazy.js';
-import { Disposable, IDisposable } from '../../../../base/common/lifecycle.js';
-import { derived, IObservable, observableValue } from '../../../../base/common/observable.js';
-import { basename } from '../../../../base/common/resources.js';
+import { Disposable, DisposableStore, IDisposable } from '../../../../base/common/lifecycle.js';
+import { autorun, derived, IObservable, observableValue } from '../../../../base/common/observable.js';
+import { isDefined } from '../../../../base/common/types.js';
+import { URI } from '../../../../base/common/uri.js';
 import { localize } from '../../../../nls.js';
 import { ConfigurationTarget, IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { IDialogService } from '../../../../platform/dialogs/common/dialogs.js';
+import { ExtensionIdentifier } from '../../../../platform/extensions/common/extensions.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
+import { ILabelService } from '../../../../platform/label/common/label.js';
+import { ILogService } from '../../../../platform/log/common/log.js';
 import { mcpEnabledConfig } from '../../../../platform/mcp/common/mcpManagement.js';
 import { INotificationService, Severity } from '../../../../platform/notification/common/notification.js';
-import { observableMemento } from '../../../../platform/observable/common/observableMemento.js';
 import { observableConfigValue } from '../../../../platform/observable/common/platformObservableUtils.js';
-import { IProductService } from '../../../../platform/product/common/productService.js';
-import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
+import { IQuickInputButton, IQuickInputService, IQuickPickItem } from '../../../../platform/quickinput/common/quickInput.js';
+import { StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
 import { IWorkspaceFolderData } from '../../../../platform/workspace/common/workspace.js';
 import { IConfigurationResolverService } from '../../../services/configurationResolver/common/configurationResolver.js';
 import { ConfigurationResolverExpression, IResolvedValue } from '../../../services/configurationResolver/common/configurationResolverExpression.js';
@@ -28,17 +33,12 @@ import { IMcpDevModeDebugging } from './mcpDevMode.js';
 import { McpRegistryInputStorage } from './mcpRegistryInputStorage.js';
 import { IMcpHostDelegate, IMcpRegistry, IMcpResolveConnectionOptions } from './mcpRegistryTypes.js';
 import { McpServerConnection } from './mcpServerConnection.js';
-import { IMcpServerConnection, LazyCollectionState, McpCollectionDefinition, McpCollectionReference, McpDefinitionReference, McpServerDefinition, McpServerLaunch } from './mcpTypes.js';
+import { IMcpServerConnection, LazyCollectionState, McpCollectionDefinition, McpDefinitionReference, McpServerDefinition, McpServerLaunch, McpServerTrust, McpStartServerInteraction } from './mcpTypes.js';
 
-const createTrustMemento = observableMemento<Readonly<Record<string, boolean>>>({
-	defaultValue: {},
-	key: 'mcp.trustedCollections'
-});
+const notTrustedNonce = '__vscode_not_trusted';
 
 export class McpRegistry extends Disposable implements IMcpRegistry {
 	declare public readonly _serviceBrand: undefined;
-
-	private readonly _trustPrompts = new Map</* collection ID */string, Promise<boolean | undefined>>();
 
 	private readonly _collections = observableValue<readonly McpCollectionDefinition[]>('collections', []);
 	private readonly _delegates = observableValue<readonly IMcpHostDelegate[]>('delegates', []);
@@ -53,7 +53,6 @@ export class McpRegistry extends Disposable implements IMcpRegistry {
 	private readonly _workspaceStorage = new Lazy(() => this._register(this._instantiationService.createInstance(McpRegistryInputStorage, StorageScope.WORKSPACE, StorageTarget.USER)));
 	private readonly _profileStorage = new Lazy(() => this._register(this._instantiationService.createInstance(McpRegistryInputStorage, StorageScope.PROFILE, StorageTarget.USER)));
 
-	private readonly _trustMemento = new Lazy(() => this._register(createTrustMemento(StorageScope.APPLICATION, StorageTarget.MACHINE, this._storageService)));
 	private readonly _ongoingLazyActivations = observableValue(this, 0);
 
 	public readonly lazyCollectionState = derived(reader => {
@@ -79,11 +78,12 @@ export class McpRegistry extends Disposable implements IMcpRegistry {
 		@IInstantiationService private readonly _instantiationService: IInstantiationService,
 		@IConfigurationResolverService private readonly _configurationResolverService: IConfigurationResolverService,
 		@IDialogService private readonly _dialogService: IDialogService,
-		@IStorageService private readonly _storageService: IStorageService,
-		@IProductService private readonly _productService: IProductService,
 		@INotificationService private readonly _notificationService: INotificationService,
 		@IEditorService private readonly _editorService: IEditorService,
 		@IConfigurationService configurationService: IConfigurationService,
+		@IQuickInputService private readonly _quickInputService: IQuickInputService,
+		@ILabelService private readonly _labelService: ILabelService,
+		@ILogService private readonly _logService: ILogService,
 	) {
 		super();
 		this._enabled = observableConfigValue(mcpEnabledConfig, true, configurationService);
@@ -203,59 +203,208 @@ export class McpRegistry extends Disposable implements IMcpRegistry {
 		return this._getInputStorage(scope).getMap();
 	}
 
-	public resetTrust(): void {
-		this._trustMemento.value.set({}, undefined);
-	}
-
-	public getTrust(collectionRef: McpCollectionReference): IObservable<boolean | undefined> {
-		return derived(reader => {
-			const collection = this._collections.read(reader).find(c => c.id === collectionRef.id);
-			if (!collection || collection.isTrustedByDefault) {
+	private async _checkTrust(collection: McpCollectionDefinition, definition: McpServerDefinition, {
+		trustNonceBearer,
+		interaction,
+		promptType = 'only-new',
+		autoTrustChanges = false,
+	}: IMcpResolveConnectionOptions) {
+		if (collection.trustBehavior === McpServerTrust.Kind.Trusted) {
+			this._logService.trace(`MCP server ${definition.id} is trusted, no trust prompt needed`);
+			return true;
+		} else if (collection.trustBehavior === McpServerTrust.Kind.TrustedOnNonce) {
+			if (definition.cacheNonce === trustNonceBearer.trustedAtNonce) {
+				this._logService.trace(`MCP server ${definition.id} is unchanged, no trust prompt needed`);
 				return true;
 			}
 
-			const memento = this._trustMemento.value.read(reader);
-			return memento.hasOwnProperty(collection.id) ? memento[collection.id] : undefined;
-		});
+			if (autoTrustChanges) {
+				this._logService.trace(`MCP server ${definition.id} is was changed but user explicitly executed`);
+				trustNonceBearer.trustedAtNonce = definition.cacheNonce;
+				return true;
+			}
+
+			if (trustNonceBearer.trustedAtNonce === notTrustedNonce) {
+				if (promptType === 'all-untrusted') {
+					return this._promptForTrust(definition, collection, interaction, trustNonceBearer);
+				} else {
+					this._logService.trace(`MCP server ${definition.id} is untrusted, denying trust prompt`);
+					return false;
+				}
+			}
+
+			if (promptType === 'never') {
+				this._logService.trace(`MCP server ${definition.id} trust state is unknown, skipping prompt`);
+				return false;
+			}
+
+			if (await this._promptForTrust(definition, collection, interaction, trustNonceBearer)) {
+				return true;
+			}
+
+			trustNonceBearer.trustedAtNonce = notTrustedNonce;
+			return false;
+		} else {
+			assertNever(collection.trustBehavior);
+		}
 	}
 
-	private _promptForTrust(collection: McpCollectionDefinition): Promise<boolean | undefined> {
-		// Collect all trust prompts for a single config so that concurrently trying to start N
-		// servers in a config don't result in N different dialogs
-		let resultPromise = this._trustPrompts.get(collection.id);
-		resultPromise ??= this._promptForTrustOpenDialog(collection).finally(() => {
-			this._trustPrompts.delete(collection.id);
-		});
-		this._trustPrompts.set(collection.id, resultPromise);
+	private async _promptForTrust(definition: McpServerDefinition, collection: McpCollectionDefinition, interaction: McpStartServerInteraction | undefined, trustNonceBearer: { trustedAtNonce: string | undefined }): Promise<boolean> {
+		interaction ??= new McpStartServerInteraction();
+		interaction.participants.set(definition.id, { s: 'waiting', definition, collection });
 
-		return resultPromise;
+		const trustedDefinitionIds = await new Promise<string[] | undefined>(resolve => {
+			let runner: IDisposable | undefined;
+			let didRun = false;
+			// eslint-disable-next-line prefer-const
+			runner = autorun(reader => {
+				const map = interaction.participants.observable.read(reader);
+				if (Iterable.some(map.values(), p => p.s === 'unknown')) {
+					return; // wait to gather all calls
+				}
+
+				runner?.dispose();
+				didRun = true;
+				interaction.choice ??= this._promptForTrustOpenDialog(
+					[...map.values()].map((v) => v.s === 'waiting' ? v : undefined).filter(isDefined),
+				);
+				resolve(interaction.choice);
+			});
+
+			if (didRun) { // work around sync disposal
+				runner.dispose();
+			}
+		});
+
+		this._logService.trace(`MCP trusted servers:`, trustedDefinitionIds);
+
+		if (trustedDefinitionIds) {
+			trustNonceBearer.trustedAtNonce = trustedDefinitionIds.includes(definition.id)
+				? definition.cacheNonce
+				: notTrustedNonce;
+		}
+
+		return !!trustedDefinitionIds?.includes(definition.id);
 	}
 
-	private async _promptForTrustOpenDialog(collection: McpCollectionDefinition): Promise<boolean | undefined> {
-		const originURI = collection.presentation?.origin;
-		const labelWithOrigin = originURI ? `[\`${basename(originURI)}\`](${originURI})` : collection.label;
+	private async _promptForTrustOpenDialog(definitions: { definition: McpServerDefinition; collection: McpCollectionDefinition }[]): Promise<string[] | undefined> {
+		function labelFor(r: { definition: McpServerDefinition; collection: McpCollectionDefinition }) {
+			const originURI = r.definition.presentation?.origin?.uri || r.collection.presentation?.origin;
+			let labelWithOrigin = originURI ? `[\`${r.definition.label}\`](${originURI})` : '`' + r.definition.label + '`';
 
-		const result = await this._dialogService.prompt(
+			if (r.collection.source instanceof ExtensionIdentifier) {
+				labelWithOrigin += ` (${localize('trustFromExt', 'from {0}', r.collection.source.value)})`;
+			}
+
+			return labelWithOrigin;
+		}
+
+		if (definitions.length === 1) {
+			const def = definitions[0];
+			const originURI = def.definition.presentation?.origin?.uri;
+
+			const { result } = await this._dialogService.prompt(
+				{
+					message: localize('trustTitleWithOrigin', 'Trust and run MCP server {0}?', def.definition.label),
+					custom: {
+						icon: Codicon.shield,
+						markdownDetails: [{
+							markdown: new MarkdownString(localize('mcp.trust.details', 'The MCP server {0} was updated. MCP servers may add context to your chat session and lead to unexpected behavior. Do you want to trust and run this server?', labelFor(def))),
+							actionHandler: () => {
+								const editor = this._editorService.openEditor({ resource: originURI! }, AUX_WINDOW_GROUP);
+								return editor.then(Boolean);
+							},
+						}]
+					},
+					buttons: [
+						{ label: localize('mcp.trust.yes', 'Trust'), run: () => true },
+						{ label: localize('mcp.trust.no', 'Do not trust'), run: () => false }
+					],
+				},
+			);
+
+			return result === undefined ? undefined : (result ? [def.definition.id] : []);
+		}
+
+		const list = definitions.map(d => `- ${labelFor(d)}`).join('\n');
+		const { result } = await this._dialogService.prompt(
 			{
-				message: localize('trustTitleWithOrigin', 'Trust MCP servers from {0}?', collection.label),
+				message: localize('trustTitleWithOriginMulti', 'Trust and run {0} MCP servers?', definitions.length),
 				custom: {
 					icon: Codicon.shield,
 					markdownDetails: [{
-						markdown: new MarkdownString(localize('mcp.trust.details', '{0} discovered Model Context Protocol servers from {1} (`{2}`). {0} can use their capabilities in Chat.\n\nDo you want to allow running MCP servers from {3}?', this._productService.nameShort, collection.label, collection.serverDefinitions.get().map(s => s.label).join('`, `'), labelWithOrigin)),
-						actionHandler: () => {
-							const editor = this._editorService.openEditor({ resource: collection.presentation!.origin! }, AUX_WINDOW_GROUP);
+						markdown: new MarkdownString(localize('mcp.trust.detailsMulti', 'Several updated MCP servers were discovered:\n\n{0}\n\n MCP servers may add context to your chat session and lead to unexpected behavior. Do you want to trust and run these server?', list)),
+						actionHandler: (uri) => {
+							const editor = this._editorService.openEditor({ resource: URI.parse(uri) }, AUX_WINDOW_GROUP);
 							return editor.then(Boolean);
 						},
 					}]
 				},
 				buttons: [
-					{ label: localize('mcp.trust.yes', 'Trust'), run: () => true },
-					{ label: localize('mcp.trust.no', 'Do not trust'), run: () => false }
+					{ label: localize('mcp.trust.yes', 'Trust'), run: () => 'all' },
+					{ label: localize('mcp.trust.pick', 'Pick Trusted'), run: () => 'pick' },
+					{ label: localize('mcp.trust.no', 'Do not trust'), run: () => 'none' },
 				],
 			},
 		);
 
-		return result.result;
+		if (result === undefined) {
+			return undefined;
+		} else if (result === 'all') {
+			return definitions.map(d => d.definition.id);
+		} else if (result === 'none') {
+			return [];
+		}
+
+		type ActionableButton = IQuickInputButton & { action: () => void };
+		function isActionableButton(obj: IQuickInputButton): obj is ActionableButton {
+			return typeof (obj as ActionableButton).action === 'function';
+		}
+
+		const store = new DisposableStore();
+		const picker = store.add(this._quickInputService.createQuickPick<IQuickPickItem & { definitonId: string }>({ useSeparators: false }));
+		picker.canSelectMany = true;
+		picker.items = definitions.map(({ definition, collection }) => {
+			const buttons: ActionableButton[] = [];
+			if (definition.presentation?.origin) {
+				const origin = definition.presentation.origin;
+				buttons.push({
+					iconClass: 'codicon-go-to-file',
+					tooltip: 'Go to Definition',
+					action: () => this._editorService.openEditor({ resource: origin.uri, options: { selection: origin.range } })
+				});
+			}
+
+			return {
+				type: 'item',
+				label: definition.label,
+				definitonId: definition.id,
+				description: collection.source instanceof ExtensionIdentifier
+					? collection.source.value
+					: (definition.presentation?.origin ? this._labelService.getUriLabel(definition.presentation.origin.uri) : undefined),
+				picked: false,
+				buttons
+			};
+		});
+		picker.placeholder = 'Select MCP servers to trust';
+		picker.ignoreFocusOut = true;
+
+		store.add(picker.onDidTriggerItemButton(e => {
+			if (isActionableButton(e.button)) {
+				e.button.action();
+			}
+		}));
+
+		return new Promise<string[] | undefined>(resolve => {
+			picker.onDidAccept(() => {
+				resolve(picker.selectedItems.map(item => item.definitonId));
+				picker.hide();
+			});
+			picker.onDidHide(() => {
+				resolve(undefined);
+			});
+			picker.show();
+		}).finally(() => store.dispose());
 	}
 
 	private async _updateStorageWithExpressionInputs(inputStorage: McpRegistryInputStorage, expr: ConfigurationResolverExpression<unknown>): Promise<void> {
@@ -300,7 +449,8 @@ export class McpRegistry extends Disposable implements IMcpRegistry {
 		return await this._configurationResolverService.resolveAsync(folder, expr);
 	}
 
-	public async resolveConnection({ collectionRef, definitionRef, forceTrust, logger, debug }: IMcpResolveConnectionOptions): Promise<IMcpServerConnection | undefined> {
+	public async resolveConnection(opts: IMcpResolveConnectionOptions): Promise<IMcpServerConnection | undefined> {
+		const { collectionRef, definitionRef, interaction, logger, debug } = opts;
 		let collection = this._collections.get().find(c => c.id === collectionRef.id);
 		if (collection?.lazy) {
 			await collection.lazy.load();
@@ -317,23 +467,10 @@ export class McpRegistry extends Disposable implements IMcpRegistry {
 			throw new Error('No delegate found that can handle the connection');
 		}
 
-		if (!collection.isTrustedByDefault) {
-			const memento = this._trustMemento.value.get();
-			const trusted = memento.hasOwnProperty(collection.id) ? memento[collection.id] : undefined;
-
-			if (trusted) {
-				// continue
-			} else if (trusted === undefined || forceTrust) {
-				const trustValue = await this._promptForTrust(collection);
-				if (trustValue !== undefined) {
-					this._trustMemento.value.set({ ...memento, [collection.id]: trustValue }, undefined);
-				}
-				if (!trustValue) {
-					return;
-				}
-			} else /** trusted === false && !forceTrust */ {
-				return undefined;
-			}
+		const trusted = await this._checkTrust(collection, definition, opts);
+		interaction?.participants.set(definition.id, { s: 'resolved' });
+		if (!trusted) {
+			return undefined;
 		}
 
 		let launch: McpServerLaunch | undefined = definition.launch;

--- a/src/vs/workbench/contrib/mcp/common/mcpRegistryTypes.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpRegistryTypes.ts
@@ -12,7 +12,7 @@ import { ILogger, LogLevel } from '../../../../platform/log/common/log.js';
 import { StorageScope } from '../../../../platform/storage/common/storage.js';
 import { IWorkspaceFolderData } from '../../../../platform/workspace/common/workspace.js';
 import { IResolvedValue } from '../../../services/configurationResolver/common/configurationResolverExpression.js';
-import { IMcpServerConnection, LazyCollectionState, McpCollectionDefinition, McpCollectionReference, McpConnectionState, McpDefinitionReference, McpServerDefinition, McpServerLaunch } from './mcpTypes.js';
+import { IMcpServerConnection, LazyCollectionState, McpCollectionDefinition, McpCollectionReference, McpConnectionState, McpDefinitionReference, McpServerDefinition, McpServerLaunch, McpStartServerInteraction } from './mcpTypes.js';
 import { MCP } from './modelContextProtocol.js';
 
 export const IMcpRegistry = createDecorator<IMcpRegistry>('mcpRegistry');
@@ -36,10 +36,14 @@ export interface IMcpHostDelegate {
 
 export interface IMcpResolveConnectionOptions {
 	logger: ILogger;
+	interaction?: McpStartServerInteraction;
 	collectionRef: McpCollectionReference;
 	definitionRef: McpDefinitionReference;
-	/** If set, the user will be asked to trust the collection even if they untrusted it previously */
-	forceTrust?: boolean;
+
+	trustNonceBearer: { trustedAtNonce: string | undefined };
+	promptType?: 'only-new' | 'all-untrusted' | 'never';
+	autoTrustChanges?: boolean;
+
 	/** If set, try to launch with debugging when dev mode is configured */
 	debug?: boolean;
 }
@@ -63,12 +67,6 @@ export interface IMcpRegistry {
 
 	registerDelegate(delegate: IMcpHostDelegate): IDisposable;
 	registerCollection(collection: McpCollectionDefinition): IDisposable;
-
-	/** Resets the trust state of all collections. */
-	resetTrust(): void;
-
-	/** Gets whether the collection is trusted. */
-	getTrust(collection: McpCollectionReference): IObservable<boolean | undefined>;
 
 	/** Resets any saved inputs for the input, or globally. */
 	clearSavedInputs(scope: StorageScope, inputId?: string): Promise<void>;

--- a/src/vs/workbench/contrib/mcp/common/mcpRegistryTypes.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpRegistryTypes.ts
@@ -40,8 +40,19 @@ export interface IMcpResolveConnectionOptions {
 	collectionRef: McpCollectionReference;
 	definitionRef: McpDefinitionReference;
 
+	/** A reference (on the server) to its last nonce where trust was given. */
 	trustNonceBearer: { trustedAtNonce: string | undefined };
+	/**
+	 * When to trigger the trust prompt.
+	 * - only-new: only prompt for servers that are not previously explicitly untrusted (default)
+	 * - all-untrusted: prompt for all servers that are not trusted
+	 * - never: don't prompt, fail silently when trying to start an untrusted server
+	 */
 	promptType?: 'only-new' | 'all-untrusted' | 'never';
+	/**
+	 * Automatically trust if changed. This should ONLY be set for afforances that
+	 * ensure the user sees the config before it gets started (e.g. code lenses)
+	 */
 	autoTrustChanges?: boolean;
 
 	/** If set, try to launch with debugging when dev mode is configured */

--- a/src/vs/workbench/contrib/mcp/common/mcpService.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpService.ts
@@ -4,35 +4,16 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { RunOnceScheduler } from '../../../../base/common/async.js';
-import { decodeBase64, VSBuffer } from '../../../../base/common/buffer.js';
-import { CancellationToken } from '../../../../base/common/cancellation.js';
-import { Codicon } from '../../../../base/common/codicons.js';
-import { markdownCommandLink, MarkdownString } from '../../../../base/common/htmlContent.js';
-import { Lazy } from '../../../../base/common/lazy.js';
-import { Disposable, DisposableStore, IReference, toDisposable } from '../../../../base/common/lifecycle.js';
-import { equals } from '../../../../base/common/objects.js';
+import { Disposable } from '../../../../base/common/lifecycle.js';
 import { autorun, IObservable, observableValue, transaction } from '../../../../base/common/observable.js';
-import { basename } from '../../../../base/common/resources.js';
-import { URI } from '../../../../base/common/uri.js';
-import { localize } from '../../../../nls.js';
-import { IFileService } from '../../../../platform/files/common/files.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
-import { IProductService } from '../../../../platform/product/common/productService.js';
 import { StorageScope } from '../../../../platform/storage/common/storage.js';
-import { ChatResponseResource, getAttachableImageExtension } from '../../chat/common/chatModel.js';
-import { CountTokensCallback, ILanguageModelToolsService, IPreparedToolInvocation, IToolData, IToolImpl, IToolInvocation, IToolInvocationPreparationContext, IToolResult, IToolResultInputOutputDetails, ToolDataSource, ToolProgress, ToolSet } from '../../chat/common/languageModelToolsService.js';
-import { McpCommandIds } from './mcpCommandIds.js';
 import { IMcpRegistry } from './mcpRegistryTypes.js';
 import { McpServer, McpServerMetadataCache } from './mcpServer.js';
-import { IMcpServer, IMcpService, IMcpTool, McpCollectionDefinition, McpResourceURI, McpServerCacheState, McpServerDefinition, McpToolName } from './mcpTypes.js';
+import { IMcpServer, IMcpService, McpCollectionDefinition, McpServerCacheState, McpServerDefinition, McpToolName } from './mcpTypes.js';
 
-interface ISyncedToolData {
-	toolData: IToolData;
-	store: DisposableStore;
-}
-
-type IMcpServerRec = IReference<IMcpServer> & { toolPrefix: string };
+type IMcpServerRec = { object: IMcpServer; toolPrefix: string };
 
 export class McpService extends Disposable implements IMcpService {
 
@@ -49,7 +30,6 @@ export class McpService extends Disposable implements IMcpService {
 	constructor(
 		@IInstantiationService private readonly _instantiationService: IInstantiationService,
 		@IMcpRegistry private readonly _mcpRegistry: IMcpRegistry,
-		@ILanguageModelToolsService private readonly _toolsService: ILanguageModelToolsService,
 		@ILogService private readonly _logService: ILogService,
 	) {
 		super();
@@ -74,6 +54,10 @@ export class McpService extends Disposable implements IMcpService {
 		this.workspaceCache.reset();
 	}
 
+	public resetTrust(): void {
+		this.resetCaches(); // same difference now
+	}
+
 	public async activateCollections(): Promise<void> {
 		const collections = await this._mcpRegistry.discoverCollections();
 		const collectionIds = new Set(collections.map(c => c.id));
@@ -92,76 +76,6 @@ export class McpService extends Disposable implements IMcpService {
 		}
 
 		await Promise.all(todo);
-	}
-
-	private _syncTools(server: McpServer, collectionData: Lazy<{ toolSet: ToolSet; source: ToolDataSource }>, store: DisposableStore) {
-		const tools = new Map</* tool ID */string, ISyncedToolData>();
-
-		store.add(autorun(reader => {
-			const toDelete = new Set(tools.keys());
-
-			// toRegister is deferred until deleting tools that moving a tool between
-			// servers (or deleting one instance of a multi-instance server) doesn't cause an error.
-			const toRegister: (() => void)[] = [];
-			const registerTool = (tool: IMcpTool, toolData: IToolData, store: DisposableStore) => {
-				store.add(this._toolsService.registerToolData(toolData));
-				store.add(this._toolsService.registerToolImplementation(tool.id, this._instantiationService.createInstance(McpToolImplementation, tool, server)));
-				store.add(collectionData.value.toolSet.addTool(toolData));
-			};
-
-			for (const tool of server.tools.read(reader)) {
-				const existing = tools.get(tool.id);
-				const collection = this._mcpRegistry.collections.get().find(c => c.id === server.collection.id);
-				const toolData: IToolData = {
-					id: tool.id,
-					source: collectionData.value.source,
-					icon: Codicon.tools,
-					// duplicative: https://github.com/modelcontextprotocol/modelcontextprotocol/pull/813
-					displayName: tool.definition.annotations?.title || tool.definition.title || tool.definition.name,
-					toolReferenceName: tool.referenceName,
-					modelDescription: tool.definition.description ?? '',
-					userDescription: tool.definition.description ?? '',
-					inputSchema: tool.definition.inputSchema,
-					canBeReferencedInPrompt: true,
-					alwaysDisplayInputOutput: true,
-					runsInWorkspace: collection?.scope === StorageScope.WORKSPACE || !!collection?.remoteAuthority,
-					tags: ['mcp'],
-				};
-
-				if (existing) {
-					if (!equals(existing.toolData, toolData)) {
-						existing.toolData = toolData;
-						existing.store.clear();
-						// We need to re-register both the data and implementation, as the
-						// implementation is discarded when the data is removed (#245921)
-						registerTool(tool, toolData, store);
-					}
-					toDelete.delete(tool.id);
-				} else {
-					const store = new DisposableStore();
-					toRegister.push(() => registerTool(tool, toolData, store));
-					tools.set(tool.id, { toolData, store });
-				}
-			}
-
-			for (const id of toDelete) {
-				const tool = tools.get(id);
-				if (tool) {
-					tool.store.dispose();
-					tools.delete(id);
-				}
-			}
-
-			for (const fn of toRegister) {
-				fn();
-			}
-		}));
-
-		store.add(toDisposable(() => {
-			for (const tool of tools.values()) {
-				tool.store.dispose();
-			}
-		}));
 	}
 
 	public updateCollectedServers() {
@@ -193,13 +107,12 @@ export class McpService extends Disposable implements IMcpService {
 			if (match) {
 				pushMatch(match, server);
 			} else {
-				server.dispose();
+				server.object.dispose();
 			}
 		}
 
 		// Create any new servers that are needed.
 		for (const def of nextDefinitions) {
-			const store = new DisposableStore();
 			const object = this._instantiationService.createInstance(
 				McpServer,
 				def.collectionDefinition,
@@ -210,32 +123,7 @@ export class McpService extends Disposable implements IMcpService {
 				def.toolPrefix,
 			);
 
-			const toolSet = new Lazy(() => {
-				const metadata = object.serverMetadata.get();
-				const source: ToolDataSource = {
-					type: 'mcp',
-					serverLabel: metadata.serverName,
-					instructions: metadata.serverInstructions,
-					label: object.definition.label,
-					collectionId: object.collection.id,
-					definitionId: object.definition.id
-				};
-				const toolSet = store.add(this._toolsService.createToolSet(
-					source,
-					def.serverDefinition.id, def.serverDefinition.label,
-					{
-						icon: Codicon.mcp,
-						description: localize('mcp.toolset', "{0}: All Tools", def.serverDefinition.label)
-					}
-				));
-
-				return { source, toolSet };
-			});
-
-			store.add(object);
-			this._syncTools(object, toolSet, store);
-
-			nextServers.push({ object, dispose: () => store.dispose(), toolPrefix: def.toolPrefix });
+			nextServers.push({ object, toolPrefix: def.toolPrefix });
 		}
 
 		transaction(tx => {
@@ -244,163 +132,13 @@ export class McpService extends Disposable implements IMcpService {
 	}
 
 	public override dispose(): void {
-		this._servers.get().forEach(s => s.dispose());
+		this._servers.get().forEach(s => s.object.dispose());
 		super.dispose();
 	}
 }
 
 function defsEqual(server: IMcpServer, def: { serverDefinition: McpServerDefinition; collectionDefinition: McpCollectionDefinition }) {
 	return server.collection.id === def.collectionDefinition.id && server.definition.id === def.serverDefinition.id;
-}
-
-class McpToolImplementation implements IToolImpl {
-	constructor(
-		private readonly _tool: IMcpTool,
-		private readonly _server: IMcpServer,
-		@IProductService private readonly _productService: IProductService,
-		@IFileService private readonly _fileService: IFileService,
-	) { }
-
-	async prepareToolInvocation(context: IToolInvocationPreparationContext): Promise<IPreparedToolInvocation> {
-		const tool = this._tool;
-		const server = this._server;
-
-		const mcpToolWarning = localize(
-			'mcp.tool.warning',
-			"Note that MCP servers or malicious conversation content may attempt to misuse '{0}' through tools.",
-			this._productService.nameShort
-		);
-
-		const needsConfirmation = !tool.definition.annotations?.readOnlyHint;
-		// duplicative: https://github.com/modelcontextprotocol/modelcontextprotocol/pull/813
-		const title = tool.definition.annotations?.title || tool.definition.title || ('`' + tool.definition.name + '`');
-		const subtitle = localize('msg.subtitle', "{0} (MCP Server)", server.definition.label);
-
-		return {
-			confirmationMessages: needsConfirmation ? {
-				title: new MarkdownString(localize('msg.title', "Run {0}", title)),
-				message: new MarkdownString(tool.definition.description, { supportThemeIcons: true }),
-				disclaimer: mcpToolWarning,
-				allowAutoConfirm: true,
-			} : undefined,
-			invocationMessage: new MarkdownString(localize('msg.run', "Running {0}", title)),
-			pastTenseMessage: new MarkdownString(localize('msg.ran', "Ran {0} ", title)),
-			originMessage: new MarkdownString(markdownCommandLink({
-				id: McpCommandIds.ShowConfiguration,
-				title: subtitle,
-				arguments: [server.collection.id, server.definition.id],
-			}), { isTrusted: true }),
-			toolSpecificData: {
-				kind: 'input',
-				rawInput: context.parameters
-			}
-		};
-	}
-
-	async invoke(invocation: IToolInvocation, _countTokens: CountTokensCallback, progress: ToolProgress, token: CancellationToken) {
-
-		const result: IToolResult = {
-			content: []
-		};
-
-		const callResult = await this._tool.callWithProgress(invocation.parameters as Record<string, any>, progress, { chatRequestId: invocation.chatRequestId, chatSessionId: invocation.context?.sessionId }, token);
-		const details: IToolResultInputOutputDetails = {
-			input: JSON.stringify(invocation.parameters, undefined, 2),
-			output: [],
-			isError: callResult.isError === true,
-		};
-
-		for (const item of callResult.content) {
-			const audience = item.annotations?.audience || ['assistant'];
-			if (audience.includes('user')) {
-				if (item.type === 'text') {
-					progress.report({ message: item.text });
-				}
-			}
-
-			// Rewrite image rsources to images so they are inlined nicely
-			const addAsInlineData = (mimeType: string, value: string, uri?: URI) => {
-				details.output.push({ type: 'embed', mimeType, value, uri });
-				if (isForModel) {
-					result.content.push({
-						kind: 'data',
-						value: { mimeType, data: decodeBase64(value) }
-					});
-				}
-			};
-
-			const isForModel = audience.includes('assistant');
-			if (item.type === 'text') {
-				details.output.push({ type: 'embed', isText: true, value: item.text });
-				// structured content 'represents the result of the tool call', so take
-				// that in place of any textual description when present.
-				if (isForModel && !callResult.structuredContent) {
-					result.content.push({
-						kind: 'text',
-						value: item.text
-					});
-				}
-			} else if (item.type === 'image' || item.type === 'audio') {
-				// default to some image type if not given to hint
-				addAsInlineData(item.mimeType || 'image/png', item.data);
-			} else if (item.type === 'resource_link') {
-				const uri = McpResourceURI.fromServer(this._server.definition, item.uri);
-				details.output.push({
-					type: 'ref',
-					uri,
-					mimeType: item.mimeType,
-				});
-
-				if (isForModel) {
-					if (item.mimeType && getAttachableImageExtension(item.mimeType)) {
-						result.content.push({
-							kind: 'data',
-							value: {
-								mimeType: item.mimeType,
-								data: await this._fileService.readFile(uri).then(f => f.value).catch(() => VSBuffer.alloc(0)),
-							}
-						});
-					} else {
-						result.content.push({
-							kind: 'text',
-							value: `The tool returns a resource which can be read from the URI ${uri}\n`,
-						});
-					}
-				}
-			} else if (item.type === 'resource') {
-				const uri = McpResourceURI.fromServer(this._server.definition, item.resource.uri);
-				if (item.resource.mimeType && getAttachableImageExtension(item.resource.mimeType) && 'blob' in item.resource) {
-					addAsInlineData(item.resource.mimeType, item.resource.blob, uri);
-				} else {
-					details.output.push({
-						type: 'embed',
-						uri,
-						isText: 'text' in item.resource,
-						mimeType: item.resource.mimeType,
-						value: 'blob' in item.resource ? item.resource.blob : item.resource.text,
-						asResource: true,
-					});
-
-					if (isForModel) {
-						const permalink = invocation.chatRequestId && invocation.context && ChatResponseResource.createUri(invocation.context.sessionId, invocation.chatRequestId, invocation.callId, result.content.length, basename(uri));
-
-						result.content.push({
-							kind: 'text',
-							value: 'text' in item.resource ? item.resource.text : `The tool returns a resource which can be read from the URI ${permalink || uri}\n`,
-						});
-					}
-				}
-			}
-		}
-
-		if (callResult.structuredContent) {
-			details.output.push({ type: 'embed', isText: true, value: JSON.stringify(callResult.structuredContent, null, 2) });
-			result.content.push({ kind: 'text', value: JSON.stringify(callResult.structuredContent) });
-		}
-
-		result.toolResultDetails = details;
-		return result;
-	}
 }
 
 // Helper class for generating unique MCP tool prefixes

--- a/src/vs/workbench/contrib/mcp/common/mcpTypes.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpTypes.ts
@@ -11,7 +11,7 @@ import { Event } from '../../../../base/common/event.js';
 import { IMarkdownString } from '../../../../base/common/htmlContent.js';
 import { Disposable, IDisposable } from '../../../../base/common/lifecycle.js';
 import { equals as objectsEqual } from '../../../../base/common/objects.js';
-import { IObservable } from '../../../../base/common/observable.js';
+import { IObservable, ObservableMap } from '../../../../base/common/observable.js';
 import { URI, UriComponents } from '../../../../base/common/uri.js';
 import { Location } from '../../../../editor/common/languages.js';
 import { localize } from '../../../../nls.js';
@@ -20,7 +20,7 @@ import { RawContextKey } from '../../../../platform/contextkey/common/contextkey
 import { IEditorOptions } from '../../../../platform/editor/common/editor.js';
 import { ExtensionIdentifier } from '../../../../platform/extensions/common/extensions.js';
 import { createDecorator } from '../../../../platform/instantiation/common/instantiation.js';
-import { IInstallableMcpServer as IInstallableMcpServer, IGalleryMcpServer, IQueryOptions, IMcpServerManifest } from '../../../../platform/mcp/common/mcpManagement.js';
+import { IGalleryMcpServer, IInstallableMcpServer, IMcpServerManifest, IQueryOptions } from '../../../../platform/mcp/common/mcpManagement.js';
 import { IMcpDevModeConfig, IMcpServerConfiguration } from '../../../../platform/mcp/common/mcpPlatformTypes.js';
 import { StorageScope } from '../../../../platform/storage/common/storage.js';
 import { IWorkspaceFolder, IWorkspaceFolderData } from '../../../../platform/workspace/common/workspace.js';
@@ -50,8 +50,11 @@ export interface McpCollectionDefinition {
 	readonly label: string;
 	/** Definitions this collection contains. */
 	readonly serverDefinitions: IObservable<readonly McpServerDefinition[]>;
-	/** If 'false', consent is required before any MCP servers in this collection are automatically launched. */
-	readonly isTrustedByDefault: boolean;
+	/**
+	 * Trust behavior of the servers. `Trusted` means it will run without a prompt, always.
+	 * `TrustedOnNonce` means it will run without a prompt as long as the nonce matches.
+	 */
+	readonly trustBehavior: McpServerTrust.Kind.Trusted | McpServerTrust.Kind.TrustedOnNonce;
 	/** Scope where associated collection info should be stored. */
 	readonly scope: StorageScope;
 	/** Configuration target where configuration related to this server should be stored. */
@@ -105,7 +108,7 @@ export namespace McpCollectionDefinition {
 		return a.id === b.id
 			&& a.remoteAuthority === b.remoteAuthority
 			&& a.label === b.label
-			&& a.isTrustedByDefault === b.isTrustedByDefault;
+			&& a.trustBehavior === b.trustBehavior;
 	}
 }
 
@@ -121,7 +124,7 @@ export interface McpServerDefinition {
 	/** If set, allows configuration variables to be resolved in the {@link launch} with the given context */
 	readonly variableReplacement?: McpServerDefinitionVariableReplacement;
 	/** Nonce used for caching the server. Changing the nonce will indicate that tools need to be refreshed. */
-	readonly cacheNonce?: string;
+	readonly cacheNonce: string;
 	/** Dev mode configuration for the server */
 	readonly devMode?: IMcpDevModeConfig;
 
@@ -137,7 +140,7 @@ export namespace McpServerDefinition {
 	export interface Serialized {
 		readonly id: string;
 		readonly label: string;
-		readonly cacheNonce?: string;
+		readonly cacheNonce: string;
 		readonly launch: McpServerLaunch.Serialized;
 		readonly variableReplacement?: McpServerDefinitionVariableReplacement.Serialized;
 	}
@@ -201,6 +204,9 @@ export interface IMcpService {
 	/** Resets the cached tools. */
 	resetCaches(): void;
 
+	/** Resets trusted MCP servers. */
+	resetTrust(): void;
+
 	/** Set if there are extensions that register MCP servers that have never been activated. */
 	readonly lazyCollectionState: IObservable<LazyCollectionState>;
 	/** Activatese extensions and runs their MCP servers. */
@@ -226,28 +232,57 @@ export interface McpDefinitionReference {
 	label: string;
 }
 
-export interface IMcpServerStartOpts {
-	isFromInteraction?: boolean;
-	debug?: boolean;
+export class McpStartServerInteraction {
+	/** @internal */
+	public readonly participants = new ObservableMap</* server definition ID */ string, { s: 'unknown' | 'resolved' } | { s: 'waiting'; definition: McpServerDefinition; collection: McpCollectionDefinition }>();
+	choice?: Promise<string[] | undefined>;
 }
+
+export interface IMcpServerStartOpts {
+	/**
+	 * Automatically trust if changed. This should ONLY be set for afforances that
+	 * ensure the user sees the config before it gets started (e.g. code lenses)
+	 */
+	autoTrustChanges?: boolean;
+	/**
+	 * When to trigger the trust prompt.
+	 * - only-new: only prompt for servers that are not previously explicitly untrusted (default)
+	 * - all-untrusted: prompt for all servers that are not trusted
+	 * - never: don't prompt, fail silently when trying to start an untrusted server
+	 */
+	promptType?: 'only-new' | 'all-untrusted' | 'never';
+	/** True if th servre should be launched with debugging. */
+	debug?: boolean;
+	/** Correlate multiple interactions such that any trust prompts are presented in combination. */
+	interaction?: McpStartServerInteraction;
+}
+
+export namespace McpServerTrust {
+	export const enum Kind {
+		/** The server is trusted */
+		Trusted,
+		/** The server is trusted as long as its nonce matches */
+		TrustedOnNonce,
+		/** The server trust was denied. */
+		Untrusted,
+		/** The server is not yet trusted or untrusted. */
+		Unknown,
+	}
+}
+
 
 export interface IMcpServer extends IDisposable {
 	readonly collection: McpCollectionReference;
 	readonly definition: McpDefinitionReference;
 	readonly connection: IObservable<IMcpServerConnection | undefined>;
 	readonly connectionState: IObservable<McpConnectionState>;
+	readonly serverMetadata: IObservable<{ serverName?: string; serverInstructions?: string } | undefined>;
 
 	/**
 	 * Full definition as it exists in the MCP registry. Unlike the references
 	 * in `collection` and `definition`, this may change over time.
 	 */
 	readDefinitions(): IObservable<{ server: McpServerDefinition | undefined; collection: McpCollectionDefinition | undefined }>;
-
-	/**
-	 * Reflects the MCP server trust state. True if trusted, false if untrusted,
-	 * undefined if consent is required but not indicated.
-	 */
-	readonly trusted: IObservable<boolean | undefined>;
 
 	showOutput(): void;
 	/**
@@ -431,6 +466,11 @@ export namespace McpServerLaunch {
 					envFile: launch.envFile,
 				};
 		}
+	}
+
+	export async function hash(launch: McpServerLaunch): Promise<string> {
+		const nonce = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(JSON.stringify(launch)));
+		return encodeHex(VSBuffer.wrap(new Uint8Array(nonce)));
 	}
 }
 

--- a/src/vs/workbench/contrib/mcp/common/mcpTypesUtils.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpTypesUtils.ts
@@ -1,0 +1,42 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { CancellationToken } from '../../../../base/common/cancellation.js';
+import { DisposableStore } from '../../../../base/common/lifecycle.js';
+import { autorun } from '../../../../base/common/observable.js';
+import { IMcpServer, IMcpServerStartOpts, McpConnectionState, McpServerCacheState } from './mcpTypes.js';
+
+/**
+ * Starts a server (if needed) and waits for its tools to be live. Returns
+ * true/false whether this happened successfully.
+ */
+export function startServerAndWaitForLiveTools(server: IMcpServer, opts?: IMcpServerStartOpts, token?: CancellationToken): Promise<boolean> {
+	const store = new DisposableStore();
+	return new Promise<boolean>(resolve => {
+		server.start(opts).catch(() => undefined).then(r => {
+			if (token?.isCancellationRequested || !r || r.state === McpConnectionState.Kind.Error || r.state === McpConnectionState.Kind.Stopped) {
+				return resolve(false);
+			}
+
+			if (token) {
+				store.add(token.onCancellationRequested(() => {
+					resolve(false);
+				}));
+			}
+
+			store.add(autorun(reader => {
+				const connState = server.connectionState.read(reader).state;
+				if (connState === McpConnectionState.Kind.Error || connState === McpConnectionState.Kind.Stopped) {
+					resolve(false); // some error, don't block the request
+				}
+
+				const toolState = server.cacheState.read(reader);
+				if (toolState === McpServerCacheState.Live) {
+					resolve(true); // got tools, all done
+				}
+			}));
+		});
+	}).finally(() => store.dispose());
+}

--- a/src/vs/workbench/contrib/mcp/common/modelContextProtocol.ts
+++ b/src/vs/workbench/contrib/mcp/common/modelContextProtocol.ts
@@ -677,9 +677,7 @@ export namespace MCP {
 	/**
 	 * Describes a message returned as part of a prompt.
 	 *
-	 * This is similar to `SamplingMessage`, but also supports the embedding of
-	 * resources from the MCP server.
-	 */
+	 * This is similar to `	 */
 	export interface PromptMessage {
 		role: Role;
 		content: ContentBlock;

--- a/src/vs/workbench/contrib/mcp/test/common/mcpRegistryTypes.ts
+++ b/src/vs/workbench/contrib/mcp/test/common/mcpRegistryTypes.ts
@@ -14,7 +14,7 @@ import { IWorkspaceFolderData } from '../../../../../platform/workspace/common/w
 import { IResolvedValue } from '../../../../services/configurationResolver/common/configurationResolverExpression.js';
 import { IMcpHostDelegate, IMcpMessageTransport, IMcpRegistry, IMcpResolveConnectionOptions } from '../../common/mcpRegistryTypes.js';
 import { McpServerConnection } from '../../common/mcpServerConnection.js';
-import { IMcpServerConnection, LazyCollectionState, McpCollectionDefinition, McpCollectionReference, McpConnectionState, McpDefinitionReference, McpServerDefinition, McpServerTransportType } from '../../common/mcpTypes.js';
+import { IMcpServerConnection, LazyCollectionState, McpCollectionDefinition, McpCollectionReference, McpConnectionState, McpDefinitionReference, McpServerDefinition, McpServerTransportType, McpServerTrust } from '../../common/mcpTypes.js';
 import { MCP } from '../../common/modelContextProtocol.js';
 
 /**
@@ -172,8 +172,9 @@ export class TestMcpRegistry implements IMcpRegistry {
 			id: 'test-server',
 			label: 'Test Server',
 			launch: { type: McpServerTransportType.Stdio, command: 'echo', args: ['Hello MCP'], env: {}, envFile: undefined, cwd: undefined },
+			cacheNonce: 'a',
 		} satisfies McpServerDefinition]),
-		isTrustedByDefault: true,
+		trustBehavior: McpServerTrust.Kind.Trusted,
 		scope: StorageScope.APPLICATION,
 	}]);
 	delegates = observableValue<readonly IMcpHostDelegate[]>(this, [{
@@ -207,9 +208,6 @@ export class TestMcpRegistry implements IMcpRegistry {
 		throw new Error('Method not implemented.');
 	}
 	resetTrust(): void {
-		throw new Error('Method not implemented.');
-	}
-	getTrust(collection: McpCollectionReference): IObservable<boolean | undefined> {
 		throw new Error('Method not implemented.');
 	}
 	clearSavedInputs(scope: StorageScope, inputId?: string): Promise<void> {

--- a/src/vs/workbench/contrib/mcp/test/common/mcpResourceFilesystem.test.ts
+++ b/src/vs/workbench/contrib/mcp/test/common/mcpResourceFilesystem.test.ts
@@ -4,13 +4,14 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as assert from 'assert';
-import { Disposable } from '../../../../../base/common/lifecycle.js';
+import { Barrier, timeout } from '../../../../../base/common/async.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { FileChangeType, FileSystemProviderErrorCode, FileType, IFileChange, IFileService } from '../../../../../platform/files/common/files.js';
 import { ServiceCollection } from '../../../../../platform/instantiation/common/serviceCollection.js';
 import { TestInstantiationService } from '../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
 import { ILoggerService, NullLogService } from '../../../../../platform/log/common/log.js';
+import { IProductService } from '../../../../../platform/product/common/productService.js';
 import { IStorageService } from '../../../../../platform/storage/common/storage.js';
 import { ITelemetryService } from '../../../../../platform/telemetry/common/telemetry.js';
 import { NullTelemetryService } from '../../../../../platform/telemetry/common/telemetryUtils.js';
@@ -22,8 +23,6 @@ import { McpService } from '../../common/mcpService.js';
 import { IMcpService } from '../../common/mcpTypes.js';
 import { MCP } from '../../common/modelContextProtocol.js';
 import { TestMcpMessageTransport, TestMcpRegistry } from './mcpRegistryTypes.js';
-import { IProductService } from '../../../../../platform/product/common/productService.js';
-import { Barrier, timeout } from '../../../../../base/common/async.js';
 
 
 suite('Workbench - MCP - ResourceFilesystem', () => {
@@ -47,7 +46,7 @@ suite('Workbench - MCP - ResourceFilesystem', () => {
 		const registry = new TestMcpRegistry(parentInsta1);
 
 		const parentInsta2 = ds.add(parentInsta1.createChild(new ServiceCollection([IMcpRegistry, registry])));
-		const mcpService = ds.add(new McpService(parentInsta2, registry, { registerToolData: () => Disposable.None, registerToolImplementation: () => Disposable.None, createToolSet: () => Disposable.None } as any, new NullLogService()));
+		const mcpService = ds.add(new McpService(parentInsta2, registry, new NullLogService()));
 		mcpService.updateCollectedServers();
 
 		const instaService = ds.add(parentInsta2.createChild(new ServiceCollection(

--- a/src/vs/workbench/contrib/mcp/test/common/mcpServerConnection.test.ts
+++ b/src/vs/workbench/contrib/mcp/test/common/mcpServerConnection.test.ts
@@ -18,7 +18,7 @@ import { IOutputService } from '../../../../services/output/common/output.js';
 import { TestLoggerService, TestProductService, TestStorageService } from '../../../../test/common/workbenchTestServices.js';
 import { IMcpHostDelegate, IMcpMessageTransport } from '../../common/mcpRegistryTypes.js';
 import { McpServerConnection } from '../../common/mcpServerConnection.js';
-import { McpCollectionDefinition, McpConnectionState, McpServerDefinition, McpServerTransportType } from '../../common/mcpTypes.js';
+import { McpCollectionDefinition, McpConnectionState, McpServerDefinition, McpServerTransportType, McpServerTrust } from '../../common/mcpTypes.js';
 import { TestMcpMessageTransport } from './mcpRegistryTypes.js';
 import { ConfigurationTarget } from '../../../../../platform/configuration/common/configuration.js';
 import { Event } from '../../../../../base/common/event.js';
@@ -87,7 +87,7 @@ suite('Workbench - MCP - ServerConnection', () => {
 			label: 'Test Collection',
 			remoteAuthority: null,
 			serverDefinitions: observableValue('serverDefs', []),
-			isTrustedByDefault: true,
+			trustBehavior: McpServerTrust.Kind.Trusted,
 			scope: StorageScope.APPLICATION,
 			configTarget: ConfigurationTarget.USER,
 		};
@@ -96,6 +96,7 @@ suite('Workbench - MCP - ServerConnection', () => {
 		serverDefinition = {
 			id: 'test-server',
 			label: 'Test Server',
+			cacheNonce: 'a',
 			launch: {
 				type: McpServerTransportType.Stdio,
 				command: 'test-command',

--- a/src/vs/workbench/contrib/mcp/test/common/testMcpService.ts
+++ b/src/vs/workbench/contrib/mcp/test/common/testMcpService.ts
@@ -1,0 +1,24 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { observableValue } from '../../../../../base/common/observable.js';
+import { IMcpServer, IMcpService, LazyCollectionState } from '../../common/mcpTypes.js';
+
+export class TestMcpService implements IMcpService {
+	declare readonly _serviceBrand: undefined;
+	public servers = observableValue<readonly IMcpServer[]>(this, []);
+	resetCaches(): void {
+
+	}
+	resetTrust(): void {
+
+	}
+
+	public lazyCollectionState = observableValue<LazyCollectionState>(this, LazyCollectionState.AllKnown);
+
+	activateCollections(): Promise<void> {
+		return Promise.resolve();
+	}
+}


### PR DESCRIPTION
This adds an on-by-default MCP autorun setting, which will start any new
or changed MCP servers when a chat request is sent. When the setting is
on, we will no longer show the infamous 'refresh' indicator. We also
now respond to changes in existing mcp.jsons server definitions as a
signal that we need to refresh the tools.

This also means we need a new take on trust. We don't want a
prompt-injected model to be able to add an MCP server in the workspace
that's silently run on the next chat request. For user level settings,
there's no change -- these are outside the workspace and editing by the
agent is generally disallowed.

For workspace-level servers, users are asked to trust the server the
first time they run it or whenever its definition changes. If they
decline, we won't prompt them again, but they can still manually choose
to run it later on. We also nicely group servers together to avoid a
flurry of prompts. This is what that looks like. In the case of multiple
servers, users can pick ones they wish to trust, or not.

<img width="820" height="506" alt="image" src="https://github.com/user-attachments/assets/600c4e06-03f7-4ed1-ba7a-ecffa6dac782" />

This gets most of the way there but I need to do more testing so I will
not merge this yet.

Closes https://github.com/microsoft/vscode/issues/248010

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
