### PR TITLE
add basic regex auto-reply support

### DIFF
--- a/src/vs/workbench/contrib/elicitation/browser/elicitation.ts
+++ b/src/vs/workbench/contrib/elicitation/browser/elicitation.ts
@@ -1,0 +1,66 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { MarkdownString } from '../../../../base/common/htmlContent.js';
+import { localize } from '../../../../nls.js';
+import { ChatElicitationRequestPart } from '../../chat/browser/chatElicitationRequestPart.js';
+import { ChatModel } from '../../chat/common/chatModel.js';
+import { IChatService } from '../../chat/common/chatService.js';
+import { IToolInvocationContext } from '../../chat/common/languageModelToolsService.js';
+
+function createYesNoPrompt(
+	context: IToolInvocationContext,
+	chatService: IChatService,
+	title: string | MarkdownString,
+	description: string | MarkdownString
+): { promise: Promise<boolean>; part?: ChatElicitationRequestPart } {
+	const chatModel = chatService.getSession(context.sessionId);
+	if (chatModel instanceof ChatModel) {
+		const request = chatModel.getRequests().at(-1);
+		if (request) {
+			let part: ChatElicitationRequestPart | undefined = undefined;
+			const promise = new Promise<boolean>(resolve => {
+				const thePart = part = new ChatElicitationRequestPart(
+					title,
+					description,
+					'',
+					localize('poll.terminal.accept', 'Yes'),
+					localize('poll.terminal.reject', 'No'),
+					async () => {
+						thePart.state = 'accepted';
+						thePart.hide();
+						resolve(true);
+					},
+					async () => {
+						thePart.state = 'rejected';
+						thePart.hide();
+						resolve(false);
+					}
+				);
+				chatModel.acceptResponseProgress(request, thePart);
+			});
+			return { promise, part };
+		}
+	}
+	return { promise: Promise.resolve(false) };
+}
+
+export function promptForMorePolling(title: string, message: string, context: IToolInvocationContext, chatService: IChatService): { promise: Promise<boolean>; part?: ChatElicitationRequestPart } {
+	return createYesNoPrompt(
+		context,
+		chatService,
+		title,
+		message
+	);
+}
+
+export function promptForYesNo(title: string | MarkdownString, message: string | MarkdownString, context: IToolInvocationContext, chatService: IChatService): { promise: Promise<boolean>; part?: ChatElicitationRequestPart } {
+	return createYesNoPrompt(
+		context,
+		chatService,
+		title,
+		message
+	);
+}

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/bufferOutputPolling.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/bufferOutputPolling.ts
@@ -304,7 +304,7 @@ export async function handleYesNoUserPrompt(
 			const outputAndIdle = await pollForOutputAndIdleFn();
 			return { handled: true, outputAndIdle };
 		} else {
-			await terminal.sendText(options[0] === 'n' ? 'n' : 'no', true);
+			await terminal.sendText(options[1] === 'n' ? 'n' : 'no', true);
 			return { handled: true };
 		}
 	}

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/bufferOutputPolling.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/bufferOutputPolling.ts
@@ -9,10 +9,10 @@ import { MarkdownString } from '../../../../../base/common/htmlContent.js';
 import { localize } from '../../../../../nls.js';
 import { ExtensionIdentifier } from '../../../../../platform/extensions/common/extensions.js';
 import { ChatElicitationRequestPart } from '../../../chat/browser/chatElicitationRequestPart.js';
-import { ChatModel } from '../../../chat/common/chatModel.js';
 import { IChatService } from '../../../chat/common/chatService.js';
 import { ChatMessageRole, ILanguageModelsService } from '../../../chat/common/languageModels.js';
 import { IToolInvocationContext } from '../../../chat/common/languageModelToolsService.js';
+import { promptForYesNo } from '../../../elicitation/browser/elicitation.js';
 import { ITerminalInstance } from '../../../terminal/browser/terminal.js';
 import type { IMarker as IXtermMarker } from '@xterm/xterm';
 
@@ -152,61 +152,6 @@ export async function pollForOutputAndIdle(
 	return { terminalExecutionIdleBeforeTimeout: false, output: buffer, pollDurationMs: Date.now() - pollStartTime + (extendedPolling ? PollingConsts.FirstPollingMaxDuration : 0) };
 }
 
-
-function createYesNoPrompt(
-	context: IToolInvocationContext,
-	chatService: IChatService,
-	title: string | MarkdownString,
-	description: string | MarkdownString
-): { promise: Promise<boolean>; part?: ChatElicitationRequestPart } {
-	const chatModel = chatService.getSession(context.sessionId);
-	if (chatModel instanceof ChatModel) {
-		const request = chatModel.getRequests().at(-1);
-		if (request) {
-			let part: ChatElicitationRequestPart | undefined = undefined;
-			const promise = new Promise<boolean>(resolve => {
-				const thePart = part = new ChatElicitationRequestPart(
-					title,
-					description,
-					'',
-					localize('poll.terminal.accept', 'Yes'),
-					localize('poll.terminal.reject', 'No'),
-					async () => {
-						thePart.state = 'accepted';
-						thePart.hide();
-						resolve(true);
-					},
-					async () => {
-						thePart.state = 'rejected';
-						thePart.hide();
-						resolve(false);
-					}
-				);
-				chatModel.acceptResponseProgress(request, thePart);
-			});
-			return { promise, part };
-		}
-	}
-	return { promise: Promise.resolve(false) };
-}
-
-export function promptForMorePolling(title: string, message: string, context: IToolInvocationContext, chatService: IChatService): { promise: Promise<boolean>; part?: ChatElicitationRequestPart } {
-	return createYesNoPrompt(
-		context,
-		chatService,
-		title,
-		message
-	);
-}
-
-export function promptForYesNo(title: string | MarkdownString, message: string | MarkdownString, context: IToolInvocationContext, chatService: IChatService): { promise: Promise<boolean>; part?: ChatElicitationRequestPart } {
-	return createYesNoPrompt(
-		context,
-		chatService,
-		title,
-		message
-	);
-}
 
 
 export async function assessOutputForErrors(buffer: string, token: CancellationToken, languageModelsService: ILanguageModelsService): Promise<string> {

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/bufferOutputPolling.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/bufferOutputPolling.ts
@@ -160,7 +160,7 @@ export async function handleTerminalUserInputPrompt(
 	executableLabel: string,
 	token: CancellationToken,
 	languageModelsService: ILanguageModelsService
-): Promise<{ handled: boolean; outputAndIdle: { output: string; terminalExecutionIdleBeforeTimeout: boolean; pollDurationMs?: number; modelOutputEvalResponse?: string }; message?: IToolResult }> {
+): Promise<{ handled: boolean; userResponse?: 'accepted' | 'rejected'; outputAndIdle: { output: string; terminalExecutionIdleBeforeTimeout: boolean; pollDurationMs?: number; modelOutputEvalResponse?: string }; message?: IToolResult }> {
 	const userInputKind = await getExpectedUserInputKind(outputAndIdle.output);
 	if (userInputKind) {
 		const handleResult = await handleYesNoUserPrompt(
@@ -283,7 +283,7 @@ export async function handleYesNoUserPrompt(
 	chatService: IChatService,
 	terminal: ITerminalInstance,
 	pollForOutputAndIdleFn: () => Promise<{ terminalExecutionIdleBeforeTimeout: boolean; output: string; pollDurationMs?: number; modelOutputEvalResponse?: string }>,
-): Promise<{ handled: boolean; outputAndIdle?: { terminalExecutionIdleBeforeTimeout: boolean; output: string; pollDurationMs?: number; modelOutputEvalResponse?: string } }> {
+): Promise<{ handled: boolean; userResponse?: 'accepted' | 'rejected'; outputAndIdle?: { terminalExecutionIdleBeforeTimeout: boolean; output: string; pollDurationMs?: number; modelOutputEvalResponse?: string } }> {
 	if (userInputKind && userInputKind !== 'choice' && userInputKind !== 'key') {
 		const options = userInputKind.split('/');
 		const acceptAnswer = options[0]?.trim();
@@ -297,10 +297,10 @@ export async function handleYesNoUserPrompt(
 		if (result) {
 			await terminal.sendText(acceptAnswer, true);
 			const outputAndIdle = await pollForOutputAndIdleFn();
-			return { handled: true, outputAndIdle };
+			return { handled: true, outputAndIdle, userResponse: 'accepted' };
 		} else {
 			await terminal.sendText(rejectAnswer, true);
-			return { handled: true };
+			return { handled: true, userResponse: 'rejected' };
 		}
 	}
 	return { handled: false };

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/bufferOutputPolling.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/bufferOutputPolling.ts
@@ -254,23 +254,32 @@ export function getExpectedUserInputKind(output: string): string | undefined {
 		return undefined;
 	}
 
-	const patterns: { regex: RegExp; kind: string }[] = [
-		{ regex: /\bdo you want to continue\b.*\(y\/n\)/ig, kind: 'y/n' },
-		{ regex: /\bcontinue\? \(y\/n\)/ig, kind: 'y/n' },
-		{ regex: /\bproceed\? \(y\/n\)/ig, kind: 'y/n' },
-		{ regex: /\btype yes or no\b/ig, kind: 'yes/no' },
-		{ regex: /\b\(yes\/no\)/ig, kind: 'yes/no' },
-		{ regex: /\b\[y\/n\]/ig, kind: 'y/n' },
-		{ regex: /\benter your choice\b/ig, kind: 'choice' },
-		{ regex: /\bselect an option\b/ig, kind: 'choice' },
-		{ regex: /\bplease respond\b/ig, kind: 'response' },
-		{ regex: /\bpress (enter|return|any key)\b/ig, kind: 'press key' }
-	];
-
-	for (const { regex, kind } of patterns) {
-		if (regex.test(output)) {
-			return kind;
+	// Only match if the last non-empty line matches a prompt pattern and the next line is blank
+	const lines = output.split('\n');
+	for (let i = lines.length - 2; i >= 0; i--) {
+		const line = lines[i].trim();
+		const nextLine = lines[i + 1]?.trim();
+		if (!line) {
+			continue;
 		}
+		const patterns: { regex: RegExp; kind: string }[] = [
+			{ regex: /\bdo you want to continue\b.*\(y\/n\)/i, kind: 'y/n' },
+			{ regex: /\bcontinue\? \(y\/n\)/i, kind: 'y/n' },
+			{ regex: /\bproceed\? \(y\/n\)/i, kind: 'y/n' },
+			{ regex: /\btype yes or no\b/i, kind: 'yes/no' },
+			{ regex: /\b\(yes\/no\)/i, kind: 'yes/no' },
+			{ regex: /\b\[y\/n\]/i, kind: 'y/n' },
+			{ regex: /\benter your choice\b/i, kind: 'choice' },
+			{ regex: /\bselect an option\b/i, kind: 'choice' },
+			{ regex: /\bplease respond\b/i, kind: 'response' },
+			{ regex: /\bpress (enter|return|any key)\b/i, kind: 'press key' }
+		];
+		for (const { regex, kind } of patterns) {
+			if (regex.test(line) && (!nextLine || nextLine === '')) {
+				return kind;
+			}
+		}
+		break;
 	}
 	return undefined;
 }

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/bufferOutputPolling.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/bufferOutputPolling.ts
@@ -215,3 +215,39 @@ export async function assessOutputForErrors(buffer: string, token: CancellationT
 		return 'Error occurred ' + err;
 	}
 }
+
+/**
+ * Returns true if the last line of the output is a prompt asking for user input (e.g., "Do you want to continue? (y/n)").
+ * This is a heuristic and matches common prompt patterns.
+ */
+/**
+ * Returns the kind of input expected by the last line of the output if it appears to be a user prompt.
+ * For example, returns 'y/n', 'yes/no', 'press key', 'choice', etc., or undefined if not a prompt.
+ */
+export function getExpectedUserInputKind(output: string): string | undefined {
+	if (!output) {
+		return undefined;
+	}
+	const lines = output.split(/\r?\n/);
+	const lastLine = lines[lines.length - 1].trim();
+
+	const patterns: { regex: RegExp; kind: string }[] = [
+		{ regex: /\bdo you want to continue\b.*\(y\/n\)/i, kind: 'y/n' },
+		{ regex: /\bcontinue\? \(y\/n\)/i, kind: 'y/n' },
+		{ regex: /\bproceed\? \(y\/n\)/i, kind: 'y/n' },
+		{ regex: /\btype yes or no\b/i, kind: 'yes/no' },
+		{ regex: /\b\(yes\/no\)/i, kind: 'yes/no' },
+		{ regex: /\b\[y\/n\]/i, kind: 'y/n' },
+		{ regex: /\benter your choice\b/i, kind: 'choice' },
+		{ regex: /\bselect an option\b/i, kind: 'choice' },
+		{ regex: /\bplease respond\b/i, kind: 'response' },
+		{ regex: /\bpress (enter|return|any key)\b/i, kind: 'press key' }
+	];
+
+	for (const { regex, kind } of patterns) {
+		if (regex.test(lastLine)) {
+			return kind;
+		}
+	}
+	return undefined;
+}

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/bufferOutputPolling.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/bufferOutputPolling.ts
@@ -156,8 +156,8 @@ export async function pollForOutputAndIdle(
 function createYesNoPrompt(
 	context: IToolInvocationContext,
 	chatService: IChatService,
-	title: string,
-	description: string
+	title: string | MarkdownString,
+	description: string | MarkdownString
 ): { promise: Promise<boolean>; part?: ChatElicitationRequestPart } {
 	const chatModel = chatService.getSession(context.sessionId);
 	if (chatModel instanceof ChatModel) {
@@ -166,8 +166,8 @@ function createYesNoPrompt(
 			let part: ChatElicitationRequestPart | undefined = undefined;
 			const promise = new Promise<boolean>(resolve => {
 				const thePart = part = new ChatElicitationRequestPart(
-					new MarkdownString(title),
-					new MarkdownString(description),
+					title,
+					description,
 					'',
 					localize('poll.terminal.accept', 'Yes'),
 					localize('poll.terminal.reject', 'No'),
@@ -194,8 +194,8 @@ export function promptForMorePolling(title: string, message: string, context: IT
 	return createYesNoPrompt(
 		context,
 		chatService,
-		new MarkdownString(localize('poll.terminal.waiting', "Continue waiting for `{0}` to finish?", command)),
-		new MarkdownString(localize('poll.terminal.polling', "Copilot will continue to poll for output to determine when the terminal becomes idle for up to 2 minutes.")),
+		title,
+		message
 	);
 }
 

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/bufferOutputPolling.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/bufferOutputPolling.ts
@@ -262,17 +262,26 @@ export function getExpectedUserInputKind(output: string): string | undefined {
 		if (!line) {
 			continue;
 		}
+		// Each pattern includes a comment with an example command that produces such a prompt
 		const patterns: { regex: RegExp; kind: string }[] = [
-			{ regex: /\bdo you want to continue\b.*\(y\/n\)/i, kind: 'y/n' },
-			{ regex: /\bcontinue\? \(y\/n\)/i, kind: 'y/n' },
-			{ regex: /\bproceed\? \(y\/n\)/i, kind: 'y/n' },
-			{ regex: /\btype yes or no\b/i, kind: 'yes/no' },
-			{ regex: /\b\(yes\/no\)/i, kind: 'yes/no' },
-			{ regex: /\b\[y\/n\]/i, kind: 'y/n' },
-			{ regex: /\benter your choice\b/i, kind: 'choice' },
-			{ regex: /\bselect an option\b/i, kind: 'choice' },
-			{ regex: /\bplease respond\b/i, kind: 'response' },
-			{ regex: /\bpress (enter|return|any key)\b/i, kind: 'press key' }
+			// Generic: ends with (y/n)
+			// Example: apt-get install foo, rm -i file.txt, git clean -fd, etc.
+			{ regex: /\(y\/n\)\s*$/i, kind: 'y/n' },
+			// [y/n] prompt (alternative format)
+			// Example: some package managers
+			{ regex: /\[y\/n\]/ig, kind: 'y/n' },
+			// yes/no prompt (matches most common forms)
+			// Example: sudo shutdown now, custom bash scripts
+			{ regex: /yes\/no\s*$/i, kind: 'yes/no' },
+			// PowerShell Remove-Item -Confirm
+			// Example: Remove-Item file.txt
+			{ regex: /\[Y\] Yes\s+\[A\] Yes to All\s+\[N\] No\s+\[L\] No to All\s+\[S\] Suspend\s+\[\?\] Help \(default is ".*"\):/i, kind: 'pwsh choice' },
+			// Choice prompt
+			// Example: interactive install scripts, menu-driven CLI tools
+			{ regex: /(enter your choice|select an option)/ig, kind: 'choice' },
+			// Response prompt
+			// Example: expect scripts
+			{ regex: /please respond/ig, kind: 'response' },
 		];
 		for (const { regex, kind } of patterns) {
 			if (regex.test(line) && (!nextLine || nextLine === '')) {

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/runInTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/runInTerminalTool.ts
@@ -36,7 +36,8 @@ import { isPowerShell } from './runInTerminalHelpers.js';
 import { extractInlineSubCommands, splitCommandLineIntoSubCommands } from './subCommands.js';
 import { ShellIntegrationQuality, ToolTerminalCreator, type IToolTerminal } from './toolTerminalCreator.js';
 import { ILanguageModelsService } from '../../../chat/common/languageModels.js';
-import { getExpectedUserInputKind, getOutput, pollForOutputAndIdle, promptForMorePolling, racePollingOrPrompt, handleYesNoUserPrompt } from './bufferOutputPolling.js';
+import { getExpectedUserInputKind, getOutput, pollForOutputAndIdle, racePollingOrPrompt, handleYesNoUserPrompt } from './bufferOutputPolling.js';
+import { promptForMorePolling } from '../../../elicitation/browser/elicitation.js';
 
 const TERMINAL_SESSION_STORAGE_KEY = 'chat.terminalSessions';
 

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/runInTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/runInTerminalTool.ts
@@ -323,8 +323,9 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 						} else {
 							await toolTerminal.instance.sendText(options[0] === 'n' ? 'n' : 'no', true);
 						}
+					} else {
+						return { content: [{ kind: 'text', value: `The task is still running and requires user input of ${userInputKind}.` }], toolResultMessage: new MarkdownString(localize('copilotChat.taskRequiresUserInput', 'The task `{0}` is still running and requires user input. {1}', command, userInputKind)) };
 					}
-					return { content: [{ kind: 'text', value: `The task is still running and requires user input of ${userInputKind}.` }], toolResultMessage: new MarkdownString(localize('copilotChat.taskRequiresUserInput', 'The task `{0}` is still running and requires user input. {1}', command, userInputKind)) };
 				}
 				let resultText = (
 					didUserEditCommand

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/runInTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/runInTerminalTool.ts
@@ -312,11 +312,19 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 						const result = await response.promise;
 						if (result) {
 							await toolTerminal.instance.sendText(options[0] === 'y' ? 'y' : 'yes', true);
+							outputAndIdle = await racePollingOrPrompt(
+								() => pollForOutputAndIdle({ getOutput: () => getOutput(toolTerminal.instance) }, true, token, this._languageModelsService),
+								() => promptForMorePolling(localize('poll.terminal.waiting', "Continue waiting for `{0}` to finish?", command), localize('poll.terminal.polling', "Copilot will continue to poll for output to determine when the terminal becomes idle for up to 2 minutes."), invocation.context!, this._chatService),
+								outputAndIdle,
+								token,
+								this._languageModelsService,
+								{ getOutput: () => getOutput(toolTerminal.instance) }
+							);
 						} else {
 							await toolTerminal.instance.sendText(options[0] === 'n' ? 'n' : 'no', true);
 						}
 					}
-					return { content: [{ kind: 'text', value: `The task is still running and requires user input of ${userInputKind}. Ask the user which input they'd like to provide.` }], toolResultMessage: new MarkdownString(localize('copilotChat.taskRequiresUserInput', 'The task `{0}` is still running and requires user input. {1}', command, userInputKind)) };
+					return { content: [{ kind: 'text', value: `The task is still running and requires user input of ${userInputKind}.` }], toolResultMessage: new MarkdownString(localize('copilotChat.taskRequiresUserInput', 'The task `{0}` is still running and requires user input. {1}', command, userInputKind)) };
 				}
 				let resultText = (
 					didUserEditCommand

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/runInTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/runInTerminalTool.ts
@@ -297,7 +297,7 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 				if (!outputAndIdle.terminalExecutionIdleBeforeTimeout) {
 					outputAndIdle = await racePollingOrPrompt(
 						() => pollForOutputAndIdle(execution, true, token, this._languageModelsService),
-						() => promptForMorePolling(command, invocation.context!, this._chatService),
+						() => promptForMorePolling(localize('poll.terminal.waiting', "Continue waiting for `{0}` to finish?", command), localize('poll.terminal.polling', "Copilot will continue to poll for output to determine when the terminal becomes idle for up to 2 minutes."), invocation.context!, this._chatService),
 						outputAndIdle,
 						token,
 						this._languageModelsService,

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/runInTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/runInTerminalTool.ts
@@ -36,7 +36,7 @@ import { isPowerShell } from './runInTerminalHelpers.js';
 import { extractInlineSubCommands, splitCommandLineIntoSubCommands } from './subCommands.js';
 import { ShellIntegrationQuality, ToolTerminalCreator, type IToolTerminal } from './toolTerminalCreator.js';
 import { ILanguageModelsService } from '../../../chat/common/languageModels.js';
-import { getOutput, pollForOutputAndIdle, promptForMorePolling, racePollingOrPrompt } from './bufferOutputPolling.js';
+import { getExpectedUserInputKind, getOutput, pollForOutputAndIdle, promptForMorePolling, racePollingOrPrompt } from './bufferOutputPolling.js';
 
 const TERMINAL_SESSION_STORAGE_KEY = 'chat.terminalSessions';
 
@@ -304,7 +304,10 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 						execution
 					);
 				}
-
+				const userInputKind = getExpectedUserInputKind(outputAndIdle.output);
+				if (userInputKind) {
+					return { content: [{ kind: 'text', value: `The terminal command is still running and requires user input of ${userInputKind}. Ask the user which input they'd like to provide.` }], toolResultMessage: new MarkdownString(localize('copilotChat.taskRequiresUserInput', 'The terminal command `{0}` is still running and requires user input. {1}', command, userInputKind)) };
+				}
 				let resultText = (
 					didUserEditCommand
 						? `Note: The user manually edited the command to \`${command}\`, and that command is now running in terminal with ID=${termId}`

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/runInTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/runInTerminalTool.ts
@@ -312,14 +312,7 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 						const result = await response.promise;
 						if (result) {
 							await toolTerminal.instance.sendText(options[0] === 'y' ? 'y' : 'yes', true);
-							outputAndIdle = await racePollingOrPrompt(
-								() => pollForOutputAndIdle({ getOutput: () => getOutput(toolTerminal.instance) }, true, token, this._languageModelsService),
-								() => promptForMorePolling(localize('poll.terminal.waiting', "Continue waiting for `{0}` to finish?", command), localize('poll.terminal.polling', "Copilot will continue to poll for output to determine when the terminal becomes idle for up to 2 minutes."), invocation.context!, this._chatService),
-								outputAndIdle,
-								token,
-								this._languageModelsService,
-								{ getOutput: () => getOutput(toolTerminal.instance) }
-							);
+							outputAndIdle = await pollForOutputAndIdle({ getOutput: () => getOutput(toolTerminal.instance) }, true, token, this._languageModelsService);
 						} else {
 							await toolTerminal.instance.sendText(options[0] === 'n' ? 'n' : 'no', true);
 						}

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/task/createAndRunTaskTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/task/createAndRunTaskTool.ts
@@ -115,7 +115,7 @@ export class CreateAndRunTaskTool implements IToolImpl {
 		if (!outputAndIdle.terminalExecutionIdleBeforeTimeout) {
 			outputAndIdle = await racePollingOrPrompt(
 				() => pollForOutputAndIdle({ getOutput: () => getOutput(terminal), isActive: () => this._isTaskActive(task) }, true, token, this._languageModelsService),
-				() => promptForMorePolling(args.task.label, invocation.context!, this._chatService),
+				() => promptForMorePolling(localize('poll.terminal.waiting', "Continue waiting for `{0}` to finish?", args.task.label), localize('poll.terminal.polling', "Copilot will continue to poll for output to determine when the terminal becomes idle for up to 2 minutes."), invocation.context!, this._chatService),
 				outputAndIdle,
 				token,
 				this._languageModelsService,

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/task/createAndRunTaskTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/task/createAndRunTaskTool.ts
@@ -12,13 +12,14 @@ import { ILanguageModelsService } from '../../../../chat/common/languageModels.j
 import { CountTokensCallback, IPreparedToolInvocation, IToolData, IToolImpl, IToolInvocation, IToolInvocationPreparationContext, IToolResult, ToolDataSource, ToolProgress } from '../../../../chat/common/languageModelToolsService.js';
 import { ITaskService, ITaskSummary, Task } from '../../../../tasks/common/taskService.js';
 import { ITerminalService } from '../../../../terminal/browser/terminal.js';
-import { getExpectedUserInputKind, pollForOutputAndIdle, promptForMorePolling, racePollingOrPrompt, handleYesNoUserPrompt } from '../bufferOutputPolling.js';
+import { getExpectedUserInputKind, pollForOutputAndIdle, racePollingOrPrompt, handleYesNoUserPrompt } from '../bufferOutputPolling.js';
 import { getOutput } from '../outputHelpers.js';
 import { IConfiguredTask } from './taskHelpers.js';
 import { MarkdownString } from '../../../../../../base/common/htmlContent.js';
 import { URI } from '../../../../../../base/common/uri.js';
 import { IFileService } from '../../../../../../platform/files/common/files.js';
 import { VSBuffer } from '../../../../../../base/common/buffer.js';
+import { promptForMorePolling } from '../../../../elicitation/browser/elicitation.js';
 
 type CreateAndRunTaskToolClassification = {
 	taskLabel: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The label of the task.' };

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/task/createAndRunTaskTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/task/createAndRunTaskTool.ts
@@ -12,7 +12,7 @@ import { ILanguageModelsService } from '../../../../chat/common/languageModels.j
 import { CountTokensCallback, IPreparedToolInvocation, IToolData, IToolImpl, IToolInvocation, IToolInvocationPreparationContext, IToolResult, ToolDataSource, ToolProgress } from '../../../../chat/common/languageModelToolsService.js';
 import { ITaskService, ITaskSummary, Task } from '../../../../tasks/common/taskService.js';
 import { ITerminalService } from '../../../../terminal/browser/terminal.js';
-import { getExpectedUserInputKind, pollForOutputAndIdle, promptForMorePolling, promptForYesNo, racePollingOrPrompt } from '../bufferOutputPolling.js';
+import { getExpectedUserInputKind, pollForOutputAndIdle, promptForMorePolling, racePollingOrPrompt, handleYesNoUserPrompt } from '../bufferOutputPolling.js';
 import { getOutput } from '../outputHelpers.js';
 import { IConfiguredTask } from './taskHelpers.js';
 import { MarkdownString } from '../../../../../../base/common/htmlContent.js';
@@ -124,15 +124,16 @@ export class CreateAndRunTaskTool implements IToolImpl {
 		}
 		const userInputKind = await getExpectedUserInputKind(outputAndIdle.output);
 		if (userInputKind) {
-			if (userInputKind !== 'choice' && userInputKind !== 'key') {
-				const options = userInputKind.split('/');
-				const response = await promptForYesNo(invocation.context, this._chatService);
-				const result = await response.promise;
-				if (result) {
-					await terminal.sendText(options[0] === 'y' ? 'y' : 'yes', true);
-					outputAndIdle = await pollForOutputAndIdle({ getOutput: () => getOutput(terminal), isActive: () => this._isTaskActive(task) }, true, token, this._languageModelsService);
-				} else {
-					await terminal.sendText(options[0] === 'n' ? 'n' : 'no', true);
+			const handleResult = await handleYesNoUserPrompt(
+				userInputKind,
+				invocation.context,
+				this._chatService,
+				terminal,
+				async () => await pollForOutputAndIdle({ getOutput: () => getOutput(terminal), isActive: () => this._isTaskActive(task) }, true, token, this._languageModelsService),
+			);
+			if (handleResult.handled) {
+				if (handleResult.outputAndIdle) {
+					outputAndIdle = handleResult.outputAndIdle;
 				}
 			} else {
 				return { content: [{ kind: 'text', value: `The task is still running and requires user input of ${userInputKind}.` }], toolResultMessage: new MarkdownString(localize('copilotChat.taskRequiresUserInput', 'The task `{0}` is still running and requires user input. {1}', task._label, userInputKind)) };

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/task/runTaskTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/task/runTaskTool.ts
@@ -81,7 +81,7 @@ export class RunTaskTool implements IToolImpl {
 		if (!outputAndIdle.terminalExecutionIdleBeforeTimeout) {
 			outputAndIdle = await racePollingOrPrompt(
 				() => pollForOutputAndIdle({ getOutput: () => getOutput(terminal), isActive: () => this._isTaskActive(task) }, true, token, this._languageModelsService),
-				() => promptForMorePolling(taskDefinition.taskLabel, invocation.context!, this._chatService),
+				() => promptForMorePolling(localize('poll.terminal.waiting', "Continue waiting for `{0}` to finish?", taskDefinition.taskLabel), localize('poll.terminal.polling', "Copilot will continue to poll for output to determine when the terminal becomes idle for up to 2 minutes."), invocation.context!, this._chatService),
 				outputAndIdle,
 				token,
 				this._languageModelsService,

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/task/runTaskTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/task/runTaskTool.ts
@@ -12,11 +12,12 @@ import { ILanguageModelsService } from '../../../../chat/common/languageModels.j
 import { CountTokensCallback, IPreparedToolInvocation, IToolData, IToolImpl, IToolInvocation, IToolInvocationPreparationContext, IToolResult, ToolDataSource, ToolProgress } from '../../../../chat/common/languageModelToolsService.js';
 import { ITaskService, ITaskSummary, Task } from '../../../../tasks/common/taskService.js';
 import { ITerminalService } from '../../../../terminal/browser/terminal.js';
-import { getExpectedUserInputKind, pollForOutputAndIdle, promptForMorePolling, racePollingOrPrompt, handleYesNoUserPrompt } from '../bufferOutputPolling.js';
+import { getExpectedUserInputKind, pollForOutputAndIdle, racePollingOrPrompt, handleYesNoUserPrompt } from '../bufferOutputPolling.js';
 import { getOutput } from '../outputHelpers.js';
 import { getTaskDefinition, getTaskForTool } from './taskHelpers.js';
 import { MarkdownString } from '../../../../../../base/common/htmlContent.js';
 import { IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
+import { promptForMorePolling } from '../../../../elicitation/browser/elicitation.js';
 
 type RunTaskToolClassification = {
 	taskId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The ID of the task.' };

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/task/runTaskTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/task/runTaskTool.ts
@@ -12,7 +12,7 @@ import { ILanguageModelsService } from '../../../../chat/common/languageModels.j
 import { CountTokensCallback, IPreparedToolInvocation, IToolData, IToolImpl, IToolInvocation, IToolInvocationPreparationContext, IToolResult, ToolDataSource, ToolProgress } from '../../../../chat/common/languageModelToolsService.js';
 import { ITaskService, ITaskSummary, Task } from '../../../../tasks/common/taskService.js';
 import { ITerminalService } from '../../../../terminal/browser/terminal.js';
-import { getExpectedUserInputKind, pollForOutputAndIdle, promptForMorePolling, promptForYesNo, racePollingOrPrompt } from '../bufferOutputPolling.js';
+import { getExpectedUserInputKind, pollForOutputAndIdle, promptForMorePolling, racePollingOrPrompt, handleYesNoUserPrompt } from '../bufferOutputPolling.js';
 import { getOutput } from '../outputHelpers.js';
 import { getTaskDefinition, getTaskForTool } from './taskHelpers.js';
 import { MarkdownString } from '../../../../../../base/common/htmlContent.js';
@@ -90,15 +90,16 @@ export class RunTaskTool implements IToolImpl {
 		}
 		const userInputKind = await getExpectedUserInputKind(outputAndIdle.output);
 		if (userInputKind) {
-			if (userInputKind !== 'choice' && userInputKind !== 'key') {
-				const options = userInputKind.split('/');
-				const response = await promptForYesNo(invocation.context, this._chatService);
-				const result = await response.promise;
-				if (result) {
-					await terminal.sendText(options[0] === 'y' ? 'y' : 'yes', true);
-					outputAndIdle = await pollForOutputAndIdle({ getOutput: () => getOutput(terminal), isActive: () => this._isTaskActive(task) }, true, token, this._languageModelsService);
-				} else {
-					await terminal.sendText(options[0] === 'n' ? 'n' : 'no', true);
+			const handleResult = await handleYesNoUserPrompt(
+				userInputKind,
+				invocation.context,
+				this._chatService,
+				terminal,
+				async () => await pollForOutputAndIdle({ getOutput: () => getOutput(terminal), isActive: () => this._isTaskActive(task) }, true, token, this._languageModelsService),
+			);
+			if (handleResult.handled) {
+				if (handleResult.outputAndIdle) {
+					outputAndIdle = handleResult.outputAndIdle;
 				}
 			} else {
 				return { content: [{ kind: 'text', value: `The task is still running and requires user input of ${userInputKind}.` }], toolResultMessage: new MarkdownString(localize('copilotChat.taskRequiresUserInput', 'The task `{0}` is still running and requires user input. {1}', taskDefinition.taskLabel, userInputKind)) };

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/task/runTaskTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/task/runTaskTool.ts
@@ -12,7 +12,7 @@ import { ILanguageModelsService } from '../../../../chat/common/languageModels.j
 import { CountTokensCallback, IPreparedToolInvocation, IToolData, IToolImpl, IToolInvocation, IToolInvocationPreparationContext, IToolResult, ToolDataSource, ToolProgress } from '../../../../chat/common/languageModelToolsService.js';
 import { ITaskService, ITaskSummary, Task } from '../../../../tasks/common/taskService.js';
 import { ITerminalService } from '../../../../terminal/browser/terminal.js';
-import { getExpectedUserInputKind, pollForOutputAndIdle, racePollingOrPrompt, handleYesNoUserPrompt } from '../bufferOutputPolling.js';
+import { pollForOutputAndIdle, racePollingOrPrompt, handleTerminalUserInputPrompt } from '../bufferOutputPolling.js';
 import { getOutput } from '../outputHelpers.js';
 import { getTaskDefinition, getTaskForTool } from './taskHelpers.js';
 import { MarkdownString } from '../../../../../../base/common/htmlContent.js';
@@ -89,22 +89,21 @@ export class RunTaskTool implements IToolImpl {
 				{ getOutput: () => getOutput(terminal), isActive: () => this._isTaskActive(task) }
 			);
 		}
-		const userInputKind = await getExpectedUserInputKind(outputAndIdle.output);
-		if (userInputKind) {
-			const handleResult = await handleYesNoUserPrompt(
-				userInputKind,
-				invocation.context,
-				this._chatService,
-				terminal,
-				async () => await pollForOutputAndIdle({ getOutput: () => getOutput(terminal), isActive: () => this._isTaskActive(task) }, true, token, this._languageModelsService),
-			);
-			if (handleResult.handled) {
-				if (handleResult.outputAndIdle) {
-					outputAndIdle = handleResult.outputAndIdle;
-				}
-			} else {
-				return { content: [{ kind: 'text', value: `The task is still running and requires user input of ${userInputKind}.` }], toolResultMessage: new MarkdownString(localize('copilotChat.taskRequiresUserInput', 'The task `{0}` is still running and requires user input. {1}', taskDefinition.taskLabel, userInputKind)) };
+		const handleResult = await handleTerminalUserInputPrompt(
+			outputAndIdle,
+			invocation,
+			this._chatService,
+			terminal,
+			task._label,
+			token,
+			this._languageModelsService
+		);
+		if (handleResult.handled) {
+			if (handleResult.outputAndIdle) {
+				outputAndIdle = handleResult.outputAndIdle;
 			}
+		} else if (handleResult.message) {
+			return handleResult.message;
 		}
 		let output = '';
 		if (result?.exitCode) {

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/task/runTaskTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/task/runTaskTool.ts
@@ -12,7 +12,7 @@ import { ILanguageModelsService } from '../../../../chat/common/languageModels.j
 import { CountTokensCallback, IPreparedToolInvocation, IToolData, IToolImpl, IToolInvocation, IToolInvocationPreparationContext, IToolResult, ToolDataSource, ToolProgress } from '../../../../chat/common/languageModelToolsService.js';
 import { ITaskService, ITaskSummary, Task } from '../../../../tasks/common/taskService.js';
 import { ITerminalService } from '../../../../terminal/browser/terminal.js';
-import { getExpectedUserInputKind, pollForOutputAndIdle, promptForMorePolling, racePollingOrPrompt } from '../bufferOutputPolling.js';
+import { getExpectedUserInputKind, pollForOutputAndIdle, promptForMorePolling, promptForYesNo, racePollingOrPrompt } from '../bufferOutputPolling.js';
 import { getOutput } from '../outputHelpers.js';
 import { getTaskDefinition, getTaskForTool } from './taskHelpers.js';
 import { MarkdownString } from '../../../../../../base/common/htmlContent.js';
@@ -88,8 +88,18 @@ export class RunTaskTool implements IToolImpl {
 				{ getOutput: () => getOutput(terminal), isActive: () => this._isTaskActive(task) }
 			);
 		}
-		const userInputKind = getExpectedUserInputKind(outputAndIdle.output);
+		const userInputKind = await getExpectedUserInputKind(outputAndIdle.output);
 		if (userInputKind) {
+			if (userInputKind !== 'choice' && userInputKind !== 'key') {
+				const options = userInputKind.split('/');
+				const response = await promptForYesNo(invocation.context, this._chatService);
+				const result = await response.promise;
+				if (result) {
+					await terminal.sendText(options[0] === 'y' ? 'y' : 'yes', true);
+				} else {
+					await terminal.sendText(options[0] === 'n' ? 'n' : 'no', true);
+				}
+			}
 			return { content: [{ kind: 'text', value: `The task is still running and requires user input of ${userInputKind}. Ask the user which input they'd like to provide.` }], toolResultMessage: new MarkdownString(localize('copilotChat.taskRequiresUserInput', 'The task `{0}` is still running and requires user input. {1}', taskDefinition.taskLabel, userInputKind)) };
 		}
 		let output = '';

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/task/runTaskTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/task/runTaskTool.ts
@@ -96,14 +96,7 @@ export class RunTaskTool implements IToolImpl {
 				const result = await response.promise;
 				if (result) {
 					await terminal.sendText(options[0] === 'y' ? 'y' : 'yes', true);
-					outputAndIdle = await racePollingOrPrompt(
-						() => pollForOutputAndIdle({ getOutput: () => getOutput(terminal), isActive: () => this._isTaskActive(task) }, true, token, this._languageModelsService),
-						() => promptForMorePolling(localize('poll.terminal.waiting', "Continue waiting for `{0}` to finish?", taskDefinition.taskLabel), localize('poll.terminal.polling', "Copilot will continue to poll for output to determine when the terminal becomes idle for up to 2 minutes."), invocation.context!, this._chatService),
-						outputAndIdle,
-						token,
-						this._languageModelsService,
-						{ getOutput: () => getOutput(terminal), isActive: () => this._isTaskActive(task) }
-					);
+					outputAndIdle = await pollForOutputAndIdle({ getOutput: () => getOutput(terminal), isActive: () => this._isTaskActive(task) }, true, token, this._languageModelsService);
 				} else {
 					await terminal.sendText(options[0] === 'n' ? 'n' : 'no', true);
 				}

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/task/runTaskTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/task/runTaskTool.ts
@@ -107,8 +107,9 @@ export class RunTaskTool implements IToolImpl {
 				} else {
 					await terminal.sendText(options[0] === 'n' ? 'n' : 'no', true);
 				}
+			} else {
+				return { content: [{ kind: 'text', value: `The task is still running and requires user input of ${userInputKind}.` }], toolResultMessage: new MarkdownString(localize('copilotChat.taskRequiresUserInput', 'The task `{0}` is still running and requires user input. {1}', taskDefinition.taskLabel, userInputKind)) };
 			}
-			return { content: [{ kind: 'text', value: `The task is still running and requires user input of ${userInputKind}.` }], toolResultMessage: new MarkdownString(localize('copilotChat.taskRequiresUserInput', 'The task `{0}` is still running and requires user input. {1}', taskDefinition.taskLabel, userInputKind)) };
 		}
 		let output = '';
 		if (result?.exitCode) {


### PR DESCRIPTION
fixes https://github.com/microsoft/vscode-copilot/issues/16430

Have a new issue  #257726 to track:
- multiple prompts (include this in output polling instead of after)
- support for foreground terminals
- delayed prompts
- ask the llm to determine options vs using regex
- consider automatically replying

