### PR TITLE
update ManageTasksTool ID

### DIFF
--- a/src/vs/workbench/contrib/chat/common/tools/manageTasksTool.ts
+++ b/src/vs/workbench/contrib/chat/common/tools/manageTasksTool.ts
@@ -23,11 +23,13 @@ import { ContextKeyExpr } from '../../../../../platform/contextkey/common/contex
 
 const ManageToolSettingId = 'chat.manageTasksTool.enabled';
 
+export const ManageTasksToolToolId = 'vscode_manageTasks';
+
 export const ManageTasksToolData: IToolData = {
-	id: 'vscode_tasks_internal',
+	id: ManageTasksToolToolId,
 	toolReferenceName: 'manageTasks',
 	when: ContextKeyExpr.equals(`config.${ManageToolSettingId}`, true),
-	canBeReferencedInPrompt: false,
+	canBeReferencedInPrompt: true,
 	icon: ThemeIcon.fromId(Codicon.checklist.id),
 	displayName: 'Manage Tasks',
 	modelDescription: 'A tool for managing tasks. Can create/update and read tasks in a todo list. Operations: write (add new todo tasks or update todo tasks), read(retrieve all todo tasks).',


### PR DESCRIPTION
Tool is still disabled by default and controlled via a setting