### PR TITLE
Better align chat output renders api with existing apis

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadChatOutputRenderer.ts
+++ b/src/vs/workbench/api/browser/mainThreadChatOutputRenderer.ts
@@ -18,7 +18,7 @@ export class MainThreadChatOutputRenderer extends Disposable implements MainThre
 
 	private _webviewHandlePool = 0;
 
-	private readonly registeredRenderers = new Map<string, IDisposable>();
+	private readonly registeredRenderers = new Map</* viewType */ string, IDisposable>();
 
 	constructor(
 		extHostContext: IExtHostContext,
@@ -36,8 +36,8 @@ export class MainThreadChatOutputRenderer extends Disposable implements MainThre
 		this.registeredRenderers.clear();
 	}
 
-	$registerChatOutputRenderer(mime: string, extensionId: ExtensionIdentifier, extensionLocation: UriComponents): void {
-		this._rendererService.registerRenderer(mime, {
+	$registerChatOutputRenderer(viewType: string, extensionId: ExtensionIdentifier, extensionLocation: UriComponents): void {
+		this._rendererService.registerRenderer(viewType, {
 			renderOutputPart: async (mime, data, webview, token) => {
 				const webviewHandle = `chat-output-${++this._webviewHandlePool}`;
 
@@ -45,14 +45,14 @@ export class MainThreadChatOutputRenderer extends Disposable implements MainThre
 					serializeBuffersForPostMessage: true,
 				});
 
-				this._proxy.$renderChatOutput(mime, VSBuffer.wrap(data), webviewHandle, token);
+				this._proxy.$renderChatOutput(viewType, mime, VSBuffer.wrap(data), webviewHandle, token);
 			},
 		}, {
 			extension: { id: extensionId, location: URI.revive(extensionLocation) }
 		});
 	}
 
-	$unregisterChatOutputRenderer(mime: string): void {
-		this.registeredRenderers.get(mime)?.dispose();
+	$unregisterChatOutputRenderer(viewType: string): void {
+		this.registeredRenderers.get(viewType)?.dispose();
 	}
 }

--- a/src/vs/workbench/api/common/extHost.api.impl.ts
+++ b/src/vs/workbench/api/common/extHost.api.impl.ts
@@ -1519,9 +1519,9 @@ export function createApiFactoryAndRegisterActors(accessor: ServicesAccessor): I
 				checkProposedApiEnabled(extension, 'chatSessionsProvider');
 				return extHostChatSessions.registerChatSessionContentProvider(extension, chatSessionType, provider);
 			},
-			registerChatOutputRenderer: (mime: string, renderer: vscode.ChatOutputRenderer) => {
+			registerChatOutputRenderer: (viewType: string, renderer: vscode.ChatOutputRenderer) => {
 				checkProposedApiEnabled(extension, 'chatOutputRenderer');
-				return extHostChatOutputRenderer.registerChatOutputRenderer(extension, mime, renderer);
+				return extHostChatOutputRenderer.registerChatOutputRenderer(extension, viewType, renderer);
 			},
 		};
 

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -1455,12 +1455,12 @@ export interface ExtHostUriOpenersShape {
 }
 
 export interface MainThreadChatOutputRendererShape extends IDisposable {
-	$registerChatOutputRenderer(mime: string, extensionId: ExtensionIdentifier, extensionLocation: UriComponents): void;
-	$unregisterChatOutputRenderer(mime: string): void;
+	$registerChatOutputRenderer(viewType: string, extensionId: ExtensionIdentifier, extensionLocation: UriComponents): void;
+	$unregisterChatOutputRenderer(viewType: string): void;
 }
 
 export interface ExtHostChatOutputRendererShape {
-	$renderChatOutput(mime: string, valueData: VSBuffer, webviewHandle: string, token: CancellationToken): Promise<void>;
+	$renderChatOutput(viewType: string, mime: string, valueData: VSBuffer, webviewHandle: string, token: CancellationToken): Promise<void>;
 }
 
 export interface MainThreadProfileContentHandlersShape {

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatToolOutputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatToolOutputPart.ts
@@ -56,7 +56,7 @@ export class ChatToolOutputSubPart extends BaseChatToolInvocationSubPart {
 					value: decodeBase64((toolInvocation.resultDetails as IToolResultOutputDetailsSerialized).output.base64Data),
 				},
 			};
-		console.log(context.content[context.contentIndex]);
+
 		this.domNode = dom.$('div.tool-output-part');
 
 		const titleEl = dom.$('.output-title');

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatToolOutputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatToolOutputPart.ts
@@ -56,7 +56,7 @@ export class ChatToolOutputSubPart extends BaseChatToolInvocationSubPart {
 					value: decodeBase64((toolInvocation.resultDetails as IToolResultOutputDetailsSerialized).output.base64Data),
 				},
 			};
-
+		console.log(context.content[context.contentIndex]);
 		this.domNode = dom.$('div.tool-output-part');
 
 		const titleEl = dom.$('.output-title');

--- a/src/vs/workbench/contrib/customEditor/common/contributedCustomEditors.ts
+++ b/src/vs/workbench/contrib/customEditor/common/contributedCustomEditors.ts
@@ -33,9 +33,9 @@ export class ContributedCustomEditors extends Disposable {
 			this.add(new CustomEditorInfo(info));
 		}
 
-		customEditorsExtensionPoint.setHandler(extensions => {
+		this._register(customEditorsExtensionPoint.setHandler(extensions => {
 			this.update(extensions);
-		});
+		}));
 	}
 
 	private readonly _onChange = this._register(new Emitter<void>());

--- a/src/vscode-dts/vscode.proposed.chatOutputRenderer.d.ts
+++ b/src/vscode-dts/vscode.proposed.chatOutputRenderer.d.ts
@@ -29,14 +29,26 @@ declare module 'vscode' {
 		toolResultDetails2?: Array<Uri | Location> | ToolResultDataOutput;
 	}
 
+	/**
+	 * The data to be rendered by a {@link ChatOutputRenderer}.
+	 */
+	export interface ChatOutputDataItem {
+		/**
+		 * The MIME type of the data.
+		 */
+		readonly mime: string;
+
+		/**
+		 * The contents of the data.
+		 */
+		readonly value: Uint8Array;
+	}
+
 	export interface ChatOutputRenderer {
 		/**
 		 * Given an output, render it into the provided webview.
 		 *
-		 * TODO:Should this take an object instead of Uint8Array? That would let you get the original mime. Useful
-		 * if we ever support registering for multiple mime types or using image/*.
-		 *
-		 * TODO: Figure out what to pass as context?
+		 * TODO: Figure out what to pass as context? Probably at least basic info such as chat location.
 		 *
 		 * @param data The data to render.
 		 * @param webview The webview to render the data into.
@@ -45,7 +57,7 @@ declare module 'vscode' {
 		 *
 		 * @returns A promise that resolves when the webview has been initialized and is ready to be presented to the user.
 		 */
-		renderChatOutput(data: Uint8Array, webview: Webview, ctx: {}, token: CancellationToken): Thenable<void>;
+		renderChatOutput(data: ChatOutputDataItem, webview: Webview, ctx: {}, token: CancellationToken): Thenable<void>;
 	}
 
 	export namespace chat {
@@ -59,15 +71,16 @@ declare module 'vscode' {
 		 * "contributes": {
 		 *   "chatOutputRenderer": [
 		 *     {
+		 *       "viewType": "myExt.myChatOutputRenderer",
 		 *       "mimeTypes": ["application/your-mime-type"]
 		 *     }
 		 *   ]
 		 * }
 		 * ```
 		 *
-		 * @param mime The MIME type of the output that this renderer can handle.
+		 * @param viewType Unique identifier for the renderer. This should match the `viewType` in your contribution point.
 		 * @param renderer The renderer to register.
 		 */
-		export function registerChatOutputRenderer(mime: string, renderer: ChatOutputRenderer): Disposable;
+		export function registerChatOutputRenderer(viewType: string, renderer: ChatOutputRenderer): Disposable;
 	}
 }


### PR DESCRIPTION
For #257761

Change to register with a `viewType` that is mapped to mime types by the contributions. This better matches other apis such as custom documents and also would enable having multiple possible renderers for a given output item


