### PR TITLE
fix(git): prevent deleting currently active worktree

### DIFF
--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -3456,6 +3456,13 @@ export class CommandCenter {
 			? (branch ?? commitish).substring(branchPrefix.length)
 			: (branch ?? commitish);
 
+		// Check if user is trying to delete the worktree they are currently in
+		const currentWorktree = repository.worktrees.find(wt => wt.uri.path === Uri.file(repository.root).path);
+		if (currentWorktree && worktreeName === currentWorktree.name) {
+			window.showErrorMessage(l10n.t('You cannot delete the worktree you are currently in. Please switch to another worktree or the main repository first.'));
+			return;
+		}
+
 		// If user selects folder button, they manually select the worktree path through folder picker
 		const getWorktreePath = async (): Promise<string | undefined> => {
 			const worktreeRoot = this.globalState.get<string>(`${CommandCenter.WORKTREE_ROOT_KEY}:${repository.root}`);


### PR DESCRIPTION
- Add a check to prevent users from deleting the worktree they are currently in
- Display an error message if the user tries to delete the active worktree
- Suggest switching to another worktree or the main repository before deleting

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
