### PR TITLE
Fix action view items being too long

### DIFF
--- a/src/vs/base/browser/ui/actionbar/actionViewItems.ts
+++ b/src/vs/base/browser/ui/actionbar/actionViewItems.ts
@@ -7,7 +7,7 @@ import { isFirefox } from '../../browser.js';
 import { DataTransfers } from '../../dnd.js';
 import { addDisposableListener, EventHelper, EventLike, EventType } from '../../dom.js';
 import { EventType as TouchEventType, Gesture } from '../../touch.js';
-import { IActionViewItem } from './actionbar.js';
+import { IActionViewItem, IResponsiveActionViewItem } from './actionbar.js';
 import { IContextViewProvider } from '../contextview/contextview.js';
 import { getDefaultHoverDelegate } from '../hover/hoverDelegateFactory.js';
 import { IHoverDelegate } from '../hover/hoverDelegate.js';
@@ -438,7 +438,7 @@ export class ActionViewItem extends BaseActionViewItem {
 	}
 }
 
-export class SelectActionViewItem<T = string> extends BaseActionViewItem {
+export class SelectActionViewItem<T = string> extends BaseActionViewItem implements IResponsiveActionViewItem {
 	protected selectBox: SelectBox;
 
 	constructor(ctx: unknown, action: IAction, options: ISelectOptionItem[], selected: number, contextViewProvider: IContextViewProvider, styles: ISelectBoxStyles, selectBoxOptions?: ISelectBoxOptions) {
@@ -449,6 +449,11 @@ export class SelectActionViewItem<T = string> extends BaseActionViewItem {
 
 		this._register(this.selectBox);
 		this.registerListeners();
+	}
+
+	getMinWidth(): number {
+		// min-width for .action-item.select-container and .action-item.select-box
+		return 100;
 	}
 
 	setOptions(options: ISelectOptionItem[], selected?: number): void {

--- a/src/vs/base/browser/ui/actionbar/actionbar.ts
+++ b/src/vs/base/browser/ui/actionbar/actionbar.ts
@@ -26,6 +26,10 @@ export interface IActionViewItem extends IDisposable {
 	showHover?(): void;
 }
 
+export interface IResponsiveActionViewItem extends IActionViewItem {
+	getMinWidth(): number;
+}
+
 export interface IActionViewItemProvider {
 	(action: IAction, options: IActionViewItemOptions): IActionViewItem | undefined;
 }
@@ -408,6 +412,22 @@ export class ActionBar extends Disposable implements IActionRunner {
 		}
 
 		return 0;
+	}
+
+	getMinWidth(index: number): number {
+		if (index >= 0 && index < this.viewItems.length) {
+			const viewItem = this.viewItems[index];
+			if (this.isResponsiveActionViewItem(viewItem)) {
+				return viewItem.getMinWidth();
+			}
+			// Fall back to current width
+			return this.getWidth(index);
+		}
+		return 0;
+	}
+
+	private isResponsiveActionViewItem(item: IActionViewItem): item is IResponsiveActionViewItem {
+		return 'getMinWidth' in item;
 	}
 
 	getHeight(index: number): number {

--- a/src/vs/base/browser/ui/toolbar/toolbar.ts
+++ b/src/vs/base/browser/ui/toolbar/toolbar.ts
@@ -175,6 +175,14 @@ export class ToolBar extends Disposable {
 		return itemsWidth;
 	}
 
+	getItemsMinWidth(): number {
+		let itemsMinWidth = 0;
+		for (let i = 0; i < this.actionBar.length(); i++) {
+			itemsMinWidth += this.actionBar.getMinWidth(i);
+		}
+		return itemsMinWidth;
+	}
+
 	getItemAction(indexOrElement: number | HTMLElement) {
 		return this.actionBar.getAction(indexOrElement);
 	}

--- a/src/vs/workbench/browser/parts/paneCompositePart.ts
+++ b/src/vs/workbench/browser/parts/paneCompositePart.ts
@@ -619,7 +619,7 @@ export abstract class AbstractPaneCompositePart extends CompositePart<PaneCompos
 			const padding = this.compositeBarPosition === CompositeBarPosition.TITLE ? 16 : 8;
 			const borderWidth = this.partId === Parts.PANEL_PART ? 0 : 1;
 			let availableWidth = this.contentDimension.width - padding - borderWidth;
-			availableWidth = Math.max(AbstractPaneCompositePart.MIN_COMPOSITE_BAR_WIDTH, availableWidth - this.getToolbarWidth());
+			availableWidth = Math.max(AbstractPaneCompositePart.MIN_COMPOSITE_BAR_WIDTH, availableWidth - this.getToolbarMinWidth());
 			this.paneCompositeBar.value.layout(availableWidth, this.dimension.height);
 		}
 	}
@@ -646,6 +646,27 @@ export abstract class AbstractPaneCompositePart extends CompositePart<PaneCompos
 		const toolBarWidth = this.toolBar.getItemsWidth() + this.toolBar.getItemsLength() * 4;
 		const globalToolBarWidth = this.globalToolBar ? this.globalToolBar.getItemsWidth() + this.globalToolBar.getItemsLength() * 4 : 0;
 		return toolBarWidth + globalToolBarWidth + 5; // 5px padding left
+	}
+
+	/**
+	 * Get the minimum toolbar width when items can be compressed.
+	 * This is currently duplicate code
+	 * but I'm not sure if I can modify the original APIs.
+	 */
+	protected getToolbarMinWidth(): number {
+		if (!this.toolBar || this.compositeBarPosition !== CompositeBarPosition.TITLE) {
+			return 0;
+		}
+
+		const activePane = this.getActivePaneComposite();
+		if (!activePane) {
+			return 0;
+		}
+
+		// Each toolbar item has 4px margin
+		const toolBarMinWidth = this.toolBar.getItemsMinWidth() + this.toolBar.getItemsLength() * 4;
+		const globalToolBarMinWidth = this.globalToolBar ? this.globalToolBar.getItemsMinWidth() + this.globalToolBar.getItemsLength() * 4 : 0;
+		return toolBarMinWidth + globalToolBarMinWidth + 5; // 5px padding left
 	}
 
 	private onTitleAreaContextMenu(event: StandardMouseEvent): void {

--- a/src/vs/workbench/browser/parts/views/viewPane.ts
+++ b/src/vs/workbench/browser/parts/views/viewPane.ts
@@ -12,7 +12,7 @@ import { createCSSRule } from '../../../../base/browser/domStylesheets.js';
 import { asCssValueWithDefault, asCSSUrl } from '../../../../base/browser/cssValue.js';
 import { DisposableMap, DisposableStore, toDisposable } from '../../../../base/common/lifecycle.js';
 import { Action, IAction, IActionRunner } from '../../../../base/common/actions.js';
-import { ActionsOrientation, IActionViewItem, prepareActions } from '../../../../base/browser/ui/actionbar/actionbar.js';
+import { ActionsOrientation, IActionViewItem, IResponsiveActionViewItem, prepareActions } from '../../../../base/browser/ui/actionbar/actionbar.js';
 import { Registry } from '../../../../platform/registry/common/platform.js';
 import { IKeybindingService } from '../../../../platform/keybinding/common/keybinding.js';
 import { IContextMenuService } from '../../../../platform/contextview/browser/contextView.js';
@@ -696,7 +696,7 @@ export abstract class ViewPane extends Pane implements IView {
 	createActionViewItem(action: IAction, options?: IDropdownMenuActionViewItemOptions): IActionViewItem | undefined {
 		if (action.id === VIEWPANE_FILTER_ACTION.id) {
 			const that = this;
-			return new class extends BaseActionViewItem {
+			return new class extends BaseActionViewItem implements IResponsiveActionViewItem {
 				constructor() { super(null, action); }
 				override setFocusable(): void { /* noop input elements are focusable by default */ }
 				override get trapsArrowNavigation(): boolean { return true; }
@@ -705,6 +705,10 @@ export abstract class ViewPane extends Pane implements IView {
 					const filter = that.getFilterWidget()!;
 					append(container, filter.element);
 					filter.relayout();
+				}
+				getMinWidth(): number {
+					// This magic number comes from CSS .viewpane-filter-container
+					return 150;
 				}
 			};
 		}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
The filter input textbox might take up large spaces despite the screen being wide enough.
If we hit "PROBLEMS" then "OUTPUT", the behavior is normal:
<img width="1878" height="288" alt="problems_to_output" src="https://github.com/user-attachments/assets/d17c7576-bff4-49f9-a687-942fac23a84d" />
However, if we hit "DEBUG CONSOLE" first and then "OUTPUT", all action buttons are hidden in the ellipsis:
<img width="1878" height="256" alt="debug_to_output" src="https://github.com/user-attachments/assets/d566f965-d0da-42cb-8c4a-2aaa85daf105" />
This is an inconsistent behavior that may reduce productivity.

The cause of this issue is that the available width of the left toolbar depends on the width of the right toolbar, which is then computed from `clientWidth`, i.e., the current width. In "DEBUG CONSOLE", the filter input box is stretching (`flex: 1`) to occupy the remaining space, and this space is not freed when switching to the "OUTPUT" tab.

The proposed change is to add `getMinWidth()` to supported components like textboxes and select dropdowns. When calculating their widths in layout, use their minimum width first so that other elements can take up more space. After that, they can grow to their desired length in the final rendering.