### PR TITLE
Filter out tasks without `type` or with `hide` to align with prompt agent context

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/task/taskHelpers.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/task/taskHelpers.ts
@@ -38,11 +38,16 @@ export async function getTaskForTool(id: string | undefined, taskDefinition: { t
 	let task: IConfiguredTask | undefined;
 	const configTasks: IConfiguredTask[] = (configurationService.getValue('tasks') as { tasks: IConfiguredTask[] }).tasks ?? [];
 	for (const configTask of configTasks) {
+		if (!configTask.type || 'hide' in configTask && configTask.hide) {
+			// Skip thse as they
+			// and not included in the agent prompt.
+			continue;
+		}
 		if ((configTask.type && taskDefinition.taskType ? configTask.type === taskDefinition.taskType : true) &&
 			((getTaskRepresentation(configTask) === taskDefinition?.taskLabel) || (id === configTask.label))) {
 			task = configTask;
 			break;
-		} else if (id === `${configTask.type}: ${index}`) {
+		} else if (!configTask.label && id === `${configTask.type}: ${index}`) {
 			task = configTask;
 			break;
 		}


### PR DESCRIPTION
In the prompt chat agent, tasks without `type` or with `hide` set are filtered out. We weren't doing that in core, so the index of a task could be off for tasks lacking labels when such tasks were present in the `tasks.json` file. 

https://github.com/microsoft/vscode-copilot-chat/blob/c41a3eb66f2695c27d354a590f4ee68b1e33f660/src/extension/prompts/node/agent/agentPrompt.tsx#L564

This fix just aligns with the prompt agent.

Ideally, we'd also allow tasks without `type` that have dependencies so that compound tasks are runnable by the agent. Tracking that here https://github.com/microsoft/vscode/issues/258241

fixes #258242