### PR TITLE
fix: avoid leaking focus tracker

### DIFF
--- a/src/vs/workbench/browser/contextkeys.ts
+++ b/src/vs/workbench/browser/contextkeys.ts
@@ -315,7 +315,9 @@ export class WorkbenchContextKeysHandler extends Disposable {
 		this.inputFocusedContext.set(isInputFocused);
 
 		if (isInputFocused) {
-			const tracker = disposables.add(trackFocus(ownerDocument.activeElement as HTMLElement));
+			const store = new DisposableStore();
+			disposables.add(store);
+			const tracker = store.add(trackFocus(ownerDocument.activeElement as HTMLElement));
 			Event.once(tracker.onDidBlur)(() => {
 
 				// Ensure we are only updating the context key if we are
@@ -330,8 +332,8 @@ export class WorkbenchContextKeysHandler extends Disposable {
 					this.inputFocusedContext.set(activeElementIsInput());
 				}
 
-				tracker.dispose();
-			}, undefined, disposables);
+				store.dispose();
+			}, undefined, store);
 		}
 	}
 


### PR DESCRIPTION
While we dispose the tracker, we still hold the reference to it and the once event through the disposable array. It means that we will keep the focus tracker and everything related to it in memory until we dispose `WorkbenchContextKeysHandler`.

Fixes https://github.com/microsoft/vscode/issues/246173

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
