### PR TITLE
Don't attempt to cancel command when basic SI is used

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/executeStrategy/basicExecuteStrategy.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/executeStrategy/basicExecuteStrategy.ts
@@ -91,8 +91,12 @@ export class BasicExecuteStrategy implements ITerminalExecuteStrategy {
 			}));
 
 			// Execute the command
+			// IMPORTANT: This uses `sendText` not `runCommand` since when basic shell integration
+			// is used as it's more common to not recognize the prompt input which would result in
+			// ^C being sent and also to return the exit code of 130 when from the shell when that
+			// occurs.
 			this._log(`Executing command line \`${commandLine}\``);
-			this._instance.runCommand(commandLine, true);
+			this._instance.sendText(commandLine, true);
 
 			// Wait for the next end execution event - note that this may not correspond to the actual
 			// execution requested


### PR DESCRIPTION
Because of the complications that arise when ^C is sent to the shell, this change disables that functionality when basic SI is used. That means that the command will probably fail if the user types into the terminal, but that's an edge case vs almost everything failing without this change

Fixes #258294

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
