### PR TITLE
fix: align counter element

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/media/settingsEditor2.css
+++ b/src/vs/workbench/contrib/preferences/browser/media/settingsEditor2.css
@@ -42,6 +42,12 @@
 	position: absolute;
 	right: 49px;
 	top: 0px;
+	margin: 3.2px 0px;
+}
+
+.monaco-workbench.hc-black .settings-editor > .settings-header > .search-container > .settings-count-widget,
+.monaco-workbench.hc-light .settings-editor > .settings-header > .search-container > .settings-count-widget {
+	/* Reduce the margin because there is a border in this case. */
 	margin: 2.5px 0px;
 }
 

--- a/src/vs/workbench/contrib/preferences/browser/media/settingsEditor2.css
+++ b/src/vs/workbench/contrib/preferences/browser/media/settingsEditor2.css
@@ -42,12 +42,6 @@
 	position: absolute;
 	right: 49px;
 	top: 0px;
-	margin: 3.2px 0px;
-}
-
-.monaco-workbench.hc-black .settings-editor > .settings-header > .search-container > .settings-count-widget,
-.monaco-workbench.hc-light .settings-editor > .settings-header > .search-container > .settings-count-widget {
-	/* Reduce the margin because there is a border in this case. */
 	margin: 2.5px 0px;
 }
 

--- a/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
@@ -43,7 +43,7 @@ import { Registry } from '../../../../platform/registry/common/platform.js';
 import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
 import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry.js';
 import { defaultButtonStyles, defaultToggleStyles } from '../../../../platform/theme/browser/defaultStyles.js';
-import { asCssVariable, badgeBackground, badgeForeground, contrastBorder, editorForeground } from '../../../../platform/theme/common/colorRegistry.js';
+import { asCssVariable, asCssVariableWithDefault, badgeBackground, badgeForeground, contrastBorder, editorForeground, inputBackground } from '../../../../platform/theme/common/colorRegistry.js';
 import { IThemeService } from '../../../../platform/theme/common/themeService.js';
 import { IUserDataSyncEnablementService, IUserDataSyncService, SyncStatus } from '../../../../platform/userDataSync/common/userDataSync.js';
 import { IWorkspaceTrustManagementService } from '../../../../platform/workspace/common/workspaceTrust.js';
@@ -722,7 +722,7 @@ export class SettingsEditor2 extends EditorPane {
 
 		this.countElement.style.backgroundColor = asCssVariable(badgeBackground);
 		this.countElement.style.color = asCssVariable(badgeForeground);
-		this.countElement.style.border = `1px solid ${asCssVariable(contrastBorder)}`;
+		this.countElement.style.border = `1px solid ${asCssVariableWithDefault(contrastBorder, asCssVariable(inputBackground))}`;
 
 		this._register(this.searchWidget.onInputDidChange(() => {
 			const searchVal = this.searchWidget.getValue();


### PR DESCRIPTION
This PR aligns the counter element in the Settings editor for themes that do not have a defined contrast border.

Fixes https://github.com/microsoft/vscode/issues/258147.
