### PR TITLE
Only change the line height of the view line

### DIFF
--- a/src/vs/editor/common/model/decorationProvider.ts
+++ b/src/vs/editor/common/model/decorationProvider.ts
@@ -29,14 +29,15 @@ export interface DecorationProvider {
 export class LineHeightChangingDecoration {
 
 	public static toKey(obj: LineHeightChangingDecoration): string {
-		return `${obj.ownerId};${obj.decorationId};${obj.lineNumber}`;
+		return `${obj.ownerId};${obj.decorationId}`;
 	}
 
 	constructor(
 		public readonly ownerId: number,
 		public readonly decorationId: string,
-		public readonly lineNumber: number,
-		public readonly lineHeight: number | null
+		public readonly range: Range,
+		public readonly lineHeight: number | null,
+		public readonly isWholeLine: boolean
 	) { }
 }
 

--- a/src/vs/editor/common/model/textModel.ts
+++ b/src/vs/editor/common/model/textModel.ts
@@ -1654,7 +1654,7 @@ export class TextModel extends Disposable implements model.ITextModel, IDecorati
 	private _fireOnDidChangeLineHeight(affectedLineHeights: Set<LineHeightChangingDecoration> | null): void {
 		if (affectedLineHeights && affectedLineHeights.size > 0) {
 			const affectedLines = Array.from(affectedLineHeights);
-			const lineHeightChangeEvent = affectedLines.map(specialLineHeightChange => new ModelLineHeightChanged(specialLineHeightChange.ownerId, specialLineHeightChange.decorationId, specialLineHeightChange.lineNumber, specialLineHeightChange.lineHeight));
+			const lineHeightChangeEvent = affectedLines.map(specialLineHeightChange => new ModelLineHeightChanged(specialLineHeightChange.ownerId, specialLineHeightChange.decorationId, specialLineHeightChange.range, specialLineHeightChange.lineHeight, specialLineHeightChange.isWholeLine));
 			this._onDidChangeLineHeight.fire(new ModelLineHeightChangedEvent(lineHeightChangeEvent));
 		}
 	}
@@ -1896,7 +1896,7 @@ export class TextModel extends Disposable implements model.ITextModel, IDecorati
 		}
 		if (node.options.lineHeight !== null) {
 			const oldRange = this.getDecorationRange(decorationId);
-			this._onDidChangeDecorations.recordLineAffectedByLineHeightChange(ownerId, decorationId, oldRange!.startLineNumber, null);
+			this._onDidChangeDecorations.recordLineAffectedByLineHeightChange(ownerId, decorationId, oldRange!, null, node.options.isWholeLine);
 		}
 		if (node.options.affectsFont) {
 			const oldRange = this.getDecorationRange(decorationId);
@@ -1919,7 +1919,7 @@ export class TextModel extends Disposable implements model.ITextModel, IDecorati
 			this._onDidChangeDecorations.recordLineAffectedByInjectedText(range.startLineNumber);
 		}
 		if (node.options.lineHeight !== null) {
-			this._onDidChangeDecorations.recordLineAffectedByLineHeightChange(ownerId, decorationId, range.startLineNumber, node.options.lineHeight);
+			this._onDidChangeDecorations.recordLineAffectedByLineHeightChange(ownerId, decorationId, range, node.options.lineHeight, node.options.isWholeLine);
 		}
 		if (node.options.affectsFont) {
 			this._onDidChangeDecorations.recordLineAffectedByFontChange(ownerId, node.id, range.startLineNumber);
@@ -1948,7 +1948,7 @@ export class TextModel extends Disposable implements model.ITextModel, IDecorati
 		}
 		if (node.options.lineHeight !== null || options.lineHeight !== null) {
 			const nodeRange = this._decorationsTree.getNodeRange(this, node);
-			this._onDidChangeDecorations.recordLineAffectedByLineHeightChange(ownerId, decorationId, nodeRange.startLineNumber, options.lineHeight);
+			this._onDidChangeDecorations.recordLineAffectedByLineHeightChange(ownerId, decorationId, nodeRange, options.lineHeight, options.isWholeLine);
 		}
 		if (node.options.affectsFont || options.affectsFont) {
 			const nodeRange = this._decorationsTree.getNodeRange(this, node);
@@ -2002,7 +2002,7 @@ export class TextModel extends Disposable implements model.ITextModel, IDecorati
 						}
 						if (node.options.lineHeight !== null) {
 							const nodeRange = this._decorationsTree.getNodeRange(this, node);
-							this._onDidChangeDecorations.recordLineAffectedByLineHeightChange(ownerId, decorationId, nodeRange.startLineNumber, null);
+							this._onDidChangeDecorations.recordLineAffectedByLineHeightChange(ownerId, decorationId, nodeRange, null, node.options.isWholeLine);
 						}
 						if (node.options.affectsFont) {
 							const nodeRange = this._decorationsTree.getNodeRange(this, node);
@@ -2043,7 +2043,7 @@ export class TextModel extends Disposable implements model.ITextModel, IDecorati
 						this._onDidChangeDecorations.recordLineAffectedByInjectedText(range.startLineNumber);
 					}
 					if (node.options.lineHeight !== null) {
-						this._onDidChangeDecorations.recordLineAffectedByLineHeightChange(ownerId, node.id, range.startLineNumber, node.options.lineHeight);
+						this._onDidChangeDecorations.recordLineAffectedByLineHeightChange(ownerId, node.id, range, node.options.lineHeight, node.options.isWholeLine);
 					}
 					if (node.options.affectsFont) {
 						this._onDidChangeDecorations.recordLineAffectedByFontChange(ownerId, node.id, range.startLineNumber);
@@ -2595,11 +2595,11 @@ class DidChangeDecorationsEmitter extends Disposable {
 		this._affectedInjectedTextLines.add(lineNumber);
 	}
 
-	public recordLineAffectedByLineHeightChange(ownerId: number, decorationId: string, lineNumber: number, lineHeight: number | null): void {
+	public recordLineAffectedByLineHeightChange(ownerId: number, decorationId: string, range: Range, lineHeight: number | null, isWholeLine: boolean): void {
 		if (!this._affectedLineHeights) {
 			this._affectedLineHeights = new SetWithKey<LineHeightChangingDecoration>([], LineHeightChangingDecoration.toKey);
 		}
-		this._affectedLineHeights.add(new LineHeightChangingDecoration(ownerId, decorationId, lineNumber, lineHeight));
+		this._affectedLineHeights.add(new LineHeightChangingDecoration(ownerId, decorationId, range, lineHeight, isWholeLine));
 	}
 
 	public recordLineAffectedByFontChange(ownerId: number, decorationId: string, lineNumber: number): void {

--- a/src/vs/editor/common/textModelEvents.ts
+++ b/src/vs/editor/common/textModelEvents.ts
@@ -342,19 +342,24 @@ export class ModelLineHeightChanged {
 	 */
 	public readonly decorationId: string;
 	/**
-	 * The line that has changed.
+	 * The range that has changed.
 	 */
-	public readonly lineNumber: number;
+	public readonly range: Range;
 	/**
 	 * The line height on the line.
 	 */
 	public readonly lineHeight: number | null;
+	/**
+	 * The range that has changed.
+	 */
+	public readonly isWholeLine: boolean;
 
-	constructor(ownerId: number, decorationId: string, lineNumber: number, lineHeight: number | null) {
+	constructor(ownerId: number, decorationId: string, range: Range, lineHeight: number | null, isWholeLine: boolean) {
 		this.ownerId = ownerId;
 		this.decorationId = decorationId;
-		this.lineNumber = lineNumber;
+		this.range = range;
 		this.lineHeight = lineHeight;
+		this.isWholeLine = isWholeLine;
 	}
 }
 
@@ -520,14 +525,14 @@ export class ModelLineHeightChangedEvent {
 	public affects(rangeOrPosition: IRange | IPosition) {
 		if (Range.isIRange(rangeOrPosition)) {
 			for (const change of this.changes) {
-				if (change.lineNumber >= rangeOrPosition.startLineNumber && change.lineNumber <= rangeOrPosition.endLineNumber) {
+				if (change.range.intersectRanges(rangeOrPosition)) {
 					return true;
 				}
 			}
 			return false;
 		} else {
 			for (const change of this.changes) {
-				if (change.lineNumber === rangeOrPosition.lineNumber) {
+				if (change.range.containsPosition(rangeOrPosition)) {
 					return true;
 				}
 			}


### PR DESCRIPTION
Previously, if a decoration specified a custom line height, this affected all viewlines that are covered by model line. Now the line height is only applied to the view lines that render the decoration.

It is still possible to change the line height of an entire view line by setting the decoration option `isWholeLine`.

<img width="721" height="801" alt="image" src="https://github.com/user-attachments/assets/f98dbaf9-bc80-47bc-ac7e-4d4e3c4d7b0e" />

Closes #249967
Closes #295179

cc @aiday-mar 