### PR TITLE
fix(workspace.openTextDocument): handle fragments for selection in URIs

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadEditors.ts
+++ b/src/vs/workbench/api/browser/mainThreadEditors.ts
@@ -14,7 +14,6 @@ import { IDecorationOptions, IDecorationRenderOptions } from '../../../editor/co
 import { ISingleEditOperation } from '../../../editor/common/core/editOperation.js';
 import { CommandsRegistry } from '../../../platform/commands/common/commands.js';
 import { ITextEditorOptions, IResourceEditorInput, EditorActivation, EditorResolution, ITextEditorDiffInformation, isTextEditorDiffInformationEqual, ITextEditorChange } from '../../../platform/editor/common/editor.js';
-import { extractSelection } from '../../../platform/opener/common/opener.js';
 import { ServicesAccessor } from '../../../platform/instantiation/common/instantiation.js';
 import { MainThreadTextEditor } from './mainThreadEditor.js';
 import { ExtHostContext, ExtHostEditorsShape, IApplyEditsOptions, ITextDocumentShowOptions, ITextEditorConfigurationUpdate, ITextEditorPositionData, IUndoStopOptions, MainThreadTextEditorsShape, TextEditorRevealType } from '../common/extHost.protocol.js';

--- a/src/vs/workbench/api/browser/mainThreadEditors.ts
+++ b/src/vs/workbench/api/browser/mainThreadEditors.ts
@@ -14,6 +14,7 @@ import { IDecorationOptions, IDecorationRenderOptions } from '../../../editor/co
 import { ISingleEditOperation } from '../../../editor/common/core/editOperation.js';
 import { CommandsRegistry } from '../../../platform/commands/common/commands.js';
 import { ITextEditorOptions, IResourceEditorInput, EditorActivation, EditorResolution, ITextEditorDiffInformation, isTextEditorDiffInformationEqual, ITextEditorChange } from '../../../platform/editor/common/editor.js';
+import { extractSelection } from '../../../platform/opener/common/opener.js';
 import { ServicesAccessor } from '../../../platform/instantiation/common/instantiation.js';
 import { MainThreadTextEditor } from './mainThreadEditor.js';
 import { ExtHostContext, ExtHostEditorsShape, IApplyEditsOptions, ITextDocumentShowOptions, ITextEditorConfigurationUpdate, ITextEditorPositionData, IUndoStopOptions, MainThreadTextEditorsShape, TextEditorRevealType } from '../common/extHost.protocol.js';
@@ -240,7 +241,8 @@ export class MainThreadTextEditors implements MainThreadTextEditorsShape {
 	// --- from extension host process
 
 	async $tryShowTextDocument(resource: UriComponents, options: ITextDocumentShowOptions): Promise<string | undefined> {
-		const uri = URI.revive(resource);
+		// Remove selection from URI fragment if present (for file URIs with line range fragments like #L42)
+		const uri = URI.revive(resource).with({ fragment: '' });
 
 		const editorOptions: ITextEditorOptions = {
 			preserveFocus: options.preserveFocus,


### PR DESCRIPTION
TL;DR - because `vscode.workspace.openTextDocument()` does not handle fragments in URIs, we can wrongly open files as external and break search.

## VSCode build details
```
Version: 1.102.2
Commit: c306e94f98122556ca081f527b466015e1bc37b0
Date: 2025-07-22T12:15:48.520Z
Electron: 35.6.0
ElectronBuildId: 11847422
Chromium: 134.0.6998.205
Node.js: 22.15.1
V8: 13.4.114.21-electron.0
OS: Darwin arm64 24.5.0
```

## Reproduction
1. Open a folder in VSCode. The folder should contain a text file.
2. Call [`vscode.workspace.openTextDocument()`](https://code.visualstudio.com/api/references/vscode-api#workspace) with a URI containing a link fragment . The URI should point to the text file in the opened folder.
3. The file is opened as external despite being in the directory. Furthermore, if your fragment is a line selection like `#L4`, the cursor will not move to the target line.
4. If you pass the URI without the link fragment, it will open as expected.

Video demonstration: https://www.loom.com/share/e30501c3c3414efd81464024fc83decd?sid=945e0362-a38d-4848-b4aa-00847fd63e10

### Extension
It's easiest to reproduce this with a minimal extension:
`package.json`:
```json
{
  "name": "simple-webview-extension",
  "version": "0.0.1",
  "engines": {
    "vscode": "^1.60.0"
  },
  "main": "./extension.js",
  "contributes": {
    "views": {
      "explorer": [
        {
          "id": "simpleWebview",
          "name": "File Opener",
          "type": "webview"
        }
      ]
    }
  }
}
```


`extension.js`:
```javascript
const vscode = require('vscode');
const os = require('os');

class SimpleWebviewProvider {
    resolveWebviewView(webviewView) {
        webviewView.webview.options = { enableScripts: true };
        webviewView.webview.html = `<!DOCTYPE html>
<html>
<body>
    <button onclick="openFile()">Open foo.txt</button>
    <button onclick="openFileWithLine()">Open foo.txt at line 4</button>
    
    <script>
        const vscode = acquireVsCodeApi();

        function openFile() {
            vscode.postMessage({ type: 'openFile' });
        }

        function openFileWithLine() {
            vscode.postMessage({ type: 'openFileWithLine' });
        }
    </script>
</body>
</html>`;

        webviewView.webview.onDidReceiveMessage(async data => {
            try {
                let link = `${os.homedir()}/.tmp/debug/foo.txt`
                if (data.type === 'openFileWithLine') {
                    link += '#L4'
                }
                
                const uri = vscode.Uri.parse(link)
                const document = await vscode.workspace.openTextDocument(uri)
                await vscode.window.showTextDocument(document)
            } catch (error) {
                console.log('Error', error)
            }
        });
    }
}

function activate(context) {
    context.subscriptions.push(
        vscode.window.registerWebviewViewProvider('simpleWebview', new SimpleWebviewProvider())
    );
}

module.exports = { activate };
```

Directory preparation:
```bash
mkdir -p ~/.tmp/debug
echo "a\nb\nc\nd\ne" > ~/.tmp/debug/foo.txt
```

Launch the extension, open the sidebar and click on the buttons. 
`Open foo.txt` should work as expected, `Open foo.txt at line 4` should open the file as external and not move the cursor to the specified line.
<img width="198" height="80" alt="image" src="https://github.com/user-attachments/assets/93ce1861-2222-449b-b609-37f051b5b7bc" />

## Additional issue
I also noticed that if you open a file with a link fragment (so that it shows as external), then do a directory-wide search for a term present in the file, search will hang and dev tools will contain an error (see below). If you repeat the search, you'll see an error message under the search box.

<details> <summary> Error log </summary>

```
ERR file:///Users/jan/.tmp/debug/foo.txt#L4 is not a descendant of file:///Users/jan/.tmp/debug: Error: file:///Users/jan/.tmp/debug/foo.txt#L4 is not a descendant of file:///Users/jan/.tmp/debug
    at rst.createAndConfigureFileMatch (vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/workbench/workbench.desktop.main.js:1987:6272)
    at vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/workbench/workbench.desktop.main.js:1987:4705
    at Array.forEach (<anonymous>)
    at rst.addFileMatch (vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/workbench/workbench.desktop.main.js:1987:4266)
    at vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/workbench/workbench.desktop.main.js:1987:8325
    at Nre.forEach (vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/workbench/workbench.desktop.main.js:8:9060)
    at ast.add (vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/workbench/workbench.desktop.main.js:1987:8257)
    at sut.add (vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/workbench/workbench.desktop.main.js:2547:2406)
    at vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/workbench/workbench.desktop.main.js:2547:7600
```

</details>

I believe this happens because [this call](https://github.com/microsoft/vscode/blob/main/src/vs/workbench/contrib/search/browser/searchTreeModel/folderMatch.ts#L238) doesn't pass `ignoreFragment=true`.

This PR prevents this behavior, but perhaps it should also be addressed.