### PR TITLE
fix default path bug related to branch prefix

### DIFF
--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -3400,6 +3400,7 @@ export class CommandCenter {
 
 	private async _createWorktree(repository: Repository): Promise<void> {
 		const config = workspace.getConfiguration('git');
+		const branchPrefix = config.get<string>('branchPrefix')!;
 		const showRefDetails = config.get<boolean>('showReferenceDetails') === true;
 
 		const createBranch = new CreateBranchItem();
@@ -3450,9 +3451,10 @@ export class CommandCenter {
 			commitish = choice.refName;
 		}
 
-		const worktreeName = (branch ?? commitish).includes('/')
-			? (branch ?? commitish).substring((branch ?? commitish).lastIndexOf('/') + 1)
-			: (branch ?? commitish);
+		const worktreeName = ((branch ?? commitish).startsWith(branchPrefix)
+			? (branch ?? commitish).substring(branchPrefix.length)
+			: (branch ?? commitish)
+		).split('/').pop() || (branch ?? commitish);
 
 		// If user selects folder button, they manually select the worktree path through folder picker
 		const getWorktreePath = async (): Promise<string | undefined> => {

--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -3454,7 +3454,7 @@ export class CommandCenter {
 		const worktreeName = ((branch ?? commitish).startsWith(branchPrefix)
 			? (branch ?? commitish).substring(branchPrefix.length)
 			: (branch ?? commitish)
-		).split('-').pop() || (branch ?? commitish);
+		).replace(/\//g, '-');
 
 		// If user selects folder button, they manually select the worktree path through folder picker
 		const getWorktreePath = async (): Promise<string | undefined> => {

--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -3454,7 +3454,7 @@ export class CommandCenter {
 		const worktreeName = ((branch ?? commitish).startsWith(branchPrefix)
 			? (branch ?? commitish).substring(branchPrefix.length)
 			: (branch ?? commitish)
-		).split('/').pop() || (branch ?? commitish);
+		).split('-').pop() || (branch ?? commitish);
 
 		// If user selects folder button, they manually select the worktree path through folder picker
 		const getWorktreePath = async (): Promise<string | undefined> => {

--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -3452,9 +3452,8 @@ export class CommandCenter {
 		}
 
 		const worktreeName = ((branch ?? commitish).startsWith(branchPrefix)
-			? (branch ?? commitish).substring(branchPrefix.length)
-			: (branch ?? commitish)
-		).replace(/\//g, '-');
+			? (branch ?? commitish).substring(branchPrefix.length).replace(/\//g, '-')
+			: (branch ?? commitish).replace(/\//g, '-'));
 
 		// If user selects folder button, they manually select the worktree path through folder picker
 		const getWorktreePath = async (): Promise<string | undefined> => {

--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -3400,7 +3400,6 @@ export class CommandCenter {
 
 	private async _createWorktree(repository: Repository): Promise<void> {
 		const config = workspace.getConfiguration('git');
-		const branchPrefix = config.get<string>('branchPrefix')!;
 		const showRefDetails = config.get<boolean>('showReferenceDetails') === true;
 
 		const createBranch = new CreateBranchItem();
@@ -3451,9 +3450,8 @@ export class CommandCenter {
 			commitish = choice.refName;
 		}
 
-
-		const worktreeName = (branch ?? commitish).startsWith(branchPrefix)
-			? (branch ?? commitish).substring(branchPrefix.length)
+		const worktreeName = (branch ?? commitish).includes('/')
+			? (branch ?? commitish).substring((branch ?? commitish).lastIndexOf('/') + 1)
 			: (branch ?? commitish);
 
 		// If user selects folder button, they manually select the worktree path through folder picker


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
Fixes https://github.com/microsoft/vscode/issues/258623#issue-3274659521

The default worktree name will be the branch name with the user's branch prefix removed. If there are still '/', then replace with '-' to prevent nested worktree paths. 