### PR TITLE
fix: preserve OAuth subpaths in endpoint construction per RFC 8414

### DIFF
--- a/src/vs/base/common/oauth.ts
+++ b/src/vs/base/common/oauth.ts
@@ -693,11 +693,15 @@ export function isAuthorizationRegistrationErrorResponse(obj: unknown): obj is I
 //#endregion
 
 export function getDefaultMetadataForUrl(authorizationServer: URL): IAuthorizationServerMetadata {
+	// Preserve existing path when constructing endpoints per RFC 8414 Section 3
+	// https://datatracker.ietf.org/doc/html/rfc8414#section-3
+	const basePath = authorizationServer.pathname.endsWith('/') ? authorizationServer.pathname : authorizationServer.pathname + '/';
+
 	return {
 		issuer: authorizationServer.toString(),
-		authorization_endpoint: new URL('/authorize', authorizationServer).toString(),
-		token_endpoint: new URL('/token', authorizationServer).toString(),
-		registration_endpoint: new URL('/register', authorizationServer).toString(),
+		authorization_endpoint: new URL(basePath + 'authorize', authorizationServer.origin).toString(),
+		token_endpoint: new URL(basePath + 'token', authorizationServer.origin).toString(),
+		registration_endpoint: new URL(basePath + 'register', authorizationServer.origin).toString(),
 		// Default values for Dynamic OpenID Providers
 		// https://openid.net/specs/openid-connect-discovery-1_0.html
 		response_types_supported: ['code', 'id_token', 'id_token token'],

--- a/src/vs/base/test/common/oauth.test.ts
+++ b/src/vs/base/test/common/oauth.test.ts
@@ -188,6 +188,28 @@ suite('OAuth', () => {
 			assert.strictEqual(metadata.registration_endpoint, 'https://auth.example.com/register');
 			assert.deepStrictEqual(metadata.response_types_supported, ['code', 'id_token', 'id_token token']);
 		});
+
+		test('getDefaultMetadataForUrl should preserve subpaths', () => {
+			const authorizationServer = new URL('https://api.example.com/oauth/server');
+			const metadata = getDefaultMetadataForUrl(authorizationServer);
+
+			assert.strictEqual(metadata.issuer, 'https://api.example.com/oauth/server');
+			assert.strictEqual(metadata.authorization_endpoint, 'https://api.example.com/oauth/server/authorize');
+			assert.strictEqual(metadata.token_endpoint, 'https://api.example.com/oauth/server/token');
+			assert.strictEqual(metadata.registration_endpoint, 'https://api.example.com/oauth/server/register');
+			assert.deepStrictEqual(metadata.response_types_supported, ['code', 'id_token', 'id_token token']);
+		});
+
+		test('getDefaultMetadataForUrl should handle subpaths with trailing slash', () => {
+			const authorizationServer = new URL('https://api.example.com/oauth/server/');
+			const metadata = getDefaultMetadataForUrl(authorizationServer);
+
+			assert.strictEqual(metadata.issuer, 'https://api.example.com/oauth/server/');
+			assert.strictEqual(metadata.authorization_endpoint, 'https://api.example.com/oauth/server/authorize');
+			assert.strictEqual(metadata.token_endpoint, 'https://api.example.com/oauth/server/token');
+			assert.strictEqual(metadata.registration_endpoint, 'https://api.example.com/oauth/server/register');
+			assert.deepStrictEqual(metadata.response_types_supported, ['code', 'id_token', 'id_token token']);
+		});
 	});
 
 	suite('Parsing Functions', () => {


### PR DESCRIPTION
Dev from https://smithery.ai here 👋! We noticed a bug when testing our server's OAuth flow where subpaths were being dropped when creating OAuth endpoints. This PR fixes `getDefaultMetadataForUrl` to preserve them per rfc 8414 section 3: https://datatracker.ietf.org/doc/html/rfc8414#section-3

Authorization servers supporting metadata MUST make a JSON document containing metadata as specified in Section 2 available at a path formed by inserting a well-known URI string into the authorization server's issuer identifier between the host component and the path component, if any. By default, the well-known URI string used is "/.well-known/oauth-authorization-server". This path MUST use the "https" scheme. The syntax and semantics of ".well-known" are defined in RFC 5785 [RFC5785]. The well-known URI suffix used MUST be registered in the IANA "Well-Known URIs" registry [IANA.well-known].

## Issue

See https://github.com/microsoft/vscode/issues/258845

OAuth servers hosted at subpaths (e.g., `https://api.example.com/oauth/server`) were having their paths dropped:

```typescript
// Before (broken)
Input: https://api.example.com/oauth/server
Output: https://api.example.com/authorize 

// After (fixed)  
Input: https://api.example.com/oauth/server
Output: https://api.example.com/oauth/server/authorize 
```

## Changes

- Preserve existing paths in `getDefaultMetadataForUrl`
- Add RFC 8414 reference

Fixes the same issue as [modelcontextprotocol/typescript-sdk#687](https://github.com/modelcontextprotocol/typescript-sdk/pull/687).

See tests in `src/vs/base/test/common/oauth.test.ts`