### PR TITLE
Handle worktree errors

### DIFF
--- a/extensions/git/src/api/git.d.ts
+++ b/extensions/git/src/api/git.d.ts
@@ -442,5 +442,6 @@ export const enum GitErrorCodes {
 	CherryPickEmpty = 'CherryPickEmpty',
 	CherryPickConflict = 'CherryPickConflict',
 	WorktreeContainsChanges = 'WorktreeContainsChanges',
-	WorktreeAlreadyExists = 'WorktreeAlreadyExists'
+	WorktreeAlreadyExists = 'WorktreeAlreadyExists',
+	WorktreeBranchAlreadyUsed = 'WorktreeBranchAlreadyUsed'
 }

--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -3525,7 +3525,7 @@ export class CommandCenter {
 		};
 
 		const getValidationMessage = (value: string): InputBoxValidationMessage | undefined => {
-			const worktree = repository.worktrees.find(worktree => pathEquals(worktree.path, value));
+			const worktree = repository.worktrees.find(worktree => pathEquals(path.normalize(worktree.path), path.normalize(value)));
 			return worktree ? {
 				message: l10n.t('A worktree already exists at "{0}".', value),
 				severity: InputBoxValidationSeverity.Warning

--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -3442,16 +3442,6 @@ export class CommandCenter {
 				return;
 			}
 
-			// If the worktree is locked, we prompt to create a new branch
-			// otherwise we can use the existing selected branch or tag
-			const isWorktreeLocked = await this.isWorktreeLocked(repository, choice);
-			if (isWorktreeLocked) {
-				branch = await this.promptForBranchName(repository);
-
-				if (!branch) {
-					return;
-				}
-			}
 			commitish = choice.refName;
 		}
 
@@ -3546,23 +3536,8 @@ export class CommandCenter {
 		}
 	}
 
-	// If the user picks a branch that is present in any of the worktrees or the current branch, return true
-	// Otherwise, return false.
-	private async isWorktreeLocked(repository: Repository, choice: RefItem): Promise<boolean> {
-		if (!choice.refName) {
-			return false;
-		}
-
-		const worktrees = await repository.getWorktrees();
-
-		const isInWorktree = worktrees.some(worktree => worktree.ref === `refs/heads/${choice.refName}`);
-		const isCurrentBranch = repository.HEAD?.name === choice.refName;
-
-		return isInWorktree || isCurrentBranch;
-	}
-
 	private async handleWorktreeError(err: any): Promise<void> {
-		const match = err.stderr.match(/^fatal: '([^']+)' is already used by worktree at '([^']+)'/);
+		const match = err.stderr.match(/fatal: '([^']+)' is already used by worktree at '([^']+)'/);
 		if (!match) {
 			return;
 		}

--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -351,10 +351,11 @@ function getGitErrorCode(stderr: string): string | undefined {
 		return GitErrorCodes.NotASafeGitRepository;
 	} else if (/contains modified or untracked files|use --force to delete it/.test(stderr)) {
 		return GitErrorCodes.WorktreeContainsChanges;
-	} else if (/is already used by worktree at|already exists/.test(stderr)) {
+	} else if (/fatal: '[^']+' already exists/.test(stderr)) {
 		return GitErrorCodes.WorktreeAlreadyExists;
+	} else if (/is already used by worktree at/.test(stderr)) {
+		return GitErrorCodes.WorktreeBranchAlreadyUsed;
 	}
-
 	return undefined;
 }
 

--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -2813,7 +2813,7 @@ export class Repository {
 					result.push({
 						name: dirent.name,
 						// Remove '/.git' suffix
-						path: gitdirContent.replace(/\.git.*$/, ''),
+						path: gitdirContent.replace(/\/.git.*$/, ''),
 						// Remove 'ref: ' prefix
 						ref: headContent.replace(/^ref: /, ''),
 					});


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
Fixes https://github.com/microsoft/vscode/issues/258557#event-18883432995 and https://github.com/microsoft/vscode/issues/258619#event-18884722720

This PR handles 2 separate kinds of worktree errors: (1) when a user wants to create a worktree at a path where a worktree already exists and (2) if a user attempts to check out a branch that already has a worktree. 
<img width="1095" height="407" alt="image" src="https://github.com/user-attachments/assets/8d2ba751-c1fc-4bb7-80a8-40e8e03096d1" />

Shows:
1) Checking out branch that is currently used by worktree
2) Creating worktree at a path where a worktree already exists
3) Checking out a branch that already has a worktree
4) Creating a worktree by checking out a branch you're currently on 

https://github.com/user-attachments/assets/26cf37b9-efb1-4516-a65a-39763652bfab

