### PR TITLE
Display "Manage Dynamic Auth Providers" in Account menu

### DIFF
--- a/src/vs/workbench/browser/parts/globalCompositeBar.ts
+++ b/src/vs/workbench/browser/parts/globalCompositeBar.ts
@@ -427,6 +427,15 @@ export class AccountsActivityActionViewItem extends AbstractGlobalActivityAction
 			for (const providerId of dynamicProviders) {
 				const provider = this.authenticationService.getProvider(providerId);
 				const accounts = this.groupedAccounts.get(providerId);
+				// Provide _some_ discoverable way to manage dynamic authentication providers.
+				// This will either show up inside the account submenu or as a top-level menu item if there
+				// are no accounts.
+				const manageDynamicAuthProvidersAction = toAction({
+					id: 'manageDynamicAuthProviders',
+					label: localize('manageDynamicAuthProviders', "Manage Dynamic Authentication Providers..."),
+					enabled: true,
+					run: () => this.commandService.executeCommand('workbench.action.removeDynamicAuthenticationProviders')
+				});
 				if (!accounts) {
 					if (this.problematicProviders.has(providerId)) {
 						const providerUnavailableAction = disposables.add(new Action('providerUnavailable', localize('authProviderUnavailable', '{0} is currently unavailable', provider.label), undefined, false));
@@ -438,6 +447,7 @@ export class AccountsActivityActionViewItem extends AbstractGlobalActivityAction
 							this.logService.error(e);
 						}
 					}
+					menus.push(manageDynamicAuthProvidersAction);
 					continue;
 				}
 
@@ -458,6 +468,7 @@ export class AccountsActivityActionViewItem extends AbstractGlobalActivityAction
 						run: () => this.commandService.executeCommand('_manageTrustedMCPServersForAccount', { providerId, accountLabel: account.label })
 					});
 					providerSubMenuActions.push(manageMCPAction);
+					providerSubMenuActions.push(manageDynamicAuthProvidersAction);
 					if (account.canSignOut) {
 						providerSubMenuActions.push(toAction({
 							id: 'signOut',


### PR DESCRIPTION
This seems like the best place for now. It either is shown:
* Under an account if one is available
* Top level if there are no accounts

Fixes https://github.com/microsoft/vscode/issues/258523

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
