### PR TITLE
Fix --commit-id flag for code serve-web

### DIFF
--- a/cli/src/commands/serve_web.rs
+++ b/cli/src/commands/serve_web.rs
@@ -91,6 +91,12 @@ pub async fn serve_web(ctx: CommandContext, mut args: ServeWebArgs) -> Result<i3
 	if args.commit_id.is_none() {
 		cm.clone()
 			.start_update_checker(Duration::from_secs(update_check_interval));
+	} else {
+		// If a commit was provided, invoke get_latest_release() once to ensure we're using that exact version;
+		// get_latest_release() will short-circuit to args.commit_id.
+		if let Err(e) = cm.clone().get_latest_release().await {
+			warning!(cm.log, "error getting latest version: {}", e);
+		}
 	}
 
 	let key = get_server_key_half(&ctx.paths);

--- a/cli/src/commands/serve_web.rs
+++ b/cli/src/commands/serve_web.rs
@@ -94,7 +94,7 @@ pub async fn serve_web(ctx: CommandContext, mut args: ServeWebArgs) -> Result<i3
 	} else {
 		// If a commit was provided, invoke get_latest_release() once to ensure we're using that exact version;
 		// get_latest_release() will short-circuit to args.commit_id.
-		if let Err(e) = cm.clone().get_latest_release().await {
+		if let Err(e) = cm.get_latest_release().await {
 			warning!(cm.log, "error getting latest version: {}", e);
 		}
 	}


### PR DESCRIPTION
Fixes a bug where passing --commit-id during `code serve-web` would prevent serve-web from downloading a new version of the client at all.

See [this comment](https://github.com/microsoft/vscode/issues/255218#issuecomment-3137695656) from #255218 for additional context.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
