### PR TITLE
Avoid ctrl+c when no shell integration is active

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/executeStrategy/noneExecuteStrategy.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/executeStrategy/noneExecuteStrategy.ts
@@ -56,8 +56,11 @@ export class NoneExecuteStrategy implements ITerminalExecuteStrategy {
 			}));
 
 			// Execute the command
+			// IMPORTANT: This uses `sendText` not `runCommand` since when no shell integration
+			// is used as sending ctrl+c before a shell is initialized (eg. PSReadLine) can result
+			// in failure (https://github.com/microsoft/vscode/issues/258989)
 			this._log(`Executing command line \`${commandLine}\``);
-			this._instance.runCommand(commandLine, true);
+			this._instance.sendText(commandLine, true);
 
 			// Assume the command is done when it's idle
 			this._log('Waiting for idle');


### PR DESCRIPTION
Fixes #258989
