### PR TITLE
Fix remote and multi-root issues with task tools

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/task/taskHelpers.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/task/taskHelpers.ts
@@ -38,12 +38,10 @@ export async function getTaskForTool(id: string | undefined, taskDefinition: { t
 	let task: IConfiguredTask | undefined;
 	const workspaceFolderToTaskMap = await taskService.getWorkspaceTasks();
 	let configTasks: IConfiguredTask[] = [];
-	if (workspaceFolderToTaskMap) {
-		for (const folder of workspaceFolderToTaskMap.keys()) {
-			const tasksConfig = configurationService.getValue('tasks', { resource: URI.parse(folder) }) as { tasks: IConfiguredTask[] } | undefined;
-			if (tasksConfig?.tasks) {
-				configTasks = configTasks.concat(tasksConfig.tasks);
-			}
+	for (const folder of workspaceFolderToTaskMap.keys()) {
+		const tasksConfig = configurationService.getValue('tasks', { resource: URI.parse(folder) }) as { tasks: IConfiguredTask[] } | undefined;
+		if (tasksConfig?.tasks) {
+			configTasks = configTasks.concat(tasksConfig.tasks);
 		}
 	}
 	for (const configTask of configTasks) {


### PR DESCRIPTION
1) Task tools weren't working for remotes

It can take longer in a remote window for the tasks service to update after a config change, such as when a task is added to the `tasks.json`. Before, we had a static timeout of 200 ms. Now, we poll for up to 5 seconds to wait for the task to be discovered. 

The key for tasks in a remote window is different from the local case, so we have to parse the URI to check for the workspace folder 
<img width="657" height="66" alt="Screenshot 2025-07-31 at 11 39 44 AM" src="https://github.com/user-attachments/assets/53d4fd36-c2e7-42f3-b3a4-f31320467fb1" />
<img width="790" height="267" alt="Screenshot 2025-07-31 at 11 37 30 AM" src="https://github.com/user-attachments/assets/40aaa740-77cc-4c77-9194-95e42f1fffec" />

2) Task tools weren't working for mult-root repos, just needed to loop over all folders to find task config

fixes #258720
fixes #258723
fixes https://github.com/microsoft/vscode/issues/259014