### PR TITLE
Add `.slnx` to `xml` language extension list

### DIFF
--- a/extensions/xml/package.json
+++ b/extensions/xml/package.json
@@ -54,6 +54,7 @@
           ".rng",
           ".rss",
           ".shproj",
+          ".slnx",
           ".storyboard",
           ".svg",
           ".targets",


### PR DESCRIPTION
`slnx` is a [new xml-based solution file format](https://devblogs.microsoft.com/dotnet/introducing-slnx-support-dotnet-cli/) for Visual Studio. Added `.slnx` to list of known xml extensions, so VS Code can easily pick it up