### PR TITLE
Allow the canonical package name and version to be sent back from the install flow

### DIFF
--- a/src/vs/workbench/contrib/mcp/browser/mcpCommandsAddConfiguration.ts
+++ b/src/vs/workbench/contrib/mcp/browser/mcpCommandsAddConfiguration.ts
@@ -85,7 +85,9 @@ const enum AddConfigurationCopilotCommand {
 	StartFlow = 'github.copilot.chat.mcp.setup.flow',
 }
 
-type ValidatePackageResult = { state: 'ok'; publisher: string } | { state: 'error'; error: string };
+type ValidatePackageResult =
+	{ state: 'ok'; publisher: string; name?: string; version?: string }
+	| { state: 'error'; error: string };
 
 type AddServerData = {
 	packageType: string;
@@ -319,7 +321,11 @@ export class McpAddConfigurationCommand {
 				loadingQuickPick.title = result?.error || 'Unknown error loading package';
 				loadingQuickPick.items = [{ id: LoadAction.Retry, label: localize('mcp.error.retry', 'Try a different package') }, { id: LoadAction.Cancel, label: localize('cancel', 'Cancel') }];
 			} else {
-				loadingQuickPick.title = localize('mcp.confirmPublish', 'Install {0} from {1}?', packageName, result.publisher);
+				loadingQuickPick.title = localize(
+					'mcp.confirmPublish', 'Install {0}{1} from {2}?',
+					result.name ?? packageName,
+					result.version ? `@${result.version}` : '',
+					result.publisher);
 				loadingQuickPick.items = [
 					{ id: LoadAction.Allow, label: localize('allow', "Allow") },
 					{ id: LoadAction.Cancel, label: localize('cancel', 'Cancel') }


### PR DESCRIPTION
Related to https://github.com/microsoft/vscode-copilot-chat/pull/420.

If available, the package `name` and `version` will be used to improve the UI asking the user to consent installation. For example, if the user typed `nuget.mcp.server` for installing a NuGet MCP server, it will show `Install NuGet.Mcp.Server@0.1.2-preview from microsoft, NuGet?`.