### PR TITLE
Important fix for resource validation in MCP

### DIFF
--- a/src/vs/base/common/oauth.ts
+++ b/src/vs/base/common/oauth.ts
@@ -819,35 +819,3 @@ export function getClaimsFromJWT(token: string): IAuthorizationJWTClaims {
 		throw new Error('Failed to parse JWT token');
 	}
 }
-
-/**
- * Extracts the resource server base URL from an OAuth protected resource metadata discovery endpoint URL.
- *
- * @param discoveryUrl The full URL to the OAuth protected resource metadata discovery endpoint
- * @returns The base URL of the resource server
- *
- * @example
- * ```typescript
- * getResourceServerBaseUrlFromDiscoveryUrl('https://mcp.example.com/.well-known/oauth-protected-resource')
- * // Returns: 'https://mcp.example.com/'
- *
- * getResourceServerBaseUrlFromDiscoveryUrl('https://mcp.example.com/.well-known/oauth-protected-resource/mcp')
- * // Returns: 'https://mcp.example.com/mcp'
- * ```
- */
-export function getResourceServerBaseUrlFromDiscoveryUrl(discoveryUrl: string): string {
-	const url = new URL(discoveryUrl);
-
-	// Remove the well-known discovery path only if it appears at the beginning
-	if (!url.pathname.startsWith(AUTH_PROTECTED_RESOURCE_METADATA_DISCOVERY_PATH)) {
-		throw new Error(`Invalid discovery URL: expected path to start with ${AUTH_PROTECTED_RESOURCE_METADATA_DISCOVERY_PATH}`);
-	}
-
-	const pathWithoutDiscovery = url.pathname.substring(AUTH_PROTECTED_RESOURCE_METADATA_DISCOVERY_PATH.length);
-
-	// Construct the base URL
-	const baseUrl = new URL(url.origin);
-	baseUrl.pathname = pathWithoutDiscovery || '/';
-
-	return baseUrl.toString();
-}

--- a/src/vs/base/test/common/oauth.test.ts
+++ b/src/vs/base/test/common/oauth.test.ts
@@ -8,7 +8,6 @@ import * as sinon from 'sinon';
 import {
 	getClaimsFromJWT,
 	getDefaultMetadataForUrl,
-	getResourceServerBaseUrlFromDiscoveryUrl,
 	isAuthorizationAuthorizeResponse,
 	isAuthorizationDeviceResponse,
 	isAuthorizationErrorResponse,
@@ -622,106 +621,6 @@ suite('OAuth', () => {
 				async () => await fetchDynamicRegistration(serverMetadata, 'Test Client'),
 				/Text parsing failed/
 			);
-		});
-	});
-
-	suite('getResourceServerBaseUrlFromDiscoveryUrl', () => {
-		test('should extract base URL from discovery URL at root', () => {
-			const discoveryUrl = 'https://mcp.example.com/.well-known/oauth-protected-resource';
-			const result = getResourceServerBaseUrlFromDiscoveryUrl(discoveryUrl);
-			assert.strictEqual(result, 'https://mcp.example.com/');
-		});
-
-		test('should extract base URL from discovery URL with subpath', () => {
-			const discoveryUrl = 'https://mcp.example.com/.well-known/oauth-protected-resource/mcp';
-			const result = getResourceServerBaseUrlFromDiscoveryUrl(discoveryUrl);
-			assert.strictEqual(result, 'https://mcp.example.com/mcp');
-		});
-
-		test('should extract base URL from discovery URL with nested subpath', () => {
-			const discoveryUrl = 'https://api.example.com/.well-known/oauth-protected-resource/v1/services/mcp';
-			const result = getResourceServerBaseUrlFromDiscoveryUrl(discoveryUrl);
-			assert.strictEqual(result, 'https://api.example.com/v1/services/mcp');
-		});
-
-		test('should handle discovery URL with port number', () => {
-			const discoveryUrl = 'https://localhost:8443/.well-known/oauth-protected-resource/api';
-			const result = getResourceServerBaseUrlFromDiscoveryUrl(discoveryUrl);
-			assert.strictEqual(result, 'https://localhost:8443/api');
-		});
-
-		test('should handle discovery URL with query parameters', () => {
-			const discoveryUrl = 'https://example.com/.well-known/oauth-protected-resource/api?version=1';
-			const result = getResourceServerBaseUrlFromDiscoveryUrl(discoveryUrl);
-			assert.strictEqual(result, 'https://example.com/api');
-		});
-
-		test('should handle discovery URL with fragment', () => {
-			const discoveryUrl = 'https://example.com/.well-known/oauth-protected-resource/api#section';
-			const result = getResourceServerBaseUrlFromDiscoveryUrl(discoveryUrl);
-			assert.strictEqual(result, 'https://example.com/api');
-		});
-
-		test('should handle discovery URL ending with trailing slash', () => {
-			const discoveryUrl = 'https://example.com/.well-known/oauth-protected-resource/api/';
-			const result = getResourceServerBaseUrlFromDiscoveryUrl(discoveryUrl);
-			assert.strictEqual(result, 'https://example.com/api/');
-		});
-
-		test('should handle HTTP URLs', () => {
-			const discoveryUrl = 'http://localhost:3000/.well-known/oauth-protected-resource/dev';
-			const result = getResourceServerBaseUrlFromDiscoveryUrl(discoveryUrl);
-			assert.strictEqual(result, 'http://localhost:3000/dev');
-		});
-
-		test('should throw error for URL without discovery path', () => {
-			const discoveryUrl = 'https://example.com/some/other/path';
-			assert.throws(
-				() => getResourceServerBaseUrlFromDiscoveryUrl(discoveryUrl),
-				/Invalid discovery URL: expected path to start with \/\.well-known\/oauth-protected-resource/
-			);
-		});
-
-		test('should throw error for URL with partial discovery path', () => {
-			const discoveryUrl = 'https://example.com/.well-known/oauth';
-			assert.throws(
-				() => getResourceServerBaseUrlFromDiscoveryUrl(discoveryUrl),
-				/Invalid discovery URL: expected path to start with \/\.well-known\/oauth-protected-resource/
-			);
-		});
-
-		test('should throw error for URL with discovery path not at beginning', () => {
-			const discoveryUrl = 'https://example.com/api/.well-known/oauth-protected-resource';
-			assert.throws(
-				() => getResourceServerBaseUrlFromDiscoveryUrl(discoveryUrl),
-				/Invalid discovery URL: expected path to start with \/\.well-known\/oauth-protected-resource/
-			);
-		});
-
-		test('should throw error for invalid URL format', () => {
-			const discoveryUrl = 'not-a-valid-url';
-			assert.throws(
-				() => getResourceServerBaseUrlFromDiscoveryUrl(discoveryUrl),
-				TypeError
-			);
-		});
-
-		test('should handle empty path after discovery path', () => {
-			const discoveryUrl = 'https://example.com/.well-known/oauth-protected-resource';
-			const result = getResourceServerBaseUrlFromDiscoveryUrl(discoveryUrl);
-			assert.strictEqual(result, 'https://example.com/');
-		});
-
-		test('should preserve URL encoding in subpath', () => {
-			const discoveryUrl = 'https://example.com/.well-known/oauth-protected-resource/api%20v1';
-			const result = getResourceServerBaseUrlFromDiscoveryUrl(discoveryUrl);
-			assert.strictEqual(result, 'https://example.com/api%20v1');
-		});
-
-		test('should normalize hostname case consistently', () => {
-			const discoveryUrl = 'https://MCP.EXAMPLE.COM/.well-known/oauth-protected-resource';
-			const result = getResourceServerBaseUrlFromDiscoveryUrl(discoveryUrl);
-			assert.strictEqual(result, 'https://mcp.example.com/');
 		});
 	});
 


### PR DESCRIPTION
In this example:

MCP url: https://foo.com/mcp
WWW-Auth resource_metadata: https://foo.com/laugh/in/the/face/of/conventions.json
PRM: https://foo.com/laugh/in/the/face/of/conventions.json
PRM resource property: https://foo.com/mcp

I use to do:
a URL derived from "WWW-Auth resource_metadata" (which is actually just PRM) is compared to "PRM resource property"

but instead it should be:

"MCP url" compared to "PRM resource property"

Which is what this PR addresses

ref https://datatracker.ietf.org/doc/html/rfc9728#section-3.3

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
