### PR TITLE
fix typo

### DIFF
--- a/src/vs/workbench/contrib/chat/common/languageModels.ts
+++ b/src/vs/workbench/contrib/chat/common/languageModels.ts
@@ -432,7 +432,7 @@ export class LanguageModelsService implements ILanguageModelsService {
 
 		if (selector.vendor) {
 			// selective activation
-			await this._extensionService.activateByEvent(`onLanguageModelChat:${selector.vendor}}`);
+			await this._extensionService.activateByEvent(`onLanguageModelChat:${selector.vendor}`);
 			await this.resolveLanguageModels([selector.vendor], !allowPromptingUser);
 		} else {
 			// activate all extensions that do language models


### PR DESCRIPTION
There is an extra closing curly brace, causing the extension to fail to be activated correctly.

https://github.com/microsoft/vscode/blob/9df0b59e5ca6306647e032c091d760ab54bfa344/src/vs/workbench/contrib/chat/common/languageModels.ts#L435