### PR TITLE
use URI equals to compare paths

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/task/taskHelpers.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/task/taskHelpers.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { IStringDictionary } from '../../../../../../base/common/collections.js';
+import { isEqual } from '../../../../../../base/common/resources.js';
 import { URI } from '../../../../../../base/common/uri.js';
 import { IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
 import { ConfiguringTask, Task } from '../../../../tasks/common/tasks.js';
@@ -66,7 +67,8 @@ export async function getTaskForTool(id: string | undefined, taskDefinition: { t
 
 	let tasksForWorkspace;
 	for (const [folder, tasks] of workspaceFolderToTaskMap) {
-		if (URI.parse(folder).path === workspaceFolder) {
+		// Use isEqual to compare URIs for cross-platform compatibility
+		if (isEqual(URI.parse(folder), URI.file(workspaceFolder))) {
 			tasksForWorkspace = tasks;
 			break;
 		}


### PR DESCRIPTION
fix #259014

Debugging with @DonJayamanne (bc away from my windows machine) confirmed this suspected fix works

<img width="590" height="273" alt="Screenshot 2025-07-31 at 10 22 39 PM" src="https://github.com/user-attachments/assets/bdda402a-e396-419e-bd19-2abb94f9e5d3" />
<img width="411" height="203" alt="Screenshot 2025-07-31 at 10 22 13 PM" src="https://github.com/user-attachments/assets/5fcba7f8-52e8-4043-9a5e-09a990650b42" />
