### PR TITLE
Use platform agnostic URI comparison for task resolution

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/task/taskHelpers.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/task/taskHelpers.ts
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { IStringDictionary } from '../../../../../../base/common/collections.js';
-import { isEqual } from '../../../../../../base/common/resources.js';
 import { URI } from '../../../../../../base/common/uri.js';
 import { IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
 import { ConfiguringTask, Task } from '../../../../tasks/common/tasks.js';
@@ -67,8 +66,7 @@ export async function getTaskForTool(id: string | undefined, taskDefinition: { t
 
 	let tasksForWorkspace;
 	for (const [folder, tasks] of workspaceFolderToTaskMap) {
-		// Use isEqual to compare URIs for cross-platform compatibility
-		if (isEqual(URI.parse(folder), URI.file(workspaceFolder))) {
+		if (URI.parse(folder).path === URI.parse(workspaceFolder).path) {
 			tasksForWorkspace = tasks;
 			break;
 		}


### PR DESCRIPTION
addresses #259213 in main

I learned from @Tyriar that `path` always uses `/`