### PR TITLE
api: generalize ToolResultAudience->LanguageModelTextPart

### DIFF
--- a/src/vs/workbench/api/common/extHost.api.impl.ts
+++ b/src/vs/workbench/api/common/extHost.api.impl.ts
@@ -1876,7 +1876,8 @@ export function createApiFactoryAndRegisterActors(accessor: ServicesAccessor): I
 			LanguageModelToolResultPart2: extHostTypes.LanguageModelToolResultPart2,
 			LanguageModelTextPart: extHostTypes.LanguageModelTextPart,
 			LanguageModelTextPart2: extHostTypes.LanguageModelTextPart,
-			ToolResultAudience: extHostTypes.ToolResultAudience,
+			LanguageModelPartAudience: extHostTypes.LanguageModelPartAudience,
+			ToolResultAudience: extHostTypes.LanguageModelPartAudience, // back compat
 			LanguageModelToolCallPart: extHostTypes.LanguageModelToolCallPart,
 			LanguageModelError: extHostTypes.LanguageModelError,
 			LanguageModelToolResult: extHostTypes.LanguageModelToolResult,

--- a/src/vs/workbench/api/common/extHostTypes.ts
+++ b/src/vs/workbench/api/common/extHostTypes.ts
@@ -5024,16 +5024,17 @@ export class LanguageModelToolCallPart implements vscode.LanguageModelToolCallPa
 	}
 }
 
-export enum ToolResultAudience {
+export enum LanguageModelPartAudience {
 	Assistant = 0,
 	User = 1,
+	Extension = 2,
 }
 
 export class LanguageModelTextPart implements vscode.LanguageModelTextPart2 {
 	value: string;
-	audience: vscode.ToolResultAudience[] | undefined;
+	audience: vscode.LanguageModelPartAudience[] | undefined;
 
-	constructor(value: string, audience?: vscode.ToolResultAudience[]) {
+	constructor(value: string, audience?: vscode.LanguageModelPartAudience[]) {
 		this.value = value;
 		audience = audience;
 	}
@@ -5050,9 +5051,9 @@ export class LanguageModelTextPart implements vscode.LanguageModelTextPart2 {
 export class LanguageModelDataPart implements vscode.LanguageModelDataPart2 {
 	mimeType: string;
 	data: Uint8Array<ArrayBufferLike>;
-	audience: vscode.ToolResultAudience[] | undefined;
+	audience: vscode.LanguageModelPartAudience[] | undefined;
 
-	constructor(data: Uint8Array<ArrayBufferLike>, mimeType: string, audience?: vscode.ToolResultAudience[]) {
+	constructor(data: Uint8Array<ArrayBufferLike>, mimeType: string, audience?: vscode.LanguageModelPartAudience[]) {
 		this.mimeType = mimeType;
 		this.data = data;
 		this.audience = audience;

--- a/src/vs/workbench/contrib/chat/common/languageModelToolsService.ts
+++ b/src/vs/workbench/contrib/chat/common/languageModelToolsService.ts
@@ -22,7 +22,7 @@ import { VSBuffer } from '../../../../base/common/buffer.js';
 import { derived, IObservable, IReader, ITransaction, ObservableSet } from '../../../../base/common/observable.js';
 import { Iterable } from '../../../../base/common/iterator.js';
 import { localize } from '../../../../nls.js';
-import { ToolResultAudience } from './languageModels.js';
+import { LanguageModelPartAudience } from './languageModels.js';
 
 export interface IToolData {
 	id: string;
@@ -192,7 +192,7 @@ export function stringifyPromptTsxPart(part: IToolResultPromptTsxPart): string {
 export interface IToolResultTextPart {
 	kind: 'text';
 	value: string;
-	audience?: ToolResultAudience[];
+	audience?: LanguageModelPartAudience[];
 }
 
 export interface IToolResultDataPart {
@@ -201,7 +201,7 @@ export interface IToolResultDataPart {
 		mimeType: string;
 		data: VSBuffer;
 	};
-	audience?: ToolResultAudience[];
+	audience?: LanguageModelPartAudience[];
 }
 
 export interface IToolConfirmationMessages {

--- a/src/vs/workbench/contrib/chat/common/languageModels.ts
+++ b/src/vs/workbench/contrib/chat/common/languageModels.ts
@@ -27,15 +27,16 @@ export const enum ChatMessageRole {
 	Assistant,
 }
 
-export enum ToolResultAudience {
+export enum LanguageModelPartAudience {
 	Assistant = 0,
 	User = 1,
+	Extension = 2,
 }
 
 export interface IChatMessageTextPart {
 	type: 'text';
 	value: string;
-	audience?: ToolResultAudience[];
+	audience?: LanguageModelPartAudience[];
 }
 
 export interface IChatMessageImagePart {
@@ -47,7 +48,7 @@ export interface IChatMessageDataPart {
 	type: 'data';
 	mimeType: string;
 	data: VSBuffer;
-	audience?: ToolResultAudience[];
+	audience?: LanguageModelPartAudience[];
 }
 
 export interface IChatImageURLPart {
@@ -100,7 +101,7 @@ export interface IChatMessage {
 export interface IChatResponseTextPart {
 	type: 'text';
 	value: string;
-	audience?: ToolResultAudience[];
+	audience?: LanguageModelPartAudience[];
 }
 
 export interface IChatResponsePromptTsxPart {
@@ -111,7 +112,7 @@ export interface IChatResponsePromptTsxPart {
 export interface IChatResponseDataPart {
 	type: 'data';
 	value: IChatImageURLPart;
-	audience?: ToolResultAudience[];
+	audience?: LanguageModelPartAudience[];
 }
 
 export interface IChatResponseToolUsePart {

--- a/src/vscode-dts/vscode.proposed.languageModelToolResultAudience.d.ts
+++ b/src/vscode-dts/vscode.proposed.languageModelToolResultAudience.d.ts
@@ -5,21 +5,32 @@
 
 declare module 'vscode' {
 
-	export enum ToolResultAudience {
+	export enum LanguageModelPartAudience {
+		/**
+		 * The part should be shown to the language model.
+		 */
 		Assistant = 0,
+		/**
+		 * The part should be shown to the user.
+		 */
 		User = 1,
+		/**
+		 * The part should should be retained for internal bookkeeping within
+		 * extensions.
+		 */
+		Extension = 2,
 	}
 
 	/**
 	 * A language model response part containing a piece of text, returned from a {@link LanguageModelChatResponse}.
 	 */
 	export class LanguageModelTextPart2 extends LanguageModelTextPart {
-		audience: ToolResultAudience[] | undefined;
-		constructor(value: string, audience?: ToolResultAudience[]);
+		audience: LanguageModelPartAudience[] | undefined;
+		constructor(value: string, audience?: LanguageModelPartAudience[]);
 	}
 
 	export class LanguageModelDataPart2 extends LanguageModelDataPart {
-		audience: ToolResultAudience[] | undefined;
-		constructor(data: Uint8Array, mimeType: string, audience?: ToolResultAudience[]);
+		audience: LanguageModelPartAudience[] | undefined;
+		constructor(data: Uint8Array, mimeType: string, audience?: LanguageModelPartAudience[]);
 	}
 }


### PR DESCRIPTION
- Generalize as these parts are used in chat responses as well as tool
  results.
- Add a new 'extension' type for internal-only use (we can use this to transfer response IDs over BYOK)

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
