### PR TITLE
Restore alt+left/right keybinding to switch terminal pane

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminalActions.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalActions.ts
@@ -383,8 +383,9 @@ export function registerTerminalActions() {
 				primary: KeyMod.Alt | KeyMod.CtrlCmd | KeyCode.LeftArrow,
 				secondary: [KeyMod.Alt | KeyMod.CtrlCmd | KeyCode.UpArrow]
 			},
-			when: TerminalContextKeys.focus,
-			weight: KeybindingWeight.WorkbenchContrib
+			when: ContextKeyExpr.and(TerminalContextKeys.focus, TerminalContextKeys.splitTerminalActive),
+			// Should win over send sequence commands https://github.com/microsoft/vscode/issues/259326
+			weight: KeybindingWeight.WorkbenchContrib + 1
 		},
 		precondition: sharedWhenClause.terminalAvailable,
 		run: async (c) => {
@@ -403,8 +404,9 @@ export function registerTerminalActions() {
 				primary: KeyMod.Alt | KeyMod.CtrlCmd | KeyCode.RightArrow,
 				secondary: [KeyMod.Alt | KeyMod.CtrlCmd | KeyCode.DownArrow]
 			},
-			when: TerminalContextKeys.focus,
-			weight: KeybindingWeight.WorkbenchContrib
+			when: ContextKeyExpr.and(TerminalContextKeys.focus, TerminalContextKeys.splitTerminalActive),
+			// Should win over send sequence commands https://github.com/microsoft/vscode/issues/259326
+			weight: KeybindingWeight.WorkbenchContrib + 1
 		},
 		precondition: sharedWhenClause.terminalAvailable,
 		run: async (c) => {

--- a/src/vs/workbench/contrib/terminal/browser/terminalGroupService.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalGroupService.ts
@@ -8,7 +8,7 @@ import { timeout } from '../../../../base/common/async.js';
 import { Emitter, Event } from '../../../../base/common/event.js';
 import { Disposable } from '../../../../base/common/lifecycle.js';
 import { URI } from '../../../../base/common/uri.js';
-import { IContextKey, IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
+import { IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { IShellLaunchConfig } from '../../../../platform/terminal/common/terminal.js';
 import { IViewDescriptorService } from '../../../common/views.js';
@@ -32,8 +32,6 @@ export class TerminalGroupService extends Disposable implements ITerminalGroupSe
 	}
 
 	lastAccessedMenu: 'inline-tab' | 'tab-list' = 'inline-tab';
-
-	private _terminalGroupCountContextKey: IContextKey<number>;
 
 	private _container: HTMLElement | undefined;
 
@@ -71,10 +69,16 @@ export class TerminalGroupService extends Disposable implements ITerminalGroupSe
 	) {
 		super();
 
-		this._terminalGroupCountContextKey = TerminalContextKeys.groupCount.bindTo(this._contextKeyService);
+		const terminalGroupCountContextKey = TerminalContextKeys.groupCount.bindTo(this._contextKeyService);
+		this._register(Event.runAndSubscribe(this.onDidChangeGroups, () => terminalGroupCountContextKey.set(this.groups.length)));
+
+		const splitTerminalActiveContextKey = TerminalContextKeys.splitTerminalActive.bindTo(this._contextKeyService);
+		this._register(Event.runAndSubscribe(this.onDidFocusInstance, () => {
+			const activeInstance = this.activeInstance;
+			splitTerminalActiveContextKey.set(activeInstance ? this.instanceIsSplit(activeInstance) : false);
+		}));
 
 		this._register(this.onDidDisposeGroup(group => this._removeGroup(group)));
-		this._register(this.onDidChangeGroups(() => this._terminalGroupCountContextKey.set(this.groups.length)));
 		this._register(Event.any(this.onDidChangeActiveGroup, this.onDidChangeInstances)(() => this.updateVisibility()));
 		this._register(this._quickInputService.onShow(() => this._isQuickInputOpened = true));
 		this._register(this._quickInputService.onHide(() => this._isQuickInputOpened = false));

--- a/src/vs/workbench/contrib/terminal/browser/terminalMenus.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalMenus.ts
@@ -602,7 +602,7 @@ export function setupTerminalMenus(): void {
 						id: TerminalCommandId.Unsplit,
 						title: terminalStrings.unsplit.value
 					},
-					when: ContextKeyExpr.and(TerminalContextKeys.tabsSingularSelection, TerminalContextKeys.splitTerminal),
+					when: ContextKeyExpr.and(TerminalContextKeys.tabsSingularSelection, TerminalContextKeys.splitTerminalTabFocused),
 					group: ContextMenuGroup.Config
 				}
 			},

--- a/src/vs/workbench/contrib/terminal/browser/terminalTabsList.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalTabsList.ts
@@ -193,7 +193,7 @@ export class TerminalTabList extends WorkbenchList<ITerminalInstance> {
 		}));
 
 		this._terminalTabsSingleSelectedContextKey = TerminalContextKeys.tabsSingularSelection.bindTo(contextKeyService);
-		this._isSplitContextKey = TerminalContextKeys.splitTerminal.bindTo(contextKeyService);
+		this._isSplitContextKey = TerminalContextKeys.splitTerminalTabFocused.bindTo(contextKeyService);
 
 		this.disposables.add(this.onDidChangeSelection(e => this._updateContextKey()));
 		this.disposables.add(this.onDidChangeFocus(() => this._updateContextKey()));

--- a/src/vs/workbench/contrib/terminal/common/terminalContextKey.ts
+++ b/src/vs/workbench/contrib/terminal/common/terminalContextKey.ts
@@ -36,6 +36,7 @@ export const enum TerminalContextKeyStrings {
 	FindFocused = 'terminalFindFocused',
 	TabsSingularSelection = 'terminalTabsSingularSelection',
 	SplitTerminal = 'terminalSplitTerminal',
+	SplitPaneActive = 'terminalSplitPaneActive',
 	ShellType = 'terminalShellType',
 	InTerminalRunCommandPicker = 'inTerminalRunCommandPicker',
 	TerminalShellIntegrationEnabled = 'terminalShellIntegrationEnabled',
@@ -127,7 +128,10 @@ export namespace TerminalContextKeys {
 	export const tabsSingularSelection = new RawContextKey<boolean>(TerminalContextKeyStrings.TabsSingularSelection, false, localize('terminalTabsSingularSelectedContextKey', "Whether one terminal is selected in the terminal tabs list."));
 
 	/** Whether the focused tab's terminal is a split terminal. */
-	export const splitTerminal = new RawContextKey<boolean>(TerminalContextKeyStrings.SplitTerminal, false, localize('isSplitTerminalContextKey', "Whether the focused tab's terminal is a split terminal."));
+	export const splitTerminalTabFocused = new RawContextKey<boolean>(TerminalContextKeyStrings.SplitTerminal, false, localize('isSplitTerminalContextKey', "Whether the focused tab's terminal is a split terminal."));
+
+	/** Whether the active terminal is a split pane */
+	export const splitTerminalActive = new RawContextKey<boolean>(TerminalContextKeyStrings.SplitPaneActive, false, localize('splitPaneActive', "Whether the active terminal is a split pane."));
 
 	/** Whether the terminal run command picker is currently open. */
 	export const inTerminalRunCommandPicker = new RawContextKey<boolean>(TerminalContextKeyStrings.InTerminalRunCommandPicker, false, localize('inTerminalRunCommandPickerContextKey', "Whether the terminal run command picker is currently open."));

--- a/src/vs/workbench/contrib/terminalContrib/sendSequence/browser/terminal.sendSequence.contribution.ts
+++ b/src/vs/workbench/contrib/terminalContrib/sendSequence/browser/terminal.sendSequence.contribution.ts
@@ -158,8 +158,9 @@ registerSendSequenceKeybinding('\x1b[1;2H', { // Shift+home
 });
 
 // Map alt+arrow to ctrl+arrow to allow word navigation in most shells to just work with alt. This
-// is non-standard behavior, but a lot of terminals act like this (see #190629). Note that
-// macOS uses different sequences here to get the desired behavior.
+// is non-standard behavior, but a lot of terminals act like this (see
+// https://github.com/microsoft/vscode/issues/190629). Note that macOS uses different sequences here
+// to get the desired behavior.
 registerSendSequenceKeybinding('\x1b[1;5A', {
 	when: ContextKeyExpr.and(TerminalContextKeys.focus),
 	primary: KeyMod.Alt | KeyCode.UpArrow


### PR DESCRIPTION
This was caused due to the new approach for mapping alt+arrow to ctrl using VS Code keybindings, rather than being built into xterm.js. This unfortunately meant it regressed behavior for navigating terminal panes using alt+left/right (or up/down) which is a long established keybinding. The fix was a decent size, here's what it includes:

- Changing the weight so the pane nav keybindings win out
- Adding a when clause to the pane nav keybindings so they're disabled unless you're in a split pane
- Adding a new context key since the existing one that sounds correct is specific to the _focused_ tab and is primarily there to drive the tab context menu

Fixes #259326

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
