### PR TITLE
Add performance logging and improve performance in terminal suggest

### DIFF
--- a/extensions/terminal-suggest/src/fig/figInterface.ts
+++ b/extensions/terminal-suggest/src/fig/figInterface.ts
@@ -46,6 +46,18 @@ export async function getFigSuggestions(
 		items: [],
 	};
 	const currentCommand = currentCommandAndArgString.split(' ')[0];
+
+	// Assemble a map to allow O(1) access to the available command from a spec
+	// label. The label does not include an extension on Windows.
+	const specLabelToAvailableCommandMap = new Map<string, ICompletionResource>();
+	for (const command of availableCommands) {
+		let label = typeof command.label === 'string' ? command.label : command.label.label;
+		if (osIsWindows()) {
+			label = removeAnyFileExtension(label);
+		}
+		specLabelToAvailableCommandMap.set(label, command);
+	}
+
 	for (const spec of specs) {
 		const specLabels = getFigSuggestionLabel(spec);
 
@@ -53,9 +65,7 @@ export async function getFigSuggestions(
 			continue;
 		}
 		for (const specLabel of specLabels) {
-			const availableCommand = (osIsWindows()
-				? availableCommands.find(command => (typeof command.label === 'string' ? command.label : command.label.label).match(new RegExp(`${specLabel}(\\.[^ ]+)?$`)))
-				: availableCommands.find(command => (typeof command.label === 'string' ? command.label : command.label.label) === (specLabel)));
+			const availableCommand = specLabelToAvailableCommandMap.get(specLabel);
 			if (!availableCommand || (token && token.isCancellationRequested)) {
 				continue;
 			}

--- a/extensions/terminal-suggest/src/terminalSuggestMain.ts
+++ b/extensions/terminal-suggest/src/terminalSuggestMain.ts
@@ -295,6 +295,7 @@ export async function activate(context: vscode.ExtensionContext) {
 				}
 			}
 
+
 			if (terminal.shellIntegration?.cwd && (result.filesRequested || result.foldersRequested)) {
 				return new vscode.TerminalCompletionList(result.items, {
 					filesRequested: result.filesRequested,

--- a/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalCompletionService.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalCompletionService.ts
@@ -225,8 +225,8 @@ export class TerminalCompletionService extends Disposable implements ITerminalCo
 				const resourceCompletions = await this.resolveResources(completions.resourceRequestConfig, promptValue, cursorPosition, `core:path:ext:${provider.id}`, capabilities, shellType);
 				this._logService.trace(`TerminalCompletionService#_collectCompletions dedupe`);
 				if (resourceCompletions) {
+					const labels = new Set(completionItems.map(c => c.label));
 					for (const item of resourceCompletions) {
-						const labels = new Set(completionItems.map(c => c.label));
 						// Ensure no duplicates such as .
 						if (!labels.has(item.label)) {
 							completionItems.push(item);

--- a/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalCompletionService.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalCompletionService.ts
@@ -406,7 +406,7 @@ export class TerminalCompletionService extends Disposable implements ITerminalCo
 		// - (absolute) `cd c:/src/` -> `cd c:/src/folder1/`, ...
 		// - (tilde)    `cd ~/src/`  -> `cd ~/src/folder1/`, ...
 		this._logService.trace(`TerminalCompletionService#resolveResources direct children`);
-		for (const child of stat.children) {
+		await Promise.all(stat.children.map(child => (async () => {
 			let kind: TerminalCompletionItemKind | undefined;
 			let detail: string | undefined = undefined;
 			if (foldersRequested && child.isDirectory) {
@@ -423,7 +423,7 @@ export class TerminalCompletionService extends Disposable implements ITerminalCo
 				}
 			}
 			if (kind === undefined) {
-				continue;
+				return;
 			}
 
 			let label = lastWordFolder;
@@ -443,7 +443,7 @@ export class TerminalCompletionService extends Disposable implements ITerminalCo
 			if (child.isFile && fileExtensions) {
 				const extension = child.name.split('.').length > 1 ? child.name.split('.').at(-1) : undefined;
 				if (extension && !fileExtensions.includes(extension)) {
-					continue;
+					return;
 				}
 			}
 
@@ -467,7 +467,7 @@ export class TerminalCompletionService extends Disposable implements ITerminalCo
 				replacementIndex: cursorPosition - lastWord.length,
 				replacementLength: lastWord.length
 			});
-		}
+		})()));
 
 		// Support $CDPATH specially for the `cd` command only
 		//

--- a/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalSuggestAddon.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalSuggestAddon.ts
@@ -249,6 +249,8 @@ export class SuggestAddon extends Disposable implements ITerminalAddon, ISuggest
 	}
 
 	private async _handleCompletionProviders(terminal: Terminal | undefined, token: CancellationToken, explicitlyInvoked?: boolean): Promise<void> {
+		this._logService.trace('SuggestAddon#_handleCompletionProviders');
+
 		// Nothing to handle if the terminal is not attached
 		if (!terminal?.element || !this._enableWidget || !this._promptInputModel) {
 			return;
@@ -273,6 +275,7 @@ export class SuggestAddon extends Disposable implements ITerminalAddon, ISuggest
 		}
 
 		if (!doNotRequestExtensionCompletions) {
+			this._logService.trace('SuggestAddon#_handleCompletionProviders onTerminalCompletionsRequested');
 			await this._extensionService.activateByEvent('onTerminalCompletionsRequested');
 		}
 		this._currentPromptInputState = {
@@ -295,7 +298,9 @@ export class SuggestAddon extends Disposable implements ITerminalAddon, ISuggest
 
 		const quickSuggestionsConfig = this._configurationService.getValue<ITerminalSuggestConfiguration>(terminalSuggestConfigSection).quickSuggestions;
 		const allowFallbackCompletions = explicitlyInvoked || quickSuggestionsConfig.unknown === 'on';
+		this._logService.trace('SuggestAddon#_handleCompletionProviders provideCompletions');
 		const providedCompletions = await this._terminalCompletionService.provideCompletions(this._currentPromptInputState.prefix, this._currentPromptInputState.cursorIndex, allowFallbackCompletions, this.shellType, this._capabilities, token, false, doNotRequestExtensionCompletions, explicitlyInvoked);
+		this._logService.trace('SuggestAddon#_handleCompletionProviders provideCompletions done');
 
 		if (token.isCancellationRequested) {
 			return;
@@ -388,6 +393,7 @@ export class SuggestAddon extends Disposable implements ITerminalAddon, ISuggest
 	}
 
 	async requestCompletions(explicitlyInvoked?: boolean): Promise<void> {
+		this._logService.trace('SuggestAddon#requestCompletions');
 		if (!this._promptInputModel) {
 			this._shouldSyncWhenReady = true;
 			return;
@@ -707,11 +713,15 @@ export class SuggestAddon extends Disposable implements ITerminalAddon, ISuggest
 	}
 
 	private _showCompletions(model: TerminalCompletionModel, explicitlyInvoked?: boolean): void {
+		this._logService.trace('SuggestAddon#_showCompletions');
 		if (!this._terminal?.element) {
 			return;
 		}
 		const suggestWidget = this._ensureSuggestWidget(this._terminal);
+
+		this._logService.trace('SuggestAddon#_showCompletions setCompletionModel');
 		suggestWidget.setCompletionModel(model);
+
 		this._register(suggestWidget.onDidFocus(() => this._terminal?.focus()));
 		if (!this._promptInputModel || !explicitlyInvoked && model.items.length === 0) {
 			return;
@@ -731,6 +741,7 @@ export class SuggestAddon extends Disposable implements ITerminalAddon, ISuggest
 			}
 			this._completionRequestTimestamp = undefined;
 		}
+		this._logService.trace('SuggestAddon#_showCompletions suggestWidget.showSuggestions');
 		suggestWidget.showSuggestions(0, false, !explicitlyInvoked, cursorPosition);
 	}
 

--- a/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalSuggestAddon.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalSuggestAddon.ts
@@ -356,10 +356,13 @@ export class SuggestAddon extends Disposable implements ITerminalAddon, ISuggest
 			items.push(this._inlineCompletionItem);
 		}
 
+		this._logService.trace('TerminalCompletionService#_collectCompletions create model');
 		const model = new TerminalCompletionModel(
 			items,
 			lineContext
 		);
+		this._logService.trace('TerminalCompletionService#_collectCompletions create model done');
+
 		if (token.isCancellationRequested) {
 			this._completionRequestTimestamp = undefined;
 			return;

--- a/src/vs/workbench/contrib/terminalContrib/suggest/test/browser/terminalCompletionService.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/test/browser/terminalCompletionService.test.ts
@@ -18,9 +18,9 @@ import { ShellEnvDetectionCapability } from '../../../../../../platform/terminal
 import { TerminalCapability } from '../../../../../../platform/terminal/common/capabilities/capabilities.js';
 import { ITerminalCompletion, TerminalCompletionItemKind } from '../../browser/terminalCompletionItem.js';
 import { count } from '../../../../../../base/common/strings.js';
-import { WindowsShellType } from '../../../../../../platform/terminal/common/terminal.js';
+import { ITerminalLogService, WindowsShellType } from '../../../../../../platform/terminal/common/terminal.js';
 import { gitBashToWindowsPath, windowsToGitBashPath } from '../../browser/terminalGitBashHelpers.js';
-import { ILogService, NullLogService } from '../../../../../../platform/log/common/log.js';
+import { NullLogService } from '../../../../../../platform/log/common/log.js';
 import { TerminalSuggestSettingId } from '../../common/terminalSuggestConfiguration.js';
 
 const pathSeparator = isWindows ? '\\' : '/';
@@ -107,7 +107,7 @@ suite('TerminalCompletionService', () => {
 	setup(() => {
 		instantiationService = store.add(new TestInstantiationService());
 		configurationService = new TestConfigurationService();
-		instantiationService.stub(ILogService, new NullLogService());
+		instantiationService.stub(ITerminalLogService, new NullLogService());
 		instantiationService.stub(IConfigurationService, configurationService);
 		instantiationService.stub(IFileService, {
 			async stat(resource) {


### PR DESCRIPTION
Fixes #258512

gifs don't do the best job of change, but the difference is huge. They show when the globals cache hits.

Before (~200-500ms):

![Recording 2025-08-02 at 08 15 55](https://github.com/user-attachments/assets/7f791c5b-2b1a-4ed6-8877-d5d34f911084)


After (~30-100ms):

![Recording 2025-08-02 at 08 14 55](https://github.com/user-attachments/assets/c7124d46-b75c-4ee1-9019-bd52453f63a4)

There are more improvements that can be made around the globals, but the part after the globals is pretty well optimized now:

- https://github.com/microsoft/vscode/issues/259343
- https://github.com/microsoft/vscode/issues/259342
- https://github.com/microsoft/vscode/issues/259339