### PR TITLE
Use app.dock.hide when connecting to an existing instance

### DIFF
--- a/src/vs/code/electron-main/main.ts
+++ b/src/vs/code/electron-main/main.ts
@@ -314,6 +314,11 @@ class CodeMain {
 			}
 
 			// there's a running instance, let's connect to it
+			// Hide the dock icon since we're connecting to an existing instance
+			if (app.dock) {
+				app.dock.hide();
+			}
+
 			let client: NodeIPCClient<string>;
 			try {
 				client = await nodeIPCConnect(environmentMainService.mainIPCHandle, 'main');

--- a/src/vs/code/electron-main/main.ts
+++ b/src/vs/code/electron-main/main.ts
@@ -304,6 +304,10 @@ class CodeMain {
 			mainProcessNodeIpcServer = await nodeIPCServe(environmentMainService.mainIPCHandle);
 			mark('code/didStartMainServer');
 			Event.once(lifecycleMainService.onWillShutdown)(() => mainProcessNodeIpcServer.dispose());
+			// If this instance is the only one, show the dock icon
+   if (app.dock) {
+       app.dock.show();
+   }
 		} catch (error) {
 
 			// Handle unexpected errors (the only expected error is EADDRINUSE that

--- a/src/vs/code/electron-main/main.ts
+++ b/src/vs/code/electron-main/main.ts
@@ -290,6 +290,10 @@ class CodeMain {
 	}
 
 	private async claimInstance(logService: ILogService, environmentMainService: IEnvironmentMainService, lifecycleMainService: ILifecycleMainService, instantiationService: IInstantiationService, productService: IProductService, retry: boolean): Promise<NodeIPCServer> {
+		// hide from dock immediately 
+		if (app.dock) {
+      app.dock.hide();
+  }
 
 		// Try to setup a server for running. If that succeeds it means
 		// we are the first instance to startup. Otherwise it is likely
@@ -314,10 +318,7 @@ class CodeMain {
 			}
 
 			// there's a running instance, let's connect to it
-			// Hide the dock icon since we're connecting to an existing instance
-			if (app.dock) {
-				app.dock.hide();
-			}
+			
 
 			let client: NodeIPCClient<string>;
 			try {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->


As discussed in https://github.com/microsoft/vscode/issues/258824#issuecomment-3146091562

(and previously https://github.com/microsoft/vscode/pull/131213#issuecomment-912251877)

Calls app.dock.hide() after another running instance is detected. 

@deepak1556