### PR TITLE
Don't refresh cached globals automatically 

### DIFF
--- a/extensions/terminal-suggest/package.json
+++ b/extensions/terminal-suggest/package.json
@@ -17,6 +17,15 @@
     "terminalCompletionProvider",
     "terminalShellEnv"
   ],
+  "contributes": {
+    "commands": [
+      {
+        "command": "terminal.integrated.suggest.clearCachedGlobals",
+        "category": "Terminal",
+        "title": "%terminal.integrated.suggest.clearCachedGlobals%"
+      }
+    ]
+  },
   "scripts": {
     "compile": "npx gulp compile-extension:terminal-suggest",
     "watch": "npx gulp watch-extension:terminal-suggest",

--- a/extensions/terminal-suggest/package.nls.json
+++ b/extensions/terminal-suggest/package.nls.json
@@ -1,5 +1,6 @@
 {
 	"description": "Extension to add terminal completions for zsh, bash, and fish terminals.",
 	"displayName": "Terminal Suggest for VS Code",
-	"view.name": "Terminal Suggest"
+	"view.name": "Terminal Suggest",
+	"terminal.integrated.suggest.clearCachedGlobals": "Clear Suggest Cached Globals"
 }


### PR DESCRIPTION
It turns out that on Windows the `exec` calls can end up blocking the exthost for over a second:

<img width="979" height="475" alt="image" src="https://github.com/user-attachments/assets/4a7737f5-a652-449c-b623-ff3d508082cc" />

This is likely due to Windows Defender, but adding node to exclusions didn't seem to help. Because of this, plus we shouldn't be launching processes so often, the caching now must be explicitly cleared in order to get the latest. This is just a limitation we'll have to include in the documentation (https://github.com/microsoft/vscode-docs/issues/8700).

Fixes https://github.com/microsoft/vscode/issues/259343
Fixes https://github.com/microsoft/vscode/issues/256746

Merge first:

- https://github.com/microsoft/vscode/pull/259347
- https://github.com/microsoft/vscode/pull/259350

Before (after reload, ext host initialized):

![Recording 2025-08-03 at 05 18 39](https://github.com/user-attachments/assets/ad79c813-02da-4fae-b205-393e6ea0f5b9)

After (after reload, ext host initialized):

![Recording 2025-08-03 at 05 17 23 (1)](https://github.com/user-attachments/assets/9769f1c7-0c0a-4678-b8d3-a026bb1d2589)
