### PR TITLE
Add new terminal to tab well and empty editor menus

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminalMenus.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalMenus.ts
@@ -188,6 +188,26 @@ export function setupTerminalMenus(): void {
 		]
 	);
 
+	MenuRegistry.appendMenuItem(MenuId.EditorTabsBarContext, {
+		command: {
+			id: TerminalCommandId.CreateTerminalEditorSameGroup,
+			title: terminalStrings.new
+		},
+		group: '1_file',
+		order: 30,
+		when: TerminalContextKeys.processSupported
+	});
+
+	MenuRegistry.appendMenuItem(MenuId.EmptyEditorGroupContext, {
+		command: {
+			id: TerminalCommandId.CreateTerminalEditorSameGroup,
+			title: terminalStrings.new
+		},
+		group: '1_file',
+		order: 30,
+		when: TerminalContextKeys.processSupported
+	});
+
 	MenuRegistry.appendMenuItems(
 		[
 			{


### PR DESCRIPTION
This increases discoverability of terminal editors and by extension terminals in aux windows.

Fixes #259002

FYI @bpasero 

<img width="856" height="884" alt="image" src="https://github.com/user-attachments/assets/937f22a5-01ba-47a5-955f-e7f96a2be8c7" />
<img width="1590" height="390" alt="image" src="https://github.com/user-attachments/assets/2b217040-626d-44f7-9ea9-ab8b57f5e746" />
