### PR TITLE
fix: register WorkerTextModelSyncClient

### DIFF
--- a/src/vs/workbench/contrib/output/browser/outputLinkProvider.ts
+++ b/src/vs/workbench/contrib/output/browser/outputLinkProvider.ts
@@ -102,7 +102,7 @@ class OutputLinkWorkerClient extends Disposable {
 			FileAccess.asBrowserUri('vs/workbench/contrib/output/common/outputLinkComputerMain.js'),
 			'OutputLinkDetectionWorker'
 		));
-		this._workerTextModelSyncClient = WorkerTextModelSyncClient.create(this._workerClient, modelService);
+		this._workerTextModelSyncClient = this._register(WorkerTextModelSyncClient.create(this._workerClient, modelService));
 		this._initializeBarrier = this._ensureWorkspaceFolders();
 	}
 
@@ -112,7 +112,7 @@ class OutputLinkWorkerClient extends Disposable {
 
 	public async provideLinks(modelUri: URI): Promise<ILink[]> {
 		await this._initializeBarrier;
-		await this._workerTextModelSyncClient.ensureSyncedResources([modelUri]);
+		this._workerTextModelSyncClient.ensureSyncedResources([modelUri]);
 		return this._workerClient.proxy.$computeLinks(modelUri.toString());
 	}
 }

--- a/src/vs/workbench/services/languageDetection/browser/languageDetectionWorkerServiceImpl.ts
+++ b/src/vs/workbench/services/languageDetection/browser/languageDetectionWorkerServiceImpl.ts
@@ -212,7 +212,7 @@ export class LanguageDetectionWorkerClient extends Disposable {
 				$getModelJsonUri: async () => this.getModelJsonUri(),
 				$getWeightsUri: async () => this.getWeightsUri(),
 			});
-			const workerTextModelSyncClient = WorkerTextModelSyncClient.create(workerClient, this._modelService);
+			const workerTextModelSyncClient = this._register(WorkerTextModelSyncClient.create(workerClient, this._modelService));
 			this.worker = { workerClient, workerTextModelSyncClient };
 		}
 		return this.worker;
@@ -272,7 +272,7 @@ export class LanguageDetectionWorkerClient extends Disposable {
 		}
 
 		const { workerClient, workerTextModelSyncClient } = this._getOrCreateLanguageDetectionWorker();
-		await workerTextModelSyncClient.ensureSyncedResources([resource]);
+		workerTextModelSyncClient.ensureSyncedResources([resource]);
 		const modelId = await workerClient.proxy.$detectLanguage(resource.toString(), langBiases, preferHistory, supportedLangs);
 		const languageId = this.getLanguageId(modelId);
 


### PR DESCRIPTION
It is disposable object which might run timer until it is disposed.

Drive-by: removed await for non async call.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
