### PR TITLE
Adjust button padding in dialog and settings widgets

### DIFF
--- a/src/vs/base/browser/ui/dialog/dialog.css
+++ b/src/vs/base/browser/ui/dialog/dialog.css
@@ -194,7 +194,7 @@
 }
 
 .monaco-dialog-box > .dialog-buttons-row > .dialog-buttons > .monaco-button {
-	padding: 5px 10px;
+	padding: 4px 10px;
 	overflow: hidden;
 	text-overflow: ellipsis;
 	margin: 4px 5px; /* allows button focus outline to be visible */

--- a/src/vs/workbench/contrib/preferences/browser/media/settingsWidgets.css
+++ b/src/vs/workbench/contrib/preferences/browser/media/settingsWidgets.css
@@ -180,7 +180,7 @@
 .settings-editor > .settings-body .settings-tree-container .setting-item.setting-item-list .monaco-text-button {
 	width: initial;
 	white-space: nowrap;
-	padding: 2px 14px;
+	padding: 4px 14px;
 }
 
 .settings-editor > .settings-body .settings-tree-container .setting-item.setting-item-list .setting-item-control.setting-list-hide-add-button .setting-list-new-row {


### PR DESCRIPTION
Modify button padding for improved layout in dialog and settings components. This aligns button heights to 28px.

This addresses #251008 & #250995.