### PR TITLE
Move New Terminal menu items to own section

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminalMenus.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalMenus.ts
@@ -206,7 +206,7 @@ export function setupTerminalMenus(): void {
 			id: TerminalCommandId.CreateTerminalEditorSameGroup,
 			title: terminalStrings.new
 		},
-		group: '1_file',
+		group: '1_zzz_file',
 		order: 30,
 		when: TerminalContextKeys.processSupported
 	});
@@ -216,7 +216,7 @@ export function setupTerminalMenus(): void {
 			id: TerminalCommandId.CreateTerminalEditorSameGroup,
 			title: terminalStrings.new
 		},
-		group: '1_file',
+		group: '1_zzz_file',
 		order: 30,
 		when: TerminalContextKeys.processSupported
 	});


### PR DESCRIPTION
Follows up on #259424
<img width="704" height="696" alt="image" src="https://github.com/user-attachments/assets/8b321dd5-ad60-4be7-bcd1-128f3f198e58" />
<img width="928" height="892" alt="image" src="https://github.com/user-attachments/assets/102930fb-2243-490c-96c2-5f42ab50be5c" />
