### PR TITLE
Clean up markdownDocumentRenderer api

### DIFF
--- a/src/vs/base/browser/markdownRenderer.ts
+++ b/src/vs/base/browser/markdownRenderer.ts
@@ -434,7 +434,6 @@ export const allowedMarkdownHtmlAttributes = [
 	'autoplay',
 	'alt',
 	'checked',
-	'class',
 	'colspan',
 	'controls',
 	'disabled',

--- a/src/vs/workbench/contrib/extensions/browser/extensionEditor.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionEditor.ts
@@ -750,7 +750,9 @@ export class ExtensionEditor extends EditorPane {
 			return '';
 		}
 
-		const content = await renderMarkdownDocument(contents, this.extensionService, this.languageService, { shouldSanitize: extension.type !== ExtensionType.System }, token);
+		const content = await renderMarkdownDocument(contents, this.extensionService, this.languageService, {
+			sanitizerConfig: extension.type === ExtensionType.System ? 'skipSanitization' : {}
+		}, token);
 		if (token?.isCancellationRequested) {
 			return '';
 		}

--- a/src/vs/workbench/contrib/markdown/browser/markdownDocumentRenderer.ts
+++ b/src/vs/workbench/contrib/markdown/browser/markdownDocumentRenderer.ts
@@ -3,8 +3,9 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { basicMarkupHtmlTags, sanitizeHtml } from '../../../../base/browser/domSanitize.js';
-import { allowedMarkdownHtmlAttributes } from '../../../../base/browser/markdownRenderer.js';
+import { sanitizeHtml } from '../../../../base/browser/domSanitize.js';
+import { allowedMarkdownHtmlAttributes, allowedMarkdownHtmlTags } from '../../../../base/browser/markdownRenderer.js';
+import { raceCancellationError } from '../../../../base/common/async.js';
 import { CancellationToken } from '../../../../base/common/cancellation.js';
 import * as marked from '../../../../base/common/marked/marked.js';
 import { Schemas } from '../../../../base/common/network.js';
@@ -156,48 +157,57 @@ pre code {
 }
 `;
 
-const allowedProtocols = [
+const defaultAllowedProtocols = Object.freeze([
 	Schemas.http,
 	Schemas.https,
 	Schemas.command,
-];
+]);
 
-function sanitize(documentContent: string, allowAllProtocols = false): TrustedHTML {
-	// TODO: Move most of these options to the callers
+function sanitize(documentContent: string, sanitizerConfig: MarkdownDocumentSanitizerConfig | undefined): TrustedHTML {
 	return sanitizeHtml(documentContent, {
 		allowedLinkProtocols: {
-			override: allowAllProtocols ? '*' : allowedProtocols,
+			override: sanitizerConfig?.allowedProtocols?.override ?? defaultAllowedProtocols,
 		},
 		allowedTags: {
-			override: [
-				...basicMarkupHtmlTags,
-				'input',
-				'select',
-				'checkbox',
-				'checklist',
-			],
+			override: allowedMarkdownHtmlTags,
+			augment: sanitizerConfig?.allowedTags?.augment
 		},
 		allowedAttributes: {
 			override: [
 				...allowedMarkdownHtmlAttributes,
-				'data-command', 'name', 'id', 'role', 'tabindex',
-				'x-dispatch',
-				'required', 'checked', 'placeholder', 'when-checked', 'checked-on',
+				'name',
+				'id',
+				'role',
+				'tabindex',
+				'placeholder',
 			],
+			augment: sanitizerConfig?.allowedAttributes?.augment ?? [],
 		}
 	});
 }
 
+interface MarkdownDocumentSanitizerConfig {
+	readonly allowedProtocols?: {
+		readonly override: readonly string[] | '*';
+	};
+	readonly allowedTags?: {
+		readonly augment: readonly string[];
+	};
+	readonly allowedAttributes?: {
+		readonly augment: readonly string[];
+	};
+}
+
 interface IRenderMarkdownDocumentOptions {
-	readonly shouldSanitize?: boolean;
-	readonly allowUnknownProtocols?: boolean;
-	readonly markedExtensions?: marked.MarkedExtension[];
+	readonly sanitizerConfig?: 'skipSanitization' | MarkdownDocumentSanitizerConfig;
+	readonly markedExtensions?: readonly marked.MarkedExtension[];
 }
 
 /**
- * Renders a string of markdown as a document.
+ * Renders a string of markdown for use in an external document context.
  *
- * Uses VS Code's syntax highlighting code blocks.
+ * Uses VS Code's syntax highlighting code blocks. Also does not attach all the hooks and customization that normal
+ * markdown renderer.
  */
 export async function renderMarkdownDocument(
 	text: string,
@@ -227,11 +237,11 @@ export async function renderMarkdownDocument(
 		...(options?.markedExtensions ?? []),
 	);
 
-	const raw = await m.parse(text, { async: true });
-	if (options?.shouldSanitize ?? true) {
-		return sanitize(raw, options?.allowUnknownProtocols ?? false) as any as string;
-	} else {
+	const raw = await raceCancellationError(m.parse(text, { async: true }), token ?? CancellationToken.None);
+	if (options?.sanitizerConfig === 'skipSanitization') {
 		return raw;
+	} else {
+		return sanitize(raw, options?.sanitizerConfig) as any as string;
 	}
 }
 

--- a/src/vs/workbench/contrib/mcp/browser/mcpServerEditor.ts
+++ b/src/vs/workbench/contrib/mcp/browser/mcpServerEditor.ts
@@ -529,7 +529,7 @@ export class McpServerEditor extends EditorPane {
 			return '';
 		}
 
-		const content = await renderMarkdownDocument(contents, this.extensionService, this.languageService, { shouldSanitize: true }, token);
+		const content = await renderMarkdownDocument(contents, this.extensionService, this.languageService, {}, token);
 		if (token?.isCancellationRequested) {
 			return '';
 		}

--- a/src/vs/workbench/contrib/update/browser/releaseNotesEditor.ts
+++ b/src/vs/workbench/contrib/update/browser/releaseNotesEditor.ts
@@ -264,7 +264,7 @@ export class ReleaseNotesManager {
 		const nonce = generateUuid();
 
 		const content = await renderMarkdownDocument(fileContent.text, this._extensionService, this._languageService, {
-			shouldSanitize: false,
+			sanitizerConfig: 'skipSanitization',
 			markedExtensions: [{
 				renderer: {
 					html: this._simpleSettingRenderer.getHtmlRenderer(),

--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStartedDetailsRenderer.ts
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStartedDetailsRenderer.ts
@@ -236,7 +236,29 @@ export class GettingStartedDetailsRenderer {
 	private async readAndCacheStepMarkdown(path: URI, base: URI): Promise<string> {
 		if (!this.mdCache.has(path)) {
 			const contents = await this.readContentsOfPath(path);
-			const markdownContents = await renderMarkdownDocument(transformUris(contents, base), this.extensionService, this.languageService, { allowUnknownProtocols: true });
+			const markdownContents = await renderMarkdownDocument(transformUris(contents, base), this.extensionService, this.languageService, {
+				sanitizerConfig: {
+					allowedProtocols: {
+						override: '*'
+					},
+					allowedTags: {
+						augment: [
+							'select',
+							'checkbox',
+							'checklist',
+						]
+					},
+					allowedAttributes: {
+						augment: [
+							'x-dispatch',
+							'data-command',
+							'when-checked',
+							'checked-on',
+							'checked',
+						]
+					},
+				}
+			});
 			this.mdCache.set(path, markdownContents);
 		}
 		return assertReturnsDefined(this.mdCache.get(path));


### PR DESCRIPTION
Similar changes to those made for markdown renderer:

- Clarify api and how override vs augment works
- Move most defaults into callers

@bhavyaus Let me know if you notice any issues with welcome flows since these seemed to use the customization most heavily 