### PR TITLE
Support server.json being returned by assisted MCP install

### DIFF
--- a/src/vs/platform/mcp/common/mcpManagementService.ts
+++ b/src/vs/platform/mcp/common/mcpManagementService.ts
@@ -325,10 +325,10 @@ export abstract class AbstractMcpResourceManagementService extends Disposable {
 			}
 			else if (serverPackage.registry_name === PackageType.NUGET) {
 				args.push(serverPackage.version ? `${serverPackage.name}@${serverPackage.version}` : serverPackage.name);
-			}
-
-			if (serverPackage.package_arguments && serverPackage.registry_name === PackageType.NUGET) {
-				args.push('--');
+				args.push('--yes'); // installation is confirmed by the UI, so --yes is appropriate here
+				if (serverPackage.package_arguments?.length) {
+					args.push('--');
+				}
 			}
 
 			for (const arg of serverPackage.package_arguments ?? []) {

--- a/src/vs/platform/mcp/common/mcpManagementService.ts
+++ b/src/vs/platform/mcp/common/mcpManagementService.ts
@@ -232,7 +232,7 @@ export abstract class AbstractMcpResourceManagementService extends Disposable {
 		}
 	}
 
-	protected toScannedMcpServerAndInputs(manifest: IMcpServerManifest, packageType?: PackageType): { config: IMcpServerConfiguration; inputs?: IMcpServerVariable[] } {
+	static toScannedMcpServerAndInputs(manifest: IMcpServerManifest, packageType?: PackageType): { config: IMcpServerConfiguration; inputs?: IMcpServerVariable[] } {
 		if (packageType === undefined) {
 			packageType = manifest.packages?.[0]?.registry_name ?? PackageType.REMOTE;
 		}
@@ -246,7 +246,7 @@ export abstract class AbstractMcpResourceManagementService extends Disposable {
 				const variables = input.variables ? this.getVariables(input.variables) : [];
 				let value = input.value;
 				for (const variable of variables) {
-					value = value.replace(`{${variable.id}}`, `{input:${variable.id}}`);
+					value = value.replace(`{${variable.id}}`, `\${input:${variable.id}}`);
 				}
 				headers[input.name] = value;
 				if (variables.length) {
@@ -279,7 +279,7 @@ export abstract class AbstractMcpResourceManagementService extends Disposable {
 					let value = arg.value;
 					if (value) {
 						for (const variable of variables) {
-							value = value.replace(`{${variable.id}}`, `{input:${variable.id}}`);
+							value = value.replace(`{${variable.id}}`, `\${input:${variable.id}}`);
 						}
 					}
 					args.push(value ?? arg.value_hint);
@@ -288,7 +288,7 @@ export abstract class AbstractMcpResourceManagementService extends Disposable {
 					if (arg.value) {
 						let value = arg.value;
 						for (const variable of variables) {
-							value = value.replace(`{${variable.id}}`, `{input:${variable.id}}`);
+							value = value.replace(`{${variable.id}}`, `\${input:${variable.id}}`);
 						}
 						args.push(value);
 					}
@@ -302,7 +302,7 @@ export abstract class AbstractMcpResourceManagementService extends Disposable {
 				const variables = input.variables ? this.getVariables(input.variables) : [];
 				let value = input.value;
 				for (const variable of variables) {
-					value = value.replace(`{${variable.id}}`, `{input:${variable.id}}`);
+					value = value.replace(`{${variable.id}}`, `\${input:${variable.id}}`);
 				}
 				env[input.name] = value;
 				if (variables.length) {
@@ -337,7 +337,7 @@ export abstract class AbstractMcpResourceManagementService extends Disposable {
 					let value = arg.value;
 					if (value) {
 						for (const variable of variables) {
-							value = value.replace(`{${variable.id}}`, `{input:${variable.id}}`);
+							value = value.replace(`{${variable.id}}`, `\${input:${variable.id}}`);
 						}
 					}
 					args.push(value ?? arg.value_hint);
@@ -346,7 +346,7 @@ export abstract class AbstractMcpResourceManagementService extends Disposable {
 					if (arg.value) {
 						let value = arg.value;
 						for (const variable of variables) {
-							value = value.replace(`{${variable.id}}`, `{input:${variable.id}}`);
+							value = value.replace(`{${variable.id}}`, `\${input:${variable.id}}`);
 						}
 						args.push(value);
 					}
@@ -370,7 +370,7 @@ export abstract class AbstractMcpResourceManagementService extends Disposable {
 		};
 	}
 
-	private getCommandName(packageType: PackageType): string {
+	private static getCommandName(packageType: PackageType): string {
 		switch (packageType) {
 			case PackageType.NODE: return 'npx';
 			case PackageType.DOCKER: return 'docker';
@@ -380,7 +380,7 @@ export abstract class AbstractMcpResourceManagementService extends Disposable {
 		return packageType;
 	}
 
-	private getVariables(variableInputs: Record<string, IMcpServerInput>): IMcpServerVariable[] {
+	private static getVariables(variableInputs: Record<string, IMcpServerInput>): IMcpServerVariable[] {
 		const variables: IMcpServerVariable[] = [];
 		for (const [key, value] of Object.entries(variableInputs)) {
 			variables.push({
@@ -425,7 +425,7 @@ export class McpUserResourceManagementService extends AbstractMcpResourceManagem
 
 		try {
 			const manifest = await this.updateMetadataFromGallery(server);
-			const { config, inputs } = this.toScannedMcpServerAndInputs(manifest, options?.packageType);
+			const { config, inputs } = AbstractMcpResourceManagementService.toScannedMcpServerAndInputs(manifest, options?.packageType);
 			const installable: IInstallableMcpServer = {
 				name: server.name,
 				config: {

--- a/src/vs/workbench/contrib/mcp/browser/mcpCommandsAddConfiguration.ts
+++ b/src/vs/workbench/contrib/mcp/browser/mcpCommandsAddConfiguration.ts
@@ -18,6 +18,8 @@ import { ICommandService } from '../../../../platform/commands/common/commands.j
 import { ConfigurationTarget, IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { IFileService } from '../../../../platform/files/common/files.js';
 import { ILabelService } from '../../../../platform/label/common/label.js';
+import { IMcpServerManifest, PackageType } from '../../../../platform/mcp/common/mcpManagement.js';
+import { AbstractMcpResourceManagementService } from '../../../../platform/mcp/common/mcpManagementService.js';
 import { IMcpRemoteServerConfiguration, IMcpServerConfiguration, IMcpServerVariable, IMcpStdioServerConfiguration, McpServerType } from '../../../../platform/mcp/common/mcpPlatformTypes.js';
 import { INotificationService } from '../../../../platform/notification/common/notification.js';
 import { IQuickInputService, IQuickPickItem, QuickPickInput } from '../../../../platform/quickinput/common/quickInput.js';
@@ -108,6 +110,18 @@ type AddServerCompletedClassification = {
 	packageType: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The type of MCP server package' };
 	serverType: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The type of MCP server' };
 	target: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The target of the MCP server configuration' };
+};
+
+type AssistedServerConfiguration = {
+	type?: 'vscode';
+	name?: string;
+	server: Omit<IMcpStdioServerConfiguration, 'type'>;
+	inputs?: IMcpServerVariable[];
+	inputValues?: Record<string, string>;
+} | {
+	type: 'server.json';
+	name?: string;
+	server: IMcpServerManifest;
 };
 
 export class McpAddConfigurationCommand {
@@ -270,7 +284,7 @@ export class McpAddConfigurationCommand {
 		return targetPick?.target;
 	}
 
-	private async getAssistedConfig(type: AssistedConfigurationType): Promise<{ name: string; server: Omit<IMcpStdioServerConfiguration, 'type'>; inputs?: IMcpServerVariable[]; inputValues?: Record<string, string> } | undefined> {
+	private async getAssistedConfig(type: AssistedConfigurationType): Promise<{ name?: string; server: Omit<IMcpStdioServerConfiguration, 'type'>; inputs?: IMcpServerVariable[]; inputValues?: Record<string, string> } | undefined> {
 		const packageName = await this._quickInputService.input({
 			ignoreFocusLost: true,
 			title: AssistedTypes[type].title,
@@ -350,13 +364,33 @@ export class McpAddConfigurationCommand {
 				return undefined;
 		}
 
-		return await this._commandService.executeCommand<{ name: string; server: Omit<IMcpStdioServerConfiguration, 'type'>; inputs?: IMcpServerVariable[]; inputValues?: Record<string, string> }>(
+		const config = await this._commandService.executeCommand<AssistedServerConfiguration>(
 			AddConfigurationCopilotCommand.StartFlow,
 			{
 				name: packageName,
 				type: packageType
 			}
 		);
+
+		if (config?.type === 'server.json') {
+			const packageType = this.getPackageTypeEnum(type);
+			if (!packageType) {
+				throw new Error(`Unsupported assisted package type ${type}`);
+			}
+			const server = AbstractMcpResourceManagementService.toScannedMcpServerAndInputs(config.server, packageType);
+			if (server.config.type !== McpServerType.LOCAL) {
+				throw new Error(`Unexpected server type ${server.config.type} for assisted configuration from server.json.`);
+			}
+			return {
+				name: config.name,
+				server: server.config,
+				inputs: server.inputs,
+			};
+		} else if (config?.type === 'vscode' || !config?.type) {
+			return config;
+		} else {
+			assertNever(config?.type);
+		}
 	}
 
 	/** Shows the location of a server config once it's discovered. */
@@ -513,6 +547,21 @@ export class McpAddConfigurationCommand {
 				}
 				break;
 			}
+		}
+	}
+
+	private getPackageTypeEnum(type: AddConfigurationType): PackageType | undefined {
+		switch (type) {
+			case AddConfigurationType.NpmPackage:
+				return PackageType.NODE;
+			case AddConfigurationType.PipPackage:
+				return PackageType.PYTHON;
+			case AddConfigurationType.NuGetPackage:
+				return PackageType.NUGET;
+			case AddConfigurationType.DockerImage:
+				return PackageType.DOCKER;
+			default:
+				return undefined;
 		}
 	}
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This works around the lack of https://github.com/microsoft/vscode/issues/259100 and is progress on https://github.com/microsoft/vscode/issues/257679. There will be a separate PR on the chat extension to support server.json in NuGet packages.

It enhances the `github.copilot.chat.mcp.setup.flow` command to have an additional `type` property. When this type property is set to `"server.json"`, the result is treated as an MCP Registry server.json and mapped to the VS Code configuration format. If the `type` property is falsey set or set to `"vscode"`, the existing codepath is used.

Additionally, I updated the `toScannedMcpServerAndInputs` to be a public static method so it can be called after the `github.copilot.chat.mcp.setup.flow` command returns. 

I noticed the resulting `args` and `env` placeholder values had the format `{input:foo}`, instead of format `${input:foo}`. Based on https://code.visualstudio.com/docs/reference/variables-reference#_input-variables, it seems like this was a bug in the original implementation, but I may be wrong. @sandy081 - could you confirm?

Verified with:
- npm: `@azure/mcp` (old flow, no server.json)
- Python: `mcp-server-fetch` (old flow, no server.json)
- Docker: `mcp/node-code-sandbox` (old flow, no server.json)
- NuGet: `NuGet.Mcp.Server` (new flow), `Knacode.SampleMcpServer` (new flow, this one has an input)

