### PR TITLE
Fix memory reference handling in Watch window

### DIFF
--- a/src/vs/workbench/contrib/debug/common/debugModel.ts
+++ b/src/vs/workbench/contrib/debug/common/debugModel.ts
@@ -234,6 +234,7 @@ export class ExpressionContainer implements IExpressionContainer {
 		} catch (e) {
 			this.value = e.message || '';
 			this.reference = 0;
+			this.memoryReference = undefined;
 			return false;
 		}
 	}


### PR DESCRIPTION
This patch fixes a small problem when the `View Binary Data` button showed in the `Watch` window in case of an error returned from the debug adapter (`memoryReference` field is not updated).

Before:
![memory-reference-before](https://github.com/user-attachments/assets/c97c7af7-9954-4fa5-9fc4-d6a53c24e06c)

After:

![memory-reference-after](https://github.com/user-attachments/assets/9e18a5b0-5b76-4d8f-9fdb-52eef20054ff)
