### PR TITLE
Fix theme not being synchronized with external windows on firefox

### DIFF
--- a/src/vs/workbench/services/themes/browser/workbenchThemeService.ts
+++ b/src/vs/workbench/services/themes/browser/workbenchThemeService.ts
@@ -33,7 +33,7 @@ import { updateColorThemeConfigurationSchemas, updateFileIconThemeConfigurationS
 import { ProductIconThemeData, DEFAULT_PRODUCT_ICON_THEME_ID } from './productIconThemeData.js';
 import { registerProductIconThemeSchemas } from '../common/productIconThemeSchema.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
-import { isWeb } from '../../../../base/common/platform.js';
+import { isFirefox, isWeb } from '../../../../base/common/platform.js';
 import { ColorScheme, ThemeTypeSelector } from '../../../../platform/theme/common/theme.js';
 import { IHostColorSchemeService } from '../common/hostColorSchemeService.js';
 import { RunOnceScheduler, Sequencer } from '../../../../base/common/async.js';
@@ -42,6 +42,7 @@ import { getIconsStyleSheet } from '../../../../platform/theme/browser/iconsStyl
 import { asCssVariableName, getColorRegistry } from '../../../../platform/theme/common/colorRegistry.js';
 import { ILanguageService } from '../../../../editor/common/languages/language.js';
 import { mainWindow } from '../../../../base/browser/window.js';
+import { generateUuid } from '../../../../base/common/uuid.js';
 
 // implementation
 
@@ -793,13 +794,21 @@ class ThemeFileWatcher {
 }
 
 function _applyRules(styleSheetContent: string, rulesClassName: string) {
-	const themeStyles = mainWindow.document.head.getElementsByClassName(rulesClassName);
-	if (themeStyles.length === 0) {
-		const elStyle = createStyleSheet();
-		elStyle.className = rulesClassName;
-		elStyle.textContent = styleSheetContent;
-	} else {
-		(<HTMLStyleElement>themeStyles[0]).textContent = styleSheetContent;
+	let themeStyle = mainWindow.document.head.getElementsByClassName(rulesClassName).item(0);
+	if (!themeStyle) {
+		themeStyle = createStyleSheet();
+		themeStyle.className = rulesClassName;
+	}
+
+	if (themeStyle.textContent !== styleSheetContent) {
+		themeStyle.textContent = styleSheetContent;
+
+		if (isFirefox) {
+			// Firefox doesn't support observing style tag contents
+			// As a workaround, also update the data-version attribute
+			// when it changes so it can be observed
+			themeStyle.setAttribute('data-version', generateUuid());
+		}
 	}
 }
 


### PR DESCRIPTION
fix #259835

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Firefox doesn't allow to watch style element content using a MutationObserver. A MutationObserver is used to synchronize main windows styles with external windows. As a consequence, the theme is not properly updated on external windows on Firefox.

As a workaround, also add a data-hash attribute on the style elements, and watch it as well in the MutationObserver
