### PR TITLE
Reversed diff editor order for comparing to clipboard

### DIFF
--- a/src/vs/workbench/contrib/files/browser/fileActions.ts
+++ b/src/vs/workbench/contrib/files/browser/fileActions.ts
@@ -860,11 +860,11 @@ export class CompareWithClipboardAction extends Action2 {
 			}
 
 			const name = resources.basename(resource);
-			const editorLabel = nls.localize('clipboardComparisonLabel', "Clipboard ↔ {0}", name);
+			const editorLabel = nls.localize('clipboardComparisonLabelReversed', "{0} ↔ Clipboard", name);
 
 			await editorService.openEditor({
-				original: { resource: resource.with({ scheme }) },
-				modified: { resource: resource },
+				original: { resource: resource },
+				modified: { resource: resource.with({ scheme }) },
 				label: editorLabel,
 				options: { pinned: true }
 			}).finally(() => {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Changes the editor pane order for comparing active file to clipboard, so that the clipboard is on the right (modified) instead of left (original) side.

<img width="516" height="160" alt="Image" src="https://github.com/user-attachments/assets/b5a61c7a-aa86-45d5-af44-e90c513d8425" />

This is to reflect the behavior of all the other `Compare...` commands where the active file is on the left.

<img width="348" height="170" alt="Image" src="https://github.com/user-attachments/assets/88920f5e-35ce-4fca-b41f-3cf182427735" />

This is the simplest fix for issue https://github.com/microsoft/vscode/issues/259434 if it is to be considered a bug, which is indicated by the behavior of the other similar commands.

Regarding changing the localization key, I'm not sure if this is needed or not as I'm unaware of how such a change in the message prompts updates for translations, please correct if not needed.