### PR TITLE
Bump implicit js/ts target to ES2024

### DIFF
--- a/extensions/typescript-language-features/package.json
+++ b/extensions/typescript-language-features/package.json
@@ -258,7 +258,7 @@
           },
           "js/ts.implicitProjectConfig.target": {
             "type": "string",
-            "default": "ES2022",
+            "default": "ES2024",
             "markdownDescription": "%configuration.implicitProjectConfig.target%",
             "enum": [
               "ES3",

--- a/extensions/typescript-language-features/schemas/jsconfig.schema.json
+++ b/extensions/typescript-language-features/schemas/jsconfig.schema.json
@@ -4,7 +4,7 @@
 	"type": "object",
 	"default": {
 		"compilerOptions": {
-			"target": "es2020"
+			"target": "es2024"
 		}
 	}
 }


### PR DESCRIPTION
This is well supported across modern browsers and node versions 