### PR TITLE
Migrates from stack trace processing to DebugLocation

### DIFF
--- a/src/vs/base/common/observableInternal/debugLocation.ts
+++ b/src/vs/base/common/observableInternal/debugLocation.ts
@@ -1,0 +1,86 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+export type DebugLocation = DebugLocationImpl | undefined;
+
+export namespace DebugLocation {
+	let enabled = false;
+
+	export function enable(): void {
+		enabled = true;
+	}
+
+	export function ofCaller(): DebugLocation {
+		if (!enabled) {
+			return undefined;
+		}
+		const Err = Error as any as { stackTraceLimit: number }; // For the monaco editor checks, which don't have the nodejs types.
+
+		const l = Err.stackTraceLimit;
+		Err.stackTraceLimit = 3;
+		const stack = new Error().stack!;
+		Err.stackTraceLimit = l;
+
+		return DebugLocationImpl.fromStack(stack, 2);
+	}
+}
+
+class DebugLocationImpl implements ILocation {
+	public static fromStack(stack: string, parentIdx: number): DebugLocationImpl | undefined {
+		const lines = stack.split('\n');
+		const location = parseLine(lines[parentIdx + 1]);
+		if (location) {
+			return new DebugLocationImpl(
+				location.fileName,
+				location.line,
+				location.column,
+				location.id
+			);
+		} else {
+			return undefined;
+		}
+	}
+
+	constructor(
+		public readonly fileName: string,
+		public readonly line: number,
+		public readonly column: number,
+		public readonly id: string,
+	) {
+	}
+}
+
+
+export interface ILocation {
+	fileName: string;
+	line: number;
+	column: number;
+	id: string;
+}
+
+function parseLine(stackLine: string): ILocation | undefined {
+	const match = stackLine.match(/\((.*):(\d+):(\d+)\)/);
+	if (match) {
+		return {
+			fileName: match[1],
+			line: parseInt(match[2]),
+			column: parseInt(match[3]),
+			id: stackLine,
+		};
+	}
+
+	const match2 = stackLine.match(/at ([^\(\)]*):(\d+):(\d+)/);
+
+	if (match2) {
+		return {
+			fileName: match2[1],
+			line: parseInt(match2[2]),
+			column: parseInt(match2[3]),
+			id: stackLine,
+		};
+	}
+
+	return undefined;
+}

--- a/src/vs/base/common/observableInternal/experimental/reducer.ts
+++ b/src/vs/base/common/observableInternal/experimental/reducer.ts
@@ -9,6 +9,7 @@ import { subtransaction } from '../transaction.js';
 import { IChangeTracker } from '../changeTracker.js';
 import { DebugNameData, DebugOwner } from '../debugName.js';
 import { DerivedWithSetter, IDerivedReader } from '../observables/derivedImpl.js';
+import { DebugLocation } from '../debugLocation.js';
 
 export interface IReducerOptions<T, TChangeSummary = void, TOutChange = void> {
 	/**
@@ -73,7 +74,8 @@ export function observableReducerSettable<T, TInChanges, TOutChange = void>(owne
 				prevValue = value;
 				d.setValue(value, tx, change);
 			});
-		}
+		},
+		DebugLocation.ofCaller()
 	);
 
 	return d;

--- a/src/vs/base/common/observableInternal/index.ts
+++ b/src/vs/base/common/observableInternal/index.ts
@@ -34,6 +34,7 @@ export { observableValue } from './observables/observableValue.js';
 
 export { ObservableSet } from './set.js';
 export { ObservableMap } from './map.js';
+export { DebugLocation } from './debugLocation.js';
 
 import { addLogger, setLogObservableFn } from './logging/logging.js';
 import { ConsoleObservableLogger, logObservableToConsole } from './logging/consoleObservableLogger.js';

--- a/src/vs/base/common/observableInternal/logging/debugger/devToolsLogger.ts
+++ b/src/vs/base/common/observableInternal/logging/debugger/devToolsLogger.ts
@@ -9,7 +9,7 @@ import { IChangeInformation, IObservableLogger } from '../logging.js';
 import { formatValue } from '../consoleObservableLogger.js';
 import { ObsDebuggerApi, IObsDeclaration, ObsInstanceId, ObsStateUpdate, ITransactionState, ObserverInstanceState } from './debuggerApi.js';
 import { registerDebugChannel } from './debuggerRpc.js';
-import { deepAssign, deepAssignDeleteNulls, getFirstStackFrameOutsideOf, ILocation, Throttler } from './utils.js';
+import { deepAssign, deepAssignDeleteNulls, Throttler } from './utils.js';
 import { isDefined } from '../../../types.js';
 import { FromEventObservable } from '../../observables/observableFromEvent.js';
 import { BugIndicatingError, onUnexpectedError } from '../../../errors.js';
@@ -17,6 +17,7 @@ import { IObservable, IObserver } from '../../base.js';
 import { BaseObservable } from '../../observables/baseObservable.js';
 import { Derived, DerivedState } from '../../observables/derivedImpl.js';
 import { ObservableValue } from '../../observables/observableValue.js';
+import { DebugLocation } from '../../debugLocation.js';
 
 interface IInstanceInfo {
 	declarationId: number;
@@ -272,7 +273,9 @@ export class DevToolsLogger implements IObservableLogger {
 		return undefined;
 	}
 
-	private constructor() { }
+	private constructor() {
+		DebugLocation.enable();
+	}
 
 	private _pendingChanges: ObsStateUpdate | null = null;
 	private readonly _changeThrottler = new Throttler();
@@ -298,54 +301,29 @@ export class DevToolsLogger implements IObservableLogger {
 		}
 	};
 
-	private _getDeclarationId(type: IObsDeclaration['type']): number {
-
-		let shallow = true;
-		let loc!: ILocation;
-
-		const Err = Error as any as { stackTraceLimit: number }; // For the monaco editor checks, which don't have the nodejs types.
-
-		while (true) {
-			const l = Err.stackTraceLimit;
-			Err.stackTraceLimit = shallow ? 6 : 20;
-			const stack = new Error().stack!;
-			Err.stackTraceLimit = l;
-
-			let result = getFirstStackFrameOutsideOf(stack, /[/\\]observableInternal[/\\]|\.observe|[/\\]util(s)?\./);
-
-			if (!shallow && !result) {
-				result = getFirstStackFrameOutsideOf(stack, /[/\\]observableInternal[/\\]|\.observe/)!;
-			}
-			if (result) {
-				loc = result;
-				break;
-			}
-			if (!shallow) {
-				console.error('Could not find location for declaration', new Error().stack);
-				loc = { fileName: 'unknown', line: 0, column: 0, id: 'unknown' };
-				break;
-			}
-			shallow = false;
+	private _getDeclarationId(type: IObsDeclaration['type'], location: DebugLocation): number {
+		if (!location) {
+			return -1;
 		}
 
-		let decInfo = this._declarations.get(loc.id);
+		let decInfo = this._declarations.get(location.id);
 		if (decInfo === undefined) {
 			decInfo = {
 				id: this._declarationId++,
 				type,
-				url: loc.fileName,
-				line: loc.line,
-				column: loc.column,
+				url: location.fileName,
+				line: location.line,
+				column: location.column,
 			};
-			this._declarations.set(loc.id, decInfo);
+			this._declarations.set(location.id, decInfo);
 
 			this._handleChange({ decls: { [decInfo.id]: decInfo } });
 		}
 		return decInfo.id;
 	}
 
-	handleObservableCreated(observable: IObservable<any>): void {
-		const declarationId = this._getDeclarationId('observable/value');
+	handleObservableCreated(observable: IObservable<any>, location: DebugLocation): void {
+		const declarationId = this._getDeclarationId('observable/value', location);
 
 		const info: IObservableInfo = {
 			declarationId,
@@ -405,8 +383,8 @@ export class DevToolsLogger implements IObservableLogger {
 		}
 	}
 
-	handleAutorunCreated(autorun: AutorunObserver): void {
-		const declarationId = this._getDeclarationId('autorun');
+	handleAutorunCreated(autorun: AutorunObserver, location: DebugLocation): void {
+		const declarationId = this._getDeclarationId('autorun', location);
 		const info: IAutorunInfo = {
 			declarationId,
 			instanceId: this._instanceId++,

--- a/src/vs/base/common/observableInternal/logging/debugger/utils.ts
+++ b/src/vs/base/common/observableInternal/logging/debugger/utils.ts
@@ -5,64 +5,6 @@
 
 import { IDisposable } from '../../../lifecycle.js';
 
-export function getFirstStackFrameOutsideOf(stack: string, pattern?: RegExp): ILocation | undefined {
-	const lines = stack.split('\n');
-
-	for (let i = 1; i < lines.length; i++) {
-		const line = lines[i];
-
-		if (pattern && pattern.test(line)) {
-			continue;
-		}
-
-		const showFramesUpMatch = line.match(/\$show(\d+)FramesUp/);
-		if (showFramesUpMatch) {
-			const n = parseInt(showFramesUpMatch[1], 10);
-			i += (n - 1);
-			continue;
-		}
-
-		const result = parseLine(line);
-		if (result) {
-			return result;
-		}
-	}
-
-	return undefined;
-}
-
-export interface ILocation {
-	fileName: string;
-	line: number;
-	column: number;
-	id: string;
-}
-
-function parseLine(stackLine: string): ILocation | undefined {
-	const match = stackLine.match(/\((.*):(\d+):(\d+)\)/);
-	if (match) {
-		return {
-			fileName: match[1],
-			line: parseInt(match[2]),
-			column: parseInt(match[3]),
-			id: stackLine,
-		};
-	}
-
-	const match2 = stackLine.match(/at ([^\(\)]*):(\d+):(\d+)/);
-
-	if (match2) {
-		return {
-			fileName: match2[1],
-			line: parseInt(match2[2]),
-			column: parseInt(match2[3]),
-			id: stackLine,
-		};
-	}
-
-	return undefined;
-}
-
 export class Debouncer implements IDisposable {
 	private _timeout: Timeout | undefined = undefined;
 

--- a/src/vs/base/common/observableInternal/logging/logging.ts
+++ b/src/vs/base/common/observableInternal/logging/logging.ts
@@ -7,6 +7,7 @@ import { AutorunObserver } from '../reactions/autorunImpl.js';
 import { IObservable } from '../base.js';
 import { TransactionImpl } from '../transaction.js';
 import type { Derived } from '../observables/derivedImpl.js';
+import { DebugLocation } from '../debugLocation.js';
 
 let globalObservableLogger: IObservableLogger | undefined;
 
@@ -44,12 +45,12 @@ export interface IChangeInformation {
 }
 
 export interface IObservableLogger {
-	handleObservableCreated(observable: IObservable<any>): void;
+	handleObservableCreated(observable: IObservable<any>, location: DebugLocation): void;
 	handleOnListenerCountChanged(observable: IObservable<any>, newCount: number): void;
 
 	handleObservableUpdated(observable: IObservable<any>, info: IChangeInformation): void;
 
-	handleAutorunCreated(autorun: AutorunObserver): void;
+	handleAutorunCreated(autorun: AutorunObserver, location: DebugLocation): void;
 	handleAutorunDisposed(autorun: AutorunObserver): void;
 	handleAutorunDependencyChanged(autorun: AutorunObserver, observable: IObservable<any>, change: unknown): void;
 	handleAutorunStarted(autorun: AutorunObserver): void;
@@ -67,9 +68,9 @@ class ComposedLogger implements IObservableLogger {
 		public readonly loggers: IObservableLogger[],
 	) { }
 
-	handleObservableCreated(observable: IObservable<any>): void {
+	handleObservableCreated(observable: IObservable<any>, location: DebugLocation): void {
 		for (const logger of this.loggers) {
-			logger.handleObservableCreated(observable);
+			logger.handleObservableCreated(observable, location);
 		}
 	}
 	handleOnListenerCountChanged(observable: IObservable<any>, newCount: number): void {
@@ -82,9 +83,9 @@ class ComposedLogger implements IObservableLogger {
 			logger.handleObservableUpdated(observable, info);
 		}
 	}
-	handleAutorunCreated(autorun: AutorunObserver): void {
+	handleAutorunCreated(autorun: AutorunObserver, location: DebugLocation): void {
 		for (const logger of this.loggers) {
-			logger.handleAutorunCreated(autorun);
+			logger.handleAutorunCreated(autorun, location);
 		}
 	}
 	handleAutorunDisposed(autorun: AutorunObserver): void {

--- a/src/vs/base/common/observableInternal/observables/baseObservable.ts
+++ b/src/vs/base/common/observableInternal/observables/baseObservable.ts
@@ -5,6 +5,7 @@
 
 import { IObservableWithChange, IObserver, IReader, IObservable } from '../base.js';
 import { DisposableStore } from '../commonFacade/deps.js';
+import { DebugLocation } from '../debugLocation.js';
 import { DebugOwner, getFunctionName } from '../debugName.js';
 import { getLogger, logObservable } from '../logging/logging.js';
 import type { keepObserved, recomputeInitiallyAndOnChange } from '../utils/utils.js';
@@ -124,9 +125,9 @@ export abstract class ConvenientObservable<T, TChange> implements IObservableWit
 export abstract class BaseObservable<T, TChange = void> extends ConvenientObservable<T, TChange> {
 	protected readonly _observers = new Set<IObserver>();
 
-	constructor() {
+	constructor(debugLocation: DebugLocation) {
 		super();
-		getLogger()?.handleObservableCreated(this);
+		getLogger()?.handleObservableCreated(this, debugLocation);
 	}
 
 	public addObserver(observer: IObserver): void {
@@ -157,7 +158,7 @@ export abstract class BaseObservable<T, TChange = void> extends ConvenientObserv
 		const hadLogger = !!getLogger();
 		logObservable(this);
 		if (!hadLogger) {
-			getLogger()?.handleObservableCreated(this);
+			getLogger()?.handleObservableCreated(this, DebugLocation.ofCaller());
 		}
 		return this;
 	}

--- a/src/vs/base/common/observableInternal/observables/derived.ts
+++ b/src/vs/base/common/observableInternal/observables/derived.ts
@@ -6,6 +6,7 @@
 import { IObservable, IReader, ITransaction, ISettableObservable, IObservableWithChange } from '../base.js';
 import { IChangeTracker } from '../changeTracker.js';
 import { DisposableStore, EqualityComparer, IDisposable, strictEquals } from '../commonFacade/deps.js';
+import { DebugLocation } from '../debugLocation.js';
 import { DebugOwner, DebugNameData, IDebugNameData } from '../debugName.js';
 import { _setDerivedOpts } from './baseObservable.js';
 import { IDerivedReader, Derived, DerivedWithSetter } from './derivedImpl.js';
@@ -18,14 +19,19 @@ import { IDerivedReader, Derived, DerivedWithSetter } from './derivedImpl.js';
  */
 export function derived<T, TChange = void>(computeFn: (reader: IDerivedReader<TChange>) => T): IObservableWithChange<T, TChange>;
 export function derived<T, TChange = void>(owner: DebugOwner, computeFn: (reader: IDerivedReader<TChange>) => T): IObservableWithChange<T, TChange>;
-export function derived<T, TChange = void>(computeFnOrOwner: ((reader: IDerivedReader<TChange>) => T) | DebugOwner, computeFn?: ((reader: IDerivedReader<TChange>) => T) | undefined): IObservable<T> {
+export function derived<T, TChange = void>(
+	computeFnOrOwner: ((reader: IDerivedReader<TChange>) => T) | DebugOwner,
+	computeFn?: ((reader: IDerivedReader<TChange>) => T) | undefined,
+	debugLocation = DebugLocation.ofCaller()
+): IObservable<T> {
 	if (computeFn !== undefined) {
 		return new Derived(
 			new DebugNameData(computeFnOrOwner, undefined, computeFn),
 			computeFn,
 			undefined,
 			undefined,
-			strictEquals
+			strictEquals,
+			debugLocation,
 		);
 	}
 	return new Derived(
@@ -33,18 +39,20 @@ export function derived<T, TChange = void>(computeFnOrOwner: ((reader: IDerivedR
 		computeFnOrOwner as any,
 		undefined,
 		undefined,
-		strictEquals
+		strictEquals,
+		debugLocation,
 	);
 }
 
-export function derivedWithSetter<T>(owner: DebugOwner | undefined, computeFn: (reader: IReader) => T, setter: (value: T, transaction: ITransaction | undefined) => void): ISettableObservable<T> {
+export function derivedWithSetter<T>(owner: DebugOwner | undefined, computeFn: (reader: IReader) => T, setter: (value: T, transaction: ITransaction | undefined) => void, debugLocation = DebugLocation.ofCaller()): ISettableObservable<T> {
 	return new DerivedWithSetter(
 		new DebugNameData(owner, undefined, computeFn),
 		computeFn,
 		undefined,
 		undefined,
 		strictEquals,
-		setter
+		setter,
+		debugLocation
 	);
 }
 
@@ -53,14 +61,16 @@ export function derivedOpts<T>(
 		equalsFn?: EqualityComparer<T>;
 		onLastObserverRemoved?: (() => void);
 	},
-	computeFn: (reader: IReader) => T
+	computeFn: (reader: IReader) => T,
+	debugLocation = DebugLocation.ofCaller()
 ): IObservable<T> {
 	return new Derived(
 		new DebugNameData(options.owner, options.debugName, options.debugReferenceFn),
 		computeFn,
 		undefined,
 		options.onLastObserverRemoved,
-		options.equalsFn ?? strictEquals
+		options.equalsFn ?? strictEquals,
+		debugLocation
 	);
 }
 _setDerivedOpts(derivedOpts);
@@ -83,14 +93,16 @@ export function derivedHandleChanges<T, TDelta, TChangeSummary>(
 		changeTracker: IChangeTracker<TChangeSummary>;
 		equalityComparer?: EqualityComparer<T>;
 	},
-	computeFn: (reader: IDerivedReader<TDelta>, changeSummary: TChangeSummary) => T
+	computeFn: (reader: IDerivedReader<TDelta>, changeSummary: TChangeSummary) => T,
+	debugLocation = DebugLocation.ofCaller()
 ): IObservableWithChange<T, TDelta> {
 	return new Derived(
 		new DebugNameData(options.owner, options.debugName, undefined),
 		computeFn,
 		options.changeTracker,
 		undefined,
-		options.equalityComparer ?? strictEquals
+		options.equalityComparer ?? strictEquals,
+		debugLocation
 	);
 }
 
@@ -103,7 +115,7 @@ export function derivedWithStore<T>(computeFn: (reader: IReader, store: Disposab
  * @deprecated Use `derived(reader => { reader.store.add(...) })` instead!
 */
 export function derivedWithStore<T>(owner: DebugOwner, computeFn: (reader: IReader, store: DisposableStore) => T): IObservable<T>;
-export function derivedWithStore<T>(computeFnOrOwner: ((reader: IReader, store: DisposableStore) => T) | DebugOwner, computeFnOrUndefined?: ((reader: IReader, store: DisposableStore) => T)): IObservable<T> {
+export function derivedWithStore<T>(computeFnOrOwner: ((reader: IReader, store: DisposableStore) => T) | DebugOwner, computeFnOrUndefined?: ((reader: IReader, store: DisposableStore) => T), debugLocation = DebugLocation.ofCaller()): IObservable<T> {
 	let computeFn: (reader: IReader, store: DisposableStore) => T;
 	let owner: DebugOwner;
 	if (computeFnOrUndefined === undefined) {
@@ -130,13 +142,14 @@ export function derivedWithStore<T>(computeFnOrOwner: ((reader: IReader, store: 
 		},
 		undefined,
 		() => store.dispose(),
-		strictEquals
+		strictEquals,
+		debugLocation
 	);
 }
 
 export function derivedDisposable<T extends IDisposable | undefined>(computeFn: (reader: IReader) => T): IObservable<T>;
 export function derivedDisposable<T extends IDisposable | undefined>(owner: DebugOwner, computeFn: (reader: IReader) => T): IObservable<T>;
-export function derivedDisposable<T extends IDisposable | undefined>(computeFnOrOwner: ((reader: IReader) => T) | DebugOwner, computeFnOrUndefined?: ((reader: IReader) => T)): IObservable<T> {
+export function derivedDisposable<T extends IDisposable | undefined>(computeFnOrOwner: ((reader: IReader) => T) | DebugOwner, computeFnOrUndefined?: ((reader: IReader) => T), debugLocation = DebugLocation.ofCaller()): IObservable<T> {
 	let computeFn: (reader: IReader) => T;
 	let owner: DebugOwner;
 	if (computeFnOrUndefined === undefined) {
@@ -169,6 +182,7 @@ export function derivedDisposable<T extends IDisposable | undefined>(computeFnOr
 				store = undefined;
 			}
 		},
-		strictEquals
+		strictEquals,
+		debugLocation
 	);
 }

--- a/src/vs/base/common/observableInternal/observables/derivedImpl.ts
+++ b/src/vs/base/common/observableInternal/observables/derivedImpl.ts
@@ -9,6 +9,7 @@ import { DebugNameData } from '../debugName.js';
 import { BugIndicatingError, DisposableStore, EqualityComparer, assertFn, onBugIndicatingError } from '../commonFacade/deps.js';
 import { getLogger } from '../logging/logging.js';
 import { IChangeTracker } from '../changeTracker.js';
+import { DebugLocation } from '../debugLocation.js';
 
 export interface IDerivedReader<TChange = void> extends IReaderWithStore {
 	/**
@@ -65,8 +66,9 @@ export class Derived<T, TChangeSummary = any, TChange = void> extends BaseObserv
 		private readonly _changeTracker: IChangeTracker<TChangeSummary> | undefined,
 		private readonly _handleLastObserverRemoved: (() => void) | undefined = undefined,
 		private readonly _equalityComparator: EqualityComparer<T>,
+		debugLocation: DebugLocation,
 	) {
-		super();
+		super(debugLocation);
 		this._changeSummary = this._changeTracker?.createChangeSummary(undefined);
 	}
 
@@ -427,6 +429,7 @@ export class DerivedWithSetter<T, TChangeSummary = any, TOutChanges = any> exten
 		handleLastObserverRemoved: (() => void) | undefined = undefined,
 		equalityComparator: EqualityComparer<T>,
 		public readonly set: (value: T, tx: ITransaction | undefined, change: TOutChanges) => void,
+		debugLocation: DebugLocation,
 	) {
 		super(
 			debugNameData,
@@ -434,6 +437,7 @@ export class DerivedWithSetter<T, TChangeSummary = any, TOutChanges = any> exten
 			changeTracker,
 			handleLastObserverRemoved,
 			equalityComparator,
+			debugLocation,
 		);
 	}
 }

--- a/src/vs/base/common/observableInternal/observables/lazyObservableValue.ts
+++ b/src/vs/base/common/observableInternal/observables/lazyObservableValue.ts
@@ -9,6 +9,7 @@ import { TransactionImpl } from '../transaction.js';
 import { DebugNameData } from '../debugName.js';
 import { getLogger } from '../logging/logging.js';
 import { BaseObservable } from './baseObservable.js';
+import { DebugLocation } from '../debugLocation.js';
 
 /**
  * Holds off updating observers until the value is actually read.
@@ -28,8 +29,9 @@ export class LazyObservableValue<T, TChange = void>
 		private readonly _debugNameData: DebugNameData,
 		initialValue: T,
 		private readonly _equalityComparator: EqualityComparer<T>,
+		debugLocation: DebugLocation
 	) {
-		super();
+		super(debugLocation);
 		this._value = initialValue;
 	}
 

--- a/src/vs/base/common/observableInternal/observables/observableFromEvent.ts
+++ b/src/vs/base/common/observableInternal/observables/observableFromEvent.ts
@@ -9,35 +9,39 @@ import { EqualityComparer, Event, IDisposable, strictEquals } from '../commonFac
 import { DebugOwner, DebugNameData, IDebugNameData } from '../debugName.js';
 import { getLogger } from '../logging/logging.js';
 import { BaseObservable } from './baseObservable.js';
+import { DebugLocation } from '../debugLocation.js';
 
 
 export function observableFromEvent<T, TArgs = unknown>(
 	owner: DebugOwner,
 	event: Event<TArgs>,
-	getValue: (args: TArgs | undefined) => T
+	getValue: (args: TArgs | undefined) => T,
+	debugLocation?: DebugLocation,
 ): IObservable<T>;
 export function observableFromEvent<T, TArgs = unknown>(
 	event: Event<TArgs>,
-	getValue: (args: TArgs | undefined) => T
+	getValue: (args: TArgs | undefined) => T,
 ): IObservable<T>;
 export function observableFromEvent(...args:
-	[owner: DebugOwner, event: Event<any>, getValue: (args: any | undefined) => any] |
+	[owner: DebugOwner, event: Event<any>, getValue: (args: any | undefined) => any, debugLocation?: DebugLocation] |
 	[event: Event<any>, getValue: (args: any | undefined) => any]
 ): IObservable<any> {
 	let owner;
 	let event;
 	let getValue;
-	if (args.length === 3) {
-		[owner, event, getValue] = args;
-	} else {
+	let debugLocation;
+	if (args.length === 2) {
 		[event, getValue] = args;
+	} else {
+		[owner, event, getValue, debugLocation] = args;
 	}
 	return new FromEventObservable(
 		new DebugNameData(owner, undefined, getValue),
 		event,
 		getValue,
 		() => FromEventObservable.globalTransaction,
-		strictEquals
+		strictEquals,
+		debugLocation ?? DebugLocation.ofCaller()
 	);
 }
 
@@ -46,12 +50,13 @@ export function observableFromEventOpts<T, TArgs = unknown>(
 		equalsFn?: EqualityComparer<T>;
 	},
 	event: Event<TArgs>,
-	getValue: (args: TArgs | undefined) => T
+	getValue: (args: TArgs | undefined) => T,
+	debugLocation = DebugLocation.ofCaller()
 ): IObservable<T> {
 	return new FromEventObservable(
 		new DebugNameData(options.owner, options.debugName, options.debugReferenceFn ?? getValue),
 		event,
-		getValue, () => FromEventObservable.globalTransaction, options.equalsFn ?? strictEquals
+		getValue, () => FromEventObservable.globalTransaction, options.equalsFn ?? strictEquals, debugLocation
 	);
 }
 
@@ -67,9 +72,10 @@ export class FromEventObservable<TArgs, T> extends BaseObservable<T> {
 		private readonly event: Event<TArgs>,
 		public readonly _getValue: (args: TArgs | undefined) => T,
 		private readonly _getTransaction: () => ITransaction | undefined,
-		private readonly _equalityComparator: EqualityComparer<T>
+		private readonly _equalityComparator: EqualityComparer<T>,
+		debugLocation: DebugLocation
 	) {
-		super();
+		super(debugLocation);
 	}
 
 	private getDebugName(): string | undefined {

--- a/src/vs/base/common/observableInternal/observables/observableSignal.ts
+++ b/src/vs/base/common/observableInternal/observables/observableSignal.ts
@@ -7,6 +7,7 @@ import { IObservableWithChange, ITransaction } from '../base.js';
 import { transaction } from '../transaction.js';
 import { DebugNameData } from '../debugName.js';
 import { BaseObservable } from './baseObservable.js';
+import { DebugLocation } from '../debugLocation.js';
 
 /**
  * Creates a signal that can be triggered to invalidate observers.
@@ -15,11 +16,11 @@ import { BaseObservable } from './baseObservable.js';
  */
 export function observableSignal<TDelta = void>(debugName: string): IObservableSignal<TDelta>;
 export function observableSignal<TDelta = void>(owner: object): IObservableSignal<TDelta>;
-export function observableSignal<TDelta = void>(debugNameOrOwner: string | object): IObservableSignal<TDelta> {
+export function observableSignal<TDelta = void>(debugNameOrOwner: string | object, debugLocation = DebugLocation.ofCaller()): IObservableSignal<TDelta> {
 	if (typeof debugNameOrOwner === 'string') {
-		return new ObservableSignal<TDelta>(debugNameOrOwner);
+		return new ObservableSignal<TDelta>(debugNameOrOwner, undefined, debugLocation);
 	} else {
-		return new ObservableSignal<TDelta>(undefined, debugNameOrOwner);
+		return new ObservableSignal<TDelta>(undefined, debugNameOrOwner, debugLocation);
 	}
 }
 
@@ -38,9 +39,10 @@ class ObservableSignal<TChange> extends BaseObservable<void, TChange> implements
 
 	constructor(
 		private readonly _debugName: string | undefined,
-		private readonly _owner?: object
+		private readonly _owner: object | undefined,
+		debugLocation: DebugLocation
 	) {
-		super();
+		super(debugLocation);
 	}
 
 	public trigger(tx: ITransaction | undefined, change: TChange): void {

--- a/src/vs/base/common/observableInternal/observables/observableSignalFromEvent.ts
+++ b/src/vs/base/common/observableInternal/observables/observableSignalFromEvent.ts
@@ -8,12 +8,14 @@ import { transaction } from '../transaction.js';
 import { Event, IDisposable } from '../commonFacade/deps.js';
 import { DebugOwner, DebugNameData } from '../debugName.js';
 import { BaseObservable } from './baseObservable.js';
+import { DebugLocation } from '../debugLocation.js';
 
 export function observableSignalFromEvent(
 	owner: DebugOwner | string,
-	event: Event<any>
+	event: Event<any>,
+	debugLocation = DebugLocation.ofCaller()
 ): IObservable<void> {
-	return new FromEventObservableSignal(typeof owner === 'string' ? owner : new DebugNameData(owner, undefined, undefined), event);
+	return new FromEventObservableSignal(typeof owner === 'string' ? owner : new DebugNameData(owner, undefined, undefined), event, debugLocation);
 }
 
 class FromEventObservableSignal extends BaseObservable<void> {
@@ -22,9 +24,10 @@ class FromEventObservableSignal extends BaseObservable<void> {
 	public readonly debugName: string;
 	constructor(
 		debugNameDataOrName: DebugNameData | string,
-		private readonly event: Event<any>
+		private readonly event: Event<any>,
+		debugLocation: DebugLocation
 	) {
-		super();
+		super(debugLocation);
 		this.debugName = typeof debugNameDataOrName === 'string'
 			? debugNameDataOrName
 			: debugNameDataOrName.getDebugName(this) ?? 'Observable Signal From Event';

--- a/src/vs/base/common/observableInternal/observables/observableValue.ts
+++ b/src/vs/base/common/observableInternal/observables/observableValue.ts
@@ -9,6 +9,7 @@ import { BaseObservable } from './baseObservable.js';
 import { EqualityComparer, IDisposable, strictEquals } from '../commonFacade/deps.js';
 import { DebugNameData } from '../debugName.js';
 import { getLogger } from '../logging/logging.js';
+import { DebugLocation } from '../debugLocation.js';
 
 /**
  * Creates an observable value.
@@ -19,14 +20,14 @@ import { getLogger } from '../logging/logging.js';
 
 export function observableValue<T, TChange = void>(name: string, initialValue: T): ISettableObservable<T, TChange>;
 export function observableValue<T, TChange = void>(owner: object, initialValue: T): ISettableObservable<T, TChange>;
-export function observableValue<T, TChange = void>(nameOrOwner: string | object, initialValue: T): ISettableObservable<T, TChange> {
+export function observableValue<T, TChange = void>(nameOrOwner: string | object, initialValue: T, debugLocation = DebugLocation.ofCaller()): ISettableObservable<T, TChange> {
 	let debugNameData: DebugNameData;
 	if (typeof nameOrOwner === 'string') {
 		debugNameData = new DebugNameData(undefined, nameOrOwner, undefined);
 	} else {
 		debugNameData = new DebugNameData(nameOrOwner, undefined, undefined);
 	}
-	return new ObservableValue(debugNameData, initialValue, strictEquals);
+	return new ObservableValue(debugNameData, initialValue, strictEquals, debugLocation);
 }
 
 export class ObservableValue<T, TChange = void>
@@ -41,9 +42,10 @@ export class ObservableValue<T, TChange = void>
 	constructor(
 		private readonly _debugNameData: DebugNameData,
 		initialValue: T,
-		private readonly _equalityComparator: EqualityComparer<T>
+		private readonly _equalityComparator: EqualityComparer<T>,
+		debugLocation: DebugLocation
 	) {
-		super();
+		super(debugLocation);
 		this._value = initialValue;
 
 		getLogger()?.handleObservableUpdated(this, { hadValue: false, newValue: initialValue, change: undefined, didChange: true, oldValue: undefined });
@@ -100,14 +102,14 @@ export class ObservableValue<T, TChange = void>
  * When a new value is set, the previous value is disposed.
  */
 
-export function disposableObservableValue<T extends IDisposable | undefined, TChange = void>(nameOrOwner: string | object, initialValue: T): ISettableObservable<T, TChange> & IDisposable {
+export function disposableObservableValue<T extends IDisposable | undefined, TChange = void>(nameOrOwner: string | object, initialValue: T, debugLocation = DebugLocation.ofCaller()): ISettableObservable<T, TChange> & IDisposable {
 	let debugNameData: DebugNameData;
 	if (typeof nameOrOwner === 'string') {
 		debugNameData = new DebugNameData(undefined, nameOrOwner, undefined);
 	} else {
 		debugNameData = new DebugNameData(nameOrOwner, undefined, undefined);
 	}
-	return new DisposableObservableValue(debugNameData, initialValue, strictEquals);
+	return new DisposableObservableValue(debugNameData, initialValue, strictEquals, debugLocation);
 }
 
 export class DisposableObservableValue<T extends IDisposable | undefined, TChange = void> extends ObservableValue<T, TChange> implements IDisposable {

--- a/src/vs/base/common/observableInternal/observables/observableValueOpts.ts
+++ b/src/vs/base/common/observableInternal/observables/observableValueOpts.ts
@@ -8,24 +8,28 @@ import { DebugNameData, IDebugNameData } from '../debugName.js';
 import { EqualityComparer, strictEquals } from '../commonFacade/deps.js';
 import { ObservableValue } from './observableValue.js';
 import { LazyObservableValue } from './lazyObservableValue.js';
+import { DebugLocation } from '../debugLocation.js';
 
 export function observableValueOpts<T, TChange = void>(
 	options: IDebugNameData & {
 		equalsFn?: EqualityComparer<T>;
 		lazy?: boolean;
 	},
-	initialValue: T
+	initialValue: T,
+	debugLocation = DebugLocation.ofCaller(),
 ): ISettableObservable<T, TChange> {
 	if (options.lazy) {
 		return new LazyObservableValue(
 			new DebugNameData(options.owner, options.debugName, undefined),
 			initialValue,
 			options.equalsFn ?? strictEquals,
+			debugLocation
 		);
 	}
 	return new ObservableValue(
 		new DebugNameData(options.owner, options.debugName, undefined),
 		initialValue,
 		options.equalsFn ?? strictEquals,
+		debugLocation
 	);
 }

--- a/src/vs/base/common/observableInternal/reactions/autorun.ts
+++ b/src/vs/base/common/observableInternal/reactions/autorun.ts
@@ -8,16 +8,18 @@ import { IChangeTracker } from '../changeTracker.js';
 import { DisposableStore, IDisposable, toDisposable } from '../commonFacade/deps.js';
 import { DebugNameData, IDebugNameData } from '../debugName.js';
 import { AutorunObserver } from './autorunImpl.js';
+import { DebugLocation } from '../debugLocation.js';
 
 /**
  * Runs immediately and whenever a transaction ends and an observed observable changed.
  * {@link fn} should start with a JS Doc using `@description` to name the autorun.
  */
-export function autorun(fn: (reader: IReaderWithStore) => void): IDisposable {
+export function autorun(fn: (reader: IReaderWithStore) => void, debugLocation = DebugLocation.ofCaller()): IDisposable {
 	return new AutorunObserver(
 		new DebugNameData(undefined, undefined, fn),
 		fn,
-		undefined
+		undefined,
+		debugLocation
 	);
 }
 
@@ -25,11 +27,12 @@ export function autorun(fn: (reader: IReaderWithStore) => void): IDisposable {
  * Runs immediately and whenever a transaction ends and an observed observable changed.
  * {@link fn} should start with a JS Doc using `@description` to name the autorun.
  */
-export function autorunOpts(options: IDebugNameData & {}, fn: (reader: IReaderWithStore) => void): IDisposable {
+export function autorunOpts(options: IDebugNameData & {}, fn: (reader: IReaderWithStore) => void, debugLocation = DebugLocation.ofCaller()): IDisposable {
 	return new AutorunObserver(
 		new DebugNameData(options.owner, options.debugName, options.debugReferenceFn ?? fn),
 		fn,
-		undefined
+		undefined,
+		debugLocation
 	);
 }
 
@@ -48,12 +51,14 @@ export function autorunHandleChanges<TChangeSummary>(
 	options: IDebugNameData & {
 		changeTracker: IChangeTracker<TChangeSummary>;
 	},
-	fn: (reader: IReader, changeSummary: TChangeSummary) => void
+	fn: (reader: IReader, changeSummary: TChangeSummary) => void,
+	debugLocation = DebugLocation.ofCaller()
 ): IDisposable {
 	return new AutorunObserver(
 		new DebugNameData(options.owner, options.debugName, options.debugReferenceFn ?? fn),
 		fn,
-		options.changeTracker
+		options.changeTracker,
+		debugLocation
 	);
 }
 

--- a/src/vs/base/common/observableInternal/reactions/autorunImpl.ts
+++ b/src/vs/base/common/observableInternal/reactions/autorunImpl.ts
@@ -8,6 +8,7 @@ import { DebugNameData } from '../debugName.js';
 import { assertFn, BugIndicatingError, DisposableStore, IDisposable, markAsDisposed, onBugIndicatingError, trackDisposable } from '../commonFacade/deps.js';
 import { getLogger } from '../logging/logging.js';
 import { IChangeTracker } from '../changeTracker.js';
+import { DebugLocation } from '../debugLocation.js';
 
 export const enum AutorunState {
 	/**
@@ -40,9 +41,10 @@ export class AutorunObserver<TChangeSummary = any> implements IObserver, IReader
 		public readonly _debugNameData: DebugNameData,
 		public readonly _runFn: (reader: IReaderWithStore, changeSummary: TChangeSummary) => void,
 		private readonly _changeTracker: IChangeTracker<TChangeSummary> | undefined,
+		debugLocation: DebugLocation
 	) {
 		this._changeSummary = this._changeTracker?.createChangeSummary(undefined);
-		getLogger()?.handleAutorunCreated(this);
+		getLogger()?.handleAutorunCreated(this, debugLocation);
 		this._run();
 
 		trackDisposable(this);

--- a/src/vs/base/common/observableInternal/utils/utilsCancellation.ts
+++ b/src/vs/base/common/observableInternal/utils/utilsCancellation.ts
@@ -9,6 +9,7 @@ import { CancellationError, CancellationToken, CancellationTokenSource } from '.
 import { strictEquals } from '../commonFacade/deps.js';
 import { autorun } from '../reactions/autorun.js';
 import { Derived } from '../observables/derivedImpl.js';
+import { DebugLocation } from '../debugLocation.js';
 
 /**
  * Resolves the promise when the observables state matches the predicate.
@@ -92,6 +93,7 @@ export function derivedWithCancellationToken<T>(computeFnOrOwner: ((reader: IRea
 			return computeFn(r, cancellationTokenSource.token);
 		}, undefined,
 		() => cancellationTokenSource?.dispose(),
-		strictEquals
+		strictEquals,
+		DebugLocation.ofCaller()
 	);
 }

--- a/src/vs/base/test/common/observable.test.ts
+++ b/src/vs/base/test/common/observable.test.ts
@@ -7,7 +7,7 @@ import assert from 'assert';
 import { setUnexpectedErrorHandler } from '../../common/errors.js';
 import { Emitter, Event } from '../../common/event.js';
 import { DisposableStore, toDisposable } from '../../common/lifecycle.js';
-import { IDerivedReader, IObservableWithChange, autorun, autorunHandleChanges, autorunWithStoreHandleChanges, derived, derivedDisposable, IObservable, IObserver, ISettableObservable, ITransaction, keepObserved, observableFromEvent, observableSignal, observableValue, recordChanges, transaction, waitForState, derivedHandleChanges, runOnChange } from '../../common/observable.js';
+import { IDerivedReader, IObservableWithChange, autorun, autorunHandleChanges, autorunWithStoreHandleChanges, derived, derivedDisposable, IObservable, IObserver, ISettableObservable, ITransaction, keepObserved, observableFromEvent, observableSignal, observableValue, recordChanges, transaction, waitForState, derivedHandleChanges, runOnChange, DebugLocation } from '../../common/observable.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from './utils.js';
 // eslint-disable-next-line local/code-no-deep-import-of-internal
 import { observableReducer } from '../../common/observableInternal/experimental/reducer.js';
@@ -1767,8 +1767,12 @@ export class LoggingObservableValue<T, TChange = void>
 	implements ISettableObservable<T, TChange> {
 	private value: T;
 
-	constructor(public readonly debugName: string, initialValue: T, private readonly logger: Log) {
-		super();
+	constructor(
+		public readonly debugName: string,
+		initialValue: T,
+		private readonly logger: Log
+	) {
+		super(DebugLocation.ofCaller());
 		this.value = initialValue;
 	}
 

--- a/src/vs/platform/observable/common/observableMemento.ts
+++ b/src/vs/platform/observable/common/observableMemento.ts
@@ -5,6 +5,7 @@
 
 import { strictEquals } from '../../../base/common/equals.js';
 import { DisposableStore, IDisposable } from '../../../base/common/lifecycle.js';
+import { DebugLocation } from '../../../base/common/observable.js';
 // eslint-disable-next-line local/code-no-deep-import-of-internal
 import { DebugNameData } from '../../../base/common/observableInternal/debugName.js';
 // eslint-disable-next-line local/code-no-deep-import-of-internal
@@ -63,7 +64,7 @@ export class ObservableMemento<T> extends ObservableValue<T> implements IDisposa
 			}
 		}
 
-		super(new DebugNameData(undefined, `storage/${opts.key}`, undefined), initialValue, strictEquals);
+		super(new DebugNameData(undefined, `storage/${opts.key}`, undefined), initialValue, strictEquals, DebugLocation.ofCaller());
 
 		const didChange = storageService.onDidChangeValue(storageScope, opts.key, this._store);
 		// only take external changes if there aren't local changes we've made

--- a/src/vs/platform/observable/common/platformObservableUtils.ts
+++ b/src/vs/platform/observable/common/platformObservableUtils.ts
@@ -4,43 +4,46 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { DisposableStore, IDisposable } from '../../../base/common/lifecycle.js';
-import { derivedOpts, IObservable, IReader, observableFromEvent, observableFromEventOpts } from '../../../base/common/observable.js';
+import { DebugLocation, derivedOpts, IObservable, IReader, observableFromEvent, observableFromEventOpts } from '../../../base/common/observable.js';
 import { IConfigurationService } from '../../configuration/common/configuration.js';
 import { ContextKeyValue, IContextKeyService, RawContextKey } from '../../contextkey/common/contextkey.js';
 
 /** Creates an observable update when a configuration key updates. */
-export function observableConfigValue<T>(key: string, defaultValue: T, configurationService: IConfigurationService): IObservable<T> {
-	function compute_$show2FramesUp() {
-		return observableFromEventOpts({ debugName: () => `Configuration Key "${key}"`, },
-			(handleChange) => configurationService.onDidChangeConfiguration(e => {
-				if (e.affectsConfiguration(key)) {
-					handleChange(e);
-				}
-			}),
-			() => configurationService.getValue<T>(key) ?? defaultValue
-		);
-	}
-	return compute_$show2FramesUp();
+export function observableConfigValue<T>(
+	key: string,
+	defaultValue: T,
+	configurationService: IConfigurationService,
+	debugLocation = DebugLocation.ofCaller(),
+): IObservable<T> {
+	return observableFromEventOpts({ debugName: () => `Configuration Key "${key}"`, },
+		(handleChange) => configurationService.onDidChangeConfiguration(e => {
+			if (e.affectsConfiguration(key)) {
+				handleChange(e);
+			}
+		}),
+		() => configurationService.getValue<T>(key) ?? defaultValue,
+		debugLocation,
+	);
 }
 
 /** Update the configuration key with a value derived from observables. */
-export function bindContextKey<T extends ContextKeyValue>(key: RawContextKey<T>, service: IContextKeyService, computeValue: (reader: IReader) => T): IDisposable {
+export function bindContextKey<T extends ContextKeyValue>(
+	key: RawContextKey<T>,
+	service: IContextKeyService,
+	computeValue: (reader: IReader) => T,
+	debugLocation = DebugLocation.ofCaller(),
+): IDisposable {
 	const boundKey = key.bindTo(service);
-
-	function compute_$show2FramesUp() {
-		const store = new DisposableStore();
-		derivedOpts({ debugName: () => `Set Context Key "${key.key}"` }, reader => {
-			const value = computeValue(reader);
-			boundKey.set(value);
-			return value;
-		}).recomputeInitiallyAndOnChange(store);
-		return store;
-	}
-
-	return compute_$show2FramesUp();
+	const store = new DisposableStore();
+	derivedOpts({ debugName: () => `Set Context Key "${key.key}"` }, reader => {
+		const value = computeValue(reader);
+		boundKey.set(value);
+		return value;
+	}, debugLocation).recomputeInitiallyAndOnChange(store);
+	return store;
 }
 
 
-export function observableContextKey<T>(key: string, contextKeyService: IContextKeyService): IObservable<T | undefined> {
-	return observableFromEvent(contextKeyService.onDidChangeContext, () => contextKeyService.getContextKeyValue<T>(key));
+export function observableContextKey<T>(key: string, contextKeyService: IContextKeyService, debugLocation = DebugLocation.ofCaller()): IObservable<T | undefined> {
+	return observableFromEvent(undefined, contextKeyService.onDidChangeContext, () => contextKeyService.getContextKeyValue<T>(key), debugLocation);
 }


### PR DESCRIPTION
The stack trace processing approach used file and method name conventions to detect the location of an observable.
This would break when the code is bundled (e.g. in insiders).

With this PR, the DebugLocation class is introduced that fixes this.
