### PR TITLE
Separator in notebook toolbar should show with opacity (fix #259651)

### DIFF
--- a/src/vs/base/browser/ui/actionbar/actionbar.css
+++ b/src/vs/base/browser/ui/actionbar/actionbar.css
@@ -77,7 +77,7 @@
 
 .monaco-action-bar.vertical .action-label.separator {
 	display: block;
-	border-bottom: 1px solid #bbb;
+	border-bottom: 1px solid var(--vscode-disabledForeground);
 	padding-top: 1px;
 	margin-left: .8em;
 	margin-right: .8em;
@@ -90,7 +90,7 @@
 	cursor: default;
 	min-width: 1px;
 	padding: 0;
-	background-color: #bbb;
+	background-color: var(--vscode-disabledForeground);
 }
 
 .secondary-actions .monaco-action-bar .action-label {

--- a/src/vs/workbench/browser/parts/media/paneCompositePart.css
+++ b/src/vs/workbench/browser/parts/media/paneCompositePart.css
@@ -12,10 +12,6 @@
 	margin-right: 4px;
 }
 
-.monaco-workbench .pane-composite-part > .title > .global-actions .monaco-action-bar .action-item .action-label.separator {
-	background-color: var(--vscode-disabledForeground);
-}
-
 .monaco-workbench .pane-composite-part > .title.has-composite-bar > .title-actions .monaco-action-bar .action-item .action-label {
 	outline-offset: -2px;
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
