### PR TITLE
Add recent completion ID for snooze

### DIFF
--- a/src/vs/editor/contrib/inlineCompletions/browser/model/inlineCompletionsModel.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/model/inlineCompletionsModel.ts
@@ -146,6 +146,12 @@ export class InlineCompletionsModel extends Disposable {
 					: InlineCompletionEditorType.TextEditor;
 		}
 
+		this._register(recomputeInitiallyAndOnChange(this.state, (s) => {
+			if (s && s.inlineCompletion) {
+				this._inlineCompletionsService.reportNewCompletion(s.inlineCompletion.requestUuid);
+			}
+		}));
+
 		this._register(recomputeInitiallyAndOnChange(this._fetchInlineCompletionsPromise));
 
 		this._register(autorun(reader => {


### PR DESCRIPTION
```Copilot Generated Description:``` Introduce a method to report new inline completions, storing the last and recent completion IDs for telemetry purposes.

closes https://github.com/microsoft/vscode/issues/260007