### PR TITLE
Saving untitled editor with encoding drops that encoding (fix #260117)

### DIFF
--- a/src/vs/workbench/services/untitled/common/untitledTextEditorModel.ts
+++ b/src/vs/workbench/services/untitled/common/untitledTextEditorModel.ts
@@ -65,6 +65,16 @@ export interface IUntitledTextEditorModel extends ITextEditorModel, ILanguageSup
 	 * Resolves the untitled model.
 	 */
 	resolve(): Promise<void>;
+
+	/**
+	 * Whether this model is resolved or not.
+	 */
+	isResolved(): this is IResolvedUntitledTextEditorModel;
+}
+
+export interface IResolvedUntitledTextEditorModel extends IUntitledTextEditorModel {
+
+	readonly textEditorModel: ITextModel;
 }
 
 export class UntitledTextEditorModel extends BaseTextEditorModel implements IUntitledTextEditorModel {
@@ -372,6 +382,10 @@ export class UntitledTextEditorModel extends BaseTextEditorModel implements IUnt
 		}
 
 		return super.resolve();
+	}
+
+	override isResolved(): this is IResolvedUntitledTextEditorModel {
+		return !!this.textEditorModelHandle;
 	}
 
 	protected override installModelListeners(model: ITextModel): void {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
