### PR TITLE
Use ts-native to compile our build scripts

### DIFF
--- a/build/azure-pipelines/common/checkForArtifact.js
+++ b/build/azure-pipelines/common/checkForArtifact.js
@@ -1,9 +1,9 @@
 "use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
 /*---------------------------------------------------------------------------------------------
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-Object.defineProperty(exports, "__esModule", { value: true });
 const publish_1 = require("./publish");
 const retry_1 = require("./retry");
 async function getPipelineArtifacts() {

--- a/build/azure-pipelines/common/codesign.js
+++ b/build/azure-pipelines/common/codesign.js
@@ -1,12 +1,12 @@
 "use strict";
-/*---------------------------------------------------------------------------------------------
- *  Copyright (c) Microsoft Corporation. All rights reserved.
- *  Licensed under the MIT License. See License.txt in the project root for license information.
- *--------------------------------------------------------------------------------------------*/
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.printBanner = printBanner;
 exports.streamProcessOutputAndCheckResult = streamProcessOutputAndCheckResult;
 exports.spawnCodesignProcess = spawnCodesignProcess;
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
 const zx_1 = require("zx");
 function printBanner(title) {
     title = `${title} (${new Date().toISOString()})`;

--- a/build/azure-pipelines/common/computeBuiltInDepsCacheKey.js
+++ b/build/azure-pipelines/common/computeBuiltInDepsCacheKey.js
@@ -1,12 +1,12 @@
 "use strict";
-/*---------------------------------------------------------------------------------------------
- *  Copyright (c) Microsoft Corporation. All rights reserved.
- *  Licensed under the MIT License. See License.txt in the project root for license information.
- *--------------------------------------------------------------------------------------------*/
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
 const fs_1 = __importDefault(require("fs"));
 const path_1 = __importDefault(require("path"));
 const crypto_1 = __importDefault(require("crypto"));

--- a/build/azure-pipelines/common/computeNodeModulesCacheKey.js
+++ b/build/azure-pipelines/common/computeNodeModulesCacheKey.js
@@ -1,12 +1,12 @@
 "use strict";
-/*---------------------------------------------------------------------------------------------
- *  Copyright (c) Microsoft Corporation. All rights reserved.
- *  Licensed under the MIT License. See License.txt in the project root for license information.
- *--------------------------------------------------------------------------------------------*/
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
 const fs_1 = __importDefault(require("fs"));
 const path_1 = __importDefault(require("path"));
 const crypto_1 = __importDefault(require("crypto"));

--- a/build/azure-pipelines/common/createBuild.js
+++ b/build/azure-pipelines/common/createBuild.js
@@ -1,9 +1,9 @@
 "use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
 /*---------------------------------------------------------------------------------------------
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-Object.defineProperty(exports, "__esModule", { value: true });
 const identity_1 = require("@azure/identity");
 const cosmos_1 = require("@azure/cosmos");
 const retry_1 = require("./retry");

--- a/build/azure-pipelines/common/getPublishAuthTokens.js
+++ b/build/azure-pipelines/common/getPublishAuthTokens.js
@@ -1,8 +1,4 @@
 "use strict";
-/*---------------------------------------------------------------------------------------------
- *  Copyright (c) Microsoft Corporation. All rights reserved.
- *  Licensed under the MIT License. See License.txt in the project root for license information.
- *--------------------------------------------------------------------------------------------*/
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.getAccessToken = getAccessToken;
 const msal_node_1 = require("@azure/msal-node");

--- a/build/azure-pipelines/common/listNodeModules.js
+++ b/build/azure-pipelines/common/listNodeModules.js
@@ -1,12 +1,12 @@
 "use strict";
-/*---------------------------------------------------------------------------------------------
- *  Copyright (c) Microsoft Corporation. All rights reserved.
- *  Licensed under the MIT License. See License.txt in the project root for license information.
- *--------------------------------------------------------------------------------------------*/
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
 const fs_1 = __importDefault(require("fs"));
 const path_1 = __importDefault(require("path"));
 if (process.argv.length !== 3) {

--- a/build/azure-pipelines/common/publish.js
+++ b/build/azure-pipelines/common/publish.js
@@ -1,14 +1,14 @@
 "use strict";
-/*---------------------------------------------------------------------------------------------
- *  Copyright (c) Microsoft Corporation. All rights reserved.
- *  Licensed under the MIT License. See License.txt in the project root for license information.
- *--------------------------------------------------------------------------------------------*/
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.e = e;
 exports.requestAZDOAPI = requestAZDOAPI;
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
 const fs_1 = __importDefault(require("fs"));
 const path_1 = __importDefault(require("path"));
 const stream_1 = require("stream");

--- a/build/azure-pipelines/common/releaseBuild.js
+++ b/build/azure-pipelines/common/releaseBuild.js
@@ -1,9 +1,9 @@
 "use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
 /*---------------------------------------------------------------------------------------------
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-Object.defineProperty(exports, "__esModule", { value: true });
 const identity_1 = require("@azure/identity");
 const cosmos_1 = require("@azure/cosmos");
 const retry_1 = require("./retry");

--- a/build/azure-pipelines/common/retry.js
+++ b/build/azure-pipelines/common/retry.js
@@ -1,10 +1,10 @@
 "use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.retry = retry;
 /*---------------------------------------------------------------------------------------------
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-Object.defineProperty(exports, "__esModule", { value: true });
-exports.retry = retry;
 async function retry(fn) {
     let lastError;
     for (let run = 1; run <= 10; run++) {

--- a/build/azure-pipelines/common/sign-win32.js
+++ b/build/azure-pipelines/common/sign-win32.js
@@ -1,12 +1,12 @@
 "use strict";
-/*---------------------------------------------------------------------------------------------
- *  Copyright (c) Microsoft Corporation. All rights reserved.
- *  Licensed under the MIT License. See License.txt in the project root for license information.
- *--------------------------------------------------------------------------------------------*/
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
 const sign_1 = require("./sign");
 const path_1 = __importDefault(require("path"));
 (0, sign_1.main)([

--- a/build/azure-pipelines/common/sign.js
+++ b/build/azure-pipelines/common/sign.js
@@ -1,14 +1,14 @@
 "use strict";
-/*---------------------------------------------------------------------------------------------
- *  Copyright (c) Microsoft Corporation. All rights reserved.
- *  Licensed under the MIT License. See License.txt in the project root for license information.
- *--------------------------------------------------------------------------------------------*/
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.Temp = void 0;
 exports.main = main;
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
 const child_process_1 = __importDefault(require("child_process"));
 const fs_1 = __importDefault(require("fs"));
 const crypto_1 = __importDefault(require("crypto"));
@@ -159,8 +159,10 @@ function main([esrpCliPath, type, folderPath, pattern]) {
     const args = [
         esrpCliPath,
         'vsts.sign',
-        '-a', process.env['ESRP_CLIENT_ID'],
-        '-d', process.env['ESRP_TENANT_ID'],
+        '-a',
+        process.env['ESRP_CLIENT_ID'],
+        '-d',
+        process.env['ESRP_TENANT_ID'],
         '-k', JSON.stringify({ akv: 'vscode-esrp' }),
         '-z', JSON.stringify({ akv: 'vscode-esrp', cert: 'esrp-sign' }),
         '-f', folderPath,
@@ -186,7 +188,8 @@ function main([esrpCliPath, type, folderPath, pattern]) {
         '-pendingAnalysisWaitTimeoutMinutes', '5',
         '-adoTaskVersion', adoTaskVersion,
         '-resourceUri', 'https://msazurecloud.onmicrosoft.com/api.esrp.microsoft.com',
-        '-esrpClientId', process.env['ESRP_CLIENT_ID'],
+        '-esrpClientId',
+        process.env['ESRP_CLIENT_ID'],
         '-useMSIAuthentication', 'true',
         '-federatedTokenData', JSON.stringify(federatedTokenData)
     ];

--- a/build/azure-pipelines/common/waitForArtifacts.js
+++ b/build/azure-pipelines/common/waitForArtifacts.js
@@ -1,9 +1,9 @@
 "use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
 /*---------------------------------------------------------------------------------------------
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-Object.defineProperty(exports, "__esModule", { value: true });
 const publish_1 = require("../common/publish");
 const retry_1 = require("../common/retry");
 async function getPipelineArtifacts() {

--- a/build/azure-pipelines/darwin/codesign.js
+++ b/build/azure-pipelines/darwin/codesign.js
@@ -1,9 +1,9 @@
 "use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
 /*---------------------------------------------------------------------------------------------
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-Object.defineProperty(exports, "__esModule", { value: true });
 const codesign_1 = require("../common/codesign");
 const publish_1 = require("../common/publish");
 async function main() {

--- a/build/azure-pipelines/distro/mixin-npm.js
+++ b/build/azure-pipelines/distro/mixin-npm.js
@@ -1,12 +1,12 @@
 "use strict";
-/*---------------------------------------------------------------------------------------------
- *  Copyright (c) Microsoft Corporation. All rights reserved.
- *  Licensed under the MIT License. See License.txt in the project root for license information.
- *--------------------------------------------------------------------------------------------*/
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
 const fs_1 = __importDefault(require("fs"));
 const path_1 = __importDefault(require("path"));
 const { dirs } = require('../../npm/dirs');

--- a/build/azure-pipelines/distro/mixin-quality.js
+++ b/build/azure-pipelines/distro/mixin-quality.js
@@ -1,12 +1,12 @@
 "use strict";
-/*---------------------------------------------------------------------------------------------
- *  Copyright (c) Microsoft Corporation. All rights reserved.
- *  Licensed under the MIT License. See License.txt in the project root for license information.
- *--------------------------------------------------------------------------------------------*/
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
 const fs_1 = __importDefault(require("fs"));
 const path_1 = __importDefault(require("path"));
 function log(...args) {

--- a/build/azure-pipelines/linux/codesign.js
+++ b/build/azure-pipelines/linux/codesign.js
@@ -1,9 +1,9 @@
 "use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
 /*---------------------------------------------------------------------------------------------
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-Object.defineProperty(exports, "__esModule", { value: true });
 const codesign_1 = require("../common/codesign");
 const publish_1 = require("../common/publish");
 async function main() {

--- a/build/azure-pipelines/publish-types/check-version.js
+++ b/build/azure-pipelines/publish-types/check-version.js
@@ -1,12 +1,12 @@
 "use strict";
-/*---------------------------------------------------------------------------------------------
- *  Copyright (c) Microsoft Corporation. All rights reserved.
- *  Licensed under the MIT License. See License.txt in the project root for license information.
- *--------------------------------------------------------------------------------------------*/
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
 const child_process_1 = __importDefault(require("child_process"));
 let tag = '';
 try {

--- a/build/azure-pipelines/publish-types/update-types.js
+++ b/build/azure-pipelines/publish-types/update-types.js
@@ -1,12 +1,12 @@
 "use strict";
-/*---------------------------------------------------------------------------------------------
- *  Copyright (c) Microsoft Corporation. All rights reserved.
- *  Licensed under the MIT License. See License.txt in the project root for license information.
- *--------------------------------------------------------------------------------------------*/
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
 const fs_1 = __importDefault(require("fs"));
 const child_process_1 = __importDefault(require("child_process"));
 const path_1 = __importDefault(require("path"));

--- a/build/azure-pipelines/upload-cdn.js
+++ b/build/azure-pipelines/upload-cdn.js
@@ -1,12 +1,12 @@
 "use strict";
-/*---------------------------------------------------------------------------------------------
- *  Copyright (c) Microsoft Corporation. All rights reserved.
- *  Licensed under the MIT License. See License.txt in the project root for license information.
- *--------------------------------------------------------------------------------------------*/
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
 const event_stream_1 = __importDefault(require("event-stream"));
 const vinyl_1 = __importDefault(require("vinyl"));
 const vinyl_fs_1 = __importDefault(require("vinyl-fs"));

--- a/build/azure-pipelines/upload-nlsmetadata.js
+++ b/build/azure-pipelines/upload-nlsmetadata.js
@@ -1,12 +1,12 @@
 "use strict";
-/*---------------------------------------------------------------------------------------------
- *  Copyright (c) Microsoft Corporation. All rights reserved.
- *  Licensed under the MIT License. See License.txt in the project root for license information.
- *--------------------------------------------------------------------------------------------*/
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
 const event_stream_1 = __importDefault(require("event-stream"));
 const vinyl_fs_1 = __importDefault(require("vinyl-fs"));
 const gulp_merge_json_1 = __importDefault(require("gulp-merge-json"));

--- a/build/azure-pipelines/upload-sourcemaps.js
+++ b/build/azure-pipelines/upload-sourcemaps.js
@@ -1,8 +1,4 @@
 "use strict";
-/*---------------------------------------------------------------------------------------------
- *  Copyright (c) Microsoft Corporation. All rights reserved.
- *  Licensed under the MIT License. See License.txt in the project root for license information.
- *--------------------------------------------------------------------------------------------*/
 var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
     var desc = Object.getOwnPropertyDescriptor(m, k);
@@ -40,6 +36,10 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
 const path_1 = __importDefault(require("path"));
 const event_stream_1 = __importDefault(require("event-stream"));
 const vinyl_fs_1 = __importDefault(require("vinyl-fs"));

--- a/build/azure-pipelines/win32/codesign.js
+++ b/build/azure-pipelines/win32/codesign.js
@@ -1,9 +1,9 @@
 "use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
 /*---------------------------------------------------------------------------------------------
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-Object.defineProperty(exports, "__esModule", { value: true });
 const zx_1 = require("zx");
 const codesign_1 = require("../common/codesign");
 const publish_1 = require("../common/publish");

--- a/build/checker/layersChecker.js
+++ b/build/checker/layersChecker.js
@@ -1,12 +1,12 @@
 "use strict";
-/*---------------------------------------------------------------------------------------------
- *  Copyright (c) Microsoft Corporation. All rights reserved.
- *  Licensed under the MIT License. See License.txt in the project root for license information.
- *--------------------------------------------------------------------------------------------*/
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
 const typescript_1 = __importDefault(require("typescript"));
 const fs_1 = require("fs");
 const path_1 = require("path");
@@ -51,7 +51,7 @@ const RULES = [
             'browserElements/common/browserElements.ts',
             'browserElements/common/nativeBrowserElementsService.ts'
         ].join(',')}}`,
-        disallowedTypes: [ /* Ignore native types that are defined from here */],
+        disallowedTypes: [ /* Ignore native types that are defined from here */ /* Ignore native types that are defined from here */],
     },
     // Common: vs/base/parts/sandbox/electron-browser/preload{,-aux}.ts
     {

--- a/build/darwin/create-universal-app.js
+++ b/build/darwin/create-universal-app.js
@@ -1,12 +1,12 @@
 "use strict";
-/*---------------------------------------------------------------------------------------------
- *  Copyright (c) Microsoft Corporation. All rights reserved.
- *  Licensed under the MIT License. See License.txt in the project root for license information.
- *--------------------------------------------------------------------------------------------*/
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
 const path_1 = __importDefault(require("path"));
 const fs_1 = __importDefault(require("fs"));
 const minimatch_1 = __importDefault(require("minimatch"));

--- a/build/darwin/sign.js
+++ b/build/darwin/sign.js
@@ -1,12 +1,12 @@
 "use strict";
-/*---------------------------------------------------------------------------------------------
- *  Copyright (c) Microsoft Corporation. All rights reserved.
- *  Licensed under the MIT License. See License.txt in the project root for license information.
- *--------------------------------------------------------------------------------------------*/
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
 const fs_1 = __importDefault(require("fs"));
 const path_1 = __importDefault(require("path"));
 const osx_sign_1 = require("@electron/osx-sign");
@@ -89,7 +89,7 @@ async function main(buildDir) {
     await (0, osx_sign_1.sign)(appOpts);
 }
 if (require.main === module) {
-    main(process.argv[2]).catch(async (err) => {
+    main(process.argv[2]).catch(async err => {
         console.error(err);
         const tempDir = process.env['AGENT_TEMPDIRECTORY'];
         if (tempDir) {

--- a/build/darwin/verify-macho.js
+++ b/build/darwin/verify-macho.js
@@ -1,12 +1,12 @@
 "use strict";
-/*---------------------------------------------------------------------------------------------
- *  Copyright (c) Microsoft Corporation. All rights reserved.
- *  Licensed under the MIT License. See License.txt in the project root for license information.
- *--------------------------------------------------------------------------------------------*/
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
 const assert_1 = __importDefault(require("assert"));
 const path_1 = __importDefault(require("path"));
 const promises_1 = require("fs/promises");

--- a/build/lib/asar.js
+++ b/build/lib/asar.js
@@ -1,13 +1,13 @@
 "use strict";
-/*---------------------------------------------------------------------------------------------
- *  Copyright (c) Microsoft Corporation. All rights reserved.
- *  Licensed under the MIT License. See License.txt in the project root for license information.
- *--------------------------------------------------------------------------------------------*/
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.createAsar = createAsar;
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
 const path_1 = __importDefault(require("path"));
 const event_stream_1 = __importDefault(require("event-stream"));
 const pickle = require('chromium-pickle-js');

--- a/build/lib/builtInExtensions.js
+++ b/build/lib/builtInExtensions.js
@@ -1,8 +1,4 @@
 "use strict";
-/*---------------------------------------------------------------------------------------------
- *  Copyright (c) Microsoft Corporation. All rights reserved.
- *  Licensed under the MIT License. See License.txt in the project root for license information.
- *--------------------------------------------------------------------------------------------*/
 var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
     var desc = Object.getOwnPropertyDescriptor(m, k);
@@ -42,6 +38,10 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.getExtensionStream = getExtensionStream;
 exports.getBuiltInExtensions = getBuiltInExtensions;
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
 const fs_1 = __importDefault(require("fs"));
 const path_1 = __importDefault(require("path"));
 const os_1 = __importDefault(require("os"));

--- a/build/lib/builtInExtensionsCG.js
+++ b/build/lib/builtInExtensionsCG.js
@@ -1,12 +1,12 @@
 "use strict";
-/*---------------------------------------------------------------------------------------------
- *  Copyright (c) Microsoft Corporation. All rights reserved.
- *  Licensed under the MIT License. See License.txt in the project root for license information.
- *--------------------------------------------------------------------------------------------*/
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
 const fs_1 = __importDefault(require("fs"));
 const path_1 = __importDefault(require("path"));
 const url_1 = __importDefault(require("url"));

--- a/build/lib/bundle.js
+++ b/build/lib/bundle.js
@@ -1,8 +1,4 @@
 "use strict";
-/*---------------------------------------------------------------------------------------------
- *  Copyright (c) Microsoft Corporation. All rights reserved.
- *  Licensed under the MIT License. See License.txt in the project root for license information.
- *--------------------------------------------------------------------------------------------*/
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.removeAllTSBoilerplate = removeAllTSBoilerplate;
 function removeAllTSBoilerplate(source) {

--- a/build/lib/compilation.js
+++ b/build/lib/compilation.js
@@ -1,8 +1,4 @@
 "use strict";
-/*---------------------------------------------------------------------------------------------
- *  Copyright (c) Microsoft Corporation. All rights reserved.
- *  Licensed under the MIT License. See License.txt in the project root for license information.
- *--------------------------------------------------------------------------------------------*/
 var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
     var desc = Object.getOwnPropertyDescriptor(m, k);
@@ -45,6 +41,10 @@ exports.createCompile = createCompile;
 exports.transpileTask = transpileTask;
 exports.compileTask = compileTask;
 exports.watchTask = watchTask;
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
 const event_stream_1 = __importDefault(require("event-stream"));
 const fs_1 = __importDefault(require("fs"));
 const gulp_1 = __importDefault(require("gulp"));

--- a/build/lib/date.js
+++ b/build/lib/date.js
@@ -1,14 +1,14 @@
 "use strict";
-/*---------------------------------------------------------------------------------------------
- *  Copyright (c) Microsoft Corporation. All rights reserved.
- *  Licensed under the MIT License. See License.txt in the project root for license information.
- *--------------------------------------------------------------------------------------------*/
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.writeISODate = writeISODate;
 exports.readISODate = readISODate;
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
 const path_1 = __importDefault(require("path"));
 const fs_1 = __importDefault(require("fs"));
 const root = path_1.default.join(__dirname, '..', '..');

--- a/build/lib/dependencies.js
+++ b/build/lib/dependencies.js
@@ -1,13 +1,13 @@
 "use strict";
-/*---------------------------------------------------------------------------------------------
- *  Copyright (c) Microsoft Corporation. All rights reserved.
- *  Licensed under the MIT License. See License.txt in the project root for license information.
- *--------------------------------------------------------------------------------------------*/
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.getProductionDependencies = getProductionDependencies;
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
 const fs_1 = __importDefault(require("fs"));
 const path_1 = __importDefault(require("path"));
 const child_process_1 = __importDefault(require("child_process"));

--- a/build/lib/electron.js
+++ b/build/lib/electron.js
@@ -1,8 +1,4 @@
 "use strict";
-/*---------------------------------------------------------------------------------------------
- *  Copyright (c) Microsoft Corporation. All rights reserved.
- *  Licensed under the MIT License. See License.txt in the project root for license information.
- *--------------------------------------------------------------------------------------------*/
 var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
     var desc = Object.getOwnPropertyDescriptor(m, k);
@@ -41,6 +37,10 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.config = void 0;
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
 const fs_1 = __importDefault(require("fs"));
 const path_1 = __importDefault(require("path"));
 const vinyl_fs_1 = __importDefault(require("vinyl-fs"));

--- a/build/lib/extensions.js
+++ b/build/lib/extensions.js
@@ -1,8 +1,4 @@
 "use strict";
-/*---------------------------------------------------------------------------------------------
- *  Copyright (c) Microsoft Corporation. All rights reserved.
- *  Licensed under the MIT License. See License.txt in the project root for license information.
- *--------------------------------------------------------------------------------------------*/
 var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
     var desc = Object.getOwnPropertyDescriptor(m, k);
@@ -51,6 +47,10 @@ exports.scanBuiltinExtensions = scanBuiltinExtensions;
 exports.translatePackageJSON = translatePackageJSON;
 exports.webpackExtensions = webpackExtensions;
 exports.buildExtensionMedia = buildExtensionMedia;
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
 const event_stream_1 = __importDefault(require("event-stream"));
 const fs_1 = __importDefault(require("fs"));
 const child_process_1 = __importDefault(require("child_process"));

--- a/build/lib/fetch.js
+++ b/build/lib/fetch.js
@@ -1,8 +1,4 @@
 "use strict";
-/*---------------------------------------------------------------------------------------------
- *  Copyright (c) Microsoft Corporation. All rights reserved.
- *  Licensed under the MIT License. See License.txt in the project root for license information.
- *--------------------------------------------------------------------------------------------*/
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
@@ -10,6 +6,10 @@ Object.defineProperty(exports, "__esModule", { value: true });
 exports.fetchUrls = fetchUrls;
 exports.fetchUrl = fetchUrl;
 exports.fetchGithub = fetchGithub;
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
 const event_stream_1 = __importDefault(require("event-stream"));
 const vinyl_1 = __importDefault(require("vinyl"));
 const fancy_log_1 = __importDefault(require("fancy-log"));

--- a/build/lib/getVersion.js
+++ b/build/lib/getVersion.js
@@ -1,8 +1,4 @@
 "use strict";
-/*---------------------------------------------------------------------------------------------
- *  Copyright (c) Microsoft Corporation. All rights reserved.
- *  Licensed under the MIT License. See License.txt in the project root for license information.
- *--------------------------------------------------------------------------------------------*/
 var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
     var desc = Object.getOwnPropertyDescriptor(m, k);
@@ -38,6 +34,10 @@ var __importStar = (this && this.__importStar) || (function () {
 })();
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.getVersion = getVersion;
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
 const git = __importStar(require("./git"));
 function getVersion(root) {
     let version = process.env['BUILD_SOURCEVERSION'];

--- a/build/lib/i18n.js
+++ b/build/lib/i18n.js
@@ -1,8 +1,4 @@
 "use strict";
-/*---------------------------------------------------------------------------------------------
- *  Copyright (c) Microsoft Corporation. All rights reserved.
- *  Licensed under the MIT License. See License.txt in the project root for license information.
- *--------------------------------------------------------------------------------------------*/
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
@@ -15,6 +11,10 @@ exports.createXlfFilesForExtensions = createXlfFilesForExtensions;
 exports.createXlfFilesForIsl = createXlfFilesForIsl;
 exports.prepareI18nPackFiles = prepareI18nPackFiles;
 exports.prepareIslFiles = prepareIslFiles;
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
 const path_1 = __importDefault(require("path"));
 const fs_1 = __importDefault(require("fs"));
 const event_stream_1 = require("event-stream");

--- a/build/lib/inlineMeta.js
+++ b/build/lib/inlineMeta.js
@@ -1,13 +1,13 @@
 "use strict";
-/*---------------------------------------------------------------------------------------------
- *  Copyright (c) Microsoft Corporation. All rights reserved.
- *  Licensed under the MIT License. See License.txt in the project root for license information.
- *--------------------------------------------------------------------------------------------*/
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.inlineMeta = inlineMeta;
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
 const event_stream_1 = __importDefault(require("event-stream"));
 const path_1 = require("path");
 const packageJsonMarkerId = 'BUILD_INSERT_PACKAGE_CONFIGURATION';

--- a/build/lib/mangle/index.js
+++ b/build/lib/mangle/index.js
@@ -1,13 +1,13 @@
 "use strict";
-/*---------------------------------------------------------------------------------------------
- *  Copyright (c) Microsoft Corporation. All rights reserved.
- *  Licensed under the MIT License. See License.txt in the project root for license information.
- *--------------------------------------------------------------------------------------------*/
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.Mangler = void 0;
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
 const node_v8_1 = __importDefault(require("node:v8"));
 const fs_1 = __importDefault(require("fs"));
 const path_1 = __importDefault(require("path"));
@@ -63,10 +63,10 @@ class ClassData {
     parent;
     children;
     constructor(fileName, node) {
-        // analyse all fields (properties and methods). Find usages of all protected and
-        // private ones and keep track of all public ones (to prevent naming collisions)
         this.fileName = fileName;
         this.node = node;
+        // analyse all fields (properties and methods). Find usages of all protected and
+        // private ones and keep track of all public ones (to prevent naming collisions)
         const candidates = [];
         for (const member of node.members) {
             if (typescript_1.default.isMethodDeclaration(member)) {
@@ -124,34 +124,34 @@ class ClassData {
     }
     static _getFieldType(node) {
         if (hasModifier(node, typescript_1.default.SyntaxKind.PrivateKeyword)) {
-            return 2 /* FieldType.Private */;
+            return FieldType.Private;
         }
         else if (hasModifier(node, typescript_1.default.SyntaxKind.ProtectedKeyword)) {
-            return 1 /* FieldType.Protected */;
+            return FieldType.Protected;
         }
         else {
-            return 0 /* FieldType.Public */;
+            return FieldType.Public;
         }
     }
     static _shouldMangle(type) {
-        return type === 2 /* FieldType.Private */
-            || type === 1 /* FieldType.Protected */;
+        return type === FieldType.Private
+            || type === FieldType.Protected;
     }
     static makeImplicitPublicActuallyPublic(data, reportViolation) {
         // TS-HACK
         // A subtype can make an inherited protected field public. To prevent accidential
         // mangling of public fields we mark the original (protected) fields as public...
         for (const [name, info] of data.fields) {
-            if (info.type !== 0 /* FieldType.Public */) {
+            if (info.type !== FieldType.Public) {
                 continue;
             }
             let parent = data.parent;
             while (parent) {
-                if (parent.fields.get(name)?.type === 1 /* FieldType.Protected */) {
+                if (parent.fields.get(name)?.type === FieldType.Protected) {
                     const parentPos = parent.node.getSourceFile().getLineAndCharacterOfPosition(parent.fields.get(name).pos);
                     const infoPos = data.node.getSourceFile().getLineAndCharacterOfPosition(info.pos);
                     reportViolation(name, `'${name}' from ${parent.fileName}:${parentPos.line + 1}`, `${data.fileName}:${infoPos.line + 1}`);
-                    parent.fields.get(name).type = 0 /* FieldType.Public */;
+                    parent.fields.get(name).type = FieldType.Public;
                 }
                 parent = parent.parent;
             }
@@ -227,7 +227,7 @@ class ClassData {
         let value = this.replacements.get(name);
         let parent = this.parent;
         while (parent) {
-            if (parent.replacements.has(name) && parent.fields.get(name)?.type === 1 /* FieldType.Protected */) {
+            if (parent.replacements.has(name) && parent.fields.get(name)?.type === FieldType.Protected) {
                 value = parent.replacements.get(name) ?? value;
             }
             parent = parent.parent;
@@ -509,7 +509,7 @@ class Mangler {
                 // and because of that we might need to ignore this now
                 let parent = data.parent;
                 while (parent) {
-                    if (parent.fields.get(name)?.type === 0 /* FieldType.Public */) {
+                    if (parent.fields.get(name)?.type === FieldType.Public) {
                         continue fields;
                     }
                     parent = parent.parent;

--- a/build/lib/mangle/renameWorker.js
+++ b/build/lib/mangle/renameWorker.js
@@ -1,12 +1,12 @@
 "use strict";
-/*---------------------------------------------------------------------------------------------
- *  Copyright (c) Microsoft Corporation. All rights reserved.
- *  Licensed under the MIT License. See License.txt in the project root for license information.
- *--------------------------------------------------------------------------------------------*/
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
 const typescript_1 = __importDefault(require("typescript"));
 const workerpool_1 = __importDefault(require("workerpool"));
 const staticLanguageServiceHost_1 = require("./staticLanguageServiceHost");

--- a/build/lib/mangle/staticLanguageServiceHost.js
+++ b/build/lib/mangle/staticLanguageServiceHost.js
@@ -1,13 +1,13 @@
 "use strict";
-/*---------------------------------------------------------------------------------------------
- *  Copyright (c) Microsoft Corporation. All rights reserved.
- *  Licensed under the MIT License. See License.txt in the project root for license information.
- *--------------------------------------------------------------------------------------------*/
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.StaticLanguageServiceHost = void 0;
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
 const typescript_1 = __importDefault(require("typescript"));
 const path_1 = __importDefault(require("path"));
 class StaticLanguageServiceHost {

--- a/build/lib/monaco-api.js
+++ b/build/lib/monaco-api.js
@@ -1,8 +1,4 @@
 "use strict";
-/*---------------------------------------------------------------------------------------------
- *  Copyright (c) Microsoft Corporation. All rights reserved.
- *  Licensed under the MIT License. See License.txt in the project root for license information.
- *--------------------------------------------------------------------------------------------*/
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
@@ -10,6 +6,10 @@ Object.defineProperty(exports, "__esModule", { value: true });
 exports.DeclarationResolver = exports.FSProvider = exports.RECIPE_PATH = void 0;
 exports.run3 = run3;
 exports.execute = execute;
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
 const fs_1 = __importDefault(require("fs"));
 const path_1 = __importDefault(require("path"));
 const fancy_log_1 = __importDefault(require("fancy-log"));

--- a/build/lib/nls.js
+++ b/build/lib/nls.js
@@ -1,8 +1,4 @@
 "use strict";
-/*---------------------------------------------------------------------------------------------
- *  Copyright (c) Microsoft Corporation. All rights reserved.
- *  Licensed under the MIT License. See License.txt in the project root for license information.
- *--------------------------------------------------------------------------------------------*/
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };

--- a/build/lib/node.js
+++ b/build/lib/node.js
@@ -1,12 +1,12 @@
 "use strict";
-/*---------------------------------------------------------------------------------------------
- *  Copyright (c) Microsoft Corporation. All rights reserved.
- *  Licensed under the MIT License. See License.txt in the project root for license information.
- *--------------------------------------------------------------------------------------------*/
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
 const path_1 = __importDefault(require("path"));
 const fs_1 = __importDefault(require("fs"));
 const root = path_1.default.dirname(path_1.default.dirname(__dirname));

--- a/build/lib/optimize.js
+++ b/build/lib/optimize.js
@@ -1,8 +1,4 @@
 "use strict";
-/*---------------------------------------------------------------------------------------------
- *  Copyright (c) Microsoft Corporation. All rights reserved.
- *  Licensed under the MIT License. See License.txt in the project root for license information.
- *--------------------------------------------------------------------------------------------*/
 var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
     var desc = Object.getOwnPropertyDescriptor(m, k);
@@ -42,6 +38,10 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.bundleTask = bundleTask;
 exports.minifyTask = minifyTask;
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
 const event_stream_1 = __importDefault(require("event-stream"));
 const gulp_1 = __importDefault(require("gulp"));
 const gulp_filter_1 = __importDefault(require("gulp-filter"));

--- a/build/lib/policies.js
+++ b/build/lib/policies.js
@@ -1,12 +1,12 @@
 "use strict";
-/*---------------------------------------------------------------------------------------------
- *  Copyright (c) Microsoft Corporation. All rights reserved.
- *  Licensed under the MIT License. See License.txt in the project root for license information.
- *--------------------------------------------------------------------------------------------*/
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
 const child_process_1 = require("child_process");
 const fs_1 = require("fs");
 const path_1 = __importDefault(require("path"));

--- a/build/lib/preLaunch.js
+++ b/build/lib/preLaunch.js
@@ -1,12 +1,12 @@
 "use strict";
-/*---------------------------------------------------------------------------------------------
- *  Copyright (c) Microsoft Corporation. All rights reserved.
- *  Licensed under the MIT License. See License.txt in the project root for license information.
- *--------------------------------------------------------------------------------------------*/
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
 // @ts-check
 const path_1 = __importDefault(require("path"));
 const child_process_1 = require("child_process");

--- a/build/lib/propertyInitOrderChecker.js
+++ b/build/lib/propertyInitOrderChecker.js
@@ -1,8 +1,4 @@
 "use strict";
-/*---------------------------------------------------------------------------------------------
- *  Copyright (c) Microsoft Corporation. All rights reserved.
- *  Licensed under the MIT License. See License.txt in the project root for license information.
- *--------------------------------------------------------------------------------------------*/
 var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
     var desc = Object.getOwnPropertyDescriptor(m, k);
@@ -38,6 +34,10 @@ var __importStar = (this && this.__importStar) || (function () {
 })();
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.EntryKind = void 0;
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
 const ts = __importStar(require("typescript"));
 const path = __importStar(require("path"));
 const fs = __importStar(require("fs"));
@@ -213,7 +213,7 @@ function* findAllReferencesInClass(node) {
     }
     for (const ref of findAllReferences(node)) {
         for (const entry of ref.references) {
-            if (entry.kind !== 1 /* EntryKind.Node */ || entry.node === node) {
+            if (entry.kind !== EntryKind.Node || entry.node === node) {
                 continue;
             }
             if (findClass(entry.node) === classDecl) {

--- a/build/lib/propertyInitOrderChecker.js
+++ b/build/lib/propertyInitOrderChecker.js
@@ -33,7 +33,6 @@ var __importStar = (this && this.__importStar) || (function () {
     };
 })();
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.EntryKind = void 0;
 /*---------------------------------------------------------------------------------------------
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
@@ -247,5 +246,5 @@ var EntryKind;
     EntryKind[EntryKind["StringLiteral"] = 2] = "StringLiteral";
     EntryKind[EntryKind["SearchedLocalFoundProperty"] = 3] = "SearchedLocalFoundProperty";
     EntryKind[EntryKind["SearchedPropertyFoundLocal"] = 4] = "SearchedPropertyFoundLocal";
-})(EntryKind || (exports.EntryKind = EntryKind = {}));
+})(EntryKind || (EntryKind = {}));
 //# sourceMappingURL=propertyInitOrderChecker.js.map

--- a/build/lib/propertyInitOrderChecker.js
+++ b/build/lib/propertyInitOrderChecker.js
@@ -52,6 +52,14 @@ const TS_CONFIG_PATH = path.join(__dirname, '../../', 'src', 'tsconfig.json');
 //
 // #############################################################################################
 //
+var EntryKind;
+(function (EntryKind) {
+    EntryKind[EntryKind["Span"] = 0] = "Span";
+    EntryKind[EntryKind["Node"] = 1] = "Node";
+    EntryKind[EntryKind["StringLiteral"] = 2] = "StringLiteral";
+    EntryKind[EntryKind["SearchedLocalFoundProperty"] = 3] = "SearchedLocalFoundProperty";
+    EntryKind[EntryKind["SearchedPropertyFoundLocal"] = 4] = "SearchedPropertyFoundLocal";
+})(EntryKind || (EntryKind = {}));
 const cancellationToken = {
     isCancellationRequested: () => false,
     throwIfCancellationRequested: () => { },
@@ -238,13 +246,4 @@ var DefinitionKind;
     DefinitionKind[DefinitionKind["String"] = 4] = "String";
     DefinitionKind[DefinitionKind["TripleSlashReference"] = 5] = "TripleSlashReference";
 })(DefinitionKind || (DefinitionKind = {}));
-/** @internal */
-var EntryKind;
-(function (EntryKind) {
-    EntryKind[EntryKind["Span"] = 0] = "Span";
-    EntryKind[EntryKind["Node"] = 1] = "Node";
-    EntryKind[EntryKind["StringLiteral"] = 2] = "StringLiteral";
-    EntryKind[EntryKind["SearchedLocalFoundProperty"] = 3] = "SearchedLocalFoundProperty";
-    EntryKind[EntryKind["SearchedPropertyFoundLocal"] = 4] = "SearchedPropertyFoundLocal";
-})(EntryKind || (EntryKind = {}));
 //# sourceMappingURL=propertyInitOrderChecker.js.map

--- a/build/lib/propertyInitOrderChecker.ts
+++ b/build/lib/propertyInitOrderChecker.ts
@@ -22,6 +22,13 @@ const TS_CONFIG_PATH = path.join(__dirname, '../../', 'src', 'tsconfig.json');
 // #############################################################################################
 //
 
+enum EntryKind {
+	Span,
+	Node,
+	StringLiteral,
+	SearchedLocalFoundProperty,
+	SearchedPropertyFoundLocal,
+}
 
 const cancellationToken: ts.CancellationToken = {
 	isCancellationRequested: () => false,
@@ -271,14 +278,6 @@ type Definition =
 	| { readonly type: DefinitionKind.String; readonly node: ts.StringLiteralLike }
 	| { readonly type: DefinitionKind.TripleSlashReference; readonly reference: ts.FileReference; readonly file: ts.SourceFile };
 
-/** @internal */
-enum EntryKind {
-	Span,
-	Node,
-	StringLiteral,
-	SearchedLocalFoundProperty,
-	SearchedPropertyFoundLocal,
-}
 type NodeEntryKind = EntryKind.Node | EntryKind.StringLiteral | EntryKind.SearchedLocalFoundProperty | EntryKind.SearchedPropertyFoundLocal;
 type Entry = NodeEntry | SpanEntry;
 interface ContextWithStartAndEndNode {

--- a/build/lib/propertyInitOrderChecker.ts
+++ b/build/lib/propertyInitOrderChecker.ts
@@ -272,7 +272,7 @@ type Definition =
 	| { readonly type: DefinitionKind.TripleSlashReference; readonly reference: ts.FileReference; readonly file: ts.SourceFile };
 
 /** @internal */
-export const enum EntryKind {
+enum EntryKind {
 	Span,
 	Node,
 	StringLiteral,

--- a/build/lib/reporter.js
+++ b/build/lib/reporter.js
@@ -1,13 +1,13 @@
 "use strict";
-/*---------------------------------------------------------------------------------------------
- *  Copyright (c) Microsoft Corporation. All rights reserved.
- *  Licensed under the MIT License. See License.txt in the project root for license information.
- *--------------------------------------------------------------------------------------------*/
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.createReporter = createReporter;
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
 const event_stream_1 = __importDefault(require("event-stream"));
 const fancy_log_1 = __importDefault(require("fancy-log"));
 const ansi_colors_1 = __importDefault(require("ansi-colors"));

--- a/build/lib/snapshotLoader.js
+++ b/build/lib/snapshotLoader.js
@@ -1,10 +1,10 @@
 "use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.snaps = void 0;
 /*---------------------------------------------------------------------------------------------
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-Object.defineProperty(exports, "__esModule", { value: true });
-exports.snaps = void 0;
 var snaps;
 (function (snaps) {
     const fs = require('fs');

--- a/build/lib/standalone.js
+++ b/build/lib/standalone.js
@@ -1,8 +1,4 @@
 "use strict";
-/*---------------------------------------------------------------------------------------------
- *  Copyright (c) Microsoft Corporation. All rights reserved.
- *  Licensed under the MIT License. See License.txt in the project root for license information.
- *--------------------------------------------------------------------------------------------*/
 var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
     var desc = Object.getOwnPropertyDescriptor(m, k);
@@ -41,6 +37,10 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.extractEditor = extractEditor;
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
 const fs_1 = __importDefault(require("fs"));
 const path_1 = __importDefault(require("path"));
 const tss = __importStar(require("./treeshaking"));

--- a/build/lib/stats.js
+++ b/build/lib/stats.js
@@ -1,13 +1,13 @@
 "use strict";
-/*---------------------------------------------------------------------------------------------
- *  Copyright (c) Microsoft Corporation. All rights reserved.
- *  Licensed under the MIT License. See License.txt in the project root for license information.
- *--------------------------------------------------------------------------------------------*/
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.createStatsStream = createStatsStream;
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
 const event_stream_1 = __importDefault(require("event-stream"));
 const fancy_log_1 = __importDefault(require("fancy-log"));
 const ansi_colors_1 = __importDefault(require("ansi-colors"));

--- a/build/lib/stylelint/validateVariableNames.js
+++ b/build/lib/stylelint/validateVariableNames.js
@@ -1,13 +1,13 @@
 "use strict";
-/*---------------------------------------------------------------------------------------------
- *  Copyright (c) Microsoft Corporation. All rights reserved.
- *  Licensed under the MIT License. See License.txt in the project root for license information.
- *--------------------------------------------------------------------------------------------*/
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.getVariableNameValidator = getVariableNameValidator;
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
 const fs_1 = require("fs");
 const path_1 = __importDefault(require("path"));
 const RE_VAR_PROP = /var\(\s*(--([\w\-\.]+))/g;

--- a/build/lib/task.js
+++ b/build/lib/task.js
@@ -1,8 +1,4 @@
 "use strict";
-/*---------------------------------------------------------------------------------------------
- *  Copyright (c) Microsoft Corporation. All rights reserved.
- *  Licensed under the MIT License. See License.txt in the project root for license information.
- *--------------------------------------------------------------------------------------------*/
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
@@ -10,6 +6,10 @@ Object.defineProperty(exports, "__esModule", { value: true });
 exports.series = series;
 exports.parallel = parallel;
 exports.define = define;
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
 const fancy_log_1 = __importDefault(require("fancy-log"));
 const ansi_colors_1 = __importDefault(require("ansi-colors"));
 function _isPromise(p) {

--- a/build/lib/test/i18n.test.js
+++ b/build/lib/test/i18n.test.js
@@ -1,8 +1,4 @@
 "use strict";
-/*---------------------------------------------------------------------------------------------
- *  Copyright (c) Microsoft Corporation. All rights reserved.
- *  Licensed under the MIT License. See License.txt in the project root for license information.
- *--------------------------------------------------------------------------------------------*/
 var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
     var desc = Object.getOwnPropertyDescriptor(m, k);
@@ -40,6 +36,10 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
 const assert_1 = __importDefault(require("assert"));
 const i18n = __importStar(require("../i18n"));
 suite('XLF Parser Tests', () => {

--- a/build/lib/treeshaking.js
+++ b/build/lib/treeshaking.js
@@ -3,7 +3,6 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.ShakeLevel = void 0;
 exports.toStringShakeLevel = toStringShakeLevel;
 exports.shake = shake;
 /*---------------------------------------------------------------------------------------------
@@ -18,7 +17,7 @@ var ShakeLevel;
     ShakeLevel[ShakeLevel["Files"] = 0] = "Files";
     ShakeLevel[ShakeLevel["InnerFile"] = 1] = "InnerFile";
     ShakeLevel[ShakeLevel["ClassMembers"] = 2] = "ClassMembers";
-})(ShakeLevel || (exports.ShakeLevel = ShakeLevel = {}));
+})(ShakeLevel || (ShakeLevel = {}));
 function toStringShakeLevel(shakeLevel) {
     switch (shakeLevel) {
         case ShakeLevel.Files:

--- a/build/lib/treeshaking.js
+++ b/build/lib/treeshaking.js
@@ -1,8 +1,4 @@
 "use strict";
-/*---------------------------------------------------------------------------------------------
- *  Copyright (c) Microsoft Corporation. All rights reserved.
- *  Licensed under the MIT License. See License.txt in the project root for license information.
- *--------------------------------------------------------------------------------------------*/
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
@@ -10,6 +6,10 @@ Object.defineProperty(exports, "__esModule", { value: true });
 exports.ShakeLevel = void 0;
 exports.toStringShakeLevel = toStringShakeLevel;
 exports.shake = shake;
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
 const fs_1 = __importDefault(require("fs"));
 const path_1 = __importDefault(require("path"));
 const TYPESCRIPT_LIB_FOLDER = path_1.default.dirname(require.resolve('typescript/lib/lib.d.ts'));
@@ -21,11 +21,11 @@ var ShakeLevel;
 })(ShakeLevel || (exports.ShakeLevel = ShakeLevel = {}));
 function toStringShakeLevel(shakeLevel) {
     switch (shakeLevel) {
-        case 0 /* ShakeLevel.Files */:
+        case ShakeLevel.Files:
             return 'Files (0)';
-        case 1 /* ShakeLevel.InnerFile */:
+        case ShakeLevel.InnerFile:
             return 'InnerFile (1)';
-        case 2 /* ShakeLevel.ClassMembers */:
+        case ShakeLevel.ClassMembers:
             return 'ClassMembers (2)';
     }
 }
@@ -231,7 +231,7 @@ var NodeColor;
     NodeColor[NodeColor["Black"] = 2] = "Black";
 })(NodeColor || (NodeColor = {}));
 function getColor(node) {
-    return node.$$$color || 0 /* NodeColor.White */;
+    return node.$$$color || NodeColor.White;
 }
 function setColor(node, color) {
     node.$$$color = color;
@@ -245,7 +245,7 @@ function isNeededSourceFile(node) {
 function nodeOrParentIsBlack(node) {
     while (node) {
         const color = getColor(node);
-        if (color === 2 /* NodeColor.Black */) {
+        if (color === NodeColor.Black) {
             return true;
         }
         node = node.parent;
@@ -253,7 +253,7 @@ function nodeOrParentIsBlack(node) {
     return false;
 }
 function nodeOrChildIsBlack(node) {
-    if (getColor(node) === 2 /* NodeColor.Black */) {
+    if (getColor(node) === NodeColor.Black) {
         return true;
     }
     for (const child of node.getChildren()) {
@@ -317,10 +317,10 @@ function markNodes(ts, languageService, options) {
     if (!program) {
         throw new Error('Could not get program from language service');
     }
-    if (options.shakeLevel === 0 /* ShakeLevel.Files */) {
+    if (options.shakeLevel === ShakeLevel.Files) {
         // Mark all source files Black
         program.getSourceFiles().forEach((sourceFile) => {
-            setColor(sourceFile, 2 /* NodeColor.Black */);
+            setColor(sourceFile, NodeColor.Black);
         });
         return;
     }
@@ -332,7 +332,7 @@ function markNodes(ts, languageService, options) {
         sourceFile.forEachChild((node) => {
             if (ts.isImportDeclaration(node)) {
                 if (!node.importClause && ts.isStringLiteral(node.moduleSpecifier)) {
-                    setColor(node, 2 /* NodeColor.Black */);
+                    setColor(node, NodeColor.Black);
                     enqueueImport(node, node.moduleSpecifier.text);
                 }
                 return;
@@ -340,7 +340,7 @@ function markNodes(ts, languageService, options) {
             if (ts.isExportDeclaration(node)) {
                 if (!node.exportClause && node.moduleSpecifier && ts.isStringLiteral(node.moduleSpecifier)) {
                     // export * from "foo";
-                    setColor(node, 2 /* NodeColor.Black */);
+                    setColor(node, NodeColor.Black);
                     enqueueImport(node, node.moduleSpecifier.text);
                 }
                 if (node.exportClause && ts.isNamedExports(node.exportClause)) {
@@ -381,21 +381,21 @@ function markNodes(ts, languageService, options) {
         return null;
     }
     function enqueue_gray(node) {
-        if (nodeOrParentIsBlack(node) || getColor(node) === 1 /* NodeColor.Gray */) {
+        if (nodeOrParentIsBlack(node) || getColor(node) === NodeColor.Gray) {
             return;
         }
-        setColor(node, 1 /* NodeColor.Gray */);
+        setColor(node, NodeColor.Gray);
         gray_queue.push(node);
     }
     function enqueue_black(node) {
         const previousColor = getColor(node);
-        if (previousColor === 2 /* NodeColor.Black */) {
+        if (previousColor === NodeColor.Black) {
             return;
         }
-        if (previousColor === 1 /* NodeColor.Gray */) {
+        if (previousColor === NodeColor.Gray) {
             // remove from gray queue
             gray_queue.splice(gray_queue.indexOf(node), 1);
-            setColor(node, 0 /* NodeColor.White */);
+            setColor(node, NodeColor.White);
             // add to black queue
             enqueue_black(node);
             // move from one queue to the other
@@ -408,7 +408,7 @@ function markNodes(ts, languageService, options) {
         }
         const fileName = node.getSourceFile().fileName;
         if (/^defaultLib:/.test(fileName) || /\.d\.ts$/.test(fileName)) {
-            setColor(node, 2 /* NodeColor.Black */);
+            setColor(node, NodeColor.Black);
             return;
         }
         const sourceFile = node.getSourceFile();
@@ -419,9 +419,9 @@ function markNodes(ts, languageService, options) {
         if (ts.isSourceFile(node)) {
             return;
         }
-        setColor(node, 2 /* NodeColor.Black */);
+        setColor(node, NodeColor.Black);
         black_queue.push(node);
-        if (options.shakeLevel === 2 /* ShakeLevel.ClassMembers */ && (ts.isMethodDeclaration(node) || ts.isMethodSignature(node) || ts.isPropertySignature(node) || ts.isPropertyDeclaration(node) || ts.isGetAccessor(node) || ts.isSetAccessor(node))) {
+        if (options.shakeLevel === ShakeLevel.ClassMembers && (ts.isMethodDeclaration(node) || ts.isMethodSignature(node) || ts.isPropertySignature(node) || ts.isPropertyDeclaration(node) || ts.isGetAccessor(node) || ts.isSetAccessor(node))) {
             const references = languageService.getReferencesAtPosition(node.getSourceFile().fileName, node.name.pos + node.name.getLeadingTriviaWidth());
             if (references) {
                 for (let i = 0, len = references.length; i < len; i++) {
@@ -487,7 +487,7 @@ function markNodes(ts, languageService, options) {
                 if ((ts.isClassDeclaration(nodeParent) || ts.isInterfaceDeclaration(nodeParent)) && nodeOrChildIsBlack(nodeParent)) {
                     gray_queue.splice(i, 1);
                     black_queue.push(node);
-                    setColor(node, 2 /* NodeColor.Black */);
+                    setColor(node, NodeColor.Black);
                     i--;
                 }
             }
@@ -504,7 +504,7 @@ function markNodes(ts, languageService, options) {
             const symbols = getRealNodeSymbol(ts, checker, node);
             for (const { symbol, symbolImportNode } of symbols) {
                 if (symbolImportNode) {
-                    setColor(symbolImportNode, 2 /* NodeColor.Black */);
+                    setColor(symbolImportNode, NodeColor.Black);
                     const importDeclarationNode = findParentImportDeclaration(symbolImportNode);
                     if (importDeclarationNode && ts.isStringLiteral(importDeclarationNode.moduleSpecifier)) {
                         enqueueImport(importDeclarationNode, importDeclarationNode.moduleSpecifier.text);
@@ -518,7 +518,7 @@ function markNodes(ts, languageService, options) {
                             // (they can be the declaration of a module import)
                             continue;
                         }
-                        if (options.shakeLevel === 2 /* ShakeLevel.ClassMembers */ && (ts.isClassDeclaration(declaration) || ts.isInterfaceDeclaration(declaration)) && !isLocalCodeExtendingOrInheritingFromDefaultLibSymbol(ts, program, checker, declaration)) {
+                        if (options.shakeLevel === ShakeLevel.ClassMembers && (ts.isClassDeclaration(declaration) || ts.isInterfaceDeclaration(declaration)) && !isLocalCodeExtendingOrInheritingFromDefaultLibSymbol(ts, program, checker, declaration)) {
                             enqueue_black(declaration.name);
                             for (let j = 0; j < declaration.members.length; j++) {
                                 const member = declaration.members[j];
@@ -569,7 +569,7 @@ function markNodes(ts, languageService, options) {
         const aliased = checker.getAliasedSymbol(symbol);
         if (aliased.declarations && aliased.declarations.length > 0) {
             if (nodeOrParentIsBlack(aliased.declarations[0]) || nodeOrChildIsBlack(aliased.declarations[0])) {
-                setColor(node, 2 /* NodeColor.Black */);
+                setColor(node, NodeColor.Black);
             }
         }
     }
@@ -616,7 +616,7 @@ function generateResult(ts, languageService, shakeLevel) {
             result += data;
         }
         function writeMarkedNodes(node) {
-            if (getColor(node) === 2 /* NodeColor.Black */) {
+            if (getColor(node) === NodeColor.Black) {
                 return keep(node);
             }
             // Always keep certain top-level statements
@@ -632,34 +632,34 @@ function generateResult(ts, languageService, shakeLevel) {
             if (ts.isImportDeclaration(node)) {
                 if (node.importClause && node.importClause.namedBindings) {
                     if (ts.isNamespaceImport(node.importClause.namedBindings)) {
-                        if (getColor(node.importClause.namedBindings) === 2 /* NodeColor.Black */) {
+                        if (getColor(node.importClause.namedBindings) === NodeColor.Black) {
                             return keep(node);
                         }
                     }
                     else {
                         const survivingImports = [];
                         for (const importNode of node.importClause.namedBindings.elements) {
-                            if (getColor(importNode) === 2 /* NodeColor.Black */) {
+                            if (getColor(importNode) === NodeColor.Black) {
                                 survivingImports.push(importNode.getFullText(sourceFile));
                             }
                         }
                         const leadingTriviaWidth = node.getLeadingTriviaWidth();
                         const leadingTrivia = sourceFile.text.substr(node.pos, leadingTriviaWidth);
                         if (survivingImports.length > 0) {
-                            if (node.importClause && node.importClause.name && getColor(node.importClause) === 2 /* NodeColor.Black */) {
+                            if (node.importClause && node.importClause.name && getColor(node.importClause) === NodeColor.Black) {
                                 return write(`${leadingTrivia}import ${node.importClause.name.text}, {${survivingImports.join(',')} } from${node.moduleSpecifier.getFullText(sourceFile)};`);
                             }
                             return write(`${leadingTrivia}import {${survivingImports.join(',')} } from${node.moduleSpecifier.getFullText(sourceFile)};`);
                         }
                         else {
-                            if (node.importClause && node.importClause.name && getColor(node.importClause) === 2 /* NodeColor.Black */) {
+                            if (node.importClause && node.importClause.name && getColor(node.importClause) === NodeColor.Black) {
                                 return write(`${leadingTrivia}import ${node.importClause.name.text} from${node.moduleSpecifier.getFullText(sourceFile)};`);
                             }
                         }
                     }
                 }
                 else {
-                    if (node.importClause && getColor(node.importClause) === 2 /* NodeColor.Black */) {
+                    if (node.importClause && getColor(node.importClause) === NodeColor.Black) {
                         return keep(node);
                     }
                 }
@@ -668,7 +668,7 @@ function generateResult(ts, languageService, shakeLevel) {
                 if (node.exportClause && node.moduleSpecifier && ts.isNamedExports(node.exportClause)) {
                     const survivingExports = [];
                     for (const exportSpecifier of node.exportClause.elements) {
-                        if (getColor(exportSpecifier) === 2 /* NodeColor.Black */) {
+                        if (getColor(exportSpecifier) === NodeColor.Black) {
                             survivingExports.push(exportSpecifier.getFullText(sourceFile));
                         }
                     }
@@ -679,11 +679,11 @@ function generateResult(ts, languageService, shakeLevel) {
                     }
                 }
             }
-            if (shakeLevel === 2 /* ShakeLevel.ClassMembers */ && (ts.isClassDeclaration(node) || ts.isInterfaceDeclaration(node)) && nodeOrChildIsBlack(node)) {
+            if (shakeLevel === ShakeLevel.ClassMembers && (ts.isClassDeclaration(node) || ts.isInterfaceDeclaration(node)) && nodeOrChildIsBlack(node)) {
                 let toWrite = node.getFullText();
                 for (let i = node.members.length - 1; i >= 0; i--) {
                     const member = node.members[i];
-                    if (getColor(member) === 2 /* NodeColor.Black */ || !member.name) {
+                    if (getColor(member) === NodeColor.Black || !member.name) {
                         // keep method
                         continue;
                     }
@@ -699,7 +699,7 @@ function generateResult(ts, languageService, shakeLevel) {
             }
             node.forEachChild(writeMarkedNodes);
         }
-        if (getColor(sourceFile) !== 2 /* NodeColor.Black */) {
+        if (getColor(sourceFile) !== NodeColor.Black) {
             if (!nodeOrChildIsBlack(sourceFile)) {
                 // none of the elements are reachable
                 if (isNeededSourceFile(sourceFile)) {

--- a/build/lib/treeshaking.ts
+++ b/build/lib/treeshaking.ts
@@ -9,7 +9,7 @@ import type * as ts from 'typescript';
 
 const TYPESCRIPT_LIB_FOLDER = path.dirname(require.resolve('typescript/lib/lib.d.ts'));
 
-export const enum ShakeLevel {
+enum ShakeLevel {
 	Files = 0,
 	InnerFile = 1,
 	ClassMembers = 2

--- a/build/lib/tsb/builder.js
+++ b/build/lib/tsb/builder.js
@@ -1,8 +1,4 @@
 "use strict";
-/*---------------------------------------------------------------------------------------------
- *  Copyright (c) Microsoft Corporation. All rights reserved.
- *  Licensed under the MIT License. See License.txt in the project root for license information.
- *--------------------------------------------------------------------------------------------*/
 var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
     var desc = Object.getOwnPropertyDescriptor(m, k);
@@ -42,6 +38,10 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.CancellationToken = void 0;
 exports.createTypeScriptBuilder = createTypeScriptBuilder;
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
 const fs_1 = __importDefault(require("fs"));
 const path_1 = __importDefault(require("path"));
 const crypto_1 = __importDefault(require("crypto"));

--- a/build/lib/tsb/index.js
+++ b/build/lib/tsb/index.js
@@ -1,8 +1,4 @@
 "use strict";
-/*---------------------------------------------------------------------------------------------
- *  Copyright (c) Microsoft Corporation. All rights reserved.
- *  Licensed under the MIT License. See License.txt in the project root for license information.
- *--------------------------------------------------------------------------------------------*/
 var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
     var desc = Object.getOwnPropertyDescriptor(m, k);
@@ -41,6 +37,10 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.create = create;
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
 const vinyl_1 = __importDefault(require("vinyl"));
 const through_1 = __importDefault(require("through"));
 const builder = __importStar(require("./builder"));

--- a/build/lib/tsb/transpiler.js
+++ b/build/lib/tsb/transpiler.js
@@ -1,13 +1,13 @@
 "use strict";
-/*---------------------------------------------------------------------------------------------
- *  Copyright (c) Microsoft Corporation. All rights reserved.
- *  Licensed under the MIT License. See License.txt in the project root for license information.
- *--------------------------------------------------------------------------------------------*/
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.ESBuildTranspiler = exports.TscTranspiler = void 0;
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
 const esbuild_1 = __importDefault(require("esbuild"));
 const typescript_1 = __importDefault(require("typescript"));
 const node_worker_threads_1 = __importDefault(require("node:worker_threads"));
@@ -100,12 +100,12 @@ class TranspileWorker {
                     SuffixTypes[SuffixTypes["Ts"] = 3] = "Ts";
                     SuffixTypes[SuffixTypes["Unknown"] = 0] = "Unknown";
                 })(SuffixTypes || (SuffixTypes = {}));
-                const suffixLen = file.path.endsWith('.d.ts') ? 5 /* SuffixTypes.Dts */
-                    : file.path.endsWith('.ts') ? 3 /* SuffixTypes.Ts */
-                        : 0 /* SuffixTypes.Unknown */;
+                const suffixLen = file.path.endsWith('.d.ts') ? SuffixTypes.Dts
+                    : file.path.endsWith('.ts') ? SuffixTypes.Ts
+                        : SuffixTypes.Unknown;
                 // check if output of a DTS-files isn't just "empty" and iff so
                 // skip this file
-                if (suffixLen === 5 /* SuffixTypes.Dts */ && _isDefaultEmpty(jsSrc)) {
+                if (suffixLen === SuffixTypes.Dts && _isDefaultEmpty(jsSrc)) {
                     continue;
                 }
                 const outBase = options.compilerOptions?.outDir ?? file.base;

--- a/build/lib/tsb/utils.js
+++ b/build/lib/tsb/utils.js
@@ -1,10 +1,10 @@
 "use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.graph = exports.strings = void 0;
 /*---------------------------------------------------------------------------------------------
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-Object.defineProperty(exports, "__esModule", { value: true });
-exports.graph = exports.strings = void 0;
 var strings;
 (function (strings) {
     function format(value, ...rest) {

--- a/build/lib/util.js
+++ b/build/lib/util.js
@@ -1,8 +1,4 @@
 "use strict";
-/*---------------------------------------------------------------------------------------------
- *  Copyright (c) Microsoft Corporation. All rights reserved.
- *  Licensed under the MIT License. See License.txt in the project root for license information.
- *--------------------------------------------------------------------------------------------*/
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
@@ -26,6 +22,10 @@ exports.rebase = rebase;
 exports.filter = filter;
 exports.streamToPromise = streamToPromise;
 exports.getElectronVersion = getElectronVersion;
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
 const event_stream_1 = __importDefault(require("event-stream"));
 const debounce_1 = __importDefault(require("debounce"));
 const gulp_filter_1 = __importDefault(require("gulp-filter"));

--- a/build/lib/watch/index.js
+++ b/build/lib/watch/index.js
@@ -1,9 +1,9 @@
 "use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
 /*---------------------------------------------------------------------------------------------
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-Object.defineProperty(exports, "__esModule", { value: true });
 const watch = process.platform === 'win32' ? require('./watch-win32') : require('vscode-gulp-watch');
 module.exports = function () {
     return watch.apply(null, arguments);

--- a/build/lib/watch/watch-win32.js
+++ b/build/lib/watch/watch-win32.js
@@ -1,12 +1,12 @@
 "use strict";
-/*---------------------------------------------------------------------------------------------
- *  Copyright (c) Microsoft Corporation. All rights reserved.
- *  Licensed under the MIT License. See License.txt in the project root for license information.
- *--------------------------------------------------------------------------------------------*/
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
 const path_1 = __importDefault(require("path"));
 const child_process_1 = __importDefault(require("child_process"));
 const fs_1 = __importDefault(require("fs"));

--- a/build/linux/debian/calculate-deps.js
+++ b/build/linux/debian/calculate-deps.js
@@ -1,13 +1,13 @@
 "use strict";
-/*---------------------------------------------------------------------------------------------
- *  Copyright (c) Microsoft Corporation. All rights reserved.
- *  Licensed under the MIT License. See License.txt in the project root for license information.
- *--------------------------------------------------------------------------------------------*/
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.generatePackageDeps = generatePackageDeps;
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
 const child_process_1 = require("child_process");
 const fs_1 = require("fs");
 const os_1 = require("os");

--- a/build/linux/debian/dep-lists.js
+++ b/build/linux/debian/dep-lists.js
@@ -1,10 +1,10 @@
 "use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.referenceGeneratedDepsByArch = exports.recommendedDeps = exports.additionalDeps = void 0;
 /*---------------------------------------------------------------------------------------------
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-Object.defineProperty(exports, "__esModule", { value: true });
-exports.referenceGeneratedDepsByArch = exports.recommendedDeps = exports.additionalDeps = void 0;
 // Based on https://source.chromium.org/chromium/chromium/src/+/main:chrome/installer/linux/debian/additional_deps
 // Additional dependencies not in the dpkg-shlibdeps output.
 exports.additionalDeps = [

--- a/build/linux/debian/install-sysroot.js
+++ b/build/linux/debian/install-sysroot.js
@@ -1,14 +1,14 @@
 "use strict";
-/*---------------------------------------------------------------------------------------------
- *  Copyright (c) Microsoft Corporation. All rights reserved.
- *  Licensed under the MIT License. See License.txt in the project root for license information.
- *--------------------------------------------------------------------------------------------*/
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.getVSCodeSysroot = getVSCodeSysroot;
 exports.getChromiumSysroot = getChromiumSysroot;
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
 const child_process_1 = require("child_process");
 const os_1 = require("os");
 const fs_1 = __importDefault(require("fs"));

--- a/build/linux/debian/types.js
+++ b/build/linux/debian/types.js
@@ -1,8 +1,4 @@
 "use strict";
-/*---------------------------------------------------------------------------------------------
- *  Copyright (c) Microsoft Corporation. All rights reserved.
- *  Licensed under the MIT License. See License.txt in the project root for license information.
- *--------------------------------------------------------------------------------------------*/
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.isDebianArchString = isDebianArchString;
 function isDebianArchString(s) {

--- a/build/linux/libcxx-fetcher.js
+++ b/build/linux/libcxx-fetcher.js
@@ -1,14 +1,14 @@
 "use strict";
-/*---------------------------------------------------------------------------------------------
- *  Copyright (c) Microsoft Corporation. All rights reserved.
- *  Licensed under the MIT License. See License.txt in the project root for license information.
- *--------------------------------------------------------------------------------------------*/
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.downloadLibcxxHeaders = downloadLibcxxHeaders;
 exports.downloadLibcxxObjects = downloadLibcxxObjects;
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
 // Can be removed once https://github.com/electron/electron-rebuild/pull/703 is available.
 const fs_1 = __importDefault(require("fs"));
 const path_1 = __importDefault(require("path"));

--- a/build/linux/rpm/calculate-deps.js
+++ b/build/linux/rpm/calculate-deps.js
@@ -1,10 +1,10 @@
 "use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.generatePackageDeps = generatePackageDeps;
 /*---------------------------------------------------------------------------------------------
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-Object.defineProperty(exports, "__esModule", { value: true });
-exports.generatePackageDeps = generatePackageDeps;
 const child_process_1 = require("child_process");
 const fs_1 = require("fs");
 const dep_lists_1 = require("./dep-lists");

--- a/build/linux/rpm/dep-lists.js
+++ b/build/linux/rpm/dep-lists.js
@@ -1,10 +1,10 @@
 "use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.referenceGeneratedDepsByArch = exports.additionalDeps = void 0;
 /*---------------------------------------------------------------------------------------------
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-Object.defineProperty(exports, "__esModule", { value: true });
-exports.referenceGeneratedDepsByArch = exports.additionalDeps = void 0;
 // Based on https://source.chromium.org/chromium/chromium/src/+/main:chrome/installer/linux/rpm/additional_deps
 // Additional dependencies not in the rpm find-requires output.
 exports.additionalDeps = [

--- a/build/linux/rpm/types.js
+++ b/build/linux/rpm/types.js
@@ -1,8 +1,4 @@
 "use strict";
-/*---------------------------------------------------------------------------------------------
- *  Copyright (c) Microsoft Corporation. All rights reserved.
- *  Licensed under the MIT License. See License.txt in the project root for license information.
- *--------------------------------------------------------------------------------------------*/
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.isRpmArchString = isRpmArchString;
 function isRpmArchString(s) {

--- a/build/package.json
+++ b/build/package.json
@@ -58,9 +58,9 @@
   },
   "type": "commonjs",
   "scripts": {
-    "compile": "../node_modules/.bin/tsc -p tsconfig.build.json",
-    "watch": "../node_modules/.bin/tsc -p tsconfig.build.json --watch",
-    "npmCheckJs": "../node_modules/.bin/tsc --noEmit"
+    "compile": "cd .. && npx tsgo --project build/tsconfig.build.json",
+    "watch": "cd .. && npx tsgo --project build/tsconfig.build.json --watch",
+    "npmCheckJs": "cd .. && npx tsgo --project build/tsconfig.build.json --noEmit"
   },
   "optionalDependencies": {
     "tree-sitter-typescript": "^0.23.2",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "extensions-ci": "node ./node_modules/gulp/bin/gulp.js extensions-ci",
     "extensions-ci-pr": "node ./node_modules/gulp/bin/gulp.js extensions-ci-pr",
     "perf": "node scripts/code-perf.js",
-    "update-build-ts-version": "npm install -D typescript@next && npm install -D @typescript/native-preview && tsc -p ./build/tsconfig.build.json"
+    "update-build-ts-version": "npm install -D typescript@next && npm install -D @typescript/native-preview && (cd build && npm run compile)"
   },
   "dependencies": {
     "@microsoft/1ds-core-js": "^3.2.13",


### PR DESCRIPTION
There are a few minor differences in output, mostly around formatting/comments (see https://github.com/microsoft/typescript-go/issues/1526). Const enums are also not inlined (https://github.com/microsoft/typescript-go/issues/1216) so converting those over

