### PR TITLE
Bump main build target to es2024

### DIFF
--- a/src/tsconfig.base.json
+++ b/src/tsconfig.base.json
@@ -13,10 +13,10 @@
 		"exactOptionalPropertyTypes": false,
 		"useUnknownInCatchVariables": false,
 		"forceConsistentCasingInFileNames": true,
-		"target": "es2022",
+		"target": "ES2024",
 		"useDefineForClassFields": false,
 		"lib": [
-			"ES2022",
+			"ES2024",
 			"DOM",
 			"DOM.Iterable",
 			"WebWorker.ImportScripts"


### PR DESCRIPTION
The es2024 library additions are now widely supported in node 22 and in modern browsers

