### PR TITLE
Add support for a help link when MCP assisted installation fails

### DIFF
--- a/src/vs/workbench/contrib/mcp/browser/mcpCommandsAddConfiguration.ts
+++ b/src/vs/workbench/contrib/mcp/browser/mcpCommandsAddConfiguration.ts
@@ -20,6 +20,7 @@ import { IFileService } from '../../../../platform/files/common/files.js';
 import { ILabelService } from '../../../../platform/label/common/label.js';
 import { IMcpRemoteServerConfiguration, IMcpServerConfiguration, IMcpServerVariable, IMcpStdioServerConfiguration, McpServerType } from '../../../../platform/mcp/common/mcpPlatformTypes.js';
 import { INotificationService } from '../../../../platform/notification/common/notification.js';
+import { IOpenerService } from '../../../../platform/opener/common/opener.js';
 import { IQuickInputService, IQuickPickItem, QuickPickInput } from '../../../../platform/quickinput/common/quickInput.js';
 import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry.js';
 import { isWorkspaceFolder, IWorkspaceContextService, IWorkspaceFolder, WorkbenchState } from '../../../../platform/workspace/common/workspace.js';
@@ -87,7 +88,7 @@ const enum AddConfigurationCopilotCommand {
 
 type ValidatePackageResult =
 	{ state: 'ok'; publisher: string; name?: string; version?: string }
-	| { state: 'error'; error: string };
+	| { state: 'error'; error: string; helpUri?: string; helpUriLabel?: string };
 
 type AddServerData = {
 	packageType: string;
@@ -119,7 +120,7 @@ export class McpAddConfigurationCommand {
 		@IWorkbenchEnvironmentService private readonly _environmentService: IWorkbenchEnvironmentService,
 		@ICommandService private readonly _commandService: ICommandService,
 		@IMcpRegistry private readonly _mcpRegistry: IMcpRegistry,
-		@IEditorService private readonly _openerService: IEditorService,
+		@IOpenerService private readonly _openerService: IOpenerService,
 		@IEditorService private readonly _editorService: IEditorService,
 		@IFileService private readonly _fileService: IFileService,
 		@INotificationService private readonly _notificationService: INotificationService,
@@ -284,11 +285,12 @@ export class McpAddConfigurationCommand {
 		const enum LoadAction {
 			Retry = 'retry',
 			Cancel = 'cancel',
-			Allow = 'allow'
+			Allow = 'allow',
+			OpenUri = 'openUri',
 		}
 
 		const loadingQuickPickStore = new DisposableStore();
-		const loadingQuickPick = loadingQuickPickStore.add(this._quickInputService.createQuickPick<IQuickPickItem & { id: LoadAction }>());
+		const loadingQuickPick = loadingQuickPickStore.add(this._quickInputService.createQuickPick<IQuickPickItem & { id: LoadAction; helpUri?: URI }>());
 		loadingQuickPick.title = localize('mcp.loading.title', "Loading package details...");
 		loadingQuickPick.busy = true;
 		loadingQuickPick.ignoreFocusOut = true;
@@ -319,7 +321,23 @@ export class McpAddConfigurationCommand {
 		).then(result => {
 			if (!result || result.state === 'error') {
 				loadingQuickPick.title = result?.error || 'Unknown error loading package';
-				loadingQuickPick.items = [{ id: LoadAction.Retry, label: localize('mcp.error.retry', 'Try a different package') }, { id: LoadAction.Cancel, label: localize('cancel', 'Cancel') }];
+
+				const items: Array<IQuickPickItem & { id: LoadAction; helpUri?: URI }> = [];
+
+				if (result?.helpUri) {
+					items.push({
+						id: LoadAction.OpenUri,
+						label: result.helpUriLabel ?? localize('mcp.error.openHelpUri', 'Open help URL'),
+						helpUri: URI.parse(result.helpUri),
+					});
+				}
+
+				items.push(...[
+					{ id: LoadAction.Retry, label: localize('mcp.error.retry', 'Try a different package') },
+					{ id: LoadAction.Cancel, label: localize('cancel', 'Cancel') },
+				]);
+
+				loadingQuickPick.items = items;
 			} else {
 				loadingQuickPick.title = localize(
 					'mcp.confirmPublish', 'Install {0}{1} from {2}?',
@@ -334,15 +352,18 @@ export class McpAddConfigurationCommand {
 			loadingQuickPick.busy = false;
 		});
 
-		const loadingAction = await new Promise<LoadAction | undefined>(resolve => {
-			loadingQuickPick.onDidAccept(() => resolve(loadingQuickPick.selectedItems[0]?.id));
+		const loadingAction = await new Promise<{ id: LoadAction; helpUri?: URI } | undefined>(resolve => {
+			loadingQuickPick.onDidAccept(() => resolve(loadingQuickPick.selectedItems[0]));
 			loadingQuickPick.onDidHide(() => resolve(undefined));
 			loadingQuickPick.show();
 		}).finally(() => loadingQuickPick.dispose());
 
-		switch (loadingAction) {
+		switch (loadingAction?.id) {
 			case LoadAction.Retry:
 				return this.getAssistedConfig(type);
+			case LoadAction.OpenUri:
+				if (loadingAction.helpUri) { this._openerService.open(loadingAction.helpUri); }
+				return undefined;
 			case LoadAction.Allow:
 				break;
 			case LoadAction.Cancel:
@@ -372,7 +393,7 @@ export class McpAddConfigurationCommand {
 
 			if (match && server) {
 				if (match.collection.presentation?.origin) {
-					this._openerService.openEditor({
+					this._editorService.openEditor({
 						resource: match.collection.presentation.origin,
 						options: {
 							selection: match.server.presentation?.origin?.range,

--- a/src/vs/workbench/contrib/mcp/browser/mcpCommandsAddConfiguration.ts
+++ b/src/vs/workbench/contrib/mcp/browser/mcpCommandsAddConfiguration.ts
@@ -332,10 +332,10 @@ export class McpAddConfigurationCommand {
 					});
 				}
 
-				items.push(...[
+				items.push(
 					{ id: LoadAction.Retry, label: localize('mcp.error.retry', 'Try a different package') },
 					{ id: LoadAction.Cancel, label: localize('cancel', 'Cancel') },
-				]);
+				);
 
 				loadingQuickPick.items = items;
 			} else {

--- a/src/vs/workbench/contrib/mcp/common/mcpServer.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpServer.ts
@@ -579,6 +579,9 @@ export class McpServer extends Disposable implements IMcpServer {
 				case 'dnx':
 					docsLink = `https://aka.ms/vscode-mcp-install/dnx`;
 					break;
+				case 'dotnet':
+					docsLink = `https://aka.ms/vscode-mcp-install/dotnet`;
+					break;
 			}
 
 			const options: IPromptChoice[] = [{


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This is in support of https://github.com/microsoft/vscode/issues/257679.

This will also support https://github.com/microsoft/vscode/issues/259901 if, for example, we move to using `npm` for the "does the package exist" check and npm is not available.

I am working in using the server.json contained in NuGet packages to improve MCP installation. To do these, I need to invoke `dotnet tool install` commands to download the package. If the user does not have `dotnet` installed, we should let them known. This is prior to the MCP server being installed so the existing notification flow will not kick in yet.

The URL and label are optionally sent back as part of the error. I believe this is a useful additional to the contract of `github.copilot.chat.mcp.setup.validatePackage`.

It looks like this:

<img width="1393" height="337" alt="image" src="https://github.com/user-attachments/assets/7ce7dc7e-8443-46e1-ae94-678faa2c7a4e" />

Also, added `dotnet` to the list of recognized missing commands in case `dotnet tool exec` is used.
Also, fix a misnamed editor service dependency.