### PR TITLE
Critical Data Loss Bug in Encoding Handling: Ctrl+Z Causes Permanent Content Corruption (fix #259409)

### DIFF
--- a/src/vs/workbench/contrib/scm/browser/quickDiffModel.ts
+++ b/src/vs/workbench/contrib/scm/browser/quickDiffModel.ts
@@ -378,11 +378,11 @@ export class QuickDiffModel extends Disposable {
 
 					this._originalEditorModels.set(quickDiff.originalResource, ref.object);
 
-					if (isTextFileEditorModel(ref.object)) {
+					if (isTextFileEditorModel(ref.object) && !ref.object.isDirty()) {
 						const encoding = this._model.getEncoding();
 
 						if (encoding) {
-							ref.object.setEncoding(encoding, EncodingMode.Decode);
+							(ref.object as ITextFileEditorModel).setEncoding(encoding, EncodingMode.Decode);
 						}
 					}
 

--- a/src/vs/workbench/services/textfile/common/textFileEditorModel.ts
+++ b/src/vs/workbench/services/textfile/common/textFileEditorModel.ts
@@ -1151,8 +1151,8 @@ export class TextFileEditorModel extends BaseTextEditorModel implements ITextFil
 				return; // return early if the encoding is already the same
 			}
 
-			if (this.isDirty() && !this.inConflictMode) {
-				await this.save();
+			if (this.isDirty()) {
+				throw new Error('Cannot re-open a dirty text document with different encoding. Save it first.');
 			}
 
 			this.updatePreferredEncoding(encoding);

--- a/src/vs/workbench/services/textfile/test/browser/textFileEditorModel.test.ts
+++ b/src/vs/workbench/services/textfile/test/browser/textFileEditorModel.test.ts
@@ -8,7 +8,7 @@ import { IInstantiationService } from '../../../../../platform/instantiation/com
 import { TextFileEditorModel } from '../../common/textFileEditorModel.js';
 import { EncodingMode, TextFileEditorModelState, snapshotToString, isTextFileEditorModel, ITextFileEditorModelSaveEvent } from '../../common/textfiles.js';
 import { createFileEditorInput, workbenchInstantiationService, TestServiceAccessor, TestReadonlyTextFileEditorModel, getLastResolvedFileStat } from '../../../../test/browser/workbenchTestServices.js';
-import { ensureNoDisposablesAreLeakedInTestSuite, toResource } from '../../../../../base/test/common/utils.js';
+import { assertThrowsAsync, ensureNoDisposablesAreLeakedInTestSuite, toResource } from '../../../../../base/test/common/utils.js';
 import { TextFileEditorModelManager } from '../../common/textFileEditorModelManager.js';
 import { FileOperationResult, FileOperationError, NotModifiedSinceFileOperationError } from '../../../../../platform/files/common/files.js';
 import { DeferredPromise, timeout } from '../../../../../base/common/async.js';
@@ -318,7 +318,7 @@ suite('Files - TextFileEditorModel', () => {
 		assert.ok(model.isResolved()); // model got resolved due to decoding
 	});
 
-	test('setEncoding - decode dirty file saves first', async function () {
+	test('setEncoding - decode dirty file throws', async function () {
 		const model: TextFileEditorModel = disposables.add(instantiationService.createInstance(TextFileEditorModel, toResource.call(this, '/path/index_async.txt'), 'utf8', undefined));
 		accessor.workingCopyService.testUnregisterWorkingCopy(model); // causes issues with subsequent resolves otherwise
 
@@ -327,9 +327,7 @@ suite('Files - TextFileEditorModel', () => {
 		model.updateTextEditorModel(createTextBufferFactory('bar'));
 		assert.strictEqual(model.isDirty(), true);
 
-		await model.setEncoding('utf16', EncodingMode.Decode);
-
-		assert.strictEqual(model.isDirty(), false);
+		assertThrowsAsync(() => model.setEncoding('utf16', EncodingMode.Decode));
 	});
 
 	test('encoding updates with language based configuration', async function () {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
