### PR TITLE
fix(sourcemap): normalize paths to avoid duplicated prefixes like fil…

### DIFF
--- a/build/lib/optimize.ts
+++ b/build/lib/optimize.ts
@@ -152,9 +152,17 @@ function bundleESMTask(opts: IBundleESMTaskOpts): NodeJS.ReadWriteStream {
 						sourceMapFile = res.outputFiles.find(f => f.path === `${file.path}.map`);
 					}
 
+					let sourceMap = sourceMapFile ? JSON.parse(sourceMapFile.text) : undefined;
+
+					if (sourceMap && sourceMap.sources) {
+						sourceMap.sources = sourceMap.sources.map(src =>
+							src.replace(/^file:\/\/\//, '')         // Remove file:///
+								.replace(/^.*?\/src\//, 'vs/')       // Replace long /src/... path with vs/
+						);
+					}
 					const fileProps = {
 						contents: Buffer.from(file.contents),
-						sourceMap: sourceMapFile ? JSON.parse(sourceMapFile.text) : undefined, // support gulp-sourcemaps
+						sourceMap: sourceMap,
 						path: file.path,
 						base: path.join(REPO_ROOT_PATH, opts.src)
 					};

--- a/build/lib/tsb/builder.ts
+++ b/build/lib/tsb/builder.ts
@@ -221,10 +221,11 @@ export function createTypeScriptBuilder(config: IConfiguration, projectFile: str
 
 										[tsSMC, inputSMC].forEach((consumer) => {
 											(<SourceMapConsumer & { sources: string[] }>consumer).sources.forEach((sourceFile: any) => {
-												(<any>smg)._sources.add(sourceFile);
+												const normalized = sourceFile.replace(/^file:\/\/\//, '').replace(/^file:\//, '');
+												(<any>smg)._sources.add(normalized);
 												const sourceContent = consumer.sourceContentFor(sourceFile);
 												if (sourceContent !== null) {
-													smg.setSourceContent(sourceFile, sourceContent);
+													smg.setSourceContent(normalized, sourceContent);
 												}
 											});
 										});


### PR DESCRIPTION
fixes : #251233
### Problem

When building with esbuild and gulp-sourcemaps, the generated `.map` files often include:

- `file:///` prefixes in `sources`
- Full absolute paths like `/home/user/vscode/src/vs/...`

These break debugging tools and create duplicated or corrupted paths when loading source maps in the editor or browser.
### Solution

This PR fixes the sourcemap path normalization by:

- Removing `file:///` prefixes from `sourceMap.sources`
- Replacing long absolute `/src/...` paths with the expected `vs/...` format


