### PR TITLE
feat: add engines property to root package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -236,5 +236,9 @@
   },
   "optionalDependencies": {
     "windows-foreground-love": "0.5.0"
+  },
+  "engines": {
+    "node": ">=22.17.0",
+    "npm": ">=10.8.0"
   }
 }


### PR DESCRIPTION
## Description

This PR adds the `engines` property to the root `package.json` to specify the required Node.js and npm versions for VS Code development, addressing issue #252372.

## Changes

- Added `engines` property with Node.js version `>=22.17.0` (matching the `.nvmrc` file)
- Added npm version `>=10.8.0` (compatible with the required Node.js version)
- This provides clear version requirements for contributors
- Helps prevent installation issues with unsupported Node.js/npm versions

## Why this change is needed

As mentioned in the original issue, the [How to Contribute](https://github.com/microsoft/vscode/wiki/How-to-Contribute) guide mentions using `npm install` but doesn't specify which npm or Node.js versions are required. This change:

1. **Provides quick reference** for required versions
2. **Prevents errors** when using unsupported versions  
3. **Matches existing `.nvmrc`** specification (22.17.0)
4. **Follows npm standards** for version specification

## Testing

- [x] Verified the `engines` field is valid JSON
- [x] Confirmed Node.js version matches `.nvmrc` 
- [x] Verified npm version is compatible with Node.js 22.17.0
- [x] No breaking changes - this is purely additive metadata

## Associated Issue

Fixes #252372