### PR TITLE
Delete old Tools picker based on Quick Pick and `indented` QP API

### DIFF
--- a/src/vs/platform/quickinput/browser/media/quickInput.css
+++ b/src/vs/platform/quickinput/browser/media/quickInput.css
@@ -189,10 +189,6 @@
 	padding: 0 6px;
 }
 
-.quick-input-list .quick-input-list-entry.indented {
-	padding-left: 1.3em;
-}
-
 .quick-input-list .quick-input-list-entry.quick-input-list-separator-border {
 	border-top-width: 1px;
 	border-top-style: solid;

--- a/src/vs/platform/quickinput/browser/quickInputList.ts
+++ b/src/vs/platform/quickinput/browser/quickInputList.ts
@@ -442,7 +442,6 @@ class QuickPickItemElementRenderer extends BaseQuickInputListRenderer<QuickPickI
 		element.element = data.entry ?? undefined;
 		const mainItem: IQuickPickItem = element.item;
 
-		element.element.classList.toggle('indented', Boolean(mainItem.indented));
 		element.element.classList.toggle('not-pickable', element.item.pickable === false);
 
 		this.ensureCheckbox(element, data);

--- a/src/vs/platform/quickinput/common/quickInput.ts
+++ b/src/vs/platform/quickinput/common/quickInput.ts
@@ -51,7 +51,6 @@ export interface IQuickPickItem {
 	 */
 	disabled?: boolean;
 	alwaysShow?: boolean;
-	indented?: boolean;
 	/** Defauls to true with `IQuickPick.canSelectMany`, can be false to disable picks for a single item */
 	pickable?: boolean;
 }

--- a/src/vs/workbench/contrib/chat/browser/actions/chatToolPicker.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatToolPicker.ts
@@ -4,19 +4,16 @@
  *--------------------------------------------------------------------------------------------*/
 import { assertNever } from '../../../../../base/common/assert.js';
 import { Codicon } from '../../../../../base/common/codicons.js';
-import { diffSets } from '../../../../../base/common/collections.js';
 import { Event } from '../../../../../base/common/event.js';
 import { DisposableStore } from '../../../../../base/common/lifecycle.js';
 import { ThemeIcon } from '../../../../../base/common/themables.js';
 import { assertType } from '../../../../../base/common/types.js';
-import { generateUuid } from '../../../../../base/common/uuid.js';
 import { localize } from '../../../../../nls.js';
 import { CommandsRegistry, ICommandService } from '../../../../../platform/commands/common/commands.js';
 import { ExtensionIdentifier } from '../../../../../platform/extensions/common/extensions.js';
 import { ServicesAccessor } from '../../../../../platform/instantiation/common/instantiation.js';
-import { IQuickInputButton, IQuickInputService, IQuickPickItem, IQuickPickSeparator, IQuickTreeItem } from '../../../../../platform/quickinput/common/quickInput.js';
+import { IQuickInputButton, IQuickInputService, IQuickPickItem, IQuickTreeItem } from '../../../../../platform/quickinput/common/quickInput.js';
 import { URI } from '../../../../../base/common/uri.js';
-import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 import { IEditorService } from '../../../../services/editor/common/editorService.js';
 import { ExtensionEditorTab, IExtensionsWorkbenchService } from '../../../extensions/common/extensions.js';
 import { McpCommandIds } from '../../../mcp/common/mcpCommandIds.js';
@@ -26,33 +23,8 @@ import { ILanguageModelToolsService, IToolData, ToolDataSource, ToolSet } from '
 import { ConfigureToolSets } from '../tools/toolSetsContribution.js';
 import { IContextKeyService } from '../../../../../platform/contextkey/common/contextkey.js';
 import { ChatContextKeys } from '../../common/chatContextKeys.js';
-import { Iterable } from '../../../../../base/common/iterator.js';
 import Severity from '../../../../../base/common/severity.js';
 import { markdownCommandLink } from '../../../../../base/common/htmlContent.js';
-
-/**
- * Chat Tools Picker - Dual Implementation
- *
- * This module provides a tools picker for the chat interface with two implementations:
- * 1. Legacy QuickPick implementation (showToolsPickerLegacy) - the original flat list approach
- * 2. New QuickTree implementation (showToolsPickerTree) - hierarchical tree approach
- *
- * The implementation is controlled by the workspace setting 'chat.tools.useTreePicker':
- * - false (default): Uses the legacy QuickPick implementation for backward compatibility
- * - true: Uses the new QuickTree implementation for improved UX with hierarchical structure
- *
- * Key differences between implementations:
- * - QuickPick: Flat list with indentation to show hierarchy
- * - QuickTree: True hierarchical tree with collapsible nodes and checkboxes
- *
- * MCP Server Special Case: MCP servers are represented differently in the tree:
- * - MCP Server appears as a bucket (parent node)
- * - Tools appear as direct children of the server bucket
- * - The MCP ToolSet is stored in bucket.toolset but not shown as separate tree node
- *
- * Both implementations maintain the same external API and return the same result format:
- * Map<IToolData | ToolSet, boolean> representing selected tools and toolsets.
- */
 
 const enum BucketOrdinal { User, BuiltIn, Mcp, Extension }
 
@@ -60,8 +32,6 @@ const enum BucketOrdinal { User, BuiltIn, Mcp, Extension }
 type BucketPick = IQuickPickItem & { picked: boolean; ordinal: BucketOrdinal; status?: string; toolset?: ToolSet; children: (ToolPick | ToolSetPick)[] };
 type ToolSetPick = IQuickPickItem & { picked: boolean; toolset: ToolSet; parent: BucketPick };
 type ToolPick = IQuickPickItem & { picked: boolean; tool: IToolData; parent: BucketPick };
-type CallbackPick = IQuickPickItem & { pickable: false; run: () => void };
-type AnyPick = BucketPick | ToolSetPick | ToolPick | CallbackPick;
 type ActionableButton = IQuickInputButton & { action: () => void };
 
 // New QuickTree types for tree-based implementation
@@ -116,23 +86,6 @@ interface ICallbackTreeItem extends IToolTreeItem {
 }
 
 type AnyTreeItem = IBucketTreeItem | IToolSetTreeItem | IToolTreeItemData | ICallbackTreeItem;
-
-// Type guards for legacy QuickPick types
-function isBucketPick(obj: any): obj is BucketPick {
-	return Boolean((obj as BucketPick).children);
-}
-function isToolSetPick(obj: AnyPick): obj is ToolSetPick {
-	return Boolean((obj as ToolSetPick).toolset);
-}
-function isToolPick(obj: AnyPick): obj is ToolPick {
-	return Boolean((obj as ToolPick).tool);
-}
-function isCallbackPick(obj: AnyPick): obj is CallbackPick {
-	return Boolean((obj as CallbackPick).run);
-}
-function isActionableButton(obj: IQuickInputButton): obj is ActionableButton {
-	return typeof (obj as ActionableButton).action === 'function';
-}
 
 // Type guards for new QuickTree types
 function isBucketTreeItem(item: AnyTreeItem): item is IBucketTreeItem {
@@ -194,9 +147,14 @@ function createToolTreeItemFromData(tool: IToolData, checked: boolean): IToolTre
  * - Special handling for MCP servers (server as bucket, tools as direct children)
  * - Built-in filtering and search capabilities
  *
- * This implementation provides improved UX over the legacy flat list approach.
+ * @param accessor - Service accessor for dependency injection
+ * @param placeHolder - Placeholder text shown in the picker
+ * @param description - Optional description text shown in the picker
+ * @param toolsEntries - Optional initial selection state for tools and toolsets
+ * @param onUpdate - Optional callback fired when the selection changes
+ * @returns Promise resolving to the final selection map, or undefined if cancelled
  */
-async function showToolsPickerTree(
+export async function showToolsPicker(
 	accessor: ServicesAccessor,
 	placeHolder: string,
 	description?: string,
@@ -552,428 +510,5 @@ async function showToolsPickerTree(
 	store.dispose();
 
 	collectResults();
-	return didAccept ? result : undefined;
-}
-
-/**
- * Main entry point for the tools picker. Supports both QuickPick and QuickTree implementations
- * based on the 'chat.tools.useTreePicker' workspace setting.
- *
- * @param accessor - Service accessor for dependency injection
- * @param placeHolder - Placeholder text shown in the picker
- * @param description - Optional description text shown in the picker
- * @param toolsEntries - Optional initial selection state for tools and toolsets
- * @param onUpdate - Optional callback fired when the selection changes
- * @returns Promise resolving to the final selection map, or undefined if cancelled
- */
-export async function showToolsPicker(
-	accessor: ServicesAccessor,
-	placeHolder: string,
-	description?: string,
-	toolsEntries?: ReadonlyMap<ToolSet | IToolData, boolean>,
-	onUpdate?: (toolsEntries: ReadonlyMap<ToolSet | IToolData, boolean>) => void
-): Promise<ReadonlyMap<ToolSet | IToolData, boolean> | undefined> {
-
-	// Feature flag logic: Choose between QuickTree and QuickPick implementations
-	const configurationService = accessor.get(IConfigurationService);
-	const useTreePicker = configurationService.getValue<boolean>('chat.tools.useTreePicker');
-
-	if (useTreePicker) {
-		// New implementation: Use IQuickTree for hierarchical tree structure with checkboxes
-		return showToolsPickerTree(accessor, placeHolder, description, toolsEntries, onUpdate);
-	} else {
-		// Legacy implementation: Use QuickPick for backward compatibility
-		return showToolsPickerLegacy(accessor, placeHolder, description, toolsEntries, onUpdate);
-	}
-}
-
-/**
- * Legacy QuickPick implementation (renamed from original showToolsPicker).
- * Uses a flat list with indentation to represent hierarchy.
- * Maintained for backward compatibility when 'chat.tools.useTreePicker' is false.
- */
-async function showToolsPickerLegacy(
-	accessor: ServicesAccessor,
-	placeHolder: string,
-	description?: string,
-	toolsEntries?: ReadonlyMap<ToolSet | IToolData, boolean>,
-	onUpdate?: (toolsEntries: ReadonlyMap<ToolSet | IToolData, boolean>) => void
-): Promise<ReadonlyMap<ToolSet | IToolData, boolean> | undefined> {
-
-	const quickPickService = accessor.get(IQuickInputService);
-	const mcpService = accessor.get(IMcpService);
-	const mcpRegistry = accessor.get(IMcpRegistry);
-	const commandService = accessor.get(ICommandService);
-	const extensionsWorkbenchService = accessor.get(IExtensionsWorkbenchService);
-	const editorService = accessor.get(IEditorService);
-	const mcpWorkbenchService = accessor.get(IMcpWorkbenchService);
-	const toolsService = accessor.get(ILanguageModelToolsService);
-
-	const mcpServerByTool = new Map<string, IMcpServer>();
-	for (const server of mcpService.servers.get()) {
-		for (const tool of server.tools.get()) {
-			mcpServerByTool.set(tool.id, server);
-		}
-	}
-	const builtinBucket: BucketPick = {
-		type: 'item',
-		children: [],
-		label: localize('defaultBucketLabel', "Built-In"),
-		ordinal: BucketOrdinal.BuiltIn,
-		picked: false,
-	};
-
-	const userBucket: BucketPick = {
-		type: 'item',
-		children: [],
-		label: localize('userBucket', "User Defined Tool Sets"),
-		ordinal: BucketOrdinal.User,
-		alwaysShow: true,
-		picked: false,
-	};
-
-	const toolLimit = accessor.get(IContextKeyService).getContextKeyValue<number>(ChatContextKeys.chatToolGroupingThreshold.key);
-	const addMcpPick: CallbackPick = { type: 'item', label: localize('addServer', "Add MCP Server..."), iconClass: ThemeIcon.asClassName(Codicon.add), pickable: false, run: () => commandService.executeCommand(McpCommandIds.AddConfiguration) };
-	const configureToolSetsPick: CallbackPick = { type: 'item', label: localize('configToolSet', "Configure Tool Sets..."), iconClass: ThemeIcon.asClassName(Codicon.gear), pickable: false, run: () => commandService.executeCommand(ConfigureToolSets.ID) };
-	const addExpPick: CallbackPick = { type: 'item', label: localize('addExtension', "Install Extension..."), iconClass: ThemeIcon.asClassName(Codicon.add), pickable: false, run: () => extensionsWorkbenchService.openSearch('@tag:language-model-tools') };
-	const addPick: CallbackPick = {
-		type: 'item', label: localize('addAny', "Add More Tools..."), iconClass: ThemeIcon.asClassName(Codicon.add), pickable: false, run: async () => {
-			const pick = await quickPickService.pick(
-				[addMcpPick, addExpPick],
-				{
-					canPickMany: false,
-					placeHolder: localize('noTools', "Add tools to chat")
-				}
-			);
-			pick?.run();
-		}
-	};
-
-	const toolBuckets = new Map<string, BucketPick>();
-
-	if (!toolsEntries) {
-		const defaultEntries = new Map();
-		for (const tool of toolsService.getTools()) {
-			if (tool.canBeReferencedInPrompt) {
-				defaultEntries.set(tool, false);
-			}
-		}
-		for (const toolSet of toolsService.toolSets.get()) {
-			defaultEntries.set(toolSet, false);
-		}
-		toolsEntries = defaultEntries;
-	}
-
-	for (const [toolSetOrTool, picked] of toolsEntries) {
-
-		let bucket: BucketPick | undefined;
-		const buttons: ActionableButton[] = [];
-
-		if (toolSetOrTool.source.type === 'mcp') {
-			const key = ToolDataSource.toKey(toolSetOrTool.source);
-
-			const { definitionId } = toolSetOrTool.source;
-			const mcpServer = mcpService.servers.get().find(candidate => candidate.definition.id === definitionId);
-			if (!mcpServer) {
-				continue;
-			}
-
-			const buttons: ActionableButton[] = [];
-
-			bucket = toolBuckets.get(key) ?? {
-				type: 'item',
-				label: localize('mcplabel', "MCP Server: {0}", toolSetOrTool.source.label),
-				ordinal: BucketOrdinal.Mcp,
-				picked: false,
-				alwaysShow: true,
-				children: [],
-				buttons
-			};
-			toolBuckets.set(key, bucket);
-
-			const collection = mcpRegistry.collections.get().find(c => c.id === mcpServer.collection.id);
-			if (collection?.source) {
-				buttons.push({
-					iconClass: ThemeIcon.asClassName(Codicon.settingsGear),
-					tooltip: localize('configMcpCol', "Configure {0}", collection.label),
-					action: () => collection.source ? collection.source instanceof ExtensionIdentifier ? extensionsWorkbenchService.open(collection.source.value, { tab: ExtensionEditorTab.Features, feature: 'mcp' }) : mcpWorkbenchService.open(collection.source, { tab: McpServerEditorTab.Configuration }) : undefined
-				});
-			} else if (collection?.presentation?.origin) {
-				buttons.push({
-					iconClass: ThemeIcon.asClassName(Codicon.settingsGear),
-					tooltip: localize('configMcpCol', "Configure {0}", collection.label),
-					action: () => editorService.openEditor({
-						resource: collection!.presentation!.origin,
-					})
-				});
-			}
-			if (mcpServer.connectionState.get().state === McpConnectionState.Kind.Error) {
-				buttons.push({
-					iconClass: ThemeIcon.asClassName(Codicon.warning),
-					tooltip: localize('mcpShowOutput', "Show Output"),
-					action: () => mcpServer.showOutput(),
-				});
-			}
-
-		} else if (toolSetOrTool.source.type === 'extension') {
-			const key = ToolDataSource.toKey(toolSetOrTool.source);
-			bucket = toolBuckets.get(key) ?? {
-				type: 'item',
-				label: localize('ext', 'Extension: {0}', toolSetOrTool.source.label),
-				ordinal: BucketOrdinal.Extension,
-				picked: false,
-				alwaysShow: true,
-				children: []
-			};
-			toolBuckets.set(key, bucket);
-		} else if (toolSetOrTool.source.type === 'internal') {
-			bucket = builtinBucket;
-		} else if (toolSetOrTool.source.type === 'user') {
-			bucket = userBucket;
-			buttons.push({
-				iconClass: ThemeIcon.asClassName(Codicon.edit),
-				tooltip: localize('editUserBucket', "Edit Tool Set"),
-				action: () => {
-					assertType(toolSetOrTool.source.type === 'user');
-					editorService.openEditor({ resource: toolSetOrTool.source.file });
-				}
-			});
-		} else {
-			assertNever(toolSetOrTool.source);
-		}
-
-		if (toolSetOrTool instanceof ToolSet) {
-			if (toolSetOrTool.source.type !== 'mcp') { // don't show the MCP toolset
-				bucket.children.push({
-					parent: bucket,
-					type: 'item',
-					picked,
-					toolset: toolSetOrTool,
-					label: toolSetOrTool.referenceName,
-					description: toolSetOrTool.description,
-					indented: true,
-					buttons
-				});
-			} else {
-				// stash the MCP toolset into the bucket item
-				bucket.toolset = toolSetOrTool;
-				bucket.picked = picked;
-			}
-		} else if (toolSetOrTool.canBeReferencedInPrompt) {
-			bucket.children.push({
-				parent: bucket,
-				type: 'item',
-				picked,
-				tool: toolSetOrTool,
-				label: toolSetOrTool.toolReferenceName ?? toolSetOrTool.displayName,
-				description: toolSetOrTool.userDescription ?? toolSetOrTool.modelDescription,
-				indented: true,
-			});
-		}
-	}
-
-	for (const bucket of [builtinBucket, userBucket]) {
-		if (bucket.children.length > 0) {
-			toolBuckets.set(generateUuid(), bucket);
-		}
-	}
-
-	// set the checkmarks in the UI:
-	// bucket is checked if at least one of the children is checked
-	// tool is checked if the bucket is checked or the tool itself is checked
-	for (const bucket of toolBuckets.values()) {
-		if (bucket.picked) {
-			// check all children if the bucket is checked
-			for (const child of bucket.children) {
-				child.picked = true;
-			}
-		} else {
-			// check the bucket if one of the children is checked
-			bucket.picked = bucket.children.some(child => child.picked);
-		}
-	}
-
-	const store = new DisposableStore();
-
-	const picks: (AnyPick | IQuickPickSeparator)[] = [];
-
-	for (const bucket of Array.from(toolBuckets.values()).sort((a, b) => a.ordinal - b.ordinal)) {
-		picks.push({
-			type: 'separator',
-			label: bucket.status
-		});
-
-		picks.push(bucket);
-		picks.push(...bucket.children.sort((a, b) => a.label.localeCompare(b.label)));
-	}
-
-	const picker = store.add(quickPickService.createQuickPick<AnyPick>({ useSeparators: true }));
-	picker.placeholder = placeHolder;
-	picker.ignoreFocusOut = true;
-	picker.description = description;
-	picker.canSelectMany = true;
-	picker.keepScrollPosition = true;
-	picker.sortByLabel = false;
-	picker.matchOnDescription = true;
-
-	if (picks.length === 0) {
-		picker.placeholder = localize('noTools', "Add tools to chat");
-		picker.canSelectMany = false;
-		picks.push(
-			addMcpPick,
-			addExpPick,
-		);
-	} else {
-		picks.push(
-			{ type: 'separator' },
-			configureToolSetsPick,
-			addPick,
-		);
-	}
-
-	let lastSelectedItems = new Set<AnyPick>();
-	let ignoreEvent = false;
-
-	const result = new Map<IToolData | ToolSet, boolean>();
-
-	const _update = () => {
-		ignoreEvent = true;
-		try {
-			const items = picks.filter((p): p is AnyPick => p.type === 'item' && Boolean(p.picked));
-			lastSelectedItems = new Set(items);
-			picker.selectedItems = items;
-			let count = 0;
-
-			result.clear();
-			for (const item of picks) {
-				if (item.type !== 'item') {
-					continue;
-				}
-				if (isToolSetPick(item)) {
-					result.set(item.toolset, item.picked);
-					count += Iterable.length(item.toolset.getTools());
-				} else if (isToolPick(item)) {
-					result.set(item.tool, item.picked);
-					count++;
-				} else if (isBucketPick(item)) {
-					if (item.toolset) {
-						result.set(item.toolset, item.picked);
-					}
-					for (const child of item.children) {
-						if (isToolSetPick(child)) {
-							result.set(child.toolset, item.picked);
-							count += Iterable.length(child.toolset.getTools());
-						} else if (isToolPick(child)) {
-							result.set(child.tool, item.picked);
-							count++;
-						}
-					}
-				}
-			}
-
-			if (toolLimit) {
-				if (count > toolLimit) {
-					picker.severity = Severity.Warning;
-					picker.validationMessage = localize('toolLimitExceeded', "{0} tools are enabled. You may experience degraded tool calling above {1} tools.", count, toolLimit);
-				} else {
-					picker.severity = Severity.Ignore;
-					picker.validationMessage = undefined;
-				}
-			}
-
-			if (onUpdate) {
-				let didChange = toolsEntries.size !== result.size;
-				for (const [key, value] of toolsEntries) {
-					if (didChange) {
-						break;
-					}
-					didChange = result.get(key) !== value;
-				}
-
-				if (didChange) {
-					onUpdate(result);
-				}
-			}
-
-		} finally {
-			ignoreEvent = false;
-		}
-	};
-
-	_update();
-	picker.items = picks;
-	picker.show();
-
-	store.add(picker.onDidTriggerItemButton(e => {
-		if (isActionableButton(e.button)) {
-			e.button.action();
-			store.dispose();
-		}
-	}));
-
-	store.add(picker.onDidChangeSelection(selectedPicks => {
-		if (ignoreEvent) {
-			return;
-		}
-
-		const addPick = selectedPicks.find(isCallbackPick);
-		if (addPick) {
-			return;
-		}
-
-		const { added, removed } = diffSets(lastSelectedItems, new Set(selectedPicks));
-
-		for (const item of added) {
-			item.picked = true;
-
-			if (isBucketPick(item)) {
-				// add server -> add back tools
-				for (const toolPick of item.children) {
-					toolPick.picked = true;
-				}
-			} else if (isToolPick(item) || isToolSetPick(item)) {
-				// add server when tool is picked
-				item.parent.picked = true;
-			}
-		}
-
-		for (const item of removed) {
-			item.picked = false;
-
-			if (isBucketPick(item)) {
-				// removed server -> remove tools
-				for (const toolPick of item.children) {
-					toolPick.picked = false;
-				}
-			} else if ((isToolPick(item) || isToolSetPick(item)) && item.parent.children.every(child => !child.picked)) {
-				// remove LAST tool -> remove server
-				item.parent.picked = false;
-			}
-		}
-
-		_update();
-	}));
-
-	let didAccept = false;
-	store.add(picker.onDidAccept(() => {
-		const callbackPick = picker.activeItems.find(isCallbackPick);
-		if (callbackPick) {
-			callbackPick.run();
-		} else {
-			didAccept = true;
-		}
-	}));
-
-	await Promise.race([Event.toPromise(Event.any(picker.onDidAccept, picker.onDidHide))]);
-
-	store.dispose();
-
-	// in the result, a MCP toolset is only enabled if all tools in the toolset are enabled
-	for (const item of toolsService.toolSets.get()) {
-		if (item.source.type === 'mcp') {
-			const toolsInSet = Array.from(item.getTools());
-			result.set(item, toolsInSet.every(tool => result.get(tool)));
-		}
-	}
 	return didAccept ? result : undefined;
 }

--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -545,12 +545,6 @@ configurationRegistry.registerConfiguration({
 				mode: 'startup'
 			}
 		},
-		'chat.tools.useTreePicker': {
-			type: 'boolean',
-			default: true,
-			description: nls.localize('chat.tools.useTreePicker', "Use the new Quick Tree-based tools picker instead of the Quick Pick-based one. Provides better hierarchical organization of tools and tool sets with collapsible sections, improved visual hierarchy, and native tree interactions."),
-			tags: ['experimental'],
-		},
 		[ChatConfiguration.ShowThinking]: {
 			type: 'boolean',
 			default: false,


### PR DESCRIPTION
We have the Quick Tree now... that should be used instead of faking it with `indented`.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
