### PR TITLE
Fix OAuth redirect URI format to align with Microsoft's URL standards

### DIFF
--- a/src/vs/base/common/oauth.ts
+++ b/src/vs/base/common/oauth.ts
@@ -736,14 +736,14 @@ export async function fetchDynamicRegistration(serverMetadata: IAuthorizationSer
 			redirect_uris: [
 				'https://insiders.vscode.dev/redirect',
 				'https://vscode.dev/redirect',
-				'http://localhost',
-				'http://127.0.0.1',
+				'http://localhost/',
+				'http://127.0.0.1/',
 				// Added these for any server that might do
 				// only exact match on the redirect URI even
 				// though the spec says it should not care
 				// about the port.
-				`http://localhost:${DEFAULT_AUTH_FLOW_PORT}`,
-				`http://127.0.0.1:${DEFAULT_AUTH_FLOW_PORT}`
+				`http://localhost:${DEFAULT_AUTH_FLOW_PORT}/`,
+				`http://127.0.0.1:${DEFAULT_AUTH_FLOW_PORT}/`
 			],
 			scope: scopes?.join(AUTH_SCOPE_SEPARATOR),
 			token_endpoint_auth_method: 'none',

--- a/src/vs/base/test/common/oauth.test.ts
+++ b/src/vs/base/test/common/oauth.test.ts
@@ -358,10 +358,10 @@ suite('OAuth', () => {
 			assert.deepStrictEqual(requestBody.redirect_uris, [
 				'https://insiders.vscode.dev/redirect',
 				'https://vscode.dev/redirect',
-				'http://localhost',
-				'http://127.0.0.1',
-				`http://localhost:${DEFAULT_AUTH_FLOW_PORT}`,
-				`http://127.0.0.1:${DEFAULT_AUTH_FLOW_PORT}`
+				'http://localhost/',
+				'http://127.0.0.1/',
+				`http://localhost:${DEFAULT_AUTH_FLOW_PORT}/`,
+				`http://127.0.0.1:${DEFAULT_AUTH_FLOW_PORT}/`
 			]);
 
 			// Verify response is processed correctly

--- a/src/vs/workbench/api/node/loopbackServer.ts
+++ b/src/vs/workbench/api/node/loopbackServer.ts
@@ -102,7 +102,7 @@ export class LoopbackAuthServer implements ILoopbackServer {
 		if (this._port === undefined) {
 			throw new Error('Server is not started yet');
 		}
-		return `http://127.0.0.1:${this._port}`;
+		return `http://127.0.0.1:${this._port}/`;
 	}
 
 	private _sendPage(res: http.ServerResponse): void {


### PR DESCRIPTION
## OAuth Redirect URI Format Not Aligned with Microsoft's URL Standards

### Problem
VS Code's OAuth implementation generates redirect URIs without trailing slashes, while Microsoft's own OAuth 2.0 documentation and standards-compliant identity providers (including Entra ID) require trailing slashes in redirect URIs per RFC specifications.

This creates a mismatch where:
- **VS Code generates**: `http://127.0.0.1:3000`
- **IDP expects**: `http://127.0.0.1:3000/`

### Root Cause
Microsoft Entra ID (and other compliant IDPs) automatically append trailing slashes to redirect URIs during OAuth flows, following Microsoft's documented standards. However, VS Code's implementation returns URLs without trailing slashes, causing URI mismatch validation failures.

### Recent Change Context
A June 29th PR that modified `loopbackServer.ts` removed the trailing slash, introducing this standards compliance issue. This change made VS Code generate non-compliant redirect URIs that don't align with Microsoft's own OAuth 2.0 format requirements.

### Solution
This PR restores trailing slashes in two key locations:

1. **`loopbackServer.ts`** (line 105): Runtime redirect URI generation
2. **`oauth.ts`** (lines 739-746): Dynamic client registration redirect URIs

**Changes:**
- `http://127.0.0.1:${port}` → `http://127.0.0.1:${port}/`
- `http://localhost` → `http://localhost/`
- `http://127.0.0.1` → `http://127.0.0.1/`
- `http://localhost:${port}` → `http://localhost:${port}/`

### Impact
- Resolves OAuth authentication failures with "redirect_uri_mismatch" errors
- Ensures compatibility with standards-compliant OAuth providers
- Aligns VS Code with Microsoft's documented OAuth 2.0 URL format requirements

### Standards Reference
This change ensures VS Code follows Microsoft's own OAuth 2.0 redirect URI format requirements, improving compatibility with standards-compliant identity providers.

Fixes #260425