### PR TITLE
Clean up tools service and improve invocation handling

### DIFF
--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -57,12 +57,12 @@ import { IChatAgentMetadata, IChatAgentRequest, IChatAgentResult } from '../../c
 import { ICodeMapperRequest, ICodeMapperResult } from '../../contrib/chat/common/chatCodeMapperService.js';
 import { IChatRelatedFile, IChatRelatedFileProviderMetadata as IChatRelatedFilesProviderMetadata, IChatRequestDraft } from '../../contrib/chat/common/chatEditingService.js';
 import { IChatProgressHistoryResponseContent } from '../../contrib/chat/common/chatModel.js';
-import { IChatContentInlineReference, IChatFollowup, IChatNotebookEdit, IChatProgress, IChatTask, IChatTaskDto, IChatUserActionEvent, IChatVoteAction, ChatResponseClearToPreviousToolInvocationReason } from '../../contrib/chat/common/chatService.js';
+import { ChatResponseClearToPreviousToolInvocationReason, IChatContentInlineReference, IChatFollowup, IChatNotebookEdit, IChatProgress, IChatTask, IChatTaskDto, IChatUserActionEvent, IChatVoteAction } from '../../contrib/chat/common/chatService.js';
 import { IChatSessionItem } from '../../contrib/chat/common/chatSessionsService.js';
 import { IChatRequestVariableValue } from '../../contrib/chat/common/chatVariables.js';
 import { ChatAgentLocation } from '../../contrib/chat/common/constants.js';
 import { IChatMessage, IChatResponseFragment, ILanguageModelChatMetadataAndIdentifier, ILanguageModelChatSelector } from '../../contrib/chat/common/languageModels.js';
-import { IPreparedToolInvocation, IToolInvocation, IToolInvocationInput, IToolInvocationPreparationContext, IToolProgressStep, IToolResult, ToolDataSource } from '../../contrib/chat/common/languageModelToolsService.js';
+import { IInvokeToolInput, IPreparedToolInvocation, IToolInvocation, IToolInvocationPreparationContext, IToolProgressStep, IToolResult, ToolDataSource } from '../../contrib/chat/common/languageModelToolsService.js';
 import { DebugConfigurationProviderTriggerKind, IAdapterDescriptor, IConfig, IDebugSessionReplMode, IDebugTestRunReference, IDebugVisualization, IDebugVisualizationContext, IDebugVisualizationTreeItem, MainThreadDebugVisualization } from '../../contrib/debug/common/debug.js';
 import { McpCollectionDefinition, McpConnectionState, McpServerDefinition, McpServerLaunch } from '../../contrib/mcp/common/mcpTypes.js';
 import * as notebookCommon from '../../contrib/notebook/common/notebookCommon.js';
@@ -1401,7 +1401,7 @@ export interface IToolDataDto {
 export interface MainThreadLanguageModelToolsShape extends IDisposable {
 	$getTools(): Promise<Dto<IToolDataDto>[]>;
 	$acceptToolProgress(callId: string, progress: IToolProgressStep): void;
-	$invokeTool(dto: IToolInvocationInput, token?: CancellationToken): Promise<Dto<IToolResult> | SerializableObjectWithBuffers<Dto<IToolResult>>>;
+	$invokeTool(dto: IInvokeToolInput, token?: CancellationToken): Promise<Dto<IToolResult> | SerializableObjectWithBuffers<Dto<IToolResult>>>;
 	$countTokensForInvocation(callId: string, input: string, token: CancellationToken): Promise<number>;
 	$registerTool(id: string): void;
 	$unregisterTool(name: string): void;

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -62,7 +62,7 @@ import { IChatSessionItem } from '../../contrib/chat/common/chatSessionsService.
 import { IChatRequestVariableValue } from '../../contrib/chat/common/chatVariables.js';
 import { ChatAgentLocation } from '../../contrib/chat/common/constants.js';
 import { IChatMessage, IChatResponseFragment, ILanguageModelChatMetadataAndIdentifier, ILanguageModelChatSelector } from '../../contrib/chat/common/languageModels.js';
-import { IPreparedToolInvocation, IToolInvocation, IToolInvocationPreparationContext, IToolProgressStep, IToolResult, ToolDataSource } from '../../contrib/chat/common/languageModelToolsService.js';
+import { IPreparedToolInvocation, IToolInvocation, IToolInvocationInput, IToolInvocationPreparationContext, IToolProgressStep, IToolResult, ToolDataSource } from '../../contrib/chat/common/languageModelToolsService.js';
 import { DebugConfigurationProviderTriggerKind, IAdapterDescriptor, IConfig, IDebugSessionReplMode, IDebugTestRunReference, IDebugVisualization, IDebugVisualizationContext, IDebugVisualizationTreeItem, MainThreadDebugVisualization } from '../../contrib/debug/common/debug.js';
 import { McpCollectionDefinition, McpConnectionState, McpServerDefinition, McpServerLaunch } from '../../contrib/mcp/common/mcpTypes.js';
 import * as notebookCommon from '../../contrib/notebook/common/notebookCommon.js';
@@ -1401,7 +1401,7 @@ export interface IToolDataDto {
 export interface MainThreadLanguageModelToolsShape extends IDisposable {
 	$getTools(): Promise<Dto<IToolDataDto>[]>;
 	$acceptToolProgress(callId: string, progress: IToolProgressStep): void;
-	$invokeTool(dto: IToolInvocation, token?: CancellationToken): Promise<Dto<IToolResult> | SerializableObjectWithBuffers<Dto<IToolResult>>>;
+	$invokeTool(dto: IToolInvocationInput, token?: CancellationToken): Promise<Dto<IToolResult> | SerializableObjectWithBuffers<Dto<IToolResult>>>;
 	$countTokensForInvocation(callId: string, input: string, token: CancellationToken): Promise<number>;
 	$registerTool(id: string): void;
 	$unregisterTool(name: string): void;

--- a/src/vs/workbench/api/common/extHostLanguageModelTools.ts
+++ b/src/vs/workbench/api/common/extHostLanguageModelTools.ts
@@ -184,8 +184,8 @@ export class ExtHostLanguageModelTools implements ExtHostLanguageModelToolsShape
 			options.chatSessionId = dto.input.context?.sessionId;
 		}
 
-		if (isProposedApiEnabled(item.extension, 'chatParticipantAdditions') && dto.input.modelId) {
-			options.model = await this.getModel(dto.input.modelId, item.extension);
+		if (isProposedApiEnabled(item.extension, 'chatParticipantAdditions') && dto.modelId) {
+			options.model = await this.getModel(dto.modelId, item.extension);
 		}
 
 		if (dto.input.tokenBudget !== undefined) {

--- a/src/vs/workbench/api/common/extHostLanguageModelTools.ts
+++ b/src/vs/workbench/api/common/extHostLanguageModelTools.ts
@@ -124,7 +124,6 @@ export class ExtHostLanguageModelTools implements ExtHostLanguageModelToolsShape
 				tokenBudget: options.tokenizationOptions?.tokenBudget,
 				context: options.toolInvocationToken as IToolInvocationContext | undefined,
 				chatRequestId: isProposedApiEnabled(extension, 'chatParticipantPrivate') ? options.chatRequestId : undefined,
-				chatInteractionId: isProposedApiEnabled(extension, 'chatParticipantPrivate') ? options.chatInteractionId : undefined,
 			}, token);
 
 			const dto: Dto<IToolResult> = result instanceof SerializableObjectWithBuffers ? result.value : result;
@@ -182,7 +181,6 @@ export class ExtHostLanguageModelTools implements ExtHostLanguageModelToolsShape
 		};
 		if (isProposedApiEnabled(item.extension, 'chatParticipantPrivate')) {
 			options.chatRequestId = dto.chatRequestId;
-			options.chatInteractionId = dto.chatInteractionId;
 			options.chatSessionId = dto.context?.sessionId;
 		}
 
@@ -245,7 +243,6 @@ export class ExtHostLanguageModelTools implements ExtHostLanguageModelToolsShape
 			input: context.parameters,
 			chatRequestId: context.chatRequestId,
 			chatSessionId: context.chatSessionId,
-			chatInteractionId: context.chatInteractionId
 		};
 		if (item.tool.prepareInvocation) {
 			const result = await item.tool.prepareInvocation(options, token);

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatTerminalToolSubPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatTerminalToolSubPart.ts
@@ -115,10 +115,11 @@ export class TerminalConfirmationWidgetSubPart extends BaseChatToolInvocationSub
 			}
 		};
 		const langId = this.languageService.getLanguageIdByLanguageName(terminalData.language ?? 'sh') ?? 'shellscript';
+		const uri = this._getUniqueCodeBlockUri();
 		const model = this.modelService.createModel(
 			terminalData.commandLine.toolEdited ?? terminalData.commandLine.original,
 			this.languageService.createById(langId),
-			this._getUniqueCodeBlockUri(),
+			uri,
 			true
 		);
 		const editor = this._register(this.editorPool.get());

--- a/src/vs/workbench/contrib/chat/browser/chatSetup.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSetup.ts
@@ -567,8 +567,8 @@ class SetupTool extends Disposable implements IToolImpl {
 		return result;
 	}
 
-	async prepareToolInvocation?(parameters: any, token: CancellationToken): Promise<IPreparedToolInvocation | undefined> {
-		return undefined;
+	async prepareToolInvocation(parameters: any, token: CancellationToken): Promise<IPreparedToolInvocation> {
+		return {};
 	}
 }
 

--- a/src/vs/workbench/contrib/chat/browser/languageModelToolsService.ts
+++ b/src/vs/workbench/contrib/chat/browser/languageModelToolsService.ts
@@ -3,14 +3,9 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { renderAsPlaintext } from '../../../../base/browser/markdownRenderer.js';
-import { assertNever } from '../../../../base/common/assert.js';
 import { RunOnceScheduler } from '../../../../base/common/async.js';
-import { encodeBase64 } from '../../../../base/common/buffer.js';
-import { CancellationToken, CancellationTokenSource } from '../../../../base/common/cancellation.js';
+import { CancellationToken } from '../../../../base/common/cancellation.js';
 import { Codicon } from '../../../../base/common/codicons.js';
-import { toErrorMessage } from '../../../../base/common/errorMessage.js';
-import { CancellationError, isCancellationError } from '../../../../base/common/errors.js';
 import { Emitter } from '../../../../base/common/event.js';
 import { Iterable } from '../../../../base/common/iterator.js';
 import { Lazy } from '../../../../base/common/lazy.js';
@@ -18,25 +13,15 @@ import { Disposable, DisposableStore, IDisposable, toDisposable } from '../../..
 import { LRUCache } from '../../../../base/common/map.js';
 import { IObservable, ObservableSet } from '../../../../base/common/observable.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
-import { IAccessibilityService } from '../../../../platform/accessibility/common/accessibility.js';
-import { AccessibilitySignal, IAccessibilitySignalService } from '../../../../platform/accessibilitySignal/browser/accessibilitySignalService.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { IContextKey, IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
-import { IDialogService } from '../../../../platform/dialogs/common/dialogs.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import * as JSONContributionRegistry from '../../../../platform/jsonschemas/common/jsonContributionRegistry.js';
-import { ILogService } from '../../../../platform/log/common/log.js';
 import { Registry } from '../../../../platform/registry/common/platform.js';
 import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
-import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry.js';
-import { IExtensionService } from '../../../services/extensions/common/extensions.js';
 import { ChatContextKeys } from '../common/chatContextKeys.js';
-import { ChatModel } from '../common/chatModel.js';
-import { ChatToolInvocation } from '../common/chatProgressTypes/chatToolInvocation.js';
-import { IChatService } from '../common/chatService.js';
 import { ChatConfiguration } from '../common/constants.js';
-import { CountTokensCallback, createToolSchemaUri, IInvokeToolInput, ILanguageModelToolsService, IPreparedToolInvocationWithData, IToolData, IToolImpl, IToolInvocation, IToolResult, IToolResultInputOutputDetails, stringifyPromptTsxPart, ToolDataSource, ToolSet } from '../common/languageModelToolsService.js';
-import { getToolConfirmationAlert } from './chatAccessibilityProvider.js';
+import { CountTokensCallback, createToolSchemaUri, IInvokeToolInput, ILanguageModelToolsService, IToolData, IToolImpl, IToolResult, ToolDataSource, ToolSet } from '../common/languageModelToolsService.js';
 
 const jsonSchemaRegistry = Registry.as<JSONContributionRegistry.IJSONContributionRegistry>(JSONContributionRegistry.Extensions.JSONContribution);
 
@@ -44,14 +29,6 @@ interface IToolEntry<T> {
 	data: IToolData;
 	impl?: IToolImpl<T>;
 }
-
-interface ITrackedCall extends IDisposable {
-	invocation?: ChatToolInvocation;
-	token: CancellationToken;
-}
-
-type RequestId = string;
-type ToolCallId = string;
 
 export class LanguageModelToolsService extends Disposable implements ILanguageModelToolsService {
 	_serviceBrand: undefined;
@@ -66,23 +43,14 @@ export class LanguageModelToolsService extends Disposable implements ILanguageMo
 	private _toolContextKeys = new Set<string>();
 	private readonly _ctxToolsCount: IContextKey<number>;
 
-	private _callsByRequestId = new Map<RequestId, Map<ToolCallId, ITrackedCall>>();
-
 	private _workspaceToolConfirmStore: Lazy<ToolConfirmStore>;
 	private _profileToolConfirmStore: Lazy<ToolConfirmStore>;
 	private _memoryToolConfirmStore = new Set<string>();
 
 	constructor(
 		@IInstantiationService private readonly _instantiationService: IInstantiationService,
-		@IExtensionService private readonly _extensionService: IExtensionService,
 		@IContextKeyService private readonly _contextKeyService: IContextKeyService,
-		@IChatService private readonly _chatService: IChatService,
-		@IDialogService private readonly _dialogService: IDialogService,
-		@ITelemetryService private readonly _telemetryService: ITelemetryService,
-		@ILogService private readonly _logService: ILogService,
 		@IConfigurationService private readonly _configurationService: IConfigurationService,
-		@IAccessibilityService private readonly _accessibilityService: IAccessibilityService,
-		@IAccessibilitySignalService private readonly _accessibilitySignalService: IAccessibilitySignalService
 	) {
 		super();
 
@@ -107,7 +75,6 @@ export class LanguageModelToolsService extends Disposable implements ILanguageMo
 	override dispose(): void {
 		super.dispose();
 
-		this._callsByRequestId.forEach(calls => calls.forEach(call => call.dispose()));
 		this._ctxToolsCount.reset();
 	}
 
@@ -218,288 +185,10 @@ export class LanguageModelToolsService extends Disposable implements ILanguageMo
 	}
 
 	async invokeTool(toolInput: IInvokeToolInput, countTokens: CountTokensCallback, token: CancellationToken): Promise<IToolResult> {
-		this._logService.trace(`[LanguageModelToolsService#invokeTool] Invoking tool ${toolInput.toolId} with parameters ${JSON.stringify(toolInput.parameters)}`);
 
-		// When invoking a tool, don't validate the "when" clause. An extension may have invoked a tool just as it was becoming disabled, and just let it go through rather than throw and break the chat.
-		let tool = this._tools.get(toolInput.toolId);
-		if (!tool) {
-			throw new Error(`Tool ${toolInput.toolId} was not contributed`);
-		}
-
-		if (!tool.impl) {
-			await this._extensionService.activateByEvent(`onLanguageModelTool:${toolInput.toolId}`);
-
-			// Extension should activate and register the tool implementation
-			tool = this._tools.get(toolInput.toolId);
-			if (!tool?.impl) {
-				throw new Error(`Tool ${toolInput.toolId} does not have an implementation registered.`);
-			}
-		}
-
-		// Shortcut to write to the model directly here, but could call all the way back to use the real stream.
-		let chatModelToolInvocation: ChatToolInvocation | undefined;
-		let invocationInput: IInvokeToolInput = toolInput;
-		let requestId: string | undefined;
-		let toolResult: IToolResult | undefined;
-		try {
-			let prepared: IPreparedToolInvocationWithData<unknown>;
-			let modelId: string | undefined;
-			if (toolInput.context) {
-				const inChat = await this.prepareInvocationInChatSession(toolInput, tool, token);
-				prepared = inChat.prepared;
-				chatModelToolInvocation = inChat.toolInvocation;
-				modelId = inChat.modelId;
-				requestId = inChat.requestId;
-			} else {
-				prepared = await this.prepareInvocationStandalone(toolInput, tool, token);
-			}
-
-			if (token.isCancellationRequested) {
-				throw new CancellationError();
-			}
-
-			let toolSpecificData = prepared.toolSpecificData;
-			if (toolSpecificData?.kind === 'input') {
-				invocationInput = { ...invocationInput, parameters: toolSpecificData.rawInput };
-				toolSpecificData = undefined;
-			}
-			const toolInvocation: IToolInvocation<unknown> = {
-				input: invocationInput,
-				preparedData: prepared.preparedData,
-				toolSpecificData,
-				modelId
-			};
-			toolResult = await tool.impl.invoke(toolInvocation, countTokens, {
-				report: step => {
-					chatModelToolInvocation?.acceptProgress(step);
-				}
-			}, token);
-			this.ensureToolDetails(invocationInput, toolResult, tool.data);
-
-			this._telemetryService.publicLog2<LanguageModelToolInvokedEvent, LanguageModelToolInvokedClassification>(
-				'languageModelToolInvoked',
-				{
-					result: 'success',
-					chatSessionId: toolInput.context?.sessionId,
-					toolId: tool.data.id,
-					toolExtensionId: tool.data.source.type === 'extension' ? tool.data.source.extensionId.value : undefined,
-					toolSourceKind: tool.data.source.type,
-				});
-			return toolResult;
-		} catch (err) {
-			const result = isCancellationError(err) ? 'userCancelled' : 'error';
-			this._telemetryService.publicLog2<LanguageModelToolInvokedEvent, LanguageModelToolInvokedClassification>(
-				'languageModelToolInvoked',
-				{
-					result,
-					chatSessionId: toolInput.context?.sessionId,
-					toolId: tool.data.id,
-					toolExtensionId: tool.data.source.type === 'extension' ? tool.data.source.extensionId.value : undefined,
-					toolSourceKind: tool.data.source.type,
-				});
-			this._logService.error(`[LanguageModelToolsService#invokeTool] Error from tool ${toolInput.toolId} with parameters ${JSON.stringify(toolInput.parameters)}:\n${toErrorMessage(err, true)}`);
-
-			toolResult ??= { content: [] };
-			toolResult.toolResultError = err instanceof Error ? err.message : String(err);
-			if (tool.data.alwaysDisplayInputOutput) {
-				toolResult.toolResultDetails = { input: this.formatToolInput(toolInput), output: [{ type: 'embed', isText: true, value: String(err) }], isError: true };
-			}
-
-			throw err;
-		} finally {
-			chatModelToolInvocation?.complete(toolResult);
-
-			if (requestId) {
-				this.cleanupCallDisposables(requestId, toolInput.callId);
-			}
-		}
-	}
-
-	/** Prepare a tool invocation that is occurring outside of a chat session. */
-	private async prepareInvocationStandalone(toolInput: IInvokeToolInput, tool: IToolEntry<unknown>, token: CancellationToken): Promise<IPreparedToolInvocationWithData<unknown>> {
-		const prepared = await this.callPrepareToolInvocation(tool, toolInput, token);
-		if (prepared.confirmationMessages && !this.shouldAutoConfirm(tool.data.id, tool.data.runsInWorkspace)) {
-			const result = await this._dialogService.confirm({ message: renderAsPlaintext(prepared.confirmationMessages.title), detail: renderAsPlaintext(prepared.confirmationMessages.message) });
-			if (!result.confirmed) {
-				throw new CancellationError();
-			}
-		}
-		return prepared;
-	}
-
-	/**
-	 * Prepare a tool invocation that is occurring within a chat session context. This wires up
-	 * cancellation, confirmation, and progress reporting to the active chat model/request.
-	 */
-	private async prepareInvocationInChatSession(toolInput: IInvokeToolInput, tool: IToolEntry<unknown>, token: CancellationToken): Promise<{ prepared: IPreparedToolInvocationWithData<unknown>; toolInvocation: ChatToolInvocation; modelId?: string; requestId?: string }> {
-		const model = this._chatService.getSession(toolInput.context!.sessionId) as ChatModel | undefined;
-		if (!model) {
-			throw new Error(`Tool called for unknown chat session`);
-		}
-
-		const request = model.getRequests().at(-1)!;
-		const requestId = request.id;
-
-		const trackedCall = this.setupTrackedCall(requestId, toolInput.callId, token);
-		const prepared = await this.callPrepareToolInvocation(tool, toolInput, trackedCall.token);
-		const toolInvocation = new ChatToolInvocation(prepared, tool.data, toolInput.callId);
-		trackedCall.invocation = toolInvocation;
-		const autoConfirmed = this.shouldAutoConfirm(tool.data.id, tool.data.runsInWorkspace);
-		if (autoConfirmed) {
-			toolInvocation.confirmed.complete(true);
-		}
-
-		model.acceptResponseProgress(request, toolInvocation);
-
-		if (prepared.confirmationMessages) {
-			if (!toolInvocation.isConfirmed && !autoConfirmed) {
-				this.playAccessibilitySignal([toolInvocation]);
-			}
-			const userConfirmed = await toolInvocation.confirmed.p;
-			if (!userConfirmed) {
-				throw new CancellationError();
-			}
-		}
-
-		return {
-			prepared,
-			toolInvocation,
-			modelId: request.modelId,
-			requestId
-		};
-	}
-
-	private setupTrackedCall(requestId: RequestId, toolCallId: ToolCallId, token: CancellationToken): ITrackedCall {
-		if (!this._callsByRequestId.has(requestId)) {
-			this._callsByRequestId.set(requestId, new Map());
-		}
-		const store = new DisposableStore();
-		const cts = new CancellationTokenSource();
-		const trackedCall: ITrackedCall = {
-			dispose: () => store.dispose(),
-			token: cts.token
-		};
-		this._callsByRequestId.get(requestId)!.set(toolCallId, trackedCall);
-
-		store.add(toDisposable(() => {
-			cts.dispose(true);
-		}));
-		store.add(token.onCancellationRequested(() => {
-			trackedCall.invocation?.confirmed.complete(false);
-			cts.cancel();
-		}));
-		store.add(cts.token.onCancellationRequested(() => {
-			trackedCall.invocation?.confirmed.complete(false);
-		}));
-
-		return trackedCall;
-	}
-
-	private async callPrepareToolInvocation<T>(tool: IToolEntry<T>, input: IInvokeToolInput, token: CancellationToken): Promise<IPreparedToolInvocationWithData<T>> {
-		const prepared = await tool.impl!.prepareToolInvocation({
-			parameters: input.parameters,
-			chatRequestId: input.chatRequestId,
-			chatSessionId: input.context?.sessionId,
-		}, token);
-
-		if (prepared.confirmationMessages) {
-			if (prepared.toolSpecificData?.kind !== 'terminal' && typeof prepared.confirmationMessages.allowAutoConfirm !== 'boolean') {
-				prepared.confirmationMessages.allowAutoConfirm = true;
-			}
-
-			if (!prepared.toolSpecificData && tool.data.alwaysDisplayInputOutput) {
-				prepared.toolSpecificData = {
-					kind: 'input',
-					rawInput: input.parameters,
-				};
-			}
-		}
-
-		return prepared;
-	}
-
-	private playAccessibilitySignal(toolInvocations: ChatToolInvocation[]): void {
-		const autoApproved = this._configurationService.getValue('chat.tools.autoApprove');
-		if (autoApproved) {
-			return;
-		}
-		const setting: { sound?: 'auto' | 'on' | 'off'; announcement?: 'auto' | 'off' } | undefined = this._configurationService.getValue(AccessibilitySignal.chatUserActionRequired.settingsKey);
-		if (!setting) {
-			return;
-		}
-		const soundEnabled = setting.sound === 'on' || (setting.sound === 'auto' && (this._accessibilityService.isScreenReaderOptimized()));
-		const announcementEnabled = this._accessibilityService.isScreenReaderOptimized() && setting.announcement === 'auto';
-		if (soundEnabled || announcementEnabled) {
-			this._accessibilitySignalService.playSignal(AccessibilitySignal.chatUserActionRequired, { customAlertMessage: this._instantiationService.invokeFunction(getToolConfirmationAlert, toolInvocations), userGesture: true, modality: !soundEnabled ? 'announcement' : undefined });
-		}
-	}
-
-	private ensureToolDetails(input: IInvokeToolInput, toolResult: IToolResult, toolData: IToolData): void {
-		if (!toolResult.toolResultDetails && toolData.alwaysDisplayInputOutput) {
-			toolResult.toolResultDetails = {
-				input: this.formatToolInput(input),
-				output: this.toolResultToIO(toolResult),
-			};
-		}
-	}
-
-	private formatToolInput(input: IInvokeToolInput): string {
-		return JSON.stringify(input.parameters, undefined, 2);
-	}
-
-	private toolResultToIO(toolResult: IToolResult): IToolResultInputOutputDetails['output'] {
-		return toolResult.content.map(part => {
-			if (part.kind === 'text') {
-				return { type: 'embed', isText: true, value: part.value };
-			} else if (part.kind === 'promptTsx') {
-				return { type: 'embed', isText: true, value: stringifyPromptTsxPart(part) };
-			} else if (part.kind === 'data') {
-				return { type: 'embed', value: encodeBase64(part.value.data), mimeType: part.value.mimeType };
-			} else {
-				assertNever(part);
-			}
-		});
-	}
-
-	private shouldAutoConfirm(toolId: string, runsInWorkspace: boolean | undefined): boolean {
-		if (this._workspaceToolConfirmStore.value.getAutoConfirm(toolId) || this._profileToolConfirmStore.value.getAutoConfirm(toolId) || this._memoryToolConfirmStore.has(toolId)) {
-			return true;
-		}
-
-		const config = this._configurationService.inspect<boolean | Record<string, boolean>>('chat.tools.autoApprove');
-
-		// If we know the tool runs at a global level, only consider the global config.
-		// If we know the tool runs at a workspace level, use those specific settings when appropriate.
-		let value = config.value ?? config.defaultValue;
-		if (typeof runsInWorkspace === 'boolean') {
-			value = config.userLocalValue ?? config.applicationValue;
-			if (runsInWorkspace) {
-				value = config.workspaceValue ?? config.workspaceFolderValue ?? config.userRemoteValue ?? value;
-			}
-		}
-
-		return value === true || (typeof value === 'object' && value.hasOwnProperty(toolId) && value[toolId] === true);
-	}
-
-	private cleanupCallDisposables(requestId: RequestId, callId: string): void {
-		const byToolCallId = this._callsByRequestId.get(requestId);
-		if (byToolCallId) {
-			const trackedCall = byToolCallId.get(callId);
-			if (trackedCall) {
-				trackedCall.dispose();
-			}
-			if (byToolCallId.size === 0) {
-				this._callsByRequestId.delete(requestId);
-			}
-		}
 	}
 
 	cancelToolCallsForRequest(requestId: string): void {
-		const calls = this._callsByRequestId.get(requestId);
-		if (calls) {
-			calls.forEach(call => call.dispose());
-			this._callsByRequestId.delete(requestId);
-		}
 	}
 
 	toToolEnablementMap(toolOrToolsetNames: Set<string>): Record<string, boolean> {
@@ -592,24 +281,6 @@ export class LanguageModelToolsService extends Disposable implements ILanguageMo
 		return result;
 	}
 }
-
-type LanguageModelToolInvokedEvent = {
-	result: 'success' | 'error' | 'userCancelled';
-	chatSessionId: string | undefined;
-	toolId: string;
-	toolExtensionId: string | undefined;
-	toolSourceKind: string;
-};
-
-type LanguageModelToolInvokedClassification = {
-	result: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Whether invoking the LanguageModelTool resulted in an error.' };
-	chatSessionId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The ID of the chat session that the tool was used within, if applicable.' };
-	toolId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The ID of the tool used.' };
-	toolExtensionId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The extension that contributed the tool.' };
-	toolSourceKind: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The source (mcp/extension/internal) of the tool.' };
-	owner: 'roblourens';
-	comment: 'Provides insight into the usage of language model tools.';
-};
 
 class ToolConfirmStore extends Disposable {
 	private static readonly STORED_KEY = 'chat/autoconfirm';

--- a/src/vs/workbench/contrib/chat/common/chatProgressTypes/chatToolInvocation.ts
+++ b/src/vs/workbench/contrib/chat/common/chatProgressTypes/chatToolInvocation.ts
@@ -11,6 +11,9 @@ import { localize } from '../../../../../nls.js';
 import { IChatExtensionsContent, IChatToolInputInvocationData, IChatTodoListContent, IChatToolInvocation, IChatToolInvocationSerialized, type IChatTerminalToolInvocationData } from '../chatService.js';
 import { IPreparedToolInvocation, isToolResultOutputDetails, IToolConfirmationMessages, IToolData, IToolProgressStep, IToolResult } from '../languageModelToolsService.js';
 
+/**
+ * The ChatModel content part representing a tool invocation.
+ */
 export class ChatToolInvocation implements IChatToolInvocation {
 	public readonly kind: 'toolInvocation' = 'toolInvocation';
 
@@ -46,6 +49,9 @@ export class ChatToolInvocation implements IChatToolInvocation {
 	public readonly presentation: IPreparedToolInvocation['presentation'];
 	public readonly toolId: string;
 
+	/**
+	 * Tool-specific data that is relevant for display
+	 */
 	public readonly toolSpecificData?: IChatTerminalToolInvocationData | IChatToolInputInvocationData | IChatExtensionsContent | IChatTodoListContent;
 
 	public readonly progress = observableValue<{ message?: string | IMarkdownString; progress: number }>(this, { progress: 0 });

--- a/src/vs/workbench/contrib/chat/common/chatService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService.ts
@@ -307,6 +307,9 @@ export interface IChatToolInputInvocationData {
 	rawInput: any;
 }
 
+/**
+ * The ChatModel content part representing a tool invocation.
+ */
 export interface IChatToolInvocation {
 	presentation: IPreparedToolInvocation['presentation'];
 	toolSpecificData?: IChatTerminalToolInvocationData | ILegacyChatTerminalToolInvocationData | IChatToolInputInvocationData | IChatExtensionsContent | IChatPullRequestContent | IChatTodoListContent;

--- a/src/vs/workbench/contrib/chat/common/languageModelToolsService.ts
+++ b/src/vs/workbench/contrib/chat/common/languageModelToolsService.ts
@@ -3,26 +3,26 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { VSBuffer } from '../../../../base/common/buffer.js';
 import { CancellationToken } from '../../../../base/common/cancellation.js';
 import { Event } from '../../../../base/common/event.js';
 import { IMarkdownString } from '../../../../base/common/htmlContent.js';
+import { Iterable } from '../../../../base/common/iterator.js';
 import { IJSONSchema } from '../../../../base/common/jsonSchema.js';
 import { Disposable, IDisposable, toDisposable } from '../../../../base/common/lifecycle.js';
 import { Schemas } from '../../../../base/common/network.js';
+import { derived, IObservable, IReader, ITransaction, ObservableSet } from '../../../../base/common/observable.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
 import { URI } from '../../../../base/common/uri.js';
 import { Location } from '../../../../editor/common/languages.js';
+import { localize } from '../../../../nls.js';
 import { ContextKeyExpression } from '../../../../platform/contextkey/common/contextkey.js';
 import { ExtensionIdentifier } from '../../../../platform/extensions/common/extensions.js';
 import { createDecorator } from '../../../../platform/instantiation/common/instantiation.js';
 import { IProgress } from '../../../../platform/progress/common/progress.js';
-import { IChatExtensionsContent, IChatToolInputInvocationData, IChatTodoListContent, type IChatTerminalToolInvocationData } from './chatService.js';
-import { PromptElementJSON, stringifyPromptElementJSON } from './tools/promptTsxTypes.js';
-import { VSBuffer } from '../../../../base/common/buffer.js';
-import { derived, IObservable, IReader, ITransaction, ObservableSet } from '../../../../base/common/observable.js';
-import { Iterable } from '../../../../base/common/iterator.js';
-import { localize } from '../../../../nls.js';
+import { IChatExtensionsContent, IChatTodoListContent, IChatToolInputInvocationData, type IChatTerminalToolInvocationData } from './chatService.js';
 import { LanguageModelPartAudience } from './languageModels.js';
+import { PromptElementJSON, stringifyPromptElementJSON } from './tools/promptTsxTypes.js';
 
 export interface IToolData {
 	id: string;
@@ -106,35 +106,26 @@ export namespace ToolDataSource {
 	}
 }
 
-export interface IToolInvocationInput {
-	callId: string;
-	toolId: string;
-	parameters: Object;
-	tokenBudget?: number;
-	context: IToolInvocationContext | undefined;
+export interface IInvokeToolInput {
+	readonly callId: string;
+	readonly toolId: string;
+	readonly parameters: Object;
+	readonly tokenBudget?: number;
+	readonly context: IToolInvocationContext | undefined;
 
 	// Plumbing telemetry data through from the extension
-	chatRequestId?: string;
-	modelId?: string;
+	readonly chatRequestId?: string;
+	readonly modelId?: string;
 }
 
-// TODO refactor to have an InvocationInput prop
 export interface IToolInvocation<T = void> {
-	callId: string;
-	toolId: string;
-	parameters: Object;
-	tokenBudget?: number;
-	context: IToolInvocationContext | undefined;
-	toolSpecificData?: IChatTerminalToolInvocationData | IChatToolInputInvocationData | IChatExtensionsContent | IChatTodoListContent;
-	preparedData: T;
-
-	// Plumbing telemetry data through from the extension
-	modelId?: string;
-	chatRequestId?: string;
+	readonly input: IInvokeToolInput;
+	readonly toolSpecificData?: IChatTerminalToolInvocationData | IChatToolInputInvocationData | IChatExtensionsContent | IChatTodoListContent;
+	readonly preparedData: T;
 }
 
 export interface IToolInvocationContext {
-	sessionId: string;
+	readonly sessionId: string;
 }
 
 export function isToolInvocationContext(obj: any): obj is IToolInvocationContext {
@@ -142,9 +133,9 @@ export function isToolInvocationContext(obj: any): obj is IToolInvocationContext
 }
 
 export interface IToolInvocationPreparationContext {
-	parameters: any;
-	chatRequestId?: string;
-	chatSessionId?: string;
+	readonly parameters: any;
+	readonly chatRequestId?: string;
+	readonly chatSessionId?: string;
 }
 
 export type ToolInputOutputBase = {
@@ -315,7 +306,7 @@ export interface ILanguageModelToolsService {
 	getTools(): Iterable<Readonly<IToolData>>;
 	getTool(id: string): IToolData | undefined;
 	getToolByName(name: string, includeDisabled?: boolean): IToolData | undefined;
-	invokeTool(invocation: IToolInvocationInput, countTokens: CountTokensCallback, token: CancellationToken): Promise<IToolResult>;
+	invokeTool(invocation: IInvokeToolInput, countTokens: CountTokensCallback, token: CancellationToken): Promise<IToolResult>;
 	setToolAutoConfirmation(toolId: string, scope: 'workspace' | 'profile' | 'memory', autoConfirm?: boolean): void;
 	resetToolAutoConfirmation(): void;
 	cancelToolCallsForRequest(requestId: string): void;

--- a/src/vs/workbench/contrib/chat/common/languageModelToolsService.ts
+++ b/src/vs/workbench/contrib/chat/common/languageModelToolsService.ts
@@ -115,11 +115,11 @@ export interface IInvokeToolInput {
 
 	// Plumbing telemetry data through from the extension
 	readonly chatRequestId?: string;
-	readonly modelId?: string;
 }
 
 export interface IToolInvocation<T = void> {
 	readonly input: IInvokeToolInput;
+	readonly modelId?: string;
 	readonly toolSpecificData?: IChatTerminalToolInvocationData | IChatToolInputInvocationData | IChatExtensionsContent | IChatTodoListContent;
 	readonly preparedData: T;
 }

--- a/src/vs/workbench/contrib/chat/common/languageModelToolsService.ts
+++ b/src/vs/workbench/contrib/chat/common/languageModelToolsService.ts
@@ -236,7 +236,16 @@ export interface IPreparedToolInvocation {
 export type IPreparedToolInvocationWithData<T> = IPreparedToolInvocation & ([T] extends [void] ? {} : { preparedData: T });
 
 export interface IToolImpl<TToolData = void> {
+	/**
+	 * This method is where the real work of the tool implementation should be done.
+	 */
 	invoke(invocation: IToolInvocation<TToolData>, countTokens: CountTokensCallback, progress: ToolProgress, token: CancellationToken): Promise<IToolResult>;
+
+	/**
+	 * Produce display metadata for the tool invocation. This should generally be fast so we can move on to showing a proper progress message in the chat view.
+	 * Can optionally return `preparedData` when data needs to be shared with the `invoke` call.
+	 * This should not do any work or have any side effects.
+	 */
 	prepareToolInvocation(context: IToolInvocationPreparationContext, token: CancellationToken): Promise<IPreparedToolInvocationWithData<TToolData>>;
 }
 

--- a/src/vs/workbench/contrib/chat/common/tools/editFileTool.ts
+++ b/src/vs/workbench/contrib/chat/common/tools/editFileTool.ts
@@ -136,7 +136,7 @@ export class EditTool implements IToolImpl {
 		};
 	}
 
-	async prepareToolInvocation(context: IToolInvocationPreparationContext, token: CancellationToken): Promise<IPreparedToolInvocation | undefined> {
+	async prepareToolInvocation(context: IToolInvocationPreparationContext, token: CancellationToken): Promise<IPreparedToolInvocation> {
 		return {
 			presentation: 'hidden'
 		};

--- a/src/vs/workbench/contrib/chat/common/tools/editFileTool.ts
+++ b/src/vs/workbench/contrib/chat/common/tools/editFileTool.ts
@@ -87,7 +87,7 @@ export class EditTool implements IToolImpl {
 			codeBlocks: [{ code: parameters.code, resource: uri, markdownBeforeBlock: parameters.explanation }],
 			location: 'tool',
 			chatRequestId: invocation.input.chatRequestId,
-			chatRequestModel: invocation.input.modelId,
+			chatRequestModel: invocation.modelId,
 			chatSessionId: invocation.input.context.sessionId,
 		}, {
 			textEdit: (target, edits) => {

--- a/src/vs/workbench/contrib/chat/common/tools/editFileTool.ts
+++ b/src/vs/workbench/contrib/chat/common/tools/editFileTool.ts
@@ -39,15 +39,15 @@ export class EditTool implements IToolImpl {
 	) { }
 
 	async invoke(invocation: IToolInvocation, countTokens: CountTokensCallback, _progress: ToolProgress, token: CancellationToken): Promise<IToolResult> {
-		if (!invocation.context) {
+		if (!invocation.input.context) {
 			throw new Error('toolInvocationToken is required for this tool');
 		}
 
-		const parameters = invocation.parameters as EditToolParams;
+		const parameters = invocation.input.parameters as EditToolParams;
 		const fileUri = URI.revive(parameters.uri);
 		const uri = CellUri.parse(fileUri)?.notebook || fileUri;
 
-		const model = this.chatService.getSession(invocation.context?.sessionId) as ChatModel;
+		const model = this.chatService.getSession(invocation.input.context?.sessionId) as ChatModel;
 		const request = model.getRequests().at(-1)!;
 
 		model.acceptResponseProgress(request, {
@@ -86,9 +86,9 @@ export class EditTool implements IToolImpl {
 		const result = await this.codeMapperService.mapCode({
 			codeBlocks: [{ code: parameters.code, resource: uri, markdownBeforeBlock: parameters.explanation }],
 			location: 'tool',
-			chatRequestId: invocation.chatRequestId,
-			chatRequestModel: invocation.modelId,
-			chatSessionId: invocation.context.sessionId,
+			chatRequestId: invocation.input.chatRequestId,
+			chatRequestModel: invocation.input.modelId,
+			chatSessionId: invocation.input.context.sessionId,
 		}, {
 			textEdit: (target, edits) => {
 				model.acceptResponseProgress(request, { kind: 'textEdit', uri: target, edits });

--- a/src/vs/workbench/contrib/chat/common/tools/manageTodoListTool.ts
+++ b/src/vs/workbench/contrib/chat/common/tools/manageTodoListTool.ts
@@ -154,7 +154,7 @@ export class ManageTodoListTool extends Disposable implements IToolImpl {
 		}
 	}
 
-	async prepareToolInvocation(context: IToolInvocationPreparationContext, _token: CancellationToken): Promise<IPreparedToolInvocation | undefined> {
+	async prepareToolInvocation(context: IToolInvocationPreparationContext, _token: CancellationToken): Promise<IPreparedToolInvocation> {
 
 		if (!context.chatSessionId) {
 			throw new Error('chatSessionId undefined');

--- a/src/vs/workbench/contrib/chat/common/tools/manageTodoListTool.ts
+++ b/src/vs/workbench/contrib/chat/common/tools/manageTodoListTool.ts
@@ -4,22 +4,22 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { CancellationToken } from '../../../../../base/common/cancellation.js';
-import { Disposable } from '../../../../../base/common/lifecycle.js';
 import { Codicon } from '../../../../../base/common/codicons.js';
-import { ThemeIcon } from '../../../../../base/common/themables.js';
 import { MarkdownString } from '../../../../../base/common/htmlContent.js';
+import { Disposable } from '../../../../../base/common/lifecycle.js';
+import { ThemeIcon } from '../../../../../base/common/themables.js';
+import { ContextKeyExpr } from '../../../../../platform/contextkey/common/contextkey.js';
+import { ILogService } from '../../../../../platform/log/common/log.js';
+import { IChatTodo, IChatTodoListService, IChatTodoListStorage } from '../chatTodoListService.js';
 import {
+	IPreparedToolInvocation,
 	IToolData,
 	IToolImpl,
 	IToolInvocation,
-	IToolResult,
-	ToolDataSource,
 	IToolInvocationPreparationContext,
-	IPreparedToolInvocation
+	IToolResult,
+	ToolDataSource
 } from '../languageModelToolsService.js';
-import { ILogService } from '../../../../../platform/log/common/log.js';
-import { IChatTodo, IChatTodoListService, IChatTodoListStorage } from '../chatTodoListService.js';
-import { ContextKeyExpr } from '../../../../../platform/contextkey/common/contextkey.js';
 
 export const TodoListToolSettingId = 'chat.todoListTool.enabled';
 
@@ -96,12 +96,12 @@ export class ManageTodoListTool extends Disposable implements IToolImpl {
 	}
 
 	async invoke(invocation: IToolInvocation, _countTokens: any, _progress: any, _token: CancellationToken): Promise<IToolResult> {
-		const chatSessionId = invocation.context?.sessionId;
+		const chatSessionId = invocation.input.context?.sessionId;
 		if (chatSessionId === undefined) {
 			throw new Error('A chat session ID is required for this tool');
 		}
 
-		const args = invocation.parameters as IManageTodoListToolInputParams;
+		const args = invocation.input.parameters as IManageTodoListToolInputParams;
 		this.logService.debug(`ManageTodoListTool: Invoking with options ${JSON.stringify(args)}`);
 
 		try {

--- a/src/vs/workbench/contrib/chat/electron-browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/electron-browser/chat.contribution.ts
@@ -45,9 +45,9 @@ class NativeBuiltinToolsContribution extends Disposable implements IWorkbenchCon
 	) {
 		super();
 
-		const editTool = instantiationService.createInstance(FetchWebPageTool);
+		const fetchTool = instantiationService.createInstance(FetchWebPageTool);
 		this._register(toolsService.registerToolData(FetchWebPageToolData));
-		this._register(toolsService.registerToolImplementation(FetchWebPageToolData.id, editTool));
+		this._register(toolsService.registerToolImplementation(FetchWebPageToolData.id, fetchTool));
 	}
 }
 

--- a/src/vs/workbench/contrib/chat/electron-browser/tools/fetchPageTool.ts
+++ b/src/vs/workbench/contrib/chat/electron-browser/tools/fetchPageTool.ts
@@ -46,7 +46,7 @@ export class FetchWebPageTool implements IToolImpl {
 	) { }
 
 	async invoke(invocation: IToolInvocation, _countTokens: CountTokensCallback, _progress: ToolProgress, token: CancellationToken): Promise<IToolResult> {
-		const urls = (invocation.parameters as { urls?: string[] }).urls || [];
+		const urls = (invocation.input.parameters as { urls?: string[] }).urls || [];
 		const { webUris, fileUris, invalidUris } = this._parseUris(urls);
 		const allValidUris = [...webUris.values(), ...fileUris.values()];
 

--- a/src/vs/workbench/contrib/chat/electron-browser/tools/fetchPageTool.ts
+++ b/src/vs/workbench/contrib/chat/electron-browser/tools/fetchPageTool.ts
@@ -131,7 +131,7 @@ export class FetchWebPageTool implements IToolImpl {
 		};
 	}
 
-	async prepareToolInvocation(context: IToolInvocationPreparationContext, token: CancellationToken): Promise<IPreparedToolInvocation | undefined> {
+	async prepareToolInvocation(context: IToolInvocationPreparationContext, token: CancellationToken): Promise<IPreparedToolInvocation> {
 		const { webUris, fileUris, invalidUris } = this._parseUris(context.parameters.urls);
 
 		// Check which file URIs can actually be read

--- a/src/vs/workbench/contrib/chat/test/browser/languageModelToolsService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/languageModelToolsService.test.ts
@@ -5,18 +5,90 @@
 
 import * as assert from 'assert';
 import { Barrier } from '../../../../../base/common/async.js';
+import { VSBuffer } from '../../../../../base/common/buffer.js';
 import { CancellationToken } from '../../../../../base/common/cancellation.js';
 import { CancellationError, isCancellationError } from '../../../../../base/common/errors.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { IAccessibilityService } from '../../../../../platform/accessibility/common/accessibility.js';
+import { TestAccessibilityService } from '../../../../../platform/accessibility/test/common/testAccessibilityService.js';
+import { AccessibilitySignal, IAccessibilitySignalService } from '../../../../../platform/accessibilitySignal/browser/accessibilitySignalService.js';
 import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
 import { ContextKeyService } from '../../../../../platform/contextkey/browser/contextKeyService.js';
 import { ContextKeyEqualsExpr, IContextKeyService } from '../../../../../platform/contextkey/common/contextkey.js';
+import { ITelemetryService } from '../../../../../platform/telemetry/common/telemetry.js';
 import { workbenchInstantiationService } from '../../../../test/browser/workbenchTestServices.js';
 import { LanguageModelToolsService } from '../../browser/languageModelToolsService.js';
 import { IChatModel } from '../../common/chatModel.js';
-import { IChatService } from '../../common/chatService.js';
+import { IChatService, IChatToolInputInvocationData } from '../../common/chatService.js';
 import { IInvokeToolInput, IToolData, IToolImpl, ToolDataSource } from '../../common/languageModelToolsService.js';
 import { MockChatService } from '../common/mockChatService.js';
+
+// --- Test helpers to reduce repetition and improve readability ---
+
+class TestAccessibilitySignalService implements Partial<IAccessibilitySignalService> {
+	public signalPlayedCalls: { signal: AccessibilitySignal; options?: any }[] = [];
+
+	async playSignal(signal: AccessibilitySignal, options?: any): Promise<void> {
+		this.signalPlayedCalls.push({ signal, options });
+	}
+
+	reset() {
+		this.signalPlayedCalls = [];
+	}
+}
+
+class TestTelemetryService implements Partial<ITelemetryService> {
+	public events: Array<{ eventName: string; data: any }> = [];
+
+	publicLog2<E extends Record<string, any>, T extends Record<string, any>>(eventName: string, data?: E): void {
+		this.events.push({ eventName, data });
+	}
+
+	reset() {
+		this.events = [];
+	}
+}
+
+function registerToolForTest(service: LanguageModelToolsService, store: any, id: string, impl: IToolImpl, data?: Partial<IToolData>) {
+	const toolData: IToolData = {
+		id,
+		modelDescription: data?.modelDescription ?? 'Test Tool',
+		displayName: data?.displayName ?? 'Test Tool',
+		source: ToolDataSource.Internal,
+		...data,
+	};
+	store.add(service.registerToolData(toolData));
+	store.add(service.registerToolImplementation(id, impl));
+	return {
+		id,
+		makeDto: (parameters: any, context?: { sessionId: string }, callId: string = '1'): IInvokeToolInput => ({
+			callId,
+			toolId: id,
+			tokenBudget: 100,
+			parameters,
+			context,
+		}),
+	};
+}
+
+function stubGetSession(chatService: MockChatService, sessionId: string, options?: { requestId?: string; capture?: { invocation?: any } }): IChatModel {
+	const requestId = options?.requestId ?? 'requestId';
+	const capture = options?.capture;
+	const fakeModel = {
+		sessionId,
+		getRequests: () => [{ id: requestId, modelId: 'test-model' }],
+		acceptResponseProgress: (_req: any, progress: any) => { if (capture) { capture.invocation = progress; } },
+	} as any as IChatModel;
+	chatService.addSession(fakeModel);
+	return fakeModel;
+}
+
+async function waitForPublishedInvocation(capture: { invocation?: any }, tries = 5): Promise<any> {
+	for (let i = 0; i < tries && !capture.invocation; i++) {
+		await Promise.resolve();
+	}
+	return capture.invocation;
+}
 
 suite('LanguageModelToolsService', () => {
 	const store = ensureNoDisposablesAreLeakedInTestSuite();
@@ -24,10 +96,13 @@ suite('LanguageModelToolsService', () => {
 	let contextKeyService: IContextKeyService;
 	let service: LanguageModelToolsService;
 	let chatService: MockChatService;
+	let configurationService: TestConfigurationService;
 
 	setup(() => {
+		configurationService = new TestConfigurationService();
 		const instaService = workbenchInstantiationService({
-			contextKeyService: () => store.add(new ContextKeyService(new TestConfigurationService)),
+			contextKeyService: () => store.add(new ContextKeyService(configurationService)),
+			configurationService: () => configurationService
 		}, store);
 		contextKeyService = instaService.get(IContextKeyService);
 		chatService = new MockChatService();
@@ -163,32 +238,115 @@ suite('LanguageModelToolsService', () => {
 
 		store.add(service.registerToolImplementation('testTool', toolImpl));
 
-		const dto: IInvokeToolInput = {
-			callId: '1',
-			toolId: 'testTool',
-			tokenBudget: 100,
-			parameters: {
-				a: 1
-			},
-			context: undefined,
-		};
+		const dto: IInvokeToolInput = { callId: '1', toolId: 'testTool', tokenBudget: 100, parameters: { a: 1 }, context: undefined };
 
 		const result = await service.invokeTool(dto, async () => 0, CancellationToken.None);
 		assert.strictEqual(result.content[0].value, 'result');
 	});
 
-	test('cancel tool call', async () => {
+	test('invocation parameters are overridden by input toolSpecificData', async () => {
 		const toolData: IToolData = {
-			id: 'testTool',
+			id: 'testToolInputOverride',
+			modelDescription: 'Test Tool',
+			displayName: 'Test Tool',
+			source: ToolDataSource.Internal,
+		};
+		store.add(service.registerToolData(toolData));
+
+		const rawInput = { b: 2 };
+		const toolImpl: IToolImpl = {
+			prepareToolInvocation: async () => ({
+				toolSpecificData: { kind: 'input', rawInput } satisfies IChatToolInputInvocationData
+			}),
+			invoke: async (invocation) => {
+				// The service should replace parameters with rawInput and strip toolSpecificData
+				assert.deepStrictEqual(invocation.input.parameters, rawInput);
+				assert.strictEqual(invocation.toolSpecificData, undefined);
+				return { content: [{ kind: 'text', value: 'ok' }] };
+			},
+		};
+
+		store.add(service.registerToolImplementation(toolData.id, toolImpl));
+
+		const dto: IInvokeToolInput = { callId: '1', toolId: toolData.id, tokenBudget: 100, parameters: { a: 1 }, context: undefined };
+
+		const result = await service.invokeTool(dto, async () => 0, CancellationToken.None);
+		assert.strictEqual(result.content[0].value, 'ok');
+	});
+
+	test('chat invocation injects input toolSpecificData for confirmation when alwaysDisplayInputOutput', async () => {
+		const toolData: IToolData = {
+			id: 'testToolDisplayIO',
+			modelDescription: 'Test Tool',
+			displayName: 'Test Tool',
+			source: ToolDataSource.Internal,
+			alwaysDisplayInputOutput: true,
+		};
+
+		const tool = registerToolForTest(service, store, 'testToolDisplayIO', {
+			prepareToolInvocation: async () => ({
+				confirmationMessages: { title: 'Confirm', message: 'Proceed?' }
+			}),
+			invoke: async () => ({ content: [{ kind: 'text', value: 'done' }] }),
+		}, toolData);
+
+		const sessionId = 'sessionId-io';
+		const capture: { invocation?: any } = {};
+		stubGetSession(chatService, sessionId, { requestId: 'requestId-io', capture });
+
+		const dto = tool.makeDto({ a: 1 }, { sessionId });
+
+		const invokeP = service.invokeTool(dto, async () => 0, CancellationToken.None);
+		const published = await waitForPublishedInvocation(capture);
+		assert.ok(published, 'expected ChatToolInvocation to be published');
+		assert.strictEqual(published.toolId, tool.id);
+		// The service should have injected input toolSpecificData with the raw parameters
+		assert.strictEqual(published.toolSpecificData?.kind, 'input');
+		assert.deepStrictEqual(published.toolSpecificData?.rawInput, dto.parameters);
+
+		// Confirm to let invoke proceed
+		published.confirmed.complete(true);
+		const result = await invokeP;
+		assert.strictEqual(result.content[0].value, 'done');
+	});
+
+	test('chat invocation waits for user confirmation before invoking', async () => {
+		const toolData: IToolData = {
+			id: 'testToolConfirm',
 			modelDescription: 'Test Tool',
 			displayName: 'Test Tool',
 			source: ToolDataSource.Internal,
 		};
 
-		store.add(service.registerToolData(toolData));
+		let invoked = false;
+		const tool = registerToolForTest(service, store, toolData.id, {
+			prepareToolInvocation: async () => ({ confirmationMessages: { title: 'Confirm', message: 'Go?' } }),
+			invoke: async () => {
+				invoked = true;
+				return { content: [{ kind: 'text', value: 'ran' }] };
+			},
+		}, toolData);
 
+		const sessionId = 'sessionId-confirm';
+		const capture: { invocation?: any } = {};
+		stubGetSession(chatService, sessionId, { requestId: 'requestId-confirm', capture });
+
+		const dto = tool.makeDto({ x: 1 }, { sessionId });
+
+		const promise = service.invokeTool(dto, async () => 0, CancellationToken.None);
+		const published = await waitForPublishedInvocation(capture);
+		assert.ok(published, 'expected ChatToolInvocation to be published');
+		assert.strictEqual(invoked, false, 'invoke should not run before confirmation');
+
+		published.confirmed.complete(true);
+		const result = await promise;
+		assert.strictEqual(invoked, true, 'invoke should have run after confirmation');
+		assert.strictEqual(result.content[0].value, 'ran');
+	});
+
+	test('cancel tool call', async () => {
 		const toolBarrier = new Barrier();
-		const toolImpl: IToolImpl = {
+		const tool = registerToolForTest(service, store, 'testTool', {
 			prepareToolInvocation: async () => ({}),
 			invoke: async (invocation, countTokens, progress, cancelToken) => {
 				assert.strictEqual(invocation.input.callId, '1');
@@ -201,32 +359,13 @@ suite('LanguageModelToolsService', () => {
 					throw new Error('Tool call should be cancelled');
 				}
 			}
-		};
-
-		store.add(service.registerToolImplementation('testTool', toolImpl));
+		});
 
 		const sessionId = 'sessionId';
 		const requestId = 'requestId';
-		const dto: IInvokeToolInput = {
-			callId: '1',
-			toolId: 'testTool',
-			tokenBudget: 100,
-			parameters: {
-				a: 1
-			},
-			context: {
-				sessionId
-			},
-		};
-		chatService.addSession({
-			sessionId: sessionId,
-			getRequests: () => {
-				return [{
-					id: requestId
-				}];
-			},
-			acceptResponseProgress: () => { }
-		} as any as IChatModel);
+		stubGetSession(chatService, sessionId, { requestId });
+
+		const dto = tool.makeDto({ a: 1 }, { sessionId });
 
 		const toolPromise = service.invokeTool(dto, async () => 0, CancellationToken.None);
 		service.cancelToolCallsForRequest(requestId);
@@ -366,5 +505,450 @@ suite('LanguageModelToolsService', () => {
 		assert.strictEqual(result['tool1'], true, 'existing tool should be enabled');
 		// Non-existent tools should not appear in the result map
 		assert.strictEqual(result['nonExistentTool'], undefined, 'non-existent tool should not be in result');
+	});
+
+	test('accessibility signal for tool confirmation', async () => {
+		// Create a test configuration service with proper settings
+		const testConfigService = new TestConfigurationService();
+		testConfigService.setUserConfiguration('chat.tools.autoApprove', false);
+		testConfigService.setUserConfiguration('accessibility.signals.chatUserActionRequired', { sound: 'auto', announcement: 'auto' });
+
+		// Create a test accessibility service that simulates screen reader being enabled
+		const testAccessibilityService = new class extends TestAccessibilityService {
+			override isScreenReaderOptimized(): boolean { return true; }
+		}();
+
+		// Create a test accessibility signal service that tracks calls
+		const testAccessibilitySignalService = new TestAccessibilitySignalService();
+
+		// Create a new service instance with the test services
+		const instaService = workbenchInstantiationService({
+			contextKeyService: () => store.add(new ContextKeyService(testConfigService)),
+			configurationService: () => testConfigService
+		}, store);
+		instaService.stub(IChatService, chatService);
+		instaService.stub(IAccessibilityService, testAccessibilityService);
+		instaService.stub(IAccessibilitySignalService, testAccessibilitySignalService as unknown as IAccessibilitySignalService);
+		const testService = store.add(instaService.createInstance(LanguageModelToolsService));
+
+		const toolData: IToolData = {
+			id: 'testAccessibilityTool',
+			modelDescription: 'Test Accessibility Tool',
+			displayName: 'Test Accessibility Tool',
+			source: ToolDataSource.Internal,
+		};
+
+		const tool = registerToolForTest(testService, store, toolData.id, {
+			prepareToolInvocation: async () => ({ confirmationMessages: { title: 'Accessibility Test', message: 'Testing accessibility signal' } }),
+			invoke: async () => ({ content: [{ kind: 'text', value: 'executed' }] }),
+		}, toolData);
+
+		const sessionId = 'sessionId-accessibility';
+		const capture: { invocation?: any } = {};
+		stubGetSession(chatService, sessionId, { requestId: 'requestId-accessibility', capture });
+
+		const dto = tool.makeDto({ param: 'value' }, { sessionId });
+
+		const promise = testService.invokeTool(dto, async () => 0, CancellationToken.None);
+		const published = await waitForPublishedInvocation(capture);
+
+		assert.ok(published, 'expected ChatToolInvocation to be published');
+		assert.ok(published.confirmationMessages, 'should have confirmation messages');
+
+		// The accessibility signal should have been played
+		assert.strictEqual(testAccessibilitySignalService.signalPlayedCalls.length, 1, 'accessibility signal should have been played once');
+		const signalCall = testAccessibilitySignalService.signalPlayedCalls[0];
+		assert.strictEqual(signalCall.signal, AccessibilitySignal.chatUserActionRequired, 'correct signal should be played');
+		assert.ok(signalCall.options?.customAlertMessage.includes('Accessibility Test'), 'alert message should include tool title');
+		assert.ok(signalCall.options?.customAlertMessage.includes('Chat confirmation required'), 'alert message should include confirmation text');
+
+		// Complete the invocation
+		published.confirmed.complete(true);
+		const result = await promise;
+		assert.strictEqual(result.content[0].value, 'executed');
+	});
+
+	test('accessibility signal respects autoApprove configuration', async () => {
+		// Create a test configuration service with auto-approve enabled
+		const testConfigService = new TestConfigurationService();
+		testConfigService.setUserConfiguration('chat.tools.autoApprove', true);
+		testConfigService.setUserConfiguration('accessibility.signals.chatUserActionRequired', { sound: 'auto', announcement: 'auto' });
+
+		// Create a test accessibility service that simulates screen reader being enabled
+		const testAccessibilityService = new class extends TestAccessibilityService {
+			override isScreenReaderOptimized(): boolean { return true; }
+		}();
+
+		// Create a test accessibility signal service that tracks calls
+		const testAccessibilitySignalService = new TestAccessibilitySignalService();
+
+		// Create a new service instance with the test services
+		const instaService = workbenchInstantiationService({
+			contextKeyService: () => store.add(new ContextKeyService(testConfigService)),
+			configurationService: () => testConfigService
+		}, store);
+		instaService.stub(IChatService, chatService);
+		instaService.stub(IAccessibilityService, testAccessibilityService);
+		instaService.stub(IAccessibilitySignalService, testAccessibilitySignalService as unknown as IAccessibilitySignalService);
+		const testService = store.add(instaService.createInstance(LanguageModelToolsService));
+
+		const toolData: IToolData = {
+			id: 'testAutoApproveTool',
+			modelDescription: 'Test Auto Approve Tool',
+			displayName: 'Test Auto Approve Tool',
+			source: ToolDataSource.Internal,
+		};
+
+		const tool = registerToolForTest(testService, store, toolData.id, {
+			prepareToolInvocation: async () => ({ confirmationMessages: { title: 'Auto Approve Test', message: 'Testing auto approve' } }),
+			invoke: async () => ({ content: [{ kind: 'text', value: 'auto approved' }] }),
+		}, toolData);
+
+		const sessionId = 'sessionId-auto-approve';
+		const capture: { invocation?: any } = {};
+		stubGetSession(chatService, sessionId, { requestId: 'requestId-auto-approve', capture });
+
+		const dto = tool.makeDto({ config: 'test' }, { sessionId });
+
+		// When auto-approve is enabled, tool should complete without user intervention
+		const result = await testService.invokeTool(dto, async () => 0, CancellationToken.None);
+
+		// Verify the tool completed and no accessibility signal was played
+		assert.strictEqual(result.content[0].value, 'auto approved');
+		assert.strictEqual(testAccessibilitySignalService.signalPlayedCalls.length, 0, 'accessibility signal should not be played when auto-approve is enabled');
+	});
+
+	test('shouldAutoConfirm with basic configuration', async () => {
+		// Test basic shouldAutoConfirm behavior with simple configuration
+		const testConfigService = new TestConfigurationService();
+		testConfigService.setUserConfiguration('chat.tools.autoApprove', true); // Global enabled
+
+		const instaService = workbenchInstantiationService({
+			contextKeyService: () => store.add(new ContextKeyService(testConfigService)),
+			configurationService: () => testConfigService
+		}, store);
+		instaService.stub(IChatService, chatService);
+		const testService = store.add(instaService.createInstance(LanguageModelToolsService));
+
+		// Register a tool that should be auto-approved
+		const autoTool = registerToolForTest(testService, store, 'autoTool', {
+			prepareToolInvocation: async () => ({ confirmationMessages: { title: 'Test', message: 'Should auto-approve' } }),
+			invoke: async () => ({ content: [{ kind: 'text', value: 'auto approved' }] })
+		});
+
+		const sessionId = 'test-basic-config';
+		stubGetSession(chatService, sessionId, { requestId: 'req1' });
+
+		// Tool should be auto-approved (global config = true)
+		const result = await testService.invokeTool(
+			autoTool.makeDto({ test: 1 }, { sessionId }),
+			async () => 0,
+			CancellationToken.None
+		);
+		assert.strictEqual(result.content[0].value, 'auto approved');
+	});
+
+	test('shouldAutoConfirm with per-tool configuration object', async () => {
+		// Test per-tool configuration: { toolId: true/false }
+		const testConfigService = new TestConfigurationService();
+		testConfigService.setUserConfiguration('chat.tools.autoApprove', {
+			'approvedTool': true,
+			'deniedTool': false
+		});
+
+		const instaService = workbenchInstantiationService({
+			contextKeyService: () => store.add(new ContextKeyService(testConfigService)),
+			configurationService: () => testConfigService
+		}, store);
+		instaService.stub(IChatService, chatService);
+		const testService = store.add(instaService.createInstance(LanguageModelToolsService));
+
+		// Tool explicitly approved
+		const approvedTool = registerToolForTest(testService, store, 'approvedTool', {
+			prepareToolInvocation: async () => ({ confirmationMessages: { title: 'Test', message: 'Should auto-approve' } }),
+			invoke: async () => ({ content: [{ kind: 'text', value: 'approved' }] })
+		});
+
+		const sessionId = 'test-per-tool';
+		stubGetSession(chatService, sessionId, { requestId: 'req1' });
+
+		// Approved tool should auto-approve
+		const approvedResult = await testService.invokeTool(
+			approvedTool.makeDto({ test: 1 }, { sessionId }),
+			async () => 0,
+			CancellationToken.None
+		);
+		assert.strictEqual(approvedResult.content[0].value, 'approved');
+
+		// Test that non-specified tools require confirmation (default behavior)
+		const unspecifiedTool = registerToolForTest(testService, store, 'unspecifiedTool', {
+			prepareToolInvocation: async () => ({ confirmationMessages: { title: 'Test', message: 'Should require confirmation' } }),
+			invoke: async () => ({ content: [{ kind: 'text', value: 'unspecified' }] })
+		});
+
+		const capture: { invocation?: any } = {};
+		stubGetSession(chatService, sessionId + '2', { requestId: 'req2', capture });
+		const unspecifiedPromise = testService.invokeTool(
+			unspecifiedTool.makeDto({ test: 2 }, { sessionId: sessionId + '2' }),
+			async () => 0,
+			CancellationToken.None
+		);
+		const published = await waitForPublishedInvocation(capture);
+		assert.ok(published?.confirmationMessages, 'unspecified tool should require confirmation');
+
+		published.confirmed.complete(true);
+		const unspecifiedResult = await unspecifiedPromise;
+		assert.strictEqual(unspecifiedResult.content[0].value, 'unspecified');
+	});
+
+	test('tool content formatting with alwaysDisplayInputOutput', async () => {
+		// Test ensureToolDetails, formatToolInput, and toolResultToIO
+		const toolData: IToolData = {
+			id: 'formatTool',
+			modelDescription: 'Format Test Tool',
+			displayName: 'Format Test Tool',
+			source: ToolDataSource.Internal,
+			alwaysDisplayInputOutput: true
+		};
+
+		const tool = registerToolForTest(service, store, toolData.id, {
+			prepareToolInvocation: async () => ({}),
+			invoke: async (invocation) => ({
+				content: [
+					{ kind: 'text', value: 'Text result' },
+					{ kind: 'data', value: { data: VSBuffer.fromByteArray([1, 2, 3]), mimeType: 'application/octet-stream' } }
+				]
+			})
+		}, toolData);
+
+		const input = { a: 1, b: 'test', c: [1, 2, 3] };
+		const result = await service.invokeTool(
+			tool.makeDto(input),
+			async () => 0,
+			CancellationToken.None
+		);
+
+		// Should have tool result details because alwaysDisplayInputOutput = true
+		assert.ok(result.toolResultDetails, 'should have toolResultDetails');
+		const details = result.toolResultDetails as any; // Type assertion needed for test
+
+		// Test formatToolInput - should be formatted JSON
+		const expectedInputJson = JSON.stringify(input, undefined, 2);
+		assert.strictEqual(details.input, expectedInputJson, 'input should be formatted JSON');
+
+		// Test toolResultToIO - should convert different content types
+		assert.strictEqual(details.output.length, 2, 'should have 2 output items');
+
+		// Text content
+		const textOutput = details.output[0];
+		assert.strictEqual(textOutput.type, 'embed');
+		assert.strictEqual(textOutput.isText, true);
+		assert.strictEqual(textOutput.value, 'Text result');
+
+		// Data content (base64 encoded)
+		const dataOutput = details.output[1];
+		assert.strictEqual(dataOutput.type, 'embed');
+		assert.strictEqual(dataOutput.mimeType, 'application/octet-stream');
+		assert.strictEqual(dataOutput.value, 'AQID'); // base64 of [1,2,3]
+	});
+
+	test('tool error handling and telemetry', async () => {
+		const testTelemetryService = new TestTelemetryService();
+
+		const instaService = workbenchInstantiationService({
+			contextKeyService: () => store.add(new ContextKeyService(configurationService)),
+			configurationService: () => configurationService
+		}, store);
+		instaService.stub(IChatService, chatService);
+		instaService.stub(ITelemetryService, testTelemetryService as any);
+		const testService = store.add(instaService.createInstance(LanguageModelToolsService));
+
+		// Test successful invocation telemetry
+		const successTool = registerToolForTest(testService, store, 'successTool', {
+			prepareToolInvocation: async () => ({}),
+			invoke: async () => ({ content: [{ kind: 'text', value: 'success' }] })
+		});
+
+		const sessionId = 'telemetry-test';
+		stubGetSession(chatService, sessionId, { requestId: 'req1' });
+
+		await testService.invokeTool(
+			successTool.makeDto({ test: 1 }, { sessionId }),
+			async () => 0,
+			CancellationToken.None
+		);
+
+		// Check success telemetry
+		const successEvents = testTelemetryService.events.filter(e => e.eventName === 'languageModelToolInvoked');
+		assert.strictEqual(successEvents.length, 1, 'should have success telemetry event');
+		assert.strictEqual(successEvents[0].data.result, 'success');
+		assert.strictEqual(successEvents[0].data.toolId, 'successTool');
+		assert.strictEqual(successEvents[0].data.chatSessionId, sessionId);
+
+		testTelemetryService.reset();
+
+		// Test error telemetry
+		const errorTool = registerToolForTest(testService, store, 'errorTool', {
+			prepareToolInvocation: async () => ({}),
+			invoke: async () => { throw new Error('Tool error'); }
+		});
+
+		stubGetSession(chatService, sessionId + '2', { requestId: 'req2' });
+
+		try {
+			await testService.invokeTool(
+				errorTool.makeDto({ test: 2 }, { sessionId: sessionId + '2' }),
+				async () => 0,
+				CancellationToken.None
+			);
+			assert.fail('Should have thrown');
+		} catch (err) {
+			// Expected
+		}
+
+		// Check error telemetry
+		const errorEvents = testTelemetryService.events.filter(e => e.eventName === 'languageModelToolInvoked');
+		assert.strictEqual(errorEvents.length, 1, 'should have error telemetry event');
+		assert.strictEqual(errorEvents[0].data.result, 'error');
+		assert.strictEqual(errorEvents[0].data.toolId, 'errorTool');
+	});
+
+	test('call tracking and cleanup', async () => {
+		// Test that cancelToolCallsForRequest method exists and can be called
+		// (The detailed cancellation behavior is already tested in "cancel tool call" test)
+		const sessionId = 'tracking-session';
+		const requestId = 'tracking-request';
+		stubGetSession(chatService, sessionId, { requestId });
+
+		// Just verify the method exists and doesn't throw
+		assert.doesNotThrow(() => {
+			service.cancelToolCallsForRequest(requestId);
+		}, 'cancelToolCallsForRequest should not throw');
+
+		// Verify calling with non-existent request ID doesn't throw
+		assert.doesNotThrow(() => {
+			service.cancelToolCallsForRequest('non-existent-request');
+		}, 'cancelToolCallsForRequest with non-existent ID should not throw');
+	});
+
+	test('accessibility signal with different settings combinations', async () => {
+		const testAccessibilitySignalService = new TestAccessibilitySignalService();
+
+		// Test case 1: Sound enabled, announcement disabled, screen reader off
+		const testConfigService1 = new TestConfigurationService();
+		testConfigService1.setUserConfiguration('chat.tools.autoApprove', false);
+		testConfigService1.setUserConfiguration('accessibility.signals.chatUserActionRequired', { sound: 'on', announcement: 'off' });
+
+		const testAccessibilityService1 = new class extends TestAccessibilityService {
+			override isScreenReaderOptimized(): boolean { return false; }
+		}();
+
+		const instaService1 = workbenchInstantiationService({
+			contextKeyService: () => store.add(new ContextKeyService(testConfigService1)),
+			configurationService: () => testConfigService1
+		}, store);
+		instaService1.stub(IChatService, chatService);
+		instaService1.stub(IAccessibilityService, testAccessibilityService1);
+		instaService1.stub(IAccessibilitySignalService, testAccessibilitySignalService as unknown as IAccessibilitySignalService);
+		const testService1 = store.add(instaService1.createInstance(LanguageModelToolsService));
+
+		const tool1 = registerToolForTest(testService1, store, 'soundOnlyTool', {
+			prepareToolInvocation: async () => ({ confirmationMessages: { title: 'Sound Test', message: 'Testing sound only' } }),
+			invoke: async () => ({ content: [{ kind: 'text', value: 'executed' }] })
+		});
+
+		const sessionId1 = 'sound-test';
+		const capture1: { invocation?: any } = {};
+		stubGetSession(chatService, sessionId1, { requestId: 'req1', capture: capture1 });
+
+		const promise1 = testService1.invokeTool(tool1.makeDto({ test: 1 }, { sessionId: sessionId1 }), async () => 0, CancellationToken.None);
+		const published1 = await waitForPublishedInvocation(capture1);
+
+		// Signal should be played (sound=on, no screen reader requirement)
+		assert.strictEqual(testAccessibilitySignalService.signalPlayedCalls.length, 1, 'sound should be played when sound=on');
+		const call1 = testAccessibilitySignalService.signalPlayedCalls[0];
+		assert.strictEqual(call1.options?.modality, undefined, 'should use default modality for sound');
+
+		published1.confirmed.complete(true);
+		await promise1;
+
+		testAccessibilitySignalService.reset();
+
+		// Test case 2: Sound auto, announcement auto, screen reader on
+		const testConfigService2 = new TestConfigurationService();
+		testConfigService2.setUserConfiguration('chat.tools.autoApprove', false);
+		testConfigService2.setUserConfiguration('accessibility.signals.chatUserActionRequired', { sound: 'auto', announcement: 'auto' });
+
+		const testAccessibilityService2 = new class extends TestAccessibilityService {
+			override isScreenReaderOptimized(): boolean { return true; }
+		}();
+
+		const instaService2 = workbenchInstantiationService({
+			contextKeyService: () => store.add(new ContextKeyService(testConfigService2)),
+			configurationService: () => testConfigService2
+		}, store);
+		instaService2.stub(IChatService, chatService);
+		instaService2.stub(IAccessibilityService, testAccessibilityService2);
+		instaService2.stub(IAccessibilitySignalService, testAccessibilitySignalService as unknown as IAccessibilitySignalService);
+		const testService2 = store.add(instaService2.createInstance(LanguageModelToolsService));
+
+		const tool2 = registerToolForTest(testService2, store, 'autoScreenReaderTool', {
+			prepareToolInvocation: async () => ({ confirmationMessages: { title: 'Auto Test', message: 'Testing auto with screen reader' } }),
+			invoke: async () => ({ content: [{ kind: 'text', value: 'executed' }] })
+		});
+
+		const sessionId2 = 'auto-sr-test';
+		const capture2: { invocation?: any } = {};
+		stubGetSession(chatService, sessionId2, { requestId: 'req2', capture: capture2 });
+
+		const promise2 = testService2.invokeTool(tool2.makeDto({ test: 2 }, { sessionId: sessionId2 }), async () => 0, CancellationToken.None);
+		const published2 = await waitForPublishedInvocation(capture2);
+
+		// Signal should be played (both sound and announcement enabled for screen reader)
+		assert.strictEqual(testAccessibilitySignalService.signalPlayedCalls.length, 1, 'signal should be played with screen reader optimization');
+		const call2 = testAccessibilitySignalService.signalPlayedCalls[0];
+		assert.ok(call2.options?.customAlertMessage, 'should have custom alert message');
+		assert.strictEqual(call2.options?.userGesture, true, 'should mark as user gesture');
+
+		published2.confirmed.complete(true);
+		await promise2;
+
+		testAccessibilitySignalService.reset();
+
+		// Test case 3: Sound off, announcement off - no signal
+		const testConfigService3 = new TestConfigurationService();
+		testConfigService3.setUserConfiguration('chat.tools.autoApprove', false);
+		testConfigService3.setUserConfiguration('accessibility.signals.chatUserActionRequired', { sound: 'off', announcement: 'off' });
+
+		const testAccessibilityService3 = new class extends TestAccessibilityService {
+			override isScreenReaderOptimized(): boolean { return true; }
+		}();
+
+		const instaService3 = workbenchInstantiationService({
+			contextKeyService: () => store.add(new ContextKeyService(testConfigService3)),
+			configurationService: () => testConfigService3
+		}, store);
+		instaService3.stub(IChatService, chatService);
+		instaService3.stub(IAccessibilityService, testAccessibilityService3);
+		instaService3.stub(IAccessibilitySignalService, testAccessibilitySignalService as unknown as IAccessibilitySignalService);
+		const testService3 = store.add(instaService3.createInstance(LanguageModelToolsService));
+
+		const tool3 = registerToolForTest(testService3, store, 'offTool', {
+			prepareToolInvocation: async () => ({ confirmationMessages: { title: 'Off Test', message: 'Testing off settings' } }),
+			invoke: async () => ({ content: [{ kind: 'text', value: 'executed' }] })
+		});
+
+		const sessionId3 = 'off-test';
+		const capture3: { invocation?: any } = {};
+		stubGetSession(chatService, sessionId3, { requestId: 'req3', capture: capture3 });
+
+		const promise3 = testService3.invokeTool(tool3.makeDto({ test: 3 }, { sessionId: sessionId3 }), async () => 0, CancellationToken.None);
+		const published3 = await waitForPublishedInvocation(capture3);
+
+		// No signal should be played
+		assert.strictEqual(testAccessibilitySignalService.signalPlayedCalls.length, 0, 'no signal should be played when both sound and announcement are off');
+
+		published3.confirmed.complete(true);
+		await promise3;
 	});
 });

--- a/src/vs/workbench/contrib/chat/test/browser/languageModelToolsService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/languageModelToolsService.test.ts
@@ -4,7 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as assert from 'assert';
+import { Barrier } from '../../../../../base/common/async.js';
 import { CancellationToken } from '../../../../../base/common/cancellation.js';
+import { CancellationError, isCancellationError } from '../../../../../base/common/errors.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
 import { ContextKeyService } from '../../../../../platform/contextkey/browser/contextKeyService.js';
@@ -13,10 +15,8 @@ import { workbenchInstantiationService } from '../../../../test/browser/workbenc
 import { LanguageModelToolsService } from '../../browser/languageModelToolsService.js';
 import { IChatModel } from '../../common/chatModel.js';
 import { IChatService } from '../../common/chatService.js';
-import { IToolData, IToolImpl, IToolInvocation, ToolDataSource } from '../../common/languageModelToolsService.js';
+import { IToolData, IToolImpl, IToolInvocationInput, ToolDataSource } from '../../common/languageModelToolsService.js';
 import { MockChatService } from '../common/mockChatService.js';
-import { CancellationError, isCancellationError } from '../../../../../base/common/errors.js';
-import { Barrier } from '../../../../../base/common/async.js';
 
 suite('LanguageModelToolsService', () => {
 	const store = ensureNoDisposablesAreLeakedInTestSuite();
@@ -60,6 +60,7 @@ suite('LanguageModelToolsService', () => {
 		store.add(service.registerToolData(toolData));
 
 		const toolImpl: IToolImpl = {
+			prepareToolInvocation: async () => ({}),
 			invoke: async () => ({ content: [{ kind: 'text', value: 'result' }] }),
 		};
 
@@ -151,6 +152,7 @@ suite('LanguageModelToolsService', () => {
 		store.add(service.registerToolData(toolData));
 
 		const toolImpl: IToolImpl = {
+			prepareToolInvocation: async () => ({}),
 			invoke: async (invocation) => {
 				assert.strictEqual(invocation.callId, '1');
 				assert.strictEqual(invocation.toolId, 'testTool');
@@ -161,7 +163,7 @@ suite('LanguageModelToolsService', () => {
 
 		store.add(service.registerToolImplementation('testTool', toolImpl));
 
-		const dto: IToolInvocation = {
+		const dto: IToolInvocationInput = {
 			callId: '1',
 			toolId: 'testTool',
 			tokenBudget: 100,
@@ -187,6 +189,7 @@ suite('LanguageModelToolsService', () => {
 
 		const toolBarrier = new Barrier();
 		const toolImpl: IToolImpl = {
+			prepareToolInvocation: async () => ({}),
 			invoke: async (invocation, countTokens, progress, cancelToken) => {
 				assert.strictEqual(invocation.callId, '1');
 				assert.strictEqual(invocation.toolId, 'testTool');
@@ -204,7 +207,7 @@ suite('LanguageModelToolsService', () => {
 
 		const sessionId = 'sessionId';
 		const requestId = 'requestId';
-		const dto: IToolInvocation = {
+		const dto: IToolInvocationInput = {
 			callId: '1',
 			toolId: 'testTool',
 			tokenBudget: 100,

--- a/src/vs/workbench/contrib/chat/test/browser/languageModelToolsService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/languageModelToolsService.test.ts
@@ -15,7 +15,7 @@ import { workbenchInstantiationService } from '../../../../test/browser/workbenc
 import { LanguageModelToolsService } from '../../browser/languageModelToolsService.js';
 import { IChatModel } from '../../common/chatModel.js';
 import { IChatService } from '../../common/chatService.js';
-import { IToolData, IToolImpl, IToolInvocationInput, ToolDataSource } from '../../common/languageModelToolsService.js';
+import { IInvokeToolInput, IToolData, IToolImpl, ToolDataSource } from '../../common/languageModelToolsService.js';
 import { MockChatService } from '../common/mockChatService.js';
 
 suite('LanguageModelToolsService', () => {
@@ -154,16 +154,16 @@ suite('LanguageModelToolsService', () => {
 		const toolImpl: IToolImpl = {
 			prepareToolInvocation: async () => ({}),
 			invoke: async (invocation) => {
-				assert.strictEqual(invocation.callId, '1');
-				assert.strictEqual(invocation.toolId, 'testTool');
-				assert.deepStrictEqual(invocation.parameters, { a: 1 });
+				assert.strictEqual(invocation.input.callId, '1');
+				assert.strictEqual(invocation.input.toolId, 'testTool');
+				assert.deepStrictEqual(invocation.input.parameters, { a: 1 });
 				return { content: [{ kind: 'text', value: 'result' }] };
 			}
 		};
 
 		store.add(service.registerToolImplementation('testTool', toolImpl));
 
-		const dto: IToolInvocationInput = {
+		const dto: IInvokeToolInput = {
 			callId: '1',
 			toolId: 'testTool',
 			tokenBudget: 100,
@@ -191,9 +191,9 @@ suite('LanguageModelToolsService', () => {
 		const toolImpl: IToolImpl = {
 			prepareToolInvocation: async () => ({}),
 			invoke: async (invocation, countTokens, progress, cancelToken) => {
-				assert.strictEqual(invocation.callId, '1');
-				assert.strictEqual(invocation.toolId, 'testTool');
-				assert.deepStrictEqual(invocation.parameters, { a: 1 });
+				assert.strictEqual(invocation.input.callId, '1');
+				assert.strictEqual(invocation.input.toolId, 'testTool');
+				assert.deepStrictEqual(invocation.input.parameters, { a: 1 });
 				await toolBarrier.wait();
 				if (cancelToken.isCancellationRequested) {
 					throw new CancellationError();
@@ -207,7 +207,7 @@ suite('LanguageModelToolsService', () => {
 
 		const sessionId = 'sessionId';
 		const requestId = 'requestId';
-		const dto: IToolInvocationInput = {
+		const dto: IInvokeToolInput = {
 			callId: '1',
 			toolId: 'testTool',
 			tokenBudget: 100,

--- a/src/vs/workbench/contrib/chat/test/common/mockLanguageModelToolsService.ts
+++ b/src/vs/workbench/contrib/chat/test/common/mockLanguageModelToolsService.ts
@@ -36,7 +36,7 @@ export class MockLanguageModelToolsService implements ILanguageModelToolsService
 
 	}
 
-	registerToolImplementation(name: string, tool: IToolImpl): IDisposable {
+	registerToolImplementation<T>(name: string, tool: IToolImpl<T>): IDisposable {
 		return Disposable.None;
 	}
 

--- a/src/vs/workbench/contrib/chat/test/common/mockLanguageModelToolsService.ts
+++ b/src/vs/workbench/contrib/chat/test/common/mockLanguageModelToolsService.ts
@@ -8,7 +8,7 @@ import { Event } from '../../../../../base/common/event.js';
 import { Disposable, IDisposable } from '../../../../../base/common/lifecycle.js';
 import { constObservable, IObservable } from '../../../../../base/common/observable.js';
 import { IProgressStep } from '../../../../../platform/progress/common/progress.js';
-import { CountTokensCallback, ILanguageModelToolsService, IToolData, IToolImpl, IToolInvocation, IToolResult, ToolSet } from '../../common/languageModelToolsService.js';
+import { CountTokensCallback, ILanguageModelToolsService, IInvokeToolInput, IToolData, IToolImpl, IToolResult, ToolSet } from '../../common/languageModelToolsService.js';
 
 export class MockLanguageModelToolsService implements ILanguageModelToolsService {
 	_serviceBrand: undefined;
@@ -56,7 +56,7 @@ export class MockLanguageModelToolsService implements ILanguageModelToolsService
 
 	}
 
-	async invokeTool(dto: IToolInvocation, countTokens: CountTokensCallback, token: CancellationToken): Promise<IToolResult> {
+	async invokeTool(dto: IInvokeToolInput, countTokens: CountTokensCallback, token: CancellationToken): Promise<IToolResult> {
 		return {
 			content: [{ kind: 'text', value: 'result' }]
 		};

--- a/src/vs/workbench/contrib/chat/test/electron-browser/fetchPageTool.test.ts
+++ b/src/vs/workbench/contrib/chat/test/electron-browser/fetchPageTool.test.ts
@@ -66,11 +66,10 @@ class ExtendedTestFileService extends TestFileService {
 	}
 }
 
-function invokeTool(tool: FetchWebPageTool, input: Omit<IToolInvocation, 'preparedData' | 'context'>): Promise<IToolResult> {
+function invokeTool(tool: FetchWebPageTool, input: { callId: string; toolId: string; parameters: any }): Promise<IToolResult> {
 	const toolInvocation: IToolInvocation = {
-		...input,
+		input: { ...input, context: undefined },
 		preparedData: undefined,
-		context: undefined
 	};
 	return tool.invoke(toolInvocation, () => Promise.resolve(0), { report: () => { } }, CancellationToken.None);
 }

--- a/src/vs/workbench/contrib/extensions/common/installExtensionsTool.ts
+++ b/src/vs/workbench/contrib/extensions/common/installExtensionsTool.ts
@@ -59,7 +59,7 @@ export class InstallExtensionsTool implements IToolImpl {
 	}
 
 	async invoke(invocation: IToolInvocation, _countTokens: CountTokensCallback, _progress: ToolProgress, token: CancellationToken): Promise<IToolResult> {
-		const input = invocation.parameters as InputParams;
+		const input = invocation.input.parameters as InputParams;
 		const installed = this.extensionsWorkbenchService.local.filter(e => input.ids.some(id => areSameExtensions({ id }, e.identifier)));
 		return {
 			content: [{

--- a/src/vs/workbench/contrib/extensions/common/installExtensionsTool.ts
+++ b/src/vs/workbench/contrib/extensions/common/installExtensionsTool.ts
@@ -44,7 +44,7 @@ export class InstallExtensionsTool implements IToolImpl {
 		@IExtensionsWorkbenchService private readonly extensionsWorkbenchService: IExtensionsWorkbenchService,
 	) { }
 
-	async prepareToolInvocation(context: IToolInvocationPreparationContext, token: CancellationToken): Promise<IPreparedToolInvocation | undefined> {
+	async prepareToolInvocation(context: IToolInvocationPreparationContext, token: CancellationToken): Promise<IPreparedToolInvocation> {
 		const parameters = context.parameters as InputParams;
 		return {
 			confirmationMessages: {

--- a/src/vs/workbench/contrib/extensions/common/searchExtensionsTool.ts
+++ b/src/vs/workbench/contrib/extensions/common/searchExtensionsTool.ts
@@ -73,7 +73,7 @@ export class SearchExtensionsTool implements IToolImpl {
 	) { }
 
 	async invoke(invocation: IToolInvocation, _countTokens: CountTokensCallback, _progress: ToolProgress, token: CancellationToken): Promise<IToolResult> {
-		const params = invocation.parameters as InputParams;
+		const params = invocation.input.parameters as InputParams;
 		if (!params.keywords?.length && !params.category && !params.ids?.length) {
 			return {
 				content: [{

--- a/src/vs/workbench/contrib/extensions/common/searchExtensionsTool.ts
+++ b/src/vs/workbench/contrib/extensions/common/searchExtensionsTool.ts
@@ -9,7 +9,7 @@ import { ThemeIcon } from '../../../../base/common/themables.js';
 import { localize } from '../../../../nls.js';
 import { SortBy } from '../../../../platform/extensionManagement/common/extensionManagement.js';
 import { EXTENSION_CATEGORIES } from '../../../../platform/extensions/common/extensions.js';
-import { CountTokensCallback, IToolData, IToolImpl, IToolInvocation, IToolResult, ToolDataSource, ToolProgress } from '../../chat/common/languageModelToolsService.js';
+import { CountTokensCallback, IPreparedToolInvocation, IToolData, IToolImpl, IToolInvocation, IToolInvocationPreparationContext, IToolResult, ToolDataSource, ToolProgress } from '../../chat/common/languageModelToolsService.js';
 import { ExtensionState, IExtension, IExtensionsWorkbenchService } from '../common/extensions.js';
 
 export const SearchExtensionsToolId = 'vscode_searchExtensions_internal';
@@ -146,5 +146,10 @@ export class SearchExtensionsTool implements IToolImpl {
 				output: [{ type: 'embed', isText: true, value: JSON.stringify(result.map(extension => extension.id)) }]
 			}
 		};
+	}
+
+	async prepareToolInvocation(context: IToolInvocationPreparationContext, token: CancellationToken): Promise<IPreparedToolInvocation> {
+		// TODO
+		return {};
 	}
 }

--- a/src/vs/workbench/contrib/mcp/common/mcpLanguageModelToolContribution.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpLanguageModelToolContribution.ts
@@ -235,9 +235,9 @@ class McpToolImplementation implements IToolImpl {
 			content: []
 		};
 
-		const callResult = await this._tool.callWithProgress(invocation.parameters as Record<string, any>, progress, { chatRequestId: invocation.chatRequestId, chatSessionId: invocation.context?.sessionId }, token);
+		const callResult = await this._tool.callWithProgress(invocation.input.parameters as Record<string, any>, progress, { chatRequestId: invocation.input.chatRequestId, chatSessionId: invocation.input.context?.sessionId }, token);
 		const details: IToolResultInputOutputDetails = {
-			input: JSON.stringify(invocation.parameters, undefined, 2),
+			input: JSON.stringify(invocation.input.parameters, undefined, 2),
 			output: [],
 			isError: callResult.isError === true,
 		};
@@ -318,7 +318,7 @@ class McpToolImplementation implements IToolImpl {
 					});
 
 					if (isForModel) {
-						const permalink = invocation.chatRequestId && invocation.context && ChatResponseResource.createUri(invocation.context.sessionId, invocation.chatRequestId, invocation.callId, result.content.length, basename(uri));
+						const permalink = invocation.input.chatRequestId && invocation.input.context && ChatResponseResource.createUri(invocation.input.context.sessionId, invocation.input.chatRequestId, invocation.input.callId, result.content.length, basename(uri));
 
 						result.content.push({
 							kind: 'text',

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/getTerminalOutputTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/getTerminalOutputTool.ts
@@ -34,7 +34,7 @@ export interface IGetTerminalOutputInputParams {
 }
 
 export class GetTerminalOutputTool extends Disposable implements IToolImpl {
-	async prepareToolInvocation(context: IToolInvocationPreparationContext, token: CancellationToken): Promise<IPreparedToolInvocation | undefined> {
+	async prepareToolInvocation(context: IToolInvocationPreparationContext, token: CancellationToken): Promise<IPreparedToolInvocation> {
 		return {
 			invocationMessage: localize('bg.progressive', "Checking background terminal output"),
 			pastTenseMessage: localize('bg.past', "Checked background terminal output"),

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/getTerminalOutputTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/getTerminalOutputTool.ts
@@ -42,7 +42,7 @@ export class GetTerminalOutputTool extends Disposable implements IToolImpl {
 	}
 
 	async invoke(invocation: IToolInvocation, _countTokens: CountTokensCallback, _progress: ToolProgress, token: CancellationToken): Promise<IToolResult> {
-		const args = invocation.parameters as IGetTerminalOutputInputParams;
+		const args = invocation.input.parameters as IGetTerminalOutputInputParams;
 		return {
 			content: [{
 				kind: 'text',

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
@@ -369,11 +369,11 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 			};
 		}
 
-		const args = invocation.parameters as IRunInTerminalInputParams;
+		const args = invocation.input.parameters as IRunInTerminalInputParams;
 		this._logService.debug(`RunInTerminalTool: Invoking with options ${JSON.stringify(args)}`);
 		let toolResultMessage: string | undefined;
 
-		const chatSessionId = invocation.context?.sessionId ?? 'no-chat-session';
+		const chatSessionId = invocation.input.context?.sessionId ?? 'no-chat-session';
 		const command = toolSpecificData.commandLine.userEdited ?? toolSpecificData.commandLine.toolEdited ?? toolSpecificData.commandLine.original;
 		const didUserEditCommand = (
 			toolSpecificData.commandLine.userEdited !== undefined &&
@@ -432,7 +432,7 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 				outputMonitor = this._instantiationService.createInstance(OutputMonitor, execution);
 				store.add(outputMonitor);
 
-				outputAndIdle = await outputMonitor.startMonitoring(this._chatService, command, invocation.context!, token);
+				outputAndIdle = await outputMonitor.startMonitoring(this._chatService, command, invocation.input.context!, token);
 				if (token.isCancellationRequested) {
 					throw new CancellationError();
 				}

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
@@ -4,13 +4,16 @@
  *--------------------------------------------------------------------------------------------*/
 
 import type { IMarker as IXtermMarker } from '@xterm/xterm';
+import { asArray } from '../../../../../../base/common/arrays.js';
 import { timeout } from '../../../../../../base/common/async.js';
 import { CancellationToken } from '../../../../../../base/common/cancellation.js';
+import { Codicon } from '../../../../../../base/common/codicons.js';
 import { CancellationError } from '../../../../../../base/common/errors.js';
 import { MarkdownString, type IMarkdownString } from '../../../../../../base/common/htmlContent.js';
 import { Disposable, DisposableStore } from '../../../../../../base/common/lifecycle.js';
 import { OperatingSystem, OS } from '../../../../../../base/common/platform.js';
 import { count } from '../../../../../../base/common/strings.js';
+import type { SingleOrMany } from '../../../../../../base/common/types.js';
 import type { URI } from '../../../../../../base/common/uri.js';
 import { generateUuid } from '../../../../../../base/common/uuid.js';
 import { localize } from '../../../../../../nls.js';
@@ -21,6 +24,7 @@ import { TerminalCapability } from '../../../../../../platform/terminal/common/c
 import { ITerminalLogService } from '../../../../../../platform/terminal/common/terminal.js';
 import { IWorkspaceContextService } from '../../../../../../platform/workspace/common/workspace.js';
 import { IRemoteAgentService } from '../../../../../services/remote/common/remoteAgentService.js';
+import type { TerminalNewAutoApproveButtonData } from '../../../../chat/browser/chatContentParts/toolInvocationParts/chatTerminalToolSubPart.js';
 import { IChatService, type IChatTerminalToolInvocationData } from '../../../../chat/common/chatService.js';
 import { CountTokensCallback, ILanguageModelToolsService, IPreparedToolInvocation, IToolData, IToolImpl, IToolInvocation, IToolInvocationPreparationContext, IToolResult, ToolDataSource, ToolProgress, type IToolConfirmationAction, type IToolConfirmationMessages } from '../../../../chat/common/languageModelToolsService.js';
 import { ITerminalService, type ITerminalInstance } from '../../../../terminal/browser/terminal.js';
@@ -33,14 +37,10 @@ import { BasicExecuteStrategy } from '../executeStrategy/basicExecuteStrategy.js
 import type { ITerminalExecuteStrategy } from '../executeStrategy/executeStrategy.js';
 import { NoneExecuteStrategy } from '../executeStrategy/noneExecuteStrategy.js';
 import { RichExecuteStrategy } from '../executeStrategy/richExecuteStrategy.js';
+import { OutputMonitor } from '../outputMonitor.js';
 import { isPowerShell } from '../runInTerminalHelpers.js';
 import { extractInlineSubCommands, splitCommandLineIntoSubCommands } from '../subCommands.js';
 import { ShellIntegrationQuality, ToolTerminalCreator, type IToolTerminal } from '../toolTerminalCreator.js';
-import { Codicon } from '../../../../../../base/common/codicons.js';
-import { OutputMonitor } from '../outputMonitor.js';
-import type { TerminalNewAutoApproveButtonData } from '../../../../chat/browser/chatContentParts/toolInvocationParts/chatTerminalToolSubPart.js';
-import type { SingleOrMany } from '../../../../../../base/common/types.js';
-import { asArray } from '../../../../../../base/common/arrays.js';
 
 const TERMINAL_SESSION_STORAGE_KEY = 'chat.terminalSessions';
 
@@ -183,7 +183,7 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 		}));
 	}
 
-	async prepareToolInvocation(context: IToolInvocationPreparationContext, token: CancellationToken): Promise<IPreparedToolInvocation | undefined> {
+	async prepareToolInvocation(context: IToolInvocationPreparationContext, token: CancellationToken): Promise<IPreparedToolInvocation> {
 		const args = context.parameters as IRunInTerminalInputParams;
 
 		const alternativeRecommendation = getRecommendedToolsOverRunInTerminal(args.command, this._languageModelToolsService);

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/task/createAndRunTaskTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/task/createAndRunTaskTool.ts
@@ -58,9 +58,9 @@ export class CreateAndRunTaskTool implements IToolImpl {
 	) { }
 
 	async invoke(invocation: IToolInvocation, _countTokens: CountTokensCallback, _progress: ToolProgress, token: CancellationToken): Promise<IToolResult> {
-		const args = invocation.parameters as ICreateAndRunTaskToolInput;
+		const args = invocation.input.parameters as ICreateAndRunTaskToolInput;
 
-		if (!invocation.context) {
+		if (!invocation.input.context) {
 			return { content: [{ kind: 'text', value: `No invocation context` }], toolResultMessage: `No invocation context` };
 		}
 
@@ -122,7 +122,7 @@ export class CreateAndRunTaskTool implements IToolImpl {
 		if (!outputAndIdle.terminalExecutionIdleBeforeTimeout) {
 			outputAndIdle = await racePollingOrPrompt(
 				() => pollForOutputAndIdle({ getOutput: () => getOutput(terminal), isActive: () => this._isTaskActive(task) }, true, token, this._languageModelsService),
-				() => promptForMorePolling(args.task.label, token, invocation.context!, this._chatService),
+				() => promptForMorePolling(args.task.label, token, invocation.input.context!, this._chatService),
 				outputAndIdle,
 				token,
 				this._languageModelsService,

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/task/createAndRunTaskTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/task/createAndRunTaskTool.ts
@@ -152,7 +152,7 @@ export class CreateAndRunTaskTool implements IToolImpl {
 		return activeTasks?.includes(task) ?? false;
 	}
 
-	async prepareToolInvocation(context: IToolInvocationPreparationContext, token: CancellationToken): Promise<IPreparedToolInvocation | undefined> {
+	async prepareToolInvocation(context: IToolInvocationPreparationContext, token: CancellationToken): Promise<IPreparedToolInvocation> {
 		const args = context.parameters as ICreateAndRunTaskToolInput;
 		const task = args.task;
 
@@ -262,5 +262,3 @@ export const CreateAndRunTaskToolData: IToolData = {
 		]
 	},
 };
-
-

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/task/getTaskOutputTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/task/getTaskOutputTool.ts
@@ -73,7 +73,7 @@ export class GetTaskOutputTool extends Disposable implements IToolImpl {
 	}
 
 	async invoke(invocation: IToolInvocation, _countTokens: CountTokensCallback, _progress: ToolProgress, token: CancellationToken): Promise<IToolResult> {
-		const args = invocation.parameters as IGetTaskOutputInputParams;
+		const args = invocation.input.parameters as IGetTaskOutputInputParams;
 		const taskDefinition = getTaskDefinition(args.id);
 		const task = await getTaskForTool(args.id, taskDefinition, args.workspaceFolder, this._configurationService, this._tasksService);
 		if (!task) {

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/task/getTaskOutputTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/task/getTaskOutputTool.ts
@@ -52,7 +52,7 @@ export class GetTaskOutputTool extends Disposable implements IToolImpl {
 	) {
 		super();
 	}
-	async prepareToolInvocation(context: IToolInvocationPreparationContext, token: CancellationToken): Promise<IPreparedToolInvocation | undefined> {
+	async prepareToolInvocation(context: IToolInvocationPreparationContext, token: CancellationToken): Promise<IPreparedToolInvocation> {
 		const args = context.parameters as IGetTaskOutputInputParams;
 
 		const taskDefinition = getTaskDefinition(args.id);

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/task/runTaskTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/task/runTaskTool.ts
@@ -48,9 +48,9 @@ export class RunTaskTool implements IToolImpl {
 	) { }
 
 	async invoke(invocation: IToolInvocation, _countTokens: CountTokensCallback, _progress: ToolProgress, token: CancellationToken): Promise<IToolResult> {
-		const args = invocation.parameters as IRunTaskToolInput;
+		const args = invocation.input.parameters as IRunTaskToolInput;
 
-		if (!invocation.context) {
+		if (!invocation.input.context) {
 			return { content: [{ kind: 'text', value: `No invocation context` }], toolResultMessage: `No invocation context` };
 		}
 
@@ -79,7 +79,7 @@ export class RunTaskTool implements IToolImpl {
 		if (!outputAndIdle.terminalExecutionIdleBeforeTimeout) {
 			outputAndIdle = await racePollingOrPrompt(
 				() => pollForOutputAndIdle({ getOutput: () => getOutput(terminal), isActive: () => this._isTaskActive(task) }, true, token, this._languageModelsService),
-				() => promptForMorePolling(taskLabel, token, invocation.context!, this._chatService),
+				() => promptForMorePolling(taskLabel, token, invocation.input.context!, this._chatService),
 				outputAndIdle,
 				token,
 				this._languageModelsService,

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/task/runTaskTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/task/runTaskTool.ts
@@ -109,7 +109,7 @@ export class RunTaskTool implements IToolImpl {
 		return Promise.resolve(activeTasks?.includes(task));
 	}
 
-	async prepareToolInvocation(context: IToolInvocationPreparationContext, token: CancellationToken): Promise<IPreparedToolInvocation | undefined> {
+	async prepareToolInvocation(context: IToolInvocationPreparationContext, token: CancellationToken): Promise<IPreparedToolInvocation> {
 		const args = context.parameters as IRunTaskToolInput;
 		const taskDefinition = getTaskDefinition(args.id);
 
@@ -168,5 +168,3 @@ export const RunTaskToolData: IToolData = {
 		]
 	}
 };
-
-

--- a/src/vs/workbench/contrib/testing/common/testingChatAgentTool.ts
+++ b/src/vs/workbench/contrib/testing/common/testingChatAgentTool.ts
@@ -110,7 +110,7 @@ class RunTestTool implements IToolImpl {
 	) { }
 
 	async invoke(invocation: IToolInvocation, countTokens: CountTokensCallback, progress: ToolProgress, token: CancellationToken): Promise<IToolResult> {
-		const params: IRunTestToolParams = invocation.parameters;
+		const params: IRunTestToolParams = invocation.input.parameters;
 		const testFiles = await this._getFileTestsToRun(params, progress);
 		const testCases = await this._getTestCasesToRun(params, testFiles, progress);
 		if (!testCases.length) {

--- a/src/vs/workbench/contrib/testing/common/testingChatAgentTool.ts
+++ b/src/vs/workbench/contrib/testing/common/testingChatAgentTool.ts
@@ -47,10 +47,10 @@ export class TestingChatAgentToolContribution extends Disposable implements IWor
 		@IContextKeyService contextKeyService: IContextKeyService
 	) {
 		super();
-		const runInTerminalTool = instantiationService.createInstance(RunTestTool);
+		const runTestTool = instantiationService.createInstance(RunTestTool);
 		this._register(toolsService.registerToolData(RunTestTool.DEFINITION));
 		this._register(
-			toolsService.registerToolImplementation(RunTestTool.ID, runInTerminalTool)
+			toolsService.registerToolImplementation(RunTestTool.ID, runTestTool)
 		);
 
 		// todo@connor4312: temporary for 1.103 release during changeover
@@ -299,7 +299,7 @@ class RunTestTool implements IToolImpl {
 		return tests;
 	}
 
-	prepareToolInvocation(context: IToolInvocationPreparationContext, token: CancellationToken): Promise<IPreparedToolInvocation | undefined> {
+	prepareToolInvocation(context: IToolInvocationPreparationContext, token: CancellationToken): Promise<IPreparedToolInvocation> {
 		const params: IRunTestToolParams = context.parameters;
 		const title = localize('runTestTool.confirm.title', 'Allow test run?');
 		const inFiles = params.files?.map((f: string) => '`' + basename(f) + '`');

--- a/src/vscode-dts/vscode.proposed.chatParticipantPrivate.d.ts
+++ b/src/vscode-dts/vscode.proposed.chatParticipantPrivate.d.ts
@@ -210,7 +210,6 @@ declare module 'vscode' {
 	export interface LanguageModelToolInvocationOptions<T> {
 		chatRequestId?: string;
 		chatSessionId?: string;
-		chatInteractionId?: string;
 		terminalCommand?: string;
 	}
 
@@ -221,7 +220,6 @@ declare module 'vscode' {
 		input: T;
 		chatRequestId?: string;
 		chatSessionId?: string;
-		chatInteractionId?: string;
 	}
 
 	export interface PreparedToolInvocation {


### PR DESCRIPTION
Add `preparedData`

Refactor and clean up the tools service, enhancing the handling of prepared tool invocations and reducing code duplication. This includes updates to various tool implementations for consistency and clarity.