### PR TITLE
Don't trim whitespace when calculating cursor index

### DIFF
--- a/src/vs/platform/terminal/common/capabilities/commandDetection/promptInputModel.ts
+++ b/src/vs/platform/terminal/common/capabilities/commandDetection/promptInputModel.ts
@@ -301,7 +301,7 @@ export class PromptInputModel extends Disposable implements IPromptInputModel {
 		let ghostTextIndex = -1;
 		if (cursorIndex === undefined) {
 			if (absoluteCursorY === commandStartY) {
-				cursorIndex = this._getRelativeCursorIndex(this._commandStartX, buffer, line);
+				cursorIndex = Math.min(this._getRelativeCursorIndex(this._commandStartX, buffer, line), commandLine.length);
 			} else {
 				cursorIndex = commandLine.trimEnd().length;
 			}
@@ -628,7 +628,7 @@ export class PromptInputModel extends Disposable implements IPromptInputModel {
 	}
 
 	private _getRelativeCursorIndex(startCellX: number, buffer: IBuffer, line: IBufferLine): number {
-		return line?.translateToString(true, startCellX, buffer.cursorX).length ?? 0;
+		return line?.translateToString(false, startCellX, buffer.cursorX).length ?? 0;
 	}
 
 	private _isCellStyledLikeGhostText(cell: IBufferCell): boolean {

--- a/src/vs/platform/terminal/test/common/capabilities/commandDetection/promptInputModel.test.ts
+++ b/src/vs/platform/terminal/test/common/capabilities/commandDetection/promptInputModel.test.ts
@@ -491,6 +491,57 @@ suite('PromptInputModel', () => {
 	});
 
 	suite('trailing whitespace', () => {
+		test('cursor index calculation with whitespace', async () => {
+			await writePromise('$ ');
+			fireCommandStart();
+			await assertPromptInput('|');
+
+			await writePromise('echo   ');
+			await assertPromptInput('echo   |');
+
+			await writePromise('\x1b[3D');
+			await assertPromptInput('echo|   ');
+
+			await writePromise('\x1b[C');
+			await assertPromptInput('echo |  ');
+
+			await writePromise('\x1b[C');
+			await assertPromptInput('echo  | ');
+
+			await writePromise('\x1b[C');
+			await assertPromptInput('echo   |');
+		});
+
+		test('cursor index should not exceed command line length', async () => {
+			await writePromise('$ ');
+			fireCommandStart();
+			await assertPromptInput('|');
+
+			await writePromise('cmd');
+			await assertPromptInput('cmd|');
+
+			await writePromise('\x1b[10C');
+			await assertPromptInput('cmd|');
+		});
+
+		test('whitespace preservation in cursor calculation', async () => {
+			await writePromise('$ ');
+			fireCommandStart();
+			await assertPromptInput('|');
+
+			await writePromise('ls   -la');
+			await assertPromptInput('ls   -la|');
+
+			await writePromise('\x1b[3D');
+			await assertPromptInput('ls   |-la');
+
+			await writePromise('\x1b[3D');
+			await assertPromptInput('ls|   -la');
+
+			await writePromise('\x1b[2C');
+			await assertPromptInput('ls  | -la');
+		});
+
 		test('delete whitespace with backspace', async () => {
 			await writePromise('$ ');
 			fireCommandStart();


### PR DESCRIPTION
Fixes #260746

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
