### PR TITLE
Add a separator to terminal approve dropdown

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/chatConfirmationWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/chatConfirmationWidget.ts
@@ -6,7 +6,7 @@
 import * as dom from '../../../../../base/browser/dom.js';
 import { renderAsPlaintext } from '../../../../../base/browser/markdownRenderer.js';
 import { Button, ButtonWithDropdown, IButton, IButtonOptions } from '../../../../../base/browser/ui/button/button.js';
-import { Action } from '../../../../../base/common/actions.js';
+import { Action, Separator } from '../../../../../base/common/actions.js';
 import { Emitter, Event } from '../../../../../base/common/event.js';
 import { IMarkdownString, MarkdownString } from '../../../../../base/common/htmlContent.js';
 import { Disposable, DisposableStore, MutableDisposable } from '../../../../../base/common/lifecycle.js';
@@ -34,7 +34,7 @@ export interface IChatConfirmationButton {
 	data: any;
 	disabled?: boolean;
 	onDidChangeDisablement?: Event<boolean>;
-	moreActions?: IChatConfirmationButton[];
+	moreActions?: (IChatConfirmationButton | Separator)[];
 }
 
 export interface IChatConfirmationWidgetOptions {
@@ -179,16 +179,21 @@ abstract class BaseChatConfirmationWidget extends Disposable {
 					...buttonOptions,
 					contextMenuProvider: contextMenuService,
 					addPrimaryActionToDropdown: false,
-					actions: buttonData.moreActions.map(action => this._register(new Action(
-						action.label,
-						action.label,
-						undefined,
-						!action.disabled,
-						() => {
-							this._onDidClick.fire(action);
-							return Promise.resolve();
-						},
-					))),
+					actions: buttonData.moreActions.map(action => {
+						if (action instanceof Separator) {
+							return action;
+						}
+						return this._register(new Action(
+							action.label,
+							action.label,
+							undefined,
+							!action.disabled,
+							() => {
+								this._onDidClick.fire(action);
+								return Promise.resolve();
+							},
+						));
+					}),
 				});
 			} else {
 				button = new Button(elements.buttons, buttonOptions);

--- a/src/vs/workbench/contrib/chat/common/languageModelToolsService.ts
+++ b/src/vs/workbench/contrib/chat/common/languageModelToolsService.ts
@@ -23,6 +23,7 @@ import { derived, IObservable, IReader, ITransaction, ObservableSet } from '../.
 import { Iterable } from '../../../../base/common/iterator.js';
 import { localize } from '../../../../nls.js';
 import { LanguageModelPartAudience } from './languageModels.js';
+import { Separator } from '../../../../base/common/actions.js';
 
 export interface IToolData {
 	id: string;
@@ -209,7 +210,7 @@ export interface IToolConfirmationMessages {
 	message: string | IMarkdownString;
 	disclaimer?: string | IMarkdownString;
 	allowAutoConfirm?: boolean;
-	terminalCustomActions?: IToolConfirmationAction[];
+	terminalCustomActions?: ToolConfirmationAction[];
 }
 
 export interface IToolConfirmationAction {
@@ -217,6 +218,8 @@ export interface IToolConfirmationAction {
 	tooltip?: string;
 	data: any;
 }
+
+export type ToolConfirmationAction = IToolConfirmationAction | Separator;
 
 export interface IPreparedToolInvocation {
 	invocationMessage?: string | IMarkdownString;

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
@@ -22,7 +22,8 @@ import { ITerminalLogService } from '../../../../../../platform/terminal/common/
 import { IWorkspaceContextService } from '../../../../../../platform/workspace/common/workspace.js';
 import { IRemoteAgentService } from '../../../../../services/remote/common/remoteAgentService.js';
 import { IChatService, type IChatTerminalToolInvocationData } from '../../../../chat/common/chatService.js';
-import { CountTokensCallback, ILanguageModelToolsService, IPreparedToolInvocation, IToolData, IToolImpl, IToolInvocation, IToolInvocationPreparationContext, IToolResult, ToolDataSource, ToolProgress, type IToolConfirmationAction, type IToolConfirmationMessages } from '../../../../chat/common/languageModelToolsService.js';
+import { CountTokensCallback, ILanguageModelToolsService, IPreparedToolInvocation, IToolData, IToolImpl, IToolInvocation, IToolInvocationPreparationContext, IToolResult, ToolDataSource, ToolProgress, type IToolConfirmationMessages, type ToolConfirmationAction } from '../../../../chat/common/languageModelToolsService.js';
+import { Separator } from '../../../../../../base/common/actions.js';
 import { ITerminalService, type ITerminalInstance } from '../../../../terminal/browser/terminal.js';
 import type { XtermTerminal } from '../../../../terminal/browser/xterm/xtermTerminal.js';
 import { ITerminalProfileResolverService } from '../../../../terminal/common/terminal.js';
@@ -323,7 +324,7 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 				disclaimer = new MarkdownString(`$(${Codicon.info.id}) ` + localize('runInTerminal.promptInjectionDisclaimer', 'Web content may contain malicious code or attempt prompt injection attacks.'), { supportThemeIcons: true });
 			}
 
-			let customActions: IToolConfirmationAction[] | undefined;
+			let customActions: ToolConfirmationAction[] | undefined;
 			if (!isAutoApproved) {
 				customActions = this._generateAutoApproveActions(args.command, subCommands, { subCommandResults, commandLineResult });
 			}
@@ -880,8 +881,8 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 		});
 	}
 
-	private _generateAutoApproveActions(commandLine: string, subCommands: string[], autoApproveResult: { subCommandResults: ICommandApprovalResultWithReason[]; commandLineResult: ICommandApprovalResultWithReason }): IToolConfirmationAction[] {
-		const actions: IToolConfirmationAction[] = [];
+	private _generateAutoApproveActions(commandLine: string, subCommands: string[], autoApproveResult: { subCommandResults: ICommandApprovalResultWithReason[]; commandLineResult: ICommandApprovalResultWithReason }): ToolConfirmationAction[] {
+		const actions: ToolConfirmationAction[] = [];
 
 		// We shouldn't offer configuring rules for commands that are explicitly denied since it
 		// wouldn't get auto approved with a new rule
@@ -930,6 +931,10 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 					} satisfies TerminalNewAutoApproveButtonData
 				});
 			}
+		}
+
+		if (actions.length > 0) {
+			actions.push(new Separator());
 		}
 
 		// Always show configure option

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/runInTerminalTool.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/runInTerminalTool.test.ts
@@ -292,14 +292,14 @@ suite('RunInTerminalTool', () => {
 
 			strictEqual(customActions[0].label, 'Always Allow Command: npm');
 			ok(!(customActions[0] instanceof Separator), 'Expected first action to not be a separator');
-			if (!(customActions[0] instanceof Separator)) {
+			if ('data' in customActions[0]) {
 				strictEqual(customActions[0].data.type, 'newRule');
 				ok(Array.isArray(customActions[0].data.rule), 'Expected rule to be an array');
 			}
 
 			strictEqual(customActions[1].label, 'Always Allow Full Command Line: npm run build');
 			ok(!(customActions[1] instanceof Separator), 'Expected second action to not be a separator');
-			if (!(customActions[1] instanceof Separator)) {
+			if ('data' in customActions[1]) {
 				strictEqual(customActions[1].data.type, 'newRule');
 				ok(!Array.isArray(customActions[1].data.rule), 'Expected rule to be an object');
 			}
@@ -308,7 +308,7 @@ suite('RunInTerminalTool', () => {
 
 			strictEqual(customActions[3].label, 'Configure Auto Approve...');
 			ok(!(customActions[3] instanceof Separator), 'Expected fourth action to not be a separator');
-			if (!(customActions[3] instanceof Separator)) {
+			if ('data' in customActions[3]) {
 				strictEqual(customActions[3].data.type, 'configure');
 			}
 		});
@@ -328,7 +328,7 @@ suite('RunInTerminalTool', () => {
 
 			strictEqual(customActions[0].label, 'Always Allow Command: git');
 			ok(!(customActions[0] instanceof Separator), 'Expected first action to not be a separator');
-			if (!(customActions[0] instanceof Separator)) {
+			if ('data' in customActions[0]) {
 				strictEqual(customActions[0].data.type, 'newRule');
 				ok(Array.isArray(customActions[0].data.rule), 'Expected rule to be an array');
 			}
@@ -337,7 +337,7 @@ suite('RunInTerminalTool', () => {
 
 			strictEqual(customActions[2].label, 'Configure Auto Approve...');
 			ok(!(customActions[2] instanceof Separator), 'Expected third action to not be a separator');
-			if (!(customActions[2] instanceof Separator)) {
+			if ('data' in customActions[2]) {
 				strictEqual(customActions[2].data.type, 'configure');
 			}
 		});
@@ -428,12 +428,15 @@ suite('RunInTerminalTool', () => {
 			strictEqual(customActions.length, 3, 'Expected 3 custom actions');
 
 			strictEqual(customActions[0].label, 'Always Allow Command: foo', 'Should only show \'foo\' since \'head\' is auto-approved');
+			ok('data' in customActions[0]);
 			strictEqual(customActions[0].data.type, 'newRule');
 
 			strictEqual(customActions[1].label, 'Always Allow Full Command Line: foo | head -20');
+			ok('data' in customActions[1]);
 			strictEqual(customActions[1].data.type, 'newRule');
 
 			strictEqual(customActions[2].label, 'Configure Auto Approve...');
+			ok('data' in customActions[2]);
 			strictEqual(customActions[2].data.type, 'configure');
 		});
 
@@ -469,12 +472,15 @@ suite('RunInTerminalTool', () => {
 			strictEqual(customActions.length, 3, 'Expected 3 custom actions');
 
 			strictEqual(customActions[0].label, 'Always Allow Commands: foo, bar', 'Should only show \'foo, bar\' since \'head\' and \'tail\' are auto-approved');
+			ok('data' in customActions[0]);
 			strictEqual(customActions[0].data.type, 'newRule');
 
 			strictEqual(customActions[1].label, 'Always Allow Full Command Line: foo | head -20 &&& bar | tail -10');
+			ok('data' in customActions[1]);
 			strictEqual(customActions[1].data.type, 'newRule');
 
 			strictEqual(customActions[2].label, 'Configure Auto Approve...');
+			ok('data' in customActions[2]);
 			strictEqual(customActions[2].data.type, 'configure');
 		});
 

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/runInTerminalTool.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/runInTerminalTool.test.ts
@@ -7,6 +7,7 @@ import { ok, strictEqual } from 'assert';
 import { CancellationToken } from '../../../../../../base/common/cancellation.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
 import { URI } from '../../../../../../base/common/uri.js';
+import { Separator } from '../../../../../../base/common/actions.js';
 import { ConfigurationTarget } from '../../../../../../platform/configuration/common/configuration.js';
 import { TestConfigurationService } from '../../../../../../platform/configuration/test/common/testConfigurationService.js';
 import { workbenchInstantiationService } from '../../../../../test/browser/workbenchTestServices.js';
@@ -287,18 +288,29 @@ suite('RunInTerminalTool', () => {
 			ok(result!.confirmationMessages!.terminalCustomActions, 'Expected custom actions to be defined');
 
 			const customActions = result!.confirmationMessages!.terminalCustomActions!;
-			strictEqual(customActions.length, 3, 'Expected 3 custom actions');
+			strictEqual(customActions.length, 4, 'Expected 4 custom actions (including separator)');
 
 			strictEqual(customActions[0].label, 'Always Allow Command: npm');
-			strictEqual(customActions[0].data.type, 'newRule');
-			ok(Array.isArray(customActions[0].data.rule), 'Expected rule to be an array');
+			ok(!(customActions[0] instanceof Separator), 'Expected first action to not be a separator');
+			if (!(customActions[0] instanceof Separator)) {
+				strictEqual(customActions[0].data.type, 'newRule');
+				ok(Array.isArray(customActions[0].data.rule), 'Expected rule to be an array');
+			}
 
 			strictEqual(customActions[1].label, 'Always Allow Full Command Line: npm run build');
-			strictEqual(customActions[1].data.type, 'newRule');
-			ok(!Array.isArray(customActions[1].data.rule), 'Expected rule to be an object');
+			ok(!(customActions[1] instanceof Separator), 'Expected second action to not be a separator');
+			if (!(customActions[1] instanceof Separator)) {
+				strictEqual(customActions[1].data.type, 'newRule');
+				ok(!Array.isArray(customActions[1].data.rule), 'Expected rule to be an object');
+			}
 
-			strictEqual(customActions[2].label, 'Configure Auto Approve...');
-			strictEqual(customActions[2].data.type, 'configure');
+			ok(customActions[2] instanceof Separator, 'Expected third action to be a separator');
+
+			strictEqual(customActions[3].label, 'Configure Auto Approve...');
+			ok(!(customActions[3] instanceof Separator), 'Expected fourth action to not be a separator');
+			if (!(customActions[3] instanceof Separator)) {
+				strictEqual(customActions[3].data.type, 'configure');
+			}
 		});
 
 		test('should generate custom actions for single word commands', async () => {
@@ -312,14 +324,22 @@ suite('RunInTerminalTool', () => {
 
 			const customActions = result!.confirmationMessages!.terminalCustomActions!;
 
-			strictEqual(customActions.length, 2, 'Expected 2 custom actions for single word command');
+			strictEqual(customActions.length, 3, 'Expected 3 custom actions for single word command (including separator)');
 
 			strictEqual(customActions[0].label, 'Always Allow Command: git');
-			strictEqual(customActions[0].data.type, 'newRule');
-			ok(Array.isArray(customActions[0].data.rule), 'Expected rule to be an array');
+			ok(!(customActions[0] instanceof Separator), 'Expected first action to not be a separator');
+			if (!(customActions[0] instanceof Separator)) {
+				strictEqual(customActions[0].data.type, 'newRule');
+				ok(Array.isArray(customActions[0].data.rule), 'Expected rule to be an array');
+			}
 
-			strictEqual(customActions[1].label, 'Configure Auto Approve...');
-			strictEqual(customActions[1].data.type, 'configure');
+			ok(customActions[1] instanceof Separator, 'Expected second action to be a separator');
+
+			strictEqual(customActions[2].label, 'Configure Auto Approve...');
+			ok(!(customActions[2] instanceof Separator), 'Expected third action to not be a separator');
+			if (!(customActions[2] instanceof Separator)) {
+				strictEqual(customActions[2].data.type, 'configure');
+			}
 		});
 
 		test('should not generate custom actions for auto-approved commands', async () => {
@@ -352,7 +372,10 @@ suite('RunInTerminalTool', () => {
 			strictEqual(customActions.length, 1, 'Expected only 1 custom action for explicitly denied commands');
 
 			strictEqual(customActions[0].label, 'Configure Auto Approve...');
-			strictEqual(customActions[0].data.type, 'configure');
+			ok(!(customActions[0] instanceof Separator), 'Expected action to not be a separator');
+			if (!(customActions[0] instanceof Separator)) {
+				strictEqual(customActions[0].data.type, 'configure');
+			}
 		});
 
 		test('should handle && in command line labels with proper mnemonic escaping', async () => {
@@ -365,16 +388,27 @@ suite('RunInTerminalTool', () => {
 			ok(result!.confirmationMessages!.terminalCustomActions, 'Expected custom actions to be defined');
 
 			const customActions = result!.confirmationMessages!.terminalCustomActions!;
-			strictEqual(customActions.length, 3, 'Expected 3 custom actions');
+			strictEqual(customActions.length, 4, 'Expected 4 custom actions (including separator)');
 
 			strictEqual(customActions[0].label, 'Always Allow Command: npm');
-			strictEqual(customActions[0].data.type, 'newRule');
+			ok(!(customActions[0] instanceof Separator), 'Expected first action to not be a separator');
+			if (!(customActions[0] instanceof Separator)) {
+				strictEqual(customActions[0].data.type, 'newRule');
+			}
 
 			strictEqual(customActions[1].label, 'Always Allow Full Command Line: npm install &&& npm run build');
-			strictEqual(customActions[1].data.type, 'newRule');
+			ok(!(customActions[1] instanceof Separator), 'Expected second action to not be a separator');
+			if (!(customActions[1] instanceof Separator)) {
+				strictEqual(customActions[1].data.type, 'newRule');
+			}
 
-			strictEqual(customActions[2].label, 'Configure Auto Approve...');
-			strictEqual(customActions[2].data.type, 'configure');
+			ok(customActions[2] instanceof Separator, 'Expected third action to be a separator');
+
+			strictEqual(customActions[3].label, 'Configure Auto Approve...');
+			ok(!(customActions[3] instanceof Separator), 'Expected fourth action to not be a separator');
+			if (!(customActions[3] instanceof Separator)) {
+				strictEqual(customActions[3].data.type, 'configure');
+			}
 		});
 
 	});

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/runInTerminalTool.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/runInTerminalTool.test.ts
@@ -11,7 +11,7 @@ import { Separator } from '../../../../../../base/common/actions.js';
 import { ConfigurationTarget } from '../../../../../../platform/configuration/common/configuration.js';
 import { TestConfigurationService } from '../../../../../../platform/configuration/test/common/testConfigurationService.js';
 import { workbenchInstantiationService } from '../../../../../test/browser/workbenchTestServices.js';
-import { IToolInvocationPreparationContext, IPreparedToolInvocation, ILanguageModelToolsService } from '../../../../chat/common/languageModelToolsService.js';
+import { IToolInvocationPreparationContext, IPreparedToolInvocation, ILanguageModelToolsService, type ToolConfirmationAction } from '../../../../chat/common/languageModelToolsService.js';
 import { RunInTerminalTool, type IRunInTerminalInputParams } from '../../browser/tools/runInTerminalTool.js';
 import { TerminalChatAgentToolsSettingId } from '../../common/terminalChatAgentToolsConfiguration.js';
 import { IWorkspaceContextService } from '../../../../../../platform/workspace/common/workspace.js';
@@ -110,6 +110,10 @@ suite('RunInTerminalTool', () => {
 
 		const result = await runInTerminalTool.prepareToolInvocation(context, CancellationToken.None);
 		return result;
+	}
+
+	function isSeparator(action: ToolConfirmationAction): action is Separator {
+		return action instanceof Separator;
 	}
 
 	/**
@@ -288,29 +292,24 @@ suite('RunInTerminalTool', () => {
 			ok(result!.confirmationMessages!.terminalCustomActions, 'Expected custom actions to be defined');
 
 			const customActions = result!.confirmationMessages!.terminalCustomActions!;
-			strictEqual(customActions.length, 4, 'Expected 4 custom actions (including separator)');
+			strictEqual(customActions.length, 4);
 
+
+			ok(!isSeparator(customActions[0]));
 			strictEqual(customActions[0].label, 'Always Allow Command: npm');
-			ok(!(customActions[0] instanceof Separator), 'Expected first action to not be a separator');
-			if ('data' in customActions[0]) {
-				strictEqual(customActions[0].data.type, 'newRule');
-				ok(Array.isArray(customActions[0].data.rule), 'Expected rule to be an array');
-			}
+			strictEqual(customActions[0].data.type, 'newRule');
+			ok(Array.isArray(customActions[0].data.rule), 'Expected rule to be an array');
 
+			ok(!isSeparator(customActions[1]));
 			strictEqual(customActions[1].label, 'Always Allow Full Command Line: npm run build');
-			ok(!(customActions[1] instanceof Separator), 'Expected second action to not be a separator');
-			if ('data' in customActions[1]) {
-				strictEqual(customActions[1].data.type, 'newRule');
-				ok(!Array.isArray(customActions[1].data.rule), 'Expected rule to be an object');
-			}
+			strictEqual(customActions[1].data.type, 'newRule');
+			ok(!Array.isArray(customActions[1].data.rule), 'Expected rule to be an object');
 
-			ok(customActions[2] instanceof Separator, 'Expected third action to be a separator');
+			ok(isSeparator(customActions[2]));
 
+			ok(!isSeparator(customActions[3]));
 			strictEqual(customActions[3].label, 'Configure Auto Approve...');
-			ok(!(customActions[3] instanceof Separator), 'Expected fourth action to not be a separator');
-			if ('data' in customActions[3]) {
-				strictEqual(customActions[3].data.type, 'configure');
-			}
+			strictEqual(customActions[3].data.type, 'configure');
 		});
 
 		test('should generate custom actions for single word commands', async () => {
@@ -324,22 +323,18 @@ suite('RunInTerminalTool', () => {
 
 			const customActions = result!.confirmationMessages!.terminalCustomActions!;
 
-			strictEqual(customActions.length, 3, 'Expected 3 custom actions for single word command (including separator)');
+			strictEqual(customActions.length, 3);
 
+			ok(!isSeparator(customActions[0]));
 			strictEqual(customActions[0].label, 'Always Allow Command: git');
-			ok(!(customActions[0] instanceof Separator), 'Expected first action to not be a separator');
-			if ('data' in customActions[0]) {
-				strictEqual(customActions[0].data.type, 'newRule');
-				ok(Array.isArray(customActions[0].data.rule), 'Expected rule to be an array');
-			}
+			strictEqual(customActions[0].data.type, 'newRule');
+			ok(Array.isArray(customActions[0].data.rule), 'Expected rule to be an array');
 
-			ok(customActions[1] instanceof Separator, 'Expected second action to be a separator');
+			ok(isSeparator(customActions[1]));
 
+			ok(!isSeparator(customActions[2]));
 			strictEqual(customActions[2].label, 'Configure Auto Approve...');
-			ok(!(customActions[2] instanceof Separator), 'Expected third action to not be a separator');
-			if ('data' in customActions[2]) {
-				strictEqual(customActions[2].data.type, 'configure');
-			}
+			strictEqual(customActions[2].data.type, 'configure');
 		});
 
 		test('should not generate custom actions for auto-approved commands', async () => {
@@ -371,11 +366,9 @@ suite('RunInTerminalTool', () => {
 			const customActions = result!.confirmationMessages!.terminalCustomActions!;
 			strictEqual(customActions.length, 1, 'Expected only 1 custom action for explicitly denied commands');
 
+			ok(!isSeparator(customActions[0]));
 			strictEqual(customActions[0].label, 'Configure Auto Approve...');
-			ok(!(customActions[0] instanceof Separator), 'Expected action to not be a separator');
-			if (!(customActions[0] instanceof Separator)) {
-				strictEqual(customActions[0].data.type, 'configure');
-			}
+			strictEqual(customActions[0].data.type, 'configure');
 		});
 
 		test('should handle && in command line labels with proper mnemonic escaping', async () => {
@@ -388,27 +381,21 @@ suite('RunInTerminalTool', () => {
 			ok(result!.confirmationMessages!.terminalCustomActions, 'Expected custom actions to be defined');
 
 			const customActions = result!.confirmationMessages!.terminalCustomActions!;
-			strictEqual(customActions.length, 4, 'Expected 4 custom actions (including separator)');
+			strictEqual(customActions.length, 4);
 
+			ok(!isSeparator(customActions[0]));
 			strictEqual(customActions[0].label, 'Always Allow Command: npm');
-			ok(!(customActions[0] instanceof Separator), 'Expected first action to not be a separator');
-			if (!(customActions[0] instanceof Separator)) {
-				strictEqual(customActions[0].data.type, 'newRule');
-			}
+			strictEqual(customActions[0].data.type, 'newRule');
 
+			ok(!isSeparator(customActions[1]));
 			strictEqual(customActions[1].label, 'Always Allow Full Command Line: npm install &&& npm run build');
-			ok(!(customActions[1] instanceof Separator), 'Expected second action to not be a separator');
-			if (!(customActions[1] instanceof Separator)) {
-				strictEqual(customActions[1].data.type, 'newRule');
-			}
+			strictEqual(customActions[1].data.type, 'newRule');
 
-			ok(customActions[2] instanceof Separator, 'Expected third action to be a separator');
+			ok(isSeparator(customActions[2]));
 
+			ok(!isSeparator(customActions[3]));
 			strictEqual(customActions[3].label, 'Configure Auto Approve...');
-			ok(!(customActions[3] instanceof Separator), 'Expected fourth action to not be a separator');
-			if (!(customActions[3] instanceof Separator)) {
-				strictEqual(customActions[3].data.type, 'configure');
-			}
+			strictEqual(customActions[3].data.type, 'configure');
 		});
 
 		test('should not show approved commands in custom actions dropdown', async () => {
@@ -425,19 +412,21 @@ suite('RunInTerminalTool', () => {
 			ok(result!.confirmationMessages!.terminalCustomActions, 'Expected custom actions to be defined');
 
 			const customActions = result!.confirmationMessages!.terminalCustomActions!;
-			strictEqual(customActions.length, 3, 'Expected 3 custom actions');
+			strictEqual(customActions.length, 4);
 
+			ok(!isSeparator(customActions[0]));
 			strictEqual(customActions[0].label, 'Always Allow Command: foo', 'Should only show \'foo\' since \'head\' is auto-approved');
-			ok('data' in customActions[0]);
 			strictEqual(customActions[0].data.type, 'newRule');
 
+			ok(!isSeparator(customActions[1]));
 			strictEqual(customActions[1].label, 'Always Allow Full Command Line: foo | head -20');
-			ok('data' in customActions[1]);
 			strictEqual(customActions[1].data.type, 'newRule');
 
-			strictEqual(customActions[2].label, 'Configure Auto Approve...');
-			ok('data' in customActions[2]);
-			strictEqual(customActions[2].data.type, 'configure');
+			ok(isSeparator(customActions[2]));
+
+			ok(!isSeparator(customActions[3]));
+			strictEqual(customActions[3].label, 'Configure Auto Approve...');
+			strictEqual(customActions[3].data.type, 'configure');
 		});
 
 		test('should not show any command-specific actions when all sub-commands are approved', async () => {
@@ -469,19 +458,21 @@ suite('RunInTerminalTool', () => {
 			ok(result!.confirmationMessages!.terminalCustomActions, 'Expected custom actions to be defined');
 
 			const customActions = result!.confirmationMessages!.terminalCustomActions!;
-			strictEqual(customActions.length, 3, 'Expected 3 custom actions');
+			strictEqual(customActions.length, 4);
 
+			ok(!isSeparator(customActions[0]));
 			strictEqual(customActions[0].label, 'Always Allow Commands: foo, bar', 'Should only show \'foo, bar\' since \'head\' and \'tail\' are auto-approved');
-			ok('data' in customActions[0]);
 			strictEqual(customActions[0].data.type, 'newRule');
 
+			ok(!isSeparator(customActions[1]));
 			strictEqual(customActions[1].label, 'Always Allow Full Command Line: foo | head -20 &&& bar | tail -10');
-			ok('data' in customActions[1]);
 			strictEqual(customActions[1].data.type, 'newRule');
 
-			strictEqual(customActions[2].label, 'Configure Auto Approve...');
-			ok('data' in customActions[2]);
-			strictEqual(customActions[2].data.type, 'configure');
+			ok(isSeparator(customActions[2]));
+
+			ok(!isSeparator(customActions[3]));
+			strictEqual(customActions[3].label, 'Configure Auto Approve...');
+			strictEqual(customActions[3].data.type, 'configure');
 		});
 
 	});


### PR DESCRIPTION
Fixes #260888

<img width="962" height="402" alt="image" src="https://github.com/user-attachments/assets/1802560b-1143-403d-b5a1-9f80b251f474" />
