### PR TITLE
Make space for nes widget in editor

### DIFF
--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsView.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsView.ts
@@ -7,7 +7,7 @@ import { equalsIfDefined, itemEquals } from '../../../../../../base/common/equal
 import { BugIndicatingError } from '../../../../../../base/common/errors.js';
 import { Event } from '../../../../../../base/common/event.js';
 import { Disposable } from '../../../../../../base/common/lifecycle.js';
-import { autorun, autorunWithStore, derived, derivedOpts, IObservable, IReader, ISettableObservable, mapObservableArrayCached, observableFromEvent, observableValue } from '../../../../../../base/common/observable.js';
+import { autorun, autorunWithStore, derived, derivedOpts, IObservable, IReader, ISettableObservable, mapObservableArrayCached, observableValue } from '../../../../../../base/common/observable.js';
 import { IInstantiationService } from '../../../../../../platform/instantiation/common/instantiation.js';
 import { ICodeEditor } from '../../../../../browser/editorBrowser.js';
 import { ObservableCodeEditor, observableCodeEditor } from '../../../../../browser/observableCodeEditor.js';
@@ -315,14 +315,11 @@ export class InlineEditsView extends Disposable {
 		}).recomputeInitiallyAndOnChange(this._store);
 
 		const textModel = this._editor.getModel()!;
-		const onDidContentChange = observableFromEvent(this, textModel.onDidChangeContent, () => { });
 
 		let viewZoneId: string | undefined;
 		this._register(autorun(reader => {
 			const minScrollHeight = minEditorScrollHeight.read(reader);
 			this._editor.changeViewZones(accessor => {
-				onDidContentChange.read(reader);
-
 				const scrollHeight = this._editor.getScrollHeight();
 				const viewZoneHeight = minScrollHeight - scrollHeight + 1 /* Add 1px so there is a small gap */;
 

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsView.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsView.ts
@@ -7,7 +7,7 @@ import { equalsIfDefined, itemEquals } from '../../../../../../base/common/equal
 import { BugIndicatingError } from '../../../../../../base/common/errors.js';
 import { Event } from '../../../../../../base/common/event.js';
 import { Disposable } from '../../../../../../base/common/lifecycle.js';
-import { autorunWithStore, derived, derivedOpts, IObservable, IReader, ISettableObservable, mapObservableArrayCached, observableValue } from '../../../../../../base/common/observable.js';
+import { autorun, autorunWithStore, derived, derivedOpts, IObservable, IReader, ISettableObservable, mapObservableArrayCached, observableFromEvent, observableValue } from '../../../../../../base/common/observable.js';
 import { IInstantiationService } from '../../../../../../platform/instantiation/common/instantiation.js';
 import { ICodeEditor } from '../../../../../browser/editorBrowser.js';
 import { ObservableCodeEditor, observableCodeEditor } from '../../../../../browser/observableCodeEditor.js';
@@ -35,6 +35,7 @@ import { InlineEditsWordReplacementView } from './inlineEditsViews/inlineEditsWo
 import { IOriginalEditorInlineDiffViewState, OriginalEditorInlineDiffView } from './inlineEditsViews/originalEditorInlineDiffView.js';
 import { applyEditToModifiedRangeMappings, createReindentEdit } from './utils/utils.js';
 import './view.css';
+import { $ } from '../../../../../../base/browser/dom.js';
 
 
 export class InlineEditsView extends Disposable {
@@ -304,6 +305,43 @@ export class InlineEditsView extends Disposable {
 		this._indicatorCyclicDependencyCircuitBreaker.set(true, undefined);
 
 		this._register(this._instantiationService.createInstance(InlineEditsOnboardingExperience, this._host, this._model, this._indicator, this._inlineCollapsedView));
+
+		const minEditorScrollHeight = derived(this, reader => {
+			return Math.max(
+				...this._wordReplacementViews.read(reader).map(v => v.minEditorScrollHeight.read(reader)),
+				this._lineReplacementView.minEditorScrollHeight.read(reader),
+				this._customView.minEditorScrollHeight.read(reader)
+			);
+		}).recomputeInitiallyAndOnChange(this._store);
+
+		const textModel = this._editor.getModel()!;
+		const onDidContentChange = observableFromEvent(this, textModel.onDidChangeContent, () => { });
+
+		let viewZoneId: string | undefined;
+		this._register(autorun(reader => {
+			const minScrollHeight = minEditorScrollHeight.read(reader);
+			this._editor.changeViewZones(accessor => {
+				onDidContentChange.read(reader);
+
+				const scrollHeight = this._editor.getScrollHeight();
+				const viewZoneHeight = minScrollHeight - scrollHeight + 1 /* Add 1px so there is a small gap */;
+
+				if (viewZoneHeight !== 0 && viewZoneId) {
+					accessor.removeZone(viewZoneId);
+					viewZoneId = undefined;
+				}
+
+				if (viewZoneHeight <= 0) {
+					return;
+				}
+
+				viewZoneId = accessor.addZone({
+					afterLineNumber: textModel.getLineCount(),
+					heightInPx: viewZoneHeight,
+					domNode: $('div.minScrollHeightViewZone'),
+				});
+			});
+		}));
 
 		this._constructorDone.set(true, undefined); // TODO: remove and use correct initialization order
 	}

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViewInterface.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViewInterface.ts
@@ -17,6 +17,7 @@ export enum InlineEditTabAction {
 
 export interface IInlineEditsView {
 	isHovered: IObservable<boolean>;
+	minEditorScrollHeight?: IObservable<number>;
 	onDidClick: Event<IMouseEvent>;
 }
 

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/inlineEditsCustomView.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/inlineEditsCustomView.ts
@@ -41,6 +41,8 @@ export class InlineEditsCustomView extends Disposable implements IInlineEditsVie
 
 	private readonly _editorObs: ObservableCodeEditor;
 
+	readonly minEditorScrollHeight: IObservable<number>;
+
 	constructor(
 		private readonly _editor: ICodeEditor,
 		displayLocation: IObservable<InlineCompletionDisplayLocation | undefined>,
@@ -68,6 +70,14 @@ export class InlineEditsCustomView extends Disposable implements IInlineEditsVie
 		const state = displayLocation.map(dl => dl ? this.getState(dl) : undefined);
 
 		const view = state.map(s => s ? this.getRendering(s, styles) : undefined);
+
+		this.minEditorScrollHeight = derived(reader => {
+			const s = state.read(reader);
+			if (!s) {
+				return 0;
+			}
+			return s.rect.read(reader).bottom + this._editor.getScrollTop();
+		});
 
 		const overlay = n.div({
 			class: 'inline-edits-custom-view',

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/inlineEditsLineReplacementView.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/inlineEditsLineReplacementView.ts
@@ -46,6 +46,8 @@ export class InlineEditsLineReplacementView extends Disposable implements IInlin
 
 	readonly isHovered;
 
+	readonly minEditorScrollHeight;
+
 	constructor(
 		private readonly _editor: ObservableCodeEditor,
 		private readonly _edit: IObservable<{
@@ -187,6 +189,13 @@ export class InlineEditsLineReplacementView extends Disposable implements IInlin
 			const viewZoneHeight = layout.lowerBackground.height;
 			const viewZoneLineNumber = edit.originalRange.endLineNumberExclusive;
 			return { height: viewZoneHeight, lineNumber: viewZoneLineNumber };
+		});
+		this.minEditorScrollHeight = derived(reader => {
+			const layout = mapOutFalsy(this._layout).read(reader);
+			if (!layout || this._viewZoneInfo.read(reader) !== undefined) {
+				return 0;
+			}
+			return layout.read(reader).lowerText.bottom + this._editor.editor.getScrollTop();
 		});
 		this._div = n.div({
 			class: 'line-replacement',

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/inlineEditsWordReplacementView.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/inlineEditsWordReplacementView.ts
@@ -24,6 +24,8 @@ import { IInlineEditsView, InlineEditTabAction } from '../inlineEditsViewInterfa
 import { getModifiedBorderColor, getOriginalBorderColor, modifiedChangedTextOverlayColor, originalChangedTextOverlayColor } from '../theme.js';
 import { getEditorValidOverlayRect, mapOutFalsy, rectToProps } from '../utils/utils.js';
 
+const BORDER_WIDTH = 1;
+
 export class InlineEditsWordReplacementView extends Disposable implements IInlineEditsView {
 
 	public static MAX_LENGTH = 100;
@@ -39,6 +41,8 @@ export class InlineEditsWordReplacementView extends Disposable implements IInlin
 	private readonly _hoverableElement;
 
 	readonly isHovered;
+
+	readonly minEditorScrollHeight;
 
 	constructor(
 		private readonly _editor: ObservableCodeEditor,
@@ -104,6 +108,13 @@ export class InlineEditsWordReplacementView extends Disposable implements IInlin
 				lineHeight,
 			};
 		});
+		this.minEditorScrollHeight = derived(reader => {
+			const layout = mapOutFalsy(this._layout).read(reader);
+			if (!layout) {
+				return 0;
+			}
+			return layout.read(reader).modifiedLine.bottom + BORDER_WIDTH + this._editor.editor.getScrollTop();
+		});
 		this._root = n.div({
 			class: 'word-replacement',
 		}, [
@@ -112,8 +123,6 @@ export class InlineEditsWordReplacementView extends Disposable implements IInlin
 				if (!layout) {
 					return [];
 				}
-
-				const borderWidth = 1;
 
 				const originalBorderColor = getOriginalBorderColor(this._tabAction).map(c => asCssVariable(c)).read(reader);
 				const modifiedBorderColor = getModifiedBorderColor(this._tabAction).map(c => asCssVariable(c)).read(reader);
@@ -130,7 +139,7 @@ export class InlineEditsWordReplacementView extends Disposable implements IInlin
 						n.div({
 							style: {
 								position: 'absolute',
-								...rectToProps(reader => layout.read(reader).lowerBackground.withMargin(borderWidth, 2 * borderWidth, borderWidth, 0)),
+								...rectToProps(reader => layout.read(reader).lowerBackground.withMargin(BORDER_WIDTH, 2 * BORDER_WIDTH, BORDER_WIDTH, 0)),
 								background: asCssVariable(editorBackground),
 								//boxShadow: `${asCssVariable(scrollbarShadow)} 0 6px 6px -6px`,
 								cursor: 'pointer',
@@ -147,7 +156,7 @@ export class InlineEditsWordReplacementView extends Disposable implements IInlin
 						n.div({
 							style: {
 								position: 'absolute',
-								...rectToProps(reader => layout.read(reader).modifiedLine.withMargin(1, 2)),
+								...rectToProps(reader => layout.read(reader).modifiedLine.withMargin(BORDER_WIDTH, 2 * BORDER_WIDTH)),
 								fontFamily: this._editor.getOption(EditorOption.fontFamily),
 								fontSize: this._editor.getOption(EditorOption.fontSize),
 								fontWeight: this._editor.getOption(EditorOption.fontWeight),
@@ -155,7 +164,7 @@ export class InlineEditsWordReplacementView extends Disposable implements IInlin
 								pointerEvents: 'none',
 								boxSizing: 'border-box',
 								borderRadius: '4px',
-								border: `${borderWidth}px solid ${modifiedBorderColor}`,
+								border: `${BORDER_WIDTH}px solid ${modifiedBorderColor}`,
 
 								background: asCssVariable(modifiedChangedTextOverlayColor),
 								display: 'flex',
@@ -168,10 +177,10 @@ export class InlineEditsWordReplacementView extends Disposable implements IInlin
 						n.div({
 							style: {
 								position: 'absolute',
-								...rectToProps(reader => layout.read(reader).originalLine.withMargin(1)),
+								...rectToProps(reader => layout.read(reader).originalLine.withMargin(BORDER_WIDTH)),
 								boxSizing: 'border-box',
 								borderRadius: '4px',
-								border: `${borderWidth}px solid ${originalBorderColor}`,
+								border: `${BORDER_WIDTH}px solid ${originalBorderColor}`,
 								background: asCssVariable(originalChangedTextOverlayColor),
 								pointerEvents: 'none',
 							}


### PR DESCRIPTION
```Copilot Generated Description:``` Ensure sufficient space at the end of the editor to render the nes widget

fixes https://github.com/microsoft/vscode/issues/258670