### PR TITLE
Fix incorrect rendering when file uses both spaces and tabs for indentation

### DIFF
--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsView.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsView.ts
@@ -90,7 +90,7 @@ export class InlineEditsView extends Disposable {
 			}
 
 			if (state.kind === InlineCompletionViewKind.SideBySide) {
-				const indentationAdjustmentEdit = createReindentEdit(newText, inlineEdit.modifiedLineRange);
+				const indentationAdjustmentEdit = createReindentEdit(newText, inlineEdit.modifiedLineRange, textModel.getOptions().tabSize);
 				newText = indentationAdjustmentEdit.applyToString(newText);
 
 				mappings = applyEditToModifiedRangeMappings(mappings, indentationAdjustmentEdit);

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/utils/utils.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/utils/utils.ts
@@ -10,7 +10,7 @@ import { findFirstMin } from '../../../../../../../base/common/arraysFind.js';
 import { DisposableStore, toDisposable } from '../../../../../../../base/common/lifecycle.js';
 import { derived, derivedObservableWithCache, derivedOpts, IObservable, IReader, observableValue, transaction } from '../../../../../../../base/common/observable.js';
 import { OS } from '../../../../../../../base/common/platform.js';
-import { getIndentationLength, splitLines } from '../../../../../../../base/common/strings.js';
+import { splitLines } from '../../../../../../../base/common/strings.js';
 import { URI } from '../../../../../../../base/common/uri.js';
 import { MenuEntryActionViewItem } from '../../../../../../../platform/actions/browser/menuEntryActionViewItem.js';
 import { ICodeEditor } from '../../../../../../browser/editorBrowser.js';
@@ -26,6 +26,8 @@ import { TextReplacement, TextEdit } from '../../../../../../common/core/edits/t
 import { RangeMapping } from '../../../../../../common/diff/rangeMapping.js';
 import { ITextModel } from '../../../../../../common/model.js';
 import { indentOfLine } from '../../../../../../common/model/textModel.js';
+import { CharCode } from '../../../../../../../base/common/charCode.js';
+import { BugIndicatingError } from '../../../../../../../base/common/errors.js';
 
 export function maxContentWidthInRange(editor: ObservableCodeEditor, range: LineRange, reader: IReader | undefined): number {
 	editor.layoutInfo.read(reader);
@@ -183,12 +185,51 @@ function offsetRangeToRange(columnOffsetRange: OffsetRange, startPos: Position):
 	);
 }
 
-export function createReindentEdit(text: string, range: LineRange): TextEdit {
+/**
+ * Calculates the indentation size (in spaces) of a given line,
+ * interpreting tabs as the specified tab size.
+ */
+function getIndentationSize(line: string, tabSize: number): number {
+	let currentSize = 0;
+	loop: for (let i = 0, len = line.length; i < len; i++) {
+		switch (line.charCodeAt(i)) {
+			case CharCode.Tab: currentSize += tabSize; break;
+			case CharCode.Space: currentSize++; break;
+			default: break loop;
+		}
+	}
+	// if currentSize % tabSize !== 0,
+	// then there are spaces which are not part of the indentation
+	return currentSize - (currentSize % tabSize);
+}
+
+/**
+ * Calculates the number of characters at the start of a line that correspond to a given indentation size,
+ * taking into account both tabs and spaces.
+ */
+function indentSizeToIndentLength(line: string, indentSize: number, tabSize: number): number {
+	let remainingSize = indentSize - (indentSize % tabSize);
+	let i = 0;
+	for (; i < line.length; i++) {
+		if (remainingSize === 0) {
+			break;
+		}
+		switch (line.charCodeAt(i)) {
+			case CharCode.Tab: remainingSize -= tabSize; break;
+			case CharCode.Space: remainingSize--; break;
+			default: throw new BugIndicatingError('Unexpected character found while calculating indent length');
+		}
+	}
+	return i;
+}
+
+export function createReindentEdit(text: string, range: LineRange, tabSize: number): TextEdit {
 	const newLines = splitLines(text);
 	const edits: TextReplacement[] = [];
-	const minIndent = findFirstMin(range.mapToLineArray(l => getIndentationLength(newLines[l - 1])), numberComparator)!;
+	const minIndentSize = findFirstMin(range.mapToLineArray(l => getIndentationSize(newLines[l - 1], tabSize)), numberComparator)!;
 	range.forEach(lineNumber => {
-		edits.push(new TextReplacement(offsetRangeToRange(new OffsetRange(0, minIndent), new Position(lineNumber, 1)), ''));
+		const indentLength = indentSizeToIndentLength(newLines[lineNumber - 1], minIndentSize, tabSize);
+		edits.push(new TextReplacement(offsetRangeToRange(new OffsetRange(0, indentLength), new Position(lineNumber, 1)), ''));
 	});
 	return new TextEdit(edits);
 }


### PR DESCRIPTION
```Copilot Generated Description:``` Adjust the `createReindentEdit` function to accept a `tabSize` parameter for proper indentation handling. Introduce helper functions to calculate indentation size and convert it to the corresponding length, ensuring accurate reindentation in mixed indentation scenarios.

Fixes https://github.com/microsoft/vscode-copilot-issues/issues/163