### PR TITLE
Workaround electron proxy issues for GitHub by allowing to switch to node's fetch

### DIFF
--- a/extensions/github-authentication/package.json
+++ b/extensions/github-authentication/package.json
@@ -55,6 +55,12 @@
           "type": "string",
           "markdownDescription": "%config.github-enterprise.uri.description%",
           "pattern": "^(?:$|(https?)://(?!github\\.com).*)"
+        },
+        "github-authentication.useElectronFetch": {
+          "type": "boolean",
+          "default": true,
+          "scope": "application",
+          "markdownDescription": "%config.github-authentication.useElectronFetch.description%"
         }
       }
     }

--- a/extensions/github-authentication/package.nls.json
+++ b/extensions/github-authentication/package.nls.json
@@ -2,5 +2,6 @@
 	"displayName": "GitHub Authentication",
 	"description": "GitHub Authentication Provider",
 	"config.github-enterprise.title": "GHE.com & GitHub Enterprise Server Authentication",
-	"config.github-enterprise.uri.description": "The URI for your GHE.com or GitHub Enterprise Server instance.\n\nExamples:\n* GHE.com: `https://octocat.ghe.com`\n* GitHub Enterprise Server: `https://github.octocat.com`\n\n> **Note:** This should _not_ be set to a GitHub.com URI. If your account exists on GitHub.com or is a GitHub Enterprise Managed User, you do not need any additional configuration and can simply log in to GitHub."
+	"config.github-enterprise.uri.description": "The URI for your GHE.com or GitHub Enterprise Server instance.\n\nExamples:\n* GHE.com: `https://octocat.ghe.com`\n* GitHub Enterprise Server: `https://github.octocat.com`\n\n> **Note:** This should _not_ be set to a GitHub.com URI. If your account exists on GitHub.com or is a GitHub Enterprise Managed User, you do not need any additional configuration and can simply log in to GitHub.",
+	"config.github-authentication.useElectronFetch.description": "When true, uses Electron's built-in fetch function for HTTP requests. When false, uses the Node.js global fetch function. This setting only applies when running in the Electron environment. **Note:** A restart is required for this setting to take effect."
 }

--- a/extensions/github-authentication/src/extension.ts
+++ b/extensions/github-authentication/src/extension.ts
@@ -79,4 +79,21 @@ export function activate(context: vscode.ExtensionContext) {
 			}
 		}
 	}));
+
+	// Listener to prompt for reload when the fetch implementation setting changes
+	context.subscriptions.push(vscode.workspace.onDidChangeConfiguration(async e => {
+		if (e.affectsConfiguration('github-authentication.useElectronFetch')) {
+			const selection = await vscode.window.showInformationMessage(
+				vscode.l10n.t('GitHub Authentication - Reload required'),
+				{
+					modal: true,
+					detail: vscode.l10n.t('A reload is required for the fetch setting change to take effect.')
+				},
+				vscode.l10n.t('Reload Window')
+			);
+			if (selection) {
+				await vscode.commands.executeCommand('workbench.action.reloadWindow');
+			}
+		}
+	}));
 }

--- a/extensions/github-authentication/src/node/fetch.ts
+++ b/extensions/github-authentication/src/node/fetch.ts
@@ -3,10 +3,19 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { workspace } from 'vscode';
+
 let _fetch: typeof fetch;
-try {
-	_fetch = require('electron').net.fetch;
-} catch {
+
+const useElectronFetch = workspace.getConfiguration('github-authentication').get<boolean>('useElectronFetch', true);
+if (useElectronFetch) {
+	try {
+		_fetch = require('electron').net.fetch;
+	} catch {
+		_fetch = fetch;
+	}
+} else {
 	_fetch = fetch;
 }
+
 export const fetching = _fetch;


### PR DESCRIPTION
A user reported that their proxy ZScaller has issues with Electron's fetch. More research needs to be done to understand why this is not playing nice wholistically...

... but, to unblock GitHub scenarios like Copilot, we add this setting to change the implementation of fetch used.

At some point, we need to have http.useElectronFetch setting be enabled by default and when that happens, this setting can be removed in favor of that.

cc @chrmarti @alexdima

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
