### PR TITLE
Disable none shell integration message

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/runInTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/runInTerminalTool.ts
@@ -400,7 +400,6 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 				switch (toolTerminal.shellIntegrationQuality) {
 					case ShellIntegrationQuality.None: {
 						strategy = this._instantiationService.createInstance(NoneExecuteStrategy, toolTerminal.instance);
-						toolResultMessage = new MarkdownString('Enable [shell integration](https://code.visualstudio.com/docs/terminal/shell-integration) to improve command detection');
 						break;
 					}
 					case ShellIntegrationQuality.Basic: {


### PR DESCRIPTION
Part of #260880

This is a minimal defensive fix for #260880 where we just disable the message about no shell integration.

This is another hard to reproduce and verify problem and the actual suspected fix is much riskier in a pretty critical part of code that runs before every new chat terminal is created: https://github.com/microsoft/vscode/pull/261202. Right now telemetry shows similar numbers for no shell integration in the old extension tool and the new core one, so this is the safest approach and we can look into the impact of "the real" fix in Insiders.