### PR TITLE
show desktop about details even when using custom dialogs

### DIFF
--- a/src/vs/platform/dialogs/browser/dialog.ts
+++ b/src/vs/platform/dialogs/browser/dialog.ts
@@ -6,9 +6,12 @@
 import { EventHelper } from '../../../base/browser/dom.js';
 import { StandardKeyboardEvent } from '../../../base/browser/keyboardEvent.js';
 import { IDialogOptions } from '../../../base/browser/ui/dialog/dialog.js';
+import { fromNow } from '../../../base/common/date.js';
+import { localize } from '../../../nls.js';
 import { IKeybindingService } from '../../keybinding/common/keybinding.js';
 import { ResultKind } from '../../keybinding/common/keybindingResolver.js';
 import { ILayoutService } from '../../layout/browser/layoutService.js';
+import { IProductService } from '../../product/common/productService.js';
 import { defaultButtonStyles, defaultCheckboxStyles, defaultInputBoxStyles, defaultDialogStyles } from '../../theme/browser/defaultStyles.js';
 
 const defaultDialogAllowableCommands = [
@@ -39,3 +42,25 @@ export function createWorkbenchDialogOptions(options: Partial<IDialogOptions>, k
 		...options
 	};
 }
+
+export function createBrowserAboutDialogDetails(productService: IProductService): { title: string; details: string; detailsToCopy: string } {
+	const detailString = (useAgo: boolean): string => {
+		return localize('aboutDetail',
+			"Version: {0}\nCommit: {1}\nDate: {2}\nBrowser: {3}",
+			productService.version || 'Unknown',
+			productService.commit || 'Unknown',
+			productService.date ? `${productService.date}${useAgo ? ' (' + fromNow(new Date(productService.date), true) + ')' : ''}` : 'Unknown',
+			navigator.userAgent
+		);
+	};
+
+	const details = detailString(true);
+	const detailsToCopy = detailString(false);
+
+	return {
+		title: productService.nameLong,
+		details: details,
+		detailsToCopy: detailsToCopy
+	};
+}
+

--- a/src/vs/platform/dialogs/common/dialogs.ts
+++ b/src/vs/platform/dialogs/common/dialogs.ts
@@ -310,7 +310,7 @@ export interface IDialogHandler {
 	/**
 	 * Present the about dialog to the user.
 	 */
-	about(): Promise<void>;
+	about(title: string, details: string, detailsToCopy: string): Promise<void>;
 }
 
 enum DialogKind {
@@ -440,7 +440,7 @@ export abstract class AbstractDialogHandler implements IDialogHandler {
 	abstract confirm(confirmation: IConfirmation): Promise<IConfirmationResult>;
 	abstract input(input: IInput): Promise<IInputResult>;
 	abstract prompt<T>(prompt: IPrompt<T>): Promise<IAsyncPromptResult<T>>;
-	abstract about(): Promise<void>;
+	abstract about(title: string, details: string, detailsToCopy: string): Promise<void>;
 }
 
 /**

--- a/src/vs/platform/dialogs/electron-browser/dialog.ts
+++ b/src/vs/platform/dialogs/electron-browser/dialog.ts
@@ -1,0 +1,44 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { fromNow } from '../../../base/common/date.js';
+import { isLinuxSnap } from '../../../base/common/platform.js';
+import { localize } from '../../../nls.js';
+import { IOSProperties } from '../../native/common/native.js';
+import { IProductService } from '../../product/common/productService.js';
+import { process } from '../../../base/parts/sandbox/electron-browser/globals.js';
+
+export function createNativeAboutDialogDetails(productService: IProductService, osProps: IOSProperties): { title: string; details: string; detailsToCopy: string } {
+	let version = productService.version;
+	if (productService.target) {
+		version = `${version} (${productService.target} setup)`;
+	} else if (productService.darwinUniversalAssetId) {
+		version = `${version} (Universal)`;
+	}
+
+	const getDetails = (useAgo: boolean): string => {
+		return localize({ key: 'aboutDetail', comment: ['Electron, Chromium, Node.js and V8 are product names that need no translation'] },
+			"Version: {0}\nCommit: {1}\nDate: {2}\nElectron: {3}\nElectronBuildId: {4}\nChromium: {5}\nNode.js: {6}\nV8: {7}\nOS: {8}",
+			version,
+			productService.commit || 'Unknown',
+			productService.date ? `${productService.date}${useAgo ? ' (' + fromNow(new Date(productService.date), true) + ')' : ''}` : 'Unknown',
+			process.versions['electron'],
+			process.versions['microsoft-build'],
+			process.versions['chrome'],
+			process.versions['node'],
+			process.versions['v8'],
+			`${osProps.type} ${osProps.arch} ${osProps.release}${isLinuxSnap ? ' snap' : ''}`
+		);
+	};
+
+	const details = getDetails(true);
+	const detailsToCopy = getDetails(false);
+
+	return {
+		title: productService.nameLong,
+		details: details,
+		detailsToCopy: detailsToCopy
+	};
+}

--- a/src/vs/workbench/browser/parts/dialogs/dialog.web.contribution.ts
+++ b/src/vs/workbench/browser/parts/dialogs/dialog.web.contribution.ts
@@ -17,6 +17,7 @@ import { Disposable } from '../../../../base/common/lifecycle.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { Lazy } from '../../../../base/common/lazy.js';
 import { IOpenerService } from '../../../../platform/opener/common/opener.js';
+import { createBrowserAboutDialogDetails } from '../../../../platform/dialogs/browser/dialog.js';
 
 export class DialogHandlerContribution extends Disposable implements IWorkbenchContribution {
 
@@ -33,13 +34,13 @@ export class DialogHandlerContribution extends Disposable implements IWorkbenchC
 		@ILayoutService layoutService: ILayoutService,
 		@IKeybindingService keybindingService: IKeybindingService,
 		@IInstantiationService instantiationService: IInstantiationService,
-		@IProductService productService: IProductService,
+		@IProductService private productService: IProductService,
 		@IClipboardService clipboardService: IClipboardService,
 		@IOpenerService openerService: IOpenerService
 	) {
 		super();
 
-		this.impl = new Lazy(() => new BrowserDialogHandler(logService, layoutService, keybindingService, instantiationService, productService, clipboardService, openerService));
+		this.impl = new Lazy(() => new BrowserDialogHandler(logService, layoutService, keybindingService, instantiationService, clipboardService, openerService));
 
 		this.model = (this.dialogService as DialogService).model;
 
@@ -68,7 +69,8 @@ export class DialogHandlerContribution extends Disposable implements IWorkbenchC
 					const args = this.currentDialog.args.promptArgs;
 					result = await this.impl.value.prompt(args.prompt);
 				} else {
-					await this.impl.value.about();
+					const aboutDialogDetails = createBrowserAboutDialogDetails(this.productService);
+					await this.impl.value.about(aboutDialogDetails.title, aboutDialogDetails.details, aboutDialogDetails.detailsToCopy);
 				}
 			} catch (error) {
 				result = error;

--- a/src/vs/workbench/browser/parts/dialogs/dialogHandler.ts
+++ b/src/vs/workbench/browser/parts/dialogs/dialogHandler.ts
@@ -11,9 +11,7 @@ import Severity from '../../../../base/common/severity.js';
 import { Dialog, IDialogResult } from '../../../../base/browser/ui/dialog/dialog.js';
 import { DisposableStore } from '../../../../base/common/lifecycle.js';
 import { IKeybindingService } from '../../../../platform/keybinding/common/keybinding.js';
-import { IProductService } from '../../../../platform/product/common/productService.js';
 import { IClipboardService } from '../../../../platform/clipboard/common/clipboardService.js';
-import { fromNow } from '../../../../base/common/date.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { MarkdownRenderer, openLinkFromMarkdown } from '../../../../editor/browser/widget/markdownRenderer/browser/markdownRenderer.js';
 import { IOpenerService } from '../../../../platform/opener/common/opener.js';
@@ -37,7 +35,6 @@ export class BrowserDialogHandler extends AbstractDialogHandler {
 		@ILayoutService private readonly layoutService: ILayoutService,
 		@IKeybindingService private readonly keybindingService: IKeybindingService,
 		@IInstantiationService instantiationService: IInstantiationService,
-		@IProductService private readonly productService: IProductService,
 		@IClipboardService private readonly clipboardService: IClipboardService,
 		@IOpenerService private readonly openerService: IOpenerService
 	) {
@@ -76,33 +73,21 @@ export class BrowserDialogHandler extends AbstractDialogHandler {
 		return { confirmed: button === 0, checkboxChecked, values };
 	}
 
-	async about(): Promise<void> {
-		const detailString = (useAgo: boolean): string => {
-			return localize('aboutDetail',
-				"Version: {0}\nCommit: {1}\nDate: {2}\nBrowser: {3}",
-				this.productService.version || 'Unknown',
-				this.productService.commit || 'Unknown',
-				this.productService.date ? `${this.productService.date}${useAgo ? ' (' + fromNow(new Date(this.productService.date), true) + ')' : ''}` : 'Unknown',
-				navigator.userAgent
-			);
-		};
-
-		const detail = detailString(true);
-		const detailToCopy = detailString(false);
+	async about(title: string, details: string, detailsToCopy: string): Promise<void> {
 
 		const { button } = await this.doShow(
 			Severity.Info,
-			this.productService.nameLong,
+			title,
 			[
 				localize({ key: 'copy', comment: ['&& denotes a mnemonic'] }, "&&Copy"),
 				localize('ok', "OK")
 			],
-			detail,
+			details,
 			1
 		);
 
 		if (button === 0) {
-			this.clipboardService.writeText(detailToCopy);
+			this.clipboardService.writeText(detailsToCopy);
 		}
 	}
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Historically the about dialogs created their details themselves meaning they could only display details available in their layer. Now, about takes the detail information and we can calculate desktop details for both custom(html) and native dialogs.

<img width="858" height="589" alt="image" src="https://github.com/user-attachments/assets/9603f673-c107-43c5-81c5-e2cd09774754" />

This was always a pet peeve of mine since I use custom and I often use about to check our current node and electron version.