### PR TITLE
chat: refine todo list tool description

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -532,7 +532,7 @@ configurationRegistry.registerConfiguration({
 		'chat.todoListTool.enabled': {
 			type: 'boolean',
 			default: false,
-			description: nls.localize('chat.todoListTool.enabled', "Enables todo lists in chat. This tool allows you to use todo lists in chat."),
+			description: nls.localize('chat.todoListTool.enabled', "Enables todo lists in chat, which the agent uses as tool for planning, progress tracking, and context management for complex development workflows."),
 			tags: ['experimental'],
 			experiment: {
 				mode: 'startup'

--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -532,7 +532,7 @@ configurationRegistry.registerConfiguration({
 		'chat.todoListTool.enabled': {
 			type: 'boolean',
 			default: false,
-			description: nls.localize('chat.todoListTool.enabled', "Enables todo lists in chat, which the agent uses as tool for planning, progress tracking, and context management for complex development workflows."),
+			description: nls.localize('chat.todoListTool.enabled', "Enables todo lists in chat, which the agent uses as a tool for planning, progress tracking, and context management for complex development workflows."),
 			tags: ['experimental'],
 			experiment: {
 				mode: 'startup'


### PR DESCRIPTION
This PR updates the configuration description for `chat.todoListTool.enabled`:

- Clarifies the purpose: explains it enables structured todo lists used by the chat agent for planning, tracking progress, and managing context in more complex development workflows.