### PR TITLE
Disable js/ts for `chat-editing-text-model` files

### DIFF
--- a/extensions/typescript-language-features/src/configuration/fileSchemes.ts
+++ b/extensions/typescript-language-features/src/configuration/fileSchemes.ts
@@ -11,6 +11,7 @@ export const untitled = 'untitled';
 export const git = 'git';
 export const github = 'github';
 export const azurerepos = 'azurerepos';
+export const chatEditingTextModel = 'chat-editing-text-model';
 
 /** Live share scheme */
 export const vsls = 'vsls';
@@ -50,6 +51,7 @@ export const disabledSchemes = new Set([
 	vsls,
 	github,
 	azurerepos,
+	chatEditingTextModel,
 ]);
 
 export function isOfScheme(uri: vscode.Uri, ...schemes: string[]): boolean {


### PR DESCRIPTION
I don't think these need to be synced over and may be causing problems for some ts plugins 