### PR TITLE
Hook up API for `earliestShownDateTime`

### DIFF
--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -4363,6 +4363,8 @@ export interface IInlineSuggestOptions {
 
 	suppressSuggestions?: boolean;
 
+	minimalDelay?: number;
+
 	/**
 	 * Does not clear active inline suggestions when the editor loses focus.
 	 */
@@ -4424,6 +4426,7 @@ class InlineEditorSuggest extends BaseEditorOption<EditorOption.inlineSuggest, I
 			keepOnBlur: false,
 			fontFamily: 'default',
 			syntaxHighlightingEnabled: true,
+			minimalDelay: 0,
 			edits: {
 				enabled: true,
 				showCollapsed: false,
@@ -4464,6 +4467,13 @@ class InlineEditorSuggest extends BaseEditorOption<EditorOption.inlineSuggest, I
 					type: 'boolean',
 					default: defaults.suppressSuggestions,
 					description: nls.localize('inlineSuggest.suppressSuggestions', "Controls how inline suggestions interact with the suggest widget. If enabled, the suggest widget is not shown automatically when inline suggestions are available.")
+				},
+				'editor.inlineSuggest.minimalDelay': {
+					type: 'number',
+					default: 0,
+					minimum: 0,
+					maximum: 10000,
+					description: nls.localize('inlineSuggest.minimalDelay', "Controls the minimal delay in milliseconds after which inline suggestions are shown after typing."),
 				},
 				'editor.inlineSuggest.experimental.suppressInlineSuggestions': {
 					type: 'string',
@@ -4529,6 +4539,7 @@ class InlineEditorSuggest extends BaseEditorOption<EditorOption.inlineSuggest, I
 			keepOnBlur: boolean(input.keepOnBlur, this.defaultValue.keepOnBlur),
 			fontFamily: EditorStringOption.string(input.fontFamily, this.defaultValue.fontFamily),
 			syntaxHighlightingEnabled: boolean(input.syntaxHighlightingEnabled, this.defaultValue.syntaxHighlightingEnabled),
+			minimalDelay: EditorIntOption.clampedInt(input.minimalDelay, 0, 0, 10000),
 			edits: {
 				enabled: boolean(input.edits?.enabled, this.defaultValue.edits.enabled),
 				showCollapsed: boolean(input.edits?.showCollapsed, this.defaultValue.edits.showCollapsed),

--- a/src/vs/editor/common/languages.ts
+++ b/src/vs/editor/common/languages.ts
@@ -758,6 +758,7 @@ export interface InlineCompletionContext {
 	readonly includeInlineEdits: boolean;
 	readonly includeInlineCompletions: boolean;
 	readonly requestIssuedDateTime: number;
+	readonly earliestShownDateTime: number;
 }
 
 export class SelectedSuggestionInfo {

--- a/src/vs/editor/contrib/inlineCompletions/browser/model/inlineCompletionsModel.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/model/inlineCompletionsModel.ts
@@ -96,6 +96,7 @@ export class InlineCompletionsModel extends Disposable {
 	private readonly _inlineEditsEnabled;
 	private readonly _inlineEditsShowCollapsedEnabled;
 	private readonly _triggerCommandOnProviderChange;
+	private readonly _minimalDelay;
 
 	constructor(
 		public readonly textModel: ITextModel,
@@ -125,6 +126,7 @@ export class InlineCompletionsModel extends Disposable {
 		this._inlineEditsEnabled = this._editorObs.getOption(EditorOption.inlineSuggest).map(v => !!v.edits.enabled);
 		this._inlineEditsShowCollapsedEnabled = this._editorObs.getOption(EditorOption.inlineSuggest).map(s => s.edits.showCollapsed);
 		this._triggerCommandOnProviderChange = this._editorObs.getOption(EditorOption.inlineSuggest).map(s => s.experimental.triggerCommandOnProviderChange);
+		this._minimalDelay = this._editorObs.getOption(EditorOption.inlineSuggest).map(s => s.minimalDelay);
 		this._typing = this._register(new TypingInterval(this.textModel));
 
 		this._register(this._inlineCompletionsService.onDidChangeIsSnoozing((isSnoozing) => {
@@ -388,6 +390,7 @@ export class InlineCompletionsModel extends Disposable {
 			includeInlineCompletions: !changeSummary.onlyRequestInlineEdits,
 			includeInlineEdits: this._inlineEditsEnabled.read(reader),
 			requestIssuedDateTime: requestInfo.startTime,
+			earliestShownDateTime: requestInfo.startTime + this._minimalDelay.get(),
 		};
 
 		if (context.triggerKind === InlineCompletionTriggerKind.Automatic && changeSummary.textChange) {

--- a/src/vs/editor/contrib/suggest/test/browser/suggestInlineCompletions.test.ts
+++ b/src/vs/editor/contrib/suggest/test/browser/suggestInlineCompletions.test.ts
@@ -75,7 +75,7 @@ suite('Suggest Inline Completions', function () {
 
 	ensureNoDisposablesAreLeakedInTestSuite();
 
-	const context: InlineCompletionContext = { triggerKind: InlineCompletionTriggerKind.Explicit, selectedSuggestionInfo: undefined, includeInlineCompletions: true, includeInlineEdits: false, requestUuid: generateUuid(), requestIssuedDateTime: 0 };
+	const context: InlineCompletionContext = { triggerKind: InlineCompletionTriggerKind.Explicit, selectedSuggestionInfo: undefined, includeInlineCompletions: true, includeInlineEdits: false, requestUuid: generateUuid(), requestIssuedDateTime: 0, earliestShownDateTime: 0 };
 
 	test('Aggressive inline completions when typing within line #146948', async function () {
 

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -4769,6 +4769,7 @@ declare namespace monaco.editor {
 		showToolbar?: 'always' | 'onHover' | 'never';
 		syntaxHighlightingEnabled?: boolean;
 		suppressSuggestions?: boolean;
+		minimalDelay?: number;
 		/**
 		 * Does not clear active inline suggestions when the editor loses focus.
 		 */
@@ -7469,6 +7470,7 @@ declare namespace monaco.languages {
 		readonly includeInlineEdits: boolean;
 		readonly includeInlineCompletions: boolean;
 		readonly requestIssuedDateTime: number;
+		readonly earliestShownDateTime: number;
 	}
 
 	export class SelectedSuggestionInfo {

--- a/src/vs/workbench/api/common/extHostLanguageFeatures.ts
+++ b/src/vs/workbench/api/common/extHostLanguageFeatures.ts
@@ -1376,6 +1376,7 @@ class InlineCompletionAdapter {
 			triggerKind: this.languageTriggerKindToVSCodeTriggerKind[context.triggerKind],
 			requestUuid: context.requestUuid,
 			requestIssuedDateTime: context.requestIssuedDateTime,
+			earliestShownDateTime: context.earliestShownDateTime,
 		}, token);
 
 		if (!result) {

--- a/src/vscode-dts/vscode.proposed.inlineCompletionsAdditions.d.ts
+++ b/src/vscode-dts/vscode.proposed.inlineCompletionsAdditions.d.ts
@@ -156,6 +156,8 @@ declare module 'vscode' {
 		readonly requestUuid: string;
 
 		readonly requestIssuedDateTime: number;
+
+		readonly earliestShownDateTime: number;
 	}
 
 	export interface PartialAcceptInfo {


### PR DESCRIPTION
```Copilot Generated Description:``` Introduce the `earliestShownDateTime` property to the inline completion context and related classes, enabling tracking of the earliest time inline suggestions can be displayed. Additionally, add a `minimalDelay` option to control the delay before showing inline suggestions.

This not actually implemented but adds the setting and the API property