### PR TITLE
Ignore a few more files for web

### DIFF
--- a/build/.webignore
+++ b/build/.webignore
@@ -3,8 +3,10 @@
 **/*.txt
 **/*.json
 **/*.md
+**/*.ts
 **/*.d.ts
 **/*.js.map
+**/*.mjs.map
 **/LICENSE
 **/CONTRIBUTORS
 
@@ -28,6 +30,9 @@ vscode-textmate/webpack.config.js
 
 @xterm/addon-ligatures/src/**
 @xterm/addon-ligatures/out/**
+
+@xterm/addon-progress/src/**
+@xterm/addon-progress/out/**
 
 @xterm/addon-search/src/**
 @xterm/addon-search/out/**


### PR DESCRIPTION
`node_modules` should skip `.ts` or `.map` files
