### PR TITLE
Wire up the mode (ask, edit, agent or custom) to `reportEditArc`

### DIFF
--- a/src/vs/editor/common/textModelEditSource.ts
+++ b/src/vs/editor/common/textModelEditSource.ts
@@ -91,13 +91,14 @@ export const EditSources = {
 
 	rename: () => createEditSource({ source: 'rename' } as const),
 
-	chatApplyEdits(data: { modelId: string | undefined; sessionId: string | undefined; requestId: string | undefined; languageId: string }) {
+	chatApplyEdits(data: { modelId: string | undefined; sessionId: string | undefined; requestId: string | undefined; languageId: string; mode: string | undefined }) {
 		return createEditSource({
 			source: 'Chat.applyEdits',
 			$modelId: avoidPathRedaction(data.modelId),
 			$$languageId: data.languageId,
 			$$sessionId: data.sessionId,
 			$$requestId: data.requestId,
+			$$mode: data.mode,
 		} as const);
 	},
 

--- a/src/vs/workbench/contrib/chat/browser/actions/chatExecuteActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatExecuteActions.ts
@@ -595,6 +595,7 @@ export class CreateRemoteAgentJobAction extends Action2 {
 				parsedRequest,
 				{ variables: [] },
 				0,
+				undefined,
 				defaultAgent,
 			);
 

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/chatConfirmationContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/chatConfirmationContentPart.ts
@@ -55,7 +55,7 @@ export class ChatConfirmationContentPart extends Disposable implements IChatCont
 				options.confirmation = e.label;
 				const widget = chatWidgetService.getWidgetBySessionId(element.sessionId);
 				options.userSelectedModelId = widget?.input.currentLanguageModel;
-				options.mode = widget?.input.currentModeKind;
+				options.modeInfo = widget?.input.currentModeInfo;
 				Object.assign(options, widget?.getModeRequestOptions());
 
 				if (await this.chatService.sendRequest(element.sessionId, prompt, options)) {

--- a/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingTextModelChangeService.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingTextModelChangeService.ts
@@ -172,7 +172,19 @@ export class ChatEditingTextModelChangeService extends Disposable {
 		const sessionId = responseModel.session.sessionId;
 		const request = responseModel.session.getRequests().at(-1);
 		const languageId = this.modifiedModel.getLanguageId();
-		const source = EditSources.chatApplyEdits({ modelId: request?.modelId, requestId: request?.id, sessionId: sessionId, languageId });
+		const mode: 'ask' | 'agent' | 'edit' | 'custom' | undefined = (
+			(request?.modeInfo && !request.modeInfo.isBuiltin)
+				? 'custom'
+				: request?.modeInfo?.kind
+		);
+
+		const source = EditSources.chatApplyEdits({
+			modelId: request?.modelId,
+			requestId: request?.id,
+			sessionId: sessionId,
+			languageId,
+			mode
+		});
 
 		if (isAtomicEdits) {
 			// EDIT and DONE

--- a/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
@@ -104,6 +104,7 @@ import { IModelPickerDelegate, ModelPickerActionItem } from './modelPicker/model
 import { IModePickerDelegate, ModePickerActionItem } from './modelPicker/modePickerActionItem.js';
 import { isEqual } from '../../../../base/common/resources.js';
 import { isLocation } from '../../../../editor/common/languages.js';
+import { IChatRequestModeInfo } from '../common/chatModel.js';
 
 const $ = dom.$;
 
@@ -307,6 +308,15 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 
 	public get currentModeObs(): IObservable<IChatMode> {
 		return this._currentModeObservable;
+	}
+
+	public get currentModeInfo(): IChatRequestModeInfo {
+		const mode = this._currentModeObservable.get();
+		return {
+			kind: this.currentModeKind,
+			isBuiltin: mode.isBuiltin,
+			instructions: mode.body?.get()
+		};
 	}
 
 	private cachedDimensions: dom.Dimension | undefined;

--- a/src/vs/workbench/contrib/chat/browser/chatMarkdownDecorationsRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatMarkdownDecorationsRenderer.ts
@@ -195,7 +195,7 @@ export class ChatMarkdownDecorationsRenderer {
 						location: widget.location,
 						agentId: agent.id,
 						userSelectedModelId: widget.input.currentLanguageModel,
-						mode: widget.input.currentModeKind
+						modeInfo: widget.input.currentModeInfo
 					});
 			}));
 		} else {
@@ -232,7 +232,7 @@ export class ChatMarkdownDecorationsRenderer {
 				agentId: agent.id,
 				slashCommand: args.command,
 				userSelectedModelId: widget.input.currentLanguageModel,
-				mode: widget.input.currentModeKind
+				modeInfo: widget.input.currentModeInfo
 			});
 		}));
 

--- a/src/vs/workbench/contrib/chat/browser/chatSetup.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSetup.ts
@@ -274,14 +274,14 @@ class SetupAgent extends Disposable implements IChatAgentImplementation {
 
 	private async doForwardRequestToCopilotWhenReady(requestModel: IChatRequestModel, progress: (part: IChatProgress) => void, chatService: IChatService, languageModelsService: ILanguageModelsService, chatAgentService: IChatAgentService, chatWidgetService: IChatWidgetService, languageModelToolsService: ILanguageModelToolsService): Promise<void> {
 		const widget = chatWidgetService.getWidgetBySessionId(requestModel.session.sessionId);
-		const mode = widget?.input.currentModeKind;
+		const modeInfo = widget?.input.currentModeInfo;
 		const languageModel = widget?.input.currentLanguageModel;
 
 		// We need a signal to know when we can resend the request to
 		// Copilot. Waiting for the registration of the agent is not
 		// enough, we also need a language/tools model to be available.
 
-		const whenAgentReady = this.whenAgentReady(chatAgentService, mode);
+		const whenAgentReady = this.whenAgentReady(chatAgentService, modeInfo?.kind);
 		const whenLanguageModelReady = this.whenLanguageModelReady(languageModelsService);
 		const whenToolsModelReady = this.whenToolsModelReady(languageModelToolsService, requestModel);
 
@@ -325,7 +325,7 @@ class SetupAgent extends Disposable implements IChatAgentImplementation {
 
 		await chatService.resendRequest(requestModel, {
 			...widget?.getModeRequestOptions(),
-			mode,
+			modeInfo,
 			userSelectedModelId: languageModel,
 		});
 	}
@@ -479,6 +479,7 @@ class SetupAgent extends Disposable implements IChatAgentImplementation {
 			variableData: requestModel.variableData,
 			timestamp: Date.now(),
 			attempt: requestModel.attempt,
+			modeInfo: requestModel.modeInfo,
 			confirmation: requestModel.confirmation,
 			locationData: requestModel.locationData,
 			attachedContext: requestModel.attachedContext,
@@ -528,6 +529,7 @@ class SetupAgent extends Disposable implements IChatAgentImplementation {
 			variableData: variableData,
 			timestamp: Date.now(),
 			attempt: requestModel.attempt,
+			modeInfo: requestModel.modeInfo,
 			confirmation: requestModel.confirmation,
 			locationData: requestModel.locationData,
 			attachedContext: [chatRequestToolEntry],

--- a/src/vs/workbench/contrib/chat/browser/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatWidget.ts
@@ -1032,7 +1032,7 @@ export class ChatWidget extends Disposable implements IChatWidget {
 					attempt: request.attempt + 1,
 					location: this.location,
 					userSelectedModelId: this.input.currentLanguageModel,
-					mode: this.input.currentModeKind,
+					modeInfo: this.input.currentModeInfo,
 				};
 				this.chatService.resendRequest(request, options).catch(e => this.logService.error('FAILED to rerun request', e));
 			}
@@ -1854,7 +1854,7 @@ export class ChatWidget extends Disposable implements IChatWidget {
 				attachedContext: requestInputs.attachedContext.asArray(),
 				noCommandDetection: options?.noCommandDetection,
 				...this.getModeRequestOptions(),
-				modeInstructions: this.input.currentModeObs.get().body?.get()
+				modeInfo: this.input.currentModeInfo,
 			});
 
 			if (result) {
@@ -1887,7 +1887,7 @@ export class ChatWidget extends Disposable implements IChatWidget {
 
 	getModeRequestOptions(): Partial<IChatSendRequestOptions> {
 		return {
-			modeInstructions: this.input.currentModeObs.get().body?.get(),
+			modeInfo: this.input.currentModeInfo,
 			userSelectedTools: this.input.selectedToolsModel.enablementMap.map(map => {
 				const userSelectedTools: Record<string, boolean> = {};
 				for (const [tool, enablement] of map) {
@@ -1895,7 +1895,6 @@ export class ChatWidget extends Disposable implements IChatWidget {
 				}
 				return userSelectedTools;
 			}),
-			mode: this.input.currentModeKind,
 		};
 	}
 

--- a/src/vs/workbench/contrib/chat/common/chatModes.ts
+++ b/src/vs/workbench/contrib/chat/common/chatModes.ts
@@ -211,6 +211,7 @@ export interface IChatMode {
 	readonly id: string;
 	readonly name: string;
 	readonly description: IObservable<string | undefined>;
+	readonly isBuiltin: boolean;
 	readonly kind: ChatModeKind;
 	readonly customTools?: IObservable<readonly string[] | undefined>;
 	readonly model?: IObservable<string | undefined>;
@@ -247,6 +248,10 @@ export class CustomChatMode implements IChatMode {
 
 	get description(): IObservable<string | undefined> {
 		return this._descriptionObservable;
+	}
+
+	public get isBuiltin(): boolean {
+		return isBuiltinChatMode(this);
 	}
 
 	get customTools(): IObservable<readonly string[] | undefined> {
@@ -316,6 +321,10 @@ export class BuiltinChatMode implements IChatMode {
 		description: string
 	) {
 		this.description = observableValue('description', description);
+	}
+
+	public get isBuiltin(): boolean {
+		return isBuiltinChatMode(this);
 	}
 
 	get id(): string {

--- a/src/vs/workbench/contrib/chat/common/chatService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService.ts
@@ -18,7 +18,7 @@ import { createDecorator } from '../../../../platform/instantiation/common/insta
 import { ICellEditOperation } from '../../notebook/common/notebookCommon.js';
 import { IWorkspaceSymbol } from '../../search/common/search.js';
 import { IChatAgentCommand, IChatAgentData, IChatAgentResult } from './chatAgents.js';
-import { ChatModel, IChatModel, IChatRequestModel, IChatRequestVariableData, IChatResponseModel, IExportableChatData, ISerializableChatData } from './chatModel.js';
+import { ChatModel, IChatModel, IChatRequestModeInfo, IChatRequestModel, IChatRequestVariableData, IChatResponseModel, IExportableChatData, ISerializableChatData } from './chatModel.js';
 import { IParsedChatRequest } from './chatParserTypes.js';
 import { IChatParserContext } from './chatRequestParser.js';
 import { IChatRequestVariableEntry } from './chatVariableEntries.js';
@@ -610,10 +610,9 @@ export interface IChatTerminalLocationData {
 export type IChatLocationData = IChatEditorLocationData | IChatNotebookLocationData | IChatTerminalLocationData;
 
 export interface IChatSendRequestOptions {
-	mode?: ChatModeKind;
+	modeInfo?: IChatRequestModeInfo;
 	userSelectedModelId?: string;
 	userSelectedTools?: IObservable<Record<string, boolean>>;
-	modeInstructions?: string;
 	location?: ChatAgentLocation;
 	locationData?: IChatLocationData;
 	parserContext?: IChatParserContext;

--- a/src/vs/workbench/contrib/chat/test/common/chatModel.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/chatModel.test.ts
@@ -79,7 +79,7 @@ suite('ChatModel', () => {
 		const model1 = testDisposables.add(instantiationService.createInstance(ChatModel, undefined, ChatAgentLocation.Panel));
 
 		const text = 'hello';
-		const request1 = model1.addRequest({ text, parts: [new ChatRequestTextPart(new OffsetRange(0, text.length), new Range(1, text.length, 1, text.length), text)] }, { variables: [] }, 0, undefined, undefined, undefined, undefined, undefined, true);
+		const request1 = model1.addRequest({ text, parts: [new ChatRequestTextPart(new OffsetRange(0, text.length), new Range(1, text.length, 1, text.length), text)] }, { variables: [] }, 0, undefined, undefined, undefined, undefined, undefined, undefined, true);
 
 		assert.strictEqual(request1.isCompleteAddedRequest, true);
 		assert.strictEqual(request1.response!.isCompleteAddedRequest, true);

--- a/src/vs/workbench/contrib/editTelemetry/browser/telemetry/arcTelemetrySender.ts
+++ b/src/vs/workbench/contrib/editTelemetry/browser/telemetry/arcTelemetrySender.ts
@@ -129,6 +129,7 @@ export class ChatArcTelemetrySender extends Disposable {
 					requestId: string | undefined;
 					modelId: string | undefined;
 					languageId: string | undefined;
+					mode: string | undefined;
 
 					didBranchChange: number;
 					timeDelayMs: number;
@@ -150,6 +151,7 @@ export class ChatArcTelemetrySender extends Disposable {
 					requestId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The request id.' };
 					modelId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The model id.' };
 					languageId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The language id of the document.' };
+					mode: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The mode chat was in.' };
 
 					didBranchChange: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Indicates if the branch changed in the meantime. If the branch changed (value is 1); this event should probably be ignored.' };
 					timeDelayMs: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'The time delay between the user accepting the edit and measuring the survival rate.' };
@@ -175,6 +177,7 @@ export class ChatArcTelemetrySender extends Disposable {
 					requestId: data.props.$$requestId,
 					modelId: data.props.$modelId,
 					languageId: data.props.$$languageId,
+					mode: data.props.$$mode,
 
 					didBranchChange: res.didBranchChange ? 1 : 0,
 					timeDelayMs: res.timeDelayMs,


### PR DESCRIPTION
Fixes #261225

Combines `IChatSendRequestOptions`'s `mode` and `modeInstructions` into a single `modeInfo` property which also records if the mode is built-in or not. This is then funnelled to various places to be able to be used when applying edits to the text buffers.