### PR TITLE
When a task with problem matchers becomes idle, return those instead of using the LLM to evaluate the output

### DIFF
--- a/src/vs/workbench/contrib/tasks/common/taskService.ts
+++ b/src/vs/workbench/contrib/tasks/common/taskService.ts
@@ -8,7 +8,6 @@ import { Action } from '../../../../base/common/actions.js';
 import { Event } from '../../../../base/common/event.js';
 import { createDecorator } from '../../../../platform/instantiation/common/instantiation.js';
 import { IDisposable } from '../../../../base/common/lifecycle.js';
-
 import { IWorkspaceFolder, IWorkspace } from '../../../../platform/workspace/common/workspace.js';
 import { Task, ContributedTask, CustomTask, ITaskSet, TaskSorter, ITaskEvent, ITaskIdentifier, ConfiguringTask, TaskRunSource } from './tasks.js';
 import { ITaskSummary, ITaskTerminateResponse, ITaskSystemInfo } from './taskSystem.js';

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/bufferOutputPolling.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/bufferOutputPolling.ts
@@ -169,7 +169,7 @@ export async function pollForOutputAndIdle(
 					}
 				}
 				if (problemList.length === 0) {
-					return { terminalExecutionIdleBeforeTimeout, output: 'The task succeeded with no problems detected.' };
+					return { terminalExecutionIdleBeforeTimeout, output: 'The task succeeded with no problems.' };
 				}
 				return {
 					terminalExecutionIdleBeforeTimeout,

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/bufferOutputPolling.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/bufferOutputPolling.ts
@@ -14,6 +14,9 @@ import { IChatService } from '../../../chat/common/chatService.js';
 import { ChatMessageRole, ILanguageModelsService } from '../../../chat/common/languageModels.js';
 import { IToolInvocationContext } from '../../../chat/common/languageModelToolsService.js';
 import type { Terminal as RawXtermTerminal, IMarker as IXtermMarker } from '@xterm/xterm';
+import { Task } from '../../../tasks/common/taskService.js';
+import { IMarkerData, IMarkerService } from '../../../../../platform/markers/common/markers.js';
+import { ProblemMatcher, ProblemMatcherRegistry } from '../../../tasks/common/problemMatcher.js';
 
 export const enum PollingConsts {
 	MinNoDataEvents = 2, // Minimum number of no data checks before considering the terminal idle
@@ -34,7 +37,8 @@ export async function racePollingOrPrompt(
 	originalResult: { terminalExecutionIdleBeforeTimeout: boolean; output: string; pollDurationMs?: number; modelOutputEvalResponse?: string },
 	token: CancellationToken,
 	languageModelsService: ILanguageModelsService,
-	execution: { getOutput: () => string; isActive?: () => Promise<boolean> }
+	markerService: IMarkerService,
+	execution: { getOutput: () => string; isActive?: () => Promise<boolean>; task?: Task; beginsPattern?: string; endsPattern?: string; dependencyTasks?: Task[] }
 ): Promise<{ terminalExecutionIdleBeforeTimeout: boolean; output: string; pollDurationMs?: number; modelOutputEvalResponse?: string }> {
 	const pollPromise = pollFn();
 	const { promise: promptPromise, part } = promptFn();
@@ -63,7 +67,7 @@ export async function racePollingOrPrompt(
 		const promptResult = raceResult.result as boolean;
 		if (promptResult) {
 			// User accepted, poll again (extended)
-			return await pollForOutputAndIdle(execution, true, token, languageModelsService);
+			return await pollForOutputAndIdle(execution, true, token, languageModelsService, markerService);
 		} else {
 			return originalResult; // User rejected, return the original result
 		}
@@ -95,10 +99,12 @@ export function getOutput(terminal?: Pick<RawXtermTerminal, 'buffer'>, startMark
 }
 
 export async function pollForOutputAndIdle(
-	execution: { getOutput: () => string; isActive?: () => Promise<boolean> },
+	execution: { getOutput: () => string; isActive?: () => Promise<boolean>; task?: Pick<Task, 'configurationProperties'>; dependencyTasks?: Task[] },
 	extendedPolling: boolean,
 	token: CancellationToken,
-	languageModelsService: ILanguageModelsService,
+	languageModelsService: Pick<ILanguageModelsService, 'selectLanguageModels' | 'sendChatRequest'>,
+	markerService: Pick<IMarkerService, 'read'>,
+	knownMatchers?: ProblemMatcher[]
 ): Promise<{ terminalExecutionIdleBeforeTimeout: boolean; output: string; pollDurationMs?: number; modelOutputEvalResponse?: string }> {
 	const maxWaitMs = extendedPolling ? PollingConsts.ExtendedPollingMaxDuration : PollingConsts.FirstPollingMaxDuration;
 	const maxInterval = PollingConsts.MaxPollingIntervalDuration;
@@ -149,10 +155,40 @@ export async function pollForOutputAndIdle(
 				lastBufferLength = currentBufferLength;
 				continue;
 			}
-			terminalExecutionIdleBeforeTimeout = true;
-			const modelOutputEvalResponse = await assessOutputForErrors(buffer, token, languageModelsService);
-			return { modelOutputEvalResponse, terminalExecutionIdleBeforeTimeout, output: buffer, pollDurationMs: Date.now() - pollStartTime + (extendedPolling ? PollingConsts.FirstPollingMaxDuration : 0) };
 		}
+		terminalExecutionIdleBeforeTimeout = true;
+		if (execution.task) {
+			// const patterns = getTaskBeginEndPatternMap(execution.task, execution.dependencyTasks);
+			const problems = await getProblemsForTasks(execution.task, markerService, execution.dependencyTasks, knownMatchers);
+			if (problems) {
+				const problemList: string[] = [];
+				for (const [owner, problemArray] of problems.entries()) {
+					problemList.push(`Problems for task "${owner ?? 'unknown'}":`);
+					for (const p of problemArray) {
+						problemList.push(`Problem: ${p.message} (Code: ${p.code}, Severity: ${p.severity}, Range: [${p.startLineNumber},${p.startColumn}]-[${p.endLineNumber},${p.endColumn}], Target: ${typeof p.code === 'string' ? p.code : p.code?.value ?? 'unknown'})`);
+					}
+				}
+				return {
+					terminalExecutionIdleBeforeTimeout,
+					output: problemList.join('\n')
+				};
+			}
+			// else if (patterns.size) {
+			// 	for (const p of patterns.values()) {
+			// 		const beginsMatches = Array.from(buffer.matchAll(p.beginsPattern));
+			// 		const endsMatches = Array.from(buffer.matchAll(p.endsPattern));
+			// 		if (beginsMatches.length && endsMatches.length) {
+			// 			const lastBegin = beginsMatches[beginsMatches.length - 1];
+			// 			const lastEnd = endsMatches.filter(e => e.index! > lastBegin.index!).pop();
+			// 			if (lastBegin && lastEnd) {
+			// 				buffer = buffer.slice(lastBegin.index! + lastBegin[0].length, lastEnd.index);
+			// 			}
+			// 		}
+			// 	}
+			// }
+		}
+		const modelOutputEvalResponse = await assessOutputForErrors(buffer, token, languageModelsService);
+		return { modelOutputEvalResponse, terminalExecutionIdleBeforeTimeout, output: buffer, pollDurationMs: Date.now() - pollStartTime + (extendedPolling ? PollingConsts.FirstPollingMaxDuration : 0) };
 	}
 	return { terminalExecutionIdleBeforeTimeout: false, output: buffer, pollDurationMs: Date.now() - pollStartTime + (extendedPolling ? PollingConsts.FirstPollingMaxDuration : 0) };
 }
@@ -168,7 +204,7 @@ export function promptForMorePolling(command: string, token: CancellationToken, 
 			let part: ChatElicitationRequestPart | undefined = undefined;
 			const promise = new Promise<boolean>(resolve => {
 				const thePart = part = new ChatElicitationRequestPart(
-					new MarkdownString(localize('poll.terminal.waiting', "Continue waiting?")),
+					new MarkdownString(localize('poll.terminal.waiting', "Continue waiting for \`{0}\`?", command)),
 					new MarkdownString(localize('poll.terminal.polling', "This will continue to poll for output to determine when the terminal becomes idle for up to 2 minutes.")),
 					'',
 					localize('poll.terminal.accept', 'Yes'),
@@ -192,7 +228,7 @@ export function promptForMorePolling(command: string, token: CancellationToken, 
 	return { promise: Promise.resolve(false) };
 }
 
-export async function assessOutputForErrors(buffer: string, token: CancellationToken, languageModelsService: ILanguageModelsService): Promise<string> {
+export async function assessOutputForErrors(buffer: string, token: CancellationToken, languageModelsService: Pick<ILanguageModelsService, 'selectLanguageModels' | 'sendChatRequest'>): Promise<string> {
 	const models = await languageModelsService.selectLanguageModels({ vendor: 'copilot', family: 'gpt-4o-mini' });
 	if (!models.length) {
 		return 'No models available';
@@ -223,3 +259,35 @@ export async function assessOutputForErrors(buffer: string, token: CancellationT
 		return 'Error occurred ' + err;
 	}
 }
+
+export function getProblemsForTasks(task: Pick<Task, 'configurationProperties'>, markerService: Pick<IMarkerService, 'read'>, dependencyTasks?: Task[], knownMatchers?: ProblemMatcher[]): Map<string, IMarkerData[]> {
+	const problemsMap = new Map<string, IMarkerData[]>();
+
+	const collectProblems = (t: Pick<Task, 'configurationProperties'>) => {
+		const matchers = Array.isArray(t.configurationProperties.problemMatchers)
+			? t.configurationProperties.problemMatchers
+			: (t.configurationProperties.problemMatchers ? [t.configurationProperties.problemMatchers] : []);
+		for (const matcherRef of matchers) {
+			const matcher = typeof matcherRef === 'string'
+				? ProblemMatcherRegistry.get(matcherRef) ?? knownMatchers?.find(m => m.owner === matcherRef)
+				: matcherRef;
+			if (matcher?.owner) {
+				const markers = markerService.read({ owner: matcher.owner });
+				if (markers.length) {
+					problemsMap.set(matcher.owner, markers);
+				}
+			}
+		}
+	};
+
+	collectProblems(task);
+
+	if (problemsMap.size === 0 && dependencyTasks) {
+		for (const depTask of dependencyTasks) {
+			collectProblems(depTask);
+		}
+	}
+
+	return problemsMap;
+}
+

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/bufferOutputPolling.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/bufferOutputPolling.ts
@@ -162,11 +162,10 @@ export async function pollForOutputAndIdle(
 			if (problems) {
 				// Problem matchers exist for this task
 				const problemList: string[] = [];
-				for (const [owner, problemArray] of problems.entries()) {
+				for (const [, problemArray] of problems.entries()) {
 					if (problemArray.length) {
-						problemList.push(`Problems for task "${owner ?? 'unknown'}":`);
 						for (const p of problemArray) {
-							problemList.push(`Problem: ${p.message} (Code: ${p.code}, Severity: ${p.severity}, Range: [${p.startLineNumber},${p.startColumn}]-[${p.endLineNumber},${p.endColumn}], Target: ${typeof p.code === 'string' ? p.code : p.code?.value ?? 'unknown'})`);
+							problemList.push(`${p.severity}: ${p.message}`);
 						}
 					}
 				}

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/bufferOutputPolling.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/bufferOutputPolling.ts
@@ -169,11 +169,12 @@ export async function pollForOutputAndIdle(
 					}
 				}
 				if (problemList.length === 0) {
-					return { terminalExecutionIdleBeforeTimeout, output: 'The task succeeded with no problems.' };
+					return { terminalExecutionIdleBeforeTimeout, output: 'The task succeeded with no problems.', pollDurationMs: Date.now() - pollStartTime + (extendedPolling ? PollingConsts.FirstPollingMaxDuration : 0) };
 				}
 				return {
 					terminalExecutionIdleBeforeTimeout,
-					output: problemList.join('\n')
+					output: problemList.join('\n'),
+					pollDurationMs: Date.now() - pollStartTime + (extendedPolling ? PollingConsts.FirstPollingMaxDuration : 0)
 				};
 			}
 		}

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/bufferOutputPolling.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/bufferOutputPolling.ts
@@ -163,9 +163,11 @@ export async function pollForOutputAndIdle(
 				// Problem matchers exist for this task
 				const problemList: string[] = [];
 				for (const [owner, problemArray] of problems.entries()) {
-					problemList.push(`Problems for task "${owner ?? 'unknown'}":`);
-					for (const p of problemArray) {
-						problemList.push(`Problem: ${p.message} (Code: ${p.code}, Severity: ${p.severity}, Range: [${p.startLineNumber},${p.startColumn}]-[${p.endLineNumber},${p.endColumn}], Target: ${typeof p.code === 'string' ? p.code : p.code?.value ?? 'unknown'})`);
+					if (problemArray.length) {
+						problemList.push(`Problems for task "${owner ?? 'unknown'}":`);
+						for (const p of problemArray) {
+							problemList.push(`Problem: ${p.message} (Code: ${p.code}, Severity: ${p.severity}, Range: [${p.startLineNumber},${p.startColumn}]-[${p.endLineNumber},${p.endColumn}], Target: ${typeof p.code === 'string' ? p.code : p.code?.value ?? 'unknown'})`);
+						}
 					}
 				}
 				if (problemList.length === 0) {

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/taskHelpers.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/taskHelpers.ts
@@ -12,7 +12,6 @@ import { IMarkerService } from '../../../../../platform/markers/common/markers.j
 import { IChatService } from '../../../chat/common/chatService.js';
 import { ILanguageModelsService } from '../../../chat/common/languageModels.js';
 import { ToolProgress } from '../../../chat/common/languageModelToolsService.js';
-import { ProblemMatcherRegistry } from '../../../tasks/common/problemMatcher.js';
 import { ConfiguringTask, ITaskDependency, Task } from '../../../tasks/common/tasks.js';
 import { ITaskService } from '../../../tasks/common/taskService.js';
 import { ITerminalInstance } from '../../../terminal/browser/terminal.js';
@@ -168,78 +167,3 @@ export async function collectTerminalResults(
 	return results;
 }
 
-
-export function resolveTaskProblemMatcherPatterns(task: Task): { beginsPattern?: RegExp; endsPattern?: RegExp } | undefined {
-	const matchers = Array.isArray(task.configurationProperties.problemMatchers) ? task.configurationProperties.problemMatchers : (task.configurationProperties.problemMatchers ? [task.configurationProperties.problemMatchers] : []);
-	for (const matcherRef of matchers) {
-		const matcher = typeof matcherRef === 'string'
-			? ProblemMatcherRegistry.get(matcherRef)
-			: matcherRef;
-		if (matcher?.watching?.beginsPattern && matcher?.watching?.endsPattern) {
-			return {
-				beginsPattern: matcher.watching.beginsPattern.regexp,
-				endsPattern: matcher.watching.endsPattern.regexp
-			};
-		}
-	}
-	return undefined;
-}
-
-// /**
-//  * Returns a map from each task (including dependencies) to its beginsPattern and endsPattern.
-//  * If the main task does not have patterns, dependencyTasks are checked.
-//  *
-//  * @param task The main Task to parse patterns for.
-//  * @param dependencyTasks Optional array of dependency Tasks to check for patterns.
-//  * @returns A map of Task to its { beginsPattern, endsPattern }.
-//  */
-// export function getTaskBeginEndPatternMap(task: Task, dependencyTasks?: Task[]): Map<Task, { beginsPattern: RegExp; endsPattern: RegExp }> {
-// 	const result = new Map<Task, { beginsPattern: RegExp; endsPattern: RegExp }>();
-
-// 	const extractPatterns = (t: Task): { beginsPattern: RegExp; endsPattern: RegExp } | undefined => {
-// 		const matchers = Array.isArray(t.configurationProperties.problemMatchers)
-// 			? t.configurationProperties.problemMatchers
-// 			: (t.configurationProperties.problemMatchers ? [t.configurationProperties.problemMatchers] : []);
-// 		for (const matcherRef of matchers) {
-// 			const matcher = typeof matcherRef === 'string'
-// 				? ProblemMatcherRegistry.get(matcherRef)
-// 				: matcherRef;
-// 			if (matcher?.watching?.beginsPattern && matcher?.watching?.endsPattern) {
-// 				return {
-// 					beginsPattern: matcher.watching.beginsPattern.regexp,
-// 					endsPattern: matcher.watching.endsPattern.regexp
-// 				};
-// 			}
-// 		}
-// 		return undefined;
-// 	};
-
-// 	// Main task
-// 	const mainPatterns = extractPatterns(task);
-// 	if (mainPatterns) {
-// 		result.set(task, mainPatterns);
-// 	}
-
-// 	// Dependencies
-// 	if (dependencyTasks) {
-// 		for (const depTask of dependencyTasks) {
-// 			const depPatterns = extractPatterns(depTask);
-// 			if (depPatterns) {
-// 				result.set(depTask, depPatterns);
-// 			}
-// 		}
-// 	}
-
-// 	// If main task has no patterns, but dependencies do, add main task with first dependency's patterns
-// 	if (!mainPatterns && dependencyTasks && dependencyTasks.length > 0) {
-// 		for (const depTask of dependencyTasks) {
-// 			const depPatterns = extractPatterns(depTask);
-// 			if (depPatterns) {
-// 				result.set(task, depPatterns);
-// 				break;
-// 			}
-// 		}
-// 	}
-
-// 	return result;
-// }

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/task/createAndRunTaskTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/task/createAndRunTaskTool.ts
@@ -18,6 +18,7 @@ import { URI } from '../../../../../../../base/common/uri.js';
 import { IFileService } from '../../../../../../../platform/files/common/files.js';
 import { VSBuffer } from '../../../../../../../base/common/buffer.js';
 import { IConfigurationService } from '../../../../../../../platform/configuration/common/configuration.js';
+import { IMarkerService } from '../../../../../../../platform/markers/common/markers.js';
 
 type CreateAndRunTaskToolClassification = {
 	taskLabel: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The label of the task.' };
@@ -54,7 +55,8 @@ export class CreateAndRunTaskTool implements IToolImpl {
 		@ILanguageModelsService private readonly _languageModelsService: ILanguageModelsService,
 		@IChatService private readonly _chatService: IChatService,
 		@IFileService private readonly _fileService: IFileService,
-		@IConfigurationService private readonly _configurationService: IConfigurationService
+		@IConfigurationService private readonly _configurationService: IConfigurationService,
+		@IMarkerService private readonly _markerService: IMarkerService
 	) { }
 
 	async invoke(invocation: IToolInvocation, _countTokens: CountTokensCallback, _progress: ToolProgress, token: CancellationToken): Promise<IToolResult> {
@@ -111,8 +113,8 @@ export class CreateAndRunTaskTool implements IToolImpl {
 		const raceResult = await Promise.race([this._tasksService.run(task), timeout(3000)]);
 		const result: ITaskSummary | undefined = raceResult && typeof raceResult === 'object' ? raceResult as ITaskSummary : undefined;
 
-		const resolvedDependencyTasks = await resolveDependencyTasks(task, args.workspaceFolder, this._configurationService, this._tasksService);
-		const resources = this._tasksService.getTerminalsForTasks(resolvedDependencyTasks ?? task);
+		const dependencyTasks = await resolveDependencyTasks(task, args.workspaceFolder, this._configurationService, this._tasksService);
+		const resources = this._tasksService.getTerminalsForTasks(dependencyTasks ?? task);
 		const terminals = resources?.map(resource => this._terminalService.instances.find(t => t.resource.path === resource?.path && t.resource.scheme === resource.scheme)).filter(Boolean) as ITerminalInstance[];
 		if (!terminals || terminals.length === 0) {
 			return { content: [{ kind: 'text', value: `Task started but no terminal was found for: ${args.task.label}` }], toolResultMessage: new MarkdownString(localize('copilotChat.noTerminal', 'Task started but no terminal was found for: `{0}`', args.task.label)) };
@@ -122,11 +124,13 @@ export class CreateAndRunTaskTool implements IToolImpl {
 			terminals,
 			task,
 			this._languageModelsService,
+			this._markerService,
 			this._chatService,
 			invocation.context!,
 			_progress,
 			token,
-			() => this._isTaskActive(task)
+			() => this._isTaskActive(task),
+			dependencyTasks
 		);
 		for (const r of terminalResults) {
 			this._telemetryService.publicLog2?.<CreateAndRunTaskToolEvent, CreateAndRunTaskToolClassification>('copilotChat.runTaskTool.createAndRunTask', {

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/bufferOutputPolling.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/bufferOutputPolling.test.ts
@@ -173,8 +173,6 @@ suite('racePollingOrPrompt', () => {
 				[{ owner: 'terminal-output', applyTo: ApplyToKind.allDocuments, fileLocation: FileLocationKind.Absolute, pattern: { regexp: RegExp('.*') } }]
 			);
 			assert.ok(result.output.includes('problem'));
-			assert.ok(result.output.includes('E123'));
-			assert.ok(result.output.includes('Severity: 1'));
 		});
 	});
 });

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/bufferOutputPolling.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/bufferOutputPolling.test.ts
@@ -2,15 +2,18 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-
 import { strict as assert } from 'assert';
 import { CancellationToken } from '../../../../../../base/common/cancellation.js';
-import { getOutput, PollingConsts, racePollingOrPrompt } from '../../browser/bufferOutputPolling.js';
+import { getOutput, pollForOutputAndIdle, PollingConsts, racePollingOrPrompt } from '../../browser/bufferOutputPolling.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
 import { ChatElicitationRequestPart } from '../../../../chat/browser/chatElicitationRequestPart.js';
 import { Emitter } from '../../../../../../base/common/event.js';
 // eslint-disable-next-line local/code-amd-node-module
 import { Terminal as RawXtermTerminal } from '@xterm/xterm';
+import { TestMarkerService } from '../../../../../test/common/workbenchTestServices.js';
+import { ILanguageModelsService } from '../../../../chat/common/languageModels.js';
+import { URI } from '../../../../../../base/common/uri.js';
+import { ApplyToKind, FileLocationKind } from '../../../../tasks/common/problemMatcher.js';
 
 suite('racePollingOrPrompt', () => {
 	ensureNoDisposablesAreLeakedInTestSuite();
@@ -19,6 +22,7 @@ suite('racePollingOrPrompt', () => {
 	const defaultToken = CancellationToken.None;
 	const defaultLanguageModelsService = {} as any;
 	const defaultExecution = { getOutput: () => 'output' };
+	const testMarkerService = new TestMarkerService();
 
 	function write(data: string, terminal: RawXtermTerminal): Promise<void> {
 		return new Promise<void>((resolve) => {
@@ -43,6 +47,7 @@ suite('racePollingOrPrompt', () => {
 		originalResult?: Parameters<typeof racePollingOrPrompt>[2];
 		token?: CancellationToken;
 		languageModelsService?: typeof defaultLanguageModelsService;
+		markerService?: typeof testMarkerService;
 		execution?: typeof defaultExecution;
 	}) {
 		return {
@@ -51,6 +56,7 @@ suite('racePollingOrPrompt', () => {
 			originalResult: overrides?.originalResult ?? defaultOriginalResult,
 			token: overrides?.token ?? defaultToken,
 			languageModelsService: overrides?.languageModelsService ?? defaultLanguageModelsService,
+			markerService: overrides?.markerService ?? testMarkerService,
 			execution: overrides?.execution ?? defaultExecution
 		};
 	}
@@ -63,7 +69,7 @@ suite('racePollingOrPrompt', () => {
 				return { terminalExecutionIdleBeforeTimeout: true, output: 'output', pollDurationMs: 0 };
 			}
 		});
-		const result = await racePollingOrPrompt(args.pollFn, args.promptFn, args.originalResult, args.token, args.languageModelsService, args.execution);
+		const result = await racePollingOrPrompt(args.pollFn, args.promptFn, args.originalResult, args.token, args.languageModelsService, args.markerService, args.execution);
 		assert.ok(pollResolved);
 		assert.deepEqual(result, { terminalExecutionIdleBeforeTimeout: true, output: 'output', pollDurationMs: 0 });
 	});
@@ -74,7 +80,7 @@ suite('racePollingOrPrompt', () => {
 			promptFn: () => ({ promise: Promise.resolve(false), part: undefined }),
 			originalResult: { terminalExecutionIdleBeforeTimeout: false, output: 'original', pollDurationMs: PollingConsts.FirstPollingMaxDuration }
 		});
-		const result = await racePollingOrPrompt(args.pollFn, args.promptFn, args.originalResult, args.token, args.languageModelsService, args.execution);
+		const result = await racePollingOrPrompt(args.pollFn, args.promptFn, args.originalResult, args.token, args.languageModelsService, args.markerService, args.execution);
 		assert.deepEqual(result, args.originalResult);
 	});
 
@@ -89,10 +95,13 @@ suite('racePollingOrPrompt', () => {
 			originalResult: { terminalExecutionIdleBeforeTimeout: false, output: 'original', pollDurationMs: PollingConsts.FirstPollingMaxDuration },
 			languageModelsService: {
 				selectLanguageModels: async () => [],
-				sendChatRequest: async () => ({ result: '', stream: [] })
+				sendChatRequest: async () => ({
+					result: Promise.resolve(''),
+					stream: (async function* () { })()
+				})
 			}
 		});
-		const result = await racePollingOrPrompt(args.pollFn, args.promptFn, args.originalResult, args.token, args.languageModelsService, args.execution);
+		const result = await racePollingOrPrompt(args.pollFn, args.promptFn, args.originalResult, args.token, args.languageModelsService, args.markerService, args.execution);
 		assert.ok(extraPollCount === 1);
 		assert(result?.pollDurationMs && args.originalResult.pollDurationMs && result.pollDurationMs > args.originalResult.pollDurationMs);
 	});
@@ -107,7 +116,7 @@ suite('racePollingOrPrompt', () => {
 				part
 			})
 		});
-		const result = await racePollingOrPrompt(args.pollFn, args.promptFn, args.originalResult, args.token, args.languageModelsService, args.execution);
+		const result = await racePollingOrPrompt(args.pollFn, args.promptFn, args.originalResult, args.token, args.languageModelsService, args.markerService, args.execution);
 		assert.strictEqual(hideCalled, true);
 		assert.deepEqual(result, { terminalExecutionIdleBeforeTimeout: true, output: 'output', pollDurationMs: 0 });
 	});
@@ -126,8 +135,46 @@ suite('racePollingOrPrompt', () => {
 			originalResult: { terminalExecutionIdleBeforeTimeout: false, output: 'original', pollDurationMs: PollingConsts.FirstPollingMaxDuration },
 			token: { isCancellationRequested: true } as CancellationToken
 		});
-		const result = await racePollingOrPrompt(args.pollFn, args.promptFn, args.originalResult, args.token, args.languageModelsService, args.execution);
+		const result = await racePollingOrPrompt(args.pollFn, args.promptFn, args.originalResult, args.token, args.languageModelsService, args.markerService, args.execution);
 		assert.ok(pollCalled);
 		assert.deepEqual(result, await args.pollFn());
+	});
+
+	suite('pollForOutputAndIdle with task', () => {
+		test('should return problems for a given task', async () => {
+			const fakeTask = {
+				configurationProperties: {
+					problemMatchers: ['terminal-output']
+				}
+			};
+			const fakeMarkerService = {
+				changeOne: () => { },
+				remove: () => { },
+				read: ({ owner }: { owner: string }) => owner === 'terminal-output' ? [{ message: 'problem', code: 'E123', severity: 1, startLineNumber: 1, startColumn: 1, endLineNumber: 1, endColumn: 10, owner: 'terminal-output', resource: URI.file('test.txt') }] : []
+			};
+			const fakeLanguageModelsService: Pick<ILanguageModelsService, 'selectLanguageModels' | 'sendChatRequest'> = {
+				selectLanguageModels: async () => [],
+				sendChatRequest: async () => ({
+					result: Promise.resolve(''),
+					stream: (async function* () { })()
+				})
+			};
+			const execution = {
+				getOutput: () => 'exited with code E123 in test.txt',
+				task: fakeTask
+			};
+			const token = { isCancellationRequested: false } as CancellationToken;
+			const result = await pollForOutputAndIdle(
+				execution,
+				false,
+				token,
+				fakeLanguageModelsService,
+				fakeMarkerService,
+				[{ owner: 'terminal-output', applyTo: ApplyToKind.allDocuments, fileLocation: FileLocationKind.Absolute, pattern: { regexp: RegExp('.*') } }]
+			);
+			assert.ok(result.output.includes('problem'));
+			assert.ok(result.output.includes('E123'));
+			assert.ok(result.output.includes('Severity: 1'));
+		});
 	});
 });


### PR DESCRIPTION
This improves accuracy and speed of response. Also added a test.

Fixes https://github.com/microsoft/vscode/issues/261516

