### PR TITLE
Add Open Active Diff Side option to Command Palette using DIFF_OPEN_SIDE command

### DIFF
--- a/src/vs/workbench/browser/parts/editor/diffEditorCommands.ts
+++ b/src/vs/workbench/browser/parts/editor/diffEditorCommands.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { KeyCode, KeyMod } from '../../../../base/common/keyCodes.js';
+import { KeyChord, KeyCode, KeyMod } from '../../../../base/common/keyCodes.js';
 import { isEqual } from '../../../../base/common/resources.js';
 import { URI } from '../../../../base/common/uri.js';
 import { ITextResourceConfigurationService } from '../../../../editor/common/services/textResourceConfiguration.js';
@@ -17,6 +17,10 @@ import { ActiveCompareEditorCanSwapContext, TextCompareEditorActiveContext, Text
 import { DiffEditorInput } from '../../../common/editor/diffEditorInput.js';
 import { IEditorService } from '../../../services/editor/common/editorService.js';
 import { IUntypedEditorInput } from '../../../common/editor.js';
+import { EditorContextKeys } from '../../../../editor/common/editorContextKeys.js';
+import { IEditorGroupsService } from '../../../services/editor/common/editorGroupsService.js';
+import { isDiffEditor } from '../../../../editor/browser/editorBrowser.js';
+import { EditorInput } from '../../../common/editor/editorInput.js';
 
 export const TOGGLE_DIFF_SIDE_BY_SIDE = 'toggle.diff.renderSideBySide';
 export const GOTO_NEXT_CHANGE = 'workbench.action.compareEditor.nextChange';
@@ -29,6 +33,40 @@ export const TOGGLE_DIFF_IGNORE_TRIM_WHITESPACE = 'toggle.diff.ignoreTrimWhitesp
 export const DIFF_SWAP_SIDES = 'workbench.action.compareEditor.swapSides';
 
 export function registerDiffEditorCommands(): void {
+	KeybindingsRegistry.registerCommandAndKeybindingRule({
+		id: DIFF_OPEN_SIDE,
+		weight: KeybindingWeight.WorkbenchContrib,
+		when: EditorContextKeys.inDiffEditor,
+		primary: KeyChord(KeyMod.CtrlCmd | KeyCode.KeyK, KeyMod.Shift | KeyCode.KeyO),
+		handler: async accessor => {
+			const editorService = accessor.get(IEditorService);
+			const editorGroupsService = accessor.get(IEditorGroupsService);
+
+			const activeEditor = editorService.activeEditor;
+			const activeTextEditorControl = editorService.activeTextEditorControl;
+			if (!isDiffEditor(activeTextEditorControl) || !(activeEditor instanceof DiffEditorInput)) {
+				return;
+			}
+
+			let editor: EditorInput | undefined;
+			const originalEditor = activeTextEditorControl.getOriginalEditor();
+			if (originalEditor.hasTextFocus()) {
+				editor = activeEditor.original;
+			} else {
+				editor = activeEditor.modified;
+			}
+
+			return editorGroupsService.activeGroup.openEditor(editor);
+		}
+	});
+
+	MenuRegistry.appendMenuItem(MenuId.CommandPalette, {
+		command: {
+			id: DIFF_OPEN_SIDE,
+			title: localize2('compare.openSide', 'Open Active Diff Side'),
+		}
+	});
+
 	KeybindingsRegistry.registerCommandAndKeybindingRule({
 		id: GOTO_NEXT_CHANGE,
 		weight: KeybindingWeight.WorkbenchContrib,
@@ -58,6 +96,7 @@ export function registerDiffEditorCommands(): void {
 			title: localize2('compare.previousChange', 'Go to Previous Change'),
 		}
 	});
+
 
 	function getActiveTextDiffEditor(accessor: ServicesAccessor, args: any[]): TextDiffEditor | undefined {
 		const editorService = accessor.get(IEditorService);
@@ -242,12 +281,5 @@ export function registerDiffEditorCommands(): void {
 			category: localize('compare', "Compare")
 		},
 		when: ContextKeyExpr.and(TextCompareEditorActiveContext, ActiveCompareEditorCanSwapContext)
-	});
-
-	MenuRegistry.appendMenuItem(MenuId.CommandPalette, {
-		command: {
-			id: DIFF_OPEN_SIDE,
-			title: localize2('compare.openSide', 'Open File on Selected Side'),
-		}
 	});
 }

--- a/src/vs/workbench/browser/parts/editor/diffEditorCommands.ts
+++ b/src/vs/workbench/browser/parts/editor/diffEditorCommands.ts
@@ -59,13 +59,6 @@ export function registerDiffEditorCommands(): void {
 		}
 	});
 
-	MenuRegistry.appendMenuItem(MenuId.CommandPalette, {
-		command: {
-			id: DIFF_OPEN_SIDE,
-			title: localize2('compare.openSide', 'Open File on Selected Side'),
-		}
-	});
-
 	function getActiveTextDiffEditor(accessor: ServicesAccessor, args: any[]): TextDiffEditor | undefined {
 		const editorService = accessor.get(IEditorService);
 		const resource = args.length > 0 && args[0] instanceof URI ? args[0] : undefined;
@@ -249,5 +242,12 @@ export function registerDiffEditorCommands(): void {
 			category: localize('compare', "Compare")
 		},
 		when: ContextKeyExpr.and(TextCompareEditorActiveContext, ActiveCompareEditorCanSwapContext)
+	});
+
+	MenuRegistry.appendMenuItem(MenuId.CommandPalette, {
+		command: {
+			id: DIFF_OPEN_SIDE,
+			title: localize2('compare.openSide', 'Open File on Selected Side'),
+		}
 	});
 }

--- a/src/vs/workbench/browser/parts/editor/diffEditorCommands.ts
+++ b/src/vs/workbench/browser/parts/editor/diffEditorCommands.ts
@@ -59,6 +59,13 @@ export function registerDiffEditorCommands(): void {
 		}
 	});
 
+	MenuRegistry.appendMenuItem(MenuId.CommandPalette, {
+		command: {
+			id: DIFF_OPEN_SIDE,
+			title: localize2('compare.openSide', 'Open File on Selected Side'),
+		}
+	});
+
 	function getActiveTextDiffEditor(accessor: ServicesAccessor, args: any[]): TextDiffEditor | undefined {
 		const editorService = accessor.get(IEditorService);
 		const resource = args.length > 0 && args[0] instanceof URI ? args[0] : undefined;

--- a/src/vs/workbench/browser/parts/editor/editorCommands.ts
+++ b/src/vs/workbench/browser/parts/editor/editorCommands.ts
@@ -9,7 +9,6 @@ import { Schemas, matchesScheme } from '../../../../base/common/network.js';
 import { extname, isEqual } from '../../../../base/common/resources.js';
 import { isNumber, isObject, isString, isUndefined } from '../../../../base/common/types.js';
 import { URI, UriComponents } from '../../../../base/common/uri.js';
-import { isDiffEditor } from '../../../../editor/browser/editorBrowser.js';
 import { EditorContextKeys } from '../../../../editor/common/editorContextKeys.js';
 import { localize, localize2 } from '../../../../nls.js';
 import { Categories } from '../../../../platform/action/common/actionCommonCategories.js';
@@ -29,7 +28,6 @@ import { SideBySideEditor } from './sideBySideEditor.js';
 import { TextDiffEditor } from './textDiffEditor.js';
 import { ActiveEditorCanSplitInGroupContext, ActiveEditorGroupEmptyContext, ActiveEditorGroupLockedContext, ActiveEditorStickyContext, MultipleEditorGroupsContext, SideBySideEditorActiveContext, TextCompareEditorActiveContext } from '../../../common/contextkeys.js';
 import { CloseDirection, EditorInputCapabilities, EditorsOrder, IResourceDiffEditorInput, IUntitledTextResourceEditorInput, isEditorInputWithOptionsAndGroup } from '../../../common/editor.js';
-import { DiffEditorInput } from '../../../common/editor/diffEditorInput.js';
 import { EditorInput } from '../../../common/editor/editorInput.js';
 import { SideBySideEditorInput } from '../../../common/editor/sideBySideEditorInput.js';
 import { EditorGroupColumn, columnToEditorGroup } from '../../../services/editor/common/editorGroupColumn.js';
@@ -38,7 +36,7 @@ import { IEditorResolverService } from '../../../services/editor/common/editorRe
 import { IEditorService, SIDE_GROUP } from '../../../services/editor/common/editorService.js';
 import { IPathService } from '../../../services/path/common/pathService.js';
 import { IUntitledTextEditorService } from '../../../services/untitled/common/untitledTextEditorService.js';
-import { DIFF_FOCUS_OTHER_SIDE, DIFF_FOCUS_PRIMARY_SIDE, DIFF_FOCUS_SECONDARY_SIDE, DIFF_OPEN_SIDE, registerDiffEditorCommands } from './diffEditorCommands.js';
+import { DIFF_FOCUS_OTHER_SIDE, DIFF_FOCUS_PRIMARY_SIDE, DIFF_FOCUS_SECONDARY_SIDE, registerDiffEditorCommands } from './diffEditorCommands.js';
 import { IResolvedEditorCommandsContext, resolveCommandsContext } from './editorCommandsContext.js';
 import { prepareMoveCopyEditors } from './editor.js';
 import { IRange } from '../../../../editor/common/core/range.js';
@@ -1342,33 +1340,6 @@ function registerOtherEditorCommands(): void {
 					group.stickEditor(editor);
 				}
 			}
-		}
-	});
-
-	KeybindingsRegistry.registerCommandAndKeybindingRule({
-		id: DIFF_OPEN_SIDE,
-		weight: KeybindingWeight.WorkbenchContrib,
-		when: EditorContextKeys.inDiffEditor,
-		primary: KeyChord(KeyMod.CtrlCmd | KeyCode.KeyK, KeyMod.Shift | KeyCode.KeyO),
-		handler: async accessor => {
-			const editorService = accessor.get(IEditorService);
-			const editorGroupsService = accessor.get(IEditorGroupsService);
-
-			const activeEditor = editorService.activeEditor;
-			const activeTextEditorControl = editorService.activeTextEditorControl;
-			if (!isDiffEditor(activeTextEditorControl) || !(activeEditor instanceof DiffEditorInput)) {
-				return;
-			}
-
-			let editor: EditorInput | undefined;
-			const originalEditor = activeTextEditorControl.getOriginalEditor();
-			if (originalEditor.hasTextFocus()) {
-				editor = activeEditor.original;
-			} else {
-				editor = activeEditor.modified;
-			}
-
-			return editorGroupsService.activeGroup.openEditor(editor);
 		}
 	});
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Addresses issue #260762. This adds the `workbench.action.compareEditor.openSide` or `DIFF_OPEN_SIDE` constant in to the `MenuRegistry`, which registers it into the Command Palette.

Below is a screenshot showing it in the command palette.

<img width="609" height="213" alt="image" src="https://github.com/user-attachments/assets/81173809-28e6-4a08-8742-89e58595d90d" />


## How to Test
1. Open Visual Studio Code.
2. Open a folder with two files.
3. Select one file for compare in the Explorer pane by right-clicking it and click `Select for Compare` in the context menu.
4. Select another file by right-clicking it and clicking on `Compare with Selected` in the context menu.
5. The diff viewer should now open. Click on one of the file editors. This can be either side.
6. Open the Command Palette by hitting CTRL + SHIFT + P (Command/Cmd for Mac, instead of CTRL).
7. Look for "Open File on Selected Side". Click it while the desired file editor on either side is selected.
8. The desired file should be opened on its own.
