### PR TITLE
terminalProcessManager: fix disposable leak

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminalProcessManager.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalProcessManager.ts
@@ -207,6 +207,10 @@ export class TerminalProcessManager extends Disposable implements ITerminalProce
 			this._process.shutdown(immediate);
 			this._process = null;
 		}
+		if (this._processListeners) {
+			dispose(this._processListeners);
+			this._processListeners = undefined;
+		}
 		super.dispose();
 	}
 


### PR DESCRIPTION
[LEAKED DISPOSABLE] Error: CREATED via:
  at GCBasedDisposableTracker.trackDisposable src/vs/base/common/lifecycle.ts:47:23
  at trackDisposable src/vs/base/common/lifecycle.ts:218:24
  at toDisposable src/vs/base/common/lifecycle.ts:296:18
  at LocalPty._event [as onRestoreCommands] src/vs/base/common/event.ts:879:28
  at TerminalProcessManager.createProcess src/vs/workbench/contrib/terminal/browser/terminalProcessManager.ts:340:52
  at async TerminalInstance._createProcess src/vs/workbench/contrib/terminal/browser/terminalInstance.ts:1973:9

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
