### PR TITLE
Commands in warning hover are heavily truncated (fix #250424)

### DIFF
--- a/src/vs/editor/contrib/hover/browser/markerHoverParticipant.ts
+++ b/src/vs/editor/contrib/hover/browser/markerHoverParticipant.ts
@@ -271,6 +271,11 @@ export class MarkerHoverParticipant implements IEditorHoverParticipant<MarkerHov
 					});
 				}
 
+				// Notify that the contents have changed given we added
+				// actions to the hover
+				// https://github.com/microsoft/vscode/issues/250424
+				context.onContentsChanged();
+
 			}, onUnexpectedError);
 		}
 		return disposables;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
