### PR TITLE
fix: only re-render available tree elements

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
@@ -1638,10 +1638,10 @@ export class SettingsEditor2 extends EditorPane {
 	}
 
 	private refreshSingleElement(element: SettingsTreeSettingElement): void {
-		if (this.isVisible()) {
-			if (!element.setting.deprecationMessage || element.isConfigured) {
-				this.settingsTree.rerender(element);
-			}
+		if (this.isVisible()
+			&& this.settingsTree.hasElement(element)
+			&& (!element.setting.deprecationMessage || element.isConfigured)) {
+			this.settingsTree.rerender(element);
 		}
 	}
 


### PR DESCRIPTION
If a tree element isn't yet available, do not try to re-render it; a later refreshTree call will likely make it right.

Fixes https://github.com/microsoft/vscode/issues/261753
