### PR TITLE
fix(chat-sessions): add missing closing brace in CSS

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/media/chatSessions.css
+++ b/src/vs/workbench/contrib/chat/browser/media/chatSessions.css
@@ -83,6 +83,7 @@
 
 .chat-sessions-tree .session-input-container .monaco-inputbox:focus-within {
 	--vscode-input-border: var(--vscode-focusBorder) !important;
+}
 
 /* Position session content and actions inline */
 .chat-sessions-tree .chat-session-item .session-content {


### PR DESCRIPTION
This PR fixes a missing closing brace in chatSessions.css