### PR TITLE
Fix minShowDelay calculation

### DIFF
--- a/src/vs/editor/contrib/inlineCompletions/browser/model/inlineCompletionsModel.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/model/inlineCompletionsModel.ts
@@ -390,7 +390,7 @@ export class InlineCompletionsModel extends Disposable {
 			includeInlineCompletions: !changeSummary.onlyRequestInlineEdits,
 			includeInlineEdits: this._inlineEditsEnabled.read(reader),
 			requestIssuedDateTime: requestInfo.startTime,
-			earliestShownDateTime: requestInfo.startTime + changeSummary.inlineCompletionTriggerKind === InlineCompletionTriggerKind.Explicit ? 0 : this._minShowDelay.get(),
+			earliestShownDateTime: requestInfo.startTime + (changeSummary.inlineCompletionTriggerKind === InlineCompletionTriggerKind.Explicit ? 0 : this._minShowDelay.get()),
 		};
 
 		if (context.triggerKind === InlineCompletionTriggerKind.Automatic && changeSummary.textChange) {


### PR DESCRIPTION
```Copilot Generated Description:``` Correct the calculation of `earliestShownDateTime` to properly account for the `InlineCompletionTriggerKind`.