### PR TITLE
layout - go back to default size for secondary sidebar

### DIFF
--- a/src/vs/workbench/browser/layout.ts
+++ b/src/vs/workbench/browser/layout.ts
@@ -2920,9 +2920,7 @@ class LayoutStateModel extends Disposable {
 			this.storageService.isNew(StorageScope.APPLICATION) &&
 			this.contextService.getWorkbenchState() === WorkbenchState.EMPTY
 		) {
-			const mainContainerDimension = configuration.mainContainerDimension;
 			this.setRuntimeValue(LayoutStateKeys.AUXILIARYBAR_HIDDEN, false);
-			this.setInitializationValue(LayoutStateKeys.AUXILIARYBAR_SIZE, Math.ceil(mainContainerDimension.width / (1.618 * 1.618 /* golden ratio */)));
 		}
 
 		// Auxiliary bar: Based on setting for new workspaces


### PR DESCRIPTION
We optimised the default window dimensions for a 300px secondary sidebar, so lets go back to it.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
