### PR TITLE
feat: Add Swipe to Navigate for macOS touchpads.

### DIFF
--- a/src/vs/workbench/browser/workbench.contribution.ts
+++ b/src/vs/workbench/browser/workbench.contribution.ts
@@ -353,6 +353,58 @@ const registry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Con
 				'description': localize('mouseBackForwardToNavigate', "Enables the use of mouse buttons four and five for commands 'Go Back' and 'Go Forward'."),
 				'default': true
 			},
+			'workbench.editor.swipeToNavigate': {
+				'oneOf': [
+					{
+						'type': 'string',
+						'enum': [
+							'disabled',
+							'editor',
+							'editorInGroup',
+							'history',
+							'historyInGroup',
+							'group',
+							'navigation',
+							'edit',
+							'navigationEdit'
+						],
+						'enumDescriptions': [
+							localize('swipeToNavigate.disabled', "Disable swipe navigation."),
+							localize('swipeToNavigate.editor', "Switch editor tabs across all groups (previous/next)."),
+							localize('swipeToNavigate.editorInGroup', "Switch editor tabs within the current group only (previous/next)."),
+							localize('swipeToNavigate.history', "Move through most recently used editors (MRU) across all groups (previous/next)."),
+							localize('swipeToNavigate.historyInGroup', "Move through most recently used editors (MRU) within the current group (previous/next)."),
+							localize('swipeToNavigate.group', "Change focus to neighboring editor groups (left/right/up/down)."),
+							localize('swipeToNavigate.navigation', "Move through navigational history (Go To References)."),
+							localize('swipeToNavigate.edit', "Navigate cursor edit locations."),
+							localize('swipeToNavigate.navigationEdit', "Navigate combined navigation and edit history.")
+						]
+					},
+					{
+						'type': 'object',
+						'additionalProperties': false,
+						'properties': {
+							'horizontal': {
+								'default': 'navigationEdit',
+								'oneOf': [
+									{ 'type': 'string', 'enum': ['disabled', 'editor', 'editorInGroup', 'history', 'historyInGroup', 'group', 'navigation', 'edit', 'navigationEdit'] },
+									{ 'type': 'object', 'additionalProperties': false, 'properties': { 'previous': { 'type': 'string' }, 'next': { 'type': 'string' } } }
+								]
+							},
+							'vertical': {
+								'default': 'disabled',
+								'oneOf': [
+									{ 'type': 'string', 'enum': ['disabled', 'editor', 'editorInGroup', 'history', 'historyInGroup', 'group', 'navigation', 'edit', 'navigationEdit'] },
+									{ 'type': 'object', 'additionalProperties': false, 'properties': { 'previous': { 'type': 'string' }, 'next': { 'type': 'string' } } }
+								],
+								'description': localize('swipeToNavigate.vertical', "Override vertical swipe behavior. Note: 'default' is not supported for vertical; use explicit options or omit to disable.")
+							}
+						}
+					}
+				],
+				'markdownDescription': localize('swipeToNavigate', "Configure swipe gesture navigation on macOS touchpads. Accepts 'default'/'disabled', a specific mode (e.g. 'editor', 'history'), or an object that specifies separate 'horizontal' and 'vertical' behavior."),
+				'default': 'navigationEdit'
+			},
 			'workbench.editor.navigationScope': {
 				'type': 'string',
 				'enum': ['default', 'editorGroup', 'editor'],


### PR DESCRIPTION
Edit: [Alternative implementation](https://github.com/microsoft/vscode/pull/262262) registers the swipe recognizers and expose them as an extension API instead: 

Following options have been added:

- 	`"disabled"` – Disable swipe navigation.
- 	`"editor"` – Switch editor tabs across all groups (previous/next).
- 	`"editorInGroup"` – Switch editor tabs within the current group only (previous/next).
- 	`"history"` – Move through most recently used editors (MRU) across all groups (previous/next).
- 	`"historyInGroup"` – Move through most recently used editors (MRU) within the current group (previous/next).
- 	`"group"` – Change focus to neighboring editor groups (left/right/up/down).
- 	`"navigation"` – Move through navigational history (for example: Go To References).
- 	`"edit"` – Navigate cursor edit locations.
- 	`"navigationEdit"` – Navigate through a combined history of navigation and edit locations.

Alternatively, the setting can be defined as an object:

```json 
"workbench.editor.swipeToNavigate": {
  "horizontal": "navigationEdit",
  "vertical": "disabled"
}
```

Can also support custom actions: 
```json
"workbench.editor.swipeToNavigate": {
  "horizontal": "disabled",
  "vertical": { "previous": "commandId1", "next": "commandId2" }
}
```

Requires these OS settings: 
![image](https://github.com/user-attachments/assets/09e72ba6-7ae2-467f-b379-dde1b9455ae2)

Older OS settings: 
![image](https://github.com/user-attachments/assets/895e540f-dc46-4d18-9f7a-7aa0516cebbc)


Also I think there is a misunderstanding in previous threads, swipes don't work unless you activate them on OS level (as per screenshot). There is a distinction between swiping and panning, the latter is fullscreen.  
It is very possible that you had [disabled](https://github.com/electron/electron/issues/19131#issuecomment-613751165) them on your OS level and assumed they didn't work.

Previous discussions with @bpasero indicated there was no interest in adding more Electron APIs. However, Electron applications such as Discord have supported swipe gestures for years without issues, and Touch Bar integration is already supported and that uses Electron APIs. Swipe gestures have been stable in Electron for a long time and have not caused problems, outside of that misunderstanding

~~Another option would be to expose events for extensions, though I am not sure how to get started with that. I assume it would require approval before introducing a new extension API.~~

I previously attempted this through an [extension](https://marketplace.visualstudio.com/items?itemName=Seivan.swipe-to-navigate), but it relied on heavy hacks and monkey-patching the bootloader. These broke with every VS Code update and were difficult to maintain, since I had to inspect the generated JavaScript to figure out where to apply the patches. This approach is unsustainable.

I rely on swipe gestures for navigation as an accessibility feature. Swiping to move between views is a native macOS behavior supported in Xcode, Safari, Finder, Terminal, Notes, and more. The lack of support in VS Code feels inconsistent with the platform.

At the very least, the swipe gesture recognizers should be exposed via an extension like the alternative PR https://github.com/microsoft/vscode/pull/262262 and let extensions (I've done one) define actions for them. 

Discussions:
https://github.com/microsoft/vscode/issues/4803 (again)
https://github.com/microsoft/vscode/issues/40526
https://github.com/microsoft/vscode/issues/25447
https://github.com/microsoft/vscode/issues/25325
https://github.com/microsoft/vscode/issues/25449