### PR TITLE
Don't skip sanitize for system extensions readmes

### DIFF
--- a/src/vs/workbench/contrib/extensions/browser/extensionEditor.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionEditor.ts
@@ -87,6 +87,7 @@ import { ByteSize, IFileService } from '../../../../platform/files/common/files.
 import { IUserDataProfilesService } from '../../../../platform/userDataProfile/common/userDataProfile.js';
 import { IRemoteAgentService } from '../../../services/remote/common/remoteAgentService.js';
 import { IExtensionGalleryManifestService } from '../../../../platform/extensionManagement/common/extensionGalleryManifest.js';
+import { ShowCurrentReleaseNotesActionId } from '../../update/common/update.js';
 
 function toDateString(date: Date) {
 	return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}, ${date.toLocaleTimeString(language, { hourCycle: 'h23' })}`;
@@ -730,9 +731,12 @@ export class ExtensionEditor extends EditorPane {
 				// Only allow links with specific schemes
 				if (matchesScheme(link, Schemas.http) || matchesScheme(link, Schemas.https) || matchesScheme(link, Schemas.mailto)) {
 					this.openerService.open(link);
-				}
-				if (matchesScheme(link, Schemas.command) && extension.type === ExtensionType.System) {
-					this.openerService.open(link, { allowCommands: true });
+				} else if (matchesScheme(link, Schemas.command) && extension.type === ExtensionType.System) {
+					this.openerService.open(link, {
+						allowCommands: [
+							ShowCurrentReleaseNotesActionId
+						]
+					});
 				}
 			}));
 
@@ -750,8 +754,15 @@ export class ExtensionEditor extends EditorPane {
 			return '';
 		}
 
+		const allowedLinkProtocols = [Schemas.http, Schemas.https, Schemas.mailto];
 		const content = await renderMarkdownDocument(contents, this.extensionService, this.languageService, {
-			sanitizerConfig: extension.type === ExtensionType.System ? 'skipSanitization' : {}
+			sanitizerConfig: {
+				allowedLinkProtocols: {
+					override: extension.type === ExtensionType.System
+						? [...allowedLinkProtocols, Schemas.command]
+						: allowedLinkProtocols
+				}
+			}
 		}, token);
 		if (token?.isCancellationRequested) {
 			return '';

--- a/src/vs/workbench/contrib/markdown/browser/markdownDocumentRenderer.ts
+++ b/src/vs/workbench/contrib/markdown/browser/markdownDocumentRenderer.ts
@@ -157,7 +157,7 @@ pre code {
 }
 `;
 
-const defaultAllowedProtocols = Object.freeze([
+const defaultAllowedLinkProtocols = Object.freeze([
 	Schemas.http,
 	Schemas.https,
 	Schemas.command,
@@ -166,7 +166,7 @@ const defaultAllowedProtocols = Object.freeze([
 function sanitize(documentContent: string, sanitizerConfig: MarkdownDocumentSanitizerConfig | undefined): TrustedHTML {
 	return sanitizeHtml(documentContent, {
 		allowedLinkProtocols: {
-			override: sanitizerConfig?.allowedProtocols?.override ?? defaultAllowedProtocols,
+			override: sanitizerConfig?.allowedLinkProtocols?.override ?? defaultAllowedLinkProtocols,
 		},
 		allowedTags: {
 			override: allowedMarkdownHtmlTags,
@@ -187,7 +187,7 @@ function sanitize(documentContent: string, sanitizerConfig: MarkdownDocumentSani
 }
 
 interface MarkdownDocumentSanitizerConfig {
-	readonly allowedProtocols?: {
+	readonly allowedLinkProtocols?: {
 		readonly override: readonly string[] | '*';
 	};
 	readonly allowedTags?: {
@@ -214,7 +214,7 @@ export async function renderMarkdownDocument(
 	extensionService: IExtensionService,
 	languageService: ILanguageService,
 	options?: IRenderMarkdownDocumentOptions,
-	token?: CancellationToken,
+	token: CancellationToken = CancellationToken.None,
 ): Promise<string> {
 	const m = new marked.Marked(
 		MarkedHighlight.markedHighlight({

--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStartedDetailsRenderer.ts
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStartedDetailsRenderer.ts
@@ -238,7 +238,7 @@ export class GettingStartedDetailsRenderer {
 			const contents = await this.readContentsOfPath(path);
 			const markdownContents = await renderMarkdownDocument(transformUris(contents, base), this.extensionService, this.languageService, {
 				sanitizerConfig: {
-					allowedProtocols: {
+					allowedLinkProtocols: {
 						override: '*'
 					},
 					allowedTags: {


### PR DESCRIPTION
I'd really like all of our markdown rendering to have some sanitization. Originally sanitization was skipped for #211920. Instead of disabling all sanitization, I'd like to loosen just the one rule we seem to need

I tested the release notes link after this change and everything seems to work
