### PR TITLE
Worktree creation: Create new branch for remote branch 

### DIFF
--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -3514,7 +3514,7 @@ export class CommandCenter {
 				}
 
 				if (choice.refRemote) {
-					branch = choice.refName.replace(`${choice.refRemote}/`, '');
+					branch = await this.promptForBranchName(repository, undefined, choice.refName.replace(`${choice.refRemote}/`, ''));
 				}
 
 				commitish = choice.refName;

--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -3498,15 +3498,7 @@ export class CommandCenter {
 				}
 			} else {
 				// Check whether the selected branch is checked out in an existing worktree
-				let worktree: Worktree | undefined = repository.worktrees.find(w => w.ref === choice.refId);
-
-				// Check if a remote branch's corresponding local branch is already checked out in another worktree
-				if (!worktree && choice.refRemote) {
-					const localBranchName = choice.refName.replace(`${choice.refRemote}/`, '');
-					const localBranchRef = `refs/heads/${localBranchName}`;
-					worktree = repository.worktrees.find(w => w.ref === localBranchRef);
-				}
-
+				const worktree = repository.worktrees.find(worktree => worktree.ref === choice.refId);
 				if (worktree) {
 					const message = l10n.t('Branch "{0}" is already checked out in the worktree at "{1}".', choice.refName, worktree.path);
 					await this.handleWorktreeConflict(worktree.path, message);

--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -3498,12 +3498,25 @@ export class CommandCenter {
 				}
 			} else {
 				// Check whether the selected branch is checked out in an existing worktree
-				const worktree = repository.worktrees.find(worktree => worktree.ref === choice.refId);
+				let worktree: Worktree | undefined = repository.worktrees.find(w => w.ref === choice.refId);
+
+				// Check if a remote branch's corresponding local branch is already checked out in another worktree
+				if (!worktree && choice.refRemote) {
+					const localBranchName = choice.refName.replace(`${choice.refRemote}/`, '');
+					const localBranchRef = `refs/heads/${localBranchName}`;
+					worktree = repository.worktrees.find(w => w.ref === localBranchRef);
+				}
+
 				if (worktree) {
 					const message = l10n.t('Branch "{0}" is already checked out in the worktree at "{1}".', choice.refName, worktree.path);
 					await this.handleWorktreeConflict(worktree.path, message);
 					return;
 				}
+
+				if (choice.refRemote) {
+					branch = choice.refName.replace(`${choice.refRemote}/`, '');
+				}
+
 				commitish = choice.refName;
 			}
 		}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Prompts user to create a new local branch for remote branch where default name is remote branch name. Fixes detached head issue when creating a worktree from remote branch. 