### PR TITLE
feat: Add swipe gesture recognizer and `onDidReceiveSwipeGesture` extension API.

### DIFF
--- a/src/vs/workbench/api/common/extHost.api.impl.ts
+++ b/src/vs/workbench/api/common/extHost.api.impl.ts
@@ -710,6 +710,9 @@ export function createApiFactoryAndRegisterActors(accessor: ServicesAccessor): I
 
 		// namespace: window
 		const window: typeof vscode.window = {
+			onDidReceiveSwipeGesture(listener, thisArg?, disposables?) {
+				return _asExtensionEvent(extHostWindow.onDidReceiveSwipeGesture)(listener, thisArg, disposables);
+			},
 			get activeTextEditor() {
 				return extHostEditors.getActiveTextEditor();
 			},

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -2734,6 +2734,7 @@ export interface ExtHostWindowShape {
 	$onDidChangeWindowFocus(value: boolean): void;
 	$onDidChangeWindowActive(value: boolean): void;
 	$onDidChangeActiveNativeWindowHandle(handle: string | undefined): void;
+	$onDidReceiveSwipeGesture(direction: 'left' | 'right' | 'up' | 'down'): void;
 }
 
 export interface ExtHostLogLevelServiceShape {

--- a/src/vs/workbench/api/common/extHostWindow.ts
+++ b/src/vs/workbench/api/common/extHostWindow.ts
@@ -28,6 +28,10 @@ export class ExtHostWindow implements ExtHostWindowShape {
 	private readonly _onDidChangeWindowState = new Emitter<WindowState>();
 	readonly onDidChangeWindowState: Event<WindowState> = this._onDidChangeWindowState.event;
 
+	private _onDidReceiveSwipeGesture = new Emitter<'left' | 'right' | 'up' | 'down'>();
+
+	readonly onDidReceiveSwipeGesture: Event<'left' | 'right' | 'up' | 'down'> = this._onDidReceiveSwipeGesture.event;
+
 	private _nativeHandle: Uint8Array | undefined;
 	private _state = ExtHostWindow.InitialState;
 
@@ -57,6 +61,9 @@ export class ExtHostWindow implements ExtHostWindowShape {
 			this.onDidChangeWindowProperty('focused', isFocused);
 			this.onDidChangeWindowProperty('active', isActive);
 		});
+	}
+	$onDidReceiveSwipeGesture(direction: 'left' | 'right' | 'up' | 'down'): void {
+		this._onDidReceiveSwipeGesture.fire(direction);
 	}
 
 	get nativeHandle(): Uint8Array | undefined {

--- a/src/vs/workbench/browser/workbench.contribution.ts
+++ b/src/vs/workbench/browser/workbench.contribution.ts
@@ -353,6 +353,11 @@ const registry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Con
 				'description': localize('mouseBackForwardToNavigate', "Enables the use of mouse buttons four and five for commands 'Go Back' and 'Go Forward'."),
 				'default': true
 			},
+			'workbench.editor.swipeGestureRecognizer': {
+				'type': 'boolean',
+				'description': localize('swipeGestureRecognizer', "Register swipe gestures to be used in extensions."),
+				'default': false
+			},
 			'workbench.editor.navigationScope': {
 				'type': 'string',
 				'enum': ['default', 'editorGroup', 'editor'],

--- a/src/vscode-dts/vscode.d.ts
+++ b/src/vscode-dts/vscode.d.ts
@@ -11031,6 +11031,16 @@ declare module 'vscode' {
 		export const onDidChangeActiveTextEditor: Event<TextEditor | undefined>;
 
 		/**
+		 * Swipe gesture direction.
+		 */
+		export type SwipeGestureDirection = 'left' | 'right' | 'up' | 'down';
+
+		/**
+		 * An {@link Event} which fires when a swipe gesture occurs.
+		 */
+		export const onDidReceiveSwipeGesture: Event<SwipeGestureDirection>;
+
+		/**
 		 * An {@link Event} which fires when the array of {@link window.visibleTextEditors visible editors}
 		 * has changed.
 		 */


### PR DESCRIPTION
* `"workbench.editor.swipeGestureRecognizer": true`
* Defaults to `false` (disabled).
* Added extension API `window.onDidReceiveSwipeGesture(direction: 'left' | 'right' | 'up' | 'down' )`

Alternative to https://github.com/microsoft/vscode/pull/262233 that allows extensions to listen to swipe events without having the logic for its actions. Mutually exclusive. 


Edit: Closed because no interests from maintainers to expose this as an extension event, leaving the only choice for swipe events being baked in, ref:  #262233 