### PR TITLE
Revert "chore: enable verbose logs for windows electron smoketests"

### DIFF
--- a/build/azure-pipelines/win32/product-build-win32-test.yml
+++ b/build/azure-pipelines/win32/product-build-win32-test.yml
@@ -123,7 +123,7 @@ steps:
 
   - ${{ if eq(parameters.VSCODE_RUN_ELECTRON_TESTS, true) }}:
     # Additional "--" needed to workaround https://github.com/npm/cli/issues/7375
-    - powershell: npm run smoketest-no-compile -- -- --verbose --tracing --build "$(agent.builddirectory)\test\VSCode-win32-$(VSCODE_ARCH)"
+    - powershell: npm run smoketest-no-compile -- -- --tracing --build "$(agent.builddirectory)\test\VSCode-win32-$(VSCODE_ARCH)"
       displayName: 🧪 Run smoke tests (Electron)
       timeoutInMinutes: 20
 


### PR DESCRIPTION
This reverts commit cf2732fd8b2e0eaf145221bc4626097a429b7de1
