### PR TITLE
fix: add option to disable extension trust prompt

### DIFF
--- a/src/vs/platform/extensionManagement/common/extensionManagement.ts
+++ b/src/vs/platform/extensionManagement/common/extensionManagement.ts
@@ -712,6 +712,7 @@ export const PreferencesLocalizedLabel = localize2('preferences', 'Preferences')
 export const AllowedExtensionsConfigKey = 'extensions.allowed';
 export const VerifyExtensionSignatureConfigKey = 'extensions.verifySignature';
 export const ExtensionRequestsTimeoutConfigKey = 'extensions.requestTimeout';
+export const DisablePublisherTrustPromptConfigKey = 'extensions.disablePublisherTrustPrompt';
 
 Registry.as<IConfigurationRegistry>(Extensions.Configuration)
 	.registerConfiguration({

--- a/src/vs/workbench/contrib/extensions/browser/extensions.contribution.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensions.contribution.ts
@@ -26,7 +26,7 @@ import { Extensions as ConfigurationExtensions, ConfigurationScope, IConfigurati
 import { ContextKeyExpr, IContextKeyService, RawContextKey } from '../../../../platform/contextkey/common/contextkey.js';
 import { IDialogService, IFileDialogService } from '../../../../platform/dialogs/common/dialogs.js';
 import { ExtensionGalleryManifestStatus, ExtensionGalleryResourceType, ExtensionGalleryServiceUrlConfigKey, getExtensionGalleryManifestResourceUri, IExtensionGalleryManifest, IExtensionGalleryManifestService } from '../../../../platform/extensionManagement/common/extensionGalleryManifest.js';
-import { EXTENSION_INSTALL_SOURCE_CONTEXT, ExtensionInstallSource, ExtensionRequestsTimeoutConfigKey, ExtensionsLocalizedLabel, FilterType, IExtensionGalleryService, IExtensionManagementService, PreferencesLocalizedLabel, SortBy, VerifyExtensionSignatureConfigKey } from '../../../../platform/extensionManagement/common/extensionManagement.js';
+import { DisablePublisherTrustPromptConfigKey, EXTENSION_INSTALL_SOURCE_CONTEXT, ExtensionInstallSource, ExtensionRequestsTimeoutConfigKey, ExtensionsLocalizedLabel, FilterType, IExtensionGalleryService, IExtensionManagementService, PreferencesLocalizedLabel, SortBy, VerifyExtensionSignatureConfigKey } from '../../../../platform/extensionManagement/common/extensionManagement.js';
 import { areSameExtensions, getIdAndVersion } from '../../../../platform/extensionManagement/common/extensionManagementUtil.js';
 import { ExtensionStorageService } from '../../../../platform/extensionManagement/common/extensionStorage.js';
 import { IExtensionRecommendationNotificationService } from '../../../../platform/extensionRecommendations/common/extensionRecommendations.js';
@@ -308,6 +308,12 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration)
 				default: 60_000,
 				scope: ConfigurationScope.APPLICATION,
 				tags: ['advanced', 'usesOnlineServices']
+			},
+			[DisablePublisherTrustPromptConfigKey]: {
+				type: 'boolean',
+				description: localize('extensionsDisablePublisherTrustPrompt', "When enabled, publisher trust prompt will not be shown when installing extensions from new publishers. Extensions will be automatically trusted and installed without user confirmation. Note: This does not affect extensions installed through Settings Sync or other automated processes, which already skip the prompt."),
+				default: false,
+				scope: ConfigurationScope.APPLICATION,
 			},
 		}
 	});

--- a/src/vs/workbench/services/extensionManagement/common/extensionManagementService.ts
+++ b/src/vs/workbench/services/extensionManagement/common/extensionManagementService.ts
@@ -12,6 +12,7 @@ import {
 	UninstallExtensionInfo,
 	IAllowedExtensionsService,
 	EXTENSION_INSTALL_SKIP_PUBLISHER_TRUST_CONTEXT,
+	DisablePublisherTrustPromptConfigKey,
 } from '../../../../platform/extensionManagement/common/extensionManagement.js';
 import { DidChangeProfileForServerEvent, DidUninstallExtensionOnServerEvent, IExtensionManagementServer, IExtensionManagementServerService, InstallExtensionOnServerEvent, IPublisherInfo, IResourceExtension, IWorkbenchExtensionManagementService, UninstallExtensionOnServerEvent } from './extensionManagement.js';
 import { ExtensionType, isLanguagePackExtension, IExtensionManifest, getWorkspaceSupportTypeMessage, TargetPlatform } from '../../../../platform/extensions/common/extensions.js';
@@ -832,6 +833,12 @@ export class ExtensionManagementService extends CommontExtensionManagementServic
 		}
 
 		if (!untrustedExtensions.length) {
+			return;
+		}
+
+		if (this.configurationService.getValue<boolean>(DisablePublisherTrustPromptConfigKey)) {
+			const publishersToTrust = distinct(untrustedExtensions, e => e.publisher).map(e => ({ publisher: e.publisher, publisherDisplayName: e.publisherDisplayName }));
+			this.trustPublishers(...publishersToTrust);
 			return;
 		}
 


### PR DESCRIPTION
fixes #240283.

## Summary

Adds option `extensions.disablePublisherTrustPrompt`, which will skip extension trust prompt and directly trust given publisher.

## Testing

https://github.com/user-attachments/assets/a47cda8b-75e2-4e00-a955-d335de4dfceb

to enable extensions gallery from code-oss-dev, apply following patch:

```diff --git a/product.json b/product.json
index a0719353135..9a57362b960 100644
--- a/product.json
+++ b/product.json
@@ -33,6 +33,13 @@
 	"nodejsRepository": "https://nodejs.org",
 	"urlProtocol": "code-oss",
 	"webviewContentExternalBaseUrlTemplate": "https://{{uuid}}.vscode-cdn.net/insider/ef65ac1ba57f57f2a3961bfe94aa20481caca4c6/out/vs/workbench/contrib/webview/browser/pre/",
+	"extensionsGallery": {
+		"serviceUrl": "https://marketplace.visualstudio.com/_apis/public/gallery",
+		"cacheUrl": "https://vscode.blob.core.windows.net/gallery/index",
+		"itemUrl": "https://marketplace.visualstudio.com/items",
+		"controlUrl": "",
+		"recommendationsUrl": ""
+	},
 	"builtInExtensions": [
 		{
 			"name": "ms-vscode.js-debug-companion",
```
