### PR TITLE
a11y fix: updates activity bar inactive foreground icon opacity to improve visibility 

### DIFF
--- a/src/vs/workbench/common/theme.ts
+++ b/src/vs/workbench/common/theme.ts
@@ -402,8 +402,8 @@ export const ACTIVITY_BAR_FOREGROUND = registerColor('activityBar.foreground', {
 }, localize('activityBarForeground', "Activity bar item foreground color when it is active. The activity bar is showing on the far left or right and allows to switch between views of the side bar."));
 
 export const ACTIVITY_BAR_INACTIVE_FOREGROUND = registerColor('activityBar.inactiveForeground', {
-	dark: transparent(ACTIVITY_BAR_FOREGROUND, 0.4),
-	light: transparent(ACTIVITY_BAR_FOREGROUND, 0.4),
+	dark: transparent(ACTIVITY_BAR_FOREGROUND, 0.5),
+	light: transparent(ACTIVITY_BAR_FOREGROUND, 0.5),
 	hcDark: Color.white,
 	hcLight: editorForeground
 }, localize('activityBarInActiveForeground', "Activity bar item foreground color when it is inactive. The activity bar is showing on the far left or right and allows to switch between views of the side bar."));


### PR DESCRIPTION
Changes ACTIVITY_BAR_FOREGROUND opacity to 0.5 to improve/increase the activity bar inactive icon color contrast against the activity bar background. This improves the contrast for both VSCode Light default theme and VSCode Dark default theme.


* **BEFORE Change** VSCode Light Theme: [FG + opacity] rgba(255, 255, 255, 0.4) on top of [BG] rgb(44, 44, 44) interpreted as #808080 : [BG] rgb(44, 44, 44) | [#2c2c2c](https://critique.corp.google.com/#search/&q=tag:2c2c2c) = 3.53
* **AFTER Change** VSCode Light Theme: [FG + opacity] rgba(255, 255, 255, 0.5) on top of [BG] rgba(44, 44, 44) interpreted as #969696 : [BG] rgba(44, 44, 44) | [#2c2c2c](https://critique.corp.google.com/#search/&q=tag:2c2c2c) = 4.72

* **BEFORE Change** VSCode Dark Theme: [FG + opacity] rgba(255, 255, 255, 0.4) on top of [BG] rgb(51, 51, 51) interpreted as #858585 : [BG] rgb(51, 51, 51) | #333333 = 3.42
* **AFTER Change** VSCode Dark Theme: [FG + opacity] rgba(255, 255, 255, 0.5) on top of [BG] rgb(51, 51, 51) interpreted as #999999 : [BG] rgb(51, 51, 51) | #333333 = 4.43

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
