### PR TITLE
Remove `skipSanitize` option and disable command uris by default

### DIFF
--- a/src/vs/workbench/contrib/markdown/browser/markdownDocumentRenderer.ts
+++ b/src/vs/workbench/contrib/markdown/browser/markdownDocumentRenderer.ts
@@ -160,7 +160,6 @@ pre code {
 const defaultAllowedLinkProtocols = Object.freeze([
 	Schemas.http,
 	Schemas.https,
-	Schemas.command,
 ]);
 
 function sanitize(documentContent: string, sanitizerConfig: MarkdownDocumentSanitizerConfig | undefined): TrustedHTML {
@@ -200,7 +199,7 @@ interface MarkdownDocumentSanitizerConfig {
 }
 
 interface IRenderMarkdownDocumentOptions {
-	readonly sanitizerConfig?: 'skipSanitization' | MarkdownDocumentSanitizerConfig;
+	readonly sanitizerConfig?: MarkdownDocumentSanitizerConfig;
 	readonly markedExtensions?: readonly marked.MarkedExtension[];
 }
 
@@ -239,11 +238,7 @@ export async function renderMarkdownDocument(
 	);
 
 	const raw = await raceCancellationError(m.parse(text, { async: true }), token ?? CancellationToken.None);
-	if (options?.sanitizerConfig === 'skipSanitization') {
-		return raw;
-	} else {
-		return sanitize(raw, options?.sanitizerConfig) as any as string;
-	}
+	return sanitize(raw, options?.sanitizerConfig) as any as string;
 }
 
 namespace MarkedHighlight {

--- a/src/vs/workbench/contrib/update/browser/releaseNotesEditor.ts
+++ b/src/vs/workbench/contrib/update/browser/releaseNotesEditor.ts
@@ -265,6 +265,11 @@ export class ReleaseNotesManager extends Disposable {
 		const nonce = generateUuid();
 
 		const content = await renderMarkdownDocument(fileContent.text, this._extensionService, this._languageService, {
+			sanitizerConfig: {
+				allowedLinkProtocols: {
+					override: [Schemas.http, Schemas.https, Schemas.command]
+				}
+			},
 			markedExtensions: [{
 				renderer: {
 					html: this._simpleSettingRenderer.getHtmlRenderer(),


### PR DESCRIPTION
Just adding safer defaults to `renderMarkdownDocument`

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
