### PR TITLE
 Git: Fix worktree checkout default actions

### DIFF
--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -2939,7 +2939,7 @@ export class CommandCenter {
 
 				if (err.gitErrorCode === GitErrorCodes.WorktreeBranchAlreadyUsed) {
 					if (!repository.dotGit.commonPath) {
-						this.handleWorktreeBranchAlreadyUsed(err);
+						await this.handleWorktreeBranchAlreadyUsed(err);
 						return false;
 					}
 
@@ -2949,7 +2949,7 @@ export class CommandCenter {
 						await window.showErrorMessage(message, { modal: true });
 						return false;
 					}
-					this.handleWorktreeBranchAlreadyUsed(err);
+					await this.handleWorktreeBranchAlreadyUsed(err);
 					return false;
 				}
 

--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -2951,27 +2951,31 @@ export class CommandCenter {
 
 						if (pick === createBranch) {
 							await this._branch(repository, undefined, false, mainRepository.HEAD?.name);
+						} else {
+							return false;
 						}
+					} else {
+						this.handleWorktreeBranchAlreadyUsed(err);
 						return false;
 					}
-					this.handleWorktreeBranchAlreadyUsed(err);
-					return false;
 				}
 
-				const stash = l10n.t('Stash & Checkout');
-				const migrate = l10n.t('Migrate Changes');
-				const force = l10n.t('Force Checkout');
-				const choice = await window.showWarningMessage(l10n.t('Your local changes would be overwritten by checkout.'), { modal: true }, stash, migrate, force);
+				if (err.gitErrorCode === GitErrorCodes.DirtyWorkTree) {
+					const stash = l10n.t('Stash & Checkout');
+					const migrate = l10n.t('Migrate Changes');
+					const force = l10n.t('Force Checkout');
+					const choice = await window.showWarningMessage(l10n.t('Your local changes would be overwritten by checkout.'), { modal: true }, stash, migrate, force);
 
-				if (choice === force) {
-					await this.cleanAll(repository);
-					await item.run(repository, opts);
-				} else if (choice === stash || choice === migrate) {
-					if (await this._stash(repository, true)) {
+					if (choice === force) {
+						await this.cleanAll(repository);
 						await item.run(repository, opts);
+					} else if (choice === stash || choice === migrate) {
+						if (await this._stash(repository, true)) {
+							await item.run(repository, opts);
 
-						if (choice === migrate) {
-							await this.stashPopLatest(repository);
+							if (choice === migrate) {
+								await this.stashPopLatest(repository);
+							}
 						}
 					}
 				}

--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -2938,6 +2938,22 @@ export class CommandCenter {
 				}
 
 				if (err.gitErrorCode === GitErrorCodes.WorktreeBranchAlreadyUsed) {
+					if (!repository.dotGit.commonPath) {
+						this.handleWorktreeBranchAlreadyUsed(err);
+						return false;
+					}
+
+					const mainRepository = this.model.getRepository(path.dirname(repository.dotGit.commonPath));
+					if (mainRepository && item.refName && item.refName === mainRepository.HEAD?.name) {
+						const message = l10n.t('Branch "{0}" is already checked out in the current repository.', item.refName);
+						const createBranch = l10n.t('Create a new branch');
+						const pick = await window.showWarningMessage(message, { modal: true }, createBranch);
+
+						if (pick === createBranch) {
+							await this._branch(repository, undefined, false, mainRepository.HEAD?.name);
+						}
+						return false;
+					}
 					this.handleWorktreeBranchAlreadyUsed(err);
 					return false;
 				}
@@ -3658,6 +3674,23 @@ export class CommandCenter {
 		}
 		return;
 	}
+
+	// private async handleBranchAlreadyExists(repository: Repository, message: string): Promise<string | undefined> {
+	// 	const createBranch = l10n.t('Create New Branch');
+	// 	const pick = await window.showWarningMessage(message, { modal: true }, createBranch);
+
+	// 	if (pick !== createBranch) {
+	// 		return undefined;
+	// 	}
+
+	// 	const branch = await this.promptForBranchName(repository);
+
+	// 	if (!branch) {
+	// 		return undefined;
+	// 	}
+
+	// 	return branch;
+	// }
 
 
 	@command('git.deleteWorktree', { repository: true, repositoryFilter: ['worktree'] })

--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -2946,7 +2946,7 @@ export class CommandCenter {
 					const mainRepository = this.model.getRepository(path.dirname(repository.dotGit.commonPath));
 					if (mainRepository && item.refName && item.refName === mainRepository.HEAD?.name) {
 						const message = l10n.t('Branch "{0}" is already checked out in the current repository.', item.refName);
-						const createBranch = l10n.t('Create a new branch');
+						const createBranch = l10n.t('Create New Branch');
 						const pick = await window.showWarningMessage(message, { modal: true }, createBranch);
 
 						if (pick === createBranch) {

--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -3675,24 +3675,6 @@ export class CommandCenter {
 		return;
 	}
 
-	// private async handleBranchAlreadyExists(repository: Repository, message: string): Promise<string | undefined> {
-	// 	const createBranch = l10n.t('Create New Branch');
-	// 	const pick = await window.showWarningMessage(message, { modal: true }, createBranch);
-
-	// 	if (pick !== createBranch) {
-	// 		return undefined;
-	// 	}
-
-	// 	const branch = await this.promptForBranchName(repository);
-
-	// 	if (!branch) {
-	// 		return undefined;
-	// 	}
-
-	// 	return branch;
-	// }
-
-
 	@command('git.deleteWorktree', { repository: true, repositoryFilter: ['worktree'] })
 	async deleteWorktree(repository: Repository): Promise<void> {
 		if (!repository.dotGit.commonPath) {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
Fixes https://github.com/microsoft/vscode/issues/262143

When a user attempts to checkout a branch in a worktree, already in use by main repository, they are presented with an option to create a new branch off of the head of the main repository or cancel. 