### PR TITLE
Allow dialogs in automation

### DIFF
--- a/src/vs/platform/environment/common/argv.ts
+++ b/src/vs/platform/environment/common/argv.ts
@@ -118,6 +118,7 @@ export interface NativeParsedArgs {
 	'file-write'?: boolean;
 	'file-chmod'?: boolean;
 	'enable-smoke-test-driver'?: boolean;
+	'allow-dialogs-while-driven'?: boolean;
 	'remote'?: string;
 	'force'?: boolean;
 	'do-not-sync'?: boolean;

--- a/src/vs/platform/environment/node/argv.ts
+++ b/src/vs/platform/environment/node/argv.ts
@@ -163,6 +163,7 @@ export const OPTIONS: OptionDescriptions<Required<NativeParsedArgs>> = {
 	'export-default-configuration': { type: 'string' },
 	'install-source': { type: 'string' },
 	'enable-smoke-test-driver': { type: 'boolean' },
+	'allow-dialogs-while-driven': { type: 'boolean' },
 	'logExtensionHostCommunication': { type: 'boolean' },
 	'skip-release-notes': { type: 'boolean' },
 	'skip-welcome': { type: 'boolean' },

--- a/src/vs/server/node/server.cli.ts
+++ b/src/vs/server/node/server.cli.ts
@@ -43,6 +43,7 @@ const isSupportedForCmd = (optionId: keyof RemoteParsedArgs) => {
 		case 'export-default-configuration':
 		case 'install-source':
 		case 'enable-smoke-test-driver':
+		case 'allow-dialogs-while-driven':
 		case 'extensions-download-dir':
 		case 'builtin-extensions-dir':
 		case 'telemetry':

--- a/src/vs/server/node/serverEnvironmentService.ts
+++ b/src/vs/server/node/serverEnvironmentService.ts
@@ -36,6 +36,7 @@ export const serverOptions: OptionDescriptions<Required<ServerParsedArgs>> = {
 
 	'user-data-dir': OPTIONS['user-data-dir'],
 	'enable-smoke-test-driver': OPTIONS['enable-smoke-test-driver'],
+	'allow-dialogs-while-driven': OPTIONS['allow-dialogs-while-driven'],
 	'disable-telemetry': OPTIONS['disable-telemetry'],
 	'disable-experiments': OPTIONS['disable-experiments'],
 	'disable-workspace-trust': OPTIONS['disable-workspace-trust'],
@@ -159,6 +160,7 @@ export interface ServerParsedArgs {
 	'user-data-dir'?: string;
 
 	'enable-smoke-test-driver'?: boolean;
+	'allow-dialogs-while-driven'?: boolean;
 
 	'disable-telemetry'?: boolean;
 	'disable-experiments'?: boolean;

--- a/src/vs/workbench/electron-browser/parts/dialogs/dialog.contribution.ts
+++ b/src/vs/workbench/electron-browser/parts/dialogs/dialog.contribution.ts
@@ -21,6 +21,7 @@ import { IInstantiationService } from '../../../../platform/instantiation/common
 import { Lazy } from '../../../../base/common/lazy.js';
 import { IOpenerService } from '../../../../platform/opener/common/opener.js';
 import { createNativeAboutDialogDetails } from '../../../../platform/dialogs/electron-browser/dialog.js';
+import { IWorkbenchEnvironmentService } from '../../../services/environment/common/environmentService.js';
 
 export class DialogHandlerContribution extends Disposable implements IWorkbenchContribution {
 
@@ -42,6 +43,7 @@ export class DialogHandlerContribution extends Disposable implements IWorkbenchC
 		@IProductService private productService: IProductService,
 		@IClipboardService clipboardService: IClipboardService,
 		@INativeHostService private nativeHostService: INativeHostService,
+		@IWorkbenchEnvironmentService private environmentService: IWorkbenchEnvironmentService,
 		@IOpenerService openerService: IOpenerService
 	) {
 		super();
@@ -109,7 +111,9 @@ export class DialogHandlerContribution extends Disposable implements IWorkbenchC
 	}
 
 	private get useCustomDialog(): boolean {
-		return this.configurationService.getValue('window.dialogStyle') === 'custom';
+		return this.configurationService.getValue('window.dialogStyle') === 'custom' ||
+			// Use the custom dialog while driven so that the driver can interact with it
+			!!this.environmentService.allowDialogsWhileDriven;
 	}
 }
 

--- a/src/vs/workbench/services/dialogs/browser/abstractFileDialogService.ts
+++ b/src/vs/workbench/services/dialogs/browser/abstractFileDialogService.ts
@@ -146,7 +146,7 @@ export abstract class AbstractFileDialogService implements IFileDialogService {
 			return true; // integration tests
 		}
 
-		return !!this.environmentService.enableSmokeTestDriver; // smoke tests
+		return !this.environmentService.allowDialogsWhileDriven;
 	}
 
 	private async doShowSaveConfirm(fileNamesOrResources: (string | URI)[]): Promise<ConfirmResult> {

--- a/src/vs/workbench/services/dialogs/common/dialogService.ts
+++ b/src/vs/workbench/services/dialogs/common/dialogService.ts
@@ -33,7 +33,7 @@ export class DialogService extends Disposable implements IDialogService {
 			return true; // integration tests
 		}
 
-		return !!this.environmentService.enableSmokeTestDriver; // smoke tests
+		return !this.environmentService.allowDialogsWhileDriven; // smoke tests
 	}
 
 	async confirm(confirmation: IConfirmation): Promise<IConfirmationResult> {

--- a/src/vs/workbench/services/environment/common/environmentService.ts
+++ b/src/vs/workbench/services/environment/common/environmentService.ts
@@ -41,6 +41,7 @@ export interface IWorkbenchEnvironmentService extends IEnvironmentService {
 	readonly debugRenderer: boolean;
 	readonly logExtensionHostCommunication?: boolean;
 	readonly enableSmokeTestDriver?: boolean;
+	readonly allowDialogsWhileDriven?: boolean;
 	readonly profDurationMarkers?: string[];
 
 	// --- Editors to open

--- a/src/vs/workbench/services/environment/electron-browser/environmentService.ts
+++ b/src/vs/workbench/services/environment/electron-browser/environmentService.ts
@@ -120,6 +120,9 @@ export class NativeWorkbenchEnvironmentService extends AbstractNativeEnvironment
 	get enableSmokeTestDriver(): boolean { return !!this.args['enable-smoke-test-driver']; }
 
 	@memoize
+	get allowDialogsWhileDriven(): boolean { return !!this.args['allow-dialogs-while-driven']; }
+
+	@memoize
 	get extensionEnabledProposedApi(): string[] | undefined {
 		if (Array.isArray(this.args['enable-proposed-api'])) {
 			return this.args['enable-proposed-api'];

--- a/test/automation/src/code.ts
+++ b/test/automation/src/code.ts
@@ -26,6 +26,7 @@ export interface LaunchOptions {
 	readonly remote?: boolean;
 	readonly web?: boolean;
 	readonly tracing?: boolean;
+	readonly allowDialogs?: boolean;
 	snapshots?: boolean;
 	readonly headless?: boolean;
 	readonly browser?: 'chromium' | 'webkit' | 'firefox' | 'chromium-msedge' | 'chromium-chrome';

--- a/test/automation/src/playwrightBrowser.ts
+++ b/test/automation/src/playwrightBrowser.ts
@@ -57,6 +57,9 @@ async function launchServer(options: LaunchOptions) {
 	if (options.verbose) {
 		args.push('--log=trace');
 	}
+	if (options.allowDialogs) {
+		args.push('--allow-dialogs-while-driven');
+	}
 
 	let serverLocation: string | undefined;
 	if (codeServerPath) {

--- a/test/automation/src/playwrightElectron.ts
+++ b/test/automation/src/playwrightElectron.ts
@@ -15,6 +15,9 @@ export async function launch(options: LaunchOptions): Promise<{ electronProcess:
 	// Resolve electron config and update
 	const { electronPath, args, env } = await resolveElectronConfiguration(options);
 	args.push('--enable-smoke-test-driver');
+	if (options.allowDialogs) {
+		args.push('--allow-dialogs-while-driven');
+	}
 
 	// Launch electron via playwright
 	const { electron, context, page } = await launchElectron({ electronPath, args, env }, options);

--- a/test/mcp/src/playwright.ts
+++ b/test/mcp/src/playwright.ts
@@ -30,7 +30,8 @@ const opts = minimist(args, {
 		'remote',
 		'web',
 		'headless',
-		'tracing'
+		'tracing',
+		'skip-dialogs'
 	],
 	default: {
 		verbose: false
@@ -43,6 +44,7 @@ const opts = minimist(args, {
 	tracing?: boolean;
 	build?: string;
 	'stable-build'?: string;
+	'skip-dialogs'?: boolean;
 	browser?: 'chromium' | 'webkit' | 'firefox' | 'chromium-msedge' | 'chromium-chrome' | undefined;
 	electronArgs?: string;
 };
@@ -358,6 +360,7 @@ export async function getServer() {
 		userDataDir,
 		extensionsPath,
 		logger,
+		allowDialogs: !opts['skip-dialogs'] && !opts.headless,
 		logsPath: path.join(logsRootPath, 'suite_unknown'),
 		crashesPath: path.join(crashesRootPath, 'suite_unknown'),
 		verbose: opts.verbose,


### PR DESCRIPTION
So that mcp can use dialogs and let the user answer the dialogs. This is critical for auth.

This also switches to using the custom dialog in electron so that the driver can interact with it.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
ref https://github.com/microsoft/vscode/issues/262164