### PR TITLE
support model switching in automation

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/actions/chatActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatActions.ts
@@ -72,9 +72,8 @@ import { VIEWLET_ID } from '../chatSessions.js';
 import { ChatViewPane } from '../chatViewPane.js';
 import { convertBufferToScreenshotVariable } from '../contrib/screenshot.js';
 import { clearChatEditor } from './chatClear.js';
-import { ILanguageModelsService } from '../../common/languageModels.js';
+import { ILanguageModelChatSelector, ILanguageModelsService } from '../../common/languageModels.js';
 import { IChatResponseModel } from '../../common/chatModel.js';
-import { LanguageModelChatSelector } from 'vscode';
 
 export const CHAT_CATEGORY = localize2('chat.category', 'Chat');
 
@@ -127,7 +126,7 @@ export interface IChatViewOpenOptions {
 	 * }
 	 * ```
 	 */
-	modelSelector?: LanguageModelChatSelector;
+	modelSelector?: ILanguageModelChatSelector;
 
 	/**
 	 * Wait to resolve the command until the chat response reaches a terminal state (complete, error, or pending user confirmation, etc.).

--- a/src/vs/workbench/contrib/chat/browser/actions/chatActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatActions.ts
@@ -72,6 +72,7 @@ import { VIEWLET_ID } from '../chatSessions.js';
 import { ChatViewPane } from '../chatViewPane.js';
 import { convertBufferToScreenshotVariable } from '../contrib/screenshot.js';
 import { clearChatEditor } from './chatClear.js';
+import { ILanguageModelsService } from '../../common/languageModels.js';
 
 export const CHAT_CATEGORY = localize2('chat.category', 'Chat');
 
@@ -111,6 +112,11 @@ export interface IChatViewOpenOptions {
 	 * The mode ID or name to open the chat in.
 	 */
 	mode?: ChatModeKind | string;
+
+	/**
+	 * The language model ID to use for the chat (e.g. 'copilot/claude-sonnet-4').
+	 */
+	modelId?: string;
 }
 
 export interface IChatViewOpenRequestEntry {
@@ -149,6 +155,7 @@ abstract class OpenChatGlobalAction extends Action2 {
 		const commandService = accessor.get(ICommandService);
 		const chatModeService = accessor.get(IChatModeService);
 		const fileService = accessor.get(IFileService);
+		const languageModelService = accessor.get(ILanguageModelsService);
 
 		let chatWidget = widgetService.lastFocusedWidget;
 		// When this was invoked to switch to a mode via keybinding, and some chat widget is focused, use that one.
@@ -164,6 +171,17 @@ abstract class OpenChatGlobalAction extends Action2 {
 		const switchToMode = (opts?.mode ? chatModeService.findModeByName(opts?.mode) : undefined) ?? this.mode;
 		if (switchToMode) {
 			await this.handleSwitchToMode(switchToMode, chatWidget, instaService, commandService);
+		}
+
+		if (opts?.modelId) {
+			await languageModelService.selectLanguageModels({}, false);
+			const model = languageModelService.lookupLanguageModel(opts.modelId);
+			if (!model) {
+				const models = languageModelService.getLanguageModelIds();
+				throw new Error(`Language model not found for ID: ${opts.modelId}. Valid options are: ${models.join(', ')}.`);
+			}
+
+			chatWidget.input.setCurrentLanguageModel({ metadata: model, identifier: opts.modelId });
 		}
 
 		if (opts?.previousRequests?.length && chatWidget.viewModel) {

--- a/src/vs/workbench/contrib/chat/browser/actions/chatActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatActions.ts
@@ -116,13 +116,23 @@ export interface IChatViewOpenOptions {
 
 	/**
 	 * The language model selector to use for the chat.
-	 * An Error will be thrown if there's no match or if it matches multiple models.
+	 * An Error will be thrown if there's no match. If there are multiple
+	 * matches, the first match will be used.
 	 *
-	 * Example:
+	 * Examples:
+	 *
 	 * ```
 	 * {
 	 *   id: 'claude-sonnet-4',
 	 *   vendor: 'copilot'
+	 * }
+	 * ```
+	 *
+	 * Use `claude-sonnet-4` from any vendor:
+	 *
+	 * ```
+	 * {
+	 *   id: 'claude-sonnet-4',
 	 * }
 	 * ```
 	 */
@@ -194,11 +204,7 @@ abstract class OpenChatGlobalAction extends Action2 {
 				throw new Error(`No language models found matching selector: ${JSON.stringify(opts.modelSelector)}.`);
 			}
 
-			if (ids.length > 1) {
-				throw new Error(`Multiple language models found matching selector: ${JSON.stringify(opts.modelSelector)}. Please specify a more specific selector.`);
-			}
-
-			const id = ids[0];
+			const id = ids.sort()[0];
 			const model = languageModelService.lookupLanguageModel(id);
 			if (!model) {
 				throw new Error(`Language model not loaded: ${id}.`);

--- a/src/vs/workbench/contrib/chat/browser/actions/chatActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatActions.ts
@@ -200,11 +200,11 @@ abstract class OpenChatGlobalAction extends Action2 {
 
 		if (opts?.modelSelector) {
 			const ids = await languageModelService.selectLanguageModels(opts.modelSelector, false);
-			if (ids.length === 0) {
+			const id = ids.sort().at(0);
+			if (!id) {
 				throw new Error(`No language models found matching selector: ${JSON.stringify(opts.modelSelector)}.`);
 			}
 
-			const id = ids.sort()[0];
 			const model = languageModelService.lookupLanguageModel(id);
 			if (!model) {
 				throw new Error(`Language model not loaded: ${id}.`);

--- a/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
@@ -599,6 +599,20 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 		this.modeWidget?.show();
 	}
 
+	public setCurrentLanguageModel(model: ILanguageModelChatMetadataAndIdentifier) {
+		this._currentLanguageModel = model;
+
+		if (this.cachedDimensions) {
+			// For quick chat and editor chat, relayout because the input may need to shrink to accomodate the model name
+			this.layout(this.cachedDimensions.height, this.cachedDimensions.width);
+		}
+
+		this.storageService.store(this.getSelectedModelStorageKey(), model.identifier, StorageScope.APPLICATION, StorageTarget.USER);
+		this.storageService.store(this.getSelectedModelIsDefaultStorageKey(), !!model.metadata.isDefault, StorageScope.APPLICATION, StorageTarget.USER);
+
+		this._onDidChangeCurrentLanguageModel.fire(model);
+	}
+
 	private checkModelSupported(): void {
 		if (this._currentLanguageModel && !this.modelSupportedForDefaultAgent(this._currentLanguageModel)) {
 			this.setCurrentLanguageModelToDefault();
@@ -662,20 +676,6 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 		if (defaultModel) {
 			this.setCurrentLanguageModel(defaultModel);
 		}
-	}
-
-	private setCurrentLanguageModel(model: ILanguageModelChatMetadataAndIdentifier) {
-		this._currentLanguageModel = model;
-
-		if (this.cachedDimensions) {
-			// For quick chat and editor chat, relayout because the input may need to shrink to accomodate the model name
-			this.layout(this.cachedDimensions.height, this.cachedDimensions.width);
-		}
-
-		this.storageService.store(this.getSelectedModelStorageKey(), model.identifier, StorageScope.APPLICATION, StorageTarget.USER);
-		this.storageService.store(this.getSelectedModelIsDefaultStorageKey(), !!model.metadata.isDefault, StorageScope.APPLICATION, StorageTarget.USER);
-
-		this._onDidChangeCurrentLanguageModel.fire(model);
 	}
 
 	private loadHistory(): HistoryNavigator2<IChatHistoryEntry> {


### PR DESCRIPTION
Programmatically allow setting models via `workbench.action.chat.open` for automation scenarios.

`setCurrentLanguageModel` implementation visibility is changed from `private` to `public`, but it's implementation remains unchanged. Re-located to be alongside the other `public` methods.

Manually tested the command:

<img width="283" height="111" alt="Screenshot 2025-08-20 at 10 13 56 AM" src="https://github.com/user-attachments/assets/15510e4d-7271-477b-b5b1-fbc57f75b1ea" />
