### PR TITLE
Adds support for InlineCompletion.correlationId

### DIFF
--- a/src/vs/editor/common/languages.ts
+++ b/src/vs/editor/common/languages.ts
@@ -832,6 +832,11 @@ export interface InlineCompletion {
 	readonly warning?: InlineCompletionWarning;
 
 	readonly displayLocation?: InlineCompletionDisplayLocation;
+
+	/**
+	 * Used for telemetry.
+	 */
+	readonly correlationId?: string | undefined;
 }
 
 export interface InlineCompletionWarning {
@@ -1000,6 +1005,7 @@ export type InlineCompletionEndOfLifeReason<TInlineCompletion = InlineCompletion
 
 export type LifetimeSummary = {
 	requestUuid: string;
+	correlationId: string | undefined;
 	partiallyAccepted: number;
 	partiallyAcceptedCountSinceOriginal: number;
 	partiallyAcceptedRatioSinceOriginal: number;

--- a/src/vs/editor/contrib/inlineCompletions/browser/model/provideInlineCompletions.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/model/provideInlineCompletions.ts
@@ -242,6 +242,7 @@ function toInlineSuggestData(
 		inlineCompletion.isInlineEdit ?? false,
 		requestInfo,
 		providerRequestInfo,
+		inlineCompletion.correlationId,
 	);
 }
 
@@ -301,6 +302,7 @@ export class InlineSuggestData {
 
 		private readonly _requestInfo: InlineSuggestRequestInfo,
 		private readonly _providerRequestInfo: InlineSuggestProviderRequestInfo,
+		private readonly _correlationId: string | undefined,
 	) {
 		this._viewData = { editorType: _requestInfo.editorType };
 	}
@@ -368,6 +370,7 @@ export class InlineSuggestData {
 		if (this.source.provider.handleEndOfLifetime) {
 			const summary: LifetimeSummary = {
 				requestUuid: this.context.requestUuid,
+				correlationId: this._correlationId,
 				partiallyAccepted: this._partiallyAcceptedCount,
 				partiallyAcceptedCountSinceOriginal: this._partiallyAcceptedSinceOriginal.count,
 				partiallyAcceptedRatioSinceOriginal: this._partiallyAcceptedSinceOriginal.ratio,

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -7527,6 +7527,10 @@ declare namespace monaco.languages {
 		readonly showRange?: IRange;
 		readonly warning?: InlineCompletionWarning;
 		readonly displayLocation?: InlineCompletionDisplayLocation;
+		/**
+		 * Used for telemetry.
+		 */
+		readonly correlationId?: string | undefined;
 	}
 
 	export interface InlineCompletionWarning {
@@ -7633,6 +7637,7 @@ declare namespace monaco.languages {
 
 	export type LifetimeSummary = {
 		requestUuid: string;
+		correlationId: string | undefined;
 		partiallyAccepted: number;
 		partiallyAcceptedCountSinceOriginal: number;
 		partiallyAcceptedRatioSinceOriginal: number;

--- a/src/vs/workbench/api/browser/mainThreadLanguageFeatures.ts
+++ b/src/vs/workbench/api/browser/mainThreadLanguageFeatures.ts
@@ -652,6 +652,7 @@ export class MainThreadLanguageFeatures extends Disposable implements MainThread
 				const endOfLifeSummary: InlineCompletionEndOfLifeEvent = {
 					id: lifetimeSummary.requestUuid,
 					opportunityId: lifetimeSummary.requestUuid,
+					correlationId: lifetimeSummary.correlationId,
 					shown: lifetimeSummary.shown,
 					shownDuration: lifetimeSummary.shownDuration,
 					shownDurationUncollapsed: lifetimeSummary.shownDurationUncollapsed,
@@ -1315,6 +1316,7 @@ type InlineCompletionEndOfLifeEvent = {
 	 */
 	id: string;
 	opportunityId: string;
+	correlationId: string | undefined;
 	extensionId: string;
 	extensionVersion: string;
 	shown: boolean;
@@ -1352,6 +1354,7 @@ type InlineCompletionsEndOfLifeClassification = {
 	comment: 'Inline completions ended';
 	id: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The identifier for the inline completion request' };
 	opportunityId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Unique identifier for an opportunity to show an inline completion or NES' };
+	correlationId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The correlation identifier for the inline completion' };
 	extensionId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The identifier for the extension that contributed the inline completion' };
 	extensionVersion: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The version of the extension that contributed the inline completion' };
 	shown: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Whether the inline completion was shown to the user' };

--- a/src/vs/workbench/api/common/extHostLanguageFeatures.ts
+++ b/src/vs/workbench/api/common/extHostLanguageFeatures.ts
@@ -1437,6 +1437,7 @@ class InlineCompletionAdapter {
 						message: typeConvert.MarkdownString.from(item.warning.message),
 						icon: item.warning.icon ? typeConvert.IconPath.fromThemeIcon(item.warning.icon) : undefined,
 					} : undefined,
+					correlationId: this._isAdditionsProposedApiEnabled ? item.correlationId : undefined,
 				});
 			}),
 			commands: commands.map(c => {

--- a/src/vscode-dts/vscode.proposed.inlineCompletionsAdditions.d.ts
+++ b/src/vscode-dts/vscode.proposed.inlineCompletionsAdditions.d.ts
@@ -46,6 +46,9 @@ declare module 'vscode' {
 		action?: Command;
 
 		displayLocation?: InlineCompletionDisplayLocation;
+
+		/** Used for telemetry. Can be an arbitrary string. */
+		correlationId?: string;
 	}
 
 	export enum InlineCompletionDisplayLocationKind {


### PR DESCRIPTION
Providers that use `inlineCompletionsAdditions` can now set a `correlationId` on each inline completion. This id will be included in endoflife telemetry events.