### PR TITLE
debug: convert the renderer attacher to a standard websocket

### DIFF
--- a/src/vs/base/parts/ipc/node/ipc.net.ts
+++ b/src/vs/base/parts/ipc/node/ipc.net.ts
@@ -3,10 +3,13 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import * as crypto from 'crypto';
 import { createHash } from 'crypto';
-import { Server as NetServer, Socket, createServer, createConnection } from 'net';
+import * as http from 'http';
+import * as net from 'net';
+import { Server as NetServer, Socket, createConnection, createServer } from 'net';
 import { tmpdir } from 'os';
-import { createDeflateRaw, ZlibOptions, InflateRaw, DeflateRaw, createInflateRaw } from 'zlib';
+import { DeflateRaw, InflateRaw, ZlibOptions, createDeflateRaw, createInflateRaw } from 'zlib';
 import { VSBuffer } from '../../../common/buffer.js';
 import { onUnexpectedError } from '../../../common/errors.js';
 import { Emitter, Event } from '../../../common/event.js';
@@ -16,6 +19,70 @@ import { Platform, platform } from '../../../common/platform.js';
 import { generateUuid } from '../../../common/uuid.js';
 import { ClientConnectionEvent, IPCServer } from '../common/ipc.js';
 import { ChunkStream, Client, ISocket, Protocol, SocketCloseEvent, SocketCloseEventType, SocketDiagnostics, SocketDiagnosticsEventType } from '../common/ipc.net.js';
+
+export function upgradeToISocket(req: http.IncomingMessage, socket: net.Socket, {
+	debugLabel,
+	skipWebSocketFrames = false,
+	disableWebSocketCompression = false,
+}: {
+	debugLabel: string;
+	skipWebSocketFrames?: boolean;
+	disableWebSocketCompression?: boolean;
+}): NodeSocket | WebSocketNodeSocket | undefined {
+	if (req.headers['upgrade'] === undefined || req.headers['upgrade'].toLowerCase() !== 'websocket') {
+		socket.end('HTTP/1.1 400 Bad Request');
+		return;
+	}
+
+	// https://tools.ietf.org/html/rfc6455#section-4
+	const requestNonce = req.headers['sec-websocket-key'];
+	const hash = crypto.createHash('sha1');// CodeQL [SM04514] SHA1 must be used here to respect the WebSocket protocol specification
+	hash.update(requestNonce + '258EAFA5-E914-47DA-95CA-C5AB0DC85B11');
+	const responseNonce = hash.digest('base64');
+
+	const responseHeaders = [
+		`HTTP/1.1 101 Switching Protocols`,
+		`Upgrade: websocket`,
+		`Connection: Upgrade`,
+		`Sec-WebSocket-Accept: ${responseNonce}`
+	];
+
+	// See https://tools.ietf.org/html/rfc7692#page-12
+	let permessageDeflate = false;
+	if (!skipWebSocketFrames && !disableWebSocketCompression && req.headers['sec-websocket-extensions']) {
+		const websocketExtensionOptions = Array.isArray(req.headers['sec-websocket-extensions']) ? req.headers['sec-websocket-extensions'] : [req.headers['sec-websocket-extensions']];
+		for (const websocketExtensionOption of websocketExtensionOptions) {
+			if (/\b((server_max_window_bits)|(server_no_context_takeover)|(client_no_context_takeover))\b/.test(websocketExtensionOption)) {
+				// sorry, the server does not support zlib parameter tweaks
+				continue;
+			}
+			if (/\b(permessage-deflate)\b/.test(websocketExtensionOption)) {
+				permessageDeflate = true;
+				responseHeaders.push(`Sec-WebSocket-Extensions: permessage-deflate`);
+				break;
+			}
+			if (/\b(x-webkit-deflate-frame)\b/.test(websocketExtensionOption)) {
+				permessageDeflate = true;
+				responseHeaders.push(`Sec-WebSocket-Extensions: x-webkit-deflate-frame`);
+				break;
+			}
+		}
+	}
+
+	socket.write(responseHeaders.join('\r\n') + '\r\n\r\n');
+
+	// Never timeout this socket due to inactivity!
+	socket.setTimeout(0);
+	// Disable Nagle's algorithm
+	socket.setNoDelay(true);
+	// Finally!
+
+	if (skipWebSocketFrames) {
+		return new NodeSocket(socket, debugLabel);
+	} else {
+		return new WebSocketNodeSocket(new NodeSocket(socket, debugLabel), permessageDeflate, null, true);
+	}
+}
 
 /**
  * Maximum time to wait for a 'close' event to fire after the socket stream

--- a/src/vs/platform/debug/common/extensionHostDebug.ts
+++ b/src/vs/platform/debug/common/extensionHostDebug.ts
@@ -28,7 +28,7 @@ export interface ICloseSessionEvent {
 }
 
 export interface IOpenExtensionWindowResult {
-	rendererDebugPort?: number;
+	rendererDebugAddr?: string;
 	success: boolean;
 }
 

--- a/src/vs/platform/debug/electron-main/extensionHostDebugIpc.ts
+++ b/src/vs/platform/debug/electron-main/extensionHostDebugIpc.ts
@@ -4,7 +4,13 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { BrowserWindow } from 'electron';
-import { AddressInfo, createServer } from 'net';
+import { createServer } from 'http';
+import { Socket } from 'net';
+import { VSBuffer } from '../../../base/common/buffer.js';
+import { DisposableStore, toDisposable } from '../../../base/common/lifecycle.js';
+import { generateUuid } from '../../../base/common/uuid.js';
+import { ISocket } from '../../../base/parts/ipc/common/ipc.net.js';
+import { upgradeToISocket } from '../../../base/parts/ipc/node/ipc.net.js';
 import { OPTIONS, parseArgs } from '../../environment/node/argv.js';
 import { IWindowsMainService, OpenContext } from '../../windows/electron-main/windows.js';
 import { IOpenExtensionWindowResult } from '../common/extensionHostDebug.js';
@@ -65,69 +71,88 @@ export class ElectronExtensionHostDebugBroadcastChannel<TContext> extends Extens
 		return this.openCdp(win);
 	}
 
+	private openCdpServer(ident: string, onSocket: (socket: ISocket) => void) {
+		const server = createServer((req, res) => {
+			res.statusCode = 404;
+			res.end();
+		});
+
+		server.on('upgrade', (req, socket) => {
+			if (!req.url?.includes(ident)) {
+				socket.end();
+				return;
+			}
+			const upgraded = upgradeToISocket(req, socket as Socket, {
+				debugLabel: 'extension-host-cdp-' + generateUuid(),
+			});
+
+			if (upgraded) {
+				onSocket(upgraded);
+			}
+		});
+
+		return server;
+	}
+
 	private async openCdp(win: BrowserWindow): Promise<IOpenExtensionWindowResult> {
 		const debug = win.webContents.debugger;
 
 		let listeners = debug.isAttached() ? Infinity : 0;
-		const server = createServer(listener => {
+		const ident = generateUuid();
+		const server = this.openCdpServer(ident, listener => {
 			if (listeners++ === 0) {
 				debug.attach();
 			}
 
-			let closed = false;
+			const store = new DisposableStore();
+			store.add(listener);
+
 			const writeMessage = (message: object) => {
-				if (!closed) { // in case sendCommand promises settle after closed
-					listener.write(JSON.stringify(message) + '\0'); // null-delimited, CDP-compatible
+				if (!store.isDisposed) { // in case sendCommand promises settle after closed
+					listener.write(VSBuffer.fromString(JSON.stringify(message))); // null-delimited, CDP-compatible
 				}
 			};
 
 			const onMessage = (_event: Electron.Event, method: string, params: unknown, sessionId?: string) =>
-				writeMessage(({ method, params, sessionId }));
+				writeMessage({ method, params, sessionId });
 
-			win.on('close', () => {
-				debug.removeListener('message', onMessage);
+			const onWindowClose = () => {
 				listener.end();
-				closed = true;
-			});
+				store.dispose();
+			};
+
+			win.addListener('close', onWindowClose);
+			store.add(toDisposable(() => win.removeListener('close', onWindowClose)));
 
 			debug.addListener('message', onMessage);
+			store.add(toDisposable(() => debug.removeListener('message', onMessage)));
 
-			let buf = Buffer.alloc(0);
-			listener.on('data', data => {
-				buf = Buffer.concat([buf, data]);
-				for (let delimiter = buf.indexOf(0); delimiter !== -1; delimiter = buf.indexOf(0)) {
-					let data: { id: number; sessionId: string; params: {} };
-					try {
-						const contents = buf.slice(0, delimiter).toString('utf8');
-						buf = buf.slice(delimiter + 1);
-						data = JSON.parse(contents);
-					} catch (e) {
-						console.error('error reading cdp line', e);
-					}
-
-					// depends on a new API for which electron.d.ts has not been updated:
-					// @ts-ignore
-					debug.sendCommand(data.method, data.params, data.sessionId)
-						.then((result: object) => writeMessage({ id: data.id, sessionId: data.sessionId, result }))
-						.catch((error: Error) => writeMessage({ id: data.id, sessionId: data.sessionId, error: { code: 0, message: error.message } }));
+			store.add(listener.onData(rawData => {
+				let data: { id: number; sessionId: string; method: string; params: {} };
+				try {
+					data = JSON.parse(rawData.toString());
+				} catch (e) {
+					console.error('error reading cdp line', e);
+					return;
 				}
-			});
 
-			listener.on('error', err => {
-				console.error('error on cdp pipe:', err);
-			});
+				debug.sendCommand(data.method, data.params, data.sessionId)
+					.then((result: object) => writeMessage({ id: data.id, sessionId: data.sessionId, result }))
+					.catch((error: Error) => writeMessage({ id: data.id, sessionId: data.sessionId, error: { code: 0, message: error.message } }));
+			}));
 
-			listener.on('close', () => {
-				closed = true;
+			store.add(listener.onClose(() => {
 				if (--listeners === 0) {
 					debug.detach();
 				}
-			});
+			}));
 		});
 
-		await new Promise<void>(r => server.listen(0, r));
+		await new Promise<void>(r => server.listen(0, '127.0.0.1', r));
 		win.on('close', () => server.close());
 
-		return { rendererDebugPort: (server.address() as AddressInfo).port, success: true };
+		const serverAddr = server.address();
+		const serverAddrBase = typeof serverAddr === 'string' ? serverAddr : `ws://127.0.0.1:${serverAddr?.port}`;
+		return { rendererDebugAddr: `${serverAddrBase}/${ident}`, success: true };
 	}
 }

--- a/src/vs/server/node/remoteExtensionHostAgentServer.ts
+++ b/src/vs/server/node/remoteExtensionHostAgentServer.ts
@@ -3,10 +3,10 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import * as crypto from 'crypto';
 import * as fs from 'fs';
 import * as http from 'http';
 import * as net from 'net';
+import { createRequire } from 'node:module';
 import { performance } from 'perf_hooks';
 import * as url from 'url';
 import { VSBuffer } from '../../base/common/buffer.js';
@@ -25,7 +25,7 @@ import { getOSReleaseInfo } from '../../base/node/osReleaseInfo.js';
 import { findFreePort } from '../../base/node/ports.js';
 import { addUNCHostToAllowlist, disableUNCAccessRestrictions } from '../../base/node/unc.js';
 import { PersistentProtocol } from '../../base/parts/ipc/common/ipc.net.js';
-import { NodeSocket, WebSocketNodeSocket } from '../../base/parts/ipc/node/ipc.net.js';
+import { NodeSocket, upgradeToISocket, WebSocketNodeSocket } from '../../base/parts/ipc/node/ipc.net.js';
 import { IConfigurationService } from '../../platform/configuration/common/configuration.js';
 import { IInstantiationService } from '../../platform/instantiation/common/instantiation.js';
 import { ILogService } from '../../platform/log/common/log.js';
@@ -39,7 +39,6 @@ import { determineServerConnectionToken, requestHasValidConnectionToken as httpR
 import { IServerEnvironmentService, ServerParsedArgs } from './serverEnvironmentService.js';
 import { setupServerServices, SocketServer } from './serverServices.js';
 import { CacheControl, serveError, serveFile, WebClientServer } from './webClientServer.js';
-import { createRequire } from 'node:module';
 const require = createRequire(import.meta.url);
 
 const SHUTDOWN_TIMEOUT = 5 * 60 * 1000;
@@ -209,59 +208,17 @@ class RemoteExtensionHostAgentServer extends Disposable implements IServerAPI {
 			}
 		}
 
-		if (req.headers['upgrade'] === undefined || req.headers['upgrade'].toLowerCase() !== 'websocket') {
-			socket.end('HTTP/1.1 400 Bad Request');
+		const upgraded = upgradeToISocket(req, socket, {
+			debugLabel: `server-connection-${reconnectionToken}`,
+			skipWebSocketFrames,
+			disableWebSocketCompression: this._environmentService.args['disable-websocket-compression']
+		});
+
+		if (!upgraded) {
 			return;
 		}
 
-		// https://tools.ietf.org/html/rfc6455#section-4
-		const requestNonce = req.headers['sec-websocket-key'];
-		const hash = crypto.createHash('sha1');// CodeQL [SM04514] SHA1 must be used here to respect the WebSocket protocol specification
-		hash.update(requestNonce + '258EAFA5-E914-47DA-95CA-C5AB0DC85B11');
-		const responseNonce = hash.digest('base64');
-
-		const responseHeaders = [
-			`HTTP/1.1 101 Switching Protocols`,
-			`Upgrade: websocket`,
-			`Connection: Upgrade`,
-			`Sec-WebSocket-Accept: ${responseNonce}`
-		];
-
-		// See https://tools.ietf.org/html/rfc7692#page-12
-		let permessageDeflate = false;
-		if (!skipWebSocketFrames && !this._environmentService.args['disable-websocket-compression'] && req.headers['sec-websocket-extensions']) {
-			const websocketExtensionOptions = Array.isArray(req.headers['sec-websocket-extensions']) ? req.headers['sec-websocket-extensions'] : [req.headers['sec-websocket-extensions']];
-			for (const websocketExtensionOption of websocketExtensionOptions) {
-				if (/\b((server_max_window_bits)|(server_no_context_takeover)|(client_no_context_takeover))\b/.test(websocketExtensionOption)) {
-					// sorry, the server does not support zlib parameter tweaks
-					continue;
-				}
-				if (/\b(permessage-deflate)\b/.test(websocketExtensionOption)) {
-					permessageDeflate = true;
-					responseHeaders.push(`Sec-WebSocket-Extensions: permessage-deflate`);
-					break;
-				}
-				if (/\b(x-webkit-deflate-frame)\b/.test(websocketExtensionOption)) {
-					permessageDeflate = true;
-					responseHeaders.push(`Sec-WebSocket-Extensions: x-webkit-deflate-frame`);
-					break;
-				}
-			}
-		}
-
-		socket.write(responseHeaders.join('\r\n') + '\r\n\r\n');
-
-		// Never timeout this socket due to inactivity!
-		socket.setTimeout(0);
-		// Disable Nagle's algorithm
-		socket.setNoDelay(true);
-		// Finally!
-
-		if (skipWebSocketFrames) {
-			this._handleWebSocketConnection(new NodeSocket(socket, `server-connection-${reconnectionToken}`), isReconnection, reconnectionToken);
-		} else {
-			this._handleWebSocketConnection(new WebSocketNodeSocket(new NodeSocket(socket, `server-connection-${reconnectionToken}`), permessageDeflate, null, true), isReconnection, reconnectionToken);
-		}
+		this._handleWebSocketConnection(upgraded, isReconnection, reconnectionToken);
 	}
 
 	public handleServerError(err: Error): void {

--- a/src/vs/workbench/contrib/debug/browser/rawDebugSession.ts
+++ b/src/vs/workbench/contrib/debug/browser/rawDebugSession.ts
@@ -674,7 +674,7 @@ export class RawDebugSession implements IDisposable {
 					}
 				}
 				response.body = {
-					rendererDebugPort: result.rendererDebugPort,
+					rendererDebugAddr: result.rendererDebugAddr,
 				};
 				safeSendResponse(response);
 			} catch (err) {


### PR DESCRIPTION
Allows better interoperability with other tools. `rendererDebugPort`
is not `rendererDebugAddr` which is a `ws://` address.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
