### PR TITLE
Simplify `actionHandler` argument for rendering markdown

### DIFF
--- a/src/vs/base/browser/ui/selectBox/selectBox.ts
+++ b/src/vs/base/browser/ui/selectBox/selectBox.ts
@@ -3,16 +3,16 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { IContentActionHandler } from '../../formattedTextRenderer.js';
-import { IContextViewProvider } from '../contextview/contextview.js';
-import { IListStyles, unthemedListStyles } from '../list/listWidget.js';
-import { SelectBoxList } from './selectBoxCustom.js';
-import { SelectBoxNative } from './selectBoxNative.js';
-import { Widget } from '../widget.js';
 import { Event } from '../../../common/event.js';
 import { IDisposable } from '../../../common/lifecycle.js';
 import { isMacintosh } from '../../../common/platform.js';
+import { MarkdownActionHandler } from '../../markdownRenderer.js';
+import { IContextViewProvider } from '../contextview/contextview.js';
+import { IListStyles, unthemedListStyles } from '../list/listWidget.js';
+import { Widget } from '../widget.js';
 import './selectBox.css';
+import { SelectBoxList } from './selectBoxCustom.js';
+import { SelectBoxNative } from './selectBoxNative.js';
 
 
 
@@ -49,7 +49,7 @@ export interface ISelectOptionItem {
 	decoratorRight?: string;
 	description?: string;
 	descriptionIsMarkdown?: boolean;
-	descriptionMarkdownActionHandler?: IContentActionHandler;
+	readonly descriptionMarkdownActionHandler?: MarkdownActionHandler;
 	isDisabled?: boolean;
 }
 

--- a/src/vs/base/browser/ui/selectBox/selectBoxCustom.ts
+++ b/src/vs/base/browser/ui/selectBox/selectBoxCustom.ts
@@ -3,13 +3,19 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { localize } from '../../../../nls.js';
+import * as arrays from '../../../common/arrays.js';
+import { Emitter, Event } from '../../../common/event.js';
+import { KeyCode, KeyCodeUtils } from '../../../common/keyCodes.js';
+import { Disposable, IDisposable } from '../../../common/lifecycle.js';
+import { isMacintosh } from '../../../common/platform.js';
+import { ScrollbarVisibility } from '../../../common/scrollable.js';
+import * as cssJs from '../../cssValue.js';
 import * as dom from '../../dom.js';
 import * as domStylesheetsJs from '../../domStylesheets.js';
-import * as cssJs from '../../cssValue.js';
 import { DomEmitter } from '../../event.js';
-import { IContentActionHandler } from '../../formattedTextRenderer.js';
 import { StandardKeyboardEvent } from '../../keyboardEvent.js';
-import { renderMarkdown } from '../../markdownRenderer.js';
+import { MarkdownActionHandler, renderMarkdown } from '../../markdownRenderer.js';
 import { AnchorPosition, IContextViewProvider } from '../contextview/contextview.js';
 import type { IManagedHover } from '../hover/hover.js';
 import { getBaseLayerHoverDelegate } from '../hover/hoverDelegate2.js';
@@ -17,14 +23,7 @@ import { getDefaultHoverDelegate } from '../hover/hoverDelegateFactory.js';
 import { IListEvent, IListRenderer, IListVirtualDelegate } from '../list/list.js';
 import { List } from '../list/listWidget.js';
 import { ISelectBoxDelegate, ISelectBoxOptions, ISelectBoxStyles, ISelectData, ISelectOptionItem } from './selectBox.js';
-import * as arrays from '../../../common/arrays.js';
-import { Emitter, Event } from '../../../common/event.js';
-import { KeyCode, KeyCodeUtils } from '../../../common/keyCodes.js';
-import { Disposable, IDisposable } from '../../../common/lifecycle.js';
-import { isMacintosh } from '../../../common/platform.js';
-import { ScrollbarVisibility } from '../../../common/scrollable.js';
 import './selectBoxCustom.css';
-import { localize } from '../../../../nls.js';
 
 
 const $ = dom.$;
@@ -869,7 +868,7 @@ export class SelectBoxList extends Disposable implements ISelectBoxDelegate, ILi
 	}
 
 
-	private renderDescriptionMarkdown(text: string, actionHandler?: IContentActionHandler): HTMLElement {
+	private renderDescriptionMarkdown(text: string, actionHandler?: MarkdownActionHandler): HTMLElement {
 		const cleanRenderedMarkdown = (element: Node) => {
 			for (let i = 0; i < element.childNodes.length; i++) {
 				const child = <Element>element.childNodes.item(i);

--- a/src/vs/editor/browser/services/hoverService/hoverWidget.ts
+++ b/src/vs/editor/browser/services/hoverService/hoverWidget.ts
@@ -172,10 +172,7 @@ export class HoverWidget extends Widget implements IHoverWidget {
 			);
 
 			const { element, dispose } = mdRenderer.render(markdown, {
-				actionHandler: {
-					callback: (content) => this._linkHandler(content),
-					disposables: this._messageListeners
-				},
+				actionHandler: (content) => this._linkHandler(content),
 				asyncRenderCallback: () => {
 					contentsElement.classList.add('code-hover-contents');
 					this.layout();

--- a/src/vs/editor/browser/widget/markdownRenderer/browser/markdownRenderer.ts
+++ b/src/vs/editor/browser/widget/markdownRenderer/browser/markdownRenderer.ts
@@ -52,7 +52,7 @@ export class MarkdownRenderer {
 		}
 
 		const disposables = new DisposableStore();
-		const rendered = disposables.add(renderMarkdown(markdown, { ...this._getRenderOptions(markdown, disposables), ...options }, outElement));
+		const rendered = disposables.add(renderMarkdown(markdown, { ...this._getRenderOptions(markdown), ...options }, outElement));
 		rendered.element.classList.add('rendered-markdown');
 		return {
 			element: rendered.element,
@@ -60,7 +60,7 @@ export class MarkdownRenderer {
 		};
 	}
 
-	private _getRenderOptions(markdown: IMarkdownString, disposables: DisposableStore): MarkdownRenderOptions {
+	private _getRenderOptions(markdown: IMarkdownString): MarkdownRenderOptions {
 		return {
 			codeBlockRenderer: async (languageAlias, value) => {
 				// In markdown,
@@ -95,10 +95,7 @@ export class MarkdownRenderer {
 
 				return element;
 			},
-			actionHandler: {
-				callback: (link) => this.openMarkdownLink(link, markdown),
-				disposables
-			}
+			actionHandler: (link) => this.openMarkdownLink(link, markdown),
 		};
 	}
 

--- a/src/vs/editor/contrib/message/browser/messageController.ts
+++ b/src/vs/editor/contrib/message/browser/messageController.ts
@@ -37,7 +37,6 @@ export class MessageController implements IEditorContribution {
 	private readonly _visible: IContextKey<boolean>;
 	private readonly _messageWidget = new MutableDisposable<MessageWidget>();
 	private readonly _messageListeners = new DisposableStore();
-	private _message: { element: HTMLElement; dispose: () => void } | undefined;
 	private _mouseOverMessage: boolean = false;
 
 	constructor(
@@ -51,7 +50,6 @@ export class MessageController implements IEditorContribution {
 	}
 
 	dispose(): void {
-		this._message?.dispose();
 		this._messageListeners.dispose();
 		this._messageWidget.dispose();
 		this._visible.reset();
@@ -68,16 +66,18 @@ export class MessageController implements IEditorContribution {
 		this._visible.set(true);
 		this._messageWidget.clear();
 		this._messageListeners.clear();
-		this._message = isMarkdownString(message) ? renderMarkdown(message, {
-			actionHandler: {
-				callback: (url) => {
+
+		if (isMarkdownString(message)) {
+			const renderedMessage = this._messageListeners.add(renderMarkdown(message, {
+				actionHandler: (url) => {
 					this.closeMessage();
 					openLinkFromMarkdown(this._openerService, url, isMarkdownString(message) ? message.isTrusted : undefined);
 				},
-				disposables: this._messageListeners
-			},
-		}) : undefined;
-		this._messageWidget.value = new MessageWidget(this._editor, position, typeof message === 'string' ? message : this._message!.element);
+			}));
+			this._messageWidget.value = new MessageWidget(this._editor, position, renderedMessage.element);
+		} else {
+			this._messageWidget.value = new MessageWidget(this._editor, position, message);
+		}
 
 		// close on blur (debounced to allow to tab into the message), cursor, model change, dispose
 		this._messageListeners.add(Event.debounce(this._editor.onDidBlurEditorText, (last, event) => event, 0)(() => {

--- a/src/vs/workbench/browser/parts/dialogs/dialogHandler.ts
+++ b/src/vs/workbench/browser/parts/dialogs/dialogHandler.ts
@@ -97,17 +97,13 @@ export class BrowserDialogHandler extends AbstractDialogHandler {
 		const renderBody = customOptions ? (parent: HTMLElement) => {
 			parent.classList.add(...(customOptions.classes || []));
 			customOptions.markdownDetails?.forEach(markdownDetail => {
-				const result = this.markdownRenderer.render(markdownDetail.markdown, {
-					actionHandler: {
-						callback: markdownDetail.actionHandler || (link => {
-							return openLinkFromMarkdown(this.openerService, link, markdownDetail.markdown.isTrusted, true /* skip URL validation to prevent another dialog from showing which is unsupported */);
-						}),
-						disposables: dialogDisposables
-					}
-				});
+				const result = dialogDisposables.add(this.markdownRenderer.render(markdownDetail.markdown, {
+					actionHandler: markdownDetail.actionHandler || (link => {
+						return openLinkFromMarkdown(this.openerService, link, markdownDetail.markdown.isTrusted, true /* skip URL validation to prevent another dialog from showing which is unsupported */);
+					}),
+				}));
 				parent.appendChild(result.element);
 				result.element.classList.add(...(markdownDetail.classes || []));
-				dialogDisposables.add(result);
 			});
 		} : undefined;
 

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/chatConfirmationWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/chatConfirmationWidget.ts
@@ -91,7 +91,7 @@ export class ChatQueryTitlePart extends Disposable {
 			const str = this.toMdString(subtitle);
 			const renderedTitle = this._register(_renderer.render(str, {
 				asyncRenderCallback: () => this._onDidChangeHeight.fire(),
-				actionHandler: { callback: link => openLinkFromMarkdown(this._openerService, link, str.isTrusted), disposables: this._store },
+				actionHandler: link => openLinkFromMarkdown(this._openerService, link, str.isTrusted),
 			}));
 			const wrapper = document.createElement('small');
 			wrapper.appendChild(renderedTitle.element);

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart.ts
@@ -66,46 +66,43 @@ export class ChatTerminalToolProgressPart extends BaseChatToolInvocationSubPart 
 			}
 		};
 		this.markdownPart = this._register(instantiationService.createInstance(ChatMarkdownContentPart, chatMarkdownContent, context, editorPool, false, codeBlockStartIndex, renderer, {
-			actionHandler: {
-				callback: (content) => {
-					const [type, scopeRaw] = content.split('_');
-					switch (type) {
-						case 'settings': {
-							if (scopeRaw === 'global') {
-								preferencesService.openSettings({
-									query: `@id:chat.tools.autoApprove`
-								});
-							} else {
-								const scope = parseInt(scopeRaw);
-								const target = !isNaN(scope) ? scope as ConfigurationTarget : undefined;
-								const options: IOpenSettingsOptions = {
-									jsonEditor: true,
-									revealSetting: {
-										key: TerminalContribSettingId.AutoApprove
-									}
-								};
-								switch (target) {
-									case ConfigurationTarget.APPLICATION: preferencesService.openApplicationSettings(options); break;
-									case ConfigurationTarget.USER:
-									case ConfigurationTarget.USER_LOCAL: preferencesService.openUserSettings(options); break;
-									case ConfigurationTarget.USER_REMOTE: preferencesService.openRemoteSettings(options); break;
-									case ConfigurationTarget.WORKSPACE:
-									case ConfigurationTarget.WORKSPACE_FOLDER: preferencesService.openWorkspaceSettings(options); break;
-									default: {
-										// Fallback if something goes wrong
-										preferencesService.openSettings({
-											target: ConfigurationTarget.USER,
-											query: `@id:${TerminalContribSettingId.AutoApprove}`,
-										});
-										break;
-									}
+			actionHandler: (content) => {
+				const [type, scopeRaw] = content.split('_');
+				switch (type) {
+					case 'settings': {
+						if (scopeRaw === 'global') {
+							preferencesService.openSettings({
+								query: `@id:chat.tools.autoApprove`
+							});
+						} else {
+							const scope = parseInt(scopeRaw);
+							const target = !isNaN(scope) ? scope as ConfigurationTarget : undefined;
+							const options: IOpenSettingsOptions = {
+								jsonEditor: true,
+								revealSetting: {
+									key: TerminalContribSettingId.AutoApprove
+								}
+							};
+							switch (target) {
+								case ConfigurationTarget.APPLICATION: preferencesService.openApplicationSettings(options); break;
+								case ConfigurationTarget.USER:
+								case ConfigurationTarget.USER_LOCAL: preferencesService.openUserSettings(options); break;
+								case ConfigurationTarget.USER_REMOTE: preferencesService.openRemoteSettings(options); break;
+								case ConfigurationTarget.WORKSPACE:
+								case ConfigurationTarget.WORKSPACE_FOLDER: preferencesService.openWorkspaceSettings(options); break;
+								default: {
+									// Fallback if something goes wrong
+									preferencesService.openSettings({
+										target: ConfigurationTarget.USER,
+										query: `@id:${TerminalContribSettingId.AutoApprove}`,
+									});
+									break;
 								}
 							}
-							break;
 						}
+						break;
 					}
-				},
-				disposables: this._store,
+				}
 			},
 		}, currentWidthDelegate(), codeBlockModelCollection, { codeBlockRenderOptions }));
 		this._register(this.markdownPart.onDidChangeHeight(() => this._onDidChangeHeight.fire()));

--- a/src/vs/workbench/contrib/comments/browser/commentsTreeViewer.ts
+++ b/src/vs/workbench/contrib/comments/browser/commentsTreeViewer.ts
@@ -246,12 +246,9 @@ export class CommentNodeRenderer implements IListRenderer<ITreeNode<CommentNode>
 		}
 	}
 
-	private getRenderedComment(commentBody: IMarkdownString, disposables: DisposableStore) {
+	private getRenderedComment(commentBody: IMarkdownString) {
 		const renderedComment = renderMarkdown(commentBody, {
-			actionHandler: {
-				callback: (link) => openLinkFromMarkdown(this.openerService, link, commentBody.isTrusted),
-				disposables: disposables
-			}
+			actionHandler: (link) => openLinkFromMarkdown(this.openerService, link, commentBody.isTrusted),
 		}, document.createElement('span'));
 		const images = renderedComment.element.getElementsByTagName('img');
 		for (let i = 0; i < images.length; i++) {
@@ -312,7 +309,7 @@ export class CommentNodeRenderer implements IListRenderer<ITreeNode<CommentNode>
 		} else {
 			const disposables = new DisposableStore();
 			templateData.disposables.push(disposables);
-			const renderedComment = this.getRenderedComment(originalComment.comment.body, disposables);
+			const renderedComment = this.getRenderedComment(originalComment.comment.body);
 			templateData.disposables.push(renderedComment);
 			for (let i = renderedComment.element.children.length - 1; i >= 1; i--) {
 				renderedComment.element.removeChild(renderedComment.element.children[i]);

--- a/src/vs/workbench/contrib/extensions/browser/extensionFeaturesTab.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionFeaturesTab.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Disposable, DisposableStore, IDisposable, MutableDisposable, toDisposable } from '../../../../base/common/lifecycle.js';
+import { Disposable, DisposableStore, IDisposable, MutableDisposable } from '../../../../base/common/lifecycle.js';
 import { $, append, clearNode, addDisposableListener, EventType } from '../../../../base/browser/dom.js';
 import { Emitter, Event } from '../../../../base/common/event.js';
 import { ExtensionIdentifier, IExtensionManifest } from '../../../../platform/extensions/common/extensions.js';
@@ -152,19 +152,15 @@ class RuntimeStatusMarkdownRenderer extends Disposable implements IExtensionFeat
 	}
 
 	private renderMarkdown(markdown: IMarkdownString, container: HTMLElement, disposables: DisposableStore): void {
-		const { element, dispose } = renderMarkdown(
+		const { element } = disposables.add(renderMarkdown(
 			{
 				value: markdown.value,
 				isTrusted: markdown.isTrusted,
 				supportThemeIcons: true
 			},
 			{
-				actionHandler: {
-					callback: (content) => this.openerService.open(content, { allowCommands: !!markdown.isTrusted }).catch(onUnexpectedError),
-					disposables
-				},
-			});
-		disposables.add(toDisposable(dispose));
+				actionHandler: (content) => this.openerService.open(content, { allowCommands: !!markdown.isTrusted }).catch(onUnexpectedError),
+			}));
 		append(container, element);
 	}
 
@@ -706,19 +702,15 @@ class ExtensionFeatureView extends Disposable {
 	}
 
 	private renderMarkdown(markdown: IMarkdownString, container: HTMLElement): void {
-		const { element, dispose } = renderMarkdown(
+		const { element } = this._register(renderMarkdown(
 			{
 				value: markdown.value,
 				isTrusted: markdown.isTrusted,
 				supportThemeIcons: true
 			},
 			{
-				actionHandler: {
-					callback: (content) => this.openerService.open(content, { allowCommands: !!markdown.isTrusted }).catch(onUnexpectedError),
-					disposables: this._store
-				},
-			});
-		this._register(toDisposable(dispose));
+				actionHandler: (content) => this.openerService.open(content, { allowCommands: !!markdown.isTrusted }).catch(onUnexpectedError),
+			}));
 		append(container, element);
 	}
 

--- a/src/vs/workbench/contrib/extensions/browser/extensionsWidgets.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionsWidgets.ts
@@ -1024,12 +1024,9 @@ export class ExtensionStatusWidget extends ExtensionWidget {
 				}
 			}
 			const rendered = disposables.add(renderMarkdown(markdown, {
-				actionHandler: {
-					callback: (content) => {
-						this.openerService.open(content, { allowCommands: true }).catch(onUnexpectedError);
-					},
-					disposables
-				}
+				actionHandler: (content) => {
+					this.openerService.open(content, { allowCommands: true }).catch(onUnexpectedError);
+				},
 			}));
 			append(this.container, rendered.element);
 		}

--- a/src/vs/workbench/contrib/mcp/browser/mcpServerWidgets.ts
+++ b/src/vs/workbench/contrib/mcp/browser/mcpServerWidgets.ts
@@ -512,11 +512,8 @@ export class McpServerStatusWidget extends McpServerWidget {
 				}
 			}
 			const rendered = disposables.add(renderMarkdown(markdown, {
-				actionHandler: {
-					callback: (content) => {
-						this.openerService.open(content, { allowCommands: true }).catch(onUnexpectedError);
-					},
-					disposables
+				actionHandler: (content) => {
+					this.openerService.open(content, { allowCommands: true }).catch(onUnexpectedError);
 				}
 			}));
 			dom.append(this.container, rendered.element);

--- a/src/vs/workbench/contrib/mcp/browser/mcpServersView.ts
+++ b/src/vs/workbench/contrib/mcp/browser/mcpServersView.ts
@@ -232,11 +232,8 @@ export class McpServersListView extends AbstractExtensionsListView<IWorkbenchMcp
 			localize('mcp.welcome.descriptionWithLink', "Extend agent mode by installing MCP servers to bring extra tools for connecting to databases, invoking APIs and performing specialized tasks."),
 			{ isTrusted: true }
 		), {
-			actionHandler: {
-				callback: (content: string) => {
-					this.openerService.open(URI.parse(content));
-				},
-				disposables: this._store
+			actionHandler: (content: string) => {
+				this.openerService.open(URI.parse(content));
 			}
 		}));
 		description.appendChild(markdownResult.element);

--- a/src/vs/workbench/contrib/notebook/browser/view/cellParts/cellOutput.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/cellParts/cellOutput.ts
@@ -768,19 +768,13 @@ export class CellOutputContainer extends CellContentPart {
 			supportThemeIcons: true
 		};
 
-		const rendered = renderMarkdown(md, {
-			actionHandler: {
-				callback: (content) => {
-					if (content === 'command:workbench.action.openLargeOutput') {
-						this.openerService.open(CellUri.generateCellOutputUriWithId(this.notebookEditor.textModel!.uri));
-					}
-
-					return;
-				},
-				disposables
-			}
-		});
-		disposables.add(rendered);
+		const rendered = disposables.add(renderMarkdown(md, {
+			actionHandler: (content) => {
+				if (content === 'command:workbench.action.openLargeOutput') {
+					this.openerService.open(CellUri.generateCellOutputUriWithId(this.notebookEditor.textModel!.uri));
+				}
+			},
+		}));
 
 		rendered.element.classList.add('output-show-more');
 		return rendered.element;

--- a/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
@@ -1029,20 +1029,17 @@ export abstract class AbstractSettingRenderer extends Disposable implements ITre
 		// Rewrite `#editor.fontSize#` to link format
 		text = fixSettingLinks(text);
 
-		const renderedMarkdown = this.markdownRenderer.render({ value: text, isTrusted: true }, {
-			actionHandler: {
-				callback: (content: string) => {
-					if (content.startsWith('#')) {
-						const e: ISettingLinkClickEvent = {
-							source: element,
-							targetKey: content.substring(1)
-						};
-						this._onDidClickSettingLink.fire(e);
-					} else {
-						this._openerService.open(content, { allowCommands: true }).catch(onUnexpectedError);
-					}
-				},
-				disposables
+		const renderedMarkdown = disposables.add(this.markdownRenderer.render({ value: text, isTrusted: true }, {
+			actionHandler: (content: string) => {
+				if (content.startsWith('#')) {
+					const e: ISettingLinkClickEvent = {
+						source: element,
+						targetKey: content.substring(1)
+					};
+					this._onDidClickSettingLink.fire(e);
+				} else {
+					this._openerService.open(content, { allowCommands: true }).catch(onUnexpectedError);
+				}
 			},
 			asyncRenderCallback: () => {
 				const height = container.clientHeight;
@@ -1050,8 +1047,7 @@ export abstract class AbstractSettingRenderer extends Disposable implements ITre
 					this._onDidChangeSettingHeight.fire({ element, height });
 				}
 			},
-		});
-		disposables.add(renderedMarkdown);
+		}));
 
 		renderedMarkdown.element.classList.add('setting-item-markdown');
 		cleanRenderedMarkdown(renderedMarkdown.element);
@@ -1882,11 +1878,8 @@ class SettingEnumRenderer extends AbstractSettingRenderer implements ITreeRender
 					detail: enumItemLabels[index] ? data : '',
 					description,
 					descriptionIsMarkdown: enumDescriptionsAreMarkdown,
-					descriptionMarkdownActionHandler: {
-						callback: (content) => {
-							this._openerService.open(content).catch(onUnexpectedError);
-						},
-						disposables: disposables
+					descriptionMarkdownActionHandler: (content) => {
+						this._openerService.open(content).catch(onUnexpectedError);
 					},
 					decoratorRight: (((data === stringifiedDefaultValue) || (createdDefault && index === 0)) ? localize('settings.Default', "default") : '')
 				} satisfies ISelectOptionItem;

--- a/src/vs/workbench/contrib/scm/browser/scmViewPane.ts
+++ b/src/vs/workbench/contrib/scm/browser/scmViewPane.ts
@@ -2057,14 +2057,11 @@ class SCMInputWidget {
 
 					const renderer = this.instantiationService.createInstance(MarkdownRenderer, {});
 					const renderedMarkdown = renderer.render(message, {
-						actionHandler: {
-							callback: (link) => {
-								openLinkFromMarkdown(this.openerService, link, message.isTrusted);
-								this.element.style.borderBottomLeftRadius = '2px';
-								this.element.style.borderBottomRightRadius = '2px';
-								this.contextViewService.hideContextView();
-							},
-							disposables: disposables
+						actionHandler: (link) => {
+							openLinkFromMarkdown(this.openerService, link, message.isTrusted);
+							this.element.style.borderBottomLeftRadius = '2px';
+							this.element.style.borderBottomRightRadius = '2px';
+							this.contextViewService.hideContextView();
 						},
 					});
 					disposables.add(renderedMarkdown);


### PR DESCRIPTION
The markdown render result is already disposable so it was always weird you had to pass a disposable to the action handler too

This should reduce boilerplate code and the number of registered disposables