### PR TITLE
Use unattached chat editor for initial prompt

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatEditor.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditor.ts
@@ -32,6 +32,7 @@ import { ChatWidget, IChatViewState } from './chatWidget.js';
 export interface IChatEditorOptions extends IEditorOptions {
 	target?: { sessionId: string } | { data: IExportableChatData | ISerializableChatData };
 	preferredTitle?: string;
+	chatSessionType?: string;
 }
 
 export class ChatEditor extends EditorPane {
@@ -127,12 +128,12 @@ export class ChatEditor extends EditorPane {
 		}
 
 		let isContributedChatSession = false;
-		if (input.resource.scheme === Schemas.vscodeChatSession) {
-			const identifier = ChatSessionUri.parse(input.resource);
-			if (identifier) {
-				await this.chatSessionsService.canResolveContentProvider(input.resource.authority);
+		if (options?.chatSessionType || input.resource.scheme === Schemas.vscodeChatSession) {
+			const chatSessionType = options?.chatSessionType ?? ChatSessionUri.parse(input.resource)?.chatSessionType;
+			if (chatSessionType) {
+				await this.chatSessionsService.canResolveContentProvider(chatSessionType);
 				const contributions = this.chatSessionsService.getAllChatSessionContributions();
-				const contribution = contributions.find(c => c.type === identifier.chatSessionType);
+				const contribution = contributions.find(c => c.type === chatSessionType);
 				if (contribution) {
 					this.widget.lockToCodingAgent(contribution.name, contribution.displayName);
 					isContributedChatSession = true;

--- a/src/vs/workbench/contrib/chat/browser/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatWidget.ts
@@ -1489,7 +1489,7 @@ export class ChatWidget extends Disposable implements IChatWidget {
 		this.viewModel = this.instantiationService.createInstance(ChatViewModel, model, this._codeBlockModelCollection);
 
 		if (this._lockedToCodingAgent) {
-			const placeholder = localize('chat.input.placeholder.lockedToAgent', "Follow up with {0}", this._lockedToCodingAgent);
+			const placeholder = localize('chat.input.placeholder.lockedToAgent', "Chat with {0}", this._lockedToCodingAgent);
 			this.viewModel.setInputPlaceholder(placeholder);
 			this.inputEditor.updateOptions({ placeholder });
 		} else if (this.viewModel.inputPlaceholder) {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

ref https://github.com/microsoft/vscode/issues/260221

When clicking the `+` to create a new coding agent session, this will lock the user into a new chat that is _not_ attached to a remote session but has the same visual elements as an attached chat.  After the first message, we forward to the extension and replace the active editor with the newly attached editor. This makes the GH coding agent flow we're looking for possible