### PR TITLE
Accepting the NES in one cell should dismiss NES suggestion in other

### DIFF
--- a/src/vs/editor/contrib/inlineCompletions/browser/controller/inlineCompletionsController.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/controller/inlineCompletionsController.ts
@@ -161,21 +161,45 @@ export class InlineCompletionsController extends Disposable {
 			const model = this.model.read(reader);
 			if (!model) { return; }
 			const state = model.state.read(reader);
+			if (!state) { return; }
+			if (!this._focusIsInEditorOrMenu.get()) { return; }
+
 			// This controller is in focus, hence reject others.
 			// However if we display a NES that relates to another edit then trigger NES on that related controller
-			if (state !== undefined && this._focusIsInEditorOrMenu.get()) {
-				const nextEditUri = state.kind === 'inlineEdit' ? state.nextEditUri : undefined;
+			const nextEditUri = state.kind === 'inlineEdit' ? state.nextEditUri : undefined;
+			for (const ctrl of InlineCompletionsController._instances) {
+				if (ctrl === this) {
+					continue;
+				} if (nextEditUri && isEqual(nextEditUri, ctrl.editor.getModel()?.uri)) {
+					// The next edit in other edito is related to this controller, trigger it.
+					ctrl.model.get()?.trigger();
+				} else {
+					ctrl.reject();
+				}
+			}
+		}));
+		this._register(autorun(reader => {
+			// Cancel all other inline completions when a new one starts
+			const model = this.model.read(reader);
+			const uri = this.editor.getModel()?.uri;
+			if (!model || !uri) { return; }
+
+			// This NES was accepted, its possible there is an NES that points to this editor.
+			// I.e. there's an NES that reads `Go To Next Edit`,
+			// If there is one that points to this editor, then we need to hide that as this NES was accepted.
+			reader.store.add(model.onDidAccept(() => {
 				for (const ctrl of InlineCompletionsController._instances) {
 					if (ctrl === this) {
 						continue;
-					} if (nextEditUri && isEqual(nextEditUri, ctrl.editor.getModel()?.uri)) {
-						// The next edit in other edito is related to this controller, trigger it.
-						ctrl.model.get()?.trigger();
-					} else {
-						ctrl.reject();
+					}
+					// Find the nes from another editor that points to this.
+					const state = ctrl.model.get()?.state.get();
+					if (state?.kind === 'inlineEdit' && isEqual(state.nextEditUri, uri)) {
+						ctrl.model.get()?.stop('automatic');
 					}
 				}
-			}
+			}));
+
 		}));
 
 		this._register(runOnChange(this._editorObs.onDidType, (_value, _changes) => {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
For https://github.com/microsoft/vscode/issues/255704

Cell 1 as an NES suggestion pointing to an NES in Cell 2
Cell 2 has the NES displayed

Yser clicks NES in Cell 2, the NES is accepted, 
we should now hide the NES suggestion in Cell 1 as well