### PR TITLE
Update for-in loop snippet with `Object.hasOwn()`

### DIFF
--- a/extensions/javascript/snippets/javascript.code-snippets
+++ b/extensions/javascript/snippets/javascript.code-snippets
@@ -98,10 +98,11 @@
 		"prefix": "forin",
 		"body": [
 			"for (const ${1:key} in ${2:object}) {",
-			"\tif (Object.prototype.hasOwnProperty.call(${2:object}, ${1:key})) {",
-			"\t\tconst ${3:element} = ${2:object}[${1:key}];",
-			"\t\t$TM_SELECTED_TEXT$0",
-			"\t}",
+			"\tif (!${2:object}.hasOwn(${1:key})) continue;",
+			"\t",
+			"\tconst ${3:element} = ${2:object}[${1:key}];",
+			"\t",
+			"\t$TM_SELECTED_TEXT$0",
 			"}"
 		],
 		"description": "For-In Loop"

--- a/extensions/javascript/snippets/javascript.code-snippets
+++ b/extensions/javascript/snippets/javascript.code-snippets
@@ -98,7 +98,7 @@
 		"prefix": "forin",
 		"body": [
 			"for (const ${1:key} in ${2:object}) {",
-			"\tif (!${2:object}.hasOwn(${1:key})) continue;",
+			"\tif (!Object.hasOwn(${2:object}, ${1:key})) continue;",
 			"\t",
 			"\tconst ${3:element} = ${2:object}[${1:key}];",
 			"\t",

--- a/extensions/typescript-basics/snippets/typescript.code-snippets
+++ b/extensions/typescript-basics/snippets/typescript.code-snippets
@@ -150,12 +150,13 @@
 	},
 	"For-In Loop": {
 		"prefix": "forin",
-		"body": [
+		"body": [			
 			"for (const ${1:key} in ${2:object}) {",
-			"\tif (Object.prototype.hasOwnProperty.call(${2:object}, ${1:key})) {",
-			"\t\tconst ${3:element} = ${2:object}[${1:key}];",
-			"\t\t$TM_SELECTED_TEXT$0",
-			"\t}",
+			"\tif (!${2:object}.hasOwn(${1:key})) continue;",
+			"\t",
+			"\tconst ${3:element} = ${2:object}[${1:key}];",
+			"\t",
+			"\t$TM_SELECTED_TEXT$0",
 			"}"
 		],
 		"description": "For-In Loop"

--- a/extensions/typescript-basics/snippets/typescript.code-snippets
+++ b/extensions/typescript-basics/snippets/typescript.code-snippets
@@ -150,7 +150,7 @@
 	},
 	"For-In Loop": {
 		"prefix": "forin",
-		"body": [			
+		"body": [
 			"for (const ${1:key} in ${2:object}) {",
 			"\tif (!${2:object}.hasOwn(${1:key})) continue;",
 			"\t",

--- a/extensions/typescript-basics/snippets/typescript.code-snippets
+++ b/extensions/typescript-basics/snippets/typescript.code-snippets
@@ -152,7 +152,7 @@
 		"prefix": "forin",
 		"body": [
 			"for (const ${1:key} in ${2:object}) {",
-			"\tif (!${2:object}.hasOwn(${1:key})) continue;",
+			"\tif (!Object.hasOwn(${2:object}, ${1:key})) continue;",
 			"\t",
 			"\tconst ${3:element} = ${2:object}[${1:key}];",
 			"\t",


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
Cleaner change for the For-In Loop snippets. With an early continue for 1 less indent & does not trigger [ESLint no-prototype-builtins](https://eslint.org/docs/latest/rules/no-prototype-builtins)

I used `Object.hasOwn(${2:object}, ${1:key})` over `${2:object}.hasOwn(${1:key})` because the latter only showed "any" in the hover poup while the former gives the method's  documentation from the `ObjectConstructor` typescript interface.

Closes #262678