### PR TITLE
Per-item truncation for Inlay Hints

### DIFF
--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -3140,6 +3140,13 @@ export interface IEditorInlayHintsOptions {
 	 * Set to 0 to have an unlimited length.
 	 */
 	maximumLength?: number;
+
+	/**
+	 * Maximum length for a single inlay hint item.
+	 * Limits the number of characters rendered for each individual item.
+	 * Set to 0 to never truncate individual items.
+	 */
+	maximumItemLength?: number;
 }
 
 /**
@@ -3150,7 +3157,7 @@ export type EditorInlayHintsOptions = Readonly<Required<IEditorInlayHintsOptions
 class EditorInlayHints extends BaseEditorOption<EditorOption.inlayHints, IEditorInlayHintsOptions, EditorInlayHintsOptions> {
 
 	constructor() {
-		const defaults: EditorInlayHintsOptions = { enabled: 'on', fontSize: 0, fontFamily: '', padding: false, maximumLength: 43 };
+		const defaults: EditorInlayHintsOptions = { enabled: 'on', fontSize: 0, fontFamily: '', padding: false, maximumLength: 43, maximumItemLength: 0 };
 		super(
 			EditorOption.inlayHints, 'inlayHints', defaults,
 			{
@@ -3185,6 +3192,11 @@ class EditorInlayHints extends BaseEditorOption<EditorOption.inlayHints, IEditor
 					type: 'number',
 					default: defaults.maximumLength,
 					markdownDescription: nls.localize('inlayHints.maximumLength', "Maximum overall length of inlay hints, for a single line, before they get truncated by the editor. Set to `0` to never truncate")
+				},
+				'editor.inlayHints.maximumItemLength': {
+					type: 'number',
+					default: defaults.maximumItemLength,
+					markdownDescription: nls.localize('inlayHints.maximumItemLength', "Maximum length of an individual inlay hint item before it gets truncated by the editor. Set to `0` to never truncate items")
 				}
 			}
 		);
@@ -3204,6 +3216,7 @@ class EditorInlayHints extends BaseEditorOption<EditorOption.inlayHints, IEditor
 			fontFamily: EditorStringOption.string(input.fontFamily, this.defaultValue.fontFamily),
 			padding: boolean(input.padding, this.defaultValue.padding),
 			maximumLength: EditorIntOption.clampedInt(input.maximumLength, this.defaultValue.maximumLength, 0, Number.MAX_SAFE_INTEGER),
+			maximumItemLength: EditorIntOption.clampedInt(input.maximumItemLength, this.defaultValue.maximumItemLength, 0, Number.MAX_SAFE_INTEGER),
 		};
 	}
 }

--- a/src/vs/editor/contrib/inlayHints/browser/inlayHintsController.ts
+++ b/src/vs/editor/contrib/inlayHints/browser/inlayHintsController.ts
@@ -544,6 +544,7 @@ export class InlayHintsController implements IEditorContribution {
 		//
 		const { fontSize, fontFamily, padding, isUniform } = this._getLayoutInfo();
 		const maxLength = this._editor.getOption(EditorOption.inlayHints).maximumLength;
+		const maxItemLength = this._editor.getOption(EditorOption.inlayHints).maximumItemLength;
 		const fontFamilyVar = '--code-editorInlayHintsFontFamily';
 		this._editor.getContainerDomNode().style.setProperty(fontFamilyVar, fontFamily);
 
@@ -610,6 +611,21 @@ export class InlayHintsController implements IEditorContribution {
 				if (over > 0) {
 					textlabel = textlabel.slice(0, -over) + '…';
 					tooLong = true;
+				}
+
+				// Enforce per-item maximum length if configured
+				if (maxItemLength && maxItemLength > 0) {
+					const remainingForItem = maxItemLength - itemActualLength;
+					if (remainingForItem <= 0) {
+						// Item already at or above max length; just add an ellipsis and stop
+						textlabel = '…';
+						tooLong = true;
+					} else if (textlabel.length > remainingForItem) {
+						// Trim current part to fit remaining and add ellipsis
+						const keep = Math.max(0, remainingForItem - 1);
+						textlabel = (keep === 0 ? '' : textlabel.slice(0, keep)) + '…';
+						tooLong = true;
+					}
 				}
 
 				itemActualLength += textlabel.length;


### PR DESCRIPTION
Added a new configuration option to the editor's inlay hints feature, allowing users to set a maximum length for each individual inlay hint item.

* Added a new `maximumItemLength` property to the `IEditorInlayHintsOptions` interface, allowing users to specify a maximum character length for each inlay hint item. Setting it to `0` disables per-item truncation.
* Modified the option parsing logic to support the new `maximumItemLength` property, ensuring it is clamped to a valid integer range.
* Updated the `InlayHintsController` to read the new `maximumItemLength` option and enforce per-item truncation when rendering hints. If a hint exceeds the configured length, it is truncated and an ellipsis is added. [[1]](diffhunk://#diff-a4f99ac14f20ad02a66050bc0a94bf425490341ae28bbdd690d1a7da73d1b35bR547) [[2]](diffhunk://#diff-a4f99ac14f20ad02a66050bc0a94bf425490341ae28bbdd690d1a7da73d1b35bR616-R630)