### PR TITLE
User getters for events on a few common types

### DIFF
--- a/src/vs/base/browser/ui/resizable/resizable.ts
+++ b/src/vs/base/browser/ui/resizable/resizable.ts
@@ -23,10 +23,10 @@ export class ResizableHTMLElement {
 	readonly domNode: HTMLElement;
 
 	private readonly _onDidWillResize = new Emitter<void>();
-	readonly onDidWillResize: Event<void> = this._onDidWillResize.event;
+	get onDidWillResize() { return this._onDidWillResize.event; }
 
 	private readonly _onDidResize = new Emitter<IResizeEvent>();
-	readonly onDidResize: Event<IResizeEvent> = this._onDidResize.event;
+	get onDidResize() { return this._onDidResize.event; }
 
 	private readonly _northSash: Sash;
 	private readonly _eastSash: Sash;

--- a/src/vs/base/browser/ui/sash/sash.ts
+++ b/src/vs/base/browser/ui/sash/sash.ts
@@ -296,23 +296,23 @@ export class Sash extends Disposable {
 	/**
 	 * An event which fires whenever the user starts dragging this sash.
 	 */
-	readonly onDidStart: Event<ISashEvent> = this._onDidStart.event;
+	get onDidStart() { return this._onDidStart.event; }
 
 	/**
 	 * An event which fires whenever the user moves the mouse while
 	 * dragging this sash.
 	 */
-	readonly onDidChange: Event<ISashEvent> = this._onDidChange.event;
+	get onDidChange() { return this._onDidChange.event; }
 
 	/**
 	 * An event which fires whenever the user double clicks this sash.
 	 */
-	readonly onDidReset: Event<void> = this._onDidReset.event;
+	get onDidReset() { return this._onDidReset.event; }
 
 	/**
 	 * An event which fires whenever the user stops dragging this sash.
 	 */
-	readonly onDidEnd: Event<void> = this._onDidEnd.event;
+	get onDidEnd() { return this._onDidEnd.event; }
 
 	/**
 	 * A linked sash will be forwarded the same user interactions and events

--- a/src/vs/base/browser/ui/toolbar/toolbar.ts
+++ b/src/vs/base/browser/ui/toolbar/toolbar.ts
@@ -61,7 +61,8 @@ export class ToolBar extends Disposable {
 	private readonly element: HTMLElement;
 
 	private _onDidChangeDropdownVisibility = this._register(new EventMultiplexer<boolean>());
-	readonly onDidChangeDropdownVisibility = this._onDidChangeDropdownVisibility.event;
+	get onDidChangeDropdownVisibility() { return this._onDidChangeDropdownVisibility.event; }
+
 	private readonly disposables = this._register(new DisposableStore());
 
 	constructor(container: HTMLElement, contextMenuProvider: IContextMenuProvider, options: IToolBarOptions = { orientation: ActionsOrientation.HORIZONTAL }) {

--- a/src/vs/platform/actions/browser/toolbar.ts
+++ b/src/vs/platform/actions/browser/toolbar.ts
@@ -10,7 +10,7 @@ import { IAction, Separator, SubmenuAction, toAction, WorkbenchActionExecutedCla
 import { coalesceInPlace } from '../../../base/common/arrays.js';
 import { intersection } from '../../../base/common/collections.js';
 import { BugIndicatingError } from '../../../base/common/errors.js';
-import { Emitter, Event } from '../../../base/common/event.js';
+import { Emitter } from '../../../base/common/event.js';
 import { Iterable } from '../../../base/common/iterator.js';
 import { DisposableStore } from '../../../base/common/lifecycle.js';
 import { localize } from '../../../nls.js';
@@ -335,7 +335,7 @@ export interface IMenuWorkbenchToolBarOptions extends IWorkbenchToolBarOptions {
 export class MenuWorkbenchToolBar extends WorkbenchToolBar {
 
 	private readonly _onDidChangeMenuItems = this._store.add(new Emitter<this>());
-	readonly onDidChangeMenuItems: Event<this> = this._onDidChangeMenuItems.event;
+	get onDidChangeMenuItems() { return this._onDidChangeMenuItems.event; }
 
 	constructor(
 		container: HTMLElement,


### PR DESCRIPTION
This defers creating the event function until the property is accessed. Useful small optimization for very commonly created objects

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
