### PR TITLE
Prefer using addDisposableListener in sash

### DIFF
--- a/src/vs/base/browser/ui/sash/sash.ts
+++ b/src/vs/base/browser/ui/sash/sash.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { $, append, EventHelper, EventLike, getWindow, isHTMLElement } from '../../dom.js';
+import { $, addDisposableListener, append, EventHelper, EventLike, getWindow, isHTMLElement } from '../../dom.js';
 import { createStyleSheet } from '../../domStylesheets.js';
 import { DomEmitter } from '../../event.js';
 import { EventType, Gesture } from '../../touch.js';
@@ -345,10 +345,8 @@ export class Sash extends Disposable {
 				if (state !== SashState.Disabled) {
 					this._orthogonalStartDragHandle = append(this.el, $('.orthogonal-drag-handle.start'));
 					this.orthogonalStartDragHandleDisposables.add(toDisposable(() => this._orthogonalStartDragHandle!.remove()));
-					this.orthogonalStartDragHandleDisposables.add(new DomEmitter(this._orthogonalStartDragHandle, 'mouseenter')).event
-						(() => Sash.onMouseEnter(sash), undefined, this.orthogonalStartDragHandleDisposables);
-					this.orthogonalStartDragHandleDisposables.add(new DomEmitter(this._orthogonalStartDragHandle, 'mouseleave')).event
-						(() => Sash.onMouseLeave(sash), undefined, this.orthogonalStartDragHandleDisposables);
+					this.orthogonalStartDragHandleDisposables.add(addDisposableListener(this._orthogonalStartDragHandle, 'mouseenter', () => Sash.onMouseEnter(sash)));
+					this.orthogonalStartDragHandleDisposables.add(addDisposableListener(this._orthogonalStartDragHandle, 'mouseleave', () => Sash.onMouseLeave(sash)));
 				}
 			};
 
@@ -383,10 +381,8 @@ export class Sash extends Disposable {
 				if (state !== SashState.Disabled) {
 					this._orthogonalEndDragHandle = append(this.el, $('.orthogonal-drag-handle.end'));
 					this.orthogonalEndDragHandleDisposables.add(toDisposable(() => this._orthogonalEndDragHandle!.remove()));
-					this.orthogonalEndDragHandleDisposables.add(new DomEmitter(this._orthogonalEndDragHandle, 'mouseenter')).event
-						(() => Sash.onMouseEnter(sash), undefined, this.orthogonalEndDragHandleDisposables);
-					this.orthogonalEndDragHandleDisposables.add(new DomEmitter(this._orthogonalEndDragHandle, 'mouseleave')).event
-						(() => Sash.onMouseLeave(sash), undefined, this.orthogonalEndDragHandleDisposables);
+					this.orthogonalEndDragHandleDisposables.add(addDisposableListener(this._orthogonalEndDragHandle, 'mouseenter', () => Sash.onMouseEnter(sash)));
+					this.orthogonalEndDragHandleDisposables.add(addDisposableListener(this._orthogonalEndDragHandle, 'mouseleave', () => Sash.onMouseLeave(sash)));
 				}
 			};
 
@@ -427,23 +423,17 @@ export class Sash extends Disposable {
 			this.el.classList.add('mac');
 		}
 
-		const onMouseDown = this._register(new DomEmitter(this.el, 'mousedown')).event;
-		this._register(onMouseDown(e => this.onPointerStart(e, new MouseEventFactory(container)), this));
-		const onMouseDoubleClick = this._register(new DomEmitter(this.el, 'dblclick')).event;
-		this._register(onMouseDoubleClick(this.onPointerDoublePress, this));
-		const onMouseEnter = this._register(new DomEmitter(this.el, 'mouseenter')).event;
-		this._register(onMouseEnter(() => Sash.onMouseEnter(this)));
-		const onMouseLeave = this._register(new DomEmitter(this.el, 'mouseleave')).event;
-		this._register(onMouseLeave(() => Sash.onMouseLeave(this)));
+		this._register(addDisposableListener(this.el, 'mousedown', e => this.onPointerStart(e, new MouseEventFactory(container))));
+		this._register(addDisposableListener(this.el, 'dblclick', e => this.onPointerDoublePress(e)));
+		this._register(addDisposableListener(this.el, 'mouseenter', () => Sash.onMouseEnter(this)));
+		this._register(addDisposableListener(this.el, 'mouseleave', () => Sash.onMouseLeave(this)));
 
 		this._register(Gesture.addTarget(this.el));
 
-		const onTouchStart = this._register(new DomEmitter(this.el, EventType.Start)).event;
-		this._register(onTouchStart(e => this.onPointerStart(e, new GestureEventFactory(this.el)), this));
-		const onTap = this._register(new DomEmitter(this.el, EventType.Tap)).event;
+		this._register(addDisposableListener(this.el, EventType.Start, e => this.onPointerStart(e, new GestureEventFactory(this.el))));
 
 		let doubleTapTimeout: Timeout | undefined = undefined;
-		this._register(onTap(event => {
+		this._register(addDisposableListener(this.el, EventType.Tap, event => {
 			if (doubleTapTimeout) {
 				clearTimeout(doubleTapTimeout);
 				doubleTapTimeout = undefined;
@@ -453,7 +443,7 @@ export class Sash extends Disposable {
 
 			clearTimeout(doubleTapTimeout);
 			doubleTapTimeout = setTimeout(() => doubleTapTimeout = undefined, 250);
-		}, this));
+		}));
 
 		if (typeof options.size === 'number') {
 			this.size = options.size;

--- a/src/vs/workbench/contrib/keybindings/browser/keybindings.contribution.ts
+++ b/src/vs/workbench/contrib/keybindings/browser/keybindings.contribution.ts
@@ -12,10 +12,9 @@ import { ICommandService } from '../../../../platform/commands/common/commands.j
 import { showWindowLogActionId } from '../../../services/log/common/logConstants.js';
 import { DisposableStore, IDisposable, toDisposable } from '../../../../base/common/lifecycle.js';
 import { ILayoutService } from '../../../../platform/layout/browser/layoutService.js';
-import { $, append, getDomNodePagePosition, getWindows, onDidRegisterWindow } from '../../../../base/browser/dom.js';
+import { $, addDisposableListener, append, getDomNodePagePosition, getWindows, onDidRegisterWindow } from '../../../../base/browser/dom.js';
 import { createCSSRule, createStyleSheet } from '../../../../base/browser/domStylesheets.js';
 import { Emitter } from '../../../../base/common/event.js';
-import { DomEmitter } from '../../../../base/browser/event.js';
 
 class ToggleKeybindingsLogAction extends Action2 {
 	static disposable: IDisposable | undefined;
@@ -64,7 +63,7 @@ class ToggleKeybindingsLogAction extends Action2 {
 		const onKeyDown = disposables.add(new Emitter<KeyboardEvent>());
 
 		function registerWindowListeners(window: Window, disposables: DisposableStore): void {
-			disposables.add(disposables.add(new DomEmitter(window, 'keydown', true)).event(e => onKeyDown.fire(e)));
+			disposables.add(addDisposableListener(window, 'keydown', e => onKeyDown.fire(e), true));
 		}
 
 		for (const { window, disposables } of getWindows()) {


### PR DESCRIPTION
Notice this while debugging #262472. Using an emitter has extra overhead vs the simple listener. Since we sometimes create a number of sashes all at once, it's worth trying to avoid this

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
