### PR TITLE
Fix terminal sticky scroll breaking 'tab moves focus'

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/stickyScroll/browser/terminalStickyScrollOverlay.ts
+++ b/src/vs/workbench/contrib/terminalContrib/stickyScroll/browser/terminalStickyScrollOverlay.ts
@@ -7,7 +7,7 @@ import type { SerializeAddon as SerializeAddonType } from '@xterm/addon-serializ
 import type { WebglAddon as WebglAddonType } from '@xterm/addon-webgl';
 import type { LigaturesAddon as LigaturesAddonType } from '@xterm/addon-ligatures';
 import type { IBufferLine, IMarker, ITerminalOptions, ITheme, Terminal as RawXtermTerminal, Terminal as XTermTerminal } from '@xterm/xterm';
-import { $, addDisposableListener, addStandardDisposableListener, getWindow, isHTMLElement } from '../../../../../base/browser/dom.js';
+import { $, addDisposableListener, addStandardDisposableListener, getWindow } from '../../../../../base/browser/dom.js';
 import { throttle } from '../../../../../base/common/decorators.js';
 import { Event } from '../../../../../base/common/event.js';
 import { Disposable, MutableDisposable, combinedDisposable, toDisposable } from '../../../../../base/common/lifecycle.js';
@@ -396,14 +396,13 @@ export class TerminalStickyScrollOverlay extends Disposable {
 
 		this._stickyScrollOverlay.open(this._element);
 
-		// Prevent tab navigation from getting stuck in sticky scroll
-		this._element.querySelectorAll('*').forEach(el => {
-			if (isHTMLElement(el)) {
-				el.tabIndex = -1;
+		// Prevent tab key from being handled by the xterm overlay to allow natural tab navigation
+		this._stickyScrollOverlay.attachCustomKeyEventHandler((event: KeyboardEvent) => {
+			if (event.key === 'Tab') {
+				return false;
 			}
+			return true;
 		});
-		// Re-enable pointer events on the hover overlay so clicks still work
-		hoverOverlay.style.pointerEvents = 'auto';
 
 		this._xtermAddonLoader.importAddon('ligatures').then(LigaturesAddon => {
 			if (this._store.isDisposed || !this._stickyScrollOverlay) {

--- a/src/vs/workbench/contrib/terminalContrib/stickyScroll/browser/terminalStickyScrollOverlay.ts
+++ b/src/vs/workbench/contrib/terminalContrib/stickyScroll/browser/terminalStickyScrollOverlay.ts
@@ -415,7 +415,6 @@ export class TerminalStickyScrollOverlay extends Disposable {
 
 		// Apply immediately and after a short delay to catch dynamically created elements
 		makeElementsNonFocusable();
-		setTimeout(makeElementsNonFocusable, 0);
 
 		this._xtermAddonLoader.importAddon('ligatures').then(LigaturesAddon => {
 			if (this._store.isDisposed || !this._stickyScrollOverlay) {

--- a/src/vs/workbench/contrib/terminalContrib/stickyScroll/browser/terminalStickyScrollOverlay.ts
+++ b/src/vs/workbench/contrib/terminalContrib/stickyScroll/browser/terminalStickyScrollOverlay.ts
@@ -400,8 +400,6 @@ export class TerminalStickyScrollOverlay extends Disposable {
 		this._element.querySelectorAll('*').forEach(el => {
 			if (isHTMLElement(el)) {
 				el.tabIndex = -1;
-				// Remove any existing focus handlers from xterm elements
-				el.style.pointerEvents = 'none';
 			}
 		});
 		// Re-enable pointer events on the hover overlay so clicks still work

--- a/src/vs/workbench/contrib/terminalContrib/stickyScroll/browser/terminalStickyScrollOverlay.ts
+++ b/src/vs/workbench/contrib/terminalContrib/stickyScroll/browser/terminalStickyScrollOverlay.ts
@@ -396,25 +396,16 @@ export class TerminalStickyScrollOverlay extends Disposable {
 
 		this._stickyScrollOverlay.open(this._element);
 
-		// After opening the xterm overlay, make all its internal elements non-focusable
-		// This is crucial to prevent tab navigation from getting stuck
-		const makeElementsNonFocusable = () => {
-			const xtermElements = this._element?.querySelectorAll('*');
-			if (xtermElements) {
-				xtermElements.forEach(el => {
-					if (isHTMLElement(el)) {
-						el.setAttribute('tabindex', '-1');
-						// Remove any existing focus handlers from xterm elements
-						el.style.pointerEvents = 'none';
-					}
-				});
-				// Re-enable pointer events on the hover overlay so clicks still work
-				hoverOverlay.style.pointerEvents = 'auto';
+		// Prevent tab navigation from getting stuck in sticky scroll
+		this._element.querySelectorAll('*').forEach(el => {
+			if (isHTMLElement(el)) {
+				el.tabIndex = -1;
+				// Remove any existing focus handlers from xterm elements
+				el.style.pointerEvents = 'none';
 			}
-		};
-
-		// Apply immediately and after a short delay to catch dynamically created elements
-		makeElementsNonFocusable();
+		});
+		// Re-enable pointer events on the hover overlay so clicks still work
+		hoverOverlay.style.pointerEvents = 'auto';
 
 		this._xtermAddonLoader.importAddon('ligatures').then(LigaturesAddon => {
 			if (this._store.isDisposed || !this._stickyScrollOverlay) {


### PR DESCRIPTION
Resolves: https://github.com/microsoft/vscode/issues/213925

The bug is that focus can get forever "stuck" inside terminal sticky scroll when tabbing through with setting `tab moves focus`. 

Setting the index for the sticky scroll overlay to -1 would prevent this from happening.
We'd also want to make sure clicking on terminal sticky scroll still works though hence the `hoverOverlay.style.pointerEvents = 'auto';` 