### PR TITLE
make sure to dispose of any leftover overlays

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatDragAndDrop.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatDragAndDrop.ts
@@ -64,6 +64,15 @@ export class ChatDragAndDrop extends Themable {
 		this.updateStyles();
 	}
 
+	override dispose(): void {
+		for (const { overlay, disposable } of this.overlays.values()) {
+			overlay.remove();
+			disposable.dispose();
+		}
+		this.overlays.clear();
+		super.dispose();
+	}
+
 	addOverlay(target: HTMLElement, overlayContainer: HTMLElement): void {
 		this.removeOverlay(target);
 

--- a/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
@@ -846,6 +846,11 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 		return this.container;
 	}
 
+	override dispose(): void {
+		this.chatInputOverlay.remove();
+		super.dispose();
+	}
+
 	async showPreviousValue(): Promise<void> {
 		const inputState = this.getInputState();
 		if (this.history.isAtEnd()) {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

we are already doing `this.input.dispose()`, which gets rid of the current input container. 

ref https://github.com/microsoft/vscode/issues/262795