### PR TITLE
forward activeEditor URI in chatMultiDiffContentPart to its actions

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/chatMultiDiffContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/chatMultiDiffContentPart.ts
@@ -131,9 +131,9 @@ export class ChatMultiDiffContentPart extends Disposable implements IChatContent
 			actionBar.clear();
 
 			const activeEditorUri = this.editorService.activeEditor?.resource;
-			let marshalledSession: any | undefined = undefined;
+			let marshalledUri: any | undefined = undefined;
 			if (activeEditorUri) {
-				marshalledSession = {
+				marshalledUri = {
 					...activeEditorUri,
 					$mid: MarshalledId.Uri
 				};
@@ -142,7 +142,7 @@ export class ChatMultiDiffContentPart extends Disposable implements IChatContent
 			const actions = this.menuService.getMenuActions(
 				MenuId.ChatMultiDiffContext,
 				this.contextKeyService,
-				{ arg: marshalledSession, shouldForwardArgs: true }
+				{ arg: marshalledUri, shouldForwardArgs: true }
 			);
 			const allActions = actions.flatMap(([, actions]) => actions);
 			if (allActions.length > 0) {

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/chatMultiDiffContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/chatMultiDiffContentPart.ts
@@ -30,6 +30,7 @@ import { Emitter, Event } from '../../../../../base/common/event.js';
 import { MenuId, IMenuService } from '../../../../../platform/actions/common/actions.js';
 import { IContextKeyService } from '../../../../../platform/contextkey/common/contextkey.js';
 import { ActionBar, ActionsOrientation } from '../../../../../base/browser/ui/actionbar/actionbar.js';
+import { MarshalledId } from '../../../../../base/common/marshallingIds.js';
 
 const $ = dom.$;
 
@@ -128,10 +129,20 @@ export class ChatMultiDiffContentPart extends Disposable implements IChatContent
 		}));
 		const setupActionBar = () => {
 			actionBar.clear();
+
+			const activeEditorUri = this.editorService.activeEditor?.resource;
+			let marshalledSession: any | undefined = undefined;
+			if (activeEditorUri) {
+				marshalledSession = {
+					...activeEditorUri,
+					$mid: MarshalledId.Uri
+				};
+			}
+
 			const actions = this.menuService.getMenuActions(
 				MenuId.ChatMultiDiffContext,
 				this.contextKeyService,
-				{ arg: {}, shouldForwardArgs: true }
+				{ arg: marshalledSession, shouldForwardArgs: true }
 			);
 			const allActions = actions.flatMap(([, actions]) => actions);
 			if (allActions.length > 0) {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

ref: https://github.com/microsoft/vscode/issues/260227
Forwards the active editor URI as context to the contributed (in GHPR's case, the pull request number). There is likely a more robust way to do this forwarding of chatSession info to replace this.  