### PR TITLE
ci: always publish cpu profile for codesign failure

### DIFF
--- a/build/azure-pipelines/win32/product-build-win32.yml
+++ b/build/azure-pipelines/win32/product-build-win32.yml
@@ -323,6 +323,7 @@ steps:
         targetPath: .build/node-cpuprofile
         artifactName: node-cpuprofile-$(VSCODE_ARCH)
         sbomEnabled: false
+      condition: succeededOrFailed()
       displayName: Publish Codesign cpu profile
 
     - task: 1ES.PublishPipelineArtifact@1


### PR DESCRIPTION
Refs https://dev.azure.com/monacotools/Monaco/_build/results?buildId=353753&view=logs&j=672276a2-8d3a-5fab-615d-090c51352f92&t=f56c3d30-4cdd-5cdd-1035-beca4fed94e8