### PR TITLE
Implement skipping of terminal commands

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart.ts
@@ -109,10 +109,13 @@ export class ChatTerminalToolProgressPart extends BaseChatToolInvocationSubPart 
 		const isConfirmed = typeof toolInvocation.isConfirmed === 'boolean'
 			? toolInvocation.isConfirmed
 			: toolInvocation.isConfirmed?.type === ToolConfirmKind.UserAction || toolInvocation.isConfirmed?.type === ToolConfirmKind.ConfirmationNotNeeded;
-		const icon = !isConfirmed ?
-			Codicon.error :
-			toolInvocation.isComplete ?
-				Codicon.check : ThemeIcon.modify(Codicon.loading, 'spin');
+		const isSkipped = typeof toolInvocation.isConfirmed !== 'boolean' && toolInvocation.isConfirmed?.type === ToolConfirmKind.Skipped;
+		const icon = isSkipped ?
+			Codicon.circleSlash :
+			(!isConfirmed ?
+				Codicon.error :
+				toolInvocation.isComplete ?
+					Codicon.check : ThemeIcon.modify(Codicon.loading, 'spin'));
 		const progressPart = instantiationService.createInstance(ChatCustomProgressPart, this.markdownPart.domNode, icon);
 		this.domNode = progressPart.domNode;
 	}

--- a/src/vs/workbench/contrib/chat/browser/languageModelToolsService.ts
+++ b/src/vs/workbench/contrib/chat/browser/languageModelToolsService.ts
@@ -305,6 +305,15 @@ export class LanguageModelToolsService extends Disposable implements ILanguageMo
 					if (userConfirmed.type === ToolConfirmKind.Denied) {
 						throw new CancellationError();
 					}
+					if (userConfirmed.type === ToolConfirmKind.Skipped) {
+						toolResult = {
+							content: [{
+								kind: 'text',
+								value: 'The user chose to skip the tool call, they want to proceed without running it'
+							}]
+						};
+						return toolResult;
+					}
 
 					if (dto.toolSpecificData?.kind === 'input') {
 						dto.parameters = dto.toolSpecificData.rawInput;

--- a/src/vs/workbench/contrib/chat/common/chatService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService.ts
@@ -316,7 +316,8 @@ export const enum ToolConfirmKind {
 	ConfirmationNotNeeded,
 	Setting,
 	LmServicePerTool,
-	UserAction
+	UserAction,
+	Skipped
 }
 
 export type ConfirmedReason =
@@ -324,7 +325,8 @@ export type ConfirmedReason =
 	| { type: ToolConfirmKind.ConfirmationNotNeeded }
 	| { type: ToolConfirmKind.Setting; id: string }
 	| { type: ToolConfirmKind.LmServicePerTool; scope: 'session' | 'workspace' | 'profile' }
-	| { type: ToolConfirmKind.UserAction };
+	| { type: ToolConfirmKind.UserAction }
+	| { type: ToolConfirmKind.Skipped };
 
 export interface IChatToolInvocation {
 	presentation: IPreparedToolInvocation['presentation'];


### PR DESCRIPTION
Fixes #262982

Currently the feature is scoped only to the terminal, though there is the new `ToolConfirmKind.Skipped` which can be picked up in any confirmation dialog:

<img width="1280" height="1312" alt="image" src="https://github.com/user-attachments/assets/f34ea5a1-2c86-4d37-bce8-a5693b6b2ccb" />
