### PR TITLE
Preserve case in multicursor replace command

### DIFF
--- a/src/vs/editor/common/cursor/cursorTypeEditOperations.ts
+++ b/src/vs/editor/common/cursor/cursorTypeEditOperations.ts
@@ -499,12 +499,14 @@ export class InterceptorElectricCharOperation {
 
 export class SimpleCharacterTypeOperation {
 
-	public static getEdits(config: CursorConfiguration, prevEditOperationType: EditOperationType, selections: Selection[], ch: string, isDoingComposition: boolean): EditOperationResult {
+	public static getEdits(config: CursorConfiguration, model: ITextModel, prevEditOperationType: EditOperationType, selections: Selection[], ch: string, isDoingComposition: boolean): EditOperationResult {
 		// A simple character type
 		const commands: ICommand[] = [];
 		for (let i = 0, len = selections.length; i < len; i++) {
 			const ChosenReplaceCommand = config.inputMode === 'overtype' && !isDoingComposition ? ReplaceOvertypeCommand : ReplaceCommand;
-			commands[i] = new ChosenReplaceCommand(selections[i], ch);
+			const textToReplace = model.getValueInRange(selections[i]);
+			const charWithPreservedCase = selections.length > 1 && /^[A-Z]/.test(textToReplace) ? ch.toUpperCase() : ch;
+			commands[i] = new ChosenReplaceCommand(selections[i], charWithPreservedCase);
 		}
 
 		const opType = getTypingOperation(ch, prevEditOperationType);

--- a/src/vs/editor/common/cursor/cursorTypeOperations.ts
+++ b/src/vs/editor/common/cursor/cursorTypeOperations.ts
@@ -194,7 +194,7 @@ export class TypeOperations {
 			return interceptorElectricCharOperation;
 		}
 
-		return SimpleCharacterTypeOperation.getEdits(config, prevEditOperationType, selections, ch, isDoingComposition);
+		return SimpleCharacterTypeOperation.getEdits(config, model, prevEditOperationType, selections, ch, isDoingComposition);
 	}
 
 	public static typeWithoutInterceptors(prevEditOperationType: EditOperationType, config: CursorConfiguration, model: ITextModel, selections: Selection[], str: string): EditOperationResult {

--- a/src/vs/editor/test/browser/controller/cursor.test.ts
+++ b/src/vs/editor/test/browser/controller/cursor.test.ts
@@ -4442,6 +4442,33 @@ suite('Editor Controller', () => {
 		});
 	});
 
+	test('replace does not preserve case with single cursor', () => {
+		const model = createTextModel('Test');
+
+		withTestCodeEditor(model, { autoIndent: 'full' }, (editor, viewModel) => {
+			editor.setSelections([
+				new Selection(1, 1, 1, 5),
+			]);
+
+			viewModel.type('b', 'keyboard');
+			assert.strictEqual(model.getValue(), 'b');
+		});
+	});
+
+	test('replace preserves case with multicursor', () => {
+		const model = createTextModel('Test test');
+
+		withTestCodeEditor(model, { autoIndent: 'full' }, (editor, viewModel) => {
+			editor.setSelections([
+				new Selection(1, 1, 1, 5),
+				new Selection(1, 6, 1, 10),
+			]);
+
+			viewModel.type('b', 'keyboard');
+			assert.strictEqual(model.getValue(), 'B b');
+		});
+	});
+
 	test('Auto indent on type: increaseIndentPattern has higher priority than decreaseIndent when inheriting', () => {
 		usingCursor({
 			text: [


### PR DESCRIPTION
# Problem
Fixes https://github.com/microsoft/vscode/issues/106502.

Reading through the issue it seems the main problem involves preserving the case of the first letter of a variable name when executing a replace command on multiple case-insensitive selections of that word.

# Solution
To fix this, when defining the replace command for a given selection, we can check the case of the first letter of the text to replace, and update the case of the character that will replace it accordingly.

So if we have selections `"value"` and `"Value"`, and type `"a"` (while typing `array`), when composing the replace command for `"Value"` we see that it starts with a capital and replace the selection with `"A"`, not with `"a"`.

For now this logic is only applied in the case of multiple selections.

# Testing
Given
```
const [value, setValue] = useState();
```

Select `"value"` and `"Value"`, and then type `"array"`.

Expected result
```
const [array, setArray] = useState();
```

https://github.com/user-attachments/assets/2a3f2716-1785-45f5-9ff7-ae37d0e482cd

Note: it might make sense to make this feature opt-in, whether through some setting or a dedicated button as was suggested in the issue. I'm open to suggestions. 🙏
