### PR TITLE
Fix a typo in nls.localize(...) in localization.contribution.ts

### DIFF
--- a/src/vs/workbench/contrib/localization/common/localization.contribution.ts
+++ b/src/vs/workbench/contrib/localization/common/localization.contribution.ts
@@ -117,7 +117,7 @@ class LocalizationsDataRenderer extends Disposable implements IExtensionFeatureT
 
 Registry.as<IExtensionFeaturesRegistry>(Extensions.ExtensionFeaturesRegistry).registerExtensionFeature({
 	id: 'localizations',
-	label: localize('localizations', "Langauage Packs"),
+	label: localize('localizations', "Language Packs"),
 	access: {
 		canToggle: false
 	},


### PR DESCRIPTION
Fixed a single typo: "Langauage Packs" => "Language Packs". I have noticed this typo while browsing the features tab of a language pack extension I have installed.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
