### PR TITLE
Enable terminal sticky scroll as default true in both stable and insiders

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/stickyScroll/common/terminalStickyScrollConfiguration.ts
+++ b/src/vs/workbench/contrib/terminalContrib/stickyScroll/common/terminalStickyScrollConfiguration.ts
@@ -6,7 +6,6 @@
 import type { IStringDictionary } from '../../../../../base/common/collections.js';
 import { localize } from '../../../../../nls.js';
 import type { IConfigurationPropertySchema } from '../../../../../platform/configuration/common/configurationRegistry.js';
-import product from '../../../../../platform/product/common/product.js';
 import { TerminalSettingId } from '../../../../../platform/terminal/common/terminal.js';
 
 export const enum TerminalStickyScrollSettingId {

--- a/src/vs/workbench/contrib/terminalContrib/stickyScroll/common/terminalStickyScrollConfiguration.ts
+++ b/src/vs/workbench/contrib/terminalContrib/stickyScroll/common/terminalStickyScrollConfiguration.ts
@@ -23,7 +23,7 @@ export const terminalStickyScrollConfiguration: IStringDictionary<IConfiguration
 	[TerminalStickyScrollSettingId.Enabled]: {
 		markdownDescription: localize('stickyScroll.enabled', "Shows the current command at the top of the terminal. This feature requires [shell integration]({0}) to be activated. See {1}.", 'https://code.visualstudio.com/docs/terminal/shell-integration', `\`#${TerminalSettingId.ShellIntegrationEnabled}#\``),
 		type: 'boolean',
-		default: product.quality !== true
+		default: true
 	},
 	[TerminalStickyScrollSettingId.MaxLineCount]: {
 		markdownDescription: localize('stickyScroll.maxLineCount', "Defines the maximum number of sticky lines to show. Sticky scroll lines will never exceed 40% of the viewport regardless of this setting."),

--- a/src/vs/workbench/contrib/terminalContrib/stickyScroll/common/terminalStickyScrollConfiguration.ts
+++ b/src/vs/workbench/contrib/terminalContrib/stickyScroll/common/terminalStickyScrollConfiguration.ts
@@ -23,7 +23,7 @@ export const terminalStickyScrollConfiguration: IStringDictionary<IConfiguration
 	[TerminalStickyScrollSettingId.Enabled]: {
 		markdownDescription: localize('stickyScroll.enabled', "Shows the current command at the top of the terminal. This feature requires [shell integration]({0}) to be activated. See {1}.", 'https://code.visualstudio.com/docs/terminal/shell-integration', `\`#${TerminalSettingId.ShellIntegrationEnabled}#\``),
 		type: 'boolean',
-		default: product.quality !== 'stable'
+		default: product.quality !== true
 	},
 	[TerminalStickyScrollSettingId.MaxLineCount]: {
 		markdownDescription: localize('stickyScroll.maxLineCount', "Defines the maximum number of sticky lines to show. Sticky scroll lines will never exceed 40% of the viewport regardless of this setting."),


### PR DESCRIPTION
Resolves: https://github.com/microsoft/vscode/issues/209003

With only https://github.com/microsoft/vscode/issues/198116 and https://github.com/microsoft/vscode/issues/240296 remaining under `terminal-sticky-scroll` label, shall we have default to true, and have more folks in stable try out.