### PR TITLE
attempt to fix chat input completions

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/contrib/chatInputCompletions.ts
+++ b/src/vs/workbench/contrib/chat/browser/contrib/chatInputCompletions.ts
@@ -948,11 +948,12 @@ class BuiltinDynamicCompletions extends Disposable {
 		// use file search when having a pattern
 		if (pattern) {
 
-			const cacheKey = this.updateCacheKey();
+			const baseCacheKey = this.updateCacheKey();
+			const cacheKey = `${baseCacheKey.key}:${pattern}`;
 			const workspaces = this.workspaceContextService.getWorkspace().folders.map(folder => folder.uri);
 
 			for (const workspace of workspaces) {
-				const { folders, files } = await searchFilesAndFolders(workspace, pattern, true, token, cacheKey.key, this.configurationService, this.searchService);
+				const { folders, files } = await searchFilesAndFolders(workspace, pattern, true, token, cacheKey, this.configurationService, this.searchService);
 				for (const file of files) {
 					if (!seen.has(file)) {
 						result.suggestions.push(makeCompletionItem(file, FileKind.FILE));


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
# Fix #-mentions search for files and folder backspace bug

## Reproduction Steps
- have a folder called test with a file called index.md
- user types #t and "test" shows up as a result
- user blackspaces
- user types #t again

expected:
- "test" folder should show

actual:
- nothing shows

---

Additionally, you can see a large variance in search results with you type a part of a filename (e.g "hel" attempting to match a file called "hello.js"). When you first start typing, the results show quite well. Once to backspace, immediately all relevant values drop off.

---
Apologies in advance, I have not tested this and I am hoping to get some help to understand how to do that.