### PR TITLE
fix (macos): app not closing on cmd+q (only windows close)

### DIFF
--- a/src/vs/platform/menubar/electron-main/menubar.ts
+++ b/src/vs/platform/menubar/electron-main/menubar.ts
@@ -418,7 +418,11 @@ export class Menubar extends Disposable {
 		const hideOthers = new MenuItem({ label: nls.localize('mHideOthers', "Hide Others"), role: 'hideOthers', accelerator: 'Command+Alt+H' });
 		const showAll = new MenuItem({ label: nls.localize('mShowAll', "Show All"), role: 'unhide' });
 		const quit = new MenuItem(this.likeAction('workbench.action.quit', {
-			label: nls.localize('miQuit', "Quit {0}", this.productService.nameLong), click: async (item, window, event) => {
+			label: nls.localize('miQuit', "Quit {0}", this.productService.nameLong),
+			// Ensure Cmd+Q works even when no windows are open by providing a native accelerator.
+			// This is important on macOS where no renderer exists to contribute keybindings.
+			accelerator: isMacintosh ? 'Command+Q' : undefined,
+			click: async (item, window, event) => {
 				const lastActiveWindow = this.windowsMainService.getLastActiveWindow();
 				if (
 					this.windowsMainService.getWindowCount() === 0 || 	// allow to quit when no more windows are open

--- a/src/vs/platform/menubar/test/electron-main/menubar.test.ts
+++ b/src/vs/platform/menubar/test/electron-main/menubar.test.ts
@@ -1,0 +1,171 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { strictEqual } from 'assert';
+import { Menu, BrowserWindow } from 'electron';
+import { isMacintosh } from '../../../../base/common/platform.js';
+import { Menubar } from '../../electron-main/menubar.js';
+import { NullLogService } from '../../../log/common/log.js';
+import product from '../../../product/common/product.js';
+import { IProductService } from '../../../product/common/productService.js';
+import { Event } from '../../../../base/common/event.js';
+import { IWindowsMainService } from '../../../windows/electron-main/windows.js';
+import { IUpdateService, StateType } from '../../../update/common/update.js';
+import { IConfigurationService } from '../../../configuration/common/configuration.js';
+import { IEnvironmentMainService } from '../../../environment/electron-main/environmentMainService.js';
+import { ITelemetryService } from '../../../telemetry/common/telemetry.js';
+import { IWorkspacesHistoryMainService } from '../../../workspaces/electron-main/workspacesHistoryMainService.js';
+import { IStateService } from '../../../state/node/state.js';
+import { ILifecycleMainService, LifecycleMainPhase } from '../../../lifecycle/electron-main/lifecycleMainService.js';
+import { INativeHostMainService } from '../../../native/electron-main/nativeHostMainService.js';
+import { IAuxiliaryWindowsMainService } from '../../../auxiliaryWindow/electron-main/auxiliaryWindows.js';
+
+if (isMacintosh) {
+suite('Menubar (macOS)', function () {
+
+	test('Quit menu has Command+Q accelerator when no windows are open', function () {
+
+		// Stubs
+		const updateService: IUpdateService = {
+			_serviceBrand: undefined,
+			onStateChange: Event.None,
+			state: { type: StateType.Idle } as any,
+			isLatestVersion: async () => true,
+			checkForUpdates: async () => undefined,
+			downloadUpdate: async () => undefined,
+			applyUpdate: async () => undefined,
+			quitAndInstall: async () => undefined,
+			setUpdateFeedUrl: () => undefined,
+			getUpdateType: () => undefined
+		} as any;
+
+		const configurationService: IConfigurationService = {
+			_serviceBrand: undefined,
+			onDidChangeConfiguration: Event.None,
+			getValue: () => undefined,
+			updateValue: async () => undefined,
+			reloadConfiguration: async () => undefined,
+			inspect: () => undefined as any
+		} as any;
+
+		const windowsMainService: IWindowsMainService = {
+			_serviceBrand: undefined,
+			onDidOpenWindow: Event.None,
+			onDidChangeWindowsCount: Event.None,
+			getWindowCount: () => 0,
+			getLastActiveWindow: () => undefined,
+			getWindowById: () => undefined as any,
+			getFocusedWindow: () => undefined as any,
+			open: async () => [],
+			openEmptyWindow: async () => undefined,
+			focusLastActive: () => undefined,
+			sendToFocused: () => undefined,
+			ready: async () => undefined,
+			openAdditionalWindow: async () => undefined,
+			onDidTriggerSystemContextMenu: Event.None
+		} as any;
+
+		const environmentMainService: IEnvironmentMainService = {
+			_serviceBrand: undefined,
+			args: {} as any,
+			isBuilt: true
+		} as any;
+
+		const telemetryService: ITelemetryService = {
+			_serviceBrand: undefined,
+			publicLog2: () => undefined
+		} as any;
+
+		const workspacesHistoryMainService: IWorkspacesHistoryMainService = {
+			_serviceBrand: undefined,
+			clearRecentlyOpened: async () => undefined,
+			removeRecentlyOpened: async () => undefined
+		} as any;
+
+		const stateService: IStateService = {
+			_serviceBrand: undefined,
+			getItem: () => undefined,
+			setItem: () => undefined,
+			setItems: () => undefined,
+			removeItem: () => undefined,
+			close: async () => undefined
+		};
+
+		const lifecycleMainService: ILifecycleMainService = {
+			_serviceBrand: undefined,
+			onBeforeShutdown: Event.None,
+			onWillShutdown: Event.None,
+			onWillLoadWindow: Event.None,
+			onBeforeCloseWindow: Event.None,
+			wasRestarted: false,
+			quitRequested: false,
+			phase: LifecycleMainPhase.Ready,
+			registerWindow: () => undefined,
+			registerAuxWindow: () => undefined,
+			reload: async () => undefined,
+			unload: async () => false,
+			relaunch: async () => undefined,
+			setRelaunchHandler: () => undefined,
+			quit: async () => false,
+			kill: async () => undefined,
+			when: async () => undefined
+		};
+
+		const nativeHostMainService: INativeHostMainService = {
+			_serviceBrand: undefined,
+			showMessageBox: async () => ({ response: 0, checkboxChecked: false } as any)
+		} as any;
+
+		const productService: IProductService = { _serviceBrand: undefined, ...product };
+
+		const auxiliaryWindowsMainService: IAuxiliaryWindowsMainService = {
+			_serviceBrand: undefined,
+			getWindows: () => [],
+			getWindowByWebContents: () => undefined as any,
+			onDidTriggerSystemContextMenu: Event.None,
+			onDidChangeAlwaysOnTop: Event.None,
+			onDidMaximizeWindow: Event.None,
+			onDidUnmaximizeWindow: Event.None,
+			onDidChangeFullScreen: Event.None
+		} as any;
+
+		// Ensure no focused BrowserWindow to simulate no window case
+		try { BrowserWindow.getFocusedWindow()?.blur(); } catch { /* noop */ }
+
+		// Instantiate Menubar (constructor installs menu)
+		new Menubar(
+			updateService,
+			configurationService,
+			windowsMainService,
+			environmentMainService,
+			telemetryService,
+			workspacesHistoryMainService,
+			stateService,
+			lifecycleMainService,
+			new NullLogService(),
+			nativeHostMainService,
+			productService,
+			auxiliaryWindowsMainService
+		);
+
+		const appMenu = Menu.getApplicationMenu();
+		strictEqual(!!appMenu, true);
+
+		// The first item is the macOS application menu
+		const macAppMenu = appMenu!.items[0];
+		let hasCmdQ = false;
+		for (const item of macAppMenu.submenu!.items) {
+			if (item.accelerator === 'Command+Q') {
+				hasCmdQ = true;
+				break;
+			}
+		}
+
+		strictEqual(hasCmdQ, true);
+	});
+});
+}
+
+


### PR DESCRIPTION
## Steps to Reproduce:

1. Open VS Code on macOS.
Press Cmd + Q to quit the app.
2. Observe:
    - All windows close.
    - The app remains in the dock and Cmd + Tab app switcher.
    - Pressing Cmd + Q again results in a screen flash and error sound (if system if configured to alert on os error)
    - Only way to fully quit is via the "Code" menu → "Quit Visual Studio Code".

## Does this issue occur when all extensions are disabled?:
Yes

## System info

Version: 1.100.1
Commit: https://github.com/microsoft/vscode/commit/91fa95bccb027ece6a968589bb1d662fa9c8e170
Date: 2025-05-09T15:43:50.040Z (1 wk ago)
Electron: 34.5.1
ElectronBuildId: 11369351
Chromium: 132.0.6834.210
Node.js: 20.19.0
V8: 13.2.152.41-electron.0
OS: Darwin arm64 24.4.0

## Previously

This issue was posted here <https://github.com/microsoft/vscode/issues/249179> and closed then crash report data was not provided. This isn't a crash, however. Just a UX bug.