### PR TITLE
Support org governed mcp registry endpoint and access restrictions

### DIFF
--- a/src/vs/base/common/defaultAccount.ts
+++ b/src/vs/base/common/defaultAccount.ts
@@ -12,6 +12,8 @@ export interface IDefaultAccount {
 	readonly chat_enabled?: boolean;
 	readonly chat_preview_features_enabled?: boolean;
 	readonly mcp?: boolean;
+	readonly mcpRegistryUrl?: string;
+	readonly mcpAccess?: 'allow_all' | 'registry_only';
 	readonly analytics_tracking_id?: string;
 	readonly limited_user_quotas?: {
 		readonly chat: number;

--- a/src/vs/base/common/product.ts
+++ b/src/vs/base/common/product.ts
@@ -198,6 +198,7 @@ export interface IProductConfiguration {
 		};
 		readonly tokenEntitlementUrl: string;
 		readonly chatEntitlementUrl: string;
+		readonly mcpRegistryDataUrl: string;
 	};
 
 	readonly 'configurationSync.store'?: ConfigurationSyncStore;

--- a/src/vs/platform/mcp/common/allowedMcpServersService.ts
+++ b/src/vs/platform/mcp/common/allowedMcpServersService.ts
@@ -9,7 +9,7 @@ import * as nls from '../../../nls.js';
 import { IMarkdownString, MarkdownString } from '../../../base/common/htmlContent.js';
 import { IConfigurationService } from '../../configuration/common/configuration.js';
 import { Emitter } from '../../../base/common/event.js';
-import { IAllowedMcpServersService, IGalleryMcpServer, IInstallableMcpServer, ILocalMcpServer, mcpEnabledConfig } from './mcpManagement.js';
+import { IAllowedMcpServersService, IGalleryMcpServer, IInstallableMcpServer, ILocalMcpServer, mcpAccessConfig, McpAccessValue } from './mcpManagement.js';
 
 export class AllowedMcpServersService extends Disposable implements IAllowedMcpServersService {
 
@@ -23,19 +23,18 @@ export class AllowedMcpServersService extends Disposable implements IAllowedMcpS
 	) {
 		super();
 		this._register(this.configurationService.onDidChangeConfiguration(e => {
-			if (e.affectsConfiguration(mcpEnabledConfig)) {
+			if (e.affectsConfiguration(mcpAccessConfig)) {
 				this._onDidChangeAllowedMcpServers.fire();
 			}
 		}));
 	}
 
 	isAllowed(mcpServer: IGalleryMcpServer | ILocalMcpServer | IInstallableMcpServer): true | IMarkdownString {
-		const isEnabled = this.configurationService.getValue(mcpEnabledConfig) === true;
-		if (isEnabled) {
+		if (this.configurationService.getValue(mcpAccessConfig) !== McpAccessValue.None) {
 			return true;
 		}
 
-		const settingsCommandLink = URI.parse(`command:workbench.action.openSettings?${encodeURIComponent(JSON.stringify({ query: `@id:${mcpEnabledConfig}` }))}`).toString();
+		const settingsCommandLink = URI.parse(`command:workbench.action.openSettings?${encodeURIComponent(JSON.stringify({ query: `@id:${mcpAccessConfig}` }))}`).toString();
 		return new MarkdownString(nls.localize('mcp servers are not allowed', "Model Context Protocol servers are disabled in the Editor. Please check your [settings]({0}).", settingsCommandLink));
 	}
 }

--- a/src/vs/platform/mcp/common/mcpManagement.ts
+++ b/src/vs/platform/mcp/common/mcpManagement.ts
@@ -208,7 +208,7 @@ export interface IAllowedMcpServersService {
 	isAllowed(mcpServer: IGalleryMcpServer | ILocalMcpServer | IInstallableMcpServer): true | IMarkdownString;
 }
 
-export const mcpEnabledConfig = 'chat.mcp.enabled';
+export const mcpAccessConfig = 'chat.mcp.access';
 export const mcpGalleryServiceUrlConfig = 'chat.mcp.gallery.serviceUrl';
 export const mcpAutoStartConfig = 'chat.mcp.autostart';
 
@@ -216,4 +216,10 @@ export const enum McpAutoStartValue {
 	Never = 'never',
 	OnlyNew = 'onlyNew',
 	NewAndOutdated = 'newAndOutdated',
+}
+
+export const enum McpAccessValue {
+	None = 'none',
+	Registry = 'registry',
+	All = 'all',
 }

--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -19,7 +19,7 @@ import { Extensions as ConfigurationExtensions, ConfigurationScope, IConfigurati
 import { SyncDescriptor } from '../../../../platform/instantiation/common/descriptors.js';
 import { InstantiationType, registerSingleton } from '../../../../platform/instantiation/common/extensions.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
-import { McpAutoStartValue, mcpAutoStartConfig, mcpEnabledConfig, mcpGalleryServiceUrlConfig } from '../../../../platform/mcp/common/mcpManagement.js';
+import { McpAccessValue, McpAutoStartValue, mcpAccessConfig, mcpAutoStartConfig, mcpGalleryServiceUrlConfig } from '../../../../platform/mcp/common/mcpManagement.js';
 import { Registry } from '../../../../platform/registry/common/platform.js';
 import { EditorPaneDescriptor, IEditorPaneRegistry } from '../../../browser/editor.js';
 import { Extensions, IConfigurationMigrationRegistry } from '../../../common/configuration.js';
@@ -307,14 +307,32 @@ configurationRegistry.registerConfiguration({
 			description: nls.localize('chat.checkpoints.showFileChanges', "Controls whether to show chat checkpoint file changes."),
 			default: false
 		},
-		[mcpEnabledConfig]: {
-			type: 'boolean',
-			description: nls.localize('chat.mcp.enabled', "Enables integration with Model Context Protocol servers to provide additional tools and functionality."),
-			default: true,
+		[mcpAccessConfig]: {
+			type: 'string',
+			description: nls.localize('chat.mcp.access', "Controls access to Model Context Protocol servers."),
+			enum: [
+				McpAccessValue.None,
+				McpAccessValue.Registry,
+				McpAccessValue.All
+			],
+			enumDescriptions: [
+				nls.localize('chat.mcp.access.none', "No access to MCP servers."),
+				nls.localize('chat.mcp.access.registry', "Only allow access to MCP servers from the registry."),
+				nls.localize('chat.mcp.access.any', "Allow access to any MCP server.")
+			],
+			default: McpAccessValue.All,
 			policy: {
 				name: 'ChatMCP',
 				minimumVersion: '1.99',
-				value: (account) => account.mcp === false ? false : undefined,
+				value: (account) => {
+					if (account.mcp === false) {
+						return McpAccessValue.None;
+					}
+					if (account.mcpAccess === 'registry_only') {
+						return McpAccessValue.Registry;
+					}
+					return undefined;
+				},
 			}
 		},
 		[mcpAutoStartConfig]: {
@@ -430,6 +448,7 @@ configurationRegistry.registerConfiguration({
 			policy: {
 				name: 'McpGalleryServiceUrl',
 				minimumVersion: '1.101',
+				value: (account) => account.mcpRegistryUrl
 			},
 		},
 		[PromptsConfig.KEY]: {

--- a/src/vs/workbench/contrib/mcp/browser/mcp.contribution.ts
+++ b/src/vs/workbench/contrib/mcp/browser/mcp.contribution.ts
@@ -8,9 +8,11 @@ import { registerAction2 } from '../../../../platform/actions/common/actions.js'
 import { SyncDescriptor } from '../../../../platform/instantiation/common/descriptors.js';
 import { InstantiationType, registerSingleton } from '../../../../platform/instantiation/common/extensions.js';
 import * as jsonContributionRegistry from '../../../../platform/jsonschemas/common/jsonContributionRegistry.js';
+import { mcpAccessConfig, McpAccessValue } from '../../../../platform/mcp/common/mcpManagement.js';
 import { IQuickAccessRegistry, Extensions as QuickAccessExtensions } from '../../../../platform/quickinput/common/quickAccess.js';
 import { Registry } from '../../../../platform/registry/common/platform.js';
 import { EditorPaneDescriptor, IEditorPaneRegistry } from '../../../browser/editor.js';
+import { IConfigurationMigrationRegistry, Extensions as ConfigurationMigrationExtensions, ConfigurationKeyValuePairs } from '../../../common/configuration.js';
 import { registerWorkbenchContribution2, WorkbenchPhase } from '../../../common/contributions.js';
 import { EditorExtensions } from '../../../common/editor.js';
 import { mcpSchemaId } from '../../../services/configuration/common/configuration.js';
@@ -112,3 +114,19 @@ Registry.as<IQuickAccessRegistry>(QuickAccessExtensions.Quickaccess).registerQui
 		commandId: McpCommandIds.AddConfiguration
 	}]
 });
+
+
+Registry.as<IConfigurationMigrationRegistry>(ConfigurationMigrationExtensions.ConfigurationMigration)
+	.registerConfigurationMigrations([{
+		key: 'chat.mcp.enabled',
+		migrateFn: (value, accessor) => {
+			const result: ConfigurationKeyValuePairs = [['chat.mcp.enabled', { value: undefined }]];
+			if (value === true) {
+				result.push([mcpAccessConfig, { value: McpAccessValue.All }]);
+			}
+			if (value === false) {
+				result.push([mcpAccessConfig, { value: McpAccessValue.None }]);
+			}
+			return result;
+		}
+	}]);

--- a/src/vs/workbench/contrib/mcp/browser/mcpDiscovery.ts
+++ b/src/vs/workbench/contrib/mcp/browser/mcpDiscovery.ts
@@ -7,7 +7,7 @@ import { Disposable, DisposableStore } from '../../../../base/common/lifecycle.j
 import { autorun } from '../../../../base/common/observable.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
-import { mcpEnabledConfig } from '../../../../platform/mcp/common/mcpManagement.js';
+import { mcpAccessConfig, McpAccessValue } from '../../../../platform/mcp/common/mcpManagement.js';
 import { observableConfigValue } from '../../../../platform/observable/common/platformObservableUtils.js';
 import { IWorkbenchContribution } from '../../../common/contributions.js';
 import { mcpDiscoveryRegistry } from '../common/discovery/mcpDiscovery.js';
@@ -21,11 +21,11 @@ export class McpDiscovery extends Disposable implements IWorkbenchContribution {
 	) {
 		super();
 
-		const enabled = observableConfigValue(mcpEnabledConfig, true, configurationService);
+		const mcpAccessValue = observableConfigValue(mcpAccessConfig, McpAccessValue.All, configurationService);
 		const store = this._register(new DisposableStore());
 
 		this._register(autorun(reader => {
-			if (enabled.read(reader)) {
+			if (mcpAccessValue.read(reader) !== McpAccessValue.None) {
 				for (const discovery of mcpDiscoveryRegistry.getAll()) {
 					const inst = store.add(instantiationService.createInstance(discovery));
 					inst.start();

--- a/src/vs/workbench/contrib/mcp/browser/mcpServerActions.ts
+++ b/src/vs/workbench/contrib/mcp/browser/mcpServerActions.ts
@@ -17,7 +17,7 @@ import { Location } from '../../../../editor/common/languages.js';
 import { ICommandService } from '../../../../platform/commands/common/commands.js';
 import { IContextMenuService } from '../../../../platform/contextview/browser/contextView.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
-import { IAllowedMcpServersService } from '../../../../platform/mcp/common/mcpManagement.js';
+import { mcpAccessConfig, McpAccessValue } from '../../../../platform/mcp/common/mcpManagement.js';
 import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry.js';
 import { IAuthenticationService } from '../../../services/authentication/common/authentication.js';
 import { IAccountQuery, IAuthenticationQueryService } from '../../../services/authentication/common/authenticationQuery.js';
@@ -25,8 +25,9 @@ import { IEditorService } from '../../../services/editor/common/editorService.js
 import { errorIcon, infoIcon, manageExtensionIcon, trustIcon, warningIcon } from '../../extensions/browser/extensionsIcons.js';
 import { McpCommandIds } from '../common/mcpCommandIds.js';
 import { IMcpRegistry } from '../common/mcpRegistryTypes.js';
-import { IMcpSamplingService, IMcpServer, IMcpServerContainer, IMcpService, IMcpWorkbenchService, IWorkbenchMcpServer, McpCapability, McpConnectionState, McpServerEditorTab, McpServerInstallState } from '../common/mcpTypes.js';
+import { IMcpSamplingService, IMcpServer, IMcpServerContainer, IMcpService, IMcpWorkbenchService, IWorkbenchMcpServer, McpCapability, McpConnectionState, McpServerEditorTab, McpServerEnablementState, McpServerInstallState } from '../common/mcpTypes.js';
 import { startServerByFilter } from '../common/mcpTypesUtils.js';
+import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 
 export abstract class McpServerAction extends Action implements IMcpServerContainer {
 
@@ -811,11 +812,10 @@ export class McpServerStatusAction extends McpServerAction {
 
 	constructor(
 		@IMcpWorkbenchService private readonly mcpWorkbenchService: IMcpWorkbenchService,
-		@IAllowedMcpServersService private readonly allowedMcpServersService: IAllowedMcpServersService,
 		@ICommandService private readonly commandService: ICommandService,
+		@IConfigurationService private readonly configurationService: IConfigurationService,
 	) {
 		super('extensions.status', '', `${McpServerStatusAction.CLASS} hide`, false);
-		this._register(allowedMcpServersService.onDidChangeAllowedMcpServers(() => this.update()));
 		this.update();
 	}
 
@@ -839,12 +839,14 @@ export class McpServerStatusAction extends McpServerAction {
 			}
 		}
 
-		if (this.mcpServer.local && this.mcpServer.installState === McpServerInstallState.Installed) {
-			const result = this.allowedMcpServersService.isAllowed(this.mcpServer.local);
-			if (result !== true) {
-				this.updateStatus({ icon: warningIcon, message: new MarkdownString(localize('disabled - not allowed', "This MCP Server is disabled because {0}", result.value)) }, true);
-				return;
+		if (this.mcpServer.local && this.mcpServer.installState === McpServerInstallState.Installed && this.mcpServer.enablementState === McpServerEnablementState.DisabledByAccess) {
+			const settingsCommandLink = URI.parse(`command:workbench.action.openSettings?${encodeURIComponent(JSON.stringify({ query: `@id:${mcpAccessConfig}` }))}`).toString();
+			if (this.configurationService.getValue(mcpAccessConfig) === McpAccessValue.None) {
+				this.updateStatus({ icon: warningIcon, message: new MarkdownString(localize('disabled - all not allowed', "This MCP Server is disabled because MCP servers are configured to be disabled in the Editor. Please check your [settings]({0}).", settingsCommandLink)) }, true);
+			} else {
+				this.updateStatus({ icon: warningIcon, message: new MarkdownString(localize('disabled - some not allowed', "This MCP Server is disabled because it is configured to be disabled in the Editor. Please check your [settings]({0}).", settingsCommandLink)) }, true);
 			}
+			return;
 		}
 	}
 

--- a/src/vs/workbench/contrib/mcp/browser/mcpServersView.ts
+++ b/src/vs/workbench/contrib/mcp/browser/mcpServersView.ts
@@ -24,7 +24,7 @@ import { IThemeService } from '../../../../platform/theme/common/themeService.js
 import { getLocationBasedViewColors } from '../../../browser/parts/views/viewPane.js';
 import { IViewletViewOptions } from '../../../browser/parts/views/viewsViewlet.js';
 import { IViewDescriptorService, IViewsRegistry, ViewContainerLocation, Extensions as ViewExtensions } from '../../../common/views.js';
-import { HasInstalledMcpServersContext, IMcpWorkbenchService, InstalledMcpServersViewId, IWorkbenchMcpServer, McpServerContainers, McpServerInstallState } from '../common/mcpTypes.js';
+import { HasInstalledMcpServersContext, IMcpWorkbenchService, InstalledMcpServersViewId, IWorkbenchMcpServer, McpServerContainers, McpServerEnablementState, McpServerInstallState } from '../common/mcpTypes.js';
 import { DropDownAction, InstallAction, InstallingLabelAction, ManageMcpServerAction, McpServerStatusAction } from './mcpServerActions.js';
 import { PublisherWidget, InstallCountWidget, RatingsWidget, McpServerIconWidget, McpServerHoverWidget, McpServerScopeBadgeWidget } from './mcpServerWidgets.js';
 import { ActionRunner, IAction, Separator } from '../../../../base/common/actions.js';
@@ -392,7 +392,7 @@ class McpServerRenderer implements IListRenderer<IWorkbenchMcpServer, IMcpServer
 		const updateEnablement = () => {
 			const disabled = !!mcpServer.local &&
 				(mcpServer.installState === McpServerInstallState.Installed
-					? this.allowedMcpServersService.isAllowed(mcpServer.local) !== true
+					? mcpServer.enablementState === McpServerEnablementState.DisabledByAccess
 					: mcpServer.installState === McpServerInstallState.Uninstalled);
 			data.root.classList.toggle('disabled', disabled);
 		};

--- a/src/vs/workbench/contrib/mcp/common/mcpTypes.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpTypes.ts
@@ -619,6 +619,11 @@ export interface IMcpServerEditorOptions extends IEditorOptions {
 	sideByside?: boolean;
 }
 
+export const enum McpServerEnablementState {
+	DisabledByAccess,
+	Enabled,
+}
+
 export const enum McpServerInstallState {
 	Installing,
 	Installed,
@@ -637,6 +642,7 @@ export interface IWorkbenchMcpServer {
 	readonly local: IWorkbenchLocalMcpServer | undefined;
 	readonly installable: IInstallableMcpServer | undefined;
 	readonly installState: McpServerInstallState;
+	readonly enablementState: McpServerEnablementState;
 	readonly id: string;
 	readonly name: string;
 	readonly label: string;

--- a/src/vs/workbench/contrib/mcp/test/common/mcpRegistry.test.ts
+++ b/src/vs/workbench/contrib/mcp/test/common/mcpRegistry.test.ts
@@ -15,7 +15,7 @@ import { IDialogService } from '../../../../../platform/dialogs/common/dialogs.j
 import { ServiceCollection } from '../../../../../platform/instantiation/common/serviceCollection.js';
 import { TestInstantiationService } from '../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
 import { ILogger, ILoggerService, ILogService, NullLogger, NullLogService } from '../../../../../platform/log/common/log.js';
-import { mcpEnabledConfig } from '../../../../../platform/mcp/common/mcpManagement.js';
+import { mcpAccessConfig, McpAccessValue } from '../../../../../platform/mcp/common/mcpManagement.js';
 import { IProductService } from '../../../../../platform/product/common/productService.js';
 import { ISecretStorageService } from '../../../../../platform/secrets/common/secrets.js';
 import { TestSecretStorageService } from '../../../../../platform/secrets/test/common/testSecretStorageService.js';
@@ -139,7 +139,7 @@ suite('Workbench - MCP - Registry', () => {
 		testConfigResolverService = new TestConfigurationResolverService();
 		testStorageService = store.add(new TestStorageService());
 		testDialogService = new TestDialogService();
-		configurationService = new TestConfigurationService({ [mcpEnabledConfig]: true });
+		configurationService = new TestConfigurationService({ [mcpAccessConfig]: McpAccessValue.All });
 		trustNonceBearer = { trustedAtNonce: undefined };
 
 		const services = new ServiceCollection(
@@ -203,12 +203,12 @@ suite('Workbench - MCP - Registry', () => {
 
 		assert.strictEqual(registry.collections.get().length, 1);
 
-		configurationService.setUserConfiguration(mcpEnabledConfig, false);
+		configurationService.setUserConfiguration(mcpAccessConfig, McpAccessValue.None);
 		configurationService.onDidChangeConfigurationEmitter.fire({ affectsConfiguration: () => true } as any);
 
 		assert.strictEqual(registry.collections.get().length, 0);
 
-		configurationService.setUserConfiguration(mcpEnabledConfig, true);
+		configurationService.setUserConfiguration(mcpAccessConfig, McpAccessValue.All);
 		configurationService.onDidChangeConfigurationEmitter.fire({ affectsConfiguration: () => true } as any);
 	});
 

--- a/src/vs/workbench/services/accounts/common/defaultAccount.ts
+++ b/src/vs/workbench/services/accounts/common/defaultAccount.ts
@@ -52,6 +52,22 @@ interface ITokenEntitlementsResponse {
 	token: string;
 }
 
+interface IMcpRegistryProvider {
+	readonly url: string;
+	readonly registry_access: 'allow_all' | 'registry_only';
+	readonly owner: {
+		readonly login: string;
+		readonly id: number;
+		readonly type: string;
+		readonly parent_login: string | null;
+		readonly priority: number;
+	};
+}
+
+interface IMcpRegistryResponse {
+	readonly mcp_registries: ReadonlyArray<IMcpRegistryProvider>;
+}
+
 export const IDefaultAccountService = createDecorator<IDefaultAccountService>('defaultAccountService');
 
 export interface IDefaultAccountService {
@@ -136,7 +152,7 @@ export class DefaultAccountManagementContribution extends Disposable implements 
 			return;
 		}
 
-		const { authenticationProvider, tokenEntitlementUrl, chatEntitlementUrl } = this.productService.defaultAccount;
+		const { authenticationProvider, tokenEntitlementUrl, chatEntitlementUrl, mcpRegistryDataUrl } = this.productService.defaultAccount;
 		await this.extensionService.whenInstalledExtensionsRegistered();
 
 		const declaredProvider = this.authenticationService.declaredProviders.find(provider => provider.id === authenticationProvider.id);
@@ -146,7 +162,7 @@ export class DefaultAccountManagementContribution extends Disposable implements 
 		}
 
 		this.registerSignInAction(authenticationProvider.id, declaredProvider.label, authenticationProvider.enterpriseProviderId, authenticationProvider.enterpriseProviderConfig, authenticationProvider.scopes);
-		this.setDefaultAccount(await this.getDefaultAccountFromAuthenticatedSessions(authenticationProvider.id, authenticationProvider.enterpriseProviderId, authenticationProvider.enterpriseProviderConfig, authenticationProvider.scopes, tokenEntitlementUrl, chatEntitlementUrl));
+		this.setDefaultAccount(await this.getDefaultAccountFromAuthenticatedSessions(authenticationProvider.id, authenticationProvider.enterpriseProviderId, authenticationProvider.enterpriseProviderConfig, authenticationProvider.scopes, tokenEntitlementUrl, chatEntitlementUrl, mcpRegistryDataUrl));
 
 		this._register(this.authenticationService.onDidChangeSessions(async e => {
 			if (e.providerId !== authenticationProvider.id && e.providerId !== authenticationProvider.enterpriseProviderId) {
@@ -157,7 +173,7 @@ export class DefaultAccountManagementContribution extends Disposable implements 
 				this.setDefaultAccount(null);
 				return;
 			}
-			this.setDefaultAccount(await this.getDefaultAccountFromAuthenticatedSessions(authenticationProvider.id, authenticationProvider.enterpriseProviderId, authenticationProvider.enterpriseProviderConfig, authenticationProvider.scopes, tokenEntitlementUrl, chatEntitlementUrl));
+			this.setDefaultAccount(await this.getDefaultAccountFromAuthenticatedSessions(authenticationProvider.id, authenticationProvider.enterpriseProviderId, authenticationProvider.enterpriseProviderConfig, authenticationProvider.scopes, tokenEntitlementUrl, chatEntitlementUrl, mcpRegistryDataUrl));
 		}));
 
 	}
@@ -184,7 +200,7 @@ export class DefaultAccountManagementContribution extends Disposable implements 
 		return result;
 	}
 
-	private async getDefaultAccountFromAuthenticatedSessions(authProviderId: string, enterpriseAuthProviderId: string, enterpriseAuthProviderConfig: string, scopes: string[], tokenEntitlementUrl: string, chatEntitlementUrl: string): Promise<IDefaultAccount | null> {
+	private async getDefaultAccountFromAuthenticatedSessions(authProviderId: string, enterpriseAuthProviderId: string, enterpriseAuthProviderConfig: string, scopes: string[], tokenEntitlementUrl: string, chatEntitlementUrl: string, mcpRegistryDataUrl: string): Promise<IDefaultAccount | null> {
 		const id = this.configurationService.getValue(enterpriseAuthProviderConfig) === enterpriseAuthProviderId ? enterpriseAuthProviderId : authProviderId;
 		const sessions = await this.authenticationService.getSessions(id, undefined, undefined, true);
 		const session = sessions.find(s => this.scopesMatch(s.scopes, scopes));
@@ -193,9 +209,10 @@ export class DefaultAccountManagementContribution extends Disposable implements 
 			return null;
 		}
 
-		const [chatEntitlements, tokenEntitlements] = await Promise.all([
+		const [chatEntitlements, tokenEntitlements, mcpRegistryProvider] = await Promise.all([
 			this.getChatEntitlements(session.accessToken, chatEntitlementUrl),
-			this.getTokenEntitlements(session.accessToken, tokenEntitlementUrl)
+			this.getTokenEntitlements(session.accessToken, tokenEntitlementUrl),
+			this.getMcpRegistryProvider(session.accessToken, mcpRegistryDataUrl),
 		]);
 
 		return {
@@ -203,6 +220,8 @@ export class DefaultAccountManagementContribution extends Disposable implements 
 			enterprise: id === enterpriseAuthProviderId || session.account.label.includes('_'),
 			...chatEntitlements,
 			...tokenEntitlements,
+			mcpRegistryUrl: mcpRegistryProvider?.url,
+			mcpAccess: mcpRegistryProvider?.registry_access,
 		};
 	}
 
@@ -268,6 +287,29 @@ export class DefaultAccountManagementContribution extends Disposable implements 
 			this.logService.error('Failed to fetch entitlements', getErrorMessage(error));
 		}
 		return {};
+	}
+
+	private async getMcpRegistryProvider(accessToken: string, mcpRegistryDataUrl: string): Promise<IMcpRegistryProvider | undefined> {
+		try {
+			const context = await this.requestService.request({
+				type: 'GET',
+				url: mcpRegistryDataUrl,
+				disableCache: true,
+				headers: {
+					'Authorization': `Bearer ${accessToken}`
+				}
+			}, CancellationToken.None);
+
+			const data = await asJson<IMcpRegistryResponse>(context);
+			if (data) {
+				this.logService.debug('Fetched MCP registry', data.mcp_registries);
+				return data.mcp_registries[0];
+			}
+			this.logService.error('Failed to fetch entitlements', 'No data returned');
+		} catch (error) {
+			this.logService.error('Failed to fetch MCP registry URL', getErrorMessage(error));
+		}
+		return undefined;
 	}
 
 	private registerSignInAction(authProviderId: string, authProviderLabel: string, enterpriseAuthProviderId: string, enterpriseAuthProviderConfig: string, scopes: string[]): void {


### PR DESCRIPTION
@connor4312 - While adopting to org governed mcp server access restrictions, I have intrdouced a new mcp access setting - `chat.mcp.access`. I have deprecated/removed the existing `chat.mcp.enabled` setting in favour of this. 