### PR TITLE
fix: parse commands in chat.open commands

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/actions/chatActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatActions.ts
@@ -236,14 +236,15 @@ abstract class OpenChatGlobalAction extends Action2 {
 		let resp: Promise<IChatResponseModel | undefined> | undefined;
 
 		if (opts?.query) {
-			if (opts.isPartialQuery) {
-				chatWidget.setInput(opts.query);
-			} else {
+			chatWidget.setInput(opts.query);
+
+			if (!opts.isPartialQuery) {
 				await chatWidget.waitForReady();
 				await waitForDefaultAgent(chatAgentService, chatWidget.input.currentModeKind);
-				resp = chatWidget.acceptInput(opts.query);
+				resp = chatWidget.acceptInput();
 			}
 		}
+
 		if (opts?.toolIds && opts.toolIds.length > 0) {
 			for (const toolId of opts.toolIds) {
 				const tool = toolsService.getTool(toolId);


### PR DESCRIPTION
`workbench.action.chat.open` did not always trigger a parse of the input resulting in `/<prompt>` not being recognized as a prompt command when it's expected to.

If `isPartialQuery: false` (default), then the command used [`acceptInput` intead of `setInput`](https://github.com/microsoft/vscode/blob/709b8fabf55c505cbe5603ce654ecf3a8766a7a6/src/vs/workbench/contrib/chat/browser/actions/chatActions.ts#L244) only the latter of which will trigger a [re-parse of the query](https://github.com/microsoft/vscode/blob/709b8fabf55c505cbe5603ce654ecf3a8766a7a6/src/vs/workbench/contrib/chat/browser/chatWidget.ts#L1640) to critcially turn [`/<prompt>` into a `ChatRequestSlashPromptPart`](https://github.com/microsoft/vscode/blob/d2ff8d16065d4748b8a205bfebdc98d7d76f7864/src/vs/workbench/contrib/chat/common/chatRequestParser.ts#L231).

**Reviewers**: There's a few places `acceptInput` is called with a query in the codebase. It's not clear to me if the others have the same issue or if always triggering a re-parse would double parse.
