### PR TITLE
thinking part configurations: show thinking on, collapsed off

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -587,8 +587,14 @@ configurationRegistry.registerConfiguration({
 		},
 		[ChatConfiguration.ShowThinking]: {
 			type: 'boolean',
-			default: false,
+			default: true,
 			description: nls.localize('chat.agent.showThinking', "Controls whether to show the thinking process of the model in chat responses."),
+			tags: ['experimental'],
+		},
+		[ChatConfiguration.ThinkingCollapsedByDefault]: {
+			type: 'boolean',
+			default: true,
+			description: nls.localize('chat.agent.thinkingCollapsedByDefault', "Controls whether the thinking section is collapsed by default when shown."),
 			tags: ['experimental'],
 		},
 		'chat.disableAIFeatures': {

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/chatPinnedContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/chatPinnedContentPart.ts
@@ -9,6 +9,8 @@ import { ChatTreeItem } from '../chat.js';
 import { ChatCollapsibleContentPart } from './chatCollapsibleContentPart.js';
 import { IChatContentPartRenderContext } from './chatContentParts.js';
 import * as nls from '../../../../../nls.js';
+import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
+import { ChatConfiguration } from '../../common/constants.js';
 
 export class ChatPinnedContentPart extends ChatCollapsibleContentPart {
 	private body!: HTMLElement;
@@ -17,9 +19,11 @@ export class ChatPinnedContentPart extends ChatCollapsibleContentPart {
 	constructor(
 		private content: HTMLElement | undefined,
 		context: IChatContentPartRenderContext,
+		@IConfigurationService private readonly configurationService: IConfigurationService,
 	) {
 		super(nls.localize('chat.pinned.thinking.header.base', "Thinking..."), context);
-		this.setExpanded(false);
+		const collapsedByDefault = this.configurationService.getValue<boolean>(ChatConfiguration.ThinkingCollapsedByDefault) ?? true;
+		this.setExpanded(!collapsedByDefault);
 		this.domNode.classList.add('chat-thinking-box');
 		this.domNode.tabIndex = 0;
 

--- a/src/vs/workbench/contrib/chat/browser/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/media/chat.css
@@ -2612,26 +2612,71 @@ have to be updated for changes to the rules above, or to support more deeply nes
 
 .interactive-session .interactive-response .chat-used-context-list.chat-thinking-items {
 	color: var(--vscode-descriptionForeground);
-	padding-top: 6px;
+	padding-top: 0;
 }
 
 .interactive-session .interactive-response .value .chat-thinking-box {
 	outline: none;
+	position: relative;
+	color: var(--vscode-descriptionForeground);
 
 	.chat-used-context {
 		margin: 0px;
 	}
 
 	.chat-thinking-item {
-		padding: 2px 0px;
+		padding: 6px 0px;
+		padding-inline-start: 22px;
+		position: relative;
+
+		.progress-container {
+			margin-bottom: 0px;
+			padding-top: 0px;
+		}
+
+		/* chain of thought lines */
+		&::before {
+			content: '';
+			position: absolute;
+			left: 10.5px;
+			top: 0px;
+			bottom: 0px;
+			width: 1px;
+			background-color: var(--vscode-chat-requestBorder);
+			mask-image: linear-gradient(to bottom, #000 0 10px, transparent 10px 22px, #000 22px 100%);
+		}
+
+		&:first-child::before {
+
+			mask-image: linear-gradient(to bottom, transparent 0 22px, #000 22px 100%);
+		}
+
+		&:last-child::before {
+			mask-image: linear-gradient(to bottom, #000 0 10px, transparent 10px 100%);
+		}
+
+		&:only-child::before {
+			background: none;
+			mask-image: none;
+		}
+
+		/* chain of thought dot */
+		&::after {
+			content: '';
+			position: absolute;
+			left: 8px;
+			top: 13px;
+			width: 6px;
+			height: 6px;
+			border-radius: 50%;
+			background-color: var(--vscode-chat-requestBorder);
+		}
 	}
 
 	.chat-thinking-text {
 		font-size: var(--vscode-chat-font-size-body-s);
-		padding: 3px 10px;
-		line-height: inherit;
-		display: flex;
-		align-items: flex-start;
+		padding: 0 10px;
+		display: block;
 	}
 
 	.rendered-markdown > p {

--- a/src/vs/workbench/contrib/chat/common/constants.ts
+++ b/src/vs/workbench/contrib/chat/common/constants.ts
@@ -14,6 +14,7 @@ export enum ChatConfiguration {
 	CheckpointsEnabled = 'chat.checkpoints.enabled',
 	AgentSessionsViewLocation = 'chat.agentSessionsViewLocation',
 	ShowThinking = 'chat.agent.showThinking',
+	ThinkingCollapsedByDefault = 'chat.agent.thinkingCollapsedByDefault',
 	UseChatSessionsForCloudButton = 'chat.useChatSessionsForCloudButton'
 }
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

defaults thinking to be shown.

defaults thinking containers to be collapsed by default. 

new thinking UI:

<img width="342" height="432" alt="Screenshot 2025-08-26 at 6 59 41 PM" src="https://github.com/user-attachments/assets/210f0720-b784-4404-ad86-2058070c3fd0" />
