### PR TITLE
Add icon to terminal progress part

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/media/chatTerminalToolProgressPart.css
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/media/chatTerminalToolProgressPart.css
@@ -1,0 +1,44 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+.chat-terminal-content-part {
+	width: 100%;
+}
+
+.chat-terminal-content-part .chat-terminal-content-title {
+	border: 1px solid var(--vscode-chat-requestBorder);
+	border-radius: 4px;
+	padding: 5px 9px;
+	display: flex;
+	justify-content: space-between;
+	flex-direction: column;
+	column-gap: 10px;
+
+	> .rendered-markdown {
+		p {
+			margin: 0 !important;
+		}
+		code {
+			background: transparent !important;
+		}
+	}
+}
+
+.chat-terminal-content-part .chat-terminal-content-message {
+	.rendered-markdown {
+		white-space: normal;
+		line-height: normal;
+
+		& > p {
+			color: var(--vscode-descriptionForeground);
+			font-size: var(--vscode-chat-font-size-body-s);
+			margin: 0 !important;
+
+			code {
+				font-size: var(--vscode-chat-font-size-body-xs);
+			}
+		}
+	}
+}

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/media/chatTerminalToolProgressPart.css
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/media/chatTerminalToolProgressPart.css
@@ -16,11 +16,15 @@
 	flex-direction: column;
 	column-gap: 10px;
 
-	> .rendered-markdown {
+	.rendered-markdown {
+		display: flex;
+		column-gap: 4px;
+
 		p {
 			margin: 0 !important;
 		}
-		code {
+
+		.monaco-tokenized-source {
 			background: transparent !important;
 		}
 	}

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart.ts
@@ -61,7 +61,7 @@ export class ChatTerminalToolProgressPart extends BaseChatToolInvocationSubPart 
 		const titlePart = this._register(instantiationService.createInstance(
 			ChatQueryTitlePart,
 			elements.title,
-			new MarkdownString(`$(${Codicon.terminal.id}) \`${command}\``, { supportThemeIcons: true }),
+			new MarkdownString(`$(${Codicon.terminal.id})\n\n\`\`\`${terminalData.language}\n${command}\n\`\`\``, { supportThemeIcons: true }),
 			undefined,
 			markdownRenderer,
 		));


### PR DESCRIPTION
Part of #257468

This also changes the background color to align with the future design.

Before single line:

<img width="800" height="200" alt="image" src="https://github.com/user-attachments/assets/48654b7c-cabd-4eeb-896b-875d65c0c587" />

After single line:

<img width="682" height="206" alt="image" src="https://github.com/user-attachments/assets/f2c24d96-bf76-4851-a4a3-c52324ba045d" />

Before multi-line:

<img width="1242" height="896" alt="image" src="https://github.com/user-attachments/assets/f1fdf18e-4d71-4cce-b134-fc6b56a6d703" />


After multi-line:

<img width="694" height="784" alt="image" src="https://github.com/user-attachments/assets/89d20dab-0ae7-481b-9d4c-8fa20a47d180" />
