### PR TITLE
skip flakey blockOnResponse tests

### DIFF
--- a/extensions/vscode-api-tests/src/singlefolder-tests/chat.test.ts
+++ b/extensions/vscode-api-tests/src/singlefolder-tests/chat.test.ts
@@ -124,7 +124,10 @@ suite('chat', () => {
 		assert.strictEqual(request3.context.history.length, 2); // request + response = 2
 	});
 
-	test('workbench.action.chat.open.blockOnResponse defaults to non-blocking for backwards compatibility', async () => {
+	// fixme(rwoll): workbench.action.chat.open.blockOnResponse tests are flaking in CI:
+	//               * https://github.com/microsoft/vscode/issues/263572
+	//               * https://github.com/microsoft/vscode/issues/263575
+	test.skip('workbench.action.chat.open.blockOnResponse defaults to non-blocking for backwards compatibility', async () => {
 		const toolRegistration = lm.registerTool<void>('requires_confirmation_tool', {
 			invoke: async (_options, _token) => null, prepareInvocation: async (_options, _token) => {
 				return { invocationMessage: 'Invoking', pastTenseMessage: 'Invoked', confirmationMessages: { title: 'Confirm', message: 'Are you sure?' } };
@@ -145,7 +148,7 @@ suite('chat', () => {
 		assert.strictEqual(result, undefined);
 	});
 
-	test('workbench.action.chat.open.blockOnResponse resolves when waiting for user confirmation to run a tool', async () => {
+	test.skip('workbench.action.chat.open.blockOnResponse resolves when waiting for user confirmation to run a tool', async () => {
 		const toolRegistration = lm.registerTool<void>('requires_confirmation_tool', {
 			invoke: async (_options, _token) => null, prepareInvocation: async (_options, _token) => {
 				return { invocationMessage: 'Invoking', pastTenseMessage: 'Invoked', confirmationMessages: { title: 'Confirm', message: 'Are you sure?' } };
@@ -166,7 +169,7 @@ suite('chat', () => {
 		assert.strictEqual(result?.type, 'confirmation');
 	});
 
-	test('workbench.action.chat.open.blockOnResponse resolves when an error is hit', async () => {
+	test.skip('workbench.action.chat.open.blockOnResponse resolves when an error is hit', async () => {
 		const participant = chat.createChatParticipant('api-test.participant', async (_request, _context, _progress, _token) => {
 			return { errorDetails: { code: 'rate_limited', message: `You've been rate limited. Try again later!` } };
 		});


### PR DESCRIPTION
`workbench.action.chat.open.blockOnResponse` is flaking in CI. So far,
I cannot reproduce locally so skipping to avoid noise in CI while I
debug.

Since the core logic (i.e. not the test) is only hit if `blockOnResponse`
is set to `true`, leaving it in is low-risk.

Relates #263572.
Relates #263575.