### PR TITLE
chore: bump lastUpdatedDate

### DIFF
--- a/.config/guardian/.gdnsuppress
+++ b/.config/guardian/.gdnsuppress
@@ -8,7 +8,7 @@
     "default": {
       "name": "default",
       "createdDate": "2025-03-17 11:52:32Z",
-      "lastUpdatedDate": "2025-03-17 11:52:32Z"
+      "lastUpdatedDate": "2025-08-06 13:58:56Z"
     }
   },
   "results": {


### PR DESCRIPTION
I noticed that the latest suppressions were still not registering. This PR bumps the lastUpdatedDate to try and register them.