### PR TITLE
Fix disposable leak in BrowserSocketFactory

### DIFF
--- a/src/vs/platform/remote/browser/browserSocketFactory.ts
+++ b/src/vs/platform/remote/browser/browserSocketFactory.ts
@@ -283,11 +283,11 @@ export class BrowserSocketFactory implements ISocketFactory<RemoteConnectionType
 			const webSocketSchema = (/^https:/.test(mainWindow.location.href) ? 'wss' : 'ws');
 			const socket = this._webSocketFactory.create(`${webSocketSchema}://${(/:/.test(host) && !/\[/.test(host)) ? `[${host}]` : host}:${port}${path}?${query}&skipWebSocketFrames=false`, debugLabel);
 			const disposables = new DisposableStore();
-			socket.onError(reject, undefined, disposables);
-			socket.onOpen(() => {
+			disposables.add(socket.onError(reject));
+			disposables.add(socket.onOpen(() => {
 				disposables.dispose();
 				resolve(new BrowserSocket(socket, debugLabel));
-			}, undefined, disposables);
+			}));
 		});
 	}
 }

--- a/src/vs/platform/remote/browser/browserSocketFactory.ts
+++ b/src/vs/platform/remote/browser/browserSocketFactory.ts
@@ -283,11 +283,11 @@ export class BrowserSocketFactory implements ISocketFactory<RemoteConnectionType
 			const webSocketSchema = (/^https:/.test(mainWindow.location.href) ? 'wss' : 'ws');
 			const socket = this._webSocketFactory.create(`${webSocketSchema}://${(/:/.test(host) && !/\[/.test(host)) ? `[${host}]` : host}:${port}${path}?${query}&skipWebSocketFrames=false`, debugLabel);
 			const disposables = new DisposableStore();
-			socket.onError(reject, disposables);
+			socket.onError(reject, undefined, disposables);
 			socket.onOpen(() => {
 				disposables.dispose();
 				resolve(new BrowserSocket(socket, debugLabel));
-			}, disposables);
+			}, undefined, disposables);
 		});
 	}
 }


### PR DESCRIPTION
[LEAKED DISPOSABLE] Error: CREATED via:
  at GCBasedDisposableTracker.trackDisposable src/vs/base/common/lifecycle.ts:47:23
  at trackDisposable src/vs/base/common/lifecycle.ts:218:24
  at toDisposable src/vs/base/common/lifecycle.ts:296:18
  at BrowserWebSocket._event [as onOpen] src/vs/base/common/event.ts:879:28
  at new Promise (<anonymous>)
  at BrowserSocketFactory.connect src/vs/platform/remote/browser/browserSocketFactory.ts:194:16
  at RemoteSocketFactoryService.connect src/vs/platform/remote/common/remoteSocketFactoryService.ts:31:30
  at createSocket src/vs/platform/remote/common/remoteAgentConnection.ts:122:32
  at connectToRemoteExtensionHostAgent src/vs/platform/remote/common/remoteAgentConnection.ts:159:24
  at connectToRemoteExtensionHostAgentAndReadOneMessage src/vs/platform/remote/common/remoteAgentConnection.ts:232:46
  at doConnectRemoteAgentExtensionHost src/vs/platform/remote/common/remoteAgentConnection.ts:258:46
  at ExtensionHostPersistentConnection._reconnect src/vs/platform/remote/common/remoteAgentConnection.ts:622:15
  at ExtensionHostPersistentConnection._runReconnectingLoop src/vs/platform/remote/common/remoteAgentConnection.ts:515:28
  at async ExtensionHostPersistentConnection._beginReconnecting src/vs/platform/remote/common/remoteAgentConnection.ts:470:13

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
