### PR TITLE
ci: always generate artifact prefix

### DIFF
--- a/build/azure-pipelines/alpine/product-build-alpine.yml
+++ b/build/azure-pipelines/alpine/product-build-alpine.yml
@@ -140,7 +140,7 @@ steps:
     displayName: Build server (web)
 
   - script: echo "##vso[task.setvariable variable=ARTIFACT_PREFIX]attempt$(System.JobAttempt)_"
-    condition: and(succeededOrFailed(), notIn(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues'))
+    condition: succeededOrFailed()
     displayName: Generate artifact prefix
 
   - task: 1ES.PublishPipelineArtifact@1

--- a/build/azure-pipelines/darwin/product-build-darwin.yml
+++ b/build/azure-pipelines/darwin/product-build-darwin.yml
@@ -294,21 +294,21 @@ steps:
       displayName: Rename x64 build to its legacy name
       condition: and(succeeded(), eq(variables['VSCODE_ARCH'], 'x64'))
 
+    - script: echo "##vso[task.setvariable variable=ARTIFACT_PREFIX]attempt$(System.JobAttempt)_"
+      condition: succeededOrFailed()
+      displayName: Generate artifact prefix
+
     - task: 1ES.PublishPipelineArtifact@1
       inputs:
         ${{ if eq(parameters.VSCODE_ARCH, 'arm64') }}:
           targetPath: $(Pipeline.Workspace)/vscode_client_darwin_$(VSCODE_ARCH)_archive/VSCode-darwin-arm64.zip
         ${{ else }}:
           targetPath: $(Pipeline.Workspace)/vscode_client_darwin_$(VSCODE_ARCH)_archive/VSCode-darwin.zip
-        artifactName: vscode_client_darwin_$(VSCODE_ARCH)_archive
+        artifactName: $(ARTIFACT_PREFIX)vscode_client_darwin_$(VSCODE_ARCH)_archive
         sbomBuildDropPath: $(Build.ArtifactStagingDirectory)/VSCode-darwin-$(VSCODE_ARCH)
         sbomPackageName: "VS Code macOS $(VSCODE_ARCH)"
         sbomPackageVersion: $(Build.SourceVersion)
       displayName: Publish client archive
-
-    - script: echo "##vso[task.setvariable variable=ARTIFACT_PREFIX]attempt$(System.JobAttempt)_"
-      condition: and(succeededOrFailed(), notIn(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues'))
-      displayName: Generate artifact prefix
 
     - task: 1ES.PublishPipelineArtifact@1
       inputs:

--- a/build/azure-pipelines/linux/product-build-linux.yml
+++ b/build/azure-pipelines/linux/product-build-linux.yml
@@ -364,7 +364,7 @@ steps:
       displayName: "✍️ Post-job: Codesign deb & rpm"
 
     - script: echo "##vso[task.setvariable variable=ARTIFACT_PREFIX]attempt$(System.JobAttempt)_"
-      condition: and(succeededOrFailed(), notIn(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues'))
+      condition: succeededOrFailed()
       displayName: Generate artifact prefix
 
     - task: 1ES.PublishPipelineArtifact@1
@@ -420,7 +420,7 @@ steps:
     - task: 1ES.PublishPipelineArtifact@1
       inputs:
         targetPath: $(SNAP_PATH)
-        artifactName: vscode_client_linux_$(VSCODE_ARCH)_snap
+        artifactName: $(ARTIFACT_PREFIX)vscode_client_linux_$(VSCODE_ARCH)_snap
         sbomBuildDropPath: $(SNAP_EXTRACTED_PATH)
         sbomPackageName: "VS Code Linux $(VSCODE_ARCH) SNAP"
         sbomPackageVersion: $(Build.SourceVersion)

--- a/build/azure-pipelines/web/product-build-web.yml
+++ b/build/azure-pipelines/web/product-build-web.yml
@@ -159,7 +159,7 @@ steps:
     displayName: Upload NLS Metadata
 
   - script: echo "##vso[task.setvariable variable=ARTIFACT_PREFIX]attempt$(System.JobAttempt)_"
-    condition: and(succeededOrFailed(), notIn(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues'))
+    condition: succeededOrFailed()
     displayName: Generate artifact prefix
 
   - task: 1ES.PublishPipelineArtifact@1

--- a/build/azure-pipelines/win32/product-build-win32.yml
+++ b/build/azure-pipelines/win32/product-build-win32.yml
@@ -313,7 +313,7 @@ steps:
       displayName: Move setup packages
 
     - powershell: echo "##vso[task.setvariable variable=ARTIFACT_PREFIX]attempt$(System.JobAttempt)_"
-      condition: and(succeededOrFailed(), notIn(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues'))
+      condition: succeededOrFailed()
       displayName: Generate artifact prefix
 
     - task: 1ES.PublishPipelineArtifact@1


### PR DESCRIPTION
We publish artifacts in both success or failure cases, but the prefix is only being generated for failure cases

```
2025-08-28T02:39:08.8820815Z Skipping step due to condition evaluation.
Evaluating: and(succeededOrFailed(), notIn(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues'))
Expanded: and(True, notIn('Succeeded', 'Succeeded', 'SucceededWithIssues'))
Result: False
```