### PR TITLE
fix: move product.overrides resolution to an earlier stage

### DIFF
--- a/src/bootstrap-esm.ts
+++ b/src/bootstrap-esm.ts
@@ -4,13 +4,11 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as fs from 'fs';
-import { createRequire, register } from 'node:module';
+import { register } from 'node:module';
 import { product, pkg } from './bootstrap-meta.js';
 import './bootstrap-node.js';
 import * as performance from './vs/base/common/performance.js';
 import { INLSConfiguration } from './vs/nls.js';
-
-const require = createRequire(import.meta.url);
 
 // Install a hook to module resolution to map 'fs' to 'original-fs'
 if (process.env['ELECTRON_RUN_AS_NODE'] || process.versions['electron']) {
@@ -33,12 +31,6 @@ if (process.env['ELECTRON_RUN_AS_NODE'] || process.versions['electron']) {
 
 // Prepare globals that are needed for running
 globalThis._VSCODE_PRODUCT_JSON = { ...product };
-if (process.env['VSCODE_DEV']) {
-	try {
-		const overrides: unknown = require('../product.overrides.json');
-		globalThis._VSCODE_PRODUCT_JSON = Object.assign(globalThis._VSCODE_PRODUCT_JSON, overrides);
-	} catch (error) { /* ignore */ }
-}
 globalThis._VSCODE_PACKAGE_JSON = { ...pkg };
 globalThis._VSCODE_FILE_ROOT = import.meta.dirname;
 

--- a/src/bootstrap-meta.ts
+++ b/src/bootstrap-meta.ts
@@ -20,8 +20,8 @@ if (pkgObj['BUILD_INSERT_PACKAGE_CONFIGURATION']) {
 
 let productOverridesObj = {};
 if (process.env['VSCODE_DEV']) {
-	productOverridesObj = require('../product.overrides.json');
 	try {
+		productOverridesObj = require('../product.overrides.json');
 		productObj = Object.assign(productObj, productOverridesObj);
 	} catch (error) { /* ignore */ }
 }

--- a/src/bootstrap-meta.ts
+++ b/src/bootstrap-meta.ts
@@ -18,5 +18,13 @@ if (pkgObj['BUILD_INSERT_PACKAGE_CONFIGURATION']) {
 	pkgObj = require('../package.json'); // Running out of sources
 }
 
+let productOverridesObj = {};
+if (process.env['VSCODE_DEV']) {
+	productOverridesObj = require('../product.overrides.json');
+	try {
+		productObj = Object.assign(productObj, productOverridesObj);
+	} catch (error) { /* ignore */ }
+}
+
 export const product = productObj;
 export const pkg = pkgObj;


### PR DESCRIPTION
product values used within `main.ts` before [startup](https://github.com/microsoft/vscode/blob/7a1d7c43a322fb4827197a05ea9e088d23ee542c/src/main.ts#L203), ex: `product.dataFolderName` in https://github.com/microsoft/vscode/blob/7a1d7c43a322fb4827197a05ea9e088d23ee542c/src/main.ts#L436  don't get the values from override since resolution of the file happens in `bootstrap-esm`. This came up as a bug, when we tried to read an incorrect argv file in https://github.com/microsoft/vscode/blob/7a1d7c43a322fb4827197a05ea9e088d23ee542c/src/vs/code/electron-main/app.ts#L1427