### PR TITLE
Maintain line breaks in transform to Camel and Pascal case actions

### DIFF
--- a/src/vs/editor/contrib/linesOperations/browser/linesOperations.ts
+++ b/src/vs/editor/contrib/linesOperations/browser/linesOperations.ts
@@ -1239,7 +1239,8 @@ export class SnakeCaseAction extends AbstractCaseAction {
 }
 
 export class CamelCaseAction extends AbstractCaseAction {
-	public static wordBoundary = new BackwardsCompatibleRegExp('[_-]+', 'gm');
+	public static singleLineWordBoundary = new BackwardsCompatibleRegExp('[_\\s-]+', 'gm');
+	public static multilineWordBoundary = new BackwardsCompatibleRegExp('[_-]+', 'gm');
 	public static validWordStart = new BackwardsCompatibleRegExp('^(\\p{Lu}[^\\p{Lu}])', 'gmu');
 
 	constructor() {
@@ -1251,7 +1252,7 @@ export class CamelCaseAction extends AbstractCaseAction {
 	}
 
 	protected _modifyText(text: string, wordSeparators: string): string {
-		const wordBoundary = CamelCaseAction.wordBoundary.get();
+		const wordBoundary = /\r\n|\r|\n/.test(text) ? CamelCaseAction.multilineWordBoundary.get() : CamelCaseAction.singleLineWordBoundary.get();
 		const validWordStart = CamelCaseAction.validWordStart.get();
 		if (!wordBoundary || !validWordStart) {
 			// cannot support this
@@ -1359,7 +1360,7 @@ registerEditorAction(ReverseLinesAction);
 if (SnakeCaseAction.caseBoundary.isSupported() && SnakeCaseAction.singleLetters.isSupported()) {
 	registerEditorAction(SnakeCaseAction);
 }
-if (CamelCaseAction.wordBoundary.isSupported()) {
+if (CamelCaseAction.singleLineWordBoundary.isSupported() && CamelCaseAction.multilineWordBoundary.isSupported()) {
 	registerEditorAction(CamelCaseAction);
 }
 if (PascalCaseAction.wordBoundary.isSupported()) {

--- a/src/vs/editor/contrib/linesOperations/browser/linesOperations.ts
+++ b/src/vs/editor/contrib/linesOperations/browser/linesOperations.ts
@@ -1239,7 +1239,7 @@ export class SnakeCaseAction extends AbstractCaseAction {
 }
 
 export class CamelCaseAction extends AbstractCaseAction {
-	public static wordBoundary = new BackwardsCompatibleRegExp('[_\\s-]', 'gm');
+	public static wordBoundary = new BackwardsCompatibleRegExp('[_-]+', 'gm');
 	public static validWordStart = new BackwardsCompatibleRegExp('^(\\p{Lu}[^\\p{Lu}])', 'gmu');
 
 	constructor() {

--- a/src/vs/editor/contrib/linesOperations/browser/linesOperations.ts
+++ b/src/vs/editor/contrib/linesOperations/browser/linesOperations.ts
@@ -1240,7 +1240,7 @@ export class SnakeCaseAction extends AbstractCaseAction {
 
 export class CamelCaseAction extends AbstractCaseAction {
 	public static singleLineWordBoundary = new BackwardsCompatibleRegExp('[_\\s-]+', 'gm');
-	public static multilineWordBoundary = new BackwardsCompatibleRegExp('[_-]+', 'gm');
+	public static multiLineWordBoundary = new BackwardsCompatibleRegExp('[_-]+', 'gm');
 	public static validWordStart = new BackwardsCompatibleRegExp('^(\\p{Lu}[^\\p{Lu}])', 'gmu');
 
 	constructor() {
@@ -1252,7 +1252,7 @@ export class CamelCaseAction extends AbstractCaseAction {
 	}
 
 	protected _modifyText(text: string, wordSeparators: string): string {
-		const wordBoundary = /\r\n|\r|\n/.test(text) ? CamelCaseAction.multilineWordBoundary.get() : CamelCaseAction.singleLineWordBoundary.get();
+		const wordBoundary = /\r\n|\r|\n/.test(text) ? CamelCaseAction.multiLineWordBoundary.get() : CamelCaseAction.singleLineWordBoundary.get();
 		const validWordStart = CamelCaseAction.validWordStart.get();
 		if (!wordBoundary || !validWordStart) {
 			// cannot support this
@@ -1360,7 +1360,7 @@ registerEditorAction(ReverseLinesAction);
 if (SnakeCaseAction.caseBoundary.isSupported() && SnakeCaseAction.singleLetters.isSupported()) {
 	registerEditorAction(SnakeCaseAction);
 }
-if (CamelCaseAction.singleLineWordBoundary.isSupported() && CamelCaseAction.multilineWordBoundary.isSupported()) {
+if (CamelCaseAction.singleLineWordBoundary.isSupported() && CamelCaseAction.multiLineWordBoundary.isSupported()) {
 	registerEditorAction(CamelCaseAction);
 }
 if (PascalCaseAction.wordBoundary.isSupported()) {

--- a/src/vs/editor/contrib/linesOperations/browser/linesOperations.ts
+++ b/src/vs/editor/contrib/linesOperations/browser/linesOperations.ts
@@ -1265,7 +1265,7 @@ export class CamelCaseAction extends AbstractCaseAction {
 }
 
 export class PascalCaseAction extends AbstractCaseAction {
-	public static wordBoundary = new BackwardsCompatibleRegExp('[_\\s-]', 'gm');
+	public static wordBoundary = new BackwardsCompatibleRegExp('[_ \t-]', 'gm');
 	public static wordBoundaryToMaintain = new BackwardsCompatibleRegExp('(?<=\\.)', 'gm');
 
 	constructor() {

--- a/src/vs/editor/contrib/linesOperations/browser/linesOperations.ts
+++ b/src/vs/editor/contrib/linesOperations/browser/linesOperations.ts
@@ -1266,7 +1266,7 @@ export class CamelCaseAction extends AbstractCaseAction {
 }
 
 export class PascalCaseAction extends AbstractCaseAction {
-	public static wordBoundary = new BackwardsCompatibleRegExp('[_ \t-]', 'gm');
+	public static wordBoundary = new BackwardsCompatibleRegExp('[_ \\t-]', 'gm');
 	public static wordBoundaryToMaintain = new BackwardsCompatibleRegExp('(?<=\\.)', 'gm');
 
 	constructor() {

--- a/src/vs/editor/contrib/linesOperations/test/browser/linesOperations.test.ts
+++ b/src/vs/editor/contrib/linesOperations/test/browser/linesOperations.test.ts
@@ -1045,14 +1045,18 @@ suite('Editor Contrib - Line Operations', () => {
 				'ReTain_some_CAPitalization',
 				'my_var.test_function()',
 				'öçş_öç_şğü_ğü',
-				'XMLHttpRequest'
+				'XMLHttpRequest',
+				'\tfunction hello_world() {',
+				'\t\treturn some_global_object;',
+				'\t}',
+				'ignore\ttab and space',
 			], {}, (editor) => {
 				const model = editor.getModel()!;
 				const camelcaseAction = new CamelCaseAction();
 
 				editor.setSelection(new Selection(1, 1, 1, 18));
 				executeAction(camelcaseAction, editor);
-				assert.strictEqual(model.getLineContent(1), 'camelFromWords');
+				assert.strictEqual(model.getLineContent(1), 'camel from words');
 
 				editor.setSelection(new Selection(2, 1, 2, 15));
 				executeAction(camelcaseAction, editor);
@@ -1081,6 +1085,14 @@ suite('Editor Contrib - Line Operations', () => {
 				editor.setSelection(new Selection(8, 1, 8, 14));
 				executeAction(camelcaseAction, editor);
 				assert.strictEqual(model.getLineContent(8), 'XMLHttpRequest');
+
+				editor.setSelection(new Selection(9, 1, 11, 2));
+				executeAction(camelcaseAction, editor);
+				assert.strictEqual(model.getValueInRange(new Selection(9, 1, 11, 3)), '\tfunction helloWorld() {\n\t\treturn someGlobalObject;\n\t}');
+
+				editor.setSelection(new Selection(12, 1, 12, 21));
+				executeAction(camelcaseAction, editor);
+				assert.strictEqual(model.getLineContent(12), 'ignore\ttab and space');
 			}
 		);
 

--- a/src/vs/editor/contrib/linesOperations/test/browser/linesOperations.test.ts
+++ b/src/vs/editor/contrib/linesOperations/test/browser/linesOperations.test.ts
@@ -1266,6 +1266,11 @@ suite('Editor Contrib - Line Operations', () => {
 				executeAction(pascalCaseAction, editor);
 				assert.strictEqual(model.getLineContent(10), 'KebabCase');
 				assertSelection(editor, new Selection(10, 1, 10, 10));
+
+				editor.setSelection(new Selection(9, 1, 10, 11));
+				executeAction(pascalCaseAction, editor);
+				assert.strictEqual(model.getValueInRange(new Selection(9, 1, 10, 11)), 'ParseHTML4String\nKebabCase');
+				assertSelection(editor, new Selection(9, 1, 10, 10));
 			}
 		);
 	});

--- a/src/vs/editor/contrib/linesOperations/test/browser/linesOperations.test.ts
+++ b/src/vs/editor/contrib/linesOperations/test/browser/linesOperations.test.ts
@@ -1056,7 +1056,7 @@ suite('Editor Contrib - Line Operations', () => {
 
 				editor.setSelection(new Selection(1, 1, 1, 18));
 				executeAction(camelcaseAction, editor);
-				assert.strictEqual(model.getLineContent(1), 'camel from words');
+				assert.strictEqual(model.getLineContent(1), 'camelFromWords');
 
 				editor.setSelection(new Selection(2, 1, 2, 15));
 				executeAction(camelcaseAction, editor);
@@ -1089,10 +1089,6 @@ suite('Editor Contrib - Line Operations', () => {
 				editor.setSelection(new Selection(9, 1, 11, 2));
 				executeAction(camelcaseAction, editor);
 				assert.strictEqual(model.getValueInRange(new Selection(9, 1, 11, 3)), '\tfunction helloWorld() {\n\t\treturn someGlobalObject;\n\t}');
-
-				editor.setSelection(new Selection(12, 1, 12, 21));
-				executeAction(camelcaseAction, editor);
-				assert.strictEqual(model.getLineContent(12), 'ignore\ttab and space');
 			}
 		);
 

--- a/src/vs/editor/contrib/linesOperations/test/browser/linesOperations.test.ts
+++ b/src/vs/editor/contrib/linesOperations/test/browser/linesOperations.test.ts
@@ -1049,7 +1049,6 @@ suite('Editor Contrib - Line Operations', () => {
 				'\tfunction hello_world() {',
 				'\t\treturn some_global_object;',
 				'\t}',
-				'ignore\ttab and space',
 			], {}, (editor) => {
 				const model = editor.getModel()!;
 				const camelcaseAction = new CamelCaseAction();


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/261387.

# Transform to Camel Case

## Single line transformations

I split this in two cases. When a single line (without line breaks) is selected, the behavior remains unchanged. I did this because I noticed unit tests that assert that white space characters should be considered as valid word boundaries.

Example
```
"camel from words" -> "camelFromWords"
``` 

## Multiline transformations

On the other hand, in case of a selection spanning multiple lines I changed the relevant regex to only consider `_` and `-` as valid word boundaries. Effectively guaranteeing correct transformations only when coming from kebab or snake case. 

I did this because considering tabs as word boundaries will break the indentation for a code block. And as @RedCMD suggested, I also think it makes sense to treat `a-b c-d` as separate words (-> `aB cD`).

# Transform to Pascal Case

Here I was much more conservative because this transformation has some extra logic to capitalize the first letter of a word
```ts
return words.map((word: string) => word.substring(0, 1).toLocaleUpperCase() + word.substring(1))
			.join('')
```
Therefore not using spaces and tabs as word boundaries would execute the above logic on spaces and tabs. It was easier to just address the line break problem here and not get lost in edge cases.

# Testing
I added some unit tests, and this should be straightforward to test manually 🙌🏻 


https://github.com/user-attachments/assets/1c4f2b3b-e5a7-4916-bc37-4541e8683b6b
