### PR TITLE
disallow keyboard focus from moving to disabled toolbar actions

### DIFF
--- a/src/vs/base/browser/ui/toolbar/toolbar.ts
+++ b/src/vs/base/browser/ui/toolbar/toolbar.ts
@@ -83,6 +83,7 @@ export class ToolBar extends Disposable {
 			allowContextMenu: options.allowContextMenu,
 			highlightToggledItems: options.highlightToggledItems,
 			hoverDelegate: options.hoverDelegate,
+			focusOnlyEnabledItems: true,
 			actionViewItemProvider: (action, viewItemOptions) => {
 				if (action.id === ToggleMenuAction.ID) {
 					this.toggleMenuActionViewItem = new DropdownMenuActionViewItem(


### PR DESCRIPTION
fix #263684

Argument for: it would align more with the visual experience, where one cannot hover and get a tooltip for a disabled action.

Argument against: screen reader users are already aware that it's not actionable via the screen reader reporting "dimmed".

The guidelines are grey about this:

<img width="1052" height="842" alt="Screenshot 2025-08-28 at 1 51 49 PM" src="https://github.com/user-attachments/assets/a0dfa7d8-e50c-4694-9986-7f7633562d7a" />

https://github.com/user-attachments/assets/2d523a21-071e-4bb7-b919-3d99ffc974ab

