### PR TITLE
fix polling bug

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/monitoring/outputMonitor.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/monitoring/outputMonitor.ts
@@ -265,15 +265,16 @@ export class OutputMonitor extends Disposable implements IOutputMonitor {
 			const noNewData = noNewDataCount >= PollingConsts.MinNoDataEvents;
 			const isActive = execution.isActive ? await execution.isActive() : undefined;
 
-			// Became inactive or no new data for a while → idle
-			if (noNewData || isActive === false) {
-				return OutputMonitorState.Idle;
-			}
-
 			// Still active but with a no-new-data, so reset counters and keep going
 			if (noNewData && isActive === true) {
 				noNewDataCount = 0;
 				lastBufferLength = len;
+				continue;
+			}
+
+			// Became inactive, or (no new data and not explicitly active) → idle
+			if (isActive === false || (noNewData && isActive !== true)) {
+				return OutputMonitorState.Idle;
 			}
 		}
 

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/outputMonitor.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/outputMonitor.test.ts
@@ -29,7 +29,7 @@ suite('OutputMonitor', () => {
 		dataEmitter = new Emitter<string>();
 		execution = {
 			getOutput: () => 'test output',
-			isActive: async () => true,
+			isActive: async () => false,
 			instance: {
 				instanceId: 1,
 				sendText: async () => { sendTextCalled = true; },


### PR DESCRIPTION
- After a refactor, the code for checking if a task was still active was unreachable. Also updates the test execution `isActive` appropriately
- wraps monitoring in try and finally so we always fire command finished even if there's an error