### PR TITLE
fix: confirm response based on promise

### DIFF
--- a/src/vs/workbench/contrib/chat/common/chatProgressTypes/chatToolInvocation.ts
+++ b/src/vs/workbench/contrib/chat/common/chatProgressTypes/chatToolInvocation.ts
@@ -29,7 +29,6 @@ export class ChatToolInvocation implements IChatToolInvocation {
 		return this._confirmDeferred;
 	}
 
-	private _isConfirmed: ConfirmedReason | undefined;
 	public get isConfirmed(): ConfirmedReason | undefined {
 		return this._confirmDeferred.value;
 	}
@@ -65,12 +64,10 @@ export class ChatToolInvocation implements IChatToolInvocation {
 
 		if (!this._confirmationMessages) {
 			// No confirmation needed
-			this._isConfirmed = { type: ToolConfirmKind.ConfirmationNotNeeded };
-			this._confirmDeferred.complete(this._isConfirmed);
+			this._confirmDeferred.complete({ type: ToolConfirmKind.ConfirmationNotNeeded });
 		}
 
 		this._confirmDeferred.p.then(confirmed => {
-			this._isConfirmed = confirmed;
 			this._confirmationMessages = undefined;
 		});
 
@@ -107,7 +104,7 @@ export class ChatToolInvocation implements IChatToolInvocation {
 			invocationMessage: this.invocationMessage,
 			pastTenseMessage: this.pastTenseMessage,
 			originMessage: this.originMessage,
-			isConfirmed: this._isConfirmed,
+			isConfirmed: this._confirmDeferred.value,
 			isComplete: true,
 			source: this.source,
 			resultDetails: isToolResultOutputDetails(this._resultDetails)

--- a/src/vs/workbench/contrib/chat/common/chatProgressTypes/chatToolInvocation.ts
+++ b/src/vs/workbench/contrib/chat/common/chatProgressTypes/chatToolInvocation.ts
@@ -31,7 +31,7 @@ export class ChatToolInvocation implements IChatToolInvocation {
 
 	private _isConfirmed: ConfirmedReason | undefined;
 	public get isConfirmed(): ConfirmedReason | undefined {
-		return this._isConfirmed;
+		return this._confirmDeferred.value;
 	}
 
 	private _resultDetails: IToolResult['toolResultDetails'] | undefined;


### PR DESCRIPTION
When using the new `workbench.action.chat.open.blockOnResponse` feature, if the VSC instance was in auto-approve mode, it was observed that the command was resolving before the tool finished invocation.

This resulted in a race betwee sync and async code.