### PR TITLE
Avoid extra HTML re-parse when rendering markdown

### DIFF
--- a/src/vs/base/browser/domSanitize.ts
+++ b/src/vs/base/browser/domSanitize.ts
@@ -5,6 +5,7 @@
 
 import { DisposableStore, IDisposable, toDisposable } from '../common/lifecycle.js';
 import { Schemas } from '../common/network.js';
+import { reset } from './dom.js';
 import dompurify from './dompurify/dompurify.js';
 
 
@@ -207,9 +208,6 @@ export interface DomSanitizerConfig {
 const defaultDomPurifyConfig = Object.freeze({
 	ALLOWED_TAGS: [...basicMarkupHtmlTags],
 	ALLOWED_ATTR: [...defaultAllowedAttrs],
-	RETURN_DOM: false,
-	RETURN_DOM_FRAGMENT: false,
-	RETURN_TRUSTED_TYPE: true,
 	// We sanitize the src/href attributes later if needed
 	ALLOW_UNKNOWN_PROTOCOLS: true,
 } satisfies dompurify.Config);
@@ -223,6 +221,12 @@ const defaultDomPurifyConfig = Object.freeze({
  * @returns A sanitized string of html.
  */
 export function sanitizeHtml(untrusted: string, config?: DomSanitizerConfig): TrustedHTML {
+	return doSanitizeHtml(untrusted, config, 'trusted');
+}
+
+function doSanitizeHtml(untrusted: string, config: DomSanitizerConfig | undefined, outputType: 'dom'): DocumentFragment;
+function doSanitizeHtml(untrusted: string, config: DomSanitizerConfig | undefined, outputType: 'trusted'): TrustedHTML;
+function doSanitizeHtml(untrusted: string, config: DomSanitizerConfig | undefined, outputType: 'dom' | 'trusted'): TrustedHTML | DocumentFragment {
 	const store = new DisposableStore();
 	try {
 		const resolvedConfig: dompurify.Config = { ...defaultDomPurifyConfig };
@@ -286,10 +290,17 @@ export function sanitizeHtml(untrusted: string, config?: DomSanitizerConfig): Tr
 			}));
 		}
 
-		return dompurify.sanitize(untrusted, {
-			...resolvedConfig,
-			RETURN_TRUSTED_TYPE: true
-		});
+		if (outputType === 'dom') {
+			return dompurify.sanitize(untrusted, {
+				...resolvedConfig,
+				RETURN_DOM_FRAGMENT: true
+			});
+		} else {
+			return dompurify.sanitize(untrusted, {
+				...resolvedConfig,
+				RETURN_TRUSTED_TYPE: true
+			});
+		}
 	} finally {
 		store.dispose();
 	}
@@ -349,5 +360,6 @@ export function convertTagToPlaintext(element: Element): DocumentFragment {
  * Sanitizes the given `value` and reset the given `node` with it.
  */
 export function safeSetInnerHtml(node: HTMLElement, untrusted: string, config?: DomSanitizerConfig): void {
-	node.innerHTML = sanitizeHtml(untrusted, config) as any;
+	const fragment = doSanitizeHtml(untrusted, config, 'dom');
+	reset(node, fragment);
 }

--- a/src/vs/workbench/contrib/chat/browser/chatMarkdownRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatMarkdownRenderer.ts
@@ -100,6 +100,7 @@ export class ChatMarkdownRenderer extends MarkdownRenderer {
 		// In some cases, the renderer can return text that is not inside a <p>,
 		// but our CSS expects text to be in a <p> for margin to be applied properly.
 		// So just normalize it.
+		result.element.normalize();
 		const lastChild = result.element.lastChild;
 		if (lastChild?.nodeType === Node.TEXT_NODE && lastChild.textContent?.trim()) {
 			lastChild.replaceWith($('p', undefined, lastChild.textContent));


### PR DESCRIPTION
For #263896

Uses the dom fragment from dompurify instead of converting to a string and then re-parsing back to dom. This avoids this small cost every time markdown is rendered:

<img width="766" height="323" alt="Screenshot 2025-08-29 at 9 40 46 AM" src="https://github.com/user-attachments/assets/e251961a-4d28-4575-af3c-730c6d0db5ff" />

