### PR TITLE
Revert "fix: confirm response based on promise (#263894)"

### DIFF
--- a/src/vs/workbench/contrib/chat/common/chatProgressTypes/chatToolInvocation.ts
+++ b/src/vs/workbench/contrib/chat/common/chatProgressTypes/chatToolInvocation.ts
@@ -29,8 +29,9 @@ export class ChatToolInvocation implements IChatToolInvocation {
 		return this._confirmDeferred;
 	}
 
+	private _isConfirmed: ConfirmedReason | undefined;
 	public get isConfirmed(): ConfirmedReason | undefined {
-		return this._confirmDeferred.value;
+		return this._isConfirmed;
 	}
 
 	private _resultDetails: IToolResult['toolResultDetails'] | undefined;
@@ -64,10 +65,12 @@ export class ChatToolInvocation implements IChatToolInvocation {
 
 		if (!this._confirmationMessages) {
 			// No confirmation needed
-			this._confirmDeferred.complete({ type: ToolConfirmKind.ConfirmationNotNeeded });
+			this._isConfirmed = { type: ToolConfirmKind.ConfirmationNotNeeded };
+			this._confirmDeferred.complete(this._isConfirmed);
 		}
 
 		this._confirmDeferred.p.then(confirmed => {
+			this._isConfirmed = confirmed;
 			this._confirmationMessages = undefined;
 		});
 
@@ -104,7 +107,7 @@ export class ChatToolInvocation implements IChatToolInvocation {
 			invocationMessage: this.invocationMessage,
 			pastTenseMessage: this.pastTenseMessage,
 			originMessage: this.originMessage,
-			isConfirmed: this._confirmDeferred.value,
+			isConfirmed: this._isConfirmed,
 			isComplete: true,
 			source: this.source,
 			resultDetails: isToolResultOutputDetails(this._resultDetails)


### PR DESCRIPTION
This reverts commit 6f24cee6f6653292a1b61ea07feabd6b76fa399d.

It broke tool calling UI status: #264023.

I attempted to fix it (#264073) but still have some edge cases not working and will need more time to get to the bottom of it.