### PR TITLE
fix toolConfirmation icon and completion status

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatToolInvocationSubPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatToolInvocationSubPart.ts
@@ -38,7 +38,7 @@ export abstract class BaseChatToolInvocationSubPart extends Disposable {
 		const toolInvocation = this.toolInvocation;
 		const isConfirmed = typeof toolInvocation.isConfirmed === 'boolean'
 			? toolInvocation.isConfirmed
-			: toolInvocation.isConfirmed?.type === ToolConfirmKind.UserAction || toolInvocation.isConfirmed?.type === ToolConfirmKind.ConfirmationNotNeeded;
+			: toolInvocation.isConfirmed?.type === ToolConfirmKind.Setting || toolInvocation.isConfirmed?.type === ToolConfirmKind.UserAction || toolInvocation.isConfirmed?.type === ToolConfirmKind.ConfirmationNotNeeded;
 		const isSkipped = typeof toolInvocation.isConfirmed !== 'boolean' && toolInvocation.isConfirmed?.type === ToolConfirmKind.Skipped;
 		return isSkipped ?
 			Codicon.circleSlash :

--- a/src/vs/workbench/contrib/chat/browser/languageModelToolsService.ts
+++ b/src/vs/workbench/contrib/chat/browser/languageModelToolsService.ts
@@ -279,11 +279,15 @@ export class LanguageModelToolsService extends Disposable implements ILanguageMo
 					source.dispose(true);
 				}));
 				store.add(token.onCancellationRequested(() => {
-					toolInvocation?.confirmed.complete({ type: ToolConfirmKind.Denied });
+					if (!toolInvocation?.confirmed.isResolved) {
+						toolInvocation?.confirmed.complete({ type: ToolConfirmKind.Denied });
+					}
 					source.cancel();
 				}));
 				store.add(source.token.onCancellationRequested(() => {
-					toolInvocation?.confirmed.complete({ type: ToolConfirmKind.Denied });
+					if (!toolInvocation?.confirmed.isResolved) {
+						toolInvocation?.confirmed.complete({ type: ToolConfirmKind.Denied });
+					}
 				}));
 				token = source.token;
 


### PR DESCRIPTION
* `getIcon` did not account for `ToolConfirmKind.Setting` (e.g. auto-approve)
* `completion` promise was being changed to `Canceled` despite it already being resolved.

See my [verbose(!) debugging comment](https://github.com/microsoft/vscode/issues/264023#issuecomment-3237889813)
which walks you through states of `ConfirmationKind`
in `getIcon` under different commits.

Fixes #264023.
Relates #263314 (`getIcon` added by @connor4312).
Relates #262982 (`ConfirmationKind.UserSetting` added by @Tyriar).
Supercedes #264047 (revert of a commit that changed confirmation logic from sync -> async by @rwoll).

Reviewers: I'm not 100% on what the expected UI iconography experience is, so
please verify that the icons align with what y'all have in mind.

Suggested follow ups:

- Tests - especially one around `getIcon` to ensure it handles `ConfirmationKind`
      exhaustively as folks add new kinds.
