### PR TITLE
Send a real ChatRequest to provideNewChatSessionItem

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadChatSessions.ts
+++ b/src/vs/workbench/api/browser/mainThreadChatSessions.ts
@@ -9,7 +9,7 @@ import { Emitter } from '../../../base/common/event.js';
 import { IMarkdownString, MarkdownString } from '../../../base/common/htmlContent.js';
 import { Disposable, DisposableMap, DisposableStore, IDisposable } from '../../../base/common/lifecycle.js';
 import { revive } from '../../../base/common/marshalling.js';
-import { IObservable, observableValue, autorun } from '../../../base/common/observable.js';
+import { autorun, IObservable, observableValue } from '../../../base/common/observable.js';
 import { localize } from '../../../nls.js';
 import { IDialogService } from '../../../platform/dialogs/common/dialogs.js';
 import { ILogService } from '../../../platform/log/common/log.js';
@@ -365,7 +365,7 @@ export class MainThreadChatSessions extends Disposable implements MainThreadChat
 		return [];
 	}
 
-	private async _provideNewChatSessionItem(handle: number, options: { prompt?: string; history?: any[]; metadata?: any }, token: CancellationToken): Promise<IChatSessionItem> {
+	private async _provideNewChatSessionItem(handle: number, options: { request: IChatAgentRequest; prompt?: string; history?: any[]; metadata?: any }, token: CancellationToken): Promise<IChatSessionItem> {
 		try {
 			const chatSessionItem = await this._proxy.$provideNewChatSessionItem(handle, options, token);
 			if (!chatSessionItem) {

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -58,7 +58,7 @@ import { IChatAgentMetadata, IChatAgentRequest, IChatAgentResult, UserSelectedTo
 import { ICodeMapperRequest, ICodeMapperResult } from '../../contrib/chat/common/chatCodeMapperService.js';
 import { IChatRelatedFile, IChatRelatedFileProviderMetadata as IChatRelatedFilesProviderMetadata, IChatRequestDraft } from '../../contrib/chat/common/chatEditingService.js';
 import { IChatProgressHistoryResponseContent } from '../../contrib/chat/common/chatModel.js';
-import { IChatContentInlineReference, IChatFollowup, IChatNotebookEdit, IChatProgress, IChatTask, IChatTaskDto, IChatUserActionEvent, IChatVoteAction, ChatResponseClearToPreviousToolInvocationReason } from '../../contrib/chat/common/chatService.js';
+import { ChatResponseClearToPreviousToolInvocationReason, IChatContentInlineReference, IChatFollowup, IChatNotebookEdit, IChatProgress, IChatTask, IChatTaskDto, IChatUserActionEvent, IChatVoteAction } from '../../contrib/chat/common/chatService.js';
 import { IChatSessionItem } from '../../contrib/chat/common/chatSessionsService.js';
 import { IChatRequestVariableValue } from '../../contrib/chat/common/chatVariables.js';
 import { ChatAgentLocation } from '../../contrib/chat/common/constants.js';
@@ -3167,7 +3167,7 @@ export interface MainThreadChatSessionsShape extends IDisposable {
 
 export interface ExtHostChatSessionsShape {
 	$provideChatSessionItems(providerHandle: number, token: CancellationToken): Promise<Dto<IChatSessionItem>[]>;
-	$provideNewChatSessionItem(providerHandle: number, options: { prompt?: string; history?: any[]; metadata?: any }, token: CancellationToken): Promise<Dto<IChatSessionItem>>;
+	$provideNewChatSessionItem(providerHandle: number, options: { request: IChatAgentRequest; prompt?: string; history?: any[]; metadata?: any }, token: CancellationToken): Promise<Dto<IChatSessionItem>>;
 
 	$provideChatSessionContent(providerHandle: number, sessionId: string, token: CancellationToken): Promise<ChatSessionDto>;
 	$interruptChatSessionActiveResponse(providerHandle: number, sessionId: string, requestId: string): Promise<void>;

--- a/src/vs/workbench/api/common/extHostChatSessions.ts
+++ b/src/vs/workbench/api/common/extHostChatSessions.ts
@@ -11,16 +11,17 @@ import { MarshalledId } from '../../../base/common/marshallingIds.js';
 import { IExtensionDescription } from '../../../platform/extensions/common/extensions.js';
 import { ILogService } from '../../../platform/log/common/log.js';
 import { IChatAgentRequest, IChatAgentResult } from '../../contrib/chat/common/chatAgents.js';
-import { IChatSessionItem, ChatSessionStatus } from '../../contrib/chat/common/chatSessionsService.js';
+import { ChatSessionStatus, IChatSessionItem } from '../../contrib/chat/common/chatSessionsService.js';
 import { ChatAgentLocation } from '../../contrib/chat/common/constants.js';
 import { Proxied } from '../../services/extensions/common/proxyIdentifier.js';
 import { ChatSessionDto, ExtHostChatSessionsShape, IChatAgentProgressShape, MainContext, MainThreadChatSessionsShape } from './extHost.protocol.js';
 import { ChatAgentResponseStream } from './extHostChatAgents2.js';
 import { CommandsConverter, ExtHostCommands } from './extHostCommands.js';
+import { ExtHostLanguageModels } from './extHostLanguageModels.js';
 import { IExtHostRpcService } from './extHostRpcService.js';
 import * as typeConvert from './extHostTypeConverters.js';
 import * as extHostTypes from './extHostTypes.js';
-import { ExtHostLanguageModels } from './extHostLanguageModels.js';
+import { revive } from '../../../base/common/marshalling.js';
 
 class ExtHostChatSession {
 	private _stream: ChatAgentResponseStream;
@@ -163,14 +164,31 @@ export class ExtHostChatSessions extends Disposable implements ExtHostChatSessio
 		};
 	}
 
-	async $provideNewChatSessionItem(handle: number, options: { prompt?: string; history: any[]; metadata?: any }, token: CancellationToken): Promise<IChatSessionItem> {
+	async $provideNewChatSessionItem(handle: number, options: { request: IChatAgentRequest; prompt?: string; history: any[]; metadata?: any }, token: CancellationToken): Promise<IChatSessionItem> {
 		const entry = this._chatSessionItemProviders.get(handle);
 		if (!entry || !entry.provider.provideNewChatSessionItem) {
 			throw new Error(`No provider registered for handle ${handle} or provider does not support creating sessions`);
 		}
 
 		try {
-			const chatSessionItem = await entry.provider.provideNewChatSessionItem(options, token);
+			const model = await this.getModelForRequest(options.request, entry.extension);
+			const vscodeRequest = typeConvert.ChatAgentRequest.to(
+				revive(options.request),
+				undefined,
+				model,
+				[],
+				new Map(),
+				entry.extension,
+				this._logService);
+
+			const vscodeOptions = {
+				request: vscodeRequest,
+				prompt: options.prompt,
+				history: options.history,
+				metadata: options.metadata
+			};
+
+			const chatSessionItem = await entry.provider.provideNewChatSessionItem(vscodeOptions, token);
 			if (!chatSessionItem || !chatSessionItem.id) {
 				throw new Error('Provider did not create session');
 			}

--- a/src/vs/workbench/api/test/browser/mainThreadChatSessions.test.ts
+++ b/src/vs/workbench/api/test/browser/mainThreadChatSessions.test.ts
@@ -8,24 +8,26 @@ import * as sinon from 'sinon';
 import { CancellationToken } from '../../../../base/common/cancellation.js';
 import { DisposableStore } from '../../../../base/common/lifecycle.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
+import { TestConfigurationService } from '../../../../platform/configuration/test/common/testConfigurationService.js';
+import { ContextKeyService } from '../../../../platform/contextkey/browser/contextKeyService.js';
+import { IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
 import { IDialogService } from '../../../../platform/dialogs/common/dialogs.js';
 import { TestInstantiationService } from '../../../../platform/instantiation/test/common/instantiationServiceMock.js';
 import { ILogService, NullLogService } from '../../../../platform/log/common/log.js';
-import { MainThreadChatSessions, ObservableChatSession } from '../../browser/mainThreadChatSessions.js';
-import { ExtHostChatSessionsShape, IChatProgressDto } from '../../common/extHost.protocol.js';
-import { IExtHostContext } from '../../../services/extensions/common/extHostCustomers.js';
-import { ExtensionHostKind } from '../../../services/extensions/common/extensionHostKind.js';
+import { ChatSessionsService } from '../../../contrib/chat/browser/chatSessions.contribution.js';
+import { IChatAgentRequest } from '../../../contrib/chat/common/chatAgents.js';
 import { IChatProgress } from '../../../contrib/chat/common/chatService.js';
 import { IChatSessionItem, IChatSessionsService } from '../../../contrib/chat/common/chatSessionsService.js';
+import { ChatAgentLocation } from '../../../contrib/chat/common/constants.js';
 import { IEditorService } from '../../../services/editor/common/editorService.js';
+import { IExtHostContext } from '../../../services/extensions/common/extHostCustomers.js';
+import { ExtensionHostKind } from '../../../services/extensions/common/extensionHostKind.js';
+import { IExtensionService } from '../../../services/extensions/common/extensions.js';
 import { IViewsService } from '../../../services/views/common/viewsService.js';
 import { mock, TestExtensionService } from '../../../test/common/workbenchTestServices.js';
-import { ChatSessionsService } from '../../../contrib/chat/browser/chatSessions.contribution.js';
-import { IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
-import { ContextKeyService } from '../../../../platform/contextkey/browser/contextKeyService.js';
-import { TestConfigurationService } from '../../../../platform/configuration/test/common/testConfigurationService.js';
-import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
-import { IExtensionService } from '../../../services/extensions/common/extensions.js';
+import { MainThreadChatSessions, ObservableChatSession } from '../../browser/mainThreadChatSessions.js';
+import { ExtHostChatSessionsShape, IChatProgressDto } from '../../common/extHost.protocol.js';
 
 suite('ObservableChatSession', function () {
 	let disposables: DisposableStore;
@@ -372,8 +374,19 @@ suite('MainThreadChatSessions', function () {
 	test('provideNewChatSessionItem creates a new chat session', async function () {
 		mainThread.$registerChatSessionItemProvider(1, 'test-type');
 
+		// Create a mock IChatAgentRequest
+		const mockRequest: IChatAgentRequest = {
+			sessionId: 'test-session',
+			requestId: 'test-request',
+			agentId: 'test-agent',
+			message: 'my prompt',
+			location: ChatAgentLocation.Panel,
+			variables: { variables: [] }
+		};
+
 		// Valid
 		const chatSessionItem = await chatSessionsService.provideNewChatSessionItem('test-type', {
+			request: mockRequest,
 			prompt: 'my prompt',
 			metadata: {}
 		}, CancellationToken.None);
@@ -383,6 +396,7 @@ suite('MainThreadChatSessions', function () {
 		// Invalid session type should throw
 		await assert.rejects(
 			chatSessionsService.provideNewChatSessionItem('invalid-type', {
+				request: mockRequest,
 				prompt: 'my prompt',
 				metadata: {}
 			}, CancellationToken.None)

--- a/src/vs/workbench/contrib/chat/browser/actions/chatExecuteActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatExecuteActions.ts
@@ -576,6 +576,14 @@ export class CreateRemoteAgentJobAction extends Action2 {
 			type,
 			{
 				prompt: userPrompt,
+				request: {
+					agentId: '',
+					location: ChatAgentLocation.Panel,
+					message: userPrompt,
+					requestId: '',
+					sessionId: '',
+					variables: { variables: [] },
+				},
 				metadata: {
 					summary,
 					source: 'chatExecuteActions',

--- a/src/vs/workbench/contrib/chat/browser/chatSessions.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSessions.contribution.ts
@@ -495,11 +495,12 @@ export class ChatSessionsService extends Disposable implements IChatSessionsServ
 	/**
 	 * Creates a new chat session by delegating to the appropriate provider
 	 * @param chatSessionType The type of chat session provider to use
-	 * @param options Options for the new session
+	 * @param options Options for the new session including the request
 	 * @param token A cancellation token
 	 * @returns A session ID for the newly created session
 	 */
 	public async provideNewChatSessionItem(chatSessionType: string, options: {
+		request: IChatAgentRequest;
 		prompt?: string;
 		history?: any[];
 		metadata?: any;
@@ -630,6 +631,7 @@ class CodingAgentChatImplementation extends Disposable implements IChatAgentImpl
 				const chatSessionItem = await this.chatSessionService.provideNewChatSessionItem(
 					this.chatSession.type,
 					{
+						request,
 						prompt: request.message,
 						history,
 					},

--- a/src/vs/workbench/contrib/chat/browser/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatWidget.ts
@@ -1783,26 +1783,6 @@ export class ChatWidget extends Disposable implements IChatWidget {
 			return;
 		}
 
-		// Handle coding agent prefix enforcement
-		if (this._lockedToCodingAgent && this._codingAgentPrefix) {
-			if (query) {
-				// For programmatic input, ensure the prefix is added
-				if (!query.query.startsWith(this._codingAgentPrefix)) {
-					query.query = this._codingAgentPrefix + this.removeExistingAgentPrefix(query.query);
-				}
-			} else {
-				// For user input, update the editor value if needed
-				const currentValue = this.getInput();
-				if (!currentValue.length) {
-					return;
-				}
-				if (!currentValue.startsWith(this._codingAgentPrefix)) {
-					const newValue = this._codingAgentPrefix + this.removeExistingAgentPrefix(currentValue);
-					this.input.inputEditor.setValue(newValue);
-				}
-			}
-		}
-
 		if (!query && this.input.generating) {
 			// if the user submits the input and generation finishes quickly, just submit it for them
 			const generatingAutoSubmitWindow = 500;
@@ -1892,6 +1872,7 @@ export class ChatWidget extends Disposable implements IChatWidget {
 				noCommandDetection: options?.noCommandDetection,
 				...this.getModeRequestOptions(),
 				modeInfo: this.input.currentModeInfo,
+				agentId: this._lockedAgentId
 			});
 
 			if (result) {
@@ -2196,11 +2177,6 @@ export class ChatWidget extends Disposable implements IChatWidget {
 			return undefined;
 		}
 		return readFileTool;
-	}
-
-	private removeExistingAgentPrefix(text: string): string {
-		// Remove any existing agent prefix (e.g., @agent) from the beginning
-		return text.replace(/^@\w+\s*/, '');
 	}
 
 	delegateScrollFromMouseWheelEvent(browserEvent: IMouseWheelEvent): void {

--- a/src/vs/workbench/contrib/chat/common/chatSessionsService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatSessionsService.ts
@@ -75,6 +75,7 @@ export interface IChatSessionItemProvider {
 	readonly onDidChangeChatSessionItems: Event<void>;
 	provideChatSessionItems(token: CancellationToken): Promise<IChatSessionItem[]>;
 	provideNewChatSessionItem?(options: {
+		request: IChatAgentRequest;
 		prompt?: string;
 		history?: any[];
 		metadata?: any;
@@ -98,6 +99,7 @@ export interface IChatSessionsService {
 	canResolveItemProvider(chatSessionType: string): Promise<boolean>;
 	getAllChatSessionItemProviders(): IChatSessionItemProvider[];
 	provideNewChatSessionItem(chatSessionType: string, options: {
+		request: IChatAgentRequest;
 		prompt?: string;
 		history?: any[];
 		metadata?: any;

--- a/src/vscode-dts/vscode.proposed.chatSessionsProvider.d.ts
+++ b/src/vscode-dts/vscode.proposed.chatSessionsProvider.d.ts
@@ -42,6 +42,11 @@ declare module 'vscode' {
 		 */
 		provideNewChatSessionItem?(options: {
 			/**
+			 * The chat request that initiated the session creation
+			 */
+			readonly request: ChatRequest;
+
+			/**
 			 * Initial prompt to initiate the session
 			 */
 			readonly prompt?: string;


### PR DESCRIPTION
Fix #264076
This is a bit wrong. Because a ChatRequest has a toolInvocationToken tied to a particular chat session, but the real vscode chat session doesn't exist yet!

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
