### PR TITLE
Have the lifecycle dependent on the Page since we only support 1 window for now

### DIFF
--- a/test/automation/src/playwrightDriver.ts
+++ b/test/automation/src/playwrightDriver.ts
@@ -47,6 +47,10 @@ export class PlaywrightDriver {
 		return this.context;
 	}
 
+	get currentPage(): playwright.Page {
+		return this.page;
+	}
+
 	async startTracing(name: string): Promise<void> {
 		if (!this.options.tracing) {
 			return; // tracing disabled

--- a/test/mcp/src/application.ts
+++ b/test/mcp/src/application.ts
@@ -323,7 +323,7 @@ export async function getApplication() {
 		extraArgs: (opts.electronArgs || '').split(' ').map(arg => arg.trim()).filter(arg => !!arg),
 	});
 	await application.start();
-	application.code.driver.browserContext.on('close', async () => {
+	application.code.driver.currentPage.on('close', async () => {
 		fs.rmSync(testDataPath, { recursive: true, force: true, maxRetries: 10 });
 	});
 	return application;
@@ -355,7 +355,7 @@ export class ApplicationService {
 		}
 		if (!this._application) {
 			this._application = await getApplication();
-			this._application.code.driver.browserContext.on('close', () => {
+			this._application.code.driver.currentPage.on('close', () => {
 				this._closing = (async () => {
 					if (this._application) {
 						this._application.code.driver.browserContext.removeAllListeners();


### PR DESCRIPTION
This makes sure that closing the window actually closes everything to workaround the macOS behavior of having all windows closed but it's still running.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
