### PR TITLE
Git: Remove problematic ruler at 50 chars

### DIFF
--- a/extensions/git/package.json
+++ b/extensions/git/package.json
@@ -3590,7 +3590,6 @@
     "configurationDefaults": {
       "[git-commit]": {
         "editor.rulers": [
-          50,
           72
         ],
         "editor.wordWrap": "off",


### PR DESCRIPTION
The ruler at column 50, introduced in #201091, is wrong for all lines except for the first. Also, having it there breaks interaction with the (quite popular) rewrap extension:

https://marketplace.visualstudio.com/items?itemName=stkb.rewrap

The best solution would be if we could have different rulers for different lines, (50 for line 1, 0 for line 2 and 72 for the rest), but since that's not possible (or is it?), I believe dropping 50 is the best way forward.

Regarding the user experience, overflowing chars are highlighted anyway since #173195, so users who write too long subject lines will still be informed, even without that ruler in place.

Since I use rewrap all the time, and I commit things all the time, the current behavior is problematic for me.

"rewrap" uses the rulers to decide where to wrap text.

Before #201091, it wrapped at 72 chars, which was great!

With #201091 in place, it now wraps all lines at 50 chars, which is bad.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
