### PR TITLE
Trigger relayout when chat editor becomeas active from background.

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatEditor.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditor.ts
@@ -48,6 +48,7 @@ export class ChatEditor extends EditorPane {
 
 	private _memento: Memento | undefined;
 	private _viewState: IChatViewState | undefined;
+	private dimension = new dom.Dimension(0, 0);
 
 	constructor(
 		group: IEditorGroup,
@@ -108,6 +109,10 @@ export class ChatEditor extends EditorPane {
 		super.setEditorVisible(visible);
 
 		this.widget?.setVisible(visible);
+
+		if (visible && this.widget) {
+			this.widget.layout(this.dimension.height, this.dimension.width);
+		}
 	}
 
 	public override focus(): void {
@@ -184,6 +189,7 @@ export class ChatEditor extends EditorPane {
 	}
 
 	override layout(dimension: dom.Dimension, position?: dom.IDomPosition | undefined): void {
+		this.dimension = dimension;
 		if (this.widget) {
 			this.widget.layout(dimension.height, dimension.width);
 		}


### PR DESCRIPTION
ref: https://github.com/microsoft/vscode/issues/263521

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Otherwise any editor group / window resize from background is not picked up by the widget and it leads to UI glitches for some tool call parts (e.g., Terminal)