### PR TITLE
Warn about global auto approve, rename setting

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/actions/chatAccessibilityHelp.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatAccessibilityHelp.ts
@@ -15,7 +15,7 @@ import { IKeybindingService } from '../../../../../platform/keybinding/common/ke
 import { AccessibilityVerbositySettingId } from '../../../accessibility/browser/accessibilityConfiguration.js';
 import { INLINE_CHAT_ID } from '../../../inlineChat/common/inlineChat.js';
 import { ChatContextKeyExprs, ChatContextKeys } from '../../common/chatContextKeys.js';
-import { ChatAgentLocation, ChatModeKind } from '../../common/constants.js';
+import { ChatAgentLocation, ChatConfiguration, ChatModeKind } from '../../common/constants.js';
 import { IChatWidgetService } from '../chat.js';
 
 export class PanelChatAccessibilityHelp implements IAccessibleViewImplementation {
@@ -99,7 +99,7 @@ export function getAccessibilityHelpText(type: 'panelChat' | 'inlineChat' | 'qui
 		if (type === 'agentView') {
 			content.push(localize('chatAgent.userActionRequired', 'An alert will indicate when user action is required. For example, if the agent wants to run something in the terminal, you will hear Action Required: Run Command in Terminal.'));
 			content.push(localize('chatAgent.runCommand', 'To take the action, use the accept tool command{0}.', '<keybinding:workbench.action.chat.acceptTool>'));
-			content.push(localize('chatAgent.autoApprove', 'To automatically approve tool actions without manual confirmation, set chat.tools.autoApprove to true in your settings.'));
+			content.push(localize('chatAgent.autoApprove', 'To automatically approve tool actions without manual confirmation, set {0} to {1} in your settings.', ChatConfiguration.GlobalAutoApprove, 'true'));
 			content.push(localize('chatAgent.acceptTool', 'To accept a tool action, use the Accept Tool Confirmation command{0}.', '<keybinding:workbench.action.chat.acceptTool>'));
 			content.push(localize('chatAgent.openEditedFilesSetting', 'By default, when edits are made to files, they will be opened. To change this behavior, set accessibility.openChatEditedFiles to false in your settings.'));
 		}

--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -110,7 +110,7 @@ import './contrib/chatInputCompletions.js';
 import './contrib/chatInputEditorContrib.js';
 import './contrib/chatInputEditorHover.js';
 import { ChatRelatedFilesContribution } from './contrib/chatInputRelatedFilesContrib.js';
-import { LanguageModelToolsService } from './languageModelToolsService.js';
+import { globalAutoApproveDescription, LanguageModelToolsService } from './languageModelToolsService.js';
 import './promptSyntax/promptCodingAgentActionContribution.js';
 import './promptSyntax/promptToolsCodeLensProvider.js';
 import { PromptUrlHandler } from './promptSyntax/promptUrlHandler.js';
@@ -235,11 +235,11 @@ configurationRegistry.registerConfiguration({
 			description: nls.localize('chat.notifyWindowOnConfirmation', "Controls whether the Copilot window should notify the user when a confirmation is needed while the window is not in focus. This includes a window badge as well as notification toast."),
 			default: true,
 		},
-		'chat.tools.autoApprove': {
+		[ChatConfiguration.GlobalAutoApprove]: {
 			default: false,
 			// Description is added in for policy parser. See https://github.com/microsoft/vscode/issues/254526
-			description: nls.localize('chat.tools.autoApprove.description', "Controls whether tool use should be automatically approved. Allow all tools to run automatically without user confirmation, overriding any tool-specific settings such as terminal auto-approval. Use with caution: carefully review selected tools and be extra wary of possible sources of prompt injection!"),
-			markdownDescription: nls.localize('chat.tools.autoApprove.markdownDescription', "Controls whether tool use should be automatically approved.\n\nAllows _all_ tools to run automatically without user confirmation, overriding any tool-specific settings such as terminal auto-approval.\n\nUse with caution: carefully review selected tools and be extra wary of possible sources of prompt injection!"),
+			description: globalAutoApproveDescription.value,
+			markdownDescription: globalAutoApproveDescription.value,
 			type: 'boolean',
 			scope: ConfigurationScope.APPLICATION_MACHINE,
 			tags: ['experimental'],

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart.ts
@@ -24,6 +24,7 @@ import { TerminalContribSettingId } from '../../../../terminal/terminalContribEx
 import { ConfigurationTarget } from '../../../../../../platform/configuration/common/configuration.js';
 import { matchesScheme, Schemas } from '../../../../../../base/common/network.js';
 import type { ICodeBlockRenderOptions } from '../../codeBlockPart.js';
+import { ChatConfiguration } from '../../../common/constants.js';
 
 export class ChatTerminalToolProgressPart extends BaseChatToolInvocationSubPart {
 	public readonly domNode: HTMLElement;
@@ -96,7 +97,7 @@ export class ChatTerminalToolProgressPart extends BaseChatToolInvocationSubPart 
 					case 'settings': {
 						if (scopeRaw === 'global') {
 							preferencesService.openSettings({
-								query: `@id:chat.tools.autoApprove`
+								query: `@id:${ChatConfiguration.GlobalAutoApprove}`
 							});
 						} else {
 							const scope = parseInt(scopeRaw);

--- a/src/vs/workbench/contrib/chat/browser/languageModelToolsService.ts
+++ b/src/vs/workbench/contrib/chat/browser/languageModelToolsService.ts
@@ -543,13 +543,14 @@ export class LanguageModelToolsService extends Disposable implements ILanguageMo
 				}],
 			}
 		});
-		if (!promptResult.result) {
-			await this._configurationService.updateValue(ChatConfiguration.GlobalAutoApprove, false);
 
-		} if (promptResult.result === true) {
-			this._storageService.store(AutoApproveStorageKeys.GlobalAutoApproveOptIn, true, StorageScope.APPLICATION, StorageTarget.USER);
+		if (promptResult.result !== true) {
+			await this._configurationService.updateValue(ChatConfiguration.GlobalAutoApprove, false);
+			return false;
 		}
-		return promptResult.result === true;
+
+		this._storageService.store(AutoApproveStorageKeys.GlobalAutoApproveOptIn, true, StorageScope.APPLICATION, StorageTarget.USER);
+		return true;
 	}
 
 	private cleanupCallDisposables(requestId: string | undefined, store: DisposableStore): void {

--- a/src/vs/workbench/contrib/chat/browser/languageModelToolsService.ts
+++ b/src/vs/workbench/contrib/chat/browser/languageModelToolsService.ts
@@ -11,13 +11,16 @@ import { CancellationToken, CancellationTokenSource } from '../../../../base/com
 import { Codicon } from '../../../../base/common/codicons.js';
 import { toErrorMessage } from '../../../../base/common/errorMessage.js';
 import { CancellationError, isCancellationError } from '../../../../base/common/errors.js';
-import { Emitter } from '../../../../base/common/event.js';
+import { Emitter, Event } from '../../../../base/common/event.js';
+import { MarkdownString } from '../../../../base/common/htmlContent.js';
 import { Iterable } from '../../../../base/common/iterator.js';
 import { Lazy } from '../../../../base/common/lazy.js';
 import { combinedDisposable, Disposable, DisposableStore, IDisposable, toDisposable } from '../../../../base/common/lifecycle.js';
 import { LRUCache } from '../../../../base/common/map.js';
 import { IObservable, ObservableSet } from '../../../../base/common/observable.js';
+import Severity from '../../../../base/common/severity.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
+import { localize, localize2 } from '../../../../nls.js';
 import { IAccessibilityService } from '../../../../platform/accessibility/common/accessibility.js';
 import { AccessibilitySignal, IAccessibilitySignalService } from '../../../../platform/accessibilitySignal/browser/accessibilitySignalService.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
@@ -50,6 +53,23 @@ interface ITrackedCall {
 	store: IDisposable;
 }
 
+const enum AutoApproveStorageKeys {
+	GlobalAutoApproveOptIn = 'chat.tools.global.autoApprove.optIn'
+}
+
+export const globalAutoApproveDescription = localize2(
+	{
+		key: 'autoApprove2.markdown',
+		comment: [
+			'{Locked=\'](https://github.com/features/codespaces)\'}',
+			'{Locked=\'](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)\'}',
+			'{Locked=\'](https://code.visualstudio.com/docs/copilot/security)\'}',
+			'{Locked=\'**\'}',
+		]
+	},
+	'Global auto approve also known as "YOLO mode" disables manual approval completely for _all tools in all workspaces_, allowing the agent to act fully autonomously. This is extremely dangerous and is *never* recommended, even containerized environments like [Codespaces](https://github.com/features/codespaces) and [Dev Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) have user keys forwarded into the container that could be compromised.\n\n**This feature disables [critical security protections](https://code.visualstudio.com/docs/copilot/security) and makes it much easier for an attacker to compromise the machine.**'
+);
+
 export class LanguageModelToolsService extends Disposable implements ILanguageModelToolsService {
 	_serviceBrand: undefined;
 
@@ -79,7 +99,8 @@ export class LanguageModelToolsService extends Disposable implements ILanguageMo
 		@ILogService private readonly _logService: ILogService,
 		@IConfigurationService private readonly _configurationService: IConfigurationService,
 		@IAccessibilityService private readonly _accessibilityService: IAccessibilityService,
-		@IAccessibilitySignalService private readonly _accessibilitySignalService: IAccessibilitySignalService
+		@IAccessibilitySignalService private readonly _accessibilitySignalService: IAccessibilitySignalService,
+		@IStorageService private readonly _storageService: IStorageService,
 	) {
 		super();
 
@@ -96,6 +117,15 @@ export class LanguageModelToolsService extends Disposable implements ILanguageMo
 		this._register(this._configurationService.onDidChangeConfiguration(e => {
 			if (e.affectsConfiguration(ChatConfiguration.ExtensionToolsEnabled)) {
 				this._onDidChangeToolsScheduler.schedule();
+			}
+		}));
+
+		// Clear out warning accepted state if the setting is disabled
+		this._register(Event.runAndSubscribe(this._configurationService.onDidChangeConfiguration, e => {
+			if (!e || e.affectsConfiguration(AutoApproveStorageKeys.GlobalAutoApproveOptIn)) {
+				if (this._configurationService.getValue(AutoApproveStorageKeys.GlobalAutoApproveOptIn) !== true) {
+					this._storageService.remove(AutoApproveStorageKeys.GlobalAutoApproveOptIn, StorageScope.APPLICATION);
+				}
 			}
 		}));
 
@@ -290,7 +320,7 @@ export class LanguageModelToolsService extends Disposable implements ILanguageMo
 				const prepared = await this.prepareToolInvocation(tool, dto, token);
 				toolInvocation = new ChatToolInvocation(prepared, tool.data, dto.callId);
 				trackedCall.invocation = toolInvocation;
-				const autoConfirmed = this.shouldAutoConfirm(tool.data.id, tool.data.runsInWorkspace);
+				const autoConfirmed = await this.shouldAutoConfirm(tool.data.id, tool.data.runsInWorkspace);
 				if (autoConfirmed) {
 					toolInvocation.confirmed.complete(autoConfirmed);
 				}
@@ -324,7 +354,7 @@ export class LanguageModelToolsService extends Disposable implements ILanguageMo
 				}
 			} else {
 				const prepared = await this.prepareToolInvocation(tool, dto, token);
-				if (prepared?.confirmationMessages && !this.shouldAutoConfirm(tool.data.id, tool.data.runsInWorkspace)) {
+				if (prepared?.confirmationMessages && !(await this.shouldAutoConfirm(tool.data.id, tool.data.runsInWorkspace))) {
 					const result = await this._dialogService.confirm({ message: renderAsPlaintext(prepared.confirmationMessages.title), detail: renderAsPlaintext(prepared.confirmationMessages.message) });
 					if (!result.confirmed) {
 						throw new CancellationError();
@@ -411,7 +441,7 @@ export class LanguageModelToolsService extends Disposable implements ILanguageMo
 	}
 
 	private playAccessibilitySignal(toolInvocations: ChatToolInvocation[]): void {
-		const autoApproved = this._configurationService.getValue('chat.tools.autoApprove');
+		const autoApproved = this._configurationService.getValue(ChatConfiguration.GlobalAutoApprove);
 		if (autoApproved) {
 			return;
 		}
@@ -453,7 +483,7 @@ export class LanguageModelToolsService extends Disposable implements ILanguageMo
 		});
 	}
 
-	private shouldAutoConfirm(toolId: string, runsInWorkspace: boolean | undefined): ConfirmedReason | undefined {
+	private async shouldAutoConfirm(toolId: string, runsInWorkspace: boolean | undefined): Promise<ConfirmedReason | undefined> {
 		if (this._workspaceToolConfirmStore.value.getAutoConfirm(toolId)) {
 			return { type: ToolConfirmKind.LmServicePerTool, scope: 'workspace' };
 		}
@@ -464,7 +494,7 @@ export class LanguageModelToolsService extends Disposable implements ILanguageMo
 			return { type: ToolConfirmKind.LmServicePerTool, scope: 'session' };
 		}
 
-		const config = this._configurationService.inspect<boolean | Record<string, boolean>>('chat.tools.autoApprove');
+		const config = this._configurationService.inspect<boolean | Record<string, boolean>>(ChatConfiguration.GlobalAutoApprove);
 
 		// If we know the tool runs at a global level, only consider the global config.
 		// If we know the tool runs at a workspace level, use those specific settings when appropriate.
@@ -478,10 +508,48 @@ export class LanguageModelToolsService extends Disposable implements ILanguageMo
 
 		const autoConfirm = value === true || (typeof value === 'object' && value.hasOwnProperty(toolId) && value[toolId] === true);
 		if (autoConfirm) {
-			return { type: ToolConfirmKind.Setting, id: 'chat.tools.autoApprove' };
+			if (await this._checkGlobalAutoApprove()) {
+				return { type: ToolConfirmKind.Setting, id: ChatConfiguration.GlobalAutoApprove };
+			}
 		}
 
 		return undefined;
+	}
+
+	private async _checkGlobalAutoApprove(): Promise<boolean> {
+		const optedIn = this._storageService.getBoolean(AutoApproveStorageKeys.GlobalAutoApproveOptIn, StorageScope.APPLICATION, false);
+		if (optedIn) {
+			return true;
+		}
+
+		const promptResult = await this._dialogService.prompt({
+			type: Severity.Warning,
+			message: localize('autoApprove2.title', 'Enable global auto approve?'),
+			buttons: [
+				{
+					label: localize('autoApprove2.button.enable', 'Enable'),
+					run: () => true
+				},
+				{
+					label: localize('autoApprove2.button.disable', 'Disable'),
+					run: () => false
+				},
+			],
+			custom: {
+				icon: Codicon.warning,
+				disableCloseAction: true,
+				markdownDetails: [{
+					markdown: new MarkdownString(globalAutoApproveDescription.value),
+				}],
+			}
+		});
+		if (!promptResult.result) {
+			await this._configurationService.updateValue(ChatConfiguration.GlobalAutoApprove, false);
+
+		} if (promptResult.result === true) {
+			this._storageService.store(AutoApproveStorageKeys.GlobalAutoApproveOptIn, true, StorageScope.APPLICATION, StorageTarget.USER);
+		}
+		return promptResult.result === true;
 	}
 
 	private cleanupCallDisposables(requestId: string | undefined, store: DisposableStore): void {

--- a/src/vs/workbench/contrib/chat/browser/languageModelToolsService.ts
+++ b/src/vs/workbench/contrib/chat/browser/languageModelToolsService.ts
@@ -122,8 +122,8 @@ export class LanguageModelToolsService extends Disposable implements ILanguageMo
 
 		// Clear out warning accepted state if the setting is disabled
 		this._register(Event.runAndSubscribe(this._configurationService.onDidChangeConfiguration, e => {
-			if (!e || e.affectsConfiguration(AutoApproveStorageKeys.GlobalAutoApproveOptIn)) {
-				if (this._configurationService.getValue(AutoApproveStorageKeys.GlobalAutoApproveOptIn) !== true) {
+			if (!e || e.affectsConfiguration(ChatConfiguration.GlobalAutoApprove)) {
+				if (this._configurationService.getValue(ChatConfiguration.GlobalAutoApprove) !== true) {
 					this._storageService.remove(AutoApproveStorageKeys.GlobalAutoApproveOptIn, StorageScope.APPLICATION);
 				}
 			}

--- a/src/vs/workbench/contrib/chat/common/constants.ts
+++ b/src/vs/workbench/contrib/chat/common/constants.ts
@@ -9,6 +9,7 @@ export enum ChatConfiguration {
 	Edits2Enabled = 'chat.edits2.enabled',
 	ExtensionToolsEnabled = 'chat.extensionTools.enabled',
 	EditRequests = 'chat.editRequests',
+	GlobalAutoApprove = 'chat.tools.global.autoApprove',
 	AutoApproveEdits = 'chat.tools.edits.autoApprove',
 	EnableMath = 'chat.math.enabled',
 	CheckpointsEnabled = 'chat.checkpoints.enabled',

--- a/src/vs/workbench/contrib/chat/test/browser/languageModelToolsService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/languageModelToolsService.test.ts
@@ -513,7 +513,7 @@ suite('LanguageModelToolsService', () => {
 	test('accessibility signal for tool confirmation', async () => {
 		// Create a test configuration service with proper settings
 		const testConfigService = new TestConfigurationService();
-		testConfigService.setUserConfiguration('chat.tools.autoApprove', false);
+		testConfigService.setUserConfiguration('chat.tools.global.autoApprove', false);
 		testConfigService.setUserConfiguration('accessibility.signals.chatUserActionRequired', { sound: 'auto', announcement: 'auto' });
 
 		// Create a test accessibility service that simulates screen reader being enabled
@@ -574,7 +574,7 @@ suite('LanguageModelToolsService', () => {
 	test('accessibility signal respects autoApprove configuration', async () => {
 		// Create a test configuration service with auto-approve enabled
 		const testConfigService = new TestConfigurationService();
-		testConfigService.setUserConfiguration('chat.tools.autoApprove', true);
+		testConfigService.setUserConfiguration('chat.tools.global.autoApprove', true);
 		testConfigService.setUserConfiguration('accessibility.signals.chatUserActionRequired', { sound: 'auto', announcement: 'auto' });
 
 		// Create a test accessibility service that simulates screen reader being enabled
@@ -624,7 +624,7 @@ suite('LanguageModelToolsService', () => {
 	test('shouldAutoConfirm with basic configuration', async () => {
 		// Test basic shouldAutoConfirm behavior with simple configuration
 		const testConfigService = new TestConfigurationService();
-		testConfigService.setUserConfiguration('chat.tools.autoApprove', true); // Global enabled
+		testConfigService.setUserConfiguration('chat.tools.global.autoApprove', true); // Global enabled
 
 		const instaService = workbenchInstantiationService({
 			contextKeyService: () => store.add(new ContextKeyService(testConfigService)),
@@ -654,7 +654,7 @@ suite('LanguageModelToolsService', () => {
 	test('shouldAutoConfirm with per-tool configuration object', async () => {
 		// Test per-tool configuration: { toolId: true/false }
 		const testConfigService = new TestConfigurationService();
-		testConfigService.setUserConfiguration('chat.tools.autoApprove', {
+		testConfigService.setUserConfiguration('chat.tools.global.autoApprove', {
 			'approvedTool': true,
 			'deniedTool': false
 		});
@@ -839,7 +839,7 @@ suite('LanguageModelToolsService', () => {
 
 		// Test case 1: Sound enabled, announcement disabled, screen reader off
 		const testConfigService1 = new TestConfigurationService();
-		testConfigService1.setUserConfiguration('chat.tools.autoApprove', false);
+		testConfigService1.setUserConfiguration('chat.tools.global.autoApprove', false);
 		testConfigService1.setUserConfiguration('accessibility.signals.chatUserActionRequired', { sound: 'on', announcement: 'off' });
 
 		const testAccessibilityService1 = new class extends TestAccessibilityService {
@@ -879,7 +879,7 @@ suite('LanguageModelToolsService', () => {
 
 		// Test case 2: Sound auto, announcement auto, screen reader on
 		const testConfigService2 = new TestConfigurationService();
-		testConfigService2.setUserConfiguration('chat.tools.autoApprove', false);
+		testConfigService2.setUserConfiguration('chat.tools.global.autoApprove', false);
 		testConfigService2.setUserConfiguration('accessibility.signals.chatUserActionRequired', { sound: 'auto', announcement: 'auto' });
 
 		const testAccessibilityService2 = new class extends TestAccessibilityService {
@@ -920,7 +920,7 @@ suite('LanguageModelToolsService', () => {
 
 		// Test case 3: Sound off, announcement off - no signal
 		const testConfigService3 = new TestConfigurationService();
-		testConfigService3.setUserConfiguration('chat.tools.autoApprove', false);
+		testConfigService3.setUserConfiguration('chat.tools.global.autoApprove', false);
 		testConfigService3.setUserConfiguration('accessibility.signals.chatUserActionRequired', { sound: 'off', announcement: 'off' });
 
 		const testAccessibilityService3 = new class extends TestAccessibilityService {
@@ -1318,7 +1318,7 @@ suite('LanguageModelToolsService', () => {
 	test('shouldAutoConfirm with workspace-specific tool configuration', async () => {
 		const testConfigService = new TestConfigurationService();
 		// Configure per-tool settings at different scopes
-		testConfigService.setUserConfiguration('chat.tools.autoApprove', { 'workspaceTool': true });
+		testConfigService.setUserConfiguration('chat.tools.global.autoApprove', { 'workspaceTool': true });
 
 		const instaService = workbenchInstantiationService({
 			contextKeyService: () => store.add(new ContextKeyService(testConfigService)),

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
@@ -45,6 +45,7 @@ import { Event } from '../../../../../../base/common/event.js';
 import { TerminalToolConfirmationStorageKeys } from '../../../../chat/browser/chatContentParts/toolInvocationParts/chatTerminalToolConfirmationSubPart.js';
 import { IPollingResult, OutputMonitorState } from './monitoring/types.js';
 import { getOutput } from '../outputHelpers.js';
+import { ChatConfiguration } from '../../../../chat/common/constants.js';
 
 const enum TerminalToolStorageKeysInternal {
 	TerminalSession = 'chat.terminalSessions'
@@ -779,10 +780,10 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 			}).join(', ');
 		}
 
-		const config = this._configurationService.inspect<boolean | Record<string, boolean>>('chat.tools.autoApprove');
+		const config = this._configurationService.inspect<boolean | Record<string, boolean>>(ChatConfiguration.GlobalAutoApprove);
 		const isGlobalAutoApproved = config?.value ?? config.defaultValue;
 		if (isGlobalAutoApproved) {
-			return new MarkdownString(`_${localize('autoApprove.global', 'Auto approved by setting {0}', `[\`chat.tools.autoApprove\`](settings_global "${localize('ruleTooltip.global', 'View settings')}")`)}_`);
+			return new MarkdownString(`_${localize('autoApprove.global', 'Auto approved by setting {0}', `[\`${ChatConfiguration.GlobalAutoApprove}\`](settings_global "${localize('ruleTooltip.global', 'View settings')}")`)}_`);
 		}
 
 		if (isAutoApproved) {


### PR DESCRIPTION
Part of #261671

This will show a modal dialog for any tool call that triggers global auto approve, forcing the user to allow it (enable) or disable. When approved a storage key will be added to avoid the warning again. This is a stripped down version of what I wanted to bring due to time constraints.