### PR TITLE
Fix mac select box styling

### DIFF
--- a/src/vs/base/browser/ui/selectBox/selectBox.css
+++ b/src/vs/base/browser/ui/selectBox/selectBox.css
@@ -30,5 +30,6 @@
 
 .mac .monaco-action-bar .action-item .monaco-select-box {
 	font-size: 11px;
-	border-radius: 5px;
+	border-radius: 3px;
+	min-height: 24px;
 }


### PR DESCRIPTION
Adjust the border-radius and set a minimum height for the mac select box to improve its appearance and usability.