### PR TITLE
Fix vertical alignment of icon label in search results

### DIFF
--- a/src/vs/workbench/contrib/search/browser/media/searchview.css
+++ b/src/vs/workbench/contrib/search/browser/media/searchview.css
@@ -235,8 +235,7 @@
 
 .search-view .textsearchresult .monaco-icon-label .codicon {
 	position: relative;
-	font-size: 12px;
-	top: 1px;
+	top: 3px;
 	padding-right: 3px;
 }
 


### PR DESCRIPTION
Adjust the vertical alignment of the icon label in search results for improved visual consistency.