### PR TITLE
Render additional messages conditionally based on welcome view type

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/viewsWelcome/chatViewWelcomeController.ts
+++ b/src/vs/workbench/contrib/chat/browser/viewsWelcome/chatViewWelcomeController.ts
@@ -174,13 +174,8 @@ export class ChatViewWelcomePart extends Disposable {
 			if (content.isExperimental && content.inputPart) {
 				content.inputPart.querySelector('.chat-attachments-container')?.remove();
 				dom.append(this.element, content.inputPart);
-
-				if (typeof content.additionalMessage === 'string') {
-					const additionalMsg = $('.chat-welcome-view-experimental-additional-message.chat-welcome-view-disclaimer');
-					additionalMsg.textContent = content.additionalMessage;
-					dom.append(this.element, additionalMsg);
-				}
-			} else {
+			}
+			if (!content.isExperimental) {
 				// Additional message
 				if (typeof content.additionalMessage === 'string') {
 					const disclaimers = dom.append(this.element, $('.chat-welcome-view-disclaimer'));
@@ -250,6 +245,14 @@ export class ChatViewWelcomePart extends Disposable {
 				const tipsResult = this._register(renderer.render(content.tips));
 				tips.appendChild(tipsResult.element);
 			}
+
+			// In experimental mode, render the additional message after suggested prompts (deferred)
+			if (content.isExperimental && typeof content.additionalMessage === 'string') {
+				const additionalMsg = $('.chat-welcome-view-experimental-additional-message');
+				additionalMsg.textContent = content.additionalMessage;
+				dom.append(this.element, additionalMsg);
+			}
+
 		} catch (err) {
 			this.logService.error('Failed to render chat view welcome content', err);
 		}


### PR DESCRIPTION
Fixes welcome view disclaimer not being rendered in the correct position:

Regression introduced with: https://github.com/microsoft/vscode/pull/263369

🐛
<img width="316" height="323" alt="image" src="https://github.com/user-attachments/assets/4f4dab73-5822-4a86-baa5-210f16fa0d22" />

After fix:
<img width="322" height="355" alt="image" src="https://github.com/user-attachments/assets/e513e25a-461c-4f9e-948e-4e57beec9efa" />
