### PR TITLE
tools: re-apply confirm response based on promise

### DIFF
--- a/src/vs/base/common/async.ts
+++ b/src/vs/base/common/async.ts
@@ -1745,6 +1745,10 @@ export class DeferredPromise<T> {
 	}
 
 	public complete(value: T) {
+		if (this.isSettled) {
+			return Promise.resolve();
+		}
+
 		return new Promise<void>(resolve => {
 			this.completeCallback(value);
 			this.outcome = { outcome: DeferredOutcome.Resolved, value };
@@ -1753,6 +1757,10 @@ export class DeferredPromise<T> {
 	}
 
 	public error(err: unknown) {
+		if (this.isSettled) {
+			return Promise.resolve();
+		}
+
 		return new Promise<void>(resolve => {
 			this.errorCallback(err);
 			this.outcome = { outcome: DeferredOutcome.Rejected, value: err };

--- a/src/vs/base/test/common/async.test.ts
+++ b/src/vs/base/test/common/async.test.ts
@@ -1210,6 +1210,22 @@ suite('Async', () => {
 			assert.strictEqual((await deferred.p.catch(e => e)).name, 'Canceled');
 			assert.strictEqual(deferred.isRejected, true);
 		});
+
+		test('retains the original settled value', async () => {
+			const deferred = new async.DeferredPromise<number>();
+			assert.strictEqual(deferred.isResolved, false);
+			assert.strictEqual(deferred.value, undefined);
+
+			deferred.complete(42);
+			assert.strictEqual(await deferred.p, 42);
+			assert.strictEqual(deferred.value, 42);
+			assert.strictEqual(deferred.isResolved, true);
+
+			deferred.complete(-1);
+			assert.strictEqual(await deferred.p, 42);
+			assert.strictEqual(deferred.value, 42);
+			assert.strictEqual(deferred.isResolved, true);
+		});
 	});
 
 	suite('Promises.settled', () => {

--- a/src/vs/workbench/contrib/chat/common/chatProgressTypes/chatToolInvocation.ts
+++ b/src/vs/workbench/contrib/chat/common/chatProgressTypes/chatToolInvocation.ts
@@ -29,9 +29,8 @@ export class ChatToolInvocation implements IChatToolInvocation {
 		return this._confirmDeferred;
 	}
 
-	private _isConfirmed: ConfirmedReason | undefined;
 	public get isConfirmed(): ConfirmedReason | undefined {
-		return this._isConfirmed;
+		return this._confirmDeferred.value;
 	}
 
 	private _resultDetails: IToolResult['toolResultDetails'] | undefined;
@@ -65,12 +64,10 @@ export class ChatToolInvocation implements IChatToolInvocation {
 
 		if (!this._confirmationMessages) {
 			// No confirmation needed
-			this._isConfirmed = { type: ToolConfirmKind.ConfirmationNotNeeded };
-			this._confirmDeferred.complete(this._isConfirmed);
+			this._confirmDeferred.complete({ type: ToolConfirmKind.ConfirmationNotNeeded });
 		}
 
-		this._confirmDeferred.p.then(confirmed => {
-			this._isConfirmed = confirmed;
+		this._confirmDeferred.p.then(() => {
 			this._confirmationMessages = undefined;
 		});
 
@@ -107,7 +104,7 @@ export class ChatToolInvocation implements IChatToolInvocation {
 			invocationMessage: this.invocationMessage,
 			pastTenseMessage: this.pastTenseMessage,
 			originMessage: this.originMessage,
-			isConfirmed: this._isConfirmed,
+			isConfirmed: this._confirmDeferred.value,
 			isComplete: true,
 			source: this.source,
 			resultDetails: isToolResultOutputDetails(this._resultDetails)


### PR DESCRIPTION
> Note: for merging after endgame

This re-applies #263894 and fixes #264023 by removing a surprising
behavior in the DeferredPromise where calling complete() with additional
values will update the settled `deferred.value` without affecting the
original promise (which can of course only resolve once.)

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
