### PR TITLE
Don't focus chat input when opening a session from chat sessions view

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatSessions.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSessions.ts
@@ -1620,6 +1620,7 @@ class SessionsViewPane extends ViewPane {
 						pinned: true,
 						// Add a marker to indicate this session was opened from history
 						ignoreInView: true,
+						preserveFocus: true,
 					};
 					await this.editorService.openEditor({ resource: ChatEditorInput.getNewEditorUri(), options });
 				} else {
@@ -1627,8 +1628,8 @@ class SessionsViewPane extends ViewPane {
 					const providerType = sessionWithProvider.provider.chatSessionType;
 					const options: IChatEditorOptions = {
 						pinned: true,
-						preferredTitle: truncate(element.label, 20)
-
+						preferredTitle: truncate(element.label, 20),
+						preserveFocus: true,
 					};
 					await this.editorService.openEditor({
 						resource: ChatSessionUri.forSession(providerType, sessionId),
@@ -1663,6 +1664,7 @@ class SessionsViewPane extends ViewPane {
 				pinned: true,
 				ignoreInView: true,
 				preferredTitle: truncate(element.label, 20),
+				preserveFocus: true,
 			};
 			await this.editorService.openEditor({
 				resource: ChatSessionUri.forSession(providerType, sessionId),


### PR DESCRIPTION
Fixes #264650

This matches how opening files from the explorer works. Using the `Open chat editor` command still should focus the input
