### PR TITLE
Don't fail if client does not implement "vscode/content" request

### DIFF
--- a/extensions/json-language-features/server/src/jsonServer.ts
+++ b/extensions/json-language-features/server/src/jsonServer.ts
@@ -103,6 +103,9 @@ export function startServer(connection: Connection, runtime: RuntimeEnvironment)
 			return connection.sendRequest(VSCodeContentRequest.type, uri).then(responseText => {
 				return responseText;
 			}, error => {
+				if (error.code == -32601) {
+					return "{}";
+				}
 				return Promise.reject(error.message);
 			});
 		};


### PR DESCRIPTION
Sending back an error to the client is unnecessary. It will only create noise.