### PR TITLE
Chat - set minimum fontSize to 6

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -132,7 +132,7 @@ configurationRegistry.registerConfiguration({
 			type: 'number',
 			description: nls.localize('chat.fontSize', "Controls the font size in pixels in chat messages."),
 			default: 13,
-			minimum: 13,
+			minimum: 6,
 			maximum: 100
 		},
 		'chat.fontFamily': {


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/264728