### PR TITLE
Fix for issue 263098

### DIFF
--- a/src/vs/editor/browser/controller/mouseHandler.ts
+++ b/src/vs/editor/browser/controller/mouseHandler.ts
@@ -578,14 +578,12 @@ class MouseDownOperation extends Disposable {
 			return MouseTarget.createOutsideEditor(mouseColumn, new Position(possibleLineNumber, 1), 'left', outsideDistance);
 		}
 
-		const minimapShadowPadding = 10;
-
-		const contentRight = (
+		const minimapShadowPadding = 6; // See minimap-shadow-visible in minimap.css
+		const xRightBoundary = (
 			layoutInfo.minimap.minimapLeft === 0
 				? layoutInfo.width - layoutInfo.verticalScrollbarWidth // Happens when minimap is hidden
 				: layoutInfo.minimap.minimapLeft - minimapShadowPadding // Minimap needs padding because of its shadow
 		);
-		const xRightBoundary = contentRight;
 		if (e.relativePos.x >= xRightBoundary) {
 			const outsideDistance = e.relativePos.x - xRightBoundary;
 			return MouseTarget.createOutsideEditor(mouseColumn, new Position(possibleLineNumber, model.getLineMaxColumn(possibleLineNumber)), 'right', outsideDistance);

--- a/src/vs/editor/browser/controller/mouseHandler.ts
+++ b/src/vs/editor/browser/controller/mouseHandler.ts
@@ -573,7 +573,7 @@ class MouseDownOperation extends Disposable {
 		const horizontalScrollPadding = 10;
 		const layoutInfo = this._context.configuration.options.get(EditorOption.layoutInfo);
 
-		const xLeftBoundary = layoutInfo.contentLeft + horizontalScrollPadding;
+		const xLeftBoundary = layoutInfo.contentLeft;
 		if (e.relativePos.x <= xLeftBoundary) {
 			const outsideDistance = xLeftBoundary - e.relativePos.x;
 			return MouseTarget.createOutsideEditor(mouseColumn, new Position(possibleLineNumber, 1), 'left', outsideDistance);

--- a/src/vs/editor/browser/controller/mouseHandler.ts
+++ b/src/vs/editor/browser/controller/mouseHandler.ts
@@ -582,9 +582,9 @@ class MouseDownOperation extends Disposable {
 		const contentRight = (
 			layoutInfo.minimap.minimapLeft === 0
 				? layoutInfo.width - layoutInfo.verticalScrollbarWidth // Happens when minimap is hidden
-				: layoutInfo.minimap.minimapLeft
+				: layoutInfo.minimap.minimapLeft - horizontalScrollPadding // Minimap needs padding because of shadow
 		);
-		const xRightBoundary = contentRight - horizontalScrollPadding;
+		const xRightBoundary = contentRight;
 		if (e.relativePos.x >= xRightBoundary) {
 			const outsideDistance = e.relativePos.x - xRightBoundary;
 			return MouseTarget.createOutsideEditor(mouseColumn, new Position(possibleLineNumber, model.getLineMaxColumn(possibleLineNumber)), 'right', outsideDistance);

--- a/src/vs/editor/browser/controller/mouseHandler.ts
+++ b/src/vs/editor/browser/controller/mouseHandler.ts
@@ -570,7 +570,6 @@ class MouseDownOperation extends Disposable {
 
 		const possibleLineNumber = viewLayout.getLineNumberAtVerticalOffset(viewLayout.getCurrentScrollTop() + e.relativePos.y);
 
-		const horizontalScrollPadding = 10;
 		const layoutInfo = this._context.configuration.options.get(EditorOption.layoutInfo);
 
 		const xLeftBoundary = layoutInfo.contentLeft;
@@ -579,10 +578,12 @@ class MouseDownOperation extends Disposable {
 			return MouseTarget.createOutsideEditor(mouseColumn, new Position(possibleLineNumber, 1), 'left', outsideDistance);
 		}
 
+		const minimapShadowPadding = 10;
+
 		const contentRight = (
 			layoutInfo.minimap.minimapLeft === 0
 				? layoutInfo.width - layoutInfo.verticalScrollbarWidth // Happens when minimap is hidden
-				: layoutInfo.minimap.minimapLeft - horizontalScrollPadding // Minimap needs padding because of shadow
+				: layoutInfo.minimap.minimapLeft - minimapShadowPadding // Minimap needs padding because of its shadow
 		);
 		const xRightBoundary = contentRight;
 		if (e.relativePos.x >= xRightBoundary) {


### PR DESCRIPTION
Fixes issue https://github.com/microsoft/vscode/issues/263098 that was caused by https://github.com/microsoft/vscode/pull/235174

Removing the padding except where it was needed for the minimap shadow should fix issue 263098 "Caret jumps to column 0 when clicking between first two characters"