### PR TITLE
Disable macOS broker support due to blocking MSAL bug

### DIFF
--- a/extensions/microsoft-authentication/src/node/cachedPublicClientApplication.ts
+++ b/extensions/microsoft-authentication/src/node/cachedPublicClientApplication.ts
@@ -51,15 +51,17 @@ export class CachedPublicClientApplication implements ICachedPublicClientApplica
 
 		const loggerOptions = new MsalLoggerOptions(_logger, telemetryReporter);
 		let broker: BrokerOptions | undefined;
-		if (workspace.getConfiguration('microsoft-authentication').get<'msal' | 'msal-no-broker'>('implementation') !== 'msal-no-broker') {
+		if (process.platform !== 'win32') {
+			this._logger.info(`[${this._clientId}] Native Broker is only available on Windows`);
+		} else if (workspace.getConfiguration('microsoft-authentication').get<'msal' | 'msal-no-broker'>('implementation') === 'msal-no-broker') {
+			this._logger.info(`[${this._clientId}] Native Broker disabled via settings`);
+		} else {
 			const nativeBrokerPlugin = new NativeBrokerPlugin();
 			this.isBrokerAvailable = nativeBrokerPlugin.isBrokerAvailable;
 			this._logger.info(`[${this._clientId}] Native Broker enabled: ${this.isBrokerAvailable}`);
 			if (this.isBrokerAvailable) {
 				broker = { nativeBrokerPlugin };
 			}
-		} else {
-			this._logger.info(`[${this._clientId}] Native Broker disabled via settings`);
 		}
 		this._pca = new PublicClientApplication({
 			auth: { clientId: _clientId },


### PR DESCRIPTION
Sigh... Unfortunately, MSAL seems to fail for clients that don't have managed machines that have opted in to the broker... I have opened a blocking issue on them internally.

At least, when they fix it, it would just be a matter of updating the package version and the conditional here.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
Fixes https://github.com/microsoft/vscode/issues/263875