### PR TITLE
fix: memory leak in notebook text model

### DIFF
--- a/src/vs/workbench/contrib/notebook/common/model/notebookTextModel.ts
+++ b/src/vs/workbench/contrib/notebook/common/model/notebookTextModel.ts
@@ -274,7 +274,7 @@ export class NotebookTextModel extends Disposable implements INotebookTextModel 
 		};
 		this._register(_modelService.onModelAdded(e => maybeUpdateCellTextModel(e)));
 
-		this._pauseableEmitter = new NotebookEventEmitter({
+		this._pauseableEmitter = this._register(new NotebookEventEmitter({
 			merge: (events: NotebookTextModelChangedEvent[]) => {
 				const first = events[0];
 
@@ -292,7 +292,7 @@ export class NotebookTextModel extends Disposable implements INotebookTextModel 
 
 				return { rawEvents, versionId, endSelectionState, synchronous };
 			}
-		});
+		}));
 
 		this._register(this._pauseableEmitter.event(e => {
 			if (e.rawEvents.length) {


### PR DESCRIPTION
Registering the NotebookEventEmitter disposable. 

<br>

### Before
Opening a notebook diff editor 197 times:

![Untitled (2)](https://github.com/user-attachments/assets/0cdd119a-25ed-44ea-bcae-d28f71ac38b7)

