### PR TITLE
Don't cancel an all-provider request when the single-provider request is a subset

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "code-oss-dev",
-  "version": "1.103.2",
+  "version": "1.103.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "code-oss-dev",
-      "version": "1.103.2",
+      "version": "1.103.3",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "code-oss-dev",
-  "version": "1.103.2",
+  "version": "1.103.3",
   "distro": "5545a7bcc7ca289eee3a1bd8fff5d381f3811934",
   "author": {
     "name": "Microsoft Corporation"

--- a/src/vs/editor/contrib/inlineCompletions/browser/model/inlineCompletionsModel.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/model/inlineCompletionsModel.ts
@@ -407,7 +407,7 @@ export class InlineCompletionsModel extends Disposable {
 		const suppressedProviderGroupIds = this._suppressedInlineCompletionGroupIds.get();
 		const availableProviders = providers.providers.filter(provider => !(provider.groupId && suppressedProviderGroupIds.has(provider.groupId)));
 
-		return this._source.fetch(availableProviders, providers.label, context, itemToPreserve?.identity, changeSummary.shouldDebounce, userJumpedToActiveCompletion, !!changeSummary.provider, requestInfo);
+		return this._source.fetch(availableProviders, providers.label, context, itemToPreserve?.identity, changeSummary.shouldDebounce, userJumpedToActiveCompletion, requestInfo);
 	});
 
 	public async trigger(tx?: ITransaction, options?: { onlyFetchInlineEdits?: boolean; noDelay?: boolean }): Promise<void> {

--- a/src/vs/editor/contrib/inlineCompletions/browser/model/inlineCompletionsSource.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/model/inlineCompletionsSource.ts
@@ -117,7 +117,6 @@ export class InlineCompletionsSource extends Disposable {
 		activeInlineCompletion: InlineSuggestionIdentity | undefined,
 		withDebounce: boolean,
 		userJumpedToActiveCompletion: IObservable<boolean>,
-		providerhasChangedCompletion: boolean,
 		requestInfo: InlineSuggestRequestInfo
 	): Promise<boolean> {
 		const position = this._cursorPosition.get();
@@ -125,7 +124,7 @@ export class InlineCompletionsSource extends Disposable {
 
 		const target = context.selectedSuggestionInfo ? this.suggestWidgetInlineCompletions.get() : this.inlineCompletions.get();
 
-		if (!providerhasChangedCompletion && this._updateOperation.value?.request.satisfies(request)) {
+		if (this._updateOperation.value?.request.satisfies(request)) {
 			return this._updateOperation.value.promise;
 		} else if (target?.request?.satisfies(request)) {
 			return Promise.resolve(true);

--- a/src/vs/editor/contrib/inlineCompletions/browser/structuredLogger.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/structuredLogger.ts
@@ -53,7 +53,7 @@ interface IFetchResult {
  * The sourceLabel must not contain '@'!
 */
 export function formatRecordableLogEntry<T extends IRecordableLogEntry>(entry: T): string {
-	return entry.sourceId + ' @@ ' + JSON.stringify({ ...entry, sourceId: undefined });
+	return entry.sourceId + ' @@ ' + JSON.stringify({ ...entry, modelUri: (entry as any).modelUri?.toString(), sourceId: undefined });
 }
 
 export class StructuredLogger<T extends IRecordableLogEntry> extends Disposable {


### PR DESCRIPTION
Cherry picks 1f6f0fcab52b2c6946feda186606ce0209f53a1e to the release branch