### PR TITLE
Add simulation context support across environment and context key services

### DIFF
--- a/src/vs/editor/standalone/browser/standaloneServices.ts
+++ b/src/vs/editor/standalone/browser/standaloneServices.ts
@@ -243,6 +243,7 @@ class StandaloneEnvironmentService implements IEnvironmentService {
 	readonly disableTelemetry: boolean = false;
 	readonly serviceMachineIdResource: URI = URI.from({ scheme: 'monaco', authority: 'serviceMachineIdResource' });
 	readonly policyFile?: URI | undefined = undefined;
+	readonly isSimulation: boolean | undefined = undefined;
 }
 
 class StandaloneDialogService implements IDialogService {

--- a/src/vs/platform/contextkey/common/contextkeys.ts
+++ b/src/vs/platform/contextkey/common/contextkeys.ts
@@ -19,5 +19,7 @@ export const IsMobileContext = new RawContextKey<boolean>('isMobile', isMobile, 
 export const IsDevelopmentContext = new RawContextKey<boolean>('isDevelopment', false, true);
 export const ProductQualityContext = new RawContextKey<string>('productQualityType', '', localize('productQualityType', "Quality type of VS Code"));
 
+export const IsSimulationContext = new RawContextKey<boolean>('isSimulation', false, localize('isSimulation', "Whether the application runs in simulation mode"));
+
 export const InputFocusedContextKey = 'inputFocus';
 export const InputFocusedContext = new RawContextKey<boolean>(InputFocusedContextKey, false, localize('inputFocus', "Whether keyboard focus is inside an input box"));

--- a/src/vs/platform/environment/common/environment.ts
+++ b/src/vs/platform/environment/common/environment.ts
@@ -91,6 +91,9 @@ export interface IEnvironmentService {
 	// --- Policy
 	policyFile?: URI;
 
+	// -- Simulation
+	isSimulation?: boolean;
+
 	// !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 	//
 	// NOTE: KEEP THIS INTERFACE AS SMALL AS POSSIBLE.

--- a/src/vs/platform/environment/common/environmentService.ts
+++ b/src/vs/platform/environment/common/environmentService.ts
@@ -264,6 +264,10 @@ export abstract class AbstractNativeEnvironmentService implements INativeEnviron
 
 	get args(): NativeParsedArgs { return this._args; }
 
+	get isSimulation(): boolean {
+		return env['SIMULATION'] === '1';
+	}
+
 	constructor(
 		private readonly _args: NativeParsedArgs,
 		private readonly paths: INativeEnvironmentPaths,

--- a/src/vs/workbench/browser/contextkeys.ts
+++ b/src/vs/workbench/browser/contextkeys.ts
@@ -6,7 +6,7 @@
 import { Event } from '../../base/common/event.js';
 import { Disposable, DisposableStore, MutableDisposable } from '../../base/common/lifecycle.js';
 import { IContextKeyService, IContextKey, setConstant as setConstantContextKey } from '../../platform/contextkey/common/contextkey.js';
-import { InputFocusedContext, IsMacContext, IsLinuxContext, IsWindowsContext, IsWebContext, IsMacNativeContext, IsDevelopmentContext, IsIOSContext, ProductQualityContext, IsMobileContext } from '../../platform/contextkey/common/contextkeys.js';
+import { InputFocusedContext, IsMacContext, IsLinuxContext, IsWindowsContext, IsWebContext, IsMacNativeContext, IsDevelopmentContext, IsIOSContext, ProductQualityContext, IsMobileContext, IsSimulationContext } from '../../platform/contextkey/common/contextkeys.js';
 import { SplitEditorsVertically, InEditorZenModeContext, AuxiliaryBarVisibleContext, SideBarVisibleContext, PanelAlignmentContext, PanelMaximizedContext, PanelVisibleContext, EmbedderIdentifierContext, EditorTabsVisibleContext, IsMainEditorCenteredLayoutContext, MainEditorAreaVisibleContext, DirtyWorkingCopiesContext, EmptyWorkspaceSupportContext, EnterMultiRootWorkspaceSupportContext, HasWebFileSystemAccess, IsMainWindowFullscreenContext, OpenFolderWorkspaceSupportContext, RemoteNameContext, VirtualWorkspaceContext, WorkbenchStateContext, WorkspaceFolderCountContext, PanelPositionContext, TemporaryWorkspaceContext, TitleBarVisibleContext, TitleBarStyleContext, IsAuxiliaryWindowFocusedContext, ActiveEditorGroupEmptyContext, ActiveEditorGroupIndexContext, ActiveEditorGroupLastContext, ActiveEditorGroupLockedContext, MultipleEditorGroupsContext, EditorsVisibleContext, AuxiliaryBarMaximizedContext, InAutomationContext } from '../common/contextkeys.js';
 import { trackFocus, addDisposableListener, EventType, onDidRegisterWindow, getActiveWindow, isEditableElement } from '../../base/browser/dom.js';
 import { preferredSideBySideGroupDirection, GroupDirection, IEditorGroupsService } from '../services/editor/common/editorGroupsService.js';
@@ -105,6 +105,9 @@ export class WorkbenchContextKeysHandler extends Disposable {
 		const isDevelopment = !this.environmentService.isBuilt || this.environmentService.isExtensionDevelopment;
 		IsDevelopmentContext.bindTo(this.contextKeyService).set(isDevelopment);
 		setConstantContextKey(IsDevelopmentContext.key, isDevelopment);
+
+		// Simulation mode
+		IsSimulationContext.bindTo(this.contextKeyService).set(!!this.environmentService.isSimulation);
 
 		// Product Service
 		ProductQualityContext.bindTo(this.contextKeyService).set(this.productService.quality || '');

--- a/src/vs/workbench/contrib/chat/common/tools/manageTodoListTool.ts
+++ b/src/vs/workbench/contrib/chat/common/tools/manageTodoListTool.ts
@@ -20,6 +20,7 @@ import { ILogService } from '../../../../../platform/log/common/log.js';
 import { ITelemetryService } from '../../../../../platform/telemetry/common/telemetry.js';
 import { IChatTodo, IChatTodoListService } from '../chatTodoListService.js';
 import { ContextKeyExpr } from '../../../../../platform/contextkey/common/contextkey.js';
+import { IsSimulationContext } from '../../../../../platform/contextkey/common/contextkeys.js';
 
 export const TodoListToolSettingId = 'chat.todoListTool.enabled';
 export const TodoListToolWriteOnlySettingId = 'chat.todoListTool.writeOnly';
@@ -75,7 +76,10 @@ export function createManageTodoListToolData(writeOnly: boolean): IToolData {
 	return {
 		id: ManageTodoListToolToolId,
 		toolReferenceName: 'todos',
-		when: ContextKeyExpr.equals(`config.${TodoListToolSettingId}`, true),
+		when: ContextKeyExpr.or(
+			ContextKeyExpr.equals(`config.${TodoListToolSettingId}`, true),
+			IsSimulationContext
+		),
 		canBeReferencedInPrompt: true,
 		icon: ThemeIcon.fromId(Codicon.checklist.id),
 		displayName: 'Update Todo List',


### PR DESCRIPTION
I want to enable the manage_todo_list tool for s-tests. 
cc: @karthiknadig @rwoll 