### PR TITLE
Update Objective-C syntax hightlighting to support missing opaque types

### DIFF
--- a/extensions/objective-c/syntaxes/objective-c.tmLanguage.json
+++ b/extensions/objective-c/syntaxes/objective-c.tmLanguage.json
@@ -154,7 +154,7 @@
 			"name": "storage.type.id.objc"
 		},
 		"anonymous_pattern_12": {
-			"match": "\\b(IBOutlet|IBAction|BOOL|SEL|id|unichar|IMP|Class|Method|Ivar|instancetype)\\b",
+			"match": "\\b(IBOutlet|IBAction|BOOL|SEL|id|unichar|IMP|Class|Method|Ivar|Protocol|instancetype)\\b",
 			"name": "storage.type.objc"
 		},
 		"anonymous_pattern_13": {

--- a/extensions/objective-c/syntaxes/objective-c.tmLanguage.json
+++ b/extensions/objective-c/syntaxes/objective-c.tmLanguage.json
@@ -154,7 +154,7 @@
 			"name": "storage.type.id.objc"
 		},
 		"anonymous_pattern_12": {
-			"match": "\\b(IBOutlet|IBAction|BOOL|SEL|id|unichar|IMP|Class|instancetype)\\b",
+			"match": "\\b(IBOutlet|IBAction|BOOL|SEL|id|unichar|IMP|Class|Method|Ivar|instancetype)\\b",
 			"name": "storage.type.objc"
 		},
 		"anonymous_pattern_13": {


### PR DESCRIPTION
Adds syntax highlighting for the remaining opaque Objective-C types/structs: [Method](https://developer.apple.com/documentation/objectivec/method?language=objc), [Ivar](https://developer.apple.com/documentation/objectivec/ivar?language=objc), and [Protocol](https://developer.apple.com/documentation/objectivec/protocol?language=objc).

These are in addition to the currently highlighted type: [Class](https://developer.apple.com/documentation/objectivec/class?language=objc).

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
