### PR TITLE
Adjust hover action label styles in chat editor overlay

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/media/chatEditingEditorOverlay.css
+++ b/src/vs/workbench/contrib/chat/browser/media/chatEditingEditorOverlay.css
@@ -81,8 +81,8 @@
 	> .action-label:hover {
 		color: var(--vscode-button-separator);
 		opacity: 1;
-		height: 20px;
-		margin: 4px 4px !important;
+		height: 18px;
+		margin: 0px 4px !important;
 	}
 }
 


### PR DESCRIPTION
Refine the styles for hover action labels in the chat editor overlay to improve visual consistency and spacing.