### PR TITLE
Window Border: There is no straight forward way to use Windows window border color (fix #264566)

### DIFF
--- a/src/vs/platform/window/common/window.ts
+++ b/src/vs/platform/window/common/window.ts
@@ -210,7 +210,7 @@ export interface IWindowSettings {
 	readonly clickThroughInactive: boolean;
 	readonly newWindowProfile: string;
 	readonly density: IDensitySettings;
-	readonly border: 'off' | 'default' | string /* color in RGB or other formats */;
+	readonly border: 'off' | 'default' | 'system' | string /* color in RGB or other formats */;
 }
 
 export interface IDensitySettings {

--- a/src/vs/platform/windows/electron-main/windows.ts
+++ b/src/vs/platform/windows/electron-main/windows.ts
@@ -161,7 +161,10 @@ export function defaultBrowserWindowOptions(accessor: ServicesAccessor, windowSt
 	};
 
 	if (isWindows) {
-		const borderSetting = windowSettings?.border || 'default';
+		let borderSetting = windowSettings?.border || 'default';
+		if (borderSetting === 'system') {
+			borderSetting = 'default';
+		}
 		if (borderSetting !== 'default') {
 			if (borderSetting === 'off') {
 				options.accentColor = false;

--- a/src/vs/workbench/electron-browser/desktop.contribution.ts
+++ b/src/vs/workbench/electron-browser/desktop.contribution.ts
@@ -316,10 +316,10 @@ import { registerWorkbenchContribution2, WorkbenchPhase } from '../common/contri
 				'markdownDescription': (() => {
 					let windowBorderDescription = localize('window.border.prefix', "Controls the border color of the window:");
 					windowBorderDescription += '\n- ' + [
-						localize('window.border.default', "`default`: respect color theme settings, fallback to Windows settings"),
-						localize('window.border.system', "`system`: respect Windows settings only"),
-						localize('window.border.off', "`off`: disable border colors"),
-						localize('window.border.color', "`<color>`: specific color in Hex, RGB, RGBA, HSL, HSLA format"),
+						localize('window.border.default', "{0}: respect color theme settings, fallback to Windows settings", '`default`'),
+						localize('window.border.system', "{0}: respect Windows settings only", '`system`'),
+						localize('window.border.off', "{0}: disable border colors", '`off`'),
+						localize('window.border.color', "{0}: specific color in Hex, RGB, RGBA, HSL, HSLA format", '`<color>`'),
 					].join('\n- ');
 					windowBorderDescription += '\n\n' + localize('window.border.suffix', "Use {0} to set different colors for active and inactive windows. This setting is ignored when {1} is set to {2}.", '`#workbench.colorCustomizations#`', '`#window.titleBarStyle#`', '`native`');
 

--- a/src/vs/workbench/electron-browser/desktop.contribution.ts
+++ b/src/vs/workbench/electron-browser/desktop.contribution.ts
@@ -313,7 +313,18 @@ import { registerWorkbenchContribution2, WorkbenchPhase } from '../common/contri
 			'window.border': {
 				'type': 'string',
 				'default': 'default',
-				'markdownDescription': localize('window.border', "Controls the border color of the window. Set to `default` to respect Windows or color theme settings, `off` to disable, or to a specific color in Hex, RGB, RGBA, HSL, HSLA format. Use {0} to set different colors for active and inactive windows. This setting is ignored when {1} is set to {2}.", '`#workbench.colorCustomizations#`', '`#window.titleBarStyle#`', '`native`'),
+				'markdownDescription': (() => {
+					let windowBorderDescription = localize('window.border.prefix', "Controls the border color of the window:");
+					windowBorderDescription += '\n- ' + [
+						localize('window.border.default', "`default`: respect Windows or color theme settings"),
+						localize('window.border.system', "`system`: respect Windows settings only"),
+						localize('window.border.off', "`off`: disable border colors"),
+						localize('window.border.color', "`<color>`: specific color in Hex, RGB, RGBA, HSL, HSLA format"),
+					].join('\n- ');
+					windowBorderDescription += '\n\n' + localize('window.border.suffix', "Use {0} to set different colors for active and inactive windows. This setting is ignored when {1} is set to {2}.", '`#workbench.colorCustomizations#`', '`#window.titleBarStyle#`', '`native`');
+
+					return windowBorderDescription;
+				})(),
 				'included': isWindows
 			}
 		}

--- a/src/vs/workbench/electron-browser/desktop.contribution.ts
+++ b/src/vs/workbench/electron-browser/desktop.contribution.ts
@@ -316,7 +316,7 @@ import { registerWorkbenchContribution2, WorkbenchPhase } from '../common/contri
 				'markdownDescription': (() => {
 					let windowBorderDescription = localize('window.border.prefix', "Controls the border color of the window:");
 					windowBorderDescription += '\n- ' + [
-						localize('window.border.default', "`default`: respect Windows or color theme settings"),
+						localize('window.border.default', "`default`: respect color theme settings, fallback to Windows settings"),
 						localize('window.border.system', "`system`: respect Windows settings only"),
 						localize('window.border.off', "`off`: disable border colors"),
 						localize('window.border.color', "`<color>`: specific color in Hex, RGB, RGBA, HSL, HSLA format"),

--- a/src/vs/workbench/electron-browser/window.ts
+++ b/src/vs/workbench/electron-browser/window.ts
@@ -945,6 +945,9 @@ export class NativeWindow extends BaseWindow {
 			inactiveBorder = undefined;
 		} else if (borderSetting === 'default') {
 			activeBorder = activeBorder ?? 'default';
+		} else if (borderSetting === 'system') {
+			activeBorder = 'default';
+			inactiveBorder = undefined;
 		} else {
 			activeBorder = borderSetting;
 			inactiveBorder = undefined;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
