### PR TITLE
fix: elicitation email validator

### DIFF
--- a/src/vs/workbench/contrib/mcp/browser/mcpElicitationService.ts
+++ b/src/vs/workbench/contrib/mcp/browser/mcpElicitationService.ts
@@ -272,7 +272,7 @@ export class McpElicitationService implements IMcpElicitationService {
 	private _validateStringFormat(value: string, format: string): { isValid: boolean; message?: string } {
 		switch (format) {
 			case 'email':
-				return !value.includes('@')
+				return value.includes('@')
 					? { isValid: true }
 					: { isValid: false, message: localize('mcp.elicit.validation.email', 'Please enter a valid email address') };
 			case 'uri':


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
This pull request fixes a bug in the email validation logic within the `McpElicitationService`. The previous implementation incorrectly marked emails containing an '@' as invalid; this change corrects the logic to properly validate email addresses.

- Bug fix: Corrected the email validation in the `_validateStringFormat` method of `McpElicitationService` to ensure that values containing an '@' are now considered valid emails.

fixes #265325