### PR TITLE
Add fallback service to handle vscode:// requests

### DIFF
--- a/extensions/json-language-features/server/src/jsonServer.ts
+++ b/extensions/json-language-features/server/src/jsonServer.ts
@@ -73,6 +73,7 @@ export interface RequestService {
 export interface RuntimeEnvironment {
 	file?: RequestService;
 	http?: RequestService;
+	vscodeFallback: RequestService;
 	configureHttpRequests?(proxy: string | undefined, strictSSL: boolean): void;
 	readonly timer: {
 		setImmediate(callback: (...args: any[]) => void, ...args: any[]): Disposable;
@@ -84,13 +85,15 @@ const sortCodeActionKind = CodeActionKind.Source.concat('.sort', '.json');
 
 export function startServer(connection: Connection, runtime: RuntimeEnvironment) {
 
-	function getSchemaRequestService(handledSchemas: string[] = ['https', 'http', 'file']) {
+	function getSchemaRequestService(handledSchemas: string[] = ['https', 'http', 'file', 'vscode']) {
 		const builtInHandlers: { [protocol: string]: RequestService | undefined } = {};
 		for (const protocol of handledSchemas) {
 			if (protocol === 'file') {
 				builtInHandlers[protocol] = runtime.file;
 			} else if (protocol === 'http' || protocol === 'https') {
 				builtInHandlers[protocol] = runtime.http;
+			} else if (protocol === 'vscode') {
+				builtInHandlers[protocol] = runtime.vscodeFallback;
 			}
 		}
 		return (uri: string): Thenable<string> => {

--- a/extensions/json-language-features/server/src/node/jsonServerMain.ts
+++ b/extensions/json-language-features/server/src/node/jsonServerMain.ts
@@ -35,6 +35,14 @@ function getHTTPRequestService(): RequestService {
 	};
 }
 
+function getVSCodeRequestFallbackService(): RequestService {
+	return {
+		getContent(_uri: string) {
+			return Promise.resolve('{}');
+		}
+	};
+}
+
 function getFileRequestService(): RequestService {
 	return {
 		async getContent(location: string, encoding?: BufferEncoding) {
@@ -66,6 +74,7 @@ const runtime: RuntimeEnvironment = {
 	},
 	file: getFileRequestService(),
 	http: getHTTPRequestService(),
+	vscodeFallback: getVSCodeRequestFallbackService(),
 	configureHttpRequests
 };
 


### PR DESCRIPTION
Follow up to: #264867

Adds a fallback handler for non-standard "vscode://" urls.