### PR TITLE
smoke - use `workbench.action.clearEditorHistoryWithoutConfirm` consistently (#265146)

### DIFF
--- a/test/automation/src/quickaccess.ts
+++ b/test/automation/src/quickaccess.ts
@@ -7,7 +7,6 @@ import { Editors } from './editors';
 import { Code } from './code';
 import { QuickInput } from './quickinput';
 import { basename, isAbsolute } from 'path';
-import { Quality } from './application';
 
 enum QuickAccessKind {
 	Files = 1,
@@ -23,11 +22,7 @@ export class QuickAccess {
 
 		// make sure the file quick access is not "polluted"
 		// with entries from the editor history when opening
-		if (this.code.quality !== Quality.Stable) {
-			await this.runCommand('workbench.action.clearEditorHistoryWithoutConfirm');
-		} else {
-			await this.runCommand('workbench.action.clearEditorHistory');
-		}
+		await this.runCommand('workbench.action.clearEditorHistoryWithoutConfirm');
 
 		const PollingStrategy = {
 			Stop: true,


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/265345