### PR TITLE
fix button growing vertically in confirmation widget

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/media/chatConfirmationWidget.css
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/media/chatConfirmationWidget.css
@@ -12,6 +12,10 @@
 	align-items: center;
 }
 
+.chat-confirmation-widget .monaco-text-button {
+	height: 28px;
+}
+
 .chat-confirmation-widget:not(:last-child) {
 	margin-bottom: 16px;
 }

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/media/chatConfirmationWidget.css
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/media/chatConfirmationWidget.css
@@ -13,7 +13,9 @@
 }
 
 .chat-confirmation-widget .monaco-text-button {
-	height: 28px;
+	padding: 0 12px;
+	min-height: 2em;
+	box-sizing: border-box;
 }
 
 .chat-confirmation-widget:not(:last-child) {


### PR DESCRIPTION
fix #265382

Before:

<img width="421" height="183" alt="image" src="https://github.com/user-attachments/assets/f43cd292-6e71-4f88-a9cd-9dfbc52ddb67" />

After:

<img width="446" height="355" alt="Screenshot 2025-09-05 at 2 18 31 PM" src="https://github.com/user-attachments/assets/cfaa8dd7-4bd3-4d4d-8b93-0415da24858f" />

