### PR TITLE
Revert "smoke - use `workbench.action.clearEditorHistoryWithoutConfirm` consistently"

### DIFF
--- a/test/automation/src/quickaccess.ts
+++ b/test/automation/src/quickaccess.ts
@@ -7,6 +7,7 @@ import { Editors } from './editors';
 import { Code } from './code';
 import { QuickInput } from './quickinput';
 import { basename, isAbsolute } from 'path';
+import { Quality } from './application';
 
 enum QuickAccessKind {
 	Files = 1,
@@ -22,7 +23,11 @@ export class QuickAccess {
 
 		// make sure the file quick access is not "polluted"
 		// with entries from the editor history when opening
-		await this.runCommand('workbench.action.clearEditorHistoryWithoutConfirm');
+		if (this.code.quality !== Quality.Stable) {
+			await this.runCommand('workbench.action.clearEditorHistoryWithoutConfirm');
+		} else {
+			await this.runCommand('workbench.action.clearEditorHistory');
+		}
 
 		const PollingStrategy = {
 			Stop: true,


### PR DESCRIPTION
Reverts microsoft/vscode#265146

We can only do this once we have a released stable version.