### PR TITLE
Fix: transform UPPER_CASE correctly to PascalCase (Closes #261780)

### DIFF
--- a/src/vs/editor/contrib/linesOperations/browser/linesOperations.ts
+++ b/src/vs/editor/contrib/linesOperations/browser/linesOperations.ts
@@ -1281,13 +1281,16 @@ export class PascalCaseAction extends AbstractCaseAction {
 		const wordBoundaryToMaintain = PascalCaseAction.wordBoundaryToMaintain.get();
 
 		if (!wordBoundary || !wordBoundaryToMaintain) {
-			// cannot support this
 			return text;
 		}
 
 		const wordsWithMaintainBoundaries = text.split(wordBoundaryToMaintain);
-		const words = wordsWithMaintainBoundaries.map((word: string) => word.split(wordBoundary)).flat();
-		return words.map((word: string) => word.substring(0, 1).toLocaleUpperCase() + word.substring(1))
+		const words = wordsWithMaintainBoundaries.map((word: string) => word.split(wordBoundary)).flat().filter(w => w.length > 0);
+		return words.
+			map((word: string) => {
+				const lower = word.toLocaleLowerCase();
+				return lower.substring(0, 1).toLocaleUpperCase() + lower.substring(1);
+			})
 			.join('');
 	}
 }

--- a/src/vs/editor/contrib/linesOperations/test/browser/linesOperations.test.ts
+++ b/src/vs/editor/contrib/linesOperations/test/browser/linesOperations.test.ts
@@ -16,6 +16,7 @@ import { CamelCaseAction, PascalCaseAction, DeleteAllLeftAction, DeleteAllRightA
 import { withTestCodeEditor } from '../../../../test/browser/testCodeEditor.js';
 import { createTextModel } from '../../../../test/common/testTextModel.js';
 
+
 function assertSelection(editor: ICodeEditor, expected: Selection | Selection[]): void {
 	if (!Array.isArray(expected)) {
 		expected = [expected];
@@ -1257,6 +1258,21 @@ suite('Editor Contrib - Line Operations', () => {
 			}
 		);
 	});
+
+	suite('LineOperations - PascalCaseAction (issue: #261780)', () => {
+		test('transforms FOO_BAR to FooBar', () => {
+			const action = new PascalCaseAction();
+			const result = action['_modifyText']('FOO_BAR', '');
+			assert.strictEqual(result, 'FooBar');
+		});
+
+		test('transforms HTTP_RESPONSE_CODE to HttpResponseCode', () => {
+			const action = new PascalCaseAction();
+			const result = action['_modifyText']('HTTP_RESPONSE_CODE', '');
+			assert.strictEqual(result, 'HttpResponseCode');
+		});
+	});
+
 
 	suite('DeleteAllRightAction', () => {
 		test('should be noop on empty', () => {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
This PR closes #261780 by fixing the behavior of **Transform to Pascal Case** so that `UPPER_CASE` strings are correctly converted to PascalCase (e.g. `FOO_BAR` → `FooBar`).  

I’ve also added test cases in `LineOperations.test.ts`.  
You can run them directly with:  
```bash
./scripts/test.sh --grep PascalCaseAction
