### PR TITLE
fix: 'Create new branch...' label without ellipsis

### DIFF
--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -27,7 +27,7 @@ abstract class CheckoutCommandItem implements QuickPickItem {
 }
 
 class CreateBranchItem extends CheckoutCommandItem {
-	get label(): string { return l10n.t('{0} Create new branch...', '$(plus)'); }
+	get label(): string { return l10n.t('{0} Create new branch', '$(plus)'); }
 }
 
 class CreateBranchFromItem extends CheckoutCommandItem {


### PR DESCRIPTION
<!--
* Ensure that the code is up-to-date with the `main` branch.
-->

# Changes

Fixes #262054.

## How to test

### Preparation

1. Open a folder tracked with Git
2. Click on the _Source Control Checkout_ button in the bottom Status Bar
3. Enter a new branch name

### Previously

There was an option named _Create new branch..._

### Now

That option is now called _Create new branch_. The ellipsis was removed.