### PR TITLE
Add details to `run_in_terminal` tool result

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadLanguageModelTools.ts
+++ b/src/vs/workbench/api/browser/mainThreadLanguageModelTools.ts
@@ -57,7 +57,7 @@ export class MainThreadLanguageModelTools extends Disposable implements MainThre
 		);
 
 		// Don't return extra metadata to EH
-		const out: Dto<IToolResult> = { content: result.content };
+		const out: Dto<IToolResult> = { content: result.content, toolResultDetails: result.toolResultDetails };
 		return toolResultHasBuffers(result) ? new SerializableObjectWithBuffers(out) : out;
 	}
 


### PR DESCRIPTION
The current tool call log exported from chat debug view only has args and response of [`LanguageModelToolResult2`](https://github.com/microsoft/vscode-copilot-chat/blob/badc927f7d4b68b6d7c3a3ae5ccbaa014b5e281b/src/extension/prompt/vscode-node/requestLoggerImpl.ts#L324C81-L324C105), but it would be good to have more details like working directory and isError details. 

>         {
>           "id": "toolu_01Mm4K4KcAgkzvn38W3D1BJG__vscode-1757355997273",
>           "kind": "toolCall",
>           "tool": "run_in_terminal",
>           "args": "{\"command\": \"echo $((1+7))\", \"explanation\": \"Calculate 1+7 using bash arithmetic expansion\", \"isBackground\": false}",
>           "time": "2025-09-08T18:27:53.409Z",
>           "response": [
>             "8\n"
>           ]
>         }
