### PR TITLE
feat: Add session ID to telemetry events for completions provider

### DIFF
--- a/src/vs/editor/common/textModelEditSource.ts
+++ b/src/vs/editor/common/textModelEditSource.ts
@@ -122,17 +122,18 @@ export const EditSources = {
 	chatUndoEdits: () => createEditSource({ source: 'Chat.undoEdits' } as const),
 	chatReset: () => createEditSource({ source: 'Chat.reset' } as const),
 
-	inlineCompletionAccept(data: { nes: boolean; requestUuid: string; languageId: string; providerId?: ProviderId }) {
+	inlineCompletionAccept(data: { nes: boolean; requestUuid: string; languageId: string; providerId?: ProviderId; sessionId?: string }) {
 		return createEditSource({
 			source: 'inlineCompletionAccept',
 			$nes: data.nes,
 			...toProperties(data.providerId),
 			$$requestUuid: data.requestUuid,
 			$$languageId: data.languageId,
+			$$sessionId: data.sessionId,
 		} as const);
 	},
 
-	inlineCompletionPartialAccept(data: { nes: boolean; requestUuid: string; languageId: string; providerId?: ProviderId; type: 'word' | 'line' }) {
+	inlineCompletionPartialAccept(data: { nes: boolean; requestUuid: string; languageId: string; providerId?: ProviderId; type: 'word' | 'line'; sessionId?: string }) {
 		return createEditSource({
 			source: 'inlineCompletionPartialAccept',
 			type: data.type,
@@ -140,6 +141,7 @@ export const EditSources = {
 			...toProperties(data.providerId),
 			$$requestUuid: data.requestUuid,
 			$$languageId: data.languageId,
+			$$sessionId: data.sessionId,
 		} as const);
 	},
 

--- a/src/vs/editor/contrib/inlineCompletions/browser/model/inlineCompletionsModel.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/model/inlineCompletionsModel.ts
@@ -51,6 +51,7 @@ import { TypingInterval } from './typingSpeed.js';
 import { StringReplacement } from '../../../../common/core/edits/stringEdit.js';
 import { OffsetRange } from '../../../../common/core/ranges/offsetRange.js';
 import { URI } from '../../../../../base/common/uri.js';
+import { ITelemetryService } from '../../../../../platform/telemetry/common/telemetry.js';
 
 export class InlineCompletionsModel extends Disposable {
 	private readonly _source;
@@ -114,7 +115,8 @@ export class InlineCompletionsModel extends Disposable {
 		@IAccessibilityService private readonly _accessibilityService: IAccessibilityService,
 		@ILanguageFeaturesService private readonly _languageFeaturesService: ILanguageFeaturesService,
 		@ICodeEditorService private readonly _codeEditorService: ICodeEditorService,
-		@IInlineCompletionsService private readonly _inlineCompletionsService: IInlineCompletionsService
+		@IInlineCompletionsService private readonly _inlineCompletionsService: IInlineCompletionsService,
+		@ITelemetryService private readonly _telemetryService: ITelemetryService
 	) {
 		super();
 		this._source = this._register(this._instantiationService.createInstance(InlineCompletionsSource, this.textModel, this._textModelVersionId, this._debounceValue, this.primaryPosition));
@@ -848,6 +850,7 @@ export class InlineCompletionsModel extends Disposable {
 	public async previous(): Promise<void> { await this._deltaSelectedInlineCompletionIndex(-1); }
 
 	private _getMetadata(completion: InlineSuggestionItem, languageId: string, type: 'word' | 'line' | undefined = undefined): TextModelEditSource {
+		const sessionId = this._telemetryService.sessionId;
 		if (type) {
 			return EditSources.inlineCompletionPartialAccept({
 				nes: completion.isInlineEdit,
@@ -855,13 +858,15 @@ export class InlineCompletionsModel extends Disposable {
 				providerId: completion.source.provider.providerId,
 				languageId,
 				type,
+				sessionId,
 			});
 		} else {
 			return EditSources.inlineCompletionAccept({
 				nes: completion.isInlineEdit,
 				requestUuid: completion.requestUuid,
 				providerId: completion.source.provider.providerId,
-				languageId
+				languageId,
+				sessionId,
 			});
 		}
 	}

--- a/src/vs/workbench/contrib/chat/common/chatServiceTelemetry.ts
+++ b/src/vs/workbench/contrib/chat/common/chatServiceTelemetry.ts
@@ -102,6 +102,26 @@ type ChatTerminalClassification = {
 	comment: 'Provides insight into the usage of Chat features.';
 };
 
+type ChatCompletionEvent = {
+	agentId: string;
+	command: string | undefined;
+	sessionId: string;
+	requestId: string;
+	completionType: 'inline' | 'block';
+	charactersAccepted: number;
+};
+
+type ChatCompletionClassification = {
+	agentId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The ID of the chat agent that provided the completion.' };
+	command: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The name of the slash command that generated the completion.' };
+	sessionId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The chat session ID.' };
+	requestId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The request ID for this completion.' };
+	completionType: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Whether this was an inline completion or block completion.' };
+	charactersAccepted: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The number of characters accepted from the completion.'; isMeasurement: true };
+	owner: 'roblourens';
+	comment: 'Provides insight into the usage of Chat completions.';
+};
+
 type ChatFollowupsRetrievedEvent = {
 	agentId: string;
 	command: string | undefined;
@@ -229,6 +249,17 @@ export class ChatServiceTelemetry {
 			agentId,
 			command,
 			numFollowups,
+		});
+	}
+
+	completionAccepted(agentId: string, command: string | undefined, sessionId: string, requestId: string, completionType: 'inline' | 'block', charactersAccepted: number): void {
+		this.telemetryService.publicLog2<ChatCompletionEvent, ChatCompletionClassification>('chatCompletionAccepted', {
+			agentId,
+			command,
+			sessionId,
+			requestId,
+			completionType,
+			charactersAccepted,
 		});
 	}
 }

--- a/src/vs/workbench/contrib/editTelemetry/browser/telemetry/arcTelemetrySender.ts
+++ b/src/vs/workbench/contrib/editTelemetry/browser/telemetry/arcTelemetrySender.ts
@@ -48,6 +48,7 @@ export class InlineEditArcTelemetrySender extends Disposable {
 					extensionId: string;
 					extensionVersion: string;
 					opportunityId: string;
+					sessionId: string | undefined;
 					languageId: string;
 					didBranchChange: number;
 					timeDelayMs: number;
@@ -65,6 +66,7 @@ export class InlineEditArcTelemetrySender extends Disposable {
 					extensionId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The extension id (copilot or copilot-chat); which provided this inline completion.' };
 					extensionVersion: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The version of the extension.' };
 					opportunityId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Unique identifier for an opportunity to show an inline completion or NES.' };
+					sessionId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The session id for this inline completion.' };
 					languageId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The language id of the document.' };
 
 					didBranchChange: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Indicates if the branch changed in the meantime. If the branch changed (value is 1); this event should probably be ignored.' };
@@ -80,6 +82,7 @@ export class InlineEditArcTelemetrySender extends Disposable {
 					extensionId: data.$extensionId ?? '',
 					extensionVersion: data.$extensionVersion ?? '',
 					opportunityId: data.$$requestUuid ?? 'unknown',
+					sessionId: data.$$sessionId,
 					languageId: data.$$languageId,
 					didBranchChange: res.didBranchChange ? 1 : 0,
 					timeDelayMs: res.timeDelayMs,


### PR DESCRIPTION
- Add sessionId parameter to inlineCompletionAccept and inlineCompletionPartialAccept in EditSources
- Include session ID in inline completion telemetry events
- Add new chatCompletionAccepted telemetry event for completions from chat
- Enhance InlineEditArcTelemetrySender to include session ID in telemetry

Addresses issues #265831 and #265829

This change improves telemetry tracking by including session IDs in completion events, enabling better analysis of user behavior across sessions.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
