### PR TITLE
fix: race condition on supported task types

### DIFF
--- a/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts
+++ b/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts
@@ -432,7 +432,7 @@ export abstract class AbstractTaskService extends Disposable implements ITaskSer
 		// update tasks so an incomplete list isn't returned when getWorkspaceTasks is called
 		this._workspaceTasksPromise = undefined;
 		this._onDidRegisterSupportedExecutions.fire();
-		if (Platform.isWeb || (custom && shell && process)) {
+		if (ServerlessWebContext.getValue(this._contextKeyService) || (custom && shell && process)) {
 			this._onDidRegisterAllSupportedExecutions.fire();
 		}
 	}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

fix #265845

In https://github.com/microsoft/vscode/pull/212163, the `registerSupportedExecutions` was changed so that in web mode, the function doesn't wait for all default task extensions registration before running the task, because in web mode, only the `custom` mode is supported.

However, when there is a remote server, the server will register the support for all task execution types, but later.

A race condition can happen, in which the tasks are parsed before the server reports the supported task executions, leading to a `Warning: shell tasks are unavailable in the current environment.` error.

This PR makes the `registerSupportedExecutions` method wait for all task supported executions in web mode when there is a remote agent.
