### PR TITLE
Marking a few more events in vscode.d.ts readonly

### DIFF
--- a/src/vscode-dts/vscode.d.ts
+++ b/src/vscode-dts/vscode.d.ts
@@ -20867,7 +20867,6 @@ declare module 'vscode' {
 		 * Options to hint at how many tokens the tool should return in its response, and enable the tool to count tokens
 		 * accurately.
 		 */
-		// TODO api: how does this work if the model also has a countTokens?
 		tokenizationOptions?: LanguageModelToolTokenizationOptions;
 	}
 
@@ -20934,7 +20933,6 @@ declare module 'vscode' {
 		 *
 		 * The provided {@link LanguageModelToolInvocationOptions.input} has been validated against the declared schema.
 		 */
-		// TODO:API Should model always be required here?
 		invoke(options: LanguageModelToolInvocationOptions<T>, token: CancellationToken): ProviderResult<LanguageModelToolResult>;
 
 		/**

--- a/src/vscode-dts/vscode.d.ts
+++ b/src/vscode-dts/vscode.d.ts
@@ -1666,7 +1666,7 @@ declare module 'vscode' {
 		/**
 		 * An {@link Event} which fires upon cancellation.
 		 */
-		onCancellationRequested: Event<any>;
+		readonly onCancellationRequested: Event<any>;
 	}
 
 	/**
@@ -8603,7 +8603,7 @@ declare module 'vscode' {
 		/**
 		 * Fires when a secret is stored or deleted.
 		 */
-		onDidChange: Event<SecretStorageChangeEvent>;
+		readonly onDidChange: Event<SecretStorageChangeEvent>;
 	}
 
 	/**
@@ -13069,7 +13069,7 @@ declare module 'vscode' {
 		 * (Examples include: an explicit call to {@link QuickInput.hide},
 		 * the user pressing Esc, some other input UI opening, etc.)
 		 */
-		onDidHide: Event<void>;
+		readonly onDidHide: Event<void>;
 
 		/**
 		 * Dispose of this input UI and any associated resources. If it is still
@@ -18184,7 +18184,7 @@ declare module 'vscode' {
 		 * Fired when a user has changed whether this is a default profile. The
 		 * event contains the new value of {@link isDefault}
 		 */
-		onDidChangeDefault: Event<boolean>;
+		readonly onDidChangeDefault: Event<boolean>;
 
 		/**
 		 * Whether this profile supports continuous running of requests. If so,
@@ -18563,7 +18563,7 @@ declare module 'vscode' {
 		 * An event fired when the editor is no longer interested in data
 		 * associated with the test run.
 		 */
-		onDidDispose: Event<void>;
+		readonly onDidDispose: Event<void>;
 	}
 
 	/**
@@ -19639,7 +19639,7 @@ declare module 'vscode' {
 		 * The passed {@link ChatResultFeedback.result result} is guaranteed to have the same properties as the result that was
 		 * previously returned from this chat participant's handler.
 		 */
-		onDidReceiveFeedback: Event<ChatResultFeedback>;
+		readonly onDidReceiveFeedback: Event<ChatResultFeedback>;
 
 		/**
 		 * Dispose this participant and free resources.
@@ -20678,7 +20678,7 @@ declare module 'vscode' {
 		/**
 		 * An event that fires when access information changes.
 		 */
-		onDidChange: Event<void>;
+		readonly onDidChange: Event<void>;
 
 		/**
 		 * Checks if a request can be made to a language model.
@@ -20867,6 +20867,7 @@ declare module 'vscode' {
 		 * Options to hint at how many tokens the tool should return in its response, and enable the tool to count tokens
 		 * accurately.
 		 */
+		// TODO api: how does this work if the model also has a countTokens?
 		tokenizationOptions?: LanguageModelToolTokenizationOptions;
 	}
 
@@ -20933,6 +20934,7 @@ declare module 'vscode' {
 		 *
 		 * The provided {@link LanguageModelToolInvocationOptions.input} has been validated against the declared schema.
 		 */
+		// TODO:API Should model always be required here?
 		invoke(options: LanguageModelToolInvocationOptions<T>, token: CancellationToken): ProviderResult<LanguageModelToolResult>;
 
 		/**


### PR DESCRIPTION
These should only be used for registration, never overwritten

