### PR TITLE
add dictation actions to terminal overflow menu

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminalMenus.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalMenus.ts
@@ -33,8 +33,7 @@ export const enum TerminalMenuBarGroup {
 	Create = '1_create',
 	Run = '3_run',
 	Manage = '5_manage',
-	Configure = '7_configure',
-	Voice = '9_voice'
+	Configure = '7_configure'
 }
 
 export function setupTerminalMenus(): void {
@@ -108,7 +107,7 @@ export function setupTerminalMenus(): void {
 						id: TerminalCommandId.StartVoice,
 						title: localize('workbench.action.terminal.startVoice', "Start Dictation"),
 					},
-					group: TerminalMenuBarGroup.Voice,
+					group: 'navigation',
 					order: 5,
 					when: HasSpeechProvider,
 					isHiddenByDefault: true
@@ -121,7 +120,7 @@ export function setupTerminalMenus(): void {
 						id: TerminalCommandId.StopVoice,
 						title: localize('workbench.action.terminal.stopVoice', "Stop Dictation"),
 					},
-					group: TerminalMenuBarGroup.Voice,
+					group: 'navigation',
 					order: 6,
 					when: HasSpeechProvider,
 					isHiddenByDefault: true

--- a/src/vs/workbench/contrib/terminal/browser/terminalMenus.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalMenus.ts
@@ -18,6 +18,7 @@ import { TerminalContextKeys, TerminalContextKeyStrings } from '../common/termin
 import { terminalStrings } from '../common/terminalStrings.js';
 import { ACTIVE_GROUP, AUX_WINDOW_GROUP, SIDE_GROUP } from '../../../services/editor/common/editorService.js';
 import { DisposableStore } from '../../../../base/common/lifecycle.js';
+import { HasSpeechProvider } from '../../speech/common/speechService.js';
 
 export const enum TerminalContextMenuGroup {
 	Chat = '0_chat',
@@ -32,7 +33,8 @@ export const enum TerminalMenuBarGroup {
 	Create = '1_create',
 	Run = '3_run',
 	Manage = '5_manage',
-	Configure = '7_configure'
+	Configure = '7_configure',
+	Voice = '9_voice'
 }
 
 export function setupTerminalMenus(): void {
@@ -98,7 +100,33 @@ export function setupTerminalMenus(): void {
 					order: 4,
 					when: TerminalContextKeys.processSupported
 				}
-			}
+			},
+			{
+				id: MenuId.ViewTitle,
+				item: {
+					command: {
+						id: TerminalCommandId.StartVoice,
+						title: localize('workbench.action.terminal.startVoice', "Start Dictation"),
+					},
+					group: TerminalMenuBarGroup.Voice,
+					order: 5,
+					when: HasSpeechProvider,
+					isHiddenByDefault: true
+				}
+			},
+			{
+				id: MenuId.ViewTitle,
+				item: {
+					command: {
+						id: TerminalCommandId.StopVoice,
+						title: localize('workbench.action.terminal.stopVoice', "Stop Dictation"),
+					},
+					group: TerminalMenuBarGroup.Voice,
+					order: 6,
+					when: HasSpeechProvider,
+					isHiddenByDefault: true
+				}
+			},
 		]
 	);
 
@@ -724,6 +752,28 @@ export function setupTerminalMenus(): void {
 			group: 'navigation',
 			order: 8,
 			when: ResourceContextKey.Scheme.isEqualTo(Schemas.vscodeTerminal),
+			isHiddenByDefault: true
+		});
+		MenuRegistry.appendMenuItem(menuId, {
+			command: {
+				id: TerminalCommandId.StartVoice,
+				title: localize('workbench.action.terminal.startVoice', "Start Dictation"),
+				icon: Codicon.run
+			},
+			group: 'navigation',
+			order: 9,
+			when: ContextKeyExpr.and(ResourceContextKey.Scheme.isEqualTo(Schemas.vscodeTerminal), HasSpeechProvider),
+			isHiddenByDefault: true
+		});
+		MenuRegistry.appendMenuItem(menuId, {
+			command: {
+				id: TerminalCommandId.StopVoice,
+				title: localize('workbench.action.terminal.stopVoice', "Stop Dictation"),
+				icon: Codicon.run
+			},
+			group: 'navigation',
+			order: 10,
+			when: ContextKeyExpr.and(ResourceContextKey.Scheme.isEqualTo(Schemas.vscodeTerminal), HasSpeechProvider),
 			isHiddenByDefault: true
 		});
 	}


### PR DESCRIPTION
fix #265805 (also added it to the editor's menu)

<img width="703" height="391" alt="Screenshot 2025-09-09 at 2 53 14 PM" src="https://github.com/user-attachments/assets/8a7a66f8-9f57-42ad-88d1-4adc2b64f903" />

