### PR TITLE
Fix images in release notes

### DIFF
--- a/src/vs/base/browser/domSanitize.ts
+++ b/src/vs/base/browser/domSanitize.ts
@@ -113,22 +113,40 @@ function addDompurifyHook(hook: 'uponSanitizeElement' | 'uponSanitizeAttribute',
 	return toDisposable(() => dompurify.removeHook(hook));
 }
 
+const fakeRelativeUrlProtocol = 'vscode-relative-path';
+
+interface AllowedLinksConfig {
+	readonly override: readonly string[] | '*';
+	readonly allowRelativePaths: boolean;
+}
+
 /**
  * Hooks dompurify using `afterSanitizeAttributes` to check that all `href` and `src`
  * attributes are valid.
  */
-function hookDomPurifyHrefAndSrcSanitizer(allowedLinkProtocols: readonly string[] | '*', allowedMediaProtocols: readonly string[] | '*'): IDisposable {
-	// https://github.com/cure53/DOMPurify/blob/main/demos/hooks-scheme-allowlist.html
-	// build an anchor to map URLs to
-	const anchor = document.createElement('a');
-
-	function validateLink(value: string, allowedProtocols: readonly string[] | '*'): boolean {
-		if (allowedProtocols === '*') {
+function hookDomPurifyHrefAndSrcSanitizer(allowedLinkProtocols: AllowedLinksConfig, allowedMediaProtocols: AllowedLinksConfig): IDisposable {
+	function validateLink(value: string, allowedProtocols: AllowedLinksConfig): boolean {
+		if (allowedProtocols.override === '*') {
 			return true; // allow all protocols
 		}
 
-		anchor.href = value;
-		return allowedProtocols.includes(anchor.protocol.replace(/:$/, ''));
+		try {
+			const url = new URL(value, fakeRelativeUrlProtocol + '://');
+			if (allowedProtocols.override.includes(url.protocol.replace(/:$/, ''))) {
+				return true;
+			}
+
+			if (allowedProtocols.allowRelativePaths
+				&& url.protocol === fakeRelativeUrlProtocol + ':'
+				&& !value.trim().toLowerCase().startsWith(fakeRelativeUrlProtocol)
+			) {
+				return true;
+			}
+
+			return false;
+		} catch (e) {
+			return false;
+		}
 	}
 
 	dompurify.addHook('afterSanitizeAttributes', (node) => {
@@ -137,12 +155,11 @@ function hookDomPurifyHrefAndSrcSanitizer(allowedLinkProtocols: readonly string[
 			if (node.hasAttribute(attr)) {
 				const attrValue = node.getAttribute(attr) as string;
 				if (attr === 'href') {
-
 					if (!attrValue.startsWith('#') && !validateLink(attrValue, allowedLinkProtocols)) {
 						node.removeAttribute(attr);
 					}
 
-				} else {// 'src'
+				} else { // 'src'
 					if (!validateLink(attrValue, allowedMediaProtocols)) {
 						node.removeAttribute(attr);
 					}
@@ -165,6 +182,7 @@ export interface SanitizeAttributeRule {
 	readonly attributeName: string;
 	shouldKeep: SanitizeAttributePredicate;
 }
+
 
 export interface DomSanitizerConfig {
 	/**
@@ -191,11 +209,21 @@ export interface DomSanitizerConfig {
 	};
 
 	/**
+	 * If set, allows relative paths for links.
+	 */
+	readonly allowRelativeLinkPaths?: boolean;
+
+	/**
 	 * List of allowed protocols for `src` attributes.
 	 */
 	readonly allowedMediaProtocols?: {
 		readonly override?: readonly string[] | '*';
 	};
+
+	/**
+	 * If set, allows relative paths for media (images, videos, etc).
+	 */
+	readonly allowRelativeMediaPaths?: boolean;
 
 	/**
 	 * If set, replaces unsupported tags with their plaintext representation instead of removing them.
@@ -277,9 +305,14 @@ function doSanitizeHtml(untrusted: string, config: DomSanitizerConfig | undefine
 		resolvedConfig.ALLOWED_ATTR = Array.from(allowedAttrNames);
 
 		store.add(hookDomPurifyHrefAndSrcSanitizer(
-			config?.allowedLinkProtocols?.override ?? [Schemas.http, Schemas.https],
-			config?.allowedMediaProtocols?.override ?? [Schemas.http, Schemas.https]));
-
+			{
+				override: config?.allowedLinkProtocols?.override ?? [Schemas.http, Schemas.https],
+				allowRelativePaths: config?.allowRelativeLinkPaths ?? false
+			},
+			{
+				override: config?.allowedMediaProtocols?.override ?? [Schemas.http, Schemas.https],
+				allowRelativePaths: config?.allowRelativeMediaPaths ?? false
+			}));
 		if (config?.replaceWithPlaintext) {
 			store.add(addDompurifyHook('uponSanitizeElement', replaceWithPlainTextHook));
 		}

--- a/src/vs/base/browser/domSanitize.ts
+++ b/src/vs/base/browser/domSanitize.ts
@@ -117,7 +117,7 @@ function addDompurifyHook(hook: 'uponSanitizeElement' | 'uponSanitizeAttribute',
  * Hooks dompurify using `afterSanitizeAttributes` to check that all `href` and `src`
  * attributes are valid.
  */
-function hookDomPurifyHrefAndSrcSanitizer(allowedLinkProtocols: readonly string[] | '*', allowedMediaProtocols: readonly string[]): IDisposable {
+function hookDomPurifyHrefAndSrcSanitizer(allowedLinkProtocols: readonly string[] | '*', allowedMediaProtocols: readonly string[] | '*'): IDisposable {
 	// https://github.com/cure53/DOMPurify/blob/main/demos/hooks-scheme-allowlist.html
 	// build an anchor to map URLs to
 	const anchor = document.createElement('a');
@@ -194,7 +194,7 @@ export interface DomSanitizerConfig {
 	 * List of allowed protocols for `src` attributes.
 	 */
 	readonly allowedMediaProtocols?: {
-		readonly override?: readonly string[];
+		readonly override?: readonly string[] | '*';
 	};
 
 	/**

--- a/src/vs/base/test/browser/domSanitize.test.ts
+++ b/src/vs/base/test/browser/domSanitize.test.ts
@@ -99,9 +99,8 @@ suite('DomSanitize', () => {
 	test('allows safe protocols for href', () => {
 		const html = '<a href="https://example.com">safe link</a>';
 		const result = sanitizeHtml(html);
-		const str = result.toString();
 
-		assert.ok(str.includes('href="https://example.com"'));
+		assert.ok(result.toString().includes('href="https://example.com"'));
 	});
 
 	test('allows fragment links', () => {
@@ -126,9 +125,22 @@ suite('DomSanitize', () => {
 		const result = sanitizeHtml(html, {
 			allowedMediaProtocols: { override: [Schemas.data] }
 		});
-		const str = result.toString();
 
-		assert.ok(str.includes('src="data:image/png;base64,'));
+		assert.ok(result.toString().includes('src="data:image/png;base64,'));
+	});
+
+	test('Removes relative paths for img src by default', () => {
+		const html = '<img src="path/img.png">';
+		const result = sanitizeHtml(html);
+		assert.strictEqual(result.toString(), '<img>');
+	});
+
+	test('Can allow relative paths for image', () => {
+		const html = '<img src="path/img.png">';
+		const result = sanitizeHtml(html, {
+			allowRelativeMediaPaths: true,
+		});
+		assert.strictEqual(result.toString(), '<img src="path/img.png">');
 	});
 
 	test('Supports dynamic attribute sanitization', () => {
@@ -145,8 +157,7 @@ suite('DomSanitize', () => {
 				]
 			}
 		});
-		const str = result.toString();
-		assert.strictEqual(str, '<div>text1</div><div title="b">text2</div>');
+		assert.strictEqual(result.toString(), '<div>text1</div><div title="b">text2</div>');
 	});
 
 	test('Supports changing attributes in dynamic sanitization', () => {

--- a/src/vs/workbench/contrib/markdown/browser/markdownDocumentRenderer.ts
+++ b/src/vs/workbench/contrib/markdown/browser/markdownDocumentRenderer.ts
@@ -167,7 +167,9 @@ function sanitize(documentContent: string, sanitizerConfig: MarkdownDocumentSani
 		allowedLinkProtocols: {
 			override: sanitizerConfig?.allowedLinkProtocols?.override ?? defaultAllowedLinkProtocols,
 		},
+		allowRelativeLinkPaths: sanitizerConfig?.allowRelativeLinkPaths,
 		allowedMediaProtocols: sanitizerConfig?.allowedMediaProtocols,
+		allowRelativeMediaPaths: sanitizerConfig?.allowRelativeMediaPaths,
 		allowedTags: {
 			override: allowedMarkdownHtmlTags,
 			augment: sanitizerConfig?.allowedTags?.augment
@@ -191,12 +193,17 @@ interface MarkdownDocumentSanitizerConfig {
 	readonly allowedLinkProtocols?: {
 		readonly override: readonly string[] | '*';
 	};
+	readonly allowRelativeLinkPaths?: boolean;
+
 	readonly allowedMediaProtocols?: {
 		readonly override: readonly string[] | '*';
 	};
+	readonly allowRelativeMediaPaths?: boolean;
+
 	readonly allowedTags?: {
 		readonly augment: readonly string[];
 	};
+
 	readonly allowedAttributes?: {
 		readonly augment: readonly string[];
 	};

--- a/src/vs/workbench/contrib/markdown/browser/markdownDocumentRenderer.ts
+++ b/src/vs/workbench/contrib/markdown/browser/markdownDocumentRenderer.ts
@@ -167,6 +167,7 @@ function sanitize(documentContent: string, sanitizerConfig: MarkdownDocumentSani
 		allowedLinkProtocols: {
 			override: sanitizerConfig?.allowedLinkProtocols?.override ?? defaultAllowedLinkProtocols,
 		},
+		allowedMediaProtocols: sanitizerConfig?.allowedMediaProtocols,
 		allowedTags: {
 			override: allowedMarkdownHtmlTags,
 			augment: sanitizerConfig?.allowedTags?.augment
@@ -188,6 +189,9 @@ function sanitize(documentContent: string, sanitizerConfig: MarkdownDocumentSani
 
 interface MarkdownDocumentSanitizerConfig {
 	readonly allowedLinkProtocols?: {
+		readonly override: readonly string[] | '*';
+	};
+	readonly allowedMediaProtocols?: {
 		readonly override: readonly string[] | '*';
 	};
 	readonly allowedTags?: {

--- a/src/vs/workbench/contrib/markdown/test/browser/markdownDocumentRenderer.test.ts
+++ b/src/vs/workbench/contrib/markdown/test/browser/markdownDocumentRenderer.test.ts
@@ -1,0 +1,41 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { ILanguageService } from '../../../../../editor/common/languages/language.js';
+import { createCodeEditorServices } from '../../../../../editor/test/browser/testCodeEditor.js';
+import { TestInstantiationService } from '../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
+import { IExtensionService } from '../../../../services/extensions/common/extensions.js';
+import { renderMarkdownDocument } from '../../browser/markdownDocumentRenderer.js';
+
+
+suite('Markdown Document Renderer Test', () => {
+	const store = ensureNoDisposablesAreLeakedInTestSuite();
+
+	let instantiationService: TestInstantiationService;
+	let extensionService: IExtensionService;
+	let languageService: ILanguageService;
+
+	setup(() => {
+		instantiationService = createCodeEditorServices(store);
+		extensionService = instantiationService.get(IExtensionService);
+		languageService = instantiationService.get(ILanguageService);
+	});
+
+	test('Should remove images with relative paths by default', async () => {
+		const result = await renderMarkdownDocument('![alt](src/img.png)', extensionService, languageService, {});
+		assert.strictEqual(result.toString(), `<p><img alt="alt"></p>\n`);
+	});
+
+	test('Can enable images with relative paths using setting', async () => {
+		const result = await renderMarkdownDocument('![alt](src/img.png)', extensionService, languageService, {
+			sanitizerConfig: {
+				allowRelativeMediaPaths: true,
+			}
+		});
+
+		assert.strictEqual(result.toString(), `<p><img alt="alt" src="src/img.png"></p>\n`);
+	});
+});

--- a/src/vs/workbench/contrib/update/browser/releaseNotesEditor.ts
+++ b/src/vs/workbench/contrib/update/browser/releaseNotesEditor.ts
@@ -91,7 +91,7 @@ export class ReleaseNotesManager extends Disposable {
 	}
 
 	public async show(version: string, useCurrentFile: boolean): Promise<boolean> {
-		const releaseNoteText = await this.loadReleaseNotes('1.103.0', useCurrentFile);
+		const releaseNoteText = await this.loadReleaseNotes(version, useCurrentFile);
 		const base = await this.getBase(useCurrentFile);
 		this._lastMeta = { text: releaseNoteText, base };
 		const html = await this.renderBody(this._lastMeta);

--- a/src/vs/workbench/contrib/update/browser/releaseNotesEditor.ts
+++ b/src/vs/workbench/contrib/update/browser/releaseNotesEditor.ts
@@ -91,7 +91,7 @@ export class ReleaseNotesManager extends Disposable {
 	}
 
 	public async show(version: string, useCurrentFile: boolean): Promise<boolean> {
-		const releaseNoteText = await this.loadReleaseNotes(version, useCurrentFile);
+		const releaseNoteText = await this.loadReleaseNotes('1.103.0', useCurrentFile);
 		const base = await this.getBase(useCurrentFile);
 		this._lastMeta = { text: releaseNoteText, base };
 		const html = await this.renderBody(this._lastMeta);
@@ -267,6 +267,9 @@ export class ReleaseNotesManager extends Disposable {
 
 		const content = await renderMarkdownDocument(fileContent.text, this._extensionService, this._languageService, {
 			sanitizerConfig: {
+				allowedMediaProtocols: {
+					override: '*' // TODO: remove once we can use <base> to find real resource locations
+				},
 				allowedLinkProtocols: {
 					override: [Schemas.http, Schemas.https, Schemas.command]
 				}

--- a/src/vs/workbench/contrib/update/browser/releaseNotesEditor.ts
+++ b/src/vs/workbench/contrib/update/browser/releaseNotesEditor.ts
@@ -267,9 +267,7 @@ export class ReleaseNotesManager extends Disposable {
 
 		const content = await renderMarkdownDocument(fileContent.text, this._extensionService, this._languageService, {
 			sanitizerConfig: {
-				allowedMediaProtocols: {
-					override: '*' // TODO: remove once we can use <base> to find real resource locations
-				},
+				allowRelativeMediaPaths: true,
 				allowedLinkProtocols: {
 					override: [Schemas.http, Schemas.https, Schemas.command]
 				}


### PR DESCRIPTION
For  #265932

This is a more complete fix that adds new options to preserve relative paths during sanitization. The candidate was much smaller and more targeted 
