### PR TITLE
Add configuration for todo list widget position in chat and enable todo tool by default

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -615,10 +615,16 @@ configurationRegistry.registerConfiguration({
 				mode: 'auto'
 			}
 		},
-		'chat.todoListTool.enabled': {
-			type: 'boolean',
-			default: false,
-			description: nls.localize('chat.todoListTool.enabled', "Enables todo lists in chat, which the agent uses as a tool for planning, progress tracking, and context management for complex development workflows."),
+		'chat.todoListWidget.position': {
+			type: 'string',
+			default: 'default',
+			enum: ['default', 'off', 'chat-input'],
+			enumDescriptions: [
+				nls.localize('chat.todoListWidget.position.default', "Show todo list widget in the default position at the top of the chat panel."),
+				nls.localize('chat.todoListWidget.position.off', "Hide the todo list widget."),
+				nls.localize('chat.todoListWidget.position.chatInput', "Show todo list widget near the chat input.")
+			],
+			description: nls.localize('chat.todoListWidget.position', "Controls the position of the todo list widget in chat."),
 			tags: ['experimental'],
 			experiment: {
 				mode: 'auto'

--- a/src/vs/workbench/contrib/chat/browser/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatWidget.ts
@@ -60,14 +60,13 @@ import { ChatRequestVariableSet, IChatRequestVariableEntry, isPromptFileVariable
 import { ChatViewModel, IChatRequestViewModel, IChatResponseViewModel, isRequestVM, isResponseVM } from '../common/chatViewModel.js';
 import { IChatInputState } from '../common/chatWidgetHistoryService.js';
 import { CodeBlockModelCollection } from '../common/codeBlockModelCollection.js';
-import { ChatAgentLocation, ChatConfiguration, ChatModeKind } from '../common/constants.js';
+import { ChatAgentLocation, ChatConfiguration, ChatModeKind, TodoListWidgetPositionSettingId } from '../common/constants.js';
 import { ILanguageModelToolsService, IToolData, ToolSet } from '../common/languageModelToolsService.js';
 import { ComputeAutomaticInstructions } from '../common/promptSyntax/computeAutomaticInstructions.js';
 import { PromptsConfig } from '../common/promptSyntax/config/config.js';
 import { type TPromptMetadata } from '../common/promptSyntax/parsers/promptHeader/promptHeader.js';
 import { PromptsType } from '../common/promptSyntax/promptTypes.js';
 import { IPromptParserResult, IPromptsService } from '../common/promptSyntax/service/promptsService.js';
-import { TodoListToolSettingId } from '../common/tools/manageTodoListTool.js';
 import { handleModeSwitch } from './actions/chatActions.js';
 import { ChatTreeItem, IChatAcceptInputOptions, IChatAccessibilityService, IChatCodeBlockInfo, IChatFileTreeInfo, IChatListItemRendererOptions, IChatWidget, IChatWidgetService, IChatWidgetViewContext, IChatWidgetViewOptions, ChatViewId } from './chat.js';
 import { ChatAccessibilityProvider } from './chatAccessibilityProvider.js';
@@ -1128,8 +1127,8 @@ export class ChatWidget extends Disposable implements IChatWidget {
 			return;
 		}
 
-		const isChatTodoListToolEnabled = this.configurationService.getValue<boolean>(TodoListToolSettingId) === true;
-		if (!isChatTodoListToolEnabled) {
+		const todoListWidgetPosition = this.configurationService.getValue<string>(TodoListWidgetPositionSettingId) || 'default';
+		if (todoListWidgetPosition !== 'default') {
 			return;
 		}
 

--- a/src/vs/workbench/contrib/chat/common/constants.ts
+++ b/src/vs/workbench/contrib/chat/common/constants.ts
@@ -82,3 +82,5 @@ export namespace ChatAgentLocation {
 }
 
 export const ChatUnsupportedFileSchemes = new Set([Schemas.vscodeChatEditor, Schemas.walkThrough, Schemas.vscodeChatSession, 'ccreq']);
+
+export const TodoListWidgetPositionSettingId = 'chat.todoListWidget.position';

--- a/src/vs/workbench/contrib/chat/common/tools/manageTodoListTool.ts
+++ b/src/vs/workbench/contrib/chat/common/tools/manageTodoListTool.ts
@@ -19,12 +19,9 @@ import {
 import { ILogService } from '../../../../../platform/log/common/log.js';
 import { ITelemetryService } from '../../../../../platform/telemetry/common/telemetry.js';
 import { IChatTodo, IChatTodoListService } from '../chatTodoListService.js';
-import { ContextKeyExpr } from '../../../../../platform/contextkey/common/contextkey.js';
-import { IsSimulationContext } from '../../../../../platform/contextkey/common/contextkeys.js';
 import { localize } from '../../../../../nls.js';
 import { MarkdownString } from '../../../../../base/common/htmlContent.js';
 
-export const TodoListToolSettingId = 'chat.todoListTool.enabled';
 export const TodoListToolWriteOnlySettingId = 'chat.todoListTool.writeOnly';
 
 export const ManageTodoListToolToolId = 'manage_todo_list';
@@ -78,10 +75,6 @@ export function createManageTodoListToolData(writeOnly: boolean): IToolData {
 	return {
 		id: ManageTodoListToolToolId,
 		toolReferenceName: 'todos',
-		when: ContextKeyExpr.or(
-			ContextKeyExpr.equals(`config.${TodoListToolSettingId}`, true),
-			IsSimulationContext
-		),
 		canBeReferencedInPrompt: true,
 		icon: ThemeIcon.fromId(Codicon.checklist.id),
 		displayName: localize('tool.manageTodoList.displayName', 'Manage and track todo items for task planning'),

--- a/src/vs/workbench/contrib/inlineChat/test/browser/inlineChatController.test.ts
+++ b/src/vs/workbench/contrib/inlineChat/test/browser/inlineChatController.test.ts
@@ -59,6 +59,7 @@ import { IChatEditingService, IChatEditingSession } from '../../../chat/common/c
 import { IChatEntitlementService } from '../../../../services/chat/common/chatEntitlementService.js';
 import { IChatLayoutService } from '../../../chat/common/chatLayoutService.js';
 import { IChatModeService } from '../../../chat/common/chatModes.js';
+import { IChatTodo, IChatTodoListService } from '../../../chat/common/chatTodoListService.js';
 import { IChatProgress, IChatService } from '../../../chat/common/chatService.js';
 import { ChatService } from '../../../chat/common/chatServiceImpl.js';
 import { ChatSlashCommandService, IChatSlashCommandService } from '../../../chat/common/chatSlashCommands.js';
@@ -218,6 +219,10 @@ suite('InlineChatController', function () {
 			[IChatEntitlementService, new class extends mock<IChatEntitlementService>() { }],
 			[IChatModeService, new SyncDescriptor(MockChatModeService)],
 			[IChatLayoutService, new SyncDescriptor(ChatLayoutService)],
+			[IChatTodoListService, new class extends mock<IChatTodoListService>() {
+				override getTodos(sessionId: string): IChatTodo[] { return []; }
+				override setTodos(sessionId: string, todos: IChatTodo[]): void { }
+			}],
 		);
 
 		instaService = store.add((store.add(workbenchInstantiationService(undefined, store))).createChild(serviceCollection));


### PR DESCRIPTION
Updated test. The todo tool is not enabled in inline chat mode. Just fixing up the service for test.