### PR TITLE
OSC 8 hyperlink should open VS Code file explorer if inside cwd

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/links/browser/terminalLinkManager.ts
+++ b/src/vs/workbench/contrib/terminalContrib/links/browser/terminalLinkManager.ts
@@ -128,6 +128,8 @@ export class TerminalLinkManager extends DisposableStore {
 						}
 					]);
 				}
+				// This doesnt get called for the RESULT of OSC 8 hyperlink to folder.
+				// It DOES, however, gets called if I just click an echo `folder_inside_my_current_workspace`, for example.
 				this._openers.get(TerminalBuiltinLinkType.Url)?.open({
 					type: TerminalBuiltinLinkType.Url,
 					text,

--- a/src/vs/workbench/contrib/terminalContrib/links/browser/terminalLinkManager.ts
+++ b/src/vs/workbench/contrib/terminalContrib/links/browser/terminalLinkManager.ts
@@ -128,8 +128,6 @@ export class TerminalLinkManager extends DisposableStore {
 						}
 					]);
 				}
-				// This doesnt get called for the RESULT of OSC 8 hyperlink to folder.
-				// It DOES, however, gets called if I just click an echo `folder_inside_my_current_workspace`, for example.
 				this._openers.get(TerminalBuiltinLinkType.Url)?.open({
 					type: TerminalBuiltinLinkType.Url,
 					text,

--- a/src/vs/workbench/contrib/terminalContrib/links/browser/terminalLinkManager.ts
+++ b/src/vs/workbench/contrib/terminalContrib/links/browser/terminalLinkManager.ts
@@ -87,11 +87,12 @@ export class TerminalLinkManager extends DisposableStore {
 		// Setup link openers
 		const localFileOpener = this._instantiationService.createInstance(TerminalLocalFileLinkOpener);
 		const localFolderInWorkspaceOpener = this._instantiationService.createInstance(TerminalLocalFolderInWorkspaceLinkOpener);
+		const localFolderOutsideWorkspaceOpener = this._instantiationService.createInstance(TerminalLocalFolderOutsideWorkspaceLinkOpener);
 		this._openers.set(TerminalBuiltinLinkType.LocalFile, localFileOpener);
 		this._openers.set(TerminalBuiltinLinkType.LocalFolderInWorkspace, localFolderInWorkspaceOpener);
-		this._openers.set(TerminalBuiltinLinkType.LocalFolderOutsideWorkspace, this._instantiationService.createInstance(TerminalLocalFolderOutsideWorkspaceLinkOpener));
+		this._openers.set(TerminalBuiltinLinkType.LocalFolderOutsideWorkspace, localFolderOutsideWorkspaceOpener);
 		this._openers.set(TerminalBuiltinLinkType.Search, this._instantiationService.createInstance(TerminalSearchLinkOpener, capabilities, this._processInfo.initialCwd, localFileOpener, localFolderInWorkspaceOpener, () => this._processInfo.os || OS));
-		this._openers.set(TerminalBuiltinLinkType.Url, this._instantiationService.createInstance(TerminalUrlLinkOpener, !!this._processInfo.remoteAuthority, this._openers as Map<TerminalBuiltinLinkType, ITerminalLinkOpener>));
+		this._openers.set(TerminalBuiltinLinkType.Url, this._instantiationService.createInstance(TerminalUrlLinkOpener, !!this._processInfo.remoteAuthority, localFileOpener, localFolderInWorkspaceOpener, localFolderOutsideWorkspaceOpener));
 		this._registerStandardLinkProviders();
 
 		let activeHoverDisposable: IDisposable | undefined;

--- a/src/vs/workbench/contrib/terminalContrib/links/browser/terminalLinkOpeners.ts
+++ b/src/vs/workbench/contrib/terminalContrib/links/browser/terminalLinkOpeners.ts
@@ -326,30 +326,24 @@ export class TerminalUrlLinkOpener implements ITerminalLinkOpener {
 			switch (linkType) {
 				case TerminalBuiltinLinkType.LocalFile:
 					await this._localFileOpener.open(link);
-					break;
+					return;
 				case TerminalBuiltinLinkType.LocalFolderInWorkspace:
 					await this._localFolderInWorkspaceOpener.open(link);
-					break;
+					return;
 				case TerminalBuiltinLinkType.LocalFolderOutsideWorkspace:
 					await this._localFolderOutsideWorkspaceOpener.open(link);
-					break;
+					return;
 				case TerminalBuiltinLinkType.Url:
 					await this.open(link);
-					break;
-				default:
-					this._openerService.open(link.text, {
-						allowTunneling: this._isRemote && this._configurationService.getValue('remote.forwardOnOpen'),
-						allowContributedOpeners: true,
-						openExternal: true
-					});
-					break;
+					return;
 			}
 		} catch (error) {
-			this._openerService.open(link.text, {
-				allowTunneling: this._isRemote && this._configurationService.getValue('remote.forwardOnOpen'),
-				allowContributedOpeners: true,
-				openExternal: true
-			});
+			this._logService.warn('Open file via native file explorer');
 		}
+		this._openerService.open(link.text, {
+			allowTunneling: this._isRemote && this._configurationService.getValue('remote.forwardOnOpen'),
+			allowContributedOpeners: true,
+			openExternal: true
+		});
 	}
 }

--- a/src/vs/workbench/contrib/terminalContrib/links/browser/terminalLinkOpeners.ts
+++ b/src/vs/workbench/contrib/terminalContrib/links/browser/terminalLinkOpeners.ts
@@ -295,7 +295,7 @@ export class TerminalUrlLinkOpener implements ITerminalLinkOpener {
 			throw new Error('Tried to open a url without a resolved URI');
 		}
 		// Handle file:// URIs by delegating to appropriate file/folder openers
-		if (link.uri.scheme === 'file') {
+		if (link.uri.scheme === Schemas.file) {
 			return this._openFileSchemeLink(link);
 		}
 		// It's important to use the raw string value here to avoid converting pre-encoded values

--- a/src/vs/workbench/contrib/terminalContrib/links/browser/terminalLinkOpeners.ts
+++ b/src/vs/workbench/contrib/terminalContrib/links/browser/terminalLinkOpeners.ts
@@ -286,7 +286,8 @@ export class TerminalUrlLinkOpener implements ITerminalLinkOpener {
 		@IConfigurationService private readonly _configurationService: IConfigurationService,
 		@IFileService private readonly _fileService: IFileService,
 		@IUriIdentityService private readonly _uriIdentityService: IUriIdentityService,
-		@IWorkspaceContextService private readonly _workspaceContextService: IWorkspaceContextService
+		@IWorkspaceContextService private readonly _workspaceContextService: IWorkspaceContextService,
+		@ITerminalLogService private readonly _logService: ITerminalLogService,
 	) {
 	}
 

--- a/src/vs/workbench/contrib/terminalContrib/links/browser/terminalLinkOpeners.ts
+++ b/src/vs/workbench/contrib/terminalContrib/links/browser/terminalLinkOpeners.ts
@@ -15,7 +15,7 @@ import { IQuickInputService } from '../../../../../platform/quickinput/common/qu
 import { IWorkspaceContextService } from '../../../../../platform/workspace/common/workspace.js';
 import { ITerminalLinkOpener, ITerminalSimpleLink, TerminalBuiltinLinkType } from './links.js';
 import { osPathModule, updateLinkWithRelativeCwd } from './terminalLinkHelpers.js';
-import { getTerminalLinkType, isDirectoryInsideWorkspace } from './terminalLocalLinkDetector.js';
+import { getTerminalLinkType } from './terminalLocalLinkDetector.js';
 import { IUriIdentityService } from '../../../../../platform/uriIdentity/common/uriIdentity.js';
 import { ITerminalCapabilityStore, TerminalCapability } from '../../../../../platform/terminal/common/capabilities/capabilities.js';
 import { IEditorService } from '../../../../services/editor/common/editorService.js';
@@ -313,12 +313,12 @@ export class TerminalUrlLinkOpener implements ITerminalLinkOpener {
 		try {
 			const stat = await this._fileService.stat(link.uri);
 			const isDirectory = stat.isDirectory;
-			const isDirectoryInWorkspace = isDirectoryInsideWorkspace(
+			const linkType = getTerminalLinkType(
 				link.uri,
+				isDirectory,
 				this._uriIdentityService,
 				this._workspaceContextService
 			);
-			const linkType = getTerminalLinkType(isDirectory, isDirectoryInWorkspace);
 
 			// Delegate to appropriate opener
 			const opener = this._openers.get(linkType);

--- a/src/vs/workbench/contrib/terminalContrib/links/browser/terminalLinkOpeners.ts
+++ b/src/vs/workbench/contrib/terminalContrib/links/browser/terminalLinkOpeners.ts
@@ -278,28 +278,13 @@ export class TerminalUrlLinkOpener implements ITerminalLinkOpener {
 	constructor(
 		private readonly _isRemote: boolean,
 		@IOpenerService private readonly _openerService: IOpenerService,
-		@IConfigurationService private readonly _configurationService: IConfigurationService,
-		@IFileService private readonly _fileService: IFileService,
-		@ICommandService private readonly _commandService: ICommandService,
-		@IWorkspaceContextService private readonly _workspaceContextService: IWorkspaceContextService
+		@IConfigurationService private readonly _configurationService: IConfigurationService
 	) {
 	}
 
 	async open(link: ITerminalSimpleLink): Promise<void> {
 		if (!link.uri) {
 			throw new Error('Tried to open a url without a resolved URI');
-		}
-		try {
-			const stat = await this._fileService.stat(link.uri);
-			if (stat.isDirectory) {
-				const workspaceFolder = this._workspaceContextService.getWorkspaceFolder(link.uri);
-				if (workspaceFolder) {
-					await this._commandService.executeCommand('revealInExplorer', link.uri);
-					return;
-				}
-			}
-		} catch (error) {
-			// If stat fails (file doesn't exist or no access), fall through to default behavior
 		}
 		// It's important to use the raw string value here to avoid converting pre-encoded values
 		// from the URL like `%2B` -> `+`.

--- a/src/vs/workbench/contrib/terminalContrib/links/browser/terminalLinkOpeners.ts
+++ b/src/vs/workbench/contrib/terminalContrib/links/browser/terminalLinkOpeners.ts
@@ -15,7 +15,7 @@ import { IQuickInputService } from '../../../../../platform/quickinput/common/qu
 import { IWorkspaceContextService } from '../../../../../platform/workspace/common/workspace.js';
 import { ITerminalLinkOpener, ITerminalSimpleLink, TerminalBuiltinLinkType } from './links.js';
 import { osPathModule, updateLinkWithRelativeCwd } from './terminalLinkHelpers.js';
-import { isDirectoryInsideWorkspace } from './terminalLocalLinkDetector.js';
+import { getTerminalLinkType, isDirectoryInsideWorkspace } from './terminalLocalLinkDetector.js';
 import { IUriIdentityService } from '../../../../../platform/uriIdentity/common/uriIdentity.js';
 import { ITerminalCapabilityStore, TerminalCapability } from '../../../../../platform/terminal/common/capabilities/capabilities.js';
 import { IEditorService } from '../../../../services/editor/common/editorService.js';
@@ -313,20 +313,12 @@ export class TerminalUrlLinkOpener implements ITerminalLinkOpener {
 		try {
 			const stat = await this._fileService.stat(link.uri);
 			const isDirectory = stat.isDirectory;
-
-			let linkType: TerminalBuiltinLinkType;
-			if (isDirectory) {
-				const isDirectoryInWorkspace = isDirectoryInsideWorkspace(
-					link.uri,
-					this._uriIdentityService,
-					this._workspaceContextService
-				);
-				linkType = isDirectoryInWorkspace
-					? TerminalBuiltinLinkType.LocalFolderInWorkspace
-					: TerminalBuiltinLinkType.LocalFolderOutsideWorkspace;
-			} else {
-				linkType = TerminalBuiltinLinkType.LocalFile;
-			}
+			const isDirectoryInWorkspace = isDirectoryInsideWorkspace(
+				link.uri,
+				this._uriIdentityService,
+				this._workspaceContextService
+			);
+			const linkType = getTerminalLinkType(isDirectory, isDirectoryInWorkspace);
 
 			// Delegate to appropriate opener
 			const opener = this._openers.get(linkType);

--- a/src/vs/workbench/contrib/terminalContrib/links/browser/terminalLocalLinkDetector.ts
+++ b/src/vs/workbench/contrib/terminalContrib/links/browser/terminalLocalLinkDetector.ts
@@ -255,6 +255,19 @@ export class TerminalLocalLinkDetector implements ITerminalLinkDetector {
 
 		return links;
 	}
+	private async _validateLinkCandidates(linkCandidates: string[]): Promise<ResolvedLink | undefined> {
+		for (const link of linkCandidates) {
+			let uri: URI | undefined;
+			if (link.startsWith('file://')) {
+				uri = URI.parse(link);
+			}
+			const result = await this._linkResolver.resolveLink(this._processManager, link, uri);
+			if (result) {
+				return result;
+			}
+		}
+		return undefined;
+	}
 
 	/**
 	 * Validates a set of link candidates and returns a link if validated.
@@ -286,29 +299,9 @@ export class TerminalLocalLinkDetector implements ITerminalLinkDetector {
 		}
 		return undefined;
 	}
-
-	private async _validateLinkCandidates(linkCandidates: string[]): Promise<ResolvedLink | undefined> {
-		return await validateLinkCandidates(linkCandidates, this._linkResolver, this._processManager);
-	}
 }
 
-export async function validateLinkCandidates(
-	linkCandidates: string[],
-	linkResolver: ITerminalLinkResolver,
-	processManager: Pick<ITerminalProcessManager, 'initialCwd' | 'os' | 'remoteAuthority' | 'userHome'> & { backend?: Pick<ITerminalBackend, 'getWslPath'> }
-): Promise<ResolvedLink | undefined> {
-	for (const link of linkCandidates) {
-		let uri: URI | undefined;
-		if (link.startsWith('file://')) {
-			uri = URI.parse(link);
-		}
-		const result = await linkResolver.resolveLink(processManager, link, uri);
-		if (result) {
-			return result;
-		}
-	}
-	return undefined;
-}
+
 
 export function isDirectoryInsideWorkspace(
 	uri: URI,
@@ -338,4 +331,3 @@ export function getTerminalLinkType(
 		return TerminalBuiltinLinkType.LocalFile;
 	}
 }
-

--- a/src/vs/workbench/contrib/terminalContrib/links/test/browser/terminalLocalLinkDetector.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/links/test/browser/terminalLocalLinkDetector.test.ts
@@ -16,13 +16,17 @@ import type { Terminal } from '@xterm/xterm';
 import { timeout } from '../../../../../../base/common/async.js';
 import { strictEqual } from 'assert';
 import { TerminalLinkResolver } from '../../browser/terminalLinkResolver.js';
-import { IFileService } from '../../../../../../platform/files/common/files.js';
-import { createFileStat } from '../../../../../test/common/workbenchTestServices.js';
+import { IFileService, IFileStatWithPartialMetadata } from '../../../../../../platform/files/common/files.js';
+import { TestContextService } from '../../../../../test/common/workbenchTestServices.js';
 import { URI } from '../../../../../../base/common/uri.js';
 import { NullLogService } from '../../../../../../platform/log/common/log.js';
 import { ITerminalLogService } from '../../../../../../platform/terminal/common/terminal.js';
 import { importAMDNodeModule } from '../../../../../../amdX.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
+import { IWorkspaceContextService } from '../../../../../../platform/workspace/common/workspace.js';
+import { IUriIdentityService } from '../../../../../../platform/uriIdentity/common/uriIdentity.js';
+import { UriIdentityService } from '../../../../../../platform/uriIdentity/common/uriIdentityService.js';
+import { FileService } from '../../../../../../platform/files/common/fileService.js';
 
 const unixLinks: (string | { link: string; resource: URI })[] = [
 	// Absolute
@@ -166,11 +170,25 @@ const supportedFallbackLinkFormats: LinkFormatInfo[] = [
 	{ urlFormat: '{0}' },
 ];
 
+class TestFileService extends FileService {
+	private _files: URI[] | '*' = '*';
+	override async stat(resource: URI): Promise<IFileStatWithPartialMetadata> {
+		if (this._files === '*' || this._files.some(e => e.toString() === resource.toString())) {
+			return { isFile: true, isDirectory: false, isSymbolicLink: false } as IFileStatWithPartialMetadata;
+		}
+		throw new Error('ENOENT');
+	}
+	setFiles(files: URI[] | '*'): void {
+		this._files = files;
+	}
+}
+
 suite('Workbench - TerminalLocalLinkDetector', () => {
 	const store = ensureNoDisposablesAreLeakedInTestSuite();
 
 	let instantiationService: TestInstantiationService;
 	let configurationService: TestConfigurationService;
+	let fileService: TestFileService;
 	let detector: TerminalLocalLinkDetector;
 	let resolver: TerminalLinkResolver;
 	let xterm: Terminal;
@@ -201,15 +219,13 @@ suite('Workbench - TerminalLocalLinkDetector', () => {
 	setup(async () => {
 		instantiationService = store.add(new TestInstantiationService());
 		configurationService = new TestConfigurationService();
+		fileService = store.add(new TestFileService(new NullLogService()));
 		instantiationService.stub(IConfigurationService, configurationService);
-		instantiationService.stub(IFileService, {
-			async stat(resource) {
-				if (!validResources.map(e => e.path).includes(resource.path)) {
-					throw new Error('Doesn\'t exist');
-				}
-				return createFileStat(resource);
-			}
-		});
+		// Override the setFiles method to work with validResources for testing
+		fileService.setFiles(validResources);
+		instantiationService.set(IFileService, fileService);
+		instantiationService.set(IWorkspaceContextService, new TestContextService());
+		instantiationService.set(IUriIdentityService, store.add(new UriIdentityService(fileService)));
 		instantiationService.stub(ITerminalLogService, new NullLogService());
 		resolver = instantiationService.createInstance(TerminalLinkResolver);
 		validResources = [];
@@ -234,6 +250,7 @@ suite('Workbench - TerminalLocalLinkDetector', () => {
 				URI.file('/parent/cwd/foo'),
 				URI.file('/parent/cwd/bar')
 			];
+			fileService.setFiles(validResources);
 			await assertLinks(TerminalBuiltinLinkType.LocalFile, './foo ./bar', [
 				{ range: [[1, 1], [5, 1]], uri: URI.file('/parent/cwd/foo') },
 				{ range: [[7, 1], [11, 1]], uri: URI.file('/parent/cwd/bar') }
@@ -242,6 +259,7 @@ suite('Workbench - TerminalLocalLinkDetector', () => {
 
 		test('should support trimming extra quotes', async () => {
 			validResources = [URI.file('/parent/cwd/foo')];
+			fileService.setFiles(validResources);
 			await assertLinks(TerminalBuiltinLinkType.LocalFile, '"foo"" on line 5', [
 				{ range: [[1, 1], [16, 1]], uri: URI.file('/parent/cwd/foo') }
 			]);
@@ -249,6 +267,7 @@ suite('Workbench - TerminalLocalLinkDetector', () => {
 
 		test('should support trimming extra square brackets', async () => {
 			validResources = [URI.file('/parent/cwd/foo')];
+			fileService.setFiles(validResources);
 			await assertLinks(TerminalBuiltinLinkType.LocalFile, '"foo]" on line 5', [
 				{ range: [[1, 1], [16, 1]], uri: URI.file('/parent/cwd/foo') }
 			]);
@@ -256,6 +275,7 @@ suite('Workbench - TerminalLocalLinkDetector', () => {
 
 		test('should support finding links after brackets', async () => {
 			validResources = [URI.file('/parent/cwd/foo')];
+			fileService.setFiles(validResources);
 			await assertLinks(TerminalBuiltinLinkType.LocalFile, 'bar[foo:5', [
 				{ range: [[5, 1], [9, 1]], uri: URI.file('/parent/cwd/foo') }
 			]);
@@ -282,6 +302,7 @@ suite('Workbench - TerminalLocalLinkDetector', () => {
 					const formattedLink = format(linkFormat.urlFormat, baseLink, linkFormat.line, linkFormat.column);
 					test(`should detect in "${formattedLink}"`, async () => {
 						validResources = [resource];
+						fileService.setFiles(validResources);
 						await assertLinksWithWrapped(formattedLink, resource);
 					});
 				}
@@ -290,6 +311,7 @@ suite('Workbench - TerminalLocalLinkDetector', () => {
 
 		test('Git diff links', async () => {
 			validResources = [URI.file('/parent/cwd/foo/bar')];
+			fileService.setFiles(validResources);
 			await assertLinks(TerminalBuiltinLinkType.LocalFile, `diff --git a/foo/bar b/foo/bar`, [
 				{ uri: validResources[0], range: [[14, 1], [20, 1]] },
 				{ uri: validResources[0], range: [[24, 1], [30, 1]] }
@@ -332,6 +354,7 @@ suite('Workbench - TerminalLocalLinkDetector', () => {
 						const formattedLink = format(linkFormat.urlFormat, baseLink, linkFormat.line, linkFormat.column);
 						test(`should detect in "${formattedLink}"`, async () => {
 							validResources = [resource];
+							fileService.setFiles(validResources);
 							await assertLinksWithWrapped(formattedLink, resource);
 						});
 					}
@@ -349,6 +372,7 @@ suite('Workbench - TerminalLocalLinkDetector', () => {
 						const linkCellEndOffset = linkFormat.linkCellEndOffset ?? 0;
 						test(`should detect in "${formattedLink}"`, async () => {
 							validResources = [resource];
+							fileService.setFiles(validResources);
 							await assertLinks(TerminalBuiltinLinkType.LocalFile, formattedLink, [{ uri: resource, range: [[1 + linkCellStartOffset, 1], [formattedLink.length + linkCellEndOffset, 1]] }]);
 						});
 					}
@@ -358,6 +382,7 @@ suite('Workbench - TerminalLocalLinkDetector', () => {
 			test('Git diff links', async () => {
 				const resource = URI.file('C:\\Parent\\Cwd\\foo\\bar');
 				validResources = [resource];
+				fileService.setFiles(validResources);
 				await assertLinks(TerminalBuiltinLinkType.LocalFile, `diff --git a/foo/bar b/foo/bar`, [
 					{ uri: resource, range: [[14, 1], [20, 1]] },
 					{ uri: resource, range: [[24, 1], [30, 1]] }
@@ -370,16 +395,19 @@ suite('Workbench - TerminalLocalLinkDetector', () => {
 				test('Unix -> Windows /mnt/ style links', async () => {
 					wslUnixToWindowsPathMap.set('/mnt/c/foo/bar', 'C:\\foo\\bar');
 					validResources = [URI.file('C:\\foo\\bar')];
+					fileService.setFiles(validResources);
 					await assertLinksWithWrapped('/mnt/c/foo/bar', validResources[0]);
 				});
 
 				test('Windows -> Unix \\\\wsl$\\ style links', async () => {
 					validResources = [URI.file('\\\\wsl$\\Debian\\home\\foo\\bar')];
+					fileService.setFiles(validResources);
 					await assertLinksWithWrapped('\\\\wsl$\\Debian\\home\\foo\\bar');
 				});
 
 				test('Windows -> Unix \\\\wsl.localhost\\ style links', async () => {
 					validResources = [URI.file('\\\\wsl.localhost\\Debian\\home\\foo\\bar')];
+					fileService.setFiles(validResources);
 					await assertLinksWithWrapped('\\\\wsl.localhost\\Debian\\home\\foo\\bar');
 				});
 			});


### PR DESCRIPTION
Resolves: https://github.com/microsoft/vscode/issues/229374 

Current state, clicking on OSC 8 hyperlinked folder should navigate to VS Code file explorer rather than native file explorer.
But want to confirm what we want for https://github.com/microsoft/vscode/issues/229374#issuecomment-3273396525  