### PR TITLE
Fix dialog cancel button placement

### DIFF
--- a/src/vs/base/browser/ui/dialog/dialog.ts
+++ b/src/vs/base/browser/ui/dialog/dialog.ts
@@ -626,7 +626,7 @@ export class Dialog extends Disposable {
 
 			if (typeof cancelId === 'number' && buttonMap[cancelId]) {
 				const cancelButton = buttonMap.splice(cancelId, 1)[0];
-				buttonMap.splice(1, 0, cancelButton);
+				buttonMap.push(cancelButton);
 			}
 
 			buttonMap.reverse();


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
This pull request addresses issue #265989 by updating the placement of the cancel button in the dialog component.
Previously, the cancel button was inserted at a fixed position using buttonMap.splice(1, 0, cancelButton);, which could lead to inconsistencies in button order, especially when dialogs have custom button configurations.

**Change summary**:

Replaces buttonMap.splice(1, 0, cancelButton); with buttonMap.push(cancelButton); in src/vs/base/browser/ui/dialog/dialog.ts
Ensures the cancel button is always placed at the end of the button list for consistent UI behavior
Impact:

Dialog cancel button will appear in a more predictable and user-friendly position
Aligns with standard dialog button placement practices
Closes #265989.