### PR TITLE
address API feedback for terminal completion provider

### DIFF
--- a/extensions/terminal-suggest/src/terminalSuggestMain.ts
+++ b/extensions/terminal-suggest/src/terminalSuggestMain.ts
@@ -306,11 +306,12 @@ export async function activate(context: vscode.ExtensionContext) {
 
 			const cwd = result.cwd ?? terminal.shellIntegration?.cwd;
 			if (cwd && (result.filesRequested || result.foldersRequested)) {
+				const globPattern = createGlobPattern(result.fileExtensions);
 				return new vscode.TerminalCompletionList(result.items, {
 					filesRequested: result.filesRequested,
 					foldersRequested: result.foldersRequested,
-					fileExtensions: result.fileExtensions,
-					cwd
+					globPattern,
+					cwd,
 				});
 			}
 			return result.items;
@@ -563,3 +564,11 @@ export function sanitizeProcessEnvironment(env: Record<string, string>, ...prese
 		});
 }
 
+
+function createGlobPattern(fileExtensions?: string[]): string | undefined {
+	let globPattern: string | undefined;
+	if (fileExtensions && fileExtensions.length > 0) {
+		globPattern = `{${fileExtensions.map(ext => `*${ext.startsWith('.') ? ext : '.' + ext}`).join(',')}}`;
+	}
+	return globPattern;
+}

--- a/extensions/terminal-suggest/src/terminalSuggestMain.ts
+++ b/extensions/terminal-suggest/src/terminalSuggestMain.ts
@@ -566,9 +566,10 @@ export function sanitizeProcessEnvironment(env: Record<string, string>, ...prese
 
 
 function createGlobPattern(fileExtensions?: string[]): string | undefined {
-	let globPattern: string | undefined;
-	if (fileExtensions && fileExtensions.length > 0) {
-		globPattern = `{${fileExtensions.map(ext => `*${ext.startsWith('.') ? ext : '.' + ext}`).join(',')}}`;
+	if (!fileExtensions || fileExtensions.length === 0) {
+		return undefined;
 	}
-	return globPattern;
+	const exts = fileExtensions.map(ext => ext.startsWith('.') ? ext : '.' + ext);
+	// Create a regex that matches any string ending with one of the extensions
+	return `.*(${exts.map(ext => ext.replace('.', '\\.')).join('|')})$`;
 }

--- a/extensions/terminal-suggest/src/terminalSuggestMain.ts
+++ b/extensions/terminal-suggest/src/terminalSuggestMain.ts
@@ -250,8 +250,7 @@ export async function activate(context: vscode.ExtensionContext) {
 	const machineId = await vscode.env.machineId;
 	const remoteAuthority = vscode.env.remoteName;
 
-	context.subscriptions.push(vscode.window.registerTerminalCompletionProvider({
-		id: 'terminal-suggest',
+	context.subscriptions.push(vscode.window.registerTerminalCompletionProvider('terminal-suggest', {
 		async provideTerminalCompletions(terminal: vscode.Terminal, terminalContext: vscode.TerminalCompletionContext, token: vscode.CancellationToken): Promise<vscode.TerminalCompletionItem[] | vscode.TerminalCompletionList | undefined> {
 			currentTerminalEnv = terminal.shellIntegration?.env?.value ?? process.env;
 			if (token.isCancellationRequested) {

--- a/extensions/terminal-suggest/src/terminalSuggestMain.ts
+++ b/extensions/terminal-suggest/src/terminalSuggestMain.ts
@@ -311,8 +311,7 @@ export async function activate(context: vscode.ExtensionContext) {
 					filesRequested: result.filesRequested,
 					foldersRequested: result.foldersRequested,
 					fileExtensions: result.fileExtensions,
-					cwd,
-					env: terminal.shellIntegration?.env?.value,
+					cwd
 				});
 			}
 			return result.items;

--- a/extensions/terminal-suggest/src/terminalSuggestMain.ts
+++ b/extensions/terminal-suggest/src/terminalSuggestMain.ts
@@ -565,11 +565,16 @@ export function sanitizeProcessEnvironment(env: Record<string, string>, ...prese
 }
 
 
+// Escapes regex special characters in a string
+function escapeRegExp(str: string): string {
+	return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
 function createGlobPattern(fileExtensions?: string[]): vscode.GlobPattern | undefined {
 	if (!fileExtensions || fileExtensions.length === 0) {
 		return undefined;
 	}
 	const exts = fileExtensions.map(ext => ext.startsWith('.') ? ext : '.' + ext);
 	// Create a regex that matches any string ending with one of the extensions
-	return `.*(${exts.map(ext => ext.replace(/\./g, '\\.')).join('|')})$`;
+	return `.*(${exts.map(ext => escapeRegExp(ext)).join('|')})$`;
 }

--- a/extensions/terminal-suggest/src/terminalSuggestMain.ts
+++ b/extensions/terminal-suggest/src/terminalSuggestMain.ts
@@ -305,13 +305,13 @@ export async function activate(context: vscode.ExtensionContext) {
 				}
 			}
 
-
-			if (terminal.shellIntegration?.cwd && (result.filesRequested || result.foldersRequested)) {
+			const cwd = result.cwd ?? terminal.shellIntegration?.cwd;
+			if (cwd && (result.filesRequested || result.foldersRequested)) {
 				return new vscode.TerminalCompletionList(result.items, {
 					filesRequested: result.filesRequested,
 					foldersRequested: result.foldersRequested,
 					fileExtensions: result.fileExtensions,
-					cwd: result.cwd ?? terminal.shellIntegration.cwd,
+					cwd,
 					env: terminal.shellIntegration?.env?.value,
 				});
 			}

--- a/extensions/terminal-suggest/src/terminalSuggestMain.ts
+++ b/extensions/terminal-suggest/src/terminalSuggestMain.ts
@@ -565,7 +565,7 @@ export function sanitizeProcessEnvironment(env: Record<string, string>, ...prese
 }
 
 
-function createGlobPattern(fileExtensions?: string[]): string | undefined {
+function createGlobPattern(fileExtensions?: string[]): vscode.GlobPattern | undefined {
 	if (!fileExtensions || fileExtensions.length === 0) {
 		return undefined;
 	}

--- a/extensions/terminal-suggest/src/terminalSuggestMain.ts
+++ b/extensions/terminal-suggest/src/terminalSuggestMain.ts
@@ -306,7 +306,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
 			const cwd = result.cwd ?? terminal.shellIntegration?.cwd;
 			if (cwd && (result.filesRequested || result.foldersRequested)) {
-				const globPattern = createGlobPattern(result.fileExtensions);
+				const globPattern = createFileRegex(result.fileExtensions);
 				return new vscode.TerminalCompletionList(result.items, {
 					filesRequested: result.filesRequested,
 					foldersRequested: result.foldersRequested,
@@ -570,7 +570,7 @@ function escapeRegExp(str: string): string {
 	return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
-function createGlobPattern(fileExtensions?: string[]): vscode.GlobPattern | undefined {
+function createFileRegex(fileExtensions?: string[]): vscode.GlobPattern | undefined {
 	if (!fileExtensions || fileExtensions.length === 0) {
 		return undefined;
 	}

--- a/extensions/terminal-suggest/src/terminalSuggestMain.ts
+++ b/extensions/terminal-suggest/src/terminalSuggestMain.ts
@@ -571,5 +571,5 @@ function createGlobPattern(fileExtensions?: string[]): vscode.GlobPattern | unde
 	}
 	const exts = fileExtensions.map(ext => ext.startsWith('.') ? ext : '.' + ext);
 	// Create a regex that matches any string ending with one of the extensions
-	return `.*(${exts.map(ext => ext.replace('.', '\\.')).join('|')})$`;
+	return `.*(${exts.map(ext => ext.replace(/\./g, '\\.')).join('|')})$`;
 }

--- a/src/vs/workbench/api/browser/mainThreadTerminalService.ts
+++ b/src/vs/workbench/api/browser/mainThreadTerminalService.ts
@@ -279,13 +279,27 @@ export class MainThreadTerminalService implements MainThreadTerminalServiceShape
 			id,
 			provideCompletions: async (commandLine, cursorPosition, allowFallbackCompletions, token) => {
 				const completions = await this._proxy.$provideTerminalCompletions(id, { commandLine, cursorPosition, allowFallbackCompletions }, token);
-				return {
-					items: completions?.items.map(c => ({
-						provider: `ext:${id}`,
-						...c,
-					})),
-					resourceRequestConfig: completions?.resourceRequestConfig
-				};
+				if (!completions) {
+					return undefined;
+				}
+				if (completions.resourceRequestConfig) {
+					const { cwd, globPattern, ...rest } = completions.resourceRequestConfig;
+					return {
+						items: completions.items?.map(c => ({
+							provider: `ext:${id}`,
+							...c,
+						})),
+						resourceRequestConfig: {
+							...rest,
+							cwd,
+							globPattern: globPattern?.toString()
+						}
+					};
+				}
+				return completions.items?.map(c => ({
+					provider: `ext:${id}`,
+					...c,
+				}));
 			}
 		}, ...triggerCharacters));
 	}

--- a/src/vs/workbench/api/browser/mainThreadTerminalService.ts
+++ b/src/vs/workbench/api/browser/mainThreadTerminalService.ts
@@ -292,7 +292,7 @@ export class MainThreadTerminalService implements MainThreadTerminalServiceShape
 						resourceRequestConfig: {
 							...rest,
 							cwd,
-							globPattern: globPattern?.toString()
+							globPattern
 						}
 					};
 				}

--- a/src/vs/workbench/api/common/extHost.api.impl.ts
+++ b/src/vs/workbench/api/common/extHost.api.impl.ts
@@ -876,9 +876,9 @@ export function createApiFactoryAndRegisterActors(accessor: ServicesAccessor): I
 			registerTerminalProfileProvider(id: string, provider: vscode.TerminalProfileProvider): vscode.Disposable {
 				return extHostTerminalService.registerProfileProvider(extension, id, provider);
 			},
-			registerTerminalCompletionProvider(provider: vscode.TerminalCompletionProvider<vscode.TerminalCompletionItem>, ...triggerCharacters: string[]): vscode.Disposable {
+			registerTerminalCompletionProvider(id: string, provider: vscode.TerminalCompletionProvider<vscode.TerminalCompletionItem>, ...triggerCharacters: string[]): vscode.Disposable {
 				checkProposedApiEnabled(extension, 'terminalCompletionProvider');
-				return extHostTerminalService.registerTerminalCompletionProvider(extension, provider, ...triggerCharacters);
+				return extHostTerminalService.registerTerminalCompletionProvider(extension, id, provider, ...triggerCharacters);
 			},
 			registerTerminalQuickFixProvider(id: string, provider: vscode.TerminalQuickFixProvider): vscode.Disposable {
 				checkProposedApiEnabled(extension, 'terminalQuickFixProvider');

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -2527,7 +2527,7 @@ export class TerminalCompletionListDto<T extends ITerminalCompletionItemDto = IT
 export interface TerminalResourceRequestConfigDto {
 	filesRequested?: boolean;
 	foldersRequested?: boolean;
-	fileExtensions?: string[];
+	globPattern?: string;
 	cwd: UriComponents;
 	pathSeparator: string;
 }

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -2528,7 +2528,7 @@ export interface TerminalResourceRequestConfigDto {
 	filesRequested?: boolean;
 	foldersRequested?: boolean;
 	fileExtensions?: string[];
-	cwd?: UriComponents;
+	cwd: UriComponents;
 	pathSeparator: string;
 }
 

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -2527,7 +2527,7 @@ export class TerminalCompletionListDto<T extends ITerminalCompletionItemDto = IT
 export interface TerminalResourceRequestConfigDto {
 	filesRequested?: boolean;
 	foldersRequested?: boolean;
-	globPattern?: string;
+	globPattern?: string | IRelativePattern;
 	cwd: UriComponents;
 	pathSeparator: string;
 }

--- a/src/vs/workbench/api/common/extHostTerminalService.ts
+++ b/src/vs/workbench/api/common/extHostTerminalService.ts
@@ -57,7 +57,7 @@ export interface IExtHostTerminalService extends ExtHostTerminalServiceShape, ID
 	getEnvironmentVariableCollection(extension: IExtensionDescription): IEnvironmentVariableCollection;
 	getTerminalById(id: number): ExtHostTerminal | null;
 	getTerminalIdByApiObject(apiTerminal: vscode.Terminal): number | null;
-	registerTerminalCompletionProvider(extension: IExtensionDescription, provider: vscode.TerminalCompletionProvider<vscode.TerminalCompletionItem>, ...triggerCharacters: string[]): vscode.Disposable;
+	registerTerminalCompletionProvider(extension: IExtensionDescription, id: string, provider: vscode.TerminalCompletionProvider<vscode.TerminalCompletionItem>, ...triggerCharacters: string[]): vscode.Disposable;
 }
 
 interface IEnvironmentVariableCollection extends vscode.EnvironmentVariableCollection {
@@ -757,15 +757,15 @@ export abstract class BaseExtHostTerminalService extends Disposable implements I
 		});
 	}
 
-	public registerTerminalCompletionProvider(extension: IExtensionDescription, provider: vscode.TerminalCompletionProvider<TerminalCompletionItem>, ...triggerCharacters: string[]): vscode.Disposable {
-		if (this._completionProviders.has(provider.id)) {
-			throw new Error(`Terminal completion provider "${provider.id}" already registered`);
+	public registerTerminalCompletionProvider(extension: IExtensionDescription, id: string, provider: vscode.TerminalCompletionProvider<TerminalCompletionItem>, ...triggerCharacters: string[]): vscode.Disposable {
+		if (this._completionProviders.has(id)) {
+			throw new Error(`Terminal completion provider "${id}" already registered`);
 		}
-		this._completionProviders.set(provider.id, provider);
-		this._proxy.$registerCompletionProvider(provider.id, extension.identifier.value, ...triggerCharacters);
+		this._completionProviders.set(id, provider);
+		this._proxy.$registerCompletionProvider(id, extension.identifier.value, ...triggerCharacters);
 		return new VSCodeDisposable(() => {
-			this._completionProviders.delete(provider.id);
-			this._proxy.$unregisterCompletionProvider(provider.id);
+			this._completionProviders.delete(id);
+			this._proxy.$unregisterCompletionProvider(id);
 		});
 	}
 

--- a/src/vs/workbench/api/common/extHostTypeConverters.ts
+++ b/src/vs/workbench/api/common/extHostTypeConverters.ts
@@ -3407,6 +3407,7 @@ export namespace TerminalResourceRequestConfig {
 			...resourceRequestConfig,
 			pathSeparator,
 			cwd: resourceRequestConfig.cwd,
+			globPattern: resourceRequestConfig.globPattern?.toString()
 		};
 	}
 }

--- a/src/vs/workbench/api/common/extHostTypeConverters.ts
+++ b/src/vs/workbench/api/common/extHostTypeConverters.ts
@@ -3407,7 +3407,7 @@ export namespace TerminalResourceRequestConfig {
 			...resourceRequestConfig,
 			pathSeparator,
 			cwd: resourceRequestConfig.cwd,
-			globPattern: resourceRequestConfig.globPattern?.toString()
+			globPattern: GlobPattern.from(resourceRequestConfig.globPattern) ?? undefined
 		};
 	}
 }

--- a/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalCompletionService.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalCompletionService.ts
@@ -444,9 +444,11 @@ export class TerminalCompletionService extends Disposable implements ITerminalCo
 			label = escapeTerminalCompletionLabel(label, shellType, resourceRequestConfig.pathSeparator);
 
 			if (child.isFile && globPattern) {
-				if (typeof globPattern === 'string' && !(new RegExp(globPattern).test(child.resource.fsPath))) {
-					return;
-				} else if (typeof globPattern !== 'string' && !match(globPattern, child.resource.fsPath)) {
+				const filePath = child.resource.fsPath;
+				const matches = typeof globPattern === 'string'
+					? new RegExp(globPattern).test(filePath)
+					: match(globPattern, filePath);
+				if (!matches) {
 					return;
 				}
 			}

--- a/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalCompletionService.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalCompletionService.ts
@@ -444,7 +444,9 @@ export class TerminalCompletionService extends Disposable implements ITerminalCo
 			label = escapeTerminalCompletionLabel(label, shellType, resourceRequestConfig.pathSeparator);
 
 			if (child.isFile && globPattern) {
-				if (!match(globPattern, child.resource.fsPath)) {
+				if (typeof globPattern === 'string' && !(new RegExp(globPattern).test(child.resource.fsPath))) {
+					return;
+				} else if (typeof globPattern !== 'string' && !match(globPattern, child.resource.fsPath)) {
 					return;
 				}
 			}

--- a/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalCompletionService.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalCompletionService.ts
@@ -55,8 +55,7 @@ export class TerminalCompletionList<ITerminalCompletion> {
 export interface TerminalResourceRequestConfig {
 	filesRequested?: boolean;
 	foldersRequested?: boolean;
-	fileExtensions?: string[];
-	env?: { [key: string]: string | null | undefined };
+	globPattern?: string;
 	cwd: UriComponents;
 	pathSeparator: string;
 }
@@ -258,7 +257,7 @@ export class TerminalCompletionService extends Disposable implements ITerminalCo
 		// provide diagnostics when a folder is provided where a file is expected.
 		const foldersRequested = (resourceRequestConfig.foldersRequested || resourceRequestConfig.filesRequested) ?? false;
 		const filesRequested = resourceRequestConfig.filesRequested ?? false;
-		const fileExtensions = resourceRequestConfig.fileExtensions ?? undefined;
+		const globPattern = resourceRequestConfig.globPattern ?? undefined;
 
 		if (!foldersRequested && !filesRequested) {
 			return;
@@ -443,9 +442,9 @@ export class TerminalCompletionService extends Disposable implements ITerminalCo
 
 			label = escapeTerminalCompletionLabel(label, shellType, resourceRequestConfig.pathSeparator);
 
-			if (child.isFile && fileExtensions) {
+			if (child.isFile && globPattern) {
 				const extension = child.name.split('.').length > 1 ? child.name.split('.').at(-1) : undefined;
-				if (extension && !fileExtensions.includes(extension)) {
+				if (extension && !globPattern.match(extension)) {
 					return;
 				}
 			}

--- a/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalCompletionService.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalCompletionService.ts
@@ -56,9 +56,9 @@ export interface TerminalResourceRequestConfig {
 	filesRequested?: boolean;
 	foldersRequested?: boolean;
 	fileExtensions?: string[];
-	cwd?: UriComponents;
-	pathSeparator: string;
 	env?: { [key: string]: string | null | undefined };
+	cwd: UriComponents;
+	pathSeparator: string;
 }
 
 
@@ -260,8 +260,7 @@ export class TerminalCompletionService extends Disposable implements ITerminalCo
 		const filesRequested = resourceRequestConfig.filesRequested ?? false;
 		const fileExtensions = resourceRequestConfig.fileExtensions ?? undefined;
 
-		const cwd = URI.revive(resourceRequestConfig.cwd);
-		if (!cwd || (!foldersRequested && !filesRequested)) {
+		if (!foldersRequested && !filesRequested) {
 			return;
 		}
 
@@ -307,6 +306,8 @@ export class TerminalCompletionService extends Disposable implements ITerminalCo
 		const lastWordFolderHasTildePrefix = !!lastWordFolder.match(/^~[\\\/]?/);
 		const isAbsolutePath = getIsAbsolutePath(shellType, resourceRequestConfig.pathSeparator, lastWordFolder, useWindowsStylePath);
 		const type = lastWordFolderHasTildePrefix ? 'tilde' : isAbsolutePath ? 'absolute' : 'relative';
+		const cwd = URI.revive(resourceRequestConfig.cwd);
+
 		switch (type) {
 			case 'tilde': {
 				const home = this._getHomeDir(useWindowsStylePath, capabilities);

--- a/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalCompletionService.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalCompletionService.ts
@@ -442,11 +442,8 @@ export class TerminalCompletionService extends Disposable implements ITerminalCo
 
 			label = escapeTerminalCompletionLabel(label, shellType, resourceRequestConfig.pathSeparator);
 
-			if (child.isFile && globPattern) {
-				const extension = child.name.split('.').length > 1 ? child.name.split('.').at(-1) : undefined;
-				if (extension && !globPattern.match(extension)) {
-					return;
-				}
+			if (child.isFile && globPattern && !child.name.match(globPattern)) {
+				return;
 			}
 
 			// Try to resolve symlink target for symbolic links

--- a/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalCompletionService.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalCompletionService.ts
@@ -442,7 +442,7 @@ export class TerminalCompletionService extends Disposable implements ITerminalCo
 
 			label = escapeTerminalCompletionLabel(label, shellType, resourceRequestConfig.pathSeparator);
 
-			if (child.isFile && globPattern && !child.name.match(globPattern)) {
+			if (child.isFile && globPattern && !(new RegExp(globPattern).test(child.name))) {
 				return;
 			}
 

--- a/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalCompletionService.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalCompletionService.ts
@@ -21,6 +21,7 @@ import { timeout } from '../../../../../base/common/async.js';
 import { gitBashToWindowsPath, windowsToGitBashPath } from './terminalGitBashHelpers.js';
 import { isEqual } from '../../../../../base/common/resources.js';
 import { ILabelService } from '../../../../../platform/label/common/label.js';
+import { IRelativePattern, match } from '../../../../../base/common/glob.js';
 
 export const ITerminalCompletionService = createDecorator<ITerminalCompletionService>('terminalCompletionService');
 
@@ -55,7 +56,7 @@ export class TerminalCompletionList<ITerminalCompletion> {
 export interface TerminalResourceRequestConfig {
 	filesRequested?: boolean;
 	foldersRequested?: boolean;
-	globPattern?: string;
+	globPattern?: string | IRelativePattern;
 	cwd: UriComponents;
 	pathSeparator: string;
 }
@@ -442,8 +443,10 @@ export class TerminalCompletionService extends Disposable implements ITerminalCo
 
 			label = escapeTerminalCompletionLabel(label, shellType, resourceRequestConfig.pathSeparator);
 
-			if (child.isFile && globPattern && !(new RegExp(globPattern).test(child.name))) {
-				return;
+			if (child.isFile && globPattern) {
+				if (!match(globPattern, child.resource.fsPath)) {
+					return;
+				}
 			}
 
 			// Try to resolve symlink target for symbolic links

--- a/src/vs/workbench/contrib/terminalContrib/suggest/test/browser/terminalCompletionService.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/test/browser/terminalCompletionService.test.ts
@@ -147,12 +147,6 @@ suite('TerminalCompletionService', () => {
 	});
 
 	suite('resolveResources should return undefined', () => {
-		test('if cwd is not provided', async () => {
-			const resourceRequestConfig: TerminalResourceRequestConfig = { pathSeparator };
-			const result = await terminalCompletionService.resolveResources(resourceRequestConfig, 'cd ', 3, provider, capabilities);
-			assert(!result);
-		});
-
 		test('if neither filesRequested nor foldersRequested are true', async () => {
 			const resourceRequestConfig: TerminalResourceRequestConfig = {
 				cwd: URI.parse('file:///test'),

--- a/src/vscode-dts/vscode.proposed.terminalCompletionProvider.d.ts
+++ b/src/vscode-dts/vscode.proposed.terminalCompletionProvider.d.ts
@@ -19,6 +19,16 @@ declare module 'vscode' {
 	}
 
 
+	/**
+	 * If the command line is `ls -|` where | is the cursor,
+	 * the following would be the values for the completion items:
+	 * label: -A
+	 * replacementIndex: 3
+	 * replacementLength: 1
+	 * detail: List all entries except for . and ...  Always set for the super-user
+	 * documentation: none
+	 * kind: TerminalCompletionItemKind.Flag
+	 */
 	export interface TerminalCompletionItem {
 		/**
 		 * The label of the completion.
@@ -39,7 +49,6 @@ declare module 'vscode' {
 		 * The completion's detail which appears on the right of the list.
 		 */
 		detail?: string;
-
 
 		/**
 		 * A human-readable string that represents a doc-comment.

--- a/src/vscode-dts/vscode.proposed.terminalCompletionProvider.d.ts
+++ b/src/vscode-dts/vscode.proposed.terminalCompletionProvider.d.ts
@@ -142,10 +142,6 @@ declare module 'vscode' {
 		 */
 		fileExtensions?: string[];
 		/**
-		 * Environment variables to use when constructing paths.
-		*/
-		env?: { [key: string]: string | null | undefined };
-		/**
 		 * The cwd from which to request resources.
 		 */
 		cwd: Uri;

--- a/src/vscode-dts/vscode.proposed.terminalCompletionProvider.d.ts
+++ b/src/vscode-dts/vscode.proposed.terminalCompletionProvider.d.ts
@@ -137,9 +137,9 @@ declare module 'vscode' {
 		 */
 		foldersRequested?: boolean;
 		/**
-		 * File extensions to filter by.
+		 * A {@link GlobPattern glob pattern} that controls which files suggest should surface.
 		 */
-		fileExtensions?: string[];
+		globPattern?: GlobPattern;
 		/**
 		 * The cwd from which to request resources.
 		 */

--- a/src/vscode-dts/vscode.proposed.terminalCompletionProvider.d.ts
+++ b/src/vscode-dts/vscode.proposed.terminalCompletionProvider.d.ts
@@ -8,7 +8,6 @@ declare module 'vscode' {
 	// https://github.com/microsoft/vscode/issues/226562
 
 	export interface TerminalCompletionProvider<T extends TerminalCompletionItem> {
-		id: string;
 		/**
 		 * Provide completions for the given position and document.
 		 * @param terminal The terminal for which completions are being provided.
@@ -96,11 +95,11 @@ declare module 'vscode' {
 	export namespace window {
 		/**
 		 * Register a completion provider for a certain type of terminal.
-		 *
+		 * @param id The unique identifier of the terminal provider, used as a settings key and shown in the information hover of the suggest widget.
 		 * @param provider The completion provider.
 		 * @returns A {@link Disposable} that unregisters this provider when being disposed.
 		 */
-		export function registerTerminalCompletionProvider<T extends TerminalCompletionItem>(provider: TerminalCompletionProvider<T>, ...triggerCharacters: string[]): Disposable;
+		export function registerTerminalCompletionProvider<T extends TerminalCompletionItem>(id: string, provider: TerminalCompletionProvider<T>, ...triggerCharacters: string[]): Disposable;
 	}
 
 	/**

--- a/src/vscode-dts/vscode.proposed.terminalCompletionProvider.d.ts
+++ b/src/vscode-dts/vscode.proposed.terminalCompletionProvider.d.ts
@@ -20,14 +20,19 @@ declare module 'vscode' {
 
 
 	/**
-	 * If the command line is `ls -|` where | is the cursor,
-	 * the following would be the values for a completion item:
-	 * label: -A
-	 * replacementIndex: 3
-	 * replacementLength: 1
-	 * detail: List all entries except for . and ...  Always set for the super-user
-	 * documentation: none
-	 * kind: TerminalCompletionItemKind.Flag
+	 * Represents a completion suggestion for a terminal command line.
+	 *
+	 * @example <caption>Completion item for `ls -|`</caption>
+	 * const item = {
+	 * 	label: '-A',
+	 * 	replacementIndex: 3,
+	 * 	replacementLength: 1,
+	 * 	detail: 'List all entries except for . and .. (always set for the super-user)',
+	 * 	kind: TerminalCompletionItemKind.Flag
+	 * };
+	 *
+	 * The fields on a completion item describe what text should be shown to the user
+	 * and which portion of the command line should be replaced when the item is accepted.
 	 */
 	export interface TerminalCompletionItem {
 		/**

--- a/src/vscode-dts/vscode.proposed.terminalCompletionProvider.d.ts
+++ b/src/vscode-dts/vscode.proposed.terminalCompletionProvider.d.ts
@@ -142,12 +142,12 @@ declare module 'vscode' {
 		 */
 		fileExtensions?: string[];
 		/**
-		 * If no cwd is provided, no resources will be shown as completions.
-		 */
-		cwd?: Uri;
-		/**
 		 * Environment variables to use when constructing paths.
-		 */
+		*/
 		env?: { [key: string]: string | null | undefined };
+		/**
+		 * The cwd from which to request resources.
+		 */
+		cwd: Uri;
 	}
 }

--- a/src/vscode-dts/vscode.proposed.terminalCompletionProvider.d.ts
+++ b/src/vscode-dts/vscode.proposed.terminalCompletionProvider.d.ts
@@ -21,7 +21,7 @@ declare module 'vscode' {
 
 	/**
 	 * If the command line is `ls -|` where | is the cursor,
-	 * the following would be the values for the completion items:
+	 * the following would be the values for a completion item:
 	 * label: -A
 	 * replacementIndex: 3
 	 * replacementLength: 1


### PR DESCRIPTION
addresses https://github.com/microsoft/vscode/issues/224505#issuecomment-3049538549

- [x] look into why cwd is optional but somehow mandatory
    - I have made this mandatory
- [x] look into why env is on resource request config
    - I have removed this, wasn't necessary
- [x] pass in id to registerCompletionProvider vs having id on the provider
- [x] ensure it's clear that id needs to be unique, mention where it will show up (setting, hover w cmd +/ )
- [x] add comments and examples jsdoc
- [x] consider glob pattern vs file extensions?