### PR TITLE
focus terminal, await user enter if free form input is expected in the terminal

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/chatElicitationContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/chatElicitationContentPart.ts
@@ -10,7 +10,7 @@ import { IInstantiationService } from '../../../../../platform/instantiation/com
 import { IChatProgressRenderableResponseContent } from '../../common/chatModel.js';
 import { IChatElicitationRequest } from '../../common/chatService.js';
 import { IChatAccessibilityService } from '../chat.js';
-import { ChatConfirmationWidget } from './chatConfirmationWidget.js';
+import { ChatConfirmationWidget, IChatConfirmationButton } from './chatConfirmationWidget.js';
 import { IChatContentPart, IChatContentPartRenderContext } from './chatContentParts.js';
 import { IAction } from '../../../../../base/common/actions.js';
 
@@ -28,7 +28,7 @@ export class ChatElicitationContentPart extends Disposable implements IChatConte
 	) {
 		super();
 
-		const buttons = [
+		const buttons: IChatConfirmationButton<unknown>[] = [
 			{
 				label: elicitation.acceptButtonLabel,
 				data: true,
@@ -38,8 +38,10 @@ export class ChatElicitationContentPart extends Disposable implements IChatConte
 					run: action.run
 				}))
 			},
-			{ label: elicitation.rejectButtonLabel, data: false, isSecondary: true },
 		];
+		if (elicitation.rejectButtonLabel && elicitation.reject) {
+			buttons.push({ label: elicitation.rejectButtonLabel, data: false, isSecondary: true });
+		}
 		const confirmationWidget = this._register(this.instantiationService.createInstance(ChatConfirmationWidget, context.container, {
 			title: elicitation.title,
 			subtitle: elicitation.subtitle,
@@ -66,7 +68,7 @@ export class ChatElicitationContentPart extends Disposable implements IChatConte
 			}
 			if (result !== undefined) {
 				await elicitation.accept(result);
-			} else {
+			} else if (elicitation.reject) {
 				await elicitation.reject();
 			}
 

--- a/src/vs/workbench/contrib/chat/browser/chatElicitationRequestPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatElicitationRequestPart.ts
@@ -23,10 +23,10 @@ export class ChatElicitationRequestPart extends Disposable implements IChatElici
 		public readonly message: string | IMarkdownString,
 		public readonly subtitle: string | IMarkdownString,
 		public readonly acceptButtonLabel: string,
-		public readonly rejectButtonLabel: string,
+		public readonly rejectButtonLabel: string | undefined,
 		// True when the primary action is accepted, otherwise the action that was selected
 		public readonly accept: (value: IAction | true) => Promise<void>,
-		public readonly reject: () => Promise<void>,
+		public readonly reject?: () => Promise<void>,
 		public readonly source?: ToolDataSource,
 		public readonly moreActions?: IAction[],
 	) {

--- a/src/vs/workbench/contrib/chat/common/chatService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService.ts
@@ -268,14 +268,14 @@ export interface IChatElicitationRequest {
 	title: string | IMarkdownString;
 	message: string | IMarkdownString;
 	acceptButtonLabel: string;
-	rejectButtonLabel: string;
+	rejectButtonLabel: string | undefined;
 	subtitle?: string | IMarkdownString;
 	source?: ToolDataSource;
 	state: 'pending' | 'accepted' | 'rejected';
 	acceptedResult?: Record<string, unknown>;
 	moreActions?: IAction[];
 	accept(value: IAction | true): Promise<void>;
-	reject(): Promise<void>;
+	reject?: () => Promise<void>;
 	onDidRequestHide?: Event<void>;
 }
 

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/runInTerminalToolTelemetry.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/runInTerminalToolTelemetry.ts
@@ -109,6 +109,8 @@ export class RunInTerminalToolTelemetry {
 		inputToolAutoAcceptCount: number | undefined;
 		inputToolAutoChars: number | undefined;
 		inputToolManualShownCount: number | undefined;
+		inputToolFreeFormInputShownCount: number | undefined;
+		inputToolFreeFormInputCount: number | undefined;
 	}) {
 		type TelemetryEvent = {
 			terminalSessionId: string;
@@ -133,6 +135,8 @@ export class RunInTerminalToolTelemetry {
 			inputToolManualRejectCount: number;
 			inputToolManualChars: number;
 			inputToolManualShownCount: number;
+			inputToolFreeFormInputShownCount: number;
+			inputToolFreeFormInputCount: number;
 		};
 		type TelemetryClassification = {
 			owner: 'tyriar';
@@ -160,6 +164,8 @@ export class RunInTerminalToolTelemetry {
 			inputToolManualRejectCount: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'The number of times the user manually rejected a detected suggestion' };
 			inputToolManualChars: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'The number of characters input by manual acceptance of a suggestion' };
 			inputToolManualShownCount: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'The number of times the user was prompted to manually accept an input suggestion' };
+			inputToolFreeFormInputShownCount: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'The number of times the user was prompted to provide free form input' };
+			inputToolFreeFormInputCount: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'The number of times the user entered free form input after prompting' };
 		};
 		this._telemetryService.publicLog2<TelemetryEvent, TelemetryClassification>('toolUse.runInTerminal', {
 			terminalSessionId: instance.sessionId,
@@ -183,7 +189,9 @@ export class RunInTerminalToolTelemetry {
 			inputToolManualAcceptCount: state.inputToolManualAcceptCount ?? 0,
 			inputToolManualRejectCount: state.inputToolManualRejectCount ?? 0,
 			inputToolManualChars: state.inputToolManualChars ?? 0,
-			inputToolManualShownCount: state.inputToolManualShownCount ?? 0
+			inputToolManualShownCount: state.inputToolManualShownCount ?? 0,
+			inputToolFreeFormInputShownCount: state.inputToolFreeFormInputShownCount ?? 0,
+			inputToolFreeFormInputCount: state.inputToolFreeFormInputCount ?? 0,
 		});
 	}
 }

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/taskHelpers.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/taskHelpers.ts
@@ -165,8 +165,10 @@ export async function collectTerminalResults(
 	inputToolManualRejectCount: number;
 	inputToolManualChars: number;
 	inputToolManualShownCount: number;
+	inputToolFreeFormInputShownCount: number;
+	inputToolFreeFormInputCount: number;
 }>> {
-	const results: Array<{ state: OutputMonitorState; name: string; output: string; resources?: ILinkLocation[]; pollDurationMs: number; inputToolManualAcceptCount: number; inputToolManualRejectCount: number; inputToolManualChars: number; inputToolAutoAcceptCount: number; inputToolAutoChars: number; inputToolManualShownCount: number }> = [];
+	const results: Array<{ state: OutputMonitorState; name: string; output: string; resources?: ILinkLocation[]; pollDurationMs: number; inputToolManualAcceptCount: number; inputToolManualRejectCount: number; inputToolManualChars: number; inputToolAutoAcceptCount: number; inputToolAutoChars: number; inputToolManualShownCount: number; inputToolFreeFormInputCount: number; inputToolFreeFormInputShownCount: number }> = [];
 	if (token.isCancellationRequested) {
 		return results;
 	}
@@ -195,6 +197,8 @@ export async function collectTerminalResults(
 			inputToolAutoAcceptCount: outputMonitor.outputMonitorTelemetryCounters.inputToolAutoAcceptCount ?? 0,
 			inputToolAutoChars: outputMonitor.outputMonitorTelemetryCounters.inputToolAutoChars ?? 0,
 			inputToolManualShownCount: outputMonitor.outputMonitorTelemetryCounters.inputToolManualShownCount ?? 0,
+			inputToolFreeFormInputShownCount: outputMonitor.outputMonitorTelemetryCounters.inputToolFreeFormInputShownCount ?? 0,
+			inputToolFreeFormInputCount: outputMonitor.outputMonitorTelemetryCounters.inputToolFreeFormInputCount ?? 0,
 		});
 	}
 	return results;

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/monitoring/outputMonitor.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/monitoring/outputMonitor.ts
@@ -439,10 +439,8 @@ export class OutputMonitor extends Disposable implements IOutputMonitor {
 			Now, analyze this output:
 			${lastFiveLines}
 			`;
-		const response = await this._languageModelsService.sendChatRequest(models[0], new ExtensionIdentifier('core'), [
-			{ role: ChatMessageRole.User, content: [{ type: 'text', value: promptText }] }
-		], {}, token);
 
+		const response = await this._languageModelsService.sendChatRequest(models[0], new ExtensionIdentifier('core'), [{ role: ChatMessageRole.User, content: [{ type: 'text', value: promptText }] }], {}, token);
 		const responseText = await getTextResponseFromStream(response);
 		try {
 			const match = responseText.match(/\{[\s\S]*\}/);

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/monitoring/outputMonitor.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/monitoring/outputMonitor.ts
@@ -42,6 +42,8 @@ export interface IOutputMonitorTelemetryCounters {
 	inputToolAutoAcceptCount: number;
 	inputToolAutoChars: number;
 	inputToolManualShownCount: number;
+	inputToolFreeFormInputShownCount: number;
+	inputToolFreeFormInputCount: number;
 }
 
 export class OutputMonitor extends Disposable implements IOutputMonitor {
@@ -63,7 +65,9 @@ export class OutputMonitor extends Disposable implements IOutputMonitor {
 		inputToolManualChars: 0,
 		inputToolAutoAcceptCount: 0,
 		inputToolAutoChars: 0,
-		inputToolManualShownCount: 0
+		inputToolManualShownCount: 0,
+		inputToolFreeFormInputShownCount: 0,
+		inputToolFreeFormInputCount: 0,
 	};
 	get outputMonitorTelemetryCounters(): Readonly<IOutputMonitorTelemetryCounters> { return this._outputMonitorTelemetryCounters; }
 
@@ -173,6 +177,27 @@ export class OutputMonitor extends Disposable implements IOutputMonitor {
 			} else {
 				// User declined
 				this._execution.instance.focus(true);
+				return { shouldContinuePollling: false };
+			}
+		} else if (confirmationPrompt?.freeFormInput) {
+			this._outputMonitorTelemetryCounters.inputToolFreeFormInputShownCount++;
+			const focusedTerminal = await this._focusTerminalForUserInput(this._execution, confirmationPrompt);
+			if (focusedTerminal) {
+				await new Promise<void>(resolve => {
+					const disposable = this._execution.instance.onData(data => {
+						if (data === '\r' || data === '\n' || data === '\r\n') {
+							this._outputMonitorTelemetryCounters.inputToolFreeFormInputCount++;
+							disposable.dispose();
+							resolve();
+						}
+					});
+				});
+				// Small delay to ensure input is processed
+				await timeout(200);
+				// Continue polling as we sent the input
+				return { shouldContinuePollling: true };
+			} else {
+				// User declined
 				return { shouldContinuePollling: false };
 			}
 		}
@@ -384,26 +409,31 @@ export class OutputMonitor extends Disposable implements IOutputMonitor {
 		}
 		const lastFiveLines = execution.getOutput(this._lastPromptMarker).trimEnd().split('\n').slice(-5).join('\n');
 		const promptText =
-			`Analyze the following terminal output. If it contains a prompt requesting user input (such as a confirmation, selection, or yes/no question) and that prompt has NOT already been answered, extract the prompt text and the possible options as a JSON object with keys 'prompt' and 'options' (an array of strings or an object with option to description mappings). For example, if the options are "[Y] Yes  [A] Yes to All  [N] No  [L] No to All  [C] Cancel", the option to description mappings would be {"Y": "Yes", "A": "Yes to All", "N": "No", "L": "No to All", "C": "Cancel"}. If there is no such prompt, return null.
+			`Analyze the following terminal output. If it contains a prompt requesting user input (such as a confirmation, selection, or yes/no question) and that prompt has NOT already been answered, extract the prompt text. The prompt may ask to choose from a set. If so, extract the possible options as a JSON object with keys 'prompt', 'options' (an array of strings or an object with option to description mappings), and 'freeFormInput': false. If no options are provided, and free form input is requested, for example: Password:, return the word freeFormInput. For example, if the options are "[Y] Yes  [A] Yes to All  [N] No  [L] No to All  [C] Cancel", the option to description mappings would be {"Y": "Yes", "A": "Yes to All", "N": "No", "L": "No to All", "C": "Cancel"}. If there is no such prompt, return null.
 			Examples:
 			1. Output: "Do you want to overwrite? (y/n)"
-				Response: {"prompt": "Do you want to overwrite?", "options": ["y", "n"]}
+				Response: {"prompt": "Do you want to overwrite?", "options": ["y", "n"], "freeFormInput": false}
 
 			2. Output: "Confirm: [Y] Yes  [A] Yes to All  [N] No  [L] No to All  [C] Cancel"
-				Response: {"prompt": "Confirm", "options": ["Y", "A", "N", "L", "C"]}
+				Response: {"prompt": "Confirm", "options": ["Y", "A", "N", "L", "C"], "freeFormInput": false}
 
 			3. Output: "Accept license terms? (yes/no)"
-				Response: {"prompt": "Accept license terms?", "options": ["yes", "no"]}
+				Response: {"prompt": "Accept license terms?", "options": ["yes", "no"], "freeFormInput": false}
 
 			4. Output: "Press Enter to continue"
-				Response: {"prompt": "Press Enter to continue", "options": ["Enter"]}
+				Response: {"prompt": "Press Enter to continue", "options": ["Enter"], "freeFormInput": false}
 
 			5. Output: "Type Yes to proceed"
-				Response: {"prompt": "Type Yes to proceed", "options": ["Yes"]}
+				Response: {"prompt": "Type Yes to proceed", "options": ["Yes"], "freeFormInput": false}
 
 			6. Output: "Continue [y/N]"
-				Response: {"prompt": "Continue", "options": ["y", "N"]}
+				Response: {"prompt": "Continue", "options": ["y", "N"], "freeFormInput": false}
 
+			Alternatively, the prompt may request free form input, for example:
+			1. Output: "Enter your username:"
+				Response: {"prompt": "Enter your username:", "freeFormInput": true, "options": []}
+			2. Output: "Password:"
+				Response: {"prompt": "Password:", "freeFormInput": true, "options": []}
 			Now, analyze this output:
 			${lastFiveLines}
 			`;
@@ -419,15 +449,17 @@ export class OutputMonitor extends Disposable implements IOutputMonitor {
 				if (
 					isObject(obj) &&
 					'prompt' in obj && isString(obj.prompt) &&
-					'options' in obj
+					'options' in obj &&
+					'options' in obj &&
+					'freeFormInput' in obj && typeof obj.freeFormInput === 'boolean'
 				) {
 					if (this._lastPrompt === obj.prompt) {
 						return;
 					}
 					if (Array.isArray(obj.options) && obj.options.every(isString)) {
-						return { prompt: obj.prompt, options: obj.options };
+						return { prompt: obj.prompt, options: obj.options, freeFormInput: obj.freeFormInput };
 					} else if (isObject(obj.options) && Object.values(obj.options).every(isString)) {
-						return { prompt: obj.prompt, options: Object.keys(obj.options), descriptions: Object.values(obj.options) };
+						return { prompt: obj.prompt, options: Object.keys(obj.options), descriptions: Object.values(obj.options), freeFormInput: obj.freeFormInput };
 					}
 				}
 			}
@@ -489,6 +521,56 @@ export class OutputMonitor extends Disposable implements IOutputMonitor {
 		}
 		const description = confirmationPrompt.descriptions?.[index];
 		return description ? { suggestedOption: { description, option: validOption }, sentToTerminal } : { suggestedOption: validOption, sentToTerminal };
+	}
+
+	private async _focusTerminalForUserInput(execution: IExecution, confirmationPrompt: IConfirmationPrompt): Promise<boolean> {
+		const chatModel = this._chatService.getSession(execution.sessionId);
+		if (!(chatModel instanceof ChatModel)) {
+			return false;
+		}
+		const request = chatModel.getRequests().at(-1);
+		if (!request) {
+			return false;
+		}
+		const userPrompt = new Promise<boolean>(resolve => {
+			const thePart = this._register(new ChatElicitationRequestPart(
+				new MarkdownString(localize('poll.terminal.inputRequest', "The terminal is awaiting input.")),
+				new MarkdownString(localize('poll.terminal.requireInput', "{0}\nPlease provide the required input to the terminal.\n\n", confirmationPrompt.prompt)),
+				'',
+				localize('poll.terminal.enterInput', 'Focus terminal'),
+				localize('poll.terminal.focusTerminal', 'Cancel request'),
+				async () => {
+					thePart.state = 'accepted';
+					thePart.hide();
+					thePart.dispose();
+					execution.instance.focus(true);
+					resolve(true);
+				},
+				async () => {
+					thePart.state = 'rejected';
+					thePart.hide();
+					this._state = OutputMonitorState.Cancelled;
+					this._outputMonitorTelemetryCounters.inputToolManualRejectCount++;
+					inputDataDisposable.dispose();
+					resolve(false);
+				},
+				undefined
+			));
+			this._register(thePart.onDidRequestHide(() => {
+				this._outputMonitorTelemetryCounters.inputToolFreeFormInputShownCount++;
+			}));
+			const inputDataDisposable = this._register(execution.instance.onDidInputData((data) => {
+				if (!data || data === '\r' || data === '\n' || data === '\r\n') {
+					thePart.hide();
+					thePart.dispose();
+					inputDataDisposable.dispose();
+					this._state = OutputMonitorState.PollingForIdle;
+					resolve(true);
+				}
+			}));
+			chatModel.acceptResponseProgress(request, thePart);
+		});
+		return await userPrompt;
 	}
 
 	private async _confirmRunInTerminal(suggestedOption: SuggestedOption, execution: IExecution, confirmationPrompt: IConfirmationPrompt): Promise<string | undefined> {

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/monitoring/types.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/monitoring/types.ts
@@ -12,7 +12,7 @@ export interface IConfirmationPrompt {
 	prompt: string;
 	options: string[];
 	descriptions?: string[];
-	freeFormInput: boolean;
+	detectedRequestForFreeFormInput: boolean;
 }
 
 export interface IExecution {

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/monitoring/types.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/monitoring/types.ts
@@ -12,6 +12,7 @@ export interface IConfirmationPrompt {
 	prompt: string;
 	options: string[];
 	descriptions?: string[];
+	freeFormInput: boolean;
 }
 
 export interface IExecution {

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
@@ -495,6 +495,8 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 					inputToolAutoAcceptCount: outputMonitor?.outputMonitorTelemetryCounters.inputToolAutoAcceptCount,
 					inputToolAutoChars: outputMonitor?.outputMonitorTelemetryCounters.inputToolAutoChars,
 					inputToolManualShownCount: outputMonitor?.outputMonitorTelemetryCounters.inputToolManualShownCount,
+					inputToolFreeFormInputCount: outputMonitor?.outputMonitorTelemetryCounters.inputToolFreeFormInputCount,
+					inputToolFreeFormInputShownCount: outputMonitor?.outputMonitorTelemetryCounters.inputToolFreeFormInputShownCount
 				});
 			}
 		} else {
@@ -577,6 +579,8 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 					inputToolAutoAcceptCount: outputMonitor?.outputMonitorTelemetryCounters?.inputToolAutoAcceptCount,
 					inputToolAutoChars: outputMonitor?.outputMonitorTelemetryCounters?.inputToolAutoChars,
 					inputToolManualShownCount: outputMonitor?.outputMonitorTelemetryCounters?.inputToolManualShownCount,
+					inputToolFreeFormInputCount: outputMonitor?.outputMonitorTelemetryCounters?.inputToolFreeFormInputCount,
+					inputToolFreeFormInputShownCount: outputMonitor?.outputMonitorTelemetryCounters?.inputToolFreeFormInputShownCount
 				});
 			}
 

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/task/createAndRunTaskTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/task/createAndRunTaskTool.ts
@@ -127,6 +127,8 @@ export class CreateAndRunTaskTool implements IToolImpl {
 				inputToolManualRejectCount: r.inputToolManualRejectCount ?? 0,
 				inputToolManualChars: r.inputToolManualChars ?? 0,
 				inputToolManualShownCount: r.inputToolManualShownCount ?? 0,
+				inputToolFreeFormInputCount: r.inputToolFreeFormInputCount ?? 0,
+				inputToolFreeFormInputShownCount: r.inputToolFreeFormInputShownCount ?? 0
 			});
 		}
 

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/task/getTaskOutputTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/task/getTaskOutputTool.ts
@@ -115,6 +115,8 @@ export class GetTaskOutputTool extends Disposable implements IToolImpl {
 				inputToolManualRejectCount: r.inputToolManualRejectCount ?? 0,
 				inputToolManualChars: r.inputToolManualChars ?? 0,
 				inputToolManualShownCount: r.inputToolManualShownCount ?? 0,
+				inputToolFreeFormInputCount: r.inputToolFreeFormInputCount ?? 0,
+				inputToolFreeFormInputShownCount: r.inputToolFreeFormInputShownCount ?? 0
 			});
 		}
 		const details = terminalResults.map(r => `Terminal: ${r.name}\nOutput:\n${r.output}`);

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/task/runTaskTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/task/runTaskTool.ts
@@ -87,6 +87,8 @@ export class RunTaskTool implements IToolImpl {
 				inputToolManualRejectCount: r.inputToolManualRejectCount ?? 0,
 				inputToolManualChars: r.inputToolManualChars ?? 0,
 				inputToolManualShownCount: r.inputToolManualShownCount ?? 0,
+				inputToolFreeFormInputShownCount: r.inputToolFreeFormInputShownCount ?? 0,
+				inputToolFreeFormInputCount: r.inputToolFreeFormInputCount ?? 0
 			});
 		}
 

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/task/taskToolsTelemetry.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/task/taskToolsTelemetry.ts
@@ -12,6 +12,8 @@ export type TaskToolClassification = {
 	inputToolManualRejectCount: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'The number of times the user manually rejected a detected suggestion' };
 	inputToolManualChars: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'The number of characters input by manual acceptance of suggestions' };
 	inputToolManualShownCount: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'The number of times the user was prompted to manually accept an input suggestion' };
+	inputToolFreeFormInputShownCount: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'The number of times the user was prompted to provide free form input' };
+	inputToolFreeFormInputCount: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'The number of times the user provided free form input after prompting' };
 	owner: 'meganrogge';
 	comment: 'Understanding the usage of the task tools';
 };
@@ -23,4 +25,6 @@ export type TaskToolEvent = {
 	inputToolManualRejectCount: number;
 	inputToolManualChars: number;
 	inputToolManualShownCount: number;
+	inputToolFreeFormInputShownCount: number;
+	inputToolFreeFormInputCount: number;
 };


### PR DESCRIPTION
fixes https://github.com/microsoft/vscode/issues/264584

Makes the `reject` action optional in the `ChatRequestElicitationPrompt`

https://github.com/user-attachments/assets/27755674-07f6-40f5-9688-74c542fc37c7

