### PR TITLE
Add eslint rule to ban using dompurify directly

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -25,6 +25,7 @@ src/cli.ts @bpasero @deepak1556
 src/main.ts @bpasero @deepak1556
 src/server-cli.ts @bpasero @deepak1556
 src/server-main.ts @bpasero @deepak1556
+src/vs/base/browser/domSanitize.ts @mjbvz
 src/vs/base/parts/sandbox/** @bpasero @deepak1556
 src/vs/base/parts/storage/** @bpasero @deepak1556
 src/vs/platform/backup/** @bpasero

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -763,6 +763,17 @@ export default tseslint.config(
 			'local': pluginLocal,
 		},
 		rules: {
+			'no-restricted-imports': [
+				'warn',
+				{
+					'patterns': [
+						{
+							'group': ['dompurify*'],
+							'message': 'Use domSanitize instead of dompurify directly'
+						},
+					]
+				}
+			],
 			'local/code-import-patterns': [
 				'warn',
 				{

--- a/src/vs/base/browser/domSanitize.ts
+++ b/src/vs/base/browser/domSanitize.ts
@@ -5,6 +5,7 @@
 
 import { Schemas } from '../common/network.js';
 import { reset } from './dom.js';
+// eslint-disable-next-line no-restricted-imports
 import dompurify from './dompurify/dompurify.js';
 
 /**


### PR DESCRIPTION
All callers in our codebase should use our `domSanitize` wrapper instead

Also adding myself as a codeowner here to make sure I'm alerted to changes in domSanitize since they need more consideration
