### PR TITLE
Show and hide viewcontainer based on visibility toggle

### DIFF
--- a/src/vs/workbench/browser/parts/compositeBar.ts
+++ b/src/vs/workbench/browser/parts/compositeBar.ts
@@ -156,6 +156,7 @@ export interface ICompositeBarOptions {
 	readonly getContextMenuActionsForComposite: (compositeId: string) => IAction[];
 
 	readonly openComposite: (compositeId: string, preserveFocus?: boolean) => Promise<IComposite | null>;
+	readonly hideActiveComposite: () => void;
 	readonly getDefaultCompositeId: () => string | undefined;
 }
 
@@ -348,9 +349,15 @@ export class CompositeBar extends Widget implements ICompositeBar {
 	}
 
 	addComposite({ id, name, order, requestedIndex }: { id: string; name: string; order?: number; requestedIndex?: number }): void {
+		const hadVisibleComposites = this.visibleComposites.length !== 0;
 		if (this.model.add(id, name, order, requestedIndex)) {
 			this.computeSizes([this.model.findItem(id)]);
 			this.updateCompositeSwitcher();
+
+			const hasVisibleComposites = this.visibleComposites.length !== 0;
+			if (!hadVisibleComposites && hasVisibleComposites) {
+				this.options.openComposite(id, true);
+			}
 		}
 	}
 
@@ -368,9 +375,15 @@ export class CompositeBar extends Widget implements ICompositeBar {
 	}
 
 	hideComposite(id: string): void {
+		const wasVisible = this.visibleComposites.length !== 0;
 		if (this.model.hide(id)) {
 			this.resetActiveComposite(id);
 			this.updateCompositeSwitcher();
+
+			const isVisible = this.visibleComposites.length !== 0;
+			if (wasVisible && !isVisible) {
+				this.options.hideActiveComposite();
+			}
 		}
 	}
 

--- a/src/vs/workbench/browser/parts/compositePart.ts
+++ b/src/vs/workbench/browser/parts/compositePart.ts
@@ -42,7 +42,7 @@ export interface ICompositeTitleLabel {
 	/**
 	 * Asks to update the title for the composite with the given ID.
 	 */
-	updateTitle(id: string, title: string, keybinding?: string): void;
+	updateTitle(id: string | undefined, title: string, keybinding?: string): void;
 
 	/**
 	 * Called when theming information changes.
@@ -429,7 +429,7 @@ export abstract class CompositePart<T extends Composite> extends Part {
 		return {
 			updateTitle: (id, title, keybinding) => {
 				// The title label is shared for all composites in the base CompositePart
-				if (!this.activeComposite || this.activeComposite.getId() === id) {
+				if (this.activeComposite?.getId() === id) {
 					titleLabel.textContent = title;
 					hover.update(keybinding ? localize('titleTooltip', "{0} ({1})", title, keybinding) : title);
 				}

--- a/src/vs/workbench/browser/parts/paneCompositeBar.ts
+++ b/src/vs/workbench/browser/parts/paneCompositeBar.ts
@@ -144,6 +144,9 @@ export class PaneCompositeBar extends Disposable {
 			openComposite: async (compositeId, preserveFocus) => {
 				return (await this.paneCompositePart.openPaneComposite(compositeId, !preserveFocus)) ?? null;
 			},
+			hideActiveComposite: () => {
+				this.paneCompositePart.hideActivePaneComposite();
+			},
 			getActivityAction: compositeId => this.getCompositeActions(compositeId).activityAction,
 			getCompositePinnedAction: compositeId => this.getCompositeActions(compositeId).pinnedAction,
 			getCompositeBadgeAction: compositeId => this.getCompositeActions(compositeId).badgeAction,

--- a/src/vs/workbench/browser/parts/paneCompositePart.ts
+++ b/src/vs/workbench/browser/parts/paneCompositePart.ts
@@ -627,7 +627,7 @@ export abstract class AbstractPaneCompositePart extends CompositePart<PaneCompos
 		const visible = !this.getActiveComposite();
 		this.element.classList.toggle('empty', visible);
 		if (visible) {
-			this.titleLabel?.updateTitle('', '');
+			this.titleLabel?.updateTitle(undefined, '');
 		}
 	}
 


### PR DESCRIPTION
```Copilot Generated Description:``` Implement functionality to show and hide the viewcontainer when toggling visibility using context keys. This includes updates to the interface and class methods to manage the visibility state effectively.

fixes https://github.com/microsoft/vscode/issues/265248

possibly also https://github.com/microsoft/vscode/issues/261140 https://github.com/microsoft/vscode/issues/242393