### PR TITLE
Fix TOC in release notes

### DIFF
--- a/src/vs/workbench/contrib/update/browser/releaseNotesEditor.ts
+++ b/src/vs/workbench/contrib/update/browser/releaseNotesEditor.ts
@@ -265,26 +265,7 @@ export class ReleaseNotesManager extends Disposable {
 	private async renderBody(fileContent: { text: string; base: URI }) {
 		const nonce = generateUuid();
 
-		const content = await renderMarkdownDocument(fileContent.text, this._extensionService, this._languageService, {
-			sanitizerConfig: {
-				allowRelativeMediaPaths: true,
-				allowedLinkProtocols: {
-					override: [Schemas.http, Schemas.https, Schemas.command]
-				}
-			},
-			markedExtensions: [{
-				renderer: {
-					html: this._simpleSettingRenderer.getHtmlRenderer(),
-					codespan: this._simpleSettingRenderer.getCodeSpanRenderer(),
-				}
-			}]
-		});
-
-		// Remove HTML comment markers around table of contents navigation
-		const processedContent = content
-			.toString()
-			.replace(/<!--\s*TOC\s*/gi, '')
-			.replace(/\s*Navigation End\s*-->/gi, '');
+		const processedContent = await renderReleaseNotesMarkdown(fileContent.text, this._extensionService, this._languageService, this._simpleSettingRenderer);
 
 		const colorMap = TokenizationRegistry.getColorMap();
 		const css = colorMap ? generateTokensCSSForColorMap(colorMap) : '';
@@ -627,4 +608,32 @@ export class ReleaseNotesManager extends Disposable {
 			});
 		}
 	}
+}
+
+export async function renderReleaseNotesMarkdown(
+	text: string,
+	extensionService: IExtensionService,
+	languageService: ILanguageService,
+	simpleSettingRenderer: SimpleSettingRenderer,
+): Promise<TrustedHTML> {
+	// Remove HTML comment markers around table of contents navigation
+	text = text
+		.toString()
+		.replace(/<!--\s*TOC\s*/gi, '')
+		.replace(/\s*Navigation End\s*-->/gi, '');
+
+	return renderMarkdownDocument(text, extensionService, languageService, {
+		sanitizerConfig: {
+			allowRelativeMediaPaths: true,
+			allowedLinkProtocols: {
+				override: [Schemas.http, Schemas.https, Schemas.command]
+			}
+		},
+		markedExtensions: [{
+			renderer: {
+				html: simpleSettingRenderer.getHtmlRenderer(),
+				codespan: simpleSettingRenderer.getCodeSpanRenderer(),
+			}
+		}]
+	});
 }

--- a/src/vs/workbench/contrib/update/test/browser/__snapshots__/Release_notes_renderer_Should_render_TOC.0.snap
+++ b/src/vs/workbench/contrib/update/test/browser/__snapshots__/Release_notes_renderer_Should_render_TOC.0.snap
@@ -1,0 +1,22 @@
+<table class="highlights-table">
+    <tbody><tr>
+        <th>a</th>
+    </tr>
+</tbody></table>
+
+<br>
+
+<blockquote>
+<p>text</p>
+</blockquote>
+<div class="toc-nav-layout">
+    
+        <div>In this update</div>
+        <ul>
+            <li><a href="#chat">test</a></li>
+        </ul>
+    
+    <div class="notes-main">
+
+<h2 id="test">Test</h2>
+</div></div>

--- a/src/vs/workbench/contrib/update/test/browser/releaseNotesRenderer.test.ts
+++ b/src/vs/workbench/contrib/update/test/browser/releaseNotesRenderer.test.ts
@@ -1,0 +1,58 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import { assertSnapshot } from '../../../../../base/test/common/snapshot.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { ILanguageService } from '../../../../../editor/common/languages/language.js';
+import { ContextMenuService } from '../../../../../platform/contextview/browser/contextMenuService.js';
+import { IContextMenuService } from '../../../../../platform/contextview/browser/contextView.js';
+import { TestInstantiationService } from '../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
+import { IExtensionService } from '../../../../services/extensions/common/extensions.js';
+import { SimpleSettingRenderer } from '../../../markdown/browser/markdownSettingRenderer.js';
+import { renderReleaseNotesMarkdown } from '../../browser/releaseNotesEditor.js';
+
+
+suite('Release notes renderer', () => {
+	const store = ensureNoDisposablesAreLeakedInTestSuite();
+
+	let instantiationService: TestInstantiationService;
+	let extensionService: IExtensionService;
+	let languageService: ILanguageService;
+
+	setup(() => {
+		instantiationService = store.add(new TestInstantiationService());
+		extensionService = instantiationService.get(IExtensionService);
+		languageService = instantiationService.get(ILanguageService);
+
+		instantiationService.stub(IContextMenuService, store.add(instantiationService.createInstance(ContextMenuService)));
+	});
+
+	test('Should render TOC', async () => {
+		const content = `<table class="highlights-table">
+	<tr>
+		<th>a</th>
+	</tr>
+</table>
+
+<br>
+
+> text
+
+<!-- TOC
+<div class="toc-nav-layout">
+	<nav id="toc-nav">
+		<div>In this update</div>
+		<ul>
+			<li><a href="#chat">test</a></li>
+		</ul>
+	</nav>
+	<div class="notes-main">
+Navigation End -->
+
+## Test`;
+
+		const result = await renderReleaseNotesMarkdown(content, extensionService, languageService, instantiationService.createInstance(SimpleSettingRenderer));
+		await assertSnapshot(result.toString());
+	});
+});


### PR DESCRIPTION
For #266235

We should create the html content before sanitization, not after

Also adds tests so we can catch regressions in the future 

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
