### PR TITLE
Fix PowerShell shell integration when strict mode is enabled.

### DIFF
--- a/src/vs/workbench/contrib/terminal/common/scripts/shellIntegration.ps1
+++ b/src/vs/workbench/contrib/terminal/common/scripts/shellIntegration.ps1
@@ -4,7 +4,7 @@
 # ---------------------------------------------------------------------------------------------
 
 # Prevent installing more than once per session
-if ($Global:__VSCodeState.OriginalPrompt -ne $null) {
+if ((Test-Path variable:global:__VSCodeState) -and $null -ne $Global:__VSCodeState.OriginalPrompt) {
 	return;
 }
 


### PR DESCRIPTION
Check if variable exists before accessing it to prevent script failures in strict mode.

See #248625 for previous fix.

