### PR TITLE
Use mouse instead of element for Quick Pick hovers

### DIFF
--- a/src/vs/platform/quickinput/browser/quickInput.ts
+++ b/src/vs/platform/quickinput/browser/quickInput.ts
@@ -1340,7 +1340,7 @@ export class QuickInputHoverDelegate extends WorkbenchHoverDelegate {
 		@IConfigurationService configurationService: IConfigurationService,
 		@IHoverService hoverService: IHoverService
 	) {
-		super('element', undefined, (options) => this.getOverrideOptions(options), configurationService, hoverService);
+		super('mouse', undefined, (options) => this.getOverrideOptions(options), configurationService, hoverService);
 	}
 
 	private getOverrideOptions(options: IHoverDelegateOptions): Partial<IHoverOptions> {


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/263442

This is what we use to have until https://github.com/microsoft/vscode/pull/206043/files ... Doesn't seem to regress https://github.com/microsoft/vscode/issues/206039 which is what that PR was aiming to fix.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
