### PR TITLE
dispose of ref instead of object itself to avoid null objects.

### DIFF
--- a/src/vs/workbench/contrib/chat/common/codeBlockModelCollection.ts
+++ b/src/vs/workbench/contrib/chat/common/codeBlockModelCollection.ts
@@ -101,13 +101,12 @@ export class CodeBlockModelCollection extends Disposable {
 			return;
 		}
 
-		entry.model.then(ref => ref.object.dispose());
-
+		entry.model.then(ref => ref.dispose());
 		this._models.delete(key);
 	}
 
 	clear(): void {
-		this._models.forEach(async entry => (await entry.model).dispose());
+		this._models.forEach(async entry => await entry.model.then(ref => ref.dispose()));
 		this._models.clear();
 	}
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes an issue with scrolling in Copilot chats with many code blocks (100+). The behavior is that after scrolling up and down through the chat, some code blocks shrink to 0 height and the code is no longer visible. See the included video for an example:

https://github.com/user-attachments/assets/98af5b0a-6951-4bc3-b2dd-0f68c9fad906

---

### Root Cause
The problem came from how `CodeBlockModelCollection` was disposing models. It was calling `ref.object.dispose()`, which disposes the **underlying text model itself**. Instead, it should call `ref.dispose()`, which disposes the **reference** and releases it.  

By disposing the model directly, later code block components ended up with null/invalid models during virtualization cycles. That’s why editors collapsed or reported `content height = -1`.

---

### Fix
Replace calls to `ref.object.dispose()` with `ref.dispose()` in `delete()` and `clear()`. This properly disposes the reference, allowing models to remain valid and be reused when scrolling back.

---

### Testing
- Manually tested with an OSS build of VS Code and Copilot Chat, reproducing the bug with >100 code blocks. After the fix, blocks remain visible when scrolling.  
- Ran automated tests (`./scripts/test.sh`) with no regressions.  
- See fix example here:  

https://github.com/user-attachments/assets/d4425097-919a-4212-8d63-4890af7a6c57  

---

### Related
Fixes #266296  
Related telemetry issues: #240028, #248829, #255827  


