### PR TITLE
mcp: be graceful about autostarting servers that require interaction

### DIFF
--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -3019,7 +3019,7 @@ export interface ExtHostTestingShape {
 
 export interface ExtHostMcpShape {
 	$resolveMcpLaunch(collectionId: string, label: string): Promise<McpServerLaunch.Serialized | undefined>;
-	$startMcp(id: number, launch: McpServerLaunch.Serialized): void;
+	$startMcp(id: number, launch: McpServerLaunch.Serialized, errorOnUserInteraction?: boolean): void;
 	$stopMcp(id: number): void;
 	$sendMessage(id: number, message: string): void;
 	$waitForInitialCollectionProviders(): Promise<void>;
@@ -3031,7 +3031,7 @@ export interface MainThreadMcpShape {
 	$onDidReceiveMessage(id: number, message: string): void;
 	$upsertMcpCollection(collection: McpCollectionDefinition.FromExtHost, servers: McpServerDefinition.Serialized[]): void;
 	$deleteMcpCollection(collectionId: string): void;
-	$getTokenFromServerMetadata(id: number, authorizationServer: UriComponents, serverMetadata: IAuthorizationServerMetadata, resourceMetadata: IAuthorizationProtectedResourceMetadata | undefined): Promise<string | undefined>;
+	$getTokenFromServerMetadata(id: number, authorizationServer: UriComponents, serverMetadata: IAuthorizationServerMetadata, resourceMetadata: IAuthorizationProtectedResourceMetadata | undefined, errorOnUserInteraction?: boolean): Promise<string | undefined>;
 }
 
 export interface MainThreadDataChannelsShape extends IDisposable {

--- a/src/vs/workbench/api/common/extHostMcp.ts
+++ b/src/vs/workbench/api/common/extHostMcp.ts
@@ -47,13 +47,13 @@ export class ExtHostMcpService extends Disposable implements IExtHostMpcService 
 		this._proxy = extHostRpc.getProxy(MainContext.MainThreadMcp);
 	}
 
-	$startMcp(id: number, launch: McpServerLaunch.Serialized): void {
-		this._startMcp(id, McpServerLaunch.fromSerialized(launch));
+	$startMcp(id: number, launch: McpServerLaunch.Serialized, errorOnUserInteraction?: boolean): void {
+		this._startMcp(id, McpServerLaunch.fromSerialized(launch), errorOnUserInteraction);
 	}
 
-	protected _startMcp(id: number, launch: McpServerLaunch): void {
+	protected _startMcp(id: number, launch: McpServerLaunch, errorOnUserInteraction?: boolean): void {
 		if (launch.type === McpServerTransportType.HTTP) {
-			this._sseEventSources.set(id, new McpHTTPHandle(id, launch, this._proxy, this._logService));
+			this._sseEventSources.set(id, new McpHTTPHandle(id, launch, this._proxy, this._logService, errorOnUserInteraction));
 			return;
 		}
 
@@ -203,6 +203,7 @@ class McpHTTPHandle extends Disposable {
 		private readonly _launch: McpServerTransportHTTP,
 		private readonly _proxy: MainThreadMcpShape,
 		private readonly _logService: ILogService,
+		private readonly _errorOnUserInteraction?: boolean,
 	) {
 		super();
 
@@ -670,7 +671,7 @@ class McpHTTPHandle extends Disposable {
 	private async _addAuthHeader(headers: Record<string, string>) {
 		if (this._authMetadata) {
 			try {
-				const token = await this._proxy.$getTokenFromServerMetadata(this._id, this._authMetadata.authorizationServer, this._authMetadata.serverMetadata, this._authMetadata.resourceMetadata);
+				const token = await this._proxy.$getTokenFromServerMetadata(this._id, this._authMetadata.authorizationServer, this._authMetadata.serverMetadata, this._authMetadata.resourceMetadata, this._errorOnUserInteraction);
 				if (token) {
 					headers['Authorization'] = `Bearer ${token}`;
 				}

--- a/src/vs/workbench/api/node/extHostMcpNode.ts
+++ b/src/vs/workbench/api/node/extHostMcpNode.ts
@@ -30,11 +30,11 @@ export class NodeExtHostMpcService extends ExtHostMcpService {
 
 	private nodeServers = this._register(new DisposableMap<number, McpStdioStateHandler>());
 
-	protected override _startMcp(id: number, launch: McpServerLaunch): void {
+	protected override _startMcp(id: number, launch: McpServerLaunch, errorOnUserInteraction?: boolean): void {
 		if (launch.type === McpServerTransportType.Stdio) {
 			this.startNodeMpc(id, launch);
 		} else {
-			super._startMcp(id, launch);
+			super._startMcp(id, launch, errorOnUserInteraction);
 		}
 	}
 

--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -351,7 +351,7 @@ configurationRegistry.registerConfiguration({
 		[mcpAutoStartConfig]: {
 			type: 'string',
 			description: nls.localize('chat.mcp.autostart', "Controls whether MCP servers should be automatically started when the chat messages are submitted."),
-			default: McpAutoStartValue.Never,
+			default: McpAutoStartValue.NewAndOutdated,
 			enum: [
 				McpAutoStartValue.Never,
 				McpAutoStartValue.OnlyNew,

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/chatMcpServersInteractionContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/chatMcpServersInteractionContentPart.ts
@@ -1,0 +1,131 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as dom from '../../../../../base/browser/dom.js';
+import { Codicon } from '../../../../../base/common/codicons.js';
+import { Emitter } from '../../../../../base/common/event.js';
+import { markdownCommandLink, MarkdownString } from '../../../../../base/common/htmlContent.js';
+import { Disposable, IDisposable } from '../../../../../base/common/lifecycle.js';
+import { ThemeIcon } from '../../../../../base/common/themables.js';
+import { MarkdownRenderer, openLinkFromMarkdown } from '../../../../../editor/browser/widget/markdownRenderer/browser/markdownRenderer.js';
+import { localize } from '../../../../../nls.js';
+import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
+import { IOpenerService } from '../../../../../platform/opener/common/opener.js';
+import { McpCommandIds } from '../../../mcp/common/mcpCommandIds.js';
+import { IMcpService } from '../../../mcp/common/mcpTypes.js';
+import { startServerAndWaitForLiveTools } from '../../../mcp/common/mcpTypesUtils.js';
+import { IChatMcpServersInteractionRequired } from '../../common/chatService.js';
+import { IChatRendererContent } from '../../common/chatViewModel.js';
+import { IChatContentPart } from './chatContentParts.js';
+import './media/chatMcpServersInteractionContent.css';
+
+export class ChatMcpServersInteractionContentPart extends Disposable implements IChatContentPart {
+	public readonly domNode: HTMLElement;
+	private readonly _onDidChangeHeight = this._register(new Emitter<void>());
+	public readonly onDidChangeHeight = this._onDidChangeHeight.event;
+
+	constructor(
+		private readonly data: IChatMcpServersInteractionRequired,
+		@IMcpService private readonly mcpService: IMcpService,
+		@IInstantiationService private readonly instantiationService: IInstantiationService,
+		@IOpenerService private readonly _openerService: IOpenerService,
+	) {
+		super();
+
+		this.domNode = dom.$('.chat-mcp-servers-interaction');
+		if (!data.isDone) {
+			this.render();
+		}
+	}
+
+	private render(): void {
+		const container = dom.$('.chat-mcp-servers-interaction-hint');
+
+		// Create subtle hint message
+		const messageContainer = dom.$('.chat-mcp-servers-message');
+		const icon = dom.$('.chat-mcp-servers-icon');
+		icon.classList.add(...ThemeIcon.asClassNameArray(Codicon.mcp));
+
+		const count = this.data.servers.length;
+
+		const markdownRenderer = this.instantiationService.createInstance(MarkdownRenderer, {});
+		const links = this.data.servers.map(s => markdownCommandLink({
+			title: '`' + s.serverLabel + '`',
+			id: McpCommandIds.ServerOptions,
+			arguments: [s.serverId],
+		}, false)).join(', ');
+
+		const content = count === 1
+			? localize('mcp.start.single', 'The MCP server {0} may have new tools and requires interaction to start. [Start it now?]({1})', links, '#start')
+			: localize('mcp.start.multiple', 'The MCP servers {0} may have new tools and require interaction to start. [Start them now?]({1})', links, '#start');
+		const str = new MarkdownString(content, { isTrusted: true });
+		const messageMd = markdownRenderer.render(str, {
+			asyncRenderCallback: () => this._onDidChangeHeight.fire(),
+			actionHandler: (content) => {
+				if (!content.startsWith('command:')) {
+					this._start(startLink!);
+					return Promise.resolve(true);
+				}
+				return openLinkFromMarkdown(this._openerService, content, true);
+			}
+		});
+
+		const startLink = [...messageMd.element.querySelectorAll('a')].find(a => !a.getAttribute('data-href')?.startsWith('command:'));
+		if (!startLink) {
+			// Should not happen
+			return;
+		}
+
+		startLink.setAttribute('role', 'button');
+		startLink.href = '';
+
+		messageContainer.appendChild(icon);
+		messageContainer.appendChild(messageMd.element);
+
+		container.appendChild(messageContainer);
+		this.domNode.appendChild(container);
+	}
+
+	private async _start(startLink: HTMLElement) {
+
+		// Update to starting state
+		startLink.style.pointerEvents = 'none';
+		startLink.style.opacity = '0.7';
+
+		try {
+			// Start servers in sequence with progress updates
+			for (let i = 0; i < this.data.servers.length; i++) {
+				const serverInfo = this.data.servers[i];
+				startLink.textContent = localize('mcp.starting', "Starting {0}...", serverInfo.serverLabel);
+				this._onDidChangeHeight.fire();
+
+				const server = this.mcpService.servers.get().find(s => s.definition.id === serverInfo.serverId);
+				if (server) {
+					await startServerAndWaitForLiveTools(server, { promptType: 'all-untrusted' });
+				}
+			}
+
+			// Remove the component after successful start
+			this.data.isDone = true;
+			this.domNode.remove();
+		} catch (error) {
+			// Reset link on error
+			startLink.style.pointerEvents = '';
+			startLink.style.opacity = '';
+			startLink.textContent = 'Start now?';
+		} finally {
+			this._onDidChangeHeight.fire();
+		}
+	}
+
+	hasSameContent(other: IChatRendererContent): boolean {
+		// Simple implementation that checks if it's the same type
+		return (other as any).kind === 'mcpServersInteractionRequired';
+	}
+
+	addDisposable(disposable: IDisposable): void {
+		this._register(disposable);
+	}
+}

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/media/chatMcpServersInteractionContent.css
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/media/chatMcpServersInteractionContent.css
@@ -1,0 +1,14 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+.chat-mcp-servers-message {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	font-style: italic;
+	font-size: 12px;
+	color: var(--vscode-descriptionForeground);
+	opacity: 0.8;
+}

--- a/src/vs/workbench/contrib/chat/browser/chatListRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatListRenderer.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import './chatContentParts/media/chatMcpServersInteractionContent.css';
 import * as dom from '../../../../base/browser/dom.js';
 import { renderFormattedText } from '../../../../base/browser/formattedTextRenderer.js';
 import { StandardKeyboardEvent } from '../../../../base/browser/keyboardEvent.js';
@@ -52,7 +53,7 @@ import { IChatAgentMetadata } from '../common/chatAgents.js';
 import { ChatContextKeys } from '../common/chatContextKeys.js';
 import { IChatTextEditGroup } from '../common/chatModel.js';
 import { chatSubcommandLeader } from '../common/chatParserTypes.js';
-import { ChatAgentVoteDirection, ChatAgentVoteDownReason, ChatErrorLevel, IChatChangesSummary, IChatConfirmation, IChatContentReference, IChatElicitationRequest, IChatExtensionsContent, IChatFollowup, IChatMarkdownContent, IChatMultiDiffData, IChatPullRequestContent, IChatTask, IChatTaskSerialized, IChatThinkingPart, IChatToolInvocation, IChatToolInvocationSerialized, IChatTreeData, IChatUndoStop } from '../common/chatService.js';
+import { ChatAgentVoteDirection, ChatAgentVoteDownReason, ChatErrorLevel, IChatChangesSummary, IChatConfirmation, IChatContentReference, IChatElicitationRequest, IChatExtensionsContent, IChatFollowup, IChatMarkdownContent, IChatMcpServersInteractionRequired, IChatMultiDiffData, IChatPullRequestContent, IChatTask, IChatTaskSerialized, IChatThinkingPart, IChatToolInvocation, IChatToolInvocationSerialized, IChatTreeData, IChatUndoStop } from '../common/chatService.js';
 import { IChatRequestVariableEntry } from '../common/chatVariableEntries.js';
 import { IChatChangesSummaryPart, IChatCodeCitations, IChatErrorDetailsPart, IChatReferences, IChatRendererContent, IChatRequestViewModel, IChatResponseViewModel, IChatViewModel, isRequestVM, isResponseVM } from '../common/chatViewModel.js';
 import { getNWords } from '../common/chatWordCounter.js';
@@ -73,6 +74,7 @@ import { ChatErrorConfirmationContentPart } from './chatContentParts/chatErrorCo
 import { ChatErrorContentPart } from './chatContentParts/chatErrorContentPart.js';
 import { ChatExtensionsContentPart } from './chatContentParts/chatExtensionsContentPart.js';
 import { ChatMarkdownContentPart, EditorPool } from './chatContentParts/chatMarkdownContentPart.js';
+import { ChatMcpServersInteractionContentPart } from './chatContentParts/chatMcpServersInteractionContentPart.js';
 import { ChatMultiDiffContentPart } from './chatContentParts/chatMultiDiffContentPart.js';
 import { ChatProgressContentPart, ChatWorkingProgressContentPart } from './chatContentParts/chatProgressContentPart.js';
 import { ChatPullRequestContentPart } from './chatContentParts/chatPullRequestContentPart.js';
@@ -754,7 +756,7 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 			((lastPart.kind === 'toolInvocation' || lastPart.kind === 'toolInvocationSerialized') && (lastPart.isComplete || lastPart.presentation === 'hidden')) ||
 			((lastPart.kind === 'textEditGroup' || lastPart.kind === 'notebookEditGroup') && lastPart.done && !partsToRender.some(part => part.kind === 'toolInvocation' && !part.isComplete)) ||
 			(lastPart.kind === 'progressTask' && lastPart.deferred.isSettled) ||
-			lastPart.kind === 'prepareToolInvocation'
+			lastPart.kind === 'prepareToolInvocation' || lastPart.kind === 'mcpServersInteractionRequired'
 		) {
 			return true;
 		}
@@ -1237,6 +1239,8 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 				return this.renderElicitation(context, content, templateData);
 			} else if (content.kind === 'changesSummary') {
 				return this.renderChangesSummary(content, context, templateData);
+			} else if (content.kind === 'mcpServersInteractionRequired') {
+				return this.renderMcpServersInteractionRequired(content, context, templateData);
 			} else if (content.kind === 'thinking' && this.shouldShowThinkingPart()) {
 				return this.renderThinkingPart(content, context, templateData);
 			}
@@ -1564,6 +1568,10 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 			templateData.titleToolbar.context = undefined;
 		}
 		templateData.footerToolbar.context = undefined;
+	}
+
+	private renderMcpServersInteractionRequired(content: IChatMcpServersInteractionRequired, context: IChatContentPartRenderContext, templateData: IChatListItemTemplate): IChatContentPart {
+		return this.instantiationService.createInstance(ChatMcpServersInteractionContentPart, content);
 	}
 
 	disposeTemplate(templateData: IChatListItemTemplate): void {

--- a/src/vs/workbench/contrib/chat/common/chatModel.ts
+++ b/src/vs/workbench/contrib/chat/common/chatModel.ts
@@ -28,7 +28,7 @@ import { migrateLegacyTerminalToolSpecificData } from './chat.js';
 import { IChatAgentCommand, IChatAgentData, IChatAgentResult, IChatAgentService, reviveSerializedAgent } from './chatAgents.js';
 import { IChatEditingService, IChatEditingSession } from './chatEditingService.js';
 import { ChatRequestTextPart, IParsedChatRequest, reviveParsedChatRequest } from './chatParserTypes.js';
-import { ChatAgentVoteDirection, ChatAgentVoteDownReason, ChatResponseClearToPreviousToolInvocationReason, IChatAgentMarkdownContentWithVulnerability, IChatClearToPreviousToolInvocation, IChatCodeCitation, IChatCommandButton, IChatConfirmation, IChatContentInlineReference, IChatContentReference, IChatEditingSessionAction, IChatElicitationRequest, IChatExtensionsContent, IChatFollowup, IChatLocationData, IChatMarkdownContent, IChatMultiDiffData, IChatNotebookEdit, IChatPrepareToolInvocationPart, IChatProgress, IChatProgressMessage, IChatPullRequestContent, IChatResponseCodeblockUriPart, IChatResponseProgressFileTreeData, IChatTask, IChatTaskSerialized, IChatTextEdit, IChatThinkingPart, IChatToolInvocation, IChatToolInvocationSerialized, IChatTreeData, IChatUndoStop, IChatUsedContext, IChatWarningMessage, isIUsedContext } from './chatService.js';
+import { ChatAgentVoteDirection, ChatAgentVoteDownReason, ChatResponseClearToPreviousToolInvocationReason, IChatAgentMarkdownContentWithVulnerability, IChatClearToPreviousToolInvocation, IChatCodeCitation, IChatCommandButton, IChatConfirmation, IChatContentInlineReference, IChatContentReference, IChatEditingSessionAction, IChatElicitationRequest, IChatExtensionsContent, IChatFollowup, IChatLocationData, IChatMarkdownContent, IChatMcpServersInteractionRequired, IChatMultiDiffData, IChatNotebookEdit, IChatPrepareToolInvocationPart, IChatProgress, IChatProgressMessage, IChatPullRequestContent, IChatResponseCodeblockUriPart, IChatResponseProgressFileTreeData, IChatTask, IChatTaskSerialized, IChatTextEdit, IChatThinkingPart, IChatToolInvocation, IChatToolInvocationSerialized, IChatTreeData, IChatUndoStop, IChatUsedContext, IChatWarningMessage, isIUsedContext } from './chatService.js';
 import { ChatRequestToolReferenceEntry, IChatRequestVariableEntry } from './chatVariableEntries.js';
 import { ChatAgentLocation, ChatModeKind } from './constants.js';
 
@@ -138,7 +138,8 @@ export type IChatProgressResponseContent =
 	| IChatUndoStop
 	| IChatPrepareToolInvocationPart
 	| IChatElicitationRequest
-	| IChatClearToPreviousToolInvocation;
+	| IChatClearToPreviousToolInvocation
+	| IChatMcpServersInteractionRequired;
 
 const nonHistoryKinds = new Set(['toolInvocation', 'toolInvocationSerialized', 'undoStop', 'prepareToolInvocation']);
 function isChatProgressHistoryResponseContent(content: IChatProgressResponseContent): content is IChatProgressHistoryResponseContent {
@@ -393,6 +394,7 @@ class AbstractResponse implements IResponse {
 				case 'elicitation':
 				case 'thinking':
 				case 'multiDiffData':
+				case 'mcpServersInteractionRequired':
 					// Ignore
 					continue;
 				case 'toolInvocation':

--- a/src/vs/workbench/contrib/chat/common/chatService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService.ts
@@ -408,6 +408,17 @@ export interface IChatTodoListContent {
 	}>;
 }
 
+export interface IChatMcpServersInteractionRequired {
+	kind: 'mcpServersInteractionRequired';
+	isDone?: boolean;
+	servers: Array<{
+		serverId: string;
+		serverLabel: string;
+		errorMessage?: string;
+	}>;
+	startCommand: Command;
+}
+
 export interface IChatPrepareToolInvocationPart {
 	readonly kind: 'prepareToolInvocation';
 	readonly toolName: string;
@@ -441,7 +452,8 @@ export type IChatProgress =
 	| IChatPrepareToolInvocationPart
 	| IChatThinkingPart
 	| IChatTaskSerialized
-	| IChatElicitationRequest;
+	| IChatElicitationRequest
+	| IChatMcpServersInteractionRequired;
 
 export interface IChatFollowup {
 	kind: 'reply';

--- a/src/vs/workbench/contrib/chat/common/chatViewModel.ts
+++ b/src/vs/workbench/contrib/chat/common/chatViewModel.ts
@@ -17,7 +17,7 @@ import { getFullyQualifiedId, IChatAgentCommand, IChatAgentData, IChatAgentNameS
 import { IChatModel, IChatProgressRenderableResponseContent, IChatRequestDisablement, IChatRequestModel, IChatResponseModel, IChatTextEditGroup, IResponse } from './chatModel.js';
 import { IChatRequestVariableEntry } from './chatVariableEntries.js';
 import { IParsedChatRequest } from './chatParserTypes.js';
-import { ChatAgentVoteDirection, ChatAgentVoteDownReason, IChatChangesSummary, IChatCodeCitation, IChatContentReference, IChatFollowup, IChatProgressMessage, IChatResponseErrorDetails, IChatTask, IChatUsedContext } from './chatService.js';
+import { ChatAgentVoteDirection, ChatAgentVoteDownReason, IChatChangesSummary, IChatCodeCitation, IChatContentReference, IChatFollowup, IChatMcpServersInteractionRequired, IChatProgressMessage, IChatResponseErrorDetails, IChatTask, IChatUsedContext } from './chatService.js';
 import { countWords } from './chatWordCounter.js';
 import { CodeBlockModelCollection } from './codeBlockModelCollection.js';
 
@@ -180,7 +180,7 @@ export interface IChatChangesSummaryPart {
 /**
  * Type for content parts rendered by IChatListRenderer (not necessarily in the model)
  */
-export type IChatRendererContent = IChatProgressRenderableResponseContent | IChatReferences | IChatCodeCitations | IChatErrorDetailsPart | IChatChangesSummaryPart | IChatWorkingProgress;
+export type IChatRendererContent = IChatProgressRenderableResponseContent | IChatReferences | IChatCodeCitations | IChatErrorDetailsPart | IChatChangesSummaryPart | IChatWorkingProgress | IChatMcpServersInteractionRequired;
 
 export interface IChatLiveUpdateData {
 	totalTime: number;

--- a/src/vs/workbench/contrib/mcp/common/mcpRegistry.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpRegistry.ts
@@ -33,7 +33,7 @@ import { IMcpDevModeDebugging } from './mcpDevMode.js';
 import { McpRegistryInputStorage } from './mcpRegistryInputStorage.js';
 import { IMcpHostDelegate, IMcpRegistry, IMcpResolveConnectionOptions } from './mcpRegistryTypes.js';
 import { McpServerConnection } from './mcpServerConnection.js';
-import { IMcpServerConnection, LazyCollectionState, McpCollectionDefinition, McpDefinitionReference, McpServerDefinition, McpServerLaunch, McpServerTrust, McpStartServerInteraction } from './mcpTypes.js';
+import { IMcpServerConnection, LazyCollectionState, McpCollectionDefinition, McpDefinitionReference, McpServerDefinition, McpServerLaunch, McpServerTrust, McpStartServerInteraction, UserInteractionRequiredError } from './mcpTypes.js';
 
 const notTrustedNonce = '__vscode_not_trusted';
 
@@ -209,6 +209,7 @@ export class McpRegistry extends Disposable implements IMcpRegistry {
 		interaction,
 		promptType = 'only-new',
 		autoTrustChanges = false,
+		errorOnUserInteraction = false,
 	}: IMcpResolveConnectionOptions) {
 		if (collection.trustBehavior === McpServerTrust.Kind.Trusted) {
 			this._logService.trace(`MCP server ${definition.id} is trusted, no trust prompt needed`);
@@ -227,6 +228,9 @@ export class McpRegistry extends Disposable implements IMcpRegistry {
 
 			if (trustNonceBearer.trustedAtNonce === notTrustedNonce) {
 				if (promptType === 'all-untrusted') {
+					if (errorOnUserInteraction) {
+						throw new UserInteractionRequiredError('serverTrust');
+					}
 					return this._promptForTrust(definition, collection, interaction, trustNonceBearer);
 				} else {
 					this._logService.trace(`MCP server ${definition.id} is untrusted, denying trust prompt`);
@@ -237,6 +241,10 @@ export class McpRegistry extends Disposable implements IMcpRegistry {
 			if (promptType === 'never') {
 				this._logService.trace(`MCP server ${definition.id} trust state is unknown, skipping prompt`);
 				return false;
+			}
+
+			if (errorOnUserInteraction) {
+				throw new UserInteractionRequiredError('serverTrust');
 			}
 
 			const didTrust = await this._promptForTrust(definition, collection, interaction, trustNonceBearer);
@@ -425,7 +433,7 @@ export class McpRegistry extends Disposable implements IMcpRegistry {
 		this._onDidChangeInputs.fire();
 	}
 
-	private async _replaceVariablesInLaunch(definition: McpServerDefinition, launch: McpServerLaunch) {
+	private async _replaceVariablesInLaunch(definition: McpServerDefinition, launch: McpServerLaunch, errorOnUserInteraction?: boolean) {
 		if (!definition.variableReplacement) {
 			return launch;
 		}
@@ -439,6 +447,14 @@ export class McpRegistry extends Disposable implements IMcpRegistry {
 		for (const replacement of expr.unresolved()) {
 			if (previouslyStored.hasOwnProperty(replacement.id)) {
 				expr.resolve(replacement, previouslyStored[replacement.id]);
+			}
+		}
+
+		// Check if there are still unresolved variables that would require interaction
+		if (errorOnUserInteraction) {
+			const unresolved = Array.from(expr.unresolved());
+			if (unresolved.length > 0) {
+				throw new UserInteractionRequiredError('variables');
 			}
 		}
 
@@ -484,7 +500,7 @@ export class McpRegistry extends Disposable implements IMcpRegistry {
 		}
 
 		try {
-			launch = await this._replaceVariablesInLaunch(definition, launch);
+			launch = await this._replaceVariablesInLaunch(definition, launch, opts.errorOnUserInteraction);
 
 			if (definition.devMode && debug) {
 				launch = await this._instantiationService.invokeFunction(accessor => accessor.get(IMcpDevModeDebugging).transform(definition, launch!));
@@ -519,6 +535,7 @@ export class McpRegistry extends Disposable implements IMcpRegistry {
 			delegate,
 			launch,
 			logger,
+			opts.errorOnUserInteraction,
 		);
 	}
 }

--- a/src/vs/workbench/contrib/mcp/common/mcpRegistryTypes.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpRegistryTypes.ts
@@ -31,7 +31,7 @@ export interface IMcpHostDelegate {
 	readonly priority: number;
 	waitForInitialProviderPromises(): Promise<void>;
 	canStart(collectionDefinition: McpCollectionDefinition, serverDefinition: McpServerDefinition): boolean;
-	start(collectionDefinition: McpCollectionDefinition, serverDefinition: McpServerDefinition, resolvedLaunch: McpServerLaunch): IMcpMessageTransport;
+	start(collectionDefinition: McpCollectionDefinition, serverDefinition: McpServerDefinition, resolvedLaunch: McpServerLaunch, options?: { errorOnUserInteraction?: boolean }): IMcpMessageTransport;
 }
 
 export interface IMcpResolveConnectionOptions {
@@ -57,6 +57,9 @@ export interface IMcpResolveConnectionOptions {
 
 	/** If set, try to launch with debugging when dev mode is configured */
 	debug?: boolean;
+
+	/** If true, throw an error if any user interaction would be required during startup. */
+	errorOnUserInteraction?: boolean;
 }
 
 export interface IMcpRegistry {

--- a/src/vs/workbench/contrib/mcp/common/mcpServer.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpServer.ts
@@ -496,7 +496,7 @@ export class McpServer extends Disposable implements IMcpServer {
 		}, token);
 	}
 
-	public start({ interaction, autoTrustChanges, promptType, debug }: IMcpServerStartOpts = {}): Promise<McpConnectionState> {
+	public start({ interaction, autoTrustChanges, promptType, debug, errorOnUserInteraction }: IMcpServerStartOpts = {}): Promise<McpConnectionState> {
 		interaction?.participants.set(this.definition.id, { s: 'unknown' });
 
 		return this._connectionSequencer.queue<McpConnectionState>(async () => {
@@ -534,6 +534,7 @@ export class McpServer extends Disposable implements IMcpServer {
 					collectionRef: this.collection,
 					definitionRef: this.definition,
 					debug,
+					errorOnUserInteraction,
 				});
 				if (!connection) {
 					return { state: McpConnectionState.Kind.Stopped };

--- a/src/vs/workbench/contrib/mcp/common/mcpServerConnection.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpServerConnection.ts
@@ -28,6 +28,7 @@ export class McpServerConnection extends Disposable implements IMcpServerConnect
 		private readonly _delegate: IMcpHostDelegate,
 		public readonly launchDefinition: McpServerLaunch,
 		private readonly _logger: ILogger,
+		private readonly _errorOnUserInteraction: boolean | undefined,
 		@IInstantiationService private readonly _instantiationService: IInstantiationService,
 	) {
 		super();
@@ -45,7 +46,7 @@ export class McpServerConnection extends Disposable implements IMcpServerConnect
 		this._logger.info(localize('mcpServer.starting', 'Starting server {0}', this.definition.label));
 
 		try {
-			const launch = this._delegate.start(this._collection, this.definition, this.launchDefinition);
+			const launch = this._delegate.start(this._collection, this.definition, this.launchDefinition, { errorOnUserInteraction: this._errorOnUserInteraction });
 			this._launch.value = this.adoptLaunch(launch, methods);
 			return this._waitForState(McpConnectionState.Kind.Running, McpConnectionState.Kind.Error);
 		} catch (e) {

--- a/src/vs/workbench/contrib/mcp/common/mcpServerConnection.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpServerConnection.ts
@@ -91,7 +91,7 @@ export class McpServerConnection extends Disposable implements IMcpServerConnect
 						}
 					},
 					err => {
-						if (!store.isDisposed) {
+						if (!store.isDisposed && McpConnectionState.isRunning(this._state.get())) {
 							let message = err.message;
 							if (err instanceof CancellationError) {
 								message = 'Server exited before responding to `initialize` request.';

--- a/src/vs/workbench/contrib/mcp/common/mcpTypes.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpTypes.ts
@@ -261,6 +261,11 @@ export interface IMcpServerStartOpts {
 	debug?: boolean;
 	/** Correlate multiple interactions such that any trust prompts are presented in combination. */
 	interaction?: McpStartServerInteraction;
+	/**
+	 * If true, throw an error if any user interaction would be required during startup.
+	 * This includes variable resolution, trust prompts, and authentication prompts.
+	 */
+	errorOnUserInteraction?: boolean;
 }
 
 export namespace McpServerTrust {
@@ -597,6 +602,12 @@ export class MpcResponseError extends Error {
 }
 
 export class McpConnectionFailedError extends Error { }
+
+export class UserInteractionRequiredError extends Error {
+	constructor(public readonly reason: string) {
+		super(`User interaction required: ${reason}`);
+	}
+}
 
 export interface IMcpConfigPath {
 	id: string;

--- a/src/vs/workbench/contrib/mcp/test/common/mcpRegistryTypes.ts
+++ b/src/vs/workbench/contrib/mcp/test/common/mcpRegistryTypes.ts
@@ -235,6 +235,7 @@ export class TestMcpRegistry implements IMcpRegistry {
 			del,
 			definition.launch,
 			new NullLogger(),
+			false,
 			this._instantiationService,
 		));
 	}

--- a/src/vs/workbench/contrib/mcp/test/common/mcpServerConnection.test.ts
+++ b/src/vs/workbench/contrib/mcp/test/common/mcpServerConnection.test.ts
@@ -134,6 +134,7 @@ suite('Workbench - MCP - ServerConnection', () => {
 			delegate,
 			serverDefinition.launch,
 			new NullLogger(),
+			false,
 		);
 		store.add(connection);
 
@@ -162,6 +163,7 @@ suite('Workbench - MCP - ServerConnection', () => {
 			delegate,
 			serverDefinition.launch,
 			new NullLogger(),
+			false,
 		);
 		store.add(connection);
 
@@ -181,6 +183,7 @@ suite('Workbench - MCP - ServerConnection', () => {
 			delegate,
 			serverDefinition.launch,
 			new NullLogger(),
+			false,
 		);
 		store.add(connection);
 
@@ -207,6 +210,7 @@ suite('Workbench - MCP - ServerConnection', () => {
 			delegate,
 			serverDefinition.launch,
 			new NullLogger(),
+			false,
 		);
 		store.add(connection);
 
@@ -231,6 +235,7 @@ suite('Workbench - MCP - ServerConnection', () => {
 			delegate,
 			serverDefinition.launch,
 			new NullLogger(),
+			false,
 		);
 		store.add(connection);
 
@@ -265,6 +270,7 @@ suite('Workbench - MCP - ServerConnection', () => {
 			delegate,
 			serverDefinition.launch,
 			new NullLogger(),
+			false,
 		);
 
 		// Start the connection
@@ -298,6 +304,7 @@ suite('Workbench - MCP - ServerConnection', () => {
 				error: () => { },
 				dispose: () => { }
 			} as Partial<ILogger> as ILogger,
+			false,
 		);
 		store.add(connection);
 
@@ -327,6 +334,7 @@ suite('Workbench - MCP - ServerConnection', () => {
 			delegate,
 			serverDefinition.launch,
 			new NullLogger(),
+			false,
 		);
 		store.add(connection);
 
@@ -365,6 +373,7 @@ suite('Workbench - MCP - ServerConnection', () => {
 			delegate,
 			serverDefinition.launch,
 			new NullLogger(),
+			false,
 		);
 		store.add(connection);
 

--- a/src/vs/workbench/contrib/mcp/test/common/testMcpService.ts
+++ b/src/vs/workbench/contrib/mcp/test/common/testMcpService.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { observableValue } from '../../../../../base/common/observable.js';
-import { IMcpServer, IMcpService, LazyCollectionState } from '../../common/mcpTypes.js';
+import { IAutostartResult, IMcpServer, IMcpService, LazyCollectionState } from '../../common/mcpTypes.js';
 
 export class TestMcpService implements IMcpService {
 	declare readonly _serviceBrand: undefined;
@@ -16,8 +16,8 @@ export class TestMcpService implements IMcpService {
 
 	}
 
-	autostart(): Promise<void> {
-		return Promise.resolve();
+	autostart(): Promise<IAutostartResult> {
+		return Promise.resolve({ serversRequiringInteraction: [] });
 	}
 
 	public lazyCollectionState = observableValue(this, { state: LazyCollectionState.AllKnown, collections: [] });


### PR DESCRIPTION
- Add a new capability to try to start a server unless it needs interaction
- Adopt that for MCP autostart
- If autostart hits one of these servers, it shows a message once per
  chat session allowing the user to start the server(s) manually.
- With these, turns on MCP autostart by default.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
