### PR TITLE
Fire accept event even if there are active items

### DIFF
--- a/src/vs/platform/quickinput/browser/quickInput.ts
+++ b/src/vs/platform/quickinput/browser/quickInput.ts
@@ -1166,8 +1166,8 @@ export class QuickPick<T extends IQuickPickItem, O extends { useSeparators: bool
 		if (this.activeItems[0]) {
 			this._selectedItems = [this.activeItems[0]];
 			this.onDidChangeSelectionEmitter.fire(this.selectedItems);
-			this.handleAccept(inBackground ?? false);
 		}
+		this.handleAccept(inBackground ?? false);
 	}
 }
 


### PR DESCRIPTION
This regressed from a change I made to use commands to handle the ENTER.

Fixes https://github.com/microsoft/vscode/issues/266307

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
