### PR TITLE
Fix and update the definition of fullwidth characters

### DIFF
--- a/src/vs/base/common/strings.ts
+++ b/src/vs/base/common/strings.ts
@@ -688,50 +688,34 @@ export function containsUnusualLineTerminators(str: string): boolean {
 	return UNUSUAL_LINE_TERMINATORS.test(str);
 }
 
-export function isFullWidthCharacter(charCode: number): boolean {
+export function isFullWidthCharacter(codePoint: number): boolean {
 	// Do a cheap trick to better support wrapping of wide characters, treat them as 2 columns
-	// http://jrgraphix.net/research/unicode_blocks.php
-	//          2E80 - 2EFF   CJK Radicals Supplement
-	//          2F00 - 2FDF   Kangxi Radicals
-	//          2FF0 - 2FFF   Ideographic Description Characters
-	//          3000 - 303F   CJK Symbols and Punctuation
-	//          3040 - 309F   Hiragana
-	//          30A0 - 30FF   Katakana
-	//          3100 - 312F   Bopomofo
-	//          3130 - 318F   Hangul Compatibility Jamo
-	//          3190 - 319F   Kanbun
-	//          31A0 - 31BF   Bopomofo Extended
-	//          31F0 - 31FF   Katakana Phonetic Extensions
-	//          3200 - 32FF   Enclosed CJK Letters and Months
-	//          3300 - 33FF   CJK Compatibility
-	//          3400 - 4DBF   CJK Unified Ideographs Extension A
-	//          4DC0 - 4DFF   Yijing Hexagram Symbols
-	//          4E00 - 9FFF   CJK Unified Ideographs
-	//          A000 - A48F   Yi Syllables
-	//          A490 - A4CF   Yi Radicals
-	//          AC00 - D7AF   Hangul Syllables
-	// [IGNORE] D800 - DB7F   High Surrogates
-	// [IGNORE] DB80 - DBFF   High Private Use Surrogates
-	// [IGNORE] DC00 - DFFF   Low Surrogates
-	// [IGNORE] E000 - F8FF   Private Use Area
-	//          F900 - FAFF   CJK Compatibility Ideographs
-	// [IGNORE] FB00 - FB4F   Alphabetic Presentation Forms
-	// [IGNORE] FB50 - FDFF   Arabic Presentation Forms-A
-	// [IGNORE] FE00 - FE0F   Variation Selectors
-	// [IGNORE] FE20 - FE2F   Combining Half Marks
-	// [IGNORE] FE30 - FE4F   CJK Compatibility Forms
-	// [IGNORE] FE50 - FE6F   Small Form Variants
-	// [IGNORE] FE70 - FEFF   Arabic Presentation Forms-B
-	//          FF00 - FFEF   Halfwidth and Fullwidth Forms
-	//               [https://en.wikipedia.org/wiki/Halfwidth_and_fullwidth_forms]
-	//               of which FF01 - FF5E fullwidth ASCII of 21 to 7E
-	// [IGNORE]    and FF65 - FFDC halfwidth of Katakana and Hangul
-	// [IGNORE] FFF0 - FFFF   Specials
-	return (
-		(charCode >= 0x2E80 && charCode <= 0xD7AF)
-		|| (charCode >= 0xF900 && charCode <= 0xFAFF)
-		|| (charCode >= 0xFF01 && charCode <= 0xFF5E)
-	);
+
+	// Wide characters can be determined using the Unicode property East Asian Width
+	// as defined in https://www.unicode.org/reports/tr11/tr11-44.html
+	// with the actual data in https://www.unicode.org/Public/17.0.0/ucd/EastAsianWidth.txt
+
+	// The TR11 states that:
+	// "In a broad sense, wide characters include W, F, and A (when in East Asian context),
+	// and narrow characters include N, Na, H, and A (when not in East Asian context)."
+
+	return (0x1100 <= codePoint) && //early termination
+		(
+			(codePoint <= 0x115F)
+			|| (0x2E80 <= codePoint && codePoint <= 0xA4CF && codePoint != 0x303F)
+			|| (0xA960 <= codePoint && codePoint <= 0xA97F)
+			|| (0xAC00 <= codePoint && codePoint <= 0xD7AF)
+			|| (0xF900 <= codePoint && codePoint <= 0xFAFF)
+			|| (0xFE10 <= codePoint && codePoint <= 0xFE6F)
+			|| (0xFF00 <= codePoint && codePoint <= 0xFF60)
+			|| (0xFFE0 <= codePoint && codePoint <= 0xFFE6)
+			|| (0x16FE0 <= codePoint && codePoint <= 0x18DFF)
+			|| (0x1AFF0 <= codePoint && codePoint <= 0x1B2FF)
+			|| (0x1D300 <= codePoint && codePoint <= 0x1D376)
+			|| (0x1F200 <= codePoint && codePoint <= 0x1F2FF)
+			|| (0x20000 <= codePoint && codePoint <= 0x2FFFD)
+			|| (0x30000 <= codePoint && codePoint <= 0x3FFFD)
+		);
 }
 
 /**


### PR DESCRIPTION
This fixes and updates the list of wide and fullwidth Unicode characters. Previously, some wide characters were not included and some were incorrectly classified as fullwidth when they aren't.

To determine which characters to include, the Unicode East Asian Width property is used. Since this property is not commonly available in runtimes a hardcoded list is used instead.
