### PR TITLE
Don't require an editing session for "new chat" to work

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/actions/chatClearActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatClearActions.ts
@@ -17,8 +17,8 @@ import { ActiveEditorContext } from '../../../../common/contextkeys.js';
 import { ChatContextKeys } from '../../common/chatContextKeys.js';
 import { IChatEditingSession } from '../../common/chatEditingService.js';
 import { ChatModeKind } from '../../common/constants.js';
-import { ChatViewId, IChatWidget, IChatWidgetService } from '../chat.js';
-import { EditingSessionAction } from '../chatEditing/chatEditingActions.js';
+import { ChatViewId, IChatWidgetService } from '../chat.js';
+import { EditingSessionAction, getEditingSessionContext } from '../chatEditing/chatEditingActions.js';
 import { ChatEditorInput } from '../chatEditorInput.js';
 import { ACTION_ID_NEW_CHAT, ACTION_ID_NEW_EDIT_SESSION, CHAT_CATEGORY, handleCurrentEditingSession } from './chatActions.js';
 import { clearChatEditor } from './chatClear.js';
@@ -59,7 +59,7 @@ export function registerNewChatActions() {
 		}
 	});
 
-	registerAction2(class NewChatAction extends EditingSessionAction {
+	registerAction2(class NewChatAction extends Action2 {
 		constructor() {
 			super({
 				id: ACTION_ID_NEW_CHAT,
@@ -103,37 +103,45 @@ export function registerNewChatActions() {
 		}
 
 
-		async runEditingSessionAction(accessor: ServicesAccessor, editingSession: IChatEditingSession, widget: IChatWidget, ...args: any[]) {
-			const context: INewEditSessionActionContext | undefined = args[0];
+		async run(accessor: ServicesAccessor, ...args: any[]) {
+			const executeCommandContext: INewEditSessionActionContext | undefined = args[0];
+
+			// Context from toolbar or lastFocusedWidget
+			const context = getEditingSessionContext(accessor, args);
+			const { editingSession, chatWidget: widget } = context ?? {};
+			if (!widget) {
+				return;
+			}
+
 			const accessibilitySignalService = accessor.get(IAccessibilitySignalService);
 			const dialogService = accessor.get(IDialogService);
 
-			if (!(await handleCurrentEditingSession(editingSession, undefined, dialogService))) {
+			if (editingSession && !(await handleCurrentEditingSession(editingSession, undefined, dialogService))) {
 				return;
 			}
 
 			announceChatCleared(accessibilitySignalService);
 
-			await editingSession.stop();
+			await editingSession?.stop();
 			widget.clear();
 			await widget.waitForReady();
 			widget.attachmentModel.clear(true);
 			widget.input.relatedFiles?.clear();
 			widget.focusInput();
 
-			if (!context) {
+			if (!executeCommandContext) {
 				return;
 			}
 
-			if (typeof context.agentMode === 'boolean') {
-				widget.input.setChatMode(context.agentMode ? ChatModeKind.Agent : ChatModeKind.Edit);
+			if (typeof executeCommandContext.agentMode === 'boolean') {
+				widget.input.setChatMode(executeCommandContext.agentMode ? ChatModeKind.Agent : ChatModeKind.Edit);
 			}
 
-			if (context.inputValue) {
-				if (context.isPartialQuery) {
-					widget.setInput(context.inputValue);
+			if (executeCommandContext.inputValue) {
+				if (executeCommandContext.isPartialQuery) {
+					widget.setInput(executeCommandContext.inputValue);
 				} else {
-					widget.acceptInput(context.inputValue);
+					widget.acceptInput(executeCommandContext.inputValue);
 				}
 			}
 		}

--- a/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingActions.ts
@@ -56,6 +56,9 @@ export abstract class EditingSessionAction extends Action2 {
 	abstract runEditingSessionAction(accessor: ServicesAccessor, editingSession: IChatEditingSession, chatWidget: IChatWidget, ...args: any[]): any;
 }
 
+/**
+ * Resolve view title toolbar context. If none, return context from the lastFocusedWidget.
+ */
 export function getEditingSessionContext(accessor: ServicesAccessor, args: any[]): { editingSession?: IChatEditingSession; chatWidget: IChatWidget } | undefined {
 	const arg0 = args.at(0);
 	const context = isChatViewTitleActionContext(arg0) ? arg0 : undefined;
@@ -73,10 +76,6 @@ export function getEditingSessionContext(accessor: ServicesAccessor, args: any[]
 
 	const chatSessionId = chatWidget.viewModel.model.sessionId;
 	const editingSession = chatEditingService.getEditingSession(chatSessionId);
-
-	if (!editingSession) {
-		return;
-	}
 
 	return { editingSession, chatWidget };
 }


### PR DESCRIPTION
There have been some different issues causing chats to break and not have an editing session associated with the chat model. if "new chat" doesn't work in that state then there is no escape, so don't require it.
Fix #265669

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
