### PR TITLE
Adjust max-width for viewpane filter container in action bar

### DIFF
--- a/src/vs/workbench/browser/parts/views/media/views.css
+++ b/src/vs/workbench/browser/parts/views/media/views.css
@@ -298,9 +298,14 @@
 }
 
 .panel > .title .monaco-action-bar .action-item.viewpane-filter-container {
-	max-width: 400px;
+	max-width: 200px;
 	min-width: 150px;
 	margin-right: 10px;
+}
+
+.panel > .title .monaco-action-bar .action-item.viewpane-filter-container:active,
+.panel > .title .monaco-action-bar .action-item.viewpane-filter-container:focus-within {
+	max-width: 400px;
 }
 
 .pane-body .viewpane-filter-container:not(:empty) {


### PR DESCRIPTION
Change the max-width of the viewpane filter container in the action bar to improve layout, while allowing it to expand when active or focused.