### PR TITLE
Fix color detection in hsl saturation

### DIFF
--- a/src/vs/editor/common/languages/defaultDocumentColorsComputer.ts
+++ b/src/vs/editor/common/languages/defaultDocumentColorsComputer.ts
@@ -121,16 +121,13 @@ function computeColors(model: IDocumentColorComputerTarget): IColorInformation[]
 				const regexParameters = /^\(\s*(25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9][0-9]|[0-9])\s*,\s*(25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9][0-9]|[0-9])\s*,\s*(25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9][0-9]|[0-9])\s*,\s*(0[.][0-9]+|[.][0-9]+|[01][.]|[01])\s*\)$/gm;
 				colorInformation = _findRGBColorInformation(_findRange(model, initialMatch), _findMatches(colorParameters, regexParameters), true);
 			} else if (colorScheme === 'hsl') {
-				const regexParameters = /^\(\s*((?:360(?:\.0+)?|(?:36[0]|3[0-5][0-9]|[12][0-9][0-9]|[1-9]?[0-9])(?:\.\d+)?))\s*[\s,]\s*(100|\d{1,2}[.]\d*|\d{1,2})%\s*[\s,]\s*(100|\d{1,2}[.]\d*|\d{1,2})%\s*\)$/gm;
+				const regexParameters = /^\(\s*((?:360(?:\.0+)?|(?:36[0]|3[0-5][0-9]|[12][0-9][0-9]|[1-9]?[0-9])(?:\.\d+)?))\s*[\s,]\s*(100(?:\.0+)?|\d{1,2}[.]\d*|\d{1,2})%\s*[\s,]\s*(100(?:\.0+)?|\d{1,2}[.]\d*|\d{1,2})%\s*\)$/gm;
 				colorInformation = _findHSLColorInformation(_findRange(model, initialMatch), _findMatches(colorParameters, regexParameters), false);
 			} else if (colorScheme === 'hsla') {
-				const regexParameters = /^\(\s*((?:360(?:\.0+)?|(?:36[0]|3[0-5][0-9]|[12][0-9][0-9]|[1-9]?[0-9])(?:\.\d+)?))\s*[\s,]\s*(100|\d{1,2}[.]\d*|\d{1,2})%\s*[\s,]\s*(100|\d{1,2}[.]\d*|\d{1,2})%\s*[\s,]\s*(0[.][0-9]+|[.][0-9]+|[01][.]0*|[01])\s*\)$/gm;
+				const regexParameters = /^\(\s*((?:360(?:\.0+)?|(?:36[0]|3[0-5][0-9]|[12][0-9][0-9]|[1-9]?[0-9])(?:\.\d+)?))\s*[\s,]\s*(100(?:\.0+)?|\d{1,2}[.]\d*|\d{1,2})%\s*[\s,]\s*(100(?:\.0+)?|\d{1,2}[.]\d*|\d{1,2})%\s*[\s,]\s*(0[.][0-9]+|[.][0-9]+|[01][.]0*|[01])\s*\)$/gm;
 				colorInformation = _findHSLColorInformation(_findRange(model, initialMatch), _findMatches(colorParameters, regexParameters), true);
 			} else if (colorScheme === '#') {
 				colorInformation = _findHexColorInformation(_findRange(model, initialMatch), colorScheme + colorParameters);
-			}
-			if (colorInformation) {
-				result.push(colorInformation);
 			}
 		}
 	}

--- a/src/vs/editor/common/languages/defaultDocumentColorsComputer.ts
+++ b/src/vs/editor/common/languages/defaultDocumentColorsComputer.ts
@@ -129,6 +129,9 @@ function computeColors(model: IDocumentColorComputerTarget): IColorInformation[]
 			} else if (colorScheme === '#') {
 				colorInformation = _findHexColorInformation(_findRange(model, initialMatch), colorScheme + colorParameters);
 			}
+			if (colorInformation) {
+				result.push(colorInformation);
+			}
 		}
 	}
 	return result;

--- a/src/vs/editor/test/common/languages/defaultDocumentColorsComputer.test.ts
+++ b/src/vs/editor/test/common/languages/defaultDocumentColorsComputer.test.ts
@@ -99,4 +99,25 @@ suite('Default Document Colors Computer', () => {
 		assert.strictEqual(colors[0].color.blue, 0, 'Blue component should be 0');
 		assert.strictEqual(colors[0].color.alpha, 1, 'Alpha should be 1 (ff/255)');
 	});
+
+	test('hsl 100 percent saturation works with decimals', () => {
+		const model = new TestDocumentModel("const color = 'hsl(253, 100.00%, 47.10%)';");
+		const colors = computeDefaultDocumentColors(model);
+
+		assert.strictEqual(colors.length, 1, 'Should detect one hsl color');
+	});
+
+	test('hsl 100 percent saturation works without decimals', () => {
+		const model = new TestDocumentModel("const color = 'hsl(253, 100%, 47.10%)';");
+		const colors = computeDefaultDocumentColors(model);
+
+		assert.strictEqual(colors.length, 1, 'Should detect one hsl color');
+	});
+
+	test('hsl not 100 percent saturation should also work', () => {
+		const model = new TestDocumentModel("const color = 'hsl(0, 83.60%, 47.80%)';");
+		const colors = computeDefaultDocumentColors(model);
+
+		assert.strictEqual(colors.length, 1, 'Should detect one hsl color');
+	});
 });

--- a/src/vs/editor/test/common/languages/defaultDocumentColorsComputer.test.ts
+++ b/src/vs/editor/test/common/languages/defaultDocumentColorsComputer.test.ts
@@ -101,21 +101,21 @@ suite('Default Document Colors Computer', () => {
 	});
 
 	test('hsl 100 percent saturation works with decimals', () => {
-		const model = new TestDocumentModel("const color = 'hsl(253, 100.00%, 47.10%)';");
+		const model = new TestDocumentModel('const color = hsl(253, 100.00%, 47.10%);');
 		const colors = computeDefaultDocumentColors(model);
 
 		assert.strictEqual(colors.length, 1, 'Should detect one hsl color');
 	});
 
 	test('hsl 100 percent saturation works without decimals', () => {
-		const model = new TestDocumentModel("const color = 'hsl(253, 100%, 47.10%)';");
+		const model = new TestDocumentModel('const color = hsl(253, 100%, 47.10%);');
 		const colors = computeDefaultDocumentColors(model);
 
 		assert.strictEqual(colors.length, 1, 'Should detect one hsl color');
 	});
 
 	test('hsl not 100 percent saturation should also work', () => {
-		const model = new TestDocumentModel("const color = 'hsl(0, 83.60%, 47.80%)';");
+		const model = new TestDocumentModel('const color = hsl(0, 83.60%, 47.80%);');
 		const colors = computeDefaultDocumentColors(model);
 
 		assert.strictEqual(colors.length, 1, 'Should detect one hsl color');


### PR DESCRIPTION
Fixes regular expressions to deal with decimals in 100 percent so that it can recognize 100%, 100.0%, 100.00%. 

partial fix for #180436