### PR TITLE
Double click in empty area should create a new chat

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/actions/chatActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatActions.ts
@@ -87,6 +87,7 @@ export const CHAT_CATEGORY = localize2('chat.category', 'Chat');
 export const ACTION_ID_NEW_CHAT = `workbench.action.chat.newChat`;
 export const ACTION_ID_NEW_EDIT_SESSION = `workbench.action.chat.newEditSession`;
 export const CHAT_OPEN_ACTION_ID = 'workbench.action.chat.open';
+export const CHAT_OPEN_EDITOR_ACTION_ID = 'workbench.action.openChat';
 export const CHAT_SETUP_ACTION_ID = 'workbench.action.chat.triggerSetup';
 const TOGGLE_CHAT_ACTION_ID = 'workbench.action.chat.toggle';
 const CHAT_CLEAR_HISTORY_ACTION_ID = 'workbench.action.chat.clearHistory';
@@ -1051,7 +1052,7 @@ export function registerChatActions() {
 	registerAction2(class NewChatEditorAction extends Action2 {
 		constructor() {
 			super({
-				id: `workbench.action.openChat`,
+				id: CHAT_OPEN_EDITOR_ACTION_ID,
 				title: localize2('interactiveSession.open', "New Chat Editor"),
 				f1: true,
 				category: CHAT_CATEGORY,

--- a/src/vs/workbench/contrib/chat/browser/actions/chatSessionActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatSessionActions.ts
@@ -34,7 +34,7 @@ import { IChatEditorOptions } from '../chatEditor.js';
 import { ChatEditorInput } from '../chatEditorInput.js';
 import { ChatSessionItemWithProvider, findExistingChatEditorByUri, isLocalChatSessionItem } from '../chatSessions/common.js';
 import { ChatViewPane } from '../chatViewPane.js';
-import { CHAT_CATEGORY } from './chatActions.js';
+import { CHAT_CATEGORY, CHAT_OPEN_EDITOR_ACTION_ID } from './chatActions.js';
 import { CancellationToken } from '../../../../../base/common/cancellation.js';
 import { VIEWLET_ID } from '../chatSessions/view/chatSessionsView.js';
 
@@ -492,7 +492,7 @@ MenuRegistry.appendMenuItem(MenuId.ViewContainerTitle, {
 
 MenuRegistry.appendMenuItem(MenuId.ViewTitle, {
 	command: {
-		id: 'workbench.action.openChat',
+		id: CHAT_OPEN_EDITOR_ACTION_ID,
 		title: nls.localize2('interactiveSession.open', "New Chat Editor"),
 		icon: Codicon.plus
 	},

--- a/src/vs/workbench/contrib/chat/browser/chatSessions/view/sessionsViewPane.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSessions/view/sessionsViewPane.ts
@@ -76,6 +76,7 @@ export class SessionsViewPane extends ViewPane {
 	constructor(
 		private readonly provider: IChatSessionItemProvider,
 		private readonly sessionTracker: ChatSessionTracker,
+		private readonly openChatEditorCommandId: string | undefined,
 		options: IViewPaneOptions,
 		@IKeybindingService keybindingService: IKeybindingService,
 		@IContextMenuService contextMenuService: IContextMenuService,
@@ -304,6 +305,15 @@ export class SessionsViewPane extends ViewPane {
 			}
 		}));
 
+		// Register double-click event in empty area to open new chat editor
+		if (this.openChatEditorCommandId) {
+			this._register(this.tree.onMouseDblClick(e => {
+				const scrollingByPage = this.configurationService.getValue<boolean>('workbench.list.scrollByPage');
+				if (e.element === null && !scrollingByPage) {
+					this.commandService.executeCommand(this.openChatEditorCommandId!);
+				}
+			}));
+		}
 		// Handle visibility changes to load data
 		this._register(this.onDidChangeBodyVisibility(async visible => {
 			if (visible && this.tree) {

--- a/src/vs/workbench/contrib/chat/browser/media/chatSessions.css
+++ b/src/vs/workbench/contrib/chat/browser/media/chatSessions.css
@@ -8,6 +8,11 @@
 	background-color: var(--vscode-sideBarSectionHeader-background) !important;
 }
 
+/* Ensure tree container takes full height like explorer view */
+.chat-sessions-tree-container {
+	height: 100%;
+}
+
 /* Style for empty state message */
 .chat-sessions-message {
 	padding: 20px;


### PR DESCRIPTION
```Copilot Generated Description:``` Implement a double-click event in the empty area of the chat sessions view to create a new chat editor.

fixes https://github.com/microsoft/vscode/issues/264515