### PR TITLE
Revert "Remove redundant activation & log extension service activation errors…"

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadAuthentication.ts
+++ b/src/vs/workbench/api/browser/mainThreadAuthentication.ts
@@ -11,10 +11,12 @@ import { AuthenticationWWWAuthenticateRequest, ExtHostAuthenticationShape, ExtHo
 import { IDialogService, IPromptButton } from '../../../platform/dialogs/common/dialogs.js';
 import Severity from '../../../base/common/severity.js';
 import { INotificationService } from '../../../platform/notification/common/notification.js';
+import { ActivationKind, IExtensionService } from '../../services/extensions/common/extensions.js';
 import { ITelemetryService } from '../../../platform/telemetry/common/telemetry.js';
 import { Emitter, Event } from '../../../base/common/event.js';
 import { IAuthenticationAccessService } from '../../services/authentication/browser/authenticationAccessService.js';
 import { IAuthenticationUsageService } from '../../services/authentication/browser/authenticationUsageService.js';
+import { getAuthenticationProviderActivationEvent } from '../../services/authentication/browser/authenticationService.js';
 import { URI, UriComponents } from '../../../base/common/uri.js';
 import { IOpenerService } from '../../../platform/opener/common/opener.js';
 import { CancellationError } from '../../../base/common/errors.js';
@@ -116,6 +118,7 @@ export class MainThreadAuthentication extends Disposable implements MainThreadAu
 		@IAuthenticationUsageService private readonly authenticationUsageService: IAuthenticationUsageService,
 		@IDialogService private readonly dialogService: IDialogService,
 		@INotificationService private readonly notificationService: INotificationService,
+		@IExtensionService private readonly extensionService: IExtensionService,
 		@ITelemetryService private readonly telemetryService: ITelemetryService,
 		@IOpenerService private readonly openerService: IOpenerService,
 		@ILogService private readonly logService: ILogService,
@@ -197,6 +200,12 @@ export class MainThreadAuthentication extends Disposable implements MainThreadAu
 			this.authenticationService.unregisterAuthenticationProvider(id);
 		} finally {
 			this._suppressUnregisterEvent = false;
+		}
+	}
+
+	async $ensureProvider(id: string): Promise<void> {
+		if (!this.authenticationService.isAuthenticationProviderRegistered(id)) {
+			return await this.extensionService.activateByEvent(getAuthenticationProviderActivationEvent(id), ActivationKind.Immediate);
 		}
 	}
 

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -205,6 +205,7 @@ export interface AuthenticationConstraint {
 export interface MainThreadAuthenticationShape extends IDisposable {
 	$registerAuthenticationProvider(id: string, label: string, supportsMultipleAccounts: boolean, supportedAuthorizationServers?: UriComponents[], supportsChallenges?: boolean): Promise<void>;
 	$unregisterAuthenticationProvider(id: string): Promise<void>;
+	$ensureProvider(id: string): Promise<void>;
 	$sendDidChangeSessions(providerId: string, event: AuthenticationSessionsChangeEvent): Promise<void>;
 	$getSession(providerId: string, scopeListOrRequest: ReadonlyArray<string> | AuthenticationWWWAuthenticateRequest, extensionId: string, extensionName: string, options: AuthenticationGetSessionOptions): Promise<AuthenticationSession | undefined>;
 	$getAccounts(providerId: string): Promise<ReadonlyArray<AuthenticationSessionAccount>>;

--- a/src/vs/workbench/api/common/extHostAuthentication.ts
+++ b/src/vs/workbench/api/common/extHostAuthentication.ts
@@ -112,12 +112,14 @@ export class ExtHostAuthentication implements ExtHostAuthenticationShape {
 		}
 
 		return await this._getSessionTaskSingler.getOrCreate(singlerKey, async () => {
+			await this._proxy.$ensureProvider(providerId);
 			const extensionName = requestingExtension.displayName || requestingExtension.name;
 			return this._proxy.$getSession(providerId, scopesOrRequest, extensionId, extensionName, options);
 		});
 	}
 
 	async getAccounts(providerId: string) {
+		await this._proxy.$ensureProvider(providerId);
 		return await this._proxy.$getAccounts(providerId);
 	}
 

--- a/src/vs/workbench/services/authentication/browser/authenticationService.ts
+++ b/src/vs/workbench/services/authentication/browser/authenticationService.ts
@@ -396,12 +396,7 @@ export class AuthenticationService extends Disposable implements IAuthentication
 	}
 
 	private async tryActivateProvider(providerId: string, activateImmediate: boolean): Promise<IAuthenticationProvider> {
-		try {
-			await this._extensionService.activateByEvent(getAuthenticationProviderActivationEvent(providerId), activateImmediate ? ActivationKind.Immediate : ActivationKind.Normal);
-		} catch (e) {
-			this._logService.error(`Extension Service failed to activate authentication provider '${providerId}':`, e);
-			throw e;
-		}
+		await this._extensionService.activateByEvent(getAuthenticationProviderActivationEvent(providerId), activateImmediate ? ActivationKind.Immediate : ActivationKind.Normal);
 		let provider = this._authenticationProviders.get(providerId);
 		if (provider) {
 			return provider;


### PR DESCRIPTION
This reverts commit ea1973f76886eea5140ab831f96d84762217bf85.

This commit accidentally changed activation from Immediate to Normal in some situations and Normal doesn't seem to activate until after a resolver resolves.

Fixes https://github.com/microsoft/vscode/issues/266319
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
