### PR TITLE
mcp: fix image preview for links and add momentary cache

### DIFF
--- a/src/vs/base/test/common/cancellation.test.ts
+++ b/src/vs/base/test/common/cancellation.test.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 import assert from 'assert';
-import { CancellationToken, CancellationTokenSource } from '../../common/cancellation.js';
+import { CancellationToken, CancellationTokenSource, CancellationTokenPool } from '../../common/cancellation.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from './utils.js';
 
 suite('CancellationToken', function () {
@@ -123,5 +123,157 @@ suite('CancellationToken', function () {
 
 		child.dispose();
 		parent.dispose();
+	});
+});
+
+suite('CancellationTokenPool', function () {
+
+	const store = ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('empty pool token is not cancelled', function () {
+		const pool = new CancellationTokenPool();
+		store.add(pool);
+
+		assert.strictEqual(pool.token.isCancellationRequested, false);
+	});
+
+	test('pool token cancels when all tokens are cancelled', function () {
+		const pool = new CancellationTokenPool();
+		store.add(pool);
+
+		const source1 = new CancellationTokenSource();
+		const source2 = new CancellationTokenSource();
+		const source3 = new CancellationTokenSource();
+
+		pool.add(source1.token);
+		pool.add(source2.token);
+		pool.add(source3.token);
+
+		assert.strictEqual(pool.token.isCancellationRequested, false);
+
+		source1.cancel();
+		assert.strictEqual(pool.token.isCancellationRequested, false);
+
+		source2.cancel();
+		assert.strictEqual(pool.token.isCancellationRequested, false);
+
+		source3.cancel();
+		assert.strictEqual(pool.token.isCancellationRequested, true);
+
+		source1.dispose();
+		source2.dispose();
+		source3.dispose();
+	});
+
+	test('pool token fires cancellation event when all tokens are cancelled', function () {
+		return new Promise<void>(resolve => {
+			const pool = new CancellationTokenPool();
+			store.add(pool);
+
+			const source1 = new CancellationTokenSource();
+			const source2 = new CancellationTokenSource();
+
+			pool.add(source1.token);
+			pool.add(source2.token);
+
+			store.add(pool.token.onCancellationRequested(() => resolve()));
+
+			source1.cancel();
+			source2.cancel();
+
+			source1.dispose();
+			source2.dispose();
+		});
+	});
+
+	test('adding already cancelled token counts immediately', function () {
+		const pool = new CancellationTokenPool();
+		store.add(pool);
+
+		const source1 = new CancellationTokenSource();
+		const source2 = new CancellationTokenSource();
+
+		source1.cancel(); // Cancel before adding to pool
+
+		pool.add(source1.token);
+		assert.strictEqual(pool.token.isCancellationRequested, true); // 1 of 1 cancelled, so pool is cancelled
+
+		pool.add(source2.token); // Adding after pool is done should have no effect
+		assert.strictEqual(pool.token.isCancellationRequested, true);
+
+		source2.cancel(); // This should have no effect since pool is already done
+		assert.strictEqual(pool.token.isCancellationRequested, true);
+
+		source1.dispose();
+		source2.dispose();
+	});
+
+	test('adding single already cancelled token cancels pool immediately', function () {
+		const pool = new CancellationTokenPool();
+		store.add(pool);
+
+		const source = new CancellationTokenSource();
+		source.cancel();
+
+		pool.add(source.token);
+		assert.strictEqual(pool.token.isCancellationRequested, true); // 1 of 1 cancelled
+
+		source.dispose();
+	});
+
+	test('adding token after pool is done has no effect', function () {
+		const pool = new CancellationTokenPool();
+		store.add(pool);
+
+		const source1 = new CancellationTokenSource();
+		const source2 = new CancellationTokenSource();
+
+		pool.add(source1.token);
+		source1.cancel(); // Pool should be done now
+
+		assert.strictEqual(pool.token.isCancellationRequested, true);
+
+		// Adding another token should have no effect
+		pool.add(source2.token);
+		source2.cancel();
+
+		assert.strictEqual(pool.token.isCancellationRequested, true);
+
+		source1.dispose();
+		source2.dispose();
+	});
+
+	test('single token pool behaviour', function () {
+		const pool = new CancellationTokenPool();
+		store.add(pool);
+
+		const source = new CancellationTokenSource();
+		pool.add(source.token);
+
+		assert.strictEqual(pool.token.isCancellationRequested, false);
+
+		source.cancel();
+		assert.strictEqual(pool.token.isCancellationRequested, true);
+
+		source.dispose();
+	});
+
+	test('pool with only cancelled tokens', function () {
+		const pool = new CancellationTokenPool();
+		store.add(pool);
+
+		const source1 = new CancellationTokenSource();
+		const source2 = new CancellationTokenSource();
+
+		source1.cancel();
+		source2.cancel();
+
+		pool.add(source1.token);
+		pool.add(source2.token);
+
+		assert.strictEqual(pool.token.isCancellationRequested, true);
+
+		source1.dispose();
+		source2.dispose();
 	});
 });

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/chatToolInputOutputContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/chatToolInputOutputContentPart.ts
@@ -103,6 +103,7 @@ export class ChatCollapsibleInputOutputContentPart extends Disposable {
 		@IContextKeyService private readonly contextKeyService: IContextKeyService,
 		@IInstantiationService private readonly _instantiationService: IInstantiationService,
 		@IContextMenuService private readonly _contextMenuService: IContextMenuService,
+		@IFileService private readonly _fileService: IFileService,
 	) {
 		super();
 		this._currentWidth = width;
@@ -220,13 +221,21 @@ export class ChatCollapsibleInputOutputContentPart extends Disposable {
 			dom.h('.chat-collapsible-io-resource-actions@actions'),
 		]);
 
-		const entries = parts.map((part): IChatRequestVariableEntry => {
+		this.fillInResourceGroup(parts, el.items, el.actions).then(() => this._onDidChangeHeight.fire());
+
+		container.appendChild(el.root);
+		return el.root;
+	}
+
+	private async fillInResourceGroup(parts: IChatCollapsibleIODataPart[], itemsContainer: HTMLElement, actionsContainer: HTMLElement) {
+		const entries = await Promise.all(parts.map(async (part): Promise<IChatRequestVariableEntry> => {
 			if (part.mimeType && getAttachableImageExtension(part.mimeType)) {
-				return { kind: 'image', id: generateUuid(), name: basename(part.uri), value: part.value, mimeType: part.mimeType, isURL: false, references: [{ kind: 'reference', reference: part.uri }] };
+				const value = part.value ?? await this._fileService.readFile(part.uri).then(f => f.value.buffer, () => undefined);
+				return { kind: 'image', id: generateUuid(), name: basename(part.uri), value, mimeType: part.mimeType, isURL: false, references: [{ kind: 'reference', reference: part.uri }] };
 			} else {
 				return { kind: 'file', id: generateUuid(), name: basename(part.uri), fullName: part.uri.path, value: part.uri };
 			}
-		});
+		}));
 
 		const attachments = this._register(this._instantiationService.createInstance(
 			ChatAttachmentsContentPart,
@@ -251,18 +260,16 @@ export class ChatCollapsibleInputOutputContentPart extends Disposable {
 			}
 		};
 
-		el.items.appendChild(attachments.domNode!);
+		itemsContainer.appendChild(attachments.domNode!);
 
-		const toolbar = this._register(this._instantiationService.createInstance(MenuWorkbenchToolBar, el.actions, MenuId.ChatToolOutputResourceToolbar, {
+		const toolbar = this._register(this._instantiationService.createInstance(MenuWorkbenchToolBar, actionsContainer, MenuId.ChatToolOutputResourceToolbar, {
 			menuOptions: {
 				shouldForwardArgs: true,
 			},
 		}));
 		toolbar.context = { parts } satisfies IChatToolOutputResourceToolbarContext;
-
-		container.appendChild(el.root);
-		return el.root;
 	}
+
 
 	private addCodeBlock(part: IChatCollapsibleIOCodePart, container: HTMLElement) {
 		const data: ICodeBlockData = {

--- a/src/vs/workbench/contrib/mcp/common/mcpResourceFilesystem.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpResourceFilesystem.ts
@@ -256,7 +256,7 @@ export class McpResourceFilesystem extends Disposable implements IWorkbenchContr
 			return cached.promise;
 		}
 
-		const pool = new CancellationTokenPool();
+		const pool = this._store.add(new CancellationTokenPool());
 		pool.add(token || CancellationToken.None);
 
 		const promise = this._readURIInner(uri, pool.token);
@@ -265,7 +265,7 @@ export class McpResourceFilesystem extends Disposable implements IWorkbenchContr
 		const disposable = this._store.add(disposableTimeout(() => {
 			this._momentaryCache.delete(uri);
 			this._store.delete(disposable);
-			pool.dispose();
+			this._store.delete(pool);
 		}, MOMENTARY_CACHE_DURATION));
 
 		return promise;

--- a/src/vs/workbench/contrib/mcp/common/mcpResourceFilesystem.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpResourceFilesystem.ts
@@ -4,11 +4,13 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { sumBy } from '../../../../base/common/arrays.js';
+import { disposableTimeout } from '../../../../base/common/async.js';
 import { decodeBase64, VSBuffer } from '../../../../base/common/buffer.js';
-import { CancellationToken, CancellationTokenSource } from '../../../../base/common/cancellation.js';
+import { CancellationToken, CancellationTokenPool, CancellationTokenSource } from '../../../../base/common/cancellation.js';
 import { Emitter, Event } from '../../../../base/common/event.js';
 import { Lazy } from '../../../../base/common/lazy.js';
 import { Disposable, DisposableStore, IDisposable, MutableDisposable } from '../../../../base/common/lifecycle.js';
+import { ResourceMap } from '../../../../base/common/map.js';
 import { autorun } from '../../../../base/common/observable.js';
 import { newWriteableStream, ReadableStreamEvents } from '../../../../base/common/stream.js';
 import { equalsIgnoreCase } from '../../../../base/common/strings.js';
@@ -21,12 +23,28 @@ import { McpServerRequestHandler } from './mcpServerRequestHandler.js';
 import { IMcpService, McpCapability, McpResourceURI } from './mcpTypes.js';
 import { MCP } from './modelContextProtocol.js';
 
+const MOMENTARY_CACHE_DURATION = 3000;
+
+interface IReadData {
+	contents: (MCP.TextResourceContents | MCP.BlobResourceContents)[];
+	resourceURI: URL;
+	forSameURI: (MCP.TextResourceContents | MCP.BlobResourceContents)[];
+}
+
 export class McpResourceFilesystem extends Disposable implements IWorkbenchContribution,
 	IFileSystemProviderWithFileReadWriteCapability,
 	IFileSystemProviderWithFileAtomicReadCapability,
 	IFileSystemProviderWithFileReadStreamCapability {
 	/** Defer getting the MCP service since this is a BlockRestore and no need to make it unnecessarily. */
 	private readonly _mcpServiceLazy = new Lazy(() => this._instantiationService.invokeFunction(a => a.get(IMcpService)));
+
+	/**
+	 * For many file operations we re-read the resources quickly (e.g. stat
+	 * before reading the file) and would prefer to avoid spamming the MCP
+	 * with multiple reads. This is a very short-duration cache
+	 * to solve that.
+	 */
+	private readonly _momentaryCache = new ResourceMap<{ pool: CancellationTokenPool; promise: Promise<IReadData> }>();
 
 	private get _mcpService() {
 		return this._mcpServiceLazy.value;
@@ -232,6 +250,28 @@ export class McpResourceFilesystem extends Disposable implements IWorkbenchContr
 	}
 
 	private async _readURI(uri: URI, token?: CancellationToken) {
+		const cached = this._momentaryCache.get(uri);
+		if (cached) {
+			cached.pool.add(token || CancellationToken.None);
+			return cached.promise;
+		}
+
+		const pool = new CancellationTokenPool();
+		pool.add(token || CancellationToken.None);
+
+		const promise = this._readURIInner(uri, pool.token);
+		this._momentaryCache.set(uri, { pool, promise });
+
+		const disposable = this._store.add(disposableTimeout(() => {
+			this._momentaryCache.delete(uri);
+			this._store.delete(disposable);
+			pool.dispose();
+		}, MOMENTARY_CACHE_DURATION));
+
+		return promise;
+	}
+
+	private async _readURIInner(uri: URI, token?: CancellationToken): Promise<IReadData> {
 		const { resourceURI, server } = this._decodeURI(uri);
 		const res = await McpServer.callOn(server, r => r.readResource({ uri: resourceURI.toString() }, token), token);
 


### PR DESCRIPTION
- Fix tool results with resource-link's not showing image thumbnails
- Add a 'CancellationTokenPool' for memoization of cancellable operations
- Add a 'momentaryCache' to McpResourceFilesystem to avoid multiple reads
  in quick succession (since now we read the image to show the thumbnail
  in addition to two reads we were already doing)

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
