### PR TITLE
welcome - fix bad `matches` implementation

### DIFF
--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStartedInput.ts
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStartedInput.ts
@@ -60,10 +60,7 @@ export class GettingStartedInput extends EditorInput {
 			return true;
 		}
 
-		if (other instanceof GettingStartedInput) {
-			return other.selectedCategory === this.selectedCategory;
-		}
-		return false;
+		return other instanceof GettingStartedInput;
 	}
 
 	constructor(


### PR DESCRIPTION
Having `matches` be dependent on a `selectedCategory` property is very risky because it is possible that initially multiple inputs are not considered equal but then later are.

@bhavyaus fyi, I saw a bug where 2 welcome editors were opened, both active in the editor group. I am not sure if this is a recent regression but `matches` cannot be depending on a property such as `selectedCategory` that only gets set later because then there is a chance that you can open multiple getting started inputs that later all select the same category and then are all considered equal. The editor group relies on a deterministic `matches` implementation that does not change later.
