### PR TITLE
Restore PSReadline key remapping in PowerShell shell integration

### DIFF
--- a/src/vs/workbench/contrib/terminal/common/scripts/shellIntegration.ps1
+++ b/src/vs/workbench/contrib/terminal/common/scripts/shellIntegration.ps1
@@ -255,3 +255,7 @@ function Set-MappedKeyHandlers {
 	Set-MappedKeyHandler -Chord Shift+Enter -Sequence 'F12,c'
 	Set-MappedKeyHandler -Chord Shift+End -Sequence 'F12,d'
 }
+
+if ($Global:__VSCodeState.HasPSReadLine) {
+	Set-MappedKeyHandlers
+}


### PR DESCRIPTION
Commit 233c8a0c9d1d6087a44065d8b4b9506ed0bb3cf1 accidently removed the remapping of unavailable terminal key sequences for PSReadLine.

fixes #267575