### PR TITLE
fix: confirmation btn style

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/actions/chatActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatActions.ts
@@ -1550,7 +1550,7 @@ Guidelines (read more at https://aka.ms/vscode-instructions-docs):
 - If \`.github/copilot-instructions.md\` exists, merge intelligently - preserve valuable content while updating outdated sections
 - Write concise, actionable instructions (~20-50 lines) using markdown structure
 - Include specific examples from the codebase when describing patterns
-- Avoid generic advice ("write tests", "handle errors") - focus on THIS project's specific approaches
+- Avoid generic advice ("write tests", "handle errors") - focus on this project's specific approaches
 - Document only discoverable patterns, not aspirational practices
 - Reference key files/directories that exemplify important patterns
 

--- a/src/vs/workbench/contrib/chat/browser/actions/chatActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatActions.ts
@@ -1550,7 +1550,7 @@ Guidelines (read more at https://aka.ms/vscode-instructions-docs):
 - If \`.github/copilot-instructions.md\` exists, merge intelligently - preserve valuable content while updating outdated sections
 - Write concise, actionable instructions (~20-50 lines) using markdown structure
 - Include specific examples from the codebase when describing patterns
-- Avoid generic advice ("write tests", "handle errors") - focus on this project's specific approaches
+- Avoid generic advice ("write tests", "handle errors") - focus on THIS project's specific approaches
 - Document only discoverable patterns, not aspirational practices
 - Reference key files/directories that exemplify important patterns
 

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/media/chatConfirmationWidget.css
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/media/chatConfirmationWidget.css
@@ -271,9 +271,7 @@
 		.monaco-button {
 			overflow-wrap: break-word;
 			padding: 2px 5px;
+			width: inherit;
 		}
-	}
-	.monaco-text-button {
-		width: inherit;
 	}
 }

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/media/chatConfirmationWidget.css
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/media/chatConfirmationWidget.css
@@ -273,4 +273,7 @@
 			padding: 2px 5px;
 		}
 	}
+	.monaco-text-button {
+		width: inherit;
+	}
 }


### PR DESCRIPTION
This MR addresses two UI-related issues in VS Code:

Issue 1: Inconsistent Text Casing in Generate Instructions Prompt
Problem: In the generate instructions prompt text, "THIS" appears in that

Solution: Change "THIS" to lowercase "this" 

Issue 2: Layout Issues in Copilot Tool Consent Dialog
Problem: The "Continue" button in Copilot's tool consent dialog has layout issues:

In Chinese language settings, the button text wraps unexpectedly, breaking the intended layout
When the dialog content is lengthy, the button styling doesn't match the expected design
The button layout is not responsive to different content lengths and languages

Before：
<img width="699" height="459" alt="before1" src="https://github.com/user-attachments/assets/48902baf-2022-45f8-8f9d-e0d4f87dae3c" />
<img width="595" height="307" alt="before2" src="https://github.com/user-attachments/assets/d07af0c1-38cb-4fbe-8d00-253cf6456a6a" />
After

After：
<img width="495" height="307" alt="After1" src="https://github.com/user-attachments/assets/d9a59463-20fe-4128-9074-11cc6af53f0e" />
<img width="581" height="275" alt="after2" src="https://github.com/user-attachments/assets/8e97c388-a610-4d63-9ffd-a8061a46cc43" />
<img width="468" height="278" alt="after3" src="https://github.com/user-attachments/assets/bf9d2eef-df28-4a40-bbe9-89d59fe6d545" />

