### PR TITLE
fix: updates quickInputBox aria role to combobox

### DIFF
--- a/src/vs/platform/quickinput/browser/quickInputBox.ts
+++ b/src/vs/platform/quickinput/browser/quickInputBox.ts
@@ -27,7 +27,7 @@ export class QuickInputBox extends Disposable {
 		this.container = dom.append(this.parent, $('.quick-input-box'));
 		this.findInput = this._register(new FindInput(this.container, undefined, { label: '', inputBoxStyles, toggleStyles }));
 		const input = this.findInput.inputBox.inputElement;
-		input.role = 'textbox';
+		input.role = 'combobox';
 		input.ariaHasPopup = 'menu';
 		input.ariaAutoComplete = 'list';
 	}


### PR DESCRIPTION
Changes quickInputBox aria role from textbox to combobox. Combobox is more appropriate since it follows the a11y pattern of having a popup and controls a list. Attempts to improve communication with the screen reader by providing a more appropriate aria role.

Fixes: https://github.com/microsoft/vscode/issues/267445

## Steps to Test:
1. Checkout the PR: git checkout <branch-name>

2. Rebuild and Run the Project: Follow the standard process for building the project and launching the IDE.

3. Enable a screen reader: Turn on a screen reader on your operating system (e.g., VoiceOver on macOS, NVDA on Windows, or ChromeVox on ChromeOS).

4. Open the Quick Input Dialog: Use the keyboard shortcut to open the "Search Workspaces" or "Open File" dialog (e.g., Cmd+Shift+P or Cmd+P).

5. Verify the ARIA Role: Focus the search input field and listen to the screen reader's announcement. It should now announce the input as a "combobox" or something similar, confirming that the ARIA role has been correctly updated.

6. Test Functionality: Ensure that the core functionality of the input still works as expected. Verify that you can still type to filter the list of suggestions, use the arrow keys to navigate the list, and press Enter to select an item.


<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
