### PR TITLE
Fix RangeFormat wrong document race condition

### DIFF
--- a/src/vs/editor/contrib/format/browser/format.ts
+++ b/src/vs/editor/contrib/format/browser/format.ts
@@ -247,6 +247,10 @@ export async function formatDocumentRangesWithProvider(
 				allEdits.push(...minimalEdits);
 			}
 		}
+
+		if (cts.token.isCancellationRequested) {
+			return true;
+		}
 	} finally {
 		cts.dispose();
 	}


### PR DESCRIPTION
Fixes #266688
* #266688

simply just rechecks the `isCancellationRequested` token after the last `await`