### PR TITLE
Fix: Disable window shadows on macOS Tahoe to prevent GPU performance issues

### DIFF
--- a/src/vs/base/common/platform.ts
+++ b/src/vs/base/common/platform.ts
@@ -278,3 +278,7 @@ export const isAndroid = !!(userAgent && userAgent.indexOf('Android') >= 0);
 export function isBigSurOrNewer(osVersion: string): boolean {
 	return parseFloat(osVersion) >= 20;
 }
+
+export function isTahoe(osVersion: string): boolean {
+	return parseFloat(osVersion) === 25;
+}

--- a/src/vs/platform/windows/electron-main/windows.ts
+++ b/src/vs/platform/windows/electron-main/windows.ts
@@ -188,7 +188,7 @@ export function defaultBrowserWindowOptions(accessor: ServicesAccessor, windowSt
 			options.acceptFirstMouse = false;
 		}
 
-		// Mac OS 26.?.? has a `WindowServer` bug that causes windows with shadows to cause 80%+ GPU load
+		// Mac OS 26.?.? has a `WindowServer` bug that causes (some?) windows with shadows to cause 80%+ GPU load
 		// See: https://github.com/microsoft/vscode/issues/267022
 		const [osMajorVersion, _osMinorVersion, _osPatchVersion] = release().split('.', 3).map(Number);
 

--- a/src/vs/platform/windows/electron-main/windows.ts
+++ b/src/vs/platform/windows/electron-main/windows.ts
@@ -8,7 +8,7 @@ import { release } from 'os';
 import { Color } from '../../../base/common/color.js';
 import { Event } from '../../../base/common/event.js';
 import { join } from '../../../base/common/path.js';
-import { IProcessEnvironment, isLinux, isMacintosh, isWindows } from '../../../base/common/platform.js';
+import { IProcessEnvironment, isLinux, isMacintosh, isTahoe, isWindows } from '../../../base/common/platform.js';
 import { URI } from '../../../base/common/uri.js';
 import { IAuxiliaryWindow } from '../../auxiliaryWindow/electron-main/auxiliaryWindow.js';
 import { IConfigurationService } from '../../configuration/common/configuration.js';
@@ -188,12 +188,11 @@ export function defaultBrowserWindowOptions(accessor: ServicesAccessor, windowSt
 			options.acceptFirstMouse = false;
 		}
 
-		// Mac OS 26.?.? has a `WindowServer` bug that causes (some?) windows with shadows to cause 80%+ GPU load
-		// See: https://github.com/microsoft/vscode/issues/267022
-		const [osMajorVersion, _osMinorVersion, _osPatchVersion] = release().split('.', 3).map(Number);
-
-		// In the future: once the bug is fixed in the OS, lock this into a specific version
-		if (osMajorVersion === 25) {
+		// Mac OS 26.?.? has a `WindowServer` bug that causes (some?) windows with shadows
+		// to cause 80%+ GPU load.
+		// See: https://github.com/electron/electron/issues/48311
+		// TODO: once the bug is fixed in the OS, lock this into a specific version.
+		if (isTahoe(release())) {
 			options.hasShadow = false;
 		}
 	}

--- a/src/vs/platform/windows/electron-main/windows.ts
+++ b/src/vs/platform/windows/electron-main/windows.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import electron, { Display, Rectangle } from 'electron';
+import { release } from 'os';
 import { Color } from '../../../base/common/color.js';
 import { Event } from '../../../base/common/event.js';
 import { join } from '../../../base/common/path.js';
@@ -185,6 +186,15 @@ export function defaultBrowserWindowOptions(accessor: ServicesAccessor, windowSt
 
 		if (windowSettings?.clickThroughInactive === false) {
 			options.acceptFirstMouse = false;
+		}
+
+		// Mac OS 26.?.? has a `WindowServer` bug that causes windows with shadows to cause 80%+ GPU load
+		// See: https://github.com/microsoft/vscode/issues/267022
+		const [osMajorVersion, _osMinorVersion, _osPatchVersion] = release().split('.', 3).map(Number);
+
+		// In the future: once the bug is fixed in the OS, lock this into a specific version
+		if (osMajorVersion === 25) {
+			options.hasShadow = false;
 		}
 	}
 


### PR DESCRIPTION
## Summary

Fixes #267022
Fixes #267065

related: https://github.com/electron/electron/issues/48311

macOS Darwin 26 (Tahoe) has a WindowServer bug that causes (some?) windows with shadows to consume 80%+ GPU resources. This change disables VSCode window shadows specifically for Darwin 25.x to work around the performance regression.

## Changes

- Added version check in `defaultBrowserWindowOptions` to detect Darwin 25.x
- Set `options.hasShadow = false` only on affected macOS versions
- Applied fix centrally to ensure all VSCode windows are affected consistently

## Testing

- Tested on macOS Tahoe - GPU usage drops significantly - from constant 80% to normal 15%

## Notes

This is a temporary workaround until Apple fixes the underlying WindowServer bug in macOS Tahoe. The version check can be refined or removed once the OS-level issue is resolved.