### PR TITLE
always focus chat response when a11y view is closed

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatResponseAccessibleView.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatResponseAccessibleView.ts
@@ -38,7 +38,7 @@ export class ChatResponseAccessibleView implements IAccessibleViewImplementation
 			return;
 		}
 
-		return new ChatResponseAccessibleProvider(verifiedWidget, focusedItem, chatInputFocused);
+		return new ChatResponseAccessibleProvider(verifiedWidget, focusedItem);
 	}
 }
 
@@ -46,8 +46,7 @@ class ChatResponseAccessibleProvider extends Disposable implements IAccessibleVi
 	private _focusedItem: ChatTreeItem;
 	constructor(
 		private readonly _widget: IChatWidget,
-		item: ChatTreeItem,
-		private readonly _chatInputFocused: boolean
+		item: ChatTreeItem
 	) {
 		super();
 		this._focusedItem = item;
@@ -126,11 +125,7 @@ class ChatResponseAccessibleProvider extends Disposable implements IAccessibleVi
 
 	onClose(): void {
 		this._widget.reveal(this._focusedItem);
-		if (this._chatInputFocused) {
-			this._widget.focusInput();
-		} else {
-			this._widget.focus(this._focusedItem);
-		}
+		this._widget.focus(this._focusedItem);
 	}
 
 	provideNextContent(): string | undefined {


### PR DESCRIPTION
fix #267802

The user was inspecting a response, so we should focus that response on close.