### PR TITLE
fix: adds aria-description to provide screen reader context for tooltip

### DIFF
--- a/src/vs/workbench/browser/parts/titlebar/commandCenterControl.ts
+++ b/src/vs/workbench/browser/parts/titlebar/commandCenterControl.ts
@@ -142,6 +142,7 @@ class CommandCenterCenterViewItem extends BaseActionViewItem {
 							super.render(container);
 							container.classList.toggle('command-center-quick-pick');
 							container.role = 'button';
+							container.setAttribute('aria-description', this.getTooltip());
 							const action = this.action;
 
 							// icon (search)


### PR DESCRIPTION
Updates Command Command Center control workspace button to have an aria- description to provide screen reader context for the tooltip that appears when Search Workspace is hovered.

Fixes https://github.com/microsoft/vscode/issues/267817

## Steps to Test:

1. Checkout the PR: git checkout
2. Rebuild and Run the project. Follow the standard process for building the project and launching the IDE.
3. Enable a screen reader: Turn on a screen reader on your operating system (e.g., VoiceOver on macOS, NVDA on Windows, or ChromeVox on ChromeOS).
4. Hover or focus on the "Search Workspace" button in the `.monaco-action-bar`/VSCode toolbar at the top.
5. Observe the screen reader announcing the button text value as well as the text value of the tooltip that appears on focus/hover.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
