### PR TITLE
Change padding from 4px to 5px to increase target size to at least 24…

### DIFF
--- a/src/vs/base/browser/ui/inputbox/inputBox.css
+++ b/src/vs/base/browser/ui/inputbox/inputBox.css
@@ -18,7 +18,7 @@
 .monaco-inputbox > .ibwrapper > .mirror {
 
 	/* Customizable */
-	padding: 4px 6px;
+	padding: 5px 6px;
 }
 
 .monaco-inputbox > .ibwrapper {


### PR DESCRIPTION
Change padding from 4px to 5px to increase target size to at least 24 x 24 pixels

Fixes #267821

**Steps to Test:**
Go to File menu
Click "New file" menu option
Observe that the input box with placeholder text "Select File Type or Enter File Name..." now has size of 583.81 x 25 pixels.
