### PR TITLE
Don't eagerly attach pasted images in `provideDocumentPasteEdits`

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatPasteProviders.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatPasteProviders.ts
@@ -118,8 +118,6 @@ export class PasteImageProvider implements DocumentPasteEditProvider {
 			return;
 		}
 
-		widget.attachmentModel.addContext(scaledImageContext);
-
 		// Make sure to attach only new contexts
 		const currentContextIds = widget.attachmentModel.getAttachmentIDs();
 		if (currentContextIds.has(scaledImageContext.id)) {


### PR DESCRIPTION
Fixes #267850

`provideDocumentPasteEdits` should be side effect free

