### PR TITLE
add header to chat list items

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatListRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatListRenderer.ts
@@ -341,6 +341,8 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 		const templateDisposables = new DisposableStore();
 		const disabledOverlay = dom.append(container, $('.chat-row-disabled-overlay'));
 		const rowContainer = dom.append(container, $('.interactive-item-container'));
+		rowContainer.setAttribute('role', 'heading');
+		rowContainer.setAttribute('aria-level', '2');
 		if (this.rendererOptions.renderStyle === 'compact') {
 			rowContainer.classList.add('interactive-item-compact');
 		}


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/261862

An issue with this still is when I use VoiceOver's quick nav (enable with `UpArrow` and `DownArrow` simultaneously), then `H` or `Shift H` to go between headers is that the chat list does not scroll to reveal new headers. 

I have commented on https://github.com/microsoft/vscode/issues/267152 to ask why header navigation is preferrable to our `upArrow/downArrow` list navigation mechanism that does scroll properly.

https://github.com/user-attachments/assets/688abcb6-2603-4d5f-b594-b8f5d698c2ec

