### PR TITLE
Copy selection for deleted chunk in inline diff

### DIFF
--- a/src/vs/editor/browser/controller/mouseTarget.ts
+++ b/src/vs/editor/browser/controller/mouseTarget.ts
@@ -481,7 +481,8 @@ class HitTestRequest extends BareHitTestRequest {
 		return MouseTarget.createMargin(type, this.target, this._getMouseColumn(position), position, range, detail);
 	}
 	public fulfillViewZone(type: MouseTargetType.GUTTER_VIEW_ZONE | MouseTargetType.CONTENT_VIEW_ZONE, position: Position, detail: IMouseTargetViewZoneData): IMouseTargetViewZone {
-		return MouseTarget.createViewZone(type, this.target, this._getMouseColumn(position), position, detail);
+		// Always return the usual mouse column for a view zone.
+		return MouseTarget.createViewZone(type, this.target, this._getMouseColumn(), position, detail);
 	}
 	public fulfillContentText(position: Position, range: EditorRange | null, detail: IMouseTargetContentTextData): IMouseTargetContentText {
 		return MouseTarget.createContentText(this.target, this._getMouseColumn(position), position, range, detail);

--- a/src/vs/editor/browser/widget/diffEditor/components/diffEditorViewZones/copySelection.ts
+++ b/src/vs/editor/browser/widget/diffEditor/components/diffEditorViewZones/copySelection.ts
@@ -186,9 +186,7 @@ function getRealColumnNumber(
 	textModel: ITextModel,
 ) {
 	const lineContent = textModel.getLineContent(lineNumber);
-	if (lineContent.startsWith('\t')) {
-		const tabs = textModel.getLineFirstNonWhitespaceColumn(lineNumber) - 1;
-		return Math.max(1, mouseColumn - tabs * (textModel.getOptions().tabSize - 1));
-	}
-	return mouseColumn;
+	let i = 0;
+	while (lineContent[i] === '\t') { i++; }
+	return Math.max(1, mouseColumn - i * (textModel.getOptions().tabSize - 1));
 }

--- a/src/vs/editor/browser/widget/diffEditor/components/diffEditorViewZones/copySelection.ts
+++ b/src/vs/editor/browser/widget/diffEditor/components/diffEditorViewZones/copySelection.ts
@@ -189,7 +189,7 @@ function getRealColumnNumber(
 	const lineContent = textModel.getLineContent(lineNumber);
 	if (lineContent.startsWith('\t')) {
 		const tabs = textModel.getLineFirstNonWhitespaceColumn(lineNumber) - 1;
-		return mouseColumn - tabs * (textModel.getOptions().tabSize - 1);
+		return Math.max(1, mouseColumn - tabs * (textModel.getOptions().tabSize - 1));
 	}
 	return mouseColumn;
 }

--- a/src/vs/editor/browser/widget/diffEditor/components/diffEditorViewZones/copySelection.ts
+++ b/src/vs/editor/browser/widget/diffEditor/components/diffEditorViewZones/copySelection.ts
@@ -1,0 +1,195 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { addDisposableListener, getDomNodePagePosition } from '../../../../../../base/browser/dom.js';
+import { Action } from '../../../../../../base/common/actions.js';
+import { DisposableStore } from '../../../../../../base/common/lifecycle.js';
+import { ICodeEditor, MouseTargetType } from '../../../../../browser/editorBrowser.js';
+import { Position } from '../../../../../common/core/position.js';
+import { Range } from '../../../../../common/core/range.js';
+import { DetailedLineRangeMapping } from '../../../../../common/diff/rangeMapping.js';
+import { ITextModel } from '../../../../../common/model.js';
+import { localize } from '../../../../../../nls.js';
+import { IClipboardService } from '../../../../../../platform/clipboard/common/clipboardService.js';
+
+export interface IEnableViewZoneSelectionAndCopyOptions {
+	/** The view zone HTML element that contains the deleted codes. */
+	domNode: HTMLElement;
+
+	/** Returns the current view zone ID. */
+	getViewZoneId: () => string;
+
+	/** The diff entry for the current view zone. */
+	diffEntry: DetailedLineRangeMapping;
+
+	/** The original text model, to get the original text based on selection. */
+	originalModel: ITextModel;
+
+	/** The line height of the editor, to calculate the line number offset. */
+	editorLineHeight: number;
+
+	/** The actual view lines for each editor line (considers line-wrapping). */
+	viewLineCounts: number[];
+
+	/** The editor to listen to mouse events on. */
+	editor: ICodeEditor;
+
+	/**
+	 * The function to show the context menu.
+	 *
+	 * @param anchor The anchor position for the context menu.
+	 * @param baseActions The base actions to show in the context menu, which will
+	 *     include the "Copy Selection" option if any text is selected in this
+	 *     view zone.
+	 * @param onHide The function to call when the context menu is dismissed.
+	 */
+	showContextMenu:
+	(anchor: { x: number; y: number }, baseActions?: Action[],
+		onHide?: () => void) => void;
+
+	/** The clipboard service to write the selected text to. */
+	clipboardService: IClipboardService;
+}
+
+export function enableCopySelection(
+	options: IEnableViewZoneSelectionAndCopyOptions): DisposableStore {
+	const {
+		domNode,
+		getViewZoneId,
+		diffEntry,
+		originalModel,
+		editorLineHeight,
+		viewLineCounts,
+		editor,
+		showContextMenu,
+		clipboardService,
+	} = options;
+	let lastMouseDownPosition: Position | undefined;
+	const viewZoneDisposable = new DisposableStore();
+
+	viewZoneDisposable.add(editor.onMouseDown(e => {
+		if (!e.event.leftButton) {
+			return;
+		}
+		if (e.target.type !== MouseTargetType.CONTENT_VIEW_ZONE &&
+			e.target.type !== MouseTargetType.GUTTER_VIEW_ZONE) {
+			return;
+		}
+		if (e.target.detail.viewZoneId !== getViewZoneId()) {
+			return;
+		}
+
+		// Temporarily makes the *current* view zone selectable
+		// This prevents the selection from bleeding into other view zones
+		domNode.classList.add('line-delete-selectable');
+
+		const lineNumberOffset = calculateLineNumberOffset(e.event.browserEvent.y, domNode, editorLineHeight, viewLineCounts);
+		const lineNumber = diffEntry.original.startLineNumber + lineNumberOffset;
+		lastMouseDownPosition = new Position(lineNumber, getRealColumnNumber(e.target.mouseColumn, lineNumber, originalModel));
+	}));
+
+	viewZoneDisposable.add(editor.onMouseUp(e => {
+		if (!lastMouseDownPosition) {
+			return;
+		}
+		const mouseDownPosition = lastMouseDownPosition;
+		lastMouseDownPosition = undefined;
+
+		if (!e.event.leftButton) {
+			return;
+		}
+		if ((e.target.type !== MouseTargetType.CONTENT_VIEW_ZONE &&
+			e.target.type !== MouseTargetType.GUTTER_VIEW_ZONE) ||
+			e.target.detail.viewZoneId !== getViewZoneId()) {
+			// Mouse left the current view zone. Remove the selectable class
+			domNode.classList.remove('line-delete-selectable');
+			return;
+		}
+
+		const lineNumberOffset = calculateLineNumberOffset(e.event.browserEvent.y, domNode, editorLineHeight, viewLineCounts);
+		const lineNumber = diffEntry.original.startLineNumber + lineNumberOffset;
+		const mouseUpPosition = new Position(lineNumber, getRealColumnNumber(e.target.mouseColumn, lineNumber, originalModel));
+
+		const range = mouseUpPosition.isBefore(mouseDownPosition) ?
+			Range.fromPositions(mouseUpPosition, mouseDownPosition) :
+			Range.fromPositions(mouseDownPosition, mouseUpPosition);
+		const selectedText = originalModel.getValueInRange(range);
+		const onCopy =
+			viewZoneDisposable.add(addDisposableListener(domNode, 'copy', (e) => {
+				e.preventDefault();
+				clipboardService.writeText(selectedText);
+			}));
+
+		showContextMenu(
+			{ x: e.event.posx, y: e.event.posy + editorLineHeight },
+			selectedText ?
+				[new Action(
+					'diff.clipboard.copySelectedDeletedContent',
+					localize(
+						'diff.clipboard.copySelectedDeletedContent.label',
+						'Copy Selection'),
+					undefined, true,
+					async () => clipboardService.writeText(selectedText))] :
+				[],
+			() => {
+				onCopy.dispose();
+				domNode.classList.remove('line-delete-selectable');
+			});
+	}));
+	return viewZoneDisposable;
+}
+
+/**
+ * Calculate the line number offset of the given browser event y-coordinate in a
+ * view zone.
+ *
+ * @param y The y-coordinate position of the browser event.
+ * @param viewZoneNode The view zone HTML element.
+ * @param editorLineHeight The line height of the editor.
+ * @param viewLineCounts The actual view lines for each editor line (considers
+ *     line-wrapping).
+ * @return The line number offset in the given view zone.
+ */
+function calculateLineNumberOffset(
+	y: number,
+	viewZoneNode: HTMLElement,
+	editorLineHeight: number,
+	viewLineCounts: number[],
+): number {
+	const { top } = getDomNodePagePosition(viewZoneNode);
+	const offset = y - top;
+	const lineNumberOffset = Math.floor(offset / editorLineHeight);
+
+	let acc = 0;
+	for (let i = 0; i < viewLineCounts.length; i++) {
+		acc += viewLineCounts[i];
+		if (lineNumberOffset < acc) {
+			return i;
+		}
+	}
+	return lineNumberOffset;
+}
+
+/**
+ * Get the real column number of the given mouse column in a view zone. This
+ * compensates for different tab sizes.
+ *
+ * @param mouseColumn The mouse column position of the browser event.
+ * @param lineNumber The line number of the original text model.
+ * @param textModel The original text model.
+ * @return The real column number of the given mouse column in the view zone.
+ */
+function getRealColumnNumber(
+	mouseColumn: number,
+	lineNumber: number,
+	textModel: ITextModel,
+) {
+	const lineContent = textModel.getLineContent(lineNumber);
+	if (lineContent.startsWith('\t')) {
+		const tabs = textModel.getLineFirstNonWhitespaceColumn(lineNumber) - 1;
+		return mouseColumn - tabs * (textModel.getOptions().tabSize - 1);
+	}
+	return mouseColumn;
+}

--- a/src/vs/editor/browser/widget/diffEditor/components/diffEditorViewZones/copySelection.ts
+++ b/src/vs/editor/browser/widget/diffEditor/components/diffEditorViewZones/copySelection.ts
@@ -14,7 +14,7 @@ import { ITextModel } from '../../../../../common/model.js';
 import { localize } from '../../../../../../nls.js';
 import { IClipboardService } from '../../../../../../platform/clipboard/common/clipboardService.js';
 
-export interface IEnableViewZoneSelectionAndCopyOptions {
+export interface IEnableViewZoneCopySelectionOptions {
 	/** The view zone HTML element that contains the deleted codes. */
 	domNode: HTMLElement;
 
@@ -53,8 +53,7 @@ export interface IEnableViewZoneSelectionAndCopyOptions {
 	clipboardService: IClipboardService;
 }
 
-export function enableCopySelection(
-	options: IEnableViewZoneSelectionAndCopyOptions): DisposableStore {
+export function enableCopySelection(options: IEnableViewZoneCopySelectionOptions): DisposableStore {
 	const {
 		domNode,
 		getViewZoneId,

--- a/src/vs/editor/browser/widget/diffEditor/components/diffEditorViewZones/copySelection.ts
+++ b/src/vs/editor/browser/widget/diffEditor/components/diffEditorViewZones/copySelection.ts
@@ -80,10 +80,6 @@ export function enableCopySelection(options: IEnableViewZoneCopySelectionOptions
 			return;
 		}
 
-		// Temporarily makes the *current* view zone selectable
-		// This prevents the selection from bleeding into other view zones
-		domNode.classList.add('line-delete-selectable');
-
 		const lineNumberOffset = calculateLineNumberOffset(e.event.browserEvent.y, domNode, editorLineHeight, viewLineCounts);
 		const lineNumber = diffEntry.original.startLineNumber + lineNumberOffset;
 		lastMouseDownPosition = new Position(lineNumber, getRealColumnNumber(e.target.mouseColumn, lineNumber, originalModel));
@@ -102,8 +98,6 @@ export function enableCopySelection(options: IEnableViewZoneCopySelectionOptions
 		if ((e.target.type !== MouseTargetType.CONTENT_VIEW_ZONE &&
 			e.target.type !== MouseTargetType.GUTTER_VIEW_ZONE) ||
 			e.target.detail.viewZoneId !== getViewZoneId()) {
-			// Mouse left the current view zone. Remove the selectable class
-			domNode.classList.remove('line-delete-selectable');
 			return;
 		}
 
@@ -134,7 +128,6 @@ export function enableCopySelection(options: IEnableViewZoneCopySelectionOptions
 				[],
 			() => {
 				onCopy.dispose();
-				domNode.classList.remove('line-delete-selectable');
 			});
 	}));
 	return viewZoneDisposable;

--- a/src/vs/editor/browser/widget/diffEditor/components/diffEditorViewZones/copySelection.ts
+++ b/src/vs/editor/browser/widget/diffEditor/components/diffEditorViewZones/copySelection.ts
@@ -187,6 +187,6 @@ function getRealColumnNumber(
 ) {
 	const lineContent = textModel.getLineContent(lineNumber);
 	let i = 0;
-	while (lineContent[i] === '\t') { i++; }
+	while (i < lineContent.length && lineContent[i] === '\t') { i++; }
 	return Math.max(1, mouseColumn - i * (textModel.getOptions().tabSize - 1));
 }

--- a/src/vs/editor/browser/widget/diffEditor/components/diffEditorViewZones/diffEditorViewZones.ts
+++ b/src/vs/editor/browser/widget/diffEditor/components/diffEditorViewZones/diffEditorViewZones.ts
@@ -199,7 +199,7 @@ export class DiffEditorViewZones extends Disposable {
 						originalModelTokenizationCompleted.read(reader); // Update view-zones once tokenization completes
 
 						const deletedCodeDomNode = document.createElement('div');
-						deletedCodeDomNode.classList.add('view-lines', 'line-delete', 'monaco-mouse-cursor-text');
+						deletedCodeDomNode.classList.add('view-lines', 'line-delete', 'line-delete-selectable', 'monaco-mouse-cursor-text');
 						const originalModel = this._editors.original.getModel()!;
 						// `a.originalRange` can be out of bound when the diff has not been updated yet.
 						// In this case, we do an early return.

--- a/src/vs/editor/browser/widget/diffEditor/components/diffEditorViewZones/diffEditorViewZones.ts
+++ b/src/vs/editor/browser/widget/diffEditor/components/diffEditorViewZones/diffEditorViewZones.ts
@@ -241,6 +241,7 @@ export class DiffEditorViewZones extends Disposable {
 							new InlineDiffDeletedCodeMargin(
 								() => assertReturnsDefined(zoneId),
 								marginDomNode,
+								deletedCodeDomNode,
 								this._editors.modified,
 								a.diff,
 								this._diffEditorWidget,
@@ -273,7 +274,7 @@ export class DiffEditorViewZones extends Disposable {
 							marginDomNode,
 							setZoneId(id) { zoneId = id; },
 							showInHiddenAreas: true,
-							suppressMouseDown: true,
+							suppressMouseDown: false,
 						});
 					}
 

--- a/src/vs/editor/browser/widget/diffEditor/style.css
+++ b/src/vs/editor/browser/widget/diffEditor/style.css
@@ -426,3 +426,14 @@
 		margin: 0 4px;
 	}
 }
+
+.monaco-editor .line-delete-selectable {
+	user-select: text !important;
+	-webkit-user-select: text !important;
+	z-index: 1 !important;
+}
+
+.line-delete-selectable .view-line {
+	user-select: text !important;
+	-webkit-user-select: text !important;
+}


### PR DESCRIPTION
An attempt to fix #8226 

Hi @hediet , can I interest you with (yet another) PR for #8226, a.k.a. inline diff deleted chunk copy selection? :)

The main idea is to calculate the exact line and column for the start & end of the selection in a view zone, and extract the corresponding code chunk using the text model API.

Demo: 
![copySelectionInlineDelete](https://github.com/user-attachments/assets/1b64cec2-aed4-4e39-9b5f-854cf3f06c83)

This works with both the menu item, and the browser 'copy' event (Ctrl/Cmd+C).

I have put the setup in a reusable method in a separate file, following the example of [renderLines.ts](https://github.com/microsoft/vscode/blob/main/src/vs/editor/browser/widget/diffEditor/components/diffEditorViewZones/renderLines.ts)

Due to the view zone, there are some hackery involved to get those line and column numbers right (the line number extraction is the same as that from the [inlineDiffDeletedCodeMargin.ts](https://github.com/microsoft/vscode/blob/main/src/vs/editor/browser/widget/diffEditor/components/diffEditorViewZones/inlineDiffDeletedCodeMargin.ts)). Let me know if you see any issues, or if you prefer to solve it in a different way.

Thanks!


<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
