### PR TITLE
Implement welcome view rendering scheduler to prevent reentrant calls

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatWidget.ts
@@ -8,7 +8,7 @@ import { IMouseWheelEvent } from '../../../../base/browser/mouseEvent.js';
 import { Button } from '../../../../base/browser/ui/button/button.js';
 import { IListRenderer, IListVirtualDelegate } from '../../../../base/browser/ui/list/list.js';
 import { ITreeContextMenuEvent, ITreeElement } from '../../../../base/browser/ui/tree/tree.js';
-import { disposableTimeout, timeout } from '../../../../base/common/async.js';
+import { disposableTimeout, RunOnceScheduler, timeout } from '../../../../base/common/async.js';
 import { CancellationToken } from '../../../../base/common/cancellation.js';
 import { Codicon } from '../../../../base/common/codicons.js';
 import { fromNow, fromNowByDay } from '../../../../base/common/date.js';
@@ -310,6 +310,9 @@ export class ChatWidget extends Disposable implements IChatWidget {
 	private readonly viewModelDisposables = this._register(new DisposableStore());
 	private _viewModel: ChatViewModel | undefined;
 
+	// Welcome view rendering scheduler to prevent reentrant calls
+	private _welcomeRenderScheduler: RunOnceScheduler;
+
 	// Coding agent locking state
 	private _lockedToCodingAgent: string | undefined;
 	private _lockedToCodingAgentContextKey!: IContextKey<boolean>;
@@ -447,16 +450,17 @@ export class ChatWidget extends Disposable implements IChatWidget {
 
 		// Context key for when empty state history is enabled and in empty state
 		this.inEmptyStateWithHistoryEnabledKey = ChatContextKeys.inEmptyStateWithHistoryEnabled.bindTo(contextKeyService);
+		this._welcomeRenderScheduler = this._register(new RunOnceScheduler(() => this.renderWelcomeViewContentIfNeeded(), 10));
 		this._register(this.configurationService.onDidChangeConfiguration(e => {
 			if (e.affectsConfiguration(ChatConfiguration.EmptyStateHistoryEnabled)) {
 				this.updateEmptyStateWithHistoryContext();
-				this.renderWelcomeViewContentIfNeeded();
+				this._welcomeRenderScheduler.schedule();
 			}
 		}));
 		this.updateEmptyStateWithHistoryContext();
 
 		// Update welcome view content when `anonymous` condition changes
-		this._register(this.chatEntitlementService.onDidChangeAnonymous(() => this.renderWelcomeViewContentIfNeeded()));
+		this._register(this.chatEntitlementService.onDidChangeAnonymous(() => this._welcomeRenderScheduler.schedule()));
 
 		this._register(bindContextKey(decidedChatEditingResourceContextKey, contextKeyService, (reader) => {
 			const currentSession = this._editingSession.read(reader);
@@ -711,7 +715,7 @@ export class ChatWidget extends Disposable implements IChatWidget {
 			this.createInput(this.container, { renderFollowups, renderStyle });
 		}
 
-		this.renderWelcomeViewContentIfNeeded();
+		this._welcomeRenderScheduler.schedule();
 		this.createList(this.listContainer, { editable: !isInlineChat(this) && !isQuickChat(this), ...this.viewOptions.rendererOptions, renderStyle });
 
 		const scrollDownButton = this._register(new Button(this.listContainer, {
@@ -877,8 +881,12 @@ export class ChatWidget extends Disposable implements IChatWidget {
 				this.input.setChatMode(this.lastWelcomeViewChatMode ?? ChatModeKind.Ask);
 			}
 
-			this.renderWelcomeViewContentIfNeeded();
-			this.renderChatTodoListWidget();
+			if (treeItems.length > 0) {
+				this.updateChatViewVisibility();
+				this.renderChatTodoListWidget();
+			} else {
+				this._welcomeRenderScheduler.schedule();
+			}
 
 			this._onWillMaybeChangeHeight.fire();
 
@@ -920,6 +928,27 @@ export class ChatWidget extends Disposable implements IChatWidget {
 		}
 	}
 
+	/**
+	 * Updates the DOM visibility of welcome view and chat list immediately
+	 * @internal
+	 */
+	private updateChatViewVisibility(): void {
+		if (!this.viewModel) {
+			return;
+		}
+
+		const numItems = this.viewModel.getItems().length;
+		dom.setVisibility(numItems === 0, this.welcomeMessageContainer);
+		dom.setVisibility(numItems !== 0, this.listContainer);
+	}
+
+	/**
+	 * Renders the welcome view content when needed.
+	 *
+	 * Note: Do not call this method directly. Instead, use `this._welcomeRenderScheduler.schedule()`
+	 * to ensure proper debouncing and avoid potential cyclic calls
+	 * @internal
+	 */
 	private renderWelcomeViewContentIfNeeded() {
 
 		if (this.viewOptions.renderStyle === 'compact' || this.viewOptions.renderStyle === 'minimal') {
@@ -975,13 +1004,10 @@ export class ChatWidget extends Disposable implements IChatWidget {
 			}
 		}
 
-		if (this.viewModel) {
-			dom.setVisibility(numItems === 0, this.welcomeMessageContainer);
-			dom.setVisibility(numItems !== 0, this.listContainer);
+		this.updateChatViewVisibility();
 
-			if (numItems > 0) {
-				this.refreshHistoryList();
-			}
+		if (numItems > 0) {
+			this.refreshHistoryList();
 		}
 	}
 
@@ -1346,6 +1372,7 @@ export class ChatWidget extends Disposable implements IChatWidget {
 			// Get all available prompt files with their metadata
 			const promptCommands = await this.promptsService.findPromptSlashCommands();
 
+			let cacheUpdated = false;
 			// Load descriptions only for the specified prompts
 			for (const promptCommand of promptCommands) {
 				if (promptNames.includes(promptCommand.command)) {
@@ -1358,9 +1385,11 @@ export class ChatWidget extends Disposable implements IChatWidget {
 							const description = parseResult.header?.description;
 							if (description) {
 								this.promptDescriptionsCache.set(promptCommand.command, description);
+								cacheUpdated = true;
 							} else {
 								// Set empty string to indicate we've checked this prompt
 								this.promptDescriptionsCache.set(promptCommand.command, '');
+								cacheUpdated = true;
 							}
 						}
 					} catch (error) {
@@ -1368,12 +1397,15 @@ export class ChatWidget extends Disposable implements IChatWidget {
 						this.logService.warn('Failed to parse prompt file for description:', promptCommand.command, error);
 						// Set empty string to indicate we've checked this prompt
 						this.promptDescriptionsCache.set(promptCommand.command, '');
+						cacheUpdated = true;
 					}
 				}
 			}
 
-			// Trigger a re-render of the welcome view to show the loaded descriptions
-			this.renderWelcomeViewContentIfNeeded();
+			// Fire event to trigger a re-render of the welcome view only if cache was updated
+			if (cacheUpdated) {
+				this._welcomeRenderScheduler.schedule();
+			}
 		} catch (error) {
 			this.logService.warn('Failed to load specific prompt descriptions:', error);
 		}
@@ -1908,11 +1940,11 @@ export class ChatWidget extends Disposable implements IChatWidget {
 		this._register(this.chatAgentService.onDidChangeAgents(() => {
 			this.parsedChatRequest = undefined;
 			// Tools agent loads -> welcome content changes
-			this.renderWelcomeViewContentIfNeeded();
+			this._welcomeRenderScheduler.schedule();
 		}));
 		this._register(this.input.onDidChangeCurrentChatMode(() => {
 			this.lastWelcomeViewChatMode = this.input.currentModeKind;
-			this.renderWelcomeViewContentIfNeeded();
+			this._welcomeRenderScheduler.schedule();
 			this.refreshParsedInput();
 			this.renderFollowups();
 		}));
@@ -2077,7 +2109,7 @@ export class ChatWidget extends Disposable implements IChatWidget {
 		this._codingAgentPrefix = `@${name} `;
 		this._lockedAgentId = agentId;
 		this._lockedToCodingAgentContextKey.set(true);
-		this.renderWelcomeViewContentIfNeeded();
+		this._welcomeRenderScheduler.schedule();
 		this.renderer.updateOptions({ restorable: false, editable: false, noFooter: true, progressMessageAtBottomOfResponse: true });
 		this.tree.rerender();
 	}
@@ -2090,7 +2122,7 @@ export class ChatWidget extends Disposable implements IChatWidget {
 		this._lockedToCodingAgentContextKey.set(false);
 
 		// Explicitly update the DOM to reflect unlocked state
-		this.renderWelcomeViewContentIfNeeded();
+		this._welcomeRenderScheduler.schedule();
 
 		// Reset to default placeholder
 		if (this.viewModel) {


### PR DESCRIPTION
Take 2 at fixing: https://github.com/microsoft/vscode/issues/267105

Previous attempt https://github.com/microsoft/vscode/pull/267856 was [reverted](https://github.com/microsoft/vscode/pull/268002) because first chat request in an empty window was not being rendered. This was because the chat list visibility was controlled by the welcomeView rendering logic. When the welcome view rendering was scheduled from within in `onDidChangeItems`, the chat list view visibility was not updated before the chat tree was progressively rendered which caused the first request to be missed.

In this pr, additional to the logic in #267856, I also moved out the logic to toggle visibility of the welcome/chatList view out of the welcome rendering logic here: https://github.com/microsoft/vscode/pull/268023/files#diff-1a26fc97bbf0d39b6d25ad9fe509fad4d90373118985b50709f99b6ef5bde8c9R935

And update it here inside `onDidChangeItems` : https://github.com/microsoft/vscode/pull/268023/files#diff-1a26fc97bbf0d39b6d25ad9fe509fad4d90373118985b50709f99b6ef5bde8c9R884

cc: @justschen 