### PR TITLE
i18n: add missing localizations for monaco-editor

### DIFF
--- a/build/gulpfile.editor.js
+++ b/build/gulpfile.editor.js
@@ -74,7 +74,7 @@ const compileEditorESMTask = task.define('compile-editor-esm', () => {
 			.pipe(i18n.processNlsFiles({
 				out,
 				fileHeader: BUNDLED_FILE_HEADER,
-				languages: i18n.defaultLanguages,
+				languages: [...i18n.defaultLanguages, ...i18n.extraLanguages],
 			}))
 			.pipe(filter(['**', '!**/inlineEntryPoint*', '!**/tsconfig.json', '!**/loader.js']))
 			.pipe(gulp.dest(out))

--- a/build/lib/i18n.js
+++ b/build/lib/i18n.js
@@ -41,11 +41,12 @@ exports.defaultLanguages = [
     { id: 'ru', folderName: 'rus' },
     { id: 'it', folderName: 'ita' }
 ];
-// languages requested by the community to non-stable builds
+// languages requested by the community
 exports.extraLanguages = [
     { id: 'pt-br', folderName: 'ptb' },
-    { id: 'hu', folderName: 'hun' },
-    { id: 'tr', folderName: 'trk' }
+    { id: 'tr', folderName: 'trk' },
+    { id: 'cs' },
+    { id: 'pl' }
 ];
 var LocalizeInfo;
 (function (LocalizeInfo) {

--- a/build/lib/i18n.ts
+++ b/build/lib/i18n.ts
@@ -44,11 +44,12 @@ export const defaultLanguages: Language[] = [
 	{ id: 'it', folderName: 'ita' }
 ];
 
-// languages requested by the community to non-stable builds
+// languages requested by the community
 export const extraLanguages: Language[] = [
 	{ id: 'pt-br', folderName: 'ptb' },
-	{ id: 'hu', folderName: 'hun' },
-	{ id: 'tr', folderName: 'trk' }
+	{ id: 'tr', folderName: 'trk' },
+	{ id: 'cs' },
+	{ id: 'pl' }
 ];
 
 interface Item {


### PR DESCRIPTION
Fixes issues [#3500](https://github.com/microsoft/monaco-editor/issues/3500) and [#4853](https://github.com/microsoft/monaco-editor/issues/4853) in `monaco-editor`.

From what I gather the `folderName` property is not used, (see [this line](https://github.com/microsoft/vscode/blob/8bd32376b6fa728af9f11ec7c0d8a502c3f68c20/build/lib/i18n.ts#L359)), and it's optional, so I left them not defined.

Closes https://github.com/microsoft/monaco-editor/issues/3500