### PR TITLE
Show full date/time for history items

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatSessions/view/sessionsTreeRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSessions/view/sessionsTreeRenderer.ts
@@ -47,7 +47,7 @@ import { LocalChatSessionsProvider } from '../localChatSessionsProvider.js';
 import { IListRenderer, IListVirtualDelegate } from '../../../../../../base/browser/ui/list/list.js';
 import { ChatSessionTracker } from '../chatSessionTracker.js';
 import { CancellationToken } from '../../../../../../base/common/cancellation.js';
-import { language } from '../../../../../../base/common/platform.js';
+import { getLocalHistoryDateFormatter } from '../../../../localHistory/browser/localHistory.js';
 
 interface ISessionTemplateData {
 	readonly container: HTMLElement;
@@ -340,10 +340,10 @@ export class SessionsRenderer extends Disposable implements ITreeRenderer<IChatS
 
 			// Add tooltip showing full date/time when hovering over the timestamp
 			if (session.timing?.startTime) {
-				const fullDateTime = new Date(session.timing.startTime).toLocaleString(language);
+				const fullDateTime = getLocalHistoryDateFormatter().format(session.timing.startTime);
 				templateData.elementDisposable.add(
 					this.hoverService.setupDelayedHover(templateData.timestamp, {
-						content: fullDateTime
+						content: `Start Time: ${fullDateTime}`
 					})
 				);
 			}

--- a/src/vs/workbench/contrib/chat/browser/chatSessions/view/sessionsTreeRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSessions/view/sessionsTreeRenderer.ts
@@ -47,6 +47,7 @@ import { LocalChatSessionsProvider } from '../localChatSessionsProvider.js';
 import { IListRenderer, IListVirtualDelegate } from '../../../../../../base/browser/ui/list/list.js';
 import { ChatSessionTracker } from '../chatSessionTracker.js';
 import { CancellationToken } from '../../../../../../base/common/cancellation.js';
+import { language } from '../../../../../../base/common/platform.js';
 
 interface ISessionTemplateData {
 	readonly container: HTMLElement;
@@ -336,6 +337,16 @@ export class SessionsRenderer extends Disposable implements ITreeRenderer<IChatS
 			templateData.timestamp.ariaLabel = session.relativeTimeFullWord ?? '';
 			templateData.timestamp.parentElement!.classList.toggle('timestamp-duplicate', session.hideRelativeTime === true);
 			templateData.timestamp.parentElement!.style.display = '';
+
+			// Add tooltip showing full date/time when hovering over the timestamp
+			if (session.timing?.startTime) {
+				const fullDateTime = new Date(session.timing.startTime).toLocaleString(language);
+				templateData.elementDisposable.add(
+					this.hoverService.setupDelayedHover(templateData.timestamp, {
+						content: fullDateTime
+					})
+				);
+			}
 		} else {
 			// Hide timestamp container if no timestamp available
 			templateData.timestamp.parentElement!.style.display = 'none';

--- a/src/vs/workbench/contrib/chat/browser/chatSessions/view/sessionsTreeRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSessions/view/sessionsTreeRenderer.ts
@@ -343,7 +343,7 @@ export class SessionsRenderer extends Disposable implements ITreeRenderer<IChatS
 				const fullDateTime = getLocalHistoryDateFormatter().format(session.timing.startTime);
 				templateData.elementDisposable.add(
 					this.hoverService.setupDelayedHover(templateData.timestamp, {
-						content: `${nls.localize('chat.sessions.startTime', 'Start Time')}: ${fullDateTime}`
+						content: `${nls.localize('chat.sessions.lastActivity', 'Last Activity')}: ${fullDateTime}`
 					})
 				);
 			}

--- a/src/vs/workbench/contrib/chat/browser/chatSessions/view/sessionsTreeRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSessions/view/sessionsTreeRenderer.ts
@@ -343,7 +343,7 @@ export class SessionsRenderer extends Disposable implements ITreeRenderer<IChatS
 				const fullDateTime = getLocalHistoryDateFormatter().format(session.timing.startTime);
 				templateData.elementDisposable.add(
 					this.hoverService.setupDelayedHover(templateData.timestamp, {
-						content: `${nls.localize('chat.sessions.lastActivity', 'Last Activity')}: ${fullDateTime}`
+						content: `${nls.localize('chat.sessions.lastActivity', 'Last Activity: {0}', fullDateTime)}`
 					})
 				);
 			}

--- a/src/vs/workbench/contrib/chat/browser/chatSessions/view/sessionsTreeRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSessions/view/sessionsTreeRenderer.ts
@@ -343,7 +343,7 @@ export class SessionsRenderer extends Disposable implements ITreeRenderer<IChatS
 				const fullDateTime = getLocalHistoryDateFormatter().format(session.timing.startTime);
 				templateData.elementDisposable.add(
 					this.hoverService.setupDelayedHover(templateData.timestamp, {
-						content: `${nls.localize('chat.sessions.lastActivity', 'Last Activity: {0}', fullDateTime)}`
+						content: nls.localize('chat.sessions.lastActivity', 'Last Activity: {0}', fullDateTime)
 					})
 				);
 			}

--- a/src/vs/workbench/contrib/chat/browser/chatSessions/view/sessionsTreeRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSessions/view/sessionsTreeRenderer.ts
@@ -343,7 +343,7 @@ export class SessionsRenderer extends Disposable implements ITreeRenderer<IChatS
 				const fullDateTime = getLocalHistoryDateFormatter().format(session.timing.startTime);
 				templateData.elementDisposable.add(
 					this.hoverService.setupDelayedHover(templateData.timestamp, {
-						content: `Start Time: ${fullDateTime}`
+						content: `${nls.localize('chat.sessions.startTime', 'Start Time')}: ${fullDateTime}`
 					})
 				);
 			}


### PR DESCRIPTION
Fixes #264665

For items in history in Local Chat Sessions window, show full datetime on hover over the relative time.

This is the new UI
<img width="797" height="293" alt="image" src="https://github.com/user-attachments/assets/77f2e8f9-63d6-43ed-90e4-3bfecc109ed4" />


