### PR TITLE
chatSessions API redesign/experiment

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -309,7 +309,8 @@ export default tseslint.config(
 						'terminate',
 						'trigger',
 						'unregister',
-						'write'
+						'write',
+						'commit'
 					]
 				}
 			]

--- a/src/vs/platform/extensions/common/extensionsApiProposals.ts
+++ b/src/vs/platform/extensions/common/extensionsApiProposals.ts
@@ -62,6 +62,7 @@ const _allApiProposals = {
 	},
 	chatSessionsProvider: {
 		proposal: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.chatSessionsProvider.d.ts',
+		version: 2
 	},
 	chatStatusItem: {
 		proposal: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.chatStatusItem.d.ts',

--- a/src/vs/workbench/api/browser/mainThreadChatAgents2.ts
+++ b/src/vs/workbench/api/browser/mainThreadChatAgents2.ts
@@ -169,7 +169,7 @@ export class MainThreadChatAgents2 extends Disposable implements MainThreadChatA
 			invoke: async (request, progress, history, token) => {
 				this._pendingProgress.set(request.requestId, progress);
 				try {
-					const chatSessionContext = this._chatService.getChatSessionData(request.sessionId);
+					const chatSessionContext = this._chatService.getChatSessionFromInternalId(request.sessionId);
 					return await this._proxy.$invokeAgent(handle, request, { history, chatSessionContext }, token) ?? {};
 				} finally {
 					this._pendingProgress.delete(request.requestId);

--- a/src/vs/workbench/api/browser/mainThreadChatAgents2.ts
+++ b/src/vs/workbench/api/browser/mainThreadChatAgents2.ts
@@ -169,7 +169,8 @@ export class MainThreadChatAgents2 extends Disposable implements MainThreadChatA
 			invoke: async (request, progress, history, token) => {
 				this._pendingProgress.set(request.requestId, progress);
 				try {
-					return await this._proxy.$invokeAgent(handle, request, { history }, token) ?? {};
+					const chatSessionContext = this._chatService.getChatSessionData(request.sessionId);
+					return await this._proxy.$invokeAgent(handle, request, { history, chatSessionContext }, token) ?? {};
 				} finally {
 					this._pendingProgress.delete(request.requestId);
 				}

--- a/src/vs/workbench/api/browser/mainThreadChatSessions.ts
+++ b/src/vs/workbench/api/browser/mainThreadChatSessions.ts
@@ -20,6 +20,7 @@ import { IChatContentInlineReference, IChatProgress } from '../../contrib/chat/c
 import { ChatSession, IChatSessionContentProvider, IChatSessionHistoryItem, IChatSessionItem, IChatSessionItemProvider, IChatSessionsService } from '../../contrib/chat/common/chatSessionsService.js';
 import { ChatSessionUri } from '../../contrib/chat/common/chatUri.js';
 import { EditorGroupColumn } from '../../services/editor/common/editorGroupColumn.js';
+import { IEditorGroupsService } from '../../services/editor/common/editorGroupsService.js';
 import { IEditorService } from '../../services/editor/common/editorService.js';
 import { extHostNamedCustomer, IExtHostContext } from '../../services/extensions/common/extHostCustomers.js';
 import { Dto } from '../../services/extensions/common/proxyIdentifier.js';
@@ -317,6 +318,7 @@ export class MainThreadChatSessions extends Disposable implements MainThreadChat
 		@IChatSessionsService private readonly _chatSessionsService: IChatSessionsService,
 		@IDialogService private readonly _dialogService: IDialogService,
 		@IEditorService private readonly _editorService: IEditorService,
+		@IEditorGroupsService private readonly editorGroupService: IEditorGroupsService,
 		@ILogService private readonly _logService: ILogService,
 		@IViewsService private readonly _viewsService: IViewsService,
 	) {
@@ -347,6 +349,31 @@ export class MainThreadChatSessions extends Disposable implements MainThreadChat
 
 	$onDidChangeChatSessionItems(handle: number): void {
 		this._itemProvidersRegistrations.get(handle)?.onDidChangeItems.fire();
+	}
+
+	$onDidCreateChatSessionItem(handle: number, original: string, modified: string): void {
+		this._logService.trace(`$onDidCreateChatSessionItem: handle(${handle}), original(${original}), modified(${modified})`);
+		const chatSessionType = this._itemProvidersRegistrations.get(handle)?.provider.chatSessionType;
+		if (!chatSessionType) {
+			this._logService.error(`No chat session type found for provider handle ${handle}`);
+			return;
+		}
+		const originalGroup = this.editorGroupService.activeGroup; // TODO(jospicer)
+		const originalResource = ChatSessionUri.forSession(chatSessionType, original);
+		const modifiedResource = ChatSessionUri.forSession(chatSessionType, modified);
+		const originalEditor = this._editorService.editors.find(editor => editor.resource?.toString() === originalResource.toString());
+		if (originalEditor) {
+			this._editorService.replaceEditors([{
+				editor: originalEditor,
+				replacement: {
+					resource: modifiedResource,
+					options: {}
+				},
+			}], originalGroup);
+		} else {
+			this._logService.warn(`Original chat session editor not found for resource ${originalResource.toString()}`);
+			this._editorService.openEditor({ resource: modifiedResource }, originalGroup);
+		}
 	}
 
 	private async _provideChatSessionItems(handle: number, token: CancellationToken): Promise<IChatSessionItem[]> {

--- a/src/vs/workbench/api/browser/mainThreadChatSessions.ts
+++ b/src/vs/workbench/api/browser/mainThreadChatSessions.ts
@@ -365,7 +365,7 @@ export class MainThreadChatSessions extends Disposable implements MainThreadChat
 		return [];
 	}
 
-	private async _provideNewChatSessionItem(handle: number, options: { request: IChatAgentRequest; prompt?: string; history?: any[]; metadata?: any }, token: CancellationToken): Promise<IChatSessionItem> {
+	private async _provideNewChatSessionItem(handle: number, options: { request: IChatAgentRequest; metadata?: any }, token: CancellationToken): Promise<IChatSessionItem> {
 		try {
 			const chatSessionItem = await this._proxy.$provideNewChatSessionItem(handle, options, token);
 			if (!chatSessionItem) {

--- a/src/vs/workbench/api/common/extHost.api.impl.ts
+++ b/src/vs/workbench/api/common/extHost.api.impl.ts
@@ -1527,9 +1527,9 @@ export function createApiFactoryAndRegisterActors(accessor: ServicesAccessor): I
 				checkProposedApiEnabled(extension, 'chatSessionsProvider');
 				return extHostChatSessions.registerChatSessionItemProvider(extension, chatSessionType, provider);
 			},
-			registerChatSessionContentProvider(chatSessionType: string, provider: vscode.ChatSessionContentProvider, capabilities?: vscode.ChatSessionCapabilities) {
+			registerChatSessionContentProvider(chatSessionType: string, provider: vscode.ChatSessionContentProvider, chatParticipant: vscode.ChatParticipant, capabilities?: vscode.ChatSessionCapabilities) {
 				checkProposedApiEnabled(extension, 'chatSessionsProvider');
-				return extHostChatSessions.registerChatSessionContentProvider(extension, chatSessionType, provider, capabilities);
+				return extHostChatSessions.registerChatSessionContentProvider(extension, chatSessionType, chatParticipant, provider, capabilities);
 			},
 			registerChatOutputRenderer: (viewType: string, renderer: vscode.ChatOutputRenderer) => {
 				checkProposedApiEnabled(extension, 'chatOutputRenderer');

--- a/src/vs/workbench/api/common/extHost.api.impl.ts
+++ b/src/vs/workbench/api/common/extHost.api.impl.ts
@@ -232,7 +232,6 @@ export function createApiFactoryAndRegisterActors(accessor: ServicesAccessor): I
 	const extHostStatusBar = rpcProtocol.set(ExtHostContext.ExtHostStatusBar, new ExtHostStatusBar(rpcProtocol, extHostCommands.converter));
 	const extHostSpeech = rpcProtocol.set(ExtHostContext.ExtHostSpeech, new ExtHostSpeech(rpcProtocol));
 	const extHostEmbeddings = rpcProtocol.set(ExtHostContext.ExtHostEmbeddings, new ExtHostEmbeddings(rpcProtocol));
-	const extHostChatSessions = rpcProtocol.set(ExtHostContext.ExtHostChatSessions, new ExtHostChatSessions(extHostCommands, extHostLanguageModels, rpcProtocol, extHostLogService));
 
 	rpcProtocol.set(ExtHostContext.ExtHostMcp, accessor.get(IExtHostMpcService));
 

--- a/src/vs/workbench/api/common/extHost.api.impl.ts
+++ b/src/vs/workbench/api/common/extHost.api.impl.ts
@@ -224,6 +224,7 @@ export function createApiFactoryAndRegisterActors(accessor: ServicesAccessor): I
 	const extHostChatOutputRenderer = rpcProtocol.set(ExtHostContext.ExtHostChatOutputRenderer, new ExtHostChatOutputRenderer(rpcProtocol, extHostWebviews));
 	rpcProtocol.set(ExtHostContext.ExtHostInteractive, new ExtHostInteractive(rpcProtocol, extHostNotebook, extHostDocumentsAndEditors, extHostCommands, extHostLogService));
 	const extHostLanguageModelTools = rpcProtocol.set(ExtHostContext.ExtHostLanguageModelTools, new ExtHostLanguageModelTools(rpcProtocol, extHostLanguageModels));
+	const extHostChatSessions = rpcProtocol.set(ExtHostContext.ExtHostChatSessions, new ExtHostChatSessions(extHostCommands, extHostLanguageModels, rpcProtocol, extHostLogService));
 	const extHostChatAgents2 = rpcProtocol.set(ExtHostContext.ExtHostChatAgents2, new ExtHostChatAgents2(rpcProtocol, extHostLogService, extHostCommands, extHostDocuments, extHostLanguageModels, extHostDiagnostics, extHostLanguageModelTools));
 	const extHostAiRelatedInformation = rpcProtocol.set(ExtHostContext.ExtHostAiRelatedInformation, new ExtHostRelatedInformation(rpcProtocol));
 	const extHostAiEmbeddingVector = rpcProtocol.set(ExtHostContext.ExtHostAiEmbeddingVector, new ExtHostAiEmbeddingVector(rpcProtocol));

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -3157,7 +3157,7 @@ export interface MainThreadChatSessionsShape extends IDisposable {
 
 export interface ExtHostChatSessionsShape {
 	$provideChatSessionItems(providerHandle: number, token: CancellationToken): Promise<Dto<IChatSessionItem>[]>;
-	$provideNewChatSessionItem(providerHandle: number, options: { request: IChatAgentRequest; prompt?: string; history?: any[]; metadata?: any }, token: CancellationToken): Promise<Dto<IChatSessionItem>>;
+	$provideNewChatSessionItem(providerHandle: number, options: { request: IChatAgentRequest; metadata?: any }, token: CancellationToken): Promise<Dto<IChatSessionItem>>;
 
 	$provideChatSessionContent(providerHandle: number, sessionId: string, token: CancellationToken): Promise<ChatSessionDto>;
 	$interruptChatSessionActiveResponse(providerHandle: number, sessionId: string, requestId: string): Promise<void>;

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -3144,7 +3144,7 @@ export interface MainThreadChatSessionsShape extends IDisposable {
 	$registerChatSessionItemProvider(handle: number, chatSessionType: string): void;
 	$unregisterChatSessionItemProvider(handle: number): void;
 	$onDidChangeChatSessionItems(handle: number): void;
-	$onDidCreateChatSessionItem(handle: number, original: string, modified: string): void;
+	$onDidCommitChatSessionItem(handle: number, original: string, modified: string): void;
 	$registerChatSessionContentProvider(handle: number, chatSessionType: string): void;
 	$unregisterChatSessionContentProvider(handle: number): void;
 

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -3144,7 +3144,7 @@ export interface MainThreadChatSessionsShape extends IDisposable {
 	$registerChatSessionItemProvider(handle: number, chatSessionType: string): void;
 	$unregisterChatSessionItemProvider(handle: number): void;
 	$onDidChangeChatSessionItems(handle: number): void;
-
+	$onDidCreateChatSessionItem(handle: number, original: string, modified: string): void;
 	$registerChatSessionContentProvider(handle: number, chatSessionType: string): void;
 	$unregisterChatSessionContentProvider(handle: number): void;
 

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -1369,7 +1369,7 @@ export type IChatAgentHistoryEntryDto = {
 };
 
 export interface ExtHostChatAgentsShape2 {
-	$invokeAgent(handle: number, request: Dto<IChatAgentRequest>, context: { history: IChatAgentHistoryEntryDto[] }, token: CancellationToken): Promise<IChatAgentResult | undefined>;
+	$invokeAgent(handle: number, request: Dto<IChatAgentRequest>, context: { history: IChatAgentHistoryEntryDto[]; chatSessionContext?: { chatSessionType: string; chatSessionId: string; isUntitled: boolean } }, token: CancellationToken): Promise<IChatAgentResult | undefined>;
 	$provideFollowups(request: Dto<IChatAgentRequest>, handle: number, result: IChatAgentResult, context: { history: IChatAgentHistoryEntryDto[] }, token: CancellationToken): Promise<IChatFollowup[]>;
 	$acceptFeedback(handle: number, result: IChatAgentResult, voteAction: IChatVoteAction): void;
 	$acceptAction(handle: number, result: IChatAgentResult, action: IChatUserActionEvent): void;

--- a/src/vs/workbench/api/common/extHostChatAgents2.ts
+++ b/src/vs/workbench/api/common/extHostChatAgents2.ts
@@ -588,8 +588,7 @@ export class ExtHostChatAgents2 extends Disposable implements ExtHostChatAgentsS
 				};
 			}
 
-			const chatContext: vscode.ChatContext = { history, chatSessionContext }
-
+			const chatContext: vscode.ChatContext = { history, chatSessionContext };
 			const task = agent.invoke(
 				extRequest,
 				chatContext,

--- a/src/vs/workbench/api/common/extHostChatAgents2.ts
+++ b/src/vs/workbench/api/common/extHostChatAgents2.ts
@@ -541,7 +541,7 @@ export class ExtHostChatAgents2 extends Disposable implements ExtHostChatAgentsS
 		this._onDidChangeChatRequestTools.fire(request.extRequest);
 	}
 
-	async $invokeAgent(handle: number, requestDto: Dto<IChatAgentRequest>, context: { history: IChatAgentHistoryEntryDto[] }, token: CancellationToken): Promise<IChatAgentResult | undefined> {
+	async $invokeAgent(handle: number, requestDto: Dto<IChatAgentRequest>, context: { history: IChatAgentHistoryEntryDto[]; chatSessionContext?: { chatSessionType: string; chatSessionId: string; isUntitled: boolean } }, token: CancellationToken): Promise<IChatAgentResult | undefined> {
 		const agent = this._agents.get(handle);
 		if (!agent) {
 			throw new Error(`[CHAT](${handle}) CANNOT invoke agent because the agent is not registered`);
@@ -575,9 +575,24 @@ export class ExtHostChatAgents2 extends Disposable implements ExtHostChatAgentsS
 			inFlightRequest = { requestId: requestDto.requestId, extRequest, extension: agent.extension };
 			this._inFlightRequests.add(inFlightRequest);
 
+
+			// If this request originates from a contributed chat session editor, attempt to resolve the ChatSession API object
+			let chatSessionContext: vscode.ChatSessionContext | undefined;
+			if (context.chatSessionContext) {
+				chatSessionContext = {
+					chatSessionItem: {
+						id: context.chatSessionContext.chatSessionId,
+						label: context.chatSessionContext.isUntitled ? 'Untitled Session' : 'Session',
+					},
+					isUntitled: context.chatSessionContext.isUntitled,
+				};
+			}
+
+			const chatContext: vscode.ChatContext = { history, chatSessionContext }
+
 			const task = agent.invoke(
 				extRequest,
-				{ history },
+				chatContext,
 				stream.apiObject,
 				token
 			);

--- a/src/vs/workbench/api/common/extHostChatSessions.ts
+++ b/src/vs/workbench/api/common/extHostChatSessions.ts
@@ -103,6 +103,12 @@ export class ExtHostChatSessions extends Disposable implements ExtHostChatSessio
 				this._proxy.$onDidChangeChatSessionItems(handle);
 			}));
 		}
+		if (provider.onDidCreateChatSessionItem) {
+			disposables.add(provider.onDidCreateChatSessionItem((e) => {
+				const { original, modified } = e;
+				this._proxy.$onDidCreateChatSessionItem(handle, original.id, modified.id);
+			}));
+		}
 		return {
 			dispose: () => {
 				this._chatSessionItemProviders.delete(handle);

--- a/src/vs/workbench/api/common/extHostChatSessions.ts
+++ b/src/vs/workbench/api/common/extHostChatSessions.ts
@@ -103,10 +103,10 @@ export class ExtHostChatSessions extends Disposable implements ExtHostChatSessio
 				this._proxy.$onDidChangeChatSessionItems(handle);
 			}));
 		}
-		if (provider.onDidCreateChatSessionItem) {
-			disposables.add(provider.onDidCreateChatSessionItem((e) => {
+		if (provider.onDidCommitChatSessionItem) {
+			disposables.add(provider.onDidCommitChatSessionItem((e) => {
 				const { original, modified } = e;
-				this._proxy.$onDidCreateChatSessionItem(handle, original.id, modified.id);
+				this._proxy.$onDidCommitChatSessionItem(handle, original.id, modified.id);
 			}));
 		}
 		return {

--- a/src/vs/workbench/api/common/extHostChatSessions.ts
+++ b/src/vs/workbench/api/common/extHostChatSessions.ts
@@ -112,7 +112,7 @@ export class ExtHostChatSessions extends Disposable implements ExtHostChatSessio
 		};
 	}
 
-	registerChatSessionContentProvider(extension: IExtensionDescription, chatSessionType: string, provider: vscode.ChatSessionContentProvider, capabilities?: vscode.ChatSessionCapabilities): vscode.Disposable {
+	registerChatSessionContentProvider(extension: IExtensionDescription, chatSessionType: string, chatParticipant: vscode.ChatParticipant, provider: vscode.ChatSessionContentProvider, capabilities?: vscode.ChatSessionCapabilities): vscode.Disposable {
 		const handle = this._nextChatSessionContentProviderHandle++;
 		const disposables = new DisposableStore();
 
@@ -164,7 +164,7 @@ export class ExtHostChatSessions extends Disposable implements ExtHostChatSessio
 		};
 	}
 
-	async $provideNewChatSessionItem(handle: number, options: { request: IChatAgentRequest; prompt?: string; history: any[]; metadata?: any }, token: CancellationToken): Promise<IChatSessionItem> {
+	async $provideNewChatSessionItem(handle: number, options: { request: IChatAgentRequest; metadata?: any }, token: CancellationToken): Promise<IChatSessionItem> {
 		const entry = this._chatSessionItemProviders.get(handle);
 		if (!entry || !entry.provider.provideNewChatSessionItem) {
 			throw new Error(`No provider registered for handle ${handle} or provider does not support creating sessions`);
@@ -183,8 +183,6 @@ export class ExtHostChatSessions extends Disposable implements ExtHostChatSessio
 
 			const vscodeOptions = {
 				request: vscodeRequest,
-				prompt: options.prompt,
-				history: options.history,
 				metadata: options.metadata
 			};
 

--- a/src/vs/workbench/api/test/browser/mainThreadChatSessions.test.ts
+++ b/src/vs/workbench/api/test/browser/mainThreadChatSessions.test.ts
@@ -387,7 +387,6 @@ suite('MainThreadChatSessions', function () {
 		// Valid
 		const chatSessionItem = await chatSessionsService.provideNewChatSessionItem('test-type', {
 			request: mockRequest,
-			prompt: 'my prompt',
 			metadata: {}
 		}, CancellationToken.None);
 		assert.strictEqual(chatSessionItem.id, 'new-session-id');
@@ -397,7 +396,6 @@ suite('MainThreadChatSessions', function () {
 		await assert.rejects(
 			chatSessionsService.provideNewChatSessionItem('invalid-type', {
 				request: mockRequest,
-				prompt: 'my prompt',
 				metadata: {}
 			}, CancellationToken.None)
 		);

--- a/src/vs/workbench/contrib/chat/browser/actions/chatExecuteActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatExecuteActions.ts
@@ -664,7 +664,6 @@ export class CreateRemoteAgentJobAction extends Action2 {
 		const newChatSession = await chatSessionsService.provideNewChatSessionItem(
 			type,
 			{
-				prompt: userPrompt,
 				request: {
 					agentId: '',
 					location: ChatAgentLocation.Chat,

--- a/src/vs/workbench/contrib/chat/browser/chatSessions.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSessions.contribution.ts
@@ -21,6 +21,7 @@ import { ChatEditorInput } from '../browser/chatEditorInput.js';
 import { IChatAgentData, IChatAgentRequest, IChatAgentService } from '../common/chatAgents.js';
 import { ChatContextKeys } from '../common/chatContextKeys.js';
 import { ChatSession, ChatSessionStatus, IChatSessionContentProvider, IChatSessionItem, IChatSessionItemProvider, IChatSessionsExtensionPoint, IChatSessionsService } from '../common/chatSessionsService.js';
+import { ChatSessionUri } from '../common/chatUri.js';
 import { ChatAgentLocation, ChatModeKind } from '../common/constants.js';
 import { CHAT_CATEGORY } from './actions/chatActions.js';
 import { IChatEditorOptions } from './chatEditor.js';
@@ -268,7 +269,7 @@ export class ChatSessionsService extends Disposable implements IChatSessionsServ
 						pinned: true,
 					};
 					await editorService.openEditor({
-						resource: ChatEditorInput.getNewEditorUri().with({ query: `chatSessionType=${type}` }),
+						resource: ChatSessionUri.forSession(type, 'untitled-01'),
 						options,
 					});
 				} catch (e) {
@@ -557,3 +558,4 @@ export class ChatSessionsService extends Disposable implements IChatSessionsServ
 }
 
 registerSingleton(IChatSessionsService, ChatSessionsService, InstantiationType.Delayed);
+

--- a/src/vs/workbench/contrib/chat/browser/chatSessions.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSessions.contribution.ts
@@ -6,33 +6,25 @@
 import { CancellationToken } from '../../../../base/common/cancellation.js';
 import { Codicon } from '../../../../base/common/codicons.js';
 import { Emitter, Event } from '../../../../base/common/event.js';
-import { MarkdownString } from '../../../../base/common/htmlContent.js';
 import { Disposable, DisposableStore, IDisposable } from '../../../../base/common/lifecycle.js';
-import { truncate } from '../../../../base/common/strings.js';
 import { localize, localize2 } from '../../../../nls.js';
 import { Action2, MenuId, MenuRegistry, registerAction2 } from '../../../../platform/actions/common/actions.js';
 import { ContextKeyExpr, IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
 import { InstantiationType, registerSingleton } from '../../../../platform/instantiation/common/extensions.js';
-import { IInstantiationService, ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
+import { ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
 import { IEditableData } from '../../../common/views.js';
-import { IEditorGroupsService } from '../../../services/editor/common/editorGroupsService.js';
 import { IEditorService } from '../../../services/editor/common/editorService.js';
 import { IExtensionService, isProposedApiEnabled } from '../../../services/extensions/common/extensions.js';
 import { ExtensionsRegistry } from '../../../services/extensions/common/extensionsRegistry.js';
-import { IChatWidgetService } from '../browser/chat.js';
 import { ChatEditorInput } from '../browser/chatEditorInput.js';
-import { IChatAgentData, IChatAgentHistoryEntry, IChatAgentImplementation, IChatAgentRequest, IChatAgentResult, IChatAgentService } from '../common/chatAgents.js';
+import { IChatAgentData, IChatAgentRequest, IChatAgentService } from '../common/chatAgents.js';
 import { ChatContextKeys } from '../common/chatContextKeys.js';
-import { IChatProgress, IChatService } from '../common/chatService.js';
 import { ChatSession, ChatSessionStatus, IChatSessionContentProvider, IChatSessionItem, IChatSessionItemProvider, IChatSessionsExtensionPoint, IChatSessionsService } from '../common/chatSessionsService.js';
-import { ChatSessionUri } from '../common/chatUri.js';
 import { ChatAgentLocation, ChatModeKind } from '../common/constants.js';
 import { CHAT_CATEGORY } from './actions/chatActions.js';
 import { IChatEditorOptions } from './chatEditor.js';
 import { VIEWLET_ID } from './chatSessions/view/chatSessionsView.js';
-
-const CODING_AGENT_DOCS = 'https://code.visualstudio.com/docs/copilot/copilot-coding-agent';
 
 const extensionPoint = ExtensionsRegistry.registerExtensionPoint<IChatSessionsExtensionPoint[]>({
 	extensionPoint: 'chatSessions',
@@ -128,7 +120,6 @@ export class ChatSessionsService extends Disposable implements IChatSessionsServ
 
 	constructor(
 		@ILogService private readonly _logService: ILogService,
-		@IInstantiationService private readonly _instantiationService: IInstantiationService,
 		@IChatAgentService private readonly _chatAgentService: IChatAgentService,
 		@IExtensionService private readonly _extensionService: IExtensionService,
 		@IContextKeyService private readonly _contextKeyService: IContextKeyService,
@@ -323,7 +314,7 @@ export class ChatSessionsService extends Disposable implements IChatSessionsServ
 		const disposableStore = new DisposableStore();
 		this._disposableStores.set(contribution.type, disposableStore);
 
-		disposableStore.add(this._registerDynamicAgent(contribution));
+		disposableStore.add(this._registerAgent(contribution));
 		disposableStore.add(this._registerCommands(contribution));
 		disposableStore.add(this._registerMenuItems(contribution));
 	}
@@ -349,7 +340,7 @@ export class ChatSessionsService extends Disposable implements IChatSessionsServ
 		}
 	}
 
-	private _registerDynamicAgent(contribution: IChatSessionsExtensionPoint): IDisposable {
+	private _registerAgent(contribution: IChatSessionsExtensionPoint): IDisposable {
 		const { type: id, name, displayName, description, extensionDescription } = contribution;
 		const { identifier: extensionId, name: extensionName, displayName: extensionDisplayName, publisher: extensionPublisherId } = extensionDescription;
 		const agentData: IChatAgentData = {
@@ -362,7 +353,7 @@ export class ChatSessionsService extends Disposable implements IChatSessionsServ
 			isDynamic: true,
 			slashCommands: [],
 			locations: [ChatAgentLocation.Chat],
-			modes: [ChatModeKind.Agent, ChatModeKind.Ask], // TODO: These are no longer respected
+			modes: [ChatModeKind.Agent, ChatModeKind.Ask],
 			disambiguation: [],
 			metadata: {
 				themeIcon: Codicon.sendToRemoteAgent,
@@ -375,9 +366,7 @@ export class ChatSessionsService extends Disposable implements IChatSessionsServ
 			extensionPublisherId,
 		};
 
-		const agentImpl = this._instantiationService.createInstance(CodingAgentChatImplementation, contribution);
-		const disposable = this._chatAgentService.registerDynamicAgent(agentData, agentImpl);
-		return disposable;
+		return this._chatAgentService.registerAgent(id, agentData);
 	}
 
 	getAllChatSessionContributions(): IChatSessionsExtensionPoint[] {
@@ -499,8 +488,6 @@ export class ChatSessionsService extends Disposable implements IChatSessionsServ
 	 */
 	public async provideNewChatSessionItem(chatSessionType: string, options: {
 		request: IChatAgentRequest;
-		prompt?: string;
-		history?: any[];
 		metadata?: any;
 	}, token: CancellationToken): Promise<IChatSessionItem> {
 		if (!(await this.canResolveItemProvider(chatSessionType))) {
@@ -570,119 +557,3 @@ export class ChatSessionsService extends Disposable implements IChatSessionsServ
 }
 
 registerSingleton(IChatSessionsService, ChatSessionsService, InstantiationType.Delayed);
-
-/**
- * Implementation for individual remote coding agent chat functionality
- */
-class CodingAgentChatImplementation extends Disposable implements IChatAgentImplementation {
-
-	constructor(
-		private readonly chatSession: IChatSessionsExtensionPoint,
-		@IChatService private readonly chatService: IChatService,
-		@IChatWidgetService private readonly chatWidgetService: IChatWidgetService,
-		@IEditorGroupsService private readonly editorGroupService: IEditorGroupsService,
-		@IChatSessionsService private readonly chatSessionService: IChatSessionsService,
-		@IEditorService private readonly editorService: IEditorService,
-		@ILogService private readonly logService: ILogService,
-	) {
-		super();
-	}
-
-	async invoke(request: IChatAgentRequest, progress: (progress: IChatProgress[]) => void, history: IChatAgentHistoryEntry[], token: CancellationToken): Promise<IChatAgentResult> {
-		const widget = this.chatWidgetService.getWidgetBySessionId(request.sessionId);
-
-		if (!widget) {
-			return {};
-		}
-
-		let chatSession: ChatSession | undefined;
-
-		// Find the first editor that matches the chat session
-		for (const group of this.editorGroupService.groups) {
-			if (chatSession) {
-				break;
-			}
-
-			for (const editor of group.editors) {
-				if (editor instanceof ChatEditorInput) {
-					try {
-						const chatModel = await this.chatService.loadSessionForResource(editor.resource, request.location, CancellationToken.None);
-						if (chatModel?.sessionId === request.sessionId) {
-							// this is the model
-							const identifier = ChatSessionUri.parse(editor.resource);
-
-							if (identifier) {
-								chatSession = await this.chatSessionService.provideChatSessionContent(this.chatSession.type, identifier.sessionId, token);
-							}
-							break;
-						}
-					} catch (error) {
-						// might not be us
-					}
-				}
-			}
-		}
-
-		if (chatSession?.requestHandler) {
-			await chatSession.requestHandler(request, progress, history, token); // TODO: Revisit this function's signature in relation to its extension API (eg: 'history' is not strongly typed here)
-		} else {
-			try {
-				const chatSessionItem = await this.chatSessionService.provideNewChatSessionItem(
-					this.chatSession.type,
-					{
-						request,
-						prompt: request.message,
-						history,
-					},
-					token,
-				);
-				const options: IChatEditorOptions = {
-					pinned: true,
-					preferredTitle: truncate(chatSessionItem.label, 30),
-				};
-
-				// Prefetch the chat session content to make the subsequent editor swap quick
-				await this.chatSessionService.provideChatSessionContent(
-					this.chatSession.type,
-					chatSessionItem.id,
-					token,
-				);
-
-				const activeGroup = this.editorGroupService.activeGroup;
-				const currentEditor = activeGroup?.activeEditor;
-				if (currentEditor instanceof ChatEditorInput) {
-					await this.editorService.replaceEditors([{
-						editor: currentEditor,
-						replacement: {
-							resource: ChatSessionUri.forSession(this.chatSession.type, chatSessionItem.id),
-							options,
-						}
-					}], activeGroup);
-				} else {
-					// Fallback: open in new editor if we couldn't find the current one
-					await this.editorService.openEditor({
-						resource: ChatSessionUri.forSession(this.chatSession.type, chatSessionItem.id),
-						options,
-					});
-					progress([{
-						kind: 'markdownContent',
-						content: new MarkdownString(localize('continueInNewChat', 'Continue **{0}** in a new chat editor', truncate(chatSessionItem.label, 30))),
-					}]);
-				}
-			} catch (error) {
-				// NOTE: May end up here if extension does not support 'provideNewChatSessionItem' or that API usage throws
-				this.logService.error(`Failed to create new chat session for type '${this.chatSession.type}'`, error);
-				const content =
-					this.chatSession.type === 'copilot-swe-agent' // TODO: Use contributed error messages
-						? new MarkdownString(localize('chatSessionNotFoundCopilot', "Failed to create chat session. Use `#copilotCodingAgent` to begin a new [coding agent session]({0}).", CODING_AGENT_DOCS))
-						: new MarkdownString(localize('chatSessionNotFoundGeneric', "Failed to create chat session. Please try again later."));
-				progress([{
-					kind: 'markdownContent',
-					content,
-				}]);
-			}
-		}
-
-		return {};
-	}
-}

--- a/src/vs/workbench/contrib/chat/browser/chatSessions.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSessions.contribution.ts
@@ -7,6 +7,7 @@ import { CancellationToken } from '../../../../base/common/cancellation.js';
 import { Codicon } from '../../../../base/common/codicons.js';
 import { Emitter, Event } from '../../../../base/common/event.js';
 import { Disposable, DisposableStore, IDisposable } from '../../../../base/common/lifecycle.js';
+import { generateUuid } from '../../../../base/common/uuid.js';
 import { localize, localize2 } from '../../../../nls.js';
 import { Action2, MenuId, MenuRegistry, registerAction2 } from '../../../../platform/actions/common/actions.js';
 import { ContextKeyExpr, IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
@@ -268,8 +269,9 @@ export class ChatSessionsService extends Disposable implements IChatSessionsServ
 						override: ChatEditorInput.EditorID,
 						pinned: true,
 					};
+					const untitledId = `untitled-${generateUuid()}`;
 					await editorService.openEditor({
-						resource: ChatSessionUri.forSession(type, 'untitled-01'),
+						resource: ChatSessionUri.forSession(type, untitledId),
 						options,
 					});
 				} catch (e) {

--- a/src/vs/workbench/contrib/chat/common/chatService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService.ts
@@ -700,9 +700,10 @@ export interface IChatService {
 	loadSessionFromContent(data: IExportableChatData | ISerializableChatData | URI): IChatModel | undefined;
 	loadSessionForResource(resource: URI, location: ChatAgentLocation, token: CancellationToken): Promise<IChatModel | undefined>;
 	readonly editingSessions: IChatEditingSession[];
+	getChatSessionData(modelSessionId: string): { chatSessionType: string; chatSessionId: string; isUntitled: boolean } | undefined;
 
 	/**
-	 * Returns whether the request was accepted.
+	 * Returns whether the request was accepted.`
 	 */
 	sendRequest(sessionId: string, message: string, options?: IChatSendRequestOptions): Promise<IChatSendRequestData | undefined>;
 

--- a/src/vs/workbench/contrib/chat/common/chatService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService.ts
@@ -700,7 +700,7 @@ export interface IChatService {
 	loadSessionFromContent(data: IExportableChatData | ISerializableChatData | URI): IChatModel | undefined;
 	loadSessionForResource(resource: URI, location: ChatAgentLocation, token: CancellationToken): Promise<IChatModel | undefined>;
 	readonly editingSessions: IChatEditingSession[];
-	getChatSessionData(modelSessionId: string): { chatSessionType: string; chatSessionId: string; isUntitled: boolean } | undefined;
+	getChatSessionFromInternalId(sessionId: string): { chatSessionType: string; chatSessionId: string; isUntitled: boolean } | undefined;
 
 	/**
 	 * Returns whether the request was accepted.`

--- a/src/vs/workbench/contrib/chat/common/chatServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/chatServiceImpl.ts
@@ -73,6 +73,7 @@ export class ChatService extends Disposable implements IChatService {
 
 	private readonly _sessionModels = new ObservableMap<string, ChatModel>();
 	private readonly _contentProviderSessionModels = new Map<string, Map<string, { readonly model: IChatModel; readonly disposables: DisposableStore }>>();
+	private readonly _modelToExternalSession = new Map<string /* internal model sessionId */, { chatSessionType: string; chatSessionId: string }>();
 	private readonly _pendingRequests = this._register(new DisposableMap<string, CancellableRequest>());
 	private _persistedSessions: ISerializableChatsData;
 
@@ -471,6 +472,8 @@ export class ChatService extends Disposable implements IChatService {
 		const content = await this.chatSessionService.provideChatSessionContent(chatSessionType, parsed.sessionId, CancellationToken.None);
 
 		const model = this._startSession(undefined, location, true, CancellationToken.None, chatSessionType);
+		// Record mapping from internal model session id to external contributed chat session identity
+		this._modelToExternalSession.set(model.sessionId, { chatSessionType, chatSessionId: parsed.sessionId });
 		if (!this._contentProviderSessionModels.has(chatSessionType)) {
 			this._contentProviderSessionModels.set(chatSessionType, new Map());
 		}
@@ -479,6 +482,7 @@ export class ChatService extends Disposable implements IChatService {
 
 		disposables.add(model.onDidDispose(() => {
 			this._contentProviderSessionModels?.get(chatSessionType)?.delete(parsed.sessionId);
+			this._modelToExternalSession.delete(model.sessionId);
 			content.dispose();
 		}));
 
@@ -572,6 +576,17 @@ export class ChatService extends Disposable implements IChatService {
 		}
 
 		return model;
+	}
+
+	getChatSessionData(modelSessionId: string): { chatSessionType: string; chatSessionId: string; isUntitled: boolean } | undefined {
+		const data = this._modelToExternalSession.get(modelSessionId);
+		if (!data) {
+			return;
+		}
+		return {
+			...data,
+			isUntitled: data.chatSessionId.startsWith('untitled-'), // TODO:
+		};
 	}
 
 	async resendRequest(request: IChatRequestModel, options?: IChatSendRequestOptions): Promise<void> {

--- a/src/vs/workbench/contrib/chat/common/chatServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/chatServiceImpl.ts
@@ -578,14 +578,14 @@ export class ChatService extends Disposable implements IChatService {
 		return model;
 	}
 
-	getChatSessionData(modelSessionId: string): { chatSessionType: string; chatSessionId: string; isUntitled: boolean } | undefined {
+	getChatSessionFromInternalId(modelSessionId: string): { chatSessionType: string; chatSessionId: string; isUntitled: boolean } | undefined {
 		const data = this._modelToExternalSession.get(modelSessionId);
 		if (!data) {
 			return;
 		}
 		return {
 			...data,
-			isUntitled: data.chatSessionId.startsWith('untitled-'), // TODO:
+			isUntitled: data.chatSessionId.startsWith('untitled-'), // TODO(jospicer)
 		};
 	}
 

--- a/src/vs/workbench/contrib/chat/common/chatSessionsService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatSessionsService.ts
@@ -75,8 +75,6 @@ export interface IChatSessionItemProvider {
 	provideChatSessionItems(token: CancellationToken): Promise<IChatSessionItem[]>;
 	provideNewChatSessionItem?(options: {
 		request: IChatAgentRequest;
-		prompt?: string;
-		history?: any[];
 		metadata?: any;
 	}, token: CancellationToken): Promise<IChatSessionItem>;
 }
@@ -99,8 +97,6 @@ export interface IChatSessionsService {
 	getAllChatSessionItemProviders(): IChatSessionItemProvider[];
 	provideNewChatSessionItem(chatSessionType: string, options: {
 		request: IChatAgentRequest;
-		prompt?: string;
-		history?: any[];
 		metadata?: any;
 	}, token: CancellationToken): Promise<IChatSessionItem>;
 	provideChatSessionItems(chatSessionType: string, token: CancellationToken): Promise<IChatSessionItem[]>;

--- a/src/vs/workbench/contrib/chat/test/common/mockChatService.ts
+++ b/src/vs/workbench/contrib/chat/test/common/mockChatService.ts
@@ -13,7 +13,7 @@ import { IChatCompleteResponse, IChatDetail, IChatProviderInfo, IChatSendRequest
 import { ChatAgentLocation } from '../../common/constants.js';
 
 export class MockChatService implements IChatService {
-	getChatSessionData(modelSessionId: string): { chatSessionType: string; chatSessionId: string; isUntitled: boolean } | undefined {
+	getChatSessionFromInternalId(modelSessionId: string): { chatSessionType: string; chatSessionId: string; isUntitled: boolean } | undefined {
 		throw new Error('Method not implemented.');
 	}
 	requestInProgressObs = observableValue('name', false);

--- a/src/vs/workbench/contrib/chat/test/common/mockChatService.ts
+++ b/src/vs/workbench/contrib/chat/test/common/mockChatService.ts
@@ -13,6 +13,9 @@ import { IChatCompleteResponse, IChatDetail, IChatProviderInfo, IChatSendRequest
 import { ChatAgentLocation } from '../../common/constants.js';
 
 export class MockChatService implements IChatService {
+	getChatSessionData(modelSessionId: string): { chatSessionType: string; chatSessionId: string; isUntitled: boolean } | undefined {
+		throw new Error('Method not implemented.');
+	}
 	requestInProgressObs = observableValue('name', false);
 	edits2Enabled: boolean = false;
 	_serviceBrand: undefined;

--- a/src/vscode-dts/vscode.proposed.chatSessionsProvider.d.ts
+++ b/src/vscode-dts/vscode.proposed.chatSessionsProvider.d.ts
@@ -37,7 +37,7 @@ declare module 'vscode' {
 		 * Fired when a new chat session item is created from an untitled session
 		 * Clients should replace the 'original' chat session with the 'modified' chat session.
 		 */
-		readonly onDidCreateChatSessionItem: Event<{ original: ChatSessionItem /** untitled */, modified: ChatSessionItem /** newly created */ }>;
+		readonly onDidCreateChatSessionItem: Event<{ original: ChatSessionItem /** untitled */; modified: ChatSessionItem /** newly created */ }>;
 
 		/**
 		 * Creates a new chat session.

--- a/src/vscode-dts/vscode.proposed.chatSessionsProvider.d.ts
+++ b/src/vscode-dts/vscode.proposed.chatSessionsProvider.d.ts
@@ -190,7 +190,11 @@ declare module 'vscode' {
 		 *
 		 * @returns A disposable that unregisters the provider when disposed.
 		 */
-		export function registerChatSessionContentProvider(chatSessionType: string, provider: ChatSessionContentProvider, capabilities?: ChatSessionCapabilities): Disposable;
+		export function registerChatSessionContentProvider(chatSessionType: string, provider: ChatSessionContentProvider, chatParticipant: ChatParticipant, capabilities?: ChatSessionCapabilities): Disposable;
+	}
+
+	export interface ChatContext {
+		readonly chatSession?: ChatSession; // TEMP
 	}
 
 	export interface ChatSessionCapabilities {

--- a/src/vscode-dts/vscode.proposed.chatSessionsProvider.d.ts
+++ b/src/vscode-dts/vscode.proposed.chatSessionsProvider.d.ts
@@ -42,6 +42,7 @@ declare module 'vscode' {
 		readonly onDidCommitChatSessionItem: Event<{ original: ChatSessionItem /** untitled */; modified: ChatSessionItem /** newly created */ }>;
 
 		/**
+		 * DEPRECATED: Will be removed!
 		 * Creates a new chat session.
 		 *
 		 * @param options Options for the new session including an optional initial prompt and history

--- a/src/vscode-dts/vscode.proposed.chatSessionsProvider.d.ts
+++ b/src/vscode-dts/vscode.proposed.chatSessionsProvider.d.ts
@@ -34,6 +34,12 @@ declare module 'vscode' {
 		readonly onDidChangeChatSessionItems: Event<void>;
 
 		/**
+		 * Fired when a new chat session item is created from an untitled session
+		 * Clients should replace the 'original' chat session with the 'modified' chat session.
+		 */
+		readonly onDidCreateChatSessionItem: Event<{ original: ChatSessionItem /** untitled */, modified: ChatSessionItem /** newly created */ }>;
+
+		/**
 		 * Creates a new chat session.
 		 *
 		 * @param options Options for the new session including an optional initial prompt and history
@@ -184,7 +190,12 @@ declare module 'vscode' {
 	}
 
 	export interface ChatContext {
-		readonly chatSession?: ChatSession; // TEMP
+		readonly chatSessionContext?: ChatSessionContext;
+	}
+
+	export interface ChatSessionContext {
+		readonly chatSessionItem: ChatSessionItem; // Maps to URI of chat session editor (could be 'untitled-1', etc..)
+		readonly isUntitled: boolean;
 	}
 
 	export interface ChatSessionCapabilities {

--- a/src/vscode-dts/vscode.proposed.chatSessionsProvider.d.ts
+++ b/src/vscode-dts/vscode.proposed.chatSessionsProvider.d.ts
@@ -3,6 +3,8 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+// version: 2
+
 declare module 'vscode' {
 	/**
 	 * Represents the status of a chat session.
@@ -34,10 +36,10 @@ declare module 'vscode' {
 		readonly onDidChangeChatSessionItems: Event<void>;
 
 		/**
-		 * Fired when a new chat session item is created from an untitled session
-		 * Clients should replace the 'original' chat session with the 'modified' chat session.
+		 * Event that the provider can fire to signal that the current (original) chat session should be replaced with a new (modified) chat session.
+		 * The UI can use this information to gracefully migrate the user to the new session.
 		 */
-		readonly onDidCreateChatSessionItem: Event<{ original: ChatSessionItem /** untitled */; modified: ChatSessionItem /** newly created */ }>;
+		readonly onDidCommitChatSessionItem: Event<{ original: ChatSessionItem /** untitled */; modified: ChatSessionItem /** newly created */ }>;
 
 		/**
 		 * Creates a new chat session.

--- a/src/vscode-dts/vscode.proposed.chatSessionsProvider.d.ts
+++ b/src/vscode-dts/vscode.proposed.chatSessionsProvider.d.ts
@@ -47,16 +47,6 @@ declare module 'vscode' {
 			readonly request: ChatRequest;
 
 			/**
-			 * Initial prompt to initiate the session
-			 */
-			readonly prompt?: string;
-
-			/**
-			 * History to initialize the session with
-			 */
-			readonly history?: ReadonlyArray<ChatRequestTurn | ChatResponseTurn>;
-
-			/**
 			 * Additional metadata to use for session creation
 			 */
 			metadata?: any;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Experiment for https://github.com/microsoft/vscode/issues/268063
Demo extension implementation: https://github.com/joshspicer/joshbot/

GHPR: https://github.com/microsoft/vscode-pull-request-github/pull/7849
Claude: https://github.com/microsoft/vscode-copilot-chat/pull/1147

- Do not dynamically register chat participant (let extension do that)
- Introduce concept of 'untitled' chat session
  - First request is not lost (leans more on existing chat participant API)
- `onDidCommitChatSessionItem` to swap untitled sessions -> backed sessions


This change is NOT backward-compatible since we will not longer register the chat participant implementation dynamically. The implementing extension should now register the participant.

This lets us delete `provideNewChatSessionItem` and remove `requestHandler` per chat session (instead using the chat participant as the handler). Those could be removed later but will not be done here.