### PR TITLE
mcp: turn off auto extension activation, enable when clause

### DIFF
--- a/src/vs/platform/extensions/common/extensions.ts
+++ b/src/vs/platform/extensions/common/extensions.ts
@@ -196,6 +196,7 @@ export interface IToolSetContribution {
 export interface IMcpCollectionContribution {
 	readonly id: string;
 	readonly label: string;
+	readonly when?: string;
 }
 
 export interface IExtensionContributions {

--- a/src/vs/workbench/api/browser/mainThreadMcp.ts
+++ b/src/vs/workbench/api/browser/mainThreadMcp.ts
@@ -134,7 +134,7 @@ export class MainThreadMcp extends Disposable implements MainThreadMcpShape {
 
 			this._collectionDefinitions.set(collection.id, {
 				servers: serverDefinitions,
-				dispose: () => handle.dispose(),
+				dispose: () => store.dispose(),
 			});
 		}
 	}

--- a/src/vs/workbench/contrib/mcp/common/mcpConfiguration.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpConfiguration.ts
@@ -244,6 +244,10 @@ export const mcpContributionPoint: IExtensionPointDescriptor<IMcpCollectionContr
 				label: {
 					description: localize('vscode.extension.contributes.mcp.label', "Display name for the collection."),
 					type: 'string'
+				},
+				when: {
+					description: localize('vscode.extension.contributes.mcp.when', "Condition which must be true to enable this collection."),
+					type: 'string'
 				}
 			}
 		}

--- a/src/vs/workbench/contrib/mcp/common/mcpLanguageModelToolContribution.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpLanguageModelToolContribution.ts
@@ -26,7 +26,7 @@ import { ChatResponseResource, getAttachableImageExtension } from '../../chat/co
 import { LanguageModelPartAudience } from '../../chat/common/languageModels.js';
 import { CountTokensCallback, ILanguageModelToolsService, IPreparedToolInvocation, IToolData, IToolImpl, IToolInvocation, IToolInvocationPreparationContext, IToolResult, IToolResultInputOutputDetails, ToolDataSource, ToolProgress, ToolSet } from '../../chat/common/languageModelToolsService.js';
 import { IMcpRegistry } from './mcpRegistryTypes.js';
-import { IMcpServer, IMcpService, IMcpTool, IMcpToolResourceLinkContents, LazyCollectionState, McpResourceURI, McpServerCacheState, McpToolResourceLinkMimeType } from './mcpTypes.js';
+import { IMcpServer, IMcpService, IMcpTool, IMcpToolResourceLinkContents, McpResourceURI, McpServerCacheState, McpToolResourceLinkMimeType } from './mcpTypes.js';
 import { mcpServerToSourceData } from './mcpTypesUtils.js';
 
 interface ISyncedToolData {
@@ -46,15 +46,7 @@ export class McpLanguageModelToolContribution extends Disposable implements IWor
 	) {
 		super();
 
-		// 1. Auto-discover extensions with new MCP servers
-		const lazyCollectionState = mcpService.lazyCollectionState.map(s => s.state);
-		this._register(autorun(reader => {
-			if (lazyCollectionState.read(reader) === LazyCollectionState.HasUnknown) {
-				mcpService.activateCollections();
-			}
-		}));
-
-		// 2. Keep tools in sync with the tools service.
+		// Keep tools in sync with the tools service.
 		const previous = this._register(new DisposableMap<IMcpServer, DisposableStore>());
 		this._register(autorun(reader => {
 			const servers = mcpService.servers.read(reader);

--- a/src/vs/workbench/contrib/mcp/common/mcpService.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpService.ts
@@ -61,6 +61,11 @@ export class McpService extends Disposable implements IMcpService {
 
 	public async autostart(token?: CancellationToken): Promise<IAutostartResult> {
 		const autoStartConfig = this.configurationService.getValue<McpAutoStartValue>(mcpAutoStartConfig);
+		if (autoStartConfig === McpAutoStartValue.Never) {
+			return { serversRequiringInteraction: [] };
+		}
+
+		await this.activateCollections();
 
 		// don't try re-running errored servers, let the user choose if they want that
 		const candidates = this.servers.get().filter(s => s.connectionState.get().state !== McpConnectionState.Kind.Error);


### PR DESCRIPTION
- Now that MCP autostart is on by default, we can remove the special
  eager activation we did for extensions.
- Also support a `when` clause for MCP extension collections, so they
  can be activated lazily and specifically.

Closes https://github.com/microsoft/vscode/issues/266221

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
