### PR TITLE
Don't use unbound `this` for dispose

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadChatAgents2.ts
+++ b/src/vs/workbench/api/browser/mainThreadChatAgents2.ts
@@ -220,7 +220,7 @@ export class MainThreadChatAgents2 extends Disposable implements MainThreadChatA
 		this._agents.set(handle, {
 			id: id,
 			extensionId: extension,
-			dispose: disposable.dispose,
+			dispose: () => disposable.dispose(),
 			hasFollowups: metadata.hasFollowups
 		});
 	}


### PR DESCRIPTION
For #267785

This pattern is not safe when working with an `IDisposable`

