### PR TITLE
Fixes https://github.com/microsoft/vscode/issues/268206

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadLanguageFeatures.ts
+++ b/src/vs/workbench/api/browser/mainThreadLanguageFeatures.ts
@@ -631,6 +631,7 @@ export class MainThreadLanguageFeatures extends Disposable implements MainThread
 	}
 
 	$registerInlineCompletionsSupport(handle: number, selector: IDocumentFilterDto[], supportsHandleEvents: boolean, extensionId: string, extensionVersion: string, groupId: string | undefined, yieldsToExtensionIds: string[], displayName: string | undefined, debounceDelayMs: number | undefined, excludesExtensionIds: string[], eventHandle: number | undefined): void {
+		const providerId = new languages.ProviderId(extensionId, extensionVersion, groupId);
 		const provider: languages.InlineCompletionsProvider<IdentifiableInlineCompletions> = {
 			provideInlineCompletions: async (model: ITextModel, position: EditorPosition, context: languages.InlineCompletionContext, token: CancellationToken): Promise<IdentifiableInlineCompletions | undefined> => {
 				const result = await this._proxy.$provideInlineCompletions(handle, model.uri, position, context, token);
@@ -641,12 +642,13 @@ export class MainThreadLanguageFeatures extends Disposable implements MainThread
 					const aiEditTelemetryService = accessor.getIfExists(IAiEditTelemetryService);
 					item.suggestionId = aiEditTelemetryService?.createSuggestionId({
 						applyCodeBlockSuggestionId: undefined,
-						editDeltaInfo: new EditDeltaInfo(1, 1, -1, -1), // TODO@hediet, fix this approximation.
 						feature: 'inlineSuggestion',
+						source: providerId,
 						languageId: completions.languageId,
+						editDeltaInfo: new EditDeltaInfo(1, 1, -1, -1), // TODO@hediet, fix this approximation.
 						modeId: undefined,
 						modelId: undefined,
-						presentation: 'inlineSuggestion',
+						presentation: item.isInlineEdit ? 'nextEditSuggestion' : 'inlineCompletion',
 					});
 				});
 
@@ -680,17 +682,18 @@ export class MainThreadLanguageFeatures extends Disposable implements MainThread
 						const aiEditTelemetryService = accessor.getIfExists(IAiEditTelemetryService);
 						aiEditTelemetryService?.handleCodeAccepted({
 							suggestionId: item.suggestionId,
+							feature: 'inlineSuggestion',
+							source: providerId,
+							languageId: completions.languageId,
 							editDeltaInfo: EditDeltaInfo.tryCreate(
 								lifetimeSummary.lineCountModified,
 								lifetimeSummary.lineCountOriginal,
 								lifetimeSummary.characterCountModified,
 								lifetimeSummary.characterCountOriginal,
 							),
-							feature: 'inlineSuggestion',
-							languageId: completions.languageId,
 							modeId: undefined,
 							modelId: undefined,
-							presentation: 'inlineSuggestion',
+							presentation: item.isInlineEdit ? 'nextEditSuggestion' : 'inlineCompletion',
 							acceptanceMethod: 'accept',
 							applyCodeBlockSuggestionId: undefined,
 						});
@@ -749,7 +752,7 @@ export class MainThreadLanguageFeatures extends Disposable implements MainThread
 				}
 			},
 			groupId: groupId ?? extensionId,
-			providerId: new languages.ProviderId(extensionId, extensionVersion, groupId),
+			providerId,
 			yieldsToGroupIds: yieldsToExtensionIds,
 			excludesGroupIds: excludesExtensionIds,
 			debounceDelayMs,

--- a/src/vs/workbench/contrib/chat/browser/actions/chatCodeblockActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatCodeblockActions.ts
@@ -188,6 +188,7 @@ export function registerChatCodeBlockActions() {
 					modelId: request?.modelId,
 					presentation: 'codeBlock',
 					applyCodeBlockSuggestionId: undefined,
+					source: undefined,
 				});
 			}
 		}
@@ -254,6 +255,7 @@ export function registerChatCodeBlockActions() {
 				modelId: request?.modelId,
 				presentation: 'codeBlock',
 				applyCodeBlockSuggestionId: undefined,
+				source: undefined,
 			});
 		}
 
@@ -410,6 +412,7 @@ export function registerChatCodeBlockActions() {
 					modelId: request?.modelId,
 					presentation: 'codeBlock',
 					applyCodeBlockSuggestionId: undefined,
+					source: undefined,
 				});
 			}
 		}

--- a/src/vs/workbench/contrib/chat/browser/actions/codeBlockOperations.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/codeBlockOperations.ts
@@ -89,6 +89,7 @@ export class InsertCodeBlockOperation {
 				modelId: request?.modelId,
 				presentation: 'codeBlock',
 				applyCodeBlockSuggestionId: undefined,
+				source: undefined,
 			});
 		}
 	}

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/chatMarkdownContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/chatMarkdownContentPart.ts
@@ -267,6 +267,7 @@ export class ChatMarkdownContentPart extends Disposable implements IChatContentP
 							modeId: element.model.request?.modeInfo?.modeId,
 							modelId: element.model.request?.modelId,
 							applyCodeBlockSuggestionId: undefined,
+							source: undefined,
 						})
 					};
 				}));

--- a/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingModifiedFileEntry.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingModifiedFileEntry.ts
@@ -263,6 +263,7 @@ export abstract class AbstractChatEditingModifiedFileEntry extends Disposable im
 				),
 				feature: this._telemetryInfo.feature,
 				languageId: action.languageId,
+				source: undefined,
 			});
 		}
 

--- a/src/vs/workbench/contrib/editTelemetry/browser/telemetry/aiEditTelemetry/aiEditTelemetryService.ts
+++ b/src/vs/workbench/contrib/editTelemetry/browser/telemetry/aiEditTelemetry/aiEditTelemetryService.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { ProviderId } from '../../../../../../editor/common/languages.js';
 import { EditDeltaInfo, EditSuggestionId } from '../../../../../../editor/common/textModelEditSource.js';
 import { createDecorator } from '../../../../../../platform/instantiation/common/instantiation.js';
 
@@ -19,8 +20,9 @@ export interface IAiEditTelemetryService {
 export interface IEditTelemetryBaseData {
 	suggestionId: EditSuggestionId | undefined;
 
-	presentation: 'codeBlock' | 'highlightedEdit' | 'inlineSuggestion';
+	presentation: 'codeBlock' | 'highlightedEdit' | 'inlineCompletion' | 'nextEditSuggestion';
 	feature: 'sideBarChat' | 'inlineChat' | 'inlineSuggestion' | string | undefined;
+	source: ProviderId | undefined;
 
 	languageId: string | undefined;
 

--- a/src/vs/workbench/contrib/editTelemetry/browser/telemetry/aiEditTelemetry/aiEditTelemetryServiceImpl.ts
+++ b/src/vs/workbench/contrib/editTelemetry/browser/telemetry/aiEditTelemetry/aiEditTelemetryServiceImpl.ts
@@ -28,8 +28,12 @@ export class AiEditTelemetryServiceImpl implements IAiEditTelemetryService {
 			eventId: string | undefined;
 			suggestionId: string | undefined;
 
-			presentation: 'codeBlock' | 'highlightedEdit' | 'inlineSuggestion' | undefined;
+			presentation: 'codeBlock' | 'highlightedEdit' | 'inlineCompletion' | 'nextEditSuggestion' | undefined;
 			feature: 'sideBarChat' | 'inlineChat' | 'inlineSuggestion' | string | undefined;
+
+			sourceExtensionId: string | undefined;
+			sourceExtensionVersion: string | undefined;
+			sourceProviderId: string | undefined;
 
 			languageId: string | undefined;
 			editCharsInserted: number | undefined;
@@ -50,6 +54,10 @@ export class AiEditTelemetryServiceImpl implements IAiEditTelemetryService {
 			presentation: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'How the code suggestion is presented to the user.' };
 			feature: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The feature the code suggestion came from.' };
 
+			sourceExtensionId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The extension that provided the code suggestion, if any.' };
+			sourceExtensionVersion: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The version of the extension that provided the code suggestion, if any.' };
+			sourceProviderId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The provider ID of the source that provided the code suggestion, if any.' };
+
 			languageId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The programming language of the code suggestion.' };
 			editCharsInserted: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Number of characters inserted in the edit.' };
 			editCharsDeleted: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Number of characters deleted in the edit.' };
@@ -64,11 +72,17 @@ export class AiEditTelemetryServiceImpl implements IAiEditTelemetryService {
 			suggestionId: suggestionId as unknown as string,
 			presentation: data.presentation,
 			feature: data.feature,
+
+			sourceExtensionId: data.source?.extensionId,
+			sourceExtensionVersion: data.source?.extensionVersion,
+			sourceProviderId: data.source?.providerId,
+
 			languageId: data.languageId,
 			editCharsInserted: data.editDeltaInfo?.charsAdded,
 			editCharsDeleted: data.editDeltaInfo?.charsRemoved,
 			editLinesInserted: data.editDeltaInfo?.linesAdded,
 			editLinesDeleted: data.editDeltaInfo?.linesRemoved,
+
 			modeId: data.modeId,
 			modelId: new TelemetryTrustedValue(data.modelId),
 			applyCodeBlockSuggestionId: data.applyCodeBlockSuggestionId as unknown as string,
@@ -82,8 +96,13 @@ export class AiEditTelemetryServiceImpl implements IAiEditTelemetryService {
 			eventId: string | undefined;
 			suggestionId: string | undefined;
 
-			presentation: 'codeBlock' | 'highlightedEdit' | 'inlineSuggestion' | undefined;
+			presentation: 'codeBlock' | 'highlightedEdit' | 'inlineCompletion' | 'nextEditSuggestion' | undefined;
 			feature: 'sideBarChat' | 'inlineChat' | 'inlineSuggestion' | string | undefined;
+
+			sourceExtensionId: string | undefined;
+			sourceExtensionVersion: string | undefined;
+			sourceProviderId: string | undefined;
+
 
 			languageId: string | undefined;
 			editCharsInserted: number | undefined;
@@ -112,6 +131,10 @@ export class AiEditTelemetryServiceImpl implements IAiEditTelemetryService {
 			presentation: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'How the code suggestion is presented to the user.' };
 			feature: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The feature the code suggestion came from.' };
 
+			sourceExtensionId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The extension that provided the code suggestion, if any.' };
+			sourceExtensionVersion: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The version of the extension that provided the code suggestion, if any.' };
+			sourceProviderId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The provider ID of the source that provided the code suggestion, if any.' };
+
 			languageId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The programming language of the code suggestion.' };
 			editCharsInserted: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Number of characters inserted in the edit.' };
 			editCharsDeleted: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Number of characters deleted in the edit.' };
@@ -128,14 +151,20 @@ export class AiEditTelemetryServiceImpl implements IAiEditTelemetryService {
 			suggestionId: data.suggestionId as unknown as string,
 			presentation: data.presentation,
 			feature: data.feature,
+
+			sourceExtensionId: data.source?.extensionId,
+			sourceExtensionVersion: data.source?.extensionVersion,
+			sourceProviderId: data.source?.providerId,
+
+			languageId: data.languageId,
 			editCharsInserted: data.editDeltaInfo?.charsAdded,
 			editCharsDeleted: data.editDeltaInfo?.charsRemoved,
 			editLinesInserted: data.editDeltaInfo?.linesAdded,
 			editLinesDeleted: data.editDeltaInfo?.linesRemoved,
+
 			modeId: data.modeId,
 			modelId: new TelemetryTrustedValue(data.modelId),
 			applyCodeBlockSuggestionId: data.applyCodeBlockSuggestionId as unknown as string,
-			languageId: data.languageId,
 			acceptanceMethod: data.acceptanceMethod,
 		});
 	}

--- a/src/vs/workbench/contrib/editTelemetry/browser/telemetry/arcTelemetrySender.ts
+++ b/src/vs/workbench/contrib/editTelemetry/browser/telemetry/arcTelemetrySender.ts
@@ -18,6 +18,7 @@ import { IAiEditTelemetryService } from './aiEditTelemetry/aiEditTelemetryServic
 import { ArcTracker } from '../../common/arcTracker.js';
 import type { ScmRepoBridge } from './editSourceTrackingImpl.js';
 import { forwardToChannelIf, isCopilotLikeExtension } from './forwardingTelemetryService.js';
+import { ProviderId } from '../../../../../editor/common/languages.js';
 
 export class InlineEditArcTelemetrySender extends Disposable {
 	constructor(
@@ -133,12 +134,15 @@ export class AiEditTelemetryAdapter extends Disposable {
 				feature = 'inlineChat';
 			}
 
+			const providerId = new ProviderId(data.props.$extensionId, data.props.$extensionVersion, data.props.$providerId);
+
 			// TODO@hediet tie this suggestion id to hunks, so acceptance can be correlated.
 			this._aiEditTelemetryService.createSuggestionId({
 				applyCodeBlockSuggestionId,
 				languageId: data.props.$$languageId,
 				presentation: 'highlightedEdit',
 				feature,
+				source: providerId,
 				modelId: data.props.$modelId,
 				modeId: data.props.$$mode as any,
 				editDeltaInfo: EditDeltaInfo.fromEdit(edit, _prev),


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/268206

This PR changes the presentation property of the `editTelemetry.codeSuggested`/`.codeAccepted` event from `"inlineSuggestion"` to `"inlineCompletion" | "nextEditSuggestion"`. FYI @ulugbekna @alexdima 

It also adds properties:
```
sourceExtensionId: string | undefined;
sourceExtensionVersion: string | undefined;
sourceProviderId: string | undefined;
```