### PR TITLE
Use custom icon for chatSessions to continue showing when FileIcon is turned off

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatSessions/view/sessionsTreeRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSessions/view/sessionsTreeRenderer.ts
@@ -51,7 +51,6 @@ import { CancellationToken } from '../../../../../../base/common/cancellation.js
 interface ISessionTemplateData {
 	readonly container: HTMLElement;
 	readonly resourceLabel: IResourceLabel;
-	readonly customIcon: HTMLElement;
 	readonly actionBar: ActionBar;
 	readonly elementDisposable: DisposableStore;
 	readonly timestamp: HTMLElement;
@@ -191,9 +190,6 @@ export class SessionsRenderer extends Disposable implements ITreeRenderer<IChatS
 		// Create a container that holds the label, timestamp, and actions
 		const contentContainer = append(element, $('.session-content'));
 
-		// Create custom icon element that won't be affected by file icon theme
-		const customIcon = append(contentContainer, $('.chat-session-custom-icon'));
-
 		const resourceLabel = this.labels.create(contentContainer, { supportHighlights: true });
 		const descriptionRow = append(element, $('.description-row'));
 		const descriptionLabel = append(descriptionRow, $('span.description'));
@@ -224,7 +220,6 @@ export class SessionsRenderer extends Disposable implements ITreeRenderer<IChatS
 		return {
 			container: element,
 			resourceLabel,
-			customIcon,
 			actionBar,
 			elementDisposable,
 			timestamp,

--- a/src/vs/workbench/contrib/chat/browser/media/chatSessions.css
+++ b/src/vs/workbench/contrib/chat/browser/media/chatSessions.css
@@ -157,6 +157,22 @@
 	padding-bottom: 0;
 }
 
+/* Custom chat session icon that bypasses file icon theme */
+.chat-sessions-tree-container .chat-session-item .chat-session-custom-icon {
+	flex-shrink: 0;
+	width: 16px;
+	height: 16px;
+	margin-right: 6px;
+	align-items: center;
+	justify-content: center;
+	font-size: 16px;
+	color: var(--vscode-icon-foreground);
+}
+
+.chat-sessions-tree-container .chat-session-item .chat-session-custom-icon.codicon-loading::before {
+	animation: codicon-spin 1.5s steps(30) infinite;
+}
+
 /* Ensure resource label takes up available space */
 .chat-sessions-tree-container .chat-session-item .monaco-icon-label {
 	flex: 1;

--- a/src/vs/workbench/contrib/chat/browser/media/chatSessions.css
+++ b/src/vs/workbench/contrib/chat/browser/media/chatSessions.css
@@ -185,6 +185,15 @@
 	text-align: center;
 }
 
+/* Ensure consistent spacing for chat session icons after removing 'predefined-file-icon' class to keep them visible */
+/* when file icons are globally disabled. Mirrors the sizing from workbench style.css for predefined-file-icon. */
+/* Spacing for dedicated injected chat session icon span */
+.chat-sessions-tree-container .chat-session-item .chat-session-icon.codicon::before {
+	width: 16px;
+	padding-left: 3px; /* width (16px) - typical font-size (13px) = left padding (3px) */
+	padding-right: 3px;
+}
+
 .chat-sessions-tree-container .chat-session-item .monaco-icon-label.codicon-loading::before {
 	animation: codicon-spin 1.5s steps(30) infinite;
 }

--- a/src/vs/workbench/contrib/chat/browser/media/chatSessions.css
+++ b/src/vs/workbench/contrib/chat/browser/media/chatSessions.css
@@ -157,22 +157,6 @@
 	padding-bottom: 0;
 }
 
-/* Custom chat session icon that bypasses file icon theme */
-.chat-sessions-tree-container .chat-session-item .chat-session-custom-icon {
-	flex-shrink: 0;
-	width: 16px;
-	height: 16px;
-	margin-right: 6px;
-	align-items: center;
-	justify-content: center;
-	font-size: 16px;
-	color: var(--vscode-icon-foreground);
-}
-
-.chat-sessions-tree-container .chat-session-item .chat-session-custom-icon.codicon-loading::before {
-	animation: codicon-spin 1.5s steps(30) infinite;
-}
-
 /* Ensure resource label takes up available space */
 .chat-sessions-tree-container .chat-session-item .monaco-icon-label {
 	flex: 1;


### PR DESCRIPTION
Fixes #265150

Chat Sessions is using VS Code's standard ResourceLabel component which respects global file icon theme settings. When file icons setting is turned off, global CSS rule .predefined-file-icon { display: none !important; } hides all icons rendered through this system.
This change implements a custom icon for Chat Sessions similar to Timeline and Outline views that bypasses the file icon theme.