### PR TITLE
mcp: fix incorrect roots on remotes

### DIFF
--- a/src/vs/base/common/uriTransformer.ts
+++ b/src/vs/base/common/uriTransformer.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { UriParts, IRawURITransformer, URITransformer, IURITransformer } from '../../../base/common/uriIpc.js';
+import { UriParts, IRawURITransformer, URITransformer, IURITransformer } from './uriIpc.js';
 
 /**
  * ```

--- a/src/vs/server/node/remoteAgentEnvironmentImpl.ts
+++ b/src/vs/server/node/remoteAgentEnvironmentImpl.ts
@@ -7,7 +7,7 @@ import { Event } from '../../base/common/event.js';
 import * as platform from '../../base/common/platform.js';
 import * as performance from '../../base/common/performance.js';
 import { URI } from '../../base/common/uri.js';
-import { createURITransformer } from '../../workbench/api/node/uriTransformer.js';
+import { createURITransformer } from '../../base/common/uriTransformer.js';
 import { IRemoteAgentEnvironmentDTO, IGetEnvironmentDataArguments, IGetExtensionHostExitInfoArguments } from '../../workbench/services/remote/common/remoteAgentEnvironmentChannel.js';
 import { IServerEnvironmentService } from './serverEnvironmentService.js';
 import { IServerChannel } from '../../base/parts/ipc/common/ipc.js';

--- a/src/vs/server/node/remoteFileSystemProviderServer.ts
+++ b/src/vs/server/node/remoteFileSystemProviderServer.ts
@@ -8,7 +8,7 @@ import { URI, UriComponents } from '../../base/common/uri.js';
 import { IURITransformer } from '../../base/common/uriIpc.js';
 import { IFileChange } from '../../platform/files/common/files.js';
 import { ILogService } from '../../platform/log/common/log.js';
-import { createURITransformer } from '../../workbench/api/node/uriTransformer.js';
+import { createURITransformer } from '../../base/common/uriTransformer.js';
 import { RemoteAgentConnectionContext } from '../../platform/remote/common/remoteAgentEnvironment.js';
 import { DiskFileSystemProvider } from '../../platform/files/node/diskFileSystemProvider.js';
 import { posix, delimiter } from '../../base/common/path.js';

--- a/src/vs/server/node/remoteTerminalChannel.ts
+++ b/src/vs/server/node/remoteTerminalChannel.ts
@@ -17,7 +17,7 @@ import { RemoteAgentConnectionContext } from '../../platform/remote/common/remot
 import { IPtyHostService, IShellLaunchConfig, ITerminalProfile } from '../../platform/terminal/common/terminal.js';
 import { IGetTerminalLayoutInfoArgs, ISetTerminalLayoutInfoArgs } from '../../platform/terminal/common/terminalProcess.js';
 import { IWorkspaceFolder } from '../../platform/workspace/common/workspace.js';
-import { createURITransformer } from '../../workbench/api/node/uriTransformer.js';
+import { createURITransformer } from '../../base/common/uriTransformer.js';
 import { CLIServerBase, ICommandsExecuter } from '../../workbench/api/node/extHostCLIServer.js';
 import { IEnvironmentVariableCollection } from '../../platform/terminal/common/environmentVariable.js';
 import { MergedEnvironmentVariableCollection } from '../../platform/terminal/common/environmentVariableCollection.js';

--- a/src/vs/server/node/serverServices.ts
+++ b/src/vs/server/node/serverServices.ts
@@ -55,7 +55,7 @@ import { RemoteAgentFileSystemProviderChannel } from './remoteFileSystemProvider
 import { ServerTelemetryChannel } from '../../platform/telemetry/common/remoteTelemetryChannel.js';
 import { IServerTelemetryService, ServerNullTelemetryService, ServerTelemetryService } from '../../platform/telemetry/common/serverTelemetryService.js';
 import { RemoteTerminalChannel } from './remoteTerminalChannel.js';
-import { createURITransformer } from '../../workbench/api/node/uriTransformer.js';
+import { createURITransformer } from '../../base/common/uriTransformer.js';
 import { ServerConnectionToken } from './serverConnectionToken.js';
 import { ServerEnvironmentService, ServerParsedArgs } from './serverEnvironmentService.js';
 import { REMOTE_TERMINAL_CHANNEL_NAME } from '../../workbench/contrib/terminal/common/remote/remoteTerminalChannel.js';

--- a/src/vs/workbench/api/node/extensionHostProcess.ts
+++ b/src/vs/workbench/api/node/extensionHostProcess.ts
@@ -21,7 +21,7 @@ import { boolean } from '../../../editor/common/config/editorOptions.js';
 import product from '../../../platform/product/common/product.js';
 import { ExtensionHostMain, IExitFn } from '../common/extensionHostMain.js';
 import { IHostUtils } from '../common/extHostExtensionService.js';
-import { createURITransformer } from './uriTransformer.js';
+import { createURITransformer } from '../../../base/common/uriTransformer.js';
 import { ExtHostConnectionType, readExtHostConnection } from '../../services/extensions/common/extensionHostEnv.js';
 import { ExtensionHostExitCode, IExtHostReadyMessage, IExtHostReduceGraceTimeMessage, IExtHostSocketMessage, IExtensionHostInitData, MessageType, createMessageOfType, isMessageOfType } from '../../services/extensions/common/extensionHostProtocol.js';
 import { IDisposable } from '../../../base/common/lifecycle.js';

--- a/src/vs/workbench/contrib/mcp/test/common/mcpResourceFilesystem.test.ts
+++ b/src/vs/workbench/contrib/mcp/test/common/mcpResourceFilesystem.test.ts
@@ -25,6 +25,7 @@ import { McpService } from '../../common/mcpService.js';
 import { IMcpService } from '../../common/mcpTypes.js';
 import { MCP } from '../../common/modelContextProtocol.js';
 import { TestMcpMessageTransport, TestMcpRegistry } from './mcpRegistryTypes.js';
+import { IWorkbenchEnvironmentService } from '../../../../services/environment/common/environmentService.js';
 
 
 suite('Workbench - MCP - ResourceFilesystem', () => {
@@ -40,6 +41,7 @@ suite('Workbench - MCP - ResourceFilesystem', () => {
 			[IStorageService, ds.add(new TestStorageService())],
 			[ILoggerService, ds.add(new TestLoggerService())],
 			[IWorkspaceContextService, new TestContextService()],
+			[IWorkbenchEnvironmentService, {}],
 			[ITelemetryService, NullTelemetryService],
 			[IProductService, TestProductService],
 		);


### PR DESCRIPTION
- Don't show roots that live on a different RA than the MCP server
  (they have no way to deal with or represent these)
- Correctly transform roots that do live on the same RA using the URI
  transfomer, and move to the common layer.

Closes #250920

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
