### PR TITLE
mcp: correctly resolve cwd and variables on remotes

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadMcp.ts
+++ b/src/vs/workbench/api/browser/mainThreadMcp.ts
@@ -71,6 +71,10 @@ export class MainThreadMcp extends Disposable implements MainThreadMcpShape {
 				}
 				return true;
 			},
+			async substituteVariables(serverDefinition, launch) {
+				const ser = await proxy.$substituteVariables(serverDefinition.variableReplacement?.folder?.uri, McpServerLaunch.toSerialized(launch));
+				return McpServerLaunch.fromSerialized(ser);
+			},
 			start: (_collection, serverDefiniton, resolveLaunch, options) => {
 				const id = ++this._serverIdCounter;
 				const launch = new ExtHostMcpServerLaunch(
@@ -80,7 +84,11 @@ export class MainThreadMcp extends Disposable implements MainThreadMcpShape {
 				);
 				this._servers.set(id, launch);
 				this._serverDefinitions.set(id, serverDefiniton);
-				proxy.$startMcp(id, resolveLaunch, options?.errorOnUserInteraction);
+				proxy.$startMcp(id, {
+					launch: resolveLaunch,
+					defaultCwd: serverDefiniton.variableReplacement?.folder?.uri,
+					errorOnUserInteraction: options?.errorOnUserInteraction,
+				});
 
 				return launch;
 			},

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -3018,9 +3018,16 @@ export interface ExtHostTestingShape {
 	$disposeTestFollowups(id: number[]): void;
 }
 
+export interface IStartMcpOptions {
+	launch: McpServerLaunch.Serialized;
+	defaultCwd?: UriComponents;
+	errorOnUserInteraction?: boolean;
+}
+
 export interface ExtHostMcpShape {
+	$substituteVariables(workspaceFolder: UriComponents | undefined, value: McpServerLaunch.Serialized): Promise<McpServerLaunch.Serialized>;
 	$resolveMcpLaunch(collectionId: string, label: string): Promise<McpServerLaunch.Serialized | undefined>;
-	$startMcp(id: number, launch: McpServerLaunch.Serialized, errorOnUserInteraction?: boolean): void;
+	$startMcp(id: number, opts: IStartMcpOptions): void;
 	$stopMcp(id: number): void;
 	$sendMessage(id: number, message: string): void;
 	$waitForInitialCollectionProviders(): Promise<void>;

--- a/src/vs/workbench/api/common/extHostDebugService.ts
+++ b/src/vs/workbench/api/common/extHostDebugService.ts
@@ -14,7 +14,7 @@ import { URI, UriComponents } from '../../../base/common/uri.js';
 import { ExtensionIdentifier, IExtensionDescription } from '../../../platform/extensions/common/extensions.js';
 import { createDecorator } from '../../../platform/instantiation/common/instantiation.js';
 import { ISignService } from '../../../platform/sign/common/sign.js';
-import { IWorkspaceFolder } from '../../../platform/workspace/common/workspace.js';
+import { IWorkspaceFolderData } from '../../../platform/workspace/common/workspace.js';
 import { AbstractDebugAdapter } from '../../contrib/debug/common/abstractDebugAdapter.js';
 import { DebugVisualizationType, IAdapterDescriptor, IConfig, IDebugAdapter, IDebugAdapterExecutable, IDebugAdapterImpl, IDebugAdapterNamedPipeServer, IDebugAdapterServer, IDebuggerContribution, IDebugVisualization, IDebugVisualizationContext, IDebugVisualizationTreeItem, MainThreadDebugVisualization } from '../../contrib/debug/common/debug.js';
 import { convertToDAPaths, convertToVSCPaths, isDebuggerMainContribution } from '../../contrib/debug/common/debugUtils.js';
@@ -566,16 +566,13 @@ export abstract class ExtHostDebugServiceBase extends DisposableCls implements I
 	}
 
 	public async $substituteVariables(folderUri: UriComponents | undefined, config: IConfig): Promise<IConfig> {
-		let ws: IWorkspaceFolder | undefined;
+		let ws: IWorkspaceFolderData | undefined;
 		const folder = await this.getFolder(folderUri);
 		if (folder) {
 			ws = {
 				uri: folder.uri,
 				name: folder.name,
 				index: folder.index,
-				toResource: () => {
-					throw new Error('Not implemented');
-				}
 			};
 		}
 		const variableResolver = await this._variableResolver.getResolver();

--- a/src/vs/workbench/api/node/extHostMcpNode.ts
+++ b/src/vs/workbench/api/node/extHostMcpNode.ts
@@ -10,31 +10,22 @@ import { parseEnvFile } from '../../../base/common/envfile.js';
 import { untildify } from '../../../base/common/labels.js';
 import { DisposableMap } from '../../../base/common/lifecycle.js';
 import * as path from '../../../base/common/path.js';
+import { URI } from '../../../base/common/uri.js';
 import { StreamSplitter } from '../../../base/node/nodeStreams.js';
 import { findExecutable } from '../../../base/node/processes.js';
-import { ILogService, LogLevel } from '../../../platform/log/common/log.js';
+import { LogLevel } from '../../../platform/log/common/log.js';
 import { McpConnectionState, McpServerLaunch, McpServerTransportStdio, McpServerTransportType } from '../../contrib/mcp/common/mcpTypes.js';
 import { McpStdioStateHandler } from '../../contrib/mcp/node/mcpStdioStateHandler.js';
-import { IExtHostInitDataService } from '../common/extHostInitDataService.js';
 import { ExtHostMcpService } from '../common/extHostMcp.js';
-import { IExtHostRpcService } from '../common/extHostRpcService.js';
 
 export class NodeExtHostMpcService extends ExtHostMcpService {
-	constructor(
-		@IExtHostRpcService extHostRpc: IExtHostRpcService,
-		@IExtHostInitDataService initDataService: IExtHostInitDataService,
-		@ILogService logService: ILogService,
-	) {
-		super(extHostRpc, logService, initDataService);
-	}
-
 	private nodeServers = this._register(new DisposableMap<number, McpStdioStateHandler>());
 
-	protected override _startMcp(id: number, launch: McpServerLaunch, errorOnUserInteraction?: boolean): void {
+	protected override _startMcp(id: number, launch: McpServerLaunch, defaultCwd?: URI, errorOnUserInteraction?: boolean): void {
 		if (launch.type === McpServerTransportType.Stdio) {
-			this.startNodeMpc(id, launch);
+			this.startNodeMpc(id, launch, defaultCwd);
 		} else {
-			super._startMcp(id, launch, errorOnUserInteraction);
+			super._startMcp(id, launch, defaultCwd, errorOnUserInteraction);
 		}
 	}
 
@@ -56,7 +47,7 @@ export class NodeExtHostMpcService extends ExtHostMcpService {
 		}
 	}
 
-	private async startNodeMpc(id: number, launch: McpServerTransportStdio) {
+	private async startNodeMpc(id: number, launch: McpServerTransportStdio, defaultCwd?: URI): Promise<void> {
 		const onError = (err: Error | string) => this._proxy.$onDidChangeState(id, {
 			state: McpConnectionState.Kind.Error,
 			code: err.hasOwnProperty('code') ? String((err as any).code) : undefined,
@@ -85,7 +76,7 @@ export class NodeExtHostMpcService extends ExtHostMcpService {
 			const home = homedir();
 			let cwd = launch.cwd ? untildify(launch.cwd, home) : home;
 			if (!path.isAbsolute(cwd)) {
-				cwd = path.join(home, cwd);
+				cwd = defaultCwd ? path.join(defaultCwd.fsPath, cwd) : path.join(home, cwd);
 			}
 
 			const { executable, args, shell } = await formatSubprocessArguments(

--- a/src/vs/workbench/contrib/mcp/common/discovery/installedMcpServersDiscovery.ts
+++ b/src/vs/workbench/contrib/mcp/common/discovery/installedMcpServersDiscovery.ts
@@ -7,15 +7,12 @@ import { Throttler } from '../../../../../base/common/async.js';
 import { Disposable, DisposableMap, DisposableStore, IDisposable } from '../../../../../base/common/lifecycle.js';
 import { ResourceMap } from '../../../../../base/common/map.js';
 import { observableValue } from '../../../../../base/common/observable.js';
-import { posix as pathPosix, sep as pathSep, win32 as pathWin32 } from '../../../../../base/common/path.js';
-import { isWindows, OperatingSystem } from '../../../../../base/common/platform.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { Location } from '../../../../../editor/common/languages.js';
 import { ITextModelService } from '../../../../../editor/common/services/resolverService.js';
 import { ConfigurationTarget } from '../../../../../platform/configuration/common/configuration.js';
 import { StorageScope } from '../../../../../platform/storage/common/storage.js';
 import { IWorkbenchLocalMcpServer } from '../../../../services/mcp/common/mcpWorkbenchManagementService.js';
-import { IRemoteAgentService } from '../../../../services/remote/common/remoteAgentService.js';
 import { getMcpServerMapping } from '../mcpConfigFileUtils.js';
 import { mcpConfigurationSection } from '../mcpConfiguration.js';
 import { IMcpRegistry } from '../mcpRegistryTypes.js';
@@ -30,7 +27,6 @@ export class InstalledMcpServersDiscovery extends Disposable implements IMcpDisc
 	constructor(
 		@IMcpWorkbenchService private readonly mcpWorkbenchService: IMcpWorkbenchService,
 		@IMcpRegistry private readonly mcpRegistry: IMcpRegistry,
-		@IRemoteAgentService private readonly remoteAgentService: IRemoteAgentService,
 		@ITextModelService private readonly textModelService: ITextModelService,
 	) {
 		super();
@@ -58,7 +54,6 @@ export class InstalledMcpServersDiscovery extends Disposable implements IMcpDisc
 
 	private async sync(): Promise<void> {
 		try {
-			const remoteEnv = await this.remoteAgentService.getEnvironment();
 			const collections = new Map<string, [IMcpConfigPath | undefined, McpServerDefinition[]]>();
 			const mcpConfigPathInfos = new ResourceMap<Promise<IMcpConfigPath & { locations: Map<string, Location> } | undefined>>();
 			for (const server of this.mcpWorkbenchService.getEnabledLocalMcpServers()) {
@@ -82,14 +77,6 @@ export class InstalledMcpServersDiscovery extends Disposable implements IMcpDisc
 					collections.set(collectionId, definitions);
 				}
 
-				const { isAbsolute, join, sep } = mcpConfigPath?.remoteAuthority && remoteEnv
-					? (remoteEnv.os === OperatingSystem.Windows ? pathWin32 : pathPosix)
-					: (isWindows ? pathWin32 : pathPosix);
-				const fsPathForRemote = (uri: URI) => {
-					const fsPathLocal = uri.fsPath;
-					return fsPathLocal.replaceAll(pathSep, sep);
-				};
-
 				const launch: McpServerLaunch = config.type === 'http' ? {
 					type: McpServerTransportType.HTTP,
 					uri: URI.parse(config.url),
@@ -100,17 +87,7 @@ export class InstalledMcpServersDiscovery extends Disposable implements IMcpDisc
 					args: config.args || [],
 					env: config.env || {},
 					envFile: config.envFile,
-					cwd: config.cwd
-						// if the cwd is defined in a workspace folder but not absolute (and not
-						// a variable or tilde-expansion) then resolve it in the workspace folder
-						// if the cwd is defined in a workspace folder but not absolute (and not
-						// a variable or tilde-expansion) then resolve it in the workspace folder
-						? (!isAbsolute(config.cwd) && !config.cwd.startsWith('~') && !config.cwd.startsWith('${') && mcpConfigPath?.workspaceFolder
-							? join(fsPathForRemote(mcpConfigPath.workspaceFolder.uri), config.cwd)
-							: config.cwd)
-						: mcpConfigPath?.workspaceFolder
-							? fsPathForRemote(mcpConfigPath.workspaceFolder.uri)
-							: undefined,
+					cwd: config.cwd,
 				};
 
 				definitions[1].push({

--- a/src/vs/workbench/contrib/mcp/common/mcpRegistryTypes.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpRegistryTypes.ts
@@ -31,6 +31,7 @@ export interface IMcpHostDelegate {
 	readonly priority: number;
 	waitForInitialProviderPromises(): Promise<void>;
 	canStart(collectionDefinition: McpCollectionDefinition, serverDefinition: McpServerDefinition): boolean;
+	substituteVariables(serverDefinition: McpServerDefinition, launch: McpServerLaunch): Promise<McpServerLaunch>;
 	start(collectionDefinition: McpCollectionDefinition, serverDefinition: McpServerDefinition, resolvedLaunch: McpServerLaunch, options?: { errorOnUserInteraction?: boolean }): IMcpMessageTransport;
 }
 

--- a/src/vs/workbench/contrib/mcp/test/common/mcpRegistry.test.ts
+++ b/src/vs/workbench/contrib/mcp/test/common/mcpRegistry.test.ts
@@ -27,7 +27,7 @@ import { TestLoggerService, TestStorageService } from '../../../../test/common/w
 import { McpRegistry } from '../../common/mcpRegistry.js';
 import { IMcpHostDelegate, IMcpMessageTransport } from '../../common/mcpRegistryTypes.js';
 import { McpServerConnection } from '../../common/mcpServerConnection.js';
-import { LazyCollectionState, McpCollectionDefinition, McpServerDefinition, McpServerTransportStdio, McpServerTransportType, McpServerTrust, McpStartServerInteraction } from '../../common/mcpTypes.js';
+import { LazyCollectionState, McpCollectionDefinition, McpServerDefinition, McpServerLaunch, McpServerTransportStdio, McpServerTransportType, McpServerTrust, McpStartServerInteraction } from '../../common/mcpTypes.js';
 import { TestMcpMessageTransport } from './mcpRegistryTypes.js';
 
 class TestConfigurationResolverService implements Partial<IConfigurationResolverService> {
@@ -74,6 +74,10 @@ class TestConfigurationResolverService implements Partial<IConfigurationResolver
 
 class TestMcpHostDelegate implements IMcpHostDelegate {
 	priority = 0;
+
+	substituteVariables(serverDefinition: McpServerDefinition, launch: McpServerLaunch): Promise<McpServerLaunch> {
+		return Promise.resolve(launch);
+	}
 
 	canStart(): boolean {
 		return true;

--- a/src/vs/workbench/contrib/mcp/test/common/mcpRegistryTypes.ts
+++ b/src/vs/workbench/contrib/mcp/test/common/mcpRegistryTypes.ts
@@ -180,6 +180,9 @@ export class TestMcpRegistry implements IMcpRegistry {
 	delegates = observableValue<readonly IMcpHostDelegate[]>(this, [{
 		priority: 0,
 		canStart: () => true,
+		substituteVariables(serverDefinition, launch) {
+			return Promise.resolve(launch);
+		},
 		start: () => {
 			const t = this.makeTestTransport();
 			setTimeout(() => t.setConnectionState({ state: McpConnectionState.Kind.Running }));

--- a/src/vs/workbench/contrib/mcp/test/common/mcpServerConnection.test.ts
+++ b/src/vs/workbench/contrib/mcp/test/common/mcpServerConnection.test.ts
@@ -18,7 +18,7 @@ import { IOutputService } from '../../../../services/output/common/output.js';
 import { TestLoggerService, TestProductService, TestStorageService } from '../../../../test/common/workbenchTestServices.js';
 import { IMcpHostDelegate, IMcpMessageTransport } from '../../common/mcpRegistryTypes.js';
 import { McpServerConnection } from '../../common/mcpServerConnection.js';
-import { McpCollectionDefinition, McpConnectionState, McpServerDefinition, McpServerTransportType, McpServerTrust } from '../../common/mcpTypes.js';
+import { McpCollectionDefinition, McpConnectionState, McpServerDefinition, McpServerLaunch, McpServerTransportType, McpServerTrust } from '../../common/mcpTypes.js';
 import { TestMcpMessageTransport } from './mcpRegistryTypes.js';
 import { ConfigurationTarget } from '../../../../../platform/configuration/common/configuration.js';
 import { Event } from '../../../../../base/common/event.js';
@@ -32,6 +32,10 @@ class TestMcpHostDelegate extends Disposable implements IMcpHostDelegate {
 	constructor() {
 		super();
 		this._transport = this._register(new TestMcpMessageTransport());
+	}
+
+	substituteVariables(serverDefinition: McpServerDefinition, launch: McpServerLaunch): Promise<McpServerLaunch> {
+		return Promise.resolve(launch);
 	}
 
 	canStart(): boolean {

--- a/src/vs/workbench/contrib/mcp/test/common/mcpServerRequestHandler.test.ts
+++ b/src/vs/workbench/contrib/mcp/test/common/mcpServerRequestHandler.test.ts
@@ -14,7 +14,7 @@ import { IStorageService } from '../../../../../platform/storage/common/storage.
 import { TestLoggerService, TestProductService, TestStorageService } from '../../../../test/common/workbenchTestServices.js';
 import { IMcpHostDelegate } from '../../common/mcpRegistryTypes.js';
 import { McpServerRequestHandler } from '../../common/mcpServerRequestHandler.js';
-import { McpConnectionState } from '../../common/mcpTypes.js';
+import { McpConnectionState, McpServerDefinition, McpServerLaunch } from '../../common/mcpTypes.js';
 import { MCP } from '../../common/modelContextProtocol.js';
 import { TestMcpMessageTransport } from './mcpRegistryTypes.js';
 import { IOutputService } from '../../../../services/output/common/output.js';
@@ -29,6 +29,11 @@ class TestMcpHostDelegate extends Disposable implements IMcpHostDelegate {
 	constructor() {
 		super();
 		this._transport = this._register(new TestMcpMessageTransport());
+	}
+
+
+	substituteVariables(serverDefinition: McpServerDefinition, launch: McpServerLaunch): Promise<McpServerLaunch> {
+		return Promise.resolve(launch);
 	}
 
 	canStart(): boolean {


### PR DESCRIPTION
- Remove the hacky cwd resolution and do the joining in the remote EH
  when appropriate.
- Correctly resolve variables in the remote EH environment instead of local

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
