### PR TITLE
Fix: don't apply inertial scrolling if input device is a mouse.

### DIFF
--- a/src/vs/base/browser/ui/scrollbar/scrollableElement.ts
+++ b/src/vs/base/browser/ui/scrollbar/scrollableElement.ts
@@ -495,7 +495,7 @@ export abstract class AbstractScrollableElement extends Widget {
 			// Check that we are scrolling towards a location which is valid
 			desiredScrollPosition = this._scrollable.validateScrollPosition(desiredScrollPosition);
 
-			if (this._options.inertialScroll && (deltaX || deltaY)) {
+			if (this._options.inertialScroll && (deltaX || deltaY) && !classifier.isPhysicalMouseWheel()) {
 				let startPeriodic = false;
 				// Only start periodic if it's not running
 				if (this._inertialSpeed.X === 0 && this._inertialSpeed.Y === 0) {


### PR DESCRIPTION
This is a quick fix for #256269, where, if inertial scrolling is active, mouse scrolling becomes too fast.
Original pull request for inertial scrolling: #244034 

@alexdima tagging you because you seemed to have been the code owner of this last time!