### PR TITLE
Engineering - use Terrapin for CI builds

### DIFF
--- a/build/azure-pipelines/product-build.yml
+++ b/build/azure-pipelines/product-build.yml
@@ -98,10 +98,7 @@ variables:
   - name: VSCODE_PRIVATE_BUILD
     value: ${{ ne(variables['Build.Repository.Uri'], 'https://github.com/microsoft/vscode.git') }}
   - name: NPM_REGISTRY
-    ${{ if in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI') }}: # disable terrapin when in VSCODE_CIBUILD
-      value: none
-    ${{ else }}:
-      value: ${{ parameters.NPM_REGISTRY }}
+    value: ${{ parameters.NPM_REGISTRY }}
   - name: CARGO_REGISTRY
     value: ${{ parameters.CARGO_REGISTRY }}
   - name: VSCODE_QUALITY


### PR DESCRIPTION
Ensure that the CI build is using Terrapin in order to keep the node_modules cache warm for product builds.