### PR TITLE
Keep accessible view open when switching windows

### DIFF
--- a/src/vs/workbench/contrib/accessibility/browser/accessibleView.ts
+++ b/src/vs/workbench/contrib/accessibility/browser/accessibleView.ts
@@ -631,8 +631,9 @@ export class AccessibleView extends Disposable implements ITextModelContentProvi
 		this._updateToolbar(this._currentProvider.actions, provider.options.type);
 
 		const hide = (e?: KeyboardEvent | IKeyboardEvent): void => {
-			if (!getWindow(this._editorWidget.getDomNode()).document.hasFocus()) {
-				// Window focus changed, keep accessible view active
+			const thisWindowIsFocused = getWindow(this._editorWidget.getDomNode()).document.hasFocus();
+			if (!thisWindowIsFocused) {
+				// When switching windows, keep accessible view open
 				e?.preventDefault();
 				e?.stopPropagation();
 				return;

--- a/src/vs/workbench/contrib/accessibility/browser/accessibleView.ts
+++ b/src/vs/workbench/contrib/accessibility/browser/accessibleView.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { EventType, addDisposableListener, getActiveWindow, isActiveElement } from '../../../../base/browser/dom.js';
+import { EventType, addDisposableListener, getActiveWindow, getWindow, isActiveElement } from '../../../../base/browser/dom.js';
 import { IKeyboardEvent, StandardKeyboardEvent } from '../../../../base/browser/keyboardEvent.js';
 import { ActionsOrientation } from '../../../../base/browser/ui/actionbar/actionbar.js';
 import { alert } from '../../../../base/browser/ui/aria/aria.js';
@@ -631,6 +631,12 @@ export class AccessibleView extends Disposable implements ITextModelContentProvi
 		this._updateToolbar(this._currentProvider.actions, provider.options.type);
 
 		const hide = (e?: KeyboardEvent | IKeyboardEvent): void => {
+			if (!getWindow(this._editorWidget.getDomNode()).document.hasFocus()) {
+				// Window focus changed, keep accessible view active
+				e?.preventDefault();
+				e?.stopPropagation();
+				return;
+			}
 			if (!this._isInQuickPick) {
 				provider.onClose();
 			}


### PR DESCRIPTION
fix #268338

Allows screen reader users to not lose their current position when they use `alt+tab` to move between windows

https://github.com/user-attachments/assets/6de4a91a-33fa-4df0-9734-89e10507aa80

