### PR TITLE
Add context key for skipping global autoapprove setting confirmation

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/languageModelToolsService.ts
+++ b/src/vs/workbench/contrib/chat/browser/languageModelToolsService.ts
@@ -61,6 +61,8 @@ const enum AutoApproveStorageKeys {
 	GlobalAutoApproveOptIn = 'chat.tools.global.autoApprove.optIn'
 }
 
+const SkipAutoApproveConfirmationKey = 'vscode.chat.tools.global.autoApprove.testMode';
+
 export const globalAutoApproveDescription = localize2(
 	{
 		key: 'autoApprove2.markdown',
@@ -531,6 +533,10 @@ export class LanguageModelToolsService extends Disposable implements ILanguageMo
 	private async _checkGlobalAutoApprove(): Promise<boolean> {
 		const optedIn = this._storageService.getBoolean(AutoApproveStorageKeys.GlobalAutoApproveOptIn, StorageScope.APPLICATION, false);
 		if (optedIn) {
+			return true;
+		}
+
+		if (this._contextKeyService.getContextKeyValue(SkipAutoApproveConfirmationKey) === true) {
 			return true;
 		}
 


### PR DESCRIPTION
Intended to be used by vscode-copilot-chat for testing. cc @Tyriar when you're back we can decide whether there's a better way to do this