### PR TITLE
File icon display handling in chat sessions 

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatSessions/view/sessionsTreeRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSessions/view/sessionsTreeRenderer.ts
@@ -58,6 +58,7 @@ interface ISessionTemplateData {
 	readonly descriptionRow: HTMLElement;
 	readonly descriptionLabel: HTMLElement;
 	readonly statisticsLabel: HTMLElement;
+	readonly customIcon: HTMLElement;
 }
 
 export interface IGettingStartedItem {
@@ -189,6 +190,8 @@ export class SessionsRenderer extends Disposable implements ITreeRenderer<IChatS
 
 		// Create a container that holds the label, timestamp, and actions
 		const contentContainer = append(element, $('.session-content'));
+		// Create custom icon element that won't be affected by file icon theme
+		const customIcon = append(contentContainer, $('.chat-session-custom-icon'));
 		const resourceLabel = this.labels.create(contentContainer, { supportHighlights: true });
 		const descriptionRow = append(element, $('.description-row'));
 		const descriptionLabel = append(descriptionRow, $('span.description'));
@@ -205,6 +208,7 @@ export class SessionsRenderer extends Disposable implements ITreeRenderer<IChatS
 		return {
 			container: element,
 			resourceLabel,
+			customIcon,
 			actionBar,
 			elementDisposable,
 			timestamp,
@@ -305,6 +309,20 @@ export class SessionsRenderer extends Disposable implements ITreeRenderer<IChatS
 				} : undefined) :
 			undefined;
 
+		// Handle custom icon rendering (independent of file icon theme)
+		if (iconTheme) {
+			templateData.customIcon.className = `chat-session-custom-icon ${ThemeIcon.asClassName(iconTheme)}`;
+			if (iconTheme.color) {
+				const theme = this.themeService.getColorTheme();
+				templateData.customIcon.style.color = theme.getColor(iconTheme.color.id)?.toString() ?? '';
+			} else {
+				templateData.customIcon.style.color = '';
+			}
+			templateData.customIcon.style.display = 'flex';
+		} else {
+			templateData.customIcon.style.display = 'none';
+		}
+
 		// Set the resource label
 		templateData.resourceLabel.setResource({
 			name: session.label,
@@ -312,7 +330,7 @@ export class SessionsRenderer extends Disposable implements ITreeRenderer<IChatS
 			resource: iconResource
 		}, {
 			fileKind: undefined,
-			icon: iconTheme,
+			hideIcon: true, // Hide the ResourceLabel's icon since we're using custom icon
 			// Set tooltip on resourceLabel only for single-row items
 			title: !renderDescriptionOnSecondRow || !session.description ? tooltipContent : undefined
 		});

--- a/src/vs/workbench/contrib/chat/browser/chatSessions/view/sessionsTreeRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSessions/view/sessionsTreeRenderer.ts
@@ -211,7 +211,7 @@ export class SessionsRenderer extends Disposable implements ITreeRenderer<IChatS
 			iconTheme = session.iconPath;
 		}
 
-		const renderDescriptionOnSecondRow = this.configurationService.getValue(ChatConfiguration.ShowAgentSessionsViewDescription) && session.provider.chatSessionType !== 'local';
+		const renderDescriptionOnSecondRow = this.configurationService.getValue<boolean>(ChatConfiguration.ShowAgentSessionsViewDescription) && session.provider.chatSessionType !== 'local';
 
 		if (renderDescriptionOnSecondRow && session.description) {
 			templateData.container.classList.toggle('multiline', true);
@@ -251,23 +251,14 @@ export class SessionsRenderer extends Disposable implements ITreeRenderer<IChatS
 				} : undefined) :
 			undefined;
 
-		// Handle custom icon rendering
-		if (iconTheme) {
-			templateData.customIcon.className = `chat-session-custom-icon ${ThemeIcon.asClassName(iconTheme)}`;
-			// ensure no stale inline color remains
-			templateData.customIcon.style.color = '';
-			templateData.customIcon.style.display = 'flex';
-		} else {
-			// No icon for this item: hide the element so a recycled template doesn't show a stale icon from a previous row
-			templateData.customIcon.style.display = 'none';
-		}
+		templateData.customIcon.className = iconTheme ? `chat-session-custom-icon ${ThemeIcon.asClassName(iconTheme)}` : '';
 
 		// Set the icon label
 		templateData.iconLabel.setLabel(
 			session.label,
-			!renderDescriptionOnSecondRow && 'description' in session && typeof session.description === 'string' ? session.description : undefined,
+			!renderDescriptionOnSecondRow && typeof session.description === 'string' ? session.description : undefined,
 			{
-				title: !renderDescriptionOnSecondRow || !session.description ? tooltipContent as any : undefined, // match IconLabel API (string | IMarkdownString)
+				title: !renderDescriptionOnSecondRow || !session.description ? tooltipContent : undefined,
 				matches: createMatches(element.filterData)
 			}
 		);

--- a/src/vs/workbench/contrib/chat/browser/chatSessions/view/sessionsTreeRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSessions/view/sessionsTreeRenderer.ts
@@ -317,6 +317,10 @@ export class SessionsRenderer extends Disposable implements ITreeRenderer<IChatS
 			title: !renderDescriptionOnSecondRow || !session.description ? tooltipContent : undefined
 		});
 
+		// Add a CSS class to the container to enable  specific CSS rules
+		templateData.container.classList.add('chat-session-icons-always-visible');
+
+
 		// For two-row items, set tooltip on the container instead
 		if (renderDescriptionOnSecondRow && session.description && tooltipContent) {
 			if (typeof tooltipContent === 'string') {

--- a/src/vs/workbench/contrib/chat/browser/chatSessions/view/sessionsTreeRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSessions/view/sessionsTreeRenderer.ts
@@ -30,7 +30,6 @@ import { IHoverService } from '../../../../../../platform/hover/browser/hover.js
 import { IInstantiationService } from '../../../../../../platform/instantiation/common/instantiation.js';
 import product from '../../../../../../platform/product/common/product.js';
 import { defaultInputBoxStyles } from '../../../../../../platform/theme/browser/defaultStyles.js';
-import { IThemeService } from '../../../../../../platform/theme/common/themeService.js';
 import { IResourceLabel, ResourceLabels } from '../../../../../browser/labels.js';
 import { IconLabel } from '../../../../../../base/browser/ui/iconLabel/iconLabel.js';
 import { IEditableData } from '../../../../../common/views.js';
@@ -113,7 +112,6 @@ export class SessionsRenderer extends Disposable implements ITreeRenderer<IChatS
 	private markdownRenderer: MarkdownRenderer;
 
 	constructor(
-		@IThemeService private readonly themeService: IThemeService,
 		@IContextViewService private readonly contextViewService: IContextViewService,
 		@IConfigurationService private readonly configurationService: IConfigurationService,
 		@IChatSessionsService private readonly chatSessionsService: IChatSessionsService,
@@ -170,7 +168,7 @@ export class SessionsRenderer extends Disposable implements ITreeRenderer<IChatS
 	statusToIcon(status?: ChatSessionStatus) {
 		switch (status) {
 			case ChatSessionStatus.InProgress:
-				return Codicon.loading;
+				return ThemeIcon.modify(Codicon.loading, 'spin');
 			case ChatSessionStatus.Completed:
 				return Codicon.pass;
 			case ChatSessionStatus.Failed:
@@ -256,14 +254,11 @@ export class SessionsRenderer extends Disposable implements ITreeRenderer<IChatS
 		// Handle custom icon rendering
 		if (iconTheme) {
 			templateData.customIcon.className = `chat-session-custom-icon ${ThemeIcon.asClassName(iconTheme)}`;
-			if (iconTheme.color) {
-				const theme = this.themeService.getColorTheme();
-				templateData.customIcon.style.color = theme.getColor(iconTheme.color.id)?.toString() ?? '';
-			} else {
-				templateData.customIcon.style.color = '';
-			}
+			// ensure no stale inline color remains
+			templateData.customIcon.style.color = '';
 			templateData.customIcon.style.display = 'flex';
 		} else {
+			// No icon for this item: hide the element so a recycled template doesn't show a stale icon from a previous row
 			templateData.customIcon.style.display = 'none';
 		}
 

--- a/src/vs/workbench/contrib/chat/browser/chatSessions/view/sessionsTreeRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSessions/view/sessionsTreeRenderer.ts
@@ -317,7 +317,7 @@ export class SessionsRenderer extends Disposable implements ITreeRenderer<IChatS
 			title: !renderDescriptionOnSecondRow || !session.description ? tooltipContent : undefined
 		});
 
-		// Add a CSS class to the container to enable  specific CSS rules
+		// Add CSS class to enable chat session icon visibility when FileIcon setting is disabled
 		templateData.container.classList.add('chat-session-icons-always-visible');
 
 

--- a/src/vs/workbench/contrib/chat/browser/chatSessions/view/sessionsTreeRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSessions/view/sessionsTreeRenderer.ts
@@ -317,10 +317,6 @@ export class SessionsRenderer extends Disposable implements ITreeRenderer<IChatS
 			title: !renderDescriptionOnSecondRow || !session.description ? tooltipContent : undefined
 		});
 
-		// Add CSS class to enable chat session icon visibility when FileIcon setting is disabled
-		templateData.container.classList.add('chat-session-icons-always-visible');
-
-
 		// For two-row items, set tooltip on the container instead
 		if (renderDescriptionOnSecondRow && session.description && tooltipContent) {
 			if (typeof tooltipContent === 'string') {

--- a/src/vs/workbench/contrib/chat/browser/chatSessions/view/sessionsTreeRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSessions/view/sessionsTreeRenderer.ts
@@ -4,14 +4,14 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as DOM from '../../../../../../base/browser/dom.js';
-import { $, append, getActiveWindow } from '../../../../../../base/browser/dom.js';
+import { $, append } from '../../../../../../base/browser/dom.js';
 import { StandardKeyboardEvent } from '../../../../../../base/browser/keyboardEvent.js';
 import { ActionBar } from '../../../../../../base/browser/ui/actionbar/actionbar.js';
 import { InputBox, MessageType } from '../../../../../../base/browser/ui/inputbox/inputBox.js';
 import { IAsyncDataSource, ITreeNode, ITreeRenderer } from '../../../../../../base/browser/ui/tree/tree.js';
 import { timeout } from '../../../../../../base/common/async.js';
 import { Codicon } from '../../../../../../base/common/codicons.js';
-import { FuzzyScore } from '../../../../../../base/common/filters.js';
+import { FuzzyScore, createMatches } from '../../../../../../base/common/filters.js';
 import { createSingleCallFunction } from '../../../../../../base/common/functional.js';
 import { isMarkdownString } from '../../../../../../base/common/htmlContent.js';
 import { KeyCode } from '../../../../../../base/common/keyCodes.js';
@@ -19,7 +19,6 @@ import { Disposable, DisposableStore, IDisposable, toDisposable } from '../../..
 import { MarshalledId } from '../../../../../../base/common/marshallingIds.js';
 import Severity from '../../../../../../base/common/severity.js';
 import { ThemeIcon } from '../../../../../../base/common/themables.js';
-import { URI } from '../../../../../../base/common/uri.js';
 import { MarkdownRenderer } from '../../../../../../editor/browser/widget/markdownRenderer/browser/markdownRenderer.js';
 import * as nls from '../../../../../../nls.js';
 import { getActionBarActions } from '../../../../../../platform/actions/browser/menuEntryActionViewItem.js';
@@ -29,11 +28,11 @@ import { IContextKeyService } from '../../../../../../platform/contextkey/common
 import { IContextViewService } from '../../../../../../platform/contextview/browser/contextView.js';
 import { IHoverService } from '../../../../../../platform/hover/browser/hover.js';
 import { IInstantiationService } from '../../../../../../platform/instantiation/common/instantiation.js';
-import { ILogService } from '../../../../../../platform/log/common/log.js';
 import product from '../../../../../../platform/product/common/product.js';
 import { defaultInputBoxStyles } from '../../../../../../platform/theme/browser/defaultStyles.js';
 import { IThemeService } from '../../../../../../platform/theme/common/themeService.js';
 import { IResourceLabel, ResourceLabels } from '../../../../../browser/labels.js';
+import { IconLabel } from '../../../../../../base/browser/ui/iconLabel/iconLabel.js';
 import { IEditableData } from '../../../../../common/views.js';
 import { IEditorGroupsService } from '../../../../../services/editor/common/editorGroupsService.js';
 import { IChatService } from '../../../common/chatService.js';
@@ -51,7 +50,7 @@ import { getLocalHistoryDateFormatter } from '../../../../localHistory/browser/l
 
 interface ISessionTemplateData {
 	readonly container: HTMLElement;
-	readonly resourceLabel: IResourceLabel;
+	readonly iconLabel: IconLabel;
 	readonly actionBar: ActionBar;
 	readonly elementDisposable: DisposableStore;
 	readonly timestamp: HTMLElement;
@@ -111,13 +110,10 @@ export class GettingStartedRenderer implements IListRenderer<IGettingStartedItem
 
 export class SessionsRenderer extends Disposable implements ITreeRenderer<IChatSessionItem, FuzzyScore, ISessionTemplateData> {
 	static readonly TEMPLATE_ID = 'session';
-	private appliedIconColorStyles = new Set<string>();
 	private markdownRenderer: MarkdownRenderer;
 
 	constructor(
-		private readonly labels: ResourceLabels,
 		@IThemeService private readonly themeService: IThemeService,
-		@ILogService private readonly logService: ILogService,
 		@IContextViewService private readonly contextViewService: IContextViewService,
 		@IConfigurationService private readonly configurationService: IConfigurationService,
 		@IChatSessionsService private readonly chatSessionsService: IChatSessionsService,
@@ -131,54 +127,7 @@ export class SessionsRenderer extends Disposable implements ITreeRenderer<IChatS
 	) {
 		super();
 
-		// Listen for theme changes to clear applied styles
-		this._register(this.themeService.onDidColorThemeChange(() => {
-			this.appliedIconColorStyles.clear();
-		}));
-
 		this.markdownRenderer = instantiationService.createInstance(MarkdownRenderer, {});
-	}
-
-	private applyIconColorStyle(iconId: string, colorId: string): void {
-		const styleKey = `${iconId}-${colorId}`;
-		if (this.appliedIconColorStyles.has(styleKey)) {
-			return; // Already applied
-		}
-
-		const colorTheme = this.themeService.getColorTheme();
-		const color = colorTheme.getColor(colorId);
-
-		if (color) {
-			// Target the ::before pseudo-element where the actual icon is rendered
-			const css = `.monaco-workbench .chat-session-item .monaco-icon-label.codicon-${iconId}::before { color: ${color} !important; }`;
-			const activeWindow = getActiveWindow();
-
-			const styleId = `chat-sessions-icon-${styleKey}`;
-			const existingStyle = activeWindow.document.getElementById(styleId);
-			if (existingStyle) {
-				existingStyle.textContent = css;
-			} else {
-				const styleElement = activeWindow.document.createElement('style');
-				styleElement.id = styleId;
-				styleElement.textContent = css;
-				activeWindow.document.head.appendChild(styleElement);
-
-				// Clean up on dispose
-				this._register({
-					dispose: () => {
-						const activeWin = getActiveWindow();
-						const style = activeWin.document.getElementById(styleId);
-						if (style) {
-							style.remove();
-						}
-					}
-				});
-			}
-
-			this.appliedIconColorStyles.add(styleKey);
-		} else {
-			this.logService.debug('No color found for colorId:', colorId);
-		}
 	}
 
 	get templateId(): string {
@@ -190,9 +139,9 @@ export class SessionsRenderer extends Disposable implements ITreeRenderer<IChatS
 
 		// Create a container that holds the label, timestamp, and actions
 		const contentContainer = append(element, $('.session-content'));
-		// Create custom icon element that won't be affected by file icon theme
+		// Custom icon element rendered separately from label text
 		const customIcon = append(contentContainer, $('.chat-session-custom-icon'));
-		const resourceLabel = this.labels.create(contentContainer, { supportHighlights: true });
+		const iconLabel = new IconLabel(contentContainer, { supportHighlights: true, supportIcons: true });
 		const descriptionRow = append(element, $('.description-row'));
 		const descriptionLabel = append(descriptionRow, $('span.description'));
 		const statisticsLabel = append(descriptionRow, $('span.statistics'));
@@ -207,7 +156,7 @@ export class SessionsRenderer extends Disposable implements ITreeRenderer<IChatS
 
 		return {
 			container: element,
-			resourceLabel,
+			iconLabel,
 			customIcon,
 			actionBar,
 			elementDisposable,
@@ -257,16 +206,11 @@ export class SessionsRenderer extends Disposable implements ITreeRenderer<IChatS
 		templateData.actionBar.clear();
 
 		// Handle different icon types
-		let iconResource: URI | undefined;
 		let iconTheme: ThemeIcon | undefined;
 		if (!session.iconPath && session.id !== LocalChatSessionsProvider.HISTORY_NODE_ID) {
 			iconTheme = this.statusToIcon(session.status);
 		} else {
 			iconTheme = session.iconPath;
-		}
-
-		if (iconTheme?.color?.id) {
-			this.applyIconColorStyle(iconTheme.id, iconTheme.color.id);
 		}
 
 		const renderDescriptionOnSecondRow = this.configurationService.getValue(ChatConfiguration.ShowAgentSessionsViewDescription) && session.provider.chatSessionType !== 'local';
@@ -309,7 +253,7 @@ export class SessionsRenderer extends Disposable implements ITreeRenderer<IChatS
 				} : undefined) :
 			undefined;
 
-		// Handle custom icon rendering (independent of file icon theme)
+		// Handle custom icon rendering
 		if (iconTheme) {
 			templateData.customIcon.className = `chat-session-custom-icon ${ThemeIcon.asClassName(iconTheme)}`;
 			if (iconTheme.color) {
@@ -323,17 +267,15 @@ export class SessionsRenderer extends Disposable implements ITreeRenderer<IChatS
 			templateData.customIcon.style.display = 'none';
 		}
 
-		// Set the resource label
-		templateData.resourceLabel.setResource({
-			name: session.label,
-			description: !renderDescriptionOnSecondRow && 'description' in session && typeof session.description === 'string' ? session.description : '',
-			resource: iconResource
-		}, {
-			fileKind: undefined,
-			hideIcon: true, // Hide the ResourceLabel's icon since we're using custom icon
-			// Set tooltip on resourceLabel only for single-row items
-			title: !renderDescriptionOnSecondRow || !session.description ? tooltipContent : undefined
-		});
+		// Set the icon label
+		templateData.iconLabel.setLabel(
+			session.label,
+			!renderDescriptionOnSecondRow && 'description' in session && typeof session.description === 'string' ? session.description : undefined,
+			{
+				title: !renderDescriptionOnSecondRow || !session.description ? tooltipContent as any : undefined, // match IconLabel API (string | IMarkdownString)
+				matches: createMatches(element.filterData)
+			}
+		);
 
 		// For two-row items, set tooltip on the container instead
 		if (renderDescriptionOnSecondRow && session.description && tooltipContent) {
@@ -416,7 +358,6 @@ export class SessionsRenderer extends Disposable implements ITreeRenderer<IChatS
 
 	disposeElement(_element: ITreeNode<IChatSessionItem, FuzzyScore>, _index: number, templateData: ISessionTemplateData): void {
 		templateData.elementDisposable.clear();
-		templateData.resourceLabel.clear();
 		templateData.actionBar.clear();
 	}
 
@@ -549,7 +490,7 @@ export class SessionsRenderer extends Disposable implements ITreeRenderer<IChatS
 
 	disposeTemplate(templateData: ISessionTemplateData): void {
 		templateData.elementDisposable.dispose();
-		templateData.resourceLabel.dispose();
+		templateData.iconLabel.dispose();
 		templateData.actionBar.dispose();
 	}
 }

--- a/src/vs/workbench/contrib/chat/browser/chatSessions/view/sessionsViewPane.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSessions/view/sessionsViewPane.ts
@@ -295,8 +295,7 @@ export class SessionsViewPane extends ViewPane {
 		const accessibilityProvider = new SessionsAccessibilityProvider();
 
 		// Use the existing ResourceLabels service for consistent styling
-		const labels = this.instantiationService.createInstance(ResourceLabels, { onDidChangeVisibility: this.onDidChangeBodyVisibility });
-		const renderer = this.instantiationService.createInstance(SessionsRenderer, labels);
+		const renderer = this.instantiationService.createInstance(SessionsRenderer);
 		this._register(renderer);
 
 		const getResourceForElement = (element: ChatSessionItemWithProvider): URI | null => {

--- a/src/vs/workbench/contrib/chat/browser/media/chatSessions.css
+++ b/src/vs/workbench/contrib/chat/browser/media/chatSessions.css
@@ -169,16 +169,15 @@
 	text-align: center;
 }
 
-/* Custom chat session icon that bypasses file icon theme */
+/* Chat session icon */
 .chat-sessions-tree-container .chat-session-item .chat-session-custom-icon {
 	flex-shrink: 0;
 	width: 16px;
 	height: 16px;
 	margin-right: 6px;
 	font-size: 16px;
-	color: var(--vscode-icon-foreground);
+	display: flex;
 }
-
 
 /* Timestamp styling - similar to timeline pane */
 .chat-sessions-tree-container .chat-session-item .timestamp-container {

--- a/src/vs/workbench/contrib/chat/browser/media/chatSessions.css
+++ b/src/vs/workbench/contrib/chat/browser/media/chatSessions.css
@@ -173,6 +173,41 @@
 	animation: codicon-spin 1.5s steps(30) infinite;
 }
 
+/* CSS rules to ensure chat session icons are ALWAYS visible */
+/* These rules override the global FileIcon hiding with maximum specificity using the chat-session-icons-always-visible class */
+
+/* Explicit Unicode values for each chat session status icon */
+
+.monaco-workbench:not(.file-icons-enabled) .chat-sessions-tree-container .chat-session-icons-always-visible .codicon-loading::before {
+	content: "\eb19" !important;
+	font-family: codicon !important;
+	display: inline !important;
+}
+
+.monaco-workbench:not(.file-icons-enabled) .chat-sessions-tree-container .chat-session-icons-always-visible .codicon-pass::before {
+	content: "\eba4" !important;
+	font-family: codicon !important;
+	display: inline !important;
+}
+
+.monaco-workbench:not(.file-icons-enabled) .chat-sessions-tree-container .chat-session-icons-always-visible .codicon-error::before {
+	content: "\ea87" !important;
+	font-family: codicon !important;
+	display: inline !important;
+}
+
+.monaco-workbench:not(.file-icons-enabled) .chat-sessions-tree-container .chat-session-icons-always-visible .codicon-circle-outline::before {
+	content: "\eabc" !important;
+	font-family: codicon !important;
+	display: inline !important;
+}
+
+.monaco-workbench:not(.file-icons-enabled) .chat-sessions-tree-container .chat-session-icons-always-visible .codicon-chat-sparkle::before {
+	content: "\ec4f" !important;
+	font-family: codicon !important;
+	display: inline !important;
+}
+
 /* Timestamp styling - similar to timeline pane */
 .chat-sessions-tree-container .chat-session-item .timestamp-container {
 	margin-left: auto;

--- a/src/vs/workbench/contrib/chat/browser/media/chatSessions.css
+++ b/src/vs/workbench/contrib/chat/browser/media/chatSessions.css
@@ -169,8 +169,6 @@
 	text-align: center;
 }
 
-/* Removed old .monaco-icon-label loading spinner rule (no longer used after switching to custom icon element) */
-
 /* Custom chat session icon that bypasses file icon theme */
 .chat-sessions-tree-container .chat-session-item .chat-session-custom-icon {
 	flex-shrink: 0;

--- a/src/vs/workbench/contrib/chat/browser/media/chatSessions.css
+++ b/src/vs/workbench/contrib/chat/browser/media/chatSessions.css
@@ -173,39 +173,30 @@
 	animation: codicon-spin 1.5s steps(30) infinite;
 }
 
-/* CSS rules to ensure chat session icons are ALWAYS visible */
-/* These rules override the global FileIcon hiding with maximum specificity using the chat-session-icons-always-visible class */
-
-/* Explicit Unicode values for each chat session status icon */
-
-.monaco-workbench:not(.file-icons-enabled) .chat-sessions-tree-container .chat-session-icons-always-visible .codicon-loading::before {
-	content: "\eb19" !important;
-	font-family: codicon !important;
-	display: inline !important;
+/* Override global file icon hiding for chat session icons */
+.monaco-workbench:not(.file-icons-enabled) .chat-sessions-tree-container .predefined-file-icon.codicon-loading::before {
+	content: var(--vscode-icon-loading-content) !important;
+	font-family: var(--vscode-icon-loading-font-family, codicon) !important;
 }
 
-.monaco-workbench:not(.file-icons-enabled) .chat-sessions-tree-container .chat-session-icons-always-visible .codicon-pass::before {
-	content: "\eba4" !important;
-	font-family: codicon !important;
-	display: inline !important;
+.monaco-workbench:not(.file-icons-enabled) .chat-sessions-tree-container .predefined-file-icon.codicon-pass::before {
+	content: var(--vscode-icon-pass-content) !important;
+	font-family: var(--vscode-icon-pass-font-family, codicon) !important;
 }
 
-.monaco-workbench:not(.file-icons-enabled) .chat-sessions-tree-container .chat-session-icons-always-visible .codicon-error::before {
-	content: "\ea87" !important;
-	font-family: codicon !important;
-	display: inline !important;
+.monaco-workbench:not(.file-icons-enabled) .chat-sessions-tree-container .predefined-file-icon.codicon-error::before {
+	content: var(--vscode-icon-error-content) !important;
+	font-family: var(--vscode-icon-error-font-family, codicon) !important;
 }
 
-.monaco-workbench:not(.file-icons-enabled) .chat-sessions-tree-container .chat-session-icons-always-visible .codicon-circle-outline::before {
-	content: "\eabc" !important;
-	font-family: codicon !important;
-	display: inline !important;
+.monaco-workbench:not(.file-icons-enabled) .chat-sessions-tree-container .predefined-file-icon.codicon-circle-outline::before {
+	content: var(--vscode-icon-circle-outline-content) !important;
+	font-family: var(--vscode-icon-circle-outline-font-family, codicon) !important;
 }
 
-.monaco-workbench:not(.file-icons-enabled) .chat-sessions-tree-container .chat-session-icons-always-visible .codicon-chat-sparkle::before {
-	content: "\ec4f" !important;
-	font-family: codicon !important;
-	display: inline !important;
+.monaco-workbench:not(.file-icons-enabled) .chat-sessions-tree-container .predefined-file-icon.codicon-chat-sparkle::before {
+	content: var(--vscode-icon-chat-sparkle-content) !important;
+	font-family: var(--vscode-icon-chat-sparkle-font-family, codicon) !important;
 }
 
 /* Timestamp styling - similar to timeline pane */

--- a/src/vs/workbench/contrib/chat/browser/media/chatSessions.css
+++ b/src/vs/workbench/contrib/chat/browser/media/chatSessions.css
@@ -238,7 +238,7 @@
 .chat-sessions-tree-container .monaco-list-row .monaco-tl-twistie {
 	/* Ultra-small indent to separate parent/child without large gutter */
 	visibility: hidden; /* keep layout space */
-	width: 3px; /* tuned down from 6px after feedback */
+	width: 3px;
 	min-width: 3px;
 	padding: 0;
 	margin: 0;

--- a/src/vs/workbench/contrib/chat/browser/media/chatSessions.css
+++ b/src/vs/workbench/contrib/chat/browser/media/chatSessions.css
@@ -169,9 +169,7 @@
 	text-align: center;
 }
 
-.chat-sessions-tree-container .chat-session-item .monaco-icon-label.codicon-loading::before {
-	animation: codicon-spin 1.5s steps(30) infinite;
-}
+/* Removed old .monaco-icon-label loading spinner rule (no longer used after switching to custom icon element) */
 
 /* Custom chat session icon that bypasses file icon theme */
 .chat-sessions-tree-container .chat-session-item .chat-session-custom-icon {
@@ -179,8 +177,6 @@
 	width: 16px;
 	height: 16px;
 	margin-right: 6px;
-	align-items: center;
-	justify-content: center;
 	font-size: 16px;
 	color: var(--vscode-icon-foreground);
 }
@@ -245,8 +241,10 @@
 
 /* Hide twisties for elements that don't have children */
 .chat-sessions-tree-container .monaco-list-row .monaco-tl-twistie {
-	visibility: hidden;
-	width: 0;
+	/* Ultra-small indent to separate parent/child without large gutter */
+	visibility: hidden; /* keep layout space */
+	width: 3px; /* tuned down from 6px after feedback */
+	min-width: 3px;
 	padding: 0;
 	margin: 0;
 }

--- a/src/vs/workbench/contrib/chat/browser/media/chatSessions.css
+++ b/src/vs/workbench/contrib/chat/browser/media/chatSessions.css
@@ -173,33 +173,20 @@
 	animation: codicon-spin 1.5s steps(30) infinite;
 }
 
-/* Override global file icon hiding for chat session icons */
-.monaco-workbench:not(.file-icons-enabled) .chat-sessions-tree-container .predefined-file-icon.codicon-loading::before,
-.monaco-workbench:not(.file-icons-enabled) .chat-sessions-tree-container .predefined-file-icon.codicon-pass::before,
-.monaco-workbench:not(.file-icons-enabled) .chat-sessions-tree-container .predefined-file-icon.codicon-error::before,
-.monaco-workbench:not(.file-icons-enabled) .chat-sessions-tree-container .predefined-file-icon.codicon-circle-outline::before,
-.monaco-workbench:not(.file-icons-enabled) .chat-sessions-tree-container .predefined-file-icon.codicon-chat-sparkle::before {
-	font-family: codicon;
+/* Custom chat session icon that bypasses file icon theme */
+.chat-sessions-tree-container .chat-session-item .chat-session-custom-icon {
+	flex-shrink: 0;
+	width: 16px;
+	height: 16px;
+	margin-right: 6px;
+	align-items: center;
+	justify-content: center;
+	font-size: 16px;
+	color: var(--vscode-icon-foreground);
 }
 
-.monaco-workbench:not(.file-icons-enabled) .chat-sessions-tree-container .predefined-file-icon.codicon-loading::before {
-	content: var(--vscode-icon-loading-content) !important;
-}
-
-.monaco-workbench:not(.file-icons-enabled) .chat-sessions-tree-container .predefined-file-icon.codicon-pass::before {
-	content: var(--vscode-icon-pass-content) !important;
-}
-
-.monaco-workbench:not(.file-icons-enabled) .chat-sessions-tree-container .predefined-file-icon.codicon-error::before {
-	content: var(--vscode-icon-error-content) !important;
-}
-
-.monaco-workbench:not(.file-icons-enabled) .chat-sessions-tree-container .predefined-file-icon.codicon-circle-outline::before {
-	content: var(--vscode-icon-circle-outline-content) !important;
-}
-
-.monaco-workbench:not(.file-icons-enabled) .chat-sessions-tree-container .predefined-file-icon.codicon-chat-sparkle::before {
-	content: var(--vscode-icon-chat-sparkle-content) !important;
+.chat-sessions-tree-container .chat-session-item .chat-session-custom-icon.codicon-loading::before {
+	animation: codicon-spin 1.5s steps(30) infinite;
 }
 
 /* Timestamp styling - similar to timeline pane */

--- a/src/vs/workbench/contrib/chat/browser/media/chatSessions.css
+++ b/src/vs/workbench/contrib/chat/browser/media/chatSessions.css
@@ -179,9 +179,6 @@
 	color: var(--vscode-icon-foreground);
 }
 
-.chat-sessions-tree-container .chat-session-item .chat-session-custom-icon.codicon-loading::before {
-	animation: codicon-spin 1.5s steps(30) infinite;
-}
 
 /* Timestamp styling - similar to timeline pane */
 .chat-sessions-tree-container .chat-session-item .timestamp-container {

--- a/src/vs/workbench/contrib/chat/browser/media/chatSessions.css
+++ b/src/vs/workbench/contrib/chat/browser/media/chatSessions.css
@@ -174,29 +174,32 @@
 }
 
 /* Override global file icon hiding for chat session icons */
+.monaco-workbench:not(.file-icons-enabled) .chat-sessions-tree-container .predefined-file-icon.codicon-loading::before,
+.monaco-workbench:not(.file-icons-enabled) .chat-sessions-tree-container .predefined-file-icon.codicon-pass::before,
+.monaco-workbench:not(.file-icons-enabled) .chat-sessions-tree-container .predefined-file-icon.codicon-error::before,
+.monaco-workbench:not(.file-icons-enabled) .chat-sessions-tree-container .predefined-file-icon.codicon-circle-outline::before,
+.monaco-workbench:not(.file-icons-enabled) .chat-sessions-tree-container .predefined-file-icon.codicon-chat-sparkle::before {
+	font-family: codicon !important;
+}
+
 .monaco-workbench:not(.file-icons-enabled) .chat-sessions-tree-container .predefined-file-icon.codicon-loading::before {
 	content: var(--vscode-icon-loading-content) !important;
-	font-family: var(--vscode-icon-loading-font-family, codicon) !important;
 }
 
 .monaco-workbench:not(.file-icons-enabled) .chat-sessions-tree-container .predefined-file-icon.codicon-pass::before {
 	content: var(--vscode-icon-pass-content) !important;
-	font-family: var(--vscode-icon-pass-font-family, codicon) !important;
 }
 
 .monaco-workbench:not(.file-icons-enabled) .chat-sessions-tree-container .predefined-file-icon.codicon-error::before {
 	content: var(--vscode-icon-error-content) !important;
-	font-family: var(--vscode-icon-error-font-family, codicon) !important;
 }
 
 .monaco-workbench:not(.file-icons-enabled) .chat-sessions-tree-container .predefined-file-icon.codicon-circle-outline::before {
 	content: var(--vscode-icon-circle-outline-content) !important;
-	font-family: var(--vscode-icon-circle-outline-font-family, codicon) !important;
 }
 
 .monaco-workbench:not(.file-icons-enabled) .chat-sessions-tree-container .predefined-file-icon.codicon-chat-sparkle::before {
 	content: var(--vscode-icon-chat-sparkle-content) !important;
-	font-family: var(--vscode-icon-chat-sparkle-font-family, codicon) !important;
 }
 
 /* Timestamp styling - similar to timeline pane */

--- a/src/vs/workbench/contrib/chat/browser/media/chatSessions.css
+++ b/src/vs/workbench/contrib/chat/browser/media/chatSessions.css
@@ -179,7 +179,7 @@
 .monaco-workbench:not(.file-icons-enabled) .chat-sessions-tree-container .predefined-file-icon.codicon-error::before,
 .monaco-workbench:not(.file-icons-enabled) .chat-sessions-tree-container .predefined-file-icon.codicon-circle-outline::before,
 .monaco-workbench:not(.file-icons-enabled) .chat-sessions-tree-container .predefined-file-icon.codicon-chat-sparkle::before {
-	font-family: codicon !important;
+	font-family: codicon;
 }
 
 .monaco-workbench:not(.file-icons-enabled) .chat-sessions-tree-container .predefined-file-icon.codicon-loading::before {


### PR DESCRIPTION
Fixes #265150

Chat session icons use `ThemeIcon` objects (like `Codicon.loading`, `Codicon.pass`, etc.) which get the `predefined-file-icon` CSS class. When file icons are globally disabled, a CSS rule in style.css hides all elements with this class, affecting chat session icons unintentionally. 
This change switches to IconLabel from the current resourceLabel in chatSessions to address this issue.

