### PR TITLE
Add support for MCP servers over Unix domain sockets and named pipes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,6 +49,7 @@
         "node-pty": "1.1.0-beta35",
         "open": "^10.1.2",
         "tas-client-umd": "0.2.0",
+        "undici": "^7.9.0",
         "v8-inspect-profiler": "^0.1.1",
         "vscode-oniguruma": "1.7.0",
         "vscode-regexpp": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
     "node-pty": "1.1.0-beta35",
     "open": "^10.1.2",
     "tas-client-umd": "0.2.0",
+    "undici": "^7.9.0",
     "v8-inspect-profiler": "^0.1.1",
     "vscode-oniguruma": "1.7.0",
     "vscode-regexpp": "^3.1.0",

--- a/src/vs/workbench/api/common/extHostMcp.ts
+++ b/src/vs/workbench/api/common/extHostMcp.ts
@@ -33,9 +33,8 @@ export interface IExtHostMpcService extends ExtHostMcpShape {
 
 export class ExtHostMcpService extends Disposable implements IExtHostMpcService {
 	protected _proxy: MainThreadMcpShape;
-	protected _mcpHttpHandleType = McpHTTPHandle;
 	private readonly _initialProviderPromises = new Set<Promise<void>>();
-	private readonly _sseEventSources = this._register(new DisposableMap<number, McpHTTPHandle>());
+	protected readonly _sseEventSources = this._register(new DisposableMap<number, McpHTTPHandle>());
 	private readonly _unresolvedMcpServers = new Map</* collectionId */ string, {
 		provider: vscode.McpServerDefinitionProvider;
 		servers: vscode.McpServerDefinition[];
@@ -43,7 +42,7 @@ export class ExtHostMcpService extends Disposable implements IExtHostMpcService 
 
 	constructor(
 		@IExtHostRpcService extHostRpc: IExtHostRpcService,
-		@ILogService private readonly _logService: ILogService,
+		@ILogService protected readonly _logService: ILogService,
 		@IExtHostInitDataService private readonly _extHostInitData: IExtHostInitDataService,
 		@IExtHostWorkspace protected readonly _workspaceService: IExtHostWorkspace,
 		@IExtHostVariableResolverProvider private readonly _variableResolver: IExtHostVariableResolverProvider,
@@ -58,7 +57,7 @@ export class ExtHostMcpService extends Disposable implements IExtHostMpcService 
 
 	protected _startMcp(id: number, launch: McpServerLaunch, _defaultCwd?: URI, errorOnUserInteraction?: boolean): void {
 		if (launch.type === McpServerTransportType.HTTP) {
-			this._sseEventSources.set(id, new this._mcpHttpHandleType(id, launch, this._proxy, this._logService, errorOnUserInteraction));
+			this._sseEventSources.set(id, new McpHTTPHandle(id, launch, this._proxy, this._logService, errorOnUserInteraction));
 			return;
 		}
 

--- a/src/vs/workbench/api/node/extHostMcpNode.ts
+++ b/src/vs/workbench/api/node/extHostMcpNode.ts
@@ -10,6 +10,7 @@ import { homedir } from 'os';
 import type { RequestInit as UndiciRequestInit } from 'undici';
 import { parseEnvFile } from '../../../base/common/envfile.js';
 import { untildify } from '../../../base/common/labels.js';
+import { Lazy } from '../../../base/common/lazy.js';
 import { DisposableMap } from '../../../base/common/lifecycle.js';
 import * as path from '../../../base/common/path.js';
 import { URI } from '../../../base/common/uri.js';
@@ -139,8 +140,11 @@ export class NodeExtHostMpcService extends ExtHostMcpService {
 }
 
 class McpHTTPHandleNode extends McpHTTPHandle {
+	private readonly _undici = new Lazy(() => import('undici'));
+
 	protected override async _fetchInternal(url: string, init?: CommonRequestInit): Promise<Response> {
-		const { fetch, Agent } = await import('undici');
+		// Note: imported async so that we can ensure we load undici after proxy patches have been applied
+		const { fetch, Agent } = await this._undici.value;
 
 		const undiciInit: UndiciRequestInit = { ...init };
 

--- a/src/vs/workbench/api/node/extHostMcpNode.ts
+++ b/src/vs/workbench/api/node/extHostMcpNode.ts
@@ -6,6 +6,8 @@
 import { ChildProcessWithoutNullStreams, spawn } from 'child_process';
 import { readFile } from 'fs/promises';
 import { homedir } from 'os';
+// eslint-disable-next-line local/code-import-patterns
+import type { RequestInit as UndiciRequestInit } from 'undici';
 import { parseEnvFile } from '../../../base/common/envfile.js';
 import { untildify } from '../../../base/common/labels.js';
 import { DisposableMap } from '../../../base/common/lifecycle.js';
@@ -140,7 +142,7 @@ class McpHTTPHandleNode extends McpHTTPHandle {
 	protected override async _fetchInternal(url: string, init?: CommonRequestInit): Promise<Response> {
 		const { fetch, Agent } = await import('undici');
 
-		const undiciInit = { ...init, dispatcher: undefined as any };
+		const undiciInit: UndiciRequestInit = { ...init };
 
 		let httpUrl = url;
 		const uri = URI.parse(url);

--- a/src/vs/workbench/api/node/extHostMcpNode.ts
+++ b/src/vs/workbench/api/node/extHostMcpNode.ts
@@ -22,13 +22,13 @@ import { McpStdioStateHandler } from '../../contrib/mcp/node/mcpStdioStateHandle
 import { CommonRequestInit, ExtHostMcpService, McpHTTPHandle } from '../common/extHostMcp.js';
 
 export class NodeExtHostMpcService extends ExtHostMcpService {
-	protected override _mcpHttpHandleType = McpHTTPHandleNode;
-
 	private nodeServers = this._register(new DisposableMap<number, McpStdioStateHandler>());
 
 	protected override _startMcp(id: number, launch: McpServerLaunch, defaultCwd?: URI, errorOnUserInteraction?: boolean): void {
 		if (launch.type === McpServerTransportType.Stdio) {
 			this.startNodeMpc(id, launch, defaultCwd);
+		} else if (launch.type === McpServerTransportType.HTTP) {
+			this._sseEventSources.set(id, new McpHTTPHandleNode(id, launch, this._proxy, this._logService, errorOnUserInteraction));
 		} else {
 			super._startMcp(id, launch, defaultCwd, errorOnUserInteraction);
 		}


### PR DESCRIPTION
Fixes #268487.

This PR adds support for doing StreamableHTTP MCP servers over Unix domain sockets and named pipes. For local MCP servers, this is generally more secure than standard localhost HTTP. Standard IO servers are still preferable for local MCP servers, but some scenarios are better served by StreambleHTTP--for example, an MCP server can be hosted in the extension host process by an extension using this approach.

/cc @connor4312

Below is some sample extension code. In practice, a random pipe/socket name should be used, and permissions enforced as well, but this shows the gist.

```typescript
export function activate() {

    const isWindows = os.platform() === 'win32';
    const socketPath = isWindows ? '\\\\.\\pipe\\hello-world' : path.join(os.tmpdir(), 'hello-world.sock');

    const socketUri = vscode.Uri.from({
        scheme: isWindows ? 'pipe' : 'unix',
        path: socketPath,
        fragment: '/mcp' // The express app below is configured to serve MCP over the `/mcp` route
    });

    vscode.lm.registerMcpServerDefinitionProvider('hello-world', {
        provideMcpServerDefinitions(token: vscode.CancellationToken): vscode.McpServerDefinition[] {
            return [
                new vscode.McpHttpServerDefinition(
                    'hello-world',
                    socketUri,
                ),
            ];
        },
        resolveMcpServerDefinition(server: vscode.McpServerDefinition, token: vscode.CancellationToken): vscode.McpServerDefinition {
            startMcpServer(socketPath); // Additionally, the server should also be closed on extension deactivation
            return server;
        }
    });

}

function startMcpServer(socketPath: string) {
    // Uses express, same as the MCP TypeScript SDK examples
    const app = express();

    // MCP StreamableHTTP server setup, refer to examples at https://www.npmjs.com/package/@modelcontextprotocol/sdk#streamable-http
    // ...

    // Listen on the socket/named pipe
    app.listen(socketPath);
}
```

