### PR TITLE
api: allow byok model providers to hint at good edit tools

### DIFF
--- a/src/vs/workbench/api/common/extHostLanguageModels.ts
+++ b/src/vs/workbench/api/common/extHostLanguageModels.ts
@@ -172,7 +172,7 @@ export class ExtHostLanguageModels implements ExtHostLanguageModelsShape {
 		this._clearModelCache(vendor);
 		// TODO @lramos15 - Remove this old prepare method support in debt week
 		const modelInformation: vscode.LanguageModelChatInformation[] = (data.provider.provideLanguageModelChatInformation ? await data.provider.provideLanguageModelChatInformation(options, token) : await (data.provider as any).prepareLanguageModelChatInformation(options, token)) ?? [];
-		const modelMetadataAndIdentifier: ILanguageModelChatMetadataAndIdentifier[] = modelInformation.map(m => {
+		const modelMetadataAndIdentifier: ILanguageModelChatMetadataAndIdentifier[] = modelInformation.map((m): ILanguageModelChatMetadataAndIdentifier => {
 			let auth;
 			if (m.requiresAuthorization && isProposedApiEnabled(data.extension, 'chatProvider')) {
 				auth = {
@@ -180,6 +180,10 @@ export class ExtHostLanguageModels implements ExtHostLanguageModelsShape {
 					accountLabel: typeof m.requiresAuthorization === 'object' ? m.requiresAuthorization.label : undefined
 				};
 			}
+			if (m.capabilities.editTools) {
+				checkProposedApiEnabled(data.extension, 'chatProvider');
+			}
+
 			return {
 				metadata: {
 					extension: data.extension.identifier,
@@ -199,6 +203,7 @@ export class ExtHostLanguageModels implements ExtHostLanguageModelsShape {
 					modelPickerCategory: m.category ?? DEFAULT_MODEL_PICKER_CATEGORY,
 					capabilities: m.capabilities ? {
 						vision: m.capabilities.imageInput,
+						editTools: m.capabilities.editTools,
 						toolCalling: !!m.capabilities.toolCalling,
 						agentMode: !!m.capabilities.toolCalling
 					} : undefined,
@@ -360,6 +365,7 @@ export class ExtHostLanguageModels implements ExtHostLanguageModelsShape {
 				capabilities: {
 					supportsImageToText: model.metadata.capabilities?.vision ?? false,
 					supportsToolCalling: !!model.metadata.capabilities?.toolCalling,
+					editToolsHint: model.metadata.capabilities?.editTools,
 				},
 				maxInputTokens: model.metadata.maxInputTokens,
 				countTokens(text, token) {

--- a/src/vs/workbench/contrib/chat/common/languageModels.ts
+++ b/src/vs/workbench/contrib/chat/common/languageModels.ts
@@ -177,6 +177,7 @@ export interface ILanguageModelChatMetadata {
 		readonly vision?: boolean;
 		readonly toolCalling?: boolean;
 		readonly agentMode?: boolean;
+		readonly editTools?: ReadonlyArray<string>;
 	};
 }
 

--- a/src/vscode-dts/vscode.d.ts
+++ b/src/vscode-dts/vscode.d.ts
@@ -20493,20 +20493,24 @@ declare module 'vscode' {
 		/**
 		 * Various features that the model supports such as tool calling or image input.
 		 */
-		readonly capabilities: {
+		readonly capabilities: LanguageModelChatCapabilities;
+	}
 
-			/**
-			 * Whether image input is supported by the model.
-			 * Common supported images are jpg and png, but each model will vary in supported mimetypes.
-			 */
-			readonly imageInput?: boolean;
+	/**
+	 * Various features that the {@link LanguageModelChatInformation} supports such as tool calling or image input.
+	 */
+	export interface LanguageModelChatCapabilities {
+		/**
+		 * Whether image input is supported by the model.
+		 * Common supported images are jpg and png, but each model will vary in supported mimetypes.
+		 */
+		readonly imageInput?: boolean;
 
-			/**
-			 * Whether tool calling is supported by the model.
-			 * If a number is provided, that is the maximum number of tools that can be provided in a request to the model.
-			 */
-			readonly toolCalling?: boolean | number;
-		};
+		/**
+		 * Whether tool calling is supported by the model.
+		 * If a number is provided, that is the maximum number of tools that can be provided in a request to the model.
+		 */
+		readonly toolCalling?: boolean | number;
 	}
 
 	/**

--- a/src/vscode-dts/vscode.proposed.chatProvider.d.ts
+++ b/src/vscode-dts/vscode.proposed.chatProvider.d.ts
@@ -56,6 +56,25 @@ declare module 'vscode' {
 		readonly statusIcon?: ThemeIcon;
 	}
 
+	export interface LanguageModelChatCapabilities {
+		/**
+		 * The tools the model prefers for making file edits. If not provided or if none of the tools,
+		 * are recognized, the editor will try multiple edit tools and pick the best one. The available
+		 * edit tools WILL change over time and this capability only serves as a hint to the editor.
+		 *
+		 * Edit tools currently recognized include:
+		 * - 'find-replace': Find and replace text in a document.
+		 * - 'multi-find-replace': Find and replace text in a document.
+		 * - 'apply-patch': A file-oriented diff format used by some OpenAI models
+		 * - 'code-rewrite': A general but slower editing tool that allows the model
+		 *   to rewrite and code snippet and provide only the replacement to the editor.
+		 *
+		 * The order of edit tools in this array has no significance; all of the recognized edit
+		 * tools will be made available to the model.
+		 */
+		readonly editTools?: string[];
+	}
+
 	export type LanguageModelResponsePart2 = LanguageModelResponsePart | LanguageModelDataPart | LanguageModelThinkingPart;
 
 	export interface LanguageModelChatProvider<T extends LanguageModelChatInformation = LanguageModelChatInformation> {

--- a/src/vscode-dts/vscode.proposed.chatProvider.d.ts
+++ b/src/vscode-dts/vscode.proposed.chatProvider.d.ts
@@ -64,7 +64,7 @@ declare module 'vscode' {
 		 *
 		 * Edit tools currently recognized include:
 		 * - 'find-replace': Find and replace text in a document.
-		 * - 'multi-find-replace': Find and replace text in a document.
+		 * - 'multi-find-replace': Find and replace multiple text snippets across documents.
 		 * - 'apply-patch': A file-oriented diff format used by some OpenAI models
 		 * - 'code-rewrite': A general but slower editing tool that allows the model
 		 *   to rewrite and code snippet and provide only the replacement to the editor.

--- a/src/vscode-dts/vscode.proposed.languageModelCapabilities.d.ts
+++ b/src/vscode-dts/vscode.proposed.languageModelCapabilities.d.ts
@@ -20,6 +20,11 @@ declare module 'vscode' {
 			 * Whether the language model supports image to text. This means it can take an image as input and produce a text response.
 			 */
 			readonly supportsImageToText: boolean;
+
+			/**
+			 * The tools the model prefers for making file edits. See {@link LanguageModelChatCapabilities.editTools}.
+			 */
+			readonly editToolsHint?: readonly string[];
 		};
 	}
 }


### PR DESCRIPTION
For our own models, we set up the edit tools they get. For generic open-
ended providers like OpenRouter, we will have a 'learning' functionality.
But for BYOK providers that can provide a curated set of models (e.g.
Cerebras) we should let them tell us what edit tool is appropriate for
models they give us so users have a good experience from request 0.

The API is intentionally loose because edit tools continue to evolve and
our set of available tools will continue to change. So I do not surface
any of these in actual API types, but give a string array of hints the
provider can give us. If in the future none of the tools they hint are
ones we recognize, as the space evolves, then the chat extension will
fall back to its default learning behavior.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
