### PR TITLE
mcp: allow connecting to servers on unix socket/windows pipes

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -827,6 +827,7 @@ export default tseslint.config(
 						'string_decoder',
 						'tas-client-umd',
 						'tls',
+						'undici',
 						'undici-types',
 						'url',
 						'util',

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,6 +49,7 @@
         "node-pty": "1.1.0-beta35",
         "open": "^10.1.2",
         "tas-client-umd": "0.2.0",
+        "undici": "^7.9.0",
         "v8-inspect-profiler": "^0.1.1",
         "vscode-oniguruma": "1.7.0",
         "vscode-regexpp": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
     "node-pty": "1.1.0-beta35",
     "open": "^10.1.2",
     "tas-client-umd": "0.2.0",
+    "undici": "^7.9.0",
     "v8-inspect-profiler": "^0.1.1",
     "vscode-oniguruma": "1.7.0",
     "vscode-regexpp": "^3.1.0",

--- a/src/vs/workbench/api/common/extHostMcp.ts
+++ b/src/vs/workbench/api/common/extHostMcp.ts
@@ -33,9 +33,8 @@ export interface IExtHostMpcService extends ExtHostMcpShape {
 
 export class ExtHostMcpService extends Disposable implements IExtHostMpcService {
 	protected _proxy: MainThreadMcpShape;
-	protected _mcpHttpHandleType = McpHTTPHandle;
 	private readonly _initialProviderPromises = new Set<Promise<void>>();
-	private readonly _sseEventSources = this._register(new DisposableMap<number, McpHTTPHandle>());
+	protected readonly _sseEventSources = this._register(new DisposableMap<number, McpHTTPHandle>());
 	private readonly _unresolvedMcpServers = new Map</* collectionId */ string, {
 		provider: vscode.McpServerDefinitionProvider;
 		servers: vscode.McpServerDefinition[];
@@ -43,7 +42,7 @@ export class ExtHostMcpService extends Disposable implements IExtHostMpcService 
 
 	constructor(
 		@IExtHostRpcService extHostRpc: IExtHostRpcService,
-		@ILogService private readonly _logService: ILogService,
+		@ILogService protected readonly _logService: ILogService,
 		@IExtHostInitDataService private readonly _extHostInitData: IExtHostInitDataService,
 		@IExtHostWorkspace protected readonly _workspaceService: IExtHostWorkspace,
 		@IExtHostVariableResolverProvider private readonly _variableResolver: IExtHostVariableResolverProvider,
@@ -58,7 +57,7 @@ export class ExtHostMcpService extends Disposable implements IExtHostMpcService 
 
 	protected _startMcp(id: number, launch: McpServerLaunch, _defaultCwd?: URI, errorOnUserInteraction?: boolean): void {
 		if (launch.type === McpServerTransportType.HTTP) {
-			this._sseEventSources.set(id, new this._mcpHttpHandleType(id, launch, this._proxy, this._logService, errorOnUserInteraction));
+			this._sseEventSources.set(id, new McpHTTPHandle(id, launch, this._proxy, this._logService, errorOnUserInteraction));
 			return;
 		}
 

--- a/src/vs/workbench/api/node/extHostMcpNode.ts
+++ b/src/vs/workbench/api/node/extHostMcpNode.ts
@@ -10,6 +10,7 @@ import { homedir } from 'os';
 import type { RequestInit as UndiciRequestInit } from 'undici';
 import { parseEnvFile } from '../../../base/common/envfile.js';
 import { untildify } from '../../../base/common/labels.js';
+import { Lazy } from '../../../base/common/lazy.js';
 import { DisposableMap } from '../../../base/common/lifecycle.js';
 import * as path from '../../../base/common/path.js';
 import { URI } from '../../../base/common/uri.js';
@@ -139,8 +140,11 @@ export class NodeExtHostMpcService extends ExtHostMcpService {
 }
 
 class McpHTTPHandleNode extends McpHTTPHandle {
+	private readonly _undici = new Lazy(() => import('undici'));
+
 	protected override async _fetchInternal(url: string, init?: CommonRequestInit): Promise<Response> {
-		const { fetch, Agent } = await import('undici');
+		// Note: imported async so that we can ensure we load undici after proxy patches have been applied
+		const { fetch, Agent } = await this._undici.value;
 
 		const undiciInit: UndiciRequestInit = { ...init };
 

--- a/src/vs/workbench/api/node/extHostMcpNode.ts
+++ b/src/vs/workbench/api/node/extHostMcpNode.ts
@@ -6,7 +6,6 @@
 import { ChildProcessWithoutNullStreams, spawn } from 'child_process';
 import { readFile } from 'fs/promises';
 import { homedir } from 'os';
-// eslint-disable-next-line local/code-import-patterns
 import type { RequestInit as UndiciRequestInit } from 'undici';
 import { parseEnvFile } from '../../../base/common/envfile.js';
 import { untildify } from '../../../base/common/labels.js';
@@ -159,13 +158,11 @@ class McpHTTPHandleNode extends McpHTTPHandle {
 			});
 
 			// And then rewrite the URL to be http://localhost/<fragment>
-			httpUrl = uri
-				.with({
-					scheme: 'http',
-					authority: 'localhost', // HTTP always wants a host (not that we're using it), but if we're using a socket or pipe then localhost is sorta right anyway
-					path: uri.fragment,
-				})
-				.toString(true);
+			httpUrl = uri.with({
+				scheme: 'http',
+				authority: 'localhost', // HTTP always wants a host (not that we're using it), but if we're using a socket or pipe then localhost is sorta right anyway
+				path: uri.fragment,
+			}).toString(true);
 		}
 
 		const undiciResponse = await fetch(httpUrl, undiciInit);

--- a/src/vs/workbench/api/node/extHostMcpNode.ts
+++ b/src/vs/workbench/api/node/extHostMcpNode.ts
@@ -6,6 +6,8 @@
 import { ChildProcessWithoutNullStreams, spawn } from 'child_process';
 import { readFile } from 'fs/promises';
 import { homedir } from 'os';
+// eslint-disable-next-line local/code-import-patterns
+import type { RequestInit as UndiciRequestInit } from 'undici';
 import { parseEnvFile } from '../../../base/common/envfile.js';
 import { untildify } from '../../../base/common/labels.js';
 import { DisposableMap } from '../../../base/common/lifecycle.js';
@@ -140,7 +142,7 @@ class McpHTTPHandleNode extends McpHTTPHandle {
 	protected override async _fetchInternal(url: string, init?: CommonRequestInit): Promise<Response> {
 		const { fetch, Agent } = await import('undici');
 
-		const undiciInit = { ...init, dispatcher: undefined as any };
+		const undiciInit: UndiciRequestInit = { ...init };
 
 		let httpUrl = url;
 		const uri = URI.parse(url);

--- a/src/vs/workbench/api/node/extHostMcpNode.ts
+++ b/src/vs/workbench/api/node/extHostMcpNode.ts
@@ -22,13 +22,13 @@ import { McpStdioStateHandler } from '../../contrib/mcp/node/mcpStdioStateHandle
 import { CommonRequestInit, ExtHostMcpService, McpHTTPHandle } from '../common/extHostMcp.js';
 
 export class NodeExtHostMpcService extends ExtHostMcpService {
-	protected override _mcpHttpHandleType = McpHTTPHandleNode;
-
 	private nodeServers = this._register(new DisposableMap<number, McpStdioStateHandler>());
 
 	protected override _startMcp(id: number, launch: McpServerLaunch, defaultCwd?: URI, errorOnUserInteraction?: boolean): void {
 		if (launch.type === McpServerTransportType.Stdio) {
 			this.startNodeMpc(id, launch, defaultCwd);
+		} else if (launch.type === McpServerTransportType.HTTP) {
+			this._sseEventSources.set(id, new McpHTTPHandleNode(id, launch, this._proxy, this._logService, errorOnUserInteraction));
 		} else {
 			super._startMcp(id, launch, defaultCwd, errorOnUserInteraction);
 		}


### PR DESCRIPTION
#268488 from me since it touches package.json. Note that `undici` was already a transitive dependency we had in the extension host, so there is no bundle size change from the dependency.