### PR TITLE
fix: pin SDK version

### DIFF
--- a/test/mcp/package-lock.json
+++ b/test/mcp/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.18.2",
+        "@modelcontextprotocol/sdk": "1.18.1",
         "@playwright/mcp": "^0.0.37",
         "cors": "^2.8.5",
         "express": "^5.1.0",
@@ -27,9 +27,9 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.18.2",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.18.2.tgz",
-      "integrity": "sha512-beedclIvFcCnPrYgHsylqiYJVJ/CI47Vyc4tY8no1/Li/O8U4BTlJfy6ZwxkYwx+Mx10nrgwSVrA7VBbhh4slg==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.18.1.tgz",
+      "integrity": "sha512-d//GE8/Yh7aC3e7p+kZG8JqqEAwwDUmAfvH1quogtbk+ksS6E0RR6toKKESPYYZVre0meqkJb27zb+dhqE9Sgw==",
       "license": "MIT",
       "dependencies": {
         "ajv": "^6.12.6",

--- a/test/mcp/package.json
+++ b/test/mcp/package.json
@@ -12,7 +12,7 @@
     "start-stdio": "npm run -s compile && node ./out/stdio.js"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.18.2",
+    "@modelcontextprotocol/sdk": "1.18.1",
     "@playwright/mcp": "^0.0.37",
     "cors": "^2.8.5",
     "express": "^5.1.0",


### PR DESCRIPTION
Fixes the build

1.18.2 was released yesterday and isn't available yet in our feed. I'm thinking we can downgrade today and try bumping it up again on Monday.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
