### PR TITLE
fix(markdown-math): prevent KaTeX parsing conflicts with jQuery selectors

### DIFF
--- a/extensions/markdown-math/src/extension.ts
+++ b/extensions/markdown-math/src/extension.ts
@@ -8,6 +8,72 @@ declare function require(path: string): any;
 
 const markdownMathSetting = 'markdown.math';
 
+/**
+ * Determines if a dollar sign followed by parentheses represents a non-mathematical pattern
+ * that should be escaped to prevent KaTeX parsing conflicts.
+ */
+function isNonMathDollarPattern(textAfterDollar: string): boolean {
+	// Match various non-mathematical $ patterns
+	const nonMathPatterns = [
+		// JavaScript/jQuery patterns
+		/^\(["'`][^"'`]*["'`]\)/,           // $("string"), $('string'), $(`string`)
+		/^\(#[^)]+\)/,                      // $(#id) - CSS selectors
+		/^\(\.[^)]+\)/,                     // $(.class) - CSS selectors
+		/^\([a-zA-Z_$][a-zA-Z0-9_$]*\)/,    // $(variable) - JavaScript variables
+		/^\(function\s*\(/,                 // $(function( - jQuery ready
+		/^\(document\)/,                    // $(document)
+		/^\(window\)/,                      // $(window)
+		/^\(this\)/,                        // $(this)
+
+		// Shell/Command patterns
+		/^\([A-Z_][A-Z0-9_]*\)/,           // $(ENVIRONMENT_VAR) - shell variables
+		/^\(echo\s/,                        // $(echo ...) - command substitution
+		/^\(cat\s/,                         // $(cat ...) - command substitution
+		/^\(grep\s/,                        // $(grep ...) - command substitution
+		/^\(find\s/,                        // $(find ...) - command substitution
+		/^\(which\s/,                       // $(which ...) - command substitution
+		/^\(pwd\)/,                         // $(pwd) - command substitution
+		/^\(date\)/,                        // $(date) - command substitution
+		/^\(whoami\)/,                      // $(whoami) - command substitution
+
+		// Programming language patterns
+		/^\(.*\s*[=<>!]+\s*.*\)/,          // $(condition) - conditional expressions
+		/^\([^)]*\.[a-zA-Z_][a-zA-Z0-9_]*\(/,  // $(obj.method()) - method calls
+		/^\([^)]*\[[^\]]+\]\)/,            // $(array[index]) - array access
+
+		// Template/placeholder patterns
+		/^\(\{[^}]+\}\)/,                  // $({placeholder}) - template variables
+		/^\([A-Z][A-Z_]*[A-Z]\)/,          // $(CONSTANT) - constants/env vars
+
+		// Currency when followed by numbers (less common but possible)
+		/^\([0-9]+\.?[0-9]*\)/,            // $(123.45) - currency amounts
+	];
+
+	return nonMathPatterns.some(pattern => pattern.test(textAfterDollar));
+}
+
+/**
+ * Creates a markdown-it preprocessing rule to protect non-mathematical dollar patterns
+ * from being processed by KaTeX.
+ */
+function createDollarSignProtectionRule() {
+	return (state: any) => {
+		// Comprehensive pattern matching for various $ usage contexts
+		state.src = state.src.replace(/\$(?=\()/g, (match: string, offset: number, string: string) => {
+			// Look ahead to see if this looks like a non-math usage
+			const remaining = string.slice(offset + 1);
+
+			if (isNonMathDollarPattern(remaining)) {
+				// Escape the dollar sign to prevent KaTeX from processing it
+				return '\\$';
+			}
+
+			// If it doesn't match known non-math patterns, leave it for potential math processing
+			return match;
+		});
+	};
+}
+
 export function activate(context: vscode.ExtensionContext) {
 	function isEnabled(): boolean {
 		const config = vscode.workspace.getConfiguration('markdown');
@@ -38,6 +104,10 @@ export function activate(context: vscode.ExtensionContext) {
 				md.core.ruler.push('reset-katex-macros', () => {
 					options.macros = { ...settingsMacros };
 				});
+
+				// Add preprocessing rule to handle non-math dollar patterns before KaTeX processing
+				md.core.ruler.before('normalize', 'dollar-sign-protection', createDollarSignProtectionRule());
+
 				return md.use(katex, options);
 			}
 			return md;


### PR DESCRIPTION
fix(markdown-math): prevent KaTeX parsing conflicts with jQuery selectors

Adds preprocessing rule to escape dollar signs in non-mathematical contexts
like,` $("#id"), $("selector")` and shell command substitutions to prevent
KaTeX parse errors.

fix #268378

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
