### PR TITLE
fix: fix focus conflict

### DIFF
--- a/src/vs/editor/browser/controller/editContext/native/nativeEditContextUtils.ts
+++ b/src/vs/editor/browser/controller/editContext/native/nativeEditContextUtils.ts
@@ -63,6 +63,7 @@ export class FocusTracker extends Disposable {
 	public focus(): void {
 		this._domNode.focus();
 		this.refreshFocusState();
+		setTimeout(() => this.refreshFocusState(), 0);
 	}
 
 	public refreshFocusState(): void {


### PR DESCRIPTION
fix #268896

When 2 focusTracers are focused in the same event loop iteration, the first one never receives the blur event, and continue to think it's focused

This PR suggest to check a second time in the next event loop iteration

It happens for instance if VSCode web is initialized with, as `defaultLayout`:
- 2 editor columns
- a different file open in each column by default
- the window not being focused while VSCode is loading

It results in 2 editors thinking they have the focus, and the editor service always give the priority to the first focused editor, so any typed character will go in the first editor, even if the second one is focused

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
