### PR TITLE
remove elicitation prompt on timeout or when user interacts with it

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatElicitationRequestPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatElicitationRequestPart.ts
@@ -6,6 +6,7 @@
 import { IAction } from '../../../../base/common/actions.js';
 import { IMarkdownString } from '../../../../base/common/htmlContent.js';
 import { Disposable } from '../../../../base/common/lifecycle.js';
+import { IObservable, observableValue } from '../../../../base/common/observable.js';
 import { IChatElicitationRequest } from '../common/chatService.js';
 import { ToolDataSource } from '../common/languageModelToolsService.js';
 
@@ -14,7 +15,9 @@ export class ChatElicitationRequestPart extends Disposable implements IChatElici
 	public state: 'pending' | 'accepted' | 'rejected' = 'pending';
 	public acceptedResult?: Record<string, unknown>;
 
-	private _hideOrDisposeCalled = false;
+	private readonly _isHiddenValue = observableValue<boolean>('isHidden', false);
+	public readonly isHidden: IObservable<boolean> = this._isHiddenValue;
+
 	constructor(
 		public readonly title: string | IMarkdownString,
 		public readonly message: string | IMarkdownString,
@@ -26,24 +29,14 @@ export class ChatElicitationRequestPart extends Disposable implements IChatElici
 		public readonly reject?: () => Promise<void>,
 		public readonly source?: ToolDataSource,
 		public readonly moreActions?: IAction[],
-		public readonly onHideOrDispose?: () => void,
+		public readonly onHide?: () => void,
 	) {
 		super();
 	}
 
 	hide(): void {
-		if (!this._hideOrDisposeCalled && this.onHideOrDispose) {
-			this.onHideOrDispose();
-			this._hideOrDisposeCalled = true;
-		}
-	}
-
-	override dispose(): void {
-		if (!this._hideOrDisposeCalled && this.onHideOrDispose) {
-			this.onHideOrDispose();
-			this._hideOrDisposeCalled = true;
-		}
-		super.dispose();
+		this._isHiddenValue.set(true, undefined, undefined);
+		this.onHide?.();
 	}
 
 	public toJSON() {

--- a/src/vs/workbench/contrib/chat/browser/chatElicitationRequestPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatElicitationRequestPart.ts
@@ -37,6 +37,7 @@ export class ChatElicitationRequestPart extends Disposable implements IChatElici
 	hide(): void {
 		this._isHiddenValue.set(true, undefined, undefined);
 		this.onHide?.();
+		this.dispose();
 	}
 
 	public toJSON() {

--- a/src/vs/workbench/contrib/chat/common/chatService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService.ts
@@ -279,7 +279,7 @@ export interface IChatElicitationRequest {
 	accept(value: IAction | true): Promise<void>;
 	reject?: () => Promise<void>;
 	isHidden?: IObservable<boolean>;
-	hide?: () => void;
+	hide?(): void;
 }
 
 export interface IChatThinkingPart {

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/monitoring/outputMonitor.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/monitoring/outputMonitor.ts
@@ -235,7 +235,7 @@ export class OutputMonitor extends Disposable implements IOutputMonitor {
 		]);
 
 		if (race.kind === 'decision') {
-			try { continuePollingPart?.hide(); continuePollingPart?.dispose(); } catch { /* noop */ }
+			try { continuePollingPart?.hide(); } catch { /* noop */ }
 			continuePollingPart = undefined;
 
 			// User explicitly declined to keep waiting, so finish with the timed-out result
@@ -636,10 +636,7 @@ export class OutputMonitor extends Disposable implements IOutputMonitor {
 			this._promptPart = thePart;
 		});
 
-		this._register(token.onCancellationRequested(() => {
-			part.hide();
-			part.dispose();
-		}));
+		this._register(token.onCancellationRequested(() => part.hide()));
 
 		return { promise, part };
 	}

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/monitoring/outputMonitor.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/monitoring/outputMonitor.ts
@@ -119,7 +119,6 @@ export class OutputMonitor extends Disposable implements IOutputMonitor {
 							continue;
 						} else {
 							this._promptPart?.hide();
-							this._promptPart?.dispose();
 							this._promptPart = undefined;
 							break;
 						}
@@ -154,7 +153,6 @@ export class OutputMonitor extends Disposable implements IOutputMonitor {
 				resources
 			};
 			this._promptPart?.hide();
-			this._promptPart?.dispose();
 			this._promptPart = undefined;
 			this._onDidFinishCommand.fire();
 		}
@@ -255,7 +253,7 @@ export class OutputMonitor extends Disposable implements IOutputMonitor {
 			const r = race.r;
 
 			if (r === OutputMonitorState.Idle || r === OutputMonitorState.Cancelled || r === OutputMonitorState.Timeout) {
-				try { continuePollingPart?.hide(); continuePollingPart?.dispose(); } catch { /* noop */ }
+				try { continuePollingPart?.hide(); } catch { /* noop */ }
 				continuePollingPart = undefined;
 				continuePollingDecisionP = undefined;
 
@@ -563,7 +561,6 @@ export class OutputMonitor extends Disposable implements IOutputMonitor {
 		const inputPromise = new Promise<string | undefined>(resolve => {
 			inputDataDisposable = this._register(execution.instance.onDidInputData(() => {
 				part.hide();
-				part.dispose();
 				inputDataDisposable.dispose();
 				this._state = OutputMonitorState.PollingForIdle;
 				resolve(undefined);
@@ -622,7 +619,6 @@ export class OutputMonitor extends Disposable implements IOutputMonitor {
 				async () => {
 					thePart.state = 'rejected';
 					thePart.hide();
-					thePart.dispose();
 					this._promptPart = undefined;
 					try {
 						const r = await (onReject ? onReject() : undefined);

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/monitoring/outputMonitor.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/monitoring/outputMonitor.ts
@@ -119,7 +119,6 @@ export class OutputMonitor extends Disposable implements IOutputMonitor {
 							continue;
 						} else {
 							this._promptPart?.hide();
-							this._promptPart?.dispose();
 							this._promptPart = undefined;
 							break;
 						}
@@ -154,7 +153,6 @@ export class OutputMonitor extends Disposable implements IOutputMonitor {
 				resources
 			};
 			this._promptPart?.hide();
-			this._promptPart?.dispose();
 			this._promptPart = undefined;
 			this._onDidFinishCommand.fire();
 		}
@@ -237,7 +235,7 @@ export class OutputMonitor extends Disposable implements IOutputMonitor {
 		]);
 
 		if (race.kind === 'decision') {
-			try { continuePollingPart?.hide(); continuePollingPart?.dispose?.(); } catch { /* noop */ }
+			try { await continuePollingPart?.hide(); } catch { /* noop */ }
 			continuePollingPart = undefined;
 
 			// User explicitly declined to keep waiting, so finish with the timed-out result
@@ -255,7 +253,7 @@ export class OutputMonitor extends Disposable implements IOutputMonitor {
 			const r = race.r;
 
 			if (r === OutputMonitorState.Idle || r === OutputMonitorState.Cancelled || r === OutputMonitorState.Timeout) {
-				try { continuePollingPart?.hide(); continuePollingPart?.dispose?.(); } catch { /* noop */ }
+				try { await continuePollingPart?.hide(); } catch { /* noop */ }
 				continuePollingPart = undefined;
 				continuePollingDecisionP = undefined;
 
@@ -516,10 +514,9 @@ export class OutputMonitor extends Disposable implements IOutputMonitor {
 		);
 
 		const inputPromise = new Promise<boolean>(resolve => {
-			const inputDataDisposable = this._register(execution.instance.onDidInputData((data) => {
+			const inputDataDisposable = this._register(execution.instance.onDidInputData(async (data) => {
 				if (!data || data === '\r' || data === '\n' || data === '\r\n') {
-					part.hide();
-					part.dispose();
+					await part.hide();
 					inputDataDisposable.dispose();
 					this._state = OutputMonitorState.PollingForIdle;
 					resolve(true);
@@ -562,9 +559,8 @@ export class OutputMonitor extends Disposable implements IOutputMonitor {
 			getMoreActions(suggestedOption, confirmationPrompt)
 		);
 		const inputPromise = new Promise<string | undefined>(resolve => {
-			inputDataDisposable = this._register(execution.instance.onDidInputData(() => {
-				part.hide();
-				part.dispose();
+			inputDataDisposable = this._register(execution.instance.onDidInputData(async () => {
+				await part.hide();
 				inputDataDisposable.dispose();
 				this._state = OutputMonitorState.PollingForIdle;
 				resolve(undefined);
@@ -611,8 +607,7 @@ export class OutputMonitor extends Disposable implements IOutputMonitor {
 				rejectLabel,
 				async (value: IAction | true) => {
 					thePart.state = 'accepted';
-					thePart.hide();
-					thePart.dispose();
+					await thePart.hide();
 					this._promptPart = undefined;
 					try {
 						const r = await (onAccept ? onAccept(value) : undefined);
@@ -623,8 +618,7 @@ export class OutputMonitor extends Disposable implements IOutputMonitor {
 				},
 				async () => {
 					thePart.state = 'rejected';
-					thePart.hide();
-					thePart.dispose();
+					await thePart.hide();
 					this._promptPart = undefined;
 					try {
 						const r = await (onReject ? onReject() : undefined);
@@ -637,6 +631,7 @@ export class OutputMonitor extends Disposable implements IOutputMonitor {
 				moreActions,
 				() => this._outputMonitorTelemetryCounters.inputToolManualShownCount++
 			));
+
 			chatModel.acceptResponseProgress(request, thePart);
 			this._promptPart = thePart;
 		});


### PR DESCRIPTION
fix #268836

This regressed with a recent change I made. Also, noticed the disposes were not happening as expected.

https://github.com/user-attachments/assets/6a09212f-b9e5-496e-beab-bdcd5bf9635b


Before:

<img width="221" height="715" alt="Screenshot 2025-09-29 at 1 10 43 PM" src="https://github.com/user-attachments/assets/1917a038-ebd8-45dd-833e-0e6112aa9c7b" />

After:

<img width="324" height="430" alt="Screenshot 2025-09-29 at 1 10 51 PM" src="https://github.com/user-attachments/assets/3be916f1-9054-44f3-b718-f71cbcc3383d" />

The response always indicates what happened, so I don't think we should keep that prompt in the list.