### PR TITLE
Add request information telemetry

### DIFF
--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -4406,6 +4406,11 @@ export interface IInlineSuggestOptions {
 		*/
 		suppressInlineSuggestions?: string;
 
+		/**
+		* @internal
+		*/
+		requestInformation?: boolean;
+
 		showOnSuggestConflict?: 'always' | 'never' | 'whenSuggestListIsIncomplete';
 	};
 }
@@ -4444,6 +4449,7 @@ class InlineEditorSuggest extends BaseEditorOption<EditorOption.inlineSuggest, I
 			experimental: {
 				suppressInlineSuggestions: '',
 				showOnSuggestConflict: 'never',
+				requestInformation: true,
 			},
 		};
 
@@ -4493,6 +4499,15 @@ class InlineEditorSuggest extends BaseEditorOption<EditorOption.inlineSuggest, I
 					default: defaults.experimental.suppressInlineSuggestions,
 					tags: ['experimental'],
 					description: nls.localize('inlineSuggest.suppressInlineSuggestions', "Suppresses inline completions for specified extension IDs -- comma separated."),
+					experiment: {
+						mode: 'auto'
+					}
+				},
+				'editor.inlineSuggest.experimental.requestInformation': {
+					type: 'boolean',
+					default: defaults.experimental.requestInformation,
+					tags: ['experimental'],
+					description: nls.localize('inlineSuggest.requestInformation', "Controls whether to send request information from the inline suggestion provider."),
 					experiment: {
 						mode: 'auto'
 					}
@@ -4574,6 +4589,7 @@ class InlineEditorSuggest extends BaseEditorOption<EditorOption.inlineSuggest, I
 			experimental: {
 				suppressInlineSuggestions: EditorStringOption.string(input.experimental?.suppressInlineSuggestions, this.defaultValue.experimental.suppressInlineSuggestions),
 				showOnSuggestConflict: stringSet(input.experimental?.showOnSuggestConflict, this.defaultValue.experimental.showOnSuggestConflict, ['always', 'never', 'whenSuggestListIsIncomplete']),
+				requestInformation: boolean(input.experimental?.requestInformation, this.defaultValue.experimental.requestInformation),
 			},
 		};
 	}

--- a/src/vs/editor/common/languages.ts
+++ b/src/vs/editor/common/languages.ts
@@ -1034,6 +1034,7 @@ export type LifetimeSummary = {
 	sameShapeReplacements?: boolean;
 	typingInterval: number;
 	typingIntervalCharacterCount: number;
+	selectedSuggestionInfo: boolean;
 };
 
 export interface CodeAction {

--- a/src/vs/editor/contrib/inlineCompletions/browser/model/provideInlineCompletions.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/model/provideInlineCompletions.ts
@@ -123,6 +123,7 @@ export function provideInlineCompletions(
 	const inlineCompletionLists = AsyncIterableProducer.fromPromisesResolveOrder(providers.map(p => queryProvider.get(p))).filter(isDefined);
 
 	return {
+		contextWithUuid,
 		get didAllProvidersReturn() { return runningCount === 0; },
 		lists: inlineCompletionLists,
 		cancelAndDispose: reason => {
@@ -151,6 +152,8 @@ export function runWhenCancelled(token: CancellationToken, callback: () => void)
 
 export interface IInlineCompletionProviderResult {
 	get didAllProvidersReturn(): boolean;
+
+	contextWithUuid: InlineCompletionContext;
 
 	cancelAndDispose(reason: InlineCompletionsDisposeReason): void;
 
@@ -371,6 +374,7 @@ export class InlineSuggestData {
 			const summary: LifetimeSummary = {
 				requestUuid: this.context.requestUuid,
 				correlationId: this._correlationId,
+				selectedSuggestionInfo: !!this.context.selectedSuggestionInfo,
 				partiallyAccepted: this._partiallyAcceptedCount,
 				partiallyAcceptedCountSinceOriginal: this._partiallyAcceptedSinceOriginal.count,
 				partiallyAcceptedRatioSinceOriginal: this._partiallyAcceptedSinceOriginal.ratio,

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -7674,6 +7674,7 @@ declare namespace monaco.languages {
 		sameShapeReplacements?: boolean;
 		typingInterval: number;
 		typingIntervalCharacterCount: number;
+		selectedSuggestionInfo: boolean;
 	};
 
 	export interface CodeAction {

--- a/src/vs/workbench/api/browser/mainThreadLanguageFeatures.ts
+++ b/src/vs/workbench/api/browser/mainThreadLanguageFeatures.ts
@@ -726,6 +726,7 @@ export class MainThreadLanguageFeatures extends Disposable implements MainThread
 					characterCountModified: lifetimeSummary.characterCountModified,
 					disjointReplacements: lifetimeSummary.disjointReplacements,
 					sameShapeReplacements: lifetimeSummary.sameShapeReplacements,
+					selectedSuggestionInfo: lifetimeSummary.selectedSuggestionInfo,
 					extensionId,
 					extensionVersion,
 					groupId,
@@ -1393,6 +1394,7 @@ type InlineCompletionEndOfLifeEvent = {
 	typingIntervalCharacterCount: number;
 	superseded: boolean;
 	editorType: string;
+	selectedSuggestionInfo: boolean;
 	viewKind: string | undefined;
 	cursorColumnDistance: number | undefined;
 	cursorLineDistance: number | undefined;
@@ -1420,6 +1422,7 @@ type InlineCompletionsEndOfLifeClassification = {
 	timeUntilProviderRequest: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The time it took for the inline completion to be requested from the provider' };
 	timeUntilProviderResponse: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The time it took for the inline completion to be shown after the request' };
 	reason: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The reason for the inline completion ending' };
+	selectedSuggestionInfo: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Whether the inline completion was requested with a selected suggestion' };
 	partiallyAccepted: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'How often the inline completion was partially accepted by the user' };
 	partiallyAcceptedCountSinceOriginal: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'How often the inline completion was partially accepted since the original request' };
 	partiallyAcceptedRatioSinceOriginal: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The percentage of characters accepted since the original request' };


### PR DESCRIPTION
```Copilot Generated Description:``` Introduce a new telemetry feature to send request information from the inline suggestion provider, including the selected suggestion status. This change adds relevant properties to various interfaces and classes to support this telemetry.