### PR TITLE
Improve canSetExpressionValue check

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/variablesView.ts
+++ b/src/vs/workbench/contrib/debug/browser/variablesView.ts
@@ -230,6 +230,10 @@ export class VariablesView extends ViewPane implements IDebugViewWithVariables {
 			return !!e.treeItem.canEdit;
 		}
 
+		if (!session.capabilities?.supportsSetVariable && !session.capabilities?.supportsSetExpression) {
+			return false;
+		}
+
 		return e instanceof Variable && !e.presentationHint?.attributes?.includes('readOnly') && !e.presentationHint?.lazy;
 	}
 


### PR DESCRIPTION
I met unexpected behavior when cmake-tools extensiond din't send `supportsSetVariable` or `supportSetExpressoon` capabilities to VSCode, but UI still displayed an input box in the variables view. I added a simple check to handle this case.

Before:
![before](https://github.com/user-attachments/assets/6bbceb0f-7a78-4f77-bc20-ba12abc67ee9)

After:

![after](https://github.com/user-attachments/assets/e156057f-7140-4e20-a795-b9f6f4c4624b)

