### PR TITLE
mcp: don't trust-prompt workspace MCPs

### DIFF
--- a/src/vs/workbench/contrib/mcp/common/discovery/installedMcpServersDiscovery.ts
+++ b/src/vs/workbench/contrib/mcp/common/discovery/installedMcpServersDiscovery.ts
@@ -120,7 +120,7 @@ export class InstalledMcpServersDiscovery extends Disposable implements IMcpDisc
 					},
 					remoteAuthority: mcpConfigPath?.remoteAuthority ?? null,
 					serverDefinitions: observableValue(this, serverDefinitions),
-					trustBehavior: mcpConfigPath?.workspaceFolder ? McpServerTrust.Kind.TrustedOnNonce : McpServerTrust.Kind.Trusted,
+					trustBehavior: McpServerTrust.Kind.Trusted,
 					configTarget: mcpConfigPath?.target ?? ConfigurationTarget.USER,
 					scope: mcpConfigPath?.scope ?? StorageScope.PROFILE,
 				}));


### PR DESCRIPTION
The concerns for which this was initially added are now covered with the
combination of workspace trust and sensitive file approvals. Trust
workspace MCP's by default.

Closes https://github.com/microsoft/vscode/issues/268882

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
