### PR TITLE
Add ability to copy redirect URIs from dialog

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadAuthentication.ts
+++ b/src/vs/workbench/api/browser/mainThreadAuthentication.ts
@@ -561,16 +561,21 @@ export class MainThreadAuthentication extends Disposable implements MainThreadAu
 	}
 
 	async $promptForClientRegistration(authorizationServerUrl: string): Promise<{ clientId: string; clientSecret?: string } | undefined> {
+		const redirectUrls = 'http://127.0.0.1:33418\nhttps://vscode.dev/redirect';
+
 		// Show modal dialog first to explain the situation and get user consent
 		const result = await this.dialogService.prompt({
 			type: Severity.Info,
 			message: nls.localize('dcrNotSupported', "Dynamic Client Registration not supported"),
-			detail: nls.localize('dcrNotSupportedDetail', "The authorization server '{0}' does not support automatic client registration. Do you want to proceed by manually providing a client registration (client ID)?\n\nNote: When registering your OAuth application, make sure to include these redirect URIs:\nhttp://127.0.0.1:33418\nhttps://vscode.dev/redirect", authorizationServerUrl),
+			detail: nls.localize('dcrNotSupportedDetail', "The authorization server '{0}' does not support automatic client registration. Do you want to proceed by manually providing a client registration (client ID)?\n\nNote: When registering your OAuth application, make sure to include these redirect URIs:\n{1}", authorizationServerUrl, redirectUrls),
 			buttons: [
 				{
-					label: nls.localize('provideClientDetails', "Proceed"),
-					run: () => true
-				}
+					label: nls.localize('dcrCopyUrlsAndProceed', "Copy URIs & Proceed"),
+					run: async () => {
+						await this.clipboardService.writeText(redirectUrls);
+						return true;
+					}
+				},
 			],
 			cancelButton: {
 				label: nls.localize('cancel', "Cancel"),

--- a/src/vs/workbench/api/browser/mainThreadAuthentication.ts
+++ b/src/vs/workbench/api/browser/mainThreadAuthentication.ts
@@ -572,7 +572,11 @@ export class MainThreadAuthentication extends Disposable implements MainThreadAu
 				{
 					label: nls.localize('dcrCopyUrlsAndProceed', "Copy URIs & Proceed"),
 					run: async () => {
-						await this.clipboardService.writeText(redirectUrls);
+						try {
+							await this.clipboardService.writeText(redirectUrls);
+						} catch (error) {
+							this.notificationService.error(nls.localize('dcrFailedToCopy', "Failed to copy redirect URIs to clipboard."));
+						}
 						return true;
 					}
 				},


### PR DESCRIPTION
Fixes #258525: change Proceed button into "Copy URIs & Proceed" so that URIs are copied to clipboard for user to use them for registration.

<img width="569" height="231" alt="image" src="https://github.com/user-attachments/assets/fa8537c9-d962-42eb-83e5-de0977bdabeb" />

