### PR TITLE
Refactor terminal reconnection to use instances filter

### DIFF
--- a/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts
+++ b/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts
@@ -97,6 +97,8 @@ const QUICKOPEN_HISTORY_LIMIT_CONFIG = 'task.quickOpen.history';
 const PROBLEM_MATCHER_NEVER_CONFIG = 'task.problemMatchers.neverPrompt';
 const USE_SLOW_PICKER = 'task.quickOpen.showAll';
 
+const TaskTerminalType = 'Task';
+
 export namespace ConfigureTaskAction {
 	export const ID = 'workbench.action.tasks.configureTaskRunner';
 	export const TEXT = nls.localize2('ConfigureTaskRunnerAction.label', "Configure Task");
@@ -438,18 +440,17 @@ export abstract class AbstractTaskService extends Disposable implements ITaskSer
 		this._waitForAllSupportedExecutions = new Promise(resolve => {
 			Event.once(this._onDidRegisterAllSupportedExecutions.event)(() => resolve());
 		});
-		if (this._terminalService.getReconnectedTerminals('Task')?.length) {
-			this._attemptTaskReconnection();
-		} else {
-			this._terminalService.whenConnected.then(() => {
-				if (this._terminalService.getReconnectedTerminals('Task')?.length) {
-					this._attemptTaskReconnection();
-				} else {
-					this._tasksReconnected = true;
-					this._onDidReconnectToTasks.fire();
-				}
-			});
-		}
+
+		this._terminalService.whenConnected.then(() => {
+			const reconnectedInstances = this._terminalService.instances.filter(e => e.reconnectionProperties?.ownerId === TaskTerminalType);
+			if (reconnectedInstances.length) {
+				this._attemptTaskReconnection();
+			} else {
+				this._tasksReconnected = true;
+				this._onDidReconnectToTasks.fire();
+			}
+		});
+
 		this._upgrade();
 	}
 

--- a/src/vs/workbench/contrib/tasks/browser/terminalTaskSystem.ts
+++ b/src/vs/workbench/contrib/tasks/browser/terminalTaskSystem.ts
@@ -1387,14 +1387,7 @@ export class TerminalTaskSystem extends Disposable implements ITaskSystem {
 
 	private async _reconnectToTerminal(task: Task): Promise<ITerminalInstance | undefined> {
 		const reconnectedInstances = this._terminalService.instances.filter(e => e.reconnectionProperties?.ownerId === TaskTerminalType);
-		for (let i = 0; i < reconnectedInstances.length; i++) {
-			const terminal = reconnectedInstances[i];
-			if (getReconnectionData(terminal)?.lastTask === task.getCommonTaskId()) {
-				reconnectedInstances.splice(i, 1);
-				return terminal;
-			}
-		}
-		return undefined;
+		return reconnectedInstances.find(e => getReconnectionData(e)?.lastTask === task.getCommonTaskId());
 	}
 
 	private async _doCreateTerminal(task: Task, group: string | undefined, launchConfigs: IShellLaunchConfig): Promise<ITerminalInstance> {
@@ -1436,7 +1429,6 @@ export class TerminalTaskSystem extends Disposable implements ITaskSystem {
 			return;
 		}
 		const reconnectedInstances = this._terminalService.instances.filter(e => e.reconnectionProperties?.ownerId === TaskTerminalType);
-		console.log('TerminalTaskSystem, connect', reconnectedInstances);
 		this._logService.trace(`Attempting reconnection of ${reconnectedInstances.length} terminals`);
 		if (!reconnectedInstances.length) {
 			this._logService.trace(`No terminals to reconnect to so returning`);

--- a/src/vs/workbench/contrib/terminal/browser/terminal.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminal.ts
@@ -354,6 +354,7 @@ export interface ITerminalService extends ITerminalInstanceHost {
 	/**
 	 * An owner of terminals might be created after reconnection has occurred,
 	 * so store them to be requested/adopted later
+	 * @deprecated Use {@link onDidReconnectToSession}
 	 */
 	getReconnectedTerminals(reconnectionOwner: string): ITerminalInstance[] | undefined;
 

--- a/src/vs/workbench/contrib/terminal/browser/terminalService.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalService.ts
@@ -1093,20 +1093,7 @@ export class TerminalService extends Disposable implements ITerminalService {
 			shellLaunchConfig.parentTerminalId = parent.instanceId;
 			instance = group.split(shellLaunchConfig);
 		}
-		this._addToReconnected(instance);
 		return instance;
-	}
-
-	private _addToReconnected(instance: ITerminalInstance): void {
-		if (!instance.reconnectionProperties?.ownerId) {
-			return;
-		}
-		const reconnectedTerminals = this._reconnectedTerminals.get(instance.reconnectionProperties.ownerId);
-		if (reconnectedTerminals) {
-			reconnectedTerminals.push(instance);
-		} else {
-			this._reconnectedTerminals.set(instance.reconnectionProperties.ownerId, [instance]);
-		}
 	}
 
 	private _createTerminal(shellLaunchConfig: IShellLaunchConfig, location: TerminalLocation, options?: ICreateTerminalOptions): ITerminalInstance {
@@ -1120,7 +1107,6 @@ export class TerminalService extends Disposable implements ITerminalService {
 			const group = this._terminalGroupService.createGroup(shellLaunchConfig);
 			instance = group.terminalInstances[0];
 		}
-		this._addToReconnected(instance);
 		return instance;
 	}
 


### PR DESCRIPTION
- Remove deprecated getReconnectedTerminals method usage
- Use instances.filter with reconnectionProperties check
- Clean up _addToReconnected private method
- Simplify terminal reconnection logic in task system
- Add deprecation notice to getReconnectedTerminals

Fixes #268995

---

This removed the possibility of a leak in terminal land and simplifies `ITerminalService`, there are remaining memory leak issues in task land though https://github.com/microsoft/vscode/issues/269006