### PR TITLE
fix: memory leak in folding

### DIFF
--- a/src/vs/editor/contrib/folding/browser/folding.ts
+++ b/src/vs/editor/contrib/folding/browser/folding.ts
@@ -242,6 +242,7 @@ export class FoldingController extends Disposable implements IEditorContribution
 		this.localToDispose.add(this.hiddenRangeModel.onDidChange(hr => this.onHiddenRangesChanges(hr)));
 
 		this.updateScheduler = new Delayer<FoldingModel>(this.updateDebounceInfo.get(model));
+		this.localToDispose.add(this.updateScheduler);
 
 		this.cursorChangedScheduler = new RunOnceScheduler(() => this.revealCursor(), 200);
 		this.localToDispose.add(this.cursorChangedScheduler);


### PR DESCRIPTION
![Untitled](https://github.com/user-attachments/assets/a8c72b15-4107-4da0-aab4-12522c2f4763)


When typing many characters, one can see the number of functions in `FoldingController.triggerFoldingModelChanged`  growing each time. 

Registering the delayer disposable seems to solve the issue.