### PR TITLE
Update keybinding for navigating user chat

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/actions/chatPromptNavigationActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatPromptNavigationActions.ts
@@ -20,7 +20,7 @@ export function registerChatPromptNavigationActions() {
 				id: 'workbench.action.chat.nextUserPrompt',
 				title: localize2('interactive.nextUserPrompt.label', "Next User Prompt"),
 				keybinding: {
-					primary: KeyMod.CtrlCmd | KeyCode.RightArrow,
+					primary: KeyMod.CtrlCmd | KeyCode.DownArrow,
 					weight: KeybindingWeight.WorkbenchContrib,
 					when: ChatContextKeys.inChatSession,
 				},
@@ -41,7 +41,7 @@ export function registerChatPromptNavigationActions() {
 				id: 'workbench.action.chat.previousUserPrompt',
 				title: localize2('interactive.previousUserPrompt.label', "Previous User Prompt"),
 				keybinding: {
-					primary: KeyMod.CtrlCmd | KeyCode.LeftArrow,
+					primary: KeyMod.CtrlCmd | KeyCode.UpArrow,
 					weight: KeybindingWeight.WorkbenchContrib,
 					when: ChatContextKeys.inChatSession,
 				},

--- a/src/vs/workbench/contrib/chat/browser/actions/chatPromptNavigationActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatPromptNavigationActions.ts
@@ -20,7 +20,7 @@ export function registerChatPromptNavigationActions() {
 				id: 'workbench.action.chat.nextUserPrompt',
 				title: localize2('interactive.nextUserPrompt.label', "Next User Prompt"),
 				keybinding: {
-					primary: KeyMod.Shift | KeyCode.DownArrow,
+					primary: KeyMod.CtrlCmd | KeyMod.Alt | KeyCode.DownArrow,
 					weight: KeybindingWeight.WorkbenchContrib,
 					when: ChatContextKeys.inChatSession,
 				},
@@ -41,7 +41,7 @@ export function registerChatPromptNavigationActions() {
 				id: 'workbench.action.chat.previousUserPrompt',
 				title: localize2('interactive.previousUserPrompt.label', "Previous User Prompt"),
 				keybinding: {
-					primary: KeyMod.Shift | KeyCode.UpArrow,
+					primary: KeyMod.CtrlCmd | KeyMod.Alt | KeyCode.UpArrow,
 					weight: KeybindingWeight.WorkbenchContrib,
 					when: ChatContextKeys.inChatSession,
 				},

--- a/src/vs/workbench/contrib/chat/browser/actions/chatPromptNavigationActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatPromptNavigationActions.ts
@@ -20,7 +20,7 @@ export function registerChatPromptNavigationActions() {
 				id: 'workbench.action.chat.nextUserPrompt',
 				title: localize2('interactive.nextUserPrompt.label', "Next User Prompt"),
 				keybinding: {
-					primary: KeyMod.Alt | KeyCode.KeyN,
+					primary: KeyMod.Shift | KeyCode.DownArrow,
 					weight: KeybindingWeight.WorkbenchContrib,
 					when: ChatContextKeys.inChatSession,
 				},
@@ -41,7 +41,7 @@ export function registerChatPromptNavigationActions() {
 				id: 'workbench.action.chat.previousUserPrompt',
 				title: localize2('interactive.previousUserPrompt.label', "Previous User Prompt"),
 				keybinding: {
-					primary: KeyMod.Alt | KeyCode.KeyP,
+					primary: KeyMod.Shift | KeyCode.UpArrow,
 					weight: KeybindingWeight.WorkbenchContrib,
 					when: ChatContextKeys.inChatSession,
 				},

--- a/src/vs/workbench/contrib/chat/browser/actions/chatPromptNavigationActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatPromptNavigationActions.ts
@@ -20,7 +20,7 @@ export function registerChatPromptNavigationActions() {
 				id: 'workbench.action.chat.nextUserPrompt',
 				title: localize2('interactive.nextUserPrompt.label', "Next User Prompt"),
 				keybinding: {
-					primary: KeyMod.CtrlCmd | KeyCode.DownArrow,
+					primary: KeyMod.Alt | KeyCode.KeyN,
 					weight: KeybindingWeight.WorkbenchContrib,
 					when: ChatContextKeys.inChatSession,
 				},
@@ -41,7 +41,7 @@ export function registerChatPromptNavigationActions() {
 				id: 'workbench.action.chat.previousUserPrompt',
 				title: localize2('interactive.previousUserPrompt.label', "Previous User Prompt"),
 				keybinding: {
-					primary: KeyMod.CtrlCmd | KeyCode.UpArrow,
+					primary: KeyMod.Alt | KeyCode.KeyP,
 					weight: KeybindingWeight.WorkbenchContrib,
 					when: ChatContextKeys.inChatSession,
 				},


### PR DESCRIPTION
Update the keybinding from CTRL+Left/Right arrow to CTRL + ALT+ Up/down

Original issue:
[Keyboard shortcut for navigating previous/next chat messages in Chat sidebar · Issue #265417 · microsoft/vscode](https://github.com/microsoft/vscode/issues/265417)

Original PR:
https://github.com/microsoft/vscode/pull/268404