### PR TITLE
Fix name in package-lock

### DIFF
--- a/extensions/mermaid-chat-features/package-lock.json
+++ b/extensions/mermaid-chat-features/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "marmaid-chat-features",
+  "name": "mermaid-chat-features",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "marmaid-chat-features",
+      "name": "mermaid-chat-features",
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
Forgot to check this in too after fixing the main `package.json`. Will cause extra changes when running install