### PR TITLE
Fix alt icon for new chat

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/actions/chatActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatActions.ts
@@ -1056,6 +1056,7 @@ export function registerChatActions() {
 			super({
 				id: ACTION_ID_OPEN_CHAT,
 				title: localize2('interactiveSession.open', "New Chat Editor"),
+				icon: Codicon.plus,
 				f1: true,
 				category: CHAT_CATEGORY,
 				precondition: ChatContextKeys.enabled,


### PR DESCRIPTION
Alt and hover makes the + icon disappear right now

<img width="381" height="150" alt="image" src="https://github.com/user-attachments/assets/dbd7979a-a26f-476f-9521-6fa78f4b9930" />
