### PR TITLE
Git - only show "Resolve in Merge Editor" editor action when conflict markers are present

### DIFF
--- a/extensions/git/package.json
+++ b/extensions/git/package.json
@@ -2297,7 +2297,7 @@
         {
           "command": "git.openMergeEditor",
           "group": "navigation@-10",
-          "when": "config.git.enabled && !git.missing && !isInDiffEditor && !isMergeEditor && resource in git.mergeChanges"
+          "when": "config.git.enabled && !git.missing && !isInDiffEditor && !isMergeEditor && git.activeResourceHasMergeConflicts"
         }
       ],
       "multiDiffEditor/resource/title": [


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/269106