### PR TITLE
Send endOfLife event instead of requestResponse event

### DIFF
--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -4409,7 +4409,7 @@ export interface IInlineSuggestOptions {
 		/**
 		* @internal
 		*/
-		requestInformation?: boolean;
+		emptyResponseInformation?: boolean;
 
 		showOnSuggestConflict?: 'always' | 'never' | 'whenSuggestListIsIncomplete';
 	};
@@ -4449,7 +4449,7 @@ class InlineEditorSuggest extends BaseEditorOption<EditorOption.inlineSuggest, I
 			experimental: {
 				suppressInlineSuggestions: '',
 				showOnSuggestConflict: 'never',
-				requestInformation: true,
+				emptyResponseInformation: true,
 			},
 		};
 
@@ -4503,11 +4503,11 @@ class InlineEditorSuggest extends BaseEditorOption<EditorOption.inlineSuggest, I
 						mode: 'auto'
 					}
 				},
-				'editor.inlineSuggest.experimental.requestInformation': {
+				'editor.inlineSuggest.experimental.emptyResponseInformation': {
 					type: 'boolean',
-					default: defaults.experimental.requestInformation,
+					default: defaults.experimental.emptyResponseInformation,
 					tags: ['experimental'],
-					description: nls.localize('inlineSuggest.requestInformation', "Controls whether to send request information from the inline suggestion provider."),
+					description: nls.localize('inlineSuggest.emptyResponseInformation', "Controls whether to send request information from the inline suggestion provider."),
 					experiment: {
 						mode: 'auto'
 					}
@@ -4589,7 +4589,7 @@ class InlineEditorSuggest extends BaseEditorOption<EditorOption.inlineSuggest, I
 			experimental: {
 				suppressInlineSuggestions: EditorStringOption.string(input.experimental?.suppressInlineSuggestions, this.defaultValue.experimental.suppressInlineSuggestions),
 				showOnSuggestConflict: stringSet(input.experimental?.showOnSuggestConflict, this.defaultValue.experimental.showOnSuggestConflict, ['always', 'never', 'whenSuggestListIsIncomplete']),
-				requestInformation: boolean(input.experimental?.requestInformation, this.defaultValue.experimental.requestInformation),
+				emptyResponseInformation: boolean(input.experimental?.emptyResponseInformation, this.defaultValue.experimental.emptyResponseInformation),
 			},
 		};
 	}

--- a/src/vs/editor/common/languages.ts
+++ b/src/vs/editor/common/languages.ts
@@ -1018,6 +1018,7 @@ export type LifetimeSummary = {
 	timeUntilShown: number | undefined;
 	timeUntilProviderRequest: number;
 	timeUntilProviderResponse: number;
+	notShownReason: string | undefined;
 	editorType: string;
 	viewKind: string | undefined;
 	error: string | undefined;
@@ -1035,6 +1036,7 @@ export type LifetimeSummary = {
 	typingInterval: number;
 	typingIntervalCharacterCount: number;
 	selectedSuggestionInfo: boolean;
+	availableProviders: string;
 };
 
 export interface CodeAction {

--- a/src/vs/editor/contrib/inlineCompletions/browser/model/inlineCompletionsModel.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/model/inlineCompletionsModel.ts
@@ -400,6 +400,7 @@ export class InlineCompletionsModel extends Disposable {
 			reason,
 			typingInterval: typingInterval.averageInterval,
 			typingIntervalCharacterCount: typingInterval.characterCount,
+			availableProviders: [],
 		};
 
 		let context: InlineCompletionContextWithoutUuid = {
@@ -432,6 +433,7 @@ export class InlineCompletionsModel extends Disposable {
 			? { providers: [changeSummary.provider], label: 'single:' + changeSummary.provider.providerId?.toString() }
 			: { providers: this._languageFeaturesService.inlineCompletionsProvider.all(this.textModel), label: undefined }; // TODO: should use inlineCompletionProviders
 		const availableProviders = this.getAvailableProviders(providers.providers);
+		requestInfo.availableProviders = availableProviders.map(p => p.providerId).filter(isDefined);
 
 		return this._source.fetch(availableProviders, providers.label, context, itemToPreserve?.identity, changeSummary.shouldDebounce, userJumpedToActiveCompletion, requestInfo);
 	});

--- a/src/vs/editor/contrib/inlineCompletions/browser/model/inlineSuggestionItem.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/model/inlineSuggestionItem.ts
@@ -126,6 +126,10 @@ abstract class InlineSuggestionItemBase {
 		this._data.setIsPreceeded(item.partialAccepts);
 	}
 
+	public setNotShownReasonIfNotSet(reason: string): void {
+		this._data.setNotShownReason(reason);
+	}
+
 	/**
 	 * Avoid using this method. Instead introduce getters for the needed properties.
 	*/

--- a/src/vs/editor/contrib/inlineCompletions/browser/model/provideInlineCompletions.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/model/provideInlineCompletions.ts
@@ -16,7 +16,7 @@ import { OffsetRange } from '../../../../common/core/ranges/offsetRange.js';
 import { Position } from '../../../../common/core/position.js';
 import { Range } from '../../../../common/core/range.js';
 import { TextReplacement } from '../../../../common/core/edits/textEdit.js';
-import { InlineCompletionEndOfLifeReason, InlineCompletionEndOfLifeReasonKind, InlineCompletionDisplayLocationKind, InlineCompletion, InlineCompletionContext, InlineCompletions, InlineCompletionsProvider, PartialAcceptInfo, InlineCompletionsDisposeReason, LifetimeSummary } from '../../../../common/languages.js';
+import { InlineCompletionEndOfLifeReason, InlineCompletionEndOfLifeReasonKind, InlineCompletionDisplayLocationKind, InlineCompletion, InlineCompletionContext, InlineCompletions, InlineCompletionsProvider, PartialAcceptInfo, InlineCompletionsDisposeReason, LifetimeSummary, ProviderId } from '../../../../common/languages.js';
 import { ILanguageConfigurationService } from '../../../../common/languages/languageConfigurationRegistry.js';
 import { ITextModel } from '../../../../common/model.js';
 import { fixBracketsInLine } from '../../../../common/model/bracketPairsTextModelPart/fixBrackets.js';
@@ -256,6 +256,7 @@ export type InlineSuggestRequestInfo = {
 	reason: string;
 	typingInterval: number;
 	typingIntervalCharacterCount: number;
+	availableProviders: ProviderId[];
 };
 
 export type InlineSuggestProviderRequestInfo = {
@@ -283,6 +284,7 @@ export class InlineSuggestData {
 	private _shownDuration: number = 0;
 	private _showUncollapsedStartTime: number | undefined = undefined;
 	private _showUncollapsedDuration: number = 0;
+	private _notShownReason: string | undefined = undefined;
 
 	private _viewData: InlineSuggestViewData;
 	private _didReportEndOfLife = false;
@@ -390,9 +392,11 @@ export class InlineSuggestData {
 				languageId: this._requestInfo.languageId,
 				requestReason: this._requestInfo.reason,
 				viewKind: this._viewData.viewKind,
+				notShownReason: this._notShownReason,
 				error: this._viewData.error,
 				typingInterval: this._requestInfo.typingInterval,
 				typingIntervalCharacterCount: this._requestInfo.typingIntervalCharacterCount,
+				availableProviders: this._requestInfo.availableProviders.map(p => p.toString()).join(','),
 				...this._viewData.renderData,
 			};
 			this.source.provider.handleEndOfLifetime(this.source.inlineSuggestions, this.sourceInlineCompletion, reason, summary);
@@ -414,6 +418,10 @@ export class InlineSuggestData {
 			console.warn('Expected partiallyAcceptedCountSinceOriginal to be { characters: 0, rate: 0, partialAcceptances: 0 } before setIsPreceeded.');
 		}
 		this._partiallyAcceptedSinceOriginal = partialAccepts;
+	}
+
+	public setNotShownReason(reason: string): void {
+		this._notShownReason ??= reason;
 	}
 
 	/**

--- a/src/vs/editor/contrib/inlineCompletions/browser/telemetry.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/telemetry.ts
@@ -1,0 +1,102 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { DataChannelForwardingTelemetryService } from '../../../../platform/dataChannel/browser/forwardingTelemetryService.js';
+
+export function sendInlineCompletionsEndOfLifeTelemetry(dataChannel: DataChannelForwardingTelemetryService, endOfLLifeSummary: InlineCompletionEndOfLifeEvent) {
+	dataChannel.publicLog2<InlineCompletionEndOfLifeEvent, InlineCompletionsEndOfLifeClassification>('inlineCompletion.endOfLife', endOfLLifeSummary);
+}
+
+export type InlineCompletionEndOfLifeEvent = {
+	// request
+	/**
+	 * @deprecated To be removed at one point in favor of opportunityId
+	 */
+	id: string;
+	opportunityId: string;
+	requestReason: string;
+	editorType: string;
+	languageId: string;
+	typingInterval: number;
+	typingIntervalCharacterCount: number;
+	selectedSuggestionInfo: boolean;
+	availableProviders: string;
+	// response
+	correlationId: string | undefined;
+	extensionId: string;
+	extensionVersion: string;
+	groupId: string | undefined;
+	// behavior
+	shown: boolean;
+	shownDuration: number | undefined;
+	shownDurationUncollapsed: number | undefined;
+	timeUntilShown: number | undefined;
+	timeUntilProviderRequest: number | undefined;
+	timeUntilProviderResponse: number | undefined;
+	reason: 'accepted' | 'rejected' | 'ignored' | undefined;
+	partiallyAccepted: number | undefined;
+	partiallyAcceptedCountSinceOriginal: number | undefined;
+	partiallyAcceptedRatioSinceOriginal: number | undefined;
+	partiallyAcceptedCharactersSinceOriginal: number | undefined;
+	preceeded: boolean | undefined;
+	superseded: boolean | undefined;
+	error: string | undefined;
+	notShownReason: string | undefined;
+	// rendering
+	viewKind: string | undefined;
+	cursorColumnDistance: number | undefined;
+	cursorLineDistance: number | undefined;
+	lineCountOriginal: number | undefined;
+	lineCountModified: number | undefined;
+	characterCountOriginal: number | undefined;
+	characterCountModified: number | undefined;
+	disjointReplacements: number | undefined;
+	sameShapeReplacements: boolean | undefined;
+	// empty
+	noSuggestionReason: string | undefined;
+};
+
+type InlineCompletionsEndOfLifeClassification = {
+	owner: 'benibenj';
+	comment: 'Inline completions ended';
+	id: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The identifier for the inline completion request' };
+	opportunityId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Unique identifier for an opportunity to show an inline completion or NES' };
+	correlationId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The correlation identifier for the inline completion' };
+	extensionId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The identifier for the extension that contributed the inline completion' };
+	extensionVersion: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The version of the extension that contributed the inline completion' };
+	groupId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The group ID of the extension that contributed the inline completion' };
+	availableProviders: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The list of available inline completion providers at the time of the request' };
+	shown: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Whether the inline completion was shown to the user' };
+	shownDuration: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The duration for which the inline completion was shown' };
+	shownDurationUncollapsed: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The duration for which the inline completion was shown without collapsing' };
+	timeUntilShown: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The time it took for the inline completion to be shown after the request' };
+	timeUntilProviderRequest: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The time it took for the inline completion to be requested from the provider' };
+	timeUntilProviderResponse: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The time it took for the inline completion to be shown after the request' };
+	reason: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The reason for the inline completion ending' };
+	selectedSuggestionInfo: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Whether the inline completion was requested with a selected suggestion' };
+	partiallyAccepted: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'How often the inline completion was partially accepted by the user' };
+	partiallyAcceptedCountSinceOriginal: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'How often the inline completion was partially accepted since the original request' };
+	partiallyAcceptedRatioSinceOriginal: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The percentage of characters accepted since the original request' };
+	partiallyAcceptedCharactersSinceOriginal: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The character count accepted since the original request' };
+	preceeded: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Whether the inline completion was preceeded by another one' };
+	languageId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The language ID of the document where the inline completion was shown' };
+	requestReason: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The reason for the inline completion request' };
+	error: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The error message if the inline completion failed' };
+	typingInterval: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The average typing interval of the user at the moment the inline completion was requested' };
+	typingIntervalCharacterCount: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The character count involved in the typing interval calculation' };
+	superseded: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Whether the inline completion was superseded by another one' };
+	editorType: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The type of the editor where the inline completion was shown' };
+	viewKind: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The kind of the view where the inline completion was shown' };
+	cursorColumnDistance: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The distance in columns from the cursor to the inline suggestion' };
+	cursorLineDistance: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The distance in lines from the cursor to the inline suggestion' };
+	lineCountOriginal: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The number of lines in the original text' };
+	lineCountModified: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The number of lines in the modified text' };
+	characterCountOriginal: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The number of characters in the original text' };
+	characterCountModified: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The number of characters in the modified text' };
+	disjointReplacements: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The number of inner replacements made by the inline completion' };
+	sameShapeReplacements: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Whether all inner replacements are the same shape' };
+	noSuggestionReason: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The reason why no inline completion was provided' };
+	notShownReason: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The reason why the inline completion was not shown' };
+};

--- a/src/vs/editor/contrib/inlineCompletions/browser/telemetry.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/telemetry.ts
@@ -5,8 +5,8 @@
 
 import { DataChannelForwardingTelemetryService } from '../../../../platform/dataChannel/browser/forwardingTelemetryService.js';
 
-export function sendInlineCompletionsEndOfLifeTelemetry(dataChannel: DataChannelForwardingTelemetryService, endOfLLifeSummary: InlineCompletionEndOfLifeEvent) {
-	dataChannel.publicLog2<InlineCompletionEndOfLifeEvent, InlineCompletionsEndOfLifeClassification>('inlineCompletion.endOfLife', endOfLLifeSummary);
+export function sendInlineCompletionsEndOfLifeTelemetry(dataChannel: DataChannelForwardingTelemetryService, endOfLifeSummary: InlineCompletionEndOfLifeEvent) {
+	dataChannel.publicLog2<InlineCompletionEndOfLifeEvent, InlineCompletionsEndOfLifeClassification>('inlineCompletion.endOfLife', endOfLifeSummary);
 }
 
 export type InlineCompletionEndOfLifeEvent = {

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -7658,6 +7658,7 @@ declare namespace monaco.languages {
 		timeUntilShown: number | undefined;
 		timeUntilProviderRequest: number;
 		timeUntilProviderResponse: number;
+		notShownReason: string | undefined;
 		editorType: string;
 		viewKind: string | undefined;
 		error: string | undefined;
@@ -7675,6 +7676,7 @@ declare namespace monaco.languages {
 		typingInterval: number;
 		typingIntervalCharacterCount: number;
 		selectedSuggestionInfo: boolean;
+		availableProviders: string;
 	};
 
 	export interface CodeAction {

--- a/src/vs/platform/dataChannel/browser/forwardingTelemetryService.ts
+++ b/src/vs/platform/dataChannel/browser/forwardingTelemetryService.ts
@@ -3,9 +3,9 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ClassifiedEvent, OmitMetadata, IGDPRProperty, StrictPropertyCheck } from '../../../../../platform/telemetry/common/gdprTypings.js';
-import { ITelemetryData, ITelemetryService, TelemetryLevel } from '../../../../../platform/telemetry/common/telemetry.js';
-import { IDataChannelService } from '../../../../../platform/dataChannel/common/dataChannel.js';
+import { ClassifiedEvent, OmitMetadata, IGDPRProperty, StrictPropertyCheck } from '../../telemetry/common/gdprTypings.js';
+import { ITelemetryData, ITelemetryService, TelemetryLevel } from '../../telemetry/common/telemetry.js';
+import { IDataChannelService } from '../common/dataChannel.js';
 
 export class InterceptingTelemetryService implements ITelemetryService {
 	_serviceBrand: undefined;

--- a/src/vs/workbench/contrib/editTelemetry/browser/telemetry/aiEditTelemetry/aiEditTelemetryServiceImpl.ts
+++ b/src/vs/workbench/contrib/editTelemetry/browser/telemetry/aiEditTelemetry/aiEditTelemetryServiceImpl.ts
@@ -8,7 +8,7 @@ import { EditSuggestionId } from '../../../../../../editor/common/textModelEditS
 import { IInstantiationService } from '../../../../../../platform/instantiation/common/instantiation.js';
 import { ITelemetryService } from '../../../../../../platform/telemetry/common/telemetry.js';
 import { TelemetryTrustedValue } from '../../../../../../platform/telemetry/common/telemetryUtils.js';
-import { DataChannelForwardingTelemetryService } from '../forwardingTelemetryService.js';
+import { DataChannelForwardingTelemetryService } from '../../../../../../platform/dataChannel/browser/forwardingTelemetryService.js';
 import { IAiEditTelemetryService, IEditTelemetryCodeAcceptedData, IEditTelemetryCodeSuggestedData } from './aiEditTelemetryService.js';
 
 export class AiEditTelemetryServiceImpl implements IAiEditTelemetryService {

--- a/src/vs/workbench/contrib/editTelemetry/browser/telemetry/arcTelemetrySender.ts
+++ b/src/vs/workbench/contrib/editTelemetry/browser/telemetry/arcTelemetrySender.ts
@@ -17,7 +17,7 @@ import { EditSourceData, IDocumentWithAnnotatedEdits, createDocWithJustReason } 
 import { IAiEditTelemetryService } from './aiEditTelemetry/aiEditTelemetryService.js';
 import { ArcTracker } from '../../common/arcTracker.js';
 import type { ScmRepoBridge } from './editSourceTrackingImpl.js';
-import { forwardToChannelIf, isCopilotLikeExtension } from './forwardingTelemetryService.js';
+import { forwardToChannelIf, isCopilotLikeExtension } from '../../../../../platform/dataChannel/browser/forwardingTelemetryService.js';
 import { ProviderId } from '../../../../../editor/common/languages.js';
 
 export class InlineEditArcTelemetrySender extends Disposable {

--- a/src/vs/workbench/contrib/editTelemetry/browser/telemetry/editSourceTrackingFeature.ts
+++ b/src/vs/workbench/contrib/editTelemetry/browser/telemetry/editSourceTrackingFeature.ts
@@ -23,7 +23,7 @@ import { IStatusbarService, StatusbarAlignment } from '../../../../services/stat
 import { EditSource } from '../helpers/documentWithAnnotatedEdits.js';
 import { EditSourceTrackingImpl } from './editSourceTrackingImpl.js';
 import { AnnotatedDocuments } from '../helpers/annotatedDocuments.js';
-import { DataChannelForwardingTelemetryService } from './forwardingTelemetryService.js';
+import { DataChannelForwardingTelemetryService } from '../../../../../platform/dataChannel/browser/forwardingTelemetryService.js';
 import { EDIT_TELEMETRY_DETAILS_SETTING_ID, EDIT_TELEMETRY_SHOW_DECORATIONS, EDIT_TELEMETRY_SHOW_STATUS_BAR } from '../settings.js';
 import { VSCodeWorkspace } from '../helpers/vscodeObservableWorkspace.js';
 import { IExtensionService } from '../../../../services/extensions/common/extensions.js';


### PR DESCRIPTION
```Copilot Generated Description:``` Modify the inline suggestion handling to send an endOfLife event instead of a requestResponse event, and introduce a mechanism to set a not shown reason for inline suggestions. Additional updates include changes to the LifetimeSummary type and related interfaces to accommodate these adjustments.