### PR TITLE
rm unneeded content from chat response aria label

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatAccessibilityProvider.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatAccessibilityProvider.ts
@@ -88,20 +88,6 @@ export class ChatAccessibilityProvider implements IListAccessibilityProvider<Cha
 			const waitingForConfirmation = toolInvocation.filter(v => !v.isComplete);
 			if (waitingForConfirmation.length) {
 				toolInvocationHint = this._instantiationService.invokeFunction(getToolConfirmationAlert, toolInvocation);
-			} else { // all completed
-				for (const invocation of toolInvocation) {
-					const titleObj = invocation.confirmationMessages?.title;
-					let title = '';
-					if (typeof titleObj === 'string' && titleObj.trim()) {
-						title = titleObj;
-					} else if (titleObj && typeof titleObj === 'object' && 'value' in titleObj && titleObj.value && titleObj.value.trim()) {
-						title = titleObj.value;
-					} else {
-						// Fallback to toolId if no valid title
-						title = invocation.toolId;
-					}
-					toolInvocationHint += localize('toolCompletedHint', "Tool {0} completed.", title);
-				}
 			}
 		}
 		const tableCount = marked.lexer(element.response.toString()).filter(token => token.type === 'table')?.length ?? 0;


### PR DESCRIPTION
fix #269227

now that we indicate tool progress messages, we only want to include those that are in progress in the response's aria label