### PR TITLE
enable chat response OS notification by default

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -315,7 +315,7 @@ configurationRegistry.registerConfiguration({
 		},
 		[ChatConfiguration.NotifyWindowOnResponseReceived]: {
 			type: 'boolean',
-			default: false,
+			default: true,
 			description: nls.localize('chat.notifyWindowOnResponseReceived', "Controls whether a chat session should notify the user when a response is received while the window is not in focus. This includes a window badge as well as notification toast."),
 		},
 		'chat.checkpoints.enabled': {


### PR DESCRIPTION
fix #268388

Feedback was strong in this direction and with improvements like https://github.com/microsoft/vscode/pull/269137, this makes sense