### PR TITLE
Remove restart call when enabling TS native

### DIFF
--- a/extensions/typescript-language-features/src/commands/useTsgo.ts
+++ b/extensions/typescript-language-features/src/commands/useTsgo.ts
@@ -68,7 +68,5 @@ async function updateTsgoSetting(enable: boolean): Promise<void> {
 		}
 	}
 
-	// Update the setting, restart the extension host, and enable the TypeScript Go extension
 	await tsConfig.update('experimental.useTsgo', enable, target);
-	await vscode.commands.executeCommand('workbench.action.restartExtensionHost');
 }


### PR DESCRIPTION
Fixes #266087

Should no longer be required after upstream changes

