### PR TITLE
Only disable built-in TS if TS go is installed

### DIFF
--- a/extensions/typescript-language-features/src/commands/useTsgo.ts
+++ b/extensions/typescript-language-features/src/commands/useTsgo.ts
@@ -6,6 +6,8 @@
 import * as vscode from 'vscode';
 import { Command } from './commandManager';
 
+export const tsNativeExtensionId = 'typescriptteam.native-preview';
+
 export class EnableTsgoCommand implements Command {
 	public readonly id = 'typescript.experimental.enableTsgo';
 
@@ -27,7 +29,7 @@ export class DisableTsgoCommand implements Command {
  * @param enable Whether to enable or disable TypeScript Go
  */
 async function updateTsgoSetting(enable: boolean): Promise<void> {
-	const tsgoExtension = vscode.extensions.getExtension('typescriptteam.native-preview');
+	const tsgoExtension = vscode.extensions.getExtension(tsNativeExtensionId);
 	// Error if the TypeScript Go extension is not installed with a button to open the GitHub repo
 	if (!tsgoExtension) {
 		const selection = await vscode.window.showErrorMessage(

--- a/extensions/typescript-language-features/src/extension.ts
+++ b/extensions/typescript-language-features/src/extension.ts
@@ -8,7 +8,7 @@ import * as fs from 'fs';
 import * as vscode from 'vscode';
 import { Api, getExtensionApi } from './api';
 import { CommandManager } from './commands/commandManager';
-import { DisableTsgoCommand } from './commands/useTsgo';
+import { DisableTsgoCommand, tsNativeExtensionId } from './commands/useTsgo';
 import { registerBaseCommands } from './commands/index';
 import { ElectronServiceConfigurationProvider } from './configuration/configuration.electron';
 import { ExperimentationTelemetryReporter, IExperimentationTelemetryReporter } from './experimentTelemetryReporter';
@@ -25,7 +25,7 @@ import { onCaseInsensitiveFileSystem } from './utils/fs.electron';
 import { Lazy } from './utils/lazy';
 import { getPackageInfo } from './utils/packageInfo';
 import * as temp from './utils/temp.electron';
-import { conditionalRegistration, requireGlobalConfiguration } from './languageFeatures/util/dependentRegistration';
+import { conditionalRegistration, requireGlobalConfiguration, requireHasVsCodeExtension } from './languageFeatures/util/dependentRegistration';
 import { DisposableStore } from './utils/dispose';
 
 export function activate(
@@ -55,6 +55,7 @@ export function activate(
 
 	context.subscriptions.push(conditionalRegistration([
 		requireGlobalConfiguration('typescript', 'experimental.useTsgo'),
+		requireHasVsCodeExtension(tsNativeExtensionId),
 	], () => {
 		// TSGO. Only register a small set of features that don't use TS Server
 		const disposables = new DisposableStore();

--- a/extensions/typescript-language-features/src/languageFeatures/util/dependentRegistration.ts
+++ b/extensions/typescript-language-features/src/languageFeatures/util/dependentRegistration.ts
@@ -111,3 +111,15 @@ export function requireSomeCapability(
 		client.onDidChangeCapabilities
 	);
 }
+
+export function requireHasVsCodeExtension(
+	extensionId: string
+) {
+	return new Condition(
+		() => {
+			return !!vscode.extensions.getExtension(extensionId);
+		},
+		vscode.extensions.onDidChange
+	);
+}
+


### PR DESCRIPTION
Fixes #269036

We should check both the setting that the native extension is actually installed

