### PR TITLE
Fix ripgrep when called with empty search string

### DIFF
--- a/src/vs/workbench/services/search/node/ripgrepTextSearchEngine.ts
+++ b/src/vs/workbench/services/search/node/ripgrepTextSearchEngine.ts
@@ -56,6 +56,10 @@ export class RipgrepTextSearchEngine {
 			}
 		})}`);
 
+		if (!query.pattern) {
+			return Promise.resolve({ limitHit: false });
+		}
+
 		return new Promise((resolve, reject) => {
 			token.onCancellationRequested(() => cancel());
 


### PR DESCRIPTION
Fixes #269417

Add a simple workaround for ripgrep failing on searches for an empty string

I don't think you can hit this through the UI but you can through the API/tools

