### PR TITLE
Fix Wayland display detection in snap electron-launch

### DIFF
--- a/resources/linux/snap/electron-launch
+++ b/resources/linux/snap/electron-launch
@@ -153,13 +153,14 @@ if [[ -n "$XDG_RUNTIME_DIR" && -z "$DISABLE_WAYLAND" ]]; then
     fi
     wayland_sockpath="$XDG_RUNTIME_DIR/../$wdisplay"
     wayland_snappath="$XDG_RUNTIME_DIR/$wdisplay"
-    if [ -S "$wayland_sockpath" ]; then
+    # Check both the snap path and the parent directory path for the Wayland socket
+    if [ -S "$wayland_snappath" ] || [ -S "$wayland_sockpath" ]; then
         # if running under wayland, use it
         #export WAYLAND_DEBUG=1
         # shellcheck disable=SC2034
         wayland_available=true
-        # create the compat symlink for now
-        if [ ! -e "$wayland_snappath" ]; then
+        # create the compat symlink for now (only if parent path exists and snap path doesn't)
+        if [ -S "$wayland_sockpath" ] && [ ! -e "$wayland_snappath" ]; then
             ln -s "$wayland_sockpath" "$wayland_snappath"
         fi
     fi


### PR DESCRIPTION
## Description

This PR fixes the Wayland display detection issue in the snap electron-launch script that causes Firefox and other applications to fail when opened via `xdg-open` from VSCode terminal.

## Related Issue

Fixes #223591
Related to #213004
Related to #229096

## Root Cause

The electron-launch script only checked for the Wayland socket at `$XDG_RUNTIME_DIR/../wayland-0`, but on many Linux distributions (including Fedora 40), the socket is located at `$XDG_RUNTIME_DIR/wayland-0`. This caused the script to fail detecting Wayland, leaving `GDK_BACKEND` unset, which made applications fall back to X11 with errors.

## Changes Made

- Modified Wayland detection logic to check **both** possible socket paths
- Updated symlink creation to only create when appropriate
- Maintains backward compatibility with existing setups
- Ensures `GDK_BACKEND="wayland"` is properly exported when Wayland is available

## Testing

- Verified shell script syntax
- Tested logic handles both socket path scenarios
- Maintains existing behavior for systems using parent directory path
- No breaking changes to existing functionality

## Screenshots/Logs

**Before:** Applications opened via `xdg-open` showed:

```
Error: Failed to open Wayland display, fallback to X11.
WAYLAND_DISPLAY='wayland-0' DISPLAY=':0'
```

**After:** Applications correctly detect and use Wayland display

## Checklist

- [x] My code follows the project's coding guidelines
- [x] I have tested my changes
- [x] I have linked the related issue(s)