### PR TITLE
Add "Go to Next/Previous Uncovered Line" navigation for Test Coverage

### DIFF
--- a/src/vs/workbench/contrib/testing/browser/codeCoverageDecorations.ts
+++ b/src/vs/workbench/contrib/testing/browser/codeCoverageDecorations.ts
@@ -60,6 +60,8 @@ const TOGGLE_INLINE_COMMAND_ID = 'testing.toggleInlineCoverage';
 const BRANCH_MISS_INDICATOR_CHARS = 4;
 
 export class CodeCoverageDecorations extends Disposable implements IEditorContribution {
+	public static readonly ID = 'editor.contrib.coverageDecorations';
+
 	private loadingCancellation?: CancellationTokenSource;
 	private readonly displayedStore = this._register(new DisposableStore());
 	private readonly hoveredStore = this._register(new DisposableStore());
@@ -263,15 +265,6 @@ export class CodeCoverageDecorations extends Disposable implements IEditorContri
 	 */
 	public goToPreviousMissedLine(): boolean {
 		return this.navigateToMissedLine(false);
-	}
-
-	private isMissedLine(detail: CoverageDetailsWithBranch): boolean {
-		if (detail.type === DetailType.Statement) {
-			return !detail.count;
-		} else if (detail.type === DetailType.Branch) {
-			return !detail.detail.branches![detail.branch].count;
-		}
-		return false;
 	}
 
 	private navigateToMissedLine(next: boolean): boolean {

--- a/src/vs/workbench/contrib/testing/browser/codeCoverageDecorations.ts
+++ b/src/vs/workbench/contrib/testing/browser/codeCoverageDecorations.ts
@@ -317,15 +317,7 @@ export class CodeCoverageDecorations extends Disposable implements IEditorContri
 			// Find the last missed line before the current line
 			for (let i = missedLines.length - 1; i >= 0; i--) {
 				if (missedLines[i].lineNumber < currentLine) {
-			// If no line found after, wrap around to the first missed line
-			if (!targetLine) {
-				targetLine = missedLines[0];
-			}
-			// If no line found before, wrap around to the last missed line
-			if (!targetLine) {
-				targetLine = missedLines[missedLines.length - 1];
-			}
-		}
+					targetLine = missedLines[i];
 					break;
 				}
 			}

--- a/src/vs/workbench/contrib/testing/browser/codeCoverageDecorations.ts
+++ b/src/vs/workbench/contrib/testing/browser/codeCoverageDecorations.ts
@@ -42,7 +42,7 @@ import { IQuickInputButton, IQuickInputService, QuickPickInput } from '../../../
 import { ActiveEditorContext } from '../../../common/contextkeys.js';
 import { TEXT_FILE_EDITOR_ID } from '../../files/common/files.js';
 import { getTestingConfiguration, TestingConfigKeys } from '../common/configuration.js';
-import { TestCommandId } from '../common/constants.js';
+import { TestCommandId, Testing } from '../common/constants.js';
 import { FileCoverage } from '../common/testCoverage.js';
 import { ITestCoverageService } from '../common/testCoverageService.js';
 import { TestId } from '../common/testId.js';
@@ -60,7 +60,7 @@ const TOGGLE_INLINE_COMMAND_ID = 'testing.toggleInlineCoverage';
 const BRANCH_MISS_INDICATOR_CHARS = 4;
 
 export class CodeCoverageDecorations extends Disposable implements IEditorContribution {
-	public static readonly ID = 'editor.contrib.coverageDecorations';
+	public static readonly ID = Testing.CoverageDecorationsContributionId;
 
 	private loadingCancellation?: CancellationTokenSource;
 	private readonly displayedStore = this._register(new DisposableStore());

--- a/src/vs/workbench/contrib/testing/browser/codeCoverageDecorations.ts
+++ b/src/vs/workbench/contrib/testing/browser/codeCoverageDecorations.ts
@@ -58,6 +58,8 @@ const CLASS_MISS = 'coverage-deco-miss';
 const TOGGLE_INLINE_COMMAND_TEXT = localize('testing.toggleInlineCoverage', 'Toggle Inline');
 const TOGGLE_INLINE_COMMAND_ID = 'testing.toggleInlineCoverage';
 const BRANCH_MISS_INDICATOR_CHARS = 4;
+const GO_TO_NEXT_MISSED_LINE_TITLE = localize2('testing.goToNextMissedLine', "Go to Next Uncovered Line");
+const GO_TO_PREVIOUS_MISSED_LINE_TITLE = localize2('testing.goToPreviousMissedLine', "Go to Previous Uncovered Line");
 
 export class CodeCoverageDecorations extends Disposable implements IEditorContribution {
 	public static readonly ID = Testing.CoverageDecorationsContributionId;
@@ -719,7 +721,7 @@ class CoverageToolbarWidget extends Disposable implements IOverlayWidget {
 		// Navigation buttons for missed coverage lines
 		this.actionBar.push(new ActionWithIcon(
 			'goToPreviousMissed',
-			localize('testing.goToPreviousMissedLine', 'Go to Previous Uncovered Line'),
+			GO_TO_PREVIOUS_MISSED_LINE_TITLE.value,
 			Codicon.arrowUp,
 			undefined,
 			() => this.commandService.executeCommand(TestCommandId.CoverageGoToPreviousMissedLine),
@@ -727,7 +729,7 @@ class CoverageToolbarWidget extends Disposable implements IOverlayWidget {
 
 		this.actionBar.push(new ActionWithIcon(
 			'goToNextMissed',
-			localize('testing.goToNextMissedLine', 'Go to Next Uncovered Line'),
+			GO_TO_NEXT_MISSED_LINE_TITLE.value,
 			Codicon.arrowDown,
 			undefined,
 			() => this.commandService.executeCommand(TestCommandId.CoverageGoToNextMissedLine),
@@ -1003,7 +1005,7 @@ registerAction2(class GoToNextMissedCoverageLine extends Action2 {
 	constructor() {
 		super({
 			id: TestCommandId.CoverageGoToNextMissedLine,
-			title: localize2('testing.goToNextMissedLine', "Go to Next Uncovered Line"),
+			title: GO_TO_NEXT_MISSED_LINE_TITLE,
 			metadata: {
 				description: localize2('testing.goToNextMissedLineDesc', 'Navigate to the next line that is not covered by tests.')
 			},
@@ -1039,7 +1041,7 @@ registerAction2(class GoToPreviousMissedCoverageLine extends Action2 {
 	constructor() {
 		super({
 			id: TestCommandId.CoverageGoToPreviousMissedLine,
-			title: localize2('testing.goToPreviousMissedLine', "Go to Previous Uncovered Line"),
+			title: GO_TO_PREVIOUS_MISSED_LINE_TITLE,
 			metadata: {
 				description: localize2('testing.goToPreviousMissedLineDesc', 'Navigate to the previous line that is not covered by tests.')
 			},

--- a/src/vs/workbench/contrib/testing/common/constants.ts
+++ b/src/vs/workbench/contrib/testing/common/constants.ts
@@ -67,6 +67,8 @@ export const enum TestCommandId {
 	CoverageCurrentFile = 'testing.coverageCurrentFile',
 	CoverageFilterToTest = 'testing.coverageFilterToTest',
 	CoverageFilterToTestInEditor = 'testing.coverageFilterToTestInEditor',
+	CoverageGoToNextMissedLine = 'testing.coverage.goToNextMissedLine',
+	CoverageGoToPreviousMissedLine = 'testing.coverage.goToPreviousMissedLine',
 	CoverageLastRun = 'testing.coverageLastRun',
 	CoverageSelectedAction = 'testing.coverageSelected',
 	CoverageToggleInExplorer = 'testing.toggleCoverageInExplorer',


### PR DESCRIPTION
Fixes #258967
Related to #258961

## Description

Adds navigation buttons and keyboard shortcuts to jump between uncovered lines in the test coverage view.

### Changes

- **New Commands**: 
  - `testing.coverage.goToNextMissedLine` (Alt+F9)
  - `testing.coverage.goToPreviousMissedLine` (Shift+Alt+F9)

- **UI Enhancements**:
  - Added up/down arrow buttons to the Coverage Toolbar Widget
  - Added menu items in Editor Title when coverage is active
  - Commands available in Command Palette when coverage is open

- **Navigation Behavior**:
  - Jumps to next/previous line with zero test coverage
  - Wraps around at file boundaries for continuous navigation
  - Centers the target line in the editor for better visibility
  - Only enabled when coverage data is available for the current file

### Implementation Details

The implementation follows VS Code's existing navigation patterns (similar to "Go to Next Error"):
- Navigation methods in `CodeCoverageDecorations` class iterate through decorations marked with `CLASS_MISS`
- Action2 classes provide command registration with keybindings and menu integration
- Toolbar buttons execute the commands via `ICommandService`

### Testing

To test:
1. Open a file with test coverage
2. Use Alt+F9 to jump to next uncovered line
3. Use Shift+Alt+F9 to jump to previous uncovered line
4. Verify navigation wraps around at file boundaries
5. Check toolbar buttons appear and function correctly