### PR TITLE
Fix webview find widget not working after moving editor group to new window

### DIFF
--- a/src/vs/workbench/contrib/webview/browser/webviewElement.ts
+++ b/src/vs/workbench/contrib/webview/browser/webviewElement.ts
@@ -348,6 +348,7 @@ export class WebviewElement extends Disposable implements IWebviewElement, Webvi
 
 	setContextKeyService(contextKeyService: IContextKeyService) {
 		this._contextKeyService = contextKeyService;
+		this._webviewFindWidget?.updateContextKeyService(contextKeyService);
 	}
 
 	private readonly _onMissingCsp = this._register(new Emitter<ExtensionIdentifier>());

--- a/src/vs/workbench/contrib/webview/browser/webviewFindWidget.ts
+++ b/src/vs/workbench/contrib/webview/browser/webviewFindWidget.ts
@@ -26,7 +26,8 @@ export class WebviewFindWidget extends SimpleFindWidget {
 		return undefined;
 	}
 
-	protected readonly _findWidgetFocused: IContextKey<boolean>;
+	protected _findWidgetFocused: IContextKey<boolean>;
+	private _contextKeyService: IContextKeyService;
 
 	constructor(
 		private readonly _delegate: WebviewFindDelegate,
@@ -40,6 +41,7 @@ export class WebviewFindWidget extends SimpleFindWidget {
 			checkImeCompletionState: _delegate.checkImeCompletionState,
 			enableSash: true,
 		}, contextViewService, contextKeyService, hoverService, keybindingService);
+		this._contextKeyService = contextKeyService;
 		this._findWidgetFocused = KEYBINDING_CONTEXT_WEBVIEW_FIND_WIDGET_FOCUSED.bindTo(contextKeyService);
 
 		this._register(_delegate.hasFindResult(hasResult => {
@@ -50,6 +52,12 @@ export class WebviewFindWidget extends SimpleFindWidget {
 		this._register(_delegate.onDidStopFind(() => {
 			this.updateButtons(false);
 		}));
+	}
+
+	public updateContextKeyService(contextKeyService: IContextKeyService): void {
+		this._findWidgetFocused.reset();
+		this._contextKeyService = contextKeyService;
+		this._findWidgetFocused = KEYBINDING_CONTEXT_WEBVIEW_FIND_WIDGET_FOCUSED.bindTo(contextKeyService);
 	}
 
 	public find(previous: boolean) {


### PR DESCRIPTION
## Description

Fixes #233044

This PR fixes an issue where webview panels with `enableFindWidget` enabled would stop working after being moved to a new window using the "View: Move Editor Group into New Window" command. The find widget would appear, but search results would not be highlighted in the webview.

## Root Cause

When a webview is moved to a new window, `setContextKeyService()` is called to update the context key service to the new window's instance. However, the `WebviewFindWidget` was not updating its internal context keys. Specifically, the `_findWidgetFocused` context key remained bound to the old window's context key service, causing the find functionality to break.

## Changes

### `webviewFindWidget.ts`
- Store the context key service reference for later updates
- Add `updateContextKeyService()` method that:
  - Resets the old `_findWidgetFocused` context key
  - Updates the stored context key service reference  
  - Rebinds `_findWidgetFocused` to the new context key service

### `webviewElement.ts`
- Update `setContextKeyService()` to propagate context key service updates to the find widget

## Testing

To verify the fix:
1. Install the webview-sample extension from the VS Code Extension Samples
2. Replace `src/extension.ts` with the code from the issue description
3. Run the extension and execute "Cat Coding: Start cat coding session"
4. Press Ctrl-F and search for "text" - verify it highlights correctly
5. Run "View: Move Editor Group into New Window"
6. Press Ctrl-F and search for "text" - verify it now highlights correctly (previously would not work)

---

This is a minimal, focused fix that follows the existing pattern for updating context keys when components move between windows.