### PR TITLE
Fix linked editing when clearing and retyping tag names

### DIFF
--- a/src/vs/editor/contrib/linkedEditing/browser/linkedEditing.ts
+++ b/src/vs/editor/contrib/linkedEditing/browser/linkedEditing.ts
@@ -194,7 +194,9 @@ export class LinkedEditingContribution extends Disposable implements IEditorCont
 		if (this._currentWordPattern) {
 			const match = referenceValue.match(this._currentWordPattern);
 			const matchLength = match ? match[0].length : 0;
-			if (matchLength !== referenceValue.length) {
+			// Allow empty string and partial matches (for cases where user clears tag and retypes)
+			// Only clear if there's text that doesn't match the pattern at all (matchLength is 0 but text exists)
+			if (referenceValue.length > 0 && matchLength === 0) {
 				return this.clearRanges();
 			}
 		}

--- a/src/vs/editor/contrib/linkedEditing/test/browser/linkedEditing.test.ts
+++ b/src/vs/editor/contrib/linkedEditing/test/browser/linkedEditing.test.ts
@@ -477,4 +477,37 @@ suite('linked editing', () => {
 		'<iooo>',
 		'</iooo>'
 	]);
+
+	/**
+	 * Clear and retype - regression test for #239351
+	 */
+	testCase('Clear tag and retype - single char', state, async (editor) => {
+		// Select "ooo" in the opening tag and delete it
+		await editor.setSelection(new Range(1, 2, 1, 5));
+		await editor.trigger('keyboard', 'deleteLeft', {});
+		// Type a single character
+		await editor.trigger('keyboard', Handler.Type, { text: 's' });
+	}, '<s></s>');
+
+	testCase('Clear tag and retype - multiple chars', state, async (editor) => {
+		// Select "ooo" in the opening tag and delete it
+		await editor.setSelection(new Range(1, 2, 1, 5));
+		await editor.trigger('keyboard', 'deleteLeft', {});
+		// Type multiple characters one by one
+		await editor.trigger('keyboard', Handler.Type, { text: 'd' });
+		await editor.trigger('keyboard', Handler.Type, { text: 'i' });
+		await editor.trigger('keyboard', Handler.Type, { text: 'v' });
+	}, '<div></div>');
+
+	testCase('Clear tag completely and retype', state, async (editor) => {
+		// Position at the start of "ooo" and delete all left
+		const pos = new Position(1, 5);
+		await editor.setPosition(pos);
+		await editor.trigger('keyboard', 'deleteAllLeft', {});
+		// Type a new tag name
+		await editor.trigger('keyboard', Handler.Type, { text: 's' });
+		await editor.trigger('keyboard', Handler.Type, { text: 'p' });
+		await editor.trigger('keyboard', Handler.Type, { text: 'a' });
+		await editor.trigger('keyboard', Handler.Type, { text: 'n' });
+	}, '<span></span>');
 });


### PR DESCRIPTION
## Summary
Fixes #239351 - Linked editing now continues working when users clear tag names and type new ones.

## Description
The linked editing feature (which keeps paired HTML tags in sync) would stop working when users:
1. Completely cleared a tag name (e.g., deleted "div" from `<div>`)
2. Started typing a new tag name character by character

### Root Cause
The word pattern validation in `_syncRanges` was too strict. It would clear the linked editing ranges whenever the partial text being typed didn't fully match the word pattern:

```typescript
// Old code
if (matchLength !== referenceValue.length) {
    return this.clearRanges();
}

// New code
if (referenceValue.length > 0 && matchLength === 0) {
    return this.clearRanges();
}