### PR TITLE
Enhance action label styling for high-contrast themes

### DIFF
--- a/src/vs/workbench/browser/parts/compositeBarActions.ts
+++ b/src/vs/workbench/browser/parts/compositeBarActions.ts
@@ -158,6 +158,7 @@ export class CompositeBarActionViewItem extends BaseActionViewItem {
 	protected badge!: HTMLElement;
 	protected override readonly options: ICompositeBarActionViewItemOptions;
 
+	private labelContainer: HTMLElement | undefined;
 	private badgeContent: HTMLElement | undefined;
 	private readonly badgeDisposable = this._register(new MutableDisposable<DisposableStore>());
 	private mouseUpTimeout: Timeout | undefined;
@@ -401,6 +402,16 @@ export class CompositeBarActionViewItem extends BaseActionViewItem {
 
 		if (!this.options.icon) {
 			this.label.textContent = this.action.label;
+		}
+
+		const hasUriIcon = this.compositeBarActionItem.classNames?.includes('uri-icon');
+		if (hasUriIcon && !this.labelContainer) {
+			this.labelContainer = $('.action-label-hc-container');
+			this.label.replaceWith(this.labelContainer);
+			this.labelContainer.appendChild(this.label);
+		} else if (!hasUriIcon && this.labelContainer) {
+			this.labelContainer.replaceWith(this.label);
+			this.labelContainer = undefined;
 		}
 	}
 

--- a/src/vs/workbench/browser/parts/compositeBarActions.ts
+++ b/src/vs/workbench/browser/parts/compositeBarActions.ts
@@ -406,10 +406,20 @@ export class CompositeBarActionViewItem extends BaseActionViewItem {
 
 		const hasUriIcon = this.compositeBarActionItem?.classNames?.includes('uri-icon');
 		if (hasUriIcon && !this.labelContainer) {
-			this.labelContainer = $('.action-label-hc-container');
-			this.label.replaceWith(this.labelContainer);
-			this.labelContainer.appendChild(this.label);
+			this.addHighContrastContainer();
 		} else if (!hasUriIcon && this.labelContainer) {
+			this.removeHighContrastContainer();
+		}
+	}
+
+	private addHighContrastContainer(): void {
+		this.labelContainer = $('.action-label-hc-container');
+		this.label.replaceWith(this.labelContainer);
+		this.labelContainer.appendChild(this.label);
+	}
+
+	private removeHighContrastContainer(): void {
+		if (this.labelContainer) {
 			this.labelContainer.replaceWith(this.label);
 			this.labelContainer = undefined;
 		}

--- a/src/vs/workbench/browser/parts/compositeBarActions.ts
+++ b/src/vs/workbench/browser/parts/compositeBarActions.ts
@@ -396,7 +396,7 @@ export class CompositeBarActionViewItem extends BaseActionViewItem {
 	protected override updateLabel(): void {
 		this.label.className = 'action-label';
 
-		if (this.compositeBarActionItem.classNames) {
+		if (this.compositeBarActionItem?.classNames) {
 			this.label.classList.add(...this.compositeBarActionItem.classNames);
 		}
 
@@ -404,7 +404,7 @@ export class CompositeBarActionViewItem extends BaseActionViewItem {
 			this.label.textContent = this.action.label;
 		}
 
-		const hasUriIcon = this.compositeBarActionItem.classNames?.includes('uri-icon');
+		const hasUriIcon = this.compositeBarActionItem?.classNames?.includes('uri-icon');
 		if (hasUriIcon && !this.labelContainer) {
 			this.labelContainer = $('.action-label-hc-container');
 			this.label.replaceWith(this.labelContainer);

--- a/src/vs/workbench/browser/parts/media/paneCompositePart.css
+++ b/src/vs/workbench/browser/parts/media/paneCompositePart.css
@@ -319,16 +319,40 @@
 	border-top-width: 2px;
 }
 
-.monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.checked .action-label,
-.monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:hover .action-label,
-.monaco-workbench .pane-composite-part > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.checked .action-label,
-.monaco-workbench .pane-composite-part > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:hover .action-label {
+/* Apply outline to action-label for non-uri-icon elements */
+.monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.checked .action-label:not(.uri-icon),
+.monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:hover .action-label:not(.uri-icon),
+.monaco-workbench .pane-composite-part > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.checked .action-label:not(.uri-icon),
+.monaco-workbench .pane-composite-part > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:hover .action-label:not(.uri-icon) {
 	outline: var(--vscode-contrastActiveBorder, unset) solid 1px !important;
 }
 
-.monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:not(.checked):hover .action-label,
-.monaco-workbench .pane-composite-part > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:not(.checked):hover .action-label {
+.monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:not(.checked):hover .action-label:not(.uri-icon),
+.monaco-workbench .pane-composite-part > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:not(.checked):hover .action-label:not(.uri-icon) {
 	outline: var(--vscode-contrastActiveBorder, unset) dashed 1px !important;
+}
+
+/* Apply outline to action-label-hc-container wrapper for uri-icon elements to avoid masking issues */
+.monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.checked .action-label-hc-container:has(.uri-icon),
+.monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:hover .action-label-hc-container:has(.uri-icon),
+.monaco-workbench .pane-composite-part > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.checked .action-label-hc-container:has(.uri-icon),
+.monaco-workbench .pane-composite-part > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:hover .action-label-hc-container:has(.uri-icon) {
+	outline: var(--vscode-contrastActiveBorder, unset) solid 1px !important;
+	outline-offset: 2px;
+}
+
+.monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:not(.checked):hover .action-label-hc-container:has(.uri-icon),
+.monaco-workbench .pane-composite-part > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:not(.checked):hover .action-label-hc-container:has(.uri-icon) {
+	outline: var(--vscode-contrastActiveBorder, unset) dashed 1px !important;
+	outline-offset: 2px;
+}
+
+/* Style the wrapper to match the label dimensions for uri-icons */
+.monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon .action-label-hc-container,
+.monaco-workbench .pane-composite-part > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon .action-label-hc-container {
+	display: flex;
+	align-items: center;
+	justify-content: center;
 }
 
 /** Empty Pane Message **/


### PR DESCRIPTION
Improve the styling of action labels in high-contrast themes by adding outlines for non-uri-icon elements and adjusting the wrapper for uri-icons to prevent masking issues.