### PR TITLE
Add copy context menu for chat math equations

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/media/chatMarkdownPart.css
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/media/chatMarkdownPart.css
@@ -22,17 +22,18 @@
 	}
 
 	/* Interactive math equation styling */
-	.katex {
+	.katex.interactive-katex {
 		transition: background-color 0.1s ease-in-out;
 		border-radius: 3px;
 		padding: 2px 4px;
+		cursor: context-menu;
 	}
 
-	.katex:hover {
+	.katex.interactive-katex:hover {
 		background-color: var(--vscode-editor-hoverHighlightBackground);
 	}
 
-	.katex-display .katex {
+	.katex-display .katex.interactive-katex {
 		padding: 4px 8px;
 	}
 }

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/media/chatMarkdownPart.css
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/media/chatMarkdownPart.css
@@ -20,4 +20,19 @@
 		width: fit-content;
 		overflow: hidden;
 	}
+
+	/* Interactive math equation styling */
+	.katex {
+		transition: background-color 0.1s ease-in-out;
+		border-radius: 3px;
+		padding: 2px 4px;
+	}
+
+	.katex:hover {
+		background-color: var(--vscode-editor-hoverHighlightBackground);
+	}
+
+	.katex-display .katex {
+		padding: 4px 8px;
+	}
 }


### PR DESCRIPTION
Fixes #258286

### Summary
Adds a right-click context menu to math equations in chat responses, allowing users to copy the LaTeX source. This implements a simplified version of the MathJax "Copy to Clipboard" feature requested in the issue.

### Changes Made

#### Modified Files
1. **`src/vs/workbench/contrib/chat/browser/chatContentParts/chatMarkdownContentPart.ts`**
   - Added `IClipboardService` and `IContextMenuService` to constructor
   - Implemented `setupKatexContextMenus()` method to register context menu on KaTeX elements
   - Extracts LaTeX source from KaTeX's `<annotation encoding="application/x-tex">` element
   - Single context menu option: "Copy Math Source"

2. **`src/vs/workbench/contrib/chat/browser/chatContentParts/media/chatMarkdownPart.css`**
   - Added `.interactive-katex` styles with hover effect
   - Added `cursor: context-menu` for visual feedback
   - Subtle background highlight on hover

### Features

✅ Copy LaTeX source (raw LaTeX without delimiters)  
✅ Visual feedback on hover (background highlight + cursor change)  
✅ Works with both inline (`$...$`) and block (`$$...$$`) equations  
✅ Proper lifecycle management with disposables  

### User Experience

1. User hovers over a math equation in chat → subtle highlight appears with context-menu cursor
2. User right-clicks → "Copy Math Source" option appears in context menu
3. User clicks → raw LaTeX copied to clipboard (e.g., `\frac{1}{2}`)

### Example
- **Rendered equation**: $\frac{1}{2}$
- **Right-click → Copy Math Source**
- **Clipboard**: `\frac{1}{2}`

### Design Decisions

#### Simplified Approach
Started with a minimal single-option implementation as suggested by @mjbvz, since the original issue hasn't received much attention. This can be expanded based on user feedback to add:
- Additional copy formats (MathML, TeX with delimiters)
- Keyboard shortcuts
- Visible copy button on hover

#### Proper Separation of Concerns
- Styling via CSS classes (`.interactive-katex`) instead of inline styles
- Uses existing VS Code services for consistency
- Localized strings with `nls.localize()`

### Testing

To test:
1. Build VS Code with these changes
2. Open a chat session
3. Request math equations (e.g., "Show me the quadratic formula")
4. Hover over any rendered equation - verify highlight and cursor change
5. Right-click on equation - verify "Copy Math Source" menu item appears
6. Click the option - verify raw LaTeX (without delimiters) is copied to clipboard
7. Test with both inline and block equations
