### PR TITLE
Format Selection now honors configured tab size

### DIFF
--- a/src/vs/editor/common/model/textModel.ts
+++ b/src/vs/editor/common/model/textModel.ts
@@ -655,7 +655,7 @@ export class TextModel extends Disposable implements model.ITextModel, IDecorati
 
 	public getFormattingOptions(): FormattingOptions {
 		return {
-			tabSize: this._options.indentSize,
+			tabSize: this._options.tabSize,
 			insertSpaces: this._options.insertSpaces
 		};
 	}


### PR DESCRIPTION
Fixes #250520

## Problem
When users press **Ctrl+K Ctrl+F** (Format Selection command), the formatter does not honor the configured `editor.tabSize` setting. For example, if a user has `tabSize` set to 4, the formatter might use 2 spaces instead, causing unexpected and inconsistent indentation.

## Root Cause
The bug was in the `getFormattingOptions()` method in `src/vs/editor/common/model/textModel.ts`. This method returns the formatting options that are passed to all document formatters.

The method was incorrectly returning `indentSize` for the `tabSize` property:
```typescript
// BEFORE (incorrect)
public getFormattingOptions(): FormattingOptions {
    return {
        tabSize: this._options.indentSize,  // ❌ Wrong!
        insertSpaces: this._options.insertSpaces
    };
}
```

## Solution
Updated `getFormattingOptions()` to return the correct `tabSize`:
```typescript
// AFTER (correct)
public getFormattingOptions(): FormattingOptions {
    return {
        tabSize: this._options.tabSize,  // ✅ Correct!
        insertSpaces: this._options.insertSpaces
    };
}
```

## Impact
This fix ensures that:
- ✅ Format Selection (Ctrl+K Ctrl+F) respects the configured `editor.tabSize` setting
- ✅ Format Document also uses the correct tab size
- ✅ All document formatters receive the correct tab size value
- ✅ Behavior is consistent whether `indentSize` is set to `'tabSize'` (default) or a custom value

## Testing
- No compilation errors after the change
- The fix aligns with the TypeScript interface definition for `FormattingOptions`
- All existing usages of `getFormattingOptions()` will now receive the correct tab size value

## Related
- Issue: #250520
- Labels: `bug`, `editor-autoindent`, `help wanted`