### PR TITLE
git: persist repositories opened outside workspace

### DIFF
--- a/extensions/git/src/model.ts
+++ b/extensions/git/src/model.ts
@@ -354,8 +354,12 @@ export class Model implements IRepositoryResolver, IBranchProtectionProviderRegi
 			this.onDidChangeWorkspaceFolders({ added: workspace.workspaceFolders || [], removed: [] }),
 			this.onDidChangeVisibleTextEditors(window.visibleTextEditors),
 			this.scanWorkspaceFolders(),
-			// Restore previously opened repositories
-			...this._openedRepositoriesManager.repositories.map(r => this.openRepository(r, false, false))
+			// Restore previously opened repositories with error handling
+			...this._openedRepositoriesManager.repositories.map(r =>
+				this.openRepository(r, false, false).catch(err => {
+					this.logger.warn(`[Model][doInitialScan] Failed to restore previously opened repository: ${r}. Error: ${err && err.message ? err.message : err}`);
+				})
+			)
 		]);
 
 		if (config.get<boolean>('showProgress', true)) {

--- a/extensions/git/src/model.ts
+++ b/extensions/git/src/model.ts
@@ -139,6 +139,40 @@ class ParentRepositoriesManager {
 	}
 }
 
+class OpenedRepositoriesManager {
+
+	private _repositories: Set<string>;
+	get repositories(): string[] {
+		return [...this._repositories.values()];
+	}
+
+	constructor(private readonly workspaceState: Memento) {
+		this._repositories = new Set<string>(workspaceState.get<string[]>('openedRepositories', []));
+	}
+
+	addRepository(repository: string): void {
+		this._repositories.add(repository);
+		this.onDidChangeRepositories();
+	}
+
+	deleteRepository(repository: string): boolean {
+		const result = this._repositories.delete(repository);
+		if (result) {
+			this.onDidChangeRepositories();
+		}
+
+		return result;
+	}
+
+	hasRepository(repository: string): boolean {
+		return this._repositories.has(repository);
+	}
+
+	private onDidChangeRepositories(): void {
+		this.workspaceState.update('openedRepositories', [...this._repositories.values()]);
+	}
+}
+
 class UnsafeRepositoriesManager {
 
 	/**
@@ -265,6 +299,11 @@ export class Model implements IRepositoryResolver, IBranchProtectionProviderRegi
 		return [...this._closedRepositoriesManager.repositories];
 	}
 
+	private _openedRepositoriesManager: OpenedRepositoriesManager;
+	get openedRepositories(): string[] {
+		return [...this._openedRepositoriesManager.repositories];
+	}
+
 	/**
 	 * We maintain a map containing both the path and the canonical path of the
 	 * workspace folders. We are doing this as `git.exe` expands the symbolic links
@@ -282,6 +321,7 @@ export class Model implements IRepositoryResolver, IBranchProtectionProviderRegi
 		this._closedRepositoriesManager = new ClosedRepositoriesManager(workspaceState);
 		this._parentRepositoriesManager = new ParentRepositoriesManager(globalState);
 		this._unsafeRepositoriesManager = new UnsafeRepositoriesManager();
+		this._openedRepositoriesManager = new OpenedRepositoriesManager(workspaceState);
 
 		workspace.onDidChangeWorkspaceFolders(this.onDidChangeWorkspaceFolders, this, this.disposables);
 		window.onDidChangeVisibleTextEditors(this.onDidChangeVisibleTextEditors, this, this.disposables);
@@ -313,7 +353,9 @@ export class Model implements IRepositoryResolver, IBranchProtectionProviderRegi
 		const initialScanFn = () => Promise.all([
 			this.onDidChangeWorkspaceFolders({ added: workspace.workspaceFolders || [], removed: [] }),
 			this.onDidChangeVisibleTextEditors(window.visibleTextEditors),
-			this.scanWorkspaceFolders()
+			this.scanWorkspaceFolders(),
+			// Restore previously opened repositories
+			...this._openedRepositoriesManager.repositories.map(r => this.openRepository(r, false, false))
 		]);
 
 		if (config.get<boolean>('showProgress', true)) {
@@ -339,7 +381,7 @@ export class Model implements IRepositoryResolver, IBranchProtectionProviderRegi
 			}
 		*/
 		this.telemetryReporter.sendTelemetryEvent('git.repositoryInitialScan', { autoRepositoryDetection: String(autoRepositoryDetection) }, { repositoryCount: this.openRepositories.length });
-		this.logger.info(`[Model][doInitialScan] Initial repository scan completed - repositories (${this.repositories.length}), closed repositories (${this.closedRepositories.length}), parent repositories (${this.parentRepositories.length}), unsafe repositories (${this.unsafeRepositories.length})`);
+		this.logger.info(`[Model][doInitialScan] Initial repository scan completed - repositories (${this.repositories.length}), closed repositories (${this.closedRepositories.length}), parent repositories (${this.parentRepositories.length}), unsafe repositories (${this.unsafeRepositories.length}), opened repositories (${this.openedRepositories.length})`);
 	}
 
 	/**
@@ -658,6 +700,13 @@ export class Model implements IRepositoryResolver, IBranchProtectionProviderRegi
 			this.open(repository);
 			this._closedRepositoriesManager.deleteRepository(repository.root);
 
+			// Track repositories outside workspace so they can be restored on next session
+			const isRepositoryOutsideWorkspace = await this.isRepositoryOutsideWorkspace(repositoryRoot);
+			if (isRepositoryOutsideWorkspace && !this._openedRepositoriesManager.hasRepository(repositoryRoot)) {
+				this._openedRepositoriesManager.addRepository(repositoryRoot);
+				this.logger.trace(`[Model][openRepository] Added repository to opened repositories: ${repositoryRoot}`);
+			}
+
 			this.logger.info(`[Model][openRepository] Opened repository (path): ${repository.root}`);
 			this.logger.info(`[Model][openRepository] Opened repository (real path): ${repository.rootRealPath ?? repository.root}`);
 			this.logger.info(`[Model][openRepository] Opened repository (kind): ${gitRepository.kind}`);
@@ -858,6 +907,7 @@ export class Model implements IRepositoryResolver, IBranchProtectionProviderRegi
 
 		this.logger.info(`[Model][close] Repository: ${repository.root}`);
 		this._closedRepositoriesManager.addRepository(openRepository.repository.root);
+		this._openedRepositoriesManager.deleteRepository(openRepository.repository.root);
 
 		openRepository.dispose();
 	}


### PR DESCRIPTION
Fixes #250580

### Problem
When users open a Git repository outside the workspace folder using the "Git: Open Repository" command, the repository is not persisted across VS Code sessions. After closing and reopening VS Code, the manually added repository disappears from the Source Control panel and is not available in the "Git: Reopen Closed Repositories..." command.

### Root Cause
The Git extension had mechanisms to track:
- **Closed repositories** (`ClosedRepositoriesManager`) - manually closed by users
- **Parent repositories** (`ParentRepositoriesManager`) - repositories in parent folders
- **Unsafe repositories** (`UnsafeRepositoriesManager`) - repositories with security warnings

However, there was no mechanism to persist repositories that were manually opened via commands, especially those outside the workspace folder structure. During initialization, the extension only scanned workspace folders, visible editors, and configured paths - but not previously opened external repositories.

### Solution
Introduced an `OpenedRepositoriesManager` class that:
- Tracks repositories opened outside the workspace in workspace state (using VS Code's Memento API)
- Automatically restores these repositories during the initial scan on VS Code startup
- Removes repositories from tracking when they are manually closed
- Only tracks repositories outside the workspace (repositories inside workspace folders are auto-discovered by the existing scan logic)

### Implementation Details
The implementation follows the same pattern as `ClosedRepositoriesManager`:
1. **New Manager Class**: `OpenedRepositoriesManager` stores repository paths in workspace state
2. **Initialization**: Manager is instantiated in the `Model` constructor
3. **Restoration**: During `doInitialScan()`, previously opened repositories are reopened
4. **Tracking**: When a repository outside the workspace is opened, it's added to the manager
5. **Cleanup**: When a repository is closed, it's removed from the manager

### Changes
- `extensions/git/src/model.ts`
  - Added `OpenedRepositoriesManager` class
  - Added `_openedRepositoriesManager` property to `Model` class
  - Updated `doInitialScan()` to restore opened repositories
  - Updated `openRepository()` to track external repositories
  - Updated `close()` to remove from tracking

### Testing
**Before this fix:**
1. Open workspace in VS Code
2. Run "Git: Open Repository" and select a repo outside workspace
3. Repository appears in Source Control ✓
4. Close VS Code
5. Reopen VS Code
6. Repository is missing ✗

**After this fix:**
1. Open workspace in VS Code
2. Run "Git: Open Repository" and select a repo outside workspace
3. Repository appears in Source Control ✓
4. Close VS Code
5. Reopen VS Code
6. Repository is automatically restored ✓

**Additional test cases:**
- ✓ Repository manually closed is not restored (respects user intent)
- ✓ Multiple external repositories are all persisted and restored
- ✓ Repositories inside workspace are not redundantly tracked
- ✓ Each workspace maintains its own list of opened repositories

### Edge Cases Handled
- Repositories that no longer exist on disk will fail silently during restore
- Closing a tracked repository removes it from the opened list
- Repositories inside workspace folders are excluded from tracking (auto-discovered)
- Workspace-specific tracking ensures multi-workspace scenarios work correctly

### Notes
This change uses `workspaceState` (not `globalState`) because opened repositories are specific to each workspace context, similar to how closed repositories are tracked.

---

**Risk Assessment:** Low
- Follows existing patterns in the codebase
- Only adds new functionality without modifying existing behavior
- Uses well-tested Memento API for persistence
- Gracefully handles missing repositories