### PR TITLE
Improve handling when speech ext not installed/enabled and start dictation is used

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminalMenus.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalMenus.ts
@@ -761,7 +761,7 @@ export function setupTerminalMenus(): void {
 			},
 			group: 'navigation',
 			order: 9,
-			when: ContextKeyExpr.and(ResourceContextKey.Scheme.isEqualTo(Schemas.vscodeTerminal), HasSpeechProvider, TerminalContextKeys.terminalDictationInProgress.negate()),
+			when: ContextKeyExpr.and(ResourceContextKey.Scheme.isEqualTo(Schemas.vscodeTerminal), TerminalContextKeys.terminalDictationInProgress.negate()),
 			isHiddenByDefault: true
 		});
 		MenuRegistry.appendMenuItem(menuId, {

--- a/src/vs/workbench/contrib/terminalContrib/voice/browser/terminalVoiceActions.ts
+++ b/src/vs/workbench/contrib/terminalContrib/voice/browser/terminalVoiceActions.ts
@@ -48,8 +48,8 @@ export function registerTerminalVoiceActions() {
 				enabled: true
 			};
 
-			const actions = [];
-			let message;
+			const actions: INotificationAction[] = [];
+			let message: string;
 			if (extensionIsDisabled) {
 				message = localize('terminal.voice.enableSpeechExtension', "You must enable the Speech extension to use Dictation in the Terminal.");
 				actions.push({

--- a/src/vs/workbench/contrib/terminalContrib/voice/browser/terminalVoiceActions.ts
+++ b/src/vs/workbench/contrib/terminalContrib/voice/browser/terminalVoiceActions.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { IAction } from '../../../../../base/common/actions.js';
 import { localize, localize2 } from '../../../../../nls.js';
 import { ICommandService } from '../../../../../platform/commands/common/commands.js';
 import { ContextKeyExpr, IContextKeyService } from '../../../../../platform/contextkey/common/contextkey.js';
@@ -48,7 +49,7 @@ export function registerTerminalVoiceActions() {
 				enabled: true
 			};
 
-			const actions: INotificationAction[] = [];
+			const actions: IAction[] = [];
 			let message: string;
 			if (extensionIsDisabled) {
 				message = localize('terminal.voice.enableSpeechExtension', "You must enable the Speech extension to use Dictation in the Terminal.");

--- a/src/vs/workbench/contrib/terminalContrib/voice/browser/terminalVoiceActions.ts
+++ b/src/vs/workbench/contrib/terminalContrib/voice/browser/terminalVoiceActions.ts
@@ -37,7 +37,7 @@ export function registerTerminalVoiceActions() {
 				return;
 			}
 			const extensions = await extensionManagementService.getInstalled();
-			const extension = extensions.filter(extension => (extension.identifier.id === 'ms-vscode.vscode-speech'))?.[0];
+			const extension = extensions.find(extension => extension.identifier.id === 'ms-vscode.vscode-speech');
 			const extensionIsDisabled = extension && !workbenchExtensionEnablementService.isEnabled(extension);
 			const learnMoreAction = {
 				label: localize('viewExtension', "View Extension"),

--- a/src/vs/workbench/contrib/terminalContrib/voice/browser/terminalVoiceActions.ts
+++ b/src/vs/workbench/contrib/terminalContrib/voice/browser/terminalVoiceActions.ts
@@ -3,9 +3,13 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { localize2 } from '../../../../../nls.js';
-import { ContextKeyExpr } from '../../../../../platform/contextkey/common/contextkey.js';
+import { localize, localize2 } from '../../../../../nls.js';
+import { ICommandService } from '../../../../../platform/commands/common/commands.js';
+import { ContextKeyExpr, IContextKeyService } from '../../../../../platform/contextkey/common/contextkey.js';
+import { IExtensionManagementService } from '../../../../../platform/extensionManagement/common/extensionManagement.js';
 import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
+import { INotificationService, Severity } from '../../../../../platform/notification/common/notification.js';
+import { EnablementState, IWorkbenchExtensionEnablementService } from '../../../../services/extensionManagement/common/extensionManagement.js';
 import { HasSpeechProvider, SpeechToTextInProgress } from '../../../speech/common/speechService.js';
 import { registerActiveInstanceAction, sharedWhenClause } from '../../../terminal/browser/terminalActions.js';
 import { TerminalCommandId } from '../../../terminal/common/terminal.js';
@@ -17,14 +21,58 @@ export function registerTerminalVoiceActions() {
 		id: TerminalCommandId.StartVoice,
 		title: localize2('workbench.action.terminal.startDictation', "Start Dictation in Terminal"),
 		precondition: ContextKeyExpr.and(
-			HasSpeechProvider,
 			SpeechToTextInProgress.toNegated(),
 			sharedWhenClause.terminalAvailable
 		),
 		f1: true,
-		run: (activeInstance, c, accessor) => {
-			const instantiationService = accessor.get(IInstantiationService);
-			TerminalVoiceSession.getInstance(instantiationService).start();
+		run: async (activeInstance, c, accessor) => {
+			const contextKeyService = accessor.get(IContextKeyService);
+			const commandService = accessor.get(ICommandService);
+			const notificationService = accessor.get(INotificationService);
+			const workbenchExtensionEnablementService = accessor.get(IWorkbenchExtensionEnablementService);
+			const extensionManagementService = accessor.get(IExtensionManagementService);
+			if (HasSpeechProvider.getValue(contextKeyService)) {
+				const instantiationService = accessor.get(IInstantiationService);
+				TerminalVoiceSession.getInstance(instantiationService).start();
+				return;
+			}
+			const extensions = await extensionManagementService.getInstalled();
+			const extension = extensions.filter(extension => (extension.identifier.id === 'ms-vscode.vscode-speech'))?.[0];
+			const extensionIsDisabled = extension && !workbenchExtensionEnablementService.isEnabled(extension);
+			const learnMoreAction = {
+				label: localize('viewExtension', "View Extension"),
+				run: () => commandService.executeCommand('workbench.extensions.search', '@id:ms-vscode.vscode-speech'),
+				id: '',
+				tooltip: '',
+				class: undefined,
+				enabled: true
+			};
+
+			const actions = [];
+			let message;
+			if (extensionIsDisabled) {
+				message = localize('terminal.voice.enableSpeechExtension', "You must enable the Speech extension to use Dictation in the Terminal.");
+				actions.push({
+					id: 'enableSpeechExtension',
+					tooltip: '',
+					class: undefined,
+					enabled: true,
+					label: localize('enableSpeechExtension', "Enable for Workspace"),
+					run: () => workbenchExtensionEnablementService.setEnablement([extension], EnablementState.EnabledWorkspace),
+				}, learnMoreAction);
+			} else {
+				message = localize('terminal.voice.installSpeechExtension', "You must install the Speech extension to use Dictation in the Terminal.");
+				actions.push({
+					id: 'installSpeechExtension',
+					label: localize('installSpeechExtension', "Install Speech Extension"),
+					run: () => commandService.executeCommand('workbench.extensions.installExtension', 'ms-vscode.vscode-speech'),
+					tooltip: '',
+					class: undefined,
+					enabled: true
+				}, learnMoreAction);
+			}
+			notificationService.notify({ severity: Severity.Info, message, actions: { primary: actions } });
+			return;
 		}
 	});
 

--- a/src/vs/workbench/contrib/terminalContrib/voice/browser/terminalVoiceActions.ts
+++ b/src/vs/workbench/contrib/terminalContrib/voice/browser/terminalVoiceActions.ts
@@ -72,7 +72,6 @@ export function registerTerminalVoiceActions() {
 				}, learnMoreAction);
 			}
 			notificationService.notify({ severity: Severity.Info, message, actions: { primary: actions } });
-			return;
 		}
 	});
 


### PR DESCRIPTION
fix #269054

We added `Start Dictation` to the terminal's overflow menu to increase discoverability. That action relies on having the `VS Code Speech` extension installed. If users do not have the extension installed / enabled, we want to still show the action, but have it prompt them to install or enable the extension.

cc @bpasero - we could do something similar for editor dictation.

https://github.com/user-attachments/assets/41bad69b-c392-4f12-8e7f-eaac7bdb658a

