### PR TITLE
for tasks with problem matchers, don't pass back output, only succinct reply

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/taskHelpers.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/taskHelpers.ts
@@ -224,9 +224,8 @@ export async function taskProblemPollFn(execution: IExecution, token: Cancellati
 							? new Range(marker.startLineNumber, marker.startColumn, marker.endLineNumber, marker.endColumn)
 							: undefined
 					});
-					const label: string = uri ? uri.path.split('/').pop() ?? uri.toString() : '';
 					const message = marker.message ?? '';
-					problemList.push(`Problem: ${message} in ${label} coming from ${owner}`);
+					problemList.push(`Problem: ${message} in ${uri.fsPath} coming from ${owner} starting on line ${marker.startLineNumber}${marker.startColumn ? `, column ${marker.startColumn} and ending on line ${marker.endLineNumber}${marker.endColumn ? `, column ${marker.endColumn}` : ''}` : ''}`);
 				}
 			}
 			if (problemList.length === 0) {


### PR DESCRIPTION
fixes #269563

Discovered while investigating https://github.com/microsoft/vscode/issues/268782.

For tasks with problem matchers, we were still providing the task output, which could confuse the agent and lead it to mention earlier compilation problems when we know the exact number of problems. Now, for tasks with problem matchers, we only return the exact problems or that no problems were detected.

I thought by including the problems in `resources`, those were provided to the agent, but learned that's only for the UI 🤦🏼‍♀️ .

Before:

<img width="1224" height="911" alt="image" src="https://github.com/user-attachments/assets/57b05831-842d-44a9-a347-84c5774a526a" />

<img width="354" height="774" alt="image" src="https://github.com/user-attachments/assets/cbc401b5-2455-44c1-b36a-f833b1abc8e9" />

After:

<img width="720" height="477" alt="image" src="https://github.com/user-attachments/assets/df9aef6b-258b-43bf-9783-0467bfc0eef9" />

<img width="860" height="666" alt="Screenshot 2025-10-02 at 12 59 20 PM" src="https://github.com/user-attachments/assets/4da7abbf-9d33-4271-9b13-a89d04a936b4" />


<img width="610" height="663" alt="Screenshot 2025-10-02 at 12 59 49 PM" src="https://github.com/user-attachments/assets/c6f5f4fc-bc96-4405-922b-00bfe9437753" />


