### PR TITLE
html: add setting to disable end tag suggestions

### DIFF
--- a/extensions/html-language-features/package.json
+++ b/extensions/html-language-features/package.json
@@ -182,6 +182,12 @@
           "default": true,
           "description": "%html.suggest.html5.desc%"
         },
+        "html.suggest.hideEndTagSuggestions": {
+          "type": "boolean",
+          "scope": "resource",
+          "default": false,
+          "description": "%html.suggest.hideEndTagSuggestions.desc%"
+        },
         "html.validate.scripts": {
           "type": "boolean",
           "scope": "resource",

--- a/extensions/html-language-features/package.nls.json
+++ b/extensions/html-language-features/package.nls.json
@@ -23,6 +23,7 @@
 	"html.format.unformattedContentDelimiter.desc": "Keep text content together between this string.",
 	"html.format.wrapAttributesIndentSize.desc": "Indent wrapped attributes to after N characters. Use `null` to use the default indent size. Ignored if `#html.format.wrapAttributes#` is set to `aligned`.",
 	"html.suggest.html5.desc": "Controls whether the built-in HTML language support suggests HTML5 tags, properties and values.",
+	"html.suggest.hideEndTagSuggestions.desc": "Controls whether the built-in HTML language support suggests closing tags. When disabled, end tag completions like `</div>` will not be shown.",
 	"html.trace.server.desc": "Traces the communication between VS Code and the HTML language server.",
 	"html.validate.scripts": "Controls whether the built-in HTML language support validates embedded scripts.",
 	"html.validate.styles": "Controls whether the built-in HTML language support validates embedded styles.",


### PR DESCRIPTION
Closes microsoft/vscode-html-languageservice#216

## Summary

This PR adds a new setting `html.suggest.hideEndTagSuggestions` to the HTML extension, allowing users to disable automatic end tag completion suggestions.

## Related Changes

⚠️ **Important**: This PR has corresponding changes in the **vscode-html-languageservice** repository: microsoft/vscode-html-languageservice#219

## Changes

### Added
- **New Setting**: `html.suggest.hideEndTagSuggestions`
  - Type: `boolean`
  - Default: `false`
  - Description: "When enabled, end tag completion suggestions will not be shown"
  - Location: `extensions/html-language-features/package.json`

### Files Modified
- `extensions/html-language-features/package.json` - Added new configuration setting
- `extensions/html-language-features/package.nls.json` - Added localized description

## Behavior

### Before
Users had no way to disable end tag suggestions. The `html.suggest.html5` setting only controlled element suggestions but not closing tag suggestions.

### After
Users can now set `html.suggest.hideEndTagSuggestions: true` to disable end tag completion suggestions:

```json
{
  "html.suggest.hideEndTagSuggestions": true
}
```

When typing:
```html
<body>
<
```

With the setting disabled (default), users see closing tag suggestions like `</body>`.
With the setting enabled, no closing tag suggestions appear.

## Testing

This setting relies on the underlying implementation in microsoft/vscode-html-languageservice#219 which includes comprehensive unit tests.

Manual testing:
1. Open an HTML file
2. Type `<body>\n<` and verify closing tag suggestion appears
3. Enable `html.suggest.hideEndTagSuggestions`
4. Type `<body>\n<` and verify no closing tag suggestion appears

## Dependencies

This PR depends on an updated version of `vscode-html-languageservice` that includes support for the `hideEndTagSuggestions` option in the `CompletionConfiguration` interface.

## Checklist

- [x] Code follows VS Code contribution guidelines
- [x] Setting added to `package.json` with appropriate metadata
- [x] Localized strings added to `package.nls.json`
- [x] Setting description is clear and user-friendly
- [x] Commit message follows conventional format
- [x] Changes are backward compatible (default behavior unchanged)
