### PR TITLE
mcp: fix user interaction notification for variable resolution

### DIFF
--- a/src/vs/workbench/contrib/mcp/common/mcpRegistry.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpRegistry.ts
@@ -508,6 +508,10 @@ export class McpRegistry extends Disposable implements IMcpRegistry {
 				launch = await this._instantiationService.invokeFunction(accessor => accessor.get(IMcpDevModeDebugging).transform(definition, launch!));
 			}
 		} catch (e) {
+			if (e instanceof UserInteractionRequiredError) {
+				throw e;
+			}
+
 			this._notificationService.notify({
 				severity: Severity.Error,
 				message: localize('mcp.launchError', 'Error starting {0}: {1}', definition.label, String(e)),


### PR DESCRIPTION
The UserInteractionRequiredError should instead be thrown to be
handled by the autostart logic.

Closes https://github.com/microsoft/vscode/issues/269625

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
