### PR TITLE
Fix powershell venv Python prompt

### DIFF
--- a/src/vs/workbench/contrib/terminal/common/scripts/shellIntegration.ps1
+++ b/src/vs/workbench/contrib/terminal/common/scripts/shellIntegration.ps1
@@ -82,6 +82,7 @@ if (-not $env:VSCODE_PYTHON_AUTOACTIVATE_GUARD) {
 
 		try {
 			Invoke-Expression $activateScript
+			$Global:__VSCodeState.OriginalPrompt = $function:Prompt
 		}
 		catch {
 			$activationError = $_


### PR DESCRIPTION
Resolves: https://github.com/microsoft/vscode/issues/269636

/cc @karthiknadig @Tyriar 

This would make sure the prompt for ps1 gets properly updated with (.venv) 


Candidate: https://github.com/microsoft/vscode/pull/269739 