### PR TITLE
Fix blue NES arrow display issue for code block highlighting

### DIFF
--- a/src/vs/editor/contrib/inlineCompletions/browser/model/inlineCompletionsModel.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/model/inlineCompletionsModel.ts
@@ -823,6 +823,9 @@ export class InlineCompletionsModel extends Disposable {
 		if (this.showCollapsed.read(reader)) {
 			return false;
 		}
+		if (this._tabShouldIndent.read(reader)) {
+			return false;
+		}
 		if (this._inAcceptFlow.read(reader) && this._appearedInsideViewport.read(reader)) {
 			return true;
 		}
@@ -831,9 +834,6 @@ export class InlineCompletionsModel extends Disposable {
 		}
 		if (this._jumpedToId.read(reader) === s.inlineCompletion.semanticId) {
 			return true;
-		}
-		if (this._tabShouldIndent.read(reader)) {
-			return false;
 		}
 
 		return s.cursorAtInlineEdit.read(reader);


### PR DESCRIPTION
```Copilot Generated Description:``` Adjust the logic in the `InlineCompletionsModel` to correctly handle the display of the blue NES arrow when a code block is highlighted. This change ensures that the arrow only appears when appropriate conditions are met.

Fixes microsoft/vscode-copilot-issues#297