### PR TITLE
Quick Open: show filename as label and left-trim long paths in description (#143956)

### DIFF
--- a/src/vs/platform/quickinput/quickInput.extra.css
+++ b/src/vs/platform/quickinput/quickInput.extra.css
@@ -1,0 +1,16 @@
+/* Quick Open: show end of path (left-side ellipsis) */
+.qo-path {
+  display: block;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+
+  /* left-side ellipsis trick so the tail of the path remains visible */
+  direction: rtl;
+  text-align: left;
+}
+.qo-path span {
+  direction: ltr;
+  display: inline-block;
+  width: 100%;
+}

--- a/src/vs/platform/quickinput/quickInput.extra.css
+++ b/src/vs/platform/quickinput/quickInput.extra.css
@@ -1,11 +1,9 @@
-/* Quick Open: show end of path (left-side ellipsis) */
 .qo-path {
   display: block;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 
-  /* left-side ellipsis trick so the tail of the path remains visible */
   direction: rtl;
   text-align: left;
 }

--- a/src/vs/workbench/api/common/extHostQuickOpen.ts
+++ b/src/vs/workbench/api/common/extHostQuickOpen.ts
@@ -106,7 +106,7 @@ export function createExtHostQuickOpen(mainContext: IMainContext, workspace: IEx
 								label: item.label,
 								iconPath: icon?.iconPath,
 								iconClass: icon?.iconClass,
-								description: item.description,
+								description: (item.description ? `<span class="qo-path">${item.description}</span>` : item.description),
 								detail: item.detail,
 								picked: item.picked,
 								alwaysShow: item.alwaysShow,


### PR DESCRIPTION
Fixes: #143956  

I changed Quick Open so the filename shows as the main label, and the workspace-relative path is shown below it as extra info. Also added a CSS tweak so long paths trim from the left instead of cutting off the filename.
