### PR TITLE
Update chat sessions hover to not block the items

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatSessions/view/chatSessionsView.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSessions/view/chatSessionsView.ts
@@ -266,13 +266,14 @@ class ChatSessionsViewPaneContainer extends ViewPaneContainer {
 			orderedProviders.forEach(({ provider, displayName, baseOrder, when }) => {
 				// Only register if not already registered
 				if (!this.registeredViewDescriptors.has(provider.chatSessionType)) {
+					const viewId = `${VIEWLET_ID}.${provider.chatSessionType}`;
 					const viewDescriptor: IViewDescriptor = {
-						id: `${VIEWLET_ID}.${provider.chatSessionType}`,
+						id: viewId,
 						name: {
 							value: displayName,
 							original: displayName,
 						},
-						ctorDescriptor: new SyncDescriptor(SessionsViewPane, [provider, this.sessionTracker, `${VIEWLET_ID}.${provider.chatSessionType}`]),
+						ctorDescriptor: new SyncDescriptor(SessionsViewPane, [provider, this.sessionTracker, viewId]),
 						canToggleVisibility: true,
 						canMoveView: true,
 						order: baseOrder, // Use computed order based on priority and alphabetical sorting

--- a/src/vs/workbench/contrib/chat/browser/chatSessions/view/chatSessionsView.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSessions/view/chatSessionsView.ts
@@ -272,7 +272,7 @@ class ChatSessionsViewPaneContainer extends ViewPaneContainer {
 							value: displayName,
 							original: displayName,
 						},
-						ctorDescriptor: new SyncDescriptor(SessionsViewPane, [provider, this.sessionTracker]),
+						ctorDescriptor: new SyncDescriptor(SessionsViewPane, [provider, this.sessionTracker, `${VIEWLET_ID}.${provider.chatSessionType}`]),
 						canToggleVisibility: true,
 						canMoveView: true,
 						order: baseOrder, // Use computed order based on priority and alphabetical sorting
@@ -301,7 +301,7 @@ class ChatSessionsViewPaneContainer extends ViewPaneContainer {
 						value: nls.localize('chat.sessions.gettingStarted', "Getting Started"),
 						original: 'Getting Started',
 					},
-					ctorDescriptor: new SyncDescriptor(SessionsViewPane, [null, this.sessionTracker]),
+					ctorDescriptor: new SyncDescriptor(SessionsViewPane, [null, this.sessionTracker, gettingStartedViewId]),
 					canToggleVisibility: true,
 					canMoveView: true,
 					order: 1000,

--- a/src/vs/workbench/contrib/chat/browser/chatSessions/view/sessionsTreeRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSessions/view/sessionsTreeRenderer.ts
@@ -138,16 +138,13 @@ export class SessionsRenderer extends Disposable implements ITreeRenderer<IChatS
 
 	private getHoverPosition(): HoverPosition {
 		const sideBarPosition = this.layoutService.getSideBarPosition();
-
-		if (this.viewLocation === ViewContainerLocation.Sidebar) {
-			const hoverPosition = sideBarPosition === Position.LEFT ? HoverPosition.RIGHT : HoverPosition.LEFT;
-			return hoverPosition;
-		} else if (this.viewLocation === ViewContainerLocation.AuxiliaryBar) {
-			const hoverPosition = sideBarPosition === Position.LEFT ? HoverPosition.LEFT : HoverPosition.RIGHT;
-			return hoverPosition;
-		} else {
-			const hoverPosition = HoverPosition.RIGHT;
-			return hoverPosition;
+		switch (this.viewLocation) {
+			case ViewContainerLocation.Sidebar:
+				return sideBarPosition === Position.LEFT ? HoverPosition.RIGHT : HoverPosition.LEFT;
+			case ViewContainerLocation.AuxiliaryBar:
+				return sideBarPosition === Position.LEFT ? HoverPosition.LEFT : HoverPosition.RIGHT;
+			default:
+				return HoverPosition.RIGHT;
 		}
 	}
 

--- a/src/vs/workbench/contrib/chat/browser/chatSessions/view/sessionsTreeRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSessions/view/sessionsTreeRenderer.ts
@@ -140,16 +140,16 @@ export class SessionsRenderer extends Disposable implements ITreeRenderer<IChatS
 		const viewLocation = this.viewDescriptorService.getViewLocationById('workbench.panel.chatSessions');
 		const sideBarPosition = this.layoutService.getSideBarPosition();
 
-		let hoverPosition: HoverPosition;
 		if (viewLocation === ViewContainerLocation.Sidebar) {
-			hoverPosition = sideBarPosition === Position.LEFT ? HoverPosition.RIGHT : HoverPosition.LEFT;
+			const hoverPosition = sideBarPosition === Position.LEFT ? HoverPosition.RIGHT : HoverPosition.LEFT;
+			return hoverPosition;
 		} else if (viewLocation === ViewContainerLocation.AuxiliaryBar) {
-			hoverPosition = sideBarPosition === Position.LEFT ? HoverPosition.LEFT : HoverPosition.RIGHT;
+			const hoverPosition = sideBarPosition === Position.LEFT ? HoverPosition.LEFT : HoverPosition.RIGHT;
+			return hoverPosition;
 		} else {
-			hoverPosition = HoverPosition.RIGHT;
+			const hoverPosition = HoverPosition.RIGHT;
+			return hoverPosition;
 		}
-
-		return hoverPosition;
 	}
 
 	renderTemplate(container: HTMLElement): ISessionTemplateData {

--- a/src/vs/workbench/contrib/chat/browser/chatSessions/view/sessionsTreeRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSessions/view/sessionsTreeRenderer.ts
@@ -32,7 +32,7 @@ import product from '../../../../../../platform/product/common/product.js';
 import { defaultInputBoxStyles } from '../../../../../../platform/theme/browser/defaultStyles.js';
 import { HoverPosition } from '../../../../../../base/browser/ui/hover/hoverWidget.js';
 import { IWorkbenchLayoutService, Position } from '../../../../../services/layout/browser/layoutService.js';
-import { ViewContainerLocation, IViewDescriptorService, IEditableData } from '../../../../../common/views.js';
+import { ViewContainerLocation, IEditableData } from '../../../../../common/views.js';
 import { IResourceLabel, ResourceLabels } from '../../../../../browser/labels.js';
 import { IconLabel } from '../../../../../../base/browser/ui/iconLabel/iconLabel.js';
 import { IEditorGroupsService } from '../../../../../services/editor/common/editorGroupsService.js';
@@ -114,6 +114,7 @@ export class SessionsRenderer extends Disposable implements ITreeRenderer<IChatS
 	private markdownRenderer: MarkdownRenderer;
 
 	constructor(
+		private readonly viewLocation: ViewContainerLocation | null,
 		@IContextViewService private readonly contextViewService: IContextViewService,
 		@IConfigurationService private readonly configurationService: IConfigurationService,
 		@IChatSessionsService private readonly chatSessionsService: IChatSessionsService,
@@ -124,7 +125,6 @@ export class SessionsRenderer extends Disposable implements ITreeRenderer<IChatS
 		@IChatWidgetService private readonly chatWidgetService: IChatWidgetService,
 		@IChatService private readonly chatService: IChatService,
 		@IEditorGroupsService private readonly editorGroupsService: IEditorGroupsService,
-		@IViewDescriptorService private readonly viewDescriptorService: IViewDescriptorService,
 		@IWorkbenchLayoutService private readonly layoutService: IWorkbenchLayoutService,
 	) {
 		super();
@@ -137,13 +137,12 @@ export class SessionsRenderer extends Disposable implements ITreeRenderer<IChatS
 	}
 
 	private getHoverPosition(): HoverPosition {
-		const viewLocation = this.viewDescriptorService.getViewLocationById('workbench.panel.chatSessions');
 		const sideBarPosition = this.layoutService.getSideBarPosition();
 
-		if (viewLocation === ViewContainerLocation.Sidebar) {
+		if (this.viewLocation === ViewContainerLocation.Sidebar) {
 			const hoverPosition = sideBarPosition === Position.LEFT ? HoverPosition.RIGHT : HoverPosition.LEFT;
 			return hoverPosition;
-		} else if (viewLocation === ViewContainerLocation.AuxiliaryBar) {
+		} else if (this.viewLocation === ViewContainerLocation.AuxiliaryBar) {
 			const hoverPosition = sideBarPosition === Position.LEFT ? HoverPosition.LEFT : HoverPosition.RIGHT;
 			return hoverPosition;
 		} else {

--- a/src/vs/workbench/contrib/chat/browser/chatSessions/view/sessionsTreeRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSessions/view/sessionsTreeRenderer.ts
@@ -49,8 +49,6 @@ import { ChatSessionTracker } from '../chatSessionTracker.js';
 import { CancellationToken } from '../../../../../../base/common/cancellation.js';
 import { getLocalHistoryDateFormatter } from '../../../../localHistory/browser/localHistory.js';
 
-
-
 interface ISessionTemplateData {
 	readonly container: HTMLElement;
 	readonly iconLabel: IconLabel;

--- a/src/vs/workbench/contrib/chat/browser/chatSessions/view/sessionsViewPane.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSessions/view/sessionsViewPane.ts
@@ -81,6 +81,7 @@ export class SessionsViewPane extends ViewPane {
 	constructor(
 		private readonly provider: IChatSessionItemProvider,
 		private readonly sessionTracker: ChatSessionTracker,
+		private readonly viewId: string,
 		options: IViewPaneOptions,
 		@IKeybindingService keybindingService: IKeybindingService,
 		@IContextMenuService contextMenuService: IContextMenuService,
@@ -296,7 +297,7 @@ export class SessionsViewPane extends ViewPane {
 		const accessibilityProvider = new SessionsAccessibilityProvider();
 
 		// Use the existing ResourceLabels service for consistent styling
-		const renderer = this.instantiationService.createInstance(SessionsRenderer);
+		const renderer = this.instantiationService.createInstance(SessionsRenderer, this.viewDescriptorService.getViewLocationById(this.viewId));
 		this._register(renderer);
 
 		const getResourceForElement = (element: ChatSessionItemWithProvider): URI | null => {

--- a/src/vs/workbench/contrib/chat/browser/chatSessions/view/sessionsViewPane.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSessions/view/sessionsViewPane.ts
@@ -298,6 +298,7 @@ export class SessionsViewPane extends ViewPane {
 		// Use the existing ResourceLabels service for consistent styling
 		const renderer = this.instantiationService.createInstance(SessionsRenderer);
 		this._register(renderer);
+
 		const getResourceForElement = (element: ChatSessionItemWithProvider): URI | null => {
 			if (element.id === LocalChatSessionsProvider.CHAT_WIDGET_VIEW_ID) {
 				return null;

--- a/src/vs/workbench/contrib/chat/browser/chatSessions/view/sessionsViewPane.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSessions/view/sessionsViewPane.ts
@@ -297,7 +297,8 @@ export class SessionsViewPane extends ViewPane {
 
 		// Use the existing ResourceLabels service for consistent styling
 		const renderer = this.instantiationService.createInstance(SessionsRenderer);
-		this._register(renderer); const getResourceForElement = (element: ChatSessionItemWithProvider): URI | null => {
+		this._register(renderer);
+		const getResourceForElement = (element: ChatSessionItemWithProvider): URI | null => {
 			if (element.id === LocalChatSessionsProvider.CHAT_WIDGET_VIEW_ID) {
 				return null;
 			}

--- a/src/vs/workbench/contrib/chat/browser/chatSessions/view/sessionsViewPane.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSessions/view/sessionsViewPane.ts
@@ -297,9 +297,7 @@ export class SessionsViewPane extends ViewPane {
 
 		// Use the existing ResourceLabels service for consistent styling
 		const renderer = this.instantiationService.createInstance(SessionsRenderer);
-		this._register(renderer);
-
-		const getResourceForElement = (element: ChatSessionItemWithProvider): URI | null => {
+		this._register(renderer); const getResourceForElement = (element: ChatSessionItemWithProvider): URI | null => {
 			if (element.id === LocalChatSessionsProvider.CHAT_WIDGET_VIEW_ID) {
 				return null;
 			}


### PR DESCRIPTION
Fixes #268298

Updated the chat sessions hover to place it on the right or left instead of top which was blocking the items.

Before:
<img width="1102" height="371" alt="image" src="https://github.com/user-attachments/assets/ab44847d-8da6-458e-81ff-7662a763f220" />

After:
<img width="1355" height="366" alt="image" src="https://github.com/user-attachments/assets/cf70365b-cdbb-467c-be7c-a1b901ca6e39" />
