### PR TITLE
Update PHPDoc array tokenization with spaces and newlines

### DIFF
--- a/extensions/php/syntaxes/php.tmLanguage.json
+++ b/extensions/php/syntaxes/php.tmLanguage.json
@@ -2931,9 +2931,12 @@
 			]
 		},
 		"php_doc_types_array_shape": {
-			"begin": "\\{",
+			"begin": "(array)(\\{)",
 			"beginCaptures": {
-				"0": {
+				"1": {
+					"name": "keyword.other.type.php"
+				},
+				"2": {
 					"name": "punctuation.definition.type.begin.bracket.curly.phpdoc.php"
 				}
 			},
@@ -2966,9 +2969,12 @@
 			]
 		},
 		"php_doc_types_array_with_key_type": {
-			"begin": "\\<",
+			"begin": "(array)(\\<)",
 			"beginCaptures": {
-				"0": {
+				"1": {
+					"name": "keyword.other.type.php"
+				},
+				"2": {
 					"name": "punctuation.definition.type.begin.bracket.angle.phpdoc.php"
 				}
 			},

--- a/extensions/php/syntaxes/php.tmLanguage.json
+++ b/extensions/php/syntaxes/php.tmLanguage.json
@@ -2839,6 +2839,12 @@
 							"include": "#php_doc_types_array_single"
 						},
 						{
+							"include": "#php_doc_types_array_with_key_type"
+						},
+						{
+							"include": "#php_doc_types_array_shape"
+						},
+						{
 							"include": "#php_doc_types"
 						},
 						{
@@ -2910,10 +2916,86 @@
 					"include": "#php_doc_types_array_single"
 				},
 				{
+					"include": "#php_doc_types_array_with_key_type"
+				},
+				{
+					"include": "#php_doc_types_array_shape"
+				},
+				{
 					"include": "#php_doc_types"
 				},
 				{
 					"match": "[|&]",
+					"name": "punctuation.separator.delimiter.php"
+				}
+			]
+		},
+		"php_doc_types_array_shape": {
+			"begin": "\\{",
+			"beginCaptures": {
+				"0": {
+					"name": "punctuation.definition.type.begin.bracket.curly.phpdoc.php"
+				}
+			},
+			"end": "(\\})",
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.definition.type.end.bracket.curly.phpdoc.php"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#php_doc_types_array_multiple"
+				},
+				{
+					"include": "#php_doc_types_array_single"
+				},
+				{
+					"include": "#php_doc_types_array_with_key_type"
+				},
+				{
+					"include": "#php_doc_types_array_shape"
+				},
+				{
+					"include": "#php_doc_types"
+				},
+				{
+					"match": "[,]\\s*",
+					"name": "punctuation.separator.delimiter.php"
+				}
+			]
+		},
+		"php_doc_types_array_with_key_type": {
+			"begin": "\\<",
+			"beginCaptures": {
+				"0": {
+					"name": "punctuation.definition.type.begin.bracket.angle.phpdoc.php"
+				}
+			},
+			"end": "(\\>)",
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.definition.type.end.bracket.angle.phpdoc.php"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#php_doc_types_array_multiple"
+				},
+				{
+					"include": "#php_doc_types_array_single"
+				},
+				{
+					"include": "#php_doc_types_array_with_key_type"
+				},
+				{
+					"include": "#php_doc_types_array_shape"
+				},
+				{
+					"include": "#php_doc_types"
+				},
+				{
+					"match": "[,]\\s*",
 					"name": "punctuation.separator.delimiter.php"
 				}
 			]


### PR DESCRIPTION
Closes https://github.com/microsoft/vscode/issues/269846

See issue for example code and a before and after screenshot from this PR.


Based on https://github.com/microsoft/vscode/issues/162707 and the code comments below, I wasn't clear which repo the change needed to be submitted to or if it needed to be in both, so I did both.

https://github.com/microsoft/vscode/blob/9defb53a3bf4267858fb2a57a47cdd8c244c261f/extensions/php/syntaxes/php.tmLanguage.json#L2-L7

The other report PR is https://github.com/KapitanOczywisty/language-php/pull/33.