### PR TITLE
Git - respect configured submodule names in SCM

### DIFF
--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -890,6 +890,10 @@ export interface Submodule {
 	url: string;
 }
 
+export function getSubmoduleDisplayName(submodule: Submodule): string | undefined {
+	return submodule.name !== submodule.path ? submodule.name : undefined;
+}
+
 export function parseGitmodules(raw: string): Submodule[] {
 	const result: Submodule[] = [];
 

--- a/extensions/git/src/model.ts
+++ b/extensions/git/src/model.ts
@@ -24,7 +24,7 @@ import { RepositoryCache } from './repositoryCache';
 
 class RepositoryPick implements QuickPickItem {
 	@memoize get label(): string {
-		return path.basename(this.repository.root);
+		return this.repository.name;
 	}
 
 	@memoize get description(): string {

--- a/extensions/git/src/repository.ts
+++ b/extensions/git/src/repository.ts
@@ -18,7 +18,7 @@ import { ForcePushMode, GitErrorCodes, RefType, Status } from './api/git.constan
 import { AutoFetcher } from './autofetch';
 import { GitBranchProtectionProvider, IBranchProtectionProviderRegistry } from './branchProtection';
 import { debounce, memoize, sequentialize, throttle } from './decorators';
-import { Repository as BaseRepository, BlameInformation, Commit, CommitShortStat, GitError, IDotGit, LogFileOptions, LsTreeElement, PullOptions, RefQuery, Stash, Submodule, Worktree } from './git';
+import { Repository as BaseRepository, BlameInformation, Commit, CommitShortStat, getSubmoduleDisplayName, GitError, IDotGit, LogFileOptions, LsTreeElement, PullOptions, RefQuery, Stash, Submodule, Worktree } from './git';
 import { GitHistoryProvider } from './historyProvider';
 import { Operation, OperationKind, OperationManager, OperationResult } from './operation';
 import { CommitCommandsCenter, IPostCommitCommandsProviderRegistry } from './postCommitCommands';
@@ -734,6 +734,9 @@ export class Repository implements Disposable {
 	private _sourceControl: SourceControl;
 	get sourceControl(): SourceControl { return this._sourceControl; }
 
+	private readonly _name: string | undefined;
+	get name(): string { return this._name ?? path.basename(this.root); }
+
 	get inputBox(): SourceControlInputBox { return this._sourceControl.inputBox; }
 
 	private _mergeGroup: SourceControlResourceGroup;
@@ -957,9 +960,17 @@ export class Repository implements Disposable {
 				: repository.kind === 'worktree' && repository.dotGit.commonPath
 					? path.dirname(repository.dotGit.commonPath)
 					: undefined;
-		const parent = parentRoot
-			? this.repositoryResolver.getRepository(parentRoot)?.sourceControl
+		const parentRepository = parentRoot
+			? this.repositoryResolver.getRepository(parentRoot)
 			: undefined;
+		const parent = parentRepository?.sourceControl;
+
+		let submodule: Submodule | undefined;
+		if (repository.kind === 'submodule' && parentRepository) {
+			submodule = parentRepository.submodules.find(submodule =>
+				pathEquals(path.join(parentRepository.root, submodule.path), repository.root));
+		}
+		this._name = submodule ? getSubmoduleDisplayName(submodule) : undefined;
 
 		// Icon
 		const icon = repository.kind === 'submodule'
@@ -981,7 +992,7 @@ export class Repository implements Disposable {
 				isCopilotWorktreeFolder(repository.root) && parent !== undefined);
 
 		const root = Uri.file(repository.root);
-		this._sourceControl = scm.createSourceControl('git', 'Git', root, icon, this._isHidden, parent);
+		this._sourceControl = scm.createSourceControl('git', 'Git', root, icon, this._isHidden, parent, this._name);
 		this._sourceControl.contextValue = repository.kind;
 
 		this._sourceControl.quickDiffProvider = new GitQuickDiffProvider(this, this.repositoryResolver, logger);

--- a/extensions/git/src/test/git.test.ts
+++ b/extensions/git/src/test/git.test.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import 'mocha';
-import { GitStatusParser, parseGitCommits, parseGitmodules, parseLsTree, parseLsFiles, parseGitRemotes, parseCoAuthors } from '../git';
+import { getSubmoduleDisplayName, GitStatusParser, parseGitCommits, parseGitmodules, parseLsTree, parseLsFiles, parseGitRemotes, parseCoAuthors } from '../git';
 import * as assert from 'assert';
 import { splitInChunks } from '../util';
 
@@ -194,6 +194,16 @@ suite('git', () => {
 			assert.deepStrictEqual(parseGitmodules(sample), [
 				{ name: 'deps/spdlog', path: 'deps/spdlog', url: 'https://github.com/gabime/spdlog.git' }
 			]);
+		});
+	});
+
+	suite('getSubmoduleDisplayName', () => {
+		test('returns customized names only', () => {
+			assert.deepStrictEqual([
+				getSubmoduleDisplayName({ name: 'mpil', path: 'dependencies/metaprogramming', url: 'https://example.com/mpil.git' }),
+				getSubmoduleDisplayName({ name: 'dependencies/spdlog', path: 'dependencies/spdlog', url: 'https://example.com/spdlog.git' }),
+				getSubmoduleDisplayName({ name: 'foo', path: 'dependencies/foo', url: 'https://example.com/foo.git' })
+			], ['mpil', undefined, 'foo']);
 		});
 	});
 

--- a/src/vs/workbench/api/browser/mainThreadSCM.ts
+++ b/src/vs/workbench/api/browser/mainThreadSCM.ts
@@ -355,12 +355,15 @@ class MainThreadSCMProvider implements ISCMProvider {
 		private readonly _rootUri: URI | undefined,
 		private readonly _iconPath: URI | { light: URI; dark: URI } | ThemeIcon | undefined,
 		private readonly _isHidden: boolean | undefined,
+		name: string | undefined,
 		private readonly _inputBoxTextModel: ITextModel,
 		private readonly _quickDiffService: IQuickDiffService,
 		private readonly _uriIdentService: IUriIdentityService,
 		private readonly _workspaceContextService: IWorkspaceContextService
 	) {
-		if (_rootUri) {
+		if (name !== undefined) {
+			this._name = name;
+		} else if (_rootUri) {
 			const folder = this._workspaceContextService.getWorkspaceFolder(_rootUri);
 			if (folder?.uri.toString() === _rootUri.toString()) {
 				this._name = folder.name;
@@ -639,11 +642,11 @@ export class MainThreadSCM implements MainThreadSCMShape {
 		this._disposables.dispose();
 	}
 
-	async $registerSourceControl(handle: number, parentHandle: number | undefined, id: string, label: string, rootUri: UriComponents | undefined, iconPath: UriComponents | { light: UriComponents; dark: UriComponents } | ThemeIcon | undefined, isHidden: boolean | undefined, inputBoxDocumentUri: UriComponents): Promise<void> {
+	async $registerSourceControl(handle: number, parentHandle: number | undefined, id: string, label: string, rootUri: UriComponents | undefined, iconPath: UriComponents | { light: UriComponents; dark: UriComponents } | ThemeIcon | undefined, isHidden: boolean | undefined, inputBoxDocumentUri: UriComponents, name: string | undefined): Promise<void> {
 		this._repositoryBarriers.set(handle, new Barrier());
 
 		const inputBoxTextModelRef = await this.textModelService.createModelReference(URI.revive(inputBoxDocumentUri));
-		const provider = new MainThreadSCMProvider(this._proxy, handle, parentHandle, id, label, rootUri ? URI.revive(rootUri) : undefined, getIconFromIconDto(iconPath), isHidden, inputBoxTextModelRef.object.textEditorModel, this.quickDiffService, this._uriIdentService, this.workspaceContextService);
+		const provider = new MainThreadSCMProvider(this._proxy, handle, parentHandle, id, label, rootUri ? URI.revive(rootUri) : undefined, getIconFromIconDto(iconPath), isHidden, name, inputBoxTextModelRef.object.textEditorModel, this.quickDiffService, this._uriIdentService, this.workspaceContextService);
 		const repository = this.scmService.registerSCMProvider(provider);
 		this._repositories.set(handle, repository);
 

--- a/src/vs/workbench/api/common/extHost.api.impl.ts
+++ b/src/vs/workbench/api/common/extHost.api.impl.ts
@@ -1504,11 +1504,11 @@ export function createApiFactoryAndRegisterActors(accessor: ServicesAccessor): I
 
 				return extHostSCM.getLastInputBox(extension)!; // Strict null override - Deprecated api
 			},
-			createSourceControl(id: string, label: string, rootUri?: vscode.Uri, iconPath?: vscode.IconPath, isHidden?: boolean, parent?: vscode.SourceControl): vscode.SourceControl {
-				if (iconPath || isHidden || parent) {
+			createSourceControl(id: string, label: string, rootUri?: vscode.Uri, iconPath?: vscode.IconPath, isHidden?: boolean, parent?: vscode.SourceControl, name?: string): vscode.SourceControl {
+				if (iconPath || isHidden || parent || name !== undefined) {
 					checkProposedApiEnabled(extension, 'scmProviderOptions');
 				}
-				return extHostSCM.createSourceControl(extension, id, label, rootUri, iconPath, isHidden, parent);
+				return extHostSCM.createSourceControl(extension, id, label, rootUri, iconPath, isHidden, parent, name);
 			}
 		};
 

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -2170,7 +2170,7 @@ export interface SCMArtifactDto {
 }
 
 export interface MainThreadSCMShape extends IDisposable {
-	$registerSourceControl(handle: number, parentHandle: number | undefined, id: string, label: string, rootUri: UriComponents | undefined, iconPath: IconPathDto | undefined, isHidden: boolean | undefined, inputBoxDocumentUri: UriComponents): Promise<void>;
+	$registerSourceControl(handle: number, parentHandle: number | undefined, id: string, label: string, rootUri: UriComponents | undefined, iconPath: IconPathDto | undefined, isHidden: boolean | undefined, inputBoxDocumentUri: UriComponents, name: string | undefined): Promise<void>;
 	$updateSourceControl(handle: number, features: SCMProviderFeatures): Promise<void>;
 	$unregisterSourceControl(handle: number): Promise<void>;
 

--- a/src/vs/workbench/api/common/extHostSCM.ts
+++ b/src/vs/workbench/api/common/extHostSCM.ts
@@ -820,7 +820,8 @@ class ExtHostSourceControl implements vscode.SourceControl {
 		private _rootUri?: vscode.Uri,
 		_iconPath?: vscode.IconPath,
 		_isHidden?: boolean,
-		_parent?: ExtHostSourceControl
+		_parent?: ExtHostSourceControl,
+		_name?: string
 	) {
 		this.#proxy = proxy;
 
@@ -831,7 +832,7 @@ class ExtHostSourceControl implements vscode.SourceControl {
 		});
 
 		this._inputBox = new ExtHostSCMInputBox(_extension, _extHostDocuments, this.#proxy, this.handle, inputBoxDocumentUri);
-		this.#proxy.$registerSourceControl(this.handle, _parent?.handle, _id, _label, _rootUri, getHistoryItemIconDto(_iconPath), _isHidden, inputBoxDocumentUri);
+		this.#proxy.$registerSourceControl(this.handle, _parent?.handle, _id, _label, _rootUri, getHistoryItemIconDto(_iconPath), _isHidden, inputBoxDocumentUri, _name);
 
 		this.onDidDisposeParent = _parent ? _parent.onDidDispose : Event.None;
 	}
@@ -1005,7 +1006,7 @@ export class ExtHostSCM implements ExtHostSCMShape {
 		});
 	}
 
-	createSourceControl(extension: IExtensionDescription, id: string, label: string, rootUri: vscode.Uri | undefined, iconPath: vscode.IconPath | undefined, isHidden: boolean | undefined, parent: vscode.SourceControl | undefined): vscode.SourceControl {
+	createSourceControl(extension: IExtensionDescription, id: string, label: string, rootUri: vscode.Uri | undefined, iconPath: vscode.IconPath | undefined, isHidden: boolean | undefined, parent: vscode.SourceControl | undefined, name: string | undefined): vscode.SourceControl {
 		this.logService.trace('ExtHostSCM#createSourceControl', extension.identifier.value, id, label, rootUri);
 
 		type TEvent = { extensionId: string };
@@ -1019,7 +1020,7 @@ export class ExtHostSCM implements ExtHostSCMShape {
 		});
 
 		const parentSourceControl = parent ? Iterable.find(this._sourceControls.values(), s => s === parent) : undefined;
-		const sourceControl = new ExtHostSourceControl(extension, this._extHostDocuments, this._proxy, this._commands, id, label, rootUri, iconPath, isHidden, parentSourceControl);
+		const sourceControl = new ExtHostSourceControl(extension, this._extHostDocuments, this._proxy, this._commands, id, label, rootUri, iconPath, isHidden, parentSourceControl, name);
 		this._sourceControls.set(sourceControl.handle, sourceControl);
 
 		const sourceControls = this._sourceControlsByExtension.get(extension.identifier) || [];

--- a/src/vs/workbench/api/test/common/extHostSCM.test.ts
+++ b/src/vs/workbench/api/test/common/extHostSCM.test.ts
@@ -56,7 +56,7 @@ suite('ExtHostSCM', () => {
 		assert.strictEqual(extHostSCM.getLastInputBox(extension), undefined);
 	});
 
-	test('repository names are forwarded when source controls are registered', () => {
+	test('repository names are forwarded when source controls are registered', async () => {
 		const registeredNames: (string | undefined)[] = [];
 		const rpcProtocol = new TestRPCProtocol();
 		rpcProtocol.set(MainContext.MainThreadSCM, new class extends mock<MainThreadSCMShape>() {
@@ -91,9 +91,11 @@ suite('ExtHostSCM', () => {
 		const unnamedSourceControl = extHostSCM.createSourceControl(extension, 'git', 'Git', URI.file('/repo'), undefined, undefined, undefined, undefined);
 		const namedSourceControl = extHostSCM.createSourceControl(extension, 'git', 'Git', URI.file('/submodule'), undefined, undefined, undefined, 'configured-name');
 
+		await rpcProtocol.sync();
 		assert.deepStrictEqual(registeredNames, [undefined, 'configured-name']);
 
 		unnamedSourceControl.dispose();
 		namedSourceControl.dispose();
+		await rpcProtocol.sync();
 	});
 });

--- a/src/vs/workbench/api/test/common/extHostSCM.test.ts
+++ b/src/vs/workbench/api/test/common/extHostSCM.test.ts
@@ -48,11 +48,52 @@ suite('ExtHostSCM', () => {
 			new NullLogService()
 		);
 
-		const sourceControl = extHostSCM.createSourceControl(extension, 'git', 'Git', URI.file('/repo'), undefined, undefined, undefined);
+		const sourceControl = extHostSCM.createSourceControl(extension, 'git', 'Git', URI.file('/repo'), undefined, undefined, undefined, undefined);
 		assert.ok(extHostSCM.getLastInputBox(extension));
 
 		sourceControl.dispose();
 
 		assert.strictEqual(extHostSCM.getLastInputBox(extension), undefined);
+	});
+
+	test('repository names are forwarded when source controls are registered', () => {
+		const registeredNames: (string | undefined)[] = [];
+		const rpcProtocol = new TestRPCProtocol();
+		rpcProtocol.set(MainContext.MainThreadSCM, new class extends mock<MainThreadSCMShape>() {
+			override async $registerSourceControl(...args: Parameters<MainThreadSCMShape['$registerSourceControl']>): Promise<void> {
+				registeredNames.push(args[8]);
+			}
+			override async $unregisterSourceControl(): Promise<void> { }
+		});
+		rpcProtocol.set(MainContext.MainThreadTelemetry, new class extends mock<MainThreadTelemetryShape>() {
+			override $publicLog2(): void { }
+		});
+
+		const commands = new class extends mock<ExtHostCommands>() {
+			override registerArgumentProcessor(_processor: ArgumentProcessor): void { }
+		};
+		const extension = {
+			...nullExtensionDescription,
+			identifier: new ExtensionIdentifier('vscode.git'),
+			name: 'git',
+			displayName: 'Git',
+			extensionLocation: URI.file('/extension'),
+			isBuiltin: true
+		};
+
+		const extHostSCM = new ExtHostSCM(
+			rpcProtocol,
+			commands,
+			{} as ExtHostDocuments,
+			new NullLogService()
+		);
+
+		const unnamedSourceControl = extHostSCM.createSourceControl(extension, 'git', 'Git', URI.file('/repo'), undefined, undefined, undefined, undefined);
+		const namedSourceControl = extHostSCM.createSourceControl(extension, 'git', 'Git', URI.file('/submodule'), undefined, undefined, undefined, 'configured-name');
+
+		assert.deepStrictEqual(registeredNames, [undefined, 'configured-name']);
+
+		unnamedSourceControl.dispose();
+		namedSourceControl.dispose();
 	});
 });

--- a/src/vs/workbench/contrib/scm/browser/scmRepositoryRenderer.ts
+++ b/src/vs/workbench/contrib/scm/browser/scmRepositoryRenderer.ts
@@ -151,6 +151,7 @@ export class RepositoryRenderer implements ICompressibleTreeRenderer<ISCMReposit
 		if (this.scmViewService.explorerEnabledConfig.get() === false) {
 			label = repository.provider.name;
 		} else {
+			// Include the parent name when repositories are shown as a tree.
 			const parentRepository = this.scmViewService.repositories
 				.find(r => r.provider.id === repository.provider.parentId);
 

--- a/src/vs/workbench/contrib/scm/browser/scmViewService.ts
+++ b/src/vs/workbench/contrib/scm/browser/scmViewService.ts
@@ -11,9 +11,7 @@ import { IInstantiationService } from '../../../../platform/instantiation/common
 import { SCMMenus } from './menus.js';
 import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
 import { debounce } from '../../../../base/common/decorators.js';
-import { IWorkspaceContextService } from '../../../../platform/workspace/common/workspace.js';
 import { compareFileNames, comparePaths } from '../../../../base/common/comparers.js';
-import { basename } from '../../../../base/common/resources.js';
 import { binarySearch } from '../../../../base/common/arrays.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { IContextKey, IContextKeyService, RawContextKey } from '../../../../platform/contextkey/common/contextkey.js';
@@ -30,15 +28,6 @@ import { getSCMRepositoryIcon } from './util.js';
 
 function getProviderStorageKey(provider: ISCMProvider): string {
 	return `${provider.providerId}:${provider.label}${provider.rootUri ? `:${provider.rootUri.toString()}` : ''}`;
-}
-
-function getRepositoryName(workspaceContextService: IWorkspaceContextService, repository: ISCMRepository): string {
-	if (!repository.provider.rootUri) {
-		return repository.provider.label;
-	}
-
-	const folder = workspaceContextService.getWorkspaceFolder(repository.provider.rootUri);
-	return folder?.uri.toString() === repository.provider.rootUri.toString() ? folder.name : basename(repository.provider.rootUri);
 }
 
 export const RepositoryContextKeys = {
@@ -239,8 +228,7 @@ export class SCMViewService implements ISCMViewService {
 		@IExtensionService extensionService: IExtensionService,
 		@IInstantiationService instantiationService: IInstantiationService,
 		@IConfigurationService private readonly configurationService: IConfigurationService,
-		@IStorageService private readonly storageService: IStorageService,
-		@IWorkspaceContextService private readonly workspaceContextService: IWorkspaceContextService
+		@IStorageService private readonly storageService: IStorageService
 	) {
 		this.menus = instantiationService.createInstance(SCMMenus);
 
@@ -530,8 +518,8 @@ export class SCMViewService implements ISCMViewService {
 		}
 
 		// Sort by repository name, using the path as a tie-breaker.
-		const name1 = getRepositoryName(this.workspaceContextService, op1.repository);
-		const name2 = getRepositoryName(this.workspaceContextService, op2.repository);
+		const name1 = op1.repository.provider.name;
+		const name2 = op2.repository.provider.name;
 
 		const nameComparison = compareFileNames(name1, name2);
 		if (nameComparison === 0 && op1.repository.provider.rootUri && op2.repository.provider.rootUri) {

--- a/src/vs/workbench/contrib/scm/browser/scmViewService.ts
+++ b/src/vs/workbench/contrib/scm/browser/scmViewService.ts
@@ -529,7 +529,7 @@ export class SCMViewService implements ISCMViewService {
 			return comparePaths(op1.repository.provider.rootUri.fsPath, op2.repository.provider.rootUri.fsPath);
 		}
 
-		// Sort by name, path
+		// Sort by repository name, using the path as a tie-breaker.
 		const name1 = getRepositoryName(this.workspaceContextService, op1.repository);
 		const name2 = getRepositoryName(this.workspaceContextService, op2.repository);
 

--- a/src/vs/workbench/contrib/scm/test/browser/scmViewService.test.ts
+++ b/src/vs/workbench/contrib/scm/test/browser/scmViewService.test.ts
@@ -1,0 +1,78 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { Event } from '../../../../../base/common/event.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { upcastPartial } from '../../../../../base/test/common/mock.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
+import { IContextKeyService } from '../../../../../platform/contextkey/common/contextkey.js';
+import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
+import { IStorageService } from '../../../../../platform/storage/common/storage.js';
+import { workbenchInstantiationService } from '../../../../test/browser/workbenchTestServices.js';
+import { IEditorService } from '../../../../services/editor/common/editorService.js';
+import { IExtensionService } from '../../../../services/extensions/common/extensions.js';
+import { SCMViewService } from '../../browser/scmViewService.js';
+import { ISCMMenus, ISCMProvider, ISCMRepository, ISCMRepositorySortKey, ISCMService } from '../../common/scm.js';
+
+function createRepository(name: string, path: string): ISCMRepository {
+	const provider = upcastPartial<ISCMProvider>({
+		id: path,
+		providerId: 'git',
+		label: 'Git',
+		name,
+		rootUri: URI.file(path)
+	});
+
+	return upcastPartial<ISCMRepository>({ id: path, provider });
+}
+
+suite('SCMViewService', () => {
+	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('sorts repositories by provider name with path as a tie-breaker', () => {
+		const repositories = [
+			createRepository('zeta', '/a'),
+			createRepository('alpha', '/c'),
+			createRepository('alpha', '/b')
+		];
+		const scmService = upcastPartial<ISCMService>({
+			repositories,
+			onDidAddRepository: Event.None,
+			onDidRemoveRepository: Event.None,
+			getRepository: () => undefined
+		});
+		const instantiationService = workbenchInstantiationService(undefined, disposables);
+		const menus = upcastPartial<ISCMMenus>({});
+		const menuInstantiationService = upcastPartial<IInstantiationService>({
+			createInstance: (() => menus) as IInstantiationService['createInstance']
+		});
+
+		const scmViewService = disposables.add(new SCMViewService(
+			scmService,
+			instantiationService.get(IContextKeyService),
+			instantiationService.get(IEditorService),
+			instantiationService.get(IExtensionService),
+			menuInstantiationService,
+			instantiationService.get(IConfigurationService),
+			instantiationService.get(IStorageService)
+		));
+		disposables.add(scmViewService.onDidChangeVisibleRepositories(() => { }));
+		scmViewService.toggleSortKey(ISCMRepositorySortKey.Name);
+
+		assert.deepStrictEqual(
+			scmViewService.repositories.map(repository => ({
+				name: repository.provider.name,
+				path: repository.provider.rootUri?.path
+			})),
+			[
+				{ name: 'alpha', path: '/b' },
+				{ name: 'alpha', path: '/c' },
+				{ name: 'zeta', path: '/a' }
+			]
+		);
+	});
+});

--- a/src/vscode-dts/vscode.proposed.scmProviderOptions.d.ts
+++ b/src/vscode-dts/vscode.proposed.scmProviderOptions.d.ts
@@ -34,6 +34,18 @@ declare module 'vscode' {
 	}
 
 	export namespace scm {
-		export function createSourceControl(id: string, label: string, rootUri?: Uri, iconPath?: IconPath, isHidden?: boolean, parent?: SourceControl): SourceControl;
+		/**
+		 * Creates a new source control instance.
+		 *
+		 * @param id An `id` for the source control. Something short, e.g. `git`.
+		 * @param label A human-readable label for the source control provider. E.g. `Git`.
+		 * @param rootUri An optional Uri of the root of the source control.
+		 * @param iconPath An optional icon for the source control.
+		 * @param isHidden Whether the source control is hidden by default.
+		 * @param parent An optional parent source control.
+		 * @param name An optional human-readable name for the source control repository.
+		 * @returns An instance of source control.
+		 */
+		export function createSourceControl(id: string, label: string, rootUri?: Uri, iconPath?: IconPath, isHidden?: boolean, parent?: SourceControl, name?: string): SourceControl;
 	}
 }


### PR DESCRIPTION
## Summary

- respect customized submodule names from the superproject's `.gitmodules` throughout SCM UI
- add a creation-time repository name to the proposed `scmProviderOptions` API
- preserve existing workspace-folder and basename behavior for ordinary repositories, worktrees, generated submodule names, and independently opened submodules
- use the same resolved name in the built-in Git repository picker

Addresses #269812

## Behavior

A submodule discovered through an open superproject uses its configured name only when that name differs from its path. The explicit name flows into `ISCMProvider.name`, so the repositories tree, active repository status, SCM and history pickers, accessibility text, and Git repository picker remain consistent. Opening the submodule independently retains the current behavior.

## Validation

- `npm run typecheck-client`
- `npm run gulp compile-extension:git`
- `npm run valid-layers-check`
- `git diff --check upstream/main...HEAD`

The full `compile-extensions` command was also attempted; it stopped in the unrelated CSS language extension because that extension's separate Node typings were not installed in this clone. Focused core and Git test launchers could not start because the local `.build/electron` test runtime is absent.