### PR TITLE
Use `replaceWith` in to avoid not null assertions

### DIFF
--- a/src/vs/editor/browser/view/viewLayer.ts
+++ b/src/vs/editor/browser/view/viewLayer.ts
@@ -546,7 +546,7 @@ class ViewLayerRenderer<T extends IVisibleLine> {
 			if (wasInvalid[i]) {
 				const source = <HTMLElement>hugeDomNode.firstChild;
 				const lineDomNode = line.getDomNode()!;
-				lineDomNode.parentNode!.replaceChild(source, lineDomNode);
+				lineDomNode.replaceWith(source);
 				line.setDomNode(source);
 			}
 		}

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/chatConfirmationWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/chatConfirmationWidget.ts
@@ -64,7 +64,7 @@ export class ChatQueryTitlePart extends Disposable {
 
 		const previousEl = this._renderedTitle.value?.element;
 		if (previousEl?.parentElement) {
-			previousEl.parentElement.replaceChild(next.element, previousEl);
+			previousEl.replaceWith(next.element);
 		} else {
 			this.element.appendChild(next.element); // unreachable?
 		}

--- a/src/vs/workbench/contrib/chat/browser/chatMarkdownDecorationsRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatMarkdownDecorationsRenderer.ts
@@ -135,9 +135,7 @@ export class ChatMarkdownDecorationsRenderer {
 					}
 
 					if (args) {
-						a.parentElement!.replaceChild(
-							this.renderAgentWidget(args, store),
-							a);
+						a.replaceWith(this.renderAgentWidget(args, store));
 					}
 				} else if (href.startsWith(agentSlashRefUrl)) {
 					let args: ISlashCommandWidgetArgs | undefined;
@@ -148,9 +146,7 @@ export class ChatMarkdownDecorationsRenderer {
 					}
 
 					if (args) {
-						a.parentElement!.replaceChild(
-							this.renderSlashCommandWidget(a.textContent!, args, store),
-							a);
+						a.replaceWith(this.renderSlashCommandWidget(a.textContent!, args, store));
 					}
 				} else if (href.startsWith(decorationRefUrl)) {
 					let args: IDecorationWidgetArgs | undefined;
@@ -158,9 +154,7 @@ export class ChatMarkdownDecorationsRenderer {
 						args = JSON.parse(decodeURIComponent(href.slice(decorationRefUrl.length + 1)));
 					} catch (e) { }
 
-					a.parentElement!.replaceChild(
-						this.renderResourceWidget(a.textContent!, args, store),
-						a);
+					a.replaceWith(this.renderResourceWidget(a.textContent!, args, store));
 				} else if (href.startsWith(contentRefUrl)) {
 					this.renderFileWidget(content, href, a, store);
 				} else if (href.startsWith('command:')) {

--- a/src/vs/workbench/contrib/comments/browser/commentsTreeViewer.ts
+++ b/src/vs/workbench/contrib/comments/browser/commentsTreeViewer.ts
@@ -250,12 +250,12 @@ export class CommentNodeRenderer implements IListRenderer<ITreeNode<CommentNode>
 			const image = images[i];
 			const textDescription = dom.$('');
 			textDescription.textContent = image.alt ? nls.localize('imageWithLabel', "Image: {0}", image.alt) : nls.localize('image', "Image");
-			image.parentNode!.replaceChild(textDescription, image);
+			image.replaceWith(textDescription);
 		}
 		const headings = [...renderedComment.element.getElementsByTagName('h1'), ...renderedComment.element.getElementsByTagName('h2'), ...renderedComment.element.getElementsByTagName('h3'), ...renderedComment.element.getElementsByTagName('h4'), ...renderedComment.element.getElementsByTagName('h5'), ...renderedComment.element.getElementsByTagName('h6')];
 		for (const heading of headings) {
 			const textNode = document.createTextNode(heading.textContent || '');
-			heading.parentNode!.replaceChild(textNode, heading);
+			heading.replaceWith(textNode);
 		}
 		while ((renderedComment.element.children.length > 1) && (renderedComment.element.firstElementChild?.tagName === 'HR')) {
 			renderedComment.element.removeChild(renderedComment.element.firstElementChild);

--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewPreloads.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewPreloads.ts
@@ -831,7 +831,7 @@ async function webviewPreloads(ctx: PreloadContext) {
 		// Remove a highlight element created with wrapNodeInHighlight.
 		function _removeHighlight(highlightElement: Element) {
 			if (highlightElement.childNodes.length === 1) {
-				highlightElement.parentNode?.replaceChild(highlightElement.firstChild!, highlightElement);
+				highlightElement.replaceWith(highlightElement.firstChild!);
 			} else {
 				// If the highlight somehow contains multiple nodes now, move them all.
 				while (highlightElement.firstChild) {


### PR DESCRIPTION
Switches from `node.parent.replaceChild(x, node)` to `node.replaceWith(x)`. This lets us avoid having to check that the parent exists

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
