### PR TITLE
Move tool progress announcements from `LanguageModelToolsService` -> `ChatListRenderer` 

### DIFF
--- a/src/vs/platform/terminal/common/capabilities/commandDetection/promptInputModel.ts
+++ b/src/vs/platform/terminal/common/capabilities/commandDetection/promptInputModel.ts
@@ -546,6 +546,12 @@ export class PromptInputModel extends Disposable implements IPromptInputModel {
 		// Retrieve the positions of all cells with the same style as `lastNonWhitespaceCell`
 		const positionsWithGhostStyle = styleMap.get(this._getCellStyleAsString(lastNonWhitespaceCell));
 		if (positionsWithGhostStyle) {
+			// Ghost text must start exactly at the cursor
+			// This avoids misclassifying a right prompt as ghost text when it
+			// introduces a new color/style not seen earlier in the line.
+			if (positionsWithGhostStyle[0] !== buffer.cursorX) {
+				return -1;
+			}
 			// Ensure these positions are contiguous
 			for (let i = 1; i < positionsWithGhostStyle.length; i++) {
 				if (positionsWithGhostStyle[i] !== positionsWithGhostStyle[i - 1] + 1) {
@@ -553,7 +559,7 @@ export class PromptInputModel extends Disposable implements IPromptInputModel {
 					return -1;
 				}
 			}
-			// Calculate the ghost text start index
+			// Calculate the ghost text start index relative to command start.
 			if (buffer.baseY + buffer.cursorY === this._commandStartMarker?.line) {
 				ghostTextIndex = positionsWithGhostStyle[0] - this._commandStartX;
 			} else {
@@ -566,10 +572,11 @@ export class PromptInputModel extends Disposable implements IPromptInputModel {
 		if (ghostTextIndex !== -1) {
 			for (let checkPos = buffer.cursorX; checkPos >= this._commandStartX; checkPos--) {
 				const checkCell = line.getCell(checkPos);
-				if (!checkCell?.getChars.length) {
+				const chars = checkCell?.getChars();
+				if (!checkCell || !chars || !chars.trim().length) {
 					continue;
 				}
-				if (checkCell && checkCell.getCode() !== 0 && this._cellStylesMatch(lastNonWhitespaceCell, checkCell)) {
+				if (checkCell.getCode() !== 0 && this._cellStylesMatch(lastNonWhitespaceCell, checkCell)) {
 					return -1;
 				}
 			}

--- a/src/vs/platform/terminal/common/capabilities/commandDetection/promptInputModel.ts
+++ b/src/vs/platform/terminal/common/capabilities/commandDetection/promptInputModel.ts
@@ -546,12 +546,6 @@ export class PromptInputModel extends Disposable implements IPromptInputModel {
 		// Retrieve the positions of all cells with the same style as `lastNonWhitespaceCell`
 		const positionsWithGhostStyle = styleMap.get(this._getCellStyleAsString(lastNonWhitespaceCell));
 		if (positionsWithGhostStyle) {
-			// Ghost text must start exactly at the cursor
-			// This avoids misclassifying a right prompt as ghost text when it
-			// introduces a new color/style not seen earlier in the line.
-			if (positionsWithGhostStyle[0] !== buffer.cursorX) {
-				return -1;
-			}
 			// Ensure these positions are contiguous
 			for (let i = 1; i < positionsWithGhostStyle.length; i++) {
 				if (positionsWithGhostStyle[i] !== positionsWithGhostStyle[i - 1] + 1) {
@@ -559,7 +553,7 @@ export class PromptInputModel extends Disposable implements IPromptInputModel {
 					return -1;
 				}
 			}
-			// Calculate the ghost text start index relative to command start.
+			// Calculate the ghost text start index
 			if (buffer.baseY + buffer.cursorY === this._commandStartMarker?.line) {
 				ghostTextIndex = positionsWithGhostStyle[0] - this._commandStartX;
 			} else {
@@ -572,11 +566,10 @@ export class PromptInputModel extends Disposable implements IPromptInputModel {
 		if (ghostTextIndex !== -1) {
 			for (let checkPos = buffer.cursorX; checkPos >= this._commandStartX; checkPos--) {
 				const checkCell = line.getCell(checkPos);
-				const chars = checkCell?.getChars();
-				if (!checkCell || !chars || !chars.trim().length) {
+				if (!checkCell?.getChars.length) {
 					continue;
 				}
-				if (checkCell.getCode() !== 0 && this._cellStylesMatch(lastNonWhitespaceCell, checkCell)) {
+				if (checkCell && checkCell.getCode() !== 0 && this._cellStylesMatch(lastNonWhitespaceCell, checkCell)) {
 					return -1;
 				}
 			}

--- a/src/vs/workbench/contrib/accessibility/browser/accessibilityConfiguration.ts
+++ b/src/vs/workbench/contrib/accessibility/browser/accessibilityConfiguration.ts
@@ -563,6 +563,10 @@ const configuration: IConfigurationNode = {
 		'accessibility.signals.progress': {
 			...signalFeatureBase,
 			'description': localize('accessibility.signals.progress', "Plays a signal - sound (audio cue) and/or announcement (alert) - on loop while progress is occurring."),
+			'default': {
+				'sound': 'auto',
+				'announcement': 'off'
+			},
 			'properties': {
 				'sound': {
 					'description': localize('accessibility.signals.progress.sound', "Plays a sound on loop while progress is occurring."),

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/chatProgressContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/chatProgressContentPart.ts
@@ -18,6 +18,8 @@ import { ChatTreeItem } from '../chat.js';
 import { renderFileWidgets } from '../chatInlineAnchorWidget.js';
 import { IChatContentPart, IChatContentPartRenderContext } from './chatContentParts.js';
 import { IChatMarkdownAnchorService } from './chatMarkdownAnchorService.js';
+import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
+import { AccessibilityWorkbenchSettingId } from '../../../accessibility/browser/accessibilityConfiguration.js';
 
 export class ChatProgressContentPart extends Disposable implements IChatContentPart {
 	public readonly domNode: HTMLElement;
@@ -34,6 +36,7 @@ export class ChatProgressContentPart extends Disposable implements IChatContentP
 		icon: ThemeIcon | undefined,
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
 		@IChatMarkdownAnchorService private readonly chatMarkdownAnchorService: IChatMarkdownAnchorService,
+		@IConfigurationService private readonly configurationService: IConfigurationService
 	) {
 		super();
 
@@ -46,7 +49,7 @@ export class ChatProgressContentPart extends Disposable implements IChatContentP
 			return;
 		}
 
-		if (this.showSpinner) {
+		if (this.showSpinner && !this.configurationService.getValue(AccessibilityWorkbenchSettingId.VerboseChatProgressUpdates)) {
 			// TODO@roblourens is this the right place for this?
 			// this step is in progress, communicate it to SR users
 			alert(progress.content.value);
@@ -105,12 +108,13 @@ export class ChatWorkingProgressContentPart extends ChatProgressContentPart impl
 		context: IChatContentPartRenderContext,
 		@IInstantiationService instantiationService: IInstantiationService,
 		@IChatMarkdownAnchorService chatMarkdownAnchorService: IChatMarkdownAnchorService,
+		@IConfigurationService configurationService: IConfigurationService
 	) {
 		const progressMessage: IChatProgressMessage = {
 			kind: 'progressMessage',
 			content: new MarkdownString().appendText(localize('workingMessage', "Working..."))
 		};
-		super(progressMessage, renderer, context, undefined, undefined, undefined, instantiationService, chatMarkdownAnchorService);
+		super(progressMessage, renderer, context, undefined, undefined, undefined, instantiationService, chatMarkdownAnchorService, configurationService);
 	}
 
 	override hasSameContent(other: IChatRendererContent, followingContent: IChatRendererContent[], element: ChatTreeItem): boolean {

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatToolInvocationPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatToolInvocationPart.ts
@@ -52,6 +52,7 @@ export class ChatToolInvocationPart extends Disposable implements IChatContentPa
 		private readonly editorPool: EditorPool,
 		private readonly currentWidthDelegate: () => number,
 		private readonly codeBlockModelCollection: CodeBlockModelCollection,
+		private readonly announcedToolProgressKeys: Set<string> | undefined,
 		private readonly codeBlockStartIndex: number,
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
 	) {
@@ -198,7 +199,7 @@ export class ChatToolInvocationPart extends Disposable implements IChatContentPa
 			);
 		}
 
-		return this.instantiationService.createInstance(ChatToolProgressSubPart, this.toolInvocation, this.context, this.renderer);
+		return this.instantiationService.createInstance(ChatToolProgressSubPart, this.toolInvocation, this.context, this.renderer, this.announcedToolProgressKeys);
 	}
 
 	hasSameContent(other: IChatRendererContent, followingContent: IChatRendererContent[], element: ChatTreeItem): boolean {

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatToolProgressPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatToolProgressPart.ts
@@ -4,11 +4,14 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as dom from '../../../../../../base/browser/dom.js';
+import { status } from '../../../../../../base/browser/ui/aria/aria.js';
 import { IMarkdownString, MarkdownString } from '../../../../../../base/common/htmlContent.js';
 import { autorun } from '../../../../../../base/common/observable.js';
 import { MarkdownRenderer } from '../../../../../../editor/browser/widget/markdownRenderer/browser/markdownRenderer.js';
+import { IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
 import { IInstantiationService } from '../../../../../../platform/instantiation/common/instantiation.js';
 import { IChatProgressMessage, IChatToolInvocation, IChatToolInvocationSerialized, ToolConfirmKind } from '../../../common/chatService.js';
+import { AccessibilityWorkbenchSettingId } from '../../../../accessibility/browser/accessibilityConfiguration.js';
 import { IChatCodeBlockInfo } from '../../chat.js';
 import { IChatContentPartRenderContext } from '../chatContentParts.js';
 import { ChatProgressContentPart } from '../chatProgressContentPart.js';
@@ -23,7 +26,9 @@ export class ChatToolProgressSubPart extends BaseChatToolInvocationSubPart {
 		toolInvocation: IChatToolInvocation | IChatToolInvocationSerialized,
 		private readonly context: IChatContentPartRenderContext,
 		private readonly renderer: MarkdownRenderer,
+		private readonly announcedToolProgressKeys: Set<string> | undefined,
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
+		@IConfigurationService private readonly configurationService: IConfigurationService,
 	) {
 		super(toolInvocation);
 
@@ -32,7 +37,10 @@ export class ChatToolProgressSubPart extends BaseChatToolInvocationSubPart {
 
 	private createProgressPart(): HTMLElement {
 		if (this.toolInvocation.isComplete && this.toolIsConfirmed && this.toolInvocation.pastTenseMessage) {
-			const part = this.renderProgressContent(this.toolInvocation.pastTenseMessage);
+			const key = this.getAnnouncementKey('complete');
+			const completionContent = this.toolInvocation.pastTenseMessage ?? this.toolInvocation.invocationMessage;
+			const shouldAnnounce = this.toolInvocation.kind === 'toolInvocation' && this.hasMeaningfulContent(this.toolInvocation.pastTenseMessage) ? this.computeShouldAnnounce(key) : false;
+			const part = this.renderProgressContent(completionContent, shouldAnnounce);
 			this._register(part);
 			return part.domNode;
 		} else {
@@ -40,7 +48,10 @@ export class ChatToolProgressSubPart extends BaseChatToolInvocationSubPart {
 			const progressObservable = this.toolInvocation.kind === 'toolInvocation' ? this.toolInvocation.progress : undefined;
 			this._register(autorun(reader => {
 				const progress = progressObservable?.read(reader);
-				const part = reader.store.add(this.renderProgressContent(progress?.message || this.toolInvocation.invocationMessage));
+				const key = this.getAnnouncementKey('progress');
+				const progressContent = progress?.message ?? this.toolInvocation.invocationMessage;
+				const shouldAnnounce = this.toolInvocation.kind === 'toolInvocation' && this.hasMeaningfulContent(progress?.message) ? this.computeShouldAnnounce(key) : false;
+				const part = reader.store.add(this.renderProgressContent(progressContent, shouldAnnounce));
 				dom.reset(container, part.domNode);
 			}));
 			return container;
@@ -57,7 +68,7 @@ export class ChatToolProgressSubPart extends BaseChatToolInvocationSubPart {
 		return this.toolInvocation.isConfirmed.type !== ToolConfirmKind.Denied;
 	}
 
-	private renderProgressContent(content: IMarkdownString | string) {
+	private renderProgressContent(content: IMarkdownString | string, shouldAnnounce: boolean) {
 		if (typeof content === 'string') {
 			content = new MarkdownString().appendText(content);
 		}
@@ -67,6 +78,42 @@ export class ChatToolProgressSubPart extends BaseChatToolInvocationSubPart {
 			content
 		};
 
+		if (shouldAnnounce) {
+			this.provideScreenReaderStatus(content);
+		}
+
 		return this.instantiationService.createInstance(ChatProgressContentPart, progressMessage, this.renderer, this.context, undefined, true, this.getIcon());
+	}
+
+	private getAnnouncementKey(kind: 'progress' | 'complete'): string {
+		return `${kind}:${this.toolInvocation.toolCallId}`;
+	}
+
+	private computeShouldAnnounce(key: string): boolean {
+		if (!this.announcedToolProgressKeys) {
+			return false;
+		}
+		if (!this.configurationService.getValue(AccessibilityWorkbenchSettingId.VerboseChatProgressUpdates)) {
+			return false;
+		}
+		if (this.announcedToolProgressKeys.has(key)) {
+			return false;
+		}
+		this.announcedToolProgressKeys.add(key);
+		return true;
+	}
+
+	private provideScreenReaderStatus(content: IMarkdownString | string): void {
+		const message = typeof content === 'string' ? content : content.value;
+		status(message);
+	}
+
+	private hasMeaningfulContent(content: IMarkdownString | string | undefined): boolean {
+		if (!content) {
+			return false;
+		}
+
+		const text = typeof content === 'string' ? content : content.value;
+		return text.trim().length > 0;
 	}
 }

--- a/src/vs/workbench/contrib/chat/browser/chatListRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatListRenderer.ts
@@ -1263,7 +1263,7 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 			} else if (content.kind === 'mcpServersInteractionRequired') {
 				return this.renderMcpServersInteractionRequired(content, context, templateData);
 			} else if (content.kind === 'thinking' && this.shouldShowThinkingPart()) {
-				this.renderThinkingPart(content, context, templateData);
+				return this.renderThinkingPart(content, context, templateData);
 			}
 
 			return this.renderNoContent(other => content.kind === other.kind);

--- a/src/vs/workbench/contrib/chat/browser/chatListRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatListRenderer.ts
@@ -197,6 +197,12 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 	 */
 	private readonly _toolInvocationCodeBlockCollection: CodeBlockModelCollection;
 
+	/**
+	 * Prevents re-announcement of already rendered chat progress
+	 * by screen readers
+	 */
+	private readonly _announcedToolProgressKeys = new Set<string>();
+
 	constructor(
 		editorOptions: ChatEditorOptions,
 		private rendererOptions: IChatListItemRendererOptions,
@@ -212,7 +218,7 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 		@ICommandService private readonly commandService: ICommandService,
 		@IHoverService private readonly hoverService: IHoverService,
 		@IChatWidgetService private readonly chatWidgetService: IChatWidgetService,
-		@IChatEntitlementService private readonly chatEntitlementService: IChatEntitlementService,
+		@IChatEntitlementService private readonly chatEntitlementService: IChatEntitlementService
 	) {
 		super();
 
@@ -282,6 +288,7 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 
 	updateViewModel(viewModel: IChatViewModel | undefined): void {
 		this.viewModel = viewModel;
+		this._announcedToolProgressKeys.clear();
 	}
 
 	getCodeBlockInfoForEditor(uri: URI): IChatCodeBlockInfo | undefined {
@@ -1256,7 +1263,7 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 			} else if (content.kind === 'mcpServersInteractionRequired') {
 				return this.renderMcpServersInteractionRequired(content, context, templateData);
 			} else if (content.kind === 'thinking' && this.shouldShowThinkingPart()) {
-				return this.renderThinkingPart(content, context, templateData);
+				this.renderThinkingPart(content, context, templateData);
 			}
 
 			return this.renderNoContent(other => content.kind === other.kind);
@@ -1271,6 +1278,12 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 			};
 		}
 	}
+
+	override dispose(): void {
+		this._announcedToolProgressKeys.clear();
+		super.dispose();
+	}
+
 
 	private renderChatErrorDetails(context: IChatContentPartRenderContext, content: IChatErrorDetailsPart, templateData: IChatListItemTemplate): IChatContentPart {
 		if (!isResponseVM(context.element)) {
@@ -1407,7 +1420,7 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 
 	private renderToolInvocation(toolInvocation: IChatToolInvocation | IChatToolInvocationSerialized, context: IChatContentPartRenderContext, templateData: IChatListItemTemplate): IChatContentPart | undefined {
 		const codeBlockStartIndex = this.getCodeBlockStartIndex(context);
-		const part = this.instantiationService.createInstance(ChatToolInvocationPart, toolInvocation, context, this.renderer, this._contentReferencesListPool, this._toolEditorPool, () => this._currentLayoutWidth, this._toolInvocationCodeBlockCollection, codeBlockStartIndex);
+		const part = this.instantiationService.createInstance(ChatToolInvocationPart, toolInvocation, context, this.renderer, this._contentReferencesListPool, this._toolEditorPool, () => this._currentLayoutWidth, this._toolInvocationCodeBlockCollection, this._announcedToolProgressKeys, codeBlockStartIndex);
 		part.addDisposable(part.onDidChangeHeight(() => {
 			this.updateItemHeight(templateData);
 		}));
@@ -1537,7 +1550,7 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 		return markdownPart;
 	}
 
-	renderThinkingPart(content: IChatThinkingPart, context: IChatContentPartRenderContext, templateData: IChatListItemTemplate,): IChatContentPart {
+	renderThinkingPart(content: IChatThinkingPart, context: IChatContentPartRenderContext, templateData: IChatListItemTemplate): IChatContentPart {
 		this._streamingThinking = true;
 
 		// TODO @justschen @karthiknadig: remove this when OSWE moves off commentary channel

--- a/src/vs/workbench/contrib/chat/browser/languageModelToolsService.ts
+++ b/src/vs/workbench/contrib/chat/browser/languageModelToolsService.ts
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { renderAsPlaintext } from '../../../../base/browser/markdownRenderer.js';
-import { alert } from '../../../../base/browser/ui/aria/aria.js';
 import { assertNever } from '../../../../base/common/assert.js';
 import { RunOnceScheduler } from '../../../../base/common/async.js';
 import { encodeBase64 } from '../../../../base/common/buffer.js';
@@ -13,7 +12,7 @@ import { Codicon } from '../../../../base/common/codicons.js';
 import { toErrorMessage } from '../../../../base/common/errorMessage.js';
 import { CancellationError, isCancellationError } from '../../../../base/common/errors.js';
 import { Emitter, Event } from '../../../../base/common/event.js';
-import { IMarkdownString, MarkdownString } from '../../../../base/common/htmlContent.js';
+import { MarkdownString } from '../../../../base/common/htmlContent.js';
 import { Iterable } from '../../../../base/common/iterator.js';
 import { Lazy } from '../../../../base/common/lazy.js';
 import { combinedDisposable, Disposable, DisposableStore, IDisposable, toDisposable } from '../../../../base/common/lifecycle.js';
@@ -34,7 +33,6 @@ import { Registry } from '../../../../platform/registry/common/platform.js';
 import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
 import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry.js';
 import { IExtensionService } from '../../../services/extensions/common/extensions.js';
-import { AccessibilityWorkbenchSettingId } from '../../accessibility/browser/accessibilityConfiguration.js';
 import { ChatContextKeys } from '../common/chatContextKeys.js';
 import { ChatModel } from '../common/chatModel.js';
 import { IVariableReference } from '../common/chatModes.js';
@@ -335,8 +333,6 @@ export class LanguageModelToolsService extends Disposable implements ILanguageMo
 				model.acceptResponseProgress(request, toolInvocation);
 
 				dto.toolSpecificData = toolInvocation?.toolSpecificData;
-				this.informScreenReader(prepared?.invocationMessage ?? `${tool.data.displayName} started`);
-
 				if (prepared?.confirmationMessages) {
 					if (!toolInvocation.isConfirmed?.type && !autoConfirmed) {
 						this.playAccessibilitySignal([toolInvocation]);
@@ -415,9 +411,6 @@ export class LanguageModelToolsService extends Disposable implements ILanguageMo
 			throw err;
 		} finally {
 			toolInvocation?.complete(toolResult);
-			if (ChatContextKeys.requestInProgress.getValue(this._contextKeyService)) {
-				this.informScreenReader(toolInvocation?.pastTenseMessage ?? `${tool.data.displayName} finished`);
-			}
 			if (store) {
 				this.cleanupCallDisposables(requestId, store);
 			}
@@ -448,12 +441,6 @@ export class LanguageModelToolsService extends Disposable implements ILanguageMo
 		}
 
 		return prepared;
-	}
-
-	private informScreenReader(msg: string | IMarkdownString): void {
-		if (this._configurationService.getValue(AccessibilityWorkbenchSettingId.VerboseChatProgressUpdates)) {
-			alert(typeof msg === 'string' ? msg : msg.value);
-		}
 	}
 
 	private playAccessibilitySignal(toolInvocations: ChatToolInvocation[]): void {


### PR DESCRIPTION
- Enables us to announce extension contributed tool progress messages
- We prevent re-announcement by storing the ID and by checking that the type is not a serialized tool invocation
- We now use `status` instead of `alert` to ensure overlapping announcements are not lost, but instead, queued
- Disables generic `Working` message when our verbose setting is enabled, already covered by our progress signal in most cases
- Sets the default for `progress.announcement` to `false` 

Investigated also adding announcements for `thinking` parts, but found that couldn't happen because we stream in the progress message, so it was trunchated. We also don't have a place where we know that streaming has finished. 
<img width="720" height="449" alt="image" src="https://github.com/user-attachments/assets/46fd99fc-9709-4865-b928-add5f9ffa562" />

fixes #266256
fixes part of #269758