### PR TITLE
Update caller side of CommandService to use `unknown` instead of `any` for args

### DIFF
--- a/src/vs/editor/standalone/browser/standaloneServices.ts
+++ b/src/vs/editor/standalone/browser/standaloneServices.ts
@@ -382,7 +382,7 @@ export class StandaloneCommandService implements ICommandService {
 		this._instantiationService = instantiationService;
 	}
 
-	public executeCommand<T>(id: string, ...args: any[]): Promise<T> {
+	public executeCommand<T>(id: string, ...args: unknown[]): Promise<T> {
 		const command = CommandsRegistry.getCommand(id);
 		if (!command) {
 			return Promise.reject(new Error(`command '${id}' not found`));

--- a/src/vs/editor/test/browser/editorTestServices.ts
+++ b/src/vs/editor/test/browser/editorTestServices.ts
@@ -69,7 +69,7 @@ export class TestCommandService implements ICommandService {
 		this._instantiationService = instantiationService;
 	}
 
-	public executeCommand<T>(id: string, ...args: any[]): Promise<T> {
+	public executeCommand<T>(id: string, ...args: unknown[]): Promise<T> {
 		const command = CommandsRegistry.getCommand(id);
 		if (!command) {
 			return Promise.reject(new Error(`command '${id}' not found`));

--- a/src/vs/editor/test/browser/services/openerService.test.ts
+++ b/src/vs/editor/test/browser/services/openerService.test.ts
@@ -24,7 +24,7 @@ suite('OpenerService', function () {
 		declare readonly _serviceBrand: undefined;
 		onWillExecuteCommand = () => Disposable.None;
 		onDidExecuteCommand = () => Disposable.None;
-		executeCommand(id: string, ...args: any[]): Promise<any> {
+		executeCommand(id: string, ...args: unknown[]): Promise<any> {
 			lastCommand = { id, args };
 			return Promise.resolve(undefined);
 		}

--- a/src/vs/platform/commands/common/commands.ts
+++ b/src/vs/platform/commands/common/commands.ts
@@ -15,15 +15,15 @@ import { createDecorator, ServicesAccessor } from '../../instantiation/common/in
 export const ICommandService = createDecorator<ICommandService>('commandService');
 
 export interface ICommandEvent {
-	commandId: string;
-	args: any[];
+	readonly commandId: string;
+	readonly args: unknown[];
 }
 
 export interface ICommandService {
 	readonly _serviceBrand: undefined;
-	onWillExecuteCommand: Event<ICommandEvent>;
-	onDidExecuteCommand: Event<ICommandEvent>;
-	executeCommand<T = any>(commandId: string, ...args: any[]): Promise<T | undefined>;
+	readonly onWillExecuteCommand: Event<ICommandEvent>;
+	readonly onDidExecuteCommand: Event<ICommandEvent>;
+	executeCommand<T = any>(commandId: string, ...args: unknown[]): Promise<T | undefined>;
 }
 
 export type ICommandsMap = Map<string, ICommand>;
@@ -93,7 +93,7 @@ export const CommandsRegistry: ICommandRegistry = new class implements ICommandR
 				constraints.push(arg.constraint);
 			}
 			const actualHandler = idOrCommand.handler;
-			idOrCommand.handler = function (accessor, ...args: any[]) {
+			idOrCommand.handler = function (accessor, ...args: unknown[]) {
 				validateConstraints(args, constraints);
 				return actualHandler(accessor, ...args);
 			};

--- a/src/vs/platform/keybinding/test/common/abstractKeybindingService.test.ts
+++ b/src/vs/platform/keybinding/test/common/abstractKeybindingService.test.ts
@@ -104,7 +104,7 @@ suite('AbstractKeybindingService', () => {
 
 	let createTestKeybindingService: (items: ResolvedKeybindingItem[], contextValue?: any) => TestKeybindingService = null!;
 	let currentContextValue: IContext | null = null;
-	let executeCommandCalls: { commandId: string; args: any[] }[] = null!;
+	let executeCommandCalls: { commandId: string; args: unknown[] }[] = null!;
 	let showMessageCalls: { sev: Severity; message: any }[] = null!;
 	let statusMessageCalls: string[] | null = null;
 	let statusMessageCallsDisposed: string[] | null = null;
@@ -148,7 +148,7 @@ suite('AbstractKeybindingService', () => {
 				_serviceBrand: undefined,
 				onWillExecuteCommand: () => Disposable.None,
 				onDidExecuteCommand: () => Disposable.None,
-				executeCommand: (commandId: string, ...args: any[]): Promise<any> => {
+				executeCommand: (commandId: string, ...args: unknown[]): Promise<any> => {
 					executeCommandCalls.push({
 						commandId: commandId,
 						args: args

--- a/src/vs/workbench/api/browser/mainThreadCommands.ts
+++ b/src/vs/workbench/api/browser/mainThreadCommands.ts
@@ -78,7 +78,7 @@ export class MainThreadCommands implements MainThreadCommandsShape {
 		}
 	}
 
-	async $executeCommand<T>(id: string, args: any[] | SerializableObjectWithBuffers<any[]>, retry: boolean): Promise<T | undefined> {
+	async $executeCommand<T>(id: string, args: unknown[] | SerializableObjectWithBuffers<unknown[]>, retry: boolean): Promise<T | undefined> {
 		if (args instanceof SerializableObjectWithBuffers) {
 			args = args.value;
 		}

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -120,7 +120,7 @@ export interface MainThreadCommandsShape extends IDisposable {
 	$registerCommand(id: string): void;
 	$unregisterCommand(id: string): void;
 	$fireCommandActivationEvent(id: string): void;
-	$executeCommand(id: string, args: any[] | SerializableObjectWithBuffers<any[]>, retry: boolean): Promise<unknown | undefined>;
+	$executeCommand(id: string, args: unknown[] | SerializableObjectWithBuffers<unknown[]>, retry: boolean): Promise<unknown | undefined>;
 	$getCommands(): Promise<string[]>;
 }
 

--- a/src/vs/workbench/api/common/extHostCommands.ts
+++ b/src/vs/workbench/api/common/extHostCommands.ts
@@ -171,12 +171,12 @@ export class ExtHostCommands implements ExtHostCommandsShape {
 		});
 	}
 
-	executeCommand<T>(id: string, ...args: any[]): Promise<T> {
+	executeCommand<T>(id: string, ...args: unknown[]): Promise<T> {
 		this._logService.trace('ExtHostCommands#executeCommand', id);
 		return this._doExecuteCommand(id, args, true);
 	}
 
-	private async _doExecuteCommand<T>(id: string, args: any[], retry: boolean): Promise<T> {
+	private async _doExecuteCommand<T>(id: string, args: unknown[], retry: boolean): Promise<T> {
 
 		if (this._commands.has(id)) {
 			// - We stay inside the extension host and support
@@ -229,7 +229,7 @@ export class ExtHostCommands implements ExtHostCommandsShape {
 		}
 	}
 
-	private async _executeContributedCommand<T = unknown>(id: string, args: any[], annotateError: boolean): Promise<T> {
+	private async _executeContributedCommand<T = unknown>(id: string, args: unknown[], annotateError: boolean): Promise<T> {
 		const command = this._commands.get(id);
 		if (!command) {
 			throw new Error('Unknown command');
@@ -310,7 +310,7 @@ export class ExtHostCommands implements ExtHostCommandsShape {
 		});
 	}
 
-	$executeContributedCommand(id: string, ...args: any[]): Promise<unknown> {
+	$executeContributedCommand(id: string, ...args: unknown[]): Promise<unknown> {
 		this._logService.trace('ExtHostCommands#$executeContributedCommand', id);
 
 		const cmdHandler = this._commands.get(id);

--- a/src/vs/workbench/contrib/notebook/test/browser/notebookExecutionService.test.ts
+++ b/src/vs/workbench/contrib/notebook/test/browser/notebookExecutionService.test.ts
@@ -79,7 +79,7 @@ suite('NotebookExecutionService', () => {
 		});
 
 		instantiationService.stub(ICommandService, new class extends mock<ICommandService>() {
-			override executeCommand(_commandId: string, ..._args: any[]) {
+			override executeCommand(_commandId: string, ..._args: unknown[]) {
 				return Promise.resolve(undefined);
 			}
 		});

--- a/src/vs/workbench/contrib/scm/browser/scmViewPane.ts
+++ b/src/vs/workbench/contrib/scm/browser/scmViewPane.ts
@@ -3138,7 +3138,7 @@ export class SCMActionButton implements IDisposable {
 		clearNode(this.container);
 	}
 
-	private async executeCommand(commandId: string, ...args: any[]): Promise<void> {
+	private async executeCommand(commandId: string, ...args: unknown[]): Promise<void> {
 		try {
 			await this.commandService.executeCommand(commandId, ...args);
 		} catch (ex) {

--- a/src/vs/workbench/services/commands/common/commandService.ts
+++ b/src/vs/workbench/services/commands/common/commandService.ts
@@ -49,7 +49,7 @@ export class CommandService extends Disposable implements ICommandService {
 		return notCancellablePromise(this._starActivation);
 	}
 
-	async executeCommand<T>(id: string, ...args: any[]): Promise<T> {
+	async executeCommand<T>(id: string, ...args: unknown[]): Promise<T> {
 		this._logService.trace('CommandService#executeCommand', id);
 
 		const activationEvent = `onCommand:${id}`;
@@ -89,7 +89,7 @@ export class CommandService extends Disposable implements ICommandService {
 		return this._tryExecuteCommand(id, args);
 	}
 
-	private _tryExecuteCommand(id: string, args: any[]): Promise<any> {
+	private _tryExecuteCommand(id: string, args: unknown[]): Promise<any> {
 		const command = CommandsRegistry.getCommand(id);
 		if (!command) {
 			return Promise.reject(new Error(`command '${id}' not found`));


### PR DESCRIPTION
Part of #269213

Updates the command service to use `unknown` for args internally. Does not yet update `ICommandHandler` as this will require many more changes

Typing only change. Shouldn't have any runtime impact 