### PR TITLE
chore: add tag for CG tracking

### DIFF
--- a/src/vs/base/browser/dompurify/cgmanifest.json
+++ b/src/vs/base/browser/dompurify/cgmanifest.json
@@ -6,7 +6,8 @@
 				"git": {
 					"name": "dompurify",
 					"repositoryUrl": "https://github.com/cure53/DOMPurify",
-					"commitHash": "15f54ed66d99a824d8d3030f711ff82af68ad191"
+					"commitHash": "15f54ed66d99a824d8d3030f711ff82af68ad191",
+					"tag": "3.1.7"
 				}
 			},
 			"license": "Apache 2.0",


### PR DESCRIPTION
With this PR, we should now get CG alerts for dompurify. The tag needs to be manually updated with commitHash.