### PR TITLE
feat: disable send button and prevent Enter key from creating new lines when input is empty

### DIFF
--- a/src/vs/base/browser/dom.ts
+++ b/src/vs/base/browser/dom.ts
@@ -5,7 +5,7 @@
 
 import * as browser from './browser.js';
 import { BrowserFeatures } from './canIUse.js';
-import { IKeyboardEvent, StandardKeyboardEvent } from './keyboardEvent.js';
+import { hasModifierKeys, IKeyboardEvent, StandardKeyboardEvent } from './keyboardEvent.js';
 import { IMouseEvent, StandardMouseEvent } from './mouseEvent.js';
 import { AbstractIdleValue, IntervalTimer, TimeoutTimer, _runWhenIdle, IdleDeadline } from '../common/async.js';
 import { BugIndicatingError, onUnexpectedError } from '../common/errors.js';
@@ -1813,7 +1813,7 @@ export class ModifierKeyEmitter extends event.Emitter<IModifierKeyStatus> {
 	}
 
 	get isModifierPressed(): boolean {
-		return this._keyStatus.altKey || this._keyStatus.ctrlKey || this._keyStatus.metaKey || this._keyStatus.shiftKey;
+		return hasModifierKeys(this._keyStatus);
 	}
 
 	/**

--- a/src/vs/base/browser/keyboardEvent.ts
+++ b/src/vs/base/browser/keyboardEvent.ts
@@ -114,6 +114,15 @@ export function printStandardKeyboardEvent(e: StandardKeyboardEvent): string {
 	return `modifiers: [${modifiers.join(',')}], code: ${e.code}, keyCode: ${e.keyCode} ('${KeyCodeUtils.toString(e.keyCode)}')`;
 }
 
+export function hasModifierKeys(keyStatus: {
+	readonly ctrlKey: boolean;
+	readonly shiftKey: boolean;
+	readonly altKey: boolean;
+	readonly metaKey: boolean;
+}): boolean {
+	return keyStatus.ctrlKey || keyStatus.shiftKey || keyStatus.altKey || keyStatus.metaKey;
+}
+
 export class StandardKeyboardEvent implements IKeyboardEvent {
 
 	readonly _standardKeyboardEventBrand = true;

--- a/src/vs/base/browser/keyboardEvent.ts
+++ b/src/vs/base/browser/keyboardEvent.ts
@@ -115,10 +115,10 @@ export function printStandardKeyboardEvent(e: StandardKeyboardEvent): string {
 }
 
 /**
- * Checks if a keyboard event has no modifier keys pressed
+ * Checks if a keyboard event has any modifier keys pressed
  */
-export function hasNoModifierKeys(e: IKeyboardEvent): boolean {
-	return !e.altKey && !e.ctrlKey && !e.metaKey && !e.shiftKey;
+export function hasAnyModifierKeys(e: IKeyboardEvent): boolean {
+	return e.altKey || e.ctrlKey || e.metaKey || e.shiftKey;
 }
 
 export class StandardKeyboardEvent implements IKeyboardEvent {

--- a/src/vs/base/browser/keyboardEvent.ts
+++ b/src/vs/base/browser/keyboardEvent.ts
@@ -114,13 +114,6 @@ export function printStandardKeyboardEvent(e: StandardKeyboardEvent): string {
 	return `modifiers: [${modifiers.join(',')}], code: ${e.code}, keyCode: ${e.keyCode} ('${KeyCodeUtils.toString(e.keyCode)}')`;
 }
 
-/**
- * Checks if a keyboard event has any modifier keys pressed
- */
-export function hasAnyModifierKeys(e: IKeyboardEvent): boolean {
-	return e.altKey || e.ctrlKey || e.metaKey || e.shiftKey;
-}
-
 export class StandardKeyboardEvent implements IKeyboardEvent {
 
 	readonly _standardKeyboardEventBrand = true;

--- a/src/vs/base/browser/keyboardEvent.ts
+++ b/src/vs/base/browser/keyboardEvent.ts
@@ -114,6 +114,13 @@ export function printStandardKeyboardEvent(e: StandardKeyboardEvent): string {
 	return `modifiers: [${modifiers.join(',')}], code: ${e.code}, keyCode: ${e.keyCode} ('${KeyCodeUtils.toString(e.keyCode)}')`;
 }
 
+/**
+ * Checks if a keyboard event has no modifier keys pressed
+ */
+export function hasNoModifierKeys(e: IKeyboardEvent): boolean {
+	return !e.altKey && !e.ctrlKey && !e.metaKey && !e.shiftKey;
+}
+
 export class StandardKeyboardEvent implements IKeyboardEvent {
 
 	readonly _standardKeyboardEventBrand = true;

--- a/src/vs/platform/keybinding/common/keybindingResolver.ts
+++ b/src/vs/platform/keybinding/common/keybindingResolver.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { implies, ContextKeyExpression, ContextKeyExprType, IContext, IContextKeyService, expressionsAreEqualWithConstantSubstitution } from '../../contextkey/common/contextkey.js';
+import { implies, ContextKeyExpression, ContextKeyExprType, IContext, IContextKeyService } from '../../contextkey/common/contextkey.js';
 import { ResolvedKeybindingItem } from './resolvedKeybindingItem.js';
 
 //#region resolution-result
@@ -103,7 +103,12 @@ export class KeybindingResolver {
 			if (!defaultKb.when) {
 				return false;
 			}
-			if (!expressionsAreEqualWithConstantSubstitution(when, defaultKb.when)) {
+
+			// Check if `when` is entirely included in `defaultKb.when`
+			// e.g. `when` is `a && b`, and `defaultKb.when` is `a && b && c`
+			// this means the removal `when` is more general than the `defaultKb.when`
+			// so the removal applies
+			if (!KeybindingResolver.whenIsEntirelyIncluded(defaultKb.when, when)) {
 				return false;
 			}
 		}

--- a/src/vs/platform/keybinding/common/keybindingResolver.ts
+++ b/src/vs/platform/keybinding/common/keybindingResolver.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { implies, ContextKeyExpression, ContextKeyExprType, IContext, IContextKeyService } from '../../contextkey/common/contextkey.js';
+import { implies, ContextKeyExpression, ContextKeyExprType, IContext, IContextKeyService, expressionsAreEqualWithConstantSubstitution } from '../../contextkey/common/contextkey.js';
 import { ResolvedKeybindingItem } from './resolvedKeybindingItem.js';
 
 //#region resolution-result
@@ -103,12 +103,7 @@ export class KeybindingResolver {
 			if (!defaultKb.when) {
 				return false;
 			}
-
-			// Check if `when` is entirely included in `defaultKb.when`
-			// e.g. `when` is `a && b`, and `defaultKb.when` is `a && b && c`
-			// this means the removal `when` is more general than the `defaultKb.when`
-			// so the removal applies
-			if (!KeybindingResolver.whenIsEntirelyIncluded(defaultKb.when, when)) {
+			if (!expressionsAreEqualWithConstantSubstitution(when, defaultKb.when)) {
 				return false;
 			}
 		}

--- a/src/vs/workbench/contrib/chat/browser/actions/chatExecuteActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatExecuteActions.ts
@@ -162,6 +162,10 @@ export class ChatSubmitAction extends SubmitAction {
 
 	constructor() {
 		const menuCondition = ChatContextKeys.chatModeKind.isEqualTo(ChatModeKind.Ask);
+		const precondition = ContextKeyExpr.and(
+			ChatContextKeys.inputHasText,
+			whenNotInProgress,
+		);
 
 		super({
 			id: ChatSubmitAction.ID,
@@ -169,6 +173,7 @@ export class ChatSubmitAction extends SubmitAction {
 			f1: false,
 			category: CHAT_CATEGORY,
 			icon: Codicon.send,
+			precondition,
 			toggled: {
 				condition: ChatContextKeys.lockedToCodingAgent,
 				icon: Codicon.sendToRemoteAgent,
@@ -507,6 +512,10 @@ export class ChatEditingSessionSubmitAction extends SubmitAction {
 
 	constructor() {
 		const menuCondition = ChatContextKeys.chatModeKind.notEqualsTo(ChatModeKind.Ask);
+		const precondition = ContextKeyExpr.and(
+			ChatContextKeys.inputHasText,
+			whenNotInProgress
+		);
 
 		super({
 			id: ChatEditingSessionSubmitAction.ID,
@@ -514,6 +523,7 @@ export class ChatEditingSessionSubmitAction extends SubmitAction {
 			f1: false,
 			category: CHAT_CATEGORY,
 			icon: Codicon.send,
+			precondition,
 			menu: [
 				{
 					id: MenuId.ChatExecuteSecondary,
@@ -586,6 +596,7 @@ export class CreateRemoteAgentJobAction extends Action2 {
 
 	constructor() {
 		const precondition = ContextKeyExpr.and(
+			ChatContextKeys.inputHasText,
 			whenNotInProgress,
 			ChatContextKeys.remoteJobCreating.negate(),
 		);

--- a/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
@@ -7,7 +7,7 @@ import * as dom from '../../../../base/browser/dom.js';
 import { addDisposableListener } from '../../../../base/browser/dom.js';
 import { DEFAULT_FONT_FAMILY } from '../../../../base/browser/fonts.js';
 import { IHistoryNavigationWidget } from '../../../../base/browser/history.js';
-import { hasNoModifierKeys, StandardKeyboardEvent } from '../../../../base/browser/keyboardEvent.js';
+import { hasAnyModifierKeys, StandardKeyboardEvent } from '../../../../base/browser/keyboardEvent.js';
 import { ActionViewItem, IActionViewItemOptions } from '../../../../base/browser/ui/actionbar/actionViewItems.js';
 import * as aria from '../../../../base/browser/ui/aria/aria.js';
 import { Button, ButtonWithIcon } from '../../../../base/browser/ui/button/button.js';
@@ -1203,7 +1203,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 		// We need to prevent Monaco's default Enter behavior while still allowing the VS Code keybinding service
 		// to receive and process the Enter key for ChatSubmitAction
 		this._register(this._inputEditor.onKeyDown((e) => {
-			if (e.keyCode === KeyCode.Enter && hasNoModifierKeys(e)) {
+			if (e.keyCode === KeyCode.Enter && !hasAnyModifierKeys(e)) {
 				// Only prevent the default Monaco behavior (newline insertion)
 				// Do NOT call stopPropagation() so the keybinding service can still process this event
 				e.preventDefault();

--- a/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
@@ -1210,7 +1210,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 				// Only prevent default if the keybinding exists AND matches plain Enter (no modifiers)
 				if (chatSubmitKeybinding) {
 					const chords = chatSubmitKeybinding.getDispatchChords();
-					const isPlainEnter = chords.length === 1 && chords[0] === 'Enter';
+					const isPlainEnter = chords.length === 1 && chords[0] === '[Enter]';
 
 					if (isPlainEnter) {
 						// Also check if the action's precondition is met (e.g., inputHasText)

--- a/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
@@ -4,10 +4,10 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as dom from '../../../../base/browser/dom.js';
-import { addDisposableListener } from '../../../../base/browser/dom.js';
+import { addDisposableListener, ModifierKeyEmitter } from '../../../../base/browser/dom.js';
 import { DEFAULT_FONT_FAMILY } from '../../../../base/browser/fonts.js';
 import { IHistoryNavigationWidget } from '../../../../base/browser/history.js';
-import { hasAnyModifierKeys, StandardKeyboardEvent } from '../../../../base/browser/keyboardEvent.js';
+import { StandardKeyboardEvent } from '../../../../base/browser/keyboardEvent.js';
 import { ActionViewItem, IActionViewItemOptions } from '../../../../base/browser/ui/actionbar/actionViewItems.js';
 import * as aria from '../../../../base/browser/ui/aria/aria.js';
 import { Button, ButtonWithIcon } from '../../../../base/browser/ui/button/button.js';
@@ -1203,7 +1203,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 		// We need to prevent Monaco's default Enter behavior while still allowing the VS Code keybinding service
 		// to receive and process the Enter key for ChatSubmitAction
 		this._register(this._inputEditor.onKeyDown((e) => {
-			if (e.keyCode === KeyCode.Enter && !hasAnyModifierKeys(e)) {
+			if (e.keyCode === KeyCode.Enter && !ModifierKeyEmitter.getInstance().isModifierPressed) {
 				// Only prevent the default Monaco behavior (newline insertion)
 				// Do NOT call stopPropagation() so the keybinding service can still process this event
 				e.preventDefault();

--- a/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
@@ -1205,16 +1205,13 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 			if (e.keyCode === KeyCode.Enter && !hasModifierKeys(e)) {
 				// Check if ChatSubmitAction has a keybinding for plain Enter in the current context
 				// This respects user's custom keybindings that disable the submit action
-				const chatSubmitKeybinding = this.keybindingService.lookupKeybinding(ChatSubmitAction.ID, this.contextKeyService);
-
-				// Only prevent default if the keybinding exists AND matches plain Enter (no modifiers)
-				if (chatSubmitKeybinding) {
-					const chords = chatSubmitKeybinding.getDispatchChords();
+				for (const keybinding of this.keybindingService.lookupKeybindings(ChatSubmitAction.ID)) {
+					const chords = keybinding.getDispatchChords();
 					const isPlainEnter = chords.length === 1 && chords[0] === '[Enter]';
-
 					if (isPlainEnter) {
 						// Do NOT call stopPropagation() so the keybinding service can still process this event
 						e.preventDefault();
+						break;
 					}
 				}
 			}

--- a/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
@@ -1199,6 +1199,18 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 		options.overflowWidgetsDomNode?.classList.add('hideSuggestTextIcons');
 		this._inputEditorElement.classList.add('hideSuggestTextIcons');
 
+		// Prevent Enter key from creating new lines when input is empty
+		this._register(this._inputEditor.onKeyDown((e) => {
+			if (e.keyCode === KeyCode.Enter && !e.altKey && !e.ctrlKey && !e.metaKey && !e.shiftKey) {
+				const model = this._inputEditor.getModel();
+				const inputHasText = !!model && model.getValue().trim().length > 0;
+				if (!inputHasText) {
+					e.preventDefault();
+					e.stopPropagation();
+				}
+			}
+		}));
+
 		this._register(this._inputEditor.onDidChangeModelContent(() => {
 			const currentHeight = Math.min(this._inputEditor.getContentHeight(), this.inputEditorMaxHeight);
 			if (currentHeight !== this.inputEditorHeight) {

--- a/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
@@ -4,10 +4,10 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as dom from '../../../../base/browser/dom.js';
-import { addDisposableListener, ModifierKeyEmitter } from '../../../../base/browser/dom.js';
+import { addDisposableListener } from '../../../../base/browser/dom.js';
 import { DEFAULT_FONT_FAMILY } from '../../../../base/browser/fonts.js';
 import { IHistoryNavigationWidget } from '../../../../base/browser/history.js';
-import { StandardKeyboardEvent } from '../../../../base/browser/keyboardEvent.js';
+import { hasModifierKeys, StandardKeyboardEvent } from '../../../../base/browser/keyboardEvent.js';
 import { ActionViewItem, IActionViewItemOptions } from '../../../../base/browser/ui/actionbar/actionViewItems.js';
 import * as aria from '../../../../base/browser/ui/aria/aria.js';
 import { Button, ButtonWithIcon } from '../../../../base/browser/ui/button/button.js';
@@ -1203,7 +1203,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 		// We need to prevent Monaco's default Enter behavior while still allowing the VS Code keybinding service
 		// to receive and process the Enter key for ChatSubmitAction
 		this._register(this._inputEditor.onKeyDown((e) => {
-			if (e.keyCode === KeyCode.Enter && !ModifierKeyEmitter.getInstance().isModifierPressed) {
+			if (e.keyCode === KeyCode.Enter && !hasModifierKeys(e)) {
 				// Only prevent the default Monaco behavior (newline insertion)
 				// Do NOT call stopPropagation() so the keybinding service can still process this event
 				e.preventDefault();

--- a/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
@@ -50,7 +50,7 @@ import { MenuWorkbenchButtonBar } from '../../../../platform/actions/browser/but
 import { DropdownWithPrimaryActionViewItem, IDropdownWithPrimaryActionViewItemOptions } from '../../../../platform/actions/browser/dropdownWithPrimaryActionViewItem.js';
 import { getFlatActionBarActions } from '../../../../platform/actions/browser/menuEntryActionViewItem.js';
 import { HiddenItemStrategy, MenuWorkbenchToolBar } from '../../../../platform/actions/browser/toolbar.js';
-import { IMenuService, MenuId, MenuItemAction, MenuRegistry } from '../../../../platform/actions/common/actions.js';
+import { IMenuService, MenuId, MenuItemAction } from '../../../../platform/actions/common/actions.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { IContextKey, IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
 import { IContextMenuService } from '../../../../platform/contextview/browser/contextView.js';
@@ -1213,18 +1213,10 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 					const isPlainEnter = chords.length === 1 && chords[0] === '[Enter]';
 
 					if (isPlainEnter) {
-						// Also check if the action's precondition is met (e.g., inputHasText)
-						const commandAction = MenuRegistry.getCommand(ChatSubmitAction.ID);
-						const preconditionMet = !commandAction?.precondition ||
-							this.contextKeyService.contextMatchesRules(commandAction.precondition);
-
-						// Only prevent default if both keybinding exists and precondition is met
-						if (preconditionMet) {
-							e.preventDefault();
-						}
+						// Do NOT call stopPropagation() so the keybinding service can still process this event
+						e.preventDefault();
 					}
 				}
-				// Do NOT call stopPropagation() so the keybinding service can still process this event
 			}
 		}));
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
When input is empty in chat, disable the send button and also prevent Enter key creating new lines.

Fixes #264462 264462


This also fixes an issue from https://github.com/microsoft/vscode/issues/259730 that when there is a tool pending confirmation, user hits enter when input is empty will cancel the tool.
Root cause of that is the Enter key is bound to the chat.submit action which eventually calls into cancel the pending tool invocation.
With this fix that disabled the action when intput is empty, that codeflow is not activated anymore thus that issue is addressed.
