### PR TITLE
Try to not render above cursor when not allowing code shifting

### DIFF
--- a/src/vs/editor/contrib/inlineCompletions/browser/model/inlineCompletionsModel.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/model/inlineCompletionsModel.ts
@@ -64,6 +64,7 @@ export class InlineCompletionsModel extends Disposable {
 	// We use a semantic id to keep the same inline completion selected even if the provider reorders the completions.
 	private readonly _selectedInlineCompletionId = observableValue<string | undefined>(this, undefined);
 	public readonly primaryPosition = derived(this, reader => this._positions.read(reader)[0] ?? new Position(1, 1));
+	public readonly allPositions = derived(this, reader => this._positions.read(reader));
 
 	private _isAcceptingPartially = false;
 	private readonly _appearedInsideViewport = derived<boolean>(this, reader => {

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditWithChanges.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditWithChanges.ts
@@ -31,6 +31,7 @@ export class InlineEditWithChanges {
 		public readonly originalText: AbstractText,
 		public readonly edit: TextEdit,
 		public readonly cursorPosition: Position,
+		public readonly multiCursorPositions: readonly Position[],
 		public readonly commands: readonly InlineCompletionCommand[],
 		public readonly inlineCompletion: InlineSuggestionItem
 	) {

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsModel.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsModel.ts
@@ -98,6 +98,7 @@ export class GhostTextIndicator {
 				new StringText(''),
 				new TextEdit([inlineCompletion.getSingleTextEdit()]),
 				model.primaryPosition.get(),
+				model.allPositions.get(),
 				inlineCompletion.source.inlineSuggestions.commands ?? [],
 				inlineCompletion
 			),

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsView.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsView.ts
@@ -575,19 +575,19 @@ export class InlineEditsView extends Disposable {
 			return false;
 		}
 
-		if (
-			view === InlineCompletionViewKind.WordReplacements &&
-			inlineEdit.cursorPosition.lineNumber === inlineEdit.originalLineRange.startLineNumber + 1
-		) {
-			return true;
-		}
+		for (const cursorPosition of inlineEdit.multiCursorPositions) {
+			if (view === InlineCompletionViewKind.WordReplacements &&
+				cursorPosition.lineNumber === inlineEdit.originalLineRange.startLineNumber + 1
+			) {
+				return true;
+			}
 
-		if (
-			view === InlineCompletionViewKind.LineReplacement &&
-			inlineEdit.cursorPosition.lineNumber >= inlineEdit.originalLineRange.endLineNumberExclusive &&
-			inlineEdit.cursorPosition.lineNumber < inlineEdit.modifiedLineRange.endLineNumberExclusive + inlineEdit.modifiedLineRange.length
-		) {
-			return true;
+			if (view === InlineCompletionViewKind.LineReplacement &&
+				cursorPosition.lineNumber >= inlineEdit.originalLineRange.endLineNumberExclusive &&
+				cursorPosition.lineNumber < inlineEdit.modifiedLineRange.endLineNumberExclusive + inlineEdit.modifiedLineRange.length
+			) {
+				return true;
+			}
 		}
 
 		return false;

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsView.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsView.ts
@@ -474,7 +474,16 @@ export class InlineEditsView extends Disposable {
 	private determineRenderState(model: IInlineEditModel, reader: IReader, diff: DetailedLineRangeMapping[], newText: StringText) {
 		const inlineEdit = model.inlineEdit;
 
-		const view = this.determineView(model, reader, diff, newText);
+		let view = this.determineView(model, reader, diff, newText);
+
+		if (this._willRenderAboveCursor(reader, inlineEdit, view)) {
+			switch (view) {
+				case InlineCompletionViewKind.LineReplacement:
+				case InlineCompletionViewKind.WordReplacements:
+					view = InlineCompletionViewKind.SideBySide;
+					break;
+			}
+		}
 
 		this._previousView = { id: this.getCacheId(model), view, editorWidth: this._editor.getLayoutInfo().width, timestamp: Date.now() };
 
@@ -558,6 +567,30 @@ export class InlineEditsView extends Disposable {
 		}
 
 		return undefined;
+	}
+
+	private _willRenderAboveCursor(reader: IReader, inlineEdit: InlineEditWithChanges, view: InlineCompletionViewKind): boolean {
+		const useCodeShifting = this._useCodeShifting.read(reader);
+		if (useCodeShifting === 'always') {
+			return false;
+		}
+
+		if (
+			view === InlineCompletionViewKind.WordReplacements &&
+			inlineEdit.cursorPosition.lineNumber === inlineEdit.originalLineRange.startLineNumber + 1
+		) {
+			return true;
+		}
+
+		if (
+			view === InlineCompletionViewKind.LineReplacement &&
+			inlineEdit.cursorPosition.lineNumber >= inlineEdit.originalLineRange.endLineNumberExclusive &&
+			inlineEdit.cursorPosition.lineNumber < inlineEdit.modifiedLineRange.endLineNumberExclusive + inlineEdit.modifiedLineRange.length
+		) {
+			return true;
+		}
+
+		return false;
 	}
 
 	private _viewHasBeenShownLongerThan(durationMs: number): boolean {

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViewProducer.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViewProducer.ts
@@ -47,7 +47,7 @@ export class InlineEditsViewAndDiffProducer extends Disposable { // TODO: This c
 		const diffEdits = new TextEdit(edits);
 		const text = new TextModelText(textModel);
 
-		return new InlineEditWithChanges(text, diffEdits, model.primaryPosition.read(undefined), inlineEdit.commands, inlineEdit.inlineCompletion);
+		return new InlineEditWithChanges(text, diffEdits, model.primaryPosition.read(undefined), model.allPositions.read(undefined), inlineEdit.commands, inlineEdit.inlineCompletion);
 	});
 
 	private readonly _inlineEditModel = derived<InlineEditModel | undefined>(this, reader => {


### PR DESCRIPTION
```Copilot Generated Description:``` Implement logic to prevent rendering above the cursor when code shifting is not allowed. Introduce a method to determine if rendering should occur based on the current view and cursor position.

fixes https://github.com/microsoft/vscode/issues/259773