### PR TITLE
switch to async producer for variable Provider

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadNotebookKernels.ts
+++ b/src/vs/workbench/api/browser/mainThreadNotebookKernels.ts
@@ -20,7 +20,7 @@ import { IKernelSourceActionProvider, INotebookKernel, INotebookKernelChangeEven
 import { SerializableObjectWithBuffers } from '../../services/extensions/common/proxyIdentifier.js';
 import { ExtHostContext, ExtHostNotebookKernelsShape, ICellExecuteUpdateDto, ICellExecutionCompleteDto, INotebookKernelDto2, MainContext, MainThreadNotebookKernelsShape } from '../common/extHost.protocol.js';
 import { INotebookService } from '../../contrib/notebook/common/notebookService.js';
-import { AsyncIterableObject, AsyncIterableSource } from '../../../base/common/async.js';
+import { AsyncIterableEmitter, AsyncIterableProducer } from '../../../base/common/async.js';
 
 abstract class MainThreadKernel implements INotebookKernel {
 	private readonly _onDidChange = new Emitter<INotebookKernelChangeEvent>();
@@ -101,7 +101,7 @@ abstract class MainThreadKernel implements INotebookKernel {
 
 	abstract executeNotebookCellsRequest(uri: URI, cellHandles: number[]): Promise<void>;
 	abstract cancelNotebookCellExecution(uri: URI, cellHandles: number[]): Promise<void>;
-	abstract provideVariables(notebookUri: URI, parentId: number | undefined, kind: 'named' | 'indexed', start: number, token: CancellationToken): AsyncIterableObject<VariablesResult>;
+	abstract provideVariables(notebookUri: URI, parentId: number | undefined, kind: 'named' | 'indexed', start: number, token: CancellationToken): AsyncIterableProducer<VariablesResult>;
 }
 
 class MainThreadKernelDetectionTask implements INotebookKernelDetectionTask {
@@ -227,11 +227,11 @@ export class MainThreadNotebookKernels implements MainThreadNotebookKernelsShape
 	}
 
 	private variableRequestIndex = 0;
-	private variableRequestMap = new Map<string, AsyncIterableSource<VariablesResult>>();
+	private variableRequestMap = new Map<string, AsyncIterableEmitter<VariablesResult>>();
 	$receiveVariable(requestId: string, variable: VariablesResult) {
-		const source = this.variableRequestMap.get(requestId);
-		if (source) {
-			source.emitOne(variable);
+		const emitter = this.variableRequestMap.get(requestId);
+		if (emitter) {
+			emitter.emitOne(variable);
 		}
 	}
 
@@ -246,23 +246,18 @@ export class MainThreadNotebookKernels implements MainThreadNotebookKernelsShape
 			async cancelNotebookCellExecution(uri: URI, handles: number[]): Promise<void> {
 				await that._proxy.$cancelCells(handle, uri, handles);
 			}
-			provideVariables(notebookUri: URI, parentId: number | undefined, kind: 'named' | 'indexed', start: number, token: CancellationToken): AsyncIterableObject<VariablesResult> {
+			provideVariables(notebookUri: URI, parentId: number | undefined, kind: 'named' | 'indexed', start: number, token: CancellationToken): AsyncIterableProducer<VariablesResult> {
 				const requestId = `${handle}variables${that.variableRequestIndex++}`;
-				if (that.variableRequestMap.has(requestId)) {
-					return that.variableRequestMap.get(requestId)!.asyncIterable;
-				}
 
-				const source = new AsyncIterableSource<VariablesResult>();
-				that.variableRequestMap.set(requestId, source);
-				that._proxy.$provideVariables(handle, requestId, notebookUri, parentId, kind, start, token).then(() => {
-					source.resolve();
-					that.variableRequestMap.delete(requestId);
-				}).catch((err) => {
-					source.reject(err);
-					that.variableRequestMap.delete(requestId);
+				return new AsyncIterableProducer<VariablesResult>(async emitter => {
+					that.variableRequestMap.set(requestId, emitter);
+
+					try {
+						await that._proxy.$provideVariables(handle, requestId, notebookUri, parentId, kind, start, token);
+					} finally {
+						that.variableRequestMap.delete(requestId);
+					}
 				});
-
-				return source.asyncIterable;
 			}
 		}(data, this._languageService);
 

--- a/src/vs/workbench/contrib/notebook/browser/contrib/notebookVariables/notebookVariableCommands.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/notebookVariables/notebookVariableCommands.ts
@@ -59,10 +59,12 @@ registerAction2(class extends Action2 {
 
 		const selectedKernel = notebookKernelService.getMatchingKernel(notebookTextModel).selected;
 		if (selectedKernel && selectedKernel.hasVariableProvider) {
-			const variables = selectedKernel.provideVariables(notebookTextModel.uri, undefined, 'named', 0, CancellationToken.None);
-			return await variables
-				.map(variable => { return variable; })
-				.toPromise();
+			const variableIterable = selectedKernel.provideVariables(notebookTextModel.uri, undefined, 'named', 0, CancellationToken.None);
+			const collected: VariablesResult[] = [];
+			for await (const variable of variableIterable) {
+				collected.push(variable);
+			}
+			return collected;
 		}
 
 		return [];

--- a/src/vs/workbench/contrib/notebook/browser/contrib/notebookVariables/notebookVariablesDataSource.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/notebookVariables/notebookVariablesDataSource.ts
@@ -70,10 +70,9 @@ export class NotebookVariableDataSource implements IAsyncDataSource<INotebookSco
 			let children: INotebookVariableElement[] = [];
 			if (parent.hasNamedChildren) {
 				const variables = selectedKernel.provideVariables(parent.notebook.uri, parent.extHostId, 'named', 0, this.cancellationTokenSource.token);
-				const childNodes = await variables
-					.map(variable => { return this.createVariableElement(variable, parent.notebook); })
-					.toPromise();
-				children = children.concat(childNodes);
+				for await (const variable of variables) {
+					children.push(this.createVariableElement(variable, parent.notebook));
+				}
 			}
 			if (parent.indexedChildrenCount > 0) {
 				const childNodes = await this.getIndexedChildren(parent, selectedKernel);
@@ -145,9 +144,11 @@ export class NotebookVariableDataSource implements IAsyncDataSource<INotebookSco
 		const selectedKernel = this.notebookKernelService.getMatchingKernel(notebook).selected;
 		if (selectedKernel && selectedKernel.hasVariableProvider) {
 			const variables = selectedKernel.provideVariables(notebook.uri, undefined, 'named', 0, this.cancellationTokenSource.token);
-			return await variables
-				.map(variable => { return this.createVariableElement(variable, notebook); })
-				.toPromise();
+			const varElements: INotebookVariableElement[] = [];
+			for await (const variable of variables) {
+				varElements.push(this.createVariableElement(variable, notebook));
+			}
+			return varElements;
 		}
 
 		return [];

--- a/src/vs/workbench/contrib/notebook/browser/controller/chat/notebook.chat.contribution.ts
+++ b/src/vs/workbench/contrib/notebook/browser/controller/chat/notebook.chat.contribution.ts
@@ -131,7 +131,7 @@ class NotebookChatContribution extends Disposable implements IWorkbenchContribut
 			return;
 		}
 
-		const variables = await selectedKernel.provideVariables(notebook.uri, undefined, 'named', 0, CancellationToken.None);
+		const variables = selectedKernel.provideVariables(notebook.uri, undefined, 'named', 0, CancellationToken.None);
 
 		for await (const variable of variables) {
 			if (pattern && !variable.name.toLowerCase().includes(pattern)) {
@@ -195,7 +195,7 @@ export class SelectAndInsertKernelVariableAction extends Action2 {
 			return;
 		}
 
-		const variables = await selectedKernel.provideVariables(notebook.uri, undefined, 'named', 0, CancellationToken.None);
+		const variables = selectedKernel.provideVariables(notebook.uri, undefined, 'named', 0, CancellationToken.None);
 
 		const quickPickItems: IQuickPickItem[] = [];
 		for await (const variable of variables) {

--- a/src/vs/workbench/contrib/notebook/common/notebookKernelService.ts
+++ b/src/vs/workbench/contrib/notebook/common/notebookKernelService.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { IAction } from '../../../../base/common/actions.js';
-import { AsyncIterableObject } from '../../../../base/common/async.js';
+import { AsyncIterableProducer } from '../../../../base/common/async.js';
 import { CancellationToken } from '../../../../base/common/cancellation.js';
 import { Event } from '../../../../base/common/event.js';
 import { IDisposable } from '../../../../base/common/lifecycle.js';
@@ -70,7 +70,7 @@ export interface INotebookKernel {
 	executeNotebookCellsRequest(uri: URI, cellHandles: number[]): Promise<void>;
 	cancelNotebookCellExecution(uri: URI, cellHandles: number[]): Promise<void>;
 
-	provideVariables(notebookUri: URI, parentId: number | undefined, kind: 'named' | 'indexed', start: number, token: CancellationToken): AsyncIterableObject<VariablesResult>;
+	provideVariables(notebookUri: URI, parentId: number | undefined, kind: 'named' | 'indexed', start: number, token: CancellationToken): AsyncIterableProducer<VariablesResult>;
 }
 
 export const enum ProxyKernelState {

--- a/src/vs/workbench/contrib/notebook/test/browser/notebookExecutionService.test.ts
+++ b/src/vs/workbench/contrib/notebook/test/browser/notebookExecutionService.test.ts
@@ -5,7 +5,7 @@
 
 import assert from 'assert';
 import * as sinon from 'sinon';
-import { AsyncIterableObject } from '../../../../../base/common/async.js';
+import { AsyncIterableProducer } from '../../../../../base/common/async.js';
 import { CancellationToken } from '../../../../../base/common/cancellation.js';
 import { Event } from '../../../../../base/common/event.js';
 import { DisposableStore } from '../../../../../base/common/lifecycle.js';
@@ -183,8 +183,8 @@ class TestNotebookKernel implements INotebookKernel {
 	preloadUris: URI[] = [];
 	preloadProvides: string[] = [];
 	supportedLanguages: string[] = [];
-	provideVariables(notebookUri: URI, parentId: number | undefined, kind: 'named' | 'indexed', start: number, token: CancellationToken): AsyncIterableObject<VariablesResult> {
-		return AsyncIterableObject.EMPTY;
+	provideVariables(notebookUri: URI, parentId: number | undefined, kind: 'named' | 'indexed', start: number, token: CancellationToken): AsyncIterableProducer<VariablesResult> {
+		return AsyncIterableProducer.EMPTY;
 	}
 	executeNotebookCellsRequest(): Promise<void> {
 		throw new Error('Method not implemented.');

--- a/src/vs/workbench/contrib/notebook/test/browser/notebookExecutionStateService.test.ts
+++ b/src/vs/workbench/contrib/notebook/test/browser/notebookExecutionStateService.test.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
-import { AsyncIterableObject, DeferredPromise } from '../../../../../base/common/async.js';
+import { AsyncIterableProducer, DeferredPromise } from '../../../../../base/common/async.js';
 import { CancellationToken } from '../../../../../base/common/cancellation.js';
 import { Event } from '../../../../../base/common/event.js';
 import { DisposableStore } from '../../../../../base/common/lifecycle.js';
@@ -371,8 +371,8 @@ class TestNotebookKernel implements INotebookKernel {
 	supportedLanguages: string[] = [];
 	async executeNotebookCellsRequest(): Promise<void> { }
 	async cancelNotebookCellExecution(uri: URI, cellHandles: number[]): Promise<void> { }
-	provideVariables(notebookUri: URI, parentId: number | undefined, kind: 'named' | 'indexed', start: number, token: CancellationToken): AsyncIterableObject<VariablesResult> {
-		return AsyncIterableObject.EMPTY;
+	provideVariables(notebookUri: URI, parentId: number | undefined, kind: 'named' | 'indexed', start: number, token: CancellationToken): AsyncIterableProducer<VariablesResult> {
+		return AsyncIterableProducer.EMPTY;
 	}
 
 	constructor(opts?: { languages?: string[]; id?: string }) {

--- a/src/vs/workbench/contrib/notebook/test/browser/notebookKernelHistory.test.ts
+++ b/src/vs/workbench/contrib/notebook/test/browser/notebookKernelHistory.test.ts
@@ -22,7 +22,7 @@ import { IApplicationStorageValueChangeEvent, IProfileStorageValueChangeEvent, I
 import { INotebookLoggingService } from '../../common/notebookLoggingService.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { CancellationToken } from '../../../../../base/common/cancellation.js';
-import { AsyncIterableObject } from '../../../../../base/common/async.js';
+import { AsyncIterableProducer } from '../../../../../base/common/async.js';
 
 suite('NotebookKernelHistoryService', () => {
 
@@ -186,8 +186,8 @@ class TestNotebookKernel implements INotebookKernel {
 	cancelNotebookCellExecution(): Promise<void> {
 		throw new Error('Method not implemented.');
 	}
-	provideVariables(notebookUri: URI, parentId: number | undefined, kind: 'named' | 'indexed', start: number, token: CancellationToken): AsyncIterableObject<VariablesResult> {
-		return AsyncIterableObject.EMPTY;
+	provideVariables(notebookUri: URI, parentId: number | undefined, kind: 'named' | 'indexed', start: number, token: CancellationToken): AsyncIterableProducer<VariablesResult> {
+		return AsyncIterableProducer.EMPTY;
 	}
 
 	constructor(opts?: { languages?: string[]; label?: string; notebookType?: string }) {

--- a/src/vs/workbench/contrib/notebook/test/browser/notebookKernelService.test.ts
+++ b/src/vs/workbench/contrib/notebook/test/browser/notebookKernelService.test.ts
@@ -20,7 +20,7 @@ import { IMenu, IMenuService } from '../../../../../platform/actions/common/acti
 import { TransientOptions } from '../../common/notebookCommon.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { CancellationToken } from '../../../../../base/common/cancellation.js';
-import { AsyncIterableObject } from '../../../../../base/common/async.js';
+import { AsyncIterableProducer } from '../../../../../base/common/async.js';
 
 suite('NotebookKernelService', () => {
 
@@ -199,8 +199,8 @@ class TestNotebookKernel implements INotebookKernel {
 	cancelNotebookCellExecution(): Promise<void> {
 		throw new Error('Method not implemented.');
 	}
-	provideVariables(notebookUri: URI, parentId: number | undefined, kind: 'named' | 'indexed', start: number, token: CancellationToken): AsyncIterableObject<VariablesResult> {
-		return AsyncIterableObject.EMPTY;
+	provideVariables(notebookUri: URI, parentId: number | undefined, kind: 'named' | 'indexed', start: number, token: CancellationToken): AsyncIterableProducer<VariablesResult> {
+		return AsyncIterableProducer.EMPTY;
 	}
 
 	constructor(opts?: { languages?: string[]; label?: string; viewType?: string }) {

--- a/src/vs/workbench/contrib/notebook/test/browser/notebookVariablesDataSource.test.ts
+++ b/src/vs/workbench/contrib/notebook/test/browser/notebookVariablesDataSource.test.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 import assert from 'assert';
-import { AsyncIterableObject, AsyncIterableSource } from '../../../../../base/common/async.js';
+import { AsyncIterableProducer } from '../../../../../base/common/async.js';
 import { CancellationToken } from '../../../../../base/common/cancellation.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { mock } from '../../../../../base/test/common/mock.js';
@@ -29,21 +29,19 @@ suite('NotebookVariableDataSource', () => {
 			kind: 'named' | 'indexed',
 			start: number,
 			token: CancellationToken
-		): AsyncIterableObject<VariablesResult> {
+		): AsyncIterableProducer<VariablesResult> {
 			provideVariablesCalled = true;
-			const source = new AsyncIterableSource<VariablesResult>();
-			for (let i = 0; i < results.length; i++) {
-				if (token.isCancellationRequested) {
-					break;
+			return new AsyncIterableProducer<VariablesResult>((emitter) => {
+				for (let i = 0; i < results.length; i++) {
+					if (token.isCancellationRequested) {
+						break;
+					}
+					if (results[i].action) {
+						results[i].action!();
+					}
+					emitter.emitOne(results[i]);
 				}
-				if (results[i].action) {
-					results[i].action!();
-				}
-				source.emitOne(results[i]);
-			}
-
-			setTimeout(() => source.resolve(), 0);
-			return source.asyncIterable;
+			});
 		}
 	};
 


### PR DESCRIPTION
https://github.com/microsoft/vscode/issues/256854

the variable results are only cached in the extension, every request creates a new async iterable in the workbench, so this is a good candidate to migrate.