### PR TITLE
fix: Increase workbench border radius on macos tahoe

### DIFF
--- a/src/vs/base/common/platform.ts
+++ b/src/vs/base/common/platform.ts
@@ -278,3 +278,7 @@ export const isAndroid = !!(userAgent && userAgent.indexOf('Android') >= 0);
 export function isBigSurOrNewer(osVersion: string): boolean {
 	return parseFloat(osVersion) >= 20;
 }
+
+export function isTahoeOrNewer(osVersion: string): boolean {
+	return parseFloat(osVersion) >= 25;
+}

--- a/src/vs/workbench/browser/media/style.css
+++ b/src/vs/workbench/browser/media/style.css
@@ -73,6 +73,10 @@ body {
 	border-radius: 10px; /* macOS Big Sur increased rounded corners size */
 }
 
+.monaco-workbench.border.mac.macos-tahoe-or-newer {
+	border-radius: 12px; /* macOS Tahoe increased rounded corners size even more */
+}
+
 .monaco-workbench img {
 	border: 0;
 }

--- a/src/vs/workbench/browser/parts/statusbar/media/statusbarpart.css
+++ b/src/vs/workbench/browser/parts/statusbar/media/statusbarpart.css
@@ -27,6 +27,11 @@
 	border-bottom-right-radius: 10px;
 	border-bottom-left-radius: 10px;
 }
+.monaco-workbench.mac:not(.fullscreen).macos-tahoe-or-newer .part.statusbar:focus {
+	/* macOS Tahoe increased rounded corners size even more */
+	border-bottom-right-radius: 12px;
+	border-bottom-left-radius: 12px;
+}
 
 .monaco-workbench .part.statusbar:not(:focus).status-border-top::after {
 	/* Top border only visible unless focused to make room for focus outline */

--- a/src/vs/workbench/contrib/processExplorer/browser/media/processExplorer.css
+++ b/src/vs/workbench/contrib/processExplorer/browser/media/processExplorer.css
@@ -67,6 +67,12 @@
 	border-bottom-left-radius: 10px;
 }
 
+.mac:not(.fullscreen).macos-tahoe-or-newer .process-explorer .monaco-list:focus::before {
+	/* macOS Tahoe increased rounded corners size even more */
+	border-bottom-right-radius: 12px;
+	border-bottom-left-radius: 12px;
+}
+
 .process-explorer .monaco-list-row:first-of-type {
 	border-bottom: 1px solid var(--vscode-tree-tableColumnsBorder);
 }

--- a/src/vs/workbench/electron-browser/desktop.main.ts
+++ b/src/vs/workbench/electron-browser/desktop.main.ts
@@ -45,7 +45,7 @@ import { WorkspaceTrustEnablementService, WorkspaceTrustManagementService } from
 import { IWorkspaceTrustEnablementService, IWorkspaceTrustManagementService } from '../../platform/workspace/common/workspaceTrust.js';
 import { safeStringify } from '../../base/common/objects.js';
 import { IUtilityProcessWorkerWorkbenchService, UtilityProcessWorkerWorkbenchService } from '../services/utilityProcess/electron-browser/utilityProcessWorkerWorkbenchService.js';
-import { isBigSurOrNewer, isCI, isMacintosh } from '../../base/common/platform.js';
+import { isBigSurOrNewer, isCI, isMacintosh, isTahoeOrNewer } from '../../base/common/platform.js';
 import { Schemas } from '../../base/common/network.js';
 import { DiskFileSystemProvider } from '../services/files/electron-browser/diskFileSystemProvider.js';
 import { FileUserDataProvider } from '../../platform/userData/common/fileUserDataProvider.js';
@@ -153,8 +153,13 @@ export class DesktopMain extends Disposable {
 	}
 
 	private getExtraClasses(): string[] {
-		if (isMacintosh && isBigSurOrNewer(this.configuration.os.release)) {
-			return ['macos-bigsur-or-newer'];
+		if (isMacintosh) {
+			if (isTahoeOrNewer(this.configuration.os.release)) {
+				return ['macos-tahoe-or-newer'];
+			}
+			if (isBigSurOrNewer(this.configuration.os.release)) {
+				return ['macos-bigsur-or-newer'];
+			}
 		}
 
 		return [];

--- a/src/vs/workbench/electron-browser/desktop.main.ts
+++ b/src/vs/workbench/electron-browser/desktop.main.ts
@@ -154,6 +154,9 @@ export class DesktopMain extends Disposable {
 
 	private getExtraClasses(): string[] {
 		if (isMacintosh) {
+             // TODO: Revisit the border radius values till Electron v40 adoption
+             // Refs https://github.com/electron/electron/issues/47514 and
+             // https://github.com/microsoft/vscode/pull/270236#issuecomment-3379301185
 			if (isTahoeOrNewer(this.configuration.os.release)) {
 				return ['macos-tahoe-or-newer'];
 			}

--- a/src/vs/workbench/electron-browser/desktop.main.ts
+++ b/src/vs/workbench/electron-browser/desktop.main.ts
@@ -154,9 +154,9 @@ export class DesktopMain extends Disposable {
 
 	private getExtraClasses(): string[] {
 		if (isMacintosh) {
-             // TODO: Revisit the border radius values till Electron v40 adoption
-             // Refs https://github.com/electron/electron/issues/47514 and
-             // https://github.com/microsoft/vscode/pull/270236#issuecomment-3379301185
+			// TODO: Revisit the border radius values till Electron v40 adoption
+			// Refs https://github.com/electron/electron/issues/47514 and
+			// https://github.com/microsoft/vscode/pull/270236#issuecomment-3379301185
 			if (isTahoeOrNewer(this.configuration.os.release)) {
 				return ['macos-tahoe-or-newer'];
 			}


### PR DESCRIPTION
fixes: https://github.com/microsoft/vscode/issues/270188
<img width="1000" alt="image" src="https://github.com/user-attachments/assets/4029dafa-3138-49a5-a2f5-d39839fb2258" />

⚠️ important notes:

Electron will (sometime in the near future) bump their build workflow to build on MacOS 26 Tahoe, which uses XCode 26.
Apps built with XCode 26 will have *even bigger* corner radius, here's an example

<img width="239" height="127" alt="image" src="https://github.com/user-attachments/assets/c53c80b9-4b47-4a8f-8c01-7df98166f3ce" />

electron preparing for xcode26 is tracked here: https://github.com/electron/electron/issues/47514

So this will be revisited in the future to increase *even more* (possibly to 18px?)