### PR TITLE
Add /investigate chat command

### DIFF
--- a/.github/prompts/investigate.prompt.md
+++ b/.github/prompts/investigate.prompt.md
@@ -1,0 +1,32 @@
+---
+mode: agent
+tools: ['search', 'github/github-mcp-server/get_commit', 'github/github-mcp-server/get_issue', 'github/github-mcp-server/get_issue_comments', 'github/github-mcp-server/get_pull_request', 'github/github-mcp-server/get_pull_request_diff', 'github/github-mcp-server/get_pull_request_files', 'github/github-mcp-server/get_pull_request_review_comments', 'github/github-mcp-server/get_pull_request_reviews', 'github/github-mcp-server/get_pull_request_status', 'changes', 'fetch', 'todos']
+---
+Your goal is to perform an investigation of a given issue and return with investigation notes. For this you need to:
+1. Understand the context of the bug or feature by reading the issue description and comments.
+2. Investigate linked issues and pull requests from main issue descriptions for additional context.
+3. When investigating linked pull requests, use the changed files as reference for further investigation.
+4. Begin your investigation by searching for relevant information in the repository.
+
+Your output should follow this <example>:
+<example>
+# Investigation Notes for [issue]
+**TL;DR**: [One to two sentence summary of the issue and its context, explained in a way that a non-technical user can understand]
+
+## Context
+[Detailed context of the issue, including relevant information from issue description, comments, linked issues, and pull requests]
+
+## Background
+[Detailed findings from the investigation, including relevant code changes, configurations, and any other pertinent information]
+
+## Relevant Files
+[List of files relevant to the issue, with brief descriptions of their purpose and how they relate to the issue]
+
+## Suggested Implementation
+[If applicable, suggest a possible implementation or solution based on the investigation]
+</example>
+
+## Guidelines
+- Do not make any code edits, just generate investigation notes.
+- Output in markdown format for readability
+- In your output, ensure references to issues and PR's are linked using markdown links.

--- a/.github/prompts/investigate.prompt.md
+++ b/.github/prompts/investigate.prompt.md
@@ -1,32 +1,50 @@
 ---
-mode: agent
+agent: agent
 tools: ['search', 'github/github-mcp-server/get_commit', 'github/github-mcp-server/get_issue', 'github/github-mcp-server/get_issue_comments', 'github/github-mcp-server/get_pull_request', 'github/github-mcp-server/get_pull_request_diff', 'github/github-mcp-server/get_pull_request_files', 'github/github-mcp-server/get_pull_request_review_comments', 'github/github-mcp-server/get_pull_request_reviews', 'github/github-mcp-server/get_pull_request_status', 'changes', 'fetch', 'todos']
 ---
-Your goal is to perform an investigation of a given issue and return with investigation notes. For this you need to:
-1. Understand the context of the bug or feature by reading the issue description and comments.
+# Your Task
+Investigate a given issue, provide investigation notes written as a learning guide, and get me to a point where I can decide on a solution. To do this:
+1. Understand the context of the issue by reading the issue description and comments.
 2. Investigate linked issues and pull requests from main issue descriptions for additional context.
-3. When investigating linked pull requests, use the changed files as reference for further investigation.
-4. Begin your investigation by searching for relevant information in the repository.
+3. Starting with context found from step 2, investigate the repository to discover the relevant systems.
+4. Understand the systems relevant to the issue and how they connect to the larger codebase, and teach me about them. Include a section about what I can breakpoint or log to understand the runtime behavior of the system.
+5. Suggest a high level approach to solving the issue. Include implications on what the change will do to the system, and if it could affect other systems.
 
-Your output should follow this <example>:
+# Example Output
 <example>
-# Investigation Notes for [issue]
-**TL;DR**: [One to two sentence summary of the issue and its context, explained in a way that a non-technical user can understand]
 
-## Context
-[Detailed context of the issue, including relevant information from issue description, comments, linked issues, and pull requests]
+# Investigation Notes for [issue]
+
+## Summary
+
+**Difficulty:** [Easy/Medium/Hard][emoji]
+
+**Problem:** [One sentence summary of the problem.]
+
+**Expected Behavior:** [One sentence summary of the expected behavior.]
+
+**Possible Root Cause:** [What is the root cause of the problem? Provide a link to the relevant code if applicable.]
 
 ## Background
-[Detailed findings from the investigation, including relevant code changes, configurations, and any other pertinent information]
+[Detailed investigation notes written to accelerate understanding of the code surrounding the issue. Provide context on the relevant systems, how they connect to the larger codebase, and any other relevant information that will help me understand the issue. Highlight the areas that will likely need changes.]
+```mermaid
+[Simplified mermaid diagram illustrating the relevant systems and their interactions.]
+```
 
-## Relevant Files
-[List of files relevant to the issue, with brief descriptions of their purpose and how they relate to the issue]
+## Understanding Runtime Behavior
+[Describe what I can breakpoint or log to understand the runtime behavior of the system. Include specific areas of the code to focus on and what to look for when debugging or logging.]
 
 ## Suggested Implementation
-[If applicable, suggest a possible implementation or solution based on the investigation]
+[Suggest a high level approach to solving the issue. Include implications on what the change will do to the system, and if it could affect other systems. Do not provide code here.]
 </example>
 
-## Guidelines
+# Guidelines
 - Do not make any code edits, just generate investigation notes.
-- Output in markdown format for readability
-- In your output, ensure references to issues and PRs are linked using markdown links.
+- Output in markdown format for readability.
+- When referring to any code, excessively link to specific relevant areas.
+- Ensure references to issues and PR's are markdown links.
+- Use the following guidelines when assigning a difficulty for the issue:
+  - Easy: Straightforward issues that require minimal changes and have clear solutions.
+  - Medium: Issues that may require some research or moderate changes to the codebase.
+  - Hard: Complex issues that may involve significant changes, deep understanding of the codebase, or extensive testing.
+- Do not respond as if you know what the solution is.

--- a/.github/prompts/investigate.prompt.md
+++ b/.github/prompts/investigate.prompt.md
@@ -29,4 +29,4 @@ Your output should follow this <example>:
 ## Guidelines
 - Do not make any code edits, just generate investigation notes.
 - Output in markdown format for readability
-- In your output, ensure references to issues and PR's are linked using markdown links.
+- In your output, ensure references to issues and PRs are linked using markdown links.


### PR DESCRIPTION
# The Goal
`/investigate <github_issue>` -> Returns `<investigation_notes>` to help developers get up to speed on a given issue

Ideally, those notes can be plugged into...
- A "Teaching Agent" to go in depth on the given area with the dev
- Ask mode to discuss potential solutions -> Agent mode to implement the solution
- etc.