### PR TITLE
Fix F3 and Shift+F3 in notebooks

### DIFF
--- a/src/vs/editor/contrib/find/browser/findController.ts
+++ b/src/vs/editor/contrib/find/browser/findController.ts
@@ -684,63 +684,98 @@ export abstract class MatchFindAction extends EditorAction {
 	protected abstract _run(controller: CommonFindController): boolean;
 }
 
-export class NextMatchFindAction extends MatchFindAction {
+export const NextMatchFindAction = registerMultiEditorAction(new MultiEditorAction({
+	id: FIND_IDS.NextMatchFindAction,
+	label: nls.localize2('findNextMatchAction', "Find Next"),
+	precondition: undefined,
+	kbOpts: [{
+		kbExpr: EditorContextKeys.focus,
+		primary: KeyCode.F3,
+		mac: { primary: KeyMod.CtrlCmd | KeyCode.KeyG, secondary: [KeyCode.F3] },
+		weight: KeybindingWeight.EditorContrib
+	}, {
+		kbExpr: ContextKeyExpr.and(EditorContextKeys.focus, CONTEXT_FIND_INPUT_FOCUSED),
+		primary: KeyCode.Enter,
+		weight: KeybindingWeight.EditorContrib
+	}]
+}));
 
-	constructor() {
-		super({
-			id: FIND_IDS.NextMatchFindAction,
-			label: nls.localize2('findNextMatchAction', "Find Next"),
-			precondition: undefined,
-			kbOpts: [{
-				kbExpr: EditorContextKeys.focus,
-				primary: KeyCode.F3,
-				mac: { primary: KeyMod.CtrlCmd | KeyCode.KeyG, secondary: [KeyCode.F3] },
-				weight: KeybindingWeight.EditorContrib
-			}, {
-				kbExpr: ContextKeyExpr.and(EditorContextKeys.focus, CONTEXT_FIND_INPUT_FOCUSED),
-				primary: KeyCode.Enter,
-				weight: KeybindingWeight.EditorContrib
-			}]
-		});
+NextMatchFindAction.addImplementation(0, async (accessor: ServicesAccessor, editor: ICodeEditor, args: any): Promise<void> => {
+	const controller = CommonFindController.get(editor);
+	if (!controller) {
+		return;
 	}
 
-	protected _run(controller: CommonFindController): boolean {
+	const runMatch = (): boolean => {
 		const result = controller.moveToNextMatch();
 		if (result) {
 			controller.editor.pushUndoStop();
 			return true;
 		}
-
 		return false;
-	}
-}
+	};
 
-
-export class PreviousMatchFindAction extends MatchFindAction {
-
-	constructor() {
-		super({
-			id: FIND_IDS.PreviousMatchFindAction,
-			label: nls.localize2('findPreviousMatchAction', "Find Previous"),
-			precondition: undefined,
-			kbOpts: [{
-				kbExpr: EditorContextKeys.focus,
-				primary: KeyMod.Shift | KeyCode.F3,
-				mac: { primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KeyG, secondary: [KeyMod.Shift | KeyCode.F3] },
-				weight: KeybindingWeight.EditorContrib
-			}, {
-				kbExpr: ContextKeyExpr.and(EditorContextKeys.focus, CONTEXT_FIND_INPUT_FOCUSED),
-				primary: KeyMod.Shift | KeyCode.Enter,
-				weight: KeybindingWeight.EditorContrib
-			}
-			]
+	if (!runMatch()) {
+		await controller.start({
+			forceRevealReplace: false,
+			seedSearchStringFromSelection: (controller.getState().searchString.length === 0) && editor.getOption(EditorOption.find).seedSearchStringFromSelection !== 'never' ? 'single' : 'none',
+			seedSearchStringFromNonEmptySelection: editor.getOption(EditorOption.find).seedSearchStringFromSelection === 'selection',
+			seedSearchStringFromGlobalClipboard: true,
+			shouldFocus: FindStartFocusAction.NoFocusChange,
+			shouldAnimate: true,
+			updateSearchScope: false,
+			loop: editor.getOption(EditorOption.find).loop
 		});
+		runMatch();
+	}
+});
+
+
+export const PreviousMatchFindAction = registerMultiEditorAction(new MultiEditorAction({
+	id: FIND_IDS.PreviousMatchFindAction,
+	label: nls.localize2('findPreviousMatchAction', "Find Previous"),
+	precondition: undefined,
+	kbOpts: [{
+		kbExpr: EditorContextKeys.focus,
+		primary: KeyMod.Shift | KeyCode.F3,
+		mac: { primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KeyG, secondary: [KeyMod.Shift | KeyCode.F3] },
+		weight: KeybindingWeight.EditorContrib
+	}, {
+		kbExpr: ContextKeyExpr.and(EditorContextKeys.focus, CONTEXT_FIND_INPUT_FOCUSED),
+		primary: KeyMod.Shift | KeyCode.Enter,
+		weight: KeybindingWeight.EditorContrib
+	}]
+}));
+
+PreviousMatchFindAction.addImplementation(0, async (accessor: ServicesAccessor, editor: ICodeEditor, args: any): Promise<void> => {
+	const controller = CommonFindController.get(editor);
+	if (!controller) {
+		return;
 	}
 
-	protected _run(controller: CommonFindController): boolean {
-		return controller.moveToPrevMatch();
+	const runMatch = (): boolean => {
+		const result = controller.moveToPrevMatch();
+		if (result) {
+			controller.editor.pushUndoStop();
+			return true;
+		}
+		return false;
+	};
+
+	if (!runMatch()) {
+		await controller.start({
+			forceRevealReplace: false,
+			seedSearchStringFromSelection: (controller.getState().searchString.length === 0) && editor.getOption(EditorOption.find).seedSearchStringFromSelection !== 'never' ? 'single' : 'none',
+			seedSearchStringFromNonEmptySelection: editor.getOption(EditorOption.find).seedSearchStringFromSelection === 'selection',
+			seedSearchStringFromGlobalClipboard: true,
+			shouldFocus: FindStartFocusAction.NoFocusChange,
+			shouldAnimate: true,
+			updateSearchScope: false,
+			loop: editor.getOption(EditorOption.find).loop
+		});
+		runMatch();
 	}
-}
+});
 
 export class MoveToMatchFindAction extends EditorAction {
 
@@ -989,8 +1024,6 @@ registerEditorContribution(CommonFindController.ID, FindController, EditorContri
 
 registerEditorAction(StartFindWithArgsAction);
 registerEditorAction(StartFindWithSelectionAction);
-registerEditorAction(NextMatchFindAction);
-registerEditorAction(PreviousMatchFindAction);
 registerEditorAction(MoveToMatchFindAction);
 registerEditorAction(NextSelectionMatchFindAction);
 registerEditorAction(PreviousSelectionMatchFindAction);

--- a/src/vs/editor/contrib/find/test/browser/findController.test.ts
+++ b/src/vs/editor/contrib/find/test/browser/findController.test.ts
@@ -168,7 +168,7 @@ suite('FindController', () => {
 			// The cursor is at the very top, of the file, at the first ABC
 			const findController = editor.registerAndInstantiateContribution(TestFindController.ID, TestFindController);
 			const findState = findController.getState();
-			const nextMatchFindAction = new NextMatchFindAction();
+			const nextMatchFindAction = NextMatchFindAction;
 
 			// I hit Ctrl+F to show the Find dialog
 			await executeAction(instantiationService, editor, StartFindAction);
@@ -220,7 +220,7 @@ suite('FindController', () => {
 		], { serviceCollection: serviceCollection }, async (editor) => {
 			clipboardState = '';
 			const findController = editor.registerAndInstantiateContribution(TestFindController.ID, TestFindController);
-			const nextMatchFindAction = new NextMatchFindAction();
+			const nextMatchFindAction = NextMatchFindAction;
 
 			editor.setPosition({
 				lineNumber: 1,
@@ -245,7 +245,7 @@ suite('FindController', () => {
 		], { serviceCollection: serviceCollection }, async (editor, _, instantiationService) => {
 			clipboardState = '';
 			const findController = editor.registerAndInstantiateContribution(TestFindController.ID, TestFindController);
-			const nextMatchFindAction = new NextMatchFindAction();
+			const nextMatchFindAction = NextMatchFindAction;
 
 			editor.setSelection(new Selection(1, 9, 1, 13));
 
@@ -268,7 +268,7 @@ suite('FindController', () => {
 		], { serviceCollection: serviceCollection }, async (editor, _, instantiationService) => {
 			const testRegexString = 'tes.';
 			const findController = editor.registerAndInstantiateContribution(TestFindController.ID, TestFindController);
-			const nextMatchFindAction = new NextMatchFindAction();
+			const nextMatchFindAction = NextMatchFindAction;
 
 			findController.toggleRegex();
 			findController.setSearchString(testRegexString);

--- a/src/vs/workbench/contrib/notebook/browser/contrib/find/notebookFind.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/find/notebookFind.ts
@@ -273,7 +273,7 @@ registerAction2(class extends Action2 {
 	constructor() {
 		super({
 			id: 'notebook.findNext.fromWidget',
-			title: localize2('notebook.findNext.fromWidget', 'Find Next (from Find Widget)'),
+			title: localize2('notebook.findNext.fromWidget', 'Find Next'),
 			keybinding: {
 				when: ContextKeyExpr.and(
 					NOTEBOOK_EDITOR_FOCUSED,
@@ -295,7 +295,7 @@ registerAction2(class extends Action2 {
 	constructor() {
 		super({
 			id: 'notebook.findPrevious.fromWidget',
-			title: localize2('notebook.findPrevious.fromWidget', 'Find Previous (from Find Widget)'),
+			title: localize2('notebook.findPrevious.fromWidget', 'Find Previous'),
 			keybinding: {
 				when: ContextKeyExpr.and(
 					NOTEBOOK_EDITOR_FOCUSED,
@@ -317,7 +317,7 @@ registerAction2(class extends Action2 {
 	constructor() {
 		super({
 			id: 'notebook.findNext.enter',
-			title: localize2('notebook.findNext.enter', 'Find Next (Enter)'),
+			title: localize2('notebook.findNext.enter', 'Find Next'),
 			keybinding: {
 				when: ContextKeyExpr.and(
 					NOTEBOOK_EDITOR_FOCUSED,

--- a/src/vs/workbench/contrib/notebook/browser/contrib/find/notebookFind.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/find/notebookFind.ts
@@ -13,15 +13,16 @@ import { ICodeEditorService } from '../../../../../../editor/browser/services/co
 import { EditorOption } from '../../../../../../editor/common/config/editorOptions.js';
 import { EditorContextKeys } from '../../../../../../editor/common/editorContextKeys.js';
 import { ITextModel } from '../../../../../../editor/common/model.js';
-import { FindStartFocusAction, getSelectionSearchString, IFindStartOptions, StartFindAction, StartFindReplaceAction } from '../../../../../../editor/contrib/find/browser/findController.js';
+import { FindStartFocusAction, getSelectionSearchString, IFindStartOptions, NextMatchFindAction, PreviousMatchFindAction, StartFindAction, StartFindReplaceAction } from '../../../../../../editor/contrib/find/browser/findController.js';
 import { localize2 } from '../../../../../../nls.js';
 import { Action2, registerAction2 } from '../../../../../../platform/actions/common/actions.js';
+
 import { ContextKeyExpr } from '../../../../../../platform/contextkey/common/contextkey.js';
 import { ServicesAccessor } from '../../../../../../platform/instantiation/common/instantiation.js';
 import { KeybindingWeight } from '../../../../../../platform/keybinding/common/keybindingsRegistry.js';
 import { IShowNotebookFindWidgetOptions, NotebookFindContrib } from './notebookFindWidget.js';
 import { INotebookCommandContext, NotebookMultiCellAction } from '../../controller/coreActions.js';
-import { getNotebookEditorFromEditorPane } from '../../notebookBrowser.js';
+import { getNotebookEditorFromEditorPane, INotebookEditor } from '../../notebookBrowser.js';
 import { registerNotebookContribution } from '../../notebookEditorExtensions.js';
 import { CellUri, NotebookFindScopeType } from '../../../common/notebookCommon.js';
 import { INTERACTIVE_WINDOW_IS_ACTIVE_EDITOR, KEYBINDING_CONTEXT_NOTEBOOK_FIND_WIDGET_FOCUSED, NOTEBOOK_EDITOR_FOCUSED, NOTEBOOK_IS_ACTIVE_EDITOR } from '../../../common/notebookContextKeys.js';
@@ -116,11 +117,7 @@ function getSearchStringOptions(editor: ICodeEditor, opts: IFindStartOptions) {
 	return undefined;
 }
 
-
-StartFindAction.addImplementation(100, (accessor: ServicesAccessor, codeEditor: ICodeEditor, args: any) => {
-	const editorService = accessor.get(IEditorService);
-	const editor = getNotebookEditorFromEditorPane(editorService.activeEditorPane);
-
+function isNotebookEditor(accessor: ServicesAccessor, editor: INotebookEditor | undefined, codeEditor: ICodeEditor) {
 	if (!editor) {
 		return false;
 	}
@@ -135,12 +132,22 @@ StartFindAction.addImplementation(100, (accessor: ServicesAccessor, codeEditor: 
 		const textEditor = codeEditorService.getFocusedCodeEditor() || codeEditorService.getActiveCodeEditor();
 		if (editor.hasModel() && textEditor && textEditor.hasModel() && notebookContainsTextModel(editor.textModel.uri, textEditor.getModel())) {
 			// the active text editor is in notebook editor
+			return true;
 		} else {
 			return false;
 		}
 	}
+	return true;
+}
 
-	const controller = editor.getContribution<NotebookFindContrib>(NotebookFindContrib.id);
+function openFindWidget(controller: NotebookFindContrib | undefined, editor: INotebookEditor | undefined, codeEditor: ICodeEditor | undefined) {
+	if (!editor || !codeEditor || !controller) {
+		return false;
+	}
+
+	if (!codeEditor.hasModel()) {
+		return false;
+	}
 
 	const searchStringOptions = getSearchStringOptions(codeEditor, {
 		forceRevealReplace: false,
@@ -167,6 +174,18 @@ StartFindAction.addImplementation(100, (accessor: ServicesAccessor, codeEditor: 
 
 	controller.show(searchStringOptions?.searchString, options);
 	return true;
+}
+
+StartFindAction.addImplementation(100, (accessor: ServicesAccessor, codeEditor: ICodeEditor, args: any) => {
+	const editorService = accessor.get(IEditorService);
+	const editor = getNotebookEditorFromEditorPane(editorService.activeEditorPane);
+
+	if (!isNotebookEditor(accessor, editor, codeEditor)) {
+		return false;
+	}
+
+	const controller = editor?.getContribution<NotebookFindContrib>(NotebookFindContrib.id);
+	return openFindWidget(controller, editor, codeEditor);
 });
 
 StartFindReplaceAction.addImplementation(100, (accessor: ServicesAccessor, codeEditor: ICodeEditor, args: any) => {
@@ -200,4 +219,150 @@ StartFindReplaceAction.addImplementation(100, (accessor: ServicesAccessor, codeE
 	}
 
 	return false;
+});
+
+NextMatchFindAction.addImplementation(100, (accessor: ServicesAccessor, codeEditor: ICodeEditor, args: any) => {
+	const editorService = accessor.get(IEditorService);
+	const editor = getNotebookEditorFromEditorPane(editorService.activeEditorPane);
+
+	if (!isNotebookEditor(accessor, editor, codeEditor)) {
+		return false;
+	}
+
+	const controller = editor?.getContribution<NotebookFindContrib>(NotebookFindContrib.id);
+	if (!controller) {
+		return false;
+	}
+
+	// Check if find widget is already visible
+	if (controller.isVisible()) {
+		// Find widget is open, navigate to next match
+		controller.findNext();
+		return true;
+	} else {
+		// Find widget is not open, open it with search string (similar to StartFindAction)
+		return openFindWidget(controller, editor, codeEditor);
+	}
+});
+
+PreviousMatchFindAction.addImplementation(100, (accessor: ServicesAccessor, codeEditor: ICodeEditor, args: any) => {
+	const editorService = accessor.get(IEditorService);
+	const editor = getNotebookEditorFromEditorPane(editorService.activeEditorPane);
+
+	if (!isNotebookEditor(accessor, editor, codeEditor)) {
+		return false;
+	}
+
+	const controller = editor?.getContribution<NotebookFindContrib>(NotebookFindContrib.id);
+	if (!controller) {
+		return false;
+	}
+
+	// Check if find widget is already visible
+	if (controller.isVisible()) {
+		// Find widget is open, navigate to previous match
+		controller.findPrevious();
+		return true;
+	} else {
+		// Find widget is not open, open it with search string (similar to StartFindAction)
+		return openFindWidget(controller, editor, codeEditor);
+	}
+});
+
+// Widget-focused keybindings - these handle F3/Shift+F3 when the notebook find widget has focus
+// This follows the same pattern as the text editor which has separate keybindings for widget focus
+
+registerAction2(class extends Action2 {
+	constructor() {
+		super({
+			id: 'notebook.findNext.fromWidget',
+			title: localize2('notebook.findNext.fromWidget', 'Find Next (from Find Widget)'),
+			keybinding: {
+				when: ContextKeyExpr.and(
+					NOTEBOOK_EDITOR_FOCUSED,
+					KEYBINDING_CONTEXT_NOTEBOOK_FIND_WIDGET_FOCUSED
+				),
+				primary: KeyCode.F3,
+				mac: { primary: KeyMod.CtrlCmd | KeyCode.KeyG, secondary: [KeyCode.F3] },
+				weight: KeybindingWeight.WorkbenchContrib + 1  // Higher priority than editor
+			}
+		});
+	}
+
+	async run(accessor: ServicesAccessor): Promise<void> {
+		const editorService = accessor.get(IEditorService);
+		const editor = getNotebookEditorFromEditorPane(editorService.activeEditorPane);
+
+		if (!editor) {
+			return;
+		}
+
+		const controller = editor.getContribution<NotebookFindContrib>(NotebookFindContrib.id);
+		if (controller && controller.isVisible()) {
+			controller.findNext();
+		}
+	}
+});
+
+registerAction2(class extends Action2 {
+	constructor() {
+		super({
+			id: 'notebook.findPrevious.fromWidget',
+			title: localize2('notebook.findPrevious.fromWidget', 'Find Previous (from Find Widget)'),
+			keybinding: {
+				when: ContextKeyExpr.and(
+					NOTEBOOK_EDITOR_FOCUSED,
+					KEYBINDING_CONTEXT_NOTEBOOK_FIND_WIDGET_FOCUSED
+				),
+				primary: KeyMod.Shift | KeyCode.F3,
+				mac: { primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KeyG, secondary: [KeyMod.Shift | KeyCode.F3] },
+				weight: KeybindingWeight.WorkbenchContrib + 1  // Higher priority than editor
+			}
+		});
+	}
+
+	async run(accessor: ServicesAccessor): Promise<void> {
+		const editorService = accessor.get(IEditorService);
+		const editor = getNotebookEditorFromEditorPane(editorService.activeEditorPane);
+
+		if (!editor) {
+			return;
+		}
+
+		const controller = editor.getContribution<NotebookFindContrib>(NotebookFindContrib.id);
+		if (controller && controller.isVisible()) {
+			controller.findPrevious();
+		}
+	}
+});
+
+registerAction2(class extends Action2 {
+	constructor() {
+		super({
+			id: 'notebook.findNext.enter',
+			title: localize2('notebook.findNext.enter', 'Find Next (Enter)'),
+			keybinding: {
+				when: ContextKeyExpr.and(
+					NOTEBOOK_EDITOR_FOCUSED,
+					KEYBINDING_CONTEXT_NOTEBOOK_FIND_WIDGET_FOCUSED
+				),
+				primary: KeyCode.Enter,
+				weight: KeybindingWeight.WorkbenchContrib + 1  // Higher priority than editor
+			}
+		});
+	}
+
+	async run(accessor: ServicesAccessor): Promise<void> {
+		const editorService = accessor.get(IEditorService);
+		const editor = getNotebookEditorFromEditorPane(editorService.activeEditorPane);
+
+		if (!editor) {
+			return;
+		}
+
+		const controller = editor.getContribution<NotebookFindContrib>(NotebookFindContrib.id);
+		if (controller && controller.isVisible()) {
+			controller.findNext();
+		}
+	}
 });

--- a/src/vs/workbench/contrib/notebook/browser/contrib/find/notebookFind.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/find/notebookFind.ts
@@ -117,7 +117,7 @@ function getSearchStringOptions(editor: ICodeEditor, opts: IFindStartOptions) {
 	return undefined;
 }
 
-function isNotebookEditor(accessor: ServicesAccessor, editor: INotebookEditor | undefined, codeEditor: ICodeEditor) {
+function isNotebookEditorValidForSearch(accessor: ServicesAccessor, editor: INotebookEditor | undefined, codeEditor: ICodeEditor) {
 	if (!editor) {
 		return false;
 	}
@@ -180,7 +180,7 @@ function findWidgetAction(accessor: ServicesAccessor, codeEditor: ICodeEditor, n
 	const editorService = accessor.get(IEditorService);
 	const editor = getNotebookEditorFromEditorPane(editorService.activeEditorPane);
 
-	if (!isNotebookEditor(accessor, editor, codeEditor)) {
+	if (!isNotebookEditorValidForSearch(accessor, editor, codeEditor)) {
 		return false;
 	}
 
@@ -218,7 +218,7 @@ StartFindAction.addImplementation(100, (accessor: ServicesAccessor, codeEditor: 
 	const editorService = accessor.get(IEditorService);
 	const editor = getNotebookEditorFromEditorPane(editorService.activeEditorPane);
 
-	if (!isNotebookEditor(accessor, editor, codeEditor)) {
+	if (!isNotebookEditorValidForSearch(accessor, editor, codeEditor)) {
 		return false;
 	}
 

--- a/src/vs/workbench/contrib/notebook/browser/contrib/find/notebookFindWidget.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/find/notebookFindWidget.ts
@@ -76,6 +76,22 @@ export class NotebookFindContrib extends Disposable implements INotebookEditorCo
 	replace(searchString: string | undefined) {
 		return this._widget.value.replace(searchString);
 	}
+
+	isVisible(): boolean {
+		return this._widget.rawValue?.isVisible ?? false;
+	}
+
+	findNext(): void {
+		if (this._widget.rawValue) {
+			this._widget.value.findNext();
+		}
+	}
+
+	findPrevious(): void {
+		if (this._widget.rawValue) {
+			this._widget.value.findPrevious();
+		}
+	}
 }
 
 class NotebookFindWidget extends SimpleFindReplaceWidget implements INotebookEditorContribution {
@@ -183,6 +199,14 @@ class NotebookFindWidget extends SimpleFindReplaceWidget implements INotebookEdi
 		this._findModel.find({ previous });
 	}
 
+	public findNext(): void {
+		this.find(false);
+	}
+
+	public findPrevious(): void {
+		this.find(true);
+	}
+
 	protected replaceOne() {
 		if (!this._notebookEditor.hasModel()) {
 			return;
@@ -275,7 +299,7 @@ class NotebookFindWidget extends SimpleFindReplaceWidget implements INotebookEdi
 				await this._findModel.research();
 			}
 			this.findIndex(options.matchIndex);
-		} else {
+		} else if (options?.focus !== false) {
 			this._findInput.select();
 		}
 


### PR DESCRIPTION
This change addresses the following two issues. This change fixes F3 and Shift+F3 functionality in notebooks
  - F3 in notebook stopped working https://github.com/microsoft/vscode/issues/174087
  - More multi commands for Find widget https://github.com/microsoft/vscode/issues/235762
  
  To test:
  1. Open notebook
  2. Put cursor on a word
  3. Hit F3 or Ctrl+F -> this will open find widget
  4. Hitting F3 will move next. Hitting Shift+F3 will move previous. 