### PR TITLE
Use param expansion with default to reduce warning in set -u nounset mode

### DIFF
--- a/src/vs/workbench/contrib/terminal/common/scripts/shellIntegration-bash.sh
+++ b/src/vs/workbench/contrib/terminal/common/scripts/shellIntegration-bash.sh
@@ -15,7 +15,7 @@ vsc_env_values=()
 use_associative_array=0
 bash_major_version=${BASH_VERSINFO[0]}
 
-__vscode_shell_env_reporting="$VSCODE_SHELL_ENV_REPORTING"
+__vscode_shell_env_reporting="${VSCODE_SHELL_ENV_REPORTING:-}"
 unset VSCODE_SHELL_ENV_REPORTING
 
 envVarsToReport=()
@@ -93,9 +93,9 @@ fi
 
 # Register Python shell activate hooks
 # Prevent multiple activation with guard
-if [ -z "$VSCODE_PYTHON_AUTOACTIVATE_GUARD" ]; then
+if [ -z "${VSCODE_PYTHON_AUTOACTIVATE_GUARD:-}" ]; then
 	export VSCODE_PYTHON_AUTOACTIVATE_GUARD=1
-	if [ -n "$VSCODE_PYTHON_BASH_ACTIVATE" ] && [ "$TERM_PROGRAM" = "vscode" ]; then
+	if [ -n "${VSCODE_PYTHON_BASH_ACTIVATE:-}" ] && [ "$TERM_PROGRAM" = "vscode" ]; then
 		# Prevent crashing by negating exit code
 		if ! builtin eval "$VSCODE_PYTHON_BASH_ACTIVATE"; then
 			__vsc_activation_status=$?
@@ -184,7 +184,7 @@ fi
 # Allow verifying $BASH_COMMAND doesn't have aliases resolved via history when the right HISTCONTROL
 # configuration is used
 __vsc_regex_histcontrol=".*(erasedups|ignoreboth|ignoredups).*"
-if [[ "$HISTCONTROL" =~ $__vsc_regex_histcontrol ]]; then
+if [[ "${HISTCONTROL:-}" =~ $__vsc_regex_histcontrol ]]; then
 	__vsc_history_verify=0
 else
 	__vsc_history_verify=1

--- a/src/vs/workbench/contrib/terminal/common/scripts/shellIntegration-rc.zsh
+++ b/src/vs/workbench/contrib/terminal/common/scripts/shellIntegration-rc.zsh
@@ -70,9 +70,9 @@ fi
 
 # Register Python shell activate hooks
 # Prevent multiple activation with guard
-if [ -z "$VSCODE_PYTHON_AUTOACTIVATE_GUARD" ]; then
+if [ -z "${VSCODE_PYTHON_AUTOACTIVATE_GUARD:-}" ]; then
 	export VSCODE_PYTHON_AUTOACTIVATE_GUARD=1
-	if [ -n "$VSCODE_PYTHON_ZSH_ACTIVATE" ] && [ "$TERM_PROGRAM" = "vscode" ]; then
+	if [ -n "${VSCODE_PYTHON_ZSH_ACTIVATE:-}" ] && [ "$TERM_PROGRAM" = "vscode" ]; then
 		# Prevent crashing by negating exit code
 		if ! builtin eval "$VSCODE_PYTHON_ZSH_ACTIVATE"; then
 			__vsc_activation_status=$?
@@ -82,11 +82,11 @@ if [ -z "$VSCODE_PYTHON_AUTOACTIVATE_GUARD" ]; then
 fi
 
 # Report prompt type
-if [ -n "$P9K_SSH" ] || [ -n "$P9K_TTY" ]; then
+if [ -n "${P9K_SSH:-}" ] || [ -n "${P9K_TTY:-}" ]; then
 	builtin printf '\e]633;P;PromptType=p10k\a'
-elif [ -n "$ZSH" ] && [ -n "$ZSH_VERSION" ] && (( ${+functions[omz]} )); then
+elif [ -n "${ZSH:-}" ] && [ -n "$ZSH_VERSION" ] && (( ${+functions[omz]} )); then
 	builtin printf '\e]633;P;PromptType=oh-my-zsh\a'
-elif [ -n "$STARSHIP_SESSION_KEY" ]; then
+elif [ -n "${STARSHIP_SESSION_KEY:-}" ]; then
 	builtin printf '\e]633;P;PromptType=starship\a'
 fi
 
@@ -132,7 +132,7 @@ __vsc_current_command=""
 __vsc_nonce="$VSCODE_NONCE"
 unset VSCODE_NONCE
 
-__vscode_shell_env_reporting="$VSCODE_SHELL_ENV_REPORTING"
+__vscode_shell_env_reporting="${VSCODE_SHELL_ENV_REPORTING:-}"
 unset VSCODE_SHELL_ENV_REPORTING
 
 envVarsToReport=()


### PR DESCRIPTION
Resolves: https://github.com/microsoft/vscode/issues/266489 

We've previously done this in the past, but have added more variable since then: https://github.com/microsoft/vscode/pull/185425 

This will reduce warnings users will get when in nounset mode.
Should resolve: https://github.com/microsoft/vscode/issues/270410 in future as well.

/cc @demccormack

