### PR TITLE
Do not prefix `Folders:` when explorer merges with container

### DIFF
--- a/src/vs/workbench/contrib/files/browser/views/explorerView.ts
+++ b/src/vs/workbench/contrib/files/browser/views/explorerView.ts
@@ -185,7 +185,7 @@ export class ExplorerView extends ViewPane implements IExplorerView {
 	private decorationsProvider: ExplorerDecorationsProvider | undefined;
 	private readonly delegate: IExplorerViewContainerDelegate | undefined;
 
-	public override get singleViewPaneContainerTitle(): string {
+	override get singleViewPaneContainerTitle(): string {
 		return this.name;
 	}
 

--- a/src/vs/workbench/contrib/files/browser/views/explorerView.ts
+++ b/src/vs/workbench/contrib/files/browser/views/explorerView.ts
@@ -185,6 +185,10 @@ export class ExplorerView extends ViewPane implements IExplorerView {
 	private decorationsProvider: ExplorerDecorationsProvider | undefined;
 	private readonly delegate: IExplorerViewContainerDelegate | undefined;
 
+	public override get singleViewPaneContainerTitle(): string {
+		return this.name;
+	}
+
 	constructor(
 		options: IExplorerViewPaneOptions,
 		@IContextMenuService contextMenuService: IContextMenuService,


### PR DESCRIPTION
```Copilot Generated Description:``` Remove the prefix `Folders:` from the title when the explorer merges with the container. Additionally, override the `singleViewPaneContainerTitle` method to return the name directly.

fixes https://github.com/microsoft/vscode/issues/269862