### PR TITLE
Fix separator CSS hack

### DIFF
--- a/src/vs/base/browser/ui/toolbar/toolbar.ts
+++ b/src/vs/base/browser/ui/toolbar/toolbar.ts
@@ -31,6 +31,7 @@ export interface IToolBarOptions {
 	allowContextMenu?: boolean;
 	skipTelemetry?: boolean;
 	hoverDelegate?: IHoverDelegate;
+	trailingSeparator?: boolean;
 
 	/**
 	 * If true, toggled primary items are highlighted with a background color.
@@ -201,6 +202,10 @@ export class ToolBar extends Disposable {
 		if (this.hasSecondaryActions && secondaryActions) {
 			this.toggleMenuAction.menuActions = secondaryActions.slice(0);
 			primaryActionsToSet.push(this.toggleMenuAction);
+		}
+
+		if (primaryActionsToSet.length > 0 && this.options.trailingSeparator) {
+			primaryActionsToSet.push(new Separator());
 		}
 
 		primaryActionsToSet.forEach(action => {

--- a/src/vs/base/browser/ui/toolbar/toolbar.ts
+++ b/src/vs/base/browser/ui/toolbar/toolbar.ts
@@ -7,7 +7,7 @@ import { IContextMenuProvider } from '../../contextmenu.js';
 import { ActionBar, ActionsOrientation, IActionViewItemProvider } from '../actionbar/actionbar.js';
 import { AnchorAlignment } from '../contextview/contextview.js';
 import { DropdownMenuActionViewItem } from '../dropdown/dropdownActionViewItem.js';
-import { Action, IAction, IActionRunner, SubmenuAction } from '../../../common/actions.js';
+import { Action, IAction, IActionRunner, Separator, SubmenuAction } from '../../../common/actions.js';
 import { Codicon } from '../../../common/codicons.js';
 import { ThemeIcon } from '../../../common/themables.js';
 import { EventMultiplexer } from '../../../common/event.js';

--- a/src/vs/workbench/browser/parts/compositePart.ts
+++ b/src/vs/workbench/browser/parts/compositePart.ts
@@ -413,7 +413,8 @@ export abstract class CompositePart<T extends Composite, MementoType extends obj
 			anchorAlignmentProvider: () => this.getTitleAreaDropDownAnchorAlignment(),
 			toggleMenuTitle: localize('viewsAndMoreActions', "Views and More Actions..."),
 			telemetrySource: this.nameForTelemetry,
-			hoverDelegate: this.toolbarHoverDelegate
+			hoverDelegate: this.toolbarHoverDelegate,
+			trailingSeparator: true
 		}));
 
 		this.collectCompositeActions()();

--- a/src/vs/workbench/browser/parts/media/paneCompositePart.css
+++ b/src/vs/workbench/browser/parts/media/paneCompositePart.css
@@ -3,16 +3,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-.monaco-workbench .pane-composite-part:not(.empty) > .title.has-composite-bar.has-actions > .global-actions .actions-container::before {
-	/* Separate global actions from view actions unless pane is empty */
-	content: '';
-	width: 1px;
-	height: 16px;
-	background-color: var(--vscode-disabledForeground);
-	margin-right: 8px;
-	margin-left: 4px;
-}
-
 .monaco-workbench .pane-composite-part > .title.has-composite-bar > .title-actions .monaco-action-bar .actions-container {
 	justify-content: flex-end;
 }

--- a/src/vs/workbench/browser/parts/paneCompositePart.ts
+++ b/src/vs/workbench/browser/parts/paneCompositePart.ts
@@ -369,16 +369,6 @@ export abstract class AbstractPaneCompositePart extends CompositePart<PaneCompos
 			}
 		));
 
-		this._register(this.globalToolBar.onDidRerenderItem(() => {
-			this.layoutCompositeBar();
-		}));
-
-		if (this.toolBar) {
-			this._register(this.toolBar.onDidRerenderItem(() => {
-				this.layoutCompositeBar();
-			}));
-		}
-
 		return titleArea;
 	}
 

--- a/src/vs/workbench/browser/parts/paneCompositePart.ts
+++ b/src/vs/workbench/browser/parts/paneCompositePart.ts
@@ -369,6 +369,16 @@ export abstract class AbstractPaneCompositePart extends CompositePart<PaneCompos
 			}
 		));
 
+		this._register(this.globalToolBar.onDidRerenderItem(() => {
+			this.layoutCompositeBar();
+		}));
+
+		if (this.toolBar) {
+			this._register(this.toolBar.onDidRerenderItem(() => {
+				this.layoutCompositeBar();
+			}));
+		}
+
 		return titleArea;
 	}
 
@@ -643,7 +653,7 @@ export abstract class AbstractPaneCompositePart extends CompositePart<PaneCompos
 		// Each toolbar item has 4px margin
 		const toolBarWidth = this.toolBar.getItemsWidth() + this.toolBar.getItemsLength() * 4;
 		const globalToolBarWidth = this.globalToolBar ? this.globalToolBar.getItemsWidth() + this.globalToolBar.getItemsLength() * 4 : 0;
-		return toolBarWidth + globalToolBarWidth + 5; // 5px padding left
+		return toolBarWidth + globalToolBarWidth + 8; // 8px padding left
 	}
 
 	private onTitleAreaContextMenu(event: StandardMouseEvent): void {


### PR DESCRIPTION
```Copilot Generated Description:``` Introduce a trailing separator option in the toolbar and remove the old CSS hack for separating global actions from view actions. Adjust padding in the toolbar layout calculations.

related https://github.com/microsoft/vscode/issues/248571