### PR TITLE
fix `hideOnRequest` mode so that it doesn't show the inline chat for "good" responses

### DIFF
--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChatController.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChatController.ts
@@ -1417,6 +1417,8 @@ export class InlineChatController2 implements IEditorContribution {
 								return;
 							}
 
+							responseListener.value = undefined; // listen only ONCE
+
 							const shouldShow = response.isCanceled // cancelled
 								|| response.result?.errorDetails // errors
 								|| !response.response.value.find(part => part.kind === 'textEditGroup'


### PR DESCRIPTION
Looks like `ChatResponse#onDidChange` fires with a modified response array after completion...