### PR TITLE
Fix swapped findMatch foreground colors (#228782)

### DIFF
--- a/src/vs/editor/contrib/find/browser/findWidget.ts
+++ b/src/vs/editor/contrib/find/browser/findWidget.ts
@@ -1396,10 +1396,10 @@ registerThemingParticipant((theme, collector) => {
 	}
 	const findMatchForeground = theme.getColor(editorFindMatchForeground);
 	if (findMatchForeground) {
-		collector.addRule(`.monaco-editor .findMatchInline { color: ${findMatchForeground}; }`);
+		collector.addRule(`.monaco-editor .currentFindMatchInline { color: ${findMatchForeground}; }`);
 	}
 	const findMatchHighlightForeground = theme.getColor(editorFindMatchHighlightForeground);
 	if (findMatchHighlightForeground) {
-		collector.addRule(`.monaco-editor .currentFindMatchInline { color: ${findMatchHighlightForeground}; }`);
+		collector.addRule(`.monaco-editor .findMatchInline { color: ${findMatchHighlightForeground}; }`);
 	}
 });


### PR DESCRIPTION
## Summary

- #228782

Fixes an issue where the `editor.findMatchForeground` and `editor.findMatchHighlightForeground` color settings were swapped.

## Problem

The find match foreground colors were incorrectly assigned:
- `editor.findMatchForeground` (documented as “current search match”) was applied to other matches.
- `editor.findMatchHighlightForeground` (documented as “other search matches”) was applied to the current match.

## Solution

Swapped the CSS class selectors in `findWidget.ts`:
- `editor.findMatchForeground` now correctly targets `.currentFindMatchInline` (current match)
- `editor.findMatchHighlightForeground` now correctly targets `.findMatchInline` (other matches)

### Before
<img width="586" height="158" alt="Before screenshot" src="https://github.com/user-attachments/assets/655320e3-bdb7-4803-8201-2f28c2624c98" />

### After
<img width="682" height="255" alt="After screenshot" src="https://github.com/user-attachments/assets/88ba32ef-f1b2-4e53-a53a-5cf23f81558a" />

## Test Plan

- [x] Set `editor.findMatchForeground` to a distinct color and verify it colors the current match.
- [x] Set `editor.findMatchHighlightForeground` to a distinct color and verify it colors other matches.
