### PR TITLE
Re-use `TypeScriptLanguageServiceHost` for monaco and treeshaker build steps

### DIFF
--- a/build/lib/monaco-api.ts
+++ b/build/lib/monaco-api.ts
@@ -8,6 +8,7 @@ import type * as ts from 'typescript';
 import path from 'path';
 import fancyLog from 'fancy-log';
 import ansiColors from 'ansi-colors';
+import { IFileMap, TypeScriptLanguageServiceHost } from './typeScriptLanguageServiceHost';
 
 const dtsv = '3';
 
@@ -661,7 +662,7 @@ export class DeclarationResolver {
 		const fileMap: IFileMap = new Map([
 			['file.ts', fileContents]
 		]);
-		const service = this.ts.createLanguageService(new TypeScriptLanguageServiceHost(this.ts, new Map(), fileMap, {}));
+		const service = this.ts.createLanguageService(new TypeScriptLanguageServiceHost(this.ts, new Map(), fileMap, {}, 'defaultLib:es5'));
 		const text = service.getEmitOutput('file.ts', true, true).outputFiles[0].text;
 		return new CacheEntry(
 			this.ts.createSourceFile(fileName, text, this.ts.ScriptTarget.ES5),
@@ -675,69 +676,6 @@ export function run3(resolver: DeclarationResolver): IMonacoDeclarationResult | 
 	return _run(resolver.ts as Typescript, sourceFileGetter);
 }
 
-
-type ILibMap = Map</*libName*/ string, string>;
-type IFileMap = Map</*fileName*/ string, string>;
-
-class TypeScriptLanguageServiceHost implements ts.LanguageServiceHost {
-
-	private readonly _ts: typeof import('typescript');
-	private readonly _libs: ILibMap;
-	private readonly _files: IFileMap;
-	private readonly _compilerOptions: ts.CompilerOptions;
-
-	constructor(ts: typeof import('typescript'), libs: ILibMap, files: IFileMap, compilerOptions: ts.CompilerOptions) {
-		this._ts = ts;
-		this._libs = libs;
-		this._files = files;
-		this._compilerOptions = compilerOptions;
-	}
-
-	// --- language service host ---------------
-
-	getCompilationSettings(): ts.CompilerOptions {
-		return this._compilerOptions;
-	}
-	getScriptFileNames(): string[] {
-		return [
-			...this._libs.keys(),
-			...this._files.keys(),
-		];
-	}
-	getScriptVersion(_fileName: string): string {
-		return '1';
-	}
-	getProjectVersion(): string {
-		return '1';
-	}
-	getScriptSnapshot(fileName: string): ts.IScriptSnapshot {
-		if (this._files.has(fileName)) {
-			return this._ts.ScriptSnapshot.fromString(this._files.get(fileName)!);
-		} else if (this._libs.has(fileName)) {
-			return this._ts.ScriptSnapshot.fromString(this._libs.get(fileName)!);
-		} else {
-			return this._ts.ScriptSnapshot.fromString('');
-		}
-	}
-	getScriptKind(_fileName: string): ts.ScriptKind {
-		return this._ts.ScriptKind.TS;
-	}
-	getCurrentDirectory(): string {
-		return '';
-	}
-	getDefaultLibFileName(_options: ts.CompilerOptions): string {
-		return 'defaultLib:es5';
-	}
-	isDefaultLibFileName(fileName: string): boolean {
-		return fileName === this.getDefaultLibFileName(this._compilerOptions);
-	}
-	readFile(path: string, _encoding?: string): string | undefined {
-		return this._files.get(path) || this._libs.get(path);
-	}
-	fileExists(path: string): boolean {
-		return this._files.has(path) || this._libs.has(path);
-	}
-}
 
 export function execute(): IMonacoDeclarationResult {
 	const r = run3(new DeclarationResolver(new FSProvider()));

--- a/build/lib/treeshaking.js
+++ b/build/lib/treeshaking.js
@@ -11,6 +11,7 @@ exports.shake = shake;
  *--------------------------------------------------------------------------------------------*/
 const fs_1 = __importDefault(require("fs"));
 const path_1 = __importDefault(require("path"));
+const typeScriptLanguageServiceHost_1 = require("./typeScriptLanguageServiceHost");
 const TYPESCRIPT_LIB_FOLDER = path_1.default.dirname(require.resolve('typescript/lib/lib.d.ts'));
 var ShakeLevel;
 (function (ShakeLevel) {
@@ -80,7 +81,7 @@ function createTypeScriptLanguageService(ts, options) {
     // Resolve libs
     const RESOLVED_LIBS = processLibFiles(ts, options);
     const compilerOptions = ts.convertCompilerOptionsFromJson(options.compilerOptions, options.sourcesRoot).options;
-    const host = new TypeScriptLanguageServiceHost(ts, RESOLVED_LIBS, FILES, compilerOptions);
+    const host = new typeScriptLanguageServiceHost_1.TypeScriptLanguageServiceHost(ts, RESOLVED_LIBS, FILES, compilerOptions, 'defaultLib:lib.d.ts');
     return ts.createLanguageService(host);
 }
 /**
@@ -161,66 +162,6 @@ function processLibFiles(ts, options) {
         }
     }
     return result;
-}
-/**
- * A TypeScript language service host
- */
-class TypeScriptLanguageServiceHost {
-    _ts;
-    _libs;
-    _files;
-    _compilerOptions;
-    constructor(ts, libs, files, compilerOptions) {
-        this._ts = ts;
-        this._libs = libs;
-        this._files = files;
-        this._compilerOptions = compilerOptions;
-    }
-    // --- language service host ---------------
-    getCompilationSettings() {
-        return this._compilerOptions;
-    }
-    getScriptFileNames() {
-        return [
-            ...this._libs.keys(),
-            ...this._files.keys(),
-        ];
-    }
-    getScriptVersion(_fileName) {
-        return '1';
-    }
-    getProjectVersion() {
-        return '1';
-    }
-    getScriptSnapshot(fileName) {
-        if (this._files.has(fileName)) {
-            return this._ts.ScriptSnapshot.fromString(this._files.get(fileName));
-        }
-        else if (this._libs.has(fileName)) {
-            return this._ts.ScriptSnapshot.fromString(this._libs.get(fileName));
-        }
-        else {
-            return this._ts.ScriptSnapshot.fromString('');
-        }
-    }
-    getScriptKind(_fileName) {
-        return this._ts.ScriptKind.TS;
-    }
-    getCurrentDirectory() {
-        return '';
-    }
-    getDefaultLibFileName(_options) {
-        return 'defaultLib:lib.d.ts';
-    }
-    isDefaultLibFileName(fileName) {
-        return fileName === this.getDefaultLibFileName(this._compilerOptions);
-    }
-    readFile(path, _encoding) {
-        return this._files.get(path) || this._libs.get(path);
-    }
-    fileExists(path) {
-        return this._files.has(path) || this._libs.has(path);
-    }
 }
 //#endregion
 //#region Tree Shaking

--- a/build/lib/typeScriptLanguageServiceHost.js
+++ b/build/lib/typeScriptLanguageServiceHost.js
@@ -1,0 +1,67 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.TypeScriptLanguageServiceHost = void 0;
+/**
+ * A TypeScript language service host
+ */
+class TypeScriptLanguageServiceHost {
+    ts;
+    libs;
+    files;
+    compilerOptions;
+    defaultLibName;
+    constructor(ts, libs, files, compilerOptions, defaultLibName) {
+        this.ts = ts;
+        this.libs = libs;
+        this.files = files;
+        this.compilerOptions = compilerOptions;
+        this.defaultLibName = defaultLibName;
+    }
+    // --- language service host ---------------
+    getCompilationSettings() {
+        return this.compilerOptions;
+    }
+    getScriptFileNames() {
+        return [
+            ...this.libs.keys(),
+            ...this.files.keys(),
+        ];
+    }
+    getScriptVersion(_fileName) {
+        return '1';
+    }
+    getProjectVersion() {
+        return '1';
+    }
+    getScriptSnapshot(fileName) {
+        if (this.files.has(fileName)) {
+            return this.ts.ScriptSnapshot.fromString(this.files.get(fileName));
+        }
+        else if (this.libs.has(fileName)) {
+            return this.ts.ScriptSnapshot.fromString(this.libs.get(fileName));
+        }
+        else {
+            return this.ts.ScriptSnapshot.fromString('');
+        }
+    }
+    getScriptKind(_fileName) {
+        return this.ts.ScriptKind.TS;
+    }
+    getCurrentDirectory() {
+        return '';
+    }
+    getDefaultLibFileName(_options) {
+        return this.defaultLibName;
+    }
+    isDefaultLibFileName(fileName) {
+        return fileName === this.getDefaultLibFileName(this.compilerOptions);
+    }
+    readFile(path, _encoding) {
+        return this.files.get(path) || this.libs.get(path);
+    }
+    fileExists(path) {
+        return this.files.has(path) || this.libs.has(path);
+    }
+}
+exports.TypeScriptLanguageServiceHost = TypeScriptLanguageServiceHost;
+//# sourceMappingURL=typeScriptLanguageServiceHost.js.map

--- a/build/lib/typeScriptLanguageServiceHost.ts
+++ b/build/lib/typeScriptLanguageServiceHost.ts
@@ -1,0 +1,67 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import ts from 'typescript';
+
+export type ILibMap = Map</*libName*/ string, string>;
+export type IFileMap = Map</*fileName*/ string, string>;
+
+/**
+ * A TypeScript language service host
+ */
+export class TypeScriptLanguageServiceHost implements ts.LanguageServiceHost {
+
+	constructor(
+		private readonly ts: typeof import('typescript'),
+		private readonly libs: ILibMap,
+		private readonly files: IFileMap,
+		private readonly compilerOptions: ts.CompilerOptions,
+		private readonly defaultLibName: string,
+	) { }
+
+	// --- language service host ---------------
+	getCompilationSettings(): ts.CompilerOptions {
+		return this.compilerOptions;
+	}
+	getScriptFileNames(): string[] {
+		return [
+			...this.libs.keys(),
+			...this.files.keys(),
+		];
+	}
+	getScriptVersion(_fileName: string): string {
+		return '1';
+	}
+	getProjectVersion(): string {
+		return '1';
+	}
+	getScriptSnapshot(fileName: string): ts.IScriptSnapshot {
+		if (this.files.has(fileName)) {
+			return this.ts.ScriptSnapshot.fromString(this.files.get(fileName)!);
+		} else if (this.libs.has(fileName)) {
+			return this.ts.ScriptSnapshot.fromString(this.libs.get(fileName)!);
+		} else {
+			return this.ts.ScriptSnapshot.fromString('');
+		}
+	}
+	getScriptKind(_fileName: string): ts.ScriptKind {
+		return this.ts.ScriptKind.TS;
+	}
+	getCurrentDirectory(): string {
+		return '';
+	}
+	getDefaultLibFileName(_options: ts.CompilerOptions): string {
+		return this.defaultLibName;
+	}
+	isDefaultLibFileName(fileName: string): boolean {
+		return fileName === this.getDefaultLibFileName(this.compilerOptions);
+	}
+	readFile(path: string, _encoding?: string): string | undefined {
+		return this.files.get(path) || this.libs.get(path);
+	}
+	fileExists(path: string): boolean {
+		return this.files.has(path) || this.libs.has(path);
+	}
+}


### PR DESCRIPTION
For #270408

There are currently duplicated `LanguageServiceHost` definitions in our build folder. As far as I can tell, the two hosts are the same except for the default lib

As part of #270408 I'll have to touch these service hosts. Having a single definition will make this easier
