### PR TITLE
Remove markdown code block font family option

### DIFF
--- a/src/vs/editor/browser/services/hoverService/hoverWidget.ts
+++ b/src/vs/editor/browser/services/hoverService/hoverWidget.ts
@@ -10,8 +10,6 @@ import * as dom from '../../../../base/browser/dom.js';
 import { IKeybindingService } from '../../../../platform/keybinding/common/keybinding.js';
 import { KeyCode } from '../../../../base/common/keyCodes.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
-import { IEditorOptions } from '../../../common/config/editorOptions.js';
-import { EDITOR_FONT_DEFAULTS } from '../../../common/config/fontInfo.js';
 import { HoverAction, HoverPosition, HoverWidget as BaseHoverWidget, getHoverAccessibleViewHint } from '../../../../base/browser/ui/hover/hoverWidget.js';
 import { Widget } from '../../../../base/browser/ui/widget.js';
 import { AnchorPosition } from '../../../../base/browser/ui/contextview/contextview.js';
@@ -167,10 +165,7 @@ export class HoverWidget extends Widget implements IHoverWidget {
 
 		} else {
 			const markdown = options.content;
-			const mdRenderer = this._instantiationService.createInstance(
-				MarkdownRenderer,
-				{ codeBlockFontFamily: this._configurationService.getValue<IEditorOptions>('editor').fontFamily || EDITOR_FONT_DEFAULTS.fontFamily }
-			);
+			const mdRenderer = this._instantiationService.createInstance(MarkdownRenderer, {});
 
 			const { element, dispose } = mdRenderer.render(markdown, {
 				actionHandler: (content) => this._linkHandler(content),

--- a/src/vs/editor/browser/widget/markdownRenderer/browser/markdownRenderer.ts
+++ b/src/vs/editor/browser/widget/markdownRenderer/browser/markdownRenderer.ts
@@ -8,8 +8,10 @@ import { createTrustedTypesPolicy } from '../../../../../base/browser/trustedTyp
 import { onUnexpectedError } from '../../../../../base/common/errors.js';
 import { IMarkdownString, MarkdownStringTrustedOptions } from '../../../../../base/common/htmlContent.js';
 import { IDisposable } from '../../../../../base/common/lifecycle.js';
+import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 import { IOpenerService } from '../../../../../platform/opener/common/opener.js';
-import { EditorOption } from '../../../../common/config/editorOptions.js';
+import { EditorOption, IEditorOptions } from '../../../../common/config/editorOptions.js';
+import { EDITOR_FONT_DEFAULTS } from '../../../../common/config/fontInfo.js';
 import { ILanguageService } from '../../../../common/languages/language.js';
 import { PLAINTEXT_LANGUAGE_ID } from '../../../../common/languages/modesRegistry.js';
 import { tokenizeToString } from '../../../../common/languages/textToHtmlTokenizer.js';
@@ -23,7 +25,6 @@ export interface IMarkdownRenderResult extends IDisposable {
 
 export interface IMarkdownRendererOptions {
 	readonly editor?: ICodeEditor;
-	readonly codeBlockFontFamily?: string;
 	readonly codeBlockFontSize?: string;
 }
 
@@ -41,6 +42,7 @@ export class MarkdownRenderer {
 
 	constructor(
 		private readonly _options: IMarkdownRendererOptions,
+		@IConfigurationService private readonly _configurationService: IConfigurationService,
 		@ILanguageService private readonly _languageService: ILanguageService,
 		@IOpenerService private readonly _openerService: IOpenerService,
 	) { }
@@ -78,8 +80,8 @@ export class MarkdownRenderer {
 		if (this._options.editor) {
 			const fontInfo = this._options.editor.getOption(EditorOption.fontInfo);
 			applyFontInfo(element, fontInfo);
-		} else if (this._options.codeBlockFontFamily) {
-			element.style.fontFamily = this._options.codeBlockFontFamily;
+		} else {
+			element.style.fontFamily = this._configurationService.getValue<IEditorOptions>('editor').fontFamily || EDITOR_FONT_DEFAULTS.fontFamily;
 		}
 
 		if (this._options.codeBlockFontSize !== undefined) {

--- a/src/vs/editor/contrib/hover/browser/glyphHoverWidget.ts
+++ b/src/vs/editor/contrib/hover/browser/glyphHoverWidget.ts
@@ -8,13 +8,12 @@ import { Disposable, DisposableStore } from '../../../../base/common/lifecycle.j
 import { MarkdownRenderer } from '../../../browser/widget/markdownRenderer/browser/markdownRenderer.js';
 import { ICodeEditor, IEditorMouseEvent, IOverlayWidget, IOverlayWidgetPosition, MouseTargetType } from '../../../browser/editorBrowser.js';
 import { ConfigurationChangedEvent, EditorOption } from '../../../common/config/editorOptions.js';
-import { ILanguageService } from '../../../common/languages/language.js';
 import { HoverOperation, HoverResult, HoverStartMode } from './hoverOperation.js';
-import { IOpenerService } from '../../../../platform/opener/common/opener.js';
 import { HoverWidget } from '../../../../base/browser/ui/hover/hoverWidget.js';
 import { IHoverWidget } from './hoverTypes.js';
 import { IHoverMessage, LaneOrLineNumber, GlyphHoverComputer, GlyphHoverComputerOptions } from './glyphHoverComputer.js';
 import { isMousePositionWithinElement } from './hoverUtils.js';
+import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 
 const $ = dom.$;
 
@@ -36,8 +35,7 @@ export class GlyphHoverWidget extends Disposable implements IOverlayWidget, IHov
 
 	constructor(
 		editor: ICodeEditor,
-		@ILanguageService languageService: ILanguageService,
-		@IOpenerService openerService: IOpenerService,
+		@IInstantiationService instantiationService: IInstantiationService,
 	) {
 		super();
 		this._editor = editor;
@@ -48,7 +46,7 @@ export class GlyphHoverWidget extends Disposable implements IOverlayWidget, IHov
 		this._hover = this._register(new HoverWidget(true));
 		this._hover.containerDomNode.classList.toggle('hidden', !this._isVisible);
 
-		this._markdownRenderer = new MarkdownRenderer({ editor: this._editor }, languageService, openerService);
+		this._markdownRenderer = instantiationService.createInstance(MarkdownRenderer, { editor: this._editor });
 		this._hoverOperation = this._register(new HoverOperation(this._editor, new GlyphHoverComputer(this._editor)));
 		this._register(this._hoverOperation.onResult((result) => this._withResult(result)));
 

--- a/src/vs/editor/contrib/hover/browser/markdownHoverParticipant.ts
+++ b/src/vs/editor/contrib/hover/browser/markdownHoverParticipant.ts
@@ -14,11 +14,9 @@ import { ICodeEditor } from '../../../browser/editorBrowser.js';
 import { Position } from '../../../common/core/position.js';
 import { Range } from '../../../common/core/range.js';
 import { IModelDecoration, ITextModel } from '../../../common/model.js';
-import { ILanguageService } from '../../../common/languages/language.js';
 import { HoverAnchor, HoverAnchorType, HoverRangeAnchor, IEditorHoverParticipant, IEditorHoverRenderContext, IHoverPart, IRenderedHoverPart, IRenderedHoverParts, RenderedHoverParts } from './hoverTypes.js';
 import * as nls from '../../../../nls.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
-import { IOpenerService } from '../../../../platform/opener/common/opener.js';
 import { ILanguageFeaturesService } from '../../../common/services/languageFeatures.js';
 import { EditorOption } from '../../../common/config/editorOptions.js';
 import { Hover, HoverContext, HoverProvider, HoverVerbosityAction } from '../../../common/languages.js';
@@ -36,6 +34,7 @@ import { getHoverProviderResultsAsAsyncIterable } from './getHover.js';
 import { ICommandService } from '../../../../platform/commands/common/commands.js';
 import { HoverStartSource } from './hoverOperation.js';
 import { ScrollEvent } from '../../../../base/common/scrollable.js';
+import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 
 const $ = dom.$;
 const increaseHoverVerbosityIcon = registerIcon('hover-increase-verbosity', Codicon.add, nls.localize('increaseHoverVerbosity', 'Icon for increaseing hover verbosity.'));
@@ -87,8 +86,7 @@ export class MarkdownHoverParticipant implements IEditorHoverParticipant<Markdow
 
 	constructor(
 		protected readonly _editor: ICodeEditor,
-		@ILanguageService private readonly _languageService: ILanguageService,
-		@IOpenerService private readonly _openerService: IOpenerService,
+		@IInstantiationService private readonly _instantiationService: IInstantiationService,
 		@IConfigurationService private readonly _configurationService: IConfigurationService,
 		@ILanguageFeaturesService protected readonly _languageFeaturesService: ILanguageFeaturesService,
 		@IKeybindingService private readonly _keybindingService: IKeybindingService,
@@ -186,12 +184,11 @@ export class MarkdownHoverParticipant implements IEditorHoverParticipant<Markdow
 			context.fragment,
 			this,
 			this._editor,
-			this._languageService,
-			this._openerService,
 			this._commandService,
 			this._keybindingService,
 			this._hoverService,
 			this._configurationService,
+			this._instantiationService,
 			context.onContentsChanged
 		);
 		return this._renderedHoverParts;
@@ -245,12 +242,11 @@ class MarkdownRenderedHoverParts implements IRenderedHoverParts<MarkdownHover> {
 		hoverPartsContainer: DocumentFragment,
 		private readonly _hoverParticipant: MarkdownHoverParticipant,
 		private readonly _editor: ICodeEditor,
-		private readonly _languageService: ILanguageService,
-		private readonly _openerService: IOpenerService,
 		private readonly _commandService: ICommandService,
 		private readonly _keybindingService: IKeybindingService,
 		private readonly _hoverService: IHoverService,
 		private readonly _configurationService: IConfigurationService,
+		private readonly _instantiationService: IInstantiationService,
 		private readonly _onFinishedRendering: () => void,
 	) {
 		this.renderedHoverParts = this._renderHoverParts(hoverParts, hoverPartsContainer, this._onFinishedRendering);
@@ -315,8 +311,7 @@ class MarkdownRenderedHoverParts implements IRenderedHoverParts<MarkdownHover> {
 		const renderedMarkdownHover = renderMarkdown(
 			this._editor,
 			markdownHover,
-			this._languageService,
-			this._openerService,
+			this._instantiationService,
 			onFinishedRendering,
 		);
 		return renderedMarkdownHover;
@@ -476,8 +471,7 @@ export function renderMarkdownHovers(
 	context: IEditorHoverRenderContext,
 	markdownHovers: MarkdownHover[],
 	editor: ICodeEditor,
-	languageService: ILanguageService,
-	openerService: IOpenerService,
+	instantiationService: IInstantiationService,
 ): IRenderedHoverParts<MarkdownHover> {
 
 	// Sort hover parts to keep them stable since they might come in async, out-of-order
@@ -487,8 +481,7 @@ export function renderMarkdownHovers(
 		const renderedHoverPart = renderMarkdown(
 			editor,
 			markdownHover,
-			languageService,
-			openerService,
+			instantiationService,
 			context.onContentsChanged,
 		);
 		context.fragment.appendChild(renderedHoverPart.hoverElement);
@@ -500,8 +493,7 @@ export function renderMarkdownHovers(
 function renderMarkdown(
 	editor: ICodeEditor,
 	markdownHover: MarkdownHover,
-	languageService: ILanguageService,
-	openerService: IOpenerService,
+	instantiationService: IInstantiationService,
 	onFinishedRendering: () => void,
 ): IRenderedHoverPart<MarkdownHover> {
 	const disposables = new DisposableStore();
@@ -515,7 +507,7 @@ function renderMarkdown(
 		}
 		const markdownHoverElement = $('div.markdown-hover');
 		const hoverContentsElement = dom.append(markdownHoverElement, $('div.hover-contents'));
-		const renderer = new MarkdownRenderer({ editor }, languageService, openerService);
+		const renderer = instantiationService.createInstance(MarkdownRenderer, { editor });
 
 		const renderedContents = disposables.add(renderer.render(markdownString, {
 			asyncRenderCallback: () => {

--- a/src/vs/editor/contrib/inlayHints/browser/inlayHintsHover.ts
+++ b/src/vs/editor/contrib/inlayHints/browser/inlayHintsHover.ts
@@ -11,13 +11,11 @@ import { Position } from '../../../common/core/position.js';
 import { IModelDecoration } from '../../../common/model.js';
 import { ModelDecorationInjectedTextOptions } from '../../../common/model/textModel.js';
 import { HoverAnchor, HoverForeignElementAnchor, IEditorHoverParticipant } from '../../hover/browser/hoverTypes.js';
-import { ILanguageService } from '../../../common/languages/language.js';
 import { ITextModelService } from '../../../common/services/resolverService.js';
 import { getHoverProviderResultsAsAsyncIterable } from '../../hover/browser/getHover.js';
 import { MarkdownHover, MarkdownHoverParticipant } from '../../hover/browser/markdownHoverParticipant.js';
 import { RenderedInlayHintLabelPart, InlayHintsController } from './inlayHintsController.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
-import { IOpenerService } from '../../../../platform/opener/common/opener.js';
 import { ILanguageFeaturesService } from '../../../common/services/languageFeatures.js';
 import { EditorOption } from '../../../common/config/editorOptions.js';
 import { localize } from '../../../../nls.js';
@@ -28,6 +26,7 @@ import { IKeybindingService } from '../../../../platform/keybinding/common/keybi
 import { IHoverService } from '../../../../platform/hover/browser/hover.js';
 import { ICommandService } from '../../../../platform/commands/common/commands.js';
 import { HoverStartSource } from '../../hover/browser/hoverOperation.js';
+import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 
 class InlayHintsHoverAnchor extends HoverForeignElementAnchor {
 	constructor(
@@ -46,16 +45,15 @@ export class InlayHintsHover extends MarkdownHoverParticipant implements IEditor
 
 	constructor(
 		editor: ICodeEditor,
-		@ILanguageService languageService: ILanguageService,
-		@IOpenerService openerService: IOpenerService,
+		@IInstantiationService instantiationService: IInstantiationService,
 		@IKeybindingService keybindingService: IKeybindingService,
 		@IHoverService hoverService: IHoverService,
 		@IConfigurationService configurationService: IConfigurationService,
 		@ITextModelService private readonly _resolverService: ITextModelService,
 		@ILanguageFeaturesService languageFeaturesService: ILanguageFeaturesService,
-		@ICommandService commandService: ICommandService
+		@ICommandService commandService: ICommandService,
 	) {
-		super(editor, languageService, openerService, configurationService, languageFeaturesService, keybindingService, hoverService, commandService);
+		super(editor, instantiationService, configurationService, languageFeaturesService, keybindingService, hoverService, commandService);
 	}
 
 	suggestHoverAnchor(mouseEvent: IEditorMouseEvent): HoverAnchor | null {

--- a/src/vs/editor/contrib/inlineCompletions/browser/hintsWidget/hoverParticipant.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/hintsWidget/hoverParticipant.ts
@@ -10,7 +10,6 @@ import { autorun, autorunWithStore, constObservable } from '../../../../../base/
 import { ICodeEditor, IEditorMouseEvent, MouseTargetType } from '../../../../browser/editorBrowser.js';
 import { EditorOption } from '../../../../common/config/editorOptions.js';
 import { Range } from '../../../../common/core/range.js';
-import { ILanguageService } from '../../../../common/languages/language.js';
 import { IModelDecoration } from '../../../../common/model.js';
 import { HoverAnchor, HoverAnchorType, HoverForeignElementAnchor, IEditorHoverParticipant, IEditorHoverRenderContext, IHoverPart, IRenderedHoverPart, IRenderedHoverParts, RenderedHoverParts } from '../../../hover/browser/hoverTypes.js';
 import { InlineCompletionsController } from '../controller/inlineCompletionsController.js';
@@ -19,7 +18,6 @@ import { MarkdownRenderer } from '../../../../browser/widget/markdownRenderer/br
 import * as nls from '../../../../../nls.js';
 import { IAccessibilityService } from '../../../../../platform/accessibility/common/accessibility.js';
 import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
-import { IOpenerService } from '../../../../../platform/opener/common/opener.js';
 import { ITelemetryService } from '../../../../../platform/telemetry/common/telemetry.js';
 import { GhostTextView } from '../view/ghostText/ghostTextView.js';
 
@@ -45,8 +43,6 @@ export class InlineCompletionsHoverParticipant implements IEditorHoverParticipan
 
 	constructor(
 		private readonly _editor: ICodeEditor,
-		@ILanguageService private readonly _languageService: ILanguageService,
-		@IOpenerService private readonly _openerService: IOpenerService,
 		@IAccessibilityService private readonly accessibilityService: IAccessibilityService,
 		@IInstantiationService private readonly _instantiationService: IInstantiationService,
 		@ITelemetryService private readonly _telemetryService: ITelemetryService,
@@ -154,7 +150,7 @@ export class InlineCompletionsHoverParticipant implements IEditorHoverParticipan
 		const $ = dom.$;
 		const markdownHoverElement = $('div.hover-row.markdown-hover');
 		const hoverContentsElement = dom.append(markdownHoverElement, $('div.hover-contents', { ['aria-live']: 'assertive' }));
-		const renderer = new MarkdownRenderer({ editor: this._editor }, this._languageService, this._openerService);
+		const renderer = this._instantiationService.createInstance(MarkdownRenderer, { editor: this._editor });
 		const render = (code: string) => {
 			const inlineSuggestionAvailable = nls.localize('inlineSuggestionFollows', "Suggestion:");
 			const renderedContents = disposables.add(renderer.render(new MarkdownString().appendText(inlineSuggestionAvailable).appendCodeblock('text', code), {

--- a/src/vs/editor/contrib/parameterHints/browser/parameterHintsWidget.ts
+++ b/src/vs/editor/contrib/parameterHints/browser/parameterHintsWidget.ts
@@ -17,16 +17,15 @@ import { ContentWidgetPositionPreference, ICodeEditor, IContentWidget, IContentW
 import { EditorOption } from '../../../common/config/editorOptions.js';
 import { EDITOR_FONT_DEFAULTS } from '../../../common/config/fontInfo.js';
 import * as languages from '../../../common/languages.js';
-import { ILanguageService } from '../../../common/languages/language.js';
 import { IMarkdownRenderResult, MarkdownRenderer } from '../../../browser/widget/markdownRenderer/browser/markdownRenderer.js';
 import { ParameterHintsModel } from './parameterHintsModel.js';
 import { Context } from './provideSignatureHelp.js';
 import * as nls from '../../../../nls.js';
 import { IContextKey, IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
-import { IOpenerService } from '../../../../platform/opener/common/opener.js';
 import { listHighlightForeground, registerColor } from '../../../../platform/theme/common/colorRegistry.js';
 import { registerIcon } from '../../../../platform/theme/common/iconRegistry.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
+import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 
 const $ = dom.$;
 
@@ -60,12 +59,11 @@ export class ParameterHintsWidget extends Disposable implements IContentWidget {
 		private readonly editor: ICodeEditor,
 		private readonly model: ParameterHintsModel,
 		@IContextKeyService contextKeyService: IContextKeyService,
-		@IOpenerService openerService: IOpenerService,
-		@ILanguageService languageService: ILanguageService
+		@IInstantiationService instantiationService: IInstantiationService
 	) {
 		super();
 
-		this.markdownRenderer = new MarkdownRenderer({ editor }, languageService, openerService);
+		this.markdownRenderer = instantiationService.createInstance(MarkdownRenderer, { editor });
 
 		this.keyVisible = Context.Visible.bindTo(contextKeyService);
 		this.keyMultipleSignatures = Context.MultipleSignatures.bindTo(contextKeyService);

--- a/src/vs/editor/contrib/unicodeHighlighter/browser/unicodeHighlighter.ts
+++ b/src/vs/editor/contrib/unicodeHighlighter/browser/unicodeHighlighter.ts
@@ -20,14 +20,12 @@ import { IModelDecoration, IModelDeltaDecoration, ITextModel, TrackedRangeSticki
 import { ModelDecorationOptions } from '../../../common/model/textModel.js';
 import { UnicodeHighlighterOptions, UnicodeHighlighterReason, UnicodeHighlighterReasonKind, UnicodeTextModelHighlighter } from '../../../common/services/unicodeTextModelHighlighter.js';
 import { IEditorWorkerService, IUnicodeHighlightsResult } from '../../../common/services/editorWorker.js';
-import { ILanguageService } from '../../../common/languages/language.js';
 import { HoverAnchor, HoverAnchorType, HoverParticipantRegistry, IEditorHoverParticipant, IEditorHoverRenderContext, IHoverPart, IRenderedHoverParts } from '../../hover/browser/hoverTypes.js';
 import { MarkdownHover, renderMarkdownHovers } from '../../hover/browser/markdownHoverParticipant.js';
 import { BannerController } from './bannerController.js';
 import * as nls from '../../../../nls.js';
 import { ConfigurationTarget, IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
-import { IOpenerService } from '../../../../platform/opener/common/opener.js';
 import { IQuickInputService, IQuickPickItem } from '../../../../platform/quickinput/common/quickInput.js';
 import { registerIcon } from '../../../../platform/theme/common/iconRegistry.js';
 import { IWorkspaceTrustManagementService } from '../../../../platform/workspace/common/workspaceTrust.js';
@@ -419,10 +417,8 @@ export class UnicodeHighlighterHoverParticipant implements IEditorHoverParticipa
 
 	constructor(
 		private readonly _editor: ICodeEditor,
-		@ILanguageService private readonly _languageService: ILanguageService,
-		@IOpenerService private readonly _openerService: IOpenerService,
-	) {
-	}
+		@IInstantiationService private readonly _instantiationService: IInstantiationService,
+	) { }
 
 	computeSync(anchor: HoverAnchor, lineDecorations: IModelDecoration[]): MarkdownHover[] {
 		if (!this._editor.hasModel() || anchor.type !== HoverAnchorType.Range) {
@@ -513,7 +509,7 @@ export class UnicodeHighlighterHoverParticipant implements IEditorHoverParticipa
 	}
 
 	public renderHoverParts(context: IEditorHoverRenderContext, hoverParts: MarkdownHover[]): IRenderedHoverParts<MarkdownHover> {
-		return renderMarkdownHovers(context, hoverParts, this._editor, this._languageService, this._openerService);
+		return renderMarkdownHovers(context, hoverParts, this._editor, this._instantiationService);
 	}
 
 	public getAccessibleContent(hoverPart: MarkdownHover): string {

--- a/src/vs/workbench/contrib/chat/browser/chatMarkdownRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatMarkdownRenderer.ts
@@ -12,6 +12,7 @@ import { URI } from '../../../../base/common/uri.js';
 import { IMarkdownRendererOptions, IMarkdownRenderResult, MarkdownRenderer } from '../../../../editor/browser/widget/markdownRenderer/browser/markdownRenderer.js';
 import { ILanguageService } from '../../../../editor/common/languages/language.js';
 import { ICommandService } from '../../../../platform/commands/common/commands.js';
+import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { IFileService } from '../../../../platform/files/common/files.js';
 import { IHoverService } from '../../../../platform/hover/browser/hover.js';
 import { IOpenerService } from '../../../../platform/opener/common/opener.js';
@@ -68,11 +69,12 @@ export class ChatMarkdownRenderer extends MarkdownRenderer {
 		options: IMarkdownRendererOptions | undefined,
 		@ILanguageService languageService: ILanguageService,
 		@IOpenerService openerService: IOpenerService,
+		@IConfigurationService configurationService: IConfigurationService,
 		@IHoverService private readonly hoverService: IHoverService,
 		@IFileService private readonly fileService: IFileService,
 		@ICommandService private readonly commandService: ICommandService,
 	) {
-		super(options ?? {}, languageService, openerService);
+		super(options ?? {}, configurationService, languageService, openerService);
 	}
 
 	override render(markdown: IMarkdownString, options?: MarkdownRenderOptions, outElement?: HTMLElement): IMarkdownRenderResult {

--- a/src/vs/workbench/contrib/comments/browser/commentThreadBody.ts
+++ b/src/vs/workbench/contrib/comments/browser/commentThreadBody.ts
@@ -16,8 +16,6 @@ import { IInstantiationService } from '../../../../platform/instantiation/common
 import { URI } from '../../../../base/common/uri.js';
 import { ICommentThreadWidget } from '../common/commentThreadWidget.js';
 import { IMarkdownRendererOptions, MarkdownRenderer } from '../../../../editor/browser/widget/markdownRenderer/browser/markdownRenderer.js';
-import { IOpenerService } from '../../../../platform/opener/common/opener.js';
-import { ILanguageService } from '../../../../editor/common/languages/language.js';
 import { ICellRange } from '../../notebook/common/notebookRange.js';
 import { IRange } from '../../../../editor/common/core/range.js';
 import { LayoutableEditor } from './simpleCommentEditor.js';
@@ -52,8 +50,6 @@ export class CommentThreadBody<T extends IRange | ICellRange = IRange> extends D
 		private _scopedInstatiationService: IInstantiationService,
 		private _parentCommentThreadWidget: ICommentThreadWidget,
 		@ICommentService private commentService: ICommentService,
-		@IOpenerService private openerService: IOpenerService,
-		@ILanguageService private languageService: ILanguageService,
 	) {
 		super();
 
@@ -62,7 +58,7 @@ export class CommentThreadBody<T extends IRange | ICellRange = IRange> extends D
 			this.commentService.setActiveEditingCommentThread(this._commentThread);
 		}));
 
-		this._markdownRenderer = new MarkdownRenderer(this._options, this.languageService, this.openerService);
+		this._markdownRenderer = this._scopedInstatiationService.createInstance(MarkdownRenderer, this._options);
 	}
 
 	focus(commentUniqueId?: number) {

--- a/src/vs/workbench/contrib/comments/browser/commentThreadZoneWidget.ts
+++ b/src/vs/workbench/contrib/comments/browser/commentThreadZoneWidget.ts
@@ -18,8 +18,7 @@ import { IColorTheme, IThemeService } from '../../../../platform/theme/common/th
 import { CommentGlyphWidget } from './commentGlyphWidget.js';
 import { ICommentService } from './commentService.js';
 import { ICommentThreadWidget } from '../common/commentThreadWidget.js';
-import { EditorOption, IEditorOptions } from '../../../../editor/common/config/editorOptions.js';
-import { EDITOR_FONT_DEFAULTS } from '../../../../editor/common/config/fontInfo.js';
+import { EditorOption } from '../../../../editor/common/config/editorOptions.js';
 import { ServiceCollection } from '../../../../platform/instantiation/common/serviceCollection.js';
 import { CommentThreadWidget } from './commentThreadWidget.js';
 import { ICellRange } from '../../notebook/common/notebookRange.js';
@@ -273,7 +272,7 @@ export class ReviewZoneWidget extends ZoneWidget implements ICommentThreadWidget
 			this._commentThread as unknown as languages.CommentThread<IRange | ICellRange>,
 			this._pendingComment,
 			this._pendingEdits,
-			{ editor: this.editor, codeBlockFontSize: '', codeBlockFontFamily: this.configurationService.getValue<IEditorOptions>('editor').fontFamily || EDITOR_FONT_DEFAULTS.fontFamily },
+			{ editor: this.editor, codeBlockFontSize: '' },
 			this._commentOptions,
 			{
 				actionRunner: async () => {

--- a/src/vs/workbench/contrib/notebook/browser/view/cellParts/cellComments.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/cellParts/cellComments.ts
@@ -5,10 +5,7 @@
 
 import { coalesce } from '../../../../../../base/common/arrays.js';
 import { DisposableMap, DisposableStore } from '../../../../../../base/common/lifecycle.js';
-import { IEditorOptions } from '../../../../../../editor/common/config/editorOptions.js';
-import { EDITOR_FONT_DEFAULTS } from '../../../../../../editor/common/config/fontInfo.js';
 import * as languages from '../../../../../../editor/common/languages.js';
-import { IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
 import { IContextKeyService } from '../../../../../../platform/contextkey/common/contextkey.js';
 import { IInstantiationService } from '../../../../../../platform/instantiation/common/instantiation.js';
 import { IThemeService } from '../../../../../../platform/theme/common/themeService.js';
@@ -29,7 +26,6 @@ export class CellComments extends CellContentPart {
 		@IContextKeyService private readonly contextKeyService: IContextKeyService,
 		@IThemeService private readonly themeService: IThemeService,
 		@ICommentService private readonly commentService: ICommentService,
-		@IConfigurationService private readonly configurationService: IConfigurationService,
 		@IInstantiationService private readonly instantiationService: IInstantiationService
 	) {
 		super();
@@ -65,9 +61,7 @@ export class CellComments extends CellContentPart {
 			commentThread,
 			undefined,
 			undefined,
-			{
-				codeBlockFontFamily: this.configurationService.getValue<IEditorOptions>('editor').fontFamily || EDITOR_FONT_DEFAULTS.fontFamily
-			},
+			{},
 			undefined,
 			{
 				actionRunner: () => {


### PR DESCRIPTION
For #206228

Always use the configuration service to look up the editor defaults instead of requiring it from each caller
