### PR TITLE
Inline edit toolbar is tiny (fix microsoft/vscode-copilot#17191)

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingCodeEditorIntegration.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingCodeEditorIntegration.ts
@@ -40,6 +40,8 @@ import { IChatAgentService } from '../../common/chatAgents.js';
 import { IModifiedFileEntry, IModifiedFileEntryChangeHunk, IModifiedFileEntryEditorIntegration, ModifiedFileEntryState } from '../../common/chatEditingService.js';
 import { ChatAgentLocation } from '../../common/constants.js';
 import { isTextDiffEditorForEntry } from './chatEditing.js';
+import { ActionViewItem } from '../../../../../base/browser/ui/actionbar/actionViewItems.js';
+import { AcceptHunkAction, RejectHunkAction } from './chatEditingEditorActions.js';
 
 export interface IDocumentDiff2 extends IDocumentDiff {
 
@@ -690,6 +692,16 @@ class DiffHunkWidget implements IOverlayWidget, IModifiedFileEntryChangeHunk {
 				renderShortTitle: true,
 				arg: this,
 			},
+			actionViewItemProvider: (action, options) => {
+				if (action.id === AcceptHunkAction.ID || action.id === RejectHunkAction.ID) {
+					return new class extends ActionViewItem {
+						constructor() {
+							super(undefined, action, { ...options, keybindingNotRenderedWithLabel: true, icon: false, label: true });
+						}
+					};
+				}
+				return undefined;
+			}
 		});
 
 		this._store.add(toolbar);

--- a/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingEditorActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingEditorActions.ts
@@ -226,15 +226,17 @@ export class RejectAction extends KeepOrUndoAction {
 	}
 }
 
+const acceptHunkId = 'chatEditor.action.acceptHunk';
+const undoHunkId = 'chatEditor.action.undoHunk';
 abstract class AcceptRejectHunkAction extends ChatEditingEditorAction {
 
 	constructor(private readonly _accept: boolean) {
 		super(
 			{
-				id: _accept ? 'chatEditor.action.acceptHunk' : 'chatEditor.action.undoHunk',
+				id: _accept ? acceptHunkId : undoHunkId,
 				title: _accept ? localize2('acceptHunk', 'Keep this Change') : localize2('undo', 'Undo this Change'),
+				shortTitle: _accept ? localize2('acceptHunkShort', 'Keep') : localize2('undoShort', 'Undo'),
 				precondition: ContextKeyExpr.and(ctxHasEditorModification, ctxIsCurrentlyBeingModified.negate()),
-				icon: _accept ? Codicon.check : Codicon.discard,
 				f1: true,
 				keybinding: {
 					when: ContextKeyExpr.or(EditorContextKeys.focus, NOTEBOOK_CELL_LIST_FOCUSED),
@@ -265,6 +267,24 @@ abstract class AcceptRejectHunkAction extends ChatEditingEditorAction {
 			// no more changes, move to next file
 			await instaService.invokeFunction(openNextOrPreviousChange, session, entry, true);
 		}
+	}
+}
+
+export class AcceptHunkAction extends AcceptRejectHunkAction {
+
+	static readonly ID = acceptHunkId;
+
+	constructor() {
+		super(true);
+	}
+}
+
+export class RejectHunkAction extends AcceptRejectHunkAction {
+
+	static readonly ID = undoHunkId;
+
+	constructor() {
+		super(false);
 	}
 }
 
@@ -422,8 +442,8 @@ export function registerChatEditorActions() {
 	registerAction2(AcceptAction);
 	registerAction2(RejectAction);
 	registerAction2(AcceptAllEditsAction);
-	registerAction2(class AcceptHunkAction extends AcceptRejectHunkAction { constructor() { super(true); } });
-	registerAction2(class RejectHunkAction extends AcceptRejectHunkAction { constructor() { super(false); } });
+	registerAction2(AcceptHunkAction);
+	registerAction2(RejectHunkAction);
 	registerAction2(ToggleDiffAction);
 	registerAction2(ToggleAccessibleDiffViewAction);
 

--- a/src/vs/workbench/contrib/chat/browser/chatEditing/notebook/overlayToolbarDecorator.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditing/notebook/overlayToolbarDecorator.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { ActionViewItem } from '../../../../../../base/browser/ui/actionbar/actionViewItems.js';
 import { Disposable, DisposableStore } from '../../../../../../base/common/lifecycle.js';
 import { AccessibilitySignal, IAccessibilitySignalService } from '../../../../../../platform/accessibilitySignal/browser/accessibilitySignalService.js';
 import { MenuWorkbenchToolBar, HiddenItemStrategy } from '../../../../../../platform/actions/browser/toolbar.js';
@@ -14,6 +15,7 @@ import { CellEditState, INotebookEditor } from '../../../../notebook/browser/not
 import { NotebookTextModel } from '../../../../notebook/common/model/notebookTextModel.js';
 import { CellKind } from '../../../../notebook/common/notebookCommon.js';
 import { IModifiedFileEntryChangeHunk } from '../../../common/chatEditingService.js';
+import { AcceptHunkAction, RejectHunkAction } from '../chatEditingEditorActions.js';
 import { ICellDiffInfo } from './notebookCellChanges.js';
 
 
@@ -120,6 +122,16 @@ export class OverlayToolbarDecorator extends Disposable {
 						}
 					} satisfies IModifiedFileEntryChangeHunk,
 				},
+				actionViewItemProvider: (action, options) => {
+					if (action.id === AcceptHunkAction.ID || action.id === RejectHunkAction.ID) {
+						return new class extends ActionViewItem {
+							constructor() {
+								super(undefined, action, { ...options, keybindingNotRenderedWithLabel: true, icon: false, label: true });
+							}
+						};
+					}
+					return undefined;
+				}
 			});
 
 			this.overlayDisposables.add(toolbarWidget);

--- a/src/vs/workbench/contrib/chat/browser/media/chatEditorController.css
+++ b/src/vs/workbench/contrib/chat/browser/media/chatEditorController.css
@@ -22,9 +22,9 @@
 }
 
 .chat-diff-change-content-widget .monaco-action-bar .action-item .action-label {
-	height: 14px;
 	border-radius: 2px;
 	color: var(--vscode-button-foreground);
+	padding: 2px 5px;
 }
 
 .chat-diff-change-content-widget .monaco-action-bar .action-item .action-label.codicon {


### PR DESCRIPTION
This changes the accept/reject hunk toolbar to use the same visuals as the other one we have per-editor:

<img width="571" height="892" alt="image" src="https://github.com/user-attachments/assets/9e22ed8a-6710-468c-b281-5a3dc4b1e905" />

@jrieken please take a look, I was able to find the `keybindingNotRenderedWithLabel` trick, but it has the disadvantage that a menu needs to know about the actions it shows? I think a cleaner approach would be that I can configure this for all action items on the toolbar, did we ever consider this?

fyi @mrleemurray for visual consistency (check the change in CSS)