### PR TITLE
Move all markdown renderer options into `render` call

### DIFF
--- a/src/vs/editor/browser/services/hoverService/hoverWidget.ts
+++ b/src/vs/editor/browser/services/hoverService/hoverWidget.ts
@@ -165,7 +165,7 @@ export class HoverWidget extends Widget implements IHoverWidget {
 
 		} else {
 			const markdown = options.content;
-			const mdRenderer = this._instantiationService.createInstance(MarkdownRenderer, {});
+			const mdRenderer = this._instantiationService.createInstance(MarkdownRenderer);
 
 			const { element, dispose } = mdRenderer.render(markdown, {
 				actionHandler: (content) => this._linkHandler(content),

--- a/src/vs/editor/contrib/hover/browser/glyphHoverWidget.ts
+++ b/src/vs/editor/contrib/hover/browser/glyphHoverWidget.ts
@@ -46,7 +46,7 @@ export class GlyphHoverWidget extends Disposable implements IOverlayWidget, IHov
 		this._hover = this._register(new HoverWidget(true));
 		this._hover.containerDomNode.classList.toggle('hidden', !this._isVisible);
 
-		this._markdownRenderer = instantiationService.createInstance(MarkdownRenderer, { editor: this._editor });
+		this._markdownRenderer = instantiationService.createInstance(MarkdownRenderer);
 		this._hoverOperation = this._register(new HoverOperation(this._editor, new GlyphHoverComputer(this._editor)));
 		this._register(this._hoverOperation.onResult((result) => this._withResult(result)));
 
@@ -148,7 +148,7 @@ export class GlyphHoverWidget extends Disposable implements IOverlayWidget, IHov
 		for (const msg of messages) {
 			const markdownHoverElement = $('div.hover-row.markdown-hover');
 			const hoverContentsElement = dom.append(markdownHoverElement, $('div.hover-contents'));
-			const renderedContents = this._renderDisposeables.add(this._markdownRenderer.render(msg.value));
+			const renderedContents = this._renderDisposeables.add(this._markdownRenderer.render(msg.value, { editor: this._editor }));
 			hoverContentsElement.appendChild(renderedContents.element);
 			fragment.appendChild(markdownHoverElement);
 		}

--- a/src/vs/editor/contrib/hover/browser/markdownHoverParticipant.ts
+++ b/src/vs/editor/contrib/hover/browser/markdownHoverParticipant.ts
@@ -507,9 +507,10 @@ function renderMarkdown(
 		}
 		const markdownHoverElement = $('div.markdown-hover');
 		const hoverContentsElement = dom.append(markdownHoverElement, $('div.hover-contents'));
-		const renderer = instantiationService.createInstance(MarkdownRenderer, { editor });
+		const renderer = instantiationService.createInstance(MarkdownRenderer);
 
 		const renderedContents = disposables.add(renderer.render(markdownString, {
+			editor,
 			asyncRenderCallback: () => {
 				hoverContentsElement.className = 'hover-contents code-hover-contents';
 				onFinishedRendering();

--- a/src/vs/editor/contrib/inlineCompletions/browser/hintsWidget/hoverParticipant.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/hintsWidget/hoverParticipant.ts
@@ -150,10 +150,11 @@ export class InlineCompletionsHoverParticipant implements IEditorHoverParticipan
 		const $ = dom.$;
 		const markdownHoverElement = $('div.hover-row.markdown-hover');
 		const hoverContentsElement = dom.append(markdownHoverElement, $('div.hover-contents', { ['aria-live']: 'assertive' }));
-		const renderer = this._instantiationService.createInstance(MarkdownRenderer, { editor: this._editor });
+		const renderer = this._instantiationService.createInstance(MarkdownRenderer);
 		const render = (code: string) => {
 			const inlineSuggestionAvailable = nls.localize('inlineSuggestionFollows', "Suggestion:");
 			const renderedContents = disposables.add(renderer.render(new MarkdownString().appendText(inlineSuggestionAvailable).appendCodeblock('text', code), {
+				editor: this._editor,
 				asyncRenderCallback: () => {
 					hoverContentsElement.className = 'hover-contents code-hover-contents';
 					context.onContentsChanged();

--- a/src/vs/editor/contrib/parameterHints/browser/parameterHintsWidget.ts
+++ b/src/vs/editor/contrib/parameterHints/browser/parameterHintsWidget.ts
@@ -64,7 +64,7 @@ export class ParameterHintsWidget extends Disposable implements IContentWidget {
 	) {
 		super();
 
-		this.markdownRenderer = instantiationService.createInstance(MarkdownRenderer, { editor });
+		this.markdownRenderer = instantiationService.createInstance(MarkdownRenderer);
 
 		this.keyVisible = Context.Visible.bindTo(contextKeyService);
 		this.keyMultipleSignatures = Context.MultipleSignatures.bindTo(contextKeyService);
@@ -273,6 +273,7 @@ export class ParameterHintsWidget extends Disposable implements IContentWidget {
 
 	private renderMarkdownDocs(markdown: IMarkdownString): IRenderedMarkdown {
 		const renderedContents = this.renderDisposeables.add(this.markdownRenderer.render(markdown, {
+			editor: this.editor,
 			asyncRenderCallback: () => {
 				this.domNodes?.scrollbar.scanDomNode();
 			}

--- a/src/vs/editor/contrib/suggest/browser/suggestWidgetDetails.ts
+++ b/src/vs/editor/contrib/suggest/browser/suggestWidgetDetails.ts
@@ -54,7 +54,7 @@ export class SuggestDetailsWidget {
 		this.domNode = dom.$('.suggest-details');
 		this.domNode.classList.add('no-docs');
 
-		this._markdownRenderer = instaService.createInstance(MarkdownRenderer, { editor: _editor });
+		this._markdownRenderer = instaService.createInstance(MarkdownRenderer);
 
 		this._body = dom.$('.body');
 
@@ -177,6 +177,7 @@ export class SuggestDetailsWidget {
 			this._docs.classList.add('markdown-docs');
 			dom.clearNode(this._docs);
 			const renderedContents = this._markdownRenderer.render(documentation, {
+				editor: this._editor,
 				asyncRenderCallback: () => {
 					this.layout(this._size.width, this._type.clientHeight + this._docs.clientHeight);
 					this._onDidChangeContents.fire(this);

--- a/src/vs/editor/contrib/unicodeHighlighter/browser/bannerController.ts
+++ b/src/vs/editor/contrib/unicodeHighlighter/browser/bannerController.ts
@@ -62,7 +62,7 @@ class Banner extends Disposable {
 	) {
 		super();
 
-		this.markdownRenderer = this.instantiationService.createInstance(MarkdownRenderer, {});
+		this.markdownRenderer = this.instantiationService.createInstance(MarkdownRenderer);
 
 		this.element = $('div.editor-banner');
 		this.element.tabIndex = 0;

--- a/src/vs/workbench/browser/parts/banner/bannerPart.ts
+++ b/src/vs/workbench/browser/parts/banner/bannerPart.ts
@@ -72,7 +72,7 @@ export class BannerPart extends Part implements IBannerService {
 	) {
 		super(Parts.BANNER_PART, { hasTitle: false }, themeService, storageService, layoutService);
 
-		this.markdownRenderer = this.instantiationService.createInstance(MarkdownRenderer, {});
+		this.markdownRenderer = this.instantiationService.createInstance(MarkdownRenderer);
 	}
 
 	protected override createContentArea(parent: HTMLElement): HTMLElement {

--- a/src/vs/workbench/browser/parts/dialogs/dialogHandler.ts
+++ b/src/vs/workbench/browser/parts/dialogs/dialogHandler.ts
@@ -40,7 +40,7 @@ export class BrowserDialogHandler extends AbstractDialogHandler {
 	) {
 		super();
 
-		this.markdownRenderer = instantiationService.createInstance(MarkdownRenderer, {});
+		this.markdownRenderer = instantiationService.createInstance(MarkdownRenderer);
 	}
 
 	async prompt<T>(prompt: IPrompt<T>): Promise<IAsyncPromptResult<T>> {

--- a/src/vs/workbench/browser/parts/views/treeView.ts
+++ b/src/vs/workbench/browser/parts/views/treeView.ts
@@ -949,7 +949,7 @@ abstract class AbstractTreeView extends Disposable implements ITreeView {
 			this._messageValue.disposables.dispose();
 		}
 		if (isMarkdownString(message) && !this.markdownRenderer) {
-			this.markdownRenderer = this.instantiationService.createInstance(MarkdownRenderer, {});
+			this.markdownRenderer = this.instantiationService.createInstance(MarkdownRenderer);
 		}
 		if (isMarkdownString(message)) {
 			const disposables = new DisposableStore();

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/chatConfirmationWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/chatConfirmationWidget.ts
@@ -161,7 +161,7 @@ abstract class BaseSimpleChatConfirmationWidget<T> extends Disposable {
 		]);
 		configureAccessibilityContainer(elements.container, title, message);
 		this._domNode = elements.root;
-		this.markdownRenderer = this.instantiationService.createInstance(MarkdownRenderer, {});
+		this.markdownRenderer = this.instantiationService.createInstance(MarkdownRenderer);
 
 		const titlePart = this._register(instantiationService.createInstance(
 			ChatQueryTitlePart,
@@ -374,7 +374,7 @@ abstract class BaseChatConfirmationWidget<T> extends Disposable {
 		this._domNode = elements.root;
 		this._buttonsDomNode = elements.buttons;
 
-		this.markdownRenderer = this.instantiationService.createInstance(MarkdownRenderer, {});
+		this.markdownRenderer = this.instantiationService.createInstance(MarkdownRenderer);
 
 		const titlePart = this._register(instantiationService.createInstance(
 			ChatQueryTitlePart,

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/chatMcpServersInteractionContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/chatMcpServersInteractionContentPart.ts
@@ -57,7 +57,7 @@ export class ChatMcpServersInteractionContentPart extends Disposable implements 
 		super();
 
 		this.domNode = dom.$('.chat-mcp-servers-interaction');
-		this.markdownRenderer = this.instantiationService.createInstance(MarkdownRenderer, {});
+		this.markdownRenderer = this.instantiationService.createInstance(MarkdownRenderer);
 
 		// Listen to autostart state changes if available
 		if (data.state) {

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/chatThinkingContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/chatThinkingContentPart.ts
@@ -67,7 +67,7 @@ export class ChatThinkingContentPart extends ChatCollapsibleContentPart implemen
 
 		super(extractedTitle, context);
 
-		this.renderer = instantiationService.createInstance(MarkdownRenderer, {});
+		this.renderer = instantiationService.createInstance(MarkdownRenderer);
 		this.id = content.id;
 
 		const mode = this.configurationService.getValue<string>('chat.agent.thinkingStyle') ?? 'none';

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/chatToolInputOutputContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/chatToolInputOutputContentPart.ts
@@ -120,7 +120,7 @@ export class ChatCollapsibleInputOutputContentPart extends Disposable {
 			titleEl.root,
 			title,
 			subtitle,
-			_instantiationService.createInstance(MarkdownRenderer, {}),
+			_instantiationService.createInstance(MarkdownRenderer),
 		));
 		this._register(titlePart.onDidChangeHeight(() => this._onDidChangeHeight.fire()));
 

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart.ts
@@ -57,7 +57,7 @@ export class ChatTerminalToolProgressPart extends BaseChatToolInvocationSubPart 
 
 		const command = terminalData.commandLine.userEdited ?? terminalData.commandLine.toolEdited ?? terminalData.commandLine.original;
 
-		const markdownRenderer = instantiationService.createInstance(MarkdownRenderer, {});
+		const markdownRenderer = instantiationService.createInstance(MarkdownRenderer);
 		const titlePart = this._register(instantiationService.createInstance(
 			ChatQueryTitlePart,
 			elements.title,

--- a/src/vs/workbench/contrib/chat/browser/chatListRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatListRenderer.ts
@@ -222,7 +222,7 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 	) {
 		super();
 
-		this.renderer = this.instantiationService.createInstance(ChatMarkdownRenderer, undefined);
+		this.renderer = this.instantiationService.createInstance(ChatMarkdownRenderer);
 		this.markdownDecorationsRenderer = this.instantiationService.createInstance(ChatMarkdownDecorationsRenderer);
 		this._editorPool = this._register(this.instantiationService.createInstance(EditorPool, editorOptions, delegate, overflowWidgetsDomNode, false));
 		this._toolEditorPool = this._register(this.instantiationService.createInstance(EditorPool, editorOptions, delegate, overflowWidgetsDomNode, true));

--- a/src/vs/workbench/contrib/chat/browser/chatMarkdownRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatMarkdownRenderer.ts
@@ -9,7 +9,7 @@ import { getDefaultHoverDelegate } from '../../../../base/browser/ui/hover/hover
 import { IMarkdownString } from '../../../../base/common/htmlContent.js';
 import { DisposableStore } from '../../../../base/common/lifecycle.js';
 import { URI } from '../../../../base/common/uri.js';
-import { IMarkdownRendererOptions, MarkdownRenderer } from '../../../../editor/browser/widget/markdownRenderer/browser/markdownRenderer.js';
+import { MarkdownRenderer } from '../../../../editor/browser/widget/markdownRenderer/browser/markdownRenderer.js';
 import { ILanguageService } from '../../../../editor/common/languages/language.js';
 import { ICommandService } from '../../../../platform/commands/common/commands.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
@@ -66,7 +66,6 @@ export const allowedChatMarkdownHtmlTags = Object.freeze([
  */
 export class ChatMarkdownRenderer extends MarkdownRenderer {
 	constructor(
-		options: IMarkdownRendererOptions | undefined,
 		@ILanguageService languageService: ILanguageService,
 		@IOpenerService openerService: IOpenerService,
 		@IConfigurationService configurationService: IConfigurationService,
@@ -74,7 +73,7 @@ export class ChatMarkdownRenderer extends MarkdownRenderer {
 		@IFileService private readonly fileService: IFileService,
 		@ICommandService private readonly commandService: ICommandService,
 	) {
-		super(options ?? {}, configurationService, languageService, openerService);
+		super(configurationService, languageService, openerService);
 	}
 
 	override render(markdown: IMarkdownString, options?: MarkdownRenderOptions, outElement?: HTMLElement): IRenderedMarkdown {

--- a/src/vs/workbench/contrib/chat/browser/chatQuick.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatQuick.ts
@@ -261,7 +261,7 @@ class QuickChat extends Disposable {
 			disclaimerElement.classList.toggle('hidden', !showDisclaimer);
 
 			if (showDisclaimer) {
-				const markdown = this.instantiationService.createInstance(MarkdownRenderer, {});
+				const markdown = this.instantiationService.createInstance(MarkdownRenderer);
 				const renderedMarkdown = disposables.add(markdown.render(new MarkdownString(localize({ key: 'termsDisclaimer', comment: ['{Locked="]({2})"}', '{Locked="]({3})"}'] }, "By continuing with {0} Copilot, you agree to {1}'s [Terms]({2}) and [Privacy Statement]({3})", product.defaultChatAgent?.provider?.default?.name ?? '', product.defaultChatAgent?.provider?.default?.name ?? '', product.defaultChatAgent?.termsStatementUrl ?? '', product.defaultChatAgent?.privacyStatementUrl ?? ''), { isTrusted: true })));
 				disclaimerElement.appendChild(renderedMarkdown.element);
 			}

--- a/src/vs/workbench/contrib/chat/browser/chatSessions/view/sessionsTreeRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSessions/view/sessionsTreeRenderer.ts
@@ -129,7 +129,7 @@ export class SessionsRenderer extends Disposable implements ITreeRenderer<IChatS
 	) {
 		super();
 
-		this.markdownRenderer = instantiationService.createInstance(MarkdownRenderer, {});
+		this.markdownRenderer = instantiationService.createInstance(MarkdownRenderer);
 	}
 
 	get templateId(): string {

--- a/src/vs/workbench/contrib/chat/browser/chatSetup.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSetup.ts
@@ -833,7 +833,7 @@ class ChatSetup {
 	private createDialogFooter(disposables: DisposableStore, options?: { forceAnonymous?: ChatSetupAnonymous }): HTMLElement {
 		const element = $('.chat-setup-dialog-footer');
 
-		const markdown = this.instantiationService.createInstance(MarkdownRenderer, {});
+		const markdown = this.instantiationService.createInstance(MarkdownRenderer);
 
 		let footer: string;
 		if (options?.forceAnonymous || this.telemetryService.telemetryLevel === TelemetryLevel.NONE) {

--- a/src/vs/workbench/contrib/chat/browser/chatStatus.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatStatus.ts
@@ -549,7 +549,7 @@ class ChatStatusDashboard extends Disposable {
 				if (typeof descriptionText === 'string') {
 					this.element.appendChild($(`div${descriptionClass}`, undefined, descriptionText));
 				} else {
-					const markdown = this.instantiationService.createInstance(MarkdownRenderer, {});
+					const markdown = this.instantiationService.createInstance(MarkdownRenderer);
 					this.element.appendChild($(`div${descriptionClass}`, undefined, disposables.add(markdown.render(descriptionText)).element));
 				}
 

--- a/src/vs/workbench/contrib/chat/browser/viewsWelcome/chatViewWelcomeController.ts
+++ b/src/vs/workbench/contrib/chat/browser/viewsWelcome/chatViewWelcomeController.ts
@@ -147,7 +147,7 @@ export class ChatViewWelcomePart extends Disposable {
 		this.element = dom.$('.chat-welcome-view');
 
 		try {
-			const renderer = this.instantiationService.createInstance(MarkdownRenderer, {});
+			const renderer = this.instantiationService.createInstance(MarkdownRenderer);
 
 			// Icon
 			const icon = dom.append(this.element, $('.chat-welcome-view-icon'));

--- a/src/vs/workbench/contrib/chat/test/browser/chatMarkdownRenderer.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/chatMarkdownRenderer.test.ts
@@ -15,7 +15,7 @@ suite('ChatMarkdownRenderer', () => {
 	let testRenderer: ChatMarkdownRenderer;
 	setup(() => {
 		const instantiationService = store.add(workbenchInstantiationService(undefined, store));
-		testRenderer = instantiationService.createInstance(ChatMarkdownRenderer, {});
+		testRenderer = instantiationService.createInstance(ChatMarkdownRenderer);
 	});
 
 	test('simple', async () => {

--- a/src/vs/workbench/contrib/comments/browser/commentNode.ts
+++ b/src/vs/workbench/contrib/comments/browser/commentNode.ts
@@ -10,7 +10,7 @@ import { ActionsOrientation, ActionBar } from '../../../../base/browser/ui/actio
 import { Action, IAction, Separator, ActionRunner } from '../../../../base/common/actions.js';
 import { Disposable, DisposableStore, IReference, MutableDisposable } from '../../../../base/common/lifecycle.js';
 import { URI, UriComponents } from '../../../../base/common/uri.js';
-import { MarkdownRenderer } from '../../../../editor/browser/widget/markdownRenderer/browser/markdownRenderer.js';
+import { IMarkdownRendererExtraOptions, MarkdownRenderer } from '../../../../editor/browser/widget/markdownRenderer/browser/markdownRenderer.js';
 import { IRenderedMarkdown } from '../../../../base/browser/markdownRenderer.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { ICommentService } from './commentService.js';
@@ -107,7 +107,8 @@ export class CommentNode<T extends IRange | ICellRange> extends Disposable {
 		private owner: string,
 		private resource: URI,
 		private parentThread: ICommentThreadWidget,
-		private markdownRenderer: MarkdownRenderer,
+		private readonly markdownRenderer: MarkdownRenderer,
+		private readonly markdownRendererOptions: IMarkdownRendererExtraOptions,
 		@IInstantiationService private instantiationService: IInstantiationService,
 		@ICommentService private commentService: ICommentService,
 		@INotificationService private notificationService: INotificationService,
@@ -210,7 +211,7 @@ export class CommentNode<T extends IRange | ICellRange> extends Disposable {
 			this._plainText = dom.append(this._body, dom.$('.comment-body-plainstring'));
 			this._plainText.innerText = body;
 		} else {
-			this._md.value = this.markdownRenderer.render(body);
+			this._md.value = this.markdownRenderer.render(body, this.markdownRendererOptions);
 			this._body.appendChild(this._md.value.element);
 		}
 	}

--- a/src/vs/workbench/contrib/comments/browser/commentThreadBody.ts
+++ b/src/vs/workbench/contrib/comments/browser/commentThreadBody.ts
@@ -15,7 +15,7 @@ import { CommentNode } from './commentNode.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { URI } from '../../../../base/common/uri.js';
 import { ICommentThreadWidget } from '../common/commentThreadWidget.js';
-import { IMarkdownRendererOptions, MarkdownRenderer } from '../../../../editor/browser/widget/markdownRenderer/browser/markdownRenderer.js';
+import { IMarkdownRendererExtraOptions, MarkdownRenderer } from '../../../../editor/browser/widget/markdownRenderer/browser/markdownRenderer.js';
 import { ICellRange } from '../../notebook/common/notebookRange.js';
 import { IRange } from '../../../../editor/common/core/range.js';
 import { LayoutableEditor } from './simpleCommentEditor.js';
@@ -44,7 +44,7 @@ export class CommentThreadBody<T extends IRange | ICellRange = IRange> extends D
 		readonly owner: string,
 		readonly parentResourceUri: URI,
 		readonly container: HTMLElement,
-		private _options: IMarkdownRendererOptions,
+		private _markdownRendererOptions: IMarkdownRendererExtraOptions,
 		private _commentThread: languages.CommentThread<T>,
 		private _pendingEdits: { [key: number]: languages.PendingComment } | undefined,
 		private _scopedInstatiationService: IInstantiationService,
@@ -58,7 +58,7 @@ export class CommentThreadBody<T extends IRange | ICellRange = IRange> extends D
 			this.commentService.setActiveEditingCommentThread(this._commentThread);
 		}));
 
-		this._markdownRenderer = this._scopedInstatiationService.createInstance(MarkdownRenderer, this._options);
+		this._markdownRenderer = this._scopedInstatiationService.createInstance(MarkdownRenderer);
 	}
 
 	focus(commentUniqueId?: number) {
@@ -284,7 +284,8 @@ export class CommentThreadBody<T extends IRange | ICellRange = IRange> extends D
 			this.owner,
 			this.parentResourceUri,
 			this._parentCommentThreadWidget,
-			this._markdownRenderer) as unknown as CommentNode<T>;
+			this._markdownRenderer,
+			this._markdownRendererOptions) as unknown as CommentNode<T>;
 
 		const disposables: DisposableStore = new DisposableStore();
 		disposables.add(newCommentNode.onDidClick(clickedNode =>

--- a/src/vs/workbench/contrib/comments/browser/commentThreadWidget.ts
+++ b/src/vs/workbench/contrib/comments/browser/commentThreadWidget.ts
@@ -10,7 +10,7 @@ import { Emitter } from '../../../../base/common/event.js';
 import { Disposable, dispose, IDisposable, toDisposable } from '../../../../base/common/lifecycle.js';
 import { URI } from '../../../../base/common/uri.js';
 import * as languages from '../../../../editor/common/languages.js';
-import { IMarkdownRendererOptions } from '../../../../editor/browser/widget/markdownRenderer/browser/markdownRenderer.js';
+import { IMarkdownRendererExtraOptions } from '../../../../editor/browser/widget/markdownRenderer/browser/markdownRenderer.js';
 import { IContextKey, IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { CommentMenus } from './commentMenus.js';
@@ -69,7 +69,7 @@ export class CommentThreadWidget<T extends IRange | ICellRange = IRange> extends
 		private _commentThread: languages.CommentThread<T>,
 		private _pendingComment: languages.PendingComment | undefined,
 		private _pendingEdits: { [key: number]: languages.PendingComment } | undefined,
-		private _markdownOptions: IMarkdownRendererOptions,
+		private _markdownOptions: IMarkdownRendererExtraOptions,
 		private _commentOptions: languages.CommentOptions | undefined,
 		private _containerDelegate: {
 			actionRunner: (() => void) | null;

--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChatWidget.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChatWidget.ts
@@ -316,7 +316,7 @@ export class InlineChatWidget {
 			this._elements.disclaimerLabel.classList.toggle('hidden', !showDisclaimer);
 
 			if (showDisclaimer) {
-				const markdown = this._instantiationService.createInstance(MarkdownRenderer, {});
+				const markdown = this._instantiationService.createInstance(MarkdownRenderer);
 				const renderedMarkdown = disposables.add(markdown.render(new MarkdownString(localize({ key: 'termsDisclaimer', comment: ['{Locked="]({2})"}', '{Locked="]({3})"}'] }, "By continuing with {0} Copilot, you agree to {1}'s [Terms]({2}) and [Privacy Statement]({3})", product.defaultChatAgent?.provider?.default?.name ?? '', product.defaultChatAgent?.provider?.default?.name ?? '', product.defaultChatAgent?.termsStatementUrl ?? '', product.defaultChatAgent?.privacyStatementUrl ?? ''), { isTrusted: true })));
 				this._elements.disclaimerLabel.appendChild(renderedMarkdown.element);
 			}

--- a/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
@@ -845,7 +845,7 @@ export abstract class AbstractSettingRenderer extends Disposable implements ITre
 	) {
 		super();
 
-		this.markdownRenderer = _instantiationService.createInstance(MarkdownRenderer, {});
+		this.markdownRenderer = _instantiationService.createInstance(MarkdownRenderer);
 
 		this.ignoredSettings = getIgnoredSettings(getDefaultIgnoredSettings(), this._configService);
 		this._register(this._configService.onDidChangeConfiguration(e => {

--- a/src/vs/workbench/contrib/scm/browser/scmViewPane.ts
+++ b/src/vs/workbench/contrib/scm/browser/scmViewPane.ts
@@ -2052,7 +2052,7 @@ class SCMInputWidget {
 						this.contextViewService.hideContextView();
 					}));
 
-					const renderer = this.instantiationService.createInstance(MarkdownRenderer, {});
+					const renderer = this.instantiationService.createInstance(MarkdownRenderer);
 					const renderedMarkdown = renderer.render(message, {
 						actionHandler: (link, mdStr) => {
 							openLinkFromMarkdown(this.openerService, link, mdStr.isTrusted);

--- a/src/vs/workbench/contrib/testing/browser/testResultsView/testResultsOutput.ts
+++ b/src/vs/workbench/contrib/testing/browser/testResultsView/testResultsOutput.ts
@@ -255,7 +255,7 @@ export class DiffContentProvider extends Disposable implements IPeekOutputRender
 
 export class MarkdownTestMessagePeek extends Disposable implements IPeekOutputRenderer {
 	private readonly markdown = new Lazy(
-		() => this.instantiationService.createInstance(MarkdownRenderer, {}),
+		() => this.instantiationService.createInstance(MarkdownRenderer),
 	);
 	private readonly rendered = this._register(new DisposableStore());
 

--- a/src/vs/workbench/contrib/testing/browser/testingExplorerView.ts
+++ b/src/vs/workbench/contrib/testing/browser/testingExplorerView.ts
@@ -1457,7 +1457,7 @@ class ErrorRenderer implements ITreeRenderer<TestTreeErrorMessage, FuzzyScore, I
 		@IHoverService private readonly hoverService: IHoverService,
 		@IInstantiationService instantionService: IInstantiationService,
 	) {
-		this.renderer = instantionService.createInstance(MarkdownRenderer, {});
+		this.renderer = instantionService.createInstance(MarkdownRenderer);
 	}
 
 	get templateId(): string {

--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.ts
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.ts
@@ -1540,7 +1540,7 @@ export class GettingStartedPage extends EditorPane {
 	}
 
 	private buildTelemetryFooter(parent: HTMLElement) {
-		const mdRenderer = this.instantiationService.createInstance(MarkdownRenderer, {});
+		const mdRenderer = this.instantiationService.createInstance(MarkdownRenderer);
 
 		const privacyStatementCopy = localize('privacy statement', "privacy statement");
 		const privacyStatementButton = `[${privacyStatementCopy}](command:workbench.action.openPrivacyStatementUrl)`;

--- a/src/vs/workbench/services/suggest/browser/simpleSuggestWidgetDetails.ts
+++ b/src/vs/workbench/services/suggest/browser/simpleSuggestWidgetDetails.ts
@@ -56,7 +56,7 @@ export class SimpleSuggestDetailsWidget {
 		this.domNode = dom.$('.suggest-details');
 		this.domNode.classList.add('no-docs');
 
-		this._markdownRenderer = instaService.createInstance(MarkdownRenderer, {});
+		this._markdownRenderer = instaService.createInstance(MarkdownRenderer);
 
 		this._body = dom.$('.body');
 


### PR DESCRIPTION
For #206228

This makes the MarkdownRenderer very close to a service interface. The next step will be converting it into a real service

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
