### PR TITLE
Move opener folder reveal logic into general workbench behavior

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatMarkdownRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatMarkdownRenderer.ts
@@ -8,16 +8,12 @@ import { IRenderedMarkdown, MarkdownRenderOptions } from '../../../../base/brows
 import { getDefaultHoverDelegate } from '../../../../base/browser/ui/hover/hoverDelegateFactory.js';
 import { IMarkdownString } from '../../../../base/common/htmlContent.js';
 import { DisposableStore } from '../../../../base/common/lifecycle.js';
-import { URI } from '../../../../base/common/uri.js';
 import { MarkdownRenderer } from '../../../../editor/browser/widget/markdownRenderer/browser/markdownRenderer.js';
 import { ILanguageService } from '../../../../editor/common/languages/language.js';
-import { ICommandService } from '../../../../platform/commands/common/commands.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
-import { IFileService } from '../../../../platform/files/common/files.js';
 import { IHoverService } from '../../../../platform/hover/browser/hover.js';
 import { IOpenerService } from '../../../../platform/opener/common/opener.js';
 import product from '../../../../platform/product/common/product.js';
-import { REVEAL_IN_EXPLORER_COMMAND_ID } from '../../files/browser/fileConstants.js';
 
 export const allowedChatMarkdownHtmlTags = Object.freeze([
 	'b',
@@ -70,8 +66,6 @@ export class ChatMarkdownRenderer extends MarkdownRenderer {
 		@IOpenerService openerService: IOpenerService,
 		@IConfigurationService configurationService: IConfigurationService,
 		@IHoverService private readonly hoverService: IHoverService,
-		@IFileService private readonly fileService: IFileService,
-		@ICommandService private readonly commandService: ICommandService,
 	) {
 		super(configurationService, languageService, openerService);
 	}
@@ -130,18 +124,5 @@ export class ChatMarkdownRenderer extends MarkdownRenderer {
 				store.dispose();
 			}
 		};
-	}
-
-	protected override async openMarkdownLink(link: string, markdown: IMarkdownString) {
-		try {
-			const uri = URI.parse(link);
-			if ((await this.fileService.stat(uri)).isDirectory) {
-				return this.commandService.executeCommand(REVEAL_IN_EXPLORER_COMMAND_ID, uri);
-			}
-		} catch {
-			// noop
-		}
-
-		return super.openMarkdownLink(link, markdown);
 	}
 }

--- a/src/vs/workbench/contrib/opener/browser/opener.contribution.ts
+++ b/src/vs/workbench/contrib/opener/browser/opener.contribution.ts
@@ -1,0 +1,47 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Disposable } from '../../../../base/common/lifecycle.js';
+import { URI } from '../../../../base/common/uri.js';
+import { ICommandService } from '../../../../platform/commands/common/commands.js';
+import { IFileService } from '../../../../platform/files/common/files.js';
+import { IOpener, IOpenerService, OpenExternalOptions, OpenInternalOptions } from '../../../../platform/opener/common/opener.js';
+import { IWorkspaceContextService } from '../../../../platform/workspace/common/workspace.js';
+import { registerWorkbenchContribution2, WorkbenchPhase } from '../../../common/contributions.js';
+import { REVEAL_IN_EXPLORER_COMMAND_ID } from '../../files/browser/fileConstants.js';
+
+class WorkbenchOpenerContribution extends Disposable implements IOpener {
+	public static readonly ID = 'workbench.contrib.opener';
+
+	constructor(
+		@IOpenerService openerService: IOpenerService,
+		@ICommandService private readonly commandService: ICommandService,
+		@IFileService private readonly fileService: IFileService,
+		@IWorkspaceContextService private readonly workspaceContextService: IWorkspaceContextService,
+	) {
+		super();
+
+		this._register(openerService.registerOpener(this));
+	}
+
+	async open(link: URI | string, options?: OpenInternalOptions | OpenExternalOptions): Promise<boolean> {
+		try {
+			const uri = typeof link === 'string' ? URI.parse(link) : link;
+			if (this.workspaceContextService.isInsideWorkspace(uri)) {
+				if ((await this.fileService.stat(uri)).isDirectory) {
+					await this.commandService.executeCommand(REVEAL_IN_EXPLORER_COMMAND_ID, uri);
+					return true;
+				}
+			}
+		} catch {
+			// noop
+		}
+
+		return false;
+	}
+}
+
+
+registerWorkbenchContribution2(WorkbenchOpenerContribution.ID, WorkbenchOpenerContribution, WorkbenchPhase.Eventually);

--- a/src/vs/workbench/workbench.common.main.ts
+++ b/src/vs/workbench/workbench.common.main.ts
@@ -421,5 +421,7 @@ import './contrib/dropOrPasteInto/browser/dropOrPasteInto.contribution.js';
 // Edit Telemetry
 import './contrib/editTelemetry/browser/editTelemetry.contribution.js';
 
+// Opener
+import './contrib/opener/browser/opener.contribution.js';
 
 //#endregion


### PR DESCRIPTION
This registers an opener for folders in the workspace. When you try opening a folder in the workspace, we reveal it in the explorer

Previously this was done on a case by case basis. I think it makes sense to always have this behavior at the workbench layer
