### PR TITLE
Replace `MarkdownRenderer`

### DIFF
--- a/src/vs/editor/browser/widget/markdownRenderer/browser/markdownRenderer.ts
+++ b/src/vs/editor/browser/widget/markdownRenderer/browser/markdownRenderer.ts
@@ -55,7 +55,7 @@ export interface IMarkdownRendererService extends IMarkdownRenderer {
 }
 
 
-class MarkdownRendererService implements IMarkdownRendererService {
+export class MarkdownRendererService implements IMarkdownRendererService {
 	declare readonly _serviceBrand: undefined;
 
 	private static _ttpTokenizer = createTrustedTypesPolicy('tokenizeToString', {

--- a/src/vs/editor/browser/widget/markdownRenderer/browser/markdownRenderer.ts
+++ b/src/vs/editor/browser/widget/markdownRenderer/browser/markdownRenderer.ts
@@ -20,16 +20,43 @@ import { applyFontInfo } from '../../../config/domFontInfo.js';
 import { ICodeEditor } from '../../../editorBrowser.js';
 import './renderedMarkdown.css';
 
+/**
+ * Renders markdown to HTML.
+ *
+ * This interface allows a upper level component to pass a custom markdown renderer to sub-components.
+ *
+ * If you want to render markdown content in a standard way, prefer using the {@linkcode IMarkdownRendererService}.
+ */
+export interface IMarkdownRenderer {
+	render(markdown: IMarkdownString, options?: MarkdownRenderOptions, outElement?: HTMLElement): IRenderedMarkdown;
+}
+
+
 export interface IMarkdownRendererExtraOptions {
 	readonly editor?: ICodeEditor;
 	readonly codeBlockFontSize?: string;
 }
 
+
+export const IMarkdownRendererService = createDecorator<IMarkdownRendererService>('markdownRendererService');
+
 /**
- * Markdown renderer that can render codeblocks with the editor mechanics. This
- * renderer should always be preferred.
+ * Service that renders markdown content in a standard manner.
+ *
+ * Unlike the lower-level {@linkcode renderMarkdown} function, this includes built-in support for features such as syntax
+ * highlighting of code blocks and link handling.
+ *
+ * This service should be preferred for rendering markdown in most cases.
  */
-export class MarkdownRenderer {
+export interface IMarkdownRendererService extends IMarkdownRenderer {
+	readonly _serviceBrand: undefined;
+
+	render(markdown: IMarkdownString, options?: MarkdownRenderOptions & IMarkdownRendererExtraOptions, outElement?: HTMLElement): IRenderedMarkdown;
+}
+
+
+class MarkdownRendererService implements IMarkdownRendererService {
+	declare readonly _serviceBrand: undefined;
 
 	private static _ttpTokenizer = createTrustedTypesPolicy('tokenizeToString', {
 		createHTML(html: string) {
@@ -46,7 +73,9 @@ export class MarkdownRenderer {
 	render(markdown: IMarkdownString, options?: MarkdownRenderOptions & IMarkdownRendererExtraOptions, outElement?: HTMLElement): IRenderedMarkdown {
 		const rendered = renderMarkdown(markdown, {
 			codeBlockRenderer: (alias, value) => this.renderCodeBlock(alias, value, options ?? {}),
-			actionHandler: (link, mdStr) => this.openMarkdownLink(link, mdStr),
+			actionHandler: (link, mdStr) => {
+				return openLinkFromMarkdown(this._openerService, link, mdStr.isTrusted);
+			},
 			...options,
 		}, outElement);
 		rendered.element.classList.add('rendered-markdown');
@@ -70,7 +99,7 @@ export class MarkdownRenderer {
 
 		const element = document.createElement('span');
 
-		element.innerHTML = (MarkdownRenderer._ttpTokenizer?.createHTML(html) ?? html) as string;
+		element.innerHTML = (MarkdownRendererService._ttpTokenizer?.createHTML(html) ?? html) as string;
 
 		// use "good" font
 		if (options.editor) {
@@ -86,45 +115,7 @@ export class MarkdownRenderer {
 
 		return element;
 	}
-
-	protected async openMarkdownLink(link: string, markdown: IMarkdownString) {
-		await openLinkFromMarkdown(this._openerService, link, markdown.isTrusted);
-	}
 }
-
-export const IMarkdownRendererService = createDecorator<IMarkdownRendererService>('markdownRendererService');
-
-export interface IMarkdownRendererService {
-	readonly _serviceBrand: undefined;
-
-	/**
-	 * Renders markdown with codeblocks with the editor mechanics.
-	 */
-	render(markdown: IMarkdownString, options?: MarkdownRenderOptions & IMarkdownRendererExtraOptions, outElement?: HTMLElement): IRenderedMarkdown;
-}
-
-
-class MarkdownRendererService implements IMarkdownRendererService {
-	declare readonly _serviceBrand: undefined;
-
-	constructor(
-		@IConfigurationService private readonly _configurationService: IConfigurationService,
-		@ILanguageService private readonly _languageService: ILanguageService,
-		@IOpenerService private readonly _openerService: IOpenerService,
-	) { }
-
-	render(markdown: IMarkdownString, options?: MarkdownRenderOptions & IMarkdownRendererExtraOptions, outElement?: HTMLElement): IRenderedMarkdown {
-		const renderer = new MarkdownRenderer(
-			this._configurationService,
-			this._languageService,
-			this._openerService
-		);
-		return renderer.render(markdown, options, outElement);
-	}
-}
-
-registerSingleton(IMarkdownRendererService, MarkdownRendererService, InstantiationType.Delayed);
-
 
 export async function openLinkFromMarkdown(openerService: IOpenerService, link: string, isTrusted: boolean | MarkdownStringTrustedOptions | undefined, skipValidation?: boolean): Promise<boolean> {
 	try {
@@ -151,3 +142,5 @@ function toAllowCommandsOption(isTrusted: boolean | MarkdownStringTrustedOptions
 
 	return false; // Block commands
 }
+
+registerSingleton(IMarkdownRendererService, MarkdownRendererService, InstantiationType.Delayed);

--- a/src/vs/workbench/contrib/chat/browser/chatContentMarkdownRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentMarkdownRenderer.ts
@@ -8,7 +8,7 @@ import { IRenderedMarkdown, MarkdownRenderOptions } from '../../../../base/brows
 import { getDefaultHoverDelegate } from '../../../../base/browser/ui/hover/hoverDelegateFactory.js';
 import { IMarkdownString } from '../../../../base/common/htmlContent.js';
 import { DisposableStore } from '../../../../base/common/lifecycle.js';
-import { MarkdownRenderer } from '../../../../editor/browser/widget/markdownRenderer/browser/markdownRenderer.js';
+import { IMarkdownRenderer, IMarkdownRendererService } from '../../../../editor/browser/widget/markdownRenderer/browser/markdownRenderer.js';
 import { ILanguageService } from '../../../../editor/common/languages/language.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { IHoverService } from '../../../../platform/hover/browser/hover.js';
@@ -58,19 +58,18 @@ export const allowedChatMarkdownHtmlTags = Object.freeze([
 ]);
 
 /**
- * This wraps the MarkdownRenderer and applies sanitizer options needed for Chat.
+ * This wraps the MarkdownRenderer and applies sanitizer options needed for chat content.
  */
-export class ChatMarkdownRenderer extends MarkdownRenderer {
+export class ChatContentMarkdownRenderer implements IMarkdownRenderer {
 	constructor(
 		@ILanguageService languageService: ILanguageService,
 		@IOpenerService openerService: IOpenerService,
 		@IConfigurationService configurationService: IConfigurationService,
 		@IHoverService private readonly hoverService: IHoverService,
-	) {
-		super(configurationService, languageService, openerService);
-	}
+		@IMarkdownRendererService private readonly markdownRendererService: IMarkdownRendererService,
+	) { }
 
-	override render(markdown: IMarkdownString, options?: MarkdownRenderOptions, outElement?: HTMLElement): IRenderedMarkdown {
+	render(markdown: IMarkdownString, options?: MarkdownRenderOptions, outElement?: HTMLElement): IRenderedMarkdown {
 		options = {
 			...options,
 			sanitizerConfig: {
@@ -93,7 +92,7 @@ export class ChatMarkdownRenderer extends MarkdownRenderer {
 				value: `<body>\n\n${markdown.value}</body>`,
 			}
 			: markdown;
-		const result = super.render(mdWithBody, options, outElement);
+		const result = this.markdownRendererService.render(mdWithBody, options, outElement);
 
 		// In some cases, the renderer can return top level text nodes  but our CSS expects
 		// all text to be in a <p> for margin to be applied properly.

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/chatConfirmationWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/chatConfirmationWidget.ts
@@ -11,7 +11,7 @@ import { Emitter, Event } from '../../../../../base/common/event.js';
 import { IMarkdownString, MarkdownString } from '../../../../../base/common/htmlContent.js';
 import { Disposable, DisposableStore, MutableDisposable } from '../../../../../base/common/lifecycle.js';
 import type { ThemeIcon } from '../../../../../base/common/themables.js';
-import { MarkdownRenderer } from '../../../../../editor/browser/widget/markdownRenderer/browser/markdownRenderer.js';
+import { IMarkdownRendererService } from '../../../../../editor/browser/widget/markdownRenderer/browser/markdownRenderer.js';
 import { localize } from '../../../../../nls.js';
 import { MenuWorkbenchToolBar } from '../../../../../platform/actions/browser/toolbar.js';
 import { MenuId } from '../../../../../platform/actions/common/actions.js';
@@ -76,7 +76,7 @@ export class ChatQueryTitlePart extends Disposable {
 		private readonly element: HTMLElement,
 		private _title: IMarkdownString | string,
 		subtitle: string | IMarkdownString | undefined,
-		private readonly _renderer: MarkdownRenderer,
+		@IMarkdownRendererService private readonly _renderer: IMarkdownRendererService,
 	) {
 		super();
 
@@ -127,7 +127,6 @@ abstract class BaseSimpleChatConfirmationWidget<T> extends Disposable {
 	}
 
 	private readonly messageElement: HTMLElement;
-	protected readonly markdownRenderer: MarkdownRenderer;
 	private readonly title: string | IMarkdownString;
 
 	private readonly silent: boolean;
@@ -136,6 +135,7 @@ abstract class BaseSimpleChatConfirmationWidget<T> extends Disposable {
 	constructor(
 		options: IChatConfirmationWidgetOptions<T>,
 		@IInstantiationService protected readonly instantiationService: IInstantiationService,
+		@IMarkdownRendererService protected readonly _markdownRendererService: IMarkdownRendererService,
 		@IContextMenuService contextMenuService: IContextMenuService,
 		@IConfigurationService private readonly _configurationService: IConfigurationService,
 		@IHostService private readonly _hostService: IHostService,
@@ -161,14 +161,12 @@ abstract class BaseSimpleChatConfirmationWidget<T> extends Disposable {
 		]);
 		configureAccessibilityContainer(elements.container, title, message);
 		this._domNode = elements.root;
-		this.markdownRenderer = this.instantiationService.createInstance(MarkdownRenderer);
 
 		const titlePart = this._register(instantiationService.createInstance(
 			ChatQueryTitlePart,
 			elements.title,
 			title,
-			subtitle,
-			this.markdownRenderer,
+			subtitle
 		));
 
 		this._register(titlePart.onDidChangeHeight(() => this._onDidChangeHeight.fire()));
@@ -284,19 +282,20 @@ export class SimpleChatConfirmationWidget<T> extends BaseSimpleChatConfirmationW
 		private readonly _container: HTMLElement,
 		options: IChatConfirmationWidgetOptions<T>,
 		@IInstantiationService instantiationService: IInstantiationService,
+		@IMarkdownRendererService markdownRendererService: IMarkdownRendererService,
 		@IContextMenuService contextMenuService: IContextMenuService,
 		@IConfigurationService configurationService: IConfigurationService,
 		@IHostService hostService: IHostService,
 		@IViewsService viewsService: IViewsService,
 		@IContextKeyService contextKeyService: IContextKeyService,
 	) {
-		super(options, instantiationService, contextMenuService, configurationService, hostService, viewsService, contextKeyService);
+		super(options, instantiationService, markdownRendererService, contextMenuService, configurationService, hostService, viewsService, contextKeyService);
 		this.updateMessage(options.message);
 	}
 
 	public updateMessage(message: string | IMarkdownString): void {
 		this._renderedMessage?.remove();
-		const renderedMessage = this._register(this.markdownRenderer.render(
+		const renderedMessage = this._register(this._markdownRendererService.render(
 			typeof message === 'string' ? new MarkdownString(message) : message,
 			{ asyncRenderCallback: () => this._onDidChangeHeight.fire() }
 		));
@@ -337,7 +336,6 @@ abstract class BaseChatConfirmationWidget<T> extends Disposable {
 	}
 
 	private readonly messageElement: HTMLElement;
-	protected readonly markdownRenderer: MarkdownRenderer;
 	private readonly title: string | IMarkdownString;
 
 	private readonly notification = this._register(new MutableDisposable<DisposableStore>());
@@ -345,6 +343,7 @@ abstract class BaseChatConfirmationWidget<T> extends Disposable {
 	constructor(
 		options: IChatConfirmationWidget2Options<T>,
 		@IInstantiationService protected readonly instantiationService: IInstantiationService,
+		@IMarkdownRendererService protected readonly markdownRendererService: IMarkdownRendererService,
 		@IContextMenuService private readonly contextMenuService: IContextMenuService,
 		@IConfigurationService private readonly _configurationService: IConfigurationService,
 		@IHostService private readonly _hostService: IHostService,
@@ -374,14 +373,11 @@ abstract class BaseChatConfirmationWidget<T> extends Disposable {
 		this._domNode = elements.root;
 		this._buttonsDomNode = elements.buttons;
 
-		this.markdownRenderer = this.instantiationService.createInstance(MarkdownRenderer);
-
 		const titlePart = this._register(instantiationService.createInstance(
 			ChatQueryTitlePart,
 			elements.title,
 			new MarkdownString(icon ? `$(${icon.id}) ${typeof title === 'string' ? title : title.value}` : typeof title === 'string' ? title : title.value),
 			subtitle,
-			this.markdownRenderer,
 		));
 
 		this._register(titlePart.onDidChangeHeight(() => this._onDidChangeHeight.fire()));
@@ -456,7 +452,7 @@ abstract class BaseChatConfirmationWidget<T> extends Disposable {
 
 	protected renderMessage(element: HTMLElement | IMarkdownString | string, listContainer: HTMLElement): void {
 		if (!dom.isHTMLElement(element)) {
-			const messageElement = this._register(this.markdownRenderer.render(
+			const messageElement = this._register(this.markdownRendererService.render(
 				typeof element === 'string' ? new MarkdownString(element) : element,
 				{ asyncRenderCallback: () => this._onDidChangeHeight.fire() }
 			));
@@ -512,19 +508,20 @@ export class ChatConfirmationWidget<T> extends BaseChatConfirmationWidget<T> {
 		private readonly _container: HTMLElement,
 		options: IChatConfirmationWidget2Options<T>,
 		@IInstantiationService instantiationService: IInstantiationService,
+		@IMarkdownRendererService markdownRendererService: IMarkdownRendererService,
 		@IContextMenuService contextMenuService: IContextMenuService,
 		@IConfigurationService configurationService: IConfigurationService,
 		@IHostService hostService: IHostService,
 		@IViewsService viewsService: IViewsService,
 		@IContextKeyService contextKeyService: IContextKeyService,
 	) {
-		super(options, instantiationService, contextMenuService, configurationService, hostService, viewsService, contextKeyService);
+		super(options, instantiationService, markdownRendererService, contextMenuService, configurationService, hostService, viewsService, contextKeyService);
 		this.renderMessage(options.message, this._container);
 	}
 
 	public updateMessage(message: string | IMarkdownString): void {
 		this._renderedMessage?.remove();
-		const renderedMessage = this._register(this.markdownRenderer.render(
+		const renderedMessage = this._register(this.markdownRendererService.render(
 			typeof message === 'string' ? new MarkdownString(message) : message,
 			{ asyncRenderCallback: () => this._onDidChangeHeight.fire() }
 		));
@@ -537,13 +534,14 @@ export class ChatCustomConfirmationWidget<T> extends BaseChatConfirmationWidget<
 		container: HTMLElement,
 		options: IChatConfirmationWidget2Options<T>,
 		@IInstantiationService instantiationService: IInstantiationService,
+		@IMarkdownRendererService markdownRendererService: IMarkdownRendererService,
 		@IContextMenuService contextMenuService: IContextMenuService,
 		@IConfigurationService configurationService: IConfigurationService,
 		@IHostService hostService: IHostService,
 		@IViewsService viewsService: IViewsService,
 		@IContextKeyService contextKeyService: IContextKeyService,
 	) {
-		super(options, instantiationService, contextMenuService, configurationService, hostService, viewsService, contextKeyService);
+		super(options, instantiationService, markdownRendererService, contextMenuService, configurationService, hostService, viewsService, contextKeyService);
 		this.renderMessage(options.message, container);
 	}
 }

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/chatErrorConfirmationPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/chatErrorConfirmationPart.ts
@@ -8,7 +8,7 @@ import { Button, IButtonOptions } from '../../../../../base/browser/ui/button/bu
 import { Emitter } from '../../../../../base/common/event.js';
 import { IMarkdownString } from '../../../../../base/common/htmlContent.js';
 import { Disposable, IDisposable } from '../../../../../base/common/lifecycle.js';
-import { MarkdownRenderer } from '../../../../../editor/browser/widget/markdownRenderer/browser/markdownRenderer.js';
+import { IMarkdownRenderer } from '../../../../../editor/browser/widget/markdownRenderer/browser/markdownRenderer.js';
 import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
 import { defaultButtonStyles } from '../../../../../platform/theme/browser/defaultStyles.js';
 import { ChatErrorLevel, IChatResponseErrorDetailsConfirmationButton, IChatSendRequestOptions, IChatService } from '../../common/chatService.js';
@@ -30,7 +30,7 @@ export class ChatErrorConfirmationContentPart extends Disposable implements ICha
 		content: IMarkdownString,
 		private readonly errorDetails: IChatErrorDetailsPart,
 		confirmationButtons: IChatResponseErrorDetailsConfirmationButton[],
-		renderer: MarkdownRenderer,
+		renderer: IMarkdownRenderer,
 		context: IChatContentPartRenderContext,
 		@IInstantiationService instantiationService: IInstantiationService,
 		@IChatWidgetService chatWidgetService: IChatWidgetService,

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/chatErrorContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/chatErrorContentPart.ts
@@ -8,7 +8,7 @@ import { renderIcon } from '../../../../../base/browser/ui/iconLabel/iconLabels.
 import { Codicon } from '../../../../../base/common/codicons.js';
 import { IMarkdownString } from '../../../../../base/common/htmlContent.js';
 import { Disposable } from '../../../../../base/common/lifecycle.js';
-import { MarkdownRenderer } from '../../../../../editor/browser/widget/markdownRenderer/browser/markdownRenderer.js';
+import { IMarkdownRenderer } from '../../../../../editor/browser/widget/markdownRenderer/browser/markdownRenderer.js';
 import { ChatErrorLevel } from '../../common/chatService.js';
 import { IChatRendererContent } from '../../common/chatViewModel.js';
 import { IChatContentPart } from './chatContentParts.js';
@@ -22,7 +22,7 @@ export class ChatErrorContentPart extends Disposable implements IChatContentPart
 		kind: ChatErrorLevel,
 		content: IMarkdownString,
 		private readonly errorDetails: IChatRendererContent,
-		renderer: MarkdownRenderer,
+		renderer: IMarkdownRenderer,
 	) {
 		super();
 
@@ -40,7 +40,7 @@ export class ChatErrorWidget extends Disposable {
 	constructor(
 		kind: ChatErrorLevel,
 		content: IMarkdownString,
-		renderer: MarkdownRenderer,
+		renderer: IMarkdownRenderer,
 	) {
 		super();
 

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/chatMarkdownContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/chatMarkdownContentPart.ts
@@ -21,7 +21,7 @@ import { ScrollbarVisibility } from '../../../../../base/common/scrollable.js';
 import { equalsIgnoreCase } from '../../../../../base/common/strings.js';
 import { ThemeIcon } from '../../../../../base/common/themables.js';
 import { URI } from '../../../../../base/common/uri.js';
-import { MarkdownRenderer } from '../../../../../editor/browser/widget/markdownRenderer/browser/markdownRenderer.js';
+import { IMarkdownRenderer } from '../../../../../editor/browser/widget/markdownRenderer/browser/markdownRenderer.js';
 import { Range } from '../../../../../editor/common/core/range.js';
 import { ILanguageService } from '../../../../../editor/common/languages/language.js';
 import { ITextModel } from '../../../../../editor/common/model.js';
@@ -52,7 +52,7 @@ import { ChatConfiguration } from '../../common/constants.js';
 import { IChatCodeBlockInfo } from '../chat.js';
 import { IChatRendererDelegate } from '../chatListRenderer.js';
 import { ChatMarkdownDecorationsRenderer } from '../chatMarkdownDecorationsRenderer.js';
-import { allowedChatMarkdownHtmlTags } from '../chatMarkdownRenderer.js';
+import { allowedChatMarkdownHtmlTags } from '../chatContentMarkdownRenderer.js';
 import { ChatEditorOptions } from '../chatOptions.js';
 import { CodeBlockPart, ICodeBlockData, ICodeBlockRenderOptions, localFileLanguageId, parseLocalFileData } from '../codeBlockPart.js';
 import { IDisposableReference, ResourcePool } from './chatCollections.js';
@@ -88,7 +88,7 @@ export class ChatMarkdownContentPart extends Disposable implements IChatContentP
 		private readonly editorPool: EditorPool,
 		fillInIncompleteTokens = false,
 		codeBlockStartIndex = 0,
-		renderer: MarkdownRenderer,
+		renderer: IMarkdownRenderer,
 		markdownRenderOptions: MarkdownRenderOptions | undefined,
 		currentWidth: number,
 		private readonly codeBlockModelCollection: CodeBlockModelCollection,

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/chatMcpServersInteractionContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/chatMcpServersInteractionContentPart.ts
@@ -12,7 +12,7 @@ import { Lazy } from '../../../../../base/common/lazy.js';
 import { Disposable, IDisposable, MutableDisposable } from '../../../../../base/common/lifecycle.js';
 import { autorun } from '../../../../../base/common/observable.js';
 import { ThemeIcon } from '../../../../../base/common/themables.js';
-import { MarkdownRenderer, openLinkFromMarkdown } from '../../../../../editor/browser/widget/markdownRenderer/browser/markdownRenderer.js';
+import { IMarkdownRendererService, openLinkFromMarkdown } from '../../../../../editor/browser/widget/markdownRenderer/browser/markdownRenderer.js';
 import { IRenderedMarkdown } from '../../../../../base/browser/markdownRenderer.js';
 import { localize } from '../../../../../nls.js';
 import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
@@ -34,7 +34,6 @@ export class ChatMcpServersInteractionContentPart extends Disposable implements 
 	private workingProgressPart: ChatProgressContentPart | undefined;
 	private interactionContainer: HTMLElement | undefined;
 	private readonly interactionMd = this._register(new MutableDisposable<IRenderedMarkdown>());
-	private readonly markdownRenderer: MarkdownRenderer;
 	private readonly showSpecificServersScheduler = this._register(new RunOnceScheduler(() => this.updateDetailedProgress(this.data.state!.get()), 2500));
 	private readonly previousParts = new Lazy(() => {
 		if (!isResponseVM(this.context.element)) {
@@ -53,11 +52,11 @@ export class ChatMcpServersInteractionContentPart extends Disposable implements 
 		@IMcpService private readonly mcpService: IMcpService,
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
 		@IOpenerService private readonly _openerService: IOpenerService,
+		@IMarkdownRendererService private readonly _markdownRendererService: IMarkdownRendererService,
 	) {
 		super();
 
 		this.domNode = dom.$('.chat-mcp-servers-interaction');
-		this.markdownRenderer = this.instantiationService.createInstance(MarkdownRenderer);
 
 		// Listen to autostart state changes if available
 		if (data.state) {
@@ -139,7 +138,7 @@ export class ChatMcpServersInteractionContentPart extends Disposable implements 
 			this.workingProgressPart = this._register(this.instantiationService.createInstance(
 				ChatProgressContentPart,
 				{ kind: 'progressMessage', content },
-				this.markdownRenderer,
+				this._markdownRendererService,
 				this.context,
 				true, // forceShowSpinner
 				true, // forceShowMessage
@@ -181,7 +180,7 @@ export class ChatMcpServersInteractionContentPart extends Disposable implements 
 			? localize('mcp.start.single', 'The MCP server {0} may have new tools and requires interaction to start. [Start it now?]({1})', links, '#start')
 			: localize('mcp.start.multiple', 'The MCP servers {0} may have new tools and require interaction to start. [Start them now?]({1})', links, '#start');
 		const str = new MarkdownString(content, { isTrusted: true });
-		const messageMd = this.interactionMd.value = this.markdownRenderer.render(str, {
+		const messageMd = this.interactionMd.value = this._markdownRendererService.render(str, {
 			asyncRenderCallback: () => this._onDidChangeHeight.fire(),
 			actionHandler: (content) => {
 				if (!content.startsWith('command:')) {

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/chatProgressContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/chatProgressContentPart.ts
@@ -9,7 +9,7 @@ import { Codicon } from '../../../../../base/common/codicons.js';
 import { MarkdownString } from '../../../../../base/common/htmlContent.js';
 import { Disposable, MutableDisposable } from '../../../../../base/common/lifecycle.js';
 import { ThemeIcon } from '../../../../../base/common/themables.js';
-import { MarkdownRenderer } from '../../../../../editor/browser/widget/markdownRenderer/browser/markdownRenderer.js';
+import { IMarkdownRenderer } from '../../../../../editor/browser/widget/markdownRenderer/browser/markdownRenderer.js';
 import { IRenderedMarkdown } from '../../../../../base/browser/markdownRenderer.js';
 import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
 import { localize } from '../../../../../nls.js';
@@ -31,7 +31,7 @@ export class ChatProgressContentPart extends Disposable implements IChatContentP
 
 	constructor(
 		progress: IChatProgressMessage | IChatTask | IChatTaskSerialized,
-		private readonly renderer: MarkdownRenderer,
+		private readonly chatContentMarkdownRenderer: IMarkdownRenderer,
 		context: IChatContentPartRenderContext,
 		forceShowSpinner: boolean | undefined,
 		forceShowMessage: boolean | undefined,
@@ -57,7 +57,7 @@ export class ChatProgressContentPart extends Disposable implements IChatContentP
 			alert(progress.content.value);
 		}
 		const codicon = icon ? icon : this.showSpinner ? ThemeIcon.modify(Codicon.loading, 'spin') : Codicon.check;
-		const result = this.renderer.render(progress.content);
+		const result = this.chatContentMarkdownRenderer.render(progress.content);
 		result.element.classList.add('progress-step');
 		renderFileWidgets(result.element, this.instantiationService, this.chatMarkdownAnchorService, this._store);
 
@@ -75,7 +75,7 @@ export class ChatProgressContentPart extends Disposable implements IChatContentP
 		}
 
 		// Render the new message
-		const result = this._register(this.renderer.render(content));
+		const result = this._register(this.chatContentMarkdownRenderer.render(content));
 		result.element.classList.add('progress-step');
 		renderFileWidgets(result.element, this.instantiationService, this.chatMarkdownAnchorService, this._store);
 
@@ -127,7 +127,7 @@ export class ChatCustomProgressPart {
 export class ChatWorkingProgressContentPart extends ChatProgressContentPart implements IChatContentPart {
 	constructor(
 		_workingProgress: { kind: 'working' },
-		renderer: MarkdownRenderer,
+		chatContentMarkdownRenderer: IMarkdownRenderer,
 		context: IChatContentPartRenderContext,
 		@IInstantiationService instantiationService: IInstantiationService,
 		@IChatMarkdownAnchorService chatMarkdownAnchorService: IChatMarkdownAnchorService,
@@ -137,7 +137,7 @@ export class ChatWorkingProgressContentPart extends ChatProgressContentPart impl
 			kind: 'progressMessage',
 			content: new MarkdownString().appendText(localize('workingMessage', "Working..."))
 		};
-		super(progressMessage, renderer, context, undefined, undefined, undefined, instantiationService, chatMarkdownAnchorService, configurationService);
+		super(progressMessage, chatContentMarkdownRenderer, context, undefined, undefined, undefined, instantiationService, chatMarkdownAnchorService, configurationService);
 	}
 
 	override hasSameContent(other: IChatRendererContent, followingContent: IChatRendererContent[], element: ChatTreeItem): boolean {

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/chatQuotaExceededPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/chatQuotaExceededPart.ts
@@ -12,7 +12,7 @@ import { MarkdownString } from '../../../../../base/common/htmlContent.js';
 import { Disposable, IDisposable } from '../../../../../base/common/lifecycle.js';
 import { ThemeIcon } from '../../../../../base/common/themables.js';
 import { assertType } from '../../../../../base/common/types.js';
-import { MarkdownRenderer } from '../../../../../editor/browser/widget/markdownRenderer/browser/markdownRenderer.js';
+import { IMarkdownRenderer } from '../../../../../editor/browser/widget/markdownRenderer/browser/markdownRenderer.js';
 import { localize } from '../../../../../nls.js';
 import { ICommandService } from '../../../../../platform/commands/common/commands.js';
 import { ITelemetryService } from '../../../../../platform/telemetry/common/telemetry.js';
@@ -47,7 +47,7 @@ export class ChatQuotaExceededPart extends Disposable implements IChatContentPar
 	constructor(
 		element: IChatResponseViewModel,
 		private readonly content: IChatErrorDetailsPart,
-		renderer: MarkdownRenderer,
+		renderer: IMarkdownRenderer,
 		@IChatWidgetService chatWidgetService: IChatWidgetService,
 		@ICommandService commandService: ICommandService,
 		@ITelemetryService telemetryService: ITelemetryService,

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/chatTaskContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/chatTaskContentPart.ts
@@ -6,7 +6,7 @@
 import * as dom from '../../../../../base/browser/dom.js';
 import { Event } from '../../../../../base/common/event.js';
 import { Disposable, IDisposable } from '../../../../../base/common/lifecycle.js';
-import { MarkdownRenderer } from '../../../../../editor/browser/widget/markdownRenderer/browser/markdownRenderer.js';
+import { IMarkdownRenderer } from '../../../../../editor/browser/widget/markdownRenderer/browser/markdownRenderer.js';
 import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
 import { IChatProgressRenderableResponseContent } from '../../common/chatModel.js';
 import { IChatTask, IChatTaskSerialized } from '../../common/chatService.js';
@@ -23,7 +23,7 @@ export class ChatTaskContentPart extends Disposable implements IChatContentPart 
 	constructor(
 		private readonly task: IChatTask | IChatTaskSerialized,
 		contentReferencesListPool: CollapsibleListPool,
-		renderer: MarkdownRenderer,
+		chatContentMarkdownRenderer: IMarkdownRenderer,
 		context: IChatContentPartRenderContext,
 		@IInstantiationService instantiationService: IInstantiationService,
 	) {
@@ -41,7 +41,7 @@ export class ChatTaskContentPart extends Disposable implements IChatContentPart 
 				true;
 			this.isSettled = isSettled;
 			const showSpinner = !isSettled && !context.element.isComplete;
-			const progressPart = this._register(instantiationService.createInstance(ChatProgressContentPart, task, renderer, context, showSpinner, true, undefined));
+			const progressPart = this._register(instantiationService.createInstance(ChatProgressContentPart, task, chatContentMarkdownRenderer, context, showSpinner, true, undefined));
 			this.domNode = progressPart.domNode;
 			this.onDidChangeHeight = Event.None;
 		}

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/chatThinkingContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/chatThinkingContentPart.ts
@@ -11,7 +11,7 @@ import { ChatTreeItem } from '../chat.js';
 import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 import { MarkdownString } from '../../../../../base/common/htmlContent.js';
-import { MarkdownRenderer } from '../../../../../editor/browser/widget/markdownRenderer/browser/markdownRenderer.js';
+import { IMarkdownRendererService } from '../../../../../editor/browser/widget/markdownRenderer/browser/markdownRenderer.js';
 import { IRenderedMarkdown } from '../../../../../base/browser/markdownRenderer.js';
 import { ChatCollapsibleContentPart } from './chatCollapsibleContentPart.js';
 import { localize } from '../../../../../nls.js';
@@ -41,7 +41,6 @@ export class ChatThinkingContentPart extends ChatCollapsibleContentPart implemen
 	private currentThinkingValue: string;
 	private currentTitle: string;
 	private defaultTitle = localize('chat.thinking.header', 'Thinking...');
-	private readonly renderer: MarkdownRenderer;
 	private textContainer!: HTMLElement;
 	private markdownResult: IRenderedMarkdown | undefined;
 	private wrapper!: HTMLElement;
@@ -60,6 +59,7 @@ export class ChatThinkingContentPart extends ChatCollapsibleContentPart implemen
 		context: IChatContentPartRenderContext,
 		@IInstantiationService instantiationService: IInstantiationService,
 		@IConfigurationService private readonly configurationService: IConfigurationService,
+		@IMarkdownRendererService private readonly markdownRendererService: IMarkdownRendererService,
 	) {
 		const initialText = extractTextFromPart(content);
 		const extractedTitle = extractTitleFromThinkingContent(initialText)
@@ -67,7 +67,6 @@ export class ChatThinkingContentPart extends ChatCollapsibleContentPart implemen
 
 		super(extractedTitle, context);
 
-		this.renderer = instantiationService.createInstance(MarkdownRenderer);
 		this.id = content.id;
 
 		const mode = this.configurationService.getValue<string>('chat.agent.thinkingStyle') ?? 'none';
@@ -222,7 +221,7 @@ export class ChatThinkingContentPart extends ChatCollapsibleContentPart implemen
 		}
 
 		clearNode(this.textContainer);
-		this.markdownResult = this._register(this.renderer.render(new MarkdownString(cleanedContent)));
+		this.markdownResult = this._register(this.markdownRendererService.render(new MarkdownString(cleanedContent)));
 		this.textContainer.appendChild(this.markdownResult.element);
 	}
 

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/chatToolInputOutputContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/chatToolInputOutputContentPart.ts
@@ -14,7 +14,6 @@ import { basename, joinPath } from '../../../../../base/common/resources.js';
 import { ThemeIcon } from '../../../../../base/common/themables.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { generateUuid } from '../../../../../base/common/uuid.js';
-import { MarkdownRenderer } from '../../../../../editor/browser/widget/markdownRenderer/browser/markdownRenderer.js';
 import { ITextModel } from '../../../../../editor/common/model.js';
 import { localize, localize2 } from '../../../../../nls.js';
 import { MenuWorkbenchToolBar } from '../../../../../platform/actions/browser/toolbar.js';
@@ -120,7 +119,6 @@ export class ChatCollapsibleInputOutputContentPart extends Disposable {
 			titleEl.root,
 			title,
 			subtitle,
-			_instantiationService.createInstance(MarkdownRenderer),
 		));
 		this._register(titlePart.onDidChangeHeight(() => this._onDidChangeHeight.fire()));
 

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatTerminalToolConfirmationSubPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatTerminalToolConfirmationSubPart.ts
@@ -16,7 +16,7 @@ import Severity from '../../../../../../base/common/severity.js';
 import { isObject } from '../../../../../../base/common/types.js';
 import { URI } from '../../../../../../base/common/uri.js';
 import { generateUuid } from '../../../../../../base/common/uuid.js';
-import { MarkdownRenderer } from '../../../../../../editor/browser/widget/markdownRenderer/browser/markdownRenderer.js';
+import { IMarkdownRenderer } from '../../../../../../editor/browser/widget/markdownRenderer/browser/markdownRenderer.js';
 import { ILanguageService } from '../../../../../../editor/common/languages/language.js';
 import { IModelService } from '../../../../../../editor/common/services/model.js';
 import { ITextModelService } from '../../../../../../editor/common/services/resolverService.js';
@@ -69,7 +69,7 @@ export class ChatTerminalToolConfirmationSubPart extends BaseChatToolInvocationS
 		toolInvocation: IChatToolInvocation,
 		terminalData: IChatTerminalToolInvocationData | ILegacyChatTerminalToolInvocationData,
 		private readonly context: IChatContentPartRenderContext,
-		private readonly renderer: MarkdownRenderer,
+		private readonly renderer: IMarkdownRenderer,
 		private readonly editorPool: EditorPool,
 		private readonly currentWidthDelegate: () => number,
 		private readonly codeBlockModelCollection: CodeBlockModelCollection,

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart.ts
@@ -6,9 +6,8 @@
 import { h } from '../../../../../../base/browser/dom.js';
 import { Codicon } from '../../../../../../base/common/codicons.js';
 import { isMarkdownString, MarkdownString } from '../../../../../../base/common/htmlContent.js';
-import { MarkdownRenderer } from '../../../../../../editor/browser/widget/markdownRenderer/browser/markdownRenderer.js';
+import { IMarkdownRenderer } from '../../../../../../editor/browser/widget/markdownRenderer/browser/markdownRenderer.js';
 import { IInstantiationService } from '../../../../../../platform/instantiation/common/instantiation.js';
-import { IOpenerService } from '../../../../../../platform/opener/common/opener.js';
 import { IPreferencesService, type IOpenSettingsOptions } from '../../../../../services/preferences/common/preferences.js';
 import { migrateLegacyTerminalToolSpecificData } from '../../../common/chat.js';
 import { IChatToolInvocation, IChatToolInvocationSerialized, type IChatMarkdownContent, type IChatTerminalToolInvocationData, type ILegacyChatTerminalToolInvocationData } from '../../../common/chatService.js';
@@ -38,13 +37,12 @@ export class ChatTerminalToolProgressPart extends BaseChatToolInvocationSubPart 
 		toolInvocation: IChatToolInvocation | IChatToolInvocationSerialized,
 		terminalData: IChatTerminalToolInvocationData | ILegacyChatTerminalToolInvocationData,
 		context: IChatContentPartRenderContext,
-		renderer: MarkdownRenderer,
+		renderer: IMarkdownRenderer,
 		editorPool: EditorPool,
 		currentWidthDelegate: () => number,
 		codeBlockStartIndex: number,
 		codeBlockModelCollection: CodeBlockModelCollection,
 		@IInstantiationService instantiationService: IInstantiationService,
-		@IOpenerService openerService: IOpenerService,
 	) {
 		super(toolInvocation);
 
@@ -57,13 +55,11 @@ export class ChatTerminalToolProgressPart extends BaseChatToolInvocationSubPart 
 
 		const command = terminalData.commandLine.userEdited ?? terminalData.commandLine.toolEdited ?? terminalData.commandLine.original;
 
-		const markdownRenderer = instantiationService.createInstance(MarkdownRenderer);
 		const titlePart = this._register(instantiationService.createInstance(
 			ChatQueryTitlePart,
 			elements.title,
 			new MarkdownString(`$(${Codicon.terminal.id})\n\n\`\`\`${terminalData.language}\n${command}\n\`\`\``, { supportThemeIcons: true }),
 			undefined,
-			markdownRenderer,
 		));
 		this._register(titlePart.onDidChangeHeight(() => this._onDidChangeHeight.fire()));
 

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatToolConfirmationSubPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatToolConfirmationSubPart.ts
@@ -12,7 +12,7 @@ import { count } from '../../../../../../base/common/strings.js';
 import { isEmptyObject } from '../../../../../../base/common/types.js';
 import { generateUuid } from '../../../../../../base/common/uuid.js';
 import { ElementSizeObserver } from '../../../../../../editor/browser/config/elementSizeObserver.js';
-import { MarkdownRenderer } from '../../../../../../editor/browser/widget/markdownRenderer/browser/markdownRenderer.js';
+import { IMarkdownRenderer } from '../../../../../../editor/browser/widget/markdownRenderer/browser/markdownRenderer.js';
 import { ILanguageService } from '../../../../../../editor/common/languages/language.js';
 import { IModelService } from '../../../../../../editor/common/services/model.js';
 import { localize } from '../../../../../../nls.js';
@@ -48,7 +48,7 @@ export class ToolConfirmationSubPart extends BaseChatToolInvocationSubPart {
 	constructor(
 		toolInvocation: IChatToolInvocation,
 		private readonly context: IChatContentPartRenderContext,
-		private readonly renderer: MarkdownRenderer,
+		private readonly renderer: IMarkdownRenderer,
 		private readonly editorPool: EditorPool,
 		private readonly currentWidthDelegate: () => number,
 		private readonly codeBlockModelCollection: CodeBlockModelCollection,

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatToolInvocationPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatToolInvocationPart.ts
@@ -7,7 +7,7 @@ import * as dom from '../../../../../../base/browser/dom.js';
 import { Emitter } from '../../../../../../base/common/event.js';
 import { markdownCommandLink, MarkdownString } from '../../../../../../base/common/htmlContent.js';
 import { Disposable, DisposableStore, IDisposable } from '../../../../../../base/common/lifecycle.js';
-import { MarkdownRenderer } from '../../../../../../editor/browser/widget/markdownRenderer/browser/markdownRenderer.js';
+import { IMarkdownRenderer } from '../../../../../../editor/browser/widget/markdownRenderer/browser/markdownRenderer.js';
 import { localize } from '../../../../../../nls.js';
 import { IInstantiationService } from '../../../../../../platform/instantiation/common/instantiation.js';
 import { IChatToolInvocation, IChatToolInvocationSerialized, ToolConfirmKind } from '../../../common/chatService.js';
@@ -47,7 +47,7 @@ export class ChatToolInvocationPart extends Disposable implements IChatContentPa
 	constructor(
 		private readonly toolInvocation: IChatToolInvocation | IChatToolInvocationSerialized,
 		private readonly context: IChatContentPartRenderContext,
-		private readonly renderer: MarkdownRenderer,
+		private readonly renderer: IMarkdownRenderer,
 		private readonly listPool: CollapsibleListPool,
 		private readonly editorPool: EditorPool,
 		private readonly currentWidthDelegate: () => number,

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatToolProgressPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatToolProgressPart.ts
@@ -7,7 +7,7 @@ import * as dom from '../../../../../../base/browser/dom.js';
 import { status } from '../../../../../../base/browser/ui/aria/aria.js';
 import { IMarkdownString, MarkdownString } from '../../../../../../base/common/htmlContent.js';
 import { autorun } from '../../../../../../base/common/observable.js';
-import { MarkdownRenderer } from '../../../../../../editor/browser/widget/markdownRenderer/browser/markdownRenderer.js';
+import { IMarkdownRenderer } from '../../../../../../editor/browser/widget/markdownRenderer/browser/markdownRenderer.js';
 import { IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
 import { IInstantiationService } from '../../../../../../platform/instantiation/common/instantiation.js';
 import { IChatProgressMessage, IChatToolInvocation, IChatToolInvocationSerialized, ToolConfirmKind } from '../../../common/chatService.js';
@@ -25,7 +25,7 @@ export class ChatToolProgressSubPart extends BaseChatToolInvocationSubPart {
 	constructor(
 		toolInvocation: IChatToolInvocation | IChatToolInvocationSerialized,
 		private readonly context: IChatContentPartRenderContext,
-		private readonly renderer: MarkdownRenderer,
+		private readonly renderer: IMarkdownRenderer,
 		private readonly announcedToolProgressKeys: Set<string> | undefined,
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
 		@IConfigurationService private readonly configurationService: IConfigurationService,

--- a/src/vs/workbench/contrib/chat/browser/chatQuick.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatQuick.ts
@@ -12,7 +12,7 @@ import { MarkdownString } from '../../../../base/common/htmlContent.js';
 import { autorun } from '../../../../base/common/observable.js';
 import { Disposable, DisposableStore, IDisposable, MutableDisposable } from '../../../../base/common/lifecycle.js';
 import { Selection } from '../../../../editor/common/core/selection.js';
-import { MarkdownRenderer } from '../../../../editor/browser/widget/markdownRenderer/browser/markdownRenderer.js';
+import { IMarkdownRendererService } from '../../../../editor/browser/widget/markdownRenderer/browser/markdownRenderer.js';
 import { MenuId } from '../../../../platform/actions/common/actions.js';
 import { localize } from '../../../../nls.js';
 import { IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
@@ -162,6 +162,7 @@ class QuickChat extends Disposable {
 		@ILayoutService private readonly layoutService: ILayoutService,
 		@IViewsService private readonly viewsService: IViewsService,
 		@IChatEntitlementService private readonly chatEntitlementService: IChatEntitlementService,
+		@IMarkdownRendererService private readonly markdownRendererService: IMarkdownRendererService,
 	) {
 		super();
 	}
@@ -261,8 +262,7 @@ class QuickChat extends Disposable {
 			disclaimerElement.classList.toggle('hidden', !showDisclaimer);
 
 			if (showDisclaimer) {
-				const markdown = this.instantiationService.createInstance(MarkdownRenderer);
-				const renderedMarkdown = disposables.add(markdown.render(new MarkdownString(localize({ key: 'termsDisclaimer', comment: ['{Locked="]({2})"}', '{Locked="]({3})"}'] }, "By continuing with {0} Copilot, you agree to {1}'s [Terms]({2}) and [Privacy Statement]({3})", product.defaultChatAgent?.provider?.default?.name ?? '', product.defaultChatAgent?.provider?.default?.name ?? '', product.defaultChatAgent?.termsStatementUrl ?? '', product.defaultChatAgent?.privacyStatementUrl ?? ''), { isTrusted: true })));
+				const renderedMarkdown = disposables.add(this.markdownRendererService.render(new MarkdownString(localize({ key: 'termsDisclaimer', comment: ['{Locked="]({2})"}', '{Locked="]({3})"}'] }, "By continuing with {0} Copilot, you agree to {1}'s [Terms]({2}) and [Privacy Statement]({3})", product.defaultChatAgent?.provider?.default?.name ?? '', product.defaultChatAgent?.provider?.default?.name ?? '', product.defaultChatAgent?.termsStatementUrl ?? '', product.defaultChatAgent?.privacyStatementUrl ?? ''), { isTrusted: true })));
 				disclaimerElement.appendChild(renderedMarkdown.element);
 			}
 		}));

--- a/src/vs/workbench/contrib/chat/browser/chatSessions/view/sessionsTreeRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSessions/view/sessionsTreeRenderer.ts
@@ -39,7 +39,7 @@ import { IChatService } from '../../../common/chatService.js';
 import { ChatSessionStatus, IChatSessionItem, IChatSessionItemProvider, IChatSessionsService } from '../../../common/chatSessionsService.js';
 import { ChatConfiguration } from '../../../common/constants.js';
 import { IChatWidgetService } from '../../chat.js';
-import { allowedChatMarkdownHtmlTags } from '../../chatMarkdownRenderer.js';
+import { allowedChatMarkdownHtmlTags } from '../../chatContentMarkdownRenderer.js';
 import { ChatSessionItemWithProvider, extractTimestamp, getSessionItemContextOverlay, isLocalChatSessionItem, processSessionsWithTimeGrouping } from '../common.js';
 import '../../media/chatSessions.css';
 import { LocalChatSessionsProvider } from '../localChatSessionsProvider.js';

--- a/src/vs/workbench/contrib/chat/browser/viewsWelcome/chatViewWelcomeController.ts
+++ b/src/vs/workbench/contrib/chat/browser/viewsWelcome/chatViewWelcomeController.ts
@@ -12,7 +12,7 @@ import { IMarkdownString } from '../../../../../base/common/htmlContent.js';
 import { KeyCode } from '../../../../../base/common/keyCodes.js';
 import { Disposable, DisposableStore } from '../../../../../base/common/lifecycle.js';
 import { ThemeIcon } from '../../../../../base/common/themables.js';
-import { MarkdownRenderer } from '../../../../../editor/browser/widget/markdownRenderer/browser/markdownRenderer.js';
+import { IMarkdownRendererService } from '../../../../../editor/browser/widget/markdownRenderer/browser/markdownRenderer.js';
 import { IRenderedMarkdown } from '../../../../../base/browser/markdownRenderer.js';
 import { localize } from '../../../../../nls.js';
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
@@ -136,18 +136,17 @@ export class ChatViewWelcomePart extends Disposable {
 		public readonly content: IChatViewWelcomeContent,
 		options: IChatViewWelcomeRenderOptions | undefined,
 		@IOpenerService private openerService: IOpenerService,
-		@IInstantiationService private instantiationService: IInstantiationService,
 		@ILogService private logService: ILogService,
 		@IChatWidgetService private chatWidgetService: IChatWidgetService,
 		@ITelemetryService private telemetryService: ITelemetryService,
 		@IConfigurationService private configurationService: IConfigurationService,
+		@IMarkdownRendererService private readonly markdownRendererService: IMarkdownRendererService,
 	) {
 		super();
 
 		this.element = dom.$('.chat-welcome-view');
 
 		try {
-			const renderer = this.instantiationService.createInstance(MarkdownRenderer);
 
 			// Icon
 			const icon = dom.append(this.element, $('.chat-welcome-view-icon'));
@@ -170,7 +169,7 @@ export class ChatViewWelcomePart extends Disposable {
 			const message = dom.append(this.element, content.isNew ? $('.chat-welcome-new-view-message') : $('.chat-welcome-view-message'));
 			message.classList.toggle('empty-state', expEmptyState);
 
-			const messageResult = this.renderMarkdownMessageContent(renderer, content.message, options);
+			const messageResult = this.renderMarkdownMessageContent(content.message, options);
 			dom.append(message, messageResult.element);
 
 			if (content.isNew && content.inputPart) {
@@ -184,7 +183,7 @@ export class ChatViewWelcomePart extends Disposable {
 				if (typeof content.additionalMessage === 'string') {
 					disclaimers.textContent = content.additionalMessage;
 				} else {
-					const additionalMessageResult = this.renderMarkdownMessageContent(renderer, content.additionalMessage, options);
+					const additionalMessageResult = this.renderMarkdownMessageContent(content.additionalMessage, options);
 					disclaimers.appendChild(additionalMessageResult.element);
 				}
 			}
@@ -253,7 +252,7 @@ export class ChatViewWelcomePart extends Disposable {
 			// Tips
 			if (content.tips) {
 				const tips = dom.append(this.element, $('.chat-welcome-view-tips'));
-				const tipsResult = this._register(renderer.render(content.tips));
+				const tipsResult = this._register(this.markdownRendererService.render(content.tips));
 				tips.appendChild(tipsResult.element);
 			}
 
@@ -263,7 +262,7 @@ export class ChatViewWelcomePart extends Disposable {
 				if (typeof content.additionalMessage === 'string') {
 					additionalMsg.textContent = content.additionalMessage;
 				} else {
-					const additionalMessageResult = this.renderMarkdownMessageContent(renderer, content.additionalMessage, options);
+					const additionalMessageResult = this.renderMarkdownMessageContent(content.additionalMessage, options);
 					additionalMsg.appendChild(additionalMessageResult.element);
 				}
 			}
@@ -287,8 +286,8 @@ export class ChatViewWelcomePart extends Disposable {
 			}));
 	}
 
-	private renderMarkdownMessageContent(renderer: MarkdownRenderer, content: IMarkdownString, options: IChatViewWelcomeRenderOptions | undefined): IRenderedMarkdown {
-		const messageResult = this._register(renderer.render(content));
+	private renderMarkdownMessageContent(content: IMarkdownString, options: IChatViewWelcomeRenderOptions | undefined): IRenderedMarkdown {
+		const messageResult = this._register(this.markdownRendererService.render(content));
 		const firstLink = options?.firstLinkToButton ? messageResult.element.querySelector('a') : undefined;
 		if (firstLink) {
 			const target = firstLink.getAttribute('data-href');

--- a/src/vs/workbench/contrib/chat/test/browser/chatMarkdownRenderer.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/chatMarkdownRenderer.test.ts
@@ -6,16 +6,16 @@
 import { MarkdownString } from '../../../../../base/common/htmlContent.js';
 import { assertSnapshot } from '../../../../../base/test/common/snapshot.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
-import { ChatMarkdownRenderer } from '../../browser/chatMarkdownRenderer.js';
+import { ChatContentMarkdownRenderer } from '../../browser/chatContentMarkdownRenderer.js';
 import { workbenchInstantiationService } from '../../../../test/browser/workbenchTestServices.js';
 
 suite('ChatMarkdownRenderer', () => {
 	const store = ensureNoDisposablesAreLeakedInTestSuite();
 
-	let testRenderer: ChatMarkdownRenderer;
+	let testRenderer: ChatContentMarkdownRenderer;
 	setup(() => {
 		const instantiationService = store.add(workbenchInstantiationService(undefined, store));
-		testRenderer = instantiationService.createInstance(ChatMarkdownRenderer);
+		testRenderer = instantiationService.createInstance(ChatContentMarkdownRenderer);
 	});
 
 	test('simple', async () => {

--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChatWidget.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChatWidget.ts
@@ -14,7 +14,7 @@ import { DisposableStore, MutableDisposable, toDisposable } from '../../../../ba
 import { autorun, constObservable, derived, IObservable, ISettableObservable, observableValue } from '../../../../base/common/observable.js';
 import { ICodeEditor } from '../../../../editor/browser/editorBrowser.js';
 import { AccessibleDiffViewer, IAccessibleDiffViewerModel } from '../../../../editor/browser/widget/diffEditor/components/accessibleDiffViewer.js';
-import { MarkdownRenderer } from '../../../../editor/browser/widget/markdownRenderer/browser/markdownRenderer.js';
+import { IMarkdownRendererService } from '../../../../editor/browser/widget/markdownRenderer/browser/markdownRenderer.js';
 import { EditorOption, IComputedEditorOptions } from '../../../../editor/common/config/editorOptions.js';
 import { LineRange } from '../../../../editor/common/core/ranges/lineRange.js';
 import { Position } from '../../../../editor/common/core/position.js';
@@ -127,6 +127,7 @@ export class InlineChatWidget {
 		@IChatService private readonly _chatService: IChatService,
 		@IHoverService private readonly _hoverService: IHoverService,
 		@IChatEntitlementService private readonly _chatEntitlementService: IChatEntitlementService,
+		@IMarkdownRendererService private readonly _markdownRendererService: IMarkdownRendererService,
 	) {
 		this.scopedContextKeyService = this._store.add(_contextKeyService.createScoped(this._elements.chatWidget));
 		const scopedInstaService = _instantiationService.createChild(
@@ -316,8 +317,7 @@ export class InlineChatWidget {
 			this._elements.disclaimerLabel.classList.toggle('hidden', !showDisclaimer);
 
 			if (showDisclaimer) {
-				const markdown = this._instantiationService.createInstance(MarkdownRenderer);
-				const renderedMarkdown = disposables.add(markdown.render(new MarkdownString(localize({ key: 'termsDisclaimer', comment: ['{Locked="]({2})"}', '{Locked="]({3})"}'] }, "By continuing with {0} Copilot, you agree to {1}'s [Terms]({2}) and [Privacy Statement]({3})", product.defaultChatAgent?.provider?.default?.name ?? '', product.defaultChatAgent?.provider?.default?.name ?? '', product.defaultChatAgent?.termsStatementUrl ?? '', product.defaultChatAgent?.privacyStatementUrl ?? ''), { isTrusted: true })));
+				const renderedMarkdown = disposables.add(this._markdownRendererService.render(new MarkdownString(localize({ key: 'termsDisclaimer', comment: ['{Locked="]({2})"}', '{Locked="]({3})"}'] }, "By continuing with {0} Copilot, you agree to {1}'s [Terms]({2}) and [Privacy Statement]({3})", product.defaultChatAgent?.provider?.default?.name ?? '', product.defaultChatAgent?.provider?.default?.name ?? '', product.defaultChatAgent?.termsStatementUrl ?? '', product.defaultChatAgent?.privacyStatementUrl ?? ''), { isTrusted: true })));
 				this._elements.disclaimerLabel.appendChild(renderedMarkdown.element);
 			}
 
@@ -546,6 +546,7 @@ export class EditorBasedInlineChatWidget extends InlineChatWidget {
 		@IHoverService hoverService: IHoverService,
 		@ILayoutService layoutService: ILayoutService,
 		@IChatEntitlementService chatEntitlementService: IChatEntitlementService,
+		@IMarkdownRendererService markdownRendererService: IMarkdownRendererService,
 	) {
 		const overflowWidgetsNode = layoutService.getContainer(getWindow(_parentEditor.getContainerDomNode())).appendChild($('.inline-chat-overflow.monaco-editor'));
 		super(location, {
@@ -554,7 +555,7 @@ export class EditorBasedInlineChatWidget extends InlineChatWidget {
 				...options.chatWidgetViewOptions,
 				editorOverflowWidgetsDomNode: overflowWidgetsNode
 			}
-		}, instantiationService, contextKeyService, keybindingService, accessibilityService, configurationService, accessibleViewService, textModelResolverService, chatService, hoverService, chatEntitlementService);
+		}, instantiationService, contextKeyService, keybindingService, accessibilityService, configurationService, accessibleViewService, textModelResolverService, chatService, hoverService, chatEntitlementService, markdownRendererService);
 
 		this._store.add(toDisposable(() => {
 			overflowWidgetsNode.remove();

--- a/src/vs/workbench/test/browser/workbenchTestServices.ts
+++ b/src/vs/workbench/test/browser/workbenchTestServices.ts
@@ -26,6 +26,7 @@ import { assertReturnsDefined, upcast } from '../../../base/common/types.js';
 import { URI } from '../../../base/common/uri.js';
 import { ICodeEditor } from '../../../editor/browser/editorBrowser.js';
 import { ICodeEditorService } from '../../../editor/browser/services/codeEditorService.js';
+import { IMarkdownRendererService, MarkdownRendererService } from '../../../editor/browser/widget/markdownRenderer/browser/markdownRenderer.js';
 import { Position as EditorPosition, IPosition } from '../../../editor/common/core/position.js';
 import { Range } from '../../../editor/common/core/range.js';
 import { Selection } from '../../../editor/common/core/selection.js';
@@ -372,6 +373,7 @@ export function workbenchInstantiationService(
 	instantiationService.stub(ICustomEditorLabelService, disposables.add(new CustomEditorLabelService(configService, workspaceContextService)));
 	instantiationService.stub(IHoverService, NullHoverService);
 	instantiationService.stub(IChatEntitlementService, new TestChatEntitlementService());
+	instantiationService.stub(IMarkdownRendererService, instantiationService.createInstance(MarkdownRendererService));
 
 	return instantiationService;
 }


### PR DESCRIPTION
Final step of refactoring in this space. This change:

- Introduces an `IMarkdownRenderer` for cases where a top level component needs to control how other components render markdown. Main user is chat

- Deletes `MarkdownRenderer`

- Makes chat adopt either `IMarkdownRenderer` for stuff in a response, or `IMarkdownRendererService` for rendering non-response content


cc @roblourens: For chat, I update any places that were creating their own instance of `MarkdownRenderer` to instead use the standard markdown renderer service. I kept any places that were using the `ChatMarkdownRenderer`. This is now passed along as a `IMarkdownRenderer`

