### PR TITLE
Use css to override font-size in rendered markdown

### DIFF
--- a/src/vs/editor/browser/widget/markdownRenderer/browser/markdownRenderer.ts
+++ b/src/vs/editor/browser/widget/markdownRenderer/browser/markdownRenderer.ts
@@ -98,20 +98,23 @@ export class MarkdownRendererService implements IMarkdownRendererService {
 		const html = await tokenizeToString(this._languageService, value, languageId);
 
 		const content = MarkdownRendererService._ttpTokenizer ? MarkdownRendererService._ttpTokenizer.createHTML(html) ?? html : html;
-		const element = new DOMParser().parseFromString(content as string, 'text/html').body.firstChild;
-		if (!isHTMLElement(element)) {
+
+		const root = document.createElement('span');
+		root.innerHTML = content as string;
+		const codeElement = root.querySelector('.monaco-tokenized-source');
+		if (!isHTMLElement(codeElement)) {
 			return document.createElement('span');
 		}
 
 		// use "good" font
 		if (options.editor) {
 			const fontInfo = options.editor.getOption(EditorOption.fontInfo);
-			applyFontInfo(element, fontInfo);
+			applyFontInfo(codeElement, fontInfo);
 		} else {
-			element.style.fontFamily = this._configurationService.getValue<IEditorOptions>('editor').fontFamily || EDITOR_FONT_DEFAULTS.fontFamily;
+			codeElement.style.fontFamily = this._configurationService.getValue<IEditorOptions>('editor').fontFamily || EDITOR_FONT_DEFAULTS.fontFamily;
 		}
 
-		return element;
+		return root;
 	}
 }
 

--- a/src/vs/editor/browser/widget/markdownRenderer/browser/markdownRenderer.ts
+++ b/src/vs/editor/browser/widget/markdownRenderer/browser/markdownRenderer.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { isHTMLElement } from '../../../../../base/browser/dom.js';
 import { IRenderedMarkdown, MarkdownRenderOptions, renderMarkdown } from '../../../../../base/browser/markdownRenderer.js';
 import { createTrustedTypesPolicy } from '../../../../../base/browser/trustedTypes.js';
 import { onUnexpectedError } from '../../../../../base/common/errors.js';
@@ -34,7 +35,6 @@ export interface IMarkdownRenderer {
 
 export interface IMarkdownRendererExtraOptions {
 	readonly editor?: ICodeEditor;
-	readonly codeBlockFontSize?: string;
 }
 
 
@@ -97,9 +97,11 @@ export class MarkdownRendererService implements IMarkdownRendererService {
 		}
 		const html = await tokenizeToString(this._languageService, value, languageId);
 
-		const element = document.createElement('span');
-
-		element.innerHTML = (MarkdownRendererService._ttpTokenizer?.createHTML(html) ?? html) as string;
+		const content = MarkdownRendererService._ttpTokenizer ? MarkdownRendererService._ttpTokenizer.createHTML(html) ?? html : html;
+		const element = new DOMParser().parseFromString(content as string, 'text/html').body.firstChild;
+		if (!isHTMLElement(element)) {
+			return document.createElement('span');
+		}
 
 		// use "good" font
 		if (options.editor) {
@@ -107,10 +109,6 @@ export class MarkdownRendererService implements IMarkdownRendererService {
 			applyFontInfo(element, fontInfo);
 		} else {
 			element.style.fontFamily = this._configurationService.getValue<IEditorOptions>('editor').fontFamily || EDITOR_FONT_DEFAULTS.fontFamily;
-		}
-
-		if (options.codeBlockFontSize !== undefined) {
-			element.style.fontSize = options.codeBlockFontSize;
 		}
 
 		return element;

--- a/src/vs/workbench/contrib/comments/browser/commentThreadZoneWidget.ts
+++ b/src/vs/workbench/contrib/comments/browser/commentThreadZoneWidget.ts
@@ -271,7 +271,7 @@ export class ReviewZoneWidget extends ZoneWidget implements ICommentThreadWidget
 			this._commentThread,
 			this._pendingComment,
 			this._pendingEdits,
-			{ editor: this.editor, codeBlockFontSize: '' },
+			{ editor: this.editor, },
 			this._commentOptions,
 			{
 				actionRunner: async () => {

--- a/src/vs/workbench/contrib/comments/browser/media/review.css
+++ b/src/vs/workbench/contrib/comments/browser/media/review.css
@@ -246,6 +246,11 @@
 	max-width: 100%;
 }
 
+.review-widget .body .comment-body .monaco-tokenized-source {
+	font-size: inherit !important;
+	line-height: auto !important;
+}
+
 .review-widget .body .comment-form-container {
 	margin: 8px 20px;
 }


### PR DESCRIPTION
Also updates the structure of code blocks to avoid the extra wrapping span. This make overriding the styles much easier 