### PR TITLE
Fixed issue with findFiles2 returning dups (#263911 and #263400)

### DIFF
--- a/src/vs/workbench/api/common/extHostWorkspace.ts
+++ b/src/vs/workbench/api/common/extHostWorkspace.ts
@@ -552,7 +552,20 @@ export class ExtHostWorkspace implements ExtHostWorkspaceShape, IExtHostWorkspac
 			token).then(data => Array.isArray(data) ? data.map(d => URI.revive(d)) : [])
 		) ?? []);
 
-		return result.flat();
+		const flatResult = result.flat();
+
+		// Dedupe entries in a flat array
+		const extUri = new ExtUri(uri => ignorePathCasing(uri, this._extHostFileSystemInfo));
+		const uriMap = new Map<string, vscode.Uri>();
+
+		for (const uri of flatResult) {
+			const key = extUri.getComparisonKey(uri);
+			if (!uriMap.has(key)) {
+				uriMap.set(key, uri);
+			}
+		}
+
+		return Array.from(uriMap.values());
 	}
 
 	findTextInFiles2(query: vscode.TextSearchQuery2, options: vscode.FindTextInFilesOptions2 | undefined, extensionId: ExtensionIdentifier, token: vscode.CancellationToken = CancellationToken.None): vscode.FindTextInFilesResponse {


### PR DESCRIPTION
Fixed issue with findFiles2 returning dups 
- findFiles2 returns duplicate results when an array is passed in #263911
- Copilot search showing double results #263400

Updated API to dedup the URIs and added test/