### PR TITLE
Add high contrast theme support for settings editor links and buttons

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/media/settingsEditor2.css
+++ b/src/vs/workbench/contrib/preferences/browser/media/settingsEditor2.css
@@ -589,11 +589,7 @@
 }
 
 /* High contrast theme support - ensure proper color visibility */
-.monaco-workbench.hc-light .settings-editor > .settings-body .settings-tree-container .setting-item-contents .setting-item-markdown a,
-.monaco-workbench.hc-light .settings-editor > .settings-body .settings-tree-container .setting-item-contents .edit-in-settings-button,
 .monaco-workbench.hc-light .settings-editor > .settings-body .settings-tree-container .setting-item-contents .setting-item-markdown a > code,
-.monaco-workbench.hc-black .settings-editor > .settings-body .settings-tree-container .setting-item-contents .setting-item-markdown a,
-.monaco-workbench.hc-black .settings-editor > .settings-body .settings-tree-container .setting-item-contents .edit-in-settings-button,
 .monaco-workbench.hc-black .settings-editor > .settings-body .settings-tree-container .setting-item-contents .setting-item-markdown a > code {
 	color: var(--vscode-textPreformat-foreground);
 }

--- a/src/vs/workbench/contrib/preferences/browser/media/settingsEditor2.css
+++ b/src/vs/workbench/contrib/preferences/browser/media/settingsEditor2.css
@@ -588,6 +588,16 @@
 	color: var(--vscode-textLink-activeForeground);
 }
 
+/* High contrast theme support - ensure proper color visibility */
+.monaco-workbench.hc-light .settings-editor > .settings-body .settings-tree-container .setting-item-contents .setting-item-markdown a,
+.monaco-workbench.hc-light .settings-editor > .settings-body .settings-tree-container .setting-item-contents .edit-in-settings-button,
+.monaco-workbench.hc-light .settings-editor > .settings-body .settings-tree-container .setting-item-contents .setting-item-markdown a > code,
+.monaco-workbench.hc-black .settings-editor > .settings-body .settings-tree-container .setting-item-contents .setting-item-markdown a,
+.monaco-workbench.hc-black .settings-editor > .settings-body .settings-tree-container .setting-item-contents .edit-in-settings-button,
+.monaco-workbench.hc-black .settings-editor > .settings-body .settings-tree-container .setting-item-contents .setting-item-markdown a > code {
+	color: var(--vscode-textPreformat-foreground);
+}
+
 .settings-editor > .settings-body .settings-tree-container .setting-item-contents .setting-item-markdown a:hover,
 .settings-editor > .settings-body .settings-tree-container .edit-in-settings-button:hover {
 	cursor: pointer;


### PR DESCRIPTION
Implement high contrast theme support to enhance color visibility for links and buttons in the settings editor.

Before:
<img width="1064" height="250" alt="image" src="https://github.com/user-attachments/assets/6872a055-e627-401b-bacb-32af8319a6cd" />

After:
<img width="1130" height="608" alt="image" src="https://github.com/user-attachments/assets/65e6f564-3399-4dc8-b126-21fd84736554" />
