### PR TITLE
pass back profile instead of just shell

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
@@ -616,7 +616,7 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 
 	// #region Terminal init
 
-	protected async _getCopilotShellOrProfile(): Promise<string | ITerminalProfile> {
+	protected async _getCopilotShellOrProfile(): Promise<ITerminalProfile> {
 		const os = await this._osBackend;
 
 		// Check for chat agent terminal profile first

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
@@ -626,17 +626,17 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 		}
 
 		// When setting is null, use the previous behavior
-		const defaultShell = await this._terminalProfileResolverService.getDefaultShell({
+		const defaultProfile = await this._terminalProfileResolverService.getDefaultProfile({
 			os,
 			remoteAuthority: this._remoteAgentService.getConnection()?.remoteAuthority
 		});
 
 		// Force pwsh over cmd as cmd doesn't have shell integration
-		if (basename(defaultShell) === 'cmd.exe') {
+		if (basename(defaultProfile.path) === 'cmd.exe') {
 			return 'C:\\WINDOWS\\System32\\WindowsPowerShell\\v1.0\\powershell.exe';
 		}
 
-		return defaultShell;
+		return defaultProfile;
 	}
 
 	private async _getCopilotShell(): Promise<string> {

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
@@ -633,7 +633,11 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 
 		// Force pwsh over cmd as cmd doesn't have shell integration
 		if (basename(defaultProfile.path) === 'cmd.exe') {
-			return 'C:\\WINDOWS\\System32\\WindowsPowerShell\\v1.0\\powershell.exe';
+			return {
+				...defaultProfile,
+				path: 'C:\\WINDOWS\\System32\\WindowsPowerShell\\v1.0\\powershell.exe',
+				profileName: 'PowerShell'
+			};
 		}
 
 		return defaultProfile;

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
@@ -616,7 +616,7 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 
 	// #region Terminal init
 
-	protected async _getCopilotShellOrProfile(): Promise<ITerminalProfile> {
+	protected async _getCopilotProfile(): Promise<ITerminalProfile> {
 		const os = await this._osBackend;
 
 		// Check for chat agent terminal profile first
@@ -644,7 +644,7 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 	}
 
 	private async _getCopilotShell(): Promise<string> {
-		const shellOrProfile = await this._getCopilotShellOrProfile();
+		const shellOrProfile = await this._getCopilotProfile();
 		if (typeof shellOrProfile === 'string') {
 			return shellOrProfile;
 		}
@@ -686,7 +686,7 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 
 	private async _initBackgroundTerminal(chatSessionId: string, termId: string, token: CancellationToken): Promise<IToolTerminal> {
 		this._logService.debug(`RunInTerminalTool: Creating background terminal with ID=${termId}`);
-		const shellOrProfile = await this._getCopilotShellOrProfile();
+		const shellOrProfile = await this._getCopilotProfile();
 		const toolTerminal = await this._terminalToolCreator.createTerminal(shellOrProfile, token);
 		this._registerInputListener(toolTerminal);
 		this._sessionTerminalAssociations.set(chatSessionId, toolTerminal);
@@ -705,7 +705,7 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 			this._terminalToolCreator.refreshShellIntegrationQuality(cachedTerminal);
 			return cachedTerminal;
 		}
-		const shellOrProfile = await this._getCopilotShellOrProfile();
+		const shellOrProfile = await this._getCopilotProfile();
 		const toolTerminal = await this._terminalToolCreator.createTerminal(shellOrProfile, token);
 		this._registerInputListener(toolTerminal);
 		this._sessionTerminalAssociations.set(chatSessionId, toolTerminal);

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
@@ -644,11 +644,7 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 	}
 
 	private async _getCopilotShell(): Promise<string> {
-		const shellOrProfile = await this._getCopilotProfile();
-		if (typeof shellOrProfile === 'string') {
-			return shellOrProfile;
-		}
-		return shellOrProfile.path;
+		return (await this._getCopilotProfile()).path;
 	}
 
 	private _getChatTerminalProfile(os: OperatingSystem): ITerminalProfile | undefined {
@@ -686,8 +682,8 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 
 	private async _initBackgroundTerminal(chatSessionId: string, termId: string, token: CancellationToken): Promise<IToolTerminal> {
 		this._logService.debug(`RunInTerminalTool: Creating background terminal with ID=${termId}`);
-		const shellOrProfile = await this._getCopilotProfile();
-		const toolTerminal = await this._terminalToolCreator.createTerminal(shellOrProfile, token);
+		const profile = await this._getCopilotProfile();
+		const toolTerminal = await this._terminalToolCreator.createTerminal(profile, token);
 		this._registerInputListener(toolTerminal);
 		this._sessionTerminalAssociations.set(chatSessionId, toolTerminal);
 		if (token.isCancellationRequested) {
@@ -705,8 +701,8 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 			this._terminalToolCreator.refreshShellIntegrationQuality(cachedTerminal);
 			return cachedTerminal;
 		}
-		const shellOrProfile = await this._getCopilotProfile();
-		const toolTerminal = await this._terminalToolCreator.createTerminal(shellOrProfile, token);
+		const profile = await this._getCopilotProfile();
+		const toolTerminal = await this._terminalToolCreator.createTerminal(profile, token);
 		this._registerInputListener(toolTerminal);
 		this._sessionTerminalAssociations.set(chatSessionId, toolTerminal);
 		if (token.isCancellationRequested) {

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/runInTerminalTool.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/runInTerminalTool.test.ts
@@ -32,7 +32,7 @@ class TestRunInTerminalTool extends RunInTerminalTool {
 	get sessionTerminalAssociations() { return this._sessionTerminalAssociations; }
 
 	getCopilotShellOrProfile() {
-		return this._getCopilotShellOrProfile();
+		return this._getCopilotProfile();
 	}
 	setBackendOs(os: OperatingSystem) {
 		this._osBackend = Promise.resolve(os);

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/runInTerminalTool.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/runInTerminalTool.test.ts
@@ -23,6 +23,7 @@ import { terminalChatAgentToolsConfiguration, TerminalChatAgentToolsSettingId } 
 import { IStorageService, StorageScope, StorageTarget } from '../../../../../../platform/storage/common/storage.js';
 import { TerminalToolConfirmationStorageKeys } from '../../../../chat/browser/chatContentParts/toolInvocationParts/chatTerminalToolConfirmationSubPart.js';
 import { count } from '../../../../../../base/common/strings.js';
+import { ITerminalProfile } from '../../../../../../platform/terminal/common/terminal.js';
 
 class TestRunInTerminalTool extends RunInTerminalTool {
 	protected override _osBackend: Promise<OperatingSystem> = Promise.resolve(OperatingSystem.Windows);
@@ -70,7 +71,7 @@ suite('RunInTerminalTool', () => {
 			onDidDisposeSession: chatServiceDisposeEmitter.event
 		});
 		instantiationService.stub(ITerminalProfileResolverService, {
-			getDefaultShell: async () => 'pwsh'
+			getDefaultProfile: async () => ({ path: 'pwsh' } as ITerminalProfile)
 		});
 
 		storageService = instantiationService.get(IStorageService);
@@ -960,7 +961,8 @@ suite('RunInTerminalTool', () => {
 			setConfig(TerminalChatAgentToolsSettingId.TerminalProfileLinux, null);
 
 			const result = await runInTerminalTool.getCopilotShellOrProfile();
-			strictEqual(result, 'pwsh'); // From the mock ITerminalProfileResolverService
+			strictEqual(typeof result, 'object');
+			strictEqual((result as ITerminalProfile).path, 'pwsh'); // From the mock ITerminalProfileResolverService
 		});
 	});
 });

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/runInTerminalTool.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/runInTerminalTool.test.ts
@@ -31,7 +31,7 @@ class TestRunInTerminalTool extends RunInTerminalTool {
 	get commandLineAutoApprover() { return this._commandLineAutoApprover; }
 	get sessionTerminalAssociations() { return this._sessionTerminalAssociations; }
 
-	getCopilotShellOrProfile() {
+	getCopilotProfile() {
 		return this._getCopilotProfile();
 	}
 	setBackendOs(os: OperatingSystem) {
@@ -952,7 +952,7 @@ suite('RunInTerminalTool', () => {
 			const customProfile = Object.freeze({ path: 'C:\\Windows\\System32\\powershell.exe', args: ['-NoProfile'] });
 			setConfig(TerminalChatAgentToolsSettingId.TerminalProfileWindows, customProfile);
 
-			const result = await runInTerminalTool.getCopilotShellOrProfile();
+			const result = await runInTerminalTool.getCopilotProfile();
 			strictEqual(result, customProfile);
 		});
 
@@ -960,7 +960,7 @@ suite('RunInTerminalTool', () => {
 			runInTerminalTool.setBackendOs(OperatingSystem.Linux);
 			setConfig(TerminalChatAgentToolsSettingId.TerminalProfileLinux, null);
 
-			const result = await runInTerminalTool.getCopilotShellOrProfile();
+			const result = await runInTerminalTool.getCopilotProfile();
 			strictEqual(typeof result, 'object');
 			strictEqual((result as ITerminalProfile).path, 'pwsh'); // From the mock ITerminalProfileResolverService
 		});


### PR DESCRIPTION
fixes https://github.com/microsoft/vscode/issues/270609

There was a discrepancy between a user created `zsh` terminal and one created by the agent because the `-l` arg was missing from the latter.

This was because we were only passing the `shell` back. Unclear to me if this was intentional, but seems like these experiences should be aligned. 

Not having `-l` would cause some env that was set in a `.zprofile` to be missing, so when the agent would try to run a command, it might fail. 

<img width="762" height="331" alt="Screenshot 2025-10-09 at 1 18 55 PM" src="https://github.com/user-attachments/assets/c00e9061-f4ad-4248-97f4-c46799c93930" />
