### PR TITLE
Fix debug exception navigation appearing in all editor groups

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/debugEditorContribution.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugEditorContribution.ts
@@ -586,7 +586,7 @@ export class DebugEditorContribution implements IDebugEditorContribution {
 		if (this.exceptionWidget && !sameUri) {
 			this.closeExceptionWidget();
 		} else if (sameUri) {
-			// Only show exception widget in the active editor, not all editors with the same file
+			// Only show exception widget in the active editor to prevent disrupting workflow in multiple editor groups with the same file
 			const activeControl = this.editorService.activeTextEditorControl;
 			const isActiveEditor = activeControl === this.editor;
 

--- a/src/vs/workbench/contrib/debug/browser/debugEditorContribution.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugEditorContribution.ts
@@ -52,6 +52,7 @@ import { ExceptionWidget } from './exceptionWidget.js';
 import { CONTEXT_EXCEPTION_WIDGET_VISIBLE, IDebugConfiguration, IDebugEditorContribution, IDebugService, IDebugSession, IExceptionInfo, IExpression, IStackFrame, State } from '../common/debug.js';
 import { Expression } from '../common/debugModel.js';
 import { IHostService } from '../../../services/host/browser/host.js';
+import { IEditorService } from '../../../services/editor/common/editorService.js';
 import { MarkdownString } from '../../../../base/common/htmlContent.js';
 
 const MAX_NUM_INLINE_VALUES = 100; // JS Global scope can have 700+ entries. We want to limit ourselves for perf reasons
@@ -279,7 +280,8 @@ export class DebugEditorContribution implements IDebugEditorContribution {
 		@IUriIdentityService private readonly uriIdentityService: IUriIdentityService,
 		@IContextKeyService contextKeyService: IContextKeyService,
 		@ILanguageFeaturesService private readonly languageFeaturesService: ILanguageFeaturesService,
-		@ILanguageFeatureDebounceService featureDebounceService: ILanguageFeatureDebounceService
+		@ILanguageFeatureDebounceService featureDebounceService: ILanguageFeatureDebounceService,
+		@IEditorService private readonly editorService: IEditorService
 	) {
 		this.oldDecorations = this.editor.createDecorationsCollection();
 		this.debounceInfo = featureDebounceService.for(languageFeaturesService.inlineValuesProvider, 'InlineValues', { min: DEAFULT_INLINE_DEBOUNCE_DELAY });
@@ -584,9 +586,18 @@ export class DebugEditorContribution implements IDebugEditorContribution {
 		if (this.exceptionWidget && !sameUri) {
 			this.closeExceptionWidget();
 		} else if (sameUri) {
-			const exceptionInfo = await focusedSf.thread.exceptionInfo;
-			if (exceptionInfo) {
-				this.showExceptionWidget(exceptionInfo, this.debugService.getViewModel().focusedSession, exceptionSf.range.startLineNumber, exceptionSf.range.startColumn);
+			// Only show exception widget in the active editor, not all editors with the same file
+			const activeControl = this.editorService.activeTextEditorControl;
+			const isActiveEditor = activeControl === this.editor;
+
+			if (isActiveEditor) {
+				const exceptionInfo = await focusedSf.thread.exceptionInfo;
+				if (exceptionInfo) {
+					this.showExceptionWidget(exceptionInfo, this.debugService.getViewModel().focusedSession, exceptionSf.range.startLineNumber, exceptionSf.range.startColumn);
+				}
+			} else {
+				// For non-active editors, close any existing exception widget
+				this.closeExceptionWidget();
 			}
 		}
 	}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->


## Problem
When debugging encounters an exception, VS Code was showing exception widgets and navigating to the error line in all open editor groups that contain the same file, not just the active editor group. This occurred because:

DebugEditorContribution is instantiated per editor instance (one for each editor)
When a debug stack frame is focused via onFocusStackFrame, all instances of DebugEditorContribution with the same file URI receive the event
Each instance would then call toggleExceptionWidget() and showExceptionWidget(), causing the exception widget and range reveal to happen in every editor with the same file open across all editor groups
This behavior disrupted users' workflow when they had multiple windows/editor groups open with different focus areas, as described in issue #136574.

## What's the fix
The fix ensures that debug exception navigation respects the user's current focus and only affects the active editor group, resolving the issue where debugging would disrupt the user's navigation state across multiple editor groups.

The fix modifies DebugEditorContribution.toggleExceptionWidget() to:

Check if the current editor is active: Uses IEditorService.activeTextEditorControl to determine if the current editor instance is the active one
Show exception widget only in active editor: Exception widgets and navigation now only occur in the currently active editor group
Clean up non-active editors: Existing exception widgets in non-active editors are properly closed to avoid stale UI

Fixes #136574