### PR TITLE
Mark most `Event` properties as `readonly`

### DIFF
--- a/src/vs/base/browser/history.ts
+++ b/src/vs/base/browser/history.ts
@@ -13,8 +13,8 @@ export interface IHistoryNavigationWidget {
 
 	showNextValue(): void;
 
-	onDidFocus: Event<void>;
+	readonly onDidFocus: Event<void>;
 
-	onDidBlur: Event<void>;
+	readonly onDidBlur: Event<void>;
 
 }

--- a/src/vs/base/browser/ui/list/listWidget.ts
+++ b/src/vs/base/browser/ui/list/listWidget.ts
@@ -859,7 +859,7 @@ export interface IListAccessibilityProvider<T> extends IListViewAccessibilityPro
 	getWidgetAriaLabel(): string | IObservable<string>;
 	getWidgetRole?(): AriaRole;
 	getAriaLevel?(element: T): number | undefined;
-	onDidChangeActiveDescendant?: Event<void>;
+	readonly onDidChangeActiveDescendant?: Event<void>;
 	getActiveDescendantId?(element: T): string | undefined;
 }
 

--- a/src/vs/base/browser/ui/tree/tree.ts
+++ b/src/vs/base/browser/ui/tree/tree.ts
@@ -167,7 +167,7 @@ export interface ITreeRenderer<T, TFilterData = void, TTemplateData = void> exte
 	renderElement(element: ITreeNode<T, TFilterData>, index: number, templateData: TTemplateData, details?: ITreeElementRenderDetails): void;
 	disposeElement?(element: ITreeNode<T, TFilterData>, index: number, templateData: TTemplateData, details?: ITreeElementRenderDetails): void;
 	renderTwistie?(element: T, twistieElement: HTMLElement): boolean;
-	onDidChangeTwistieState?: Event<T>;
+	readonly onDidChangeTwistieState?: Event<T>;
 }
 
 export interface ITreeEvent<T> {

--- a/src/vs/base/common/history.ts
+++ b/src/vs/base/common/history.ts
@@ -15,7 +15,7 @@ export interface IHistory<T> {
 	clear(): void;
 	forEach(callbackfn: (value: T, value2: T, set: Set<T>) => void, thisArg?: any): void;
 	replace?(t: T[]): void;
-	onDidChange?: Event<string[]>;
+	readonly onDidChange?: Event<string[]>;
 }
 
 export class HistoryNavigator<T> implements INavigator<T> {

--- a/src/vs/base/common/worker/webWorker.ts
+++ b/src/vs/base/common/worker/webWorker.ts
@@ -15,8 +15,8 @@ const INITIALIZE = '$initialize';
 
 export interface IWebWorker extends IDisposable {
 	getId(): number;
-	onMessage: Event<Message>;
-	onError: Event<unknown>;
+	readonly onMessage: Event<Message>;
+	readonly onError: Event<unknown>;
 	postMessage(message: Message, transfer: ArrayBuffer[]): void;
 }
 

--- a/src/vs/base/parts/ipc/common/ipc.ts
+++ b/src/vs/base/parts/ipc/common/ipc.ts
@@ -98,7 +98,7 @@ interface IHandler {
 
 export interface IMessagePassingProtocol {
 	send(buffer: VSBuffer): void;
-	onMessage: Event<VSBuffer>;
+	readonly onMessage: Event<VSBuffer>;
 	/**
 	 * Wait for the write buffer (if applicable) to become empty.
 	 */
@@ -784,7 +784,7 @@ export class ChannelClient implements IChannelClient, IDisposable {
 
 export interface ClientConnectionEvent {
 	protocol: IMessagePassingProtocol;
-	onDidClientDisconnect: Event<void>;
+	readonly onDidClientDisconnect: Event<void>;
 }
 
 interface Connection<TContext> extends Client<TContext> {

--- a/src/vs/base/parts/ipc/test/common/ipc.test.ts
+++ b/src/vs/base/parts/ipc/test/common/ipc.test.ts
@@ -108,7 +108,7 @@ interface ITestService {
 	marshall(uri: URI): Promise<URI>;
 	context(): Promise<unknown>;
 
-	onPong: Event<string>;
+	readonly onPong: Event<string>;
 }
 
 class TestService implements ITestService {

--- a/src/vs/base/parts/ipc/test/node/testService.ts
+++ b/src/vs/base/parts/ipc/test/node/testService.ts
@@ -12,7 +12,7 @@ export interface IMarcoPoloEvent {
 }
 
 export interface ITestService {
-	onMarco: Event<IMarcoPoloEvent>;
+	readonly onMarco: Event<IMarcoPoloEvent>;
 	marco(): Promise<string>;
 	pong(ping: string): Promise<{ incoming: string; outgoing: string }>;
 	cancelMe(): Promise<boolean>;
@@ -21,7 +21,7 @@ export interface ITestService {
 export class TestService implements ITestService {
 
 	private readonly _onMarco = new Emitter<IMarcoPoloEvent>();
-	onMarco: Event<IMarcoPoloEvent> = this._onMarco.event;
+	readonly onMarco: Event<IMarcoPoloEvent> = this._onMarco.event;
 
 	marco(): Promise<string> {
 		this._onMarco.fire({ answer: 'polo' });

--- a/src/vs/base/test/common/event.test.ts
+++ b/src/vs/base/test/common/event.test.ts
@@ -34,7 +34,7 @@ namespace Samples {
 
 		private readonly _onDidChange = new Emitter<string>();
 
-		onDidChange: Event<string> = this._onDidChange.event;
+		readonly onDidChange: Event<string> = this._onDidChange.event;
 
 		setText(value: string) {
 			//...

--- a/src/vs/editor/browser/editorBrowser.ts
+++ b/src/vs/editor/browser/editorBrowser.ts
@@ -281,7 +281,7 @@ export interface IOverlayWidget {
 	/**
 	 * Event fired when the widget layout changes.
 	 */
-	onDidLayout?: Event<void>;
+	readonly onDidLayout?: Event<void>;
 	/**
 	 * Render this overlay widget in a location where it could overflow the editor's view dom node.
 	 */
@@ -898,14 +898,14 @@ export interface ICodeEditor extends editorCommon.IEditor {
 	 * @internal
 	 * @event
 	 */
-	onDidChangeLineHeight: Event<ModelLineHeightChangedEvent>;
+	readonly onDidChangeLineHeight: Event<ModelLineHeightChangedEvent>;
 
 	/**
 	 * An event emitted when the font of the editor has changed.
 	 * @internal
 	 * @event
 	 */
-	onDidChangeFont: Event<ModelFontChangedEvent>;
+	readonly onDidChangeFont: Event<ModelFontChangedEvent>;
 
 	/**
 	 * Get value of the current model attached to this editor.

--- a/src/vs/editor/browser/services/inlineCompletionsService.ts
+++ b/src/vs/editor/browser/services/inlineCompletionsService.ts
@@ -21,7 +21,7 @@ export const IInlineCompletionsService = createDecorator<IInlineCompletionsServi
 export interface IInlineCompletionsService {
 	readonly _serviceBrand: undefined;
 
-	onDidChangeIsSnoozing: Event<boolean>;
+	readonly onDidChangeIsSnoozing: Event<boolean>;
 
 	/**
 	 * Get the remaining time (in ms) for which inline completions should be snoozed,

--- a/src/vs/editor/browser/widget/markdownRenderer/browser/editorMarkdownCodeBlockRenderer.ts
+++ b/src/vs/editor/browser/widget/markdownRenderer/browser/editorMarkdownCodeBlockRenderer.ts
@@ -35,8 +35,7 @@ export class EditorMarkdownCodeBlockRenderer implements IMarkdownCodeBlockRender
 	public async renderCodeBlock(languageAlias: string | undefined, value: string, options: IMarkdownRendererExtraOptions): Promise<HTMLElement> {
 		const editor = isCodeEditor(options.context) ? options.context : undefined;
 
-		// In markdown,
-		// it is possible that we stumble upon language aliases (e.g.js instead of javascript)
+		// In markdown, it is possible that we stumble upon language aliases (e.g.js instead of javascript).
 		// it is possible no alias is given in which case we fall back to the current editor lang
 		let languageId: string | undefined | null;
 		if (languageAlias) {

--- a/src/vs/editor/common/config/editorConfiguration.ts
+++ b/src/vs/editor/common/config/editorConfiguration.ts
@@ -25,11 +25,11 @@ export interface IEditorConfiguration extends IDisposable {
 	/**
 	 * The `options` have changed (quick event)
 	 */
-	onDidChangeFast: Event<ConfigurationChangedEvent>;
+	readonly onDidChangeFast: Event<ConfigurationChangedEvent>;
 	/**
 	 * The `options` have changed (slow event)
 	 */
-	onDidChange: Event<ConfigurationChangedEvent>;
+	readonly onDidChange: Event<ConfigurationChangedEvent>;
 	/**
 	 * Get the raw options as they were passed in to the editor
 	 * and merged with all calls to `updateOptions`.

--- a/src/vs/editor/common/config/editorZoom.ts
+++ b/src/vs/editor/common/config/editorZoom.ts
@@ -6,7 +6,7 @@
 import { Emitter, Event } from '../../../base/common/event.js';
 
 export interface IEditorZoom {
-	onDidChangeZoomLevel: Event<number>;
+	readonly onDidChangeZoomLevel: Event<number>;
 	getZoomLevel(): number;
 	setZoomLevel(zoomLevel: number): void;
 }

--- a/src/vs/editor/common/diff/documentDiffProvider.ts
+++ b/src/vs/editor/common/diff/documentDiffProvider.ts
@@ -23,7 +23,7 @@ export interface IDocumentDiffProvider {
 	 * Is fired when settings of the diff algorithm change that could alter the result of the diffing computation.
 	 * Any user of this provider should recompute the diff when this event is fired.
 	 */
-	onDidChange: Event<void>;
+	readonly onDidChange: Event<void>;
 }
 
 /**

--- a/src/vs/editor/common/editorCommon.ts
+++ b/src/vs/editor/common/editorCommon.ts
@@ -546,7 +546,7 @@ export interface IEditorDecorationsCollection {
 	 * An event emitted when decorations change in the editor,
 	 * but the change is not caused by us setting or clearing the collection.
 	 */
-	onDidChange: Event<IModelDecorationsChangedEvent>;
+	readonly onDidChange: Event<IModelDecorationsChangedEvent>;
 	/**
 	 * Get the decorations count.
 	 */

--- a/src/vs/editor/common/languages.ts
+++ b/src/vs/editor/common/languages.ts
@@ -2143,7 +2143,7 @@ export interface CommentWidget {
 	commentThread: CommentThread;
 	comment?: Comment;
 	input: string;
-	onDidChangeInput: Event<string>;
+	readonly onDidChangeInput: Event<string>;
 }
 
 /**
@@ -2173,19 +2173,19 @@ export interface CommentThread<T = IRange> {
 	label: string | undefined;
 	contextValue: string | undefined;
 	comments: ReadonlyArray<Comment> | undefined;
-	onDidChangeComments: Event<readonly Comment[] | undefined>;
+	readonly onDidChangeComments: Event<readonly Comment[] | undefined>;
 	collapsibleState?: CommentThreadCollapsibleState;
 	initialCollapsibleState?: CommentThreadCollapsibleState;
-	onDidChangeInitialCollapsibleState: Event<CommentThreadCollapsibleState | undefined>;
+	readonly onDidChangeInitialCollapsibleState: Event<CommentThreadCollapsibleState | undefined>;
 	state?: CommentThreadState;
 	applicability?: CommentThreadApplicability;
 	canReply: boolean | CommentAuthorInformation;
 	input?: CommentInput;
-	onDidChangeInput: Event<CommentInput | undefined>;
-	onDidChangeLabel: Event<string | undefined>;
-	onDidChangeCollapsibleState: Event<CommentThreadCollapsibleState | undefined>;
-	onDidChangeState: Event<CommentThreadState | undefined>;
-	onDidChangeCanReply: Event<boolean>;
+	readonly onDidChangeInput: Event<CommentInput | undefined>;
+	readonly onDidChangeLabel: Event<string | undefined>;
+	readonly onDidChangeCollapsibleState: Event<CommentThreadCollapsibleState | undefined>;
+	readonly onDidChangeState: Event<CommentThreadState | undefined>;
+	readonly onDidChangeCanReply: Event<boolean>;
 	isDisposed: boolean;
 	isTemplate: boolean;
 }
@@ -2384,14 +2384,14 @@ export interface SemanticTokensEdits {
 }
 
 export interface DocumentSemanticTokensProvider {
-	onDidChange?: Event<void>;
+	readonly onDidChange?: Event<void>;
 	getLegend(): SemanticTokensLegend;
 	provideDocumentSemanticTokens(model: model.ITextModel, lastResultId: string | null, token: CancellationToken): ProviderResult<SemanticTokens | SemanticTokensEdits>;
 	releaseDocumentSemanticTokens(resultId: string | undefined): void;
 }
 
 export interface DocumentRangeSemanticTokensProvider {
-	onDidChange?: Event<void>;
+	readonly onDidChange?: Event<void>;
 	getLegend(): SemanticTokensLegend;
 	provideDocumentRangeSemanticTokens(model: model.ITextModel, range: Range, token: CancellationToken): ProviderResult<SemanticTokens>;
 }
@@ -2448,7 +2448,7 @@ export interface ITokenizationRegistry<TSupport> {
 	 *  - a tokenization support is registered, unregistered or changed.
 	 *  - the color map is changed.
 	 */
-	onDidChange: Event<ITokenizationSupportChangedEvent>;
+	readonly onDidChange: Event<ITokenizationSupportChangedEvent>;
 
 	/**
 	 * Fire a change event for a language.

--- a/src/vs/editor/common/languages/language.ts
+++ b/src/vs/editor/common/languages/language.ts
@@ -57,7 +57,7 @@ export interface ILanguageService {
 	 * **Note**: Basic language features refers to language configuration related features.
 	 * **Note**: This event is a superset of `onDidRequestRichLanguageFeatures`
 	 */
-	onDidRequestBasicLanguageFeatures: Event<string>;
+	readonly onDidRequestBasicLanguageFeatures: Event<string>;
 
 	/**
 	 * An event emitted when rich language features are requested for the first time.
@@ -66,12 +66,12 @@ export interface ILanguageService {
 	 * **Note**: Rich language features refers to tokenizers, language features based on providers, etc.
 	 * **Note**: This event is a subset of `onDidRequestRichLanguageFeatures`
 	 */
-	onDidRequestRichLanguageFeatures: Event<string>;
+	readonly onDidRequestRichLanguageFeatures: Event<string>;
 
 	/**
 	 * An event emitted when languages have changed.
 	 */
-	onDidChange: Event<void>;
+	readonly onDidChange: Event<void>;
 
 	/**
 	 * Register a language.

--- a/src/vs/editor/common/languages/languageConfigurationRegistry.ts
+++ b/src/vs/editor/common/languages/languageConfigurationRegistry.ts
@@ -35,7 +35,7 @@ export interface ICommentsConfiguration {
 export interface ILanguageConfigurationService {
 	readonly _serviceBrand: undefined;
 
-	onDidChange: Event<LanguageConfigurationServiceChangeEvent>;
+	readonly onDidChange: Event<LanguageConfigurationServiceChangeEvent>;
 
 	/**
 	 * @param priority Use a higher number for higher priority

--- a/src/vs/editor/common/model.ts
+++ b/src/vs/editor/common/model.ts
@@ -1503,7 +1503,7 @@ export class ValidAnnotatedEditOperation implements IIdentifiedSingleEditOperati
  * `lineNumber` is 1 based.
  */
 export interface IReadonlyTextBuffer {
-	onDidChangeContent: Event<void>;
+	readonly onDidChangeContent: Event<void>;
 	equals(other: ITextBuffer): boolean;
 	mightContainRTL(): boolean;
 	mightContainUnusualLineTerminators(): boolean;

--- a/src/vs/editor/common/model/decorationProvider.ts
+++ b/src/vs/editor/common/model/decorationProvider.ts
@@ -25,5 +25,5 @@ export interface DecorationProvider {
 	 */
 	getAllDecorations(ownerId?: number, filterOutValidation?: boolean, onlyMinimapDecorations?: boolean): IModelDecoration[];
 
-	onDidChange: Event<void>;
+	readonly onDidChange: Event<void>;
 }

--- a/src/vs/editor/common/services/markerDecorations.ts
+++ b/src/vs/editor/common/services/markerDecorations.ts
@@ -16,7 +16,7 @@ export const IMarkerDecorationsService = createDecorator<IMarkerDecorationsServi
 export interface IMarkerDecorationsService {
 	readonly _serviceBrand: undefined;
 
-	onDidChangeMarker: Event<ITextModel>;
+	readonly onDidChangeMarker: Event<ITextModel>;
 
 	getMarker(uri: URI, decoration: IModelDecoration): IMarker | null;
 

--- a/src/vs/editor/common/services/textResourceConfiguration.ts
+++ b/src/vs/editor/common/services/textResourceConfiguration.ts
@@ -36,7 +36,7 @@ export interface ITextResourceConfigurationService {
 	/**
 	 * Event that fires when the configuration changes.
 	 */
-	onDidChangeConfiguration: Event<ITextResourceConfigurationChangeEvent>;
+	readonly onDidChangeConfiguration: Event<ITextResourceConfigurationChangeEvent>;
 
 	/**
 	 * Fetches the value of the section for the given resource by applying language overrides.

--- a/src/vs/editor/common/textModelBracketPairs.ts
+++ b/src/vs/editor/common/textModelBracketPairs.ts
@@ -14,7 +14,7 @@ export interface IBracketPairsTextModelPart {
 	/**
 	 * Is fired when bracket pairs change, either due to a text or a settings change.
 	*/
-	onDidChange: Event<void>;
+	readonly onDidChange: Event<void>;
 
 	/**
 	 * Gets all bracket pairs that intersect the given position.

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViewInterface.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViewInterface.ts
@@ -18,7 +18,7 @@ export enum InlineEditTabAction {
 export interface IInlineEditsView {
 	isHovered: IObservable<boolean>;
 	minEditorScrollHeight?: IObservable<number>;
-	onDidClick: Event<IMouseEvent>;
+	readonly onDidClick: Event<IMouseEvent>;
 }
 
 export interface IInlineEditHost {

--- a/src/vs/editor/contrib/stickyScroll/browser/stickyScrollController.ts
+++ b/src/vs/editor/contrib/stickyScroll/browser/stickyScrollController.ts
@@ -44,7 +44,7 @@ export interface IStickyScrollController {
 	findScrollWidgetState(): StickyScrollWidgetState;
 	dispose(): void;
 	selectEditor(): void;
-	onDidChangeStickyScrollHeight: Event<{ height: number }>;
+	readonly onDidChangeStickyScrollHeight: Event<{ height: number }>;
 }
 
 export class StickyScrollController extends Disposable implements IEditorContribution, IStickyScrollController {

--- a/src/vs/editor/contrib/stickyScroll/browser/stickyScrollProvider.ts
+++ b/src/vs/editor/contrib/stickyScroll/browser/stickyScrollProvider.ts
@@ -50,7 +50,7 @@ export interface IStickyLineCandidateProvider {
 	/**
 	 * Event triggered when sticky scroll changes.
 	 */
-	onDidChangeStickyScroll: Event<void>;
+	readonly onDidChangeStickyScroll: Event<void>;
 }
 
 export class StickyLineCandidateProvider extends Disposable implements IStickyLineCandidateProvider {

--- a/src/vs/editor/standalone/browser/standaloneServices.ts
+++ b/src/vs/editor/standalone/browser/standaloneServices.ts
@@ -1009,7 +1009,7 @@ class StandaloneWorkspaceTrustManagementService implements IWorkspaceTrustManage
 
 	private _neverEmitter = new Emitter<never>();
 	public readonly onDidChangeTrust: Event<boolean> = this._neverEmitter.event;
-	onDidChangeTrustedFolders: Event<void> = this._neverEmitter.event;
+	readonly onDidChangeTrustedFolders: Event<void> = this._neverEmitter.event;
 	public readonly workspaceResolved = Promise.resolve();
 	public readonly workspaceTrustInitialized = Promise.resolve();
 	public readonly acceptsOutOfWorkspaceFiles = true;

--- a/src/vs/editor/test/browser/diff/testDiffProviderFactoryService.ts
+++ b/src/vs/editor/test/browser/diff/testDiffProviderFactoryService.ts
@@ -29,5 +29,5 @@ class SyncDocumentDiffProvider implements IDocumentDiffProvider {
 		});
 	}
 
-	onDidChange: Event<void> = () => toDisposable(() => { });
+	readonly onDidChange: Event<void> = () => toDisposable(() => { });
 }

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -2880,7 +2880,7 @@ declare namespace monaco.editor {
 		 * An event emitted when decorations change in the editor,
 		 * but the change is not caused by us setting or clearing the collection.
 		 */
-		onDidChange: IEvent<IModelDecorationsChangedEvent>;
+		readonly onDidChange: IEvent<IModelDecorationsChangedEvent>;
 		/**
 		 * Get the decorations count.
 		 */
@@ -5687,7 +5687,7 @@ declare namespace monaco.editor {
 		/**
 		 * Event fired when the widget layout changes.
 		 */
-		onDidLayout?: IEvent<void>;
+		readonly onDidLayout?: IEvent<void>;
 		/**
 		 * Render this overlay widget in a location where it could overflow the editor's view dom node.
 		 */
@@ -6505,7 +6505,7 @@ declare namespace monaco.editor {
 	export const EditorZoom: IEditorZoom;
 
 	export interface IEditorZoom {
-		onDidChangeZoomLevel: IEvent<number>;
+		readonly onDidChangeZoomLevel: IEvent<number>;
 		getZoomLevel(): number;
 		setZoomLevel(zoomLevel: number): void;
 	}
@@ -8492,14 +8492,14 @@ declare namespace monaco.languages {
 	}
 
 	export interface DocumentSemanticTokensProvider {
-		onDidChange?: IEvent<void>;
+		readonly onDidChange?: IEvent<void>;
 		getLegend(): SemanticTokensLegend;
 		provideDocumentSemanticTokens(model: editor.ITextModel, lastResultId: string | null, token: CancellationToken): ProviderResult<SemanticTokens | SemanticTokensEdits>;
 		releaseDocumentSemanticTokens(resultId: string | undefined): void;
 	}
 
 	export interface DocumentRangeSemanticTokensProvider {
-		onDidChange?: IEvent<void>;
+		readonly onDidChange?: IEvent<void>;
 		getLegend(): SemanticTokensLegend;
 		provideDocumentRangeSemanticTokens(model: editor.ITextModel, range: Range, token: CancellationToken): ProviderResult<SemanticTokens>;
 	}

--- a/src/vs/platform/accessibility/browser/accessibleView.ts
+++ b/src/vs/platform/accessibility/browser/accessibleView.ts
@@ -100,7 +100,7 @@ export interface IAccessibleViewContentProvider extends IBasicContentProvider, I
 	/**
 	 * Note that this will only take effect if the provider has an ID.
 	 */
-	onDidRequestClearLastProvider?: Event<AccessibleViewProviderId>;
+	readonly onDidRequestClearLastProvider?: Event<AccessibleViewProviderId>;
 }
 
 
@@ -201,5 +201,5 @@ export interface IBasicContentProvider extends IDisposable {
 	actions?: IAction[];
 	providePreviousContent?(): void;
 	provideNextContent?(): void;
-	onDidChangeContent?: Event<void>;
+	readonly onDidChangeContent?: Event<void>;
 }

--- a/src/vs/platform/actions/browser/actionViewItemService.ts
+++ b/src/vs/platform/actions/browser/actionViewItemService.ts
@@ -24,7 +24,7 @@ export interface IActionViewItemService {
 
 	_serviceBrand: undefined;
 
-	onDidChange: Event<MenuId>;
+	readonly onDidChange: Event<MenuId>;
 
 	register(menu: MenuId, submenu: MenuId, provider: IActionViewItemFactory, event?: Event<unknown>): IDisposable;
 	register(menu: MenuId, commandId: string, provider: IActionViewItemFactory, event?: Event<unknown>): IDisposable;
@@ -36,7 +36,7 @@ export interface IActionViewItemService {
 export class NullActionViewItemService implements IActionViewItemService {
 	_serviceBrand: undefined;
 
-	onDidChange: Event<MenuId> = Event.None;
+	readonly onDidChange: Event<MenuId> = Event.None;
 
 	register(menu: MenuId, commandId: string | MenuId, provider: IActionViewItemFactory, event?: Event<unknown>): IDisposable {
 		return Disposable.None;

--- a/src/vs/platform/commands/common/commands.ts
+++ b/src/vs/platform/commands/common/commands.ts
@@ -58,7 +58,7 @@ export interface ICommandMetadata {
 }
 
 export interface ICommandRegistry {
-	onDidRegisterCommand: Event<string>;
+	readonly onDidRegisterCommand: Event<string>;
 	registerCommand(id: string, command: ICommandHandler): IDisposable;
 	registerCommand(command: ICommand): IDisposable;
 	registerCommandAlias(oldId: string, newId: string): IDisposable;

--- a/src/vs/platform/configuration/common/configuration.ts
+++ b/src/vs/platform/configuration/common/configuration.ts
@@ -150,7 +150,7 @@ export interface IConfigurationUpdateOptions {
 export interface IConfigurationService {
 	readonly _serviceBrand: undefined;
 
-	onDidChangeConfiguration: Event<IConfigurationChangeEvent>;
+	readonly onDidChangeConfiguration: Event<IConfigurationChangeEvent>;
 
 	getConfigurationData(): IConfigurationData | null;
 

--- a/src/vs/platform/contextkey/common/contextkey.ts
+++ b/src/vs/platform/contextkey/common/contextkey.ts
@@ -2054,7 +2054,7 @@ export type IScopedContextKeyService = IContextKeyService & IDisposable;
 export interface IContextKeyService {
 	readonly _serviceBrand: undefined;
 
-	onDidChangeContext: Event<IContextKeyChangeEvent>;
+	readonly onDidChangeContext: Event<IContextKeyChangeEvent>;
 	bufferChangeEvents(callback: Function): void;
 
 	createKey<T extends ContextKeyValue>(key: string, defaultValue: T | undefined): IContextKey<T>;

--- a/src/vs/platform/dialogs/common/dialogs.ts
+++ b/src/vs/platform/dialogs/common/dialogs.ts
@@ -456,12 +456,12 @@ export interface IDialogService {
 	/**
 	 * An event that fires when a dialog is about to show.
 	 */
-	onWillShowDialog: Event<void>;
+	readonly onWillShowDialog: Event<void>;
 
 	/**
 	 * An event that fires when a dialog did show (closed).
 	 */
-	onDidShowDialog: Event<void>;
+	readonly onDidShowDialog: Event<void>;
 
 	/**
 	 * Ask the user for confirmation with a modal dialog.

--- a/src/vs/platform/extensionManagement/common/extensionManagementIpc.ts
+++ b/src/vs/platform/extensionManagement/common/extensionManagementIpc.ts
@@ -46,11 +46,11 @@ function transformOutgoingExtension(extension: ILocalExtension, transformer: IUR
 
 export class ExtensionManagementChannel implements IServerChannel {
 
-	onInstallExtension: Event<InstallExtensionEvent>;
-	onDidInstallExtensions: Event<readonly InstallExtensionResult[]>;
-	onUninstallExtension: Event<UninstallExtensionEvent>;
-	onDidUninstallExtension: Event<DidUninstallExtensionEvent>;
-	onDidUpdateExtensionMetadata: Event<DidUpdateExtensionMetadata>;
+	readonly onInstallExtension: Event<InstallExtensionEvent>;
+	readonly onDidInstallExtensions: Event<readonly InstallExtensionResult[]>;
+	readonly onUninstallExtension: Event<UninstallExtensionEvent>;
+	readonly onDidUninstallExtension: Event<DidUninstallExtensionEvent>;
+	readonly onDidUpdateExtensionMetadata: Event<DidUpdateExtensionMetadata>;
 
 	constructor(private service: IExtensionManagementService, private getUriTransformer: (requestContext: any) => IURITransformer | null) {
 		this.onInstallExtension = Event.buffer(service.onInstallExtension, true);

--- a/src/vs/platform/instantiation/test/common/instantiationService.test.ts
+++ b/src/vs/platform/instantiation/test/common/instantiationService.test.ts
@@ -467,7 +467,7 @@ suite('Instantiation Service', () => {
 		const A = createDecorator<A>('A');
 		interface A {
 			_serviceBrand: undefined;
-			onDidDoIt: Event<any>;
+			readonly onDidDoIt: Event<any>;
 			doIt(): void;
 		}
 
@@ -477,7 +477,7 @@ suite('Instantiation Service', () => {
 			_doIt = 0;
 
 			_onDidDoIt = new Emitter<this>();
-			onDidDoIt: Event<this> = this._onDidDoIt.event;
+			readonly onDidDoIt: Event<this> = this._onDidDoIt.event;
 
 			constructor() {
 				created = true;
@@ -531,7 +531,7 @@ suite('Instantiation Service', () => {
 		const A = createDecorator<A>('A');
 		interface A {
 			_serviceBrand: undefined;
-			onDidDoIt: Event<any>;
+			readonly onDidDoIt: Event<any>;
 			doIt(): void;
 			noop(): void;
 		}
@@ -542,7 +542,7 @@ suite('Instantiation Service', () => {
 			_doIt = 0;
 
 			_onDidDoIt = new Emitter<this>();
-			onDidDoIt: Event<this> = this._onDidDoIt.event;
+			readonly onDidDoIt: Event<this> = this._onDidDoIt.event;
 
 			constructor() {
 				created = true;
@@ -599,7 +599,7 @@ suite('Instantiation Service', () => {
 		const A = createDecorator<A>('A');
 		interface A {
 			_serviceBrand: undefined;
-			onDidDoIt: Event<any>;
+			readonly onDidDoIt: Event<any>;
 			doIt(): void;
 		}
 		let created = false;
@@ -608,7 +608,7 @@ suite('Instantiation Service', () => {
 			_doIt = 0;
 
 			_onDidDoIt = new Emitter<this>();
-			onDidDoIt: Event<this> = this._onDidDoIt.event;
+			readonly onDidDoIt: Event<this> = this._onDidDoIt.event;
 
 			constructor() {
 				created = true;

--- a/src/vs/platform/keybinding/common/keybinding.ts
+++ b/src/vs/platform/keybinding/common/keybinding.ts
@@ -45,7 +45,7 @@ export interface IKeybindingService {
 
 	readonly inChordMode: boolean;
 
-	onDidUpdateKeybindings: Event<void>;
+	readonly onDidUpdateKeybindings: Event<void>;
 
 	/**
 	 * Returns none, one or many (depending on keyboard layout)!

--- a/src/vs/platform/label/common/label.ts
+++ b/src/vs/platform/label/common/label.ts
@@ -30,7 +30,7 @@ export interface ILabelService {
 	getSeparator(scheme: string, authority?: string): '/' | '\\';
 
 	registerFormatter(formatter: ResourceLabelFormatter): IDisposable;
-	onDidChangeFormatters: Event<IFormatterChangeEvent>;
+	readonly onDidChangeFormatters: Event<IFormatterChangeEvent>;
 
 	/**
 	 * Registers a formatter that's cached for the machine beyond the lifecycle

--- a/src/vs/platform/log/common/log.ts
+++ b/src/vs/platform/log/common/log.ts
@@ -41,7 +41,7 @@ export enum LogLevel {
 export const DEFAULT_LOG_LEVEL: LogLevel = LogLevel.Info;
 
 export interface ILogger extends IDisposable {
-	onDidChangeLogLevel: Event<LogLevel>;
+	readonly onDidChangeLogLevel: Event<LogLevel>;
 	getLevel(): LogLevel;
 	setLevel(level: LogLevel): void;
 

--- a/src/vs/platform/quickinput/browser/quickInput.ts
+++ b/src/vs/platform/quickinput/browser/quickInput.ts
@@ -121,9 +121,9 @@ export interface QuickInputUI {
 	progressBar: ProgressBar;
 	list: QuickInputList;
 	tree: QuickInputTreeController;
-	onDidAccept: Event<void>;
-	onDidCustom: Event<void>;
-	onDidTriggerButton: Event<IQuickInputButton>;
+	readonly onDidAccept: Event<void>;
+	readonly onDidCustom: Event<void>;
+	readonly onDidTriggerButton: Event<IQuickInputButton>;
 	ignoreFocusOut: boolean;
 	keyMods: Writeable<IKeyMods>;
 	show(controller: QuickInput): void;

--- a/src/vs/platform/quickinput/browser/quickInputList.ts
+++ b/src/vs/platform/quickinput/browser/quickInputList.ts
@@ -674,16 +674,16 @@ export class QuickInputList extends Disposable {
 	readonly onLeave: Event<void> = this._onLeave.event;
 
 	private readonly _visibleCountObservable = observableValue('VisibleCount', 0);
-	onChangedVisibleCount: Event<number> = Event.fromObservable(this._visibleCountObservable, this._store);
+	readonly onChangedVisibleCount: Event<number> = Event.fromObservable(this._visibleCountObservable, this._store);
 
 	private readonly _allVisibleCheckedObservable = observableValue('AllVisibleChecked', false);
-	onChangedAllVisibleChecked: Event<boolean> = Event.fromObservable(this._allVisibleCheckedObservable, this._store);
+	readonly onChangedAllVisibleChecked: Event<boolean> = Event.fromObservable(this._allVisibleCheckedObservable, this._store);
 
 	private readonly _checkedCountObservable = observableValue('CheckedCount', 0);
-	onChangedCheckedCount: Event<number> = Event.fromObservable(this._checkedCountObservable, this._store);
+	readonly onChangedCheckedCount: Event<number> = Event.fromObservable(this._checkedCountObservable, this._store);
 
 	private readonly _checkedElementsObservable = observableValueOpts({ equalsFn: equals }, new Array<IQuickPickItem>());
-	onChangedCheckedElements: Event<IQuickPickItem[]> = Event.fromObservable(this._checkedElementsObservable, this._store);
+	readonly onChangedCheckedElements: Event<IQuickPickItem[]> = Event.fromObservable(this._checkedElementsObservable, this._store);
 
 	private readonly _onButtonTriggered = new Emitter<IQuickPickItemButtonEvent<IQuickPickItem>>();
 	onButtonTriggered = this._onButtonTriggered.event;

--- a/src/vs/platform/quickinput/browser/tree/quickTree.ts
+++ b/src/vs/platform/quickinput/browser/tree/quickTree.ts
@@ -29,7 +29,7 @@ export class QuickTree<T extends IQuickTreeItem> extends QuickInput implements I
 	readonly onDidChangeActive = Event.fromObservable(this._activeItems, this._store);
 
 	private readonly _onDidChangeCheckedLeafItems = new Emitter<T[]>();
-	onDidChangeCheckedLeafItems: Event<T[]> = this._onDidChangeCheckedLeafItems.event;
+	readonly onDidChangeCheckedLeafItems: Event<T[]> = this._onDidChangeCheckedLeafItems.event;
 
 	readonly onDidAccept: Event<void>;
 

--- a/src/vs/platform/quickinput/common/quickInput.ts
+++ b/src/vs/platform/quickinput/common/quickInput.ts
@@ -702,7 +702,7 @@ export interface IQuickInputToggle {
 	 * Event that is fired when the toggle value changes.
 	 * The boolean value indicates whether the change was triggered via keyboard.
 	 */
-	onChange: Event<boolean>;
+	readonly onChange: Event<boolean>;
 }
 
 /**

--- a/src/vs/platform/secrets/common/secrets.ts
+++ b/src/vs/platform/secrets/common/secrets.ts
@@ -24,7 +24,7 @@ export interface ISecretStorageProvider {
 
 export interface ISecretStorageService extends ISecretStorageProvider {
 	readonly _serviceBrand: undefined;
-	onDidChangeSecret: Event<string>;
+	readonly onDidChangeSecret: Event<string>;
 }
 
 export class BaseSecretStorageService extends Disposable implements ISecretStorageService {
@@ -33,7 +33,7 @@ export class BaseSecretStorageService extends Disposable implements ISecretStora
 	private readonly _storagePrefix = 'secret://';
 
 	protected readonly onDidChangeSecretEmitter = this._register(new Emitter<string>());
-	onDidChangeSecret: Event<string> = this.onDidChangeSecretEmitter.event;
+	readonly onDidChangeSecret: Event<string> = this.onDidChangeSecretEmitter.event;
 
 	protected readonly _sequencer = new SequencerByKey<string>();
 

--- a/src/vs/platform/terminal/common/capabilities/capabilities.ts
+++ b/src/vs/platform/terminal/common/capabilities/capabilities.ts
@@ -187,7 +187,7 @@ export interface ICommandInvalidationRequest {
 export interface IBufferMarkCapability {
 	type: TerminalCapability.BufferMarkDetection;
 	markers(): IterableIterator<IMarker>;
-	onMarkAdded: Event<IMarkProperties>;
+	readonly onMarkAdded: Event<IMarkProperties>;
 	addMark(properties?: IMarkProperties): void;
 	getMark(id: string): IMarker | undefined;
 }

--- a/src/vs/platform/terminal/common/terminal.ts
+++ b/src/vs/platform/terminal/common/terminal.ts
@@ -760,12 +760,12 @@ export interface ITerminalChildProcess {
 	 */
 	shouldPersist: boolean;
 
-	onProcessData: Event<IProcessDataEvent | string>;
-	onProcessReady: Event<IProcessReadyEvent>;
-	onProcessReplayComplete?: Event<void>;
-	onDidChangeProperty: Event<IProcessProperty<any>>;
-	onProcessExit: Event<number | undefined>;
-	onRestoreCommands?: Event<ISerializedCommandDetectionCapability>;
+	readonly onProcessData: Event<IProcessDataEvent | string>;
+	readonly onProcessReady: Event<IProcessReadyEvent>;
+	readonly onProcessReplayComplete?: Event<void>;
+	readonly onDidChangeProperty: Event<IProcessProperty<any>>;
+	readonly onProcessExit: Event<number | undefined>;
+	readonly onRestoreCommands?: Event<ISerializedCommandDetectionCapability>;
 
 	/**
 	 * Starts the process.
@@ -1109,19 +1109,19 @@ export interface ITerminalBackend extends ITerminalBackendPtyServiceContribution
 	 * Fired when the ptyHost process becomes non-responsive, this should disable stdin for all
 	 * terminals using this pty host connection and mark them as disconnected.
 	 */
-	onPtyHostUnresponsive: Event<void>;
+	readonly onPtyHostUnresponsive: Event<void>;
 	/**
 	 * Fired when the ptyHost process becomes responsive after being non-responsive. Allowing
 	 * previously disconnected terminals to reconnect.
 	 */
-	onPtyHostResponsive: Event<void>;
+	readonly onPtyHostResponsive: Event<void>;
 	/**
 	 * Fired when the ptyHost has been restarted, this is used as a signal for listening terminals
 	 * that its pty has been lost and will remain disconnected.
 	 */
-	onPtyHostRestart: Event<void>;
+	readonly onPtyHostRestart: Event<void>;
 
-	onDidRequestDetach: Event<{ requestId: number; workspaceId: string; instanceId: number }>;
+	readonly onDidRequestDetach: Event<{ requestId: number; workspaceId: string; instanceId: number }>;
 
 	attachToProcess(id: number): Promise<ITerminalChildProcess | undefined>;
 	attachToRevivedProcess(id: number): Promise<ITerminalChildProcess | undefined>;

--- a/src/vs/platform/terminal/node/ptyHost.ts
+++ b/src/vs/platform/terminal/node/ptyHost.ts
@@ -14,8 +14,8 @@ export interface IPtyHostConnection {
 }
 
 export interface IPtyHostStarter extends IDisposable {
-	onRequestConnection?: Event<void>;
-	onWillShutdown?: Event<void>;
+	readonly onRequestConnection?: Event<void>;
+	readonly onWillShutdown?: Event<void>;
 
 	/**
 	 * Creates a pty host and connects to it.

--- a/src/vs/platform/tunnel/common/tunnel.ts
+++ b/src/vs/platform/tunnel/common/tunnel.ts
@@ -107,7 +107,7 @@ export interface ITunnel {
 	/**
 	 * Implementers of Tunnel should fire onDidDispose when dispose is called.
 	 */
-	onDidDispose: Event<void>;
+	readonly onDidDispose: Event<void>;
 
 	dispose(): Promise<void> | void;
 }
@@ -202,7 +202,7 @@ export function isPortPrivileged(port: number, host: string, os: OperatingSystem
 
 export class DisposableTunnel {
 	private _onDispose: Emitter<void> = new Emitter();
-	onDidDispose: Event<void> = this._onDispose.event;
+	readonly onDidDispose: Event<void> = this._onDispose.event;
 
 	constructor(
 		public readonly remoteAddress: { port: number; host: string },

--- a/src/vs/platform/webview/common/webviewManagerService.ts
+++ b/src/vs/platform/webview/common/webviewManagerService.ts
@@ -33,7 +33,7 @@ export interface FoundInFrameResult {
 export interface IWebviewManagerService {
 	_serviceBrand: unknown;
 
-	onFoundInFrame: Event<FoundInFrameResult>;
+	readonly onFoundInFrame: Event<FoundInFrameResult>;
 
 	setIgnoreMenuShortcuts(id: WebviewWebContentsId | WebviewWindowId, enabled: boolean): Promise<void>;
 

--- a/src/vs/platform/windows/node/windowTracker.ts
+++ b/src/vs/platform/windows/node/windowTracker.ts
@@ -15,8 +15,8 @@ export class ActiveWindowManager extends Disposable {
 	private activeWindowId: number | undefined;
 
 	constructor({ onDidOpenMainWindow, onDidFocusMainWindow, getActiveWindowId }: {
-		onDidOpenMainWindow: Event<number>;
-		onDidFocusMainWindow: Event<number>;
+		readonly onDidOpenMainWindow: Event<number>;
+		readonly onDidFocusMainWindow: Event<number>;
 		getActiveWindowId(): Promise<number | undefined>;
 	}) {
 		super();

--- a/src/vs/platform/windows/test/electron-main/windowsFinder.test.ts
+++ b/src/vs/platform/windows/test/electron-main/windowsFinder.test.ts
@@ -34,15 +34,15 @@ suite('WindowsFinder', () => {
 
 	function createTestCodeWindow(options: { lastFocusTime: number; openedFolderUri?: URI; openedWorkspace?: IWorkspaceIdentifier }): ICodeWindow {
 		return new class implements ICodeWindow {
-			onWillLoad: Event<ILoadEvent> = Event.None;
+			readonly onWillLoad: Event<ILoadEvent> = Event.None;
 			onDidMaximize = Event.None;
 			onDidUnmaximize = Event.None;
-			onDidTriggerSystemContextMenu: Event<{ x: number; y: number }> = Event.None;
-			onDidSignalReady: Event<void> = Event.None;
-			onDidClose: Event<void> = Event.None;
-			onDidDestroy: Event<void> = Event.None;
-			onDidEnterFullScreen: Event<void> = Event.None;
-			onDidLeaveFullScreen: Event<void> = Event.None;
+			readonly onDidTriggerSystemContextMenu: Event<{ x: number; y: number }> = Event.None;
+			readonly onDidSignalReady: Event<void> = Event.None;
+			readonly onDidClose: Event<void> = Event.None;
+			readonly onDidDestroy: Event<void> = Event.None;
+			readonly onDidEnterFullScreen: Event<void> = Event.None;
+			readonly onDidLeaveFullScreen: Event<void> = Event.None;
 			whenClosedOrLoaded: Promise<void> = Promise.resolve();
 			id: number = -1;
 			win: Electron.BrowserWindow = null!;

--- a/src/vs/platform/workspace/common/workspaceTrust.ts
+++ b/src/vs/platform/workspace/common/workspaceTrust.ts
@@ -36,8 +36,8 @@ export const IWorkspaceTrustManagementService = createDecorator<IWorkspaceTrustM
 export interface IWorkspaceTrustManagementService {
 	readonly _serviceBrand: undefined;
 
-	onDidChangeTrust: Event<boolean>;
-	onDidChangeTrustedFolders: Event<void>;
+	readonly onDidChangeTrust: Event<boolean>;
+	readonly onDidChangeTrustedFolders: Event<void>;
 
 	readonly workspaceResolved: Promise<void>;
 	readonly workspaceTrustInitialized: Promise<void>;

--- a/src/vs/workbench/api/browser/mainThreadLanguageModels.ts
+++ b/src/vs/workbench/api/browser/mainThreadLanguageModels.ts
@@ -237,7 +237,7 @@ class LanguageModelAccessAuthProvider implements IAuthenticationProvider {
 
 	// Important for updating the UI
 	private _onDidChangeSessions: Emitter<AuthenticationSessionsChangeEvent> = new Emitter<AuthenticationSessionsChangeEvent>();
-	onDidChangeSessions: Event<AuthenticationSessionsChangeEvent> = this._onDidChangeSessions.event;
+	readonly onDidChangeSessions: Event<AuthenticationSessionsChangeEvent> = this._onDidChangeSessions.event;
 
 	private _session: AuthenticationSession | undefined;
 

--- a/src/vs/workbench/api/browser/statusBarExtensionPoint.ts
+++ b/src/vs/workbench/api/browser/statusBarExtensionPoint.ts
@@ -48,7 +48,7 @@ export const enum StatusBarUpdateKind {
 export interface IExtensionStatusBarItemService {
 	readonly _serviceBrand: undefined;
 
-	onDidChange: Event<IExtensionStatusBarItemChangeEvent>;
+	readonly onDidChange: Event<IExtensionStatusBarItemChangeEvent>;
 
 	setOrUpdateEntry(id: string, statusId: string, extensionId: string | undefined, name: string, text: string, tooltip: IMarkdownString | string | undefined | IManagedHoverTooltipMarkdownString, command: Command | undefined, color: string | ThemeColor | undefined, backgroundColor: ThemeColor | undefined, alignLeft: boolean, priority: number | undefined, accessibilityInformation: IAccessibilityInformation | undefined): StatusBarUpdateKind;
 

--- a/src/vs/workbench/api/common/extHostDebugService.ts
+++ b/src/vs/workbench/api/common/extHostDebugService.ts
@@ -38,15 +38,15 @@ export interface IExtHostDebugService extends ExtHostDebugServiceShape {
 
 	readonly _serviceBrand: undefined;
 
-	onDidStartDebugSession: Event<vscode.DebugSession>;
-	onDidTerminateDebugSession: Event<vscode.DebugSession>;
-	onDidChangeActiveDebugSession: Event<vscode.DebugSession | undefined>;
+	readonly onDidStartDebugSession: Event<vscode.DebugSession>;
+	readonly onDidTerminateDebugSession: Event<vscode.DebugSession>;
+	readonly onDidChangeActiveDebugSession: Event<vscode.DebugSession | undefined>;
 	activeDebugSession: vscode.DebugSession | undefined;
 	activeDebugConsole: vscode.DebugConsole;
-	onDidReceiveDebugSessionCustomEvent: Event<vscode.DebugSessionCustomEvent>;
-	onDidChangeBreakpoints: Event<vscode.BreakpointsChangeEvent>;
+	readonly onDidReceiveDebugSessionCustomEvent: Event<vscode.DebugSessionCustomEvent>;
+	readonly onDidChangeBreakpoints: Event<vscode.BreakpointsChangeEvent>;
 	breakpoints: vscode.Breakpoint[];
-	onDidChangeActiveStackItem: Event<vscode.DebugThread | vscode.DebugStackFrame | undefined>;
+	readonly onDidChangeActiveStackItem: Event<vscode.DebugThread | vscode.DebugStackFrame | undefined>;
 	activeStackItem: vscode.DebugThread | vscode.DebugStackFrame | undefined;
 
 	addBreakpoints(breakpoints0: readonly vscode.Breakpoint[]): Promise<void>;

--- a/src/vs/workbench/api/common/extHostExtensionService.ts
+++ b/src/vs/workbench/api/common/extHostExtensionService.ts
@@ -1162,7 +1162,7 @@ export interface IExtHostExtensionService extends AbstractExtHostExtensionServic
 	registerRemoteAuthorityResolver(authorityPrefix: string, resolver: vscode.RemoteAuthorityResolver): vscode.Disposable;
 	getRemoteExecServer(authority: string): Promise<vscode.ExecServer | undefined>;
 
-	onDidChangeRemoteConnectionData: Event<void>;
+	readonly onDidChangeRemoteConnectionData: Event<void>;
 	getRemoteConnectionData(): IRemoteConnectionData | null;
 }
 

--- a/src/vs/workbench/api/common/extHostNotebook.ts
+++ b/src/vs/workbench/api/common/extHostNotebook.ts
@@ -65,9 +65,9 @@ export class ExtHostNotebookController implements ExtHostNotebookShape {
 	}
 
 	private _onDidOpenNotebookDocument = new Emitter<vscode.NotebookDocument>();
-	onDidOpenNotebookDocument: Event<vscode.NotebookDocument> = this._onDidOpenNotebookDocument.event;
+	readonly onDidOpenNotebookDocument: Event<vscode.NotebookDocument> = this._onDidOpenNotebookDocument.event;
 	private _onDidCloseNotebookDocument = new Emitter<vscode.NotebookDocument>();
-	onDidCloseNotebookDocument: Event<vscode.NotebookDocument> = this._onDidCloseNotebookDocument.event;
+	readonly onDidCloseNotebookDocument: Event<vscode.NotebookDocument> = this._onDidCloseNotebookDocument.event;
 
 	private _onDidChangeVisibleNotebookEditors = new Emitter<vscode.NotebookEditor[]>();
 	onDidChangeVisibleNotebookEditors = this._onDidChangeVisibleNotebookEditors.event;

--- a/src/vs/workbench/api/common/extHostTask.ts
+++ b/src/vs/workbench/api/common/extHostTask.ts
@@ -36,12 +36,12 @@ export interface IExtHostTask extends ExtHostTaskShape {
 	readonly _serviceBrand: undefined;
 
 	taskExecutions: vscode.TaskExecution[];
-	onDidStartTask: Event<vscode.TaskStartEvent>;
-	onDidEndTask: Event<vscode.TaskEndEvent>;
-	onDidStartTaskProcess: Event<vscode.TaskProcessStartEvent>;
-	onDidEndTaskProcess: Event<vscode.TaskProcessEndEvent>;
-	onDidStartTaskProblemMatchers: Event<vscode.TaskProblemMatcherStartedEvent>;
-	onDidEndTaskProblemMatchers: Event<vscode.TaskProblemMatcherEndedEvent>;
+	readonly onDidStartTask: Event<vscode.TaskStartEvent>;
+	readonly onDidEndTask: Event<vscode.TaskEndEvent>;
+	readonly onDidStartTaskProcess: Event<vscode.TaskProcessStartEvent>;
+	readonly onDidEndTaskProcess: Event<vscode.TaskProcessEndEvent>;
+	readonly onDidStartTaskProblemMatchers: Event<vscode.TaskProblemMatcherStartedEvent>;
+	readonly onDidEndTaskProblemMatchers: Event<vscode.TaskProblemMatcherEndedEvent>;
 
 	registerTaskProvider(extension: IExtensionDescription, type: string, provider: vscode.TaskProvider): vscode.Disposable;
 	registerTaskSystem(scheme: string, info: tasks.ITaskSystemInfoDTO): void;

--- a/src/vs/workbench/api/test/browser/extHostMessagerService.test.ts
+++ b/src/vs/workbench/api/test/browser/extHostMessagerService.test.ts
@@ -26,7 +26,7 @@ const emptyCommandService: ICommandService = {
 
 const emptyNotificationService = new class implements INotificationService {
 	declare readonly _serviceBrand: undefined;
-	onDidChangeFilter: Event<void> = Event.None;
+	readonly onDidChangeFilter: Event<void> = Event.None;
 	notify(...args: unknown[]): never {
 		throw new Error('not implemented');
 	}
@@ -65,7 +65,7 @@ class EmptyNotificationService implements INotificationService {
 	constructor(private withNotify: (notification: INotification) => void) {
 	}
 
-	onDidChangeFilter: Event<void> = Event.None;
+	readonly onDidChangeFilter: Event<void> = Event.None;
 	notify(notification: INotification): INotificationHandle {
 		this.withNotify(notification);
 

--- a/src/vs/workbench/browser/web.api.ts
+++ b/src/vs/workbench/browser/web.api.ts
@@ -521,7 +521,7 @@ export interface ITunnel {
 	/**
 	 * Implementers of Tunnel should fire onDidDispose when dispose is called.
 	 */
-	onDidDispose: Event<void>;
+	readonly onDidDispose: Event<void>;
 
 	dispose(): Promise<void> | void;
 }

--- a/src/vs/workbench/common/views.ts
+++ b/src/vs/workbench/common/views.ts
@@ -845,7 +845,7 @@ export class NoTreeViewError extends Error {
 
 export interface ITreeViewDataProvider {
 	readonly isTreeEmpty?: boolean;
-	onDidChangeEmpty?: Event<void>;
+	readonly onDidChangeEmpty?: Event<void>;
 	getChildren(element?: ITreeItem): Promise<ITreeItem[] | undefined>;
 	getChildrenBatch?(element?: ITreeItem[]): Promise<ITreeItem[][] | undefined>;
 }
@@ -865,9 +865,9 @@ export interface IEditableData {
 }
 
 export interface IViewPaneContainer {
-	onDidAddViews: Event<IView[]>;
-	onDidRemoveViews: Event<IView[]>;
-	onDidChangeViewVisibility: Event<IView>;
+	readonly onDidAddViews: Event<IView[]>;
+	readonly onDidRemoveViews: Event<IView[]>;
+	readonly onDidChangeViewVisibility: Event<IView>;
 
 	readonly views: IView[];
 

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/chatConfirmationWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/chatConfirmationWidget.ts
@@ -33,7 +33,7 @@ export interface IChatConfirmationButton<T> {
 	tooltip?: string;
 	data: T;
 	disabled?: boolean;
-	onDidChangeDisablement?: Event<boolean>;
+	readonly onDidChangeDisablement?: Event<boolean>;
 	moreActions?: (IChatConfirmationButton<T> | Separator)[];
 }
 

--- a/src/vs/workbench/contrib/chat/browser/viewsWelcome/chatViewsWelcome.ts
+++ b/src/vs/workbench/contrib/chat/browser/viewsWelcome/chatViewsWelcome.ts
@@ -22,7 +22,7 @@ export interface IChatViewsWelcomeDescriptor {
 }
 
 export interface IChatViewsWelcomeContributionRegistry {
-	onDidChange: Event<void>;
+	readonly onDidChange: Event<void>;
 	get(): ReadonlyArray<IChatViewsWelcomeDescriptor>;
 	register(descriptor: IChatViewsWelcomeDescriptor): void;
 }

--- a/src/vs/workbench/contrib/chat/common/chatModes.ts
+++ b/src/vs/workbench/contrib/chat/common/chatModes.ts
@@ -24,7 +24,7 @@ export interface IChatModeService {
 	readonly _serviceBrand: undefined;
 
 	// TODO expose an observable list of modes
-	onDidChangeChatModes: Event<void>;
+	readonly onDidChangeChatModes: Event<void>;
 	getModes(): { builtin: readonly IChatMode[]; custom: readonly IChatMode[] };
 	findModeById(id: string): IChatMode | undefined;
 	findModeByName(name: string): IChatMode | undefined;

--- a/src/vs/workbench/contrib/chat/common/chatService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService.ts
@@ -176,7 +176,7 @@ export interface IChatProgressMessage {
 export interface IChatTask extends IChatTaskDto {
 	deferred: DeferredPromise<string | void>;
 	progress: (IChatWarningMessage | IChatContentReference)[];
-	onDidAddProgress: Event<IChatWarningMessage | IChatContentReference>;
+	readonly onDidAddProgress: Event<IChatWarningMessage | IChatContentReference>;
 	add(progress: IChatWarningMessage | IChatContentReference): void;
 
 	complete: (result: string | void) => void;
@@ -725,7 +725,7 @@ export interface IChatService {
 	_serviceBrand: undefined;
 	transferredSessionData: IChatTransferredSessionData | undefined;
 
-	onDidSubmitRequest: Event<{ chatSessionId: string }>;
+	readonly onDidSubmitRequest: Event<{ chatSessionId: string }>;
 
 	isEnabled(location: ChatAgentLocation): boolean;
 	hasSessions(): boolean;
@@ -757,9 +757,9 @@ export interface IChatService {
 	getChatStorageFolder(): URI;
 	logChatIndex(): void;
 
-	onDidPerformUserAction: Event<IChatUserActionEvent>;
+	readonly onDidPerformUserAction: Event<IChatUserActionEvent>;
 	notifyUserAction(event: IChatUserActionEvent): void;
-	onDidDisposeSession: Event<{ sessionId: string; reason: 'cleared' }>;
+	readonly onDidDisposeSession: Event<{ sessionId: string; reason: 'cleared' }>;
 
 	transferChatSession(transferredSessionData: IChatTransferredSessionData, toWorkspace: URI): void;
 

--- a/src/vs/workbench/contrib/chat/common/languageModelToolsService.ts
+++ b/src/vs/workbench/contrib/chat/common/languageModelToolsService.ts
@@ -316,7 +316,7 @@ export type CountTokensCallback = (input: string, token: CancellationToken) => P
 
 export interface ILanguageModelToolsService {
 	_serviceBrand: undefined;
-	onDidChangeTools: Event<void>;
+	readonly onDidChangeTools: Event<void>;
 	registerToolData(toolData: IToolData): IDisposable;
 	registerToolImplementation(id: string, tool: IToolImpl): IDisposable;
 	registerTool(toolData: IToolData, tool: IToolImpl): IDisposable;

--- a/src/vs/workbench/contrib/chat/common/languageModels.ts
+++ b/src/vs/workbench/contrib/chat/common/languageModels.ts
@@ -206,7 +206,7 @@ export interface ILanguageModelChatResponse {
 }
 
 export interface ILanguageModelChatProvider {
-	onDidChange: Event<void>;
+	readonly onDidChange: Event<void>;
 	provideLanguageModelChatInfo(options: { silent: boolean }, token: CancellationToken): Promise<ILanguageModelChatMetadataAndIdentifier[]>;
 	sendChatRequest(modelId: string, messages: IChatMessage[], from: ExtensionIdentifier, options: { [name: string]: any }, token: CancellationToken): Promise<ILanguageModelChatResponse>;
 	provideTokenCount(modelId: string, message: string | IChatMessage, token: CancellationToken): Promise<number>;
@@ -240,7 +240,7 @@ export interface ILanguageModelsService {
 	readonly _serviceBrand: undefined;
 
 	// TODO @lramos15 - Make this a richer event in the future. Right now it just indicates some change happened, but not what
-	onDidChangeLanguageModels: Event<void>;
+	readonly onDidChangeLanguageModels: Event<void>;
 
 	updateModelPickerPreference(modelIdentifier: string, showInModelPicker: boolean): void;
 

--- a/src/vs/workbench/contrib/chat/test/common/mockChatService.ts
+++ b/src/vs/workbench/contrib/chat/test/common/mockChatService.ts
@@ -21,7 +21,7 @@ export class MockChatService implements IChatService {
 	_serviceBrand: undefined;
 	editingSessions = [];
 	transferredSessionData: IChatTransferredSessionData | undefined;
-	onDidSubmitRequest: Event<{ chatSessionId: string }> = Event.None;
+	readonly onDidSubmitRequest: Event<{ chatSessionId: string }> = Event.None;
 
 	private sessions = new Map<string, IChatModel>();
 
@@ -90,11 +90,11 @@ export class MockChatService implements IChatService {
 		throw new Error('Method not implemented.');
 	}
 
-	onDidPerformUserAction: Event<IChatUserActionEvent> = undefined!;
+	readonly onDidPerformUserAction: Event<IChatUserActionEvent> = undefined!;
 	notifyUserAction(event: IChatUserActionEvent): void {
 		throw new Error('Method not implemented.');
 	}
-	onDidDisposeSession: Event<{ sessionId: string; reason: 'cleared' }> = undefined!;
+	readonly onDidDisposeSession: Event<{ sessionId: string; reason: 'cleared' }> = undefined!;
 
 	transferChatSession(transferredSessionData: IChatTransferredSessionData, toWorkspace: URI): void {
 		throw new Error('Method not implemented.');

--- a/src/vs/workbench/contrib/chat/test/common/mockLanguageModelToolsService.ts
+++ b/src/vs/workbench/contrib/chat/test/common/mockLanguageModelToolsService.ts
@@ -20,7 +20,7 @@ export class MockLanguageModelToolsService implements ILanguageModelToolsService
 	cancelToolCallsForRequest(requestId: string): void {
 	}
 
-	onDidChangeTools: Event<void> = Event.None;
+	readonly onDidChangeTools: Event<void> = Event.None;
 
 	registerToolData(toolData: IToolData): IDisposable {
 		return Disposable.None;

--- a/src/vs/workbench/contrib/comments/test/browser/commentsView.test.ts
+++ b/src/vs/workbench/contrib/comments/test/browser/commentsView.test.ts
@@ -34,15 +34,15 @@ class TestCommentThread implements CommentThread<IRange> {
 		public readonly range: IRange,
 		public readonly comments: Comment[]) { }
 
-	onDidChangeComments: Event<readonly Comment[] | undefined> = new Emitter<readonly Comment[] | undefined>().event;
-	onDidChangeInitialCollapsibleState: Event<CommentThreadCollapsibleState | undefined> = new Emitter<CommentThreadCollapsibleState | undefined>().event;
+	readonly onDidChangeComments: Event<readonly Comment[] | undefined> = new Emitter<readonly Comment[] | undefined>().event;
+	readonly onDidChangeInitialCollapsibleState: Event<CommentThreadCollapsibleState | undefined> = new Emitter<CommentThreadCollapsibleState | undefined>().event;
 	canReply: boolean = false;
-	onDidChangeInput: Event<CommentInput | undefined> = new Emitter<CommentInput | undefined>().event;
-	onDidChangeRange: Event<IRange> = new Emitter<IRange>().event;
-	onDidChangeLabel: Event<string | undefined> = new Emitter<string | undefined>().event;
-	onDidChangeCollapsibleState: Event<CommentThreadCollapsibleState | undefined> = new Emitter<CommentThreadCollapsibleState | undefined>().event;
-	onDidChangeState: Event<CommentThreadState | undefined> = new Emitter<CommentThreadState | undefined>().event;
-	onDidChangeCanReply: Event<boolean> = new Emitter<boolean>().event;
+	readonly onDidChangeInput: Event<CommentInput | undefined> = new Emitter<CommentInput | undefined>().event;
+	readonly onDidChangeRange: Event<IRange> = new Emitter<IRange>().event;
+	readonly onDidChangeLabel: Event<string | undefined> = new Emitter<string | undefined>().event;
+	readonly onDidChangeCollapsibleState: Event<CommentThreadCollapsibleState | undefined> = new Emitter<CommentThreadCollapsibleState | undefined>().event;
+	readonly onDidChangeState: Event<CommentThreadState | undefined> = new Emitter<CommentThreadState | undefined>().event;
+	readonly onDidChangeCanReply: Event<boolean> = new Emitter<boolean>().event;
 	isDisposed: boolean = false;
 	isTemplate: boolean = false;
 	label: string | undefined = undefined;

--- a/src/vs/workbench/contrib/debug/browser/debugAdapterManager.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugAdapterManager.ts
@@ -38,7 +38,7 @@ import { ILifecycleService, LifecyclePhase } from '../../../services/lifecycle/c
 const jsonRegistry = Registry.as<IJSONContributionRegistry>(JSONExtensions.JSONContribution);
 
 export interface IAdapterManagerDelegate {
-	onDidNewSession: Event<IDebugSession>;
+	readonly onDidNewSession: Event<IDebugSession>;
 	configurationManager(): IConfigurationManager;
 }
 

--- a/src/vs/workbench/contrib/debug/common/debug.ts
+++ b/src/vs/workbench/contrib/debug/common/debug.ts
@@ -720,17 +720,17 @@ export interface IViewModel extends ITreeElement {
 
 	isMultiSessionView(): boolean;
 
-	onDidFocusSession: Event<IDebugSession | undefined>;
-	onDidFocusThread: Event<{ thread: IThread | undefined; explicit: boolean; session: IDebugSession | undefined }>;
-	onDidFocusStackFrame: Event<{ stackFrame: IStackFrame | undefined; explicit: boolean; session: IDebugSession | undefined }>;
-	onDidSelectExpression: Event<{ expression: IExpression; settingWatch: boolean } | undefined>;
-	onDidEvaluateLazyExpression: Event<IExpressionContainer>;
+	readonly onDidFocusSession: Event<IDebugSession | undefined>;
+	readonly onDidFocusThread: Event<{ thread: IThread | undefined; explicit: boolean; session: IDebugSession | undefined }>;
+	readonly onDidFocusStackFrame: Event<{ stackFrame: IStackFrame | undefined; explicit: boolean; session: IDebugSession | undefined }>;
+	readonly onDidSelectExpression: Event<{ expression: IExpression; settingWatch: boolean } | undefined>;
+	readonly onDidEvaluateLazyExpression: Event<IExpressionContainer>;
 	/**
 	 * Fired when `setVisualizedExpression`, to migrate elements currently
 	 * rendered as `original` to the `replacement`.
 	 */
-	onDidChangeVisualization: Event<{ original: IExpression; replacement: IExpression }>;
-	onWillUpdateViews: Event<void>;
+	readonly onDidChangeVisualization: Event<{ original: IExpression; replacement: IExpression }>;
+	readonly onWillUpdateViews: Event<void>;
 
 	evaluateLazyExpression(expression: IExpressionContainer): void;
 }
@@ -762,16 +762,16 @@ export interface IDebugModel extends ITreeElement {
 	getWatchExpressions(): ReadonlyArray<IExpression & IEvaluate>;
 	registerBreakpointModes(debugType: string, modes: DebugProtocol.BreakpointMode[]): void;
 	getBreakpointModes(forBreakpointType: 'source' | 'exception' | 'data' | 'instruction'): DebugProtocol.BreakpointMode[];
-	onDidChangeBreakpoints: Event<IBreakpointsChangeEvent | undefined>;
-	onDidChangeCallStack: Event<void>;
+	readonly onDidChangeBreakpoints: Event<IBreakpointsChangeEvent | undefined>;
+	readonly onDidChangeCallStack: Event<void>;
 	/**
 	 * The expression has been added, removed, or repositioned.
 	 */
-	onDidChangeWatchExpressions: Event<IExpression | undefined>;
+	readonly onDidChangeWatchExpressions: Event<IExpression | undefined>;
 	/**
 	 * The expression's value has changed.
 	 */
-	onDidChangeWatchExpressionValue: Event<IExpression | undefined>;
+	readonly onDidChangeWatchExpressionValue: Event<IExpression | undefined>;
 
 	fetchCallstack(thread: IThread, levels?: number): Promise<void>;
 }
@@ -1022,12 +1022,12 @@ export interface IConfigurationManager {
 	/**
 	 * Allows to register on change of selected debug configuration.
 	 */
-	onDidSelectConfiguration: Event<void>;
+	readonly onDidSelectConfiguration: Event<void>;
 
 	/**
 	 * Allows to register on change of selected debug configuration.
 	 */
-	onDidChangeConfigurationProviders: Event<void>;
+	readonly onDidChangeConfigurationProviders: Event<void>;
 
 	hasDebugConfigurationProvider(debugType: string, triggerKind?: DebugConfigurationProviderTriggerKind): boolean;
 	getDynamicProviders(): Promise<{ label: string; type: string; pick: () => Promise<{ launch: ILaunch; config: IConfig; label: string } | undefined> }[]>;
@@ -1045,7 +1045,7 @@ export enum DebuggerString {
 
 export interface IAdapterManager {
 
-	onDidRegisterDebugger: Event<void>;
+	readonly onDidRegisterDebugger: Event<void>;
 
 	hasEnabledDebuggers(): boolean;
 	getDebugAdapterDescriptor(session: IDebugSession): Promise<IAdapterDescriptor | undefined>;
@@ -1139,19 +1139,19 @@ export interface IDebugService {
 	/**
 	 * Allows to register on debug state changes.
 	 */
-	onDidChangeState: Event<State>;
+	readonly onDidChangeState: Event<State>;
 
 	/**
 	 * Allows to register on sessions about to be created (not yet fully initialised).
 	 * This is fired exactly one time for any given session.
 	 */
-	onWillNewSession: Event<IDebugSession>;
+	readonly onWillNewSession: Event<IDebugSession>;
 
 	/**
 	 * Fired when a new debug session is started. This may fire multiple times
 	 * for a single session due to restarts.
 	 */
-	onDidNewSession: Event<IDebugSession>;
+	readonly onDidNewSession: Event<IDebugSession>;
 
 	/**
 	 * Allows to register on end session events.
@@ -1159,7 +1159,7 @@ export interface IDebugService {
 	 * Contains a boolean indicating whether the session will restart. If restart
 	 * is true, the session should not considered to be dead yet.
 	 */
-	onDidEndSession: Event<{ session: IDebugSession; restart: boolean }>;
+	readonly onDidEndSession: Event<{ session: IDebugSession; restart: boolean }>;
 
 	/**
 	 * Gets the configuration manager.

--- a/src/vs/workbench/contrib/extensions/browser/extensionsViews.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionsViews.ts
@@ -85,7 +85,7 @@ class ExtensionsViewState extends Disposable implements IExtensionsViewState {
 export interface ExtensionsListViewOptions {
 	server?: IExtensionManagementServer;
 	flexibleHeight?: boolean;
-	onDidChangeTitle?: Event<string>;
+	readonly onDidChangeTitle?: Event<string>;
 	hideBadge?: boolean;
 }
 

--- a/src/vs/workbench/contrib/extensions/common/extensions.ts
+++ b/src/vs/workbench/contrib/extensions/common/extensions.ts
@@ -203,8 +203,8 @@ export interface IExtensionContainer extends IDisposable {
 }
 
 export interface IExtensionsViewState {
-	onFocus: Event<IExtension>;
-	onBlur: Event<IExtension>;
+	readonly onFocus: Event<IExtension>;
+	readonly onBlur: Event<IExtension>;
 	filters: {
 		featureId?: string;
 	};

--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChatSessionService.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChatSessionService.ts
@@ -42,10 +42,10 @@ export interface IInlineChatSession2 {
 export interface IInlineChatSessionService {
 	_serviceBrand: undefined;
 
-	onWillStartSession: Event<IActiveCodeEditor>;
-	onDidMoveSession: Event<IInlineChatSessionEvent>;
-	onDidStashSession: Event<IInlineChatSessionEvent>;
-	onDidEndSession: Event<IInlineChatSessionEndEvent>;
+	readonly onWillStartSession: Event<IActiveCodeEditor>;
+	readonly onDidMoveSession: Event<IInlineChatSessionEvent>;
+	readonly onDidStashSession: Event<IInlineChatSessionEvent>;
+	readonly onDidEndSession: Event<IInlineChatSessionEndEvent>;
 
 	createSession(editor: IActiveCodeEditor, options: { wholeRange?: IRange; session?: Session; headless?: boolean }, token: CancellationToken): Promise<Session | undefined>;
 
@@ -68,5 +68,5 @@ export interface IInlineChatSessionService {
 
 	createSession2(editor: ICodeEditor, uri: URI, token: CancellationToken): Promise<IInlineChatSession2>;
 	getSession2(uri: URI): IInlineChatSession2 | undefined;
-	onDidChangeSessions: Event<this>;
+	readonly onDidChangeSessions: Event<this>;
 }

--- a/src/vs/workbench/contrib/interactive/browser/interactiveDocumentService.ts
+++ b/src/vs/workbench/contrib/interactive/browser/interactiveDocumentService.ts
@@ -12,8 +12,8 @@ export const IInteractiveDocumentService = createDecorator<IInteractiveDocumentS
 
 export interface IInteractiveDocumentService {
 	readonly _serviceBrand: undefined;
-	onWillAddInteractiveDocument: Event<{ notebookUri: URI; inputUri: URI; languageId: string }>;
-	onWillRemoveInteractiveDocument: Event<{ notebookUri: URI; inputUri: URI }>;
+	readonly onWillAddInteractiveDocument: Event<{ notebookUri: URI; inputUri: URI; languageId: string }>;
+	readonly onWillRemoveInteractiveDocument: Event<{ notebookUri: URI; inputUri: URI }>;
 	willCreateInteractiveDocument(notebookUri: URI, inputUri: URI, languageId: string): void;
 	willRemoveInteractiveDocument(notebookUri: URI, inputUri: URI): void;
 }

--- a/src/vs/workbench/contrib/mcp/browser/mcpServersView.ts
+++ b/src/vs/workbench/contrib/mcp/browser/mcpServersView.ts
@@ -61,7 +61,7 @@ interface IQueryResult {
 	model: IPagedModel<IWorkbenchMcpServer>;
 	disposables: DisposableStore;
 	showWelcomeContent?: boolean;
-	onDidChangeModel?: Event<IPagedModel<IWorkbenchMcpServer>>;
+	readonly onDidChangeModel?: Event<IPagedModel<IWorkbenchMcpServer>>;
 }
 
 type Message = {

--- a/src/vs/workbench/contrib/notebook/browser/diff/notebookDiffEditorBrowser.ts
+++ b/src/vs/workbench/contrib/notebook/browser/diff/notebookDiffEditorBrowser.ts
@@ -34,9 +34,9 @@ export interface INotebookTextDiffEditor {
 	readonly textModel?: NotebookTextModel;
 	inlineNotebookEditor: INotebookEditor | undefined;
 	readonly currentChangedIndex: IObservable<number>;
-	onMouseUp: Event<{ readonly event: MouseEvent; readonly target: IDiffElementViewModelBase }>;
-	onDidScroll: Event<void>;
-	onDidDynamicOutputRendered: Event<{ cell: IGenericCellViewModel; output: ICellOutputViewModel }>;
+	readonly onMouseUp: Event<{ readonly event: MouseEvent; readonly target: IDiffElementViewModelBase }>;
+	readonly onDidScroll: Event<void>;
+	readonly onDidDynamicOutputRendered: Event<{ cell: IGenericCellViewModel; output: ICellOutputViewModel }>;
 	getOverflowContainerDomNode(): HTMLElement;
 	getLayoutInfo(): NotebookLayoutInfo;
 	getScrollTop(): number;
@@ -112,7 +112,7 @@ export interface NotebookDocumentDiffElementRenderTemplate extends CellDiffCommo
 }
 
 export interface IDiffCellMarginOverlay extends IDisposable {
-	onAction: Event<void>;
+	readonly onAction: Event<void>;
 	show(): void;
 	hide(): void;
 }
@@ -185,7 +185,7 @@ export interface INotebookDiffViewModel extends IDisposable {
 	/**
 	 * Triggered when ever there's a change in the view model items.
 	 */
-	onDidChangeItems: Event<INotebookDiffViewModelUpdateEvent>;
+	readonly onDidChangeItems: Event<INotebookDiffViewModelUpdateEvent>;
 	/**
 	 * Computes the differences and generates the viewmodel.
 	 * If view models are generated, then the onDidChangeItems is triggered.

--- a/src/vs/workbench/contrib/notebook/browser/diff/unchangedEditorRegions.ts
+++ b/src/vs/workbench/contrib/notebook/browser/diff/unchangedEditorRegions.ts
@@ -14,7 +14,7 @@ export type UnchangedEditorRegionOptions = {
 		minimumLineCount: number;
 		revealLineCount: number;
 	};
-	onDidChangeEnablement: Event<boolean>;
+	readonly onDidChangeEnablement: Event<boolean>;
 };
 
 export function getUnchangedRegionSettings(configurationService: IConfigurationService): (Readonly<UnchangedEditorRegionOptions> & IDisposable) {

--- a/src/vs/workbench/contrib/notebook/browser/notebookBrowser.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebookBrowser.ts
@@ -493,9 +493,9 @@ export interface INotebookViewModel {
 	readonly viewCells: ICellViewModel[];
 	layoutInfo: NotebookLayoutInfo | null;
 	viewType: string;
-	onDidChangeViewCells: Event<INotebookViewCellsUpdateEvent>;
-	onDidChangeSelection: Event<string>;
-	onDidFoldingStateChanged: Event<void>;
+	readonly onDidChangeViewCells: Event<INotebookViewCellsUpdateEvent>;
+	readonly onDidChangeSelection: Event<string>;
+	readonly onDidFoldingStateChanged: Event<void>;
 	getNearestVisibleCellIndexUpwards(index: number): number;
 	getTrackedRange(id: string): ICellRange | null;
 	setTrackedRange(id: string | null, newRange: ICellRange | null, newStickiness: TrackedRangeStickiness): string | null;

--- a/src/vs/workbench/contrib/notebook/browser/services/notebookEditorService.ts
+++ b/src/vs/workbench/contrib/notebook/browser/services/notebookEditorService.ts
@@ -24,8 +24,8 @@ export interface INotebookEditorService {
 
 	retrieveExistingWidgetFromURI(resource: URI): IBorrowValue<NotebookEditorWidget> | undefined;
 	retrieveAllExistingWidgets(): IBorrowValue<NotebookEditorWidget>[];
-	onDidAddNotebookEditor: Event<INotebookEditor>;
-	onDidRemoveNotebookEditor: Event<INotebookEditor>;
+	readonly onDidAddNotebookEditor: Event<INotebookEditor>;
+	readonly onDidRemoveNotebookEditor: Event<INotebookEditor>;
 	addNotebookEditor(editor: INotebookEditor): void;
 	removeNotebookEditor(editor: INotebookEditor): void;
 	getNotebookEditor(editorId: string): INotebookEditor | undefined;

--- a/src/vs/workbench/contrib/notebook/browser/services/notebookServiceImpl.ts
+++ b/src/vs/workbench/contrib/notebook/browser/services/notebookServiceImpl.ts
@@ -570,7 +570,7 @@ export class NotebookService extends Disposable implements INotebookService {
 	readonly onWillRemoveViewType;
 
 	private readonly _onDidChangeEditorTypes;
-	onDidChangeEditorTypes: Event<void>;
+	readonly onDidChangeEditorTypes: Event<void>;
 
 	private _cutItems: NotebookCellTextModel[] | undefined;
 	private _lastClipboardIsCopy: boolean;

--- a/src/vs/workbench/contrib/notebook/browser/view/notebookCellList.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/notebookCellList.ts
@@ -114,7 +114,7 @@ export class NotebookCellList extends WorkbenchList<CellViewModel> implements ID
 
 	private readonly _onDidChangeVisibleRanges = this._localDisposableStore.add(new Emitter<void>());
 
-	onDidChangeVisibleRanges: Event<void> = this._onDidChangeVisibleRanges.event;
+	readonly onDidChangeVisibleRanges: Event<void> = this._onDidChangeVisibleRanges.event;
 	private _visibleRanges: ICellRange[] = [];
 
 	get visibleRanges() {

--- a/src/vs/workbench/contrib/notebook/browser/view/notebookRenderingCommon.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/notebookRenderingCommon.ts
@@ -32,11 +32,11 @@ export interface INotebookCellList extends ICoordinatesConverter {
 	element(index: number): ICellViewModel | undefined;
 	elementAt(position: number): ICellViewModel | undefined;
 	elementHeight(element: ICellViewModel): number;
-	onWillScroll: Event<ScrollEvent>;
-	onDidScroll: Event<ScrollEvent>;
-	onDidChangeFocus: Event<IListEvent<ICellViewModel>>;
-	onDidChangeContentHeight: Event<number>;
-	onDidChangeVisibleRanges: Event<void>;
+	readonly onWillScroll: Event<ScrollEvent>;
+	readonly onDidScroll: Event<ScrollEvent>;
+	readonly onDidChangeFocus: Event<IListEvent<ICellViewModel>>;
+	readonly onDidChangeContentHeight: Event<number>;
+	readonly onDidChangeVisibleRanges: Event<void>;
 	visibleRanges: ICellRange[];
 	scrollTop: number;
 	scrollHeight: number;

--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewPreloads.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewPreloads.ts
@@ -53,7 +53,7 @@ type Listener<T> = { fn: (evt: T) => void; thisArg: unknown };
 
 interface EmitterLike<T> {
 	fire(data: T): void;
-	event: Event<T>;
+	readonly event: Event<T>;
 }
 
 interface PreloadStyles {

--- a/src/vs/workbench/contrib/notebook/browser/viewModel/baseCellViewModel.ts
+++ b/src/vs/workbench/contrib/notebook/browser/viewModel/baseCellViewModel.ts
@@ -117,7 +117,7 @@ export abstract class BaseCellViewModel extends Disposable {
 	private readonly _textModelRefChangeDisposable = this._register(new MutableDisposable());
 
 	private readonly _cellDecorationsChanged = this._register(new Emitter<{ added: INotebookCellDecorationOptions[]; removed: INotebookCellDecorationOptions[] }>());
-	onCellDecorationsChanged: Event<{ added: INotebookCellDecorationOptions[]; removed: INotebookCellDecorationOptions[] }> = this._cellDecorationsChanged.event;
+	readonly onCellDecorationsChanged: Event<{ added: INotebookCellDecorationOptions[]; removed: INotebookCellDecorationOptions[] }> = this._cellDecorationsChanged.event;
 
 	private _resolvedDecorations = new Map<string, {
 		id?: string;

--- a/src/vs/workbench/contrib/notebook/browser/viewModel/notebookViewModelImpl.ts
+++ b/src/vs/workbench/contrib/notebook/browser/viewModel/notebookViewModelImpl.ts
@@ -178,7 +178,7 @@ export class NotebookViewModel extends Disposable implements EditorFoldingStateD
 	public readonly id: string;
 	private _foldingRanges: FoldingRegions | null = null;
 	private _onDidFoldingStateChanged = new Emitter<void>();
-	onDidFoldingStateChanged: Event<void> = this._onDidFoldingStateChanged.event;
+	readonly onDidFoldingStateChanged: Event<void> = this._onDidFoldingStateChanged.event;
 	private _hiddenRanges: ICellRange[] = [];
 	private _focused: boolean = true;
 

--- a/src/vs/workbench/contrib/notebook/browser/viewParts/notebookEditorToolbar.ts
+++ b/src/vs/workbench/contrib/notebook/browser/viewParts/notebookEditorToolbar.ts
@@ -243,7 +243,7 @@ export class NotebookEditorWorkbenchToolbar extends Disposable {
 		}
 	}
 	private readonly _onDidChangeVisibility = this._register(new Emitter<boolean>());
-	onDidChangeVisibility: Event<boolean> = this._onDidChangeVisibility.event;
+	readonly onDidChangeVisibility: Event<boolean> = this._onDidChangeVisibility.event;
 
 	get useGlobalToolbar(): boolean {
 		return this._useGlobalToolbar;

--- a/src/vs/workbench/contrib/notebook/common/notebookCommon.ts
+++ b/src/vs/workbench/contrib/notebook/common/notebookCommon.ts
@@ -235,7 +235,7 @@ export interface ICellOutput {
 	 * Alternative output id that's reused when the output is updated.
 	 */
 	alternativeOutputId: string;
-	onDidChangeData: Event<void>;
+	readonly onDidChangeData: Event<void>;
 	replaceData(items: IOutputDto): void;
 	appendData(items: IOutputItemDto[]): void;
 	appendedSinceVersion(versionId: number, mime: string): VSBuffer | undefined;
@@ -277,13 +277,13 @@ export interface ICell {
 	getHashValue(): number;
 	textBuffer: IReadonlyTextBuffer;
 	textModel?: ITextModel;
-	onDidChangeTextModel: Event<void>;
+	readonly onDidChangeTextModel: Event<void>;
 	getValue(): string;
-	onDidChangeOutputs?: Event<NotebookCellOutputsSplice>;
-	onDidChangeOutputItems?: Event<void>;
-	onDidChangeLanguage: Event<string>;
-	onDidChangeMetadata: Event<void>;
-	onDidChangeInternalMetadata: Event<CellInternalMetadataChangedEvent>;
+	readonly onDidChangeOutputs?: Event<NotebookCellOutputsSplice>;
+	readonly onDidChangeOutputItems?: Event<void>;
+	readonly onDidChangeLanguage: Event<string>;
+	readonly onDidChangeMetadata: Event<void>;
+	readonly onDidChangeInternalMetadata: Event<CellInternalMetadataChangedEvent>;
 }
 
 export interface INotebookSnapshotOptions {
@@ -305,8 +305,8 @@ export interface INotebookTextModel extends INotebookTextModelLike {
 	createSnapshot(options: INotebookSnapshotOptions): NotebookData;
 	restoreSnapshot(snapshot: NotebookData, transientOptions?: TransientOptions): void;
 	applyEdits(rawEdits: ICellEditOperation[], synchronous: boolean, beginSelectionState: ISelectionState | undefined, endSelectionsComputer: () => ISelectionState | undefined, undoRedoGroup: UndoRedoGroup | undefined, computeUndoRedo?: boolean): boolean;
-	onDidChangeContent: Event<NotebookTextModelChangedEvent>;
-	onWillDispose: Event<void>;
+	readonly onDidChangeContent: Event<NotebookTextModelChangedEvent>;
+	readonly onWillDispose: Event<void>;
 }
 
 export type NotebookCellTextModelSplice<T> = [

--- a/src/vs/workbench/contrib/notebook/common/notebookExecutionStateService.ts
+++ b/src/vs/workbench/contrib/notebook/common/notebookExecutionStateService.ts
@@ -83,8 +83,8 @@ export const INotebookExecutionStateService = createDecorator<INotebookExecution
 export interface INotebookExecutionStateService {
 	_serviceBrand: undefined;
 
-	onDidChangeExecution: Event<ICellExecutionStateChangedEvent | IExecutionStateChangedEvent>;
-	onDidChangeLastRunFailState: Event<INotebookFailStateChangedEvent>;
+	readonly onDidChangeExecution: Event<ICellExecutionStateChangedEvent | IExecutionStateChangedEvent>;
+	readonly onDidChangeLastRunFailState: Event<INotebookFailStateChangedEvent>;
 
 	forceCancelNotebookExecutions(notebookUri: URI): void;
 	getCellExecutionsForNotebook(notebook: URI): INotebookCellExecution[];

--- a/src/vs/workbench/contrib/notebook/common/notebookRendererMessagingService.ts
+++ b/src/vs/workbench/contrib/notebook/common/notebookRendererMessagingService.ts
@@ -15,7 +15,7 @@ export interface INotebookRendererMessagingService {
 	/**
 	 * Event that fires when a message should be posted to extension hosts.
 	 */
-	onShouldPostMessage: Event<{ editorId: string; rendererId: string; message: unknown }>;
+	readonly onShouldPostMessage: Event<{ editorId: string; rendererId: string; message: unknown }>;
 
 	/**
 	 * Prepares messaging for the given renderer ID.

--- a/src/vs/workbench/contrib/notebook/test/browser/contrib/notebookCellDiagnostics.test.ts
+++ b/src/vs/workbench/contrib/notebook/test/browser/contrib/notebookCellDiagnostics.test.ts
@@ -55,7 +55,7 @@ suite('notebookCellDiagnostics', () => {
 
 	interface ITestMarkerService extends IMarkerService {
 		markers: ResourceMap<IMarkerData[]>;
-		onMarkersUpdated: Event<void>;
+		readonly onMarkersUpdated: Event<void>;
 	}
 
 	setup(function () {

--- a/src/vs/workbench/contrib/preferences/browser/keybindingWidgets.ts
+++ b/src/vs/workbench/contrib/preferences/browser/keybindingWidgets.ts
@@ -149,7 +149,7 @@ export class DefineKeybindingWidget extends Widget {
 	private _onHide = this._register(new Emitter<void>());
 
 	private _onDidChange = this._register(new Emitter<string>());
-	onDidChange: Event<string> = this._onDidChange.event;
+	readonly onDidChange: Event<string> = this._onDidChange.event;
 
 	private _onShowExistingKeybindings = this._register(new Emitter<string | null>());
 	readonly onShowExistingKeybidings: Event<string | null> = this._onShowExistingKeybindings.event;

--- a/src/vs/workbench/contrib/remote/browser/remote.ts
+++ b/src/vs/workbench/contrib/remote/browser/remote.ts
@@ -57,7 +57,7 @@ import { mainWindow } from '../../../../base/browser/window.js';
 import { IHoverService } from '../../../../platform/hover/browser/hover.js';
 
 interface IViewModel {
-	onDidChangeHelpInformation: Event<void>;
+	readonly onDidChangeHelpInformation: Event<void>;
 	helpInformation: HelpInformation[];
 }
 

--- a/src/vs/workbench/contrib/search/common/searchHistoryService.ts
+++ b/src/vs/workbench/contrib/search/common/searchHistoryService.ts
@@ -10,7 +10,7 @@ import { createDecorator } from '../../../../platform/instantiation/common/insta
 
 export interface ISearchHistoryService {
 	readonly _serviceBrand: undefined;
-	onDidClearHistory: Event<void>;
+	readonly onDidClearHistory: Event<void>;
 	clearHistory(): void;
 	load(): ISearchHistoryValues;
 	save(history: ISearchHistoryValues): void;

--- a/src/vs/workbench/contrib/tasks/common/taskDefinitionRegistry.ts
+++ b/src/vs/workbench/contrib/tasks/common/taskDefinitionRegistry.ts
@@ -103,7 +103,7 @@ export interface ITaskDefinitionRegistry {
 	get(key: string): Tasks.ITaskDefinition;
 	all(): Tasks.ITaskDefinition[];
 	getJsonSchema(): IJSONSchema;
-	onDefinitionsChanged: Event<void>;
+	readonly onDefinitionsChanged: Event<void>;
 }
 
 class TaskDefinitionRegistryImpl implements ITaskDefinitionRegistry {

--- a/src/vs/workbench/contrib/tasks/common/taskService.ts
+++ b/src/vs/workbench/contrib/tasks/common/taskService.ts
@@ -63,11 +63,11 @@ export interface IWorkspaceFolderTaskResult extends IWorkspaceTaskResult {
 
 export interface ITaskService {
 	readonly _serviceBrand: undefined;
-	onDidStateChange: Event<ITaskEvent>;
+	readonly onDidStateChange: Event<ITaskEvent>;
 	/** Fired when task providers are registered or unregistered */
-	onDidChangeTaskProviders: Event<void>;
+	readonly onDidChangeTaskProviders: Event<void>;
 	isReconnected: boolean;
-	onDidReconnectToTasks: Event<void>;
+	readonly onDidReconnectToTasks: Event<void>;
 	supportsMultipleTaskExecutions: boolean;
 
 	configureAction(): Action;
@@ -103,8 +103,8 @@ export interface ITaskService {
 	registerTaskProvider(taskProvider: ITaskProvider, type: string): IDisposable;
 
 	registerTaskSystem(scheme: string, taskSystemInfo: ITaskSystemInfo): void;
-	onDidChangeTaskSystemInfo: Event<void>;
-	onDidChangeTaskConfig: Event<void>;
+	readonly onDidChangeTaskSystemInfo: Event<void>;
+	readonly onDidChangeTaskConfig: Event<void>;
 	readonly hasTaskSystemInfo: boolean;
 	registerSupportedExecutions(custom?: boolean, shell?: boolean, process?: boolean): void;
 

--- a/src/vs/workbench/contrib/tasks/common/taskSystem.ts
+++ b/src/vs/workbench/contrib/tasks/common/taskSystem.ts
@@ -136,7 +136,7 @@ export interface ITaskSystemInfoResolver {
 }
 
 export interface ITaskSystem {
-	onDidStateChange: Event<ITaskEvent>;
+	readonly onDidStateChange: Event<ITaskEvent>;
 	reconnect(task: Task, resolver: ITaskResolver): ITaskExecuteResult;
 	run(task: Task, resolver: ITaskResolver): ITaskExecuteResult;
 	rerun(): ITaskExecuteResult | undefined;

--- a/src/vs/workbench/contrib/terminal/browser/terminal.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminal.ts
@@ -67,12 +67,12 @@ export interface ITerminalInstanceService {
 	/**
 	 * An event that's fired when a terminal instance is created.
 	 */
-	onDidCreateInstance: Event<ITerminalInstance>;
+	readonly onDidCreateInstance: Event<ITerminalInstance>;
 
 	/**
 	 * An event that's fired when a new backend is registered.
 	 */
-	onDidRegisterBackend: Event<ITerminalBackend>;
+	readonly onDidRegisterBackend: Event<ITerminalBackend>;
 
 	/**
 	 * Helper function to convert a shell launch config, a profile or undefined into its equivalent
@@ -740,52 +740,52 @@ export interface ITerminalInstance extends IBaseTerminalInstance {
 	/**
 	 * An event that fires when the terminal instance's title changes.
 	 */
-	onTitleChanged: Event<ITerminalInstance>;
+	readonly onTitleChanged: Event<ITerminalInstance>;
 
 	/**
 	 * An event that fires when the terminal instance's icon changes.
 	 */
-	onIconChanged: Event<{ instance: ITerminalInstance; userInitiated: boolean }>;
+	readonly onIconChanged: Event<{ instance: ITerminalInstance; userInitiated: boolean }>;
 
 	/**
 	 * An event that fires when the terminal instance is disposed.
 	 */
-	onDisposed: Event<ITerminalInstance>;
+	readonly onDisposed: Event<ITerminalInstance>;
 
-	onProcessIdReady: Event<ITerminalInstance>;
-	onProcessReplayComplete: Event<void>;
-	onRequestExtHostProcess: Event<ITerminalInstance>;
-	onDimensionsChanged: Event<void>;
-	onMaximumDimensionsChanged: Event<void>;
-	onDidChangeHasChildProcesses: Event<boolean>;
+	readonly onProcessIdReady: Event<ITerminalInstance>;
+	readonly onProcessReplayComplete: Event<void>;
+	readonly onRequestExtHostProcess: Event<ITerminalInstance>;
+	readonly onDimensionsChanged: Event<void>;
+	readonly onMaximumDimensionsChanged: Event<void>;
+	readonly onDidChangeHasChildProcesses: Event<boolean>;
 
-	onDidFocus: Event<ITerminalInstance>;
-	onDidRequestFocus: Event<void>;
-	onDidBlur: Event<ITerminalInstance>;
-	onDidInputData: Event<string>;
-	onDidChangeSelection: Event<ITerminalInstance>;
-	onDidExecuteText: Event<void>;
-	onDidChangeTarget: Event<TerminalLocation | undefined>;
-	onDidSendText: Event<string>;
-	onDidChangeShellType: Event<TerminalShellType>;
-	onDidChangeVisibility: Event<boolean>;
+	readonly onDidFocus: Event<ITerminalInstance>;
+	readonly onDidRequestFocus: Event<void>;
+	readonly onDidBlur: Event<ITerminalInstance>;
+	readonly onDidInputData: Event<string>;
+	readonly onDidChangeSelection: Event<ITerminalInstance>;
+	readonly onDidExecuteText: Event<void>;
+	readonly onDidChangeTarget: Event<TerminalLocation | undefined>;
+	readonly onDidSendText: Event<string>;
+	readonly onDidChangeShellType: Event<TerminalShellType>;
+	readonly onDidChangeVisibility: Event<boolean>;
 
 	/**
 	 * An event that fires when a terminal is dropped on this instance via drag and drop.
 	 */
-	onRequestAddInstanceToGroup: Event<IRequestAddInstanceToGroupEvent>;
+	readonly onRequestAddInstanceToGroup: Event<IRequestAddInstanceToGroupEvent>;
 
 	/**
 	 * Attach a listener to the raw data stream coming from the pty, including ANSI escape
 	 * sequences.
 	 */
-	onData: Event<string>;
-	onWillData: Event<string>;
+	readonly onData: Event<string>;
+	readonly onWillData: Event<string>;
 
 	/**
 	 * Attach a listener to the binary data stream coming from xterm and going to pty
 	 */
-	onBinary: Event<string>;
+	readonly onBinary: Event<string>;
 
 	/**
 	 * Attach a listener to listen for new lines added to this terminal instance.
@@ -797,14 +797,14 @@ export interface ITerminalInstance extends IBaseTerminalInstance {
 	 * is exited. The lineData string will contain the fully wrapped line, not containing any LF/CR
 	 * characters.
 	 */
-	onLineData: Event<string>;
+	readonly onLineData: Event<string>;
 
 	/**
 	 * Attach a listener that fires when the terminal's pty process exits. The number in the event
 	 * is the processes' exit code, an exit code of undefined means the process was killed as a result of
 	 * the ITerminalInstance being disposed.
 	 */
-	onExit: Event<number | ITerminalLaunchError | undefined>;
+	readonly onExit: Event<number | ITerminalLaunchError | undefined>;
 
 	/**
 	 * The exit code or undefined when the terminal process hasn't yet exited or

--- a/src/vs/workbench/contrib/terminal/common/environmentVariable.ts
+++ b/src/vs/workbench/contrib/terminal/common/environmentVariable.ts
@@ -32,7 +32,7 @@ export interface IEnvironmentVariableService {
 	 * An event that is fired when an extension's environment variable collection changes, the event
 	 * provides the new merged collection.
 	 */
-	onDidChangeCollections: Event<IMergedEnvironmentVariableCollection>;
+	readonly onDidChangeCollections: Event<IMergedEnvironmentVariableCollection>;
 
 	/**
 	 * Sets an extension's environment variable collection.

--- a/src/vs/workbench/contrib/terminal/common/terminal.ts
+++ b/src/vs/workbench/contrib/terminal/common/terminal.ts
@@ -79,7 +79,7 @@ export interface ITerminalProfileService {
 	refreshAvailableProfiles(): void;
 	getDefaultProfileName(): string | undefined;
 	getDefaultProfile(os?: OperatingSystem): ITerminalProfile | undefined;
-	onDidChangeAvailableProfiles: Event<ITerminalProfile[]>;
+	readonly onDidChangeAvailableProfiles: Event<ITerminalProfile[]>;
 	getContributedDefaultProfile(shellLaunchConfig: IShellLaunchConfig): Promise<IExtensionTerminalProfile | undefined>;
 	registerContributedProfile(args: IRegisterContributedProfileArgs): Promise<void>;
 	getContributedProfileProvider(extensionIdentifier: string, id: string): ITerminalProfileProvider | undefined;
@@ -337,13 +337,13 @@ export interface ITerminalProcessExtHostProxy extends IDisposable {
 	emitReady(pid: number, cwd: string, windowsPty: IProcessReadyWindowsPty | undefined): void;
 	emitExit(exitCode: number | undefined): void;
 
-	onInput: Event<string>;
-	onBinary: Event<string>;
-	onResize: Event<{ cols: number; rows: number }>;
-	onAcknowledgeDataEvent: Event<number>;
-	onShutdown: Event<boolean>;
-	onRequestInitialCwd: Event<void>;
-	onRequestCwd: Event<void>;
+	readonly onInput: Event<string>;
+	readonly onBinary: Event<string>;
+	readonly onResize: Event<{ cols: number; rows: number }>;
+	readonly onAcknowledgeDataEvent: Event<number>;
+	readonly onShutdown: Event<boolean>;
+	readonly onRequestInitialCwd: Event<void>;
+	readonly onRequestCwd: Event<void>;
 }
 
 export interface IStartExtensionTerminalRequest {

--- a/src/vs/workbench/contrib/terminal/test/browser/terminalInstance.test.ts
+++ b/src/vs/workbench/contrib/terminal/test/browser/terminalInstance.test.ts
@@ -70,9 +70,9 @@ class TestTerminalChildProcess extends Disposable implements ITerminalChildProce
 		throw new Error('Method not implemented.');
 	}
 
-	onProcessOverrideDimensions?: Event<any> | undefined;
-	onProcessResolvedShellLaunchConfig?: Event<any> | undefined;
-	onDidChangeHasChildProcesses?: Event<any> | undefined;
+	readonly onProcessOverrideDimensions?: Event<any> | undefined;
+	readonly onProcessResolvedShellLaunchConfig?: Event<any> | undefined;
+	readonly onDidChangeHasChildProcesses?: Event<any> | undefined;
 
 	onDidChangeProperty = Event.None;
 	onProcessData = Event.None;

--- a/src/vs/workbench/contrib/terminal/test/browser/terminalProcessManager.test.ts
+++ b/src/vs/workbench/contrib/terminal/test/browser/terminalProcessManager.test.ts
@@ -26,9 +26,9 @@ class TestTerminalChildProcess implements ITerminalChildProcess {
 		throw new Error('Method not implemented.');
 	}
 
-	onProcessOverrideDimensions?: Event<any> | undefined;
-	onProcessResolvedShellLaunchConfig?: Event<any> | undefined;
-	onDidChangeHasChildProcesses?: Event<any> | undefined;
+	readonly onProcessOverrideDimensions?: Event<any> | undefined;
+	readonly onProcessResolvedShellLaunchConfig?: Event<any> | undefined;
+	readonly onDidChangeHasChildProcesses?: Event<any> | undefined;
 
 	onDidChangeProperty = Event.None;
 	onProcessData = Event.None;

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/executeStrategy/executeStrategy.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/executeStrategy/executeStrategy.ts
@@ -18,7 +18,7 @@ export interface ITerminalExecuteStrategy {
 	 */
 	execute(commandLine: string, token: CancellationToken): Promise<ITerminalExecuteStrategyResult>;
 
-	onDidCreateStartMarker: Event<IXtermMarker | undefined>;
+	readonly onDidCreateStartMarker: Event<IXtermMarker | undefined>;
 }
 
 export interface ITerminalExecuteStrategyResult {

--- a/src/vs/workbench/contrib/terminalContrib/quickFix/browser/quickFix.ts
+++ b/src/vs/workbench/contrib/terminalContrib/quickFix/browser/quickFix.ts
@@ -14,9 +14,9 @@ import { ITerminalCommand } from '../../../../../platform/terminal/common/capabi
 
 export const ITerminalQuickFixService = createDecorator<ITerminalQuickFixService>('terminalQuickFixService');
 export interface ITerminalQuickFixService {
-	onDidRegisterProvider: Event<ITerminalQuickFixProviderSelector>;
-	onDidRegisterCommandSelector: Event<ITerminalCommandSelector>;
-	onDidUnregisterProvider: Event<string>;
+	readonly onDidRegisterProvider: Event<ITerminalQuickFixProviderSelector>;
+	readonly onDidRegisterCommandSelector: Event<ITerminalCommandSelector>;
+	readonly onDidUnregisterProvider: Event<string>;
 	readonly _serviceBrand: undefined;
 	readonly extensionQuickFixes: Promise<Array<ITerminalCommandSelector>>;
 	providers: Map<string, ITerminalQuickFixProvider>;

--- a/src/vs/workbench/contrib/testing/browser/explorerProjections/index.ts
+++ b/src/vs/workbench/contrib/testing/browser/explorerProjections/index.ts
@@ -26,7 +26,7 @@ export interface ITestTreeProjection extends IDisposable {
 	/**
 	 * Event that fires when the projection changes.
 	 */
-	onUpdate: Event<void>;
+	readonly onUpdate: Event<void>;
 
 	/**
 	 * State to use for applying default collapse state of items.

--- a/src/vs/workbench/contrib/testing/browser/testResultsView/testResultsOutput.ts
+++ b/src/vs/workbench/contrib/testing/browser/testResultsView/testResultsOutput.ts
@@ -67,7 +67,7 @@ class SimpleDiffEditorModel extends EditorModel {
 
 
 export interface IPeekOutputRenderer extends IDisposable {
-	onDidContentSizeChange?: Event<void>;
+	readonly onDidContentSizeChange?: Event<void>;
 	onScrolled?(evt: ScrollEvent): void;
 	/** Updates the displayed test. Should clear if it cannot display the test. */
 	update(subject: InspectSubject): Promise<boolean>;

--- a/src/vs/workbench/contrib/testing/browser/testResultsView/testResultsTree.ts
+++ b/src/vs/workbench/contrib/testing/browser/testResultsView/testResultsTree.ts
@@ -57,7 +57,7 @@ interface ITreeElement {
 	context: unknown;
 	id: string;
 	label: string;
-	onDidChange: Event<void>;
+	readonly onDidChange: Event<void>;
 	labelWithIcons?: readonly (HTMLSpanElement | string)[];
 	icon?: ThemeIcon;
 	description?: string;
@@ -69,7 +69,7 @@ interface ITreeElement {
 	context: unknown;
 	id: string;
 	label: string;
-	onDidChange: Event<void>;
+	readonly onDidChange: Event<void>;
 	labelWithIcons?: readonly (HTMLSpanElement | string)[];
 	icon?: ThemeIcon;
 	description?: string;
@@ -301,7 +301,7 @@ export class OutputPeekTree extends Disposable {
 
 	constructor(
 		container: HTMLElement,
-		onDidReveal: Event<{ subject: InspectSubject; preserveFocus: boolean }>,
+		readonly onDidReveal: Event<{ subject: InspectSubject; preserveFocus: boolean }>,
 		options: { showRevealLocationOnMessages: boolean; locationForProgress: string },
 		@IContextMenuService private readonly contextMenuService: IContextMenuService,
 		@ITestResultService results: ITestResultService,

--- a/src/vs/workbench/contrib/testing/common/observableValue.ts
+++ b/src/vs/workbench/contrib/testing/common/observableValue.ts
@@ -8,7 +8,7 @@ import { Disposable } from '../../../../base/common/lifecycle.js';
 import { StoredValue } from './storedValue.js';
 
 export interface IObservableValue<T> {
-	onDidChange: Event<T>;
+	readonly onDidChange: Event<T>;
 	readonly value: T;
 }
 

--- a/src/vs/workbench/contrib/testing/common/testService.ts
+++ b/src/vs/workbench/contrib/testing/common/testService.ts
@@ -47,7 +47,7 @@ export interface IMainThreadTestHostProxy {
 }
 
 export interface IMainThreadTestCollection extends AbstractIncrementalTestCollection<IncrementalTestCollectionItem> {
-	onBusyProvidersChange: Event<number>;
+	readonly onBusyProvidersChange: Event<number>;
 
 	/**
 	 * Number of providers working to discover tests.

--- a/src/vs/workbench/contrib/testing/common/testingContinuousRunService.ts
+++ b/src/vs/workbench/contrib/testing/common/testingContinuousRunService.ts
@@ -33,7 +33,7 @@ export interface ITestingContinuousRunService {
 	 * Fired when a test is added or removed from continous run, or when
 	 * enablement is changed globally.
 	 */
-	onDidChange: Event<string | undefined>;
+	readonly onDidChange: Event<string | undefined>;
 
 	/**
 	 * Gets whether continous run is specifically enabled for the given test ID.

--- a/src/vs/workbench/contrib/testing/common/testingDecorations.ts
+++ b/src/vs/workbench/contrib/testing/common/testingDecorations.ts
@@ -19,7 +19,7 @@ export interface ITestingDecorationsService {
 	 * Fires when something happened to change decorations in an editor.
 	 * Interested consumers should call {@link syncDecorations} to update them.
 	 */
-	onDidChange: Event<void>;
+	readonly onDidChange: Event<void>;
 
 	/**
 	 * Signals the code underlying a test message has changed, and it should

--- a/src/vs/workbench/contrib/timeline/common/timeline.ts
+++ b/src/vs/workbench/contrib/timeline/common/timeline.ts
@@ -96,7 +96,7 @@ export interface Timeline {
 }
 
 export interface TimelineProvider extends TimelineProviderDescriptor, IDisposable {
-	onDidChange?: Event<TimelineChangeEvent>;
+	readonly onDidChange?: Event<TimelineChangeEvent>;
 
 	provideTimeline(uri: URI, options: TimelineOptions, token: CancellationToken): Promise<Timeline | undefined>;
 }
@@ -140,9 +140,9 @@ export interface TimelineRequest {
 export interface ITimelineService {
 	readonly _serviceBrand: undefined;
 
-	onDidChangeProviders: Event<TimelineProvidersChangeEvent>;
-	onDidChangeTimeline: Event<TimelineChangeEvent>;
-	onDidChangeUri: Event<URI>;
+	readonly onDidChangeProviders: Event<TimelineProvidersChangeEvent>;
+	readonly onDidChangeTimeline: Event<TimelineChangeEvent>;
+	readonly onDidChangeUri: Event<URI>;
 
 	registerTimelineProvider(provider: TimelineProvider): IDisposable;
 	unregisterTimelineProvider(id: string): void;

--- a/src/vs/workbench/contrib/url/browser/trustedDomainService.ts
+++ b/src/vs/workbench/contrib/url/browser/trustedDomainService.ts
@@ -17,7 +17,7 @@ export const ITrustedDomainService = createDecorator<ITrustedDomainService>('ITr
 
 export interface ITrustedDomainService {
 	_serviceBrand: undefined;
-	onDidChangeTrustedDomains: Event<void>;
+	readonly onDidChangeTrustedDomains: Event<void>;
 	isValid(resource: URI): boolean;
 }
 
@@ -27,7 +27,7 @@ export class TrustedDomainService extends Disposable implements ITrustedDomainSe
 	private _staticTrustedDomainsResult!: WindowIdleValue<string[]>;
 
 	private _onDidChangeTrustedDomains: Emitter<void> = this._register(new Emitter<void>());
-	onDidChangeTrustedDomains: Event<void> = this._onDidChangeTrustedDomains.event;
+	readonly onDidChangeTrustedDomains: Event<void> = this._onDidChangeTrustedDomains.event;
 
 	constructor(
 		@IInstantiationService private readonly _instantiationService: IInstantiationService,

--- a/src/vs/workbench/contrib/url/test/browser/mockTrustedDomainService.ts
+++ b/src/vs/workbench/contrib/url/test/browser/mockTrustedDomainService.ts
@@ -14,7 +14,7 @@ export class MockTrustedDomainService implements ITrustedDomainService {
 	constructor(private readonly _trustedDomains: string[] = []) {
 	}
 
-	onDidChangeTrustedDomains: Event<void> = Event.None;
+	readonly onDidChangeTrustedDomains: Event<void> = Event.None;
 
 	isValid(resource: URI): boolean {
 		return isURLDomainTrusted(resource, this._trustedDomains);

--- a/src/vs/workbench/services/authentication/browser/authenticationMcpService.ts
+++ b/src/vs/workbench/services/authentication/browser/authenticationMcpService.ts
@@ -44,7 +44,7 @@ export interface IAuthenticationMcpService {
 	 * * A session preference is changed (because it's deprecated)
 	 * * A session preference is removed (because it's deprecated)
 	 */
-	onDidChangeAccountPreference: Event<{ mcpServerIds: string[]; providerId: string }>;
+	readonly onDidChangeAccountPreference: Event<{ mcpServerIds: string[]; providerId: string }>;
 	/**
 	 * Returns the accountName (also known as account.label) to pair with `IAuthenticationMCPServerAccessService` to get the account preference
 	 * @param providerId The authentication provider id

--- a/src/vs/workbench/services/authentication/common/authentication.ts
+++ b/src/vs/workbench/services/authentication/common/authentication.ts
@@ -313,7 +313,7 @@ export interface IAuthenticationExtensionsService {
 	 * * A session preference is changed (because it's deprecated)
 	 * * A session preference is removed (because it's deprecated)
 	 */
-	onDidChangeAccountPreference: Event<{ extensionIds: string[]; providerId: string }>;
+	readonly onDidChangeAccountPreference: Event<{ extensionIds: string[]; providerId: string }>;
 	/**
 	 * Returns the accountName (also known as account.label) to pair with `IAuthenticationAccessService` to get the account preference
 	 * @param providerId The authentication provider id

--- a/src/vs/workbench/services/configurationResolver/test/electron-browser/configurationResolverService.test.ts
+++ b/src/vs/workbench/services/configurationResolver/test/electron-browser/configurationResolverService.test.ts
@@ -802,7 +802,7 @@ class MockLabelService implements ILabelService {
 	registerCachedFormatter(formatter: ResourceLabelFormatter): IDisposable {
 		throw new Error('Method not implemented.');
 	}
-	onDidChangeFormatters: Event<IFormatterChangeEvent> = new Emitter<IFormatterChangeEvent>().event;
+	readonly onDidChangeFormatters: Event<IFormatterChangeEvent> = new Emitter<IFormatterChangeEvent>().event;
 }
 
 class MockPathService implements IPathService {

--- a/src/vs/workbench/services/decorations/browser/decorationsService.ts
+++ b/src/vs/workbench/services/decorations/browser/decorationsService.ts
@@ -250,7 +250,7 @@ export class DecorationsService implements IDecorationsService {
 	private readonly _onDidChangeDecorationsDelayed = this._store.add(new DebounceEmitter<URI | URI[]>({ merge: all => all.flat() }));
 	private readonly _onDidChangeDecorations = this._store.add(new Emitter<IResourceDecorationChangeEvent>());
 
-	onDidChangeDecorations: Event<IResourceDecorationChangeEvent> = this._onDidChangeDecorations.event;
+	readonly onDidChangeDecorations: Event<IResourceDecorationChangeEvent> = this._onDidChangeDecorations.event;
 
 	private readonly _provider = new LinkedList<IDecorationsProvider>();
 	private readonly _decorationStyles: DecorationStyles;

--- a/src/vs/workbench/services/decorations/test/browser/decorationsService.test.ts
+++ b/src/vs/workbench/services/decorations/test/browser/decorationsService.test.ts
@@ -182,7 +182,7 @@ suite('DecorationsService', function () {
 		const provider = new class implements IDecorationsProvider {
 
 			_onDidChange = new Emitter<URI[]>();
-			onDidChange: Event<readonly URI[]> = this._onDidChange.event;
+			readonly onDidChange: Event<readonly URI[]> = this._onDidChange.event;
 
 			label: string = 'foo';
 

--- a/src/vs/workbench/services/extensionRecommendations/common/extensionRecommendations.ts
+++ b/src/vs/workbench/services/extensionRecommendations/common/extensionRecommendations.ts
@@ -52,10 +52,10 @@ export const IExtensionIgnoredRecommendationsService = createDecorator<IExtensio
 export interface IExtensionIgnoredRecommendationsService {
 	readonly _serviceBrand: undefined;
 
-	onDidChangeIgnoredRecommendations: Event<void>;
+	readonly onDidChangeIgnoredRecommendations: Event<void>;
 	readonly ignoredRecommendations: string[];
 
-	onDidChangeGlobalIgnoredRecommendation: Event<IgnoredRecommendationChangeNotification>;
+	readonly onDidChangeGlobalIgnoredRecommendation: Event<IgnoredRecommendationChangeNotification>;
 	readonly globalIgnoredRecommendations: string[];
 	toggleGlobalIgnoredRecommendation(extensionId: string, ignore: boolean): void;
 }

--- a/src/vs/workbench/services/extensionRecommendations/common/workspaceExtensionsConfig.ts
+++ b/src/vs/workbench/services/extensionRecommendations/common/workspaceExtensionsConfig.ts
@@ -32,7 +32,7 @@ export const IWorkspaceExtensionsConfigService = createDecorator<IWorkspaceExten
 export interface IWorkspaceExtensionsConfigService {
 	readonly _serviceBrand: undefined;
 
-	onDidChangeExtensionsConfigs: Event<void>;
+	readonly onDidChangeExtensionsConfigs: Event<void>;
 	getExtensionsConfigs(): Promise<IExtensionsConfigContent[]>;
 	getRecommendations(): Promise<string[]>;
 	getUnwantedRecommendations(): Promise<string[]>;

--- a/src/vs/workbench/services/extensions/common/extensions.ts
+++ b/src/vs/workbench/services/extensions/common/extensions.ts
@@ -418,19 +418,19 @@ export interface IExtensionService {
 	 *
 	 * @returns the extensions that got registered
 	 */
-	onDidRegisterExtensions: Event<void>;
+	readonly onDidRegisterExtensions: Event<void>;
 
 	/**
 	 * @event
 	 * Fired when extensions status changes.
 	 * The event contains the ids of the extensions that have changed.
 	 */
-	onDidChangeExtensionsStatus: Event<ExtensionIdentifier[]>;
+	readonly onDidChangeExtensionsStatus: Event<ExtensionIdentifier[]>;
 
 	/**
 	 * Fired when the available extensions change (i.e. when extensions are added or removed).
 	 */
-	onDidChangeExtensions: Event<{ readonly added: readonly IExtensionDescription[]; readonly removed: readonly IExtensionDescription[] }>;
+	readonly onDidChangeExtensions: Event<{ readonly added: readonly IExtensionDescription[]; readonly removed: readonly IExtensionDescription[] }>;
 
 	/**
 	 * All registered extensions.
@@ -443,19 +443,19 @@ export interface IExtensionService {
 	/**
 	 * An event that is fired when activation happens.
 	 */
-	onWillActivateByEvent: Event<IWillActivateEvent>;
+	readonly onWillActivateByEvent: Event<IWillActivateEvent>;
 
 	/**
 	 * An event that is fired when an extension host changes its
 	 * responsive-state.
 	 */
-	onDidChangeResponsiveChange: Event<IResponsiveStateChangeEvent>;
+	readonly onDidChangeResponsiveChange: Event<IResponsiveStateChangeEvent>;
 
 	/**
 	 * Fired before stop of extension hosts happens. Allows listeners to veto against the
 	 * stop to prevent it from happening.
 	 */
-	onWillStop: Event<WillStopExtensionHostsEvent>;
+	readonly onWillStop: Event<WillStopExtensionHostsEvent>;
 
 	/**
 	 * Send an activation event and activate interested extensions.
@@ -593,12 +593,12 @@ export function toExtensionDescription(extension: IExtension, isUnderDevelopment
 
 export class NullExtensionService implements IExtensionService {
 	declare readonly _serviceBrand: undefined;
-	onDidRegisterExtensions: Event<void> = Event.None;
-	onDidChangeExtensionsStatus: Event<ExtensionIdentifier[]> = Event.None;
+	readonly onDidRegisterExtensions: Event<void> = Event.None;
+	readonly onDidChangeExtensionsStatus: Event<ExtensionIdentifier[]> = Event.None;
 	onDidChangeExtensions = Event.None;
-	onWillActivateByEvent: Event<IWillActivateEvent> = Event.None;
-	onDidChangeResponsiveChange: Event<IResponsiveStateChangeEvent> = Event.None;
-	onWillStop: Event<WillStopExtensionHostsEvent> = Event.None;
+	readonly onWillActivateByEvent: Event<IWillActivateEvent> = Event.None;
+	readonly onDidChangeResponsiveChange: Event<IResponsiveStateChangeEvent> = Event.None;
+	readonly onWillStop: Event<WillStopExtensionHostsEvent> = Event.None;
 	readonly extensions = [];
 	activateByEvent(_activationEvent: string): Promise<void> { return Promise.resolve(undefined); }
 	activateById(extensionId: ExtensionIdentifier, reason: ExtensionActivationReason): Promise<void> { return Promise.resolve(undefined); }

--- a/src/vs/workbench/services/inlineCompletions/common/inlineCompletionsUnification.ts
+++ b/src/vs/workbench/services/inlineCompletions/common/inlineCompletionsUnification.ts
@@ -23,7 +23,7 @@ export interface IInlineCompletionsUnificationService {
 	readonly _serviceBrand: undefined;
 
 	readonly state: IInlineCompletionsUnificationState;
-	onDidStateChange: Event<void>;
+	readonly onDidStateChange: Event<void>;
 }
 
 const CODE_UNIFICATION_PREFIX = 'cmp-cht-';

--- a/src/vs/workbench/services/label/test/common/mockLabelService.ts
+++ b/src/vs/workbench/services/label/test/common/mockLabelService.ts
@@ -37,5 +37,5 @@ export class MockLabelService implements ILabelService {
 	registerFormatter(formatter: ResourceLabelFormatter): IDisposable {
 		return Disposable.None;
 	}
-	onDidChangeFormatters: Event<IFormatterChangeEvent> = new Emitter<IFormatterChangeEvent>().event;
+	readonly onDidChangeFormatters: Event<IFormatterChangeEvent> = new Emitter<IFormatterChangeEvent>().event;
 }

--- a/src/vs/workbench/services/languageStatus/common/languageStatusService.ts
+++ b/src/vs/workbench/services/languageStatus/common/languageStatusService.ts
@@ -39,7 +39,7 @@ export interface ILanguageStatusService {
 
 	_serviceBrand: undefined;
 
-	onDidChange: Event<void>;
+	readonly onDidChange: Event<void>;
 
 	addStatus(status: ILanguageStatus): IDisposable;
 

--- a/src/vs/workbench/services/outline/browser/outline.ts
+++ b/src/vs/workbench/services/outline/browser/outline.ts
@@ -25,7 +25,7 @@ export const enum OutlineTarget {
 
 export interface IOutlineService {
 	_serviceBrand: undefined;
-	onDidChange: Event<void>;
+	readonly onDidChange: Event<void>;
 	canCreateOutline(editor: IEditorPane): boolean;
 	createOutline(editor: IEditorPane, target: OutlineTarget, token: CancellationToken): Promise<IOutline<any> | undefined>;
 	registerOutlineCreator(creator: IOutlineCreator<any, any>): IDisposable;

--- a/src/vs/workbench/services/output/common/output.ts
+++ b/src/vs/workbench/services/output/common/output.ts
@@ -109,7 +109,7 @@ export interface IOutputService {
 	/**
 	 * Allows to register on active output channel change.
 	 */
-	onActiveOutputChannel: Event<string>;
+	readonly onActiveOutputChannel: Event<string>;
 
 	/**
 	 * Register a compound log channel with the given channels.

--- a/src/vs/workbench/services/remote/common/remoteExplorerService.ts
+++ b/src/vs/workbench/services/remote/common/remoteExplorerService.ts
@@ -125,12 +125,12 @@ export enum PortsEnablement {
 
 export interface IRemoteExplorerService {
 	readonly _serviceBrand: undefined;
-	onDidChangeTargetType: Event<string[]>;
+	readonly onDidChangeTargetType: Event<string[]>;
 	targetType: string[];
-	onDidChangeHelpInformation: Event<readonly IExtensionPointUser<HelpInformation>[]>;
+	readonly onDidChangeHelpInformation: Event<readonly IExtensionPointUser<HelpInformation>[]>;
 	helpInformation: IExtensionPointUser<HelpInformation>[];
 	readonly tunnelModel: TunnelModel;
-	onDidChangeEditable: Event<{ tunnel: ITunnelItem; editId: TunnelEditId } | undefined>;
+	readonly onDidChangeEditable: Event<{ tunnel: ITunnelItem; editId: TunnelEditId } | undefined>;
 	setEditable(tunnelItem: ITunnelItem | undefined, editId: TunnelEditId, data: IEditableData | null): void;
 	getEditableData(tunnelItem: ITunnelItem | undefined, editId?: TunnelEditId): IEditableData | undefined;
 	forward(tunnelProperties: TunnelProperties, attributes?: Attributes | null): Promise<RemoteTunnel | string | undefined>;
@@ -140,7 +140,7 @@ export interface IRemoteExplorerService {
 	onFoundNewCandidates(candidates: CandidatePort[]): void;
 	restore(): Promise<void>;
 	enablePortsFeatures(viewOnly: boolean): void;
-	onEnabledPortsFeatures: Event<void>;
+	readonly onEnabledPortsFeatures: Event<void>;
 	portsFeaturesEnabled: PortsEnablement;
 	readonly namedProcesses: Map<number, string>;
 }

--- a/src/vs/workbench/services/search/node/rawSearchService.ts
+++ b/src/vs/workbench/services/search/node/rawSearchService.ts
@@ -408,7 +408,7 @@ interface ICacheRow {
 	// TODO@roblou - never actually canceled
 	promise: CancelablePromise<[ISearchEngineSuccess, IRawFileMatch[]]>;
 	resolved: boolean;
-	event: Event<IFileSearchProgressItem>;
+	readonly event: Event<IFileSearchProgressItem>;
 }
 
 class Cache {

--- a/src/vs/workbench/services/terminal/common/embedderTerminalService.ts
+++ b/src/vs/workbench/services/terminal/common/embedderTerminalService.ts
@@ -39,9 +39,9 @@ export interface IEmbedderTerminalOptions {
  * See Pseudoterminal on the vscode API for usage.
  */
 export interface IEmbedderTerminalPty {
-	onDidWrite: Event<string>;
-	onDidClose?: Event<void | number>;
-	onDidChangeName?: Event<string>;
+	readonly onDidWrite: Event<string>;
+	readonly onDidClose?: Event<void | number>;
+	readonly onDidChangeName?: Event<string>;
 
 	open(): void;
 	close(): void;

--- a/src/vs/workbench/services/themes/common/workbenchThemeService.ts
+++ b/src/vs/workbench/services/themes/common/workbenchThemeService.ts
@@ -380,7 +380,7 @@ export interface IWorkbenchThemeService extends IThemeService {
 	getColorTheme(): IWorkbenchColorTheme;
 	getColorThemes(): Promise<IWorkbenchColorTheme[]>;
 	getMarketplaceColorThemes(publisher: string, name: string, version: string): Promise<IWorkbenchColorTheme[]>;
-	onDidColorThemeChange: Event<IWorkbenchColorTheme>;
+	readonly onDidColorThemeChange: Event<IWorkbenchColorTheme>;
 
 	getPreferredColorScheme(): ColorScheme | undefined;
 
@@ -388,13 +388,13 @@ export interface IWorkbenchThemeService extends IThemeService {
 	getFileIconTheme(): IWorkbenchFileIconTheme;
 	getFileIconThemes(): Promise<IWorkbenchFileIconTheme[]>;
 	getMarketplaceFileIconThemes(publisher: string, name: string, version: string): Promise<IWorkbenchFileIconTheme[]>;
-	onDidFileIconThemeChange: Event<IWorkbenchFileIconTheme>;
+	readonly onDidFileIconThemeChange: Event<IWorkbenchFileIconTheme>;
 
 	setProductIconTheme(iconThemeId: string | undefined | IWorkbenchProductIconTheme, settingsTarget: ThemeSettingTarget): Promise<IWorkbenchProductIconTheme>;
 	getProductIconTheme(): IWorkbenchProductIconTheme;
 	getProductIconThemes(): Promise<IWorkbenchProductIconTheme[]>;
 	getMarketplaceProductIconThemes(publisher: string, name: string, version: string): Promise<IWorkbenchProductIconTheme[]>;
-	onDidProductIconThemeChange: Event<IWorkbenchProductIconTheme>;
+	readonly onDidProductIconThemeChange: Event<IWorkbenchProductIconTheme>;
 }
 
 export interface IThemeScopedColorCustomizations {

--- a/src/vs/workbench/services/userActivity/common/userActivityService.ts
+++ b/src/vs/workbench/services/userActivity/common/userActivityService.ts
@@ -67,7 +67,7 @@ export class UserActivityService extends Disposable implements IUserActivityServ
 	public isActive = true;
 
 	/** @inheritdoc */
-	onDidChangeIsActive: Event<boolean> = this.changeEmitter.event;
+	readonly onDidChangeIsActive: Event<boolean> = this.changeEmitter.event;
 
 	constructor(@IInstantiationService instantiationService: IInstantiationService) {
 		super();

--- a/src/vs/workbench/services/workingCopy/common/workingCopyHistory.ts
+++ b/src/vs/workbench/services/workingCopy/common/workingCopyHistory.ts
@@ -83,32 +83,32 @@ export interface IWorkingCopyHistoryService {
 	/**
 	 * An event when an entry is added to the history.
 	 */
-	onDidAddEntry: Event<IWorkingCopyHistoryEvent>;
+	readonly onDidAddEntry: Event<IWorkingCopyHistoryEvent>;
 
 	/**
 	 * An event when an entry is changed in the history.
 	 */
-	onDidChangeEntry: Event<IWorkingCopyHistoryEvent>;
+	readonly onDidChangeEntry: Event<IWorkingCopyHistoryEvent>;
 
 	/**
 	 * An event when an entry is replaced in the history.
 	 */
-	onDidReplaceEntry: Event<IWorkingCopyHistoryEvent>;
+	readonly onDidReplaceEntry: Event<IWorkingCopyHistoryEvent>;
 
 	/**
 	 * An event when an entry is removed from the history.
 	 */
-	onDidRemoveEntry: Event<IWorkingCopyHistoryEvent>;
+	readonly onDidRemoveEntry: Event<IWorkingCopyHistoryEvent>;
 
 	/**
 	 * An event when entries are moved in history.
 	 */
-	onDidMoveEntries: Event<void>;
+	readonly onDidMoveEntries: Event<void>;
 
 	/**
 	 * An event when all entries are removed from the history.
 	 */
-	onDidRemoveEntries: Event<void>;
+	readonly onDidRemoveEntries: Event<void>;
 
 	/**
 	 * Adds a new entry to the history for the given working copy

--- a/src/vs/workbench/test/browser/workbenchTestServices.ts
+++ b/src/vs/workbench/test/browser/workbenchTestServices.ts
@@ -555,7 +555,7 @@ export class TestDecorationsService implements IDecorationsService {
 
 	declare readonly _serviceBrand: undefined;
 
-	onDidChangeDecorations: Event<IResourceDecorationChangeEvent> = Event.None;
+	readonly onDidChangeDecorations: Event<IResourceDecorationChangeEvent> = Event.None;
 
 	registerDecorationsProvider(_provider: IDecorationsProvider): IDisposable { return Disposable.None; }
 	getDecoration(_uri: URI, _includeChildren: boolean, _overwrite?: IDecorationData): IDecoration | undefined { return undefined; }
@@ -630,12 +630,12 @@ export class TestLayoutService implements IWorkbenchLayoutService {
 	containers = [mainWindow.document.body];
 	activeContainer: HTMLElement = mainWindow.document.body;
 
-	onDidChangeZenMode: Event<boolean> = Event.None;
-	onDidChangeMainEditorCenteredLayout: Event<boolean> = Event.None;
-	onDidChangeWindowMaximized: Event<{ windowId: number; maximized: boolean }> = Event.None;
-	onDidChangePanelPosition: Event<string> = Event.None;
-	onDidChangePanelAlignment: Event<PanelAlignment> = Event.None;
-	onDidChangePartVisibility: Event<void> = Event.None;
+	readonly onDidChangeZenMode: Event<boolean> = Event.None;
+	readonly onDidChangeMainEditorCenteredLayout: Event<boolean> = Event.None;
+	readonly onDidChangeWindowMaximized: Event<{ windowId: number; maximized: boolean }> = Event.None;
+	readonly onDidChangePanelPosition: Event<string> = Event.None;
+	readonly onDidChangePanelAlignment: Event<PanelAlignment> = Event.None;
+	readonly onDidChangePartVisibility: Event<void> = Event.None;
 	onDidLayoutMainContainer = Event.None;
 	onDidLayoutActiveContainer = Event.None;
 	onDidLayoutContainer = Event.None;
@@ -701,8 +701,8 @@ const activeViewlet: PaneComposite = {} as any;
 export class TestPaneCompositeService extends Disposable implements IPaneCompositePartService {
 	declare readonly _serviceBrand: undefined;
 
-	onDidPaneCompositeOpen: Event<{ composite: IPaneComposite; viewContainerLocation: ViewContainerLocation }>;
-	onDidPaneCompositeClose: Event<{ composite: IPaneComposite; viewContainerLocation: ViewContainerLocation }>;
+	readonly onDidPaneCompositeOpen: Event<{ composite: IPaneComposite; viewContainerLocation: ViewContainerLocation }>;
+	readonly onDidPaneCompositeClose: Event<{ composite: IPaneComposite; viewContainerLocation: ViewContainerLocation }>;
 
 	private parts = new Map<ViewContainerLocation, IPaneCompositePart>();
 
@@ -853,17 +853,17 @@ export class TestEditorGroupsService implements IEditorGroupsService {
 
 	windowId = mainWindow.vscodeWindowId;
 
-	onDidCreateAuxiliaryEditorPart: Event<IAuxiliaryEditorPart> = Event.None;
-	onDidChangeActiveGroup: Event<IEditorGroup> = Event.None;
-	onDidActivateGroup: Event<IEditorGroup> = Event.None;
-	onDidAddGroup: Event<IEditorGroup> = Event.None;
-	onDidRemoveGroup: Event<IEditorGroup> = Event.None;
-	onDidMoveGroup: Event<IEditorGroup> = Event.None;
-	onDidChangeGroupIndex: Event<IEditorGroup> = Event.None;
-	onDidChangeGroupLabel: Event<IEditorGroup> = Event.None;
-	onDidChangeGroupLocked: Event<IEditorGroup> = Event.None;
-	onDidChangeGroupMaximized: Event<boolean> = Event.None;
-	onDidLayout: Event<IDimension> = Event.None;
+	readonly onDidCreateAuxiliaryEditorPart: Event<IAuxiliaryEditorPart> = Event.None;
+	readonly onDidChangeActiveGroup: Event<IEditorGroup> = Event.None;
+	readonly onDidActivateGroup: Event<IEditorGroup> = Event.None;
+	readonly onDidAddGroup: Event<IEditorGroup> = Event.None;
+	readonly onDidRemoveGroup: Event<IEditorGroup> = Event.None;
+	readonly onDidMoveGroup: Event<IEditorGroup> = Event.None;
+	readonly onDidChangeGroupIndex: Event<IEditorGroup> = Event.None;
+	readonly onDidChangeGroupLabel: Event<IEditorGroup> = Event.None;
+	readonly onDidChangeGroupLocked: Event<IEditorGroup> = Event.None;
+	readonly onDidChangeGroupMaximized: Event<boolean> = Event.None;
+	readonly onDidLayout: Event<IDimension> = Event.None;
 	onDidChangeEditorPartOptions = Event.None;
 	onDidScroll = Event.None;
 	onWillDispose = Event.None;
@@ -949,16 +949,16 @@ export class TestEditorGroupView implements IEditorGroupView {
 
 	isEmpty = true;
 
-	onWillDispose: Event<void> = Event.None;
-	onDidModelChange: Event<IGroupModelChangeEvent> = Event.None;
-	onWillCloseEditor: Event<IEditorCloseEvent> = Event.None;
-	onDidCloseEditor: Event<IEditorCloseEvent> = Event.None;
-	onDidOpenEditorFail: Event<EditorInput> = Event.None;
-	onDidFocus: Event<void> = Event.None;
-	onDidChange: Event<{ width: number; height: number }> = Event.None;
-	onWillMoveEditor: Event<IEditorWillMoveEvent> = Event.None;
-	onWillOpenEditor: Event<IEditorWillOpenEvent> = Event.None;
-	onDidActiveEditorChange: Event<IActiveEditorChangeEvent> = Event.None;
+	readonly onWillDispose: Event<void> = Event.None;
+	readonly onDidModelChange: Event<IGroupModelChangeEvent> = Event.None;
+	readonly onWillCloseEditor: Event<IEditorCloseEvent> = Event.None;
+	readonly onDidCloseEditor: Event<IEditorCloseEvent> = Event.None;
+	readonly onDidOpenEditorFail: Event<EditorInput> = Event.None;
+	readonly onDidFocus: Event<void> = Event.None;
+	readonly onDidChange: Event<{ width: number; height: number }> = Event.None;
+	readonly onWillMoveEditor: Event<IEditorWillMoveEvent> = Event.None;
+	readonly onWillOpenEditor: Event<IEditorWillOpenEvent> = Event.None;
+	readonly onDidActiveEditorChange: Event<IActiveEditorChangeEvent> = Event.None;
 
 	getEditors(_order?: EditorsOrder): readonly EditorInput[] { return []; }
 	findEditors(_resource: URI): readonly EditorInput[] { return []; }
@@ -1030,13 +1030,13 @@ export class TestEditorService extends Disposable implements EditorServiceImpl {
 
 	declare readonly _serviceBrand: undefined;
 
-	onDidActiveEditorChange: Event<void> = Event.None;
-	onDidVisibleEditorsChange: Event<void> = Event.None;
-	onDidEditorsChange: Event<IEditorsChangeEvent> = Event.None;
-	onWillOpenEditor: Event<IEditorWillOpenEvent> = Event.None;
-	onDidCloseEditor: Event<IEditorCloseEvent> = Event.None;
-	onDidOpenEditorFail: Event<IEditorIdentifier> = Event.None;
-	onDidMostRecentlyActiveEditorsChange: Event<void> = Event.None;
+	readonly onDidActiveEditorChange: Event<void> = Event.None;
+	readonly onDidVisibleEditorsChange: Event<void> = Event.None;
+	readonly onDidEditorsChange: Event<IEditorsChangeEvent> = Event.None;
+	readonly onWillOpenEditor: Event<IEditorWillOpenEvent> = Event.None;
+	readonly onDidCloseEditor: Event<IEditorCloseEvent> = Event.None;
+	readonly onDidOpenEditorFail: Event<IEditorIdentifier> = Event.None;
+	readonly onDidMostRecentlyActiveEditorsChange: Event<void> = Event.None;
 
 	private _activeTextEditorControl: ICodeEditor | IDiffEditor | undefined;
 	public get activeTextEditorControl(): ICodeEditor | IDiffEditor | undefined { return this._activeTextEditorControl; }

--- a/src/vs/workbench/test/common/workbenchTestServices.ts
+++ b/src/vs/workbench/test/common/workbenchTestServices.ts
@@ -265,9 +265,9 @@ export class TestWorkingCopyFileService implements IWorkingCopyFileService {
 
 	declare readonly _serviceBrand: undefined;
 
-	onWillRunWorkingCopyFileOperation: Event<WorkingCopyFileEvent> = Event.None;
-	onDidFailWorkingCopyFileOperation: Event<WorkingCopyFileEvent> = Event.None;
-	onDidRunWorkingCopyFileOperation: Event<WorkingCopyFileEvent> = Event.None;
+	readonly onWillRunWorkingCopyFileOperation: Event<WorkingCopyFileEvent> = Event.None;
+	readonly onDidFailWorkingCopyFileOperation: Event<WorkingCopyFileEvent> = Event.None;
+	readonly onDidRunWorkingCopyFileOperation: Event<WorkingCopyFileEvent> = Event.None;
 
 	addFileOperationParticipant(participant: IWorkingCopyFileOperationParticipant): IDisposable { return Disposable.None; }
 

--- a/src/vs/workbench/test/electron-browser/workbenchTestServices.ts
+++ b/src/vs/workbench/test/electron-browser/workbenchTestServices.ts
@@ -65,17 +65,17 @@ export class TestNativeHostService implements INativeHostService {
 
 	readonly windowId = -1;
 
-	onDidOpenMainWindow: Event<number> = Event.None;
-	onDidMaximizeWindow: Event<number> = Event.None;
-	onDidUnmaximizeWindow: Event<number> = Event.None;
-	onDidFocusMainWindow: Event<number> = Event.None;
-	onDidBlurMainWindow: Event<number> = Event.None;
-	onDidFocusMainOrAuxiliaryWindow: Event<number> = Event.None;
-	onDidBlurMainOrAuxiliaryWindow: Event<number> = Event.None;
-	onDidResumeOS: Event<unknown> = Event.None;
+	readonly onDidOpenMainWindow: Event<number> = Event.None;
+	readonly onDidMaximizeWindow: Event<number> = Event.None;
+	readonly onDidUnmaximizeWindow: Event<number> = Event.None;
+	readonly onDidFocusMainWindow: Event<number> = Event.None;
+	readonly onDidBlurMainWindow: Event<number> = Event.None;
+	readonly onDidFocusMainOrAuxiliaryWindow: Event<number> = Event.None;
+	readonly onDidBlurMainOrAuxiliaryWindow: Event<number> = Event.None;
+	readonly onDidResumeOS: Event<unknown> = Event.None;
 	onDidChangeColorScheme = Event.None;
 	onDidChangePassword = Event.None;
-	onDidTriggerWindowSystemContextMenu: Event<{ windowId: number; x: number; y: number }> = Event.None;
+	readonly onDidTriggerWindowSystemContextMenu: Event<{ windowId: number; x: number; y: number }> = Event.None;
 	onDidChangeWindowFullScreen = Event.None;
 	onDidChangeWindowAlwaysOnTop = Event.None;
 	onDidChangeDisplay = Event.None;

--- a/src/vscode-dts/vscode.proposed.chatParticipantAdditions.d.ts
+++ b/src/vscode-dts/vscode.proposed.chatParticipantAdditions.d.ts
@@ -6,7 +6,7 @@
 declare module 'vscode' {
 
 	export interface ChatParticipant {
-		onDidPerformAction: Event<ChatUserActionEvent>;
+		readonly onDidPerformAction: Event<ChatUserActionEvent>;
 	}
 
 	/**
@@ -442,7 +442,7 @@ declare module 'vscode' {
 		 * Event that fires when a request is paused or unpaused.
 		 * Chat requests are initially unpaused in the {@link requestHandler}.
 		 */
-		onDidChangePauseState: Event<ChatParticipantPauseStateEvent>;
+		readonly onDidChangePauseState: Event<ChatParticipantPauseStateEvent>;
 	}
 
 	export interface ChatParticipantPauseStateEvent {

--- a/src/vscode-dts/vscode.proposed.dataChannels.d.ts
+++ b/src/vscode-dts/vscode.proposed.dataChannels.d.ts
@@ -10,7 +10,7 @@ declare module 'vscode' {
 	}
 
 	export interface DataChannel<T = unknown> {
-		onDidReceiveData: Event<DataChannelEvent<T>>;
+		readonly onDidReceiveData: Event<DataChannelEvent<T>>;
 	}
 
 	export interface DataChannelEvent<T> {

--- a/src/vscode-dts/vscode.proposed.inlineCompletionsAdditions.d.ts
+++ b/src/vscode-dts/vscode.proposed.inlineCompletionsAdditions.d.ts
@@ -131,7 +131,7 @@ declare module 'vscode' {
 		// eslint-disable-next-line local/vscode-dts-provider-naming
 		handleListEndOfLifetime?(list: InlineCompletionList, reason: InlineCompletionsDisposeReason): void;
 
-		onDidChange?: Event<void>;
+		readonly onDidChange?: Event<void>;
 
 		// #region Deprecated methods
 

--- a/src/vscode-dts/vscode.proposed.notebookKernelSource.d.ts
+++ b/src/vscode-dts/vscode.proposed.notebookKernelSource.d.ts
@@ -25,7 +25,7 @@ declare module 'vscode' {
 		/**
 		 * An optional event to signal that the kernel source actions have changed.
 		 */
-		onDidChangeNotebookKernelSourceActions?: Event<void>;
+		readonly onDidChangeNotebookKernelSourceActions?: Event<void>;
 		/**
 		 * Provide kernel source actions
 		 */

--- a/src/vscode-dts/vscode.proposed.notebookVariableProvider.d.ts
+++ b/src/vscode-dts/vscode.proposed.notebookVariableProvider.d.ts
@@ -21,7 +21,7 @@ declare module 'vscode' {
 	}
 
 	export interface NotebookVariableProvider {
-		onDidChangeVariables: Event<NotebookDocument>;
+		readonly onDidChangeVariables: Event<NotebookDocument>;
 
 		/** When parent is undefined, this is requesting global Variables. When a variable is passed, it's requesting child props of that Variable. */
 		provideVariables(notebook: NotebookDocument, parent: Variable | undefined, kind: NotebookVariablesRequestKind, start: number, token: CancellationToken): AsyncIterable<VariablesResult>;

--- a/src/vscode-dts/vscode.proposed.resolvers.d.ts
+++ b/src/vscode-dts/vscode.proposed.resolvers.d.ts
@@ -34,9 +34,9 @@ declare module 'vscode' {
 	}
 
 	export interface ManagedMessagePassing {
-		onDidReceiveMessage: Event<Uint8Array>;
-		onDidClose: Event<Error | undefined>;
-		onDidEnd: Event<void>;
+		readonly onDidReceiveMessage: Event<Uint8Array>;
+		readonly onDidClose: Event<Error | undefined>;
+		readonly onDidEnd: Event<void>;
 
 		send: (data: Uint8Array) => void;
 		end: () => void;
@@ -102,7 +102,7 @@ declare module 'vscode' {
 
 	export interface Tunnel extends TunnelDescription {
 		// Implementers of Tunnel should fire onDidDispose when dispose is called.
-		onDidDispose: Event<void>;
+		readonly onDidDispose: Event<void>;
 		dispose(): void | Thenable<void>;
 	}
 

--- a/src/vscode-dts/vscode.proposed.scmHistoryProvider.d.ts
+++ b/src/vscode-dts/vscode.proposed.scmHistoryProvider.d.ts
@@ -19,12 +19,12 @@ declare module 'vscode' {
 		 * Fires when the current history item refs (local, remote, base)
 		 * change after a user action (ex: commit, checkout, fetch, pull, push)
 		 */
-		onDidChangeCurrentHistoryItemRefs: Event<void>;
+		readonly onDidChangeCurrentHistoryItemRefs: Event<void>;
 
 		/**
 		 * Fires when history item refs change
 		 */
-		onDidChangeHistoryItemRefs: Event<SourceControlHistoryItemRefsChangeEvent>;
+		readonly onDidChangeHistoryItemRefs: Event<SourceControlHistoryItemRefsChangeEvent>;
 
 		provideHistoryItemRefs(historyItemRefs: string[] | undefined, token: CancellationToken): ProviderResult<SourceControlHistoryItemRef[]>;
 		provideHistoryItems(options: SourceControlHistoryOptions, token: CancellationToken): ProviderResult<SourceControlHistoryItem[]>;

--- a/src/vscode-dts/vscode.proposed.timeline.d.ts
+++ b/src/vscode-dts/vscode.proposed.timeline.d.ts
@@ -122,7 +122,7 @@ declare module 'vscode' {
 		 * An optional event to signal that the timeline for a source has changed.
 		 * To signal that the timeline for all resources (uris) has changed, do not pass any argument or pass `undefined`.
 		 */
-		onDidChange?: Event<TimelineChangeEvent | undefined>;
+		readonly onDidChange?: Event<TimelineChangeEvent | undefined>;
 
 		/**
 		 * An identifier of the source of the timeline items. This can be used to filter sources.

--- a/src/vscode-dts/vscode.proposed.tunnels.d.ts
+++ b/src/vscode-dts/vscode.proposed.tunnels.d.ts
@@ -35,7 +35,7 @@ declare module 'vscode' {
 
 	export interface Tunnel extends TunnelDescription {
 		// Implementers of Tunnel should fire onDidDispose when dispose is called.
-		onDidDispose: Event<void>;
+		readonly onDidDispose: Event<void>;
 		dispose(): void | Thenable<void>;
 	}
 


### PR DESCRIPTION
We want to prevent mistaken changes that do something like this:

```ts
foo.onEvent = () => { ... };
```

When they almost always meant to write:

```ts
foo.onEvent(() => { ... })
```

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
