### PR TITLE
Update button styles for high contrast mode

### DIFF
--- a/src/vs/platform/theme/common/colors/inputColors.ts
+++ b/src/vs/platform/theme/common/colors/inputColors.ts
@@ -118,7 +118,7 @@ export const buttonSeparator = registerColor('button.separator',
 	nls.localize('buttonSeparator', "Button separator color."));
 
 export const buttonBackground = registerColor('button.background',
-	{ dark: '#0E639C', light: '#007ACC', hcDark: null, hcLight: '#0F4A85' },
+	{ dark: '#0E639C', light: '#007ACC', hcDark: Color.black, hcLight: '#0F4A85' },
 	nls.localize('buttonBackground', "Button background color."));
 
 export const buttonHoverBackground = registerColor('button.hoverBackground',

--- a/src/vs/workbench/contrib/chat/browser/media/chatEditorController.css
+++ b/src/vs/workbench/contrib/chat/browser/media/chatEditorController.css
@@ -19,6 +19,7 @@
 	border-radius: 2px;
 	background-color: var(--vscode-button-background);
 	color: var(--vscode-button-foreground);
+	border: 1px solid var(--vscode-contrastBorder);
 }
 
 .chat-diff-change-content-widget .monaco-action-bar .action-item .action-label {


### PR DESCRIPTION
Enhance button background color and add a border to the chat action bar for better visibility in high contrast mode.

**Before**
<img width="737" height="638" alt="image" src="https://github.com/user-attachments/assets/9bdbca5f-5892-4da1-adc4-29fe960154f6" />



**After**
<img width="717" height="586" alt="image" src="https://github.com/user-attachments/assets/44d79ddc-052e-45aa-ae02-4ddaa1c58860" />
