### PR TITLE
Prevent flicker when opening a webview in a panel

### DIFF
--- a/src/vs/workbench/browser/parts/paneCompositePart.ts
+++ b/src/vs/workbench/browser/parts/paneCompositePart.ts
@@ -231,15 +231,15 @@ export abstract class AbstractPaneCompositePart extends CompositePart<PaneCompos
 	}
 
 	protected override showComposite(composite: Composite): void {
+		this.layoutEmptyMessage(false);
 		super.showComposite(composite);
 		this.layoutCompositeBar();
-		this.layoutEmptyMessage();
 	}
 
 	protected override hideActiveComposite(): Composite | undefined {
 		const composite = super.hideActiveComposite();
 		this.layoutCompositeBar();
-		this.layoutEmptyMessage();
+		this.layoutEmptyMessage(true);
 		return composite;
 	}
 
@@ -621,8 +621,7 @@ export abstract class AbstractPaneCompositePart extends CompositePart<PaneCompos
 		}
 	}
 
-	private layoutEmptyMessage(): void {
-		const visible = !this.getActiveComposite();
+	private layoutEmptyMessage(visible = !this.getActiveComposite()): void {
 		this.element.classList.toggle('empty', visible);
 		if (visible) {
 			this.titleLabel?.updateTitle('', '');


### PR DESCRIPTION
Because the empty message div is hidden AFTER the actual webview is layout, the first webview layout occurs while it's placed outside of the workbench (at the bottom on the empty message div).

So another layout is required to place it correctly, leading to a flicker

fix #270776

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
