### PR TITLE
Use setTimeout0 to defer setting Count til element is fully shown for now

### DIFF
--- a/src/vs/platform/quickinput/browser/quickInputController.ts
+++ b/src/vs/platform/quickinput/browser/quickInputController.ts
@@ -29,7 +29,7 @@ import { autorun, observableValue } from '../../../base/common/observable.js';
 import { StandardMouseEvent } from '../../../base/browser/mouseEvent.js';
 import { IStorageService, StorageScope, StorageTarget } from '../../storage/common/storage.js';
 import { IConfigurationService } from '../../configuration/common/configuration.js';
-import { Platform, platform } from '../../../base/common/platform.js';
+import { Platform, platform, setTimeout0 } from '../../../base/common/platform.js';
 import { getWindowControlsStyle, WindowControlsStyle } from '../../window/common/window.js';
 import { getZoomFactor } from '../../../base/browser/browser.js';
 import { TriStateCheckbox } from '../../../base/browser/ui/toggle/toggle.js';
@@ -227,7 +227,10 @@ export class QuickInputController extends Disposable {
 			visibleCount.setCount(c);
 		}));
 		this._register(list.onChangedCheckedCount(c => {
-			count.setCount(c);
+			// TODO@TylerLeonhardt: Without this setTimeout, the screen reader will not read out
+			// the final count of checked items correctly. Investigate a better way
+			// to do this. ref https://github.com/microsoft/vscode/issues/258617
+			setTimeout0(() => count.setCount(c));
 		}));
 		this._register(list.onLeave(() => {
 			// Defer to avoid the input field reacting to the triggering key.

--- a/src/vs/platform/quickinput/browser/tree/quickTree.ts
+++ b/src/vs/platform/quickinput/browser/tree/quickTree.ts
@@ -5,6 +5,7 @@
 
 import { Emitter, Event } from '../../../../base/common/event.js';
 import { autorun, IReader, observableValue } from '../../../../base/common/observable.js';
+import { setTimeout0 } from '../../../../base/common/platform.js';
 import { localize } from '../../../../nls.js';
 import { IQuickTree, IQuickTreeItem, IQuickTreeItemButtonEvent, QuickInputType, QuickPickFocus } from '../../common/quickInput.js';
 import { QuickInput, QuickInputUI, Visibilities } from '../quickInput.js';
@@ -135,7 +136,10 @@ export class QuickTree<T extends IQuickTreeItem> extends QuickInput implements I
 		super.show(); // TODO: Why have show() bubble up while update() trickles down?
 
 		// Intial state
-		this.ui.count.setCount(this.ui.tree.getCheckedLeafItems().length);
+		// TODO@TylerLeonhardt: Without this setTimeout, the screen reader will not read out
+		// the final count of checked items correctly. Investigate a better way
+		// to do this. ref https://github.com/microsoft/vscode/issues/258617
+		setTimeout0(() => this.ui.count.setCount(this.ui.tree.getCheckedLeafItems().length));
 		const checkAllState = getParentNodeState([...this.ui.tree.tree.getNode().children]);
 		if (this.ui.checkAll.checked !== checkAllState) {
 			this.ui.checkAll.checked = checkAllState;


### PR DESCRIPTION
This is a workaround for now for an accessibility bug that should be addressed.

The way that the checked count works is that it's a `CountBadge` widget wrapped in an `aria-live` that reports when the text content (aka the number) changes.

However, when the QuickPick is initially shown to the user, the resolved count is done so before actually made visible... `aria-live` does not read out anything that is changed when hidden.

I think a proper change here would be to have a separate `aria-live` element that is always off screen (so "technically" visible)... that can be updated when a Count is made visible... but this small fix is fine to at least give screen reader users a count.

Fixes https://github.com/microsoft/vscode/issues/258617

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
