### PR TITLE
Terminal suggest addon should always multiply line height config

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalSuggestAddon.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalSuggestAddon.ts
@@ -721,11 +721,11 @@ export class SuggestAddon extends Disposable implements ITerminalAddon, ISuggest
 		// Unlike editor suggestions, line height in terminal is always multiplied to the font size.
 		// Make sure that we still enforce a minimum line height to avoid content from being clipped.
 		// See https://github.com/microsoft/vscode/issues/255851
-		const minTerminalLineHeight = GOLDEN_LINE_HEIGHT_RATIO * fontSize;
 		lineHeight = lineHeight * fontSize;
 
 		// Enforce integer, minimum constraints
 		lineHeight = Math.round(lineHeight);
+		const minTerminalLineHeight = GOLDEN_LINE_HEIGHT_RATIO * fontSize;
 		if (lineHeight < minTerminalLineHeight) {
 			lineHeight = minTerminalLineHeight;
 		}

--- a/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalSuggestAddon.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalSuggestAddon.ts
@@ -29,7 +29,7 @@ import { ThemeIcon } from '../../../../../base/common/themables.js';
 import { MenuId } from '../../../../../platform/actions/common/actions.js';
 import { ISimpleSuggestWidgetFontInfo } from '../../../../services/suggest/browser/simpleSuggestWidgetRenderer.js';
 import { ITerminalConfigurationService } from '../../../terminal/browser/terminal.js';
-import { GOLDEN_LINE_HEIGHT_RATIO, MINIMUM_LINE_HEIGHT } from '../../../../../editor/common/config/fontInfo.js';
+import { GOLDEN_LINE_HEIGHT_RATIO } from '../../../../../editor/common/config/fontInfo.js';
 import { TerminalCompletionModel } from './terminalCompletionModel.js';
 import { TerminalCompletionItem, TerminalCompletionItemKind, type ITerminalCompletion } from './terminalCompletionItem.js';
 import { localize } from '../../../../../nls.js';
@@ -718,17 +718,16 @@ export class SuggestAddon extends Disposable implements ITerminalAddon, ISuggest
 		const letterSpacing: number = font.letterSpacing;
 		const fontWeight: string = this._configurationService.getValue('editor.fontWeight');
 
-		if (lineHeight <= 1) {
-			lineHeight = GOLDEN_LINE_HEIGHT_RATIO * fontSize;
-		} else if (lineHeight < MINIMUM_LINE_HEIGHT) {
-			// Values too small to be line heights in pixels are in ems.
-			lineHeight = lineHeight * fontSize;
-		}
+		// Unlike editor suggestions, line height in terminal is always multiplied to the font size.
+		// Make sure that we still enforce a minimum line height to avoid content from being clipped.
+		// See https://github.com/microsoft/vscode/issues/255851
+		const minTerminalLineHeight = GOLDEN_LINE_HEIGHT_RATIO * fontSize;
+		lineHeight = lineHeight * fontSize;
 
 		// Enforce integer, minimum constraints
 		lineHeight = Math.round(lineHeight);
-		if (lineHeight < MINIMUM_LINE_HEIGHT) {
-			lineHeight = MINIMUM_LINE_HEIGHT;
+		if (lineHeight < minTerminalLineHeight) {
+			lineHeight = minTerminalLineHeight;
 		}
 
 		const fontInfo = {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

| Before | After |
| -- | -- |
| <img width="584" height="601" alt="image" src="https://github.com/user-attachments/assets/fc3bccb0-0f76-4610-be11-4608d3e5edcc" /> | <img width="574" height="585" alt="image" src="https://github.com/user-attachments/assets/f114f5ac-3283-44c7-871b-ebf1fc21677b" /> |


Based on the configuration description the treatment here should differ from regular editor suggest line heights:
<img width="757" height="140" alt="image" src="https://github.com/user-attachments/assets/cd205edb-192f-4830-8765-36a6135a8368" />

Compare with:
<img width="486" height="168" alt="image" src="https://github.com/user-attachments/assets/5790ab27-8c88-4cc2-bc89-973e945fd396" />

Fixes https://github.com/microsoft/vscode/issues/255851