### PR TITLE
Switch editor build steps off of `moduleResolution: classic`

### DIFF
--- a/build/gulpfile.editor.js
+++ b/build/gulpfile.editor.js
@@ -41,15 +41,19 @@ const extractEditorSrcTask = task.define('extract-editor-src', () => {
 	standalone.extractEditor({
 		sourcesRoot: path.join(root, 'src'),
 		entryPoints: [
-			'vs/editor/editor.main',
-			'vs/editor/editor.worker.start',
-			'vs/editor/common/services/editorWebWorkerMain',
+			'vs/editor/editor.main.ts',
+			'vs/editor/editor.worker.start.ts',
+			'vs/editor/common/services/editorWebWorkerMain.ts',
 		],
 		inlineEntryPoints: [
 			apiusages,
 			extrausages
 		],
 		typings: [],
+		additionalFilesToCopyOut: [
+			'vs/base/browser/dompurify/dompurify.js',
+			'vs/base/common/marked/marked.js',
+		],
 		shakeLevel: 2, // 0-Files, 1-InnerFile, 2-ClassMembers
 		importIgnorePattern: /\.css$/,
 		destRoot: path.join(root, 'out-editor-src'),

--- a/build/gulpfile.editor.js
+++ b/build/gulpfile.editor.js
@@ -54,9 +54,6 @@ const extractEditorSrcTask = task.define('extract-editor-src', () => {
 		importIgnorePattern: /\.css$/,
 		destRoot: path.join(root, 'out-editor-src'),
 		tsOutDir: '../out-monaco-editor-core/esm/vs',
-		redirects: {
-			'@vscode/tree-sitter-wasm': '../node_modules/@vscode/tree-sitter-wasm/wasm/web-tree-sitter',
-		}
 	});
 });
 

--- a/build/lib/monaco-api.js
+++ b/build/lib/monaco-api.js
@@ -336,7 +336,7 @@ function generateDeclarationFile(ts, recipe, sourceFileGetter) {
     usage.push(`var b: any;`);
     const generateUsageImport = (moduleId) => {
         const importName = 'm' + (++usageCounter);
-        usageImports.push(`import * as ${importName} from './${moduleId.replace(/\.d\.ts$/, '')}';`);
+        usageImports.push(`import * as ${importName} from './${moduleId}';`);
         return importName;
     };
     const enums = [];
@@ -538,6 +538,9 @@ class DeclarationResolver {
         if (/\.d\.ts$/.test(moduleId)) {
             return path_1.default.join(SRC, moduleId);
         }
+        if (/\.js$/.test(moduleId)) {
+            return path_1.default.join(SRC, moduleId.replace(/\.js$/, '.ts'));
+        }
         return path_1.default.join(SRC, `${moduleId}.ts`);
     }
     _getDeclarationSourceFile(moduleId) {
@@ -555,7 +558,7 @@ class DeclarationResolver {
         const fileMap = new Map([
             ['file.ts', fileContents]
         ]);
-        const service = this.ts.createLanguageService(new typeScriptLanguageServiceHost_1.TypeScriptLanguageServiceHost(this.ts, new Map(), fileMap, {}, 'defaultLib:es5'));
+        const service = this.ts.createLanguageService(new typeScriptLanguageServiceHost_1.TypeScriptLanguageServiceHost(this.ts, fileMap, {}));
         const text = service.getEmitOutput('file.ts', true, true).outputFiles[0].text;
         return new CacheEntry(this.ts.createSourceFile(fileName, text, this.ts.ScriptTarget.ES5), mtime);
     }

--- a/build/lib/monaco-api.ts
+++ b/build/lib/monaco-api.ts
@@ -406,7 +406,7 @@ function generateDeclarationFile(ts: Typescript, recipe: string, sourceFileGette
 
 	const generateUsageImport = (moduleId: string) => {
 		const importName = 'm' + (++usageCounter);
-		usageImports.push(`import * as ${importName} from './${moduleId.replace(/\.d\.ts$/, '')}';`);
+		usageImports.push(`import * as ${importName} from './${moduleId}';`);
 		return importName;
 	};
 
@@ -641,6 +641,9 @@ export class DeclarationResolver {
 		if (/\.d\.ts$/.test(moduleId)) {
 			return path.join(SRC, moduleId);
 		}
+		if (/\.js$/.test(moduleId)) {
+			return path.join(SRC, moduleId.replace(/\.js$/, '.ts'));
+		}
 		return path.join(SRC, `${moduleId}.ts`);
 	}
 
@@ -662,7 +665,7 @@ export class DeclarationResolver {
 		const fileMap: IFileMap = new Map([
 			['file.ts', fileContents]
 		]);
-		const service = this.ts.createLanguageService(new TypeScriptLanguageServiceHost(this.ts, new Map(), fileMap, {}, 'defaultLib:es5'));
+		const service = this.ts.createLanguageService(new TypeScriptLanguageServiceHost(this.ts, fileMap, {}));
 		const text = service.getEmitOutput('file.ts', true, true).outputFiles[0].text;
 		return new CacheEntry(
 			this.ts.createSourceFile(fileName, text, this.ts.ScriptTarget.ES5),

--- a/build/lib/standalone.js
+++ b/build/lib/standalone.js
@@ -134,6 +134,9 @@ function extractEditor(options) {
     }
     delete tsConfig.compilerOptions.moduleResolution;
     writeOutputFile('tsconfig.json', JSON.stringify(tsConfig, null, '\t'));
+    options.additionalFilesToCopyOut?.forEach((file) => {
+        copyFile(file);
+    });
     copyFile('vs/loader.js');
     copyFile('typings/css.d.ts');
     copyFile('../node_modules/@vscode/tree-sitter-wasm/wasm/web-tree-sitter.d.ts', '@vscode/tree-sitter-wasm.d.ts');

--- a/build/lib/standalone.js
+++ b/build/lib/standalone.js
@@ -90,19 +90,19 @@ function extractEditor(options) {
         }
     }
     const copied = {};
-    const copyFile = (fileName) => {
+    const copyFile = (fileName, toFileName) => {
         if (copied[fileName]) {
             return;
         }
         copied[fileName] = true;
         if (path_1.default.isAbsolute(fileName)) {
             const relativePath = path_1.default.relative(options.sourcesRoot, fileName);
-            const dstPath = path_1.default.join(options.destRoot, relativePath);
+            const dstPath = path_1.default.join(options.destRoot, toFileName ?? relativePath);
             writeFile(dstPath, fs_1.default.readFileSync(fileName));
         }
         else {
             const srcPath = path_1.default.join(options.sourcesRoot, fileName);
-            const dstPath = path_1.default.join(options.destRoot, fileName);
+            const dstPath = path_1.default.join(options.destRoot, toFileName ?? fileName);
             writeFile(dstPath, fs_1.default.readFileSync(srcPath));
         }
     };
@@ -134,10 +134,9 @@ function extractEditor(options) {
     }
     delete tsConfig.compilerOptions.moduleResolution;
     writeOutputFile('tsconfig.json', JSON.stringify(tsConfig, null, '\t'));
-    [
-        'vs/loader.js',
-        'typings/css.d.ts'
-    ].forEach(copyFile);
+    copyFile('vs/loader.js');
+    copyFile('typings/css.d.ts');
+    copyFile('../node_modules/@vscode/tree-sitter-wasm/wasm/web-tree-sitter.d.ts', '@vscode/tree-sitter-wasm.d.ts');
 }
 function transportCSS(module, enqueue, write) {
     if (!/\.css/.test(module)) {

--- a/build/lib/standalone.ts
+++ b/build/lib/standalone.ts
@@ -26,7 +26,7 @@ function writeFile(filePath: string, contents: Buffer | string): void {
 	fs.writeFileSync(filePath, contents);
 }
 
-export function extractEditor(options: tss.ITreeShakingOptions & { destRoot: string; tsOutDir: string }): void {
+export function extractEditor(options: tss.ITreeShakingOptions & { destRoot: string; tsOutDir: string; additionalFilesToCopyOut?: string[]; }): void {
 	const ts = require('typescript') as typeof import('typescript');
 
 	const tsConfig = JSON.parse(fs.readFileSync(path.join(options.sourcesRoot, 'tsconfig.monaco.json')).toString());
@@ -109,6 +109,10 @@ export function extractEditor(options: tss.ITreeShakingOptions & { destRoot: str
 
 	delete tsConfig.compilerOptions.moduleResolution;
 	writeOutputFile('tsconfig.json', JSON.stringify(tsConfig, null, '\t'));
+
+	options.additionalFilesToCopyOut?.forEach((file) => {
+		copyFile(file);
+	});
 
 	copyFile('vs/loader.js');
 	copyFile('typings/css.d.ts');

--- a/build/lib/standalone.ts
+++ b/build/lib/standalone.ts
@@ -62,7 +62,7 @@ export function extractEditor(options: tss.ITreeShakingOptions & { destRoot: str
 		}
 	}
 	const copied: { [fileName: string]: boolean } = {};
-	const copyFile = (fileName: string) => {
+	const copyFile = (fileName: string, toFileName?: string) => {
 		if (copied[fileName]) {
 			return;
 		}
@@ -70,11 +70,11 @@ export function extractEditor(options: tss.ITreeShakingOptions & { destRoot: str
 
 		if (path.isAbsolute(fileName)) {
 			const relativePath = path.relative(options.sourcesRoot, fileName);
-			const dstPath = path.join(options.destRoot, relativePath);
+			const dstPath = path.join(options.destRoot, toFileName ?? relativePath);
 			writeFile(dstPath, fs.readFileSync(fileName));
 		} else {
 			const srcPath = path.join(options.sourcesRoot, fileName);
-			const dstPath = path.join(options.destRoot, fileName);
+			const dstPath = path.join(options.destRoot, toFileName ?? fileName);
 			writeFile(dstPath, fs.readFileSync(srcPath));
 		}
 	};
@@ -110,10 +110,9 @@ export function extractEditor(options: tss.ITreeShakingOptions & { destRoot: str
 	delete tsConfig.compilerOptions.moduleResolution;
 	writeOutputFile('tsconfig.json', JSON.stringify(tsConfig, null, '\t'));
 
-	[
-		'vs/loader.js',
-		'typings/css.d.ts'
-	].forEach(copyFile);
+	copyFile('vs/loader.js');
+	copyFile('typings/css.d.ts');
+	copyFile('../node_modules/@vscode/tree-sitter-wasm/wasm/web-tree-sitter.d.ts', '@vscode/tree-sitter-wasm.d.ts');
 }
 
 function transportCSS(module: string, enqueue: (module: string) => void, write: (path: string, contents: string | Buffer) => void): boolean {

--- a/build/lib/standalone.ts
+++ b/build/lib/standalone.ts
@@ -26,7 +26,7 @@ function writeFile(filePath: string, contents: Buffer | string): void {
 	fs.writeFileSync(filePath, contents);
 }
 
-export function extractEditor(options: tss.ITreeShakingOptions & { destRoot: string; tsOutDir: string; additionalFilesToCopyOut?: string[]; }): void {
+export function extractEditor(options: tss.ITreeShakingOptions & { destRoot: string; tsOutDir: string; additionalFilesToCopyOut?: string[] }): void {
 	const ts = require('typescript') as typeof import('typescript');
 
 	const tsConfig = JSON.parse(fs.readFileSync(path.join(options.sourcesRoot, 'tsconfig.monaco.json')).toString());

--- a/build/lib/treeshaking.js
+++ b/build/lib/treeshaking.js
@@ -12,7 +12,6 @@ exports.shake = shake;
 const fs_1 = __importDefault(require("fs"));
 const path_1 = __importDefault(require("path"));
 const typeScriptLanguageServiceHost_1 = require("./typeScriptLanguageServiceHost");
-const TYPESCRIPT_LIB_FOLDER = path_1.default.dirname(require.resolve('typescript/lib/lib.d.ts'));
 var ShakeLevel;
 (function (ShakeLevel) {
     ShakeLevel[ShakeLevel["Files"] = 0] = "Files";
@@ -68,100 +67,25 @@ function shake(options) {
 //#region Discovery, LanguageService & Setup
 function createTypeScriptLanguageService(ts, options) {
     // Discover referenced files
-    const FILES = discoverAndReadFiles(ts, options);
+    const FILES = new Map();
+    // Add entrypoints
+    options.entryPoints.forEach(entryPoint => {
+        const filePath = path_1.default.join(options.sourcesRoot, `${entryPoint}.ts`);
+        FILES.set(filePath, fs_1.default.readFileSync(filePath).toString());
+    });
     // Add fake usage files
     options.inlineEntryPoints.forEach((inlineEntryPoint, index) => {
-        FILES.set(`inlineEntryPoint.${index}.ts`, inlineEntryPoint);
+        FILES.set(path_1.default.join(options.sourcesRoot, `inlineEntryPoint.${index}.ts`), inlineEntryPoint);
     });
     // Add additional typings
     options.typings.forEach((typing) => {
         const filePath = path_1.default.join(options.sourcesRoot, typing);
-        FILES.set(typing, fs_1.default.readFileSync(filePath).toString());
+        FILES.set(filePath, fs_1.default.readFileSync(filePath).toString());
     });
-    // Resolve libs
-    const RESOLVED_LIBS = processLibFiles(ts, options);
-    const compilerOptions = ts.convertCompilerOptionsFromJson(options.compilerOptions, options.sourcesRoot).options;
-    const host = new typeScriptLanguageServiceHost_1.TypeScriptLanguageServiceHost(ts, RESOLVED_LIBS, FILES, compilerOptions, 'defaultLib:lib.d.ts');
+    const basePath = path_1.default.join(options.sourcesRoot, '..');
+    const compilerOptions = ts.convertCompilerOptionsFromJson(options.compilerOptions, basePath).options;
+    const host = new typeScriptLanguageServiceHost_1.TypeScriptLanguageServiceHost(ts, FILES, compilerOptions);
     return ts.createLanguageService(host);
-}
-/**
- * Read imports and follow them until all files have been handled
- */
-function discoverAndReadFiles(ts, options) {
-    const FILES = new Map();
-    const in_queue = Object.create(null);
-    const queue = [];
-    const enqueue = (moduleId) => {
-        // To make the treeshaker work on windows...
-        moduleId = moduleId.replace(/\\/g, '/');
-        if (in_queue[moduleId]) {
-            return;
-        }
-        in_queue[moduleId] = true;
-        queue.push(moduleId);
-    };
-    options.entryPoints.forEach((entryPoint) => enqueue(entryPoint));
-    while (queue.length > 0) {
-        const moduleId = queue.shift();
-        let redirectedModuleId = moduleId;
-        if (options.redirects[moduleId]) {
-            redirectedModuleId = options.redirects[moduleId];
-        }
-        const dts_filename = path_1.default.join(options.sourcesRoot, redirectedModuleId + '.d.ts');
-        if (fs_1.default.existsSync(dts_filename)) {
-            const dts_filecontents = fs_1.default.readFileSync(dts_filename).toString();
-            FILES.set(`${moduleId}.d.ts`, dts_filecontents);
-            continue;
-        }
-        const js_filename = path_1.default.join(options.sourcesRoot, redirectedModuleId + '.js');
-        if (fs_1.default.existsSync(js_filename)) {
-            // This is an import for a .js file, so ignore it...
-            continue;
-        }
-        const ts_filename = path_1.default.join(options.sourcesRoot, redirectedModuleId + '.ts');
-        const ts_filecontents = fs_1.default.readFileSync(ts_filename).toString();
-        const info = ts.preProcessFile(ts_filecontents);
-        for (let i = info.importedFiles.length - 1; i >= 0; i--) {
-            const importedFileName = info.importedFiles[i].fileName;
-            if (options.importIgnorePattern.test(importedFileName)) {
-                // Ignore *.css imports
-                continue;
-            }
-            let importedModuleId = importedFileName;
-            if (/(^\.\/)|(^\.\.\/)/.test(importedModuleId)) {
-                importedModuleId = path_1.default.join(path_1.default.dirname(moduleId), importedModuleId);
-                if (importedModuleId.endsWith('.js')) { // ESM: code imports require to be relative and have a '.js' file extension
-                    importedModuleId = importedModuleId.substr(0, importedModuleId.length - 3);
-                }
-            }
-            enqueue(importedModuleId);
-        }
-        FILES.set(`${moduleId}.ts`, ts_filecontents);
-    }
-    return FILES;
-}
-/**
- * Read lib files and follow lib references
- */
-function processLibFiles(ts, options) {
-    const stack = [...options.compilerOptions.lib];
-    const result = new Map();
-    while (stack.length > 0) {
-        const filename = `lib.${stack.shift().toLowerCase()}.d.ts`;
-        const key = `defaultLib:${filename}`;
-        if (!result.has(key)) {
-            // add this file
-            const filepath = path_1.default.join(TYPESCRIPT_LIB_FOLDER, filename);
-            const sourceText = fs_1.default.readFileSync(filepath).toString();
-            result.set(key, sourceText);
-            // precess dependencies and "recurse"
-            const info = ts.preProcessFile(sourceText);
-            for (const ref of info.libReferenceDirectives) {
-                stack.push(ref.fileName);
-            }
-        }
-    }
-    return result;
 }
 //#endregion
 //#region Tree Shaking
@@ -410,9 +334,9 @@ function markNodes(ts, languageService, options) {
         }
         enqueueFile(fullPath);
     }
-    options.entryPoints.forEach(moduleId => enqueueFile(moduleId + '.ts'));
+    options.entryPoints.forEach(moduleId => enqueueFile(path_1.default.join(options.sourcesRoot, moduleId + '.ts')));
     // Add fake usage files
-    options.inlineEntryPoints.forEach((_, index) => enqueueFile(`inlineEntryPoint.${index}.ts`));
+    options.inlineEntryPoints.forEach((_, index) => enqueueFile(path_1.default.join(options.sourcesRoot, `inlineEntryPoint.${index}.ts`)));
     let step = 0;
     const checker = program.getTypeChecker();
     while (black_queue.length > 0 || gray_queue.length > 0) {

--- a/build/lib/treeshaking.js
+++ b/build/lib/treeshaking.js
@@ -70,7 +70,7 @@ function createTypeScriptLanguageService(ts, options) {
     const FILES = new Map();
     // Add entrypoints
     options.entryPoints.forEach(entryPoint => {
-        const filePath = path_1.default.join(options.sourcesRoot, `${entryPoint}.ts`);
+        const filePath = path_1.default.join(options.sourcesRoot, entryPoint);
         FILES.set(filePath, fs_1.default.readFileSync(filePath).toString());
     });
     // Add fake usage files
@@ -327,14 +327,20 @@ function markNodes(ts, languageService, options) {
             if (importText.endsWith('.js')) { // ESM: code imports require to be relative and to have a '.js' file extension
                 importText = importText.substr(0, importText.length - 3);
             }
-            fullPath = path_1.default.join(path_1.default.dirname(nodeSourceFile.fileName), importText) + '.ts';
+            fullPath = path_1.default.join(path_1.default.dirname(nodeSourceFile.fileName), importText);
         }
         else {
-            fullPath = importText + '.ts';
+            fullPath = importText;
+        }
+        if (fs_1.default.existsSync(fullPath + '.ts')) {
+            fullPath = fullPath + '.ts';
+        }
+        else {
+            fullPath = fullPath + '.js';
         }
         enqueueFile(fullPath);
     }
-    options.entryPoints.forEach(moduleId => enqueueFile(path_1.default.join(options.sourcesRoot, moduleId + '.ts')));
+    options.entryPoints.forEach(moduleId => enqueueFile(path_1.default.join(options.sourcesRoot, moduleId)));
     // Add fake usage files
     options.inlineEntryPoints.forEach((_, index) => enqueueFile(path_1.default.join(options.sourcesRoot, `inlineEntryPoint.${index}.ts`)));
     let step = 0;

--- a/build/lib/treeshaking.ts
+++ b/build/lib/treeshaking.ts
@@ -111,7 +111,7 @@ function createTypeScriptLanguageService(ts: typeof import('typescript'), option
 
 	// Add entrypoints
 	options.entryPoints.forEach(entryPoint => {
-		const filePath = path.join(options.sourcesRoot, `${entryPoint}.ts`);
+		const filePath = path.join(options.sourcesRoot, entryPoint);
 		FILES.set(filePath, fs.readFileSync(filePath).toString());
 	});
 
@@ -423,14 +423,21 @@ function markNodes(ts: typeof import('typescript'), languageService: ts.Language
 			if (importText.endsWith('.js')) { // ESM: code imports require to be relative and to have a '.js' file extension
 				importText = importText.substr(0, importText.length - 3);
 			}
-			fullPath = path.join(path.dirname(nodeSourceFile.fileName), importText) + '.ts';
+			fullPath = path.join(path.dirname(nodeSourceFile.fileName), importText);
 		} else {
-			fullPath = importText + '.ts';
+			fullPath = importText;
 		}
+
+		if (fs.existsSync(fullPath + '.ts')) {
+			fullPath = fullPath + '.ts';
+		} else {
+			fullPath = fullPath + '.js';
+		}
+
 		enqueueFile(fullPath);
 	}
 
-	options.entryPoints.forEach(moduleId => enqueueFile(path.join(options.sourcesRoot, moduleId + '.ts')));
+	options.entryPoints.forEach(moduleId => enqueueFile(path.join(options.sourcesRoot, moduleId)));
 	// Add fake usage files
 	options.inlineEntryPoints.forEach((_, index) => enqueueFile(path.join(options.sourcesRoot, `inlineEntryPoint.${index}.ts`)));
 

--- a/build/lib/treeshaking.ts
+++ b/build/lib/treeshaking.ts
@@ -6,9 +6,7 @@
 import fs from 'fs';
 import path from 'path';
 import type * as ts from 'typescript';
-import { IFileMap, ILibMap, TypeScriptLanguageServiceHost } from './typeScriptLanguageServiceHost';
-
-const TYPESCRIPT_LIB_FOLDER = path.dirname(require.resolve('typescript/lib/lib.d.ts'));
+import { IFileMap, TypeScriptLanguageServiceHost } from './typeScriptLanguageServiceHost';
 
 enum ShakeLevel {
 	Files = 0,
@@ -58,7 +56,7 @@ export interface ITreeShakingOptions {
 	 */
 	importIgnorePattern: RegExp;
 
-	redirects: { [module: string]: string };
+	// redirects: { [module: string]: string };
 }
 
 export interface ITreeShakingResult {
@@ -111,124 +109,29 @@ export function shake(options: ITreeShakingOptions): ITreeShakingResult {
 //#region Discovery, LanguageService & Setup
 function createTypeScriptLanguageService(ts: typeof import('typescript'), options: ITreeShakingOptions): ts.LanguageService {
 	// Discover referenced files
-	const FILES = discoverAndReadFiles(ts, options);
+	const FILES: IFileMap = new Map();
+
+	// Add entrypoints
+	options.entryPoints.forEach(entryPoint => {
+		const filePath = path.join(options.sourcesRoot, `${entryPoint}.ts`);
+		FILES.set(filePath, fs.readFileSync(filePath).toString());
+	});
 
 	// Add fake usage files
 	options.inlineEntryPoints.forEach((inlineEntryPoint, index) => {
-		FILES.set(`inlineEntryPoint.${index}.ts`, inlineEntryPoint);
+		FILES.set(path.join(options.sourcesRoot, `inlineEntryPoint.${index}.ts`), inlineEntryPoint);
 	});
 
 	// Add additional typings
 	options.typings.forEach((typing) => {
 		const filePath = path.join(options.sourcesRoot, typing);
-		FILES.set(typing, fs.readFileSync(filePath).toString());
+		FILES.set(filePath, fs.readFileSync(filePath).toString());
 	});
 
-	// Resolve libs
-	const RESOLVED_LIBS = processLibFiles(ts, options);
-
-	const compilerOptions = ts.convertCompilerOptionsFromJson(options.compilerOptions, options.sourcesRoot).options;
-
-	const host = new TypeScriptLanguageServiceHost(ts, RESOLVED_LIBS, FILES, compilerOptions, 'defaultLib:lib.d.ts');
+	const basePath = path.join(options.sourcesRoot, '..');
+	const compilerOptions = ts.convertCompilerOptionsFromJson(options.compilerOptions, basePath).options;
+	const host = new TypeScriptLanguageServiceHost(ts, FILES, compilerOptions);
 	return ts.createLanguageService(host);
-}
-
-/**
- * Read imports and follow them until all files have been handled
- */
-function discoverAndReadFiles(ts: typeof import('typescript'), options: ITreeShakingOptions): IFileMap {
-	const FILES: IFileMap = new Map();
-
-	const in_queue: { [module: string]: boolean } = Object.create(null);
-	const queue: string[] = [];
-
-	const enqueue = (moduleId: string) => {
-		// To make the treeshaker work on windows...
-		moduleId = moduleId.replace(/\\/g, '/');
-		if (in_queue[moduleId]) {
-			return;
-		}
-		in_queue[moduleId] = true;
-		queue.push(moduleId);
-	};
-
-	options.entryPoints.forEach((entryPoint) => enqueue(entryPoint));
-
-	while (queue.length > 0) {
-		const moduleId = queue.shift()!;
-		let redirectedModuleId: string = moduleId;
-		if (options.redirects[moduleId]) {
-			redirectedModuleId = options.redirects[moduleId];
-		}
-
-		const dts_filename = path.join(options.sourcesRoot, redirectedModuleId + '.d.ts');
-		if (fs.existsSync(dts_filename)) {
-			const dts_filecontents = fs.readFileSync(dts_filename).toString();
-			FILES.set(`${moduleId}.d.ts`, dts_filecontents);
-			continue;
-		}
-
-
-		const js_filename = path.join(options.sourcesRoot, redirectedModuleId + '.js');
-		if (fs.existsSync(js_filename)) {
-			// This is an import for a .js file, so ignore it...
-			continue;
-		}
-
-		const ts_filename = path.join(options.sourcesRoot, redirectedModuleId + '.ts');
-
-		const ts_filecontents = fs.readFileSync(ts_filename).toString();
-		const info = ts.preProcessFile(ts_filecontents);
-		for (let i = info.importedFiles.length - 1; i >= 0; i--) {
-			const importedFileName = info.importedFiles[i].fileName;
-
-			if (options.importIgnorePattern.test(importedFileName)) {
-				// Ignore *.css imports
-				continue;
-			}
-
-			let importedModuleId = importedFileName;
-			if (/(^\.\/)|(^\.\.\/)/.test(importedModuleId)) {
-				importedModuleId = path.join(path.dirname(moduleId), importedModuleId);
-				if (importedModuleId.endsWith('.js')) { // ESM: code imports require to be relative and have a '.js' file extension
-					importedModuleId = importedModuleId.substr(0, importedModuleId.length - 3);
-				}
-			}
-			enqueue(importedModuleId);
-		}
-
-		FILES.set(`${moduleId}.ts`, ts_filecontents);
-	}
-
-	return FILES;
-}
-
-/**
- * Read lib files and follow lib references
- */
-function processLibFiles(ts: typeof import('typescript'), options: ITreeShakingOptions): ILibMap {
-
-	const stack: string[] = [...options.compilerOptions.lib];
-	const result: ILibMap = new Map();
-
-	while (stack.length > 0) {
-		const filename = `lib.${stack.shift()!.toLowerCase()}.d.ts`;
-		const key = `defaultLib:${filename}`;
-		if (!result.has(key)) {
-			// add this file
-			const filepath = path.join(TYPESCRIPT_LIB_FOLDER, filename);
-			const sourceText = fs.readFileSync(filepath).toString();
-			result.set(key, sourceText);
-
-			// precess dependencies and "recurse"
-			const info = ts.preProcessFile(sourceText);
-			for (const ref of info.libReferenceDirectives) {
-				stack.push(ref.fileName);
-			}
-		}
-	}
-
-	return result;
 }
 
 //#endregion
@@ -529,9 +432,9 @@ function markNodes(ts: typeof import('typescript'), languageService: ts.Language
 		enqueueFile(fullPath);
 	}
 
-	options.entryPoints.forEach(moduleId => enqueueFile(moduleId + '.ts'));
+	options.entryPoints.forEach(moduleId => enqueueFile(path.join(options.sourcesRoot, moduleId + '.ts')));
 	// Add fake usage files
-	options.inlineEntryPoints.forEach((_, index) => enqueueFile(`inlineEntryPoint.${index}.ts`));
+	options.inlineEntryPoints.forEach((_, index) => enqueueFile(path.join(options.sourcesRoot, `inlineEntryPoint.${index}.ts`)));
 
 	let step = 0;
 

--- a/build/lib/treeshaking.ts
+++ b/build/lib/treeshaking.ts
@@ -55,8 +55,6 @@ export interface ITreeShakingOptions {
 	 * regex pattern to ignore certain imports e.g. `.css` imports
 	 */
 	importIgnorePattern: RegExp;
-
-	// redirects: { [module: string]: string };
 }
 
 export interface ITreeShakingResult {

--- a/build/lib/typeScriptLanguageServiceHost.js
+++ b/build/lib/typeScriptLanguageServiceHost.js
@@ -1,21 +1,26 @@
 "use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.TypeScriptLanguageServiceHost = void 0;
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+const typescript_1 = __importDefault(require("typescript"));
+const node_fs_1 = __importDefault(require("node:fs"));
 /**
  * A TypeScript language service host
  */
 class TypeScriptLanguageServiceHost {
     ts;
-    libs;
-    files;
+    topLevelFiles;
     compilerOptions;
-    defaultLibName;
-    constructor(ts, libs, files, compilerOptions, defaultLibName) {
+    constructor(ts, topLevelFiles, compilerOptions) {
         this.ts = ts;
-        this.libs = libs;
-        this.files = files;
+        this.topLevelFiles = topLevelFiles;
         this.compilerOptions = compilerOptions;
-        this.defaultLibName = defaultLibName;
     }
     // --- language service host ---------------
     getCompilationSettings() {
@@ -23,8 +28,8 @@ class TypeScriptLanguageServiceHost {
     }
     getScriptFileNames() {
         return [
-            ...this.libs.keys(),
-            ...this.files.keys(),
+            ...this.topLevelFiles.keys(),
+            this.ts.getDefaultLibFilePath(this.compilerOptions)
         ];
     }
     getScriptVersion(_fileName) {
@@ -34,14 +39,11 @@ class TypeScriptLanguageServiceHost {
         return '1';
     }
     getScriptSnapshot(fileName) {
-        if (this.files.has(fileName)) {
-            return this.ts.ScriptSnapshot.fromString(this.files.get(fileName));
-        }
-        else if (this.libs.has(fileName)) {
-            return this.ts.ScriptSnapshot.fromString(this.libs.get(fileName));
+        if (this.topLevelFiles.has(fileName)) {
+            return this.ts.ScriptSnapshot.fromString(this.topLevelFiles.get(fileName));
         }
         else {
-            return this.ts.ScriptSnapshot.fromString('');
+            return typescript_1.default.ScriptSnapshot.fromString(node_fs_1.default.readFileSync(fileName).toString());
         }
     }
     getScriptKind(_fileName) {
@@ -51,16 +53,19 @@ class TypeScriptLanguageServiceHost {
         return '';
     }
     getDefaultLibFileName(_options) {
-        return this.defaultLibName;
-    }
-    isDefaultLibFileName(fileName) {
-        return fileName === this.getDefaultLibFileName(this.compilerOptions);
+        return this.ts.getDefaultLibFilePath(_options);
     }
     readFile(path, _encoding) {
-        return this.files.get(path) || this.libs.get(path);
+        if (this.topLevelFiles.get(path)) {
+            return this.topLevelFiles.get(path);
+        }
+        return typescript_1.default.sys.readFile(path, _encoding);
     }
     fileExists(path) {
-        return this.files.has(path) || this.libs.has(path);
+        if (this.topLevelFiles.has(path)) {
+            return true;
+        }
+        return typescript_1.default.sys.fileExists(path);
     }
 }
 exports.TypeScriptLanguageServiceHost = TypeScriptLanguageServiceHost;

--- a/build/lib/typeScriptLanguageServiceHost.js
+++ b/build/lib/typeScriptLanguageServiceHost.js
@@ -52,14 +52,14 @@ class TypeScriptLanguageServiceHost {
     getCurrentDirectory() {
         return '';
     }
-    getDefaultLibFileName(_options) {
-        return this.ts.getDefaultLibFilePath(_options);
+    getDefaultLibFileName(options) {
+        return this.ts.getDefaultLibFilePath(options);
     }
-    readFile(path, _encoding) {
+    readFile(path, encoding) {
         if (this.topLevelFiles.get(path)) {
             return this.topLevelFiles.get(path);
         }
-        return typescript_1.default.sys.readFile(path, _encoding);
+        return typescript_1.default.sys.readFile(path, encoding);
     }
     fileExists(path) {
         if (this.topLevelFiles.has(path)) {

--- a/build/lib/typeScriptLanguageServiceHost.ts
+++ b/build/lib/typeScriptLanguageServiceHost.ts
@@ -5,7 +5,6 @@
 
 import ts from 'typescript';
 import fs from 'node:fs';
-// import path from 'node:path';
 
 export type IFileMap = Map</*fileName*/ string, string>;
 
@@ -49,14 +48,14 @@ export class TypeScriptLanguageServiceHost implements ts.LanguageServiceHost {
 	getCurrentDirectory(): string {
 		return '';
 	}
-	getDefaultLibFileName(_options: ts.CompilerOptions): string {
-		return this.ts.getDefaultLibFilePath(_options);
+	getDefaultLibFileName(options: ts.CompilerOptions): string {
+		return this.ts.getDefaultLibFilePath(options);
 	}
-	readFile(path: string, _encoding?: string): string | undefined {
+	readFile(path: string, encoding?: string): string | undefined {
 		if (this.topLevelFiles.get(path)) {
 			return this.topLevelFiles.get(path);
 		}
-		return ts.sys.readFile(path, _encoding);
+		return ts.sys.readFile(path, encoding);
 	}
 	fileExists(path: string): boolean {
 		if (this.topLevelFiles.has(path)) {

--- a/build/monaco/monaco.d.ts.recipe
+++ b/build/monaco/monaco.d.ts.recipe
@@ -70,27 +70,27 @@ declare namespace monaco {
 		dispose(): void;
 	}
 
-#include(vs/platform/markers/common/markers): MarkerTag, MarkerSeverity
-#include(vs/base/common/cancellation): CancellationTokenSource, CancellationToken
-#include(vs/base/common/uri): URI, UriComponents
-#include(vs/base/common/keyCodes): KeyCode
-#include(vs/editor/common/services/editorBaseApi): KeyMod
-#include(vs/base/common/htmlContent): IMarkdownString, MarkdownStringTrustedOptions
-#include(vs/base/browser/keyboardEvent): IKeyboardEvent
-#include(vs/base/browser/mouseEvent): IMouseEvent
-#include(vs/editor/common/editorCommon): IScrollEvent
-#include(vs/editor/common/core/position): IPosition, Position
-#include(vs/editor/common/core/range): IRange, Range
-#include(vs/editor/common/core/selection): ISelection, Selection, SelectionDirection
-#include(vs/editor/common/languages): Token
+#include(vs/platform/markers/common/markers.js): MarkerTag, MarkerSeverity
+#include(vs/base/common/cancellation.js): CancellationTokenSource, CancellationToken
+#include(vs/base/common/uri.js): URI, UriComponents
+#include(vs/base/common/keyCodes.js): KeyCode
+#include(vs/editor/common/services/editorBaseApi.js): KeyMod
+#include(vs/base/common/htmlContent.js): IMarkdownString, MarkdownStringTrustedOptions
+#include(vs/base/browser/keyboardEvent.js): IKeyboardEvent
+#include(vs/base/browser/mouseEvent.js): IMouseEvent
+#include(vs/editor/common/editorCommon.js): IScrollEvent
+#include(vs/editor/common/core/position.js): IPosition, Position
+#include(vs/editor/common/core/range.js): IRange, Range
+#include(vs/editor/common/core/selection.js): ISelection, Selection, SelectionDirection
+#include(vs/editor/common/languages.js): Token
 }
 
 declare namespace monaco.editor {
-#includeAll(vs/editor/standalone/browser/standaloneEditor;languages.Token=>Token):
-#include(vs/editor/standalone/common/standaloneTheme): BuiltinTheme, IStandaloneThemeData, IColors
-#include(vs/editor/common/languages/supports/tokenization): ITokenThemeRule
-#include(vs/editor/standalone/browser/standaloneWebWorker): MonacoWebWorker, IInternalWebWorkerOptions
-#include(vs/editor/standalone/browser/standaloneCodeEditor): IActionDescriptor, IGlobalEditorOptions, IStandaloneEditorConstructionOptions, IStandaloneDiffEditorConstructionOptions, IStandaloneCodeEditor, IStandaloneDiffEditor
+#includeAll(vs/editor/standalone/browser/standaloneEditor.js;languages.Token=>Token):
+#include(vs/editor/standalone/common/standaloneTheme.js): BuiltinTheme, IStandaloneThemeData, IColors
+#include(vs/editor/common/languages/supports/tokenization.js): ITokenThemeRule
+#include(vs/editor/standalone/browser/standaloneWebWorker.js): MonacoWebWorker, IInternalWebWorkerOptions
+#include(vs/editor/standalone/browser/standaloneCodeEditor.js): IActionDescriptor, IGlobalEditorOptions, IStandaloneEditorConstructionOptions, IStandaloneDiffEditorConstructionOptions, IStandaloneCodeEditor, IStandaloneDiffEditor
 export interface ICommandHandler {
 	(...args: any[]): void;
 }
@@ -101,27 +101,27 @@ export interface ILocalizedString {
 export interface ICommandMetadata {
 	readonly description: ILocalizedString | string;
 }
-#include(vs/platform/contextkey/common/contextkey): IContextKey, ContextKeyValue
-#include(vs/editor/standalone/browser/standaloneServices): IEditorOverrideServices
-#include(vs/platform/markers/common/markers): IMarker, IMarkerData, IRelatedInformation
-#include(vs/editor/standalone/browser/colorizer): IColorizerOptions, IColorizerElementOptions
-#include(vs/base/common/scrollable): ScrollbarVisibility
-#include(vs/base/common/themables): ThemeColor, ThemeIcon
-#include(vs/editor/common/core/editOperation): ISingleEditOperation
-#include(vs/editor/common/core/wordHelper): IWordAtPosition
-#includeAll(vs/editor/common/model): IScrollEvent
-#include(vs/editor/common/diff/legacyLinesDiffComputer): IChange, ICharChange, ILineChange
-#include(vs/editor/common/core/2d/dimension): IDimension
-#includeAll(vs/editor/common/editorCommon): IScrollEvent
-#includeAll(vs/editor/common/textModelEvents):
-#include(vs/editor/common/model/mirrorTextModel): IModelContentChange
-#includeAll(vs/editor/common/cursorEvents):
-#include(vs/platform/accessibility/common/accessibility): AccessibilitySupport
-#includeAll(vs/editor/common/config/editorOptions):
-#include(vs/editor/browser/config/editorConfiguration): IEditorConstructionOptions
-#includeAll(vs/editor/browser/editorBrowser;editorCommon.=>):
-#include(vs/editor/common/config/fontInfo): FontInfo, BareFontInfo
-#include(vs/editor/common/config/editorZoom): EditorZoom, IEditorZoom
+#include(vs/platform/contextkey/common/contextkey.js): IContextKey, ContextKeyValue
+#include(vs/editor/standalone/browser/standaloneServices.js): IEditorOverrideServices
+#include(vs/platform/markers/common/markers.js): IMarker, IMarkerData, IRelatedInformation
+#include(vs/editor/standalone/browser/colorizer.js): IColorizerOptions, IColorizerElementOptions
+#include(vs/base/common/scrollable.js): ScrollbarVisibility
+#include(vs/base/common/themables.js): ThemeColor, ThemeIcon
+#include(vs/editor/common/core/editOperation.js): ISingleEditOperation
+#include(vs/editor/common/core/wordHelper.js): IWordAtPosition
+#includeAll(vs/editor/common/model.js): IScrollEvent
+#include(vs/editor/common/diff/legacyLinesDiffComputer.js): IChange, ICharChange, ILineChange
+#include(vs/editor/common/core/2d/dimension.js): IDimension
+#includeAll(vs/editor/common/editorCommon.js): IScrollEvent
+#includeAll(vs/editor/common/textModelEvents.js):
+#include(vs/editor/common/model/mirrorTextModel.js): IModelContentChange
+#includeAll(vs/editor/common/cursorEvents.js):
+#include(vs/platform/accessibility/common/accessibility.js): AccessibilitySupport
+#includeAll(vs/editor/common/config/editorOptions.js):
+#include(vs/editor/browser/config/editorConfiguration.js): IEditorConstructionOptions
+#includeAll(vs/editor/browser/editorBrowser.js;editorCommon.=>):
+#include(vs/editor/common/config/fontInfo.js): FontInfo, BareFontInfo
+#include(vs/editor/common/config/editorZoom.js): EditorZoom, IEditorZoom
 
 //compatibility:
 export type IReadOnlyModel = ITextModel;
@@ -130,21 +130,21 @@ export type IModel = ITextModel;
 
 declare namespace monaco.languages {
 
-#include(vs/editor/common/textModelEditSource): EditDeltaInfo
-#include(vs/base/common/glob): IRelativePattern
-#include(vs/editor/common/languageSelector): LanguageSelector, LanguageFilter
-#includeAll(vs/editor/standalone/browser/standaloneLanguages;languages.=>;editorCommon.=>editor.;model.=>editor.;IMarkerData=>editor.IMarkerData):
-#includeAll(vs/editor/common/languages/languageConfiguration):
-#includeAll(vs/editor/common/languages;IMarkerData=>editor.IMarkerData;ISingleEditOperation=>editor.ISingleEditOperation;model.=>editor.;ThemeIcon=>editor.ThemeIcon): Token
-#include(vs/editor/common/languages/language): ILanguageExtensionPoint
-#includeAll(vs/editor/standalone/common/monarch/monarchTypes):
+#include(vs/editor/common/textModelEditSource.js): EditDeltaInfo
+#include(vs/base/common/glob.js): IRelativePattern
+#include(vs/editor/common/languageSelector.js): LanguageSelector, LanguageFilter
+#includeAll(vs/editor/standalone/browser/standaloneLanguages.js;languages.=>;editorCommon.=>editor.;model.=>editor.;IMarkerData=>editor.IMarkerData):
+#includeAll(vs/editor/common/languages/languageConfiguration.js):
+#includeAll(vs/editor/common/languages.js;IMarkerData=>editor.IMarkerData;ISingleEditOperation=>editor.ISingleEditOperation;model.=>editor.;ThemeIcon=>editor.ThemeIcon): Token
+#include(vs/editor/common/languages/language.js): ILanguageExtensionPoint
+#includeAll(vs/editor/standalone/common/monarch/monarchTypes.js):
 
 }
 
 declare namespace monaco.worker {
 
-#include(vs/editor/common/model/mirrorTextModel): IMirrorTextModel
-#includeAll(vs/editor/common/services/editorWebWorker;):
+#include(vs/editor/common/model/mirrorTextModel.js): IMirrorTextModel
+#includeAll(vs/editor/common/services/editorWebWorker.js;):
 
 }
 

--- a/build/monaco/monaco.usage.recipe
+++ b/build/monaco/monaco.usage.recipe
@@ -1,12 +1,12 @@
 
 // This file is adding references to various symbols which should not be removed via tree shaking
 
-import { IObservable } from './vs/base/common/observable';
+import { IObservable } from './vs/base/common/observable.js';
 
-import { ServiceIdentifier } from './vs/platform/instantiation/common/instantiation';
-import { start } from './vs/editor/editor.worker.start';
-import { SyncDescriptor0 } from './vs/platform/instantiation/common/descriptors';
-import * as editorAPI from './vs/editor/editor.api';
+import { ServiceIdentifier } from './vs/platform/instantiation/common/instantiation.js';
+import { start } from './vs/editor/editor.worker.start.js';
+import { SyncDescriptor0 } from './vs/platform/instantiation/common/descriptors.js';
+import * as editorAPI from './vs/editor/editor.api.js';
 
 (function () {
 	var a: any;

--- a/package-lock.json
+++ b/package-lock.json
@@ -74,7 +74,7 @@
         "@types/trusted-types": "^1.0.6",
         "@types/vscode-notebook-renderer": "^1.72.0",
         "@types/webpack": "^5.28.5",
-        "@types/wicg-file-system-access": "^2020.9.6",
+        "@types/wicg-file-system-access": "^2023.10.7",
         "@types/windows-foreground-love": "^0.3.0",
         "@types/winreg": "^1.2.30",
         "@types/yauzl": "^2.10.0",
@@ -2197,10 +2197,11 @@
       }
     },
     "node_modules/@types/wicg-file-system-access": {
-      "version": "2020.9.6",
-      "resolved": "https://registry.npmjs.org/@types/wicg-file-system-access/-/wicg-file-system-access-2020.9.6.tgz",
-      "integrity": "sha512-6hogE75Hl2Ov/jgp8ZhDaGmIF/q3J07GtXf8nCJCwKTHq7971po5+DId7grft09zG7plBwpF6ZU0yx9Du4/e1A==",
-      "dev": true
+      "version": "2023.10.7",
+      "resolved": "https://registry.npmjs.org/@types/wicg-file-system-access/-/wicg-file-system-access-2023.10.7.tgz",
+      "integrity": "sha512-g49ijasEJvCd7ifmAY2D0wdEtt1xRjBbA33PJTiv8mKBr7DoMsPeISoJ8oQOTopSRi+FBWPpPW5ouDj2QPKtGA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/windows-foreground-love": {
       "version": "0.3.0",

--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
     "@types/trusted-types": "^1.0.6",
     "@types/vscode-notebook-renderer": "^1.72.0",
     "@types/webpack": "^5.28.5",
-    "@types/wicg-file-system-access": "^2020.9.6",
+    "@types/wicg-file-system-access": "^2023.10.7",
     "@types/windows-foreground-love": "^0.3.0",
     "@types/winreg": "^1.2.30",
     "@types/yauzl": "^2.10.0",

--- a/src/tsconfig.monaco.json
+++ b/src/tsconfig.monaco.json
@@ -7,8 +7,7 @@
 			"trusted-types",
 			"wicg-file-system-access"
 		],
-		"paths": {},
-		"module": "esnext",
+		"module": "nodenext",
 		"moduleResolution": "nodenext",
 		"removeComments": false,
 		"preserveConstEnums": true,

--- a/src/tsconfig.monaco.json
+++ b/src/tsconfig.monaco.json
@@ -9,7 +9,7 @@
 		],
 		"paths": {},
 		"module": "esnext",
-		"moduleResolution": "classic",
+		"moduleResolution": "nodenext",
 		"removeComments": false,
 		"preserveConstEnums": true,
 		"target": "ES2022",

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -5356,7 +5356,7 @@ declare namespace monaco.editor {
 		renderWhitespace: IEditorOption<EditorOption.renderWhitespace, 'all' | 'none' | 'boundary' | 'selection' | 'trailing'>;
 		revealHorizontalRightPadding: IEditorOption<EditorOption.revealHorizontalRightPadding, number>;
 		roundedSelection: IEditorOption<EditorOption.roundedSelection, boolean>;
-		rulers: IEditorOption<EditorOption.rulers, {}>;
+		rulers: IEditorOption<EditorOption.rulers, IRulerOption[]>;
 		scrollbar: IEditorOption<EditorOption.scrollbar, InternalEditorScrollbarOptions>;
 		scrollBeyondLastColumn: IEditorOption<EditorOption.scrollBeyondLastColumn, number>;
 		scrollBeyondLastLine: IEditorOption<EditorOption.scrollBeyondLastLine, boolean>;
@@ -5385,12 +5385,12 @@ declare namespace monaco.editor {
 		tabCompletion: IEditorOption<EditorOption.tabCompletion, 'on' | 'off' | 'onlySnippets'>;
 		tabIndex: IEditorOption<EditorOption.tabIndex, number>;
 		trimWhitespaceOnDelete: IEditorOption<EditorOption.trimWhitespaceOnDelete, boolean>;
-		unicodeHighlight: IEditorOption<EditorOption.unicodeHighlighting, any>;
+		unicodeHighlight: IEditorOption<EditorOption.unicodeHighlighting, Required<Readonly<IUnicodeHighlightOptions>>>;
 		unusualLineTerminators: IEditorOption<EditorOption.unusualLineTerminators, 'off' | 'auto' | 'prompt'>;
 		useShadowDOM: IEditorOption<EditorOption.useShadowDOM, boolean>;
 		useTabStops: IEditorOption<EditorOption.useTabStops, boolean>;
 		wordBreak: IEditorOption<EditorOption.wordBreak, 'normal' | 'keepAll'>;
-		wordSegmenterLocales: IEditorOption<EditorOption.wordSegmenterLocales, {}>;
+		wordSegmenterLocales: IEditorOption<EditorOption.wordSegmenterLocales, string[]>;
 		wordSeparators: IEditorOption<EditorOption.wordSeparators, string>;
 		wordWrap: IEditorOption<EditorOption.wordWrap, 'wordWrapColumn' | 'on' | 'off' | 'bounded'>;
 		wordWrapBreakAfterCharacters: IEditorOption<EditorOption.wordWrapBreakAfterCharacters, string>;

--- a/src/vs/workbench/services/dialogs/browser/fileDialogService.ts
+++ b/src/vs/workbench/services/dialogs/browser/fileDialogService.ts
@@ -142,10 +142,10 @@ export class FileDialogService extends AbstractFileDialogService implements IFil
 	private getFilePickerTypes(filters?: FileFilter[]): FilePickerAcceptType[] | undefined {
 		return filters?.filter(filter => {
 			return !((filter.extensions.length === 1) && ((filter.extensions[0] === '*') || filter.extensions[0] === ''));
-		}).map(filter => {
-			const accept: Record<string, string[]> = {};
+		}).map((filter): FilePickerAcceptType => {
+			const accept: Record<MIMEType, FileExtension[]> = {};
 			const extensions = filter.extensions.filter(ext => (ext.indexOf('-') < 0) && (ext.indexOf('*') < 0) && (ext.indexOf('_') < 0));
-			accept[getMediaOrTextMime(`fileName.${filter.extensions[0]}`) ?? 'text/plain'] = extensions.map(ext => ext.startsWith('.') ? ext : `.${ext}`);
+			accept[(getMediaOrTextMime(`fileName.${filter.extensions[0]}`) ?? 'text/plain') as MIMEType] = extensions.map(ext => ext.startsWith('.') ? ext : `.${ext}`) as FileExtension[];
 			return {
 				description: filter.name,
 				accept


### PR DESCRIPTION
Fixes #270408

Trying to move some of the monaco related checks/tconfigs off of `moduleResolution: classic`. This legacy config is causing a lot of pain while trying to update the trusted-types typings, which is itself blocking picking up the latest dompurify

I initially tried a more scoped change but just could not get it working. So instead I ended up trying to rework our `LanguageServiceHost` and remove some other workarounds we had in code

cc @alexdima @hediet: Could use your help reviewing this. Here's the current diff of `out-editor-src`:

```diff
diff -r out-editor-src-main/inlineEntryPoint.0.ts out-editor-src/inlineEntryPoint.0.ts
2,45c2,45
< import * as m2 from './vs/base/common/cancellation';
< import * as m3 from './vs/base/common/uri';
< import * as m5 from './vs/editor/common/services/editorBaseApi';
< import * as m6 from './vs/base/common/htmlContent';
< import * as m7 from './vs/base/browser/keyboardEvent';
< import * as m8 from './vs/base/browser/mouseEvent';
< import * as m9 from './vs/editor/common/editorCommon';
< import * as m10 from './vs/editor/common/core/position';
< import * as m11 from './vs/editor/common/core/range';
< import * as m12 from './vs/editor/common/core/selection';
< import * as m13 from './vs/editor/common/languages';
< import * as m14 from './vs/editor/standalone/browser/standaloneEditor';
< import * as m15 from './vs/editor/standalone/common/standaloneTheme';
< import * as m16 from './vs/editor/common/languages/supports/tokenization';
< import * as m17 from './vs/editor/standalone/browser/standaloneWebWorker';
< import * as m18 from './vs/editor/standalone/browser/standaloneCodeEditor';
< import * as m19 from './vs/platform/contextkey/common/contextkey';
< import * as m21 from './vs/platform/markers/common/markers';
< import * as m22 from './vs/editor/standalone/browser/colorizer';
< import * as m24 from './vs/base/common/themables';
< import * as m25 from './vs/editor/common/core/editOperation';
< import * as m26 from './vs/editor/common/core/wordHelper';
< import * as m27 from './vs/editor/common/model';
< import * as m28 from './vs/editor/common/diff/legacyLinesDiffComputer';
< import * as m29 from './vs/editor/common/core/2d/dimension';
< import * as m30 from './vs/editor/common/editorCommon';
< import * as m31 from './vs/editor/common/textModelEvents';
< import * as m32 from './vs/editor/common/model/mirrorTextModel';
< import * as m33 from './vs/editor/common/cursorEvents';
< import * as m35 from './vs/editor/common/config/editorOptions';
< import * as m36 from './vs/editor/browser/config/editorConfiguration';
< import * as m37 from './vs/editor/browser/editorBrowser';
< import * as m38 from './vs/editor/common/config/fontInfo';
< import * as m39 from './vs/editor/common/config/editorZoom';
< import * as m40 from './vs/editor/common/textModelEditSource';
< import * as m41 from './vs/base/common/glob';
< import * as m42 from './vs/editor/common/languageSelector';
< import * as m43 from './vs/editor/standalone/browser/standaloneLanguages';
< import * as m44 from './vs/editor/common/languages/languageConfiguration';
< import * as m45 from './vs/editor/common/languages';
< import * as m46 from './vs/editor/common/languages/language';
< import * as m47 from './vs/editor/standalone/common/monarch/monarchTypes';
< import * as m48 from './vs/editor/common/model/mirrorTextModel';
< import * as m49 from './vs/editor/common/services/editorWebWorker';
---
> import * as m2 from './vs/base/common/cancellation.js';
> import * as m3 from './vs/base/common/uri.js';
> import * as m5 from './vs/editor/common/services/editorBaseApi.js';
> import * as m6 from './vs/base/common/htmlContent.js';
> import * as m7 from './vs/base/browser/keyboardEvent.js';
> import * as m8 from './vs/base/browser/mouseEvent.js';
> import * as m9 from './vs/editor/common/editorCommon.js';
> import * as m10 from './vs/editor/common/core/position.js';
> import * as m11 from './vs/editor/common/core/range.js';
> import * as m12 from './vs/editor/common/core/selection.js';
> import * as m13 from './vs/editor/common/languages.js';
> import * as m14 from './vs/editor/standalone/browser/standaloneEditor.js';
> import * as m15 from './vs/editor/standalone/common/standaloneTheme.js';
> import * as m16 from './vs/editor/common/languages/supports/tokenization.js';
> import * as m17 from './vs/editor/standalone/browser/standaloneWebWorker.js';
> import * as m18 from './vs/editor/standalone/browser/standaloneCodeEditor.js';
> import * as m19 from './vs/platform/contextkey/common/contextkey.js';
> import * as m21 from './vs/platform/markers/common/markers.js';
> import * as m22 from './vs/editor/standalone/browser/colorizer.js';
> import * as m24 from './vs/base/common/themables.js';
> import * as m25 from './vs/editor/common/core/editOperation.js';
> import * as m26 from './vs/editor/common/core/wordHelper.js';
> import * as m27 from './vs/editor/common/model.js';
> import * as m28 from './vs/editor/common/diff/legacyLinesDiffComputer.js';
> import * as m29 from './vs/editor/common/core/2d/dimension.js';
> import * as m30 from './vs/editor/common/editorCommon.js';
> import * as m31 from './vs/editor/common/textModelEvents.js';
> import * as m32 from './vs/editor/common/model/mirrorTextModel.js';
> import * as m33 from './vs/editor/common/cursorEvents.js';
> import * as m35 from './vs/editor/common/config/editorOptions.js';
> import * as m36 from './vs/editor/browser/config/editorConfiguration.js';
> import * as m37 from './vs/editor/browser/editorBrowser.js';
> import * as m38 from './vs/editor/common/config/fontInfo.js';
> import * as m39 from './vs/editor/common/config/editorZoom.js';
> import * as m40 from './vs/editor/common/textModelEditSource.js';
> import * as m41 from './vs/base/common/glob.js';
> import * as m42 from './vs/editor/common/languageSelector.js';
> import * as m43 from './vs/editor/standalone/browser/standaloneLanguages.js';
> import * as m44 from './vs/editor/common/languages/languageConfiguration.js';
> import * as m45 from './vs/editor/common/languages.js';
> import * as m46 from './vs/editor/common/languages/language.js';
> import * as m47 from './vs/editor/standalone/common/monarch/monarchTypes.js';
> import * as m48 from './vs/editor/common/model/mirrorTextModel.js';
> import * as m49 from './vs/editor/common/services/editorWebWorker.js';
diff -r out-editor-src-main/inlineEntryPoint.1.ts out-editor-src/inlineEntryPoint.1.ts
4c4
< import { IObservable } from './vs/base/common/observable';
---
> import { IObservable } from './vs/base/common/observable.js';
6,9c6,9
< import { ServiceIdentifier } from './vs/platform/instantiation/common/instantiation';
< import { start } from './vs/editor/editor.worker.start';
< import { SyncDescriptor0 } from './vs/platform/instantiation/common/descriptors';
< import * as editorAPI from './vs/editor/editor.api';
---
> import { ServiceIdentifier } from './vs/platform/instantiation/common/instantiation.js';
> import { start } from './vs/editor/editor.worker.start.js';
> import { SyncDescriptor0 } from './vs/platform/instantiation/common/descriptors.js';
> import * as editorAPI from './vs/editor/editor.api.js';
diff -r out-editor-src-main/tsconfig.json out-editor-src/tsconfig.json
3c3
< 		"module": "esnext",
---
> 		"module": "nodenext",
30c30
< 		"paths": {},
diff -r out-editor-src-main/vs/monaco.d.ts out-editor-src/vs/monaco.d.ts
5359c5359
< 		rulers: IEditorOption<EditorOption.rulers, {}>;
---
> 		rulers: IEditorOption<EditorOption.rulers, IRulerOption[]>;
5388c5388
< 		unicodeHighlight: IEditorOption<EditorOption.unicodeHighlighting, any>;
---
> 		unicodeHighlight: IEditorOption<EditorOption.unicodeHighlighting, Required<Readonly<IUnicodeHighlightOptions>>>;
5393c5393
< 		wordSegmenterLocales: IEditorOption<EditorOption.wordSegmenterLocales, {}>;
---
> 		wordSegmenterLocales: IEditorOption<EditorOption.wordSegmenterLocales, string[]>;
```