### PR TITLE
chat - fix height compute of tree

### DIFF
--- a/.github/CODENOTIFY
+++ b/.github/CODENOTIFY
@@ -92,7 +92,9 @@ src/vs/workbench/electron-browser/** @bpasero
 
 # Workbench Contributions
 src/vs/workbench/contrib/files/** @bpasero
-src/vs/workbench/contrib/chat/browser/chatListRenderer.ts @roblourens
+src/vs/workbench/contrib/chat/browser/chatListRenderer.ts @roblourens @bpasero
+src/vs/workbench/contrib/chat/browser/chatInputPart.ts @bpasero
+src/vs/workbench/contrib/chat/browser/chatWidget.ts @bpasero
 src/vs/workbench/contrib/chat/browser/chatSetup.ts @bpasero
 src/vs/workbench/contrib/chat/browser/chatStatus.ts @bpasero
 src/vs/workbench/contrib/update/browser/releaseNotesEditor.ts @alexr00 @joaomoreno

--- a/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
@@ -1921,7 +1921,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 			followupsHeight: this.followupsContainer.offsetHeight,
 			inputPartEditorHeight: Math.min(this._inputEditor.getContentHeight(), this.inputEditorMaxHeight),
 			inputPartHorizontalPadding: this.options.renderStyle === 'compact' ? 16 : 32,
-			inputPartVerticalPadding: this.options.renderStyle === 'compact' ? 12 : 28,
+			inputPartVerticalPadding: this.options.renderStyle === 'compact' ? 12 : (16 /* entire part */ + 6 /* input container */ + (3 * 4) /* flex gap: todo|edits|input */),
 			attachmentsHeight: this.attachmentsHeight,
 			editorBorder: 2,
 			inputPartHorizontalPaddingInside: 12,

--- a/src/vs/workbench/contrib/chat/browser/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatWidget.ts
@@ -2606,8 +2606,7 @@ export class ChatWidget extends Disposable implements IChatWidget {
 
 		if (this.container.classList.contains('new-welcome-view')) {
 			this.inputPart.layout(layoutHeight, Math.min(width, 650));
-		}
-		else {
+		} else {
 			this.inputPart.layout(layoutHeight, width);
 		}
 
@@ -2622,7 +2621,6 @@ export class ChatWidget extends Disposable implements IChatWidget {
 			this.listContainer.style.setProperty('--chat-current-response-min-height', contentHeight * .75 + 'px');
 		}
 		this.tree.layout(contentHeight, width);
-		this.tree.getHTMLElement().style.height = `${contentHeight}px`;
 
 		// Push the welcome message down so it doesn't change position
 		// when followups, attachments or working set appear

--- a/src/vs/workbench/contrib/chat/browser/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/media/chat.css
@@ -757,7 +757,7 @@ have to be updated for changes to the rules above, or to support more deeply nes
 }
 
 .interactive-session .chat-editing-session {
-	margin-bottom: -4px;
+	margin-bottom: -4px; /* reset the 4px gap of the container for editing sessions */
 	width: 100%;
 	position: relative;
 }


### PR DESCRIPTION
The `gap: 4px` directive for the chat input part needs to be accounted for.

In addition, the tree container itself should not require to get a height applied provided its parent list container has a proper height.

This fixes issues where the blue outline box would be cut off at the bottom.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
