### PR TITLE
Resolve "Error: Invalid problemMatcher reference: $esbuild-watch" using problemMatcher.ts

### DIFF
--- a/src/vs/workbench/contrib/tasks/common/problemMatcher.ts
+++ b/src/vs/workbench/contrib/tasks/common/problemMatcher.ts
@@ -1603,11 +1603,12 @@ class ProblemPatternRegistryImpl implements IProblemPatternRegistry {
 				loop: true
 			}
 		]);
-		// esbuild prints a header like `X [ERROR] Missing import` followed by indented
-		// location lines such as `    src/app.ts:10:7:` (watch mode may append notes).
+		// esbuild prints a header like `X [ERROR] Missing import` (severity glyph may
+		// be ✘, ▲, X, etc.) followed by indented location lines such as
+		// `    src/app.ts:10:7:` (watch mode may append notes).
 		this.add('esbuild', [
 			{
-				regexp: /^[✘▲X] \[([A-Z]+)\] (.+)$/,
+				regexp: /^\S \[([A-Z]+)\] (.+)$/,
 				kind: ProblemLocationKind.Location,
 				severity: 1,
 				message: 2

--- a/src/vs/workbench/contrib/tasks/common/problemMatcher.ts
+++ b/src/vs/workbench/contrib/tasks/common/problemMatcher.ts
@@ -1603,12 +1603,10 @@ class ProblemPatternRegistryImpl implements IProblemPatternRegistry {
 				loop: true
 			}
 		]);
-		// esbuild prints a header like `X [ERROR] Missing import` where the leading
-		// severity glyph varies by platform/TTY (ASCII `X`, Unicode ✘/▲, terminals that
-		// rewrite the character, etc.). Using `\S` instead of enumerating symbols keeps
-		// the matcher resilient to those variations, while the second line captures the
-		// indented location lines such as `    src/app.ts:10:7:` (watch mode may append
-		// notes).
+		// esbuild prints headers like `X [ERROR] Missing import`; the leading glyph varies by
+		// platform (ASCII `X`, Unicode ✘/▲, terminals that rewrite the character, etc.), so
+		// `\S` keeps the matcher resilient. The looped line pattern then captures indented
+		// location lines such as `    src/app.ts:10:7:` (watch mode may append notes).
 		this.add('esbuild', [
 			{
 				regexp: /^\S \[([A-Z]+)\] (.+)$/,
@@ -1617,7 +1615,7 @@ class ProblemPatternRegistryImpl implements IProblemPatternRegistry {
 				message: 2
 			},
 			{
-				regexp: /^\s*(?:(.+?):(\d+):(\d+):?(?:\s.*)?)?$/,
+				regexp: /^\s*(.+?):(\d+)(?::(\d+))?:?(?:\s.*)?$/,
 				file: 1,
 				line: 2,
 				character: 3,

--- a/src/vs/workbench/contrib/tasks/common/problemMatcher.ts
+++ b/src/vs/workbench/contrib/tasks/common/problemMatcher.ts
@@ -1603,9 +1603,6 @@ class ProblemPatternRegistryImpl implements IProblemPatternRegistry {
 				loop: true
 			}
 		]);
-		// esbuild prints a header like `X [ERROR] Missing import` (severity glyph may
-		// be ✘, ▲, X, etc.) followed by indented location lines such as
-		// `    src/app.ts:10:7:` (watch mode may append notes).
 		// esbuild prints a header like `X [ERROR] Missing import` where the leading
 		// severity glyph varies by platform/TTY (ASCII `X`, Unicode ✘/▲, terminals that
 		// rewrite the character, etc.). Using `\S` instead of enumerating symbols keeps

--- a/src/vs/workbench/contrib/tasks/common/problemMatcher.ts
+++ b/src/vs/workbench/contrib/tasks/common/problemMatcher.ts
@@ -1603,6 +1603,8 @@ class ProblemPatternRegistryImpl implements IProblemPatternRegistry {
 				loop: true
 			}
 		]);
+		// esbuild prints a header like `X [ERROR] Missing import` followed by indented
+		// location lines such as `    src/app.ts:10:7:` (watch mode may append notes).
 		this.add('esbuild', [
 			{
 				regexp: /^[✘▲X] \[([A-Z]+)\] (.+)$/,

--- a/src/vs/workbench/contrib/tasks/common/problemMatcher.ts
+++ b/src/vs/workbench/contrib/tasks/common/problemMatcher.ts
@@ -2032,6 +2032,35 @@ class ProblemMatcherRegistryImpl implements IProblemMatcherRegistry {
 			filePrefix: '${workspaceFolder}',
 			pattern: ProblemPatternRegistry.get('go')
 		});
+
+		this.add({
+			name: 'esbuild',
+			label: localize('esbuild', 'esbuild problems'),
+			owner: 'esbuild',
+			source: 'esbuild',
+			applyTo: ApplyToKind.allDocuments,
+			fileLocation: FileLocationKind.Relative,
+			filePrefix: '${workspaceFolder}',
+			pattern: ProblemPatternRegistry.get('esbuild'),
+			severity: Severity.Info
+		});
+
+		this.add({
+			name: 'esbuild-watch',
+			label: localize('esbuild-watch', 'esbuild watch mode problems'),
+			owner: 'esbuild',
+			source: 'esbuild',
+			applyTo: ApplyToKind.allDocuments,
+			fileLocation: FileLocationKind.Relative,
+			filePrefix: '${workspaceFolder}',
+			pattern: ProblemPatternRegistry.get('esbuild'),
+			severity: Severity.Info,
+			watching: {
+				activeOnStart: true,
+				beginsPattern: { regexp: /> \[watch\] build started/ },
+				endsPattern: { regexp: /> \[watch\] build finished/ }
+			}
+		});
 	}
 }
 

--- a/src/vs/workbench/contrib/tasks/common/problemMatcher.ts
+++ b/src/vs/workbench/contrib/tasks/common/problemMatcher.ts
@@ -1603,6 +1603,21 @@ class ProblemPatternRegistryImpl implements IProblemPatternRegistry {
 				loop: true
 			}
 		]);
+		this.add('esbuild', [
+			{
+				regexp: /^[✘▲X] \[([A-Z]+)\] (.+)$/,
+				kind: ProblemLocationKind.Location,
+				severity: 1,
+				message: 2
+			},
+			{
+				regexp: /^\s*(?:(.+?):(\d+):(\d+):?(?:\s.*)?)?$/,
+				file: 1,
+				line: 2,
+				character: 3,
+				loop: true
+			}
+		]);
 		this.add('go', {
 			regexp: /^([^:]*: )?((.:)?[^:]*):(\d+)(:(\d+))?: (.*)$/,
 			kind: ProblemLocationKind.Location,

--- a/src/vs/workbench/contrib/tasks/common/problemMatcher.ts
+++ b/src/vs/workbench/contrib/tasks/common/problemMatcher.ts
@@ -2041,8 +2041,7 @@ class ProblemMatcherRegistryImpl implements IProblemMatcherRegistry {
 			applyTo: ApplyToKind.allDocuments,
 			fileLocation: FileLocationKind.Relative,
 			filePrefix: '${workspaceFolder}',
-			pattern: ProblemPatternRegistry.get('esbuild'),
-			severity: Severity.Info
+			pattern: ProblemPatternRegistry.get('esbuild')
 		});
 
 		this.add({
@@ -2054,7 +2053,6 @@ class ProblemMatcherRegistryImpl implements IProblemMatcherRegistry {
 			fileLocation: FileLocationKind.Relative,
 			filePrefix: '${workspaceFolder}',
 			pattern: ProblemPatternRegistry.get('esbuild'),
-			severity: Severity.Info,
 			watching: {
 				activeOnStart: true,
 				beginsPattern: { regexp: /> \[watch\] build started/ },

--- a/src/vs/workbench/contrib/tasks/common/problemMatcher.ts
+++ b/src/vs/workbench/contrib/tasks/common/problemMatcher.ts
@@ -1606,6 +1606,12 @@ class ProblemPatternRegistryImpl implements IProblemPatternRegistry {
 		// esbuild prints a header like `X [ERROR] Missing import` (severity glyph may
 		// be ✘, ▲, X, etc.) followed by indented location lines such as
 		// `    src/app.ts:10:7:` (watch mode may append notes).
+		// esbuild prints a header like `X [ERROR] Missing import` where the leading
+		// severity glyph varies by platform/TTY (ASCII `X`, Unicode ✘/▲, terminals that
+		// rewrite the character, etc.). Using `\S` instead of enumerating symbols keeps
+		// the matcher resilient to those variations, while the second line captures the
+		// indented location lines such as `    src/app.ts:10:7:` (watch mode may append
+		// notes).
 		this.add('esbuild', [
 			{
 				regexp: /^\S \[([A-Z]+)\] (.+)$/,


### PR DESCRIPTION
**Resolve "Error: Invalid problemMatcher reference: $esbuild-watch" using problemMatcher.ts**

This is a VSCode native solution to the esbuild issue "Error: Invalid problemMatcher reference: $esbuild-watch", over the known workaround to use the per-extension fix in tasks.json as such: https://gist.github.com/Barrixar/d624ebe99c8ec4f4169c8fcd10a66773

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
