### PR TITLE
fix: memory leak in chat welcome

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatWidget.ts
@@ -314,6 +314,8 @@ export class ChatWidget extends Disposable implements IChatWidget {
 
 	private welcomeMessageContainer!: HTMLElement;
 	private readonly welcomePart: MutableDisposable<ChatViewWelcomePart> = this._register(new MutableDisposable());
+	private readonly welcomeContextMenuDisposable: MutableDisposable<IDisposable> = this._register(new MutableDisposable());
+
 	private readonly historyViewStore = this._register(new DisposableStore());
 	private readonly chatTodoListWidget: ChatTodoListWidget;
 	private historyList: WorkbenchList<IChatHistoryListItem> | undefined;
@@ -1066,7 +1068,7 @@ export class ChatWidget extends Disposable implements IChatWidget {
 				dom.append(this.welcomeMessageContainer, this.welcomePart.value.element);
 
 				// Add right-click context menu to the entire welcome container
-				this._register(dom.addDisposableListener(this.welcomeMessageContainer, dom.EventType.CONTEXT_MENU, (e) => {
+				this.welcomeContextMenuDisposable.value = dom.addDisposableListener(this.welcomeMessageContainer, dom.EventType.CONTEXT_MENU, (e) => {
 					e.preventDefault();
 					e.stopPropagation();
 					this.contextMenuService.showContextMenu({
@@ -1078,7 +1080,7 @@ export class ChatWidget extends Disposable implements IChatWidget {
 						getAnchor: () => ({ x: e.clientX, y: e.clientY }),
 						getActionsContext: () => ({})
 					});
-				}));
+				});
 			}
 		}
 


### PR DESCRIPTION
Changes the context menu listener in `chatWidget.ts` to a `MutableDisposable` so that there is at most one context menu listener. 

Without the change it seems that each time opening the chat welcome view, a new context menu event listener is added:

<img width="1837" height="326" alt="context-menu-listener" src="https://github.com/user-attachments/assets/1749366a-f066-4958-8f24-f43663ab9519" />
