### PR TITLE
Remove mode + model exp from core

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
@@ -551,9 +551,6 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 
 	private initSelectedModel() {
 		const persistedSelection = this.storageService.get(this.getSelectedModelStorageKey(), StorageScope.APPLICATION);
-		if (persistedSelection && persistedSelection.startsWith('github.copilot-chat/')) {
-			this.storageService.store(this.getSelectedModelStorageKey(), persistedSelection, StorageScope.APPLICATION, StorageTarget.USER);
-		}
 		const persistedAsDefault = this.storageService.getBoolean(this.getSelectedModelIsDefaultStorageKey(), StorageScope.APPLICATION, persistedSelection === 'copilot/gpt-4.1');
 
 		if (persistedSelection) {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
With https://github.com/microsoft/vscode/pull/270592 we will no longer need to experiment with mode. We will also move default model experiment to the extension so data is modified on the "provider" side and then consumed by core. This better aligns with the fact that all other model experiments will live in the extension (i.e. auto mode, context window, etc). Extension PR: https://github.com/microsoft/vscode-copilot-chat/pull/1301

cc @roblourens, @isidorn, @sbatten