### PR TITLE
Improve count badge CSS padding for better alignment and layout

### DIFF
--- a/src/vs/base/browser/ui/countBadge/countBadge.css
+++ b/src/vs/base/browser/ui/countBadge/countBadge.css
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 .monaco-count-badge {
-	padding: 3px 3px;
+	padding: 3px;
 	border-radius: 11px;
 	font-size: 11px;
 	min-width: 18px;

--- a/src/vs/base/browser/ui/countBadge/countBadge.css
+++ b/src/vs/base/browser/ui/countBadge/countBadge.css
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 .monaco-count-badge {
-	padding: 3px 6px;
+	padding: 3px 3px;
 	border-radius: 11px;
 	font-size: 11px;
 	min-width: 18px;

--- a/src/vs/base/browser/ui/countBadge/countBadge.css
+++ b/src/vs/base/browser/ui/countBadge/countBadge.css
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 .monaco-count-badge {
-	padding: 3px;
+	padding: 3px 5px;
 	border-radius: 11px;
 	font-size: 11px;
 	min-width: 18px;


### PR DESCRIPTION
Adjustments to the padding in the count badge CSS to make a perfect circle with single digits
