### PR TITLE
chore: fix tag versions

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -516,7 +516,8 @@
 				"git": {
 					"name": "nodejs",
 					"repositoryUrl": "https://github.com/nodejs/node",
-					"commitHash": "f8fe6858549f75a4b4e9633abf39dd2038dbf496"
+					"commitHash": "f8fe6858549f75a4b4e9633abf39dd2038dbf496",
+					"tag": "22.19.0"
 				}
 			},
 			"isOnlyProductionDependency": true,
@@ -528,7 +529,8 @@
 				"git": {
 					"name": "electron",
 					"repositoryUrl": "https://github.com/electron/electron",
-					"commitHash": "9a2b4f84be2f4bcc468a63ef93520e60790b8f3c"
+					"commitHash": "9a2b4f84be2f4bcc468a63ef93520e60790b8f3c",
+					"tag": "37.6.0"
 				}
 			},
 			"isOnlyProductionDependency": true,
@@ -587,12 +589,12 @@
 				"git": {
 					"name": "spdlog original",
 					"repositoryUrl": "https://github.com/gabime/spdlog",
-					"commitHash": "4fba14c79f356ae48d6141c561bf9fd7ba33fabd"
+					"commitHash": "7e635fca68d014934b4af8a1cf874f63989352b7"
 				}
 			},
 			"isOnlyProductionDependency": true,
 			"license": "MIT",
-			"version": "0.14.0"
+			"version": "1.12.0"
 		},
 		{
 			"component": {
@@ -634,12 +636,13 @@
 				"git": {
 					"name": "ripgrep",
 					"repositoryUrl": "https://github.com/BurntSushi/ripgrep",
-					"commitHash": "973de50c9ef451da2cfcdfa86f2b2711d8d6ff48"
+					"commitHash": "af6b6c543b224d348a8876f0c06245d9ea7929c5",
+					"tag": "13.0.0"
 				}
 			},
 			"isOnlyProductionDependency": true,
 			"license": "MIT",
-			"version": "0.10.0"
+			"version": "13.0.0"
 		},
 		{
 			"name": "@vscode/win32-app-container-tokens",

--- a/extensions/docker/cgmanifest.json
+++ b/extensions/docker/cgmanifest.json
@@ -6,12 +6,13 @@
 				"git": {
 					"name": "language-docker",
 					"repositoryUrl": "https://github.com/moby/moby",
-					"commitHash": "c2029cb2574647e4bc28ed58486b8e85883eedb9"
+					"commitHash": "c2029cb2574647e4bc28ed58486b8e85883eedb9",
+					"tag": "28.0.0"
 				}
 			},
 			"license": "Apache-2.0",
 			"description": "The file syntaxes/docker.tmLanguage was included from https://github.com/moby/moby/blob/master/contrib/syntax/textmate/Docker.tmbundle/Syntaxes/Dockerfile.tmLanguage.",
-			"version": "0.0.0"
+			"version": "28.0.0"
 		}
 	],
 	"version": 1

--- a/extensions/java/cgmanifest.json
+++ b/extensions/java/cgmanifest.json
@@ -6,7 +6,8 @@
 				"git": {
 					"name": "redhat-developer/vscode-java",
 					"repositoryUrl": "https://github.com/redhat-developer/vscode-java",
-					"commitHash": "f09b712f5d6d6339e765f58c8dfab3f78a378183"
+					"commitHash": "f09b712f5d6d6339e765f58c8dfab3f78a378183",
+					"tag": "1.26.0"
 				}
 			},
 			"license": "MIT",

--- a/extensions/terminal-suggest/cgmanifest.json
+++ b/extensions/terminal-suggest/cgmanifest.json
@@ -88,7 +88,8 @@
 				"type": "git",
 				"git": {
 					"repositoryUrl": "https://github.com/zsh-users/zsh",
-					"commitHash": "435cb1b748ce1f2f5c38edc1d64f4ee2424f9b3a"
+					"commitHash": "435cb1b748ce1f2f5c38edc1d64f4ee2424f9b3a",
+					"tag": "5.9"
 				}
 			},
 			"version": "5.9",


### PR DESCRIPTION
This PR should resolve several CG alerts related to our cgmanifest git dependencies.