### PR TITLE
Work towards getting isolated built-in extension compiles

### DIFF
--- a/build/npm/dirs.js
+++ b/build/npm/dirs.js
@@ -42,6 +42,7 @@ const dirs = [
 	'extensions/search-result',
 	'extensions/simple-browser',
 	'extensions/tunnel-forwarding',
+	'extensions/terminal-suggest',
 	'extensions/typescript-language-features',
 	'extensions/vscode-api-tests',
 	'extensions/vscode-colorize-tests',

--- a/extensions/configuration-editing/tsconfig.json
+++ b/extensions/configuration-editing/tsconfig.json
@@ -4,6 +4,9 @@
 		"outDir": "./out",
 		"types": [
 			"node"
+		],
+		"typeRoots": [
+			"./node_modules/@types"
 		]
 	},
 	"include": [

--- a/extensions/css-language-features/client/tsconfig.json
+++ b/extensions/css-language-features/client/tsconfig.json
@@ -6,6 +6,9 @@
 			"webworker"
 		],
 		"module": "Node16",
+		"typeRoots": [
+			"../node_modules/@types"
+		]
 	},
 	"include": [
 		"src/**/*",

--- a/extensions/css-language-features/server/package-lock.json
+++ b/extensions/css-language-features/server/package-lock.json
@@ -15,7 +15,7 @@
         "vscode-uri": "^3.1.0"
       },
       "devDependencies": {
-        "@types/mocha": "^9.1.1",
+        "@types/mocha": "^10.0.10",
         "@types/node": "22.x"
       },
       "engines": {
@@ -23,10 +23,11 @@
       }
     },
     "node_modules/@types/mocha": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-9.1.1.tgz",
-      "integrity": "sha512-Z61JK7DKDtdKTWwLeElSEBcWGRLY8g95ic5FoQqI9CMx0ns/Ghep3B4DfcEimiKMvtamNVULVNKEsiwV3aQmXw==",
-      "dev": true
+      "version": "10.0.10",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.10.tgz",
+      "integrity": "sha512-xPyYSz1cMPnJQhl0CLMH68j3gprKZaTjG3s5Vi+fDgx+uhG9NOXwbVt52eFS8ECyXhyKcjDLCBEqBExKuiZb7Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "22.13.10",

--- a/extensions/css-language-features/server/package.json
+++ b/extensions/css-language-features/server/package.json
@@ -16,7 +16,7 @@
     "vscode-uri": "^3.1.0"
   },
   "devDependencies": {
-    "@types/mocha": "^9.1.1",
+    "@types/mocha": "^10.0.10",
     "@types/node": "22.x"
   },
   "scripts": {

--- a/extensions/css-language-features/server/tsconfig.json
+++ b/extensions/css-language-features/server/tsconfig.json
@@ -7,6 +7,9 @@
 			"WebWorker"
 		],
 		"module": "Node16",
+		"typeRoots": [
+			"../node_modules/@types"
+		]
 	},
 	"include": [
 		"src/**/*"

--- a/extensions/debug-auto-launch/tsconfig.json
+++ b/extensions/debug-auto-launch/tsconfig.json
@@ -5,6 +5,9 @@
 		"downlevelIteration": true,
 		"types": [
 			"node"
+		],
+		"typeRoots": [
+			"./node_modules/@types"
 		]
 	},
 	"include": [

--- a/extensions/debug-server-ready/tsconfig.json
+++ b/extensions/debug-server-ready/tsconfig.json
@@ -5,6 +5,9 @@
 		"downlevelIteration": true,
 		"types": [
 			"node"
+		],
+		"typeRoots": [
+			"./node_modules/@types"
 		]
 	},
 	"include": [

--- a/extensions/emmet/tsconfig.json
+++ b/extensions/emmet/tsconfig.json
@@ -1,7 +1,11 @@
 {
 	"extends": "../tsconfig.base.json",
 	"compilerOptions": {
-		"outDir": "./out"
+		"outDir": "./out",
+		"typeRoots": [
+			"./node_modules/@types"
+		],
+		"skipLibCheck": true
 	},
 	"exclude": [
 		"node_modules",

--- a/extensions/extension-editing/tsconfig.json
+++ b/extensions/extension-editing/tsconfig.json
@@ -3,7 +3,7 @@
 	"compilerOptions": {
 		"outDir": "./out",
 		"typeRoots": [
-			"node_modules/@types"
+			"./node_modules/@types"
 		]
 	},
 	"include": [

--- a/extensions/git/package-lock.json
+++ b/extensions/git/package-lock.json
@@ -19,7 +19,7 @@
       },
       "devDependencies": {
         "@types/byline": "4.2.31",
-        "@types/mocha": "^9.1.1",
+        "@types/mocha": "^10.0.10",
         "@types/node": "22.x",
         "@types/picomatch": "2.3.0",
         "@types/which": "3.0.0"
@@ -176,10 +176,11 @@
       }
     },
     "node_modules/@types/mocha": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-9.1.1.tgz",
-      "integrity": "sha512-Z61JK7DKDtdKTWwLeElSEBcWGRLY8g95ic5FoQqI9CMx0ns/Ghep3B4DfcEimiKMvtamNVULVNKEsiwV3aQmXw==",
-      "dev": true
+      "version": "10.0.10",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.10.tgz",
+      "integrity": "sha512-xPyYSz1cMPnJQhl0CLMH68j3gprKZaTjG3s5Vi+fDgx+uhG9NOXwbVt52eFS8ECyXhyKcjDLCBEqBExKuiZb7Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "22.13.10",

--- a/extensions/git/package.json
+++ b/extensions/git/package.json
@@ -3732,7 +3732,7 @@
   },
   "devDependencies": {
     "@types/byline": "4.2.31",
-    "@types/mocha": "^9.1.1",
+    "@types/mocha": "^10.0.10",
     "@types/node": "22.x",
     "@types/picomatch": "2.3.0",
     "@types/which": "3.0.0"

--- a/extensions/git/tsconfig.json
+++ b/extensions/git/tsconfig.json
@@ -4,7 +4,8 @@
 		"outDir": "./out",
 		"typeRoots": [
 			"./node_modules/@types"
-		]
+		],
+		"skipLibCheck": true
 	},
 	"include": [
 		"src/**/*",

--- a/extensions/github-authentication/package-lock.json
+++ b/extensions/github-authentication/package-lock.json
@@ -14,7 +14,7 @@
         "vscode-tas-client": "^0.1.84"
       },
       "devDependencies": {
-        "@types/mocha": "^9.1.1",
+        "@types/mocha": "^10.0.10",
         "@types/node": "22.x",
         "@types/node-fetch": "^2.5.7"
       },
@@ -147,10 +147,11 @@
       "license": "MIT"
     },
     "node_modules/@types/mocha": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-9.1.1.tgz",
-      "integrity": "sha512-Z61JK7DKDtdKTWwLeElSEBcWGRLY8g95ic5FoQqI9CMx0ns/Ghep3B4DfcEimiKMvtamNVULVNKEsiwV3aQmXw==",
-      "dev": true
+      "version": "10.0.10",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.10.tgz",
+      "integrity": "sha512-xPyYSz1cMPnJQhl0CLMH68j3gprKZaTjG3s5Vi+fDgx+uhG9NOXwbVt52eFS8ECyXhyKcjDLCBEqBExKuiZb7Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "22.13.10",

--- a/extensions/github-authentication/package.json
+++ b/extensions/github-authentication/package.json
@@ -48,23 +48,24 @@
         ]
       }
     ],
-    "configuration": [{
-      "title": "%config.github-enterprise.title%",
-      "properties": {
-        "github-enterprise.uri": {
-          "type": "string",
-          "markdownDescription": "%config.github-enterprise.uri.description%",
-          "pattern": "^(?:$|(https?)://(?!github\\.com).*)"
-        },
-        "github-authentication.useElectronFetch": {
-          "type": "boolean",
-          "default": true,
-          "scope": "application",
-          "markdownDescription": "%config.github-authentication.useElectronFetch.description%"
+    "configuration": [
+      {
+        "title": "%config.github-enterprise.title%",
+        "properties": {
+          "github-enterprise.uri": {
+            "type": "string",
+            "markdownDescription": "%config.github-enterprise.uri.description%",
+            "pattern": "^(?:$|(https?)://(?!github\\.com).*)"
+          },
+          "github-authentication.useElectronFetch": {
+            "type": "boolean",
+            "default": true,
+            "scope": "application",
+            "markdownDescription": "%config.github-authentication.useElectronFetch.description%"
+          }
         }
       }
-    }
-  ]
+    ]
   },
   "aiKey": "0c6ae279ed8443289764825290e4f9e2-1a736e7c-1324-4338-be46-fc2a58ae4d14-7255",
   "main": "./out/extension.js",
@@ -82,7 +83,7 @@
     "vscode-tas-client": "^0.1.84"
   },
   "devDependencies": {
-    "@types/mocha": "^9.1.1",
+    "@types/mocha": "^10.0.10",
     "@types/node": "22.x",
     "@types/node-fetch": "^2.5.7"
   },

--- a/extensions/grunt/tsconfig.json
+++ b/extensions/grunt/tsconfig.json
@@ -4,6 +4,9 @@
 		"outDir": "./out",
 		"types": [
 			"node"
+		],
+		"typeRoots": [
+			"./node_modules/@types"
 		]
 	},
 	"include": [

--- a/extensions/gulp/tsconfig.json
+++ b/extensions/gulp/tsconfig.json
@@ -4,6 +4,9 @@
 		"outDir": "./out",
 		"types": [
 			"node"
+		],
+		"typeRoots": [
+			"./node_modules/@types"
 		]
 	},
 	"include": [

--- a/extensions/html-language-features/client/tsconfig.json
+++ b/extensions/html-language-features/client/tsconfig.json
@@ -6,6 +6,9 @@
 			"webworker"
 		],
 		"module": "Node16",
+		"typeRoots": [
+			"../node_modules/@types"
+		]
 	},
 	"include": [
 		"src/**/*",

--- a/extensions/html-language-features/server/package-lock.json
+++ b/extensions/html-language-features/server/package-lock.json
@@ -17,7 +17,7 @@
         "vscode-uri": "^3.1.0"
       },
       "devDependencies": {
-        "@types/mocha": "^9.1.1",
+        "@types/mocha": "^10.0.10",
         "@types/node": "22.x"
       },
       "engines": {
@@ -25,10 +25,11 @@
       }
     },
     "node_modules/@types/mocha": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-9.1.1.tgz",
-      "integrity": "sha512-Z61JK7DKDtdKTWwLeElSEBcWGRLY8g95ic5FoQqI9CMx0ns/Ghep3B4DfcEimiKMvtamNVULVNKEsiwV3aQmXw==",
-      "dev": true
+      "version": "10.0.10",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.10.tgz",
+      "integrity": "sha512-xPyYSz1cMPnJQhl0CLMH68j3gprKZaTjG3s5Vi+fDgx+uhG9NOXwbVt52eFS8ECyXhyKcjDLCBEqBExKuiZb7Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "22.13.10",

--- a/extensions/html-language-features/server/package.json
+++ b/extensions/html-language-features/server/package.json
@@ -17,7 +17,7 @@
     "vscode-uri": "^3.1.0"
   },
   "devDependencies": {
-    "@types/mocha": "^9.1.1",
+    "@types/mocha": "^10.0.10",
     "@types/node": "22.x"
   },
   "scripts": {

--- a/extensions/html-language-features/server/tsconfig.json
+++ b/extensions/html-language-features/server/tsconfig.json
@@ -7,6 +7,9 @@
 			"WebWorker"
 		],
 		"module": "Node16",
+		"typeRoots": [
+			"../node_modules/@types"
+		]
 	},
 	"include": [
 		"src/**/*"

--- a/extensions/ipynb/package-lock.json
+++ b/extensions/ipynb/package-lock.json
@@ -14,7 +14,8 @@
       },
       "devDependencies": {
         "@jupyterlab/nbformat": "^3.2.9",
-        "@types/markdown-it": "12.2.3"
+        "@types/markdown-it": "12.2.3",
+        "@types/node": "^22.18.10"
       },
       "engines": {
         "vscode": "^1.57.0"
@@ -65,6 +66,16 @@
       "integrity": "sha512-eC4U9MlIcu2q0KQmXszyn5Akca/0jrQmwDRgpAMJai7qBWq4amIQhZyNau4VYGtCeALvW1/NtjzJJ567aZxfKA==",
       "dev": true
     },
+    "node_modules/@types/node": {
+      "version": "22.18.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.18.10.tgz",
+      "integrity": "sha512-anNG/V/Efn/YZY4pRzbACnKxNKoBng2VTFydVu8RRs5hQjikP8CQfaeAV59VFSCzKNp90mXiVXW2QzV56rwMrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
     "node_modules/detect-indent": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-6.1.0.tgz",
@@ -72,6 +83,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
     }
   }
 }

--- a/extensions/ipynb/package.json
+++ b/extensions/ipynb/package.json
@@ -166,7 +166,8 @@
   },
   "devDependencies": {
     "@jupyterlab/nbformat": "^3.2.9",
-    "@types/markdown-it": "12.2.3"
+    "@types/markdown-it": "12.2.3",
+    "@types/node": "^22.18.10"
   },
   "repository": {
     "type": "git",

--- a/extensions/ipynb/tsconfig.json
+++ b/extensions/ipynb/tsconfig.json
@@ -2,7 +2,13 @@
 	"extends": "../tsconfig.base.json",
 	"compilerOptions": {
 		"outDir": "./out",
-		"lib": ["dom"]
+		"lib": [
+			"ES2024",
+			"DOM"
+		],
+		"typeRoots": [
+			"./node_modules/@types"
+		]
 	},
 	"include": [
 		"src/**/*",

--- a/extensions/jake/tsconfig.json
+++ b/extensions/jake/tsconfig.json
@@ -4,6 +4,9 @@
 		"outDir": "./out",
 		"types": [
 			"node"
+		],
+		"typeRoots": [
+			"./node_modules/@types"
 		]
 	},
 	"include": [

--- a/extensions/json-language-features/client/tsconfig.json
+++ b/extensions/json-language-features/client/tsconfig.json
@@ -6,6 +6,9 @@
 			"webworker"
 		],
 		"module": "Node16",
+		"typeRoots": [
+			"../node_modules/@types"
+		]
 	},
 	"include": [
 		"src/**/*",

--- a/extensions/json-language-features/server/package-lock.json
+++ b/extensions/json-language-features/server/package-lock.json
@@ -20,7 +20,7 @@
         "vscode-json-languageserver": "bin/vscode-json-languageserver"
       },
       "devDependencies": {
-        "@types/mocha": "^9.1.1",
+        "@types/mocha": "^10.0.10",
         "@types/node": "22.x"
       },
       "engines": {
@@ -28,10 +28,11 @@
       }
     },
     "node_modules/@types/mocha": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-9.1.1.tgz",
-      "integrity": "sha512-Z61JK7DKDtdKTWwLeElSEBcWGRLY8g95ic5FoQqI9CMx0ns/Ghep3B4DfcEimiKMvtamNVULVNKEsiwV3aQmXw==",
-      "dev": true
+      "version": "10.0.10",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.10.tgz",
+      "integrity": "sha512-xPyYSz1cMPnJQhl0CLMH68j3gprKZaTjG3s5Vi+fDgx+uhG9NOXwbVt52eFS8ECyXhyKcjDLCBEqBExKuiZb7Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "22.13.10",

--- a/extensions/json-language-features/server/package.json
+++ b/extensions/json-language-features/server/package.json
@@ -20,7 +20,7 @@
     "vscode-uri": "^3.1.0"
   },
   "devDependencies": {
-    "@types/mocha": "^9.1.1",
+    "@types/mocha": "^10.0.10",
     "@types/node": "22.x"
   },
   "scripts": {

--- a/extensions/json-language-features/server/tsconfig.json
+++ b/extensions/json-language-features/server/tsconfig.json
@@ -9,6 +9,9 @@
 			"WebWorker"
 		],
 		"module": "Node16",
+		"typeRoots": [
+			"../node_modules/@types"
+		]
 	},
 	"include": [
 		"src/**/*"

--- a/extensions/markdown-language-features/notebook/tsconfig.json
+++ b/extensions/markdown-language-features/notebook/tsconfig.json
@@ -9,6 +9,11 @@
 			"ES2024",
 			"DOM",
 			"DOM.Iterable"
-		]
+		],
+		"types": [],
+		"typeRoots": [
+			"../node_modules/@types"
+		],
+		"skipLibCheck": true
 	}
 }

--- a/extensions/markdown-language-features/package-lock.json
+++ b/extensions/markdown-language-features/package-lock.json
@@ -24,7 +24,7 @@
       },
       "devDependencies": {
         "@types/dompurify": "^3.0.5",
-        "@types/lodash.throttle": "^4.1.3",
+        "@types/lodash.throttle": "^4.1.9",
         "@types/markdown-it": "12.2.3",
         "@types/picomatch": "^2.3.0",
         "@types/vscode-notebook-renderer": "^1.60.0",
@@ -184,10 +184,11 @@
       "dev": true
     },
     "node_modules/@types/lodash.throttle": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/@types/lodash.throttle/-/lodash.throttle-4.1.3.tgz",
-      "integrity": "sha512-FUm7uMuYRX7dzqmgX02bxdBwC75owUxGA4dDKtFePDLJ6N1ofXxkRX3NhJV8wOrNs/wCjaY6sDVJrD1lbyERoQ==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@types/lodash.throttle/-/lodash.throttle-4.1.9.tgz",
+      "integrity": "sha512-PCPVfpfueguWZQB7pJQK890F2scYKoDUL3iM522AptHWn7d5NQmeS/LTEHIcLr5PaTzl3dK2Z0xSUHHTHwaL5g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/lodash": "*"
       }

--- a/extensions/markdown-language-features/package.json
+++ b/extensions/markdown-language-features/package.json
@@ -781,7 +781,7 @@
   },
   "devDependencies": {
     "@types/dompurify": "^3.0.5",
-    "@types/lodash.throttle": "^4.1.3",
+    "@types/lodash.throttle": "^4.1.9",
     "@types/markdown-it": "12.2.3",
     "@types/picomatch": "^2.3.0",
     "@types/vscode-notebook-renderer": "^1.60.0",

--- a/extensions/markdown-language-features/preview-src/tsconfig.json
+++ b/extensions/markdown-language-features/preview-src/tsconfig.json
@@ -8,7 +8,14 @@
 			"es2024",
 			"DOM",
 			"DOM.Iterable"
-		]
+		],
+		"types": [
+			"vscode-webview"
+		],
+		"typeRoots": [
+			"../node_modules/@types"
+		],
+		"skipLibCheck": true
 	},
 	"typeAcquisition": {
 		"include": [

--- a/extensions/markdown-language-features/tsconfig.json
+++ b/extensions/markdown-language-features/tsconfig.json
@@ -1,7 +1,11 @@
 {
 	"extends": "../tsconfig.base.json",
 	"compilerOptions": {
-		"outDir": "./out"
+		"outDir": "./out",
+		"typeRoots": [
+			"./node_modules/@types"
+		],
+		"skipLibCheck": true
 	},
 	"include": [
 		"src/**/*",

--- a/extensions/markdown-math/notebook/tsconfig.json
+++ b/extensions/markdown-math/notebook/tsconfig.json
@@ -8,6 +8,12 @@
 			"ES2024",
 			"DOM",
 			"DOM.Iterable"
+		],
+		"types": [
+			"node"
+		],
+		"typeRoots": [
+			"../node_modules/@types"
 		]
 	}
 }

--- a/extensions/markdown-math/tsconfig.json
+++ b/extensions/markdown-math/tsconfig.json
@@ -2,7 +2,10 @@
 	"extends": "../tsconfig.base.json",
 	"compilerOptions": {
 		"outDir": "./out",
-		"types": []
+		"types": [],
+		"typeRoots": [
+			"./node_modules/@types"
+		]
 	},
 	"include": [
 		"src/**/*",

--- a/extensions/media-preview/tsconfig.json
+++ b/extensions/media-preview/tsconfig.json
@@ -1,7 +1,10 @@
 {
 	"extends": "../tsconfig.base.json",
 	"compilerOptions": {
-		"outDir": "./out"
+		"outDir": "./out",
+		"typeRoots": [
+			"./node_modules/@types"
+		]
 	},
 	"include": [
 		"src/**/*",

--- a/extensions/merge-conflict/tsconfig.json
+++ b/extensions/merge-conflict/tsconfig.json
@@ -4,6 +4,9 @@
 		"outDir": "./out",
 		"types": [
 			"node"
+		],
+		"typeRoots": [
+			"./node_modules/@types"
 		]
 	},
 	"include": [

--- a/extensions/mermaid-chat-features/chat-webview-src/tsconfig.json
+++ b/extensions/mermaid-chat-features/chat-webview-src/tsconfig.json
@@ -7,6 +7,12 @@
 			"ES2024",
 			"DOM",
 			"DOM.Iterable"
+		],
+		"types": [
+			"node"
+		],
+		"typeRoots": [
+			"../node_modules/@types"
 		]
 	}
 }

--- a/extensions/mermaid-chat-features/package-lock.json
+++ b/extensions/mermaid-chat-features/package-lock.json
@@ -13,8 +13,7 @@
         "mermaid": "^11.11.0"
       },
       "devDependencies": {
-        "@types/jsdom": "^21.1.7",
-        "@types/node": "^24"
+        "@types/node": "^22.18.10"
       },
       "engines": {
         "vscode": "^1.104.0"
@@ -389,34 +388,15 @@
       "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
       "license": "MIT"
     },
-    "node_modules/@types/jsdom": {
-      "version": "21.1.7",
-      "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-21.1.7.tgz",
-      "integrity": "sha512-yOriVnggzrnQ3a9OKOCxaVuSug3w3/SbOj5i7VwXWZEyUNl3bLF9V3MfxGbZKuwqJOQyRfqXyROBB1CoZLFWzA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "@types/tough-cookie": "*",
-        "parse5": "^7.0.0"
-      }
-    },
     "node_modules/@types/node": {
-      "version": "24.5.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.5.0.tgz",
-      "integrity": "sha512-y1dMvuvJspJiPSDZUQ+WMBvF7dpnEqN4x9DDC9ie5Fs/HUZJA3wFp7EhHoVaKX/iI0cRoECV8X2jL8zi0xrHCg==",
+      "version": "22.18.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.18.10.tgz",
+      "integrity": "sha512-anNG/V/Efn/YZY4pRzbACnKxNKoBng2VTFydVu8RRs5hQjikP8CQfaeAV59VFSCzKNp90mXiVXW2QzV56rwMrg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.12.0"
+        "undici-types": "~6.21.0"
       }
-    },
-    "node_modules/@types/tough-cookie": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
-      "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@types/trusted-types": {
       "version": "2.0.7",
@@ -1036,19 +1016,6 @@
         "@types/trusted-types": "^2.0.7"
       }
     },
-    "node_modules/entities": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
-      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
     "node_modules/exsolve": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.7.tgz",
@@ -1235,19 +1202,6 @@
       "integrity": "sha512-ZsEbbZORsyHuO00lY1kV3/t72yp6Ysay6Pd17ZAlNGuGwmWDLCJxFpRs0IzfXfj1o4icJOkUEioexFHzyPurSQ==",
       "license": "MIT"
     },
-    "node_modules/parse5": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
-      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "entities": "^6.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/inikulin/parse5?sponsor=1"
-      }
-    },
     "node_modules/path-data-parser": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/path-data-parser/-/path-data-parser-0.1.0.tgz",
@@ -1361,9 +1315,9 @@
       "license": "MIT"
     },
     "node_modules/undici-types": {
-      "version": "7.12.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.12.0.tgz",
-      "integrity": "sha512-goOacqME2GYyOZZfb5Lgtu+1IDmAlAEu5xnD3+xTzS10hT0vzpf0SPjkXwAw9Jm+4n/mQGDP3LO8CPbYROeBfQ==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/extensions/mermaid-chat-features/package.json
+++ b/extensions/mermaid-chat-features/package.json
@@ -79,8 +79,7 @@
     "watch-web": "npx webpack-cli --config extension-browser.webpack.config --mode none --watch --info-verbosity verbose"
   },
   "devDependencies": {
-    "@types/jsdom": "^21.1.7",
-    "@types/node": "^24"
+    "@types/node": "^22.18.10"
   },
   "dependencies": {
     "dompurify": "^3.2.6",

--- a/extensions/mermaid-chat-features/tsconfig.json
+++ b/extensions/mermaid-chat-features/tsconfig.json
@@ -2,6 +2,12 @@
 	"extends": "../tsconfig.base.json",
 	"compilerOptions": {
 		"outDir": "./out",
+		"types": [
+			"node"
+		],
+		"typeRoots": [
+			"./node_modules/@types"
+		]
 	},
 	"include": [
 		"src/**/*",

--- a/extensions/notebook-renderers/package-lock.json
+++ b/extensions/notebook-renderers/package-lock.json
@@ -10,6 +10,7 @@
 			"license": "MIT",
 			"devDependencies": {
 				"@types/jsdom": "^21.1.0",
+				"@types/node": "^22.18.10",
 				"@types/vscode-notebook-renderer": "^1.60.0",
 				"jsdom": "^21.1.1"
 			},
@@ -38,10 +39,14 @@
 			}
 		},
 		"node_modules/@types/node": {
-			"version": "18.15.3",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.3.tgz",
-			"integrity": "sha512-p6ua9zBxz5otCmbpb5D3U4B5Nanw6Pk3PPyX05xnxbB/fRv71N7CPmORg7uAD5P70T0xmx1pzAx/FUfa5X+3cw==",
-			"dev": true
+			"version": "22.18.10",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.18.10.tgz",
+			"integrity": "sha512-anNG/V/Efn/YZY4pRzbACnKxNKoBng2VTFydVu8RRs5hQjikP8CQfaeAV59VFSCzKNp90mXiVXW2QzV56rwMrg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"undici-types": "~6.21.0"
+			}
 		},
 		"node_modules/@types/tough-cookie": {
 			"version": "4.0.2",
@@ -576,6 +581,13 @@
 			"engines": {
 				"node": ">= 0.8.0"
 			}
+		},
+		"node_modules/undici-types": {
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+			"integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/universalify": {
 			"version": "0.2.0",

--- a/extensions/notebook-renderers/package.json
+++ b/extensions/notebook-renderers/package.json
@@ -5,7 +5,7 @@
 	"publisher": "vscode",
 	"version": "1.0.0",
 	"license": "MIT",
-  "icon": "media/icon.png",
+	"icon": "media/icon.png",
 	"engines": {
 		"vscode": "^1.57.0"
 	},
@@ -46,9 +46,9 @@
 		"watch": "npx gulp compile-watch:notebook-renderers",
 		"build-notebook": "node ./esbuild.mjs"
 	},
-	"dependencies": {},
 	"devDependencies": {
 		"@types/jsdom": "^21.1.0",
+		"@types/node": "^22.18.10",
 		"@types/vscode-notebook-renderer": "^1.60.0",
 		"jsdom": "^21.1.1"
 	},

--- a/extensions/notebook-renderers/src/htmlHelper.ts
+++ b/extensions/notebook-renderers/src/htmlHelper.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 export const ttPolicy = (typeof window !== 'undefined') ?
-	window.trustedTypes?.createPolicy('notebookRenderer', {
-		createHTML: value => value,
-		createScript: value => value,
+	(window as Window & { trustedTypes?: any }).trustedTypes?.createPolicy('notebookRenderer', {
+		createHTML: (value: string) => value,
+		createScript: (value: string) => value,
 	}) : undefined;

--- a/extensions/notebook-renderers/tsconfig.json
+++ b/extensions/notebook-renderers/tsconfig.json
@@ -3,7 +3,14 @@
 	"compilerOptions": {
 		"outDir": "./out",
 		"lib": [
+			"es2024",
 			"dom"
+		],
+		"types": [
+			"node"
+		],
+		"typeRoots": [
+			"./node_modules/@types"
 		]
 	},
 	"include": [

--- a/extensions/npm/tsconfig.json
+++ b/extensions/npm/tsconfig.json
@@ -4,6 +4,9 @@
 		"outDir": "./out",
 		"types": [
 			"node"
+		],
+		"typeRoots": [
+			"./node_modules/@types"
 		]
 	},
 	"include": [

--- a/extensions/php-language-features/tsconfig.json
+++ b/extensions/php-language-features/tsconfig.json
@@ -4,7 +4,10 @@
 		"outDir": "./out",
 		"types": [
 			"node"
-		]
+		],
+		"typeRoots": [
+			"./node_modules/@types"
+		],
 	},
 	"include": [
 		"src/**/*",

--- a/extensions/references-view/tsconfig.json
+++ b/extensions/references-view/tsconfig.json
@@ -2,6 +2,9 @@
 	"extends": "../tsconfig.base.json",
 	"compilerOptions": {
 		"outDir": "./out",
+		"typeRoots": [
+			"./node_modules/@types"
+		]
 	},
 	"include": [
 		"src/**/*",

--- a/extensions/search-result/package-lock.json
+++ b/extensions/search-result/package-lock.json
@@ -8,9 +8,29 @@
       "name": "search-result",
       "version": "1.0.0",
       "license": "MIT",
+      "devDependencies": {
+        "@types/node": "^22.18.10"
+      },
       "engines": {
         "vscode": "^1.39.0"
       }
+    },
+    "node_modules/@types/node": {
+      "version": "22.18.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.18.10.tgz",
+      "integrity": "sha512-anNG/V/Efn/YZY4pRzbACnKxNKoBng2VTFydVu8RRs5hQjikP8CQfaeAV59VFSCzKNp90mXiVXW2QzV56rwMrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
     }
   }
 }

--- a/extensions/search-result/package.json
+++ b/extensions/search-result/package.json
@@ -55,5 +55,8 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/microsoft/vscode.git"
+  },
+  "devDependencies": {
+    "@types/node": "^22.18.10"
   }
 }

--- a/extensions/search-result/tsconfig.json
+++ b/extensions/search-result/tsconfig.json
@@ -2,6 +2,9 @@
 	"extends": "../tsconfig.base.json",
 	"compilerOptions": {
 		"outDir": "./out",
+		"typeRoots": [
+			"./node_modules/@types"
+		]
 	},
 	"include": [
 		"src/**/*",

--- a/extensions/simple-browser/preview-src/tsconfig.json
+++ b/extensions/simple-browser/preview-src/tsconfig.json
@@ -7,6 +7,9 @@
 			"ES2024",
 			"DOM",
 			"DOM.Iterable"
+		],
+		"typeRoots": [
+			"../node_modules/@types"
 		]
 	}
 }

--- a/extensions/simple-browser/tsconfig.json
+++ b/extensions/simple-browser/tsconfig.json
@@ -2,7 +2,10 @@
 	"extends": "../tsconfig.base.json",
 	"compilerOptions": {
 		"outDir": "./out",
-		"types": []
+		"types": [],
+		"typeRoots": [
+			"./node_modules/@types"
+		]
 	},
 	"include": [
 		"src/**/*",

--- a/extensions/terminal-suggest/.npmrc
+++ b/extensions/terminal-suggest/.npmrc
@@ -1,0 +1,2 @@
+legacy-peer-deps="true"
+timeout=180000

--- a/extensions/terminal-suggest/package-lock.json
+++ b/extensions/terminal-suggest/package-lock.json
@@ -8,9 +8,29 @@
       "name": "terminal-suggest",
       "version": "1.0.1",
       "license": "MIT",
+      "devDependencies": {
+        "@types/node": "^22.18.10"
+      },
       "engines": {
         "vscode": "^1.95.0"
       }
+    },
+    "node_modules/@types/node": {
+      "version": "22.18.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.18.10.tgz",
+      "integrity": "sha512-anNG/V/Efn/YZY4pRzbACnKxNKoBng2VTFydVu8RRs5hQjikP8CQfaeAV59VFSCzKNp90mXiVXW2QzV56rwMrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
     }
   }
 }

--- a/extensions/terminal-suggest/package.json
+++ b/extensions/terminal-suggest/package.json
@@ -47,5 +47,8 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/microsoft/vscode.git"
+  },
+  "devDependencies": {
+    "@types/node": "^22.18.10"
   }
 }

--- a/extensions/terminal-suggest/tsconfig.json
+++ b/extensions/terminal-suggest/tsconfig.json
@@ -8,10 +8,7 @@
 		"esModuleInterop": true,
 		// Needed to suppress warnings in upstream completions
 		"noImplicitReturns": false,
-		"noUnusedParameters": false,
-		"typeRoots": [
-			"./node_modules/@types"
-		]
+		"noUnusedParameters": false
 	},
 	"include": [
 		"src/**/*",

--- a/extensions/terminal-suggest/tsconfig.json
+++ b/extensions/terminal-suggest/tsconfig.json
@@ -2,6 +2,9 @@
 	"extends": "../tsconfig.base.json",
 	"compilerOptions": {
 		"outDir": "./out",
+		"types": [
+			"node"
+		],
 		"typeRoots": [
 			"./node_modules/@types"
 		],

--- a/extensions/terminal-suggest/tsconfig.json
+++ b/extensions/terminal-suggest/tsconfig.json
@@ -2,13 +2,16 @@
 	"extends": "../tsconfig.base.json",
 	"compilerOptions": {
 		"outDir": "./out",
-		"esModuleInterop": true,
-		"types": [
-			"node"
+		"typeRoots": [
+			"./node_modules/@types"
 		],
+		"esModuleInterop": true,
 		// Needed to suppress warnings in upstream completions
 		"noImplicitReturns": false,
-		"noUnusedParameters": false
+		"noUnusedParameters": false,
+		"typeRoots": [
+			"./node_modules/@types"
+		]
 	},
 	"include": [
 		"src/**/*",

--- a/extensions/tunnel-forwarding/tsconfig.json
+++ b/extensions/tunnel-forwarding/tsconfig.json
@@ -2,6 +2,9 @@
 	"extends": "../tsconfig.base.json",
 	"compilerOptions": {
 		"outDir": "./out",
+		"typeRoots": [
+			"./node_modules/@types"
+		],
 		"downlevelIteration": true,
 		"types": [
 			"node"

--- a/extensions/typescript-language-features/tsconfig.json
+++ b/extensions/typescript-language-features/tsconfig.json
@@ -2,6 +2,9 @@
 	"extends": "../tsconfig.base.json",
 	"compilerOptions": {
 		"outDir": "./out",
+		"typeRoots": [
+			"./node_modules/@types"
+		],
 		"esModuleInterop": true,
 		"types": [
 			"node"

--- a/extensions/vscode-api-tests/package-lock.json
+++ b/extensions/vscode-api-tests/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "MIT",
       "devDependencies": {
-        "@types/mocha": "^9.1.1",
+        "@types/mocha": "^10.0.10",
         "@types/node": "22.x",
         "@types/node-forge": "^1.3.11",
         "node-forge": "^1.3.1",
@@ -20,10 +20,11 @@
       }
     },
     "node_modules/@types/mocha": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-9.1.1.tgz",
-      "integrity": "sha512-Z61JK7DKDtdKTWwLeElSEBcWGRLY8g95ic5FoQqI9CMx0ns/Ghep3B4DfcEimiKMvtamNVULVNKEsiwV3aQmXw==",
-      "dev": true
+      "version": "10.0.10",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.10.tgz",
+      "integrity": "sha512-xPyYSz1cMPnJQhl0CLMH68j3gprKZaTjG3s5Vi+fDgx+uhG9NOXwbVt52eFS8ECyXhyKcjDLCBEqBExKuiZb7Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "22.13.10",

--- a/extensions/vscode-api-tests/package.json
+++ b/extensions/vscode-api-tests/package.json
@@ -80,7 +80,9 @@
           }
         ],
         "modes": [
-          "agent", "ask", "edit"
+          "agent",
+          "ask",
+          "edit"
         ]
       },
       {
@@ -91,15 +93,15 @@
       }
     ],
     "languageModelTools": [
-			{
-				"name": "requires_confirmation_tool",
-				"toolReferenceName": "requires_confirmation_tool",
-				"displayName": "Requires Confirmation Tool",
-				"modelDescription": "A noop tool to trigger confirmation.",
-				"canBeReferencedInPrompt": true,
-				"icon": "$(files)",
-				"inputSchema": {}
-			}
+      {
+        "name": "requires_confirmation_tool",
+        "toolReferenceName": "requires_confirmation_tool",
+        "displayName": "Requires Confirmation Tool",
+        "modelDescription": "A noop tool to trigger confirmation.",
+        "canBeReferencedInPrompt": true,
+        "icon": "$(files)",
+        "inputSchema": {}
+      }
     ],
     "configuration": {
       "type": "object",
@@ -266,7 +268,7 @@
     "vscode:prepublish": "node ../../node_modules/gulp/bin/gulp.js --gulpfile ../../build/gulpfile.extensions.js compile-extension:vscode-api-tests ./tsconfig.json"
   },
   "devDependencies": {
-    "@types/mocha": "^9.1.1",
+    "@types/mocha": "^10.0.10",
     "@types/node": "22.x",
     "@types/node-forge": "^1.3.11",
     "node-forge": "^1.3.1",

--- a/extensions/vscode-api-tests/tsconfig.json
+++ b/extensions/vscode-api-tests/tsconfig.json
@@ -2,9 +2,10 @@
 	"extends": "../tsconfig.base.json",
 	"compilerOptions": {
 		"outDir": "./out",
-		"types": [
-			"node"
-		]
+		"typeRoots": [
+			"./node_modules/@types"
+		],
+		"skipLibCheck": true
 	},
 	"include": [
 		"src/**/*",

--- a/extensions/vscode-colorize-perf-tests/tsconfig.json
+++ b/extensions/vscode-colorize-perf-tests/tsconfig.json
@@ -2,6 +2,9 @@
 	"extends": "../tsconfig.base.json",
 	"compilerOptions": {
 		"outDir": "./out",
+		"typeRoots": [
+			"./node_modules/@types"
+		],
 		"types": [
 			"node"
 		]

--- a/extensions/vscode-colorize-tests/tsconfig.json
+++ b/extensions/vscode-colorize-tests/tsconfig.json
@@ -2,6 +2,9 @@
 	"extends": "../tsconfig.base.json",
 	"compilerOptions": {
 		"outDir": "./out",
+		"typeRoots": [
+			"./node_modules/@types"
+		],
 		"types": [
 			"node"
 		]

--- a/extensions/vscode-test-resolver/tsconfig.json
+++ b/extensions/vscode-test-resolver/tsconfig.json
@@ -2,6 +2,9 @@
 	"extends": "../tsconfig.base.json",
 	"compilerOptions": {
 		"outDir": "./out",
+		"typeRoots": [
+			"./node_modules/@types"
+		],
 		"types": [
 			"node"
 		],


### PR DESCRIPTION
For #271167

This makes it so our built-in extensions can mostly be built using `tsc` on the command line:

```sh
cd extensions/markdown-language-features
npx tsc -p tsconfig.json -noEmit
```

Previously the extensions were picking up a lot of typing info from the root `node_modules` which meant they weren't truly independent

I had to add a few skipLibChecks for tricky issues with published `@types`. Will revisit these later

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
