### PR TITLE
Pick up latest `@types/trusted-types`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -71,7 +71,7 @@
         "@types/node": "22.x",
         "@types/sinon": "^10.0.2",
         "@types/sinon-test": "^2.4.2",
-        "@types/trusted-types": "^1.0.6",
+        "@types/trusted-types": "^2.0.7",
         "@types/vscode-notebook-renderer": "^1.72.0",
         "@types/webpack": "^5.28.5",
         "@types/wicg-file-system-access": "^2023.10.7",
@@ -2155,10 +2155,11 @@
       "dev": true
     },
     "node_modules/@types/trusted-types": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-1.0.6.tgz",
-      "integrity": "sha512-230RC8sFeHoT6sSUlRO6a8cAnclO06eeiq1QDfiv2FGCLWFvvERWgwIQD4FWqD9A69BN7Lzee4OXwoMVnnsWDw==",
-      "dev": true
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/tunnel": {
       "version": "0.0.3",

--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
     "@types/node": "22.x",
     "@types/sinon": "^10.0.2",
     "@types/sinon-test": "^2.4.2",
-    "@types/trusted-types": "^1.0.6",
+    "@types/trusted-types": "^2.0.7",
     "@types/vscode-notebook-renderer": "^1.72.0",
     "@types/webpack": "^5.28.5",
     "@types/wicg-file-system-access": "^2023.10.7",

--- a/src/typings/vscode-globals-ttp.d.ts
+++ b/src/typings/vscode-globals-ttp.d.ts
@@ -7,10 +7,9 @@
 
 declare global {
 
-	var _VSCODE_WEB_PACKAGE_TTP: Pick<TrustedTypePolicy<{
-		createScriptURL(value: string): string;
-	}>, 'name' | 'createScriptURL'> | undefined;
+	var _VSCODE_WEB_PACKAGE_TTP: Pick<TrustedTypePolicy, 'name' | 'createScriptURL'> | undefined;
 }
 
 // fake export to make global work
-export { }
+export { };
+

--- a/src/vs/amdX.ts
+++ b/src/vs/amdX.ts
@@ -38,9 +38,7 @@ class AMDModuleImporter {
 
 	private readonly _defineCalls: DefineCall[] = [];
 	private _state = AMDModuleImporterState.Uninitialized;
-	private _amdPolicy: Pick<TrustedTypePolicy<{
-		createScriptURL(value: string): string;
-	}>, 'name' | 'createScriptURL'> | undefined;
+	private _amdPolicy: Pick<TrustedTypePolicy, 'name' | 'createScriptURL'> | undefined;
 
 	constructor() { }
 

--- a/src/vs/base/browser/trustedTypes.ts
+++ b/src/vs/base/browser/trustedTypes.ts
@@ -5,16 +5,18 @@
 
 import { onUnexpectedError } from '../common/errors.js';
 
+type TrustedTypePolicyOptions = import('trusted-types/lib/index.d.ts').TrustedTypePolicyOptions;
+
 export function createTrustedTypesPolicy<Options extends TrustedTypePolicyOptions>(
 	policyName: string,
 	policyOptions?: Options,
-): undefined | Pick<TrustedTypePolicy<Options>, 'name' | Extract<keyof Options, keyof TrustedTypePolicyOptions>> {
+): undefined | Pick<TrustedTypePolicy, 'name' | Extract<keyof Options, keyof TrustedTypePolicyOptions>> {
 
 	interface IMonacoEnvironment {
 		createTrustedTypesPolicy<Options extends TrustedTypePolicyOptions>(
 			policyName: string,
 			policyOptions?: Options,
-		): undefined | Pick<TrustedTypePolicy<Options>, 'name' | Extract<keyof Options, keyof TrustedTypePolicyOptions>>;
+		): undefined | Pick<TrustedTypePolicy, 'name' | Extract<keyof Options, keyof TrustedTypePolicyOptions>>;
 	}
 	// eslint-disable-next-line local/code-no-any-casts
 	const monacoEnvironment: IMonacoEnvironment | undefined = (globalThis as any).MonacoEnvironment;

--- a/src/vs/workbench/workbench.web.main.ts
+++ b/src/vs/workbench/workbench.web.main.ts
@@ -73,7 +73,7 @@
 	}
 	globalThis._VSCODE_FILE_ROOT = baseUrl;
 
-	const trustedTypesPolicy: Pick<TrustedTypePolicy<{ createScriptURL(value: string): string }>, 'name' | 'createScriptURL'> | undefined = require.getConfig().trustedTypesPolicy;
+	const trustedTypesPolicy: Pick<TrustedTypePolicy, 'name' | 'createScriptURL'> | undefined = require.getConfig().trustedTypesPolicy;
 	if (trustedTypesPolicy) {
 		globalThis._VSCODE_WEB_PACKAGE_TTP = trustedTypesPolicy;
 	}


### PR DESCRIPTION
Should unblock #270041

With `@types/trusted-types` version 2, they split the typings up in to two files:

- The top level `index.d.ts` contains the global types
- A new `lib/index.d.ts` contains the generic version of these types

This has made updating much more challenging than expected (see #270830)

Could use some help confirming that these changes look somewhat sane
