### PR TITLE
Remove `downlevelIteration` compile option in extensions

### DIFF
--- a/extensions/debug-auto-launch/tsconfig.json
+++ b/extensions/debug-auto-launch/tsconfig.json
@@ -2,7 +2,6 @@
 	"extends": "../tsconfig.base.json",
 	"compilerOptions": {
 		"outDir": "./out",
-		"downlevelIteration": true,
 		"types": [
 			"node"
 		]

--- a/extensions/debug-server-ready/tsconfig.json
+++ b/extensions/debug-server-ready/tsconfig.json
@@ -2,7 +2,6 @@
 	"extends": "../tsconfig.base.json",
 	"compilerOptions": {
 		"outDir": "./out",
-		"downlevelIteration": true,
 		"types": [
 			"node"
 		]

--- a/extensions/tunnel-forwarding/tsconfig.json
+++ b/extensions/tunnel-forwarding/tsconfig.json
@@ -2,7 +2,6 @@
 	"extends": "../tsconfig.base.json",
 	"compilerOptions": {
 		"outDir": "./out",
-		"downlevelIteration": true,
 		"types": [
 			"node"
 		]


### PR DESCRIPTION
We're targeting modern es versions so I don't think we need this anymore

