### PR TITLE
Fix output for microsoft-authentication

### DIFF
--- a/extensions/microsoft-authentication/tsconfig.json
+++ b/extensions/microsoft-authentication/tsconfig.json
@@ -1,14 +1,10 @@
 {
 	"extends": "../tsconfig.base.json",
 	"compilerOptions": {
-		"baseUrl": ".",
+		"outDir": "./out",
 		"noFallthroughCasesInSwitch": true,
 		"noUnusedLocals": false,
-		"outDir": "dist",
-		"resolveJsonModule": true,
-		"rootDir": "src",
 		"skipLibCheck": true,
-		"sourceMap": true,
 		"lib": [
 			"WebWorker"
 		]


### PR DESCRIPTION
For #271167

All out of extensions normally target `out`. `dist` is for webpack
