### PR TITLE
Proper fix for missing node types in web build

### DIFF
--- a/extensions/markdown-language-features/package-lock.json
+++ b/extensions/markdown-language-features/package-lock.json
@@ -26,6 +26,7 @@
         "@types/dompurify": "^3.0.5",
         "@types/lodash.throttle": "^4.1.9",
         "@types/markdown-it": "12.2.3",
+        "@types/node": "22.x",
         "@types/picomatch": "^2.3.0",
         "@types/vscode-notebook-renderer": "^1.60.0",
         "@types/vscode-webview": "^1.57.0",
@@ -208,6 +209,16 @@
       "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
       "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
       "dev": true
+    },
+    "node_modules/@types/node": {
+      "version": "22.18.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.18.10.tgz",
+      "integrity": "sha512-anNG/V/Efn/YZY4pRzbACnKxNKoBng2VTFydVu8RRs5hQjikP8CQfaeAV59VFSCzKNp90mXiVXW2QzV56rwMrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
     },
     "node_modules/@types/picomatch": {
       "version": "2.3.0",
@@ -576,6 +587,13 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
       "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA=="
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/vscode-jsonrpc": {
       "version": "8.0.2",

--- a/extensions/markdown-language-features/package.json
+++ b/extensions/markdown-language-features/package.json
@@ -783,6 +783,7 @@
     "@types/dompurify": "^3.0.5",
     "@types/lodash.throttle": "^4.1.9",
     "@types/markdown-it": "12.2.3",
+    "@types/node": "22.x",
     "@types/picomatch": "^2.3.0",
     "@types/vscode-notebook-renderer": "^1.60.0",
     "@types/vscode-webview": "^1.57.0",

--- a/extensions/markdown-language-features/src/languageFeatures/linkUpdater.ts
+++ b/extensions/markdown-language-features/src/languageFeatures/linkUpdater.ts
@@ -3,10 +3,10 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import * as path from 'path';
 import * as picomatch from 'picomatch';
 import * as vscode from 'vscode';
 import { TextDocumentEdit } from 'vscode-languageclient';
+import { Utils } from 'vscode-uri';
 import { MdLanguageClient } from '../client/client';
 import { Delayer } from '../util/async';
 import { noopToken } from '../util/cancellation';
@@ -137,7 +137,7 @@ class UpdateLinksOnFileRenameHandler extends Disposable {
 
 		const choice = await vscode.window.showInformationMessage(
 			newResources.length === 1
-				? vscode.l10n.t("Update Markdown links for '{0}'?", path.basename(newResources[0].fsPath))
+				? vscode.l10n.t("Update Markdown links for '{0}'?", Utils.basename(newResources[0]))
 				: this._getConfirmMessage(vscode.l10n.t("Update Markdown links for the following {0} files?", newResources.length), newResources), {
 			modal: true,
 		}, rejectItem, acceptItem, alwaysItem, neverItem);
@@ -197,7 +197,7 @@ class UpdateLinksOnFileRenameHandler extends Disposable {
 
 		const paths = [start];
 		paths.push('');
-		paths.push(...resourcesToConfirm.slice(0, MAX_CONFIRM_FILES).map(r => path.basename(r.fsPath)));
+		paths.push(...resourcesToConfirm.slice(0, MAX_CONFIRM_FILES).map(r => Utils.basename(r)));
 
 		if (resourcesToConfirm.length > MAX_CONFIRM_FILES) {
 			if (resourcesToConfirm.length - MAX_CONFIRM_FILES === 1) {

--- a/extensions/markdown-language-features/tsconfig.browser.json
+++ b/extensions/markdown-language-features/tsconfig.browser.json
@@ -1,8 +1,6 @@
 {
 	"extends": "./tsconfig.json",
-	"compilerOptions": {
-		"types": []
-	},
+	"compilerOptions": {},
 	"exclude": [
 		"./src/test/**"
 	]

--- a/extensions/markdown-language-features/tsconfig.json
+++ b/extensions/markdown-language-features/tsconfig.json
@@ -2,6 +2,9 @@
 	"extends": "../tsconfig.base.json",
 	"compilerOptions": {
 		"outDir": "./out",
+		"typeRoots": [
+			"./node_modules/@types"
+		],
 		"skipLibCheck": true
 	},
 	"include": [


### PR DESCRIPTION
Using `path` in web for these cases is ok (but not ideal) because webpack shims it out

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
