### PR TITLE
Respect editor auto-closing and surrounding settings in chat input

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
@@ -519,8 +519,8 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 
 		this._register(this.languageModelsService.onDidChangeLanguageModels(() => {
 			// We've changed models and the current one is no longer available. Select a new one
-			const selectedModel = this._currentLanguageModel ? this.languageModelsService.lookupLanguageModel(this._currentLanguageModel.identifier) : undefined;
-			if (this._currentLanguageModel && (!selectedModel || !selectedModel.isUserSelectable)) {
+			const selectedModel = this._currentLanguageModel ? this.getModels().find(m => m.identifier === this._currentLanguageModel?.identifier) : undefined;
+			if (this._currentLanguageModel && (!selectedModel || !selectedModel.metadata.isUserSelectable)) {
 				this.setCurrentLanguageModelToDefault();
 			}
 		}));

--- a/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
@@ -498,6 +498,15 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 			if (e.affectsConfiguration('editor.wordSegmenterLocales')) {
 				newOptions.wordSegmenterLocales = this.configurationService.getValue<string | string[]>('editor.wordSegmenterLocales');
 			}
+			if (e.affectsConfiguration('editor.autoClosingBrackets')) {
+				newOptions.autoClosingBrackets = this.configurationService.getValue('editor.autoClosingBrackets');
+			}
+			if (e.affectsConfiguration('editor.autoClosingQuotes')) {
+				newOptions.autoClosingQuotes = this.configurationService.getValue('editor.autoClosingQuotes');
+			}
+			if (e.affectsConfiguration('editor.autoSurround')) {
+				newOptions.autoSurround = this.configurationService.getValue('editor.autoSurround');
+			}
 
 			this.inputEditor.updateOptions(newOptions);
 		}));
@@ -510,8 +519,8 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 
 		this._register(this.languageModelsService.onDidChangeLanguageModels(() => {
 			// We've changed models and the current one is no longer available. Select a new one
-			const selectedModel = this._currentLanguageModel ? this.getModels().find(m => m.identifier === this._currentLanguageModel?.identifier) : undefined;
-			if (this._currentLanguageModel && (!selectedModel || !selectedModel.metadata.isUserSelectable)) {
+			const selectedModel = this._currentLanguageModel ? this.languageModelsService.lookupLanguageModel(this._currentLanguageModel.identifier) : undefined;
+			if (this._currentLanguageModel && (!selectedModel || !selectedModel.isUserSelectable)) {
 				this.setCurrentLanguageModelToDefault();
 			}
 		}));
@@ -1171,6 +1180,10 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 		options.cursorWidth = 1;
 		options.wrappingStrategy = 'advanced';
 		options.bracketPairColorization = { enabled: false };
+		// Respect user's editor settings for auto-closing and auto-surrounding behavior
+		options.autoClosingBrackets = this.configurationService.getValue('editor.autoClosingBrackets');
+		options.autoClosingQuotes = this.configurationService.getValue('editor.autoClosingQuotes');
+		options.autoSurround = this.configurationService.getValue('editor.autoSurround');
 		options.suggest = {
 			showIcons: true,
 			showSnippets: false,


### PR DESCRIPTION
Incorporate user preferences for auto-closing brackets, quotes, and surrounding behavior in the chat input component. This change enhances the user experience by aligning the chat input functionality with the editor's configuration settings.

Fixes https://github.com/microsoft/vscode/issues/252297