### PR TITLE
Hookup semantic tokens range refresh notification to the viewport contribution

### DIFF
--- a/src/vs/editor/contrib/semanticTokens/browser/viewportSemanticTokens.ts
+++ b/src/vs/editor/contrib/semanticTokens/browser/viewportSemanticTokens.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { CancelablePromise, createCancelablePromise, RunOnceScheduler } from '../../../../base/common/async.js';
-import { Disposable } from '../../../../base/common/lifecycle.js';
+import { Disposable, dispose, IDisposable } from '../../../../base/common/lifecycle.js';
 import { ICodeEditor } from '../../../browser/editorBrowser.js';
 import { EditorContributionInstantiation, registerEditorContribution } from '../../../browser/editorExtensions.js';
 import { Range } from '../../../common/core/range.js';
@@ -35,6 +35,7 @@ export class ViewportSemanticTokensContribution extends Disposable implements IE
 	private readonly _debounceInformation: IFeatureDebounceInformation;
 	private readonly _tokenizeViewport: RunOnceScheduler;
 	private _outstandingRequests: CancelablePromise<any>[];
+	private _rangeProvidersChangeListeners: IDisposable[];
 
 	constructor(
 		editor: ICodeEditor,
@@ -50,15 +51,33 @@ export class ViewportSemanticTokensContribution extends Disposable implements IE
 		this._debounceInformation = languageFeatureDebounceService.for(this._provider, 'DocumentRangeSemanticTokens', { min: 100, max: 500 });
 		this._tokenizeViewport = this._register(new RunOnceScheduler(() => this._tokenizeViewportNow(), 100));
 		this._outstandingRequests = [];
+		this._rangeProvidersChangeListeners = [];
 		const scheduleTokenizeViewport = () => {
 			if (this._editor.hasModel()) {
 				this._tokenizeViewport.schedule(this._debounceInformation.get(this._editor.getModel()));
 			}
 		};
+		const bindRangeProvidersChangeListeners = () => {
+			dispose(this._rangeProvidersChangeListeners);
+			this._rangeProvidersChangeListeners = [];
+			if (this._editor.hasModel()) {
+				const model = this._editor.getModel();
+				for (const provider of this._provider.all(model)) {
+					if (typeof provider.onDidChange === 'function') {
+						this._rangeProvidersChangeListeners.push(provider.onDidChange(() => {
+							this._cancelAll();
+							scheduleTokenizeViewport();
+						}));
+					}
+				}
+			}
+		};
+
 		this._register(this._editor.onDidScrollChange(() => {
 			scheduleTokenizeViewport();
 		}));
 		this._register(this._editor.onDidChangeModel(() => {
+			bindRangeProvidersChangeListeners();
 			this._cancelAll();
 			scheduleTokenizeViewport();
 		}));
@@ -66,7 +85,10 @@ export class ViewportSemanticTokensContribution extends Disposable implements IE
 			this._cancelAll();
 			scheduleTokenizeViewport();
 		}));
+
+		bindRangeProvidersChangeListeners();
 		this._register(this._provider.onDidChange(() => {
+			bindRangeProvidersChangeListeners();
 			this._cancelAll();
 			scheduleTokenizeViewport();
 		}));
@@ -81,6 +103,12 @@ export class ViewportSemanticTokensContribution extends Disposable implements IE
 			scheduleTokenizeViewport();
 		}));
 		scheduleTokenizeViewport();
+	}
+
+	public override dispose(): void {
+		dispose(this._rangeProvidersChangeListeners);
+		this._rangeProvidersChangeListeners = [];
+		super.dispose();
 	}
 
 	private _cancelAll(): void {

--- a/src/vs/editor/contrib/semanticTokens/test/browser/viewportSemanticTokens.test.ts
+++ b/src/vs/editor/contrib/semanticTokens/test/browser/viewportSemanticTokens.test.ts
@@ -1,0 +1,125 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { Barrier, timeout } from '../../../../../base/common/async.js';
+import { CancellationToken } from '../../../../../base/common/cancellation.js';
+import { Emitter } from '../../../../../base/common/event.js';
+import { DisposableStore } from '../../../../../base/common/lifecycle.js';
+import { mock } from '../../../../../base/test/common/mock.js';
+import { runWithFakedTimers } from '../../../../../base/test/common/timeTravelScheduler.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { Range } from '../../../../common/core/range.js';
+import { DocumentRangeSemanticTokensProvider, SemanticTokens, SemanticTokensLegend } from '../../../../common/languages.js';
+import { ILanguageService } from '../../../../common/languages/language.js';
+import { ITextModel } from '../../../../common/model.js';
+import { ILanguageFeatureDebounceService, LanguageFeatureDebounceService } from '../../../../common/services/languageFeatureDebounce.js';
+import { ILanguageFeaturesService } from '../../../../common/services/languageFeatures.js';
+import { LanguageFeaturesService } from '../../../../common/services/languageFeaturesService.js';
+import { LanguageService } from '../../../../common/services/languageService.js';
+import { ISemanticTokensStylingService } from '../../../../common/services/semanticTokensStyling.js';
+import { SemanticTokensStylingService } from '../../../../common/services/semanticTokensStylingService.js';
+import { ViewportSemanticTokensContribution } from '../../browser/viewportSemanticTokens.js';
+import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
+import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
+import { IEnvironmentService } from '../../../../../platform/environment/common/environment.js';
+import { NullLogService } from '../../../../../platform/log/common/log.js';
+import { ColorScheme } from '../../../../../platform/theme/common/theme.js';
+import { IThemeService } from '../../../../../platform/theme/common/themeService.js';
+import { TestColorTheme, TestThemeService } from '../../../../../platform/theme/test/common/testThemeService.js';
+import { createTextModel } from '../../../../test/common/testTextModel.js';
+import { createTestCodeEditor } from '../../../../test/browser/testCodeEditor.js';
+import { ServiceCollection } from '../../../../../platform/instantiation/common/serviceCollection.js';
+import { TestInstantiationService } from '../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
+
+suite('ViewportSemanticTokens', () => {
+
+	const disposables = new DisposableStore();
+	let languageService: ILanguageService;
+	let languageFeaturesService: ILanguageFeaturesService;
+	let serviceCollection: ServiceCollection;
+
+	setup(() => {
+		const configService = new TestConfigurationService({ editor: { semanticHighlighting: true } });
+		const themeService = new TestThemeService();
+		themeService.setTheme(new TestColorTheme({}, ColorScheme.DARK, true));
+		languageFeaturesService = new LanguageFeaturesService();
+		languageService = disposables.add(new LanguageService(false));
+
+		const logService = new NullLogService();
+		const semanticTokensStylingService = new SemanticTokensStylingService(themeService, logService, languageService);
+		const envService = new class extends mock<IEnvironmentService>() {
+			override isBuilt: boolean = true;
+			override isExtensionDevelopment: boolean = false;
+		};
+		const languageFeatureDebounceService = new LanguageFeatureDebounceService(logService, envService);
+
+		serviceCollection = new ServiceCollection(
+			[ILanguageFeaturesService, languageFeaturesService],
+			[ILanguageFeatureDebounceService, languageFeatureDebounceService],
+			[ISemanticTokensStylingService, semanticTokensStylingService],
+			[IThemeService, themeService],
+			[IConfigurationService, configService]
+		);
+	});
+
+	teardown(() => {
+		disposables.clear();
+	});
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('DocumentRangeSemanticTokens provider onDidChange event should trigger refresh', async () => {
+		await runWithFakedTimers({}, async () => {
+
+			disposables.add(languageService.registerLanguage({ id: 'testMode' }));
+
+			const inFirstCall = new Barrier();
+			const inRefreshCall = new Barrier();
+
+			const emitter = new Emitter<void>();
+			let requestCount = 0;
+			disposables.add(languageFeaturesService.documentRangeSemanticTokensProvider.register('testMode', new class implements DocumentRangeSemanticTokensProvider {
+				onDidChange = emitter.event;
+				getLegend(): SemanticTokensLegend {
+					return { tokenTypes: ['class'], tokenModifiers: [] };
+				}
+				async provideDocumentRangeSemanticTokens(model: ITextModel, range: Range, token: CancellationToken): Promise<SemanticTokens | null> {
+					requestCount++;
+					if (requestCount === 1) {
+						inFirstCall.open();
+					} else if (requestCount === 2) {
+						inRefreshCall.open();
+					}
+					return {
+						data: new Uint32Array([0, 1, 1, 1, 1])
+					};
+				}
+			}));
+
+			const textModel = disposables.add(createTextModel('Hello world', 'testMode'));
+			const editor = disposables.add(createTestCodeEditor(textModel, { serviceCollection }));
+			const instantiationService = new TestInstantiationService(serviceCollection);
+			disposables.add(instantiationService.createInstance(ViewportSemanticTokensContribution, editor));
+
+			textModel.onBeforeAttached();
+
+			await inFirstCall.wait();
+
+			assert.strictEqual(requestCount, 1, 'Initial request should have been made');
+
+			// Make sure no other requests are made for a little while
+			await timeout(1000);
+			assert.strictEqual(requestCount, 1, 'No additional requests should have been made');
+
+			// Fire the provider's onDidChange event
+			emitter.fire();
+
+			await inRefreshCall.wait();
+
+			assert.strictEqual(requestCount, 2, 'Provider onDidChange should trigger a refresh of viewport semantic tokens');
+		});
+	});
+});


### PR DESCRIPTION
Resolves https://github.com/microsoft/vscode/issues/268140

The semantic tokens range refresh event was introduced recently in https://github.com/microsoft/vscode/pull/268148 however it looks like it was not hooked up to the viewportSemanticTokens part, and so didn't actually refresh.  Took a stab at fixing it and adding a test for it.  Used the document provider as inspiration here - https://github.com/microsoft/vscode/blob/main/src/vs/editor/contrib/semanticTokens/browser/documentSemanticTokens.ts#L153

Also tested with https://github.com/dibarbet/vscode-extension-samples/commit/59cd7511724615303ec8d5ccc9330f217abec695 to make sure it works


https://github.com/user-attachments/assets/7915b75c-cd61-4bda-af83-da45636b17c3


