### PR TITLE
chat - tweaks to accept/undo buttons

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/media/chat.css
@@ -883,13 +883,10 @@ have to be updated for changes to the rules above, or to support more deeply nes
 }
 
 .interactive-session .chat-editing-session .monaco-button {
-	height: 17px;
+	height: 18px;
 	width: fit-content;
 	padding: 2px 6px;
 	font-size: 11px;
-	background-color: var(--vscode-button-background);
-	border: 1px solid var(--vscode-button-border);
-	color: var(--vscode-button-foreground);
 }
 
 .interactive-session .chat-editing-session .chat-editing-session-toolbar-actions .monaco-button:hover {


### PR DESCRIPTION
Do not explicitly set foreground color for buttons, otherwise hover effect will not apply the color due to a less specific CSS rule.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
