### PR TITLE
Resolve issue where first input gets ignored on new conpty with a ding sound

### DIFF
--- a/src/vs/platform/terminal/node/ptyService.ts
+++ b/src/vs/platform/terminal/node/ptyService.ts
@@ -238,18 +238,14 @@ export class PtyService extends Disposable implements IPtyService {
 	private async _reviveTerminalProcess(workspaceId: string, terminal: ISerializedTerminalState): Promise<void> {
 		const restoreMessage = localize('terminal-history-restored', "History restored");
 
-		// Conpty v1.22+ uses passthrough and doesn't reprint the buffer often, this means that when
-		// the terminal is revived, the cursor would be at the bottom of the buffer then when
-		// PSReadLine requests `GetConsoleCursorInfo` it will be handled by conpty itself by design.
-		// This causes the cursor to move to the top into the replayed terminal contents. To avoid
-		// this, the post restore message will print new lines to get a clear viewport and put the
-		// cursor back at to top left.
-		let postRestoreMessage = '';
-		if (isWindows) {
-			const lastReplayEvent = terminal.replayEvent.events.length > 0 ? terminal.replayEvent.events.at(-1) : undefined;
-			if (lastReplayEvent) {
-				postRestoreMessage += '\r\n'.repeat(lastReplayEvent.rows - 1) + `\x1b[H`;
-			}
+		// For Windows ConPTY, we must NOT pass the replay data as initialText because that enables
+		// conptyInheritCursor which tries to parse cursor positions from the serialized xterm data.
+		// This causes cursor misalignment because the escape sequences were from a different session.
+		// Instead, we let ConPTY start with a completely clean slate and handle everything via replay.
+		let initialText: string | undefined;
+		if (!isWindows) {
+			// Non-Windows: Preserve legacy behavior of passing replay as initialText (safe on pty implementations)
+			initialText = terminal.replayEvent.events[0].data + formatMessageForTerminal(restoreMessage, { loudFormatting: true });
 		}
 
 		// TODO: We may at some point want to show date information in a hover via a custom sequence:
@@ -262,7 +258,7 @@ export class PtyService extends Disposable implements IPtyService {
 				color: terminal.processDetails.color,
 				icon: terminal.processDetails.icon,
 				name: terminal.processDetails.titleSource === TitleEventSource.Api ? terminal.processDetails.title : undefined,
-				initialText: terminal.replayEvent.events[0].data + formatMessageForTerminal(restoreMessage, { loudFormatting: true }) + postRestoreMessage
+				initialText
 			},
 			terminal.processDetails.cwd,
 			terminal.replayEvent.events[0].cols,
@@ -314,7 +310,26 @@ export class PtyService extends Disposable implements IPtyService {
 			executableEnv,
 			options
 		};
-		const persistentProcess = new PersistentTerminalProcess(id, process, workspaceId, workspaceName, shouldPersist, cols, rows, processLaunchOptions, unicodeVersion, this._reconnectConstants, this._logService, isReviving && typeof shellLaunchConfig.initialText === 'string' ? shellLaunchConfig.initialText : undefined, rawReviveBuffer, shellLaunchConfig.icon, shellLaunchConfig.color, shellLaunchConfig.name, shellLaunchConfig.fixedDimensions);
+		const persistentProcess = new PersistentTerminalProcess(
+			id,
+			process,
+			workspaceId,
+			workspaceName,
+			shouldPersist,
+			cols,
+			rows,
+			processLaunchOptions,
+			unicodeVersion,
+			this._reconnectConstants,
+			this._logService,
+			!!isReviving,
+			isReviving ? rawReviveBuffer : undefined,
+			rawReviveBuffer,
+			shellLaunchConfig.icon,
+			shellLaunchConfig.color,
+			shellLaunchConfig.name,
+			shellLaunchConfig.fixedDimensions
+		);
 		process.onProcessExit(event => {
 			for (const contrib of this._contributions) {
 				contrib.handleProcessDispose(id);
@@ -737,6 +752,7 @@ class PersistentTerminalProcess extends Disposable {
 		public unicodeVersion: '6' | '11',
 		reconnectConstants: IReconnectConstants,
 		private readonly _logService: ILogService,
+		wasRevived: boolean,
 		reviveBuffer: string | undefined,
 		rawReviveBuffer: string | undefined,
 		private _icon?: TerminalIcon,
@@ -746,7 +762,7 @@ class PersistentTerminalProcess extends Disposable {
 	) {
 		super();
 		this._interactionState = new MutationLogger(`Persistent process "${this._persistentProcessId}" interaction state`, InteractionState.None, this._logService);
-		this._wasRevived = reviveBuffer !== undefined;
+		this._wasRevived = wasRevived;
 		this._serializer = new XtermSerializer(
 			cols,
 			rows,
@@ -823,21 +839,24 @@ class PersistentTerminalProcess extends Disposable {
 
 	async start(): Promise<ITerminalLaunchError | ITerminalLaunchResult | undefined> {
 		if (!this._isStarted) {
+			// On Windows when reviving, perform replay BEFORE starting the actual pty so that
+			// the viewport and scrollback are prepared (blank viewport, history in scrollback)
+			// before the shell prompt is emitted. This avoids the race where the shell prompt
+			// appears in the middle of replay manipulation causing cursor/beep issues.
+			if (this._wasRevived && isWindows) {
+				await this._preStartReplayWindows();
+			}
+
 			const result = await this._terminalProcess.start();
 			if (result && 'message' in result) {
-				// it's a terminal launch error
-				return result;
+				return result; // launch error
 			}
 			this._isStarted = true;
 
-			// If the process was revived, trigger a replay on first start. An alternative approach
-			// could be to start it on the pty host before attaching but this fails on Windows as
-			// conpty's inherit cursor option which is required, ends up sending DSR CPR which
-			// causes conhost to hang when no response is received from the terminal (which wouldn't
-			// be attached yet). https://github.com/microsoft/terminal/issues/11213
-			if (this._wasRevived) {
+			if (this._wasRevived && !isWindows) {
+				// Non-Windows: do normal replay after start
 				this.triggerReplay();
-			} else {
+			} else if (!this._wasRevived) {
 				this._onPersistentProcessReady.fire();
 			}
 			return result;
@@ -912,9 +931,52 @@ class PersistentTerminalProcess extends Disposable {
 			dataLength += e.data.length;
 		}
 		this._logService.info(`Persistent process "${this._persistentProcessId}": Replaying ${dataLength} chars and ${ev.events.length} size events`);
+
+		// Windows runtime replay path (only if process already started). For Windows we now
+		// prefer pre-start replay (_preStartReplayWindows). If we still end up here (eg. non-prestart
+		// scenario), fall back to normal replay without viewport tricks to avoid corruption.
+		if (!(isWindows && this._wasRevived)) {
+			this._logService.info(`Persistent process "${this._persistentProcessId}": Standard replay path`);
+		} else {
+			this._logService.info(`Persistent process "${this._persistentProcessId}": Skipping in-start Windows replay (already handled pre-start)`);
+			return; // Avoid double replay on Windows revival
+		}
+
 		this._onProcessReplay.fire(ev);
 		this._terminalProcess.clearUnacknowledgedChars();
 		this._onPersistentProcessReady.fire();
+	}
+
+	private async _preStartReplayWindows(): Promise<void> {
+		// Generate replay event BEFORE starting underlying pty so shell prompt comes after
+		// we prepared the viewport.
+		const ev = await this._serializer.generateReplayEvent();
+		if (!ev.events.length) {
+			return;
+		}
+		const event = ev.events[0];
+		const rows = event.rows;
+		// 1. Remove any trailing partial line (prompt) so shell will re-render it fresh
+		const lastNl = event.data.lastIndexOf('\n');
+		if (lastNl !== -1 && lastNl < event.data.length - 1) {
+			// Keep inclusive of newline so buffer ends at line boundary
+			event.data = event.data.slice(0, lastNl + 1);
+		}
+		// 2. Append History restored banner at the END of the historical scrollback so that
+		//    when the user scrolls up it's the most recent (bottom) scrollback line, not the oldest.
+		const restoreMessage = localize('terminal-history-restored', "History restored");
+		if (!event.data.endsWith('\n')) {
+			event.data += '\r\n';
+		}
+		event.data += formatMessageForTerminal(restoreMessage, { loudFormatting: true }) + '\r\n';
+		// 3. Append push-to-scrollback newlines and move cursor to home so viewport blank
+		//    Newlines push current viewport lines above, cursor ends bottom, then move to top.
+		//    Use rows+1 to ensure full scroll.
+		const push = '\r\n'.repeat(rows + 1) + '\x1b[H';
+		event.data += push;
+		this._logService.info(`Persistent process "${this._persistentProcessId}": Pre-start Windows replay prepared (rows=${rows})`);
+		this._onProcessReplay.fire(ev);
+		this._terminalProcess.clearUnacknowledgedChars();
 	}
 
 	sendCommandResult(reqId: number, isError: boolean, serializedPayload: any): void {

--- a/src/vs/platform/terminal/node/ptyService.ts
+++ b/src/vs/platform/terminal/node/ptyService.ts
@@ -849,14 +849,15 @@ class PersistentTerminalProcess extends Disposable {
 
 			const result = await this._terminalProcess.start();
 			if (result && 'message' in result) {
-				return result; // launch error
+				// it's a terminal launch error
+				return result;
 			}
 			this._isStarted = true;
 
 			if (this._wasRevived && !isWindows) {
 				// Non-Windows: do normal replay after start
 				this.triggerReplay();
-			} else if (!this._wasRevived) {
+			} else {
 				this._onPersistentProcessReady.fire();
 			}
 			return result;

--- a/src/vs/workbench/contrib/terminal/browser/terminal.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminal.ts
@@ -30,7 +30,6 @@ import { ACTIVE_GROUP_TYPE, AUX_WINDOW_GROUP_TYPE, SIDE_GROUP_TYPE } from '../..
 import type { ICurrentPartialCommand } from '../../../../platform/terminal/common/capabilities/commandDetection/terminalCommand.js';
 import type { IXtermCore } from './xterm-private.js';
 import type { IMenu } from '../../../../platform/actions/common/actions.js';
-import type { Barrier } from '../../../../base/common/async.js';
 import type { IProgressState } from '@xterm/addon-progress';
 import type { IEditorOptions } from '../../../../platform/editor/common/editor.js';
 import type { TerminalEditorInput } from './terminalEditorInput.js';
@@ -1111,12 +1110,6 @@ export interface ITerminalInstance extends IBaseTerminalInstance {
 	 * @returns Whether the context menu should be suppressed.
 	 */
 	handleMouseEvent(event: MouseEvent, contextMenu: IMenu): Promise<{ cancelContextMenu: boolean } | void>;
-
-	/**
-	 * Pause input events until the provided barrier is resolved.
-	 * @param barrier The barrier to wait for until input events can continue.
-	 */
-	pauseInputEvents(barrier: Barrier): void;
 }
 
 export const enum XtermTerminalConstants {

--- a/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
@@ -646,7 +646,7 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 		return this._contributions.get(id) as T | null;
 	}
 
-	private async _sendDataToProcess(data: string): Promise<void> {
+	private async _handleOnData(data: string): Promise<void> {
 		await this._processManager.write(data);
 		this._onDidInputData.fire(data);
 	}
@@ -845,7 +845,7 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 
 		this._register(this._processManager.onProcessData(e => this._onProcessData(e)));
 		this._register(xterm.raw.onData(async data => {
-			await this._sendDataToProcess(data);
+			await this._handleOnData(data);
 		}));
 		this._register(xterm.raw.onBinary(data => this._processManager.processBinary(data)));
 		// Init winpty compat and link handler after process creation as they rely on the
@@ -857,7 +857,7 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 			if (processTraits?.windowsPty?.backend === 'conpty') {
 				this._register(xterm.raw.parser.registerCsiHandler({ final: 'c' }, params => {
 					if (params.length === 0 || params.length === 1 && params[0] === 0) {
-						this._sendDataToProcess('\x1b[?61;4c');
+						this._handleOnData('\x1b[?61;4c');
 						return true;
 					}
 					return false;

--- a/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
@@ -857,7 +857,9 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 			if (processTraits?.windowsPty?.backend === 'conpty') {
 				this._register(xterm.raw.parser.registerCsiHandler({ final: 'c' }, params => {
 					if (params.length === 0 || params.length === 1 && params[0] === 0) {
-						this._processManager.write('\x1b[?61;4c');
+						queueMicrotask(() => {
+							this._processManager.write('\x1b[?61;4c');
+						});
 						return true;
 					}
 					return false;

--- a/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
@@ -855,9 +855,9 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 			// a long delay in conpty 1.22+ where it waits for the response.
 			// Reference: https://github.com/microsoft/terminal/blob/3760caed97fa9140a40777a8fbc1c95785e6d2ab/src/terminal/adapter/adaptDispatch.cpp#L1471-L1495
 			if (processTraits?.windowsPty?.backend === 'conpty') {
-				this._register(xterm.raw.parser.registerCsiHandler({ final: 'c' }, async params => {
+				this._register(xterm.raw.parser.registerCsiHandler({ final: 'c' }, params => {
 					if (params.length === 0 || params.length === 1 && params[0] === 0) {
-						await this._sendDataToProcess('\x1b[?61;4c');
+						this._sendDataToProcess('\x1b[?61;4c');
 						return true;
 					}
 					return false;

--- a/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
@@ -844,7 +844,6 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 
 		this._register(this._processManager.onProcessData(e => this._onProcessData(e)));
 		this._register(xterm.raw.onData(async data => {
-			await this._pauseInputEventBarrier?.wait();
 			await this._processManager.write(data);
 			this._onDidInputData.fire(data);
 		}));

--- a/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
@@ -10,7 +10,7 @@ import * as dom from '../../../../base/browser/dom.js';
 import { StandardKeyboardEvent } from '../../../../base/browser/keyboardEvent.js';
 import { Orientation } from '../../../../base/browser/ui/sash/sash.js';
 import { DomScrollableElement } from '../../../../base/browser/ui/scrollbar/scrollableElement.js';
-import { AutoOpenBarrier, Barrier, Promises, disposableTimeout, timeout } from '../../../../base/common/async.js';
+import { AutoOpenBarrier, Promises, disposableTimeout, timeout } from '../../../../base/common/async.js';
 import { Codicon } from '../../../../base/common/codicons.js';
 import { debounce } from '../../../../base/common/decorators.js';
 import { BugIndicatingError, onUnexpectedError } from '../../../../base/common/errors.js';

--- a/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
@@ -200,10 +200,6 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 	private _lineDataEventAddon: LineDataEventAddon | undefined;
 	private readonly _scopedContextKeyService: IContextKeyService;
 	private _resizeDebouncer?: TerminalResizeDebouncer;
-	private _pauseInputEventBarrier: Barrier | undefined;
-	pauseInputEvents(barrier: Barrier): void {
-		this._pauseInputEventBarrier = barrier;
-	}
 
 	readonly capabilities = this._register(new TerminalCapabilityStoreMultiplexer());
 	readonly statusList: ITerminalStatusList;


### PR DESCRIPTION
Resolves: https://github.com/microsoft/vscode/issues/243584

Updated summary:
There were two request I think in `\e[6n\e[c`.
We were sending `\e[?61;4c\e[2;1R`, which is wrong.
The one ending with 4c, was supposed to come later.

Because the order was wrong, ConPTY "ate" the first input from user thinking that must've been the response to their cursor position request, and made a ding sound because it was invalid.
