### PR TITLE
Enforce single quote strings in tests too

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -326,7 +326,6 @@ export default tseslint.config(
 			'local/code-must-use-super-dispose': 'off',
 			'local/code-no-test-only': 'error',
 			'local/code-no-test-async-suite': 'warn',
-			'local/code-no-unexternalized-strings': 'off',
 			'local/code-must-use-result': [
 				'warn',
 				[

--- a/test/smoke/src/areas/multiroot/multiroot.test.ts
+++ b/test/smoke/src/areas/multiroot/multiroot.test.ts
@@ -32,7 +32,7 @@ function createWorkspaceFile(workspacePath: string): string {
 			'npm.fetchOnlinePackageInfo': false,
 			'npm.autoDetect': 'off',
 			'workbench.editor.languageDetection': false,
-			"workbench.localHistory.enabled": false
+			'workbench.localHistory.enabled': false
 		}
 	};
 

--- a/test/smoke/src/areas/task/task-quick-pick.test.ts
+++ b/test/smoke/src/areas/task/task-quick-pick.test.ts
@@ -24,9 +24,9 @@ export function setup(options?: { skipSuite: boolean }) {
 		});
 
 		describe('Tasks: Run Task', () => {
-			const label = "name";
-			const type = "shell";
-			const command = "echo 'test'";
+			const label = 'name';
+			const type = 'shell';
+			const command = `echo 'test'`;
 			it('hide property - true', async () => {
 				await task.configureTask({ type, command, label, hide: true });
 				await task.assertTasks(label, [], 'run');
@@ -40,26 +40,26 @@ export function setup(options?: { skipSuite: boolean }) {
 				await task.assertTasks(label, [{ label }], 'run');
 			});
 			(options?.skipSuite ? it.skip : it.skip)('icon - icon only', async () => {
-				const config = { label, type, command, icon: { id: "lightbulb" } };
+				const config = { label, type, command, icon: { id: 'lightbulb' } };
 				await task.configureTask(config);
 				await task.assertTasks(label, [config], 'run');
 			});
 			(options?.skipSuite ? it.skip : it.skip)('icon - color only', async () => {
-				const config = { label, type, command, icon: { color: "terminal.ansiRed" } };
+				const config = { label, type, command, icon: { color: 'terminal.ansiRed' } };
 				await task.configureTask(config);
-				await task.assertTasks(label, [{ label, type, command, icon: { color: "Red" } }], 'run');
+				await task.assertTasks(label, [{ label, type, command, icon: { color: 'Red' } }], 'run');
 			});
 			(options?.skipSuite ? it.skip : it.skip)('icon - icon & color', async () => {
-				const config = { label, type, command, icon: { id: "lightbulb", color: "terminal.ansiRed" } };
+				const config = { label, type, command, icon: { id: 'lightbulb', color: 'terminal.ansiRed' } };
 				await task.configureTask(config);
-				await task.assertTasks(label, [{ label, type, command, icon: { id: "lightbulb", color: "Red" } }], 'run');
+				await task.assertTasks(label, [{ label, type, command, icon: { id: 'lightbulb', color: 'Red' } }], 'run');
 			});
 		});
 		//TODO: why won't this command run
 		describe.skip('Tasks: Configure Task', () => {
-			const label = "name";
-			const type = "shell";
-			const command = "echo 'test'";
+			const label = 'name';
+			const type = 'shell';
+			const command = `echo 'test'`;
 			describe('hide', () => {
 				it('true should still show the task', async () => {
 					await task.configureTask({ type, command, label, hide: true });

--- a/test/smoke/src/areas/terminal/terminal-stickyScroll.test.ts
+++ b/test/smoke/src/areas/terminal/terminal-stickyScroll.test.ts
@@ -71,13 +71,13 @@ export function setup(options?: { skipSuite: boolean }) {
 			await beforeEachSetup();
 
 			// Standard multi-line prompt
-			await checkCommandAndOutput('sticky scroll 1', 0, "Multi-line\\r\\nPrompt> ", 2);
+			await checkCommandAndOutput('sticky scroll 1', 0, 'Multi-line\\r\\nPrompt> ', 2);
 
 			// New line before prompt
-			await checkCommandAndOutput('sticky scroll 2', 0, "\\r\\nMulti-line Prompt> ", 1);
+			await checkCommandAndOutput('sticky scroll 2', 0, '\\r\\nMulti-line Prompt> ', 1);
 
 			// New line before multi-line prompt
-			await checkCommandAndOutput('sticky scroll 3', 0, "\\r\\nMulti-line\\r\\nPrompt> ", 2);
+			await checkCommandAndOutput('sticky scroll 3', 0, '\\r\\nMulti-line\\r\\nPrompt> ', 2);
 		});
 	});
 }


### PR DESCRIPTION
Fixes #271473

Final small pass of fixes and removes the eslint exception for test files. Now test files have the same string requirements as our main source

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
