### PR TITLE
rm `isActive` check

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/monitoring/outputMonitor.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/monitoring/outputMonitor.ts
@@ -313,11 +313,6 @@ export class OutputMonitor extends Disposable implements IOutputMonitor {
 				const recentlyIdle = consecutiveIdleEvents >= PollingConsts.MinIdleEvents;
 				const isActive = execution.isActive ? await execution.isActive() : undefined;
 				this._logService.trace(`OutputMonitor: waitForIdle check: waited=${waited}ms, recentlyIdle=${recentlyIdle}, isActive=${isActive}`);
-				// Keep polling if still active with no recent data
-				if (recentlyIdle && isActive === true) {
-					consecutiveIdleEvents = 0;
-					continue;
-				}
 
 				if (recentlyIdle || isActive === false) {
 					this._state = OutputMonitorState.Idle;


### PR DESCRIPTION
We want to use `isBusy` instead as `isActive` is always `true` https://github.com/microsoft/vscode/pull/271549/files, but this prevents hanging for now.