### PR TITLE
watcher - track `associatedResources` in events

### DIFF
--- a/src/vs/platform/files/common/files.ts
+++ b/src/vs/platform/files/common/files.ts
@@ -960,7 +960,7 @@ export interface IFileChange {
 	/**
 	 * The type of change that occurred to the file.
 	 */
-	type: FileChangeType;
+	readonly type: FileChangeType;
 
 	/**
 	 * The unified resource identifier of the file that changed.
@@ -1007,6 +1007,12 @@ export class FileChangesEvent {
 					break;
 				case FileChangeType.DELETED:
 					this.rawDeleted.push(change.resource);
+					if (change.associatedResources?.length) {
+						if (!this.rawAssociatedDeleted) {
+							this.rawAssociatedDeleted = [];
+						}
+						this.rawAssociatedDeleted.push(...change.associatedResources);
+					}
 					break;
 			}
 
@@ -1179,6 +1185,14 @@ export class FileChangesEvent {
 	* - correctly handles `FileChangeType.DELETED` events
 	*/
 	readonly rawDeleted: URI[] = [];
+
+	/**
+	 * @deprecated use the `contains` or `affects` method to efficiently find
+	* out if the event relates to a given resource. these methods ensure:
+	* - that there is no expensive lookup needed (by using a `TernarySearchTree`)
+	* - correctly handles `FileChangeType.DELETED` events
+	 */
+	readonly rawAssociatedDeleted: URI[] | undefined;
 }
 
 export function isParent(path: string, candidate: string, ignoreCase?: boolean): boolean {

--- a/src/vs/platform/files/common/files.ts
+++ b/src/vs/platform/files/common/files.ts
@@ -968,6 +968,18 @@ export interface IFileChange {
 	readonly resource: URI;
 
 	/**
+	 * Associated resources for this file change. For performance
+	 * optimization we might drop certain file change events for
+	 * example when a folder is deleted to not report every child
+	 * as well. In such a case, the folder being deleted is the
+	 * main `resource` but the children are provided as associated
+	 * resources.
+	 *
+	 * Note: this is optional and only provided in certain cases.
+	 */
+	readonly associatedResources?: URI[];
+
+	/**
 	 * If provided when starting the file watcher, the correlation
 	 * identifier will match the original file watching request as
 	 * a way to identify the original component that is interested


### PR DESCRIPTION
✋ a real disadvantage of this is that deletion events would be inconsistent: sometimes reporting for all children and sometimes not, depending on how the deletion was done. Today at least we are consistent in that we do NOT report events for children.

On macOS for example, deleting a folder from the finder is a `rename` of that folder into the "Bin", so you never get individual events for all files within.