### PR TITLE
Fix hover widget out of bounds

### DIFF
--- a/src/vs/editor/browser/widget/multiDiffEditor/diffEditorItemTemplate.ts
+++ b/src/vs/editor/browser/widget/multiDiffEditor/diffEditorItemTemplate.ts
@@ -113,6 +113,7 @@ export class DiffEditorItemTemplate extends Disposable implements IPooledObject<
 		]) as Record<string, HTMLElement>;
 		this.editor = this._register(this._instantiationService.createInstance(DiffEditorWidget, this._elements.editor, {
 			overflowWidgetsDomNode: this._overflowWidgetsDomNode,
+			fixedOverflowWidgets: true
 		}, {}));
 		this.isModifedFocused = observableCodeEditor(this.editor.getModifiedEditor()).isFocused;
 		this.isOriginalFocused = observableCodeEditor(this.editor.getOriginalEditor()).isFocused;

--- a/src/vs/editor/contrib/hover/browser/glyphHoverWidget.ts
+++ b/src/vs/editor/contrib/hover/browser/glyphHoverWidget.ts
@@ -19,6 +19,7 @@ const $ = dom.$;
 export class GlyphHoverWidget extends Disposable implements IOverlayWidget, IHoverWidget {
 
 	public static readonly ID = 'editor.contrib.modesGlyphHoverWidget';
+	public readonly allowEditorOverflow = true;
 
 	private readonly _editor: ICodeEditor;
 	private readonly _hover: HoverWidget;
@@ -179,8 +180,22 @@ export class GlyphHoverWidget extends Disposable implements IOverlayWidget, IHov
 		const maxTop = editorHeight - nodeHeight;
 		const constrainedTop = Math.max(0, Math.min(Math.round(top), maxTop));
 
-		this._hover.containerDomNode.style.left = `${left}px`;
-		this._hover.containerDomNode.style.top = `${constrainedTop}px`;
+		const fixedOverflowWidgets = this._editor.getOption(EditorOption.fixedOverflowWidgets);
+		if (fixedOverflowWidgets) {
+			// Use fixed positioning relative to the viewport
+			const editorDomNode = this._editor.getDomNode();
+			if (editorDomNode) {
+				const editorRect = dom.getDomNodePagePosition(editorDomNode);
+				this._hover.containerDomNode.style.position = 'fixed';
+				this._hover.containerDomNode.style.left = `${editorRect.left + left}px`;
+				this._hover.containerDomNode.style.top = `${editorRect.top + constrainedTop}px`;
+			}
+		} else {
+			// Use absolute positioning relative to the editor
+			this._hover.containerDomNode.style.position = 'absolute';
+			this._hover.containerDomNode.style.left = `${left}px`;
+			this._hover.containerDomNode.style.top = `${constrainedTop}px`;
+		}
 		this._hover.containerDomNode.style.zIndex = '11'; // 1 more than the zone widget at 10 (#233819)
 	}
 

--- a/src/vs/editor/contrib/hover/browser/glyphHoverWidget.ts
+++ b/src/vs/editor/contrib/hover/browser/glyphHoverWidget.ts
@@ -173,8 +173,14 @@ export class GlyphHoverWidget extends Disposable implements IOverlayWidget, IHov
 		const nodeHeight = this._hover.containerDomNode.clientHeight;
 		const top = topForLineNumber - editorScrollTop - ((nodeHeight - lineHeight) / 2);
 		const left = editorLayout.glyphMarginLeft + editorLayout.glyphMarginWidth + (laneOrLine === 'lineNo' ? editorLayout.lineNumbersWidth : 0);
+
+		// Constrain the hover widget to stay within the editor bounds
+		const editorHeight = editorLayout.height;
+		const maxTop = editorHeight - nodeHeight;
+		const constrainedTop = Math.max(0, Math.min(Math.round(top), maxTop));
+
 		this._hover.containerDomNode.style.left = `${left}px`;
-		this._hover.containerDomNode.style.top = `${Math.max(Math.round(top), 0)}px`;
+		this._hover.containerDomNode.style.top = `${constrainedTop}px`;
 		this._hover.containerDomNode.style.zIndex = '11'; // 1 more than the zone widget at 10 (#233819)
 	}
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
## Context
When the monaco editor is really short (like in the cell/multi diff scenario), the widget is being clipped due to the `overflow-guard` and other parent divs. We should allow the positioning to be fixed using the `fixedOverflowWidgets` setting.

## Screenshots
| Before | After |
| -- | -- |
| <img width="702" height="184" alt="image" src="https://github.com/user-attachments/assets/123a30e2-9be2-4209-bc51-0f63c64bbeb4" /> | <img width="320" height="81" alt="image" src="https://github.com/user-attachments/assets/c954f629-c7d2-4233-8631-6cf3ce5ba160" /> |

Fixes #226808