### PR TITLE
Add `resource` to chat session, replacing id

### DIFF
--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -58,7 +58,7 @@ import { IChatAgentMetadata, IChatAgentRequest, IChatAgentResult, UserSelectedTo
 import { ICodeMapperRequest, ICodeMapperResult } from '../../contrib/chat/common/chatCodeMapperService.js';
 import { IChatRelatedFile, IChatRelatedFileProviderMetadata as IChatRelatedFilesProviderMetadata, IChatRequestDraft } from '../../contrib/chat/common/chatEditingService.js';
 import { IChatProgressHistoryResponseContent } from '../../contrib/chat/common/chatModel.js';
-import { ChatResponseClearToPreviousToolInvocationReason, IChatContentInlineReference, IChatFollowup, IChatNotebookEdit, IChatProgress, IChatTask, IChatTaskDto, IChatUserActionEvent, IChatVoteAction } from '../../contrib/chat/common/chatService.js';
+import { ChatResponseClearToPreviousToolInvocationReason, IChatContentInlineReference, IChatFollowup, IChatNotebookEdit, IChatProgress, IChatSessionContext, IChatTask, IChatTaskDto, IChatUserActionEvent, IChatVoteAction } from '../../contrib/chat/common/chatService.js';
 import { IChatSessionItem } from '../../contrib/chat/common/chatSessionsService.js';
 import { IChatRequestVariableValue } from '../../contrib/chat/common/chatVariables.js';
 import { ChatAgentLocation } from '../../contrib/chat/common/constants.js';
@@ -1372,7 +1372,7 @@ export type IChatAgentHistoryEntryDto = {
 };
 
 export interface ExtHostChatAgentsShape2 {
-	$invokeAgent(handle: number, request: Dto<IChatAgentRequest>, context: { history: IChatAgentHistoryEntryDto[]; chatSessionContext?: { chatSessionType: string; chatSessionId: string; isUntitled: boolean }; chatSummary?: { prompt?: string; history?: string } }, token: CancellationToken): Promise<IChatAgentResult | undefined>;
+	$invokeAgent(handle: number, request: Dto<IChatAgentRequest>, context: { history: IChatAgentHistoryEntryDto[]; chatSessionContext?: IChatSessionContext; chatSummary?: { prompt?: string; history?: string } }, token: CancellationToken): Promise<IChatAgentResult | undefined>;
 	$provideFollowups(request: Dto<IChatAgentRequest>, handle: number, result: IChatAgentResult, context: { history: IChatAgentHistoryEntryDto[] }, token: CancellationToken): Promise<IChatFollowup[]>;
 	$acceptFeedback(handle: number, result: IChatAgentResult, voteAction: IChatVoteAction): void;
 	$acceptAction(handle: number, result: IChatAgentResult, action: IChatUserActionEvent): void;
@@ -3158,6 +3158,7 @@ export type IChatSessionHistoryItemDto = { type: 'request'; prompt: string; part
 
 export interface ChatSessionDto {
 	id: string;
+	resource: UriComponents;
 	history: Array<IChatSessionHistoryItemDto>;
 	hasActiveResponseCallback: boolean;
 	hasRequestHandler: boolean;
@@ -3169,7 +3170,7 @@ export interface MainThreadChatSessionsShape extends IDisposable {
 	$registerChatSessionItemProvider(handle: number, chatSessionType: string): void;
 	$unregisterChatSessionItemProvider(handle: number): void;
 	$onDidChangeChatSessionItems(handle: number): void;
-	$onDidCommitChatSessionItem(handle: number, original: string, modified: string): void;
+	$onDidCommitChatSessionItem(handle: number, original: { id: string; resource: UriComponents }, modified: { id: string; resource: UriComponents }): void;
 	$registerChatSessionContentProvider(handle: number, chatSessionType: string): void;
 	$unregisterChatSessionContentProvider(handle: number): void;
 
@@ -3184,7 +3185,7 @@ export interface ExtHostChatSessionsShape {
 	$provideChatSessionItems(providerHandle: number, token: CancellationToken): Promise<Dto<IChatSessionItem>[]>;
 	$provideNewChatSessionItem(providerHandle: number, options: { request: IChatAgentRequest; metadata?: any }, token: CancellationToken): Promise<Dto<IChatSessionItem>>;
 
-	$provideChatSessionContent(providerHandle: number, sessionId: string, token: CancellationToken): Promise<ChatSessionDto>;
+	$provideChatSessionContent(providerHandle: number, sessionId: string, sessionResource: UriComponents, token: CancellationToken): Promise<ChatSessionDto>;
 	$interruptChatSessionActiveResponse(providerHandle: number, sessionId: string, requestId: string): Promise<void>;
 	$disposeChatSessionContent(providerHandle: number, sessionId: string): Promise<void>;
 	$invokeChatSessionRequestHandler(providerHandle: number, id: string, request: IChatAgentRequest, history: any[], token: CancellationToken): Promise<IChatAgentResult>;

--- a/src/vs/workbench/api/common/extHostChatAgents2.ts
+++ b/src/vs/workbench/api/common/extHostChatAgents2.ts
@@ -22,7 +22,7 @@ import { ILogService } from '../../../platform/log/common/log.js';
 import { isChatViewTitleActionContext } from '../../contrib/chat/common/chatActions.js';
 import { IChatAgentRequest, IChatAgentResult, IChatAgentResultTimings, UserSelectedTools } from '../../contrib/chat/common/chatAgents.js';
 import { IChatRelatedFile, IChatRequestDraft } from '../../contrib/chat/common/chatEditingService.js';
-import { ChatAgentVoteDirection, IChatContentReference, IChatFollowup, IChatResponseErrorDetails, IChatUserActionEvent, IChatVoteAction } from '../../contrib/chat/common/chatService.js';
+import { ChatAgentVoteDirection, IChatContentReference, IChatFollowup, IChatResponseErrorDetails, IChatSessionContext, IChatUserActionEvent, IChatVoteAction } from '../../contrib/chat/common/chatService.js';
 import { ChatAgentLocation } from '../../contrib/chat/common/constants.js';
 import { checkProposedApiEnabled, isProposedApiEnabled } from '../../services/extensions/common/extensions.js';
 import { Dto } from '../../services/extensions/common/proxyIdentifier.js';
@@ -541,7 +541,7 @@ export class ExtHostChatAgents2 extends Disposable implements ExtHostChatAgentsS
 		this._onDidChangeChatRequestTools.fire(request.extRequest);
 	}
 
-	async $invokeAgent(handle: number, requestDto: Dto<IChatAgentRequest>, context: { history: IChatAgentHistoryEntryDto[]; chatSessionContext?: { chatSessionType: string; chatSessionId: string; isUntitled: boolean }; chatSummary?: { prompt?: string; history?: string } }, token: CancellationToken): Promise<IChatAgentResult | undefined> {
+	async $invokeAgent(handle: number, requestDto: Dto<IChatAgentRequest>, context: { history: IChatAgentHistoryEntryDto[]; chatSessionContext?: IChatSessionContext; chatSummary?: { prompt?: string; history?: string } }, token: CancellationToken): Promise<IChatAgentResult | undefined> {
 		const agent = this._agents.get(handle);
 		if (!agent) {
 			throw new Error(`[CHAT](${handle}) CANNOT invoke agent because the agent is not registered`);
@@ -582,6 +582,7 @@ export class ExtHostChatAgents2 extends Disposable implements ExtHostChatAgentsS
 				chatSessionContext = {
 					chatSessionItem: {
 						id: context.chatSessionContext.chatSessionId,
+						resource: URI.revive(context.chatSessionContext.chatSessionResource),
 						label: context.chatSessionContext.isUntitled ? 'Untitled Session' : 'Session',
 					},
 					isUntitled: context.chatSessionContext.isUntitled,

--- a/src/vs/workbench/api/test/browser/mainThreadChatSessions.test.ts
+++ b/src/vs/workbench/api/test/browser/mainThreadChatSessions.test.ts
@@ -7,6 +7,8 @@ import assert from 'assert';
 import * as sinon from 'sinon';
 import { CancellationToken } from '../../../../base/common/cancellation.js';
 import { DisposableStore } from '../../../../base/common/lifecycle.js';
+import { Schemas } from '../../../../base/common/network.js';
+import { URI } from '../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { TestConfigurationService } from '../../../../platform/configuration/test/common/testConfigurationService.js';
@@ -77,14 +79,17 @@ suite('ObservableChatSession', function () {
 	}
 
 	async function createInitializedSession(sessionContent: any, sessionId = 'test-id'): Promise<ObservableChatSession> {
-		const session = new ObservableChatSession(sessionId, 1, proxy, logService, dialogService);
+		const resource = URI.parse(`${Schemas.vscodeChatSession}:/test/${sessionId}`);
+		const session = new ObservableChatSession(sessionId, resource, 1, proxy, logService, dialogService);
 		(proxy.$provideChatSessionContent as sinon.SinonStub).resolves(sessionContent);
 		await session.initialize(CancellationToken.None);
 		return session;
 	}
 
 	test('constructor creates session with proper initial state', function () {
-		const session = disposables.add(new ObservableChatSession('test-id', 1, proxy, logService, dialogService));
+		const sessionId = 'test-id';
+		const resource = URI.parse(`${Schemas.vscodeChatSession}:/test/${sessionId}`);
+		const session = disposables.add(new ObservableChatSession(sessionId, resource, 1, proxy, logService, dialogService));
 
 		assert.strictEqual(session.sessionId, 'test-id');
 		assert.strictEqual(session.providerHandle, 1);
@@ -98,7 +103,9 @@ suite('ObservableChatSession', function () {
 	});
 
 	test('session queues progress before initialization and processes it after', async function () {
-		const session = disposables.add(new ObservableChatSession('test-id', 1, proxy, logService, dialogService));
+		const sessionId = 'test-id';
+		const resource = URI.parse(`${Schemas.vscodeChatSession}:/test/${sessionId}`);
+		const session = disposables.add(new ObservableChatSession(sessionId, resource, 1, proxy, logService, dialogService));
 
 		const progress1: IChatProgress = { kind: 'progressMessage', content: { value: 'Hello', isTrusted: false } };
 		const progress2: IChatProgress = { kind: 'progressMessage', content: { value: 'World', isTrusted: false } };
@@ -147,7 +154,10 @@ suite('ObservableChatSession', function () {
 	});
 
 	test('initialization is idempotent and returns same promise', async function () {
-		const session = disposables.add(new ObservableChatSession('test-id', 1, proxy, logService, dialogService));
+		const sessionId = 'test-id';
+		const resource = URI.parse(`${Schemas.vscodeChatSession}:/test/${sessionId}`);
+		const session = disposables.add(new ObservableChatSession(sessionId, resource, 1, proxy, logService, dialogService));
+
 		const sessionContent = createSessionContent();
 		(proxy.$provideChatSessionContent as sinon.SinonStub).resolves(sessionContent);
 
@@ -272,7 +282,9 @@ suite('ObservableChatSession', function () {
 	});
 
 	test('dispose properly cleans up resources and notifies listeners', function () {
-		const session = new ObservableChatSession('test-id', 1, proxy, logService, dialogService);
+		const sessionId = 'test-id';
+		const resource = URI.parse(`${Schemas.vscodeChatSession}:/test/${sessionId}`);
+		const session = disposables.add(new ObservableChatSession(sessionId, resource, 1, proxy, logService, dialogService));
 
 		let disposeEventFired = false;
 		const disposable = session.onWillDispose(() => {
@@ -288,7 +300,9 @@ suite('ObservableChatSession', function () {
 	});
 
 	test('session key generation is consistent', function () {
-		const session = new ObservableChatSession('test-id', 42, proxy, logService, dialogService);
+		const sessionId = 'test-id';
+		const resource = URI.parse(`${Schemas.vscodeChatSession}:/test/${sessionId}`);
+		const session = disposables.add(new ObservableChatSession(sessionId, resource, 42, proxy, logService, dialogService));
 
 		assert.strictEqual(session.sessionKey, '42_test-id');
 		assert.strictEqual(ObservableChatSession.generateSessionKey(42, 'test-id'), '42_test-id');
@@ -427,13 +441,15 @@ suite('MainThreadChatSessions', function () {
 			hasRequestHandler: false
 		};
 
+		const resource = URI.parse(`${Schemas.vscodeChatSession}:/test-type/test-session`);
+
 		(proxy.$provideChatSessionContent as sinon.SinonStub).resolves(sessionContent);
-		const session1 = await chatSessionsService.provideChatSessionContent('test-type', 'test-session', CancellationToken.None);
+		const session1 = await chatSessionsService.provideChatSessionContent('test-type', 'test-session', resource, CancellationToken.None);
 
 		assert.ok(session1);
 		assert.strictEqual(session1.sessionId, 'test-session');
 
-		const session2 = await chatSessionsService.provideChatSessionContent('test-type', 'test-session', CancellationToken.None);
+		const session2 = await chatSessionsService.provideChatSessionContent('test-type', 'test-session', resource, CancellationToken.None);
 		assert.strictEqual(session1, session2);
 
 		assert.ok((proxy.$provideChatSessionContent as sinon.SinonStub).calledOnce);
@@ -452,7 +468,8 @@ suite('MainThreadChatSessions', function () {
 
 		(proxy.$provideChatSessionContent as sinon.SinonStub).resolves(sessionContent);
 
-		const session = await chatSessionsService.provideChatSessionContent('test-type', 'test-session', CancellationToken.None) as ObservableChatSession;
+		const resource = URI.parse(`${Schemas.vscodeChatSession}:/test-type/test-session`);
+		const session = await chatSessionsService.provideChatSessionContent('test-type', 'test-session', resource, CancellationToken.None) as ObservableChatSession;
 
 		const progressDto: IChatProgressDto = { kind: 'progressMessage', content: { value: 'Test', isTrusted: false } };
 		await mainThread.$handleProgressChunk(1, 'test-session', 'req1', [progressDto]);
@@ -475,7 +492,8 @@ suite('MainThreadChatSessions', function () {
 
 		(proxy.$provideChatSessionContent as sinon.SinonStub).resolves(sessionContent);
 
-		const session = await chatSessionsService.provideChatSessionContent('test-type', 'test-session', CancellationToken.None) as ObservableChatSession;
+		const resource = URI.parse(`${Schemas.vscodeChatSession}:/test-type/test-session`);
+		const session = await chatSessionsService.provideChatSessionContent('test-type', 'test-session', resource, CancellationToken.None) as ObservableChatSession;
 
 		const progressDto: IChatProgressDto = { kind: 'progressMessage', content: { value: 'Test', isTrusted: false } };
 		await mainThread.$handleProgressChunk(1, 'test-session', 'req1', [progressDto]);
@@ -503,7 +521,8 @@ suite('MainThreadChatSessions', function () {
 
 		(proxy.$provideChatSessionContent as sinon.SinonStub).resolves(sessionContent);
 
-		const session = await chatSessionsService.provideChatSessionContent('test-type', 'multi-turn-session', CancellationToken.None) as ObservableChatSession;
+		const resource = URI.parse(`${Schemas.vscodeChatSession}:/test-type/multi-turn-session`);
+		const session = await chatSessionsService.provideChatSessionContent('test-type', 'multi-turn-session', resource, CancellationToken.None) as ObservableChatSession;
 
 		// Verify the session loaded correctly
 		assert.ok(session);

--- a/src/vs/workbench/contrib/chat/browser/chatSessions.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSessions.contribution.ts
@@ -7,6 +7,7 @@ import { CancellationToken } from '../../../../base/common/cancellation.js';
 import { Codicon } from '../../../../base/common/codicons.js';
 import { Emitter, Event } from '../../../../base/common/event.js';
 import { Disposable, DisposableStore, IDisposable } from '../../../../base/common/lifecycle.js';
+import { URI } from '../../../../base/common/uri.js';
 import { generateUuid } from '../../../../base/common/uuid.js';
 import { localize, localize2 } from '../../../../nls.js';
 import { Action2, MenuId, MenuRegistry, registerAction2 } from '../../../../platform/actions/common/actions.js';
@@ -538,7 +539,7 @@ export class ChatSessionsService extends Disposable implements IChatSessionsServ
 		return chatSessionItem;
 	}
 
-	public async provideChatSessionContent(chatSessionType: string, id: string, token: CancellationToken): Promise<ChatSession> {
+	public async provideChatSessionContent(chatSessionType: string, id: string, resource: URI, token: CancellationToken): Promise<ChatSession> {
 		if (!(await this.canResolveContentProvider(chatSessionType))) {
 			throw Error(`Can not find provider for ${chatSessionType}`);
 		}
@@ -554,7 +555,7 @@ export class ChatSessionsService extends Disposable implements IChatSessionsServ
 			return existingSessionData.session;
 		}
 
-		const session = await provider.provideChatSessionContent(id, token);
+		const session = await provider.provideChatSessionContent(id, resource, token);
 		const sessionData = new ContributedChatSessionData(session, chatSessionType, id, this._onWillDisposeSession.bind(this));
 
 		this._sessions.set(sessionKey, sessionData);

--- a/src/vs/workbench/contrib/chat/browser/chatSessions/chatSessionTracker.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSessions/chatSessionTracker.ts
@@ -102,6 +102,7 @@ export class ChatSessionTracker extends Disposable {
 			const parsed = ChatSessionUri.parse(editor.resource);
 			const hybridSession: ChatSessionItemWithProvider = {
 				id: parsed?.sessionId || editor.sessionId || `${provider.chatSessionType}-local-${index}`,
+				resource: editor.resource,
 				label: editor.getName(),
 				iconPath: Codicon.chatSparkle,
 				status,

--- a/src/vs/workbench/contrib/chat/browser/chatSessions/localChatSessionsProvider.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSessions/localChatSessionsProvider.ts
@@ -6,7 +6,9 @@ import { CancellationToken } from '../../../../../base/common/cancellation.js';
 import { Codicon } from '../../../../../base/common/codicons.js';
 import { Emitter, Event } from '../../../../../base/common/event.js';
 import { Disposable } from '../../../../../base/common/lifecycle.js';
+import { Schemas } from '../../../../../base/common/network.js';
 import { IObservable } from '../../../../../base/common/observable.js';
+import { URI } from '../../../../../base/common/uri.js';
 import * as nls from '../../../../../nls.js';
 import { EditorInput } from '../../../../common/editor/editorInput.js';
 import { IEditorGroupsService, IEditorGroup } from '../../../../services/editor/common/editorGroupsService.js';
@@ -198,6 +200,7 @@ export class LocalChatSessionsProvider extends Disposable implements IChatSessio
 		const status = chatWidget?.viewModel?.model ? this.modelToStatus(chatWidget.viewModel.model) : undefined;
 		const widgetSession: ChatSessionItemWithProvider = {
 			id: LocalChatSessionsProvider.CHAT_WIDGET_VIEW_ID,
+			resource: URI.parse(`${Schemas.vscodeChatSession}://widget`),
 			label: chatWidget?.viewModel?.model.title || nls.localize2('chat.sessions.chatView', "Chat").value,
 			description: nls.localize('chat.sessions.chatView.description', "Chat View"),
 			iconPath: Codicon.chatSparkle,
@@ -229,6 +232,7 @@ export class LocalChatSessionsProvider extends Disposable implements IChatSessio
 					}
 					const editorSession: ChatSessionItemWithProvider = {
 						id: editorInfo.editor.sessionId,
+						resource: editorInfo.editor.resource,
 						label: editorInfo.editor.getName(),
 						iconPath: Codicon.chatSparkle,
 						status,
@@ -242,8 +246,10 @@ export class LocalChatSessionsProvider extends Disposable implements IChatSessio
 			}
 		});
 
+		// TODO: This should not be a session items
 		const historyNode: IChatSessionItem = {
 			id: LocalChatSessionsProvider.HISTORY_NODE_ID,
+			resource: URI.parse(`${Schemas.vscodeChatSession}://history`),
 			label: nls.localize('chat.sessions.showHistory', "History"),
 		};
 

--- a/src/vs/workbench/contrib/chat/browser/chatSessions/view/sessionsTreeRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSessions/view/sessionsTreeRenderer.ts
@@ -47,6 +47,7 @@ import { IListRenderer, IListVirtualDelegate } from '../../../../../../base/brow
 import { ChatSessionTracker } from '../chatSessionTracker.js';
 import { CancellationToken } from '../../../../../../base/common/cancellation.js';
 import { getLocalHistoryDateFormatter } from '../../../../localHistory/browser/localHistory.js';
+import { ChatSessionUri } from '../../../common/chatUri.js';
 
 interface ISessionTemplateData {
 	readonly container: HTMLElement;
@@ -575,8 +576,9 @@ export class SessionsDataSource implements IAsyncDataSource<IChatSessionItemProv
 			const allHistory = await this.chatService.getHistory();
 
 			// Create history items with provider reference and timestamps
-			const historyItems = allHistory.map((historyDetail: any): ChatSessionItemWithProvider => ({
+			const historyItems = allHistory.map((historyDetail): ChatSessionItemWithProvider => ({
 				id: historyDetail.sessionId,
+				resource: ChatSessionUri.forSession(this.provider.chatSessionType, historyDetail.sessionId),
 				label: historyDetail.title,
 				iconPath: Codicon.chatSparkle,
 				provider: this.provider,

--- a/src/vs/workbench/contrib/chat/common/chatService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService.ts
@@ -10,7 +10,7 @@ import { Event } from '../../../../base/common/event.js';
 import { IMarkdownString } from '../../../../base/common/htmlContent.js';
 import { autorunSelfDisposable, IObservable } from '../../../../base/common/observable.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
-import { URI } from '../../../../base/common/uri.js';
+import { URI, UriComponents } from '../../../../base/common/uri.js';
 import { IRange, Range } from '../../../../editor/common/core/range.js';
 import { ISelection } from '../../../../editor/common/core/selection.js';
 import { Command, Location, TextEdit } from '../../../../editor/common/languages.js';
@@ -737,7 +737,7 @@ export interface IChatService {
 	loadSessionFromContent(data: IExportableChatData | ISerializableChatData | URI): IChatModel | undefined;
 	loadSessionForResource(resource: URI, location: ChatAgentLocation, token: CancellationToken): Promise<IChatModel | undefined>;
 	readonly editingSessions: IChatEditingSession[];
-	getChatSessionFromInternalId(sessionId: string): { chatSessionType: string; chatSessionId: string; isUntitled: boolean } | undefined;
+	getChatSessionFromInternalId(sessionId: string): IChatSessionContext | undefined;
 
 	/**
 	 * Returns whether the request was accepted.`
@@ -768,6 +768,13 @@ export interface IChatService {
 	readonly edits2Enabled: boolean;
 
 	readonly requestInProgressObs: IObservable<boolean>;
+}
+
+export interface IChatSessionContext {
+	chatSessionType: string;
+	chatSessionId: string;
+	chatSessionResource: UriComponents;
+	isUntitled: boolean;
 }
 
 export const KEYWORD_ACTIVIATION_SETTING_ID = 'accessibility.voice.keywordActivation';

--- a/src/vs/workbench/contrib/chat/common/chatSessionsService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatSessionsService.ts
@@ -9,6 +9,7 @@ import { IMarkdownString } from '../../../../base/common/htmlContent.js';
 import { IDisposable } from '../../../../base/common/lifecycle.js';
 import { IObservable } from '../../../../base/common/observable.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
+import { URI } from '../../../../base/common/uri.js';
 import { IRelaxedExtensionDescription } from '../../../../platform/extensions/common/extensions.js';
 import { createDecorator } from '../../../../platform/instantiation/common/instantiation.js';
 import { IEditableData } from '../../../common/views.js';
@@ -41,7 +42,8 @@ export interface IChatSessionsExtensionPoint {
 	readonly commands?: IChatSessionCommandContribution[];
 }
 export interface IChatSessionItem {
-	id: string;
+	id: string; // TODO: remove
+	resource: URI;
 	label: string;
 	iconPath?: ThemeIcon;
 	description?: string | IMarkdownString;
@@ -62,6 +64,7 @@ export type IChatSessionHistoryItem = { type: 'request'; prompt: string; partici
 
 export interface ChatSession extends IDisposable {
 	readonly sessionId: string;
+	readonly sessionResource: URI;
 	readonly onWillDispose: Event<void>;
 	history: Array<IChatSessionHistoryItem>;
 	readonly progressObs?: IObservable<IChatProgress[]>;
@@ -87,7 +90,7 @@ export interface IChatSessionItemProvider {
 }
 
 export interface IChatSessionContentProvider {
-	provideChatSessionContent(sessionId: string, token: CancellationToken): Promise<ChatSession>;
+	provideChatSessionContent(sessionId: string, sessionResource: URI, token: CancellationToken): Promise<ChatSession>;
 }
 
 export interface IChatSessionsService {
@@ -112,7 +115,7 @@ export interface IChatSessionsService {
 
 	registerChatSessionContentProvider(chatSessionType: string, provider: IChatSessionContentProvider): IDisposable;
 	canResolveContentProvider(chatSessionType: string): Promise<boolean>;
-	provideChatSessionContent(chatSessionType: string, id: string, token: CancellationToken): Promise<ChatSession>;
+	provideChatSessionContent(chatSessionType: string, id: string, sessionResource: URI, token: CancellationToken): Promise<ChatSession>;
 
 	// Editable session support
 	setEditableSession(sessionId: string, data: IEditableData | null): Promise<void>;

--- a/src/vs/workbench/contrib/chat/test/common/mockChatService.ts
+++ b/src/vs/workbench/contrib/chat/test/common/mockChatService.ts
@@ -9,11 +9,11 @@ import { observableValue } from '../../../../../base/common/observable.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { ChatModel, IChatModel, IChatRequestModel, IChatRequestVariableData, ISerializableChatData } from '../../common/chatModel.js';
 import { IParsedChatRequest } from '../../common/chatParserTypes.js';
-import { IChatCompleteResponse, IChatDetail, IChatProviderInfo, IChatSendRequestData, IChatSendRequestOptions, IChatService, IChatTransferredSessionData, IChatUserActionEvent } from '../../common/chatService.js';
+import { IChatCompleteResponse, IChatDetail, IChatProviderInfo, IChatSendRequestData, IChatSendRequestOptions, IChatService, IChatSessionContext, IChatTransferredSessionData, IChatUserActionEvent } from '../../common/chatService.js';
 import { ChatAgentLocation } from '../../common/constants.js';
 
 export class MockChatService implements IChatService {
-	getChatSessionFromInternalId(modelSessionId: string): { chatSessionType: string; chatSessionId: string; isUntitled: boolean } | undefined {
+	getChatSessionFromInternalId(modelSessionId: string): IChatSessionContext | undefined {
 		throw new Error('Method not implemented.');
 	}
 	requestInProgressObs = observableValue('name', false);

--- a/src/vscode-dts/vscode.proposed.chatSessionsProvider.d.ts
+++ b/src/vscode-dts/vscode.proposed.chatSessionsProvider.d.ts
@@ -71,8 +71,17 @@ declare module 'vscode' {
 	export interface ChatSessionItem {
 		/**
 		 * Unique identifier for the chat session.
+		 *
+		 * @deprecated Will be replaced by `resource`
 		 */
 		id: string;
+
+		/**
+		 * The resource associated with the chat session.
+		 *
+		 * This is uniquely identifies the chat session and is used to open the chat session.
+		 */
+		resource: Uri | undefined;
 
 		/**
 		 * Human readable name of the session shown in the UI
@@ -212,6 +221,9 @@ declare module 'vscode' {
 		supportsInterruptions?: boolean;
 	}
 
+	/**
+	 * @deprecated
+	 */
 	export interface ChatSessionShowOptions {
 		/**
 		 * The editor view column to show the chat session in.
@@ -224,6 +236,8 @@ declare module 'vscode' {
 	export namespace window {
 		/**
 		 * Shows a chat session in the panel or editor.
+		 *
+		 * @deprecated
 		 */
 		export function showChatSession(chatSessionType: string, sessionId: string, options: ChatSessionShowOptions): Thenable<void>;
 	}


### PR DESCRIPTION
Adds `resource` as the replacement for `id` in the chat session. Marks existing fields as deprecated and tries to add migrations in most places

Doesn't yet hook up opening by resource