### PR TITLE
Make sure more TS commands are disabled when tsgo is active

### DIFF
--- a/extensions/typescript-language-features/package.json
+++ b/extensions/typescript-language-features/package.json
@@ -1632,7 +1632,7 @@
         },
         {
           "command": "typescript.goToProjectConfig",
-          "when": "editorLangId == typescriptreact"
+          "when": "editorLangId == typescriptreact && typescript.isManagedFile"
         },
         {
           "command": "javascript.goToProjectConfig",
@@ -1682,7 +1682,7 @@
       "editor/context": [
         {
           "command": "typescript.goToSourceDefinition",
-          "when": "tsSupportsSourceDefinition && (resourceLangId == typescript || resourceLangId == typescriptreact || resourceLangId == javascript || resourceLangId == javascriptreact)",
+          "when": "!config.typescript.experimental.useTsgo && tsSupportsSourceDefinition && (resourceLangId == typescript || resourceLangId == typescriptreact || resourceLangId == javascript || resourceLangId == javascriptreact)",
           "group": "navigation@1.41"
         }
       ],

--- a/extensions/typescript-language-features/src/languageFeatures/fileReferences.ts
+++ b/extensions/typescript-language-features/src/languageFeatures/fileReferences.ts
@@ -79,11 +79,14 @@ export function register(
 	client: ITypeScriptServiceClient,
 	commandManager: CommandManager
 ) {
-	function updateContext() {
-		vscode.commands.executeCommand('setContext', FileReferencesCommand.context, client.apiVersion.gte(FileReferencesCommand.minVersion));
+	function updateContext(overrideValue?: boolean) {
+		vscode.commands.executeCommand('setContext', FileReferencesCommand.context, overrideValue ?? client.apiVersion.gte(FileReferencesCommand.minVersion));
 	}
 	updateContext();
 
 	commandManager.register(new FileReferencesCommand(client));
-	return client.onTsServerStarted(() => updateContext());
+	return vscode.Disposable.from(
+		client.onTsServerStarted(() => updateContext()),
+		new vscode.Disposable(() => updateContext(false)),
+	);
 }

--- a/extensions/typescript-language-features/src/languageFeatures/sourceDefinition.ts
+++ b/extensions/typescript-language-features/src/languageFeatures/sourceDefinition.ts
@@ -80,12 +80,15 @@ class SourceDefinitionCommand implements Command {
 export function register(
 	client: ITypeScriptServiceClient,
 	commandManager: CommandManager
-) {
-	function updateContext() {
-		vscode.commands.executeCommand('setContext', SourceDefinitionCommand.context, client.apiVersion.gte(SourceDefinitionCommand.minVersion));
+): vscode.Disposable {
+	function updateContext(overrideValue?: boolean) {
+		vscode.commands.executeCommand('setContext', SourceDefinitionCommand.context, overrideValue ?? client.apiVersion.gte(SourceDefinitionCommand.minVersion));
 	}
 	updateContext();
 
 	commandManager.register(new SourceDefinitionCommand(client));
-	return client.onTsServerStarted(() => updateContext());
+	return vscode.Disposable.from(
+		client.onTsServerStarted(() => updateContext()),
+		new vscode.Disposable(() => updateContext(false)),
+	);
 }

--- a/extensions/typescript-language-features/src/ui/managedFileContext.ts
+++ b/extensions/typescript-language-features/src/ui/managedFileContext.ts
@@ -18,11 +18,18 @@ export default class ManagedFileContextManager extends Disposable {
 
 	private isInManagedFileContext: boolean = false;
 
-	public constructor(activeJsTsEditorTracker: ActiveJsTsEditorTracker) {
+	constructor(activeJsTsEditorTracker: ActiveJsTsEditorTracker) {
 		super();
 		activeJsTsEditorTracker.onDidChangeActiveJsTsEditor(this.onDidChangeActiveTextEditor, this, this._disposables);
 
 		this.onDidChangeActiveTextEditor(activeJsTsEditorTracker.activeJsTsEditor);
+	}
+
+	override dispose() {
+		// Clear the context
+		this.updateContext(false);
+
+		super.dispose();
 	}
 
 	private onDidChangeActiveTextEditor(editor?: vscode.TextEditor): void {


### PR DESCRIPTION
We need to clear the contexts when switching to tsgo

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
