### PR TITLE
Show workspace-level agent instruction files in 'configure instructions' picker

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatWidget.ts
@@ -1286,7 +1286,7 @@ export class ChatWidget extends Disposable implements IChatWidget {
 	private _getGenerateInstructionsMessage(): IMarkdownString {
 		// Start checking for instruction files immediately if not already done
 		if (!this._instructionFilesCheckPromise) {
-			this._instructionFilesCheckPromise = this._checkForInstructionFiles();
+			this._instructionFilesCheckPromise = this._checkForAgentInstructionFiles();
 			// Use VS Code's idiomatic pattern for disposal-safe promise callbacks
 			this._register(thenIfNotDisposed(this._instructionFilesCheckPromise, hasFiles => {
 				this._instructionFilesExist = hasFiles;
@@ -1316,10 +1316,23 @@ export class ChatWidget extends Disposable implements IChatWidget {
 		return new MarkdownString('');
 	}
 
-	private async _checkForInstructionFiles(): Promise<boolean> {
+	/**
+	 * Checks if any agent instruction files (.github/copilot-instructions.md or AGENTS.md) exist in the workspace.
+	 * Used to determine whether to show the "Generate Agent Instructions" hint.
+	 *
+	 * @returns true if instruction files exist OR if instruction features are disabled (to hide the hint)
+	 */
+	private async _checkForAgentInstructionFiles(): Promise<boolean> {
 		try {
-			const computer = this.instantiationService.createInstance(ComputeAutomaticInstructions, undefined);
-			return await computer.hasAgentInstructions(CancellationToken.None);
+			const useCopilotInstructionsFiles = this.configurationService.getValue(PromptsConfig.USE_COPILOT_INSTRUCTION_FILES);
+			const useAgentMd = this.configurationService.getValue(PromptsConfig.USE_AGENT_MD);
+			if (!useCopilotInstructionsFiles && !useAgentMd) {
+				// If both settings are disabled, return true to hide the hint (since the features aren't enabled)
+				return true;
+			}
+			const hasAnyCopilotInstructionsMd = (await this.promptsService.listCopilotInstructionsMDs(CancellationToken.None)).length > 0;
+			const hasAnyAgentMd = (await this.promptsService.listAgentMDs(CancellationToken.None)).length > 0;
+			return hasAnyCopilotInstructionsMd || hasAnyAgentMd;
 		} catch (error) {
 			// On error, assume no instruction files exist to be safe
 			this.logService.warn('[ChatWidget] Error checking for instruction files:', error);

--- a/src/vs/workbench/contrib/chat/browser/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatWidget.ts
@@ -1330,9 +1330,11 @@ export class ChatWidget extends Disposable implements IChatWidget {
 				// If both settings are disabled, return true to hide the hint (since the features aren't enabled)
 				return true;
 			}
-			const hasAnyCopilotInstructionsMd = (await this.promptsService.listCopilotInstructionsMDs(CancellationToken.None)).length > 0;
-			const hasAnyAgentMd = (await this.promptsService.listAgentMDs(CancellationToken.None)).length > 0;
-			return hasAnyCopilotInstructionsMd || hasAnyAgentMd;
+			return (
+				(await this.promptsService.listCopilotInstructionsMDs(CancellationToken.None)).length > 0 ||
+				// Note: only checking for AGENTS.md files at the root folder, not ones in subfolders.
+				(await this.promptsService.listAgentMDs(CancellationToken.None, false)).length > 0
+			);
 		} catch (error) {
 			// On error, assume no instruction files exist to be safe
 			this.logService.warn('[ChatWidget] Error checking for instruction files:', error);

--- a/src/vs/workbench/contrib/chat/browser/promptSyntax/pickers/promptFilePickers.ts
+++ b/src/vs/workbench/contrib/chat/browser/promptSyntax/pickers/promptFilePickers.ts
@@ -26,6 +26,8 @@ import { UILabelProvider } from '../../../../../../base/common/keybindingLabels.
 import { OS } from '../../../../../../base/common/platform.js';
 import { askForPromptSourceFolder } from './askForPromptSourceFolder.js';
 import { ILabelService } from '../../../../../../platform/label/common/label.js';
+import { IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
+import { PromptsConfig } from '../../../common/promptSyntax/config/config.js';
 
 /**
  * Options for the {@link askToSelectInstructions} function.
@@ -194,6 +196,7 @@ export class PromptFilePickers {
 		@IInstantiationService private readonly _instaService: IInstantiationService,
 		@IPromptsService private readonly _promptsService: IPromptsService,
 		@ILabelService private readonly _labelService: ILabelService,
+		@IConfigurationService private readonly _configurationService: IConfigurationService,
 	) {
 	}
 
@@ -297,7 +300,8 @@ export class PromptFilePickers {
 		}
 		const locals = await this._promptsService.listPromptFilesForStorage(options.type, PromptsStorage.local, CancellationToken.None);
 		if (locals.length) {
-			result.push({ type: 'separator', label: localize('separator.workspace-github-instructions', ".github/instructions") });
+			// Note: No need to localize the label ".github/instructions', since it's the same in all languages.
+			result.push({ type: 'separator', label: '.github/instructions' });
 			result.push(...locals.map(l => this._createPromptPickItem(l, buttons)));
 		}
 
@@ -305,9 +309,10 @@ export class PromptFilePickers {
 		// listPromptFilesForStorage() because that function only handles *.instructions.md files (under `.github/instructions/`, etc.)
 		let agentInstructionFiles: IPromptPath[] = [];
 		if (options.type === PromptsType.instructions) {
+			const useNestedAgentMD = this._configurationService.getValue(PromptsConfig.USE_NESTED_AGENT_MD);
 			const agentInstructionUris = [
 				...await this._promptsService.listCopilotInstructionsMDs(CancellationToken.None),
-				...await this._promptsService.listAgentMDs(CancellationToken.None)
+				...await this._promptsService.listAgentMDs(CancellationToken.None, !!useNestedAgentMD)
 			];
 			agentInstructionFiles = agentInstructionUris.map(uri => {
 				const folderName = this._labelService.getUriLabel(dirname(uri), { relative: true });

--- a/src/vs/workbench/contrib/chat/browser/promptSyntax/pickers/promptFilePickers.ts
+++ b/src/vs/workbench/contrib/chat/browser/promptSyntax/pickers/promptFilePickers.ts
@@ -315,7 +315,7 @@ export class PromptFilePickers {
 				const shouldShowFolderPath = folderName?.toLowerCase() !== '.github';
 				return {
 					uri,
-					description: shouldShowFolderPath ? this._labelService.getUriLabel(dirname(uri), { relative: true }) : undefined,
+					description: shouldShowFolderPath ? folderName : undefined,
 					storage: PromptsStorage.local,
 					type: options.type
 				} satisfies IPromptPath;

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/computeAutomaticInstructions.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/computeAutomaticInstructions.ts
@@ -191,7 +191,7 @@ export class ComputeAutomaticInstructions {
 			await this._addReferencedInstructions(entries, telemetryEvent, token);
 		}
 		if (useAgentMd) {
-			const files = await this._promptsService.listAgentMDs(token);
+			const files = await this._promptsService.listAgentMDs(token, false);
 			for (const file of files) {
 				entries.add(toPromptFileVariableEntry(file, PromptFileVariableKind.Instruction, localize('instruction.file.reason.agentsmd', 'Automatically attached as setting {0} is enabled', PromptsConfig.USE_AGENT_MD), true));
 				telemetryEvent.agentInstructionsCount++;

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/computeAutomaticInstructions.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/computeAutomaticInstructions.ts
@@ -7,7 +7,7 @@ import { CancellationToken } from '../../../../../base/common/cancellation.js';
 import { match, splitGlobAware } from '../../../../../base/common/glob.js';
 import { ResourceMap, ResourceSet } from '../../../../../base/common/map.js';
 import { Schemas } from '../../../../../base/common/network.js';
-import { basename, dirname, joinPath } from '../../../../../base/common/resources.js';
+import { basename, dirname } from '../../../../../base/common/resources.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { localize } from '../../../../../nls.js';
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
@@ -19,7 +19,7 @@ import { IWorkspaceContextService } from '../../../../../platform/workspace/comm
 import { ChatRequestVariableSet, IChatRequestVariableEntry, isPromptFileVariableEntry, toPromptFileVariableEntry, toPromptTextVariableEntry, PromptFileVariableKind } from '../chatVariableEntries.js';
 import { IToolData } from '../languageModelToolsService.js';
 import { PromptsConfig } from './config/config.js';
-import { COPILOT_CUSTOM_INSTRUCTIONS_FILENAME, isPromptOrInstructionsFile } from './config/promptFileLocations.js';
+import { isPromptOrInstructionsFile } from './config/promptFileLocations.js';
 import { PromptsType } from './promptTypes.js';
 import { ParsedPromptFile } from './service/newPromptsParser.js';
 import { IPromptPath, IPromptsService } from './service/promptsService.js';
@@ -110,48 +110,6 @@ export class ComputeAutomaticInstructions {
 		this.sendTelemetry(telemetryEvent);
 	}
 
-	/**
-	 * Checks if any agent instruction files (.github/copilot-instructions.md or agents.md) exist in the workspace.
-	 * Used to determine whether to show the "Generate Agent Instructions" hint.
-	 *
-	 * @returns true if instruction files exist OR if instruction features are disabled (to hide the hint)
-	 */
-	public async hasAgentInstructions(token: CancellationToken): Promise<boolean> {
-		const useCopilotInstructionsFiles = this._configurationService.getValue(PromptsConfig.USE_COPILOT_INSTRUCTION_FILES);
-		const useAgentMd = this._configurationService.getValue(PromptsConfig.USE_AGENT_MD);
-
-		// If both settings are disabled, return true to hide the hint (since the features aren't enabled)
-		if (!useCopilotInstructionsFiles && !useAgentMd) {
-			return true;
-		}
-		const { folders } = this._workspaceService.getWorkspace();
-
-		// Check for copilot-instructions.md files
-		if (useCopilotInstructionsFiles) {
-			for (const folder of folders) {
-				const file = joinPath(folder.uri, `.github/` + COPILOT_CUSTOM_INSTRUCTIONS_FILENAME);
-				if (await this._fileService.exists(file)) {
-					return true;
-				}
-			}
-		}
-
-		// Check for agents.md files
-		if (useAgentMd) {
-			const resolvedRoots = await this._fileService.resolveAll(folders.map(f => ({ resource: f.uri })));
-			for (const root of resolvedRoots) {
-				if (root.success && root.stat?.children) {
-					const agentMd = root.stat.children.find(c => c.isFile && c.name.toLowerCase() === 'agents.md');
-					if (agentMd) {
-						return true;
-					}
-				}
-			}
-		}
-
-		return false;
-	}
-
 	private sendTelemetry(telemetryEvent: InstructionsCollectionEvent): void {
 		// Emit telemetry
 		telemetryEvent.totalInstructionsCount = telemetryEvent.agentInstructionsCount + telemetryEvent.referencedInstructionsCount + telemetryEvent.applyingInstructionsCount + telemetryEvent.listedInstructionsCount;
@@ -221,33 +179,23 @@ export class ComputeAutomaticInstructions {
 			this._logService.trace(`[InstructionsContextComputer] No agent instructions files added (settings disabled).`);
 			return;
 		}
-		const instructionFiles: string[] = [];
-		instructionFiles.push(`.github/` + COPILOT_CUSTOM_INSTRUCTIONS_FILENAME);
 
-		const { folders } = this._workspaceService.getWorkspace();
 		const entries: ChatRequestVariableSet = new ChatRequestVariableSet();
 		if (useCopilotInstructionsFiles) {
-			for (const folder of folders) {
-				const file = joinPath(folder.uri, `.github/` + COPILOT_CUSTOM_INSTRUCTIONS_FILENAME);
-				if (await this._fileService.exists(file)) {
-					entries.add(toPromptFileVariableEntry(file, PromptFileVariableKind.Instruction, localize('instruction.file.reason.copilot', 'Automatically attached as setting {0} is enabled', PromptsConfig.USE_COPILOT_INSTRUCTION_FILES), true));
-					telemetryEvent.agentInstructionsCount++;
-					this._logService.trace(`[InstructionsContextComputer] copilot-instruction.md files added: ${file.toString()}`);
-				}
+			const files: URI[] = await this._promptsService.listCopilotInstructionsMDs(token);
+			for (const file of files) {
+				entries.add(toPromptFileVariableEntry(file, PromptFileVariableKind.Instruction, localize('instruction.file.reason.copilot', 'Automatically attached as setting {0} is enabled', PromptsConfig.USE_COPILOT_INSTRUCTION_FILES), true));
+				telemetryEvent.agentInstructionsCount++;
+				this._logService.trace(`[InstructionsContextComputer] copilot-instruction.md files added: ${file.toString()}`);
 			}
 			await this._addReferencedInstructions(entries, telemetryEvent, token);
 		}
 		if (useAgentMd) {
-			const resolvedRoots = await this._fileService.resolveAll(folders.map(f => ({ resource: f.uri })));
-			for (const root of resolvedRoots) {
-				if (root.success && root.stat?.children) {
-					const agentMd = root.stat.children.find(c => c.isFile && c.name.toLowerCase() === 'agents.md');
-					if (agentMd) {
-						entries.add(toPromptFileVariableEntry(agentMd.resource, PromptFileVariableKind.Instruction, localize('instruction.file.reason.agentsmd', 'Automatically attached as setting {0} is enabled', PromptsConfig.USE_AGENT_MD), true));
-						telemetryEvent.agentInstructionsCount++;
-						this._logService.trace(`[InstructionsContextComputer] AGENTS.md files added: ${agentMd.resource.toString()}`);
-					}
-				}
+			const files = await this._promptsService.listAgentMDs(token);
+			for (const file of files) {
+				entries.add(toPromptFileVariableEntry(file, PromptFileVariableKind.Instruction, localize('instruction.file.reason.agentsmd', 'Automatically attached as setting {0} is enabled', PromptsConfig.USE_AGENT_MD), true));
+				telemetryEvent.agentInstructionsCount++;
+				this._logService.trace(`[InstructionsContextComputer] AGENTS.md files added: ${file.toString()}`);
 			}
 		}
 		for (const entry of entries.asArray()) {

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsService.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsService.ts
@@ -234,12 +234,12 @@ export interface IPromptsService extends IDisposable {
 	getPromptLocationLabel(promptPath: IPromptPath): string;
 
 	/**
-	 * Gets list of all AGENT.md files in the workspace.
+	 * Gets list of all AGENTS.md files in the workspace.
 	 */
 	findAgentMDsInWorkspace(token: CancellationToken): Promise<URI[]>;
 
 	/**
-	 * Gets list of AGENT.md files, either at the root or the entire workspace depending on the feature flag.
+	 * Gets list of AGENTS.md files, either at the root or the entire workspace depending on the feature flag.
 	 */
 	listAgentMDs(token: CancellationToken): Promise<URI[]>;
 

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsService.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsService.ts
@@ -233,7 +233,20 @@ export interface IPromptsService extends IDisposable {
 
 	getPromptLocationLabel(promptPath: IPromptPath): string;
 
+	/**
+	 * Gets list of all AGENT.md files in the workspace.
+	 */
 	findAgentMDsInWorkspace(token: CancellationToken): Promise<URI[]>;
+
+	/**
+	 * Gets list of AGENT.md files, either at the root or the entire workspace depending on the feature flag.
+	 */
+	listAgentMDs(token: CancellationToken): Promise<URI[]>;
+
+	/**
+	 * Gets list of .github/copilot-instructions.md files.
+	 */
+	listCopilotInstructionsMDs(token: CancellationToken): Promise<URI[]>;
 }
 
 export interface IChatPromptSlashCommand {

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsService.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsService.ts
@@ -239,9 +239,10 @@ export interface IPromptsService extends IDisposable {
 	findAgentMDsInWorkspace(token: CancellationToken): Promise<URI[]>;
 
 	/**
-	 * Gets list of AGENTS.md files, either at the root or the entire workspace depending on the feature flag.
+	 * Gets list of AGENTS.md files.
+	 * @param includeNested Whether to include AGENTS.md files from subfolders, or only from the root.
 	 */
-	listAgentMDs(token: CancellationToken): Promise<URI[]>;
+	listAgentMDs(token: CancellationToken, includeNested: boolean): Promise<URI[]>;
 
 	/**
 	 * Gets list of .github/copilot-instructions.md files.

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsServiceImpl.ts
@@ -348,6 +348,27 @@ export class PromptsService extends Disposable implements IPromptsService {
 	findAgentMDsInWorkspace(token: CancellationToken): Promise<URI[]> {
 		return this.fileLocator.findAgentMDsInWorkspace(token);
 	}
+
+	public async listAgentMDs(token: CancellationToken): Promise<URI[]> {
+		const useAgentMD = this.configurationService.getValue(PromptsConfig.USE_AGENT_MD);
+		if (!useAgentMD) {
+			return [];
+		}
+		const useNestedAgentMD = this.configurationService.getValue(PromptsConfig.USE_NESTED_AGENT_MD);
+		if (useNestedAgentMD) {
+			return await this.fileLocator.findAgentMDsInWorkspace(token);
+		} else {
+			return await this.fileLocator.findAgentMDsInWorkspaceRoots(token);
+		}
+	}
+
+	public async listCopilotInstructionsMDs(token: CancellationToken): Promise<URI[]> {
+		const useCopilotInstructionsFiles = this.configurationService.getValue(PromptsConfig.USE_COPILOT_INSTRUCTION_FILES);
+		if (!useCopilotInstructionsFiles) {
+			return [];
+		}
+		return await this.fileLocator.findCopilotInstructionsMDsInWorkspace(token);
+	}
 }
 
 function getCommandNameFromPromptPath(promptPath: IPromptPath): string {

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsServiceImpl.ts
@@ -349,13 +349,12 @@ export class PromptsService extends Disposable implements IPromptsService {
 		return this.fileLocator.findAgentMDsInWorkspace(token);
 	}
 
-	public async listAgentMDs(token: CancellationToken): Promise<URI[]> {
+	public async listAgentMDs(token: CancellationToken, includeNested: boolean): Promise<URI[]> {
 		const useAgentMD = this.configurationService.getValue(PromptsConfig.USE_AGENT_MD);
 		if (!useAgentMD) {
 			return [];
 		}
-		const useNestedAgentMD = this.configurationService.getValue(PromptsConfig.USE_NESTED_AGENT_MD);
-		if (useNestedAgentMD) {
+		if (includeNested) {
 			return await this.fileLocator.findAgentMDsInWorkspace(token);
 		} else {
 			return await this.fileLocator.findAgentMDsInWorkspaceRoots(token);

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/utils/promptFilesLocator.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/utils/promptFilesLocator.ts
@@ -11,7 +11,7 @@ import { getPromptFileLocationsConfigKey, PromptsConfig } from '../config/config
 import { basename, dirname, joinPath } from '../../../../../../base/common/resources.js';
 import { IWorkspaceContextService } from '../../../../../../platform/workspace/common/workspace.js';
 import { IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
-import { getPromptFileExtension, getPromptFileType } from '../config/promptFileLocations.js';
+import { COPILOT_CUSTOM_INSTRUCTIONS_FILENAME, getPromptFileExtension, getPromptFileType } from '../config/promptFileLocations.js';
 import { PromptsType } from '../promptTypes.js';
 import { IWorkbenchEnvironmentService } from '../../../../../services/environment/common/environmentService.js';
 import { Schemas } from '../../../../../../base/common/network.js';
@@ -275,7 +275,21 @@ export class PromptFilesLocator extends Disposable {
 		return [];
 	}
 
+	public async findCopilotInstructionsMDsInWorkspace(token: CancellationToken): Promise<URI[]> {
+		const result: URI[] = [];
+		const { folders } = this.workspaceService.getWorkspace();
+		for (const folder of folders) {
+			const file = joinPath(folder.uri, `.github/` + COPILOT_CUSTOM_INSTRUCTIONS_FILENAME);
+			if (await this.fileService.exists(file)) {
+				result.push(file);
+			}
+		}
+		return result;
+	}
 
+	/**
+	 * Gets list of `AGENTS.md` files anywhere in the workspace.
+	 */
 	public async findAgentMDsInWorkspace(token: CancellationToken): Promise<URI[]> {
 		const result = await Promise.all(this.workspaceService.getWorkspace().folders.map(folder => this.findAgentMDsInFolder(folder.uri, token)));
 		return result.flat(1);
@@ -304,6 +318,24 @@ export class PromptFilesLocator extends Disposable {
 		}
 		return [];
 
+	}
+
+	/**
+	 * Gets list of `AGENTS.md` files only at the root workspace folder(s).
+	 */
+	public async findAgentMDsInWorkspaceRoots(token: CancellationToken): Promise<URI[]> {
+		const result: URI[] = [];
+		const { folders } = this.workspaceService.getWorkspace();
+		const resolvedRoots = await this.fileService.resolveAll(folders.map(f => ({ resource: f.uri })));
+		for (const root of resolvedRoots) {
+			if (root.success && root.stat?.children) {
+				const agentMd = root.stat.children.find(c => c.isFile && c.name.toLowerCase() === 'agents.md');
+				if (agentMd) {
+					result.push(agentMd.resource);
+				}
+			}
+		}
+		return result;
 	}
 }
 

--- a/src/vs/workbench/contrib/chat/test/common/mockPromptsService.ts
+++ b/src/vs/workbench/contrib/chat/test/common/mockPromptsService.ts
@@ -46,6 +46,8 @@ export class MockPromptsService implements IPromptsService {
 	registerContributedFile(type: PromptsType, name: string, description: string, uri: URI, extension: IExtensionDescription): IDisposable { throw new Error('Not implemented'); }
 	getPromptLocationLabel(promptPath: IPromptPath): string { throw new Error('Not implemented'); }
 	findAgentMDsInWorkspace(token: CancellationToken): Promise<URI[]> { throw new Error('Not implemented'); }
+	listAgentMDs(token: CancellationToken): Promise<URI[]> { throw new Error('Not implemented'); }
+	listCopilotInstructionsMDs(token: CancellationToken): Promise<URI[]> { throw new Error('Not implemented'); }
 
 	dispose(): void { }
 }

--- a/src/vs/workbench/contrib/chat/test/common/promptSyntax/service/promptsService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/promptSyntax/service/promptsService.test.ts
@@ -58,6 +58,7 @@ suite('PromptsService', () => {
 		testConfigService.setUserConfiguration(PromptsConfig.KEY, true);
 		testConfigService.setUserConfiguration(PromptsConfig.USE_COPILOT_INSTRUCTION_FILES, true);
 		testConfigService.setUserConfiguration(PromptsConfig.USE_AGENT_MD, true);
+		testConfigService.setUserConfiguration(PromptsConfig.USE_NESTED_AGENT_MD, false);
 		testConfigService.setUserConfiguration(PromptsConfig.INSTRUCTIONS_LOCATION_KEY, { [INSTRUCTIONS_DEFAULT_SOURCE_FOLDER]: true });
 		testConfigService.setUserConfiguration(PromptsConfig.PROMPT_LOCATIONS_KEY, { [PROMPT_DEFAULT_SOURCE_FOLDER]: true });
 		testConfigService.setUserConfiguration(PromptsConfig.MODE_LOCATION_KEY, { [MODE_DEFAULT_SOURCE_FOLDER]: true });
@@ -701,7 +702,18 @@ suite('PromptsService', () => {
 								},
 							],
 						},
-
+						{
+							name: 'folder1',
+							children: [
+								// This will not be returned because we have PromptsConfig.USE_NESTED_AGENT_MD set to false.
+								{
+									name: 'AGENTS.md',
+									contents: [
+										'An AGENTS.md file in another repo'
+									]
+								}
+							]
+						}
 					],
 				}])).mock();
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Fixes issue where `copilot-instructions.md` and `AGENTS.md` weren't appearing in list of existing instruction files.

**Before the fix:**
Open the "Chat Instructions" dialog
<img width="338" height="256" alt="image" src="https://github.com/user-attachments/assets/b60afe62-5c4d-4015-8a0c-c0a3e835d553" />

No copilot-instructions.md or AGENTS.md files are shown in the dropdown, even though both `<root>/.github/copilot-instructions.md` and `<root>/AGENTS.md` exist:

<img width="1027" height="441" alt="image" src="https://github.com/user-attachments/assets/7eb9312b-2d36-4ebe-9dfa-e7a3ce3b0f1e" />

**After the fix:**

When it pops up, you will see that it now includes `copilot-instructions.md` files and `AGENTS.md` files. This is what it looks like with "Use Nested Agents Md Files" on, showing `copilot-instructions.md` as well as three `AGENTS.md` files, each one listing the relative directory it's in:
<img width="859" height="446" alt="image" src="https://github.com/user-attachments/assets/db9fb77d-d057-4dda-9439-e624e3c14c42" />

With "Use Nested Agents Md Files" off, it shows `copilot-instructions.md` and only the root `AGENTS.md` file:
<img width="856" height="443" alt="image" src="https://github.com/user-attachments/assets/ab176042-0a0b-47fb-abab-b9606635c09f" />

Note that the "Workspace" section of the dialog (in blue) has been renamed to ".github/instructions", and the new section is named "Agent Instructions" to match the nearby "Generate agent instructions..." button.

