### PR TITLE
Ensure restored terminal sessions are accounted for in `runInTerminal` tool

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart.ts
@@ -122,9 +122,12 @@ export class ChatTerminalToolProgressPart extends BaseChatToolInvocationSubPart 
 			this._registerInstanceListener(terminalInstance);
 			this._addFocusAction(terminalInstance, terminalToolSessionId);
 		} else {
-			const listener = this._register(this._terminalChatService.onDidRegisterTerminalInstanceWithToolSession(terminalInstance => {
-				this._registerInstanceListener(terminalInstance);
-				this._addFocusAction(terminalInstance, terminalToolSessionId);
+			const listener = this._register(this._terminalChatService.onDidRegisterTerminalInstanceWithToolSession(e => {
+				if (e.toolSessionId !== terminalToolSessionId) {
+					return;
+				}
+				this._registerInstanceListener(e.instance);
+				this._addFocusAction(e.instance, terminalToolSessionId);
 				this._store.delete(listener);
 			}));
 		}

--- a/src/vs/workbench/contrib/terminal/browser/terminal.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminal.ts
@@ -112,7 +112,7 @@ export interface ITerminalChatService {
 	 * Fired when a terminal instance is registered for a tool session id. This can happen after
 	 * the chat UI first renders, enabling late binding of the focus action.
 	 */
-	readonly onDidRegisterTerminalInstanceWithToolSession: Event<ITerminalInstance>;
+	readonly onDidRegisterTerminalInstanceWithToolSession: Event<{ toolSessionId: string; instance: ITerminalInstance }>;
 
 	/**
 	 * Associate a tool session id with a terminal instance. The association is automatically
@@ -126,6 +126,8 @@ export interface ITerminalChatService {
 	 * If no tool session ID is provided, we do nothing.
 	 */
 	getTerminalInstanceByToolSessionId(terminalToolSessionId: string): ITerminalInstance | undefined;
+
+	getToolSessionTerminalInstances(): readonly ITerminalInstance[];
 
 	isBackgroundTerminal(terminalToolSessionId: string): boolean;
 }

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/runInTerminalTool.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/runInTerminalTool.test.ts
@@ -73,9 +73,14 @@ suite('RunInTerminalTool', () => {
 		instantiationService.stub(ITerminalProfileResolverService, {
 			getDefaultProfile: async () => ({ path: 'pwsh' } as ITerminalProfile)
 		});
+		const terminalChatServiceEmitter = new Emitter<{ toolSessionId: string; instance: ITerminalInstance }>();
+		store.add(terminalChatServiceEmitter);
 		instantiationService.stub(ITerminalChatService, {
 			getToolSessionTerminalInstances: () => [],
-			onDidRegisterTerminalInstanceWithToolSession: new Emitter<any>().event
+			onDidRegisterTerminalInstanceWithToolSession: terminalChatServiceEmitter.event,
+			registerTerminalInstanceWithToolSession: () => { },
+			getTerminalInstanceByToolSessionId: () => undefined,
+			isBackgroundTerminal: () => false
 		});
 
 		storageService = instantiationService.get(IStorageService);

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/runInTerminalTool.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/runInTerminalTool.test.ts
@@ -15,7 +15,7 @@ import type { TestInstantiationService } from '../../../../../../platform/instan
 import { workbenchInstantiationService } from '../../../../../test/browser/workbenchTestServices.js';
 import { IChatService, type IChatTerminalToolInvocationData } from '../../../../chat/common/chatService.js';
 import { ILanguageModelToolsService, IPreparedToolInvocation, IToolInvocationPreparationContext, type ToolConfirmationAction } from '../../../../chat/common/languageModelToolsService.js';
-import { ITerminalService, type ITerminalInstance } from '../../../../terminal/browser/terminal.js';
+import { ITerminalChatService, ITerminalService, type ITerminalInstance } from '../../../../terminal/browser/terminal.js';
 import { ITerminalProfileResolverService } from '../../../../terminal/common/terminal.js';
 import { RunInTerminalTool, type IRunInTerminalInputParams } from '../../browser/tools/runInTerminalTool.js';
 import { ShellIntegrationQuality } from '../../browser/toolTerminalCreator.js';
@@ -72,6 +72,9 @@ suite('RunInTerminalTool', () => {
 		});
 		instantiationService.stub(ITerminalProfileResolverService, {
 			getDefaultProfile: async () => ({ path: 'pwsh' } as ITerminalProfile)
+		});
+		instantiationService.stub(ITerminalChatService, {
+			getToolSessionTerminalInstances: () => []
 		});
 
 		storageService = instantiationService.get(IStorageService);

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/runInTerminalTool.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/runInTerminalTool.test.ts
@@ -74,7 +74,8 @@ suite('RunInTerminalTool', () => {
 			getDefaultProfile: async () => ({ path: 'pwsh' } as ITerminalProfile)
 		});
 		instantiationService.stub(ITerminalChatService, {
-			getToolSessionTerminalInstances: () => []
+			getToolSessionTerminalInstances: () => [],
+			onDidRegisterTerminalInstanceWithToolSession: new Emitter<any>().event
 		});
 
 		storageService = instantiationService.get(IStorageService);


### PR DESCRIPTION
fix #271964

Now that we persist terminals in `terminalChatService`, we need to be sure that the `RunInTerminal` tool's associations are updated.

It would be good to eventually just have the `RunInTerminalTool` pull from `terminalChatService`.