### PR TITLE
Fix editor tabs disappearance issue while loading Copilot chat items

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatEditor.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditor.ts
@@ -79,7 +79,7 @@ export class ChatEditor extends EditorPane {
 	protected override createEditor(parent: HTMLElement): void {
 		this._editorContainer = parent;
 		// Ensure the container has position relative for the loading overlay
-		parent.style.position = 'relative';
+		parent.classList.add('chat-editor-relative');
 		this._scopedContextKeyService = this._register(this.contextKeyService.createScoped(parent));
 		const scopedInstantiationService = this._register(this.instantiationService.createChild(new ServiceCollection([IContextKeyService, this.scopedContextKeyService])));
 		ChatContextKeys.inChatEditor.bindTo(this._scopedContextKeyService).set(true);

--- a/src/vs/workbench/contrib/chat/browser/chatEditor.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditor.ts
@@ -78,6 +78,8 @@ export class ChatEditor extends EditorPane {
 
 	protected override createEditor(parent: HTMLElement): void {
 		this._editorContainer = parent;
+		// Ensure the container has position relative for the loading overlay
+		parent.style.position = 'relative';
 		this._scopedContextKeyService = this._register(this.contextKeyService.createScoped(parent));
 		const scopedInstantiationService = this._register(this.instantiationService.createChild(new ServiceCollection([IContextKeyService, this.scopedContextKeyService])));
 		ChatContextKeys.inChatEditor.bindTo(this._scopedContextKeyService).set(true);
@@ -178,8 +180,17 @@ export class ChatEditor extends EditorPane {
 	}
 
 	override async setInput(input: ChatEditorInput, options: IChatEditorOptions | undefined, context: IEditorOpenContext, token: CancellationToken): Promise<void> {
+		// Show loading indicator early for non-local sessions to prevent layout shifts
+		let isContributedChatSession = false;
+		const chatSessionType = getChatSessionType(input);
+		if (chatSessionType !== 'local') {
+			const loadingMessage = nls.localize('chatEditor.loadingSession', "Loading...");
+			this.showLoadingInChatWidget(loadingMessage);
+		}
+
 		await super.setInput(input, options, context, token);
 		if (token.isCancellationRequested) {
+			this.hideLoadingInChatWidget();
 			return;
 		}
 
@@ -187,13 +198,7 @@ export class ChatEditor extends EditorPane {
 			throw new Error('ChatEditor lifecycle issue: no editor widget');
 		}
 
-		let isContributedChatSession = false;
-		const chatSessionType = getChatSessionType(input);
 		if (chatSessionType !== 'local') {
-			// Show single loading state for contributed sessions
-			const loadingMessage = nls.localize('chatEditor.loadingSession', "Loading...");
-			this.showLoadingInChatWidget(loadingMessage);
-
 			try {
 				await raceCancellationError(this.chatSessionsService.canResolveContentProvider(chatSessionType), token);
 				const contributions = this.chatSessionsService.getAllChatSessionContributions();

--- a/src/vs/workbench/contrib/chat/browser/media/chatSessions.css
+++ b/src/vs/workbench/contrib/chat/browser/media/chatSessions.css
@@ -261,6 +261,11 @@
 	background-color: var(--vscode-list-hoverBackground);
 }
 
+/* Chat editor relative positioning for loading overlay */
+.chat-editor-relative {
+	position: relative;
+}
+
 /* Chat editor loading overlay styles */
 .chat-loading-overlay {
 	position: absolute;


### PR DESCRIPTION
Fixes #271997
Fixes an issue where editor tabs would temporarily disappear while loading a GitHub Copilot coding agent session from the sidebar. Caused because loading overlay was being added to the editor container AFTER super.setInput() was called. This meant the editor pane was already being manipulated in the DOM (shown, positioned, laid out) before the loading indicator was present, triggering layout recalculations that affected the tab bar rendering.