### PR TITLE
Support slash commands for silent agent selection (such as chat editors created for a specific agent)

### DIFF
--- a/src/vs/workbench/contrib/chat/common/chatRequestParser.ts
+++ b/src/vs/workbench/contrib/chat/common/chatRequestParser.ts
@@ -206,8 +206,9 @@ export class ChatRequestParser {
 		const slashRange = new OffsetRange(offset, offset + full.length);
 		const slashEditorRange = new Range(position.lineNumber, position.column, position.lineNumber, position.column + full.length);
 
-		const usedAgent = parts.find((p): p is ChatRequestAgentPart => p instanceof ChatRequestAgentPart)?.agent ??
-			(context?.forcedAgent ? context.forcedAgent : undefined);
+		const usedAgent = parts.find((p): p is ChatRequestAgentPart => p instanceof
+			ChatRequestAgentPart)?.agent ??
+			context?.forcedAgent ?? context?.selectedAgent ?? undefined;
 		if (usedAgent) {
 			const subCommand = usedAgent.slashCommands.find(c => c.name === command);
 			if (subCommand) {

--- a/src/vs/workbench/contrib/chat/common/chatServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/chatServiceImpl.ts
@@ -674,6 +674,12 @@ export class ChatService extends Disposable implements IChatService {
 			parserContext = { selectedAgent: agent, mode: options.modeInfo?.kind };
 			const commandPart = options.slashCommand ? ` ${chatSubcommandLeader}${options.slashCommand}` : '';
 			request = `${chatAgentLeader}${agent.name}${commandPart} ${request}`;
+		} else if (options?.agentIdSilent) {
+			const agent = this.chatAgentService.getAgent(options.agentIdSilent);
+			if (!agent) {
+				throw new Error(`Unknown agent: ${options.agentIdSilent}`);
+			}
+			parserContext = { selectedAgent: agent, mode: options.modeInfo?.kind };
 		}
 
 		const parsedRequest = this.instantiationService.createInstance(ChatRequestParser).parseChatRequest(sessionId, request, location, parserContext);


### PR DESCRIPTION
This will allow users to see the list of commands in the chat input.
On the extension side we can add this back to the prompt if required (e.g. the cli tools.)

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
For #270852
For microsoft/vscode-internalbacklog#5982