### PR TITLE
Don't imply appearance via style

### DIFF
--- a/src/vs/editor/browser/services/hoverService/hoverWidget.ts
+++ b/src/vs/editor/browser/services/hoverService/hoverWidget.ts
@@ -112,8 +112,6 @@ export class HoverWidget extends Widget implements IHoverWidget {
 					options.appearance ??= {};
 					options.appearance.compact ??= true;
 					options.appearance.showPointer ??= true;
-					options.position ??= {};
-					options.position.hoverPosition ??= HoverPosition.BELOW;
 					break;
 				}
 				case HoverStyle.Mouse: {


### PR DESCRIPTION
Position should be determined through the regular mechanism. Top is actually better generally as there's less change it will be obscured by the cursor.

Part of #243348
Part of #270314

Before

<img width="508" height="117" alt="image" src="https://github.com/user-attachments/assets/261c4b86-f7df-408d-84b4-3efdac69f9c4" />

After

<img width="902" height="170" alt="image" src="https://github.com/user-attachments/assets/4a782585-5d22-4ad8-a2db-224a73ec841d" />
