### PR TITLE
Adjust extension badge positioning in extension list items

### DIFF
--- a/src/vs/workbench/contrib/extensions/browser/media/extension.css
+++ b/src/vs/workbench/contrib/extensions/browser/media/extension.css
@@ -28,7 +28,7 @@
 
 .extension-list-item > .icon-container .extension-badge {
 	position: absolute;
-	bottom: 9px;
+	bottom: 10px;
 	left: -8px;
 }
 

--- a/src/vs/workbench/contrib/extensions/browser/media/extension.css
+++ b/src/vs/workbench/contrib/extensions/browser/media/extension.css
@@ -28,7 +28,8 @@
 
 .extension-list-item > .icon-container .extension-badge {
 	position: absolute;
-	bottom: 5px;
+	bottom: 9px;
+	left: -8px;
 }
 
 .extension-list-item > .icon-container .extension-badge.extension-icon-badge {


### PR DESCRIPTION
Modify the positioning of the extension badge to improve its alignment within the extension list items.

Before:
<img width="424" height="94" alt="image" src="https://github.com/user-attachments/assets/49e552b6-7caa-4227-ad32-5578b93a0d3c" />


After:
<img width="336" height="89" alt="image" src="https://github.com/user-attachments/assets/86efe97c-f0f4-40cd-9280-0505ba4f5a66" />
