### PR TITLE
fix(chat): guard against undefined customModes.custom Fix #272223 and #272236

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/modelPicker/modePickerActionItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/modelPicker/modePickerActionItem.ts
@@ -89,7 +89,7 @@ export class ModePickerActionItem extends ActionWidgetDropdownActionViewItem {
 					agentMode && makeAction(agentMode, currentMode),
 					...customBuiltinModeActions,
 					...otherBuiltinModes.map(mode => mode && makeAction(mode, currentMode)),
-					...customModes.custom.map(mode => makeActionFromCustomMode(mode, currentMode))
+					...customModes.custom?.map(mode => makeActionFromCustomMode(mode, currentMode)) ?? []
 				]);
 
 				return orderedModes;


### PR DESCRIPTION
Guard against undefined customModes.custom. Fix #272223 and #272236
