### PR TITLE
Make pair colorizer ignore \@ifnextchar

### DIFF
--- a/extensions/latex/cgmanifest.json
+++ b/extensions/latex/cgmanifest.json
@@ -6,7 +6,7 @@
 				"git": {
 					"name": "jlelong/vscode-latex-basics",
 					"repositoryUrl": "https://github.com/jlelong/vscode-latex-basics",
-					"commitHash": "84ce12aa6be384369ff218ac25efb27e6f34e78c"
+					"commitHash": "ca85e20304afcb5c6a28a6e0b9fc1ead8f124001"
 				}
 			},
 			"license": "MIT",

--- a/extensions/latex/package.json
+++ b/extensions/latex/package.json
@@ -72,6 +72,9 @@
         "language": "latex",
         "scopeName": "text.tex.latex",
         "path": "./syntaxes/LaTeX.tmLanguage.json",
+        "unbalancedBracketScopes": [
+          "keyword.control.ifnextchar.tex"
+        ],
         "embeddedLanguages": {
           "source.cpp": "cpp_embedded_latex",
           "source.css": "css",

--- a/extensions/latex/syntaxes/TeX.tmLanguage.json
+++ b/extensions/latex/syntaxes/TeX.tmLanguage.json
@@ -4,7 +4,7 @@
 		"If you want to provide a fix or improvement, please create a pull request against the original repository.",
 		"Once accepted there, we are happy to receive an update request."
 	],
-	"version": "https://github.com/jlelong/vscode-latex-basics/commit/6bd99800f7b2cbd0e36cecb56fe1936da5affadb",
+	"version": "https://github.com/jlelong/vscode-latex-basics/commit/ca85e20304afcb5c6a28a6e0b9fc1ead8f124001",
 	"name": "TeX",
 	"scopeName": "text.tex",
 	"patterns": [
@@ -30,6 +30,9 @@
 		{
 			"match": "\\\\\\\\",
 			"name": "keyword.control.newline.tex"
+		},
+		{
+			"include": "#ifnextchar"
 		},
 		{
 			"include": "#macro-general"
@@ -85,6 +88,10 @@
 					"include": "#conditionals"
 				}
 			]
+		},
+		"ifnextchar": {
+			"match": "\\\\@ifnextchar[(\\{\\[]",
+			"name": "keyword.control.ifnextchar.tex"
 		},
 		"macro-control": {
 			"match": "(\\\\)(backmatter|csname|else|endcsname|fi|frontmatter|mainmatter|unless|if(case|cat|csname|defined|dim|eof|false|fontchar|hbox|hmode|inner|mmode|num|odd|true|vbox|vmode|void|x)?)(?![a-zA-Z@])",

--- a/extensions/latex/syntaxes/TeX.tmLanguage.json
+++ b/extensions/latex/syntaxes/TeX.tmLanguage.json
@@ -90,7 +90,7 @@
 			]
 		},
 		"ifnextchar": {
-			"match": "\\\\@ifnextchar[(\\{\\[]",
+			"match": "\\\\@ifnextchar[({\\[]",
 			"name": "keyword.control.ifnextchar.tex"
 		},
 		"macro-control": {


### PR DESCRIPTION
This PR fixes https://github.com/jlelong/vscode-latex-basics/issues/123. It prevents the bracket pair colorizer to be misled by `\@ifnextchar{`, `\@ifnextchar(` and `\@ifnextchar[`.