### PR TITLE
chat: refactor into `IChatToolInvocation.state`

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/actions/chatToolActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatToolActions.ts
@@ -54,9 +54,12 @@ abstract class ToolConfirmationAction extends Action2 {
 			return;
 		}
 
-		const unconfirmedToolInvocation = lastItem.model.response.value.find((item): item is IChatToolInvocation => item.kind === 'toolInvocation' && item.isConfirmed === undefined);
-		if (unconfirmedToolInvocation) {
-			unconfirmedToolInvocation.confirmed.complete(this.getReason());
+		for (const item of lastItem.model.response.value) {
+			const state = item.kind === 'toolInvocation' ? item.state.get() : undefined;
+			if (state?.type === IChatToolInvocation.StateKind.WaitingForConfirmation) {
+				state.confirm(this.getReason());
+				break;
+			}
 		}
 
 		// Return focus to the chat input, in case it was in the tool confirmation editor

--- a/src/vs/workbench/contrib/chat/browser/chatAccessibilityProvider.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatAccessibilityProvider.ts
@@ -85,7 +85,7 @@ export class ChatAccessibilityProvider implements IListAccessibilityProvider<Cha
 		const toolInvocation = element.response.value.filter(v => v.kind === 'toolInvocation');
 		let toolInvocationHint = '';
 		if (toolInvocation.length) {
-			const waitingForConfirmation = toolInvocation.filter(v => !v.isComplete);
+			const waitingForConfirmation = toolInvocation.filter(v => v.state.get().type === IChatToolInvocation.StateKind.WaitingForConfirmation);
 			if (waitingForConfirmation.length) {
 				toolInvocationHint = this._instantiationService.invokeFunction(getToolConfirmationAlert, toolInvocation);
 			}

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatInputOutputMarkdownProgressPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatInputOutputMarkdownProgressPart.ts
@@ -136,15 +136,15 @@ export class ChatInputOutputMarkdownProgressPart extends BaseChatToolInvocationS
 		this._register(collapsibleListPart.onDidChangeHeight(() => this._onDidChangeHeight.fire()));
 		this._register(toDisposable(() => ChatInputOutputMarkdownProgressPart._expandedByDefault.set(toolInvocation, collapsibleListPart.expanded)));
 
-		const progressObservable = toolInvocation.kind === 'toolInvocation' ? toolInvocation.progress : undefined;
+		const progressObservable = toolInvocation.kind === 'toolInvocation' ? toolInvocation.state.map((s, r) => s.type === IChatToolInvocation.StateKind.Executing ? s.progress.read(r) : undefined) : undefined;
 		const progressBar = new Lazy(() => this._register(new ProgressBar(collapsibleListPart.domNode)));
 		if (progressObservable) {
 			this._register(autorun(reader => {
 				const progress = progressObservable?.read(reader);
-				if (progress.message) {
+				if (progress?.message) {
 					collapsibleListPart.title = progress.message;
 				}
-				if (progress.progress && !toolInvocation.isComplete) {
+				if (progress?.progress && !IChatToolInvocation.isComplete(toolInvocation, reader)) {
 					progressBar.value.setWorked(progress.progress * 100);
 				}
 			}));

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatToolInvocationPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatToolInvocationPart.ts
@@ -74,7 +74,7 @@ export class ChatToolInvocationPart extends Disposable implements IChatContentPa
 			dom.clearNode(this.domNode);
 			partStore.clear();
 
-			if (toolInvocation.presentation === ToolInvocationPresentation.HiddenAfterComplete && toolInvocation.isComplete) {
+			if (toolInvocation.presentation === ToolInvocationPresentation.HiddenAfterComplete && IChatToolInvocation.isComplete(toolInvocation)) {
 				return;
 			}
 
@@ -98,7 +98,7 @@ export class ChatToolInvocationPart extends Disposable implements IChatContentPa
 	}
 
 	private get autoApproveMessageContent() {
-		const reason = this.toolInvocation.isConfirmed;
+		const reason = IChatToolInvocation.isConfirmed(this.toolInvocation);
 		if (!reason || typeof reason === 'boolean') {
 			return;
 		}
@@ -146,7 +146,7 @@ export class ChatToolInvocationPart extends Disposable implements IChatContentPa
 			if (this.toolInvocation.toolSpecificData?.kind === 'extensions') {
 				return this.instantiationService.createInstance(ExtensionsInstallConfirmationWidgetSubPart, this.toolInvocation, this.context);
 			}
-			if (this.toolInvocation.confirmationMessages) {
+			if (this.toolInvocation.state.get().type === IChatToolInvocation.StateKind.WaitingForConfirmation) {
 				if (this.toolInvocation.toolSpecificData?.kind === 'terminal') {
 					return this.instantiationService.createInstance(ChatTerminalToolConfirmationSubPart, this.toolInvocation, this.toolInvocation.toolSpecificData, this.context, this.renderer, this.editorPool, this.currentWidthDelegate, this.codeBlockModelCollection, this.codeBlockStartIndex);
 				} else {
@@ -159,15 +159,16 @@ export class ChatToolInvocationPart extends Disposable implements IChatContentPa
 			return this.instantiationService.createInstance(ChatTerminalToolProgressPart, this.toolInvocation, this.toolInvocation.toolSpecificData, this.context, this.renderer, this.editorPool, this.currentWidthDelegate, this.codeBlockStartIndex, this.codeBlockModelCollection);
 		}
 
-		if (Array.isArray(this.toolInvocation.resultDetails) && this.toolInvocation.resultDetails?.length) {
-			return this.instantiationService.createInstance(ChatResultListSubPart, this.toolInvocation, this.context, this.toolInvocation.pastTenseMessage ?? this.toolInvocation.invocationMessage, this.toolInvocation.resultDetails, this.listPool);
+		const resultDetails = IChatToolInvocation.resultDetails(this.toolInvocation);
+		if (Array.isArray(resultDetails) && resultDetails.length) {
+			return this.instantiationService.createInstance(ChatResultListSubPart, this.toolInvocation, this.context, this.toolInvocation.pastTenseMessage ?? this.toolInvocation.invocationMessage, resultDetails, this.listPool);
 		}
 
-		if (isToolResultOutputDetails(this.toolInvocation.resultDetails)) {
+		if (isToolResultOutputDetails(resultDetails)) {
 			return this.instantiationService.createInstance(ChatToolOutputSubPart, this.toolInvocation, this.context);
 		}
 
-		if (isToolResultInputOutputDetails(this.toolInvocation.resultDetails)) {
+		if (isToolResultInputOutputDetails(resultDetails)) {
 			return this.instantiationService.createInstance(
 				ChatInputOutputMarkdownProgressPart,
 				this.toolInvocation,
@@ -176,14 +177,14 @@ export class ChatToolInvocationPart extends Disposable implements IChatContentPa
 				this.codeBlockStartIndex,
 				this.toolInvocation.pastTenseMessage ?? this.toolInvocation.invocationMessage,
 				this.toolInvocation.originMessage,
-				this.toolInvocation.resultDetails.input,
-				this.toolInvocation.resultDetails.output,
-				!!this.toolInvocation.resultDetails.isError,
+				resultDetails.input,
+				resultDetails.output,
+				!!resultDetails.isError,
 				this.currentWidthDelegate
 			);
 		}
 
-		if (this.toolInvocation.kind === 'toolInvocation' && this.toolInvocation.toolSpecificData?.kind === 'input' && !this.toolInvocation.isComplete) {
+		if (this.toolInvocation.kind === 'toolInvocation' && this.toolInvocation.toolSpecificData?.kind === 'input' && !IChatToolInvocation.isComplete(this.toolInvocation)) {
 			return this.instantiationService.createInstance(
 				ChatInputOutputMarkdownProgressPart,
 				this.toolInvocation,

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatToolOutputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatToolOutputPart.ts
@@ -48,7 +48,7 @@ export class ChatToolOutputSubPart extends BaseChatToolInvocationSubPart {
 		super(toolInvocation);
 
 		const details: IToolResultOutputDetails = toolInvocation.kind === 'toolInvocation'
-			? toolInvocation.resultDetails as IToolResultOutputDetails
+			? IChatToolInvocation.resultDetails(toolInvocation) as IToolResultOutputDetails
 			: {
 				output: {
 					type: 'data',

--- a/src/vs/workbench/contrib/chat/browser/chatListRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatListRenderer.ts
@@ -778,8 +778,8 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 		if (
 			!lastPart ||
 			lastPart.kind === 'references' || lastPart.kind === 'thinking' ||
-			((lastPart.kind === 'toolInvocation' || lastPart.kind === 'toolInvocationSerialized') && (lastPart.isComplete || lastPart.presentation === 'hidden')) ||
-			((lastPart.kind === 'textEditGroup' || lastPart.kind === 'notebookEditGroup') && lastPart.done && !partsToRender.some(part => part.kind === 'toolInvocation' && !part.isComplete)) ||
+			((lastPart.kind === 'toolInvocation' || lastPart.kind === 'toolInvocationSerialized') && (IChatToolInvocation.isComplete(lastPart) || lastPart.presentation === 'hidden')) ||
+			((lastPart.kind === 'textEditGroup' || lastPart.kind === 'notebookEditGroup') && lastPart.done && !partsToRender.some(part => part.kind === 'toolInvocation' && !IChatToolInvocation.isComplete(part))) ||
 			(lastPart.kind === 'progressTask' && lastPart.deferred.isSettled) ||
 			lastPart.kind === 'prepareToolInvocation' || lastPart.kind === 'mcpServersStarting'
 		) {

--- a/src/vs/workbench/contrib/chat/browser/chatResponseAccessibleView.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatResponseAccessibleView.ts
@@ -110,7 +110,7 @@ class ChatResponseAccessibleProvider extends Disposable implements IAccessibleVi
 				} else {
 					const resultDetails = IChatToolInvocation.resultDetails(toolInvocation);
 					if (resultDetails && 'input' in resultDetails) {
-						responseContent += '\n' + resultDetails.isError ? 'Errored ' : 'Completed ';
+						responseContent += '\n' + (resultDetails.isError ? 'Errored ' : 'Completed ');
 						responseContent += `${`${typeof toolInvocation.invocationMessage === 'string' ? toolInvocation.invocationMessage : stripIcons(renderAsPlaintext(toolInvocation.invocationMessage))} with input: ${resultDetails.input}`}\n`;
 					}
 				}

--- a/src/vs/workbench/contrib/chat/browser/chatResponseAccessibleView.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatResponseAccessibleView.ts
@@ -13,6 +13,7 @@ import { ServicesAccessor } from '../../../../platform/instantiation/common/inst
 import { AccessibilityVerbositySettingId } from '../../accessibility/browser/accessibilityConfiguration.js';
 import { migrateLegacyTerminalToolSpecificData } from '../common/chat.js';
 import { ChatContextKeys } from '../common/chatContextKeys.js';
+import { IChatToolInvocation } from '../common/chatService.js';
 import { isResponseVM } from '../common/chatViewModel.js';
 import { ChatTreeItem, IChatWidget, IChatWidgetService } from './chat.js';
 
@@ -83,7 +84,7 @@ class ChatResponseAccessibleProvider extends Disposable implements IAccessibleVi
 			});
 			const toolInvocations = item.response.value.filter(item => item.kind === 'toolInvocation');
 			for (const toolInvocation of toolInvocations) {
-				if (toolInvocation.confirmationMessages) {
+				if (toolInvocation.confirmationMessages && toolInvocation.state.get().type === IChatToolInvocation.StateKind.WaitingForConfirmation) {
 					const title = typeof toolInvocation.confirmationMessages.title === 'string' ? toolInvocation.confirmationMessages.title : toolInvocation.confirmationMessages.title.value;
 					const message = typeof toolInvocation.confirmationMessages.message === 'string' ? toolInvocation.confirmationMessages.message : stripIcons(renderAsPlaintext(toolInvocation.confirmationMessages.message));
 					let input = '';
@@ -106,9 +107,12 @@ class ChatResponseAccessibleProvider extends Disposable implements IAccessibleVi
 						responseContent += `: ${input}`;
 					}
 					responseContent += `\n${message}\n`;
-				} else if (toolInvocation.isComplete && toolInvocation.resultDetails && 'input' in toolInvocation.resultDetails) {
-					responseContent += '\n' + toolInvocation.resultDetails.isError ? 'Errored ' : 'Completed ';
-					responseContent += `${`${typeof toolInvocation.invocationMessage === 'string' ? toolInvocation.invocationMessage : stripIcons(renderAsPlaintext(toolInvocation.invocationMessage))} with input: ${toolInvocation.resultDetails.input}`}\n`;
+				} else {
+					const resultDetails = IChatToolInvocation.resultDetails(toolInvocation);
+					if (resultDetails && 'input' in resultDetails) {
+						responseContent += '\n' + resultDetails.isError ? 'Errored ' : 'Completed ';
+						responseContent += `${`${typeof toolInvocation.invocationMessage === 'string' ? toolInvocation.invocationMessage : stripIcons(renderAsPlaintext(toolInvocation.invocationMessage))} with input: ${resultDetails.input}`}\n`;
+					}
 				}
 			}
 

--- a/src/vs/workbench/contrib/chat/common/chatModel.ts
+++ b/src/vs/workbench/contrib/chat/common/chatModel.ts
@@ -12,7 +12,7 @@ import { ResourceMap } from '../../../../base/common/map.js';
 import { revive } from '../../../../base/common/marshalling.js';
 import { Schemas } from '../../../../base/common/network.js';
 import { equals } from '../../../../base/common/objects.js';
-import { IObservable, ObservablePromise, observableFromEvent, observableSignalFromEvent } from '../../../../base/common/observable.js';
+import { IObservable, ObservablePromise, autorunSelfDisposable, observableFromEvent, observableSignalFromEvent } from '../../../../base/common/observable.js';
 import { basename, isEqual } from '../../../../base/common/resources.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
 import { URI, UriComponents, UriDto, isUriComponents } from '../../../../base/common/uri.js';
@@ -492,10 +492,11 @@ class AbstractResponse implements IResponse {
 		}
 
 		// For completed tool invocations, also include the result details if available
-		if (toolInvocation.kind === 'toolInvocationSerialized' || (toolInvocation.kind === 'toolInvocation' && toolInvocation.isComplete)) {
-			if (toolInvocation.resultDetails && 'input' in toolInvocation.resultDetails) {
-				const resultPrefix = toolInvocation.kind === 'toolInvocationSerialized' || toolInvocation.isComplete ? 'Completed' : 'Errored';
-				text += `\n${resultPrefix} with input: ${toolInvocation.resultDetails.input}`;
+		if (toolInvocation.kind === 'toolInvocationSerialized' || (toolInvocation.kind === 'toolInvocation' && IChatToolInvocation.isComplete(toolInvocation))) {
+			const resultDetails = IChatToolInvocation.resultDetails(toolInvocation);
+			if (resultDetails && 'input' in resultDetails) {
+				const resultPrefix = toolInvocation.kind === 'toolInvocationSerialized' || IChatToolInvocation.isComplete(toolInvocation) ? 'Completed' : 'Errored';
+				text += `\n${resultPrefix} with input: ${resultDetails.input}`;
 			}
 		}
 
@@ -680,13 +681,13 @@ export class Response extends AbstractResponse implements IDisposable {
 			});
 
 		} else if (progress.kind === 'toolInvocation') {
-			if (progress.confirmationMessages) {
-				progress.confirmed.p.then(() => {
-					this._updateRepr(false);
-				});
-			}
-			progress.isCompletePromise.then(() => {
+			autorunSelfDisposable(reader => {
+				progress.state.read(reader); // update repr when state changes
 				this._updateRepr(false);
+
+				if (IChatToolInvocation.isComplete(progress, reader)) {
+					reader.dispose();
+				}
 			});
 			this._responseParts.push(progress);
 			this._updateRepr(quiet);
@@ -908,7 +909,7 @@ export class ChatResponseModel extends Disposable implements IChatResponseModel 
 			signal.read(r);
 
 			return this._response.value.some(part =>
-				part.kind === 'toolInvocation' && part.isConfirmed === undefined
+				part.kind === 'toolInvocation' && part.state.read(r).type === IChatToolInvocation.StateKind.WaitingForConfirmation
 				|| part.kind === 'confirmation' && part.isUsed === false
 			);
 		});

--- a/src/vs/workbench/contrib/chat/common/chatProgressTypes/chatToolInvocation.ts
+++ b/src/vs/workbench/contrib/chat/common/chatProgressTypes/chatToolInvocation.ts
@@ -3,45 +3,20 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { DeferredPromise } from '../../../../../base/common/async.js';
 import { encodeBase64 } from '../../../../../base/common/buffer.js';
 import { IMarkdownString } from '../../../../../base/common/htmlContent.js';
-import { observableValue } from '../../../../../base/common/observable.js';
+import { IObservable, ISettableObservable, observableValue } from '../../../../../base/common/observable.js';
 import { localize } from '../../../../../nls.js';
-import { ConfirmedReason, IChatExtensionsContent, IChatTodoListContent, IChatToolInputInvocationData, IChatToolInvocation, IChatToolInvocationSerialized, ToolConfirmKind, type IChatTerminalToolInvocationData } from '../chatService.js';
+import { IChatExtensionsContent, IChatTodoListContent, IChatToolInputInvocationData, IChatToolInvocation, IChatToolInvocationSerialized, ToolConfirmKind, type IChatTerminalToolInvocationData } from '../chatService.js';
 import { IPreparedToolInvocation, isToolResultOutputDetails, IToolConfirmationMessages, IToolData, IToolProgressStep, IToolResult, ToolDataSource } from '../languageModelToolsService.js';
 
 export class ChatToolInvocation implements IChatToolInvocation {
 	public readonly kind: 'toolInvocation' = 'toolInvocation';
 
-	private _isComplete = false;
-	public get isComplete(): boolean {
-		return this._isComplete;
-	}
-
-	private _isCompleteDeferred = new DeferredPromise<void>();
-	public get isCompletePromise(): Promise<void> {
-		return this._isCompleteDeferred.p;
-	}
-
-	private _confirmDeferred = new DeferredPromise<ConfirmedReason>();
-	public get confirmed() {
-		return this._confirmDeferred;
-	}
-
-	public get isConfirmed(): ConfirmedReason | undefined {
-		return this._confirmDeferred.value;
-	}
-
-	private _resultDetails: IToolResult['toolResultDetails'] | undefined;
-	public get resultDetails(): IToolResult['toolResultDetails'] | undefined {
-		return this._resultDetails;
-	}
-
 	public readonly invocationMessage: string | IMarkdownString;
 	public readonly originMessage: string | IMarkdownString | undefined;
 	public pastTenseMessage: string | IMarkdownString | undefined;
-	private _confirmationMessages: IToolConfirmationMessages | undefined;
+	public confirmationMessages: IToolConfirmationMessages | undefined;
 	public readonly presentation: IPreparedToolInvocation['presentation'];
 	public readonly toolId: string;
 	public readonly source: ToolDataSource;
@@ -49,7 +24,13 @@ export class ChatToolInvocation implements IChatToolInvocation {
 
 	public readonly toolSpecificData?: IChatTerminalToolInvocationData | IChatToolInputInvocationData | IChatExtensionsContent | IChatTodoListContent;
 
-	public readonly progress = observableValue<{ message?: string | IMarkdownString; progress: number }>(this, { progress: 0 });
+	private readonly _progress = observableValue<{ message?: string | IMarkdownString; progress: number | undefined }>(this, { progress: 0 });
+	private readonly _state: ISettableObservable<IChatToolInvocation.State>;
+
+	public get state(): IObservable<IChatToolInvocation.State> {
+		return this._state;
+	}
+
 
 	constructor(preparedInvocation: IPreparedToolInvocation | undefined, toolData: IToolData, public readonly toolCallId: string, fromSubAgent: boolean | undefined) {
 		const defaultMessage = localize('toolInvocationMessage', "Using {0}", `"${toolData.displayName}"`);
@@ -57,61 +38,66 @@ export class ChatToolInvocation implements IChatToolInvocation {
 		this.invocationMessage = invocationMessage;
 		this.pastTenseMessage = preparedInvocation?.pastTenseMessage;
 		this.originMessage = preparedInvocation?.originMessage;
-		this._confirmationMessages = preparedInvocation?.confirmationMessages;
+		this.confirmationMessages = preparedInvocation?.confirmationMessages;
 		this.presentation = preparedInvocation?.presentation;
 		this.toolSpecificData = preparedInvocation?.toolSpecificData;
 		this.toolId = toolData.id;
 		this.source = toolData.source;
 		this.fromSubAgent = fromSubAgent;
 
-		if (!this._confirmationMessages) {
-			// No confirmation needed
-			this._confirmDeferred.complete({ type: ToolConfirmKind.ConfirmationNotNeeded });
+		if (!this.confirmationMessages) {
+			this._state = observableValue(this, { type: IChatToolInvocation.StateKind.Executing, confirmed: { type: ToolConfirmKind.ConfirmationNotNeeded }, progress: this._progress });
+		} else {
+			this._state = observableValue(this, {
+				type: IChatToolInvocation.StateKind.WaitingForConfirmation,
+				confirm: reason => {
+					if (reason.type === ToolConfirmKind.Denied || reason.type === ToolConfirmKind.Skipped) {
+						this._state.set({ type: IChatToolInvocation.StateKind.Cancelled, reason: reason.type }, undefined);
+					} else {
+						this._state.set({ type: IChatToolInvocation.StateKind.Executing, confirmed: reason, progress: this._progress }, undefined);
+					}
+				}
+			});
 		}
-
-		this._confirmDeferred.p.then(() => {
-			this._confirmationMessages = undefined;
-		});
-
-		this._isCompleteDeferred.p.then(() => {
-			this._isComplete = true;
-		});
 	}
 
 	public complete(result: IToolResult | undefined): void {
 		if (result?.toolResultMessage) {
 			this.pastTenseMessage = result.toolResultMessage;
+		} else if (this._progress.get().message) {
+			this.pastTenseMessage = this._progress.get().message;
 		}
 
-		this._resultDetails = result?.toolResultDetails;
-		this._isCompleteDeferred.complete();
-	}
-
-	public get confirmationMessages(): IToolConfirmationMessages | undefined {
-		return this._confirmationMessages;
+		this._state.set({
+			type: IChatToolInvocation.StateKind.Completed,
+			confirmed: IChatToolInvocation.isConfirmed(this) || { type: ToolConfirmKind.UserAction },
+			resultDetails: result?.toolResultDetails,
+			postConfirmed: undefined,
+		}, undefined);
 	}
 
 	public acceptProgress(step: IToolProgressStep) {
-		const prev = this.progress.get();
-		this.progress.set({
+		const prev = this._progress.get();
+		this._progress.set({
 			progress: step.progress || prev.progress || 0,
 			message: step.message,
 		}, undefined);
 	}
 
 	public toJSON(): IChatToolInvocationSerialized {
+		const details = IChatToolInvocation.resultDetails(this);
 		return {
 			kind: 'toolInvocationSerialized',
 			presentation: this.presentation,
 			invocationMessage: this.invocationMessage,
 			pastTenseMessage: this.pastTenseMessage,
 			originMessage: this.originMessage,
-			isConfirmed: this._confirmDeferred.value,
+			isConfirmed: IChatToolInvocation.isConfirmed(this),
 			isComplete: true,
 			source: this.source,
-			resultDetails: isToolResultOutputDetails(this._resultDetails)
-				? { output: { type: 'data', mimeType: this._resultDetails.output.mimeType, base64Data: encodeBase64(this._resultDetails.output.value) } }
-				: this._resultDetails,
+			resultDetails: isToolResultOutputDetails(details)
+				? { output: { type: 'data', mimeType: details.output.mimeType, base64Data: encodeBase64(details.output.value) } }
+				: details,
 			toolSpecificData: this.toolSpecificData,
 			toolCallId: this.toolCallId,
 			toolId: this.toolId,

--- a/src/vs/workbench/contrib/chat/common/chatResponseResourceFileSystemProvider.ts
+++ b/src/vs/workbench/contrib/chat/common/chatResponseResourceFileSystemProvider.ts
@@ -109,11 +109,12 @@ export class ChatResponseResourceFileSystemProvider extends Disposable implement
 
 	private lookupURI(uri: URI): Uint8Array | Promise<Uint8Array> {
 		const { result, index } = this.findMatchingInvocation(uri);
-		if (!isToolResultInputOutputDetails(result.resultDetails)) {
+		const details = IChatToolInvocation.resultDetails(result);
+		if (!isToolResultInputOutputDetails(details)) {
 			throw createFileSystemProviderError(`Tool does not have I/O`, FileSystemProviderErrorCode.FileNotFound);
 		}
 
-		const part = result.resultDetails.output.at(index);
+		const part = details.output.at(index);
 		if (!part) {
 			throw createFileSystemProviderError(`Tool does not have part`, FileSystemProviderErrorCode.FileNotFound);
 		}


### PR DESCRIPTION
This iteration we'll be adding a post-execution confirmation step for
tools that read data from the outside world. This is another state that
tool invocation may be in.

Previously the state of a tool invocation was a complex arithmetic of
various properties that were valid or invalid in various different
states. This PR sets the groundwork for post-confirmations by moving
these into a `state` observable which is the point of truth for the
invocation's state. Helpers in the `IChatToolInvocation` provide drop-in
methods for existing callers.

Validated the confirmation approve/skip/deny flows still work for the
terminal tool, built-in tools, and MCP tools.

cc @Tyriar