### PR TITLE
Show chat item title while loading in editor

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatEditorInput.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditorInput.ts
@@ -180,6 +180,11 @@ export class ChatEditorInput extends EditorInput implements IEditorCloseHandler 
 			}
 		}
 
+		// If a preferred title was provided in options, use it (even while loading)
+		if (this.options.title?.preferred) {
+			return this.options.title.preferred;
+		}
+
 		// Fall back to default naming pattern
 		const inputCountSuffix = (this.inputCount > 0 ? ` ${this.inputCount + 1}` : '');
 		const defaultName = this.options.title?.fallback ?? nls.localize('chatEditorName', "Chat");

--- a/src/vs/workbench/contrib/chat/browser/chatEditorInput.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditorInput.ts
@@ -180,7 +180,7 @@ export class ChatEditorInput extends EditorInput implements IEditorCloseHandler 
 			}
 		}
 
-		// If a preferred title was provided in options, use it (even while loading)
+		// If a preferred title was provided in options, use it
 		if (this.options.title?.preferred) {
 			return this.options.title.preferred;
 		}


### PR DESCRIPTION
Fixes #261554

In the getName method, when there's no resolved model yet, it doesn't check for options.title?.preferred which is passed to the editor, it only checks the model title, persisted session title, and falls back to the default name with a count. This change returns title?.preferred value if available. 

