### PR TITLE
Allow custom editors to change title

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadCustomEditors.ts
+++ b/src/vs/workbench/api/browser/mainThreadCustomEditors.ts
@@ -670,6 +670,7 @@ class MainThreadCustomEditorModel extends ResourceWorkingCopy implements ICustom
 		const backupMeta: CustomDocumentBackupData = {
 			viewType: this.viewType,
 			editorResource: this._editorResource,
+			customTitle: primaryEditor.getCustomTitle(),
 			backupId: '',
 			extension: primaryEditor.extension ? {
 				id: primaryEditor.extension.id.value,

--- a/src/vs/workbench/contrib/customEditor/browser/customEditorInput.ts
+++ b/src/vs/workbench/contrib/customEditor/browser/customEditorInput.ts
@@ -36,29 +36,29 @@ import { IUntitledTextEditorService } from '../../../services/untitled/common/un
 interface CustomEditorInputInitInfo {
 	readonly resource: URI;
 	readonly viewType: string;
+	readonly customTitle: string | undefined;
 }
 
 export class CustomEditorInput extends LazilyResolvedWebviewEditorInput {
 
 	static create(
 		instantiationService: IInstantiationService,
-		resource: URI,
-		viewType: string,
+		init: CustomEditorInputInitInfo,
 		group: GroupIdentifier | undefined,
 		options?: { readonly customClasses?: string; readonly oldResource?: URI },
 	): EditorInput {
 		return instantiationService.invokeFunction(accessor => {
 			// If it's an untitled file we must populate the untitledDocumentData
-			const untitledString = accessor.get(IUntitledTextEditorService).getValue(resource);
+			const untitledString = accessor.get(IUntitledTextEditorService).getValue(init.resource);
 			const untitledDocumentData = untitledString ? VSBuffer.fromString(untitledString) : undefined;
 			const webview = accessor.get(IWebviewService).createWebviewOverlay({
-				providedViewType: viewType,
-				title: undefined,
+				providedViewType: init.viewType,
+				title: init.customTitle,
 				options: { customClasses: options?.customClasses },
 				contentOptions: {},
 				extension: undefined,
 			});
-			const input = instantiationService.createInstance(CustomEditorInput, { resource, viewType }, webview, { untitledDocumentData: untitledDocumentData, oldResource: options?.oldResource });
+			const input = instantiationService.createInstance(CustomEditorInput, init, webview, { untitledDocumentData: untitledDocumentData, oldResource: options?.oldResource });
 			if (typeof group !== 'undefined') {
 				input.updateGroup(group);
 			}
@@ -71,6 +71,9 @@ export class CustomEditorInput extends LazilyResolvedWebviewEditorInput {
 	private readonly _editorResource: URI;
 	public readonly oldResource?: URI;
 	private _defaultDirtyState: boolean | undefined;
+
+	private _editorName: string | undefined = undefined;
+	private _customTitle: string | undefined = undefined;
 
 	private readonly _backupId: string | undefined;
 
@@ -102,6 +105,8 @@ export class CustomEditorInput extends LazilyResolvedWebviewEditorInput {
 		this._defaultDirtyState = options.startsDirty;
 		this._backupId = options.backupId;
 		this._untitledDocumentData = options.untitledDocumentData;
+
+		this._customTitle = init.customTitle;
 
 		this.registerListeners();
 	}
@@ -171,13 +176,25 @@ export class CustomEditorInput extends LazilyResolvedWebviewEditorInput {
 		return capabilities;
 	}
 
-	private _editorName: string | undefined = undefined;
 	override getName(): string {
+		if (this._customTitle) {
+			return this._customTitle;
+		}
+
 		if (typeof this._editorName !== 'string') {
 			this._editorName = this.customEditorLabelService.getName(this.resource) ?? basename(this.labelService.getUriLabel(this.resource));
 		}
 
 		return this._editorName;
+	}
+
+	override setName(value: string): void {
+		this._customTitle = value;
+		super.setName(value);
+	}
+
+	getCustomTitle(): string | undefined {
+		return this._customTitle;
 	}
 
 	override getDescription(verbosity = Verbosity.MEDIUM): string | undefined {
@@ -247,6 +264,10 @@ export class CustomEditorInput extends LazilyResolvedWebviewEditorInput {
 	}
 
 	override getTitle(verbosity?: Verbosity): string {
+		if (this._customTitle) {
+			return this._customTitle;
+		}
+
 		switch (verbosity) {
 			case Verbosity.SHORT:
 				return this.shortTitle;
@@ -268,7 +289,10 @@ export class CustomEditorInput extends LazilyResolvedWebviewEditorInput {
 	}
 
 	public override copy(): EditorInput {
-		return CustomEditorInput.create(this.instantiationService, this.resource, this.viewType, this.group, this.webview.options);
+		return CustomEditorInput.create(this.instantiationService,
+			{ resource: this.resource, viewType: this.viewType, customTitle: this._customTitle },
+			this.group,
+			this.webview.options);
 	}
 
 	public override isReadonly(): boolean | IMarkdownString {

--- a/src/vs/workbench/contrib/customEditor/browser/customEditors.ts
+++ b/src/vs/workbench/contrib/customEditor/browser/customEditors.ts
@@ -138,10 +138,10 @@ export class CustomEditorService extends Disposable implements ICustomEditorServ
 					},
 					{
 						createEditorInput: ({ resource }, group) => {
-							return { editor: CustomEditorInput.create(this.instantiationService, resource, contributedEditor.id, group.id) };
+							return { editor: CustomEditorInput.create(this.instantiationService, { resource, viewType: contributedEditor.id, customTitle: undefined }, group.id) };
 						},
 						createUntitledEditorInput: ({ resource }, group) => {
-							return { editor: CustomEditorInput.create(this.instantiationService, resource ?? URI.from({ scheme: Schemas.untitled, authority: `Untitled-${this._untitledCounter++}` }), contributedEditor.id, group.id) };
+							return { editor: CustomEditorInput.create(this.instantiationService, { resource: resource ?? URI.from({ scheme: Schemas.untitled, authority: `Untitled-${this._untitledCounter++}` }), viewType: contributedEditor.id, customTitle: undefined }, group.id) };
 						},
 						createDiffEditorInput: (diffEditorInput, group) => {
 							return { editor: this.createDiffEditorInput(diffEditorInput, contributedEditor.id, group) };
@@ -157,8 +157,8 @@ export class CustomEditorService extends Disposable implements ICustomEditorServ
 		editorID: string,
 		group: IEditorGroup
 	): DiffEditorInput {
-		const modifiedOverride = CustomEditorInput.create(this.instantiationService, assertReturnsDefined(editor.modified.resource), editorID, group.id, { customClasses: 'modified' });
-		const originalOverride = CustomEditorInput.create(this.instantiationService, assertReturnsDefined(editor.original.resource), editorID, group.id, { customClasses: 'original' });
+		const modifiedOverride = CustomEditorInput.create(this.instantiationService, { resource: assertReturnsDefined(editor.modified.resource), viewType: editorID, customTitle: undefined }, group.id, { customClasses: 'modified' });
+		const originalOverride = CustomEditorInput.create(this.instantiationService, { resource: assertReturnsDefined(editor.original.resource), viewType: editorID, customTitle: undefined }, group.id, { customClasses: 'original' });
 		return this.instantiationService.createInstance(DiffEditorInput, editor.label, editor.description, originalOverride, modifiedOverride, true);
 	}
 
@@ -259,7 +259,7 @@ export class CustomEditorService extends Disposable implements ICustomEditorServ
 				let replacement: EditorInput | IResourceEditorInput;
 				if (possibleEditors.defaultEditor) {
 					const viewType = possibleEditors.defaultEditor.id;
-					replacement = CustomEditorInput.create(this.instantiationService, newResource, viewType, group);
+					replacement = CustomEditorInput.create(this.instantiationService, { resource: newResource, viewType, customTitle: undefined }, group);
 				} else {
 					replacement = { resource: newResource, options: { override: DEFAULT_EDITOR_ASSOCIATION.id } };
 				}


### PR DESCRIPTION
Fixes #105299

Allows custom editors to set a title using `WebviewPanel.title`. This matches how webviews work today

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
