### PR TITLE
Skip rendering the "Suggest Next" widget when locked to a coding agent

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatWidget.ts
@@ -1715,6 +1715,12 @@ export class ChatWidget extends Disposable implements IChatWidget {
 	}
 
 	private renderChatSuggestNextWidget(): void {
+		// Skip rendering in coding agent sessions
+		if (ChatContextKeys.lockedToCodingAgent.getValue(this.contextKeyService) === true) {
+			this.chatSuggestNextWidget.hide();
+			return;
+		}
+
 		const items = this.viewModel?.getItems() ?? [];
 		if (!items.length) {
 			return;

--- a/src/vs/workbench/contrib/chat/browser/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatWidget.ts
@@ -1716,7 +1716,7 @@ export class ChatWidget extends Disposable implements IChatWidget {
 
 	private renderChatSuggestNextWidget(): void {
 		// Skip rendering in coding agent sessions
-		if (ChatContextKeys.lockedToCodingAgent.getValue(this.contextKeyService) === true) {
+		if (this.isLockedToCodingAgent) {
 			this.chatSuggestNextWidget.hide();
 			return;
 		}


### PR DESCRIPTION
Fixes:
https://github.com/microsoft/vscode/issues/272367