### PR TITLE
Fix terminal tab prompt input breaking when backticks are included

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminalTooltip.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalTooltip.ts
@@ -6,7 +6,7 @@
 import { localize } from '../../../../nls.js';
 import { ITerminalInstance } from './terminal.js';
 import { asArray } from '../../../../base/common/arrays.js';
-import { MarkdownString } from '../../../../base/common/htmlContent.js';
+import { escapeMarkdownSyntaxTokens, MarkdownString } from '../../../../base/common/htmlContent.js';
 import type { IHoverAction } from '../../../../base/browser/ui/hover/hover.js';
 import { TerminalCapability } from '../../../../platform/terminal/common/capabilities/capabilities.js';
 import { TerminalStatus } from './terminalStatusList.js';
@@ -109,10 +109,10 @@ export function refreshShellIntegrationInfoStatus(instance: ITerminalInstance) {
 	}
 	const combinedString = instance.capabilities.get(TerminalCapability.CommandDetection)?.promptInputModel.getCombinedString();
 	if (combinedString !== undefined) {
-		const escapedPromptInput = combinedString
+		const escapedPromptInput = escapeMarkdownSyntaxTokens(combinedString
 			.replaceAll('<', '&lt;').replaceAll('>', '&gt;') 		 //Prevent escaping from wrapping
 			.replaceAll(/\((.+?)(\|?(?: (?:.+?)?)?)\)/g, '(<$1>$2)') //Escape links as clickable links
-			.replaceAll(/([\[\]\(\)\-\*\!\#\`])/g, '\\$1'); 		 //Comment most of the markdown elements to not render them inside
+		);
 		detailedAdditions.push(`Prompt input: <code>\n${escapedPromptInput}\n</code>`);
 	}
 	const detailedAdditionsString = detailedAdditions.length > 0

--- a/src/vs/workbench/contrib/terminal/browser/terminalTooltip.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalTooltip.ts
@@ -44,7 +44,7 @@ export function getInstanceHoverInfo(instance: ITerminalInstance, storageService
 	});
 
 	const shellProcessString = getShellProcessTooltip(instance, !!showDetailed);
-	const content = new MarkdownString(instance.title + shellProcessString + statusString, { supportThemeIcons: true });
+	const content = new MarkdownString(instance.title + shellProcessString + statusString, { supportThemeIcons: true, supportHtml: true });
 
 	return { content, actions };
 }

--- a/src/vs/workbench/contrib/terminal/browser/terminalTooltip.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalTooltip.ts
@@ -109,7 +109,7 @@ export function refreshShellIntegrationInfoStatus(instance: ITerminalInstance) {
 	}
 	const combinedString = instance.capabilities.get(TerminalCapability.CommandDetection)?.promptInputModel.getCombinedString();
 	if (combinedString !== undefined) {
-		detailedAdditions.push(`Prompt input: <code>${combinedString.replaceAll('<', '&lt;').replaceAll('>', '&gt;')}</code>`);
+		detailedAdditions.push(`Prompt input: <code>${combinedString.replaceAll('<', '&lt;').replaceAll('>', '&gt;').replaceAll('`', '\\`')}</code>`);
 	}
 	const detailedAdditionsString = detailedAdditions.length > 0
 		? '\n\n' + detailedAdditions.map(e => `- ${e}`).join('\n')

--- a/src/vs/workbench/contrib/terminal/browser/terminalTooltip.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalTooltip.ts
@@ -109,7 +109,11 @@ export function refreshShellIntegrationInfoStatus(instance: ITerminalInstance) {
 	}
 	const combinedString = instance.capabilities.get(TerminalCapability.CommandDetection)?.promptInputModel.getCombinedString();
 	if (combinedString !== undefined) {
-		detailedAdditions.push(`Prompt input: <code>${combinedString.replaceAll('<', '&lt;').replaceAll('>', '&gt;').replaceAll('`', '\\`')}</code>`);
+		const escapedPromptInput = combinedString
+			.replaceAll('<', '&lt;').replaceAll('>', '&gt;') 		 //Prevent escaping from wrapping
+			.replaceAll(/\((.+?)(\|?(?: (?:.+?)?)?)\)/g, '(<$1>$2)') //Escape links as clickable links
+			.replaceAll(/([\[\]\(\)\-\*\!\#\`])/g, '\\$1'); 		 //Comment most of the markdown elements to not render them inside
+		detailedAdditions.push(`Prompt input: <code>\n${escapedPromptInput}\n</code>`);
 	}
 	const detailedAdditionsString = detailedAdditions.length > 0
 		? '\n\n' + detailedAdditions.map(e => `- ${e}`).join('\n')

--- a/src/vs/workbench/contrib/terminal/browser/terminalTooltip.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalTooltip.ts
@@ -109,7 +109,7 @@ export function refreshShellIntegrationInfoStatus(instance: ITerminalInstance) {
 	}
 	const combinedString = instance.capabilities.get(TerminalCapability.CommandDetection)?.promptInputModel.getCombinedString();
 	if (combinedString !== undefined) {
-		detailedAdditions.push(`Prompt input: \`${combinedString}\``);
+		detailedAdditions.push(`Prompt input: <code>${combinedString.replaceAll('<', '&lt;').replaceAll('>', '&gt;')}</code>`);
 	}
 	const detailedAdditionsString = detailedAdditions.length > 0
 		? '\n\n' + detailedAdditions.map(e => `- ${e}`).join('\n')


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
Closes #272416.
I have tested the changes manually via codespaces.