### PR TITLE
Fix #272423

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
@@ -727,7 +727,6 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 		}
 
 		const mode2 = this.chatModeService.findModeById(mode) ??
-			this.chatModeService.findModeByName(mode) ??
 			this.chatModeService.findModeById(ChatModeKind.Agent) ??
 			ChatMode.Ask;
 		this.setChatMode2(mode2, storeSelection);

--- a/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
@@ -727,6 +727,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 		}
 
 		const mode2 = this.chatModeService.findModeById(mode) ??
+			this.chatModeService.findModeByName(mode) ??
 			this.chatModeService.findModeById(ChatModeKind.Agent) ??
 			ChatMode.Ask;
 		this.setChatMode2(mode2, storeSelection);

--- a/src/vs/workbench/contrib/chat/browser/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatWidget.ts
@@ -1754,7 +1754,7 @@ export class ChatWidget extends Disposable implements IChatWidget {
 
 		// Switch to the specified agent/mode if provided
 		if (handoff.agent) {
-			// Handoffs specify modes by name, so try ID first (for builtin modes), then name (for custom modes)
+			// Try resolving by ID first (for builtin modes) or by name (for custom modes that may be specified by display name in handoffs)
 			const mode = this.chatModeService.findModeById(handoff.agent) ?? this.chatModeService.findModeByName(handoff.agent);
 			if (mode) {
 				this.input.setChatMode(mode.id);

--- a/src/vs/workbench/contrib/chat/browser/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatWidget.ts
@@ -1754,7 +1754,11 @@ export class ChatWidget extends Disposable implements IChatWidget {
 
 		// Switch to the specified agent/mode if provided
 		if (handoff.agent) {
-			this.input.setChatMode(handoff.agent);
+			// Handoffs specify modes by name, so try ID first (for builtin modes), then name (for custom modes)
+			const mode = this.chatModeService.findModeById(handoff.agent) ?? this.chatModeService.findModeByName(handoff.agent);
+			if (mode) {
+				this.input.setChatMode(mode.id);
+			}
 		}
 		// Insert the handoff prompt into the input
 		this.input.setValue(handoff.prompt, false);


### PR DESCRIPTION
## Problem

The `handoff.agent` property contains human-readable mode names (e.g., "Default"), but `setChatMode` expects mode IDs. This caused a mismatch where:
- Builtin modes have `id === ChatModeKind` (e.g., "agent")  
- Custom modes have `id === URI.toString()` (e.g., "file:///...")
- Handoffs specify modes by their display name (e.g., "Default")

When `setChatMode(handoff.agent)` was called with a name like "Default", it couldn't find the matching mode because it only looked up by ID.

## Solution

Added targeted mode resolution in the `handleNextPromptSelection` method in `chatWidget.ts` where handoffs are actually processed. The fix:

1. First tries `findModeById(handoff.agent)` for builtin modes
2. Falls back to `findModeByName(handoff.agent)` for custom modes specified by name
3. Passes the resolved mode's ID to `setChatMode`

```typescript
if (handoff.agent) {
    // Handoffs specify modes by name, so try ID first (for builtin modes), then name (for custom modes)
    const mode = this.chatModeService.findModeById(handoff.agent) ?? this.chatModeService.findModeByName(handoff.agent);
    if (mode) {
        this.input.setChatMode(mode.id);
    }
}
```

## Why This Approach

- **Targeted**: Only affects handoff processing, not all `setChatMode` calls
- **Clear intent**: Comment explains that handoffs use mode names
- **Explicit resolution**: Shows the ID→name fallback logic where it's needed
- **Safer**: Doesn't change `setChatMode` behavior for other callers
- **Maintainable**: Future developers see the special handling at the handoff point

## Testing

- ✅ No compilation errors
- ✅ Handoffs with custom agent names now correctly resolve modes
- ✅ Falls back gracefully if mode is not found
- ✅ Builtin modes still work by ID