### PR TITLE
Fix policies integration test flow

### DIFF
--- a/src/vs/workbench/contrib/policyExport/test/node/policyExport.integrationTest.ts
+++ b/src/vs/workbench/contrib/policyExport/test/node/policyExport.integrationTest.ts
@@ -19,8 +19,13 @@ suite('PolicyExport Integration Tests', () => {
 	ensureNoDisposablesAreLeakedInTestSuite();
 
 	test('exported policy data matches checked-in file', async function () {
+		// Skip this test in ADO pipelines
+		if (process.env['TF_BUILD']) {
+			this.skip();
+		}
+
 		// This test launches VS Code with --export-policy-data flag, so it takes longer
-		this.timeout(120000);
+		this.timeout(60000);
 
 		// Get the repository root (FileAccess.asFileUri('') points to the 'out' directory)
 		const rootPath = dirname(FileAccess.asFileUri('').fsPath);

--- a/src/vs/workbench/contrib/policyExport/test/node/policyExport.integrationTest.ts
+++ b/src/vs/workbench/contrib/policyExport/test/node/policyExport.integrationTest.ts
@@ -9,7 +9,7 @@ import { promises as fs } from 'fs';
 import * as os from 'os';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { isWindows } from '../../../../../base/common/platform.js';
-import { join } from '../../../../../base/common/path.js';
+import { dirname, join } from '../../../../../base/common/path.js';
 import { FileAccess } from '../../../../../base/common/network.js';
 import * as util from 'util';
 
@@ -20,9 +20,10 @@ suite('PolicyExport Integration Tests', () => {
 
 	test('exported policy data matches checked-in file', async function () {
 		// This test launches VS Code with --export-policy-data flag, so it takes longer
-		this.timeout(60000);
+		this.timeout(120000);
 
-		const rootPath = FileAccess.asFileUri('').fsPath.replace(/[\/\\]out[\/\\].*$/, '');
+		// Get the repository root (FileAccess.asFileUri('') points to the 'out' directory)
+		const rootPath = dirname(FileAccess.asFileUri('').fsPath);
 		const checkedInFile = join(rootPath, 'build/lib/policies/policyData.jsonc');
 		const tempFile = join(os.tmpdir(), `policyData-test-${Date.now()}.jsonc`);
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
## Description
The test runs significantly longer in ADO build agents (over 120s vs. 10s) on GitHub action runners. We don't actually need the test to run except during PR process when people may be making changes to policy config, so this updates it to skip on ADO runners.