### PR TITLE
Use fixed 16px font-size for chat todo status icon

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/media/chat.css
@@ -2713,7 +2713,7 @@ have to be updated for changes to the rules above, or to support more deeply nes
 
 .chat-todo-list-widget .todo-item > .todo-status-icon.codicon {
 	flex-shrink: 0;
-	font-size: var(--vscode-chat-font-size-body-l);
+	font-size: 16px;
 }
 
 .chat-todo-list-widget .todo-content {


### PR DESCRIPTION
Set the font size of the chat todo status icon to a fixed 16px for consistency in appearance.