### PR TITLE
chatMode.name is case sensitive, expect when used in the URL handler

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatSetup.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSetup.ts
@@ -1268,21 +1268,20 @@ export class ChatSetupContribution extends Disposable implements IWorkbenchContr
 				const params = new URLSearchParams(url.query);
 				this.telemetryService.publicLog2<WorkbenchActionExecutedEvent, WorkbenchActionExecutedClassification>('workbenchActionExecuted', { id: CHAT_SETUP_ACTION_ID, from: 'url', detail: params.get('referrer') ?? undefined });
 
-				const modeParam = params.get('agent') ?? params.get('mode');
-				let modeToUse: ChatModeKind | string | undefined;
-				if (modeParam) {
-					// check if the given param is a valid mode ID
-					let foundMode = this.chatModeService.findModeById(modeParam);
-					if (!foundMode) {
-						// if not, check if the given param is a valid mode name, note the name is case insensitive
-						foundMode = this.chatModeService.findModeByName(modeParam);
-					}
+				const agentParam = params.get('agent') ?? params.get('mode');
+				if (agentParam) {
+					const agents = this.chatModeService.getModes();
+					const allAgents = [...agents.builtin, ...agents.custom];
 
-					if (foundMode) {
-						modeToUse = foundMode.id;
+					// check if the given param is a valid mode ID
+					let foundAgent = allAgents.find(agent => agent.id === agentParam);
+					if (!foundAgent) {
+						// if not, check if the given param is a valid mode name, note the parameter as name is case insensitive
+						const nameLower = agentParam.toLowerCase();
+						foundAgent = allAgents.find(agent => agent.name.toLowerCase() === nameLower);
 					}
 					// execute the command to change the mode in panel, note that the command only supports mode IDs, not names
-					await this.commandService.executeCommand(CHAT_SETUP_ACTION_ID, modeToUse);
+					await this.commandService.executeCommand(CHAT_SETUP_ACTION_ID, foundAgent?.id);
 					return true;
 				}
 

--- a/src/vs/workbench/contrib/chat/common/chatModes.ts
+++ b/src/vs/workbench/contrib/chat/common/chatModes.ts
@@ -176,8 +176,7 @@ export class ChatModeService extends Disposable implements IChatModeService {
 	}
 
 	findModeByName(name: string): IChatMode | undefined {
-		const lowerCasedName = name.toLowerCase();
-		return this.getBuiltinModes().find(mode => mode.name.toLowerCase() === lowerCasedName) ?? this.getCustomModes().find(mode => mode.name.toLowerCase() === lowerCasedName);
+		return this.getBuiltinModes().find(mode => mode.name === name) ?? this.getCustomModes().find(mode => mode.name === name);
 	}
 
 	private getBuiltinModes(): IChatMode[] {


### PR DESCRIPTION
https://github.com/microsoft/vscode/commit/4aa07c50dc1de4c0dd894aada8737fda4944fc8a changed `IChatModeService.findModeByName` to be case insensitive. But at other places we still treat mode names as case sensitive
- PromptFileValidator: https://github.com/microsoft/vscode/blob/04c143a191cd3d07aa1cb7363c75ce7d9a4eaa84/src/vs/workbench/contrib/chat/common/promptSyntax/languageProviders/promptValidator.ts#L247
- ChatWidget switch to mode
https://github.com/microsoft/vscode/blob/04c143a191cd3d07aa1cb7363c75ce7d9a4eaa84/src/vs/workbench/contrib/chat/browser/chatWidget.ts#L2968

I suggest we continue to treat the agent name as case sensitive and just fix this for the URL prompt handler where it seems some users pass in case insensitive mode names. But it would be best to educate these users.

Note that we have the `name` and the `label`
- the name (e.g. 'ask') is used as reference name in prompt files
- the label is used in the UI (e.g 'Ask'). It is localized.

So maybe the URL handler users expected to find the mode by label?