### PR TITLE
Show exception widget in inactive editors

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/exceptionWidget.ts
+++ b/src/vs/workbench/contrib/debug/browser/exceptionWidget.ts
@@ -20,6 +20,7 @@ import { EditorOption } from '../../../../editor/common/config/editorOptions.js'
 import { ActionBar } from '../../../../base/browser/ui/actionbar/actionbar.js';
 import { Action } from '../../../../base/common/actions.js';
 import { widgetClose } from '../../../../platform/theme/common/iconRegistry.js';
+import { Range } from '../../../../editor/common/core/range.js';
 const $ = dom.$;
 
 // theming
@@ -35,6 +36,7 @@ export class ExceptionWidget extends ZoneWidget {
 		editor: ICodeEditor,
 		private exceptionInfo: IExceptionInfo,
 		private debugSession: IDebugSession | undefined,
+		private readonly shouldScroll: () => boolean,
 		@IThemeService themeService: IThemeService,
 		@IInstantiationService private readonly instantiationService: IInstantiationService
 	) {
@@ -115,6 +117,14 @@ export class ExceptionWidget extends ZoneWidget {
 		const computedLinesNumber = Math.ceil((this.container!.offsetHeight + arrowHeight) / lineHeight);
 
 		this._relayout(computedLinesNumber);
+	}
+
+	protected override revealRange(range: Range, isLastLine: boolean): void {
+		// Only reveal/scroll if this widget should scroll
+		// For inactive editors, skip the reveal to prevent scrolling
+		if (this.shouldScroll()) {
+			super.revealRange(range, isLastLine);
+		}
 	}
 
 	focus(): void {

--- a/src/vs/workbench/contrib/debug/browser/exceptionWidget.ts
+++ b/src/vs/workbench/contrib/debug/browser/exceptionWidget.ts
@@ -139,4 +139,16 @@ export class ExceptionWidget extends ZoneWidget {
 
 		return dom.isAncestorOfActiveElement(this.container);
 	}
+
+	getWhitespaceHeight(): number {
+		// Returns the height of the whitespace zone from the editor's whitespaces
+		// This is more accurate than the container height as it includes the actual zone dimensions
+		if (!this._viewZone || !this._viewZone.id) {
+			return 0;
+		}
+
+		const whitespaces = this.editor.getWhitespaces();
+		const whitespace = whitespaces.find(ws => ws.id === this._viewZone!.id);
+		return whitespace ? whitespace.height : 0;
+	}
 }


### PR DESCRIPTION
Follow-up PR to fix https://github.com/microsoft/vscode/issues/272516, which is an issue from PR https://github.com/microsoft/vscode/pull/270615. 

Show exception widget in the inactive editors, controlling the editor to not move the current focus range in the inactive editors.