### PR TITLE
clarify `chatSessions.name` cannot contain whitespace

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatSessions.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSessions.contribution.ts
@@ -44,8 +44,9 @@ const extensionPoint = ExtensionsRegistry.registerExtensionPoint<IChatSessionsEx
 					type: 'string',
 				},
 				name: {
-					description: localize('chatSessionsExtPoint.name', 'Name shown in the chat widget. (eg: @agent)'),
+					description: localize('chatSessionsExtPoint.name', 'Name of the dynamically registered chat participant (eg: @agent). Must not contain whitespace.'),
 					type: 'string',
+					pattern: '^[\\w-]+$'
 				},
 				displayName: {
 					description: localize('chatSessionsExtPoint.displayName', 'A longer name for this item which is used for display in menus.'),


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Mirror the pattern for `chatParticipant.name`

https://github.com/microsoft/vscode/blob/db714300fbc8c96aa40299988d374990cdeae3f2/src/vs/workbench/contrib/chat/browser/chatParticipant.contribution.ts#L94-L98

Prevent bugs like https://github.com/microsoft/vscode-copilot-chat/pull/1483/commits/352aa202e26807127493473e73c0b932f7d753f1

As with most chat session things, this should be reconsidered before finalization