### PR TITLE
Include input state when adding history

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
@@ -1075,7 +1075,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 			const inputState = this.getInputState();
 			const entry = this.getFilteredEntry(userQuery, inputState);
 			this.history.replaceLast(entry);
-			this.history.add({ text: '' });
+			this.history.add({ text: '', state: this.getInputState() });
 		}
 
 		// Clear attached context, fire event to clear input state, and clear the input editor


### PR DESCRIPTION
## Description

Fixes #272584

When custom agent handoffs are set to send automatically (`send: true`), the handoff was being sent correctly but the chat input mode was not persisted. After auto-sending, the chat input would reset from the handoff's target agent back to the default "Agent" mode.

## Root Cause

When `ChatInputPart.acceptInput()` was called after a message was sent, it would add a new empty history entry without preserving the current input state:

```typescript
this.history.add({ text: '' });  // Missing state!
```

This caused the chat mode (and other input state like attachments and context) to be lost. When the history was later accessed or a new session initialized, the missing state would cause the mode to fall back to `GlobalLastChatModeKey` (the default "Agent" mode stored in settings).

## Solution

Preserve the input state when adding a new history entry after message submission:

```typescript
this.history.add({ text: '', state: this.getInputState() });
```

This ensures that when a handoff with `send: true` switches to a custom agent mode, that mode is preserved in the chat history and won't revert to the default mode.

## Flow After Fix

1. Handoff selection calls `_switchToAgentByName(handoff.agent)` → agent mode is switched ✓
2. Prompt text is set in the input
3. `acceptInput()` sends the message
4. **NEW**: The history entry now includes the current input state with the custom agent mode ✓
5. Chat input remains on the handoff agent instead of resetting ✓