### PR TITLE
Add horizontal padding to dropdown action label

### DIFF
--- a/src/vs/workbench/contrib/extensions/browser/media/extensionEditor.css
+++ b/src/vs/workbench/contrib/extensions/browser/media/extensionEditor.css
@@ -281,6 +281,7 @@
 .extension-editor > .header > .details > .actions-status-container > .monaco-action-bar > .actions-container > .action-item.action-dropdown-item:not(.empty) > .monaco-dropdown .extension-action.label {
 	border-left-width: 0;
 	border-radius: 0 2px 2px 0;
+	padding: 0 2px;
 }
 
 .extension-editor > .header > .details > .actions-status-container > .monaco-action-bar > .actions-container > .action-item > .action-label.extension-status {


### PR DESCRIPTION
Introduce 2px horizontal padding to enhance the appearance of the dropdown action label in the extension editor.

Before:
<img width="312" height="50" alt="image" src="https://github.com/user-attachments/assets/c9eb0ed1-8f37-4e92-98eb-0b1176290eda" />


After:
<img width="324" height="47" alt="image" src="https://github.com/user-attachments/assets/a1a72c64-cb8e-4479-a7d0-4caa1a96bc8a" />
