### PR TITLE
Adjust extension editor layout and spacing

### DIFF
--- a/src/vs/workbench/contrib/extensions/browser/media/extensionEditor.css
+++ b/src/vs/workbench/contrib/extensions/browser/media/extensionEditor.css
@@ -9,7 +9,7 @@
 	display: flex;
 	flex-direction: column;
 	margin: 0px auto;
-	max-width: 80%;
+	max-width: 90%;
 }
 
 .extension-editor .clickable {
@@ -19,9 +19,8 @@
 .extension-editor > .header {
 	display: flex;
 	padding-top: 20px;
-	padding-bottom: 14px;
+	padding-bottom: 12px;
 	padding-left: 20px;
-	padding-right: 20px;
 	overflow: hidden;
 	font-size: 14px;
 }
@@ -59,7 +58,7 @@
 }
 
 .extension-editor > .header > .details {
-	padding-left: 20px;
+	padding-left: 12px;
 	overflow: hidden;
 	user-select: text;
 	-webkit-user-select: text;
@@ -460,16 +459,16 @@
 .extension-editor > .body > .content > .details > .additional-details-container > .monaco-scrollable-element > .additional-details-content {
 	height: 100%;
 	overflow-y: scroll;
-	padding: 20px;
+	padding: 12px;
 	box-sizing: border-box;
 }
 
 .extension-editor > .body > .content > .details > .additional-details-container .additional-details-element:not(:first-child) {
-	padding-top: 15px;
+	padding-top: 16px;
 }
 
 .extension-editor > .body > .content > .details > .additional-details-container .additional-details-element {
-	padding-bottom: 15px;
+	padding-bottom: 16px;
 }
 
 .extension-editor > .body > .content > .details > .additional-details-container .additional-details-element:not(:last-child) {
@@ -478,7 +477,7 @@
 
 .extension-editor > .body > .content > .details > .additional-details-container .additional-details-element > .additional-details-title {
 	font-size: 120%;
-	padding-bottom: 15px;
+	padding-bottom: 12px;
 }
 
 .extension-editor > .body > .content > .details > .additional-details-container .categories-container > .categories > .category {


### PR DESCRIPTION
Increase the maximum width of the extension editor to 90% and refine padding for improved layout consistency.

As the secondary side panel is open more often it makes sense to use as much of the editor panel as possible, without affecting user experience.  

Before:
<img width="1155" height="968" alt="image" src="https://github.com/user-attachments/assets/66fbc934-78f6-4e82-91e7-ff45649fcda3" />


After:
<img width="1167" height="967" alt="image" src="https://github.com/user-attachments/assets/94e3e2c8-07ab-4cdd-8aaf-ac059406d63c" />

Comparison:

![Recording 2025-10-22 at 15 31 22](https://github.com/user-attachments/assets/66610f9b-208f-4a0a-a828-afb248976f26)

