### PR TITLE
Exclude trailing underscore from bracket pairs in LaTeX

### DIFF
--- a/extensions/latex/package.json
+++ b/extensions/latex/package.json
@@ -66,7 +66,11 @@
       {
         "language": "tex",
         "scopeName": "text.tex",
-        "path": "./syntaxes/TeX.tmLanguage.json"
+        "path": "./syntaxes/TeX.tmLanguage.json",
+        "unbalancedBracketScopes": [
+          "keyword.control.ifnextchar.tex",
+          "punctuation.math.operator.tex"
+        ]
       },
       {
         "language": "latex",

--- a/extensions/latex/package.json
+++ b/extensions/latex/package.json
@@ -73,7 +73,8 @@
         "scopeName": "text.tex.latex",
         "path": "./syntaxes/LaTeX.tmLanguage.json",
         "unbalancedBracketScopes": [
-          "keyword.control.ifnextchar.tex"
+          "keyword.control.ifnextchar.tex",
+          "punctuation.math.operator.tex"
         ],
         "embeddedLanguages": {
           "source.cpp": "cpp_embedded_latex",


### PR DESCRIPTION
Fix #251460. 
See also https://github.com/jlelong/vscode-latex-basics/issues/124

This PR also brings to the TeX grammar the changes introduced in #272329 to the LaTeX grammar only.