### PR TITLE
tools: adopt postapproval in the fetch tool

### DIFF
--- a/src/vs/platform/webContentExtractor/common/webContentExtractor.ts
+++ b/src/vs/platform/webContentExtractor/common/webContentExtractor.ts
@@ -11,10 +11,22 @@ import { createDecorator } from '../../instantiation/common/instantiation.js';
 export const IWebContentExtractorService = createDecorator<IWebContentExtractorService>('IWebContentExtractorService');
 export const ISharedWebContentExtractorService = createDecorator<ISharedWebContentExtractorService>('ISharedWebContentExtractorService');
 
+export interface IWebContentExtractorOptions {
+	/**
+	 * Whether to allow cross-authority redirects on the web content.
+	 * 'false' by default.
+	 */
+	followRedirects?: boolean;
+}
+
+export type WebContentExtractResult =
+	| { status: 'ok'; result: string }
+	| { status: 'error'; error: string }
+	| { status: 'redirect'; toURI: URI };
 
 export interface IWebContentExtractorService {
 	_serviceBrand: undefined;
-	extract(uri: URI[]): Promise<string[]>;
+	extract(uri: URI[], options?: IWebContentExtractorOptions): Promise<WebContentExtractResult[]>;
 }
 
 /*
@@ -33,7 +45,7 @@ export interface ISharedWebContentExtractorService {
 export class NullWebContentExtractorService implements IWebContentExtractorService {
 	_serviceBrand: undefined;
 
-	extract(_uri: URI[]): Promise<string[]> {
+	extract(_uri: URI[]): Promise<WebContentExtractResult[]> {
 		throw new Error('Not implemented');
 	}
 }

--- a/src/vs/platform/webContentExtractor/electron-main/webContentExtractorService.ts
+++ b/src/vs/platform/webContentExtractor/electron-main/webContentExtractorService.ts
@@ -3,17 +3,21 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { BrowserWindow } from 'electron';
-import { IWebContentExtractorService } from '../common/webContentExtractor.js';
+import { BrowserWindow, Event as ElectronEvent, WebContentsWillNavigateEventParams, WebContentsWillRedirectEventParams } from 'electron';
+import { IWebContentExtractorOptions, IWebContentExtractorService, WebContentExtractResult } from '../common/webContentExtractor.js';
 import { URI } from '../../../base/common/uri.js';
 import { AXNode, convertAXTreeToMarkdown } from './cdpAccessibilityDomain.js';
 import { Limiter } from '../../../base/common/async.js';
 import { ResourceMap } from '../../../base/common/map.js';
 import { ILogService } from '../../log/common/log.js';
+import { DisposableStore, toDisposable } from '../../../base/common/lifecycle.js';
+import { CancellationError } from '../../../base/common/errors.js';
+import { generateUuid } from '../../../base/common/uuid.js';
 
 interface CacheEntry {
-	content: string;
+	result: string;
 	timestamp: number;
+	finalURI: URI;
 }
 
 export class NativeWebContentExtractorService implements IWebContentExtractorService {
@@ -21,7 +25,7 @@ export class NativeWebContentExtractorService implements IWebContentExtractorSer
 
 	// Only allow 3 windows to be opened at a time
 	// to avoid overwhelming the system with too many processes.
-	private _limiter = new Limiter<string>(3);
+	private _limiter = new Limiter<WebContentExtractResult>(3);
 	private _webContentsCache = new ResourceMap<CacheEntry>();
 	private readonly _cacheDuration = 24 * 60 * 60 * 1000; // 1 day in milliseconds
 
@@ -31,53 +35,90 @@ export class NativeWebContentExtractorService implements IWebContentExtractorSer
 		return Date.now() - entry.timestamp > this._cacheDuration;
 	}
 
-	extract(uris: URI[]): Promise<string[]> {
+	extract(uris: URI[], options?: IWebContentExtractorOptions): Promise<WebContentExtractResult[]> {
 		if (uris.length === 0) {
 			this._logger.info('[NativeWebContentExtractorService] No URIs provided for extraction');
 			return Promise.resolve([]);
 		}
 		this._logger.info(`[NativeWebContentExtractorService] Extracting content from ${uris.length} URIs`);
-		return Promise.all(uris.map((uri) => this._limiter.queue(() => this.doExtract(uri))));
+		return Promise.all(uris.map((uri) => this._limiter.queue(() => this.doExtract(uri, options))));
 	}
 
-	async doExtract(uri: URI): Promise<string> {
+	async doExtract(uri: URI, options: IWebContentExtractorOptions | undefined): Promise<WebContentExtractResult> {
 		const cached = this._webContentsCache.get(uri);
 		if (cached) {
 			this._logger.info(`[NativeWebContentExtractorService] Found cached content for ${uri}`);
 			if (this.isExpired(cached)) {
 				this._logger.info(`[NativeWebContentExtractorService] Cache expired for ${uri}, removing entry...`);
 				this._webContentsCache.delete(uri);
+			} else if (!options?.followRedirects && cached.finalURI.authority !== uri.authority) {
+				return { status: 'redirect', toURI: cached.finalURI };
 			} else {
-				return cached.content;
+				return { status: 'ok', result: cached.result };
 			}
 		}
 
 		this._logger.info(`[NativeWebContentExtractorService] Extracting content from ${uri}...`);
+		const store = new DisposableStore();
 		const win = new BrowserWindow({
 			width: 800,
 			height: 600,
 			show: false,
 			webPreferences: {
+				partition: generateUuid(), // do not share any state with the default renderer session
 				javascript: true,
 				offscreen: true,
 				sandbox: true,
 				webgl: false
 			}
 		});
+
+		store.add(toDisposable(() => win.destroy()));
+
 		try {
-			await win.loadURL(uri.toString(true));
-			win.webContents.debugger.attach('1.1');
-			const result: { nodes: AXNode[] } = await win.webContents.debugger.sendCommand('Accessibility.getFullAXTree');
-			const str = convertAXTreeToMarkdown(uri, result.nodes);
-			this._logger.info(`[NativeWebContentExtractorService] Content extracted from ${uri}`);
-			this._logger.trace(`[NativeWebContentExtractorService] Extracted content: ${str}`);
-			this._webContentsCache.set(uri, { content: str, timestamp: Date.now() });
-			return str;
+			const result = options?.followRedirects
+				? await this.extractAX(win, uri)
+				: await Promise.race([this.interceptRedirects(win, uri, store), this.extractAX(win, uri)]);
+
+			if (result.status === 'ok') {
+				this._webContentsCache.set(uri, { result: result.result, timestamp: Date.now(), finalURI: URI.parse(win.webContents.getURL()) });
+			}
+
+			return result;
 		} catch (err) {
 			this._logger.error(`[NativeWebContentExtractorService] Error extracting content from ${uri}: ${err}`);
+			return { status: 'error', error: String(err) };
 		} finally {
-			win.destroy();
+			store.dispose();
 		}
-		return '';
+	}
+
+	private async extractAX(win: BrowserWindow, uri: URI): Promise<WebContentExtractResult> {
+		await win.loadURL(uri.toString(true));
+		win.webContents.debugger.attach('1.1');
+		const result: { nodes: AXNode[] } = await win.webContents.debugger.sendCommand('Accessibility.getFullAXTree');
+		const str = convertAXTreeToMarkdown(uri, result.nodes);
+		this._logger.info(`[NativeWebContentExtractorService] Content extracted from ${uri}`);
+		this._logger.trace(`[NativeWebContentExtractorService] Extracted content: ${str}`);
+		return { status: 'ok', result: str };
+	}
+
+	private interceptRedirects(win: BrowserWindow, uri: URI, store: DisposableStore) {
+		return new Promise<WebContentExtractResult>((resolve, reject) => {
+			const onNavigation = (e: ElectronEvent<WebContentsWillNavigateEventParams | WebContentsWillRedirectEventParams>) => {
+				const newURI = URI.parse(e.url);
+				if (newURI.authority !== uri.authority) {
+					e.preventDefault();
+					resolve({ status: 'redirect', toURI: newURI });
+				}
+			};
+
+			win.webContents.on('will-navigate', onNavigation);
+			win.webContents.on('will-redirect', onNavigation);
+
+			store.add(toDisposable(() => {
+				reject(new CancellationError());
+			}));
+		});
 	}
 }

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/abstractToolConfirmationSubPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/abstractToolConfirmationSubPart.ts
@@ -7,7 +7,6 @@ import { Separator } from '../../../../../../base/common/actions.js';
 import { assertNever } from '../../../../../../base/common/assert.js';
 import { Codicon } from '../../../../../../base/common/codicons.js';
 import { toDisposable } from '../../../../../../base/common/lifecycle.js';
-import { autorunSelfDisposable, IReader } from '../../../../../../base/common/observable.js';
 import { localize } from '../../../../../../nls.js';
 import { IContextKeyService } from '../../../../../../platform/contextkey/common/contextkey.js';
 import { IInstantiationService } from '../../../../../../platform/instantiation/common/instantiation.js';
@@ -138,13 +137,6 @@ export abstract class AbstractToolConfirmationSubPart extends BaseChatToolInvoca
 
 		this._register(confirmWidget.onDidChangeHeight(() => this._onDidChangeHeight.fire()));
 		this._register(toDisposable(() => hasToolConfirmation.reset()));
-		this._register(autorunSelfDisposable(reader => {
-			if (this.shouldDismiss(toolInvocation, reader)) {
-				reader.dispose();
-				hasToolConfirmation.reset();
-				this._onNeedsRerender.fire();
-			}
-		}));
 
 		this.domNode = confirmWidget.domNode;
 	}
@@ -159,5 +151,4 @@ export abstract class AbstractToolConfirmationSubPart extends BaseChatToolInvoca
 
 	protected abstract createContentElement(): HTMLElement | string;
 	protected abstract getTitle(): string;
-	protected abstract shouldDismiss(toolInvocation: IChatToolInvocation, reader: IReader): boolean;
 }

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatExtensionsInstallToolSubPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatExtensionsInstallToolSubPart.ts
@@ -5,7 +5,7 @@
 
 import * as dom from '../../../../../../base/browser/dom.js';
 import { Emitter } from '../../../../../../base/common/event.js';
-import { autorunSelfDisposable } from '../../../../../../base/common/observable.js';
+import { toDisposable } from '../../../../../../base/common/lifecycle.js';
 import { localize } from '../../../../../../nls.js';
 import { IContextKeyService } from '../../../../../../platform/contextkey/common/contextkey.js';
 import { IExtensionManagementService } from '../../../../../../platform/extensionManagement/common/extensionManagement.js';
@@ -17,7 +17,7 @@ import { ConfirmedReason, IChatToolInvocation, ToolConfirmKind } from '../../../
 import { CancelChatActionId } from '../../actions/chatExecuteActions.js';
 import { AcceptToolConfirmationActionId } from '../../actions/chatToolActions.js';
 import { IChatCodeBlockInfo, IChatWidgetService } from '../../chat.js';
-import { IChatConfirmationButton, ChatConfirmationWidget } from '../chatConfirmationWidget.js';
+import { ChatConfirmationWidget, IChatConfirmationButton } from '../chatConfirmationWidget.js';
 import { IChatContentPartRenderContext } from '../chatContentParts.js';
 import { ChatExtensionsContentPart } from '../chatExtensionsContentPart.js';
 import { BaseChatToolInvocationSubPart } from './chatToolInvocationSubPart.js';
@@ -88,13 +88,9 @@ export class ExtensionsInstallConfirmationWidgetSubPart extends BaseChatToolInvo
 				IChatToolInvocation.confirmWith(toolInvocation, button.data);
 				chatWidgetService.getWidgetBySessionId(context.element.sessionId)?.focusInput();
 			}));
-			this._register(autorunSelfDisposable(reader => {
-				if (IChatToolInvocation.executionConfirmedOrDenied(toolInvocation, reader)) {
-					reader.dispose();
-					ChatContextKeys.Editing.hasToolConfirmation.bindTo(contextKeyService).set(false);
-					this._onNeedsRerender.fire();
-				}
-			}));
+			const hasToolConfirmationKey = ChatContextKeys.Editing.hasToolConfirmation.bindTo(contextKeyService);
+			hasToolConfirmationKey.set(true);
+			this._register(toDisposable(() => hasToolConfirmationKey.reset()));
 			const disposable = this._register(extensionManagementService.onInstallExtension(e => {
 				if (extensionsContent.extensions.some(id => areSameExtensions({ id }, e.identifier))) {
 					disposable.dispose();

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatInputOutputMarkdownProgressPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatInputOutputMarkdownProgressPart.ts
@@ -136,15 +136,6 @@ export class ChatInputOutputMarkdownProgressPart extends BaseChatToolInvocationS
 		this._register(collapsibleListPart.onDidChangeHeight(() => this._onDidChangeHeight.fire()));
 		this._register(toDisposable(() => ChatInputOutputMarkdownProgressPart._expandedByDefault.set(toolInvocation, collapsibleListPart.expanded)));
 
-		// Make sure to rerender back into a confirmation when reviewing output
-		this._register(autorun(reader => {
-			if (toolInvocation.kind === 'toolInvocation') {
-				if (toolInvocation.state.read(reader).type === IChatToolInvocation.StateKind.WaitingForPostApproval) {
-					this._onNeedsRerender.fire();
-				}
-			}
-		}));
-
 		const progressObservable = toolInvocation.kind === 'toolInvocation' ? toolInvocation.state.map((s, r) => s.type === IChatToolInvocation.StateKind.Executing ? s.progress.read(r) : undefined) : undefined;
 		const progressBar = new Lazy(() => this._register(new ProgressBar(collapsibleListPart.domNode)));
 		if (progressObservable) {

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatToolConfirmationSubPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatToolConfirmationSubPart.ts
@@ -8,7 +8,6 @@ import { Separator } from '../../../../../../base/common/actions.js';
 import { RunOnceScheduler } from '../../../../../../base/common/async.js';
 import { IMarkdownString, MarkdownString } from '../../../../../../base/common/htmlContent.js';
 import { toDisposable } from '../../../../../../base/common/lifecycle.js';
-import { IReader } from '../../../../../../base/common/observable.js';
 import { count } from '../../../../../../base/common/strings.js';
 import { isEmptyObject } from '../../../../../../base/common/types.js';
 import { generateUuid } from '../../../../../../base/common/uuid.js';
@@ -282,10 +281,6 @@ export class ToolConfirmationSubPart extends AbstractToolConfirmationSubPart {
 	protected getTitle(): string {
 		const { title } = this.toolInvocation.confirmationMessages!;
 		return typeof title === 'string' ? title : title!.value;
-	}
-
-	protected shouldDismiss(toolInvocation: IChatToolInvocation, reader: IReader): boolean {
-		return !!IChatToolInvocation.executionConfirmedOrDenied(toolInvocation, reader);
 	}
 
 	private _makeMarkdownPart(container: HTMLElement, message: string | IMarkdownString, codeBlockRenderOptions: ICodeBlockRenderOptions) {

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatToolInvocationSubPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatToolInvocationSubPart.ts
@@ -6,7 +6,6 @@
 import { Codicon } from '../../../../../../base/common/codicons.js';
 import { Emitter } from '../../../../../../base/common/event.js';
 import { Disposable } from '../../../../../../base/common/lifecycle.js';
-import { autorunSelfDisposable } from '../../../../../../base/common/observable.js';
 import { ThemeIcon } from '../../../../../../base/common/themables.js';
 import { IChatToolInvocation, IChatToolInvocationSerialized, ToolConfirmKind } from '../../../common/chatService.js';
 import { IChatCodeBlockInfo } from '../../chat.js';
@@ -29,15 +28,6 @@ export abstract class BaseChatToolInvocationSubPart extends Disposable {
 		protected readonly toolInvocation: IChatToolInvocation | IChatToolInvocationSerialized,
 	) {
 		super();
-
-		if (toolInvocation.kind === 'toolInvocation' && !IChatToolInvocation.isComplete(toolInvocation)) {
-			this._register(autorunSelfDisposable(reader => {
-				if (IChatToolInvocation.isComplete(toolInvocation, reader)) {
-					this._onNeedsRerender.fire();
-					reader.dispose();
-				}
-			}));
-		}
 	}
 
 	protected getIcon() {

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatToolPostExecuteConfirmationPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatToolPostExecuteConfirmationPart.ts
@@ -5,7 +5,6 @@
 
 import * as dom from '../../../../../../base/browser/dom.js';
 import { getExtensionForMimeType } from '../../../../../../base/common/mime.js';
-import { IReader } from '../../../../../../base/common/observable.js';
 import { ILanguageService } from '../../../../../../editor/common/languages/language.js';
 import { IModelService } from '../../../../../../editor/common/services/model.js';
 import { localize } from '../../../../../../nls.js';

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatToolPostExecuteConfirmationPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatToolPostExecuteConfirmationPart.ts
@@ -70,11 +70,6 @@ export class ChatToolPostExecuteConfirmationPart extends AbstractToolConfirmatio
 		return localize('approveToolResult', "Approve Tool Result");
 	}
 
-	protected shouldDismiss(toolInvocation: IChatToolInvocation, reader: IReader): boolean {
-		const currentState = toolInvocation.state.read(reader);
-		return currentState.type !== IChatToolInvocation.StateKind.WaitingForPostApproval;
-	}
-
 	protected override additionalPrimaryActions() {
 		const actions = super.additionalPrimaryActions();
 		actions.push(

--- a/src/vs/workbench/contrib/chat/common/chatProgressTypes/chatToolInvocation.ts
+++ b/src/vs/workbench/contrib/chat/common/chatProgressTypes/chatToolInvocation.ts
@@ -83,7 +83,7 @@ export class ChatToolInvocation implements IChatToolInvocation {
 			this.pastTenseMessage = this._progress.get().message;
 		}
 
-		if (this.confirmationMessages?.confirmResults && !result?.toolResultError && !final) {
+		if (this.confirmationMessages?.confirmResults && !result?.toolResultError && result?.confirmResults !== false && !final) {
 			this._state.set({
 				type: IChatToolInvocation.StateKind.WaitingForPostApproval,
 				confirmed: IChatToolInvocation.executionConfirmedOrDenied(this) || { type: ToolConfirmKind.ConfirmationNotNeeded },

--- a/src/vs/workbench/contrib/chat/common/languageModelToolsService.ts
+++ b/src/vs/workbench/contrib/chat/common/languageModelToolsService.ts
@@ -191,6 +191,8 @@ export interface IToolResult {
 	toolResultDetails?: Array<URI | Location> | IToolResultInputOutputDetails | IToolResultOutputDetails;
 	toolResultError?: string;
 	toolMetadata?: unknown;
+	/** Whether to ask the user to confirm these tool results. Overrides {@link IToolConfirmationMessages.confirmResults}. */
+	confirmResults?: boolean;
 }
 
 export function toolResultHasBuffers(result: IToolResult): boolean {

--- a/src/vs/workbench/contrib/chat/test/electron-browser/fetchPageTool.test.ts
+++ b/src/vs/workbench/contrib/chat/test/electron-browser/fetchPageTool.test.ts
@@ -13,6 +13,7 @@ import { IFileContent, IReadFileOptions } from '../../../../../platform/files/co
 import { IWebContentExtractorService } from '../../../../../platform/webContentExtractor/common/webContentExtractor.js';
 import { FetchWebPageTool } from '../../electron-browser/tools/fetchPageTool.js';
 import { TestFileService } from '../../../../test/common/workbenchTestServices.js';
+import { MockTrustedDomainService } from '../../../url/test/browser/mockTrustedDomainService.js';
 
 class TestWebContentExtractorService implements IWebContentExtractorService {
 	_serviceBrand: undefined;
@@ -81,7 +82,8 @@ suite('FetchWebPageTool', () => {
 
 		const tool = new FetchWebPageTool(
 			new TestWebContentExtractorService(webContentMap),
-			new ExtendedTestFileService(fileContentMap)
+			new ExtendedTestFileService(fileContentMap),
+			new MockTrustedDomainService(),
 		);
 
 		const testUrls = [
@@ -128,7 +130,8 @@ suite('FetchWebPageTool', () => {
 	test('should handle empty and undefined URLs', async () => {
 		const tool = new FetchWebPageTool(
 			new TestWebContentExtractorService(new ResourceMap<string>()),
-			new ExtendedTestFileService(new ResourceMap<string | VSBuffer>())
+			new ExtendedTestFileService(new ResourceMap<string | VSBuffer>()),
+			new MockTrustedDomainService([]),
 		);
 
 		// Test empty array
@@ -175,7 +178,8 @@ suite('FetchWebPageTool', () => {
 
 		const tool = new FetchWebPageTool(
 			new TestWebContentExtractorService(webContentMap),
-			new ExtendedTestFileService(fileContentMap)
+			new ExtendedTestFileService(fileContentMap),
+			new MockTrustedDomainService(),
 		);
 
 		const preparation = await tool.prepareToolInvocation(
@@ -202,7 +206,8 @@ suite('FetchWebPageTool', () => {
 
 		const tool = new FetchWebPageTool(
 			new TestWebContentExtractorService(new ResourceMap<string>()),
-			new ExtendedTestFileService(fileContentMap)
+			new ExtendedTestFileService(fileContentMap),
+			new MockTrustedDomainService(),
 		);
 
 		const result = await tool.invoke(
@@ -248,7 +253,8 @@ suite('FetchWebPageTool', () => {
 
 		const tool = new FetchWebPageTool(
 			new TestWebContentExtractorService(new ResourceMap<string>()),
-			new ExtendedTestFileService(fileContentMap)
+			new ExtendedTestFileService(fileContentMap),
+			new MockTrustedDomainService(),
 		);
 
 		const result = await tool.invoke(
@@ -287,7 +293,8 @@ suite('FetchWebPageTool', () => {
 
 		const tool = new FetchWebPageTool(
 			new TestWebContentExtractorService(new ResourceMap<string>()),
-			new ExtendedTestFileService(fileContentMap)
+			new ExtendedTestFileService(fileContentMap),
+			new MockTrustedDomainService(),
 		);
 
 		const result = await tool.invoke(
@@ -332,7 +339,8 @@ suite('FetchWebPageTool', () => {
 
 		const tool = new FetchWebPageTool(
 			new TestWebContentExtractorService(new ResourceMap<string>()),
-			new ExtendedTestFileService(fileContentMap)
+			new ExtendedTestFileService(fileContentMap),
+			new MockTrustedDomainService(),
 		);
 
 		const result = await tool.invoke(
@@ -396,7 +404,8 @@ suite('FetchWebPageTool', () => {
 
 		const tool = new FetchWebPageTool(
 			new TestWebContentExtractorService(new ResourceMap<string>()),
-			new ExtendedTestFileService(fileContentMap)
+			new ExtendedTestFileService(fileContentMap),
+			new MockTrustedDomainService(),
 		);
 
 		const result = await tool.invoke(
@@ -434,7 +443,8 @@ suite('FetchWebPageTool', () => {
 
 		const tool = new FetchWebPageTool(
 			new TestWebContentExtractorService(new ResourceMap<string>()),
-			new ExtendedTestFileService(fileContentMap)
+			new ExtendedTestFileService(fileContentMap),
+			new MockTrustedDomainService(),
 		);
 
 		const result = await tool.invoke(
@@ -476,7 +486,8 @@ suite('FetchWebPageTool', () => {
 
 			const tool = new FetchWebPageTool(
 				new TestWebContentExtractorService(webContentMap),
-				new ExtendedTestFileService(fileContentMap)
+				new ExtendedTestFileService(fileContentMap),
+				new MockTrustedDomainService(),
 			);
 
 			const testUrls = [
@@ -533,7 +544,8 @@ suite('FetchWebPageTool', () => {
 
 			const tool = new FetchWebPageTool(
 				new TestWebContentExtractorService(webContentMap),
-				new ExtendedTestFileService(new ResourceMap<string | VSBuffer>())
+				new ExtendedTestFileService(new ResourceMap<string | VSBuffer>()),
+				new MockTrustedDomainService([]),
 			);
 
 			const testUrls = [
@@ -567,7 +579,8 @@ suite('FetchWebPageTool', () => {
 
 			const tool = new FetchWebPageTool(
 				new TestWebContentExtractorService(new ResourceMap<string>()),
-				new ExtendedTestFileService(fileContentMap)
+				new ExtendedTestFileService(fileContentMap),
+				new MockTrustedDomainService(),
 			);
 
 			const testUrls = [
@@ -607,7 +620,8 @@ suite('FetchWebPageTool', () => {
 
 			const tool = new FetchWebPageTool(
 				new TestWebContentExtractorService(webContentMap),
-				new ExtendedTestFileService(fileContentMap)
+				new ExtendedTestFileService(fileContentMap),
+				new MockTrustedDomainService(),
 			);
 
 			const testUrls = [
@@ -653,7 +667,8 @@ suite('FetchWebPageTool', () => {
 		test('should return empty toolResultDetails when all requests fail', async () => {
 			const tool = new FetchWebPageTool(
 				new TestWebContentExtractorService(new ResourceMap<string>()), // Empty - all web requests fail
-				new ExtendedTestFileService(new ResourceMap<string | VSBuffer>()) // Empty - all file requests fail
+				new ExtendedTestFileService(new ResourceMap<string | VSBuffer>()), // Empty - all file ,
+				new MockTrustedDomainService([]),
 			);
 
 			const testUrls = [
@@ -685,7 +700,8 @@ suite('FetchWebPageTool', () => {
 		test('should handle empty URL array', async () => {
 			const tool = new FetchWebPageTool(
 				new TestWebContentExtractorService(new ResourceMap<string>()),
-				new ExtendedTestFileService(new ResourceMap<string | VSBuffer>())
+				new ExtendedTestFileService(new ResourceMap<string | VSBuffer>()),
+				new MockTrustedDomainService([]),
 			);
 
 			const result = await tool.invoke(
@@ -709,7 +725,8 @@ suite('FetchWebPageTool', () => {
 
 			const tool = new FetchWebPageTool(
 				new TestWebContentExtractorService(new ResourceMap<string>()),
-				new ExtendedTestFileService(fileContentMap)
+				new ExtendedTestFileService(fileContentMap),
+				new MockTrustedDomainService(),
 			);
 
 			const result = await tool.invoke(

--- a/src/vs/workbench/contrib/chat/test/electron-browser/fetchPageTool.test.ts
+++ b/src/vs/workbench/contrib/chat/test/electron-browser/fetchPageTool.test.ts
@@ -10,23 +10,24 @@ import { URI } from '../../../../../base/common/uri.js';
 import { ResourceMap } from '../../../../../base/common/map.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { IFileContent, IReadFileOptions } from '../../../../../platform/files/common/files.js';
-import { IWebContentExtractorService } from '../../../../../platform/webContentExtractor/common/webContentExtractor.js';
+import { IWebContentExtractorService, WebContentExtractResult } from '../../../../../platform/webContentExtractor/common/webContentExtractor.js';
 import { FetchWebPageTool } from '../../electron-browser/tools/fetchPageTool.js';
 import { TestFileService } from '../../../../test/common/workbenchTestServices.js';
 import { MockTrustedDomainService } from '../../../url/test/browser/mockTrustedDomainService.js';
+import { InternalFetchWebPageToolId } from '../../common/tools/tools.js';
 
 class TestWebContentExtractorService implements IWebContentExtractorService {
 	_serviceBrand: undefined;
 
 	constructor(private uriToContentMap: ResourceMap<string>) { }
 
-	async extract(uris: URI[]): Promise<string[]> {
+	async extract(uris: URI[]): Promise<WebContentExtractResult[]> {
 		return uris.map(uri => {
 			const content = this.uriToContentMap.get(uri);
 			if (content === undefined) {
 				throw new Error(`No content configured for URI: ${uri.toString()}`);
 			}
-			return content;
+			return { status: 'ok', result: content };
 		});
 	}
 }
@@ -747,6 +748,119 @@ suite('FetchWebPageTool', () => {
 			// Check content types
 			assert.strictEqual(result.content[0].kind, 'data', 'Image should be data part');
 			assert.strictEqual(result.content[1].kind, 'text', 'Text file should be text part');
+		});
+
+		test('confirmResults is false when all web contents are errors or redirects', async () => {
+			const webContentMap = new ResourceMap<string>();
+
+			const tool = new FetchWebPageTool(
+				new class extends TestWebContentExtractorService {
+					constructor() {
+						super(webContentMap);
+					}
+					override async extract(uris: URI[]): Promise<WebContentExtractResult[]> {
+						return uris.map(() => ({ status: 'error', error: 'Failed to fetch' }));
+					}
+				}(),
+				new ExtendedTestFileService(new ResourceMap<string | VSBuffer>()),
+				new MockTrustedDomainService(),
+			);
+
+			const result = await tool.invoke(
+				{ callId: 'test-call', toolId: 'fetch-page', parameters: { urls: ['https://example.com'] }, context: undefined },
+				() => Promise.resolve(0),
+				{ report: () => { } },
+				CancellationToken.None
+			);
+
+			assert.strictEqual(result.confirmResults, false, 'confirmResults should be false when all results are errors');
+		});
+
+		test('confirmResults is false when all web contents are redirects', async () => {
+			const webContentMap = new ResourceMap<string>();
+
+			const tool = new FetchWebPageTool(
+				new class extends TestWebContentExtractorService {
+					constructor() {
+						super(webContentMap);
+					}
+					override async extract(uris: URI[]): Promise<WebContentExtractResult[]> {
+						return uris.map(() => ({ status: 'redirect', toURI: URI.parse('https://redirected.com') }));
+					}
+				}(),
+				new ExtendedTestFileService(new ResourceMap<string | VSBuffer>()),
+				new MockTrustedDomainService(),
+			);
+
+			const result = await tool.invoke(
+				{ callId: 'test-call', toolId: 'fetch-page', parameters: { urls: ['https://example.com'] }, context: undefined },
+				() => Promise.resolve(0),
+				{ report: () => { } },
+				CancellationToken.None
+			);
+
+			assert.strictEqual(result.confirmResults, false, 'confirmResults should be false when all results are redirects');
+		});
+
+		test('confirmResults is undefined when at least one web content succeeds', async () => {
+			const webContentMap = new ResourceMap<string>([
+				[URI.parse('https://success.com'), 'Success content']
+			]);
+
+			const tool = new FetchWebPageTool(
+				new class extends TestWebContentExtractorService {
+					constructor() {
+						super(webContentMap);
+					}
+					override async extract(uris: URI[]): Promise<WebContentExtractResult[]> {
+						return [
+							{ status: 'ok', result: 'Success content' },
+							{ status: 'error', error: 'Failed' }
+						];
+					}
+				}(),
+				new ExtendedTestFileService(new ResourceMap<string | VSBuffer>()),
+				new MockTrustedDomainService(),
+			);
+
+			const result = await tool.invoke(
+				{ callId: 'test-call', toolId: 'fetch-page', parameters: { urls: ['https://success.com', 'https://error.com'] }, context: undefined },
+				() => Promise.resolve(0),
+				{ report: () => { } },
+				CancellationToken.None
+			);
+
+			assert.strictEqual(result.confirmResults, undefined, 'confirmResults should be undefined when at least one result succeeds');
+		});
+
+		test('redirect result provides correct message with new URL', async () => {
+			const redirectURI = URI.parse('https://redirected.com/page');
+			const tool = new FetchWebPageTool(
+				new class extends TestWebContentExtractorService {
+					constructor() {
+						super(new ResourceMap<string>());
+					}
+					override async extract(uris: URI[]): Promise<WebContentExtractResult[]> {
+						return [{ status: 'redirect', toURI: redirectURI }];
+					}
+				}(),
+				new ExtendedTestFileService(new ResourceMap<string | VSBuffer>()),
+				new MockTrustedDomainService(),
+			);
+
+			const result = await tool.invoke(
+				{ callId: 'test-call', toolId: 'fetch-page', parameters: { urls: ['https://example.com'] }, context: undefined },
+				() => Promise.resolve(0),
+				{ report: () => { } },
+				CancellationToken.None
+			);
+
+			assert.strictEqual(result.content.length, 1);
+			assert.strictEqual(result.content[0].kind, 'text');
+			if (result.content[0].kind === 'text') {
+				assert.ok(result.content[0].value.includes(redirectURI.toString(true)), 'Redirect message should include target URL');
+				assert.ok(result.content[0].value.includes(InternalFetchWebPageToolId), 'Redirect message should suggest using tool again');
+			}
 		});
 	});
 });


### PR DESCRIPTION
- Trusted domains won't require preapproval any longer
- All #fetch'es will ask for postapproval
- Cleanup some re-rendering logic now that we have an observable `state`,
  previously the fetch tool UI did not show the postapproval.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
