### PR TITLE
Fix built-in/user/mcp sorting in tool picker

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/actions/chatContext.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatContext.ts
@@ -95,14 +95,18 @@ class ToolsContextPickerPick implements IChatContextPickerItem {
 		}
 
 		items.sort((a, b) => {
-			let res = a.toolInfo.ordinal - b.toolInfo.ordinal;
-			if (res === 0) {
-				res = a.toolInfo.label.localeCompare(b.toolInfo.label);
+			// Primary sort: by ordinal (Built-In=0, User=1, MCP/Extension=2)
+			const ordinalDiff = a.toolInfo.ordinal - b.toolInfo.ordinal;
+			if (ordinalDiff !== 0) {
+				return ordinalDiff;
 			}
-			if (res === 0) {
-				res = a.label.localeCompare(b.label);
+			// Secondary sort: by source label (within same ordinal group)
+			const labelComp = a.toolInfo.label.localeCompare(b.toolInfo.label);
+			if (labelComp !== 0) {
+				return labelComp;
 			}
-			return res;
+			// Tertiary sort: by tool name (within same source)
+			return a.label.localeCompare(b.label);
 		});
 
 		let lastGroupLabel: string | undefined;

--- a/src/vs/workbench/contrib/chat/browser/actions/chatToolPicker.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatToolPicker.ts
@@ -26,7 +26,7 @@ import { ChatContextKeys } from '../../common/chatContextKeys.js';
 import { ILanguageModelToolsService, IToolData, ToolDataSource, ToolSet } from '../../common/languageModelToolsService.js';
 import { ConfigureToolSets } from '../tools/toolSetsContribution.js';
 
-const enum BucketOrdinal { User, BuiltIn, Mcp, Extension }
+const enum BucketOrdinal { BuiltIn, User, Contributed }
 
 // Legacy QuickPick types (existing implementation)
 type BucketPick = IQuickPickItem & { picked: boolean; ordinal: BucketOrdinal; status?: string; toolset?: ToolSet; children: (ToolPick | ToolSetPick)[] };
@@ -309,7 +309,7 @@ export async function showToolsPicker(
 				}
 				const bucket: IBucketTreeItem = {
 					itemType: 'bucket',
-					ordinal: BucketOrdinal.Mcp,
+					ordinal: BucketOrdinal.Contributed,
 					id: key,
 					label: source.label,
 					checked: undefined,
@@ -327,7 +327,7 @@ export async function showToolsPicker(
 			} else if (source.type === 'extension') {
 				return {
 					itemType: 'bucket',
-					ordinal: BucketOrdinal.Extension,
+					ordinal: BucketOrdinal.Contributed,
 					id: key,
 					label: source.label,
 					checked: undefined,

--- a/src/vs/workbench/contrib/chat/common/languageModelToolsService.ts
+++ b/src/vs/workbench/contrib/chat/common/languageModelToolsService.ts
@@ -105,13 +105,13 @@ export namespace ToolDataSource {
 
 	export function classify(source: ToolDataSource): { readonly ordinal: number; readonly label: string } {
 		if (source.type === 'internal') {
-			return { ordinal: 1, label: localize('builtin', 'Built-In') };
+			return { ordinal: 0, label: localize('builtin', 'Built-In') };
 		} else if (source.type === 'mcp') {
 			return { ordinal: 2, label: source.label };
 		} else if (source.type === 'user') {
-			return { ordinal: 0, label: localize('user', 'User Defined') };
+			return { ordinal: 1, label: localize('user', 'User Defined') };
 		} else {
-			return { ordinal: 3, label: source.label };
+			return { ordinal: 2, label: source.label };
 		}
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/272773

## Changes

This PR fixes the tool picker sorting after PR #271572 removed the "MCP Server:" and "Extension:" prefixes from category labels. The removal of prefixes was correct, but the underlying sorting order needed adjustment.

### Problem
After #271572, the bucket sorting had an unintuitive order where "User Defined" tools appeared before "Built-In" tools, which users didn't expect since Built-In tools are core system functionality.

### Solution
Reordered the tool picker buckets to prioritize Built-In tools first:

**New order:**
- **Built-In** (ordinal 0) - Core system tools, always first
- **User Defined** (ordinal 1) - Custom user tool sets
- **Contributed** (ordinal 2) - MCP servers and Extensions, sorted alphabetically by name

### Implementation Details

1. **Updated `BucketOrdinal` enum** in `chatToolPicker.ts`:
   - Changed from `User, BuiltIn, Mcp, Extension` to `BuiltIn, User, Contributed`
   - MCP and Extension now share the same ordinal value, so they sort alphabetically together

2. **Updated ordinal assignments** in `languageModelToolsService.ts`:
   - Built-In: 1 → 0
   - User: 0 → 1
   - MCP: 2 (unchanged)
   - Extension: 3 → 2

3. **Clarified sorting logic** in `chatContext.ts`:
   - Added comments explaining the three-tier sort: ordinal → source label → tool name
   - Improved code readability without changing functionality

### Testing
- ✅ TypeScript compilation passes with 0 errors
- Tools now appear in the expected intuitive order
- MCP servers and extensions intermix alphabetically as intended