### PR TITLE
Show user description for tool tooltips

### DIFF
--- a/src/vs/workbench/contrib/chat/common/promptSyntax/languageProviders/promptHovers.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/languageProviders/promptHovers.ts
@@ -128,7 +128,7 @@ export class PromptHoverProvider implements HoverProvider {
 			if (tool instanceof ToolSet) {
 				return this.getToolsetHover(tool, range);
 			} else {
-				return this.createHover(tool.modelDescription, range);
+				return this.createHover(tool.userDescription ?? tool.modelDescription, range);
 			}
 		}
 		return undefined;


### PR DESCRIPTION
## Summary

Fixes tool hovers in chat prompts to display concise, user-friendly descriptions instead of verbose technical descriptions intended for language models.

## Changes

**File**: `src/vs/workbench/contrib/chat/common/promptSyntax/languageProviders/promptHovers.ts`

- Changed `getToolHoverByName()` method to use `tool.userDescription ?? tool.modelDescription` instead of only `tool.modelDescription`
- Now displays short descriptions like "Runs unit tests (optionally with coverage)" instead of long technical explanations

## Example

Before:
<img width="612" height="292" alt="image" src="https://github.com/user-attachments/assets/5969e993-fbe6-4207-841d-a63be8f6b997" />

After:
<img width="288" height="74" alt="image" src="https://github.com/user-attachments/assets/24bf5f6b-d7bf-4816-b61b-f28fdebdfabc" />


## Consistency

This change aligns the hover behavior with other parts of the codebase that already use this pattern:
- `chatAttachmentWidgets.ts:638`
- `chatToolPicker.ts:142`

The `modelDescription` field remains as a fallback for tools that haven't defined a `userDescription`, ensuring backward compatibility.