### PR TITLE
Enables next and previous navigation in multi file diff editor

### DIFF
--- a/src/vs/editor/browser/widget/multiDiffEditor/diffEditorItemTemplate.ts
+++ b/src/vs/editor/browser/widget/multiDiffEditor/diffEditorItemTemplate.ts
@@ -223,7 +223,6 @@ export class DiffEditorItemTemplate extends Disposable implements IPooledObject<
 				renderOverviewRuler: false,
 				fixedOverflowWidgets: true,
 				overviewRulerBorder: false,
-				renderGutterMenu: true,
 			};
 		}
 

--- a/src/vs/editor/browser/widget/multiDiffEditor/diffEditorItemTemplate.ts
+++ b/src/vs/editor/browser/widget/multiDiffEditor/diffEditorItemTemplate.ts
@@ -223,6 +223,7 @@ export class DiffEditorItemTemplate extends Disposable implements IPooledObject<
 				renderOverviewRuler: false,
 				fixedOverflowWidgets: true,
 				overviewRulerBorder: false,
+				renderGutterMenu: true,
 			};
 		}
 

--- a/src/vs/editor/browser/widget/multiDiffEditor/multiDiffEditorWidget.ts
+++ b/src/vs/editor/browser/widget/multiDiffEditor/multiDiffEditorWidget.ts
@@ -85,6 +85,14 @@ export class MultiDiffEditorWidget extends Disposable {
 	public findDocumentDiffItem(resource: URI): IDocumentDiffItem | undefined {
 		return this._widgetImpl.get().findDocumentDiffItem(resource);
 	}
+
+	public goToNextChange(): void {
+		this._widgetImpl.get().goToNextChange();
+	}
+
+	public goToPreviousChange(): void {
+		this._widgetImpl.get().goToPreviousChange();
+	}
 }
 
 export interface RevealOptions {

--- a/src/vs/editor/browser/widget/multiDiffEditor/multiDiffEditorWidgetImpl.ts
+++ b/src/vs/editor/browser/widget/multiDiffEditor/multiDiffEditorWidgetImpl.ts
@@ -372,6 +372,12 @@ export class MultiDiffEditorWidgetImpl extends Disposable {
 		}
 
 		const activeViewItem = viewItems[activeViewItemIndex];
+
+		// Ensure the current file is expanded before navigating
+		if (activeViewItem.viewModel.collapsed.get()) {
+			activeViewItem.viewModel.collapsed.set(false, undefined);
+		}
+
 		const template = activeViewItem.template.get();
 		if (!template) {
 			return;

--- a/src/vs/editor/browser/widget/multiDiffEditor/multiDiffEditorWidgetImpl.ts
+++ b/src/vs/editor/browser/widget/multiDiffEditor/multiDiffEditorWidgetImpl.ts
@@ -426,14 +426,7 @@ export class MultiDiffEditorWidgetImpl extends Disposable {
 		const nextIndex = direction === 'next' ? currentIndex + 1 : currentIndex - 1;
 
 		// Wrap around if needed
-		let targetIndex: number;
-		if (nextIndex >= viewItems.length) {
-			targetIndex = 0; // Wrap to first file
-		} else if (nextIndex < 0) {
-			targetIndex = viewItems.length - 1; // Wrap to last file
-		} else {
-			targetIndex = nextIndex;
-		}
+		const targetIndex = (nextIndex + viewItems.length) % viewItems.length;
 
 		const targetViewItem = viewItems[targetIndex];
 

--- a/src/vs/editor/common/editorContextKeys.ts
+++ b/src/vs/editor/common/editorContextKeys.ts
@@ -27,6 +27,7 @@ export namespace EditorContextKeys {
 	export const readOnly = new RawContextKey<boolean>('editorReadonly', false, nls.localize('editorReadonly', "Whether the editor is read-only"));
 	export const inDiffEditor = new RawContextKey<boolean>('inDiffEditor', false, nls.localize('inDiffEditor', "Whether the context is a diff editor"));
 	export const isEmbeddedDiffEditor = new RawContextKey<boolean>('isEmbeddedDiffEditor', false, nls.localize('isEmbeddedDiffEditor', "Whether the context is an embedded diff editor"));
+	export const inMultiDiffEditor = new RawContextKey<boolean>('inMultiDiffEditor', false, nls.localize('inMultiDiffEditor', "Whether the context is a multi diff editor"));
 	export const multiDiffEditorAllCollapsed = new RawContextKey<boolean>('multiDiffEditorAllCollapsed', undefined, nls.localize('multiDiffEditorAllCollapsed', "Whether all files in multi diff editor are collapsed"));
 	export const hasChanges = new RawContextKey<boolean>('diffEditorHasChanges', false, nls.localize('diffEditorHasChanges', "Whether the diff editor has changes"));
 	export const comparingMovedCode = new RawContextKey<boolean>('comparingMovedCode', false, nls.localize('comparingMovedCode', "Whether a moved code block is selected for comparison"));

--- a/src/vs/workbench/contrib/multiDiffEditor/browser/actions.ts
+++ b/src/vs/workbench/contrib/multiDiffEditor/browser/actions.ts
@@ -98,7 +98,7 @@ export class GoToNextChangeAction extends Action2 {
 			return;
 		}
 
-		(activeEditorPane as MultiDiffEditor).goToNextChange();
+		activeEditorPane.goToNextChange();
 	}
 }
 
@@ -132,7 +132,7 @@ export class GoToPreviousChangeAction extends Action2 {
 			return;
 		}
 
-		(activeEditorPane as MultiDiffEditor).goToPreviousChange();
+		activeEditorPane.goToPreviousChange();
 	}
 }
 

--- a/src/vs/workbench/contrib/multiDiffEditor/browser/actions.ts
+++ b/src/vs/workbench/contrib/multiDiffEditor/browser/actions.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Codicon } from '../../../../base/common/codicons.js';
+import { KeyCode, KeyMod } from '../../../../base/common/keyCodes.js';
 import { URI } from '../../../../base/common/uri.js';
 import { Selection } from '../../../../editor/common/core/selection.js';
 import { localize2 } from '../../../../nls.js';
@@ -11,6 +12,7 @@ import { Action2, MenuId } from '../../../../platform/actions/common/actions.js'
 import { ContextKeyExpr } from '../../../../platform/contextkey/common/contextkey.js';
 import { ITextEditorOptions, TextEditorSelectionRevealType } from '../../../../platform/editor/common/editor.js';
 import { ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
+import { KeybindingWeight } from '../../../../platform/keybinding/common/keybindingsRegistry.js';
 import { IListService } from '../../../../platform/list/browser/listService.js';
 import { resolveCommandsContext } from '../../../browser/parts/editor/editorCommandsContext.js';
 import { MultiDiffEditor } from './multiDiffEditor.js';
@@ -63,6 +65,74 @@ export class GoToFileAction extends Action2 {
 				selectionRevealType: TextEditorSelectionRevealType.CenterIfOutsideViewport,
 			} satisfies ITextEditorOptions,
 		});
+	}
+}
+
+export class GoToNextChangeAction extends Action2 {
+	constructor() {
+		super({
+			id: 'multiDiffEditor.goToNextChange',
+			title: localize2('goToNextChange', 'Go to Next Change'),
+			icon: Codicon.arrowDown,
+			precondition: ContextKeyExpr.equals('activeEditor', MultiDiffEditor.ID),
+			menu: [MenuId.EditorTitle, MenuId.CompactWindowEditorTitle].map(id => ({
+				id,
+				when: ContextKeyExpr.equals('activeEditor', MultiDiffEditor.ID),
+				group: 'navigation',
+				order: 2
+			})),
+			keybinding: {
+				primary: KeyMod.Alt | KeyCode.F5,
+				weight: KeybindingWeight.EditorContrib,
+				when: ContextKeyExpr.equals('activeEditor', MultiDiffEditor.ID),
+			},
+			f1: true,
+		});
+	}
+
+	async run(accessor: ServicesAccessor): Promise<void> {
+		const editorService = accessor.get(IEditorService);
+		const activeEditorPane = editorService.activeEditorPane;
+
+		if (!(activeEditorPane instanceof MultiDiffEditor)) {
+			return;
+		}
+
+		(activeEditorPane as MultiDiffEditor).goToNextChange();
+	}
+}
+
+export class GoToPreviousChangeAction extends Action2 {
+	constructor() {
+		super({
+			id: 'multiDiffEditor.goToPreviousChange',
+			title: localize2('goToPreviousChange', 'Go to Previous Change'),
+			icon: Codicon.arrowUp,
+			precondition: ContextKeyExpr.equals('activeEditor', MultiDiffEditor.ID),
+			menu: [MenuId.EditorTitle, MenuId.CompactWindowEditorTitle].map(id => ({
+				id,
+				when: ContextKeyExpr.equals('activeEditor', MultiDiffEditor.ID),
+				group: 'navigation',
+				order: 1
+			})),
+			keybinding: {
+				primary: KeyMod.Alt | KeyMod.Shift | KeyCode.F5,
+				weight: KeybindingWeight.EditorContrib,
+				when: ContextKeyExpr.equals('activeEditor', MultiDiffEditor.ID),
+			},
+			f1: true,
+		});
+	}
+
+	async run(accessor: ServicesAccessor): Promise<void> {
+		const editorService = accessor.get(IEditorService);
+		const activeEditorPane = editorService.activeEditorPane;
+
+		if (!(activeEditorPane instanceof MultiDiffEditor)) {
+			return;
+		}
+
+		(activeEditorPane as MultiDiffEditor).goToPreviousChange();
 	}
 }
 

--- a/src/vs/workbench/contrib/multiDiffEditor/browser/multiDiffEditor.contribution.ts
+++ b/src/vs/workbench/contrib/multiDiffEditor/browser/multiDiffEditor.contribution.ts
@@ -13,12 +13,14 @@ import { WorkbenchPhase, registerWorkbenchContribution2 } from '../../../common/
 import { EditorExtensions, IEditorFactoryRegistry } from '../../../common/editor.js';
 import { MultiDiffEditor } from './multiDiffEditor.js';
 import { MultiDiffEditorInput, MultiDiffEditorResolverContribution, MultiDiffEditorSerializer } from './multiDiffEditorInput.js';
-import { CollapseAllAction, ExpandAllAction, GoToFileAction } from './actions.js';
+import { CollapseAllAction, ExpandAllAction, GoToFileAction, GoToNextChangeAction, GoToPreviousChangeAction } from './actions.js';
 import { IMultiDiffSourceResolverService, MultiDiffSourceResolverService } from './multiDiffSourceResolverService.js';
 import { InstantiationType, registerSingleton } from '../../../../platform/instantiation/common/extensions.js';
 import { OpenScmGroupAction, ScmMultiDiffSourceResolverContribution } from './scmMultiDiffSourceResolver.js';
 
 registerAction2(GoToFileAction);
+registerAction2(GoToNextChangeAction);
+registerAction2(GoToPreviousChangeAction);
 registerAction2(CollapseAllAction);
 registerAction2(ExpandAllAction);
 

--- a/src/vs/workbench/contrib/multiDiffEditor/browser/multiDiffEditor.ts
+++ b/src/vs/workbench/contrib/multiDiffEditor/browser/multiDiffEditor.ts
@@ -26,18 +26,15 @@ import { MultiDiffEditorViewModel } from '../../../../editor/browser/widget/mult
 import { IMultiDiffEditorOptions, IMultiDiffEditorViewState } from '../../../../editor/browser/widget/multiDiffEditor/multiDiffEditorWidgetImpl.js';
 import { ICodeEditor } from '../../../../editor/browser/editorBrowser.js';
 import { IDiffEditor } from '../../../../editor/common/editorCommon.js';
-import { EditorContextKeys } from '../../../../editor/common/editorContextKeys.js';
 import { Range } from '../../../../editor/common/core/range.js';
 import { MultiDiffEditorItem } from './multiDiffSourceResolverService.js';
 import { IEditorProgressService } from '../../../../platform/progress/common/progress.js';
-import { IContextKeyService, IContextKey } from '../../../../platform/contextkey/common/contextkey.js';
 
 export class MultiDiffEditor extends AbstractEditorWithViewState<IMultiDiffEditorViewState> {
 	static readonly ID = 'multiDiffEditor';
 
 	private _multiDiffEditorWidget: MultiDiffEditorWidget | undefined = undefined;
 	private _viewModel: MultiDiffEditorViewModel | undefined;
-	private readonly _inMultiDiffEditorContextKey: IContextKey<boolean>;
 
 	public get viewModel(): MultiDiffEditorViewModel | undefined {
 		return this._viewModel;
@@ -53,7 +50,6 @@ export class MultiDiffEditor extends AbstractEditorWithViewState<IMultiDiffEdito
 		@IEditorGroupsService editorGroupService: IEditorGroupsService,
 		@ITextResourceConfigurationService textResourceConfigurationService: ITextResourceConfigurationService,
 		@IEditorProgressService private editorProgressService: IEditorProgressService,
-		@IContextKeyService contextKeyService: IContextKeyService,
 	) {
 		super(
 			MultiDiffEditor.ID,
@@ -67,7 +63,6 @@ export class MultiDiffEditor extends AbstractEditorWithViewState<IMultiDiffEdito
 			editorService,
 			editorGroupService
 		);
-		this._inMultiDiffEditorContextKey = EditorContextKeys.inMultiDiffEditor.bindTo(contextKeyService);
 	}
 
 	protected createEditor(parent: HTMLElement): void {
@@ -80,8 +75,6 @@ export class MultiDiffEditor extends AbstractEditorWithViewState<IMultiDiffEdito
 		this._register(this._multiDiffEditorWidget.onDidChangeActiveControl(() => {
 			this._onDidChangeControl.fire();
 		}));
-
-		this._inMultiDiffEditorContextKey.set(true);
 	}
 
 	override async setInput(input: MultiDiffEditorInput, options: IMultiDiffEditorOptions | undefined, context: IEditorOpenContext, token: CancellationToken): Promise<void> {
@@ -167,11 +160,6 @@ export class MultiDiffEditor extends AbstractEditorWithViewState<IMultiDiffEdito
 
 	public async showWhile(promise: Promise<unknown>): Promise<void> {
 		return this.editorProgressService.showWhile(promise);
-	}
-
-	override dispose(): void {
-		this._inMultiDiffEditorContextKey.reset();
-		super.dispose();
 	}
 }
 

--- a/src/vs/workbench/contrib/multiDiffEditor/browser/multiDiffEditor.ts
+++ b/src/vs/workbench/contrib/multiDiffEditor/browser/multiDiffEditor.ts
@@ -26,15 +26,18 @@ import { MultiDiffEditorViewModel } from '../../../../editor/browser/widget/mult
 import { IMultiDiffEditorOptions, IMultiDiffEditorViewState } from '../../../../editor/browser/widget/multiDiffEditor/multiDiffEditorWidgetImpl.js';
 import { ICodeEditor } from '../../../../editor/browser/editorBrowser.js';
 import { IDiffEditor } from '../../../../editor/common/editorCommon.js';
+import { EditorContextKeys } from '../../../../editor/common/editorContextKeys.js';
 import { Range } from '../../../../editor/common/core/range.js';
 import { MultiDiffEditorItem } from './multiDiffSourceResolverService.js';
 import { IEditorProgressService } from '../../../../platform/progress/common/progress.js';
+import { IContextKeyService, IContextKey } from '../../../../platform/contextkey/common/contextkey.js';
 
 export class MultiDiffEditor extends AbstractEditorWithViewState<IMultiDiffEditorViewState> {
 	static readonly ID = 'multiDiffEditor';
 
 	private _multiDiffEditorWidget: MultiDiffEditorWidget | undefined = undefined;
 	private _viewModel: MultiDiffEditorViewModel | undefined;
+	private readonly _inMultiDiffEditorContextKey: IContextKey<boolean>;
 
 	public get viewModel(): MultiDiffEditorViewModel | undefined {
 		return this._viewModel;
@@ -50,6 +53,7 @@ export class MultiDiffEditor extends AbstractEditorWithViewState<IMultiDiffEdito
 		@IEditorGroupsService editorGroupService: IEditorGroupsService,
 		@ITextResourceConfigurationService textResourceConfigurationService: ITextResourceConfigurationService,
 		@IEditorProgressService private editorProgressService: IEditorProgressService,
+		@IContextKeyService contextKeyService: IContextKeyService,
 	) {
 		super(
 			MultiDiffEditor.ID,
@@ -63,6 +67,7 @@ export class MultiDiffEditor extends AbstractEditorWithViewState<IMultiDiffEdito
 			editorService,
 			editorGroupService
 		);
+		this._inMultiDiffEditorContextKey = EditorContextKeys.inMultiDiffEditor.bindTo(contextKeyService);
 	}
 
 	protected createEditor(parent: HTMLElement): void {
@@ -75,6 +80,8 @@ export class MultiDiffEditor extends AbstractEditorWithViewState<IMultiDiffEdito
 		this._register(this._multiDiffEditorWidget.onDidChangeActiveControl(() => {
 			this._onDidChangeControl.fire();
 		}));
+
+		this._inMultiDiffEditorContextKey.set(true);
 	}
 
 	override async setInput(input: MultiDiffEditorInput, options: IMultiDiffEditorOptions | undefined, context: IEditorOpenContext, token: CancellationToken): Promise<void> {
@@ -150,8 +157,21 @@ export class MultiDiffEditor extends AbstractEditorWithViewState<IMultiDiffEdito
 		return i2.multiDiffEditorItem;
 	}
 
+	public goToNextChange(): void {
+		this._multiDiffEditorWidget?.goToNextChange();
+	}
+
+	public goToPreviousChange(): void {
+		this._multiDiffEditorWidget?.goToPreviousChange();
+	}
+
 	public async showWhile(promise: Promise<unknown>): Promise<void> {
 		return this.editorProgressService.showWhile(promise);
+	}
+
+	override dispose(): void {
+		this._inMultiDiffEditorContextKey.reset();
+		super.dispose();
 	}
 }
 


### PR DESCRIPTION
In single file diff editor, user can navigate through changes using next / previous functionality. This change enables the same in multi-file diff editor (gif attached). Fixes issue: https://github.com/microsoft/vscode/issues/264299

Notes:
If the change is out of view, will scroll to bring this in view. 
If file is collapsed, will expand the file to make the change visible. 

![multiFileDiffEditor](https://github.com/user-attachments/assets/7264ecc3-6dff-4f66-b373-af83f8f6c238)
