### PR TITLE
Enabled search in agent sessions panes for GH coding agent, local ses…

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatSessions/view/sessionsViewPane.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSessions/view/sessionsViewPane.ts
@@ -348,6 +348,16 @@ export class SessionsViewPane extends ViewPane {
 				},
 				accessibilityProvider,
 				identityProvider,
+				keyboardNavigationLabelProvider: {
+					getKeyboardNavigationLabel: (session: ChatSessionItemWithProvider) => {
+						const parts = [
+							session.label || '',
+							session.id || '',
+							typeof session.description === 'string' ? session.description : (session.description?.value || '')
+						];
+						return parts.filter(text => text.length > 0).join(' ');
+					}
+				},
 				multipleSelectionSupport: false,
 				overrideStyles: {
 					listBackground: undefined


### PR DESCRIPTION
Enabled find functionality for agent sessions in following panes: GH coding agent, Codex CLI, local sessions. Works with nested tree view

Attached gif shows this in action.

![sessionsSearch](https://github.com/user-attachments/assets/24aa6be0-6068-45c0-9fd3-72eafdb5eb22)
