### PR TITLE
SCM - fix sync action spinning icon

### DIFF
--- a/src/vs/workbench/contrib/scm/browser/media/scm.css
+++ b/src/vs/workbench/contrib/scm/browser/media/scm.css
@@ -79,7 +79,7 @@
 	min-width: 20px;
 
 	.action-label > span:nth-child(1) {
-		padding-right: 2px;
+		margin-right: 2px;
 	}
 }
 
@@ -88,7 +88,6 @@
 	text-overflow: ellipsis;
 	white-space: nowrap;
 	min-width: 0;
-	direction: rtl;
 }
 
 .scm-view .scm-provider > .actions > .monaco-toolbar > .monaco-action-bar > .actions-container > .action-item:nth-child(1) > .action-label > .codicon {


### PR DESCRIPTION
Fix sync action and move the text ellipsis back to the right-hand side.