### PR TITLE
Simplify git clone API

### DIFF
--- a/extensions/git/src/api/api1.ts
+++ b/extensions/git/src/api/api1.ts
@@ -395,6 +395,11 @@ export class ApiImpl implements API {
 		}
 	}
 
+	async getRepositoryWorkspace(uri: Uri): Promise<Uri[] | null> {
+		const workspaces = this.#model.repositoryCache.get(uri.toString());
+		return workspaces ? workspaces.map(r => Uri.file(r.workspacePath)) : null;
+	}
+
 	async init(root: Uri, options?: InitOptions): Promise<Repository | null> {
 		const path = root.fsPath;
 		await this.#model.git.init(path, options);
@@ -404,7 +409,7 @@ export class ApiImpl implements API {
 
 	async clone(uri: Uri, options?: CloneOptions): Promise<Uri | null> {
 		const parentPath = options?.parentPath?.fsPath;
-		const result = await this.#cloneManager.clone(uri.toString(), { parentPath, recursive: options?.recursive, ref: options?.ref, postCloneAction: options?.postCloneAction, skipCache: options?.skipCache });
+		const result = await this.#cloneManager.clone(uri.toString(), { parentPath, recursive: options?.recursive, ref: options?.ref, postCloneAction: options?.postCloneAction });
 		return result ? Uri.file(result) : null;
 	}
 

--- a/extensions/git/src/api/git.d.ts
+++ b/extensions/git/src/api/git.d.ts
@@ -193,8 +193,7 @@ export interface CloneOptions {
 	/**
 	 * If no postCloneAction is provided, then the users setting for git.openAfterClone is used.
 	 */
-	postCloneAction?: 'none' | 'open' | 'prompt';
-	skipCache?: boolean;
+	postCloneAction?: 'none';
 }
 
 export interface RefQuery {
@@ -379,9 +378,12 @@ export interface API {
 	toGitUri(uri: Uri, ref: string): Uri;
 	getRepository(uri: Uri): Repository | null;
 	getRepositoryRoot(uri: Uri): Promise<Uri | null>;
+	getRepositoryWorkspace(uri: Uri): Promise<Uri[] | null>;
 	init(root: Uri, options?: InitOptions): Promise<Repository | null>;
 	/**
-	 * @returns The URI of either the cloned repository, or the workspace file or folder which contains the cloned repository.
+	 * Checks the cache of known cloned repositories, and clones if the repository is not found.
+	 * Make sure to pass `postCloneAction` 'none' if you want to have the uri where you can find the repository returned.
+	 * @returns The URI of a folder or workspace file which, when opened, will open the cloned repository.
 	 */
 	clone(uri: Uri, options?: CloneOptions): Promise<Uri | null>;
 	openRepository(root: Uri): Promise<Repository | null>;


### PR DESCRIPTION
- Don't allow to skip the cache
- Only have "none" post commit action
- Consolidate post commit logic
- I ended up keeping the `Uri | null` return type for the `clone` API. It's just too useful, and there's no reason why we couldn't pass it back if the user didn't decide to open the clone and reload the window.