### PR TITLE
Ensure regular model picker keybinding doesn't work for coding agent locked chats

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/actions/chatExecuteActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatExecuteActions.ts
@@ -397,7 +397,7 @@ class OpenModelPickerAction extends Action2 {
 			keybinding: {
 				primary: KeyMod.CtrlCmd | KeyMod.Alt | KeyCode.Period,
 				weight: KeybindingWeight.WorkbenchContrib,
-				when: ChatContextKeys.inChatInput
+				when: ContextKeyExpr.and(ChatContextKeys.inChatInput, ChatContextKeys.lockedToCodingAgent.negate()),
 			},
 			precondition: ChatContextKeys.enabled,
 			menu: {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Fixes https://github.com/microsoft/vscode/issues/272964