### PR TITLE
Keep quick pick's progress bar rendered, and use aria-hidden to hide from a11y tree

### DIFF
--- a/src/vs/platform/quickinput/browser/quickInput.ts
+++ b/src/vs/platform/quickinput/browser/quickInput.ts
@@ -420,12 +420,14 @@ export abstract class QuickInput extends Disposable implements IQuickInput {
 			this.busyDelay = new TimeoutTimer();
 			this.busyDelay.setIfNotSet(() => {
 				if (this.visible) {
-					this.ui.progressBar.infinite().show();
+					this.ui.progressBar.infinite();
+					this.ui.progressBar.getContainer().removeAttribute('aria-hidden');
 				}
 			}, 800);
 		}
 		if (!this.busy && this.busyDelay) {
-			this.ui.progressBar.stop().hide();
+			this.ui.progressBar.stop();
+			this.ui.progressBar.getContainer().setAttribute('aria-hidden', 'true');
 			this.busyDelay.cancel();
 			this.busyDelay = undefined;
 		}

--- a/src/vs/platform/quickinput/browser/quickInputController.ts
+++ b/src/vs/platform/quickinput/browser/quickInputController.ts
@@ -648,7 +648,8 @@ export class QuickInputController extends Disposable {
 		ui.visibleCount.setCount(0);
 		ui.count.setCount(0);
 		dom.reset(ui.message);
-		ui.progressBar.stop().hide();
+		ui.progressBar.stop();
+		ui.progressBar.getContainer().setAttribute('aria-hidden', 'true');
 		ui.list.setElements([]);
 		ui.list.matchOnDescription = false;
 		ui.list.matchOnDetail = false;


### PR DESCRIPTION
Fixes #272985