### PR TITLE
Use argument-hint for prompt placeholders

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/contrib/chatInputEditorContrib.ts
+++ b/src/vs/workbench/contrib/chat/browser/contrib/chatInputEditorContrib.ts
@@ -146,7 +146,7 @@ class InputEditorDecorations extends Disposable {
 			if (this.configurationService.getValue<boolean>('chat.emptyChatState.enabled')) {
 				placeholder = localize('chatPlaceholderHint', "Add context (#), extensions (@), commands (/)");
 			} else {
-				placeholder = mode.description.get() ?? '';
+				placeholder = mode.argumentHint?.get() ?? mode.description.get() ?? '';
 			}
 
 			const decoration: IDecorationOptions[] = [
@@ -252,7 +252,7 @@ class InputEditorDecorations extends Disposable {
 			// Resolve the prompt file (this will use cache if available)
 			const promptFile = this.promptsService.resolvePromptSlashCommandFromCache(slashPromptPart.slashPromptCommand.command);
 
-			const description = promptFile?.header?.description;
+			const description = promptFile?.header?.argumentHint ?? promptFile?.header?.description;
 			if (description) {
 				placeholderDecoration = [{
 					range: getRangeForPlaceholder(slashPromptPart),


### PR DESCRIPTION
## Summary

Updates chat input placeholder text to prioritize `argument-hint` over `description` for prompts and agents, providing better guidance about expected inputs.

<img width="861" height="594" alt="image" src="https://github.com/user-attachments/assets/c4108ba7-4d7d-4632-a8a4-c6f8caaf8e0d" />

And Fallback:

<img width="861" height="594" alt="image" src="https://github.com/user-attachments/assets/06a7833d-973a-475f-be25-ee05075a42c2" />


## Implementation

**Modified:** `src/vs/workbench/contrib/chat/browser/contrib/chatInputEditorContrib.ts`

### Changes:

1. **Agent mode placeholders (line 149):**
   - Now checks `mode.argumentHint?.get()` first before falling back to `mode.description.get()`
   - Provides contextual hints about what inputs the agent expects

2. **Slash prompt command placeholders (line 255):**
   - Uses `promptFile?.header?.argumentHint` with fallback to `promptFile?.header?.description`
   - Shows argument hints for prompts when available

### Behavior:

- When a prompt/agent defines `argument-hint` in its header, that text displays as the placeholder
- Falls back to `description` if no `argument-hint` is defined (maintains existing behavior)
- Leverages infrastructure added in #272918

## Related

- Builds on #272918 (argument-hint parsing support)
- Follows #271187 (placeholder UI implementation)