### PR TITLE
Rename 'partial' checkbox state to 'mixed' to be consistent with a11y value

### DIFF
--- a/src/vs/base/browser/ui/toggle/toggle.ts
+++ b/src/vs/base/browser/ui/toggle/toggle.ts
@@ -349,7 +349,7 @@ export class Checkbox extends BaseCheckbox {
 export class TriStateCheckbox extends BaseCheckbox {
 	constructor(
 		title: string,
-		private _state: boolean | 'partial',
+		private _state: boolean | 'mixed',
 		styles: ICheckboxStyles
 	) {
 		let icon: ThemeIcon | undefined;
@@ -357,7 +357,7 @@ export class TriStateCheckbox extends BaseCheckbox {
 			case true:
 				icon = Codicon.check;
 				break;
-			case 'partial':
+			case 'mixed':
 				icon = Codicon.dash;
 				break;
 			case false:
@@ -386,11 +386,11 @@ export class TriStateCheckbox extends BaseCheckbox {
 		}));
 	}
 
-	get checked(): boolean | 'partial' {
+	get checked(): boolean | 'mixed' {
 		return this._state;
 	}
 
-	set checked(newState: boolean | 'partial') {
+	set checked(newState: boolean | 'mixed') {
 		if (this._state !== newState) {
 			this._state = newState;
 			this.checkbox.checked = newState === true;
@@ -403,7 +403,7 @@ export class TriStateCheckbox extends BaseCheckbox {
 			case true:
 				this.checkbox.setIcon(Codicon.check);
 				break;
-			case 'partial':
+			case 'mixed':
 				this.checkbox.setIcon(Codicon.dash);
 				break;
 			case false:

--- a/src/vs/platform/quickinput/browser/tree/quickInputTree.ts
+++ b/src/vs/platform/quickinput/browser/tree/quickInputTree.ts
@@ -12,15 +12,15 @@ export interface IQuickTreeFilterData {
 	readonly descriptionHighlights?: IMatch[];
 }
 
-export function getParentNodeState(parentChildren: ITreeNode<IQuickTreeItem | null, IQuickTreeFilterData>[] | IObjectTreeElement<IQuickTreeItem>[]): boolean | 'partial' {
+export function getParentNodeState(parentChildren: ITreeNode<IQuickTreeItem | null, IQuickTreeFilterData>[] | IObjectTreeElement<IQuickTreeItem>[]): boolean | 'mixed' {
 	let containsChecks = false;
 	let containsUnchecks = false;
-	let containsPartial = false;
+	let containsMixed = false;
 
 	for (const element of parentChildren) {
 		switch (element.element?.checked) {
-			case 'partial':
-				containsPartial = true;
+			case 'mixed':
+				containsMixed = true;
 				break;
 			case true:
 				containsChecks = true;
@@ -29,18 +29,18 @@ export function getParentNodeState(parentChildren: ITreeNode<IQuickTreeItem | nu
 				containsUnchecks = true;
 				break;
 		}
-		if (containsChecks && containsUnchecks && containsPartial) {
+		if (containsChecks && containsUnchecks && containsMixed) {
 			break;
 		}
 	}
 	const newState = containsUnchecks
-		? containsPartial
-			? 'partial'
+		? containsMixed
+			? 'mixed'
 			: containsChecks
-				? 'partial'
+				? 'mixed'
 				: false
-		: containsPartial
-			? 'partial'
+		: containsMixed
+			? 'mixed'
 			: containsChecks;
 	return newState;
 }

--- a/src/vs/platform/quickinput/browser/tree/quickInputTreeAccessibilityProvider.ts
+++ b/src/vs/platform/quickinput/browser/tree/quickInputTreeAccessibilityProvider.ts
@@ -37,7 +37,7 @@ export class QuickTreeAccessibilityProvider<T extends IQuickTreeItem> implements
 
 	isChecked(element: T): IValueWithChangeEvent<CheckBoxAccessibleState> | undefined {
 		return {
-			get value() { return element.checked === 'partial' ? 'mixed' : !!element.checked; },
+			get value() { return element.checked === 'mixed' ? 'mixed' : !!element.checked; },
 			onDidChange: e => Event.filter(this.onCheckedEvent, e => e.item === element)(_ => e()),
 		};
 	}

--- a/src/vs/platform/quickinput/browser/tree/quickInputTreeController.ts
+++ b/src/vs/platform/quickinput/browser/tree/quickInputTreeController.ts
@@ -313,7 +313,7 @@ export class QuickInputTreeController extends Disposable {
 		return this._tree.getFocus().filter((item): item is IQuickTreeItem => item !== null);
 	}
 
-	check(element: IQuickTreeItem, checked: boolean | 'partial') {
+	check(element: IQuickTreeItem, checked: boolean | 'mixed') {
 		if (element.checked === checked) {
 			return;
 		}
@@ -321,7 +321,7 @@ export class QuickInputTreeController extends Disposable {
 		this._onDidCheckedLeafItemsChange.fire(this.getCheckedLeafItems());
 	}
 
-	checkAll(checked: boolean | 'partial') {
+	checkAll(checked: boolean | 'mixed') {
 		const updated = new Set<IQuickTreeItem>();
 		const toUpdate = [...this._tree.getNode().children];
 		let fireCheckedChangeEvent = false;

--- a/src/vs/platform/quickinput/browser/tree/quickTree.ts
+++ b/src/vs/platform/quickinput/browser/tree/quickTree.ts
@@ -86,7 +86,7 @@ export class QuickTree<T extends IQuickTreeItem> extends QuickInput implements I
 		return this.ui.tree.tree.getParentElement(element) as T ?? undefined;
 	}
 
-	setCheckboxState(element: T, checked: boolean | 'partial'): void {
+	setCheckboxState(element: T, checked: boolean | 'mixed'): void {
 		this.ui.tree.check(element, checked);
 	}
 	expand(element: T): void {
@@ -139,7 +139,7 @@ export class QuickTree<T extends IQuickTreeItem> extends QuickInput implements I
 		}
 		super.show(); // TODO: Why have show() bubble up while update() trickles down?
 
-		// Intial state
+		// Initial state
 		// TODO@TylerLeonhardt: Without this setTimeout, the screen reader will not read out
 		// the final count of checked items correctly. Investigate a better way
 		// to do this. ref https://github.com/microsoft/vscode/issues/258617

--- a/src/vs/platform/quickinput/common/quickInput.ts
+++ b/src/vs/platform/quickinput/common/quickInput.ts
@@ -1136,7 +1136,7 @@ export interface IQuickTree<T extends IQuickTreeItem> extends IQuickInput {
 	 * @param element The item to update.
 	 * @param checked The new checkbox state.
 	 */
-	setCheckboxState(element: T, checked: boolean | 'partial'): void;
+	setCheckboxState(element: T, checked: boolean | 'mixed'): void;
 
 	/**
 	 * Expands an item.
@@ -1180,12 +1180,12 @@ export interface IQuickTree<T extends IQuickTreeItem> extends IQuickInput {
  */
 export interface IQuickTreeItem extends IQuickItem {
 	/**
-	 * The checked state of the item. Can be true, false, or 'partial' for tri-state.
+	 * The checked state of the item. Can be true, false, or 'mixed' for tri-state.
 	 * When canSelectMany is false, this is ignored and the item is treated as a single selection.
 	 * When canSelectMany is true, this indicates the checkbox state of the item.
 	 * If undefined, the item is unchecked by default.
 	 */
-	checked?: boolean | 'partial';
+	checked?: boolean | 'mixed';
 
 	/**
 	 * The collapsible state of the tree item. Defaults to 'Expanded' if children are present.
@@ -1217,7 +1217,7 @@ export interface IQuickTreeCheckboxEvent<T extends IQuickTreeItem> {
 	/**
 	 * The new checked state.
 	 */
-	checked: boolean | 'partial';
+	checked: boolean | 'mixed';
 }
 
 /**

--- a/src/vs/workbench/contrib/chat/browser/actions/chatToolPicker.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatToolPicker.ts
@@ -56,7 +56,7 @@ interface IBucketTreeItem extends IToolTreeItem {
 	toolset?: ToolSet; // For MCP servers where the bucket represents the ToolSet - mutable
 	readonly status?: string;
 	readonly children: AnyTreeItem[];
-	checked: boolean | 'partial' | undefined;
+	checked: boolean | 'mixed' | undefined;
 }
 
 /**
@@ -67,7 +67,7 @@ interface IToolSetTreeItem extends IToolTreeItem {
 	readonly itemType: 'toolset';
 	readonly toolset: ToolSet;
 	children: AnyTreeItem[] | undefined;
-	checked: boolean | 'partial';
+	checked: boolean | 'mixed';
 }
 
 /**

--- a/src/vs/workbench/contrib/search/browser/anythingQuickAccess.ts
+++ b/src/vs/workbench/contrib/search/browser/anythingQuickAccess.ts
@@ -264,7 +264,7 @@ export class AnythingQuickAccessProvider extends PickerQuickAccessProvider<IAnyt
 			return Disposable.None; // we need a text editor control to decorate and reveal
 		}
 
-		// we must remember our curret view state to be able to restore
+		// we must remember our current view state to be able to restore
 		this.pickState.editorViewState.set();
 
 		// Reveal
@@ -912,7 +912,7 @@ export class AnythingQuickAccessProvider extends PickerQuickAccessProvider<IAnyt
 		// Bring the editor to front to review symbols to go to
 		try {
 
-			// we must remember our curret view state to be able to restore
+			// we must remember our current view state to be able to restore
 			this.pickState.editorViewState.set();
 
 			// open it


### PR DESCRIPTION
Follow up on https://github.com/microsoft/vscode/pull/272610.
In addition, fixed some spelling mistakes.