### PR TITLE
Fix session open in a new window actions

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/actions/chatSessionActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatSessionActions.ts
@@ -27,7 +27,6 @@ import { IViewsService } from '../../../../services/views/common/viewsService.js
 import { ChatContextKeys } from '../../common/chatContextKeys.js';
 import { IChatService } from '../../common/chatService.js';
 import { IChatSessionsService } from '../../common/chatSessionsService.js';
-import { ChatSessionUri } from '../../common/chatUri.js';
 import { ChatConfiguration, AGENT_SESSIONS_VIEWLET_ID } from '../../common/constants.js';
 import { ChatViewId, IChatWidgetService } from '../chat.js';
 import { IChatEditorOptions } from '../chatEditor.js';
@@ -183,7 +182,8 @@ export class OpenChatSessionInNewWindowAction extends Action2 {
 		const sessionId = context.session.id;
 		const editorGroupsService = accessor.get(IEditorGroupsService);
 		if (context.session.provider?.chatSessionType) {
-			const uri = ChatSessionUri.forSession(context.session.provider.chatSessionType, sessionId);
+			const uri = context.session.resource;
+
 			// Check if this session is already open in another editor
 			const existingEditor = findExistingChatEditorByUri(uri, sessionId, editorGroupsService);
 			if (existingEditor) {
@@ -240,7 +240,7 @@ export class OpenChatSessionInNewEditorGroupAction extends Action2 {
 		const sessionId = context.session.id;
 		const editorGroupsService = accessor.get(IEditorGroupsService);
 		if (context.session.provider?.chatSessionType) {
-			const uri = ChatSessionUri.forSession(context.session.provider.chatSessionType, sessionId);
+			const uri = context.session.resource;
 			// Check if this session is already open in another editor
 			const existingEditor = findExistingChatEditorByUri(uri, sessionId, editorGroupsService);
 			if (existingEditor) {
@@ -298,9 +298,8 @@ export class OpenChatSessionInSidebarAction extends Action2 {
 		const editorGroupsService = accessor.get(IEditorGroupsService);
 		const sessionId = context.session.id;
 		if (context.session.provider?.chatSessionType) {
-			const uri = ChatSessionUri.forSession(context.session.provider.chatSessionType, sessionId);
 			// Check if this session is already open in another editor
-			const existingEditor = findExistingChatEditorByUri(uri, sessionId, editorGroupsService);
+			const existingEditor = findExistingChatEditorByUri(context.session.resource, sessionId, editorGroupsService);
 			if (existingEditor) {
 				await editorService.openEditor(existingEditor.editor, existingEditor.groupId);
 				return;
@@ -316,10 +315,7 @@ export class OpenChatSessionInSidebarAction extends Action2 {
 			if (context.session && (isLocalChatSessionItem(context.session))) {
 				await chatViewPane.loadSession(sessionId);
 			} else {
-				// For external provider sessions, create a URI and load using that
-				const providerType = context.session.provider?.chatSessionType || 'external';
-				const sessionUri = ChatSessionUri.forSession(providerType, sessionId);
-				await chatViewPane.loadSession(sessionUri);
+				await chatViewPane.loadSession(context.session.resource);
 			}
 
 			// Focus the chat input


### PR DESCRIPTION
We should use the session uri now instead of trying to create the URI ourselves