### PR TITLE
Disable `open in sidebar` action for non-native sessions

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/actions/chatSessionActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatSessionActions.ts
@@ -466,6 +466,7 @@ MenuRegistry.appendMenuItem(MenuId.ChatSessionsMenu, {
 	},
 	group: 'navigation',
 	order: 3,
+	when: ChatContextKeys.sessionType.isEqualTo('local'),
 });
 
 // Register the toggle command for the ViewTitle menu


### PR DESCRIPTION
We can only support this for sessions that use our native chat UI. We can't correctly support it for ones that use custom editors or terminals

For now, I'm thinking we should just limit it to local sessions. In the future we could instead allow it for any session with a content provider

