### PR TITLE
fix: remoteAgentConnection should attempt to reconnect on RemoteAuthorityResolverError

### DIFF
--- a/src/vs/platform/remote/common/remoteAgentConnection.ts
+++ b/src/vs/platform/remote/common/remoteAgentConnection.ts
@@ -701,10 +701,10 @@ export abstract class PersistentConnection extends Disposable {
 					continue;
 				}
 				if (err instanceof RemoteAuthorityResolverError) {
-					this._options.logService.error(`${logPrefix} A RemoteAuthorityResolverError occurred while trying to reconnect. Will give up now! Error:`);
+					this._options.logService.error(`${logPrefix} A RemoteAuthorityResolverError occurred while trying to reconnect. Error:`);
 					this._options.logService.error(err);
-					this._onReconnectionPermanentFailure(this.protocol.getMillisSinceLastIncomingData(), attempt + 1, RemoteAuthorityResolverError.isHandled(err));
-					break;
+					// try again!
+					continue;
 				}
 				this._options.logService.error(`${logPrefix} An unknown error occurred while trying to reconnect, since this is an unknown case, it will be treated as a permanent error! Will give up now! Error:`);
 				this._options.logService.error(err);


### PR DESCRIPTION
Addresses issues in: https://github.com/microsoft/vscode-remote-release/issues/3096

This PR is an attempt to resolve VSCode aggressively forcing users to Reload their IDE when experiencing temporary network issues. 

`_runReconnectingLoop` in `remoteAgentConnection.ts` will currently fail the remote connection on any `RemoteAuthorityResolverErrors` that are not `TemporarilyNotAvailable`. That logic is flawed. It will immediately fail the remote connection in scenarios like:
* switching networks when moving around the office,
* macOS while sleeping will wake up it's network interfaces occasionaly - this causes VSCode to fail the [remote connection keepalive](https://github.com/microsoft/vscode/blame/main/src/vs/base/parts/ipc/common/ipc.net.ts).

The actual vscode-server still runs on the remote server and can be gracefully reconnected to - if allowed to.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
