### PR TITLE
Increase codicon font-size and adjust padding in SCM history view

### DIFF
--- a/src/vs/workbench/contrib/scm/browser/media/scm.css
+++ b/src/vs/workbench/contrib/scm/browser/media/scm.css
@@ -205,7 +205,7 @@
 }
 
 .scm-view .monaco-list-row .history-item > .label-container > .label > .codicon {
-	font-size: 14px;
+	font-size: 16px;
 	color: inherit !important;
 	padding: 2px;
 }

--- a/src/vs/workbench/contrib/scm/browser/media/scm.css
+++ b/src/vs/workbench/contrib/scm/browser/media/scm.css
@@ -205,7 +205,6 @@
 }
 
 .scm-view .monaco-list-row .history-item > .label-container > .label > .codicon {
-	font-size: 16px;
 	color: inherit !important;
 	padding: 1px;
 }
@@ -572,7 +571,6 @@
 
 .monaco-hover.history-item-hover .hover-row.status-bar .action .codicon {
 	color: inherit;
-	font-size: 16px;
 }
 
 .monaco-hover.history-item-hover .markdown-hover .hover-contents:not(.code-hover-contents):not(.html-hover-contents) span.codicon {
@@ -619,7 +617,6 @@
 
 .monaco-toolbar .action-label.scm-graph-repository-picker .codicon,
 .monaco-toolbar .action-label.scm-graph-history-item-picker .codicon {
-	font-size: 16px;
 	color: inherit;
 }
 

--- a/src/vs/workbench/contrib/scm/browser/media/scm.css
+++ b/src/vs/workbench/contrib/scm/browser/media/scm.css
@@ -207,7 +207,7 @@
 .scm-view .monaco-list-row .history-item > .label-container > .label > .codicon {
 	font-size: 16px;
 	color: inherit !important;
-	padding: 2px;
+	padding: 1px;
 }
 
 .scm-view .monaco-list-row .history-item > .label-container > .label > .codicon.codicon-git-branch {
@@ -572,7 +572,11 @@
 
 .monaco-hover.history-item-hover .hover-row.status-bar .action .codicon {
 	color: inherit;
-	font-size: 12px;
+	font-size: 16px;
+}
+
+.monaco-hover.history-item-hover .markdown-hover .hover-contents:not(.code-hover-contents):not(.html-hover-contents) span.codicon {
+	font-size: 16px;
 }
 
 /* Graph */

--- a/src/vs/workbench/contrib/scm/browser/media/scm.css
+++ b/src/vs/workbench/contrib/scm/browser/media/scm.css
@@ -573,10 +573,6 @@
 	color: inherit;
 }
 
-.monaco-hover.history-item-hover .markdown-hover .hover-contents:not(.code-hover-contents):not(.html-hover-contents) span.codicon {
-	font-size: 16px;
-}
-
 /* Graph */
 
 .pane-header .scm-graph-view-badge-container {

--- a/src/vs/workbench/contrib/scm/browser/media/scm.css
+++ b/src/vs/workbench/contrib/scm/browser/media/scm.css
@@ -615,7 +615,7 @@
 
 .monaco-toolbar .action-label.scm-graph-repository-picker .codicon,
 .monaco-toolbar .action-label.scm-graph-history-item-picker .codicon {
-	font-size: 14px;
+	font-size: 16px;
 	color: inherit;
 }
 


### PR DESCRIPTION
Enhance the visibility of codicons in the SCM history view by increasing their font size to 16px and reducing padding to 1px. This improves the overall user experience and consistency across various components.

Before:
<img width="896" height="152" alt="image" src="https://github.com/user-attachments/assets/74379943-80b7-4e1a-9c10-1aca9c142dae" />


After:
<img width="899" height="189" alt="image" src="https://github.com/user-attachments/assets/b4d25bc3-ed22-4409-84a8-08b088756ea5" />
