### PR TITLE
Make checks grey, errors red

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/media/chat.css
@@ -2179,8 +2179,8 @@ have to be updated for changes to the rules above, or to support more deeply nes
 		/* Very aggressive list styles try to apply focus colors to every codicon in a list row. */
 		color: var(--vscode-icon-foreground) !important;
 
-		&.codicon-check {
-			color: var(--vscode-debugIcon-startForeground) !important;
+		&.codicon-error {
+			color: var(--vscode-editorError-foreground) !important;
 		}
 	}
 


### PR DESCRIPTION
Fixes #273104

<img width="902" height="1720" alt="image" src="https://github.com/user-attachments/assets/5fac1cba-4519-4577-894e-7ecb877818a9" />
