### PR TITLE
Add jumpToEdit support for inline completions

### DIFF
--- a/src/vs/editor/common/languages.ts
+++ b/src/vs/editor/common/languages.ts
@@ -854,6 +854,7 @@ export interface InlineCompletionDisplayLocation {
 	range: IRange;
 	kind: InlineCompletionDisplayLocationKind;
 	label: string;
+	jumpToEdit: boolean;
 }
 
 /**

--- a/src/vs/editor/contrib/inlineCompletions/browser/model/inlineCompletionsModel.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/model/inlineCompletionsModel.ts
@@ -73,14 +73,7 @@ export class InlineCompletionsModel extends Disposable {
 			return false;
 		}
 
-		const targetRange = state.inlineCompletion.targetRange;
-		const visibleRanges = this._editorObs.editor.getVisibleRanges();
-		if (visibleRanges.length < 1) {
-			return false;
-		}
-
-		const viewportRange = new Range(visibleRanges[0].startLineNumber, visibleRanges[0].startColumn, visibleRanges[visibleRanges.length - 1].endLineNumber, visibleRanges[visibleRanges.length - 1].endColumn);
-		return viewportRange.containsRange(targetRange);
+		return isSuggestionInViewport(this._editor, state.inlineCompletion);
 	});
 	public get isAcceptingPartially() { return this._isAcceptingPartially; }
 
@@ -828,7 +821,7 @@ export class InlineCompletionsModel extends Disposable {
 		if (this._tabShouldIndent.read(reader)) {
 			return false;
 		}
-		if (this._inAcceptFlow.read(reader) && this._appearedInsideViewport.read(reader)) {
+		if (this._inAcceptFlow.read(reader) && this._appearedInsideViewport.read(reader) && !s.inlineCompletion.displayLocation?.jumpToEdit) {
 			return true;
 		}
 		if (s.inlineCompletion.targetRange.startLineNumber === this._editorObs.cursorLineNumber.read(reader)) {
@@ -1120,6 +1113,8 @@ export class InlineCompletionsModel extends Disposable {
 				this._editor.revealRange(revealRange, ScrollType.Immediate);
 			}
 
+			s.inlineCompletion.identity.setJumpTo(tx);
+
 			this._editor.focus();
 		});
 	}
@@ -1209,4 +1204,15 @@ class FadeoutDecoration extends Disposable {
 			}
 		}));
 	}
+}
+
+function isSuggestionInViewport(editor: ICodeEditor, suggestion: InlineSuggestionItem): boolean {
+	const targetRange = suggestion.targetRange;
+	const visibleRanges = editor.getVisibleRanges();
+	if (visibleRanges.length < 1) {
+		return false;
+	}
+
+	const viewportRange = new Range(visibleRanges[0].startLineNumber, visibleRanges[0].startColumn, visibleRanges[visibleRanges.length - 1].endLineNumber, visibleRanges[visibleRanges.length - 1].endColumn);
+	return viewportRange.containsRange(targetRange);
 }

--- a/src/vs/editor/contrib/inlineCompletions/browser/model/inlineCompletionsSource.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/model/inlineCompletionsSource.ts
@@ -270,6 +270,7 @@ export class InlineCompletionsSource extends Disposable {
 						text: c.insertText,
 						isInlineEdit: !!c.isInlineEdit,
 						source: c.source.provider.groupId,
+						displayLocation: c.displayLocation ? { label: c.displayLocation.label, range: c.displayLocation.range.toString(), kind: c.displayLocation.kind, jumpToEdit: c.displayLocation.jumpToEdit } : undefined,
 					}));
 					this._log({ sourceId: 'InlineCompletions.fetch', kind: 'end', requestId, durationMs: (Date.now() - startTime.getTime()), error, result, time: Date.now(), didAllProvidersReturn });
 				}

--- a/src/vs/editor/contrib/inlineCompletions/browser/model/provideInlineCompletions.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/model/provideInlineCompletions.ts
@@ -231,7 +231,8 @@ function toInlineSuggestData(
 	const displayLocation = inlineCompletion.displayLocation ? {
 		range: Range.lift(inlineCompletion.displayLocation.range),
 		label: inlineCompletion.displayLocation.label,
-		kind: inlineCompletion.displayLocation.kind
+		kind: inlineCompletion.displayLocation.kind,
+		jumpToEdit: inlineCompletion.displayLocation.jumpToEdit,
 	} : undefined;
 
 	return new InlineSuggestData(
@@ -476,6 +477,7 @@ export interface IDisplayLocation {
 	range: Range;
 	label: string;
 	kind: InlineCompletionDisplayLocationKind;
+	jumpToEdit: boolean;
 }
 
 export enum InlineCompletionEditorType {

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsView.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsView.ts
@@ -46,7 +46,7 @@ export class InlineEditsView extends Disposable {
 
 	private readonly _tabAction;
 
-	private _previousView: { // TODO, move into identitiy
+	private _previousView: { // TODO, move into identity
 		id: string;
 		view: ReturnType<typeof InlineEditsView.prototype.determineView>;
 		editorWidth: number;

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsView.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsView.ts
@@ -46,7 +46,7 @@ export class InlineEditsView extends Disposable {
 
 	private readonly _tabAction;
 
-	private _previousView: {
+	private _previousView: { // TODO, move into identitiy
 		id: string;
 		view: ReturnType<typeof InlineEditsView.prototype.determineView>;
 		editorWidth: number;
@@ -384,7 +384,7 @@ export class InlineEditsView extends Disposable {
 	private determineView(model: IInlineEditModel, reader: IReader, diff: DetailedLineRangeMapping[], newText: StringText): InlineCompletionViewKind {
 		// Check if we can use the previous view if it is the same InlineCompletion as previously shown
 		const inlineEdit = model.inlineEdit;
-		const canUseCache = this._previousView?.id === this.getCacheId(model);
+		const canUseCache = this._previousView?.id === this.getCacheId(model) && !model.displayLocation?.jumpToEdit;
 		const reconsiderViewEditorWidthChange = this._previousView?.editorWidth !== this._editorObs.layoutInfoWidth.read(reader) &&
 			(
 				this._previousView?.view === InlineCompletionViewKind.SideBySide ||
@@ -395,7 +395,7 @@ export class InlineEditsView extends Disposable {
 			return this._previousView!.view;
 		}
 
-		if (model.displayLocation) {
+		if (model.displayLocation && !model.inlineEdit.inlineCompletion.identity.jumpedTo.read(reader)) {
 			return InlineCompletionViewKind.Custom;
 		}
 

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -7566,6 +7566,7 @@ declare namespace monaco.languages {
 		range: IRange;
 		kind: InlineCompletionDisplayLocationKind;
 		label: string;
+		jumpToEdit: boolean;
 	}
 
 	/**

--- a/src/vs/workbench/api/common/extHostLanguageFeatures.ts
+++ b/src/vs/workbench/api/common/extHostLanguageFeatures.ts
@@ -1440,6 +1440,7 @@ class InlineCompletionAdapter {
 						range: typeConvert.Range.from(item.displayLocation.range),
 						label: item.displayLocation.label,
 						kind: item.displayLocation.kind ? typeConvert.InlineCompletionDisplayLocationKind.from(item.displayLocation.kind) : InlineCompletionDisplayLocationKind.Code,
+						jumpToEdit: item.displayLocation.jumpToEdit ?? false,
 					} : undefined,
 					warning: (item.warning && this._isAdditionsProposedApiEnabled) ? {
 						message: typeConvert.MarkdownString.from(item.warning.message),

--- a/src/vscode-dts/vscode.proposed.inlineCompletionsAdditions.d.ts
+++ b/src/vscode-dts/vscode.proposed.inlineCompletionsAdditions.d.ts
@@ -78,6 +78,7 @@ declare module 'vscode' {
 		range: Range;
 		kind: InlineCompletionDisplayLocationKind;
 		label: string;
+		jumpToEdit?: boolean;
 	}
 
 	export interface InlineCompletionWarning {


### PR DESCRIPTION
```Copilot Generated Description:``` Introduce a `jumpToEdit` property in the inline completion display location, allowing for enhanced handling of inline suggestions. Update related logic to accommodate this new property across various components.