### PR TITLE
Remove error handling from inline suggestions

### DIFF
--- a/src/vs/editor/common/languages.ts
+++ b/src/vs/editor/common/languages.ts
@@ -1033,7 +1033,6 @@ export type LifetimeSummary = {
 	notShownReason: string | undefined;
 	editorType: string;
 	viewKind: string | undefined;
-	error: string | undefined;
 	preceeded: boolean;
 	languageId: string;
 	requestReason: string;

--- a/src/vs/editor/contrib/inlineCompletions/browser/model/inlineCompletionsSource.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/model/inlineCompletionsSource.ts
@@ -418,7 +418,6 @@ export class InlineCompletionsSource extends Disposable {
 			timeUntilProviderResponse: undefined,
 			viewKind: undefined,
 			preceeded: undefined,
-			error: undefined,
 			superseded: undefined,
 			reason: undefined,
 			correlationId: undefined,

--- a/src/vs/editor/contrib/inlineCompletions/browser/model/inlineSuggestionItem.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/model/inlineSuggestionItem.ts
@@ -118,10 +118,6 @@ abstract class InlineSuggestionItemBase {
 		this._data.setEndOfLifeReason(reason);
 	}
 
-	public reportInlineEditError(reason: string): void {
-		this._data.reportInlineEditError(reason);
-	}
-
 	public setIsPreceeded(item: InlineSuggestionItem): void {
 		this._data.setIsPreceeded(item.partialAccepts);
 	}

--- a/src/vs/editor/contrib/inlineCompletions/browser/model/provideInlineCompletions.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/model/provideInlineCompletions.ts
@@ -275,7 +275,6 @@ export type InlineSuggestViewData = {
 	editorType: InlineCompletionEditorType;
 	renderData?: InlineCompletionViewData;
 	viewKind?: InlineCompletionViewKind;
-	error?: string;
 };
 
 export class InlineSuggestData {
@@ -395,21 +394,12 @@ export class InlineSuggestData {
 				requestReason: this._requestInfo.reason,
 				viewKind: this._viewData.viewKind,
 				notShownReason: this._notShownReason,
-				error: this._viewData.error,
 				typingInterval: this._requestInfo.typingInterval,
 				typingIntervalCharacterCount: this._requestInfo.typingIntervalCharacterCount,
 				availableProviders: this._requestInfo.availableProviders.map(p => p.toString()).join(','),
 				...this._viewData.renderData,
 			};
 			this.source.provider.handleEndOfLifetime(this.source.inlineSuggestions, this.sourceInlineCompletion, reason, summary);
-		}
-	}
-
-	public reportInlineEditError(message: string): void {
-		if (this._viewData.error) {
-			this._viewData.error += `; ${message}`;
-		} else {
-			this._viewData.error = message;
 		}
 	}
 

--- a/src/vs/editor/contrib/inlineCompletions/browser/telemetry.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/telemetry.ts
@@ -38,7 +38,6 @@ export type InlineCompletionEndOfLifeEvent = {
 	partiallyAcceptedCharactersSinceOriginal: number | undefined;
 	preceeded: boolean | undefined;
 	superseded: boolean | undefined;
-	error: string | undefined;
 	notShownReason: string | undefined;
 	// rendering
 	viewKind: string | undefined;
@@ -78,7 +77,6 @@ type InlineCompletionsEndOfLifeClassification = {
 	preceeded: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Whether the inline completion was preceeded by another one' };
 	languageId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The language ID of the document where the inline completion was shown' };
 	requestReason: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The reason for the inline completion request' };
-	error: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The error message if the inline completion failed' };
 	typingInterval: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The average typing interval of the user at the moment the inline completion was requested' };
 	typingIntervalCharacterCount: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The character count involved in the typing interval calculation' };
 	superseded: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Whether the inline completion was superseded by another one' };

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsModel.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsModel.ts
@@ -49,12 +49,6 @@ export class InlineEditModel implements IInlineEditModel {
 		this._model.jump();
 	}
 
-	abort(reason: string) {
-		console.error(reason);
-		this.inlineEdit.inlineCompletion.reportInlineEditError(reason);
-		this._model.stop();
-	}
-
 	handleInlineEditShown(viewKind: InlineCompletionViewKind, viewData: InlineCompletionViewData) {
 		this._model.handleInlineSuggestionShown(this.inlineEdit.inlineCompletion, viewKind, viewData);
 	}

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsView.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsView.ts
@@ -5,7 +5,7 @@
 
 import { $ } from '../../../../../../base/browser/dom.js';
 import { equalsIfDefined, itemEquals } from '../../../../../../base/common/equals.js';
-import { BugIndicatingError } from '../../../../../../base/common/errors.js';
+import { BugIndicatingError, onUnexpectedError } from '../../../../../../base/common/errors.js';
 import { Event } from '../../../../../../base/common/event.js';
 import { Disposable } from '../../../../../../base/common/lifecycle.js';
 import { autorun, autorunWithStore, derived, derivedOpts, IObservable, IReader, ISettableObservable, mapObservableArrayCached, observableValue } from '../../../../../../base/common/observable.js';
@@ -85,7 +85,7 @@ export class InlineEditsView extends Disposable {
 
 			let state = this.determineRenderState(model, reader, diff, new StringText(newText));
 			if (!state) {
-				model.abort(`unable to determine view: tried to render ${this._previousView?.view}`);
+				onUnexpectedError(`unable to determine view: tried to render ${this._previousView?.view}`);
 				return undefined;
 			}
 

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsView.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsView.ts
@@ -85,7 +85,7 @@ export class InlineEditsView extends Disposable {
 
 			let state = this.determineRenderState(model, reader, diff, new StringText(newText));
 			if (!state) {
-				onUnexpectedError(`unable to determine view: tried to render ${this._previousView?.view}`);
+				onUnexpectedError(new Error(`unable to determine view: tried to render ${this._previousView?.view}`));
 				return undefined;
 			}
 

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViewInterface.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViewInterface.ts
@@ -39,7 +39,6 @@ export interface IInlineEditModel {
 	handleInlineEditShown(viewKind: string, viewData?: InlineCompletionViewData): void;
 	accept(): void;
 	jump(): void;
-	abort(reason: string): void;
 }
 
 // TODO: Move this out of here as it is also includes ghosttext

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -7671,7 +7671,6 @@ declare namespace monaco.languages {
 		notShownReason: string | undefined;
 		editorType: string;
 		viewKind: string | undefined;
-		error: string | undefined;
 		preceeded: boolean;
 		languageId: string;
 		requestReason: string;

--- a/src/vs/workbench/api/browser/mainThreadLanguageFeatures.ts
+++ b/src/vs/workbench/api/browser/mainThreadLanguageFeatures.ts
@@ -731,7 +731,6 @@ export class MainThreadLanguageFeatures extends Disposable implements MainThread
 					viewKind: lifetimeSummary.viewKind,
 					preceeded: lifetimeSummary.preceeded,
 					requestReason: lifetimeSummary.requestReason,
-					error: lifetimeSummary.error,
 					typingInterval: lifetimeSummary.typingInterval,
 					typingIntervalCharacterCount: lifetimeSummary.typingIntervalCharacterCount,
 					languageId: lifetimeSummary.languageId,


### PR DESCRIPTION
```Copilot Generated Description:``` Remove error properties and related handling from inline suggestion data structures and methods. This includes eliminating error reporting and associated logic throughout the relevant classes and interfaces.