### PR TITLE
Jump instead of indent

### DIFF
--- a/src/vs/editor/contrib/inlineCompletions/browser/model/inlineCompletionsModel.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/model/inlineCompletionsModel.ts
@@ -803,7 +803,7 @@ export class InlineCompletionsModel extends Disposable {
 			return true;
 		}
 
-		if (this._inAcceptFlow.read(reader) && this._appearedInsideViewport.read(reader)) {
+		if (this._inAcceptFlow.read(reader) && this._appearedInsideViewport.read(reader) && !s.inlineCompletion.displayLocation?.jumpToEdit) {
 			return false;
 		}
 


### PR DESCRIPTION
```Copilot Generated Description:``` Modify the condition to prevent jumping to edit when inline completion display location is set to jump.