### PR TITLE
Fix backward selection when EditContext is off

### DIFF
--- a/src/vs/editor/browser/controller/editContext/screenReaderUtils.ts
+++ b/src/vs/editor/browser/controller/editContext/screenReaderUtils.ts
@@ -27,7 +27,7 @@ export interface ISimpleScreenReaderContentState {
 	selectionEnd: number;
 
 	/** the editor range in the view coordinate system that matches the selection inside `value` */
-	selection: Range;
+	selection: Selection;
 
 	/** the position of the start of the `value` in the editor */
 	startPositionWithinEditor: Position;

--- a/src/vs/editor/browser/controller/editContext/textArea/textAreaEditContext.ts
+++ b/src/vs/editor/browser/controller/editContext/textArea/textAreaEditContext.ts
@@ -263,8 +263,15 @@ export class TextAreaEditContext extends AbstractEditContext {
 					return TextAreaState.EMPTY;
 				}
 
-				const screenReaderContentState = simplePagedScreenReaderStrategy.fromEditorSelection(this._context.viewModel, this._selections[0], this._accessibilityPageSize, this._accessibilitySupport === AccessibilitySupport.Unknown);
-				return TextAreaState.fromScreenReaderContentState(screenReaderContentState);
+				const selection = this._selections[0];
+				const screenReaderContentState = simplePagedScreenReaderStrategy.fromEditorSelection(
+					this._context.viewModel,
+					selection,
+					this._accessibilityPageSize,
+					this._accessibilitySupport === AccessibilitySupport.Unknown);
+				return TextAreaState.fromScreenReaderContentState(
+					screenReaderContentState,
+					selection.getDirection());
 			},
 
 			deduceModelPosition: (viewAnchorPosition: Position, deltaOffset: number, lineFeedCnt: number): Position => {

--- a/src/vs/editor/browser/controller/editContext/textArea/textAreaEditContext.ts
+++ b/src/vs/editor/browser/controller/editContext/textArea/textAreaEditContext.ts
@@ -263,15 +263,8 @@ export class TextAreaEditContext extends AbstractEditContext {
 					return TextAreaState.EMPTY;
 				}
 
-				const selection = this._selections[0];
-				const screenReaderContentState = simplePagedScreenReaderStrategy.fromEditorSelection(
-					this._context.viewModel,
-					selection,
-					this._accessibilityPageSize,
-					this._accessibilitySupport === AccessibilitySupport.Unknown);
-				return TextAreaState.fromScreenReaderContentState(
-					screenReaderContentState,
-					selection.getDirection());
+				const screenReaderContentState = simplePagedScreenReaderStrategy.fromEditorSelection(this._context.viewModel, this._selections[0], this._accessibilityPageSize, this._accessibilitySupport === AccessibilitySupport.Unknown);
+				return TextAreaState.fromScreenReaderContentState(screenReaderContentState);
 			},
 
 			deduceModelPosition: (viewAnchorPosition: Position, deltaOffset: number, lineFeedCnt: number): Position => {

--- a/src/vs/editor/browser/controller/editContext/textArea/textAreaEditContextState.ts
+++ b/src/vs/editor/browser/controller/editContext/textArea/textAreaEditContextState.ts
@@ -3,9 +3,11 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { assertNever } from '../../../../../base/common/assert.js';
 import { commonPrefixLength, commonSuffixLength } from '../../../../../base/common/strings.js';
 import { Position } from '../../../../common/core/position.js';
 import { Range } from '../../../../common/core/range.js';
+import { SelectionDirection } from '../../../../common/core/selection.js';
 import { ISimpleScreenReaderContentState } from '../screenReaderUtils.js';
 
 export const _debugComposition = false;
@@ -225,11 +227,25 @@ export class TextAreaState {
 		};
 	}
 
-	public static fromScreenReaderContentState(screenReaderContentState: ISimpleScreenReaderContentState) {
+	public static fromScreenReaderContentState(
+		screenReaderContentState: ISimpleScreenReaderContentState,
+		direction: SelectionDirection,
+	) {
+		let selectionStart;
+		let selectionEnd;
+		if (direction === SelectionDirection.LTR) {
+			selectionStart = screenReaderContentState.selectionStart;
+			selectionEnd = screenReaderContentState.selectionEnd;
+		} else if (direction === SelectionDirection.RTL) {
+			selectionStart = screenReaderContentState.selectionEnd;
+			selectionEnd = screenReaderContentState.selectionStart;
+		} else {
+			assertNever(direction, 'Unknown selection direction');
+		}
 		return new TextAreaState(
 			screenReaderContentState.value,
-			screenReaderContentState.selectionStart,
-			screenReaderContentState.selectionEnd,
+			selectionStart,
+			selectionEnd,
 			screenReaderContentState.selection,
 			screenReaderContentState.newlineCountBeforeSelection
 		);

--- a/src/vs/editor/browser/controller/editContext/textArea/textAreaEditContextState.ts
+++ b/src/vs/editor/browser/controller/editContext/textArea/textAreaEditContextState.ts
@@ -3,7 +3,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { assertNever } from '../../../../../base/common/assert.js';
 import { commonPrefixLength, commonSuffixLength } from '../../../../../base/common/strings.js';
 import { Position } from '../../../../common/core/position.js';
 import { Range } from '../../../../common/core/range.js';
@@ -227,20 +226,19 @@ export class TextAreaState {
 		};
 	}
 
-	public static fromScreenReaderContentState(
-		screenReaderContentState: ISimpleScreenReaderContentState,
-		direction: SelectionDirection,
-	) {
+	public static fromScreenReaderContentState(screenReaderContentState: ISimpleScreenReaderContentState) {
 		let selectionStart;
 		let selectionEnd;
-		if (direction === SelectionDirection.LTR) {
-			selectionStart = screenReaderContentState.selectionStart;
-			selectionEnd = screenReaderContentState.selectionEnd;
-		} else if (direction === SelectionDirection.RTL) {
-			selectionStart = screenReaderContentState.selectionEnd;
-			selectionEnd = screenReaderContentState.selectionStart;
-		} else {
-			assertNever(direction, 'Unknown selection direction');
+		const direction = screenReaderContentState.selection.getDirection();
+		switch (direction) {
+			case SelectionDirection.LTR:
+				selectionStart = screenReaderContentState.selectionStart;
+				selectionEnd = screenReaderContentState.selectionEnd;
+				break;
+			case SelectionDirection.RTL:
+				selectionStart = screenReaderContentState.selectionEnd;
+				selectionEnd = screenReaderContentState.selectionStart;
+				break;
 		}
 		return new TextAreaState(
 			screenReaderContentState.value,


### PR DESCRIPTION
Similar to #259042 fixing selectionDirection for `TextAreaEditContext`.

Fixes  #273146 
