### PR TITLE
Add a happy path for URI path normalization when we can just return t…

### DIFF
--- a/src/vs/base/common/path.ts
+++ b/src/vs/base/common/path.ts
@@ -96,6 +96,9 @@ function isWindowsDeviceRoot(code: number) {
 
 // Resolves . and .. elements in a path with directory names
 function normalizeString(path: string, allowAboveRoot: boolean, separator: string, isPathSeparator: (code?: number) => boolean) {
+	if (!path.includes('./') {
+		return path;
+	}
 	let res = '';
 	let lastSegmentLength = 0;
 	let lastSlash = -1;


### PR DESCRIPTION
…he incoming value

String search should work very efficiently - for the path without ./ and ../ we typically expect one dot symbol for the file extension, so it will mostly only compare each symbol with dot.

This should save us a lot or operations (and memory allocation) for most cases when relative paths are not used.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
