### PR TITLE
Fix chatInput matches check for custom schemes

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatEditorInput.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditorInput.ts
@@ -140,15 +140,11 @@ export class ChatEditorInput extends EditorInput implements IEditorCloseHandler 
 			return false;
 		}
 
-		if (this.resource.scheme === Schemas.vscodeChatSession) {
-			return isEqual(this.resource, otherInput.resource);
-		}
-
 		if (this.resource.scheme === Schemas.vscodeChatEditor && otherInput.resource.scheme === Schemas.vscodeChatEditor) {
 			return this.sessionId === otherInput.sessionId;
 		}
 
-		return false;
+		return isEqual(this.resource, otherInput.resource);
 	}
 
 	override get typeId(): string {


### PR DESCRIPTION
This could result in duplicate editors being opened in some cases

