### PR TITLE
PROTOTYPE: Lightweight rendering of fixed scroll height

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/media/chat.css
@@ -2922,39 +2922,33 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	.chat-thinking-fixed-header {
 		display: flex;
 		align-items: center;
-		gap: 4px;
-		border: 1px solid var(--vscode-chat-requestBorder);
-		color: var(--vscode-interactive-session-foreground);
-		opacity: 0.85;
+		gap: 7px;
+		font-size: var(--vscode-chat-font-size-body-s);
+		font-family: var(--vscode-chat-font-family, inherit);
+		color: var(--vscode-descriptionForeground);
 		outline: none;
-		margin: 3px;
-		border: none;
+		padding-top: 2px;
 
 		&:focus-visible {
 			outline: 1px solid var(--vscode-focusBorder);
 			outline-offset: -1px;
 		}
 
-		.chat-thinking-fixed-title-icon {
-			font-size: 16px;
-			margin-left: auto;
-			line-height: 0;
-		}
-
-		.chat-thinking-fixed-title-icon .codicon-check {
-			color: var(--vscode-debugIcon-startForeground) !important;
-		}
-
 		.monaco-button {
-			display: flex;
+			display: inline-flex;
 			align-items: center;
-			width: 100%;
+			width: fit-content;
 			border: none;
+			border-radius: 4px;
 			outline: none;
-			padding: 3px 8px;
+			padding: 2px 6px 2px 2px;
+			text-align: initial;
+			justify-content: initial;
+			gap: 4px;
 
 			&:hover {
-				background: var(--vscode-toolbar-hoverBackground);
+				background-color: var(--vscode-list-hoverBackground);
+				color: var(--vscode-foreground);
 			}
 		}
 
@@ -2967,9 +2961,8 @@ have to be updated for changes to the rules above, or to support more deeply nes
 			outline-offset: -1px;
 		}
 
-		.chat-thinking-item-caret {
-			margin-left: auto;
-			font-size: 12px;
+		.monaco-button .codicon {
+			font-size: var(--vscode-chat-font-size-body-s);
 		}
 
 		.monaco-button-label,
@@ -2984,8 +2977,6 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	.chat-thinking-fixed-height-controller {
 		display: flex;
 		flex-direction: column;
-		border: 1px solid var(--vscode-chat-requestBorder);
-		border-radius: 4px;
 		margin-bottom: 8px;
 
 		&.collapsed {
@@ -3009,9 +3000,8 @@ have to be updated for changes to the rules above, or to support more deeply nes
 
 	/* item and dot rendering */
 	.chat-used-context-list.chat-thinking-collapsible {
-		border: none;
-		border-top: 1px solid var(--vscode-chat-requestBorder);
-		border-radius: 0;
+		border: 1px solid var(--vscode-chat-requestBorder);
+		border-radius: 4px;
 		margin-bottom: 0;
 		position: relative;
 		overflow: hidden;


### PR DESCRIPTION
This prototype updates the fixed height scrolling thinking part to be consistent with the general tool invocation (e.g. Search tool invocation)

<img width="411" height="253" alt="image" src="https://github.com/user-attachments/assets/8120ec15-9469-42af-b8a8-cbaac57dc99c" />

<img width="409" height="686" alt="image" src="https://github.com/user-attachments/assets/a3dfb1e3-709d-4abe-888e-cf15b4b70656" />

<img width="411" height="225" alt="image" src="https://github.com/user-attachments/assets/24ac10e7-f4b9-47df-bf67-03ef3b2bb123" />

cc @bpasero per https://github.com/microsoft/vscode/issues/273029
