### PR TITLE
Enable Inner Scopes Option for Sticky Scroll

### DIFF
--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -3102,6 +3102,10 @@ export interface IEditorStickyScrollOptions {
 	 * Define whether to scroll sticky scroll with editor horizontal scrollbae
 	 */
 	scrollWithEditor?: boolean;
+	/**
+	 * Define whether to show outer scopes or inner scopes when the max line count is reached
+	 */
+	scopePreference?: 'outerScopes' | 'innerScopes';
 }
 
 /**
@@ -3112,7 +3116,7 @@ export type EditorStickyScrollOptions = Readonly<Required<IEditorStickyScrollOpt
 class EditorStickyScroll extends BaseEditorOption<EditorOption.stickyScroll, IEditorStickyScrollOptions, EditorStickyScrollOptions> {
 
 	constructor() {
-		const defaults: EditorStickyScrollOptions = { enabled: true, maxLineCount: 5, defaultModel: 'outlineModel', scrollWithEditor: true };
+		const defaults: EditorStickyScrollOptions = { enabled: true, maxLineCount: 5, defaultModel: 'outlineModel', scrollWithEditor: true, scopePreference: 'outerScopes' };
 		super(
 			EditorOption.stickyScroll, 'stickyScroll', defaults,
 			{
@@ -3139,6 +3143,16 @@ class EditorStickyScroll extends BaseEditorOption<EditorOption.stickyScroll, IEd
 					default: defaults.scrollWithEditor,
 					description: nls.localize('editor.stickyScroll.scrollWithEditor', "Enable scrolling of Sticky Scroll with the editor's horizontal scrollbar.")
 				},
+				'editor.stickyScroll.scopePreference': {
+					type: 'string',
+					enum: ['outerScopes', 'innerScopes'],
+					enumDescriptions: [
+						nls.localize('editor.stickyScroll.scopePreference.outerScopes', "Show outer scopes at the top when source code is nested beyond the maximum number of sticky lines."),
+						nls.localize('editor.stickyScroll.scopePreference.innerScopes', "Show inner scopes at the top when source code is nested beyond the maximum number of sticky lines.")
+					],
+					default: defaults.scopePreference,
+					description: nls.localize('editor.stickyScroll.scopePreference', "Defines whether to show outer or inner scopes at the top of the editor when source code is nested beyond the maximum number of sticky lines.")
+				},
 			}
 		);
 	}
@@ -3152,7 +3166,8 @@ class EditorStickyScroll extends BaseEditorOption<EditorOption.stickyScroll, IEd
 			enabled: boolean(input.enabled, this.defaultValue.enabled),
 			maxLineCount: EditorIntOption.clampedInt(input.maxLineCount, this.defaultValue.maxLineCount, 1, 20),
 			defaultModel: stringSet<'outlineModel' | 'foldingProviderModel' | 'indentationModel'>(input.defaultModel, this.defaultValue.defaultModel, ['outlineModel', 'foldingProviderModel', 'indentationModel']),
-			scrollWithEditor: boolean(input.scrollWithEditor, this.defaultValue.scrollWithEditor)
+			scrollWithEditor: boolean(input.scrollWithEditor, this.defaultValue.scrollWithEditor),
+			scopePreference: stringSet<'outerScopes' | 'innerScopes'>(input.scopePreference, this.defaultValue.scopePreference, ['outerScopes', 'innerScopes'])
 		};
 	}
 }

--- a/src/vs/editor/contrib/stickyScroll/browser/stickyScrollController.ts
+++ b/src/vs/editor/contrib/stickyScroll/browser/stickyScrollController.ts
@@ -592,29 +592,26 @@ export class StickyScrollController extends Disposable implements IEditorContrib
 	}
 
 	private _shouldAppendStickyLine(
-		line: StickyLineCandidate,
-		startLineNumbers: number[],
-		innerScopes: boolean,
-		maxNumberStickyLines: number,
+		candidate: StickyLineCandidate,
+		useInnerScopes: boolean,
+		isAtMaxLines: boolean,
 		scrollTop: number,
-		stickyWidgetHeight: number
+		currentWidgetHeight: number
 	): boolean {
-		const topOfBeginningLine = this._editor.getTopForLineNumber(line.startLineNumber) - scrollTop;
-		const bottomOfEndLine = this._editor.getBottomForLineNumber(line.endLineNumber + (innerScopes ? 1 : 0)) - scrollTop;
+		const topOfBeginningLine = this._editor.getTopForLineNumber(candidate.startLineNumber) - scrollTop;
+		const bottomOfEndLine = this._editor.getBottomForLineNumber(candidate.endLineNumber + (useInnerScopes ? 1 : 0)) - scrollTop;
 
-		if (!innerScopes) {
-			return topOfBeginningLine < stickyWidgetHeight && bottomOfEndLine >= stickyWidgetHeight;
+		if (!useInnerScopes) {
+			return topOfBeginningLine < currentWidgetHeight && bottomOfEndLine >= currentWidgetHeight;
 		}
-
-		const isAtMaxLines = startLineNumbers.length === maxNumberStickyLines;
 
 		if (isAtMaxLines) {
-			const bottomOfBeginningLine = this._editor.getBottomForLineNumber(line.startLineNumber) - scrollTop;
-			return (bottomOfBeginningLine) < stickyWidgetHeight
-				&& (bottomOfEndLine) >= stickyWidgetHeight;
+			const bottomOfBeginningLine = this._editor.getBottomForLineNumber(candidate.startLineNumber) - scrollTop;
+			return (bottomOfBeginningLine) < currentWidgetHeight
+				&& (bottomOfEndLine) >= currentWidgetHeight;
 		}
 
-		return topOfBeginningLine < stickyWidgetHeight && bottomOfEndLine >= stickyWidgetHeight;
+		return topOfBeginningLine < currentWidgetHeight && bottomOfEndLine >= currentWidgetHeight;
 	}
 
 	findScrollWidgetState(): StickyScrollWidgetState {
@@ -631,7 +628,7 @@ export class StickyScrollController extends Disposable implements IEditorContrib
 			let stickyWidgetHeight = 0;
 			for (const range of candidateRanges) {
 				const bottomOfEndLine = this._editor.getBottomForLineNumber(range.endLineNumber + (innerScopes ? 1 : 0)) - scrollTop;
-				const shouldAppendStickyLine = this._shouldAppendStickyLine(range, startLineNumbers, innerScopes, maxNumberStickyLines, scrollTop, stickyWidgetHeight);
+				const shouldAppendStickyLine = this._shouldAppendStickyLine(range, innerScopes, startLineNumbers.length === maxNumberStickyLines, scrollTop, stickyWidgetHeight);
 
 				if (shouldAppendStickyLine) {
 					startLineNumbers.push(range.startLineNumber);

--- a/src/vs/editor/contrib/stickyScroll/browser/stickyScrollController.ts
+++ b/src/vs/editor/contrib/stickyScroll/browser/stickyScrollController.ts
@@ -602,24 +602,25 @@ export class StickyScrollController extends Disposable implements IEditorContrib
 			const fullVisibleRange = new StickyRange(arrayVisibleRanges[0].startLineNumber, arrayVisibleRanges[arrayVisibleRanges.length - 1].endLineNumber);
 			const candidateRanges = this._stickyLineCandidateProvider.getCandidateStickyLinesIntersecting(fullVisibleRange);
 			const innerScopes = this._editor.getOption(EditorOption.stickyScroll).scopePreference === 'innerScopes';
+			let stickyWidgetHeight = 0;
 			for (const range of candidateRanges) {
 				const start = range.startLineNumber;
 				const end = range.endLineNumber;
-				const topOfElement = range.top;
-				const bottomOfElement = topOfElement + range.height;
 				const topOfBeginningLine = this._editor.getTopForLineNumber(start) - scrollTop;
 				const bottomOfEndLine = this._editor.getBottomForLineNumber(end) - scrollTop;
 
-				if (topOfBeginningLine < bottomOfElement && bottomOfEndLine >= bottomOfElement) {
+				if (topOfBeginningLine < stickyWidgetHeight && bottomOfEndLine >= stickyWidgetHeight) {
 					startLineNumbers.push(start);
 					endLineNumbers.push(end + 1);
-					if (bottomOfElement > bottomOfEndLine) {
-						lastLineRelativePosition = bottomOfEndLine - bottomOfElement;
+					stickyWidgetHeight += range.height;
+					if (stickyWidgetHeight > bottomOfEndLine) {
+						lastLineRelativePosition = bottomOfEndLine - stickyWidgetHeight;
 					}
 
-					if (innerScopes && startLineNumbers.length === maxNumberStickyLines) {
-						startLineNumbers.shift();
+					if (innerScopes && startLineNumbers.length > maxNumberStickyLines) {
+						const line = startLineNumbers.shift()!;
 						endLineNumbers.shift();
+						stickyWidgetHeight -= this._editor.getLineHeightForPosition(new Position(line, 1));
 					}
 				}
 				if (startLineNumbers.length === maxNumberStickyLines && !innerScopes) {

--- a/src/vs/editor/contrib/stickyScroll/browser/stickyScrollController.ts
+++ b/src/vs/editor/contrib/stickyScroll/browser/stickyScrollController.ts
@@ -601,7 +601,7 @@ export class StickyScrollController extends Disposable implements IEditorContrib
 		if (arrayVisibleRanges.length !== 0) {
 			const fullVisibleRange = new StickyRange(arrayVisibleRanges[0].startLineNumber, arrayVisibleRanges[arrayVisibleRanges.length - 1].endLineNumber);
 			const candidateRanges = this._stickyLineCandidateProvider.getCandidateStickyLinesIntersecting(fullVisibleRange);
-			const innerScopes = this._editor.getOption(EditorOption.stickyScroll).innerScopes === 'innerScopes';
+			const innerScopes = this._editor.getOption(EditorOption.stickyScroll).scopePreference === 'innerScopes';
 			for (const range of candidateRanges) {
 				const start = range.startLineNumber;
 				const end = range.endLineNumber;

--- a/src/vs/editor/contrib/stickyScroll/browser/stickyScrollController.ts
+++ b/src/vs/editor/contrib/stickyScroll/browser/stickyScrollController.ts
@@ -601,6 +601,7 @@ export class StickyScrollController extends Disposable implements IEditorContrib
 		if (arrayVisibleRanges.length !== 0) {
 			const fullVisibleRange = new StickyRange(arrayVisibleRanges[0].startLineNumber, arrayVisibleRanges[arrayVisibleRanges.length - 1].endLineNumber);
 			const candidateRanges = this._stickyLineCandidateProvider.getCandidateStickyLinesIntersecting(fullVisibleRange);
+			const innerScopes = this._editor.getOption(EditorOption.stickyScroll).innerScopes === 'innerScopes';
 			for (const range of candidateRanges) {
 				const start = range.startLineNumber;
 				const end = range.endLineNumber;
@@ -608,14 +609,20 @@ export class StickyScrollController extends Disposable implements IEditorContrib
 				const bottomOfElement = topOfElement + range.height;
 				const topOfBeginningLine = this._editor.getTopForLineNumber(start) - scrollTop;
 				const bottomOfEndLine = this._editor.getBottomForLineNumber(end) - scrollTop;
-				if (topOfElement > topOfBeginningLine && topOfElement <= bottomOfEndLine) {
+
+				if (topOfBeginningLine < bottomOfElement && bottomOfEndLine >= bottomOfElement) {
 					startLineNumbers.push(start);
 					endLineNumbers.push(end + 1);
 					if (bottomOfElement > bottomOfEndLine) {
 						lastLineRelativePosition = bottomOfEndLine - bottomOfElement;
 					}
+
+					if (innerScopes && startLineNumbers.length === maxNumberStickyLines) {
+						startLineNumbers.shift();
+						endLineNumbers.shift();
+					}
 				}
-				if (startLineNumbers.length === maxNumberStickyLines) {
+				if (startLineNumbers.length === maxNumberStickyLines && !innerScopes) {
 					break;
 				}
 			}

--- a/src/vs/editor/contrib/stickyScroll/browser/stickyScrollController.ts
+++ b/src/vs/editor/contrib/stickyScroll/browser/stickyScrollController.ts
@@ -594,9 +594,9 @@ export class StickyScrollController extends Disposable implements IEditorContrib
 	/**
 	 * Determines if a candidate sticky line should be appended to the sticky scroll widget.
 	 *
-	 * outer scopes: top of the start line triggers the sticky line.
-	 * inner scopes not at max lines: same as outer scopes.
-	 * inner scopes at max lines: bottom of start line triggers the sticky line.
+	 * outer scopes: top of the scope's starting line triggers the sticky line.
+	 * inner scopes before widget is full: same as outer scopes.
+	 * inner scopes when widget is full: bottom of the scope's starting line triggers the sticky line.
 	 */
 	private _shouldAppendStickyLine(
 		candidate: StickyLineCandidate,

--- a/src/vs/editor/contrib/stickyScroll/browser/stickyScrollController.ts
+++ b/src/vs/editor/contrib/stickyScroll/browser/stickyScrollController.ts
@@ -599,11 +599,8 @@ export class StickyScrollController extends Disposable implements IEditorContrib
 		scrollTop: number,
 		stickyWidgetHeight: number
 	): boolean {
-		const start = line.startLineNumber;
-		const end = line.endLineNumber + (innerScopes ? 1 : 0);
-		const topOfBeginningLine = this._editor.getTopForLineNumber(start) - scrollTop;
-		const bottomOfBeginningLine = this._editor.getBottomForLineNumber(start) - scrollTop;
-		const bottomOfEndLine = this._editor.getBottomForLineNumber(end) - scrollTop;
+		const topOfBeginningLine = this._editor.getTopForLineNumber(line.startLineNumber) - scrollTop;
+		const bottomOfEndLine = this._editor.getBottomForLineNumber(line.endLineNumber + (innerScopes ? 1 : 0)) - scrollTop;
 
 		if (!innerScopes) {
 			return topOfBeginningLine < stickyWidgetHeight && bottomOfEndLine >= stickyWidgetHeight;
@@ -612,6 +609,7 @@ export class StickyScrollController extends Disposable implements IEditorContrib
 		const isAtMaxLines = startLineNumbers.length === maxNumberStickyLines;
 
 		if (isAtMaxLines) {
+			const bottomOfBeginningLine = this._editor.getBottomForLineNumber(line.startLineNumber) - scrollTop;
 			return (bottomOfBeginningLine) < stickyWidgetHeight
 				&& (bottomOfEndLine) >= stickyWidgetHeight;
 		}

--- a/src/vs/editor/contrib/stickyScroll/browser/stickyScrollWidget.ts
+++ b/src/vs/editor/contrib/stickyScroll/browser/stickyScrollWidget.ts
@@ -152,7 +152,9 @@ export class StickyScrollWidget extends Disposable implements IOverlayWidget {
 		const previousLineNumbers = this._lineNumbers;
 		this._lineNumbers = data.lineNumbers;
 		this._lastLineRelativePosition = data.lastLineRelativePosition;
-		const rebuildFromIndex = this._findIndexToRebuildFrom(previousLineNumbers, this._lineNumbers, rebuildFromIndexCandidate);
+		const innerScopes = this._editor.getOption(EditorOption.stickyScroll).scopePreference === 'innerScopes';
+		const indexCandidate = innerScopes ? 0 : rebuildFromIndexCandidate;
+		const rebuildFromIndex = this._findIndexToRebuildFrom(previousLineNumbers, this._lineNumbers, indexCandidate);
 		this._renderRootNode(this._lineNumbers, this._lastLineRelativePosition, foldingModel, rebuildFromIndex);
 		this._state = state;
 	}

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -4450,6 +4450,10 @@ declare namespace monaco.editor {
 		 * Define whether to scroll sticky scroll with editor horizontal scrollbae
 		 */
 		scrollWithEditor?: boolean;
+		/**
+		 * Define whether to show outer scopes or inner scopes when the max line count is reached
+		 */
+		scopePreference?: 'outerScopes' | 'innerScopes';
 	}
 
 	/**


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/208406

## Changes Made
- Added a `scopePreference` setting. Values are `innerScope` and `outerScope`.
  - Note on the naming: VS has the same feature, they use the same naming
- Modified `stickyScrollController` to support inner scopes

## To Test
1. Settings (UI) > Search "Sticky scroll" > `Scope Preference: innerScopes`
2. Consider: `Default Model: foldingProviderModel` to help test.
3. Open a file that contains lots of nesting (functions, classes, html nodes, etc.) Optionally, create an html file and use the contents I've provided below.
4. Scroll around and observe the sticky behavior

## Video (Updated 10/31 🎃)

https://github.com/user-attachments/assets/478ea1a4-944e-4b17-875e-4769cb0b3c5e



I tested the logic on the following files:

```html
<html>




    <head>



        <h1>



            <h2>



                <h3>
                    
                    <h1>

                        <h2>

                            <h3>

                            </h3>
                        </h2>   
                    </h1>

                </h3>           

                
            </h2>
        </h1>
    </head>

</html>
```

```
export function level1() {



    function level2() {


    
        function level3() {
            
            function level4() {


                function level5() {
                    function level6() {
                        function level7() {
                            function level8() {
                                function level9() {
                                    function level10() {
                                        // Deepest level reached
                                    }
                                    level10();
                                }
                                level9();
                            }
                            level8();
                        }
                        level7();
                    }
                    level6();
                }
                level5();
            }
            level4();
        }
        level3();
    }
    level2();
}



```