### PR TITLE
Prevent replacement of chat agent editor after opening

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatSessions/view/sessionsViewPane.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSessions/view/sessionsViewPane.ts
@@ -468,7 +468,8 @@ export class SessionsViewPane extends ViewPane {
 				editorOptions: upcast<IEditorOptions, IChatEditorOptions>({
 					title: {
 						preferred: session.label
-					}
+					},
+					pinned: true
 				})
 			});
 			return;


### PR DESCRIPTION
Ensure the chat agent editor remains pinned and is not replaced when opened.

Fix https://github.com/microsoft/vscode-internalbacklog/issues/6139