### PR TITLE
Align terminal suggest command with editor's

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/accessibility/browser/terminalAccessibilityHelp.ts
+++ b/src/vs/workbench/contrib/terminalContrib/accessibility/browser/terminalAccessibilityHelp.ts
@@ -69,7 +69,7 @@ export class TerminalAccessibilityHelpProvider extends Disposable implements IAc
 		}
 
 		if (this._configurationService.getValue(TerminalSuggestSettingId.Enabled)) {
-			content.push(localize('suggestTrigger', 'The terminal request completions command can be invoked manually<keybinding:{0}>, but also appears while typing.', TerminalSuggestCommandId.RequestCompletions));
+			content.push(localize('suggestTrigger', 'The terminal request completions command can be invoked manually<keybinding:{0}>, but also appears while typing.', TerminalSuggestCommandId.TriggerSuggest));
 			content.push(localize('suggest', 'When the terminal suggest widget is focused:'));
 			content.push(localize('suggestCommands', '- Accept the suggestion<keybinding:{0}> and configure suggest settings<keybinding:{1}>.', TerminalSuggestCommandId.AcceptSelectedSuggestion, TerminalSuggestCommandId.ConfigureSettings));
 			content.push(localize('suggestCommandsMore', '- Toggle between the widget and terminal<keybinding:{0}> and toggle details focus<keybinding:{1}> to learn more about the suggestion.', TerminalSuggestCommandId.ToggleDetails, TerminalSuggestCommandId.ToggleDetailsFocus));

--- a/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminal.suggest.contribution.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminal.suggest.contribution.ts
@@ -276,7 +276,8 @@ registerTerminalAction({
 
 registerActiveInstanceAction({
 	id: TerminalSuggestCommandId.RequestCompletions,
-	title: localize2('workbench.action.terminal.requestCompletions', 'Request Completions'),
+	title: localize2('workbench.action.terminal.triggerSuggest', 'Trigger Suggest'),
+	f1: false,
 	keybinding: {
 		primary: KeyMod.CtrlCmd | KeyCode.Space,
 		mac: { primary: KeyMod.WinCtrl | KeyCode.Space },

--- a/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminal.suggest.contribution.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminal.suggest.contribution.ts
@@ -275,7 +275,7 @@ registerTerminalAction({
 });
 
 registerActiveInstanceAction({
-	id: TerminalSuggestCommandId.RequestCompletions,
+	id: TerminalSuggestCommandId.TriggerSuggest,
 	title: localize2('workbench.action.terminal.triggerSuggest', 'Trigger Suggest'),
 	f1: false,
 	keybinding: {

--- a/src/vs/workbench/contrib/terminalContrib/suggest/common/terminal.suggest.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/common/terminal.suggest.ts
@@ -12,7 +12,7 @@ export const enum TerminalSuggestCommandId {
 	AcceptSelectedSuggestionEnter = 'workbench.action.terminal.acceptSelectedSuggestionEnter',
 	HideSuggestWidget = 'workbench.action.terminal.hideSuggestWidget',
 	HideSuggestWidgetAndNavigateHistory = 'workbench.action.terminal.hideSuggestWidgetAndNavigateHistory',
-	RequestCompletions = 'workbench.action.terminal.requestCompletions',
+	TriggerSuggest = 'workbench.action.terminal.triggerSuggest',
 	ResetWidgetSize = 'workbench.action.terminal.resetSuggestWidgetSize',
 	ToggleDetails = 'workbench.action.terminal.suggestToggleDetails',
 	ToggleDetailsFocus = 'workbench.action.terminal.suggestToggleDetailsFocus',
@@ -29,7 +29,7 @@ export const defaultTerminalSuggestCommandsToSkipShell = [
 	TerminalSuggestCommandId.AcceptSelectedSuggestion,
 	TerminalSuggestCommandId.AcceptSelectedSuggestionEnter,
 	TerminalSuggestCommandId.HideSuggestWidget,
-	TerminalSuggestCommandId.RequestCompletions,
+	TerminalSuggestCommandId.TriggerSuggest,
 	TerminalSuggestCommandId.ToggleDetails,
 	TerminalSuggestCommandId.ToggleDetailsFocus,
 ];


### PR DESCRIPTION
Fixes #273375

Note that this does break the command name, but that's not strict API and we should do this now if at all before it goes to stable.

cc @meganrogge 