### PR TITLE
Handle single character on line prompt terminators

### DIFF
--- a/src/vs/platform/terminal/common/capabilities/commandDetectionCapability.ts
+++ b/src/vs/platform/terminal/common/capabilities/commandDetectionCapability.ts
@@ -968,7 +968,7 @@ class WindowsPtyHeuristics extends Disposable {
 		}
 
 		// Dynamic prompt detection
-		if (this._capability.promptTerminator && lineText.trim().endsWith(this._capability.promptTerminator)) {
+		if (this._capability.promptTerminator && (lineText === this._capability.promptTerminator || lineText.trim().endsWith(this._capability.promptTerminator))) {
 			const adjustedPrompt = this._adjustPrompt(lineText, lineText, this._capability.promptTerminator);
 			if (adjustedPrompt) {
 				return adjustedPrompt;

--- a/src/vs/platform/terminal/common/xterm/shellIntegrationAddon.ts
+++ b/src/vs/platform/terminal/common/xterm/shellIntegrationAddon.ts
@@ -618,7 +618,14 @@ export class ShellIntegrationAddon extends Disposable implements IShellIntegrati
 			return;
 		}
 		const lastPromptLine = prompt.substring(prompt.lastIndexOf('\n') + 1);
-		const promptTerminator = lastPromptLine.substring(lastPromptLine.lastIndexOf(' '));
+		const lastPromptLineTrimmed = lastPromptLine.trim();
+		const promptTerminator = (
+			lastPromptLineTrimmed.length === 1
+				// The prompt line contains a single character, treat the full line as the
+				// terminator for example "\u2b9e "
+				? lastPromptLine
+				: lastPromptLine.substring(lastPromptLine.lastIndexOf(' '))
+		);
 		if (promptTerminator) {
 			this._createOrGetCommandDetection(this._terminal).setPromptTerminator(promptTerminator, lastPromptLine);
 		}


### PR DESCRIPTION
This issue happened because using \u2b9e as a prompt character is not handled explicitly, unlike \u276f. The fix is to detect single character prompt terminators (excluding whitespace).

Fixes #224553

<img width="1312" height="714" alt="image" src="https://github.com/user-attachments/assets/710549e7-1cab-4c6b-ac3f-5cadce70dfa8" />
