### PR TITLE
Ignore inline env var setting prefix in path completions

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalCompletionService.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalCompletionService.ts
@@ -271,7 +271,13 @@ export class TerminalCompletionService extends Disposable implements ITerminalCo
 		// TODO: Leverage Fig's tokens array here?
 		// The last word (or argument). When the cursor is following a space it will be the empty
 		// string
-		const lastWord = cursorPrefix.endsWith(' ') ? '' : cursorPrefix.split(/(?<!\\) /).at(-1) ?? '';
+		let lastWord = cursorPrefix.endsWith(' ') ? '' : cursorPrefix.split(/(?<!\\) /).at(-1) ?? '';
+
+		// Ignore prefixes in the word that look like setting an environment variable
+		const matchEnvVarPrefix = lastWord.match(/^[a-zA-Z_]+=(?<rhs>.+)$/);
+		if (matchEnvVarPrefix?.groups?.rhs) {
+			lastWord = matchEnvVarPrefix.groups.rhs;
+		}
 
 		// Get the nearest folder path from the prefix. This ignores everything after the `/` as
 		// they are what triggers changes in the directory.

--- a/src/vs/workbench/contrib/terminalContrib/suggest/test/browser/terminalCompletionService.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/test/browser/terminalCompletionService.test.ts
@@ -461,6 +461,29 @@ suite('TerminalCompletionService', () => {
 			], { replacementRange: [0, 0] });
 		});
 
+		test('should ignore environment variable setting prefixes', async () => {
+			const resourceOptions: TerminalCompletionResourceOptions = {
+				cwd: URI.parse('file:///test'),
+				showDirectories: true,
+				pathSeparator
+			};
+			validResources = [URI.parse('file:///test')];
+			childResources = [
+				{ resource: URI.parse('file:///test/folder1/'), isDirectory: true },
+				{ resource: URI.parse('file:///test/folder2/'), isDirectory: true }
+			];
+			const result = await terminalCompletionService.resolveResources(resourceOptions, 'FOO=./', 2, provider, capabilities);
+
+			// Must not include FOO= prefix in completions
+			assertCompletions(result, [
+				{ label: '.', detail: '/test/' },
+				{ label: './folder1/', detail: '/test/folder1/' },
+				{ label: './folder2/', detail: '/test/folder2/' },
+				{ label: '../', detail: '/' },
+				standardTidleItem,
+			], { replacementRange: [0, 2] });
+		});
+
 		test('./| should handle large directories with many results gracefully', async () => {
 			const resourceOptions: TerminalCompletionResourceOptions = {
 				cwd: URI.parse('file:///test'),

--- a/src/vs/workbench/contrib/terminalContrib/suggest/test/browser/terminalCompletionService.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/test/browser/terminalCompletionService.test.ts
@@ -88,7 +88,7 @@ let homeDir = isWindows ? testEnv['USERPROFILE'] : testEnv['HOME'];
 if (!homeDir!.endsWith('/')) {
 	homeDir += '/';
 }
-const standardTidleItem = Object.freeze({ label: '~', detail: homeDir });
+const standardTildeItem = Object.freeze({ label: '~', detail: homeDir });
 
 suite('TerminalCompletionService', () => {
 	const store = ensureNoDisposablesAreLeakedInTestSuite();
@@ -174,7 +174,7 @@ suite('TerminalCompletionService', () => {
 				{ label: '.', detail: '/test/' },
 				{ label: './folder1/', detail: '/test/folder1/' },
 				{ label: '../', detail: '/' },
-				standardTidleItem,
+				standardTildeItem,
 			], { replacementRange: [1, 1] });
 		});
 
@@ -457,7 +457,7 @@ suite('TerminalCompletionService', () => {
 				{ label: './folder1/', detail: '/test/folder1/' },
 				{ label: './folder2/', detail: '/test/folder2/' },
 				{ label: '../', detail: '/' },
-				standardTidleItem,
+				standardTildeItem,
 			], { replacementRange: [0, 0] });
 		});
 
@@ -480,7 +480,7 @@ suite('TerminalCompletionService', () => {
 				{ label: './folder1/', detail: '/test/folder1/' },
 				{ label: './folder2/', detail: '/test/folder2/' },
 				{ label: '../', detail: '/' },
-				standardTidleItem,
+				standardTildeItem,
 			], { replacementRange: [0, 2] });
 		});
 
@@ -779,7 +779,7 @@ suite('TerminalCompletionService', () => {
 				{ label: './\!special\$chars\&/', detail: '/test/\!special\$chars\&/' },
 				{ label: './\!special\$chars2\&', detail: '/test/\!special\$chars2\&', kind: TerminalCompletionItemKind.File },
 				{ label: '../', detail: '/' },
-				standardTidleItem,
+				standardTildeItem,
 			], { replacementRange: [0, 0] });
 		});
 


### PR DESCRIPTION
Fixes #255709

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
