### PR TITLE
Walkthrough Guide is not opened, Welcome tab is opened instead (no extensions) (fix #271542)

### DIFF
--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.contribution.ts
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.contribution.ts
@@ -61,13 +61,7 @@ registerAction2(class extends Action2 {
 		const commandService = accessor.get(ICommandService);
 
 		const toSide = typeof optionsOrToSide === 'object' ? optionsOrToSide.toSide : optionsOrToSide;
-		let inactive = typeof optionsOrToSide === 'object' ? optionsOrToSide.inactive : false;
-
 		const activeEditor = editorService.activeEditor;
-		// If there's already a walkthrough open, open new walkthroughs in the background
-		if (!inactive && !toSide && activeEditor instanceof GettingStartedInput) {
-			inactive = true;
-		}
 
 		if (walkthroughID) {
 			const selectedCategory = typeof walkthroughID === 'string' ? walkthroughID : walkthroughID.category;
@@ -88,10 +82,10 @@ registerAction2(class extends Action2 {
 			let options: GettingStartedEditorOptions;
 			if (selectedCategory) {
 				// Otherwise open the walkthrough editor with the selected category and step
-				options = { selectedCategory: selectedCategory, selectedStep: selectedStep, showWelcome: false, preserveFocus: toSide ?? false, inactive };
+				options = { selectedCategory, selectedStep, showWelcome: false, preserveFocus: toSide ?? false };
 			} else {
 				// Open Welcome page
-				options = { selectedCategory: selectedCategory, selectedStep: selectedStep, showWelcome: true, preserveFocus: toSide ?? false, inactive };
+				options = { selectedCategory, selectedStep, showWelcome: true, preserveFocus: toSide ?? false };
 			}
 			editorService.openEditor({
 				resource: GettingStartedInput.RESOURCE,
@@ -101,7 +95,7 @@ registerAction2(class extends Action2 {
 		} else {
 			editorService.openEditor({
 				resource: GettingStartedInput.RESOURCE,
-				options: { preserveFocus: toSide ?? false, inactive }
+				options: { preserveFocus: toSide ?? false }
 			}, toSide ? SIDE_GROUP : undefined);
 		}
 	}

--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.ts
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.ts
@@ -34,7 +34,6 @@ import { IAccessibilityService } from '../../../../platform/accessibility/common
 import { ICommandService } from '../../../../platform/commands/common/commands.js';
 import { ConfigurationTarget, IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { ContextKeyExpr, ContextKeyExpression, IContextKeyService, RawContextKey } from '../../../../platform/contextkey/common/contextkey.js';
-import { IEditorOptions } from '../../../../platform/editor/common/editor.js';
 import { IFileService } from '../../../../platform/files/common/files.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { IKeybindingService } from '../../../../platform/keybinding/common/keybinding.js';
@@ -121,7 +120,6 @@ export class GettingStartedPage extends EditorPane {
 
 	public static readonly ID = 'gettingStartedPage';
 
-	private editorInput!: GettingStartedInput;
 	private inProgressScroll = Promise.resolve();
 
 	private readonly dispatchListeners: DisposableStore = new DisposableStore();
@@ -164,6 +162,10 @@ export class GettingStartedPage extends EditorPane {
 
 	private readonly categoriesSlideDisposables: DisposableStore;
 	private showFeaturedWalkthrough = true;
+
+	get editorInput(): GettingStartedInput {
+		return this._input as GettingStartedInput;
+	}
 
 	constructor(
 		group: IEditorGroup,
@@ -340,11 +342,28 @@ export class GettingStartedPage extends EditorPane {
 		};
 	}
 
-	override async setInput(newInput: GettingStartedInput, options: IEditorOptions | undefined, context: IEditorOpenContext, token: CancellationToken) {
-		this.container.classList.remove('animatable');
-		this.editorInput = newInput;
-		this.editorInput.showTelemetryNotice = (options as GettingStartedEditorOptions)?.showTelemetryNotice ?? true;
+	override async setInput(newInput: GettingStartedInput, options: GettingStartedEditorOptions | undefined, context: IEditorOpenContext, token: CancellationToken) {
 		await super.setInput(newInput, options, context, token);
+		await this.applyInput(options);
+	}
+
+	override async setOptions(options: GettingStartedEditorOptions | undefined): Promise<void> {
+		super.setOptions(options);
+
+		if (
+			this.editorInput.selectedCategory !== options?.selectedCategory ||
+			this.editorInput.selectedStep !== options?.selectedStep
+		) {
+			await this.applyInput(options);
+		}
+	}
+
+	private async applyInput(options: GettingStartedEditorOptions | undefined): Promise<void> {
+		this.editorInput.showTelemetryNotice = options?.showTelemetryNotice ?? true;
+		this.editorInput.selectedCategory = options?.selectedCategory;
+		this.editorInput.selectedStep = options?.selectedStep;
+
+		this.container.classList.remove('animatable');
 		await this.buildCategoriesSlide();
 		if (this.shouldAnimate()) {
 			setTimeout(() => this.container.classList.add('animatable'), 0);


### PR DESCRIPTION
With https://github.com/microsoft/vscode/pull/267223, a getting started / welcome editor will no longer be unique per selected category. We still want to allow to open specific getting started pages though or even go back to the welcome editor by calling `openEditor` with different `GettingStartedEditorOptions`, specifically `selectedCategory` and `selectedStep`.

With https://github.com/microsoft/vscode/pull/267223 I broke the support to open fundamentals when the welcome editor was already opened because the editor was not identified as different. In this PR I am trying to address that: when `setInput` or `setOptions` is called, apply category and step and call `buildCategoriesSlide`. We need both methods to use this because:
* `setInput` is called when either the editor is not yet opened or not active
* `setOptions` is called when the editor is the active one

@bhavyaus happy for your review on this, I was not entirely sure if there are other options from `GettingStartedEditorOptions` to consider for applying.