### PR TITLE
Prevent quickInput.accept from firing during IME composition. Fix #272407

### DIFF
--- a/src/vs/platform/quickinput/browser/quickInputActions.ts
+++ b/src/vs/platform/quickinput/browser/quickInputActions.ts
@@ -205,7 +205,8 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 		// All other kinds of Quick things handle Accept, except Widget. In other words, Accepting is a detail on the things
 		// that extend IQuickInput
 		ContextKeyExpr.notEquals(quickInputTypeContextKeyValue, QuickInputType.QuickWidget),
-		inQuickInputContext
+		inQuickInputContext,
+		ContextKeyExpr.not('isComposing')
 	),
 	metadata: { description: localize('nonQuickWidget', "Used while in the context of some quick input. If you change one keybinding for this command, you should change all of the other keybindings (modifier variants) of this command as well.") },
 	handler: (accessor) => {


### PR DESCRIPTION
Prevent quickInput.accept from firing during IME composition. Fix #272407

Similar to #174829
