### PR TITLE
Fix workspace path resolution when glob-like segments exist in folder names

### DIFF
--- a/src/vs/workbench/services/search/common/queryBuilder.ts
+++ b/src/vs/workbench/services/search/common/queryBuilder.ts
@@ -431,18 +431,11 @@ export class QueryBuilder {
 		}
 
 		const expandedSearchPaths = searchPaths.flatMap(searchPath => {
-			// 1 open folder => just resolve the search paths to absolute paths
-			let { pathPortion, globPortion } = splitGlobFromPath(searchPath);
-
-			if (globPortion) {
-				globPortion = normalizeGlobPattern(globPortion);
-			}
-
-			// One pathPortion to multiple expanded search paths (e.g. duplicate matching workspace folders)
-			const oneExpanded = this.expandOneSearchPath(pathPortion);
+			// One searchPath to multiple expanded search paths (e.g. duplicate matching workspace folders)
+			const oneExpanded = this.expandOneSearchPath(searchPath);
 
 			// Expanded search paths to multiple resolved patterns (with ** and without)
-			return oneExpanded.flatMap(oneExpandedResult => this.resolveOneSearchPathPattern(oneExpandedResult, globPortion));
+			return oneExpanded.flatMap(oneExpandedResult => this.resolveOneSearchPathPattern(oneExpandedResult));
 		});
 
 		const searchPathPatternMap = new Map<string, ISearchPathPattern>();
@@ -469,40 +462,54 @@ export class QueryBuilder {
 	 * Takes a searchPath like `./a/foo` or `../a/foo` and expands it to absolute paths for all the workspaces it matches.
 	 */
 	private expandOneSearchPath(searchPath: string): IOneSearchPathPattern[] {
+		let { pathPortion, globPortion } = splitGlobFromPath(searchPath);
+		if (globPortion) {
+			globPortion = normalizeGlobPattern(globPortion);
+		}
+
+		const joinPattern = (pattern?: string, globPortion?: string) => {
+			return pattern && globPortion ? `${pattern}/${globPortion}` : pattern || globPortion;
+		};
+
 		if (path.isAbsolute(searchPath)) {
 			const workspaceFolders = this.workspaceContextService.getWorkspace().folders;
 			if (workspaceFolders[0] && workspaceFolders[0].uri.scheme !== Schemas.file) {
 				return [{
-					searchPath: workspaceFolders[0].uri.with({ path: searchPath })
+					searchPath: workspaceFolders[0].uri.with({ path: pathPortion }),
+					pattern: globPortion
 				}];
 			}
 
 			// Currently only local resources can be searched for with absolute search paths.
 			// TODO convert this to a workspace folder + pattern, so excludes will be resolved properly for an absolute path inside a workspace folder
 			return [{
-				searchPath: uri.file(path.normalize(searchPath))
+				searchPath: uri.file(path.normalize(pathPortion)),
+				pattern: globPortion
 			}];
 		}
 
 		if (this.workspaceContextService.getWorkbenchState() === WorkbenchState.FOLDER) {
 			const workspaceUri = this.workspaceContextService.getWorkspace().folders[0].uri;
 
-			searchPath = normalizeSlashes(searchPath);
-			if (searchPath.startsWith('../') || searchPath === '..') {
-				const resolvedPath = path.posix.resolve(workspaceUri.path, searchPath);
+			pathPortion = normalizeSlashes(pathPortion);
+			if (pathPortion.startsWith('../') || pathPortion === '..') {
+				const resolvedPath = path.posix.resolve(workspaceUri.path, pathPortion);
 				return [{
-					searchPath: workspaceUri.with({ path: resolvedPath })
+					searchPath: workspaceUri.with({ path: resolvedPath }),
+					pattern: globPortion,
 				}];
 			}
 
-			const cleanedPattern = normalizeGlobPattern(searchPath);
+			const cleanedPattern = normalizeGlobPattern(pathPortion);
 			return [{
 				searchPath: workspaceUri,
-				pattern: cleanedPattern
+				pattern: joinPattern(cleanedPattern, globPortion),
 			}];
 		} else if (searchPath === './' || searchPath === '.\\') {
 			return []; // ./ or ./**/foo makes sense for single-folder but not multi-folder workspaces
 		} else {
+			// We need to use the original searchPath to determine if there's a workspace folder match, not the processed pathPortion
+			// Because workspace folder names may contain glob characters, the pathPortion obtained after splitGlobFromPath might be incorrectly truncated
 			const searchPathWithoutDotSlash = searchPath.replace(/^\.[\/\\]/, '');
 			const folders = this.workspaceContextService.getWorkspace().folders;
 			const folderMatches = folders.map(folder => {
@@ -518,12 +525,12 @@ export class QueryBuilder {
 					const patternMatch = match.match[1];
 					return {
 						searchPath: match.folder.uri,
-						pattern: patternMatch && normalizeGlobPattern(patternMatch)
+						pattern: patternMatch && normalizeGlobPattern(patternMatch),
 					};
 				});
 			} else {
-				const probableWorkspaceFolderNameMatch = searchPath.match(/\.[\/\\](.+)[\/\\]?/);
-				const probableWorkspaceFolderName = probableWorkspaceFolderNameMatch ? probableWorkspaceFolderNameMatch[1] : searchPath;
+				const probableWorkspaceFolderNameMatch = pathPortion.match(/\.[\/\\](.+)[\/\\]?/);
+				const probableWorkspaceFolderName = probableWorkspaceFolderNameMatch ? probableWorkspaceFolderNameMatch[1] : pathPortion;
 
 				// No root folder with name
 				const searchPathNotFoundError = nls.localize('search.noWorkspaceWithName', "Workspace folder does not exist: {0}", probableWorkspaceFolderName);
@@ -532,21 +539,17 @@ export class QueryBuilder {
 		}
 	}
 
-	private resolveOneSearchPathPattern(oneExpandedResult: IOneSearchPathPattern, globPortion?: string): IOneSearchPathPattern[] {
-		const pattern = oneExpandedResult.pattern && globPortion ?
-			`${oneExpandedResult.pattern}/${globPortion}` :
-			oneExpandedResult.pattern || globPortion;
-
+	private resolveOneSearchPathPattern(oneExpandedResult: IOneSearchPathPattern): IOneSearchPathPattern[] {
 		const results = [
 			{
 				searchPath: oneExpandedResult.searchPath,
-				pattern
+				pattern: oneExpandedResult.pattern,
 			}];
 
-		if (pattern && !pattern.endsWith('**')) {
+		if (oneExpandedResult.pattern && !oneExpandedResult.pattern.endsWith('**')) {
 			results.push({
 				searchPath: oneExpandedResult.searchPath,
-				pattern: pattern + '/**'
+				pattern: oneExpandedResult.pattern + '/**'
 			});
 		}
 


### PR DESCRIPTION
**For problem details, please refer to this issue: https://github.com/microsoft/vscode/issues/273517**

The cause of this problem lies in the `expandSearchPathPatterns` function in the `src/vs/workbench/services/search/common/queryBuilder.ts` file. This function is responsible for converting the raw content entered by the user in the Include/Exclude text boxes into formal file paths.

The specific problem is in this sub-function within `expandSearchPathPatterns`:

```ts
const expandedSearchPaths = searchPaths.flatMap(searchPath => {
	// 1 open folder => just resolve the search paths to absolute paths
	let { pathPortion, globPortion } = splitGlobFromPath(searchPath);

	if (globPortion) {
		globPortion = normalizeGlobPattern(globPortion);
	}

	// One pathPortion to multiple expanded search paths (e.g. duplicate matching workspace folders)
	const oneExpanded = this.expandOneSearchPath(pathPortion);

	// Expanded search paths to multiple resolved patterns (with ** and without)
	return oneExpanded.flatMap(oneExpandedResult => this.resolveOneSearchPathPattern(oneExpandedResult, globPortion));
});
```

Before calling `this.expandOneSearchPath` to get the real path, the file path has already been corrupted by the `splitGlobFromPath` function.

**Here are two examples to illustrate. Before reading the examples, please check this [issue](https://github.com/microsoft/vscode/issues/273517) for background information.**

**Example 1**

If our `searchPath` is `./monorepo (dev)`, after being processed by the `splitGlobFromPath` function, we get a `pathPortion` with the value `'./'` and a `globPortion` with the value `'monorepo (dev)'`.

<img width="750" height="262" alt="image" src="https://github.com/user-attachments/assets/9aae719b-3fa6-4a6f-811a-1d0f397e4500" />

Consequently, in the `this.expandOneSearchPath` function, because the passed parameter is `'./'`, the Include parameter does not take effect, resulting in a search across all folders.

<img width="1034" height="110" alt="image" src="https://github.com/user-attachments/assets/090d98cc-0df2-4553-a685-12020abb9ee1" />

**Example 2**

If our `searchPath` is `./apps/vscode (dev)`, after being processed by the `splitGlobFromPath` function, we get a `pathPortion` with the value `'./apps'` and a `globPortion` with the value `'vscode (dev)'`.

Since `'./apps'` does not exist, an error is triggered. However, the folder `./apps/vscode (dev)` actually exists in the project.

<img width="810" height="344" alt="image" src="https://github.com/user-attachments/assets/c1a566e5-9d76-4eac-bcc9-86c9644e966d" />

**Solution**

We move the processing of `splitGlobFromPath` down into the `this.expandOneSearchPath` function. When checking if `searchPath` is a project folder path, we use the original `searchPath` for the check instead of the `pathPortion` trimmed by `splitGlobFromPath`.