### PR TITLE
Throw error when grammar loading fails

### DIFF
--- a/src/vs/editor/common/services/treeSitter/treeSitterLibraryService.ts
+++ b/src/vs/editor/common/services/treeSitter/treeSitterLibraryService.ts
@@ -33,6 +33,16 @@ export interface ITreeSitterLibraryService {
 	getLanguage(languageId: string, ignoreSupportsCheck: boolean, reader: IReader | undefined): Language | undefined;
 
 	/**
+	 * Gets the language as a promise, as opposed to via observables. This ignores the automatic
+	 * supportsLanguage check.
+	 *
+	 * Warning: This approach is generally not recommended as it's not reactive, but it's the only
+	 * way to catch and handle import errors when the grammar fails to load.
+	 * @param languageId The language identifier to retrieve.
+	 */
+	getLanguagePromise(languageId: string): Promise<Language | undefined>;
+
+	/**
 	 * Gets the injection queries for a language. A return value of `null`
 	 * indicates that there are no highlights queries for this language.
 	 * @param languageId The language identifier to retrieve queries for.

--- a/src/vs/editor/standalone/browser/standaloneTreeSitterLibraryService.ts
+++ b/src/vs/editor/standalone/browser/standaloneTreeSitterLibraryService.ts
@@ -22,6 +22,10 @@ export class StandaloneTreeSitterLibraryService implements ITreeSitterLibrarySer
 		return undefined;
 	}
 
+	async getLanguagePromise(languageId: string): Promise<Language | undefined> {
+		return undefined;
+	}
+
 	getInjectionQueries(languageId: string, reader: IReader | undefined): Query | null | undefined {
 		return null;
 	}

--- a/src/vs/editor/test/common/services/testTreeSitterLibraryService.ts
+++ b/src/vs/editor/test/common/services/testTreeSitterLibraryService.ts
@@ -22,6 +22,10 @@ export class TestTreeSitterLibraryService implements ITreeSitterLibraryService {
 		return undefined;
 	}
 
+	async getLanguagePromise(languageId: string): Promise<Language | undefined> {
+		return undefined;
+	}
+
 	getInjectionQueries(languageId: string, reader: IReader | undefined): Query | null | undefined {
 		return null;
 	}

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/treeSitterCommandParser.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/treeSitterCommandParser.ts
@@ -3,11 +3,10 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { BugIndicatingError } from '../../../../../base/common/errors.js';
-import { derived, waitForState } from '../../../../../base/common/observable.js';
+import type { Parser, Query, QueryCapture, Tree } from '@vscode/tree-sitter-wasm';
+import { BugIndicatingError, ErrorNoTelemetry } from '../../../../../base/common/errors.js';
 import { arch } from '../../../../../base/common/process.js';
 import { ITreeSitterLibraryService } from '../../../../../editor/common/services/treeSitter/treeSitterLibraryService.js';
-import type { Language, Parser, Query, QueryCapture } from '@vscode/tree-sitter-wasm';
 
 export const enum TreeSitterCommandParserLanguage {
 	Bash = 'bash',
@@ -16,51 +15,38 @@ export const enum TreeSitterCommandParserLanguage {
 
 export class TreeSitterCommandParser {
 	private readonly _parser: Promise<Parser>;
-	private readonly _queries: Map<Language, Query> = new Map();
 
 	constructor(
-		@ITreeSitterLibraryService private readonly _treeSitterLibraryService: ITreeSitterLibraryService
+		@ITreeSitterLibraryService private readonly _treeSitterLibraryService: ITreeSitterLibraryService,
 	) {
 		this._parser = this._treeSitterLibraryService.getParserClass().then(ParserCtor => new ParserCtor());
 	}
 
 	async extractSubCommands(languageId: TreeSitterCommandParserLanguage, commandLine: string): Promise<string[]> {
-		this._throwIfCanCrash(languageId);
-
-		const parser = await this._parser;
-		const language = await waitForState(derived(reader => {
-			return this._treeSitterLibraryService.getLanguage(languageId, true, reader);
-		}));
-		parser.setLanguage(language);
-
-		const tree = parser.parse(commandLine);
-		if (!tree) {
-			throw new BugIndicatingError('Failed to parse tree');
-		}
-
-		const query = await this._getQuery(language);
-		if (!query) {
-			throw new BugIndicatingError('Failed to create tree sitter query');
-		}
-
+		const { tree, query } = await this._doQuery(languageId, commandLine, '(command) @command');
 		const captures = query.captures(tree.rootNode);
-		const subCommands = captures.map(e => e.node.text);
-
-		return subCommands;
+		return captures.map(e => e.node.text);
 	}
 
 	async queryTree(languageId: TreeSitterCommandParserLanguage, commandLine: string, querySource: string): Promise<QueryCapture[]> {
+		const { tree, query } = await this._doQuery(languageId, commandLine, querySource);
+		return query.captures(tree.rootNode);
+	}
+
+	private async _doQuery(languageId: TreeSitterCommandParserLanguage, commandLine: string, querySource: string): Promise<{ tree: Tree; query: Query }> {
 		this._throwIfCanCrash(languageId);
 
 		const parser = await this._parser;
-		const language = await waitForState(derived(reader => {
-			return this._treeSitterLibraryService.getLanguage(languageId, true, reader);
-		}));
+		const language = await this._treeSitterLibraryService.getLanguagePromise(languageId);
+		if (!language) {
+			throw new BugIndicatingError('Failed to fetch language grammar');
+		}
+
 		parser.setLanguage(language);
 
 		const tree = parser.parse(commandLine);
 		if (!tree) {
-			throw new BugIndicatingError('Failed to parse tree');
+			throw new ErrorNoTelemetry('Failed to parse tree');
 		}
 
 		const query = await this._treeSitterLibraryService.createQuery(language, querySource);
@@ -68,18 +54,7 @@ export class TreeSitterCommandParser {
 			throw new BugIndicatingError('Failed to create tree sitter query');
 		}
 
-		const captures = query.captures(tree.rootNode);
-
-		return captures;
-	}
-
-	private async _getQuery(language: Language): Promise<Query> {
-		let query = this._queries.get(language);
-		if (!query) {
-			query = await this._treeSitterLibraryService.createQuery(language, '(command) @command');
-			this._queries.set(language, query);
-		}
-		return query;
+		return { tree, query };
 	}
 
 	private _throwIfCanCrash(languageId: TreeSitterCommandParserLanguage) {
@@ -88,7 +63,7 @@ export class TreeSitterCommandParser {
 			(arch === 'arm' || arch === 'arm64') &&
 			languageId === TreeSitterCommandParserLanguage.PowerShell
 		) {
-			throw new Error('powershell grammar is not supported on arm or arm64');
+			throw new ErrorNoTelemetry('powershell grammar is not supported on arm or arm64');
 		}
 	}
 }

--- a/src/vs/workbench/services/treeSitter/browser/treeSitterLibraryService.ts
+++ b/src/vs/workbench/services/treeSitter/browser/treeSitterLibraryService.ts
@@ -129,6 +129,10 @@ export class TreeSitterLibraryService extends Disposable implements ITreeSitterL
 		return lang;
 	}
 
+	async getLanguagePromise(languageId: string): Promise<Language | undefined> {
+		return this._languagesCache.get(languageId).promise;
+	}
+
 	getInjectionQueries(languageId: string, reader: IReader | undefined): Query | null | undefined {
 		if (!this.supportsLanguage(languageId, reader)) {
 			return undefined;


### PR DESCRIPTION
Part of #261794

I debated using a notification when this happens but settled on gracefully continuing the tool call if it fails (ie. auto approve and some command rewriting is skipped), the error then shows in devtools:

<img width="1073" height="195" alt="image" src="https://github.com/user-attachments/assets/c7896060-1d3b-40e2-b0e7-4b033dc38850" />
