### PR TITLE
Suggest: add editor.suggest.excludeCommitCharacters to ignore specifi…

### DIFF
--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -5300,6 +5300,9 @@ class EditorSuggest extends BaseEditorOption<EditorOption.suggest, ISuggestOptio
                     default: true,
                     markdownDescription: nls.localize('editor.suggest.showIssues', "When enabled IntelliSense shows `issues`-suggestions.")
                 },
+                // Allow users to exclude specific commit characters from accepting suggestions.
+                // This is language-overridable, so users can configure e.g. C# to exclude '.'
+                // to avoid committing suggestions when typing new collection expressions "[..]".
                 'editor.suggest.excludeCommitCharacters': {
                     type: 'array',
                     default: defaults.excludeCommitCharacters,

--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -5015,10 +5015,15 @@ export interface ISuggestOptions {
 	 * Show user-suggestions.
 	 */
 	showUsers?: boolean;
-	/**
-	 * Show snippet-suggestions.
-	 */
-	showSnippets?: boolean;
+    /**
+     * Show snippet-suggestions.
+     */
+    showSnippets?: boolean;
+    /**
+     * Characters in this list will not accept suggestions when typed as commit characters.
+     * Useful to exclude characters like '.' in certain languages (e.g. C# collection expressions).
+     */
+    excludeCommitCharacters?: string[];
 }
 
 /**
@@ -5029,7 +5034,7 @@ export type InternalSuggestOptions = Readonly<Required<ISuggestOptions>>;
 class EditorSuggest extends BaseEditorOption<EditorOption.suggest, ISuggestOptions, InternalSuggestOptions> {
 
 	constructor() {
-		const defaults: InternalSuggestOptions = {
+        const defaults: InternalSuggestOptions = {
 			insertMode: 'insert',
 			filterGraceful: true,
 			snippetsPreventQuickSuggestions: false,
@@ -5068,9 +5073,10 @@ class EditorSuggest extends BaseEditorOption<EditorOption.suggest, ISuggestOptio
 			showFolders: true,
 			showTypeParameters: true,
 			showSnippets: true,
-			showUsers: true,
-			showIssues: true,
-		};
+            showUsers: true,
+            showIssues: true,
+            excludeCommitCharacters: [] as string[],
+        };
 		super(
 			EditorOption.suggest, 'suggest', defaults,
 			{
@@ -5289,63 +5295,70 @@ class EditorSuggest extends BaseEditorOption<EditorOption.suggest, ISuggestOptio
 					default: true,
 					markdownDescription: nls.localize('editor.suggest.showUsers', "When enabled IntelliSense shows `user`-suggestions.")
 				},
-				'editor.suggest.showIssues': {
-					type: 'boolean',
-					default: true,
-					markdownDescription: nls.localize('editor.suggest.showIssues', "When enabled IntelliSense shows `issues`-suggestions.")
-				}
-			}
-		);
-	}
+                'editor.suggest.showIssues': {
+                    type: 'boolean',
+                    default: true,
+                    markdownDescription: nls.localize('editor.suggest.showIssues', "When enabled IntelliSense shows `issues`-suggestions.")
+                },
+                'editor.suggest.excludeCommitCharacters': {
+                    type: 'array',
+                    default: defaults.excludeCommitCharacters,
+                    items: { type: 'string' },
+                    markdownDescription: nls.localize('editor.suggest.excludeCommitCharacters', "Characters in this list will not accept a suggestion when typed as commit characters. Can be configured per language, for example to exclude '.' in C# when typing collection expressions.")
+                }
+            }
+        );
+    }
 
 	public validate(_input: unknown): InternalSuggestOptions {
 		if (!_input || typeof _input !== 'object') {
 			return this.defaultValue;
 		}
 		const input = _input as Unknown<ISuggestOptions>;
-		return {
-			insertMode: stringSet(input.insertMode, this.defaultValue.insertMode, ['insert', 'replace']),
-			filterGraceful: boolean(input.filterGraceful, this.defaultValue.filterGraceful),
-			snippetsPreventQuickSuggestions: boolean(input.snippetsPreventQuickSuggestions, this.defaultValue.filterGraceful),
-			localityBonus: boolean(input.localityBonus, this.defaultValue.localityBonus),
-			shareSuggestSelections: boolean(input.shareSuggestSelections, this.defaultValue.shareSuggestSelections),
-			selectionMode: stringSet(input.selectionMode, this.defaultValue.selectionMode, ['always', 'never', 'whenQuickSuggestion', 'whenTriggerCharacter']),
-			showIcons: boolean(input.showIcons, this.defaultValue.showIcons),
-			showStatusBar: boolean(input.showStatusBar, this.defaultValue.showStatusBar),
-			preview: boolean(input.preview, this.defaultValue.preview),
-			previewMode: stringSet(input.previewMode, this.defaultValue.previewMode, ['prefix', 'subword', 'subwordSmart']),
-			showInlineDetails: boolean(input.showInlineDetails, this.defaultValue.showInlineDetails),
-			showMethods: boolean(input.showMethods, this.defaultValue.showMethods),
-			showFunctions: boolean(input.showFunctions, this.defaultValue.showFunctions),
-			showConstructors: boolean(input.showConstructors, this.defaultValue.showConstructors),
-			showDeprecated: boolean(input.showDeprecated, this.defaultValue.showDeprecated),
-			matchOnWordStartOnly: boolean(input.matchOnWordStartOnly, this.defaultValue.matchOnWordStartOnly),
-			showFields: boolean(input.showFields, this.defaultValue.showFields),
-			showVariables: boolean(input.showVariables, this.defaultValue.showVariables),
-			showClasses: boolean(input.showClasses, this.defaultValue.showClasses),
-			showStructs: boolean(input.showStructs, this.defaultValue.showStructs),
-			showInterfaces: boolean(input.showInterfaces, this.defaultValue.showInterfaces),
-			showModules: boolean(input.showModules, this.defaultValue.showModules),
-			showProperties: boolean(input.showProperties, this.defaultValue.showProperties),
-			showEvents: boolean(input.showEvents, this.defaultValue.showEvents),
-			showOperators: boolean(input.showOperators, this.defaultValue.showOperators),
-			showUnits: boolean(input.showUnits, this.defaultValue.showUnits),
-			showValues: boolean(input.showValues, this.defaultValue.showValues),
-			showConstants: boolean(input.showConstants, this.defaultValue.showConstants),
-			showEnums: boolean(input.showEnums, this.defaultValue.showEnums),
-			showEnumMembers: boolean(input.showEnumMembers, this.defaultValue.showEnumMembers),
-			showKeywords: boolean(input.showKeywords, this.defaultValue.showKeywords),
-			showWords: boolean(input.showWords, this.defaultValue.showWords),
-			showColors: boolean(input.showColors, this.defaultValue.showColors),
-			showFiles: boolean(input.showFiles, this.defaultValue.showFiles),
-			showReferences: boolean(input.showReferences, this.defaultValue.showReferences),
-			showFolders: boolean(input.showFolders, this.defaultValue.showFolders),
-			showTypeParameters: boolean(input.showTypeParameters, this.defaultValue.showTypeParameters),
-			showSnippets: boolean(input.showSnippets, this.defaultValue.showSnippets),
-			showUsers: boolean(input.showUsers, this.defaultValue.showUsers),
-			showIssues: boolean(input.showIssues, this.defaultValue.showIssues),
-		};
-	}
+        return {
+            insertMode: stringSet(input.insertMode, this.defaultValue.insertMode, ['insert', 'replace']),
+            filterGraceful: boolean(input.filterGraceful, this.defaultValue.filterGraceful),
+            snippetsPreventQuickSuggestions: boolean(input.snippetsPreventQuickSuggestions, this.defaultValue.filterGraceful),
+            localityBonus: boolean(input.localityBonus, this.defaultValue.localityBonus),
+            shareSuggestSelections: boolean(input.shareSuggestSelections, this.defaultValue.shareSuggestSelections),
+            selectionMode: stringSet(input.selectionMode, this.defaultValue.selectionMode, ['always', 'never', 'whenQuickSuggestion', 'whenTriggerCharacter']),
+            showIcons: boolean(input.showIcons, this.defaultValue.showIcons),
+            showStatusBar: boolean(input.showStatusBar, this.defaultValue.showStatusBar),
+            preview: boolean(input.preview, this.defaultValue.preview),
+            previewMode: stringSet(input.previewMode, this.defaultValue.previewMode, ['prefix', 'subword', 'subwordSmart']),
+            showInlineDetails: boolean(input.showInlineDetails, this.defaultValue.showInlineDetails),
+            showMethods: boolean(input.showMethods, this.defaultValue.showMethods),
+            showFunctions: boolean(input.showFunctions, this.defaultValue.showFunctions),
+            showConstructors: boolean(input.showConstructors, this.defaultValue.showConstructors),
+            showDeprecated: boolean(input.showDeprecated, this.defaultValue.showDeprecated),
+            matchOnWordStartOnly: boolean(input.matchOnWordStartOnly, this.defaultValue.matchOnWordStartOnly),
+            showFields: boolean(input.showFields, this.defaultValue.showFields),
+            showVariables: boolean(input.showVariables, this.defaultValue.showVariables),
+            showClasses: boolean(input.showClasses, this.defaultValue.showClasses),
+            showStructs: boolean(input.showStructs, this.defaultValue.showStructs),
+            showInterfaces: boolean(input.showInterfaces, this.defaultValue.showInterfaces),
+            showModules: boolean(input.showModules, this.defaultValue.showModules),
+            showProperties: boolean(input.showProperties, this.defaultValue.showProperties),
+            showEvents: boolean(input.showEvents, this.defaultValue.showEvents),
+            showOperators: boolean(input.showOperators, this.defaultValue.showOperators),
+            showUnits: boolean(input.showUnits, this.defaultValue.showUnits),
+            showValues: boolean(input.showValues, this.defaultValue.showValues),
+            showConstants: boolean(input.showConstants, this.defaultValue.showConstants),
+            showEnums: boolean(input.showEnums, this.defaultValue.showEnums),
+            showEnumMembers: boolean(input.showEnumMembers, this.defaultValue.showEnumMembers),
+            showKeywords: boolean(input.showKeywords, this.defaultValue.showKeywords),
+            showWords: boolean(input.showWords, this.defaultValue.showWords),
+            showColors: boolean(input.showColors, this.defaultValue.showColors),
+            showFiles: boolean(input.showFiles, this.defaultValue.showFiles),
+            showReferences: boolean(input.showReferences, this.defaultValue.showReferences),
+            showFolders: boolean(input.showFolders, this.defaultValue.showFolders),
+            showTypeParameters: boolean(input.showTypeParameters, this.defaultValue.showTypeParameters),
+            showSnippets: boolean(input.showSnippets, this.defaultValue.showSnippets),
+            showUsers: boolean(input.showUsers, this.defaultValue.showUsers),
+            showIssues: boolean(input.showIssues, this.defaultValue.showIssues),
+            excludeCommitCharacters: Array.isArray(input.excludeCommitCharacters) ? input.excludeCommitCharacters.filter(e => typeof e === 'string') : this.defaultValue.excludeCommitCharacters,
+        };
+    }
 }
 
 //#endregion

--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -5015,15 +5015,15 @@ export interface ISuggestOptions {
 	 * Show user-suggestions.
 	 */
 	showUsers?: boolean;
-    /**
-     * Show snippet-suggestions.
-     */
-    showSnippets?: boolean;
-    /**
-     * Characters in this list will not accept suggestions when typed as commit characters.
-     * Useful to exclude characters like '.' in certain languages (e.g. C# collection expressions).
-     */
-    excludeCommitCharacters?: string[];
+	/**
+	 * Show snippet-suggestions.
+	 */
+	showSnippets?: boolean;
+	/**
+	 * Characters in this list will not accept suggestions when typed as commit characters.
+	 * Useful to exclude characters like '.' in certain languages (e.g. C# collection expressions).
+	 */
+	excludeCommitCharacters?: string[];
 }
 
 /**
@@ -5034,7 +5034,7 @@ export type InternalSuggestOptions = Readonly<Required<ISuggestOptions>>;
 class EditorSuggest extends BaseEditorOption<EditorOption.suggest, ISuggestOptions, InternalSuggestOptions> {
 
 	constructor() {
-        const defaults: InternalSuggestOptions = {
+		const defaults: InternalSuggestOptions = {
 			insertMode: 'insert',
 			filterGraceful: true,
 			snippetsPreventQuickSuggestions: false,
@@ -5073,10 +5073,10 @@ class EditorSuggest extends BaseEditorOption<EditorOption.suggest, ISuggestOptio
 			showFolders: true,
 			showTypeParameters: true,
 			showSnippets: true,
-            showUsers: true,
-            showIssues: true,
-            excludeCommitCharacters: [] as string[],
-        };
+			showUsers: true,
+			showIssues: true,
+			excludeCommitCharacters: [] as string[],
+		};
 		super(
 			EditorOption.suggest, 'suggest', defaults,
 			{
@@ -5295,73 +5295,70 @@ class EditorSuggest extends BaseEditorOption<EditorOption.suggest, ISuggestOptio
 					default: true,
 					markdownDescription: nls.localize('editor.suggest.showUsers', "When enabled IntelliSense shows `user`-suggestions.")
 				},
-                'editor.suggest.showIssues': {
-                    type: 'boolean',
-                    default: true,
-                    markdownDescription: nls.localize('editor.suggest.showIssues', "When enabled IntelliSense shows `issues`-suggestions.")
-                },
-                // Allow users to exclude specific commit characters from accepting suggestions.
-                // This is language-overridable, so users can configure e.g. C# to exclude '.'
-                // to avoid committing suggestions when typing new collection expressions "[..]".
-                'editor.suggest.excludeCommitCharacters': {
-                    type: 'array',
-                    default: defaults.excludeCommitCharacters,
-                    items: { type: 'string' },
-                    markdownDescription: nls.localize('editor.suggest.excludeCommitCharacters', "Characters in this list will not accept a suggestion when typed as commit characters. Can be configured per language, for example to exclude '.' in C# when typing collection expressions.")
-                }
-            }
-        );
-    }
+				'editor.suggest.showIssues': {
+					type: 'boolean',
+					default: true,
+					markdownDescription: nls.localize('editor.suggest.showIssues', "When enabled IntelliSense shows `issues`-suggestions.")
+				},
+				'editor.suggest.excludeCommitCharacters': {
+					type: 'array',
+					default: defaults.excludeCommitCharacters,
+					items: { type: 'string' },
+					markdownDescription: nls.localize('editor.suggest.excludeCommitCharacters', "Characters in this list will not accept a suggestion when typed as commit characters. Can be configured per language, for example to exclude '.' in C# when typing collection expressions.")
+				}
+			}
+		);
+	}
 
 	public validate(_input: unknown): InternalSuggestOptions {
 		if (!_input || typeof _input !== 'object') {
 			return this.defaultValue;
 		}
 		const input = _input as Unknown<ISuggestOptions>;
-        return {
-            insertMode: stringSet(input.insertMode, this.defaultValue.insertMode, ['insert', 'replace']),
-            filterGraceful: boolean(input.filterGraceful, this.defaultValue.filterGraceful),
-            snippetsPreventQuickSuggestions: boolean(input.snippetsPreventQuickSuggestions, this.defaultValue.filterGraceful),
-            localityBonus: boolean(input.localityBonus, this.defaultValue.localityBonus),
-            shareSuggestSelections: boolean(input.shareSuggestSelections, this.defaultValue.shareSuggestSelections),
-            selectionMode: stringSet(input.selectionMode, this.defaultValue.selectionMode, ['always', 'never', 'whenQuickSuggestion', 'whenTriggerCharacter']),
-            showIcons: boolean(input.showIcons, this.defaultValue.showIcons),
-            showStatusBar: boolean(input.showStatusBar, this.defaultValue.showStatusBar),
-            preview: boolean(input.preview, this.defaultValue.preview),
-            previewMode: stringSet(input.previewMode, this.defaultValue.previewMode, ['prefix', 'subword', 'subwordSmart']),
-            showInlineDetails: boolean(input.showInlineDetails, this.defaultValue.showInlineDetails),
-            showMethods: boolean(input.showMethods, this.defaultValue.showMethods),
-            showFunctions: boolean(input.showFunctions, this.defaultValue.showFunctions),
-            showConstructors: boolean(input.showConstructors, this.defaultValue.showConstructors),
-            showDeprecated: boolean(input.showDeprecated, this.defaultValue.showDeprecated),
-            matchOnWordStartOnly: boolean(input.matchOnWordStartOnly, this.defaultValue.matchOnWordStartOnly),
-            showFields: boolean(input.showFields, this.defaultValue.showFields),
-            showVariables: boolean(input.showVariables, this.defaultValue.showVariables),
-            showClasses: boolean(input.showClasses, this.defaultValue.showClasses),
-            showStructs: boolean(input.showStructs, this.defaultValue.showStructs),
-            showInterfaces: boolean(input.showInterfaces, this.defaultValue.showInterfaces),
-            showModules: boolean(input.showModules, this.defaultValue.showModules),
-            showProperties: boolean(input.showProperties, this.defaultValue.showProperties),
-            showEvents: boolean(input.showEvents, this.defaultValue.showEvents),
-            showOperators: boolean(input.showOperators, this.defaultValue.showOperators),
-            showUnits: boolean(input.showUnits, this.defaultValue.showUnits),
-            showValues: boolean(input.showValues, this.defaultValue.showValues),
-            showConstants: boolean(input.showConstants, this.defaultValue.showConstants),
-            showEnums: boolean(input.showEnums, this.defaultValue.showEnums),
-            showEnumMembers: boolean(input.showEnumMembers, this.defaultValue.showEnumMembers),
-            showKeywords: boolean(input.showKeywords, this.defaultValue.showKeywords),
-            showWords: boolean(input.showWords, this.defaultValue.showWords),
-            showColors: boolean(input.showColors, this.defaultValue.showColors),
-            showFiles: boolean(input.showFiles, this.defaultValue.showFiles),
-            showReferences: boolean(input.showReferences, this.defaultValue.showReferences),
-            showFolders: boolean(input.showFolders, this.defaultValue.showFolders),
-            showTypeParameters: boolean(input.showTypeParameters, this.defaultValue.showTypeParameters),
-            showSnippets: boolean(input.showSnippets, this.defaultValue.showSnippets),
-            showUsers: boolean(input.showUsers, this.defaultValue.showUsers),
-            showIssues: boolean(input.showIssues, this.defaultValue.showIssues),
-            excludeCommitCharacters: Array.isArray(input.excludeCommitCharacters) ? input.excludeCommitCharacters.filter(e => typeof e === 'string') : this.defaultValue.excludeCommitCharacters,
-        };
-    }
+		return {
+			insertMode: stringSet(input.insertMode, this.defaultValue.insertMode, ['insert', 'replace']),
+			filterGraceful: boolean(input.filterGraceful, this.defaultValue.filterGraceful),
+			snippetsPreventQuickSuggestions: boolean(input.snippetsPreventQuickSuggestions, this.defaultValue.filterGraceful),
+			localityBonus: boolean(input.localityBonus, this.defaultValue.localityBonus),
+			shareSuggestSelections: boolean(input.shareSuggestSelections, this.defaultValue.shareSuggestSelections),
+			selectionMode: stringSet(input.selectionMode, this.defaultValue.selectionMode, ['always', 'never', 'whenQuickSuggestion', 'whenTriggerCharacter']),
+			showIcons: boolean(input.showIcons, this.defaultValue.showIcons),
+			showStatusBar: boolean(input.showStatusBar, this.defaultValue.showStatusBar),
+			preview: boolean(input.preview, this.defaultValue.preview),
+			previewMode: stringSet(input.previewMode, this.defaultValue.previewMode, ['prefix', 'subword', 'subwordSmart']),
+			showInlineDetails: boolean(input.showInlineDetails, this.defaultValue.showInlineDetails),
+			showMethods: boolean(input.showMethods, this.defaultValue.showMethods),
+			showFunctions: boolean(input.showFunctions, this.defaultValue.showFunctions),
+			showConstructors: boolean(input.showConstructors, this.defaultValue.showConstructors),
+			showDeprecated: boolean(input.showDeprecated, this.defaultValue.showDeprecated),
+			matchOnWordStartOnly: boolean(input.matchOnWordStartOnly, this.defaultValue.matchOnWordStartOnly),
+			showFields: boolean(input.showFields, this.defaultValue.showFields),
+			showVariables: boolean(input.showVariables, this.defaultValue.showVariables),
+			showClasses: boolean(input.showClasses, this.defaultValue.showClasses),
+			showStructs: boolean(input.showStructs, this.defaultValue.showStructs),
+			showInterfaces: boolean(input.showInterfaces, this.defaultValue.showInterfaces),
+			showModules: boolean(input.showModules, this.defaultValue.showModules),
+			showProperties: boolean(input.showProperties, this.defaultValue.showProperties),
+			showEvents: boolean(input.showEvents, this.defaultValue.showEvents),
+			showOperators: boolean(input.showOperators, this.defaultValue.showOperators),
+			showUnits: boolean(input.showUnits, this.defaultValue.showUnits),
+			showValues: boolean(input.showValues, this.defaultValue.showValues),
+			showConstants: boolean(input.showConstants, this.defaultValue.showConstants),
+			showEnums: boolean(input.showEnums, this.defaultValue.showEnums),
+			showEnumMembers: boolean(input.showEnumMembers, this.defaultValue.showEnumMembers),
+			showKeywords: boolean(input.showKeywords, this.defaultValue.showKeywords),
+			showWords: boolean(input.showWords, this.defaultValue.showWords),
+			showColors: boolean(input.showColors, this.defaultValue.showColors),
+			showFiles: boolean(input.showFiles, this.defaultValue.showFiles),
+			showReferences: boolean(input.showReferences, this.defaultValue.showReferences),
+			showFolders: boolean(input.showFolders, this.defaultValue.showFolders),
+			showTypeParameters: boolean(input.showTypeParameters, this.defaultValue.showTypeParameters),
+			showSnippets: boolean(input.showSnippets, this.defaultValue.showSnippets),
+			showUsers: boolean(input.showUsers, this.defaultValue.showUsers),
+			showIssues: boolean(input.showIssues, this.defaultValue.showIssues),
+			excludeCommitCharacters: Array.isArray(input.excludeCommitCharacters) ? input.excludeCommitCharacters.filter(e => typeof e === 'string') : this.defaultValue.excludeCommitCharacters,
+		};
+	}
 }
 
 //#endregion

--- a/src/vs/editor/contrib/suggest/browser/suggestCommitCharacters.ts
+++ b/src/vs/editor/contrib/suggest/browser/suggestCommitCharacters.ts
@@ -39,6 +39,13 @@ export class CommitCharacterController {
 			if (this._active && !widget.isFrozen() && model.state !== State.Idle) {
 				const ch = text.charCodeAt(text.length - 1);
 				if (this._active.acceptCharacters.has(ch) && editor.getOption(EditorOption.acceptSuggestionOnCommitCharacter)) {
+					// honor excludeCommitCharacters setting
+					const typed = String.fromCharCode(ch);
+					const suggestOpts = editor.getOption(EditorOption.suggest);
+					const excluded = Array.isArray(suggestOpts.excludeCommitCharacters) && suggestOpts.excludeCommitCharacters.indexOf(typed) >= 0;
+					if (excluded) {
+						return;
+					}
 					accept(this._active.item);
 				}
 			}

--- a/src/vs/editor/contrib/suggest/test/browser/suggestController.test.ts
+++ b/src/vs/editor/contrib/suggest/test/browser/suggestController.test.ts
@@ -108,7 +108,7 @@ suite('SuggestController', function () {
 			}
 		}));
 
-		// without exclusion: typing '.' accepts the suggestion
+    // Part 1: without exclusion -> typing '.' should accept the suggestion
 		editor.setValue('x');
 		editor.setSelection(new Selection(1, 2, 1, 2));
 		const p1 = Event.toPromise(controller.model.onDidSuggest);
@@ -117,7 +117,7 @@ suite('SuggestController', function () {
 		editor.trigger('keyboard', 'type', { text: '.' });
 		assert.strictEqual(editor.getValue(), 'foo.');
 
-		// with exclusion: typing '.' does not accept the suggestion
+    // Part 2: with exclusion -> typing '.' should NOT accept; it should be inserted literally
 		editor.updateOptions({ suggest: { excludeCommitCharacters: ['.'] } });
 		editor.setValue('y');
 		editor.setSelection(new Selection(1, 2, 1, 2));

--- a/src/vs/editor/contrib/suggest/test/browser/suggestController.test.ts
+++ b/src/vs/editor/contrib/suggest/test/browser/suggestController.test.ts
@@ -108,7 +108,7 @@ suite('SuggestController', function () {
 			}
 		}));
 
-    // Part 1: without exclusion -> typing '.' should accept the suggestion
+		// without exclusion: typing '.' accepts the suggestion
 		editor.setValue('x');
 		editor.setSelection(new Selection(1, 2, 1, 2));
 		const p1 = Event.toPromise(controller.model.onDidSuggest);
@@ -117,7 +117,7 @@ suite('SuggestController', function () {
 		editor.trigger('keyboard', 'type', { text: '.' });
 		assert.strictEqual(editor.getValue(), 'foo.');
 
-    // Part 2: with exclusion -> typing '.' should NOT accept; it should be inserted literally
+		// with exclusion: typing '.' does not accept the suggestion
 		editor.updateOptions({ suggest: { excludeCommitCharacters: ['.'] } });
 		editor.setValue('y');
 		editor.setSelection(new Selection(1, 2, 1, 2));


### PR DESCRIPTION
**Summary**

*   Adds a per-language setting to prevent specific commit characters (e.g. “.”) from accepting suggestions. This fixes the C# “\[..\]” collection expression scenario where the second dot would commit a suggestion instead of inserting literally.
    
*   Default is no-op; existing behavior is preserved unless users opt in.
    

**Problem**

*   In C#, typing “\[..” triggers IntelliSense after the first “.”. Pressing “.” again accepts the selected completion (since “.” is a commit character), interrupting the collection expression. Users want Tab-only acceptance or a way to block “.” from committing in this context.
    

**New Setting**

*   Key: editor.suggest.excludeCommitCharacters
    
*   Type: string\[\]
    
*   Scope: Per-language override supported
    
*   Default: \[\]
    
*   Behavior: If a typed character is both a provider’s commit character and appears in this list, the suggestion is not accepted and the character is inserted literally.
    

Example (C#)

*   In Settings (JSON):"\[csharp\]": {"editor.suggest.excludeCommitCharacters": \["."\]}
    

**Why This Design**

*   Fine-grained, user-controlled, and language-scoped.
    
*   Backward-compatible: No change unless configured.
    
*   Complements existing settings (e.g., editor.acceptSuggestionOnCommitCharacter, editor.acceptSuggestionOnEnter, editor.tabCompletion).
    

**Implementation**

*   Config and schema: Adds excludeCommitCharacters to EditorOption.suggest.
    
    *   src/vs/editor/common/config/editorOptions.ts
        
*   Commit-character path: Checks the exclusion list before accepting on commit characters.
    
    *   src/vs/editor/contrib/suggest/browser/suggestCommitCharacters.ts
        

**Tests**

*   Adds a test ensuring:
    
    *   By default, typing “.” (as a commit character) accepts a suggestion.
        
    *   With excludeCommitCharacters: \["."\], typing “.” does not accept and inserts “.” literally.
        
    *   src/vs/editor/contrib/suggest/test/browser/suggestController.test.ts
        

**Manual Verification**

*   Open a C# file.
    
*   Without setting: type “\[..”; the second “.” accepts the suggestion.
    
*   With:"\[csharp\]": { "editor.suggest.excludeCommitCharacters": \["."\] }type “\[..”; the second “.” inserts literally; Tab still accepts suggestions.
    

**Compatibility**

*   No behavior changes by default. The setting only takes effect when configured.
    
*   Works independently of editor.acceptSuggestionOnCommitCharacter; if that is false, commit characters are globally disabled as before.
    

**Docs / Release Notes**

*   New: editor.suggest.excludeCommitCharacters lets you disable specific commit characters per language (e.g., “.” for C#) to avoid accidental suggestion acceptance. Helps with C# collection expressions “\[..\]”. Fixes #273571.
    

**Telemetry**

*   None. Local editor behavior only.