### PR TITLE
Set QuickPick title to "Toggle Auto Attach" and move scope hint to placeholder

### DIFF
--- a/extensions/debug-auto-launch/src/extension.ts
+++ b/extensions/debug-auto-launch/src/extension.ts
@@ -33,6 +33,8 @@ const TEXT_STATE_DESCRIPTION = {
 	[State.Smart]: vscode.l10n.t("Auto attach when running scripts that aren't in a node_modules folder"),
 	[State.OnlyWithFlag]: vscode.l10n.t('Only auto attach when the `--inspect` flag is given')
 };
+
+const TEXT_TOGGLE_TITLE = vscode.l10n.t('Toogle Auto Attach');
 const TEXT_TOGGLE_WORKSPACE = vscode.l10n.t('Toggle auto attach in this workspace');
 const TEXT_TOGGLE_GLOBAL = vscode.l10n.t('Toggle auto attach on this machine');
 const TEXT_TEMP_DISABLE = vscode.l10n.t('Temporarily disable auto attach in this session');
@@ -134,7 +136,8 @@ async function toggleAutoAttachSetting(context: vscode.ExtensionContext, scope?:
 	quickPick.activeItems = isTemporarilyDisabled
 		? [items[0]]
 		: quickPick.items.filter(i => 'state' in i && i.state === current);
-	quickPick.title = isGlobalScope ? TEXT_TOGGLE_GLOBAL : TEXT_TOGGLE_WORKSPACE;
+	quickPick.title = TEXT_TOGGLE_TITLE;
+	quickPick.placeholder = isGlobalScope ? TEXT_TOGGLE_GLOBAL : TEXT_TOGGLE_WORKSPACE;
 	quickPick.buttons = [
 		{
 			iconPath: new vscode.ThemeIcon(isGlobalScope ? 'folder' : 'globe'),

--- a/extensions/debug-auto-launch/src/extension.ts
+++ b/extensions/debug-auto-launch/src/extension.ts
@@ -34,7 +34,7 @@ const TEXT_STATE_DESCRIPTION = {
 	[State.OnlyWithFlag]: vscode.l10n.t('Only auto attach when the `--inspect` flag is given')
 };
 
-const TEXT_TOGGLE_TITLE = vscode.l10n.t('Toogle Auto Attach');
+const TEXT_TOGGLE_TITLE = vscode.l10n.t('Toggle Auto Attach');
 const TEXT_TOGGLE_WORKSPACE = vscode.l10n.t('Toggle auto attach in this workspace');
 const TEXT_TOGGLE_GLOBAL = vscode.l10n.t('Toggle auto attach on this machine');
 const TEXT_TEMP_DISABLE = vscode.l10n.t('Temporarily disable auto attach in this session');


### PR DESCRIPTION
Use a dedicated TEXT_TOGGLE_TITLE for the quick pick title and show the
workspace/global hint in quickPick.placeholder instead of using it as the title.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
