### PR TITLE
Add a bit more typing around json schemas for extension points

### DIFF
--- a/src/vs/base/common/jsonSchema.ts
+++ b/src/vs/base/common/jsonSchema.ts
@@ -105,7 +105,7 @@ export interface IJSONSchemaSnippet {
  *
  * Doesn't support all JSON schema features, such as `additionalProperties`.
  */
-export type TypeForJsonSchema<T> =
+export type TypeFromJsonSchema<T> =
 	// String
 	T extends { type: 'string' }
 	? string
@@ -126,17 +126,17 @@ export type TypeForJsonSchema<T> =
 	// Values are required or optional based on `required` list.
 	: T extends { type: 'object'; properties: infer P; required: infer RequiredList }
 	? {
-		[K in keyof P]: IsRequired<K, RequiredList> extends true ? TypeForJsonSchema<P[K]> : TypeForJsonSchema<P[K]> | undefined;
+		[K in keyof P]: IsRequired<K, RequiredList> extends true ? TypeFromJsonSchema<P[K]> : TypeFromJsonSchema<P[K]> | undefined;
 	}
 
 	// Object with no required properties.
 	// All values are optional
 	: T extends { type: 'object'; properties: infer P }
-	? { [K in keyof P]: TypeForJsonSchema<P[K]> | undefined }
+	? { [K in keyof P]: TypeFromJsonSchema<P[K]> | undefined }
 
 	// Array
 	: T extends { type: 'array'; items: infer I }
-	? Array<TypeForJsonSchema<I>>
+	? Array<TypeFromJsonSchema<I>>
 
 	// OneOf
 	: T extends { oneOf: infer I }
@@ -158,7 +158,7 @@ type IsRequired<K, RequiredList> =
 	: false;
 
 type MapSchemaToType<T> = T extends [infer First, ...infer Rest]
-	? TypeForJsonSchema<First> | MapSchemaToType<Rest>
+	? TypeFromJsonSchema<First> | MapSchemaToType<Rest>
 	: never;
 
 /**
@@ -168,7 +168,7 @@ type MapSchemaToType<T> = T extends [infer First, ...infer Rest]
  *
  * Doesn't support all JSON schema features. Notably, doesn't support converting unions or intersections to `oneOf` or `anyOf`.
  */
-export type JsonSchemaForType<T> =
+export type JsonSchemaFromType<T> =
 	// String
 	T extends string
 	? IJSONSchema & { type: 'string' }
@@ -188,14 +188,14 @@ export type JsonSchemaForType<T> =
 
 	// Array
 	: T extends ReadonlyArray<infer U>
-	? IJSONSchema & { items: JsonSchemaForType<U> }
+	? IJSONSchema & { items: JsonSchemaFromType<U> }
 
 	// Record
 	: T extends Record<string, infer V>
-	? IJSONSchema & { additionalProperties: JsonSchemaForType<V> }
+	? IJSONSchema & { additionalProperties: JsonSchemaFromType<V> }
 
 	// Object
-	: IJSONSchema & { properties: { [K in keyof T]: JsonSchemaForType<T[K]> } };
+	: IJSONSchema & { properties: { [K in keyof T]: JsonSchemaFromType<T[K]> } };
 
 
 interface Equals { schemas: IJSONSchema[]; id?: string }

--- a/src/vs/editor/contrib/codeAction/browser/codeActionCommands.ts
+++ b/src/vs/editor/contrib/codeAction/browser/codeActionCommands.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { HierarchicalKind } from '../../../../base/common/hierarchicalKind.js';
-import { IJSONSchema, TypeForJsonSchema } from '../../../../base/common/jsonSchema.js';
+import { IJSONSchema, TypeFromJsonSchema } from '../../../../base/common/jsonSchema.js';
 import { KeyCode, KeyMod } from '../../../../base/common/keyCodes.js';
 import { escapeRegExpCharacters } from '../../../../base/common/strings.js';
 import { ICodeEditor } from '../../../browser/editorBrowser.js';
@@ -97,7 +97,7 @@ export class CodeActionCommand extends EditorCommand {
 		});
 	}
 
-	public runEditorCommand(_accessor: ServicesAccessor, editor: ICodeEditor, userArgs?: TypeForJsonSchema<typeof argsSchema>): void {
+	public runEditorCommand(_accessor: ServicesAccessor, editor: ICodeEditor, userArgs?: TypeFromJsonSchema<typeof argsSchema>): void {
 		const args = CodeActionCommandArgs.fromUser(userArgs, {
 			kind: HierarchicalKind.Empty,
 			apply: CodeActionAutoApply.IfSingle,
@@ -149,7 +149,7 @@ export class RefactorAction extends EditorAction {
 		});
 	}
 
-	public run(_accessor: ServicesAccessor, editor: ICodeEditor, userArgs?: TypeForJsonSchema<typeof argsSchema>): void {
+	public run(_accessor: ServicesAccessor, editor: ICodeEditor, userArgs?: TypeFromJsonSchema<typeof argsSchema>): void {
 		const args = CodeActionCommandArgs.fromUser(userArgs, {
 			kind: CodeActionKind.Refactor,
 			apply: CodeActionAutoApply.Never
@@ -191,7 +191,7 @@ export class SourceAction extends EditorAction {
 		});
 	}
 
-	public run(_accessor: ServicesAccessor, editor: ICodeEditor, userArgs?: TypeForJsonSchema<typeof argsSchema>): void {
+	public run(_accessor: ServicesAccessor, editor: ICodeEditor, userArgs?: TypeFromJsonSchema<typeof argsSchema>): void {
 		const args = CodeActionCommandArgs.fromUser(userArgs, {
 			kind: CodeActionKind.Source,
 			apply: CodeActionAutoApply.Never

--- a/src/vs/editor/contrib/codeAction/browser/codeActionCommands.ts
+++ b/src/vs/editor/contrib/codeAction/browser/codeActionCommands.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { HierarchicalKind } from '../../../../base/common/hierarchicalKind.js';
-import { IJSONSchema } from '../../../../base/common/jsonSchema.js';
+import { IJSONSchema, TypeForJsonSchema } from '../../../../base/common/jsonSchema.js';
 import { KeyCode, KeyMod } from '../../../../base/common/keyCodes.js';
 import { escapeRegExpCharacters } from '../../../../base/common/strings.js';
 import { ICodeEditor } from '../../../browser/editorBrowser.js';
@@ -24,7 +24,7 @@ function contextKeyForSupportedActions(kind: HierarchicalKind) {
 		new RegExp('(\\s|^)' + escapeRegExpCharacters(kind.value) + '\\b'));
 }
 
-const argsSchema: IJSONSchema = {
+const argsSchema = {
 	type: 'object',
 	defaultSnippets: [{ body: { kind: '' } }],
 	properties: {
@@ -49,7 +49,7 @@ const argsSchema: IJSONSchema = {
 			description: nls.localize('args.schema.preferred', "Controls if only preferred code actions should be returned."),
 		}
 	}
-};
+} as const satisfies IJSONSchema;
 
 function triggerCodeActionsForEditorSelection(
 	editor: ICodeEditor,
@@ -97,7 +97,7 @@ export class CodeActionCommand extends EditorCommand {
 		});
 	}
 
-	public runEditorCommand(_accessor: ServicesAccessor, editor: ICodeEditor, userArgs: any) {
+	public runEditorCommand(_accessor: ServicesAccessor, editor: ICodeEditor, userArgs?: TypeForJsonSchema<typeof argsSchema>): void {
 		const args = CodeActionCommandArgs.fromUser(userArgs, {
 			kind: HierarchicalKind.Empty,
 			apply: CodeActionAutoApply.IfSingle,
@@ -149,7 +149,7 @@ export class RefactorAction extends EditorAction {
 		});
 	}
 
-	public run(_accessor: ServicesAccessor, editor: ICodeEditor, userArgs: any): void {
+	public run(_accessor: ServicesAccessor, editor: ICodeEditor, userArgs?: TypeForJsonSchema<typeof argsSchema>): void {
 		const args = CodeActionCommandArgs.fromUser(userArgs, {
 			kind: CodeActionKind.Refactor,
 			apply: CodeActionAutoApply.Never
@@ -191,7 +191,7 @@ export class SourceAction extends EditorAction {
 		});
 	}
 
-	public run(_accessor: ServicesAccessor, editor: ICodeEditor, userArgs: any): void {
+	public run(_accessor: ServicesAccessor, editor: ICodeEditor, userArgs?: TypeForJsonSchema<typeof argsSchema>): void {
 		const args = CodeActionCommandArgs.fromUser(userArgs, {
 			kind: CodeActionKind.Source,
 			apply: CodeActionAutoApply.Never

--- a/src/vs/editor/contrib/dropOrPasteInto/browser/copyPasteContribution.ts
+++ b/src/vs/editor/contrib/dropOrPasteInto/browser/copyPasteContribution.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { HierarchicalKind } from '../../../../base/common/hierarchicalKind.js';
-import { IJSONSchema, TypeForJsonSchema } from '../../../../base/common/jsonSchema.js';
+import { IJSONSchema, TypeFromJsonSchema } from '../../../../base/common/jsonSchema.js';
 import { KeyCode, KeyMod } from '../../../../base/common/keyCodes.js';
 import * as nls from '../../../../nls.js';
 import { KeybindingWeight } from '../../../../platform/keybinding/common/keybindingsRegistry.js';
@@ -96,7 +96,7 @@ registerEditorAction(class PasteAsAction extends EditorAction {
 		});
 	}
 
-	public override run(_accessor: ServicesAccessor, editor: ICodeEditor, args?: TypeForJsonSchema<typeof PasteAsAction.argsSchema>) {
+	public override run(_accessor: ServicesAccessor, editor: ICodeEditor, args?: TypeFromJsonSchema<typeof PasteAsAction.argsSchema>) {
 		let preference: PastePreference | undefined;
 		if (args) {
 			if ('kind' in args) {

--- a/src/vs/editor/contrib/dropOrPasteInto/browser/copyPasteContribution.ts
+++ b/src/vs/editor/contrib/dropOrPasteInto/browser/copyPasteContribution.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { HierarchicalKind } from '../../../../base/common/hierarchicalKind.js';
-import { IJSONSchema, SchemaToType } from '../../../../base/common/jsonSchema.js';
+import { IJSONSchema, TypeForJsonSchema } from '../../../../base/common/jsonSchema.js';
 import { KeyCode, KeyMod } from '../../../../base/common/keyCodes.js';
 import * as nls from '../../../../nls.js';
 import { KeybindingWeight } from '../../../../platform/keybinding/common/keybindingsRegistry.js';
@@ -96,7 +96,7 @@ registerEditorAction(class PasteAsAction extends EditorAction {
 		});
 	}
 
-	public override run(_accessor: ServicesAccessor, editor: ICodeEditor, args?: SchemaToType<typeof PasteAsAction.argsSchema>) {
+	public override run(_accessor: ServicesAccessor, editor: ICodeEditor, args?: TypeForJsonSchema<typeof PasteAsAction.argsSchema>) {
 		let preference: PastePreference | undefined;
 		if (args) {
 			if ('kind' in args) {

--- a/src/vs/workbench/contrib/chat/browser/chatOutputItemRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatOutputItemRenderer.ts
@@ -9,6 +9,7 @@ import { CancellationToken } from '../../../../base/common/cancellation.js';
 import { matchesMimeType } from '../../../../base/common/dataTransfer.js';
 import { CancellationError } from '../../../../base/common/errors.js';
 import { Emitter, Event } from '../../../../base/common/event.js';
+import { IJSONSchema, TypeForJsonSchema } from '../../../../base/common/jsonSchema.js';
 import { Disposable, DisposableStore, IDisposable } from '../../../../base/common/lifecycle.js';
 import { autorun } from '../../../../base/common/observable.js';
 import { URI } from '../../../../base/common/uri.js';
@@ -171,14 +172,30 @@ export class ChatOutputRendererService extends Disposable implements IChatOutput
 	}
 }
 
-interface IChatOutputRendererContribution {
-	readonly viewType: string;
-	readonly mimeTypes: readonly string[];
-}
+const chatOutputRendererContributionSchema = {
+	type: 'object',
+	additionalProperties: false,
+	required: ['viewType', 'mimeTypes'],
+	properties: {
+		viewType: {
+			type: 'string',
+			description: nls.localize('chatOutputRenderer.viewType', 'Unique identifier for the renderer.'),
+		},
+		mimeTypes: {
+			type: 'array',
+			description: nls.localize('chatOutputRenderer.mimeTypes', 'MIME types that this renderer can handle'),
+			items: {
+				type: 'string'
+			}
+		}
+	}
+} as const satisfies IJSONSchema;
+
+type IChatOutputRendererContribution = TypeForJsonSchema<typeof chatOutputRendererContributionSchema>;
 
 const chatOutputRenderContributionPoint = ExtensionsRegistry.registerExtensionPoint<IChatOutputRendererContribution[]>({
 	extensionPoint: 'chatOutputRenderers',
-	activationEventsGenerator: function* (contributions: readonly IChatOutputRendererContribution[]) {
+	activationEventsGenerator: function* (contributions) {
 		for (const contrib of contributions) {
 			yield `onChatOutputRenderer:${contrib.viewType}`;
 		}
@@ -186,24 +203,7 @@ const chatOutputRenderContributionPoint = ExtensionsRegistry.registerExtensionPo
 	jsonSchema: {
 		description: nls.localize('vscode.extension.contributes.chatOutputRenderer', 'Contributes a renderer for specific MIME types in chat outputs'),
 		type: 'array',
-		items: {
-			type: 'object',
-			additionalProperties: false,
-			required: ['viewType', 'mimeTypes'],
-			properties: {
-				viewType: {
-					type: 'string',
-					description: nls.localize('chatOutputRenderer.viewType', 'Unique identifier for the renderer.'),
-				},
-				mimeTypes: {
-					type: 'array',
-					description: nls.localize('chatOutputRenderer.mimeTypes', 'MIME types that this renderer can handle'),
-					items: {
-						type: 'string'
-					}
-				}
-			}
-		}
+		items: chatOutputRendererContributionSchema,
 	}
 });
 

--- a/src/vs/workbench/contrib/chat/browser/chatOutputItemRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatOutputItemRenderer.ts
@@ -9,7 +9,7 @@ import { CancellationToken } from '../../../../base/common/cancellation.js';
 import { matchesMimeType } from '../../../../base/common/dataTransfer.js';
 import { CancellationError } from '../../../../base/common/errors.js';
 import { Emitter, Event } from '../../../../base/common/event.js';
-import { IJSONSchema, TypeForJsonSchema } from '../../../../base/common/jsonSchema.js';
+import { IJSONSchema, TypeFromJsonSchema } from '../../../../base/common/jsonSchema.js';
 import { Disposable, DisposableStore, IDisposable } from '../../../../base/common/lifecycle.js';
 import { autorun } from '../../../../base/common/observable.js';
 import { URI } from '../../../../base/common/uri.js';
@@ -191,7 +191,7 @@ const chatOutputRendererContributionSchema = {
 	}
 } as const satisfies IJSONSchema;
 
-type IChatOutputRendererContribution = TypeForJsonSchema<typeof chatOutputRendererContributionSchema>;
+type IChatOutputRendererContribution = TypeFromJsonSchema<typeof chatOutputRendererContributionSchema>;
 
 const chatOutputRenderContributionPoint = ExtensionsRegistry.registerExtensionPoint<IChatOutputRendererContribution[]>({
 	extensionPoint: 'chatOutputRenderers',

--- a/src/vs/workbench/contrib/chat/browser/viewsWelcome/chatViewsWelcomeHandler.ts
+++ b/src/vs/workbench/contrib/chat/browser/viewsWelcome/chatViewsWelcomeHandler.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { MarkdownString } from '../../../../../base/common/htmlContent.js';
-import { JsonSchemaForType } from '../../../../../base/common/jsonSchema.js';
+import { JsonSchemaFromType } from '../../../../../base/common/jsonSchema.js';
 import { ThemeIcon } from '../../../../../base/common/themables.js';
 import { localize } from '../../../../../nls.js';
 import { ContextKeyExpr } from '../../../../../platform/contextkey/common/contextkey.js';
@@ -50,7 +50,7 @@ const chatViewsWelcomeExtensionPoint = extensionsRegistry.ExtensionsRegistry.reg
 			}
 		},
 		required: ['icon', 'title', 'contents', 'when'],
-	} satisfies JsonSchemaForType<IRawChatViewsWelcomeContribution[]>,
+	} satisfies JsonSchemaFromType<IRawChatViewsWelcomeContribution[]>,
 });
 
 export class ChatViewsWelcomeHandler implements IWorkbenchContribution {

--- a/src/vs/workbench/contrib/chat/browser/viewsWelcome/chatViewsWelcomeHandler.ts
+++ b/src/vs/workbench/contrib/chat/browser/viewsWelcome/chatViewsWelcomeHandler.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { MarkdownString } from '../../../../../base/common/htmlContent.js';
+import { JsonSchemaForType } from '../../../../../base/common/jsonSchema.js';
 import { ThemeIcon } from '../../../../../base/common/themables.js';
 import { localize } from '../../../../../nls.js';
 import { ContextKeyExpr } from '../../../../../platform/contextkey/common/contextkey.js';
@@ -49,7 +50,7 @@ const chatViewsWelcomeExtensionPoint = extensionsRegistry.ExtensionsRegistry.reg
 			}
 		},
 		required: ['icon', 'title', 'contents', 'when'],
-	}
+	} satisfies JsonSchemaForType<IRawChatViewsWelcomeContribution[]>,
 });
 
 export class ChatViewsWelcomeHandler implements IWorkbenchContribution {

--- a/src/vs/workbench/contrib/chat/common/languageModels.ts
+++ b/src/vs/workbench/contrib/chat/common/languageModels.ts
@@ -8,7 +8,7 @@ import { VSBuffer } from '../../../../base/common/buffer.js';
 import { CancellationToken } from '../../../../base/common/cancellation.js';
 import { Emitter, Event } from '../../../../base/common/event.js';
 import { Iterable } from '../../../../base/common/iterator.js';
-import { JsonSchemaForType } from '../../../../base/common/jsonSchema.js';
+import { JsonSchemaFromType } from '../../../../base/common/jsonSchema.js';
 import { DisposableStore, IDisposable, toDisposable } from '../../../../base/common/lifecycle.js';
 import { isFalsyOrWhitespace } from '../../../../base/common/strings.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
@@ -265,7 +265,7 @@ export interface ILanguageModelsService {
 	computeTokenLength(modelId: string, message: string | IChatMessage, token: CancellationToken): Promise<number>;
 }
 
-const languageModelChatProviderType: JsonSchemaForType<IUserFriendlyLanguageModel> = {
+const languageModelChatProviderType: JsonSchemaFromType<IUserFriendlyLanguageModel> = {
 	type: 'object',
 	properties: {
 		vendor: {

--- a/src/vs/workbench/contrib/chat/common/languageModels.ts
+++ b/src/vs/workbench/contrib/chat/common/languageModels.ts
@@ -8,7 +8,7 @@ import { VSBuffer } from '../../../../base/common/buffer.js';
 import { CancellationToken } from '../../../../base/common/cancellation.js';
 import { Emitter, Event } from '../../../../base/common/event.js';
 import { Iterable } from '../../../../base/common/iterator.js';
-import { IJSONSchema } from '../../../../base/common/jsonSchema.js';
+import { JsonSchemaForType } from '../../../../base/common/jsonSchema.js';
 import { DisposableStore, IDisposable, toDisposable } from '../../../../base/common/lifecycle.js';
 import { isFalsyOrWhitespace } from '../../../../base/common/strings.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
@@ -265,7 +265,7 @@ export interface ILanguageModelsService {
 	computeTokenLength(modelId: string, message: string | IChatMessage, token: CancellationToken): Promise<number>;
 }
 
-const languageModelChatProviderType: IJSONSchema = {
+const languageModelChatProviderType: JsonSchemaForType<IUserFriendlyLanguageModel> = {
 	type: 'object',
 	properties: {
 		vendor: {

--- a/src/vs/workbench/services/keybinding/browser/keybindingService.ts
+++ b/src/vs/workbench/services/keybinding/browser/keybindingService.ts
@@ -14,7 +14,7 @@ import { mainWindow } from '../../../../base/browser/window.js';
 import { DeferredPromise, RunOnceScheduler } from '../../../../base/common/async.js';
 import { Emitter, Event } from '../../../../base/common/event.js';
 import { parse } from '../../../../base/common/json.js';
-import { IJSONSchema } from '../../../../base/common/jsonSchema.js';
+import { IJSONSchema, JsonSchemaForType } from '../../../../base/common/jsonSchema.js';
 import { UserSettingsLabelProvider } from '../../../../base/common/keybindingLabels.js';
 import { KeybindingParser } from '../../../../base/common/keybindingParser.js';
 import { Keybinding, KeyCodeChord, ResolvedKeybinding, ScanCodeChord } from '../../../../base/common/keybindings.js';
@@ -99,7 +99,7 @@ function isValidContributedKeyBinding(keyBinding: ContributedKeyBinding, rejects
 	return true;
 }
 
-const keybindingType: IJSONSchema = {
+const keybindingType: JsonSchemaForType<ContributedKeyBinding> = {
 	type: 'object',
 	default: { command: '', key: '' },
 	properties: {

--- a/src/vs/workbench/services/keybinding/browser/keybindingService.ts
+++ b/src/vs/workbench/services/keybinding/browser/keybindingService.ts
@@ -14,7 +14,7 @@ import { mainWindow } from '../../../../base/browser/window.js';
 import { DeferredPromise, RunOnceScheduler } from '../../../../base/common/async.js';
 import { Emitter, Event } from '../../../../base/common/event.js';
 import { parse } from '../../../../base/common/json.js';
-import { IJSONSchema, JsonSchemaForType } from '../../../../base/common/jsonSchema.js';
+import { IJSONSchema, JsonSchemaFromType } from '../../../../base/common/jsonSchema.js';
 import { UserSettingsLabelProvider } from '../../../../base/common/keybindingLabels.js';
 import { KeybindingParser } from '../../../../base/common/keybindingParser.js';
 import { Keybinding, KeyCodeChord, ResolvedKeybinding, ScanCodeChord } from '../../../../base/common/keybindings.js';
@@ -99,7 +99,7 @@ function isValidContributedKeyBinding(keyBinding: ContributedKeyBinding, rejects
 	return true;
 }
 
-const keybindingType: JsonSchemaForType<ContributedKeyBinding> = {
+const keybindingType: JsonSchemaFromType<ContributedKeyBinding> = {
 	type: 'object',
 	default: { command: '', key: '' },
 	properties: {


### PR DESCRIPTION
- Adds helper to go from type -> basic schema
- Uses schema -> type in one more place
- Improves checking for required vs optional properties in `TypeForJsonSchema`
