### PR TITLE
feat(extensions/git): add revert and reset commit graph commands

### DIFF
--- a/extensions/git/package.json
+++ b/extensions/git/package.json
@@ -715,6 +715,18 @@
         "enablement": "!operationInProgress"
       },
       {
+        "command": "git.graph.revertCommit",
+        "title": "%command.graphRevertCommit%",
+        "category": "Git",
+        "enablement": "!operationInProgress"
+      },
+      {
+        "command": "git.graph.resetCommit",
+        "title": "%command.graphResetCommit%",
+        "category": "Git",
+        "enablement": "!operationInProgress"
+      },
+      {
         "command": "git.cherryPickAbort",
         "title": "%command.cherryPickAbort%",
         "category": "Git",
@@ -2459,6 +2471,16 @@
           "command": "git.graph.compareRef",
           "when": "scmProvider == git",
           "group": "5_compare@3"
+        },
+        {
+          "command": "git.graph.revertCommit",
+          "when": "scmProvider == git",
+          "group": "4_modify@2"
+        },
+        {
+          "command": "git.graph.resetCommit",
+          "when": "scmProvider == git",
+          "group": "4_modify@3"
         },
         {
           "command": "git.copyCommitId",

--- a/extensions/git/package.nls.json
+++ b/extensions/git/package.nls.json
@@ -138,6 +138,8 @@
 	"command.graphCheckout": "Checkout",
 	"command.graphCheckoutDetached": "Checkout (Detached)",
 	"command.graphCherryPick": "Cherry Pick",
+	"command.graphRevertCommit": "Revert Commit",
+	"command.graphResetCommit": "Reset Commit",
 	"command.graphDeleteBranch": "Delete Branch",
 	"command.graphDeleteTag": "Delete Tag",
 	"command.graphCompareRef": "Compare with...",

--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -4278,6 +4278,33 @@ export class CommandCenter {
 		await repository.cherryPick(historyItem.id);
 	}
 
+	@command('git.graph.revertCommit', { repository: true })
+	async revertCommit(repository: Repository, historyItem?: SourceControlHistoryItem): Promise<void> {
+		if (!historyItem) {
+			return;
+		}
+
+		await repository.revertCommit(historyItem.id, true);
+	}
+
+	@command('git.graph.resetCommit', { repository: true })
+	async resetCommit(repository: Repository, historyItem?: SourceControlHistoryItem): Promise<void> {
+		if (!historyItem) {
+			return;
+		}
+
+		const message = l10n.t('Are you sure you want to reset to \'{0}\'?\n\nThis is IRREVERSIBLE!\nYour current working set will be FOREVER LOST if you proceed.', historyItem.id.substring(0, 8));
+		const yes = l10n.t('Reset');
+
+		const pick = await window.showWarningMessage(message, { modal: true }, yes);
+
+		if (pick !== yes) {
+			return;
+		}
+
+		await repository.reset(historyItem.id, true);
+	}
+
 	@command('git.cherryPickAbort', { repository: true })
 	async cherryPickAbort(repository: Repository): Promise<void> {
 		await repository.cherryPickAbort();

--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -4284,7 +4284,7 @@ export class CommandCenter {
 			return;
 		}
 
-		await repository.revertCommit(historyItem.id, true);
+		await repository.revertCommit(historyItem.id);
 	}
 
 	@command('git.graph.resetCommit', { repository: true })

--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -4293,7 +4293,7 @@ export class CommandCenter {
 			return;
 		}
 
-		const message = l10n.t('Are you sure you want to reset to \'{0}\'?\n\nThis is IRREVERSIBLE!\nYour current working set will be FOREVER LOST if you proceed.', historyItem.id.substring(0, 8));
+		const message = l10n.t("Are you sure you want to reset to '{0}'?\n\nThis action cannot be undone.\nYour current working set will be lost if you proceed.", historyItem.id.substring(0, 8));
 		const yes = l10n.t('Reset');
 
 		const pick = await window.showWarningMessage(message, { modal: true }, yes);

--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -2141,11 +2141,8 @@ export class Repository {
 		}
 	}
 
-	async revertCommit(commitHash: string, noEdit: boolean = false): Promise<void> {
-		const args = ['revert', commitHash];
-		if (noEdit) {
-			args.push('--no-edit');
-		}
+	async revertCommit(commitHash: string): Promise<void> {
+		const args = ['revert', '--no-edit', commitHash];
 		await this.exec(args);
 	}
 

--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -2141,6 +2141,14 @@ export class Repository {
 		}
 	}
 
+	async revertCommit(commitHash: string, noEdit: boolean = false): Promise<void> {
+		const args = ['revert', commitHash];
+		if (noEdit) {
+			args.push('--no-edit');
+		}
+		await this.exec(args);
+	}
+
 	async addRemote(name: string, url: string): Promise<void> {
 		const args = ['remote', 'add', name, url];
 		await this.exec(args);

--- a/extensions/git/src/operation.ts
+++ b/extensions/git/src/operation.ts
@@ -49,6 +49,7 @@ export const enum OperationKind {
 	RenameBranch = 'RenameBranch',
 	Remove = 'Remove',
 	Reset = 'Reset',
+	Revert = 'Revert',
 	Rebase = 'Rebase',
 	RebaseAbort = 'RebaseAbort',
 	RebaseContinue = 'RebaseContinue',
@@ -73,7 +74,7 @@ export type Operation = AddOperation | ApplyOperation | BlameOperation | BranchO
 	GetBranchOperation | GetBranchesOperation | GetCommitTemplateOperation | GetObjectDetailsOperation | GetObjectFilesOperation | GetRefsOperation | GetWorktreesOperation |
 	GetRemoteRefsOperation | HashObjectOperation | IgnoreOperation | LogOperation | LogFileOperation | MergeOperation | MergeAbortOperation |
 	MergeBaseOperation | MoveOperation | PostCommitCommandOperation | PullOperation | PushOperation | RemoteOperation | RenameBranchOperation |
-	RemoveOperation | ResetOperation | RebaseOperation | RebaseAbortOperation | RebaseContinueOperation | RefreshOperation | RevertFilesOperation |
+	RemoveOperation | ResetOperation | RevertOperation | RebaseOperation | RebaseAbortOperation | RebaseContinueOperation | RefreshOperation | RevertFilesOperation |
 	RevListOperation | RevParseOperation | SetBranchUpstreamOperation | ShowOperation | StageOperation | StatusOperation | StashOperation |
 	SubmoduleUpdateOperation | SyncOperation | TagOperation | WorktreeOperation;
 
@@ -120,6 +121,7 @@ export type RemoteOperation = BaseOperation & { kind: OperationKind.Remote };
 export type RenameBranchOperation = BaseOperation & { kind: OperationKind.RenameBranch };
 export type RemoveOperation = BaseOperation & { kind: OperationKind.Remove };
 export type ResetOperation = BaseOperation & { kind: OperationKind.Reset };
+export type RevertOperation = BaseOperation & { kind: OperationKind.Revert };
 export type RebaseOperation = BaseOperation & { kind: OperationKind.Rebase };
 export type RebaseAbortOperation = BaseOperation & { kind: OperationKind.RebaseAbort };
 export type RebaseContinueOperation = BaseOperation & { kind: OperationKind.RebaseContinue };
@@ -180,6 +182,7 @@ export const Operation = {
 	RenameBranch: { kind: OperationKind.RenameBranch, blocking: false, readOnly: false, remote: false, retry: false, showProgress: true } as RenameBranchOperation,
 	Remove: { kind: OperationKind.Remove, blocking: false, readOnly: false, remote: false, retry: false, showProgress: true } as RemoveOperation,
 	Reset: { kind: OperationKind.Reset, blocking: false, readOnly: false, remote: false, retry: false, showProgress: true } as ResetOperation,
+	Revert: { kind: OperationKind.Revert, blocking: false, readOnly: false, remote: false, retry: false, showProgress: true } as RevertOperation,
 	Rebase: { kind: OperationKind.Rebase, blocking: false, readOnly: false, remote: false, retry: false, showProgress: true } as RebaseOperation,
 	RebaseAbort: { kind: OperationKind.RebaseAbort, blocking: false, readOnly: false, remote: false, retry: false, showProgress: true } as RebaseAbortOperation,
 	RebaseContinue: { kind: OperationKind.RebaseContinue, blocking: false, readOnly: false, remote: false, retry: false, showProgress: true } as RebaseContinueOperation,

--- a/extensions/git/src/repository.ts
+++ b/extensions/git/src/repository.ts
@@ -1625,6 +1625,10 @@ export class Repository implements Disposable {
 		await this.run(Operation.CherryPick, () => this.repository.cherryPickAbort());
 	}
 
+	async revertCommit(commitHash: string, noEdit: boolean = false): Promise<void> {
+		await this.run(Operation.Revert, () => this.repository.revertCommit(commitHash, noEdit));
+	}
+
 	async move(from: string, to: string): Promise<void> {
 		await this.run(Operation.Move, () => this.repository.move(from, to));
 	}

--- a/extensions/git/src/repository.ts
+++ b/extensions/git/src/repository.ts
@@ -1625,8 +1625,8 @@ export class Repository implements Disposable {
 		await this.run(Operation.CherryPick, () => this.repository.cherryPickAbort());
 	}
 
-	async revertCommit(commitHash: string, noEdit: boolean = false): Promise<void> {
-		await this.run(Operation.Revert, () => this.repository.revertCommit(commitHash, noEdit));
+	async revertCommit(commitHash: string): Promise<void> {
+		await this.run(Operation.Revert, () => this.repository.revertCommit(commitHash));
 	}
 
 	async move(from: string, to: string): Promise<void> {


### PR DESCRIPTION
adds `Revert Commit` and `Reset Commit` to SCM graph view - part of #217987

- Introduced `git.graph.revertCommit` and `git.graph.resetCommit` commands
- Implemented functionality for reverting commits.


https://github.com/user-attachments/assets/123d2ae0-c1c9-4f48-9141-5df753d3ccac


<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
