### PR TITLE
Update todo progress messages to show title first with position

### DIFF
--- a/src/vs/workbench/contrib/chat/common/tools/manageTodoListTool.ts
+++ b/src/vs/workbench/contrib/chat/common/tools/manageTodoListTool.ts
@@ -227,7 +227,7 @@ export class ManageTodoListTool extends Disposable implements IToolImpl {
 			const startedTodo = startedTodos[0]; // Should only be one in-progress at a time
 			const totalTodos = newTodos.length;
 			const currentPosition = newTodos.findIndex(todo => todo.id === startedTodo.id) + 1;
-			return localize('todo.starting', "Starting ({0}/{1}) *{2}*", currentPosition, totalTodos, startedTodo.title);
+			return localize('todo.starting', "Starting: *{0}* ({1}/{2})", startedTodo.title, currentPosition, totalTodos);
 		}
 
 		// Check for newly completed todos
@@ -240,7 +240,7 @@ export class ManageTodoListTool extends Disposable implements IToolImpl {
 			const completedTodo = completedTodos[0]; // Get the first completed todo for the message
 			const totalTodos = newTodos.length;
 			const currentPosition = newTodos.findIndex(todo => todo.id === completedTodo.id) + 1;
-			return localize('todo.completed', "Completed ({0}/{1}) *{2}*", currentPosition, totalTodos, completedTodo.title);
+			return localize('todo.completed', "Completed: *{0}* ({1}/{2})", completedTodo.title, currentPosition, totalTodos);
 		}
 
 		// Check for new todos added


### PR DESCRIPTION
Matches widget progress style:
<img width="622" height="67" alt="image" src="https://github.com/user-attachments/assets/92603b13-9aab-4d2e-ab63-3a996bc1be94" />

Related: https://github.com/microsoft/vscode/pull/273368