### PR TITLE
add DnD for SCM history items into terminal, editor and external

### DIFF
--- a/src/vs/workbench/contrib/scm/browser/scmHistoryViewPane.ts
+++ b/src/vs/workbench/contrib/scm/browser/scmHistoryViewPane.ts
@@ -71,7 +71,7 @@ import { ITreeCompressionDelegate } from '../../../../base/browser/ui/tree/async
 import { ICompressibleKeyboardNavigationLabelProvider, ICompressibleTreeRenderer } from '../../../../base/browser/ui/tree/objectTree.js';
 import { ICompressedTreeNode } from '../../../../base/browser/ui/tree/compressedObjectTreeModel.js';
 import { ILabelService } from '../../../../platform/label/common/label.js';
-import { IDragAndDropData } from '../../../../base/browser/dnd.js';
+import { DataTransfers, IDragAndDropData } from '../../../../base/browser/dnd.js';
 import { ElementsDragAndDropData, ListViewTargetSector } from '../../../../base/browser/ui/list/listView.js';
 import { CodeDataTransfers } from '../../../../platform/dnd/browser/dnd.js';
 import { SCMHistoryItemTransferData } from './scmHistoryChatContext.js';
@@ -952,6 +952,8 @@ class SCMHistoryTreeDragAndDrop implements ITreeDragAndDrop<TreeElement> {
 		if (historyItems.length === 0) {
 			return;
 		}
+
+		originalEvent.dataTransfer.setData(DataTransfers.TEXT, historyItems.map(hi => hi.historyItem.id).join(' '));
 
 		originalEvent.dataTransfer.setData(CodeDataTransfers.SCM_HISTORY_ITEM, JSON.stringify(historyItems));
 	}

--- a/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
@@ -93,6 +93,7 @@ import type { IProgressState } from '@xterm/addon-progress';
 import { refreshShellIntegrationInfoStatus } from './terminalTooltip.js';
 import { generateUuid } from '../../../../base/common/uuid.js';
 import { PromptInputState } from '../../../../platform/terminal/common/capabilities/commandDetection/promptInputModel.js';
+import { extractSCMHistoryItemDropData, SCMHistoryItemTransferData } from '../../scm/browser/scmHistoryChatContext.js';
 
 const enum Constants {
 	/**
@@ -1203,6 +1204,10 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 		store.add(dndController.onDropFile(async path => {
 			this.focus();
 			await this.sendPath(path, false);
+		}));
+		store.add(dndController.onDropSCMHistoryItem(commitHash => {
+			this.focus();
+			this.sendText(commitHash.historyItem.id, false);
 		}));
 		store.add(new dom.DragAndDropObserver(container, dndController));
 		this._dndObserver.value = store;
@@ -2428,6 +2433,8 @@ class TerminalInstanceDragAndDropController extends Disposable implements dom.ID
 	get onDropFile(): Event<string | URI> { return this._onDropFile.event; }
 	private readonly _onDropTerminal = this._register(new Emitter<IRequestAddInstanceToGroupEvent>());
 	get onDropTerminal(): Event<IRequestAddInstanceToGroupEvent> { return this._onDropTerminal.event; }
+	private readonly _onDropSCMHistoryItem = this._register(new Emitter<SCMHistoryItemTransferData>());
+	get onDropSCMHistoryItem(): Event<SCMHistoryItemTransferData> { return this._onDropSCMHistoryItem.event; }
 
 	constructor(
 		private readonly _container: HTMLElement,
@@ -2444,7 +2451,7 @@ class TerminalInstanceDragAndDropController extends Disposable implements dom.ID
 	}
 
 	onDragEnter(e: DragEvent) {
-		if (!containsDragType(e, DataTransfers.FILES, DataTransfers.RESOURCES, TerminalDataTransfers.Terminals, CodeDataTransfers.FILES)) {
+		if (!containsDragType(e, DataTransfers.FILES, DataTransfers.RESOURCES, TerminalDataTransfers.Terminals, CodeDataTransfers.FILES, CodeDataTransfers.SCM_HISTORY_ITEM)) {
 			return;
 		}
 
@@ -2518,6 +2525,12 @@ class TerminalInstanceDragAndDropController extends Disposable implements dom.ID
 		if (!path && e.dataTransfer.files.length > 0 && getPathForFile(e.dataTransfer.files[0])) {
 			// Check if the file was dragged from the filesystem
 			path = URI.file(getPathForFile(e.dataTransfer.files[0])!);
+		}
+
+		const commitHashes = extractSCMHistoryItemDropData(e);
+		if (!path && commitHashes?.length) {
+			this._onDropSCMHistoryItem.fire(commitHashes[0]);
+			return;
 		}
 
 		if (!path) {


### PR DESCRIPTION
enables SCM graph history item to be DnD into,
- terminal
- editor
- external apps

https://github.com/user-attachments/assets/39cf6b0e-5eb4-476a-85d3-93fef2ad4ca4

## Before
- we can't drop commits into terminal
- dropping into editor will paste internal URI
- can't drag outside of vscode

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
