### PR TITLE
Remove `JsonSchemaFromType`

### DIFF
--- a/src/vs/base/common/jsonSchema.ts
+++ b/src/vs/base/common/jsonSchema.ts
@@ -161,43 +161,6 @@ type MapSchemaToType<T> = T extends [infer First, ...infer Rest]
 	? TypeFromJsonSchema<First> | MapSchemaToType<Rest>
 	: never;
 
-/**
- * Converts a type into a JSON schema shape with basic typing.
- *
- * This enforces that the schema has the expected properties and types.
- *
- * Doesn't support all JSON schema features. Notably, doesn't support converting unions or intersections to `oneOf` or `anyOf`.
- */
-export type JsonSchemaFromType<T> =
-	// String
-	T extends string
-	? IJSONSchema & { type: 'string' }
-
-	// Number
-	: T extends number
-	? IJSONSchema & { type: 'number' | 'integer' }
-
-	// Boolean
-	: T extends boolean
-	? IJSONSchema & { type: 'boolean' }
-
-	// Any
-	// https://stackoverflow.com/questions/61624719/how-to-conditionally-detect-the-any-type-in-typescript
-	: 0 extends (1 & T)
-	? IJSONSchema
-
-	// Array
-	: T extends ReadonlyArray<infer U>
-	? IJSONSchema & { items: JsonSchemaFromType<U> }
-
-	// Record
-	: T extends Record<string, infer V>
-	? IJSONSchema & { additionalProperties: JsonSchemaFromType<V> }
-
-	// Object
-	: IJSONSchema & { properties: { [K in keyof T]: JsonSchemaFromType<T[K]> } };
-
-
 interface Equals { schemas: IJSONSchema[]; id?: string }
 
 export function getCompressedContent(schema: IJSONSchema): string {

--- a/src/vs/workbench/contrib/chat/browser/viewsWelcome/chatViewsWelcomeHandler.ts
+++ b/src/vs/workbench/contrib/chat/browser/viewsWelcome/chatViewsWelcomeHandler.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { MarkdownString } from '../../../../../base/common/htmlContent.js';
-import { JsonSchemaFromType } from '../../../../../base/common/jsonSchema.js';
+import { IJSONSchema, TypeFromJsonSchema } from '../../../../../base/common/jsonSchema.js';
 import { ThemeIcon } from '../../../../../base/common/themables.js';
 import { localize } from '../../../../../nls.js';
 import { ContextKeyExpr } from '../../../../../platform/contextkey/common/contextkey.js';
@@ -15,42 +15,40 @@ import { checkProposedApiEnabled } from '../../../../services/extensions/common/
 import * as extensionsRegistry from '../../../../services/extensions/common/extensionsRegistry.js';
 import { ChatViewsWelcomeExtensions, IChatViewsWelcomeContributionRegistry, IChatViewsWelcomeDescriptor } from './chatViewsWelcome.js';
 
-interface IRawChatViewsWelcomeContribution {
-	icon: string;
-	title: string;
-	content: string;
-	when: string;
-}
+
+const chatViewsWelcomeJsonSchema = {
+	type: 'object',
+	additionalProperties: false,
+	required: ['icon', 'title', 'contents', 'when'],
+	properties: {
+		icon: {
+			type: 'string',
+			description: localize('chatViewsWelcome.icon', 'The icon for the welcome message.'),
+		},
+		title: {
+			type: 'string',
+			description: localize('chatViewsWelcome.title', 'The title of the welcome message.'),
+		},
+		content: {
+			type: 'string',
+			description: localize('chatViewsWelcome.content', 'The content of the welcome message. The first command link will be rendered as a button.'),
+		},
+		when: {
+			type: 'string',
+			description: localize('chatViewsWelcome.when', 'Condition when the welcome message is shown.'),
+		}
+	}
+} as const satisfies IJSONSchema;
+
+type IRawChatViewsWelcomeContribution = TypeFromJsonSchema<typeof chatViewsWelcomeJsonSchema>;
 
 const chatViewsWelcomeExtensionPoint = extensionsRegistry.ExtensionsRegistry.registerExtensionPoint<IRawChatViewsWelcomeContribution[]>({
 	extensionPoint: 'chatViewsWelcome',
 	jsonSchema: {
 		description: localize('vscode.extension.contributes.chatViewsWelcome', 'Contributes a welcome message to a chat view'),
 		type: 'array',
-		items: {
-			additionalProperties: false,
-			type: 'object',
-			properties: {
-				icon: {
-					type: 'string',
-					description: localize('chatViewsWelcome.icon', 'The icon for the welcome message.'),
-				},
-				title: {
-					type: 'string',
-					description: localize('chatViewsWelcome.title', 'The title of the welcome message.'),
-				},
-				content: {
-					type: 'string',
-					description: localize('chatViewsWelcome.content', 'The content of the welcome message. The first command link will be rendered as a button.'),
-				},
-				when: {
-					type: 'string',
-					description: localize('chatViewsWelcome.when', 'Condition when the welcome message is shown.'),
-				}
-			}
-		},
-		required: ['icon', 'title', 'contents', 'when'],
-	} satisfies JsonSchemaFromType<IRawChatViewsWelcomeContribution[]>,
+		items: chatViewsWelcomeJsonSchema,
+	},
 });
 
 export class ChatViewsWelcomeHandler implements IWorkbenchContribution {

--- a/src/vs/workbench/contrib/chat/common/languageModels.ts
+++ b/src/vs/workbench/contrib/chat/common/languageModels.ts
@@ -8,7 +8,7 @@ import { VSBuffer } from '../../../../base/common/buffer.js';
 import { CancellationToken } from '../../../../base/common/cancellation.js';
 import { Emitter, Event } from '../../../../base/common/event.js';
 import { Iterable } from '../../../../base/common/iterator.js';
-import { JsonSchemaFromType } from '../../../../base/common/jsonSchema.js';
+import { IJSONSchema, TypeFromJsonSchema } from '../../../../base/common/jsonSchema.js';
 import { DisposableStore, IDisposable, toDisposable } from '../../../../base/common/lifecycle.js';
 import { isFalsyOrWhitespace } from '../../../../base/common/strings.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
@@ -265,8 +265,9 @@ export interface ILanguageModelsService {
 	computeTokenLength(modelId: string, message: string | IChatMessage, token: CancellationToken): Promise<number>;
 }
 
-const languageModelChatProviderType: JsonSchemaFromType<IUserFriendlyLanguageModel> = {
+const languageModelChatProviderType = {
 	type: 'object',
+	required: ['vendor', 'displayName'],
 	properties: {
 		vendor: {
 			type: 'string',
@@ -285,14 +286,9 @@ const languageModelChatProviderType: JsonSchemaFromType<IUserFriendlyLanguageMod
 			description: localize('vscode.extension.contributes.languageModels.when', "Condition which must be true to show this language model chat provider in the Manage Models list.")
 		}
 	}
-};
+} as const satisfies IJSONSchema;
 
-export interface IUserFriendlyLanguageModel {
-	vendor: string;
-	displayName: string;
-	managementCommand?: string;
-	when?: string;
-}
+export type IUserFriendlyLanguageModel = TypeFromJsonSchema<typeof languageModelChatProviderType>;
 
 export const languageModelChatProviderExtensionPoint = ExtensionsRegistry.registerExtensionPoint<IUserFriendlyLanguageModel | IUserFriendlyLanguageModel[]>({
 	extensionPoint: 'languageModelChatProviders',

--- a/src/vs/workbench/services/keybinding/browser/keybindingService.ts
+++ b/src/vs/workbench/services/keybinding/browser/keybindingService.ts
@@ -14,7 +14,7 @@ import { mainWindow } from '../../../../base/browser/window.js';
 import { DeferredPromise, RunOnceScheduler } from '../../../../base/common/async.js';
 import { Emitter, Event } from '../../../../base/common/event.js';
 import { parse } from '../../../../base/common/json.js';
-import { IJSONSchema, JsonSchemaFromType } from '../../../../base/common/jsonSchema.js';
+import { IJSONSchema, TypeFromJsonSchema } from '../../../../base/common/jsonSchema.js';
 import { UserSettingsLabelProvider } from '../../../../base/common/keybindingLabels.js';
 import { KeybindingParser } from '../../../../base/common/keybindingParser.js';
 import { Keybinding, KeyCodeChord, ResolvedKeybinding, ScanCodeChord } from '../../../../base/common/keybindings.js';
@@ -57,16 +57,6 @@ import { IUserKeybindingItem, KeybindingIO, OutputBuilder } from '../common/keyb
 import { IKeyboard, INavigatorWithKeyboard } from './navigatorKeyboard.js';
 import { getAllUnboundCommands } from './unboundCommands.js';
 
-interface ContributedKeyBinding {
-	command: string;
-	args?: any;
-	key: string;
-	when?: string;
-	mac?: string;
-	linux?: string;
-	win?: string;
-}
-
 function isValidContributedKeyBinding(keyBinding: ContributedKeyBinding, rejects: string[]): boolean {
 	if (!keyBinding) {
 		rejects.push(nls.localize('nonempty', "expected non-empty value."));
@@ -99,9 +89,10 @@ function isValidContributedKeyBinding(keyBinding: ContributedKeyBinding, rejects
 	return true;
 }
 
-const keybindingType: JsonSchemaFromType<ContributedKeyBinding> = {
+const keybindingType = {
 	type: 'object',
 	default: { command: '', key: '' },
+	required: ['command', 'key'],
 	properties: {
 		command: {
 			description: nls.localize('vscode.extension.contributes.keybindings.command', 'Identifier of the command to run when keybinding is triggered.'),
@@ -131,7 +122,9 @@ const keybindingType: JsonSchemaFromType<ContributedKeyBinding> = {
 			type: 'string'
 		},
 	}
-};
+} as const satisfies IJSONSchema;
+
+type ContributedKeyBinding = TypeFromJsonSchema<typeof keybindingType>;
 
 const keybindingsExtPoint = ExtensionsRegistry.registerExtensionPoint<ContributedKeyBinding | ContributedKeyBinding[]>({
 	extensionPoint: 'keybindings',


### PR DESCRIPTION
Fun experiment but it seems better to always do the reverse (schema -> type). We're much more limited in how well we can convert from a type to the schema

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
