### PR TITLE
Add extension unification feature

### DIFF
--- a/src/vs/workbench/api/common/extHostLanguageFeatures.ts
+++ b/src/vs/workbench/api/common/extHostLanguageFeatures.ts
@@ -2137,6 +2137,7 @@ export class ExtHostLanguageFeatures extends CoreDisposable implements extHostPr
 		this._inlineCompletionsUnificationState = {
 			codeUnification: false,
 			modelUnification: false,
+			extensionUnification: false,
 			expAssignments: []
 		};
 	}

--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -733,6 +733,15 @@ configurationRegistry.registerConfiguration({
 				mode: 'auto'
 			}
 		},
+		'copilot.extensionUnification.enabled': {
+			type: 'boolean',
+			description: nls.localize('copilot.extensionUnification.enabled', "Enables unification of GitHub Copilot extensions. When enabled, only the GitHub Copilot Chat extension will be active and all functionality will be served by it. When disabled, GitHub Copilot Chat and GitHub Copilot extensions will operate independently."),
+			default: false,
+			tags: ['experimental'],
+			experiment: {
+				mode: 'auto'
+			}
+		}
 	}
 });
 Registry.as<IEditorPaneRegistry>(EditorExtensions.EditorPane).registerEditorPane(

--- a/src/vs/workbench/services/assignment/common/assignmentService.ts
+++ b/src/vs/workbench/services/assignment/common/assignmentService.ts
@@ -23,12 +23,18 @@ import { importAMDNodeModule } from '../../../../amdX.js';
 import { timeout } from '../../../../base/common/async.js';
 import { CopilotAssignmentFilterProvider } from './assignmentFilters.js';
 import { Disposable, DisposableStore } from '../../../../base/common/lifecycle.js';
-import { Emitter } from '../../../../base/common/event.js';
+import { Emitter, Event } from '../../../../base/common/event.js';
+
+export interface IAssignmentFilter {
+	exclude(assignment: string): boolean;
+	onDidChange: Event<void>;
+}
 
 export const IWorkbenchAssignmentService = createDecorator<IWorkbenchAssignmentService>('assignmentService');
 
 export interface IWorkbenchAssignmentService extends IAssignmentService {
 	getCurrentExperiments(): Promise<string[] | undefined>;
+	addTelemetryAssignmentFilter(filter: IAssignmentFilter): void;
 }
 
 class MementoKeyValueStorage implements IKeyValueStorage {
@@ -56,10 +62,14 @@ class WorkbenchAssignmentServiceTelemetry extends Disposable implements IExperim
 	private readonly _onDidUpdateAssignmentContext = this._register(new Emitter<void>());
 	readonly onDidUpdateAssignmentContext = this._onDidUpdateAssignmentContext.event;
 
+	private _previousAssignmentContext: string | undefined;
 	private _lastAssignmentContext: string | undefined;
 	get assignmentContext(): string[] | undefined {
 		return this._lastAssignmentContext?.split(';');
 	}
+
+	private _assignmentFilters: IAssignmentFilter[] = [];
+	private _assignmentFilterDisposables = this._register(new DisposableStore());
 
 	constructor(
 		private readonly telemetryService: ITelemetryService,
@@ -68,11 +78,48 @@ class WorkbenchAssignmentServiceTelemetry extends Disposable implements IExperim
 		super();
 	}
 
+	private _filterAssignmentContext(assignmentContext: string): string {
+		const assignments = assignmentContext.split(';');
+
+		const filteredAssignments = assignments.filter(assignment => {
+			for (const filter of this._assignmentFilters) {
+				if (filter.exclude(assignment)) {
+					return false;
+				}
+			}
+			return true;
+		});
+
+		return filteredAssignments.join(';');
+	}
+
+	private _setAssignmentContext(value: string): void {
+		value = this._filterAssignmentContext(value);
+		this._lastAssignmentContext = value;
+		this._onDidUpdateAssignmentContext.fire();
+
+		if (this.productService.tasConfig?.assignmentContextTelemetryPropertyName) {
+			this.telemetryService.setExperimentProperty(this.productService.tasConfig.assignmentContextTelemetryPropertyName, value);
+		}
+	}
+
+	addAssignmentFilter(filter: IAssignmentFilter): void {
+		this._assignmentFilters.push(filter);
+		this._assignmentFilterDisposables.add(filter.onDidChange(() => {
+			if (this._previousAssignmentContext) {
+				this._setAssignmentContext(this._previousAssignmentContext);
+			}
+		}));
+		if (this._previousAssignmentContext) {
+			this._setAssignmentContext(this._previousAssignmentContext);
+		}
+	}
+
 	// __GDPR__COMMON__ "abexp.assignmentcontext" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" }
 	setSharedProperty(name: string, value: string): void {
 		if (name === this.productService.tasConfig?.assignmentContextTelemetryPropertyName) {
-			this._lastAssignmentContext = value;
-			this._onDidUpdateAssignmentContext.fire();
+			this._previousAssignmentContext = value;
+			return this._setAssignmentContext(value);
 		}
 
 		this.telemetryService.setExperimentProperty(name, value);
@@ -264,6 +311,10 @@ export class WorkbenchAssignmentService extends Disposable implements IAssignmen
 		await this.tasClient;
 
 		return this.telemetry.assignmentContext;
+	}
+
+	addTelemetryAssignmentFilter(filter: IAssignmentFilter): void {
+		this.telemetry.addAssignmentFilter(filter);
 	}
 }
 

--- a/src/vs/workbench/services/assignment/common/assignmentService.ts
+++ b/src/vs/workbench/services/assignment/common/assignmentService.ts
@@ -94,12 +94,12 @@ class WorkbenchAssignmentServiceTelemetry extends Disposable implements IExperim
 	}
 
 	private _setAssignmentContext(value: string): void {
-		value = this._filterAssignmentContext(value);
-		this._lastAssignmentContext = value;
+		const filteredValue = this._filterAssignmentContext(value);
+		this._lastAssignmentContext = filteredValue;
 		this._onDidUpdateAssignmentContext.fire();
 
 		if (this.productService.tasConfig?.assignmentContextTelemetryPropertyName) {
-			this.telemetryService.setExperimentProperty(this.productService.tasConfig.assignmentContextTelemetryPropertyName, value);
+			this.telemetryService.setExperimentProperty(this.productService.tasConfig.assignmentContextTelemetryPropertyName, filteredValue);
 		}
 	}
 

--- a/src/vs/workbench/services/assignment/test/common/nullAssignmentService.ts
+++ b/src/vs/workbench/services/assignment/test/common/nullAssignmentService.ts
@@ -4,13 +4,12 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Event } from '../../../../../base/common/event.js';
-import { IWorkbenchAssignmentService } from '../../common/assignmentService.js';
+import { IAssignmentFilter, IWorkbenchAssignmentService } from '../../common/assignmentService.js';
 
 export class NullWorkbenchAssignmentService implements IWorkbenchAssignmentService {
 	_serviceBrand: undefined;
 
 	readonly onDidRefetchAssignments: Event<void> = Event.None;
-
 
 	async getCurrentExperiments(): Promise<string[] | undefined> {
 		return [];
@@ -19,4 +18,6 @@ export class NullWorkbenchAssignmentService implements IWorkbenchAssignmentServi
 	async getTreatment<T extends string | number | boolean>(name: string): Promise<T | undefined> {
 		return undefined;
 	}
+
+	addTelemetryAssignmentFilter(filter: IAssignmentFilter): void { }
 }

--- a/src/vs/workbench/services/inlineCompletions/common/inlineCompletionsUnification.ts
+++ b/src/vs/workbench/services/inlineCompletions/common/inlineCompletionsUnification.ts
@@ -6,6 +6,7 @@
 import { equals } from '../../../../base/common/arrays.js';
 import { Event, Emitter } from '../../../../base/common/event.js';
 import { Disposable } from '../../../../base/common/lifecycle.js';
+import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { IContextKeyService, RawContextKey } from '../../../../platform/contextkey/common/contextkey.js';
 import { InstantiationType, registerSingleton } from '../../../../platform/instantiation/common/extensions.js';
 import { createDecorator } from '../../../../platform/instantiation/common/instantiation.js';
@@ -16,6 +17,7 @@ export const IInlineCompletionsUnificationService = createDecorator<IInlineCompl
 export interface IInlineCompletionsUnificationState {
 	codeUnification: boolean;
 	modelUnification: boolean;
+	extensionUnification: boolean;
 	expAssignments: string[];
 }
 
@@ -27,15 +29,18 @@ export interface IInlineCompletionsUnificationService {
 }
 
 const CODE_UNIFICATION_PREFIX = 'cmp-cht-';
+const EXTENSION_UNIFICATION_PREFIX = 'cmp-ext-';
 const CODE_UNIFICATION_FF = 'inlineCompletionsUnificationCode';
 const MODEL_UNIFICATION_FF = 'inlineCompletionsUnificationModel';
 
 export const isRunningUnificationExperiment = new RawContextKey<boolean>('isRunningUnificationExperiment', false);
 
+const ExtensionUnificationSetting = 'copilot.extensionUnification.enabled';
+
 export class InlineCompletionsUnificationImpl extends Disposable implements IInlineCompletionsUnificationService {
 	readonly _serviceBrand: undefined;
 
-	private _state = new InlineCompletionsUnificationState(false, false, []);
+	private _state = new InlineCompletionsUnificationState(false, false, false, []);
 	public get state(): IInlineCompletionsUnificationState { return this._state; }
 
 	private isRunningUnificationExperiment;
@@ -43,34 +48,58 @@ export class InlineCompletionsUnificationImpl extends Disposable implements IInl
 	private readonly _onDidStateChange = this._register(new Emitter<void>());
 	public readonly onDidStateChange = this._onDidStateChange.event;
 
+	private readonly _onDidChangeExtensionUnification = this._register(new Emitter<void>());
+
 	constructor(
 		@IWorkbenchAssignmentService private readonly _assignmentService: IWorkbenchAssignmentService,
 		@IContextKeyService private readonly _contextKeyService: IContextKeyService,
+		@IConfigurationService private readonly _configurationService: IConfigurationService,
 	) {
 		super();
 		this.isRunningUnificationExperiment = isRunningUnificationExperiment.bindTo(this._contextKeyService);
+
+		this._assignmentService.addTelemetryAssignmentFilter({
+			exclude: (assignment) => !this._state.extensionUnification && assignment.startsWith(EXTENSION_UNIFICATION_PREFIX),
+			onDidChange: this._onDidChangeExtensionUnification.event
+		});
+
+		this._configurationService.onDidChangeConfiguration(e => {
+			if (e.affectsConfiguration(ExtensionUnificationSetting)) {
+				this._update();
+			}
+		});
 		this._register(this._assignmentService.onDidRefetchAssignments(() => this._update()));
 		this._update();
 	}
 
 	private async _update(): Promise<void> {
+		// TODO@benibenj@sandy081 extensionUnificationEnabled should depend on extension enablement state
+		const extensionUnificationEnabled = this._configurationService.getValue<boolean>(ExtensionUnificationSetting);
 		const [codeUnificationFF, modelUnificationFF] = await Promise.all([
 			this._assignmentService.getTreatment<boolean>(CODE_UNIFICATION_FF),
 			this._assignmentService.getTreatment<boolean>(MODEL_UNIFICATION_FF),
 		]);
+
 		// Intentionally read the current experiments after fetching the treatments
 		const currentExperiments = await this._assignmentService.getCurrentExperiments();
 		const newState = new InlineCompletionsUnificationState(
 			codeUnificationFF === true,
 			modelUnificationFF === true,
-			currentExperiments?.filter(exp => exp.startsWith(CODE_UNIFICATION_PREFIX)) ?? []
+			extensionUnificationEnabled,
+			currentExperiments?.filter(exp => exp.startsWith(CODE_UNIFICATION_PREFIX) || (extensionUnificationEnabled && exp.startsWith(EXTENSION_UNIFICATION_PREFIX))) ?? []
 		);
 		if (this._state.equals(newState)) {
 			return;
 		}
+
+		const previousState = this._state;
 		this._state = newState;
-		this.isRunningUnificationExperiment.set(this._state.codeUnification || this._state.modelUnification);
+		this.isRunningUnificationExperiment.set(this._state.codeUnification || this._state.modelUnification || this._state.extensionUnification);
 		this._onDidStateChange.fire();
+
+		if (previousState.extensionUnification !== this._state.extensionUnification) {
+			this._onDidChangeExtensionUnification.fire();
+		}
 	}
 }
 
@@ -78,6 +107,7 @@ class InlineCompletionsUnificationState implements IInlineCompletionsUnification
 	constructor(
 		public readonly codeUnification: boolean,
 		public readonly modelUnification: boolean,
+		public readonly extensionUnification: boolean,
 		public readonly expAssignments: string[]
 	) {
 	}
@@ -85,6 +115,7 @@ class InlineCompletionsUnificationState implements IInlineCompletionsUnification
 	equals(other: IInlineCompletionsUnificationState): boolean {
 		return this.codeUnification === other.codeUnification
 			&& this.modelUnification === other.modelUnification
+			&& this.extensionUnification === other.extensionUnification
 			&& equals(this.expAssignments, other.expAssignments);
 	}
 }

--- a/src/vscode-dts/vscode.proposed.inlineCompletionsAdditions.d.ts
+++ b/src/vscode-dts/vscode.proposed.inlineCompletionsAdditions.d.ts
@@ -225,6 +225,7 @@ declare module 'vscode' {
 	export interface InlineCompletionsUnificationState {
 		codeUnification: boolean;
 		modelUnification: boolean;
+		extensionUnification: boolean;
 		expAssignments: string[];
 	}
 }


### PR DESCRIPTION
```Copilot Generated Description:``` Introduce a new configuration option for enabling unification of GitHub Copilot extensions, along with related state management and telemetry assignment filters. This includes updates to the inline completions unification service to accommodate the new extension unification state.

https://github.com/microsoft/vscode-internalbacklog/issues/6073