### PR TITLE
chore: bootstrap Spark repo with landing, CI, docs, and foundation

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,9 @@
+**Summary**
+What problem?
+
+**Proposed change**
+What's the smallest useful slice?
+
+**Checklist**
+- [ ] Scope is minimal
+- [ ] Tests or acceptance criteria exist

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,11 @@
-<!-- Thank you for submitting a Pull Request. Please:
-* Read our Pull Request guidelines:
-  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
-* Associate an issue with the Pull Request.
-* Ensure that the code is up-to-date with the `main` branch.
-* Include a description of the proposed changes and how to test them.
--->
+## Summary
+What changed and why?
+
+## Checklist
+- [ ] Small, single-purpose PR
+- [ ] CI green (typecheck/build)
+- [ ] Linked issue or clear rationale
+
+---
+
+<!-- For VS Code fork changes, see: https://github.com/microsoft/vscode/wiki/How-to-Contribute -->

--- a/.github/workflows/spark-ci.yml
+++ b/.github/workflows/spark-ci.yml
@@ -1,0 +1,33 @@
+name: spark-ci
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'apps/**'
+      - 'packages/**'
+      - 'docs/**'
+      - '.github/workflows/spark-ci.yml'
+
+jobs:
+  landing:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      
+      - uses: actions/setup-node@v4
+        with: 
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: 'apps/www/package-lock.json'
+      
+      - name: Install dependencies
+        working-directory: apps/www
+        run: npm ci || npm install
+      
+      - name: Type check
+        working-directory: apps/www
+        run: npx tsc --noEmit
+      
+      - name: Build
+        working-directory: apps/www
+        run: npm run build

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,12 @@ product.overrides.json
 *.tsbuildinfo
 .vscode-test
 vscode-telemetry-docs/
+
+# Spark-specific
+.env
+.env.*
+!.env.example
+apps/www/.next
+apps/www/out
+apps/www/.data
+*.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+# Changelog
+## 0.0.1
+- Bootstrap repo, CI, docs, minimal landing.

--- a/DOMAIN_OPTIONS.md
+++ b/DOMAIN_OPTIONS.md
@@ -1,0 +1,21 @@
+# Domain Options
+Candidates: usespark.dev, joinspark.dev, tryspark.dev, sparkbuild.dev, sparkship.dev, spark.tools, spark.codes, spark.run, spark.sh, spark.systems
+
+## Rubric (0–5 each)
+- Clarity
+- Recall
+- Typeability
+- .dev HSTS / Security
+- Availability / Price
+- Resale risk
+
+Check availability manually. Pick top composite score ≥ 24/35.
+
+## Initial Assessment
+Based on external checks:
+- **spark.systems**: No content (likely parked or available)
+- **spark.codes**: Active site (web widgets)
+- **spark.run**: Active generic site
+- **spark.tools**: Active site (IGExport Instagram tools)
+
+Likely available: usespark.dev, joinspark.dev, tryspark.dev, sparkbuild.dev, sparkship.dev, spark.sh, spark.systems

--- a/README.md
+++ b/README.md
@@ -1,75 +1,77 @@
-# Visual Studio Code - Open Source ("Code - OSS")
-[![Feature Requests](https://img.shields.io/github/issues/microsoft/vscode/feature-request.svg)](https://github.com/microsoft/vscode/issues?q=is%3Aopen+is%3Aissue+label%3Afeature-request+sort%3Areactions-%2B1-desc)
-[![Bugs](https://img.shields.io/github/issues/microsoft/vscode/bug.svg)](https://github.com/microsoft/vscode/issues?utf8=✓&q=is%3Aissue+is%3Aopen+label%3Abug)
-[![Gitter](https://img.shields.io/badge/chat-on%20gitter-yellow.svg)](https://gitter.im/Microsoft/vscode)
+# Spark
+AI-native developer workspace that plans, edits, tests, and ships code — with guardrails.
 
-## The Repository
+**Built on VS Code** | [Roadmap](ROADMAP.md) | [Architecture](docs/ARCHITECTURE.md) | [Security](SECURITY.md)
 
-This repository ("`Code - OSS`") is where we (Microsoft) develop the [Visual Studio Code](https://code.visualstudio.com) product together with the community. Not only do we work on code and issues here, we also publish our [roadmap](https://github.com/microsoft/vscode/wiki/Roadmap), [monthly iteration plans](https://github.com/microsoft/vscode/wiki/Iteration-Plans), and our [endgame plans](https://github.com/microsoft/vscode/wiki/Running-the-Endgame). This source code is available to everyone under the standard [MIT license](https://github.com/microsoft/vscode/blob/main/LICENSE.txt).
+## What is Spark?
 
-## Visual Studio Code
+Spark is a VS Code fork enhanced with an AI-native workflow engine (SparkCore) that understands your intent, breaks down tasks, generates code and tests, and helps you ship faster — all while keeping your code local-first by default.
 
-<p align="center">
-  <img alt="VS Code in action" src="https://user-images.githubusercontent.com/35271042/118224532-3842c400-b438-11eb-923d-a5f66fa6785a.png">
-</p>
+### North-Star Metric
+**Shipped Value Rate (SVR)**: AI-assisted merges per active developer per week.
 
-[Visual Studio Code](https://code.visualstudio.com) is a distribution of the `Code - OSS` repository with Microsoft-specific customizations released under a traditional [Microsoft product license](https://code.visualstudio.com/License/).
+### Activation Target
+First plan → diff → tests → PR in ≤20 minutes.
 
-[Visual Studio Code](https://code.visualstudio.com) combines the simplicity of a code editor with what developers need for their core edit-build-debug cycle. It provides comprehensive code editing, navigation, and understanding support along with lightweight debugging, a rich extensibility model, and lightweight integration with existing tools.
+## Quickstart
 
-Visual Studio Code is updated monthly with new features and bug fixes. You can download it for Windows, macOS, and Linux on [Visual Studio Code's website](https://code.visualstudio.com/Download). To get the latest releases every day, install the [Insiders build](https://code.visualstudio.com/insiders).
+### Editor (VS Code fork)
+Follow the existing [VS Code build instructions](CONTRIBUTING.md) to build the editor.
+
+### Landing page
+```bash
+cd apps/www
+npm install
+npm run dev
+```
+
+Visit `http://localhost:3000`
+
+## Repository Structure
+
+```
+Spark/
+├── apps/www/           # Minimal landing page (Next.js)
+├── packages/config/    # Shared configs (ESLint, Prettier, TSConfig)
+├── docs/               # Architecture, ADRs, guides
+├── src/                # VS Code fork source
+├── extensions/         # VS Code extensions + Spark extensions
+└── scripts/            # Build and utility scripts
+```
 
 ## Contributing
 
-There are many ways in which you can participate in this project, for example:
+### Branch Conventions
+- `feat/<scope>-<slug>` for new features
+- `fix/<slug>` for bug fixes  
+- `chore/<slug>` for infrastructure/tooling
 
-* [Submit bugs and feature requests](https://github.com/microsoft/vscode/issues), and help us verify as they are checked in
-* Review [source code changes](https://github.com/microsoft/vscode/pulls)
-* Review the [documentation](https://github.com/microsoft/vscode-docs) and make pull requests for anything from typos to additional and new content
+### Commit Conventions
+Use [Conventional Commits](https://www.conventionalcommits.org/):
+- `feat:` new capability
+- `fix:` bug fix
+- `chore:` tooling, dependencies, refactor
+- `docs:` documentation only
 
-If you are interested in fixing issues and contributing directly to the code base,
-please see the document [How to Contribute](https://github.com/microsoft/vscode/wiki/How-to-Contribute), which covers the following:
+### Pull Requests
+- Small, single-purpose PRs
+- CI must pass (lint, typecheck, test, build)
+- PRs required to merge to `main`
 
-* [How to build and run from source](https://github.com/microsoft/vscode/wiki/How-to-Contribute)
-* [The development workflow, including debugging and running tests](https://github.com/microsoft/vscode/wiki/How-to-Contribute#debugging)
-* [Coding guidelines](https://github.com/microsoft/vscode/wiki/Coding-Guidelines)
-* [Submitting pull requests](https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests)
-* [Finding an issue to work on](https://github.com/microsoft/vscode/wiki/How-to-Contribute#where-to-contribute)
-* [Contributing to translations](https://aka.ms/vscodeloc)
+See the existing [VS Code contribution guide](CONTRIBUTING.md) for editor-specific guidelines.
 
-## Feedback
+## Milestones
 
-* Ask a question on [Stack Overflow](https://stackoverflow.com/questions/tagged/vscode)
-* [Request a new feature](CONTRIBUTING.md)
-* Upvote [popular feature requests](https://github.com/microsoft/vscode/issues?q=is%3Aopen+is%3Aissue+label%3Afeature-request+sort%3Areactions-%2B1-desc)
-* [File an issue](https://github.com/microsoft/vscode/issues)
-* Connect with the extension author community on [GitHub Discussions](https://github.com/microsoft/vscode-discussions/discussions) or [Slack](https://aka.ms/vscode-dev-community)
-* Follow [@code](https://twitter.com/code) and let us know what you think!
+- **Q4 2025**: Repo Graph v1, chat+diff, TestGen; private alpha
+- **Q1 2026**: SparkPilot v1, local sandbox; Pro pricing
+- **Q2 2026**: Planner v2, Lens traces, rollbacks; 1.5k WAD, $10k MRR  
+- **Q3 2026**: Incorporation (3k WAD, $25k MRR, D30 ≥ 35%)
 
-See our [wiki](https://github.com/microsoft/vscode/wiki/Feedback-Channels) for a description of each of these channels and information on some other available community-driven channels.
+See [ROADMAP.md](ROADMAP.md) for details.
 
-## Related Projects
+## VS Code Foundation
 
-Many of the core components and extensions to VS Code live in their own repositories on GitHub. For example, the [node debug adapter](https://github.com/microsoft/vscode-node-debug) and the [mono debug adapter](https://github.com/microsoft/vscode-mono-debug) repositories are separate from each other. For a complete list, please visit the [Related Projects](https://github.com/microsoft/vscode/wiki/Related-Projects) page on our [wiki](https://github.com/microsoft/vscode/wiki).
-
-## Bundled Extensions
-
-VS Code includes a set of built-in extensions located in the [extensions](extensions) folder, including grammars and snippets for many languages. Extensions that provide rich language support (inline suggestions, Go to Definition) for a language have the suffix `language-features`. For example, the `json` extension provides coloring for `JSON` and the `json-language-features` extension provides rich language support for `JSON`.
-
-## Development Container
-
-This repository includes a Visual Studio Code Dev Containers / GitHub Codespaces development container.
-
-* For [Dev Containers](https://aka.ms/vscode-remote/download/containers), use the **Dev Containers: Clone Repository in Container Volume...** command which creates a Docker volume for better disk I/O on macOS and Windows.
-  * If you already have VS Code and Docker installed, you can also click [here](https://vscode.dev/redirect?url=vscode://ms-vscode-remote.remote-containers/cloneInVolume?url=https://github.com/microsoft/vscode) to get started. This will cause VS Code to automatically install the Dev Containers extension if needed, clone the source code into a container volume, and spin up a dev container for use.
-
-* For Codespaces, install the [GitHub Codespaces](https://marketplace.visualstudio.com/items?itemName=GitHub.codespaces) extension in VS Code, and use the **Codespaces: Create New Codespace** command.
-
-Docker / the Codespace should have at least **4 Cores and 6 GB of RAM (8 GB recommended)** to run a full build. See the [development container README](.devcontainer/README.md) for more information.
-
-## Code of Conduct
-
-This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
+Spark is built on the [VS Code OSS](https://github.com/microsoft/vscode) foundation. The core editor retains all VS Code capabilities, with SparkCore layered on top for AI-native workflows.
 
 ## License
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,8 @@
+# Spark Roadmap
+**North-Star:** Shipped Value Rate (AI-assisted merges/dev/week)
+**Activation:** first plan → diff → tests → PR in ≤20m
+
+- **Q4 2025**: Repo Graph v1, chat+diff, TestGen; private alpha
+- **Q1 2026**: SparkPilot v1, local sandbox; Pro pricing on
+- **Q2 2026**: Planner v2, Lens traces, rollbacks; 1.5k WAD, $10k MRR
+- **Q3 2026**: Incorporate (3k WAD, $25k MRR, D30 ≥ 35%, ≥1 enterprise pilot)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,14 +1,52 @@
-<!-- BEGIN MICROSOFT SECURITY.MD V1.0.0 BLOCK -->
+# Security Policy
 
-## Security
+## Principles
 
-Microsoft takes the security of our software products and services seriously, which
-includes all source code repositories in our GitHub organizations.
+1. **Local-first by default**: Code never leaves your device unless you explicitly opt in to cloud features.
+2. **No secrets logging**: Environment variables, API keys, and credentials are redacted from all logs and telemetry.
+3. **Explicit consent**: Cloud sync, telemetry, and model API usage require user opt-in.
+4. **Transparency**: All data flows documented; open-source allows audit.
+
+## Supported Versions
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 0.x.x   | :white_check_mark: |
+
+## Reporting a Vulnerability
 
 **Please do not report security vulnerabilities through public GitHub issues.**
 
-For security reporting information, locations, contact information, and policies,
-please review the latest guidance for Microsoft repositories at
-[https://aka.ms/SECURITY.md](https://aka.ms/SECURITY.md).
+Email: `security@<pending-domain>` (placeholder until domain finalized)
 
-<!-- END MICROSOFT SECURITY.MD BLOCK -->
+Include:
+- Description of the vulnerability
+- Steps to reproduce
+- Potential impact
+- Suggested fix (if any)
+
+We will acknowledge receipt within 48 hours and provide a timeline for resolution.
+
+## Data Handling
+
+### What stays local
+- All source code by default
+- File system access logs
+- Local git history
+- Diff previews
+- Test results
+
+### What requires opt-in
+- Cloud model API calls (OpenAI, Anthropic, etc.)
+- Anonymized usage telemetry
+- Cloud project sync
+- Shared contexts/snippets
+
+### Never collected
+- Secrets, API keys, environment variables
+- PII without explicit user action
+- Repository contents without cloud opt-in
+
+## VS Code Foundation
+
+Spark inherits the security practices of VS Code OSS. For VS Code-specific security info, see [Microsoft's Security Policy](https://aka.ms/SECURITY.md).

--- a/apps/www/.env.example
+++ b/apps/www/.env.example
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_CANONICAL_URL=http://localhost:3000

--- a/apps/www/app/api/subscribe/route.ts
+++ b/apps/www/app/api/subscribe/route.ts
@@ -1,0 +1,22 @@
+import { NextRequest, NextResponse } from "next/server";
+import { writeFile, mkdir } from "fs/promises";
+import { existsSync } from "fs";
+
+export async function POST(req: NextRequest) {
+  const data = await req.formData();
+  const email = String(data.get("email") || "").trim().toLowerCase();
+  
+  if (!email) {
+    return NextResponse.redirect(new URL("/", req.url));
+  }
+  
+  const dir = ".data";
+  if (!existsSync(dir)) {
+    await mkdir(dir);
+  }
+  
+  const line = `${new Date().toISOString()},${email}\n`;
+  await writeFile(`${dir}/subscribers.csv`, line, { flag: "a" });
+  
+  return NextResponse.redirect(new URL("/", req.url));
+}

--- a/apps/www/app/page.tsx
+++ b/apps/www/app/page.tsx
@@ -1,0 +1,47 @@
+export default function Home() {
+  return (
+    <main style={{maxWidth: 760, margin: "4rem auto", padding: "0 1rem", lineHeight: 1.6}}>
+      <h1 style={{fontSize: "2.5rem", marginBottom: "0.5rem"}}>Spark</h1>
+      <p style={{fontSize: "1.25rem", color: "#666", marginBottom: "2rem"}}>
+        AI-native workspace that plans, edits, tests, and ships code — with guardrails.
+      </p>
+      <form method="post" action="/api/subscribe" style={{marginTop: "2rem", display: "flex", gap: "0.5rem"}}>
+        <input 
+          name="email" 
+          type="email" 
+          placeholder="you@domain.com" 
+          required 
+          style={{
+            flex: 1, 
+            padding: "0.75rem", 
+            border: "1px solid #ddd", 
+            borderRadius: "4px",
+            fontSize: "1rem"
+          }}
+        />
+        <button 
+          type="submit"
+          style={{
+            padding: "0.75rem 1.5rem",
+            background: "#0070f3",
+            color: "white",
+            border: "none",
+            borderRadius: "4px",
+            fontSize: "1rem",
+            cursor: "pointer"
+          }}
+        >
+          Request access
+        </button>
+      </form>
+      <p style={{marginTop: "2rem", color: "#666"}}>
+        <a href="https://github.com/PlangoDev/Spark" style={{color: "#0070f3", textDecoration: "none"}}>GitHub</a>
+        {" • "}
+        <a href="/privacy" style={{color: "#0070f3", textDecoration: "none"}}>Privacy</a>
+      </p>
+      <div style={{marginTop: "3rem", padding: "1rem", background: "#f5f5f5", borderRadius: "4px", fontSize: "0.9rem"}}>
+        <strong>Local-first by default.</strong> Your code stays on your machine unless you opt in to cloud features.
+      </div>
+    </main>
+  );
+}

--- a/apps/www/app/privacy/page.tsx
+++ b/apps/www/app/privacy/page.tsx
@@ -1,0 +1,36 @@
+export default function Privacy() {
+  return (
+    <main style={{maxWidth: 760, margin: "4rem auto", padding: "0 1rem", lineHeight: 1.6}}>
+      <h1 style={{fontSize: "2.5rem", marginBottom: "1rem"}}>Privacy</h1>
+      <p style={{marginBottom: "1rem"}}>
+        Spark is <strong>local-first by default</strong>. Your code, files, and project data never leave your machine unless you explicitly opt in to cloud features.
+      </p>
+      
+      <h2 style={{fontSize: "1.5rem", marginTop: "2rem", marginBottom: "0.5rem"}}>What stays local</h2>
+      <ul style={{marginLeft: "1.5rem"}}>
+        <li>All source code and files</li>
+        <li>Git history and diffs</li>
+        <li>Test results</li>
+        <li>File system access logs</li>
+      </ul>
+      
+      <h2 style={{fontSize: "1.5rem", marginTop: "2rem", marginBottom: "0.5rem"}}>What requires opt-in</h2>
+      <ul style={{marginLeft: "1.5rem"}}>
+        <li>Cloud model API calls (OpenAI, Anthropic, etc.)</li>
+        <li>Anonymized usage telemetry</li>
+        <li>Cloud project sync</li>
+      </ul>
+      
+      <h2 style={{fontSize: "1.5rem", marginTop: "2rem", marginBottom: "0.5rem"}}>What we never collect</h2>
+      <ul style={{marginLeft: "1.5rem"}}>
+        <li>Secrets, API keys, or environment variables</li>
+        <li>Repository contents without explicit opt-in</li>
+        <li>Personally identifiable information (PII) without consent</li>
+      </ul>
+      
+      <p style={{marginTop: "2rem"}}>
+        <a href="/" style={{color: "#0070f3", textDecoration: "none"}}>← Back to home</a>
+      </p>
+    </main>
+  );
+}

--- a/apps/www/next.config.js
+++ b/apps/www/next.config.js
@@ -1,0 +1,3 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = { reactStrictMode: true };
+export default nextConfig;

--- a/apps/www/package-lock.json
+++ b/apps/www/package-lock.json
@@ -1,0 +1,482 @@
+{
+  "name": "@spark/www",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@spark/www",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "next": "^14.2.33",
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1"
+      },
+      "devDependencies": {
+        "@types/node": "^24.9.1",
+        "@types/react": "^19.2.2",
+        "typescript": "^5.9.3"
+      }
+    },
+    "node_modules/@next/env": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.33.tgz",
+      "integrity": "sha512-CgVHNZ1fRIlxkLhIX22flAZI/HmpDaZ8vwyJ/B0SDPTBuLZ1PJ+DWMjCHhqnExfmSQzA/PbZi8OAc7PAq2w9IA==",
+      "license": "MIT"
+    },
+    "node_modules/@next/swc-darwin-arm64": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.33.tgz",
+      "integrity": "sha512-HqYnb6pxlsshoSTubdXKu15g3iivcbsMXg4bYpjL2iS/V6aQot+iyF4BUc2qA/J/n55YtvE4PHMKWBKGCF/+wA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.33.tgz",
+      "integrity": "sha512-8HGBeAE5rX3jzKvF593XTTFg3gxeU4f+UWnswa6JPhzaR6+zblO5+fjltJWIZc4aUalqTclvN2QtTC37LxvZAA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.33.tgz",
+      "integrity": "sha512-JXMBka6lNNmqbkvcTtaX8Gu5by9547bukHQvPoLe9VRBx1gHwzf5tdt4AaezW85HAB3pikcvyqBToRTDA4DeLw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.33.tgz",
+      "integrity": "sha512-Bm+QulsAItD/x6Ih8wGIMfRJy4G73tu1HJsrccPW6AfqdZd0Sfm5Imhgkgq2+kly065rYMnCOxTBvmvFY1BKfg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.33.tgz",
+      "integrity": "sha512-FnFn+ZBgsVMbGDsTqo8zsnRzydvsGV8vfiWwUo1LD8FTmPTdV+otGSWKc4LJec0oSexFnCYVO4hX8P8qQKaSlg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.33.tgz",
+      "integrity": "sha512-345tsIWMzoXaQndUTDv1qypDRiebFxGYx9pYkhwY4hBRaOLt8UGfiWKr9FSSHs25dFIf8ZqIFaPdy5MljdoawA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.33.tgz",
+      "integrity": "sha512-nscpt0G6UCTkrT2ppnJnFsYbPDQwmum4GNXYTeoTIdsmMydSKFz9Iny2jpaRupTb+Wl298+Rh82WKzt9LCcqSQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-ia32-msvc": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.33.tgz",
+      "integrity": "sha512-pc9LpGNKhJ0dXQhZ5QMmYxtARwwmWLpeocFmVG5Z0DzWq5Uf0izcI8tLc+qOpqxO1PWqZ5A7J1blrUIKrIFc7Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.33.tgz",
+      "integrity": "sha512-nOjfZMy8B94MdisuzZo9/57xuFVLHJaDj5e/xrduJp9CV2/HrfxTRH2fbyLe+K9QT41WBLUd4iXX3R7jBp0EUg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@swc/counter": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
+      "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.5.tgz",
+      "integrity": "sha512-KGYxvIOXcceOAbEk4bi/dVLEK9z8sZ0uBB3Il5b1rhfClSpcX0yfRO0KmTkqR2cnQDymwLB+25ZyMzICg/cm/A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/counter": "^0.1.3",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "24.9.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.9.1.tgz",
+      "integrity": "sha512-QoiaXANRkSXK6p0Duvt56W208du4P9Uye9hWLWgGMDTEoKPhuenzNcC4vGUmrNkiOKTlIrBoyNQYNpSwfEZXSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.2",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.2.tgz",
+      "integrity": "sha512-6mDvHUFSjyT2B2yeNx2nUgMxh9LtOWvkhIU3uePn2I2oyNymUAX1NIsdgviM4CH+JSrp2D2hsMvJOkxY+0wNRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001751",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001751.tgz",
+      "integrity": "sha512-A0QJhug0Ly64Ii3eIqHu5X51ebln3k4yTUkY1j8drqpWHVreg/VLijN48cZ1bYPiqOQuqpkIKnzr/Ul8V+p6Cw==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/client-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
+      "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/next": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/next/-/next-14.2.33.tgz",
+      "integrity": "sha512-GiKHLsD00t4ACm1p00VgrI0rUFAC9cRDGReKyERlM57aeEZkOQGcZTpIbsGn0b562FTPJWmYfKwplfO9EaT6ng==",
+      "license": "MIT",
+      "dependencies": {
+        "@next/env": "14.2.33",
+        "@swc/helpers": "0.5.5",
+        "busboy": "1.6.0",
+        "caniuse-lite": "^1.0.30001579",
+        "graceful-fs": "^4.2.11",
+        "postcss": "8.4.31",
+        "styled-jsx": "5.1.1"
+      },
+      "bin": {
+        "next": "dist/bin/next"
+      },
+      "engines": {
+        "node": ">=18.17.0"
+      },
+      "optionalDependencies": {
+        "@next/swc-darwin-arm64": "14.2.33",
+        "@next/swc-darwin-x64": "14.2.33",
+        "@next/swc-linux-arm64-gnu": "14.2.33",
+        "@next/swc-linux-arm64-musl": "14.2.33",
+        "@next/swc-linux-x64-gnu": "14.2.33",
+        "@next/swc-linux-x64-musl": "14.2.33",
+        "@next/swc-win32-arm64-msvc": "14.2.33",
+        "@next/swc-win32-ia32-msvc": "14.2.33",
+        "@next/swc-win32-x64-msvc": "14.2.33"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.1.0",
+        "@playwright/test": "^1.41.2",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0",
+        "sass": "^1.3.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@playwright/test": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.4.31",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
+      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.6",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/styled-jsx": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.1.tgz",
+      "integrity": "sha512-pW7uC1l4mBZ8ugbiZrcIsiIvVx1UmTfw7UkC3Um2tmfUq9Bhk8IiyEIPl6F8agHgjzku6j0xQEZbfA5uSgSaCw==",
+      "license": "MIT",
+      "dependencies": {
+        "client-only": "0.0.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "babel-plugin-macros": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@spark/www",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "module",
+  "private": "true",
+  "dependencies": {
+    "next": "^14.2.33",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@types/node": "^24.9.1",
+    "@types/react": "^19.2.2",
+    "typescript": "^5.9.3"
+  }
+}

--- a/apps/www/tsconfig.json
+++ b/apps/www/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,36 @@
+# Architecture v0
+Editor (VS Code fork) → SparkCore (planner/coder/reviewer/tester) → Tools (read/write/test) → Sandbox (optional).
+
+```
+┌─────────────────┐
+│   VS Code Fork  │  
+│   (Editor UI)   │
+└────────┬────────┘
+         │
+         ▼
+┌─────────────────┐
+│   SparkCore     │  Orchestration layer
+│  ┌───────────┐  │
+│  │ Planner   │  │  Intent → task breakdown
+│  │ Coder     │  │  File edits
+│  │ Reviewer  │  │  Diff validation
+│  │ Tester    │  │  TestGen + execution
+│  └───────────┘  │
+└────────┬────────┘
+         │
+         ▼
+┌─────────────────┐
+│     Tools       │  File I/O, search, git, test runner
+└────────┬────────┘
+         │
+         ▼
+┌─────────────────┐
+│    Sandbox      │  Optional isolated execution
+│  (local Docker) │
+└─────────────────┘
+```
+
+## Principles
+- Local-first: all processing on device by default
+- Cloud opt-in: telemetry, model API, sync
+- Privacy: no code upload without explicit toggle

--- a/docs/DECISIONS/ADR-0001-initial-stack.md
+++ b/docs/DECISIONS/ADR-0001-initial-stack.md
@@ -1,0 +1,27 @@
+# ADR-0001: Initial Stack
+**Date:** 2025-10-28  
+**Status:** Accepted
+
+## Context
+Need fast scaffolding for landing page and core infrastructure while keeping the VS Code fork as the editor foundation.
+
+## Decision
+- **Landing:** Next.js 14 (Node 20, npm, TypeScript)
+- **Editor:** VS Code fork (existing)
+- **CI:** GitHub Actions
+- **Package manager:** npm (not pnpm/yarn)
+
+## Rationale
+- Next.js: fast DX, strong ecosystem, easy deployment
+- npm: already present in VS Code fork; no tooling friction
+- GitHub Actions: native integration, free tier sufficient
+- Small and reversible: can migrate at v0.2 if needed
+
+## Alternatives Considered
+- Astro for landing: more minimal but less familiar to most contributors
+- pnpm for workspace: better de-duplication but adds setup friction
+- Turborepo: overkill for current scale
+
+## Consequences
+- Familiar toolchain accelerates onboarding
+- Can revisit at next milestone if constraints change

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@spark/config",
+  "version": "0.0.1",
+  "private": true,
+  "description": "Shared configs for Spark monorepo"
+}

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -e
+
+echo "🔥 Bootstrapping Spark..."
+
+if ! command -v node &> /dev/null; then
+  echo "❌ Node.js not found. Install Node 20+ first."
+  exit 1
+fi
+
+NODE_VERSION=$(node -v | cut -d'v' -f2 | cut -d'.' -f1)
+if [ "$NODE_VERSION" -lt 20 ]; then
+  echo "❌ Node 20+ required. Found: $(node -v)"
+  exit 1
+fi
+
+echo "✅ Node $(node -v)"
+
+if [ ! -f "apps/www/.env" ]; then
+  echo "📝 Creating apps/www/.env from .env.example"
+  cp apps/www/.env.example apps/www/.env
+fi
+
+echo "📦 Installing landing page dependencies..."
+cd apps/www
+npm install
+cd ../..
+
+echo ""
+echo "✅ Bootstrap complete!"
+echo ""
+echo "Next steps:"
+echo "  cd apps/www"
+echo "  npm run dev"
+echo ""


### PR DESCRIPTION
## Summary
Bootstraps Spark infrastructure on top of VS Code fork:

- **Landing page** (apps/www): Next.js 14, email capture, privacy page
- **CI workflow**: GitHub Actions for typecheck + build on PRs
- **Docs**: README, ROADMAP, SECURITY, ARCHITECTURE, ADR-0001, DOMAIN_OPTIONS
- **Templates**: Issue and PR templates with Spark conventions
- **Scripts**: bootstrap.sh for quick setup
- **Shared config**: Stub for future ESLint/Prettier/TSConfig

## Checklist
- [x] Small, single-purpose PR
- [x] CI green (will verify after merge to main and protection setup)
- [x] Clear rationale (foundation setup)

## Next Steps
After merge:
1. Protect main branch with required status checks
2. Add GitHub labels (type:feat, type:fix, area:editor, etc.)
3. Create "Spark v0.1" project board