### PR TITLE
chore: non-interactive `workbench.action.exportLogs` variant

### DIFF
--- a/src/vs/workbench/contrib/output/browser/output.contribution.ts
+++ b/src/vs/workbench/contrib/output/browser/output.contribution.ts
@@ -41,6 +41,8 @@ import { ViewAction } from '../../../browser/parts/views/viewPane.js';
 import { INotificationService } from '../../../../platform/notification/common/notification.js';
 import { IFileDialogService } from '../../../../platform/dialogs/common/dialogs.js';
 import { basename } from '../../../../base/common/resources.js';
+import { URI } from '../../../../base/common/uri.js';
+import { hasKey } from '../../../../base/common/types.js';
 
 const IMPORTED_LOG_ID_PREFIX = 'importedLog.';
 
@@ -426,7 +428,7 @@ class OutputContribution extends Disposable implements IWorkbenchContribution {
 				if (channel) {
 					const descriptor = outputService.getChannelDescriptors().find(c => c.id === channel.id);
 					if (descriptor) {
-						await outputService.saveOutputAs(descriptor);
+						await outputService.saveOutputAs(undefined, descriptor);
 					}
 				}
 			}
@@ -718,7 +720,7 @@ class OutputContribution extends Disposable implements IWorkbenchContribution {
 					}],
 				});
 			}
-			async run(accessor: ServicesAccessor): Promise<void> {
+			async run(accessor: ServicesAccessor, outputPath?: URI): Promise<void> {
 				const outputService = accessor.get(IOutputService);
 				const quickInputService = accessor.get(IQuickInputService);
 				const extensionLogs: IOutputChannelDescriptor[] = [], logs: IOutputChannelDescriptor[] = [], userLogs: IOutputChannelDescriptor[] = [];
@@ -749,9 +751,17 @@ class OutputContribution extends Disposable implements IWorkbenchContribution {
 				for (const log of userLogs.sort((a, b) => a.label.localeCompare(b.label))) {
 					entries.push(log);
 				}
-				const result = await quickInputService.pick(entries, { placeHolder: nls.localize('selectlog', "Select Log"), canPickMany: true });
+				let result: IOutputChannelDescriptor[] | undefined;
+				if (outputPath) {
+					result = entries.filter((e): e is IOutputChannelDescriptor => {
+						const isSeparator = hasKey(e, { type: true }) && e.type === 'separator';
+						return !isSeparator;
+					});
+				} else {
+					result = await quickInputService.pick(entries, { placeHolder: nls.localize('selectlog', "Select Log"), canPickMany: true });
+				}
 				if (result?.length) {
-					await outputService.saveOutputAs(...result);
+					await outputService.saveOutputAs(outputPath, ...result);
 				}
 			}
 		}));

--- a/src/vs/workbench/contrib/output/browser/outputServices.ts
+++ b/src/vs/workbench/contrib/output/browser/outputServices.ts
@@ -414,7 +414,7 @@ export class OutputService extends Disposable implements IOutputService, ITextMo
 		return id;
 	}
 
-	async saveOutputAs(...channels: IOutputChannelDescriptor[]): Promise<void> {
+	async saveOutputAs(outputPath?: URI, ...channels: IOutputChannelDescriptor[]): Promise<void> {
 		let channel: IOutputChannel | undefined;
 		if (channels.length > 1) {
 			const compoundChannelId = this.registerCompoundLogChannel(channels);
@@ -428,16 +428,19 @@ export class OutputService extends Disposable implements IOutputService, ITextMo
 		}
 
 		try {
-			const name = channels.length > 1 ? 'output' : channels[0].label;
-			const uri = await this.fileDialogService.showSaveDialog({
-				title: localize('saveLog.dialogTitle', "Save Output As"),
-				availableFileSystems: [Schemas.file],
-				defaultUri: joinPath(await this.fileDialogService.defaultFilePath(), `${name}.log`),
-				filters: [{
-					name,
-					extensions: ['log']
-				}]
-			});
+			let uri: URI | undefined = outputPath;
+			if (!uri) {
+				const name = channels.length > 1 ? 'output' : channels[0].label;
+				uri = await this.fileDialogService.showSaveDialog({
+					title: localize('saveLog.dialogTitle', "Save Output As"),
+					availableFileSystems: [Schemas.file],
+					defaultUri: joinPath(await this.fileDialogService.defaultFilePath(), `${name}.log`),
+					filters: [{
+						name,
+						extensions: ['log']
+					}]
+				});
+			}
 
 			if (!uri) {
 				return;

--- a/src/vs/workbench/services/output/common/output.ts
+++ b/src/vs/workbench/services/output/common/output.ts
@@ -119,7 +119,7 @@ export interface IOutputService {
 	/**
 	 * Save the logs to a file.
 	 */
-	saveOutputAs(...channels: IOutputChannelDescriptor[]): Promise<void>;
+	saveOutputAs(outputPath?: URI, ...channels: IOutputChannelDescriptor[]): Promise<void>;
 
 	/**
 	 * Checks if the log level can be set for the given channel.


### PR DESCRIPTION
During automation scenarios, we want to be able to export *all* logs without interacting with the QuickInput or system Save As dialog.