### PR TITLE
scm: improve hover widget avatar rendering

### DIFF
--- a/src/vs/workbench/contrib/scm/browser/media/scm.css
+++ b/src/vs/workbench/contrib/scm/browser/media/scm.css
@@ -522,6 +522,17 @@
 
 .monaco-hover.history-item-hover p:first-child {
 	margin-top: 4px;
+	display: flex;
+	align-items: center;
+}
+
+.monaco-hover.history-item-hover p:first-child img {
+	border-radius: 50%;
+	margin-right: 4px;
+}
+
+.monaco-hover.history-item-hover p:first-child .codicon {
+	margin: 0 2px;
 }
 
 .monaco-hover.history-item-hover p:last-child {


### PR DESCRIPTION
This pull request introduces UI improvements to the SCM history hover feature, focusing on the layout and appearance of user avatars and icons.

**SCM history hover UI enhancements:**

* Made the first paragraph in `.monaco-hover.history-item-hover` use a flex layout and vertically center its contents for better alignment.
* Styled avatar images in the hover to appear circular and added spacing to the right for improved readability.
* Adjusted the spacing around `.codicon` icons in the hover for a cleaner look.…acing

Before:
<img width="398" height="219" alt="Screenshot 2025-10-28 at 16 07 07" src="https://github.com/user-attachments/assets/0476adbe-411d-47bd-b569-5906a8b0908b" />

After:
<img width="404" height="210" alt="Screenshot 2025-10-28 at 16 06 18" src="https://github.com/user-attachments/assets/a3a2a145-1d54-4347-9c24-f928315324c5" />
