### PR TITLE
titlebar: reduce Command Center spacer icon horizontal padding to 8px

### DIFF
--- a/src/vs/workbench/browser/parts/titlebar/commandCenterControl.ts
+++ b/src/vs/workbench/browser/parts/titlebar/commandCenterControl.ts
@@ -209,7 +209,7 @@ class CommandCenterCenterViewItem extends BaseActionViewItem {
 			// spacer
 			if (i < groups.length - 1) {
 				const icon = renderIcon(Codicon.circleSmallFilled);
-				icon.style.padding = '0 12px';
+				icon.style.padding = '0 8px';
 				icon.style.height = '100%';
 				icon.style.opacity = '0.5';
 				container.appendChild(icon);


### PR DESCRIPTION
This pull request makes a minor UI adjustment to the command center control in the title bar. The change reduces the horizontal padding around the spacer icon for better visual spacing.

* UI adjustment: The padding for the spacer icon in `CommandCenterCenterViewItem` (`commandCenterControl.ts`) was reduced from `0 12px` to `0 8px` for improved layout.
