### PR TITLE
feat: add alwaysShowActions option to TreeView API

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadTreeViews.ts
+++ b/src/vs/workbench/api/browser/mainThreadTreeViews.ts
@@ -39,7 +39,7 @@ export class MainThreadTreeViews extends Disposable implements MainThreadTreeVie
 		this._proxy = extHostContext.getProxy(ExtHostContext.ExtHostTreeViews);
 	}
 
-	async $registerTreeViewDataProvider(treeViewId: string, options: { showCollapseAll: boolean; canSelectMany: boolean; dropMimeTypes: string[]; dragMimeTypes: string[]; hasHandleDrag: boolean; hasHandleDrop: boolean; manuallyManageCheckboxes: boolean }): Promise<void> {
+	async $registerTreeViewDataProvider(treeViewId: string, options: { showCollapseAll: boolean; canSelectMany: boolean; dropMimeTypes: string[]; dragMimeTypes: string[]; hasHandleDrag: boolean; hasHandleDrop: boolean; manuallyManageCheckboxes: boolean; alwaysShowActions: boolean }): Promise<void> {
 		this.logService.trace('MainThreadTreeViews#$registerTreeViewDataProvider', treeViewId, options);
 
 		this.extensionService.whenInstalledExtensionsRegistered().then(() => {
@@ -55,6 +55,7 @@ export class MainThreadTreeViews extends Disposable implements MainThreadTreeVie
 				viewer.showCollapseAllAction = options.showCollapseAll;
 				viewer.canSelectMany = options.canSelectMany;
 				viewer.manuallyManageCheckboxes = options.manuallyManageCheckboxes;
+				viewer.alwaysShowActions = options.alwaysShowActions;
 				viewer.dragAndDropController = dndController;
 				if (dndController) {
 					this._dndControllers.set(treeViewId, dndController);

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -330,7 +330,7 @@ export interface MainThreadTextEditorsShape extends IDisposable {
 }
 
 export interface MainThreadTreeViewsShape extends IDisposable {
-	$registerTreeViewDataProvider(treeViewId: string, options: { showCollapseAll: boolean; canSelectMany: boolean; dropMimeTypes: readonly string[]; dragMimeTypes: readonly string[]; hasHandleDrag: boolean; hasHandleDrop: boolean; manuallyManageCheckboxes: boolean }): Promise<void>;
+	$registerTreeViewDataProvider(treeViewId: string, options: { showCollapseAll: boolean; canSelectMany: boolean; dropMimeTypes: readonly string[]; dragMimeTypes: readonly string[]; hasHandleDrag: boolean; hasHandleDrop: boolean; manuallyManageCheckboxes: boolean; alwaysShowActions: boolean }): Promise<void>;
 	$refresh(treeViewId: string, itemsToRefresh?: { [treeItemHandle: string]: ITreeItem }): Promise<void>;
 	$reveal(treeViewId: string, itemInfo: { item: ITreeItem; parentChain: ITreeItem[] } | undefined, options: IRevealOptions): Promise<void>;
 	$setMessage(treeViewId: string, message: string | IMarkdownString): void;

--- a/src/vs/workbench/api/common/extHostTreeViews.ts
+++ b/src/vs/workbench/api/common/extHostTreeViews.ts
@@ -95,7 +95,7 @@ export class ExtHostTreeViews extends Disposable implements ExtHostTreeViewsShap
 		const hasHandleDrag = !!options.dragAndDropController?.handleDrag;
 		const hasHandleDrop = !!options.dragAndDropController?.handleDrop;
 		const treeView = this._createExtHostTreeView(viewId, options, extension);
-		const proxyOptions = { showCollapseAll: !!options.showCollapseAll, canSelectMany: !!options.canSelectMany, dropMimeTypes, dragMimeTypes, hasHandleDrag, hasHandleDrop, manuallyManageCheckboxes: !!options.manageCheckboxStateManually };
+		const proxyOptions = { showCollapseAll: !!options.showCollapseAll, canSelectMany: !!options.canSelectMany, dropMimeTypes, dragMimeTypes, hasHandleDrag, hasHandleDrop, manuallyManageCheckboxes: !!options.manageCheckboxStateManually, alwaysShowActions: !!options.alwaysShowActions };
 		const registerPromise = this._proxy.$registerTreeViewDataProvider(viewId, proxyOptions);
 		const view = {
 			get onDidCollapseElement() { return treeView.onDidCollapseElement; },

--- a/src/vs/workbench/browser/parts/views/media/views.css
+++ b/src/vs/workbench/browser/parts/views/media/views.css
@@ -245,6 +245,11 @@
 	display: block;
 }
 
+/* Always show actions when the setting is enabled */
+.customview-tree.always-show-actions .monaco-list .monaco-list-row .custom-view-tree-node-item .actions {
+	display: block;
+}
+
 /* filter view pane */
 
 .monaco-workbench .auxiliarybar.pane-composite-part > .title.has-composite-bar > .title-actions .monaco-action-bar .action-item.viewpane-filter-container {

--- a/src/vs/workbench/browser/parts/views/treeView.ts
+++ b/src/vs/workbench/browser/parts/views/treeView.ts
@@ -226,6 +226,7 @@ abstract class AbstractTreeView extends Disposable implements ITreeView {
 	private _messageValue: string | { element: HTMLElement; disposables: DisposableStore } | undefined;
 	private _canSelectMany: boolean = false;
 	private _manuallyManageCheckboxes: boolean = false;
+	private _alwaysShowActions: boolean = false;
 	private messageElement: HTMLElement | undefined;
 	private tree: Tree | undefined;
 	private treeLabels: ResourceLabels | undefined;
@@ -522,6 +523,15 @@ abstract class AbstractTreeView extends Disposable implements ITreeView {
 		this._manuallyManageCheckboxes = manuallyManageCheckboxes;
 	}
 
+	get alwaysShowActions(): boolean {
+		return this._alwaysShowActions;
+	}
+
+	set alwaysShowActions(alwaysShowActions: boolean) {
+		this._alwaysShowActions = alwaysShowActions;
+		this.updateTreeActionsVisibility();
+	}
+
 	get hasIconForParentNode(): boolean {
 		return this._hasIconForParentNode;
 	}
@@ -675,12 +685,20 @@ abstract class AbstractTreeView extends Disposable implements ITreeView {
 		DOM.append(container, this.domNode);
 	}
 
+	private updateTreeActionsVisibility(): void {
+		if (!this.treeContainer) {
+			return;
+		}
+		this.treeContainer.classList.toggle('always-show-actions', this._alwaysShowActions);
+	}
+
 	private create() {
 		this.domNode = DOM.$('.tree-explorer-viewlet-tree-view');
 		this.messageElement = DOM.append(this.domNode, DOM.$('.message'));
 		this.updateMessage();
 		this.treeContainer = DOM.append(this.domNode, DOM.$('.customview-tree'));
 		this.treeContainer.classList.add('file-icon-themable-tree', 'show-file-icons');
+		this.updateTreeActionsVisibility();
 		const focusTracker = this._register(DOM.trackFocus(this.domNode));
 		this._register(focusTracker.onDidFocus(() => this.focused = true));
 		this._register(focusTracker.onDidBlur(() => this.focused = false));

--- a/src/vs/workbench/common/views.ts
+++ b/src/vs/workbench/common/views.ts
@@ -632,6 +632,8 @@ export interface ITreeView extends IDisposable {
 
 	manuallyManageCheckboxes: boolean;
 
+	alwaysShowActions: boolean;
+
 	message?: string | IMarkdownString;
 
 	title: string;

--- a/src/vscode-dts/vscode.d.ts
+++ b/src/vscode-dts/vscode.d.ts
@@ -12117,6 +12117,13 @@ declare module 'vscode' {
 		 *     - [x] Child 2
 		 */
 		manageCheckboxStateManually?: boolean;
+
+		/**
+		 * Whether tree item actions (inline action buttons) should always be visible or only visible on hover, selection, or focus.
+		 * By default, actions are only visible when the tree item is hovered, selected, or focused.
+		 * When set to `true`, actions will always be visible for all tree items.
+		 */
+		alwaysShowActions?: boolean;
 	}
 
 	/**


### PR DESCRIPTION
Add a new optional property 'alwaysShowActions' to TreeViewOptions that allows extension developers to control whether tree item action buttons are always visible or only shown on hover/selection/focus.

Changes:
- Add alwaysShowActions property to vscode.d.ts TreeViewOptions interface
- Extend ITreeView interface with alwaysShowActions property
- Update extension host to pass alwaysShowActions option to main thread
- Implement alwaysShowActions getter/setter in AbstractTreeView
- Add CSS rule for always-show-actions class
- Update MainThreadTreeViews to handle the new option

When alwaysShowActions is set to true, inline action buttons in tree items are always visible instead of only appearing on hover, selection, or focus. This gives extension authors per-tree-view control over action visibility.

Default behavior (false) maintains backward compatibility.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
