### PR TITLE
Use `isEqual` to compare uris

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatSessions/common.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSessions/common.ts
@@ -5,6 +5,7 @@
 
 import { fromNow } from '../../../../../base/common/date.js';
 import { Schemas } from '../../../../../base/common/network.js';
+import { isEqual } from '../../../../../base/common/resources.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { EditorInput } from '../../../../common/editor/editorInput.js';
 import { IEditorGroupsService } from '../../../../services/editor/common/editorGroupsService.js';
@@ -55,13 +56,9 @@ export function getChatSessionType(editor: ChatEditorInput): string {
  * Find existing chat editors that have the same session URI (for external providers)
  */
 export function findExistingChatEditorByUri(sessionUri: URI, sessionId: string, editorGroupsService: IEditorGroupsService): { editor: ChatEditorInput; groupId: number } | undefined {
-	if (!sessionUri) {
-		return undefined;
-	}
-
 	for (const group of editorGroupsService.groups) {
 		for (const editor of group.editors) {
-			if (editor instanceof ChatEditorInput && (editor.resource.toString() === sessionUri.toString() || editor.sessionId === sessionId)) {
+			if (editor instanceof ChatEditorInput && (isEqual(editor.resource, sessionUri) || editor.sessionId === sessionId)) {
 				return { editor, groupId: group.id };
 			}
 		}


### PR DESCRIPTION
Also removes an extra safe guard since the type isn't nullable. If we're ending up with undefined, we should fix the caller