### PR TITLE
Unify extension activation logic

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -734,9 +734,9 @@ configurationRegistry.registerConfiguration({
 				mode: 'auto'
 			}
 		},
-		'copilot.extensionUnification.enabled': {
+		'chat.extensionUnification.enabled': {
 			type: 'boolean',
-			description: nls.localize('copilot.extensionUnification.enabled', "Enables unification of GitHub Copilot extensions. When enabled, only the GitHub Copilot Chat extension will be active and all functionality will be served by it. When disabled, GitHub Copilot Chat and GitHub Copilot extensions will operate independently."),
+			description: nls.localize('chat.extensionUnification.enabled', "Enables unification of GitHub Copilot extensions. When enabled, only the GitHub Copilot Chat extension will be active and all functionality will be served by it. When disabled, GitHub Copilot Chat and GitHub Copilot extensions will operate independently."),
 			default: false,
 			tags: ['experimental'],
 			experiment: {

--- a/src/vs/workbench/contrib/extensions/browser/extensionsActions.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionsActions.ts
@@ -2687,6 +2687,12 @@ export class ExtensionStatusAction extends ExtensionAction {
 			}
 		}
 
+		// Unification
+		if (this.extension.enablementState === EnablementState.DisabledByUnification) {
+			this.updateStatus({ icon: infoIcon, message: new MarkdownString(localize('extension disabled because of unification', "The Copilot extension has been disabled. Copilot functionality will now be served by the Copilot Chat extension. In case this is causing issues, please create an issue on the vscode repository. The setting {0} can be used to revert back to having both extensions enabled.", '`chat.extensionUnification.enabled`')) }, true);
+			return;
+		}
+
 		if (!this.workspaceTrustService.isWorkspaceTrusted() &&
 			// Extension is disabled by untrusted workspace
 			(this.extension.enablementState === EnablementState.DisabledByTrustRequirement ||

--- a/src/vs/workbench/services/extensionManagement/common/extensionManagement.ts
+++ b/src/vs/workbench/services/extensionManagement/common/extensionManagement.ts
@@ -108,6 +108,7 @@ export const enum EnablementState {
 	DisabledByInvalidExtension,
 	DisabledByAllowlist,
 	DisabledByExtensionDependency,
+	DisabledByUnification, // Temporary TODO@benibenj remove when unification transition is complete
 	DisabledGlobally,
 	DisabledWorkspace,
 	EnabledGlobally,

--- a/src/vs/workbench/services/extensionManagement/test/browser/extensionEnablementService.test.ts
+++ b/src/vs/workbench/services/extensionManagement/test/browser/extensionEnablementService.test.ts
@@ -19,7 +19,7 @@ import { IConfigurationService } from '../../../../../platform/configuration/com
 import { URI } from '../../../../../base/common/uri.js';
 import { Schemas } from '../../../../../base/common/network.js';
 import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
-import { TestLifecycleService } from '../../../../test/browser/workbenchTestServices.js';
+import { productService, TestLifecycleService } from '../../../../test/browser/workbenchTestServices.js';
 import { GlobalExtensionEnablementService } from '../../../../../platform/extensionManagement/common/extensionEnablementService.js';
 import { IUserDataSyncAccountService, UserDataSyncAccountService } from '../../../../../platform/userDataSync/common/userDataSyncAccount.js';
 import { IUserDataSyncEnablementService } from '../../../../../platform/userDataSync/common/userDataSync.js';
@@ -97,7 +97,8 @@ export class TestExtensionEnablementService extends ExtensionEnablementService {
 			new class extends mock<IWorkspaceTrustRequestService>() { override requestWorkspaceTrust(options?: WorkspaceTrustRequestOptions): Promise<boolean> { return Promise.resolve(true); } },
 			instantiationService.get(IExtensionManifestPropertiesService) || instantiationService.stub(IExtensionManifestPropertiesService, disposables.add(new ExtensionManifestPropertiesService(TestProductService, new TestConfigurationService(), new TestWorkspaceTrustEnablementService(), new NullLogService()))),
 			instantiationService,
-			new NullLogService()
+			new NullLogService(),
+			productService
 		);
 		this._register(disposables);
 	}


### PR DESCRIPTION
```Copilot Generated Description:``` Implement logic for unifying the activation of GitHub Copilot extensions, allowing only the Copilot Chat extension to be active when enabled. Adjust the enablement state and configuration settings accordingly.

https://github.com/microsoft/vscode-internalbacklog/issues/6073