### PR TITLE
Expand hover setting to allow for key modifier mode

### DIFF
--- a/src/vs/editor/browser/config/migrateOptions.ts
+++ b/src/vs/editor/browser/config/migrateOptions.ts
@@ -251,3 +251,10 @@ registerEditorSettingMigration('inlineSuggest.edits.codeShifting', (value, read,
 		write('inlineSuggest.edits.allowCodeShifting', value ? 'always' : 'never');
 	}
 });
+
+// Migrate Hover
+registerEditorSettingMigration('hover.enabled', (value, read, write) => {
+	if (typeof value === 'boolean') {
+		write('hover.enabled', value ? undefined : 'off');
+	}
+});

--- a/src/vs/editor/browser/config/migrateOptions.ts
+++ b/src/vs/editor/browser/config/migrateOptions.ts
@@ -255,6 +255,6 @@ registerEditorSettingMigration('inlineSuggest.edits.codeShifting', (value, read,
 // Migrate Hover
 registerEditorSettingMigration('hover.enabled', (value, read, write) => {
 	if (typeof value === 'boolean') {
-		write('hover.enabled', value ? undefined : 'off');
+		write('hover.enabled', value ? 'on' : 'off');
 	}
 });

--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -2344,7 +2344,7 @@ class EditorHover extends BaseEditorOption<EditorOption.hover, IEditorHoverOptio
 					markdownEnumDescriptions: [
 						nls.localize('hover.enabled.on', "Hover is enabled."),
 						nls.localize('hover.enabled.off', "Hover is disabled."),
-						nls.localize('hover.enabled.onKeyboardModifier', "Hover is shown when holding {0} or Alt (the opposite modifier of `#editor.multiCursorModifier#`)", platform.isMacintosh ? `Cmd` : `Ctrl`)
+						nls.localize('hover.enabled.onKeyboardModifier', "Hover is shown when holding `{0}` or `Alt` (the opposite modifier of `#editor.multiCursorModifier#`)", platform.isMacintosh ? `Command` : `Control`)
 					],
 					description: nls.localize('hover.enabled', "Controls whether the hover is shown.")
 				},

--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -2380,10 +2380,6 @@ class EditorHover extends BaseEditorOption<EditorOption.hover, IEditorHoverOptio
 			return this.defaultValue;
 		}
 		const input = _input as Unknown<IEditorHoverOptions>;
-		// Backward compatibility
-		if (typeof input.enabled === 'boolean') {
-			input.enabled = input.enabled ? 'on' : 'off';
-		}
 		return {
 			enabled: stringSet<'on' | 'off' | 'onKeyboardModifier'>(input.enabled, this.defaultValue.enabled, ['on', 'off', 'onKeyboardModifier']),
 			delay: EditorIntOption.clampedInt(input.delay, this.defaultValue.delay, 0, 10000),

--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -2344,7 +2344,7 @@ class EditorHover extends BaseEditorOption<EditorOption.hover, IEditorHoverOptio
 					markdownEnumDescriptions: [
 						nls.localize('hover.enabled.on', "Hover is enabled."),
 						nls.localize('hover.enabled.off', "Hover is disabled."),
-						nls.localize('hover.enabled.onKeyboardModifier', "Hover is shown when the opposite modifier key of the Multi Cursor Modifier is pressed. (ctrlCmd or alt)")
+						nls.localize('hover.enabled.onKeyboardModifier', "Hover is shown when holding {0} or Alt (the opposite modifier of `#editor.multiCursorModifier#`)", platform.isMacintosh ? `Cmd` : `Ctrl`)
 					],
 					description: nls.localize('hover.enabled', "Controls whether the hover is shown.")
 				},

--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -2344,7 +2344,7 @@ class EditorHover extends BaseEditorOption<EditorOption.hover, IEditorHoverOptio
 					markdownEnumDescriptions: [
 						nls.localize('hover.enabled.on', "Hover is enabled."),
 						nls.localize('hover.enabled.off', "Hover is disabled."),
-						nls.localize('hover.enabled.onKeyboardModifier', "Hover is shown when the opposite modifier key of the multi-cursor modifier is pressed.")
+						nls.localize('hover.enabled.onKeyboardModifier', "Hover is shown when the opposite modifier key of the Multi Cursor Modifier is pressed. (ctrlCmd or alt)")
 					],
 					description: nls.localize('hover.enabled', "Controls whether the hover is shown.")
 				},

--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -2294,9 +2294,12 @@ class EditorGoToLocation extends BaseEditorOption<EditorOption.gotoLocation, IGo
 export interface IEditorHoverOptions {
 	/**
 	 * Enable the hover.
+	 * - true: Always enabled
+	 * - false: Always disabled
+	 * - 'onKeyboardModifier': Enabled when the opposite modifier key of multiCursorModifier is pressed
 	 * Defaults to true.
 	 */
-	enabled?: boolean;
+	enabled?: boolean | 'onKeyboardModifier';
 	/**
 	 * Delay for showing the hover.
 	 * Defaults to 300.
@@ -2338,8 +2341,14 @@ class EditorHover extends BaseEditorOption<EditorOption.hover, IEditorHoverOptio
 			EditorOption.hover, 'hover', defaults,
 			{
 				'editor.hover.enabled': {
-					type: 'boolean',
+					type: ['boolean', 'string'],
+					enum: [true, false, 'onKeyboardModifier'],
 					default: defaults.enabled,
+					markdownEnumDescriptions: [
+						nls.localize('hover.enabled.true', "Always show the hover."),
+						nls.localize('hover.enabled.false', "Never show the hover."),
+						nls.localize('hover.enabled.onKeyboardModifier', "Show the hover when the opposite modifier key of the multi-cursor modifier is pressed.")
+					],
 					description: nls.localize('hover.enabled', "Controls whether the hover is shown.")
 				},
 				'editor.hover.delay': {
@@ -2374,8 +2383,16 @@ class EditorHover extends BaseEditorOption<EditorOption.hover, IEditorHoverOptio
 			return this.defaultValue;
 		}
 		const input = _input as Unknown<IEditorHoverOptions>;
+		let enabled: boolean | 'onKeyboardModifier';
+		if (input.enabled === 'onKeyboardModifier') {
+			enabled = 'onKeyboardModifier';
+		} else if (typeof input.enabled === 'boolean') {
+			enabled = input.enabled;
+		} else {
+			enabled = this.defaultValue.enabled;
+		}
 		return {
-			enabled: boolean(input.enabled, this.defaultValue.enabled),
+			enabled,
 			delay: EditorIntOption.clampedInt(input.delay, this.defaultValue.delay, 0, 10000),
 			sticky: boolean(input.sticky, this.defaultValue.sticky),
 			hidingDelay: EditorIntOption.clampedInt(input.hidingDelay, this.defaultValue.hidingDelay, 0, 600000),

--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -2294,12 +2294,9 @@ class EditorGoToLocation extends BaseEditorOption<EditorOption.gotoLocation, IGo
 export interface IEditorHoverOptions {
 	/**
 	 * Enable the hover.
-	 * - true: Always enabled
-	 * - false: Always disabled
-	 * - 'onKeyboardModifier': Enabled when the opposite modifier key of multiCursorModifier is pressed
-	 * Defaults to true.
+	 * Defaults to 'on'.
 	 */
-	enabled?: boolean | 'onKeyboardModifier';
+	enabled?: 'on' | 'off' | 'onKeyboardModifier';
 	/**
 	 * Delay for showing the hover.
 	 * Defaults to 300.
@@ -2331,7 +2328,7 @@ class EditorHover extends BaseEditorOption<EditorOption.hover, IEditorHoverOptio
 
 	constructor() {
 		const defaults: EditorHoverOptions = {
-			enabled: true,
+			enabled: 'on',
 			delay: 300,
 			hidingDelay: 300,
 			sticky: true,
@@ -2341,13 +2338,13 @@ class EditorHover extends BaseEditorOption<EditorOption.hover, IEditorHoverOptio
 			EditorOption.hover, 'hover', defaults,
 			{
 				'editor.hover.enabled': {
-					type: ['boolean', 'string'],
-					enum: [true, false, 'onKeyboardModifier'],
+					type: 'string',
+					enum: ['on', 'off', 'onKeyboardModifier'],
 					default: defaults.enabled,
 					markdownEnumDescriptions: [
-						nls.localize('hover.enabled.true', "Always show the hover."),
-						nls.localize('hover.enabled.false', "Never show the hover."),
-						nls.localize('hover.enabled.onKeyboardModifier', "Show the hover when the opposite modifier key of the multi-cursor modifier is pressed.")
+						nls.localize('hover.enabled.on', "Hover is enabled."),
+						nls.localize('hover.enabled.off', "Hover is disabled."),
+						nls.localize('hover.enabled.onKeyboardModifier', "Hover is shown when the opposite modifier key of the multi-cursor modifier is pressed.")
 					],
 					description: nls.localize('hover.enabled', "Controls whether the hover is shown.")
 				},
@@ -2383,16 +2380,12 @@ class EditorHover extends BaseEditorOption<EditorOption.hover, IEditorHoverOptio
 			return this.defaultValue;
 		}
 		const input = _input as Unknown<IEditorHoverOptions>;
-		let enabled: boolean | 'onKeyboardModifier';
-		if (input.enabled === 'onKeyboardModifier') {
-			enabled = 'onKeyboardModifier';
-		} else if (typeof input.enabled === 'boolean') {
-			enabled = input.enabled;
-		} else {
-			enabled = this.defaultValue.enabled;
+		// Handle backward compatibility with boolean values
+		if (typeof input.enabled === 'boolean') {
+			input.enabled = input.enabled ? 'on' : 'off';
 		}
 		return {
-			enabled,
+			enabled: stringSet<'on' | 'off' | 'onKeyboardModifier'>(input.enabled, this.defaultValue.enabled, ['on', 'off', 'onKeyboardModifier']),
 			delay: EditorIntOption.clampedInt(input.delay, this.defaultValue.delay, 0, 10000),
 			sticky: boolean(input.sticky, this.defaultValue.sticky),
 			hidingDelay: EditorIntOption.clampedInt(input.hidingDelay, this.defaultValue.hidingDelay, 0, 600000),

--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -2380,7 +2380,7 @@ class EditorHover extends BaseEditorOption<EditorOption.hover, IEditorHoverOptio
 			return this.defaultValue;
 		}
 		const input = _input as Unknown<IEditorHoverOptions>;
-		// Handle backward compatibility with boolean values
+		// Backward compatibility
 		if (typeof input.enabled === 'boolean') {
 			input.enabled = input.enabled ? 'on' : 'off';
 		}

--- a/src/vs/editor/contrib/hover/browser/contentHoverController.ts
+++ b/src/vs/editor/contrib/hover/browser/contentHoverController.ts
@@ -17,7 +17,7 @@ import { IKeybindingService } from '../../../../platform/keybinding/common/keybi
 import { ResultKind } from '../../../../platform/keybinding/common/keybindingResolver.js';
 import { HoverVerbosityAction } from '../../../common/languages.js';
 import { RunOnceScheduler } from '../../../../base/common/async.js';
-import { isMousePositionWithinElement } from './hoverUtils.js';
+import { isMousePositionWithinElement, shouldShowHover } from './hoverUtils.js';
 import { ContentHoverWidgetWrapper } from './contentHoverWidgetWrapper.js';
 import './hover.css';
 import { Emitter } from '../../../../base/common/event.js';
@@ -249,7 +249,11 @@ export class ContentHoverController extends Disposable implements IEditorContrib
 	}
 
 	private _reactToEditorMouseMove(mouseEvent: IEditorMouseEvent): void {
-		if (this._shouldShowHover(mouseEvent)) {
+		if (shouldShowHover(
+			this._hoverSettings.enabled,
+			this._editor.getOption(EditorOption.multiCursorModifier),
+			mouseEvent
+		)) {
 			const contentWidget: ContentHoverWidgetWrapper = this._getOrCreateContentWidget();
 			if (contentWidget.showsOrWillShow(mouseEvent)) {
 				return;
@@ -259,21 +263,6 @@ export class ContentHoverController extends Disposable implements IEditorContrib
 			return;
 		}
 		this.hideContentHover();
-	}
-
-	private _shouldShowHover(mouseEvent: IEditorMouseEvent): boolean {
-		if (this._hoverSettings.enabled === 'on') {
-			return true;
-		}
-		if (this._hoverSettings.enabled === 'off') {
-			return false;
-		}
-		const multiCursorModifier = this._editor.getOption(EditorOption.multiCursorModifier);
-		if (multiCursorModifier === 'altKey') {
-			return mouseEvent.event.ctrlKey;
-		} else {
-			return mouseEvent.event.altKey;
-		}
 	}
 
 	private _onKeyDown(e: IKeyboardEvent): void {

--- a/src/vs/editor/contrib/hover/browser/contentHoverController.ts
+++ b/src/vs/editor/contrib/hover/browser/contentHoverController.ts
@@ -249,8 +249,7 @@ export class ContentHoverController extends Disposable implements IEditorContrib
 	}
 
 	private _reactToEditorMouseMove(mouseEvent: IEditorMouseEvent): void {
-		const shouldShowHover = this._shouldShowHover(mouseEvent);
-		if (shouldShowHover) {
+		if (this._shouldShowHover(mouseEvent)) {
 			const contentWidget: ContentHoverWidgetWrapper = this._getOrCreateContentWidget();
 			if (contentWidget.showsOrWillShow(mouseEvent)) {
 				return;
@@ -269,10 +268,7 @@ export class ContentHoverController extends Disposable implements IEditorContrib
 		if (this._hoverSettings.enabled === 'off') {
 			return false;
 		}
-		// enabled === 'onKeyboardModifier'
 		const multiCursorModifier = this._editor.getOption(EditorOption.multiCursorModifier);
-		// If multiCursorModifier is 'ctrlKey' or 'metaKey', check for altKey
-		// If multiCursorModifier is 'altKey', check for ctrlKey
 		if (multiCursorModifier === 'altKey') {
 			return mouseEvent.event.ctrlKey;
 		} else {

--- a/src/vs/editor/contrib/hover/browser/contentHoverController.ts
+++ b/src/vs/editor/contrib/hover/browser/contentHoverController.ts
@@ -31,7 +31,7 @@ const _sticky = false
 	;
 
 interface IHoverSettings {
-	readonly enabled: boolean | 'onKeyboardModifier';
+	readonly enabled: 'on' | 'off' | 'onKeyboardModifier';
 	readonly sticky: boolean;
 	readonly hidingDelay: number;
 }
@@ -98,7 +98,7 @@ export class ContentHoverController extends Disposable implements IEditorContrib
 			sticky: hoverOpts.sticky,
 			hidingDelay: hoverOpts.hidingDelay
 		};
-		if (hoverOpts.enabled === false) {
+		if (hoverOpts.enabled === 'off') {
 			this._cancelSchedulerAndHide();
 		}
 		this._listenersStore.add(this._editor.onMouseDown((e: IEditorMouseEvent) => this._onEditorMouseDown(e)));
@@ -263,10 +263,10 @@ export class ContentHoverController extends Disposable implements IEditorContrib
 	}
 
 	private _shouldShowHover(mouseEvent: IEditorMouseEvent): boolean {
-		if (this._hoverSettings.enabled === true) {
+		if (this._hoverSettings.enabled === 'on') {
 			return true;
 		}
-		if (this._hoverSettings.enabled === false) {
+		if (this._hoverSettings.enabled === 'off') {
 			return false;
 		}
 		// enabled === 'onKeyboardModifier'

--- a/src/vs/editor/contrib/hover/browser/contentHoverController.ts
+++ b/src/vs/editor/contrib/hover/browser/contentHoverController.ts
@@ -249,7 +249,7 @@ export class ContentHoverController extends Disposable implements IEditorContrib
 	}
 
 	private _reactToEditorMouseMove(mouseEvent: IEditorMouseEvent): void {
-		if (this._hoverSettings.enabled) {
+		if (this._hoverSettings.enabled || mouseEvent.event.ctrlKey) {
 			const contentWidget: ContentHoverWidgetWrapper = this._getOrCreateContentWidget();
 			if (contentWidget.showsOrWillShow(mouseEvent)) {
 				return;

--- a/src/vs/editor/contrib/hover/browser/glyphHoverController.ts
+++ b/src/vs/editor/contrib/hover/browser/glyphHoverController.ts
@@ -12,7 +12,7 @@ import { IEditorContribution, IScrollEvent } from '../../../common/editorCommon.
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { IHoverWidget } from './hoverTypes.js';
 import { RunOnceScheduler } from '../../../../base/common/async.js';
-import { isMousePositionWithinElement } from './hoverUtils.js';
+import { isMousePositionWithinElement, shouldShowHover } from './hoverUtils.js';
 import './hover.css';
 import { GlyphHoverWidget } from './glyphHoverWidget.js';
 
@@ -176,7 +176,11 @@ export class GlyphHoverController extends Disposable implements IEditorContribut
 		if (!mouseEvent) {
 			return;
 		}
-		if (!this._shouldShowHover(mouseEvent)) {
+		if (!shouldShowHover(
+			this._hoverSettings.enabled,
+			this._editor.getOption(EditorOption.multiCursorModifier),
+			mouseEvent
+		)) {
 			if (_sticky) {
 				return;
 			}
@@ -191,24 +195,6 @@ export class GlyphHoverController extends Disposable implements IEditorContribut
 			return;
 		}
 		this.hideGlyphHover();
-	}
-
-	private _shouldShowHover(mouseEvent: IEditorMouseEvent): boolean {
-		if (this._hoverSettings.enabled === 'on') {
-			return true;
-		}
-		if (this._hoverSettings.enabled === 'off') {
-			return false;
-		}
-		// enabled === 'onKeyboardModifier'
-		const multiCursorModifier = this._editor.getOption(EditorOption.multiCursorModifier);
-		// If multiCursorModifier is 'ctrlKey' or 'metaKey', check for altKey
-		// If multiCursorModifier is 'altKey', check for ctrlKey
-		if (multiCursorModifier === 'altKey') {
-			return mouseEvent.event.ctrlKey;
-		} else {
-			return mouseEvent.event.altKey;
-		}
 	}
 
 	private _tryShowHoverWidget(mouseEvent: IEditorMouseEvent): boolean {

--- a/src/vs/editor/contrib/hover/browser/glyphHoverController.ts
+++ b/src/vs/editor/contrib/hover/browser/glyphHoverController.ts
@@ -22,7 +22,7 @@ const _sticky = false
 	;
 
 interface IHoverSettings {
-	readonly enabled: boolean | 'onKeyboardModifier';
+	readonly enabled: 'on' | 'off' | 'onKeyboardModifier';
 	readonly sticky: boolean;
 	readonly hidingDelay: number;
 }
@@ -80,7 +80,7 @@ export class GlyphHoverController extends Disposable implements IEditorContribut
 			hidingDelay: hoverOpts.hidingDelay
 		};
 
-		if (hoverOpts.enabled !== false) {
+		if (hoverOpts.enabled !== 'off') {
 			this._listenersStore.add(this._editor.onMouseDown((e: IEditorMouseEvent) => this._onEditorMouseDown(e)));
 			this._listenersStore.add(this._editor.onMouseUp(() => this._onEditorMouseUp()));
 			this._listenersStore.add(this._editor.onMouseMove((e: IEditorMouseEvent) => this._onEditorMouseMove(e)));
@@ -194,10 +194,10 @@ export class GlyphHoverController extends Disposable implements IEditorContribut
 	}
 
 	private _shouldShowHover(mouseEvent: IEditorMouseEvent): boolean {
-		if (this._hoverSettings.enabled === true) {
+		if (this._hoverSettings.enabled === 'on') {
 			return true;
 		}
-		if (this._hoverSettings.enabled === false) {
+		if (this._hoverSettings.enabled === 'off') {
 			return false;
 		}
 		// enabled === 'onKeyboardModifier'

--- a/src/vs/editor/contrib/hover/browser/hoverUtils.ts
+++ b/src/vs/editor/contrib/hover/browser/hoverUtils.ts
@@ -16,7 +16,16 @@ export function isMousePositionWithinElement(element: HTMLElement, posx: number,
 	}
 	return true;
 }
-
+/**
+ * Determines whether hover should be shown based on the hover setting and current keyboard modifiers.
+ * When `hoverEnabled` is 'onKeyboardModifier', hover is shown when the user presses the opposite
+ * modifier key from the multi-cursor modifier (e.g., if multi-cursor uses Alt, hover shows on Ctrl/Cmd).
+ *
+ * @param hoverEnabled - The hover enabled setting
+ * @param multiCursorModifier - The modifier key used for multi-cursor operations
+ * @param mouseEvent - The current mouse event containing modifier key states
+ * @returns true if hover should be shown, false otherwise
+ */
 export function shouldShowHover(
 	hoverEnabled: 'on' | 'off' | 'onKeyboardModifier',
 	multiCursorModifier: 'altKey' | 'ctrlKey' | 'metaKey',

--- a/src/vs/editor/contrib/hover/browser/hoverUtils.ts
+++ b/src/vs/editor/contrib/hover/browser/hoverUtils.ts
@@ -29,7 +29,7 @@ export function shouldShowHover(
 		return false;
 	}
 	if (multiCursorModifier === 'altKey') {
-		return mouseEvent.event.ctrlKey;
+		return mouseEvent.event.ctrlKey || mouseEvent.event.metaKey;
 	} else {
 		return mouseEvent.event.altKey;
 	}

--- a/src/vs/editor/contrib/hover/browser/hoverUtils.ts
+++ b/src/vs/editor/contrib/hover/browser/hoverUtils.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as dom from '../../../../base/browser/dom.js';
+import { IEditorMouseEvent } from '../../../browser/editorBrowser.js';
 
 export function isMousePositionWithinElement(element: HTMLElement, posx: number, posy: number): boolean {
 	const elementRect = dom.getDomNodePagePosition(element);
@@ -14,4 +15,22 @@ export function isMousePositionWithinElement(element: HTMLElement, posx: number,
 		return false;
 	}
 	return true;
+}
+
+export function shouldShowHover(
+	hoverEnabled: 'on' | 'off' | 'onKeyboardModifier',
+	multiCursorModifier: 'altKey' | 'ctrlKey' | 'metaKey',
+	mouseEvent: IEditorMouseEvent
+): boolean {
+	if (hoverEnabled === 'on') {
+		return true;
+	}
+	if (hoverEnabled === 'off') {
+		return false;
+	}
+	if (multiCursorModifier === 'altKey') {
+		return mouseEvent.event.ctrlKey;
+	} else {
+		return mouseEvent.event.altKey;
+	}
 }

--- a/src/vs/editor/contrib/hover/test/browser/hoverUtils.test.ts
+++ b/src/vs/editor/contrib/hover/test/browser/hoverUtils.test.ts
@@ -1,0 +1,82 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { shouldShowHover } from '../../browser/hoverUtils.js';
+import { IEditorMouseEvent } from '../../../../browser/editorBrowser.js';
+
+suite('Hover Utils', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	suite('shouldShowHover', () => {
+
+		function createMockMouseEvent(ctrlKey: boolean, altKey: boolean): IEditorMouseEvent {
+			return {
+				event: {
+					ctrlKey,
+					altKey,
+					shiftKey: false,
+					metaKey: false
+				}
+			} as IEditorMouseEvent;
+		}
+
+		test('returns true when enabled is "on"', () => {
+			const mouseEvent = createMockMouseEvent(false, false);
+			const result = shouldShowHover('on', 'altKey', mouseEvent);
+			assert.strictEqual(result, true);
+		});
+
+		test('returns false when enabled is "off"', () => {
+			const mouseEvent = createMockMouseEvent(false, false);
+			const result = shouldShowHover('off', 'altKey', mouseEvent);
+			assert.strictEqual(result, false);
+		});
+
+		test('returns true with ctrl pressed when multiCursorModifier is altKey', () => {
+			const mouseEvent = createMockMouseEvent(true, false);
+			const result = shouldShowHover('onKeyboardModifier', 'altKey', mouseEvent);
+			assert.strictEqual(result, true);
+		});
+
+		test('returns false without ctrl pressed when multiCursorModifier is altKey', () => {
+			const mouseEvent = createMockMouseEvent(false, false);
+			const result = shouldShowHover('onKeyboardModifier', 'altKey', mouseEvent);
+			assert.strictEqual(result, false);
+		});
+
+		test('returns true with alt pressed when multiCursorModifier is ctrlKey', () => {
+			const mouseEvent = createMockMouseEvent(false, true);
+			const result = shouldShowHover('onKeyboardModifier', 'ctrlKey', mouseEvent);
+			assert.strictEqual(result, true);
+		});
+
+		test('returns false without alt pressed when multiCursorModifier is ctrlKey', () => {
+			const mouseEvent = createMockMouseEvent(false, false);
+			const result = shouldShowHover('onKeyboardModifier', 'ctrlKey', mouseEvent);
+			assert.strictEqual(result, false);
+		});
+
+		test('returns true with alt pressed when multiCursorModifier is metaKey', () => {
+			const mouseEvent = createMockMouseEvent(false, true);
+			const result = shouldShowHover('onKeyboardModifier', 'metaKey', mouseEvent);
+			assert.strictEqual(result, true);
+		});
+
+		test('ignores alt when multiCursorModifier is altKey', () => {
+			const mouseEvent = createMockMouseEvent(false, true);
+			const result = shouldShowHover('onKeyboardModifier', 'altKey', mouseEvent);
+			assert.strictEqual(result, false);
+		});
+
+		test('ignores ctrl when multiCursorModifier is ctrlKey', () => {
+			const mouseEvent = createMockMouseEvent(true, false);
+			const result = shouldShowHover('onKeyboardModifier', 'ctrlKey', mouseEvent);
+			assert.strictEqual(result, false);
+		});
+	});
+});

--- a/src/vs/editor/contrib/hover/test/browser/hoverUtils.test.ts
+++ b/src/vs/editor/contrib/hover/test/browser/hoverUtils.test.ts
@@ -14,67 +14,73 @@ suite('Hover Utils', () => {
 
 	suite('shouldShowHover', () => {
 
-		function createMockMouseEvent(ctrlKey: boolean, altKey: boolean): IEditorMouseEvent {
+		function createMockMouseEvent(ctrlKey: boolean, altKey: boolean, metaKey: boolean): IEditorMouseEvent {
 			return {
 				event: {
 					ctrlKey,
 					altKey,
+					metaKey,
 					shiftKey: false,
-					metaKey: false
 				}
 			} as IEditorMouseEvent;
 		}
 
 		test('returns true when enabled is "on"', () => {
-			const mouseEvent = createMockMouseEvent(false, false);
+			const mouseEvent = createMockMouseEvent(false, false, false);
 			const result = shouldShowHover('on', 'altKey', mouseEvent);
 			assert.strictEqual(result, true);
 		});
 
 		test('returns false when enabled is "off"', () => {
-			const mouseEvent = createMockMouseEvent(false, false);
+			const mouseEvent = createMockMouseEvent(false, false, false);
 			const result = shouldShowHover('off', 'altKey', mouseEvent);
 			assert.strictEqual(result, false);
 		});
 
 		test('returns true with ctrl pressed when multiCursorModifier is altKey', () => {
-			const mouseEvent = createMockMouseEvent(true, false);
+			const mouseEvent = createMockMouseEvent(true, false, false);
 			const result = shouldShowHover('onKeyboardModifier', 'altKey', mouseEvent);
 			assert.strictEqual(result, true);
 		});
 
 		test('returns false without ctrl pressed when multiCursorModifier is altKey', () => {
-			const mouseEvent = createMockMouseEvent(false, false);
+			const mouseEvent = createMockMouseEvent(false, false, false);
 			const result = shouldShowHover('onKeyboardModifier', 'altKey', mouseEvent);
 			assert.strictEqual(result, false);
 		});
 
+		test('returns true with metaKey pressed when multiCursorModifier is altKey', () => {
+			const mouseEvent = createMockMouseEvent(false, false, true);
+			const result = shouldShowHover('onKeyboardModifier', 'altKey', mouseEvent);
+			assert.strictEqual(result, true);
+		});
+
 		test('returns true with alt pressed when multiCursorModifier is ctrlKey', () => {
-			const mouseEvent = createMockMouseEvent(false, true);
+			const mouseEvent = createMockMouseEvent(false, true, false);
 			const result = shouldShowHover('onKeyboardModifier', 'ctrlKey', mouseEvent);
 			assert.strictEqual(result, true);
 		});
 
 		test('returns false without alt pressed when multiCursorModifier is ctrlKey', () => {
-			const mouseEvent = createMockMouseEvent(false, false);
+			const mouseEvent = createMockMouseEvent(false, false, false);
 			const result = shouldShowHover('onKeyboardModifier', 'ctrlKey', mouseEvent);
 			assert.strictEqual(result, false);
 		});
 
 		test('returns true with alt pressed when multiCursorModifier is metaKey', () => {
-			const mouseEvent = createMockMouseEvent(false, true);
+			const mouseEvent = createMockMouseEvent(false, true, false);
 			const result = shouldShowHover('onKeyboardModifier', 'metaKey', mouseEvent);
 			assert.strictEqual(result, true);
 		});
 
 		test('ignores alt when multiCursorModifier is altKey', () => {
-			const mouseEvent = createMockMouseEvent(false, true);
+			const mouseEvent = createMockMouseEvent(false, true, false);
 			const result = shouldShowHover('onKeyboardModifier', 'altKey', mouseEvent);
 			assert.strictEqual(result, false);
 		});
 
 		test('ignores ctrl when multiCursorModifier is ctrlKey', () => {
-			const mouseEvent = createMockMouseEvent(true, false);
+			const mouseEvent = createMockMouseEvent(true, false, false);
 			const result = shouldShowHover('onKeyboardModifier', 'ctrlKey', mouseEvent);
 			assert.strictEqual(result, false);
 		});

--- a/src/vs/editor/test/browser/config/editorConfiguration.test.ts
+++ b/src/vs/editor/test/browser/config/editorConfiguration.test.ts
@@ -380,8 +380,8 @@ suite('migrateOptions', () => {
 		assert.deepStrictEqual(migrate({ quickSuggestions: { comments: 'on', strings: 'off' } }), { quickSuggestions: { comments: 'on', strings: 'off' } });
 	});
 	test('hover', () => {
-		assert.deepStrictEqual(migrate({ hover: true }), { hover: { enabled: true } });
-		assert.deepStrictEqual(migrate({ hover: false }), { hover: { enabled: false } });
+		assert.deepStrictEqual(migrate({ hover: true }), { hover: { enabled: 'on' } });
+		assert.deepStrictEqual(migrate({ hover: false }), { hover: { enabled: 'off' } });
 	});
 	test('parameterHints', () => {
 		assert.deepStrictEqual(migrate({ parameterHints: true }), { parameterHints: { enabled: true } });

--- a/src/vs/editor/test/browser/config/editorConfiguration.test.ts
+++ b/src/vs/editor/test/browser/config/editorConfiguration.test.ts
@@ -380,7 +380,7 @@ suite('migrateOptions', () => {
 		assert.deepStrictEqual(migrate({ quickSuggestions: { comments: 'on', strings: 'off' } }), { quickSuggestions: { comments: 'on', strings: 'off' } });
 	});
 	test('hover', () => {
-		assert.deepStrictEqual(migrate({ hover: true }), { hover: { enabled: undefined } });
+		assert.deepStrictEqual(migrate({ hover: true }), { hover: { enabled: 'on' } });
 		assert.deepStrictEqual(migrate({ hover: false }), { hover: { enabled: 'off' } });
 	});
 	test('parameterHints', () => {

--- a/src/vs/editor/test/browser/config/editorConfiguration.test.ts
+++ b/src/vs/editor/test/browser/config/editorConfiguration.test.ts
@@ -204,13 +204,13 @@ suite('Common Editor Config', () => {
 		const hoverOptions: IEditorHoverOptions = {};
 		Object.defineProperty(hoverOptions, 'enabled', {
 			writable: false,
-			value: true
+			value: 'on'
 		});
 		const config = new TestConfiguration({ hover: hoverOptions });
 
-		assert.strictEqual(config.options.get(EditorOption.hover).enabled, true);
-		config.updateOptions({ hover: { enabled: false } });
-		assert.strictEqual(config.options.get(EditorOption.hover).enabled, false);
+		assert.strictEqual(config.options.get(EditorOption.hover).enabled, 'on');
+		config.updateOptions({ hover: { enabled: 'off' } });
+		assert.strictEqual(config.options.get(EditorOption.hover).enabled, 'off');
 
 		config.dispose();
 	});

--- a/src/vs/editor/test/browser/config/editorConfiguration.test.ts
+++ b/src/vs/editor/test/browser/config/editorConfiguration.test.ts
@@ -380,7 +380,7 @@ suite('migrateOptions', () => {
 		assert.deepStrictEqual(migrate({ quickSuggestions: { comments: 'on', strings: 'off' } }), { quickSuggestions: { comments: 'on', strings: 'off' } });
 	});
 	test('hover', () => {
-		assert.deepStrictEqual(migrate({ hover: true }), { hover: { enabled: 'on' } });
+		assert.deepStrictEqual(migrate({ hover: true }), { hover: { enabled: undefined } });
 		assert.deepStrictEqual(migrate({ hover: false }), { hover: { enabled: 'off' } });
 	});
 	test('parameterHints', () => {

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -4270,12 +4270,9 @@ declare namespace monaco.editor {
 	export interface IEditorHoverOptions {
 		/**
 		 * Enable the hover.
-		 * - true: Always enabled
-		 * - false: Always disabled
-		 * - 'onKeyboardModifier': Enabled when the opposite modifier key of multiCursorModifier is pressed
-		 * Defaults to true.
+		 * Defaults to 'on'.
 		 */
-		enabled?: boolean | 'onKeyboardModifier';
+		enabled?: 'on' | 'off' | 'onKeyboardModifier';
 		/**
 		 * Delay for showing the hover.
 		 * Defaults to 300.

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -4270,9 +4270,12 @@ declare namespace monaco.editor {
 	export interface IEditorHoverOptions {
 		/**
 		 * Enable the hover.
+		 * - true: Always enabled
+		 * - false: Always disabled
+		 * - 'onKeyboardModifier': Enabled when the opposite modifier key of multiCursorModifier is pressed
 		 * Defaults to true.
 		 */
-		enabled?: boolean;
+		enabled?: boolean | 'onKeyboardModifier';
 		/**
 		 * Delay for showing the hover.
 		 * Defaults to 300.

--- a/src/vs/workbench/contrib/debug/browser/debugEditorContribution.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugEditorContribution.ts
@@ -429,18 +429,18 @@ export class DebugEditorContribution implements IDebugEditorContribution {
 	}
 
 	private preventDefaultEditorHover() {
-		if (this.defaultHoverLockout.value || this.editorHoverOptions?.enabled === false) {
+		if (this.defaultHoverLockout.value || this.editorHoverOptions?.enabled === 'off') {
 			return;
 		}
 
 		const hoverController = this.editor.getContribution<ContentHoverController>(ContentHoverController.ID);
 		hoverController?.hideContentHover();
 
-		this.editor.updateOptions({ hover: { enabled: false } });
+		this.editor.updateOptions({ hover: { enabled: 'off' } });
 		this.defaultHoverLockout.value = {
 			dispose: () => {
 				this.editor.updateOptions({
-					hover: { enabled: this.editorHoverOptions?.enabled ?? true }
+					hover: { enabled: this.editorHoverOptions?.enabled ?? 'on' }
 				});
 			}
 		};

--- a/src/vs/workbench/contrib/interactive/browser/interactiveEditor.ts
+++ b/src/vs/workbench/contrib/interactive/browser/interactiveEditor.ts
@@ -296,7 +296,7 @@ export class InteractiveEditor extends EditorPane implements IEditorPaneWithScro
 					bottom: INPUT_EDITOR_PADDING
 				},
 				hover: {
-					enabled: true
+					enabled: 'on' as const
 				},
 				rulers: []
 			}

--- a/src/vs/workbench/contrib/replNotebook/browser/replEditor.ts
+++ b/src/vs/workbench/contrib/replNotebook/browser/replEditor.ts
@@ -288,7 +288,7 @@ export class ReplEditor extends EditorPane implements IEditorPaneWithScrolling {
 					bottom: INPUT_EDITOR_PADDING
 				},
 				hover: {
-					enabled: true
+					enabled: 'on' as const
 				},
 				rulers: []
 			}


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/72025

## Changes Made
- Modifies existing `hover.enabled` setting from a boolean to an enum with values [`on`, `off`, `onKeyboardModifier`]
  - Mimics how [`inlayHints.enabled`](https://github.com/microsoft/vscode/commit/5a0df1cec15847cf7f234d3fe77397fc5f666581#diff-0dfa7db579eface8250affb76bc88717725a121401d4d8598bc36b92b0b6ef62) went from boolean to enum
- When set to `onKeyboardModifier`, hover only appears when `ctrl`, `cmd`, or `alt` are held down.
  - The key is determined by which key is currently set at `Multi Cursor Modifier`. If MCM is set to `ctrlCmd`, hover triggers on `alt` and vice versa.

https://github.com/user-attachments/assets/8ee8f4c7-0b2c-4cbc-b6d9-43a1b143145f

## To Test
- Set `Hover: Enabled` to `onKeyboardModifier`
- Observe your current setting for `Multi Cursor Modifier`
- Observe that hovers do not show unless the opposite value of `Multi Cursor Modifier` is held down
  - If set to `ctrlCmd`, hover should only show when `alt` is held down.
  - If set to `alt`, hover should show when either `ctrl` or `cmd` (macOS) are held down.
- Set `Multi Cursor Modifier` to whatever it is not currently
- Observe that hovers do not show unless the opposite button is pressed
- Also worth ensuring `Hover: Enabled` `on` and `off` work as expected