### PR TITLE
Mark .ignore and .rgignore files as ignore language

### DIFF
--- a/extensions/git-base/package.json
+++ b/extensions/git-base/package.json
@@ -77,6 +77,10 @@
           "Ignore",
           "ignore"
         ],
+        "filenamePatterns": [
+          "**/.config/git/ignore",
+          "**/.git/info/exclude"
+        ],
         "extensions": [
           ".gitignore_global",
           ".gitignore",

--- a/extensions/git-base/package.json
+++ b/extensions/git-base/package.json
@@ -80,7 +80,9 @@
         "extensions": [
           ".gitignore_global",
           ".gitignore",
-          ".git-blame-ignore-revs"
+          ".git-blame-ignore-revs",
+          ".ignore",
+          ".rgignore"
         ],
         "configuration": "./languages/ignore.language-configuration.json"
       }


### PR DESCRIPTION
These files are used by Ripgrep. The `.ignore` file is also used by other tools.
