### PR TITLE
do not render working set unless `options.renderWorkingSet` is set

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
@@ -128,7 +128,7 @@ export interface IChatInputPartOptions {
 		inputSideToolbar?: MenuId;
 	};
 	editorOverflowWidgetsDomNode?: HTMLElement;
-	renderWorkingSet?: boolean;
+	renderWorkingSet: boolean;
 	enableImplicitContext?: boolean;
 	supportsChangingModes?: boolean;
 	dndContainer?: HTMLElement;
@@ -1866,7 +1866,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 		const shouldRender = listEntries.map(r => r.length > 0);
 
 		this._renderingChatEdits.value = autorun(reader => {
-			if (shouldRender.read(reader)) {
+			if (this.options.renderWorkingSet && shouldRender.read(reader)) {
 				this.renderChatEditingSessionWithEntries(
 					reader.store,
 					chatEditingSession!,


### PR DESCRIPTION
fy @connor4312 you broke this with 8f24b33b0d806e7f0f5908ef3c9c483a564c2f44