### PR TITLE
debt - set `es2024` as target for `esbuild`

### DIFF
--- a/build/lib/optimize.ts
+++ b/build/lib/optimize.ts
@@ -137,7 +137,7 @@ function bundleESMTask(opts: IBundleESMTaskOpts): NodeJS.ReadWriteStream {
 				format: 'esm',
 				sourcemap: 'external',
 				plugins: [contentsMapper, externalOverride],
-				target: ['es2022'],
+				target: ['es2024'],
 				loader: {
 					'.ttf': 'file',
 					'.svg': 'file',
@@ -240,7 +240,7 @@ export function minifyTask(src: string, sourceMapBaseUrl?: string): (cb: any) =>
 					outdir: '.',
 					packages: 'external', // "external all the things", see https://esbuild.github.io/api/#packages
 					platform: 'neutral', // makes esm
-					target: ['es2022'],
+					target: ['es2024'],
 					write: false,
 				}).then(res => {
 					const jsOrCSSFile = res.outputFiles.find(f => /\.(js|css)$/.test(f.path))!;


### PR DESCRIPTION
Our `tsconfig.json` is using ES2024

fyi @mjbvz @jrieken 
