### PR TITLE
Revert "Debugging web server + edge shows odd coloring in chat input (fix #273973)"

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/media/chat.css
@@ -1280,7 +1280,7 @@ have to be updated for changes to the rules above, or to support more deeply nes
 
 .interactive-session .interactive-input-part .chat-editor-container .interactive-input-editor .monaco-editor,
 .interactive-session .interactive-input-part .chat-editor-container .interactive-input-editor .monaco-editor .monaco-editor-background {
-	background-color: var(--vscode-input-background) !important;
+	background-color: var(--vscode-input-background);
 }
 
 .interactive-session .interactive-input-part.editing .chat-input-container .chat-editor-container .monaco-editor,


### PR DESCRIPTION
Reverts microsoft/vscode#274051

because of:

<img width="304" height="168" alt="image" src="https://github.com/user-attachments/assets/57bc7f26-cad0-4c12-a8b9-0e611d052f12" />
