### PR TITLE
Use case-insensitive glob API

### DIFF
--- a/src/vs/workbench/contrib/notebook/common/notebookCommon.ts
+++ b/src/vs/workbench/contrib/notebook/common/notebookCommon.ts
@@ -693,15 +693,15 @@ export class MimeTypeDisplayOrder {
 	) {
 		this.order = [...new Set(initialValue)].map(pattern => ({
 			pattern,
-			matches: glob.parse(normalizeSlashes(pattern))
+			matches: glob.parse(normalizeSlashes(pattern), { ignoreCase: true })
 		}));
 	}
 
 	/**
-	 * Returns a sorted array of the input mimetypes.
+	 * Returns a sorted array of the input mimeTypes.
 	 */
-	public sort(mimetypes: Iterable<string>): string[] {
-		const remaining = new Map(Iterable.map(mimetypes, m => [m, normalizeSlashes(m)]));
+	public sort(mimeTypes: Iterable<string>): string[] {
+		const remaining = new Map(Iterable.map(mimeTypes, m => [m, normalizeSlashes(m)]));
 		let sorted: string[] = [];
 
 		for (const { matches } of this.order) {
@@ -725,21 +725,21 @@ export class MimeTypeDisplayOrder {
 
 	/**
 	 * Records that the user selected the given mimetype over the other
-	 * possible mimetypes, prioritizing it for future reference.
+	 * possible mimeTypes, prioritizing it for future reference.
 	 */
-	public prioritize(chosenMimetype: string, otherMimetypes: readonly string[]) {
+	public prioritize(chosenMimetype: string, otherMimeTypes: readonly string[]) {
 		const chosenIndex = this.findIndex(chosenMimetype);
 		if (chosenIndex === -1) {
 			// always first, nothing more to do
-			this.order.unshift({ pattern: chosenMimetype, matches: glob.parse(normalizeSlashes(chosenMimetype)) });
+			this.order.unshift({ pattern: chosenMimetype, matches: glob.parse(normalizeSlashes(chosenMimetype), { ignoreCase: true }) });
 			return;
 		}
 
-		// Get the other mimetypes that are before the chosenMimetype. Then, move
+		// Get the other mimeTypes that are before the chosenMimetype. Then, move
 		// them after it, retaining order.
-		const uniqueIndicies = new Set(otherMimetypes.map(m => this.findIndex(m, chosenIndex)));
-		uniqueIndicies.delete(-1);
-		const otherIndices = Array.from(uniqueIndicies).sort();
+		const uniqueIndices = new Set(otherMimeTypes.map(m => this.findIndex(m, chosenIndex)));
+		uniqueIndices.delete(-1);
+		const otherIndices = Array.from(uniqueIndices).sort();
 		this.order.splice(chosenIndex + 1, 0, ...otherIndices.map(i => this.order[i]));
 
 		for (let oi = otherIndices.length - 1; oi >= 0; oi--) {
@@ -954,11 +954,10 @@ export function notebookDocumentFilterMatch(filter: INotebookDocumentFilter, vie
 		const filenamePattern = isDocumentExcludePattern(filter.filenamePattern) ? filter.filenamePattern.include : (filter.filenamePattern as string | glob.IRelativePattern);
 		const excludeFilenamePattern = isDocumentExcludePattern(filter.filenamePattern) ? filter.filenamePattern.exclude : undefined;
 
-		if (glob.match(filenamePattern, basename(resource.fsPath).toLowerCase())) {
+		if (glob.match(filenamePattern, basename(resource.fsPath), { ignoreCase: true })) {
 			if (excludeFilenamePattern) {
-				if (glob.match(excludeFilenamePattern, basename(resource.fsPath).toLowerCase())) {
+				if (glob.match(excludeFilenamePattern, basename(resource.fsPath), { ignoreCase: true })) {
 					// should exclude
-
 					return false;
 				}
 			}

--- a/src/vs/workbench/contrib/notebook/common/notebookOutputRenderer.ts
+++ b/src/vs/workbench/contrib/notebook/common/notebookOutputRenderer.ts
@@ -72,7 +72,7 @@ export class NotebookOutputRendererInfo implements INotebookRendererInfo {
 
 		this.displayName = descriptor.displayName;
 		this.mimeTypes = descriptor.mimeTypes;
-		this.mimeTypeGlobs = this.mimeTypes.map(pattern => glob.parse(pattern));
+		this.mimeTypeGlobs = this.mimeTypes.map(pattern => glob.parse(pattern, { ignoreCase: true }));
 		this.hardDependencies = new DependencyList(descriptor.dependencies ?? Iterable.empty());
 		this.optionalDependencies = new DependencyList(descriptor.optionalDependencies ?? Iterable.empty());
 		this.messaging = descriptor.requiresMessaging ?? RendererMessagingSpec.Never;

--- a/src/vs/workbench/contrib/notebook/common/notebookProvider.ts
+++ b/src/vs/workbench/contrib/notebook/common/notebookProvider.ts
@@ -77,15 +77,8 @@ export class NotebookProviderInfo {
 	}
 
 	static selectorMatches(selector: NotebookSelector, resource: URI): boolean {
-		if (typeof selector === 'string') {
-			// filenamePattern
-			if (glob.match(selector.toLowerCase(), basename(resource.fsPath).toLowerCase())) {
-				return true;
-			}
-		}
-
-		if (glob.isRelativePattern(selector)) {
-			if (glob.match(selector, basename(resource.fsPath).toLowerCase())) {
+		if (typeof selector === 'string' || glob.isRelativePattern(selector)) {
+			if (glob.match(selector, basename(resource.fsPath), { ignoreCase: true })) {
 				return true;
 			}
 		}
@@ -97,9 +90,9 @@ export class NotebookProviderInfo {
 		const filenamePattern = selector.include;
 		const excludeFilenamePattern = selector.exclude;
 
-		if (glob.match(filenamePattern, basename(resource.fsPath).toLowerCase())) {
+		if (glob.match(filenamePattern, basename(resource.fsPath), { ignoreCase: true })) {
 			if (excludeFilenamePattern) {
-				if (glob.match(excludeFilenamePattern, basename(resource.fsPath).toLowerCase())) {
+				if (glob.match(excludeFilenamePattern, basename(resource.fsPath), { ignoreCase: true })) {
 					return false;
 				}
 			}

--- a/src/vs/workbench/services/editor/common/editorResolverService.ts
+++ b/src/vs/workbench/services/editor/common/editorResolverService.ts
@@ -164,7 +164,7 @@ export interface IEditorResolverService {
 	): IDisposable;
 
 	/**
-	 * Given an editor resolves it to the suitable ResolvedEitor based on user extensions, settings, and built-in editors
+	 * Given an editor resolves it to the suitable ResolvedEditor based on user extensions, settings, and built-in editors
 	 * @param editor The editor to resolve
 	 * @param preferredGroup The group you want to open the editor in
 	 * @returns An EditorInputWithOptionsAndGroup if there is an available editor or a status of how to proceed
@@ -220,6 +220,6 @@ export function globMatchesResource(globPattern: string | glob.IRelativePattern,
 	}
 	const matchOnPath = typeof globPattern === 'string' && globPattern.indexOf(posix.sep) >= 0;
 	const target = matchOnPath ? `${resource.scheme}:${resource.path}` : basename(resource);
-	return glob.match(typeof globPattern === 'string' ? globPattern.toLowerCase() : globPattern, target.toLowerCase());
+	return glob.match(globPattern, target, { ignoreCase: true });
 }
 //#endregion

--- a/src/vs/workbench/services/label/common/labelService.ts
+++ b/src/vs/workbench/services/label/common/labelService.ts
@@ -192,8 +192,7 @@ export class LabelService extends Disposable implements ILabelService {
 					continue;
 				}
 
-				if (
-					match(formatter.authority.toLowerCase(), resource.authority.toLowerCase()) &&
+				if (match(formatter.authority, resource.authority, { ignoreCase: true }) &&
 					(
 						!bestResult ||
 						!bestResult.authority ||


### PR DESCRIPTION
Follow up on case-insensitive glob support change:
- Updated places where `toLowercase()` was used in place of case-sensitive glob to use the new API
- Update MIME type pattern matching to use case-insensitive glob since MIME types are not case sensitive
- Minor spelling corrections

Contributes towards fixing #10633.