### PR TITLE
Convert ChatService to use uris instead of ids in public apis

### DIFF
--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -1389,8 +1389,6 @@ export type IChatAgentHistoryEntryDto = {
 };
 
 export interface IChatSessionContextDto {
-	readonly chatSessionType: string;
-	readonly chatSessionId: string;
 	readonly chatSessionResource: UriComponents;
 	readonly isUntitled: boolean;
 }

--- a/src/vs/workbench/contrib/chat/browser/actions/chatActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatActions.ts
@@ -236,7 +236,7 @@ abstract class OpenChatGlobalAction extends Action2 {
 
 		if (opts?.previousRequests?.length && chatWidget.viewModel) {
 			for (const { request, response } of opts.previousRequests) {
-				chatService.addCompleteRequest(chatWidget.viewModel.sessionId, request, undefined, 0, { message: response });
+				chatService.addCompleteRequest(chatWidget.viewModel.sessionResource, request, undefined, 0, { message: response });
 			}
 		}
 		if (opts?.attachScreenshot) {

--- a/src/vs/workbench/contrib/chat/browser/actions/chatCodeblockActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatCodeblockActions.ts
@@ -160,7 +160,7 @@ export function registerChatCodeBlockActions() {
 				chatService.notifyUserAction({
 					agentId: context.element.agent?.id,
 					command: context.element.slashCommand?.name,
-					sessionId: context.element.sessionId,
+					sessionResource: context.element.sessionResource,
 					requestId: context.element.requestId,
 					result: context.element.result,
 					action: {
@@ -227,7 +227,7 @@ export function registerChatCodeBlockActions() {
 			chatService.notifyUserAction({
 				agentId: element.agent?.id,
 				command: element.slashCommand?.name,
-				sessionId: element.sessionId,
+				sessionResource: element.sessionResource,
 				requestId: element.requestId,
 				result: element.result,
 				action: {
@@ -386,7 +386,7 @@ export function registerChatCodeBlockActions() {
 				chatService.notifyUserAction({
 					agentId: context.element.agent?.id,
 					command: context.element.slashCommand?.name,
-					sessionId: context.element.sessionId,
+					sessionResource: context.element.sessionResource,
 					requestId: context.element.requestId,
 					result: context.element.result,
 					action: {
@@ -488,7 +488,7 @@ export function registerChatCodeBlockActions() {
 				chatService.notifyUserAction({
 					agentId: context.element.agent?.id,
 					command: context.element.slashCommand?.name,
-					sessionId: context.element.sessionId,
+					sessionResource: context.element.sessionResource,
 					requestId: context.element.requestId,
 					result: context.element.result,
 					action: {

--- a/src/vs/workbench/contrib/chat/browser/actions/chatExecuteActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatExecuteActions.ts
@@ -65,7 +65,7 @@ abstract class SubmitAction extends Action2 {
 			const configurationService = accessor.get(IConfigurationService);
 			const dialogService = accessor.get(IDialogService);
 			const chatService = accessor.get(IChatService);
-			const chatModel = chatService.getSession(widget.viewModel.sessionId);
+			const chatModel = chatService.getSession(widget.viewModel.sessionResource);
 			if (!chatModel) {
 				return;
 			}
@@ -679,7 +679,7 @@ export class CreateRemoteAgentJobAction extends Action2 {
 		chatSessionsService: IChatSessionsService,
 		chatService: IChatService,
 		quickPickService: IQuickInputService,
-		sessionId: string,
+		sessionResource: URI,
 		attachedContext: ChatRequestVariableSet,
 		userPrompt: string,
 		chatSummary?: {
@@ -687,7 +687,7 @@ export class CreateRemoteAgentJobAction extends Action2 {
 			history?: string;
 		}
 	) {
-		await chatService.sendRequest(sessionId, userPrompt, {
+		await chatService.sendRequest(sessionResource, userPrompt, {
 			agentIdSilent: targetAgentId,
 			attachedContext: attachedContext.asArray(),
 			chatSummary,
@@ -802,6 +802,7 @@ export class CreateRemoteAgentJobAction extends Action2 {
 				return;
 			}
 
+			const sessionResource = widget.viewModel.sessionResource;
 			const chatRequests = chatModel.getRequests();
 			let userPrompt = widget.getInput();
 			if (!userPrompt) {
@@ -880,7 +881,7 @@ export class CreateRemoteAgentJobAction extends Action2 {
 			const { type } = agent;
 
 			// Add the request to the model first
-			const parsedRequest = requestParser.parseChatRequest(sessionId, userPrompt, ChatAgentLocation.Chat);
+			const parsedRequest = requestParser.parseChatRequest(sessionResource, userPrompt, ChatAgentLocation.Chat);
 			const addedRequest = chatModel.addRequest(
 				parsedRequest,
 				{ variables: attachedContext.asArray() },
@@ -955,13 +956,13 @@ export class CreateRemoteAgentJobAction extends Action2 {
 
 			const isChatSessionsExperimentEnabled = configurationService.getValue<boolean>(ChatConfiguration.UseCloudButtonV2);
 			if (isChatSessionsExperimentEnabled) {
-				await chatService.removeRequest(sessionId, addedRequest.id);
+				await chatService.removeRequest(sessionResource, addedRequest.id);
 				return await this.createWithChatSessions(
 					type,
 					chatSessionsService,
 					chatService,
 					quickPickService,
-					sessionId,
+					sessionResource,
 					attachedContext,
 					userPrompt,
 					{
@@ -1181,7 +1182,7 @@ export class CancelAction extends Action2 {
 
 		const chatService = accessor.get(IChatService);
 		if (widget.viewModel) {
-			chatService.cancelCurrentRequestForSession(widget.viewModel.sessionId);
+			chatService.cancelCurrentRequestForSession(widget.viewModel.sessionResource);
 		}
 	}
 }

--- a/src/vs/workbench/contrib/chat/browser/actions/chatImportExport.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatImportExport.ts
@@ -57,7 +57,7 @@ export function registerChatExportActions() {
 				outputPath = result;
 			}
 
-			const model = chatService.getSession(widget.viewModel.sessionId);
+			const model = chatService.getSession(widget.viewModel.sessionResource);
 			if (!model) {
 				return;
 			}

--- a/src/vs/workbench/contrib/chat/browser/actions/chatTitleActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatTitleActions.ts
@@ -22,6 +22,7 @@ import { NOTEBOOK_IS_ACTIVE_EDITOR } from '../../../notebook/common/notebookCont
 import { ChatContextKeys } from '../../common/chatContextKeys.js';
 import { applyingChatEditsFailedContextKey, isChatEditingActionContext } from '../../common/chatEditingService.js';
 import { ChatAgentVoteDirection, ChatAgentVoteDownReason, IChatService } from '../../common/chatService.js';
+import { LocalChatSessionUri } from '../../common/chatUri.js';
 import { isResponseVM } from '../../common/chatViewModel.js';
 import { ChatModeKind } from '../../common/constants.js';
 import { IChatWidgetService } from '../chat.js';
@@ -64,7 +65,7 @@ export function registerChatTitleActions() {
 			chatService.notifyUserAction({
 				agentId: item.agent?.id,
 				command: item.slashCommand?.name,
-				sessionId: item.sessionId,
+				sessionResource: item.session.sessionResource,
 				requestId: item.requestId,
 				result: item.result,
 				action: {
@@ -119,7 +120,7 @@ export function registerChatTitleActions() {
 			chatService.notifyUserAction({
 				agentId: item.agent?.id,
 				command: item.slashCommand?.name,
-				sessionId: item.sessionId,
+				sessionResource: item.session.sessionResource,
 				requestId: item.requestId,
 				result: item.result,
 				action: {
@@ -163,7 +164,7 @@ export function registerChatTitleActions() {
 			chatService.notifyUserAction({
 				agentId: item.agent?.id,
 				command: item.slashCommand?.name,
-				sessionId: item.sessionId,
+				sessionResource: item.session.sessionResource,
 				requestId: item.requestId,
 				result: item.result,
 				action: {
@@ -212,7 +213,7 @@ export function registerChatTitleActions() {
 			}
 
 			const chatService = accessor.get(IChatService);
-			const chatModel = chatService.getSession(item.sessionId);
+			const chatModel = chatService.getSession(LocalChatSessionUri.forSession(item.sessionId));
 			const chatRequests = chatModel?.getRequests();
 			if (!chatRequests) {
 				return;

--- a/src/vs/workbench/contrib/chat/browser/actions/codeBlockOperations.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/codeBlockOperations.ts
@@ -432,7 +432,7 @@ function notifyUserAction(chatService: IChatService, context: ICodeBlockActionCo
 		chatService.notifyUserAction({
 			agentId: context.element.agent?.id,
 			command: context.element.slashCommand?.name,
-			sessionId: context.element.sessionId,
+			sessionResource: context.element.sessionResource,
 			requestId: context.element.requestId,
 			result: context.element.result,
 			action

--- a/src/vs/workbench/contrib/chat/browser/chat.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.ts
@@ -49,6 +49,7 @@ export interface IChatWidgetService {
 	getAllWidgets(): ReadonlyArray<IChatWidget>;
 	getWidgetByInputUri(uri: URI): IChatWidget | undefined;
 	getWidgetBySessionId(sessionId: string): IChatWidget | undefined;
+	getWidgetBySessionResource(sessionResource: URI): IChatWidget | undefined;
 	getWidgetsByLocations(location: ChatAgentLocation): ReadonlyArray<IChatWidget>;
 }
 

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/chatChangesSummaryPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/chatChangesSummaryPart.ts
@@ -31,6 +31,7 @@ import { IEditorGroupsService } from '../../../../services/editor/common/editorG
 import { Emitter } from '../../../../../base/common/event.js';
 import { IHoverService } from '../../../../../platform/hover/browser/hover.js';
 import { localize2 } from '../../../../../nls.js';
+import { LocalChatSessionUri } from '../../common/chatUri.js';
 
 export class ChatCheckpointFileChangesSummaryContentPart extends Disposable implements IChatContentPart {
 
@@ -83,7 +84,7 @@ export class ChatCheckpointFileChangesSummaryContentPart extends Disposable impl
 			const lastRequestId = changes[changes.length - 1].requestId;
 			for (const change of changes) {
 				const sessionId = change.sessionId;
-				const session = this.chatService.getSession(sessionId);
+				const session = this.chatService.getSession(LocalChatSessionUri.forSession(sessionId));
 				if (!session || !session.editingSessionObs) {
 					continue;
 				}

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/chatConfirmationContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/chatConfirmationContentPart.ts
@@ -60,7 +60,7 @@ export class ChatConfirmationContentPart extends Disposable implements IChatCont
 				options.location = widget?.location;
 				Object.assign(options, widget?.getModeRequestOptions());
 
-				if (await this.chatService.sendRequest(element.sessionId, prompt, options)) {
+				if (await this.chatService.sendRequest(element.sessionResource, prompt, options)) {
 					confirmation.isUsed = true;
 					confirmationWidget.setShowButtons(false);
 					this._onDidChangeHeight.fire();

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/chatErrorConfirmationPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/chatErrorConfirmationPart.ts
@@ -62,7 +62,7 @@ export class ChatErrorConfirmationContentPart extends Disposable implements ICha
 				const widget = chatWidgetService.getWidgetBySessionId(element.sessionId);
 				options.userSelectedModelId = widget?.input.currentLanguageModel;
 				Object.assign(options, widget?.getModeRequestOptions());
-				if (await chatService.sendRequest(element.sessionId, prompt, options)) {
+				if (await chatService.sendRequest(element.sessionResource, prompt, options)) {
 					this._onDidChangeHeight.fire();
 				}
 			}));

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/chatMarkdownContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/chatMarkdownContentPart.ts
@@ -220,7 +220,7 @@ export class ChatMarkdownContentPart extends Disposable implements IChatContentP
 						return ref.object.element;
 					} else {
 						const requestId = isRequestVM(element) ? element.id : element.requestId;
-						const ref = this.renderCodeBlockPill(element.sessionId, requestId, inUndoStop, codeBlockInfo.codemapperUri);
+						const ref = this.renderCodeBlockPill(element.sessionId, element.sessionResource, requestId, inUndoStop, codeBlockInfo.codemapperUri);
 						if (isResponseVM(codeBlockInfo.element)) {
 							// TODO@joyceerhl: remove this code when we change the codeblockUri API to make the URI available synchronously
 							this.codeBlockModelCollection.update(codeBlockInfo.element.sessionId, codeBlockInfo.element, codeBlockInfo.codeBlockIndex, { text, languageId: codeBlockInfo.languageId, isComplete: isCodeBlockComplete }).then((e) => {
@@ -322,8 +322,8 @@ export class ChatMarkdownContentPart extends Disposable implements IChatContentP
 		}
 	}
 
-	private renderCodeBlockPill(sessionId: string, requestId: string, inUndoStop: string | undefined, codemapperUri: URI | undefined): IDisposableReference<CollapsedCodeBlock> {
-		const codeBlock = this.instantiationService.createInstance(CollapsedCodeBlock, sessionId, requestId, inUndoStop);
+	private renderCodeBlockPill(sessionId: string, sessionResource: URI, requestId: string, inUndoStop: string | undefined, codemapperUri: URI | undefined): IDisposableReference<CollapsedCodeBlock> {
+		const codeBlock = this.instantiationService.createInstance(CollapsedCodeBlock, sessionId, sessionResource, requestId, inUndoStop);
 		if (codemapperUri) {
 			codeBlock.render(codemapperUri);
 		}
@@ -432,6 +432,7 @@ export class CollapsedCodeBlock extends Disposable {
 
 	constructor(
 		private readonly sessionId: string,
+		private readonly sessionResource: URI,
 		private readonly requestId: string,
 		private readonly inUndoStop: string | undefined,
 		@ILabelService private readonly labelService: ILabelService,
@@ -501,7 +502,7 @@ export class CollapsedCodeBlock extends Disposable {
 
 		this._uri = uri;
 
-		const session = this.chatService.getSession(this.sessionId);
+		const session = this.chatService.getSession(this.sessionResource);
 		const iconText = this.labelService.getUriBasenameLabel(uri);
 
 		const iconEl = dom.$('span.icon');

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/chatTextEditContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/chatTextEditContentPart.ts
@@ -210,7 +210,7 @@ class CodeCompareModelService implements ICodeCompareModelService {
 		}
 
 		// apply edits to the "modified" model
-		const chatModel = this.chatService.getSession(element.sessionId)!;
+		const chatModel = this.chatService.getSession(element.sessionResource)!;
 		const editGroups: ISingleEditOperation[][] = [];
 		for (const request of chatModel.getRequests()) {
 			if (!request.response) {

--- a/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingEditorActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingEditorActions.ts
@@ -21,6 +21,7 @@ import { MultiDiffEditorInput } from '../../../multiDiffEditor/browser/multiDiff
 import { NOTEBOOK_CELL_LIST_FOCUSED, NOTEBOOK_EDITOR_FOCUSED } from '../../../notebook/common/notebookContextKeys.js';
 import { ChatContextKeys } from '../../common/chatContextKeys.js';
 import { CHAT_EDITING_MULTI_DIFF_SOURCE_RESOLVER_SCHEME, IChatEditingService, IChatEditingSession, IModifiedFileEntry, IModifiedFileEntryChangeHunk, IModifiedFileEntryEditorIntegration, ModifiedFileEntryState } from '../../common/chatEditingService.js';
+import { LocalChatSessionUri } from '../../common/chatUri.js';
 import { CHAT_CATEGORY } from '../actions/chatActions.js';
 import { ctxHasEditorModification, ctxIsCurrentlyBeingModified, ctxIsGlobalEditingSession, ctxReviewModeEnabled } from './chatEditingEditorContextKeys.js';
 
@@ -422,7 +423,7 @@ abstract class MultiDiffAcceptDiscardAction extends Action2 {
 			return;
 		}
 
-		const session = chatEditingService.getEditingSession(editor.resource.authority);
+		const session = chatEditingService.getEditingSession(LocalChatSessionUri.forSession(editor.resource.authority));
 		if (this.accept) {
 			await session?.accept();
 		} else {

--- a/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingEditorContextKeys.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingEditorContextKeys.ts
@@ -115,7 +115,7 @@ class ContextKeyGroup {
 
 			const { session, entry } = tuple;
 
-			const chatModel = chatService.getSession(session.chatSessionId);
+			const chatModel = chatService.getSession(session.chatSessionResource);
 
 			this._ctxHasEditorModification.set(entry?.state.read(r) === ModifiedFileEntryState.Modified);
 			this._ctxIsGlobalEditingSession.set(session.isGlobalEditingSession);

--- a/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingEditorOverlay.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingEditorOverlay.ts
@@ -66,7 +66,7 @@ class ChatEditorOverlayWidget extends Disposable {
 		const requestMessage = derived(r => {
 
 			const session = this._session.read(r);
-			const chatModel = this._chatService.getSession(session?.chatSessionId ?? '');
+			const chatModel = session?.chatSessionResource && this._chatService.getSession(session?.chatSessionResource);
 			if (!session || !chatModel) {
 				return undefined;
 			}
@@ -375,7 +375,7 @@ class ChatEditingOverlayController {
 				return false;
 			}
 
-			const chatModel = chatService.getSession(session.chatSessionId)!;
+			const chatModel = chatService.getSession(session.chatSessionResource)!;
 			return chatModel.requestInProgressObs.read(r);
 		});
 

--- a/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingModifiedFileEntry.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingModifiedFileEntry.ts
@@ -26,6 +26,7 @@ import { ICellEditOperation } from '../../../notebook/common/notebookCommon.js';
 import { ChatEditKind, IModifiedEntryTelemetryInfo, IModifiedFileEntry, IModifiedFileEntryEditorIntegration, ISnapshotEntry, ModifiedFileEntryState } from '../../common/chatEditingService.js';
 import { IChatResponseModel } from '../../common/chatModel.js';
 import { ChatUserAction, IChatService } from '../../common/chatService.js';
+import { LocalChatSessionUri } from '../../common/chatUri.js';
 
 class AutoAcceptControl {
 	constructor(
@@ -296,7 +297,7 @@ export abstract class AbstractChatEditingModifiedFileEntry extends Disposable im
 			modelId: this._telemetryInfo.modelId,
 			modeId: this._telemetryInfo.modeId,
 			command: this._telemetryInfo.command,
-			sessionId: this._telemetryInfo.sessionId,
+			sessionResource: LocalChatSessionUri.forSession(this._telemetryInfo.sessionId),
 			requestId: this._telemetryInfo.requestId,
 			result: this._telemetryInfo.result
 		});

--- a/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingServiceImpl.ts
@@ -90,7 +90,7 @@ export class ChatEditingService extends Disposable implements IChatEditingServic
 
 		this._register(this._chatService.onDidDisposeSession((e) => {
 			if (e.reason === 'cleared') {
-				this.getEditingSession(e.sessionId)?.stop();
+				this.getEditingSession(e.sessionResource)?.stop();
 			}
 		}));
 
@@ -143,7 +143,7 @@ export class ChatEditingService extends Disposable implements IChatEditingServic
 			await this._restoringEditingSession;
 		}
 
-		const session = this.getEditingSession(chatModel.sessionId);
+		const session = this.getEditingSession(chatModel.sessionResource);
 		if (session) {
 			return session;
 		}
@@ -164,16 +164,16 @@ export class ChatEditingService extends Disposable implements IChatEditingServic
 		return undefined;
 	}
 
-	getEditingSession(chatSessionId: string): IChatEditingSession | undefined {
+	getEditingSession(chatSessionResource: URI): IChatEditingSession | undefined {
 		return this.editingSessionsObs.get()
-			.find(candidate => candidate.chatSessionId === chatSessionId);
+			.find(candidate => isEqual(candidate.chatSessionResource, chatSessionResource));
 	}
 
 	async createEditingSession(chatModel: ChatModel, global: boolean = false): Promise<IChatEditingSession> {
 
-		assertType(this.getEditingSession(chatModel.sessionId) === undefined, 'CANNOT have more than one editing session per chat session');
+		assertType(this.getEditingSession(chatModel.sessionResource) === undefined, 'CANNOT have more than one editing session per chat session');
 
-		const session = this._instantiationService.createInstance(ChatEditingSession, chatModel.sessionId, global, this._lookupEntry.bind(this));
+		const session = this._instantiationService.createInstance(ChatEditingSession, chatModel.sessionId, chatModel.sessionResource, global, this._lookupEntry.bind(this));
 		await session.init();
 
 		const list = this._sessionsObs.get();

--- a/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingSession.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingSession.ts
@@ -166,6 +166,7 @@ export class ChatEditingSession extends Disposable implements IChatEditingSessio
 
 	constructor(
 		readonly chatSessionId: string,
+		readonly chatSessionResource: URI,
 		readonly isGlobalEditingSession: boolean,
 		private _lookupExternalEntry: (uri: URI) => AbstractChatEditingModifiedFileEntry | undefined,
 		@IInstantiationService private readonly _instantiationService: IInstantiationService,
@@ -193,7 +194,7 @@ export class ChatEditingSession extends Disposable implements IChatEditingSessio
 
 		this._register(autorun(reader => {
 			const disabled = this._timeline.requestDisablement.read(reader);
-			this._chatService.getSession(this.chatSessionId)?.setDisabledRequests(disabled);
+			this._chatService.getSession(this.chatSessionResource)?.setDisabledRequests(disabled);
 		}));
 	}
 
@@ -430,7 +431,7 @@ export class ChatEditingSession extends Disposable implements IChatEditingSessio
 	override dispose() {
 		this._assertNotDisposed();
 
-		this._chatService.cancelCurrentRequestForSession(this.chatSessionId);
+		this._chatService.cancelCurrentRequestForSession(this.chatSessionResource);
 
 		dispose(this._entriesObs.get());
 		super.dispose();

--- a/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingTextModelContentProviders.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingTextModelContentProviders.ts
@@ -9,6 +9,7 @@ import { ITextModel } from '../../../../../editor/common/model.js';
 import { IModelService } from '../../../../../editor/common/services/model.js';
 import { ITextModelContentProvider } from '../../../../../editor/common/services/resolverService.js';
 import { IChatEditingService } from '../../common/chatEditingService.js';
+import { LocalChatSessionUri } from '../../common/chatUri.js';
 
 type ChatEditingTextModelContentQueryData = { kind: 'doc'; documentId: string; chatSessionId: string };
 
@@ -36,7 +37,7 @@ export class ChatEditingTextModelContentProvider implements ITextModelContentPro
 
 		const data: ChatEditingTextModelContentQueryData = JSON.parse(resource.query);
 
-		const session = this._chatEditingService.getEditingSession(data.chatSessionId);
+		const session = this._chatEditingService.getEditingSession(LocalChatSessionUri.forSession(data.chatSessionId));
 
 		const entry = session?.entries.get().find(candidate => candidate.entryId === data.documentId);
 		if (!entry) {
@@ -70,7 +71,7 @@ export class ChatEditingSnapshotTextModelContentProvider implements ITextModelCo
 		}
 
 		const data: ChatEditingSnapshotTextModelContentQueryData = JSON.parse(resource.query);
-		const session = this._chatEditingService.getEditingSession(data.sessionId);
+		const session = this._chatEditingService.getEditingSession(LocalChatSessionUri.forSession(data.sessionId));
 		if (!session || !data.requestId) {
 			return null;
 		}

--- a/src/vs/workbench/contrib/chat/browser/chatEditing/notebook/chatEditingNotebookFileSystemProvider.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditing/notebook/chatEditingNotebookFileSystemProvider.ts
@@ -14,6 +14,7 @@ import { FileSystemProviderCapabilities, FileType, IFileChange, IFileDeleteOptio
 import { IInstantiationService } from '../../../../../../platform/instantiation/common/instantiation.js';
 import { IWorkbenchContribution } from '../../../../../common/contributions.js';
 import { IChatEditingService } from '../../../common/chatEditingService.js';
+import { LocalChatSessionUri } from '../../../common/chatUri.js';
 import { ChatEditingNotebookSnapshotScheme } from './chatEditingModifiedNotebookSnapshot.js';
 
 
@@ -85,7 +86,7 @@ export class ChatEditingNotebookFileSystemProvider implements IFileSystemProvide
 		if (!queryData.viewType) {
 			throw new Error('File not found, viewType not found');
 		}
-		const session = this._chatEditingService.getEditingSession(queryData.sessionId);
+		const session = this._chatEditingService.getEditingSession(LocalChatSessionUri.forSession(queryData.sessionId));
 		if (!session || !queryData.requestId) {
 			throw new Error('File not found, session not found');
 		}

--- a/src/vs/workbench/contrib/chat/browser/chatEditorInput.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditorInput.ts
@@ -262,13 +262,13 @@ export class ChatEditorInput extends EditorInput implements IEditorCloseHandler 
 		const chatSessionType = searchParams.get('chatSessionType');
 		const inputType = chatSessionType ?? this.resource.authority;
 
-		if (this.resource.scheme !== Schemas.vscodeChatEditor && this.resource.scheme !== Schemas.vscodeLocalChatSession) {
+		if (this.resource.scheme !== Schemas.vscodeChatEditor) {
 			this.model = await this.chatService.loadSessionForResource(this.resource, ChatAgentLocation.Chat, CancellationToken.None);
 		} else if (this._sessionInfo?.sessionId) {
 			this.model = await this.chatService.getOrRestoreSession(this._sessionInfo.resource)
-				?? this.chatService.startSession(ChatAgentLocation.Chat, CancellationToken.None, undefined, { canUseTools: false, inputType: inputType });
+				?? this.chatService.startSession(ChatAgentLocation.Chat, CancellationToken.None, undefined, { canUseTools: false });
 		} else if (!this.options.target) {
-			this.model = this.chatService.startSession(ChatAgentLocation.Chat, CancellationToken.None, undefined, { canUseTools: !inputType, inputType: inputType });
+			this.model = this.chatService.startSession(ChatAgentLocation.Chat, CancellationToken.None, undefined, { canUseTools: !inputType });
 		} else if ('data' in this.options.target) {
 			this.model = this.chatService.loadSessionFromContent(this.options.target.data);
 		}

--- a/src/vs/workbench/contrib/chat/browser/chatEditorInput.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditorInput.ts
@@ -101,8 +101,8 @@ export class ChatEditorInput extends EditorInput implements IEditorCloseHandler 
 
 		// Check if we already have a custom title for this session
 		const hasExistingCustomTitle = this._sessionInfo?.sessionId && (
-			this.chatService.getSession(this._sessionInfo?.sessionId)?.title ||
-			this.chatService.getPersistedSessionTitle(this._sessionInfo?.sessionId)?.trim()
+			this.chatService.getSession(this._sessionInfo?.resource)?.title ||
+			this.chatService.getPersistedSessionTitle(this._sessionInfo?.resource)?.trim()
 		);
 
 		this.hasCustomTitle = Boolean(hasExistingCustomTitle);
@@ -178,13 +178,13 @@ export class ChatEditorInput extends EditorInput implements IEditorCloseHandler 
 		// If we have a sessionId but no resolved model, try to get the title from persisted sessions
 		if (this._sessionInfo?.sessionId) {
 			// First try the active session registry
-			const existingSession = this.chatService.getSession(this._sessionInfo?.sessionId);
+			const existingSession = this.chatService.getSession(this._sessionInfo?.resource);
 			if (existingSession?.title) {
 				return existingSession.title;
 			}
 
 			// If not in active registry, try persisted session data
-			const persistedTitle = this.chatService.getPersistedSessionTitle(this._sessionInfo?.sessionId);
+			const persistedTitle = this.chatService.getPersistedSessionTitle(this._sessionInfo?.resource);
 			if (persistedTitle && persistedTitle.trim()) { // Only use non-empty persisted titles
 				return persistedTitle;
 			}
@@ -265,7 +265,7 @@ export class ChatEditorInput extends EditorInput implements IEditorCloseHandler 
 		if (this.resource.scheme !== Schemas.vscodeChatEditor && this.resource.scheme !== Schemas.vscodeLocalChatSession) {
 			this.model = await this.chatService.loadSessionForResource(this.resource, ChatAgentLocation.Chat, CancellationToken.None);
 		} else if (this._sessionInfo?.sessionId) {
-			this.model = await this.chatService.getOrRestoreSession(this._sessionInfo.sessionId)
+			this.model = await this.chatService.getOrRestoreSession(this._sessionInfo.resource)
 				?? this.chatService.startSession(ChatAgentLocation.Chat, CancellationToken.None, undefined, { canUseTools: false, inputType: inputType });
 		} else if (!this.options.target) {
 			this.model = this.chatService.startSession(ChatAgentLocation.Chat, CancellationToken.None, undefined, { canUseTools: !inputType, inputType: inputType });
@@ -319,8 +319,8 @@ export class ChatEditorInput extends EditorInput implements IEditorCloseHandler 
 	override dispose(): void {
 		super.dispose();
 
-		if (this._sessionInfo?.sessionId) {
-			this.chatService.clearSession(this._sessionInfo.sessionId);
+		if (this._sessionInfo) {
+			this.chatService.clearSession(this._sessionInfo.resource);
 		}
 	}
 }

--- a/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
@@ -655,11 +655,11 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 
 		// Helper to resolve chat session context
 		const resolveChatSessionContext = () => {
-			const sessionId = this._widget?.viewModel?.model.sessionId;
-			if (!sessionId) {
+			const sessionResource = this._widget?.viewModel?.model.sessionResource;
+			if (!sessionResource) {
 				return undefined;
 			}
-			return this.chatService.getChatSessionFromInternalId(sessionId);
+			return this.chatService.getChatSessionFromInternalUri(sessionResource);
 		};
 
 		// Get all option groups for the current session type
@@ -1141,16 +1141,16 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 	 * Fires events for each option group with their current selection.
 	 */
 	private refreshChatSessionPickers(): void {
-		const sessionId = this._widget?.viewModel?.model.sessionId;
+		const sessionResource = this._widget?.viewModel?.model.sessionResource;
 		const hideAll = () => {
 			this.chatSessionHasOptions.set(false);
 			this.hideAllSessionPickerWidgets();
 		};
 
-		if (!sessionId) {
+		if (!sessionResource) {
 			return hideAll();
 		}
-		const ctx = this.chatService.getChatSessionFromInternalId(sessionId);
+		const ctx = this.chatService.getChatSessionFromInternalUri(sessionResource);
 		if (!ctx) {
 			return hideAll();
 		}
@@ -1218,11 +1218,11 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 	 * If no option is currently set, initializes with the first item as default.
 	 */
 	private getCurrentOptionForGroup(optionGroupId: string): IChatSessionProviderOptionItem | undefined {
-		const sessionId = this._widget?.viewModel?.model.sessionId;
-		if (!sessionId) {
+		const sessionResource = this._widget?.viewModel?.model.sessionResource;
+		if (!sessionResource) {
 			return;
 		}
-		const ctx = this.chatService.getChatSessionFromInternalId(sessionId);
+		const ctx = this.chatService.getChatSessionFromInternalUri(sessionResource);
 		if (!ctx) {
 			return;
 		}

--- a/src/vs/workbench/contrib/chat/browser/chatMarkdownDecorationsRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatMarkdownDecorationsRenderer.ts
@@ -184,7 +184,7 @@ export class ChatMarkdownDecorationsRenderer {
 					return;
 				}
 
-				this.chatService.sendRequest(widget.viewModel!.sessionId, agent.metadata.sampleRequest ?? '',
+				this.chatService.sendRequest(widget.viewModel!.sessionResource, agent.metadata.sampleRequest ?? '',
 					{
 						location: widget.location,
 						agentId: agent.id,
@@ -221,7 +221,7 @@ export class ChatMarkdownDecorationsRenderer {
 			}
 
 			const command = agent.slashCommands.find(c => c.name === args.command);
-			this.chatService.sendRequest(widget.viewModel!.sessionId, command?.sampleRequest ?? '', {
+			this.chatService.sendRequest(widget.viewModel!.sessionResource, command?.sampleRequest ?? '', {
 				location: widget.location,
 				agentId: agent.id,
 				slashCommand: args.command,

--- a/src/vs/workbench/contrib/chat/browser/chatPasteProviders.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatPasteProviders.ts
@@ -212,7 +212,7 @@ class CopyAttachmentsProvider implements DocumentPasteEditProvider {
 		}
 
 		const attachments = widget.attachmentModel.attachments;
-		const dynamicVariables = this.chatVariableService.getDynamicVariables(widget.viewModel.sessionId);
+		const dynamicVariables = this.chatVariableService.getDynamicVariables(widget.viewModel.sessionResource);
 
 		if (attachments.length === 0 && dynamicVariables.length === 0) {
 			return undefined;

--- a/src/vs/workbench/contrib/chat/browser/chatQuick.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatQuick.ts
@@ -358,7 +358,7 @@ class QuickChat extends Disposable {
 					}
 				}
 
-				this.chatService.addCompleteRequest(widget.viewModel.sessionId,
+				this.chatService.addCompleteRequest(widget.viewModel.sessionResource,
 					request.message as IParsedChatRequest,
 					request.variableData,
 					request.attempt,

--- a/src/vs/workbench/contrib/chat/browser/chatSessions/chatSessionTracker.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSessions/chatSessionTracker.ts
@@ -90,8 +90,8 @@ export class ChatSessionTracker extends Disposable {
 			let status: ChatSessionStatus = ChatSessionStatus.Completed;
 			let timestamp: number | undefined;
 
-			if (editor.sessionId) {
-				const model = this.chatService.getSession(editor.sessionId);
+			if (editor.sessionResource) {
+				const model = this.chatService.getSession(editor.sessionResource);
 				const modelStatus = model ? this.modelToStatus(model) : undefined;
 				if (model && modelStatus) {
 					status = modelStatus;

--- a/src/vs/workbench/contrib/chat/browser/chatSessions/localChatSessionsProvider.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSessions/localChatSessionsProvider.ts
@@ -220,8 +220,8 @@ export class LocalChatSessionsProvider extends Disposable implements IChatSessio
 				// Determine status and timestamp for editor-based session
 				let status: ChatSessionStatus | undefined;
 				let startTime: number | undefined;
-				if (editorInfo.editor instanceof ChatEditorInput && editorInfo.editor.sessionId) {
-					const model = this.chatService.getSession(editorInfo.editor.sessionId);
+				if (editorInfo.editor instanceof ChatEditorInput && editorInfo.editor.sessionResource && editorInfo.editor.sessionId) {
+					const model = this.chatService.getSession(editorInfo.editor.sessionResource);
 					if (model) {
 						status = this.modelToStatus(model);
 						// Get the last interaction timestamp from the model

--- a/src/vs/workbench/contrib/chat/browser/chatVariables.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatVariables.ts
@@ -8,6 +8,7 @@ import { IToolAndToolSetEnablementMap } from '../common/languageModelToolsServic
 import { IChatWidgetService } from './chat.js';
 import { ChatDynamicVariableModel } from './contrib/chatDynamicVariables.js';
 import { Range } from '../../../../editor/common/core/range.js';
+import { URI } from '../../../../base/common/uri.js';
 
 export class ChatVariablesService implements IChatVariablesService {
 	declare _serviceBrand: undefined;
@@ -16,12 +17,12 @@ export class ChatVariablesService implements IChatVariablesService {
 		@IChatWidgetService private readonly chatWidgetService: IChatWidgetService,
 	) { }
 
-	getDynamicVariables(sessionId: string): ReadonlyArray<IDynamicVariable> {
+	getDynamicVariables(sessionResource: URI): ReadonlyArray<IDynamicVariable> {
 		// This is slightly wrong... the parser pulls dynamic references from the input widget, but there is no guarantee that message came from the input here.
 		// Need to ...
 		// - Parser takes list of dynamic references (annoying)
 		// - Or the parser is known to implicitly act on the input widget, and we need to call it before calling the chat service (maybe incompatible with the future, but easy)
-		const widget = this.chatWidgetService.getWidgetBySessionId(sessionId);
+		const widget = this.chatWidgetService.getWidgetBySessionResource(sessionResource);
 		if (!widget || !widget.viewModel || !widget.supportsFileReferences) {
 			return [];
 		}
@@ -56,13 +57,12 @@ export class ChatVariablesService implements IChatVariablesService {
 		return model.variables;
 	}
 
-	getSelectedToolAndToolSets(sessionId: string): IToolAndToolSetEnablementMap {
-		const widget = this.chatWidgetService.getWidgetBySessionId(sessionId);
+	getSelectedToolAndToolSets(sessionResource: URI): IToolAndToolSetEnablementMap {
+		const widget = this.chatWidgetService.getWidgetBySessionResource(sessionResource);
 		if (!widget) {
 			return new Map();
 		}
 		return widget.input.selectedToolsModel.entriesMap.get();
 
 	}
-
 }

--- a/src/vs/workbench/contrib/chat/browser/chatViewPane.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatViewPane.ts
@@ -84,7 +84,7 @@ export class ChatViewPane extends ViewPane implements IViewWelcomeDelegate {
 			const lastEditsState = editsMemento.getMemento(StorageScope.WORKSPACE, StorageTarget.MACHINE);
 			if (lastEditsState.sessionId) {
 				this.logService.trace(`ChatViewPane: last edits session was ${lastEditsState.sessionId}`);
-				if (!this.chatService.isPersistedSessionEmpty(lastEditsState.sessionId)) {
+				if (!this.chatService.isPersistedSessionEmpty(LocalChatSessionUri.forSession(lastEditsState.sessionId))) {
 					this.logService.info(`ChatViewPane: migrating ${lastEditsState.sessionId} to unified view`);
 					this.viewState.sessionId = lastEditsState.sessionId;
 					this.viewState.inputValue = lastEditsState.inputValue;
@@ -102,7 +102,7 @@ export class ChatViewPane extends ViewPane implements IViewWelcomeDelegate {
 				if (!this._widget?.viewModel && !this._restoringSession) {
 					const info = this.getTransferredOrPersistedSessionInfo();
 					this._restoringSession =
-						(info.sessionId ? this.chatService.getOrRestoreSession(info.sessionId) : Promise.resolve(undefined)).then(async model => {
+						(info.sessionId ? this.chatService.getOrRestoreSession(LocalChatSessionUri.forSession(info.sessionId)) : Promise.resolve(undefined)).then(async model => {
 							if (!this._widget) {
 								// renderBody has not been called yet
 								return;
@@ -141,7 +141,7 @@ export class ChatViewPane extends ViewPane implements IViewWelcomeDelegate {
 		this.modelDisposables.clear();
 
 		model = model ?? (this.chatService.transferredSessionData?.sessionId && this.chatService.transferredSessionData?.location === this.chatOptions.location
-			? await this.chatService.getOrRestoreSession(this.chatService.transferredSessionData.sessionId)
+			? await this.chatService.getOrRestoreSession(LocalChatSessionUri.forSession(this.chatService.transferredSessionData.sessionId))
 			: this.chatService.startSession(this.chatOptions.location, CancellationToken.None));
 		if (!model) {
 			throw new Error('Could not start chat session');
@@ -225,7 +225,7 @@ export class ChatViewPane extends ViewPane implements IViewWelcomeDelegate {
 		this._widget.render(parent);
 
 		const info = this.getTransferredOrPersistedSessionInfo();
-		const model = info.sessionId ? await this.chatService.getOrRestoreSession(info.sessionId) : undefined;
+		const model = info.sessionId ? await this.chatService.getOrRestoreSession(LocalChatSessionUri.forSession(info.sessionId)) : undefined;
 
 		await this.updateModel(model, info.inputValue || info.mode ? { inputState: { chatMode: info.mode }, inputValue: info.inputValue } : undefined);
 	}
@@ -236,7 +236,7 @@ export class ChatViewPane extends ViewPane implements IViewWelcomeDelegate {
 
 	private async clear(): Promise<void> {
 		if (this.widget.viewModel) {
-			await this.chatService.clearSession(this.widget.viewModel.sessionId);
+			await this.chatService.clearSession(this.widget.viewModel.sessionResource);
 		}
 
 		// Grab the widget's latest view state because it will be loaded back into the widget
@@ -249,7 +249,7 @@ export class ChatViewPane extends ViewPane implements IViewWelcomeDelegate {
 
 	async loadSession(sessionId: string | URI, viewState?: IChatViewState): Promise<void> {
 		if (this.widget.viewModel) {
-			await this.chatService.clearSession(this.widget.viewModel.sessionId);
+			await this.chatService.clearSession(this.widget.viewModel.sessionResource);
 		}
 
 		// Handle locking for contributed chat sessions
@@ -265,7 +265,7 @@ export class ChatViewPane extends ViewPane implements IViewWelcomeDelegate {
 			}
 		}
 
-		const newModel = await (URI.isUri(sessionId) ? this.chatService.loadSessionForResource(sessionId, ChatAgentLocation.Chat, CancellationToken.None) : this.chatService.getOrRestoreSession(sessionId));
+		const newModel = await (URI.isUri(sessionId) ? this.chatService.loadSessionForResource(sessionId, ChatAgentLocation.Chat, CancellationToken.None) : this.chatService.getOrRestoreSession(LocalChatSessionUri.forSession(sessionId)));
 		await this.updateModel(newModel, viewState);
 	}
 

--- a/src/vs/workbench/contrib/chat/browser/contrib/chatInputEditorContrib.ts
+++ b/src/vs/workbench/contrib/chat/browser/contrib/chatInputEditorContrib.ts
@@ -363,7 +363,7 @@ class ChatTokenDeleter extends Disposable {
 
 			// If this was a simple delete, try to find out whether it was inside a token
 			if (!change.text && this.widget.viewModel) {
-				const previousParsedValue = parser.parseChatRequest(this.widget.viewModel.sessionId, previousInputValue, widget.location, { selectedAgent: previousSelectedAgent, mode: this.widget.input.currentModeKind });
+				const previousParsedValue = parser.parseChatRequest(this.widget.viewModel.sessionResource, previousInputValue, widget.location, { selectedAgent: previousSelectedAgent, mode: this.widget.input.currentModeKind });
 
 				// For dynamic variables, this has to happen in ChatDynamicVariableModel with the other bookkeeping
 				const deletableTokens = previousParsedValue.parts.filter(p => p instanceof ChatRequestAgentPart || p instanceof ChatRequestAgentSubcommandPart || p instanceof ChatRequestSlashCommandPart || p instanceof ChatRequestSlashPromptPart || p instanceof ChatRequestToolPart);

--- a/src/vs/workbench/contrib/chat/browser/contrib/chatInputRelatedFilesContrib.ts
+++ b/src/vs/workbench/contrib/chat/browser/contrib/chatInputRelatedFilesContrib.ts
@@ -55,7 +55,7 @@ export class ChatRelatedFilesContribution extends Disposable implements IWorkben
 					return;
 				}
 
-				const currentEditingSession = this.chatEditingService.getEditingSession(widget.viewModel.sessionId);
+				const currentEditingSession = this.chatEditingService.getEditingSession(widget.viewModel.sessionResource);
 				if (!currentEditingSession || currentEditingSession.entries.get().length) {
 					return; // Might have disposed while we were calculating
 				}

--- a/src/vs/workbench/contrib/chat/browser/languageModelToolsService.ts
+++ b/src/vs/workbench/contrib/chat/browser/languageModelToolsService.ts
@@ -43,6 +43,7 @@ import { ChatRequestToolReferenceEntry, toToolSetVariableEntry, toToolVariableEn
 import { ChatConfiguration } from '../common/constants.js';
 import { CountTokensCallback, createToolSchemaUri, ILanguageModelToolsService, IPreparedToolInvocation, IToolAndToolSetEnablementMap, IToolData, IToolImpl, IToolInvocation, IToolResult, IToolResultInputOutputDetails, stringifyPromptTsxPart, ToolDataSource, ToolSet } from '../common/languageModelToolsService.js';
 import { getToolConfirmationAlert } from './chatAccessibilityProvider.js';
+import { LocalChatSessionUri } from '../common/chatUri.js';
 
 const jsonSchemaRegistry = Registry.as<JSONContributionRegistry.IJSONContributionRegistry>(JSONContributionRegistry.Extensions.JSONContribution);
 
@@ -284,7 +285,7 @@ export class LanguageModelToolsService extends Disposable implements ILanguageMo
 		try {
 			if (dto.context) {
 				store = new DisposableStore();
-				const model = this._chatService.getSession(dto.context?.sessionId) as ChatModel | undefined;
+				const model = this._chatService.getSession(LocalChatSessionUri.forSession(dto.context.sessionId)) as ChatModel | undefined;
 				if (!model) {
 					throw new Error(`Tool called for unknown chat session`);
 				}

--- a/src/vs/workbench/contrib/chat/common/chatEditingService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatEditingService.ts
@@ -30,7 +30,7 @@ export interface IChatEditingService {
 
 	startOrContinueGlobalEditingSession(chatModel: ChatModel): Promise<IChatEditingSession>;
 
-	getEditingSession(chatSessionId: string): IChatEditingSession | undefined;
+	getEditingSession(chatSessionResource: URI): IChatEditingSession | undefined;
 
 	/**
 	 * All editing sessions, sorted by recency, e.g the last created session comes first.
@@ -107,7 +107,9 @@ export interface ISnapshotEntry {
 
 export interface IChatEditingSession extends IDisposable {
 	readonly isGlobalEditingSession: boolean;
+	/** @deprecated */
 	readonly chatSessionId: string;
+	readonly chatSessionResource: URI;
 	readonly onDidDispose: Event<void>;
 	readonly state: IObservable<ChatEditingSessionState>;
 	readonly entries: IObservable<readonly IModifiedFileEntry[]>;

--- a/src/vs/workbench/contrib/chat/common/chatModel.ts
+++ b/src/vs/workbench/contrib/chat/common/chatModel.ts
@@ -1163,7 +1163,6 @@ export interface ISerializableChatData2 extends ISerializableChatData1 {
 export interface ISerializableChatData3 extends Omit<ISerializableChatData2, 'version' | 'computedTitle'> {
 	version: 3;
 	customTitle: string | undefined;
-	inputType?: string;
 }
 
 /**

--- a/src/vs/workbench/contrib/chat/common/chatModel.ts
+++ b/src/vs/workbench/contrib/chat/common/chatModel.ts
@@ -1139,7 +1139,6 @@ export interface IExportableChatData {
 	responderUsername: string;
 	requesterAvatarIconUri: UriComponents | undefined;
 	responderAvatarIconUri: ThemeIcon | UriComponents | undefined; // Keeping Uri name for backcompat
-	inputType?: string;
 }
 
 /*
@@ -1454,11 +1453,6 @@ export class ChatModel extends Disposable implements IChatModel {
 		return this._editingSession?.promiseResult.get()?.data;
 	}
 
-	private readonly _inputType: string | undefined;
-	get inputType(): string | undefined {
-		return this._inputType;
-	}
-
 	private readonly _initialLocation: ChatAgentLocation;
 	get initialLocation(): ChatAgentLocation {
 		return this._initialLocation;
@@ -1471,7 +1465,7 @@ export class ChatModel extends Disposable implements IChatModel {
 
 	constructor(
 		initialData: ISerializableChatData | IExportableChatData | undefined,
-		initialModelProps: { initialLocation: ChatAgentLocation; canUseTools: boolean; inputType?: string; resource?: URI },
+		initialModelProps: { initialLocation: ChatAgentLocation; canUseTools: boolean; resource?: URI },
 		@ILogService private readonly logService: ILogService,
 		@IChatAgentService private readonly chatAgentService: IChatAgentService,
 		@IChatEditingService private readonly chatEditingService: IChatEditingService,
@@ -1497,7 +1491,6 @@ export class ChatModel extends Disposable implements IChatModel {
 		this._initialRequesterAvatarIconUri = initialData?.requesterAvatarIconUri && URI.revive(initialData.requesterAvatarIconUri);
 		this._initialResponderAvatarIconUri = isUriComponents(initialData?.responderAvatarIconUri) ? URI.revive(initialData.responderAvatarIconUri) : initialData?.responderAvatarIconUri;
 
-		this._inputType = initialData?.inputType ?? initialModelProps.inputType;
 		this._initialLocation = initialData?.initialLocation ?? initialModelProps.initialLocation;
 		this._canUseTools = initialModelProps.canUseTools;
 

--- a/src/vs/workbench/contrib/chat/common/chatRequestParser.ts
+++ b/src/vs/workbench/contrib/chat/common/chatRequestParser.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { URI } from '../../../../base/common/uri.js';
 import { IPosition, Position } from '../../../../editor/common/core/position.js';
 import { Range } from '../../../../editor/common/core/range.js';
 import { OffsetRange } from '../../../../editor/common/core/ranges/offsetRange.js';
@@ -34,12 +35,12 @@ export class ChatRequestParser {
 		@IPromptsService private readonly promptsService: IPromptsService,
 	) { }
 
-	parseChatRequest(sessionId: string, message: string, location: ChatAgentLocation = ChatAgentLocation.Chat, context?: IChatParserContext): IParsedChatRequest {
+	parseChatRequest(sessionResource: URI, message: string, location: ChatAgentLocation = ChatAgentLocation.Chat, context?: IChatParserContext): IParsedChatRequest {
 		const parts: IParsedChatRequestPart[] = [];
-		const references = this.variableService.getDynamicVariables(sessionId); // must access this list before any async calls
+		const references = this.variableService.getDynamicVariables(sessionResource); // must access this list before any async calls
 		const toolsByName = new Map<string, IToolData>();
 		const toolSetsByName = new Map<string, ToolSet>();
-		for (const [entry, enabled] of this.variableService.getSelectedToolAndToolSets(sessionId)) {
+		for (const [entry, enabled] of this.variableService.getSelectedToolAndToolSets(sessionResource)) {
 			if (enabled) {
 				if (entry instanceof ToolSet) {
 					toolSetsByName.set(entry.referenceName, entry);

--- a/src/vs/workbench/contrib/chat/common/chatResponseResourceFileSystemProvider.ts
+++ b/src/vs/workbench/contrib/chat/common/chatResponseResourceFileSystemProvider.ts
@@ -12,6 +12,7 @@ import { createFileSystemProviderError, FileSystemProviderCapabilities, FileSyst
 import { IWorkbenchContribution } from '../../../common/contributions.js';
 import { ChatResponseResource } from './chatModel.js';
 import { IChatService, IChatToolInvocation, IChatToolInvocationSerialized } from './chatService.js';
+import { LocalChatSessionUri } from './chatUri.js';
 import { isToolResultInputOutputDetails } from './languageModelToolsService.js';
 
 export class ChatResponseResourceFileSystemProvider extends Disposable implements
@@ -90,7 +91,7 @@ export class ChatResponseResourceFileSystemProvider extends Disposable implement
 			throw createFileSystemProviderError(`File not found`, FileSystemProviderErrorCode.FileNotFound);
 		}
 		const { sessionId, toolCallId, index } = parsed;
-		const session = this.chatService.getSession(sessionId);
+		const session = this.chatService.getSession(LocalChatSessionUri.forSession(sessionId));
 		if (!session) {
 			throw createFileSystemProviderError(`File not found`, FileSystemProviderErrorCode.FileNotFound);
 		}

--- a/src/vs/workbench/contrib/chat/common/chatService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService.ts
@@ -790,7 +790,7 @@ export interface IChatUserActionEvent {
 	action: ChatUserAction;
 	agentId: string | undefined;
 	command: string | undefined;
-	sessionId: string;
+	sessionResource: URI;
 	requestId: string;
 	result: IChatAgentResult | undefined;
 	modelId?: string | undefined;
@@ -905,31 +905,31 @@ export interface IChatService {
 	_serviceBrand: undefined;
 	transferredSessionData: IChatTransferredSessionData | undefined;
 
-	readonly onDidSubmitRequest: Event<{ chatSessionId: string }>;
+	readonly onDidSubmitRequest: Event<{ readonly chatSessionId: string }>;
 
 	isEnabled(location: ChatAgentLocation): boolean;
 	hasSessions(): boolean;
 	startSession(location: ChatAgentLocation, token: CancellationToken, isGlobalEditingSession?: boolean, options?: { canUseTools?: boolean; inputType?: string }): ChatModel;
-	getSession(sessionId: string): IChatModel | undefined;
-	getOrRestoreSession(sessionId: string): Promise<IChatModel | undefined>;
-	getPersistedSessionTitle(sessionId: string): string | undefined;
-	isPersistedSessionEmpty(sessionId: string): boolean;
+	getSession(sessionResource: URI): IChatModel | undefined;
+	getOrRestoreSession(sessionResource: URI): Promise<IChatModel | undefined>;
+	getPersistedSessionTitle(sessionResource: URI): string | undefined;
+	isPersistedSessionEmpty(sessionResource: URI): boolean;
 	loadSessionFromContent(data: IExportableChatData | ISerializableChatData | URI): IChatModel | undefined;
 	loadSessionForResource(resource: URI, location: ChatAgentLocation, token: CancellationToken): Promise<IChatModel | undefined>;
 	readonly editingSessions: IChatEditingSession[];
-	getChatSessionFromInternalId(sessionId: string): IChatSessionContext | undefined;
+	getChatSessionFromInternalUri(sessionResource: URI): IChatSessionContext | undefined;
 
 	/**
 	 * Returns whether the request was accepted.`
 	 */
-	sendRequest(sessionId: string, message: string, options?: IChatSendRequestOptions): Promise<IChatSendRequestData | undefined>;
+	sendRequest(sessionResource: URI, message: string, options?: IChatSendRequestOptions): Promise<IChatSendRequestData | undefined>;
 
 	resendRequest(request: IChatRequestModel, options?: IChatSendRequestOptions): Promise<void>;
-	adoptRequest(sessionId: string, request: IChatRequestModel): Promise<void>;
-	removeRequest(sessionid: string, requestId: string): Promise<void>;
-	cancelCurrentRequestForSession(sessionId: string): void;
-	clearSession(sessionId: string): Promise<void>;
-	addCompleteRequest(sessionId: string, message: IParsedChatRequest | string, variableData: IChatRequestVariableData | undefined, attempt: number | undefined, response: IChatCompleteResponse): void;
+	adoptRequest(sessionResource: URI, request: IChatRequestModel): Promise<void>;
+	removeRequest(sessionResource: URI, requestId: string): Promise<void>;
+	cancelCurrentRequestForSession(sessionResource: URI): void;
+	clearSession(sessionResource: URI): Promise<void>;
+	addCompleteRequest(sessionResource: URI, message: IParsedChatRequest | string, variableData: IChatRequestVariableData | undefined, attempt: number | undefined, response: IChatCompleteResponse): void;
 	setChatSessionTitle(sessionResource: URI, title: string): void;
 	getLocalSessionHistory(): Promise<IChatDetail[]>;
 	clearAllHistoryEntries(): Promise<void>;
@@ -939,7 +939,7 @@ export interface IChatService {
 
 	readonly onDidPerformUserAction: Event<IChatUserActionEvent>;
 	notifyUserAction(event: IChatUserActionEvent): void;
-	readonly onDidDisposeSession: Event<{ sessionId: string; reason: 'cleared' }>;
+	readonly onDidDisposeSession: Event<{ readonly sessionResource: URI; readonly reason: 'cleared' }>;
 
 	transferChatSession(transferredSessionData: IChatTransferredSessionData, toWorkspace: URI): void;
 
@@ -951,10 +951,9 @@ export interface IChatService {
 }
 
 export interface IChatSessionContext {
-	chatSessionType: string;
-	chatSessionId: string;
-	chatSessionResource: URI;
-	isUntitled: boolean;
+	readonly chatSessionType: string;
+	readonly chatSessionResource: URI;
+	readonly isUntitled: boolean;
 }
 
 export const KEYWORD_ACTIVIATION_SETTING_ID = 'accessibility.voice.keywordActivation';

--- a/src/vs/workbench/contrib/chat/common/chatService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService.ts
@@ -909,7 +909,7 @@ export interface IChatService {
 
 	isEnabled(location: ChatAgentLocation): boolean;
 	hasSessions(): boolean;
-	startSession(location: ChatAgentLocation, token: CancellationToken, isGlobalEditingSession?: boolean, options?: { canUseTools?: boolean; inputType?: string }): ChatModel;
+	startSession(location: ChatAgentLocation, token: CancellationToken, isGlobalEditingSession?: boolean, options?: { canUseTools?: boolean }): ChatModel;
 	getSession(sessionResource: URI): IChatModel | undefined;
 	getOrRestoreSession(sessionResource: URI): Promise<IChatModel | undefined>;
 	getPersistedSessionTitle(sessionResource: URI): string | undefined;

--- a/src/vs/workbench/contrib/chat/common/chatServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/chatServiceImpl.ts
@@ -401,7 +401,7 @@ export class ChatService extends Disposable implements IChatService {
 		await this._chatSessionStore.clearAllSessions();
 	}
 
-	startSession(location: ChatAgentLocation, token: CancellationToken, isGlobalEditingSession: boolean = true, options?: { canUseTools?: boolean; inputType?: string }): ChatModel {
+	startSession(location: ChatAgentLocation, token: CancellationToken, isGlobalEditingSession: boolean = true, options?: { canUseTools?: boolean }): ChatModel {
 		this.trace('startSession');
 		return this._startSession(undefined, location, isGlobalEditingSession, token, options);
 	}

--- a/src/vs/workbench/contrib/chat/common/chatServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/chatServiceImpl.ts
@@ -70,12 +70,74 @@ class CancellableRequest implements IDisposable {
 	}
 }
 
+class ChatModelStore {
+	private readonly _models = new ObservableMap<string, ChatModel>();
+
+	public get observable() {
+		return this._models.observable;
+	}
+
+	public values(): Iterable<ChatModel> {
+		return this._models.values();
+	}
+
+	public get(uri: URI): ChatModel | undefined {
+		return this._models.get(this.toKey(uri));
+	}
+
+	public has(uri: URI): boolean {
+		return this._models.has(this.toKey(uri));
+	}
+
+	public set(uri: URI, value: ChatModel): void {
+		this._models.set(this.toKey(uri), value);
+	}
+
+	public delete(uri: URI): boolean {
+		return this._models.delete(this.toKey(uri));
+	}
+
+	private toKey(uri: URI): string {
+		return uri.toString();
+	}
+}
+
+class DisposableResourceMap<T extends IDisposable> extends Disposable {
+
+	private readonly _map = this._register(new DisposableMap<string, T>());
+
+	get(sessionResource: URI) {
+		return this._map.get(this.toKey(sessionResource));
+	}
+
+	set(sessionResource: URI, value: T) {
+		this._map.set(this.toKey(sessionResource), value);
+	}
+
+	has(sessionResource: URI) {
+		return this._map.has(this.toKey(sessionResource));
+	}
+
+	deleteAndLeak(sessionResource: URI) {
+		return this._map.deleteAndLeak(this.toKey(sessionResource));
+	}
+
+	deleteAndDispose(sessionResource: URI) {
+		this._map.deleteAndDispose(this.toKey(sessionResource));
+	}
+
+	private toKey(uri: URI): string {
+		return uri.toString();
+	}
+}
+
+
 export class ChatService extends Disposable implements IChatService {
 	declare _serviceBrand: undefined;
 
-	private readonly _sessionModels = new ObservableMap<string, ChatModel>();
+	private readonly _sessionModels = new ChatModelStore();
 	private readonly _contentProviderSessionModels = new ResourceMap<{ readonly model: IChatModel; readonly disposables: DisposableStore }>();
-	private readonly _pendingRequests = this._register(new DisposableMap<string, CancellableRequest>());
+	private readonly _pendingRequests = this._register(new DisposableResourceMap<CancellableRequest>());
 	private _persistedSessions: ISerializableChatsData;
 
 	private _transferredSessionData: IChatTransferredSessionData | undefined;
@@ -89,10 +151,10 @@ export class ChatService extends Disposable implements IChatService {
 	private readonly _onDidPerformUserAction = this._register(new Emitter<IChatUserActionEvent>());
 	public readonly onDidPerformUserAction: Event<IChatUserActionEvent> = this._onDidPerformUserAction.event;
 
-	private readonly _onDidDisposeSession = this._register(new Emitter<{ sessionId: string; reason: 'cleared' }>());
+	private readonly _onDidDisposeSession = this._register(new Emitter<{ readonly sessionResource: URI; reason: 'cleared' }>());
 	public readonly onDidDisposeSession = this._onDidDisposeSession.event;
 
-	private readonly _sessionFollowupCancelTokens = this._register(new DisposableMap<string, CancellationTokenSource>());
+	private readonly _sessionFollowupCancelTokens = this._register(new DisposableResourceMap<CancellationTokenSource>());
 	private readonly _chatServiceTelemetry: ChatServiceTelemetry;
 	private readonly _chatSessionStore: ChatSessionStore;
 
@@ -173,8 +235,12 @@ export class ChatService extends Disposable implements IChatService {
 
 	private saveState(): void {
 		const liveChats = Array.from(this._sessionModels.values())
-			.filter(session =>
-				!session.inputType && (session.initialLocation === ChatAgentLocation.Chat || session.initialLocation === ChatAgentLocation.EditorInline));
+			.filter(session => {
+				if (!LocalChatSessionUri.parseLocalSessionId(session.sessionResource)) {
+					return false;
+				}
+				return session.initialLocation === ChatAgentLocation.Chat || session.initialLocation === ChatAgentLocation.EditorInline;
+			});
 
 		this._chatSessionStore.storeSessions(liveChats);
 	}
@@ -183,7 +249,7 @@ export class ChatService extends Disposable implements IChatService {
 		this._chatServiceTelemetry.notifyUserAction(action);
 		this._onDidPerformUserAction.fire(action);
 		if (action.action.kind === 'chatEditingSessionAction') {
-			const model = this._sessionModels.get(action.sessionId);
+			const model = this._sessionModels.get(action.sessionResource);
 			if (model) {
 				model.notifyEditingAction(action.action);
 			}
@@ -192,7 +258,7 @@ export class ChatService extends Disposable implements IChatService {
 
 	async setChatSessionTitle(sessionResource: URI, title: string): Promise<void> {
 		const sessionId = this.toLocalSessionId(sessionResource);
-		const model = this._sessionModels.get(sessionId);
+		const model = this._sessionModels.get(sessionResource);
 		if (model) {
 			model.setCustomTitle(title);
 		}
@@ -301,7 +367,7 @@ export class ChatService extends Disposable implements IChatService {
 	 */
 	async getLocalSessionHistory(): Promise<IChatDetail[]> {
 		const liveSessionItems = Array.from(this._sessionModels.values())
-			.filter(session => !session.isImported && !session.inputType)
+			.filter(session => !session.isImported && LocalChatSessionUri.parseLocalSessionId(session.sessionResource))
 			.map((session): IChatDetail => {
 				const title = session.title || localize('newChat', "New Chat");
 				return {
@@ -315,12 +381,15 @@ export class ChatService extends Disposable implements IChatService {
 
 		const index = await this._chatSessionStore.getIndex();
 		const entries = Object.values(index)
-			.filter(entry => !this._sessionModels.has(entry.sessionId) && !entry.isImported && !entry.isEmpty)
-			.map((entry): IChatDetail => ({
-				...entry,
-				sessionResource: LocalChatSessionUri.forSession(entry.sessionId),
-				isActive: this._sessionModels.has(entry.sessionId),
-			}));
+			.filter(entry => !this._sessionModels.has(LocalChatSessionUri.forSession(entry.sessionId)) && !entry.isImported && !entry.isEmpty)
+			.map((entry): IChatDetail => {
+				const sessionResource = LocalChatSessionUri.forSession(entry.sessionId);
+				return ({
+					...entry,
+					sessionResource,
+					isActive: this._sessionModels.has(sessionResource),
+				});
+			});
 		return [...liveSessionItems, ...entries];
 	}
 
@@ -337,13 +406,13 @@ export class ChatService extends Disposable implements IChatService {
 		return this._startSession(undefined, location, isGlobalEditingSession, token, options);
 	}
 
-	private _startSession(someSessionHistory: IExportableChatData | ISerializableChatData | undefined, location: ChatAgentLocation, isGlobalEditingSession: boolean, token: CancellationToken, options?: { sessionResource?: URI; canUseTools?: boolean; inputType?: string }): ChatModel {
-		const model = this.instantiationService.createInstance(ChatModel, someSessionHistory, { initialLocation: location, canUseTools: options?.canUseTools ?? true, inputType: options?.inputType });
+	private _startSession(someSessionHistory: IExportableChatData | ISerializableChatData | undefined, location: ChatAgentLocation, isGlobalEditingSession: boolean, token: CancellationToken, options?: { sessionResource?: URI; canUseTools?: boolean }): ChatModel {
+		const model = this.instantiationService.createInstance(ChatModel, someSessionHistory, { initialLocation: location, canUseTools: options?.canUseTools ?? true });
 		if (location === ChatAgentLocation.Chat) {
 			model.startEditingSession(isGlobalEditingSession);
 		}
 
-		this._sessionModels.set(model.sessionId, model);
+		this._sessionModels.set(model.sessionResource, model);
 		this.initializeSession(model, token);
 		return model;
 	}
@@ -382,15 +451,20 @@ export class ChatService extends Disposable implements IChatService {
 		}
 	}
 
-	getSession(sessionId: string): IChatModel | undefined {
-		return this._sessionModels.get(sessionId);
+	getSession(sessionResource: URI): IChatModel | undefined {
+		return this._sessionModels.get(sessionResource);
 	}
 
-	async getOrRestoreSession(sessionId: string): Promise<ChatModel | undefined> {
-		this.trace('getOrRestoreSession', `sessionId: ${sessionId}`);
-		const model = this._sessionModels.get(sessionId);
+	async getOrRestoreSession(sessionResource: URI): Promise<ChatModel | undefined> {
+		this.trace('getOrRestoreSession', `${sessionResource}`);
+		const model = this._sessionModels.get(sessionResource);
 		if (model) {
 			return model;
+		}
+
+		const sessionId = LocalChatSessionUri.parse(sessionResource)?.sessionId;
+		if (!sessionId) {
+			throw new Error(`Cannot restore non-local session ${sessionResource}`);
 		}
 
 		let sessionData: ISerializableChatData | undefined;
@@ -417,7 +491,12 @@ export class ChatService extends Disposable implements IChatService {
 	/**
 	 * This is really just for migrating data from the edit session location to the panel.
 	 */
-	isPersistedSessionEmpty(sessionId: string): boolean {
+	isPersistedSessionEmpty(sessionResource: URI): boolean {
+		const sessionId = LocalChatSessionUri.parse(sessionResource)?.sessionId;
+		if (!sessionId) {
+			throw new Error(`Cannot restore non-local session ${sessionResource}`);
+		}
+
 		const session = this._persistedSessions[sessionId];
 		if (session) {
 			return session.requests.length === 0;
@@ -426,7 +505,12 @@ export class ChatService extends Disposable implements IChatService {
 		return this._chatSessionStore.isSessionEmpty(sessionId);
 	}
 
-	getPersistedSessionTitle(sessionId: string): string | undefined {
+	getPersistedSessionTitle(sessionResource: URI): string | undefined {
+		const sessionId = LocalChatSessionUri.parse(sessionResource)?.sessionId;
+		if (!sessionId) {
+			throw new Error(`Cannot restore non-local session ${sessionResource}`);
+		}
+
 		// First check the memory cache (_persistedSessions)
 		const session = this._persistedSessions[sessionId];
 		if (session) {
@@ -459,12 +543,7 @@ export class ChatService extends Disposable implements IChatService {
 		// TODO: Move this into a new ChatModelService
 
 		if (chatSessionResource.scheme === Schemas.vscodeLocalChatSession) {
-			const parsed = LocalChatSessionUri.parse(chatSessionResource);
-			if (!parsed) {
-				throw new ErrorNoTelemetry('Invalid local chat session URI');
-			}
-
-			return this.getOrRestoreSession(parsed.sessionId);
+			return this.getOrRestoreSession(chatSessionResource);
 		}
 
 		const existing = this._contentProviderSessionModels.get(chatSessionResource);
@@ -476,11 +555,10 @@ export class ChatService extends Disposable implements IChatService {
 		const chatSessionType = chatSessionResource.scheme;
 
 		// Contributed sessions do not use UI tools
-		const model = this._startSession(undefined, location, true, CancellationToken.None, { sessionResource: chatSessionResource, canUseTools: false, inputType: chatSessionType });
+		const model = this._startSession(undefined, location, true, CancellationToken.None, { sessionResource: chatSessionResource, canUseTools: false });
 		model.setContributedChatSession({
-			chatSessionType: chatSessionType,
-			chatSessionId: chatSessionResource.toString(),
 			chatSessionResource,
+			chatSessionType,
 			isUntitled: chatSessionResource.path.startsWith('/untitled-')  //TODO(jospicer)
 		});
 
@@ -536,7 +614,7 @@ export class ChatService extends Disposable implements IChatService {
 
 		if (providedSession.progressObs && lastRequest && providedSession.interruptActiveResponseCallback) {
 			const initialCancellationRequest = this.instantiationService.createInstance(CancellableRequest, new CancellationTokenSource(), undefined);
-			this._pendingRequests.set(model.sessionId, initialCancellationRequest);
+			this._pendingRequests.set(model.sessionResource, initialCancellationRequest);
 			const cancellationListener = new MutableDisposable();
 
 			const createCancellationListener = (token: CancellationToken) => {
@@ -545,7 +623,7 @@ export class ChatService extends Disposable implements IChatService {
 						if (!userConfirmedInterruption) {
 							// User cancelled the interruption
 							const newCancellationRequest = this.instantiationService.createInstance(CancellableRequest, new CancellationTokenSource(), undefined);
-							this._pendingRequests.set(model.sessionId, newCancellationRequest);
+							this._pendingRequests.set(model.sessionResource, newCancellationRequest);
 							cancellationListener.value = createCancellationListener(newCancellationRequest.cancellationTokenSource.token);
 						}
 					});
@@ -584,8 +662,8 @@ export class ChatService extends Disposable implements IChatService {
 		return model;
 	}
 
-	getChatSessionFromInternalId(modelSessionId: string): IChatSessionContext | undefined {
-		const model = this._sessionModels.get(modelSessionId);
+	getChatSessionFromInternalUri(sessionResource: URI): IChatSessionContext | undefined {
+		const model = this._sessionModels.get(sessionResource);
 		if (!model) {
 			return;
 		}
@@ -594,14 +672,14 @@ export class ChatService extends Disposable implements IChatService {
 	}
 
 	async resendRequest(request: IChatRequestModel, options?: IChatSendRequestOptions): Promise<void> {
-		const model = this._sessionModels.get(request.session.sessionId);
+		const model = this._sessionModels.get(request.session.sessionResource);
 		if (!model && model !== request.session) {
-			throw new Error(`Unknown session: ${request.session.sessionId}`);
+			throw new Error(`Unknown session: ${request.session.sessionResource}`);
 		}
 
-		const cts = this._pendingRequests.get(request.session.sessionId);
+		const cts = this._pendingRequests.get(request.session.sessionResource);
 		if (cts) {
-			this.trace('resendRequest', `Session ${request.session.sessionId} already has a pending request, cancelling...`);
+			this.trace('resendRequest', `Session ${request.session.sessionResource} already has a pending request, cancelling...`);
 			cts.cancel();
 		}
 
@@ -617,11 +695,11 @@ export class ChatService extends Disposable implements IChatService {
 			locationData: request.locationData,
 			attachedContext: request.attachedContext,
 		};
-		await this._sendRequestAsync(model, model.sessionId, request.message, attempt, enableCommandDetection, defaultAgent, location, resendOptions).responseCompletePromise;
+		await this._sendRequestAsync(model, model.sessionResource, request.message, attempt, enableCommandDetection, defaultAgent, location, resendOptions).responseCompletePromise;
 	}
 
-	async sendRequest(sessionId: string, request: string, options?: IChatSendRequestOptions): Promise<IChatSendRequestData | undefined> {
-		this.trace('sendRequest', `sessionId: ${sessionId}, message: ${request.substring(0, 20)}${request.length > 20 ? '[...]' : ''}}`);
+	async sendRequest(sessionResource: URI, request: string, options?: IChatSendRequestOptions): Promise<IChatSendRequestData | undefined> {
+		this.trace('sendRequest', `sessionResource: ${sessionResource.toString()}, message: ${request.substring(0, 20)}${request.length > 20 ? '[...]' : ''}}`);
 
 
 		if (!request.trim() && !options?.slashCommand && !options?.agentId && !options?.agentIdSilent) {
@@ -629,13 +707,13 @@ export class ChatService extends Disposable implements IChatService {
 			return;
 		}
 
-		const model = this._sessionModels.get(sessionId);
+		const model = this._sessionModels.get(sessionResource);
 		if (!model) {
-			throw new Error(`Unknown session: ${sessionId}`);
+			throw new Error(`Unknown session: ${sessionResource}`);
 		}
 
-		if (this._pendingRequests.has(sessionId)) {
-			this.trace('sendRequest', `Session ${sessionId} already has a pending request`);
+		if (this._pendingRequests.has(sessionResource)) {
+			this.trace('sendRequest', `Session ${sessionResource} already has a pending request`);
 			return;
 		}
 
@@ -646,7 +724,7 @@ export class ChatService extends Disposable implements IChatService {
 				if (request.shouldBeRemovedOnSend.afterUndoStop) {
 					request.response?.finalizeUndoState();
 				} else {
-					await this.removeRequest(sessionId, request.id);
+					await this.removeRequest(sessionResource, request.id);
 				}
 			}
 		}
@@ -655,20 +733,20 @@ export class ChatService extends Disposable implements IChatService {
 		const attempt = options?.attempt ?? 0;
 		const defaultAgent = this.chatAgentService.getDefaultAgent(location, options?.modeInfo?.kind)!;
 
-		const parsedRequest = this.parseChatRequest(sessionId, request, location, options);
+		const parsedRequest = this.parseChatRequest(sessionResource, request, location, options);
 		const silentAgent = options?.agentIdSilent ? this.chatAgentService.getAgent(options.agentIdSilent) : undefined;
 		const agent = silentAgent ?? parsedRequest.parts.find((r): r is ChatRequestAgentPart => r instanceof ChatRequestAgentPart)?.agent ?? defaultAgent;
 		const agentSlashCommandPart = parsedRequest.parts.find((r): r is ChatRequestAgentSubcommandPart => r instanceof ChatRequestAgentSubcommandPart);
 
 		// This method is only returning whether the request was accepted - don't block on the actual request
 		return {
-			...this._sendRequestAsync(model, sessionId, parsedRequest, attempt, !options?.noCommandDetection, silentAgent ?? defaultAgent, location, options),
+			...this._sendRequestAsync(model, sessionResource, parsedRequest, attempt, !options?.noCommandDetection, silentAgent ?? defaultAgent, location, options),
 			agent,
 			slashCommand: agentSlashCommandPart?.command,
 		};
 	}
 
-	private parseChatRequest(sessionId: string, request: string, location: ChatAgentLocation, options: IChatSendRequestOptions | undefined): IParsedChatRequest {
+	private parseChatRequest(sessionResource: URI, request: string, location: ChatAgentLocation, options: IChatSendRequestOptions | undefined): IParsedChatRequest {
 		let parserContext = options?.parserContext;
 		if (options?.agentId) {
 			const agent = this.chatAgentService.getAgent(options.agentId);
@@ -680,20 +758,20 @@ export class ChatService extends Disposable implements IChatService {
 			request = `${chatAgentLeader}${agent.name}${commandPart} ${request}`;
 		}
 
-		const parsedRequest = this.instantiationService.createInstance(ChatRequestParser).parseChatRequest(sessionId, request, location, parserContext);
+		const parsedRequest = this.instantiationService.createInstance(ChatRequestParser).parseChatRequest(sessionResource, request, location, parserContext);
 		return parsedRequest;
 	}
 
-	private refreshFollowupsCancellationToken(sessionId: string): CancellationToken {
-		this._sessionFollowupCancelTokens.get(sessionId)?.cancel();
+	private refreshFollowupsCancellationToken(sessionResource: URI): CancellationToken {
+		this._sessionFollowupCancelTokens.get(sessionResource)?.cancel();
 		const newTokenSource = new CancellationTokenSource();
-		this._sessionFollowupCancelTokens.set(sessionId, newTokenSource);
+		this._sessionFollowupCancelTokens.set(sessionResource, newTokenSource);
 
 		return newTokenSource.token;
 	}
 
-	private _sendRequestAsync(model: ChatModel, sessionId: string, parsedRequest: IParsedChatRequest, attempt: number, enableCommandDetection: boolean, defaultAgent: IChatAgentData, location: ChatAgentLocation, options?: IChatSendRequestOptions): IChatSendRequestResponseState {
-		const followupsCancelToken = this.refreshFollowupsCancellationToken(sessionId);
+	private _sendRequestAsync(model: ChatModel, sessionResource: URI, parsedRequest: IParsedChatRequest, attempt: number, enableCommandDetection: boolean, defaultAgent: IChatAgentData, location: ChatAgentLocation, options?: IChatSendRequestOptions): IChatSendRequestResponseState {
+		const followupsCancelToken = this.refreshFollowupsCancellationToken(sessionResource);
 		let request: ChatRequestModel;
 		const agentPart = 'kind' in parsedRequest ? undefined : parsedRequest.parts.find((r): r is ChatRequestAgentPart => r instanceof ChatRequestAgentPart);
 		const agentSlashCommandPart = 'kind' in parsedRequest ? undefined : parsedRequest.parts.find((r): r is ChatRequestAgentSubcommandPart => r instanceof ChatRequestAgentSubcommandPart);
@@ -809,7 +887,7 @@ export class ChatService extends Disposable implements IChatService {
 						}));
 
 						return {
-							sessionId,
+							sessionId: model.sessionId,
 							requestId: request.id,
 							agentId: agent.id,
 							message,
@@ -864,7 +942,7 @@ export class ChatService extends Disposable implements IChatService {
 					// Recompute history in case the agent or command changed
 					const history = this.getHistoryEntriesFromModel(requests, model.sessionId, location, agent.id);
 					const requestProps = prepareChatAgentRequest(agent, command, enableCommandDetection, request /* Reuse the request object if we already created it for participant detection */, !!detectedAgent);
-					const pendingRequest = this._pendingRequests.get(sessionId);
+					const pendingRequest = this._pendingRequests.get(sessionResource);
 					if (pendingRequest && !pendingRequest.requestId) {
 						pendingRequest.requestId = requestProps.requestId;
 					}
@@ -987,9 +1065,9 @@ export class ChatService extends Disposable implements IChatService {
 		};
 		const rawResponsePromise = sendRequestInternal();
 		// Note- requestId is not known at this point, assigned later
-		this._pendingRequests.set(model.sessionId, this.instantiationService.createInstance(CancellableRequest, source, undefined));
+		this._pendingRequests.set(model.sessionResource, this.instantiationService.createInstance(CancellableRequest, source, undefined));
 		rawResponsePromise.finally(() => {
-			this._pendingRequests.deleteAndDispose(model.sessionId);
+			this._pendingRequests.deleteAndDispose(model.sessionResource);
 		});
 		this._onDidSubmitRequest.fire({ chatSessionId: model.sessionId });
 		return {
@@ -1050,52 +1128,52 @@ export class ChatService extends Disposable implements IChatService {
 		return history;
 	}
 
-	async removeRequest(sessionId: string, requestId: string): Promise<void> {
-		const model = this._sessionModels.get(sessionId);
+	async removeRequest(sessionResource: URI, requestId: string): Promise<void> {
+		const model = this._sessionModels.get(sessionResource);
 		if (!model) {
-			throw new Error(`Unknown session: ${sessionId}`);
+			throw new Error(`Unknown session: ${sessionResource}`);
 		}
 
-		const pendingRequest = this._pendingRequests.get(sessionId);
+		const pendingRequest = this._pendingRequests.get(sessionResource);
 		if (pendingRequest?.requestId === requestId) {
 			pendingRequest.cancel();
-			this._pendingRequests.deleteAndDispose(sessionId);
+			this._pendingRequests.deleteAndDispose(sessionResource);
 		}
 
 		model.removeRequest(requestId);
 	}
 
-	async adoptRequest(sessionId: string, request: IChatRequestModel) {
+	async adoptRequest(sessionResource: URI, request: IChatRequestModel) {
 		if (!(request instanceof ChatRequestModel)) {
 			throw new TypeError('Can only adopt requests of type ChatRequestModel');
 		}
-		const target = this._sessionModels.get(sessionId);
+		const target = this._sessionModels.get(sessionResource);
 		if (!target) {
-			throw new Error(`Unknown session: ${sessionId}`);
+			throw new Error(`Unknown session: ${sessionResource}`);
 		}
 
 		const oldOwner = request.session;
 		target.adoptRequest(request);
 
 		if (request.response && !request.response.isComplete) {
-			const cts = this._pendingRequests.deleteAndLeak(oldOwner.sessionId);
+			const cts = this._pendingRequests.deleteAndLeak(oldOwner.sessionResource);
 			if (cts) {
 				cts.requestId = request.id;
-				this._pendingRequests.set(target.sessionId, cts);
+				this._pendingRequests.set(target.sessionResource, cts);
 			}
 		}
 	}
 
-	async addCompleteRequest(sessionId: string, message: IParsedChatRequest | string, variableData: IChatRequestVariableData | undefined, attempt: number | undefined, response: IChatCompleteResponse): Promise<void> {
+	async addCompleteRequest(sessionResource: URI, message: IParsedChatRequest | string, variableData: IChatRequestVariableData | undefined, attempt: number | undefined, response: IChatCompleteResponse): Promise<void> {
 		this.trace('addCompleteRequest', `message: ${message}`);
 
-		const model = this._sessionModels.get(sessionId);
+		const model = this._sessionModels.get(sessionResource);
 		if (!model) {
-			throw new Error(`Unknown session: ${sessionId}`);
+			throw new Error(`Unknown session: ${sessionResource}`);
 		}
 
 		const parsedRequest = typeof message === 'string' ?
-			this.instantiationService.createInstance(ChatRequestParser).parseChatRequest(sessionId, message) :
+			this.instantiationService.createInstance(ChatRequestParser).parseChatRequest(sessionResource, message) :
 			message;
 		const request = model.addRequest(parsedRequest, variableData || { variables: [] }, attempt ?? 0, undefined, undefined, undefined, undefined, undefined, undefined, true);
 		if (typeof response.message === 'string') {
@@ -1113,33 +1191,34 @@ export class ChatService extends Disposable implements IChatService {
 		model.completeResponse(request);
 	}
 
-	cancelCurrentRequestForSession(sessionId: string): void {
-		this.trace('cancelCurrentRequestForSession', `sessionId: ${sessionId}`);
-		this._pendingRequests.get(sessionId)?.cancel();
-		this._pendingRequests.deleteAndDispose(sessionId);
+	cancelCurrentRequestForSession(sessionResource: URI): void {
+		this.trace('cancelCurrentRequestForSession', `session: ${sessionResource}`);
+		this._pendingRequests.get(sessionResource)?.cancel();
+		this._pendingRequests.deleteAndDispose(sessionResource);
 	}
 
-	async clearSession(sessionId: string): Promise<void> {
-		this.trace('clearSession', `sessionId: ${sessionId}`);
-		const model = this._sessionModels.get(sessionId);
+	async clearSession(sessionResource: URI): Promise<void> {
+		this.trace('clearSession', `session: ${sessionResource}`);
+		const model = this._sessionModels.get(sessionResource);
 		if (!model) {
-			throw new Error(`Unknown session: ${sessionId}`);
+			throw new Error(`Unknown session: ${sessionResource}`);
 		}
-		this.trace(`Model input type: ${model.inputType}`);
-		if (!model.inputType && (model.initialLocation === ChatAgentLocation.Chat || model.initialLocation === ChatAgentLocation.EditorInline)) {
+
+		const localSession = LocalChatSessionUri.parse(sessionResource);
+		if (localSession && (model.initialLocation === ChatAgentLocation.Chat || model.initialLocation === ChatAgentLocation.EditorInline)) {
 			// Always preserve sessions that have custom titles, even if empty
 			if (model.getRequests().length === 0 && !model.customTitle) {
-				await this._chatSessionStore.deleteSession(sessionId);
+				await this._chatSessionStore.deleteSession(localSession.sessionId);
 			} else {
 				await this._chatSessionStore.storeSessions([model]);
 			}
 		}
 
-		this._sessionModels.delete(sessionId);
+		this._sessionModels.delete(sessionResource);
 		model.dispose();
-		this._pendingRequests.get(sessionId)?.cancel();
-		this._pendingRequests.deleteAndDispose(sessionId);
-		this._onDidDisposeSession.fire({ sessionId, reason: 'cleared' });
+		this._pendingRequests.get(sessionResource)?.cancel();
+		this._pendingRequests.deleteAndDispose(sessionResource);
+		this._onDidDisposeSession.fire({ sessionResource, reason: 'cleared' });
 	}
 
 	public hasSessions(): boolean {

--- a/src/vs/workbench/contrib/chat/common/chatUri.ts
+++ b/src/vs/workbench/contrib/chat/common/chatUri.ts
@@ -31,6 +31,11 @@ export namespace LocalChatSessionUri {
 		return URI.from({ scheme, authority: chatSessionType, path: '/' + encodedId });
 	}
 
+	export function parseLocalSessionId(resource: URI): string | undefined {
+		const parsed = parse(resource);
+		return parsed?.chatSessionType === localChatSessionType ? parsed.sessionId : undefined;
+	}
+
 	export function parse(resource: URI): ChatSessionIdentifier | undefined {
 		if (resource.scheme !== scheme) {
 			return undefined;

--- a/src/vs/workbench/contrib/chat/common/chatVariables.ts
+++ b/src/vs/workbench/contrib/chat/common/chatVariables.ts
@@ -46,8 +46,8 @@ export const IChatVariablesService = createDecorator<IChatVariablesService>('ICh
 
 export interface IChatVariablesService {
 	_serviceBrand: undefined;
-	getDynamicVariables(sessionId: string): ReadonlyArray<IDynamicVariable>;
-	getSelectedToolAndToolSets(sessionId: string): IToolAndToolSetEnablementMap;
+	getDynamicVariables(sessionResource: URI): ReadonlyArray<IDynamicVariable>;
+	getSelectedToolAndToolSets(sessionResource: URI): IToolAndToolSetEnablementMap;
 }
 
 export interface IDynamicVariable {

--- a/src/vs/workbench/contrib/chat/common/chatViewModel.ts
+++ b/src/vs/workbench/contrib/chat/common/chatViewModel.ts
@@ -78,7 +78,9 @@ export interface IChatViewModel {
 
 export interface IChatRequestViewModel {
 	readonly id: string;
+	/** @deprecated */
 	readonly sessionId: string;
+	readonly sessionResource: URI;
 	/** This ID updates every time the underlying data changes */
 	readonly dataId: string;
 	readonly username: string;
@@ -194,7 +196,9 @@ export interface IChatResponseViewModel {
 	readonly model: IChatResponseModel;
 	readonly id: string;
 	readonly session: IChatViewModel;
+	/** @deprecated */
 	readonly sessionId: string;
+	readonly sessionResource: URI;
 	/** This ID updates every time the underlying data changes */
 	readonly dataId: string;
 	/** The ID of the associated IChatRequestViewModel */
@@ -392,6 +396,10 @@ export class ChatRequestViewModel implements IChatRequestViewModel {
 		return this._model.session.sessionId;
 	}
 
+	get sessionResource() {
+		return this._model.session.sessionResource;
+	}
+
 	get username() {
 		return this._model.username;
 	}
@@ -481,6 +489,10 @@ export class ChatResponseViewModel extends Disposable implements IChatResponseVi
 
 	get sessionId() {
 		return this._model.session.sessionId;
+	}
+
+	get sessionResource(): URI {
+		return this._model.session.sessionResource;
 	}
 
 	get username() {

--- a/src/vs/workbench/contrib/chat/common/tools/editFileTool.ts
+++ b/src/vs/workbench/contrib/chat/common/tools/editFileTool.ts
@@ -14,6 +14,7 @@ import { ICodeMapperService } from '../../common/chatCodeMapperService.js';
 import { ChatModel } from '../../common/chatModel.js';
 import { IChatService } from '../../common/chatService.js';
 import { CountTokensCallback, IPreparedToolInvocation, IToolData, IToolImpl, IToolInvocation, IToolInvocationPreparationContext, IToolResult, ToolDataSource, ToolInvocationPresentation, ToolProgress } from '../../common/languageModelToolsService.js';
+import { LocalChatSessionUri } from '../chatUri.js';
 
 export const ExtensionEditToolId = 'vscode_editFile';
 export const InternalEditToolId = 'vscode_editFile_internal';
@@ -47,7 +48,7 @@ export class EditTool implements IToolImpl {
 		const fileUri = URI.revive(parameters.uri);
 		const uri = CellUri.parse(fileUri)?.notebook || fileUri;
 
-		const model = this.chatService.getSession(invocation.context?.sessionId) as ChatModel;
+		const model = this.chatService.getSession(LocalChatSessionUri.forSession(invocation.context?.sessionId)) as ChatModel;
 		const request = model.getRequests().at(-1)!;
 
 		model.acceptResponseProgress(request, {

--- a/src/vs/workbench/contrib/chat/test/browser/languageModelToolsService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/languageModelToolsService.test.ts
@@ -27,6 +27,7 @@ import { ChatConfiguration } from '../../common/constants.js';
 import { isToolResultInputOutputDetails, IToolData, IToolImpl, IToolInvocation, ToolDataSource, ToolSet } from '../../common/languageModelToolsService.js';
 import { MockChatService } from '../common/mockChatService.js';
 import { ChatToolInvocation } from '../../common/chatProgressTypes/chatToolInvocation.js';
+import { LocalChatSessionUri } from '../../common/chatUri.js';
 
 // --- Test helpers to reduce repetition and improve readability ---
 
@@ -80,6 +81,7 @@ function stubGetSession(chatService: MockChatService, sessionId: string, options
 	const capture = options?.capture;
 	const fakeModel = {
 		sessionId,
+		sessionResource: LocalChatSessionUri.forSession(sessionId),
 		getRequests: () => [{ id: requestId, modelId: 'test-model' }],
 		acceptResponseProgress: (_req: any, progress: any) => { if (capture) { capture.invocation = progress; } },
 	} as IChatModel;

--- a/src/vs/workbench/contrib/chat/test/browser/mockChatWidget.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/mockChatWidget.ts
@@ -26,6 +26,10 @@ export class MockChatWidgetService implements IChatWidgetService {
 		return undefined;
 	}
 
+	getWidgetBySessionResource(sessionResource: URI): IChatWidget | undefined {
+		return undefined;
+	}
+
 	getWidgetsByLocations(location: ChatAgentLocation): ReadonlyArray<IChatWidget> {
 		return [];
 	}

--- a/src/vs/workbench/contrib/chat/test/common/chatRequestParser.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/chatRequestParser.test.ts
@@ -17,6 +17,7 @@ import { ChatAgentService, IChatAgentCommand, IChatAgentData, IChatAgentService 
 import { ChatRequestParser } from '../../common/chatRequestParser.js';
 import { IChatService } from '../../common/chatService.js';
 import { IChatSlashCommandService } from '../../common/chatSlashCommands.js';
+import { LocalChatSessionUri } from '../../common/chatUri.js';
 import { IChatVariablesService } from '../../common/chatVariables.js';
 import { ChatAgentLocation, ChatModeKind } from '../../common/constants.js';
 import { IToolData, ToolDataSource, ToolSet } from '../../common/languageModelToolsService.js';
@@ -24,6 +25,8 @@ import { IPromptsService } from '../../common/promptSyntax/service/promptsServic
 import { MockChatService } from './mockChatService.js';
 import { MockChatVariablesService } from './mockChatVariables.js';
 import { MockPromptsService } from './mockPromptsService.js';
+
+const testSessionUri = LocalChatSessionUri.forSession('test-session');
 
 suite('ChatRequestParser', () => {
 	const testDisposables = ensureNoDisposablesAreLeakedInTestSuite();
@@ -48,21 +51,21 @@ suite('ChatRequestParser', () => {
 
 	test('plain text', async () => {
 		parser = instantiationService.createInstance(ChatRequestParser);
-		const result = parser.parseChatRequest('1', 'test');
+		const result = parser.parseChatRequest(testSessionUri, 'test');
 		await assertSnapshot(result);
 	});
 
 	test('plain text with newlines', async () => {
 		parser = instantiationService.createInstance(ChatRequestParser);
 		const text = 'line 1\nline 2\r\nline 3';
-		const result = parser.parseChatRequest('1', text);
+		const result = parser.parseChatRequest(testSessionUri, text);
 		await assertSnapshot(result);
 	});
 
 	test('slash in text', async () => {
 		parser = instantiationService.createInstance(ChatRequestParser);
 		const text = 'can we add a new file for an Express router to handle the / route';
-		const result = parser.parseChatRequest('1', text);
+		const result = parser.parseChatRequest(testSessionUri, text);
 		await assertSnapshot(result);
 	});
 
@@ -74,7 +77,7 @@ suite('ChatRequestParser', () => {
 
 		parser = instantiationService.createInstance(ChatRequestParser);
 		const text = '/fix this';
-		const result = parser.parseChatRequest('1', text);
+		const result = parser.parseChatRequest(testSessionUri, text);
 		await assertSnapshot(result);
 	});
 
@@ -86,7 +89,7 @@ suite('ChatRequestParser', () => {
 
 		parser = instantiationService.createInstance(ChatRequestParser);
 		const text = '/explain this';
-		const result = parser.parseChatRequest('1', text);
+		const result = parser.parseChatRequest(testSessionUri, text);
 		await assertSnapshot(result);
 	});
 
@@ -98,7 +101,7 @@ suite('ChatRequestParser', () => {
 
 		parser = instantiationService.createInstance(ChatRequestParser);
 		const text = '/fix /fix';
-		const result = parser.parseChatRequest('1', text);
+		const result = parser.parseChatRequest(testSessionUri, text);
 		await assertSnapshot(result);
 	});
 
@@ -110,7 +113,7 @@ suite('ChatRequestParser', () => {
 
 		parser = instantiationService.createInstance(ChatRequestParser);
 		const text = 'Hello /fix';
-		const result = parser.parseChatRequest('1', text);
+		const result = parser.parseChatRequest(testSessionUri, text);
 		await assertSnapshot(result);
 	});
 
@@ -122,7 +125,7 @@ suite('ChatRequestParser', () => {
 
 		parser = instantiationService.createInstance(ChatRequestParser);
 		const text = '    /fix';
-		const result = parser.parseChatRequest('1', text);
+		const result = parser.parseChatRequest(testSessionUri, text);
 		await assertSnapshot(result);
 	});
 
@@ -144,7 +147,7 @@ suite('ChatRequestParser', () => {
 
 		parser = instantiationService.createInstance(ChatRequestParser);
 		const text = '    /prompt';
-		const result = parser.parseChatRequest('1', text);
+		const result = parser.parseChatRequest(testSessionUri, text);
 		await assertSnapshot(result);
 	});
 
@@ -166,7 +169,7 @@ suite('ChatRequestParser', () => {
 
 		parser = instantiationService.createInstance(ChatRequestParser);
 		const text = 'handle the / route and the request of /search-option';
-		const result = parser.parseChatRequest('1', text);
+		const result = parser.parseChatRequest(testSessionUri, text);
 		await assertSnapshot(result);
 	});
 
@@ -188,7 +191,7 @@ suite('ChatRequestParser', () => {
 
 		parser = instantiationService.createInstance(ChatRequestParser);
 		const text = '/ route and the request of /search-option';
-		const result = parser.parseChatRequest('1', text);
+		const result = parser.parseChatRequest(testSessionUri, text);
 		await assertSnapshot(result);
 	});
 
@@ -210,7 +213,7 @@ suite('ChatRequestParser', () => {
 
 		parser = instantiationService.createInstance(ChatRequestParser);
 		const text = '/001-sample this is a test';
-		const result = parser.parseChatRequest('1', text);
+		const result = parser.parseChatRequest(testSessionUri, text);
 		await assertSnapshot(result);
 	});
 
@@ -220,7 +223,7 @@ suite('ChatRequestParser', () => {
 
 	// 	parser = instantiationService.createInstance(ChatRequestParser);
 	// 	const text = 'What does #selection mean?';
-	// 	const result = parser.parseChatRequest('1', text);
+	// 	const result = parser.parseChatRequest(testSessionUri, text);
 	// 	await assertSnapshot(result);
 	// });
 
@@ -230,7 +233,7 @@ suite('ChatRequestParser', () => {
 
 	// 	parser = instantiationService.createInstance(ChatRequestParser);
 	// 	const text = 'What is #selection?';
-	// 	const result = parser.parseChatRequest('1', text);
+	// 	const result = parser.parseChatRequest(testSessionUri, text);
 	// 	await assertSnapshot(result);
 	// });
 
@@ -239,7 +242,7 @@ suite('ChatRequestParser', () => {
 
 	// 	parser = instantiationService.createInstance(ChatRequestParser);
 	// 	const text = 'What does #selection mean?';
-	// 	const result = parser.parseChatRequest('1', text);
+	// 	const result = parser.parseChatRequest(testSessionUri, text);
 	// 	await assertSnapshot(result);
 	// });
 
@@ -254,7 +257,7 @@ suite('ChatRequestParser', () => {
 		instantiationService.stub(IChatAgentService, agentsService as any);
 
 		parser = instantiationService.createInstance(ChatRequestParser);
-		const result = parser.parseChatRequest('1', '@agent Please do /subCommand thanks');
+		const result = parser.parseChatRequest(testSessionUri, '@agent Please do /subCommand thanks');
 		await assertSnapshot(result);
 	});
 
@@ -265,7 +268,7 @@ suite('ChatRequestParser', () => {
 		instantiationService.stub(IChatAgentService, agentsService as any);
 
 		parser = instantiationService.createInstance(ChatRequestParser);
-		const result = parser.parseChatRequest('1', '@agent /subCommand Please do thanks');
+		const result = parser.parseChatRequest(testSessionUri, '@agent /subCommand Please do thanks');
 		await assertSnapshot(result);
 	});
 
@@ -276,7 +279,7 @@ suite('ChatRequestParser', () => {
 		instantiationService.stub(IChatAgentService, agentsService as any);
 
 		parser = instantiationService.createInstance(ChatRequestParser);
-		const result = parser.parseChatRequest('1', '@agent hello', undefined, { mode: ChatModeKind.Edit });
+		const result = parser.parseChatRequest(testSessionUri, '@agent hello', undefined, { mode: ChatModeKind.Edit });
 		await assertSnapshot(result);
 	});
 
@@ -287,7 +290,7 @@ suite('ChatRequestParser', () => {
 		instantiationService.stub(IChatAgentService, agentsService as any);
 
 		parser = instantiationService.createInstance(ChatRequestParser);
-		const result = parser.parseChatRequest('1', '@agent? Are you there');
+		const result = parser.parseChatRequest(testSessionUri, '@agent? Are you there');
 		await assertSnapshot(result);
 	});
 
@@ -298,7 +301,7 @@ suite('ChatRequestParser', () => {
 		instantiationService.stub(IChatAgentService, agentsService as any);
 
 		parser = instantiationService.createInstance(ChatRequestParser);
-		const result = parser.parseChatRequest('1', '    \r\n\t   @agent \r\n\t   /subCommand Thanks');
+		const result = parser.parseChatRequest(testSessionUri, '    \r\n\t   @agent \r\n\t   /subCommand Thanks');
 		await assertSnapshot(result);
 	});
 
@@ -309,7 +312,7 @@ suite('ChatRequestParser', () => {
 		instantiationService.stub(IChatAgentService, agentsService as any);
 
 		parser = instantiationService.createInstance(ChatRequestParser);
-		const result = parser.parseChatRequest('1', '    \n@agent\n/subCommand Thanks');
+		const result = parser.parseChatRequest(testSessionUri, '    \n@agent\n/subCommand Thanks');
 		await assertSnapshot(result);
 	});
 
@@ -320,7 +323,7 @@ suite('ChatRequestParser', () => {
 		instantiationService.stub(IChatAgentService, agentsService as any);
 
 		parser = instantiationService.createInstance(ChatRequestParser);
-		const result = parser.parseChatRequest('1', 'Hello Mr. @agent');
+		const result = parser.parseChatRequest(testSessionUri, 'Hello Mr. @agent');
 		await assertSnapshot(result);
 	});
 
@@ -330,13 +333,13 @@ suite('ChatRequestParser', () => {
 		// eslint-disable-next-line local/code-no-any-casts
 		instantiationService.stub(IChatAgentService, agentsService as any);
 
-		variableService.setSelectedToolAndToolSets('1', new Map([
+		variableService.setSelectedToolAndToolSets(testSessionUri, new Map([
 			[{ id: 'get_selection', toolReferenceName: 'selection', canBeReferencedInPrompt: true, displayName: '', modelDescription: '', source: ToolDataSource.Internal }, true],
 			[{ id: 'get_debugConsole', toolReferenceName: 'debugConsole', canBeReferencedInPrompt: true, displayName: '', modelDescription: '', source: ToolDataSource.Internal }, true]
 		] satisfies [IToolData | ToolSet, boolean][]));
 
 		parser = instantiationService.createInstance(ChatRequestParser);
-		const result = parser.parseChatRequest('1', '@agent /subCommand \nPlease do with #selection\nand #debugConsole');
+		const result = parser.parseChatRequest(testSessionUri, '@agent /subCommand \nPlease do with #selection\nand #debugConsole');
 		await assertSnapshot(result);
 	});
 
@@ -346,13 +349,13 @@ suite('ChatRequestParser', () => {
 		// eslint-disable-next-line local/code-no-any-casts
 		instantiationService.stub(IChatAgentService, agentsService as any);
 
-		variableService.setSelectedToolAndToolSets('1', new Map([
+		variableService.setSelectedToolAndToolSets(testSessionUri, new Map([
 			[{ id: 'get_selection', toolReferenceName: 'selection', canBeReferencedInPrompt: true, displayName: '', modelDescription: '', source: ToolDataSource.Internal }, true],
 			[{ id: 'get_debugConsole', toolReferenceName: 'debugConsole', canBeReferencedInPrompt: true, displayName: '', modelDescription: '', source: ToolDataSource.Internal }, true]
 		] satisfies [IToolData | ToolSet, boolean][]));
 
 		parser = instantiationService.createInstance(ChatRequestParser);
-		const result = parser.parseChatRequest('1', '@agent Please \ndo /subCommand with #selection\nand #debugConsole');
+		const result = parser.parseChatRequest(testSessionUri, '@agent Please \ndo /subCommand with #selection\nand #debugConsole');
 		await assertSnapshot(result);
 	});
 });

--- a/src/vs/workbench/contrib/chat/test/common/chatService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/chatService.test.ts
@@ -179,8 +179,8 @@ suite('ChatService', () => {
 		session2.addRequest({ parts: [], text: 'request 2' }, { variables: [] }, 0);
 
 		// Clear sessions to trigger persistence to file service
-		await testService.clearSession(session1.sessionId);
-		await testService.clearSession(session2.sessionId);
+		await testService.clearSession(session1.sessionResource);
+		await testService.clearSession(session2.sessionResource);
 
 		// Verify that sessions were written to the file service
 		assert.strictEqual(testFileService.writeOperations.length, 2, 'Should have written 2 sessions to file service');
@@ -197,8 +197,8 @@ suite('ChatService', () => {
 		const testService2 = testDisposables.add(instantiationService.createInstance(ChatService));
 
 		// Retrieve sessions and verify they're loaded from file service
-		const retrieved1 = testDisposables.add((await testService2.getOrRestoreSession(session1.sessionId))!);
-		const retrieved2 = testDisposables.add((await testService2.getOrRestoreSession(session2.sessionId))!);
+		const retrieved1 = testDisposables.add((await testService2.getOrRestoreSession(session1.sessionResource))!);
+		const retrieved2 = testDisposables.add((await testService2.getOrRestoreSession(session2.sessionResource))!);
 
 		assert.ok(retrieved1, 'Should retrieve session 1');
 		assert.ok(retrieved2, 'Should retrieve session 2');
@@ -212,7 +212,7 @@ suite('ChatService', () => {
 		const model = testDisposables.add(testService.startSession(ChatAgentLocation.Chat, CancellationToken.None));
 		assert.strictEqual(model.getRequests().length, 0);
 
-		await testService.addCompleteRequest(model.sessionId, 'test request', undefined, 0, { message: 'test response' });
+		await testService.addCompleteRequest(model.sessionResource, 'test request', undefined, 0, { message: 'test response' });
 		assert.strictEqual(model.getRequests().length, 1);
 		assert.ok(model.getRequests()[0].response);
 		assert.strictEqual(model.getRequests()[0].response?.response.toString(), 'test response');
@@ -222,7 +222,7 @@ suite('ChatService', () => {
 		const testService = testDisposables.add(instantiationService.createInstance(ChatService));
 
 		const model = testDisposables.add(testService.startSession(ChatAgentLocation.Chat, CancellationToken.None));
-		const response = await testService.sendRequest(model.sessionId, `@${chatAgentWithUsedContextId} test request`);
+		const response = await testService.sendRequest(model.sessionResource, `@${chatAgentWithUsedContextId} test request`);
 		assert(response);
 		await response.responseCompletePromise;
 
@@ -247,21 +247,21 @@ suite('ChatService', () => {
 		const model = testDisposables.add(testService.startSession(ChatAgentLocation.Chat, CancellationToken.None));
 
 		// Send a request to default agent
-		const response = await testService.sendRequest(model.sessionId, `test request`, { agentId: 'defaultAgent' });
+		const response = await testService.sendRequest(model.sessionResource, `test request`, { agentId: 'defaultAgent' });
 		assert(response);
 		await response.responseCompletePromise;
 		assert.strictEqual(model.getRequests().length, 1);
 		assert.strictEqual(model.getRequests()[0].response?.result?.metadata?.historyLength, 0);
 
 		// Send a request to agent2- it can't see the default agent's message
-		const response2 = await testService.sendRequest(model.sessionId, `test request`, { agentId: 'agent2' });
+		const response2 = await testService.sendRequest(model.sessionResource, `test request`, { agentId: 'agent2' });
 		assert(response2);
 		await response2.responseCompletePromise;
 		assert.strictEqual(model.getRequests().length, 2);
 		assert.strictEqual(model.getRequests()[1].response?.result?.metadata?.historyLength, 0);
 
 		// Send a request to defaultAgent - the default agent can see agent2's message
-		const response3 = await testService.sendRequest(model.sessionId, `test request`, { agentId: 'defaultAgent' });
+		const response3 = await testService.sendRequest(model.sessionResource, `test request`, { agentId: 'defaultAgent' });
 		assert(response3);
 		await response3.responseCompletePromise;
 		assert.strictEqual(model.getRequests().length, 3);
@@ -278,12 +278,12 @@ suite('ChatService', () => {
 
 		await assertSnapshot(toSnapshotExportData(model));
 
-		const response = await testService.sendRequest(model.sessionId, `@${chatAgentWithUsedContextId} test request`);
+		const response = await testService.sendRequest(model.sessionResource, `@${chatAgentWithUsedContextId} test request`);
 		assert(response);
 		await response.responseCompletePromise;
 		assert.strictEqual(model.getRequests().length, 1);
 
-		const response2 = await testService.sendRequest(model.sessionId, `test request 2`);
+		const response2 = await testService.sendRequest(model.sessionResource, `test request 2`);
 		assert(response2);
 		await response2.responseCompletePromise;
 		assert.strictEqual(model.getRequests().length, 2);
@@ -302,7 +302,7 @@ suite('ChatService', () => {
 			const chatModel1 = testDisposables.add(testService.startSession(ChatAgentLocation.Chat, CancellationToken.None));
 			assert.strictEqual(chatModel1.getRequests().length, 0);
 
-			const response = await testService.sendRequest(chatModel1.sessionId, `@${chatAgentWithUsedContextId} test request`);
+			const response = await testService.sendRequest(chatModel1.sessionResource, `@${chatAgentWithUsedContextId} test request`);
 			assert(response);
 
 			await response.responseCompletePromise;
@@ -331,7 +331,7 @@ suite('ChatService', () => {
 			const chatModel1 = testDisposables.add(testService.startSession(ChatAgentLocation.Chat, CancellationToken.None));
 			assert.strictEqual(chatModel1.getRequests().length, 0);
 
-			const response = await testService.sendRequest(chatModel1.sessionId, `@${chatAgentWithUsedContextId} test request`);
+			const response = await testService.sendRequest(chatModel1.sessionResource, `@${chatAgentWithUsedContextId} test request`);
 			assert(response);
 
 			await response.responseCompletePromise;

--- a/src/vs/workbench/contrib/chat/test/common/mockChatService.ts
+++ b/src/vs/workbench/contrib/chat/test/common/mockChatService.ts
@@ -5,6 +5,7 @@
 
 import { CancellationToken } from '../../../../../base/common/cancellation.js';
 import { Event } from '../../../../../base/common/event.js';
+import { ResourceMap } from '../../../../../base/common/map.js';
 import { observableValue } from '../../../../../base/common/observable.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { ChatModel, IChatModel, IChatRequestModel, IChatRequestVariableData, ISerializableChatData } from '../../common/chatModel.js';
@@ -13,9 +14,6 @@ import { IChatCompleteResponse, IChatDetail, IChatProviderInfo, IChatSendRequest
 import { ChatAgentLocation } from '../../common/constants.js';
 
 export class MockChatService implements IChatService {
-	getChatSessionFromInternalId(modelSessionId: string): IChatSessionContext | undefined {
-		throw new Error('Method not implemented.');
-	}
 	requestInProgressObs = observableValue('name', false);
 	edits2Enabled: boolean = false;
 	_serviceBrand: undefined;
@@ -23,7 +21,7 @@ export class MockChatService implements IChatService {
 	transferredSessionData: IChatTransferredSessionData | undefined;
 	readonly onDidSubmitRequest: Event<{ chatSessionId: string }> = Event.None;
 
-	private sessions = new Map<string, IChatModel>();
+	private sessions = new ResourceMap<IChatModel>();
 
 	isEnabled(location: ChatAgentLocation): boolean {
 		throw new Error('Method not implemented.');
@@ -38,16 +36,16 @@ export class MockChatService implements IChatService {
 		throw new Error('Method not implemented.');
 	}
 	addSession(session: IChatModel): void {
-		this.sessions.set(session.sessionId, session);
+		this.sessions.set(session.sessionResource, session);
 	}
-	getSession(sessionId: string): IChatModel | undefined {
+	getSession(sessionResource: URI): IChatModel | undefined {
 		// eslint-disable-next-line local/code-no-dangerous-type-assertions
-		return this.sessions.get(sessionId) ?? {} as IChatModel;
+		return this.sessions.get(sessionResource) ?? {} as IChatModel;
 	}
-	async getOrRestoreSession(sessionId: string): Promise<IChatModel | undefined> {
+	async getOrRestoreSession(sessionResource: URI): Promise<IChatModel | undefined> {
 		throw new Error('Method not implemented.');
 	}
-	getPersistedSessionTitle(sessionId: string): string | undefined {
+	getPersistedSessionTitle(sessionResource: URI): string | undefined {
 		throw new Error('Method not implemented.');
 	}
 	loadSessionFromContent(data: ISerializableChatData): IChatModel | undefined {
@@ -59,25 +57,25 @@ export class MockChatService implements IChatService {
 	/**
 	 * Returns whether the request was accepted.
 	 */
-	sendRequest(sessionId: string, message: string): Promise<IChatSendRequestData | undefined> {
+	sendRequest(sessionResource: URI, message: string): Promise<IChatSendRequestData | undefined> {
 		throw new Error('Method not implemented.');
 	}
 	resendRequest(request: IChatRequestModel, options?: IChatSendRequestOptions | undefined): Promise<void> {
 		throw new Error('Method not implemented.');
 	}
-	adoptRequest(sessionId: string, request: IChatRequestModel): Promise<void> {
+	adoptRequest(sessionResource: URI, request: IChatRequestModel): Promise<void> {
 		throw new Error('Method not implemented.');
 	}
-	removeRequest(sessionid: string, requestId: string): Promise<void> {
+	removeRequest(sessionResource: URI, requestId: string): Promise<void> {
 		throw new Error('Method not implemented.');
 	}
-	cancelCurrentRequestForSession(sessionId: string): void {
+	cancelCurrentRequestForSession(sessionResource: URI): void {
 		throw new Error('Method not implemented.');
 	}
-	clearSession(sessionId: string): Promise<void> {
+	clearSession(sessionResource: URI): Promise<void> {
 		throw new Error('Method not implemented.');
 	}
-	addCompleteRequest(sessionId: string, message: IParsedChatRequest | string, variableData: IChatRequestVariableData | undefined, attempt: number | undefined, response: IChatCompleteResponse): void {
+	addCompleteRequest(sessionResource: URI, message: IParsedChatRequest | string, variableData: IChatRequestVariableData | undefined, attempt: number | undefined, response: IChatCompleteResponse): void {
 		throw new Error('Method not implemented.');
 	}
 	async getLocalSessionHistory(): Promise<IChatDetail[]> {
@@ -94,7 +92,7 @@ export class MockChatService implements IChatService {
 	notifyUserAction(event: IChatUserActionEvent): void {
 		throw new Error('Method not implemented.');
 	}
-	readonly onDidDisposeSession: Event<{ sessionId: string; reason: 'cleared' }> = undefined!;
+	readonly onDidDisposeSession: Event<{ sessionResource: URI; reason: 'cleared' }> = undefined!;
 
 	transferChatSession(transferredSessionData: IChatTransferredSessionData, toWorkspace: URI): void {
 		throw new Error('Method not implemented.');
@@ -116,11 +114,15 @@ export class MockChatService implements IChatService {
 		throw new Error('Method not implemented.');
 	}
 
-	isPersistedSessionEmpty(sessionId: string): boolean {
+	isPersistedSessionEmpty(sessionResource: URI): boolean {
 		throw new Error('Method not implemented.');
 	}
 
 	activateDefaultAgent(location: ChatAgentLocation): Promise<void> {
+		throw new Error('Method not implemented.');
+	}
+
+	getChatSessionFromInternalUri(sessionResource: URI): IChatSessionContext | undefined {
 		throw new Error('Method not implemented.');
 	}
 }

--- a/src/vs/workbench/contrib/chat/test/common/mockChatVariables.ts
+++ b/src/vs/workbench/contrib/chat/test/common/mockChatVariables.ts
@@ -3,28 +3,30 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { ResourceMap } from '../../../../../base/common/map.js';
+import { URI } from '../../../../../base/common/uri.js';
 import { IChatVariablesService, IDynamicVariable } from '../../common/chatVariables.js';
 import { IToolAndToolSetEnablementMap } from '../../common/languageModelToolsService.js';
 
 export class MockChatVariablesService implements IChatVariablesService {
 	_serviceBrand: undefined;
 
-	private _dynamicVariables = new Map<string, readonly IDynamicVariable[]>();
-	private _selectedToolAndToolSets = new Map<string, IToolAndToolSetEnablementMap>();
+	private _dynamicVariables = new ResourceMap<readonly IDynamicVariable[]>();
+	private _selectedToolAndToolSets = new ResourceMap<IToolAndToolSetEnablementMap>();
 
-	getDynamicVariables(sessionId: string): readonly IDynamicVariable[] {
-		return this._dynamicVariables.get(sessionId) ?? [];
+	getDynamicVariables(sessionResource: URI): readonly IDynamicVariable[] {
+		return this._dynamicVariables.get(sessionResource) ?? [];
 	}
 
-	getSelectedToolAndToolSets(sessionId: string): IToolAndToolSetEnablementMap {
-		return this._selectedToolAndToolSets.get(sessionId) ?? new Map();
+	getSelectedToolAndToolSets(sessionResource: URI): IToolAndToolSetEnablementMap {
+		return this._selectedToolAndToolSets.get(sessionResource) ?? new Map();
 	}
 
-	setDynamicVariables(sessionId: string, variables: readonly IDynamicVariable[]): void {
-		this._dynamicVariables.set(sessionId, variables);
+	setDynamicVariables(sessionResource: URI, variables: readonly IDynamicVariable[]): void {
+		this._dynamicVariables.set(sessionResource, variables);
 	}
 
-	setSelectedToolAndToolSets(sessionId: string, tools: IToolAndToolSetEnablementMap): void {
-		this._selectedToolAndToolSets.set(sessionId, tools);
+	setSelectedToolAndToolSets(sessionResource: URI, tools: IToolAndToolSetEnablementMap): void {
+		this._selectedToolAndToolSets.set(sessionResource, tools);
 	}
 }

--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChatActions.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChatActions.ts
@@ -764,7 +764,7 @@ export class CancelRequestAction extends AbstractInline2ChatAction {
 		if (viewModel) {
 			ctrl.toggleWidgetUntilNextRequest();
 			ctrl.markActiveController();
-			chatService.cancelCurrentRequestForSession(viewModel.sessionId);
+			chatService.cancelCurrentRequestForSession(viewModel.sessionResource);
 		}
 	}
 }

--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChatController.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChatController.ts
@@ -688,7 +688,7 @@ export class InlineChatController1 implements IEditorContribution {
 		let next: State.WAIT_FOR_INPUT | State.SHOW_REQUEST | State.CANCEL | State.PAUSE | State.ACCEPT = State.WAIT_FOR_INPUT;
 		store.add(Event.once(this._messages.event)(message => {
 			this._log('state=_makeRequest) message received', message);
-			this._chatService.cancelCurrentRequestForSession(chatModel.sessionId);
+			this._chatService.cancelCurrentRequestForSession(chatModel.sessionResource);
 			if (message & Message.CANCEL_SESSION) {
 				next = State.CANCEL;
 			} else if (message & Message.PAUSE_SESSION) {
@@ -755,7 +755,7 @@ export class InlineChatController1 implements IEditorContribution {
 
 		// cancel the request when the user types
 		store.add(this._ui.value.widget.chatWidget.inputEditor.onDidChangeModelContent(() => {
-			this._chatService.cancelCurrentRequestForSession(chatModel.sessionId);
+			this._chatService.cancelCurrentRequestForSession(chatModel.sessionResource);
 		}));
 
 		let lastLength = 0;
@@ -1141,7 +1141,7 @@ export class InlineChatController1 implements IEditorContribution {
 		const response = this._session?.chatModel.getRequests().at(-1)?.response;
 		if (response) {
 			this._chatService.notifyUserAction({
-				sessionId: response.session.sessionId,
+				sessionResource: response.session.sessionResource,
 				requestId: response.requestId,
 				agentId: response.agent?.id,
 				command: response.slashCommand?.name,
@@ -1176,7 +1176,7 @@ export class InlineChatController1 implements IEditorContribution {
 		const response = this._session?.chatModel.lastRequest?.response;
 		if (response) {
 			this._chatService.notifyUserAction({
-				sessionId: response.session.sessionId,
+				sessionResource: response.session.sessionResource,
 				requestId: response.requestId,
 				agentId: response.agent?.id,
 				command: response.slashCommand?.name,
@@ -1196,7 +1196,7 @@ export class InlineChatController1 implements IEditorContribution {
 		const response = this._session?.chatModel.lastRequest?.response;
 		if (response) {
 			this._chatService.notifyUserAction({
-				sessionId: response.session.sessionId,
+				sessionResource: response.session.sessionResource,
 				requestId: response.requestId,
 				agentId: response.agent?.id,
 				command: response.slashCommand?.name,

--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChatSessionService.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChatSessionService.ts
@@ -83,7 +83,7 @@ export async function moveToPanelChat(accessor: ServicesAccessor, model: IChatMo
 	if (widget && widget.viewModel && model) {
 		let lastRequest: IChatRequestModel | undefined;
 		for (const request of model.getRequests().slice()) {
-			await chatService.adoptRequest(widget.viewModel.model.sessionId, request);
+			await chatService.adoptRequest(widget.viewModel.model.sessionResource, request);
 			lastRequest = request;
 		}
 

--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChatSessionServiceImpl.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChatSessionServiceImpl.ts
@@ -130,7 +130,7 @@ export class InlineChatSessionServiceImpl implements IInlineChatSessionService {
 			const doesOtherSessionUseChatModel = [...this._sessions.values()].some(data => data.session !== session && data.session.chatModel === chatModel);
 
 			if (!doesOtherSessionUseChatModel) {
-				this._chatService.clearSession(chatModel.sessionId);
+				this._chatService.clearSession(chatModel.sessionResource);
 				chatModel.dispose();
 			}
 		}));
@@ -353,7 +353,7 @@ export class InlineChatSessionServiceImpl implements IInlineChatSessionService {
 
 		const store = new DisposableStore();
 		store.add(toDisposable(() => {
-			this._chatService.cancelCurrentRequestForSession(chatModel.sessionId);
+			this._chatService.cancelCurrentRequestForSession(chatModel.sessionResource);
 			editingSession.reject();
 			this._sessions2.delete(uri);
 			this._onDidChangeSessions.fire(this);
@@ -545,7 +545,7 @@ export class InlineChatEscapeToolContribution extends Disposable {
 
 				} else {
 					logService.trace('InlineChatEscapeToolContribution: rephrase prompt');
-					chatService.removeRequest(session.chatModel.sessionId, session.chatModel.getRequests().at(-1)!.id);
+					chatService.removeRequest(session.chatModel.sessionResource, session.chatModel.getRequests().at(-1)!.id);
 				}
 
 				return { content: [{ kind: 'text', value: 'Success' }] };

--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChatWidget.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChatWidget.ts
@@ -57,6 +57,7 @@ import { CTX_INLINE_CHAT_FOCUSED, CTX_INLINE_CHAT_RESPONSE_FOCUSED, inlineChatBa
 import { HunkInformation, Session } from './inlineChatSession.js';
 import './media/inlineChat.css';
 import { ChatMode } from '../../chat/common/chatModes.js';
+import { isEqual } from '../../../../base/common/resources.js';
 
 export interface InlineChatWidgetViewState {
 	editorViewState: ICodeEditorViewState;
@@ -282,7 +283,7 @@ export class InlineChatWidget {
 		}));
 
 		this._store.add(this._chatService.onDidPerformUserAction(e => {
-			if (e.sessionId === this._chatWidget.viewModel?.model.sessionId && e.action.kind === 'vote') {
+			if (isEqual(e.sessionResource, this._chatWidget.viewModel?.model.sessionResource) && e.action.kind === 'vote') {
 				this.updateStatus(localize('feedbackThanks', "Thank you for your feedback!"), { resetAfter: 1250 });
 			}
 		}));

--- a/src/vs/workbench/contrib/inlineChat/test/browser/inlineChatController.test.ts
+++ b/src/vs/workbench/contrib/inlineChat/test/browser/inlineChatController.test.ts
@@ -900,7 +900,7 @@ suite('InlineChatController', function () {
 		assert.strictEqual(model.getValue(), 'HelloWorld'); // first word has been streamed
 
 		const p2 = ctrl.awaitStates([State.WAIT_FOR_INPUT]);
-		chatService.cancelCurrentRequestForSession(ctrl.chatWidget.viewModel!.model.sessionId);
+		chatService.cancelCurrentRequestForSession(ctrl.chatWidget.viewModel!.model.sessionResource);
 		assert.strictEqual(await p2, undefined);
 
 		assert.strictEqual(model.getValue(), 'HelloWorld'); // CANCEL just stops the request and progressive typing but doesn't undo
@@ -914,7 +914,7 @@ suite('InlineChatController', function () {
 		const newSession = await inlineChatSessionService.createSession(editor, {}, CancellationToken.None);
 		assertType(newSession);
 
-		await (await chatService.sendRequest(newSession.chatModel.sessionId, 'Existing', { location: ChatAgentLocation.EditorInline }))?.responseCreatedPromise;
+		await (await chatService.sendRequest(newSession.chatModel.sessionResource, 'Existing', { location: ChatAgentLocation.EditorInline }))?.responseCreatedPromise;
 
 		assert.strictEqual(newSession.chatModel.requestInProgress, true);
 
@@ -1021,7 +1021,7 @@ suite('InlineChatController', function () {
 		assert.strictEqual(await p, undefined);
 
 		const p2 = ctrl.awaitStates([State.WAIT_FOR_INPUT]);
-		chatService.cancelCurrentRequestForSession(ctrl.chatWidget.viewModel!.model.sessionId);
+		chatService.cancelCurrentRequestForSession(ctrl.chatWidget.viewModel!.model.sessionResource);
 		assert.strictEqual(await p2, undefined);
 
 

--- a/src/vs/workbench/contrib/mcp/browser/mcpElicitationService.ts
+++ b/src/vs/workbench/contrib/mcp/browser/mcpElicitationService.ts
@@ -13,6 +13,7 @@ import { IQuickInputService, IQuickPick, IQuickPickItem } from '../../../../plat
 import { ChatElicitationRequestPart } from '../../chat/browser/chatElicitationRequestPart.js';
 import { ChatModel } from '../../chat/common/chatModel.js';
 import { IChatService } from '../../chat/common/chatService.js';
+import { LocalChatSessionUri } from '../../chat/common/chatUri.js';
 import { IMcpElicitationService, IMcpServer, IMcpToolCallContext } from '../common/mcpTypes.js';
 import { mcpServerToSourceData } from '../common/mcpTypesUtils.js';
 import { MCP } from '../common/modelContextProtocol.js';
@@ -31,7 +32,7 @@ export class McpElicitationService implements IMcpElicitationService {
 	public elicit(server: IMcpServer, context: IMcpToolCallContext | undefined, elicitation: MCP.ElicitRequest['params'], token: CancellationToken): Promise<MCP.ElicitResult> {
 		const store = new DisposableStore();
 		return new Promise<MCP.ElicitResult>(resolve => {
-			const chatModel = context?.chatSessionId && this._chatService.getSession(context.chatSessionId);
+			const chatModel = context?.chatSessionId && this._chatService.getSession(LocalChatSessionUri.forSession(context.chatSessionId));
 			if (chatModel instanceof ChatModel) {
 				const request = chatModel.getRequests().at(-1);
 				if (request) {

--- a/src/vs/workbench/contrib/terminalContrib/chat/browser/terminalChatController.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chat/browser/terminalChatController.ts
@@ -154,7 +154,6 @@ export class TerminalChatController extends Disposable implements ITerminalContr
 }
 
 async function moveToPanelChat(accessor: ServicesAccessor, model: IChatModel | undefined) {
-
 	const viewsService = accessor.get(IViewsService);
 	const chatService = accessor.get(IChatService);
 	const layoutService = accessor.get(IWorkbenchLayoutService);
@@ -163,7 +162,7 @@ async function moveToPanelChat(accessor: ServicesAccessor, model: IChatModel | u
 
 	if (widget && widget.viewModel && model) {
 		for (const request of model.getRequests().slice()) {
-			await chatService.adoptRequest(widget.viewModel.model.sessionId, request);
+			await chatService.adoptRequest(widget.viewModel.model.sessionResource, request);
 		}
 		widget.focusResponseItem();
 	}

--- a/src/vs/workbench/contrib/terminalContrib/chat/browser/terminalChatService.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chat/browser/terminalChatService.ts
@@ -12,6 +12,7 @@ import { IStorageService, StorageScope, StorageTarget } from '../../../../../pla
 import { TerminalCapability } from '../../../../../platform/terminal/common/capabilities/capabilities.js';
 import { IChatService } from '../../../chat/common/chatService.js';
 import { TerminalChatContextKeys } from './terminalChat.js';
+import { LocalChatSessionUri } from '../../../chat/common/chatUri.js';
 
 const enum StorageKeys {
 	ToolSessionMappings = 'terminalChat.toolSessionMappings',
@@ -73,7 +74,7 @@ export class TerminalChatService extends Disposable implements ITerminalChatServ
 			listener.dispose();
 		}));
 		this._register(this._chatService.onDidDisposeSession(e => {
-			if (e.sessionId === terminalToolSessionId) {
+			if (LocalChatSessionUri.parseLocalSessionId(e.sessionResource) === terminalToolSessionId) {
 				this._terminalInstancesByToolSessionId.delete(terminalToolSessionId);
 				this._terminalInstanceListenersByToolSessionId.deleteAndDispose(terminalToolSessionId);
 				this._commandIdByToolSessionId.delete(terminalToolSessionId);

--- a/src/vs/workbench/contrib/terminalContrib/chat/browser/terminalChatWidget.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chat/browser/terminalChatWidget.ts
@@ -425,10 +425,10 @@ export class TerminalChatWidget extends Disposable {
 		this._activeRequestCts?.cancel();
 		this._requestActiveContextKey.set(false);
 		const model = this._inlineChatWidget.getChatModel();
-		if (!model?.sessionId) {
+		if (!model?.sessionResource) {
 			return;
 		}
-		this._chatService.cancelCurrentRequestForSession(model?.sessionId);
+		this._chatService.cancelCurrentRequestForSession(model?.sessionResource);
 	}
 
 	async viewInChat(): Promise<void> {
@@ -469,7 +469,7 @@ export class TerminalChatWidget extends Disposable {
 			}
 		}
 
-		this._chatService.addCompleteRequest(widget!.viewModel!.sessionId,
+		this._chatService.addCompleteRequest(widget!.viewModel!.sessionResource,
 			`@${this._terminalAgentName} ${currentRequest.message.text}`,
 			currentRequest.variableData,
 			currentRequest.attempt,

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/monitoring/outputMonitor.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/monitoring/outputMonitor.ts
@@ -29,6 +29,7 @@ import { IConfigurationService } from '../../../../../../../platform/configurati
 import { TerminalChatAgentToolsSettingId } from '../../../common/terminalChatAgentToolsConfiguration.js';
 import { ILogService } from '../../../../../../../platform/log/common/log.js';
 import { ITerminalService } from '../../../../../terminal/browser/terminal.js';
+import { LocalChatSessionUri } from '../../../../../chat/common/chatUri.js';
 
 export interface IOutputMonitor extends Disposable {
 	readonly pollingResult: IPollingResult & { pollDurationMs: number } | undefined;
@@ -622,7 +623,7 @@ export class OutputMonitor extends Disposable implements IOutputMonitor {
 		onReject?: () => Promise<T | undefined> | T | undefined,
 		moreActions?: IAction[] | undefined
 	): { promise: Promise<T | undefined>; part: ChatElicitationRequestPart } {
-		const chatModel = sessionId && this._chatService.getSession(sessionId);
+		const chatModel = sessionId && this._chatService.getSession(LocalChatSessionUri.forSession(sessionId));
 		if (!(chatModel instanceof ChatModel)) {
 			throw new Error('No model');
 		}

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
@@ -46,6 +46,7 @@ import { CommandLineAutoApproveAnalyzer } from './commandLineAnalyzer/commandLin
 import { CommandLineFileWriteAnalyzer } from './commandLineAnalyzer/commandLineFileWriteAnalyzer.js';
 import { OutputMonitor } from './monitoring/outputMonitor.js';
 import { IPollingResult, OutputMonitorState } from './monitoring/types.js';
+import { LocalChatSessionUri } from '../../../../chat/common/chatUri.js';
 
 // #region Tool data
 
@@ -313,7 +314,10 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 
 		// Listen for chat session disposal to clean up associated terminals
 		this._register(this._chatService.onDidDisposeSession(e => {
-			this._cleanupSessionTerminals(e.sessionId);
+			const localSession = LocalChatSessionUri.parse(e.sessionResource);
+			if (localSession) {
+				this._cleanupSessionTerminals(localSession.sessionId);
+			}
 		}));
 	}
 


### PR DESCRIPTION
Moves the chat service public APIs to use uris for identifying sessions instead of ids. These uris are preferred as they work correctly for both contributed and local session

This ends up touch a lot of the chat apis. In most cases, the change is simply to pass in the URI instead of the id. In a few cases where the URI hasn't been fully hooked up, I am using `LocalChatSessionUri` to do this conversation

For the chat session implementation, I also switched to use resource maps to store session specific information instead of a normal map

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
