### PR TITLE
Switch many callers to use `getWidgetBySessionResource`

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/actions/chatMoveActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatMoveActions.ts
@@ -121,8 +121,7 @@ async function executeMoveToAction(accessor: ServicesAccessor, moveTo: MoveToNew
 		return;
 	}
 
-	const sessionId = widget.viewModel.sessionId;
-	const existingWidget = widgetService.getWidgetBySessionId(sessionId);
+	const existingWidget = widgetService.getWidgetBySessionResource(widget.viewModel.sessionResource);
 	if (!existingWidget) {
 		// Do NOT attempt to open a session that isn't already open since we cannot guarantee its state.
 		await editorService.openEditor({ resource: ChatEditorInput.getNewEditorUri(), options: { pinned: true, auxiliary: { compact: true, bounds: { width: 640, height: 640 } } } }, moveTo === MoveToNewLocation.Window ? AUX_WINDOW_GROUP : ACTIVE_GROUP);

--- a/src/vs/workbench/contrib/chat/browser/actions/chatSessionActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatSessionActions.ts
@@ -176,7 +176,6 @@ export class OpenChatSessionInNewWindowAction extends Action2 {
 
 		const editorService = accessor.get(IEditorService);
 		const chatWidgetService = accessor.get(IChatWidgetService);
-		const sessionId = context.session.id;
 		const editorGroupsService = accessor.get(IEditorGroupsService);
 		if (context.session.provider?.chatSessionType) {
 			const uri = context.session.resource;
@@ -186,7 +185,7 @@ export class OpenChatSessionInNewWindowAction extends Action2 {
 			if (existingEditor) {
 				await editorService.openEditor(existingEditor.editor, existingEditor.group);
 				return;
-			} else if (chatWidgetService.getWidgetBySessionId(sessionId)) {
+			} else if (chatWidgetService.getWidgetBySessionResource(uri)) {
 				return;
 			} else {
 				const options: IChatEditorOptions = {
@@ -223,7 +222,6 @@ export class OpenChatSessionInNewEditorGroupAction extends Action2 {
 
 		const editorService = accessor.get(IEditorService);
 		const chatWidgetService = accessor.get(IChatWidgetService);
-		const sessionId = context.session.id;
 		const editorGroupsService = accessor.get(IEditorGroupsService);
 		if (context.session.provider?.chatSessionType) {
 			const uri = context.session.resource;
@@ -232,7 +230,7 @@ export class OpenChatSessionInNewEditorGroupAction extends Action2 {
 			if (existingEditor) {
 				await editorService.openEditor(existingEditor.editor, existingEditor.group);
 				return;
-			} else if (chatWidgetService.getWidgetBySessionId(sessionId)) {
+			} else if (chatWidgetService.getWidgetBySessionResource(uri)) {
 				// Already opened in chat widget
 				return;
 			} else {
@@ -284,7 +282,7 @@ export class OpenChatSessionInSidebarAction extends Action2 {
 		if (existingEditor) {
 			await editorService.openEditor(existingEditor.editor, existingEditor.group);
 			return;
-		} else if (chatWidgetService.getWidgetBySessionId(context.session.id)) {
+		} else if (chatWidgetService.getWidgetBySessionResource(context.session.resource)) {
 			return;
 		}
 

--- a/src/vs/workbench/contrib/chat/browser/actions/chatTitleActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatTitleActions.ts
@@ -219,7 +219,7 @@ export function registerChatTitleActions() {
 				return;
 			}
 			const itemIndex = chatRequests?.findIndex(request => request.id === item.requestId);
-			const widget = chatWidgetService.getWidgetBySessionId(item.sessionId);
+			const widget = chatWidgetService.getWidgetBySessionResource(item.sessionResource);
 			const mode = widget?.input.currentModeKind;
 			if (chatModel && (mode === ChatModeKind.Edit || mode === ChatModeKind.Agent)) {
 				const configurationService = accessor.get(IConfigurationService);

--- a/src/vs/workbench/contrib/chat/browser/chat.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.ts
@@ -48,8 +48,11 @@ export interface IChatWidgetService {
 
 	getAllWidgets(): ReadonlyArray<IChatWidget>;
 	getWidgetByInputUri(uri: URI): IChatWidget | undefined;
+
+	/** @deprecated Use {@link getWidgetBySessionResource} instead */
 	getWidgetBySessionId(sessionId: string): IChatWidget | undefined;
 	getWidgetBySessionResource(sessionResource: URI): IChatWidget | undefined;
+
 	getWidgetsByLocations(location: ChatAgentLocation): ReadonlyArray<IChatWidget>;
 }
 

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/chatConfirmationContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/chatConfirmationContentPart.ts
@@ -54,7 +54,7 @@ export class ChatConfirmationContentPart extends Disposable implements IChatCont
 				options.agentId = element.agent?.id;
 				options.slashCommand = element.slashCommand?.name;
 				options.confirmation = e.label;
-				const widget = chatWidgetService.getWidgetBySessionId(element.sessionId);
+				const widget = chatWidgetService.getWidgetBySessionResource(element.sessionResource);
 				options.userSelectedModelId = widget?.input.currentLanguageModel;
 				options.modeInfo = widget?.input.currentModeInfo;
 				options.location = widget?.location;

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/chatErrorConfirmationPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/chatErrorConfirmationPart.ts
@@ -59,7 +59,7 @@ export class ChatErrorConfirmationContentPart extends Disposable implements ICha
 				options.agentId = element.agent?.id;
 				options.slashCommand = element.slashCommand?.name;
 				options.confirmation = buttonData.label;
-				const widget = chatWidgetService.getWidgetBySessionId(element.sessionId);
+				const widget = chatWidgetService.getWidgetBySessionResource(element.sessionResource);
 				options.userSelectedModelId = widget?.input.currentLanguageModel;
 				Object.assign(options, widget?.getModeRequestOptions());
 				if (await chatService.sendRequest(element.sessionResource, prompt, options)) {

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/chatQuotaExceededPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/chatQuotaExceededPart.ts
@@ -104,7 +104,7 @@ export class ChatQuotaExceededPart extends Disposable implements IChatContentPar
 			this._onDidChangeHeight.fire();
 
 			this._register(retryButton.onDidClick(() => {
-				const widget = chatWidgetService.getWidgetBySessionId(element.sessionId);
+				const widget = chatWidgetService.getWidgetBySessionResource(element.sessionResource);
 				if (!widget) {
 					return;
 				}

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/abstractToolConfirmationSubPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/abstractToolConfirmationSubPart.ts
@@ -132,7 +132,7 @@ export abstract class AbstractToolConfirmationSubPart extends BaseChatToolInvoca
 				}
 			}
 
-			this.chatWidgetService.getWidgetBySessionId(this.context.element.sessionId)?.focusInput();
+			this.chatWidgetService.getWidgetBySessionResource(this.context.element.sessionResource)?.focusInput();
 		}));
 
 		this._register(confirmWidget.onDidChangeHeight(() => this._onDidChangeHeight.fire()));

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatExtensionsInstallToolSubPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatExtensionsInstallToolSubPart.ts
@@ -86,7 +86,7 @@ export class ExtensionsInstallConfirmationWidgetSubPart extends BaseChatToolInvo
 			dom.append(this.domNode, confirmWidget.domNode);
 			this._register(confirmWidget.onDidClick(button => {
 				IChatToolInvocation.confirmWith(toolInvocation, button.data);
-				chatWidgetService.getWidgetBySessionId(context.element.sessionId)?.focusInput();
+				chatWidgetService.getWidgetBySessionResource(context.element.sessionResource)?.focusInput();
 			}));
 			const hasToolConfirmationKey = ChatContextKeys.Editing.hasToolConfirmation.bindTo(contextKeyService);
 			hasToolConfirmationKey.set(true);

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatTerminalToolConfirmationSubPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatTerminalToolConfirmationSubPart.ts
@@ -303,7 +303,7 @@ export class ChatTerminalToolConfirmationSubPart extends BaseChatToolInvocationS
 
 			if (doComplete) {
 				IChatToolInvocation.confirmWith(toolInvocation, { type: toolConfirmKind });
-				this.chatWidgetService.getWidgetBySessionId(this.context.element.sessionId)?.focusInput();
+				this.chatWidgetService.getWidgetBySessionResource(this.context.element.sessionResource)?.focusInput();
 			}
 		}));
 		this._register(confirmWidget.onDidChangeHeight(() => this._onDidChangeHeight.fire()));

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatToolOutputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatToolOutputPart.ts
@@ -77,7 +77,7 @@ export class ChatToolOutputSubPart extends BaseChatToolInvocationSubPart {
 	}
 
 	private createOutputPart(toolInvocation: IChatToolInvocation | IChatToolInvocationSerialized, details: IToolResultOutputDetails): HTMLElement {
-		const vm = this.chatWidgetService.getWidgetBySessionId(this.context.element.sessionId)?.viewModel;
+		const vm = this.chatWidgetService.getWidgetBySessionResource(this.context.element.sessionResource)?.viewModel;
 
 		const parent = dom.$('div.webview-output');
 		parent.style.maxHeight = '80vh';
@@ -124,7 +124,7 @@ export class ChatToolOutputSubPart extends BaseChatToolInvocationSubPart {
 			}));
 
 			this._register(renderedItem.webview.onDidWheel(e => {
-				this.chatWidgetService.getWidgetBySessionId(this.context.element.sessionId)?.delegateScrollFromMouseWheelEvent({
+				this.chatWidgetService.getWidgetBySessionResource(this.context.element.sessionResource)?.delegateScrollFromMouseWheelEvent({
 					...e,
 					preventDefault: () => { },
 					stopPropagation: () => { }
@@ -132,7 +132,7 @@ export class ChatToolOutputSubPart extends BaseChatToolInvocationSubPart {
 			}));
 
 			// When the webview is disconnected from the DOM due to being hidden, we need to reload it when it is shown again.
-			const widget = this.chatWidgetService.getWidgetBySessionId(this.context.element.sessionId);
+			const widget = this.chatWidgetService.getWidgetBySessionResource(this.context.element.sessionResource);
 			if (widget) {
 				this._register(widget?.onDidShow(() => {
 					renderedItem.reinitialize();

--- a/src/vs/workbench/contrib/chat/browser/chatListRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatListRenderer.ts
@@ -575,7 +575,7 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 		const isFiltered = !!(isResponseVM(element) && element.errorDetails?.responseIsFiltered);
 		ChatContextKeys.responseIsFiltered.bindTo(templateData.contextKeyService).set(isFiltered);
 
-		const location = this.chatWidgetService.getWidgetBySessionId(element.sessionId)?.location;
+		const location = this.chatWidgetService.getWidgetBySessionResource(element.sessionResource)?.location;
 		templateData.rowContainer.classList.toggle('editing-session', location === ChatAgentLocation.Chat);
 		templateData.rowContainer.classList.toggle('interactive-request', isRequestVM(element));
 		templateData.rowContainer.classList.toggle('interactive-response', isResponseVM(element));

--- a/src/vs/workbench/contrib/chat/browser/chatSessions/common.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSessions/common.ts
@@ -155,7 +155,7 @@ export function getSessionItemContextOverlay(
 		isActiveSession = true;
 	} else if (session.isHistory && chatWidgetService && chatService && editorGroupsService) {
 		// Check if session is open in a chat widget
-		const widget = chatWidgetService.getWidgetBySessionId(session.id);
+		const widget = chatWidgetService.getWidgetBySessionResource(session.resource);
 		if (widget) {
 			isActiveSession = true;
 		} else {

--- a/src/vs/workbench/contrib/chat/browser/chatSessions/view/sessionsViewPane.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSessions/view/sessionsViewPane.ts
@@ -461,7 +461,7 @@ export class SessionsViewPane extends ViewPane {
 				await this.editorService.openEditor(existingEditor.editor, existingEditor.group);
 				return;
 			}
-			if (this.chatWidgetService.getWidgetBySessionId(session.id)) {
+			if (this.chatWidgetService.getWidgetBySessionResource(session.resource)) {
 				return;
 			}
 

--- a/src/vs/workbench/contrib/chat/browser/chatSetup.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSetup.ts
@@ -309,7 +309,7 @@ class SetupAgent extends Disposable implements IChatAgentImplementation {
 	}
 
 	private async doForwardRequestToChatWhenReady(requestModel: IChatRequestModel, progress: (part: IChatProgress) => void, chatService: IChatService, languageModelsService: ILanguageModelsService, chatAgentService: IChatAgentService, chatWidgetService: IChatWidgetService, languageModelToolsService: ILanguageModelToolsService): Promise<void> {
-		const widget = chatWidgetService.getWidgetBySessionId(requestModel.session.sessionId);
+		const widget = chatWidgetService.getWidgetBySessionResource(requestModel.session.sessionResource);
 		const modeInfo = widget?.input.currentModeInfo;
 
 		// We need a signal to know when we can resend the request to

--- a/src/vs/workbench/contrib/chat/browser/contrib/chatInputRelatedFilesContrib.ts
+++ b/src/vs/workbench/contrib/chat/browser/contrib/chatInputRelatedFilesContrib.ts
@@ -30,7 +30,7 @@ export class ChatRelatedFilesContribution extends Disposable implements IWorkben
 		this._register(autorun((reader) => {
 			const sessions = this.chatEditingService.editingSessionsObs.read(reader);
 			sessions.forEach(session => {
-				const widget = this.chatWidgetService.getWidgetBySessionId(session.chatSessionId);
+				const widget = this.chatWidgetService.getWidgetBySessionResource(session.chatSessionResource);
 				if (widget && !this.chatEditingSessionDisposables.has(session.chatSessionId)) {
 					this._handleNewEditingSession(session, widget);
 				}

--- a/src/vs/workbench/contrib/chat/electron-browser/actions/voiceChatActions.ts
+++ b/src/vs/workbench/contrib/chat/electron-browser/actions/voiceChatActions.ts
@@ -686,7 +686,7 @@ class ChatSynthesizerSessionController {
 	private static doCreateForFocusedChat(accessor: ServicesAccessor, response: IChatResponseModel): IChatSynthesizerSessionController {
 		const chatWidgetService = accessor.get(IChatWidgetService);
 		const contextKeyService = accessor.get(IContextKeyService);
-		let chatWidget = chatWidgetService.getWidgetBySessionId(response.session.sessionId);
+		let chatWidget = chatWidgetService.getWidgetBySessionResource(response.session.sessionResource);
 		if (chatWidget?.location === ChatAgentLocation.EditorInline) {
 			// workaround for https://github.com/microsoft/vscode/issues/212785
 			chatWidget = chatWidgetService.lastFocusedWidget;

--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChatActions.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChatActions.ts
@@ -382,7 +382,7 @@ export class RerunAction extends AbstractInline1ChatAction {
 
 		const lastRequest = model.getRequests().at(-1);
 		if (lastRequest) {
-			const widget = chatWidgetService.getWidgetBySessionId(model.sessionId);
+			const widget = chatWidgetService.getWidgetBySessionResource(model.sessionResource);
 			await chatService.resendRequest(lastRequest, {
 				noCommandDetection: false,
 				attempt: lastRequest.attempt + 1,

--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChatSessionServiceImpl.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChatSessionServiceImpl.ts
@@ -348,7 +348,7 @@ export class InlineChatSessionServiceImpl implements IInlineChatSessionService {
 		const chatModel = this._chatService.startSession(ChatAgentLocation.Chat, token, false);
 
 		const editingSession = await chatModel.editingSessionObs?.promise!;
-		const widget = this._chatWidgetService.getWidgetBySessionId(chatModel.sessionId);
+		const widget = this._chatWidgetService.getWidgetBySessionResource(chatModel.sessionResource);
 		await widget?.attachmentModel.addFile(uri);
 
 		const store = new DisposableStore();

--- a/src/vs/workbench/contrib/terminalContrib/chat/browser/terminalChatActions.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chat/browser/terminalChatActions.ts
@@ -265,7 +265,7 @@ registerActiveXtermAction({
 
 		const lastRequest = model.getRequests().at(-1);
 		if (lastRequest) {
-			const widget = chatWidgetService.getWidgetBySessionId(model.sessionId);
+			const widget = chatWidgetService.getWidgetBySessionResource(model.sessionResource);
 			await chatService.resendRequest(lastRequest, {
 				noCommandDetection: false,
 				attempt: lastRequest.attempt + 1,


### PR DESCRIPTION
This new version of the function should be preferred as it helps move us further along with using URIs for chat sessions

Will hold off on merging this until my bigger sessionId -> URI change lands in a released insiders  build