### PR TITLE
Make `workbench.editor.customLabels.patterns` setting case-insensitive

### DIFF
--- a/src/vs/workbench/services/editor/common/customEditorLabelService.ts
+++ b/src/vs/workbench/services/editor/common/customEditorLabelService.ts
@@ -90,7 +90,7 @@ export class CustomEditorLabelService extends Disposable implements ICustomEdito
 			}
 
 			const isAbsolutePath = isAbsolute(pattern);
-			const parsedPattern = parseGlob(pattern);
+			const parsedPattern = parseGlob(pattern, { ignoreCase: true });
 
 			this.patterns.push({ pattern, template, isAbsolutePath, parsedPattern });
 		}


### PR DESCRIPTION
Pass `{ ignoreCase: true }` to `glob.parse()` to make glob matching on the `workbench.editor.customLabels.patterns` setting case-insensitive. 

This simplifies experience for the users of this setting and I believe a case-sensitive functionality in this case is not expected/required.

Contributes towards fixing #10633.