### PR TITLE
Make `applyTo` glob pattern in prompt instructions case-insensitive

### DIFF
--- a/src/vs/workbench/contrib/chat/common/promptSyntax/computeAutomaticInstructions.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/computeAutomaticInstructions.ts
@@ -219,7 +219,7 @@ export class ComputeAutomaticInstructions {
 			// add the instructions file if its rule matches the file
 			for (const file of files) {
 				// if the file is not a valid URI, skip it
-				if (match(pattern, file.path)) {
+				if (match(pattern, file.path, { ignoreCase: true })) {
 					return { pattern, file }; // return the matched pattern and file URI
 				}
 			}
@@ -309,7 +309,7 @@ export class ComputeAutomaticInstructions {
 						const uri = refsToCheck[i].resource;
 						if (stat.success && stat.stat?.isFile) {
 							if (isPromptOrInstructionsFile(uri)) {
-								// only recursivly parse instruction files
+								// only recursively parse instruction files
 								todo.push(uri);
 							}
 							const reason = localize('instruction.file.reason.referenced', 'Referenced by {0}', basename(next));


### PR DESCRIPTION
Pass `{ ignoreCase: true }` to `glob.match()` to make glob matching on the `applyTo` pattern of prompt instructions case-insensitive.

This simplifies experience for the users of this setting and I believe a case-sensitive functionality in this case is not expected/required.

Contributes towards fixing #10633.