### PR TITLE
Add the missing 'StructuredBuffer' keyword in the HLSL syntax highlighting

### DIFF
--- a/extensions/hlsl/syntaxes/hlsl.tmLanguage.json
+++ b/extensions/hlsl/syntaxes/hlsl.tmLanguage.json
@@ -104,7 +104,7 @@
 		},
 		{
 			"name": "support.type.object.hlsl",
-			"match": "\\b(AppendStructuredBuffer|Buffer|ByteAddressBuffer|ConstantBuffer|ConsumeStructuredBuffer|InputPatch|OutputPatch)\\b"
+			"match": "\\b(AppendStructuredBuffer|Buffer|ByteAddressBuffer|StructuredBuffer|ConstantBuffer|ConsumeStructuredBuffer|InputPatch|OutputPatch)\\b"
 		},
 		{
 			"name": "support.type.object.rasterizerordered.hlsl",


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

`StructuredBuffer` is missing from `hlsl.tmLanguage.json` and this PR just adds that

Fixes #274290
