### PR TITLE
Standardize header metadata font-size and tighten codicon spacing

### DIFF
--- a/src/vs/workbench/contrib/extensions/browser/media/extension.css
+++ b/src/vs/workbench/contrib/extensions/browser/media/extension.css
@@ -92,17 +92,17 @@
 }
 
 .extension-list-item > .details > .header-container > .header .extension-kind-indicator {
-	font-size: 80%;
+	font-size: 11px;
 	margin-left: 4px;
 }
 
 .extension-list-item > .details > .header-container > .header > .install-count:not(:empty) {
-	font-size: 80%;
+	font-size: 11px;
 	margin: 0 6px;
 }
 
 .extension-list-item > .details > .header-container > .header > .activation-status:not(:empty) {
-	font-size: 80%;
+	font-size: 11px;
 	margin-left: 2px;
 }
 
@@ -112,8 +112,7 @@
 }
 
 .extension-list-item > .details > .header-container > .header .codicon {
-	font-size: 120%;
-	margin-right: 3px;
+	margin-right: 2px;
 	-webkit-mask: inherit;
 }
 


### PR DESCRIPTION
Adjust the font-size of header metadata to 11px & ensure codicons are 16px for consistency and reduce the spacing of codicons for a cleaner layout. No issues are associated with this change.

