### PR TITLE
extension unification ignore settings validation

### DIFF
--- a/src/vs/workbench/api/common/configurationExtensionPoint.ts
+++ b/src/vs/workbench/api/common/configurationExtensionPoint.ts
@@ -10,7 +10,7 @@ import { IJSONSchema } from '../../../base/common/jsonSchema.js';
 import { ExtensionsRegistry, IExtensionPointUser } from '../../services/extensions/common/extensionsRegistry.js';
 import { IConfigurationNode, IConfigurationRegistry, Extensions, validateProperty, ConfigurationScope, OVERRIDE_PROPERTY_REGEX, IConfigurationDefaults, configurationDefaultsSchemaId, IConfigurationDelta, getDefaultValue, getAllConfigurationProperties, parseScope } from '../../../platform/configuration/common/configurationRegistry.js';
 import { IJSONContributionRegistry, Extensions as JSONExtensions } from '../../../platform/jsonschemas/common/jsonContributionRegistry.js';
-import { workspaceSettingsSchemaId, launchSchemaId, tasksSchemaId, mcpSchemaId } from '../../services/configuration/common/configuration.js';
+import { workspaceSettingsSchemaId, launchSchemaId, tasksSchemaId, mcpSchemaId, IGNORE_VALIDATION_SETTINGS } from '../../services/configuration/common/configuration.js';
 import { isObject, isUndefined } from '../../../base/common/types.js';
 import { ExtensionIdentifierMap, IExtensionManifest } from '../../../platform/extensions/common/extensions.js';
 import { IStringDictionary } from '../../../base/common/collections.js';
@@ -269,12 +269,12 @@ configurationExtPoint.setHandler((extensions, { added, removed }) => {
 			for (const key in properties) {
 				const propertyConfiguration = properties[key];
 				const message = validateProperty(key, propertyConfiguration);
-				if (message) {
+				if (message && !IGNORE_VALIDATION_SETTINGS.has(key)) {
 					delete properties[key];
 					extension.collector.warn(message);
 					continue;
 				}
-				if (seenProperties.has(key)) {
+				if (seenProperties.has(key) && !IGNORE_VALIDATION_SETTINGS.has(key)) {
 					delete properties[key];
 					extension.collector.warn(nls.localize('config.property.duplicate', "Cannot register '{0}'. This property is already registered.", key));
 					continue;

--- a/src/vs/workbench/services/configuration/common/configuration.ts
+++ b/src/vs/workbench/services/configuration/common/configuration.ts
@@ -101,5 +101,5 @@ export const TASKS_DEFAULT = '{\n\t\"version\": \"2.0.0\",\n\t\"tasks\": []\n}';
 
 export const APPLY_ALL_PROFILES_SETTING = 'workbench.settings.applyToAllProfiles';
 
-// Used for extension unification. Shoulds be removed when complete.
+// Used for extension unification. Should be removed when complete.
 export const IGNORE_VALIDATION_SETTINGS: Set<string> = new Set([product.defaultChatAgent?.completionsEnablementSetting].filter(Boolean) as string[]);

--- a/src/vs/workbench/services/configuration/common/configuration.ts
+++ b/src/vs/workbench/services/configuration/common/configuration.ts
@@ -10,6 +10,7 @@ import { refineServiceDecorator } from '../../../../platform/instantiation/commo
 import { Event } from '../../../../base/common/event.js';
 import { ResourceMap } from '../../../../base/common/map.js';
 import { IAnyWorkspaceIdentifier } from '../../../../platform/workspace/common/workspace.js';
+import product from '../../../../platform/product/common/product.js';
 
 export const FOLDER_CONFIG_FOLDER_NAME = '.vscode';
 export const FOLDER_SETTINGS_NAME = 'settings';
@@ -99,3 +100,6 @@ export interface IWorkbenchConfigurationService extends IConfigurationService {
 export const TASKS_DEFAULT = '{\n\t\"version\": \"2.0.0\",\n\t\"tasks\": []\n}';
 
 export const APPLY_ALL_PROFILES_SETTING = 'workbench.settings.applyToAllProfiles';
+
+// Used for extension unification. Shoulds be removed when complete.
+export const IGNORE_VALIDATION_SETTINGS: Set<string> = new Set([product.defaultChatAgent?.completionsEnablementSetting].filter(Boolean) as string[]);

--- a/src/vs/workbench/services/configuration/common/configurationEditing.ts
+++ b/src/vs/workbench/services/configuration/common/configurationEditing.ts
@@ -13,7 +13,7 @@ import { Registry } from '../../../../platform/registry/common/platform.js';
 import { IWorkspaceContextService, WorkbenchState } from '../../../../platform/workspace/common/workspace.js';
 import { ITextFileService } from '../../textfile/common/textfiles.js';
 import { IConfigurationUpdateOptions, IConfigurationUpdateOverrides } from '../../../../platform/configuration/common/configuration.js';
-import { FOLDER_SETTINGS_PATH, WORKSPACE_STANDALONE_CONFIGURATIONS, TASKS_CONFIGURATION_KEY, LAUNCH_CONFIGURATION_KEY, USER_STANDALONE_CONFIGURATIONS, TASKS_DEFAULT, FOLDER_SCOPES, IWorkbenchConfigurationService, APPLICATION_SCOPES, MCP_CONFIGURATION_KEY } from './configuration.js';
+import { FOLDER_SETTINGS_PATH, WORKSPACE_STANDALONE_CONFIGURATIONS, TASKS_CONFIGURATION_KEY, LAUNCH_CONFIGURATION_KEY, USER_STANDALONE_CONFIGURATIONS, TASKS_DEFAULT, FOLDER_SCOPES, IWorkbenchConfigurationService, APPLICATION_SCOPES, MCP_CONFIGURATION_KEY, IGNORE_VALIDATION_SETTINGS } from './configuration.js';
 import { FileOperationError, FileOperationResult, IFileService } from '../../../../platform/files/common/files.js';
 import { IResolvedTextEditorModel, ITextModelService } from '../../../../editor/common/services/resolverService.js';
 import { IConfigurationRegistry, Extensions as ConfigurationExtensions, ConfigurationScope, keyFromOverrideIdentifiers, OVERRIDE_PROPERTY_REGEX } from '../../../../platform/configuration/common/configurationRegistry.js';
@@ -522,7 +522,7 @@ export class ConfigurationEditing {
 		 * 	- the key is an override identifier
 		 * 	- the operation is to delete the key
 		 */
-		if (!operation.workspaceStandAloneConfigurationKey) {
+		if (!operation.workspaceStandAloneConfigurationKey && !IGNORE_VALIDATION_SETTINGS.has(operation.key)) {
 			const validKeys = this.configurationService.keys().default;
 			if (validKeys.indexOf(operation.key) < 0 && !OVERRIDE_PROPERTY_REGEX.test(operation.key) && operation.value !== undefined) {
 				throw this.toConfigurationEditingError(ConfigurationEditingErrorCode.ERROR_UNKNOWN_KEY, target, operation);


### PR DESCRIPTION
This is the only way I could come up with which would support both extensions contributing the same configuration and being able to write to them when either one or both are enabled.

https://github.com/microsoft/vscode-internalbacklog/issues/6073