### PR TITLE
Update node-pty version for conpty 1.23.251008001

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
         "native-is-elevated": "0.7.0",
         "native-keymap": "^3.3.5",
         "native-watchdog": "^1.4.1",
-        "node-pty": "1.1.0-beta35",
+        "node-pty": "1.1.0-beta38",
         "open": "^10.1.2",
         "tas-client-umd": "0.2.0",
         "undici": "^7.9.0",
@@ -12927,9 +12927,9 @@
       }
     },
     "node_modules/node-pty": {
-      "version": "1.1.0-beta35",
-      "resolved": "https://registry.npmjs.org/node-pty/-/node-pty-1.1.0-beta35.tgz",
-      "integrity": "sha512-dGKw3PtLj/+uiFWUODNjr3QMyNjxRB2JY372AN4uzonfb6ri23d4PMr4s6UoibiqsXOQ3elXRCdq1qDLd86J8Q==",
+      "version": "1.1.0-beta38",
+      "resolved": "https://registry.npmjs.org/node-pty/-/node-pty-1.1.0-beta38.tgz",
+      "integrity": "sha512-B7Ga1ScEhFnGTknC0YarA0eyobsjTBcGjL1EGO5S/4DBFQZ5MjeIXJchc/o5Z6Kp1TcN8royOCIIqlYGMoPLVg==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "native-is-elevated": "0.7.0",
     "native-keymap": "^3.3.5",
     "native-watchdog": "^1.4.1",
-    "node-pty": "1.1.0-beta35",
+    "node-pty": "1.1.0-beta38",
     "open": "^10.1.2",
     "tas-client-umd": "0.2.0",
     "undici": "^7.9.0",

--- a/remote/package-lock.json
+++ b/remote/package-lock.json
@@ -38,7 +38,7 @@
         "kerberos": "2.1.1",
         "minimist": "^1.2.8",
         "native-watchdog": "^1.4.1",
-        "node-pty": "1.1.0-beta35",
+        "node-pty": "1.1.0-beta38",
         "tas-client-umd": "0.2.0",
         "vscode-oniguruma": "1.7.0",
         "vscode-regexpp": "^3.1.0",

--- a/remote/package.json
+++ b/remote/package.json
@@ -33,7 +33,7 @@
     "kerberos": "2.1.1",
     "minimist": "^1.2.8",
     "native-watchdog": "^1.4.1",
-    "node-pty": "1.1.0-beta35",
+    "node-pty": "1.1.0-beta38",
     "tas-client-umd": "0.2.0",
     "vscode-oniguruma": "1.7.0",
     "vscode-regexpp": "^3.1.0",

--- a/src/vs/workbench/contrib/terminal/common/terminalConfiguration.ts
+++ b/src/vs/workbench/contrib/terminal/common/terminalConfiguration.ts
@@ -469,7 +469,7 @@ const terminalConfiguration: IStringDictionary<IConfigurationPropertySchema> = {
 		default: true
 	},
 	[TerminalSettingId.WindowsUseConptyDll]: {
-		markdownDescription: localize('terminal.integrated.windowsUseConptyDll', "Whether to use the experimental conpty.dll (v1.22.250204002) shipped with VS Code, instead of the one bundled with Windows."),
+		markdownDescription: localize('terminal.integrated.windowsUseConptyDll', "Whether to use the experimental conpty.dll (v1.23.251008001) shipped with VS Code, instead of the one bundled with Windows."),
 		type: 'boolean',
 		tags: ['preview'],
 		default: false


### PR DESCRIPTION
This is so we get https://github.com/microsoft/node-pty/pull/811 
Also updating conpty dll version number defined in setting description. 