### PR TITLE
Revert back to using "Workspace" as group label for prompt file picker

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/promptSyntax/pickers/promptFilePickers.ts
+++ b/src/vs/workbench/contrib/chat/browser/promptSyntax/pickers/promptFilePickers.ts
@@ -305,8 +305,7 @@ export class PromptFilePickers {
 		}
 		const locals = await this._promptsService.listPromptFilesForStorage(options.type, PromptsStorage.local, token);
 		if (locals.length) {
-			// Note: No need to localize the label ".github/instructions', since it's the same in all languages.
-			result.push({ type: 'separator', label: '.github/instructions' });
+			result.push({ type: 'separator', label: localize('separator.workspace', "Workspace") });
 			result.push(...await Promise.all(locals.map(l => this._createPromptPickItem(l, buttons, token))));
 		}
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Mitigates Issue https://github.com/microsoft/vscode/issues/274004 (introduced in PR https://github.com/microsoft/vscode/pull/271952) where ".github/instructions" was even showing up for other non-instruction pickers like the Prompts picker. Now we go back to showing "Workspace"

With this change, the instructions picker will now have these three categories:
* **Workspace** - includes scoped instruction files in the workspace. Before the change in this PR, this used to say ".github/instructions"
* **Agent Instructions** - includes copilot-instructions.md and AGENTS.md files.
* **User Data** - includes scoped instruction files at the user level

In a follow-up PR, will explore if it would be beneficial to group "Workspace" into a group per containing folder as suggested in https://github.com/microsoft/vscode/issues/274004