### PR TITLE
More sessionId -> sessionResource conversation

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadChatAgents2.ts
+++ b/src/vs/workbench/api/browser/mainThreadChatAgents2.ts
@@ -118,9 +118,9 @@ export class MainThreadChatAgents2 extends Disposable implements MainThreadChatA
 		this._proxy = extHostContext.getProxy(ExtHostContext.ExtHostChatAgents2);
 
 		this._register(this._chatService.onDidDisposeSession(e => {
-			const local = LocalChatSessionUri.parse(e.sessionResource);
-			if (local) {
-				this._proxy.$releaseSession(local.sessionId);
+			const localSessionId = LocalChatSessionUri.parseLocalSessionId(e.sessionResource);
+			if (localSessionId) {
+				this._proxy.$releaseSession(localSessionId);
 			}
 		}));
 		this._register(this._chatService.onDidPerformUserAction(e => {

--- a/src/vs/workbench/contrib/accessibility/browser/accessibleView.ts
+++ b/src/vs/workbench/contrib/accessibility/browser/accessibleView.ts
@@ -63,7 +63,7 @@ interface ICodeBlock {
 	endLine: number;
 	code: string;
 	languageId?: string;
-	chatSessionId: string | undefined;
+	chatSessionResource: URI | undefined;
 }
 
 export class AccessibleView extends Disposable implements ITextModelContentProvider {
@@ -261,7 +261,7 @@ export class AccessibleView extends Disposable implements ITextModelContentProvi
 		if (!codeBlock || codeBlockIndex === undefined) {
 			return;
 		}
-		return { code: codeBlock.code, languageId: codeBlock.languageId, codeBlockIndex, element: undefined, chatSessionId: codeBlock.chatSessionId };
+		return { code: codeBlock.code, languageId: codeBlock.languageId, codeBlockIndex, element: undefined, chatSessionResource: codeBlock.chatSessionResource };
 	}
 
 	navigateToCodeBlock(type: 'next' | 'previous'): void {
@@ -405,7 +405,7 @@ export class AccessibleView extends Disposable implements ITextModelContentProvi
 				inBlock = false;
 				const endLine = i;
 				const code = lines.slice(startLine, endLine).join('\n');
-				this._codeBlocks?.push({ startLine, endLine, code, languageId, chatSessionId: undefined });
+				this._codeBlocks?.push({ startLine, endLine, code, languageId, chatSessionResource: undefined });
 			}
 		});
 		this._accessibleViewContainsCodeBlocks.set(this._codeBlocks.length > 0);

--- a/src/vs/workbench/contrib/chat/browser/actions/chatActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatActions.ts
@@ -761,7 +761,6 @@ export function registerChatActions() {
 										description: '',
 										session: { providerType: chatSessionType, session: session },
 										chat: {
-											sessionId: session.id,
 											sessionResource: session.resource,
 											title: session.label,
 											isActive: false,

--- a/src/vs/workbench/contrib/chat/browser/actions/chatCodeblockActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatCodeblockActions.ts
@@ -604,7 +604,7 @@ function getContextFromEditor(editor: ICodeEditor, accessor: ServicesAccessor): 
 		code: editor.getValue(),
 		languageId: editor.getModel()!.getLanguageId(),
 		codemapperUri: codeBlockInfo.codemapperUri,
-		chatSessionId: codeBlockInfo.chatSessionId,
+		chatSessionResource: codeBlockInfo.chatSessionResource,
 	};
 }
 

--- a/src/vs/workbench/contrib/chat/browser/actions/chatExecuteActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatExecuteActions.ts
@@ -44,6 +44,7 @@ import { IChatWidget, IChatWidgetService, showChatWidgetInViewOrEditor } from '.
 import { getEditingSessionContext } from '../chatEditing/chatEditingActions.js';
 import { ACTION_ID_NEW_CHAT, CHAT_CATEGORY, handleCurrentEditingSession, handleModeSwitch } from './chatActions.js';
 import { ctxHasEditorModification } from '../chatEditing/chatEditingEditorContextKeys.js';
+import { chatSessionResourceToId } from '../../common/chatUri.js';
 
 export interface IVoiceChatExecuteActionContext {
 	readonly disableTimeout?: boolean;
@@ -259,8 +260,8 @@ export class ChatDelegateToEditSessionAction extends Action2 {
 		const inlineWidget = context?.widget ?? widgetService.lastFocusedWidget;
 		const locationData = inlineWidget?.locationData;
 
-		if (inlineWidget && locationData?.type === ChatAgentLocation.EditorInline && locationData.delegateSessionId) {
-			const sessionWidget = widgetService.getWidgetBySessionId(locationData.delegateSessionId);
+		if (inlineWidget && locationData?.type === ChatAgentLocation.EditorInline && locationData.delegateSessionResource) {
+			const sessionWidget = widgetService.getWidgetBySessionResource(locationData.delegateSessionResource);
 
 			if (sessionWidget) {
 				await instantiationService.invokeFunction(showChatWidgetInViewOrEditor, sessionWidget);
@@ -793,11 +794,10 @@ export class CreateRemoteAgentJobAction extends Action2 {
 			if (!widget) {
 				return;
 			}
-			const sessionId = widget.viewModel?.sessionId;
-			if (!sessionId) {
+			if (!widget.viewModel) {
 				return;
 			}
-			const chatModel = widget.viewModel?.model;
+			const chatModel = widget.viewModel.model;
 			if (!chatModel) {
 				return;
 			}
@@ -813,7 +813,7 @@ export class CreateRemoteAgentJobAction extends Action2 {
 				userPrompt = 'implement this.';
 			}
 
-			const attachedContext = widget.input.getAttachedAndImplicitContext(sessionId);
+			const attachedContext = widget.input.getAttachedAndImplicitContext(sessionResource);
 			widget.input.acceptInput(true);
 
 			// For inline editor mode, add selection or cursor information
@@ -903,7 +903,7 @@ export class CreateRemoteAgentJobAction extends Action2 {
 					)
 				});
 
-				({ title, summarizedUserPrompt } = await this.generateSummarizedUserPrompt(sessionId, userPrompt, attachedContext, title, chatAgentService, defaultAgent, summarizedUserPrompt));
+				({ title, summarizedUserPrompt } = await this.generateSummarizedUserPrompt(sessionResource, userPrompt, attachedContext, title, chatAgentService, defaultAgent, summarizedUserPrompt));
 			}
 
 			let summary: string = '';
@@ -946,7 +946,7 @@ export class CreateRemoteAgentJobAction extends Action2 {
 						CreateRemoteAgentJobAction.markdownStringTrustedOptions
 					)
 				});
-				({ title, summary } = await this.generateSummarizedChatHistory(chatRequests, sessionId, title, chatAgentService, defaultAgent, summary));
+				({ title, summary } = await this.generateSummarizedChatHistory(chatRequests, sessionResource, title, chatAgentService, defaultAgent, summary));
 			}
 
 			if (title) {
@@ -993,11 +993,11 @@ export class CreateRemoteAgentJobAction extends Action2 {
 		}
 	}
 
-	private async generateSummarizedChatHistory(chatRequests: IChatRequestModel[], sessionId: string, title: string | undefined, chatAgentService: IChatAgentService, defaultAgent: IChatAgent, summary: string) {
+	private async generateSummarizedChatHistory(chatRequests: IChatRequestModel[], sessionResource: URI, title: string | undefined, chatAgentService: IChatAgentService, defaultAgent: IChatAgent, summary: string) {
 		const historyEntries: IChatAgentHistoryEntry[] = chatRequests
 			.map(req => ({
 				request: {
-					sessionId: sessionId,
+					sessionId: chatSessionResourceToId(sessionResource),
 					requestId: req.id,
 					agentId: req.response?.agent?.id ?? '',
 					message: req.message.text,
@@ -1018,10 +1018,10 @@ export class CreateRemoteAgentJobAction extends Action2 {
 		return { title, summary };
 	}
 
-	private async generateSummarizedUserPrompt(sessionId: string, userPrompt: string, attachedContext: ChatRequestVariableSet, title: string | undefined, chatAgentService: IChatAgentService, defaultAgent: IChatAgent, summarizedUserPrompt: string | undefined) {
+	private async generateSummarizedUserPrompt(sessionResource: URI, userPrompt: string, attachedContext: ChatRequestVariableSet, title: string | undefined, chatAgentService: IChatAgentService, defaultAgent: IChatAgent, summarizedUserPrompt: string | undefined) {
 		const userPromptEntry: IChatAgentHistoryEntry = {
 			request: {
-				sessionId: sessionId,
+				sessionId: chatSessionResourceToId(sessionResource),
 				requestId: generateUuid(),
 				agentId: '',
 				message: userPrompt,

--- a/src/vs/workbench/contrib/chat/browser/actions/chatMoveActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatMoveActions.ts
@@ -5,6 +5,7 @@
 
 import { Codicon } from '../../../../../base/common/codicons.js';
 import { ThemeIcon } from '../../../../../base/common/themables.js';
+import { URI } from '../../../../../base/common/uri.js';
 import { localize, localize2 } from '../../../../../nls.js';
 import { Action2, MenuId, MenuRegistry, registerAction2 } from '../../../../../platform/actions/common/actions.js';
 import { ContextKeyExpr, ContextKeyExpression } from '../../../../../platform/contextkey/common/contextkey.js';
@@ -48,7 +49,7 @@ export function registerMoveActions() {
 
 		async run(accessor: ServicesAccessor, ...args: unknown[]) {
 			const context = args[0];
-			executeMoveToAction(accessor, MoveToNewLocation.Editor, isChatViewTitleActionContext(context) ? context.sessionId : undefined);
+			executeMoveToAction(accessor, MoveToNewLocation.Editor, isChatViewTitleActionContext(context) ? context.sessionResource : undefined);
 		}
 	});
 
@@ -71,7 +72,7 @@ export function registerMoveActions() {
 
 		async run(accessor: ServicesAccessor, ...args: unknown[]) {
 			const context = args[0];
-			executeMoveToAction(accessor, MoveToNewLocation.Window, isChatViewTitleActionContext(context) ? context.sessionId : undefined);
+			executeMoveToAction(accessor, MoveToNewLocation.Window, isChatViewTitleActionContext(context) ? context.sessionResource : undefined);
 		}
 	});
 
@@ -110,11 +111,11 @@ export function registerMoveActions() {
 	});
 }
 
-async function executeMoveToAction(accessor: ServicesAccessor, moveTo: MoveToNewLocation, _sessionId?: string) {
+async function executeMoveToAction(accessor: ServicesAccessor, moveTo: MoveToNewLocation, sessionResource?: URI) {
 	const widgetService = accessor.get(IChatWidgetService);
 	const editorService = accessor.get(IEditorService);
 
-	const widget = (_sessionId ? widgetService.getWidgetBySessionId(_sessionId) : undefined)
+	const widget = (sessionResource ? widgetService.getWidgetBySessionResource(sessionResource) : undefined)
 		?? widgetService.lastFocusedWidget;
 	if (!widget || !widget.viewModel || widget.location !== ChatAgentLocation.Chat) {
 		await editorService.openEditor({ resource: ChatEditorInput.getNewEditorUri(), options: { pinned: true, auxiliary: { compact: true, bounds: { width: 640, height: 640 } } } }, moveTo === MoveToNewLocation.Window ? AUX_WINDOW_GROUP : ACTIVE_GROUP);

--- a/src/vs/workbench/contrib/chat/browser/actions/chatTitleActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatTitleActions.ts
@@ -22,7 +22,6 @@ import { NOTEBOOK_IS_ACTIVE_EDITOR } from '../../../notebook/common/notebookCont
 import { ChatContextKeys } from '../../common/chatContextKeys.js';
 import { applyingChatEditsFailedContextKey, isChatEditingActionContext } from '../../common/chatEditingService.js';
 import { ChatAgentVoteDirection, ChatAgentVoteDownReason, IChatService } from '../../common/chatService.js';
-import { LocalChatSessionUri } from '../../common/chatUri.js';
 import { isResponseVM } from '../../common/chatViewModel.js';
 import { ChatModeKind } from '../../common/constants.js';
 import { IChatWidgetService } from '../chat.js';
@@ -206,14 +205,14 @@ export function registerChatTitleActions() {
 			let item = args[0];
 			if (isChatEditingActionContext(item)) {
 				// Resolve chat editing action context to the last response VM
-				item = chatWidgetService.getWidgetBySessionId(item.sessionId)?.viewModel?.getItems().at(-1);
+				item = chatWidgetService.getWidgetBySessionResource(item.sessionResource)?.viewModel?.getItems().at(-1);
 			}
 			if (!isResponseVM(item)) {
 				return;
 			}
 
 			const chatService = accessor.get(IChatService);
-			const chatModel = chatService.getSession(LocalChatSessionUri.forSession(item.sessionId));
+			const chatModel = chatService.getSession(item.sessionResource);
 			const chatRequests = chatModel?.getRequests();
 			if (!chatRequests) {
 				return;

--- a/src/vs/workbench/contrib/chat/browser/actions/codeBlockOperations.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/codeBlockOperations.ts
@@ -36,6 +36,7 @@ import { CellKind, ICellEditOperation, NOTEBOOK_EDITOR_ID } from '../../../noteb
 import { INotebookService } from '../../../notebook/common/notebookService.js';
 import { ICodeMapperCodeBlock, ICodeMapperRequest, ICodeMapperResponse, ICodeMapperService } from '../../common/chatCodeMapperService.js';
 import { ChatUserAction, IChatService } from '../../common/chatService.js';
+import { chatSessionResourceToId } from '../../common/chatUri.js';
 import { IChatRequestViewModel, isRequestVM, isResponseVM } from '../../common/chatViewModel.js';
 import { ICodeBlockActionContext } from '../codeBlockPart.js';
 
@@ -185,11 +186,11 @@ export class ApplyCodeBlockOperation {
 		let result: IComputeEditsResult | undefined = undefined;
 
 		if (activeEditorControl && !this.notebookService.hasSupportedNotebooks(codemapperUri)) {
-			result = await this.handleTextEditor(activeEditorControl, context.chatSessionId, context.code, codeBlockSuggestionId);
+			result = await this.handleTextEditor(activeEditorControl, context.chatSessionResource, context.code, codeBlockSuggestionId);
 		} else {
 			const activeNotebookEditor = getActiveNotebookEditor(this.editorService);
 			if (activeNotebookEditor) {
-				result = await this.handleNotebookEditor(activeNotebookEditor, context.chatSessionId, context.code);
+				result = await this.handleNotebookEditor(activeNotebookEditor, context.chatSessionResource, context.code);
 			} else {
 				this.notify(localize('applyCodeBlock.noActiveEditor', "To apply this code block, open a code or notebook editor."));
 			}
@@ -257,7 +258,7 @@ export class ApplyCodeBlockOperation {
 		return undefined;
 	}
 
-	private async handleNotebookEditor(notebookEditor: IActiveNotebookEditor, chatSessionId: string | undefined, code: string): Promise<IComputeEditsResult | undefined> {
+	private async handleNotebookEditor(notebookEditor: IActiveNotebookEditor, chatSessionResource: URI | undefined, code: string): Promise<IComputeEditsResult | undefined> {
 		if (notebookEditor.isReadOnly) {
 			this.notify(localize('applyCodeBlock.readonlyNotebook', "Cannot apply code block to read-only notebook editor."));
 			return undefined;
@@ -276,7 +277,7 @@ export class ApplyCodeBlockOperation {
 				{ location: ProgressLocation.Notification, delay: 500, sticky: true, cancellable: true },
 				async progress => {
 					progress.report({ message: localize('applyCodeBlock.progress', "Applying code block using {0}...", codeMapper) });
-					const editsIterable = this.getNotebookEdits(codeBlock, chatSessionId, cancellationTokenSource.token);
+					const editsIterable = this.getNotebookEdits(codeBlock, chatSessionResource, cancellationTokenSource.token);
 					return await this.waitForFirstElement(editsIterable);
 				},
 				() => cancellationTokenSource.cancel()
@@ -296,14 +297,14 @@ export class ApplyCodeBlockOperation {
 		};
 	}
 
-	private async handleTextEditor(codeEditor: IActiveCodeEditor, chatSessionId: string | undefined, code: string, applyCodeBlockSuggestionId: EditSuggestionId | undefined): Promise<IComputeEditsResult | undefined> {
+	private async handleTextEditor(codeEditor: IActiveCodeEditor, chatSessionResource: URI | undefined, code: string, applyCodeBlockSuggestionId: EditSuggestionId | undefined): Promise<IComputeEditsResult | undefined> {
 		const activeModel = codeEditor.getModel();
 		if (isReadOnly(activeModel, this.textFileService)) {
 			this.notify(localize('applyCodeBlock.readonly', "Cannot apply code block to read-only file."));
 			return undefined;
 		}
 
-		const codeBlock = { code, resource: activeModel.uri, chatSessionId, markdownBeforeBlock: undefined };
+		const codeBlock = { code, resource: activeModel.uri, chatSessionResource, markdownBeforeBlock: undefined };
 
 		const codeMapper = this.codeMapperService.providers[0]?.displayName;
 		if (!codeMapper) {
@@ -317,7 +318,7 @@ export class ApplyCodeBlockOperation {
 				{ location: ProgressLocation.Notification, delay: 500, sticky: true, cancellable: true },
 				async progress => {
 					progress.report({ message: localize('applyCodeBlock.progress', "Applying code block using {0}...", codeMapper) });
-					const editsIterable = this.getTextEdits(codeBlock, chatSessionId, cancellationTokenSource.token);
+					const editsIterable = this.getTextEdits(codeBlock, chatSessionResource, cancellationTokenSource.token);
 					return await this.waitForFirstElement(editsIterable);
 				},
 				() => cancellationTokenSource.cancel()
@@ -337,11 +338,11 @@ export class ApplyCodeBlockOperation {
 		};
 	}
 
-	private getTextEdits(codeBlock: ICodeMapperCodeBlock, chatSessionId: string | undefined, token: CancellationToken): AsyncIterable<TextEdit[]> {
+	private getTextEdits(codeBlock: ICodeMapperCodeBlock, chatSessionResource: URI | undefined, token: CancellationToken): AsyncIterable<TextEdit[]> {
 		return new AsyncIterableObject<TextEdit[]>(async executor => {
 			const request: ICodeMapperRequest = {
 				codeBlocks: [codeBlock],
-				chatSessionId
+				chatSessionId: chatSessionResource && chatSessionResourceToId(chatSessionResource),
 			};
 			const response: ICodeMapperResponse = {
 				textEdit: (target: URI, edit: TextEdit[]) => {
@@ -358,11 +359,11 @@ export class ApplyCodeBlockOperation {
 		});
 	}
 
-	private getNotebookEdits(codeBlock: ICodeMapperCodeBlock, chatSessionId: string | undefined, token: CancellationToken): AsyncIterable<[URI, TextEdit[]] | ICellEditOperation[]> {
+	private getNotebookEdits(codeBlock: ICodeMapperCodeBlock, chatSessionResource: URI | undefined, token: CancellationToken): AsyncIterable<[URI, TextEdit[]] | ICellEditOperation[]> {
 		return new AsyncIterableObject<[URI, TextEdit[]] | ICellEditOperation[]>(async executor => {
 			const request: ICodeMapperRequest = {
 				codeBlocks: [codeBlock],
-				chatSessionId,
+				chatSessionId: chatSessionResource && chatSessionResourceToId(chatSessionResource),
 				location: 'panel'
 			};
 			const response: ICodeMapperResponse = {

--- a/src/vs/workbench/contrib/chat/browser/chat.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.ts
@@ -122,7 +122,7 @@ export interface IChatCodeBlockInfo {
 	readonly uri: URI | undefined;
 	readonly uriPromise: Promise<URI | undefined>;
 	codemapperUri: URI | undefined;
-	readonly chatSessionId: string;
+	readonly chatSessionResource: URI | undefined;
 	focus(): void;
 	readonly languageId?: string | undefined;
 	readonly editDeltaInfo?: EditDeltaInfo | undefined;

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/chatToolInputOutputContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/chatToolInputOutputContentPart.ts
@@ -212,7 +212,7 @@ export class ChatCollapsibleInputOutputContentPart extends Disposable {
 			element: this.context.element,
 			parentContextKeyService: this.contextKeyService,
 			renderOptions: part.options,
-			chatSessionId: this.context.element.sessionId,
+			chatSessionResource: this.context.element.sessionResource,
 		};
 		const editorReference = this._register(this.editorPool.get());
 		editorReference.object.render(data, this._currentWidth || 300);

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/chatToolOutputContentSubPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/chatToolOutputContentSubPart.ts
@@ -156,7 +156,7 @@ export class ChatToolOutputContentSubPart extends Disposable {
 			element: this.context.element,
 			parentContextKeyService: this.contextKeyService,
 			renderOptions: part.options,
-			chatSessionId: this.context.element.sessionId,
+			chatSessionResource: this.context.element.sessionResource,
 		};
 		const editorReference = this._register(this.editorPool.get());
 		editorReference.object.render(data, this._currentWidth || 300);

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatInputOutputMarkdownProgressPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatInputOutputMarkdownProgressPart.ts
@@ -80,7 +80,7 @@ export class ChatInputOutputMarkdownProgressPart extends BaseChatToolInvocationS
 					focus: () => { },
 					ownerMarkdownPartId: this.codeblocksPartId,
 					uri: model.uri,
-					chatSessionId: context.element.sessionId,
+					chatSessionResource: context.element.sessionResource,
 					uriPromise: Promise.resolve(model.uri)
 				}
 			};

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatTerminalToolConfirmationSubPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatTerminalToolConfirmationSubPart.ts
@@ -157,7 +157,7 @@ export class ChatTerminalToolConfirmationSubPart extends BaseChatToolInvocationS
 			languageId,
 			renderOptions: codeBlockRenderOptions,
 			textModel: Promise.resolve(model),
-			chatSessionId: this.context.element.sessionId
+			chatSessionResource: this.context.element.sessionResource
 		}, this.currentWidthDelegate());
 		this._register(thenIfNotDisposed(renderPromise, () => this._onDidChangeHeight.fire()));
 		this.codeblocks.push({
@@ -168,7 +168,7 @@ export class ChatTerminalToolConfirmationSubPart extends BaseChatToolInvocationS
 			ownerMarkdownPartId: this.codeblocksPartId,
 			uri: model.uri,
 			uriPromise: Promise.resolve(model.uri),
-			chatSessionId: this.context.element.sessionId
+			chatSessionResource: this.context.element.sessionResource
 		});
 		this._register(editor.object.onDidChangeContentHeight(() => {
 			editor.object.layout(this.currentWidthDelegate());

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatToolConfirmationSubPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatToolConfirmationSubPart.ts
@@ -202,7 +202,7 @@ export class ToolConfirmationSubPart extends AbstractToolConfirmationSubPart {
 					languageId: langId ?? 'json',
 					renderOptions: codeBlockRenderOptions,
 					textModel: Promise.resolve(model),
-					chatSessionId: this.context.element.sessionId
+					chatSessionResource: this.context.element.sessionResource
 				}, this.currentWidthDelegate());
 				this.codeblocks.push({
 					codeBlockIndex: this.codeBlockStartIndex,
@@ -212,7 +212,7 @@ export class ToolConfirmationSubPart extends AbstractToolConfirmationSubPart {
 					ownerMarkdownPartId: this.codeblocksPartId,
 					uri: model.uri,
 					uriPromise: Promise.resolve(model.uri),
-					chatSessionId: this.context.element.sessionId
+					chatSessionResource: this.context.element.sessionResource
 				});
 				this._register(editor.object.onDidChangeContentHeight(() => {
 					editor.object.layout(this.currentWidthDelegate());

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatToolPostExecuteConfirmationPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatToolPostExecuteConfirmationPart.ts
@@ -118,7 +118,7 @@ export class ChatToolPostExecuteConfirmationPart extends AbstractToolConfirmatio
 						focus: () => { },
 						ownerMarkdownPartId: this.codeblocksPartId,
 						uri: model.uri,
-						chatSessionId: this.context.element.sessionId,
+						chatSessionResource: this.context.element.sessionResource,
 						uriPromise: Promise.resolve(model.uri)
 					}
 				});
@@ -150,7 +150,7 @@ export class ChatToolPostExecuteConfirmationPart extends AbstractToolConfirmatio
 						focus: () => { },
 						ownerMarkdownPartId: this.codeblocksPartId,
 						uri: model.uri,
-						chatSessionId: this.context.element.sessionId,
+						chatSessionResource: this.context.element.sessionResource,
 						uriPromise: Promise.resolve(model.uri)
 					}
 				});
@@ -194,7 +194,7 @@ export class ChatToolPostExecuteConfirmationPart extends AbstractToolConfirmatio
 								focus: () => { },
 								ownerMarkdownPartId: this.codeblocksPartId,
 								uri: model.uri,
-								chatSessionId: this.context.element.sessionId,
+								chatSessionResource: this.context.element.sessionResource,
 								uriPromise: Promise.resolve(model.uri)
 							}
 						});
@@ -226,7 +226,7 @@ export class ChatToolPostExecuteConfirmationPart extends AbstractToolConfirmatio
 								focus: () => { },
 								ownerMarkdownPartId: this.codeblocksPartId,
 								uri: model.uri,
-								chatSessionId: this.context.element.sessionId,
+								chatSessionResource: this.context.element.sessionResource,
 								uriPromise: Promise.resolve(model.uri)
 							}
 						});

--- a/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingActions.ts
@@ -30,7 +30,6 @@ import { isChatViewTitleActionContext } from '../../common/chatActions.js';
 import { ChatContextKeys } from '../../common/chatContextKeys.js';
 import { applyingChatEditsFailedContextKey, CHAT_EDITING_MULTI_DIFF_SOURCE_RESOLVER_SCHEME, chatEditingResourceContextKey, chatEditingWidgetFileStateContextKey, decidedChatEditingResourceContextKey, hasAppliedChatEditsContextKey, hasUndecidedChatEditingResourceContextKey, IChatEditingService, IChatEditingSession, ModifiedFileEntryState } from '../../common/chatEditingService.js';
 import { IChatService } from '../../common/chatService.js';
-import { LocalChatSessionUri } from '../../common/chatUri.js';
 import { isRequestVM, isResponseVM } from '../../common/chatViewModel.js';
 import { ChatAgentLocation, ChatConfiguration, ChatModeKind } from '../../common/constants.js';
 import { CHAT_CATEGORY } from '../actions/chatActions.js';
@@ -66,7 +65,7 @@ export function getEditingSessionContext(accessor: ServicesAccessor, args: any[]
 
 	const chatWidgetService = accessor.get(IChatWidgetService);
 	const chatEditingService = accessor.get(IChatEditingService);
-	let chatWidget = context ? chatWidgetService.getWidgetBySessionId(context.sessionId) : undefined;
+	let chatWidget = context ? chatWidgetService.getWidgetBySessionResource(context.sessionResource) : undefined;
 	if (!chatWidget) {
 		chatWidget = chatWidgetService.lastFocusedWidget ?? chatWidgetService.getWidgetsByLocations(ChatAgentLocation.Chat).find(w => w.supportsChangingModes);
 	}
@@ -308,7 +307,7 @@ async function restoreSnapshotWithConfirmation(accessor: ServicesAccessor, item:
 	const chatWidgetService = accessor.get(IChatWidgetService);
 	const widget = chatWidgetService.lastFocusedWidget;
 	const chatService = accessor.get(IChatService);
-	const chatModel = chatService.getSession(LocalChatSessionUri.forSession(item.sessionId));
+	const chatModel = chatService.getSession(item.sessionResource);
 	if (!chatModel) {
 		return;
 	}
@@ -503,7 +502,7 @@ registerAction2(class RestoreLastCheckpoint extends Action2 {
 			return;
 		}
 
-		const chatModel = chatService.getSession(LocalChatSessionUri.forSession(item.sessionId));
+		const chatModel = chatService.getSession(item.sessionResource);
 		if (!chatModel) {
 			return;
 		}
@@ -568,6 +567,13 @@ registerAction2(class EditAction extends Action2 {
 	}
 });
 
+export interface ChatEditingActionContext {
+	readonly sessionResource: URI;
+	readonly requestId: string;
+	readonly uri: URI;
+	readonly stopId: string | undefined;
+}
+
 registerAction2(class OpenWorkingSetHistoryAction extends Action2 {
 
 	static readonly id = 'chat.openFileUpdatedBySnapshot';
@@ -584,8 +590,8 @@ registerAction2(class OpenWorkingSetHistoryAction extends Action2 {
 	}
 
 	override async run(accessor: ServicesAccessor, ...args: unknown[]): Promise<void> {
-		const context = args[0] as { sessionId: string; requestId: string; uri: URI; stopId: string | undefined } | undefined;
-		if (!context?.sessionId) {
+		const context = args[0] as ChatEditingActionContext | undefined;
+		if (!context?.sessionResource) {
 			return;
 		}
 
@@ -610,8 +616,8 @@ registerAction2(class OpenWorkingSetHistoryAction extends Action2 {
 	}
 
 	override async run(accessor: ServicesAccessor, ...args: unknown[]): Promise<void> {
-		const context = args[0] as { sessionId: string; requestId: string; uri: URI; stopId: string | undefined } | undefined;
-		if (!context?.sessionId) {
+		const context = args[0] as ChatEditingActionContext | undefined;
+		if (!context?.sessionResource) {
 			return;
 		}
 
@@ -619,7 +625,7 @@ registerAction2(class OpenWorkingSetHistoryAction extends Action2 {
 		const chatEditingService = accessor.get(IChatEditingService);
 		const editorService = accessor.get(IEditorService);
 
-		const chatModel = chatService.getSession(LocalChatSessionUri.forSession(context.sessionId));
+		const chatModel = chatService.getSession(context.sessionResource);
 		if (!chatModel) {
 			return;
 		}

--- a/src/vs/workbench/contrib/chat/browser/chatEditorInput.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditorInput.ts
@@ -87,14 +87,11 @@ export class ChatEditorInput extends EditorInput implements IEditorCloseHandler 
 				throw new Error('Invalid chat URI');
 			}
 		} else if (resource.scheme === Schemas.vscodeLocalChatSession) {
-			const parsed = LocalChatSessionUri.parse(resource);
-			if (!parsed?.sessionId) {
-				throw new Error('Invalid chat session URI');
+			const localSessionId = LocalChatSessionUri.parseLocalSessionId(resource);
+			if (!localSessionId) {
+				throw new Error('Invalid local chat session URI');
 			}
-			if (parsed.chatSessionType !== localChatSessionType) {
-				throw new Error('Chat session URI must be of local chat session type');
-			}
-			this._sessionInfo = { resource, sessionId: parsed.sessionId };
+			this._sessionInfo = { resource, sessionId: localSessionId };
 		} else {
 			this._sessionInfo = { resource, sessionId: undefined };
 		}

--- a/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
@@ -184,15 +184,15 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 
 	readonly selectedToolsModel: ChatSelectedTools;
 
-	public getAttachedContext(sessionId: string) {
+	public getAttachedContext(sessionResource: URI) {
 		const contextArr = new ChatRequestVariableSet();
 		contextArr.add(...this.attachmentModel.attachments);
 		return contextArr;
 	}
 
-	public getAttachedAndImplicitContext(sessionId: string): ChatRequestVariableSet {
+	public getAttachedAndImplicitContext(sessionResource: URI): ChatRequestVariableSet {
 
-		const contextArr = this.getAttachedContext(sessionId);
+		const contextArr = this.getAttachedContext(sessionResource);
 
 		if ((this.implicitContext?.enabled && this.implicitContext?.value) || (isLocation(this.implicitContext?.value) && this.configurationService.getValue<boolean>('chat.implicitContext.suggestedContext'))) {
 			const implicitChatVariables = this.implicitContext.toBaseEntries();

--- a/src/vs/workbench/contrib/chat/browser/chatSessions/view/sessionsTreeRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSessions/view/sessionsTreeRenderer.ts
@@ -42,6 +42,7 @@ import { IWorkbenchLayoutService, Position } from '../../../../../services/layou
 import { getLocalHistoryDateFormatter } from '../../../../localHistory/browser/localHistory.js';
 import { IChatService } from '../../../common/chatService.js';
 import { ChatSessionStatus, IChatSessionItem, IChatSessionItemProvider, IChatSessionsService, localChatSessionType } from '../../../common/chatSessionsService.js';
+import { chatSessionResourceToId } from '../../../common/chatUri.js';
 import { ChatConfiguration } from '../../../common/constants.js';
 import { IChatWidgetService } from '../../chat.js';
 import { allowedChatMarkdownHtmlTags } from '../../chatContentMarkdownRenderer.js';
@@ -580,7 +581,7 @@ export class SessionsDataSource implements IAsyncDataSource<IChatSessionItemProv
 
 			// Create history items with provider reference and timestamps
 			const historyItems = allHistory.map((historyDetail): ChatSessionItemWithProvider => ({
-				id: historyDetail.sessionId,
+				id: chatSessionResourceToId(historyDetail.sessionResource),
 				resource: historyDetail.sessionResource,
 				label: historyDetail.title,
 				iconPath: Codicon.chatSparkle,

--- a/src/vs/workbench/contrib/chat/browser/chatViewPane.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatViewPane.ts
@@ -132,7 +132,7 @@ export class ChatViewPane extends ViewPane implements IViewWelcomeDelegate {
 
 	override getActionsContext(): IChatViewTitleActionContext | undefined {
 		return this.widget?.viewModel ? {
-			sessionId: this.widget.viewModel.sessionId,
+			sessionResource: this.widget.viewModel.sessionResource,
 			$mid: MarshalledId.ChatViewContext
 		} : undefined;
 	}

--- a/src/vs/workbench/contrib/chat/browser/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatWidget.ts
@@ -2527,7 +2527,7 @@ export class ChatWidget extends Disposable implements IChatWidget {
 			const requestId = this.chatAccessibilityService.acceptRequest();
 			const requestInputs: IChatRequestInputOptions = {
 				input: !query ? editorValue : query.query,
-				attachedContext: options?.enableImplicitContext === false ? this.input.getAttachedContext(this.viewModel.sessionId) : this.input.getAttachedAndImplicitContext(this.viewModel.sessionId),
+				attachedContext: options?.enableImplicitContext === false ? this.input.getAttachedContext(this.viewModel.sessionResource) : this.input.getAttachedAndImplicitContext(this.viewModel.sessionResource),
 			};
 
 			const isUserQuery = !query;

--- a/src/vs/workbench/contrib/chat/browser/codeBlockPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/codeBlockPart.ts
@@ -91,7 +91,7 @@ export interface ICodeBlockData {
 	readonly parentContextKeyService?: IContextKeyService;
 	readonly renderOptions?: ICodeBlockRenderOptions;
 
-	readonly chatSessionId: string;
+	readonly chatSessionResource: URI;
 }
 
 /**
@@ -139,7 +139,7 @@ export interface ICodeBlockActionContext {
 	readonly codeBlockIndex: number;
 	readonly element: unknown;
 
-	readonly chatSessionId: string | undefined;
+	readonly chatSessionResource: URI | undefined;
 }
 
 export interface ICodeBlockRenderOptions {
@@ -498,7 +498,7 @@ export class CodeBlockPart extends Disposable {
 			element: data.element,
 			languageId: textModel.getLanguageId(),
 			codemapperUri: data.codemapperUri,
-			chatSessionId: data.chatSessionId
+			chatSessionResource: data.chatSessionResource
 		} satisfies ICodeBlockActionContext;
 		this.resourceContextKey.set(textModel.uri);
 	}

--- a/src/vs/workbench/contrib/chat/browser/contrib/chatInputRelatedFilesContrib.ts
+++ b/src/vs/workbench/contrib/chat/browser/contrib/chatInputRelatedFilesContrib.ts
@@ -51,7 +51,7 @@ export class ChatRelatedFilesContribution extends Disposable implements IWorkben
 
 		this._currentRelatedFilesRetrievalOperation = this.chatEditingService.getRelatedFiles(currentEditingSession.chatSessionResource, widget.getInput(), widget.attachmentModel.fileAttachments, CancellationToken.None)
 			.then((files) => {
-				if (!files?.length || !widget.viewModel?.sessionId || !widget.input.relatedFiles) {
+				if (!files?.length || !widget.viewModel || !widget.input.relatedFiles) {
 					return;
 				}
 

--- a/src/vs/workbench/contrib/chat/common/chatActions.ts
+++ b/src/vs/workbench/contrib/chat/common/chatActions.ts
@@ -4,14 +4,15 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { MarshalledId } from '../../../../base/common/marshallingIds.js';
+import { URI } from '../../../../base/common/uri.js';
 
 export interface IChatViewTitleActionContext {
-	$mid: MarshalledId.ChatViewContext;
-	sessionId: string;
+	readonly $mid: MarshalledId.ChatViewContext;
+	readonly sessionResource: URI;
 }
 
 export function isChatViewTitleActionContext(obj: unknown): obj is IChatViewTitleActionContext {
 	return !!obj &&
-		typeof (obj as IChatViewTitleActionContext).sessionId === 'string'
+		URI.isUri((obj as IChatViewTitleActionContext).sessionResource)
 		&& (obj as IChatViewTitleActionContext).$mid === MarshalledId.ChatViewContext;
 }

--- a/src/vs/workbench/contrib/chat/common/chatEditingService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatEditingService.ts
@@ -8,6 +8,7 @@ import { CancellationToken } from '../../../../base/common/cancellation.js';
 import { Event } from '../../../../base/common/event.js';
 import { IDisposable } from '../../../../base/common/lifecycle.js';
 import { IObservable, IReader } from '../../../../base/common/observable.js';
+import { hasKey } from '../../../../base/common/types.js';
 import { URI } from '../../../../base/common/uri.js';
 import { IDocumentDiff } from '../../../../editor/common/diff/documentDiffProvider.js';
 import { Location, TextEdit } from '../../../../editor/common/languages.js';
@@ -328,12 +329,12 @@ export const enum ChatEditKind {
 }
 
 export interface IChatEditingActionContext {
-	// The chat session ID that this editing session is associated with
-	sessionId: string;
+	// The chat session that this editing session is associated with
+	sessionResource: URI;
 }
 
 export function isChatEditingActionContext(thing: unknown): thing is IChatEditingActionContext {
-	return typeof thing === 'object' && !!thing && 'sessionId' in thing;
+	return typeof thing === 'object' && !!thing && hasKey(thing, { sessionResource: true });
 }
 
 export function getMultiDiffSourceUri(session: IChatEditingSession, showPreviousChanges?: boolean): URI {

--- a/src/vs/workbench/contrib/chat/common/chatModel.ts
+++ b/src/vs/workbench/contrib/chat/common/chatModel.ts
@@ -1060,6 +1060,7 @@ export interface IChatRequestDisablement {
 export interface IChatModel extends IDisposable {
 	readonly onDidDispose: Event<void>;
 	readonly onDidChange: Event<IChatChangeEvent>;
+	/** @deprecated Use {@link sessionResource} instead */
 	readonly sessionId: string;
 	readonly sessionResource: URI;
 	readonly initialLocation: ChatAgentLocation;
@@ -1363,6 +1364,7 @@ export class ChatModel extends Disposable implements IChatModel {
 	// TODO to be clear, this is not the same as the id from the session object, which belongs to the provider.
 	// It's easier to be able to identify this model before its async initialization is complete
 	private readonly _sessionId: string;
+	/** @deprecated Use {@link sessionResource} instead */
 	get sessionId(): string {
 		return this._sessionId;
 	}

--- a/src/vs/workbench/contrib/chat/common/chatService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService.ts
@@ -816,8 +816,6 @@ export interface IChatCompleteResponse {
 }
 
 export interface IChatDetail {
-	/** @deprecated Use {@link sessionResource} instead */
-	sessionId: string;
 	sessionResource: URI;
 	title: string;
 	lastMessageDate: number;
@@ -851,7 +849,7 @@ export interface IChatEditorLocationData {
 	selection: ISelection;
 	wholeRange: IRange;
 	close: () => void;
-	delegateSessionId: string | undefined;
+	delegateSessionResource: URI | undefined;
 }
 
 export interface IChatNotebookLocationData {

--- a/src/vs/workbench/contrib/chat/common/chatUri.ts
+++ b/src/vs/workbench/contrib/chat/common/chatUri.ts
@@ -8,7 +8,7 @@ import { Schemas } from '../../../../base/common/network.js';
 import { URI } from '../../../../base/common/uri.js';
 import { localChatSessionType } from './chatSessionsService.js';
 
-export type ChatSessionIdentifier = {
+type ChatSessionIdentifier = {
 	readonly chatSessionType: string;
 	readonly sessionId: string;
 };
@@ -22,6 +22,11 @@ export namespace LocalChatSessionUri {
 		return forChatSessionTypeAndId(localChatSessionType, sessionId);
 	}
 
+	export function parseLocalSessionId(resource: URI): string | undefined {
+		const parsed = parse(resource);
+		return parsed?.chatSessionType === localChatSessionType ? parsed.sessionId : undefined;
+	}
+
 	/**
 	 * @deprecated Does not support non-local sessions
 	 */
@@ -31,11 +36,9 @@ export namespace LocalChatSessionUri {
 		return URI.from({ scheme, authority: chatSessionType, path: '/' + encodedId });
 	}
 
-	export function parseLocalSessionId(resource: URI): string | undefined {
-		const parsed = parse(resource);
-		return parsed?.chatSessionType === localChatSessionType ? parsed.sessionId : undefined;
-	}
-
+	/**
+	 * @deprecated Legacy parser that supports non-local sessions.
+	 */
 	export function parse(resource: URI): ChatSessionIdentifier | undefined {
 		if (resource.scheme !== scheme) {
 			return undefined;

--- a/src/vs/workbench/contrib/chat/common/languageModelToolsService.ts
+++ b/src/vs/workbench/contrib/chat/common/languageModelToolsService.ts
@@ -323,7 +323,7 @@ export type CountTokensCallback = (input: string, token: CancellationToken) => P
 export interface ILanguageModelToolsService {
 	_serviceBrand: undefined;
 	readonly onDidChangeTools: Event<void>;
-	readonly onDidPrepareToolCallBecomeUnresponsive: Event<{ sessionId: string; toolData: IToolData }>;
+	readonly onDidPrepareToolCallBecomeUnresponsive: Event<{ readonly sessionId: string; readonly toolData: IToolData }>;
 	registerToolData(toolData: IToolData): IDisposable;
 	registerToolImplementation(id: string, tool: IToolImpl): IDisposable;
 	registerTool(toolData: IToolData, tool: IToolImpl): IDisposable;

--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChatController.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChatController.ts
@@ -243,7 +243,7 @@ export class InlineChatController1 implements IEditorContribution {
 						document: this._session.textModelN.uri,
 						wholeRange: this._session?.wholeRange.trackedInitialRange,
 						close: () => this.cancelSession(),
-						delegateSessionId: this._delegateSession?.chatSessionId,
+						delegateSessionResource: this._delegateSession?.chatSessionResource,
 					};
 				}
 			};
@@ -1292,12 +1292,12 @@ export class InlineChatController2 implements IEditorContribution {
 						document,
 						wholeRange,
 						close: () => this._showWidgetOverrideObs.set(false, undefined),
-						delegateSessionId: chatService.editingSessions.find(session =>
+						delegateSessionResource: chatService.editingSessions.find(session =>
 							session.entries.get().some(e => e.hasModificationAt({
 								range: wholeRange,
 								uri: document
 							}))
-						)?.chatSessionId,
+						)?.chatSessionResource,
 					};
 				}
 			};

--- a/src/vs/workbench/contrib/terminalContrib/chat/browser/terminalChatController.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chat/browser/terminalChatController.ts
@@ -77,7 +77,7 @@ export class TerminalChatController extends Disposable implements ITerminalContr
 					code: editor.getValue(),
 					codeBlockIndex: 0,
 					languageId: editor.getModel()!.getLanguageId(),
-					chatSessionId: this._terminalChatWidget.value.inlineChatWidget.chatWidget.viewModel?.sessionId
+					chatSessionResource: this._terminalChatWidget.value.inlineChatWidget.chatWidget.viewModel?.sessionResource
 				};
 			}
 		}, 'terminal'));

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
@@ -314,9 +314,9 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 
 		// Listen for chat session disposal to clean up associated terminals
 		this._register(this._chatService.onDidDisposeSession(e => {
-			const localSession = LocalChatSessionUri.parse(e.sessionResource);
-			if (localSession) {
-				this._cleanupSessionTerminals(localSession.sessionId);
+			const localSessionId = LocalChatSessionUri.parseLocalSessionId(e.sessionResource);
+			if (localSessionId) {
+				this._cleanupSessionTerminals(localSessionId);
 			}
 		}));
 	}


### PR DESCRIPTION
- Adopting for code blocks
- Switching to use safer `LocalChatSessionUri.parseLocalSessionId` in a few more spots
- Adopting for some contexts and a few more apis

