### PR TITLE
Add `Manage Extension Account Preferences` to the Account Menu to make it more discoverable

### DIFF
--- a/src/vs/workbench/contrib/authentication/browser/actions/manageAccountPreferencesForExtensionAction.ts
+++ b/src/vs/workbench/contrib/authentication/browser/actions/manageAccountPreferencesForExtensionAction.ts
@@ -6,7 +6,7 @@
 import { Event } from '../../../../../base/common/event.js';
 import { DisposableStore, IDisposable } from '../../../../../base/common/lifecycle.js';
 import { localize, localize2 } from '../../../../../nls.js';
-import { Action2 } from '../../../../../platform/actions/common/actions.js';
+import { Action2, MenuId } from '../../../../../platform/actions/common/actions.js';
 import { IDialogService } from '../../../../../platform/dialogs/common/dialogs.js';
 import { IInstantiationService, ServicesAccessor } from '../../../../../platform/instantiation/common/instantiation.js';
 import { ILogService } from '../../../../../platform/log/common/log.js';
@@ -19,9 +19,13 @@ export class ManageAccountPreferencesForExtensionAction extends Action2 {
 	constructor() {
 		super({
 			id: '_manageAccountPreferencesForExtension',
-			title: localize2('manageAccountPreferenceForExtension', "Manage Extension Account Preferences"),
+			title: localize2('manageAccountPreferenceForExtension', "Manage Extension Account Preferences..."),
 			category: localize2('accounts', "Accounts"),
-			f1: true
+			f1: true,
+			menu: [{
+				id: MenuId.AccountsContext,
+				order: 100,
+			}],
 		});
 	}
 


### PR DESCRIPTION
I've gotten an increased number of issues related to switching Copilot account preferences. This will help users self service that because right now it's only available via the Command Palette, on the Extension view item, or in other hard to find places.

<img width="444" height="172" alt="image" src="https://github.com/user-attachments/assets/b640ea0b-ec8e-41a5-969e-d9dbea51d14e" />

Fixes https://github.com/microsoft/vscode/issues/274425

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
