### PR TITLE
Fixed error in starting mcp server on windows

### DIFF
--- a/test/mcp/package.json
+++ b/test/mcp/package.json
@@ -9,7 +9,7 @@
     "watch-automation": "cd ../automation && npm run watch",
     "watch-mcp": "node ../../node_modules/typescript/bin/tsc --watch --preserveWatchOutput",
     "watch": "npm-run-all -lp watch-automation watch-mcp",
-    "start-stdio": "echo 'Starting vscode-playwright-mcp... For customization & troubleshooting, see ./test/mcp/README.md' && npm ci && npm run -s compile && node ./out/stdio.js"
+    "start-stdio": "echo 'Starting vscode-playwright-mcp... For customization and troubleshooting, see ./test/mcp/README.md' && npm ci && npm run -s compile && node ./out/stdio.js"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "1.18.1",


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
On windows, the '&' char breaks the execution of `npm run start-stdio` in starting the mcp server. 
