### PR TITLE
tools: split out confirmation service from tools service

### DIFF
--- a/src/vs/platform/quickinput/browser/quickInput.ts
+++ b/src/vs/platform/quickinput/browser/quickInput.ts
@@ -465,6 +465,10 @@ export abstract class QuickInput extends Disposable implements IQuickInput {
 			// it requires a HTMLElement on its interface
 			const concreteToggles = this.toggles?.filter(opts => opts instanceof Toggle) as Toggle[] ?? [];
 			this.ui.inputBox.toggles = concreteToggles;
+			// Adjust count badge position based on number of toggles (each toggle is ~22px wide)
+			const toggleOffset = concreteToggles.length * 22;
+			this.ui.countContainer.style.right = toggleOffset > 0 ? `${4 + toggleOffset}px` : '4px';
+			this.ui.visibleCountContainer.style.right = toggleOffset > 0 ? `${4 + toggleOffset}px` : '4px';
 		}
 		this.ui.ignoreFocusOut = this.ignoreFocusOut;
 		this.ui.setEnabled(this.enabled);

--- a/src/vs/platform/quickinput/browser/tree/quickTree.ts
+++ b/src/vs/platform/quickinput/browser/tree/quickTree.ts
@@ -30,8 +30,11 @@ export class QuickTree<T extends IQuickTreeItem> extends QuickInput implements I
 	readonly onDidChangeValue = Event.fromObservable(this._value, this._store);
 	readonly onDidChangeActive = Event.fromObservable(this._activeItems, this._store);
 
-	private readonly _onDidChangeCheckedLeafItems = new Emitter<T[]>();
+	private readonly _onDidChangeCheckedLeafItems = this._register(new Emitter<T[]>());
 	readonly onDidChangeCheckedLeafItems: Event<T[]> = this._onDidChangeCheckedLeafItems.event;
+
+	private readonly _onDidChangeCheckboxState = this._register(new Emitter<T>());
+	readonly onDidChangeCheckboxState: Event<T> = this._onDidChangeCheckboxState.event;
 
 	readonly onDidAccept: Event<void>;
 
@@ -40,6 +43,7 @@ export class QuickTree<T extends IQuickTreeItem> extends QuickInput implements I
 		this.onDidAccept = ui.onDidAccept;
 		this._registerAutoruns();
 		this._register(ui.tree.onDidChangeCheckedLeafItems(e => this._onDidChangeCheckedLeafItems.fire(e as T[])));
+		this._register(ui.tree.onDidChangeCheckboxState(e => this._onDidChangeCheckboxState.fire(e.item as T)));
 		// Sync active items with tree focus changes
 		this._register(ui.tree.tree.onDidChangeFocus(e => {
 			this._activeItems.set(ui.tree.getActiveItems() as T[], undefined);

--- a/src/vs/platform/quickinput/common/quickInput.ts
+++ b/src/vs/platform/quickinput/common/quickInput.ts
@@ -1121,6 +1121,11 @@ export interface IQuickTree<T extends IQuickTreeItem> extends IQuickInput {
 	readonly onDidChangeCheckedLeafItems: Event<ReadonlyArray<T>>;
 
 	/**
+	 * An event that is fired when the checkbox state of an item changes.
+	 */
+	readonly onDidChangeCheckboxState: Event<T>;
+
+	/**
 	 * An event that is fired when an item button is triggered.
 	 */
 	readonly onDidTriggerItemButton: Event<IQuickTreeItemButtonEvent<T>>;

--- a/src/vs/workbench/contrib/chat/browser/actions/chatActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatActions.ts
@@ -1939,6 +1939,7 @@ registerAction2(class EditToolApproval extends Action2 {
 			metadata: {
 				description: localize2('chat.editToolApproval.description', "Edit/manage the tool approval and confirmation preferences for AI chat agents."),
 			},
+			precondition: ChatContextKeys.enabled,
 			f1: true,
 			category: CHAT_CATEGORY,
 		});

--- a/src/vs/workbench/contrib/chat/browser/actions/chatActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatActions.ts
@@ -71,6 +71,7 @@ import { AGENT_SESSIONS_VIEWLET_ID, ChatAgentLocation, ChatConfiguration, ChatMo
 import { ILanguageModelChatSelector, ILanguageModelsService } from '../../common/languageModels.js';
 import { CopilotUsageExtensionFeatureId } from '../../common/languageModelStats.js';
 import { ILanguageModelToolsService } from '../../common/languageModelToolsService.js';
+import { ILanguageModelToolsConfirmationService } from '../../common/languageModelToolsConfirmationService.js';
 import { ChatViewId, IChatWidget, IChatWidgetService, showChatView } from '../chat.js';
 import { IChatEditorOptions } from '../chatEditor.js';
 import { ChatEditorInput, shouldShowClearEditingSessionConfirmation, showClearEditingSessionConfirmation } from '../chatEditorInput.js';
@@ -1506,7 +1507,7 @@ export function registerChatActions() {
 			});
 		}
 		override run(accessor: ServicesAccessor): void {
-			accessor.get(ILanguageModelToolsService).resetToolAutoConfirmation();
+			accessor.get(ILanguageModelToolsConfirmationService).resetToolAutoConfirmation();
 			accessor.get(INotificationService).info(localize('resetTrustedToolsSuccess', "Tool confirmation preferences have been reset."));
 		}
 	});
@@ -1934,59 +1935,19 @@ registerAction2(class EditToolApproval extends Action2 {
 	constructor() {
 		super({
 			id: 'workbench.action.chat.editToolApproval',
-			title: localize2('chat.editToolApproval.label', "Edit Tool Approval"),
-			f1: false
+			title: localize2('chat.editToolApproval.label', "Manage Tool Approval"),
+			metadata: {
+				description: localize2('chat.editToolApproval.description', "Edit/manage the tool approval and confirmation preferences for AI chat agents."),
+			},
+			f1: true,
+			category: CHAT_CATEGORY,
 		});
 	}
 
-	async run(accessor: ServicesAccessor, toolId: string): Promise<void> {
-		if (!toolId) {
-			return;
-		}
-
-		const quickInputService = accessor.get(IQuickInputService);
+	async run(accessor: ServicesAccessor, scope?: 'workspace' | 'profile' | 'session'): Promise<void> {
+		const confirmationService = accessor.get(ILanguageModelToolsConfirmationService);
 		const toolsService = accessor.get(ILanguageModelToolsService);
-		const tool = toolsService.getTool(toolId);
-		if (!tool) {
-			return;
-		}
-
-		const currentState = toolsService.getToolAutoConfirmation(toolId);
-
-		interface TItem extends IQuickPickItem {
-			id: 'session' | 'workspace' | 'profile' | 'never';
-		}
-
-		const items: TItem[] = [
-			{ id: 'never', label: localize('chat.toolApproval.manual', "Always require manual approval") },
-			{ id: 'session', label: localize('chat.toolApproval.session', "Auto-approve for this session") },
-			{ id: 'workspace', label: localize('chat.toolApproval.workspace', "Auto-approve for this workspace") },
-			{ id: 'profile', label: localize('chat.toolApproval.profile', "Auto-approve globally") }
-		];
-
-		const quickPick = quickInputService.createQuickPick<TItem>();
-		quickPick.placeholder = localize('chat.editToolApproval.title', "Approval setting for {0}", tool.displayName ?? tool.id);
-		quickPick.items = items;
-		quickPick.canSelectMany = false;
-		quickPick.activeItems = items.filter(item => item.id === currentState);
-
-		const selection = await new Promise<TItem | undefined>((resolve) => {
-			quickPick.onDidAccept(() => {
-				const selected = quickPick.selectedItems[0];
-				resolve(selected);
-			});
-			quickPick.onDidHide(() => {
-				resolve(undefined);
-
-			});
-			quickPick.show();
-		});
-
-		quickPick.dispose();
-
-		if (selection) {
-			toolsService.setToolAutoConfirmation(toolId, selection.id);
-		}
+		confirmationService.manageConfirmationPreferences([...toolsService.getTools()], scope ? { defaultScope: scope } : undefined);
 	}
 });
 

--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -126,6 +126,8 @@ import { PromptUrlHandler } from './promptSyntax/promptUrlHandler.js';
 import { ConfigureToolSets, UserToolSetsContributions } from './tools/toolSetsContribution.js';
 import { ChatViewsWelcomeHandler } from './viewsWelcome/chatViewsWelcomeHandler.js';
 import './chatManagement/chatManagement.contribution.js';
+import { ILanguageModelToolsConfirmationService } from '../common/languageModelToolsConfirmationService.js';
+import { LanguageModelToolsConfirmationService } from './languageModelToolsConfirmationService.js';
 
 // Register configuration
 const configurationRegistry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration);
@@ -1012,6 +1014,7 @@ registerSingleton(IChatAgentService, ChatAgentService, InstantiationType.Delayed
 registerSingleton(IChatAgentNameService, ChatAgentNameService, InstantiationType.Delayed);
 registerSingleton(IChatVariablesService, ChatVariablesService, InstantiationType.Delayed);
 registerSingleton(ILanguageModelToolsService, LanguageModelToolsService, InstantiationType.Delayed);
+registerSingleton(ILanguageModelToolsConfirmationService, LanguageModelToolsConfirmationService, InstantiationType.Delayed);
 registerSingleton(IVoiceChatService, VoiceChatService, InstantiationType.Delayed);
 registerSingleton(IChatCodeBlockContextProviderService, ChatCodeBlockContextProviderService, InstantiationType.Delayed);
 registerSingleton(ICodeMapperService, CodeMapperService, InstantiationType.Delayed);

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/chatProgressContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/chatProgressContentPart.ts
@@ -124,7 +124,7 @@ export class ChatProgressContentPart extends Disposable implements IChatContentP
 					: reason.scope === 'workspace'
 						? localize('chat.autoapprove.lmServicePerTool.workspace', 'Auto approved for this workspace')
 						: localize('chat.autoapprove.lmServicePerTool.profile', 'Auto approved for this profile');
-				md += ' (' + markdownCommandLink({ title: localize('edit', 'Edit'), id: 'workbench.action.chat.editToolApproval', arguments: [this.toolInvocation.toolId] }) + ')';
+				md += ' (' + markdownCommandLink({ title: localize('edit', 'Edit'), id: 'workbench.action.chat.editToolApproval', arguments: [reason.scope] }) + ')';
 				break;
 			case ToolConfirmKind.UserAction:
 			case ToolConfirmKind.Denied:

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/abstractToolConfirmationSubPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/abstractToolConfirmationSubPart.ts
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Separator } from '../../../../../../base/common/actions.js';
-import { assertNever } from '../../../../../../base/common/assert.js';
 import { Codicon } from '../../../../../../base/common/codicons.js';
 import { toDisposable } from '../../../../../../base/common/lifecycle.js';
 import { localize } from '../../../../../../nls.js';
@@ -19,14 +18,6 @@ import { ChatCustomConfirmationWidget, IChatConfirmationButton } from '../chatCo
 import { IChatContentPartRenderContext } from '../chatContentParts.js';
 import { BaseChatToolInvocationSubPart } from './chatToolInvocationSubPart.js';
 
-export const enum ConfirmationOutcome {
-	Allow,
-	Skip,
-	AllowWorkspace,
-	AllowGlobally,
-	AllowSession,
-}
-
 export interface IToolConfirmationConfig {
 	allowActionId: string;
 	skipActionId: string;
@@ -36,7 +27,7 @@ export interface IToolConfirmationConfig {
 	subtitle?: string;
 }
 
-type AbstractToolPrimaryAction = IChatConfirmationButton<(() => void) | ConfirmationOutcome> | Separator;
+type AbstractToolPrimaryAction = IChatConfirmationButton<(() => void)> | Separator;
 
 /**
  * Base class for a tool confirmation.
@@ -69,17 +60,21 @@ export abstract class AbstractToolConfirmationSubPart extends BaseChatToolInvoca
 		const skipTooltip = skipKeybinding ? `${config.skipLabel} (${skipKeybinding})` : config.skipLabel;
 
 
-		const buttons: IChatConfirmationButton<ConfirmationOutcome | (() => void)>[] = [
+		const buttons: IChatConfirmationButton<(() => void)>[] = [
 			{
 				label: config.allowLabel,
 				tooltip: allowTooltip,
-				data: ConfirmationOutcome.Allow,
+				data: () => {
+					this.confirmWith(toolInvocation, { type: ToolConfirmKind.UserAction });
+				},
 				moreActions: this.additionalPrimaryActions(),
 			},
 			{
 				label: localize('skip', "Skip"),
 				tooltip: skipTooltip,
-				data: ConfirmationOutcome.Skip,
+				data: () => {
+					this.confirmWith(toolInvocation, { type: ToolConfirmKind.Skipped });
+				},
 				isSecondary: true,
 			}
 		];
@@ -87,7 +82,7 @@ export abstract class AbstractToolConfirmationSubPart extends BaseChatToolInvoca
 		const contentElement = this.createContentElement();
 		const tool = languageModelToolsService.getTool(toolInvocation.toolId);
 		const confirmWidget = this._register(this.instantiationService.createInstance(
-			ChatCustomConfirmationWidget<ConfirmationOutcome | (() => void)>,
+			ChatCustomConfirmationWidget<(() => void)>,
 			this.context,
 			{
 				title: this.getTitle(),
@@ -107,31 +102,7 @@ export abstract class AbstractToolConfirmationSubPart extends BaseChatToolInvoca
 		hasToolConfirmation.set(true);
 
 		this._register(confirmWidget.onDidClick(button => {
-			const confirm = (reason: ConfirmedReason) => this.confirmWith(toolInvocation, reason);
-			if (typeof button.data === 'function') {
-				button.data();
-			} else {
-				switch (button.data) {
-					case ConfirmationOutcome.AllowGlobally:
-						confirm({ type: ToolConfirmKind.LmServicePerTool, scope: 'profile' });
-						break;
-					case ConfirmationOutcome.AllowWorkspace:
-						confirm({ type: ToolConfirmKind.LmServicePerTool, scope: 'workspace' });
-						break;
-					case ConfirmationOutcome.AllowSession:
-						confirm({ type: ToolConfirmKind.LmServicePerTool, scope: 'session' });
-						break;
-					case ConfirmationOutcome.Allow:
-						confirm({ type: ToolConfirmKind.UserAction });
-						break;
-					case ConfirmationOutcome.Skip:
-						confirm({ type: ToolConfirmKind.Skipped });
-						break;
-					default:
-						assertNever(button.data);
-				}
-			}
-
+			button.data();
 			this.chatWidgetService.getWidgetBySessionResource(this.context.element.sessionResource)?.focusInput();
 		}));
 

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatToolInvocationPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatToolInvocationPart.ts
@@ -125,7 +125,7 @@ export class ChatToolInvocationPart extends Disposable implements IChatContentPa
 					: reason.scope === 'workspace'
 						? localize('chat.autoapprove.lmServicePerTool.workspace', 'Auto approved for this workspace')
 						: localize('chat.autoapprove.lmServicePerTool.profile', 'Auto approved for this profile');
-				md += ' (' + markdownCommandLink({ title: localize('edit', 'Edit'), id: 'workbench.action.chat.editToolApproval', arguments: [this.toolInvocation.toolId] }) + ')';
+				md += ' (' + markdownCommandLink({ title: localize('edit', 'Edit'), id: 'workbench.action.chat.editToolApproval', arguments: [reason.scope] }) + ')';
 				break;
 			case ToolConfirmKind.UserAction:
 			case ToolConfirmKind.Denied:

--- a/src/vs/workbench/contrib/chat/browser/languageModelToolsConfirmationService.ts
+++ b/src/vs/workbench/contrib/chat/browser/languageModelToolsConfirmationService.ts
@@ -1,0 +1,789 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Toggle } from '../../../../base/browser/ui/toggle/toggle.js';
+import { Codicon } from '../../../../base/common/codicons.js';
+import { Lazy } from '../../../../base/common/lazy.js';
+import { Disposable, DisposableStore, IDisposable } from '../../../../base/common/lifecycle.js';
+import { LRUCache } from '../../../../base/common/map.js';
+import { ThemeIcon } from '../../../../base/common/themables.js';
+import { localize } from '../../../../nls.js';
+import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
+import { IQuickInputService, IQuickTreeItem } from '../../../../platform/quickinput/common/quickInput.js';
+import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
+import { inputActiveOptionBackground, inputActiveOptionBorder, inputActiveOptionForeground } from '../../../../platform/theme/common/colorRegistry.js';
+import { asCssVariable } from '../../../../platform/theme/common/colorUtils.js';
+import { ConfirmedReason, ToolConfirmKind } from '../common/chatService.js';
+import { ILanguageModelToolConfirmationActions, ILanguageModelToolConfirmationContribution, ILanguageModelToolConfirmationContributionQuickTreeItem, ILanguageModelToolConfirmationRef, ILanguageModelToolsConfirmationService } from '../common/languageModelToolsConfirmationService.js';
+import { IToolData, ToolDataSource } from '../common/languageModelToolsService.js';
+
+const RUN_WITHOUT_APPROVAL = localize('runWithoutApproval', "without approval");
+const CONTINUE_WITHOUT_REVIEWING_RESULTS = localize('continueWithoutReviewingResults', "without reviewing result");
+
+
+class GenericConfirmStore extends Disposable {
+	private _workspaceStore: Lazy<ToolConfirmStore>;
+	private _profileStore: Lazy<ToolConfirmStore>;
+	private _memoryStore = new Set<string>();
+
+	constructor(
+		private readonly _storageKey: string,
+		private readonly _instantiationService: IInstantiationService,
+	) {
+		super();
+		this._workspaceStore = new Lazy(() => this._register(this._instantiationService.createInstance(ToolConfirmStore, StorageScope.WORKSPACE, this._storageKey)));
+		this._profileStore = new Lazy(() => this._register(this._instantiationService.createInstance(ToolConfirmStore, StorageScope.PROFILE, this._storageKey)));
+	}
+
+	public setAutoConfirmation(id: string, scope: 'workspace' | 'profile' | 'session' | 'never'): void {
+		// Clear from all scopes first
+		this._workspaceStore.value.setAutoConfirm(id, false);
+		this._profileStore.value.setAutoConfirm(id, false);
+		this._memoryStore.delete(id);
+
+		// Set in the appropriate scope
+		if (scope === 'workspace') {
+			this._workspaceStore.value.setAutoConfirm(id, true);
+		} else if (scope === 'profile') {
+			this._profileStore.value.setAutoConfirm(id, true);
+		} else if (scope === 'session') {
+			this._memoryStore.add(id);
+		}
+	}
+
+	public getAutoConfirmation(id: string): 'workspace' | 'profile' | 'session' | 'never' {
+		if (this._workspaceStore.value.getAutoConfirm(id)) {
+			return 'workspace';
+		}
+		if (this._profileStore.value.getAutoConfirm(id)) {
+			return 'profile';
+		}
+		if (this._memoryStore.has(id)) {
+			return 'session';
+		}
+		return 'never';
+	}
+
+	public getAutoConfirmationIn(id: string, scope: 'workspace' | 'profile' | 'session'): boolean {
+		if (scope === 'workspace') {
+			return this._workspaceStore.value.getAutoConfirm(id);
+		} else if (scope === 'profile') {
+			return this._profileStore.value.getAutoConfirm(id);
+		} else {
+			return this._memoryStore.has(id);
+		}
+	}
+
+	public reset(): void {
+		this._workspaceStore.value.reset();
+		this._profileStore.value.reset();
+		this._memoryStore.clear();
+	}
+
+	public checkAutoConfirmation(id: string): ConfirmedReason | undefined {
+		if (this._workspaceStore.value.getAutoConfirm(id)) {
+			return { type: ToolConfirmKind.LmServicePerTool, scope: 'workspace' };
+		}
+		if (this._profileStore.value.getAutoConfirm(id)) {
+			return { type: ToolConfirmKind.LmServicePerTool, scope: 'profile' };
+		}
+		if (this._memoryStore.has(id)) {
+			return { type: ToolConfirmKind.LmServicePerTool, scope: 'session' };
+		}
+		return undefined;
+	}
+
+	public getAllConfirmed(): Set<string> {
+		const all = new Set<string>();
+		for (const key of this._workspaceStore.value.getAll()) {
+			all.add(key);
+		}
+		for (const key of this._profileStore.value.getAll()) {
+			all.add(key);
+		}
+		for (const key of this._memoryStore) {
+			all.add(key);
+		}
+		return all;
+	}
+}
+
+class ToolConfirmStore extends Disposable {
+	private _autoConfirmTools: LRUCache<string, boolean> = new LRUCache<string, boolean>(100);
+	private _didChange = false;
+
+	constructor(
+		private readonly _scope: StorageScope,
+		private readonly _storageKey: string,
+		@IStorageService private readonly storageService: IStorageService,
+	) {
+		super();
+
+		const stored = storageService.getObject<string[]>(this._storageKey, this._scope);
+		if (stored) {
+			for (const key of stored) {
+				this._autoConfirmTools.set(key, true);
+			}
+		}
+
+		this._register(storageService.onWillSaveState(() => {
+			if (this._didChange) {
+				this.storageService.store(this._storageKey, [...this._autoConfirmTools.keys()], this._scope, StorageTarget.MACHINE);
+				this._didChange = false;
+			}
+		}));
+	}
+
+	public reset() {
+		this._autoConfirmTools.clear();
+		this._didChange = true;
+	}
+
+	public getAutoConfirm(id: string): boolean {
+		if (this._autoConfirmTools.get(id)) {
+			this._didChange = true;
+			return true;
+		}
+
+		return false;
+	}
+
+	public setAutoConfirm(id: string, autoConfirm: boolean): void {
+		if (autoConfirm) {
+			this._autoConfirmTools.set(id, true);
+		} else {
+			this._autoConfirmTools.delete(id);
+		}
+		this._didChange = true;
+	}
+
+	public getAll(): string[] {
+		return [...this._autoConfirmTools.keys()];
+	}
+}
+
+export class LanguageModelToolsConfirmationService extends Disposable implements ILanguageModelToolsConfirmationService {
+	declare readonly _serviceBrand: undefined;
+
+	private _preExecutionToolConfirmStore: GenericConfirmStore;
+	private _postExecutionToolConfirmStore: GenericConfirmStore;
+	private _preExecutionServerConfirmStore: GenericConfirmStore;
+	private _postExecutionServerConfirmStore: GenericConfirmStore;
+
+	private _contributions = new Map<string, ILanguageModelToolConfirmationContribution>();
+
+	constructor(
+		@IInstantiationService private readonly _instantiationService: IInstantiationService,
+		@IQuickInputService private readonly _quickInputService: IQuickInputService,
+	) {
+		super();
+
+		this._preExecutionToolConfirmStore = this._register(new GenericConfirmStore('chat/autoconfirm', this._instantiationService));
+		this._postExecutionToolConfirmStore = this._register(new GenericConfirmStore('chat/autoconfirm-post', this._instantiationService));
+		this._preExecutionServerConfirmStore = this._register(new GenericConfirmStore('chat/servers/autoconfirm', this._instantiationService));
+		this._postExecutionServerConfirmStore = this._register(new GenericConfirmStore('chat/servers/autoconfirm-post', this._instantiationService));
+	}
+
+	getPreConfirmAction(ref: ILanguageModelToolConfirmationRef): ConfirmedReason | undefined {
+		// Check contribution first
+		const contribution = this._contributions.get(ref.toolId);
+		if (contribution?.getPreConfirmAction) {
+			const result = contribution.getPreConfirmAction(ref);
+			if (result) {
+				return result;
+			}
+		}
+
+		// If contribution disables default approvals, don't check default stores
+		if (contribution && contribution.canUseDefaultApprovals === false) {
+			return undefined;
+		}
+
+		// Check tool-level confirmation
+		const toolResult = this._preExecutionToolConfirmStore.checkAutoConfirmation(ref.toolId);
+		if (toolResult) {
+			return toolResult;
+		}
+
+		// Check server-level confirmation for MCP tools
+		if (ref.source.type === 'mcp') {
+			const serverResult = this._preExecutionServerConfirmStore.checkAutoConfirmation(ref.source.definitionId);
+			if (serverResult) {
+				return serverResult;
+			}
+		}
+
+		return undefined;
+	}
+
+	getPostConfirmAction(ref: ILanguageModelToolConfirmationRef): ConfirmedReason | undefined {
+		// Check contribution first
+		const contribution = this._contributions.get(ref.toolId);
+		if (contribution?.getPostConfirmAction) {
+			const result = contribution.getPostConfirmAction(ref);
+			if (result) {
+				return result;
+			}
+		}
+
+		// If contribution disables default approvals, don't check default stores
+		if (contribution && contribution.canUseDefaultApprovals === false) {
+			return undefined;
+		}
+
+		// Check tool-level confirmation
+		const toolResult = this._postExecutionToolConfirmStore.checkAutoConfirmation(ref.toolId);
+		if (toolResult) {
+			return toolResult;
+		}
+
+		// Check server-level confirmation for MCP tools
+		if (ref.source.type === 'mcp') {
+			const serverResult = this._postExecutionServerConfirmStore.checkAutoConfirmation(ref.source.definitionId);
+			if (serverResult) {
+				return serverResult;
+			}
+		}
+
+		return undefined;
+	}
+
+	getPreConfirmActions(ref: ILanguageModelToolConfirmationRef): ILanguageModelToolConfirmationActions[] {
+		const actions: ILanguageModelToolConfirmationActions[] = [];
+
+		// Add contribution actions first
+		const contribution = this._contributions.get(ref.toolId);
+		if (contribution?.getPreConfirmActions) {
+			actions.push(...contribution.getPreConfirmActions(ref));
+		}
+
+		// If contribution disables default approvals, only return contribution actions
+		if (contribution && contribution.canUseDefaultApprovals === false) {
+			return actions;
+		}
+
+		// Add default tool-level actions
+		actions.push(
+			{
+				label: localize('allowSession', 'Allow in this Session'),
+				detail: localize('allowSessionTooltip', 'Allow this tool to run in this session without confirmation.'),
+				divider: !!actions.length,
+				select: async () => {
+					this._preExecutionToolConfirmStore.setAutoConfirmation(ref.toolId, 'session');
+					return true;
+				}
+			},
+			{
+				label: localize('allowWorkspace', 'Allow in this Workspace'),
+				detail: localize('allowWorkspaceTooltip', 'Allow this tool to run in this workspace without confirmation.'),
+				select: async () => {
+					this._preExecutionToolConfirmStore.setAutoConfirmation(ref.toolId, 'workspace');
+					return true;
+				}
+			},
+			{
+				label: localize('allowGlobally', 'Always Allow'),
+				detail: localize('allowGloballyTooltip', 'Always allow this tool to run without confirmation.'),
+				select: async () => {
+					this._preExecutionToolConfirmStore.setAutoConfirmation(ref.toolId, 'profile');
+					return true;
+				}
+			}
+		);
+
+		// Add server-level actions for MCP tools
+		if (ref.source.type === 'mcp') {
+			const { serverLabel, definitionId } = ref.source;
+			actions.push(
+				{
+					label: localize('allowServerSession', 'Allow Tools from {0} in this Session', serverLabel),
+					detail: localize('allowServerSessionTooltip', 'Allow all tools from this server to run in this session without confirmation.'),
+					divider: true,
+					select: async () => {
+						this._preExecutionServerConfirmStore.setAutoConfirmation(definitionId, 'session');
+						return true;
+					}
+				},
+				{
+					label: localize('allowServerWorkspace', 'Allow Tools from {0} in this Workspace', serverLabel),
+					detail: localize('allowServerWorkspaceTooltip', 'Allow all tools from this server to run in this workspace without confirmation.'),
+					select: async () => {
+						this._preExecutionServerConfirmStore.setAutoConfirmation(definitionId, 'workspace');
+						return true;
+					}
+				},
+				{
+					label: localize('allowServerGlobally', 'Always Allow Tools from {0}', serverLabel),
+					detail: localize('allowServerGloballyTooltip', 'Always allow all tools from this server to run without confirmation.'),
+					select: async () => {
+						this._preExecutionServerConfirmStore.setAutoConfirmation(definitionId, 'profile');
+						return true;
+					}
+				}
+			);
+		}
+
+		return actions;
+	}
+
+	getPostConfirmActions(ref: ILanguageModelToolConfirmationRef): ILanguageModelToolConfirmationActions[] {
+		const actions: ILanguageModelToolConfirmationActions[] = [];
+
+		// Add contribution actions first
+		const contribution = this._contributions.get(ref.toolId);
+		if (contribution?.getPostConfirmActions) {
+			actions.push(...contribution.getPostConfirmActions(ref));
+		}
+
+		// If contribution disables default approvals, only return contribution actions
+		if (contribution && contribution.canUseDefaultApprovals === false) {
+			return actions;
+		}
+
+		// Add default tool-level actions
+		actions.push(
+			{
+				label: localize('allowSessionPost', 'Allow Without Review in this Session'),
+				detail: localize('allowSessionPostTooltip', 'Allow results from this tool to be sent without confirmation in this session.'),
+				divider: !!actions.length,
+				select: async () => {
+					this._postExecutionToolConfirmStore.setAutoConfirmation(ref.toolId, 'session');
+					return true;
+				}
+			},
+			{
+				label: localize('allowWorkspacePost', 'Allow Without Review in this Workspace'),
+				detail: localize('allowWorkspacePostTooltip', 'Allow results from this tool to be sent without confirmation in this workspace.'),
+				select: async () => {
+					this._postExecutionToolConfirmStore.setAutoConfirmation(ref.toolId, 'workspace');
+					return true;
+				}
+			},
+			{
+				label: localize('allowGloballyPost', 'Always Allow Without Review'),
+				detail: localize('allowGloballyPostTooltip', 'Always allow results from this tool to be sent without confirmation.'),
+				select: async () => {
+					this._postExecutionToolConfirmStore.setAutoConfirmation(ref.toolId, 'profile');
+					return true;
+				}
+			}
+		);
+
+		// Add server-level actions for MCP tools
+		if (ref.source.type === 'mcp') {
+			const { serverLabel, definitionId } = ref.source;
+			actions.push(
+				{
+					label: localize('allowServerSessionPost', 'Allow Tools from {0} Without Review in this Session', serverLabel),
+					detail: localize('allowServerSessionPostTooltip', 'Allow results from all tools from this server to be sent without confirmation in this session.'),
+					divider: true,
+					select: async () => {
+						this._postExecutionServerConfirmStore.setAutoConfirmation(definitionId, 'session');
+						return true;
+					}
+				},
+				{
+					label: localize('allowServerWorkspacePost', 'Allow Tools from {0} Without Review in this Workspace', serverLabel),
+					detail: localize('allowServerWorkspacePostTooltip', 'Allow results from all tools from this server to be sent without confirmation in this workspace.'),
+					select: async () => {
+						this._postExecutionServerConfirmStore.setAutoConfirmation(definitionId, 'workspace');
+						return true;
+					}
+				},
+				{
+					label: localize('allowServerGloballyPost', 'Always Allow Tools from {0} Without Review', serverLabel),
+					detail: localize('allowServerGloballyPostTooltip', 'Always allow results from all tools from this server to be sent without confirmation.'),
+					select: async () => {
+						this._postExecutionServerConfirmStore.setAutoConfirmation(definitionId, 'profile');
+						return true;
+					}
+				}
+			);
+		}
+
+		return actions;
+	}
+
+	registerConfirmationContribution(toolName: string, contribution: ILanguageModelToolConfirmationContribution): IDisposable {
+		this._contributions.set(toolName, contribution);
+		return {
+			dispose: () => {
+				this._contributions.delete(toolName);
+			}
+		};
+	}
+
+	manageConfirmationPreferences(tools: Readonly<IToolData>[], options?: { defaultScope?: 'workspace' | 'profile' | 'session' }): void {
+		interface IToolTreeItem extends IQuickTreeItem {
+			type: 'tool' | 'server' | 'tool-pre' | 'tool-post' | 'server-pre' | 'server-post' | 'manage';
+			toolId?: string;
+			serverId?: string;
+			scope?: 'workspace' | 'profile';
+		}
+
+		// Helper to track tools under servers
+		const trackServerTool = (serverId: string, label: string, toolId: string, serversWithTools: Map<string, { label: string; tools: Set<string> }>) => {
+			if (!serversWithTools.has(serverId)) {
+				serversWithTools.set(serverId, { label, tools: new Set() });
+			}
+			serversWithTools.get(serverId)!.tools.add(toolId);
+		};
+
+		// Helper to add server tool from source
+		const addServerToolFromSource = (source: ToolDataSource, toolId: string, serversWithTools: Map<string, { label: string; tools: Set<string> }>) => {
+			if (source.type === 'mcp') {
+				trackServerTool(source.definitionId, source.serverLabel || source.label, toolId, serversWithTools);
+			} else if (source.type === 'extension') {
+				trackServerTool(source.extensionId.value, source.label, toolId, serversWithTools);
+			}
+		};
+
+		// Determine which tools should be shown
+		const relevantTools = new Set<string>();
+		const serversWithTools = new Map<string, { label: string; tools: Set<string> }>();
+
+		// Add tools that request approval
+		for (const tool of tools) {
+			if (tool.canRequestPreApproval || tool.canRequestPostApproval || this._contributions.has(tool.id)) {
+				relevantTools.add(tool.id);
+				addServerToolFromSource(tool.source, tool.id, serversWithTools);
+			}
+		}
+
+		// Add tools that have stored approvals (but we can't display them without metadata)
+		for (const id of this._preExecutionToolConfirmStore.getAllConfirmed()) {
+			if (!relevantTools.has(id)) {
+				// Only add if we have the tool data
+				const tool = tools.find(t => t.id === id);
+				if (tool) {
+					relevantTools.add(id);
+					addServerToolFromSource(tool.source, id, serversWithTools);
+				}
+			}
+		}
+		for (const id of this._postExecutionToolConfirmStore.getAllConfirmed()) {
+			if (!relevantTools.has(id)) {
+				// Only add if we have the tool data
+				const tool = tools.find(t => t.id === id);
+				if (tool) {
+					relevantTools.add(id);
+					addServerToolFromSource(tool.source, id, serversWithTools);
+				}
+			}
+		}
+
+		if (relevantTools.size === 0) {
+			return; // Nothing to show
+		}
+
+		// Determine initial scope from options
+		let currentScope = options?.defaultScope ?? 'workspace';
+
+		// Helper function to build tree items based on current scope
+		const buildTreeItems = (): IToolTreeItem[] => {
+			const treeItems: IToolTreeItem[] = [];
+
+			// Add server nodes
+			for (const [serverId, serverInfo] of serversWithTools) {
+				const serverChildren: IToolTreeItem[] = [];
+
+				// Add server-level controls as first children
+				const hasAnyPre = Array.from(serverInfo.tools).some(toolId => {
+					const tool = tools.find(t => t.id === toolId);
+					return tool?.canRequestPreApproval;
+				});
+				const hasAnyPost = Array.from(serverInfo.tools).some(toolId => {
+					const tool = tools.find(t => t.id === toolId);
+					return tool?.canRequestPostApproval;
+				});
+
+				const serverPreConfirmed = this._preExecutionServerConfirmStore.getAutoConfirmationIn(serverId, currentScope);
+				const serverPostConfirmed = this._postExecutionServerConfirmStore.getAutoConfirmationIn(serverId, currentScope);
+
+				// Add individual tools from this server as children
+				for (const toolId of serverInfo.tools) {
+					const tool = tools.find(t => t.id === toolId);
+					if (!tool) {
+						continue;
+					}
+
+					const toolChildren: IToolTreeItem[] = [];
+					const hasPre = !serverPreConfirmed && (tool.canRequestPreApproval || this._preExecutionToolConfirmStore.getAutoConfirmationIn(tool.id, currentScope));
+					const hasPost = !serverPostConfirmed && (tool.canRequestPostApproval || this._postExecutionToolConfirmStore.getAutoConfirmationIn(tool.id, currentScope));
+
+					// Add child items for granular control when both approval types exist
+					if (hasPre && hasPost) {
+						toolChildren.push({
+							type: 'tool-pre',
+							toolId: tool.id,
+							label: RUN_WITHOUT_APPROVAL,
+							checked: this._preExecutionToolConfirmStore.getAutoConfirmationIn(tool.id, currentScope)
+						});
+						toolChildren.push({
+							type: 'tool-post',
+							toolId: tool.id,
+							label: CONTINUE_WITHOUT_REVIEWING_RESULTS,
+							checked: this._postExecutionToolConfirmStore.getAutoConfirmationIn(tool.id, currentScope)
+						});
+					}
+
+					// Tool item always has a checkbox
+					const preApproval = this._preExecutionToolConfirmStore.getAutoConfirmationIn(tool.id, currentScope);
+					const postApproval = this._postExecutionToolConfirmStore.getAutoConfirmationIn(tool.id, currentScope);
+					let checked: boolean | 'mixed';
+					let description: string | undefined;
+
+					if (hasPre && hasPost) {
+						// Both: checkbox is mixed if only one is enabled
+						checked = preApproval && postApproval ? true : (!preApproval && !postApproval ? false : 'mixed');
+					} else if (hasPre) {
+						checked = preApproval;
+						description = RUN_WITHOUT_APPROVAL;
+					} else if (hasPost) {
+						checked = postApproval;
+						description = CONTINUE_WITHOUT_REVIEWING_RESULTS;
+					} else {
+						continue;
+					}
+
+					serverChildren.push({
+						type: 'tool',
+						toolId: tool.id,
+						label: tool.displayName || tool.id,
+						description,
+						checked,
+						collapsed: true,
+						children: toolChildren.length > 0 ? toolChildren : undefined
+					});
+				}
+
+				serverChildren.sort((a, b) => a.label.localeCompare(b.label));
+
+				if (hasAnyPost) {
+					serverChildren.unshift({
+						type: 'server-post',
+						serverId,
+						iconClass: ThemeIcon.asClassName(Codicon.play),
+						label: localize('continueWithoutReviewing', "Continue without reviewing any tool results"),
+						checked: serverPostConfirmed
+					});
+				}
+				if (hasAnyPre) {
+					serverChildren.unshift({
+						type: 'server-pre',
+						serverId,
+						iconClass: ThemeIcon.asClassName(Codicon.play),
+						label: localize('runToolsWithoutApproval', "Run any tool without approval"),
+						checked: serverPreConfirmed
+					});
+				}
+
+				// Server node has checkbox to control both pre and post
+				const serverHasPre = this._preExecutionServerConfirmStore.getAutoConfirmationIn(serverId, currentScope);
+				const serverHasPost = this._postExecutionServerConfirmStore.getAutoConfirmationIn(serverId, currentScope);
+				let serverChecked: boolean | 'mixed';
+				if (hasAnyPre && hasAnyPost) {
+					serverChecked = serverHasPre && serverHasPost ? true : (!serverHasPre && !serverHasPost ? false : 'mixed');
+				} else if (hasAnyPre) {
+					serverChecked = serverHasPre;
+				} else if (hasAnyPost) {
+					serverChecked = serverHasPost;
+				} else {
+					serverChecked = false;
+				}
+
+				const existingItem = quickTree.itemTree.find(i => i.serverId === serverId);
+				treeItems.push({
+					type: 'server',
+					serverId,
+					label: serverInfo.label,
+					checked: serverChecked,
+					children: serverChildren,
+					collapsed: existingItem ? quickTree.isCollapsed(existingItem) : true,
+					pickable: false
+				});
+			}
+
+			// Add individual tool nodes (only for non-MCP/extension tools)
+			const sortedTools = tools.slice().sort((a, b) => a.displayName.localeCompare(b.displayName));
+			for (const tool of sortedTools) {
+				if (!relevantTools.has(tool.id)) {
+					continue;
+				}
+
+				// Skip tools that belong to MCP/extension servers (they're shown under server nodes)
+				if (tool.source.type === 'mcp' || tool.source.type === 'extension') {
+					continue;
+				}
+
+				const contributed = this._contributions.get(tool.id);
+				const toolChildren: IToolTreeItem[] = [];
+
+				const manageActions = contributed?.getManageActions?.();
+				if (manageActions) {
+					toolChildren.push(...manageActions.map(action => ({
+						type: 'manage' as const,
+						...action,
+					})));
+				}
+
+
+				let checked: boolean | 'mixed' = false;
+				let description: string | undefined;
+				let pickable = false;
+
+				if (contributed?.canUseDefaultApprovals !== false) {
+					pickable = true;
+					const hasPre = tool.canRequestPreApproval || this._preExecutionToolConfirmStore.getAutoConfirmationIn(tool.id, currentScope);
+					const hasPost = tool.canRequestPostApproval || this._postExecutionToolConfirmStore.getAutoConfirmationIn(tool.id, currentScope);
+
+					// Add child items for granular control when both approval types exist
+					if (hasPre && hasPost) {
+						toolChildren.push({
+							type: 'tool-pre',
+							toolId: tool.id,
+							label: RUN_WITHOUT_APPROVAL,
+							checked: this._preExecutionToolConfirmStore.getAutoConfirmationIn(tool.id, currentScope)
+						});
+						toolChildren.push({
+							type: 'tool-post',
+							toolId: tool.id,
+							label: CONTINUE_WITHOUT_REVIEWING_RESULTS,
+							checked: this._postExecutionToolConfirmStore.getAutoConfirmationIn(tool.id, currentScope)
+						});
+					}
+
+					// Tool item always has a checkbox
+					const preApproval = this._preExecutionToolConfirmStore.getAutoConfirmationIn(tool.id, currentScope);
+					const postApproval = this._postExecutionToolConfirmStore.getAutoConfirmationIn(tool.id, currentScope);
+
+					if (hasPre && hasPost) {
+						// Both: checkbox is mixed if only one is enabled
+						checked = preApproval && postApproval ? true : (!preApproval && !postApproval ? false : 'mixed');
+					} else if (hasPre) {
+						checked = preApproval;
+						description = RUN_WITHOUT_APPROVAL;
+					} else if (hasPost) {
+						checked = postApproval;
+						description = CONTINUE_WITHOUT_REVIEWING_RESULTS;
+					} else {
+						// No approval capabilities - shouldn't happen but handle it
+						checked = false;
+					}
+				}
+
+				treeItems.push({
+					type: 'tool',
+					toolId: tool.id,
+					label: tool.displayName || tool.id,
+					description,
+					checked,
+					pickable,
+					collapsed: true,
+					children: toolChildren.length > 0 ? toolChildren : undefined
+				});
+			}
+
+			return treeItems;
+		};
+
+		const disposables = new DisposableStore();
+		const quickTree = disposables.add(this._quickInputService.createQuickTree<IToolTreeItem>());
+		quickTree.ignoreFocusOut = true;
+		quickTree.sortByLabel = false;
+
+		// Only show toggle if not in session scope
+		if (currentScope !== 'session') {
+			const scopeToggle = disposables.add(new Toggle({
+				title: localize('workspaceScope', "Configure for this workspace only"),
+				icon: Codicon.folder,
+				isChecked: currentScope === 'workspace',
+				inputActiveOptionBorder: asCssVariable(inputActiveOptionBorder),
+				inputActiveOptionForeground: asCssVariable(inputActiveOptionForeground),
+				inputActiveOptionBackground: asCssVariable(inputActiveOptionBackground)
+			}));
+			quickTree.toggles = [scopeToggle];
+			disposables.add(scopeToggle.onChange(() => {
+				currentScope = currentScope === 'workspace' ? 'profile' : 'workspace';
+				updatePlaceholder();
+				quickTree.setItemTree(buildTreeItems());
+			}));
+		}
+
+		const updatePlaceholder = () => {
+			if (currentScope === 'session') {
+				quickTree.placeholder = localize('configureSessionToolApprovals', "Configure session tool approvals");
+			} else {
+				quickTree.placeholder = currentScope === 'workspace'
+					? localize('configureWorkspaceToolApprovals', "Configure workspace tool approvals")
+					: localize('configureGlobalToolApprovals', "Configure global tool approvals");
+			}
+		};
+		updatePlaceholder();
+
+		quickTree.setItemTree(buildTreeItems());
+
+		disposables.add(quickTree.onDidChangeCheckboxState(item => {
+			const newState = item.checked ? currentScope : 'never';
+
+			if (item.type === 'server' && item.serverId) {
+				// Server-level checkbox: update both pre and post based on server capabilities
+				const serverInfo = serversWithTools.get(item.serverId);
+				if (serverInfo) {
+					this._preExecutionServerConfirmStore.setAutoConfirmation(item.serverId, newState);
+					this._postExecutionServerConfirmStore.setAutoConfirmation(item.serverId, newState);
+				}
+			} else if (item.type === 'tool' && item.toolId) {
+				const tool = tools.find(t => t.id === item.toolId);
+				if (tool?.canRequestPostApproval || newState === 'never') {
+					this._postExecutionToolConfirmStore.setAutoConfirmation(item.toolId, newState);
+				}
+				if (tool?.canRequestPreApproval || newState === 'never') {
+					this._preExecutionToolConfirmStore.setAutoConfirmation(item.toolId, newState);
+				}
+			} else if (item.type === 'tool-pre' && item.toolId) {
+				this._preExecutionToolConfirmStore.setAutoConfirmation(item.toolId, newState);
+			} else if (item.type === 'tool-post' && item.toolId) {
+				this._postExecutionToolConfirmStore.setAutoConfirmation(item.toolId, newState);
+			} else if (item.type === 'server-pre' && item.serverId) {
+				this._preExecutionServerConfirmStore.setAutoConfirmation(item.serverId, newState);
+				quickTree.setItemTree(buildTreeItems());
+			} else if (item.type === 'server-post' && item.serverId) {
+				this._postExecutionServerConfirmStore.setAutoConfirmation(item.serverId, newState);
+				quickTree.setItemTree(buildTreeItems());
+			} else if (item.type === 'manage') {
+				(item as ILanguageModelToolConfirmationContributionQuickTreeItem).onDidChangeChecked?.(!!item.checked);
+			}
+		}));
+
+		disposables.add(quickTree.onDidTriggerItemButton(i => {
+			if (i.item.type === 'manage') {
+				(i.item as ILanguageModelToolConfirmationContributionQuickTreeItem).onDidTriggerItemButton?.(i.button);
+			}
+		}));
+
+		disposables.add(quickTree.onDidAccept(() => {
+			quickTree.hide();
+		}));
+
+		disposables.add(quickTree.onDidHide(() => {
+			disposables.dispose();
+		}));
+
+		quickTree.show();
+	}
+
+	public resetToolAutoConfirmation(): void {
+		this._preExecutionToolConfirmStore.reset();
+		this._postExecutionToolConfirmStore.reset();
+		this._preExecutionServerConfirmStore.reset();
+		this._postExecutionServerConfirmStore.reset();
+
+		// Reset all contributions
+		for (const contribution of this._contributions.values()) {
+			contribution.reset?.();
+		}
+	}
+}

--- a/src/vs/workbench/contrib/chat/browser/languageModelToolsService.ts
+++ b/src/vs/workbench/contrib/chat/browser/languageModelToolsService.ts
@@ -15,9 +15,7 @@ import { CancellationError, isCancellationError } from '../../../../base/common/
 import { Emitter, Event } from '../../../../base/common/event.js';
 import { MarkdownString } from '../../../../base/common/htmlContent.js';
 import { Iterable } from '../../../../base/common/iterator.js';
-import { Lazy } from '../../../../base/common/lazy.js';
 import { combinedDisposable, Disposable, DisposableStore, IDisposable, toDisposable } from '../../../../base/common/lifecycle.js';
-import { LRUCache } from '../../../../base/common/map.js';
 import { IObservable, ObservableSet } from '../../../../base/common/observable.js';
 import Severity from '../../../../base/common/severity.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
@@ -42,6 +40,7 @@ import { ConfirmedReason, IChatService, IChatToolInvocation, ToolConfirmKind } f
 import { ChatRequestToolReferenceEntry, toToolSetVariableEntry, toToolVariableEntry } from '../common/chatVariableEntries.js';
 import { ChatConfiguration } from '../common/constants.js';
 import { CountTokensCallback, createToolSchemaUri, ILanguageModelToolsService, IPreparedToolInvocation, IToolAndToolSetEnablementMap, IToolData, IToolImpl, IToolInvocation, IToolResult, IToolResultInputOutputDetails, stringifyPromptTsxPart, ToolDataSource, ToolSet } from '../common/languageModelToolsService.js';
+import { ILanguageModelToolsConfirmationService } from '../common/languageModelToolsConfirmationService.js';
 import { getToolConfirmationAlert } from './chatAccessibilityProvider.js';
 import { LocalChatSessionUri } from '../common/chatUri.js';
 
@@ -93,9 +92,6 @@ export class LanguageModelToolsService extends Disposable implements ILanguageMo
 
 	private _callsByRequestId = new Map<string, ITrackedCall[]>();
 
-	private _preExecutionConfirmStore: GenericConfirmStore;
-	private _postExecutionConfirmStore: GenericConfirmStore;
-
 	constructor(
 		@IInstantiationService private readonly _instantiationService: IInstantiationService,
 		@IExtensionService private readonly _extensionService: IExtensionService,
@@ -108,11 +104,9 @@ export class LanguageModelToolsService extends Disposable implements ILanguageMo
 		@IAccessibilityService private readonly _accessibilityService: IAccessibilityService,
 		@IAccessibilitySignalService private readonly _accessibilitySignalService: IAccessibilitySignalService,
 		@IStorageService private readonly _storageService: IStorageService,
+		@ILanguageModelToolsConfirmationService private readonly _confirmationService: ILanguageModelToolsConfirmationService,
 	) {
 		super();
-
-		this._preExecutionConfirmStore = this._register(new GenericConfirmStore('chat/autoconfirm', this._instantiationService));
-		this._postExecutionConfirmStore = this._register(new GenericConfirmStore('chat/autoconfirm-post', this._instantiationService));
 
 		this._register(this._contextKeyService.onDidChangeContext(e => {
 			if (e.affectsSome(this._toolContextKeys)) {
@@ -237,23 +231,6 @@ export class LanguageModelToolsService extends Disposable implements ILanguageMo
 		return undefined;
 	}
 
-	setToolAutoConfirmation(toolId: string, scope: 'workspace' | 'profile' | 'session' | 'never'): void {
-		this._preExecutionConfirmStore.setAutoConfirmation(toolId, scope);
-	}
-
-	getToolAutoConfirmation(toolId: string): 'workspace' | 'profile' | 'session' | 'never' {
-		return this._preExecutionConfirmStore.getAutoConfirmation(toolId);
-	}
-
-	resetToolAutoConfirmation(): void {
-		this._preExecutionConfirmStore.reset();
-		this._postExecutionConfirmStore.reset();
-	}
-
-	getToolPostExecutionAutoConfirmation(toolId: string): 'workspace' | 'profile' | 'session' | 'never' {
-		return this._postExecutionConfirmStore.getAutoConfirmation(toolId);
-	}
-
 	async invokeTool(dto: IToolInvocation, countTokens: CountTokensCallback, token: CancellationToken): Promise<IToolResult> {
 		this._logService.trace(`[LanguageModelToolsService#invokeTool] Invoking tool ${dto.toolId} with parameters ${JSON.stringify(dto.parameters)}`);
 
@@ -318,9 +295,9 @@ export class LanguageModelToolsService extends Disposable implements ILanguageMo
 				preparedInvocation = await this.prepareToolInvocation(tool, dto, token);
 				prepareTimeWatch.stop();
 
-				toolInvocation = new ChatToolInvocation(preparedInvocation, tool.data, dto.callId, dto.fromSubAgent);
+				toolInvocation = new ChatToolInvocation(preparedInvocation, tool.data, dto.callId, dto.fromSubAgent, dto.parameters);
 				trackedCall.invocation = toolInvocation;
-				const autoConfirmed = await this.shouldAutoConfirm(tool.data.id, tool.data.runsInWorkspace);
+				const autoConfirmed = await this.shouldAutoConfirm(tool.data.id, tool.data.runsInWorkspace, tool.data.source, dto.parameters);
 				if (autoConfirmed) {
 					IChatToolInvocation.confirmWith(toolInvocation, autoConfirmed);
 				}
@@ -345,9 +322,6 @@ export class LanguageModelToolsService extends Disposable implements ILanguageMo
 						};
 						return toolResult;
 					}
-					if (userConfirmed.type === ToolConfirmKind.LmServicePerTool) {
-						this._preExecutionConfirmStore.setAutoConfirmation(dto.toolId, userConfirmed.scope);
-					}
 
 					if (dto.toolSpecificData?.kind === 'input') {
 						dto.parameters = dto.toolSpecificData.rawInput;
@@ -358,14 +332,12 @@ export class LanguageModelToolsService extends Disposable implements ILanguageMo
 				prepareTimeWatch = StopWatch.create(true);
 				preparedInvocation = await this.prepareToolInvocation(tool, dto, token);
 				prepareTimeWatch.stop();
-				if (preparedInvocation?.confirmationMessages?.title && !(await this.shouldAutoConfirm(tool.data.id, tool.data.runsInWorkspace))) {
+				if (preparedInvocation?.confirmationMessages?.title && !(await this.shouldAutoConfirm(tool.data.id, tool.data.runsInWorkspace, tool.data.source, dto.parameters))) {
 					const result = await this._dialogService.confirm({ message: renderAsPlaintext(preparedInvocation.confirmationMessages.title), detail: renderAsPlaintext(preparedInvocation.confirmationMessages.message!) });
 					if (!result.confirmed) {
 						throw new CancellationError();
 					}
-				}
-
-				dto.toolSpecificData = preparedInvocation?.toolSpecificData;
+				} dto.toolSpecificData = preparedInvocation?.toolSpecificData;
 			}
 
 			if (token.isCancellationRequested) {
@@ -382,7 +354,7 @@ export class LanguageModelToolsService extends Disposable implements ILanguageMo
 			this.ensureToolDetails(dto, toolResult, tool.data);
 
 			if (toolInvocation?.didExecuteTool(toolResult).type === IChatToolInvocation.StateKind.WaitingForPostApproval) {
-				const autoConfirmedPost = await this.shouldAutoConfirmPostExecution(tool.data.id, tool.data.runsInWorkspace);
+				const autoConfirmedPost = await this.shouldAutoConfirmPostExecution(tool.data.id, tool.data.runsInWorkspace, tool.data.source, dto.parameters);
 				if (autoConfirmedPost) {
 					IChatToolInvocation.confirmWith(toolInvocation, autoConfirmedPost);
 				}
@@ -398,9 +370,6 @@ export class LanguageModelToolsService extends Disposable implements ILanguageMo
 							value: 'The tool executed but the user chose not to share the results'
 						}]
 					};
-				}
-				if (postConfirm.type === ToolConfirmKind.LmServicePerTool) {
-					this._postExecutionConfirmStore.setAutoConfirmation(dto.toolId, postConfirm.scope);
 				}
 			}
 
@@ -529,8 +498,8 @@ export class LanguageModelToolsService extends Disposable implements ILanguageMo
 		});
 	}
 
-	private async shouldAutoConfirm(toolId: string, runsInWorkspace: boolean | undefined): Promise<ConfirmedReason | undefined> {
-		const reason = this._preExecutionConfirmStore.checkAutoConfirmation(toolId);
+	private async shouldAutoConfirm(toolId: string, runsInWorkspace: boolean | undefined, source: ToolDataSource, parameters: unknown): Promise<ConfirmedReason | undefined> {
+		const reason = this._confirmationService.getPreConfirmAction({ toolId, source, parameters });
 		if (reason) {
 			return reason;
 		}
@@ -557,12 +526,12 @@ export class LanguageModelToolsService extends Disposable implements ILanguageMo
 		return undefined;
 	}
 
-	private async shouldAutoConfirmPostExecution(toolId: string, runsInWorkspace: boolean | undefined): Promise<ConfirmedReason | undefined> {
+	private async shouldAutoConfirmPostExecution(toolId: string, runsInWorkspace: boolean | undefined, source: ToolDataSource, parameters: unknown): Promise<ConfirmedReason | undefined> {
 		if (this._configurationService.getValue<boolean>(ChatConfiguration.GlobalAutoApprove) && await this._checkGlobalAutoApprove()) {
 			return { type: ToolConfirmKind.Setting, id: ChatConfiguration.GlobalAutoApprove };
 		}
 
-		return this._postExecutionConfirmStore.checkAutoConfirmation(toolId);
+		return this._confirmationService.getPostConfirmAction({ toolId, source, parameters });
 	}
 
 	private async _checkGlobalAutoApprove(): Promise<boolean> {
@@ -849,111 +818,3 @@ type LanguageModelToolInvokedClassification = {
 	owner: 'roblourens';
 	comment: 'Provides insight into the usage of language model tools.';
 };
-
-class GenericConfirmStore extends Disposable {
-	private _workspaceStore: Lazy<ToolConfirmStore>;
-	private _profileStore: Lazy<ToolConfirmStore>;
-	private _memoryStore = new Set<string>();
-
-	constructor(
-		private readonly _storageKey: string,
-		private readonly _instantiationService: IInstantiationService,
-	) {
-		super();
-		this._workspaceStore = new Lazy(() => this._register(this._instantiationService.createInstance(ToolConfirmStore, StorageScope.WORKSPACE, this._storageKey)));
-		this._profileStore = new Lazy(() => this._register(this._instantiationService.createInstance(ToolConfirmStore, StorageScope.PROFILE, this._storageKey)));
-	}
-
-	public setAutoConfirmation(toolId: string, scope: 'workspace' | 'profile' | 'session' | 'never'): void {
-		this._workspaceStore.value.setAutoConfirm(toolId, scope === 'workspace');
-		this._profileStore.value.setAutoConfirm(toolId, scope === 'profile');
-
-		if (scope === 'session') {
-			this._memoryStore.add(toolId);
-		} else {
-			this._memoryStore.delete(toolId);
-		}
-	}
-
-	public getAutoConfirmation(toolId: string): 'workspace' | 'profile' | 'session' | 'never' {
-		if (this._workspaceStore.value.getAutoConfirm(toolId)) {
-			return 'workspace';
-		}
-		if (this._profileStore.value.getAutoConfirm(toolId)) {
-			return 'profile';
-		}
-		if (this._memoryStore.has(toolId)) {
-			return 'session';
-		}
-		return 'never';
-	}
-
-	public reset(): void {
-		this._workspaceStore.value.reset();
-		this._profileStore.value.reset();
-		this._memoryStore.clear();
-	}
-
-	public checkAutoConfirmation(toolId: string): ConfirmedReason | undefined {
-		if (this._workspaceStore.value.getAutoConfirm(toolId)) {
-			return { type: ToolConfirmKind.LmServicePerTool, scope: 'workspace' };
-		}
-		if (this._profileStore.value.getAutoConfirm(toolId)) {
-			return { type: ToolConfirmKind.LmServicePerTool, scope: 'profile' };
-		}
-		if (this._memoryStore.has(toolId)) {
-			return { type: ToolConfirmKind.LmServicePerTool, scope: 'session' };
-		}
-		return undefined;
-	}
-}
-
-class ToolConfirmStore extends Disposable {
-	private _autoConfirmTools: LRUCache<string, boolean> = new LRUCache<string, boolean>(100);
-	private _didChange = false;
-
-	constructor(
-		private readonly _scope: StorageScope,
-		private readonly _storageKey: string,
-		@IStorageService private readonly storageService: IStorageService,
-	) {
-		super();
-
-		const stored = storageService.getObject<string[]>(this._storageKey, this._scope);
-		if (stored) {
-			for (const key of stored) {
-				this._autoConfirmTools.set(key, true);
-			}
-		}
-
-		this._register(storageService.onWillSaveState(() => {
-			if (this._didChange) {
-				this.storageService.store(this._storageKey, [...this._autoConfirmTools.keys()], this._scope, StorageTarget.MACHINE);
-				this._didChange = false;
-			}
-		}));
-	}
-
-	public reset() {
-		this._autoConfirmTools.clear();
-		this._didChange = true;
-	}
-
-	public getAutoConfirm(toolId: string): boolean {
-		if (this._autoConfirmTools.get(toolId)) {
-			this._didChange = true;
-			return true;
-		}
-
-		return false;
-	}
-
-	public setAutoConfirm(toolId: string, autoConfirm: boolean): void {
-		if (autoConfirm) {
-			this._autoConfirmTools.set(toolId, true);
-		} else {
-			this._autoConfirmTools.delete(toolId);
-		}
-		this._didChange = true;
-	}
-}

--- a/src/vs/workbench/contrib/chat/browser/languageModelToolsService.ts
+++ b/src/vs/workbench/contrib/chat/browser/languageModelToolsService.ts
@@ -337,7 +337,8 @@ export class LanguageModelToolsService extends Disposable implements ILanguageMo
 					if (!result.confirmed) {
 						throw new CancellationError();
 					}
-				} dto.toolSpecificData = preparedInvocation?.toolSpecificData;
+				}
+				dto.toolSpecificData = preparedInvocation?.toolSpecificData;
 			}
 
 			if (token.isCancellationRequested) {

--- a/src/vs/workbench/contrib/chat/common/chatProgressTypes/chatToolInvocation.ts
+++ b/src/vs/workbench/contrib/chat/common/chatProgressTypes/chatToolInvocation.ts
@@ -21,6 +21,7 @@ export class ChatToolInvocation implements IChatToolInvocation {
 	public readonly toolId: string;
 	public readonly source: ToolDataSource;
 	public readonly fromSubAgent: boolean | undefined;
+	public readonly parameters: unknown;
 
 	public readonly toolSpecificData?: IChatTerminalToolInvocationData | IChatToolInputInvocationData | IChatExtensionsContent | IChatTodoListContent;
 
@@ -32,7 +33,7 @@ export class ChatToolInvocation implements IChatToolInvocation {
 	}
 
 
-	constructor(preparedInvocation: IPreparedToolInvocation | undefined, toolData: IToolData, public readonly toolCallId: string, fromSubAgent: boolean | undefined) {
+	constructor(preparedInvocation: IPreparedToolInvocation | undefined, toolData: IToolData, public readonly toolCallId: string, fromSubAgent: boolean | undefined, parameters: unknown) {
 		const defaultMessage = localize('toolInvocationMessage', "Using {0}", `"${toolData.displayName}"`);
 		const invocationMessage = preparedInvocation?.invocationMessage ?? defaultMessage;
 		this.invocationMessage = invocationMessage;
@@ -44,6 +45,7 @@ export class ChatToolInvocation implements IChatToolInvocation {
 		this.toolId = toolData.id;
 		this.source = toolData.source;
 		this.fromSubAgent = fromSubAgent;
+		this.parameters = parameters;
 
 		if (!this.confirmationMessages?.title) {
 			this._state = observableValue(this, { type: IChatToolInvocation.StateKind.Executing, confirmed: { type: ToolConfirmKind.ConfirmationNotNeeded }, progress: this._progress });

--- a/src/vs/workbench/contrib/chat/common/chatService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService.ts
@@ -363,6 +363,7 @@ export interface IChatToolInvocation {
 	readonly source: ToolDataSource;
 	readonly toolId: string;
 	readonly toolCallId: string;
+	readonly parameters: unknown;
 	readonly fromSubAgent?: boolean;
 	readonly state: IObservable<IChatToolInvocation.State>;
 

--- a/src/vs/workbench/contrib/chat/common/languageModelToolsConfirmationService.ts
+++ b/src/vs/workbench/contrib/chat/common/languageModelToolsConfirmationService.ts
@@ -86,7 +86,7 @@ export interface ILanguageModelToolsConfirmationService extends ILanguageModelTo
 	 * Registers a contribution that provides more specific confirmation logic
 	 * for a tool, in addition to the default confirmation handling.
 	 */
-	registerConfirmationContribution(toolNAme: string, contribution: ILanguageModelToolConfirmationContribution): IDisposable;
+	registerConfirmationContribution(toolName: string, contribution: ILanguageModelToolConfirmationContribution): IDisposable;
 
 	/** Resets all tool and server confirmation preferences */
 	resetToolAutoConfirmation(): void;

--- a/src/vs/workbench/contrib/chat/common/languageModelToolsConfirmationService.ts
+++ b/src/vs/workbench/contrib/chat/common/languageModelToolsConfirmationService.ts
@@ -1,0 +1,95 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IDisposable } from '../../../../base/common/lifecycle.js';
+import { createDecorator } from '../../../../platform/instantiation/common/instantiation.js';
+import { IQuickInputButton, IQuickTreeItem } from '../../../../platform/quickinput/common/quickInput.js';
+import { ConfirmedReason } from './chatService.js';
+import { IToolData, ToolDataSource } from './languageModelToolsService.js';
+
+export interface ILanguageModelToolConfirmationActions {
+	/** Label for the action */
+	label: string;
+	/** Action detail (e.g. tooltip) */
+	detail?: string;
+	/** Show a separator before this action */
+	divider?: boolean;
+	/** Selects this action. Resolves true if the action should be confirmed after selection */
+	select(): Promise<boolean>;
+}
+
+export interface ILanguageModelToolConfirmationRef {
+	toolId: string;
+	source: ToolDataSource;
+	parameters: unknown;
+}
+
+export interface ILanguageModelToolConfirmationActionProducer {
+	getPreConfirmAction(ref: ILanguageModelToolConfirmationRef): ConfirmedReason | undefined;
+	getPostConfirmAction(ref: ILanguageModelToolConfirmationRef): ConfirmedReason | undefined;
+
+	/** Gets the selectable actions to take to memorize confirmation changes */
+	getPreConfirmActions(ref: ILanguageModelToolConfirmationRef): ILanguageModelToolConfirmationActions[];
+	getPostConfirmActions(ref: ILanguageModelToolConfirmationRef): ILanguageModelToolConfirmationActions[];
+}
+
+export interface ILanguageModelToolConfirmationContributionQuickTreeItem extends IQuickTreeItem {
+	onDidTriggerItemButton?(button: IQuickInputButton): void;
+	onDidChangeChecked?(checked: boolean): void;
+}
+
+/**
+ * Type that can be registered to provide more specific confirmation
+ * actions for a specific tool.
+ */
+export type ILanguageModelToolConfirmationContribution = Partial<ILanguageModelToolConfirmationActionProducer> & {
+	/**
+	 * Gets items to be shown in the `manageConfirmationPreferences` quick tree.
+	 * These are added under the tool's category.
+	 */
+	getManageActions?(): ILanguageModelToolConfirmationContributionQuickTreeItem[];
+
+	/**
+	 * Defaults to true. If false, the "Always Allow" options will not be shown
+	 * and _only_ your custom manage actions will be shown.
+	 */
+	canUseDefaultApprovals?: boolean;
+
+	/**
+	 * Reset all confirmation settings for this tool.
+	 */
+	reset?(): void;
+};
+
+/**
+ * Handles language model tool confirmation.
+ *
+ * - By default, all tools can have their confirmation preferences saved within
+ *   a session, workspace, or globally.
+ * - Tools with ToolDataSource from an extension or MCP can have that entire
+ *   source's preference saved within a session, workspace, or globally.
+ * - Contributable confirmations may also be registered for specific behaviors.
+ *
+ * Note: this interface MUST NOT depend in the ILanguageModelToolsService.
+ * The ILanguageModelToolsService depends on this service instead in order to
+ * call getPreConfirmAction/getPostConfirmAction.
+ */
+export interface ILanguageModelToolsConfirmationService extends ILanguageModelToolConfirmationActionProducer {
+	readonly _serviceBrand: undefined;
+
+	/** Opens an IQuickTree to let the user manage their preferences.  */
+	manageConfirmationPreferences(tools: Readonly<IToolData>[], options?: { defaultScope?: 'workspace' | 'profile' | 'session' }): void;
+
+	/**
+	 * Registers a contribution that provides more specific confirmation logic
+	 * for a tool, in addition to the default confirmation handling.
+	 */
+	registerConfirmationContribution(toolNAme: string, contribution: ILanguageModelToolConfirmationContribution): IDisposable;
+
+	/** Resets all tool and server confirmation preferences */
+	resetToolAutoConfirmation(): void;
+}
+
+export const ILanguageModelToolsConfirmationService = createDecorator<ILanguageModelToolsConfirmationService>('ILanguageModelToolsConfirmationService');

--- a/src/vs/workbench/contrib/chat/common/languageModelToolsService.ts
+++ b/src/vs/workbench/contrib/chat/common/languageModelToolsService.ts
@@ -45,6 +45,10 @@ export interface IToolData {
 	 */
 	runsInWorkspace?: boolean;
 	alwaysDisplayInputOutput?: boolean;
+	/** True if this tool might ask for pre-approval */
+	canRequestPreApproval?: boolean;
+	/** True if this tool might ask for post-approval */
+	canRequestPostApproval?: boolean;
 }
 
 export interface IToolProgressStep {
@@ -331,10 +335,6 @@ export interface ILanguageModelToolsService {
 	getTool(id: string): IToolData | undefined;
 	getToolByName(name: string, includeDisabled?: boolean): IToolData | undefined;
 	invokeTool(invocation: IToolInvocation, countTokens: CountTokensCallback, token: CancellationToken): Promise<IToolResult>;
-	setToolAutoConfirmation(toolId: string, scope: 'workspace' | 'profile' | 'session' | 'never'): void;
-	getToolAutoConfirmation(toolId: string): 'workspace' | 'profile' | 'session' | 'never';
-	resetToolAutoConfirmation(): void;
-	getToolPostExecutionAutoConfirmation(toolId: string): 'workspace' | 'profile' | 'session' | 'never';
 	cancelToolCallsForRequest(requestId: string): void;
 
 	readonly toolSets: IObservable<Iterable<ToolSet>>;

--- a/src/vs/workbench/contrib/chat/electron-browser/tools/fetchPageTool.ts
+++ b/src/vs/workbench/contrib/chat/electron-browser/tools/fetchPageTool.ts
@@ -23,6 +23,8 @@ export const FetchWebPageToolData: IToolData = {
 	canBeReferencedInPrompt: false,
 	modelDescription: localize('fetchWebPage.modelDescription', 'Fetches the main content from a web page. This tool is useful for summarizing or analyzing the content of a webpage.'),
 	source: ToolDataSource.Internal,
+	canRequestPostApproval: true,
+	canRequestPreApproval: true,
 	inputSchema: {
 		type: 'object',
 		properties: {

--- a/src/vs/workbench/contrib/chat/test/browser/languageModelToolsConfirmationService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/languageModelToolsConfirmationService.test.ts
@@ -1,0 +1,528 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { TestInstantiationService } from '../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
+import { IStorageService, InMemoryStorageService } from '../../../../../platform/storage/common/storage.js';
+import { LanguageModelToolsConfirmationService } from '../../browser/languageModelToolsConfirmationService.js';
+import { ToolConfirmKind } from '../../common/chatService.js';
+import { ILanguageModelToolConfirmationActions, ILanguageModelToolConfirmationContribution, ILanguageModelToolConfirmationRef } from '../../common/languageModelToolsConfirmationService.js';
+import { ToolDataSource } from '../../common/languageModelToolsService.js';
+
+suite('LanguageModelToolsConfirmationService', () => {
+	const store = ensureNoDisposablesAreLeakedInTestSuite();
+
+	let service: LanguageModelToolsConfirmationService;
+	let instantiationService: TestInstantiationService;
+
+	setup(() => {
+		instantiationService = store.add(new TestInstantiationService());
+		instantiationService.stub(IStorageService, store.add(new InMemoryStorageService()));
+
+		service = store.add(instantiationService.createInstance(LanguageModelToolsConfirmationService));
+	});
+
+	function createToolRef(toolId: string, source: ToolDataSource = ToolDataSource.Internal, parameters: unknown = {}): ILanguageModelToolConfirmationRef {
+		return { toolId, source, parameters };
+	}
+
+	function createMcpToolRef(toolId: string, definitionId: string, serverLabel: string, parameters: unknown = {}): ILanguageModelToolConfirmationRef {
+		return {
+			toolId,
+			source: {
+				type: 'mcp',
+				label: serverLabel,
+				serverLabel,
+				instructions: undefined,
+				collectionId: 'testCollection',
+				definitionId
+			},
+			parameters
+		};
+	}
+
+	test('getPreConfirmAction returns undefined by default', () => {
+		const ref = createToolRef('testTool');
+		const result = service.getPreConfirmAction(ref);
+		assert.strictEqual(result, undefined);
+	});
+
+	test('getPostConfirmAction returns undefined by default', () => {
+		const ref = createToolRef('testTool');
+		const result = service.getPostConfirmAction(ref);
+		assert.strictEqual(result, undefined);
+	});
+
+	test('getPreConfirmActions returns default tool-level actions', () => {
+		const ref = createToolRef('testTool');
+		const actions = service.getPreConfirmActions(ref);
+
+		assert.ok(actions.length >= 3);
+		assert.ok(actions.some(a => a.label.includes('Session')));
+		assert.ok(actions.some(a => a.label.includes('Workspace')));
+		assert.ok(actions.some(a => a.label.includes('Always Allow')));
+	});
+
+	test('getPostConfirmActions returns default tool-level actions', () => {
+		const ref = createToolRef('testTool');
+		const actions = service.getPostConfirmActions(ref);
+
+		assert.ok(actions.length >= 3);
+		assert.ok(actions.some(a => a.label.includes('Session')));
+		assert.ok(actions.some(a => a.label.includes('Workspace')));
+		assert.ok(actions.some(a => a.label.includes('Always Allow')));
+	});
+
+	test('getPreConfirmActions includes server-level actions for MCP tools', () => {
+		const ref = createMcpToolRef('mcpTool', 'serverId', 'Test Server');
+		const actions = service.getPreConfirmActions(ref);
+
+		assert.ok(actions.some(a => a.label.includes('Test Server') && a.label.includes('Session')));
+		assert.ok(actions.some(a => a.label.includes('Test Server') && a.label.includes('Workspace')));
+		assert.ok(actions.some(a => a.label.includes('Test Server') && a.label.includes('Always Allow')));
+	});
+
+	test('getPostConfirmActions includes server-level actions for MCP tools', () => {
+		const ref = createMcpToolRef('mcpTool', 'serverId', 'Test Server');
+		const actions = service.getPostConfirmActions(ref);
+
+		assert.ok(actions.some(a => a.label.includes('Test Server') && a.label.includes('Session')));
+		assert.ok(actions.some(a => a.label.includes('Test Server') && a.label.includes('Workspace')));
+		assert.ok(actions.some(a => a.label.includes('Test Server') && a.label.includes('Always Allow')));
+	});
+
+	test('pre-execution session confirmation works', async () => {
+		const ref = createToolRef('testTool');
+		const actions = service.getPreConfirmActions(ref);
+		const sessionAction = actions.find(a => a.label.includes('Session') && !a.label.includes('Server'));
+
+		assert.ok(sessionAction);
+		await sessionAction.select();
+
+		const result = service.getPreConfirmAction(ref);
+		assert.deepStrictEqual(result, { type: ToolConfirmKind.LmServicePerTool, scope: 'session' });
+	});
+
+	test('pre-execution workspace confirmation works', async () => {
+		const ref = createToolRef('testTool');
+		const actions = service.getPreConfirmActions(ref);
+		const workspaceAction = actions.find(a => a.label.includes('Workspace') && !a.label.includes('Server'));
+
+		assert.ok(workspaceAction);
+		await workspaceAction.select();
+
+		const result = service.getPreConfirmAction(ref);
+		assert.deepStrictEqual(result, { type: ToolConfirmKind.LmServicePerTool, scope: 'workspace' });
+	});
+
+	test('pre-execution profile confirmation works', async () => {
+		const ref = createToolRef('testTool');
+		const actions = service.getPreConfirmActions(ref);
+		const profileAction = actions.find(a => a.label.includes('Always Allow') && !a.label.includes('Server'));
+
+		assert.ok(profileAction);
+		await profileAction.select();
+
+		const result = service.getPreConfirmAction(ref);
+		assert.deepStrictEqual(result, { type: ToolConfirmKind.LmServicePerTool, scope: 'profile' });
+	});
+
+	test('post-execution session confirmation works', async () => {
+		const ref = createToolRef('testTool');
+		const actions = service.getPostConfirmActions(ref);
+		const sessionAction = actions.find(a => a.label.includes('Session') && !a.label.includes('Server'));
+
+		assert.ok(sessionAction);
+		await sessionAction.select();
+
+		const result = service.getPostConfirmAction(ref);
+		assert.deepStrictEqual(result, { type: ToolConfirmKind.LmServicePerTool, scope: 'session' });
+	});
+
+	test('post-execution workspace confirmation works', async () => {
+		const ref = createToolRef('testTool');
+		const actions = service.getPostConfirmActions(ref);
+		const workspaceAction = actions.find(a => a.label.includes('Workspace') && !a.label.includes('Server'));
+
+		assert.ok(workspaceAction);
+		await workspaceAction.select();
+
+		const result = service.getPostConfirmAction(ref);
+		assert.deepStrictEqual(result, { type: ToolConfirmKind.LmServicePerTool, scope: 'workspace' });
+	});
+
+	test('post-execution profile confirmation works', async () => {
+		const ref = createToolRef('testTool');
+		const actions = service.getPostConfirmActions(ref);
+		const profileAction = actions.find(a => a.label.includes('Always Allow') && !a.label.includes('Server'));
+
+		assert.ok(profileAction);
+		await profileAction.select();
+
+		const result = service.getPostConfirmAction(ref);
+		assert.deepStrictEqual(result, { type: ToolConfirmKind.LmServicePerTool, scope: 'profile' });
+	});
+
+	test('MCP server-level pre-execution session confirmation works', async () => {
+		const ref = createMcpToolRef('mcpTool', 'serverId', 'Test Server');
+		const actions = service.getPreConfirmActions(ref);
+		const serverAction = actions.find(a => a.label.includes('Test Server') && a.label.includes('Session'));
+
+		assert.ok(serverAction);
+		await serverAction.select();
+
+		const result = service.getPreConfirmAction(ref);
+		assert.deepStrictEqual(result, { type: ToolConfirmKind.LmServicePerTool, scope: 'session' });
+	});
+
+	test('MCP server-level pre-execution workspace confirmation works', async () => {
+		const ref = createMcpToolRef('mcpTool', 'serverId', 'Test Server');
+		const actions = service.getPreConfirmActions(ref);
+		const serverAction = actions.find(a => a.label.includes('Test Server') && a.label.includes('Workspace'));
+
+		assert.ok(serverAction);
+		await serverAction.select();
+
+		const result = service.getPreConfirmAction(ref);
+		assert.deepStrictEqual(result, { type: ToolConfirmKind.LmServicePerTool, scope: 'workspace' });
+	});
+
+	test('MCP server-level pre-execution profile confirmation works', async () => {
+		const ref = createMcpToolRef('mcpTool', 'serverId', 'Test Server');
+		const actions = service.getPreConfirmActions(ref);
+		const serverAction = actions.find(a => a.label.includes('Test Server') && a.label.includes('Always Allow'));
+
+		assert.ok(serverAction);
+		await serverAction.select();
+
+		const result = service.getPreConfirmAction(ref);
+		assert.deepStrictEqual(result, { type: ToolConfirmKind.LmServicePerTool, scope: 'profile' });
+	});
+
+	test('MCP server-level post-execution session confirmation works', async () => {
+		const ref = createMcpToolRef('mcpTool', 'serverId', 'Test Server');
+		const actions = service.getPostConfirmActions(ref);
+		const serverAction = actions.find(a => a.label.includes('Test Server') && a.label.includes('Session'));
+
+		assert.ok(serverAction);
+		await serverAction.select();
+
+		const result = service.getPostConfirmAction(ref);
+		assert.deepStrictEqual(result, { type: ToolConfirmKind.LmServicePerTool, scope: 'session' });
+	});
+
+	test('MCP server-level confirmation applies to all tools from that server', async () => {
+		const ref1 = createMcpToolRef('mcpTool1', 'serverId', 'Test Server');
+		const ref2 = createMcpToolRef('mcpTool2', 'serverId', 'Test Server');
+
+		const actions = service.getPreConfirmActions(ref1);
+		const serverAction = actions.find(a => a.label.includes('Test Server') && a.label.includes('Session'));
+
+		assert.ok(serverAction);
+		await serverAction.select();
+
+		const result1 = service.getPreConfirmAction(ref1);
+		const result2 = service.getPreConfirmAction(ref2);
+
+		assert.deepStrictEqual(result1, { type: ToolConfirmKind.LmServicePerTool, scope: 'session' });
+		assert.deepStrictEqual(result2, { type: ToolConfirmKind.LmServicePerTool, scope: 'session' });
+	});
+
+	test('tool-level confirmation takes precedence over server-level confirmation', async () => {
+		const ref = createMcpToolRef('mcpTool', 'serverId', 'Test Server');
+
+		// Set server-level confirmation
+		const serverActions = service.getPreConfirmActions(ref);
+		const serverAction = serverActions.find(a => a.label.includes('Test Server') && a.label.includes('Session'));
+		assert.ok(serverAction);
+		await serverAction.select();
+
+		// Set tool-level confirmation to a different scope
+		const toolActions = service.getPreConfirmActions(ref);
+		const toolAction = toolActions.find(a => !a.label.includes('Test Server') && a.label.includes('Workspace'));
+		assert.ok(toolAction);
+		await toolAction.select();
+
+		// Tool-level should take precedence
+		const result = service.getPreConfirmAction(ref);
+		assert.deepStrictEqual(result, { type: ToolConfirmKind.LmServicePerTool, scope: 'workspace' });
+	});
+
+	test('registerConfirmationContribution allows custom pre-confirm actions', () => {
+		const contribution: ILanguageModelToolConfirmationContribution = {
+			getPreConfirmAction: (ref) => {
+				return { type: ToolConfirmKind.UserAction };
+			}
+		};
+
+		store.add(service.registerConfirmationContribution('customTool', contribution));
+
+		const ref = createToolRef('customTool');
+		const result = service.getPreConfirmAction(ref);
+
+		assert.ok(result);
+		assert.strictEqual(result.type, ToolConfirmKind.UserAction);
+	});
+
+	test('registerConfirmationContribution allows custom post-confirm actions', () => {
+		const contribution: ILanguageModelToolConfirmationContribution = {
+			getPostConfirmAction: (ref) => {
+				return { type: ToolConfirmKind.UserAction };
+			}
+		};
+
+		store.add(service.registerConfirmationContribution('customTool', contribution));
+
+		const ref = createToolRef('customTool');
+		const result = service.getPostConfirmAction(ref);
+
+		assert.ok(result);
+		assert.strictEqual(result.type, ToolConfirmKind.UserAction);
+	});
+
+	test('registerConfirmationContribution allows custom pre-confirm action list', () => {
+		const customActions: ILanguageModelToolConfirmationActions[] = [
+			{
+				label: 'Custom Action 1',
+				select: async () => true
+			},
+			{
+				label: 'Custom Action 2',
+				select: async () => true
+			}
+		];
+
+		const contribution: ILanguageModelToolConfirmationContribution = {
+			getPreConfirmActions: (ref) => customActions
+		};
+
+		store.add(service.registerConfirmationContribution('customTool', contribution));
+
+		const ref = createToolRef('customTool');
+		const actions = service.getPreConfirmActions(ref);
+
+		// Should include both custom actions and default actions
+		assert.ok(actions.some(a => a.label === 'Custom Action 1'));
+		assert.ok(actions.some(a => a.label === 'Custom Action 2'));
+		assert.ok(actions.some(a => a.label.includes('Session')));
+	});
+
+	test('registerConfirmationContribution with canUseDefaultApprovals=false only shows custom actions', () => {
+		const customActions: ILanguageModelToolConfirmationActions[] = [
+			{
+				label: 'Custom Action Only',
+				select: async () => true
+			}
+		];
+
+		const contribution: ILanguageModelToolConfirmationContribution = {
+			canUseDefaultApprovals: false,
+			getPreConfirmActions: (ref) => customActions
+		};
+
+		store.add(service.registerConfirmationContribution('customTool', contribution));
+
+		const ref = createToolRef('customTool');
+		const actions = service.getPreConfirmActions(ref);
+
+		assert.strictEqual(actions.length, 1);
+		assert.strictEqual(actions[0].label, 'Custom Action Only');
+	});
+
+	test('contribution getPreConfirmAction takes precedence over default stores', () => {
+		const contribution: ILanguageModelToolConfirmationContribution = {
+			getPreConfirmAction: (ref) => {
+				return { type: ToolConfirmKind.UserAction };
+			}
+		};
+
+		store.add(service.registerConfirmationContribution('customTool', contribution));
+
+		// Contribution should take precedence even without setting default
+		const ref = createToolRef('customTool');
+		const result = service.getPreConfirmAction(ref);
+		assert.ok(result);
+		assert.strictEqual(result.type, ToolConfirmKind.UserAction);
+	});
+
+	test('contribution with canUseDefaultApprovals=false prevents default store checks', () => {
+		const contribution: ILanguageModelToolConfirmationContribution = {
+			canUseDefaultApprovals: false,
+			getPreConfirmAction: () => undefined
+		};
+
+		store.add(service.registerConfirmationContribution('customTool', contribution));
+
+		const ref = createToolRef('customTool');
+		const actions = service.getPreConfirmActions(ref);
+
+		// Should have no actions since canUseDefaultApprovals is false
+		assert.strictEqual(actions.length, 0);
+	});
+
+	test('resetToolAutoConfirmation clears all confirmations', async () => {
+		const ref1 = createToolRef('tool1');
+		const ref2 = createMcpToolRef('mcpTool', 'serverId', 'Test Server');
+
+		// Set some confirmations
+		const actions1 = service.getPreConfirmActions(ref1);
+		const sessionAction1 = actions1.find(a => a.label.includes('Session') && !a.label.includes('Server'));
+		assert.ok(sessionAction1);
+		await sessionAction1.select();
+
+		const actions2 = service.getPreConfirmActions(ref2);
+		const serverAction = actions2.find(a => a.label.includes('Test Server') && a.label.includes('Session'));
+		assert.ok(serverAction);
+		await serverAction.select();
+
+		// Verify they're set
+		assert.ok(service.getPreConfirmAction(ref1));
+		assert.ok(service.getPreConfirmAction(ref2));
+
+		// Reset
+		service.resetToolAutoConfirmation();
+
+		// Verify they're cleared
+		assert.strictEqual(service.getPreConfirmAction(ref1), undefined);
+		assert.strictEqual(service.getPreConfirmAction(ref2), undefined);
+	});
+
+	test('resetToolAutoConfirmation calls contribution reset', () => {
+		let resetCalled = false;
+		const contribution: ILanguageModelToolConfirmationContribution = {
+			reset: () => {
+				resetCalled = true;
+			}
+		};
+
+		store.add(service.registerConfirmationContribution('customTool', contribution));
+
+		service.resetToolAutoConfirmation();
+
+		assert.strictEqual(resetCalled, true);
+	});
+
+	test('disposing contribution registration removes it', () => {
+		const contribution: ILanguageModelToolConfirmationContribution = {
+			getPreConfirmAction: (ref) => {
+				return { type: ToolConfirmKind.UserAction };
+			}
+		};
+
+		const disposable = service.registerConfirmationContribution('customTool', contribution);
+
+		const ref = createToolRef('customTool');
+		let result = service.getPreConfirmAction(ref);
+		assert.ok(result);
+		assert.strictEqual(result.type, ToolConfirmKind.UserAction);
+
+		disposable.dispose();
+
+		result = service.getPreConfirmAction(ref);
+		assert.strictEqual(result, undefined);
+	});
+
+	test('different tools have independent confirmations', async () => {
+		const ref1 = createToolRef('tool1');
+		const ref2 = createToolRef('tool2');
+
+		// Set session for tool1
+		const actions1 = service.getPreConfirmActions(ref1);
+		const sessionAction = actions1.find(a => a.label.includes('Session') && !a.label.includes('Server'));
+		assert.ok(sessionAction);
+		await sessionAction.select();
+
+		// Set workspace for tool2
+		const actions2 = service.getPreConfirmActions(ref2);
+		const workspaceAction = actions2.find(a => a.label.includes('Workspace') && !a.label.includes('Server'));
+		assert.ok(workspaceAction);
+		await workspaceAction.select();
+
+		// Verify they're independent
+		const result1 = service.getPreConfirmAction(ref1);
+		const result2 = service.getPreConfirmAction(ref2);
+
+		assert.deepStrictEqual(result1, { type: ToolConfirmKind.LmServicePerTool, scope: 'session' });
+		assert.deepStrictEqual(result2, { type: ToolConfirmKind.LmServicePerTool, scope: 'workspace' });
+	});
+
+	test('pre and post execution confirmations are independent', async () => {
+		const ref = createToolRef('testTool');
+
+		// Set pre-execution to session
+		const preActions = service.getPreConfirmActions(ref);
+		const preSessionAction = preActions.find(a => a.label.includes('Session') && !a.label.includes('Server'));
+		assert.ok(preSessionAction);
+		await preSessionAction.select();
+
+		// Set post-execution to workspace
+		const postActions = service.getPostConfirmActions(ref);
+		const postWorkspaceAction = postActions.find(a => a.label.includes('Workspace') && !a.label.includes('Server'));
+		assert.ok(postWorkspaceAction);
+		await postWorkspaceAction.select();
+
+		// Verify they're independent
+		const preResult = service.getPreConfirmAction(ref);
+		const postResult = service.getPostConfirmAction(ref);
+
+		assert.deepStrictEqual(preResult, { type: ToolConfirmKind.LmServicePerTool, scope: 'session' });
+		assert.deepStrictEqual(postResult, { type: ToolConfirmKind.LmServicePerTool, scope: 'workspace' });
+	});
+
+	test('different MCP servers have independent confirmations', async () => {
+		const ref1 = createMcpToolRef('tool1', 'server1', 'Server 1');
+		const ref2 = createMcpToolRef('tool2', 'server2', 'Server 2');
+
+		// Set server1 to session
+		const actions1 = service.getPreConfirmActions(ref1);
+		const serverAction1 = actions1.find(a => a.label.includes('Server 1') && a.label.includes('Session'));
+		assert.ok(serverAction1);
+		await serverAction1.select();
+
+		// Set server2 to workspace
+		const actions2 = service.getPreConfirmActions(ref2);
+		const serverAction2 = actions2.find(a => a.label.includes('Server 2') && a.label.includes('Workspace'));
+		assert.ok(serverAction2);
+		await serverAction2.select();
+
+		// Verify they're independent
+		const result1 = service.getPreConfirmAction(ref1);
+		const result2 = service.getPreConfirmAction(ref2);
+
+		assert.deepStrictEqual(result1, { type: ToolConfirmKind.LmServicePerTool, scope: 'session' });
+		assert.deepStrictEqual(result2, { type: ToolConfirmKind.LmServicePerTool, scope: 'workspace' });
+	});
+
+	test('actions return true when select is called', async () => {
+		const ref = createToolRef('testTool');
+		const actions = service.getPreConfirmActions(ref);
+
+		for (const action of actions) {
+			const result = await action.select();
+			assert.strictEqual(result, true);
+		}
+	});
+
+	test('session confirmations are stored in memory only', async () => {
+		const ref = createToolRef('testTool');
+		const actions = service.getPreConfirmActions(ref);
+		const sessionAction = actions.find(a => a.label.includes('Session') && !a.label.includes('Server'));
+
+		assert.ok(sessionAction);
+		await sessionAction.select();
+
+		// Verify it's set
+		const result = service.getPreConfirmAction(ref);
+		assert.deepStrictEqual(result, { type: ToolConfirmKind.LmServicePerTool, scope: 'session' });
+
+		// Create new service instance (simulating restart)
+		const newService = store.add(instantiationService.createInstance(LanguageModelToolsConfirmationService));
+
+		// Session confirmation should not persist
+		const newResult = newService.getPreConfirmAction(ref);
+		assert.strictEqual(newResult, undefined);
+	});
+});

--- a/src/vs/workbench/contrib/chat/test/browser/languageModelToolsService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/languageModelToolsService.test.ts
@@ -28,6 +28,8 @@ import { isToolResultInputOutputDetails, IToolData, IToolImpl, IToolInvocation, 
 import { MockChatService } from '../common/mockChatService.js';
 import { ChatToolInvocation } from '../../common/chatProgressTypes/chatToolInvocation.js';
 import { LocalChatSessionUri } from '../../common/chatUri.js';
+import { ILanguageModelToolsConfirmationService } from '../../common/languageModelToolsConfirmationService.js';
+import { MockLanguageModelToolsConfirmationService } from '../common/mockLanguageModelToolsConfirmationService.js';
 
 // --- Test helpers to reduce repetition and improve readability ---
 
@@ -114,6 +116,7 @@ suite('LanguageModelToolsService', () => {
 		contextKeyService = instaService.get(IContextKeyService);
 		chatService = new MockChatService();
 		instaService.stub(IChatService, chatService);
+		instaService.stub(ILanguageModelToolsConfirmationService, new MockLanguageModelToolsConfirmationService());
 		service = store.add(instaService.createInstance(LanguageModelToolsService));
 	});
 
@@ -780,6 +783,7 @@ suite('LanguageModelToolsService', () => {
 		instaService.stub(IChatService, chatService);
 		instaService.stub(IAccessibilityService, testAccessibilityService);
 		instaService.stub(IAccessibilitySignalService, testAccessibilitySignalService as unknown as IAccessibilitySignalService);
+		instaService.stub(ILanguageModelToolsConfirmationService, new MockLanguageModelToolsConfirmationService());
 		const testService = store.add(instaService.createInstance(LanguageModelToolsService));
 
 		const toolData: IToolData = {
@@ -841,6 +845,7 @@ suite('LanguageModelToolsService', () => {
 		instaService.stub(IChatService, chatService);
 		instaService.stub(IAccessibilityService, testAccessibilityService);
 		instaService.stub(IAccessibilitySignalService, testAccessibilitySignalService as unknown as IAccessibilitySignalService);
+		instaService.stub(ILanguageModelToolsConfirmationService, new MockLanguageModelToolsConfirmationService());
 		const testService = store.add(instaService.createInstance(LanguageModelToolsService));
 
 		const toolData: IToolData = {
@@ -879,6 +884,7 @@ suite('LanguageModelToolsService', () => {
 			configurationService: () => testConfigService
 		}, store);
 		instaService.stub(IChatService, chatService);
+		instaService.stub(ILanguageModelToolsConfirmationService, new MockLanguageModelToolsConfirmationService());
 		const testService = store.add(instaService.createInstance(LanguageModelToolsService));
 
 		// Register a tool that should be auto-approved
@@ -912,6 +918,7 @@ suite('LanguageModelToolsService', () => {
 			configurationService: () => testConfigService
 		}, store);
 		instaService.stub(IChatService, chatService);
+		instaService.stub(ILanguageModelToolsConfirmationService, new MockLanguageModelToolsConfirmationService());
 		const testService = store.add(instaService.createInstance(LanguageModelToolsService));
 
 		// Tool explicitly approved
@@ -1013,6 +1020,7 @@ suite('LanguageModelToolsService', () => {
 		}, store);
 		instaService.stub(IChatService, chatService);
 		instaService.stub(ITelemetryService, testTelemetryService);
+		instaService.stub(ILanguageModelToolsConfirmationService, new MockLanguageModelToolsConfirmationService());
 		const testService = store.add(instaService.createInstance(LanguageModelToolsService));
 
 		// Test successful invocation telemetry
@@ -1102,6 +1110,7 @@ suite('LanguageModelToolsService', () => {
 		instaService1.stub(IChatService, chatService);
 		instaService1.stub(IAccessibilityService, testAccessibilityService1);
 		instaService1.stub(IAccessibilitySignalService, testAccessibilitySignalService as unknown as IAccessibilitySignalService);
+		instaService1.stub(ILanguageModelToolsConfirmationService, new MockLanguageModelToolsConfirmationService());
 		const testService1 = store.add(instaService1.createInstance(LanguageModelToolsService));
 
 		const tool1 = registerToolForTest(testService1, store, 'soundOnlyTool', {
@@ -1142,6 +1151,7 @@ suite('LanguageModelToolsService', () => {
 		instaService2.stub(IChatService, chatService);
 		instaService2.stub(IAccessibilityService, testAccessibilityService2);
 		instaService2.stub(IAccessibilitySignalService, testAccessibilitySignalService as unknown as IAccessibilitySignalService);
+		instaService2.stub(ILanguageModelToolsConfirmationService, new MockLanguageModelToolsConfirmationService());
 		const testService2 = store.add(instaService2.createInstance(LanguageModelToolsService));
 
 		const tool2 = registerToolForTest(testService2, store, 'autoScreenReaderTool', {
@@ -1183,6 +1193,7 @@ suite('LanguageModelToolsService', () => {
 		instaService3.stub(IChatService, chatService);
 		instaService3.stub(IAccessibilityService, testAccessibilityService3);
 		instaService3.stub(IAccessibilitySignalService, testAccessibilitySignalService as unknown as IAccessibilitySignalService);
+		instaService3.stub(ILanguageModelToolsConfirmationService, new MockLanguageModelToolsConfirmationService());
 		const testService3 = store.add(instaService3.createInstance(LanguageModelToolsService));
 
 		const tool3 = registerToolForTest(testService3, store, 'offTool', {
@@ -1543,6 +1554,7 @@ suite('LanguageModelToolsService', () => {
 			configurationService: () => testConfigService
 		}, store);
 		instaService.stub(IChatService, chatService);
+		instaService.stub(ILanguageModelToolsConfirmationService, new MockLanguageModelToolsConfirmationService());
 		const testService = store.add(instaService.createInstance(LanguageModelToolsService));
 
 		const workspaceTool = registerToolForTest(testService, store, 'workspaceTool', {

--- a/src/vs/workbench/contrib/chat/test/common/mockLanguageModelToolsConfirmationService.ts
+++ b/src/vs/workbench/contrib/chat/test/common/mockLanguageModelToolsConfirmationService.ts
@@ -1,0 +1,34 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IDisposable } from '../../../../../base/common/lifecycle.js';
+import { ConfirmedReason } from '../../common/chatService.js';
+import { ILanguageModelToolConfirmationActions, ILanguageModelToolConfirmationContribution, ILanguageModelToolConfirmationRef, ILanguageModelToolsConfirmationService } from '../../common/languageModelToolsConfirmationService.js';
+import { IToolData } from '../../common/languageModelToolsService.js';
+
+export class MockLanguageModelToolsConfirmationService implements ILanguageModelToolsConfirmationService {
+	manageConfirmationPreferences(tools: Readonly<IToolData>[], options?: { defaultScope?: 'workspace' | 'profile' | 'session' }): void {
+		throw new Error('Method not implemented.');
+	}
+	registerConfirmationContribution(toolNAme: string, contribution: ILanguageModelToolConfirmationContribution): IDisposable {
+		throw new Error('Method not implemented.');
+	}
+	resetToolAutoConfirmation(): void {
+
+	}
+	getPreConfirmAction(ref: ILanguageModelToolConfirmationRef): ConfirmedReason | undefined {
+		return undefined;
+	}
+	getPostConfirmAction(ref: ILanguageModelToolConfirmationRef): ConfirmedReason | undefined {
+		return undefined;
+	}
+	getPreConfirmActions(ref: ILanguageModelToolConfirmationRef): ILanguageModelToolConfirmationActions[] {
+		return [];
+	}
+	getPostConfirmActions(ref: ILanguageModelToolConfirmationRef): ILanguageModelToolConfirmationActions[] {
+		return [];
+	}
+	declare readonly _serviceBrand: undefined;
+}

--- a/src/vs/workbench/contrib/chat/test/common/mockLanguageModelToolsConfirmationService.ts
+++ b/src/vs/workbench/contrib/chat/test/common/mockLanguageModelToolsConfirmationService.ts
@@ -12,7 +12,7 @@ export class MockLanguageModelToolsConfirmationService implements ILanguageModel
 	manageConfirmationPreferences(tools: Readonly<IToolData>[], options?: { defaultScope?: 'workspace' | 'profile' | 'session' }): void {
 		throw new Error('Method not implemented.');
 	}
-	registerConfirmationContribution(toolNAme: string, contribution: ILanguageModelToolConfirmationContribution): IDisposable {
+	registerConfirmationContribution(toolName: string, contribution: ILanguageModelToolConfirmationContribution): IDisposable {
 		throw new Error('Method not implemented.');
 	}
 	resetToolAutoConfirmation(): void {

--- a/src/vs/workbench/contrib/mcp/common/mcpLanguageModelToolContribution.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpLanguageModelToolContribution.ts
@@ -115,6 +115,8 @@ export class McpLanguageModelToolContribution extends Disposable implements IWor
 					inputSchema: tool.definition.inputSchema,
 					canBeReferencedInPrompt: true,
 					alwaysDisplayInputOutput: true,
+					canRequestPreApproval: !tool.definition.annotations?.readOnlyHint,
+					canRequestPostApproval: !!tool.definition.annotations?.openWorldHint,
 					runsInWorkspace: collection?.scope === StorageScope.WORKSPACE || !!collection?.remoteAuthority,
 					tags: ['mcp'],
 				};


### PR DESCRIPTION
- Refactors tool confirmation logic from LanguageModelToolsService into
  a dedicated ILanguageModelToolsConfirmationService. This cleans up some
  increasingly large state in the LanguageModelToolsService
- Adds an MCP/extension-wide approval mechanism. This is useful for cases
  like playwright which are correctly marked as openWorldHint but it's
  really annoying to use practically because every result needs approval.
- Adds a contribution model so that other tools can register their custom
  logic, either in addition to or replacing the base confirmation logic.

Closes #264370

cc @Tyriar @TylerLeonhardt