### PR TITLE
Fix wrong session opened in new window

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/actions/chatMoveActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatMoveActions.ts
@@ -128,13 +128,16 @@ async function executeMoveToAction(accessor: ServicesAccessor, moveTo: MoveToNew
 		await editorService.openEditor({ resource: ChatEditorInput.getNewEditorUri(), options: { pinned: true, auxiliary: { compact: true, bounds: { width: 640, height: 640 } } } }, moveTo === MoveToNewLocation.Window ? AUX_WINDOW_GROUP : ACTIVE_GROUP);
 		return;
 	}
+
+	// Save off the state before clearing
 	const viewState = widget.getViewState();
+	const resourceToOpen = widget.viewModel.sessionResource;
 
 	widget.clear();
 	await widget.waitForReady();
 
 	const options: IChatEditorOptions = { pinned: true, viewState, auxiliary: { compact: true, bounds: { width: 640, height: 640 } } };
-	await editorService.openEditor({ resource: widget.viewModel.sessionResource, options }, moveTo === MoveToNewLocation.Window ? AUX_WINDOW_GROUP : ACTIVE_GROUP);
+	await editorService.openEditor({ resource: resourceToOpen, options }, moveTo === MoveToNewLocation.Window ? AUX_WINDOW_GROUP : ACTIVE_GROUP);
 }
 
 async function moveToSidebar(accessor: ServicesAccessor): Promise<void> {


### PR DESCRIPTION
Fixes #274552

We need to grab the session resource before clearing, not after 
