### PR TITLE
Fix inconsistent tool progress opacity

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/media/chatConfirmationWidget.css
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/media/chatConfirmationWidget.css
@@ -58,6 +58,10 @@
 		margin-top: -12px;
 		margin-bottom: 12px;
 	}
+
+	.rendered-markdown p {
+		opacity: 0.85;
+	}
 }
 
 .chat-confirmation-widget .chat-confirmation-widget-title.expandable {

--- a/src/vs/workbench/contrib/chat/browser/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/media/chat.css
@@ -450,7 +450,6 @@
 .interactive-item-container .value > .chat-tool-invocation-part {
 	.rendered-markdown p {
 		margin: 0 0 6px 0;
-		opacity: 0.85;
 	}
 
 	.disclaimer {


### PR DESCRIPTION
I think this matches the original intent of this rule cc @connor4312. 
Rules targetting 'rendered-markdown' are confusing because it's looking at some text, not all text, but it's not clear which text in particular. I originated the pattern though.
Fix microsoft/vscode-copilot#18275

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
