### PR TITLE
Fix: hit target, padding and appearance #233555

### DIFF
--- a/src/vs/editor/contrib/hover/browser/hover.css
+++ b/src/vs/editor/contrib/hover/browser/hover.css
@@ -11,6 +11,7 @@
 	border: 1px solid var(--vscode-editorHoverWidget-border);
 	border-radius: 3px;
 	box-sizing: content-box;
+	padding-bottom: 2px;
 }
 
 .monaco-editor .monaco-resizable-hover > .monaco-hover {
@@ -46,7 +47,6 @@
 .monaco-editor .monaco-hover .hover-row .verbosity-actions {
 	border-right: 1px solid var(--vscode-editorHoverWidget-border);
 	width: 22px;
-	overflow-y: clip;
 }
 
 .monaco-editor .monaco-hover .hover-row .verbosity-actions-inner {
@@ -56,11 +56,17 @@
 	padding-right: 5px;
 	justify-content: flex-end;
 	position: relative;
+	gap: 4px;
 }
 
 .monaco-editor .monaco-hover .hover-row .verbosity-actions-inner .codicon {
 	cursor: pointer;
 	font-size: 11px;
+	position: relative;
+	display: inline-flex;
+	padding: 2px;
+	margin: -2px;
+	margin-bottom: -4px;
 }
 
 .monaco-editor .monaco-hover .hover-row .verbosity-actions-inner .codicon.enabled {


### PR DESCRIPTION
Closes issue #233555 

Description of changes:
- Added padding-bottom: 2px to .monaco-resizable-hover to increase space at the bottom of the hover container, because minus sign was overflowing. This is why overflow-y was also removed.
- Adjusted .codicon with padding: 2px, margin: -2px, and margin-bottom: -4px to enlarge the clickable area without affecting visual size. 
- Increased gap to 4px in .verbosity-actions-inner because the click area of the plus and minus signs began to overlap. 

Hopefully these changes are helpful or on the mark. Can change anything or make improvements if necessary.
