### PR TITLE
fix extension unification remote setup

### DIFF
--- a/src/vs/workbench/services/inlineCompletions/common/inlineCompletionsUnification.ts
+++ b/src/vs/workbench/services/inlineCompletions/common/inlineCompletionsUnification.ts
@@ -148,12 +148,13 @@ export class InlineCompletionsUnificationImpl extends Disposable implements IInl
 			return false;
 		}
 
-		const completionExtensionInstalled = installedExtensions.find(ext => ext.identifier.id.toLowerCase() === this._completionsExtensionId);
-		if (!completionExtensionInstalled) {
+		// Extension might be installed on remote and local
+		const completionExtensionInstalled = installedExtensions.filter(ext => ext.identifier.id.toLowerCase() === this._completionsExtensionId);
+		if (completionExtensionInstalled.length === 0) {
 			return false;
 		}
 
-		const completionsExtensionDisabledByUnification = this._extensionEnablementService.getEnablementState(completionExtensionInstalled) === EnablementState.DisabledByUnification;
+		const completionsExtensionDisabledByUnification = completionExtensionInstalled.some(ext => this._extensionEnablementService.getEnablementState(ext) === EnablementState.DisabledByUnification);
 
 		return !!chatExtension && completionsExtensionDisabledByUnification;
 	}


### PR DESCRIPTION
```Copilot Generated Description:``` Update the logic to check for the completion extension installation on both remote and local environments. Adjust the condition to determine if the extension is disabled by unification.

