### PR TITLE
rm margin from chat output element

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/media/chatTerminalToolProgressPart.css
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/media/chatTerminalToolProgressPart.css
@@ -93,6 +93,10 @@
 	white-space: pre;
 	font-size: 12px;
 }
+
+.chat-terminal-output pre {
+	margin: 0;
+}
 .chat-terminal-output-info {
 	color: var(--vscode-descriptionForeground);
 	font-size: var(--vscode-chat-font-size-body-xs);


### PR DESCRIPTION
fix #274308

<img width="279" height="103" alt="Screenshot 2025-11-03 at 2 30 49 PM" src="https://github.com/user-attachments/assets/e0f7765d-39b5-497c-a269-f63dfd7753ba" />
