### PR TITLE
Hide some internals of `ChatEditorUri`

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatEditorInput.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditorInput.ts
@@ -60,11 +60,10 @@ export class ChatEditorInput extends EditorInput implements IEditorCloseHandler 
 	private model: IChatModel | undefined;
 
 	static getNewEditorUri(): URI {
-		const handle = Math.floor(Math.random() * 1e9);
-		return ChatEditorUri.forHandle(handle);
+		return ChatEditorUri.getNewEditorUri();
 	}
 
-	static getNextCount(inputName: string): number {
+	private static getNextCount(inputName: string): number {
 		let count = 0;
 		while (ChatEditorInput.countsInUseMap.get(inputName)?.has(count)) {
 			count++;
@@ -352,11 +351,12 @@ export class ChatEditorModel extends Disposable {
 }
 
 
-export namespace ChatEditorUri {
+namespace ChatEditorUri {
 
-	export const scheme = Schemas.vscodeChatEditor;
+	const scheme = Schemas.vscodeChatEditor;
 
-	export function forHandle(handle: number): URI {
+	export function getNewEditorUri(): URI {
+		const handle = Math.floor(Math.random() * 1e9);
 		return URI.from({ scheme, path: `chat-${handle}` });
 	}
 


### PR DESCRIPTION
We don't need to export this namespace anymore
