### PR TITLE
remote: configurable 'reconnection grace time'

### DIFF
--- a/cli/src/commands/args.rs
+++ b/cli/src/commands/args.rs
@@ -686,6 +686,10 @@ pub struct BaseServerArgs {
 	/// Set the root path for extensions.
 	#[clap(long)]
 	pub extensions_dir: Option<String>,
+
+	/// Reconnection grace time in seconds. Defaults to 10800 (3 hours).
+	#[clap(long)]
+	pub reconnection_grace_time: Option<u32>,
 }
 
 impl BaseServerArgs {
@@ -699,6 +703,10 @@ impl BaseServerArgs {
 
 		if let Some(d) = &self.extensions_dir {
 			csa.extensions_dir = Some(d.clone());
+		}
+
+		if let Some(t) = self.reconnection_grace_time {
+			csa.reconnection_grace_time = Some(t);
 		}
 	}
 }

--- a/cli/src/tunnels/code_server.rs
+++ b/cli/src/tunnels/code_server.rs
@@ -74,6 +74,8 @@ pub struct CodeServerArgs {
 	pub connection_token: Option<String>,
 	pub connection_token_file: Option<String>,
 	pub without_connection_token: bool,
+	// reconnection
+	pub reconnection_grace_time: Option<u32>,
 }
 
 impl CodeServerArgs {
@@ -119,6 +121,9 @@ impl CodeServerArgs {
 		}
 		if let Some(i) = self.log {
 			args.push(format!("--log={i}"));
+		}
+		if let Some(t) = self.reconnection_grace_time {
+			args.push(format!("--reconnection-grace-time={t}"));
 		}
 
 		for extension in &self.install_extensions {

--- a/src/vs/platform/remote/common/remoteAgentConnection.ts
+++ b/src/vs/platform/remote/common/remoteAgentConnection.ts
@@ -14,7 +14,7 @@ import * as performance from '../../../base/common/performance.js';
 import { StopWatch } from '../../../base/common/stopwatch.js';
 import { generateUuid } from '../../../base/common/uuid.js';
 import { IIPCLogger } from '../../../base/parts/ipc/common/ipc.js';
-import { Client, ISocket, PersistentProtocol, SocketCloseEventType } from '../../../base/parts/ipc/common/ipc.net.js';
+import { Client, ISocket, PersistentProtocol, ProtocolConstants, SocketCloseEventType } from '../../../base/parts/ipc/common/ipc.net.js';
 import { ILogService } from '../../log/common/log.js';
 import { RemoteAgentConnectionContext } from './remoteAgentEnvironment.js';
 import { RemoteAuthorityResolverError, RemoteConnection } from './remoteAuthorityResolver.js';
@@ -552,6 +552,13 @@ export abstract class PersistentConnection extends Disposable {
 	private static _permanentFailureAttempt: number = 0;
 	private static _permanentFailureHandled: boolean = false;
 	private static _instances: PersistentConnection[] = [];
+	private static _defaultReconnectionGraceTime: number = ProtocolConstants.ReconnectionGraceTime;
+
+	public static updateDefaultGraceTime(graceTime: number): void {
+		const sanitizedGrace = sanitizeGraceTime(graceTime, ProtocolConstants.ReconnectionGraceTime);
+		this._defaultReconnectionGraceTime = sanitizedGrace;
+		this._instances.forEach(instance => instance._applyGraceTimes(sanitizedGrace));
+	}
 
 	private readonly _onDidStateChange = this._register(new Emitter<PersistentConnectionEvent>());
 	public readonly onDidStateChange = this._onDidStateChange.event;
@@ -563,6 +570,7 @@ export abstract class PersistentConnection extends Disposable {
 
 	private _isReconnecting: boolean = false;
 	private _isDisposed: boolean = false;
+	private _reconnectionGraceTime: number = ProtocolConstants.ReconnectionGraceTime;
 
 	constructor(
 		private readonly _connectionType: ConnectionType,
@@ -572,6 +580,7 @@ export abstract class PersistentConnection extends Disposable {
 		private readonly _reconnectionFailureIsFatal: boolean
 	) {
 		super();
+		this._applyGraceTimes(PersistentConnection._defaultReconnectionGraceTime);
 
 		this._onDidStateChange.fire(new ConnectionGainEvent(this.reconnectionToken, 0, 0));
 
@@ -611,6 +620,10 @@ export abstract class PersistentConnection extends Disposable {
 		}
 	}
 
+	private _applyGraceTimes(graceTime: number): void {
+		this._reconnectionGraceTime = graceTime;
+	}
+
 	public override dispose(): void {
 		super.dispose();
 		this._isDisposed = true;
@@ -638,6 +651,13 @@ export abstract class PersistentConnection extends Disposable {
 		this._options.logService.info(`${logPrefix} starting reconnecting loop. You can get more information with the trace log level.`);
 		this._onDidStateChange.fire(new ConnectionLostEvent(this.reconnectionToken, this.protocol.getMillisSinceLastIncomingData()));
 		const TIMES = [0, 5, 5, 10, 10, 10, 10, 10, 30];
+		const graceTime = this._reconnectionGraceTime;
+		if (graceTime <= 0) {
+			this._options.logService.error(`${logPrefix} reconnection grace time is set to 0ms, will not attempt to reconnect.`);
+			this._onReconnectionPermanentFailure(this.protocol.getMillisSinceLastIncomingData(), 0, false);
+			return;
+		}
+		const loopStartTime = Date.now();
 		let attempt = -1;
 		do {
 			attempt++;
@@ -675,9 +695,9 @@ export abstract class PersistentConnection extends Disposable {
 					this._onReconnectionPermanentFailure(this.protocol.getMillisSinceLastIncomingData(), attempt + 1, false);
 					break;
 				}
-				if (attempt > 360) {
-					// ReconnectionGraceTime is 3hrs, with 30s between attempts that yields a maximum of 360 attempts
-					this._options.logService.error(`${logPrefix} An error occurred while reconnecting, but it will be treated as a permanent error because the reconnection grace time has expired! Will give up now! Error:`);
+				if (Date.now() - loopStartTime >= graceTime) {
+					const graceSeconds = Math.round(graceTime / 1000);
+					this._options.logService.error(`${logPrefix} An error occurred while reconnecting, but it will be treated as a permanent error because the reconnection grace time (${graceSeconds}s) has expired! Will give up now! Error:`);
 					this._options.logService.error(err);
 					this._onReconnectionPermanentFailure(this.protocol.getMillisSinceLastIncomingData(), attempt + 1, false);
 					break;
@@ -786,6 +806,16 @@ function getErrorFromMessage(msg: any): Error | null {
 		return error;
 	}
 	return null;
+}
+
+function sanitizeGraceTime(candidate: number, fallback: number): number {
+	if (typeof candidate !== 'number' || !isFinite(candidate) || candidate < 0) {
+		return fallback;
+	}
+	if (candidate > Number.MAX_SAFE_INTEGER) {
+		return Number.MAX_SAFE_INTEGER;
+	}
+	return Math.floor(candidate);
 }
 
 function stringRightPad(str: string, len: number): string {

--- a/src/vs/platform/remote/common/remoteAgentConnection.ts
+++ b/src/vs/platform/remote/common/remoteAgentConnection.ts
@@ -573,7 +573,7 @@ export abstract class PersistentConnection extends Disposable {
 		private readonly _reconnectionFailureIsFatal: boolean
 	) {
 		super();
-		this._reconnectionGraceTime = ProtocolConstants.ReconnectionGraceTime;
+
 
 		this._onDidStateChange.fire(new ConnectionGainEvent(this.reconnectionToken, 0, 0));
 

--- a/src/vs/platform/remote/common/remoteAgentConnection.ts
+++ b/src/vs/platform/remote/common/remoteAgentConnection.ts
@@ -556,6 +556,7 @@ export abstract class PersistentConnection extends Disposable {
 
 	public static updateDefaultGraceTime(graceTime: number): void {
 		const sanitizedGrace = sanitizeGraceTime(graceTime, ProtocolConstants.ReconnectionGraceTime);
+		console.log(`[reconnection-grace-time] Updating default grace time: ${graceTime}ms -> ${sanitizedGrace}ms (${Math.floor(sanitizedGrace / 1000)}s), updating ${this._instances.length} existing connection(s)`);
 		this._defaultReconnectionGraceTime = sanitizedGrace;
 		this._instances.forEach(instance => instance._applyGraceTimes(sanitizedGrace));
 	}
@@ -621,6 +622,8 @@ export abstract class PersistentConnection extends Disposable {
 	}
 
 	private _applyGraceTimes(graceTime: number): void {
+		const logPrefix = commonLogPrefix(this._connectionType, this.reconnectionToken, false);
+		this._options.logService.trace(`${logPrefix} Applying reconnection grace time: ${graceTime}ms (${Math.floor(graceTime / 1000)}s)`);
 		this._reconnectionGraceTime = graceTime;
 	}
 
@@ -652,6 +655,7 @@ export abstract class PersistentConnection extends Disposable {
 		this._onDidStateChange.fire(new ConnectionLostEvent(this.reconnectionToken, this.protocol.getMillisSinceLastIncomingData()));
 		const TIMES = [0, 5, 5, 10, 10, 10, 10, 10, 30];
 		const graceTime = this._reconnectionGraceTime;
+		this._options.logService.info(`${logPrefix} starting reconnection with grace time: ${graceTime}ms (${Math.floor(graceTime / 1000)}s)`);
 		if (graceTime <= 0) {
 			this._options.logService.error(`${logPrefix} reconnection grace time is set to 0ms, will not attempt to reconnect.`);
 			this._onReconnectionPermanentFailure(this.protocol.getMillisSinceLastIncomingData(), 0, false);

--- a/src/vs/platform/remote/common/remoteAgentEnvironment.ts
+++ b/src/vs/platform/remote/common/remoteAgentEnvironment.ts
@@ -29,6 +29,7 @@ export interface IRemoteAgentEnvironment {
 		home: URI;
 	};
 	isUnsupportedGlibc: boolean;
+	reconnectionGraceTime?: number;
 }
 
 export interface RemoteAgentConnectionContext {

--- a/src/vs/server/node/extensionHostConnection.ts
+++ b/src/vs/server/node/extensionHostConnection.ts
@@ -63,6 +63,8 @@ export async function buildUserEnvironment(startParamsEnv: { [key: string]: stri
 		env.BROWSER = join(binFolder, 'helpers', isWindows ? 'browser.cmd' : 'browser.sh'); // a command that opens a browser on the local machine
 	}
 
+	env.VSCODE_RECONNECTION_GRACE_TIME = String(environmentService.reconnectionGraceTime);
+
 	removeNulls(env);
 	return env;
 }

--- a/src/vs/server/node/extensionHostConnection.ts
+++ b/src/vs/server/node/extensionHostConnection.ts
@@ -64,6 +64,7 @@ export async function buildUserEnvironment(startParamsEnv: { [key: string]: stri
 	}
 
 	env.VSCODE_RECONNECTION_GRACE_TIME = String(environmentService.reconnectionGraceTime);
+	logService.trace(`[reconnection-grace-time] Setting VSCODE_RECONNECTION_GRACE_TIME env var for extension host: ${environmentService.reconnectionGraceTime}ms (${Math.floor(environmentService.reconnectionGraceTime / 1000)}s)`);
 
 	removeNulls(env);
 	return env;

--- a/src/vs/server/node/remoteAgentEnvironmentImpl.ts
+++ b/src/vs/server/node/remoteAgentEnvironmentImpl.ts
@@ -125,7 +125,8 @@ export class RemoteAgentEnvironmentChannel implements IServerChannel {
 				home: this._userDataProfilesService.profilesHome,
 				all: [...this._userDataProfilesService.profiles].map(profile => ({ ...profile }))
 			},
-			isUnsupportedGlibc
+			isUnsupportedGlibc,
+			reconnectionGraceTime: this._environmentService.reconnectionGraceTime
 		};
 	}
 

--- a/src/vs/server/node/remoteAgentEnvironmentImpl.ts
+++ b/src/vs/server/node/remoteAgentEnvironmentImpl.ts
@@ -21,6 +21,7 @@ import { ServerConnectionToken, ServerConnectionTokenType } from './serverConnec
 import { IExtensionHostStatusService } from './extensionHostStatusService.js';
 import { IUserDataProfilesService } from '../../platform/userDataProfile/common/userDataProfile.js';
 import { joinPath } from '../../base/common/resources.js';
+import { ILogService } from '../../platform/log/common/log.js';
 
 export class RemoteAgentEnvironmentChannel implements IServerChannel {
 
@@ -31,6 +32,7 @@ export class RemoteAgentEnvironmentChannel implements IServerChannel {
 		private readonly _environmentService: IServerEnvironmentService,
 		private readonly _userDataProfilesService: IUserDataProfilesService,
 		private readonly _extensionHostStatusService: IExtensionHostStatusService,
+		private readonly _logService: ILogService,
 	) {
 	}
 
@@ -105,6 +107,7 @@ export class RemoteAgentEnvironmentChannel implements IServerChannel {
 			const minorVersion = glibcVersion ? parseInt(glibcVersion.split('.')[1]) : 28;
 			isUnsupportedGlibc = (minorVersion <= 27) || !!process.env['VSCODE_SERVER_CUSTOM_GLIBC_LINKER'];
 		}
+		this._logService.trace(`[reconnection-grace-time] Server sending grace time to client: ${this._environmentService.reconnectionGraceTime}ms (${Math.floor(this._environmentService.reconnectionGraceTime / 1000)}s)`);
 		return {
 			pid: process.pid,
 			connectionToken: (this._connectionToken.type !== ServerConnectionTokenType.None ? this._connectionToken.value : ''),

--- a/src/vs/server/node/remoteExtensionHostAgentServer.ts
+++ b/src/vs/server/node/remoteExtensionHostAgentServer.ts
@@ -64,6 +64,7 @@ class RemoteExtensionHostAgentServer extends Disposable implements IServerAPI {
 	private readonly _allReconnectionTokens: Set<string>;
 	private readonly _webClientServer: WebClientServer | null;
 	private readonly _webEndpointOriginChecker: WebEndpointOriginChecker;
+	private readonly _reconnectionGraceTime: number;
 
 	private readonly _serverBasePath: string | undefined;
 	private readonly _serverProductPath: string;
@@ -99,6 +100,7 @@ class RemoteExtensionHostAgentServer extends Disposable implements IServerAPI {
 				: null
 		);
 		this._logService.info(`Extension host agent started.`);
+		this._reconnectionGraceTime = this._environmentService.reconnectionGraceTime;
 
 		this._waitThenShutdown(true);
 	}
@@ -419,7 +421,7 @@ class RemoteExtensionHostAgentServer extends Disposable implements IServerAPI {
 				}
 
 				protocol.sendControl(VSBuffer.fromString(JSON.stringify({ type: 'ok' })));
-				const con = new ManagementConnection(this._logService, reconnectionToken, remoteAddress, protocol);
+				const con = new ManagementConnection(this._logService, reconnectionToken, remoteAddress, protocol, this._reconnectionGraceTime);
 				this._socketServer.acceptConnection(con.protocol, con.onClose);
 				this._managementConnections[reconnectionToken] = con;
 				this._allReconnectionTokens.add(reconnectionToken);

--- a/src/vs/server/node/remoteExtensionManagement.ts
+++ b/src/vs/server/node/remoteExtensionManagement.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { PersistentProtocol, ProtocolConstants, ISocket } from '../../base/parts/ipc/common/ipc.net.js';
+import { PersistentProtocol, ISocket, ProtocolConstants } from '../../base/parts/ipc/common/ipc.net.js';
 import { ILogService } from '../../platform/log/common/log.js';
 import { Emitter, Event } from '../../base/common/event.js';
 import { VSBuffer } from '../../base/common/buffer.js';
@@ -50,10 +50,12 @@ export class ManagementConnection {
 		private readonly _logService: ILogService,
 		private readonly _reconnectionToken: string,
 		remoteAddress: string,
-		protocol: PersistentProtocol
+		protocol: PersistentProtocol,
+		reconnectionGraceTime: number
 	) {
-		this._reconnectionGraceTime = ProtocolConstants.ReconnectionGraceTime;
-		this._reconnectionShortGraceTime = ProtocolConstants.ReconnectionShortGraceTime;
+		this._reconnectionGraceTime = reconnectionGraceTime;
+		const defaultShortGrace = ProtocolConstants.ReconnectionShortGraceTime;
+		this._reconnectionShortGraceTime = reconnectionGraceTime > 0 ? Math.min(defaultShortGrace, reconnectionGraceTime) : 0;
 		this._remoteAddress = remoteAddress;
 
 		this.protocol = protocol;

--- a/src/vs/server/node/serverEnvironmentService.ts
+++ b/src/vs/server/node/serverEnvironmentService.ts
@@ -250,15 +250,19 @@ export class ServerEnvironmentService extends NativeEnvironmentService implement
 
 function parseGraceTime(rawValue: string | undefined, fallback: number): number {
 	if (typeof rawValue !== 'string' || rawValue.trim().length === 0) {
+		console.log(`[reconnection-grace-time] No CLI argument provided, using default: ${fallback}ms (${Math.floor(fallback / 1000)}s)`);
 		return fallback;
 	}
 	const parsedSeconds = Number(rawValue);
 	if (!isFinite(parsedSeconds) || parsedSeconds < 0) {
+		console.log(`[reconnection-grace-time] Invalid value '${rawValue}', using default: ${fallback}ms (${Math.floor(fallback / 1000)}s)`);
 		return fallback;
 	}
 	const millis = Math.floor(parsedSeconds * 1000);
 	if (!isFinite(millis) || millis > Number.MAX_SAFE_INTEGER) {
+		console.log(`[reconnection-grace-time] Value too large '${rawValue}', using default: ${fallback}ms (${Math.floor(fallback / 1000)}s)`);
 		return fallback;
 	}
+	console.log(`[reconnection-grace-time] Parsed CLI argument: ${parsedSeconds}s -> ${millis}ms`);
 	return millis;
 }

--- a/src/vs/server/node/serverServices.ts
+++ b/src/vs/server/node/serverServices.ts
@@ -216,8 +216,8 @@ export async function setupServerServices(connectionToken: ServerConnectionToken
 	const ptyHostStarter = instantiationService.createInstance(
 		NodePtyHostStarter,
 		{
-			graceTime: ProtocolConstants.ReconnectionGraceTime,
-			shortGraceTime: ProtocolConstants.ReconnectionShortGraceTime,
+			graceTime: environmentService.reconnectionGraceTime,
+			shortGraceTime: environmentService.reconnectionGraceTime > 0 ? Math.min(ProtocolConstants.ReconnectionShortGraceTime, environmentService.reconnectionGraceTime) : 0,
 			scrollback: configurationService.getValue<number>(TerminalSettingId.PersistentSessionScrollback) ?? 100
 		}
 	);

--- a/src/vs/server/node/serverServices.ts
+++ b/src/vs/server/node/serverServices.ts
@@ -235,7 +235,7 @@ export async function setupServerServices(connectionToken: ServerConnectionToken
 		const extensionsScannerService = accessor.get(IExtensionsScannerService);
 		const extensionGalleryService = accessor.get(IExtensionGalleryService);
 		const languagePackService = accessor.get(ILanguagePackService);
-		const remoteExtensionEnvironmentChannel = new RemoteAgentEnvironmentChannel(connectionToken, environmentService, userDataProfilesService, extensionHostStatusService);
+		const remoteExtensionEnvironmentChannel = new RemoteAgentEnvironmentChannel(connectionToken, environmentService, userDataProfilesService, extensionHostStatusService, logService);
 		socketServer.registerChannel('remoteextensionsenvironment', remoteExtensionEnvironmentChannel);
 
 		const telemetryChannel = new ServerTelemetryChannel(accessor.get(IServerTelemetryService), oneDsAppender);

--- a/src/vs/workbench/api/node/extensionHostProcess.ts
+++ b/src/vs/workbench/api/node/extensionHostProcess.ts
@@ -159,6 +159,19 @@ let onTerminate = function (reason: string) {
 	nativeExit();
 };
 
+function readReconnectionValue(envKey: string, fallback: number): number {
+	const raw = process.env[envKey];
+	if (typeof raw !== 'string' || raw.trim().length === 0) {
+		return fallback;
+	}
+	const parsed = Number(raw);
+	if (!isFinite(parsed) || parsed < 0) {
+		return fallback;
+	}
+	const millis = Math.floor(parsed);
+	return millis > Number.MAX_SAFE_INTEGER ? Number.MAX_SAFE_INTEGER : millis;
+}
+
 function _createExtHostProtocol(): Promise<IMessagePassingProtocol> {
 	const extHostConnection = readExtHostConnection(process.env);
 
@@ -194,8 +207,8 @@ function _createExtHostProtocol(): Promise<IMessagePassingProtocol> {
 				onTerminate('VSCODE_EXTHOST_IPC_SOCKET timeout');
 			}, 60000);
 
-			const reconnectionGraceTime = ProtocolConstants.ReconnectionGraceTime;
-			const reconnectionShortGraceTime = ProtocolConstants.ReconnectionShortGraceTime;
+			const reconnectionGraceTime = readReconnectionValue('VSCODE_RECONNECTION_GRACE_TIME', ProtocolConstants.ReconnectionGraceTime);
+			const reconnectionShortGraceTime = reconnectionGraceTime > 0 ? Math.min(ProtocolConstants.ReconnectionShortGraceTime, reconnectionGraceTime) : 0;
 			const disconnectRunner1 = new ProcessTimeRunOnceScheduler(() => onTerminate('renderer disconnected for too long (1)'), reconnectionGraceTime);
 			const disconnectRunner2 = new ProcessTimeRunOnceScheduler(() => onTerminate('renderer disconnected for too long (2)'), reconnectionShortGraceTime);
 

--- a/src/vs/workbench/api/node/extensionHostProcess.ts
+++ b/src/vs/workbench/api/node/extensionHostProcess.ts
@@ -162,14 +162,18 @@ let onTerminate = function (reason: string) {
 function readReconnectionValue(envKey: string, fallback: number): number {
 	const raw = process.env[envKey];
 	if (typeof raw !== 'string' || raw.trim().length === 0) {
+		console.log(`[reconnection-grace-time] Extension host: env var ${envKey} not set, using default: ${fallback}ms (${Math.floor(fallback / 1000)}s)`);
 		return fallback;
 	}
 	const parsed = Number(raw);
 	if (!isFinite(parsed) || parsed < 0) {
+		console.log(`[reconnection-grace-time] Extension host: env var ${envKey} invalid value '${raw}', using default: ${fallback}ms (${Math.floor(fallback / 1000)}s)`);
 		return fallback;
 	}
 	const millis = Math.floor(parsed);
-	return millis > Number.MAX_SAFE_INTEGER ? Number.MAX_SAFE_INTEGER : millis;
+	const result = millis > Number.MAX_SAFE_INTEGER ? Number.MAX_SAFE_INTEGER : millis;
+	console.log(`[reconnection-grace-time] Extension host: read ${envKey}=${raw}ms (${Math.floor(result / 1000)}s)`);
+	return result;
 }
 
 function _createExtHostProtocol(): Promise<IMessagePassingProtocol> {

--- a/src/vs/workbench/services/remote/common/abstractRemoteAgentService.ts
+++ b/src/vs/workbench/services/remote/common/abstractRemoteAgentService.ts
@@ -7,7 +7,7 @@ import { Disposable } from '../../../../base/common/lifecycle.js';
 import { IChannel, IServerChannel, getDelayedChannel, IPCLogger } from '../../../../base/parts/ipc/common/ipc.js';
 import { Client } from '../../../../base/parts/ipc/common/ipc.net.js';
 import { IWorkbenchEnvironmentService } from '../../environment/common/environmentService.js';
-import { connectRemoteAgentManagement, IConnectionOptions, ManagementPersistentConnection, PersistentConnectionEvent } from '../../../../platform/remote/common/remoteAgentConnection.js';
+import { connectRemoteAgentManagement, IConnectionOptions, ManagementPersistentConnection, PersistentConnection, PersistentConnectionEvent } from '../../../../platform/remote/common/remoteAgentConnection.js';
 import { IExtensionHostExitInfo, IRemoteAgentConnection, IRemoteAgentService } from './remoteAgentService.js';
 import { IRemoteAuthorityResolverService } from '../../../../platform/remote/common/remoteAuthorityResolver.js';
 import { RemoteAgentConnectionContext, IRemoteAgentEnvironment } from '../../../../platform/remote/common/remoteAgentEnvironment.js';
@@ -60,6 +60,9 @@ export abstract class AbstractRemoteAgentService extends Disposable implements I
 				async (channel, connection) => {
 					const env = await RemoteExtensionEnvironmentChannelClient.getEnvironmentData(channel, connection.remoteAuthority, this.userDataProfileService.currentProfile.isDefault ? undefined : this.userDataProfileService.currentProfile.id);
 					this._remoteAuthorityResolverService._setAuthorityConnectionToken(connection.remoteAuthority, env.connectionToken);
+					if (typeof env.reconnectionGraceTime === 'number') {
+						PersistentConnection.updateDefaultGraceTime(env.reconnectionGraceTime);
+					}
 					return env;
 				},
 				null

--- a/src/vs/workbench/services/remote/common/abstractRemoteAgentService.ts
+++ b/src/vs/workbench/services/remote/common/abstractRemoteAgentService.ts
@@ -61,7 +61,10 @@ export abstract class AbstractRemoteAgentService extends Disposable implements I
 					const env = await RemoteExtensionEnvironmentChannelClient.getEnvironmentData(channel, connection.remoteAuthority, this.userDataProfileService.currentProfile.isDefault ? undefined : this.userDataProfileService.currentProfile.id);
 					this._remoteAuthorityResolverService._setAuthorityConnectionToken(connection.remoteAuthority, env.connectionToken);
 					if (typeof env.reconnectionGraceTime === 'number') {
+						console.log(`[reconnection-grace-time] Client received grace time from server: ${env.reconnectionGraceTime}ms (${Math.floor(env.reconnectionGraceTime / 1000)}s)`);
 						PersistentConnection.updateDefaultGraceTime(env.reconnectionGraceTime);
+					} else {
+						console.log(`[reconnection-grace-time] Server did not provide grace time, using default`);
 					}
 					return env;
 				},

--- a/src/vs/workbench/services/remote/common/remoteAgentEnvironmentChannel.ts
+++ b/src/vs/workbench/services/remote/common/remoteAgentEnvironmentChannel.ts
@@ -13,6 +13,7 @@ import { ITelemetryData, TelemetryLevel } from '../../../../platform/telemetry/c
 import { IExtensionHostExitInfo } from './remoteAgentService.js';
 import { revive } from '../../../../base/common/marshalling.js';
 import { IUserDataProfile } from '../../../../platform/userDataProfile/common/userDataProfile.js';
+import { ProtocolConstants } from '../../../../base/parts/ipc/common/ipc.net.js';
 
 export interface IGetEnvironmentDataArguments {
 	remoteAuthority: string;
@@ -45,6 +46,7 @@ export interface IRemoteAgentEnvironmentDTO {
 		home: UriComponents;
 	};
 	isUnsupportedGlibc: boolean;
+	reconnectionGraceTime?: number;
 }
 
 export class RemoteExtensionEnvironmentChannelClient {
@@ -56,6 +58,9 @@ export class RemoteExtensionEnvironmentChannelClient {
 		};
 
 		const data = await channel.call<IRemoteAgentEnvironmentDTO>('getEnvironmentData', args);
+		const reconnectionGraceTime = (typeof data.reconnectionGraceTime === 'number' && data.reconnectionGraceTime >= 0)
+			? data.reconnectionGraceTime
+			: ProtocolConstants.ReconnectionGraceTime;
 
 		return {
 			pid: data.pid,
@@ -74,7 +79,8 @@ export class RemoteExtensionEnvironmentChannelClient {
 			marks: data.marks,
 			useHostProxy: data.useHostProxy,
 			profiles: revive(data.profiles),
-			isUnsupportedGlibc: data.isUnsupportedGlibc
+			isUnsupportedGlibc: data.isUnsupportedGlibc,
+			reconnectionGraceTime
 		};
 	}
 

--- a/src/vs/workbench/services/remote/common/remoteAgentService.ts
+++ b/src/vs/workbench/services/remote/common/remoteAgentService.ts
@@ -65,6 +65,7 @@ export interface IRemoteAgentConnection {
 	withChannel<T extends IChannel, R>(channelName: string, callback: (channel: T) => Promise<R>): Promise<R>;
 	registerChannel<T extends IServerChannel<RemoteAgentConnectionContext>>(channelName: string, channel: T): void;
 	getInitialConnectionTimeMs(): Promise<number>;
+	updateGraceTime(graceTime: number): void;
 }
 
 export interface IRemoteConnectionLatencyMeasurement {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Allow the reconnection grace time to be configured in the VS Code server process from its hardcoded value of 3 hours.  CLI and server support a flag that is optionally passed from a remote extension (eg: SSH).
