### PR TITLE
fix inappropriate height of terminal chat output widget

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/media/chatTerminalToolProgressPart.css
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/media/chatTerminalToolProgressPart.css
@@ -86,7 +86,6 @@
 .chat-terminal-output-body {
 	padding: 4px 6px;
 	max-width: 100%;
-	height: 100%;
 }
 .chat-terminal-output-content {
 	display: flex;


### PR DESCRIPTION
fix #275051

This looks bad, thus fixing ASAP

<img width="499" height="557" alt="Screenshot 2025-11-04 at 5 24 00 AM" src="https://github.com/user-attachments/assets/7c193c17-8e4e-43a4-826b-9d8d0ae531ce" />

