### PR TITLE
fire event so height of chat list row is correct when terminal chat output is expanded

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart.ts
@@ -62,6 +62,7 @@ export class ChatTerminalToolProgressPart extends BaseChatToolInvocationSubPart 
 	private _outputScrollbar: DomScrollableElement | undefined;
 	private _outputContent: HTMLElement | undefined;
 	private _outputResizeObserver: ResizeObserver | undefined;
+	private _renderedOutputHeight: number | undefined;
 
 	private readonly _showOutputAction = this._register(new MutableDisposable<ToggleChatTerminalOutputAction>());
 	private _showOutputActionAdded = false;
@@ -313,6 +314,8 @@ export class ChatTerminalToolProgressPart extends BaseChatToolInvocationSubPart 
 		if (!expanded) {
 			this._layoutOutput();
 			this._showOutputAction.value?.syncPresentation(false);
+			this._renderedOutputHeight = undefined;
+			this._onDidChangeHeight.fire();
 			return true;
 		}
 
@@ -374,6 +377,7 @@ export class ChatTerminalToolProgressPart extends BaseChatToolInvocationSubPart 
 			this._outputContainer.appendChild(scrollableDomNode);
 			this._ensureOutputResizeObserver();
 			this._outputContent = undefined;
+			this._renderedOutputHeight = undefined;
 		} else {
 			this._ensureOutputResizeObserver();
 		}
@@ -404,6 +408,10 @@ export class ChatTerminalToolProgressPart extends BaseChatToolInvocationSubPart 
 		const viewportHeight = Math.min(this._outputBody.scrollHeight, MAX_TERMINAL_OUTPUT_PREVIEW_HEIGHT);
 		scrollableDomNode.style.height = `${viewportHeight}px`;
 		this._outputScrollbar.scanDomNode();
+		if (this._renderedOutputHeight !== viewportHeight) {
+			this._renderedOutputHeight = viewportHeight;
+			this._onDidChangeHeight.fire();
+		}
 	}
 
 	private _ensureOutputResizeObserver(): void {


### PR DESCRIPTION
fixes #274215

The output would get trunchated for any but the final response, like this:

<img width="544" height="565" alt="Screenshot 2025-11-04 at 4 45 08 PM" src="https://github.com/user-attachments/assets/e19bf311-f68a-4f72-a099-e320ad955d0e" />


We now fire an event when the height changes so the chat list row height gets updated on expand/collapse

https://github.com/user-attachments/assets/72856ccc-7f16-429f-8b5a-9a9c7e9a9b19

