### PR TITLE
api: clarify wording for registerMcpServerDefinitionProvider to reflect autostart

### DIFF
--- a/src/vscode-dts/vscode.d.ts
+++ b/src/vscode-dts/vscode.d.ts
@@ -20977,9 +20977,11 @@ declare module 'vscode' {
 		 * 	}
 		 * ```
 		 *
-		 * When a new McpServerDefinitionProvider is available, the editor will present a 'refresh'
-		 * action to the user to discover new servers. To enable this flow, extensions should
-		 * call `registerMcpServerDefinitionProvider` during activation.
+		 * When a new McpServerDefinitionProvider is available, the editor will, by default,
+		 * automatically invoke it to discover new servers and tools when a chat message is
+		 * submitted. To enable this flow, extensions should call
+		 * `registerMcpServerDefinitionProvider` during activation.
+		 *
 		 * @param id The ID of the provider, which is unique to the extension.
 		 * @param provider The provider to register
 		 * @returns A disposable that unregisters the provider when disposed.


### PR DESCRIPTION
Remove wording for the old refresh button and clarify autostart interaction, closes https://github.com/microsoft/vscode/issues/272995

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
