### PR TITLE
Revert "Git - adopt new QuickInputButton location (#275071)"

### DIFF
--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -2973,11 +2973,13 @@ export class CommandCenter {
 		inputBox.placeholder = l10n.t('Branch name');
 		inputBox.prompt = l10n.t('Please provide a new branch name');
 
-		inputBox.buttons = branchRandomNameEnabled ? [{
-			iconPath: new ThemeIcon('refresh'),
-			tooltip: l10n.t('Regenerate Branch Name'),
-			location: QuickInputButtonLocation.Input
-		}] : [];
+		inputBox.buttons = branchRandomNameEnabled ? [
+			{
+				iconPath: new ThemeIcon('refresh'),
+				tooltip: l10n.t('Regenerate Branch Name'),
+				location: QuickInputButtonLocation.Inline
+			}
+		] : [];
 
 		inputBox.value = initialValue ?? await getBranchName();
 		inputBox.valueSelection = getValueSelection(inputBox.value);


### PR DESCRIPTION
This reverts commit e092054c98f425d9a8e55e22dd0f49eb206c7de3.

Unfortunetely new API only supports toggles, not regular buttons so using it as a button will not provide the right appearance. There is additional work to enable regular buttons with `Inline` location.

This is how it would look like right now (that pressed state is sticky, since it's a toggle):
<img width="686" height="95" alt="image" src="https://github.com/user-attachments/assets/42472ca8-b074-44ad-b989-5bebd98895fd" />

