### PR TITLE
fix thinking in cli agent

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chat.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.ts
@@ -144,6 +144,7 @@ export interface IChatListItemRendererOptions {
 	readonly renderDetectedCommandsWithRequest?: boolean;
 	readonly restorable?: boolean;
 	readonly editable?: boolean;
+	readonly fromCodingAgent?: boolean;
 	readonly renderTextEditsAsSummary?: (uri: URI) => boolean;
 	readonly referencesExpandedWhenEmptyResponse?: boolean | ((mode: ChatModeKind) => boolean);
 	readonly progressMessageAtBottomOfResponse?: boolean | ((mode: ChatModeKind) => boolean);

--- a/src/vs/workbench/contrib/chat/browser/chatListRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatListRenderer.ts
@@ -1269,7 +1269,7 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 
 			// TODO @justschen: when locked to CLI, have the same rendering as normal thinking.
 			// If coming from CLI, we have a much more naive rendering strategy for thinking since we don't get the special metadata from extension.
-			if (this.rendererOptions.fromCodingAgent === true) {
+			if (this.rendererOptions.fromCodingAgent) {
 				if (content.kind !== 'thinking') {
 					this.finalizeCurrentThinkingPart();
 				}

--- a/src/vs/workbench/contrib/chat/browser/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatWidget.ts
@@ -2382,7 +2382,7 @@ export class ChatWidget extends Disposable implements IChatWidget {
 		// Update capabilities for the locked agent
 		const agent = this.chatAgentService.getAgent(agentId);
 		this._updateAgentCapabilitiesContextKeys(agent);
-		this.renderer.updateOptions({ restorable: false, editable: false, noFooter: true, progressMessageAtBottomOfResponse: true });
+		this.renderer.updateOptions({ restorable: false, editable: false, noFooter: true, progressMessageAtBottomOfResponse: true, fromCodingAgent: true });
 		this.tree.rerender();
 	}
 
@@ -2400,7 +2400,7 @@ export class ChatWidget extends Disposable implements IChatWidget {
 			this.viewModel.resetInputPlaceholder();
 		}
 		this.inputEditor.updateOptions({ placeholder: undefined });
-		this.renderer.updateOptions({ restorable: true, editable: true, noFooter: false, progressMessageAtBottomOfResponse: mode => mode !== ChatModeKind.Ask });
+		this.renderer.updateOptions({ restorable: true, editable: true, noFooter: false, progressMessageAtBottomOfResponse: mode => mode !== ChatModeKind.Ask, fromCodingAgent: false });
 		this.tree.rerender();
 	}
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

fix https://github.com/microsoft/vscode/issues/275445

we want to do a _much_ more naive rendering for thinking in CLI since we do not get our special metadata "stop", something that is sent either by respones API in open ai models, or by ourselves in cases like gemini (from the extension).

 cc @joshspicer @rebornix @DonJayamanne 