### PR TITLE
Fixed issue with 'enter' skipping matches in notebook search (issue #275236)

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/contrib/find/notebookFind.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/find/notebookFind.ts
@@ -313,23 +313,3 @@ registerAction2(class extends Action2 {
 	}
 });
 
-registerAction2(class extends Action2 {
-	constructor() {
-		super({
-			id: 'notebook.findNext.enter',
-			title: localize2('notebook.findNext.enter', 'Find Next'),
-			keybinding: {
-				when: ContextKeyExpr.and(
-					NOTEBOOK_EDITOR_FOCUSED,
-					KEYBINDING_CONTEXT_NOTEBOOK_FIND_WIDGET_FOCUSED
-				),
-				primary: KeyCode.Enter,
-				weight: KeybindingWeight.WorkbenchContrib + 1  // Higher priority than editor
-			}
-		});
-	}
-
-	async run(accessor: ServicesAccessor): Promise<void> {
-		return runFind(accessor, true);
-	}
-});


### PR DESCRIPTION
Fixed issue with 'enter' skipping matches in notebook search (issue #275236)

Enter was registered twice. This is now fixed.
Shift+Enter did not have this issue, and so it worked well. 