### PR TITLE
Hightlight ghost text completion if it has whitespaces only (#275522)

### DIFF
--- a/src/vs/editor/contrib/inlineCompletions/browser/view/ghostText/ghostTextView.css
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/ghostText/ghostTextView.css
@@ -82,4 +82,10 @@
 		opacity: var(--animation-opacity, 1);
 		background-color: var(--vscode-inlineEdit-modifiedChangedTextBackground);
 	}
+
+	.ghost-text-whitespaces-only {
+		background-color: var(--vscode-inlineEdit-modifiedChangedTextBackground);
+		border-bottom: 1px dashed var(--vscode-inlineEdit-modifiedBorder);
+		padding-bottom: 1px;
+	}
 }

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/ghostText/ghostTextView.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/ghostText/ghostTextView.ts
@@ -328,6 +328,7 @@ export class GhostTextView extends Disposable {
 						tokens: p.tokens,
 						inlineClassName: (p.preview ? 'ghost-text-decoration-preview' : 'ghost-text-decoration')
 							+ (this._isClickable ? ' clickable' : '')
+							+ (p.text.length > 0 && p.text.trim().length === 0 ? ' ghost-text-whitespaces-only' : '')
 							+ extraClassNames
 							+ inlineExtraClassNames
 							+ p.lineDecorations.map(d => ' ' + d.className).join(' '), // TODO: take the ranges into account for line decorations


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Highlight ghost text if it has whitespaces only

Fixes #275522