### PR TITLE
Truncate terminal attachment hover contents

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatAttachmentWidgets.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatAttachmentWidgets.ts
@@ -291,7 +291,10 @@ export class TerminalCommandAttachmentWidget extends AbstractChatAttachmentWidge
 	}
 }
 
-const MAX_TERMINAL_ATTACHMENT_OUTPUT_LENGTH = 2000;
+const enum TerminalConstants {
+	MaxAttachmentOutputLineCount = 5,
+	MaxAttachmentOutputLineLength = 80,
+}
 
 function createTerminalCommandElements(
 	element: HTMLElement,
@@ -328,23 +331,28 @@ function createTerminalCommandElements(
 	hoverElement.append(commandTitle, commandBlock);
 
 	if (attachment.output && attachment.output.trim().length > 0) {
-		const outputTitle = dom.$('div', {}, localize('chat.terminalCommandHoverOutputTitle', "Output"));
+		const outputTitle = dom.$('div', {}, localize('chat.terminalCommandHoverOutputTitle', "Output:"));
 		outputTitle.classList.add('attachment-additional-info');
 		const outputBlock = dom.$('pre.chat-terminal-command-output');
-		let outputText = attachment.output;
-		let truncated = false;
-		if (outputText.length > MAX_TERMINAL_ATTACHMENT_OUTPUT_LENGTH) {
-			outputText = `${outputText.slice(0, MAX_TERMINAL_ATTACHMENT_OUTPUT_LENGTH)}...`;
-			truncated = true;
+		const fullOutputLines = attachment.output.split('\n');
+		const hoverOutputLines = [];
+		for (const line of fullOutputLines) {
+			if (hoverOutputLines.length >= TerminalConstants.MaxAttachmentOutputLineCount) {
+				hoverOutputLines.push('...');
+				break;
+			}
+			const trimmed = line.trim();
+			if (trimmed.length === 0) {
+				continue;
+			}
+			if (trimmed.length > TerminalConstants.MaxAttachmentOutputLineLength) {
+				hoverOutputLines.push(`${trimmed.slice(0, TerminalConstants.MaxAttachmentOutputLineLength)}...`);
+			} else {
+				hoverOutputLines.push(trimmed);
+			}
 		}
-		outputBlock.textContent = outputText;
+		outputBlock.textContent = hoverOutputLines.join('\n');
 		hoverElement.append(outputTitle, outputBlock);
-
-		if (truncated) {
-			const truncatedInfo = dom.$('div', {}, localize('chat.terminalCommandHoverOutputTruncated', "Output truncated to first {0} characters.", MAX_TERMINAL_ATTACHMENT_OUTPUT_LENGTH));
-			truncatedInfo.classList.add('attachment-additional-info');
-			hoverElement.appendChild(truncatedInfo);
-		}
 	}
 
 	const hint = dom.$('div', {}, localize('chat.terminalCommandHoverHint', "Click to focus this command in the terminal."));


### PR DESCRIPTION
Fixes #275351

<img width="1068" height="582" alt="image" src="https://github.com/user-attachments/assets/9bf98c29-c763-4438-8c33-10447a28fe94" />
