### PR TITLE
use extension identifier for terminal suggest id

### DIFF
--- a/extensions/terminal-suggest/package.json
+++ b/extensions/terminal-suggest/package.json
@@ -27,7 +27,6 @@
     "terminal": {
       "completionProviders": [
         {
-          "id": "terminal-suggest",
           "description": "Show suggestions for commands, arguments, flags, and file paths based upon the Fig spec."
         }
       ]

--- a/src/vs/platform/terminal/common/terminal.ts
+++ b/src/vs/platform/terminal/common/terminal.ts
@@ -991,7 +991,6 @@ export interface IDecorationAddon {
 }
 
 export interface ITerminalCompletionProviderContribution {
-	id: string;
 	description?: string;
 }
 

--- a/src/vs/workbench/contrib/terminal/common/terminal.ts
+++ b/src/vs/workbench/contrib/terminal/common/terminal.ts
@@ -706,10 +706,6 @@ export const terminalContributionsDescriptor: IExtensionPointDescriptor<ITermina
 						}
 					}],
 					properties: {
-						id: {
-							description: nls.localize('vscode.extension.contributes.terminal.completionProviders.id', "The ID of the terminal completion provider."),
-							type: 'string',
-						},
 						description: {
 							description: nls.localize('vscode.extension.contributes.terminal.completionProviders.description', "A description of what the completion provider does. This will be shown in the settings UI."),
 							type: 'string',

--- a/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminal.suggest.contribution.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminal.suggest.contribution.ts
@@ -488,7 +488,7 @@ class TerminalSuggestProvidersConfigurationManager extends Disposable {
 	private _updateConfiguration(): void {
 		// Add statically declared providers from package.json contributions
 		const providers = new Map<string, ITerminalSuggestProviderInfo>();
-		this._terminalContributionService.terminalCompletionProviders.forEach(o => providers.set(o.id, o));
+		this._terminalContributionService.terminalCompletionProviders.forEach(o => providers.set(o.extensionIdentifier, { ...o, id: o.extensionIdentifier }));
 
 		// Add dynamically registered providers (that aren't already declared statically)
 		for (const { id } of this._terminalCompletionService.providers) {


### PR DESCRIPTION
fix #272345

We were passing id in here, which makes sense. https://github.com/microsoft/vscode/blob/d0bec64f5aef3397dc7d78dceac9ecd455d16cfb/src/vs/workbench/api/common/extHostTerminalService.ts#L769

<img width="828" height="176" alt="Screenshot 2025-11-05 at 12 50 26 PM" src="https://github.com/user-attachments/assets/e8520c73-b131-40ce-9272-cb7c74e65ce6" />
