### PR TITLE
Fix for clearing ai search results

### DIFF
--- a/src/vs/workbench/contrib/search/browser/AISearch/aiSearchModel.ts
+++ b/src/vs/workbench/contrib/search/browser/AISearch/aiSearchModel.ts
@@ -224,8 +224,10 @@ export class AIFolderMatchWorkspaceRootImpl extends Disposable implements ISearc
 	}
 	clear(clearingAll?: boolean): void {
 		const changed: ISearchTreeFileMatch[] = this.allDownstreamFileMatches();
-		this.disposeMatches();
-		this._onChange.fire({ elements: changed, removed: true, added: false, clearingAll });
+		if (changed.length > 0) {
+			this.disposeMatches();
+			this._onChange.fire({ elements: changed, removed: true, added: false, clearingAll });
+		}
 	}
 
 	get showHighlights(): boolean {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
Fixes: https://github.com/microsoft/vscode/issues/259887

Whenever the query changes we always clear all results, but the AI text search was always firing as if we always had matches to remove