### PR TITLE
Avoid saving inline chats to history

### DIFF
--- a/src/vs/workbench/contrib/chat/common/chatServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/chatServiceImpl.ts
@@ -239,7 +239,7 @@ export class ChatService extends Disposable implements IChatService {
 				if (!LocalChatSessionUri.parseLocalSessionId(session.sessionResource)) {
 					return false;
 				}
-				return session.initialLocation === ChatAgentLocation.Chat || session.initialLocation === ChatAgentLocation.EditorInline;
+				return session.initialLocation === ChatAgentLocation.Chat;
 			});
 
 		this._chatSessionStore.storeSessions(liveChats);
@@ -1109,6 +1109,11 @@ export class ChatService extends Disposable implements IChatService {
 				continue;
 			}
 
+			// Do not save to history inline completions
+			if (location === ChatAgentLocation.EditorInline) {
+				continue;
+			}
+
 			const promptTextResult = getPromptText(request.message);
 			const historyRequest: IChatAgentRequest = {
 				sessionId: sessionId,
@@ -1203,7 +1208,7 @@ export class ChatService extends Disposable implements IChatService {
 		}
 
 		const localSessionId = LocalChatSessionUri.parseLocalSessionId(sessionResource);
-		if (localSessionId && (model.initialLocation === ChatAgentLocation.Chat || model.initialLocation === ChatAgentLocation.EditorInline)) {
+		if (localSessionId && (model.initialLocation === ChatAgentLocation.Chat)) {
 			// Always preserve sessions that have custom titles, even if empty
 			if (model.getRequests().length === 0 && !model.customTitle) {
 				await this._chatSessionStore.deleteSession(localSessionId);

--- a/src/vs/workbench/contrib/chat/common/chatServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/chatServiceImpl.ts
@@ -367,7 +367,7 @@ export class ChatService extends Disposable implements IChatService {
 	 */
 	async getLocalSessionHistory(): Promise<IChatDetail[]> {
 		const liveSessionItems = Array.from(this._sessionModels.values())
-			.filter(session => !session.isImported && LocalChatSessionUri.parseLocalSessionId(session.sessionResource))
+			.filter(session => this.shouldBeInHistory(session))
 			.map((session): IChatDetail => {
 				const title = session.title || localize('newChat', "New Chat");
 				return {
@@ -380,7 +380,7 @@ export class ChatService extends Disposable implements IChatService {
 
 		const index = await this._chatSessionStore.getIndex();
 		const entries = Object.values(index)
-			.filter(entry => !this._sessionModels.has(LocalChatSessionUri.forSession(entry.sessionId)) && !entry.isImported && !entry.isEmpty)
+			.filter(entry => !this._sessionModels.has(LocalChatSessionUri.forSession(entry.sessionId)) && this.shouldBeInHistory(entry) && !entry.isEmpty)
 			.map((entry): IChatDetail => {
 				const sessionResource = LocalChatSessionUri.forSession(entry.sessionId);
 				return ({
@@ -390,6 +390,13 @@ export class ChatService extends Disposable implements IChatService {
 				});
 			});
 		return [...liveSessionItems, ...entries];
+	}
+
+	shouldBeInHistory(entry: Partial<ChatModel>) {
+		if (entry.sessionResource) {
+			return !entry.isImported && LocalChatSessionUri.parseLocalSessionId(entry.sessionResource) && entry.initialLocation !== ChatAgentLocation.EditorInline;
+		}
+		return !entry.isImported && entry.initialLocation !== ChatAgentLocation.EditorInline;
 	}
 
 	async removeHistoryEntry(sessionResource: URI): Promise<void> {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Fixes: https://github.com/microsoft/vscode/issues/252849

@jrieken could you please review this? Looks like saving inline chats was purposely added at some point, so I want to make sure it doesn't cause any regressions
