### PR TITLE
calculate output content height for terminal chat widget

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/media/chatTerminalToolProgressPart.css
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/media/chatTerminalToolProgressPart.css
@@ -86,6 +86,7 @@
 .chat-terminal-output-body {
 	padding: 4px 6px;
 	max-width: 100%;
+	height: 100%;
 }
 .chat-terminal-output-content {
 	display: flex;

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart.ts
@@ -405,13 +405,26 @@ export class ChatTerminalToolProgressPart extends BaseChatToolInvocationSubPart 
 			return;
 		}
 		const scrollableDomNode = this._outputScrollbar.getDomNode();
-		const viewportHeight = Math.min(this._outputBody.scrollHeight, MAX_TERMINAL_OUTPUT_PREVIEW_HEIGHT);
+		const viewportHeight = Math.min(this._getOutputContentHeight(), MAX_TERMINAL_OUTPUT_PREVIEW_HEIGHT);
 		scrollableDomNode.style.height = `${viewportHeight}px`;
 		this._outputScrollbar.scanDomNode();
 		if (this._renderedOutputHeight !== viewportHeight) {
 			this._renderedOutputHeight = viewportHeight;
 			this._onDidChangeHeight.fire();
 		}
+	}
+
+	private _getOutputContentHeight(): number {
+		const firstChild = this._outputBody.firstElementChild as HTMLElement | null;
+		if (!firstChild) {
+			return this._outputBody.scrollHeight;
+		}
+		const style = dom.getComputedStyle(this._outputBody);
+		const paddingTop = Number.parseFloat(style?.paddingTop || '0');
+		const paddingBottom = Number.parseFloat(style?.paddingBottom || '0');
+		const padding = paddingTop + paddingBottom;
+
+		return firstChild.scrollHeight + padding;
 	}
 
 	private _ensureOutputResizeObserver(): void {

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart.ts
@@ -420,8 +420,8 @@ export class ChatTerminalToolProgressPart extends BaseChatToolInvocationSubPart 
 			return this._outputBody.scrollHeight;
 		}
 		const style = dom.getComputedStyle(this._outputBody);
-		const paddingTop = Number.parseFloat(style?.paddingTop || '0');
-		const paddingBottom = Number.parseFloat(style?.paddingBottom || '0');
+		const paddingTop = Number.parseFloat(style.paddingTop || '0');
+		const paddingBottom = Number.parseFloat(style.paddingBottom || '0');
 		const padding = paddingTop + paddingBottom;
 
 		return firstChild.scrollHeight + padding;


### PR DESCRIPTION
fixes #275690

The fix to prevent `height: 100%` from happening for commands with limited output caused the vertical scrollbar to no longer appear. We need to set the height based on the content so that it works for various command outputs.

<img width="582" height="585" alt="Screenshot 2025-11-05 at 4 54 03 PM" src="https://github.com/user-attachments/assets/8ee30d71-4fc2-4d8a-ba5d-2c9741f9ee93" />
