### PR TITLE
Disable cleanup contribution

### DIFF
--- a/src/vs/workbench/contrib/authentication/browser/authentication.contribution.ts
+++ b/src/vs/workbench/contrib/authentication/browser/authentication.contribution.ts
@@ -21,11 +21,6 @@ import { ManageAccountPreferencesForMcpServerAction } from './actions/manageAcco
 import { ManageTrustedMcpServersForAccountAction } from './actions/manageTrustedMcpServersForAccountAction.js';
 import { RemoveDynamicAuthenticationProvidersAction } from './actions/manageDynamicAuthenticationProvidersAction.js';
 import { ManageAccountsAction } from './actions/manageAccountsAction.js';
-import { IAuthenticationQueryService } from '../../../services/authentication/common/authenticationQuery.js';
-import { IMcpRegistry } from '../../mcp/common/mcpRegistryTypes.js';
-import { autorun } from '../../../../base/common/observable.js';
-import { IAuthenticationService } from '../../../services/authentication/common/authentication.js';
-import { Event } from '../../../../base/common/event.js';
 
 const codeExchangeProxyCommand = CommandsRegistry.registerCommand('workbench.getCodeExchangeProxyEndpoints', function (accessor, _) {
 	const environmentService = accessor.get(IBrowserWorkbenchEnvironmentService);
@@ -173,49 +168,49 @@ class AuthenticationUsageContribution implements IWorkbenchContribution {
 // 	}
 // }
 
-class AuthenticationMcpContribution extends Disposable implements IWorkbenchContribution {
-	static ID = 'workbench.contrib.authenticationMcp';
+// class AuthenticationMcpContribution extends Disposable implements IWorkbenchContribution {
+// 	static ID = 'workbench.contrib.authenticationMcp';
 
-	constructor(
-		@IMcpRegistry private readonly _mcpRegistry: IMcpRegistry,
-		@IAuthenticationQueryService private readonly _authenticationQueryService: IAuthenticationQueryService,
-		@IAuthenticationService private readonly _authenticationService: IAuthenticationService
-	) {
-		super();
-		this._cleanupRemovedMcpServers();
+// 	constructor(
+// 		@IMcpRegistry private readonly _mcpRegistry: IMcpRegistry,
+// 		@IAuthenticationQueryService private readonly _authenticationQueryService: IAuthenticationQueryService,
+// 		@IAuthenticationService private readonly _authenticationService: IAuthenticationService
+// 	) {
+// 		super();
+// 		this._cleanupRemovedMcpServers();
 
-		// Listen for MCP collections changes using autorun with observables
-		this._register(autorun(reader => {
-			// Read the collections observable to register dependency
-			this._mcpRegistry.collections.read(reader);
-			// Schedule cleanup for next tick to avoid running during observable updates
-			queueMicrotask(() => this._cleanupRemovedMcpServers());
-		}));
-		this._register(
-			Event.any(
-				this._authenticationService.onDidChangeDeclaredProviders,
-				this._authenticationService.onDidRegisterAuthenticationProvider
-			)(() => this._cleanupRemovedMcpServers())
-		);
-	}
+// 		// Listen for MCP collections changes using autorun with observables
+// 		this._register(autorun(reader => {
+// 			// Read the collections observable to register dependency
+// 			this._mcpRegistry.collections.read(reader);
+// 			// Schedule cleanup for next tick to avoid running during observable updates
+// 			queueMicrotask(() => this._cleanupRemovedMcpServers());
+// 		}));
+// 		this._register(
+// 			Event.any(
+// 				this._authenticationService.onDidChangeDeclaredProviders,
+// 				this._authenticationService.onDidRegisterAuthenticationProvider
+// 			)(() => this._cleanupRemovedMcpServers())
+// 		);
+// 	}
 
-	private _cleanupRemovedMcpServers(): void {
-		const currentServerIds = new Set(this._mcpRegistry.collections.get().flatMap(c => c.serverDefinitions.get()).map(s => s.id));
-		const providerIds = this._authenticationQueryService.getProviderIds();
-		for (const providerId of providerIds) {
-			this._authenticationQueryService.provider(providerId).forEachAccount(account => {
-				account.mcpServers().forEach(server => {
-					if (!currentServerIds.has(server.mcpServerId)) {
-						server.removeUsage();
-						server.setAccessAllowed(false);
-					}
-				});
-			});
-		}
-	}
-}
+// 	private _cleanupRemovedMcpServers(): void {
+// 		const currentServerIds = new Set(this._mcpRegistry.collections.get().flatMap(c => c.serverDefinitions.get()).map(s => s.id));
+// 		const providerIds = this._authenticationQueryService.getProviderIds();
+// 		for (const providerId of providerIds) {
+// 			this._authenticationQueryService.provider(providerId).forEachAccount(account => {
+// 				account.mcpServers().forEach(server => {
+// 					if (!currentServerIds.has(server.mcpServerId)) {
+// 						server.removeUsage();
+// 						server.setAccessAllowed(false);
+// 					}
+// 				});
+// 			});
+// 		}
+// 	}
+// }
 
 registerWorkbenchContribution2(AuthenticationContribution.ID, AuthenticationContribution, WorkbenchPhase.AfterRestored);
 registerWorkbenchContribution2(AuthenticationUsageContribution.ID, AuthenticationUsageContribution, WorkbenchPhase.Eventually);
 // registerWorkbenchContribution2(AuthenticationExtensionsContribution.ID, AuthenticationExtensionsContribution, WorkbenchPhase.Eventually);
-registerWorkbenchContribution2(AuthenticationMcpContribution.ID, AuthenticationMcpContribution, WorkbenchPhase.Eventually);
+// registerWorkbenchContribution2(AuthenticationMcpContribution.ID, AuthenticationMcpContribution, WorkbenchPhase.Eventually);


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/272359

This contribution is causing servers that are allowed to be marked as not allowed because the servers are not available at startup. We shouldn't rely on servers being available at startup...

This needs to be re-done to clean up correctly, but for now let's just disable it.

This means that approvals will accumulate but in practice this won't be many.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
