### PR TITLE
fix tab drag and drop

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/media/terminal.css
+++ b/src/vs/workbench/contrib/terminal/browser/media/terminal.css
@@ -358,6 +358,10 @@
 	background-color: var(--vscode-toolbar-hoverBackground);
 }
 
+.monaco-workbench .pane-body.integrated-terminal .tabs-list-container.drop-target {
+	background-color: var(--vscode-list-dropBackground);
+}
+
 .monaco-workbench .pane-body.integrated-terminal .terminal-tabs-chat-entry .terminal-tabs-chat-entry-label {
 	min-width: 0;
 	overflow: hidden;


### PR DESCRIPTION
fix #275592

Adding the chat entry wrapped the tabs list in an extra container. When you would drag a tab into the empty area (which is now that container instead of the list), the list’s drop handler would never runs. The fix watches for drops on the container/chat entry, recognizes terminal drags, and forwards them to the usual “move to end” logic, so behavior matches what we had before.

https://github.com/user-attachments/assets/9aa6b339-6180-4d6e-a573-d68a01fc630b

