### PR TITLE
Fixed issue: F3 stops working when focus is in the notebook #275238

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/contrib/find/notebookFind.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/find/notebookFind.ts
@@ -25,8 +25,9 @@ import { INotebookCommandContext, NotebookMultiCellAction } from '../../controll
 import { getNotebookEditorFromEditorPane, INotebookEditor } from '../../notebookBrowser.js';
 import { registerNotebookContribution } from '../../notebookEditorExtensions.js';
 import { CellUri, NotebookFindScopeType } from '../../../common/notebookCommon.js';
-import { INTERACTIVE_WINDOW_IS_ACTIVE_EDITOR, KEYBINDING_CONTEXT_NOTEBOOK_FIND_WIDGET_FOCUSED, NOTEBOOK_EDITOR_FOCUSED, NOTEBOOK_IS_ACTIVE_EDITOR } from '../../../common/notebookContextKeys.js';
+import { INTERACTIVE_WINDOW_IS_ACTIVE_EDITOR, NOTEBOOK_EDITOR_FOCUSED, NOTEBOOK_IS_ACTIVE_EDITOR } from '../../../common/notebookContextKeys.js';
 import { IEditorService } from '../../../../../services/editor/common/editorService.js';
+import { CONTEXT_FIND_WIDGET_VISIBLE } from '../../../../../../editor/contrib/find/browser/findModel.js';
 
 registerNotebookContribution(NotebookFindContrib.id, NotebookFindContrib);
 
@@ -36,9 +37,9 @@ registerAction2(class extends Action2 {
 			id: 'notebook.hideFind',
 			title: localize2('notebookActions.hideFind', 'Hide Find in Notebook'),
 			keybinding: {
-				when: ContextKeyExpr.and(NOTEBOOK_EDITOR_FOCUSED, KEYBINDING_CONTEXT_NOTEBOOK_FIND_WIDGET_FOCUSED),
+				when: ContextKeyExpr.and(NOTEBOOK_EDITOR_FOCUSED, CONTEXT_FIND_WIDGET_VISIBLE),
 				primary: KeyCode.Escape,
-				weight: KeybindingWeight.WorkbenchContrib
+				weight: KeybindingWeight.EditorContrib + 5
 			}
 		});
 	}
@@ -140,7 +141,7 @@ function isNotebookEditorValidForSearch(accessor: ServicesAccessor, editor: INot
 	return true;
 }
 
-function openFindWidget(controller: NotebookFindContrib | undefined, editor: INotebookEditor | undefined, codeEditor: ICodeEditor | undefined) {
+function openFindWidget(controller: NotebookFindContrib | undefined, editor: INotebookEditor | undefined, codeEditor: ICodeEditor | undefined, focusWidget: boolean = true) {
 	if (!editor || !codeEditor || !controller) {
 		return false;
 	}
@@ -168,8 +169,11 @@ function openFindWidget(controller: NotebookFindContrib | undefined, editor: INo
 		if (cell) {
 			options = {
 				searchStringSeededFrom: { cell, range: searchStringOptions.selection },
+				focus: focusWidget
 			};
 		}
+	} else {
+		options = { focus: focusWidget };
 	}
 
 	controller.show(searchStringOptions?.searchString, options);
@@ -195,8 +199,8 @@ function findWidgetAction(accessor: ServicesAccessor, codeEditor: ICodeEditor, n
 		next ? controller.findNext() : controller.findPrevious();
 		return true;
 	} else {
-		// Find widget is not open, open it with search string (similar to StartFindAction)
-		return openFindWidget(controller, editor, codeEditor);
+		// Find widget is not open, open it without focusing the widget (keep focus in editor)
+		return openFindWidget(controller, editor, codeEditor, false);
 	}
 }
 
@@ -223,7 +227,7 @@ StartFindAction.addImplementation(100, (accessor: ServicesAccessor, codeEditor: 
 	}
 
 	const controller = editor?.getContribution<NotebookFindContrib>(NotebookFindContrib.id);
-	return openFindWidget(controller, editor, codeEditor);
+	return openFindWidget(controller, editor, codeEditor, true);
 });
 
 StartFindReplaceAction.addImplementation(100, (accessor: ServicesAccessor, codeEditor: ICodeEditor, args: any) => {
@@ -277,11 +281,11 @@ registerAction2(class extends Action2 {
 			keybinding: {
 				when: ContextKeyExpr.and(
 					NOTEBOOK_EDITOR_FOCUSED,
-					KEYBINDING_CONTEXT_NOTEBOOK_FIND_WIDGET_FOCUSED
+					CONTEXT_FIND_WIDGET_VISIBLE
 				),
 				primary: KeyCode.F3,
 				mac: { primary: KeyMod.CtrlCmd | KeyCode.KeyG, secondary: [KeyCode.F3] },
-				weight: KeybindingWeight.WorkbenchContrib + 1  // Higher priority than editor
+				weight: KeybindingWeight.WorkbenchContrib + 1
 			}
 		});
 	}
@@ -299,11 +303,11 @@ registerAction2(class extends Action2 {
 			keybinding: {
 				when: ContextKeyExpr.and(
 					NOTEBOOK_EDITOR_FOCUSED,
-					KEYBINDING_CONTEXT_NOTEBOOK_FIND_WIDGET_FOCUSED
+					CONTEXT_FIND_WIDGET_VISIBLE
 				),
 				primary: KeyMod.Shift | KeyCode.F3,
 				mac: { primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KeyG, secondary: [KeyMod.Shift | KeyCode.F3] },
-				weight: KeybindingWeight.WorkbenchContrib + 1  // Higher priority than editor
+				weight: KeybindingWeight.WorkbenchContrib + 1
 			}
 		});
 	}

--- a/src/vs/workbench/contrib/notebook/browser/contrib/find/notebookFindWidget.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/find/notebookFindWidget.ts
@@ -12,7 +12,7 @@ import { Disposable } from '../../../../../../base/common/lifecycle.js';
 import * as strings from '../../../../../../base/common/strings.js';
 import { Range } from '../../../../../../editor/common/core/range.js';
 import { FindMatch } from '../../../../../../editor/common/model.js';
-import { MATCHES_LIMIT } from '../../../../../../editor/contrib/find/browser/findModel.js';
+import { MATCHES_LIMIT, CONTEXT_FIND_WIDGET_VISIBLE } from '../../../../../../editor/contrib/find/browser/findModel.js';
 import { FindReplaceState } from '../../../../../../editor/contrib/find/browser/findState.js';
 import { NLS_MATCHES_LOCATION, NLS_NO_RESULTS } from '../../../../../../editor/contrib/find/browser/findWidget.js';
 import { FindWidgetSearchHistory } from '../../../../../../editor/contrib/find/browser/findWidgetSearchHistory.js';
@@ -96,6 +96,7 @@ export class NotebookFindContrib extends Disposable implements INotebookEditorCo
 
 class NotebookFindWidget extends SimpleFindReplaceWidget implements INotebookEditorContribution {
 	protected _findWidgetFocused: IContextKey<boolean>;
+	protected _findWidgetVisible: IContextKey<boolean>;
 	private _isFocused: boolean = false;
 	private _showTimeout: number | null = null;
 	private _hideTimeout: number | null = null;
@@ -120,6 +121,7 @@ class NotebookFindWidget extends SimpleFindReplaceWidget implements INotebookEdi
 
 		DOM.append(this._notebookEditor.getDomNode(), this.getDomNode());
 		this._findWidgetFocused = KEYBINDING_CONTEXT_NOTEBOOK_FIND_WIDGET_FOCUSED.bindTo(contextKeyService);
+		this._findWidgetVisible = CONTEXT_FIND_WIDGET_VISIBLE.bindTo(contextKeyService);
 		this._register(this._findInput.onKeyDown((e) => this._onFindInputKeyDown(e)));
 		this._register(this._replaceInput.onKeyDown((e) => this._onReplaceInputKeyDown(e)));
 
@@ -293,6 +295,7 @@ class NotebookFindWidget extends SimpleFindReplaceWidget implements INotebookEdi
 		const searchStringUpdate = this._state.searchString !== initialInput;
 		super.show(initialInput, options);
 		this._state.change({ searchString: initialInput ?? this._state.searchString, isRevealed: true }, false);
+		this._findWidgetVisible.set(true);
 
 		if (typeof options?.matchIndex === 'number') {
 			if (!this._findModel.findMatches.length) {
@@ -349,6 +352,7 @@ class NotebookFindWidget extends SimpleFindReplaceWidget implements INotebookEdi
 	override hide() {
 		super.hide();
 		this._state.change({ isRevealed: false }, false);
+		this._findWidgetVisible.set(false);
 		this._findModel.clear();
 		this._notebookEditor.findStop();
 		this._progressBar.stop();


### PR DESCRIPTION
Fixed issue: F3 stops working when focus is in the notebook #275238 (https://github.com/microsoft/vscode/issues/275238)

With this change:
- When pressing F3/Shift-F3, focus will stay in the editor and you can move next/previous match
- When pressing Ctrl+F, focus will be in the widget and you can move next/previous match using Enter/Shift-Enter