### PR TITLE
SCM - `scm/repository` menu should use `inline` as the primary group

### DIFF
--- a/src/vs/workbench/contrib/scm/browser/scmRepositoryRenderer.ts
+++ b/src/vs/workbench/contrib/scm/browser/scmRepositoryRenderer.ts
@@ -202,7 +202,7 @@ export class RepositoryRenderer implements ICompressibleTreeRenderer<ISCMReposit
 				menuPrimaryActions = primary;
 				menuSecondaryActions = secondary;
 				updateToolbar();
-			}));
+			}, 'inline'));
 		}));
 
 		templateData.toolBar.context = repository.provider;


### PR DESCRIPTION
Related https://github.com/microsoft/vscode/issues/272941