### PR TITLE
chat: use tool call id instead of tool id for input models

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatToolConfirmationSubPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatToolConfirmationSubPart.ts
@@ -180,12 +180,12 @@ export class ToolConfirmationSubPart extends AbstractToolConfirmationSubPart {
 					// View a single JSON line by default until they 'see more'
 					rawJsonInput.replace(/\n */g, ' '),
 					this.languageService.createById(langId),
-					createToolInputUri(toolInvocation.toolId),
+					createToolInputUri(toolInvocation.toolCallId),
 					true
 				));
 
 				const markerOwner = generateUuid();
-				const schemaUri = createToolSchemaUri(toolInvocation.toolId);
+				const schemaUri = createToolSchemaUri(toolInvocation.toolCallId);
 				const validator = new RunOnceScheduler(async () => {
 
 					const newMarker: IMarkerData[] = [];

--- a/src/vs/workbench/contrib/chat/common/languageModelToolsService.ts
+++ b/src/vs/workbench/contrib/chat/common/languageModelToolsService.ts
@@ -356,11 +356,8 @@ export interface ILanguageModelToolsService {
 	toToolReferences(variableReferences: readonly IVariableReference[]): ChatRequestToolReferenceEntry[];
 }
 
-export function createToolInputUri(toolOrId: IToolData | string): URI {
-	if (typeof toolOrId !== 'string') {
-		toolOrId = toolOrId.id;
-	}
-	return URI.from({ scheme: Schemas.inMemory, path: `/lm/tool/${toolOrId}/tool_input.json` });
+export function createToolInputUri(toolCallId: string): URI {
+	return URI.from({ scheme: Schemas.inMemory, path: `/lm/tool/${toolCallId}/tool_input.json` });
 }
 
 export function createToolSchemaUri(toolOrId: IToolData | string): URI {


### PR DESCRIPTION
Closes #275675

cc @roblourens -- I didn't see any other dependents of this URI/structure and it seems to work, lmk if you have concerns