### PR TITLE
Revert "macOS - restore use of `hide` and `show` for `app.dock` second instances"

### DIFF
--- a/src/vs/code/electron-main/main.ts
+++ b/src/vs/code/electron-main/main.ts
@@ -316,11 +316,6 @@ class CodeMain {
 				throw error;
 			}
 
-			// Since we are the second instance, we do not want to show the dock
-			if (isMacintosh) {
-				app.dock?.hide();
-			}
-
 			// there's a running instance, let's connect to it
 			let client: NodeIPCClient<string>;
 			try {
@@ -418,11 +413,6 @@ class CodeMain {
 			console.log(localize('statusWarning', "Warning: The --status argument can only be used if {0} is already running. Please run it again after {0} has started.", productService.nameShort));
 
 			throw new ExpectedError('Terminating...');
-		}
-
-		// dock might be hidden at this case due to a retry
-		if (isMacintosh) {
-			app.dock?.show();
 		}
 
 		// Set the VSCODE_PID variable here when we are sure we are the first


### PR DESCRIPTION
Reverts microsoft/vscode#259883

fix https://github.com/microsoft/vscode/issues/274146