### PR TITLE
get focus terminal action to show for shell integration disabled

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart.ts
@@ -268,6 +268,7 @@ export class ChatTerminalToolProgressPart extends BaseChatToolInvocationSubPart 
 		const attachCommandDetection = async (commandDetection: ICommandDetectionCapability | undefined) => {
 			commandDetectionListener.clear();
 			if (!commandDetection) {
+				await tryResolveCommand();
 				return;
 			}
 


### PR DESCRIPTION
fix #274876

https://github.com/user-attachments/assets/e774c148-def9-42d1-bd58-18f6ee5e9bbc

