### PR TITLE
mcp: fix tool availability being racey during autostart

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/languageModelToolsService.ts
+++ b/src/vs/workbench/contrib/chat/browser/languageModelToolsService.ts
@@ -168,6 +168,10 @@ export class LanguageModelToolsService extends Disposable implements ILanguageMo
 		});
 	}
 
+	flushToolUpdates(): void {
+		this._onDidChangeToolsScheduler.flush();
+	}
+
 	private _refreshAllToolContextKeys() {
 		this._toolContextKeys.clear();
 		for (const tool of this._tools.values()) {

--- a/src/vs/workbench/contrib/chat/common/chatServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/chatServiceImpl.ts
@@ -870,21 +870,7 @@ export class ChatService extends Disposable implements IChatService {
 							message = promptTextResult.message;
 						}
 
-						let isInitialTools = true;
-
-						store.add(autorun(reader => {
-							const tools = options?.userSelectedTools?.read(reader);
-							if (isInitialTools) {
-								isInitialTools = false;
-								return;
-							}
-
-							if (tools) {
-								this.chatAgentService.setRequestTools(agent.id, request.id, tools);
-							}
-						}));
-
-						return {
+						const agentRequest: IChatAgentRequest = {
 							sessionId: model.sessionId,
 							requestId: request.id,
 							agentId: agent.id,
@@ -903,7 +889,25 @@ export class ChatService extends Disposable implements IChatService {
 							modeInstructions: options?.modeInfo?.modeInstructions,
 							editedFileEvents: request.editedFileEvents,
 							chatSummary: options?.chatSummary
-						} satisfies IChatAgentRequest;
+						};
+
+						let isInitialTools = true;
+
+						store.add(autorun(reader => {
+							const tools = options?.userSelectedTools?.read(reader);
+							if (isInitialTools) {
+								isInitialTools = false;
+								return;
+							}
+
+							if (tools) {
+								this.chatAgentService.setRequestTools(agent.id, request.id, tools);
+								// in case the request has not been sent out yet:
+								agentRequest.userSelectedTools = tools;
+							}
+						}));
+
+						return agentRequest;
 					};
 
 					if (

--- a/src/vs/workbench/contrib/chat/common/languageModelToolsService.ts
+++ b/src/vs/workbench/contrib/chat/common/languageModelToolsService.ts
@@ -352,6 +352,8 @@ export interface ILanguageModelToolsService {
 	getToolByName(name: string, includeDisabled?: boolean): IToolData | undefined;
 	invokeTool(invocation: IToolInvocation, countTokens: CountTokensCallback, token: CancellationToken): Promise<IToolResult>;
 	cancelToolCallsForRequest(requestId: string): void;
+	/** Flush any pending tool updates to the extension hosts. */
+	flushToolUpdates(): void;
 
 	readonly toolSets: IObservable<Iterable<ToolSet>>;
 	getToolSet(id: string): ToolSet | undefined;

--- a/src/vs/workbench/contrib/chat/test/common/mockLanguageModelToolsService.ts
+++ b/src/vs/workbench/contrib/chat/test/common/mockLanguageModelToolsService.ts
@@ -36,6 +36,10 @@ export class MockLanguageModelToolsService implements ILanguageModelToolsService
 
 	}
 
+	flushToolUpdates(): void {
+
+	}
+
 	cancelToolCallsForRequest(requestId: string): void {
 
 	}

--- a/src/vs/workbench/contrib/mcp/common/mcpLanguageModelToolContribution.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpLanguageModelToolContribution.ts
@@ -148,6 +148,10 @@ export class McpLanguageModelToolContribution extends Disposable implements IWor
 			for (const fn of toRegister) {
 				fn();
 			}
+
+			// Important: flush tool updates when the server is fully registered so that
+			// any consuming (e.g. autostarting) requests have the tools available immediately.
+			this._toolsService.flushToolUpdates();
 		}));
 
 		store.add(toDisposable(() => {


### PR DESCRIPTION
- Ensure tools are flushed to the EH immediately after registration
- Ensure tools are applied to the request object while it's waiting to be sent

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
