### PR TITLE
Ensure search in agent sessions pane uses visible text (fix for #275151)

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatSessions/view/sessionsViewPane.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSessions/view/sessionsViewPane.ts
@@ -5,6 +5,7 @@
 
 import * as DOM from '../../../../../../base/browser/dom.js';
 import { $, append } from '../../../../../../base/browser/dom.js';
+import { renderAsPlaintext } from '../../../../../../base/browser/markdownRenderer.js';
 import { IActionViewItem } from '../../../../../../base/browser/ui/actionbar/actionbar.js';
 import { IBaseActionViewItemOptions } from '../../../../../../base/browser/ui/actionbar/actionViewItems.js';
 import { ITreeContextMenuEvent } from '../../../../../../base/browser/ui/tree/tree.js';
@@ -349,8 +350,7 @@ export class SessionsViewPane extends ViewPane {
 					getKeyboardNavigationLabel: (session: ChatSessionItemWithProvider) => {
 						const parts = [
 							session.label || '',
-							session.id || '',
-							typeof session.description === 'string' ? session.description : (session.description?.value || '')
+							typeof session.description === 'string' ? session.description : (session.description ? renderAsPlaintext(session.description) : '')
 						];
 						return parts.filter(text => text.length > 0).join(' ');
 					}


### PR DESCRIPTION
Fix for issue #275151 

When searching ensure we use only visible text for search (session label and description). 

Session description can be markdown with links, etc. so use plain text. 
