### PR TITLE
Targeted fix for supporting non-local sessions in code paths that aren't using uris

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadChatAgents2.ts
+++ b/src/vs/workbench/api/browser/mainThreadChatAgents2.ts
@@ -175,7 +175,7 @@ export class MainThreadChatAgents2 extends Disposable implements MainThreadChatA
 
 		const impl: IChatAgentImplementation = {
 			invoke: async (request, progress, history, token) => {
-				const chatSession = this._chatService.getSession(LocalChatSessionUri.forSession(request.sessionId));
+				const chatSession = this._chatService.getSessionByLegacyId(request.sessionId);
 				this._pendingProgress.set(request.requestId, { progress, chatSession });
 				try {
 					return await this._proxy.$invokeAgent(handle, request, {

--- a/src/vs/workbench/contrib/chat/common/chatService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService.ts
@@ -907,6 +907,7 @@ export interface IChatService {
 	hasSessions(): boolean;
 	startSession(location: ChatAgentLocation, token: CancellationToken, isGlobalEditingSession?: boolean, options?: { canUseTools?: boolean }): ChatModel;
 	getSession(sessionResource: URI): IChatModel | undefined;
+	getSessionByLegacyId(sessionId: string): IChatModel | undefined;
 	getOrRestoreSession(sessionResource: URI): Promise<IChatModel | undefined>;
 	getPersistedSessionTitle(sessionResource: URI): string | undefined;
 	isPersistedSessionEmpty(sessionResource: URI): boolean;

--- a/src/vs/workbench/contrib/chat/common/chatServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/chatServiceImpl.ts
@@ -461,6 +461,10 @@ export class ChatService extends Disposable implements IChatService {
 		return this._sessionModels.get(sessionResource);
 	}
 
+	getSessionByLegacyId(sessionId: string): IChatModel | undefined {
+		return Array.from(this._sessionModels.values()).find(session => session.sessionId === sessionId);
+	}
+
 	async getOrRestoreSession(sessionResource: URI): Promise<ChatModel | undefined> {
 		this.trace('getOrRestoreSession', `${sessionResource}`);
 		const model = this._sessionModels.get(sessionResource);
@@ -484,7 +488,7 @@ export class ChatService extends Disposable implements IChatService {
 			return undefined;
 		}
 
-		const session = this._startSession(sessionData, sessionData.initialLocation ?? ChatAgentLocation.Chat, true, CancellationToken.None, { canUseTools: true });
+		const session = this._startSession(sessionData, sessionData.initialLocation ?? ChatAgentLocation.Chat, true, CancellationToken.None, { canUseTools: true, sessionResource });
 
 		const isTransferred = this.transferredSessionData?.sessionId === sessionId;
 		if (isTransferred) {

--- a/src/vs/workbench/contrib/chat/test/common/mockChatService.ts
+++ b/src/vs/workbench/contrib/chat/test/common/mockChatService.ts
@@ -42,6 +42,9 @@ export class MockChatService implements IChatService {
 		// eslint-disable-next-line local/code-no-dangerous-type-assertions
 		return this.sessions.get(sessionResource) ?? {} as IChatModel;
 	}
+	getSessionByLegacyId(sessionId: string): IChatModel | undefined {
+		return Array.from(this.sessions.values()).find(session => session.sessionId === sessionId);
+	}
 	async getOrRestoreSession(sessionResource: URI): Promise<IChatModel | undefined> {
 		throw new Error('Method not implemented.');
 	}


### PR DESCRIPTION
Fixes #275957 

This is a scoped fix to remove the dangerous call to `LocalChatSessionUri.forSession`. My previous fix ([275916](https://github.com/microsoft/vscode/pull/275916))revealed this bug by making the session's resource accurate

Instead we'll look up the session by id like we used to