### PR TITLE
Revert "Append well-known path instead of insert"

### DIFF
--- a/src/vs/base/common/oauth.ts
+++ b/src/vs/base/common/oauth.ts
@@ -1123,14 +1123,18 @@ export async function fetchResourceMetadata(
 	// If no resourceMetadataUrl is provided, try well-known URIs as per RFC 9728
 	let urlsToTry: string[];
 	if (!resourceMetadataUrl) {
-		// Per spec: append /.well-known/oauth-protected-resource to the resource URL
-		const resourceWithoutTrailingSlash = targetResource.replace(/\/$/, '');
-		urlsToTry = [
-			`${resourceWithoutTrailingSlash}${AUTH_PROTECTED_RESOURCE_METADATA_DISCOVERY_PATH}`
-		];
-		// If there's more than just the root path, also try at root as fallback
-		if (targetResourceUrlObj.pathname !== '/') {
-			urlsToTry.push(`${targetResourceUrlObj.origin}${AUTH_PROTECTED_RESOURCE_METADATA_DISCOVERY_PATH}`);
+		// Try in order: 1) with path appended, 2) at root
+		const pathComponent = targetResourceUrlObj.pathname === '/' ? undefined : targetResourceUrlObj.pathname;
+		const rootUrl = `${targetResourceUrlObj.origin}${AUTH_PROTECTED_RESOURCE_METADATA_DISCOVERY_PATH}`;
+		if (pathComponent) {
+			// Only try both URLs if we have a path component
+			urlsToTry = [
+				`${rootUrl}${pathComponent}`,
+				rootUrl
+			];
+		} else {
+			// If target is already at root, only try the root URL once
+			urlsToTry = [rootUrl];
 		}
 	} else {
 		urlsToTry = [resourceMetadataUrl];

--- a/src/vs/base/test/common/oauth.test.ts
+++ b/src/vs/base/test/common/oauth.test.ts
@@ -1209,7 +1209,7 @@ suite('OAuth', () => {
 			assert.deepStrictEqual(result, expectedMetadata);
 			assert.strictEqual(fetchStub.callCount, 1);
 			// Should try path-appended version first
-			assert.strictEqual(fetchStub.firstCall.args[0], 'https://example.com/api/v1/.well-known/oauth-protected-resource');
+			assert.strictEqual(fetchStub.firstCall.args[0], 'https://example.com/.well-known/oauth-protected-resource/api/v1');
 		});
 
 		test('should fallback to well-known URI at root when path version fails', async () => {
@@ -1241,7 +1241,7 @@ suite('OAuth', () => {
 			assert.deepStrictEqual(result, expectedMetadata);
 			assert.strictEqual(fetchStub.callCount, 2);
 			// First attempt with path
-			assert.strictEqual(fetchStub.firstCall.args[0], 'https://example.com/api/v1/.well-known/oauth-protected-resource');
+			assert.strictEqual(fetchStub.firstCall.args[0], 'https://example.com/.well-known/oauth-protected-resource/api/v1');
 			// Second attempt at root
 			assert.strictEqual(fetchStub.secondCall.args[0], 'https://example.com/.well-known/oauth-protected-resource');
 		});
@@ -1260,8 +1260,8 @@ suite('OAuth', () => {
 				(error: any) => {
 					assert.ok(error instanceof AggregateError, 'Should be an AggregateError');
 					assert.strictEqual(error.errors.length, 2, 'Should contain 2 errors');
-					assert.ok(/Failed to fetch resource metadata from.*\/api\/v1\/\.well-known.*404/.test(error.errors[0].message), 'First error should mention /api/v1/.well-known and 404');
-					assert.ok(/Failed to fetch resource metadata from.*https:\/\/example\.com\/\.well-known.*404/.test(error.errors[1].message), 'Second error should mention root .well-known and 404');
+					assert.ok(/Failed to fetch resource metadata from.*\/api\/v1.*404/.test(error.errors[0].message), 'First error should mention /api/v1 and 404');
+					assert.ok(/Failed to fetch resource metadata from.*\.well-known.*404/.test(error.errors[1].message), 'Second error should mention .well-known and 404');
 					return true;
 				}
 			); assert.strictEqual(fetchStub.callCount, 2);


### PR DESCRIPTION
Reverts microsoft/vscode#275438

🤦 I just looked up the most recent version of the spec:
https://datatracker.ietf.org/doc/html/rfc9728#name-obtaining-protected-resourc

and the previous behavior was the correct behavior... reverting this.