### PR TITLE
Clicking OS notification always opens secondary side bar, even if I'm working with Chat in editor

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chat.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.ts
@@ -57,7 +57,7 @@ export interface IChatWidgetService {
 
 export async function showChatWidgetInViewOrEditor(accessor: ServicesAccessor, widget: IChatWidget) {
 	if ('viewId' in widget.viewContext) {
-		await accessor.get(IViewsService).openView(widget.location);
+		await accessor.get(IViewsService).openView(widget.viewContext.viewId);
 	} else {
 		const sessionResource = widget.viewModel?.sessionResource;
 		if (sessionResource) {


### PR DESCRIPTION
(fix #270619)

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
