### PR TITLE
isUri -> isUriString

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/disassemblyView.ts
+++ b/src/vs/workbench/contrib/debug/browser/disassemblyView.ts
@@ -41,7 +41,7 @@ import * as icons from './debugIcons.js';
 import { CONTEXT_LANGUAGE_SUPPORTS_DISASSEMBLE_REQUEST, DISASSEMBLY_VIEW_ID, IDebugConfiguration, IDebugService, IDebugSession, IInstructionBreakpoint, State } from '../common/debug.js';
 import { InstructionBreakpoint } from '../common/debugModel.js';
 import { getUriFromSource } from '../common/debugSource.js';
-import { isUri, sourcesEqual } from '../common/debugUtils.js';
+import { isUriString, sourcesEqual } from '../common/debugUtils.js';
 import { IEditorService } from '../../../services/editor/common/editorService.js';
 import { IEditorGroup } from '../../../services/editor/common/editorGroupsService.js';
 import { IContextMenuService } from '../../../../platform/contextview/browser/contextView.js';
@@ -956,7 +956,7 @@ class InstructionRenderer extends Disposable implements ITableRenderer<IDisassem
 	private getUriFromSource(instruction: DebugProtocol.DisassembledInstruction): URI {
 		// Try to resolve path before consulting the debugSession.
 		const path = instruction.location!.path;
-		if (path && isUri(path)) {	// path looks like a uri
+		if (path && isUriString(path)) {	// path looks like a uri
 			return this.uriService.asCanonicalUri(URI.parse(path));
 		}
 		// assume a filesystem path

--- a/src/vs/workbench/contrib/debug/browser/rawDebugSession.ts
+++ b/src/vs/workbench/contrib/debug/browser/rawDebugSession.ts
@@ -9,7 +9,7 @@ import * as objects from '../../../../base/common/objects.js';
 import { toAction } from '../../../../base/common/actions.js';
 import * as errors from '../../../../base/common/errors.js';
 import { createErrorWithActions } from '../../../../base/common/errorMessage.js';
-import { formatPII, isUri } from '../common/debugUtils.js';
+import { formatPII, isUriString } from '../common/debugUtils.js';
 import { IDebugAdapter, IConfig, AdapterEndEvent, IDebugger } from '../common/debug.js';
 import { IExtensionHostDebugService, IOpenExtensionWindowResult } from '../../../../platform/debug/common/extensionHostDebug.js';
 import { URI } from '../../../../base/common/uri.js';
@@ -738,8 +738,8 @@ export class RawDebugSession implements IDisposable {
 				const key = match[1];
 				let value = match[2];
 
-				if ((key === 'file-uri' || key === 'folder-uri') && !isUri(arg.path)) {
-					value = isUri(value) ? value : URI.file(value).toString();
+				if ((key === 'file-uri' || key === 'folder-uri') && !isUriString(arg.path)) {
+					value = isUriString(value) ? value : URI.file(value).toString();
 				}
 				args.push(`--${key}=${value}`);
 			} else {

--- a/src/vs/workbench/contrib/debug/common/debugSource.ts
+++ b/src/vs/workbench/contrib/debug/common/debugSource.ts
@@ -11,7 +11,7 @@ import { DEBUG_SCHEME } from './debug.js';
 import { IRange } from '../../../../editor/common/core/range.js';
 import { IEditorService, SIDE_GROUP, ACTIVE_GROUP } from '../../../services/editor/common/editorService.js';
 import { Schemas } from '../../../../base/common/network.js';
-import { isUri } from './debugUtils.js';
+import { isUriString } from './debugUtils.js';
 import { IEditorPane } from '../../../common/editor.js';
 import { TextEditorSelectionRevealType } from '../../../../platform/editor/common/editor.js';
 import { IUriIdentityService } from '../../../../platform/uriIdentity/common/uriIdentity.js';
@@ -139,7 +139,7 @@ export function getUriFromSource(raw: DebugProtocol.Source, path: string | undef
 			});
 		}
 
-		if (path && isUri(path)) {	// path looks like a uri
+		if (path && isUriString(path)) {	// path looks like a uri
 			return uriIdentityService.asCanonicalUri(URI.parse(path));
 		}
 		// assume a filesystem path

--- a/src/vs/workbench/contrib/debug/common/debugUtils.ts
+++ b/src/vs/workbench/contrib/debug/common/debugUtils.ts
@@ -174,7 +174,7 @@ export async function getEvaluatableExpressionAtPosition(languageFeaturesService
 // RFC 2396, Appendix A: https://www.ietf.org/rfc/rfc2396.txt
 const _schemePattern = /^[a-zA-Z][a-zA-Z0-9\+\-\.]+:/;
 
-export function isUri(s: string | undefined): boolean {
+export function isUriString(s: string | undefined): boolean {
 	// heuristics: a valid uri starts with a scheme and
 	// the scheme has at least 2 characters so that it doesn't look like a drive letter.
 	return !!(s && s.match(_schemePattern));
@@ -185,7 +185,7 @@ function stringToUri(source: PathContainer): string | undefined {
 		if (typeof source.sourceReference === 'number' && source.sourceReference > 0) {
 			// if there is a source reference, don't touch path
 		} else {
-			if (isUri(source.path)) {
+			if (isUriString(source.path)) {
 				return <string><unknown>uri.parse(source.path);
 			} else {
 				// assume path


### PR DESCRIPTION
Avoid accidental auto imports/confusion of common function (`URI.isUri`)

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
