### PR TITLE
get hidden chat terminal count to update 

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminal.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminal.ts
@@ -132,7 +132,7 @@ export interface ITerminalChatService {
 	 * Returns the list of terminal instances that have been registered with a tool session id.
 	 * This is used for surfacing tool-driven/background terminals in UI (eg. quick picks).
 	 */
-	getToolSessionTerminalInstances(): readonly ITerminalInstance[];
+	getToolSessionTerminalInstances(hiddenOnly?: boolean): readonly ITerminalInstance[];
 
 	/**
 	 * Returns the tool session ID for a given terminal instance, if it has been registered.

--- a/src/vs/workbench/contrib/terminal/browser/terminalService.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalService.ts
@@ -1036,6 +1036,7 @@ export class TerminalService extends Disposable implements ITerminalService {
 					this._onDidDisposeInstance.fire(instance);
 				})
 			]);
+			this._onDidChangeInstances.fire();
 			return instance;
 		}
 

--- a/src/vs/workbench/contrib/terminal/browser/terminalTabbedView.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalTabbedView.ts
@@ -176,11 +176,11 @@ export class TerminalTabbedView extends Disposable {
 
 	private _shouldShowTabs(): boolean {
 		const enabled = this._terminalConfigurationService.config.tabs.enabled;
+		const hide = this._terminalConfigurationService.config.tabs.hideCondition;
+		const hiddenChatTerminals = this._terminalChatService.getToolSessionTerminalInstances(true);
 		if (!enabled) {
 			return false;
 		}
-		const hide = this._terminalConfigurationService.config.tabs.hideCondition;
-		const hiddenChatTerminals = this._terminalChatService.getToolSessionTerminalInstances(true);
 		if (hiddenChatTerminals.length > 0) {
 			return true;
 		}

--- a/src/vs/workbench/contrib/terminal/browser/terminalTabbedView.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalTabbedView.ts
@@ -180,19 +180,16 @@ export class TerminalTabbedView extends Disposable {
 			return false;
 		}
 		const hide = this._terminalConfigurationService.config.tabs.hideCondition;
-		const toolInstances = this._terminalChatService.getToolSessionTerminalInstances();
-		const foregroundInstances = new Set(this._terminalService.foregroundInstances.map(i => i.instanceId));
-		const hasHiddenChatTerminals = toolInstances.some(instance => !foregroundInstances.has(instance.instanceId));
-		if (hasHiddenChatTerminals) {
+		const hiddenChatTerminals = this._terminalChatService.getToolSessionTerminalInstances(true);
+		if (hiddenChatTerminals.length > 0) {
 			return true;
 		}
-		const hasChatTerminals = toolInstances.length > 0;
 
 		if (hide === 'never') {
 			return true;
 		}
 
-		if (this._terminalGroupService.instances.length && hasChatTerminals) {
+		if (this._terminalGroupService.instances.length) {
 			return true;
 		}
 

--- a/src/vs/workbench/contrib/terminal/browser/terminalTabbedView.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalTabbedView.ts
@@ -143,11 +143,7 @@ export class TerminalTabbedView extends Disposable {
 			this._updateChatTerminalsEntry();
 		}));
 
-		this._register(this._terminalChatService.onDidRegisterTerminalInstanceWithToolSession(() => {
-			this._refreshShowTabs();
-			this._updateChatTerminalsEntry();
-		}));
-		this._register(this._terminalService.onDidChangeInstances(() => {
+		this._register(Event.any(this._terminalChatService.onDidRegisterTerminalInstanceWithToolSession, this._terminalService.onDidChangeInstances)(() => {
 			this._refreshShowTabs();
 			this._updateChatTerminalsEntry();
 		}));

--- a/src/vs/workbench/contrib/terminal/browser/terminalTabsChatEntry.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalTabsChatEntry.ts
@@ -9,7 +9,7 @@ import { Disposable } from '../../../../base/common/lifecycle.js';
 import { $ } from '../../../../base/browser/dom.js';
 import { localize } from '../../../../nls.js';
 import { ICommandService } from '../../../../platform/commands/common/commands.js';
-import { ITerminalChatService, ITerminalService } from './terminal.js';
+import { ITerminalChatService } from './terminal.js';
 import * as dom from '../../../../base/browser/dom.js';
 
 export class TerminalTabsChatEntry extends Disposable {
@@ -28,7 +28,6 @@ export class TerminalTabsChatEntry extends Disposable {
 		private readonly _tabContainer: HTMLElement,
 		@ICommandService private readonly _commandService: ICommandService,
 		@ITerminalChatService private readonly _terminalChatService: ITerminalChatService,
-		@ITerminalService private readonly _terminalService: ITerminalService,
 	) {
 		super();
 
@@ -54,8 +53,6 @@ export class TerminalTabsChatEntry extends Disposable {
 				runChatTerminalsCommand();
 			}
 		}));
-		this._register(this._terminalChatService.onDidRegisterTerminalInstanceWithToolSession(() => this.update()));
-		this._register(this._terminalService.onDidChangeInstances(() => this.update()));
 		this.update();
 	}
 

--- a/src/vs/workbench/contrib/terminal/browser/terminalTabsChatEntry.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalTabsChatEntry.ts
@@ -64,8 +64,7 @@ export class TerminalTabsChatEntry extends Disposable {
 	}
 
 	update(): void {
-		const foregroundInstances = new Set(this._terminalService.foregroundInstances.map(i => i.instanceId));
-		const hiddenChatTerminalCount = this._terminalChatService.getToolSessionTerminalInstances().filter(i => foregroundInstances.has(i.instanceId) === false).length;
+		const hiddenChatTerminalCount = this._terminalChatService.getToolSessionTerminalInstances(true).length;
 		if (hiddenChatTerminalCount <= 0) {
 			this._entry.style.display = 'none';
 			this._label.textContent = '';

--- a/src/vs/workbench/contrib/terminalContrib/chat/browser/terminalChatActions.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chat/browser/terminalChatActions.ts
@@ -313,7 +313,7 @@ registerAction2(class ShowChatTerminalsAction extends Action2 {
 			precondition: ContextKeyExpr.and(TerminalChatContextKeys.hasHiddenChatTerminals, ChatContextKeys.enabled),
 			menu: [{
 				id: MenuId.ViewTitle,
-				when: ContextKeyExpr.and(TerminalChatContextKeys.hasChatTerminals, ContextKeyExpr.equals('view', ChatViewId)),
+				when: ContextKeyExpr.and(TerminalChatContextKeys.hasHiddenChatTerminals, ContextKeyExpr.equals('view', ChatViewId)),
 				group: 'terminal',
 				order: 0,
 				isHiddenByDefault: true

--- a/src/vs/workbench/contrib/terminalContrib/chat/browser/terminalChatService.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chat/browser/terminalChatService.ts
@@ -218,7 +218,7 @@ export class TerminalChatService extends Disposable implements ITerminalChatServ
 	private _updateHasToolTerminalContextKeys(): void {
 		const toolCount = this._terminalInstancesByToolSessionId.size;
 		this._hasToolTerminalContext.set(toolCount > 0);
-		const hiddenToolCount = this.getToolSessionTerminalInstances(true).length;
-		this._hasHiddenToolTerminalContext.set(hiddenToolCount > 0);
+		const hiddenTerminalCount = this.getToolSessionTerminalInstances(true).length;
+		this._hasHiddenToolTerminalContext.set(hiddenTerminalCount > 0);
 	}
 }

--- a/src/vs/workbench/contrib/terminalContrib/chat/browser/terminalChatService.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chat/browser/terminalChatService.ts
@@ -109,7 +109,11 @@ export class TerminalChatService extends Disposable implements ITerminalChatServ
 		return this._terminalInstancesByToolSessionId.get(terminalToolSessionId);
 	}
 
-	getToolSessionTerminalInstances(): readonly ITerminalInstance[] {
+	getToolSessionTerminalInstances(hiddenOnly?: boolean): readonly ITerminalInstance[] {
+		if (hiddenOnly) {
+			const foregroundInstances = new Set(this._terminalService.foregroundInstances.map(i => i.instanceId));
+			return Array.from(this._terminalInstancesByToolSessionId.values()).filter(i => !foregroundInstances.has(i.instanceId));
+		}
 		// Ensure unique instances in case multiple tool sessions map to the same terminal
 		return Array.from(new Set(this._terminalInstancesByToolSessionId.values()));
 	}
@@ -213,8 +217,7 @@ export class TerminalChatService extends Disposable implements ITerminalChatServ
 	private _updateHasToolTerminalContextKeys(): void {
 		const toolCount = this._terminalInstancesByToolSessionId.size;
 		this._hasToolTerminalContext.set(toolCount > 0);
-		const foregroundInstances = new Set(this._terminalService.foregroundInstances.map(i => i.instanceId));
-		const hiddenToolCount = Array.from(this._terminalInstancesByToolSessionId.values()).filter(instance => !foregroundInstances.has(instance.instanceId)).length;
+		const hiddenToolCount = this.getToolSessionTerminalInstances(true).length;
 		this._hasHiddenToolTerminalContext.set(hiddenToolCount > 0);
 	}
 }

--- a/src/vs/workbench/contrib/terminalContrib/chat/browser/terminalChatService.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chat/browser/terminalChatService.ts
@@ -112,7 +112,8 @@ export class TerminalChatService extends Disposable implements ITerminalChatServ
 	getToolSessionTerminalInstances(hiddenOnly?: boolean): readonly ITerminalInstance[] {
 		if (hiddenOnly) {
 			const foregroundInstances = new Set(this._terminalService.foregroundInstances.map(i => i.instanceId));
-			return Array.from(new Set(Array.from(this._terminalInstancesByToolSessionId.values()).filter(i => !foregroundInstances.has(i.instanceId))));
+			const uniqueInstances = new Set(this._terminalInstancesByToolSessionId.values());
+			return Array.from(uniqueInstances).filter(i => !foregroundInstances.has(i.instanceId));
 		}
 		// Ensure unique instances in case multiple tool sessions map to the same terminal
 		return Array.from(new Set(this._terminalInstancesByToolSessionId.values()));

--- a/src/vs/workbench/contrib/terminalContrib/chat/browser/terminalChatService.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chat/browser/terminalChatService.ts
@@ -112,7 +112,7 @@ export class TerminalChatService extends Disposable implements ITerminalChatServ
 	getToolSessionTerminalInstances(hiddenOnly?: boolean): readonly ITerminalInstance[] {
 		if (hiddenOnly) {
 			const foregroundInstances = new Set(this._terminalService.foregroundInstances.map(i => i.instanceId));
-			return Array.from(this._terminalInstancesByToolSessionId.values()).filter(i => !foregroundInstances.has(i.instanceId));
+			return Array.from(new Set(Array.from(this._terminalInstancesByToolSessionId.values()).filter(i => !foregroundInstances.has(i.instanceId))));
 		}
 		// Ensure unique instances in case multiple tool sessions map to the same terminal
 		return Array.from(new Set(this._terminalInstancesByToolSessionId.values()));


### PR DESCRIPTION
address #275789 in main

This specifically fixes the background terminal case, where `onDidChangeInstances` was not firing, so the entry would not get updated.

Also, the `terminalTabbedView` was not updated to only consider `hidden` instances.