### PR TITLE
get placeholder to be read by screen reader for chat inputs

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/contrib/chatInputEditorContrib.ts
+++ b/src/vs/workbench/contrib/chat/browser/contrib/chatInputEditorContrib.ts
@@ -24,6 +24,7 @@ import { IPromptsService } from '../../common/promptSyntax/service/promptsServic
 import { IChatWidget } from '../chat.js';
 import { ChatWidget } from '../chatWidget.js';
 import { dynamicVariableDecorationType } from './chatDynamicVariables.js';
+import { NativeEditContextRegistry } from '../../../../../editor/browser/controller/editContext/native/nativeEditContextRegistry.js';
 
 const decorationDescription = 'chat';
 const placeholderDecorationType = 'chat-session-detail';
@@ -302,15 +303,15 @@ class InputEditorDecorations extends Disposable {
 	}
 
 	private updateAriaPlaceholder(value: string | undefined): void {
-		// eslint-disable-next-line no-restricted-syntax
-		const nativeEditContext = this.widget.inputEditor.getDomNode()?.querySelector<HTMLElement>('.native-edit-context');
-		if (!nativeEditContext) {
+		const nativeEditContext = NativeEditContextRegistry.get(this.widget.inputEditor.getId());
+		const domNode = nativeEditContext?.domNode.domNode;
+		if (!domNode) {
 			return;
 		}
 		if (value && value.trim().length) {
-			nativeEditContext.setAttribute('aria-placeholder', value);
+			domNode.setAttribute('aria-placeholder', value);
 		} else {
-			nativeEditContext.removeAttribute('aria-placeholder');
+			domNode.removeAttribute('aria-placeholder');
 		}
 	}
 }

--- a/src/vs/workbench/contrib/chat/browser/contrib/chatInputEditorContrib.ts
+++ b/src/vs/workbench/contrib/chat/browser/contrib/chatInputEditorContrib.ts
@@ -134,12 +134,14 @@ class InputEditorDecorations extends Disposable {
 
 		const viewModel = this.widget.viewModel;
 		if (!viewModel) {
+			this.updateAriaPlaceholder(undefined);
 			return;
 		}
 
 		if (!inputValue) {
 			const mode = this.widget.input.currentModeObs.get();
 			const placeholder = mode.argumentHint?.get() ?? mode.description.get() ?? '';
+			const displayPlaceholder = viewModel.inputPlaceholder || placeholder;
 
 			const decoration: IDecorationOptions[] = [
 				{
@@ -151,15 +153,18 @@ class InputEditorDecorations extends Disposable {
 					},
 					renderOptions: {
 						after: {
-							contentText: viewModel.inputPlaceholder || placeholder,
+							contentText: displayPlaceholder,
 							color: this.getPlaceholderColor()
 						}
 					}
 				}
 			];
+			this.updateAriaPlaceholder(displayPlaceholder || undefined);
 			this.widget.inputEditor.setDecorationsByType(decorationDescription, placeholderDecorationType, decoration);
 			return;
 		}
+
+		this.updateAriaPlaceholder(undefined);
 
 		const parsedRequest = this.widget.parsedInput.parts;
 
@@ -294,6 +299,19 @@ class InputEditorDecorations extends Disposable {
 		}
 
 		this.widget.inputEditor.setDecorationsByType(decorationDescription, variableTextDecorationType, varDecorations);
+	}
+
+	private updateAriaPlaceholder(value: string | undefined): void {
+		// eslint-disable-next-line no-restricted-syntax
+		const nativeEditContext = this.widget.inputEditor.getDomNode()?.querySelector<HTMLElement>('.native-edit-context');
+		if (!nativeEditContext) {
+			return;
+		}
+		if (value && value.trim().length) {
+			nativeEditContext.setAttribute('aria-placeholder', value);
+		} else {
+			nativeEditContext.removeAttribute('aria-placeholder');
+		}
 	}
 }
 


### PR DESCRIPTION
fix #269070

The active element is this and that lacks aria info. Applies to all chat inputs.

<img width="209" height="61" alt="Screenshot 2025-11-07 at 3 55 45 PM" src="https://github.com/user-attachments/assets/ab3495b1-1dd8-4d13-9f67-782555586bc0" />

Before:

<img width="1136" height="601" alt="Screenshot 2025-11-07 at 3 44 57 PM" src="https://github.com/user-attachments/assets/39c9fa4b-656d-4be8-860b-b4cc51a69b2c" />

After:

<img width="930" height="495" alt="Screenshot 2025-11-07 at 3 44 25 PM" src="https://github.com/user-attachments/assets/2473662d-99e6-4c3f-b93f-93073601775b" />