### PR TITLE
Fix missing NOT

### DIFF
--- a/src/vs/editor/browser/viewParts/viewLines/viewLines.ts
+++ b/src/vs/editor/browser/viewParts/viewLines/viewLines.ts
@@ -541,7 +541,7 @@ export class ViewLines extends ViewPart implements IViewLines {
 			// only proceed if we just did a layout
 			return;
 		}
-		if (this._asyncUpdateLineWidths.isScheduled()) {
+		if (!this._asyncUpdateLineWidths.isScheduled()) {
 			// reading widths is not scheduled => widths are up-to-date
 			return;
 		}


### PR DESCRIPTION
Fixes #203945

An unfortunate 2 year old mistake that would allow updating line widths to piggy back on others doing sync layouts instead of delaying by 200ms -- https://github.com/microsoft/vscode/pull/174266