### PR TITLE
Terminal suggest - include persistent options in suggestions and improve suggestion grouping

### DIFF
--- a/extensions/terminal-suggest/src/fig/figInterface.ts
+++ b/extensions/terminal-suggest/src/fig/figInterface.ts
@@ -341,6 +341,7 @@ export async function collectCompletionItemResult(
 	}
 	if (parsedArguments.suggestionFlags & SuggestionFlag.Options) {
 		await addSuggestions(parsedArguments.completionObj.options, vscode.TerminalCompletionItemKind.Flag, parsedArguments);
+		await addSuggestions(parsedArguments.completionObj.persistentOptions, vscode.TerminalCompletionItemKind.Flag, parsedArguments);
 	}
 
 	return { showFiles, showFolders, fileExtensions };

--- a/extensions/terminal-suggest/src/test/fig.test.ts
+++ b/extensions/terminal-suggest/src/test/fig.test.ts
@@ -192,7 +192,8 @@ export const figGenericTestSuites: ISuiteSpec[] = [
 				description: 'Foo',
 				options: [
 					{ name: '--help', description: 'Show help', isPersistent: true },
-					{ name: '--verbose', description: 'Verbose output', isPersistent: true }
+					{ name: '--docs', description: 'Show docs' },
+					{ name: '--version', description: 'Version info', isPersistent: false }
 				],
 				subcommands: [
 					{
@@ -220,16 +221,16 @@ export const figGenericTestSuites: ISuiteSpec[] = [
 		],
 		availableCommands: 'foo',
 		testSpecs: [
-			// Top-level should show persistent options
-			{ input: 'foo |', expectedCompletions: ['--help', '--verbose', 'bar', 'baz'] },
-			// First-level subcommand should inherit persistent options
-			{ input: 'foo bar |', expectedCompletions: ['--help', '--verbose', '--local'] },
-			// Another first-level subcommand should also inherit persistent options
-			{ input: 'foo baz |', expectedCompletions: ['--help', '--verbose', '--another', 'nested'] },
-			// Nested subcommand should inherit persistent options from parent
-			{ input: 'foo baz nested |', expectedCompletions: ['--help', '--verbose'] },
+			// Top-level should show all options including persistent
+			{ input: 'foo |', expectedCompletions: ['--help', '--docs', '--version', 'bar', 'baz'] },
+			// First-level subcommand should only inherit persistent options (not --docs or --version)
+			{ input: 'foo bar |', expectedCompletions: ['--help', '--local'] },
+			// Another first-level subcommand should also inherit only persistent options
+			{ input: 'foo baz |', expectedCompletions: ['--help', '--another', 'nested'] },
+			// Nested subcommand should inherit persistent options from top level
+			{ input: 'foo baz nested |', expectedCompletions: ['--help'] },
 			// Persistent options should be available even after using local options
-			{ input: 'foo bar --local |', expectedCompletions: ['--help', '--verbose'] },
+			{ input: 'foo bar --local |', expectedCompletions: ['--help'] },
 		]
 	}
 ];

--- a/extensions/terminal-suggest/src/test/fig.test.ts
+++ b/extensions/terminal-suggest/src/test/fig.test.ts
@@ -183,6 +183,55 @@ export const figGenericTestSuites: ISuiteSpec[] = [
 			{ input: 'foo b|', expectedCompletions: ['b', 'foo'] },
 			{ input: 'foo c|', expectedCompletions: ['c', 'foo'] },
 		]
+	},
+	{
+		name: 'Fig persistent options',
+		completionSpecs: [
+			{
+				name: 'foo',
+				description: 'Foo',
+				options: [
+					{ name: '--help', description: 'Show help', isPersistent: true },
+					{ name: '--verbose', description: 'Verbose output', isPersistent: true }
+				],
+				subcommands: [
+					{
+						name: 'bar',
+						description: 'Bar subcommand',
+						options: [
+							{ name: '--local', description: 'Local option' }
+						]
+					},
+					{
+						name: 'baz',
+						description: 'Baz subcommand',
+						options: [
+							{ name: '--another', description: 'Another option' }
+						],
+						subcommands: [
+							{
+								name: 'nested',
+								description: 'Nested subcommand'
+							}
+						]
+					}
+				]
+			}
+		],
+		availableCommands: 'foo',
+		testSpecs: [
+			// Top-level should show persistent options
+			{ input: 'foo |', expectedCompletions: ['--help', '--verbose', 'bar', 'baz'] },
+			// First-level subcommand should inherit persistent options
+			{ input: 'foo bar |', expectedCompletions: ['--help', '--verbose', '--local'] },
+			// Another first-level subcommand should also inherit persistent options
+			{ input: 'foo baz |', expectedCompletions: ['--help', '--verbose', '--another', 'nested'] },
+			// Nested subcommand should inherit persistent options from parent
+			{ input: 'foo baz nested |', expectedCompletions: ['--help', '--verbose'] },
+			// Persistent options should be available even after using local options
+			{ input: 'foo bar --local |', expectedCompletions: ['--help', '--verbose'] },
+		]
 	}
 ];
+
 

--- a/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalCompletionModel.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalCompletionModel.ts
@@ -130,6 +130,12 @@ const compareCompletionsFn = (leadingLineContent: string, a: TerminalCompletionI
 		if ((b.completion.kind === TerminalCompletionItemKind.Method || b.completion.kind === TerminalCompletionItemKind.Alias) && (a.completion.kind !== TerminalCompletionItemKind.Method && a.completion.kind !== TerminalCompletionItemKind.Alias)) {
 			return 1; // Methods and aliases should come first
 		}
+		if (a.completion.kind === TerminalCompletionItemKind.Argument && b.completion.kind !== TerminalCompletionItemKind.Argument) {
+			return -1; // Arguments should come before other kinds
+		}
+		if (b.completion.kind === TerminalCompletionItemKind.Argument && a.completion.kind !== TerminalCompletionItemKind.Argument) {
+			return 1; // Arguments should come before other kinds
+		}
 		if ((a.completion.kind === TerminalCompletionItemKind.File || a.completion.kind === TerminalCompletionItemKind.Folder) && (b.completion.kind !== TerminalCompletionItemKind.File && b.completion.kind !== TerminalCompletionItemKind.Folder)) {
 			return 1; // Resources should come last
 		}

--- a/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalCompletionModel.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalCompletionModel.ts
@@ -136,10 +136,10 @@ const compareCompletionsFn = (leadingLineContent: string, a: TerminalCompletionI
 		if (b.completion.kind === TerminalCompletionItemKind.Argument && a.completion.kind !== TerminalCompletionItemKind.Argument) {
 			return 1; // Arguments should come before other kinds
 		}
-		if ((a.completion.kind === TerminalCompletionItemKind.File || a.completion.kind === TerminalCompletionItemKind.Folder || a.completion.kind === TerminalCompletionItemKind.SymbolicLinkFile || a.completion.kind === TerminalCompletionItemKind.SymbolicLinkFolder) && (b.completion.kind !== TerminalCompletionItemKind.File && b.completion.kind !== TerminalCompletionItemKind.Folder && b.completion.kind !== TerminalCompletionItemKind.SymbolicLinkFile && b.completion.kind !== TerminalCompletionItemKind.SymbolicLinkFolder)) {
+		if (isResourceKind(a.completion.kind) && !isResourceKind(b.completion.kind)) {
 			return 1; // Resources should come last
 		}
-		if ((b.completion.kind === TerminalCompletionItemKind.File || b.completion.kind === TerminalCompletionItemKind.Folder || b.completion.kind === TerminalCompletionItemKind.SymbolicLinkFile || b.completion.kind === TerminalCompletionItemKind.SymbolicLinkFolder) && (a.completion.kind !== TerminalCompletionItemKind.File && a.completion.kind !== TerminalCompletionItemKind.Folder && a.completion.kind !== TerminalCompletionItemKind.SymbolicLinkFile && a.completion.kind !== TerminalCompletionItemKind.SymbolicLinkFolder)) {
+		if (isResourceKind(b.completion.kind) && !isResourceKind(a.completion.kind)) {
 			return -1; // Resources should come last
 		}
 	}
@@ -148,6 +148,12 @@ const compareCompletionsFn = (leadingLineContent: string, a: TerminalCompletionI
 	// all at the top
 	return a.labelLow.localeCompare(b.labelLow, undefined, { ignorePunctuation: true });
 };
+
+const isResourceKind = (kind: TerminalCompletionItemKind | undefined) =>
+	kind === TerminalCompletionItemKind.File ||
+	kind === TerminalCompletionItemKind.Folder ||
+	kind === TerminalCompletionItemKind.SymbolicLinkFile ||
+	kind === TerminalCompletionItemKind.SymbolicLinkFolder;
 
 // TODO: This should be based on the process OS, not the local OS
 // File score boosts for specific file extensions on Windows. This only applies when the file is the

--- a/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalCompletionModel.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalCompletionModel.ts
@@ -136,10 +136,10 @@ const compareCompletionsFn = (leadingLineContent: string, a: TerminalCompletionI
 		if (b.completion.kind === TerminalCompletionItemKind.Argument && a.completion.kind !== TerminalCompletionItemKind.Argument) {
 			return 1; // Arguments should come before other kinds
 		}
-		if ((a.completion.kind === TerminalCompletionItemKind.File || a.completion.kind === TerminalCompletionItemKind.Folder) && (b.completion.kind !== TerminalCompletionItemKind.File && b.completion.kind !== TerminalCompletionItemKind.Folder)) {
+		if ((a.completion.kind === TerminalCompletionItemKind.File || a.completion.kind === TerminalCompletionItemKind.Folder || a.completion.kind === TerminalCompletionItemKind.SymbolicLinkFile || a.completion.kind === TerminalCompletionItemKind.SymbolicLinkFolder) && (b.completion.kind !== TerminalCompletionItemKind.File && b.completion.kind !== TerminalCompletionItemKind.Folder && b.completion.kind !== TerminalCompletionItemKind.SymbolicLinkFile && b.completion.kind !== TerminalCompletionItemKind.SymbolicLinkFolder)) {
 			return 1; // Resources should come last
 		}
-		if ((b.completion.kind === TerminalCompletionItemKind.File || b.completion.kind === TerminalCompletionItemKind.Folder) && (a.completion.kind !== TerminalCompletionItemKind.File && a.completion.kind !== TerminalCompletionItemKind.Folder)) {
+		if ((b.completion.kind === TerminalCompletionItemKind.File || b.completion.kind === TerminalCompletionItemKind.Folder || b.completion.kind === TerminalCompletionItemKind.SymbolicLinkFile || b.completion.kind === TerminalCompletionItemKind.SymbolicLinkFolder) && (a.completion.kind !== TerminalCompletionItemKind.File && a.completion.kind !== TerminalCompletionItemKind.Folder && a.completion.kind !== TerminalCompletionItemKind.SymbolicLinkFile && a.completion.kind !== TerminalCompletionItemKind.SymbolicLinkFolder)) {
 			return -1; // Resources should come last
 		}
 	}

--- a/src/vs/workbench/contrib/terminalContrib/suggest/test/browser/terminalCompletionModel.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/test/browser/terminalCompletionModel.test.ts
@@ -383,11 +383,11 @@ suite('TerminalCompletionModel', function () {
 				createItem({ kind: TerminalCompletionItemKind.Folder, label: 'folder/' }),
 				createItem({ kind: TerminalCompletionItemKind.Option, label: '--option' }),
 				createItem({ kind: TerminalCompletionItemKind.Alias, label: 'alias' }),
-				createItem({ kind: TerminalCompletionItemKind.SymbolicLinkFile, label: 'file-symlink.txt' }),
-				createItem({ kind: TerminalCompletionItemKind.SymbolicLinkFolder, label: 'folder-symlink/' }),
+				createItem({ kind: TerminalCompletionItemKind.SymbolicLinkFile, label: 'file2.txt' }),
+				createItem({ kind: TerminalCompletionItemKind.SymbolicLinkFolder, label: 'folder2/' }),
 			];
 			const model = new TerminalCompletionModel(items, new LineContext('', 0));
-			assertItems(model, ['alias', 'method', 'arg', '--flag', '--option', 'file.txt', 'folder/', 'file-symlink.txt', 'folder-symlink/']);
+			assertItems(model, ['alias', 'method', 'arg', '--flag', '--option', 'file2.txt', 'file.txt', 'folder/', 'folder2/']);
 		});
 	});
 });

--- a/src/vs/workbench/contrib/terminalContrib/suggest/test/browser/terminalCompletionModel.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/test/browser/terminalCompletionModel.test.ts
@@ -383,9 +383,11 @@ suite('TerminalCompletionModel', function () {
 				createItem({ kind: TerminalCompletionItemKind.Folder, label: 'folder/' }),
 				createItem({ kind: TerminalCompletionItemKind.Option, label: '--option' }),
 				createItem({ kind: TerminalCompletionItemKind.Alias, label: 'alias' }),
+				createItem({ kind: TerminalCompletionItemKind.SymbolicLinkFile, label: 'file-symlink.txt' }),
+				createItem({ kind: TerminalCompletionItemKind.SymbolicLinkFolder, label: 'folder-symlink/' }),
 			];
 			const model = new TerminalCompletionModel(items, new LineContext('', 0));
-			assertItems(model, ['alias', 'method', 'arg', '--flag', '--option', 'file.txt', 'folder/']);
+			assertItems(model, ['alias', 'method', 'arg', '--flag', '--option', 'file.txt', 'folder/', 'file-symlink.txt', 'folder-symlink/']);
 		});
 	});
 });

--- a/src/vs/workbench/contrib/terminalContrib/suggest/test/browser/terminalCompletionModel.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/test/browser/terminalCompletionModel.test.ts
@@ -360,4 +360,33 @@ suite('TerminalCompletionModel', function () {
 			assertItems(model, ['main', 'master', 'dev']);
 		});
 	});
+
+	suite('mixed kind sorting', () => {
+		test('should sort arguments before flags and options', () => {
+			const items = [
+				createItem({ kind: TerminalCompletionItemKind.Flag, label: '--verbose' }),
+				createItem({ kind: TerminalCompletionItemKind.Option, label: '--config' }),
+				createItem({ kind: TerminalCompletionItemKind.Argument, label: 'value2' }),
+				createItem({ kind: TerminalCompletionItemKind.Argument, label: 'value1' }),
+				createItem({ kind: TerminalCompletionItemKind.Flag, label: '--all' }),
+			];
+			const model = new TerminalCompletionModel(items, new LineContext('cmd ', 0));
+			assertItems(model, ['value1', 'value2', '--all', '--config', '--verbose']);
+		});
+
+		test('should sort by kind hierarchy: methods/aliases, arguments, others, files/folders', () => {
+			const items = [
+				createItem({ kind: TerminalCompletionItemKind.File, label: 'file.txt' }),
+				createItem({ kind: TerminalCompletionItemKind.Flag, label: '--flag' }),
+				createItem({ kind: TerminalCompletionItemKind.Argument, label: 'arg' }),
+				createItem({ kind: TerminalCompletionItemKind.Method, label: 'method' }),
+				createItem({ kind: TerminalCompletionItemKind.Folder, label: 'folder/' }),
+				createItem({ kind: TerminalCompletionItemKind.Option, label: '--option' }),
+				createItem({ kind: TerminalCompletionItemKind.Alias, label: 'alias' }),
+			];
+			const model = new TerminalCompletionModel(items, new LineContext('', 0));
+			assertItems(model, ['alias', 'method', 'arg', '--flag', '--option', 'file.txt', 'folder/']);
+		});
+	});
 });
+


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Fixes #272352 
Arguments are now grouped together instead of being mixed with flags/options:
<img width="978" height="510" alt="arg-grouped" src="https://github.com/user-attachments/assets/b06814cf-1fe8-4ff9-a160-a40bf14f827f" />


Fixes #276406
Symlink files and folders are now grouped together with regular files and folders
![symlinks](https://github.com/user-attachments/assets/07ae0788-1e94-4cb6-ad3b-1e5083fbe6b7)


Fixes #276407
Options marked with `isPersistent: true` are now shown in suggestions:
![persistent](https://github.com/user-attachments/assets/f399532a-0eeb-44fa-97a7-7080862b27d2)

