### PR TITLE
Clear attachPersistantProcess for relaunch

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
@@ -1826,7 +1826,12 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 
 	@debounce(1000)
 	relaunch(): void {
-		this.reuseTerminal(this._shellLaunchConfig, true);
+		// Clear the attachPersistentProcess flag to ensure we create a new process
+		// instead of trying to reattach to the existing one during relaunch.
+		const shellLaunchConfig = { ...this._shellLaunchConfig };
+		delete shellLaunchConfig.attachPersistentProcess;
+
+		this.reuseTerminal(shellLaunchConfig, true);
 	}
 
 	private _onTitleChange(title: string): void {


### PR DESCRIPTION
Resolves: https://github.com/microsoft/vscode/issues/228359 
Was able to repro on Windows, specifically when `relaunch terminal` right after reloading window or restarting VS Code.
 - Bug doesnt occur if I open new terminal before relaunching the terminal with warning sign.
 

I thought the `attachPersistentProcess` is only meant for initial revival/restoration after reload, not for user-initiated relaunches.

I think the problem is that we try to shutdown process and attach to that same process because `attachPersistentProcess` gets passed on relaunch.

