### PR TITLE
IWebWorkerDescriptor -> WebWorkerDescriptor

### DIFF
--- a/src/vs/editor/browser/services/editorWorkerService.ts
+++ b/src/vs/editor/browser/services/editorWorkerService.ts
@@ -7,7 +7,7 @@ import { timeout } from '../../../base/common/async.js';
 import { Disposable, IDisposable } from '../../../base/common/lifecycle.js';
 import { URI } from '../../../base/common/uri.js';
 import { logOnceWebWorkerWarning, IWebWorkerClient, Proxied } from '../../../base/common/worker/webWorker.js';
-import { createWebWorker, IWebWorkerDescriptor } from '../../../base/browser/webWorkerFactory.js';
+import { createWebWorker, WebWorkerDescriptor } from '../../../base/browser/webWorkerFactory.js';
 import { Position } from '../../common/core/position.js';
 import { IRange, Range } from '../../common/core/range.js';
 import { ITextModel } from '../../common/model.js';
@@ -52,7 +52,7 @@ function canSyncModel(modelService: IModelService, resource: URI): boolean {
 	return true;
 }
 
-export abstract class EditorWorkerService extends Disposable implements IEditorWorkerService {
+export class EditorWorkerService extends Disposable implements IEditorWorkerService {
 
 	declare readonly _serviceBrand: undefined;
 
@@ -61,7 +61,7 @@ export abstract class EditorWorkerService extends Disposable implements IEditorW
 	private readonly _logService: ILogService;
 
 	constructor(
-		workerDescriptor: IWebWorkerDescriptor,
+		workerDescriptor: WebWorkerDescriptor,
 		@IModelService modelService: IModelService,
 		@ITextResourceConfigurationService configurationService: ITextResourceConfigurationService,
 		@ILogService logService: ILogService,
@@ -330,7 +330,7 @@ class WorkerManager extends Disposable {
 	private _lastWorkerUsedTime: number;
 
 	constructor(
-		private readonly _workerDescriptor: IWebWorkerDescriptor,
+		private readonly _workerDescriptor: WebWorkerDescriptor,
 		@IModelService modelService: IModelService
 	) {
 		super();
@@ -427,7 +427,7 @@ export class EditorWorkerClient extends Disposable implements IEditorWorkerClien
 	private _disposed = false;
 
 	constructor(
-		private readonly _workerDescriptorOrWorker: IWebWorkerDescriptor | Worker | Promise<Worker>,
+		private readonly _workerDescriptorOrWorker: WebWorkerDescriptor | Worker | Promise<Worker>,
 		keepIdleModels: boolean,
 		@IModelService modelService: IModelService,
 	) {

--- a/src/vs/editor/standalone/browser/standaloneServices.ts
+++ b/src/vs/editor/standalone/browser/standaloneServices.ts
@@ -97,7 +97,7 @@ import { onUnexpectedError } from '../../../base/common/errors.js';
 import { ExtensionKind, IEnvironmentService, IExtensionHostDebugParams } from '../../../platform/environment/common/environment.js';
 import { mainWindow } from '../../../base/browser/window.js';
 import { ResourceMap } from '../../../base/common/map.js';
-import { IWebWorkerDescriptor } from '../../../base/browser/webWorkerFactory.js';
+import { WebWorkerDescriptor } from '../../../base/browser/webWorkerFactory.js';
 import { ITreeSitterLibraryService } from '../../common/services/treeSitter/treeSitterLibraryService.js';
 import { StandaloneTreeSitterLibraryService } from './standaloneTreeSitterLibraryService.js';
 import { IDataChannelService, NullDataChannelService } from '../../../platform/dataChannel/common/dataChannel.js';
@@ -1075,10 +1075,10 @@ class StandaloneContextMenuService extends ContextMenuService {
 	}
 }
 
-const standaloneEditorWorkerDescriptor: IWebWorkerDescriptor = {
+const standaloneEditorWorkerDescriptor = new WebWorkerDescriptor({
 	esmModuleLocation: undefined,
 	label: 'editorWorkerService'
-};
+});
 
 class StandaloneEditorWorkerService extends EditorWorkerService {
 	constructor(

--- a/src/vs/platform/profiling/electron-browser/profileAnalysisWorkerService.ts
+++ b/src/vs/platform/profiling/electron-browser/profileAnalysisWorkerService.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 
-import { createWebWorker } from '../../../base/browser/webWorkerFactory.js';
+import { createWebWorker, WebWorkerDescriptor } from '../../../base/browser/webWorkerFactory.js';
 import { URI } from '../../../base/common/uri.js';
 import { Proxied } from '../../../base/common/worker/webWorker.js';
 import { InstantiationType, registerSingleton } from '../../instantiation/common/extensions.js';
@@ -49,8 +49,10 @@ class ProfileAnalysisWorkerService implements IProfileAnalysisWorkerService {
 	private async _withWorker<R>(callback: (worker: Proxied<IProfileAnalysisWorker>) => Promise<R>): Promise<R> {
 
 		const worker = createWebWorker<IProfileAnalysisWorker>(
-			FileAccess.asBrowserUri('vs/platform/profiling/electron-browser/profileAnalysisWorkerMain.js'),
-			'CpuProfileAnalysisWorker'
+			new WebWorkerDescriptor({
+				esmModuleLocation: FileAccess.asBrowserUri('vs/platform/profiling/electron-browser/profileAnalysisWorkerMain.js'),
+				label: 'CpuProfileAnalysisWorker'
+			})
 		);
 
 		try {

--- a/src/vs/workbench/contrib/codeEditor/browser/workbenchEditorWorkerService.ts
+++ b/src/vs/workbench/contrib/codeEditor/browser/workbenchEditorWorkerService.ts
@@ -20,7 +20,11 @@ export class WorkbenchEditorWorkerService extends EditorWorkerService {
 		@ILanguageConfigurationService languageConfigurationService: ILanguageConfigurationService,
 		@ILanguageFeaturesService languageFeaturesService: ILanguageFeaturesService,
 	) {
-		const workerDescriptor = new WebWorkerDescriptor(FileAccess.asBrowserUri('vs/editor/common/services/editorWebWorkerMain.js'), 'TextEditorWorker');
+		const workerDescriptor = new WebWorkerDescriptor({
+			esmModuleLocation: FileAccess.asBrowserUri('vs/editor/common/services/editorWebWorkerMain.js'),
+			label: 'TextEditorWorker',
+		});
+
 		super(workerDescriptor, modelService, configurationService, logService, languageConfigurationService, languageFeaturesService);
 	}
 }

--- a/src/vs/workbench/contrib/notebook/browser/services/notebookWorkerServiceImpl.ts
+++ b/src/vs/workbench/contrib/notebook/browser/services/notebookWorkerServiceImpl.ts
@@ -6,7 +6,7 @@
 import { Disposable, DisposableStore, dispose, IDisposable, toDisposable } from '../../../../../base/common/lifecycle.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { IWebWorkerClient, Proxied } from '../../../../../base/common/worker/webWorker.js';
-import { createWebWorker } from '../../../../../base/browser/webWorkerFactory.js';
+import { createWebWorker, WebWorkerDescriptor } from '../../../../../base/browser/webWorkerFactory.js';
 import { NotebookCellTextModel } from '../../common/model/notebookCellTextModel.js';
 import { CellUri, IMainCellDto, INotebookDiffResult, NotebookCellsChangeType, NotebookRawContentEventDto } from '../../common/notebookCommon.js';
 import { INotebookService } from '../../common/notebookService.js';
@@ -274,8 +274,10 @@ class NotebookWorkerClient extends Disposable {
 		if (!this._worker) {
 			try {
 				this._worker = this._register(createWebWorker<NotebookWorker>(
-					FileAccess.asBrowserUri('vs/workbench/contrib/notebook/common/services/notebookWebWorkerMain.js'),
-					'NotebookEditorWorker'
+					new WebWorkerDescriptor({
+						esmModuleLocation: FileAccess.asBrowserUri('vs/workbench/contrib/notebook/common/services/notebookWebWorkerMain.js'),
+						label: 'NotebookEditorWorker'
+					})
 				));
 			} catch (err) {
 				throw (err);

--- a/src/vs/workbench/contrib/output/browser/outputLinkProvider.ts
+++ b/src/vs/workbench/contrib/output/browser/outputLinkProvider.ts
@@ -12,7 +12,7 @@ import { OUTPUT_MODE_ID, LOG_MODE_ID } from '../../../services/output/common/out
 import { OutputLinkComputer } from '../common/outputLinkComputer.js';
 import { IDisposable, dispose, Disposable } from '../../../../base/common/lifecycle.js';
 import { ILanguageFeaturesService } from '../../../../editor/common/services/languageFeatures.js';
-import { createWebWorker } from '../../../../base/browser/webWorkerFactory.js';
+import { createWebWorker, WebWorkerDescriptor } from '../../../../base/browser/webWorkerFactory.js';
 import { IWebWorkerClient } from '../../../../base/common/worker/webWorker.js';
 import { WorkerTextModelSyncClient } from '../../../../editor/common/services/textModelSync/textModelSync.impl.js';
 import { FileAccess } from '../../../../base/common/network.js';
@@ -99,8 +99,10 @@ class OutputLinkWorkerClient extends Disposable {
 	) {
 		super();
 		this._workerClient = this._register(createWebWorker<OutputLinkComputer>(
-			FileAccess.asBrowserUri('vs/workbench/contrib/output/common/outputLinkComputerMain.js'),
-			'OutputLinkDetectionWorker'
+			new WebWorkerDescriptor({
+				esmModuleLocation: FileAccess.asBrowserUri('vs/workbench/contrib/output/common/outputLinkComputerMain.js'),
+				label: 'OutputLinkDetectionWorker'
+			})
 		));
 		this._workerTextModelSyncClient = this._register(WorkerTextModelSyncClient.create(this._workerClient, modelService));
 		this._initializeBarrier = this._ensureWorkspaceFolders();

--- a/src/vs/workbench/services/languageDetection/browser/languageDetectionWorkerServiceImpl.ts
+++ b/src/vs/workbench/services/languageDetection/browser/languageDetectionWorkerServiceImpl.ts
@@ -22,7 +22,7 @@ import { IStorageService, StorageScope, StorageTarget } from '../../../../platfo
 import { LRUCache } from '../../../../base/common/map.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
 import { canASAR } from '../../../../amdX.js';
-import { createWebWorker } from '../../../../base/browser/webWorkerFactory.js';
+import { createWebWorker, WebWorkerDescriptor } from '../../../../base/browser/webWorkerFactory.js';
 import { WorkerTextModelSyncClient } from '../../../../editor/common/services/textModelSync/textModelSync.impl.js';
 import { ILanguageDetectionWorker, LanguageDetectionWorkerHost } from './languageDetectionWorker.protocol.js';
 
@@ -201,8 +201,10 @@ export class LanguageDetectionWorkerClient extends Disposable {
 	} {
 		if (!this.worker) {
 			const workerClient = this._register(createWebWorker<ILanguageDetectionWorker>(
-				FileAccess.asBrowserUri('vs/workbench/services/languageDetection/browser/languageDetectionWebWorkerMain.js'),
-				'LanguageDetectionWorker'
+				new WebWorkerDescriptor({
+					esmModuleLocation: FileAccess.asBrowserUri('vs/workbench/services/languageDetection/browser/languageDetectionWebWorkerMain.js'),
+					label: 'LanguageDetectionWorker'
+				})
 			));
 			LanguageDetectionWorkerHost.setChannel(workerClient, {
 				$getIndexJsUri: async () => this.getIndexJsUri(),

--- a/src/vs/workbench/services/search/browser/searchService.ts
+++ b/src/vs/workbench/services/search/browser/searchService.ts
@@ -16,7 +16,7 @@ import { SearchService } from '../common/searchService.js';
 import { IUriIdentityService } from '../../../../platform/uriIdentity/common/uriIdentity.js';
 import { IWebWorkerClient, logOnceWebWorkerWarning } from '../../../../base/common/worker/webWorker.js';
 import { Disposable, DisposableStore } from '../../../../base/common/lifecycle.js';
-import { createWebWorker } from '../../../../base/browser/webWorkerFactory.js';
+import { createWebWorker, WebWorkerDescriptor } from '../../../../base/browser/webWorkerFactory.js';
 import { InstantiationType, registerSingleton } from '../../../../platform/instantiation/common/extensions.js';
 import { ILocalFileSearchWorker, LocalFileSearchWorkerHost } from '../common/localFileSearchWorkerTypes.js';
 import { memoize } from '../../../../base/common/decorators.js';
@@ -188,8 +188,10 @@ export class LocalFileSearchWorkerClient extends Disposable implements ISearchRe
 		if (!this._worker) {
 			try {
 				this._worker = this._register(createWebWorker<ILocalFileSearchWorker>(
-					FileAccess.asBrowserUri('vs/workbench/services/search/worker/localFileSearchMain.js'),
-					'LocalFileSearchWorker'
+					new WebWorkerDescriptor({
+						esmModuleLocation: FileAccess.asBrowserUri('vs/workbench/services/search/worker/localFileSearchMain.js'),
+						label: 'LocalFileSearchWorker'
+					})
 				));
 				LocalFileSearchWorkerHost.setChannel(this._worker, {
 					$sendTextSearchMatch: (match, queryId) => {

--- a/src/vs/workbench/services/textMate/browser/backgroundTokenization/threadedBackgroundTokenizerFactory.ts
+++ b/src/vs/workbench/services/textMate/browser/backgroundTokenization/threadedBackgroundTokenizerFactory.ts
@@ -22,7 +22,7 @@ import { TextMateWorkerHost } from './worker/textMateWorkerHost.js';
 import { TextMateWorkerTokenizerController } from './textMateWorkerTokenizerController.js';
 import { IValidGrammarDefinition } from '../../common/TMScopeRegistry.js';
 import type { IRawTheme } from 'vscode-textmate';
-import { createWebWorker } from '../../../../../base/browser/webWorkerFactory.js';
+import { createWebWorker, WebWorkerDescriptor } from '../../../../../base/browser/webWorkerFactory.js';
 import { IWebWorkerClient, Proxied } from '../../../../../base/common/worker/webWorker.js';
 
 export class ThreadedBackgroundTokenizerFactory implements IDisposable {
@@ -138,8 +138,10 @@ export class ThreadedBackgroundTokenizerFactory implements IDisposable {
 			onigurumaWASMUri: FileAccess.asBrowserUri(onigurumaWASM).toString(true),
 		};
 		const worker = this._worker = createWebWorker<TextMateTokenizationWorker>(
-			FileAccess.asBrowserUri('vs/workbench/services/textMate/browser/backgroundTokenization/worker/textMateTokenizationWorker.workerMain.js'),
-			'TextMateWorker'
+			new WebWorkerDescriptor({
+				esmModuleLocation: FileAccess.asBrowserUri('vs/workbench/services/textMate/browser/backgroundTokenization/worker/textMateTokenizationWorker.workerMain.js'),
+				label: 'TextMateWorker'
+			})
 		);
 		TextMateWorkerHost.setChannel(worker, {
 			$readFile: async (_resource: UriComponents): Promise<string> => {


### PR DESCRIPTION
This change ensures that every place that references a webworker entrypoint goes through `WebWorkerDescriptor` (before it was `IWebWorkerDescriptor` and `createWebWorker`).
(This is to prepare unification of standalone/workbench editor worker service and to prepare a way to allow WebWorkerDescriptors to reference the web worker in a way that modern bundlers understand it)