### PR TITLE
Mark Cursor mdc files as markdown

### DIFF
--- a/extensions/markdown-basics/package.json
+++ b/extensions/markdown-basics/package.json
@@ -28,6 +28,9 @@
           ".mdtext",
           ".workbook"
         ],
+        "filenamePatterns": [
+          "**/.cursor/rules/*.mdc"
+        ],
         "configuration": "./language-configuration.json"
       }
     ],

--- a/extensions/markdown-basics/package.json
+++ b/extensions/markdown-basics/package.json
@@ -29,7 +29,7 @@
           ".workbook"
         ],
         "filenamePatterns": [
-          "**/.cursor/rules/*.mdc"
+          "**/.cursor/**/*.mdc"
         ],
         "configuration": "./language-configuration.json"
       }


### PR DESCRIPTION
The Cursor editor uses `.mdc` files to configure its LLM. It uses the markdown language ID for these files. People tend to commit these files. For users whose coworkers use Cursor, it’s nice if VSCode also uses the markdown language ID for these files.