### PR TITLE
fix: memory leak in breadcrumbs

### DIFF
--- a/src/vs/workbench/browser/parts/editor/breadcrumbsControl.ts
+++ b/src/vs/workbench/browser/parts/editor/breadcrumbsControl.ts
@@ -317,6 +317,8 @@ export class BreadcrumbsControl {
 		this._ckBreadcrumbsActive.reset();
 		this._cfUseQuickPick.dispose();
 		this._cfShowIcons.dispose();
+		this._cfTitleScrollbarSizing.dispose();
+		this._cfTitleScrollbarVisibility.dispose();
 		this._widget.dispose();
 		this._labels.dispose();
 		this.domNode.remove();


### PR DESCRIPTION
## Before

When opening and closing the Markdown Preview, the number of breadcrumb functions grows each time, https://simonsiefke.github.io/vscode-memory-leak-finder/named-function-count-3/

<img width="1816" height="482" alt="breadcrumbs" src="https://github.com/user-attachments/assets/cc7d77fc-e804-4df1-99b5-51c0253a512e" />


## After

When opening and closing the Markdown Preview, the number of breadcrumb functions stays constant.

![markdown-preview open](https://github.com/user-attachments/assets/a9f70892-0493-4a77-9031-596c434131fd)

