### PR TITLE
store command and output so it can persist when the terminal is killed

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart.ts
@@ -323,7 +323,7 @@ export class ChatTerminalToolProgressPart extends BaseChatToolInvocationSubPart 
 				this._terminalInstance = undefined;
 			}
 			commandDetectionListener.clear();
-			this._actionBar.value?.clear();
+			this._actionBar.value.clear();
 			this._focusAction.clear();
 			this._showOutputActionAdded = false;
 			this._showOutputAction.clear();

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart.ts
@@ -323,7 +323,7 @@ export class ChatTerminalToolProgressPart extends BaseChatToolInvocationSubPart 
 				this._terminalInstance = undefined;
 			}
 			commandDetectionListener.clear();
-			this._actionBar.value.clear();
+			this._actionBar.value?.clear();
 			this._focusAction.clear();
 			this._showOutputActionAdded = false;
 			this._showOutputAction.clear();

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart.ts
@@ -35,6 +35,7 @@ import { localize } from '../../../../../../nls.js';
 import { TerminalLocation } from '../../../../../../platform/terminal/common/terminal.js';
 import { ITerminalCommand, TerminalCapability, type ICommandDetectionCapability } from '../../../../../../platform/terminal/common/capabilities/capabilities.js';
 import { IMarkdownRenderer } from '../../../../../../platform/markdown/browser/markdownRenderer.js';
+import { URI } from '../../../../../../base/common/uri.js';
 import * as domSanitize from '../../../../../../base/browser/domSanitize.js';
 import { DomSanitizerConfig } from '../../../../../../base/browser/domSanitize.js';
 import { allowedMarkdownHtmlAttributes } from '../../../../../../base/browser/markdownRenderer.js';
@@ -69,6 +70,8 @@ export class ChatTerminalToolProgressPart extends BaseChatToolInvocationSubPart 
 	private readonly _focusAction = this._register(new MutableDisposable<FocusChatInstanceAction>());
 
 	private readonly _terminalData: IChatTerminalToolInvocationData;
+	private readonly _terminalCommandUri: URI | undefined;
+	private readonly _storedCommandId: string | undefined;
 	private _terminalInstance: ITerminalInstance | undefined;
 
 	private markdownPart: ChatMarkdownContentPart | undefined;
@@ -93,6 +96,8 @@ export class ChatTerminalToolProgressPart extends BaseChatToolInvocationSubPart 
 
 		terminalData = migrateLegacyTerminalToolSpecificData(terminalData);
 		this._terminalData = terminalData;
+		this._terminalCommandUri = terminalData.terminalCommandUri ? URI.revive(terminalData.terminalCommandUri) : undefined;
+		this._storedCommandId = this._terminalCommandUri ? new URLSearchParams(this._terminalCommandUri.query ?? '').get('command') ?? undefined : undefined;
 
 		const elements = h('.chat-terminal-content-part@container', [
 			h('.chat-terminal-content-title@title'),
@@ -170,19 +175,32 @@ export class ChatTerminalToolProgressPart extends BaseChatToolInvocationSubPart 
 
 		const terminalToolSessionId = this._terminalData.terminalToolSessionId;
 		if (!terminalToolSessionId) {
+			this._addActions();
 			return;
 		}
 
 		const attachInstance = async (instance: ITerminalInstance | undefined) => {
-			if (!instance || this._terminalInstance === instance || this._store.isDisposed) {
+			if (this._store.isDisposed) {
+				return;
+			}
+			if (!instance) {
+				this._addActions(undefined, terminalToolSessionId);
+				return;
+			}
+			if (this._terminalInstance === instance) {
 				return;
 			}
 			this._terminalInstance = instance;
 			this._registerInstanceListener(instance);
+			this._addActions(instance, terminalToolSessionId);
 		};
 
 		const initialInstance = await this._terminalChatService.getTerminalInstanceByToolSessionId(terminalToolSessionId);
 		await attachInstance(initialInstance);
+
+		if (!initialInstance) {
+			this._addActions(undefined, terminalToolSessionId);
+		}
 
 		if (this._store.isDisposed) {
 			return;
@@ -198,13 +216,11 @@ export class ChatTerminalToolProgressPart extends BaseChatToolInvocationSubPart 
 		}));
 	}
 
-	private async _addActions(terminalInstance: ITerminalInstance, terminalToolSessionId: string) {
-		if (!this._actionBar.value) {
+	private _addActions(terminalInstance?: ITerminalInstance, terminalToolSessionId?: string): void {
+		if (!this._actionBar.value || this._store.isDisposed) {
 			return;
 		}
 		const actionBar = this._actionBar.value;
-		const isTerminalHidden = this._terminalChatService.isBackgroundTerminal(terminalToolSessionId);
-		const command = this._getResolvedCommand(terminalInstance);
 		const existingFocus = this._focusAction.value;
 		if (existingFocus) {
 			const existingIndex = actionBar.viewItems.findIndex(item => item.action === existingFocus);
@@ -212,10 +228,26 @@ export class ChatTerminalToolProgressPart extends BaseChatToolInvocationSubPart 
 				actionBar.pull(existingIndex);
 			}
 		}
-		const focusAction = this._instantiationService.createInstance(FocusChatInstanceAction, terminalInstance, command, isTerminalHidden);
-		this._focusAction.value = focusAction;
-		actionBar.push(focusAction, { icon: true, label: false, index: 0 });
+
+		const resolvedCommand = this._getResolvedCommand(terminalInstance);
+		if (terminalInstance) {
+			const isTerminalHidden = terminalToolSessionId ? this._terminalChatService.isBackgroundTerminal(terminalToolSessionId) : false;
+			const focusAction = this._instantiationService.createInstance(FocusChatInstanceAction, terminalInstance, resolvedCommand, isTerminalHidden);
+			this._focusAction.value = focusAction;
+			actionBar.push(focusAction, { icon: true, label: false, index: 0 });
+		} else {
+			this._focusAction.clear();
+		}
+
 		this._ensureShowOutputAction();
+	}
+
+	private _getResolvedCommand(instance?: ITerminalInstance): ITerminalCommand | undefined {
+		const target = instance ?? this._terminalInstance;
+		if (!target) {
+			return undefined;
+		}
+		return this._resolveCommand(target);
 	}
 
 	private _ensureShowOutputAction(): void {
@@ -223,14 +255,15 @@ export class ChatTerminalToolProgressPart extends BaseChatToolInvocationSubPart 
 			return;
 		}
 		const command = this._getResolvedCommand();
-		if (!command) {
+		const hasStoredOutput = !!this._terminalData.terminalCommandOutput;
+		if (!command && !hasStoredOutput) {
 			return;
 		}
 		let showOutputAction = this._showOutputAction.value;
 		if (!showOutputAction) {
 			showOutputAction = new ToggleChatTerminalOutputAction(expanded => this._toggleOutput(expanded));
 			this._showOutputAction.value = showOutputAction;
-			if (command.exitCode) {
+			if (command?.exitCode) {
 				this._toggleOutput(true);
 			}
 		}
@@ -254,19 +287,11 @@ export class ChatTerminalToolProgressPart extends BaseChatToolInvocationSubPart 
 		this._showOutputActionAdded = true;
 	}
 
-	private _getResolvedCommand(instance?: ITerminalInstance): ITerminalCommand | undefined {
-		const target = instance ?? this._terminalInstance;
-		if (!target) {
-			return undefined;
-		}
-		return this._resolveCommand(target);
-	}
-
-	private _registerInstanceListener(terminalInstance: ITerminalInstance) {
+	private _registerInstanceListener(terminalInstance: ITerminalInstance): void {
 		const commandDetectionListener = this._register(new MutableDisposable<IDisposable>());
 		const tryResolveCommand = async (): Promise<ITerminalCommand | undefined> => {
 			const resolvedCommand = this._resolveCommand(terminalInstance);
-			await this._addActions(terminalInstance, this._terminalData.terminalToolSessionId!);
+			this._addActions(terminalInstance, this._terminalData.terminalToolSessionId);
 			return resolvedCommand;
 		};
 
@@ -278,7 +303,7 @@ export class ChatTerminalToolProgressPart extends BaseChatToolInvocationSubPart 
 			}
 
 			commandDetectionListener.value = commandDetection.onCommandFinished(() => {
-				this._addActions(terminalInstance, this._terminalData.terminalToolSessionId!);
+				this._addActions(terminalInstance, this._terminalData.terminalToolSessionId);
 				commandDetectionListener.clear();
 			});
 			const resolvedImmediately = await tryResolveCommand();
@@ -288,22 +313,18 @@ export class ChatTerminalToolProgressPart extends BaseChatToolInvocationSubPart 
 		};
 
 		attachCommandDetection(terminalInstance.capabilities.get(TerminalCapability.CommandDetection));
-		this._register(terminalInstance.capabilities.onDidAddCommandDetectionCapability(cd => attachCommandDetection(cd)));
-
-		this._register(this._terminalChatService.onDidRegisterTerminalInstanceWithToolSession(async () => {
-			await this._addActions(terminalInstance, this._terminalData.terminalToolSessionId!);
-		}));
+		this._register(terminalInstance.capabilities.onDidAddCommandDetectionCapability(cd => void attachCommandDetection(cd)));
 
 		const instanceListener = this._register(terminalInstance.onDisposed(() => {
 			if (this._terminalInstance === terminalInstance) {
 				this._terminalInstance = undefined;
 			}
 			commandDetectionListener.clear();
-			this._actionBar.clear();
+			this._actionBar.value?.clear();
 			this._focusAction.clear();
 			this._showOutputActionAdded = false;
 			this._showOutputAction.clear();
-			this._ensureShowOutputAction();
+			this._addActions(undefined, this._terminalData.terminalToolSessionId);
 			instanceListener.dispose();
 		}));
 	}
@@ -347,19 +368,16 @@ export class ChatTerminalToolProgressPart extends BaseChatToolInvocationSubPart 
 			return false;
 		}
 
-		if (!this._terminalData.terminalToolSessionId) {
-			return false;
-		}
-
-		if (!this._terminalInstance) {
+		if (!this._terminalInstance && this._terminalData.terminalToolSessionId) {
 			this._terminalInstance = await this._terminalChatService.getTerminalInstanceByToolSessionId(this._terminalData.terminalToolSessionId);
 		}
 		const output = await this._collectOutput(this._terminalInstance);
-		if (!output) {
+		const serializedOutput = output ?? this._getStoredCommandOutput();
+		if (!serializedOutput) {
 			return false;
 		}
-		const content = this._renderOutput(output);
-		const theme = this._terminalInstance?.xterm?.getXtermTheme();
+		const content = this._renderOutput(serializedOutput);
+		const theme = this._terminalInstance?.xterm?.getXtermTheme() ?? this._terminalData.terminalTheme;
 		if (theme && !content.classList.contains('chat-terminal-output-content-empty')) {
 			// eslint-disable-next-line no-restricted-syntax
 			const inlineTerminal = content.querySelector('div');
@@ -453,12 +471,27 @@ export class ChatTerminalToolProgressPart extends BaseChatToolInvocationSubPart 
 		if (!commands || commands.length === 0 || !terminalInstance || !xterm) {
 			return;
 		}
-		const command = commands.find(c => c.id === this._terminalData.terminalCommandId);
+		const commandId = this._terminalData.terminalCommandId ?? this._storedCommandId;
+		if (!commandId) {
+			return;
+		}
+		const command = commands.find(c => c.id === commandId);
 		if (!command?.endMarker) {
 			return;
 		}
 		const result = await xterm.getCommandOutputAsHtml(command, CHAT_TERMINAL_OUTPUT_MAX_PREVIEW_LINES);
 		return { text: result.text, truncated: result.truncated ?? false };
+	}
+
+	private _getStoredCommandOutput(): { text: string; truncated: boolean } | undefined {
+		const stored = this._terminalData.terminalCommandOutput;
+		if (!stored?.text) {
+			return undefined;
+		}
+		return {
+			text: stored.text,
+			truncated: stored.truncated ?? false
+		};
 	}
 
 	private _renderOutput(result: { text: string; truncated: boolean }): HTMLElement {
@@ -595,7 +628,7 @@ export class FocusChatInstanceAction extends Action implements IAction {
 			await this._terminalGroupService.showPanel(true);
 		}
 		this._terminalService.setActiveInstance(this._instance);
-		await this._instance?.focusWhenReady(true);
+		await this._instance.focusWhenReady(true);
 		if (this._command) {
 			this._instance.xterm?.markTracker.revealCommand(this._command);
 		}

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart.ts
@@ -231,10 +231,10 @@ export class ChatTerminalToolProgressPart extends BaseChatToolInvocationSubPart 
 			}
 		}
 
-		const resolvedCommand = this._getResolvedCommand(terminalInstance);
 		const canFocus = !!terminalInstance || (this._isSerializedInvocation && !!this._terminalCommandUri);
 		if (canFocus) {
 			const isTerminalHidden = terminalInstance && terminalToolSessionId ? this._terminalChatService.isBackgroundTerminal(terminalToolSessionId) : false;
+			const resolvedCommand = this._getResolvedCommand(terminalInstance);
 			const focusAction = this._instantiationService.createInstance(FocusChatInstanceAction, terminalInstance, resolvedCommand, this._terminalCommandUri, this._storedCommandId, isTerminalHidden);
 			this._focusAction.value = focusAction;
 			actionBar.push(focusAction, { icon: true, label: false, index: 0 });

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart.ts
@@ -316,7 +316,7 @@ export class ChatTerminalToolProgressPart extends BaseChatToolInvocationSubPart 
 		};
 
 		attachCommandDetection(terminalInstance.capabilities.get(TerminalCapability.CommandDetection));
-		this._register(terminalInstance.capabilities.onDidAddCommandDetectionCapability(cd => void attachCommandDetection(cd)));
+		this._register(terminalInstance.capabilities.onDidAddCommandDetectionCapability(cd => attachCommandDetection(cd)));
 
 		const instanceListener = this._register(terminalInstance.onDisposed(() => {
 			if (this._terminalInstance === terminalInstance) {

--- a/src/vs/workbench/contrib/chat/common/chatService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService.ts
@@ -316,6 +316,19 @@ export interface IChatTerminalToolInvocationData {
 	terminalToolSessionId?: string;
 	/** The predefined command ID that will be used for this terminal command */
 	terminalCommandId?: string;
+	/** Serialized URI for the command that was executed in the terminal */
+	terminalCommandUri?: UriComponents;
+	/** Serialized output of the executed command */
+	terminalCommandOutput?: {
+		text: string;
+		truncated?: boolean;
+		isHtml?: boolean;
+	};
+	/** Stored theme colors at execution time to style detached output */
+	terminalTheme?: {
+		background?: string;
+		foreground?: string;
+	};
 	autoApproveInfo?: IMarkdownString;
 }
 

--- a/src/vs/workbench/contrib/chat/common/chatService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService.ts
@@ -322,7 +322,6 @@ export interface IChatTerminalToolInvocationData {
 	terminalCommandOutput?: {
 		text: string;
 		truncated?: boolean;
-		isHtml?: boolean;
 	};
 	/** Stored theme colors at execution time to style detached output */
 	terminalTheme?: {

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
@@ -791,7 +791,7 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 			}
 			const serialized = await this._tryGetSerializedCommandOutput(instance, commandId);
 			if (serialized) {
-				toolSpecificData.terminalCommandOutput = { text: serialized.text, truncated: serialized.truncated, isHtml: true };
+				toolSpecificData.terminalCommandOutput = { text: serialized.text, truncated: serialized.truncated };
 				const theme = instance.xterm?.getXtermTheme();
 				if (theme) {
 					toolSpecificData.terminalTheme = { background: theme.background, foreground: theme.foreground };
@@ -801,8 +801,8 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 		}
 
 		if (fallbackOutput !== undefined) {
-			const escaped = RunInTerminalTool._escapeAsHtml(fallbackOutput);
-			toolSpecificData.terminalCommandOutput = { text: escaped, truncated: false, isHtml: true };
+			const normalized = fallbackOutput.replace(/\r\n/g, '\n');
+			toolSpecificData.terminalCommandOutput = { text: normalized, truncated: false };
 			const theme = instance.xterm?.getXtermTheme();
 			if (theme) {
 				toolSpecificData.terminalTheme = { background: theme.background, foreground: theme.foreground };
@@ -828,16 +828,6 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 			this._logService.warn(`RunInTerminalTool: Failed to serialize command output for ${commandId}`, error);
 			return undefined;
 		}
-	}
-
-	private static _escapeAsHtml(value: string): string {
-		return value
-			.replace(/\r\n/g, '\n')
-			.replace(/&/g, '&amp;')
-			.replace(/</g, '&lt;')
-			.replace(/>/g, '&gt;')
-			.replace(/"/g, '&quot;')
-			.replace(/'/g, '&#39;');
 	}
 
 	// #endregion

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
@@ -15,6 +15,7 @@ import { basename } from '../../../../../../base/common/path.js';
 import { OperatingSystem, OS } from '../../../../../../base/common/platform.js';
 import { count } from '../../../../../../base/common/strings.js';
 import { generateUuid } from '../../../../../../base/common/uuid.js';
+import { URI } from '../../../../../../base/common/uri.js';
 import { localize } from '../../../../../../nls.js';
 import { IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
 import { IInstantiationService, type ServicesAccessor } from '../../../../../../platform/instantiation/common/instantiation.js';
@@ -45,6 +46,7 @@ import { CommandLineFileWriteAnalyzer } from './commandLineAnalyzer/commandLineF
 import { OutputMonitor } from './monitoring/outputMonitor.js';
 import { IPollingResult, OutputMonitorState } from './monitoring/types.js';
 import { LocalChatSessionUri } from '../../../../chat/common/chatUri.js';
+import { CHAT_TERMINAL_OUTPUT_MAX_PREVIEW_LINES } from '../../../../chat/common/constants.js';
 import type { ICommandLineRewriter } from './commandLineRewriter/commandLineRewriter.js';
 import { CommandLineCdPrefixRewriter } from './commandLineRewriter/commandLineCdPrefixRewriter.js';
 import { CommandLinePwshChainOperatorRewriter } from './commandLineRewriter/commandLinePwshChainOperatorRewriter.js';
@@ -460,6 +462,7 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 		if (!toolSpecificData) {
 			throw new Error('toolSpecificData must be provided for this tool');
 		}
+		const commandId = toolSpecificData.terminalCommandId;
 		if (toolSpecificData.alternativeRecommendation) {
 			return {
 				content: [{
@@ -528,7 +531,6 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 			let pollingResult: IPollingResult & { pollDurationMs: number } | undefined;
 			try {
 				this._logService.debug(`RunInTerminalTool: Starting background execution \`${command}\``);
-				const commandId = (toolSpecificData as IChatTerminalToolInvocationData).terminalCommandId;
 				const execution = new BackgroundTerminalExecution(toolTerminal.instance, xterm, command, chatSessionId, commandId);
 				RunInTerminalTool._backgroundExecutions.set(termId, execution);
 
@@ -539,6 +541,8 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 				if (token.isCancellationRequested) {
 					throw new CancellationError();
 				}
+
+				await this._captureCommandArtifacts(toolSpecificData, toolTerminal.instance, commandId, pollingResult?.output);
 
 				let resultText = (
 					didUserEditCommand
@@ -627,13 +631,14 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 						outputMonitor = store.add(this._instantiationService.createInstance(OutputMonitor, { instance: toolTerminal.instance, sessionId: invocation.context?.sessionId, getOutput: (marker?: IXtermMarker) => getOutput(toolTerminal.instance, marker ?? startMarker) }, undefined, invocation.context, token, command));
 					}
 				}));
-				const commandId = (toolSpecificData as IChatTerminalToolInvocationData).terminalCommandId;
 				const executeResult = await strategy.execute(command, token, commandId);
 				// Reset user input state after command execution completes
 				toolTerminal.receivedUserInput = false;
 				if (token.isCancellationRequested) {
 					throw new CancellationError();
 				}
+
+				await this._captureCommandArtifacts(toolSpecificData, toolTerminal.instance, commandId, executeResult.output);
 
 				this._logService.debug(`RunInTerminalTool: Finished \`${strategy.type}\` execute strategy with exitCode \`${executeResult.exitCode}\`, result.length \`${executeResult.output?.length}\`, error \`${executeResult.error}\``);
 				outputLineCount = executeResult.output === undefined ? 0 : count(executeResult.output.trim(), '\n') + 1;
@@ -761,6 +766,79 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 		this._register(toolTerminal.instance.onDisposed(() => disposable.dispose()));
 	}
 
+
+	// #endregion
+
+	// #region Command serialization
+
+	private _createTerminalCommandUri(instance: ITerminalInstance, commandId: string): URI {
+		const params = new URLSearchParams(instance.resource.query);
+		params.set('command', commandId);
+		return instance.resource.with({ query: params.toString() });
+	}
+
+	private async _captureCommandArtifacts(
+		toolSpecificData: IChatTerminalToolInvocationData,
+		instance: ITerminalInstance,
+		commandId: string | undefined,
+		fallbackOutput?: string
+	): Promise<void> {
+		if (commandId) {
+			try {
+				toolSpecificData.terminalCommandUri = URI.from(this._createTerminalCommandUri(instance, commandId));
+			} catch (error) {
+				this._logService.warn(`RunInTerminalTool: Failed to create terminal command URI for ${commandId}`, error);
+			}
+			const serialized = await this._tryGetSerializedCommandOutput(instance, commandId);
+			if (serialized) {
+				toolSpecificData.terminalCommandOutput = { text: serialized.text, truncated: serialized.truncated, isHtml: true };
+				const theme = instance.xterm?.getXtermTheme();
+				if (theme) {
+					toolSpecificData.terminalTheme = { background: theme.background, foreground: theme.foreground };
+				}
+				return;
+			}
+		}
+
+		if (fallbackOutput !== undefined) {
+			const escaped = RunInTerminalTool._escapeAsHtml(fallbackOutput);
+			toolSpecificData.terminalCommandOutput = { text: escaped, truncated: false, isHtml: true };
+			const theme = instance.xterm?.getXtermTheme();
+			if (theme) {
+				toolSpecificData.terminalTheme = { background: theme.background, foreground: theme.foreground };
+			}
+		}
+	}
+
+	private async _tryGetSerializedCommandOutput(instance: ITerminalInstance, commandId: string): Promise<{ text: string; truncated?: boolean } | undefined> {
+		const commandDetection = instance.capabilities.get(TerminalCapability.CommandDetection);
+		const command = commandDetection?.commands.find(c => c.id === commandId);
+		if (!command?.endMarker) {
+			return undefined;
+		}
+
+		const xterm = await instance.xtermReadyPromise;
+		if (!xterm) {
+			return undefined;
+		}
+
+		try {
+			return await xterm.getCommandOutputAsHtml(command, CHAT_TERMINAL_OUTPUT_MAX_PREVIEW_LINES);
+		} catch (error) {
+			this._logService.warn(`RunInTerminalTool: Failed to serialize command output for ${commandId}`, error);
+			return undefined;
+		}
+	}
+
+	private static _escapeAsHtml(value: string): string {
+		return value
+			.replace(/\r\n/g, '\n')
+			.replace(/&/g, '&amp;')
+			.replace(/</g, '&lt;')
+			.replace(/>/g, '&gt;')
+			.replace(/"/g, '&quot;')
+			.replace(/'/g, '&#39;');
+	}
 
 	// #endregion
 

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
@@ -785,7 +785,7 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 	): Promise<void> {
 		if (commandId) {
 			try {
-				toolSpecificData.terminalCommandUri = URI.from(this._createTerminalCommandUri(instance, commandId));
+				toolSpecificData.terminalCommandUri = this._createTerminalCommandUri(instance, commandId);
 			} catch (error) {
 				this._logService.warn(`RunInTerminalTool: Failed to create terminal command URI for ${commandId}`, error);
 			}


### PR DESCRIPTION
fixes #274870

Also makes the terminal focus action navigate to the command after reload of window

https://github.com/user-attachments/assets/f930a7d4-d68a-4acd-9e7a-5c177d520109

