### PR TITLE
edits: show diff for sensitive edit confirmations

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/chatConfirmationWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/chatConfirmationWidget.ts
@@ -353,15 +353,15 @@ abstract class BaseChatConfirmationWidget<T> extends Disposable {
 	}
 
 	private readonly messageElement: HTMLElement;
-	private markdownContentPart?: ChatMarkdownContentPart;
+	private readonly markdownContentPart = this._register(new MutableDisposable<ChatMarkdownContentPart>());
 	private readonly notificationManager: ChatConfirmationNotifier;
 
 	public get codeblocksPartId() {
-		return this.markdownContentPart?.codeblocksPartId;
+		return this.markdownContentPart.value?.codeblocksPartId;
 	}
 
 	public get codeblocks() {
-		return this.markdownContentPart?.codeblocks;
+		return this.markdownContentPart.value?.codeblocks;
 	}
 
 	constructor(
@@ -475,6 +475,8 @@ abstract class BaseChatConfirmationWidget<T> extends Disposable {
 	}
 
 	protected renderMessage(element: HTMLElement | IMarkdownString | string, listContainer: HTMLElement): void {
+		this.markdownContentPart.clear();
+
 		if (!dom.isHTMLElement(element)) {
 			const part = this._register(this.instantiationService.createInstance(ChatMarkdownContentPart,
 				{
@@ -496,7 +498,7 @@ abstract class BaseChatConfirmationWidget<T> extends Disposable {
 			));
 			this._register(part.onDidChangeHeight(() => this._onDidChangeHeight.fire()));
 
-			this.markdownContentPart = part;
+			this.markdownContentPart.value = part;
 			element = part.domNode;
 		}
 

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/chatConfirmationWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/chatConfirmationWidget.ts
@@ -3,7 +3,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import './media/chatConfirmationWidget.css';
 import * as dom from '../../../../../base/browser/dom.js';
 import { IRenderedMarkdown } from '../../../../../base/browser/markdownRenderer.js';
 import { Button, ButtonWithDropdown, IButton, IButtonOptions } from '../../../../../base/browser/ui/button/button.js';
@@ -12,7 +11,7 @@ import { Emitter, Event } from '../../../../../base/common/event.js';
 import { IMarkdownString, MarkdownString } from '../../../../../base/common/htmlContent.js';
 import { Disposable, DisposableStore, MutableDisposable } from '../../../../../base/common/lifecycle.js';
 import type { ThemeIcon } from '../../../../../base/common/themables.js';
-import { IMarkdownRendererService } from '../../../../../platform/markdown/browser/markdownRenderer.js';
+import { URI } from '../../../../../base/common/uri.js';
 import { localize } from '../../../../../nls.js';
 import { MenuWorkbenchToolBar } from '../../../../../platform/actions/browser/toolbar.js';
 import { MenuId } from '../../../../../platform/actions/common/actions.js';
@@ -21,12 +20,14 @@ import { IContextKeyService } from '../../../../../platform/contextkey/common/co
 import { IContextMenuService } from '../../../../../platform/contextview/browser/contextView.js';
 import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
 import { ServiceCollection } from '../../../../../platform/instantiation/common/serviceCollection.js';
+import { IMarkdownRendererService } from '../../../../../platform/markdown/browser/markdownRenderer.js';
 import { FocusMode } from '../../../../../platform/native/common/native.js';
 import { defaultButtonStyles } from '../../../../../platform/theme/browser/defaultStyles.js';
 import { IHostService } from '../../../../services/host/browser/host.js';
 import { IChatWidgetService, showChatWidgetInViewOrEditor } from '../chat.js';
 import { IChatContentPartRenderContext } from './chatContentParts.js';
-import { URI } from '../../../../../base/common/uri.js';
+import { ChatMarkdownContentPart, IChatMarkdownContentPartOptions } from './chatMarkdownContentPart.js';
+import './media/chatConfirmationWidget.css';
 
 export interface IChatConfirmationButton<T> {
 	label: string;
@@ -352,8 +353,16 @@ abstract class BaseChatConfirmationWidget<T> extends Disposable {
 	}
 
 	private readonly messageElement: HTMLElement;
-
+	private markdownContentPart?: ChatMarkdownContentPart;
 	private readonly notificationManager: ChatConfirmationNotifier;
+
+	public get codeblocksPartId() {
+		return this.markdownContentPart?.codeblocksPartId;
+	}
+
+	public get codeblocks() {
+		return this.markdownContentPart?.codeblocks;
+	}
 
 	constructor(
 		protected readonly _context: IChatContentPartRenderContext,
@@ -467,11 +476,28 @@ abstract class BaseChatConfirmationWidget<T> extends Disposable {
 
 	protected renderMessage(element: HTMLElement | IMarkdownString | string, listContainer: HTMLElement): void {
 		if (!dom.isHTMLElement(element)) {
-			const messageElement = this._register(this.markdownRendererService.render(
-				typeof element === 'string' ? new MarkdownString(element) : element,
-				{ asyncRenderCallback: () => this._onDidChangeHeight.fire() }
+			const part = this._register(this.instantiationService.createInstance(ChatMarkdownContentPart,
+				{
+					kind: 'markdownContent',
+					content: typeof element === 'string' ? new MarkdownString().appendMarkdown(element) : element
+				},
+				this._context,
+				this._context.editorPool,
+				false,
+				this._context.codeBlockStartIndex,
+				this.markdownRendererService,
+				undefined,
+				this._context.currentWidth(),
+				this._context.codeBlockModelCollection,
+				{
+					allowInlineDiffs: true,
+					horizontalPadding: 6,
+				} satisfies IChatMarkdownContentPartOptions,
 			));
-			element = messageElement.element;
+			this._register(part.onDidChangeHeight(() => this._onDidChangeHeight.fire()));
+
+			this.markdownContentPart = part;
+			element = part.domNode;
 		}
 
 		for (const child of this.messageElement.children) {

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/chatContentCodePools.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/chatContentCodePools.ts
@@ -1,0 +1,84 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Disposable } from '../../../../../base/common/lifecycle.js';
+import { MenuId } from '../../../../../platform/actions/common/actions.js';
+import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
+import { IChatRendererDelegate } from '../chatListRenderer.js';
+import { ChatEditorOptions } from '../chatOptions.js';
+import { CodeBlockPart, CodeCompareBlockPart } from '../codeBlockPart.js';
+import { ResourcePool, IDisposableReference } from './chatCollections.js';
+
+export class EditorPool extends Disposable {
+
+	private readonly _pool: ResourcePool<CodeBlockPart>;
+
+	inUse(): Iterable<CodeBlockPart> {
+		return this._pool.inUse;
+	}
+
+	constructor(
+		options: ChatEditorOptions,
+		delegate: IChatRendererDelegate,
+		overflowWidgetsDomNode: HTMLElement | undefined,
+		private readonly isSimpleWidget: boolean = false,
+		@IInstantiationService instantiationService: IInstantiationService,
+	) {
+		super();
+		this._pool = this._register(new ResourcePool(() => {
+			return instantiationService.createInstance(CodeBlockPart, options, MenuId.ChatCodeBlock, delegate, overflowWidgetsDomNode, this.isSimpleWidget);
+		}));
+	}
+
+	get(): IDisposableReference<CodeBlockPart> {
+		const codeBlock = this._pool.get();
+		let stale = false;
+		return {
+			object: codeBlock,
+			isStale: () => stale,
+			dispose: () => {
+				codeBlock.reset();
+				stale = true;
+				this._pool.release(codeBlock);
+			}
+		};
+	}
+}
+
+export class DiffEditorPool extends Disposable {
+
+	private readonly _pool: ResourcePool<CodeCompareBlockPart>;
+
+	public inUse(): Iterable<CodeCompareBlockPart> {
+		return this._pool.inUse;
+	}
+
+	constructor(
+		options: ChatEditorOptions,
+		delegate: IChatRendererDelegate,
+		overflowWidgetsDomNode: HTMLElement | undefined,
+		private readonly isSimpleWidget: boolean = false,
+		@IInstantiationService instantiationService: IInstantiationService,
+	) {
+		super();
+		this._pool = this._register(new ResourcePool(() => {
+			return instantiationService.createInstance(CodeCompareBlockPart, options, MenuId.ChatCompareBlock, delegate, overflowWidgetsDomNode, this.isSimpleWidget);
+		}));
+	}
+
+	get(): IDisposableReference<CodeCompareBlockPart> {
+		const codeBlock = this._pool.get();
+		let stale = false;
+		return {
+			object: codeBlock,
+			isStale: () => stale,
+			dispose: () => {
+				codeBlock.reset();
+				stale = true;
+				this._pool.release(codeBlock);
+			}
+		};
+	}
+}

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/chatContentParts.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/chatContentParts.ts
@@ -6,6 +6,8 @@
 import { IDisposable } from '../../../../../base/common/lifecycle.js';
 import { ChatTreeItem, IChatCodeBlockInfo } from '../chat.js';
 import { IChatRendererContent } from '../../common/chatViewModel.js';
+import { CodeBlockModelCollection } from '../../common/codeBlockModelCollection.js';
+import { DiffEditorPool, EditorPool } from './chatContentCodePools.js';
 
 export interface IChatContentPart extends IDisposable {
 	domNode: HTMLElement | undefined;
@@ -37,4 +39,9 @@ export interface IChatContentPartRenderContext {
 	readonly content: ReadonlyArray<IChatRendererContent>;
 	readonly contentIndex: number;
 	readonly preceedingContentParts: ReadonlyArray<IChatContentPart>;
+	readonly editorPool: EditorPool;
+	readonly codeBlockStartIndex: number;
+	readonly diffEditorPool: DiffEditorPool;
+	readonly codeBlockModelCollection: CodeBlockModelCollection;
+	currentWidth(): number;
 }

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/chatElicitationContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/chatElicitationContentPart.ts
@@ -21,6 +21,16 @@ export class ChatElicitationContentPart extends Disposable implements IChatConte
 	private readonly _onDidChangeHeight = this._register(new Emitter<void>());
 	public readonly onDidChangeHeight = this._onDidChangeHeight.event;
 
+	private readonly _confirmWidget: ChatConfirmationWidget<unknown>;
+
+	public get codeblocks() {
+		return this._confirmWidget.codeblocks;
+	}
+
+	public get codeblocksPartId() {
+		return this._confirmWidget.codeblocksPartId;
+	}
+
 	constructor(
 		elicitation: IChatElicitationRequest,
 		context: IChatContentPartRenderContext,
@@ -48,8 +58,9 @@ export class ChatElicitationContentPart extends Disposable implements IChatConte
 			subtitle: elicitation.subtitle,
 			buttons,
 			message: this.getMessageToRender(elicitation),
-			toolbarData: { partType: 'elicitation', partSource: elicitation.source?.type, arg: elicitation }
+			toolbarData: { partType: 'elicitation', partSource: elicitation.source?.type, arg: elicitation },
 		}));
+		this._confirmWidget = confirmationWidget;
 		confirmationWidget.setShowButtons(elicitation.state === 'pending');
 
 		if (elicitation.isHidden) {

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/chatTextEditContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/chatTextEditContentPart.ts
@@ -19,18 +19,16 @@ import { IModelService } from '../../../../../editor/common/services/model.js';
 import { DefaultModelSHA1Computer } from '../../../../../editor/common/services/modelService.js';
 import { IResolvedTextEditorModel, ITextModelService } from '../../../../../editor/common/services/resolverService.js';
 import { localize } from '../../../../../nls.js';
-import { MenuId } from '../../../../../platform/actions/common/actions.js';
 import { InstantiationType, registerSingleton } from '../../../../../platform/instantiation/common/extensions.js';
-import { createDecorator, IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
-import { IChatListItemRendererOptions } from '../chat.js';
-import { IDisposableReference, ResourcePool } from './chatCollections.js';
-import { IChatContentPart, IChatContentPartRenderContext } from './chatContentParts.js';
-import { IChatRendererDelegate } from '../chatListRenderer.js';
-import { ChatEditorOptions } from '../chatOptions.js';
-import { CodeCompareBlockPart, ICodeCompareBlockData, ICodeCompareBlockDiffData } from '../codeBlockPart.js';
+import { createDecorator } from '../../../../../platform/instantiation/common/instantiation.js';
 import { IChatProgressRenderableResponseContent, IChatTextEditGroup } from '../../common/chatModel.js';
 import { IChatService } from '../../common/chatService.js';
 import { IChatResponseViewModel, isResponseVM } from '../../common/chatViewModel.js';
+import { IChatListItemRendererOptions } from '../chat.js';
+import { CodeCompareBlockPart, ICodeCompareBlockData, ICodeCompareBlockDiffData } from '../codeBlockPart.js';
+import { IDisposableReference } from './chatCollections.js';
+import { DiffEditorPool } from './chatContentCodePools.js';
+import { IChatContentPart, IChatContentPartRenderContext } from './chatContentParts.js';
 
 const $ = dom.$;
 
@@ -132,42 +130,6 @@ export class ChatTextEditContentPart extends Disposable implements IChatContentP
 
 	addDisposable(disposable: IDisposable): void {
 		this._register(disposable);
-	}
-}
-
-export class DiffEditorPool extends Disposable {
-
-	private readonly _pool: ResourcePool<CodeCompareBlockPart>;
-
-	public inUse(): Iterable<CodeCompareBlockPart> {
-		return this._pool.inUse;
-	}
-
-	constructor(
-		options: ChatEditorOptions,
-		delegate: IChatRendererDelegate,
-		overflowWidgetsDomNode: HTMLElement | undefined,
-		private readonly isSimpleWidget: boolean = false,
-		@IInstantiationService instantiationService: IInstantiationService,
-	) {
-		super();
-		this._pool = this._register(new ResourcePool(() => {
-			return instantiationService.createInstance(CodeCompareBlockPart, options, MenuId.ChatCompareBlock, delegate, overflowWidgetsDomNode, this.isSimpleWidget);
-		}));
-	}
-
-	get(): IDisposableReference<CodeCompareBlockPart> {
-		const codeBlock = this._pool.get();
-		let stale = false;
-		return {
-			object: codeBlock,
-			isStale: () => stale,
-			dispose: () => {
-				codeBlock.reset();
-				stale = true;
-				this._pool.release(codeBlock);
-			}
-		};
 	}
 }
 

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/chatToolInputOutputContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/chatToolInputOutputContentPart.ts
@@ -23,7 +23,6 @@ import { CodeBlockPart, ICodeBlockData, ICodeBlockRenderOptions } from '../codeB
 import { IDisposableReference } from './chatCollections.js';
 import { ChatQueryTitlePart } from './chatConfirmationWidget.js';
 import { IChatContentPartRenderContext } from './chatContentParts.js';
-import { EditorPool } from './chatMarkdownContentPart.js';
 import { ChatToolOutputContentSubPart } from './chatToolOutputContentSubPart.js';
 
 export interface IChatCollapsibleIOCodePart {
@@ -86,17 +85,15 @@ export class ChatCollapsibleInputOutputContentPart extends Disposable {
 		title: IMarkdownString | string,
 		subtitle: string | IMarkdownString | undefined,
 		private readonly context: IChatContentPartRenderContext,
-		private readonly editorPool: EditorPool,
 		private readonly input: IChatCollapsibleInputData,
 		private readonly output: IChatCollapsibleOutputData | undefined,
 		isError: boolean,
 		initiallyExpanded: boolean,
-		width: number,
 		@IContextKeyService private readonly contextKeyService: IContextKeyService,
 		@IInstantiationService private readonly _instantiationService: IInstantiationService,
 	) {
 		super();
-		this._currentWidth = width;
+		this._currentWidth = context.currentWidth();
 
 		const container = dom.h('.chat-confirmation-widget-container');
 		const titleEl = dom.h('.chat-confirmation-widget-title-inner');
@@ -157,9 +154,7 @@ export class ChatCollapsibleInputOutputContentPart extends Disposable {
 			const resourceSubPart = this._register(this._instantiationService.createInstance(
 				ChatToolOutputContentSubPart,
 				this.context,
-				this.editorPool,
 				topLevelResources,
-				this._currentWidth
 			));
 			const group = resourceSubPart.domNode;
 			group.classList.add('chat-collapsible-top-level-resource-group');
@@ -191,9 +186,7 @@ export class ChatCollapsibleInputOutputContentPart extends Disposable {
 			const outputSubPart = this._register(this._instantiationService.createInstance(
 				ChatToolOutputContentSubPart,
 				this.context,
-				this.editorPool,
 				output.parts,
-				this._currentWidth
 			));
 			this._outputSubPart = outputSubPart;
 			this._register(outputSubPart.onDidChangeHeight(() => this._onDidChangeHeight.fire()));
@@ -214,7 +207,7 @@ export class ChatCollapsibleInputOutputContentPart extends Disposable {
 			renderOptions: part.options,
 			chatSessionResource: this.context.element.sessionResource,
 		};
-		const editorReference = this._register(this.editorPool.get());
+		const editorReference = this._register(this.context.editorPool.get());
 		editorReference.object.render(data, this._currentWidth || 300);
 		this._register(editorReference.object.onDidChangeContentHeight(() => this._onDidChangeHeight.fire()));
 		container.appendChild(editorReference.object.element);

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/chatToolOutputContentSubPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/chatToolOutputContentSubPart.ts
@@ -31,7 +31,6 @@ import { CodeBlockPart, ICodeBlockData } from '../codeBlockPart.js';
 import { ChatAttachmentsContentPart } from './chatAttachmentsContentPart.js';
 import { IDisposableReference } from './chatCollections.js';
 import { IChatContentPartRenderContext } from './chatContentParts.js';
-import { EditorPool } from './chatMarkdownContentPart.js';
 import { ChatCollapsibleIOPart, IChatCollapsibleIOCodePart, IChatCollapsibleIODataPart } from './chatToolInputOutputContentPart.js';
 
 /**
@@ -50,17 +49,15 @@ export class ChatToolOutputContentSubPart extends Disposable {
 
 	constructor(
 		private readonly context: IChatContentPartRenderContext,
-		private readonly editorPool: EditorPool,
 		private readonly parts: ChatCollapsibleIOPart[],
-		width: number,
 		@IContextKeyService private readonly contextKeyService: IContextKeyService,
 		@IInstantiationService private readonly _instantiationService: IInstantiationService,
 		@IContextMenuService private readonly _contextMenuService: IContextMenuService,
 		@IFileService private readonly _fileService: IFileService,
 	) {
 		super();
-		this._currentWidth = width;
 		this.domNode = this.createOutputContents();
+		this._currentWidth = context.currentWidth();
 	}
 
 	private createOutputContents(): HTMLElement {
@@ -158,7 +155,7 @@ export class ChatToolOutputContentSubPart extends Disposable {
 			renderOptions: part.options,
 			chatSessionResource: this.context.element.sessionResource,
 		};
-		const editorReference = this._register(this.editorPool.get());
+		const editorReference = this._register(this.context.editorPool.get());
 		editorReference.object.render(data, this._currentWidth || 300);
 		this._register(editorReference.object.onDidChangeContentHeight(() => this._onDidChangeHeight.fire()));
 		container.appendChild(editorReference.object.element);

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/media/chatConfirmationWidget.css
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/media/chatConfirmationWidget.css
@@ -298,3 +298,9 @@
 		}
 	}
 }
+
+.chat-confirmation-widget2 .interactive-result-code-block.compare {
+	.interactive-result-header .monaco-toolbar {
+		display: none; /* Don't show keep/discard for diffs shown within confirmation */
+	}
+}

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatExtensionsInstallToolSubPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatExtensionsInstallToolSubPart.ts
@@ -16,7 +16,7 @@ import { ChatContextKeys } from '../../../common/chatContextKeys.js';
 import { ConfirmedReason, IChatToolInvocation, ToolConfirmKind } from '../../../common/chatService.js';
 import { CancelChatActionId } from '../../actions/chatExecuteActions.js';
 import { AcceptToolConfirmationActionId } from '../../actions/chatToolActions.js';
-import { IChatCodeBlockInfo, IChatWidgetService } from '../../chat.js';
+import { IChatWidgetService } from '../../chat.js';
 import { ChatConfirmationWidget, IChatConfirmationButton } from '../chatConfirmationWidget.js';
 import { IChatContentPartRenderContext } from '../chatContentParts.js';
 import { ChatExtensionsContentPart } from '../chatExtensionsContentPart.js';
@@ -24,7 +24,15 @@ import { BaseChatToolInvocationSubPart } from './chatToolInvocationSubPart.js';
 
 export class ExtensionsInstallConfirmationWidgetSubPart extends BaseChatToolInvocationSubPart {
 	public readonly domNode: HTMLElement;
-	public readonly codeblocks: IChatCodeBlockInfo[] = [];
+	private readonly _confirmWidget?: ChatConfirmationWidget<ConfirmedReason>;
+
+	public get codeblocks() {
+		return this._confirmWidget?.codeblocks || [];
+	}
+
+	public override get codeblocksPartId() {
+		return this._confirmWidget?.codeblocksPartId || '<none>';
+	}
 
 	constructor(
 		toolInvocation: IChatToolInvocation,
@@ -82,6 +90,7 @@ export class ExtensionsInstallConfirmationWidgetSubPart extends BaseChatToolInvo
 					buttons,
 				}
 			));
+			this._confirmWidget = confirmWidget;
 			this._register(confirmWidget.onDidChangeHeight(() => this._onDidChangeHeight.fire()));
 			dom.append(this.domNode, confirmWidget.domNode);
 			this._register(confirmWidget.onDidClick(button => {

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatInputOutputMarkdownProgressPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatInputOutputMarkdownProgressPart.ts
@@ -18,8 +18,8 @@ import { ChatResponseResource } from '../../../common/chatModel.js';
 import { IChatToolInvocation, IChatToolInvocationSerialized } from '../../../common/chatService.js';
 import { IToolResultInputOutputDetails } from '../../../common/languageModelToolsService.js';
 import { IChatCodeBlockInfo } from '../../chat.js';
+import { EditorPool } from '../chatContentCodePools.js';
 import { IChatContentPartRenderContext } from '../chatContentParts.js';
-import { EditorPool } from '../chatMarkdownContentPart.js';
 import { ChatCollapsibleInputOutputContentPart, ChatCollapsibleIOPart, IChatCollapsibleIOCodePart } from '../chatToolInputOutputContentPart.js';
 import { BaseChatToolInvocationSubPart } from './chatToolInvocationSubPart.js';
 
@@ -96,7 +96,6 @@ export class ChatInputOutputMarkdownProgressPart extends BaseChatToolInvocationS
 			message,
 			subtitle,
 			context,
-			editorPool,
 			toCodePart(input),
 			processedOutput && {
 				parts: processedOutput.map((o, i): ChatCollapsibleIOPart => {
@@ -129,7 +128,6 @@ export class ChatInputOutputMarkdownProgressPart extends BaseChatToolInvocationS
 			},
 			isError,
 			ChatInputOutputMarkdownProgressPart._expandedByDefault.get(toolInvocation) ?? false,
-			currentWidthDelegate(),
 		));
 		this._codeblocks.push(...collapsibleListPart.codeblocks);
 		this._register(collapsibleListPart.onDidChangeHeight(() => this._onDidChangeHeight.fire()));

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatTerminalToolConfirmationSubPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatTerminalToolConfirmationSubPart.ts
@@ -39,8 +39,9 @@ import { AcceptToolConfirmationActionId, SkipToolConfirmationActionId } from '..
 import { IChatCodeBlockInfo, IChatWidgetService } from '../../chat.js';
 import { ICodeBlockRenderOptions } from '../../codeBlockPart.js';
 import { ChatCustomConfirmationWidget, IChatConfirmationButton } from '../chatConfirmationWidget.js';
+import { EditorPool } from '../chatContentCodePools.js';
 import { IChatContentPartRenderContext } from '../chatContentParts.js';
-import { ChatMarkdownContentPart, EditorPool } from '../chatMarkdownContentPart.js';
+import { ChatMarkdownContentPart } from '../chatMarkdownContentPart.js';
 import { openTerminalSettingsLinkCommandId } from './chatTerminalToolProgressPart.js';
 import { BaseChatToolInvocationSubPart } from './chatToolInvocationSubPart.js';
 
@@ -376,7 +377,7 @@ export class ChatTerminalToolConfirmationSubPart extends BaseChatToolInvocationS
 			undefined,
 			this.currentWidthDelegate(),
 			this.codeBlockModelCollection,
-			{ codeBlockRenderOptions }
+			{ codeBlockRenderOptions },
 		));
 		append(container, part.domNode);
 		this._register(part.onDidChangeHeight(() => this._onDidChangeHeight.fire()));

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart.ts
@@ -15,7 +15,7 @@ import { CodeBlockModelCollection } from '../../../common/codeBlockModelCollecti
 import { IChatCodeBlockInfo } from '../../chat.js';
 import { ChatQueryTitlePart } from '../chatConfirmationWidget.js';
 import { IChatContentPartRenderContext } from '../chatContentParts.js';
-import { ChatMarkdownContentPart, EditorPool, type IChatMarkdownContentPartOptions } from '../chatMarkdownContentPart.js';
+import { ChatMarkdownContentPart, type IChatMarkdownContentPartOptions } from '../chatMarkdownContentPart.js';
 import { ChatProgressSubPart } from '../chatProgressContentPart.js';
 import { BaseChatToolInvocationSubPart } from './chatToolInvocationSubPart.js';
 import '../media/chatTerminalToolProgressPart.css';
@@ -39,6 +39,7 @@ import * as domSanitize from '../../../../../../base/browser/domSanitize.js';
 import { DomSanitizerConfig } from '../../../../../../base/browser/domSanitize.js';
 import { allowedMarkdownHtmlAttributes } from '../../../../../../base/browser/markdownRenderer.js';
 import { stripIcons } from '../../../../../../base/common/iconLabels.js';
+import { EditorPool } from '../chatContentCodePools.js';
 
 const MAX_TERMINAL_OUTPUT_PREVIEW_HEIGHT = 200;
 

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatToolConfirmationSubPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatToolConfirmationSubPart.ts
@@ -31,8 +31,9 @@ import { renderFileWidgets } from '../../chatInlineAnchorWidget.js';
 import { ICodeBlockRenderOptions } from '../../codeBlockPart.js';
 import { IChatContentPartRenderContext } from '../chatContentParts.js';
 import { IChatMarkdownAnchorService } from '../chatMarkdownAnchorService.js';
-import { ChatMarkdownContentPart, EditorPool } from '../chatMarkdownContentPart.js';
+import { ChatMarkdownContentPart } from '../chatMarkdownContentPart.js';
 import { AbstractToolConfirmationSubPart } from './abstractToolConfirmationSubPart.js';
+import { EditorPool } from '../chatContentCodePools.js';
 
 const SHOW_MORE_MESSAGE_HEIGHT_TRIGGER = 45;
 
@@ -322,7 +323,7 @@ export class ToolConfirmationSubPart extends AbstractToolConfirmationSubPart {
 			undefined,
 			this.currentWidthDelegate(),
 			this.codeBlockModelCollection,
-			{ codeBlockRenderOptions }
+			{ codeBlockRenderOptions },
 		));
 		renderFileWidgets(part.domNode, this.instantiationService, this.chatMarkdownAnchorService, this._store);
 		container.append(part.domNode);

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatToolInvocationPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatToolInvocationPart.ts
@@ -14,7 +14,6 @@ import { CodeBlockModelCollection } from '../../../common/codeBlockModelCollecti
 import { isToolResultInputOutputDetails, isToolResultOutputDetails, ToolInvocationPresentation } from '../../../common/languageModelToolsService.js';
 import { ChatTreeItem, IChatCodeBlockInfo } from '../../chat.js';
 import { IChatContentPart, IChatContentPartRenderContext } from '../chatContentParts.js';
-import { EditorPool } from '../chatMarkdownContentPart.js';
 import { CollapsibleListPool } from '../chatReferencesContentPart.js';
 import { ExtensionsInstallConfirmationWidgetSubPart } from './chatExtensionsInstallToolSubPart.js';
 import { ChatInputOutputMarkdownProgressPart } from './chatInputOutputMarkdownProgressPart.js';
@@ -29,6 +28,7 @@ import { ChatToolProgressSubPart } from './chatToolProgressPart.js';
 import { autorun } from '../../../../../../base/common/observable.js';
 import { localize } from '../../../../../../nls.js';
 import { markdownCommandLink, MarkdownString } from '../../../../../../base/common/htmlContent.js';
+import { EditorPool } from '../chatContentCodePools.js';
 
 export class ChatToolInvocationPart extends Disposable implements IChatContentPart {
 	public readonly domNode: HTMLElement;
@@ -167,7 +167,7 @@ export class ChatToolInvocationPart extends Disposable implements IChatContentPa
 				}
 			}
 			if (state.type === IChatToolInvocation.StateKind.WaitingForPostApproval) {
-				return this.instantiationService.createInstance(ChatToolPostExecuteConfirmationPart, this.toolInvocation, this.context, this.editorPool, this.currentWidthDelegate);
+				return this.instantiationService.createInstance(ChatToolPostExecuteConfirmationPart, this.toolInvocation, this.context);
 			}
 		}
 

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatToolInvocationSubPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatToolInvocationSubPart.ts
@@ -22,7 +22,11 @@ export abstract class BaseChatToolInvocationSubPart extends Disposable {
 
 	public abstract codeblocks: IChatCodeBlockInfo[];
 
-	public readonly codeblocksPartId = 'tool-' + (BaseChatToolInvocationSubPart.idPool++);
+	private readonly _codeBlocksPartId = 'tool-' + (BaseChatToolInvocationSubPart.idPool++);
+
+	public get codeblocksPartId() {
+		return this._codeBlocksPartId;
+	}
 
 	constructor(
 		protected readonly toolInvocation: IChatToolInvocation | IChatToolInvocationSerialized,

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatToolPostExecuteConfirmationPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatToolPostExecuteConfirmationPart.ts
@@ -19,7 +19,6 @@ import { ILanguageModelToolsService, IToolResultDataPart, IToolResultPromptTsxPa
 import { AcceptToolPostConfirmationActionId, SkipToolPostConfirmationActionId } from '../../actions/chatToolActions.js';
 import { IChatCodeBlockInfo, IChatWidgetService } from '../../chat.js';
 import { IChatContentPartRenderContext } from '../chatContentParts.js';
-import { EditorPool } from '../chatMarkdownContentPart.js';
 import { ChatCollapsibleIOPart } from '../chatToolInputOutputContentPart.js';
 import { ChatToolOutputContentSubPart } from '../chatToolOutputContentSubPart.js';
 import { AbstractToolConfirmationSubPart } from './abstractToolConfirmationSubPart.js';
@@ -33,8 +32,6 @@ export class ChatToolPostExecuteConfirmationPart extends AbstractToolConfirmatio
 	constructor(
 		toolInvocation: IChatToolInvocation,
 		context: IChatContentPartRenderContext,
-		private readonly editorPool: EditorPool,
-		private readonly currentWidthDelegate: () => number,
 		@IInstantiationService instantiationService: IInstantiationService,
 		@IKeybindingService keybindingService: IKeybindingService,
 		@IModelService private readonly modelService: IModelService,
@@ -260,9 +257,7 @@ export class ChatToolPostExecuteConfirmationPart extends AbstractToolConfirmatio
 			const outputSubPart = this._register(this.instantiationService.createInstance(
 				ChatToolOutputContentSubPart,
 				this.context,
-				this.editorPool,
 				parts,
-				this.currentWidthDelegate()
 			));
 
 			this._codeblocks.push(...outputSubPart.codeblocks);

--- a/src/vs/workbench/contrib/chat/browser/chatDiffBlockPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatDiffBlockPart.ts
@@ -1,0 +1,176 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { CancellationToken } from '../../../../base/common/cancellation.js';
+import { Emitter } from '../../../../base/common/event.js';
+import { hashAsync } from '../../../../base/common/hash.js';
+import { Disposable, IReference, MutableDisposable } from '../../../../base/common/lifecycle.js';
+import { Schemas } from '../../../../base/common/network.js';
+import { URI } from '../../../../base/common/uri.js';
+import { generateUuid } from '../../../../base/common/uuid.js';
+import { ILanguageService } from '../../../../editor/common/languages/language.js';
+import { ITextModel } from '../../../../editor/common/model.js';
+import { IModelService } from '../../../../editor/common/services/model.js';
+import { IResolvedTextEditorModel, ITextModelService } from '../../../../editor/common/services/resolverService.js';
+import { EditorModel } from '../../../common/editor/editorModel.js';
+import { IChatResponseViewModel } from '../common/chatViewModel.js';
+import { IDisposableReference } from './chatContentParts/chatCollections.js';
+import { DiffEditorPool } from './chatContentParts/chatContentCodePools.js';
+import { CodeCompareBlockPart, ICodeCompareBlockData, ICodeCompareBlockDiffData } from './codeBlockPart.js';
+
+/**
+ * Parses unified diff format into before/after content.
+ * Supports standard unified diff format with - and + prefixes.
+ */
+export function parseUnifiedDiff(diffText: string): { before: string; after: string } {
+	const lines = diffText.split('\n');
+	const beforeLines: string[] = [];
+	const afterLines: string[] = [];
+
+	for (const line of lines) {
+		if (line.startsWith('- ')) {
+			beforeLines.push(line.substring(2));
+		} else if (line.startsWith('-')) {
+			beforeLines.push(line.substring(1));
+		} else if (line.startsWith('+ ')) {
+			afterLines.push(line.substring(2));
+		} else if (line.startsWith('+')) {
+			afterLines.push(line.substring(1));
+		} else if (line.startsWith(' ')) {
+			// Context line - appears in both
+			const content = line.substring(1);
+			beforeLines.push(content);
+			afterLines.push(content);
+		} else if (!line.startsWith('@@') && !line.startsWith('---') && !line.startsWith('+++') && !line.startsWith('diff ')) {
+			// Regular line without prefix - treat as context
+			beforeLines.push(line);
+			afterLines.push(line);
+		}
+	}
+
+	return {
+		before: beforeLines.join('\n'),
+		after: afterLines.join('\n')
+	};
+}
+
+/**
+ * Simple diff editor model for inline diffs in markdown code blocks
+ */
+class SimpleDiffEditorModel extends EditorModel {
+	public readonly original: ITextModel;
+	public readonly modified: ITextModel;
+
+	constructor(
+		private readonly _original: IReference<IResolvedTextEditorModel>,
+		private readonly _modified: IReference<IResolvedTextEditorModel>,
+	) {
+		super();
+		this.original = this._original.object.textEditorModel;
+		this.modified = this._modified.object.textEditorModel;
+	}
+
+	public override dispose() {
+		super.dispose();
+		this._original.dispose();
+		this._modified.dispose();
+	}
+}
+
+export interface IMarkdownDiffBlockData {
+	readonly element: IChatResponseViewModel;
+	readonly codeBlockIndex: number;
+	readonly languageId: string;
+	readonly beforeContent: string;
+	readonly afterContent: string;
+	readonly codeBlockResource?: URI;
+	readonly isReadOnly?: boolean;
+	readonly horizontalPadding?: number;
+}
+
+/**
+ * Renders a diff block from markdown content.
+ * This is a lightweight wrapper that uses CodeCompareBlockPart for the actual rendering.
+ */
+export class MarkdownDiffBlockPart extends Disposable {
+	private readonly _onDidChangeContentHeight = this._register(new Emitter<void>());
+	public readonly onDidChangeContentHeight = this._onDidChangeContentHeight.event;
+
+	readonly element: HTMLElement;
+	private readonly comparePart: IDisposableReference<CodeCompareBlockPart>;
+	private readonly modelRef = this._register(new MutableDisposable<SimpleDiffEditorModel>());
+
+	constructor(
+		data: IMarkdownDiffBlockData,
+		diffEditorPool: DiffEditorPool,
+		currentWidth: number,
+		@IModelService private readonly modelService: IModelService,
+		@ITextModelService private readonly textModelService: ITextModelService,
+		@ILanguageService private readonly languageService: ILanguageService,
+	) {
+		super();
+
+		this.comparePart = this._register(diffEditorPool.get());
+
+		this._register(this.comparePart.object.onDidChangeContentHeight(() => {
+			this._onDidChangeContentHeight.fire();
+		}));
+
+		// Create in-memory models for the diff
+		const originalUri = URI.from({
+			scheme: Schemas.vscodeChatCodeBlock,
+			path: `/chat-diff-original-${data.codeBlockIndex}-${generateUuid()}`,
+		});
+		const modifiedUri = URI.from({
+			scheme: Schemas.vscodeChatCodeBlock,
+			path: `/chat-diff-modified-${data.codeBlockIndex}-${generateUuid()}`,
+		});
+
+		const languageSelection = this.languageService.createById(data.languageId);
+
+		// Create the models
+		this._register(this.modelService.createModel(data.beforeContent, languageSelection, originalUri, false));
+		this._register(this.modelService.createModel(data.afterContent, languageSelection, modifiedUri, false));
+
+		const modelsPromise = Promise.all([
+			this.textModelService.createModelReference(originalUri),
+			this.textModelService.createModelReference(modifiedUri)
+		]).then(([originalRef, modifiedRef]) => {
+			return new SimpleDiffEditorModel(originalRef, modifiedRef);
+		});
+
+		const compareData: ICodeCompareBlockData = {
+			element: data.element,
+			isReadOnly: data.isReadOnly,
+			horizontalPadding: data.horizontalPadding,
+			edit: {
+				uri: data.codeBlockResource || modifiedUri,
+				edits: [],
+				kind: 'textEditGroup',
+				done: true
+			},
+			diffData: modelsPromise.then(async model => {
+				this.modelRef.value = model;
+				const diffData: ICodeCompareBlockDiffData = {
+					original: model.original,
+					modified: model.modified,
+					originalSha1: await hashAsync(model.original.getValue()),
+				};
+				return diffData;
+			})
+		};
+
+		this.comparePart.object.render(compareData, currentWidth, CancellationToken.None);
+		this.element = this.comparePart.object.element;
+	}
+
+	layout(width: number): void {
+		this.comparePart.object.layout(width);
+	}
+
+	reset(): void {
+		this.modelRef.clear();
+	}
+}

--- a/src/vs/workbench/contrib/chat/browser/codeBlockPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/codeBlockPart.ts
@@ -546,6 +546,9 @@ export interface ICodeCompareBlockData {
 	readonly diffData: Promise<ICodeCompareBlockDiffData | undefined>;
 
 	readonly parentContextKeyService?: IContextKeyService;
+
+	readonly horizontalPadding?: number;
+	readonly isReadOnly?: boolean;
 	// readonly hideToolbar?: boolean;
 }
 
@@ -561,9 +564,11 @@ export class CodeCompareBlockPart extends Disposable {
 	private readonly toolbar: MenuWorkbenchToolBar;
 	readonly element: HTMLElement;
 	private readonly messageElement: HTMLElement;
+	private readonly editorHeader: HTMLElement;
 
 	private readonly _lastDiffEditorViewModel = this._store.add(new MutableDisposable());
 	private currentScrollWidth = 0;
+	private currentHorizontalPadding = 0;
 
 	constructor(
 		private readonly options: ChatEditorOptions,
@@ -600,7 +605,7 @@ export class CodeCompareBlockPart extends Disposable {
 				}
 			}],
 		)));
-		const editorHeader = dom.append(this.element, $('.interactive-result-header.show-file-icons'));
+		const editorHeader = this.editorHeader = dom.append(this.element, $('.interactive-result-header.show-file-icons'));
 		const editorElement = dom.append(this.element, $('.interactive-result-editor'));
 		this.diffEditor = this.createDiffEditor(scopedInstantiationService, editorElement, {
 			...getSimpleEditorOptions(this.configurationService),
@@ -765,12 +770,12 @@ export class CodeCompareBlockPart extends Disposable {
 	layout(width: number): void {
 		const editorBorder = 2;
 
-		const toolbar = dom.getTotalHeight(this.toolbar.getElement());
+		const toolbar = dom.getTotalHeight(this.editorHeader);
 		const content = this.diffEditor.getModel()
 			? this.diffEditor.getContentHeight()
 			: dom.getTotalHeight(this.messageElement);
 
-		const dimension = new dom.Dimension(width - editorBorder, toolbar + content);
+		const dimension = new dom.Dimension(width - editorBorder - this.currentHorizontalPadding * 2, toolbar + content);
 		this.element.style.height = `${dimension.height}px`;
 		this.element.style.width = `${dimension.width}px`;
 		this.diffEditor.layout(dimension.with(undefined, content - editorBorder));
@@ -779,6 +784,8 @@ export class CodeCompareBlockPart extends Disposable {
 
 
 	async render(data: ICodeCompareBlockData, width: number, token: CancellationToken) {
+		this.currentHorizontalPadding = data.horizontalPadding || 0;
+
 		if (data.parentContextKeyService) {
 			this.contextKeyService.updateParent(data.parentContextKeyService);
 		}
@@ -792,12 +799,17 @@ export class CodeCompareBlockPart extends Disposable {
 		await this.updateEditor(data, token);
 
 		this.layout(width);
-		this.diffEditor.updateOptions({ ariaLabel: localize('chat.compareCodeBlockLabel', "Code Edits") });
+		this.diffEditor.updateOptions({
+			ariaLabel: localize('chat.compareCodeBlockLabel', "Code Edits"),
+			readOnly: !!data.isReadOnly,
+		});
 
 		this.resourceLabel.element.setFile(data.edit.uri, {
 			fileKind: FileKind.FILE,
 			fileDecorations: { colors: true, badges: false }
 		});
+
+		this._onDidChangeContentHeight.fire();
 	}
 
 	reset() {


### PR DESCRIPTION
Goes with https://github.com/microsoft/vscode-copilot-chat/pull/1905

- Adds common markdown rendering to the `IChatContentPartRenderContext`.
  These have to get passed down everywhere that can render markdown
  'properly' and so this made sense, though we may want to revisit this
  and make them actual dependency-injected services with scope
  instantiation service.
- Add a new basic `MarkdownDiffBlockPart` and allow consumers to
  optionally enable that for handling of `diff` blocks in their markdown.
- Some further tweaks to deal with md/code in nested blocks.

Closes https://github.com/microsoft/vscode/issues/266574

<img width="551" height="646" alt="image" src="https://github.com/user-attachments/assets/44714c5b-bd40-4e9f-a708-c3be38ad17fb" />
