### PR TITLE
Refactor hover widget styles for improved layout and spacing

### DIFF
--- a/src/vs/base/browser/ui/hover/hoverWidget.css
+++ b/src/vs/base/browser/ui/hover/hoverWidget.css
@@ -99,9 +99,9 @@
 	margin-bottom: 2px;
 }
 
-.monaco-hover p:last-child span:not(.codicon) {
+/* .monaco-hover p:last-child span:not(.codicon) {
 	padding: 2px 0;
-}
+} */
 
 .monaco-hover .code:last-child,
 .monaco-hover ul:last-child {
@@ -220,7 +220,8 @@
  * https://github.com/microsoft/vscode/issues/221359
  */
 .monaco-hover .markdown-hover .hover-contents:not(.code-hover-contents):not(.html-hover-contents) span.codicon {
-	margin-bottom: 2px;
+	/* margin-bottom: 2px; */
+	margin-right: 4px;
 }
 
 .monaco-hover-content .action-container a {

--- a/src/vs/base/browser/ui/hover/hoverWidget.css
+++ b/src/vs/base/browser/ui/hover/hoverWidget.css
@@ -48,7 +48,7 @@
 .monaco-hover h4,
 .monaco-hover h5,
 .monaco-hover h6 {
-	margin: 8px 0;
+	margin: 4px 0;
 }
 
 .monaco-hover h1,
@@ -68,20 +68,41 @@
 	box-sizing: border-box;
 	border-left: 0px;
 	border-right: 0px;
-	margin-top: 4px;
-	margin-bottom: -4px;
+	margin-top: 0px;
+	margin-bottom: 0px;
 	margin-left: -8px;
 	margin-right: -8px;
 	height: 1px;
 }
 
-.monaco-hover p:first-child,
 .monaco-hover .code:first-child,
 .monaco-hover ul:first-child {
 	margin-top: 0;
 }
 
-.monaco-hover p:last-child,
+.monaco-hover p:first-child {
+	margin-top: 4px;
+	display: flex;
+	align-items: center;
+}
+
+.monaco-hover p:first-child img {
+	border-radius: 50%;
+	margin-right: 4px;
+}
+
+/* .monaco-hover p:first-child .codicon {
+	margin: 0 2px;
+} */
+
+.monaco-hover p:last-child {
+	margin-bottom: 2px;
+}
+
+.monaco-hover p:last-child span:not(.codicon) {
+	padding: 2px 0;
+}
+
 .monaco-hover .code:last-child,
 .monaco-hover ul:last-child {
 	margin-bottom: 0;

--- a/src/vs/base/browser/ui/hover/hoverWidget.css
+++ b/src/vs/base/browser/ui/hover/hoverWidget.css
@@ -91,17 +91,9 @@
 	margin-right: 4px;
 }
 
-/* .monaco-hover p:first-child .codicon {
-	margin: 0 2px;
-} */
-
 .monaco-hover p:last-child {
 	margin-bottom: 2px;
 }
-
-/* .monaco-hover p:last-child span:not(.codicon) {
-	padding: 2px 0;
-} */
 
 .monaco-hover .code:last-child,
 .monaco-hover ul:last-child {

--- a/src/vs/platform/hover/browser/hover.css
+++ b/src/vs/platform/hover/browser/hover.css
@@ -44,9 +44,13 @@
 	font-size: 16px !important;
 }
 
-.monaco-hover .monaco-hover-content p:last-child span:not(.codicon),
-.monaco-hover .monaco-hover-content p:last-child a:not(.codicon) {
-	padding: 2px 0;
+.monaco-hover .monaco-hover-content p:last-child {
+	display: flex;
+}
+
+.monaco-hover .monaco-hover-content p:last-child a {
+	display: inline-flex;
+	gap: 2px;
 }
 
 .monaco-hover.workbench-hover.compact .monaco-action-bar .action-item .codicon {

--- a/src/vs/platform/hover/browser/hover.css
+++ b/src/vs/platform/hover/browser/hover.css
@@ -8,7 +8,7 @@
 .monaco-hover.workbench-hover {
 	position: relative;
 	font-size: 13px;
-	line-height: 19px;
+	/* line-height: 19px; */
 	/* Must be higher than sash's z-index and terminal canvases */
 	z-index: 40;
 	overflow: hidden;
@@ -32,6 +32,21 @@
 
 .monaco-hover.workbench-hover.compact {
 	font-size: 12px;
+}
+
+.monaco-hover.workbench-hover.compact .codicon,
+.monaco-hover.monaco-hover-content .code-hover-contents {
+	font-size: 16px;
+}
+
+/* Increase codicon size in hover content paragraphs - use !important to override inline styles */
+.monaco-hover .monaco-hover-content p .codicon {
+	font-size: 16px !important;
+}
+
+.monaco-hover .monaco-hover-content p:last-child span:not(.codicon),
+.monaco-hover .monaco-hover-content p:last-child a:not(.codicon) {
+	padding: 2px 0;
 }
 
 .monaco-hover.workbench-hover.compact .monaco-action-bar .action-item .codicon {

--- a/src/vs/platform/hover/browser/hover.css
+++ b/src/vs/platform/hover/browser/hover.css
@@ -8,7 +8,6 @@
 .monaco-hover.workbench-hover {
 	position: relative;
 	font-size: 13px;
-	/* line-height: 19px; */
 	/* Must be higher than sash's z-index and terminal canvases */
 	z-index: 40;
 	overflow: hidden;

--- a/src/vs/workbench/contrib/scm/browser/media/scm.css
+++ b/src/vs/workbench/contrib/scm/browser/media/scm.css
@@ -591,29 +591,6 @@
 
 /* History item hover */
 
-/* .monaco-hover.history-item-hover p:first-child {
-	margin-top: 4px;
-	display: flex;
-	align-items: center;
-}
-
-.monaco-hover.history-item-hover p:first-child img {
-	border-radius: 50%;
-	margin-right: 4px;
-}
-
-.monaco-hover.history-item-hover p:first-child .codicon {
-	margin: 0 2px;
-} */
-
-.monaco-hover.history-item-hover p:last-child {
-	margin-bottom: 2px !important;
-}
-
-.monaco-hover.history-item-hover p:last-child span:not(.codicon) {
-	padding: 2px 0;
-}
-
 .monaco-hover.history-item-hover hr {
 	margin-top: 4px;
 	margin-bottom: 4px;

--- a/src/vs/workbench/contrib/scm/browser/media/scm.css
+++ b/src/vs/workbench/contrib/scm/browser/media/scm.css
@@ -591,9 +591,20 @@
 
 /* History item hover */
 
-.monaco-hover.history-item-hover p:first-child {
+/* .monaco-hover.history-item-hover p:first-child {
 	margin-top: 4px;
+	display: flex;
+	align-items: center;
 }
+
+.monaco-hover.history-item-hover p:first-child img {
+	border-radius: 50%;
+	margin-right: 4px;
+}
+
+.monaco-hover.history-item-hover p:first-child .codicon {
+	margin: 0 2px;
+} */
 
 .monaco-hover.history-item-hover p:last-child {
 	margin-bottom: 2px !important;


### PR DESCRIPTION
Improve the layout and spacing of the hover widget by refining styles and removing unused CSS rules. Adjustments enhance the overall appearance & align codicon sizes with the rest of the UI. 

<img width="1158" height="964" alt="image" src="https://github.com/user-attachments/assets/e9101e60-91d9-4532-b0dc-9854b04a752e" />


