### PR TITLE
allow disabling certain detail orientation, add `north` rendering 

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalSuggestAddon.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalSuggestAddon.ts
@@ -794,6 +794,7 @@ export class SuggestAddon extends Disposable implements ITerminalAddon, ISuggest
 					statusBarMenuId: MenuId.MenubarTerminalSuggestStatusMenu,
 					showStatusBarSettingId: TerminalSuggestSettingId.ShowStatusBar,
 					selectionModeSettingId: TerminalSuggestSettingId.SelectionMode,
+					preventDetailsPlacements: ['west'],
 				},
 				this._getFontInfo.bind(this),
 				this._onDidFontConfigurationChange.event.bind(this),

--- a/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalSuggestAddon.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalSuggestAddon.ts
@@ -35,6 +35,7 @@ import { localize } from '../../../../../nls.js';
 import { TerminalSuggestTelemetry } from './terminalSuggestTelemetry.js';
 import { terminalSymbolAliasIcon, terminalSymbolArgumentIcon, terminalSymbolEnumMember, terminalSymbolFileIcon, terminalSymbolFlagIcon, terminalSymbolInlineSuggestionIcon, terminalSymbolMethodIcon, terminalSymbolOptionIcon, terminalSymbolFolderIcon, terminalSymbolSymbolicLinkFileIcon, terminalSymbolSymbolicLinkFolderIcon, terminalSymbolCommitIcon, terminalSymbolBranchIcon, terminalSymbolTagIcon, terminalSymbolStashIcon, terminalSymbolRemoteIcon, terminalSymbolPullRequestIcon, terminalSymbolPullRequestDoneIcon, terminalSymbolSymbolTextIcon } from './terminalSymbolIcons.js';
 import { TerminalSuggestShownTracker } from './terminalSuggestShownTracker.js';
+import { SimpleSuggestDetailsPlacement } from '../../../../services/suggest/browser/simpleSuggestWidgetDetails.js';
 
 export interface ISuggestController {
 	isPasting: boolean;
@@ -794,7 +795,7 @@ export class SuggestAddon extends Disposable implements ITerminalAddon, ISuggest
 					statusBarMenuId: MenuId.MenubarTerminalSuggestStatusMenu,
 					showStatusBarSettingId: TerminalSuggestSettingId.ShowStatusBar,
 					selectionModeSettingId: TerminalSuggestSettingId.SelectionMode,
-					preventDetailsPlacements: ['west'],
+					preventDetailsPlacements: [SimpleSuggestDetailsPlacement.West],
 				},
 				this._getFontInfo.bind(this),
 				this._onDidFontConfigurationChange.event.bind(this),

--- a/src/vs/workbench/services/suggest/browser/simpleSuggestWidget.ts
+++ b/src/vs/workbench/services/suggest/browser/simpleSuggestWidget.ts
@@ -83,7 +83,6 @@ export interface IWorkbenchSuggestWidgetOptions {
 
 	/**
 	 * Disables specific detail placements when positioning the details overlay.
-	 * Valid values: `'east' | 'west' | 'south' | 'north'`.
 	 */
 	preventDetailsPlacements?: readonly SimpleSuggestDetailsPlacement[];
 }

--- a/src/vs/workbench/services/suggest/browser/simpleSuggestWidget.ts
+++ b/src/vs/workbench/services/suggest/browser/simpleSuggestWidget.ts
@@ -21,7 +21,7 @@ import { SuggestWidgetStatus } from '../../../../editor/contrib/suggest/browser/
 import { MenuId } from '../../../../platform/actions/common/actions.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
-import { canExpandCompletionItem, SimpleSuggestDetailsOverlay, SimpleSuggestDetailsWidget } from './simpleSuggestWidgetDetails.js';
+import { canExpandCompletionItem, SimpleSuggestDetailsOverlay, SimpleSuggestDetailsWidget, type SimpleSuggestDetailsPlacement } from './simpleSuggestWidgetDetails.js';
 import { IContextKey, IContextKeyService, RawContextKey } from '../../../../platform/contextkey/common/contextkey.js';
 import * as strings from '../../../../base/common/strings.js';
 import { status } from '../../../../base/browser/ui/aria/aria.js';
@@ -80,6 +80,12 @@ export interface IWorkbenchSuggestWidgetOptions {
 	 * The setting for selection mode.
 	 */
 	selectionModeSettingId?: string;
+
+	/**
+	 * Disables specific detail placements when positioning the details overlay.
+	 * Valid values: `'east' | 'west' | 'south' | 'north'`.
+	 */
+	preventDetailsPlacements?: readonly SimpleSuggestDetailsPlacement[];
 }
 
 /**
@@ -269,7 +275,7 @@ export class SimpleSuggestWidget<TModel extends SimpleCompletionModel<TItem>, TI
 
 		const details: SimpleSuggestDetailsWidget = this._register(_instantiationService.createInstance(SimpleSuggestDetailsWidget, this._getFontInfo.bind(this), this._onDidFontConfigurationChange.bind(this), this._getAdvancedExplainModeDetails.bind(this)));
 		this._register(details.onDidClose(() => this.toggleDetails()));
-		this._details = this._register(new SimpleSuggestDetailsOverlay(details, this._listElement));
+		this._details = this._register(new SimpleSuggestDetailsOverlay(details, this._listElement, this._options.preventDetailsPlacements));
 		this._register(dom.addDisposableListener(this._details.widget.domNode, 'blur', (e) => this._onDidBlurDetails.fire(e)));
 
 		if (_options.statusBarMenuId && _options.showStatusBarSettingId && _configurationService.getValue(_options.showStatusBarSettingId)) {

--- a/src/vs/workbench/services/suggest/browser/simpleSuggestWidgetDetails.ts
+++ b/src/vs/workbench/services/suggest/browser/simpleSuggestWidgetDetails.ts
@@ -24,10 +24,10 @@ export function canExpandCompletionItem(item: SimpleCompletionItem | undefined):
 export const SuggestDetailsClassName = 'suggest-details';
 
 export const enum SimpleSuggestDetailsPlacement {
-	East = 'east',
-	West = 'west',
-	South = 'south',
-	North = 'north'
+	East = 0,
+	West = 1,
+	South = 2,
+	North = 3
 }
 
 export class SimpleSuggestDetailsWidget {


### PR DESCRIPTION
fix #276741

We never want the details to render `west` of the list even if that fits best. The next best fitting in certain cases, `east`, looks very crammed. Adds `north` rendering to address this.

Before:

<img width="792" height="254" alt="image" src="https://github.com/user-attachments/assets/b59a339f-9089-4cf7-b106-469753449743" />

After:

<img width="754" height="178" alt="Screenshot 2025-11-11 at 1 04 49 PM" src="https://github.com/user-attachments/assets/2d9aaeb6-477a-4b11-a767-d022b8c6d611" />


