### PR TITLE
fix terminal output getting trunchated

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/media/chatTerminalToolProgressPart.css
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/media/chatTerminalToolProgressPart.css
@@ -87,6 +87,7 @@
 	padding: 4px 6px;
 	max-width: 100%;
 	height: 100%;
+	box-sizing: border-box;
 }
 .chat-terminal-output-content {
 	display: flex;


### PR DESCRIPTION
fix https://github.com/microsoft/vscode/issues/275884

This `box-sizing: border-box` makes the `padding` included in the height calculation so pixels aren't cutoff.

<img width="483" height="310" alt="Screenshot 2025-11-11 at 2 43 55 PM" src="https://github.com/user-attachments/assets/9e672f6c-3cb9-4455-be3a-f4f776e2ddd8" />
