### PR TITLE
Move accent-insensitive filtering to common

### DIFF
--- a/src/vs/base/common/filters.ts
+++ b/src/vs/base/common/filters.ts
@@ -96,6 +96,10 @@ export function matchesBaseContiguousSubString(word: string, wordToMatchAgainst:
 // Substring
 
 export function matchesSubString(word: string, wordToMatchAgainst: string): IMatch[] | null {
+	if (word.length > wordToMatchAgainst.length) {
+		return null;
+	}
+
 	return _matchesSubString(word.toLowerCase(), wordToMatchAgainst.toLowerCase(), 0, 0);
 }
 

--- a/src/vs/base/common/filters.ts
+++ b/src/vs/base/common/filters.ts
@@ -6,6 +6,7 @@
 import { CharCode } from './charCode.js';
 import { LRUCache } from './map.js';
 import { getKoreanAltChars } from './naturalLanguage/korean.js';
+import { tryNormalizeToBase } from './normalization.js';
 import * as strings from './strings.js';
 
 export interface IFilter {
@@ -65,7 +66,26 @@ function _matchesPrefix(ignoreCase: boolean, word: string, wordToMatchAgainst: s
 // Contiguous Substring
 
 export function matchesContiguousSubString(word: string, wordToMatchAgainst: string): IMatch[] | null {
+	if (word.length > wordToMatchAgainst.length) {
+		return null;
+	}
+
 	const index = wordToMatchAgainst.toLowerCase().indexOf(word.toLowerCase());
+	if (index === -1) {
+		return null;
+	}
+
+	return [{ start: index, end: index + word.length }];
+}
+
+export function matchesBaseContiguousSubString(word: string, wordToMatchAgainst: string): IMatch[] | null {
+	if (word.length > wordToMatchAgainst.length) {
+		return null;
+	}
+
+	word = tryNormalizeToBase(word);
+	wordToMatchAgainst = tryNormalizeToBase(wordToMatchAgainst);
+	const index = wordToMatchAgainst.indexOf(word);
 	if (index === -1) {
 		return null;
 	}
@@ -121,7 +141,7 @@ function isWhitespace(code: number): boolean {
 }
 
 const wordSeparators = new Set<number>();
-// These are chosen as natural word separators based on writen text.
+// These are chosen as natural word separators based on written text.
 // It is a subset of the word separators used by the monaco editor.
 '()[]{}<>`\'"-/;:,.?!'
 	.split('')
@@ -319,8 +339,8 @@ export function matchesWords(word: string, target: string, contiguous: boolean =
 	let result: IMatch[] | null = null;
 	let targetIndex = 0;
 
-	word = word.toLowerCase();
-	target = target.toLowerCase();
+	word = tryNormalizeToBase(word);
+	target = tryNormalizeToBase(target);
 	while (targetIndex < target.length) {
 		result = _matchesWords(word, target, 0, targetIndex, contiguous);
 		if (result !== null) {

--- a/src/vs/base/common/normalization.ts
+++ b/src/vs/base/common/normalization.ts
@@ -55,15 +55,8 @@ export const tryNormalizeToBase: (str: string) => string = function () {
 			return cached;
 		}
 
-		let result = str;
-		if (nonAsciiCharactersPattern.test(str)) {
-			const noAccents = str.normalize('NFD').replace(accentsRegex, '');
-			if (noAccents.length === str.length) {
-				result = noAccents;
-			}
-		}
-
-		result = result.toLowerCase();
+		const noAccents = normalizeNFD(str).replace(accentsRegex, '');
+		const result = (noAccents.length === str.length ? noAccents : str).toLowerCase();
 		cache.set(str, result);
 		return result;
 	};

--- a/src/vs/base/common/normalization.ts
+++ b/src/vs/base/common/normalization.ts
@@ -39,11 +39,32 @@ function normalize(str: string, form: string, normalizedCache: LRUCache<string, 
 	return res;
 }
 
-export const removeAccents: (str: string) => string = (function () {
-	// transform into NFD form and remove accents
-	// see: https://stackoverflow.com/questions/990904/remove-accents-diacritics-in-a-string-in-javascript/37511463#37511463
-	const regex = /[\u0300-\u036f]/g;
-	return function (str: string) {
-		return normalizeNFD(str).replace(regex, '');
+/**
+ * Attempts to normalize the string to Unicode base format (NFD -> remove accents -> lower case).
+ * When original string contains accent characters directly, only lower casing will be performed.
+ * This is done so as to keep the string length the same and not affect indices.
+*
+* @see https://stackoverflow.com/questions/990904/remove-accents-diacritics-in-a-string-in-javascript/37511463#37511463
+*/
+export const tryNormalizeToBase: (str: string) => string = function () {
+	const cache = new LRUCache<string, string>(10000); // bounded to 10000 elements
+	const accentsRegex = /[\u0300-\u036f]/g;
+	return function (str: string): string {
+		const cached = cache.get(str);
+		if (cached) {
+			return cached;
+		}
+
+		let result = str;
+		if (nonAsciiCharactersPattern.test(str)) {
+			const noAccents = str.normalize('NFD').replace(accentsRegex, '');
+			if (noAccents.length === str.length) {
+				result = noAccents;
+			}
+		}
+
+		result = result.toLowerCase();
+		cache.set(str, result);
+		return result;
 	};
-})();
+}();

--- a/src/vs/base/common/normalization.ts
+++ b/src/vs/base/common/normalization.ts
@@ -43,9 +43,9 @@ function normalize(str: string, form: string, normalizedCache: LRUCache<string, 
  * Attempts to normalize the string to Unicode base format (NFD -> remove accents -> lower case).
  * When original string contains accent characters directly, only lower casing will be performed.
  * This is done so as to keep the string length the same and not affect indices.
-*
-* @see https://stackoverflow.com/questions/990904/remove-accents-diacritics-in-a-string-in-javascript/37511463#37511463
-*/
+ *
+ * @see https://stackoverflow.com/questions/990904/remove-accents-diacritics-in-a-string-in-javascript/37511463#37511463
+ */
 export const tryNormalizeToBase: (str: string) => string = function () {
 	const cache = new LRUCache<string, string>(10000); // bounded to 10000 elements
 	const accentsRegex = /[\u0300-\u036f]/g;

--- a/src/vs/base/test/common/filters.test.ts
+++ b/src/vs/base/test/common/filters.test.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 import assert from 'assert';
-import { anyScore, createMatches, fuzzyScore, fuzzyScoreGraceful, fuzzyScoreGracefulAggressive, FuzzyScorer, IFilter, IMatch, matchesCamelCase, matchesContiguousSubString, matchesPrefix, matchesStrictPrefix, matchesSubString, matchesWords, or } from '../../common/filters.js';
+import { anyScore, createMatches, fuzzyScore, fuzzyScoreGraceful, fuzzyScoreGracefulAggressive, FuzzyScorer, IFilter, IMatch, matchesBaseContiguousSubString, matchesCamelCase, matchesContiguousSubString, matchesPrefix, matchesStrictPrefix, matchesSubString, matchesWords, or } from '../../common/filters.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from './utils.js';
 
 function filterOk(filter: IFilter, word: string, wordToMatchAgainst: string, highlights?: { start: number; end: number }[]) {
@@ -155,6 +155,30 @@ suite('Filters', () => {
 	test('matchesContiguousSubString', () => {
 		filterOk(matchesContiguousSubString, 'cela', 'cancelAnimationFrame()', [
 			{ start: 3, end: 7 }
+		]);
+	});
+
+	test('matchesBaseContiguousSubString', () => {
+		filterOk(matchesBaseContiguousSubString, 'cela', 'cancelAnimationFrame()', [
+			{ start: 3, end: 7 }
+		]);
+		filterOk(matchesBaseContiguousSubString, 'cafe', 'café', [
+			{ start: 0, end: 4 }
+		]);
+		filterOk(matchesBaseContiguousSubString, 'cafe', 'caféBar', [
+			{ start: 0, end: 4 }
+		]);
+		filterOk(matchesBaseContiguousSubString, 'resume', 'résumé', [
+			{ start: 0, end: 6 }
+		]);
+		filterOk(matchesBaseContiguousSubString, 'naïve', 'naïve', [
+			{ start: 0, end: 5 }
+		]);
+		filterOk(matchesBaseContiguousSubString, 'naive', 'naïve', [
+			{ start: 0, end: 5 }
+		]);
+		filterOk(matchesBaseContiguousSubString, 'aeou', 'àéöü', [
+			{ start: 0, end: 4 }
 		]);
 	});
 

--- a/src/vs/base/test/common/normalization.test.ts
+++ b/src/vs/base/test/common/normalization.test.ts
@@ -4,64 +4,86 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
-import { removeAccents } from '../../common/normalization.js';
+import { tryNormalizeToBase } from '../../common/normalization.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from './utils.js';
 
 suite('Normalization', () => {
 	ensureNoDisposablesAreLeakedInTestSuite();
 
-	test('removeAccents', function () {
-		assert.strictEqual(removeAccents('joào'), 'joao');
-		assert.strictEqual(removeAccents('joáo'), 'joao');
-		assert.strictEqual(removeAccents('joâo'), 'joao');
-		assert.strictEqual(removeAccents('joäo'), 'joao');
-		// assert.strictEqual(strings.removeAccents('joæo'), 'joao'); // not an accent
-		assert.strictEqual(removeAccents('joão'), 'joao');
-		assert.strictEqual(removeAccents('joåo'), 'joao');
-		assert.strictEqual(removeAccents('joåo'), 'joao');
-		assert.strictEqual(removeAccents('joāo'), 'joao');
+	test('tryNormalizeToBase', function () {
+		assert.strictEqual(tryNormalizeToBase('joào'), 'joao');
+		assert.strictEqual(tryNormalizeToBase('joáo'), 'joao');
+		assert.strictEqual(tryNormalizeToBase('joâo'), 'joao');
+		assert.strictEqual(tryNormalizeToBase('joäo'), 'joao');
+		// assert.strictEqual(strings.tryNormalizeToBase('joæo'), 'joao'); // not an accent
+		assert.strictEqual(tryNormalizeToBase('joão'), 'joao');
+		assert.strictEqual(tryNormalizeToBase('joåo'), 'joao');
+		assert.strictEqual(tryNormalizeToBase('joåo'), 'joao');
+		assert.strictEqual(tryNormalizeToBase('joāo'), 'joao');
 
-		assert.strictEqual(removeAccents('fôo'), 'foo');
-		assert.strictEqual(removeAccents('föo'), 'foo');
-		assert.strictEqual(removeAccents('fòo'), 'foo');
-		assert.strictEqual(removeAccents('fóo'), 'foo');
-		// assert.strictEqual(strings.removeAccents('fœo'), 'foo');
-		// assert.strictEqual(strings.removeAccents('føo'), 'foo');
-		assert.strictEqual(removeAccents('fōo'), 'foo');
-		assert.strictEqual(removeAccents('fõo'), 'foo');
+		assert.strictEqual(tryNormalizeToBase('fôo'), 'foo');
+		assert.strictEqual(tryNormalizeToBase('föo'), 'foo');
+		assert.strictEqual(tryNormalizeToBase('fòo'), 'foo');
+		assert.strictEqual(tryNormalizeToBase('fóo'), 'foo');
+		// assert.strictEqual(strings.tryNormalizeToBase('fœo'), 'foo');
+		// assert.strictEqual(strings.tryNormalizeToBase('føo'), 'foo');
+		assert.strictEqual(tryNormalizeToBase('fōo'), 'foo');
+		assert.strictEqual(tryNormalizeToBase('fõo'), 'foo');
 
-		assert.strictEqual(removeAccents('andrè'), 'andre');
-		assert.strictEqual(removeAccents('andré'), 'andre');
-		assert.strictEqual(removeAccents('andrê'), 'andre');
-		assert.strictEqual(removeAccents('andrë'), 'andre');
-		assert.strictEqual(removeAccents('andrē'), 'andre');
-		assert.strictEqual(removeAccents('andrė'), 'andre');
-		assert.strictEqual(removeAccents('andrę'), 'andre');
+		assert.strictEqual(tryNormalizeToBase('andrè'), 'andre');
+		assert.strictEqual(tryNormalizeToBase('andré'), 'andre');
+		assert.strictEqual(tryNormalizeToBase('andrê'), 'andre');
+		assert.strictEqual(tryNormalizeToBase('andrë'), 'andre');
+		assert.strictEqual(tryNormalizeToBase('andrē'), 'andre');
+		assert.strictEqual(tryNormalizeToBase('andrė'), 'andre');
+		assert.strictEqual(tryNormalizeToBase('andrę'), 'andre');
 
-		assert.strictEqual(removeAccents('hvîc'), 'hvic');
-		assert.strictEqual(removeAccents('hvïc'), 'hvic');
-		assert.strictEqual(removeAccents('hvíc'), 'hvic');
-		assert.strictEqual(removeAccents('hvīc'), 'hvic');
-		assert.strictEqual(removeAccents('hvįc'), 'hvic');
-		assert.strictEqual(removeAccents('hvìc'), 'hvic');
+		assert.strictEqual(tryNormalizeToBase('hvîc'), 'hvic');
+		assert.strictEqual(tryNormalizeToBase('hvïc'), 'hvic');
+		assert.strictEqual(tryNormalizeToBase('hvíc'), 'hvic');
+		assert.strictEqual(tryNormalizeToBase('hvīc'), 'hvic');
+		assert.strictEqual(tryNormalizeToBase('hvįc'), 'hvic');
+		assert.strictEqual(tryNormalizeToBase('hvìc'), 'hvic');
 
-		assert.strictEqual(removeAccents('ûdo'), 'udo');
-		assert.strictEqual(removeAccents('üdo'), 'udo');
-		assert.strictEqual(removeAccents('ùdo'), 'udo');
-		assert.strictEqual(removeAccents('údo'), 'udo');
-		assert.strictEqual(removeAccents('ūdo'), 'udo');
+		assert.strictEqual(tryNormalizeToBase('ûdo'), 'udo');
+		assert.strictEqual(tryNormalizeToBase('üdo'), 'udo');
+		assert.strictEqual(tryNormalizeToBase('ùdo'), 'udo');
+		assert.strictEqual(tryNormalizeToBase('údo'), 'udo');
+		assert.strictEqual(tryNormalizeToBase('ūdo'), 'udo');
 
-		assert.strictEqual(removeAccents('heÿ'), 'hey');
+		assert.strictEqual(tryNormalizeToBase('heÿ'), 'hey');
 
-		// assert.strictEqual(strings.removeAccents('gruß'), 'grus');
-		assert.strictEqual(removeAccents('gruś'), 'grus');
-		assert.strictEqual(removeAccents('gruš'), 'grus');
+		// assert.strictEqual(strings.tryNormalizeToBase('gruß'), 'grus');
+		assert.strictEqual(tryNormalizeToBase('gruś'), 'grus');
+		assert.strictEqual(tryNormalizeToBase('gruš'), 'grus');
 
-		assert.strictEqual(removeAccents('çool'), 'cool');
-		assert.strictEqual(removeAccents('ćool'), 'cool');
-		assert.strictEqual(removeAccents('čool'), 'cool');
+		assert.strictEqual(tryNormalizeToBase('çool'), 'cool');
+		assert.strictEqual(tryNormalizeToBase('ćool'), 'cool');
+		assert.strictEqual(tryNormalizeToBase('čool'), 'cool');
 
-		assert.strictEqual(removeAccents('ñice'), 'nice');
-		assert.strictEqual(removeAccents('ńice'), 'nice');
+		assert.strictEqual(tryNormalizeToBase('ñice'), 'nice');
+		assert.strictEqual(tryNormalizeToBase('ńice'), 'nice');
+
+		// Different cases
+		assert.strictEqual(tryNormalizeToBase('CAFÉ'), 'cafe');
+		assert.strictEqual(tryNormalizeToBase('Café'), 'cafe');
+		assert.strictEqual(tryNormalizeToBase('café'), 'cafe');
+		assert.strictEqual(tryNormalizeToBase('JOÃO'), 'joao');
+		assert.strictEqual(tryNormalizeToBase('João'), 'joao');
+
+		// Mixed cases with accents
+		assert.strictEqual(tryNormalizeToBase('CaFé'), 'cafe');
+		assert.strictEqual(tryNormalizeToBase('JoÃo'), 'joao');
+		assert.strictEqual(tryNormalizeToBase('AnDrÉ'), 'andre');
+
+		// Precomposed accents
+		assert.strictEqual(tryNormalizeToBase('\u00E9'), 'e');
+		assert.strictEqual(tryNormalizeToBase('\u00E0'), 'a');
+		assert.strictEqual(tryNormalizeToBase('caf\u00E9'), 'cafe');
+
+		// Base + combining accents - lower only
+		assert.strictEqual(tryNormalizeToBase('\u0065\u0301'), '\u0065\u0301');
+		assert.strictEqual(tryNormalizeToBase('Ã\u0061\u0300'), 'ã\u0061\u0300');
+		assert.strictEqual(tryNormalizeToBase('CaF\u0065\u0301'), 'caf\u0065\u0301');
 	});
 });

--- a/src/vs/workbench/contrib/chat/browser/chatManagement/chatModelsViewModel.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatManagement/chatModelsViewModel.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { distinct, coalesce } from '../../../../../base/common/arrays.js';
-import { IMatch, IFilter, or, matchesContiguousSubString, matchesPrefix, matchesCamelCase, matchesWords } from '../../../../../base/common/filters.js';
+import { IMatch, IFilter, or, matchesCamelCase, matchesWords, matchesBaseContiguousSubString } from '../../../../../base/common/filters.js';
 import { Emitter } from '../../../../../base/common/event.js';
 import { EditorModel } from '../../../../common/editor/editorModel.js';
 import { ILanguageModelsService, ILanguageModelChatMetadata, IUserFriendlyLanguageModel } from '../../../chat/common/languageModels.js';
@@ -13,7 +13,7 @@ import { IChatEntitlementService } from '../../../../services/chat/common/chatEn
 export const MODEL_ENTRY_TEMPLATE_ID = 'model.entry.template';
 export const VENDOR_ENTRY_TEMPLATE_ID = 'vendor.entry.template';
 
-const wordFilter = or(matchesPrefix, matchesWords, matchesContiguousSubString);
+const wordFilter = or(matchesBaseContiguousSubString, matchesWords);
 const CAPABILITY_REGEX = /@capability:\s*([^\s]+)/gi;
 const VISIBLE_REGEX = /@visible:\s*(true|false)/i;
 

--- a/src/vs/workbench/contrib/preferences/browser/preferencesSearch.ts
+++ b/src/vs/workbench/contrib/preferences/browser/preferencesSearch.ts
@@ -6,7 +6,7 @@
 import { distinct } from '../../../../base/common/arrays.js';
 import { CancellationToken } from '../../../../base/common/cancellation.js';
 import { IStringDictionary } from '../../../../base/common/collections.js';
-import { IMatch, matchesContiguousSubString, matchesSubString, matchesWords } from '../../../../base/common/filters.js';
+import { IMatch, matchesBaseContiguousSubString, matchesContiguousSubString, matchesSubString, matchesWords } from '../../../../base/common/filters.js';
 import { Disposable } from '../../../../base/common/lifecycle.js';
 import * as strings from '../../../../base/common/strings.js';
 import { TfIdfCalculator, TfIdfDocument } from '../../../../base/common/tfIdf.js';
@@ -261,7 +261,7 @@ export class SettingMatches {
 			for (const word of queryWords) {
 				// Search the description lines.
 				for (let lineIndex = 0; lineIndex < setting.description.length; lineIndex++) {
-					const descriptionMatches = matchesContiguousSubString(word, setting.description[lineIndex]);
+					const descriptionMatches = matchesBaseContiguousSubString(word, setting.description[lineIndex]);
 					if (descriptionMatches?.length) {
 						descriptionMatchingWords.set(word, descriptionMatches.map(match => this.toDescriptionRange(setting, match, lineIndex)));
 					}

--- a/src/vs/workbench/services/preferences/browser/keybindingsEditorModel.ts
+++ b/src/vs/workbench/services/preferences/browser/keybindingsEditorModel.ts
@@ -7,7 +7,7 @@ import { localize } from '../../../../nls.js';
 import { distinct, coalesce } from '../../../../base/common/arrays.js';
 import * as strings from '../../../../base/common/strings.js';
 import { OperatingSystem, Language } from '../../../../base/common/platform.js';
-import { IMatch, IFilter, or, matchesContiguousSubString, matchesPrefix, matchesCamelCase, matchesWords } from '../../../../base/common/filters.js';
+import { IMatch, IFilter, or, matchesCamelCase, matchesWords, matchesBaseContiguousSubString, matchesContiguousSubString } from '../../../../base/common/filters.js';
 import { ResolvedKeybinding, ResolvedChord } from '../../../../base/common/keybindings.js';
 import { AriaLabelProvider, UserSettingsLabelProvider, UILabelProvider, ModifierLabels as ModLabels } from '../../../../base/common/keybindingLabels.js';
 import { MenuRegistry } from '../../../../platform/actions/common/actions.js';
@@ -39,7 +39,7 @@ export function createKeybindingCommandQuery(commandId: string, when?: string): 
 	return `@command:${commandId}${whenPart}`;
 }
 
-const wordFilter = or(matchesPrefix, matchesWords, matchesContiguousSubString);
+const wordFilter = or(matchesBaseContiguousSubString, matchesWords);
 const COMMAND_REGEX = /@command:\s*([^\+]+)/i;
 const WHEN_REGEX = /\+when:\s*(.+)/i;
 const SOURCE_REGEX = /@source:\s*(user|default|system|extension)/i;


### PR DESCRIPTION
Fixes #270711

Added new `tryNormalizeToBase` method to `normalization.ts` which will perform NFD+accent removal+lower casing and cache the result.

Removed `removeAccents` since it was not used after this change and it is not safe to use (does not preserve the indices).

Moved accent-insensitive logic to `filters.txt` by using the new `tryNormalizeToBase` method.

Replaced filters that match on natural language and used `matchesPrefix` or `matchesContiguousSubString` with a single call to `matchesBaseContiguousSubString` filter which will do both. This does change the order of preferences (contiguous substring will now take precedence other words), but it will make one less filtering call per item.

Updated unit-tests.

**Note**: The intent of `getAlternateCodes` is similar to what `tryNormalizeToBase` is doing, but at the same time building tables for all Unicode accents and combined characters into our code seems impractical, so keep those two separate, although normalization will occur before Korean replacement, so the two will work together in `matchesWords` case.