### PR TITLE
store expanded state for terminal output items

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart.ts
@@ -58,6 +58,11 @@ const sanitizerConfig = Object.freeze<DomSanitizerConfig>({
 
 let lastFocusedProgressPart: ChatTerminalToolProgressPart | undefined;
 
+/**
+ * Remembers whether a tool invocation was last expanded so state survives virtualization re-renders.
+ */
+const expandedStateByInvocation = new WeakMap<IChatToolInvocation | IChatToolInvocationSerialized, boolean>();
+
 export class ChatTerminalToolProgressPart extends BaseChatToolInvocationSubPart {
 	public readonly domNode: HTMLElement;
 
@@ -182,6 +187,10 @@ export class ChatTerminalToolProgressPart extends BaseChatToolInvocationSubPart 
 
 		const progressPart = this._register(_instantiationService.createInstance(ChatProgressSubPart, elements.container, this.getIcon(), terminalData.autoApproveInfo));
 		this.domNode = progressPart.domNode;
+
+		if (expandedStateByInvocation.get(toolInvocation)) {
+			void this._toggleOutput(true);
+		}
 	}
 
 	private async _createActionBar(elements: { actionBar: HTMLElement }): Promise<void> {
@@ -358,6 +367,7 @@ export class ChatTerminalToolProgressPart extends BaseChatToolInvocationSubPart 
 		this._outputContainer.classList.toggle('expanded', expanded);
 		this._outputContainer.classList.toggle('collapsed', !expanded);
 		this._titlePart.classList.toggle('expanded', expanded);
+		expandedStateByInvocation.set(this.toolInvocation, expanded);
 	}
 
 	private async _renderOutputIfNeeded(): Promise<boolean> {


### PR DESCRIPTION
fixes #275929

When you scroll the chat list far enough, it throws away off screen rows. Later, when you scroll back up, it rebuilds the row for that tool invocation. The rebuilt part starts in its default collapsed state unless we remember what the user did before, which is why we now store the expanded flag so the new instance opens back up automatically.

Not sure if we care about storing this on reload of the window. I lean toward no here, but lmk what you think @tyriar


https://github.com/user-attachments/assets/639773a4-629a-4ccc-9959-aa0b0dde6445

