### PR TITLE
fetch: add domain-specific approval logic

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -274,6 +274,23 @@ configurationRegistry.registerConfiguration({
 				type: 'boolean',
 			}
 		},
+		[ChatConfiguration.ApprovedFetchUrls]: {
+			default: {},
+			markdownDescription: nls.localize('chat.tools.fetchPage.approvedUrls', "Controls which URLs are automatically approved when the fetch page tool is invoked. Keys are URL patterns (domain, wildcard domain, or full URL), and values can be `true` to approve both requests and responses, `false` to deny, or an object with `approveRequest` and `approveResponse` properties for granular control.\n\nExamples:\n- `\"example.com\": true` - Approve all requests to example.com\n- `\"*.example.com\": true` - Approve all requests to any subdomain of example.com\n- `\"example.com/api/*\": { \"approveRequest\": true, \"approveResponse\": false }` - Approve requests but not responses for example.com/api paths"),
+			type: 'object',
+			additionalProperties: {
+				oneOf: [
+					{ type: 'boolean' },
+					{
+						type: 'object',
+						properties: {
+							approveRequest: { type: 'boolean' },
+							approveResponse: { type: 'boolean' }
+						}
+					}
+				]
+			}
+		},
 		'chat.sendElementsToChat.enabled': {
 			default: true,
 			description: nls.localize('chat.sendElementsToChat.enabled', "Controls whether elements can be sent to chat from the Simple Browser."),

--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -276,7 +276,7 @@ configurationRegistry.registerConfiguration({
 		},
 		[ChatConfiguration.ApprovedFetchUrls]: {
 			default: {},
-			markdownDescription: nls.localize('chat.tools.fetchPage.approvedUrls', "Controls which URLs are automatically approved when the fetch page tool is invoked. Keys are URL patterns (domain, wildcard domain, or full URL), and values can be `true` to approve both requests and responses, `false` to deny, or an object with `approveRequest` and `approveResponse` properties for granular control.\n\nExamples:\n- `\"example.com\": true` - Approve all requests to example.com\n- `\"*.example.com\": true` - Approve all requests to any subdomain of example.com\n- `\"example.com/api/*\": { \"approveRequest\": true, \"approveResponse\": false }` - Approve requests but not responses for example.com/api paths"),
+			markdownDescription: nls.localize('chat.tools.fetchPage.approvedUrls', "Controls which URLs are automatically approved when the fetch page tool is invoked. Keys are URL patterns and values can be `true` to approve both requests and responses, `false` to deny, or an object with `approveRequest` and `approveResponse` properties for granular control.\n\nExamples:\n- `\"https://example.com\": true` - Approve all requests to example.com\n- `\"https://*.example.com\": true` - Approve all requests to any subdomain of example.com\n- `\"https://example.com/api/*\": { \"approveRequest\": true, \"approveResponse\": false }` - Approve requests but not responses for example.com/api paths"),
 			type: 'object',
 			additionalProperties: {
 				oneOf: [

--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -274,9 +274,9 @@ configurationRegistry.registerConfiguration({
 				type: 'boolean',
 			}
 		},
-		[ChatConfiguration.ApprovedFetchUrls]: {
+		[ChatConfiguration.AutoApprovedUrls]: {
 			default: {},
-			markdownDescription: nls.localize('chat.tools.fetchPage.approvedUrls', "Controls which URLs are automatically approved when the fetch page tool is invoked. Keys are URL patterns and values can be `true` to approve both requests and responses, `false` to deny, or an object with `approveRequest` and `approveResponse` properties for granular control.\n\nExamples:\n- `\"https://example.com\": true` - Approve all requests to example.com\n- `\"https://*.example.com\": true` - Approve all requests to any subdomain of example.com\n- `\"https://example.com/api/*\": { \"approveRequest\": true, \"approveResponse\": false }` - Approve requests but not responses for example.com/api paths"),
+			markdownDescription: nls.localize('chat.tools.fetchPage.approvedUrls', "Controls which URLs are automatically approved when requested by chat tools. Keys are URL patterns and values can be `true` to approve both requests and responses, `false` to deny, or an object with `approveRequest` and `approveResponse` properties for granular control.\n\nExamples:\n- `\"https://example.com\": true` - Approve all requests to example.com\n- `\"https://*.example.com\": true` - Approve all requests to any subdomain of example.com\n- `\"https://example.com/api/*\": { \"approveRequest\": true, \"approveResponse\": false }` - Approve requests but not responses for example.com/api paths"),
 			type: 'object',
 			additionalProperties: {
 				oneOf: [

--- a/src/vs/workbench/contrib/chat/browser/languageModelToolsConfirmationService.ts
+++ b/src/vs/workbench/contrib/chat/browser/languageModelToolsConfirmationService.ts
@@ -765,6 +765,11 @@ export class LanguageModelToolsConfirmationService extends Disposable implements
 		}));
 
 		disposables.add(quickTree.onDidAccept(() => {
+			for (const item of quickTree.activeItems) {
+				if (item.type === 'manage') {
+					(item as ILanguageModelToolConfirmationContributionQuickTreeItem).onDidOpen?.();
+				}
+			}
 			quickTree.hide();
 		}));
 

--- a/src/vs/workbench/contrib/chat/common/chatUrlFetchingConfirmation.ts
+++ b/src/vs/workbench/contrib/chat/common/chatUrlFetchingConfirmation.ts
@@ -66,7 +66,7 @@ export class ChatUrlFetchingConfirmationContribution implements ILanguageModelTo
 		if (allApproved) {
 			return {
 				type: ToolConfirmKind.Setting,
-				id: ChatConfiguration.ApprovedFetchUrls
+				id: ChatConfiguration.AutoApprovedUrls
 			};
 		}
 
@@ -205,7 +205,7 @@ export class ChatUrlFetchingConfirmationContribution implements ILanguageModelTo
 					}
 				}
 
-				return this._configurationService.updateValue(ChatConfiguration.ApprovedFetchUrls, current);
+				return this._configurationService.updateValue(ChatConfiguration.AutoApprovedUrls, current);
 			};
 
 			disposables.add(quickTree.onDidAccept(async () => {
@@ -239,7 +239,7 @@ export class ChatUrlFetchingConfirmationContribution implements ILanguageModelTo
 		approvedUrls[pattern] = value;
 
 		await this._configurationService.updateValue(
-			ChatConfiguration.ApprovedFetchUrls,
+			ChatConfiguration.AutoApprovedUrls,
 			approvedUrls
 		);
 	}
@@ -281,7 +281,7 @@ export class ChatUrlFetchingConfirmationContribution implements ILanguageModelTo
 						delete approvedUrls[pattern];
 					}
 
-					this._configurationService.updateValue(ChatConfiguration.ApprovedFetchUrls, approvedUrls);
+					this._configurationService.updateValue(ChatConfiguration.AutoApprovedUrls, approvedUrls);
 				}
 			};
 
@@ -293,7 +293,7 @@ export class ChatUrlFetchingConfirmationContribution implements ILanguageModelTo
 			label: localize('moreOptionsManage', "More Options..."),
 			description: localize('openSettings', "Open settings"),
 			onDidOpen: () => {
-				this._preferencesService.openUserSettings({ query: ChatConfiguration.ApprovedFetchUrls });
+				this._preferencesService.openUserSettings({ query: ChatConfiguration.AutoApprovedUrls });
 			}
 		});
 
@@ -302,14 +302,14 @@ export class ChatUrlFetchingConfirmationContribution implements ILanguageModelTo
 
 	async reset(): Promise<void> {
 		await this._configurationService.updateValue(
-			ChatConfiguration.ApprovedFetchUrls,
+			ChatConfiguration.AutoApprovedUrls,
 			{}
 		);
 	}
 
 	private _getApprovedUrls(): Readonly<Record<string, boolean | IUrlApprovalSettings>> {
 		return this._configurationService.getValue<Record<string, boolean | IUrlApprovalSettings>>(
-			ChatConfiguration.ApprovedFetchUrls
+			ChatConfiguration.AutoApprovedUrls
 		) || {};
 	}
 }

--- a/src/vs/workbench/contrib/chat/common/chatUrlFetchingConfirmation.ts
+++ b/src/vs/workbench/contrib/chat/common/chatUrlFetchingConfirmation.ts
@@ -1,0 +1,318 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Codicon } from '../../../../base/common/codicons.js';
+import { DisposableStore } from '../../../../base/common/lifecycle.js';
+import { ResourceMap } from '../../../../base/common/map.js';
+import { ThemeIcon } from '../../../../base/common/themables.js';
+import { URI } from '../../../../base/common/uri.js';
+import { localize } from '../../../../nls.js';
+import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
+import { IQuickInputButton, IQuickInputService, IQuickTreeItem } from '../../../../platform/quickinput/common/quickInput.js';
+import { IPreferencesService } from '../../../services/preferences/common/preferences.js';
+import { ConfirmedReason, ToolConfirmKind } from './chatService.js';
+import { ChatConfiguration } from './constants.js';
+import {
+	ILanguageModelToolConfirmationActions,
+	ILanguageModelToolConfirmationContribution,
+	ILanguageModelToolConfirmationContributionQuickTreeItem,
+	ILanguageModelToolConfirmationRef
+} from './languageModelToolsConfirmationService.js';
+import { extractUrlPatterns, getPatternLabel, isUrlApproved, IUrlApprovalSettings } from './chatUrlFetchingPatterns.js';
+
+const trashButton: IQuickInputButton = {
+	iconClass: ThemeIcon.asClassName(Codicon.trash),
+	tooltip: localize('delete', "Delete")
+};
+
+export class ChatUrlFetchingConfirmationContribution implements ILanguageModelToolConfirmationContribution {
+	readonly canUseDefaultApprovals = false;
+
+	constructor(
+		private readonly _getURLS: (parameters: unknown) => string[] | undefined,
+		@IConfigurationService private readonly _configurationService: IConfigurationService,
+		@IQuickInputService private readonly _quickInputService: IQuickInputService,
+		@IPreferencesService private readonly _preferencesService: IPreferencesService
+	) { }
+
+	getPreConfirmAction(ref: ILanguageModelToolConfirmationRef): ConfirmedReason | undefined {
+		return this._checkApproval(ref, true);
+	}
+
+	getPostConfirmAction(ref: ILanguageModelToolConfirmationRef): ConfirmedReason | undefined {
+		return this._checkApproval(ref, false);
+	}
+
+	private _checkApproval(ref: ILanguageModelToolConfirmationRef, checkRequest: boolean): ConfirmedReason | undefined {
+		const urls = this._getURLS(ref.parameters);
+		if (!urls || urls.length === 0) {
+			return undefined;
+		}
+
+		const approvedUrls = this._getApprovedUrls();
+
+		// Check if all URLs are approved
+		const allApproved = urls.every(url => {
+			try {
+				const uri = URI.parse(url);
+				return isUrlApproved(uri, approvedUrls, checkRequest);
+			} catch {
+				return false;
+			}
+		});
+
+		if (allApproved) {
+			return {
+				type: ToolConfirmKind.Setting,
+				id: ChatConfiguration.ApprovedFetchUrls
+			};
+		}
+
+		return undefined;
+	}
+
+	getPreConfirmActions(ref: ILanguageModelToolConfirmationRef): ILanguageModelToolConfirmationActions[] {
+		return this._getConfirmActions(ref, true);
+	}
+
+	getPostConfirmActions(ref: ILanguageModelToolConfirmationRef): ILanguageModelToolConfirmationActions[] {
+		return this._getConfirmActions(ref, false);
+	}
+
+	private _getConfirmActions(ref: ILanguageModelToolConfirmationRef, forRequest: boolean): ILanguageModelToolConfirmationActions[] {
+		const urls = this._getURLS(ref.parameters);
+		if (!urls || urls.length === 0) {
+			return [];
+		}
+
+		const actions: ILanguageModelToolConfirmationActions[] = [];
+
+		// Get unique URLs (may have duplicates)
+		const uniqueUrls = Array.from(new Set(urls)).map(u => URI.parse(u));
+
+		// For each URL, get its patterns
+		const urlPatterns = new ResourceMap<string[]>(uniqueUrls.map(u => [u, extractUrlPatterns(u)] as const));
+
+		// If only one URL, show quick actions for specific patterns
+		if (urlPatterns.size === 1) {
+			const uri = uniqueUrls[0];
+			const patterns = urlPatterns.get(uri)!;
+
+			// Show top 2 most relevant patterns as quick actions
+			const topPatterns = patterns.slice(0, 2);
+			for (const pattern of topPatterns) {
+				const patternLabel = getPatternLabel(uri, pattern);
+				actions.push({
+					label: forRequest
+						? localize('approveRequestTo', "Allow requests to {0}", patternLabel)
+						: localize('approveResponseFrom', "Allow responses from {0}", patternLabel),
+					select: async () => {
+						await this._approvePattern(pattern, forRequest, !forRequest);
+						return true;
+					}
+				});
+			}
+
+			// "More options" action
+			actions.push({
+				label: localize('moreOptions', "Allow requests to..."),
+				select: async () => {
+					const result = await this._showMoreOptions(ref, [{ uri, patterns }], forRequest);
+					return result;
+				}
+			});
+		} else {
+			// Multiple URLs - show "More options" only
+			actions.push({
+				label: localize('moreOptionsMultiple', "Configure URL Approvals..."),
+				select: async () => {
+					await this._showMoreOptions(ref, [...urlPatterns].map(([uri, patterns]) => ({ uri, patterns })), forRequest);
+					return true;
+				}
+			});
+		}
+
+		return actions;
+	}
+
+	private async _showMoreOptions(ref: ILanguageModelToolConfirmationRef, urls: { uri: URI; patterns: string[] }[], forRequest: boolean): Promise<boolean> {
+		interface IPatternTreeItem extends IQuickTreeItem {
+			pattern: string;
+			approvalType?: 'request' | 'response';
+			children?: IPatternTreeItem[];
+		}
+
+		return new Promise<boolean>((resolve) => {
+			const disposables = new DisposableStore();
+			const quickTree = disposables.add(this._quickInputService.createQuickTree<IPatternTreeItem>());
+			quickTree.ignoreFocusOut = true;
+			quickTree.sortByLabel = false;
+			quickTree.placeholder = localize('selectApproval', "Select URL pattern to approve");
+
+			const treeItems: IPatternTreeItem[] = [];
+			const approvedUrls = this._getApprovedUrls();
+
+			for (const { uri, patterns } of urls) {
+				for (const pattern of patterns.slice().sort((a, b) => b.length - a.length)) {
+					const settings = approvedUrls[pattern];
+					const requestChecked = typeof settings === 'boolean' ? settings : (settings?.approveRequest ?? false);
+					const responseChecked = typeof settings === 'boolean' ? settings : (settings?.approveResponse ?? false);
+
+					treeItems.push({
+						label: getPatternLabel(uri, pattern),
+						pattern,
+						checked: requestChecked && responseChecked ? true : (!requestChecked && !responseChecked ? false : 'mixed'),
+						collapsed: true,
+						children: [
+							{
+								label: localize('allowRequestsCheckbox', "Make requests without confirmation"),
+								pattern,
+								approvalType: 'request',
+								checked: requestChecked
+							},
+							{
+								label: localize('allowResponsesCheckbox', "Allow responses without confirmation"),
+								pattern,
+								approvalType: 'response',
+								checked: responseChecked
+							}
+						],
+					});
+				}
+			}
+
+			quickTree.setItemTree(treeItems);
+
+			const updateApprovals = () => {
+				const current = { ...this._getApprovedUrls() };
+				for (const item of quickTree.itemTree) {
+					// root-level items
+
+					const allowPre = item.children?.find(c => c.approvalType === 'request')?.checked;
+					const allowPost = item.children?.find(c => c.approvalType === 'response')?.checked;
+
+					if (allowPost && allowPre) {
+						current[item.pattern] = true;
+					} else if (!allowPost && !allowPre) {
+						delete current[item.pattern];
+					} else {
+						current[item.pattern] = {
+							approveRequest: !!allowPre || undefined,
+							approveResponse: !!allowPost || undefined,
+						};
+					}
+				}
+
+				return this._configurationService.updateValue(ChatConfiguration.ApprovedFetchUrls, current);
+			};
+
+			disposables.add(quickTree.onDidAccept(async () => {
+				quickTree.busy = true;
+				await updateApprovals();
+				resolve(!!this._checkApproval(ref, forRequest));
+				quickTree.hide();
+			}));
+
+			disposables.add(quickTree.onDidHide(() => {
+				updateApprovals();
+				disposables.dispose();
+				resolve(false);
+			}));
+
+			quickTree.show();
+		});
+	}
+
+	private async _approvePattern(pattern: string, approveRequest: boolean, approveResponse: boolean): Promise<void> {
+		const approvedUrls = { ...this._getApprovedUrls() };
+
+		// Create the approval settings
+		let value: boolean | IUrlApprovalSettings;
+		if (approveRequest && approveResponse) {
+			value = true;
+		} else {
+			value = {
+				approveRequest,
+				approveResponse
+			};
+		}
+
+		approvedUrls[pattern] = value;
+
+		await this._configurationService.updateValue(
+			ChatConfiguration.ApprovedFetchUrls,
+			approvedUrls
+		);
+	}
+
+	getManageActions(): ILanguageModelToolConfirmationContributionQuickTreeItem[] {
+		const approvedUrls = { ...this._getApprovedUrls() };
+		const items: ILanguageModelToolConfirmationContributionQuickTreeItem[] = [];
+
+		for (const [pattern, settings] of Object.entries(approvedUrls)) {
+			const label = pattern;
+			let description: string;
+
+			if (typeof settings === 'boolean') {
+				description = settings
+					? localize('approveAll', "Approve all")
+					: localize('denyAll', "Deny all");
+			} else {
+				const parts: string[] = [];
+				if (settings.approveRequest) {
+					parts.push(localize('requests', "requests"));
+				}
+				if (settings.approveResponse) {
+					parts.push(localize('responses', "responses"));
+				}
+				description = parts.length > 0
+					? localize('approves', "Approves {0}", parts.join(', '))
+					: localize('noApprovals', "No approvals");
+			}
+
+			const item: ILanguageModelToolConfirmationContributionQuickTreeItem = {
+				label,
+				description,
+				buttons: [trashButton],
+				checked: true,
+				onDidChangeChecked: (checked) => {
+					if (checked) {
+						approvedUrls[pattern] = settings;
+					} else {
+						delete approvedUrls[pattern];
+					}
+
+					this._configurationService.updateValue(ChatConfiguration.ApprovedFetchUrls, approvedUrls);
+				}
+			};
+
+			items.push(item);
+		}
+
+		items.push({
+			pickable: false,
+			label: localize('moreOptionsManage', "More Options..."),
+			description: localize('openSettings', "Open settings"),
+			onDidOpen: () => {
+				this._preferencesService.openUserSettings({ query: ChatConfiguration.ApprovedFetchUrls });
+			}
+		});
+
+		return items;
+	}
+
+	async reset(): Promise<void> {
+		await this._configurationService.updateValue(
+			ChatConfiguration.ApprovedFetchUrls,
+			{}
+		);
+	}
+
+	private _getApprovedUrls(): Readonly<Record<string, boolean | IUrlApprovalSettings>> {
+		return this._configurationService.getValue<Record<string, boolean | IUrlApprovalSettings>>(
+			ChatConfiguration.ApprovedFetchUrls
+		) || {};
+	}
+}

--- a/src/vs/workbench/contrib/chat/common/chatUrlFetchingConfirmation.ts
+++ b/src/vs/workbench/contrib/chat/common/chatUrlFetchingConfirmation.ts
@@ -230,13 +230,10 @@ export class ChatUrlFetchingConfirmationContribution implements ILanguageModelTo
 
 		// Create the approval settings
 		let value: boolean | IUrlApprovalSettings;
-		if (approveRequest && approveResponse) {
-			value = true;
+		if (approveRequest === approveResponse) {
+			value = approveRequest;
 		} else {
-			value = {
-				approveRequest,
-				approveResponse
-			};
+			value = { approveRequest, approveResponse };
 		}
 
 		approvedUrls[pattern] = value;

--- a/src/vs/workbench/contrib/chat/common/chatUrlFetchingPatterns.ts
+++ b/src/vs/workbench/contrib/chat/common/chatUrlFetchingPatterns.ts
@@ -38,8 +38,10 @@ export function extractUrlPatterns(url: URI): string[] {
 	const domainParts = authority.split('.');
 
 	// Only add wildcard subdomain if there are at least 2 parts and it's not an IP
-	const isIP = domainParts.length === 4 && domainParts.every((segment: string) =>
-		Number.isInteger(+segment) || Number.isInteger(+segment.split(':')[0]));
+	const isIPv4 = domainParts.length === 4 && domainParts.every((segment: string) =>
+		Number.isInteger(+segment));
+	const isIPv6 = authority.includes(':') && authority.match(/^(\[)?[0-9a-fA-F:]+(\])?(?::\d+)?$/);
+	const isIP = isIPv4 || isIPv6;
 
 	// Only emit subdomain patterns if there are actually subdomains (more than 2 parts)
 	if (!isIP && domainParts.length > 2) {

--- a/src/vs/workbench/contrib/chat/common/chatUrlFetchingPatterns.ts
+++ b/src/vs/workbench/contrib/chat/common/chatUrlFetchingPatterns.ts
@@ -1,0 +1,157 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { URI } from '../../../../base/common/uri.js';
+import { normalizeURL } from '../../url/common/trustedDomains.js';
+import { testUrlMatchesGlob } from '../../url/common/urlGlob.js';
+
+/**
+ * Approval settings for a URL pattern
+ */
+export interface IUrlApprovalSettings {
+	approveRequest?: boolean;
+	approveResponse?: boolean;
+}
+
+/**
+ * Extracts domain patterns from a URL for use in approval actions
+ * @param url The URL to extract patterns from
+ * @returns An array of patterns in order of specificity (most specific first)
+ */
+export function extractUrlPatterns(url: URI): string[] {
+	const normalizedStr = normalizeURL(url);
+	const normalized = URI.parse(normalizedStr);
+	const patterns = new Set<string>();
+
+	// Full URL (most specific)
+	const fullUrl = normalized.toString(true);
+	patterns.add(fullUrl);
+
+	// Domain-only pattern (without trailing slash)
+	const domainOnly = normalized.with({ path: '', query: '', fragment: '' }).toString(true);
+	patterns.add(domainOnly);
+
+	// Wildcard subdomain pattern (*.example.com)
+	const authority = normalized.authority;
+	const domainParts = authority.split('.');
+
+	// Only add wildcard subdomain if there are at least 2 parts and it's not an IP
+	const isIP = domainParts.length === 4 && domainParts.every((segment: string) =>
+		Number.isInteger(+segment) || Number.isInteger(+segment.split(':')[0]));
+
+	// Only emit subdomain patterns if there are actually subdomains (more than 2 parts)
+	if (!isIP && domainParts.length > 2) {
+		// Create patterns by replacing each subdomain segment with *
+		// For example, foo.bar.example.com -> *.bar.example.com, *.example.com
+		for (let i = 0; i < domainParts.length - 2; i++) {
+			const wildcardAuthority = '*.' + domainParts.slice(i + 1).join('.');
+			const wildcardPattern = normalized.with({
+				authority: wildcardAuthority,
+				path: '',
+				query: '',
+				fragment: ''
+			}).toString(true);
+			patterns.add(wildcardPattern);
+		}
+	}
+
+	// Path patterns (if there's a non-trivial path)
+	const pathSegments = normalized.path.split('/').filter((s: string) => s.length > 0);
+	if (pathSegments.length > 0) {
+		// Add patterns for each path level with wildcard
+		for (let i = pathSegments.length - 1; i >= 0; i--) {
+			const pathPattern = pathSegments.slice(0, i).join('/');
+			const urlWithPathPattern = normalized.with({
+				path: (i > 0 ? '/' : '') + pathPattern,
+				query: '',
+				fragment: ''
+			}).toString(true);
+			patterns.add(urlWithPathPattern);
+		}
+	}
+
+	return [...patterns].map(p => p.replace(/\/+$/, ''));
+}
+
+/**
+ * Generates user-friendly labels for URL patterns to show in quick pick
+ * @param url The original URL
+ * @param pattern The pattern to generate a label for
+ * @returns A user-friendly label describing what the pattern matches (without protocol)
+ */
+export function getPatternLabel(url: URI, pattern: string): string {
+	let displayPattern = pattern;
+
+	if (displayPattern.startsWith('https://')) {
+		displayPattern = displayPattern.substring(8);
+	} else if (displayPattern.startsWith('http://')) {
+		displayPattern = displayPattern.substring(7);
+	}
+
+	return displayPattern.replace(/\/+$/, ''); // Remove trailing slashes
+}
+
+/**
+ * Checks if a URL matches any approved pattern
+ * @param url The URL to check
+ * @param approvedUrls Map of approved URL patterns to their settings
+ * @param checkRequest Whether to check request approval (true) or response approval (false)
+ * @returns true if the URL is approved for the specified action
+ */
+export function isUrlApproved(
+	url: URI,
+	approvedUrls: Record<string, boolean | IUrlApprovalSettings>,
+	checkRequest: boolean
+): boolean {
+	const normalizedUrlStr = normalizeURL(url);
+	const normalizedUrl = URI.parse(normalizedUrlStr);
+
+	for (const [pattern, settings] of Object.entries(approvedUrls)) {
+		// Check if URL matches this pattern
+		if (testUrlMatchesGlob(normalizedUrl, pattern)) {
+			// Handle boolean settings
+			if (typeof settings === 'boolean') {
+				return settings;
+			}
+
+			// Handle granular settings
+			if (checkRequest && settings.approveRequest !== undefined) {
+				return settings.approveRequest;
+			}
+
+			if (!checkRequest && settings.approveResponse !== undefined) {
+				return settings.approveResponse;
+			}
+		}
+	}
+
+	return false;
+}
+
+/**
+ * Gets the most specific matching pattern for a URL
+ * @param url The URL to find a matching pattern for
+ * @param approvedUrls Map of approved URL patterns
+ * @returns The most specific matching pattern, or undefined if none match
+ */
+export function getMatchingPattern(
+	url: URI,
+	approvedUrls: Record<string, boolean | IUrlApprovalSettings>
+): string | undefined {
+	const normalizedUrlStr = normalizeURL(url);
+	const normalizedUrl = URI.parse(normalizedUrlStr);
+	const patterns = extractUrlPatterns(url);
+
+	// Check patterns in order of specificity (most specific first)
+	for (const pattern of patterns) {
+		for (const approvedPattern of Object.keys(approvedUrls)) {
+			if (testUrlMatchesGlob(normalizedUrl, approvedPattern) && testUrlMatchesGlob(URI.parse(pattern), approvedPattern)) {
+				return approvedPattern;
+			}
+		}
+	}
+
+	return undefined;
+}

--- a/src/vs/workbench/contrib/chat/common/constants.ts
+++ b/src/vs/workbench/contrib/chat/common/constants.ts
@@ -15,7 +15,7 @@ export enum ChatConfiguration {
 	EditRequests = 'chat.editRequests',
 	GlobalAutoApprove = 'chat.tools.global.autoApprove',
 	AutoApproveEdits = 'chat.tools.edits.autoApprove',
-	ApprovedFetchUrls = 'chat.tools.urls.autoApprove',
+	AutoApprovedUrls = 'chat.tools.urls.autoApprove',
 	EnableMath = 'chat.math.enabled',
 	CheckpointsEnabled = 'chat.checkpoints.enabled',
 	AgentSessionsViewLocation = 'chat.agentSessionsViewLocation',

--- a/src/vs/workbench/contrib/chat/common/constants.ts
+++ b/src/vs/workbench/contrib/chat/common/constants.ts
@@ -15,6 +15,7 @@ export enum ChatConfiguration {
 	EditRequests = 'chat.editRequests',
 	GlobalAutoApprove = 'chat.tools.global.autoApprove',
 	AutoApproveEdits = 'chat.tools.edits.autoApprove',
+	ApprovedFetchUrls = 'chat.tools.urls.autoApprove',
 	EnableMath = 'chat.math.enabled',
 	CheckpointsEnabled = 'chat.checkpoints.enabled',
 	AgentSessionsViewLocation = 'chat.agentSessionsViewLocation',

--- a/src/vs/workbench/contrib/chat/common/languageModelToolsConfirmationService.ts
+++ b/src/vs/workbench/contrib/chat/common/languageModelToolsConfirmationService.ts
@@ -38,6 +38,7 @@ export interface ILanguageModelToolConfirmationActionProducer {
 export interface ILanguageModelToolConfirmationContributionQuickTreeItem extends IQuickTreeItem {
 	onDidTriggerItemButton?(button: IQuickInputButton): void;
 	onDidChangeChecked?(checked: boolean): void;
+	onDidOpen?(): void;
 }
 
 /**

--- a/src/vs/workbench/contrib/chat/electron-browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/electron-browser/chat.contribution.ts
@@ -29,11 +29,14 @@ import { ACTION_ID_NEW_CHAT, CHAT_OPEN_ACTION_ID, IChatViewOpenOptions } from '.
 import { showChatView } from '../browser/chat.js';
 import { ChatContextKeys } from '../common/chatContextKeys.js';
 import { IChatService } from '../common/chatService.js';
+import { ChatUrlFetchingConfirmationContribution } from '../common/chatUrlFetchingConfirmation.js';
 import { ChatModeKind } from '../common/constants.js';
+import { ILanguageModelToolsConfirmationService } from '../common/languageModelToolsConfirmationService.js';
 import { ILanguageModelToolsService } from '../common/languageModelToolsService.js';
+import { InternalFetchWebPageToolId } from '../common/tools/tools.js';
 import { registerChatDeveloperActions } from './actions/chatDeveloperActions.js';
 import { HoldToVoiceChatInChatViewAction, InlineVoiceChatAction, KeywordActivationContribution, QuickVoiceChatAction, ReadChatResponseAloud, StartVoiceChatAction, StopListeningAction, StopListeningAndSubmitAction, StopReadAloud, StopReadChatItemAloud, VoiceChatInChatViewAction } from './actions/voiceChatActions.js';
-import { FetchWebPageTool, FetchWebPageToolData } from './tools/fetchPageTool.js';
+import { FetchWebPageTool, FetchWebPageToolData, IFetchWebPageToolParams } from './tools/fetchPageTool.js';
 
 class NativeBuiltinToolsContribution extends Disposable implements IWorkbenchContribution {
 
@@ -42,11 +45,20 @@ class NativeBuiltinToolsContribution extends Disposable implements IWorkbenchCon
 	constructor(
 		@ILanguageModelToolsService toolsService: ILanguageModelToolsService,
 		@IInstantiationService instantiationService: IInstantiationService,
+		@ILanguageModelToolsConfirmationService confirmationService: ILanguageModelToolsConfirmationService,
 	) {
 		super();
 
 		const editTool = instantiationService.createInstance(FetchWebPageTool);
 		this._register(toolsService.registerTool(FetchWebPageToolData, editTool));
+
+		this._register(confirmationService.registerConfirmationContribution(
+			InternalFetchWebPageToolId,
+			instantiationService.createInstance(
+				ChatUrlFetchingConfirmationContribution,
+				params => (params as IFetchWebPageToolParams).urls
+			)
+		));
 	}
 }
 

--- a/src/vs/workbench/contrib/chat/electron-browser/tools/fetchPageTool.ts
+++ b/src/vs/workbench/contrib/chat/electron-browser/tools/fetchPageTool.ts
@@ -40,6 +40,10 @@ export const FetchWebPageToolData: IToolData = {
 	}
 };
 
+export interface IFetchWebPageToolParams {
+	urls?: string[];
+}
+
 type ResultType = string | { type: 'tooldata'; value: IToolResultDataPart } | { type: 'extracted'; value: WebContentExtractResult } | undefined;
 
 export class FetchWebPageTool implements IToolImpl {
@@ -51,7 +55,7 @@ export class FetchWebPageTool implements IToolImpl {
 	) { }
 
 	async invoke(invocation: IToolInvocation, _countTokens: CountTokensCallback, _progress: ToolProgress, token: CancellationToken): Promise<IToolResult> {
-		const urls = (invocation.parameters as { urls?: string[] }).urls || [];
+		const urls = (invocation.parameters as IFetchWebPageToolParams).urls || [];
 		const { webUris, fileUris, invalidUris } = this._parseUris(urls);
 		const allValidUris = [...webUris.values(), ...fileUris.values()];
 

--- a/src/vs/workbench/contrib/chat/test/common/chatUrlFetchingPatterns.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/chatUrlFetchingPatterns.test.ts
@@ -1,0 +1,192 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { URI } from '../../../../../base/common/uri.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { extractUrlPatterns, getPatternLabel, isUrlApproved, getMatchingPattern, IUrlApprovalSettings } from '../../common/chatUrlFetchingPatterns.js';
+
+suite('ChatUrlFetchingPatterns', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	suite('extractUrlPatterns', () => {
+		test('simple domain', () => {
+			const url = URI.parse('https://example.com');
+			const patterns = extractUrlPatterns(url);
+			assert.deepStrictEqual(patterns, [
+				'https://example.com',
+			]);
+		});
+
+		test('subdomain', () => {
+			const url = URI.parse('https://api.example.com');
+			const patterns = extractUrlPatterns(url);
+			assert.deepStrictEqual(patterns, [
+				'https://api.example.com',
+				'https://*.example.com'
+			]);
+		});
+
+		test('multiple subdomains', () => {
+			const url = URI.parse('https://foo.bar.example.com/path');
+			const patterns = extractUrlPatterns(url);
+			assert.deepStrictEqual(patterns, [
+				'https://foo.bar.example.com/path',
+				'https://foo.bar.example.com',
+				'https://*.bar.example.com',
+				'https://*.example.com',
+			]);
+		});
+
+		test('with path', () => {
+			const url = URI.parse('https://example.com/api/v1/users');
+			const patterns = extractUrlPatterns(url);
+			assert.deepStrictEqual(patterns, [
+				'https://example.com/api/v1/users',
+				'https://example.com',
+				'https://example.com/api/v1',
+				'https://example.com/api',
+			]);
+		});
+
+		test('IP address - no wildcard subdomain', () => {
+			const url = URI.parse('https://192.168.1.1');
+			const patterns = extractUrlPatterns(url);
+			assert.strictEqual(patterns.filter(p => p.includes('*')).length, 0);
+		});
+
+		test('with query and fragment', () => {
+			const url = URI.parse('https://example.com/path?query=1#fragment');
+			const patterns = extractUrlPatterns(url);
+			assert.deepStrictEqual(patterns, [
+				'https://example.com/path?query=1#fragment',
+				'https://example.com',
+			]);
+		});
+	});
+
+	suite('getPatternLabel', () => {
+		test('removes https protocol', () => {
+			const url = URI.parse('https://example.com');
+			const label = getPatternLabel(url, 'https://example.com');
+			assert.strictEqual(label, 'example.com');
+		});
+
+		test('removes http protocol', () => {
+			const url = URI.parse('http://example.com');
+			const label = getPatternLabel(url, 'http://example.com');
+			assert.strictEqual(label, 'example.com');
+		});
+
+		test('removes trailing slashes', () => {
+			const url = URI.parse('https://example.com/');
+			const label = getPatternLabel(url, 'https://example.com/');
+			assert.strictEqual(label, 'example.com');
+		});
+
+		test('preserves path', () => {
+			const url = URI.parse('https://example.com/api/v1');
+			const label = getPatternLabel(url, 'https://example.com/api/v1');
+			assert.strictEqual(label, 'example.com/api/v1');
+		});
+	});
+
+	suite('isUrlApproved', () => {
+		test('exact match with boolean', () => {
+			const url = URI.parse('https://example.com');
+			const approved = { 'https://example.com': true };
+			assert.strictEqual(isUrlApproved(url, approved, true), true);
+			assert.strictEqual(isUrlApproved(url, approved, false), true);
+		});
+
+		test('no match returns false', () => {
+			const url = URI.parse('https://example.com');
+			const approved = { 'https://other.com': true };
+			assert.strictEqual(isUrlApproved(url, approved, true), false);
+		});
+
+		test('wildcard subdomain match', () => {
+			const url = URI.parse('https://api.example.com');
+			const approved = { 'https://*.example.com': true };
+			assert.strictEqual(isUrlApproved(url, approved, true), true);
+		});
+
+		test('path wildcard match', () => {
+			const url = URI.parse('https://example.com/api/users');
+			const approved = { 'https://example.com/api/*': true };
+			assert.strictEqual(isUrlApproved(url, approved, true), true);
+		});
+
+		test('granular settings - request approved', () => {
+			const url = URI.parse('https://example.com');
+			const approved: Record<string, IUrlApprovalSettings> = {
+				'https://example.com': { approveRequest: true, approveResponse: false }
+			};
+			assert.strictEqual(isUrlApproved(url, approved, true), true);
+			assert.strictEqual(isUrlApproved(url, approved, false), false);
+		});
+
+		test('granular settings - response approved', () => {
+			const url = URI.parse('https://example.com');
+			const approved: Record<string, IUrlApprovalSettings> = {
+				'https://example.com': { approveRequest: false, approveResponse: true }
+			};
+			assert.strictEqual(isUrlApproved(url, approved, true), false);
+			assert.strictEqual(isUrlApproved(url, approved, false), true);
+		});
+
+		test('granular settings - both approved', () => {
+			const url = URI.parse('https://example.com');
+			const approved: Record<string, IUrlApprovalSettings> = {
+				'https://example.com': { approveRequest: true, approveResponse: true }
+			};
+			assert.strictEqual(isUrlApproved(url, approved, true), true);
+			assert.strictEqual(isUrlApproved(url, approved, false), true);
+		});
+
+		test('granular settings - missing property defaults to false', () => {
+			const url = URI.parse('https://example.com');
+			const approved: Record<string, IUrlApprovalSettings> = {
+				'https://example.com': { approveRequest: true }
+			};
+			assert.strictEqual(isUrlApproved(url, approved, false), false);
+		});
+	});
+
+	suite('getMatchingPattern', () => {
+		test('exact match', () => {
+			const url = URI.parse('https://example.com/path');
+			const approved = { 'https://example.com/path': true };
+			const pattern = getMatchingPattern(url, approved);
+			assert.strictEqual(pattern, 'https://example.com/path');
+		});
+
+		test('wildcard match', () => {
+			const url = URI.parse('https://api.example.com');
+			const approved = { 'https://*.example.com': true };
+			const pattern = getMatchingPattern(url, approved);
+			assert.strictEqual(pattern, 'https://*.example.com');
+		});
+
+		test('no match returns undefined', () => {
+			const url = URI.parse('https://example.com');
+			const approved = { 'https://other.com': true };
+			const pattern = getMatchingPattern(url, approved);
+			assert.strictEqual(pattern, undefined);
+		});
+
+		test('most specific match', () => {
+			const url = URI.parse('https://api.example.com/v1/users');
+			const approved = {
+				'https://*.example.com': true,
+				'https://api.example.com': true,
+				'https://api.example.com/v1/*': true
+			};
+			const pattern = getMatchingPattern(url, approved);
+			assert.ok(pattern !== undefined);
+		});
+	});
+});
+


### PR DESCRIPTION
Adds `chat.tools.urls.autoApprove` which implements custom approval logic for `#fetch`, or any other tool that involves URLs, exercising the new contributable approval model.


https://github.com/user-attachments/assets/30f34ec7-3385-4dc0-b2b0-d4c96383445a

Fixes https://github.com/microsoft/vscode/issues/265850

cc @Tyriar @TylerLeonhardt 