### PR TITLE
fix: use childNodes instead of children in DOM.reset for markdown rendering. Fix #266103

### DIFF
--- a/src/vs/base/browser/markdownRenderer.ts
+++ b/src/vs/base/browser/markdownRenderer.ts
@@ -220,7 +220,7 @@ export function renderMarkdown(markdown: IMarkdownString, options: MarkdownRende
 	let outElement: HTMLElement;
 	if (target) {
 		outElement = target;
-		DOM.reset(target, ...renderedContent.children);
+		DOM.reset(target, ...renderedContent.childNodes);
 	} else {
 		outElement = renderedContent;
 	}


### PR DESCRIPTION
fix: use childNodes instead of children in DOM.reset for markdown rendering. Fix #266103

Might be related to #273617.

Before:

<img width="1027" height="258" alt="image" src="https://github.com/user-attachments/assets/dcfb1edc-0049-4eff-852d-79b0ee3ab1f0" />

After:

<img width="1027" height="258" alt="image" src="https://github.com/user-attachments/assets/8afaad68-1514-4710-9f39-7061cdea6c03" />

CC: @mjbvz 