### PR TITLE
Fixed maximize/minimize toggle icon

### DIFF
--- a/src/vs/workbench/browser/parts/panel/panelActions.ts
+++ b/src/vs/workbench/browser/parts/panel/panelActions.ts
@@ -23,6 +23,7 @@ import { KeybindingWeight } from '../../../../platform/keybinding/common/keybind
 import { SwitchCompositeViewAction } from '../compositeBarActions.js';
 
 const maximizeIcon = registerIcon('panel-maximize', Codicon.screenFull, localize('maximizeIcon', 'Icon to maximize a panel.'));
+const minimizeIcon = registerIcon('panel-minimize', Codicon.screenNormal, localize('minimizeIcon', 'Icon to minimize a panel.'));
 export const closeIcon = registerIcon('panel-close', Codicon.close, localize('closeIcon', 'Icon to close a panel.'));
 const panelIcon = registerIcon('panel-layout-icon', Codicon.layoutPanel, localize('togglePanelOffIcon', 'Icon to toggle the panel off when it is on.'));
 const panelOffIcon = registerIcon('panel-layout-icon-off', Codicon.layoutPanelOff, localize('togglePanelOnIcon', 'Icon to toggle the panel on when it is off.'));
@@ -283,7 +284,7 @@ registerAction2(class extends Action2 {
 			icon: maximizeIcon,
 			// the workbench grid currently prevents us from supporting panel maximization with non-center panel alignment
 			precondition: ContextKeyExpr.or(PanelAlignmentContext.isEqualTo('center'), ContextKeyExpr.and(PanelPositionContext.notEqualsTo('bottom'), PanelPositionContext.notEqualsTo('top'))),
-			toggled: { condition: PanelMaximizedContext, icon: maximizeIcon, tooltip: localize('minimizePanel', "Restore Panel Size") },
+			toggled: { condition: PanelMaximizedContext, icon: minimizeIcon, tooltip: localize('minimizePanel', "Restore Panel Size") },
 			menu: [{
 				id: MenuId.PanelTitle,
 				group: 'navigation',


### PR DESCRIPTION
Fix : Updated bottom panel maximize toggle icon
Description : This PR fixes the issue where the bottom panel’s maximize toggle button displayed the maximize icon even after expanding. The icon now correctly switches between maximize and minimize depending on the panel’s current state.

Steps to Test :
1. Open VS Code (or your local build)
2. Open bottom panel (e.g. Terminal)
3. Look on the maximize toggle icon:
     When the panel is maximized, it shows the minimize icon
     When the panel is minimized, it shows the maximize icon
4. The functionality and animations remain unchanged
