### PR TITLE
Add `ctrlCmd+enter` accept for chat elicitation request

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/actions/chatElicitationActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatElicitationActions.ts
@@ -1,0 +1,65 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { KeyCode, KeyMod } from '../../../../../base/common/keyCodes.js';
+import { ServicesAccessor } from '../../../../../editor/browser/editorExtensions.js';
+import { localize2 } from '../../../../../nls.js';
+import { Action2, registerAction2 } from '../../../../../platform/actions/common/actions.js';
+import { ContextKeyExpr } from '../../../../../platform/contextkey/common/contextkey.js';
+import { KeybindingWeight } from '../../../../../platform/keybinding/common/keybindingsRegistry.js';
+import { ChatContextKeys } from '../../common/chatContextKeys.js';
+import { isResponseVM } from '../../common/chatViewModel.js';
+import { IChatWidgetService } from '../chat.js';
+import { CHAT_CATEGORY } from './chatActions.js';
+
+export const AcceptElicitationRequestActionId = 'workbench.action.chat.acceptElicitation';
+
+class AcceptElicitationRequestAction extends Action2 {
+	constructor() {
+		super({
+			id: AcceptElicitationRequestActionId,
+			title: localize2('chat.acceptElicitation', "Accept Request"),
+			f1: false,
+			category: CHAT_CATEGORY,
+			keybinding: {
+				when: ContextKeyExpr.and(ChatContextKeys.inChatSession, ChatContextKeys.Editing.hasElicitationRequest),
+				primary: KeyMod.CtrlCmd | KeyCode.Enter,
+				weight: KeybindingWeight.WorkbenchContrib + 1,
+			},
+		});
+	}
+
+	override async run(accessor: ServicesAccessor): Promise<void> {
+		const chatWidgetService = accessor.get(IChatWidgetService);
+		const widget = chatWidgetService.lastFocusedWidget;
+		if (!widget) {
+			return;
+		}
+
+		const items = widget.viewModel?.getItems();
+		if (!items?.length) {
+			return;
+		}
+
+		for (let i = items.length - 1; i >= 0; i--) {
+			const item = items[i];
+			if (!isResponseVM(item)) {
+				continue;
+			}
+
+			for (const content of item.response.value) {
+				if (content.kind === 'elicitation' && content.state === 'pending') {
+					await content.accept(true);
+					widget.focusInput();
+					return;
+				}
+			}
+		}
+	}
+}
+
+export function registerChatElicitationActions(): void {
+	registerAction2(AcceptElicitationRequestAction);
+}

--- a/src/vs/workbench/contrib/chat/browser/actions/chatElicitationActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatElicitationActions.ts
@@ -43,18 +43,16 @@ class AcceptElicitationRequestAction extends Action2 {
 			return;
 		}
 
-		for (let i = items.length - 1; i >= 0; i--) {
-			const item = items[i];
-			if (!isResponseVM(item)) {
-				continue;
-			}
+		const lastItem = items.at(-1);
+		if (!isResponseVM(lastItem)) {
+			return;
+		}
 
-			for (const content of item.response.value) {
-				if (content.kind === 'elicitation' && content.state === 'pending') {
-					await content.accept(true);
-					widget.focusInput();
-					return;
-				}
+		for (const content of lastItem.response.value) {
+			if (content.kind === 'elicitation' && content.state === 'pending') {
+				await content.accept(true);
+				widget.focusInput();
+				return;
 			}
 		}
 	}

--- a/src/vs/workbench/contrib/chat/browser/actions/chatElicitationActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatElicitationActions.ts
@@ -43,16 +43,18 @@ class AcceptElicitationRequestAction extends Action2 {
 			return;
 		}
 
-		const lastItem = items.at(-1);
-		if (!isResponseVM(lastItem)) {
-			return;
-		}
+		for (let i = items.length - 1; i >= 0; i--) {
+			const item = items[i];
+			if (!isResponseVM(item)) {
+				continue;
+			}
 
-		for (const content of lastItem.response.value) {
-			if (content.kind === 'elicitation' && content.state === 'pending') {
-				await content.accept(true);
-				widget.focusInput();
-				return;
+			for (const content of item.response.value) {
+				if (content.kind === 'elicitation' && content.state === 'pending') {
+					await content.accept(true);
+					widget.focusInput();
+					return;
+				}
 			}
 		}
 	}

--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -81,6 +81,7 @@ import { registerChatPromptNavigationActions } from './actions/chatPromptNavigat
 import { registerQuickChatActions } from './actions/chatQuickInputActions.js';
 import { ChatSessionsGettingStartedAction, DeleteChatSessionAction, OpenChatSessionInNewEditorGroupAction, OpenChatSessionInNewWindowAction, OpenChatSessionInSidebarAction, RenameChatSessionAction, ToggleAgentSessionsViewLocationAction, ToggleChatSessionsDescriptionDisplayAction } from './actions/chatSessionActions.js';
 import { registerChatTitleActions } from './actions/chatTitleActions.js';
+import { registerChatElicitationActions } from './actions/chatElicitationActions.js';
 import { registerChatToolActions } from './actions/chatToolActions.js';
 import { ChatTransferContribution } from './actions/chatTransfer.js';
 import './agentSessions/agentSessionsView.js';
@@ -1006,6 +1007,7 @@ registerNewChatActions();
 registerChatContextActions();
 registerChatDeveloperActions();
 registerChatEditorActions();
+registerChatElicitationActions();
 registerChatToolActions();
 registerLanguageModelActions();
 

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/chatElicitationContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/chatElicitationContentPart.ts
@@ -52,7 +52,7 @@ export class ChatElicitationContentPart extends Disposable implements IChatConte
 		this._register(toDisposable(() => hasElicitationKey.reset()));
 
 		const acceptKeybinding = this.keybindingService.lookupKeybinding(AcceptElicitationRequestActionId);
-		const acceptTooltip = acceptKeybinding ? `${elicitation.acceptButtonLabel} (${acceptKeybinding.getLabel()})` : undefined;
+		const acceptTooltip = acceptKeybinding ? `${elicitation.acceptButtonLabel} (${acceptKeybinding.getLabel()})` : elicitation.acceptButtonLabel;
 
 		const buttons: IChatConfirmationButton<unknown>[] = [
 			{

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/chatElicitationContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/chatElicitationContentPart.ts
@@ -5,12 +5,16 @@
 
 import { Emitter } from '../../../../../base/common/event.js';
 import { IMarkdownString, isMarkdownString, MarkdownString } from '../../../../../base/common/htmlContent.js';
-import { Disposable, IDisposable } from '../../../../../base/common/lifecycle.js';
+import { Disposable, IDisposable, toDisposable } from '../../../../../base/common/lifecycle.js';
 import { autorun } from '../../../../../base/common/observable.js';
 import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
+import { IContextKeyService } from '../../../../../platform/contextkey/common/contextkey.js';
+import { IKeybindingService } from '../../../../../platform/keybinding/common/keybinding.js';
 import { IChatProgressRenderableResponseContent } from '../../common/chatModel.js';
+import { ChatContextKeys } from '../../common/chatContextKeys.js';
 import { IChatElicitationRequest } from '../../common/chatService.js';
 import { IChatAccessibilityService } from '../chat.js';
+import { AcceptElicitationRequestActionId } from '../actions/chatElicitationActions.js';
 import { ChatConfirmationWidget, IChatConfirmationButton } from './chatConfirmationWidget.js';
 import { IChatContentPart, IChatContentPartRenderContext } from './chatContentParts.js';
 import { IAction } from '../../../../../base/common/actions.js';
@@ -35,13 +39,25 @@ export class ChatElicitationContentPart extends Disposable implements IChatConte
 		elicitation: IChatElicitationRequest,
 		context: IChatContentPartRenderContext,
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
-		@IChatAccessibilityService private readonly chatAccessibilityService: IChatAccessibilityService
+		@IChatAccessibilityService private readonly chatAccessibilityService: IChatAccessibilityService,
+		@IContextKeyService private readonly contextKeyService: IContextKeyService,
+		@IKeybindingService private readonly keybindingService: IKeybindingService,
 	) {
 		super();
+
+		const hasElicitationKey = ChatContextKeys.Editing.hasElicitationRequest.bindTo(this.contextKeyService);
+		if (elicitation.state === 'pending') {
+			hasElicitationKey.set(true);
+		}
+		this._register(toDisposable(() => hasElicitationKey.reset()));
+
+		const acceptKeybinding = this.keybindingService.lookupKeybinding(AcceptElicitationRequestActionId);
+		const acceptTooltip = acceptKeybinding ? `${elicitation.acceptButtonLabel} (${acceptKeybinding.getLabel()})` : undefined;
 
 		const buttons: IChatConfirmationButton<unknown>[] = [
 			{
 				label: elicitation.acceptButtonLabel,
+				tooltip: acceptTooltip,
 				data: true,
 				moreActions: elicitation.moreActions?.map((action: IAction) => ({
 					label: action.label,

--- a/src/vs/workbench/contrib/chat/common/chatContextKeys.ts
+++ b/src/vs/workbench/contrib/chat/common/chatContextKeys.ts
@@ -77,6 +77,7 @@ export namespace ChatContextKeys {
 
 	export const Editing = {
 		hasToolConfirmation: new RawContextKey<boolean>('chatHasToolConfirmation', false, { type: 'boolean', description: localize('chatEditingHasToolConfirmation', "True when a tool confirmation is present.") }),
+		hasElicitationRequest: new RawContextKey<boolean>('chatHasElicitationRequest', false, { type: 'boolean', description: localize('chatEditingHasElicitationRequest', "True when a chat elicitation request is pending.") }),
 	};
 
 	export const Tools = {


### PR DESCRIPTION
fix #276833

Aligns with the keybinding for the chat confirmation widget.

https://github.com/user-attachments/assets/7a3757fa-3104-42e4-b1f9-a677f313fa5d

