### PR TITLE
Fix: Correct suggestion overwrite logic for insertMode and delays

### DIFF
--- a/src/vs/editor/contrib/suggest/browser/suggestController.ts
+++ b/src/vs/editor/contrib/suggest/browser/suggestController.ts
@@ -594,15 +594,18 @@ export class SuggestController implements IEditorContribution {
 		if (toggleMode) {
 			replace = !replace;
 		}
-		const overwriteBefore = item.position.column - item.editStart.column;
-		const overwriteAfter = (replace ? item.editReplaceEnd.column : item.editInsertEnd.column) - item.position.column;
-		const columnDelta = this.editor.getPosition().column - item.position.column;
-		const suffixDelta = this._lineSuffix.value ? this._lineSuffix.value.delta(this.editor.getPosition()) : 0;
 
-		return {
-			overwriteBefore: overwriteBefore + columnDelta,
-			overwriteAfter: overwriteAfter + suffixDelta
-		};
+		const currentPosition = this.editor.getPosition();
+		// itemPosition is item.position, which is the cursor position when the item was generated.
+		// item.editStart is the start of the word being completed.
+		// overwriteBefore is the text from the start of the word (item.editStart) up to the current cursor position.
+		const overwriteBefore = Math.max(0, currentPosition.column - item.editStart.column);
+		const overwriteAfter = (replace ?
+			// In replace mode, overwrite text from the current cursor up to where the original suggestion's replace range ended.
+			Math.max(0, item.editReplaceEnd.column - currentPosition.column) :
+			// In insert mode, overwrite text from the current cursor up to where the original suggestion's insert range ended.
+			Math.max(0, item.editInsertEnd.column - currentPosition.column));
+		return { overwriteBefore, overwriteAfter };
 	}
 
 	private _alertCompletionItem(item: CompletionItem): void {


### PR DESCRIPTION
This commit addresses an issue where editor content, particularly when `suggest.insertMode` is 'replace', could be incorrectly clobbered if a completion provider was slow and you typed additional characters.

The root cause was in `SuggestController.getOverwriteInfo`. The calculation of `overwriteBefore` and `overwriteAfter` did not correctly account for the current cursor position relative to the (potentially stale) completion item's original `editStart`, `editInsertEnd`, and `editReplaceEnd` ranges. Relying on `item.position` (the cursor position at the time of suggestion triggering) and `suffixDelta` led to incorrect overwrite boundaries when the cursor had moved.

The fix revises `getOverwriteInfo` to:
1. Calculate `overwriteBefore` as the range from `item.editStart.column` up to the `currentPosition.column`.
2. Calculate `overwriteAfter` as the range from `currentPosition.column` up to `item.editReplaceEnd.column` (for 'replace' mode) or `item.editInsertEnd.column` (for 'insert' mode). Both calculations are clamped at a minimum of 0.

This ensures that the text overwriting is based on the actual current cursor position and the originally intended ranges of the completion item, preventing excessive deletion of text, especially when characters are typed during a provider delay.

Regarding the fix for issue #10266 which made changes to the same code, the changes made here should not cause a regression. The original problem in that issue was that typing after a suggestion was triggered would cause the suggestion to be inserted at the wrong place. The old fix adjusted the overwrite range based on how much the cursor had moved. The new implementation also accounts for the cursor's current position, but does so more robustly by directly comparing the current cursor position with the suggestion's original start and end points. This should correctly handle both scenarios.

fixes #251013