### PR TITLE
hide todo widget only when session changes

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/chatTodoListWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/chatTodoListWidget.ts
@@ -235,6 +235,7 @@ export class ChatTodoListWidget extends Disposable {
 		if (!isEqual(this._currentSessionResource, sessionResource)) {
 			this._userManuallyExpanded = false;
 			this._currentSessionResource = sessionResource;
+			this.hideWidget();
 		}
 
 		this.updateTodoDisplay();
@@ -249,8 +250,6 @@ export class ChatTodoListWidget extends Disposable {
 		const shouldClear = force || (currentTodos.length > 0 && !currentTodos.some(todo => todo.status !== 'completed'));
 		if (shouldClear) {
 			this.clearAllTodos();
-		} else {
-			this.hideWidget();
 		}
 	}
 


### PR DESCRIPTION
Fixes:
https://github.com/microsoft/vscode/issues/276578

Regressed with:
https://github.com/microsoft/vscode/pull/275709

I was incorrectly hiding the widget for every time the render happens instead of only when the chat sessions changed and we needed to update the widget. 

Tested:
1. Todos are rendered on new requests if not all todos are completed.
2. Todos are cleared on new requests if all todos are completed
3. Todos are cleared if the response is stopped.
4. Todos are cleared when a previously sent request is edited. 
5. Todos are not shown when new chat editors/chat panels are opened. 
