### PR TITLE
Add option to hide branch name in SCM view

### DIFF
--- a/src/vs/workbench/contrib/scm/browser/media/scm.css
+++ b/src/vs/workbench/contrib/scm/browser/media/scm.css
@@ -112,6 +112,15 @@
 	overflow: hidden;
 }
 
+/* Hide branch name text, show only icon */
+.scm-view.hide-branch-name a:has(span.codicon-git-branch) {
+	font-size: 0;
+	padding-left: 0;
+}
+.scm-view.hide-branch-name span.codicon-git-branch {
+	font-size: 16px;
+}
+
 .scm-view .scm-provider > .actions > .monaco-toolbar > .monaco-action-bar > .actions-container  > .action-item > .action-label > .codicon {
 	justify-content: center;
 }

--- a/src/vs/workbench/contrib/scm/browser/scm.contribution.ts
+++ b/src/vs/workbench/contrib/scm/browser/scm.contribution.ts
@@ -394,6 +394,11 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).regis
 			description: localize('scm.compactFolders', "Controls whether the Source Control view should render folders in a compact form. In such a form, single child folders will be compressed in a combined tree element."),
 			default: true
 		},
+		'scm.hideBranchName': {
+			type: 'boolean',
+			description: localize('scm.hideBranchName', "Controls whether the branch name text is hidden in the Source Control view. When enabled, only the branch icon is shown."),
+			default: false
+		},
 		'scm.graph.pageOnScroll': {
 			type: 'boolean',
 			description: localize('scm.graph.pageOnScroll', "Controls whether the Source Control Graph view will load the next page of items when you scroll to the end of the list."),

--- a/src/vs/workbench/contrib/scm/browser/scmRepositoriesViewPane.ts
+++ b/src/vs/workbench/contrib/scm/browser/scmRepositoriesViewPane.ts
@@ -17,6 +17,7 @@ import { IContextKeyService } from '../../../../platform/contextkey/common/conte
 import { IKeybindingService } from '../../../../platform/keybinding/common/keybinding.js';
 import { IThemeService } from '../../../../platform/theme/common/themeService.js';
 import { combinedDisposable, Disposable, DisposableMap, DisposableStore, IDisposable } from '../../../../base/common/lifecycle.js';
+import { Event } from '../../../../base/common/event.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { IViewDescriptorService } from '../../../common/views.js';
 import { IOpenerService } from '../../../../platform/opener/common/opener.js';
@@ -415,6 +416,10 @@ export class SCMRepositoriesViewPane extends ViewPane {
 			treeContainer.classList.toggle('hide-provider-counts', providerCountBadge === 'hidden');
 			treeContainer.classList.toggle('auto-provider-counts', providerCountBadge === 'auto');
 		}));
+
+		const updateHideBranchName = () => treeContainer.classList.toggle('hide-branch-name', this.configurationService.getValue<boolean>('scm.hideBranchName'));
+		this._register(Event.filter(this.configurationService.onDidChangeConfiguration, e => e.affectsConfiguration('scm.hideBranchName'))(updateHideBranchName));
+		updateHideBranchName();
 
 		this.createTree(treeContainer);
 

--- a/src/vs/workbench/contrib/scm/browser/scmViewPane.ts
+++ b/src/vs/workbench/contrib/scm/browser/scmViewPane.ts
@@ -2299,6 +2299,10 @@ export class SCMViewPane extends ViewPane {
 		Event.filter(this.configurationService.onDidChangeConfiguration, e => e.affectsConfiguration('scm.providerCountBadge'), this.disposables)(updateProviderCountVisibility, this, this.disposables);
 		updateProviderCountVisibility();
 
+		const updateHideBranchName = () => this.treeContainer.classList.toggle('hide-branch-name', this.configurationService.getValue<boolean>('scm.hideBranchName'));
+		Event.filter(this.configurationService.onDidChangeConfiguration, e => e.affectsConfiguration('scm.hideBranchName'), this.disposables)(updateHideBranchName, this, this.disposables);
+		updateHideBranchName();
+
 		const viewState = this.loadTreeViewState();
 		this.createTree(this.treeContainer, viewState);
 


### PR DESCRIPTION
Closes #271679

This PR introduces a new user setting `scm.hideBranchName` that allows users to hide the branch name text in the Source Control view, displaying only the branch icon.

## Changes

- **Configuration**: Added `scm.hideBranchName` boolean setting (default: `false`)
- **SCM View**: Applied `.hide-branch-name` class toggle based on configuration
- **SCM Repositories View**: Applied same behavior for consistency
- **CSS**: Added rules to hide text while preserving icon visibility

## Affected Areas

- Source Control view (Changes)
- Source Control Repositories view

## Testing

- ✅ Compiled without errors
- ✅ Setting appears in Settings UI
- ✅ Branch icon remains visible when enabled
- ✅ Works in both SCM views

## Additional Notes

- Follows existing VS Code patterns (similar to `scm.alwaysShowActions`)
- Uses `Event.filter()` for configuration change handling
- CSS uses `:has()` pseudo-class for robust element targeting
