### PR TITLE
fix: update badge colors and adjust font size for activity bar badges

### DIFF
--- a/src/vs/platform/theme/common/colors/miscColors.ts
+++ b/src/vs/platform/theme/common/colors/miscColors.ts
@@ -31,11 +31,11 @@ export const badgeForeground = registerColor('badge.foreground',
 	nls.localize('badgeForeground', "Badge foreground color. Badges are small information labels, e.g. for search results count."));
 
 export const activityWarningBadgeForeground = registerColor('activityWarningBadge.foreground',
-	{ dark: Color.black.lighten(0.2), light: Color.white, hcDark: null, hcLight: Color.black.lighten(0.2) },
+	{ dark: Color.white, light: Color.white, hcDark: Color.white, hcLight: Color.white },
 	nls.localize('activityWarningBadge.foreground', 'Foreground color of the warning activity badge'));
 
 export const activityWarningBadgeBackground = registerColor('activityWarningBadge.background',
-	{ dark: '#CCA700', light: '#BF8803', hcDark: null, hcLight: '#CCA700' },
+	{ dark: '#B27C00', light: '#B27C00', hcDark: null, hcLight: '#B27C00' },
 	nls.localize('activityWarningBadge.background', 'Background color of the warning activity badge'));
 
 export const activityErrorBadgeForeground = registerColor('activityErrorBadge.foreground',

--- a/src/vs/workbench/browser/parts/activitybar/media/activityaction.css
+++ b/src/vs/workbench/browser/parts/activitybar/media/activityaction.css
@@ -190,7 +190,7 @@
 }
 
 .monaco-workbench .activitybar > .content :not(.monaco-menu) > .monaco-action-bar .badge .codicon.badge-content {
-	font-size: 12px;
+	font-size: 13px;
 	font-weight: unset;
 	padding: 0;
 	justify-content: center;


### PR DESCRIPTION
This pull request updates the appearance of warning badges in the activity bar, focusing on color consistency and slight visual adjustments for better clarity and accessibility.

**Visual and color adjustments for activity warning badges:**

* Changed the foreground color of `activityWarningBadge` to always use white (`Color.white`) across all themes for improved readability. (`src/vs/platform/theme/common/colors/miscColors.ts`)
* Updated the background color of `activityWarningBadge` to a consistent shade of gold (`#B27C00`) in both dark and light themes. (`src/vs/platform/theme/common/colors/miscColors.ts`)

**Badge styling improvements:**

* Increased the font size of badge content in the activity bar from 12px to 13px for better visibility. (`src/vs/workbench/browser/parts/activitybar/media/activityaction.css`)

<img width="943" height="686" alt="image" src="https://github.com/user-attachments/assets/b5d34f82-0f34-4915-93a1-c7012b5ab666" />

