### PR TITLE
add dialog role and aria-labelledby to non-modal dialog widget

### DIFF
--- a/src/vs/platform/quickinput/browser/quickInputController.ts
+++ b/src/vs/platform/quickinput/browser/quickInputController.ts
@@ -140,6 +140,8 @@ export class QuickInputController extends Disposable {
 		const container = dom.append(this._container, $('.quick-input-widget.show-file-icons'));
 		container.tabIndex = -1;
 		container.style.display = 'none';
+		container.setAttribute('role', 'dialog');
+		container.setAttribute('aria-labelledby', 'quick-input-title');
 
 		const styleSheet = domStylesheetsJs.createStyleSheet(container);
 
@@ -149,6 +151,7 @@ export class QuickInputController extends Disposable {
 		leftActionBar.domNode.classList.add('quick-input-left-action-bar');
 
 		const title = dom.append(titleBar, $('.quick-input-title'));
+		title.setAttribute('id', 'quick-input-title');
 
 		const rightActionBar = this._register(new ActionBar(titleBar, { hoverDelegate: this.options.hoverDelegate }));
 		rightActionBar.domNode.classList.add('quick-input-right-action-bar');


### PR DESCRIPTION
Add role="dialog" and aria-labelledby attributes to quick-input-widget to let screen reader users know that they are in a dialog as well as giving the dialog an accessible name

Fixes #277170

Steps to Test:
1. Open VSCode
2. Turn screen reader on
3. With the keyboard, press ENTER or SPACE while focused on "Search workspace" field at top of UI
4. Notice when dialog opens, screen readers now announce that user is in a dialog along with the accessible name of the dialog.