### PR TITLE
fix: memory leak in startup page

### DIFF
--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/startupPage.ts
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/startupPage.ts
@@ -13,7 +13,7 @@ import { onUnexpectedError } from '../../../../base/common/errors.js';
 import { IWorkspaceContextService, UNKNOWN_EMPTY_WINDOW_WORKSPACE, WorkbenchState } from '../../../../platform/workspace/common/workspace.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { ILifecycleService, LifecyclePhase, StartupKind } from '../../../services/lifecycle/common/lifecycle.js';
-import { Disposable, DisposableStore } from '../../../../base/common/lifecycle.js';
+import { Disposable, } from '../../../../base/common/lifecycle.js';
 import { IFileService } from '../../../../platform/files/common/files.js';
 import { joinPath } from '../../../../base/common/resources.js';
 import { IWorkbenchLayoutService } from '../../../services/layout/browser/layoutService.js';
@@ -47,10 +47,8 @@ export class StartupPageEditorResolverContribution extends Disposable implements
 		@IEditorResolverService editorResolverService: IEditorResolverService
 	) {
 		super();
-		const disposables = new DisposableStore();
-		this._register(disposables);
 
-		editorResolverService.registerEditor(
+		this._register(editorResolverService.registerEditor(
 			`${GettingStartedInput.RESOURCE.scheme}:/**`,
 			{
 				id: GettingStartedInput.ID,
@@ -62,9 +60,9 @@ export class StartupPageEditorResolverContribution extends Disposable implements
 				canSupportResource: uri => uri.scheme === GettingStartedInput.RESOURCE.scheme,
 			},
 			{
-				createEditorInput: ({ resource, options }) => {
+				createEditorInput: ({ options }) => {
 					return {
-						editor: disposables.add(this.instantiationService.createInstance(GettingStartedInput, options as GettingStartedEditorOptions)),
+						editor: this.instantiationService.createInstance(GettingStartedInput, options as GettingStartedEditorOptions),
 						options: {
 							...options,
 							pinned: false
@@ -72,7 +70,7 @@ export class StartupPageEditorResolverContribution extends Disposable implements
 					};
 				}
 			}
-		);
+		));
 	}
 }
 


### PR DESCRIPTION
Fixes a memory leak in startup page. 

There only seems to be one global `StartupPageEditorResolverContribution` instance. Registering disposables to the class adds them to that instance, but being a global instance instance, the disposables are never disposed.


### Before

When opening and closing a getting started editor, the number GettingStartedInputs grows each time:

![getting-started](https://github.com/user-attachments/assets/7021cf08-db51-4317-b9ba-cd77c646c0e6)


### After

No more leaks are detected

```json
{
  "namedFunctionCount3": [],
  "isLeak": false
}
```
