### PR TITLE
fix: update corner radius for Electron 39

### DIFF
--- a/src/vs/workbench/browser/media/style.css
+++ b/src/vs/workbench/browser/media/style.css
@@ -69,12 +69,12 @@ body {
 	border-radius: 5px;
 }
 
-.monaco-workbench.border.mac.macos-bigsur-or-newer {
+.monaco-workbench.border.mac.macos-rounded-default {
 	border-radius: 10px; /* macOS Big Sur increased rounded corners size */
 }
 
-.monaco-workbench.border.mac.macos-tahoe-or-newer {
-	border-radius: 12px; /* macOS Tahoe increased rounded corners size even more */
+.monaco-workbench.border.mac.macos-rounded-tahoe {
+	border-radius: 16px; /* macOS Tahoe increased rounded corners size even more */
 }
 
 .monaco-workbench img {

--- a/src/vs/workbench/browser/parts/statusbar/media/statusbarpart.css
+++ b/src/vs/workbench/browser/parts/statusbar/media/statusbarpart.css
@@ -22,15 +22,15 @@
 	border-bottom-right-radius: 5px;
 	border-bottom-left-radius: 5px;
 }
-.monaco-workbench.mac:not(.fullscreen).macos-bigsur-or-newer .part.statusbar:focus {
+.monaco-workbench.mac:not(.fullscreen).macos-rounded-default .part.statusbar:focus {
 	/* macOS Big Sur increased rounded corners size */
 	border-bottom-right-radius: 10px;
 	border-bottom-left-radius: 10px;
 }
-.monaco-workbench.mac:not(.fullscreen).macos-tahoe-or-newer .part.statusbar:focus {
+.monaco-workbench.mac:not(.fullscreen).macos-rounded-tahoe .part.statusbar:focus {
 	/* macOS Tahoe increased rounded corners size even more */
-	border-bottom-right-radius: 12px;
-	border-bottom-left-radius: 12px;
+	border-bottom-right-radius: 16px;
+	border-bottom-left-radius: 16px;
 }
 
 .monaco-workbench .part.statusbar:not(:focus).status-border-top::after {

--- a/src/vs/workbench/contrib/processExplorer/browser/media/processExplorer.css
+++ b/src/vs/workbench/contrib/processExplorer/browser/media/processExplorer.css
@@ -61,16 +61,16 @@
 	border-bottom-left-radius: 5px;
 }
 
-.mac:not(.fullscreen).macos-bigsur-or-newer .process-explorer .monaco-list:focus::before {
+.mac:not(.fullscreen).macos-rounded-default .process-explorer .monaco-list:focus::before {
 	/* macOS Big Sur increased rounded corners size */
 	border-bottom-right-radius: 10px;
 	border-bottom-left-radius: 10px;
 }
 
-.mac:not(.fullscreen).macos-tahoe-or-newer .process-explorer .monaco-list:focus::before {
+.mac:not(.fullscreen).macos-rounded-tahoe .process-explorer .monaco-list:focus::before {
 	/* macOS Tahoe increased rounded corners size even more */
-	border-bottom-right-radius: 12px;
-	border-bottom-left-radius: 12px;
+	border-bottom-right-radius: 16px;
+	border-bottom-left-radius: 16px;
 }
 
 .process-explorer .monaco-list-row:first-of-type {

--- a/src/vs/workbench/electron-browser/desktop.main.ts
+++ b/src/vs/workbench/electron-browser/desktop.main.ts
@@ -45,7 +45,7 @@ import { WorkspaceTrustEnablementService, WorkspaceTrustManagementService } from
 import { IWorkspaceTrustEnablementService, IWorkspaceTrustManagementService } from '../../platform/workspace/common/workspaceTrust.js';
 import { safeStringify } from '../../base/common/objects.js';
 import { IUtilityProcessWorkerWorkbenchService, UtilityProcessWorkerWorkbenchService } from '../services/utilityProcess/electron-browser/utilityProcessWorkerWorkbenchService.js';
-import { isBigSurOrNewer, isCI, isMacintosh, isTahoeOrNewer } from '../../base/common/platform.js';
+import { isCI, isMacintosh, isTahoeOrNewer } from '../../base/common/platform.js';
 import { Schemas } from '../../base/common/network.js';
 import { DiskFileSystemProvider } from '../services/files/electron-browser/diskFileSystemProvider.js';
 import { FileUserDataProvider } from '../../platform/userData/common/fileUserDataProvider.js';
@@ -154,14 +154,10 @@ export class DesktopMain extends Disposable {
 
 	private getExtraClasses(): string[] {
 		if (isMacintosh) {
-			// TODO: Revisit the border radius values till Electron v40 adoption
-			// Refs https://github.com/electron/electron/issues/47514 and
-			// https://github.com/microsoft/vscode/pull/270236#issuecomment-3379301185
 			if (isTahoeOrNewer(this.configuration.os.release)) {
-				return ['macos-tahoe-or-newer'];
-			}
-			if (isBigSurOrNewer(this.configuration.os.release)) {
-				return ['macos-bigsur-or-newer'];
+				return ['macos-rounded-tahoe'];
+			} else {
+				return ['macos-rounded-default'];
 			}
 		}
 


### PR DESCRIPTION
Follow-up to https://github.com/microsoft/vscode/pull/275786

Electron 39 is now built with macOS 26.0 sdk

```
Load command 11
      cmd LC_BUILD_VERSION
  cmdsize 32
 platform 1
    minos 12.0
      sdk 26.0
   ntools 1
     tool 4
  version 22.0
```


<img width="1858" height="1014" alt="Screenshot 2025-11-14 at 2 43 12" src="https://github.com/user-attachments/assets/6418c66c-ec95-4107-ae08-fdfad36168a9" />
