### PR TITLE
Regression: Command `vscode.executeFormatDocumentProvider` Throws "Unexpected Type" Error (fix #277352)

### DIFF
--- a/src/vs/editor/common/languages.ts
+++ b/src/vs/editor/common/languages.ts
@@ -1719,6 +1719,12 @@ export interface FormattingOptions {
 	 */
 	insertSpaces: boolean;
 }
+/** @internal */
+export function isFormattingOptions(obj: unknown): obj is FormattingOptions {
+	const candidate = obj as FormattingOptions | undefined;
+
+	return !!candidate && typeof candidate === 'object' && typeof candidate.tabSize === 'number' && typeof candidate.insertSpaces === 'boolean';
+}
 /**
  * The document formatting provider interface defines the contract between extensions and
  * the formatting-feature.

--- a/src/vs/editor/contrib/format/browser/format.ts
+++ b/src/vs/editor/contrib/format/browser/format.ts
@@ -19,7 +19,7 @@ import { Range } from '../../../common/core/range.js';
 import { Selection } from '../../../common/core/selection.js';
 import { ScrollType } from '../../../common/editorCommon.js';
 import { ITextModel } from '../../../common/model.js';
-import { DocumentFormattingEditProvider, DocumentRangeFormattingEditProvider, FormattingOptions, TextEdit } from '../../../common/languages.js';
+import { DocumentFormattingEditProvider, DocumentRangeFormattingEditProvider, FormattingOptions, isFormattingOptions, TextEdit } from '../../../common/languages.js';
 import { IEditorWorkerService } from '../../../common/services/editorWorker.js';
 import { ITextModelService } from '../../../common/services/resolverService.js';
 import { FormattingEdit } from './formattingEdit.js';
@@ -458,12 +458,6 @@ export function getOnTypeFormattingEdits(
 	return Promise.resolve(providers[0].provideOnTypeFormattingEdits(model, position, ch, options, token)).catch(onUnexpectedExternalError).then(edits => {
 		return workerService.computeMoreMinimalEdits(model.uri, edits);
 	});
-}
-
-function isFormattingOptions(obj: unknown): obj is FormattingOptions {
-	const candidate = obj as FormattingOptions | undefined;
-
-	return !!candidate && typeof candidate === 'object' && typeof candidate.tabSize === 'number' && typeof candidate.insertSpaces === 'boolean';
 }
 
 CommandsRegistry.registerCommand('_executeFormatRangeProvider', async function (accessor, ...args) {

--- a/src/vs/workbench/api/common/extHostApiCommands.ts
+++ b/src/vs/workbench/api/common/extHostApiCommands.ts
@@ -69,17 +69,17 @@ const newCommands: ApiCommand[] = [
 	// -- formatting
 	new ApiCommand(
 		'vscode.executeFormatDocumentProvider', '_executeFormatDocumentProvider', 'Execute document format provider.',
-		[ApiCommandArgument.Uri, new ApiCommandArgument('options', 'Formatting options', _ => true, v => v)],
+		[ApiCommandArgument.Uri, new ApiCommandArgument<languages.FormattingOptions>('options', 'Formatting options', options => languages.isFormattingOptions(options), v => v)],
 		new ApiCommandResult<languages.TextEdit[], types.TextEdit[] | undefined>('A promise that resolves to an array of TextEdits.', tryMapWith(typeConverters.TextEdit.to))
 	),
 	new ApiCommand(
 		'vscode.executeFormatRangeProvider', '_executeFormatRangeProvider', 'Execute range format provider.',
-		[ApiCommandArgument.Uri, ApiCommandArgument.Range, new ApiCommandArgument('options', 'Formatting options', _ => true, v => v)],
+		[ApiCommandArgument.Uri, ApiCommandArgument.Range, new ApiCommandArgument<languages.FormattingOptions>('options', 'Formatting options', options => languages.isFormattingOptions(options), v => v)],
 		new ApiCommandResult<languages.TextEdit[], types.TextEdit[] | undefined>('A promise that resolves to an array of TextEdits.', tryMapWith(typeConverters.TextEdit.to))
 	),
 	new ApiCommand(
 		'vscode.executeFormatOnTypeProvider', '_executeFormatOnTypeProvider', 'Execute format on type provider.',
-		[ApiCommandArgument.Uri, ApiCommandArgument.Position, new ApiCommandArgument('ch', 'Trigger character', v => typeof v === 'string', v => v), new ApiCommandArgument('options', 'Formatting options', _ => true, v => v)],
+		[ApiCommandArgument.Uri, ApiCommandArgument.Position, new ApiCommandArgument('ch', 'Trigger character', v => typeof v === 'string', v => v), new ApiCommandArgument<languages.FormattingOptions>('options', 'Formatting options', options => languages.isFormattingOptions(options), v => v)],
 		new ApiCommandResult<languages.TextEdit[], types.TextEdit[] | undefined>('A promise that resolves to an array of TextEdits.', tryMapWith(typeConverters.TextEdit.to))
 	),
 	// -- go to symbol (definition, type definition, declaration, impl, references)


### PR DESCRIPTION
Validates the options passed in to these 3 API commands.