### PR TITLE
Allow approving terminal tool for session

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatTerminalToolConfirmationSubPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatTerminalToolConfirmationSubPart.ts
@@ -43,7 +43,7 @@ import { ChatCustomConfirmationWidget, IChatConfirmationButton } from '../chatCo
 import { EditorPool } from '../chatContentCodePools.js';
 import { IChatContentPartRenderContext } from '../chatContentParts.js';
 import { ChatMarkdownContentPart } from '../chatMarkdownContentPart.js';
-import { openTerminalSettingsLinkCommandId } from './chatTerminalToolProgressPart.js';
+import { disableSessionAutoApprovalCommandId, openTerminalSettingsLinkCommandId } from './chatTerminalToolProgressPart.js';
 import { BaseChatToolInvocationSubPart } from './chatToolInvocationSubPart.js';
 
 export const enum TerminalToolConfirmationStorageKeys {
@@ -308,7 +308,13 @@ export class ChatTerminalToolConfirmationSubPart extends BaseChatToolInvocationS
 					case 'sessionApproval': {
 						const sessionId = this.context.element.sessionId;
 						this.terminalChatService.setChatSessionAutoApproval(sessionId, true);
-						terminalData.autoApproveInfo = new MarkdownString(localize('sessionApproval', 'All commands will be auto approved for this session'));
+						const disableUri = createCommandUri(disableSessionAutoApprovalCommandId, sessionId);
+						const mdTrustSettings = {
+							isTrusted: {
+								enabledCommands: [disableSessionAutoApprovalCommandId]
+							}
+						};
+						terminalData.autoApproveInfo = new MarkdownString(`${localize('sessionApproval', 'All commands will be auto approved for this session')} ([${localize('sessionApproval.disable', 'Disable')}](${disableUri.toString()}))`, mdTrustSettings);
 						toolConfirmKind = ToolConfirmKind.UserAction;
 						break;
 					}

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatTerminalToolConfirmationSubPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatTerminalToolConfirmationSubPart.ts
@@ -30,6 +30,7 @@ import { IKeybindingService } from '../../../../../../platform/keybinding/common
 import { IMarkdownRenderer } from '../../../../../../platform/markdown/browser/markdownRenderer.js';
 import { IStorageService, StorageScope, StorageTarget } from '../../../../../../platform/storage/common/storage.js';
 import { IPreferencesService } from '../../../../../services/preferences/common/preferences.js';
+import { ITerminalChatService } from '../../../../terminal/browser/terminal.js';
 import { TerminalContribSettingId } from '../../../../terminal/terminalContribExports.js';
 import { migrateLegacyTerminalToolSpecificData } from '../../../common/chat.js';
 import { ChatContextKeys } from '../../../common/chatContextKeys.js';
@@ -61,7 +62,8 @@ export type TerminalNewAutoApproveButtonData = (
 	{ type: 'enable' } |
 	{ type: 'configure' } |
 	{ type: 'skip' } |
-	{ type: 'newRule'; rule: ITerminalNewAutoApproveRule | ITerminalNewAutoApproveRule[] }
+	{ type: 'newRule'; rule: ITerminalNewAutoApproveRule | ITerminalNewAutoApproveRule[] } |
+	{ type: 'sessionApproval' }
 );
 
 export class ChatTerminalToolConfirmationSubPart extends BaseChatToolInvocationSubPart {
@@ -87,6 +89,7 @@ export class ChatTerminalToolConfirmationSubPart extends BaseChatToolInvocationS
 		@IChatWidgetService private readonly chatWidgetService: IChatWidgetService,
 		@IPreferencesService private readonly preferencesService: IPreferencesService,
 		@IStorageService private readonly storageService: IStorageService,
+		@ITerminalChatService private readonly terminalChatService: ITerminalChatService,
 		@ITextModelService textModelService: ITextModelService,
 		@IHoverService hoverService: IHoverService,
 	) {
@@ -300,6 +303,13 @@ export class ChatTerminalToolConfirmationSubPart extends BaseChatToolInvocationS
 							query: `@id:${TerminalContribSettingId.AutoApprove}`,
 						});
 						doComplete = false;
+						break;
+					}
+					case 'sessionApproval': {
+						const sessionId = this.context.element.sessionId;
+						this.terminalChatService.setChatSessionAutoApproval(sessionId, true);
+						terminalData.autoApproveInfo = new MarkdownString(localize('sessionApproval', 'All commands will be auto approved for this session'));
+						toolConfirmKind = ToolConfirmKind.UserAction;
 						break;
 					}
 				}

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart.ts
@@ -861,6 +861,7 @@ MenuRegistry.appendMenuItem(MenuId.CommandPalette, {
 });
 
 export const openTerminalSettingsLinkCommandId = '_chat.openTerminalSettingsLink';
+export const disableSessionAutoApprovalCommandId = '_chat.disableSessionAutoApproval';
 
 CommandsRegistry.registerCommand(openTerminalSettingsLinkCommandId, async (accessor, scopeRaw: string) => {
 	const preferencesService = accessor.get(IPreferencesService);
@@ -895,6 +896,11 @@ CommandsRegistry.registerCommand(openTerminalSettingsLinkCommandId, async (acces
 			}
 		}
 	}
+});
+
+CommandsRegistry.registerCommand(disableSessionAutoApprovalCommandId, async (accessor, chatSessionId: string) => {
+	const terminalChatService = accessor.get(ITerminalChatService);
+	terminalChatService.setChatSessionAutoApproval(chatSessionId, false);
 });
 
 

--- a/src/vs/workbench/contrib/terminal/browser/terminal.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminal.ts
@@ -172,6 +172,20 @@ export interface ITerminalChatService {
 	clearFocusedChatTerminalToolProgressPart(part: IChatTerminalToolProgressPart): void;
 	getFocusedChatTerminalToolProgressPart(): IChatTerminalToolProgressPart | undefined;
 	getMostRecentChatTerminalToolProgressPart(): IChatTerminalToolProgressPart | undefined;
+
+	/**
+	 * Enable or disable auto approval for all commands in a specific session.
+	 * @param chatSessionId The chat session ID
+	 * @param enabled Whether to enable or disable session auto approval
+	 */
+	setChatSessionAutoApproval(chatSessionId: string, enabled: boolean): void;
+
+	/**
+	 * Check if a session has auto approval enabled for all commands.
+	 * @param chatSessionId The chat session ID
+	 * @returns True if the session has auto approval enabled
+	 */
+	hasChatSessionAutoApproval(chatSessionId: string): boolean;
 }
 
 /**

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/runInTerminalHelpers.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/runInTerminalHelpers.ts
@@ -177,6 +177,18 @@ export function generateAutoApproveActions(commandLine: string, subCommands: str
 		actions.push(new Separator());
 	}
 
+
+	// Allow all commands for this session
+	actions.push({
+		label: localize('allowSession', 'Allow All Commands in this Session'),
+		tooltip: localize('allowSessionTooltip', 'Allow this tool to run in this session without confirmation.'),
+		data: {
+			type: 'sessionApproval'
+		} satisfies TerminalNewAutoApproveButtonData
+	});
+
+	actions.push(new Separator());
+
 	// Always show configure option
 	actions.push({
 		label: localize('autoApprove.configure', 'Configure Auto Approve...'),

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/commandLineAnalyzer/commandLineAnalyzer.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/commandLineAnalyzer/commandLineAnalyzer.ts
@@ -21,6 +21,7 @@ export interface ICommandLineAnalyzerOptions {
 	os: OperatingSystem;
 	treeSitterLanguage: TreeSitterCommandParserLanguage;
 	terminalToolSessionId: string;
+	chatSessionId: string | undefined;
 }
 
 export interface ICommandLineAnalyzerResult {

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/commandLineAnalyzer/commandLineAutoApproveAnalyzer.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/commandLineAnalyzer/commandLineAutoApproveAnalyzer.ts
@@ -10,6 +10,7 @@ import type { SingleOrMany } from '../../../../../../../base/common/types.js';
 import { localize } from '../../../../../../../nls.js';
 import { IConfigurationService } from '../../../../../../../platform/configuration/common/configuration.js';
 import { IInstantiationService } from '../../../../../../../platform/instantiation/common/instantiation.js';
+import { ITerminalChatService } from '../../../../../terminal/browser/terminal.js';
 import { IStorageService, StorageScope } from '../../../../../../../platform/storage/common/storage.js';
 import { TerminalToolConfirmationStorageKeys } from '../../../../../chat/browser/chatContentParts/toolInvocationParts/chatTerminalToolConfirmationSubPart.js';
 import { openTerminalSettingsLinkCommandId } from '../../../../../chat/browser/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart.js';
@@ -43,12 +44,23 @@ export class CommandLineAutoApproveAnalyzer extends Disposable implements IComma
 		@IConfigurationService private readonly _configurationService: IConfigurationService,
 		@IInstantiationService instantiationService: IInstantiationService,
 		@IStorageService private readonly _storageService: IStorageService,
+		@ITerminalChatService private readonly _terminalChatService: ITerminalChatService,
 	) {
 		super();
 		this._commandLineAutoApprover = this._register(instantiationService.createInstance(CommandLineAutoApprover));
 	}
 
 	async analyze(options: ICommandLineAnalyzerOptions): Promise<ICommandLineAnalyzerResult> {
+		if (options.chatSessionId && this._terminalChatService.hasChatSessionAutoApproval(options.chatSessionId)) {
+			this._log('Session has auto approval enabled, auto approving command');
+			return {
+				isAutoApproved: true,
+				isAutoApproveAllowed: true,
+				disclaimers: [],
+				autoApproveInfo: new MarkdownString(localize('autoApprove.session', 'Auto approved for this session')),
+			};
+		}
+
 		let subCommands: string[] | undefined;
 		try {
 			subCommands = await this._treeSitterCommandParser.extractSubCommands(options.treeSitterLanguage, options.commandLine);

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/commandLineAnalyzer/commandLineAutoApproveAnalyzer.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/commandLineAnalyzer/commandLineAutoApproveAnalyzer.ts
@@ -53,11 +53,17 @@ export class CommandLineAutoApproveAnalyzer extends Disposable implements IComma
 	async analyze(options: ICommandLineAnalyzerOptions): Promise<ICommandLineAnalyzerResult> {
 		if (options.chatSessionId && this._terminalChatService.hasChatSessionAutoApproval(options.chatSessionId)) {
 			this._log('Session has auto approval enabled, auto approving command');
+			const disableUri = createCommandUri('_chat.disableSessionAutoApproval', options.chatSessionId);
+			const mdTrustSettings = {
+				isTrusted: {
+					enabledCommands: ['_chat.disableSessionAutoApproval']
+				}
+			};
 			return {
 				isAutoApproved: true,
 				isAutoApproveAllowed: true,
 				disclaimers: [],
-				autoApproveInfo: new MarkdownString(localize('autoApprove.session', 'Auto approved for this session')),
+				autoApproveInfo: new MarkdownString(`${localize('autoApprove.session', 'Auto approved for this session')} ([${localize('autoApprove.session.disable', 'Disable')}](${disableUri.toString()}))`, mdTrustSettings),
 			};
 		}
 

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
@@ -412,6 +412,7 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 			shell,
 			treeSitterLanguage: isPowerShell(shell, os) ? TreeSitterCommandParserLanguage.PowerShell : TreeSitterCommandParserLanguage.Bash,
 			terminalToolSessionId,
+			chatSessionId: context.chatSessionId,
 		};
 		const commandLineAnalyzerResults = await Promise.all(this._commandLineAnalyzers.map(e => e.analyze(commandLineAnalyzerOptions)));
 

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/commandLineAnalyzer/commandLineFileWriteAnalyzer.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/commandLineAnalyzer/commandLineFileWriteAnalyzer.test.ts
@@ -79,7 +79,8 @@ suite('CommandLineFileWriteAnalyzer', () => {
 				shell: 'bash',
 				os: OperatingSystem.Linux,
 				treeSitterLanguage: TreeSitterCommandParserLanguage.Bash,
-				terminalToolSessionId: 'test'
+				terminalToolSessionId: 'test',
+				chatSessionId: 'test',
 			};
 
 			const result = await analyzer.analyze(options);
@@ -144,7 +145,8 @@ suite('CommandLineFileWriteAnalyzer', () => {
 					shell: 'bash',
 					os: OperatingSystem.Linux,
 					treeSitterLanguage: TreeSitterCommandParserLanguage.Bash,
-					terminalToolSessionId: 'test'
+					terminalToolSessionId: 'test',
+					chatSessionId: 'test',
 				};
 
 				const result = await analyzer.analyze(options);
@@ -180,7 +182,8 @@ suite('CommandLineFileWriteAnalyzer', () => {
 				shell: 'pwsh',
 				os: OperatingSystem.Windows,
 				treeSitterLanguage: TreeSitterCommandParserLanguage.PowerShell,
-				terminalToolSessionId: 'test'
+				terminalToolSessionId: 'test',
+				chatSessionId: 'test',
 			};
 
 			const result = await analyzer.analyze(options);
@@ -255,7 +258,8 @@ suite('CommandLineFileWriteAnalyzer', () => {
 				shell: 'bash',
 				os: OperatingSystem.Linux,
 				treeSitterLanguage: TreeSitterCommandParserLanguage.Bash,
-				terminalToolSessionId: 'test'
+				terminalToolSessionId: 'test',
+				chatSessionId: 'test',
 			};
 
 			const result = await analyzer.analyze(options);
@@ -286,7 +290,8 @@ suite('CommandLineFileWriteAnalyzer', () => {
 				shell: 'bash',
 				os: OperatingSystem.Linux,
 				treeSitterLanguage: TreeSitterCommandParserLanguage.Bash,
-				terminalToolSessionId: 'test'
+				terminalToolSessionId: 'test',
+				chatSessionId: 'test',
 			};
 
 			const result = await analyzer.analyze(options);
@@ -314,7 +319,8 @@ suite('CommandLineFileWriteAnalyzer', () => {
 				shell: 'bash',
 				os: OperatingSystem.Linux,
 				treeSitterLanguage: TreeSitterCommandParserLanguage.Bash,
-				terminalToolSessionId: 'test'
+				terminalToolSessionId: 'test',
+				chatSessionId: 'test',
 			};
 
 			const result = await analyzer.analyze(options);


### PR DESCRIPTION
Fixes #260819

@connor4312 what do you think? I considered pulling in the standard actions instead, but:

- I feel the standard wording "Allow in this Session" is too ambiguous
- We can't do workspace, adding workspace support would mean duplicating the rule suggestions and indicating user vs workspace (so out of scope imo)
- I also don't want to add "Always Allow" for similar reasons.

Something that's missing here is the ability to undo it. I could add that 

<img width="384" height="251" alt="image" src="https://github.com/user-attachments/assets/c472c0b9-109d-4592-8add-e5603a40c3e2" />

<img width="427" height="212" alt="image" src="https://github.com/user-attachments/assets/668a5159-f00e-4f24-9c2a-1cbcb2b79803" />

New command:

<img width="328" height="139" alt="image" src="https://github.com/user-attachments/assets/51a04b04-cc8f-4821-88db-5c236ae7128d" />

Clicking Disable is a bit ugly as it gives no feedback, but it does do what's advertised.

<img width="365" height="47" alt="image" src="https://github.com/user-attachments/assets/9f0fc4f8-b580-448f-a126-3984f8b2d73e" />
