### PR TITLE
Have the resourceUri be attached to the Auth Provider

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadMcp.ts
+++ b/src/vs/workbench/api/browser/mainThreadMcp.ts
@@ -185,8 +185,9 @@ export class MainThreadMcp extends Disposable implements MainThreadMcpShape {
 			return undefined;
 		}
 		const authorizationServer = URI.revive(authDetails.authorizationServer);
+		const resourceServer = authDetails.resourceMetadata?.resource ? URI.parse(authDetails.resourceMetadata.resource) : undefined;
 		const resolvedScopes = authDetails.scopes ?? authDetails.resourceMetadata?.scopes_supported ?? authDetails.authorizationServerMetadata.scopes_supported ?? [];
-		let providerId = await this._authenticationService.getOrActivateProviderIdForServer(authorizationServer);
+		let providerId = await this._authenticationService.getOrActivateProviderIdForServer(authorizationServer, resourceServer);
 		if (forceNewRegistration && providerId) {
 			this._authenticationService.unregisterAuthenticationProvider(providerId);
 			// TODO: Encapsulate this and the unregister in one call in the auth service

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -191,9 +191,23 @@ export interface AuthenticationGetSessionOptions {
 	silent?: boolean;
 	account?: AuthenticationSessionAccount;
 }
+export interface IRegisterAuthenticationProviderDetails {
+	id: string;
+	label: string;
+	supportsMultipleAccounts: boolean;
+	supportedAuthorizationServers?: UriComponents[];
+	supportsChallenges?: boolean;
+	resourceServer?: UriComponents;
+}
+
+export interface IRegisterDynamicAuthenticationProviderDetails extends IRegisterAuthenticationProviderDetails {
+	clientId: string;
+	clientSecret?: string;
+	authorizationServer: UriComponents;
+}
 
 export interface MainThreadAuthenticationShape extends IDisposable {
-	$registerAuthenticationProvider(id: string, label: string, supportsMultipleAccounts: boolean, supportedAuthorizationServers?: UriComponents[], supportsChallenges?: boolean): Promise<void>;
+	$registerAuthenticationProvider(details: IRegisterAuthenticationProviderDetails): Promise<void>;
 	$unregisterAuthenticationProvider(id: string): Promise<void>;
 	$ensureProvider(id: string): Promise<void>;
 	$sendDidChangeSessions(providerId: string, event: AuthenticationSessionsChangeEvent): Promise<void>;
@@ -204,7 +218,7 @@ export interface MainThreadAuthenticationShape extends IDisposable {
 	$showContinueNotification(message: string): Promise<boolean>;
 	$showDeviceCodeModal(userCode: string, verificationUri: string): Promise<boolean>;
 	$promptForClientRegistration(authorizationServerUrl: string): Promise<{ clientId: string; clientSecret?: string } | undefined>;
-	$registerDynamicAuthenticationProvider(id: string, label: string, authorizationServer: UriComponents, clientId: string, clientSecret?: string): Promise<void>;
+	$registerDynamicAuthenticationProvider(details: IRegisterDynamicAuthenticationProviderDetails): Promise<void>;
 	$setSessionsForDynamicAuthProvider(authProviderId: string, clientId: string, sessions: (IAuthorizationTokenResponse & { created_at: number })[]): Promise<void>;
 	$sendDidChangeDynamicProviderInfo({ providerId, clientId, authorizationServer, label, clientSecret }: { providerId: string; clientId?: string; authorizationServer?: UriComponents; label?: string; clientSecret?: string }): Promise<void>;
 }

--- a/src/vs/workbench/api/common/extHostAuthentication.ts
+++ b/src/vs/workbench/api/common/extHostAuthentication.ts
@@ -143,7 +143,13 @@ export class ExtHostAuthentication implements ExtHostAuthenticationShape {
 			}
 			const listener = provider.onDidChangeSessions(e => this._proxy.$sendDidChangeSessions(id, e));
 			this._authenticationProviders.set(id, { label, provider, disposable: listener, options: options ?? { supportsMultipleAccounts: false } });
-			await this._proxy.$registerAuthenticationProvider(id, label, options?.supportsMultipleAccounts ?? false, options?.supportedAuthorizationServers, options?.supportsChallenges);
+			await this._proxy.$registerAuthenticationProvider({
+				id,
+				label,
+				supportsMultipleAccounts: options?.supportsMultipleAccounts ?? false,
+				supportedAuthorizationServers: options?.supportedAuthorizationServers,
+				supportsChallenges: options?.supportsChallenges
+			});
 		});
 
 		// unregister
@@ -314,11 +320,23 @@ export class ExtHostAuthentication implements ExtHostAuthenticationShape {
 							clientSecret: provider.clientSecret
 						}))
 					),
-					options: { supportsMultipleAccounts: false }
+					options: { supportsMultipleAccounts: true }
 				}
 			);
-			await this._proxy.$registerDynamicAuthenticationProvider(provider.id, provider.label, provider.authorizationServer, provider.clientId, provider.clientSecret);
+
+			await this._proxy.$registerDynamicAuthenticationProvider({
+				id: provider.id,
+				label: provider.label,
+				supportsMultipleAccounts: true,
+				authorizationServer: authorizationServerComponents,
+				resourceServer: resourceMetadata ? URI.parse(resourceMetadata.resource) : undefined,
+				clientId: provider.clientId,
+				clientSecret: provider.clientSecret
+			});
 		});
+
+
+
 
 		return provider.id;
 	}

--- a/src/vs/workbench/api/test/browser/mainThreadAuthentication.integrationTest.ts
+++ b/src/vs/workbench/api/test/browser/mainThreadAuthentication.integrationTest.ts
@@ -91,7 +91,11 @@ suite('MainThreadAuthentication', () => {
 
 	test('provider registration completes without errors', async () => {
 		// Test basic registration - this should complete without throwing
-		await mainThreadAuthentication.$registerAuthenticationProvider('test-provider', 'Test Provider', false);
+		await mainThreadAuthentication.$registerAuthenticationProvider({
+			id: 'test-provider',
+			label: 'Test Provider',
+			supportsMultipleAccounts: false
+		});
 
 		// Test unregistration - this should also complete without throwing
 		await mainThreadAuthentication.$unregisterAuthenticationProvider('test-provider');
@@ -125,7 +129,11 @@ suite('MainThreadAuthentication', () => {
 		rpcProtocol.set(ExtHostContext.ExtHostAuthentication, mockExtHost);
 
 		// Register a provider
-		await mainThreadAuthentication.$registerAuthenticationProvider('test-suppress', 'Test Suppress', false);
+		await mainThreadAuthentication.$registerAuthenticationProvider({
+			id: 'test-suppress',
+			label: 'Test Suppress',
+			supportsMultipleAccounts: false
+		});
 
 		// Reset the flag
 		unregisterEventFired = false;
@@ -142,9 +150,21 @@ suite('MainThreadAuthentication', () => {
 	test('concurrent provider registrations complete without errors', async () => {
 		// Register multiple providers simultaneously
 		const registrationPromises = [
-			mainThreadAuthentication.$registerAuthenticationProvider('concurrent-1', 'Concurrent 1', false),
-			mainThreadAuthentication.$registerAuthenticationProvider('concurrent-2', 'Concurrent 2', false),
-			mainThreadAuthentication.$registerAuthenticationProvider('concurrent-3', 'Concurrent 3', false)
+			mainThreadAuthentication.$registerAuthenticationProvider({
+				id: 'concurrent-1',
+				label: 'Concurrent 1',
+				supportsMultipleAccounts: false
+			}),
+			mainThreadAuthentication.$registerAuthenticationProvider({
+				id: 'concurrent-2',
+				label: 'Concurrent 2',
+				supportsMultipleAccounts: false
+			}),
+			mainThreadAuthentication.$registerAuthenticationProvider({
+				id: 'concurrent-3',
+				label: 'Concurrent 3',
+				supportsMultipleAccounts: false
+			})
 		];
 
 		await Promise.all(registrationPromises);

--- a/src/vs/workbench/services/authentication/browser/authenticationService.ts
+++ b/src/vs/workbench/services/authentication/browser/authenticationService.ts
@@ -286,7 +286,8 @@ export class AuthenticationService extends Disposable implements IAuthentication
 			// Check if the authorization server is in the list of supported authorization servers
 			const server = options?.authorizationServer;
 			if (server) {
-				// TODO: something is off here...
+				// Skip the resource server check since the auth provider id contains a specific resource server
+				// TODO@TylerLeonhardt: this can change when we have providers that support multiple resource servers
 				if (!this.matchesProvider(authProvider, server)) {
 					throw new Error(`The authentication provider '${id}' does not support the authorization server '${server.toString(true)}'.`);
 				}
@@ -341,9 +342,9 @@ export class AuthenticationService extends Disposable implements IAuthentication
 		}
 	}
 
-	async getOrActivateProviderIdForServer(authorizationServer: URI): Promise<string | undefined> {
+	async getOrActivateProviderIdForServer(authorizationServer: URI, resourceServer?: URI): Promise<string | undefined> {
 		for (const provider of this._authenticationProviders.values()) {
-			if (this.matchesProvider(provider, authorizationServer)) {
+			if (this.matchesProvider(provider, authorizationServer, resourceServer)) {
 				return provider.id;
 			}
 		}
@@ -358,7 +359,7 @@ export class AuthenticationService extends Disposable implements IAuthentication
 		for (const provider of providers) {
 			const activeProvider = await this.tryActivateProvider(provider.id, true);
 			// Check the resolved authorization servers
-			if (this.matchesProvider(activeProvider, authorizationServer)) {
+			if (this.matchesProvider(activeProvider, authorizationServer, resourceServer)) {
 				return activeProvider.id;
 			}
 		}
@@ -396,7 +397,16 @@ export class AuthenticationService extends Disposable implements IAuthentication
 		};
 	}
 
-	private matchesProvider(provider: IAuthenticationProvider, authorizationServer: URI): boolean {
+	private matchesProvider(provider: IAuthenticationProvider, authorizationServer: URI, resourceServer?: URI): boolean {
+		// If a resourceServer is provided and the provider has a resourceServer defined, they must match
+		if (resourceServer && provider.resourceServer) {
+			const resourceServerStr = resourceServer.toString(true);
+			const providerResourceServerStr = provider.resourceServer.toString(true);
+			if (!equalsIgnoreCase(providerResourceServerStr, resourceServerStr)) {
+				return false;
+			}
+		}
+
 		if (provider.authorizationServers) {
 			const authServerStr = authorizationServer.toString(true);
 			for (const server of provider.authorizationServers) {

--- a/src/vs/workbench/services/authentication/common/authentication.ts
+++ b/src/vs/workbench/services/authentication/common/authentication.ts
@@ -257,8 +257,9 @@ export interface IAuthenticationService {
 	/**
 	 * Gets a provider id for a specified authorization server
 	 * @param authorizationServer The authorization server url that this provider is responsible for
+	 * @param resourceServer The resource server URI that should match the provider's resourceServer (if defined)
 	 */
-	getOrActivateProviderIdForServer(authorizationServer: URI): Promise<string | undefined>;
+	getOrActivateProviderIdForServer(authorizationServer: URI, resourceServer?: URI): Promise<string | undefined>;
 
 	/**
 	 * Allows the ability register a delegate that will be used to start authentication providers
@@ -397,6 +398,13 @@ export interface IAuthenticationProvider {
 	 * The display label of the authentication provider.
 	 */
 	readonly label: string;
+
+	/**
+	 * The resource server URI that this provider is responsible for, if any.
+	 * TODO@TylerLeonhardt: Rather than this being added to the provider, it should be passed in to
+	 * getSessions/createSession/etc... this way we can have providers that handle multiple resource servers.
+	 */
+	readonly resourceServer?: URI;
 
 	/**
 	 * The resolved authorization servers. These can still contain globs, but should be concrete URIs


### PR DESCRIPTION
In order to not complicate VS Code API, the initial design of dynamic auth providers was to register one per auth server/resource server pair.

> note resource server is the same as mcp server more-or-less

that's why the auth provider id was a combo of those two urls.

However, after registration, when we wanted to see what auth provider an mcp server would use, we'd only look at the auth server uri... this caused a bug where the same auth provider was being re-used for multiple mcp servers, even though those are 2 different resources.

The fix? When fetching what auth provider to use, also pass in the resource server and look at the resource server on the auth provider to see if they match.

I still think we need an larger re-design to allow auth providers to take in `resource`s ...but this addresses the issue for now. We will need to do this once Entra supports `resource` which should happen in the new year ..,,..... maybe

Fixes https://github.com/microsoft/vscode/issues/272047

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
