### PR TITLE
mcp: use approval tooltip ui for tool calls

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/chatToolInputOutputContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/chatToolInputOutputContentPart.ts
@@ -5,6 +5,7 @@
 
 import * as dom from '../../../../../base/browser/dom.js';
 import { ButtonWithIcon } from '../../../../../base/browser/ui/button/button.js';
+import { HoverStyle } from '../../../../../base/browser/ui/hover/hover.js';
 import { Codicon } from '../../../../../base/common/codicons.js';
 import { Emitter } from '../../../../../base/common/event.js';
 import { IMarkdownString } from '../../../../../base/common/htmlContent.js';
@@ -15,6 +16,7 @@ import { URI } from '../../../../../base/common/uri.js';
 import { ITextModel } from '../../../../../editor/common/model.js';
 import { localize } from '../../../../../nls.js';
 import { IContextKeyService } from '../../../../../platform/contextkey/common/contextkey.js';
+import { IHoverService } from '../../../../../platform/hover/browser/hover.js';
 import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
 import { IChatRendererContent } from '../../common/chatViewModel.js';
 import { LanguageModelPartAudience } from '../../common/languageModels.js';
@@ -84,6 +86,7 @@ export class ChatCollapsibleInputOutputContentPart extends Disposable {
 	constructor(
 		title: IMarkdownString | string,
 		subtitle: string | IMarkdownString | undefined,
+		progressTooltip: IMarkdownString | string | undefined,
 		private readonly context: IChatContentPartRenderContext,
 		private readonly input: IChatCollapsibleInputData,
 		private readonly output: IChatCollapsibleOutputData | undefined,
@@ -91,6 +94,7 @@ export class ChatCollapsibleInputOutputContentPart extends Disposable {
 		initiallyExpanded: boolean,
 		@IContextKeyService private readonly contextKeyService: IContextKeyService,
 		@IInstantiationService private readonly _instantiationService: IInstantiationService,
+		@IHoverService hoverService: IHoverService,
 	) {
 		super();
 		this._currentWidth = context.currentWidth();
@@ -124,6 +128,12 @@ export class ChatCollapsibleInputOutputContentPart extends Disposable {
 				: ThemeIcon.asCSSSelector(ThemeIcon.modify(Codicon.loading, 'spin'))
 		);
 		iconEl.root.appendChild(check.root);
+		if (progressTooltip) {
+			this._register(hoverService.setupDelayedHover(check.root, {
+				content: progressTooltip,
+				style: HoverStyle.Pointer,
+			}));
+		}
 
 		const expanded = this._expanded = observableValue(this, initiallyExpanded);
 		this._register(autorun(r => {

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatInputOutputMarkdownProgressPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatInputOutputMarkdownProgressPart.ts
@@ -5,7 +5,7 @@
 
 import { ProgressBar } from '../../../../../../base/browser/ui/progressbar/progressbar.js';
 import { decodeBase64 } from '../../../../../../base/common/buffer.js';
-import { IMarkdownString } from '../../../../../../base/common/htmlContent.js';
+import { IMarkdownString, markdownCommandLink, MarkdownString } from '../../../../../../base/common/htmlContent.js';
 import { Lazy } from '../../../../../../base/common/lazy.js';
 import { toDisposable } from '../../../../../../base/common/lifecycle.js';
 import { getExtensionForMimeType } from '../../../../../../base/common/mime.js';
@@ -13,12 +13,12 @@ import { autorun } from '../../../../../../base/common/observable.js';
 import { basename } from '../../../../../../base/common/resources.js';
 import { ILanguageService } from '../../../../../../editor/common/languages/language.js';
 import { IModelService } from '../../../../../../editor/common/services/model.js';
+import { localize } from '../../../../../../nls.js';
 import { IInstantiationService } from '../../../../../../platform/instantiation/common/instantiation.js';
 import { ChatResponseResource } from '../../../common/chatModel.js';
-import { IChatToolInvocation, IChatToolInvocationSerialized } from '../../../common/chatService.js';
+import { IChatToolInvocation, IChatToolInvocationSerialized, ToolConfirmKind } from '../../../common/chatService.js';
 import { IToolResultInputOutputDetails } from '../../../common/languageModelToolsService.js';
 import { IChatCodeBlockInfo } from '../../chat.js';
-import { EditorPool } from '../chatContentCodePools.js';
 import { IChatContentPartRenderContext } from '../chatContentParts.js';
 import { ChatCollapsibleInputOutputContentPart, ChatCollapsibleIOPart, IChatCollapsibleIOCodePart } from '../chatToolInputOutputContentPart.js';
 import { BaseChatToolInvocationSubPart } from './chatToolInvocationSubPart.js';
@@ -37,14 +37,12 @@ export class ChatInputOutputMarkdownProgressPart extends BaseChatToolInvocationS
 	constructor(
 		toolInvocation: IChatToolInvocation | IChatToolInvocationSerialized,
 		context: IChatContentPartRenderContext,
-		editorPool: EditorPool,
 		codeBlockStartIndex: number,
 		message: string | IMarkdownString,
 		subtitle: string | IMarkdownString | undefined,
 		input: string,
 		output: IToolResultInputOutputDetails['output'] | undefined,
 		isError: boolean,
-		currentWidthDelegate: () => number,
 		@IInstantiationService instantiationService: IInstantiationService,
 		@IModelService modelService: IModelService,
 		@ILanguageService languageService: ILanguageService,
@@ -95,6 +93,7 @@ export class ChatInputOutputMarkdownProgressPart extends BaseChatToolInvocationS
 			ChatCollapsibleInputOutputContentPart,
 			message,
 			subtitle,
+			this.getAutoApproveMessageContent(),
 			context,
 			toCodePart(input),
 			processedOutput && {
@@ -148,5 +147,35 @@ export class ChatInputOutputMarkdownProgressPart extends BaseChatToolInvocationS
 		}
 
 		this.domNode = collapsibleListPart.domNode;
+	}
+
+	private getAutoApproveMessageContent() {
+		const reason = IChatToolInvocation.executionConfirmedOrDenied(this.toolInvocation);
+		if (!reason || typeof reason === 'boolean') {
+			return;
+		}
+
+		let md: string;
+		switch (reason.type) {
+			case ToolConfirmKind.Setting:
+				md = localize('chat.autoapprove.setting', 'Auto approved by {0}', markdownCommandLink({ title: '`' + reason.id + '`', id: 'workbench.action.openSettings', arguments: [reason.id] }, false));
+				break;
+			case ToolConfirmKind.LmServicePerTool:
+				md = reason.scope === 'session'
+					? localize('chat.autoapprove.lmServicePerTool.session', 'Auto approved for this session')
+					: reason.scope === 'workspace'
+						? localize('chat.autoapprove.lmServicePerTool.workspace', 'Auto approved for this workspace')
+						: localize('chat.autoapprove.lmServicePerTool.profile', 'Auto approved for this profile');
+				md += ' (' + markdownCommandLink({ title: localize('edit', 'Edit'), id: 'workbench.action.chat.editToolApproval', arguments: [reason.scope] }) + ')';
+				break;
+			case ToolConfirmKind.UserAction:
+			case ToolConfirmKind.Denied:
+			case ToolConfirmKind.ConfirmationNotNeeded:
+			default:
+				return;
+		}
+
+
+		return new MarkdownString(md, { isTrusted: true });
 	}
 }

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatToolInvocationPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatToolInvocationPart.ts
@@ -6,13 +6,15 @@
 import * as dom from '../../../../../../base/browser/dom.js';
 import { Emitter } from '../../../../../../base/common/event.js';
 import { Disposable, DisposableStore, IDisposable } from '../../../../../../base/common/lifecycle.js';
-import { IMarkdownRenderer } from '../../../../../../platform/markdown/browser/markdownRenderer.js';
+import { autorun } from '../../../../../../base/common/observable.js';
 import { IInstantiationService } from '../../../../../../platform/instantiation/common/instantiation.js';
-import { IChatToolInvocation, IChatToolInvocationSerialized, ToolConfirmKind } from '../../../common/chatService.js';
+import { IMarkdownRenderer } from '../../../../../../platform/markdown/browser/markdownRenderer.js';
+import { IChatToolInvocation, IChatToolInvocationSerialized } from '../../../common/chatService.js';
 import { IChatRendererContent } from '../../../common/chatViewModel.js';
 import { CodeBlockModelCollection } from '../../../common/codeBlockModelCollection.js';
 import { isToolResultInputOutputDetails, isToolResultOutputDetails, ToolInvocationPresentation } from '../../../common/languageModelToolsService.js';
 import { ChatTreeItem, IChatCodeBlockInfo } from '../../chat.js';
+import { EditorPool } from '../chatContentCodePools.js';
 import { IChatContentPart, IChatContentPartRenderContext } from '../chatContentParts.js';
 import { CollapsibleListPool } from '../chatReferencesContentPart.js';
 import { ExtensionsInstallConfirmationWidgetSubPart } from './chatExtensionsInstallToolSubPart.js';
@@ -25,10 +27,6 @@ import { BaseChatToolInvocationSubPart } from './chatToolInvocationSubPart.js';
 import { ChatToolOutputSubPart } from './chatToolOutputPart.js';
 import { ChatToolPostExecuteConfirmationPart } from './chatToolPostExecuteConfirmationPart.js';
 import { ChatToolProgressSubPart } from './chatToolProgressPart.js';
-import { autorun } from '../../../../../../base/common/observable.js';
-import { localize } from '../../../../../../nls.js';
-import { markdownCommandLink, MarkdownString } from '../../../../../../base/common/htmlContent.js';
-import { EditorPool } from '../chatContentCodePools.js';
 
 export class ChatToolInvocationPart extends Disposable implements IChatContentPart {
 	public readonly domNode: HTMLElement;

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatToolInvocationPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatToolInvocationPart.ts
@@ -94,63 +94,9 @@ export class ChatToolInvocationPart extends Disposable implements IChatContentPa
 			partStore.add(this.subPart.onDidChangeHeight(() => this._onDidChangeHeight.fire()));
 			partStore.add(this.subPart.onNeedsRerender(render));
 
-			// todo@connor4312: Move MCP spinner to left to get consistent auto approval presentation
-			if (this.subPart instanceof ChatInputOutputMarkdownProgressPart) {
-				const approval = this.createApprovalMessage();
-				if (approval) {
-					this.domNode.appendChild(approval);
-				}
-			}
-
 			this._onDidChangeHeight.fire();
 		};
 		render();
-	}
-
-	/** @deprecated Approval should be centrally managed by passing tool invocation ChatProgressContentPart */
-	private get autoApproveMessageContent() {
-		const reason = IChatToolInvocation.executionConfirmedOrDenied(this.toolInvocation);
-		if (!reason || typeof reason === 'boolean') {
-			return;
-		}
-
-		let md: string;
-		switch (reason.type) {
-			case ToolConfirmKind.Setting:
-				md = localize('chat.autoapprove.setting', 'Auto approved by {0}', markdownCommandLink({ title: '`' + reason.id + '`', id: 'workbench.action.openSettings', arguments: [reason.id] }, false));
-				break;
-			case ToolConfirmKind.LmServicePerTool:
-				md = reason.scope === 'session'
-					? localize('chat.autoapprove.lmServicePerTool.session', 'Auto approved for this session')
-					: reason.scope === 'workspace'
-						? localize('chat.autoapprove.lmServicePerTool.workspace', 'Auto approved for this workspace')
-						: localize('chat.autoapprove.lmServicePerTool.profile', 'Auto approved for this profile');
-				md += ' (' + markdownCommandLink({ title: localize('edit', 'Edit'), id: 'workbench.action.chat.editToolApproval', arguments: [reason.scope] }) + ')';
-				break;
-			case ToolConfirmKind.UserAction:
-			case ToolConfirmKind.Denied:
-			case ToolConfirmKind.ConfirmationNotNeeded:
-			default:
-				return;
-		}
-
-
-		return md;
-	}
-
-	/** @deprecated Approval should be centrally managed by passing tool invocation ChatProgressContentPart */
-	private createApprovalMessage(): HTMLElement | undefined {
-		const md = this.autoApproveMessageContent;
-		if (!md) {
-			return undefined;
-		}
-
-		const markdownString = new MarkdownString('_' + md + '_', { isTrusted: true });
-		const result = this.renderer.render(markdownString);
-		this._register(result);
-		result.element.classList.add('chat-tool-approval-message');
-
-		return result.element;
 	}
 
 	private createToolInvocationSubPart(): BaseChatToolInvocationSubPart {
@@ -189,14 +135,12 @@ export class ChatToolInvocationPart extends Disposable implements IChatContentPa
 				ChatInputOutputMarkdownProgressPart,
 				this.toolInvocation,
 				this.context,
-				this.editorPool,
 				this.codeBlockStartIndex,
 				this.toolInvocation.pastTenseMessage ?? this.toolInvocation.invocationMessage,
 				this.toolInvocation.originMessage,
 				resultDetails.input,
 				resultDetails.output,
 				!!resultDetails.isError,
-				this.currentWidthDelegate
 			);
 		}
 
@@ -205,14 +149,12 @@ export class ChatToolInvocationPart extends Disposable implements IChatContentPa
 				ChatInputOutputMarkdownProgressPart,
 				this.toolInvocation,
 				this.context,
-				this.editorPool,
 				this.codeBlockStartIndex,
 				this.toolInvocation.invocationMessage,
 				this.toolInvocation.originMessage,
 				typeof this.toolInvocation.toolSpecificData.rawInput === 'string' ? this.toolInvocation.toolSpecificData.rawInput : JSON.stringify(this.toolInvocation.toolSpecificData.rawInput, null, 2),
 				undefined,
 				false,
-				this.currentWidthDelegate
 			);
 		}
 


### PR DESCRIPTION
Closes #277026

Just uses the consistent tooltip. Design folks are doing a unification pass on our tool display for this iteration so I didn't bother trying to do a larger style rework yet.