### PR TITLE
Add npm 10.5.0 minimum to preinstall

### DIFF
--- a/build/npm/preinstall.js
+++ b/build/npm/preinstall.js
@@ -5,6 +5,7 @@
 // @ts-check
 const path = require('path');
 const fs = require('fs');
+const semver = require('semver');
 
 if (!process.env['VSCODE_SKIP_NODE_VERSION_CHECK']) {
 	// Get the running Node.js version
@@ -33,6 +34,17 @@ if (!process.env['VSCODE_SKIP_NODE_VERSION_CHECK']) {
 		console.error(`\x1b[1;31m*** Please use Node.js v${requiredVersion} or later for development. Currently using v${process.versions.node}.\x1b[0;0m`);
 		throw new Error();
 	}
+}
+
+const requiredNpmVersion = '10.5.0';
+const npmUserAgent = process.env['npm_config_user_agent'];
+const npmVersionMatch = npmUserAgent?.match(/npm\/(\d+\.\d+\.\d+)/);
+const npmVersion = npmVersionMatch?.[1];
+const currentNpmVersion = npmVersion ? semver.coerce(npmVersion) : undefined;
+
+if (currentNpmVersion && semver.lt(currentNpmVersion, requiredNpmVersion)) {
+	console.error(`\x1b[1;31m*** Please use npm v${requiredNpmVersion} or later. Currently using v${npmVersion}. ***\x1b[0;0m`);
+	process.exit(1);
 }
 
 if (process.env.npm_execpath?.includes('yarn')) {


### PR DESCRIPTION
Fixes microsoft/vscode#252372.

Summary
- read npm_config_user_agent to detect the npm version used for install
- require npm 10.5.0 or newer via semver and exit with a clear error when older

Testing
- npm install (npm 10.5.0)
