### PR TITLE
Fix spelling errors in comments and error messages

### DIFF
--- a/extensions/vscode-test-resolver/src/extension.browser.ts
+++ b/extensions/vscode-test-resolver/src/extension.browser.ts
@@ -54,8 +54,8 @@ class InitialManagedMessagePassing implements vscode.ManagedMessagePassing {
 		// example str GET ws://localhost/oss-dev?reconnectionToken=4354a323-a45a-452c-b5d7-d8d586e1cd5c&reconnection=false&skipWebSocketFrames=true HTTP/1.1
 		const match = str.match(/GET\s+(\S+)\s+HTTP/);
 		if (!match) {
-			console.error(`Coult not parse ${str}`);
-			this.closeEmitter.fire(new Error(`Coult not parse ${str}`));
+			console.error(`Could not parse ${str}`);
+			this.closeEmitter.fire(new Error(`Could not parse ${str}`));
 			return;
 		}
 

--- a/src/vs/platform/files/node/watcher/parcel/parcelWatcher.ts
+++ b/src/vs/platform/files/node/watcher/parcel/parcelWatcher.ts
@@ -169,9 +169,9 @@ export class ParcelWatcher extends BaseWatcher implements IRecursiveWatcherWithS
 	// to schedule sufficiently after Parcel.
 	//
 	// Note: since Parcel 2.0.7, the very first event is
-	// emitted without delay if no events occured over a
+	// emitted without delay if no events occurred over a
 	// duration of 500ms. But we always want to aggregate
-	// events to apply our coleasing logic.
+	// events to apply our coalescing logic.
 	//
 	private static readonly FILE_CHANGES_HANDLER_DELAY = 75;
 

--- a/src/vs/workbench/api/common/extHostTypes.ts
+++ b/src/vs/workbench/api/common/extHostTypes.ts
@@ -3116,7 +3116,7 @@ export class ChatResponseMarkdownPart {
 
 /**
  * TODO if 'vulnerabilities' is finalized, this should be merged with the base ChatResponseMarkdownPart. I just don't see how to do that while keeping
- * vulnerabilities in a seperate API proposal in a clean way.
+ * vulnerabilities in a separate API proposal in a clean way.
  */
 export class ChatResponseMarkdownWithVulnerabilitiesPart {
 	value: vscode.MarkdownString;

--- a/src/vs/workbench/services/search/node/ripgrepTextSearchEngine.ts
+++ b/src/vs/workbench/services/search/node/ripgrepTextSearchEngine.ts
@@ -584,7 +584,7 @@ export type IRgBytesOrText = { bytes: string } | { text: string };
 const isLookBehind = (node: ReAST.Node) => node.type === 'Assertion' && node.kind === 'lookbehind';
 
 export function fixRegexNewline(pattern: string): string {
-	// we parse the pattern anew each tiem
+	// we parse the pattern anew each time
 	let re: ReAST.Pattern;
 	try {
 		re = new RegExpParser().parsePattern(pattern);


### PR DESCRIPTION
- Fix 'Coult' to 'Could' in vscode-test-resolver error messages
- Fix 'tiem' to 'time' in ripgrepTextSearchEngine comment
- Fix 'seperate' to 'separate' in extHostTypes comment
- Fix 'occured' to 'occurred' in parcelWatcher comment
- Fix 'coleasing' to 'coalescing' in parcelWatcher comment

Fixes #277653

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
