### PR TITLE
Support in-context quick pick

### DIFF
--- a/src/vs/base/browser/ui/menu/menu.ts
+++ b/src/vs/base/browser/ui/menu/menu.ts
@@ -11,7 +11,7 @@ import { StandardKeyboardEvent } from '../../keyboardEvent.js';
 import { StandardMouseEvent } from '../../mouseEvent.js';
 import { ActionBar, ActionsOrientation, IActionViewItemProvider } from '../actionbar/actionbar.js';
 import { ActionViewItem, BaseActionViewItem, IActionViewItemOptions } from '../actionbar/actionViewItems.js';
-import { AnchorAlignment, layout, LayoutAnchorPosition } from '../contextview/contextview.js';
+
 import { DomScrollableElement } from '../scrollbar/scrollableElement.js';
 import { EmptySubmenuAction, IAction, IActionRunner, Separator, SubmenuAction } from '../../../common/actions.js';
 import { RunOnceScheduler } from '../../../common/async.js';
@@ -26,6 +26,7 @@ import { DisposableStore } from '../../../common/lifecycle.js';
 import { isLinux, isMacintosh } from '../../../common/platform.js';
 import { ScrollbarVisibility, ScrollEvent } from '../../../common/scrollable.js';
 import * as strings from '../../../common/strings.js';
+import { AnchorAlignment, layout, LayoutAnchorPosition } from '../../../common/layout.js';
 
 export const MENU_MNEMONIC_REGEX = /\(&([^\s&])\)|(^|[^&])&([^\s&])/;
 export const MENU_ESCAPED_MNEMONIC_REGEX = /(&amp;)?(&amp;)([^\s&])/g;

--- a/src/vs/base/browser/ui/menu/menu.ts
+++ b/src/vs/base/browser/ui/menu/menu.ts
@@ -864,7 +864,7 @@ class SubmenuMenuActionViewItem extends BaseMenuActionViewItem {
 		const ret = { top: 0, left: 0 };
 
 		// Start with horizontal
-		ret.left = layout(windowDimensions.width, submenu.width, { position: expandDirection.horizontal === HorizontalDirection.Right ? LayoutAnchorPosition.Before : LayoutAnchorPosition.After, offset: entry.left, size: entry.width });
+		ret.left = layout(windowDimensions.width, submenu.width, { position: expandDirection.horizontal === HorizontalDirection.Right ? LayoutAnchorPosition.Before : LayoutAnchorPosition.After, offset: entry.left, size: entry.width }).position;
 
 		// We don't have enough room to layout the menu fully, so we are overlapping the menu
 		if (ret.left >= entry.left && ret.left < entry.left + entry.width) {
@@ -877,7 +877,7 @@ class SubmenuMenuActionViewItem extends BaseMenuActionViewItem {
 		}
 
 		// Now that we have a horizontal position, try layout vertically
-		ret.top = layout(windowDimensions.height, submenu.height, { position: LayoutAnchorPosition.Before, offset: entry.top, size: 0 });
+		ret.top = layout(windowDimensions.height, submenu.height, { position: LayoutAnchorPosition.Before, offset: entry.top, size: 0 }).position;
 
 		// We didn't have enough room below, but we did above, so we shift down to align the menu
 		if (ret.top + submenu.height === entry.top && ret.top + entry.height + submenu.height <= windowDimensions.height) {

--- a/src/vs/base/common/layout.ts
+++ b/src/vs/base/common/layout.ts
@@ -1,0 +1,129 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Range } from './range.js';
+
+export interface IAnchor {
+	x: number;
+	y: number;
+	width?: number;
+	height?: number;
+}
+
+export const enum AnchorAlignment {
+	LEFT, RIGHT
+}
+
+export const enum AnchorPosition {
+	BELOW, ABOVE
+}
+
+export const enum AnchorAxisAlignment {
+	VERTICAL, HORIZONTAL
+}
+
+interface IPosition {
+	readonly top: number;
+	readonly left: number;
+}
+
+interface ISize {
+	readonly width: number;
+	readonly height: number;
+}
+
+export interface IRect extends IPosition, ISize { }
+
+export const enum LayoutAnchorPosition {
+	Before,
+	After
+}
+
+export enum LayoutAnchorMode {
+	AVOID,
+	ALIGN
+}
+
+export interface ILayoutAnchor {
+	offset: number;
+	size: number;
+	mode?: LayoutAnchorMode; // default: AVOID
+	position: LayoutAnchorPosition;
+}
+
+/**
+ * Lays out a one dimensional view next to an anchor in a viewport.
+ *
+ * @returns The view offset within the viewport.
+ */
+export function layout(viewportSize: number, viewSize: number, anchor: ILayoutAnchor): number {
+	const layoutAfterAnchorBoundary = anchor.mode === LayoutAnchorMode.ALIGN ? anchor.offset : anchor.offset + anchor.size;
+	const layoutBeforeAnchorBoundary = anchor.mode === LayoutAnchorMode.ALIGN ? anchor.offset + anchor.size : anchor.offset;
+
+	if (anchor.position === LayoutAnchorPosition.Before) {
+		if (viewSize <= viewportSize - layoutAfterAnchorBoundary) {
+			return layoutAfterAnchorBoundary; // happy case, lay it out after the anchor
+		}
+
+		if (viewSize <= layoutBeforeAnchorBoundary) {
+			return layoutBeforeAnchorBoundary - viewSize; // ok case, lay it out before the anchor
+		}
+
+		return Math.max(viewportSize - viewSize, 0); // sad case, lay it over the anchor
+	} else {
+		if (viewSize <= layoutBeforeAnchorBoundary) {
+			return layoutBeforeAnchorBoundary - viewSize; // happy case, lay it out before the anchor
+		}
+
+		if (viewSize <= viewportSize - layoutAfterAnchorBoundary) {
+			return layoutAfterAnchorBoundary; // ok case, lay it out after the anchor
+		}
+
+		return 0; // sad case, lay it over the anchor
+	}
+}
+
+interface ILayout2DOptions {
+	readonly anchorAlignment?: AnchorAlignment; // default: left
+	readonly anchorPosition?: AnchorPosition; // default: below
+	readonly anchorAxisAlignment?: AnchorAxisAlignment; // default: vertical
+}
+
+export function layout2d(viewport: IRect, view: ISize, anchor: IRect, options?: ILayout2DOptions): IPosition {
+	const anchorAlignment = options?.anchorAlignment ?? AnchorAlignment.LEFT;
+	const anchorPosition = options?.anchorPosition ?? AnchorPosition.BELOW;
+	const anchorAxisAlignment = options?.anchorAxisAlignment ?? AnchorAxisAlignment.VERTICAL;
+
+	let top: number;
+	let left: number;
+
+	if (anchorAxisAlignment === AnchorAxisAlignment.VERTICAL) {
+		const verticalAnchor: ILayoutAnchor = { offset: anchor.top - viewport.top, size: anchor.height, position: anchorPosition === AnchorPosition.BELOW ? LayoutAnchorPosition.Before : LayoutAnchorPosition.After };
+		const horizontalAnchor: ILayoutAnchor = { offset: anchor.left, size: anchor.width, position: anchorAlignment === AnchorAlignment.LEFT ? LayoutAnchorPosition.Before : LayoutAnchorPosition.After, mode: LayoutAnchorMode.ALIGN };
+
+		top = layout(viewport.height, view.height, verticalAnchor) + viewport.top;
+
+		// if view intersects vertically with anchor,  we must avoid the anchor
+		if (Range.intersects({ start: top, end: top + view.height }, { start: verticalAnchor.offset, end: verticalAnchor.offset + verticalAnchor.size })) {
+			horizontalAnchor.mode = LayoutAnchorMode.AVOID;
+		}
+
+		left = layout(viewport.width, view.width, horizontalAnchor);
+	} else {
+		const horizontalAnchor: ILayoutAnchor = { offset: anchor.left, size: anchor.width, position: anchorAlignment === AnchorAlignment.LEFT ? LayoutAnchorPosition.Before : LayoutAnchorPosition.After };
+		const verticalAnchor: ILayoutAnchor = { offset: anchor.top, size: anchor.height, position: anchorPosition === AnchorPosition.BELOW ? LayoutAnchorPosition.Before : LayoutAnchorPosition.After, mode: LayoutAnchorMode.ALIGN };
+
+		left = layout(viewport.width, view.width, horizontalAnchor);
+
+		// if view intersects horizontally with anchor, we must avoid the anchor
+		if (Range.intersects({ start: left, end: left + view.width }, { start: horizontalAnchor.offset, end: horizontalAnchor.offset + horizontalAnchor.size })) {
+			verticalAnchor.mode = LayoutAnchorMode.AVOID;
+		}
+
+		top = layout(viewport.height, view.height, verticalAnchor) + viewport.top;
+	}
+
+	return { top, left };
+}

--- a/src/vs/base/test/common/layout.test.ts
+++ b/src/vs/base/test/common/layout.test.ts
@@ -10,21 +10,20 @@ import { ensureNoDisposablesAreLeakedInTestSuite } from './utils.js';
 suite('Layout', function () {
 
 	test('layout', () => {
-		assert.strictEqual(layout(200, 20, { offset: 0, size: 0, position: LayoutAnchorPosition.Before }), 0);
-		assert.strictEqual(layout(200, 20, { offset: 50, size: 0, position: LayoutAnchorPosition.Before }), 50);
-		assert.strictEqual(layout(200, 20, { offset: 200, size: 0, position: LayoutAnchorPosition.Before }), 180);
+		assert.strictEqual(layout(200, 20, { offset: 0, size: 0, position: LayoutAnchorPosition.Before }).position, 0);
+		assert.strictEqual(layout(200, 20, { offset: 50, size: 0, position: LayoutAnchorPosition.Before }).position, 50);
+		assert.strictEqual(layout(200, 20, { offset: 200, size: 0, position: LayoutAnchorPosition.Before }).position, 180);
 
-		assert.strictEqual(layout(200, 20, { offset: 0, size: 0, position: LayoutAnchorPosition.After }), 0);
-		assert.strictEqual(layout(200, 20, { offset: 50, size: 0, position: LayoutAnchorPosition.After }), 30);
-		assert.strictEqual(layout(200, 20, { offset: 200, size: 0, position: LayoutAnchorPosition.After }), 180);
+		assert.strictEqual(layout(200, 20, { offset: 0, size: 0, position: LayoutAnchorPosition.After }).position, 0);
+		assert.strictEqual(layout(200, 20, { offset: 50, size: 0, position: LayoutAnchorPosition.After }).position, 30);
+		assert.strictEqual(layout(200, 20, { offset: 200, size: 0, position: LayoutAnchorPosition.After }).position, 180);
+		assert.strictEqual(layout(200, 20, { offset: 0, size: 50, position: LayoutAnchorPosition.Before }).position, 50);
+		assert.strictEqual(layout(200, 20, { offset: 50, size: 50, position: LayoutAnchorPosition.Before }).position, 100);
+		assert.strictEqual(layout(200, 20, { offset: 150, size: 50, position: LayoutAnchorPosition.Before }).position, 130);
 
-		assert.strictEqual(layout(200, 20, { offset: 0, size: 50, position: LayoutAnchorPosition.Before }), 50);
-		assert.strictEqual(layout(200, 20, { offset: 50, size: 50, position: LayoutAnchorPosition.Before }), 100);
-		assert.strictEqual(layout(200, 20, { offset: 150, size: 50, position: LayoutAnchorPosition.Before }), 130);
-
-		assert.strictEqual(layout(200, 20, { offset: 0, size: 50, position: LayoutAnchorPosition.After }), 50);
-		assert.strictEqual(layout(200, 20, { offset: 50, size: 50, position: LayoutAnchorPosition.After }), 30);
-		assert.strictEqual(layout(200, 20, { offset: 150, size: 50, position: LayoutAnchorPosition.After }), 130);
+		assert.strictEqual(layout(200, 20, { offset: 0, size: 50, position: LayoutAnchorPosition.After }).position, 50);
+		assert.strictEqual(layout(200, 20, { offset: 50, size: 50, position: LayoutAnchorPosition.After }).position, 30);
+		assert.strictEqual(layout(200, 20, { offset: 150, size: 50, position: LayoutAnchorPosition.After }).position, 130);
 	});
 
 	ensureNoDisposablesAreLeakedInTestSuite();

--- a/src/vs/base/test/common/layout.test.ts
+++ b/src/vs/base/test/common/layout.test.ts
@@ -4,10 +4,10 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
-import { layout, LayoutAnchorPosition } from '../../../../browser/ui/contextview/contextview.js';
-import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../common/utils.js';
+import { layout, LayoutAnchorPosition } from '../../common/layout.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from './utils.js';
 
-suite('Contextview', function () {
+suite('Layout', function () {
 
 	test('layout', () => {
 		assert.strictEqual(layout(200, 20, { offset: 0, size: 0, position: LayoutAnchorPosition.Before }), 0);

--- a/src/vs/editor/contrib/indentation/browser/indentation.ts
+++ b/src/vs/editor/contrib/indentation/browser/indentation.ts
@@ -27,6 +27,7 @@ import { getGoodIndentForLine, getIndentMetadata } from '../../../common/languag
 import { getReindentEditOperations } from '../common/indentation.js';
 import { getStandardTokenTypeAtPosition } from '../../../common/tokens/lineTokens.js';
 import { Position } from '../../../common/core/position.js';
+import { mainWindow } from '../../../../base/browser/window.js';
 
 export class IndentationToSpacesAction extends EditorAction {
 	public static readonly ID = 'editor.action.indentationToSpaces';
@@ -136,7 +137,8 @@ export class ChangeIndentationSizeAction extends EditorAction {
 		const autoFocusIndex = Math.min(model.getOptions().tabSize - 1, 7);
 
 		setTimeout(() => {
-			quickInputService.pick(picks, { placeHolder: nls.localize({ key: 'selectTabWidth', comment: ['Tab corresponds to the tab key'] }, "Select Tab Size for Current File"), activeItem: picks[autoFocusIndex] }).then(pick => {
+			// TODO@joaomoreno big big hack
+			quickInputService.pick(picks, { placeHolder: nls.localize({ key: 'selectTabWidth', comment: ['Tab corresponds to the tab key'] }, "Select Tab Size for Current File"), activeItem: picks[autoFocusIndex], anchor: `changeEditorIndentation${mainWindow.vscodeWindowId}` }).then(pick => {
 				if (pick) {
 					if (model && !model.isDisposed()) {
 						const pickedVal = parseInt(pick.label, 10);

--- a/src/vs/platform/quickinput/browser/quickAccess.ts
+++ b/src/vs/platform/quickinput/browser/quickAccess.ts
@@ -108,7 +108,7 @@ export class QuickAccessController extends Disposable implements IQuickAccessCon
 		// Create a picker for the provider to use with the initial value
 		// and adjust the filtering to exclude the prefix from filtering
 		const disposables = new DisposableStore();
-		const picker = disposables.add(this.quickInputService.createQuickPick({ useSeparators: true }));
+		const picker = disposables.add(this.quickInputService.createQuickPick({ useSeparators: true, anchor: options?.anchor }));
 		picker.value = value;
 		this.adjustValueSelection(picker, descriptor, options);
 		picker.placeholder = options?.placeholder ?? descriptor?.placeholder;

--- a/src/vs/platform/quickinput/browser/quickInputController.ts
+++ b/src/vs/platform/quickinput/browser/quickInputController.ts
@@ -16,7 +16,7 @@ import { Disposable, DisposableStore, dispose } from '../../../base/common/lifec
 import Severity from '../../../base/common/severity.js';
 import { isString } from '../../../base/common/types.js';
 import { localize } from '../../../nls.js';
-import { IInputBox, IInputOptions, IKeyMods, IPickOptions, IQuickInput, IQuickInputButton, IQuickNavigateConfiguration, IQuickPick, IQuickPickItem, IQuickWidget, QuickInputHideReason, QuickPickInput, QuickPickFocus, QuickInputType, IQuickTree, IQuickTreeItem } from '../common/quickInput.js';
+import { IInputBox, IInputOptions, IKeyMods, IPickOptions, IQuickInput, IQuickInputButton, IQuickNavigateConfiguration, IQuickPick, IQuickPickItem, IQuickWidget, QuickInputHideReason, QuickPickInput, QuickPickFocus, QuickInputType, IQuickTree, IQuickTreeItem, IQuickPickOptions } from '../common/quickInput.js';
 import { QuickInputBox } from './quickInputBox.js';
 import { QuickInputUI, Writeable, IQuickInputStyles, IQuickInputOptions, QuickPick, backButton, InputBox, Visibilities, QuickWidget, InQuickInputContextKey, QuickInputTypeContextKey, EndOfQuickInputBoxContextKey, QuickInputAlignmentContextKey } from './quickInput.js';
 import { ILayoutService } from '../../layout/browser/layoutService.js';
@@ -423,7 +423,7 @@ export class QuickInputController extends Disposable {
 				resolve(undefined);
 				return;
 			}
-			const input = this.createQuickPick<T>({ useSeparators: true });
+			const input = this.createQuickPick<T>({ useSeparators: true, anchor: options.anchor });
 			let activeItem: T | undefined;
 			const disposables = [
 				input,
@@ -503,7 +503,6 @@ export class QuickInputController extends Disposable {
 			input.quickNavigate = options.quickNavigate;
 			input.hideInput = !!options.hideInput;
 			input.contextKey = options.contextKey;
-			input.anchor = options.anchor;
 			input.busy = true;
 			Promise.all([picks, options.activeItem])
 				.then(([items, _activeItem]) => {
@@ -602,11 +601,11 @@ export class QuickInputController extends Disposable {
 
 	backButton = backButton;
 
-	createQuickPick<T extends IQuickPickItem>(options: { useSeparators: true }): IQuickPick<T, { useSeparators: true }>;
-	createQuickPick<T extends IQuickPickItem>(options?: { useSeparators: boolean }): IQuickPick<T, { useSeparators: false }>;
-	createQuickPick<T extends IQuickPickItem>(options: { useSeparators: boolean } = { useSeparators: false }): IQuickPick<T, { useSeparators: boolean }> {
+	createQuickPick<T extends IQuickPickItem, O extends { useSeparators: true } = IQuickPickOptions & { useSeparators: true }>(options: O): IQuickPick<T, O>;
+	createQuickPick<T extends IQuickPickItem>(): IQuickPick<T, IQuickPickOptions>;
+	createQuickPick<T extends IQuickPickItem, O extends IQuickPickOptions = IQuickPickOptions>(options?: O): IQuickPick<T, O> {
 		const ui = this.getUI(true);
-		return new QuickPick<T, typeof options>(ui);
+		return new QuickPick<T, IQuickPickOptions>(ui, options);
 	}
 
 	createInputBox(): IInputBox {
@@ -824,25 +823,27 @@ export class QuickInputController extends Disposable {
 
 				if (anchorAlignment === AnchorAlignment.RIGHT) {
 					style.right = `${right}px`;
-					style.left = '';
+					style.left = 'auto';
 				} else {
 					style.left = `${left}px`;
-					style.right = '';
+					style.right = 'auto';
 				}
 
 				if (anchorPosition === AnchorPosition.BELOW) {
 					style.bottom = `${bottom}px`;
-					style.top = '';
+					style.top = 'auto';
 				} else {
 					style.top = `${top}px`;
-					style.bottom = '';
+					style.bottom = 'auto';
 				}
 
 				style.width = `${width}px`;
 				style.height = '';
 			} else {
 				style.top = `${this.viewState?.top ? Math.round(this.dimension!.height * this.viewState.top) : this.titleBarOffset}px`;
+				style.bottom = '';
 				style.left = `${Math.round((this.dimension!.width * (this.viewState?.left ?? 0.5 /* center */)) - (width / 2))}px`;
+				style.right = '';
 				style.height = '';
 			}
 

--- a/src/vs/platform/quickinput/browser/quickInputController.ts
+++ b/src/vs/platform/quickinput/browser/quickInputController.ts
@@ -36,7 +36,7 @@ import { TriStateCheckbox } from '../../../base/browser/ui/toggle/toggle.js';
 import { defaultCheckboxStyles } from '../../theme/browser/defaultStyles.js';
 import { QuickInputTreeController } from './tree/quickInputTreeController.js';
 import { QuickTree } from './tree/quickTree.js';
-import { layout2d } from '../../../base/common/layout.js';
+import { AnchorAlignment, AnchorPosition, layout2d } from '../../../base/common/layout.js';
 import { getAnchorRect } from '../../../base/browser/ui/contextview/contextview.js';
 
 const $ = dom.$;
@@ -815,14 +815,31 @@ export class QuickInputController extends Disposable {
 				const container = this.layoutService.getContainer(dom.getActiveWindow()).getBoundingClientRect();
 				const anchor = getAnchorRect(this.controller.anchor);
 				width = 380;
-				listHeight = (this.dimension && this.dimension?.height * 0.1) ?? 200;
-				const containerHeight = Math.floor(listHeight / 44) * 44 + 6 + 26 + 16;
+				listHeight = Math.min((this.dimension && this.dimension?.height * 0.2) ?? 200, 200);
 
-				const { top, left } = layout2d(container, { width, height: containerHeight }, anchor);
-				style.top = `${top}px`;
-				style.left = `${left}px`;
+				// Beware:
+				// We need to add some extra pixels to the height to account for the input and padding.
+				const containerHeight = Math.floor(listHeight) + 6 + 26 + 16;
+				const { top, left, right, bottom, anchorAlignment, anchorPosition } = layout2d(container, { width, height: containerHeight }, anchor);
+
+				if (anchorAlignment === AnchorAlignment.RIGHT) {
+					style.right = `${right}px`;
+					style.left = '';
+				} else {
+					style.left = `${left}px`;
+					style.right = '';
+				}
+
+				if (anchorPosition === AnchorPosition.BELOW) {
+					style.bottom = `${bottom}px`;
+					style.top = '';
+				} else {
+					style.top = `${top}px`;
+					style.bottom = '';
+				}
+
 				style.width = `${width}px`;
-				style.height = `${containerHeight}px`; // wtf
+				style.height = '';
 			} else {
 				style.top = `${this.viewState?.top ? Math.round(this.dimension!.height * this.viewState.top) : this.titleBarOffset}px`;
 				style.left = `${Math.round((this.dimension!.width * (this.viewState?.left ?? 0.5 /* center */)) - (width / 2))}px`;

--- a/src/vs/platform/quickinput/browser/quickInputController.ts
+++ b/src/vs/platform/quickinput/browser/quickInputController.ts
@@ -36,6 +36,8 @@ import { TriStateCheckbox } from '../../../base/browser/ui/toggle/toggle.js';
 import { defaultCheckboxStyles } from '../../theme/browser/defaultStyles.js';
 import { QuickInputTreeController } from './tree/quickInputTreeController.js';
 import { QuickTree } from './tree/quickTree.js';
+import { layout2d } from '../../../base/common/layout.js';
+import { getAnchorRect } from '../../../base/browser/ui/contextview/contextview.js';
 
 const $ = dom.$;
 
@@ -501,6 +503,7 @@ export class QuickInputController extends Disposable {
 			input.quickNavigate = options.quickNavigate;
 			input.hideInput = !!options.hideInput;
 			input.contextKey = options.contextKey;
+			input.anchor = options.anchor;
 			input.busy = true;
 			Promise.all([picks, options.activeItem])
 				.then(([items, _activeItem]) => {
@@ -802,16 +805,33 @@ export class QuickInputController extends Disposable {
 	private updateLayout() {
 		if (this.ui && this.isVisible()) {
 			const style = this.ui.container.style;
-			const width = Math.min(this.dimension!.width * 0.62 /* golden cut */, QuickInputController.MAX_WIDTH);
+			let width = Math.min(this.dimension!.width * 0.62 /* golden cut */, QuickInputController.MAX_WIDTH);
 			style.width = width + 'px';
 
+			let listHeight = this.dimension && this.dimension.height * 0.4;
+
 			// Position
-			style.top = `${this.viewState?.top ? Math.round(this.dimension!.height * this.viewState.top) : this.titleBarOffset}px`;
-			style.left = `${Math.round((this.dimension!.width * (this.viewState?.left ?? 0.5 /* center */)) - (width / 2))}px`;
+			if (this.controller?.anchor) {
+				const container = this.layoutService.getContainer(dom.getActiveWindow()).getBoundingClientRect();
+				const anchor = getAnchorRect(this.controller.anchor);
+				width = 380;
+				listHeight = (this.dimension && this.dimension?.height * 0.1) ?? 200;
+				const containerHeight = Math.floor(listHeight / 44) * 44 + 6 + 26 + 16;
+
+				const { top, left } = layout2d(container, { width, height: containerHeight }, anchor);
+				style.top = `${top}px`;
+				style.left = `${left}px`;
+				style.width = `${width}px`;
+				style.height = `${containerHeight}px`; // wtf
+			} else {
+				style.top = `${this.viewState?.top ? Math.round(this.dimension!.height * this.viewState.top) : this.titleBarOffset}px`;
+				style.left = `${Math.round((this.dimension!.width * (this.viewState?.left ?? 0.5 /* center */)) - (width / 2))}px`;
+				style.height = '';
+			}
 
 			this.ui.inputBox.layout();
-			this.ui.list.layout(this.dimension && this.dimension.height * 0.4);
-			this.ui.tree.layout(this.dimension && this.dimension.height * 0.4);
+			this.ui.list.layout(listHeight);
+			this.ui.tree.layout(listHeight);
 		}
 	}
 

--- a/src/vs/platform/quickinput/browser/quickInputService.ts
+++ b/src/vs/platform/quickinput/browser/quickInputService.ts
@@ -11,7 +11,7 @@ import { ILayoutService } from '../../layout/browser/layoutService.js';
 import { IOpenerService } from '../../opener/common/opener.js';
 import { QuickAccessController } from './quickAccess.js';
 import { IQuickAccessController } from '../common/quickAccess.js';
-import { IInputBox, IInputOptions, IKeyMods, IPickOptions, IQuickInputButton, IQuickInputService, IQuickNavigateConfiguration, IQuickPick, IQuickPickItem, IQuickTree, IQuickTreeItem, IQuickWidget, QuickPickInput } from '../common/quickInput.js';
+import { IInputBox, IInputOptions, IKeyMods, IPickOptions, IQuickInputButton, IQuickInputService, IQuickNavigateConfiguration, IQuickPick, IQuickPickItem, IQuickPickOptions, IQuickTree, IQuickTreeItem, IQuickWidget, QuickPickInput } from '../common/quickInput.js';
 import { defaultButtonStyles, defaultCountBadgeStyles, defaultInputBoxStyles, defaultKeybindingLabelStyles, defaultProgressBarStyles, defaultToggleStyles, getListStyles } from '../../theme/browser/defaultStyles.js';
 import { activeContrastBorder, asCssVariable, pickerGroupBorder, pickerGroupForeground, quickInputBackground, quickInputForeground, quickInputListFocusBackground, quickInputListFocusForeground, quickInputListFocusIconForeground, quickInputTitleBackground, widgetBorder, widgetShadow } from '../../theme/common/colorRegistry.js';
 import { IThemeService, Themable } from '../../theme/common/themeService.js';
@@ -157,10 +157,9 @@ export class QuickInputService extends Themable implements IQuickInputService {
 		return this.controller.input(options, token);
 	}
 
-	createQuickPick<T extends IQuickPickItem>(options: { useSeparators: true }): IQuickPick<T, { useSeparators: true }>;
-	createQuickPick<T extends IQuickPickItem>(options?: { useSeparators: boolean }): IQuickPick<T, { useSeparators: false }>;
-	createQuickPick<T extends IQuickPickItem>(options: { useSeparators: boolean } = { useSeparators: false }): IQuickPick<T, { useSeparators: boolean }> {
-		return this.controller.createQuickPick(options);
+	createQuickPick<T extends IQuickPickItem, O extends { useSeparators: true } = IQuickPickOptions & { useSeparators: true }>(options: O): IQuickPick<T, O>;
+	createQuickPick<T extends IQuickPickItem, O extends IQuickPickOptions = IQuickPickOptions>(options?: O): IQuickPick<T, O> {
+		return this.controller.createQuickPick<T, any>(options);
 	}
 
 	createInputBox(): IInputBox {

--- a/src/vs/platform/quickinput/common/quickAccess.ts
+++ b/src/vs/platform/quickinput/common/quickAccess.ts
@@ -72,6 +72,8 @@ export interface IQuickAccessOptions {
 	 * A placeholder to use for this particular showing of the quick access.
 	*/
 	readonly placeholder?: string;
+
+	readonly anchor?: HTMLElement | string;
 }
 
 export interface IQuickAccessController {

--- a/src/vs/platform/quickinput/common/quickInput.ts
+++ b/src/vs/platform/quickinput/common/quickInput.ts
@@ -197,7 +197,7 @@ export interface IPickOptions<T extends IQuickPickItem> {
 	 */
 	activeItem?: Promise<T> | T;
 
-	anchor?: HTMLElement | { x: number; y: number };
+	anchor?: HTMLElement | string;
 
 	onKeyMods?: (keyMods: IKeyMods) => void;
 	onDidFocus?: (entry: T) => void;
@@ -361,7 +361,7 @@ export interface IQuickInput extends IDisposable {
 	 */
 	ignoreFocusOut: boolean;
 
-	anchor?: HTMLElement | { x: number; y: number };
+	anchor: HTMLElement | undefined;
 
 	/**
 	 * Shows the quick input.
@@ -484,10 +484,15 @@ export enum QuickPickFocus {
 	PreviousSeparator
 }
 
+export interface IQuickPickOptions {
+	readonly useSeparators?: boolean;
+	readonly anchor?: HTMLElement | string | undefined;
+}
+
 /**
  * Represents a quick pick control that allows the user to select an item from a list of options.
  */
-export interface IQuickPick<T extends IQuickPickItem, O extends { useSeparators: boolean } = { useSeparators: false }> extends IQuickInput {
+export interface IQuickPick<T extends IQuickPickItem, O extends IQuickPickOptions = { useSeparators: false }> extends IQuickInput {
 
 	/**
 	 * The type of the quick input.
@@ -955,8 +960,8 @@ export interface IQuickInputService {
 	/**
 	 * Provides raw access to the quick pick controller.
 	 */
-	createQuickPick<T extends IQuickPickItem>(options: { useSeparators: true }): IQuickPick<T, { useSeparators: true }>;
-	createQuickPick<T extends IQuickPickItem>(options?: { useSeparators: boolean }): IQuickPick<T, { useSeparators: false }>;
+	createQuickPick<T extends IQuickPickItem, O extends { useSeparators: true } = { useSeparators: true }>(options: O): IQuickPick<T, O>;
+	createQuickPick<T extends IQuickPickItem>(options?: IQuickPickOptions): IQuickPick<T, IQuickPickOptions>;
 
 	/**
 	 * Provides raw access to the input box controller.

--- a/src/vs/platform/quickinput/common/quickInput.ts
+++ b/src/vs/platform/quickinput/common/quickInput.ts
@@ -197,6 +197,8 @@ export interface IPickOptions<T extends IQuickPickItem> {
 	 */
 	activeItem?: Promise<T> | T;
 
+	anchor?: HTMLElement | { x: number; y: number };
+
 	onKeyMods?: (keyMods: IKeyMods) => void;
 	onDidFocus?: (entry: T) => void;
 	onDidTriggerItemButton?: (context: IQuickPickItemButtonContext<T>) => void;
@@ -358,6 +360,8 @@ export interface IQuickInput extends IDisposable {
 	 * Indicates whether the quick input should be hidden when it loses focus.
 	 */
 	ignoreFocusOut: boolean;
+
+	anchor?: HTMLElement | { x: number; y: number };
 
 	/**
 	 * Shows the quick input.

--- a/src/vs/workbench/browser/parts/editor/editorStatus.ts
+++ b/src/vs/workbench/browser/parts/editor/editorStatus.ts
@@ -426,7 +426,7 @@ class EditorStatus extends Disposable {
 				label: a.label,
 				detail: (Language.isDefaultVariant() || a.label === a.alias) ? undefined : a.alias,
 				run: () => {
-					activeTextEditorControl.focus();
+					// activeTextEditorControl.focus(); // TODO@joaomoreno move this into each action's implementation
 					a.run();
 				}
 			};

--- a/src/vs/workbench/browser/parts/statusbar/statusbarItem.ts
+++ b/src/vs/workbench/browser/parts/statusbar/statusbarItem.ts
@@ -70,6 +70,13 @@ export class StatusbarEntryItem extends Disposable {
 			role: 'button',
 			tabIndex: -1 // allows screen readers to read title, but still prevents tab focus.
 		});
+
+		if (typeof entry.command === 'string') {
+			this.labelContainer.setAttribute('data-quick-input-anchor-name', entry.command);
+		} else if (entry.command && typeof entry.command !== 'string') {
+			this.labelContainer.setAttribute('data-quick-input-anchor-name', entry.command.id);
+		}
+
 		this._register(Gesture.addTarget(this.labelContainer)); // enable touch
 
 		// Label (with support for progress)

--- a/src/vs/workbench/contrib/codeEditor/browser/quickaccess/gotoLineQuickAccess.ts
+++ b/src/vs/workbench/contrib/codeEditor/browser/quickaccess/gotoLineQuickAccess.ts
@@ -95,7 +95,7 @@ class GotoLineAction extends Action2 {
 	}
 
 	async run(accessor: ServicesAccessor): Promise<void> {
-		accessor.get(IQuickInputService).quickAccess.show(GotoLineQuickAccessProvider.PREFIX);
+		accessor.get(IQuickInputService).quickAccess.show(GotoLineQuickAccessProvider.PREFIX, { anchor: 'workbench.action.gotoLine' });
 	}
 }
 

--- a/src/vs/workbench/contrib/scm/browser/scmHistoryViewPane.ts
+++ b/src/vs/workbench/contrib/scm/browser/scmHistoryViewPane.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import './media/scm.css';
-import { $, append, EventLike, h, reset } from '../../../../base/browser/dom.js';
+import { $, append, h, reset } from '../../../../base/browser/dom.js';
 import { IHoverOptions, IManagedHoverTooltipMarkdownString } from '../../../../base/browser/ui/hover/hover.js';
 import { IHoverDelegate } from '../../../../base/browser/ui/hover/hoverDelegate.js';
 import { IconLabel } from '../../../../base/browser/ui/iconLabel/iconLabel.js';
@@ -107,10 +107,6 @@ class SCMRepositoryActionViewItem extends ActionViewItem {
 	protected override getTooltip(): string | undefined {
 		return this._repository.provider.name;
 	}
-
-	override onClick(event: EventLike, preserveFocus?: boolean): void {
-		this.actionRunner?.run(this.action, this.element);
-	}
 }
 
 class SCMHistoryItemRefsActionViewItem extends ActionViewItem {
@@ -180,8 +176,8 @@ registerAction2(class extends ViewAction<SCMHistoryViewPane> {
 		});
 	}
 
-	async runInView(_: ServicesAccessor, view: SCMHistoryViewPane, anchor: HTMLElement): Promise<void> {
-		view.pickRepository(anchor);
+	async runInView(_: ServicesAccessor, view: SCMHistoryViewPane): Promise<void> {
+		view.pickRepository();
 	}
 });
 
@@ -1351,7 +1347,7 @@ class RepositoryPicker {
 		@ISCMViewService private readonly _scmViewService: ISCMViewService
 	) { }
 
-	async pickRepository(anchor: HTMLElement): Promise<RepositoryQuickPickItem | undefined> {
+	async pickRepository(): Promise<RepositoryQuickPickItem | undefined> {
 		const picks: (RepositoryQuickPickItem | IQuickPickSeparator)[] = [
 			this._autoQuickPickItem,
 			{ type: 'separator' }];
@@ -1366,8 +1362,7 @@ class RepositoryPicker {
 		})));
 
 		return this._quickInputService.pick(picks, {
-			placeHolder: localize('scmGraphRepository', "Select the repository to view, type to filter all repositories"),
-			anchor
+			placeHolder: localize('scmGraphRepository', "Select the repository to view, type to filter all repositories")
 		});
 	}
 }
@@ -1763,9 +1758,9 @@ export class SCMHistoryViewPane extends ViewPane {
 		this._tree.scrollTop = 0;
 	}
 
-	async pickRepository(anchor: HTMLElement): Promise<void> {
+	async pickRepository(): Promise<void> {
 		const picker = this._instantiationService.createInstance(RepositoryPicker);
-		const result = await picker.pickRepository(anchor);
+		const result = await picker.pickRepository();
 
 		if (result) {
 			this._treeViewModel.setRepository(result.repository);

--- a/src/vs/workbench/contrib/scm/browser/scmHistoryViewPane.ts
+++ b/src/vs/workbench/contrib/scm/browser/scmHistoryViewPane.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import './media/scm.css';
-import { $, append, h, reset } from '../../../../base/browser/dom.js';
+import { $, append, EventLike, h, reset } from '../../../../base/browser/dom.js';
 import { IHoverOptions, IManagedHoverTooltipMarkdownString } from '../../../../base/browser/ui/hover/hover.js';
 import { IHoverDelegate } from '../../../../base/browser/ui/hover/hoverDelegate.js';
 import { IconLabel } from '../../../../base/browser/ui/iconLabel/iconLabel.js';
@@ -107,6 +107,10 @@ class SCMRepositoryActionViewItem extends ActionViewItem {
 	protected override getTooltip(): string | undefined {
 		return this._repository.provider.name;
 	}
+
+	override onClick(event: EventLike, preserveFocus?: boolean): void {
+		this.actionRunner?.run(this.action, this.element);
+	}
 }
 
 class SCMHistoryItemRefsActionViewItem extends ActionViewItem {
@@ -176,8 +180,8 @@ registerAction2(class extends ViewAction<SCMHistoryViewPane> {
 		});
 	}
 
-	async runInView(_: ServicesAccessor, view: SCMHistoryViewPane): Promise<void> {
-		view.pickRepository();
+	async runInView(_: ServicesAccessor, view: SCMHistoryViewPane, anchor: HTMLElement): Promise<void> {
+		view.pickRepository(anchor);
 	}
 });
 
@@ -1347,7 +1351,7 @@ class RepositoryPicker {
 		@ISCMViewService private readonly _scmViewService: ISCMViewService
 	) { }
 
-	async pickRepository(): Promise<RepositoryQuickPickItem | undefined> {
+	async pickRepository(anchor: HTMLElement): Promise<RepositoryQuickPickItem | undefined> {
 		const picks: (RepositoryQuickPickItem | IQuickPickSeparator)[] = [
 			this._autoQuickPickItem,
 			{ type: 'separator' }];
@@ -1362,7 +1366,8 @@ class RepositoryPicker {
 		})));
 
 		return this._quickInputService.pick(picks, {
-			placeHolder: localize('scmGraphRepository', "Select the repository to view, type to filter all repositories")
+			placeHolder: localize('scmGraphRepository', "Select the repository to view, type to filter all repositories"),
+			anchor
 		});
 	}
 }
@@ -1758,9 +1763,9 @@ export class SCMHistoryViewPane extends ViewPane {
 		this._tree.scrollTop = 0;
 	}
 
-	async pickRepository(): Promise<void> {
+	async pickRepository(anchor: HTMLElement): Promise<void> {
 		const picker = this._instantiationService.createInstance(RepositoryPicker);
-		const result = await picker.pickRepository();
+		const result = await picker.pickRepository(anchor);
 
 		if (result) {
 			this._treeViewModel.setRepository(result.repository);


### PR DESCRIPTION
Fixes #238095

---

Brainstorming session with @bpasero and @lszomoru:

Here's how we stitch things up:

We decorate the DOM:

```html
<div quick-pick-in-context="ID">
  <span>Encoding</span>
</div>
```

Then we augment the quick pick service API to allow passing an _anchor name_ (`anchor`) that would match up with `ID`.

The quick pick service should:

1. Track mouse clicks and keyboard presses.
2. Whenever the mouse gets clicked or <kbd>Enter</kbd> gets pressed and the current active element is within a DOM hierarchy that contains `[quick-pick-in-context]`, then remember that `ID` and DOM node as state.
3. If there's any mouse click or keyboard press meanwhile, clear that state.
4. Likewise, if there's any generic quick pick invocation, clear that state.
5. If, on the other hand, there's a quick pick invocation that passes `anchor: ID`, then render it in context and clear that state.