### PR TITLE
do not proceed when `Focus Terminal` option is taken until input has happened, prevent build daemon prompt

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/monitoring/outputMonitor.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/monitoring/outputMonitor.ts
@@ -9,7 +9,7 @@ import { timeout, type MaybePromise } from '../../../../../../../base/common/asy
 import { CancellationToken } from '../../../../../../../base/common/cancellation.js';
 import { Emitter, Event } from '../../../../../../../base/common/event.js';
 import { MarkdownString } from '../../../../../../../base/common/htmlContent.js';
-import { Disposable } from '../../../../../../../base/common/lifecycle.js';
+import { Disposable, type IDisposable } from '../../../../../../../base/common/lifecycle.js';
 import { isObject, isString } from '../../../../../../../base/common/types.js';
 import { localize } from '../../../../../../../nls.js';
 import { ExtensionIdentifier } from '../../../../../../../platform/extensions/common/extensions.js';
@@ -171,17 +171,8 @@ export class OutputMonitor extends Disposable implements IOutputMonitor {
 
 		if (confirmationPrompt?.detectedRequestForFreeFormInput) {
 			this._outputMonitorTelemetryCounters.inputToolFreeFormInputShownCount++;
-			const focusedTerminal = await this._requestFreeFormTerminalInput(token, this._execution, confirmationPrompt);
-			if (focusedTerminal) {
-				await new Promise<void>(resolve => {
-					const disposable = this._execution.instance.onData(data => {
-						if (data === '\r' || data === '\n' || data === '\r\n') {
-							this._outputMonitorTelemetryCounters.inputToolFreeFormInputCount++;
-							disposable.dispose();
-							resolve();
-						}
-					});
-				});
+			const receivedTerminalInput = await this._requestFreeFormTerminalInput(token, this._execution, confirmationPrompt);
+			if (receivedTerminalInput) {
 				// Small delay to ensure input is processed
 				await timeout(200);
 				// Continue polling as we sent the input
@@ -415,6 +406,8 @@ export class OutputMonitor extends Disposable implements IOutputMonitor {
 
 			9. Output: "Password:"
 				Response: {"prompt": "Password:", "freeFormInput": true, "options": []}
+			10. Output: "press ctrl-c to detach, ctrl-d to kill"
+				Response: null
 
 			Alternatively, the prompt may request free form input, for example:
 			1. Output: "Enter your username:"
@@ -517,7 +510,8 @@ export class OutputMonitor extends Disposable implements IOutputMonitor {
 	}
 
 	private async _requestFreeFormTerminalInput(token: CancellationToken, execution: IExecution, confirmationPrompt: IConfirmationPrompt): Promise<boolean> {
-		const { promise: userPrompt, part } = this._createElicitationPart<boolean>(
+		const focusTerminalSelection = Symbol('focusTerminalSelection');
+		const { promise: userPrompt, part } = this._createElicitationPart<boolean | typeof focusTerminalSelection>(
 			token,
 			execution.sessionId,
 			new MarkdownString(localize('poll.terminal.inputRequest', "The terminal is awaiting input.")),
@@ -525,34 +519,45 @@ export class OutputMonitor extends Disposable implements IOutputMonitor {
 			'',
 			localize('poll.terminal.enterInput', 'Focus terminal'),
 			undefined,
-			async () => {
+			() => {
 				this._showInstance(execution.instance.instanceId);
-				return true;
+				return focusTerminalSelection;
 			}
 		);
 
+		let inputDataDisposable: IDisposable = Disposable.None;
 		const inputPromise = new Promise<boolean>(resolve => {
-			const inputDataDisposable = this._register(execution.instance.onDidInputData((data) => {
+			inputDataDisposable = this._register(execution.instance.onDidInputData((data) => {
 				if (!data || data === '\r' || data === '\n' || data === '\r\n') {
 					part.hide();
 					inputDataDisposable.dispose();
 					this._state = OutputMonitorState.PollingForIdle;
+					this._outputMonitorTelemetryCounters.inputToolFreeFormInputCount++;
 					resolve(true);
 				}
 			}));
 		});
 
 		const result = await Promise.race([userPrompt, inputPromise]);
+		if (result === focusTerminalSelection) {
+			return await inputPromise;
+		}
+		if (result === undefined) {
+			inputDataDisposable.dispose();
+			// Prompt was dismissed without providing input
+			return false;
+		}
 		return !!result;
 	}
 
-	private async _confirmRunInTerminal(token: CancellationToken, suggestedOption: SuggestedOption, execution: IExecution, confirmationPrompt: IConfirmationPrompt): Promise<string | undefined> {
+	private async _confirmRunInTerminal(token: CancellationToken, suggestedOption: SuggestedOption, execution: IExecution, confirmationPrompt: IConfirmationPrompt): Promise<string | boolean | undefined> {
 		let suggestedOptionValue = isString(suggestedOption) ? suggestedOption : suggestedOption.option;
 		if (suggestedOptionValue === 'any key') {
 			suggestedOptionValue = 'a';
 		}
-		let inputDataDisposable = Disposable.None;
-		const { promise: userPrompt, part } = this._createElicitationPart<string | undefined>(
+		const focusTerminalSelection = Symbol('focusTerminalSelection');
+		let inputDataDisposable: IDisposable = Disposable.None;
+		const { promise: userPrompt, part } = this._createElicitationPart<string | boolean | typeof focusTerminalSelection | undefined>(
 			token,
 			execution.sessionId,
 			new MarkdownString(localize('poll.terminal.confirmRequired', "The terminal is awaiting input.")),
@@ -571,28 +576,35 @@ export class OutputMonitor extends Disposable implements IOutputMonitor {
 				this._outputMonitorTelemetryCounters.inputToolManualChars += option?.length || 0;
 				return option;
 			},
-			async () => {
+			() => {
 				this._showInstance(execution.instance.instanceId);
-				this._state = OutputMonitorState.Cancelled;
 				this._outputMonitorTelemetryCounters.inputToolManualRejectCount++;
-				inputDataDisposable.dispose();
-				return undefined;
+				return focusTerminalSelection;
 			},
 			getMoreActions(suggestedOption, confirmationPrompt)
 		);
-		const inputPromise = new Promise<string | undefined>(resolve => {
+		const inputPromise = new Promise<boolean>(resolve => {
 			inputDataDisposable = this._register(execution.instance.onDidInputData(() => {
 				part.hide();
 				inputDataDisposable.dispose();
 				this._state = OutputMonitorState.PollingForIdle;
-				resolve(undefined);
+				resolve(true);
 			}));
 		});
 
 		const optionToRun = await Promise.race([userPrompt, inputPromise]);
-		if (optionToRun) {
-			await execution.instance.sendText(optionToRun, true);
+		if (optionToRun === focusTerminalSelection) {
+			return await inputPromise;
 		}
+		if (optionToRun === true) {
+			return true;
+		}
+		if (typeof optionToRun === 'string' && optionToRun.length) {
+			inputDataDisposable.dispose();
+			await execution.instance.sendText(optionToRun, true);
+			return optionToRun;
+		}
+		inputDataDisposable.dispose();
 		return optionToRun;
 	}
 


### PR DESCRIPTION
fix #277582

When there's an input request detected, using `Focus Terminal` would make the agent continue on. In that case, we want to await the user's input. This regressed at some point, it used to work. 

This also adds a case for the model to prevent it from surfacing `ctrl+c` to the terminal for our build task.

I'm on the fence about outright disabling the input detection for tasks. 