### PR TITLE
Fix chat.modeChange telemetry to use agent names and add metadata

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/actions/chatExecuteActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatExecuteActions.ts
@@ -293,15 +293,23 @@ export interface IToggleChatModeArgs {
 type ChatModeChangeClassification = {
 	owner: 'digitarald';
 	comment: 'Reporting when agent is switched between different modes';
-	fromMode?: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The previous agent' };
-	toMode?: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The new agent' };
+	fromMode?: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The previous agent name' };
+	mode?: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The new agent name' };
 	requestCount?: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Number of requests in the current chat session'; 'isMeasurement': true };
+	storage?: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Source of the target mode (builtin, local, user, extension)' };
+	extensionId?: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Extension ID if the target mode is from an extension' };
+	toolsCount?: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Number of custom tools in the target mode'; 'isMeasurement': true };
+	handoffsCount?: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Number of handoffs in the target mode'; 'isMeasurement': true };
 };
 
 type ChatModeChangeEvent = {
 	fromMode: string;
-	toMode: string;
+	mode: string;
 	requestCount: number;
+	storage?: string;
+	extensionId?: string;
+	toolsCount?: number;
+	handoffsCount?: number;
 };
 
 class ToggleChatModeAction extends Action2 {
@@ -348,10 +356,19 @@ class ToggleChatModeAction extends Action2 {
 		}
 
 		// Send telemetry for mode change
+		const storage = switchToMode.source?.storage ?? 'builtin';
+		const extensionId = switchToMode.source?.storage === 'extension' ? switchToMode.source.extensionId.value : undefined;
+		const toolsCount = switchToMode.customTools?.get()?.length ?? 0;
+		const handoffsCount = switchToMode.handOffs?.get()?.length ?? 0;
+
 		telemetryService.publicLog2<ChatModeChangeEvent, ChatModeChangeClassification>('chat.modeChange', {
-			fromMode: currentMode.id,
-			toMode: switchToMode.id,
-			requestCount: requestCount
+			fromMode: currentMode.name.get(),
+			mode: switchToMode.name.get(),
+			requestCount: requestCount,
+			storage,
+			extensionId,
+			toolsCount,
+			handoffsCount
 		});
 
 		context.chatWidget.input.setChatMode(switchToMode.id);


### PR DESCRIPTION
Backport of #277564

Closes #277565

Fixes broken telemetry in `chat.modeChange` event where custom agent modes were sending full URI paths instead of agent names.

**Changes:**
- Use `mode.name.get()` instead of `mode.id` for both `fromMode` and `mode` properties (custom modes now send readable names like "MyAgent" instead of URIs)
- Add `storage` property to track mode source (builtin, local, user, extension)
- Add `extensionId` for extension-sourced modes
- Add `toolsCount` and `handoffsCount` measurements
- Rename `toMode` → `mode` and remove `toMode` prefix from other properties for cleaner telemetry schema