### PR TITLE
chat: remove `waitForReady`

### DIFF
--- a/src/vs/base/common/event.ts
+++ b/src/vs/base/common/event.ts
@@ -601,12 +601,22 @@ export namespace Event {
 	 */
 	export function toPromise<T>(event: Event<T>, disposables?: IDisposable[] | DisposableStore): CancelablePromise<T> {
 		let cancelRef: () => void;
-		const promise = new Promise((resolve, reject) => {
-			const listener = once(event)(resolve, null, disposables);
+		let listener: IDisposable;
+		const promise = new Promise((resolve) => {
+			listener = once(event)(resolve);
+			addToDisposables(listener, disposables);
+
 			// not resolved, matching the behavior of a normal disposal
-			cancelRef = () => listener.dispose();
+			cancelRef = () => {
+				disposeAndRemove(listener, disposables);
+				listener.dispose();
+			};
 		}) as CancelablePromise<T>;
 		promise.cancel = cancelRef!;
+
+		if (disposables) {
+			promise.finally(() => disposeAndRemove(listener, disposables));
+		}
 
 		return promise;
 	}
@@ -746,11 +756,7 @@ export namespace Event {
 				}
 			};
 
-			if (disposables instanceof DisposableStore) {
-				disposables.add(disposable);
-			} else if (Array.isArray(disposables)) {
-				disposables.push(disposable);
-			}
+			addToDisposables(disposable, disposables);
 
 			return disposable;
 		};
@@ -1129,11 +1135,7 @@ export class Emitter<T> {
 				removeMonitor?.();
 				this._removeListener(contained);
 			});
-			if (disposables instanceof DisposableStore) {
-				disposables.add(result);
-			} else if (Array.isArray(disposables)) {
-				disposables.push(result);
-			}
+			addToDisposables(result, disposables);
 
 			return result;
 		};
@@ -1777,4 +1779,25 @@ export function trackSetChanges<T>(getData: () => ReadonlySet<T>, onDidChangeDat
 	}));
 	store.add(map);
 	return store;
+}
+
+
+function addToDisposables(result: IDisposable, disposables: DisposableStore | IDisposable[] | undefined) {
+	if (disposables instanceof DisposableStore) {
+		disposables.add(result);
+	} else if (Array.isArray(disposables)) {
+		disposables.push(result);
+	}
+}
+
+function disposeAndRemove(result: IDisposable, disposables: DisposableStore | IDisposable[] | undefined) {
+	if (disposables instanceof DisposableStore) {
+		disposables.delete(result);
+	} else if (Array.isArray(disposables)) {
+		const index = disposables.indexOf(result);
+		if (index !== -1) {
+			disposables.splice(index, 1);
+		}
+	}
+	result.dispose();
 }

--- a/src/vs/base/common/event.ts
+++ b/src/vs/base/common/event.ts
@@ -609,7 +609,6 @@ export namespace Event {
 			// not resolved, matching the behavior of a normal disposal
 			cancelRef = () => {
 				disposeAndRemove(listener, disposables);
-				listener.dispose();
 			};
 		}) as CancelablePromise<T>;
 		promise.cancel = cancelRef!;

--- a/src/vs/workbench/contrib/chat/browser/actions/chatExecuteActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatExecuteActions.ts
@@ -696,8 +696,7 @@ class SendToNewChatAction extends Action2 {
 			}
 		}
 
-		widget.clear();
-		await widget.waitForReady();
+		await widget.clear();
 		widget.acceptInput(context?.inputValue);
 	}
 }

--- a/src/vs/workbench/contrib/chat/browser/actions/chatMoveActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatMoveActions.ts
@@ -133,8 +133,7 @@ async function executeMoveToAction(accessor: ServicesAccessor, moveTo: MoveToNew
 	const viewState = widget.getViewState();
 	const resourceToOpen = widget.viewModel.sessionResource;
 
-	widget.clear();
-	await widget.waitForReady();
+	await widget.clear();
 
 	const options: IChatEditorOptions = { pinned: true, viewState, auxiliary: { compact: true, bounds: { width: 640, height: 640 } } };
 	await editorService.openEditor({ resource: resourceToOpen, options }, moveTo === MoveToNewLocation.Window ? AUX_WINDOW_GROUP : ACTIVE_GROUP);

--- a/src/vs/workbench/contrib/chat/browser/actions/chatNewActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatNewActions.ts
@@ -134,8 +134,7 @@ export function registerNewChatActions() {
 			accessibilitySignalService.playSignal(AccessibilitySignal.clear);
 
 			await editingSession?.stop();
-			widget.clear();
-			await widget.waitForReady();
+			await widget.clear();
 			widget.attachmentModel.clear(true);
 			widget.input.relatedFiles?.clear();
 			widget.focusInput();

--- a/src/vs/workbench/contrib/chat/browser/chat.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.ts
@@ -155,6 +155,8 @@ export interface IChatWidgetViewOptions {
 	renderInputToolbarBelowInput?: boolean;
 	supportsFileReferences?: boolean;
 	filter?: (item: ChatTreeItem) => boolean;
+	/** Action triggered when 'clear' is called on the widget. */
+	clear?: () => Promise<void>;
 	rendererOptions?: IChatListItemRendererOptions;
 	menus?: {
 		/**
@@ -256,12 +258,7 @@ export interface IChatWidget {
 	getCodeBlockInfosForResponse(response: IChatResponseViewModel): IChatCodeBlockInfo[];
 	getFileTreeInfosForResponse(response: IChatResponseViewModel): IChatFileTreeInfo[];
 	getLastFocusedFileTreeForResponse(response: IChatResponseViewModel): IChatFileTreeInfo | undefined;
-	clear(): void;
-	/**
-	 * Wait for this widget to have a VM with a fully initialized model and editing session.
-	 * Sort of a hack. See https://github.com/microsoft/vscode/issues/247484
-	 */
-	waitForReady(): Promise<void>;
+	clear(): Promise<void>;
 	getViewState(): IChatViewState;
 	lockToCodingAgent(name: string, displayName: string, agentId?: string): void;
 

--- a/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingSession.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingSession.ts
@@ -37,7 +37,7 @@ import { MultiDiffEditor } from '../../../multiDiffEditor/browser/multiDiffEdito
 import { MultiDiffEditorInput } from '../../../multiDiffEditor/browser/multiDiffEditorInput.js';
 import { CellUri, ICellEditOperation } from '../../../notebook/common/notebookCommon.js';
 import { INotebookService } from '../../../notebook/common/notebookService.js';
-import { ChatEditingSessionState, ChatEditKind, getMultiDiffSourceUri, IChatEditingSession, IModifiedEntryTelemetryInfo, IModifiedFileEntry, ISnapshotEntry, IStreamingEdits, ModifiedFileEntryState } from '../../common/chatEditingService.js';
+import { chatEditingSessionIsReady, ChatEditingSessionState, ChatEditKind, getMultiDiffSourceUri, IChatEditingSession, IModifiedEntryTelemetryInfo, IModifiedFileEntry, ISnapshotEntry, IStreamingEdits, ModifiedFileEntryState } from '../../common/chatEditingService.js';
 import { IChatResponseModel } from '../../common/chatModel.js';
 import { IChatProgress, IChatService } from '../../common/chatService.js';
 import { ChatAgentLocation } from '../../common/constants.js';
@@ -476,6 +476,8 @@ export class ChatEditingSession extends Disposable implements IChatEditingSessio
 		this._baselineCreationLocks.queue(resource.path, () => startPromise.p);
 
 		this._streamingEditLocks.queue(resource.toString(), async () => {
+			await chatEditingSessionIsReady(this);
+
 			if (!this.isDisposed) {
 				await this._acceptStreamingEditsStart(responseModel, inUndoStop, resource);
 			}
@@ -536,6 +538,8 @@ export class ChatEditingSession extends Disposable implements IChatEditingSessio
 			id: undoStopId,
 		}];
 		const telemetryInfo = this._getTelemetryInfoForModel(responseModel);
+
+		await chatEditingSessionIsReady(this);
 
 		// Acquire locks for each resource and take snapshots
 		for (const resource of resources) {

--- a/src/vs/workbench/contrib/chat/browser/chatEditor.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditor.ts
@@ -92,6 +92,7 @@ export class ChatEditor extends EditorPane {
 					autoScroll: mode => mode !== ChatModeKind.Ask,
 					renderFollowups: true,
 					supportsFileReferences: true,
+					clear: () => this.clear(),
 					rendererOptions: {
 						renderTextEditsAsSummary: (uri) => {
 							return true;
@@ -110,7 +111,6 @@ export class ChatEditor extends EditorPane {
 					inputEditorBackground: inputBackground,
 					resultEditorBackground: editorBackground
 				}));
-		this._register(this.widget.onDidClear(() => this.clear()));
 		this.widget.render(parent);
 		this.widget.setVisible(true);
 	}

--- a/src/vs/workbench/contrib/chat/browser/chatQuick.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatQuick.ts
@@ -168,11 +168,12 @@ class QuickChat extends Disposable {
 		super();
 	}
 
-	clear() {
+	private clear() {
 		this.model?.dispose();
 		this.model = undefined;
 		this.updateModel();
 		this.widget.inputEditor.setValue('');
+		return Promise.resolve();
 	}
 
 	focus(selection?: Selection): void {
@@ -236,7 +237,8 @@ class QuickChat extends Disposable {
 					renderStyle: 'compact',
 					menus: { inputSideToolbar: MenuId.ChatInputSide, telemetrySource: 'chatQuick' },
 					enableImplicitContext: true,
-					defaultMode: ChatMode.Ask
+					defaultMode: ChatMode.Ask,
+					clear: () => this.clear(),
 				},
 				{
 					listForeground: quickInputForeground,
@@ -294,7 +296,6 @@ class QuickChat extends Disposable {
 		this._register(this.widget.inputEditor.onDidChangeModelContent((e) => {
 			this._currentQuery = this.widget.inputEditor.getValue();
 		}));
-		this._register(this.widget.onDidClear(() => this.clear()));
 		this._register(this.widget.onDidChangeHeight((e) => this.sash.layout()));
 		const width = parent.offsetWidth;
 		this._register(this.sash.onDidStart(() => {

--- a/src/vs/workbench/contrib/chat/browser/chatSetup.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSetup.ts
@@ -486,7 +486,7 @@ class SetupAgent extends Disposable implements IChatAgentImplementation {
 		if (typeof result?.success === 'boolean') {
 			if (result.success) {
 				if (result.dialogSkipped) {
-					widget?.clear(); // make room for the Chat welcome experience
+					await widget?.clear(); // make room for the Chat welcome experience
 				} else if (requestModel) {
 					let newRequest = this.replaceAgentInRequestModel(requestModel, chatAgentService); 	// Replace agent part with the actual Chat agent...
 					newRequest = this.replaceToolInRequestModel(newRequest); 							// ...then replace any tool parts with the actual Chat tools

--- a/src/vs/workbench/contrib/chat/browser/chatViewPane.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatViewPane.ts
@@ -197,6 +197,7 @@ export class ChatViewPane extends ViewPane implements IViewWelcomeDelegate {
 				autoScroll: mode => mode !== ChatModeKind.Ask,
 				renderFollowups: this.chatOptions.location === ChatAgentLocation.Chat,
 				supportsFileReferences: true,
+				clear: () => this.clear(),
 				rendererOptions: {
 					renderTextEditsAsSummary: (uri) => {
 						return true;
@@ -215,9 +216,7 @@ export class ChatViewPane extends ViewPane implements IViewWelcomeDelegate {
 				overlayBackground: locationBasedColors.overlayBackground,
 				inputEditorBackground: locationBasedColors.background,
 				resultEditorBackground: editorBackground,
-
 			}));
-		this._register(this._widget.onDidClear(() => this.clear()));
 		this._widget.render(parent);
 
 		const updateWidgetVisibility = () => {

--- a/src/vs/workbench/contrib/chat/browser/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatWidget.ts
@@ -62,7 +62,7 @@ import { katexContainerClassName } from '../../markdown/common/markedKatexExtens
 import { checkModeOption } from '../common/chat.js';
 import { IChatAgentAttachmentCapabilities, IChatAgentCommand, IChatAgentData, IChatAgentService } from '../common/chatAgents.js';
 import { ChatContextKeys } from '../common/chatContextKeys.js';
-import { applyingChatEditsFailedContextKey, chatEditingSessionIsReady, decidedChatEditingResourceContextKey, hasAppliedChatEditsContextKey, hasUndecidedChatEditingResourceContextKey, IChatEditingService, IChatEditingSession, inChatEditingSessionContextKey, ModifiedFileEntryState } from '../common/chatEditingService.js';
+import { applyingChatEditsFailedContextKey, decidedChatEditingResourceContextKey, hasAppliedChatEditsContextKey, hasUndecidedChatEditingResourceContextKey, IChatEditingService, IChatEditingSession, inChatEditingSessionContextKey, ModifiedFileEntryState } from '../common/chatEditingService.js';
 import { IChatLayoutService } from '../common/chatLayoutService.js';
 import { IChatModel, IChatResponseModel } from '../common/chatModel.js';
 import { ChatMode, IChatModeService } from '../common/chatModes.js';
@@ -308,9 +308,6 @@ export class ChatWidget extends Disposable implements IChatWidget {
 	private _onDidScroll = this._register(new Emitter<void>());
 	readonly onDidScroll = this._onDidScroll.event;
 
-	private _onDidClear = this._register(new Emitter<void>());
-	readonly onDidClear = this._onDidClear.event;
-
 	private _onDidAcceptInput = this._register(new Emitter<void>());
 	readonly onDidAcceptInput = this._onDidAcceptInput.event;
 
@@ -385,11 +382,8 @@ export class ChatWidget extends Disposable implements IChatWidget {
 	*/
 	private scrollLock = true;
 
-	private _isReady = false;
-
 	private _instructionFilesCheckPromise: Promise<boolean> | undefined;
 	private _instructionFilesExist: boolean | undefined;
-	private _onDidBecomeReady = this._register(new Emitter<void>());
 
 	private readonly viewModelDisposables = this._register(new DisposableStore());
 	private _viewModel: ChatViewModel | undefined;
@@ -426,18 +420,6 @@ export class ChatWidget extends Disposable implements IChatWidget {
 		if (viewModel) {
 			this.viewModelDisposables.add(viewModel);
 			this.logService.debug('ChatWidget#setViewModel: have viewModel');
-
-			if (viewModel.model.editingSession) {
-				this.logService.debug('ChatWidget#setViewModel: waiting for editing session');
-				chatEditingSessionIsReady(viewModel.model.editingSession).then(() => {
-					this.logService.debug('ChatWidget#setViewModel: editing session ready');
-					this._isReady = true;
-					this._onDidBecomeReady.fire();
-				});
-			} else {
-				this._isReady = true;
-				this._onDidBecomeReady.fire();
-			}
 		} else {
 			this.logService.debug('ChatWidget#setViewModel: no viewModel');
 		}
@@ -774,22 +756,6 @@ export class ChatWidget extends Disposable implements IChatWidget {
 		return this.input.attachmentModel;
 	}
 
-	async waitForReady(): Promise<void> {
-		if (this._isReady) {
-			this.logService.debug('ChatWidget#waitForReady: already ready');
-			return;
-		}
-
-		this.logService.debug('ChatWidget#waitForReady: waiting for ready');
-		await Event.toPromise(this._onDidBecomeReady.event);
-
-		if (this.viewModel) {
-			this.logService.debug('ChatWidget#waitForReady: ready');
-		} else {
-			this.logService.debug('ChatWidget#waitForReady: no viewModel');
-		}
-	}
-
 	render(parent: HTMLElement): void {
 		const viewId = isIChatViewViewContext(this.viewContext) ? this.viewContext.viewId : undefined;
 		this.editorOptions = this._register(this.instantiationService.createInstance(ChatEditorOptions, viewId, this.styles.listForeground, this.styles.inputEditorBackground, this.styles.resultEditorBackground));
@@ -951,9 +917,8 @@ export class ChatWidget extends Disposable implements IChatWidget {
 		return responseItems[indexToFocus];
 	}
 
-	clear(): void {
+	async clear(): Promise<void> {
 		this.logService.debug('ChatWidget#clear');
-		this._isReady = false;
 		if (this._dynamicMessageLayoutData) {
 			this._dynamicMessageLayoutData.enabled = true;
 		}
@@ -969,7 +934,7 @@ export class ChatWidget extends Disposable implements IChatWidget {
 
 		this.inputPart.clearTodoListWidget(this.viewModel?.sessionResource, true);
 		this.chatSuggestNextWidget.hide();
-		this._onDidClear.fire();
+		await this.viewOptions.clear?.();
 	}
 
 	private onDidChangeItems(skipDynamicLayout?: boolean) {
@@ -2485,112 +2450,119 @@ export class ChatWidget extends Disposable implements IChatWidget {
 			}
 		}
 
-		if (this.viewModel) {
-			this._onDidAcceptInput.fire();
-			this.scrollLock = this.isLockedToCodingAgent || !!checkModeOption(this.input.currentModeKind, this.viewOptions.autoScroll);
+		while (!this._viewModel && !this._store.isDisposed) {
+			await Event.toPromise(this.onDidChangeViewModel, this._store);
+		}
 
-			const editorValue = this.getInput();
-			const requestId = this.chatAccessibilityService.acceptRequest();
-			const requestInputs: IChatRequestInputOptions = {
-				input: !query ? editorValue : query.query,
-				attachedContext: options?.enableImplicitContext === false ? this.input.getAttachedContext(this.viewModel.sessionResource) : this.input.getAttachedAndImplicitContext(this.viewModel.sessionResource),
+		if (!this.viewModel) {
+			return;
+		}
+
+		this._onDidAcceptInput.fire();
+		this.scrollLock = this.isLockedToCodingAgent || !!checkModeOption(this.input.currentModeKind, this.viewOptions.autoScroll);
+
+		const editorValue = this.getInput();
+		const requestId = this.chatAccessibilityService.acceptRequest();
+		const requestInputs: IChatRequestInputOptions = {
+			input: !query ? editorValue : query.query,
+			attachedContext: options?.enableImplicitContext === false ? this.input.getAttachedContext(this.viewModel.sessionResource) : this.input.getAttachedAndImplicitContext(this.viewModel.sessionResource),
+		};
+
+		const isUserQuery = !query;
+
+		// process the prompt command
+		await this._applyPromptFileIfSet(requestInputs);
+		await this._autoAttachInstructions(requestInputs);
+
+		if (this.viewOptions.enableWorkingSet !== undefined && this.input.currentModeKind === ChatModeKind.Edit && !this.chatService.edits2Enabled) {
+			const uniqueWorkingSetEntries = new ResourceSet(); // NOTE: this is used for bookkeeping so the UI can avoid rendering references in the UI that are already shown in the working set
+			const editingSessionAttachedContext: ChatRequestVariableSet = requestInputs.attachedContext;
+
+			// Collect file variables from previous requests before sending the request
+			const previousRequests = this.viewModel.model.getRequests();
+			for (const request of previousRequests) {
+				for (const variable of request.variableData.variables) {
+					if (URI.isUri(variable.value) && variable.kind === 'file') {
+						const uri = variable.value;
+						if (!uniqueWorkingSetEntries.has(uri)) {
+							editingSessionAttachedContext.add(variable);
+							uniqueWorkingSetEntries.add(variable.value);
+						}
+					}
+				}
+			}
+			requestInputs.attachedContext = editingSessionAttachedContext;
+
+			type ChatEditingWorkingSetClassification = {
+				owner: 'joyceerhl';
+				comment: 'Information about the working set size in a chat editing request';
+				originalSize: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The number of files that the user tried to attach in their editing request.' };
+				actualSize: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The number of files that were actually sent in their editing request.' };
 			};
+			type ChatEditingWorkingSetEvent = {
+				originalSize: number;
+				actualSize: number;
+			};
+			this.telemetryService.publicLog2<ChatEditingWorkingSetEvent, ChatEditingWorkingSetClassification>('chatEditing/workingSetSize', { originalSize: uniqueWorkingSetEntries.size, actualSize: uniqueWorkingSetEntries.size });
+		}
 
-			const isUserQuery = !query;
+		this.chatService.cancelCurrentRequestForSession(this.viewModel.sessionResource);
+		if (this.currentRequest) {
+			// We have to wait the current request to be properly cancelled so that it has a chance to update the model with its result metadata.
+			// This is awkward, it's basically a limitation of the chat provider-based agent.
+			await Promise.race([this.currentRequest, timeout(1000)]);
+		}
 
-			// process the prompt command
-			await this._applyPromptFileIfSet(requestInputs);
-			await this._autoAttachInstructions(requestInputs);
+		this.input.validateAgentMode();
 
-			if (this.viewOptions.enableWorkingSet !== undefined && this.input.currentModeKind === ChatModeKind.Edit && !this.chatService.edits2Enabled) {
-				const uniqueWorkingSetEntries = new ResourceSet(); // NOTE: this is used for bookkeeping so the UI can avoid rendering references in the UI that are already shown in the working set
-				const editingSessionAttachedContext: ChatRequestVariableSet = requestInputs.attachedContext;
-
-				// Collect file variables from previous requests before sending the request
-				const previousRequests = this.viewModel.model.getRequests();
-				for (const request of previousRequests) {
-					for (const variable of request.variableData.variables) {
-						if (URI.isUri(variable.value) && variable.kind === 'file') {
-							const uri = variable.value;
-							if (!uniqueWorkingSetEntries.has(uri)) {
-								editingSessionAttachedContext.add(variable);
-								uniqueWorkingSetEntries.add(variable.value);
-							}
-						}
-					}
+		if (this.viewModel.model.checkpoint) {
+			const requests = this.viewModel.model.getRequests();
+			for (let i = requests.length - 1; i >= 0; i -= 1) {
+				const request = requests[i];
+				if (request.shouldBeBlocked) {
+					this.chatService.removeRequest(this.viewModel.sessionResource, request.id);
 				}
-				requestInputs.attachedContext = editingSessionAttachedContext;
-
-				type ChatEditingWorkingSetClassification = {
-					owner: 'joyceerhl';
-					comment: 'Information about the working set size in a chat editing request';
-					originalSize: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The number of files that the user tried to attach in their editing request.' };
-					actualSize: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The number of files that were actually sent in their editing request.' };
-				};
-				type ChatEditingWorkingSetEvent = {
-					originalSize: number;
-					actualSize: number;
-				};
-				this.telemetryService.publicLog2<ChatEditingWorkingSetEvent, ChatEditingWorkingSetClassification>('chatEditing/workingSetSize', { originalSize: uniqueWorkingSetEntries.size, actualSize: uniqueWorkingSetEntries.size });
-			}
-
-			this.chatService.cancelCurrentRequestForSession(this.viewModel.sessionResource);
-			if (this.currentRequest) {
-				// We have to wait the current request to be properly cancelled so that it has a chance to update the model with its result metadata.
-				// This is awkward, it's basically a limitation of the chat provider-based agent.
-				await Promise.race([this.currentRequest, timeout(1000)]);
-			}
-
-			this.input.validateAgentMode();
-
-			if (this.viewModel.model.checkpoint) {
-				const requests = this.viewModel.model.getRequests();
-				for (let i = requests.length - 1; i >= 0; i -= 1) {
-					const request = requests[i];
-					if (request.shouldBeBlocked) {
-						this.chatService.removeRequest(this.viewModel.sessionResource, request.id);
-					}
-				}
-			}
-
-			const result = await this.chatService.sendRequest(this.viewModel.sessionResource, requestInputs.input, {
-				userSelectedModelId: this.input.currentLanguageModel,
-				location: this.location,
-				locationData: this._location.resolveData?.(),
-				parserContext: { selectedAgent: this._lastSelectedAgent, mode: this.input.currentModeKind },
-				attachedContext: requestInputs.attachedContext.asArray(),
-				noCommandDetection: options?.noCommandDetection,
-				...this.getModeRequestOptions(),
-				modeInfo: this.input.currentModeInfo,
-				agentIdSilent: this._lockedAgent?.id,
-			});
-
-			if (result) {
-				this.input.acceptInput(isUserQuery);
-				this._onDidSubmitAgent.fire({ agent: result.agent, slashCommand: result.slashCommand });
-				this.currentRequest = result.responseCompletePromise.then(() => {
-					const responses = this.viewModel?.getItems().filter(isResponseVM);
-					const lastResponse = responses?.[responses.length - 1];
-					this.chatAccessibilityService.acceptResponse(this, this.container, lastResponse, requestId, options?.isVoiceInput);
-					if (lastResponse?.result?.nextQuestion) {
-						const { prompt, participant, command } = lastResponse.result.nextQuestion;
-						const question = formatChatQuestion(this.chatAgentService, this.location, prompt, participant, command);
-						if (question) {
-							this.input.setValue(question, false);
-						}
-					}
-
-					this.currentRequest = undefined;
-				});
-
-				if (this.viewModel?.editing) {
-					this.finishedEditing(true);
-					this.viewModel.model?.setCheckpoint(undefined);
-				}
-				return result.responseCreatedPromise;
 			}
 		}
-		return undefined;
+
+		const result = await this.chatService.sendRequest(this.viewModel.sessionResource, requestInputs.input, {
+			userSelectedModelId: this.input.currentLanguageModel,
+			location: this.location,
+			locationData: this._location.resolveData?.(),
+			parserContext: { selectedAgent: this._lastSelectedAgent, mode: this.input.currentModeKind },
+			attachedContext: requestInputs.attachedContext.asArray(),
+			noCommandDetection: options?.noCommandDetection,
+			...this.getModeRequestOptions(),
+			modeInfo: this.input.currentModeInfo,
+			agentIdSilent: this._lockedAgent?.id,
+		});
+
+		if (!result) {
+			return;
+		}
+
+		this.input.acceptInput(isUserQuery);
+		this._onDidSubmitAgent.fire({ agent: result.agent, slashCommand: result.slashCommand });
+		this.currentRequest = result.responseCompletePromise.then(() => {
+			const responses = this.viewModel?.getItems().filter(isResponseVM);
+			const lastResponse = responses?.[responses.length - 1];
+			this.chatAccessibilityService.acceptResponse(this, this.container, lastResponse, requestId, options?.isVoiceInput);
+			if (lastResponse?.result?.nextQuestion) {
+				const { prompt, participant, command } = lastResponse.result.nextQuestion;
+				const question = formatChatQuestion(this.chatAgentService, this.location, prompt, participant, command);
+				if (question) {
+					this.input.setValue(question, false);
+				}
+			}
+
+			this.currentRequest = undefined;
+		});
+
+		if (this.viewModel?.editing) {
+			this.finishedEditing(true);
+			this.viewModel.model?.setCheckpoint(undefined);
+		}
+		return result.responseCreatedPromise;
 	}
 
 	getModeRequestOptions(): Partial<IChatSendRequestOptions> {
@@ -2818,10 +2790,11 @@ export class ChatWidget extends Disposable implements IChatWidget {
 				if (currentAgent.kind !== agent.kind) {
 					const chatModeCheck = await this.instantiationService.invokeFunction(handleModeSwitch, currentAgent.kind, agent.kind, this.viewModel?.model.getRequests().length ?? 0, this.viewModel?.model.editingSession);
 					if (!chatModeCheck) {
-						return undefined;
-					} else if (chatModeCheck.needToClearSession) {
-						this.clear();
-						await this.waitForReady();
+						return;
+					}
+
+					if (chatModeCheck.needToClearSession) {
+						await this.clear();
 					}
 				}
 				this.input.setChatMode(agent.id);

--- a/src/vs/workbench/contrib/chat/electron-browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/electron-browser/chat.contribution.ts
@@ -70,7 +70,6 @@ class ChatCommandLineHandler extends Disposable {
 		@INativeWorkbenchEnvironmentService private readonly environmentService: INativeWorkbenchEnvironmentService,
 		@ICommandService private readonly commandService: ICommandService,
 		@IWorkspaceTrustRequestService private readonly workspaceTrustRequestService: IWorkspaceTrustRequestService,
-		@IViewsService private readonly viewsService: IViewsService,
 		@ILogService private readonly logService: ILogService,
 		@IWorkbenchLayoutService private readonly layoutService: IWorkbenchLayoutService,
 		@IContextKeyService private readonly contextKeyService: IContextKeyService
@@ -108,8 +107,6 @@ class ChatCommandLineHandler extends Disposable {
 			attachFiles: args['add-file']?.map(file => URI.file(resolve(file))), // use `resolve` to deal with relative paths properly
 		};
 
-		const chatWidget = await showChatView(this.viewsService, this.layoutService);
-
 		if (args.maximize) {
 			const location = this.contextKeyService.getContextKeyValue<ViewContainerLocation>(ChatContextKeys.panelLocation.key);
 			if (location === ViewContainerLocation.AuxiliaryBar) {
@@ -119,7 +116,6 @@ class ChatCommandLineHandler extends Disposable {
 			}
 		}
 
-		await chatWidget?.waitForReady();
 		await this.commandService.executeCommand(ACTION_ID_NEW_CHAT);
 		await this.commandService.executeCommand(CHAT_OPEN_ACTION_ID, opts);
 	}

--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChatController.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChatController.ts
@@ -257,14 +257,14 @@ export class InlineChatController1 implements IEditorContribution {
 				location.location = ChatAgentLocation.Notebook;
 			}
 
-			const zone = _instaService.createInstance(InlineChatZoneWidget, location, undefined, { editor: this._editor, notebookEditor });
-			this._store.add(zone);
-			this._store.add(zone.widget.chatWidget.onDidClear(async () => {
+			const clear = async () => {
 				const r = this.joinCurrentRun();
 				this.cancelSession();
 				await r;
 				this.run();
-			}));
+			};
+			const zone = _instaService.createInstance(InlineChatZoneWidget, location, undefined, { editor: this._editor, notebookEditor }, clear);
+			this._store.add(zone);
 
 			return zone;
 		});
@@ -1332,6 +1332,7 @@ export class InlineChatController2 implements IEditorContribution {
 					defaultMode: ChatMode.Ask
 				},
 				{ editor: this._editor, notebookEditor },
+				() => Promise.resolve(),
 			);
 
 			result.domNode.classList.add('inline-chat-2');

--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChatZoneWidget.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChatZoneWidget.ts
@@ -53,6 +53,8 @@ export class InlineChatZoneWidget extends ZoneWidget {
 		location: IChatWidgetLocationOptions,
 		options: IChatWidgetViewOptions | undefined,
 		editors: { editor: ICodeEditor; notebookEditor?: INotebookEditor },
+		/** @deprecated should go away with inline2 */
+		clearDelegate: () => Promise<void>,
 		@IInstantiationService private readonly _instaService: IInstantiationService,
 		@ILogService private _logService: ILogService,
 		@IContextKeyService contextKeyService: IContextKeyService,
@@ -87,6 +89,7 @@ export class InlineChatZoneWidget extends ZoneWidget {
 					telemetrySource: 'interactiveEditorWidget-toolbar',
 					inputSideToolbar: MENU_INLINE_CHAT_SIDE
 				},
+				clear: clearDelegate,
 				...options,
 				rendererOptions: {
 					renderTextEditsAsSummary: (uri) => {

--- a/src/vs/workbench/contrib/scm/browser/scmHistoryChatContext.ts
+++ b/src/vs/workbench/contrib/scm/browser/scmHistoryChatContext.ts
@@ -276,7 +276,6 @@ registerAction2(class extends Action2 {
 			return;
 		}
 
-		await widget.waitForReady();
 		widget.attachmentModel.addContext(SCMHistoryItemContext.asAttachment(provider, historyItem));
 	}
 });


### PR DESCRIPTION
- Now that edit sessions are sync, we don't need to wait for them (just
  guard edits) as in https://github.com/microsoft/vscode-copilot/issues/16060
- I noticed `widget.onDidClear()` listeners were actually async and we
  do need to wait for them before we can safely make new input. Revised
  this to a delegate pattern.
- Wait for a view model when sending chat. Also, improved Event.toPromise
  so it can safely be reused -- it now cleans up its own disposable from
  the disposable store or array after it settles.

Resolves #247484
Refs https://github.com/microsoft/vscode/issues/277318

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
