### PR TITLE
chore: update electron build

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,6 +1,6 @@
 disturl="https://electronjs.org/headers"
 target="37.7.0"
-ms_build_id="12597478"
+ms_build_id="12781156"
 runtime="electron"
 build_from_source="true"
 legacy-peer-deps="true"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "code-oss-dev",
-  "version": "1.106.0",
+  "version": "1.106.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "code-oss-dev",
-      "version": "1.106.0",
+      "version": "1.106.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "code-oss-dev",
   "version": "1.106.1",
-  "distro": "14448fdebff821982801580aba09897633a6e91b",
+  "distro": "0e93c4a2ae00183c1a3c61a81a820ebea824de39",
   "author": {
     "name": "Microsoft Corporation"
   },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "code-oss-dev",
   "version": "1.106.1",
-  "distro": "0e93c4a2ae00183c1a3c61a81a820ebea824de39",
+  "distro": "4e0bc2cfee9b7647f403afab8686aa5c1cbc804d",
   "author": {
     "name": "Microsoft Corporation"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "code-oss-dev",
-  "version": "1.106.0",
+  "version": "1.106.1",
   "distro": "14448fdebff821982801580aba09897633a6e91b",
   "author": {
     "name": "Microsoft Corporation"


### PR DESCRIPTION
Ports changes from https://github.com/microsoft/vscode/commits/release/hotfix/1.106/ into `release/1.106`