### PR TITLE
ChatSessions `canAccessPreviousChatHistory`

### DIFF
--- a/src/vs/workbench/api/common/extHostChatAgents2.ts
+++ b/src/vs/workbench/api/common/extHostChatAgents2.ts
@@ -684,10 +684,7 @@ export class ExtHostChatAgents2 extends Disposable implements ExtHostChatAgentsS
 		const res: (vscode.ChatRequestTurn | vscode.ChatResponseTurn)[] = [];
 
 		for (const h of context.history) {
-			const ehResult = typeConvert.ChatAgentResult.to(h.result);
-			const result: vscode.ChatResult = agentId === h.request.agentId ?
-				ehResult :
-				{ ...ehResult, metadata: undefined };
+			const result: vscode.ChatResult = typeConvert.ChatAgentResult.to(h.result);
 
 			// REQUEST turn
 			const varsWithoutTools: vscode.ChatPromptReference[] = [];

--- a/src/vs/workbench/api/common/extHostChatAgents2.ts
+++ b/src/vs/workbench/api/common/extHostChatAgents2.ts
@@ -684,7 +684,10 @@ export class ExtHostChatAgents2 extends Disposable implements ExtHostChatAgentsS
 		const res: (vscode.ChatRequestTurn | vscode.ChatResponseTurn)[] = [];
 
 		for (const h of context.history) {
-			const result: vscode.ChatResult = typeConvert.ChatAgentResult.to(h.result);
+			const ehResult = typeConvert.ChatAgentResult.to(h.result);
+			const result: vscode.ChatResult = agentId === h.request.agentId ?
+				ehResult :
+				{ ...ehResult, metadata: undefined };
 
 			// REQUEST turn
 			const varsWithoutTools: vscode.ChatPromptReference[] = [];

--- a/src/vs/workbench/contrib/chat/browser/chatSessions.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSessions.contribution.ts
@@ -639,6 +639,7 @@ export class ChatSessionsService extends Disposable implements IChatSessionsServ
 				isSticky: false,
 			},
 			capabilities: contribution.capabilities,
+			canAccessPreviousChatHistory: true,
 			extensionId: ext.identifier,
 			extensionVersion: ext.version,
 			extensionDisplayName: ext.displayName || ext.name,

--- a/src/vs/workbench/contrib/chat/common/chatAgents.ts
+++ b/src/vs/workbench/contrib/chat/common/chatAgents.ts
@@ -70,6 +70,7 @@ export interface IChatAgentData {
 	isDynamic?: boolean;
 	/** This agent is contributed from core and not from an extension */
 	isCore?: boolean;
+	canAccessPreviousChatHistory?: boolean;
 	metadata: IChatAgentMetadata;
 	slashCommands: IChatAgentCommand[];
 	locations: ChatAgentLocation[];

--- a/src/vs/workbench/contrib/chat/common/chatServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/chatServiceImpl.ts
@@ -1113,9 +1113,9 @@ export class ChatService extends Disposable implements IChatService {
 				continue;
 			}
 
-			if (forAgentId !== request.response.agent?.id && !agent?.isDefault) {
+			if (forAgentId !== request.response.agent?.id && !agent?.isDefault && !agent?.canAccessPreviousChatHistory) {
 				// An agent only gets to see requests that were sent to this agent.
-				// The default agent (the undefined case) gets to see all of them.
+				// The default agent (the undefined case), or agents with 'canAccessPreviousChatHistory', get to see all of them.
 				continue;
 			}
 


### PR DESCRIPTION
ref https://github.com/microsoft/vscode/issues/277313

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Allow opted-in chat agents to access the preceeding chat history.  Agents contributed via the chat sessions API are opted-in