### PR TITLE
Better handle local vs. remote terminal profiles when creating terminal

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminalProfileResolverService.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalProfileResolverService.ts
@@ -232,7 +232,7 @@ export abstract class BaseTerminalProfileResolverService extends Disposable impl
 		// Try select an existing profile to fallback to, based on the default system shell, only do
 		// this when it is NOT a local terminal in a remote window where the front and back end OS
 		// differs (eg. Windows -> WSL, Mac -> Linux)
-		if (options.os === OS) {
+		if (options.os === OS && options.remoteAuthority) {
 			let existingProfile = this._terminalProfileService.availableProfiles.find(e => path.parse(e.path).name === path.parse(executable).name);
 			if (existingProfile) {
 				if (options.allowAutomationShell) {

--- a/src/vs/workbench/contrib/terminal/browser/terminalProfileResolverService.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalProfileResolverService.ts
@@ -232,7 +232,7 @@ export abstract class BaseTerminalProfileResolverService extends Disposable impl
 		// Try select an existing profile to fallback to, based on the default system shell, only do
 		// this when it is NOT a local terminal in a remote window where the front and back end OS
 		// differs (eg. Windows -> WSL, Mac -> Linux)
-		if (options.os === OS && options.remoteAuthority) {
+		if (options.os === OS) {
 			let existingProfile = this._terminalProfileService.availableProfiles.find(e => path.parse(e.path).name === path.parse(executable).name);
 			if (existingProfile) {
 				if (options.allowAutomationShell) {

--- a/src/vs/workbench/contrib/terminal/browser/terminalProfileResolverService.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalProfileResolverService.ts
@@ -232,7 +232,10 @@ export abstract class BaseTerminalProfileResolverService extends Disposable impl
 		// Try select an existing profile to fallback to, based on the default system shell, only do
 		// this when it is NOT a local terminal in a remote window where the front and back end OS
 		// differs (eg. Windows -> WSL, Mac -> Linux)
-		if (options.os === OS) {
+		// When remoteAuthority is undefined but we have a remote connection, we're creating a local
+		// terminal in a remote window - skip profile matching as availableProfiles contains remote profiles
+		const isLocalTerminalInRemoteWindow = options.remoteAuthority === undefined && this._remoteAgentService.getConnection()?.remoteAuthority !== undefined;
+		if (options.os === OS && !isLocalTerminalInRemoteWindow) {
 			let existingProfile = this._terminalProfileService.availableProfiles.find(e => path.parse(e.path).name === path.parse(executable).name);
 			if (existingProfile) {
 				if (options.allowAutomationShell) {

--- a/src/vs/workbench/contrib/terminal/browser/terminalProfileResolverService.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalProfileResolverService.ts
@@ -229,11 +229,13 @@ export abstract class BaseTerminalProfileResolverService extends Disposable impl
 	private async _getUnresolvedFallbackDefaultProfile(options: IShellLaunchConfigResolveOptions): Promise<ITerminalProfile> {
 		const executable = await this._context.getDefaultSystemShell(options.remoteAuthority, options.os);
 
-		// Try select an existing profile to fallback to, based on the default system shell, only do
-		// this when the backend OS matches the frontend OS (eg. Windows -> Windows)
+		// Try select an existing profile to fallback to, based on the default system shell.
+		// We now handle local terminal in remote as well by passing in remoteAuthority when getting available profiles.
 		if (options.os === OS) {
 			const availableProfiles = this._terminalProfileService.getAvailableProfiles(options.remoteAuthority);
+			this._logService.trace('[TerminalProfileResolver] availableProfiles:', availableProfiles);
 			let existingProfile = availableProfiles.find(e => path.parse(e.path).name === path.parse(executable).name);
+			this._logService.trace('[TerminalProfileResolver] existingProfiles:', existingProfile);
 			if (existingProfile) {
 				if (options.allowAutomationShell) {
 					existingProfile = deepClone(existingProfile);

--- a/src/vs/workbench/contrib/terminal/browser/terminalProfileResolverService.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalProfileResolverService.ts
@@ -200,12 +200,18 @@ export abstract class BaseTerminalProfileResolverService extends Disposable impl
 			}
 		}
 
+		// When creating a local terminal in a remote window, skip looking up profiles from
+		// terminalProfileService as it contains remote profiles, not local ones
+		const isLocalTerminalInRemoteWindow = options.remoteAuthority === undefined && this._remoteAgentService.getConnection()?.remoteAuthority !== undefined;
+
 		// Return the real default profile if it exists and is valid, wait for profiles to be ready
 		// if the window just opened
-		await this._terminalProfileService.profilesReady;
-		const defaultProfile = this._getUnresolvedRealDefaultProfile(options.os);
-		if (defaultProfile) {
-			return this._setIconForAutomation(options, defaultProfile);
+		if (!isLocalTerminalInRemoteWindow) {
+			await this._terminalProfileService.profilesReady;
+			const defaultProfile = this._getUnresolvedRealDefaultProfile(options.os);
+			if (defaultProfile) {
+				return this._setIconForAutomation(options, defaultProfile);
+			}
 		}
 
 		// If there is no real default profile, create a fallback default profile based on the shell

--- a/src/vs/workbench/contrib/terminal/browser/terminalProfileResolverService.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalProfileResolverService.ts
@@ -94,7 +94,7 @@ export abstract class BaseTerminalProfileResolverService extends Disposable impl
 		if (shellLaunchConfig.executable) {
 			return;
 		}
-		const defaultProfile = this._getUnresolvedRealDefaultProfile(os);
+		const defaultProfile = this._getUnresolvedRealDefaultProfile(os, this._remoteAgentService.getConnection()?.remoteAuthority);
 		if (defaultProfile) {
 			shellLaunchConfig.icon = defaultProfile.icon;
 		}
@@ -200,18 +200,12 @@ export abstract class BaseTerminalProfileResolverService extends Disposable impl
 			}
 		}
 
-		// When creating a local terminal in a remote window, skip looking up profiles from
-		// terminalProfileService as it contains remote profiles, not local ones
-		const isLocalTerminalInRemoteWindow = options.remoteAuthority === undefined && this._remoteAgentService.getConnection()?.remoteAuthority !== undefined;
-
 		// Return the real default profile if it exists and is valid, wait for profiles to be ready
 		// if the window just opened
-		if (!isLocalTerminalInRemoteWindow) {
-			await this._terminalProfileService.profilesReady;
-			const defaultProfile = this._getUnresolvedRealDefaultProfile(options.os);
-			if (defaultProfile) {
-				return this._setIconForAutomation(options, defaultProfile);
-			}
+		await this._terminalProfileService.profilesReady;
+		const defaultProfile = this._getUnresolvedRealDefaultProfile(options.os, options.remoteAuthority);
+		if (defaultProfile) {
+			return this._setIconForAutomation(options, defaultProfile);
 		}
 
 		// If there is no real default profile, create a fallback default profile based on the shell
@@ -228,21 +222,18 @@ export abstract class BaseTerminalProfileResolverService extends Disposable impl
 		return profile;
 	}
 
-	private _getUnresolvedRealDefaultProfile(os: OperatingSystem): ITerminalProfile | undefined {
-		return this._terminalProfileService.getDefaultProfile(os);
+	private _getUnresolvedRealDefaultProfile(os: OperatingSystem, remoteAuthority: string | undefined): ITerminalProfile | undefined {
+		return this._terminalProfileService.getDefaultProfile(os, remoteAuthority);
 	}
 
 	private async _getUnresolvedFallbackDefaultProfile(options: IShellLaunchConfigResolveOptions): Promise<ITerminalProfile> {
 		const executable = await this._context.getDefaultSystemShell(options.remoteAuthority, options.os);
 
 		// Try select an existing profile to fallback to, based on the default system shell, only do
-		// this when it is NOT a local terminal in a remote window where the front and back end OS
-		// differs (eg. Windows -> WSL, Mac -> Linux)
-		// When remoteAuthority is undefined but we have a remote connection, we're creating a local
-		// terminal in a remote window - skip profile matching as availableProfiles contains remote profiles
-		const isLocalTerminalInRemoteWindow = options.remoteAuthority === undefined && this._remoteAgentService.getConnection()?.remoteAuthority !== undefined;
-		if (options.os === OS && !isLocalTerminalInRemoteWindow) {
-			let existingProfile = this._terminalProfileService.availableProfiles.find(e => path.parse(e.path).name === path.parse(executable).name);
+		// this when the backend OS matches the frontend OS (eg. Windows -> Windows)
+		if (options.os === OS) {
+			const availableProfiles = this._terminalProfileService.getAvailableProfiles(options.remoteAuthority);
+			let existingProfile = availableProfiles.find(e => path.parse(e.path).name === path.parse(executable).name);
 			if (existingProfile) {
 				if (options.allowAutomationShell) {
 					existingProfile = deepClone(existingProfile);

--- a/src/vs/workbench/contrib/terminal/common/terminal.ts
+++ b/src/vs/workbench/contrib/terminal/common/terminal.ts
@@ -74,12 +74,13 @@ export const ITerminalProfileService = createDecorator<ITerminalProfileService>(
 export interface ITerminalProfileService {
 	readonly _serviceBrand: undefined;
 	readonly availableProfiles: ITerminalProfile[];
+	getAvailableProfiles(remoteAuthority?: string): ITerminalProfile[];
 	readonly contributedProfiles: IExtensionTerminalProfile[];
 	readonly profilesReady: Promise<void>;
 	getPlatformKey(): Promise<string>;
 	refreshAvailableProfiles(): void;
 	getDefaultProfileName(): string | undefined;
-	getDefaultProfile(os?: OperatingSystem): ITerminalProfile | undefined;
+	getDefaultProfile(os?: OperatingSystem, remoteAuthority?: string): ITerminalProfile | undefined;
 	readonly onDidChangeAvailableProfiles: Event<ITerminalProfile[]>;
 	getContributedDefaultProfile(shellLaunchConfig: IShellLaunchConfig): Promise<IExtensionTerminalProfile | undefined>;
 	registerContributedProfile(args: IRegisterContributedProfileArgs): Promise<void>;

--- a/src/vs/workbench/contrib/terminal/electron-browser/terminalRemote.ts
+++ b/src/vs/workbench/contrib/terminal/electron-browser/terminalRemote.ts
@@ -9,9 +9,8 @@ import { localize2 } from '../../../../nls.js';
 import { INativeEnvironmentService } from '../../../../platform/environment/common/environment.js';
 import { IRemoteAuthorityResolverService } from '../../../../platform/remote/common/remoteAuthorityResolver.js';
 import { registerTerminalAction } from '../browser/terminalActions.js';
-import { TerminalCommandId, ITerminalProfileResolverService } from '../common/terminal.js';
+import { TerminalCommandId } from '../common/terminal.js';
 import { IHistoryService } from '../../../services/history/common/history.js';
-import { OS } from '../../../../base/common/platform.js';
 
 export function registerRemoteContributions() {
 	registerTerminalAction({
@@ -21,8 +20,6 @@ export function registerRemoteContributions() {
 			const historyService = accessor.get(IHistoryService);
 			const remoteAuthorityResolverService = accessor.get(IRemoteAuthorityResolverService);
 			const nativeEnvironmentService = accessor.get(INativeEnvironmentService);
-			const terminalProfileResolverService = accessor.get(ITerminalProfileResolverService);
-
 			let cwd: URI | undefined;
 			try {
 				const activeWorkspaceRootUri = historyService.getLastActiveWorkspaceRoot(Schemas.vscodeRemote);
@@ -36,18 +33,7 @@ export function registerRemoteContributions() {
 			if (!cwd) {
 				cwd = nativeEnvironmentService.userHome;
 			}
-
-			// Make sure to explicitly get the local default profile
-			const localProfile = await terminalProfileResolverService.getDefaultProfile({
-				remoteAuthority: undefined,
-				os: OS
-			});
-
-			// Create terminal with explicit local profile configuration
-			const instance = await c.service.createTerminal({
-				cwd,
-				config: localProfile
-			});
+			const instance = await c.service.createTerminal({ cwd });
 			if (!instance) {
 				return Promise.resolve(undefined);
 			}

--- a/src/vs/workbench/contrib/terminal/electron-browser/terminalRemote.ts
+++ b/src/vs/workbench/contrib/terminal/electron-browser/terminalRemote.ts
@@ -37,11 +37,10 @@ export function registerRemoteContributions() {
 				cwd = nativeEnvironmentService.userHome;
 			}
 
-			// Fix: Explicitly get the local default profile to ensure we use the correct local shell
-			// instead of accidentally using remote shell profiles when in a remote workspace
+			// Make sure to explicitly get the local default profile
 			const localProfile = await terminalProfileResolverService.getDefaultProfile({
-				remoteAuthority: undefined, // Force local backend
-				os: OS // Use the actual local OS
+				remoteAuthority: undefined,
+				os: OS
 			});
 
 			// Create terminal with explicit local profile configuration

--- a/src/vs/workbench/test/browser/workbenchTestServices.ts
+++ b/src/vs/workbench/test/browser/workbenchTestServices.ts
@@ -1935,13 +1935,14 @@ export class TestTerminalGroupService implements ITerminalGroupService {
 export class TestTerminalProfileService implements ITerminalProfileService {
 	_serviceBrand: undefined;
 	availableProfiles: ITerminalProfile[] = [];
+	getAvailableProfiles(_remoteAuthority?: string | undefined): ITerminalProfile[] { return this.availableProfiles; }
 	contributedProfiles: IExtensionTerminalProfile[] = [];
 	profilesReady: Promise<void> = Promise.resolve();
 	onDidChangeAvailableProfiles = Event.None;
 	getPlatformKey(): Promise<string> { throw new Error('Method not implemented.'); }
 	refreshAvailableProfiles(): void { throw new Error('Method not implemented.'); }
 	getDefaultProfileName(): string | undefined { throw new Error('Method not implemented.'); }
-	getDefaultProfile(): ITerminalProfile | undefined { throw new Error('Method not implemented.'); }
+	getDefaultProfile(_os?: OperatingSystem | undefined, _remoteAuthority?: string | undefined): ITerminalProfile | undefined { throw new Error('Method not implemented.'); }
 	getContributedDefaultProfile(shellLaunchConfig: IShellLaunchConfig): Promise<IExtensionTerminalProfile | undefined> { throw new Error('Method not implemented.'); }
 	registerContributedProfile(args: IRegisterContributedProfileArgs): Promise<void> { throw new Error('Method not implemented.'); }
 	getContributedProfileProvider(extensionIdentifier: string, id: string): ITerminalProfileProvider | undefined { throw new Error('Method not implemented.'); }


### PR DESCRIPTION
Handles mac -> linux/dev container scenario.
Part of #272892
Resolves: https://github.com/microsoft/vscode/issues/140186, https://github.com/microsoft/vscode/issues/246181 

Bit different from: https://github.com/microsoft/vscode/pull/277920  (WSL) 

We need better way to differentiate and better track remote profiles and local profiles. 

Still WIP.