### PR TITLE
chat: implement and migrate to IChatWidgetService.reveal/revealWidget

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/actions/chatActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatActions.ts
@@ -71,7 +71,7 @@ import { ILanguageModelChatSelector, ILanguageModelsService } from '../../common
 import { CopilotUsageExtensionFeatureId } from '../../common/languageModelStats.js';
 import { ILanguageModelToolsService } from '../../common/languageModelToolsService.js';
 import { ILanguageModelToolsConfirmationService } from '../../common/languageModelToolsConfirmationService.js';
-import { ChatViewId, IChatWidget, IChatWidgetService, showChatView } from '../chat.js';
+import { ChatViewId, IChatWidget, IChatWidgetService } from '../chat.js';
 import { IChatEditorOptions } from '../chatEditor.js';
 import { ChatEditorInput, shouldShowClearEditingSessionConfirmation, showClearEditingSessionConfirmation } from '../chatEditorInput.js';
 import { ChatViewPane } from '../chatViewPane.js';
@@ -189,8 +189,6 @@ abstract class OpenChatGlobalAction extends Action2 {
 		const chatService = accessor.get(IChatService);
 		const widgetService = accessor.get(IChatWidgetService);
 		const toolsService = accessor.get(ILanguageModelToolsService);
-		const viewsService = accessor.get(IViewsService);
-		const layoutService = accessor.get(IWorkbenchLayoutService);
 		const hostService = accessor.get(IHostService);
 		const chatAgentService = accessor.get(IChatAgentService);
 		const instaService = accessor.get(IInstantiationService);
@@ -204,7 +202,7 @@ abstract class OpenChatGlobalAction extends Action2 {
 		// When this was invoked to switch to a mode via keybinding, and some chat widget is focused, use that one.
 		// Otherwise, open the view.
 		if (!this.mode || !chatWidget || !isAncestorOfActiveElement(chatWidget.domNode)) {
-			chatWidget = await showChatView(viewsService, layoutService);
+			chatWidget = await widgetService.revealWidget();
 		}
 
 		if (!chatWidget) {
@@ -473,6 +471,7 @@ export function registerChatActions() {
 			const layoutService = accessor.get(IWorkbenchLayoutService);
 			const viewsService = accessor.get(IViewsService);
 			const viewDescriptorService = accessor.get(IViewDescriptorService);
+			const widgetService = accessor.get(IChatWidgetService);
 
 			const chatLocation = viewDescriptorService.getViewLocationById(ChatViewId);
 
@@ -480,7 +479,7 @@ export function registerChatActions() {
 				this.updatePartVisibility(layoutService, chatLocation, false);
 			} else {
 				this.updatePartVisibility(layoutService, chatLocation, true);
-				(await showChatView(viewsService, layoutService))?.focusInput();
+				(await widgetService.revealWidget())?.focusInput();
 			}
 		}
 
@@ -1149,11 +1148,10 @@ export function registerChatActions() {
 		}
 
 		async run(accessor: ServicesAccessor) {
-			const viewsService = accessor.get(IViewsService);
-			const layoutService = accessor.get(IWorkbenchLayoutService);
+			const widgetService = accessor.get(IChatWidgetService);
 
 			// Open the chat view in the sidebar and get the widget
-			const chatWidget = await showChatView(viewsService, layoutService);
+			const chatWidget = await widgetService.revealWidget();
 
 			if (chatWidget) {
 				// Clear the current chat to start a new one

--- a/src/vs/workbench/contrib/chat/browser/actions/chatContextActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatContextActions.ts
@@ -35,8 +35,6 @@ import { ResourceContextKey } from '../../../../common/contextkeys.js';
 import { EditorResourceAccessor, isEditorCommandsContext, SideBySideEditor } from '../../../../common/editor.js';
 import { IEditorGroupsService } from '../../../../services/editor/common/editorGroupsService.js';
 import { IEditorService } from '../../../../services/editor/common/editorService.js';
-import { IWorkbenchLayoutService } from '../../../../services/layout/browser/layoutService.js';
-import { IViewsService } from '../../../../services/views/common/viewsService.js';
 import { ExplorerFolderContext } from '../../../files/common/files.js';
 import { CTX_INLINE_CHAT_V2_ENABLED } from '../../../inlineChat/common/inlineChat.js';
 import { AnythingQuickAccessProvider } from '../../../search/browser/anythingQuickAccess.js';
@@ -45,8 +43,8 @@ import { ISymbolQuickPickItem, SymbolsQuickAccessProvider } from '../../../searc
 import { SearchContext } from '../../../search/common/constants.js';
 import { ChatContextKeys } from '../../common/chatContextKeys.js';
 import { IChatRequestVariableEntry, OmittedState } from '../../common/chatVariableEntries.js';
-import { isSupportedChatFileScheme, ChatAgentLocation } from '../../common/constants.js';
-import { IChatWidget, IChatWidgetService, IQuickChatService, showChatView } from '../chat.js';
+import { ChatAgentLocation, isSupportedChatFileScheme } from '../../common/constants.js';
+import { IChatWidget, IChatWidgetService, IQuickChatService } from '../chat.js';
 import { IChatContextPickerItem, IChatContextPickService, IChatContextValueItem, isChatContextPickerPickItem } from '../chatContextPickService.js';
 import { isQuickChat } from '../chatWidget.js';
 import { resizeImage } from '../imageUtils.js';
@@ -63,13 +61,11 @@ export function registerChatContextActions() {
 }
 
 async function withChatView(accessor: ServicesAccessor): Promise<IChatWidget | undefined> {
-	const viewsService = accessor.get(IViewsService);
 	const chatWidgetService = accessor.get(IChatWidgetService);
-	const layoutService = accessor.get(IWorkbenchLayoutService);
 
 	const lastFocusedWidget = chatWidgetService.lastFocusedWidget;
 	if (!lastFocusedWidget || lastFocusedWidget.location === ChatAgentLocation.Chat) {
-		return showChatView(viewsService, layoutService); // only show chat view if we either have no chat view or its located in view container
+		return chatWidgetService.revealWidget(); // only show chat view if we either have no chat view or its located in view container
 	}
 	return lastFocusedWidget;
 }

--- a/src/vs/workbench/contrib/chat/browser/actions/chatExecuteActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatExecuteActions.ts
@@ -26,10 +26,10 @@ import { IChatService } from '../../common/chatService.js';
 import { ChatAgentLocation, ChatConfiguration, ChatModeKind, } from '../../common/constants.js';
 import { ILanguageModelChatMetadata } from '../../common/languageModels.js';
 import { ILanguageModelToolsService } from '../../common/languageModelToolsService.js';
-import { IChatWidget, IChatWidgetService, showChatWidgetInViewOrEditor } from '../chat.js';
+import { IChatWidget, IChatWidgetService } from '../chat.js';
 import { getEditingSessionContext } from '../chatEditing/chatEditingActions.js';
-import { ACTION_ID_NEW_CHAT, CHAT_CATEGORY, handleCurrentEditingSession, handleModeSwitch } from './chatActions.js';
 import { ctxHasEditorModification } from '../chatEditing/chatEditingEditorContextKeys.js';
+import { ACTION_ID_NEW_CHAT, CHAT_CATEGORY, handleCurrentEditingSession, handleModeSwitch } from './chatActions.js';
 import { ContinueChatInSessionAction } from './chatContinueInAction.js';
 
 export interface IVoiceChatExecuteActionContext {
@@ -242,7 +242,6 @@ export class ChatDelegateToEditSessionAction extends Action2 {
 	override async run(accessor: ServicesAccessor, ...args: unknown[]): Promise<void> {
 		const context = args[0] as IChatExecuteActionContext | undefined;
 		const widgetService = accessor.get(IChatWidgetService);
-		const instantiationService = accessor.get(IInstantiationService);
 		const inlineWidget = context?.widget ?? widgetService.lastFocusedWidget;
 		const locationData = inlineWidget?.locationData;
 
@@ -250,7 +249,7 @@ export class ChatDelegateToEditSessionAction extends Action2 {
 			const sessionWidget = widgetService.getWidgetBySessionResource(locationData.delegateSessionResource);
 
 			if (sessionWidget) {
-				await instantiationService.invokeFunction(showChatWidgetInViewOrEditor, sessionWidget);
+				await widgetService.reveal(sessionWidget);
 				sessionWidget.attachmentModel.addContext({
 					id: 'vscode.delegate.inline',
 					kind: 'file',
@@ -436,6 +435,7 @@ class OpenModelPickerAction extends Action2 {
 		const widgetService = accessor.get(IChatWidgetService);
 		const widget = widgetService.lastFocusedWidget;
 		if (widget) {
+			await widgetService.reveal(widget);
 			widget.input.openModelPicker();
 		}
 	}

--- a/src/vs/workbench/contrib/chat/browser/actions/chatGettingStarted.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatGettingStarted.ts
@@ -11,9 +11,7 @@ import { ExtensionIdentifier } from '../../../../../platform/extensions/common/e
 import { IExtensionManagementService, InstallOperation } from '../../../../../platform/extensionManagement/common/extensionManagement.js';
 import { IStorageService, StorageScope, StorageTarget } from '../../../../../platform/storage/common/storage.js';
 import { IDefaultChatAgent } from '../../../../../base/common/product.js';
-import { IWorkbenchLayoutService } from '../../../../services/layout/browser/layoutService.js';
-import { IViewsService } from '../../../../services/views/common/viewsService.js';
-import { showChatView } from '../chat.js';
+import { IChatWidgetService } from '../chat.js';
 
 export class ChatGettingStartedContribution extends Disposable implements IWorkbenchContribution {
 	static readonly ID = 'workbench.contrib.chatGettingStarted';
@@ -24,10 +22,9 @@ export class ChatGettingStartedContribution extends Disposable implements IWorkb
 	constructor(
 		@IProductService private readonly productService: IProductService,
 		@IExtensionService private readonly extensionService: IExtensionService,
-		@IViewsService private readonly viewsService: IViewsService,
 		@IExtensionManagementService private readonly extensionManagementService: IExtensionManagementService,
 		@IStorageService private readonly storageService: IStorageService,
-		@IWorkbenchLayoutService private readonly layoutService: IWorkbenchLayoutService,
+		@IChatWidgetService private readonly chatWidgetService: IChatWidgetService,
 	) {
 		super();
 
@@ -67,7 +64,7 @@ export class ChatGettingStartedContribution extends Disposable implements IWorkb
 	private async onDidInstallChat() {
 
 		// Open Chat view
-		showChatView(this.viewsService, this.layoutService);
+		this.chatWidgetService.revealWidget();
 
 		// Only do this once
 		this.storageService.store(ChatGettingStartedContribution.hideWelcomeView, true, StorageScope.APPLICATION, StorageTarget.MACHINE);

--- a/src/vs/workbench/contrib/chat/browser/chatAccessibilityService.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatAccessibilityService.ts
@@ -3,24 +3,24 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { alert, status } from '../../../../base/browser/ui/aria/aria.js';
-import { Disposable, DisposableMap, DisposableStore } from '../../../../base/common/lifecycle.js';
-import { AccessibilitySignal, IAccessibilitySignalService } from '../../../../platform/accessibilitySignal/browser/accessibilitySignalService.js';
-import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
-import { AccessibilityProgressSignalScheduler } from '../../../../platform/accessibilitySignal/browser/progressAccessibilitySignalScheduler.js';
-import { IChatAccessibilityService, showChatWidgetInViewOrEditor } from './chat.js';
-import { IChatResponseViewModel } from '../common/chatViewModel.js';
+import * as dom from '../../../../base/browser/dom.js';
 import { renderAsPlaintext } from '../../../../base/browser/markdownRenderer.js';
+import { alert, status } from '../../../../base/browser/ui/aria/aria.js';
+import { Event } from '../../../../base/common/event.js';
 import { MarkdownString } from '../../../../base/common/htmlContent.js';
+import { Disposable, DisposableMap, DisposableStore } from '../../../../base/common/lifecycle.js';
+import { localize } from '../../../../nls.js';
+import { AccessibilitySignal, IAccessibilitySignalService } from '../../../../platform/accessibilitySignal/browser/accessibilitySignalService.js';
+import { AccessibilityProgressSignalScheduler } from '../../../../platform/accessibilitySignal/browser/progressAccessibilitySignalScheduler.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
+import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
+import { FocusMode } from '../../../../platform/native/common/native.js';
+import { IHostService } from '../../../services/host/browser/host.js';
 import { AccessibilityVoiceSettingId } from '../../accessibility/browser/accessibilityConfiguration.js';
 import { IChatElicitationRequest } from '../common/chatService.js';
-import { IHostService } from '../../../services/host/browser/host.js';
-import { FocusMode } from '../../../../platform/native/common/native.js';
-import * as dom from '../../../../base/browser/dom.js';
-import { Event } from '../../../../base/common/event.js';
+import { IChatResponseViewModel } from '../common/chatViewModel.js';
 import { ChatConfiguration } from '../common/constants.js';
-import { localize } from '../../../../nls.js';
+import { IChatAccessibilityService, IChatWidgetService } from './chat.js';
 import { ChatWidget } from './chatWidget.js';
 
 const CHAT_RESPONSE_PENDING_ALLOWANCE_MS = 4000;
@@ -37,7 +37,8 @@ export class ChatAccessibilityService extends Disposable implements IChatAccessi
 		@IAccessibilitySignalService private readonly _accessibilitySignalService: IAccessibilitySignalService,
 		@IInstantiationService private readonly _instantiationService: IInstantiationService,
 		@IConfigurationService private readonly _configurationService: IConfigurationService,
-		@IHostService private readonly _hostService: IHostService
+		@IHostService private readonly _hostService: IHostService,
+		@IChatWidgetService private readonly _widgetService: IChatWidgetService,
 	) {
 		super();
 	}
@@ -124,7 +125,7 @@ export class ChatAccessibilityService extends Disposable implements IChatAccessi
 
 		disposables.add(Event.once(notification.onClick)(async () => {
 			await this._hostService.focus(targetWindow, { mode: FocusMode.Force });
-			await this._instantiationService.invokeFunction(showChatWidgetInViewOrEditor, widget);
+			await this._widgetService.reveal(widget);
 			widget.focusInput();
 			disposables.dispose();
 			this.notifications.delete(disposables);

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/chatConfirmationWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/chatConfirmationWidget.ts
@@ -24,7 +24,7 @@ import { IMarkdownRendererService } from '../../../../../platform/markdown/brows
 import { FocusMode } from '../../../../../platform/native/common/native.js';
 import { defaultButtonStyles } from '../../../../../platform/theme/browser/defaultStyles.js';
 import { IHostService } from '../../../../services/host/browser/host.js';
-import { IChatWidgetService, showChatWidgetInViewOrEditor } from '../chat.js';
+import { IChatWidgetService } from '../chat.js';
 import { renderFileWidgets } from '../chatInlineAnchorWidget.js';
 import { IChatContentPartRenderContext } from './chatContentParts.js';
 import { IChatMarkdownAnchorService } from './chatMarkdownAnchorService.js';
@@ -116,7 +116,6 @@ class ChatConfirmationNotifier extends Disposable {
 
 	constructor(
 		@IHostService private readonly _hostService: IHostService,
-		@IInstantiationService private readonly _instantiationService: IInstantiationService,
 		@IChatWidgetService private readonly _chatWidgetService: IChatWidgetService,
 	) {
 		super();
@@ -143,7 +142,7 @@ class ChatConfirmationNotifier extends Disposable {
 				await this._hostService.focus(targetWindow, { mode: FocusMode.Force });
 
 				if (widget) {
-					await this._instantiationService.invokeFunction(showChatWidgetInViewOrEditor, widget);
+					await this._chatWidgetService.reveal(widget);
 					widget.focusInput();
 				}
 				disposables.dispose();

--- a/src/vs/workbench/contrib/chat/browser/chatEditing/simpleBrowserEditorOverlay.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditing/simpleBrowserEditorOverlay.ts
@@ -20,8 +20,7 @@ import { EditorResourceAccessor, SideBySideEditor } from '../../../../common/edi
 import { isEqual, joinPath } from '../../../../../base/common/resources.js';
 import { CancellationTokenSource } from '../../../../../base/common/cancellation.js';
 import { IHostService } from '../../../../services/host/browser/host.js';
-import { IChatWidgetService, showChatView } from '../chat.js';
-import { IViewsService } from '../../../../services/views/common/viewsService.js';
+import { IChatWidgetService } from '../chat.js';
 import { Button, ButtonWithDropdown } from '../../../../../base/browser/ui/button/button.js';
 import { defaultButtonStyles } from '../../../../../platform/theme/browser/defaultStyles.js';
 import { addDisposableListener } from '../../../../../base/browser/dom.js';
@@ -37,7 +36,6 @@ import { IBrowserElementsService } from '../../../../services/browserElements/br
 import { IContextMenuService } from '../../../../../platform/contextview/browser/contextView.js';
 import { IAction, toAction } from '../../../../../base/common/actions.js';
 import { BrowserType } from '../../../../../platform/browserElements/common/browserElements.js';
-import { IWorkbenchLayoutService } from '../../../../services/layout/browser/layoutService.js';
 
 class SimpleBrowserOverlayWidget {
 
@@ -56,7 +54,6 @@ class SimpleBrowserOverlayWidget {
 		private readonly _container: HTMLElement,
 		@IHostService private readonly _hostService: IHostService,
 		@IChatWidgetService private readonly _chatWidgetService: IChatWidgetService,
-		@IViewsService private readonly _viewService: IViewsService,
 		@IFileService private readonly fileService: IFileService,
 		@IEnvironmentService private readonly environmentService: IEnvironmentService,
 		@ILogService private readonly logService: ILogService,
@@ -64,7 +61,6 @@ class SimpleBrowserOverlayWidget {
 		@IPreferencesService private readonly _preferencesService: IPreferencesService,
 		@IBrowserElementsService private readonly _browserElementsService: IBrowserElementsService,
 		@IContextMenuService private readonly contextMenuService: IContextMenuService,
-		@IWorkbenchLayoutService private readonly _layoutService: IWorkbenchLayoutService,
 	) {
 		this._showStore.add(this.configurationService.onDidChangeConfiguration(e => {
 			if (e.affectsConfiguration('chat.sendElementsToChat.enabled')) {
@@ -260,7 +256,7 @@ class SimpleBrowserOverlayWidget {
 		const bounds = elementData.bounds;
 		const toAttach: IChatRequestVariableEntry[] = [];
 
-		const widget = await showChatView(this._viewService, this._layoutService) ?? this._chatWidgetService.lastFocusedWidget;
+		const widget = await this._chatWidgetService.revealWidget() ?? this._chatWidgetService.lastFocusedWidget;
 		let value = 'Attached HTML and CSS Context\n\n' + elementData.outerHTML;
 		if (this.configurationService.getValue('chat.sendElementsToChat.attachCSS')) {
 			value += '\n\n' + elementData.computedStyle;

--- a/src/vs/workbench/contrib/chat/browser/chatQuick.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatQuick.ts
@@ -11,6 +11,7 @@ import { Emitter, Event } from '../../../../base/common/event.js';
 import { MarkdownString } from '../../../../base/common/htmlContent.js';
 import { Disposable, DisposableStore, IDisposable, MutableDisposable } from '../../../../base/common/lifecycle.js';
 import { autorun } from '../../../../base/common/observable.js';
+import { URI } from '../../../../base/common/uri.js';
 import { Selection } from '../../../../editor/common/core/selection.js';
 import { localize } from '../../../../nls.js';
 import { MenuId } from '../../../../platform/actions/common/actions.js';
@@ -24,13 +25,12 @@ import { editorBackground, inputBackground, quickInputBackground, quickInputFore
 import { EDITOR_DRAG_AND_DROP_BACKGROUND } from '../../../common/theme.js';
 import { IChatEntitlementService } from '../../../services/chat/common/chatEntitlementService.js';
 import { IWorkbenchLayoutService } from '../../../services/layout/browser/layoutService.js';
-import { IViewsService } from '../../../services/views/common/viewsService.js';
 import { ChatModel, isCellTextEditOperationArray } from '../common/chatModel.js';
 import { ChatMode } from '../common/chatModes.js';
 import { IParsedChatRequest } from '../common/chatParserTypes.js';
 import { IChatProgress, IChatService } from '../common/chatService.js';
 import { ChatAgentLocation } from '../common/constants.js';
-import { IQuickChatOpenOptions, IQuickChatService, showChatView } from './chat.js';
+import { IChatWidgetService, IQuickChatOpenOptions, IQuickChatService } from './chat.js';
 import { ChatWidget } from './chatWidget.js';
 
 export class QuickChatService extends Disposable implements IQuickChatService {
@@ -62,6 +62,10 @@ export class QuickChatService extends Disposable implements IQuickChatService {
 			return false;
 		}
 		return dom.isAncestorOfActiveElement(widget);
+	}
+
+	get sessionResource(): URI | undefined {
+		return this._input && this._currentChat?.sessionResource;
 	}
 
 	toggle(options?: IQuickChatOpenOptions): void {
@@ -156,12 +160,16 @@ class QuickChat extends Disposable {
 	private readonly maintainScrollTimer: MutableDisposable<IDisposable> = this._register(new MutableDisposable<IDisposable>());
 	private _deferUpdatingDynamicLayout: boolean = false;
 
+	public get sessionResource() {
+		return this.model?.sessionResource;
+	}
+
 	constructor(
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
 		@IContextKeyService private readonly contextKeyService: IContextKeyService,
 		@IChatService private readonly chatService: IChatService,
 		@IWorkbenchLayoutService private readonly layoutService: IWorkbenchLayoutService,
-		@IViewsService private readonly viewsService: IViewsService,
+		@IChatWidgetService private readonly chatWidgetService: IChatWidgetService,
 		@IChatEntitlementService private readonly chatEntitlementService: IChatEntitlementService,
 		@IMarkdownRendererService private readonly markdownRendererService: IMarkdownRendererService,
 	) {
@@ -319,7 +327,7 @@ class QuickChat extends Disposable {
 	}
 
 	async openChatView(): Promise<void> {
-		const widget = await showChatView(this.viewsService, this.layoutService);
+		const widget = await this.chatWidgetService.revealWidget();
 		if (!widget?.viewModel || !this.model) {
 			return;
 		}

--- a/src/vs/workbench/contrib/chat/browser/chatSetup.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSetup.ts
@@ -58,7 +58,6 @@ import { IHostService } from '../../../services/host/browser/host.js';
 import { IWorkbenchLayoutService, Parts } from '../../../services/layout/browser/layoutService.js';
 import { ILifecycleService } from '../../../services/lifecycle/common/lifecycle.js';
 import { IPreferencesService } from '../../../services/preferences/common/preferences.js';
-import { IViewsService } from '../../../services/views/common/viewsService.js';
 import { CountTokensCallback, ILanguageModelToolsService, IPreparedToolInvocation, IToolData, IToolImpl, IToolInvocation, IToolResult, ToolDataSource, ToolProgress } from '../../chat/common/languageModelToolsService.js';
 import { IExtension, IExtensionsWorkbenchService } from '../../extensions/common/extensions.js';
 import { IChatAgentImplementation, IChatAgentRequest, IChatAgentResult, IChatAgentService } from '../common/chatAgents.js';
@@ -72,7 +71,7 @@ import { IChatRequestToolEntry } from '../common/chatVariableEntries.js';
 import { ChatAgentLocation, ChatConfiguration, ChatModeKind } from '../common/constants.js';
 import { ILanguageModelsService } from '../common/languageModels.js';
 import { CHAT_CATEGORY, CHAT_OPEN_ACTION_ID, CHAT_SETUP_ACTION_ID, CHAT_SETUP_SUPPORT_ANONYMOUS_ACTION_ID } from './actions/chatActions.js';
-import { ChatViewId, IChatWidgetService, showChatView } from './chat.js';
+import { ChatViewId, IChatWidgetService } from './chat.js';
 import { CHAT_SIDEBAR_PANEL_ID } from './chatViewPane.js';
 import { IEnvironmentService } from '../../../../platform/environment/common/environment.js';
 import { chatViewsWelcomeRegistry } from './viewsWelcome/chatViewsWelcome.js';
@@ -826,7 +825,7 @@ class ChatSetup {
 		let instance = ChatSetup.instance;
 		if (!instance) {
 			instance = ChatSetup.instance = instantiationService.invokeFunction(accessor => {
-				return new ChatSetup(context, controller, accessor.get(ITelemetryService), accessor.get(IWorkbenchLayoutService), accessor.get(IKeybindingService), accessor.get(IChatEntitlementService) as ChatEntitlementService, accessor.get(ILogService), accessor.get(IConfigurationService), accessor.get(IViewsService), accessor.get(IWorkspaceTrustRequestService), accessor.get(IMarkdownRendererService));
+				return new ChatSetup(context, controller, accessor.get(ITelemetryService), accessor.get(IWorkbenchLayoutService), accessor.get(IKeybindingService), accessor.get(IChatEntitlementService) as ChatEntitlementService, accessor.get(ILogService), accessor.get(IConfigurationService), accessor.get(IChatWidgetService), accessor.get(IWorkspaceTrustRequestService), accessor.get(IMarkdownRendererService));
 			});
 		}
 
@@ -846,7 +845,7 @@ class ChatSetup {
 		@IChatEntitlementService private readonly chatEntitlementService: ChatEntitlementService,
 		@ILogService private readonly logService: ILogService,
 		@IConfigurationService private readonly configurationService: IConfigurationService,
-		@IViewsService private readonly viewsService: IViewsService,
+		@IChatWidgetService private readonly widgetService: IChatWidgetService,
 		@IWorkspaceTrustRequestService private readonly workspaceTrustRequestService: IWorkspaceTrustRequestService,
 		@IMarkdownRendererService private readonly markdownRendererService: IMarkdownRendererService,
 	) { }
@@ -901,7 +900,7 @@ class ChatSetup {
 		if (setupStrategy !== ChatSetupStrategy.Canceled && !options?.disableChatViewReveal) {
 			// Show the chat view now to better indicate progress
 			// while installing the extension or returning from sign in
-			showChatView(this.viewsService, this.layoutService);
+			this.widgetService.revealWidget();
 		}
 
 		let success: ChatSetupResultValue = undefined;
@@ -1181,8 +1180,7 @@ export class ChatSetupContribution extends Disposable implements IWorkbenchContr
 			}
 
 			override async run(accessor: ServicesAccessor, mode?: ChatModeKind | string, options?: { forceSignInDialog?: boolean; additionalScopes?: readonly string[]; forceAnonymous?: ChatSetupAnonymous }): Promise<boolean> {
-				const viewsService = accessor.get(IViewsService);
-				const layoutService = accessor.get(IWorkbenchLayoutService);
+				const widgetService = accessor.get(IChatWidgetService);
 				const instantiationService = accessor.get(IInstantiationService);
 				const dialogService = accessor.get(IDialogService);
 				const commandService = accessor.get(ICommandService);
@@ -1193,7 +1191,7 @@ export class ChatSetupContribution extends Disposable implements IWorkbenchContr
 				configurationService.updateValue(ChatTeardownContribution.CHAT_DISABLED_CONFIGURATION_KEY, false);
 
 				if (mode) {
-					const chatWidget = await showChatView(viewsService, layoutService);
+					const chatWidget = await widgetService.revealWidget();
 					chatWidget?.input.setChatMode(mode);
 				}
 

--- a/src/vs/workbench/contrib/chat/browser/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatWidget.ts
@@ -10,7 +10,7 @@ import { IHoverOptions } from '../../../../base/browser/ui/hover/hover.js';
 import { HoverPosition } from '../../../../base/browser/ui/hover/hoverWidget.js';
 import { IListRenderer, IListVirtualDelegate } from '../../../../base/browser/ui/list/list.js';
 import { ITreeContextMenuEvent, ITreeElement } from '../../../../base/browser/ui/tree/tree.js';
-import { disposableTimeout, RunOnceScheduler, timeout } from '../../../../base/common/async.js';
+import { disposableTimeout, raceCancellablePromises, RunOnceScheduler, timeout } from '../../../../base/common/async.js';
 import { CancellationToken } from '../../../../base/common/cancellation.js';
 import { Codicon } from '../../../../base/common/codicons.js';
 import { fromNow, fromNowByDay } from '../../../../base/common/date.js';
@@ -42,6 +42,7 @@ import { ITextResourceEditorInput } from '../../../../platform/editor/common/edi
 import { IHoverService, WorkbenchHoverDelegate } from '../../../../platform/hover/browser/hover.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { ServiceCollection } from '../../../../platform/instantiation/common/serviceCollection.js';
+import { ILayoutService } from '../../../../platform/layout/browser/layoutService.js';
 import { WorkbenchList, WorkbenchObjectTree } from '../../../../platform/list/browser/listService.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
 import { bindContextKey } from '../../../../platform/observable/common/platformObservableUtils.js';
@@ -55,6 +56,7 @@ import { EditorResourceAccessor } from '../../../../workbench/common/editor.js';
 import { IEditorService } from '../../../../workbench/services/editor/common/editorService.js';
 import { ViewContainerLocation } from '../../../common/views.js';
 import { IChatEntitlementService } from '../../../services/chat/common/chatEntitlementService.js';
+import { GroupsOrder, IEditorGroupsService } from '../../../services/editor/common/editorGroupsService.js';
 import { IWorkbenchLayoutService, Position } from '../../../services/layout/browser/layoutService.js';
 import { ILifecycleService } from '../../../services/lifecycle/common/lifecycle.js';
 import { IViewsService } from '../../../services/views/common/viewsService.js';
@@ -83,7 +85,7 @@ import { PromptsConfig } from '../common/promptSyntax/config/config.js';
 import { IHandOff, PromptHeader, Target } from '../common/promptSyntax/promptFileParser.js';
 import { IPromptsService } from '../common/promptSyntax/service/promptsService.js';
 import { handleModeSwitch } from './actions/chatActions.js';
-import { ChatTreeItem, ChatViewId, IChatAcceptInputOptions, IChatAccessibilityService, IChatCodeBlockInfo, IChatFileTreeInfo, IChatListItemRendererOptions, IChatWidget, IChatWidgetService, IChatWidgetViewContext, IChatWidgetViewOptions, isIChatResourceViewContext, isIChatViewViewContext } from './chat.js';
+import { ChatTreeItem, ChatViewId, IChatAcceptInputOptions, IChatAccessibilityService, IChatCodeBlockInfo, IChatFileTreeInfo, IChatListItemRendererOptions, IChatWidget, IChatWidgetService, IChatWidgetViewContext, IChatWidgetViewOptions, IQuickChatService, isIChatResourceViewContext, isIChatViewViewContext } from './chat.js';
 import { ChatAccessibilityProvider } from './chatAccessibilityProvider.js';
 import { ChatAttachmentModel } from './chatAttachmentModel.js';
 import { ChatSuggestNextWidget } from './chatContentParts/chatSuggestNextWidget.js';
@@ -2862,6 +2864,15 @@ export class ChatWidgetService extends Disposable implements IChatWidgetService 
 	private readonly _onDidAddWidget = this._register(new Emitter<ChatWidget>());
 	readonly onDidAddWidget: Event<IChatWidget> = this._onDidAddWidget.event;
 
+	constructor(
+		@IEditorGroupsService private readonly editorGroupsService: IEditorGroupsService,
+		@IViewsService private readonly viewsService: IViewsService,
+		@IQuickChatService private readonly quickChatService: IQuickChatService,
+		@ILayoutService private readonly layoutService: ILayoutService,
+	) {
+		super();
+	}
+
 	get lastFocusedWidget(): IChatWidget | undefined {
 		return this._lastFocusedWidget;
 	}
@@ -2880,6 +2891,58 @@ export class ChatWidgetService extends Disposable implements IChatWidgetService 
 
 	getWidgetBySessionResource(sessionResource: URI): ChatWidget | undefined {
 		return this._widgets.find(w => isEqual(w.viewModel?.sessionResource, sessionResource));
+	}
+
+	async revealWidget(preserveFocus?: boolean): Promise<IChatWidget | undefined> {
+		const last = this.lastFocusedWidget;
+		if (last && await this.reveal(last, preserveFocus)) {
+			return last;
+		}
+
+		return (await this.viewsService.openView<ChatViewPane>(ChatViewId, !preserveFocus))?.widget;
+	}
+
+	async reveal(widget: IChatWidget, preserveFocus?: boolean): Promise<boolean> {
+		if (widget.viewModel?.sessionResource) {
+			for (const group of this.editorGroupsService.getGroups(GroupsOrder.MOST_RECENTLY_ACTIVE)) {
+				const editor = group.findEditors(widget.viewModel?.sessionResource).at(0);
+				if (!editor) {
+					continue;
+				}
+
+				// focus transfer to other documents is async. If we depend on the focus
+				// being synchronously transferred in consuming code, this can fail, so
+				// wait for it to propagate
+				const isGroupActive = () => dom.getWindowId(dom.getWindow(this.layoutService.activeContainer)) === group.windowId;
+
+				let ensureFocusTransfer: Promise<void> | undefined;
+				if (!isGroupActive()) {
+					ensureFocusTransfer = raceCancellablePromises([
+						timeout(500),
+						Event.toPromise(Event.once(Event.filter(this.layoutService.onDidChangeActiveContainer, isGroupActive))),
+					]);
+				}
+
+				const pane = await group.openEditor(editor, { preserveFocus });
+				await ensureFocusTransfer;
+				return !!pane;
+			}
+
+			if (isEqual(widget.viewModel?.sessionResource, this.quickChatService.sessionResource)) {
+				this.quickChatService.focus();
+				return true;
+			}
+		}
+
+		if (isIChatViewViewContext(widget.viewContext)) {
+			const view = await this.viewsService.openView(widget.viewContext.viewId, !preserveFocus);
+			if (!preserveFocus) {
+				view?.focus();
+			}
+			return !!view;
+		}
+
+		return false;
 	}
 
 	private setLastFocusedWidget(widget: ChatWidget | undefined): void {

--- a/src/vs/workbench/contrib/chat/browser/promptSyntax/attachInstructionsAction.ts
+++ b/src/vs/workbench/contrib/chat/browser/promptSyntax/attachInstructionsAction.ts
@@ -3,13 +3,12 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ChatViewId, IChatWidget, IChatWidgetService, showChatView } from '../chat.js';
+import { ChatViewId, IChatWidget, IChatWidgetService } from '../chat.js';
 import { CHAT_CATEGORY, CHAT_CONFIG_MENU_ID } from '../actions/chatActions.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { localize, localize2 } from '../../../../../nls.js';
 import { ChatContextKeys } from '../../common/chatContextKeys.js';
 import { IPromptsService } from '../../common/promptSyntax/service/promptsService.js';
-import { IViewsService } from '../../../../services/views/common/viewsService.js';
 import { PromptFilePickers } from './pickers/promptFilePickers.js';
 import { ServicesAccessor } from '../../../../../editor/browser/editorExtensions.js';
 import { Action2, MenuId, registerAction2 } from '../../../../../platform/actions/common/actions.js';
@@ -27,7 +26,6 @@ import { KeybindingWeight } from '../../../../../platform/keybinding/common/keyb
 import { ICodeEditorService } from '../../../../../editor/browser/services/codeEditorService.js';
 import { CancellationToken } from '../../../../../base/common/cancellation.js';
 import { IOpenerService } from '../../../../../platform/opener/common/opener.js';
-import { IWorkbenchLayoutService } from '../../../../services/layout/browser/layoutService.js';
 
 /**
  * Action ID for the `Attach Instruction` action.
@@ -94,9 +92,8 @@ class AttachInstructionsAction extends Action2 {
 		accessor: ServicesAccessor,
 		options?: IAttachInstructionsActionOptions,
 	): Promise<void> {
-		const viewsService = accessor.get(IViewsService);
 		const instaService = accessor.get(IInstantiationService);
-		const layoutService = accessor.get(IWorkbenchLayoutService);
+		const widgetService = accessor.get(IChatWidgetService);
 
 		if (!options) {
 			options = {
@@ -110,7 +107,7 @@ class AttachInstructionsAction extends Action2 {
 		const { skipSelectionDialog, resource } = options;
 
 
-		const widget = options.widget ?? (await showChatView(viewsService, layoutService));
+		const widget = options.widget ?? (await widgetService.revealWidget());
 		if (!widget) {
 			return;
 		}

--- a/src/vs/workbench/contrib/chat/browser/promptSyntax/runPromptAction.ts
+++ b/src/vs/workbench/contrib/chat/browser/promptSyntax/runPromptAction.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ChatViewId, IChatWidget, showChatView } from '../chat.js';
+import { ChatViewId, IChatWidget, IChatWidgetService } from '../chat.js';
 import { ACTION_ID_NEW_CHAT, CHAT_CATEGORY, CHAT_CONFIG_MENU_ID } from '../actions/chatActions.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { OS } from '../../../../../base/common/platform.js';
@@ -16,7 +16,6 @@ import { PromptsType, PROMPT_LANGUAGE_ID } from '../../common/promptSyntax/promp
 import { ILocalizedString, localize, localize2 } from '../../../../../nls.js';
 import { UILabelProvider } from '../../../../../base/common/keybindingLabels.js';
 import { ICommandAction } from '../../../../../platform/action/common/action.js';
-import { IViewsService } from '../../../../services/views/common/viewsService.js';
 import { PromptFilePickers } from './pickers/promptFilePickers.js';
 import { ServicesAccessor } from '../../../../../editor/browser/editorExtensions.js';
 import { EditorContextKeys } from '../../../../../editor/common/editorContextKeys.js';
@@ -29,7 +28,6 @@ import { Action2, MenuId, registerAction2 } from '../../../../../platform/action
 import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
 import { IOpenerService } from '../../../../../platform/opener/common/opener.js';
 import { IPromptsService } from '../../common/promptSyntax/service/promptsService.js';
-import { IWorkbenchLayoutService } from '../../../../services/layout/browser/layoutService.js';
 import { CancellationToken } from '../../../../../base/common/cancellation.js';
 
 /**
@@ -133,10 +131,9 @@ abstract class RunPromptBaseAction extends Action2 {
 		inNewChat: boolean,
 		accessor: ServicesAccessor,
 	): Promise<IChatWidget | undefined> {
-		const viewsService = accessor.get(IViewsService);
 		const commandService = accessor.get(ICommandService);
 		const promptsService = accessor.get(IPromptsService);
-		const layoutService = accessor.get(IWorkbenchLayoutService);
+		const widgetService = accessor.get(IChatWidgetService);
 
 		resource ||= getActivePromptFileUri(accessor);
 		assertDefined(
@@ -148,7 +145,7 @@ abstract class RunPromptBaseAction extends Action2 {
 			await commandService.executeCommand(ACTION_ID_NEW_CHAT);
 		}
 
-		const widget = await showChatView(viewsService, layoutService);
+		const widget = await widgetService.revealWidget();
 		if (widget) {
 			widget.setInput(`/${await promptsService.getPromptSlashCommandName(resource, CancellationToken.None)}`);
 			// submit the prompt immediately
@@ -209,11 +206,10 @@ class RunSelectedPromptAction extends Action2 {
 	public override async run(
 		accessor: ServicesAccessor,
 	): Promise<void> {
-		const viewsService = accessor.get(IViewsService);
 		const commandService = accessor.get(ICommandService);
 		const instaService = accessor.get(IInstantiationService);
 		const promptsService = accessor.get(IPromptsService);
-		const layoutService = accessor.get(IWorkbenchLayoutService);
+		const widgetService = accessor.get(IChatWidgetService);
 
 		const pickers = instaService.createInstance(PromptFilePickers);
 
@@ -235,7 +231,7 @@ class RunSelectedPromptAction extends Action2 {
 			await commandService.executeCommand(ACTION_ID_NEW_CHAT);
 		}
 
-		const widget = await showChatView(viewsService, layoutService);
+		const widget = await widgetService.revealWidget();
 		if (widget) {
 			widget.setInput(`/${await promptsService.getPromptSlashCommandName(promptFile, CancellationToken.None)}`);
 			// submit the prompt immediately

--- a/src/vs/workbench/contrib/chat/electron-browser/actions/voiceChatActions.ts
+++ b/src/vs/workbench/contrib/chat/electron-browser/actions/voiceChatActions.ts
@@ -36,7 +36,6 @@ import { IEditorService } from '../../../../services/editor/common/editorService
 import { IHostService } from '../../../../services/host/browser/host.js';
 import { IWorkbenchLayoutService, Parts } from '../../../../services/layout/browser/layoutService.js';
 import { IStatusbarEntry, IStatusbarEntryAccessor, IStatusbarService, StatusbarAlignment } from '../../../../services/statusbar/browser/statusbar.js';
-import { IViewsService } from '../../../../services/views/common/viewsService.js';
 import { AccessibilityVoiceSettingId, SpeechTimeoutDefault, accessibilityConfigurationNodeBase } from '../../../accessibility/browser/accessibilityConfiguration.js';
 import { InlineChatController } from '../../../inlineChat/browser/inlineChatController.js';
 import { CTX_INLINE_CHAT_FOCUSED, MENU_INLINE_CHAT_WIDGET_SECONDARY } from '../../../inlineChat/common/inlineChat.js';
@@ -46,7 +45,7 @@ import { SearchContext } from '../../../search/common/constants.js';
 import { TextToSpeechInProgress as GlobalTextToSpeechInProgress, HasSpeechProvider, ISpeechService, KeywordRecognitionStatus, SpeechToTextInProgress, SpeechToTextStatus, TextToSpeechStatus } from '../../../speech/common/speechService.js';
 import { CHAT_CATEGORY } from '../../browser/actions/chatActions.js';
 import { IChatExecuteActionContext } from '../../browser/actions/chatExecuteActions.js';
-import { IChatWidget, IChatWidgetService, IQuickChatService, showChatView } from '../../browser/chat.js';
+import { IChatWidget, IChatWidgetService, IQuickChatService } from '../../browser/chat.js';
 import { IChatAgentService } from '../../common/chatAgents.js';
 import { ChatContextKeys } from '../../common/chatContextKeys.js';
 import { IChatResponseModel } from '../../common/chatModel.js';
@@ -103,7 +102,6 @@ class VoiceChatSessionControllerFactory {
 		const quickChatService = accessor.get(IQuickChatService);
 		const layoutService = accessor.get(IWorkbenchLayoutService);
 		const editorService = accessor.get(IEditorService);
-		const viewsService = accessor.get(IViewsService);
 
 		switch (context) {
 			case 'focused': {
@@ -111,7 +109,7 @@ class VoiceChatSessionControllerFactory {
 				return controller ?? VoiceChatSessionControllerFactory.create(accessor, 'view'); // fallback to 'view'
 			}
 			case 'view': {
-				const chatWidget = await showChatView(viewsService, layoutService);
+				const chatWidget = await chatWidgetService.revealWidget();
 				if (chatWidget) {
 					return VoiceChatSessionControllerFactory.doCreateForChatWidget('view', chatWidget);
 				}
@@ -475,8 +473,7 @@ export class HoldToVoiceChatInChatViewAction extends Action2 {
 
 		const instantiationService = accessor.get(IInstantiationService);
 		const keybindingService = accessor.get(IKeybindingService);
-		const viewsService = accessor.get(IViewsService);
-		const layoutService = accessor.get(IWorkbenchLayoutService);
+		const widgetService = accessor.get(IChatWidgetService);
 
 		const holdMode = keybindingService.enableKeybindingHoldMode(HoldToVoiceChatInChatViewAction.ID);
 
@@ -489,7 +486,7 @@ export class HoldToVoiceChatInChatViewAction extends Action2 {
 			}
 		}, VOICE_KEY_HOLD_THRESHOLD);
 
-		(await showChatView(viewsService, layoutService))?.focusInput();
+		(await widgetService.revealWidget())?.focusInput();
 
 		await holdMode;
 		handle.dispose();

--- a/src/vs/workbench/contrib/chat/electron-browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/electron-browser/chat.contribution.ts
@@ -24,9 +24,8 @@ import { INativeWorkbenchEnvironmentService } from '../../../services/environmen
 import { IExtensionService } from '../../../services/extensions/common/extensions.js';
 import { IWorkbenchLayoutService } from '../../../services/layout/browser/layoutService.js';
 import { ILifecycleService, ShutdownReason } from '../../../services/lifecycle/common/lifecycle.js';
-import { IViewsService } from '../../../services/views/common/viewsService.js';
 import { ACTION_ID_NEW_CHAT, CHAT_OPEN_ACTION_ID, IChatViewOpenOptions } from '../browser/actions/chatActions.js';
-import { showChatView } from '../browser/chat.js';
+import { IChatWidgetService } from '../browser/chat.js';
 import { ChatContextKeys } from '../common/chatContextKeys.js';
 import { IChatService } from '../common/chatService.js';
 import { ChatUrlFetchingConfirmationContribution } from '../common/chatUrlFetchingConfirmation.js';
@@ -150,10 +149,9 @@ class ChatLifecycleHandler extends Disposable {
 		@ILifecycleService lifecycleService: ILifecycleService,
 		@IChatService private readonly chatService: IChatService,
 		@IDialogService private readonly dialogService: IDialogService,
-		@IViewsService private readonly viewsService: IViewsService,
+		@IChatWidgetService private readonly widgetService: IChatWidgetService,
 		@IContextKeyService private readonly contextKeyService: IContextKeyService,
 		@IExtensionService extensionService: IExtensionService,
-		@IWorkbenchLayoutService private readonly layoutService: IWorkbenchLayoutService,
 	) {
 		super();
 
@@ -181,7 +179,7 @@ class ChatLifecycleHandler extends Disposable {
 
 	private async doShouldVetoShutdown(reason: ShutdownReason): Promise<boolean> {
 
-		showChatView(this.viewsService, this.layoutService);
+		this.widgetService.revealWidget();
 
 		let message: string;
 		let detail: string;

--- a/src/vs/workbench/contrib/chat/test/browser/mockChatWidget.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/mockChatWidget.ts
@@ -30,6 +30,14 @@ export class MockChatWidgetService implements IChatWidgetService {
 		return [];
 	}
 
+	revealWidget(preserveFocus?: boolean): Promise<IChatWidget | undefined> {
+		return Promise.resolve(undefined);
+	}
+
+	reveal(widget: IChatWidget, preserveFocus?: boolean): Promise<boolean> {
+		return Promise.resolve(true);
+	}
+
 	getAllWidgets(): ReadonlyArray<IChatWidget> {
 		throw new Error('Method not implemented.');
 	}

--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChatSessionService.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChatSessionService.ts
@@ -12,9 +12,7 @@ import { Position } from '../../../../editor/common/core/position.js';
 import { IRange } from '../../../../editor/common/core/range.js';
 import { IValidEditOperation } from '../../../../editor/common/model.js';
 import { createDecorator, ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
-import { IWorkbenchLayoutService } from '../../../services/layout/browser/layoutService.js';
-import { IViewsService } from '../../../services/views/common/viewsService.js';
-import { showChatView } from '../../chat/browser/chat.js';
+import { IChatWidgetService } from '../../chat/browser/chat.js';
 import { IChatEditingSession } from '../../chat/common/chatEditingService.js';
 import { IChatModel, IChatRequestModel } from '../../chat/common/chatModel.js';
 import { IChatService } from '../../chat/common/chatService.js';
@@ -75,11 +73,10 @@ export interface IInlineChatSessionService {
 
 export async function moveToPanelChat(accessor: ServicesAccessor, model: IChatModel | undefined, resend: boolean) {
 
-	const viewsService = accessor.get(IViewsService);
 	const chatService = accessor.get(IChatService);
-	const layoutService = accessor.get(IWorkbenchLayoutService);
+	const widgetService = accessor.get(IChatWidgetService);
 
-	const widget = await showChatView(viewsService, layoutService);
+	const widget = await widgetService.revealWidget();
 
 	if (widget && widget.viewModel && model) {
 		let lastRequest: IChatRequestModel | undefined;
@@ -98,10 +95,9 @@ export async function moveToPanelChat(accessor: ServicesAccessor, model: IChatMo
 
 export async function askInPanelChat(accessor: ServicesAccessor, model: IChatRequestModel) {
 
-	const viewsService = accessor.get(IViewsService);
-	const layoutService = accessor.get(IWorkbenchLayoutService);
+	const widgetService = accessor.get(IChatWidgetService);
 
-	const widget = await showChatView(viewsService, layoutService);
+	const widget = await widgetService.revealWidget();
 
 	if (!widget) {
 		return;

--- a/src/vs/workbench/contrib/inlineChat/test/browser/inlineChatController.test.ts
+++ b/src/vs/workbench/contrib/inlineChat/test/browser/inlineChatController.test.ts
@@ -49,7 +49,7 @@ import { IViewsService } from '../../../../services/views/common/viewsService.js
 import { TestViewsService, workbenchInstantiationService } from '../../../../test/browser/workbenchTestServices.js';
 import { TestChatEntitlementService, TestContextService, TestExtensionService } from '../../../../test/common/workbenchTestServices.js';
 import { AccessibilityVerbositySettingId } from '../../../accessibility/browser/accessibilityConfiguration.js';
-import { IChatAccessibilityService, IChatWidget, IChatWidgetService } from '../../../chat/browser/chat.js';
+import { IChatAccessibilityService, IChatWidget, IChatWidgetService, IQuickChatService } from '../../../chat/browser/chat.js';
 import { ChatInputBoxContentProvider } from '../../../chat/browser/chatEdinputInputContentProvider.js';
 import { ChatLayoutService } from '../../../chat/browser/chatLayoutService.js';
 import { ChatVariablesService } from '../../../chat/browser/chatVariables.js';
@@ -224,6 +224,7 @@ suite('InlineChatController', function () {
 			[IChatEntitlementService, new class extends mock<IChatEntitlementService>() { }],
 			[IChatModeService, new SyncDescriptor(MockChatModeService)],
 			[IChatLayoutService, new SyncDescriptor(ChatLayoutService)],
+			[IQuickChatService, new class extends mock<IQuickChatService>() { }],
 			[IChatTodoListService, new class extends mock<IChatTodoListService>() {
 				override onDidUpdateTodos = Event.None;
 				override getTodos(sessionResource: URI): IChatTodo[] { return []; }

--- a/src/vs/workbench/contrib/inlineChat/test/browser/inlineChatSession.test.ts
+++ b/src/vs/workbench/contrib/inlineChat/test/browser/inlineChatSession.test.ts
@@ -44,7 +44,7 @@ import { IViewsService } from '../../../../services/views/common/viewsService.js
 import { workbenchInstantiationService } from '../../../../test/browser/workbenchTestServices.js';
 import { TestContextService, TestExtensionService } from '../../../../test/common/workbenchTestServices.js';
 import { AccessibilityVerbositySettingId } from '../../../accessibility/browser/accessibilityConfiguration.js';
-import { IChatAccessibilityService, IChatWidgetService } from '../../../chat/browser/chat.js';
+import { IChatAccessibilityService, IChatWidgetService, IQuickChatService } from '../../../chat/browser/chat.js';
 import { ChatSessionsService } from '../../../chat/browser/chatSessions.contribution.js';
 import { ChatVariablesService } from '../../../chat/browser/chatVariables.js';
 import { ChatWidget, ChatWidgetService } from '../../../chat/browser/chatWidget.js';
@@ -130,6 +130,7 @@ suite('InlineChatSession', function () {
 					return null;
 				}
 			}],
+			[IQuickChatService, new class extends mock<IQuickChatService>() { }],
 			[IConfigurationService, new TestConfigurationService()],
 			[IViewDescriptorService, new class extends mock<IViewDescriptorService>() {
 				override onDidChangeLocation = Event.None;

--- a/src/vs/workbench/contrib/notebook/browser/contrib/cellDiagnostics/cellDiagnosticsActions.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/cellDiagnostics/cellDiagnosticsActions.ts
@@ -16,9 +16,7 @@ import { INotebookCellActionContext, NotebookCellAction, findTargetCellEditor } 
 import { CodeCellViewModel } from '../../viewModel/codeCellViewModel.js';
 import { NOTEBOOK_CELL_EDITOR_FOCUSED, NOTEBOOK_CELL_FOCUSED, NOTEBOOK_CELL_HAS_ERROR_DIAGNOSTICS } from '../../../common/notebookContextKeys.js';
 import { InlineChatController } from '../../../../inlineChat/browser/inlineChatController.js';
-import { showChatView } from '../../../../chat/browser/chat.js';
-import { IViewsService } from '../../../../../services/views/common/viewsService.js';
-import { IWorkbenchLayoutService } from '../../../../../services/layout/browser/layoutService.js';
+import { IChatWidgetService } from '../../../../chat/browser/chat.js';
 
 export const OPEN_CELL_FAILURE_ACTIONS_COMMAND_ID = 'notebook.cell.openFailureActions';
 export const FIX_CELL_ERROR_COMMAND_ID = 'notebook.cell.chat.fixError';
@@ -111,9 +109,8 @@ registerAction2(class extends NotebookCellAction {
 		if (context.cell instanceof CodeCellViewModel) {
 			const error = context.cell.executionErrorDiagnostic.get();
 			if (error?.message) {
-				const viewsService = accessor.get(IViewsService);
-				const layoutService = accessor.get(IWorkbenchLayoutService);
-				const chatWidget = await showChatView(viewsService, layoutService);
+				const widgetService = accessor.get(IChatWidgetService);
+				const chatWidget = await widgetService.revealWidget();
 				const message = error.name ? `${error.name}: ${error.message}` : error.message;
 				// TODO: can we add special prompt instructions? e.g. use "%pip install"
 				chatWidget?.acceptInput('@workspace /explain ' + message,);

--- a/src/vs/workbench/contrib/notebook/browser/controller/chat/notebook.chat.contribution.ts
+++ b/src/vs/workbench/contrib/notebook/browser/controller/chat/notebook.chat.contribution.ts
@@ -21,9 +21,7 @@ import { ServicesAccessor } from '../../../../../../platform/instantiation/commo
 import { IQuickInputService, IQuickPickItem } from '../../../../../../platform/quickinput/common/quickInput.js';
 import { IWorkbenchContribution, registerWorkbenchContribution2, WorkbenchPhase } from '../../../../../common/contributions.js';
 import { IEditorService } from '../../../../../services/editor/common/editorService.js';
-import { IWorkbenchLayoutService } from '../../../../../services/layout/browser/layoutService.js';
-import { IViewsService } from '../../../../../services/views/common/viewsService.js';
-import { IChatWidget, IChatWidgetService, showChatView } from '../../../../chat/browser/chat.js';
+import { IChatWidget, IChatWidgetService } from '../../../../chat/browser/chat.js';
 import { IChatContextPicker, IChatContextPickerItem, IChatContextPickerPickItem, IChatContextPickService } from '../../../../chat/browser/chatContextPickService.js';
 import { ChatDynamicVariableModel } from '../../../../chat/browser/contrib/chatDynamicVariables.js';
 import { computeCompletionRanges } from '../../../../chat/browser/contrib/chatInputCompletions.js';
@@ -338,8 +336,6 @@ registerAction2(class CopyCellOutputAction extends Action2 {
 
 	async run(accessor: ServicesAccessor, outputContext: INotebookOutputActionContext | { outputViewModel: ICellOutputViewModel } | undefined): Promise<void> {
 		const notebookEditor = this.getNoteboookEditor(accessor.get(IEditorService), outputContext);
-		const viewService = accessor.get(IViewsService);
-		const layoutService = accessor.get(IWorkbenchLayoutService);
 
 		if (!notebookEditor) {
 			return;
@@ -391,7 +387,7 @@ registerAction2(class CopyCellOutputAction extends Action2 {
 			}
 
 			widget.attachmentModel.addContext(entry);
-			(await showChatView(viewService, layoutService))?.focusInput();
+			(await chatWidgetService.revealWidget())?.focusInput();
 		}
 	}
 

--- a/src/vs/workbench/contrib/scm/browser/scmHistoryChatContext.ts
+++ b/src/vs/workbench/contrib/scm/browser/scmHistoryChatContext.ts
@@ -20,9 +20,7 @@ import { Action2, MenuId, registerAction2 } from '../../../../platform/actions/c
 import { CodeDataTransfers } from '../../../../platform/dnd/browser/dnd.js';
 import { IInstantiationService, ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
 import { IWorkbenchContribution } from '../../../common/contributions.js';
-import { IWorkbenchLayoutService } from '../../../services/layout/browser/layoutService.js';
-import { IViewsService } from '../../../services/views/common/viewsService.js';
-import { IChatWidget, showChatView } from '../../chat/browser/chat.js';
+import { IChatWidget, IChatWidgetService } from '../../chat/browser/chat.js';
 import { IChatContextPickerItem, IChatContextPickerPickItem, IChatContextPickService, picksWithPromiseFn } from '../../chat/browser/chatContextPickService.js';
 import { ChatContextKeys } from '../../chat/common/chatContextKeys.js';
 import { ISCMHistoryItemChangeVariableEntry, ISCMHistoryItemVariableEntry } from '../../chat/common/chatVariableEntries.js';
@@ -269,9 +267,8 @@ registerAction2(class extends Action2 {
 	}
 
 	override async run(accessor: ServicesAccessor, provider: ISCMProvider, historyItem: ISCMHistoryItem): Promise<void> {
-		const viewsService = accessor.get(IViewsService);
-		const layoutService = accessor.get(IWorkbenchLayoutService);
-		const widget = await showChatView(viewsService, layoutService);
+		const chatWidgetService = accessor.get(IChatWidgetService);
+		const widget = await chatWidgetService.revealWidget();
 		if (!provider || !historyItem || !widget) {
 			return;
 		}
@@ -296,9 +293,8 @@ registerAction2(class extends Action2 {
 	}
 
 	override async run(accessor: ServicesAccessor, provider: ISCMProvider, historyItem: ISCMHistoryItem): Promise<void> {
-		const viewsService = accessor.get(IViewsService);
-		const layoutService = accessor.get(IWorkbenchLayoutService);
-		const widget = await showChatView(viewsService, layoutService);
+		const chatWidgetService = accessor.get(IChatWidgetService);
+		const widget = await chatWidgetService.revealWidget();
 		if (!provider || !historyItem || !widget) {
 			return;
 		}
@@ -324,9 +320,8 @@ registerAction2(class extends Action2 {
 	}
 
 	override async run(accessor: ServicesAccessor, historyItem: ISCMHistoryItem, historyItemChange: ISCMHistoryItemChange): Promise<void> {
-		const viewsService = accessor.get(IViewsService);
-		const layoutService = accessor.get(IWorkbenchLayoutService);
-		const widget = await showChatView(viewsService, layoutService);
+		const chatWidgetService = accessor.get(IChatWidgetService);
+		const widget = await chatWidgetService.revealWidget();
 		if (!historyItem || !historyItemChange.modifiedUri || !widget) {
 			return;
 		}

--- a/src/vs/workbench/contrib/terminal/browser/xterm/decorationAddon.ts
+++ b/src/vs/workbench/contrib/terminal/browser/xterm/decorationAddon.ts
@@ -28,14 +28,12 @@ import { ILifecycleService } from '../../../../services/lifecycle/common/lifecyc
 import { IHoverService } from '../../../../../platform/hover/browser/hover.js';
 import { MarkdownString } from '../../../../../base/common/htmlContent.js';
 import { IChatContextPickService } from '../../../chat/browser/chatContextPickService.js';
-import { IChatWidgetService, showChatView } from '../../../chat/browser/chat.js';
+import { IChatWidgetService } from '../../../chat/browser/chat.js';
 import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
 import { TerminalContext } from '../../../chat/browser/actions/chatContext.js';
 import { getTerminalUri, parseTerminalUri } from '../terminalUri.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { ChatAgentLocation } from '../../../chat/common/constants.js';
-import { IViewsService } from '../../../../services/views/common/viewsService.js';
-import { IWorkbenchLayoutService } from '../../../../services/layout/browser/layoutService.js';
 import { isString } from '../../../../../base/common/types.js';
 
 interface IDisposableDecoration { decoration: IDecoration; disposables: IDisposable[]; exitCode?: number; markProperties?: IMarkProperties }
@@ -70,9 +68,7 @@ export class DecorationAddon extends Disposable implements ITerminalAddon, IDeco
 		@IHoverService private readonly _hoverService: IHoverService,
 		@IChatContextPickService private readonly _contextPickService: IChatContextPickService,
 		@IChatWidgetService private readonly _chatWidgetService: IChatWidgetService,
-		@IInstantiationService private readonly _instantiationService: IInstantiationService,
-		@IViewsService private readonly _viewsService: IViewsService,
-		@IWorkbenchLayoutService private readonly _layoutService: IWorkbenchLayoutService
+		@IInstantiationService private readonly _instantiationService: IInstantiationService
 	) {
 		super();
 		this._register(toDisposable(() => this._dispose()));
@@ -540,7 +536,7 @@ export class DecorationAddon extends Disposable implements ITerminalAddon, IDeco
 
 				// If no widget found (e.g., after window reload when chat hasn't been focused), open chat view
 				if (!widget) {
-					widget = await showChatView(this._viewsService, this._layoutService);
+					widget = await this._chatWidgetService.revealWidget();
 				}
 
 				if (!widget) {

--- a/src/vs/workbench/contrib/terminalContrib/chat/browser/terminalChatController.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chat/browser/terminalChatController.ts
@@ -8,15 +8,13 @@ import { Lazy } from '../../../../../base/common/lazy.js';
 import { Disposable } from '../../../../../base/common/lifecycle.js';
 import { IContextKeyService } from '../../../../../platform/contextkey/common/contextkey.js';
 import { IInstantiationService, type ServicesAccessor } from '../../../../../platform/instantiation/common/instantiation.js';
-import { IChatCodeBlockContextProviderService, showChatView } from '../../../chat/browser/chat.js';
+import { IChatCodeBlockContextProviderService, IChatWidgetService } from '../../../chat/browser/chat.js';
 import { IChatService } from '../../../chat/common/chatService.js';
 import { isDetachedTerminalInstance, ITerminalContribution, ITerminalInstance, ITerminalService, IXtermTerminal } from '../../../terminal/browser/terminal.js';
 import { TerminalChatWidget } from './terminalChatWidget.js';
-import { IViewsService } from '../../../../services/views/common/viewsService.js';
 import type { ITerminalContributionContext } from '../../../terminal/browser/terminalExtensions.js';
 import type { IChatModel } from '../../../chat/common/chatModel.js';
 import { IChatEntitlementService } from '../../../../services/chat/common/chatEntitlementService.js';
-import { IWorkbenchLayoutService } from '../../../../services/layout/browser/layoutService.js';
 
 export class TerminalChatController extends Disposable implements ITerminalContribution {
 	static readonly ID = 'terminal.chat';
@@ -154,11 +152,10 @@ export class TerminalChatController extends Disposable implements ITerminalContr
 }
 
 async function moveToPanelChat(accessor: ServicesAccessor, model: IChatModel | undefined) {
-	const viewsService = accessor.get(IViewsService);
 	const chatService = accessor.get(IChatService);
-	const layoutService = accessor.get(IWorkbenchLayoutService);
+	const chatWidgetService = accessor.get(IChatWidgetService);
 
-	const widget = await showChatView(viewsService, layoutService);
+	const widget = await chatWidgetService.revealWidget();
 
 	if (widget && widget.viewModel && model) {
 		for (const request of model.getRequests().slice()) {

--- a/src/vs/workbench/contrib/terminalContrib/chat/browser/terminalChatWidget.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chat/browser/terminalChatWidget.ts
@@ -16,9 +16,7 @@ import { MenuId } from '../../../../../platform/actions/common/actions.js';
 import { IContextKey, IContextKeyService } from '../../../../../platform/contextkey/common/contextkey.js';
 import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
 import { IStorageService, StorageScope, StorageTarget } from '../../../../../platform/storage/common/storage.js';
-import { IWorkbenchLayoutService } from '../../../../services/layout/browser/layoutService.js';
-import { IViewsService } from '../../../../services/views/common/viewsService.js';
-import { IChatAcceptInputOptions, showChatView } from '../../../chat/browser/chat.js';
+import { IChatAcceptInputOptions, IChatWidgetService } from '../../../chat/browser/chat.js';
 import type { IChatViewState } from '../../../chat/browser/chatWidget.js';
 import { IChatAgentService } from '../../../chat/common/chatAgents.js';
 import { ChatModel, IChatResponseModel, isCellTextEditOperationArray } from '../../../chat/common/chatModel.js';
@@ -101,10 +99,9 @@ export class TerminalChatWidget extends Disposable {
 		@IContextKeyService contextKeyService: IContextKeyService,
 		@IChatService private readonly _chatService: IChatService,
 		@IStorageService private readonly _storageService: IStorageService,
-		@IViewsService private readonly _viewsService: IViewsService,
 		@IInstantiationService instantiationService: IInstantiationService,
 		@IChatAgentService private readonly _chatAgentService: IChatAgentService,
-		@IWorkbenchLayoutService private readonly _layoutService: IWorkbenchLayoutService,
+		@IChatWidgetService private readonly _chatWidgetService: IChatWidgetService,
 	) {
 		super();
 
@@ -432,7 +429,7 @@ export class TerminalChatWidget extends Disposable {
 	}
 
 	async viewInChat(): Promise<void> {
-		const widget = await showChatView(this._viewsService, this._layoutService);
+		const widget = await this._chatWidgetService.revealWidget();
 		const currentRequest = this._inlineChatWidget.chatWidget.viewModel?.model.getRequests().find(r => r.id === this._currentRequestId);
 		if (!widget || !currentRequest?.response) {
 			return;

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/terminal.chatAgentTools.contribution.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/terminal.chatAgentTools.contribution.ts
@@ -14,9 +14,7 @@ import { ContextKeyExpr } from '../../../../../platform/contextkey/common/contex
 import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
 import { TerminalSettingId } from '../../../../../platform/terminal/common/terminal.js';
 import { registerWorkbenchContribution2, WorkbenchPhase, type IWorkbenchContribution } from '../../../../common/contributions.js';
-import { IWorkbenchLayoutService } from '../../../../services/layout/browser/layoutService.js';
-import { IViewsService } from '../../../../services/views/common/viewsService.js';
-import { IChatWidgetService, showChatView } from '../../../chat/browser/chat.js';
+import { IChatWidgetService } from '../../../chat/browser/chat.js';
 import { ChatContextKeys } from '../../../chat/common/chatContextKeys.js';
 import { ILanguageModelToolsService, ToolDataSource, VSCodeToolReference } from '../../../chat/common/languageModelToolsService.js';
 import { registerActiveInstanceAction, sharedWhenClause } from '../../../terminal/browser/terminalActions.js';
@@ -132,16 +130,14 @@ registerActiveInstanceAction({
 		},
 	],
 	run: async (activeInstance, _c, accessor) => {
-		const viewsService = accessor.get(IViewsService);
 		const chatWidgetService = accessor.get(IChatWidgetService);
-		const layoutService = accessor.get(IWorkbenchLayoutService);
 
 		const selection = activeInstance.selection;
 		if (!selection) {
 			return;
 		}
 
-		const chatView = chatWidgetService.lastFocusedWidget || await showChatView(viewsService, layoutService);
+		const chatView = chatWidgetService.lastFocusedWidget ?? await chatWidgetService.revealWidget();
 		if (!chatView) {
 			return;
 		}


### PR DESCRIPTION
Previously we did a couple of different ad-hoc things when showing chat,
which often didn't support editor chat, aux window chat, and never
supported quick chat at all.

This implement a method on the IChatWidgetService to reveal the chat
widget regardless of location, and also to reveal+open the last widget
or create a new one if there wasn't one, replacing the popular `showChatView`
which only supported sidebar chat.

Refs #277318

cc @roblourens