### PR TITLE
fix input widget appearing before request is fully submitted

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatWidget.ts
@@ -2472,6 +2472,11 @@ export class ChatWidget extends Disposable implements IChatWidget {
 
 		const isUserQuery = !query;
 
+		if (this.viewModel?.editing) {
+			this.finishedEditing(true);
+			this.viewModel.model?.setCheckpoint(undefined);
+		}
+
 		// process the prompt command
 		await this._applyPromptFileIfSet(requestInputs);
 		await this._autoAttachInstructions(requestInputs);
@@ -2560,10 +2565,6 @@ export class ChatWidget extends Disposable implements IChatWidget {
 			this.currentRequest = undefined;
 		});
 
-		if (this.viewModel?.editing) {
-			this.finishedEditing(true);
-			this.viewModel.model?.setCheckpoint(undefined);
-		}
 		return result.responseCreatedPromise;
 	}
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

fix an issue where when editing, if you submit, you will briefly see a "disposed" input widget. by moving it further up in `acceptInput`, it ensures we dispose of the newly created input widget before we do anything else.

frame 1
<img width="481" height="427" alt="Screenshot 2025-11-17 at 8 56 03 PM" src="https://github.com/user-attachments/assets/565ab20a-47a5-4aef-8d42-a90607270972" />

frame 2
<img width="487" height="469" alt="Screenshot 2025-11-17 at 8 56 10 PM" src="https://github.com/user-attachments/assets/f4666525-2a1e-4e5b-97b8-84144b5e0fb2" />

by frame 3 it is gone, but sometimes in longer snapshot restores or some processing from that `acceptInput` command, it leads to that disposed input widget staying in the list longer than it should.

i think this started after one of the timeline changes cc @connor4312 
