### PR TITLE
agent sessions - fix indentation issue

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsView.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsView.ts
@@ -336,7 +336,8 @@ export class AgentSessionsView extends ViewPane {
 				defaultFindMode: TreeFindMode.Filter,
 				keyboardNavigationLabelProvider: new AgentSessionsKeyboardNavigationLabelProvider(),
 				sorter: new AgentSessionsSorter(),
-				paddingBottom: AgentSessionsListDelegate.ITEM_HEIGHT
+				paddingBottom: AgentSessionsListDelegate.ITEM_HEIGHT,
+				twistieAdditionalCssClass: () => 'force-no-twistie',
 			}
 		)) as WorkbenchCompressibleAsyncDataTree<IAgentSessionsViewModel, IAgentSessionViewModel, FuzzyScore>;
 	}

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsViewer.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsViewer.ts
@@ -72,9 +72,6 @@ export class AgentSessionRenderer implements ICompressibleTreeRenderer<IAgentSes
 	) { }
 
 	renderTemplate(container: HTMLElement): IAgentSessionItemTemplate {
-		// Hack to disable twistie in advent of on official option
-		container.previousElementSibling?.classList.add('force-no-twistie'); // hack, but no API for hiding twistie on tree
-
 		const disposables = new DisposableStore();
 		const elementDisposable = disposables.add(new DisposableStore());
 


### PR DESCRIPTION
@lszomoru looks like a regression from your work to make twistie hiding easier, without adoption the tree is now looking like this:

<img width="679" height="434" alt="image" src="https://github.com/user-attachments/assets/4deafc67-a957-4f01-a115-9162df31ccc4" />
