### PR TITLE
fix mismatch in colors

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/media/chat.css
@@ -2176,6 +2176,7 @@ have to be updated for changes to the rules above, or to support more deeply nes
 .interactive-session .chat-file-changes-label .monaco-button .codicon,
 .interactive-session .chat-used-context-label .monaco-button .codicon {
 	font-size: var(--vscode-chat-font-size-body-s);
+	color: var(--vscode-icon-foreground) !important;
 }
 
 .interactive-item-container .progress-container {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

mismatch in colors for tool calls vs. the chat context/collapsible widget:
<img width="262" height="82" alt="Screenshot 2025-11-17 at 9 35 42 PM" src="https://github.com/user-attachments/assets/4c058afe-8887-4918-9ff3-2d53eb4fd885" />

tool call (207,207,207):
<img width="1252" height="357" alt="Screenshot 2025-11-17 at 9 33 23 PM" src="https://github.com/user-attachments/assets/484cd212-9d1d-48db-8888-222cd846d812" />

context/collapsible (157, 157, 157):
<img width="1231" height="519" alt="Screenshot 2025-11-17 at 9 33 29 PM" src="https://github.com/user-attachments/assets/06562278-5999-4820-8e9c-d03999151b42" />

caused by this:
<img width="476" height="96" alt="Screenshot 2025-11-17 at 9 35 38 PM" src="https://github.com/user-attachments/assets/eeb35f7b-d267-4098-8893-cbda378f98f9" />

fixed:
<img width="269" height="94" alt="Screenshot 2025-11-17 at 9 39 29 PM" src="https://github.com/user-attachments/assets/6a4647a9-f78e-4aab-aaa6-198b3b9c837b" />


