### PR TITLE
No auth flow from inline chat gets broken by welcome view open (fix #278048)

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatSetup.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSetup.ts
@@ -85,7 +85,6 @@ import { CodeActionKind } from '../../../../editor/contrib/codeAction/common/typ
 import { ACTION_START as INLINE_CHAT_START } from '../../inlineChat/common/inlineChat.js';
 import { IPosition } from '../../../../editor/common/core/position.js';
 import { IMarker, IMarkerService, MarkerSeverity } from '../../../../platform/markers/common/markers.js';
-import { IEditorGroupsService } from '../../../services/editor/common/editorGroupsService.js';
 import { EditorContextKeys } from '../../../../editor/common/editorContextKeys.js';
 import { ICodeEditorService } from '../../../../editor/browser/services/codeEditorService.js';
 
@@ -1414,14 +1413,8 @@ export class ChatSetupContribution extends Disposable implements IWorkbenchContr
 
 				CommandsRegistry.registerCommand(coreCommand, async accessor => {
 					const commandService = accessor.get(ICommandService);
-					const editorGroupService = accessor.get(IEditorGroupsService);
 					const codeEditorService = accessor.get(ICodeEditorService);
 					const markerService = accessor.get(IMarkerService);
-
-					if (editorGroupService.activeGroup.activeEditor) {
-						// Pinning the editor helps when the Chat extension welcome kicks in after install to keep context
-						editorGroupService.activeGroup.pinEditor(editorGroupService.activeGroup.activeEditor);
-					}
 
 					switch (coreCommand) {
 						case 'chat.internal.explain':

--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.contribution.ts
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.contribution.ts
@@ -61,6 +61,7 @@ registerAction2(class extends Action2 {
 		const commandService = accessor.get(ICommandService);
 
 		const toSide = typeof optionsOrToSide === 'object' ? optionsOrToSide.toSide : optionsOrToSide;
+		const inactive = typeof optionsOrToSide === 'object' ? optionsOrToSide.inactive : false;
 		const activeEditor = editorService.activeEditor;
 
 		if (walkthroughID) {
@@ -82,10 +83,10 @@ registerAction2(class extends Action2 {
 			let options: GettingStartedEditorOptions;
 			if (selectedCategory) {
 				// Otherwise open the walkthrough editor with the selected category and step
-				options = { selectedCategory, selectedStep, showWelcome: false, preserveFocus: toSide ?? false };
+				options = { selectedCategory, selectedStep, showWelcome: false, preserveFocus: toSide ?? false, inactive };
 			} else {
 				// Open Welcome page
-				options = { selectedCategory, selectedStep, showWelcome: true, preserveFocus: toSide ?? false };
+				options = { selectedCategory, selectedStep, showWelcome: true, preserveFocus: toSide ?? false, inactive };
 			}
 			editorService.openEditor({
 				resource: GettingStartedInput.RESOURCE,
@@ -95,7 +96,7 @@ registerAction2(class extends Action2 {
 		} else {
 			editorService.openEditor({
 				resource: GettingStartedInput.RESOURCE,
-				options: { preserveFocus: toSide ?? false }
+				options: { preserveFocus: toSide ?? false, inactive }
 			}, toSide ? SIDE_GROUP : undefined);
 		}
 	}


### PR DESCRIPTION
@bhavyaus fyi can you see why the `inactive` parameter was not used anymore in getting started?