### PR TITLE
Do not show hint after jumping to it

### DIFF
--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsView.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsView.ts
@@ -264,6 +264,9 @@ export class InlineEditsView extends Disposable {
 	} | undefined = undefined;
 
 	private _getLongDistanceHintState(model: ModelPerInlineEdit, reader: IReader): ILongDistanceHint | undefined {
+		if (model.inlineEdit.inlineCompletion.identity.jumpedTo.read(reader)) {
+			return undefined;
+		}
 		if (this._currentInlineEditCache?.inlineSuggestionIdentity !== model.inlineEdit.inlineCompletion.identity) {
 			this._currentInlineEditCache = {
 				inlineSuggestionIdentity: model.inlineEdit.inlineCompletion.identity,


### PR DESCRIPTION
```Copilot Generated Description:``` Prevent the display of hints after the user has jumped to an inline edit suggestion.

https://github.com/microsoft/vscode/issues/278121