### PR TITLE
chat: add requestNeedsInput on the chat model

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/actions/chatElicitationActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatElicitationActions.ts
@@ -10,6 +10,7 @@ import { Action2, registerAction2 } from '../../../../../platform/actions/common
 import { ContextKeyExpr } from '../../../../../platform/contextkey/common/contextkey.js';
 import { KeybindingWeight } from '../../../../../platform/keybinding/common/keybindingsRegistry.js';
 import { ChatContextKeys } from '../../common/chatContextKeys.js';
+import { ElicitationState } from '../../common/chatService.js';
 import { isResponseVM } from '../../common/chatViewModel.js';
 import { IChatWidgetService } from '../chat.js';
 import { CHAT_CATEGORY } from './chatActions.js';
@@ -50,7 +51,7 @@ class AcceptElicitationRequestAction extends Action2 {
 			}
 
 			for (const content of item.response.value) {
-				if (content.kind === 'elicitation' && content.state === 'pending') {
+				if (content.kind === 'elicitation2' && content.state.get() === ElicitationState.Pending) {
 					await content.accept(true);
 					widget.focusInput();
 					return;

--- a/src/vs/workbench/contrib/chat/browser/chatAccessibilityProvider.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatAccessibilityProvider.ts
@@ -142,7 +142,7 @@ export class ChatAccessibilityProvider implements IListAccessibilityProvider<Cha
 				break;
 		}
 
-		const elicitationCount = element.response.value.filter(v => v.kind === 'elicitation');
+		const elicitationCount = element.response.value.filter(v => v.kind === 'elicitation2' || v.kind === 'elicitationSerialized');
 		let elicitationHint = '';
 		for (const elicitation of elicitationCount) {
 			const title = typeof elicitation.title === 'string' ? elicitation.title : elicitation.title.value;

--- a/src/vs/workbench/contrib/chat/browser/chatAccessibilityService.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatAccessibilityService.ts
@@ -17,7 +17,7 @@ import { IInstantiationService } from '../../../../platform/instantiation/common
 import { FocusMode } from '../../../../platform/native/common/native.js';
 import { IHostService } from '../../../services/host/browser/host.js';
 import { AccessibilityVoiceSettingId } from '../../accessibility/browser/accessibilityConfiguration.js';
-import { IChatElicitationRequest } from '../common/chatService.js';
+import { ElicitationState, IChatElicitationRequest } from '../common/chatService.js';
 import { IChatResponseViewModel } from '../common/chatViewModel.js';
 import { ChatConfiguration } from '../common/constants.js';
 import { IChatAccessibilityService, IChatWidgetService } from './chat.js';
@@ -73,7 +73,7 @@ export class ChatAccessibilityService extends Disposable implements IChatAccessi
 		}
 	}
 	acceptElicitation(elicitation: IChatElicitationRequest): void {
-		if (elicitation.state !== 'pending') {
+		if (elicitation.state.get() !== ElicitationState.Pending) {
 			return;
 		}
 		const title = typeof elicitation.title === 'string' ? elicitation.title : elicitation.title.value;

--- a/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingEditorContextKeys.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingEditorContextKeys.ts
@@ -121,7 +121,7 @@ class ContextKeyGroup {
 			this._ctxHasEditorModification.set(entry?.state.read(r) === ModifiedFileEntryState.Modified);
 			this._ctxIsGlobalEditingSession.set(session.isGlobalEditingSession);
 			this._ctxReviewModeEnabled.set(entry ? entry.reviewMode.read(r) : false);
-			this._ctxHasRequestInProgress.set(chatModel?.requestInProgressObs.read(r) ?? false);
+			this._ctxHasRequestInProgress.set(chatModel?.requestInProgress.read(r) ?? false);
 			this._ctxIsCurrentlyBeingModified.set(!!entry?.isCurrentlyBeingModifiedBy.read(r));
 
 			// number of requests

--- a/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingEditorOverlay.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingEditorOverlay.ts
@@ -376,7 +376,7 @@ class ChatEditingOverlayController {
 			}
 
 			const chatModel = chatService.getSession(session.chatSessionResource)!;
-			return chatModel.requestInProgressObs.read(r);
+			return chatModel.requestInProgress.read(r);
 		});
 
 		this._store.add(autorun(r => {

--- a/src/vs/workbench/contrib/chat/browser/chatElicitationRequestPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatElicitationRequestPart.ts
@@ -7,12 +7,12 @@ import { IAction } from '../../../../base/common/actions.js';
 import { IMarkdownString } from '../../../../base/common/htmlContent.js';
 import { Disposable } from '../../../../base/common/lifecycle.js';
 import { IObservable, observableValue } from '../../../../base/common/observable.js';
-import { IChatElicitationRequest } from '../common/chatService.js';
+import { ElicitationState, IChatElicitationRequest, IChatElicitationRequestSerialized } from '../common/chatService.js';
 import { ToolDataSource } from '../common/languageModelToolsService.js';
 
 export class ChatElicitationRequestPart extends Disposable implements IChatElicitationRequest {
-	public readonly kind = 'elicitation';
-	public state: 'pending' | 'accepted' | 'rejected' = 'pending';
+	public readonly kind = 'elicitation2';
+	public state = observableValue('state', ElicitationState.Pending);
 	public acceptedResult?: Record<string, unknown>;
 
 	private readonly _isHiddenValue = observableValue<boolean>('isHidden', false);
@@ -25,13 +25,19 @@ export class ChatElicitationRequestPart extends Disposable implements IChatElici
 		public readonly acceptButtonLabel: string,
 		public readonly rejectButtonLabel: string | undefined,
 		// True when the primary action is accepted, otherwise the action that was selected
-		public readonly accept: (value: IAction | true) => Promise<void>,
-		public readonly reject?: () => Promise<void>,
+		public readonly _accept: (value: IAction | true) => Promise<ElicitationState>,
+		public readonly _reject?: () => Promise<ElicitationState>,
 		public readonly source?: ToolDataSource,
 		public readonly moreActions?: IAction[],
 		public readonly onHide?: () => void,
 	) {
 		super();
+	}
+
+	accept(value: IAction | true): Promise<void> {
+		return this._accept(value).then(state => {
+			this.state.set(state, undefined);
+		});
 	}
 
 	hide(): void {
@@ -44,12 +50,17 @@ export class ChatElicitationRequestPart extends Disposable implements IChatElici
 	}
 
 	public toJSON() {
+		const state = this.state.get();
+
 		return {
-			kind: 'elicitation',
+			kind: 'elicitationSerialized',
 			title: this.title,
 			message: this.message,
-			state: this.state === 'pending' ? 'rejected' : this.state,
+			state: state === ElicitationState.Pending ? ElicitationState.Rejected : state,
 			acceptedResult: this.acceptedResult,
-		} satisfies Partial<IChatElicitationRequest>;
+			subtitle: this.subtitle,
+			source: this.source,
+			isHidden: this._isHiddenValue.get(),
+		} satisfies IChatElicitationRequestSerialized;
 	}
 }

--- a/src/vs/workbench/contrib/chat/browser/chatListRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatListRenderer.ts
@@ -53,7 +53,7 @@ import { IChatAgentMetadata } from '../common/chatAgents.js';
 import { ChatContextKeys } from '../common/chatContextKeys.js';
 import { IChatTextEditGroup } from '../common/chatModel.js';
 import { chatSubcommandLeader } from '../common/chatParserTypes.js';
-import { ChatAgentVoteDirection, ChatAgentVoteDownReason, ChatErrorLevel, IChatChangesSummary, IChatConfirmation, IChatContentReference, IChatElicitationRequest, IChatExtensionsContent, IChatFollowup, IChatMarkdownContent, IChatMcpServersStarting, IChatMultiDiffData, IChatPullRequestContent, IChatTask, IChatTaskSerialized, IChatThinkingPart, IChatToolInvocation, IChatToolInvocationSerialized, IChatTreeData, IChatUndoStop, isChatFollowup } from '../common/chatService.js';
+import { ChatAgentVoteDirection, ChatAgentVoteDownReason, ChatErrorLevel, IChatChangesSummary, IChatConfirmation, IChatContentReference, IChatElicitationRequest, IChatElicitationRequestSerialized, IChatExtensionsContent, IChatFollowup, IChatMarkdownContent, IChatMcpServersStarting, IChatMultiDiffData, IChatPullRequestContent, IChatTask, IChatTaskSerialized, IChatThinkingPart, IChatToolInvocation, IChatToolInvocationSerialized, IChatTreeData, IChatUndoStop, isChatFollowup } from '../common/chatService.js';
 import { IChatRequestVariableEntry } from '../common/chatVariableEntries.js';
 import { IChatChangesSummaryPart, IChatCodeCitations, IChatErrorDetailsPart, IChatReferences, IChatRendererContent, IChatRequestViewModel, IChatResponseViewModel, IChatViewModel, isRequestVM, isResponseVM } from '../common/chatViewModel.js';
 import { getNWords } from '../common/chatWordCounter.js';
@@ -1346,7 +1346,7 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 				return this.renderUndoStop(content);
 			} else if (content.kind === 'errorDetails') {
 				return this.renderChatErrorDetails(context, content, templateData);
-			} else if (content.kind === 'elicitation') {
+			} else if (content.kind === 'elicitation2' || content.kind === 'elicitationSerialized') {
 				return this.renderElicitation(context, content, templateData);
 			} else if (content.kind === 'changesSummary') {
 				return this.renderChangesSummary(content, context, templateData);
@@ -1557,7 +1557,11 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 		return part;
 	}
 
-	private renderElicitation(context: IChatContentPartRenderContext, elicitation: IChatElicitationRequest, templateData: IChatListItemTemplate): IChatContentPart {
+	private renderElicitation(context: IChatContentPartRenderContext, elicitation: IChatElicitationRequest | IChatElicitationRequestSerialized, templateData: IChatListItemTemplate): IChatContentPart {
+		if (elicitation.kind === 'elicitationSerialized' ? elicitation.isHidden : elicitation.isHidden?.get()) {
+			return this.renderNoContent(other => elicitation.kind === other.kind);
+		}
+
 		const part = this.instantiationService.createInstance(ChatElicitationContentPart, elicitation, context);
 		part.addDisposable(part.onDidChangeHeight(() => this.updateItemHeight(templateData)));
 		return part;

--- a/src/vs/workbench/contrib/chat/browser/chatResponseAccessibleView.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatResponseAccessibleView.ts
@@ -70,7 +70,7 @@ class ChatResponseAccessibleProvider extends Disposable implements IAccessibleVi
 			responseContent = item.errorDetails.message;
 		}
 		if (isResponseVM(item)) {
-			item.response.value.filter(item => item.kind === 'elicitation').forEach(elicitation => {
+			item.response.value.filter(item => item.kind === 'elicitation2' || item.kind === 'elicitationSerialized').forEach(elicitation => {
 				const title = elicitation.title;
 				if (typeof title === 'string') {
 					responseContent += `${title}\n`;

--- a/src/vs/workbench/contrib/chat/browser/chatSessions/chatSessionTracker.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSessions/chatSessionTracker.ts
@@ -131,7 +131,7 @@ export class ChatSessionTracker extends Disposable {
 	}
 
 	private modelToStatus(model: IChatModel): ChatSessionStatus | undefined {
-		if (model.requestInProgress) {
+		if (model.requestInProgress.get()) {
 			return ChatSessionStatus.InProgress;
 		}
 		const requests = model.getRequests();

--- a/src/vs/workbench/contrib/chat/browser/chatSessions/localChatSessionsProvider.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSessions/localChatSessionsProvider.ts
@@ -92,7 +92,7 @@ export class LocalChatSessionsProvider extends Disposable implements IChatSessio
 		const register = () => {
 			this.registerModelTitleListener(widget);
 			if (widget.viewModel) {
-				this.registerProgressListener(widget.viewModel.model.requestInProgressObs);
+				this.registerProgressListener(widget.viewModel.model.requestInProgress);
 			}
 		};
 		// Listen for view model changes on this widget
@@ -156,7 +156,7 @@ export class LocalChatSessionsProvider extends Disposable implements IChatSessio
 	}
 
 	private modelToStatus(model: IChatModel): ChatSessionStatus | undefined {
-		if (model.requestInProgress) {
+		if (model.requestInProgress.get()) {
 			return ChatSessionStatus.InProgress;
 		} else {
 			const requests = model.getRequests();

--- a/src/vs/workbench/contrib/chat/browser/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatWidget.ts
@@ -2206,7 +2206,7 @@ export class ChatWidget extends Disposable implements IChatWidget {
 				return;
 			}
 
-			this.requestInProgress.set(this.viewModel.requestInProgress);
+			this.requestInProgress.set(this.viewModel.model.requestInProgress.get());
 
 			// Update the editor's placeholder text when it changes in the view model
 			if (events?.some(e => e?.kind === 'changePlaceholder')) {
@@ -2432,7 +2432,7 @@ export class ChatWidget extends Disposable implements IChatWidget {
 	}
 
 	private async _acceptInput(query: { query: string } | undefined, options?: IChatAcceptInputOptions): Promise<IChatResponseModel | undefined> {
-		if (this.viewModel?.requestInProgress) {
+		if (this.viewModel?.model.requestInProgress.get()) {
 			return;
 		}
 

--- a/src/vs/workbench/contrib/chat/common/chatService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService.ts
@@ -279,21 +279,38 @@ export interface IChatConfirmation {
 	kind: 'confirmation';
 }
 
+export const enum ElicitationState {
+	Pending = 'pending',
+	Accepted = 'accepted',
+	Rejected = 'rejected',
+}
+
 export interface IChatElicitationRequest {
-	kind: 'elicitation';
+	kind: 'elicitation2'; // '2' because initially serialized data used the same kind
 	title: string | IMarkdownString;
 	message: string | IMarkdownString;
 	acceptButtonLabel: string;
 	rejectButtonLabel: string | undefined;
 	subtitle?: string | IMarkdownString;
 	source?: ToolDataSource;
-	state: 'pending' | 'accepted' | 'rejected';
+	state: IObservable<ElicitationState>;
 	acceptedResult?: Record<string, unknown>;
 	moreActions?: IAction[];
 	accept(value: IAction | true): Promise<void>;
 	reject?: () => Promise<void>;
 	isHidden?: IObservable<boolean>;
 	hide?(): void;
+}
+
+export interface IChatElicitationRequestSerialized {
+	kind: 'elicitationSerialized';
+	title: string | IMarkdownString;
+	message: string | IMarkdownString;
+	subtitle: string | IMarkdownString | undefined;
+	source: ToolDataSource | undefined;
+	state: ElicitationState.Accepted | ElicitationState.Rejected;
+	isHidden: boolean;
+	acceptedResult?: Record<string, unknown>;
 }
 
 export interface IChatThinkingPart {
@@ -679,6 +696,7 @@ export type IChatProgress =
 	| IChatThinkingPart
 	| IChatTaskSerialized
 	| IChatElicitationRequest
+	| IChatElicitationRequestSerialized
 	| IChatMcpServersStarting;
 
 export interface IChatFollowup {

--- a/src/vs/workbench/contrib/chat/common/chatServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/chatServiceImpl.ts
@@ -221,7 +221,7 @@ export class ChatService extends Disposable implements IChatService {
 
 		this.requestInProgressObs = derived(reader => {
 			const models = this._sessionModels.observable.read(reader).values();
-			return Array.from(models).some(model => model.requestInProgressObs.read(reader));
+			return Iterable.some(models, model => model.requestInProgress.read(reader));
 		});
 	}
 

--- a/src/vs/workbench/contrib/chat/common/chatViewModel.ts
+++ b/src/vs/workbench/contrib/chat/common/chatViewModel.ts
@@ -67,7 +67,6 @@ export interface IChatViewModel {
 	readonly sessionResource: URI;
 	readonly onDidDisposeModel: Event<void>;
 	readonly onDidChange: Event<IChatViewModelChangeEvent>;
-	readonly requestInProgress: boolean;
 	readonly inputPlaceholder?: string;
 	getItems(): (IChatRequestViewModel | IChatResponseViewModel)[];
 	setInputPlaceholder(text: string): void;
@@ -265,10 +264,6 @@ export class ChatViewModel extends Disposable implements IChatViewModel {
 
 	get sessionResource(): URI {
 		return this._model.sessionResource;
-	}
-
-	get requestInProgress(): boolean {
-		return this._model.requestInProgress;
 	}
 
 	constructor(

--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChatController.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChatController.ts
@@ -565,7 +565,7 @@ export class InlineChatController1 implements IEditorContribution {
 		}
 		options.position = await this._strategy.renderChanges();
 
-		if (this._session.chatModel.requestInProgress) {
+		if (this._session.chatModel.requestInProgress.get()) {
 			return State.SHOW_REQUEST;
 		} else {
 			return State.WAIT_FOR_INPUT;
@@ -647,7 +647,7 @@ export class InlineChatController1 implements IEditorContribution {
 	private async [State.SHOW_REQUEST](options: InlineChatRunOptions): Promise<State.WAIT_FOR_INPUT | State.CANCEL | State.PAUSE | State.ACCEPT> {
 		assertType(this._session);
 		assertType(this._strategy);
-		assertType(this._session.chatModel.requestInProgress);
+		assertType(this._session.chatModel.requestInProgress.get());
 
 		this._ctxRequestInProgress.set(true);
 
@@ -1429,7 +1429,7 @@ export class InlineChatController2 implements IEditorContribution {
 				entry?.enableReviewModeUntilSettled();
 			}
 
-			const inProgress = session.chatModel.requestInProgressObs.read(r);
+			const inProgress = session.chatModel.requestInProgress.read(r);
 			this._zone.value.widget.domNode.classList.toggle('request-in-progress', inProgress);
 			if (!inProgress) {
 				this._zone.value.widget.chatWidget.setInputPlaceholder(localize('placeholder', "Edit, refactor, and generate code"));

--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChatSessionServiceImpl.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChatSessionServiceImpl.ts
@@ -392,7 +392,7 @@ export class InlineChatSessionServiceImpl implements IInlineChatSessionService {
 					&& !entry.isCurrentlyBeingModifiedBy.read(r);
 			});
 
-			if (allSettled && !chatModel.requestInProgress) {
+			if (allSettled && !chatModel.requestInProgress.read(undefined)) {
 				// self terminate
 				store.dispose();
 			}

--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChatWidget.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChatWidget.ts
@@ -209,7 +209,7 @@ export class InlineChatWidget {
 
 			viewModelStore.add(viewModel.onDidChange(() => {
 
-				this._requestInProgress.set(viewModel.requestInProgress, undefined);
+				this._requestInProgress.set(viewModel.model.requestInProgress.get(), undefined);
 
 				const last = viewModel.getItems().at(-1);
 				toolbar2.context = last;

--- a/src/vs/workbench/contrib/inlineChat/test/browser/inlineChatController.test.ts
+++ b/src/vs/workbench/contrib/inlineChat/test/browser/inlineChatController.test.ts
@@ -919,7 +919,7 @@ suite('InlineChatController', function () {
 
 		await (await chatService.sendRequest(newSession.chatModel.sessionResource, 'Existing', { location: ChatAgentLocation.EditorInline }))?.responseCreatedPromise;
 
-		assert.strictEqual(newSession.chatModel.requestInProgress, true);
+		assert.strictEqual(newSession.chatModel.requestInProgress.get(), true);
 
 		const response = newSession.chatModel.lastRequest?.response;
 		assertType(response);

--- a/src/vs/workbench/contrib/mcp/browser/mcpCommands.ts
+++ b/src/vs/workbench/contrib/mcp/browser/mcpCommands.ts
@@ -195,7 +195,7 @@ export class McpConfirmationServerOptionsCommand extends Action2 {
 			if (tool?.source.type === 'mcp') {
 				accessor.get(ICommandService).executeCommand(McpCommandIds.ServerOptions, tool.source.definitionId);
 			}
-		} else if (arg.kind === 'elicitation') {
+		} else if (arg.kind === 'elicitation2') {
 			if (arg.source?.type === 'mcp') {
 				accessor.get(ICommandService).executeCommand(McpCommandIds.ServerOptions, arg.source.definitionId);
 			}

--- a/src/vs/workbench/contrib/mcp/browser/mcpElicitationService.ts
+++ b/src/vs/workbench/contrib/mcp/browser/mcpElicitationService.ts
@@ -18,7 +18,7 @@ import { IOpenerService } from '../../../../platform/opener/common/opener.js';
 import { IQuickInputService, IQuickPick, IQuickPickItem } from '../../../../platform/quickinput/common/quickInput.js';
 import { ChatElicitationRequestPart } from '../../chat/browser/chatElicitationRequestPart.js';
 import { ChatModel } from '../../chat/common/chatModel.js';
-import { IChatService } from '../../chat/common/chatService.js';
+import { ElicitationState, IChatService } from '../../chat/common/chatService.js';
 import { LocalChatSessionUri } from '../../chat/common/chatUri.js';
 import { ElicitationKind, ElicitResult, IFormModeElicitResult, IMcpElicitationService, IMcpServer, IMcpToolCallContext, IUrlModeElicitResult, McpConnectionState, MpcResponseError } from '../common/mcpTypes.js';
 import { mcpServerToSourceData } from '../common/mcpTypesUtils.js';
@@ -26,8 +26,10 @@ import { MCP } from '../common/modelContextProtocol.js';
 
 const noneItem: IQuickPickItem = { id: undefined, label: localize('mcp.elicit.enum.none', 'None'), description: localize('mcp.elicit.enum.none.description', 'No selection'), alwaysShow: true };
 
-function isFormElicitation(params: MCP.ElicitRequest['params']): params is MCP.ElicitRequestFormParams {
-	return params.mode === 'form';
+type Pre20251125ElicitationParams = Omit<MCP.ElicitRequestFormParams, 'mode'> & { mode?: undefined };
+
+function isFormElicitation(params: MCP.ElicitRequest['params'] | Pre20251125ElicitationParams): params is (MCP.ElicitRequestFormParams | Pre20251125ElicitationParams) {
+	return params.mode === 'form' || (params.mode === undefined && !!(params as Pre20251125ElicitationParams).requestedSchema);
 }
 
 function isUrlElicitation(params: MCP.ElicitRequest['params']): params is MCP.ElicitRequestURLParams {
@@ -80,7 +82,7 @@ export class McpElicitationService implements IMcpElicitationService {
 		}
 	}
 
-	private async _elicitForm(server: IMcpServer, context: IMcpToolCallContext | undefined, elicitation: MCP.ElicitRequestFormParams, token: CancellationToken): Promise<IFormModeElicitResult> {
+	private async _elicitForm(server: IMcpServer, context: IMcpToolCallContext | undefined, elicitation: MCP.ElicitRequestFormParams | Pre20251125ElicitationParams, token: CancellationToken): Promise<IFormModeElicitResult> {
 		const store = new DisposableStore();
 		const value = await new Promise<MCP.ElicitResult>(resolve => {
 			const chatModel = context?.chatSessionId && this._chatService.getSession(LocalChatSessionUri.forSession(context.chatSessionId));
@@ -97,13 +99,12 @@ export class McpElicitationService implements IMcpElicitationService {
 							const p = this._doElicitForm(elicitation, token);
 							resolve(p);
 							const result = await p;
-							part.state = result.action === 'accept' ? 'accepted' : 'rejected';
 							part.acceptedResult = result.content;
+							return result.action === 'accept' ? ElicitationState.Accepted : ElicitationState.Rejected;
 						},
 						() => {
 							resolve({ action: 'decline' });
-							part.state = 'rejected';
-							return Promise.resolve();
+							return Promise.resolve(ElicitationState.Rejected);
 						},
 						mcpServerToSourceData(server),
 					);
@@ -166,12 +167,12 @@ export class McpElicitationService implements IMcpElicitationService {
 						async () => {
 							const result = await this._doElicitUrl(elicitation, token);
 							resolve(result);
-							part.state = result.action === 'accept' ? 'accepted' : 'rejected';
+							completePromise.then(() => part.hide());
+							return result.action === 'accept' ? ElicitationState.Accepted : ElicitationState.Rejected;
 						},
 						() => {
 							resolve({ action: 'decline' });
-							part.state = 'rejected';
-							return Promise.resolve();
+							return Promise.resolve(ElicitationState.Rejected);
 						},
 						mcpServerToSourceData(server),
 					);
@@ -216,7 +217,7 @@ export class McpElicitationService implements IMcpElicitationService {
 		return { action: 'decline' };
 	}
 
-	private async _doElicitForm(elicitation: MCP.ElicitRequestFormParams, token: CancellationToken): Promise<MCP.ElicitResult> {
+	private async _doElicitForm(elicitation: MCP.ElicitRequestFormParams | Pre20251125ElicitationParams, token: CancellationToken): Promise<MCP.ElicitResult> {
 		const quickPick = this._quickInputService.createQuickPick<IQuickPickItem>();
 		const store = new DisposableStore();
 

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/monitoring/outputMonitor.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/monitoring/outputMonitor.ts
@@ -16,7 +16,7 @@ import { ExtensionIdentifier } from '../../../../../../../platform/extensions/co
 import { IChatWidgetService } from '../../../../../chat/browser/chat.js';
 import { ChatElicitationRequestPart } from '../../../../../chat/browser/chatElicitationRequestPart.js';
 import { ChatModel } from '../../../../../chat/common/chatModel.js';
-import { IChatService } from '../../../../../chat/common/chatService.js';
+import { ElicitationState, IChatService } from '../../../../../chat/common/chatService.js';
 import { ChatAgentLocation } from '../../../../../chat/common/constants.js';
 import { ChatMessageRole, ILanguageModelsService } from '../../../../../chat/common/languageModels.js';
 import { IToolInvocationContext } from '../../../../../chat/common/languageModelToolsService.js';
@@ -650,7 +650,6 @@ export class OutputMonitor extends Disposable implements IOutputMonitor {
 				acceptLabel,
 				rejectLabel,
 				async (value: IAction | true) => {
-					thePart.state = 'accepted';
 					thePart.hide();
 					this._promptPart = undefined;
 					try {
@@ -659,9 +658,10 @@ export class OutputMonitor extends Disposable implements IOutputMonitor {
 					} catch {
 						resolve(undefined);
 					}
+
+					return ElicitationState.Accepted;
 				},
 				async () => {
-					thePart.state = 'rejected';
 					thePart.hide();
 					this._promptPart = undefined;
 					try {
@@ -670,6 +670,8 @@ export class OutputMonitor extends Disposable implements IOutputMonitor {
 					} catch {
 						resolve(undefined);
 					}
+
+					return ElicitationState.Rejected;
 				},
 				undefined, // source
 				moreActions,


### PR DESCRIPTION
With a side quest that makes elicitations correctly trigger this, which
involved refactoring their state into an observable.

Also swap requestInProgress/Obs to a single requestInProgress observable.
Synchronous callers can just `.get()` it as needed.


Refs #277318