### PR TITLE
Clean up typings and type checks for chat sessions

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsView.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsView.ts
@@ -50,6 +50,7 @@ import { IChatWidgetService } from '../chat.js';
 import { AGENT_SESSIONS_VIEW_ID, AGENT_SESSIONS_VIEW_CONTAINER_ID, AgentSessionProviders } from './agentSessions.js';
 import { TreeFindMode } from '../../../../../base/browser/ui/tree/abstractTree.js';
 import { SIDE_GROUP } from '../../../../services/editor/common/editorService.js';
+import { IMarshalledChatSessionContext } from '../actions/chatSessionActions.js';
 
 export class AgentSessionsView extends ViewPane {
 
@@ -160,7 +161,7 @@ export class AgentSessionsView extends ViewPane {
 			this.editorGroupsService
 		)));
 
-		const marshalledSession = { session, $mid: MarshalledId.ChatSessionContext };
+		const marshalledSession: IMarshalledChatSessionContext = { session, $mid: MarshalledId.ChatSessionContext };
 		const { secondary } = getActionBarActions(menu.getActions({ arg: marshalledSession, shouldForwardArgs: true }), 'inline'); this.contextMenuService.showContextMenu({
 			getActions: () => secondary,
 			getAnchor: () => anchor,

--- a/src/vs/workbench/contrib/chat/browser/chatSessions/common.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSessions/common.ts
@@ -23,9 +23,6 @@ export type ChatSessionItemWithProvider = IChatSessionItem & {
 	relativeTime?: string;
 	relativeTimeFullWord?: string;
 	hideRelativeTime?: boolean;
-	timing?: {
-		startTime: number;
-	};
 };
 
 export function isChatSession(schemes: readonly string[], editor?: EditorInput): boolean {
@@ -56,10 +53,6 @@ export function findExistingChatEditorByUri(sessionUri: URI, editorGroupsService
 		}
 	}
 	return undefined;
-}
-
-export function isLocalChatSessionItem(item: ChatSessionItemWithProvider): boolean {
-	return item.provider.chatSessionType === localChatSessionType;
 }
 
 // Helper function to update relative time for chat sessions (similar to timeline)
@@ -129,7 +122,7 @@ export function processSessionsWithTimeGrouping(sessions: ChatSessionItemWithPro
 
 // Helper function to create context overlay for session items
 export function getSessionItemContextOverlay(
-	session: ChatSessionItemWithProvider,
+	session: IChatSessionItem,
 	provider?: IChatSessionItemProvider,
 	chatWidgetService?: IChatWidgetService,
 	chatService?: IChatService,

--- a/src/vs/workbench/contrib/chat/browser/chatSessions/view/sessionsTreeRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSessions/view/sessionsTreeRenderer.ts
@@ -42,12 +42,14 @@ import { IWorkbenchLayoutService, Position } from '../../../../../services/layou
 import { getLocalHistoryDateFormatter } from '../../../../localHistory/browser/localHistory.js';
 import { IChatService } from '../../../common/chatService.js';
 import { ChatSessionStatus, IChatSessionItem, IChatSessionItemProvider, IChatSessionsService, localChatSessionType } from '../../../common/chatSessionsService.js';
+import { LocalChatSessionUri } from '../../../common/chatUri.js';
 import { ChatConfiguration } from '../../../common/constants.js';
+import { IMarshalledChatSessionContext } from '../../actions/chatSessionActions.js';
 import { IChatWidgetService } from '../../chat.js';
 import { allowedChatMarkdownHtmlTags } from '../../chatContentMarkdownRenderer.js';
 import '../../media/chatSessions.css';
 import { ChatSessionTracker } from '../chatSessionTracker.js';
-import { ChatSessionItemWithProvider, extractTimestamp, getSessionItemContextOverlay, isLocalChatSessionItem, processSessionsWithTimeGrouping } from '../common.js';
+import { ChatSessionItemWithProvider, extractTimestamp, getSessionItemContextOverlay, processSessionsWithTimeGrouping } from '../common.js';
 
 interface ISessionTemplateData {
 	readonly container: HTMLElement;
@@ -230,7 +232,7 @@ export class SessionsRenderer extends Disposable implements ITreeRenderer<IChatS
 		const session = element.element as ChatSessionItemWithProvider;
 		// Add CSS class for local sessions
 		let editableData: IEditableData | undefined;
-		if (isLocalChatSessionItem(session)) {
+		if (LocalChatSessionUri.parseLocalSessionId(session.resource)) {
 			templateData.container.classList.add('local-session');
 			editableData = this.chatSessionsService.getEditableData(session.resource);
 		} else {
@@ -375,7 +377,7 @@ export class SessionsRenderer extends Disposable implements ITreeRenderer<IChatS
 			templateData.actionBar.clear();
 
 			// Create marshalled context for command execution
-			const marshalledSession = {
+			const marshalledSession: IMarshalledChatSessionContext = {
 				session: session,
 				$mid: MarshalledId.ChatSessionContext
 			};

--- a/src/vs/workbench/contrib/chat/browser/chatSessions/view/sessionsViewPane.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSessions/view/sessionsViewPane.ts
@@ -42,6 +42,7 @@ import { IChatService } from '../../../common/chatService.js';
 import { IChatSessionItemProvider, IChatSessionsService, localChatSessionType } from '../../../common/chatSessionsService.js';
 import { ChatConfiguration, ChatEditorTitleMaxLength } from '../../../common/constants.js';
 import { ACTION_ID_OPEN_CHAT } from '../../actions/chatActions.js';
+import { IMarshalledChatSessionContext } from '../../actions/chatSessionActions.js';
 import { IChatWidgetService } from '../../chat.js';
 import { IChatEditorOptions } from '../../chatEditor.js';
 import { ChatSessionTracker } from '../chatSessionTracker.js';
@@ -503,7 +504,7 @@ export class SessionsViewPane extends ViewPane {
 		const contextKeyService = this.contextKeyService.createOverlay(contextOverlay);
 
 		// Create marshalled context for command execution
-		const marshalledSession = {
+		const marshalledSession: IMarshalledChatSessionContext = {
 			session: session,
 			$mid: MarshalledId.ChatSessionContext
 		};


### PR DESCRIPTION
For #278114

- Try to simplify the picker item typings in chatActions. Difficult to understand original intent but some fields seem unused and other didn't seem to be working correctly for the `hasKey` checks

- Reuses typings for `IMarshalledChatSessionContext`

- Remove `isLocalChatSessionItem` and check the resource instead


