### PR TITLE
Adjust padding for select box dropdown and remove border radius styles

### DIFF
--- a/src/vs/base/browser/ui/selectBox/selectBoxCustom.css
+++ b/src/vs/base/browser/ui/selectBox/selectBoxCustom.css
@@ -42,21 +42,12 @@
 }
 
 .monaco-select-box-dropdown-container > .select-box-details-pane {
-	padding: 5px;
+	padding: 5px 6px;
 }
 
 .monaco-select-box-dropdown-container > .select-box-dropdown-list-container .monaco-list .monaco-list-row {
 	cursor: pointer;
-}
-
-.monaco-select-box-dropdown-container > .select-box-dropdown-list-container .monaco-list .monaco-list-row:first-child {
-	border-top-left-radius: 5px;
-	border-top-right-radius: 5px;
-}
-
-.monaco-select-box-dropdown-container > .select-box-dropdown-list-container .monaco-list .monaco-list-row:last-child {
-	border-bottom-left-radius: 5px;
-	border-bottom-right-radius: 5px;
+	padding-left: 2px;
 }
 
 .monaco-select-box-dropdown-container > .select-box-dropdown-list-container .monaco-list .monaco-list-row > .option-text {


### PR DESCRIPTION
Modify the padding for the select box dropdown to improve layout and remove border radius styles for a cleaner appearance.

Aligns listbox content with select content & removes any radius mismatch on hovered list items:

<img width="877" height="547" alt="image" src="https://github.com/user-attachments/assets/5c27f335-f91c-4a30-8252-5cd8fbeea2f6" />


