### PR TITLE
fix: possible memory leak with decoration registration

### DIFF
--- a/src/vs/editor/browser/services/codeEditorService.ts
+++ b/src/vs/editor/browser/services/codeEditorService.ts
@@ -43,7 +43,7 @@ export interface ICodeEditorService {
 	 */
 	getFocusedCodeEditor(): ICodeEditor | null;
 
-	registerDecorationType(description: string, key: string, options: IDecorationRenderOptions, parentTypeKey?: string, editor?: ICodeEditor): void;
+	registerDecorationType(description: string, key: string, options: IDecorationRenderOptions, parentTypeKey?: string, editor?: ICodeEditor): IDisposable;
 	listDecorationTypes(): string[];
 	removeDecorationType(key: string): void;
 	resolveDecorationOptions(typeKey: string, writable: boolean): IModelDecorationOptions;

--- a/src/vs/workbench/contrib/chat/browser/contrib/chatInputEditorContrib.ts
+++ b/src/vs/workbench/contrib/chat/browser/contrib/chatInputEditorContrib.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { MarkdownString } from '../../../../../base/common/htmlContent.js';
-import { Disposable, MutableDisposable, toDisposable } from '../../../../../base/common/lifecycle.js';
+import { Disposable, MutableDisposable } from '../../../../../base/common/lifecycle.js';
 import { autorun } from '../../../../../base/common/observable.js';
 import { themeColorFromId } from '../../../../../base/common/themables.js';
 import { URI } from '../../../../../base/common/uri.js';
@@ -83,10 +83,7 @@ class InputEditorDecorations extends Disposable {
 	) {
 		super();
 
-		this.codeEditorService.registerDecorationType(decorationDescription, placeholderDecorationType, {});
-
 		this.registeredDecorationTypes();
-
 		this.triggerInputEditorDecorationsUpdate();
 		this._register(this.widget.inputEditor.onDidChangeModelContent(() => this.triggerInputEditorDecorationsUpdate()));
 		this._register(this.widget.onDidChangeParsedInput(() => this.triggerInputEditorDecorationsUpdate()));
@@ -123,28 +120,22 @@ class InputEditorDecorations extends Disposable {
 	}
 
 	private registeredDecorationTypes() {
-
-		this.codeEditorService.registerDecorationType(decorationDescription, slashCommandTextDecorationType, {
+		this._register(this.codeEditorService.registerDecorationType(decorationDescription, placeholderDecorationType, {}));
+		this._register(this.codeEditorService.registerDecorationType(decorationDescription, slashCommandTextDecorationType, {
 			color: themeColorFromId(chatSlashCommandForeground),
 			backgroundColor: themeColorFromId(chatSlashCommandBackground),
 			borderRadius: '3px'
-		});
-		this.codeEditorService.registerDecorationType(decorationDescription, variableTextDecorationType, {
+		}));
+		this._register(this.codeEditorService.registerDecorationType(decorationDescription, variableTextDecorationType, {
 			color: themeColorFromId(chatSlashCommandForeground),
 			backgroundColor: themeColorFromId(chatSlashCommandBackground),
 			borderRadius: '3px'
-		});
-		this.codeEditorService.registerDecorationType(decorationDescription, dynamicVariableDecorationType, {
+		}));
+		this._register(this.codeEditorService.registerDecorationType(decorationDescription, dynamicVariableDecorationType, {
 			color: themeColorFromId(chatSlashCommandForeground),
 			backgroundColor: themeColorFromId(chatSlashCommandBackground),
 			borderRadius: '3px',
 			rangeBehavior: TrackedRangeStickiness.NeverGrowsWhenTypingAtEdges
-		});
-
-		this._register(toDisposable(() => {
-			this.codeEditorService.removeDecorationType(variableTextDecorationType);
-			this.codeEditorService.removeDecorationType(dynamicVariableDecorationType);
-			this.codeEditorService.removeDecorationType(slashCommandTextDecorationType);
 		}));
 	}
 

--- a/src/vs/workbench/contrib/comments/browser/commentsController.ts
+++ b/src/vs/workbench/contrib/comments/browser/commentsController.ts
@@ -557,7 +557,7 @@ export class CommentController implements IEditorContribution {
 		}));
 
 		this.onModelChanged();
-		this.codeEditorService.registerDecorationType('comment-controller', COMMENTEDITOR_DECORATION_KEY, {});
+		this.globalToDispose.add(this.codeEditorService.registerDecorationType('comment-controller', COMMENTEDITOR_DECORATION_KEY, {}));
 		this.globalToDispose.add(
 			this.commentService.registerContinueOnCommentProvider({
 				provideContinueOnComments: () => {

--- a/src/vs/workbench/contrib/debug/browser/breakpointWidget.ts
+++ b/src/vs/workbench/contrib/debug/browser/breakpointWidget.ts
@@ -141,7 +141,7 @@ export class BreakpointWidget extends ZoneWidget implements IPrivateBreakpointWi
 				this.dispose();
 			}
 		}));
-		this.codeEditorService.registerDecorationType('breakpoint-widget', DECORATION_KEY, {});
+		this.store.add(this.codeEditorService.registerDecorationType('breakpoint-widget', DECORATION_KEY, {}));
 
 		this.create();
 	}

--- a/src/vs/workbench/contrib/debug/browser/repl.ts
+++ b/src/vs/workbench/contrib/debug/browser/repl.ts
@@ -164,7 +164,7 @@ export class Repl extends FilterViewPane implements IHistoryNavigationWidget {
 		this.replOptions = this._register(this.instantiationService.createInstance(ReplOptions, this.id, () => this.getLocationBasedColors().background));
 		this._register(this.replOptions.onDidChange(() => this.onDidStyleChange()));
 
-		codeEditorService.registerDecorationType('repl-decoration', DECORATION_KEY, {});
+		this._register(codeEditorService.registerDecorationType('repl-decoration', DECORATION_KEY, {}));
 		this.multiSessionRepl.set(this.isMultiSessionView);
 		this.registerListeners();
 	}

--- a/src/vs/workbench/contrib/interactive/browser/interactiveEditor.ts
+++ b/src/vs/workbench/contrib/interactive/browser/interactiveEditor.ts
@@ -174,7 +174,7 @@ export class InteractiveEditor extends EditorPane implements IEditorPaneWithScro
 		this._notebookOptions = instantiationService.createInstance(NotebookOptions, this.window, true, { cellToolbarInteraction: 'hover', globalToolbar: true, stickyScrollEnabled: false, dragAndDropEnabled: false, disableRulers: true });
 		this._editorMemento = this.getEditorMemento<InteractiveEditorViewState>(editorGroupService, textResourceConfigurationService, INTERACTIVE_EDITOR_VIEW_STATE_PREFERENCE_KEY);
 
-		codeEditorService.registerDecorationType('interactive-decoration', DECORATION_KEY, {});
+		this._register(codeEditorService.registerDecorationType('interactive-decoration', DECORATION_KEY, {}));
 		this._register(this._keybindingService.onDidUpdateKeybindings(this._updateInputHint, this));
 		this._register(this._notebookExecutionStateService.onDidChangeExecution((e) => {
 			if (e.type === NotebookExecutionType.cell && isEqual(e.notebook, this._notebookWidget.value?.viewModel?.notebookDocument.uri)) {

--- a/src/vs/workbench/contrib/notebook/browser/notebook.contribution.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebook.contribution.ts
@@ -316,7 +316,7 @@ export class NotebookContribution extends Disposable implements IWorkbenchContri
 		}));
 
 		// register comment decoration
-		this.codeEditorService.registerDecorationType('comment-controller', COMMENTEDITOR_DECORATION_KEY, {});
+		this._register(this.codeEditorService.registerDecorationType('comment-controller', COMMENTEDITOR_DECORATION_KEY, {}));
 	}
 
 	// Add or remove the cell undo redo comparison key based on the user setting

--- a/src/vs/workbench/contrib/testing/browser/testingDecorations.ts
+++ b/src/vs/workbench/contrib/testing/browser/testingDecorations.ts
@@ -158,7 +158,7 @@ export class TestingDecorationService extends Disposable implements ITestingDeco
 		@IModelService private readonly modelService: IModelService,
 	) {
 		super();
-		codeEditorService.registerDecorationType('test-message-decoration', TestMessageDecoration.decorationId, {}, undefined);
+		this._register(codeEditorService.registerDecorationType('test-message-decoration', TestMessageDecoration.decorationId, {}, undefined));
 
 		this._register(modelService.onModelRemoved(e => this.decorationCache.delete(e.uri)));
 
@@ -394,7 +394,7 @@ export class TestingDecorations extends Disposable implements IEditorContributio
 	) {
 		super();
 
-		codeEditorService.registerDecorationType('test-message-decoration', TestMessageDecoration.decorationId, {}, undefined, editor);
+		this._register(codeEditorService.registerDecorationType('test-message-decoration', TestMessageDecoration.decorationId, {}, undefined, editor));
 
 		this.attachModel(editor.getModel()?.uri);
 		this._register(decorations.onDidChange(() => {


### PR DESCRIPTION
Fixes a few possible memory leaks with decoration registration by registering the returned disposable. 


### Details
Currently decorations are registered like this:

```ts
this.codeEditorService.registerDecorationType(decorationDescription, placeholderDecorationType, {});
```

But it can be easy to forget that most likely the decoration also needs to be removed on dispose:


```ts
this.codeEditorService.removeDecorationType(placeholderDecorationType);
```


### Change

The change is to switch to using `this._register`, which seems to make it easier to register the decoration as a disposable. Now for example in `commentsController` or `breakPointWidget` the decoration registration is registered as a disposable.


