### PR TITLE
chore: disallow crashpad forwarding crashes to system crash handler

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -528,7 +528,8 @@ function configureCrashReporter(): void {
 		productName: process.env['VSCODE_DEV'] ? `${productName} Dev` : productName,
 		submitURL,
 		uploadToServer,
-		compress: true
+		compress: true,
+		ignoreSystemCrashHandler: true
 	});
 }
 


### PR DESCRIPTION
We don't want to forward when crashpad has already recorded it.

Refs https://source.chromium.org/chromium/chromium/src/+/main:third_party/crashpad/crashpad/client/crashpad_info.h;l=204-221

cc @lszomoru 