### PR TITLE
fix hover scrollbar not appearing when content overflows

### DIFF
--- a/src/vs/platform/hover/browser/hoverWidget.ts
+++ b/src/vs/platform/hover/browser/hoverWidget.ts
@@ -572,6 +572,7 @@ export class HoverWidget extends Widget implements IHoverWidget {
 		}
 
 		this._hover.containerDomNode.style.maxHeight = `${maxHeight}px`;
+		this._hover.contentsDomNode.style.maxHeight = `${maxHeight}px`;
 		if (this._hover.contentsDomNode.clientHeight < this._hover.contentsDomNode.scrollHeight) {
 			// Add padding for a vertical scrollbar
 			const extraRightPadding = `${this._hover.scrollbar.options.verticalScrollbarSize}px`;


### PR DESCRIPTION
Fixes the issue where hover tooltips with `maxHeightRatio` option don't show scrollbars when content exceeds the maximum height.

### Problem
When `IHoverService.showInstantHover()` is called with `appearance.maxHeightRatio`, the scrollbar doesn't appear even when content overflows. This affects:
- Terminal tab hovers
- Status bar hovers  
- Other components using `maxHeightRatio`

### Root Cause
`adjustHoverMaxHeight()` only set `maxHeight` on `containerDomNode`, but not on `contentsDomNode`. This caused `DomScrollableElement.scanDomNode()` to see `clientHeight === scrollHeight` (both equal to full content height), preventing scrollbar detection.

### Solution
Set `maxHeight` on both `containerDomNode` and `contentsDomNode`:
- `containerDomNode`: Controls the visible window size
- `contentsDomNode`: Enables scrollbar detection (`clientHeight < scrollHeight`)

This aligns with the existing implementation in `ContentHoverWidget._setHoverWidgetMaxDimensions()`.

### Testing

Manual Test:
Tested with terminal tab hovers containing long status information.

|Before|After|
|---|---|
|<img width="751" height="412" alt="image" src="https://github.com/user-attachments/assets/c39b3e74-821c-465b-bf85-eb7db0249995" />|<img width="769" height="414" alt="image" src="https://github.com/user-attachments/assets/3c8e57b0-ffc8-4cd3-a949-e6e9e7273f70" />|
