### PR TITLE
mergeEditor; mis-labeled button (swapped incoming/current)

### DIFF
--- a/src/vs/workbench/contrib/mergeEditor/browser/commands/commands.ts
+++ b/src/vs/workbench/contrib/mergeEditor/browser/commands/commands.ts
@@ -518,7 +518,7 @@ export class AcceptAllInput1 extends MergeEditorAction {
 		super({
 			id: 'merge.acceptAllInput1',
 			category: mergeEditorCategory,
-			title: localize2('merge.acceptAllInput1', "Accept All Incoming Changes from Left"),
+			title: localize2('merge.acceptAllInput1', "Accept All Current Changes from Left"),
 			f1: true,
 			precondition: ctxIsMergeEditor,
 			menu: { id: MenuId.MergeInput1Toolbar, group: 'primary' },
@@ -536,7 +536,7 @@ export class AcceptAllInput2 extends MergeEditorAction {
 		super({
 			id: 'merge.acceptAllInput2',
 			category: mergeEditorCategory,
-			title: localize2('merge.acceptAllInput2', "Accept All Current Changes from Right"),
+			title: localize2('merge.acceptAllInput2', "Accept All Incoming Changes from Right"),
 			f1: true,
 			precondition: ctxIsMergeEditor,
 			menu: { id: MenuId.MergeInput2Toolbar, group: 'primary' },

--- a/src/vs/workbench/contrib/mergeEditor/browser/mergeEditorAccessibilityHelp.ts
+++ b/src/vs/workbench/contrib/mergeEditor/browser/mergeEditorAccessibilityHelp.ts
@@ -28,7 +28,7 @@ export class MergeEditorAccessibilityHelpProvider implements IAccessibleViewImpl
 		const content = [
 			localize('msg1', "You are in a merge editor."),
 			localize('msg2', "Navigate between merge conflicts using the commands Go to Next Unhandled Conflict{0} and Go to Previous Unhandled Conflict{1}.", '<keybinding:merge.goToNextUnhandledConflict>', '<keybinding:merge.goToPreviousUnhandledConflict>'),
-			localize('msg3', "Run the command Merge Editor: Accept All Incoming Changes from the Left{0} and Merge Editor: Accept All Current Changes from the Right{1}", '<keybinding:merge.acceptAllInput1>', '<keybinding:merge.acceptAllInput2>'),
+			localize('msg3', "Run the command Merge Editor: Accept All Current Changes from the Left{0} and Merge Editor: Accept All Incoming Changes from the Right{1}", '<keybinding:merge.acceptAllInput1>', '<keybinding:merge.acceptAllInput2>'),
 			localize('msg4', "Complete the Merge{0}.", '<keybinding:mergeEditor.acceptMerge>'),
 			localize('msg5', "Toggle between merge editor inputs, incoming and current changes {0}.", '<keybinding:mergeEditor.toggleBetweenInputs>'),
 		];


### PR DESCRIPTION
"Accept all..." buttons are mis-labelled and confusing. :recycle: 

This was reported in #251975 