### PR TITLE
Fix purged notifications not returning promise.

### DIFF
--- a/src/vs/workbench/browser/parts/notifications/notificationsToasts.ts
+++ b/src/vs/workbench/browser/parts/notifications/notificationsToasts.ts
@@ -319,6 +319,7 @@ export class NotificationsToasts extends Themable implements INotificationsToast
 				) {
 					hideAfterTimeout();
 				} else {
+					item.close();							// ensures promise return of 'undefined' for purged notifications
 					this.removeToast(item);
 				}
 			}, NotificationsToasts.PURGE_TIMEOUT[item.severity]);


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
## The Issue
Toast notifications were not properly returning a promise when purged/auto-dismissed.
## The Explanation
Within the code, toast notifications are set to have an auto-purge timeout based on the severity of the `NotificationViewItem` passed to it. The code itself checks for when to keep the toast open (when window isn't in focus, toast is in focus, etc.) and calls `removeToast(item)` if all those checks are false. This, however, does not seem to properly call the `NotificationViewItem.close()` method which is what will return the promise back to whatever called it.
## The Fix
Calling the `.close()` method on the item before the call of `removeToast()` fixes the promise returning and properly closes the item, potentially preventing the promise from being left to hang.