### PR TITLE
chat: add additional timing information on the model

### DIFF
--- a/src/vs/base/common/types.ts
+++ b/src/vs/base/common/types.ts
@@ -348,6 +348,13 @@ export type DeepImmutable<T> = T extends (infer U)[]
  */
 export type SingleOrMany<T> = T | T[];
 
+/**
+ * Given a `type X = { foo?: string }` checking that an object `satisfies X`
+ * will ensure each property was explicitly defined, ensuring no properties
+ * are omitted or forgotten.
+ */
+export type WithDefinedProps<T> = { [K in keyof Required<T>]: T[K] };
+
 
 /**
  * A type that recursively makes all properties of `T` required

--- a/src/vs/workbench/contrib/chat/common/chatModel.ts
+++ b/src/vs/workbench/contrib/chat/common/chatModel.ts
@@ -13,9 +13,10 @@ import { ResourceMap } from '../../../../base/common/map.js';
 import { revive } from '../../../../base/common/marshalling.js';
 import { Schemas } from '../../../../base/common/network.js';
 import { equals } from '../../../../base/common/objects.js';
-import { IObservable, autorun, autorunSelfDisposable, observableFromEvent, observableSignalFromEvent } from '../../../../base/common/observable.js';
+import { IObservable, autorun, autorunSelfDisposable, derived, observableFromEvent, observableSignalFromEvent, observableValue } from '../../../../base/common/observable.js';
 import { basename, isEqual } from '../../../../base/common/resources.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
+import { WithDefinedProps } from '../../../../base/common/types.js';
 import { URI, UriComponents, UriDto, isUriComponents } from '../../../../base/common/uri.js';
 import { generateUuid } from '../../../../base/common/uuid.js';
 import { IRange } from '../../../../editor/common/core/range.js';
@@ -185,9 +186,20 @@ export interface IChatResponseModel {
 	readonly response: IResponse;
 	/** Entire response from the model. */
 	readonly entireResponse: IResponse;
+	/** Milliseconds timestamp when this chat response was created. */
+	readonly timestamp: number;
+	/** Milliseconds timestamp when this chat response was completed or cancelled. */
+	readonly completedAt?: number;
+	/**
+	 * Adjusted millisecond timestamp that excludes the duration during which
+	 * the model was pending user confirmation. `Date.now() - confirmationAdjustedTimestamp`
+	 * will return the amount of time the response was busy generating content.
+	 * This is updated only when `isPendingConfirmation` changes state.
+	 */
+	readonly confirmationAdjustedTimestamp: IObservable<number>;
 	readonly isComplete: boolean;
 	readonly isCanceled: boolean;
-	readonly isPendingConfirmation: IObservable<boolean>;
+	readonly isPendingConfirmation: IObservable<{ startedWaitingAt: number } | undefined>;
 	readonly isInProgress: IObservable<boolean>;
 	readonly shouldBeRemovedOnSend: IChatRequestDisablement | undefined;
 	shouldBeBlocked: boolean;
@@ -737,8 +749,7 @@ export interface IChatResponseModelParameters {
 	agent?: IChatAgentData;
 	slashCommand?: IChatAgentCommand;
 	requestId: string;
-	isComplete?: boolean;
-	isCanceled?: boolean;
+	timestamp?: number;
 	vote?: ChatAgentVoteDirection;
 	voteDownReason?: ChatAgentVoteDownReason;
 	result?: IChatAgentResult;
@@ -747,11 +758,23 @@ export interface IChatResponseModelParameters {
 	shouldBeRemovedOnSend?: IChatRequestDisablement;
 	shouldBeBlocked?: boolean;
 	restoredId?: string;
+	modelState?: ResponseModelStateT;
+	timeSpentWaiting?: number;
 	/**
 	 * undefined means it will be set later.
 	*/
 	codeBlockInfos: ICodeBlockInfo[] | undefined;
 }
+
+const enum ResponseModelState {
+	Pending,
+	Complete,
+	Cancelled,
+}
+
+type ResponseModelStateT =
+	| { value: ResponseModelState.Pending }
+	| { value: ResponseModelState.Complete | ResponseModelState.Cancelled; completedAt: number };
 
 export class ChatResponseModel extends Disposable implements IChatResponseModel {
 	private readonly _onDidChange = this._register(new Emitter<ChatResponseModelChangeReason>());
@@ -762,14 +785,17 @@ export class ChatResponseModel extends Disposable implements IChatResponseModel 
 	private _session: ChatModel;
 	private _agent: IChatAgentData | undefined;
 	private _slashCommand: IChatAgentCommand | undefined;
-	private _isComplete: boolean;
-	private _isCanceled: boolean;
+	private _modelState = observableValue<ResponseModelStateT>(this, { value: ResponseModelState.Pending });
 	private _vote?: ChatAgentVoteDirection;
 	private _voteDownReason?: ChatAgentVoteDownReason;
 	private _result?: IChatAgentResult;
 	private _shouldBeRemovedOnSend: IChatRequestDisablement | undefined;
 	public readonly isCompleteAddedRequest: boolean;
 	private _shouldBeBlocked: boolean = false;
+	private readonly _timestamp: number;
+	private _timeSpentWaitingAccumulator: number;
+
+	public confirmationAdjustedTimestamp: IObservable<number>;
 
 	public get shouldBeBlocked() {
 		return this._shouldBeBlocked;
@@ -788,7 +814,11 @@ export class ChatResponseModel extends Disposable implements IChatResponseModel 
 	}
 
 	public get isComplete(): boolean {
-		return this._isComplete;
+		return this._modelState.get().value !== ResponseModelState.Pending;
+	}
+
+	public get timestamp(): number {
+		return this._timestamp;
 	}
 
 	public set shouldBeRemovedOnSend(disablement: IChatRequestDisablement | undefined) {
@@ -797,7 +827,15 @@ export class ChatResponseModel extends Disposable implements IChatResponseModel 
 	}
 
 	public get isCanceled(): boolean {
-		return this._isCanceled;
+		return this._modelState.get().value === ResponseModelState.Cancelled;
+	}
+
+	public get completedAt(): number | undefined {
+		const state = this._modelState.get();
+		if (state.value === ResponseModelState.Complete || state.value === ResponseModelState.Cancelled) {
+			return state.completedAt;
+		}
+		return undefined;
 	}
 
 	public get vote(): ChatAgentVoteDirection | undefined {
@@ -871,7 +909,7 @@ export class ChatResponseModel extends Disposable implements IChatResponseModel 
 	}
 
 
-	readonly isPendingConfirmation: IObservable<boolean>;
+	readonly isPendingConfirmation: IObservable<{ startedWaitingAt: number } | undefined>;
 
 	readonly isInProgress: IObservable<boolean>;
 
@@ -901,8 +939,11 @@ export class ChatResponseModel extends Disposable implements IChatResponseModel 
 		this._agent = params.agent;
 		this._slashCommand = params.slashCommand;
 		this.requestId = params.requestId;
-		this._isComplete = params.isComplete ?? false;
-		this._isCanceled = params.isCanceled ?? false;
+		this._timestamp = params.timestamp || Date.now();
+		if (params.modelState) {
+			this._modelState.set(params.modelState, undefined);
+		}
+		this._timeSpentWaitingAccumulator = params.timeSpentWaiting || 0;
 		this._vote = params.vote;
 		this._voteDownReason = params.voteDownReason;
 		this._result = params.result;
@@ -919,7 +960,7 @@ export class ChatResponseModel extends Disposable implements IChatResponseModel 
 
 		const signal = observableSignalFromEvent(this, this.onDidChange);
 
-		this.isPendingConfirmation = signal.map((_value, r) => {
+		const _isPendingBool = signal.map((_value, r) => {
 
 			signal.read(r);
 
@@ -930,13 +971,15 @@ export class ChatResponseModel extends Disposable implements IChatResponseModel 
 			);
 		});
 
+		this.isPendingConfirmation = _isPendingBool.map(pending => pending ? { startedWaitingAt: Date.now() } : undefined);
+
 		this.isInProgress = signal.map((_value, r) => {
 
 			signal.read(r);
 
-			return !this.isPendingConfirmation.read(r)
+			return !_isPendingBool.read(r)
 				&& !this.shouldBeRemovedOnSend
-				&& !this._isComplete;
+				&& this._modelState.read(r).value === ResponseModelState.Pending;
 		});
 
 		this._register(this._response.onDidChangeValue(() => this._onDidChange.fire(defaultChatResponseModelChangeReason)));
@@ -952,6 +995,19 @@ export class ChatResponseModel extends Disposable implements IChatResponseModel 
 				}
 			}
 		}));
+
+		let lastStartedWaitingAt: number | undefined = undefined;
+		this.confirmationAdjustedTimestamp = derived(reader => {
+			const pending = this.isPendingConfirmation.read(reader);
+			if (pending && !lastStartedWaitingAt) {
+				lastStartedWaitingAt = pending.startedWaitingAt;
+			} else if (!pending && lastStartedWaitingAt) {
+				this._timeSpentWaitingAccumulator += Date.now() - lastStartedWaitingAt;
+				lastStartedWaitingAt = undefined;
+			}
+
+			return this._timestamp + this._timeSpentWaitingAccumulator;
+		}).recomputeInitiallyAndOnChange(this._store);
 	}
 
 	initializeCodeBlockInfos(codeBlockInfo: ICodeBlockInfo[]): void {
@@ -1011,13 +1067,12 @@ export class ChatResponseModel extends Disposable implements IChatResponseModel 
 			this._response.clear();
 		}
 
-		this._isComplete = true;
+		this._modelState.set({ value: ResponseModelState.Complete, completedAt: Date.now() }, undefined);
 		this._onDidChange.fire({ reason: 'completedRequest' });
 	}
 
 	cancel(): void {
-		this._isComplete = true;
-		this._isCanceled = true;
+		this._modelState.set({ value: ResponseModelState.Cancelled, completedAt: Date.now() }, undefined);
 		this._onDidChange.fire({ reason: 'completedRequest' });
 	}
 
@@ -1060,6 +1115,26 @@ export class ChatResponseModel extends Disposable implements IChatResponseModel 
 		this._shouldBeRemovedOnSend = undefined;
 	}
 
+	toJSON(): ISerializableChatResponseData {
+		const modelState = this._modelState.get();
+		const pendingConfirmation = this.isPendingConfirmation.get();
+
+		return {
+			responseId: this.id,
+			result: this.result,
+			responseMarkdownInfo: this.codeBlockInfos?.map<ISerializableMarkdownInfo>(info => ({ suggestionId: info.suggestionId })),
+			followups: this.followups,
+			modelState: modelState.value === ResponseModelState.Pending ? { value: ResponseModelState.Cancelled, completedAt: Date.now() } : modelState,
+			vote: this.vote,
+			voteDownReason: this.voteDownReason,
+			slashCommand: this.slashCommand,
+			usedContext: this.usedContext,
+			contentReferences: this.contentReferences,
+			codeCitations: this.codeCitations,
+			timestamp: this._timestamp,
+			timeSpentWaiting: (pendingConfirmation ? Date.now() - pendingConfirmation.startedWaitingAt : 0) + this._timeSpentWaitingAccumulator,
+		} satisfies WithDefinedProps<ISerializableChatResponseData>;
+	}
 }
 
 
@@ -1073,6 +1148,8 @@ export interface IChatModel extends IDisposable {
 	readonly onDidChange: Event<IChatChangeEvent>;
 	/** @deprecated Use {@link sessionResource} instead */
 	readonly sessionId: string;
+	/** Milliseconds timestamp this chat model was created. */
+	readonly timestamp: number;
 	readonly sessionResource: URI;
 	readonly initialLocation: ChatAgentLocation;
 	readonly title: string;
@@ -1098,7 +1175,24 @@ export interface ISerializableChatsData {
 
 export type ISerializableChatAgentData = UriDto<IChatAgentData>;
 
-export interface ISerializableChatRequestData {
+interface ISerializableChatResponseData {
+	responseId?: string;
+	result?: IChatAgentResult; // Optional for backcompat
+	responseMarkdownInfo?: ISerializableMarkdownInfo[];
+	followups?: ReadonlyArray<IChatFollowup>;
+	modelState?: ResponseModelStateT;
+	vote?: ChatAgentVoteDirection;
+	voteDownReason?: ChatAgentVoteDownReason;
+	timestamp?: number;
+	slashCommand?: IChatAgentCommand;
+	/** For backward compat: should be optional */
+	usedContext?: IChatUsedContext;
+	contentReferences?: ReadonlyArray<IChatContentReference>;
+	codeCitations?: ReadonlyArray<IChatCodeCitation>;
+	timeSpentWaiting?: number;
+}
+
+export interface ISerializableChatRequestData extends ISerializableChatResponseData {
 	requestId: string;
 	message: string | IParsedChatRequest; // string => old format
 	/** Is really like "prompt data". This is the message in the format in which the agent gets it + variable values. */
@@ -1108,26 +1202,15 @@ export interface ISerializableChatRequestData {
 	/**Old, persisted name for shouldBeRemovedOnSend */
 	isHidden?: boolean;
 	shouldBeRemovedOnSend?: IChatRequestDisablement;
-	responseId?: string;
 	agent?: ISerializableChatAgentData;
 	workingSet?: UriComponents[];
-	slashCommand?: IChatAgentCommand;
 	// responseErrorDetails: IChatResponseErrorDetails | undefined;
-	result?: IChatAgentResult; // Optional for backcompat
-	followups: ReadonlyArray<IChatFollowup> | undefined;
-	isCanceled: boolean | undefined;
-	vote: ChatAgentVoteDirection | undefined;
-	voteDownReason?: ChatAgentVoteDownReason;
-	/** For backward compat: should be optional */
-	usedContext?: IChatUsedContext;
-	contentReferences?: ReadonlyArray<IChatContentReference>;
-	codeCitations?: ReadonlyArray<IChatCodeCitation>;
+	/** @deprecated modelState is used instead now */
+	isCanceled?: boolean;
 	timestamp?: number;
 	confirmation?: string;
 	editedFileEvents?: IChatAgentEditedFileEvent[];
 	modelId?: string;
-
-	responseMarkdownInfo: ISerializableMarkdownInfo[] | undefined;
 }
 
 export interface ISerializableMarkdownInfo {
@@ -1382,9 +1465,9 @@ export class ChatModel extends Disposable implements IChatModel {
 		return this._requests.at(-1);
 	}
 
-	private _creationDate: number;
-	get creationDate(): number {
-		return this._creationDate;
+	private _timestamp: number;
+	get timestamp(): number {
+		return this._timestamp;
 	}
 
 	private _lastMessageDate: number;
@@ -1461,8 +1544,8 @@ export class ChatModel extends Disposable implements IChatModel {
 		this._sessionResource = initialModelProps.resource ?? LocalChatSessionUri.forSession(this._sessionId);
 
 		this._requests = initialData ? this._deserialize(initialData) : [];
-		this._creationDate = (isValid && initialData.creationDate) || Date.now();
-		this._lastMessageDate = (isValid && initialData.lastMessageDate) || this._creationDate;
+		this._timestamp = (isValid && initialData.creationDate) || Date.now();
+		this._lastMessageDate = (isValid && initialData.lastMessageDate) || this._timestamp;
 		this._customTitle = isValid ? initialData.customTitle : undefined;
 
 		this._initialResponderUsername = initialData?.responderUsername;
@@ -1491,7 +1574,7 @@ export class ChatModel extends Disposable implements IChatModel {
 		});
 
 		this.requestNeedsInput = lastRequest.map((request, r) => {
-			return request?.response?.isPendingConfirmation.read(r) ?? false;
+			return !!request?.response?.isPendingConfirmation.read(r);
 		});
 	}
 
@@ -1565,13 +1648,14 @@ export class ChatModel extends Disposable implements IChatModel {
 						agent,
 						slashCommand: raw.slashCommand,
 						requestId: request.id,
-						isComplete: true,
-						isCanceled: raw.isCanceled,
+						modelState: raw.modelState || { value: raw.isCanceled ? ResponseModelState.Cancelled : ResponseModelState.Complete, completedAt: Date.now() },
 						vote: raw.vote,
+						timestamp: raw.timestamp,
 						voteDownReason: raw.voteDownReason,
 						result,
 						followups: raw.followups,
 						restoredId: raw.responseId,
+						timeSpentWaiting: raw.timeSpentWaiting,
 						shouldBeBlocked: request.shouldBeBlocked,
 						codeBlockInfos: raw.responseMarkdownInfo?.map<ICodeBlockInfo>(info => ({ suggestionId: info.suggestionId })),
 					});
@@ -1873,23 +1957,13 @@ export class ChatModel extends Disposable implements IChatModel {
 							}
 						})
 						: undefined,
-					responseId: r.response?.id,
 					shouldBeRemovedOnSend: r.shouldBeRemovedOnSend,
-					result: r.response?.result,
-					responseMarkdownInfo: r.response?.codeBlockInfos?.map<ISerializableMarkdownInfo>(info => ({ suggestionId: info.suggestionId })),
-					followups: r.response?.followups,
-					isCanceled: r.response?.isCanceled,
-					vote: r.response?.vote,
-					voteDownReason: r.response?.voteDownReason,
 					agent: agentJson,
-					slashCommand: r.response?.slashCommand,
-					usedContext: r.response?.usedContext,
-					contentReferences: r.response?.contentReferences,
-					codeCitations: r.response?.codeCitations,
 					timestamp: r.timestamp,
 					confirmation: r.confirmation,
 					editedFileEvents: r.editedFileEvents,
 					modelId: r.modelId,
+					...r.response?.toJSON(),
 				};
 			}),
 		};
@@ -1900,7 +1974,7 @@ export class ChatModel extends Disposable implements IChatModel {
 			version: 3,
 			...this.toExport(),
 			sessionId: this.sessionId,
-			creationDate: this._creationDate,
+			creationDate: this._timestamp,
 			isImported: this._isImported,
 			lastMessageDate: this._lastMessageDate,
 			customTitle: this._customTitle

--- a/src/vs/workbench/contrib/chat/test/common/__snapshots__/ChatService_can_deserialize.0.snap
+++ b/src/vs/workbench/contrib/chat/test/common/__snapshots__/ChatService_can_deserialize.0.snap
@@ -55,14 +55,7 @@
       },
       variableData: { variables: [  ] },
       response: [  ],
-      responseId: undefined,
       shouldBeRemovedOnSend: undefined,
-      result: { metadata: { metadataKey: "value" } },
-      responseMarkdownInfo: undefined,
-      followups: undefined,
-      isCanceled: false,
-      vote: undefined,
-      voteDownReason: undefined,
       agent: {
         name: "ChatProviderWithUsedContext",
         id: "ChatProviderWithUsedContext",
@@ -79,6 +72,20 @@
         slashCommands: [  ],
         disambiguation: [  ]
       },
+      timestamp: undefined,
+      confirmation: undefined,
+      editedFileEvents: undefined,
+      modelId: undefined,
+      responseId: undefined,
+      result: { metadata: { metadataKey: "value" } },
+      responseMarkdownInfo: undefined,
+      followups: undefined,
+      modelState: {
+        value: 1,
+        completedAt: undefined
+      },
+      vote: undefined,
+      voteDownReason: undefined,
       slashCommand: undefined,
       usedContext: {
         documents: [
@@ -99,10 +106,7 @@
       },
       contentReferences: [  ],
       codeCitations: [  ],
-      timestamp: undefined,
-      confirmation: undefined,
-      editedFileEvents: undefined,
-      modelId: undefined
+      timeSpentWaiting: 0
     }
   ]
 }

--- a/src/vs/workbench/contrib/chat/test/common/__snapshots__/ChatService_can_deserialize_with_response.0.snap
+++ b/src/vs/workbench/contrib/chat/test/common/__snapshots__/ChatService_can_deserialize_with_response.0.snap
@@ -55,14 +55,7 @@
       },
       variableData: { variables: [  ] },
       response: [  ],
-      responseId: undefined,
       shouldBeRemovedOnSend: undefined,
-      result: { errorDetails: { message: "No activated agent with id \"ChatProviderWithUsedContext\"" } },
-      responseMarkdownInfo: undefined,
-      followups: undefined,
-      isCanceled: false,
-      vote: undefined,
-      voteDownReason: undefined,
       agent: {
         name: "ChatProviderWithUsedContext",
         id: "ChatProviderWithUsedContext",
@@ -79,14 +72,25 @@
         slashCommands: [  ],
         disambiguation: [  ]
       },
+      timestamp: undefined,
+      confirmation: undefined,
+      editedFileEvents: undefined,
+      modelId: undefined,
+      responseId: undefined,
+      result: { errorDetails: { message: "No activated agent with id \"ChatProviderWithUsedContext\"" } },
+      responseMarkdownInfo: undefined,
+      followups: undefined,
+      modelState: {
+        value: 1,
+        completedAt: undefined
+      },
+      vote: undefined,
+      voteDownReason: undefined,
       slashCommand: undefined,
       usedContext: undefined,
       contentReferences: [  ],
       codeCitations: [  ],
-      timestamp: undefined,
-      confirmation: undefined,
-      editedFileEvents: undefined,
-      modelId: undefined
+      timeSpentWaiting: 0
     }
   ]
 }

--- a/src/vs/workbench/contrib/chat/test/common/__snapshots__/ChatService_can_serialize.1.snap
+++ b/src/vs/workbench/contrib/chat/test/common/__snapshots__/ChatService_can_serialize.1.snap
@@ -56,21 +56,7 @@
       },
       variableData: { variables: [  ] },
       response: [  ],
-      responseId: undefined,
       shouldBeRemovedOnSend: undefined,
-      result: { metadata: { metadataKey: "value" } },
-      responseMarkdownInfo: undefined,
-      followups: [
-        {
-          kind: "reply",
-          message: "Something else",
-          agentId: "",
-          tooltip: "a tooltip"
-        }
-      ],
-      isCanceled: false,
-      vote: undefined,
-      voteDownReason: undefined,
       agent: {
         name: "ChatProviderWithUsedContext",
         id: "ChatProviderWithUsedContext",
@@ -88,6 +74,27 @@
         slashCommands: [  ],
         disambiguation: [  ]
       },
+      timestamp: undefined,
+      confirmation: undefined,
+      editedFileEvents: undefined,
+      modelId: undefined,
+      responseId: undefined,
+      result: { metadata: { metadataKey: "value" } },
+      responseMarkdownInfo: undefined,
+      followups: [
+        {
+          kind: "reply",
+          message: "Something else",
+          agentId: "",
+          tooltip: "a tooltip"
+        }
+      ],
+      modelState: {
+        value: 1,
+        completedAt: undefined
+      },
+      vote: undefined,
+      voteDownReason: undefined,
       slashCommand: undefined,
       usedContext: {
         documents: [
@@ -108,10 +115,7 @@
       },
       contentReferences: [  ],
       codeCitations: [  ],
-      timestamp: undefined,
-      confirmation: undefined,
-      editedFileEvents: undefined,
-      modelId: undefined
+      timeSpentWaiting: 0
     },
     {
       requestId: undefined,
@@ -136,14 +140,7 @@
       },
       variableData: { variables: [  ] },
       response: [  ],
-      responseId: undefined,
       shouldBeRemovedOnSend: undefined,
-      result: {  },
-      responseMarkdownInfo: undefined,
-      followups: [  ],
-      isCanceled: false,
-      vote: undefined,
-      voteDownReason: undefined,
       agent: {
         name: "testAgent",
         id: "testAgent",
@@ -162,14 +159,25 @@
         disambiguation: [  ],
         isDefault: true
       },
+      timestamp: undefined,
+      confirmation: undefined,
+      editedFileEvents: undefined,
+      modelId: undefined,
+      responseId: undefined,
+      result: {  },
+      responseMarkdownInfo: undefined,
+      followups: [  ],
+      modelState: {
+        value: 1,
+        completedAt: undefined
+      },
+      vote: undefined,
+      voteDownReason: undefined,
       slashCommand: undefined,
       usedContext: undefined,
       contentReferences: [  ],
       codeCitations: [  ],
-      timestamp: undefined,
-      confirmation: undefined,
-      editedFileEvents: undefined,
-      modelId: undefined
+      timeSpentWaiting: 0
     }
   ]
 }

--- a/src/vs/workbench/contrib/chat/test/common/__snapshots__/ChatService_sendRequest_fails.0.snap
+++ b/src/vs/workbench/contrib/chat/test/common/__snapshots__/ChatService_sendRequest_fails.0.snap
@@ -56,14 +56,7 @@
       },
       variableData: { variables: [  ] },
       response: [  ],
-      responseId: undefined,
       shouldBeRemovedOnSend: undefined,
-      result: { errorDetails: { message: "No activated agent with id \"ChatProviderWithUsedContext\"" } },
-      responseMarkdownInfo: undefined,
-      followups: undefined,
-      isCanceled: false,
-      vote: undefined,
-      voteDownReason: undefined,
       agent: {
         name: "ChatProviderWithUsedContext",
         id: "ChatProviderWithUsedContext",
@@ -81,14 +74,25 @@
         slashCommands: [  ],
         disambiguation: [  ]
       },
+      timestamp: undefined,
+      confirmation: undefined,
+      editedFileEvents: undefined,
+      modelId: undefined,
+      responseId: undefined,
+      result: { errorDetails: { message: "No activated agent with id \"ChatProviderWithUsedContext\"" } },
+      responseMarkdownInfo: undefined,
+      followups: undefined,
+      modelState: {
+        value: 1,
+        completedAt: undefined
+      },
+      vote: undefined,
+      voteDownReason: undefined,
       slashCommand: undefined,
       usedContext: undefined,
       contentReferences: [  ],
       codeCitations: [  ],
-      timestamp: undefined,
-      confirmation: undefined,
-      editedFileEvents: undefined,
-      modelId: undefined
+      timeSpentWaiting: 0
     }
   ]
 }

--- a/src/vs/workbench/contrib/chat/test/common/chatModel.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/chatModel.test.ts
@@ -4,7 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
+import * as sinon from 'sinon';
 import { MarkdownString } from '../../../../../base/common/htmlContent.js';
+import { observableValue } from '../../../../../base/common/observable.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { assertSnapshot } from '../../../../../base/test/common/snapshot.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
@@ -22,6 +24,7 @@ import { TestExtensionService, TestStorageService } from '../../../../test/commo
 import { ChatAgentService, IChatAgentService } from '../../common/chatAgents.js';
 import { ChatModel, ISerializableChatData1, ISerializableChatData2, ISerializableChatData3, normalizeSerializableChatData, Response } from '../../common/chatModel.js';
 import { ChatRequestTextPart } from '../../common/chatParserTypes.js';
+import { IChatToolInvocation } from '../../common/chatService.js';
 import { ChatAgentLocation } from '../../common/constants.js';
 
 suite('ChatModel', () => {
@@ -248,5 +251,70 @@ suite('normalizeSerializableChatData', () => {
 		assert.ok(newData.creationDate > 0);
 		assert.ok(newData.lastMessageDate > 0);
 		assert.ok(newData.sessionId);
+	});
+});
+
+suite('ChatResponseModel', () => {
+	const testDisposables = ensureNoDisposablesAreLeakedInTestSuite();
+
+	let instantiationService: TestInstantiationService;
+
+	setup(async () => {
+		instantiationService = testDisposables.add(new TestInstantiationService());
+		instantiationService.stub(IStorageService, testDisposables.add(new TestStorageService()));
+		instantiationService.stub(ILogService, new NullLogService());
+		instantiationService.stub(IExtensionService, new TestExtensionService());
+		instantiationService.stub(IContextKeyService, new MockContextKeyService());
+		instantiationService.stub(IChatAgentService, testDisposables.add(instantiationService.createInstance(ChatAgentService)));
+		instantiationService.stub(IConfigurationService, new TestConfigurationService());
+	});
+
+	test('timestamp and confirmationAdjustedTimestamp', async () => {
+		const clock = sinon.useFakeTimers();
+		try {
+			const model = testDisposables.add(instantiationService.createInstance(ChatModel, undefined, { initialLocation: ChatAgentLocation.Chat, canUseTools: true }));
+			const start = Date.now();
+
+			const text = 'hello';
+			const request = model.addRequest({ text, parts: [new ChatRequestTextPart(new OffsetRange(0, text.length), new Range(1, text.length, 1, text.length), text)] }, { variables: [] }, 0);
+			const response = request.response!;
+
+			assert.strictEqual(response.timestamp, start);
+			assert.strictEqual(response.confirmationAdjustedTimestamp.get(), start);
+
+			// Advance time, no pending confirmation
+			clock.tick(1000);
+			assert.strictEqual(response.confirmationAdjustedTimestamp.get(), start);
+
+			// Add pending confirmation via tool invocation
+			const toolState = observableValue<any>('state', { type: 0 /* IChatToolInvocation.StateKind.WaitingForConfirmation */ });
+			const toolInvocation = {
+				kind: 'toolInvocation',
+				invocationMessage: 'calling tool',
+				state: toolState
+			} as Partial<IChatToolInvocation> as IChatToolInvocation;
+
+			model.acceptResponseProgress(request, toolInvocation);
+
+			// Advance time while pending
+			clock.tick(2000);
+			// Timestamp should still be start (it includes the wait time while waiting)
+			assert.strictEqual(response.confirmationAdjustedTimestamp.get(), start);
+
+			// Resolve confirmation
+			toolState.set({ type: 3 /* IChatToolInvocation.StateKind.Completed */ }, undefined);
+
+			// Now adjusted timestamp should reflect the wait time
+			// The wait time was 2000ms.
+			// confirmationAdjustedTimestamp = start + waitTime = start + 2000
+			assert.strictEqual(response.confirmationAdjustedTimestamp.get(), start + 2000);
+
+			// Advance time again
+			clock.tick(1000);
+			assert.strictEqual(response.confirmationAdjustedTimestamp.get(), start + 2000);
+
+		} finally {
+			clock.restore();
+		}
 	});
 });

--- a/src/vs/workbench/contrib/chat/test/common/chatService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/chatService.test.ts
@@ -362,6 +362,10 @@ function toSnapshotExportData(model: IChatModel) {
 		requests: exp.requests.map(r => {
 			return {
 				...r,
+				modelState: {
+					...r.modelState,
+					completedAt: undefined
+				},
 				timestamp: undefined,
 				requestId: undefined, // id contains a random part
 				responseId: undefined, // id contains a random part


### PR DESCRIPTION
- Add a public created `timestamp` on the IChatModel
- Add a started `timestamp` and optional `completedAt` timestamp on
  the IChatResponseModel
- Make `isPendingConfirmation<{startedWaitingAt: number}> | undefined`
  to encode the time when the response started waiting for confirmation.
- Add a `confirmationAdjustedTimestamp` that can be used to reflect the
  duration a chat response was waiting for user input vs working.


cc @bpasero