### PR TITLE
fix: ensure refresh settings tree even if context view focused

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
@@ -1629,16 +1629,6 @@ export class SettingsEditor2 extends EditorPane {
 			return;
 		}
 
-		// If the context view is focused, delay rendering settings
-		if (this.contextViewFocused()) {
-			// eslint-disable-next-line no-restricted-syntax
-			const element = this.window.document.querySelector('.context-view');
-			if (element) {
-				this.scheduleRefresh(element as HTMLElement, key);
-			}
-			return;
-		}
-
 		// If a setting control is currently focused, schedule a refresh for later
 		const activeElement = this.getActiveControlInSettingsTree();
 		const focusedSetting = activeElement && this.settingRenderers.getSettingDOMElementForDOMElement(activeElement);
@@ -1679,10 +1669,6 @@ export class SettingsEditor2 extends EditorPane {
 		}
 
 		return;
-	}
-
-	private contextViewFocused(): boolean {
-		return !!DOM.findParentWithClass(<HTMLElement>this.rootElement.ownerDocument.activeElement, 'context-view');
 	}
 
 	private refreshSingleElement(element: SettingsTreeSettingElement): void {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

# Description
Remove unnecessarily code to make sure always refresh settings tree.

# Changes
I checked the git blame and found these code were committed in https://github.com/microsoft/vscode/commit/d59d014ece9b243b386fe364dc46e687e159b5a6 

And I cannot reproduce the issue related in this commit after removing these code.

# Related
Fixed #277787