### PR TITLE
Reduce padding for inline chat attached context

### DIFF
--- a/src/vs/workbench/contrib/inlineChat/browser/media/inlineChat.css
+++ b/src/vs/workbench/contrib/inlineChat/browser/media/inlineChat.css
@@ -408,5 +408,5 @@
 }
 
 .monaco-workbench .inline-chat .chat-attached-context {
-	padding: 3px 0px;
+	padding: 2px 0px;
 }


### PR DESCRIPTION
Adjust the padding for the chat attached context to align with `Add Context...` button

