### PR TITLE
CodeMapper: Migrate chat implementation to use URIs instead of string ids to track sessions

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadChatCodeMapper.ts
+++ b/src/vs/workbench/api/browser/mainThreadChatCodeMapper.ts
@@ -38,7 +38,7 @@ export class MainThreadChatCodemapper extends Disposable implements MainThreadCo
 					codeBlocks: uiRequest.codeBlocks,
 					chatRequestId: uiRequest.chatRequestId,
 					chatRequestModel: uiRequest.chatRequestModel,
-					chatSessionId: uiRequest.chatSessionId,
+					chatSessionResource: uiRequest.chatSessionResource,
 					location: uiRequest.location
 				};
 				try {

--- a/src/vs/workbench/api/common/extHostCodeMapper.ts
+++ b/src/vs/workbench/api/common/extHostCodeMapper.ts
@@ -53,7 +53,7 @@ export class ExtHostCodeMapper implements extHostProtocol.ExtHostCodeMapperShape
 			location: internalRequest.location,
 			chatRequestId: internalRequest.chatRequestId,
 			chatRequestModel: internalRequest.chatRequestModel,
-			chatSessionId: internalRequest.chatSessionId,
+			chatSessionResource: URI.revive(internalRequest.chatSessionResource),
 			codeBlocks: internalRequest.codeBlocks.map(block => {
 				return {
 					code: block.code,

--- a/src/vs/workbench/api/common/extHostCodeMapper.ts
+++ b/src/vs/workbench/api/common/extHostCodeMapper.ts
@@ -11,6 +11,7 @@ import * as extHostProtocol from './extHost.protocol.js';
 import { NotebookEdit, TextEdit } from './extHostTypeConverters.js';
 import { URI } from '../../../base/common/uri.js';
 import { asArray } from '../../../base/common/arrays.js';
+import { LocalChatSessionUri } from '../../contrib/chat/common/chatUri.js';
 
 export class ExtHostCodeMapper implements extHostProtocol.ExtHostCodeMapperShape {
 
@@ -53,7 +54,7 @@ export class ExtHostCodeMapper implements extHostProtocol.ExtHostCodeMapperShape
 			location: internalRequest.location,
 			chatRequestId: internalRequest.chatRequestId,
 			chatRequestModel: internalRequest.chatRequestModel,
-			chatSessionResource: URI.revive(internalRequest.chatSessionResource),
+			chatSessionId: internalRequest.chatSessionResource ? LocalChatSessionUri.parseLocalSessionId(URI.revive(internalRequest.chatSessionResource)) : undefined,
 			codeBlocks: internalRequest.codeBlocks.map(block => {
 				return {
 					code: block.code,

--- a/src/vs/workbench/contrib/chat/browser/actions/codeBlockOperations.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/codeBlockOperations.ts
@@ -36,7 +36,6 @@ import { CellKind, ICellEditOperation, NOTEBOOK_EDITOR_ID } from '../../../noteb
 import { INotebookService } from '../../../notebook/common/notebookService.js';
 import { ICodeMapperCodeBlock, ICodeMapperRequest, ICodeMapperResponse, ICodeMapperService } from '../../common/chatCodeMapperService.js';
 import { ChatUserAction, IChatService } from '../../common/chatService.js';
-import { chatSessionResourceToId } from '../../common/chatUri.js';
 import { IChatRequestViewModel, isRequestVM, isResponseVM } from '../../common/chatViewModel.js';
 import { ICodeBlockActionContext } from '../codeBlockPart.js';
 
@@ -342,7 +341,7 @@ export class ApplyCodeBlockOperation {
 		return new AsyncIterableObject<TextEdit[]>(async executor => {
 			const request: ICodeMapperRequest = {
 				codeBlocks: [codeBlock],
-				chatSessionId: chatSessionResource && chatSessionResourceToId(chatSessionResource),
+				chatSessionResource,
 			};
 			const response: ICodeMapperResponse = {
 				textEdit: (target: URI, edit: TextEdit[]) => {
@@ -363,7 +362,7 @@ export class ApplyCodeBlockOperation {
 		return new AsyncIterableObject<[URI, TextEdit[]] | ICellEditOperation[]>(async executor => {
 			const request: ICodeMapperRequest = {
 				codeBlocks: [codeBlock],
-				chatSessionId: chatSessionResource && chatSessionResourceToId(chatSessionResource),
+				chatSessionResource,
 				location: 'panel'
 			};
 			const response: ICodeMapperResponse = {

--- a/src/vs/workbench/contrib/chat/common/chatCodeMapperService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatCodeMapperService.ts
@@ -25,7 +25,7 @@ export interface ICodeMapperRequest {
 	readonly codeBlocks: ICodeMapperCodeBlock[];
 	readonly chatRequestId?: string;
 	readonly chatRequestModel?: string;
-	readonly chatSessionId?: string;
+	readonly chatSessionResource?: URI;
 	readonly location?: string;
 }
 

--- a/src/vs/workbench/contrib/chat/common/tools/editFileTool.ts
+++ b/src/vs/workbench/contrib/chat/common/tools/editFileTool.ts
@@ -89,7 +89,7 @@ export class EditTool implements IToolImpl {
 			location: 'tool',
 			chatRequestId: invocation.chatRequestId,
 			chatRequestModel: invocation.modelId,
-			chatSessionId: invocation.context.sessionId,
+			chatSessionResource: LocalChatSessionUri.forSession(invocation.context.sessionId),
 		}, {
 			textEdit: (target, edits) => {
 				model.acceptResponseProgress(request, { kind: 'textEdit', uri: target, edits });

--- a/src/vs/workbench/contrib/chat/common/tools/editFileTool.ts
+++ b/src/vs/workbench/contrib/chat/common/tools/editFileTool.ts
@@ -89,7 +89,7 @@ export class EditTool implements IToolImpl {
 			location: 'tool',
 			chatRequestId: invocation.chatRequestId,
 			chatRequestModel: invocation.modelId,
-			chatSessionResource: LocalChatSessionUri.forSession(invocation.context.sessionId),
+			chatSessionResource: invocation.context.sessionResource,
 		}, {
 			textEdit: (target, edits) => {
 				model.acceptResponseProgress(request, { kind: 'textEdit', uri: target, edits });

--- a/src/vscode-dts/vscode.proposed.mappedEditsProvider.d.ts
+++ b/src/vscode-dts/vscode.proposed.mappedEditsProvider.d.ts
@@ -76,7 +76,7 @@ declare module 'vscode' {
 		readonly location?: string;
 		readonly chatRequestId?: string;
 		readonly chatRequestModel?: string;
-		readonly chatSessionResource?: Uri;
+		readonly chatSessionId?: string;
 	}
 
 	export interface MappedEditsResponseStream {

--- a/src/vscode-dts/vscode.proposed.mappedEditsProvider.d.ts
+++ b/src/vscode-dts/vscode.proposed.mappedEditsProvider.d.ts
@@ -76,7 +76,7 @@ declare module 'vscode' {
 		readonly location?: string;
 		readonly chatRequestId?: string;
 		readonly chatRequestModel?: string;
-		readonly chatSessionId?: string;
+		readonly chatSessionResource?: Uri;
 	}
 
 	export interface MappedEditsResponseStream {


### PR DESCRIPTION
For #274403