### PR TITLE
Change keybinding display to inline-flex for better alignment

### DIFF
--- a/src/vs/base/browser/ui/keybindingLabel/keybindingLabel.css
+++ b/src/vs/base/browser/ui/keybindingLabel/keybindingLabel.css
@@ -10,11 +10,12 @@
 }
 
 .monaco-keybinding > .monaco-keybinding-key {
-	display: inline-block;
+	display: inline-flex;
 	border-style: solid;
 	border-width: 1px;
 	border-radius: 3px;
-	vertical-align: middle;
+	justify-content: center;
+	min-width: 12px;
 	font-size: 11px;
 	padding: 3px 5px;
 	margin: 0 2px;

--- a/src/vs/base/browser/ui/keybindingLabel/keybindingLabel.css
+++ b/src/vs/base/browser/ui/keybindingLabel/keybindingLabel.css
@@ -11,6 +11,7 @@
 
 .monaco-keybinding > .monaco-keybinding-key {
 	display: inline-flex;
+	align-items: center;
 	border-style: solid;
 	border-width: 1px;
 	border-radius: 3px;


### PR DESCRIPTION
Update the keybinding display style to use inline-flex for improved alignment and consistent widths. This change enhances the visual presentation of keybindings.

<img width="1064" height="732" alt="image" src="https://github.com/user-attachments/assets/e56d80f1-7eca-4a0f-a99f-a7f121422e32" />

<img width="1161" height="501" alt="image" src="https://github.com/user-attachments/assets/ae542495-0b45-496a-9d8c-966fc75e11a0" />

<img width="959" height="820" alt="image" src="https://github.com/user-attachments/assets/35175594-cfa5-4c52-a4de-c7f784b29eca" />
