### PR TITLE
Update focused row keybinding appearance in quick input list

### DIFF
--- a/src/vs/platform/quickinput/browser/media/quickInput.css
+++ b/src/vs/platform/quickinput/browser/media/quickInput.css
@@ -348,7 +348,7 @@
 
 .quick-input-list .monaco-list-row.focused .monaco-keybinding-key {
 	background: none;
-	border-color: unset;
+	border-color: inherit;
 	opacity: 0.8;
 }
 

--- a/src/vs/platform/quickinput/browser/media/quickInput.css
+++ b/src/vs/platform/quickinput/browser/media/quickInput.css
@@ -348,6 +348,8 @@
 
 .quick-input-list .monaco-list-row.focused .monaco-keybinding-key {
 	background: none;
+	border-color: unset;
+	opacity: 0.8;
 }
 
 .quick-input-list .quick-input-list-separator-as-item {


### PR DESCRIPTION
Enhance the visual appearance of the focused row in the quick input list by adjusting the border color and opacity. This improves the user experience by making the focused row more distinguishable.

<img width="819" height="688" alt="image" src="https://github.com/user-attachments/assets/7e28fcfb-2357-438f-b935-ebffa5c22b27" />


