### PR TITLE
Update github MCP server mapping

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/languageModelToolsService.ts
+++ b/src/vs/workbench/contrib/chat/browser/languageModelToolsService.ts
@@ -696,8 +696,7 @@ export class LanguageModelToolsService extends Disposable implements ILanguageMo
 
 	private _githubToVSCodeToolMap: Record<string, string> = {
 		[GithubCopilotToolReference.shell]: VSCodeToolReference.shell,
-		[GithubCopilotToolReference.customAgent]: VSCodeToolReference.runSubagent,
-		'github/*': 'github/github-mcp-server/*',
+		[GithubCopilotToolReference.customAgent]: VSCodeToolReference.customAgent,
 		'playwright/*': 'microsoft/playwright-mcp/*',
 	};
 	private _githubPrefixToVSCodePrefix = [['github', 'github/github-mcp-server'], ['playwright', 'microsoft/playwright-mcp']] as const;

--- a/src/vs/workbench/contrib/chat/browser/languageModelToolsService.ts
+++ b/src/vs/workbench/contrib/chat/browser/languageModelToolsService.ts
@@ -697,9 +697,10 @@ export class LanguageModelToolsService extends Disposable implements ILanguageMo
 	private _githubToVSCodeToolMap: Record<string, string> = {
 		[GithubCopilotToolReference.shell]: VSCodeToolReference.shell,
 		[GithubCopilotToolReference.customAgent]: VSCodeToolReference.customAgent,
+		'github/*': 'io.github.github/github-mcp-server/*',
 		'playwright/*': 'microsoft/playwright-mcp/*',
 	};
-	private _githubPrefixToVSCodePrefix = [['github', 'github/github-mcp-server'], ['playwright', 'microsoft/playwright-mcp']] as const;
+	private _githubPrefixToVSCodePrefix = [['github', 'io.github.github/github-mcp-server'], ['playwright', 'microsoft/playwright-mcp']] as const;
 
 	mapGithubToolName(name: string): string {
 		const mapped = this._githubToVSCodeToolMap[name];


### PR DESCRIPTION
The github MCP server now has the name `io.github.github/github-mcp-server`