### PR TITLE
Improve hasSameContent method to check codeblock URIs and content equality

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/chatMarkdownContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/chatMarkdownContentPart.ts
@@ -404,8 +404,10 @@ export class ChatMarkdownContentPart extends Disposable implements IChatContentP
 	}
 
 	hasSameContent(other: IChatProgressRenderableResponseContent): boolean {
-		return other.kind === 'markdownContent' && !!(other.content.value === this.markdown.content.value
-			|| this.codeblocks.at(-1)?.codemapperUri !== undefined && other.content.value.lastIndexOf('```') === this.markdown.content.value.lastIndexOf('```'));
+		const thisCodeblockUris = this.codeblocks.map(cb => cb.codemapperUri);
+		return other.kind === 'markdownContent'
+			&& other.content.value === this.markdown.content.value
+			&& (thisCodeblockUris.length === 0 || thisCodeblockUris.every((uri) => uri !== undefined));
 	}
 
 	layout(width: number): void {

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/chatMarkdownContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/chatMarkdownContentPart.ts
@@ -404,10 +404,9 @@ export class ChatMarkdownContentPart extends Disposable implements IChatContentP
 	}
 
 	hasSameContent(other: IChatProgressRenderableResponseContent): boolean {
-		const thisCodeblockUris = this.codeblocks.map(cb => cb.codemapperUri);
 		return other.kind === 'markdownContent'
 			&& other.content.value === this.markdown.content.value
-			&& (thisCodeblockUris.length === 0 || thisCodeblockUris.every((uri) => uri !== undefined));
+			&& (this.codeblocks.length === 0 || this.codeblocks.every((cb) => cb.codemapperUri !== undefined));
 	}
 
 	layout(width: number): void {


### PR DESCRIPTION
Improve hasSameContent method to check codeblock URIs and content equality. Fix #277214 and #277574
