### PR TITLE
Fix terminal mouse wheel zoom interference with scrollbar

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/zoom/browser/terminal.zoom.contribution.ts
+++ b/src/vs/workbench/contrib/terminalContrib/zoom/browser/terminal.zoom.contribution.ts
@@ -7,7 +7,7 @@ import type { Terminal as RawXtermTerminal } from '@xterm/xterm';
 import { Event } from '../../../../../base/common/event.js';
 import { IMouseWheelEvent } from '../../../../../base/browser/mouseEvent.js';
 import { MouseWheelClassifier } from '../../../../../base/browser/ui/scrollbar/scrollableElement.js';
-import { Disposable, MutableDisposable, toDisposable } from '../../../../../base/common/lifecycle.js';
+import { Disposable, MutableDisposable } from '../../../../../base/common/lifecycle.js';
 import { isMacintosh } from '../../../../../base/common/platform.js';
 import { TerminalSettingId } from '../../../../../platform/terminal/common/terminal.js';
 import { IDetachedTerminalInstance, ITerminalContribution, ITerminalInstance, IXtermTerminal } from '../../../terminal/browser/terminal.js';
@@ -18,6 +18,7 @@ import { localize2 } from '../../../../../nls.js';
 import { isNumber } from '../../../../../base/common/types.js';
 import { defaultTerminalFontSize } from '../../../terminal/common/terminalConfiguration.js';
 import { TerminalZoomCommandId, TerminalZoomSettingId } from '../common/terminal.zoom.js';
+import * as dom from '../../../../../base/browser/dom.js';
 
 class TerminalMouseWheelZoomContribution extends Disposable implements ITerminalContribution {
 	static readonly ID = 'terminal.mouseWheelZoom';
@@ -71,54 +72,48 @@ class TerminalMouseWheelZoomContribution extends Disposable implements ITerminal
 		let gestureHasZoomModifiers = false;
 		let gestureAccumulatedDelta = 0;
 
-		raw.attachCustomWheelEventHandler((browserEvent: WheelEvent) => {
-			function isWheelEvent(e: MouseEvent): e is IMouseWheelEvent {
-				return 'wheelDelta' in e && 'wheelDeltaX' in e && 'wheelDeltaY' in e;
-			}
-			if (isWheelEvent(browserEvent)) {
-				if (classifier.isPhysicalMouseWheel()) {
-					if (this._hasMouseWheelZoomModifiers(browserEvent)) {
-						const delta = browserEvent.deltaY > 0 ? -1 : 1;
-						const newFontSize = this._clampFontSize(this._getConfigFontSize() + delta);
-						this._configurationService.updateValue(TerminalSettingId.FontSize, newFontSize);
-						// EditorZoom.setZoomLevel(zoomLevel + delta);
-						browserEvent.preventDefault();
-						browserEvent.stopPropagation();
-						return false;
-					}
-				} else {
-					// we consider mousewheel events that occur within 50ms of each other to be part of the same gesture
-					// we don't want to consider mouse wheel events where ctrl/cmd is pressed during the inertia phase
-					// we also want to accumulate deltaY values from the same gesture and use that to set the zoom level
-					if (Date.now() - prevMouseWheelTime > 50) {
-						// reset if more than 50ms have passed
-						gestureStartFontSize = this._getConfigFontSize();
-						gestureHasZoomModifiers = this._hasMouseWheelZoomModifiers(browserEvent);
-						gestureAccumulatedDelta = 0;
-					}
+		const wheelListener = (browserEvent: WheelEvent) => {
+			if (classifier.isPhysicalMouseWheel()) {
+				if (this._hasMouseWheelZoomModifiers(browserEvent)) {
+					const delta = browserEvent.deltaY > 0 ? -1 : 1;
+					const newFontSize = this._clampFontSize(this._getConfigFontSize() + delta);
+					this._configurationService.updateValue(TerminalSettingId.FontSize, newFontSize);
+					// EditorZoom.setZoomLevel(zoomLevel + delta);
+					browserEvent.preventDefault();
+					browserEvent.stopPropagation();
+				}
+			} else {
+				// we consider mousewheel events that occur within 50ms of each other to be part of the same gesture
+				// we don't want to consider mouse wheel events where ctrl/cmd is pressed during the inertia phase
+				// we also want to accumulate deltaY values from the same gesture and use that to set the zoom level
+				if (Date.now() - prevMouseWheelTime > 50) {
+					// reset if more than 50ms have passed
+					gestureStartFontSize = this._getConfigFontSize();
+					gestureHasZoomModifiers = this._hasMouseWheelZoomModifiers(browserEvent);
+					gestureAccumulatedDelta = 0;
+				}
 
-					prevMouseWheelTime = Date.now();
+				prevMouseWheelTime = Date.now();
+				gestureAccumulatedDelta += browserEvent.deltaY;
+
+				if (gestureHasZoomModifiers) {
+					const deltaAbs = Math.ceil(Math.abs(gestureAccumulatedDelta / 5));
+					const deltaDirection = gestureAccumulatedDelta > 0 ? -1 : 1;
+					const delta = deltaAbs * deltaDirection;
+					const newFontSize = this._clampFontSize(gestureStartFontSize + delta);
+					this._configurationService.updateValue(TerminalSettingId.FontSize, newFontSize);
 					gestureAccumulatedDelta += browserEvent.deltaY;
-
-					if (gestureHasZoomModifiers) {
-						const deltaAbs = Math.ceil(Math.abs(gestureAccumulatedDelta / 5));
-						const deltaDirection = gestureAccumulatedDelta > 0 ? -1 : 1;
-						const delta = deltaAbs * deltaDirection;
-						const newFontSize = this._clampFontSize(gestureStartFontSize + delta);
-						this._configurationService.updateValue(TerminalSettingId.FontSize, newFontSize);
-						gestureAccumulatedDelta += browserEvent.deltaY;
-						browserEvent.preventDefault();
-						browserEvent.stopPropagation();
-						return false;
-					}
+					browserEvent.preventDefault();
+					browserEvent.stopPropagation();
 				}
 			}
-			return true;
-		});
-		this._listener.value = toDisposable(() => raw.attachCustomWheelEventHandler(() => true));
+		};
+
+		// Use the capture phase to ensure we catch the event before the terminal's scrollable element consumes it
+		this._listener.value = dom.addDisposableListener(raw.element!, dom.EventType.MOUSE_WHEEL, wheelListener, { capture: true, passive: false });
 	}
 
-	private _hasMouseWheelZoomModifiers(browserEvent: IMouseWheelEvent): boolean {
+	private _hasMouseWheelZoomModifiers(browserEvent: WheelEvent | IMouseWheelEvent): boolean {
 		return (
 			isMacintosh
 				// on macOS we support cmd + two fingers scroll (`metaKey` set)


### PR DESCRIPTION
Fixes #251874

#### Problem
`Ctrl+Wheel` zoom only works when the terminal scrollbar is at top/bottom. In the middle, it scrolls instead of zooming.

#### Cause
xterm.js's internal `ScrollableElement` consumes wheel events during bubbling phase, preventing the zoom handler from receiving them.

#### Solution
Use DOM capture phase (`{ capture: true }`) to intercept wheel events before they reach the scrollbar. This ensures zoom shortcuts work regardless of scroll position.

#### Alternative considered
Could fix in xterm.js by making `attachCustomWheelEventHandler` use capture phase, but that's riskier and affects all library consumers. This VS Code-level fix is more targeted.