### PR TITLE
white apple logo for all themes except high contrast white

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/media/chatSetup.css
+++ b/src/vs/workbench/contrib/chat/browser/media/chatSetup.css
@@ -51,12 +51,10 @@
 	}
 }
 
-.monaco-workbench.hc-black .chat-setup-dialog .dialog-buttons-row > .dialog-buttons > .monaco-button.continue-button.apple::before,
-.monaco-workbench.vs-dark .chat-setup-dialog .dialog-buttons-row > .dialog-buttons > .monaco-button.continue-button.apple::before {
-	background-image: url('./apple-dark.svg');
+.monaco-workbench.hc-light .chat-setup-dialog .dialog-buttons-row > .dialog-buttons > .monaco-button.continue-button.apple::before {
+	background-image: url('./apple-light.svg');
 }
 
-.monaco-workbench.hc-light .chat-setup-dialog .dialog-buttons-row > .dialog-buttons > .monaco-button.continue-button.apple::before,
-.monaco-workbench.vs .chat-setup-dialog .dialog-buttons-row > .dialog-buttons > .monaco-button.continue-button.apple::before {
-	background-image: url('./apple-light.svg');
+.chat-setup-dialog .dialog-buttons-row > .dialog-buttons > .monaco-button.continue-button.apple::before {
+	background-image: url('./apple-dark.svg');
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Using black apple logo for white high contrast theme, using white logo for all others.

<img width="395" height="529" alt="Screenshot 2025-11-20 at 3 29 44 PM" src="https://github.com/user-attachments/assets/31d33362-d04a-4045-b032-feb206d58c89" />
<img width="378" height="511" alt="Screenshot 2025-11-20 at 3 29 07 PM" src="https://github.com/user-attachments/assets/8c6ad041-0233-4180-a1b4-f7036708b0d3" />
