### PR TITLE
'Configure Tools' button not showing after start

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
@@ -529,6 +529,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 		this._register(this.chatModeService.onDidChangeChatModes(() => this.validateCurrentChatMode()));
 		this._register(autorun(r => {
 			const mode = this._currentModeObservable.read(r);
+			this.chatModeKindKey.set(mode.kind);
 			const model = mode.model?.read(r);
 			if (model) {
 				this.switchModelByQualifiedName(model);
@@ -837,7 +838,6 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 		}
 
 		this._currentModeObservable.set(mode, undefined);
-		this.chatModeKindKey.set(mode.kind);
 		this._onDidChangeCurrentChatMode.fire();
 
 		// Sync to model (mode is now persisted in the model's input state)


### PR DESCRIPTION
On startup the empty chat view has no tools button.
Workaround is to switch the mode forth and back.

<img width="478" height="140" alt="image" src="https://github.com/user-attachments/assets/91156804-58a5-49a4-9d46-c6296197b51e" />


Caused by https://github.com/microsoft/vscode/pull/278683

the chatModeKind context key no longer got initialized.

The fix is to bind it to the _currentModeObservable.