### PR TITLE
Make close button of banners focusable for keyboard only users

### DIFF
--- a/src/vs/platform/quickinput/browser/quickInputController.ts
+++ b/src/vs/platform/quickinput/browser/quickInputController.ts
@@ -140,6 +140,8 @@ export class QuickInputController extends Disposable {
 		const container = dom.append(this._container, $('.quick-input-widget.show-file-icons'));
 		container.tabIndex = -1;
 		container.style.display = 'none';
+		container.setAttribute('role', 'dialog');
+		container.setAttribute('aria-labelledby', 'quick-input-title');
 
 		const styleSheet = domStylesheetsJs.createStyleSheet(container);
 
@@ -149,6 +151,7 @@ export class QuickInputController extends Disposable {
 		leftActionBar.domNode.classList.add('quick-input-left-action-bar');
 
 		const title = dom.append(titleBar, $('.quick-input-title'));
+		title.setAttribute('id', 'quick-input-title');
 
 		const rightActionBar = this._register(new ActionBar(titleBar, { hoverDelegate: this.options.hoverDelegate }));
 		rightActionBar.domNode.classList.add('quick-input-right-action-bar');

--- a/src/vs/platform/quickinput/browser/quickInputController.ts
+++ b/src/vs/platform/quickinput/browser/quickInputController.ts
@@ -140,8 +140,6 @@ export class QuickInputController extends Disposable {
 		const container = dom.append(this._container, $('.quick-input-widget.show-file-icons'));
 		container.tabIndex = -1;
 		container.style.display = 'none';
-		container.setAttribute('role', 'dialog');
-		container.setAttribute('aria-labelledby', 'quick-input-title');
 
 		const styleSheet = domStylesheetsJs.createStyleSheet(container);
 
@@ -151,7 +149,6 @@ export class QuickInputController extends Disposable {
 		leftActionBar.domNode.classList.add('quick-input-left-action-bar');
 
 		const title = dom.append(titleBar, $('.quick-input-title'));
-		title.setAttribute('id', 'quick-input-title');
 
 		const rightActionBar = this._register(new ActionBar(titleBar, { hoverDelegate: this.options.hoverDelegate }));
 		rightActionBar.domNode.classList.add('quick-input-right-action-bar');

--- a/src/vs/workbench/browser/parts/banner/bannerPart.ts
+++ b/src/vs/workbench/browser/parts/banner/bannerPart.ts
@@ -226,7 +226,7 @@ export class BannerPart extends Part implements IBannerService {
 		const label = item.closeLabel ?? localize('closeBanner', "Close Banner");
 		const closeAction = this._register(new Action('banner.close', label, ThemeIcon.asClassName(widgetClose), true, () => this.close(item)));
 		this.actionBar.push(closeAction, { icon: true, label: false });
-		this.actionBar.setFocusable(false);
+		this.actionBar.setFocusable(true);
 
 		this.setVisibility(true);
 		this.item = item;

--- a/src/vs/workbench/browser/parts/banner/media/bannerpart.css
+++ b/src/vs/workbench/browser/parts/banner/media/bannerpart.css
@@ -78,3 +78,7 @@
 .monaco-workbench .part.banner .action-container .codicon {
 	color: var(--vscode-banner-foreground);
 }
+
+.monaco-workbench .part.banner .action-container [tabindex='0']:focus {
+	outline-color:var(--vscode-banner-foreground);
+}


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/278799

Steps to Test:

1. Open VSCode with banner present
2. Use the keyboard to tab to banner
3. Notice that the close button is not reachable by keyboard

