### PR TITLE
chat: unify history in different editors

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
@@ -1022,7 +1022,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 		}
 
 		const state = this.getCurrentInputState();
-		if (state.inputText !== '') {
+		if (state.inputText || state.attachments.length) {
 			this.history.overlay(state);
 		}
 		this.navigateHistory(true);
@@ -1034,7 +1034,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 		}
 
 		const state = this.getCurrentInputState();
-		if (state.inputText !== '') {
+		if (state.inputText || state.attachments.length) {
 			this.history.overlay(state);
 		}
 		this.navigateHistory(false);

--- a/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
@@ -19,7 +19,6 @@ import { DeferredPromise, RunOnceScheduler } from '../../../../base/common/async
 import { CancellationToken } from '../../../../base/common/cancellation.js';
 import { Codicon } from '../../../../base/common/codicons.js';
 import { Emitter, Event } from '../../../../base/common/event.js';
-import { HistoryNavigator2 } from '../../../../base/common/history.js';
 import { Iterable } from '../../../../base/common/iterator.js';
 import { KeyCode } from '../../../../base/common/keyCodes.js';
 import { Lazy } from '../../../../base/common/lazy.js';
@@ -82,7 +81,7 @@ import { IChatFollowup, IChatService } from '../common/chatService.js';
 import { IChatSessionProviderOptionItem, IChatSessionsService } from '../common/chatSessionsService.js';
 import { ChatRequestVariableSet, IChatRequestVariableEntry, isElementVariableEntry, isImageVariableEntry, isNotebookOutputVariableEntry, isPasteVariableEntry, isPromptFileVariableEntry, isPromptTextVariableEntry, isSCMHistoryItemChangeRangeVariableEntry, isSCMHistoryItemChangeVariableEntry, isSCMHistoryItemVariableEntry, isStringVariableEntry } from '../common/chatVariableEntries.js';
 import { IChatResponseViewModel } from '../common/chatViewModel.js';
-import { ChatInputHistoryMaxEntries, IChatWidgetHistoryService } from '../common/chatWidgetHistoryService.js';
+import { ChatHistoryNavigator } from '../common/chatWidgetHistoryService.js';
 import { ChatAgentLocation, ChatConfiguration, ChatModeKind, validateChatMode } from '../common/constants.js';
 import { ILanguageModelChatMetadata, ILanguageModelChatMetadataAndIdentifier, ILanguageModelsService } from '../common/languageModels.js';
 import { ILanguageModelToolsService } from '../common/languageModelToolsService.js';
@@ -283,7 +282,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 
 	readonly dnd: ChatDragAndDrop;
 
-	private history: HistoryNavigator2<IChatModelInputState>;
+	private history: ChatHistoryNavigator;
 	private historyNavigationBackwardsEnablement!: IContextKey<boolean>;
 	private historyNavigationForewardsEnablement!: IContextKey<boolean>;
 	private inputModel: ITextModel | undefined;
@@ -396,7 +395,6 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 		private readonly options: IChatInputPartOptions,
 		styles: IChatInputStyles,
 		private readonly inline: boolean,
-		@IChatWidgetHistoryService private readonly historyService: IChatWidgetHistoryService,
 		@IModelService private readonly modelService: IModelService,
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
 		@IContextKeyService private readonly contextKeyService: IContextKeyService,
@@ -462,8 +460,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 			chatToolCount.set(count);
 		}));
 
-		this.history = this.loadHistory();
-		this._register(this.historyService.onDidClearHistory(() => this.history = new HistoryNavigator2<IChatModelInputState>([this.getCurrentInputState()], ChatInputHistoryMaxEntries, historyKeyFn)));
+		this.history = this._register(this.instantiationService.createInstance(ChatHistoryNavigator, this.location));
 
 		this._register(this.configurationService.onDidChangeConfiguration(e => {
 			const newOptions: IEditorOptions = {};
@@ -874,15 +871,6 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 		}
 	}
 
-	private loadHistory(): HistoryNavigator2<IChatModelInputState> {
-		const history = this.historyService.getHistory(this.location);
-		if (history.length === 0) {
-			history.push(this.getCurrentInputState());
-		}
-
-		return new HistoryNavigator2(history, 50, historyKeyFn);
-	}
-
 	/**
 	 * Get the current input state for history
 	 */
@@ -956,13 +944,6 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 	}
 
 	initForNewChatModel(state: IChatModelInputState | undefined, chatSessionIsEmpty: boolean): void {
-		this.history = this.loadHistory();
-
-		// Note: With the new input model architecture, the state is synced automatically
-		// from the model via _syncFromModel when setInputModel is called.
-		// We only need to handle history here.
-		this.history.add(state ?? this.getCurrentInputState());
-
 		this.selectedToolsModel.resetSessionEnablementState();
 
 		// TODO@roblourens This is for an experiment which will be obsolete in a month or two and can then be removed.
@@ -1000,7 +981,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 	}
 
 	logInputHistory(): void {
-		const historyStr = [...this.history].map(entry => JSON.stringify(entry)).join('\n');
+		const historyStr = this.history.values.map(entry => JSON.stringify(entry)).join('\n');
 		this.logService.info(`[${this.location}] Chat input history:`, historyStr);
 	}
 
@@ -1035,35 +1016,27 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 		return this.container;
 	}
 
-	private isStateEmpty(state: IChatModelInputState): boolean {
-		return state.inputText.trim().length === 0 && state.attachments.length === 0;
-	}
-
 	async showPreviousValue(): Promise<void> {
-		const inputState = this.getCurrentInputState();
-		this.saveCurrentValue(inputState);
-
-		const current = this.history.current();
-		if (current.inputText !== inputState.inputText && !this.isStateEmpty(inputState)) {
-			this.saveCurrentValue(inputState);
-			this.history.resetCursor();
+		if (this.history.isAtStart()) {
+			return;
 		}
 
+		const state = this.getCurrentInputState();
+		if (state.inputText !== '') {
+			this.history.overlay(state);
+		}
 		this.navigateHistory(true);
 	}
 
 	async showNextValue(): Promise<void> {
-		const inputState = this.getCurrentInputState();
 		if (this.history.isAtEnd()) {
 			return;
-		} else {
-			const current = this.history.current();
-			if (current.inputText !== inputState.inputText) {
-				this.saveCurrentValue(inputState);
-				this.history.resetCursor();
-			}
 		}
 
+		const state = this.getCurrentInputState();
+		if (state.inputText !== '') {
+			this.history.overlay(state);
+		}
 		this.navigateHistory(false);
 	}
 
@@ -1071,7 +1044,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 		const historyEntry = previous ?
 			this.history.previous() : this.history.next();
 
-		let historyAttachments = historyEntry.attachments ?? [];
+		let historyAttachments = historyEntry?.attachments ?? [];
 
 		// Check for images in history to restore the value.
 		if (historyAttachments.length > 0) {
@@ -1097,10 +1070,12 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 
 		this._attachmentModel.clearAndSetContext(...historyAttachments);
 
-		aria.status(historyEntry.inputText);
-		this.setValue(historyEntry.inputText, true);
+		const inputText = historyEntry?.inputText ?? '';
+		const contribData = historyEntry?.contrib ?? {};
+		aria.status(inputText);
+		this.setValue(inputText, true);
 		this._widget?.contribs.forEach(contrib => {
-			contrib.setInputState?.(historyEntry.contrib);
+			contrib.setInputState?.(contribData);
 		});
 		this._onDidLoadInputState.fire();
 
@@ -1125,14 +1100,6 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 		if (model) {
 			this.inputEditor.setPosition(getLastPosition(model));
 		}
-
-		if (!transient) {
-			this.saveCurrentValue(this.getCurrentInputState());
-		}
-	}
-
-	private saveCurrentValue(inputState: IChatModelInputState): void {
-		this.history.replaceLast(inputState);
 	}
 
 	focus() {
@@ -1150,8 +1117,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 	async acceptInput(isUserQuery?: boolean): Promise<void> {
 		if (isUserQuery) {
 			const userQuery = this.getCurrentInputState();
-			this.history.replaceLast(userQuery);
-			this.history.add({ ...this.getCurrentInputState(), inputText: '', attachments: [], selections: [] });
+			this.history.append(this._getFilteredEntry(userQuery));
 		}
 
 		// Clear attached context, fire event to clear input state, and clear the input editor
@@ -1169,6 +1135,20 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 		if (!this.agentService.hasToolsAgent && this._currentModeObservable.get().kind === ChatModeKind.Agent) {
 			this.setChatMode(ChatModeKind.Edit);
 		}
+	}
+
+	// A function that filters out specifically the `value` property of the attachment.
+	private _getFilteredEntry(inputState: IChatModelInputState): IChatModelInputState {
+		const attachmentsWithoutImageValues = inputState.attachments.map(attachment => {
+			if (isImageVariableEntry(attachment) && attachment.references?.length && attachment.value) {
+				const newAttachment = { ...attachment };
+				newAttachment.value = undefined;
+				return newAttachment;
+			}
+			return attachment;
+		});
+
+		return { ...inputState, attachments: attachmentsWithoutImageValues };
 	}
 
 	private _acceptInputForVoiceover(): void {
@@ -2266,18 +2246,8 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 			todoListWidgetContainerHeight: this.chatInputTodoListWidgetContainer.offsetHeight,
 		};
 	}
-
-	saveState(): void {
-		if (this.history.isAtEnd()) {
-			this.saveCurrentValue(this.getCurrentInputState());
-		}
-
-		const inputHistory = [...this.history];
-		this.historyService.saveHistory(this.location, inputHistory);
-	}
 }
 
-const historyKeyFn = (entry: IChatModelInputState) => JSON.stringify({ ...entry, mode: { ...entry.mode }, selectedModel: undefined });
 
 function getLastPosition(model: ITextModel): IPosition {
 	return { lineNumber: model.getLineCount(), column: model.getLineLength(model.getLineCount()) + 1 };

--- a/src/vs/workbench/contrib/chat/browser/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatWidget.ts
@@ -2217,7 +2217,6 @@ export class ChatWidget extends Disposable implements IChatWidget {
 		}));
 		this.viewModelDisposables.add(this.viewModel.onDidDisposeModel(() => {
 			// Ensure that view state is saved here, because we will load it again when a new model is assigned
-			this.input.saveState();
 			if (this.viewModel?.editing) {
 				this.finishedEditing();
 			}
@@ -2741,7 +2740,7 @@ export class ChatWidget extends Disposable implements IChatWidget {
 	}
 
 	saveState(): void {
-		this.input.saveState();
+		// no-op
 	}
 
 	getViewState(): IChatModelInputState | undefined {

--- a/src/vs/workbench/contrib/chat/common/chatWidgetHistoryService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatWidgetHistoryService.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Emitter, Event } from '../../../../base/common/event.js';
+import { Disposable } from '../../../../base/common/lifecycle.js';
 import { createDecorator } from '../../../../platform/instantiation/common/instantiation.js';
 import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
 import { Memento } from '../../../common/memento.js';
@@ -33,41 +34,51 @@ export const IChatWidgetHistoryService = createDecorator<IChatWidgetHistoryServi
 export interface IChatWidgetHistoryService {
 	_serviceBrand: undefined;
 
-	readonly onDidClearHistory: Event<void>;
+	readonly onDidChangeHistory: Event<ChatHistoryChange>;
 
 	clearHistory(): void;
-	getHistory(location: ChatAgentLocation): IChatModelInputState[];
-	saveHistory(location: ChatAgentLocation, history: IChatModelInputState[]): void;
+	getHistory(location: ChatAgentLocation): readonly IChatModelInputState[];
+	append(location: ChatAgentLocation, history: IChatModelInputState): void;
 }
 
 interface IChatHistory {
 	history?: { [providerId: string]: IChatModelInputState[] };
 }
 
+export type ChatHistoryChange = { kind: 'append'; entry: IChatModelInputState } | { kind: 'clear' };
+
 export const ChatInputHistoryMaxEntries = 40;
 
-export class ChatWidgetHistoryService implements IChatWidgetHistoryService {
+export class ChatWidgetHistoryService extends Disposable implements IChatWidgetHistoryService {
 	_serviceBrand: undefined;
 
 	private memento: Memento<IChatHistory>;
 	private viewState: IChatHistory;
 
-	private readonly _onDidClearHistory = new Emitter<void>();
-	readonly onDidClearHistory: Event<void> = this._onDidClearHistory.event;
+	private readonly _onDidChangeHistory = new Emitter<ChatHistoryChange>();
+	private changed = false;
+	readonly onDidChangeHistory = this._onDidChangeHistory.event;
 
 	constructor(
 		@IStorageService storageService: IStorageService
 	) {
+		super();
+
 		this.memento = new Memento<IChatHistory>('interactive-session', storageService);
 		const loadedState = this.memento.getMemento(StorageScope.WORKSPACE, StorageTarget.MACHINE);
 		this.viewState = loadedState;
+
+		this._register(storageService.onWillSaveState(() => {
+			if (this.changed) {
+				this.memento.saveMemento();
+				this.changed = false;
+			}
+		}));
 	}
 
 	getHistory(location: ChatAgentLocation): IChatModelInputState[] {
 		const key = this.getKey(location);
 		const history = this.viewState.history?.[key] ?? [];
-
-		// Migrate old IChatHistoryEntry format to IChatModelInputState
 		return history.map(entry => this.migrateHistoryEntry(entry));
 	}
 
@@ -124,19 +135,107 @@ export class ChatWidgetHistoryService implements IChatWidgetHistoryService {
 		return location === ChatAgentLocation.Chat ? CHAT_PROVIDER_ID : location;
 	}
 
-	saveHistory(location: ChatAgentLocation, history: IChatModelInputState[]): void {
-		if (!this.viewState.history) {
-			this.viewState.history = {};
-		}
+	append(location: ChatAgentLocation, history: IChatModelInputState): void {
+		this.viewState.history ??= {};
 
 		const key = this.getKey(location);
-		this.viewState.history[key] = history.slice(-ChatInputHistoryMaxEntries);
-		this.memento.saveMemento();
+		this.viewState.history[key] = this.getHistory(location).concat(history).slice(-ChatInputHistoryMaxEntries);
+		this.changed = true;
+		this._onDidChangeHistory.fire({ kind: 'append', entry: history });
 	}
 
 	clearHistory(): void {
 		this.viewState.history = {};
-		this.memento.saveMemento();
-		this._onDidClearHistory.fire();
+		this.changed = true;
+		this._onDidChangeHistory.fire({ kind: 'clear' });
+	}
+}
+
+export class ChatHistoryNavigator extends Disposable {
+	/**
+	 * Index of our point in history. Goes 1 past the length of `_history`
+	 */
+	private _currentIndex: number;
+	private _history: readonly IChatModelInputState[];
+	private _overlay: (IChatModelInputState | undefined)[] = [];
+
+	public get values() {
+		return this.chatWidgetHistoryService.getHistory(this.location);
+	}
+
+	constructor(
+		private readonly location: ChatAgentLocation,
+		@IChatWidgetHistoryService private readonly chatWidgetHistoryService: IChatWidgetHistoryService
+	) {
+		super();
+		this._history = this.chatWidgetHistoryService.getHistory(this.location);
+		this._currentIndex = this._history.length;
+
+		this._register(this.chatWidgetHistoryService.onDidChangeHistory(e => {
+			if (e.kind === 'append') {
+				const prevLength = this._history.length;
+				this._history = this.chatWidgetHistoryService.getHistory(this.location);
+				const newLength = this._history.length;
+
+				// If this append operation adjusted all history entries back, move our index back too
+				// if we weren't pointing to the end of the history.
+				if (prevLength === newLength) {
+					this._overlay.shift();
+					if (this._currentIndex < this._history.length) {
+						this._currentIndex = Math.max(this._currentIndex - 1, 0);
+					}
+				} else if (this._currentIndex === prevLength) {
+					this._currentIndex = newLength;
+				}
+			} else if (e.kind === 'clear') {
+				this._history = [];
+				this._currentIndex = 0;
+			}
+		}));
+	}
+
+	public isAtEnd() {
+		return this._currentIndex === Math.max(this._history.length, this._overlay.length);
+	}
+
+	public isAtStart() {
+		return this._currentIndex === 0;
+	}
+
+	/**
+	 * Replaces a history entry at the current index in this view of the history.
+	 * Allows editing of old history entries while preventing accidental navigation
+	 * from losing the edits.
+	 */
+	public overlay(entry: IChatModelInputState) {
+		this._overlay[this._currentIndex] = entry;
+	}
+
+	public resetCursor() {
+		this._currentIndex = this._history.length;
+	}
+
+	public previous() {
+		this._currentIndex = Math.max(this._currentIndex - 1, 0);
+		return this.current();
+	}
+
+	public next() {
+		this._currentIndex = Math.min(this._currentIndex + 1, this._history.length);
+		return this.current();
+	}
+
+	public current() {
+		return this._overlay[this._currentIndex] ?? this._history[this._currentIndex];
+	}
+
+	/**
+	 * Appends a new entry to the navigator. Resets the state back to the end
+	 * and clears any overlayed entries.
+	 */
+	public append(entry: IChatModelInputState) {
+		this._overlay = [];
+		this._currentIndex = this._history.length;
+		this.chatWidgetHistoryService.append(this.location, entry);
 	}
 }

--- a/src/vs/workbench/contrib/chat/test/common/chatWidgetHistoryService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/chatWidgetHistoryService.test.ts
@@ -1,0 +1,413 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { TestInstantiationService } from '../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
+import { IStorageService, StorageScope } from '../../../../../platform/storage/common/storage.js';
+import { TestStorageService } from '../../../../test/common/workbenchTestServices.js';
+import { IChatModelInputState } from '../../common/chatModel.js';
+import { ChatAgentLocation, ChatModeKind } from '../../common/constants.js';
+import { ChatHistoryNavigator, ChatInputHistoryMaxEntries, ChatWidgetHistoryService, IChatWidgetHistoryService } from '../../common/chatWidgetHistoryService.js';
+import { Memento } from '../../../../common/memento.js';
+
+suite('ChatWidgetHistoryService', () => {
+	const testDisposables = ensureNoDisposablesAreLeakedInTestSuite();
+
+	setup(() => {
+		// Clear memento cache before each test to prevent state leakage
+		Memento.clear(StorageScope.APPLICATION);
+		Memento.clear(StorageScope.PROFILE);
+		Memento.clear(StorageScope.WORKSPACE);
+	});
+
+	function createHistoryService(): ChatWidgetHistoryService {
+		// Create fresh instances for each test to avoid state leakage
+		const instantiationService = testDisposables.add(new TestInstantiationService());
+		const storageService = testDisposables.add(new TestStorageService());
+		instantiationService.stub(IStorageService, storageService);
+		return testDisposables.add(instantiationService.createInstance(ChatWidgetHistoryService));
+	}
+
+	function createInputState(text: string, modeKind = ChatModeKind.Ask): IChatModelInputState {
+		return {
+			inputText: text,
+			attachments: [],
+			mode: { id: modeKind, kind: modeKind },
+			selectedModel: undefined,
+			selections: [],
+			contrib: {}
+		};
+	}
+
+	test('should start with empty history', () => {
+		const historyService = createHistoryService();
+		const history = historyService.getHistory(ChatAgentLocation.Chat);
+		assert.strictEqual(history.length, 0);
+	});
+
+	test('should append and retrieve history entries', () => {
+		const historyService = createHistoryService();
+		const entry = createInputState('test query');
+		historyService.append(ChatAgentLocation.Chat, entry);
+
+		const history = historyService.getHistory(ChatAgentLocation.Chat);
+		assert.strictEqual(history.length, 1);
+		assert.strictEqual(history[0].inputText, 'test query');
+	});
+
+	test('should maintain separate history per location', () => {
+		const historyService = createHistoryService();
+		historyService.append(ChatAgentLocation.Chat, createInputState('chat query'));
+		historyService.append(ChatAgentLocation.Terminal, createInputState('terminal query'));
+
+		const chatHistory = historyService.getHistory(ChatAgentLocation.Chat);
+		const terminalHistory = historyService.getHistory(ChatAgentLocation.Terminal);
+
+		assert.strictEqual(chatHistory.length, 1);
+		assert.strictEqual(terminalHistory.length, 1);
+		assert.strictEqual(chatHistory[0].inputText, 'chat query');
+		assert.strictEqual(terminalHistory[0].inputText, 'terminal query');
+	});
+
+	test('should limit history to max entries', () => {
+		const historyService = createHistoryService();
+		for (let i = 0; i < ChatInputHistoryMaxEntries + 10; i++) {
+			historyService.append(ChatAgentLocation.Chat, createInputState(`query ${i}`));
+		}
+
+		const history = historyService.getHistory(ChatAgentLocation.Chat);
+		assert.strictEqual(history.length, ChatInputHistoryMaxEntries);
+		assert.strictEqual(history[0].inputText, 'query 10'); // First 10 should be dropped
+		assert.strictEqual(history[history.length - 1].inputText, `query ${ChatInputHistoryMaxEntries + 9}`);
+	});
+
+	test('should fire append event when history is added', () => {
+		const historyService = createHistoryService();
+		let eventFired = false;
+		let firedEntry: IChatModelInputState | undefined;
+
+		testDisposables.add(historyService.onDidChangeHistory(e => {
+			if (e.kind === 'append') {
+				eventFired = true;
+				firedEntry = e.entry;
+			}
+		}));
+
+		const entry = createInputState('test');
+		historyService.append(ChatAgentLocation.Chat, entry);
+
+		assert.ok(eventFired);
+		assert.strictEqual(firedEntry?.inputText, 'test');
+	});
+
+	test('should clear all history', () => {
+		const historyService = createHistoryService();
+		historyService.append(ChatAgentLocation.Chat, createInputState('query 1'));
+		historyService.append(ChatAgentLocation.Terminal, createInputState('query 2'));
+
+		historyService.clearHistory();
+
+		assert.strictEqual(historyService.getHistory(ChatAgentLocation.Chat).length, 0);
+		assert.strictEqual(historyService.getHistory(ChatAgentLocation.Terminal).length, 0);
+	});
+
+	test('should fire clear event when history is cleared', () => {
+		const historyService = createHistoryService();
+		let clearEventFired = false;
+
+		testDisposables.add(historyService.onDidChangeHistory(e => {
+			if (e.kind === 'clear') {
+				clearEventFired = true;
+			}
+		}));
+
+		historyService.clearHistory();
+		assert.ok(clearEventFired);
+	});
+});
+
+suite('ChatHistoryNavigator', () => {
+	const testDisposables = ensureNoDisposablesAreLeakedInTestSuite();
+
+	setup(() => {
+		// Clear memento cache before each test to prevent state leakage
+		Memento.clear(StorageScope.APPLICATION);
+		Memento.clear(StorageScope.PROFILE);
+		Memento.clear(StorageScope.WORKSPACE);
+	});
+
+	function createNavigator(): ChatHistoryNavigator {
+		// Create fresh instances for each test to avoid state leakage
+		const instantiationService = testDisposables.add(new TestInstantiationService());
+		const storageService = testDisposables.add(new TestStorageService());
+		instantiationService.stub(IStorageService, storageService);
+
+		const historyService = testDisposables.add(instantiationService.createInstance(ChatWidgetHistoryService));
+		instantiationService.stub(IChatWidgetHistoryService, historyService);
+
+		return testDisposables.add(instantiationService.createInstance(ChatHistoryNavigator, ChatAgentLocation.Chat));
+	}
+
+	function createInputState(text: string): IChatModelInputState {
+		return {
+			inputText: text,
+			attachments: [],
+			mode: { id: ChatModeKind.Ask, kind: ChatModeKind.Ask },
+			selectedModel: undefined,
+			selections: [],
+			contrib: {}
+		};
+	}
+
+	test('should start at end of empty history', () => {
+		const nav = createNavigator();
+		assert.ok(nav.isAtEnd());
+		assert.ok(nav.isAtStart());
+	});
+
+	test('should navigate backwards through history', () => {
+		const nav = createNavigator();
+		nav.append(createInputState('first'));
+		nav.append(createInputState('second'));
+		nav.append(createInputState('third'));
+
+		assert.ok(nav.isAtEnd());
+
+		const prev1 = nav.previous();
+		assert.strictEqual(prev1?.inputText, 'third');
+
+		const prev2 = nav.previous();
+		assert.strictEqual(prev2?.inputText, 'second');
+
+		const prev3 = nav.previous();
+		assert.strictEqual(prev3?.inputText, 'first');
+		assert.ok(nav.isAtStart());
+	});
+
+	test('should navigate forwards through history', () => {
+		const nav = createNavigator();
+		nav.append(createInputState('first'));
+		nav.append(createInputState('second'));
+
+		nav.previous();
+		nav.previous();
+		assert.ok(nav.isAtStart());
+
+		const next1 = nav.next();
+		assert.strictEqual(next1?.inputText, 'second');
+
+		const next2 = nav.next();
+		assert.strictEqual(next2, undefined);
+		assert.ok(nav.isAtEnd());
+	});
+
+	test('should reset cursor to end', () => {
+		const nav = createNavigator();
+		nav.append(createInputState('first'));
+		nav.append(createInputState('second'));
+
+		nav.previous();
+		assert.ok(!nav.isAtEnd());
+
+		nav.resetCursor();
+		assert.ok(nav.isAtEnd());
+	});
+
+	test('should overlay edited entries', () => {
+		const nav = createNavigator();
+		nav.append(createInputState('first'));
+		nav.append(createInputState('second'));
+
+		nav.previous();
+		const edited = createInputState('second edited');
+		nav.overlay(edited);
+
+		const current = nav.current();
+		assert.strictEqual(current?.inputText, 'second edited');
+
+		// Original history should be unchanged
+		assert.strictEqual(nav.values[1].inputText, 'second');
+	});
+
+	test('should clear overlay on append', () => {
+		const nav = createNavigator();
+		nav.append(createInputState('first'));
+
+		nav.previous();
+		nav.overlay(createInputState('first edited'));
+
+		const currentBefore = nav.current();
+		assert.strictEqual(currentBefore?.inputText, 'first edited');
+
+		nav.append(createInputState('second'));
+
+		// After append, cursor should be at end and overlay cleared
+		assert.ok(nav.isAtEnd());
+		nav.previous();
+		assert.strictEqual(nav.current()?.inputText, 'second');
+	});
+
+	test('should stop at start when navigating backwards', () => {
+		const nav = createNavigator();
+		nav.append(createInputState('only'));
+
+		nav.previous();
+		assert.ok(nav.isAtStart());
+
+		const prev = nav.previous();
+		assert.strictEqual(prev?.inputText, 'only'); // Should stay at first
+		assert.ok(nav.isAtStart());
+	});
+
+	test('should stop at end when navigating forwards', () => {
+		const nav = createNavigator();
+		nav.append(createInputState('only'));
+
+		const next1 = nav.next();
+		assert.strictEqual(next1, undefined);
+		assert.ok(nav.isAtEnd());
+
+		const next2 = nav.next();
+		assert.strictEqual(next2, undefined);
+		assert.ok(nav.isAtEnd());
+	});
+
+	test('should update when history service appends entries', () => {
+		const instantiationService = testDisposables.add(new TestInstantiationService());
+		const storageService = testDisposables.add(new TestStorageService());
+		instantiationService.stub(IStorageService, storageService);
+
+		const historyService = testDisposables.add(instantiationService.createInstance(ChatWidgetHistoryService));
+		instantiationService.stub(IChatWidgetHistoryService, historyService);
+
+		const nav = testDisposables.add(instantiationService.createInstance(ChatHistoryNavigator, ChatAgentLocation.Chat));
+
+		historyService.append(ChatAgentLocation.Chat, createInputState('from service'));
+
+		const history = nav.values;
+		assert.strictEqual(history.length, 1);
+		assert.strictEqual(history[0].inputText, 'from service');
+	});
+
+	test('should adjust cursor when history is cleared', () => {
+		const instantiationService = testDisposables.add(new TestInstantiationService());
+		const storageService = testDisposables.add(new TestStorageService());
+		instantiationService.stub(IStorageService, storageService);
+
+		const historyService = testDisposables.add(instantiationService.createInstance(ChatWidgetHistoryService));
+		instantiationService.stub(IChatWidgetHistoryService, historyService);
+
+		const nav = testDisposables.add(instantiationService.createInstance(ChatHistoryNavigator, ChatAgentLocation.Chat));
+
+		nav.append(createInputState('first'));
+		nav.append(createInputState('second'));
+
+		nav.previous();
+		assert.ok(!nav.isAtEnd());
+
+		historyService.clearHistory();
+
+		assert.ok(nav.isAtEnd());
+		assert.ok(nav.isAtStart());
+		assert.strictEqual(nav.values.length, 0);
+	});
+
+	test('should handle cursor adjustment when max entries reached', () => {
+		const nav = createNavigator();
+		// Add entries up to the max
+		for (let i = 0; i < ChatInputHistoryMaxEntries; i++) {
+			nav.append(createInputState(`entry ${i}`));
+		}
+
+		// Navigate to middle of history
+		for (let i = 0; i < 20; i++) {
+			nav.previous();
+		}
+
+		// Add one more entry (should drop oldest)
+		nav.append(createInputState('new entry'));
+
+		// Cursor should be at end after append
+		assert.ok(nav.isAtEnd());
+	});
+
+	test('should support concurrent navigators', () => {
+		const instantiationService = testDisposables.add(new TestInstantiationService());
+		const storageService = testDisposables.add(new TestStorageService());
+		instantiationService.stub(IStorageService, storageService);
+
+		const historyService = testDisposables.add(instantiationService.createInstance(ChatWidgetHistoryService));
+		instantiationService.stub(IChatWidgetHistoryService, historyService);
+
+		const nav1 = testDisposables.add(instantiationService.createInstance(ChatHistoryNavigator, ChatAgentLocation.Chat));
+		const nav2 = testDisposables.add(instantiationService.createInstance(ChatHistoryNavigator, ChatAgentLocation.Chat));
+
+		nav1.append(createInputState('query 1'));
+
+		assert.strictEqual(nav1.values.length, 1);
+		assert.strictEqual(nav2.values.length, 1);
+		assert.strictEqual(nav1.values[0].inputText, 'query 1');
+		assert.strictEqual(nav2.values[0].inputText, 'query 1');
+
+		nav1.previous();
+		assert.ok(!nav1.isAtEnd());
+		assert.ok(nav2.isAtEnd());
+
+		nav2.append(createInputState('query 2'));
+
+		assert.strictEqual(nav1.values.length, 2);
+		assert.strictEqual(nav2.values.length, 2);
+
+		// nav1 should stay at same position (pointing to query 1)
+		assert.strictEqual(nav1.current()?.inputText, 'query 1');
+
+		// nav2 should be at end
+		assert.ok(nav2.isAtEnd());
+	});
+
+	test('should support concurrent navigators with mixed positions', () => {
+		const instantiationService = testDisposables.add(new TestInstantiationService());
+		const storageService = testDisposables.add(new TestStorageService());
+		instantiationService.stub(IStorageService, storageService);
+
+		const historyService = testDisposables.add(instantiationService.createInstance(ChatWidgetHistoryService));
+		instantiationService.stub(IChatWidgetHistoryService, historyService);
+
+		const nav1 = testDisposables.add(instantiationService.createInstance(ChatHistoryNavigator, ChatAgentLocation.Chat));
+		const nav2 = testDisposables.add(instantiationService.createInstance(ChatHistoryNavigator, ChatAgentLocation.Chat));
+
+		nav1.append(createInputState('query 1'));
+		nav1.append(createInputState('query 2'));
+		nav1.append(createInputState('query 3'));
+
+		// Both at end
+		assert.ok(nav1.isAtEnd());
+		assert.ok(nav2.isAtEnd());
+
+		// Move nav1 back to 'query 2'
+		nav1.previous();
+		assert.strictEqual(nav1.current()?.inputText, 'query 3');
+		nav1.previous();
+		assert.strictEqual(nav1.current()?.inputText, 'query 2');
+
+		// Move nav2 back to 'query 1'
+		nav2.previous();
+		nav2.previous();
+		nav2.previous();
+		assert.strictEqual(nav2.current()?.inputText, 'query 1');
+
+		// Append new query
+		nav1.append(createInputState('query 4'));
+
+		// nav1 should be at end (because it appended)
+		assert.ok(nav1.isAtEnd());
+		assert.strictEqual(nav1.values.length, 4);
+
+		// nav2 should stay at 'query 1'
+		assert.strictEqual(nav2.current()?.inputText, 'query 1');
+		assert.strictEqual(nav2.values.length, 4);
+	});
+});


### PR DESCRIPTION
Previously history was read and updated individually by chat components,
which could cause some history to get lost if multiple chat editors
were open.

This adds a ChatHistoryNavigator which is a view on the chat history.
It reacts when new entries are appended, preserving the history position
of other editors while allowing editor-local modifications via its
'overlay' (which is also used to keep the current in-progress edit
when navigating back in history).

Also brings back _getFilteredEntry which was lost in my earlier refactor.

Refs #277318

cc @TylerLeonhardt please let me know if you see any more issues
after this is in :)