### PR TITLE
Adopt IChatWidgetService.openSession in more places

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/actions/chatImportExport.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatImportExport.ts
@@ -17,7 +17,6 @@ import { ChatEditorInput } from '../chatEditorInput.js';
 import { ChatContextKeys } from '../../common/chatContextKeys.js';
 import { isExportableSessionData } from '../../common/chatModel.js';
 import { IChatService } from '../../common/chatService.js';
-import { IEditorService } from '../../../../services/editor/common/editorService.js';
 import { URI } from '../../../../../base/common/uri.js';
 
 const defaultFileName = 'chat.json';
@@ -81,7 +80,7 @@ export function registerChatExportActions() {
 		async run(accessor: ServicesAccessor, ...args: unknown[]) {
 			const fileDialogService = accessor.get(IFileDialogService);
 			const fileService = accessor.get(IFileService);
-			const editorService = accessor.get(IEditorService);
+			const widgetService = accessor.get(IChatWidgetService);
 
 			const defaultUri = joinPath(await fileDialogService.defaultFilePath(), defaultFileName);
 			const result = await fileDialogService.showOpenDialog({
@@ -101,7 +100,7 @@ export function registerChatExportActions() {
 				}
 
 				const options: IChatEditorOptions = { target: { data }, pinned: true };
-				await editorService.openEditor({ resource: ChatEditorInput.getNewEditorUri(), options });
+				await widgetService.openSession(ChatEditorInput.getNewEditorUri(), undefined, options);
 			} catch (err) {
 				throw err;
 			}

--- a/src/vs/workbench/contrib/chat/browser/actions/chatMoveActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatMoveActions.ts
@@ -113,21 +113,20 @@ export function registerMoveActions() {
 
 async function executeMoveToAction(accessor: ServicesAccessor, moveTo: MoveToNewLocation, sessionResource?: URI) {
 	const widgetService = accessor.get(IChatWidgetService);
-	const editorService = accessor.get(IEditorService);
 
 	const auxiliary = { compact: true, bounds: { width: 800, height: 640 } };
 
 	const widget = (sessionResource ? widgetService.getWidgetBySessionResource(sessionResource) : undefined)
 		?? widgetService.lastFocusedWidget;
 	if (!widget || !widget.viewModel || widget.location !== ChatAgentLocation.Chat) {
-		await editorService.openEditor({ resource: ChatEditorInput.getNewEditorUri(), options: { pinned: true, auxiliary } }, moveTo === MoveToNewLocation.Window ? AUX_WINDOW_GROUP : ACTIVE_GROUP);
+		await widgetService.openSession(ChatEditorInput.getNewEditorUri(), moveTo === MoveToNewLocation.Window ? AUX_WINDOW_GROUP : ACTIVE_GROUP, { pinned: true, auxiliary });
 		return;
 	}
 
 	const existingWidget = widgetService.getWidgetBySessionResource(widget.viewModel.sessionResource);
 	if (!existingWidget) {
 		// Do NOT attempt to open a session that isn't already open since we cannot guarantee its state.
-		await editorService.openEditor({ resource: ChatEditorInput.getNewEditorUri(), options: { pinned: true, auxiliary } }, moveTo === MoveToNewLocation.Window ? AUX_WINDOW_GROUP : ACTIVE_GROUP);
+		await widgetService.openSession(ChatEditorInput.getNewEditorUri(), moveTo === MoveToNewLocation.Window ? AUX_WINDOW_GROUP : ACTIVE_GROUP, { pinned: true, auxiliary });
 		return;
 	}
 
@@ -140,7 +139,7 @@ async function executeMoveToAction(accessor: ServicesAccessor, moveTo: MoveToNew
 	await widget.clear();
 
 	const options: IChatEditorOptions = { pinned: true, modelInputState, auxiliary };
-	await editorService.openEditor({ resource: resourceToOpen, options }, moveTo === MoveToNewLocation.Window ? AUX_WINDOW_GROUP : ACTIVE_GROUP);
+	await widgetService.openSession(resourceToOpen, moveTo === MoveToNewLocation.Window ? AUX_WINDOW_GROUP : ACTIVE_GROUP, options);
 }
 
 async function moveToSidebar(accessor: ServicesAccessor): Promise<void> {

--- a/src/vs/workbench/contrib/chat/browser/actions/chatSessionActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatSessionActions.ts
@@ -21,20 +21,17 @@ import { KeybindingWeight } from '../../../../../platform/keybinding/common/keyb
 import { ILogService } from '../../../../../platform/log/common/log.js';
 import { IProductService } from '../../../../../platform/product/common/productService.js';
 import { IQuickInputService } from '../../../../../platform/quickinput/common/quickInput.js';
-import { IEditorGroupsService } from '../../../../services/editor/common/editorGroupsService.js';
-import { AUX_WINDOW_GROUP, IEditorService, SIDE_GROUP } from '../../../../services/editor/common/editorService.js';
+import { AUX_WINDOW_GROUP, SIDE_GROUP } from '../../../../services/editor/common/editorService.js';
 import { IWorkbenchExtensionManagementService } from '../../../../services/extensionManagement/common/extensionManagement.js';
 import { IViewsService } from '../../../../services/views/common/viewsService.js';
 import { ChatContextKeys } from '../../common/chatContextKeys.js';
 import { IChatService } from '../../common/chatService.js';
 import { IChatSessionItem, IChatSessionsService, localChatSessionType } from '../../common/chatSessionsService.js';
 import { LocalChatSessionUri } from '../../common/chatUri.js';
-import { LEGACY_AGENT_SESSIONS_VIEW_ID, ChatConfiguration } from '../../common/constants.js';
+import { ChatConfiguration, LEGACY_AGENT_SESSIONS_VIEW_ID } from '../../common/constants.js';
 import { AGENT_SESSIONS_VIEW_CONTAINER_ID, AGENT_SESSIONS_VIEW_ID } from '../agentSessions/agentSessions.js';
-import { ChatViewId, IChatWidgetService } from '../chat.js';
+import { ChatViewPaneTarget, IChatWidgetService } from '../chat.js';
 import { IChatEditorOptions } from '../chatEditor.js';
-import { findExistingChatEditorByUri } from '../chatSessions/common.js';
-import { ChatViewPane } from '../chatViewPane.js';
 import { ACTION_ID_OPEN_CHAT, CHAT_CATEGORY } from './chatActions.js';
 
 export interface IMarshalledChatSessionContext {
@@ -176,29 +173,14 @@ export class OpenChatSessionInNewWindowAction extends Action2 {
 			return;
 		}
 
-		const editorService = accessor.get(IEditorService);
 		const chatWidgetService = accessor.get(IChatWidgetService);
-		const editorGroupsService = accessor.get(IEditorGroupsService);
-
 		const uri = context.session.resource;
 
-		// Check if this session is already open in another editor
-		const existingEditor = findExistingChatEditorByUri(uri, editorGroupsService);
-		if (existingEditor) {
-			await editorService.openEditor(existingEditor.editor, existingEditor.group);
-			return;
-		} else if (chatWidgetService.getWidgetBySessionResource(uri)) {
-			return;
-		} else {
-			const options: IChatEditorOptions = {
-				ignoreInView: true,
-				auxiliary: { compact: true, bounds: { width: 800, height: 640 } }
-			};
-			await editorService.openEditor({
-				resource: uri,
-				options,
-			}, AUX_WINDOW_GROUP);
-		}
+		const options: IChatEditorOptions = {
+			ignoreInView: true,
+			auxiliary: { compact: true, bounds: { width: 800, height: 640 } }
+		};
+		await chatWidgetService.openSession(uri, AUX_WINDOW_GROUP, options);
 	}
 }
 
@@ -222,29 +204,13 @@ export class OpenChatSessionInNewEditorGroupAction extends Action2 {
 			return;
 		}
 
-		const editorService = accessor.get(IEditorService);
 		const chatWidgetService = accessor.get(IChatWidgetService);
-		const editorGroupsService = accessor.get(IEditorGroupsService);
-
 		const uri = context.session.resource;
 
-		// Check if this session is already open in another editor
-		const existingEditor = findExistingChatEditorByUri(uri, editorGroupsService);
-		if (existingEditor) {
-			await editorService.openEditor(existingEditor.editor, existingEditor.group);
-			return;
-		} else if (chatWidgetService.getWidgetBySessionResource(uri)) {
-			// Already opened in chat widget
-			return;
-		} else {
-			const options: IChatEditorOptions = {
-				ignoreInView: true,
-			};
-			await editorService.openEditor({
-				resource: uri,
-				options,
-			}, SIDE_GROUP);
-		}
+		const options: IChatEditorOptions = {
+			ignoreInView: true,
+		};
+		await chatWidgetService.openSession(uri, SIDE_GROUP, options);
 	}
 }
 
@@ -264,10 +230,7 @@ export class OpenChatSessionInSidebarAction extends Action2 {
 	}
 
 	async run(accessor: ServicesAccessor, context?: IMarshalledChatSessionContext): Promise<void> {
-		const editorService = accessor.get(IEditorService);
-		const viewsService = accessor.get(IViewsService);
 		const chatWidgetService = accessor.get(IChatWidgetService);
-		const editorGroupsService = accessor.get(IEditorGroupsService);
 
 		if (!context) {
 			return;
@@ -278,25 +241,8 @@ export class OpenChatSessionInSidebarAction extends Action2 {
 			return;
 		}
 
-		// Check if this session is already open in another editor
-		// TODO: this feels strange. Should we prefer moving the editor to the sidebar instead?
-		const existingEditor = findExistingChatEditorByUri(context.session.resource, editorGroupsService);
-		if (existingEditor) {
-			await editorService.openEditor(existingEditor.editor, existingEditor.group);
-			return;
-		} else if (chatWidgetService.getWidgetBySessionResource(context.session.resource)) {
-			return;
-		}
-
-		// Open the chat view in the sidebar
-		const chatViewPane = await viewsService.openView(ChatViewId) as ChatViewPane;
-		if (chatViewPane) {
-			// Handle different session types
-			await chatViewPane.loadSession(context.session.resource);
-
-			// Focus the chat input
-			chatViewPane.focusInput();
-		}
+		// TODO: this feels strange. Should we prefer moving the editor to the sidebar instead? @osortega
+		await chatWidgetService.openSession(context.session.resource, ChatViewPaneTarget);
 	}
 }
 

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsView.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsView.ts
@@ -159,7 +159,7 @@ export class AgentSessionsView extends ViewPane {
 		}
 
 		const provider = await this.chatSessionsService.activateChatSessionItemProvider(session.providerType);
-		const contextOverlay = getSessionItemContextOverlay(session, provider, this.chatWidgetService, this.chatService, this.editorGroupsService);
+		const contextOverlay = getSessionItemContextOverlay(session, provider, this.chatService, this.editorGroupsService);
 		contextOverlay.push([ChatContextKeys.isCombinedSessionViewer.key, true]);
 		const menu = this.menuService.createMenu(MenuId.ChatSessionsMenu, this.contextKeyService.createOverlay(contextOverlay));
 

--- a/src/vs/workbench/contrib/chat/browser/chatSessions/view/sessionsTreeRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSessions/view/sessionsTreeRenderer.ts
@@ -45,7 +45,6 @@ import { ChatSessionStatus, IChatSessionItem, IChatSessionItemProvider, IChatSes
 import { LocalChatSessionUri } from '../../../common/chatUri.js';
 import { ChatConfiguration } from '../../../common/constants.js';
 import { IMarshalledChatSessionContext } from '../../actions/chatSessionActions.js';
-import { IChatWidgetService } from '../../chat.js';
 import { allowedChatMarkdownHtmlTags } from '../../chatContentMarkdownRenderer.js';
 import '../../media/chatSessions.css';
 import { ChatSessionTracker } from '../chatSessionTracker.js';
@@ -141,7 +140,6 @@ export class SessionsRenderer extends Disposable implements ITreeRenderer<IChatS
 		@IMenuService private readonly menuService: IMenuService,
 		@IContextKeyService private readonly contextKeyService: IContextKeyService,
 		@IHoverService private readonly hoverService: IHoverService,
-		@IChatWidgetService private readonly chatWidgetService: IChatWidgetService,
 		@IChatService private readonly chatService: IChatService,
 		@IEditorGroupsService private readonly editorGroupsService: IEditorGroupsService,
 		@IWorkbenchLayoutService private readonly layoutService: IWorkbenchLayoutService,
@@ -360,7 +358,6 @@ export class SessionsRenderer extends Disposable implements ITreeRenderer<IChatS
 		const contextOverlay = getSessionItemContextOverlay(
 			session,
 			session.provider,
-			this.chatWidgetService,
 			this.chatService,
 			this.editorGroupsService
 		);

--- a/src/vs/workbench/contrib/chat/browser/chatSessions/view/sessionsViewPane.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSessions/view/sessionsViewPane.ts
@@ -494,7 +494,6 @@ export class SessionsViewPane extends ViewPane {
 		const contextOverlay = getSessionItemContextOverlay(
 			session,
 			sessionWithProvider.provider,
-			this.chatWidgetService,
 			this.chatService,
 			this.editorGroupsService
 		);

--- a/src/vs/workbench/contrib/chat/browser/chatWidgetService.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatWidgetService.ts
@@ -11,12 +11,12 @@ import { isEqual } from '../../../../base/common/resources.js';
 import { URI } from '../../../../base/common/uri.js';
 import { ILayoutService } from '../../../../platform/layout/browser/layoutService.js';
 import { IEditorService, PreferredGroup } from '../../../../workbench/services/editor/common/editorService.js';
-import { IEditorGroupsService } from '../../../services/editor/common/editorGroupsService.js';
+import { IEditorGroup, IEditorGroupsService } from '../../../services/editor/common/editorGroupsService.js';
 import { IViewsService } from '../../../services/views/common/viewsService.js';
 import { ChatAgentLocation } from '../common/constants.js';
 import { ChatViewId, ChatViewPaneTarget, IChatWidget, IChatWidgetService, IQuickChatService, isIChatViewViewContext } from './chat.js';
 import { ChatEditor, IChatEditorOptions } from './chatEditor.js';
-import { findExistingChatEditorByUri } from './chatSessions/common.js';
+import { ChatEditorInput } from './chatEditorInput.js';
 import { ChatViewPane } from './chatViewPane.js';
 
 export class ChatWidgetService extends Disposable implements IChatWidgetService {
@@ -128,7 +128,7 @@ export class ChatWidgetService extends Disposable implements IChatWidgetService 
 		}
 
 		// Already open in an editor?
-		const existingEditor = findExistingChatEditorByUri(sessionResource, this.editorGroupsService);
+		const existingEditor = this.findExistingChatEditorByUri(sessionResource);
 		if (existingEditor) {
 			// focus transfer to other documents is async. If we depend on the focus
 			// being synchronously transferred in consuming code, this can fail, so
@@ -154,6 +154,17 @@ export class ChatWidgetService extends Disposable implements IChatWidgetService 
 			return undefined;
 		}
 
+		return undefined;
+	}
+
+	private findExistingChatEditorByUri(sessionUri: URI): { editor: ChatEditorInput; group: IEditorGroup } | undefined {
+		for (const group of this.editorGroupsService.groups) {
+			for (const editor of group.editors) {
+				if (editor instanceof ChatEditorInput && isEqual(editor.sessionResource, sessionUri)) {
+					return { editor, group };
+				}
+			}
+		}
 		return undefined;
 	}
 


### PR DESCRIPTION
Adopt `ChatWidgetService.openSession` in various components to streamline session handling and simplify code. Remove unnecessary dependencies on `IChatWidgetService` where applicable.

