### PR TITLE
Improve keybinding table styling for better visibility

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/media/keybindingsEditor.css
+++ b/src/vs/workbench/contrib/preferences/browser/media/keybindingsEditor.css
@@ -228,10 +228,13 @@
 
 .keybindings-editor > .keybindings-body > .keybindings-table-container .monaco-table .monaco-list-row.focused .monaco-table-tr .monaco-table-td .monaco-keybinding-key {
 	color: var(--vscode-list-focusForeground);
+
 }
 
 .keybindings-editor > .keybindings-body > .keybindings-table-container .monaco-table.focused .monaco-list-row.selected .monaco-table-tr .monaco-table-td .monaco-keybinding-key {
 	color: var(--vscode-list-activeSelectionForeground);
+	border-color: inherit !important;
+	opacity: 0.8;
 }
 
 .keybindings-editor > .keybindings-body > .keybindings-table-container .monaco-table .monaco-list-row:hover:not(.selected):not(.focused) .monaco-table-tr .monaco-table-td .monaco-keybinding-key {

--- a/src/vs/workbench/contrib/preferences/browser/media/keybindingsEditor.css
+++ b/src/vs/workbench/contrib/preferences/browser/media/keybindingsEditor.css
@@ -228,7 +228,6 @@
 
 .keybindings-editor > .keybindings-body > .keybindings-table-container .monaco-table .monaco-list-row.focused .monaco-table-tr .monaco-table-td .monaco-keybinding-key {
 	color: var(--vscode-list-focusForeground);
-
 }
 
 .keybindings-editor > .keybindings-body > .keybindings-table-container .monaco-table.focused .monaco-list-row.selected .monaco-table-tr .monaco-table-td .monaco-keybinding-key {


### PR DESCRIPTION
Enhance the styling of the keybinding table in the Keyboard Shortcuts editor to improve focus and selection visibility. This change ensures that users can easily identify focused and selected keybindings. 

Testing can be done by navigating to the Keyboard Shortcuts editor and observing the updated styles during focus and selection.

<img width="977" height="605" alt="image" src="https://github.com/user-attachments/assets/fc72568b-362f-4c0d-a34d-0b92e5b97427" />


