### PR TITLE
Build script cleanup

### DIFF
--- a/build/azure-pipelines/upload-cdn.ts
+++ b/build/azure-pipelines/upload-cdn.ts
@@ -71,7 +71,7 @@ const MimeTypesToCompress = new Set([
 function wait(stream: es.ThroughStream): Promise<void> {
 	return new Promise<void>((c, e) => {
 		stream.on('end', () => c());
-		stream.on('error', (err: any) => e(err));
+		stream.on('error', (err) => e(err));
 	});
 }
 

--- a/build/azure-pipelines/upload-sourcemaps.ts
+++ b/build/azure-pipelines/upload-sourcemaps.ts
@@ -65,7 +65,7 @@ function main(): Promise<void> {
 				prefix: `sourcemaps/${commit}/`
 			}))
 			.on('end', () => c())
-			.on('error', (err: any) => e(err));
+			.on('error', (err) => e(err));
 	});
 }
 

--- a/build/gulpfile.editor.ts
+++ b/build/gulpfile.editor.ts
@@ -6,7 +6,7 @@
 import gulp from 'gulp';
 import path from 'path';
 import * as util from './lib/util.ts';
-import * as getVersionModule from './lib/getVersion.ts';
+import { getVersion } from './lib/getVersion.ts';
 import * as task from './lib/task.ts';
 import es from 'event-stream';
 import File from 'vinyl';
@@ -17,11 +17,9 @@ import * as compilation from './lib/compilation.ts';
 import * as monacoapi from './lib/monaco-api.ts';
 import * as fs from 'fs';
 import filter from 'gulp-filter';
-import * as reporterModule from './lib/reporter.ts';
+import { createReporter } from './lib/reporter.ts';
 import monacoPackage from './monaco/package.json' with { type: 'json' };
 
-const { getVersion } = getVersionModule;
-const { createReporter } = reporterModule;
 const root = path.dirname(import.meta.dirname);
 const sha1 = getVersion(root);
 const semver = monacoPackage.version;

--- a/build/gulpfile.extensions.ts
+++ b/build/gulpfile.extensions.ts
@@ -13,18 +13,16 @@ import * as nodeUtil from 'util';
 import es from 'event-stream';
 import filter from 'gulp-filter';
 import * as util from './lib/util.ts';
-import * as getVersionModule from './lib/getVersion.ts';
+import { getVersion } from './lib/getVersion.ts';
 import * as task from './lib/task.ts';
 import watcher from './lib/watch/index.ts';
-import * as reporterModule from './lib/reporter.ts';
+import { createReporter } from './lib/reporter.ts';
 import glob from 'glob';
 import plumber from 'gulp-plumber';
 import * as ext from './lib/extensions.ts';
 import * as tsb from './lib/tsb/index.ts';
 import sourcemaps from 'gulp-sourcemaps';
 
-const { getVersion } = getVersionModule;
-const { createReporter } = reporterModule;
 const root = path.dirname(import.meta.dirname);
 const commit = getVersion(root);
 

--- a/build/gulpfile.scan.ts
+++ b/build/gulpfile.scan.ts
@@ -8,12 +8,10 @@ import * as path from 'path';
 import * as task from './lib/task.ts';
 import * as util from './lib/util.ts';
 import electron from '@vscode/gulp-electron';
-import * as electronConfigModule from './lib/electron.ts';
+import { config } from './lib/electron.ts';
 import filter from 'gulp-filter';
 import * as deps from './lib/dependencies.ts';
 import { existsSync, readdirSync } from 'fs';
-
-const { config } = electronConfigModule;
 
 const root = path.dirname(import.meta.dirname);
 

--- a/build/gulpfile.vscode.web.ts
+++ b/build/gulpfile.vscode.web.ts
@@ -86,7 +86,7 @@ const vscodeWebEntryPoints = [
 ].flat();
 
 /**
- * @param extensionsRoot {string} The location where extension will be read from
+ * @param extensionsRoot The location where extension will be read from
  * @param product The parsed product.json file contents
  */
 export const createVSCodeWebFileContentMapper = (extensionsRoot: string, product: typeof import('../product.json')) => {

--- a/build/gulpfile.vscode.win32.ts
+++ b/build/gulpfile.vscode.win32.ts
@@ -2,22 +2,22 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import gulp from 'gulp';
-import * as path from 'path';
-import * as fs from 'fs';
 import assert from 'assert';
 import * as cp from 'child_process';
-import * as util from './lib/util.ts';
-import * as getVersionModule from './lib/getVersion.ts';
-import * as task from './lib/task.ts';
+import * as fs from 'fs';
+import gulp from 'gulp';
+import * as path from 'path';
+import rcedit from 'rcedit';
+import vfs from 'vinyl-fs';
 import pkg from '../package.json' with { type: 'json' };
 import product from '../product.json' with { type: 'json' };
-import vfs from 'vinyl-fs';
-import rcedit from 'rcedit';
-import { createRequire } from 'module';
+import { getVersion } from './lib/getVersion.ts';
+import * as task from './lib/task.ts';
+import * as util from './lib/util.ts';
 
-const { getVersion } = getVersionModule;
+import { createRequire } from 'module';
 const require = createRequire(import.meta.url);
+
 const repoPath = path.dirname(import.meta.dirname);
 const commit = getVersion(repoPath);
 const buildPath = (arch: string) => path.join(path.dirname(repoPath), `VSCode-win32-${arch}`);
@@ -58,12 +58,12 @@ function packageInnoSetup(iss: string, options: { definitions?: Record<string, u
 		});
 }
 
-function buildWin32Setup(arch: string, target: string) {
+function buildWin32Setup(arch: string, target: string): task.CallbackTask {
 	if (target !== 'system' && target !== 'user') {
 		throw new Error('Invalid setup target');
 	}
 
-	return (cb?: (err?: any) => void) => {
+	return (cb) => {
 		const x64AppId = target === 'system' ? product.win32x64AppId : product.win32x64UserAppId;
 		const arm64AppId = target === 'system' ? product.win32arm64AppId : product.win32arm64UserAppId;
 

--- a/build/lib/compilation.ts
+++ b/build/lib/compilation.ts
@@ -247,7 +247,7 @@ class MonacoGenerator {
 		return r;
 	}
 
-	private _log(message: any, ...rest: unknown[]): void {
+	private _log(message: string, ...rest: unknown[]): void {
 		fancyLog(ansiColors.cyan('[monaco.d.ts]'), message, ...rest);
 	}
 

--- a/build/lib/extensions.ts
+++ b/build/lib/extensions.ts
@@ -131,7 +131,7 @@ function fromLocalWebpack(extensionPath: string, webpackConfigFileName: string, 
 		) as string[]);
 		const webpackStreams = webpackConfigLocations.flatMap(webpackConfigPath => {
 
-			const webpackDone = (err: any, stats: any) => {
+			const webpackDone = (err: Error | undefined, stats: any) => {
 				fancyLog(`Bundled extension: ${ansiColors.yellow(path.join(path.basename(extensionPath), path.relative(extensionPath, webpackConfigPath)))}...`);
 				if (err) {
 					result.emit('error', err);

--- a/build/lib/i18n.ts
+++ b/build/lib/i18n.ts
@@ -80,7 +80,7 @@ interface BundledFormat {
 
 type NLSKeysFormat = [string /* module ID */, string[] /* keys */];
 
-function isNLSKeysFormat(value: any): value is NLSKeysFormat {
+function isNLSKeysFormat(value: unknown): value is NLSKeysFormat {
 	if (value === undefined) {
 		return false;
 	}
@@ -239,7 +239,7 @@ export class XLF {
 
 			const files: { messages: Record<string, string>; name: string; language: string }[] = [];
 
-			parser.parseString(xlfString, function (err: any, result: any) {
+			parser.parseString(xlfString, function (err: Error | undefined, result: any) {
 				if (err) {
 					reject(new Error(`XLF parsing error: Failed to parse XLIFF string. ${err}`));
 				}

--- a/build/lib/nls.ts
+++ b/build/lib/nls.ts
@@ -268,7 +268,7 @@ const _nls = (() => {
 		// `localize` named imports
 		const allLocalizeImportDeclarations = importDeclarations
 			.filter(d => !!(d.importClause && d.importClause.namedBindings && d.importClause.namedBindings.kind === ts.SyntaxKind.NamedImports))
-			.map(d => ([] as any[]).concat((d.importClause!.namedBindings! as ts.NamedImports).elements))
+			.map(d => (d.importClause!.namedBindings! as ts.NamedImports).elements)
 			.flatten();
 
 		// `localize` read-only references
@@ -280,7 +280,7 @@ const _nls = (() => {
 
 		// custom named `localize` read-only references
 		const namedLocalizeReferences = allLocalizeImportDeclarations
-			.filter(d => d.propertyName && d.propertyName.getText() === functionName)
+			.filter(d => !!d.propertyName && d.propertyName.getText() === functionName)
 			.map(n => service.getReferencesAtPosition(filename, n.name.pos + 1) ?? [])
 			.flatten()
 			.filter(r => !r.isWriteAccess);

--- a/build/lib/task.ts
+++ b/build/lib/task.ts
@@ -18,7 +18,7 @@ export interface StreamTask extends BaseTask {
 	(): NodeJS.ReadWriteStream;
 }
 export interface CallbackTask extends BaseTask {
-	(cb?: (err?: any) => void): void;
+	(cb?: (err?: Error) => void): void;
 }
 
 export type Task = PromiseTask | StreamTask | CallbackTask;

--- a/build/npm/dirs.ts
+++ b/build/npm/dirs.ts
@@ -5,7 +5,9 @@
 
 import { existsSync } from 'fs';
 
-// Complete list of directories where npm should be executed to install node modules
+/**
+ * Complete list of directories where npm should be executed to install node modules
+ */
 export const dirs = [
 	'',
 	'build',

--- a/build/npm/mixin-telemetry-docs.ts
+++ b/build/npm/mixin-telemetry-docs.ts
@@ -5,9 +5,8 @@
 import { execSync } from 'child_process';
 import { join, resolve } from 'path';
 import { existsSync, rmSync } from 'fs';
-import { fileURLToPath } from 'url';
 
-const rootPath = resolve(fileURLToPath(import.meta.url), '..', '..', '..');
+const rootPath = resolve(import.meta.dirname, '..', '..');
 const telemetryDocsPath = join(rootPath, 'vscode-telemetry-docs');
 const repoUrl = 'https://github.com/microsoft/vscode-telemetry-docs';
 

--- a/build/npm/update-all-grammars.ts
+++ b/build/npm/update-all-grammars.ts
@@ -6,7 +6,6 @@
 import { spawn as _spawn } from 'child_process';
 import { readdirSync, readFileSync } from 'fs';
 import { join } from 'path';
-import url from 'url';
 
 async function spawn(cmd: string, args: string[], opts?: Parameters<typeof _spawn>[2]) {
 	return new Promise<void>((c, e) => {
@@ -40,9 +39,11 @@ async function main() {
 	}
 }
 
-if (import.meta.url === url.pathToFileURL(process.argv[1]).href) {
-	main().catch(err => {
+if (import.meta.main) {
+	try {
+		await main();
+	} catch (err) {
 		console.error(err);
 		process.exit(1);
-	});
+	}
 }

--- a/build/npm/update-distro.ts
+++ b/build/npm/update-distro.ts
@@ -5,9 +5,8 @@
 import { execSync } from 'child_process';
 import { join, resolve } from 'path';
 import { readFileSync, writeFileSync } from 'fs';
-import { fileURLToPath } from 'url';
 
-const rootPath = resolve(fileURLToPath(import.meta.url), '..', '..', '..', '..');
+const rootPath = resolve(import.meta.dirname, '..', '..', '..');
 const vscodePath = join(rootPath, 'vscode');
 const distroPath = join(rootPath, 'vscode-distro');
 const commit = execSync('git rev-parse HEAD', { cwd: distroPath, encoding: 'utf8' }).trim();

--- a/build/tsconfig.json
+++ b/build/tsconfig.json
@@ -9,14 +9,7 @@
 		"erasableSyntaxOnly": true,
 		"verbatimModuleSyntax": true,
 		"allowImportingTsExtensions": true,
-		"preserveConstEnums": true,
-		"sourceMap": true,
 		"resolveJsonModule": true,
-		// enable JavaScript type checking for the language service
-		// use the tsconfig.build.json for compiling which disable JavaScript
-		// type checking so that JavaScript file are not transpiled
-		"allowJs": true,
-		"checkJs": false,
 		"skipLibCheck": true,
 		"strict": true,
 		"exactOptionalPropertyTypes": false,


### PR DESCRIPTION
For #277526

Quick cleanup pass after converting these scripts to typescript 

- Remove unused config file options
- Reduce any
- Use `import.meta` more
