### PR TITLE
chore: bump several native modules

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@vscode/proxy-agent": "^0.36.0",
         "@vscode/ripgrep": "^1.15.13",
         "@vscode/spdlog": "^0.15.2",
-        "@vscode/sqlite3": "5.1.8-vscode",
+        "@vscode/sqlite3": "5.1.9-vscode",
         "@vscode/sudo-prompt": "9.3.1",
         "@vscode/tree-sitter-wasm": "^0.3.0",
         "@vscode/vscode-languagedetection": "1.0.21",
@@ -3015,9 +3015,9 @@
       }
     },
     "node_modules/@vscode/spdlog": {
-      "version": "0.15.2",
-      "resolved": "https://registry.npmjs.org/@vscode/spdlog/-/spdlog-0.15.2.tgz",
-      "integrity": "sha512-8RQ7JEs81x5IFONYGtFhYtaF2a3IPtNtgMdp+MFLxTDokJQBAVittx0//EN38BYhlzeVqEPgusRsOA8Yulaysg==",
+      "version": "0.15.3",
+      "resolved": "https://registry.npmjs.org/@vscode/spdlog/-/spdlog-0.15.3.tgz",
+      "integrity": "sha512-a5SE9kNpkVYpfmmVrEXt3/jzG+kswDBkHJQC0ntaMUY43GyElKcrLQ6pfVvFDLv/YKRa9I7QTl35TG9QbUsN0Q==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -3027,9 +3027,9 @@
       }
     },
     "node_modules/@vscode/sqlite3": {
-      "version": "5.1.8-vscode",
-      "resolved": "https://registry.npmjs.org/@vscode/sqlite3/-/sqlite3-5.1.8-vscode.tgz",
-      "integrity": "sha512-9Ku18yZej1kxS7mh6dhCWxkCof043HljcLIdq+RRJr65QdOeAqPOUJ2i6qXRL63l1Kd72uXV/zLA2SBwhfgiOw==",
+      "version": "5.1.9-vscode",
+      "resolved": "https://registry.npmjs.org/@vscode/sqlite3/-/sqlite3-5.1.9-vscode.tgz",
+      "integrity": "sha512-hWzRXsE7c2AXlwBYzsUGMiFSb+ZzcTp+rU9Y4dmRdt75LRFqFBtxiHKswriWRJLhOTl4EdkyQ8KRl7b2igmoyA==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -12642,10 +12642,11 @@
       "hasInstallScript": true
     },
     "node_modules/native-keymap": {
-      "version": "3.3.5",
-      "resolved": "https://registry.npmjs.org/native-keymap/-/native-keymap-3.3.5.tgz",
-      "integrity": "sha512-7XDOLPNX1FnUFC/cX3cioBz2M+dO212ai9DuwpfKFzkPu3xTmEzOm5xewOMLXE4V9YoRhNPxvq1H2YpPWDgSsg==",
-      "hasInstallScript": true
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/native-keymap/-/native-keymap-3.3.6.tgz",
+      "integrity": "sha512-ZAjwYIR7eRxZju6xdq/FES4PKfOAkSFXTV+YbxdGgffetaOXQHkXkGUUxCDKmsyAMzewOjAEo20/+uj2UqvFYg==",
+      "hasInstallScript": true,
+      "license": "MIT"
     },
     "node_modules/native-watchdog": {
       "version": "1.4.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2953,9 +2953,9 @@
       }
     },
     "node_modules/@vscode/policy-watcher": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@vscode/policy-watcher/-/policy-watcher-1.3.2.tgz",
-      "integrity": "sha512-fmNPYysU2ioH99uCaBPiRblEZSnir5cTmc7w91hAxAoYoGpHt2PZPxT5eIOn7FGmPOsjLdQcd6fduFJGYVD4Mw==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/@vscode/policy-watcher/-/policy-watcher-1.3.4.tgz",
+      "integrity": "sha512-BEr1G/zUDybqqu83u81sJSNYYtwB8NzDRdVD4nuy+8/5qmDVdQ7PBA6alb0uz3op9hz5UkFfFn7fxaIT8ZVzcQ==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "@vscode/proxy-agent": "^0.36.0",
     "@vscode/ripgrep": "^1.15.13",
     "@vscode/spdlog": "^0.15.2",
-    "@vscode/sqlite3": "5.1.8-vscode",
+    "@vscode/sqlite3": "5.1.9-vscode",
     "@vscode/sudo-prompt": "9.3.1",
     "@vscode/tree-sitter-wasm": "^0.3.0",
     "@vscode/vscode-languagedetection": "1.0.21",

--- a/remote/package-lock.json
+++ b/remote/package-lock.json
@@ -176,9 +176,9 @@
       }
     },
     "node_modules/@vscode/spdlog": {
-      "version": "0.15.2",
-      "resolved": "https://registry.npmjs.org/@vscode/spdlog/-/spdlog-0.15.2.tgz",
-      "integrity": "sha512-8RQ7JEs81x5IFONYGtFhYtaF2a3IPtNtgMdp+MFLxTDokJQBAVittx0//EN38BYhlzeVqEPgusRsOA8Yulaysg==",
+      "version": "0.15.3",
+      "resolved": "https://registry.npmjs.org/@vscode/spdlog/-/spdlog-0.15.3.tgz",
+      "integrity": "sha512-a5SE9kNpkVYpfmmVrEXt3/jzG+kswDBkHJQC0ntaMUY43GyElKcrLQ6pfVvFDLv/YKRa9I7QTl35TG9QbUsN0Q==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
This PR bumps:
- native-keymap
- vscode/spdlog
- vscode/sqlite3
- vscode/policy-watcher