### PR TITLE
Remove build-script no new files PR check

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -72,12 +72,9 @@ jobs:
           mkdir -p .build/node_modules_cache
           tar -czf .build/node_modules_cache/cache.tgz --files-from .build/node_modules_list.txt
 
-      - name: Compile /build/ folder
-        run: npm run compile
+      - name: Type check /build/ scripts
+        run: npm run typecheck
         working-directory: build
-
-      - name: Check /build/ folder
-        run: .github/workflows/check-clean-git-state.sh
 
       - name: Compile & Hygiene
         run: npm exec -- npm-run-all -lp core-ci extensions-ci hygiene eslint valid-layers-check define-class-fields-check vscode-dts-compile-check tsec-compile-check test-build-scripts

--- a/build/package.json
+++ b/build/package.json
@@ -65,9 +65,8 @@
   "type": "module",
   "scripts": {
     "copy-policy-dto": "node lib/policies/copyPolicyDto.ts",
-    "prebuild-ts": "npm run copy-policy-dto",
+    "pretypecheck": "npm run copy-policy-dto",
     "typecheck": "cd .. && npx tsgo --project build/tsconfig.json",
-    "compile": "npm run copy-policy-dto && npm run typecheck",
     "watch": "npm run typecheck -- --watch",
     "test": "mocha --ui tdd 'lib/**/*.test.ts'"
   },

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "extensions-ci": "node ./node_modules/gulp/bin/gulp.js extensions-ci",
     "extensions-ci-pr": "node ./node_modules/gulp/bin/gulp.js extensions-ci-pr",
     "perf": "node scripts/code-perf.js",
-    "update-build-ts-version": "npm install -D typescript@next && npm install -D @typescript/native-preview && (cd build && npm run compile)"
+    "update-build-ts-version": "npm install -D typescript@next && npm install -D @typescript/native-preview && (cd build && npm run typecheck)"
   },
   "dependencies": {
     "@microsoft/1ds-core-js": "^3.2.13",


### PR DESCRIPTION
For #277526

Our build scripts no longer require being compiled so we can skip this extra check. After this change we still type check the build scripts to make sure they look good
