### PR TITLE
Fix showRange field regression in InlineCompletionItem

### DIFF
--- a/src/vs/editor/contrib/inlineCompletions/browser/model/inlineCompletionsModel.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/model/inlineCompletionsModel.ts
@@ -626,7 +626,14 @@ export class InlineCompletionsModel extends Disposable {
 			let edit = inlineEditResult.getSingleTextEdit();
 			edit = singleTextRemoveCommonPrefix(edit, model);
 
+			const cursorPos = this.primaryPosition.read(reader);
 			const cursorAtInlineEdit = this.primaryPosition.map(cursorPos => LineRange.fromRangeInclusive(inlineEditResult.targetRange).addMargin(1, 1).contains(cursorPos.lineNumber));
+
+			// Check if cursor is within showRange (if specified)
+			const cursorInsideShowRange = cursorAtInlineEdit.get() || (inlineEditResult.showRange?.containsPosition(cursorPos) ?? true);
+			if (!cursorInsideShowRange && !this._inAcceptFlow.read(reader)) {
+				return undefined;
+			}
 
 			const commands = inlineEditResult.source.inlineSuggestions.commands;
 			const inlineEdit = new InlineEdit(edit, commands ?? [], inlineEditResult);

--- a/src/vs/editor/contrib/inlineCompletions/browser/model/inlineSuggestionItem.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/model/inlineSuggestionItem.ts
@@ -67,6 +67,7 @@ abstract class InlineSuggestionItemBase {
 	public get renameCommand(): Command | undefined { return this._data.renameCommand; }
 	public get warning(): InlineCompletionWarning | undefined { return this._sourceInlineCompletion.warning; }
 	public get showInlineEditMenu(): boolean { return !!this._sourceInlineCompletion.showInlineEditMenu; }
+	public get showRange(): Range | undefined { return this._data.showRange; }
 	public get hash() {
 		return JSON.stringify([
 			this.getSingleTextEdit().text,
@@ -307,11 +308,16 @@ export class InlineCompletionItem extends InlineSuggestionItemBase {
 
 	public isVisible(model: ITextModel, cursorPosition: Position): boolean {
 		const singleTextEdit = this.getSingleTextEdit();
-		return inlineCompletionIsVisible(singleTextEdit, this._originalRange, model, cursorPosition);
+		return inlineCompletionIsVisible(singleTextEdit, this._originalRange, model, cursorPosition, this.showRange);
 	}
 }
 
-export function inlineCompletionIsVisible(singleTextEdit: TextReplacement, originalRange: Range | undefined, model: ITextModel, cursorPosition: Position): boolean {
+export function inlineCompletionIsVisible(singleTextEdit: TextReplacement, originalRange: Range | undefined, model: ITextModel, cursorPosition: Position, showRange?: Range): boolean {
+	// Check if cursor is within showRange (if specified)
+	if (showRange && !showRange.containsPosition(cursorPosition)) {
+		return false;
+	}
+
 	const minimizedReplacement = singleTextRemoveCommonPrefix(singleTextEdit, model);
 	const editRange = singleTextEdit.range;
 	if (!editRange

--- a/src/vs/editor/contrib/inlineCompletions/browser/model/provideInlineCompletions.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/model/provideInlineCompletions.ts
@@ -80,7 +80,7 @@ export function provideInlineCompletions(
 						}
 						if (item.insertText !== undefined) {
 							const t = new TextReplacement(Range.lift(item.range) ?? defaultReplaceRange, item.insertText);
-							if (inlineCompletionIsVisible(t, undefined, model, position)) {
+							if (inlineCompletionIsVisible(t, undefined, model, position, Range.lift(item.showRange) ?? undefined)) {
 								return undefined;
 							}
 						}
@@ -248,6 +248,7 @@ function toInlineSuggestData(
 		inlineCompletion.isInlineEdit ?? false,
 		inlineCompletion.supportsRename ?? false,
 		undefined,
+		Range.lift(inlineCompletion.showRange) ?? undefined,
 		requestInfo,
 		providerRequestInfo,
 		inlineCompletion.correlationId,
@@ -318,6 +319,7 @@ export class InlineSuggestData {
 		public readonly isInlineEdit: boolean,
 		public readonly supportsRename: boolean,
 		public readonly renameCommand: Command | undefined,
+		public readonly showRange: Range | undefined,
 
 		private readonly _requestInfo: InlineSuggestRequestInfo,
 		private readonly _providerRequestInfo: InlineSuggestProviderRequestInfo,
@@ -493,6 +495,7 @@ export class InlineSuggestData {
 			this.isInlineEdit,
 			this.supportsRename,
 			command,
+			this.showRange,
 			this._requestInfo,
 			this._providerRequestInfo,
 			this._correlationId,


### PR DESCRIPTION
The showRange field in InlineCompletionItem (part of the inlineCompletionsAdditions proposed API) stopped working after the InlineCompletionsSource refactoring in commit b0abf06c7dc. While the field is still defined in the API and accepted from extensions, the implementation that checks cursor position against this range was removed.

See more detail: https://github.com/microsoft/vscode/issues/279266

This commit restores the showRange functionality by:

1. Adding showRange field to InlineSuggestData constructor
2. Passing showRange from InlineCompletion to InlineSuggestData in toInlineSuggestData
3. Adding showRange getter to InlineSuggestionItemBase
4. Implementing showRange check in InlineCompletionItem.isVisible() method
5. Adding cursor position check against showRange in inlineCompletionsModel state computation

The fix ensures that inline completions are only shown when the cursor is within the specified showRange (if provided), matching the original behavior from PR #237532.

Fixes regression from commit b0abf06c7dc (Refactors InlineCompletionsSource) Restores functionality from commit a016c0be118 (Support show range for inline edits)

