### PR TITLE
Increase gap in editor group watermark for better spacing

### DIFF
--- a/src/vs/workbench/browser/parts/editor/media/editorgroupview.css
+++ b/src/vs/workbench/browser/parts/editor/media/editorgroupview.css
@@ -45,7 +45,7 @@
 	flex-direction: column;
 	align-items: center;
 	justify-content: center;
-	gap: 16px;
+	gap: 24px;
 }
 
 .monaco-workbench .part.editor > .content .editor-group-container:not(.empty) > .editor-group-watermark {


### PR DESCRIPTION
Adjust the gap in the editor group watermark from 16px to 24px to enhance visual spacing. This change improves the overall layout and readability within the editor.

