### PR TITLE
chore: add support for opening content tracing ui

### DIFF
--- a/src/vs/platform/native/common/native.ts
+++ b/src/vs/platform/native/common/native.ts
@@ -214,6 +214,7 @@ export interface ICommonNativeHostService {
 	toggleDevTools(options?: INativeHostOptions): Promise<void>;
 	openGPUInfoWindow(): Promise<void>;
 	openDevToolsWindow(url: string): Promise<void>;
+	openContentTracingWindow(): Promise<void>;
 	stopTracing(): Promise<void>;
 
 	// Perf Introspection

--- a/src/vs/workbench/electron-browser/actions/developerActions.ts
+++ b/src/vs/workbench/electron-browser/actions/developerActions.ts
@@ -123,6 +123,23 @@ export class ShowGPUInfoAction extends Action2 {
 	}
 }
 
+export class ShowContentTracingAction extends Action2 {
+
+	constructor() {
+		super({
+			id: 'workbench.action.showContentTracing',
+			title: localize2('showContentTracing', 'Show Content Tracing'),
+			category: Categories.Developer,
+			f1: true
+		});
+	}
+
+	run(accessor: ServicesAccessor) {
+		const nativeHostService = accessor.get(INativeHostService);
+		nativeHostService.openContentTracingWindow();
+	}
+}
+
 export class StopTracing extends Action2 {
 
 	static readonly ID = 'workbench.action.stopTracing';

--- a/src/vs/workbench/electron-browser/desktop.contribution.ts
+++ b/src/vs/workbench/electron-browser/desktop.contribution.ts
@@ -9,7 +9,7 @@ import { MenuRegistry, MenuId, registerAction2 } from '../../platform/actions/co
 import { IConfigurationRegistry, Extensions as ConfigurationExtensions, ConfigurationScope } from '../../platform/configuration/common/configurationRegistry.js';
 import { KeyMod, KeyCode } from '../../base/common/keyCodes.js';
 import { isLinux, isMacintosh, isWindows } from '../../base/common/platform.js';
-import { ConfigureRuntimeArgumentsAction, ToggleDevToolsAction, ReloadWindowWithExtensionsDisabledAction, OpenUserDataFolderAction, ShowGPUInfoAction, StopTracing } from './actions/developerActions.js';
+import { ConfigureRuntimeArgumentsAction, ToggleDevToolsAction, ReloadWindowWithExtensionsDisabledAction, OpenUserDataFolderAction, ShowGPUInfoAction, ShowContentTracingAction, StopTracing } from './actions/developerActions.js';
 import { ZoomResetAction, ZoomOutAction, ZoomInAction, CloseWindowAction, SwitchWindowAction, QuickSwitchWindowAction, NewWindowTabHandler, ShowPreviousWindowTabHandler, ShowNextWindowTabHandler, MoveWindowTabToNewWindowHandler, MergeWindowTabsHandlerHandler, ToggleWindowTabsBarHandler, ToggleWindowAlwaysOnTopAction, DisableWindowAlwaysOnTopAction, EnableWindowAlwaysOnTopAction, CloseOtherWindowsAction } from './actions/windowActions.js';
 import { ContextKeyExpr } from '../../platform/contextkey/common/contextkey.js';
 import { KeybindingsRegistry, KeybindingWeight } from '../../platform/keybinding/common/keybindingsRegistry.js';
@@ -113,6 +113,7 @@ import { MAX_ZOOM_LEVEL, MIN_ZOOM_LEVEL } from '../../platform/window/electron-b
 	registerAction2(ToggleDevToolsAction);
 	registerAction2(OpenUserDataFolderAction);
 	registerAction2(ShowGPUInfoAction);
+	registerAction2(ShowContentTracingAction);
 	registerAction2(StopTracing);
 })();
 

--- a/src/vs/workbench/test/electron-browser/workbenchTestServices.ts
+++ b/src/vs/workbench/test/electron-browser/workbenchTestServices.ts
@@ -155,6 +155,7 @@ export class TestNativeHostService implements INativeHostService {
 	async stopTracing(): Promise<void> { }
 	async openDevToolsWindow(url: string): Promise<void> { }
 	async openGPUInfoWindow(): Promise<void> { }
+	async openContentTracingWindow(): Promise<void> { }
 	async resolveProxy(url: string): Promise<string | undefined> { return undefined; }
 	async lookupAuthorization(authInfo: AuthInfo): Promise<Credentials | undefined> { return undefined; }
 	async lookupKerberosAuthorization(url: string): Promise<string | undefined> { return undefined; }


### PR DESCRIPTION
To ease debugging https://github.com/microsoft/vscode/issues/263554, idea is that users can bind this action to a shortcut and trigger the tracing on demand when the issue arises. The problem is more on compositor side so renderer and main are responsive to keyboard actions.


https://github.com/user-attachments/assets/962edc67-e289-477c-b213-35a63886b36a

