### PR TITLE
Fix rename suggestions

### DIFF
--- a/src/vs/editor/contrib/inlineCompletions/browser/model/renameSymbolProcessor.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/model/renameSymbolProcessor.ts
@@ -61,7 +61,7 @@ export class RenameSymbolProcessor extends Disposable {
 		const { oldName, newName, position } = edits.renames;
 		let timedOut = false;
 		const loc = await raceTimeout(prepareRename(this._languageFeaturesService.renameProvider, textModel, position), 1000, () => { timedOut = true; });
-		const renamePossible = loc !== undefined && !loc.rejectReason;
+		const renamePossible = loc !== undefined && !loc.rejectReason && loc.text === oldName;
 
 		suggestItem.setRenameProcessingInfo({ createdRename: renamePossible, duration: Date.now() - start, timedOut });
 


### PR DESCRIPTION
```Copilot Generated Description:``` Update the rename suggestion logic to ensure that the old name matches the text before allowing a rename to proceed.

fixes https://github.com/microsoft/vscode-copilot-issues/issues/367