### PR TITLE
agent sessions - filter empty chats in the view pane, not globally

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/agentSessions/localAgentSessionsProvider.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/localAgentSessionsProvider.ts
@@ -2,7 +2,6 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import { coalesce } from '../../../../../base/common/arrays.js';
 import { CancellationToken } from '../../../../../base/common/cancellation.js';
 import { Codicon } from '../../../../../base/common/codicons.js';
 import { Emitter } from '../../../../../base/common/event.js';
@@ -149,7 +148,7 @@ export class LocalAgentsSessionsProvider extends Disposable implements IChatSess
 
 		if (!token.isCancellationRequested) {
 			const history = await this.getHistoryItems();
-			sessions.push(...history.filter(h => !sessionsByResource.has(h.resource)));
+			sessions.push(...history.filter(historyItem => !sessionsByResource.has(historyItem.resource)));
 		}
 
 		return sessions;
@@ -157,24 +156,20 @@ export class LocalAgentsSessionsProvider extends Disposable implements IChatSess
 
 	private async getHistoryItems(): Promise<ChatSessionItemWithProvider[]> {
 		try {
-			const allHistory = await this.chatService.getHistorySessionItems();
-			return coalesce(allHistory.map(history => this.toChatSessionItem(history)));
+			const historyItems = await this.chatService.getHistorySessionItems();
+			return historyItems.map(history => this.toChatSessionItem(history));
 		} catch (error) {
 			return [];
 		}
 	}
 
-	private toChatSessionItem(chat: IChatDetail): ChatSessionItemWithProvider | undefined {
+	private toChatSessionItem(chat: IChatDetail): ChatSessionItemWithProvider {
 		const model = this.chatService.getSession(chat.sessionResource);
 
 		let description: string | undefined;
 		let startTime: number | undefined;
 		let endTime: number | undefined;
 		if (model) {
-			if (!model.hasRequests) {
-				return undefined; // ignore sessions without requests
-			}
-
 			const lastResponse = model.getRequests().at(-1)?.response;
 
 			description = this.chatSessionsService.getSessionDescription(model);

--- a/src/vs/workbench/contrib/chat/browser/chatViewPane.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatViewPane.ts
@@ -45,6 +45,7 @@ import { localize } from '../../../../nls.js';
 import { ChatViewWelcomeController, IViewWelcomeDelegate } from './viewsWelcome/chatViewWelcomeController.js';
 import { AgentSessionsControl } from './agentSessions/agentSessionsControl.js';
 import { ICommandService } from '../../../../platform/commands/common/commands.js';
+import { Event } from '../../../../base/common/event.js';
 
 interface IChatViewPaneState extends Partial<IChatModelInputState> {
 	sessionId?: string;
@@ -253,11 +254,23 @@ export class ChatViewPane extends ViewPane implements IViewWelcomeDelegate {
 	}
 
 	private createSessionsControl(parent: HTMLElement): void {
+		const that = this;
 
 		// Sessions Control
 		this.sessionsContainer = parent.appendChild($('.agent-sessions-container'));
 		this.sessionsControl = this._register(this.instantiationService.createInstance(AgentSessionsControl, this.sessionsContainer, {
 			allowOpenSessionsInPanel: true,
+			filter: {
+				onDidChange: Event.None,
+				exclude(session) {
+					const model = that.chatService.getSession(session.resource);
+					if (model && !model.hasRequests) {
+						return true; // exclude sessions without requests
+					}
+
+					return false;
+				},
+			}
 		}));
 
 		// Link to Sessions View

--- a/src/vs/workbench/contrib/chat/test/browser/localAgentSessionsProvider.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/localAgentSessionsProvider.test.ts
@@ -367,29 +367,6 @@ suite('LocalAgentsSessionsProvider', () => {
 		});
 	});
 
-	test('should ignore sessions without requests', async () => {
-		return runWithFakedTimers({}, async () => {
-			const provider = createProvider();
-
-			const sessionResource = LocalChatSessionUri.forSession('empty-session');
-			const mockModel = createMockChatModel({
-				sessionResource,
-				hasRequests: false
-			});
-
-			mockChatService.addSession(sessionResource, mockModel);
-			mockChatService.setLiveSessionItems([{
-				sessionResource,
-				title: 'Empty Session',
-				lastMessageDate: Date.now(),
-				isActive: true
-			}]);
-
-			const sessions = await provider.provideChatSessionItems(CancellationToken.None);
-			assert.strictEqual(sessions.length, 0);
-		});
-	});
-
 	test('should provide history session items', async () => {
 		return runWithFakedTimers({}, async () => {
 			const provider = createProvider();


### PR DESCRIPTION
This fixes an issue where we no longer track progress per session.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
