### PR TITLE
Fix ADMX generation to use underscores instead of `.` (#279406)

### DIFF
--- a/build/lib/policies/stringEnumPolicy.js
+++ b/build/lib/policies/stringEnumPolicy.js
@@ -34,7 +34,7 @@ class StringEnumPolicy extends basePolicy_1.BasePolicy {
     renderADMXElements() {
         return [
             `<enum id="${this.name}" valueName="${this.name}">`,
-            ...this.enum_.map((value, index) => `	<item displayName="$(string.${this.name}_${this.enumDescriptions[index].nlsKey})"><value><string>${value}</string></value></item>`),
+            ...this.enum_.map((value, index) => `	<item displayName="$(string.${this.name}_${this.enumDescriptions[index].nlsKey.replace(/\./g, '_')})"><value><string>${value}</string></value></item>`),
             `</enum>`
         ];
     }

--- a/build/lib/policies/stringEnumPolicy.ts
+++ b/build/lib/policies/stringEnumPolicy.ts
@@ -53,7 +53,7 @@ export class StringEnumPolicy extends BasePolicy {
 	protected renderADMXElements(): string[] {
 		return [
 			`<enum id="${this.name}" valueName="${this.name}">`,
-			...this.enum_.map((value, index) => `	<item displayName="$(string.${this.name}_${this.enumDescriptions[index].nlsKey})"><value><string>${value}</string></value></item>`),
+			...this.enum_.map((value, index) => `	<item displayName="$(string.${this.name}_${this.enumDescriptions[index].nlsKey.replace(/\./g, '_')})"><value><string>${value}</string></value></item>`),
 			`</enum>`
 		];
 	}

--- a/build/lib/test/fixtures/policies/win32/CodeOSS.admx
+++ b/build/lib/test/fixtures/policies/win32/CodeOSS.admx
@@ -45,9 +45,9 @@
 			<supportedOn ref="Supported_1_99" />
 			<elements>
 		<enum id="ChatMCP" valueName="ChatMCP">
-			<item displayName="$(string.ChatMCP_chat.mcp.access.none)"><value><string>none</string></value></item>
-			<item displayName="$(string.ChatMCP_chat.mcp.access.registry)"><value><string>registry</string></value></item>
-			<item displayName="$(string.ChatMCP_chat.mcp.access.any)"><value><string>all</string></value></item>
+			<item displayName="$(string.ChatMCP_chat_mcp_access_none)"><value><string>none</string></value></item>
+			<item displayName="$(string.ChatMCP_chat_mcp_access_registry)"><value><string>registry</string></value></item>
+			<item displayName="$(string.ChatMCP_chat_mcp_access_any)"><value><string>all</string></value></item>
 		</enum>
 			</elements>
 		</policy>
@@ -113,10 +113,10 @@
 			<supportedOn ref="Supported_1_99" />
 			<elements>
 		<enum id="TelemetryLevel" valueName="TelemetryLevel">
-			<item displayName="$(string.TelemetryLevel_telemetry.telemetryLevel.default)"><value><string>all</string></value></item>
-			<item displayName="$(string.TelemetryLevel_telemetry.telemetryLevel.error)"><value><string>error</string></value></item>
-			<item displayName="$(string.TelemetryLevel_telemetry.telemetryLevel.crash)"><value><string>crash</string></value></item>
-			<item displayName="$(string.TelemetryLevel_telemetry.telemetryLevel.off)"><value><string>off</string></value></item>
+			<item displayName="$(string.TelemetryLevel_telemetry_telemetryLevel_default)"><value><string>all</string></value></item>
+			<item displayName="$(string.TelemetryLevel_telemetry_telemetryLevel_error)"><value><string>error</string></value></item>
+			<item displayName="$(string.TelemetryLevel_telemetry_telemetryLevel_crash)"><value><string>crash</string></value></item>
+			<item displayName="$(string.TelemetryLevel_telemetry_telemetryLevel_off)"><value><string>off</string></value></item>
 		</enum>
 			</elements>
 		</policy>

--- a/build/lib/test/stringEnumPolicy.test.js
+++ b/build/lib/test/stringEnumPolicy.test.js
@@ -50,9 +50,9 @@ suite('StringEnumPolicy', () => {
             '\t<supportedOn ref="Supported_1_0" />',
             '\t<elements>',
             '<enum id="TestStringEnumPolicy" valueName="TestStringEnumPolicy">',
-            '\t<item displayName="$(string.TestStringEnumPolicy_test.option.one)"><value><string>auto</string></value></item>',
-            '\t<item displayName="$(string.TestStringEnumPolicy_test.option.two)"><value><string>manual</string></value></item>',
-            '\t<item displayName="$(string.TestStringEnumPolicy_test.option.three)"><value><string>disabled</string></value></item>',
+            '\t<item displayName="$(string.TestStringEnumPolicy_test_option_one)"><value><string>auto</string></value></item>',
+            '\t<item displayName="$(string.TestStringEnumPolicy_test_option_two)"><value><string>manual</string></value></item>',
+            '\t<item displayName="$(string.TestStringEnumPolicy_test_option_three)"><value><string>disabled</string></value></item>',
             '</enum>',
             '\t</elements>',
             '</policy>'

--- a/build/lib/test/stringEnumPolicy.test.ts
+++ b/build/lib/test/stringEnumPolicy.test.ts
@@ -55,9 +55,9 @@ suite('StringEnumPolicy', () => {
 			'\t<supportedOn ref="Supported_1_0" />',
 			'\t<elements>',
 			'<enum id="TestStringEnumPolicy" valueName="TestStringEnumPolicy">',
-			'\t<item displayName="$(string.TestStringEnumPolicy_test.option.one)"><value><string>auto</string></value></item>',
-			'\t<item displayName="$(string.TestStringEnumPolicy_test.option.two)"><value><string>manual</string></value></item>',
-			'\t<item displayName="$(string.TestStringEnumPolicy_test.option.three)"><value><string>disabled</string></value></item>',
+			'\t<item displayName="$(string.TestStringEnumPolicy_test_option_one)"><value><string>auto</string></value></item>',
+			'\t<item displayName="$(string.TestStringEnumPolicy_test_option_two)"><value><string>manual</string></value></item>',
+			'\t<item displayName="$(string.TestStringEnumPolicy_test_option_three)"><value><string>disabled</string></value></item>',
 			'</enum>',
 			'\t</elements>',
 			'</policy>'


### PR DESCRIPTION
Candidate for https://github.com/microsoft/vscode/issues/278352
