### PR TITLE
Revert "Update focused row keybinding appearance in quick input list"

### DIFF
--- a/src/vs/platform/quickinput/browser/media/quickInput.css
+++ b/src/vs/platform/quickinput/browser/media/quickInput.css
@@ -348,8 +348,6 @@
 
 .quick-input-list .monaco-list-row.focused .monaco-keybinding-key {
 	background: none;
-	border-color: inherit;
-	opacity: 0.8;
 }
 
 .quick-input-list .quick-input-list-separator-as-item {


### PR DESCRIPTION
Reverts microsoft/vscode#278602

The color jump from an active item to a non active item is a bit too jarring. 