### PR TITLE
Add performance markers to inline completions

### DIFF
--- a/src/vs/editor/common/languages.ts
+++ b/src/vs/editor/common/languages.ts
@@ -1056,6 +1056,7 @@ export type LifetimeSummary = {
 	preceeded: boolean;
 	languageId: string;
 	requestReason: string;
+	performanceMarkers?: string;
 	cursorColumnDistance?: number;
 	cursorLineDistance?: number;
 	lineCountOriginal?: number;

--- a/src/vs/editor/contrib/inlineCompletions/browser/model/inlineCompletionsSource.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/model/inlineCompletionsSource.ts
@@ -249,7 +249,9 @@ export class InlineCompletionsSource extends Disposable {
 							continue;
 						}
 
+						item.addPerformanceMarker('providerReturned');
 						const i = InlineSuggestionItem.create(item, this._textModel);
+						item.addPerformanceMarker('itemCreated');
 						providerSuggestions.push(i);
 						// Stop after first visible inline completion
 						if (!i.isInlineEdit && !i.showInlineEditMenu && context.triggerKind === InlineCompletionTriggerKind.Automatic) {
@@ -264,9 +266,13 @@ export class InlineCompletionsSource extends Disposable {
 					}
 				}
 
+				providerSuggestions.forEach(s => s.addPerformanceMarker('providersResolved'));
+
 				const suggestions: InlineSuggestionItem[] = await Promise.all(providerSuggestions.map(async s => {
 					return this._renameProcessor.proposeRenameRefactoring(this._textModel, s);
 				}));
+
+				providerSuggestions.forEach(s => s.addPerformanceMarker('renameProcessed'));
 
 				providerResult.cancelAndDispose({ kind: 'lostRace' });
 
@@ -306,6 +312,8 @@ export class InlineCompletionsSource extends Disposable {
 				if (remainingTimeToWait > 0) {
 					await wait(remainingTimeToWait, source.token);
 				}
+
+				providerSuggestions.forEach(s => s.addPerformanceMarker('minShowDelayPassed'));
 
 				if (source.token.isCancellationRequested || this._store.isDisposed || this._textModel.getVersionId() !== request.versionId
 					|| userJumpedToActiveCompletion.get()  /* In the meantime the user showed interest for the active completion so dont hide it */) {
@@ -452,6 +460,7 @@ export class InlineCompletionsSource extends Disposable {
 			renameCreated: false,
 			renameDuration: undefined,
 			renameTimedOut: false,
+			performanceMarkers: undefined,
 		};
 
 		const dataChannel = this._instantiationService.createInstance(DataChannelForwardingTelemetryService);

--- a/src/vs/editor/contrib/inlineCompletions/browser/model/inlineCompletionsSource.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/model/inlineCompletionsSource.ts
@@ -313,7 +313,7 @@ export class InlineCompletionsSource extends Disposable {
 					await wait(remainingTimeToWait, source.token);
 				}
 
-				providerSuggestions.forEach(s => s.addPerformanceMarker('minShowDelayPassed'));
+				suggestions.forEach(s => s.addPerformanceMarker('minShowDelayPassed'));
 
 				if (source.token.isCancellationRequested || this._store.isDisposed || this._textModel.getVersionId() !== request.versionId
 					|| userJumpedToActiveCompletion.get()  /* In the meantime the user showed interest for the active completion so dont hide it */) {

--- a/src/vs/editor/contrib/inlineCompletions/browser/model/inlineSuggestionItem.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/model/inlineSuggestionItem.ts
@@ -143,6 +143,10 @@ abstract class InlineSuggestionItemBase {
 	public withRename(command: Command, hint: InlineSuggestHint): InlineSuggestData {
 		return this._data.withRename(command, hint);
 	}
+
+	public addPerformanceMarker(marker: string): void {
+		this._data.addPerformanceMarker(marker);
+	}
 }
 
 export class InlineSuggestionIdentity {

--- a/src/vs/editor/contrib/inlineCompletions/browser/model/provideInlineCompletions.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/model/provideInlineCompletions.ts
@@ -501,13 +501,13 @@ export class InlineSuggestData {
 		);
 	}
 
-	private performance = new Performance();
+	private performance = new InlineSuggestionsPerformance();
 	public addPerformanceMarker(marker: string): void {
 		this.performance.mark(marker);
 	}
 }
 
-class Performance {
+class InlineSuggestionsPerformance {
 	private markers: { name: string; timeStamp: number }[] = [];
 	constructor() {
 		this.markers.push({ name: 'start', timeStamp: Date.now() });

--- a/src/vs/editor/contrib/inlineCompletions/browser/model/provideInlineCompletions.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/model/provideInlineCompletions.ts
@@ -340,6 +340,7 @@ export class InlineSuggestData {
 		if (this._didShow) {
 			return;
 		}
+		this.addPerformanceMarker('shown');
 		this._didShow = true;
 		this._viewData.viewKind = viewKind;
 		this._viewData.renderData = viewData;
@@ -408,6 +409,7 @@ export class InlineSuggestData {
 				requestReason: this._requestInfo.reason,
 				viewKind: this._viewData.viewKind,
 				notShownReason: this._notShownReason,
+				performanceMarkers: this.performance.toString(),
 				renameCreated: this._renameInfo?.createdRename ?? false,
 				renameDuration: this._renameInfo?.duration,
 				renameTimedOut: this._renameInfo?.timedOut ?? false,
@@ -497,6 +499,31 @@ export class InlineSuggestData {
 			this._providerRequestInfo,
 			this._correlationId,
 		);
+	}
+
+	private performance = new Performance();
+	public addPerformanceMarker(marker: string): void {
+		this.performance.mark(marker);
+	}
+}
+
+class Performance {
+	private markers: { name: string; timeStamp: number }[] = [];
+	constructor() {
+		this.markers.push({ name: 'start', timeStamp: Date.now() });
+	}
+
+	mark(marker: string): void {
+		this.markers.push({ name: marker, timeStamp: Date.now() });
+	}
+
+	toString(): string {
+		const deltas = [];
+		for (let i = 1; i < this.markers.length; i++) {
+			const delta = this.markers[i].timeStamp - this.markers[i - 1].timeStamp;
+			deltas.push({ [this.markers[i].name]: delta });
+		}
+		return JSON.stringify(deltas);
 	}
 }
 

--- a/src/vs/editor/contrib/inlineCompletions/browser/telemetry.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/telemetry.ts
@@ -42,6 +42,7 @@ export type InlineCompletionEndOfLifeEvent = {
 	renameCreated: boolean;
 	renameDuration: number | undefined;
 	renameTimedOut: boolean;
+	performanceMarkers: string | undefined;
 	// rendering
 	viewKind: string | undefined;
 	cursorColumnDistance: number | undefined;
@@ -98,4 +99,5 @@ type InlineCompletionsEndOfLifeClassification = {
 	sameShapeReplacements: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Whether all inner replacements are the same shape' };
 	noSuggestionReason: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The reason why no inline completion was provided' };
 	notShownReason: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The reason why the inline completion was not shown' };
+	performanceMarkers: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Performance markers for the inline completion lifecycle' };
 };

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -7696,6 +7696,7 @@ declare namespace monaco.languages {
 		preceeded: boolean;
 		languageId: string;
 		requestReason: string;
+		performanceMarkers?: string;
 		cursorColumnDistance?: number;
 		cursorLineDistance?: number;
 		lineCountOriginal?: number;

--- a/src/vs/workbench/api/browser/mainThreadLanguageFeatures.ts
+++ b/src/vs/workbench/api/browser/mainThreadLanguageFeatures.ts
@@ -1435,6 +1435,7 @@ class ExtensionBackedInlineCompletionsProvider extends Disposable implements lan
 			extensionId: this.providerId.extensionId!,
 			extensionVersion: this.providerId.extensionVersion!,
 			groupId: this.groupId,
+			performanceMarkers: lifetimeSummary.performanceMarkers,
 			availableProviders: lifetimeSummary.availableProviders,
 			partiallyAccepted: lifetimeSummary.partiallyAccepted,
 			partiallyAcceptedCountSinceOriginal: lifetimeSummary.partiallyAcceptedCountSinceOriginal,


### PR DESCRIPTION
```Copilot Generated Description:``` Introduce performance markers to track various stages in the inline completions lifecycle, including creation, resolution, and display. This change adds methods to log performance data and updates relevant data structures to include performance information.

