### PR TITLE
Fetch tool bug fixes and improvements

### DIFF
--- a/src/vs/platform/webContentExtractor/common/webContentExtractor.ts
+++ b/src/vs/platform/webContentExtractor/common/webContentExtractor.ts
@@ -20,8 +20,8 @@ export interface IWebContentExtractorOptions {
 }
 
 export type WebContentExtractResult =
-	| { status: 'ok'; result: string }
-	| { status: 'error'; error: string }
+	| { status: 'ok'; result: string; title?: string }
+	| { status: 'error'; error: string; statusCode?: number; result?: string; title?: string }
 	| { status: 'redirect'; toURI: URI };
 
 export interface IWebContentExtractorService {

--- a/src/vs/platform/webContentExtractor/electron-main/webContentCache.ts
+++ b/src/vs/platform/webContentExtractor/electron-main/webContentCache.ts
@@ -1,0 +1,67 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { LRUCache } from '../../../base/common/map.js';
+import { extUriIgnorePathCase } from '../../../base/common/resources.js';
+import { URI } from '../../../base/common/uri.js';
+import { IWebContentExtractorOptions, WebContentExtractResult } from '../common/webContentExtractor.js';
+
+type CacheEntry = Readonly<{
+	result: WebContentExtractResult;
+	options: IWebContentExtractorOptions | undefined;
+	expiration: number;
+}>;
+
+/**
+ * A cache for web content extraction results.
+ */
+export class WebContentCache {
+	private static readonly MAX_CACHE_SIZE = 1000;
+	private static readonly SUCCESS_CACHE_DURATION = 1000 * 60 * 60 * 24; // 24 hours
+	private static readonly ERROR_CACHE_DURATION = 1000 * 60 * 5; // 5 minutes
+
+	private readonly _cache = new LRUCache<string, CacheEntry>(WebContentCache.MAX_CACHE_SIZE);
+
+	/**
+	 * Add a web content extraction result to the cache.
+	 */
+	public add(uri: URI, options: IWebContentExtractorOptions | undefined, result: WebContentExtractResult) {
+		let expiration: number;
+		switch (result.status) {
+			case 'ok':
+			case 'redirect':
+				expiration = Date.now() + WebContentCache.SUCCESS_CACHE_DURATION;
+				break;
+			default:
+				expiration = Date.now() + WebContentCache.ERROR_CACHE_DURATION;
+				break;
+		}
+
+		const key = WebContentCache.getKey(uri, options);
+		this._cache.set(key, { result, options, expiration });
+	}
+
+	/**
+	 * Try to get a cached web content extraction result for the given URI and options.
+	 */
+	public tryGet(uri: URI, options: IWebContentExtractorOptions | undefined): WebContentExtractResult | undefined {
+		const key = WebContentCache.getKey(uri, options);
+		const entry = this._cache.get(key);
+		if (entry === undefined) {
+			return undefined;
+		}
+
+		if (entry.expiration < Date.now()) {
+			this._cache.delete(key);
+			return undefined;
+		}
+
+		return entry.result;
+	}
+
+	private static getKey(uri: URI, options: IWebContentExtractorOptions | undefined): string {
+		return `${!!options?.followRedirects}${extUriIgnorePathCase.getComparisonKey(uri)}`;
+	}
+}

--- a/src/vs/platform/webContentExtractor/electron-main/webContentExtractorService.ts
+++ b/src/vs/platform/webContentExtractor/electron-main/webContentExtractorService.ts
@@ -3,22 +3,13 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { BrowserWindow, Event as ElectronEvent, WebContentsWillNavigateEventParams, WebContentsWillRedirectEventParams } from 'electron';
-import { IWebContentExtractorOptions, IWebContentExtractorService, WebContentExtractResult } from '../common/webContentExtractor.js';
-import { URI } from '../../../base/common/uri.js';
-import { AXNode, convertAXTreeToMarkdown } from './cdpAccessibilityDomain.js';
+import { BrowserWindow } from 'electron';
 import { Limiter } from '../../../base/common/async.js';
-import { ResourceMap } from '../../../base/common/map.js';
+import { URI } from '../../../base/common/uri.js';
 import { ILogService } from '../../log/common/log.js';
-import { DisposableStore, toDisposable } from '../../../base/common/lifecycle.js';
-import { CancellationError } from '../../../base/common/errors.js';
-import { generateUuid } from '../../../base/common/uuid.js';
-
-interface CacheEntry {
-	result: string;
-	timestamp: number;
-	finalURI: URI;
-}
+import { IWebContentExtractorOptions, IWebContentExtractorService, WebContentExtractResult } from '../common/webContentExtractor.js';
+import { WebContentCache } from './webContentCache.js';
+import { WebPageLoader } from './webPageLoader.js';
 
 export class NativeWebContentExtractorService implements IWebContentExtractorService {
 	_serviceBrand: undefined;
@@ -26,99 +17,33 @@ export class NativeWebContentExtractorService implements IWebContentExtractorSer
 	// Only allow 3 windows to be opened at a time
 	// to avoid overwhelming the system with too many processes.
 	private _limiter = new Limiter<WebContentExtractResult>(3);
-	private _webContentsCache = new ResourceMap<CacheEntry>();
-	private readonly _cacheDuration = 24 * 60 * 60 * 1000; // 1 day in milliseconds
+	private _webContentsCache = new WebContentCache();
 
 	constructor(@ILogService private readonly _logger: ILogService) { }
 
-	private isExpired(entry: CacheEntry): boolean {
-		return Date.now() - entry.timestamp > this._cacheDuration;
-	}
-
 	extract(uris: URI[], options?: IWebContentExtractorOptions): Promise<WebContentExtractResult[]> {
 		if (uris.length === 0) {
-			this._logger.info('[NativeWebContentExtractorService] No URIs provided for extraction');
+			this._logger.info('No URIs provided for extraction');
 			return Promise.resolve([]);
 		}
-		this._logger.info(`[NativeWebContentExtractorService] Extracting content from ${uris.length} URIs`);
+		this._logger.info(`Extracting content from ${uris.length} URIs`);
 		return Promise.all(uris.map((uri) => this._limiter.queue(() => this.doExtract(uri, options))));
 	}
 
 	async doExtract(uri: URI, options: IWebContentExtractorOptions | undefined): Promise<WebContentExtractResult> {
-		const cached = this._webContentsCache.get(uri);
-		if (cached) {
-			this._logger.info(`[NativeWebContentExtractorService] Found cached content for ${uri}`);
-			if (this.isExpired(cached)) {
-				this._logger.info(`[NativeWebContentExtractorService] Cache expired for ${uri}, removing entry...`);
-				this._webContentsCache.delete(uri);
-			} else if (!options?.followRedirects && cached.finalURI.authority !== uri.authority) {
-				return { status: 'redirect', toURI: cached.finalURI };
-			} else {
-				return { status: 'ok', result: cached.result };
-			}
+		const cached = this._webContentsCache.tryGet(uri, options);
+		if (cached !== undefined) {
+			this._logger.info(`Found cached content for ${uri.toString()}`);
+			return cached;
 		}
 
-		this._logger.info(`[NativeWebContentExtractorService] Extracting content from ${uri}...`);
-		const store = new DisposableStore();
-		const win = new BrowserWindow({
-			width: 800,
-			height: 600,
-			show: false,
-			webPreferences: {
-				partition: generateUuid(), // do not share any state with the default renderer session
-				javascript: true,
-				offscreen: true,
-				sandbox: true,
-				webgl: false
-			}
-		});
-
-		store.add(toDisposable(() => win.destroy()));
-
+		const loader = new WebPageLoader((options) => new BrowserWindow(options), this._logger, uri, options);
 		try {
-			const result = options?.followRedirects
-				? await this.extractAX(win, uri)
-				: await Promise.race([this.interceptRedirects(win, uri, store), this.extractAX(win, uri)]);
-
-			if (result.status === 'ok') {
-				this._webContentsCache.set(uri, { result: result.result, timestamp: Date.now(), finalURI: URI.parse(win.webContents.getURL()) });
-			}
-
+			const result = await loader.load();
+			this._webContentsCache.add(uri, options, result);
 			return result;
-		} catch (err) {
-			this._logger.error(`[NativeWebContentExtractorService] Error extracting content from ${uri}: ${err}`);
-			return { status: 'error', error: String(err) };
 		} finally {
-			store.dispose();
+			loader.dispose();
 		}
-	}
-
-	private async extractAX(win: BrowserWindow, uri: URI): Promise<WebContentExtractResult> {
-		await win.loadURL(uri.toString(true));
-		win.webContents.debugger.attach('1.1');
-		const result: { nodes: AXNode[] } = await win.webContents.debugger.sendCommand('Accessibility.getFullAXTree');
-		const str = convertAXTreeToMarkdown(uri, result.nodes);
-		this._logger.info(`[NativeWebContentExtractorService] Content extracted from ${uri}`);
-		this._logger.trace(`[NativeWebContentExtractorService] Extracted content: ${str}`);
-		return { status: 'ok', result: str };
-	}
-
-	private interceptRedirects(win: BrowserWindow, uri: URI, store: DisposableStore) {
-		return new Promise<WebContentExtractResult>((resolve, reject) => {
-			const onNavigation = (e: ElectronEvent<WebContentsWillNavigateEventParams | WebContentsWillRedirectEventParams>) => {
-				const newURI = URI.parse(e.url);
-				if (newURI.authority !== uri.authority) {
-					e.preventDefault();
-					resolve({ status: 'redirect', toURI: newURI });
-				}
-			};
-
-			win.webContents.on('will-navigate', onNavigation);
-			win.webContents.on('will-redirect', onNavigation);
-
-			store.add(toDisposable(() => {
-				reject(new CancellationError());
-			}));
-		});
 	}
 }

--- a/src/vs/platform/webContentExtractor/electron-main/webPageLoader.ts
+++ b/src/vs/platform/webContentExtractor/electron-main/webPageLoader.ts
@@ -133,7 +133,7 @@ export class WebPageLoader extends Disposable {
 
 		this.trace(`Received 'did-start-loading' event`);
 		void this._debugger.sendCommand('Network.enable').catch(() => {
-			// This throw when we destroy the window on redirect.
+			// This throws when we destroy the window on redirect.
 		});
 	}
 

--- a/src/vs/platform/webContentExtractor/electron-main/webPageLoader.ts
+++ b/src/vs/platform/webContentExtractor/electron-main/webPageLoader.ts
@@ -183,7 +183,7 @@ export class WebPageLoader extends Disposable {
 
 	/**
 	 * Handles debugger messages related to network requests, tracking their lifecycle.
-	 * @note DO NOT adding logging to this function, microsoft.com will freeze when too many logs are generated
+	 * @note DO NOT add logging to this function, microsoft.com will freeze when too many logs are generated
 	 */
 	private onDebugMessage(_event: Event, method: string, params: NetworkRequestEventParams) {
 		if (this._store.isDisposed) {

--- a/src/vs/platform/webContentExtractor/electron-main/webPageLoader.ts
+++ b/src/vs/platform/webContentExtractor/electron-main/webPageLoader.ts
@@ -72,7 +72,7 @@ export class WebPageLoader extends Disposable {
 	}
 
 	private trace(message: string) {
-		this._logger.info(`[WebPageLoader] [${this._uri}] ${message}`);
+		this._logger.trace(`[WebPageLoader] [${this._uri}] ${message}`);
 	}
 
 	/**

--- a/src/vs/platform/webContentExtractor/electron-main/webPageLoader.ts
+++ b/src/vs/platform/webContentExtractor/electron-main/webPageLoader.ts
@@ -1,0 +1,302 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import type { BrowserWindow, BrowserWindowConstructorOptions, Event } from 'electron';
+import { Queue, raceTimeout, TimeoutTimer } from '../../../base/common/async.js';
+import { createSingleCallFunction } from '../../../base/common/functional.js';
+import { Disposable, toDisposable } from '../../../base/common/lifecycle.js';
+import { equalsIgnoreCase } from '../../../base/common/strings.js';
+import { URI } from '../../../base/common/uri.js';
+import { generateUuid } from '../../../base/common/uuid.js';
+import { ILogService } from '../../log/common/log.js';
+import { IWebContentExtractorOptions, WebContentExtractResult } from '../common/webContentExtractor.js';
+import { AXNode, convertAXTreeToMarkdown } from './cdpAccessibilityDomain.js';
+
+type NetworkRequestEventParams = Readonly<{
+	requestId?: string;
+	request?: { url?: string };
+	response?: { status?: number; statusText?: string };
+	type?: string;
+}>;
+
+/**
+ * A web page loader that uses Electron to load web pages and extract their content.
+ */
+export class WebPageLoader extends Disposable {
+	private static readonly TIMEOUT = 30000; // 30 seconds
+	private static readonly POST_LOAD_TIMEOUT = 2000; // 2 seconds
+	private static readonly FRAME_TIMEOUT = 500; // 0.5 seconds
+
+	private readonly _window: BrowserWindow;
+	private readonly _debugger: Electron.Debugger;
+	private readonly _requests = new Set<string>();
+	private readonly _queue = this._register(new Queue());
+	private _timeout = this._register(new TimeoutTimer());
+	private _onResult = (_result: WebContentExtractResult) => { };
+
+	constructor(
+		browserWindowFactory: (options: BrowserWindowConstructorOptions) => BrowserWindow,
+		private readonly _logger: ILogService,
+		private readonly _uri: URI,
+		private readonly _options?: IWebContentExtractorOptions,
+	) {
+		super();
+
+		this._window = browserWindowFactory({
+			width: 800,
+			height: 600,
+			show: false,
+			webPreferences: {
+				partition: generateUuid(), // do not share any state with the default renderer session
+				javascript: true,
+				offscreen: true,
+				sandbox: true,
+				webgl: false,
+			}
+		});
+
+		this._register(toDisposable(() => this._window.destroy()));
+
+		this._debugger = this._window.webContents.debugger;
+		this._debugger.attach('1.1');
+		this._debugger.on('message', this.onDebugMessage.bind(this));
+
+		this._window.webContents
+			.once('did-start-loading', this.onStartLoading.bind(this))
+			.once('did-finish-load', this.onFinishLoad.bind(this))
+			.once('did-fail-load', this.onFailLoad.bind(this))
+			.once('will-navigate', this.onRedirect.bind(this))
+			.once('will-redirect', this.onRedirect.bind(this));
+	}
+
+	private trace(message: string) {
+		this._logger.info(`[WebPageLoader] [${this._uri}] ${message}`);
+	}
+
+	/**
+	 * Loads the web page and extracts its content.
+	 */
+	public async load() {
+		return await new Promise<WebContentExtractResult>((resolve) => {
+			this._onResult = createSingleCallFunction((result) => {
+				switch (result.status) {
+					case 'ok':
+						this.trace(`Loaded web page content, status: ${result.status}, title: '${result.title}', length: ${result.result.length}`);
+						break;
+					case 'redirect':
+						this.trace(`Loaded web page content, status: ${result.status}, toURI: ${result.toURI}`);
+						break;
+					case 'error':
+						this.trace(`Loaded web page content, status: ${result.status}, code: ${result.statusCode}, error: '${result.error}', title: '${result.title}', length: ${result.result?.length ?? 0}`);
+						break;
+				}
+
+				const content = result.status !== 'redirect' ? result.result : undefined;
+				if (content !== undefined) {
+					this.trace(content.length < 200 ? `Extracted content: '${content}'` : `Extracted content preview: '${content.substring(0, 200)}...'`);
+				}
+
+				resolve(result);
+				this.dispose();
+			});
+
+			this.trace(`Loading web page content`);
+			void this._window.loadURL(this._uri.toString(true));
+			this.setTimeout(WebPageLoader.TIMEOUT);
+		});
+	}
+
+	/**
+	 * Sets a timeout to trigger content extraction regardless of current loading state.
+	 */
+	private setTimeout(time: number) {
+		if (this._store.isDisposed) {
+			return;
+		}
+
+		this.trace(`Setting page load timeout to ${time} ms`);
+		this._timeout.cancelAndSet(() => {
+			this.trace(`Page load timeout reached`);
+			void this._queue.queue(() => this.extractContent());
+		}, time);
+	}
+
+	/**
+	 * Handles the 'did-start-loading' event, enabling network tracking.
+	 */
+	private onStartLoading() {
+		if (this._store.isDisposed) {
+			return;
+		}
+
+		this.trace(`Received 'did-start-loading' event`);
+		void this._debugger.sendCommand('Network.enable').catch(() => {
+			// This throw when we destroy the window on redirect.
+		});
+	}
+
+	/**
+	 * Handles the 'did-finish-load' event, checking for idle state
+	 * and updating timeout to allow for post-load activities.
+	 */
+	private onFinishLoad() {
+		if (this._store.isDisposed) {
+			return;
+		}
+
+		this.trace(`Received 'did-finish-load' event`);
+		this.checkForIdle();
+		this.setTimeout(WebPageLoader.POST_LOAD_TIMEOUT);
+	}
+
+	/**
+	 * Handles the 'did-fail-load' event, reporting load failures.
+	 */
+	private onFailLoad(_event: Event, statusCode: number, error: string) {
+		if (this._store.isDisposed) {
+			return;
+		}
+
+		this.trace(`Received 'did-fail-load' event, code: ${statusCode}, error: '${error}'`);
+		void this._queue.queue(() => this.extractContent({ status: 'error', statusCode, error }));
+	}
+
+	/**
+	 * Handles the 'will-navigate' and 'will-redirect' events, managing redirects.
+	 */
+	private onRedirect(event: Event, url: string) {
+		if (this._store.isDisposed) {
+			return;
+		}
+
+		this.trace(`Received 'will-navigate' or 'will-redirect' event, url: ${url}`);
+		if (!this._options?.followRedirects) {
+			const toURI = URI.parse(url);
+			if (!equalsIgnoreCase(toURI.authority, this._uri.authority)) {
+				event.preventDefault();
+				this._onResult({ status: 'redirect', toURI });
+			}
+		}
+	}
+
+	/**
+	 * Handles debugger messages related to network requests, tracking their lifecycle.
+	 * @note DO NOT adding logging to this function, microsoft.com will freeze when too many logs are generated
+	 */
+	private onDebugMessage(_event: Event, method: string, params: NetworkRequestEventParams) {
+		if (this._store.isDisposed) {
+			return;
+		}
+
+		const { requestId, type, response } = params;
+		switch (method) {
+			case 'Network.requestWillBeSent':
+				if (requestId !== undefined) {
+					this._requests.add(requestId);
+				}
+				break;
+			case 'Network.loadingFinished':
+			case 'Network.loadingFailed':
+				if (requestId !== undefined) {
+					this._requests.delete(requestId);
+					if (this._requests.size === 0) {
+						this.checkForIdle();
+					}
+				}
+				break;
+			case 'Network.responseReceived':
+				if (type === 'Document') {
+					const statusCode = response?.status ?? 0;
+					if (statusCode >= 400) {
+						const error = response?.statusText || `HTTP error ${statusCode}`;
+						void this._queue.queue(() => this.extractContent({ status: 'error', statusCode, error }));
+					}
+				}
+				break;
+		}
+	}
+
+	/**
+	 * Called to check if page is in idle state (no ongoing network requests).
+	 * If idle is detected, proceeds to extract content.
+	 */
+	private checkForIdle() {
+		void this._queue.queue(async () => {
+			if (this._store.isDisposed) {
+				return;
+			}
+
+			await this.nextFrame();
+
+			if (this._requests.size === 0) {
+				await this.extractContent();
+			} else {
+				this.trace(`New network requests detected, deferring content extraction`);
+			}
+		});
+	}
+
+	/**
+	 * Waits for a rendering frame to ensure the page had a chance to update.
+	 */
+	private async nextFrame() {
+		if (this._store.isDisposed) {
+			return;
+		}
+
+		// Wait for a rendering frame to ensure the page had a chance to update.
+		await raceTimeout(
+			new Promise<void>((resolve) => {
+				try {
+					this.trace(`Waiting for a frame to be rendered`);
+					this._window.webContents.beginFrameSubscription(false, () => {
+						try {
+							this.trace(`A frame has been rendered`);
+							this._window.webContents.endFrameSubscription();
+						} catch {
+							// ignore errors
+						}
+						resolve();
+					});
+				} catch {
+					// ignore errors
+					resolve();
+				}
+			}),
+			WebPageLoader.FRAME_TIMEOUT
+		);
+	}
+
+	/**
+	 * Extracts the content of the loaded web page using the Accessibility domain and reports the result.
+	 */
+	private async extractContent(errorResult?: WebContentExtractResult & { status: 'error' }) {
+		if (this._store.isDisposed) {
+			return;
+		}
+
+		try {
+			this.trace(`Extracting content using Accessibility domain`);
+			const title = this._window.webContents.getTitle();
+			const { nodes } = await this._debugger.sendCommand('Accessibility.getFullAXTree') as { nodes: AXNode[] };
+			const result = convertAXTreeToMarkdown(this._uri, nodes);
+
+			if (errorResult !== undefined) {
+				this._onResult({ ...errorResult, result, title });
+			} else {
+				this._onResult({ status: 'ok', result, title });
+			}
+		} catch (e) {
+			if (errorResult !== undefined) {
+				this._onResult(errorResult);
+			} else {
+				this._onResult({
+					status: 'error',
+					error: e instanceof Error ? e.message : String(e)
+				});
+			}
+		}
+	}
+}

--- a/src/vs/platform/webContentExtractor/test/electron-main/webContentCache.test.ts
+++ b/src/vs/platform/webContentExtractor/test/electron-main/webContentCache.test.ts
@@ -73,8 +73,8 @@ suite('WebContentCache', () => {
 
 	test('different options produce different cache entries', () => {
 		const uri = URI.parse('https://example.com/page');
-		const resultWithRedirects: WebContentExtractResult = { status: 'ok', result: 'With redirects' };
-		const resultWithoutRedirects: WebContentExtractResult = { status: 'ok', result: 'Without redirects' };
+		const resultWithRedirects: WebContentExtractResult = { status: 'ok', result: 'With redirects', title: 'Redirects Title' };
+		const resultWithoutRedirects: WebContentExtractResult = { status: 'ok', result: 'Without redirects', title: 'No Redirects Title' };
 
 		cache.add(uri, { followRedirects: true }, resultWithRedirects);
 		cache.add(uri, { followRedirects: false }, resultWithoutRedirects);
@@ -85,7 +85,7 @@ suite('WebContentCache', () => {
 
 	test('undefined options and followRedirects: false use same cache key', () => {
 		const uri = URI.parse('https://example.com/page');
-		const extractResult: WebContentExtractResult = { status: 'ok', result: 'Content' };
+		const extractResult: WebContentExtractResult = { status: 'ok', result: 'Content', title: 'Title' };
 
 		cache.add(uri, undefined, extractResult);
 
@@ -102,7 +102,7 @@ suite('WebContentCache', () => {
 	test('URI path case is ignored for cache lookup', () => {
 		const uri1 = URI.parse('https://example.com/Page');
 		const uri2 = URI.parse('https://example.com/page');
-		const extractResult: WebContentExtractResult = { status: 'ok', result: 'Content' };
+		const extractResult: WebContentExtractResult = { status: 'ok', result: 'Content', title: 'Title' };
 
 		cache.add(uri1, undefined, extractResult);
 
@@ -116,7 +116,7 @@ suite('WebContentCache', () => {
 
 	test('expired success entries are not returned', () => {
 		const uri = URI.parse('https://example.com/page');
-		const extractResult: WebContentExtractResult = { status: 'ok', result: 'Content' };
+		const extractResult: WebContentExtractResult = { status: 'ok', result: 'Content', title: 'Title' };
 
 		// Mock Date.now to control expiration
 		const originalDateNow = Date.now;
@@ -159,7 +159,7 @@ suite('WebContentCache', () => {
 
 	test('non-expired success entries are returned', () => {
 		const uri = URI.parse('https://example.com/page');
-		const extractResult: WebContentExtractResult = { status: 'ok', result: 'Content' };
+		const extractResult: WebContentExtractResult = { status: 'ok', result: 'Content', title: 'Title' };
 
 		const originalDateNow = Date.now;
 		let currentTime = 1000000;
@@ -226,8 +226,8 @@ suite('WebContentCache', () => {
 
 	test('adding same URI overwrites previous entry', () => {
 		const uri = URI.parse('https://example.com/page');
-		const firstResult: WebContentExtractResult = { status: 'ok', result: 'First content' };
-		const secondResult: WebContentExtractResult = { status: 'ok', result: 'Second content' };
+		const firstResult: WebContentExtractResult = { status: 'ok', result: 'First content', title: 'First Title' };
+		const secondResult: WebContentExtractResult = { status: 'ok', result: 'Second content', title: 'Second Title' };
 
 		cache.add(uri, undefined, firstResult);
 		cache.add(uri, undefined, secondResult);
@@ -243,8 +243,8 @@ suite('WebContentCache', () => {
 	test('different hosts produce different cache entries', () => {
 		const uri1 = URI.parse('https://example.com/page');
 		const uri2 = URI.parse('https://other.com/page');
-		const result1: WebContentExtractResult = { status: 'ok', result: 'Example content' };
-		const result2: WebContentExtractResult = { status: 'ok', result: 'Other content' };
+		const result1: WebContentExtractResult = { status: 'ok', result: 'Example content', title: 'Example Title' };
+		const result2: WebContentExtractResult = { status: 'ok', result: 'Other content', title: 'Other Title' };
 
 		cache.add(uri1, undefined, result1);
 		cache.add(uri2, undefined, result2);
@@ -256,8 +256,8 @@ suite('WebContentCache', () => {
 	test('different paths produce different cache entries', () => {
 		const uri1 = URI.parse('https://example.com/page1');
 		const uri2 = URI.parse('https://example.com/page2');
-		const result1: WebContentExtractResult = { status: 'ok', result: 'Page 1 content' };
-		const result2: WebContentExtractResult = { status: 'ok', result: 'Page 2 content' };
+		const result1: WebContentExtractResult = { status: 'ok', result: 'Page 1 content', title: 'Page 1 Title' };
+		const result2: WebContentExtractResult = { status: 'ok', result: 'Page 2 content', title: 'Page 2 Title' };
 
 		cache.add(uri1, undefined, result1);
 		cache.add(uri2, undefined, result2);
@@ -269,8 +269,8 @@ suite('WebContentCache', () => {
 	test('different query strings produce different cache entries', () => {
 		const uri1 = URI.parse('https://example.com/page?a=1');
 		const uri2 = URI.parse('https://example.com/page?a=2');
-		const result1: WebContentExtractResult = { status: 'ok', result: 'Query 1 content' };
-		const result2: WebContentExtractResult = { status: 'ok', result: 'Query 2 content' };
+		const result1: WebContentExtractResult = { status: 'ok', result: 'Query 1 content', title: 'Query 1 Title' };
+		const result2: WebContentExtractResult = { status: 'ok', result: 'Query 2 content', title: 'Query 2 Title' };
 
 		cache.add(uri1, undefined, result1);
 		cache.add(uri2, undefined, result2);

--- a/src/vs/platform/webContentExtractor/test/electron-main/webContentCache.test.ts
+++ b/src/vs/platform/webContentExtractor/test/electron-main/webContentCache.test.ts
@@ -1,0 +1,283 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { URI } from '../../../../base/common/uri.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+import { WebContentCache } from '../../electron-main/webContentCache.js';
+import { WebContentExtractResult } from '../../common/webContentExtractor.js';
+
+suite('WebContentCache', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	let cache: WebContentCache;
+
+	setup(() => {
+		cache = new WebContentCache();
+	});
+
+	//#region Basic Cache Operations
+
+	test('returns undefined for uncached URI', () => {
+		const uri = URI.parse('https://example.com/page');
+		const result = cache.tryGet(uri, undefined);
+		assert.strictEqual(result, undefined);
+	});
+
+	test('returns cached result for previously added URI', () => {
+		const uri = URI.parse('https://example.com/page');
+		const extractResult: WebContentExtractResult = { status: 'ok', result: 'Test content', title: 'Test Title' };
+
+		cache.add(uri, undefined, extractResult);
+		const cached = cache.tryGet(uri, undefined);
+
+		assert.deepStrictEqual(cached, extractResult);
+	});
+
+	test('returns cached ok result', () => {
+		const uri = URI.parse('https://example.com/page');
+		const extractResult: WebContentExtractResult = { status: 'ok', result: 'Content', title: 'Title' };
+
+		cache.add(uri, undefined, extractResult);
+		const cached = cache.tryGet(uri, undefined);
+
+		assert.deepStrictEqual(cached, extractResult);
+	});
+
+	test('returns cached redirect result', () => {
+		const uri = URI.parse('https://example.com/old');
+		const redirectUri = URI.parse('https://example.com/new');
+		const extractResult: WebContentExtractResult = { status: 'redirect', toURI: redirectUri };
+
+		cache.add(uri, undefined, extractResult);
+		const cached = cache.tryGet(uri, undefined);
+
+		assert.deepStrictEqual(cached, extractResult);
+	});
+
+	test('returns cached error result', () => {
+		const uri = URI.parse('https://example.com/error');
+		const extractResult: WebContentExtractResult = { status: 'error', error: 'Not found', statusCode: 404 };
+
+		cache.add(uri, undefined, extractResult);
+		const cached = cache.tryGet(uri, undefined);
+
+		assert.deepStrictEqual(cached, extractResult);
+	});
+
+	//#endregion
+
+	//#region Options-Based Cache Key
+
+	test('different options produce different cache entries', () => {
+		const uri = URI.parse('https://example.com/page');
+		const resultWithRedirects: WebContentExtractResult = { status: 'ok', result: 'With redirects' };
+		const resultWithoutRedirects: WebContentExtractResult = { status: 'ok', result: 'Without redirects' };
+
+		cache.add(uri, { followRedirects: true }, resultWithRedirects);
+		cache.add(uri, { followRedirects: false }, resultWithoutRedirects);
+
+		assert.deepStrictEqual(cache.tryGet(uri, { followRedirects: true }), resultWithRedirects);
+		assert.deepStrictEqual(cache.tryGet(uri, { followRedirects: false }), resultWithoutRedirects);
+	});
+
+	test('undefined options and followRedirects: false use same cache key', () => {
+		const uri = URI.parse('https://example.com/page');
+		const extractResult: WebContentExtractResult = { status: 'ok', result: 'Content' };
+
+		cache.add(uri, undefined, extractResult);
+
+		// Both undefined and { followRedirects: false } should resolve to the same key
+		// because !!undefined === false and !!false === false
+		assert.deepStrictEqual(cache.tryGet(uri, undefined), extractResult);
+		assert.deepStrictEqual(cache.tryGet(uri, { followRedirects: false }), extractResult);
+	});
+
+	//#endregion
+
+	//#region URI Case Sensitivity
+
+	test('URI path case is ignored for cache lookup', () => {
+		const uri1 = URI.parse('https://example.com/Page');
+		const uri2 = URI.parse('https://example.com/page');
+		const extractResult: WebContentExtractResult = { status: 'ok', result: 'Content' };
+
+		cache.add(uri1, undefined, extractResult);
+
+		// extUriIgnorePathCase should make these equivalent
+		assert.deepStrictEqual(cache.tryGet(uri2, undefined), extractResult);
+	});
+
+	//#endregion
+
+	//#region Cache Expiration
+
+	test('expired success entries are not returned', () => {
+		const uri = URI.parse('https://example.com/page');
+		const extractResult: WebContentExtractResult = { status: 'ok', result: 'Content' };
+
+		// Mock Date.now to control expiration
+		const originalDateNow = Date.now;
+		let currentTime = 1000000;
+		Date.now = () => currentTime;
+
+		try {
+			cache.add(uri, undefined, extractResult);
+
+			// Move time forward past the 24-hour success cache duration
+			currentTime += (1000 * 60 * 60 * 24) + 1; // 24 hours + 1ms
+
+			const cached = cache.tryGet(uri, undefined);
+			assert.strictEqual(cached, undefined);
+		} finally {
+			Date.now = originalDateNow;
+		}
+	});
+
+	test('expired error entries are not returned', () => {
+		const uri = URI.parse('https://example.com/error');
+		const extractResult: WebContentExtractResult = { status: 'error', error: 'Server error', statusCode: 500 };
+
+		const originalDateNow = Date.now;
+		let currentTime = 1000000;
+		Date.now = () => currentTime;
+
+		try {
+			cache.add(uri, undefined, extractResult);
+
+			// Move time forward past the 5-minute error cache duration
+			currentTime += (1000 * 60 * 5) + 1; // 5 minutes + 1ms
+
+			const cached = cache.tryGet(uri, undefined);
+			assert.strictEqual(cached, undefined);
+		} finally {
+			Date.now = originalDateNow;
+		}
+	});
+
+	test('non-expired success entries are returned', () => {
+		const uri = URI.parse('https://example.com/page');
+		const extractResult: WebContentExtractResult = { status: 'ok', result: 'Content' };
+
+		const originalDateNow = Date.now;
+		let currentTime = 1000000;
+		Date.now = () => currentTime;
+
+		try {
+			cache.add(uri, undefined, extractResult);
+
+			// Move time forward but stay within the 24-hour success cache duration
+			currentTime += (1000 * 60 * 60 * 23); // 23 hours
+
+			const cached = cache.tryGet(uri, undefined);
+			assert.deepStrictEqual(cached, extractResult);
+		} finally {
+			Date.now = originalDateNow;
+		}
+	});
+
+	test('non-expired error entries are returned', () => {
+		const uri = URI.parse('https://example.com/error');
+		const extractResult: WebContentExtractResult = { status: 'error', error: 'Server error', statusCode: 500 };
+
+		const originalDateNow = Date.now;
+		let currentTime = 1000000;
+		Date.now = () => currentTime;
+
+		try {
+			cache.add(uri, undefined, extractResult);
+
+			// Move time forward but stay within the 5-minute error cache duration
+			currentTime += (1000 * 60 * 4); // 4 minutes
+
+			const cached = cache.tryGet(uri, undefined);
+			assert.deepStrictEqual(cached, extractResult);
+		} finally {
+			Date.now = originalDateNow;
+		}
+	});
+
+	test('redirect results use success cache duration', () => {
+		const uri = URI.parse('https://example.com/old');
+		const extractResult: WebContentExtractResult = { status: 'redirect', toURI: URI.parse('https://example.com/new') };
+
+		const originalDateNow = Date.now;
+		let currentTime = 1000000;
+		Date.now = () => currentTime;
+
+		try {
+			cache.add(uri, undefined, extractResult);
+
+			// Move time forward past error duration but within success duration
+			currentTime += (1000 * 60 * 60); // 1 hour (past 5 min error, within 24 hour success)
+
+			const cached = cache.tryGet(uri, undefined);
+			assert.deepStrictEqual(cached, extractResult);
+		} finally {
+			Date.now = originalDateNow;
+		}
+	});
+
+	//#endregion
+
+	//#region Cache Overwrite
+
+	test('adding same URI overwrites previous entry', () => {
+		const uri = URI.parse('https://example.com/page');
+		const firstResult: WebContentExtractResult = { status: 'ok', result: 'First content' };
+		const secondResult: WebContentExtractResult = { status: 'ok', result: 'Second content' };
+
+		cache.add(uri, undefined, firstResult);
+		cache.add(uri, undefined, secondResult);
+
+		const cached = cache.tryGet(uri, undefined);
+		assert.deepStrictEqual(cached, secondResult);
+	});
+
+	//#endregion
+
+	//#region Different URI Components
+
+	test('different hosts produce different cache entries', () => {
+		const uri1 = URI.parse('https://example.com/page');
+		const uri2 = URI.parse('https://other.com/page');
+		const result1: WebContentExtractResult = { status: 'ok', result: 'Example content' };
+		const result2: WebContentExtractResult = { status: 'ok', result: 'Other content' };
+
+		cache.add(uri1, undefined, result1);
+		cache.add(uri2, undefined, result2);
+
+		assert.deepStrictEqual(cache.tryGet(uri1, undefined), result1);
+		assert.deepStrictEqual(cache.tryGet(uri2, undefined), result2);
+	});
+
+	test('different paths produce different cache entries', () => {
+		const uri1 = URI.parse('https://example.com/page1');
+		const uri2 = URI.parse('https://example.com/page2');
+		const result1: WebContentExtractResult = { status: 'ok', result: 'Page 1 content' };
+		const result2: WebContentExtractResult = { status: 'ok', result: 'Page 2 content' };
+
+		cache.add(uri1, undefined, result1);
+		cache.add(uri2, undefined, result2);
+
+		assert.deepStrictEqual(cache.tryGet(uri1, undefined), result1);
+		assert.deepStrictEqual(cache.tryGet(uri2, undefined), result2);
+	});
+
+	test('different query strings produce different cache entries', () => {
+		const uri1 = URI.parse('https://example.com/page?a=1');
+		const uri2 = URI.parse('https://example.com/page?a=2');
+		const result1: WebContentExtractResult = { status: 'ok', result: 'Query 1 content' };
+		const result2: WebContentExtractResult = { status: 'ok', result: 'Query 2 content' };
+
+		cache.add(uri1, undefined, result1);
+		cache.add(uri2, undefined, result2);
+
+		assert.deepStrictEqual(cache.tryGet(uri1, undefined), result1);
+		assert.deepStrictEqual(cache.tryGet(uri2, undefined), result2);
+	});
+
+	//#endregion
+});

--- a/src/vs/platform/webContentExtractor/test/electron-main/webPageLoader.test.ts
+++ b/src/vs/platform/webContentExtractor/test/electron-main/webPageLoader.test.ts
@@ -1,0 +1,632 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import * as sinon from 'sinon';
+import { URI } from '../../../../base/common/uri.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+import { NullLogService } from '../../../log/common/log.js';
+import { AXNode } from '../../electron-main/cdpAccessibilityDomain.js';
+import { WebPageLoader } from '../../electron-main/webPageLoader.js';
+
+interface MockElectronEvent {
+	preventDefault?: sinon.SinonStub;
+}
+
+class MockWebContents {
+	private readonly _listeners = new Map<string, ((...args: unknown[]) => void)[]>();
+	public readonly debugger: MockDebugger;
+	public loadURL = sinon.stub().resolves();
+	public getTitle = sinon.stub().returns('Test Page Title');
+
+	constructor() {
+		this.debugger = new MockDebugger();
+	}
+
+	once(event: string, listener: (...args: unknown[]) => void): this {
+		if (!this._listeners.has(event)) {
+			this._listeners.set(event, []);
+		}
+		this._listeners.get(event)!.push(listener);
+		return this;
+	}
+
+	emit(event: string, ...args: unknown[]): void {
+		const listeners = this._listeners.get(event) || [];
+		for (const listener of listeners) {
+			listener(...args);
+		}
+		this._listeners.delete(event);
+	}
+
+	beginFrameSubscription(_onlyDirty: boolean, callback: () => void): void {
+		setTimeout(() => callback(), 0);
+	}
+
+	endFrameSubscription(): void {
+	}
+}
+
+class MockDebugger {
+	private readonly _listeners = new Map<string, ((...args: unknown[]) => void)[]>();
+	public attach = sinon.stub();
+	public sendCommand = sinon.stub().resolves({});
+
+	on(event: string, listener: (...args: unknown[]) => void): this {
+		if (!this._listeners.has(event)) {
+			this._listeners.set(event, []);
+		}
+		this._listeners.get(event)!.push(listener);
+		return this;
+	}
+
+	emit(event: string, ...args: unknown[]): void {
+		const listeners = this._listeners.get(event) || [];
+		for (const listener of listeners) {
+			listener(...args);
+		}
+	}
+}
+
+class MockBrowserWindow {
+	public readonly webContents: MockWebContents;
+	public destroy = sinon.stub();
+	public loadURL = sinon.stub().resolves();
+
+	constructor(_options?: Electron.BrowserWindowConstructorOptions) {
+		this.webContents = new MockWebContents();
+	}
+}
+
+suite('WebPageLoader', () => {
+	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
+	let window: MockBrowserWindow;
+
+	teardown(() => {
+		sinon.restore();
+	});
+
+	function createWebPageLoader(uri: URI, options?: { followRedirects?: boolean }): WebPageLoader {
+		const loader = new WebPageLoader((options) => {
+			window = new MockBrowserWindow(options);
+			// eslint-disable-next-line local/code-no-any-casts
+			return window as any;
+		}, new NullLogService(), uri, options);
+		disposables.add(loader);
+		return loader;
+	}
+
+	function createMockAXNodes(): AXNode[] {
+		return [
+			{
+				nodeId: 'node1',
+				ignored: false,
+				role: { type: 'role', value: 'paragraph' },
+				childIds: ['node2']
+			},
+			{
+				nodeId: 'node2',
+				ignored: false,
+				role: { type: 'role', value: 'StaticText' },
+				name: { type: 'string', value: 'Test content from page' }
+			}
+		];
+	}
+
+	//#region Basic Loading Tests
+
+	test('successful page load returns ok status with content', async () => {
+		const uri = URI.parse('https://example.com/page');
+		const axNodes = createMockAXNodes();
+
+		const loader = createWebPageLoader(uri);
+
+		window.webContents.debugger.sendCommand.callsFake((command: string) => {
+			switch (command) {
+				case 'Network.enable':
+					return Promise.resolve();
+				case 'Accessibility.getFullAXTree':
+					return Promise.resolve({ nodes: axNodes });
+				default:
+					assert.fail(`Unexpected command: ${command}`);
+			}
+		});
+
+		const loadPromise = loader.load();
+
+		// Simulate page load events
+		window.webContents.emit('did-start-loading');
+		window.webContents.emit('did-finish-load');
+
+		const result = await loadPromise;
+
+		assert.strictEqual(result.status, 'ok');
+		assert.strictEqual(result.title, 'Test Page Title');
+		assert.ok(result.result.includes('Test content from page'));
+	});
+
+	test('page load failure returns error status', async () => {
+		const uri = URI.parse('https://example.com/page');
+
+		const loader = createWebPageLoader(uri);
+
+		window.webContents.debugger.sendCommand.callsFake((command: string) => {
+			switch (command) {
+				case 'Network.enable':
+					return Promise.resolve();
+				case 'Accessibility.getFullAXTree':
+					return Promise.resolve({ nodes: createMockAXNodes() });
+				default:
+					assert.fail(`Unexpected command: ${command}`);
+			}
+		});
+
+		const loadPromise = loader.load();
+
+		// Simulate page load failure
+		const mockEvent: MockElectronEvent = {};
+		window.webContents.emit('did-fail-load', mockEvent, -6, 'ERR_CONNECTION_REFUSED');
+
+		const result = await loadPromise;
+
+		assert.strictEqual(result.status, 'error');
+		if (result.status === 'error') {
+			assert.strictEqual(result.statusCode, -6);
+			assert.strictEqual(result.error, 'ERR_CONNECTION_REFUSED');
+		}
+	});
+
+	//#endregion
+
+	//#region Redirect Tests
+
+	test('redirect to different authority returns redirect status when followRedirects is false', async () => {
+		const uri = URI.parse('https://example.com/page');
+		const redirectUrl = 'https://other-domain.com/redirected';
+
+		const loader = createWebPageLoader(uri, { followRedirects: false });
+
+		window.webContents.debugger.sendCommand.resolves({});
+
+		const loadPromise = loader.load();
+
+		// Simulate redirect to different authority
+		const mockEvent: MockElectronEvent = {
+			preventDefault: sinon.stub()
+		};
+		window.webContents.emit('will-redirect', mockEvent, redirectUrl);
+
+		const result = await loadPromise;
+
+		assert.strictEqual(result.status, 'redirect');
+		if (result.status === 'redirect') {
+			assert.strictEqual(result.toURI.authority, 'other-domain.com');
+		}
+		assert.ok((mockEvent.preventDefault!).called);
+	});
+
+	test('redirect to same authority is not treated as redirect', async () => {
+		const uri = URI.parse('https://example.com/page');
+		const redirectUrl = 'https://example.com/other-page';
+		const axNodes = createMockAXNodes();
+
+		const loader = createWebPageLoader(uri, { followRedirects: false });
+
+		window.webContents.debugger.sendCommand.callsFake((command: string) => {
+			switch (command) {
+				case 'Network.enable':
+					return Promise.resolve();
+				case 'Accessibility.getFullAXTree':
+					return Promise.resolve({ nodes: axNodes });
+				default:
+					assert.fail(`Unexpected command: ${command}`);
+			}
+		});
+
+		const loadPromise = loader.load();
+
+		// Simulate redirect to same authority
+		const mockEvent: MockElectronEvent = {
+			preventDefault: sinon.stub()
+		};
+		window.webContents.emit('will-redirect', mockEvent, redirectUrl);
+
+		// Should not prevent default for same-authority redirects
+		assert.ok(!(mockEvent.preventDefault!).called);
+
+		// Continue with normal load
+		window.webContents.emit('did-start-loading');
+		window.webContents.emit('did-finish-load');
+
+		const result = await loadPromise;
+		assert.strictEqual(result.status, 'ok');
+	});
+
+	test('redirect is followed when followRedirects option is true', async () => {
+		const uri = URI.parse('https://example.com/page');
+		const redirectUrl = 'https://other-domain.com/redirected';
+		const axNodes = createMockAXNodes();
+
+		const loader = createWebPageLoader(uri, { followRedirects: true });
+
+		window.webContents.debugger.sendCommand.callsFake((command: string) => {
+			switch (command) {
+				case 'Network.enable':
+					return Promise.resolve();
+				case 'Accessibility.getFullAXTree':
+					return Promise.resolve({ nodes: axNodes });
+				default:
+					assert.fail(`Unexpected command: ${command}`);
+			}
+		});
+
+		const loadPromise = loader.load();
+
+		// Simulate redirect
+		const mockEvent: MockElectronEvent = {
+			preventDefault: sinon.stub()
+		};
+		window.webContents.emit('will-redirect', mockEvent, redirectUrl);
+
+		// Should not prevent default when followRedirects is true
+		assert.ok(!(mockEvent.preventDefault!).called);
+
+		// Continue with normal load after redirect
+		window.webContents.emit('did-start-loading');
+		window.webContents.emit('did-finish-load');
+
+		const result = await loadPromise;
+		assert.strictEqual(result.status, 'ok');
+	});
+
+	//#endregion
+
+	//#region HTTP Error Tests
+
+	test('HTTP error status code returns error with content', async () => {
+		const uri = URI.parse('https://example.com/not-found');
+		const axNodes = createMockAXNodes();
+
+		const loader = createWebPageLoader(uri);
+
+		window.webContents.debugger.sendCommand.callsFake((command: string) => {
+			switch (command) {
+				case 'Network.enable':
+					return Promise.resolve();
+				case 'Accessibility.getFullAXTree':
+					return Promise.resolve({ nodes: axNodes });
+				default:
+					assert.fail(`Unexpected command: ${command}`);
+			}
+		});
+
+		const loadPromise = loader.load();
+
+		// Simulate network response with error status
+		const mockEvent: MockElectronEvent = {};
+		window.webContents.debugger.emit('message', mockEvent, 'Network.responseReceived', {
+			requestId: 'req1',
+			type: 'Document',
+			response: {
+				status: 404,
+				statusText: 'Not Found'
+			}
+		});
+
+		const result = await loadPromise;
+
+		assert.strictEqual(result.status, 'error');
+		if (result.status === 'error') {
+			assert.strictEqual(result.statusCode, 404);
+			assert.strictEqual(result.error, 'Not Found');
+		}
+	});
+
+	test('HTTP 500 error returns server error status', async () => {
+		const uri = URI.parse('https://example.com/server-error');
+		const axNodes = createMockAXNodes();
+
+		const loader = createWebPageLoader(uri);
+
+		window.webContents.debugger.sendCommand.callsFake((command: string) => {
+			switch (command) {
+				case 'Network.enable':
+					return Promise.resolve();
+				case 'Accessibility.getFullAXTree':
+					return Promise.resolve({ nodes: axNodes });
+				default:
+					assert.fail(`Unexpected command: ${command}`);
+			}
+		});
+
+		const loadPromise = loader.load();
+
+		// Simulate network response with 500 status
+		const mockEvent: MockElectronEvent = {};
+		window.webContents.debugger.emit('message', mockEvent, 'Network.responseReceived', {
+			requestId: 'req1',
+			type: 'Document',
+			response: {
+				status: 500,
+				statusText: 'Internal Server Error'
+			}
+		});
+
+		const result = await loadPromise;
+
+		assert.strictEqual(result.status, 'error');
+		if (result.status === 'error') {
+			assert.strictEqual(result.statusCode, 500);
+			assert.strictEqual(result.error, 'Internal Server Error');
+		}
+	});
+
+	test('HTTP error without status text uses fallback message', async () => {
+		const uri = URI.parse('https://example.com/error');
+		const axNodes = createMockAXNodes();
+
+		const loader = createWebPageLoader(uri);
+
+		window.webContents.debugger.sendCommand.callsFake((command: string) => {
+			switch (command) {
+				case 'Network.enable':
+					return Promise.resolve();
+				case 'Accessibility.getFullAXTree':
+					return Promise.resolve({ nodes: axNodes });
+				default:
+					assert.fail(`Unexpected command: ${command}`);
+			}
+		});
+
+		const loadPromise = loader.load();
+
+		// Simulate network response without status text
+		const mockEvent: MockElectronEvent = {};
+		window.webContents.debugger.emit('message', mockEvent, 'Network.responseReceived', {
+			requestId: 'req1',
+			type: 'Document',
+			response: {
+				status: 503
+			}
+		});
+
+		const result = await loadPromise;
+
+		assert.strictEqual(result.status, 'error');
+		if (result.status === 'error') {
+			assert.strictEqual(result.statusCode, 503);
+			assert.strictEqual(result.error, 'HTTP error 503');
+		}
+	});
+
+	//#endregion
+
+	//#region Network Request Tracking Tests
+
+	test('tracks network requests and waits for completion', async () => {
+		const uri = URI.parse('https://example.com/page');
+		const axNodes = createMockAXNodes();
+
+		const loader = createWebPageLoader(uri);
+
+		window.webContents.debugger.sendCommand.callsFake((command: string) => {
+			switch (command) {
+				case 'Network.enable':
+					return Promise.resolve();
+				case 'Accessibility.getFullAXTree':
+					return Promise.resolve({ nodes: axNodes });
+				default:
+					assert.fail(`Unexpected command: ${command}`);
+			}
+		});
+
+		const loadPromise = loader.load();
+
+		// Simulate page starting to load
+		window.webContents.emit('did-start-loading');
+
+		// Simulate network requests
+		const mockEvent: MockElectronEvent = {};
+		window.webContents.debugger.emit('message', mockEvent, 'Network.requestWillBeSent', {
+			requestId: 'req1'
+		});
+		window.webContents.debugger.emit('message', mockEvent, 'Network.requestWillBeSent', {
+			requestId: 'req2'
+		});
+
+		// Simulate page finish load (but network requests still pending)
+		window.webContents.emit('did-finish-load');
+
+		// Simulate network requests completing
+		window.webContents.debugger.emit('message', mockEvent, 'Network.loadingFinished', {
+			requestId: 'req1'
+		});
+		window.webContents.debugger.emit('message', mockEvent, 'Network.loadingFinished', {
+			requestId: 'req2'
+		});
+
+		const result = await loadPromise;
+
+		assert.strictEqual(result.status, 'ok');
+	});
+
+	test('handles network request failures gracefully', async () => {
+		const uri = URI.parse('https://example.com/page');
+		const axNodes = createMockAXNodes();
+
+		const loader = createWebPageLoader(uri);
+
+		window.webContents.debugger.sendCommand.callsFake((command: string) => {
+			switch (command) {
+				case 'Network.enable':
+					return Promise.resolve();
+				case 'Accessibility.getFullAXTree':
+					return Promise.resolve({ nodes: axNodes });
+				default:
+					assert.fail(`Unexpected command: ${command}`);
+			}
+		});
+
+		const loadPromise = loader.load();
+
+		// Simulate page load
+		window.webContents.emit('did-start-loading');
+
+		// Simulate a network request that fails
+		const mockEvent: MockElectronEvent = {};
+		window.webContents.debugger.emit('message', mockEvent, 'Network.requestWillBeSent', {
+			requestId: 'req1'
+		});
+		window.webContents.debugger.emit('message', mockEvent, 'Network.loadingFailed', {
+			requestId: 'req1'
+		});
+
+		window.webContents.emit('did-finish-load');
+
+		const result = await loadPromise;
+
+		assert.strictEqual(result.status, 'ok');
+	});
+
+	//#endregion
+
+	//#region Accessibility Tree Extraction Tests
+
+	test('extracts content from accessibility tree', async () => {
+		const uri = URI.parse('https://example.com/page');
+		const axNodes: AXNode[] = [
+			{
+				nodeId: 'heading1',
+				ignored: false,
+				role: { type: 'role', value: 'heading' },
+				name: { type: 'string', value: 'Page Title' },
+				properties: [{ name: 'level', value: { type: 'integer', value: 1 } }],
+				childIds: ['text1']
+			},
+			{
+				nodeId: 'text1',
+				ignored: false,
+				role: { type: 'role', value: 'StaticText' },
+				name: { type: 'string', value: 'Page Title' }
+			}
+		];
+
+		const loader = createWebPageLoader(uri);
+
+		window.webContents.debugger.sendCommand.callsFake((command: string) => {
+			switch (command) {
+				case 'Network.enable':
+					return Promise.resolve();
+				case 'Accessibility.getFullAXTree':
+					return Promise.resolve({ nodes: axNodes });
+				default:
+					assert.fail(`Unexpected command: ${command}`);
+			}
+		});
+
+		const loadPromise = loader.load();
+
+		window.webContents.emit('did-start-loading');
+		window.webContents.emit('did-finish-load');
+
+		const result = await loadPromise;
+
+		assert.strictEqual(result.status, 'ok');
+		if (result.status === 'ok') {
+			assert.ok(result.result.includes('# Page Title'));
+		}
+	});
+
+	test('handles empty accessibility tree', async () => {
+		const uri = URI.parse('https://example.com/empty');
+
+		const loader = createWebPageLoader(uri);
+
+		window.webContents.debugger.sendCommand.callsFake((command: string) => {
+			switch (command) {
+				case 'Network.enable':
+					return Promise.resolve();
+				case 'Accessibility.getFullAXTree':
+					return Promise.resolve({ nodes: [] });
+				default:
+					assert.fail(`Unexpected command: ${command}`);
+			}
+		});
+
+		const loadPromise = loader.load();
+
+		window.webContents.emit('did-start-loading');
+		window.webContents.emit('did-finish-load');
+
+		const result = await loadPromise;
+
+		assert.strictEqual(result.status, 'ok');
+		if (result.status === 'ok') {
+			assert.strictEqual(result.result, '');
+		}
+	});
+
+	test('handles accessibility extraction failure', async () => {
+		const uri = URI.parse('https://example.com/page');
+
+		const loader = createWebPageLoader(uri);
+
+		window.webContents.debugger.sendCommand.callsFake((command: string) => {
+			switch (command) {
+				case 'Network.enable':
+					return Promise.resolve();
+				case 'Accessibility.getFullAXTree':
+					return Promise.reject(new Error('Debugger detached'));
+				default:
+					assert.fail(`Unexpected command: ${command}`);
+			}
+		});
+
+		const loadPromise = loader.load();
+
+		window.webContents.emit('did-start-loading');
+		window.webContents.emit('did-finish-load');
+
+		const result = await loadPromise;
+
+		assert.strictEqual(result.status, 'error');
+		if (result.status === 'error') {
+			assert.ok(result.error.includes('Debugger detached'));
+		}
+	});
+
+	//#endregion
+
+	//#region Disposal Tests
+
+	test('disposes resources after load completes', async () => {
+		const uri = URI.parse('https://example.com/page');
+
+		const loader = createWebPageLoader(uri);
+
+		window.webContents.debugger.sendCommand.callsFake((command: string) => {
+			switch (command) {
+				case 'Network.enable':
+					return Promise.resolve();
+				case 'Accessibility.getFullAXTree':
+					return Promise.resolve({ nodes: createMockAXNodes() });
+				default:
+					assert.fail(`Unexpected command: ${command}`);
+			}
+		});
+
+		const loadPromise = loader.load();
+
+		window.webContents.emit('did-start-loading');
+		window.webContents.emit('did-finish-load');
+
+		await loadPromise;
+
+		// The loader should call destroy on the window when disposed
+		assert.ok(window.destroy.called);
+	});
+
+	//#endregion
+});


### PR DESCRIPTION
Various bug fixes and improvements in the fetch tool.

Fetch tool now uses heuristics to wait longer for dynamic pages to load content via tracking network traffic.

Also included in the results:
- Page title
- Error status code
- Error message

These will be used in follow-up PRs to improve chat UI.

Caching has been improved to differentiate expiration time based on response type (error vs success). Cache keys now include options.

Added unit-tests for all new/updated code.

Fixes #248453 - most of the changes
Fixes #268104 - reduced error caching to 5 mins
Fixes #263390 - better message is provided

With this PR the fetch tool can load more web sites, e.g. we can now load microsoft.com and vscodeedu.com which produced empty or redirect content earlier.
