### PR TITLE
Add activity bar hover foreground and background color definitions

### DIFF
--- a/src/vs/workbench/common/theme.ts
+++ b/src/vs/workbench/common/theme.ts
@@ -431,6 +431,11 @@ export const ACTIVITY_BAR_ACTIVE_FOCUS_BORDER = registerColor('activityBar.activ
 
 export const ACTIVITY_BAR_ACTIVE_BACKGROUND = registerColor('activityBar.activeBackground', null, localize('activityBarActiveBackground', "Activity bar background color for the active item. The activity bar is showing on the far left or right and allows to switch between views of the side bar."));
 
+// Hover colors for activity bar items (fixes #210694)
+export const ACTIVITY_BAR_HOVER_FOREGROUND = registerColor('activityBar.hoverForeground', null, localize('activityBarHoverForeground', "Activity bar item foreground color when hovering. The activity bar is showing on the far left or right and allows to switch between views of the side bar."));
+
+export const ACTIVITY_BAR_HOVER_BACKGROUND = registerColor('activityBar.hoverBackground', null, localize('activityBarHoverBackground', "Activity bar item background color when hovering. The activity bar is showing on the far left or right and allows to switch between views of the side bar."));
+
 export const ACTIVITY_BAR_DRAG_AND_DROP_BORDER = registerColor('activityBar.dropBorder', {
 	dark: ACTIVITY_BAR_FOREGROUND,
 	light: ACTIVITY_BAR_FOREGROUND,
@@ -462,6 +467,11 @@ export const ACTIVITY_BAR_TOP_ACTIVE_BORDER = registerColor('activityBarTop.acti
 }, localize('activityBarTopActiveFocusBorder', "Focus border color for the active item in the Activity bar when it is on top / bottom. The activity allows to switch between views of the side bar."));
 
 export const ACTIVITY_BAR_TOP_ACTIVE_BACKGROUND = registerColor('activityBarTop.activeBackground', null, localize('activityBarTopActiveBackground', "Background color for the active item in the Activity bar when it is on top / bottom. The activity allows to switch between views of the side bar."));
+
+// Hover colors for top activity bar items (fixes #210694)
+export const ACTIVITY_BAR_TOP_HOVER_FOREGROUND = registerColor('activityBarTop.hoverForeground', null, localize('activityBarTopHoverForeground', "Activity bar item foreground color when hovering (top/bottom position). The activity bar allows to switch between views of the side bar."));
+
+export const ACTIVITY_BAR_TOP_HOVER_BACKGROUND = registerColor('activityBarTop.hoverBackground', null, localize('activityBarTopHoverBackground', "Activity bar item background color when hovering (top/bottom position). The activity bar allows to switch between views of the side bar."));
 
 export const ACTIVITY_BAR_TOP_INACTIVE_FOREGROUND = registerColor('activityBarTop.inactiveForeground', {
 	dark: transparent(ACTIVITY_BAR_TOP_FOREGROUND, 0.6),


### PR DESCRIPTION
Fixes #210694

## Summary
Added 4 new theme color definitions for activity bar hover states:
- `activityBar.hoverForeground` - Foreground color when hovering over activity bar items
- `activityBar.hoverBackground` - Background color when hovering over activity bar items
- `activityBarTop.hoverForeground` - Foreground color when hovering (top/bottom position)
- `activityBarTop.hoverBackground` - Background color when hovering (top/bottom position)

## Description
These new color tokens allow users to customize the foreground and background colors when hovering over activity bar items, in both the side position and top/bottom positions.

The implementation follows the existing pattern used for other activity bar colors and tab hover colors in the codebase.

## Testing
- Colors are registered with `null` default values (consistent with other hover colors)
- Users can customize via `settings.json` under `workbench.colorCustomizations`