### PR TITLE
Update watermark text color to use description foreground

### DIFF
--- a/src/vs/workbench/browser/parts/editor/media/editorgroupview.css
+++ b/src/vs/workbench/browser/parts/editor/media/editorgroupview.css
@@ -101,7 +101,7 @@
 	justify-content: space-between;
 	margin: 4px 0;
 	cursor: default;
-	color: var(--vscode-editorWatermark-foreground);
+	color: var(--vscode-descriptionForeground);
 }
 
 .monaco-workbench .part.editor > .content .editor-group-container > .editor-group-watermark .shortcuts dl:first-of-type {


### PR DESCRIPTION
Change the watermark text color to utilize the description foreground to reduce brightness.

Before:
<img width="367" height="433" alt="image" src="https://github.com/user-attachments/assets/69ff5243-0c29-41f9-a65e-d1061ab74afb" />


After:
<img width="478" height="504" alt="image" src="https://github.com/user-attachments/assets/e6b35283-e78c-45ae-a327-dc19cd83fc5c" />


