### PR TITLE
Fix stdin argument ordering with --diff flag

### DIFF
--- a/src/vs/code/node/cli.ts
+++ b/src/vs/code/node/cli.ts
@@ -255,7 +255,11 @@ export async function main(argv: string[]): Promise<void> {
 		}
 
 		const hasReadStdinArg = args._.some(arg => arg === '-') || args.chat?._.some(arg => arg === '-');
+
+		// Track the position of the first "-" argument in argv before removing it
+		let stdinArgIndex = -1;
 		if (hasReadStdinArg) {
+			stdinArgIndex = argv.indexOf('-');
 			// remove the "-" argument when we read from stdin
 			args._ = args._.filter(a => a !== '-');
 			argv = argv.filter(a => a !== '-');
@@ -299,7 +303,12 @@ export async function main(argv: string[]): Promise<void> {
 					} else {
 						// Make sure to open tmp file as editor but ignore
 						// it in the "recently open" list
-						addArg(argv, stdinFilePath);
+						// Insert stdinFilePath at the position where "-" was, or append if position unknown
+						if (stdinArgIndex !== -1) {
+							argv.splice(stdinArgIndex, 0, stdinFilePath);
+						} else {
+							addArg(argv, stdinFilePath);
+						}
 						addArg(argv, '--skip-add-to-recently-opened');
 					}
 


### PR DESCRIPTION
Fixes #260309

When using stdin with the --diff flag, the position of the `-` argument is now respected. Previously, both `code --diff - file` and `code --diff file -` would result in the same ordering because the stdin temp file was always appended at the end.

Now the stdin file is inserted at the position where the `-` argument was originally specified, making the behavior consistent with regular file arguments.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
