### PR TITLE
Update border color for focused keybinding keys

### DIFF
--- a/src/vs/platform/quickinput/browser/media/quickInput.css
+++ b/src/vs/platform/quickinput/browser/media/quickInput.css
@@ -348,6 +348,7 @@
 
 .quick-input-list .monaco-list-row.focused .monaco-keybinding-key {
 	background: none;
+	border-color: var(--vscode-widget-shadow);
 }
 
 .quick-input-list .quick-input-list-separator-as-item {

--- a/src/vs/workbench/contrib/preferences/browser/media/keybindingsEditor.css
+++ b/src/vs/workbench/contrib/preferences/browser/media/keybindingsEditor.css
@@ -232,8 +232,7 @@
 
 .keybindings-editor > .keybindings-body > .keybindings-table-container .monaco-table.focused .monaco-list-row.selected .monaco-table-tr .monaco-table-td .monaco-keybinding-key {
 	color: var(--vscode-list-activeSelectionForeground);
-	border-color: inherit !important;
-	opacity: 0.8;
+	border-color: var(--vscode-widget-shadow) !important;
 }
 
 .keybindings-editor > .keybindings-body > .keybindings-table-container .monaco-table .monaco-list-row:hover:not(.selected):not(.focused) .monaco-table-tr .monaco-table-td .monaco-keybinding-key {


### PR DESCRIPTION
Change the border color for focused keybinding keys to use a darker color to improve appearance.
![Recording 2025-11-26 at 10 15 01](https://github.com/user-attachments/assets/bc46a2c1-00af-4ff3-850a-08868278dd40)

