### PR TITLE
Adjust max-width and margin for editor group watermark

### DIFF
--- a/src/vs/workbench/browser/parts/editor/media/editorgroupview.css
+++ b/src/vs/workbench/browser/parts/editor/media/editorgroupview.css
@@ -32,7 +32,7 @@
 .monaco-workbench .part.editor > .content .editor-group-container > .editor-group-watermark  {
 	display: flex;
 	height: 100%;
-	max-width: 256px;
+	max-width: 272px;
 	margin: auto;
 	flex-direction: column;
 	align-items: center;
@@ -118,6 +118,7 @@
 
 .monaco-workbench .part.editor > .content .editor-group-container > .editor-group-watermark .shortcuts dd {
 	text-align: left;
+	margin-inline-start: 24px;
 }
 
 /* Title */


### PR DESCRIPTION
Modify the max-width and margin settings for the editor group watermark to improve layout and alignment. Test the changes by checking the appearance of the watermark in the editor group.

Before:

<img width="384" height="436" alt="image" src="https://github.com/user-attachments/assets/d7fbf415-6114-4cdb-9459-3d7a14564f4f" />


After:

<img width="387" height="425" alt="image" src="https://github.com/user-attachments/assets/bdc2a4eb-3423-4846-8c7a-587165f04a93" />


