### PR TITLE
clear parent chat when using handoff continueOn option

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatWidget.ts
@@ -1329,7 +1329,7 @@ export class ChatWidget extends Disposable implements IChatWidget {
 
 				// Clear parent editor
 				await this.clear();
-			});
+			}).catch(e => this.logService.error('Failed to handle handoff continueOn', e));
 		} else if (handoff.agent) {
 			// Regular handoff to specified agent
 			this._switchToAgentByName(handoff.agent);

--- a/src/vs/workbench/contrib/chat/browser/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatWidget.ts
@@ -1307,7 +1307,7 @@ export class ChatWidget extends Disposable implements IChatWidget {
 				const checkForComplete = () => {
 					const items = this.viewModel?.getItems() ?? [];
 					const lastItem = items[items.length - 1];
-					if (lastItem && isResponseVM(lastItem) && lastItem.isComplete && !lastItem.model.isPendingConfirmation.get()) {
+					if (lastItem && isResponseVM(lastItem) && lastItem.model && lastItem.isComplete && !lastItem.model.isPendingConfirmation.get()) {
 						return true;
 					}
 					return false;

--- a/src/vs/workbench/contrib/chat/browser/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatWidget.ts
@@ -1321,10 +1321,18 @@ export class ChatWidget extends Disposable implements IChatWidget {
 				await new Promise<void>(resolve => {
 					const disposable = this.viewModel!.onDidChange(() => {
 						if (checkForComplete()) {
-							disposable.dispose();
+							cleanup();
 							resolve();
 						}
 					});
+					const timeout = setTimeout(() => {
+						cleanup();
+						resolve();
+					}, 30000); // 30 second timeout
+					const cleanup = () => {
+						clearTimeout(timeout);
+						disposable.dispose();
+					};
 				});
 
 				// Clear parent editor


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

ref https://github.com/microsoft/vscode-internalbacklog/issues/6311

Clears the parent chat after using a handoff's continueOn option (eg: in Plan mode).  This needs to be a little bit complicated to ensure we allow for the implementing participant to show and accept confirmation inputs. 