### PR TITLE
Improve rename handling in inline edits

### DIFF
--- a/src/vs/editor/contrib/inlineCompletions/browser/model/inlineCompletionsSource.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/model/inlineCompletionsSource.ts
@@ -273,7 +273,7 @@ export class InlineCompletionsSource extends Disposable {
 					return this._renameProcessor.proposeRenameRefactoring(this._textModel, s);
 				}));
 
-				providerSuggestions.forEach(s => s.addPerformanceMarker('renameProcessed'));
+				suggestions.forEach(s => s.addPerformanceMarker('renameProcessed'));
 
 				providerResult.cancelAndDispose({ kind: 'lostRace' });
 

--- a/src/vs/editor/contrib/inlineCompletions/browser/model/renameSymbolProcessor.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/model/renameSymbolProcessor.ts
@@ -14,14 +14,15 @@ import { TextEdit } from '../../../../common/core/edits/textEdit.js';
 import { Position } from '../../../../common/core/position.js';
 import { Range } from '../../../../common/core/range.js';
 import { StandardTokenType } from '../../../../common/encodedTokenAttributes.js';
-import { Command, InlineCompletionHintStyle } from '../../../../common/languages.js';
+import { Command } from '../../../../common/languages.js';
 import { ILanguageConfigurationService } from '../../../../common/languages/languageConfigurationRegistry.js';
 import { ITextModel } from '../../../../common/model.js';
 import { ILanguageFeaturesService } from '../../../../common/services/languageFeatures.js';
 import { EditSources, TextModelEditSource } from '../../../../common/textModelEditSource.js';
 import { hasProvider, prepareRename, rename } from '../../../rename/browser/rename.js';
 import { renameSymbolCommandId } from '../controller/commandIds.js';
-import { InlineSuggestHint, InlineSuggestionItem } from './inlineSuggestionItem.js';
+import { InlineSuggestionItem } from './inlineSuggestionItem.js';
+import { IInlineSuggestDataActionRename } from './provideInlineCompletions.js';
 
 export type RenameEdits = {
 	renames: { edits: TextEdit[]; position: Position; oldName: string; newName: string };
@@ -258,14 +259,19 @@ export class RenameSymbolProcessor extends Disposable {
 			providerId: suggestItem.source.provider.providerId,
 			languageId: textModel.getLanguageId(),
 		});
-		const hintRange = edits.renames.edits[0].replacements[0].range;
 		const label = localize('renameSymbol', "Rename '{0}' to '{1}'", oldName, newName);
 		const command: Command = {
 			id: renameSymbolCommandId,
 			title: label,
 			arguments: [textModel, position, newName, source],
 		};
-		const hint = InlineSuggestHint.create({ range: hintRange, content: label, style: InlineCompletionHintStyle.Code });
-		return InlineSuggestionItem.create(suggestItem.withRename(command, hint), textModel);
+		const renameAction: IInlineSuggestDataActionRename = {
+			kind: 'rename',
+			textReplacement: edit,
+			stringEdit: suggestItem.action.stringEdit,
+			command,
+			uri: textModel.uri
+		};
+		return InlineSuggestionItem.create(suggestItem.withRename(renameAction), textModel);
 	}
 }

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditWithChanges.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditWithChanges.ts
@@ -16,7 +16,7 @@ export class InlineEditWithChanges {
 	public get lineEdit(): LineReplacement {
 		if (this.action?.kind === 'jumpTo') {
 			return new LineReplacement(LineRange.ofLength(this.action.position.lineNumber, 0), []);
-		} else if (this.action?.kind === 'edit') {
+		} else if (this.action?.kind === 'edit' || this.action?.kind === 'rename') {
 			return LineReplacement.fromSingleTextEdit(this.edit!.toReplacement(this.originalText), this.originalText);
 		}
 

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsView.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsView.ts
@@ -109,11 +109,11 @@ export class InlineEditsView extends Disposable {
 
 		this._inlineCollapsedView = this._register(this._instantiationService.createInstance(InlineEditsCollapsedView,
 			this._editor,
-			this._model.map((m, reader) => this._uiState.read(reader)?.state?.kind === 'collapsed' ? m?.inlineEdit : undefined)
+			this._model.map((m, reader) => this._uiState.read(reader)?.state?.kind === InlineCompletionViewKind.Collapsed ? m?.inlineEdit : undefined)
 		));
 		this._customView = this._register(this._instantiationService.createInstance(InlineEditsCustomView,
 			this._editor,
-			this._model.map((m, reader) => this._uiState.read(reader)?.state?.kind === 'custom' ? m?.displayLocation : undefined),
+			this._model.map((m, reader) => this._uiState.read(reader)?.state?.kind === InlineCompletionViewKind.Custom ? m?.displayLocation : undefined),
 			this._tabAction,
 		));
 
@@ -164,10 +164,10 @@ export class InlineEditsView extends Disposable {
 			equalsFn: itemsEquals(itemEquals())
 		}, reader => {
 			const s = this._uiState.read(reader);
-			return s?.state?.kind === 'wordReplacements' ? s.state.replacements : [];
+			return s?.state?.kind === InlineCompletionViewKind.WordReplacements ? s.state.replacements : [];
 		});
 		this._wordReplacementViews = mapObservableArrayCached(this, wordReplacements, (e, store) => {
-			return store.add(this._instantiationService.createInstance(InlineEditsWordReplacementView, this._editorObs, e, this._tabAction));
+			return store.add(this._instantiationService.createInstance(InlineEditsWordReplacementView, this._editorObs, e, this._model.get()?.inlineEdit.inlineCompletion.action?.kind === 'rename', this._tabAction));
 		});
 		this._lineReplacementView = this._register(this._instantiationService.createInstance(InlineEditsLineReplacementView,
 			this._editorObs,
@@ -424,6 +424,10 @@ export class InlineEditsView extends Disposable {
 
 		if (canUseCache && !reconsiderViewEditorWidthChange) {
 			return this._previousView!.view;
+		}
+
+		if (model.inlineEdit.inlineCompletion.action?.kind === 'rename') {
+			return InlineCompletionViewKind.WordReplacements;
 		}
 
 		const uri = model.inlineEdit.inlineCompletion.action?.kind === 'edit' ? model.inlineEdit.inlineCompletion.action.uri : undefined;

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViewProducer.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViewProducer.ts
@@ -35,7 +35,7 @@ export class InlineEditsViewAndDiffProducer extends Disposable { // TODO: This c
 
 		let diffEdits: TextEdit | undefined;
 
-		if (action?.kind === 'edit') {
+		if (action?.kind === 'edit' || action?.kind === 'rename') {
 			const editOffset = action.stringEdit;
 
 			const edits = editOffset.replacements.map(e => {

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/inlineEditsWordReplacementView.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/inlineEditsWordReplacementView.ts
@@ -3,12 +3,14 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { getWindow, n, ObserverNodeWithElement } from '../../../../../../../base/browser/dom.js';
+import { getWindow, ModifierKeyEmitter, n, ObserverNodeWithElement } from '../../../../../../../base/browser/dom.js';
 import { IMouseEvent, StandardMouseEvent } from '../../../../../../../base/browser/mouseEvent.js';
+import { renderIcon } from '../../../../../../../base/browser/ui/iconLabel/iconLabels.js';
+import { Codicon } from '../../../../../../../base/common/codicons.js';
 import { Emitter } from '../../../../../../../base/common/event.js';
 import { Disposable } from '../../../../../../../base/common/lifecycle.js';
-import { constObservable, derived, IObservable, observableValue } from '../../../../../../../base/common/observable.js';
-import { editorBackground, editorHoverForeground } from '../../../../../../../platform/theme/common/colorRegistry.js';
+import { constObservable, derived, IObservable, observableFromEvent, observableValue } from '../../../../../../../base/common/observable.js';
+import { editorBackground, editorHoverBorder, editorHoverForeground } from '../../../../../../../platform/theme/common/colorRegistry.js';
 import { asCssVariable } from '../../../../../../../platform/theme/common/colorUtils.js';
 import { ObservableCodeEditor } from '../../../../../../browser/observableCodeEditor.js';
 import { LineSource, renderLines, RenderOptions } from '../../../../../../browser/widget/diffEditor/components/diffEditorViewZones/renderLines.js';
@@ -48,6 +50,7 @@ export class InlineEditsWordReplacementView extends Disposable implements IInlin
 		private readonly _editor: ObservableCodeEditor,
 		/** Must be single-line in both sides */
 		private readonly _edit: TextReplacement,
+		private readonly _rename: boolean,
 		protected readonly _tabAction: IObservable<InlineEditTabAction>,
 		@ILanguageService private readonly _languageService: ILanguageService,
 	) {
@@ -76,6 +79,7 @@ export class InlineEditsWordReplacementView extends Disposable implements IInlin
 			this._line.style.width = `${res.minWidthInPx}px`;
 		});
 		const modifiedLineHeight = this._editor.observeLineHeightForPosition(this._edit.range.getStartPosition());
+		const altPressed = observableFromEvent(this, ModifierKeyEmitter.getInstance().event, keyStatus => keyStatus?.altKey ?? ModifierKeyEmitter.getInstance().keyStatus.altKey);
 		this._layout = derived(this, reader => {
 			this._renderTextEffect.read(reader);
 			const widgetStart = this._start.read(reader);
@@ -94,15 +98,26 @@ export class InlineEditsWordReplacementView extends Disposable implements IInlin
 			const modifiedTopOffset = 4;
 			const modifiedOffset = new Point(modifiedLeftOffset, modifiedTopOffset);
 
-			const originalLine = Rect.fromPoints(widgetStart, widgetEnd).withHeight(lineHeight).translateX(-scrollLeft);
-			const modifiedLine = Rect.fromPointSize(originalLine.getLeftBottom().add(modifiedOffset), new Point(this._edit.text.length * w, originalLine.height));
+			let label = undefined;
+			if (this._rename) { // TODO: make this customizable and not rename specific
+				if (altPressed.read(reader)) {
+					label = { content: 'Edit', icon: Codicon.edit };
+				} else {
+					label = { content: 'Rename', icon: Codicon.replaceAll };
+				}
+			}
 
+			const originalLine = Rect.fromPoints(widgetStart, widgetEnd).withHeight(lineHeight).translateX(-scrollLeft);
+			const codeLine = Rect.fromPointSize(originalLine.getLeftBottom().add(modifiedOffset), new Point(this._edit.text.length * w, originalLine.height));
+			const modifiedLine = codeLine.withWidth(codeLine.width + (label ? label.content.length * w + 8 + 4 + 12 : 0));
 			const lowerBackground = modifiedLine.withLeft(originalLine.left);
 
 			// debugView(debugLogRects({ lowerBackground }, this._editor.editor.getContainerDomNode()), reader);
 
 			return {
+				label,
 				originalLine,
+				codeLine,
 				modifiedLine,
 				lowerBackground,
 				lineHeight,
@@ -157,23 +172,56 @@ export class InlineEditsWordReplacementView extends Disposable implements IInlin
 							style: {
 								position: 'absolute',
 								...rectToProps(reader => layout.read(reader).modifiedLine.withMargin(BORDER_WIDTH, 2 * BORDER_WIDTH)),
-								fontFamily: this._editor.getOption(EditorOption.fontFamily),
-								fontSize: this._editor.getOption(EditorOption.fontSize),
-								fontWeight: this._editor.getOption(EditorOption.fontWeight),
-
+								width: undefined,
 								pointerEvents: 'none',
 								boxSizing: 'border-box',
 								borderRadius: '4px',
-								border: `${BORDER_WIDTH}px solid ${modifiedBorderColor}`,
 
-								background: asCssVariable(modifiedChangedTextOverlayColor),
+								background: asCssVariable(editorBackground),
 								display: 'flex',
-								justifyContent: 'center',
-								alignItems: 'center',
+								justifyContent: 'left',
 
 								outline: `2px solid ${asCssVariable(editorBackground)}`,
 							}
-						}, [this._line]),
+						}, [
+							n.div({
+								style: {
+									fontFamily: this._editor.getOption(EditorOption.fontFamily),
+									fontSize: this._editor.getOption(EditorOption.fontSize),
+									fontWeight: this._editor.getOption(EditorOption.fontWeight),
+									width: rectToProps(reader => layout.read(reader).codeLine.withMargin(BORDER_WIDTH, 2 * BORDER_WIDTH)).width,
+									borderRadius: layout.map(l => l.label ? '4px 0 0 4px' : '4px'),
+									border: `${BORDER_WIDTH}px solid ${modifiedBorderColor}`,
+									boxSizing: 'border-box',
+									padding: `${BORDER_WIDTH}px`,
+
+									background: asCssVariable(modifiedChangedTextOverlayColor),
+									display: 'flex',
+									justifyContent: 'left',
+									alignItems: 'center',
+								}
+							}, [this._line]),
+							derived(this, reader => {
+								const label = layout.read(reader).label;
+								if (!label) {
+									return undefined;
+								}
+								return n.div({
+									style: {
+										fontFamily: this._editor.getOption(EditorOption.fontFamily),
+										fontSize: this._editor.getOption(EditorOption.fontSize),
+										fontWeight: this._editor.getOption(EditorOption.fontWeight),
+										borderRadius: '0 4px 4px 0',
+										border: `${BORDER_WIDTH}px solid ${asCssVariable(editorHoverBorder)}`,
+										display: 'flex',
+										justifyContent: 'center',
+										alignItems: 'center',
+										padding: '0 4px',
+									},
+									class: 'inline-edit-rename-label',
+								}, [renderIcon(label.icon), label.content]);
+							})
+						]),
 						n.div({
 							style: {
 								position: 'absolute',

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/view.css
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/view.css
@@ -243,7 +243,7 @@
 	}
 }
 
-.go-to-label::before {
+.inline-edits-long-distance-hint-widget .go-to-label::before {
 	content: '';
 	position: absolute;
 	left: -12px;
@@ -251,4 +251,9 @@
 	width: 12px;
 	height: 100%;
 	background: linear-gradient(to left, var(--vscode-editorWidget-background) 0, transparent 12px);
+}
+
+.inline-edit-rename-label .codicon {
+	font-size: 12px !important;
+	padding-right: 4px;
 }


### PR DESCRIPTION
```Copilot Generated Description:``` Enhance the handling of rename actions in inline edits, allowing for better integration and processing of rename commands within the editor.

