### PR TITLE
Add Auto-Reveal Paired File in Explorer feature

### DIFF
--- a/src/vs/workbench/browser/workbench.contribution.ts
+++ b/src/vs/workbench/browser/workbench.contribution.ts
@@ -35,6 +35,33 @@ const registry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Con
 				included: isNative,
 				restricted: true
 			},
+			'workbench.autoRevealPairedFile.enabled': {
+				'type': 'boolean',
+				'default': false,
+				'scope': ConfigurationScope.WINDOW,
+				'markdownDescription': localize('workbench.autoRevealPairedFile.enabled', "Controls whether the Explorer automatically reveals a configured paired file (for example a matching test file) when you open an editor. Configure patterns via {0}.", '`#workbench.autoRevealPairedFile.patterns#`')
+			},
+			'workbench.autoRevealPairedFile.patterns': {
+				'type': 'array',
+				'default': [],
+				'scope': ConfigurationScope.WINDOW,
+				'markdownDescription': localize('workbench.autoRevealPairedFile.patterns', "Defines how files map to their paired matches using regular expressions. Each item must include `source` and `test` patterns. Capture group references (for example `$1`) from the match are substituted into the paired path.\n\nExample:\n```json\n[\n  {\n    \"source\": \"src/(.*)\\\\.ts\",\n    \"test\": \"tests/$1.test.ts\"\n  }\n]\n```"),
+				'items': {
+					'type': 'object',
+					'required': ['source', 'test'],
+					'properties': {
+						'source': {
+							'type': 'string',
+							'markdownDescription': localize('workbench.autoRevealPairedFile.patterns.source', "Regular expression that matches the active file path to identify the source side of a pair. Use capture groups to reference path segments.")
+						},
+						'test': {
+							'type': 'string',
+							'markdownDescription': localize('workbench.autoRevealPairedFile.patterns.test', "Replacement pattern that produces the paired file path. Supports capture group placeholders like `$1` from the source match.")
+						}
+					},
+					'additionalProperties': false
+				}
+			},
 			'workbench.editor.titleScrollbarSizing': {
 				type: 'string',
 				enum: ['default', 'large'],

--- a/src/vs/workbench/contrib/files/browser/autoRevealPairedFile.ts
+++ b/src/vs/workbench/contrib/files/browser/autoRevealPairedFile.ts
@@ -1,0 +1,300 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Disposable } from '../../../../base/common/lifecycle.js';
+import { EditorResourceAccessor, SideBySideEditor } from '../../../common/editor.js';
+import { IWorkbenchContribution } from '../../../common/contributions.js';
+import { IEditorService } from '../../../services/editor/common/editorService.js';
+import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
+import { IWorkspaceContextService, WorkbenchState } from '../../../../platform/workspace/common/workspace.js';
+import { IAutoRevealPairedFileConfiguration } from '../common/files.js';
+import { IFileService } from '../../../../platform/files/common/files.js';
+import { IExplorerService } from './files.js';
+import { URI } from '../../../../base/common/uri.js';
+import * as resources from '../../../../base/common/resources.js';
+
+interface ICompiledAutoRevealPattern {
+	sourceRegex: RegExp;
+	testRegex: RegExp;
+	sourceTemplate: string;
+	testTemplate: string;
+	isValid: boolean;
+}
+
+export class AutoRevealPairedFileContribution extends Disposable implements IWorkbenchContribution {
+
+	static readonly ID = 'workbench.contrib.autoRevealPairedFile';
+
+	private compiledPatterns: ICompiledAutoRevealPattern[] = [];
+
+	constructor(
+		@IEditorService private readonly editorService: IEditorService,
+		@IConfigurationService private readonly configurationService: IConfigurationService,
+		@IWorkspaceContextService private readonly workspaceContextService: IWorkspaceContextService,
+		@IFileService private readonly fileService: IFileService,
+		@IExplorerService private readonly explorerService: IExplorerService,
+	) {
+		super();
+
+		this.compilePatterns();
+
+		this._register(this.configurationService.onDidChangeConfiguration(e => {
+			if (e.affectsConfiguration('workbench.autoRevealPairedFile')) {
+				this.compilePatterns();
+			}
+		}));
+
+		this._register(this.editorService.onDidActiveEditorChange(() => this.onActiveEditorChange()));
+	}
+
+	private compilePatterns(): void {
+		this.compiledPatterns = [];
+
+		const config = this.configurationService.getValue<IAutoRevealPairedFileConfiguration>('workbench.autoRevealPairedFile');
+		if (!config?.patterns?.length) {
+			return;
+		}
+
+		for (const pattern of config.patterns) {
+			if (!pattern?.source || !pattern?.test) {
+				continue;
+			}
+
+			const sourceArtifacts = this.parsePattern(pattern.source);
+			const testArtifacts = this.parsePattern(pattern.test);
+
+			if (sourceArtifacts && testArtifacts) {
+				this.compiledPatterns.push({
+					sourceRegex: sourceArtifacts.regex,
+					testRegex: testArtifacts.regex,
+					sourceTemplate: sourceArtifacts.template,
+					testTemplate: testArtifacts.template,
+					isValid: true
+				});
+			} else {
+				this.compiledPatterns.push({
+					sourceRegex: /$^/,
+					testRegex: /$^/,
+					sourceTemplate: pattern.source,
+					testTemplate: pattern.test,
+					isValid: false
+				});
+			}
+		}
+	}
+
+	private parsePattern(value: string): { regex: RegExp; template: string } | undefined {
+		const hasCapturePlaceholders = /\$[0-9]+/.test(value);
+
+		if (hasCapturePlaceholders) {
+			const regex = this.buildRegexFromTemplate(value);
+			if (!regex) {
+				return undefined;
+			}
+
+			return { regex, template: value };
+		}
+
+		const regex = this.safeCreateRegex(value);
+		if (!regex) {
+			return undefined;
+		}
+
+		const template = this.createTemplateFromRegexSource(value);
+		if (!template) {
+			return undefined;
+		}
+
+		return { regex, template };
+	}
+
+	private safeCreateRegex(value: string): RegExp | undefined {
+		try {
+			return new RegExp(value);
+		} catch {
+			return undefined;
+		}
+	}
+
+	private buildRegexFromTemplate(template: string): RegExp | undefined {
+		const literalDollarPlaceholder = '\u0000';
+		let patternSource = template.replace(/\$\$/g, literalDollarPlaceholder);
+
+		patternSource = patternSource.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+		patternSource = patternSource.replace(new RegExp(literalDollarPlaceholder, 'g'), '\\$');
+		patternSource = patternSource.replace(/\\\$([0-9]+)/g, '(.+?)');
+
+		try {
+			return new RegExp(`^${patternSource}$`);
+		} catch {
+			return undefined;
+		}
+	}
+
+	private createTemplateFromRegexSource(source: string): string | undefined {
+		let result = '';
+		let groupIndex = 0;
+
+		for (let i = 0; i < source.length;) {
+			const char = source[i];
+
+			if (char === '\\') {
+				if (i + 1 < source.length) {
+					result += source[i + 1];
+					i += 2;
+				} else {
+					i++;
+				}
+				continue;
+			}
+
+			if (char === '(') {
+				if (source.startsWith('(?:', i) ||
+					source.startsWith('(?=', i) ||
+					source.startsWith('(?!', i) ||
+					source.startsWith('(?<=', i) ||
+					source.startsWith('(?<!', i)) {
+					return undefined; // Unsupported constructs for template conversion.
+				}
+
+				groupIndex++;
+				const closingIndex = this.findClosingParenIndex(source, i + 1);
+				if (closingIndex === -1) {
+					return undefined;
+				}
+
+				result += `$${groupIndex}`;
+				i = closingIndex + 1;
+				continue;
+			}
+
+			if (char === '^' || char === '$') {
+				i++;
+				continue;
+			}
+
+			result += char;
+			i++;
+		}
+
+		return result;
+	}
+
+	private findClosingParenIndex(value: string, startIndex: number): number {
+		let depth = 1;
+
+		for (let i = startIndex; i < value.length; i++) {
+			const char = value[i];
+
+			if (char === '\\') {
+				i++;
+				continue;
+			}
+
+			if (char === '(') {
+				depth++;
+				continue;
+			}
+
+			if (char === ')') {
+				depth--;
+				if (depth === 0) {
+					return i;
+				}
+			}
+		}
+
+		return -1;
+	}
+
+	private computePairedPath(relativePath: string): string | undefined {
+		for (const pattern of this.compiledPatterns) {
+			if (!pattern.isValid) {
+				continue;
+			}
+
+			pattern.sourceRegex.lastIndex = 0;
+			const sourceMatch = pattern.sourceRegex.exec(relativePath);
+			if (sourceMatch) {
+				return this.substituteCaptures(pattern.testTemplate, sourceMatch);
+			}
+
+			pattern.testRegex.lastIndex = 0;
+			const testMatch = pattern.testRegex.exec(relativePath);
+			if (testMatch) {
+				return this.substituteCaptures(pattern.sourceTemplate, testMatch);
+			}
+		}
+
+		return undefined;
+	}
+
+	private substituteCaptures(template: string, matches: RegExpExecArray): string {
+		return template.replace(/\$([0-9]+)/g, (_placeholder, index) => matches[Number(index)] ?? '');
+	}
+
+	private computePairedUri(resource: URI): URI | undefined {
+		const workspaceFolder = this.workspaceContextService.getWorkspaceFolder(resource);
+		if (!workspaceFolder) {
+			return undefined;
+		}
+
+		const relativePath = resources.relativePath(workspaceFolder.uri, resource);
+		if (!relativePath) {
+			return undefined;
+		}
+
+		const pairedPath = this.computePairedPath(relativePath);
+		if (!pairedPath) {
+			return undefined;
+		}
+
+		return resources.joinPath(workspaceFolder.uri, pairedPath);
+	}
+
+	private onActiveEditorChange(): void {
+		const config = this.configurationService.getValue<IAutoRevealPairedFileConfiguration>('workbench.autoRevealPairedFile');
+		if (!config?.enabled) {
+			return;
+		}
+
+		if (!this.compiledPatterns.length) {
+			return;
+		}
+
+		if (this.workspaceContextService.getWorkbenchState() === WorkbenchState.EMPTY) {
+			return;
+		}
+
+		const activeEditor = this.editorService.activeEditor;
+		if (!activeEditor) {
+			return;
+		}
+
+		const resource = EditorResourceAccessor.getOriginalUri(activeEditor, { supportSideBySide: SideBySideEditor.PRIMARY });
+		if (!resource) {
+			return;
+		}
+
+		const pairedResource = this.computePairedUri(resource);
+		if (!pairedResource) {
+			return;
+		}
+
+		// Resolve existence asynchronously before revealing the paired file.
+		void this.checkAndRevealPairedFile(pairedResource);
+	}
+
+	private async checkAndRevealPairedFile(pairedResource: URI): Promise<void> {
+		const exists = await this.fileService.exists(pairedResource);
+		if (!exists) {
+			return;
+		}
+
+		// Use the explorer service to reveal the paired file without stealing focus.
+		await this.explorerService.select(pairedResource, 'force');
+	}
+}
+

--- a/src/vs/workbench/contrib/files/browser/files.contribution.ts
+++ b/src/vs/workbench/contrib/files/browser/files.contribution.ts
@@ -35,6 +35,7 @@ import { FileEditorInputSerializer, FileEditorWorkingCopyEditorHandler } from '.
 import { ModesRegistry } from '../../../../editor/common/languages/modesRegistry.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { TextFileEditor } from './editors/textFileEditor.js';
+import { AutoRevealPairedFileContribution } from './autoRevealPairedFile.js';
 
 class FileUriLabelContribution implements IWorkbenchContribution {
 
@@ -98,6 +99,7 @@ Registry.as<IEditorFactoryRegistry>(EditorExtensions.EditorFactory).registerFile
 // Register Editor Input Serializer & Handler
 Registry.as<IEditorFactoryRegistry>(EditorExtensions.EditorFactory).registerEditorSerializer(FILE_EDITOR_INPUT_ID, FileEditorInputSerializer);
 registerWorkbenchContribution2(FileEditorWorkingCopyEditorHandler.ID, FileEditorWorkingCopyEditorHandler, WorkbenchPhase.BlockRestore);
+registerWorkbenchContribution2(AutoRevealPairedFileContribution.ID, AutoRevealPairedFileContribution, WorkbenchPhase.AfterRestored);
 
 // Register Explorer views
 registerWorkbenchContribution2(ExplorerViewletViewsContribution.ID, ExplorerViewletViewsContribution, WorkbenchPhase.BlockStartup);

--- a/src/vs/workbench/contrib/files/common/files.ts
+++ b/src/vs/workbench/contrib/files/common/files.ts
@@ -85,6 +85,19 @@ export const BINARY_FILE_EDITOR_ID = 'workbench.editors.files.binaryFileEditor';
  */
 export const BINARY_TEXT_FILE_MODE = 'code-text-binary';
 
+/**
+ * Configuration entry describing how to map between paired files.
+ */
+export interface IAutoRevealPairedFilePattern {
+	source: string;
+	test: string;
+}
+
+export interface IAutoRevealPairedFileConfiguration {
+	enabled: boolean;
+	patterns: IAutoRevealPairedFilePattern[];
+}
+
 export interface IFilesConfiguration extends PlatformIFilesConfiguration, IWorkbenchEditorConfiguration {
 	explorer: {
 		openEditors: {

--- a/src/vs/workbench/contrib/files/test/browser/autoRevealPairedFile.test.ts
+++ b/src/vs/workbench/contrib/files/test/browser/autoRevealPairedFile.test.ts
@@ -1,0 +1,646 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { DisposableStore } from '../../../../../base/common/lifecycle.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
+import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
+import { IFileService } from '../../../../../platform/files/common/files.js';
+import { IWorkspaceContextService, WorkbenchState } from '../../../../../platform/workspace/common/workspace.js';
+import { TestWorkspace } from '../../../../../platform/workspace/test/common/testWorkspace.js';
+import { workbenchInstantiationService } from '../../../../test/browser/workbenchTestServices.js';
+import { TestContextService, TestFileService } from '../../../../test/common/workbenchTestServices.js';
+import { AutoRevealPairedFileContribution } from '../../browser/autoRevealPairedFile.js';
+import { IExplorerService } from '../../browser/files.js';
+import { IEditorService } from '../../../../services/editor/common/editorService.js';
+import { TestInstantiationService } from '../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
+import { ExplorerItem } from '../../common/explorerModel.js';
+import { ISortOrderConfiguration } from '../../common/files.js';
+import { IEditableData } from '../../../../common/views.js';
+import { ResourceFileEdit } from '../../../../../editor/browser/services/bulkEditService.js';
+import { ProgressLocation } from '../../../../../platform/progress/common/progress.js';
+
+/**
+ * Mock ExplorerService to track select() calls for testing.
+ */
+class MockExplorerService implements IExplorerService {
+	readonly _serviceBrand: undefined;
+
+	public selectCalls: { resource: URI; reveal?: boolean | string }[] = [];
+	public roots: ExplorerItem[] = [];
+	public sortOrderConfiguration: ISortOrderConfiguration = {
+		sortOrder: 'default' as any,
+		lexicographicOptions: 'default' as any,
+		reverse: false
+	};
+
+	async select(resource: URI, reveal?: boolean | string): Promise<void> {
+		this.selectCalls.push({ resource, reveal });
+	}
+
+	getContext(_respectMultiSelection: boolean, _ignoreNestedChildren?: boolean): ExplorerItem[] {
+		return [];
+	}
+
+	hasViewFocus(): boolean {
+		return false;
+	}
+
+	async setEditable(_stat: ExplorerItem, _data: IEditableData | null): Promise<void> {
+		// noop
+	}
+
+	getEditable(): { stat: ExplorerItem; data: IEditableData } | undefined {
+		return undefined;
+	}
+
+	getEditableData(_stat: ExplorerItem): IEditableData | undefined {
+		return undefined;
+	}
+
+	isEditable(_stat: ExplorerItem | undefined): boolean {
+		return false;
+	}
+
+	findClosest(_resource: URI): ExplorerItem | null {
+		return null;
+	}
+
+	findClosestRoot(_resource: URI): ExplorerItem | null {
+		return null;
+	}
+
+	async refresh(): Promise<void> {
+		// noop
+	}
+
+	async setToCopy(_stats: ExplorerItem[], _cut: boolean): Promise<void> {
+		// noop
+	}
+
+	isCut(_stat: ExplorerItem): boolean {
+		return false;
+	}
+
+	async applyBulkEdit(_edit: ResourceFileEdit[], _options: { undoLabel: string; progressLabel: string; confirmBeforeUndo?: boolean; progressLocation?: ProgressLocation.Explorer | ProgressLocation.Window }): Promise<void> {
+		// noop
+	}
+
+	registerView(): void {
+		// noop
+	}
+
+	reset(): void {
+		this.selectCalls = [];
+	}
+}
+
+/**
+ * Mock FileService that can be configured to report file existence.
+ */
+class MockFileService extends TestFileService {
+	private existingFiles = new Set<string>();
+
+	setFileExists(uri: URI, exists: boolean): void {
+		if (exists) {
+			this.existingFiles.add(uri.toString());
+		} else {
+			this.existingFiles.delete(uri.toString());
+		}
+	}
+
+	override async exists(resource: URI): Promise<boolean> {
+		return this.existingFiles.has(resource.toString());
+	}
+
+	reset(): void {
+		this.existingFiles.clear();
+	}
+}
+
+suite('Files - AutoRevealPairedFile', () => {
+
+	const disposables = new DisposableStore();
+	let instantiationService: TestInstantiationService;
+	let configurationService: TestConfigurationService;
+	let mockExplorerService: MockExplorerService;
+	let mockFileService: MockFileService;
+	let mockContextService: TestContextService;
+
+	setup(() => {
+		instantiationService = workbenchInstantiationService(undefined, disposables);
+
+		configurationService = new TestConfigurationService();
+		instantiationService.stub(IConfigurationService, configurationService);
+
+		mockExplorerService = new MockExplorerService();
+		instantiationService.stub(IExplorerService, mockExplorerService);
+
+		mockFileService = disposables.add(new MockFileService());
+		instantiationService.stub(IFileService, mockFileService);
+
+		mockContextService = new TestContextService(TestWorkspace);
+		instantiationService.stub(IWorkspaceContextService, mockContextService);
+	});
+
+	teardown(() => {
+		disposables.clear();
+	});
+
+	// ============================================
+	// UNIT TESTS - Pattern Compilation & Matching
+	// ============================================
+
+	suite('Pattern Compilation', () => {
+
+		test('compiles valid source regex pattern', () => {
+			configurationService.setUserConfiguration('workbench', {
+				autoRevealPairedFile: {
+					enabled: true,
+					patterns: [
+						{ source: 'src/(.*)\\.ts', test: 'tests/$1.test.ts' }
+					]
+				}
+			});
+
+			const contribution = disposables.add(instantiationService.createInstance(AutoRevealPairedFileContribution));
+
+			// Access private compiledPatterns for testing
+			const compiledPatterns = (contribution as any).compiledPatterns;
+			assert.strictEqual(compiledPatterns.length, 1);
+			assert.strictEqual(compiledPatterns[0].isValid, true);
+
+			// Test that source regex matches expected path
+			const sourceRegex = compiledPatterns[0].sourceRegex;
+			const match = sourceRegex.exec('src/utils/math.ts');
+			assert.ok(match, 'Source regex should match src/utils/math.ts');
+			assert.strictEqual(match[1], 'utils/math');
+		});
+
+		test('compiles valid template-style pattern with $1 placeholder', () => {
+			configurationService.setUserConfiguration('workbench', {
+				autoRevealPairedFile: {
+					enabled: true,
+					patterns: [
+						{ source: 'src/$1.ts', test: 'tests/$1.test.ts' }
+					]
+				}
+			});
+
+			const contribution = disposables.add(instantiationService.createInstance(AutoRevealPairedFileContribution));
+
+			const compiledPatterns = (contribution as any).compiledPatterns;
+			assert.strictEqual(compiledPatterns.length, 1);
+			assert.strictEqual(compiledPatterns[0].isValid, true);
+		});
+
+		test('handles invalid regex gracefully without crashing', () => {
+			configurationService.setUserConfiguration('workbench', {
+				autoRevealPairedFile: {
+					enabled: true,
+					patterns: [
+						{ source: '[invalid(regex', test: 'tests/$1.test.ts' }
+					]
+				}
+			});
+
+			// Should not throw
+			const contribution = disposables.add(instantiationService.createInstance(AutoRevealPairedFileContribution));
+
+			const compiledPatterns = (contribution as any).compiledPatterns;
+			assert.strictEqual(compiledPatterns.length, 1);
+			assert.strictEqual(compiledPatterns[0].isValid, false);
+		});
+
+		test('skips patterns with missing source or test', () => {
+			configurationService.setUserConfiguration('workbench', {
+				autoRevealPairedFile: {
+					enabled: true,
+					patterns: [
+						{ source: 'src/(.*).ts' } as any, // missing test
+						{ test: 'tests/$1.test.ts' } as any, // missing source
+						{ source: '', test: 'tests/$1.test.ts' }, // empty source
+						{ source: 'src/(.*).ts', test: '' } // empty test
+					]
+				}
+			});
+
+			const contribution = disposables.add(instantiationService.createInstance(AutoRevealPairedFileContribution));
+
+			const compiledPatterns = (contribution as any).compiledPatterns;
+			// All patterns should be skipped due to missing/empty source or test
+			assert.strictEqual(compiledPatterns.length, 0);
+		});
+
+		test('recompiles patterns when configuration changes', () => {
+			configurationService.setUserConfiguration('workbench', {
+				autoRevealPairedFile: {
+					enabled: true,
+					patterns: [
+						{ source: 'src/(.*)\\.ts', test: 'tests/$1.test.ts' }
+					]
+				}
+			});
+
+			const contribution = disposables.add(instantiationService.createInstance(AutoRevealPairedFileContribution));
+
+			let compiledPatterns = (contribution as any).compiledPatterns;
+			assert.strictEqual(compiledPatterns.length, 1);
+
+			// Change configuration
+			configurationService.setUserConfiguration('workbench', {
+				autoRevealPairedFile: {
+					enabled: true,
+					patterns: [
+						{ source: 'lib/(.*)\\.js', test: 'spec/$1.spec.js' },
+						{ source: 'app/(.*)\\.tsx', test: '__tests__/$1.test.tsx' }
+					]
+				}
+			});
+
+			// Trigger configuration change
+			configurationService.onDidChangeConfigurationEmitter.fire({
+				affectsConfiguration: (key: string) => key === 'workbench.autoRevealPairedFile',
+				source: 1 as any,
+				affectedKeys: new Set(['workbench.autoRevealPairedFile']),
+				change: {} as any
+			});
+
+			compiledPatterns = (contribution as any).compiledPatterns;
+			assert.strictEqual(compiledPatterns.length, 2);
+		});
+
+	});
+
+	// ============================================
+	// UNIT TESTS - Capture Group Substitution
+	// ============================================
+
+	suite('Capture Group Substitution', () => {
+
+		test('substitutes single capture group $1', () => {
+			configurationService.setUserConfiguration('workbench', {
+				autoRevealPairedFile: {
+					enabled: true,
+					patterns: [
+						{ source: 'src/(.*)\\.ts', test: 'tests/$1.test.ts' }
+					]
+				}
+			});
+
+			const contribution = disposables.add(instantiationService.createInstance(AutoRevealPairedFileContribution));
+
+			const computePairedPath = (contribution as any).computePairedPath.bind(contribution);
+			const result = computePairedPath('src/utils/math.ts');
+
+			assert.strictEqual(result, 'tests/utils/math.test.ts');
+		});
+
+		test('substitutes multiple capture groups $1, $2', () => {
+			configurationService.setUserConfiguration('workbench', {
+				autoRevealPairedFile: {
+					enabled: true,
+					patterns: [
+						{ source: 'src/([^/]+)/(.*)\\.tsx', test: 'tests/$1/$2.test.tsx' }
+					]
+				}
+			});
+
+			const contribution = disposables.add(instantiationService.createInstance(AutoRevealPairedFileContribution));
+
+			const computePairedPath = (contribution as any).computePairedPath.bind(contribution);
+			const result = computePairedPath('src/components/Button.tsx');
+
+			assert.strictEqual(result, 'tests/components/Button.test.tsx');
+		});
+
+		test('handles missing capture group gracefully', () => {
+			configurationService.setUserConfiguration('workbench', {
+				autoRevealPairedFile: {
+					enabled: true,
+					patterns: [
+						{ source: 'src/(.*)\\.ts', test: 'tests/$1/$2.test.ts' } // $2 doesn't exist
+					]
+				}
+			});
+
+			const contribution = disposables.add(instantiationService.createInstance(AutoRevealPairedFileContribution));
+
+			const computePairedPath = (contribution as any).computePairedPath.bind(contribution);
+			const result = computePairedPath('src/utils/math.ts');
+
+			// $2 should be replaced with empty string
+			assert.strictEqual(result, 'tests/utils/math/.test.ts');
+		});
+
+	});
+
+	// ============================================
+	// UNIT TESTS - Bidirectional Mapping
+	// ============================================
+
+	suite('Bidirectional Mapping', () => {
+
+		test('source file maps to test file', () => {
+			configurationService.setUserConfiguration('workbench', {
+				autoRevealPairedFile: {
+					enabled: true,
+					patterns: [
+						{ source: 'src/$1.ts', test: 'tests/$1.test.ts' }
+					]
+				}
+			});
+
+			const contribution = disposables.add(instantiationService.createInstance(AutoRevealPairedFileContribution));
+
+			const computePairedPath = (contribution as any).computePairedPath.bind(contribution);
+			const result = computePairedPath('src/utils/math.ts');
+
+			assert.strictEqual(result, 'tests/utils/math.test.ts');
+		});
+
+		test('test file maps to source file', () => {
+			configurationService.setUserConfiguration('workbench', {
+				autoRevealPairedFile: {
+					enabled: true,
+					patterns: [
+						{ source: 'src/$1.ts', test: 'tests/$1.test.ts' }
+					]
+				}
+			});
+
+			const contribution = disposables.add(instantiationService.createInstance(AutoRevealPairedFileContribution));
+
+			const computePairedPath = (contribution as any).computePairedPath.bind(contribution);
+			const result = computePairedPath('tests/utils/math.test.ts');
+
+			assert.strictEqual(result, 'src/utils/math.ts');
+		});
+
+		test('first matching pattern wins', () => {
+			configurationService.setUserConfiguration('workbench', {
+				autoRevealPairedFile: {
+					enabled: true,
+					patterns: [
+						{ source: 'src/$1.ts', test: 'tests/$1.test.ts' },
+						{ source: 'src/$1.ts', test: 'spec/$1.spec.ts' } // Should not be used
+					]
+				}
+			});
+
+			const contribution = disposables.add(instantiationService.createInstance(AutoRevealPairedFileContribution));
+
+			const computePairedPath = (contribution as any).computePairedPath.bind(contribution);
+			const result = computePairedPath('src/utils/math.ts');
+
+			// First pattern should win
+			assert.strictEqual(result, 'tests/utils/math.test.ts');
+		});
+
+	});
+
+	// ============================================
+	// UNIT TESTS - Path Handling
+	// ============================================
+
+	suite('Path Handling', () => {
+
+		test('handles POSIX-style paths', () => {
+			configurationService.setUserConfiguration('workbench', {
+				autoRevealPairedFile: {
+					enabled: true,
+					patterns: [
+						{ source: 'src/$1.ts', test: 'tests/$1.test.ts' }
+					]
+				}
+			});
+
+			const contribution = disposables.add(instantiationService.createInstance(AutoRevealPairedFileContribution));
+
+			const computePairedPath = (contribution as any).computePairedPath.bind(contribution);
+			const result = computePairedPath('src/utils/math.ts');
+
+			assert.strictEqual(result, 'tests/utils/math.test.ts');
+		});
+
+		test('handles deeply nested paths', () => {
+			configurationService.setUserConfiguration('workbench', {
+				autoRevealPairedFile: {
+					enabled: true,
+					patterns: [
+						{ source: 'src/$1.ts', test: 'tests/$1.test.ts' }
+					]
+				}
+			});
+
+			const contribution = disposables.add(instantiationService.createInstance(AutoRevealPairedFileContribution));
+
+			const computePairedPath = (contribution as any).computePairedPath.bind(contribution);
+			const result = computePairedPath('src/features/auth/utils/validators/email.ts');
+
+			assert.strictEqual(result, 'tests/features/auth/utils/validators/email.test.ts');
+		});
+
+	});
+
+	// ============================================
+	// UNIT TESTS - Feature Toggle & Edge Cases
+	// ============================================
+
+	suite('Feature Toggle', () => {
+
+		test('no action when feature is disabled', async () => {
+			configurationService.setUserConfiguration('workbench', {
+				autoRevealPairedFile: {
+					enabled: false,
+					patterns: [
+						{ source: 'src/$1.ts', test: 'tests/$1.test.ts' }
+					]
+				}
+			});
+
+			const contribution = disposables.add(instantiationService.createInstance(AutoRevealPairedFileContribution));
+
+			// Trigger onActiveEditorChange
+			(contribution as any).onActiveEditorChange();
+
+			assert.strictEqual(mockExplorerService.selectCalls.length, 0);
+		});
+
+		test('no action when patterns array is empty', async () => {
+			configurationService.setUserConfiguration('workbench', {
+				autoRevealPairedFile: {
+					enabled: true,
+					patterns: []
+				}
+			});
+
+			const contribution = disposables.add(instantiationService.createInstance(AutoRevealPairedFileContribution));
+
+			// Trigger onActiveEditorChange
+			(contribution as any).onActiveEditorChange();
+
+			assert.strictEqual(mockExplorerService.selectCalls.length, 0);
+		});
+
+		test('no action when workspace is empty', async () => {
+			// Create a context service that reports empty workspace
+			const emptyContextService = new TestContextService();
+			(emptyContextService as any).getWorkbenchState = () => WorkbenchState.EMPTY;
+			instantiationService.stub(IWorkspaceContextService, emptyContextService);
+
+			configurationService.setUserConfiguration('workbench', {
+				autoRevealPairedFile: {
+					enabled: true,
+					patterns: [
+						{ source: 'src/$1.ts', test: 'tests/$1.test.ts' }
+					]
+				}
+			});
+
+			const contribution = disposables.add(instantiationService.createInstance(AutoRevealPairedFileContribution));
+
+			// Trigger onActiveEditorChange
+			(contribution as any).onActiveEditorChange();
+
+			assert.strictEqual(mockExplorerService.selectCalls.length, 0);
+		});
+
+	});
+
+	suite('No Match Behavior', () => {
+
+		test('silent exit when file does not match any pattern', () => {
+			configurationService.setUserConfiguration('workbench', {
+				autoRevealPairedFile: {
+					enabled: true,
+					patterns: [
+						{ source: 'src/$1.ts', test: 'tests/$1.test.ts' }
+					]
+				}
+			});
+
+			const contribution = disposables.add(instantiationService.createInstance(AutoRevealPairedFileContribution));
+
+			const computePairedPath = (contribution as any).computePairedPath.bind(contribution);
+			const result = computePairedPath('README.md');
+
+			assert.strictEqual(result, undefined);
+		});
+
+		test('silent exit when paired file does not exist', async () => {
+			configurationService.setUserConfiguration('workbench', {
+				autoRevealPairedFile: {
+					enabled: true,
+					patterns: [
+						{ source: 'src/$1.ts', test: 'tests/$1.test.ts' }
+					]
+				}
+			});
+
+			// File does NOT exist
+			mockFileService.setFileExists(URI.file('/workspace/tests/utils/math.test.ts'), false);
+
+			const contribution = disposables.add(instantiationService.createInstance(AutoRevealPairedFileContribution));
+
+			// Call checkAndRevealPairedFile directly
+			const checkAndReveal = (contribution as any).checkAndRevealPairedFile.bind(contribution);
+			await checkAndReveal(URI.file('/workspace/tests/utils/math.test.ts'));
+
+			assert.strictEqual(mockExplorerService.selectCalls.length, 0);
+		});
+
+	});
+
+	// ============================================
+	// INTEGRATION TESTS - Full Workflow
+	// ============================================
+
+	suite('Integration - Explorer Reveal', () => {
+
+		test('reveal is called when paired file exists', async () => {
+			configurationService.setUserConfiguration('workbench', {
+				autoRevealPairedFile: {
+					enabled: true,
+					patterns: [
+						{ source: 'src/$1.ts', test: 'tests/$1.test.ts' }
+					]
+				}
+			});
+
+			const pairedUri = URI.file('/workspace/tests/utils/math.test.ts');
+			mockFileService.setFileExists(pairedUri, true);
+
+			const contribution = disposables.add(instantiationService.createInstance(AutoRevealPairedFileContribution));
+
+			// Call checkAndRevealPairedFile directly
+			const checkAndReveal = (contribution as any).checkAndRevealPairedFile.bind(contribution);
+			await checkAndReveal(pairedUri);
+
+			assert.strictEqual(mockExplorerService.selectCalls.length, 1);
+			assert.strictEqual(mockExplorerService.selectCalls[0].resource.toString(), pairedUri.toString());
+			assert.strictEqual(mockExplorerService.selectCalls[0].reveal, 'force');
+		});
+
+		test('reveal not called when paired file does not exist', async () => {
+			configurationService.setUserConfiguration('workbench', {
+				autoRevealPairedFile: {
+					enabled: true,
+					patterns: [
+						{ source: 'src/$1.ts', test: 'tests/$1.test.ts' }
+					]
+				}
+			});
+
+			const pairedUri = URI.file('/workspace/tests/utils/math.test.ts');
+			mockFileService.setFileExists(pairedUri, false);
+
+			const contribution = disposables.add(instantiationService.createInstance(AutoRevealPairedFileContribution));
+
+			// Call checkAndRevealPairedFile directly
+			const checkAndReveal = (contribution as any).checkAndRevealPairedFile.bind(contribution);
+			await checkAndReveal(pairedUri);
+
+			assert.strictEqual(mockExplorerService.selectCalls.length, 0);
+		});
+
+	});
+
+	// ============================================
+	// UNIT TESTS - computePairedUri
+	// ============================================
+
+	suite('computePairedUri', () => {
+
+		test('returns undefined when resource has no workspace folder', () => {
+			// Create a context service that returns null for getWorkspaceFolder
+			const noFolderContextService = new TestContextService();
+			(noFolderContextService as any).getWorkspaceFolder = () => null;
+			instantiationService.stub(IWorkspaceContextService, noFolderContextService);
+
+			configurationService.setUserConfiguration('workbench', {
+				autoRevealPairedFile: {
+					enabled: true,
+					patterns: [
+						{ source: 'src/$1.ts', test: 'tests/$1.test.ts' }
+					]
+				}
+			});
+
+			const contribution = disposables.add(instantiationService.createInstance(AutoRevealPairedFileContribution));
+
+			const computePairedUri = (contribution as any).computePairedUri.bind(contribution);
+			const result = computePairedUri(URI.file('/outside/workspace/file.ts'));
+
+			assert.strictEqual(result, undefined);
+		});
+
+	});
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+});
+


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

## Summary

This PR adds a new optional feature that automatically reveals the matching paired file (e.g., test ↔ source) in the Explorer when a file is opened in the editor.

## Motivation

Developers frequently need to jump between source files and their corresponding test files. Currently, this requires manually searching or expanding folders in the Explorer. This feature streamlines TDD workflows and common navigation patterns.

## New Settings

| Setting | Type | Default | Description |
|---------|------|---------|-------------|
| `workbench.autoRevealPairedFile.enabled` | boolean | `false` | Enable/disable the feature |
| `workbench.autoRevealPairedFile.patterns` | array | `[]` | Array of `{source, test}` regex patterns |

## Example Configuration

{
  "workbench.autoRevealPairedFile.enabled": true,
  "workbench.autoRevealPairedFile.patterns": [
    {
      "source": "src/(.*)\\.ts",
      "test": "tests/$1.test.ts"
    }
  ]
}## Features

- **Bidirectional matching:** Opening `src/utils/math.ts` reveals `tests/utils/math.test.ts`, and vice versa.
- **Regex capture groups:** Flexible path mapping using `$1`, `$2`, etc.
- **Silent failure:** No UI noise when no match is found or the paired file doesn't exist.
- **Zero overhead:** No performance impact when the feature is disabled.
- **Cross-platform:** Works on Windows, macOS, and Linux.

## Testing

- Unit tests for pattern compilation, capture group substitution, and bidirectional mapping.
- Integration tests for Explorer reveal behavior.
- All tests pass: `npm run test -- --grep "AutoRevealPairedFile"`

## Files Changed

- `src/vs/workbench/browser/workbench.contribution.ts` — Settings definitions
- `src/vs/workbench/contrib/files/common/files.ts` — Configuration interfaces
- `src/vs/workbench/contrib/files/browser/autoRevealPairedFile.ts` — Main implementation
- `src/vs/workbench/contrib/files/browser/files.contribution.ts` — Contribution registration
- `src/vs/workbench/contrib/files/test/browser/autoRevealPairedFile.test.ts` — Tests
