### PR TITLE
Issue 250115 Highlight Parent Folders in Explorer Tree for Active File

### DIFF
--- a/src/vs/workbench/contrib/files/browser/media/explorerviewlet.css
+++ b/src/vs/workbench/contrib/files/browser/media/explorerviewlet.css
@@ -40,6 +40,14 @@
 	opacity: 0.5;
 }
 
+.explorer-folders-view .monaco-list-row:has(.explorer-item-focus-ancestor) {
+	background-color: rgba(128, 128, 128, 0.13);
+}
+
+.explorer-folders-view:focus-within .monaco-list-row:has(.explorer-item-focus-ancestor) {
+	background-color: rgba(0, 120, 212, 0.13);
+}
+
 .explorer-folders-view .explorer-item.explorer-item-edited .label-name {
 	flex: 0; /* do not steal space when label is hidden because we are in edit mode */
 }

--- a/src/vs/workbench/contrib/files/browser/views/explorerViewer.ts
+++ b/src/vs/workbench/contrib/files/browser/views/explorerViewer.ts
@@ -840,6 +840,7 @@ export class FilesRenderer implements ICompressibleTreeRenderer<ExplorerItem, Fu
 	private config: IFilesConfiguration;
 	private configListener: IDisposable;
 	private compressedNavigationControllers = new Map<ExplorerItem, CompressedNavigationController[]>();
+	private focusedItemAncestorUris = new Set<string>();
 
 	private _onDidChangeActiveDescendant = new EventMultiplexer<void>();
 	readonly onDidChangeActiveDescendant = this._onDidChangeActiveDescendant.event;
@@ -876,6 +877,17 @@ export class FilesRenderer implements ICompressibleTreeRenderer<ExplorerItem, Fu
 		});
 
 		updateOffsetStyles();
+	}
+
+	setFocusedItem(item: ExplorerItem | undefined): Set<string> {
+		const previous = this.focusedItemAncestorUris;
+		this.focusedItemAncestorUris = new Set<string>();
+		let parent = item?.parent;
+		while (parent) {
+			this.focusedItemAncestorUris.add(parent.resource.toString());
+			parent = parent.parent;
+		}
+		return previous;
 	}
 
 	getWidgetAriaLabel(): string {
@@ -1004,6 +1016,9 @@ export class FilesRenderer implements ICompressibleTreeRenderer<ExplorerItem, Fu
 		const extraClasses = ['explorer-item'];
 		if (this.explorerService.isCut(stat)) {
 			extraClasses.push('cut');
+		}
+		if (this.focusedItemAncestorUris.has(stat.resource.toString())) {
+			extraClasses.push('explorer-item-focus-ancestor');
 		}
 
 		// Offset nested children unless folders have both chevrons and icons, otherwise alignment breaks


### PR DESCRIPTION
## Highlight ancestor folders of selected file in Explorer
Issue: https://github.com/microsoft/vscode/issues/250115

### Summary
- Add visual highlighting to ancestor folders when a file is selected in the Explorer tree
- Uses light blue highlight when Explorer is focused, light grey when unfocused
- Improves navigation clarity in deeply nested folder structures

Desktop Explorer Focused
<img width="204" height="347" alt="image" src="https://github.com/user-attachments/assets/d2d953fe-95e7-402b-8d3e-d2e1e148e3c5" />

Desktop Explorer Unfocused
<img width="204" height="347" alt="image" src="https://github.com/user-attachments/assets/6ef7937f-54d8-4906-a04a-a61304f66e5d" />

Code Server Web Explorer Focused
<img width="204" height="347" alt="image" src="https://github.com/user-attachments/assets/d470aa59-3b33-4df3-a984-f36cb189db85" />

Code Server Web Explorer Unfocused
<img width="204" height="347" alt="image" src="https://github.com/user-attachments/assets/20d2617b-eac9-4aad-af28-070110c0ea4e" />


### Problem
When a file is selected in the Explorer, only the file itself is highlighted. This makes it difficult to quickly identify the parent folder structure, especially in deeply nested trees:

```
app/
  routes/
    auth/
      login
      logout
      signup
    home/
      * index  ← only this file is highlighted
```

### Solution
Highlight all ancestor folders to reflect the currently active file path:

```
* app/
  * routes/
      auth/
        login
        logout
        signup
    * home/
      * index
```

### Implementation
- **explorerViewer.ts**: Added `focusedItemAncestorUris` Set to track ancestor folder URIs. Uses URI strings (not object references) to survive tree refreshes when VS Code regains focus.
- **explorerView.ts**:
  - Listen to `onDidChangeSelection` to update ancestors when selection changes
  - Listen to `onDidFocus` to re-render ancestors when tree regains DOM focus
  - Added `updateAncestorHighlight()` and `rerenderAncestors()` methods
- **explorerviewlet.css**: Added styles using `:has()` selector to highlight full row:
  - Light grey (`rgba(128, 128, 128, 0.13)`) when unfocused
  - Light blue (`rgba(0, 120, 212, 0.13)`) when focused (via `:focus-within`)

### Test Plan
- [x] Select a deeply nested file → all parent folders should highlight
- [x] Change selection to different file → old ancestors unhighlight, new ancestors highlight
- [x] Click in editor → ancestor highlight turns grey
- [x] Click back in explorer → ancestor highlight turns blue
- [x] Switch to another app and back → ancestor highlight persists
- [x] Scroll the explorer tree → highlights remain on visible ancestors

Unit Tests confirmed passing.

---