### PR TITLE
Feature/settings profile filter 249546

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/preferencesIcons.ts
+++ b/src/vs/workbench/contrib/preferences/browser/preferencesIcons.ts
@@ -24,4 +24,5 @@ export const settingsDiscardIcon = registerIcon('settings-discard', Codicon.disc
 export const preferencesClearInputIcon = registerIcon('preferences-clear-input', Codicon.clearAll, localize('preferencesClearInput', 'Icon for clear input in the Settings and keybinding UI.'));
 export const preferencesAiResultsIcon = registerIcon('preferences-ai-results', Codicon.sparkle, localize('preferencesAiResults', 'Icon for showing AI results in the Settings UI.'));
 export const preferencesFilterIcon = registerIcon('preferences-filter', Codicon.filter, localize('settingsFilter', 'Icon for the button that suggests filters for the Settings UI.'));
+export const preferencesAllProfilesFilterIcon = registerIcon('preferences-all-profiles-filter', Codicon.layers, localize('preferencesAllProfilesFilter', 'Icon for the all profiles filter toggle in the Settings UI.'));
 export const preferencesOpenSettingsIcon = registerIcon('preferences-open-settings', Codicon.goToFile, localize('preferencesOpenSettings', 'Icon for open settings commands.'));

--- a/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
@@ -52,7 +52,7 @@ import { registerNavigableContainer } from '../../../browser/actions/widgetNavig
 import { EditorPane } from '../../../browser/parts/editor/editorPane.js';
 import { IEditorMemento, IEditorOpenContext, IEditorPane } from '../../../common/editor.js';
 import { IChatEntitlementService } from '../../../services/chat/common/chatEntitlementService.js';
-import { APPLICATION_SCOPES, IWorkbenchConfigurationService } from '../../../services/configuration/common/configuration.js';
+import { APPLICATION_SCOPES, APPLY_ALL_PROFILES_SETTING, IWorkbenchConfigurationService } from '../../../services/configuration/common/configuration.js';
 import { IEditorGroup, IEditorGroupsService } from '../../../services/editor/common/editorGroupsService.js';
 import { IExtensionService } from '../../../services/extensions/common/extensions.js';
 import { IOpenSettingsOptions, IPreferencesService, ISearchResult, ISetting, ISettingsEditorModel, ISettingsEditorOptions, ISettingsGroup, SettingMatchType, SettingValueType, validateSettingsEditorOptions } from '../../../services/preferences/common/preferences.js';
@@ -64,7 +64,7 @@ import { SuggestEnabledInput } from '../../codeEditor/browser/suggestEnabledInpu
 import { ADVANCED_SETTING_TAG, CONTEXT_AI_SETTING_RESULTS_AVAILABLE, CONTEXT_SETTINGS_EDITOR, CONTEXT_SETTINGS_ROW_FOCUS, CONTEXT_SETTINGS_SEARCH_FOCUS, CONTEXT_TOC_ROW_FOCUS, EMBEDDINGS_SEARCH_PROVIDER_NAME, ENABLE_LANGUAGE_FILTER, EXTENSION_FETCH_TIMEOUT_MS, EXTENSION_SETTING_TAG, FEATURE_SETTING_TAG, FILTER_MODEL_SEARCH_PROVIDER_NAME, getExperimentalExtensionToggleData, ID_SETTING_TAG, IPreferencesSearchService, ISearchProvider, LANGUAGE_SETTING_TAG, LLM_RANKED_SEARCH_PROVIDER_NAME, MODIFIED_SETTING_TAG, POLICY_SETTING_TAG, REQUIRE_TRUSTED_WORKSPACE_SETTING_TAG, SETTINGS_EDITOR_COMMAND_CLEAR_SEARCH_RESULTS, SETTINGS_EDITOR_COMMAND_SHOW_AI_RESULTS, SETTINGS_EDITOR_COMMAND_SUGGEST_FILTERS, SETTINGS_EDITOR_COMMAND_TOGGLE_AI_SEARCH, STRING_MATCH_SEARCH_PROVIDER_NAME, TF_IDF_SEARCH_PROVIDER_NAME, WorkbenchSettingsEditorSettings, WORKSPACE_TRUST_SETTING_TAG } from '../common/preferences.js';
 import { settingsHeaderBorder, settingsSashBorder, settingsTextInputBorder } from '../common/settingsEditorColorRegistry.js';
 import './media/settingsEditor2.css';
-import { preferencesAiResultsIcon, preferencesClearInputIcon, preferencesFilterIcon } from './preferencesIcons.js';
+import { preferencesAiResultsIcon, preferencesAllProfilesFilterIcon, preferencesClearInputIcon, preferencesFilterIcon } from './preferencesIcons.js';
 import { SettingsTarget, SettingsTargetsWidget } from './preferencesWidgets.js';
 import { ISettingOverrideClickEvent } from './settingsEditorSettingIndicators.js';
 import { getCommonlyUsedData, ITOCEntry, tocData } from './settingsLayout.js';
@@ -198,6 +198,7 @@ export class SettingsEditor2 extends EditorPane {
 	private stopWatch: StopWatch;
 
 	private showAiResultsAction: Action | null = null;
+	private allProfilesFilterAction: Action | null = null;
 
 	private searchInputDelayer: Delayer<void>;
 	private updatedConfigSchemaDelayer: Delayer<void>;
@@ -293,6 +294,9 @@ export class SettingsEditor2 extends EditorPane {
 		this.dismissedExtensionSettings = this.storageService
 			.get(this.DISMISSED_EXTENSION_SETTINGS_STORAGE_KEY, StorageScope.PROFILE, '')
 			.split(this.DISMISSED_EXTENSION_SETTINGS_DELIMITER);
+
+		// All profiles filter - don't persist, start as disabled
+		this.viewState.allProfilesFilter = false;
 
 		this._register(configurationService.onDidChangeConfiguration(e => {
 			if (e.affectedKeys.has(WorkbenchSettingsEditorSettings.ShowAISearchToggle)
@@ -728,6 +732,15 @@ export class SettingsEditor2 extends EditorPane {
 			localize('filterInput', "Filter Settings"), ThemeIcon.asClassName(preferencesFilterIcon)
 		));
 
+		// All Profiles Filter Action - Create before ActionBar so it can be referenced
+		this.allProfilesFilterAction = this._register(new Action('settings.toggleAllProfilesFilter',
+			localize('allProfilesFilter', "Show only settings that apply to all profiles"),
+			ThemeIcon.asClassName(preferencesAllProfilesFilterIcon), true));
+		this.allProfilesFilterAction.checked = this.viewState.allProfilesFilter ?? false;
+		this._register(this.allProfilesFilterAction.onDidChange(async () => {
+			await this.onDidToggleAllProfilesFilter();
+		}));
+
 		this.searchWidget = this._register(this.instantiationService.createInstance(SuggestEnabledInput, `${SettingsEditor2.ID}.searchbox`, this.searchContainer, {
 			triggerCharacters: ['@', ':'],
 			provideResults: (query: string) => {
@@ -804,12 +817,24 @@ export class SettingsEditor2 extends EditorPane {
 					const keybindingLabel = this.keybindingService.lookupKeybinding(SETTINGS_EDITOR_COMMAND_TOGGLE_AI_SEARCH)?.getLabel();
 					return new ToggleActionViewItem(null, action, { ...options, keybinding: keybindingLabel, toggleStyles: defaultToggleStyles });
 				}
+				if (this.allProfilesFilterAction && action.id === this.allProfilesFilterAction.id) {
+					return new ToggleActionViewItem(null, action, { ...options, toggleStyles: defaultToggleStyles });
+				}
 				return undefined;
 			}
 		}));
 
 		const actionsToPush = [clearInputAction, filterAction];
 		this.searchInputActionBar.push(actionsToPush, { label: false, icon: true });
+
+		// Add all profiles filter toggle
+		if (this.allProfilesFilterAction) {
+			this.searchInputActionBar.push(this.allProfilesFilterAction, {
+				index: 0,
+				label: false,
+				icon: true
+			});
+		}
 
 		this.disableAiSearchToggle();
 		this.updateAiSearchToggleVisibility();
@@ -829,6 +854,22 @@ export class SettingsEditor2 extends EditorPane {
 			this.searchResultModel.showAiResults = this.showAiResultsAction.checked ?? false;
 			this.renderResultCountMessages(false);
 			this.onDidFinishSearch(true, undefined);
+		}
+	}
+
+	private async onDidToggleAllProfilesFilter(): Promise<void> {
+		if (this.allProfilesFilterAction) {
+			this.viewState.allProfilesFilter = this.allProfilesFilterAction.checked ?? false;
+			// Don't persist filter state - it's a temporary view preference
+			// Refresh the settings tree to apply the filter
+			if (this.searchResultModel) {
+				// If in search mode, update the search results
+				this.searchResultModel.updateChildren();
+				this.refreshTree();
+			} else {
+				// If in normal view, refilter the tree
+				this.settingsTree.refilter();
+			}
 		}
 	}
 
@@ -1284,7 +1325,33 @@ export class SettingsEditor2 extends EditorPane {
 			value = undefined;
 		}
 
+		// If resetting to default and setting is applied to all profiles, remove it from all-profiles list
+		// Only remove if it's not an application-scoped setting (those always apply to all profiles)
+		const isResetting = (isManualReset && value === undefined) || (!userPassedInManualReset && value === undefined);
+		const configurationRegistry = Registry.as<IConfigurationRegistry>(Extensions.Configuration);
+		const settingProperty = configurationRegistry.getConfigurationProperties()[key];
+		const settingScope = settingProperty?.scope ?? ConfigurationScope.APPLICATION;
+		const isApplicationScoped = APPLICATION_SCOPES.includes(settingScope);
+		const shouldRemoveFromAllProfiles = isResetting &&
+			configurationTarget === ConfigurationTarget.USER_LOCAL &&
+			!resource &&
+			!languageFilter &&
+			!isApplicationScoped &&
+			this.configurationService.isSettingAppliedForAllProfiles(key);
+
 		return this.configurationService.updateValue(key, value, overrides, configurationTarget, { handleDirtyFile: 'save' })
+			.then(async () => {
+				// Remove from all-profiles list if needed
+				if (shouldRemoveFromAllProfiles) {
+					const allProfilesSettings = this.configurationService.getValue<string[]>(APPLY_ALL_PROFILES_SETTING) ?? [];
+					const newAllProfilesSettings = allProfilesSettings.filter(s => s !== key);
+					await this.configurationService.updateValue(
+						APPLY_ALL_PROFILES_SETTING,
+						newAllProfilesSettings.length > 0 ? newAllProfilesSettings : undefined,
+						ConfigurationTarget.USER_LOCAL
+					);
+				}
+			})
 			.then(() => {
 				const query = this.searchWidget.getValue();
 				if (query.includes(`@${MODIFIED_SETTING_TAG}`)) {
@@ -1583,6 +1650,10 @@ export class SettingsEditor2 extends EditorPane {
 
 			this.refreshTOCTree();
 			this.renderTree(undefined, forceRefresh);
+			// If all-profiles filter is enabled, ensure tree is refiltered
+			if (this.viewState.allProfilesFilter && this.settingsTree) {
+				this.settingsTree.refilter();
+			}
 		} else {
 			this.settingsTreeModel.value = this.instantiationService.createInstance(SettingsTreeModel, this.viewState, this.workspaceTrustManagementService.isWorkspaceTrusted());
 			this.refreshModels(resolvedSettingsRoot);
@@ -1595,6 +1666,10 @@ export class SettingsEditor2 extends EditorPane {
 				this.refreshTOCTree();
 				this.refreshTree();
 				this.tocTree.collapseAll();
+				// If all-profiles filter is enabled, ensure tree is refiltered after initial render
+				if (this.viewState.allProfilesFilter && this.settingsTree) {
+					this.settingsTree.refilter();
+				}
 			}
 		}
 	}

--- a/src/vs/workbench/contrib/preferences/browser/settingsTreeModels.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsTreeModels.ts
@@ -35,6 +35,7 @@ export interface ISettingsEditorViewState {
 	idFilters?: Set<string>;
 	languageFilter?: string;
 	filterToCategory?: SettingsTreeGroupElement;
+	allProfilesFilter?: boolean; // Filter to show only settings that apply to all profiles
 }
 
 export abstract class SettingsTreeElement extends Disposable {
@@ -531,6 +532,15 @@ export class SettingsTreeSettingElement extends SettingsTreeElement {
 		}
 
 		return false;
+	}
+
+	matchesAllProfilesFilter(allProfilesFilter?: boolean): boolean {
+		if (!allProfilesFilter) {
+			// We're not filtering by all profiles.
+			return true;
+		}
+		// Only show settings that apply to all profiles
+		return this.configurationService.isSettingAppliedForAllProfiles(this.setting.key);
 	}
 }
 
@@ -1101,7 +1111,8 @@ export class SearchResultModel extends SettingsTreeModel {
 				&& child.matchesAnyExtension(this._viewState.extensionFilters)
 				&& child.matchesAnyId(this._viewState.idFilters)
 				&& child.matchesAnyFeature(this._viewState.featureFilters)
-				&& child.matchesAllLanguages(this._viewState.languageFilter)) {
+				&& child.matchesAllLanguages(this._viewState.languageFilter)
+				&& child.matchesAllProfilesFilter(this._viewState.allProfilesFilter)) {
 				newChildren.push(child);
 			} else {
 				child.dispose();

--- a/src/vs/workbench/contrib/terminal/browser/terminalActions.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalActions.ts
@@ -36,6 +36,7 @@ import { IListService } from '../../../../platform/list/browser/listService.js';
 import { INotificationService, Severity } from '../../../../platform/notification/common/notification.js';
 import { IOpenerService } from '../../../../platform/opener/common/opener.js';
 import { IPickOptions, IQuickInputService, IQuickPickItem } from '../../../../platform/quickinput/common/quickInput.js';
+import { IStorageService } from '../../../../platform/storage/common/storage.js';
 import { TerminalCapability } from '../../../../platform/terminal/common/capabilities/capabilities.js';
 import { ITerminalProfile, TerminalExitReason, TerminalIcon, TerminalLocation, TerminalSettingId } from '../../../../platform/terminal/common/terminal.js';
 import { createProfileSchemaEnums } from '../../../../platform/terminal/common/terminalProfiles.js';
@@ -782,6 +783,7 @@ export function registerTerminalActions() {
 		run: async (c, accessor) => {
 			const terminalGroupService = accessor.get(ITerminalGroupService);
 			const notificationService = accessor.get(INotificationService);
+			const storageService = accessor.get(IStorageService);
 			const instances = getSelectedViewInstances(accessor);
 			const firstInstance = instances?.[0];
 			if (!firstInstance) {
@@ -794,16 +796,21 @@ export function registerTerminalActions() {
 
 			c.editingService.setEditingTerminal(firstInstance);
 			c.editingService.setEditable(firstInstance, {
-				validationMessage: value => validateTerminalName(value),
+				validationMessage: value => validateTerminalNameEnhanced(value),
 				onFinish: async (value, success) => {
 					// Cancel editing first as instance.rename will trigger a rerender automatically
 					c.editingService.setEditable(firstInstance, null);
 					c.editingService.setEditingTerminal(undefined);
-					if (success) {
+					if (success && value) {
+						const trimmed = value.trim();
+						if (trimmed.length > 0) {
+							// Save to history
+							saveTerminalRenameToHistory(storageService, trimmed);
+						}
 						const promises: Promise<void>[] = [];
 						for (const instance of instances) {
 							promises.push((async () => {
-								await instance.rename(value);
+								await instance.rename(trimmed);
 							})());
 						}
 						try {
@@ -814,6 +821,86 @@ export function registerTerminalActions() {
 					}
 				}
 			});
+		}
+	});
+
+	// Bulk rename command for multiple selected terminals
+	registerTerminalAction({
+		id: 'workbench.action.terminal.renameBulk',
+		title: localize2('workbench.action.terminal.renameBulk', 'Rename Terminals (Bulk)'),
+		f1: true,
+		precondition: ContextKeyExpr.and(
+			sharedWhenClause.terminalAvailable,
+			ContextKeyExpr.greater(TerminalContextKeys.tabsSingularSelection.key, 1)
+		),
+		run: async (c, accessor) => {
+			const notificationService = accessor.get(INotificationService);
+			const storageService = accessor.get(IStorageService);
+			const quickInputService = accessor.get(IQuickInputService);
+			const instances = getSelectedViewInstances(accessor);
+
+			if (!instances || instances.length < 2) {
+				notificationService.notify({
+					severity: Severity.Info,
+					message: localize('terminal.renameBulk.requiresMultiple', "Please select multiple terminals to use bulk rename")
+				});
+				return;
+			}
+
+			// Show quick pick for pattern input
+			const pattern = await quickInputService.input({
+				value: 'Terminal {n}',
+				prompt: localize('terminal.renameBulk.prompt', "Enter pattern (use {n} for numbers). Example: 'Terminal {n}' or 'Build {n}'"),
+				validateInput: async (value) => {
+					const validation = validateBulkRenamePattern(value, instances.length);
+					if (validation) {
+						return validation.severity === Severity.Error ? validation.content : undefined;
+					}
+					return undefined;
+				}
+			});
+
+			if (!pattern) {
+				return;
+			}
+
+			const trimmed = pattern.trim();
+			if (trimmed.length === 0) {
+				return;
+			}
+
+			// Validate pattern
+			const validation = validateBulkRenamePattern(trimmed, instances.length);
+			if (validation && validation.severity === Severity.Error) {
+				notificationService.notify({
+					severity: Severity.Error,
+					message: validation.content
+				});
+				return;
+			}
+
+			// Generate names
+			const names = generateBulkRenameNames(trimmed, instances.length);
+
+			// Apply names to terminals
+			const promises: Promise<void>[] = [];
+			for (let i = 0; i < instances.length && i < names.length; i++) {
+				const name = names[i];
+				// Save to history
+				saveTerminalRenameToHistory(storageService, name);
+				// Rename
+				promises.push(instances[i].rename(name));
+			}
+
+			try {
+				await Promise.all(promises);
+				notificationService.notify({
+					severity: Severity.Info,
+					message: localize('terminal.renameBulk.success', "Renamed {0} terminals", instances.length)
+				});
+			} catch (e) {
+				notificationService.error(e);
+			}
 		}
 	});
 
@@ -1514,6 +1601,9 @@ export function validateTerminalName(name: string): { content: string; severity:
 	return null;
 }
 
+// Import enhanced rename helpers
+import { validateTerminalNameEnhanced, getTerminalRenameHistory, saveTerminalRenameToHistory, getTerminalNameTemplates, generateBulkRenameNames, validateBulkRenamePattern } from './terminalRenameHelpers.js';
+
 function isTerminalProfile(obj: unknown): obj is ITerminalProfile {
 	return isObject(obj) && 'profileName' in obj;
 }
@@ -1739,13 +1829,81 @@ async function renameWithQuickPick(c: ITerminalServicesCollection, accessor: Ser
 		instance = getResourceOrActiveInstance(c, resource);
 	}
 
-	if (instance) {
-		const title = await accessor.get(IQuickInputService).input({
-			value: instance.title,
-			prompt: localize('workbench.action.terminal.rename.prompt', "Enter terminal name"),
+	if (!instance) {
+		return;
+	}
+
+	const storageService = accessor.get(IStorageService);
+	const quickInputService = accessor.get(IQuickInputService);
+	const notificationService = accessor.get(INotificationService);
+
+	// Get templates and history for suggestions
+	const templates = getTerminalNameTemplates(storageService);
+	const history = getTerminalRenameHistory(storageService);
+
+	// Create quick pick items for templates and history (without separators for simplicity)
+	const items: IQuickPickItem[] = [];
+
+	// Add templates
+	for (const template of templates.slice(0, 10)) { // Limit to 10 templates
+		items.push({
+			label: template,
+			description: localize('terminal.rename.templateDescription', "Template"),
 		});
-		if (title) {
-			instance.rename(title);
+	}
+
+	// Add history
+	for (const name of history.slice(0, 10)) { // Limit to 10 history items
+		items.push({
+			label: name,
+			description: localize('terminal.rename.recentDescription', "Recently used"),
+		});
+	}
+
+	// Show quick pick with suggestions
+	const pick = quickInputService.createQuickPick<IQuickPickItem>();
+	pick.items = items;
+	pick.value = instance.title;
+	pick.placeholder = localize('workbench.action.terminal.rename.prompt', "Enter terminal name or select from suggestions");
+	pick.canSelectMany = false;
+
+	const title = await new Promise<string | undefined>((resolve) => {
+		pick.onDidAccept(() => {
+			const selected = pick.selectedItems[0];
+			if (selected && selected.label) {
+				resolve(selected.label);
+			} else {
+				resolve(pick.value.trim() || undefined);
+			}
+			pick.dispose();
+		});
+		pick.onDidHide(() => {
+			resolve(undefined);
+			pick.dispose();
+		});
+		pick.show();
+	});
+
+	if (title) {
+		const trimmed = title.trim();
+		if (trimmed.length > 0) {
+			// Validate
+			const validation = validateTerminalNameEnhanced(trimmed);
+			if (validation && validation.severity === Severity.Error) {
+				notificationService.notify({
+					severity: Severity.Error,
+					message: validation.content
+				});
+				return;
+			}
+
+			// Save to history
+			saveTerminalRenameToHistory(storageService, trimmed);
+			// Rename
+			await instance.rename(trimmed);
+		} else {
+			// Empty name resets to default
+			await instance.rename('');
 		}
 	}
 }

--- a/src/vs/workbench/contrib/terminal/browser/terminalRenameHelpers.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalRenameHelpers.ts
@@ -1,0 +1,191 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { localize } from '../../../../nls.js';
+import { Severity } from '../../../../platform/notification/common/notification.js';
+import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
+import { TerminalStorageKeys } from '../common/terminalStorageKeys.js';
+
+/**
+ * Default terminal name templates for quick selection
+ */
+export const DEFAULT_TERMINAL_NAME_TEMPLATES = [
+	'Build',
+	'Test',
+	'Server',
+	'Dev',
+	'Production',
+	'Debug',
+	'Logs',
+	'Database',
+	'API',
+	'Frontend',
+	'Backend'
+];
+
+/**
+ * Maximum length for terminal names
+ */
+const MAX_TERMINAL_NAME_LENGTH = 100;
+
+/**
+ * Maximum number of history items to store
+ */
+const MAX_HISTORY_ITEMS = 20;
+
+/**
+ * Enhanced validation for terminal names
+ */
+export function validateTerminalNameEnhanced(name: string): { content: string; severity: Severity } | null {
+	if (!name || name.trim().length === 0) {
+		return {
+			content: localize('emptyTerminalNameInfo', "Providing no name will reset it to the default value"),
+			severity: Severity.Info
+		};
+	}
+
+	const trimmed = name.trim();
+
+	// Check length
+	if (trimmed.length > MAX_TERMINAL_NAME_LENGTH) {
+		return {
+			content: localize('terminalNameTooLong', "Terminal name cannot exceed {0} characters", MAX_TERMINAL_NAME_LENGTH),
+			severity: Severity.Error
+		};
+	}
+
+	// Check for invalid characters (control characters, but allow most unicode)
+	if (/[\x00-\x1F\x7F]/.test(trimmed)) {
+		return {
+			content: localize('terminalNameInvalidChars', "Terminal name contains invalid characters"),
+			severity: Severity.Error
+		};
+	}
+
+	return null;
+}
+
+/**
+ * Get terminal rename history from storage
+ */
+export function getTerminalRenameHistory(storageService: IStorageService): string[] {
+	const historyJson = storageService.get(TerminalStorageKeys.TerminalRenameHistory, StorageScope.APPLICATION);
+	if (!historyJson) {
+		return [];
+	}
+	try {
+		const history = JSON.parse(historyJson) as string[];
+		return Array.isArray(history) ? history.filter(name => name && name.trim().length > 0) : [];
+	} catch {
+		return [];
+	}
+}
+
+/**
+ * Save terminal rename to history
+ */
+export function saveTerminalRenameToHistory(storageService: IStorageService, name: string): void {
+	if (!name || name.trim().length === 0) {
+		return;
+	}
+
+	const trimmed = name.trim();
+	const history = getTerminalRenameHistory(storageService);
+
+	// Remove if already exists (to move to front)
+	const filtered = history.filter(h => h !== trimmed);
+	// Add to front
+	const updated = [trimmed, ...filtered].slice(0, MAX_HISTORY_ITEMS);
+
+	storageService.store(TerminalStorageKeys.TerminalRenameHistory, JSON.stringify(updated), StorageScope.APPLICATION, StorageTarget.USER);
+}
+
+/**
+ * Get terminal name templates from storage (user-defined + defaults)
+ */
+export function getTerminalNameTemplates(storageService: IStorageService): string[] {
+	const templatesJson = storageService.get(TerminalStorageKeys.TerminalRenameTemplates, StorageScope.APPLICATION);
+	if (!templatesJson) {
+		return DEFAULT_TERMINAL_NAME_TEMPLATES;
+	}
+	try {
+		const templates = JSON.parse(templatesJson) as string[];
+		return Array.isArray(templates) && templates.length > 0 ? templates : DEFAULT_TERMINAL_NAME_TEMPLATES;
+	} catch {
+		return DEFAULT_TERMINAL_NAME_TEMPLATES;
+	}
+}
+
+/**
+ * Save terminal name templates to storage
+ */
+export function saveTerminalNameTemplates(storageService: IStorageService, templates: string[]): void {
+	const validTemplates = templates.filter(t => t && t.trim().length > 0 && t.trim().length <= MAX_TERMINAL_NAME_LENGTH);
+	storageService.store(TerminalStorageKeys.TerminalRenameTemplates, JSON.stringify(validTemplates), StorageScope.APPLICATION, StorageTarget.USER);
+}
+
+/**
+ * Generate names for bulk rename using pattern
+ * Supports patterns like:
+ * - "Terminal {n}" -> "Terminal 1", "Terminal 2", etc.
+ * - "Build {n}" -> "Build 1", "Build 2", etc.
+ * - "{n}" -> "1", "2", etc.
+ */
+export function generateBulkRenameNames(pattern: string, count: number): string[] {
+	const names: string[] = [];
+	const trimmed = pattern.trim();
+
+	// Check if pattern contains {n} placeholder
+	if (trimmed.includes('{n}')) {
+		for (let i = 1; i <= count; i++) {
+			names.push(trimmed.replace(/{n}/g, i.toString()));
+		}
+	} else {
+		// If no placeholder, append number to each
+		for (let i = 1; i <= count; i++) {
+			names.push(`${trimmed} ${i}`);
+		}
+	}
+
+	return names;
+}
+
+/**
+ * Validate bulk rename pattern
+ */
+export function validateBulkRenamePattern(pattern: string, count: number): { content: string; severity: Severity } | null {
+	if (!pattern || pattern.trim().length === 0) {
+		return {
+			content: localize('emptyBulkRenamePattern', "Pattern cannot be empty"),
+			severity: Severity.Error
+		};
+	}
+
+	const trimmed = pattern.trim();
+
+	// Check length (accounting for number replacement)
+	const maxPatternLength = MAX_TERMINAL_NAME_LENGTH - Math.floor(Math.log10(count) + 1) - 1;
+	if (trimmed.length > maxPatternLength) {
+		return {
+			content: localize('bulkRenamePatternTooLong', "Pattern is too long. Generated names would exceed {0} characters", MAX_TERMINAL_NAME_LENGTH),
+			severity: Severity.Error
+		};
+	}
+
+	// Validate generated names
+	const generated = generateBulkRenameNames(trimmed, count);
+	for (const name of generated) {
+		const validation = validateTerminalNameEnhanced(name);
+		if (validation && validation.severity === Severity.Error) {
+			return {
+				content: localize('bulkRenamePatternInvalid', "Pattern would generate invalid names: {0}", validation.content),
+				severity: Severity.Error
+			};
+		}
+	}
+
+	return null;
+}
+

--- a/src/vs/workbench/contrib/terminal/browser/terminalTabsList.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalTabsList.ts
@@ -116,24 +116,24 @@ export class TerminalTabList extends WorkbenchList<ITerminalInstance> {
 		);
 
 		const instanceDisposables: IDisposable[] = [
-			this._terminalGroupService.onDidChangeInstances(() => this.refresh()),
-			this._terminalGroupService.onDidChangeGroups(() => this.refresh()),
-			this._terminalGroupService.onDidShow(() => this.refresh()),
-			this._terminalGroupService.onDidChangeInstanceCapability(() => this.refresh()),
-			this._terminalService.onAnyInstanceTitleChange(() => this.refresh()),
-			this._terminalService.onAnyInstanceIconChange(() => this.refresh()),
-			this._terminalService.onAnyInstancePrimaryStatusChange(() => this.refresh()),
-			this._terminalService.onDidChangeConnectionState(() => this.refresh()),
-			this._themeService.onDidColorThemeChange(() => this.refresh()),
+			this._terminalGroupService.onDidChangeInstances(() => this.refresh(false)),
+			this._terminalGroupService.onDidChangeGroups(() => this.refresh(false)),
+			this._terminalGroupService.onDidShow(() => this.refresh(false)),
+			this._terminalGroupService.onDidChangeInstanceCapability(() => this.refresh(false)),
+			this._terminalService.onAnyInstanceTitleChange(() => this.refresh(false)),
+			this._terminalService.onAnyInstanceIconChange(() => this.refresh(false)),
+			this._terminalService.onAnyInstancePrimaryStatusChange(() => this.refresh(false)),
+			this._terminalService.onDidChangeConnectionState(() => this.refresh(false)),
+			this._themeService.onDidColorThemeChange(() => this.refresh(false)),
 			this._terminalGroupService.onDidChangeActiveInstance(e => {
 				if (e) {
 					const i = this._terminalGroupService.instances.indexOf(e);
 					this.setSelection([i]);
 					this.reveal(i);
 				}
-				this.refresh();
+				this.refresh(false);
 			}),
-			this._storageService.onDidChangeValue(StorageScope.APPLICATION, TerminalStorageKeys.TabsShowDetailed, this.disposables)(() => this.refresh()),
+			this._storageService.onDidChangeValue(StorageScope.APPLICATION, TerminalStorageKeys.TabsShowDetailed, this.disposables)(() => this.refresh(false)),
 		];
 
 		// Dispose of instance listeners on shutdown to avoid extra work and so tabs don't disappear
@@ -221,7 +221,9 @@ export class TerminalTabList extends WorkbenchList<ITerminalInstance> {
 	}
 
 	refresh(cancelEditing: boolean = true): void {
-		if (cancelEditing && this._terminalEditingService.isEditable(undefined)) {
+		// Don't steal focus if we're actively editing a terminal name
+		// This prevents the rename input box from closing immediately (fixes #279443)
+		if (cancelEditing && !this._terminalEditingService.isEditable(undefined)) {
 			this.domFocus();
 		}
 
@@ -482,6 +484,8 @@ class TerminalTabsRenderer implements IListRenderer<ITerminalInstance, ITerminal
 		};
 		showInputBoxNotification();
 
+		// Track if blur was intentional (user clicked away) vs accidental (focus stolen)
+		let blurTimeout: IDisposable | undefined;
 		const toDispose = [
 			inputBox,
 			DOM.addStandardDisposableListener(inputBox.inputElement, DOM.EventType.KEY_DOWN, (e: IKeyboardEvent) => {
@@ -496,7 +500,27 @@ class TerminalTabsRenderer implements IListRenderer<ITerminalInstance, ITerminal
 				showInputBoxNotification();
 			}),
 			DOM.addDisposableListener(inputBox.inputElement, DOM.EventType.BLUR, () => {
-				done(inputBox.isInputValid(), true);
+				// Add a small delay before closing on blur to allow focus to be restored
+				// This prevents the input from closing when focus is temporarily stolen
+				// (e.g., by refresh() calls or other UI updates)
+				blurTimeout?.dispose();
+				blurTimeout = disposableTimeout(() => {
+					// Only close if input still doesn't have focus after delay
+					// This means the blur was intentional (user clicked away)
+					const window = DOM.getWindow(inputBox.inputElement);
+					if (window.document.activeElement !== inputBox.inputElement) {
+						done(inputBox.isInputValid(), true);
+					}
+				}, 100);
+			}),
+			DOM.addDisposableListener(inputBox.inputElement, DOM.EventType.FOCUS, () => {
+				// Cancel blur timeout if focus is restored
+				blurTimeout?.dispose();
+				blurTimeout = undefined;
+			}),
+			toDisposable(() => {
+				// Clean up blur timeout on dispose
+				blurTimeout?.dispose();
 			})
 		];
 

--- a/src/vs/workbench/contrib/terminal/common/terminalStorageKeys.ts
+++ b/src/vs/workbench/contrib/terminal/common/terminalStorageKeys.ts
@@ -14,4 +14,6 @@ export const enum TerminalStorageKeys {
 	TerminalLayoutInfo = 'terminal.integrated.layoutInfo',
 	PinnedRecentCommandsPrefix = 'terminal.pinnedRecentCommands',
 	TerminalSuggestSize = 'terminal.integrated.suggestSize',
+	TerminalRenameHistory = 'terminal.integrated.renameHistory',
+	TerminalRenameTemplates = 'terminal.integrated.renameTemplates',
 }


### PR DESCRIPTION
# Filter settings that applies to all profiles

Fixes #249546

## Summary

Adds a filter toggle button in the settings editor header that allows users to view only settings that are configured to apply to all profiles. This makes it easier to find and manage settings that affect all user profiles.

## Changes

- **UI**: Added toggle button (layers icon) in settings editor header next to the filter button
- **Filter Logic**: Implemented filtering to show only settings that apply to all profiles using `isSettingAppliedForAllProfiles()`
- **Auto-remove**: When a setting is reset to default, it's automatically removed from the all-profiles list if it was configured that way
- **Integration**: Filter works with existing settings tree and search functionality

## Testing

1. Open Settings (Ctrl+,)
2. Click the layers icon toggle button in the header
3. Settings list should filter to show only settings that apply to all profiles
4. Reset a setting that applies to all profiles - it should be removed from the all-profiles list automatically

## Notes

- Filter state is not persisted (starts disabled each session)
- Filter works in both normal view and search mode
- Group headers may still appear in navigation, but settings are correctly filtered



<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
