### PR TITLE
Show image preview on hover in the Explorer sidebar #270270

### DIFF
--- a/src/vs/workbench/contrib/files/browser/files.contribution.ts
+++ b/src/vs/workbench/contrib/files/browser/files.contribution.ts
@@ -636,6 +636,18 @@ configurationRegistry.registerConfiguration({
 				'tsconfig.json': 'tsconfig.*.json',
 				'package.json': 'package-lock.json, yarn.lock, pnpm-lock.yaml, bun.lockb, bun.lock',
 			}
+		},
+		'explorer.imagePreview.enabled': {
+			'type': 'boolean',
+			'description': nls.localize('explorer.imagePreview.enabled', "Controls whether hovering over an image file in the Explorer shows a preview of the image."),
+			'default': true
+		},
+		'explorer.imagePreview.maxWidth': {
+			'type': 'number',
+			'description': nls.localize('explorer.imagePreview.maxWidth', "Maximum width of the image preview in the Explorer hover, in pixels. Height auto-adjusts to maintain aspect ratio."),
+			'default': 300,
+			'minimum': 50,
+			'maximum': 600
 		}
 	}
 });

--- a/src/vs/workbench/contrib/files/common/files.ts
+++ b/src/vs/workbench/contrib/files/common/files.ts
@@ -113,6 +113,10 @@ export interface IFilesConfiguration extends PlatformIFilesConfiguration, IWorkb
 			patterns: { [parent: string]: string };
 		};
 		autoOpenDroppedFile: boolean;
+		imagePreview: {
+			enabled: boolean;
+			maxWidth: number;
+		};
 	};
 	editor: IEditorOptions;
 }


### PR DESCRIPTION
## Summary

Adds image preview on hover in the Explorer sidebar.

Fixes #270270
https://github.com/microsoft/vscode/issues/270270

## Description

Hovering over an image file in the Explorer now shows a thumbnail preview near the cursor. This makes it easier to browse assets like logos, icons, and screenshots without opening each file manually.

- Preview appears instantly on hover
- Maintains original aspect ratio
- Configurable via `explorer.imagePreview.enabled` and `explorer.imagePreview.maxWidth`

<img width="190" height="360" alt="image" src="https://github.com/user-attachments/assets/3e1d27b6-8d56-4b65-aa00-0787d212d76a" />


## Test Plan

- [x] Hover over image files in Explorer and verify preview appears
- [x] Verify preview works for common formats (PNG, JPG, SVG, GIF, WebP, etc.)
- [x] Verify `explorer.imagePreview.enabled: false` disables the feature
