### PR TITLE
Update SQL syntax highlighting for keywordsAdd SHOW keyword to SQL sy…

### DIFF
--- a/extensions/sql/syntaxes/sql.tmLanguage.json
+++ b/extensions/sql/syntaxes/sql.tmLanguage.json
@@ -384,7 +384,7 @@
 			"name": "keyword.other.sql"
 		},
 		{
-			"captures": {
+			"captures": {show|
 				"1": {
 					"name": "punctuation.section.scope.begin.sql"
 				},


### PR DESCRIPTION
…ntax highlighting

Add support for MySQL/MariaDB SHOW keyword in SQL grammar. The SHOW command is used for displaying database metadata and is a fundamental part of MySQL/MariaDB syntax.

Related to shikijs/shiki#1043

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
