### PR TITLE
chat - for now disable `chat.promptFilesRecommendations` as workspace setting

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,6 +9,7 @@
 		"scripts/test-integration.bat": true,
 		"scripts/test-integration.sh": true,
 	},
+
 	// --- Editor ---
 	"editor.insertSpaces": false,
 	"editor.experimental.asyncTokenization": true,
@@ -36,6 +37,7 @@
 	"[github-issues]": {
 		"editor.wordWrap": "on"
 	},
+
 	// --- Files ---
 	"files.trimTrailingWhitespace": true,
 	"files.insertFinalNewline": true,
@@ -71,6 +73,7 @@
 		"test/automation/out/**": true,
 		"test/integration/browser/out/**": true
 	},
+
 	// --- Search ---
 	"search.exclude": {
 		"**/node_modules": true,
@@ -93,6 +96,7 @@
 		"build/loader.min": true,
 		"**/*.snap": true,
 	},
+
 	// --- TypeScript ---
 	"typescript.tsdk": "node_modules/typescript/lib",
 	"typescript.preferences.importModuleSpecifier": "relative",
@@ -105,6 +109,7 @@
 		"vscode-notebook-renderer",
 		"src/vs/workbench/workbench.web.main.internal.ts"
 	],
+
 	// --- Languages ---
 	"json.schemas": [
 		{
@@ -121,6 +126,7 @@
 		}
 	],
 	"css.format.spaceAroundSelectorSeparator": true,
+
 	// --- Git ---
 	"git.ignoreLimitWarning": true,
 	"git.branchProtection": [
@@ -138,6 +144,7 @@
 		"ts": "warning",
 		"eslint": "warning"
 	},
+
 	// --- GitHub ---
 	"githubPullRequests.experimental.createView": true,
 	"githubPullRequests.assignCreated": "${user}",
@@ -147,6 +154,7 @@
 	],
 	"githubPullRequests.codingAgent.enabled": true,
 	"githubPullRequests.codingAgent.uiIntegration": true,
+
 	// --- Testing & Debugging ---
 	"testing.autoRun.mode": "rerun",
 	"debug.javascript.terminalOptions": {
@@ -160,6 +168,7 @@
 			"${workspaceFolder}/extensions/*/out/**/*.js",
 		]
 	},
+
 	// --- Coverage ---
 	"lcov.path": [
 		"./.build/coverage/lcov.info",
@@ -174,6 +183,7 @@
 			}
 		}
 	],
+
 	// --- Tools ---
 	"npm.exclude": "**/extensions/**",
 	"eslint.useFlatConfig": true,
@@ -192,16 +202,12 @@
 		"git",
 		"sash"
 	],
+
 	// --- Workbench ---
 	// "application.experimental.rendererProfiling": true, // https://github.com/microsoft/vscode/issues/265654
 	"editor.aiStats.enabled": true, // Team selfhosting on ai stats
-	"chat.promptFilesRecommendations": {
-		"plan-fast": true,
-		"plan-deep": true
-	},
-	// Needed for kusto tool in data.prompt.md
 	"azureMcp.enabledServices": [
-		"kusto"
+		"kusto" // Needed for kusto tool in data.prompt.md
 	],
 	"azureMcp.serverMode": "all",
 	"azureMcp.readOnly": true,


### PR DESCRIPTION
We have meanwhile added `agent` as built-in mode, so it seems counter intuitive to ask the user to use `plan-fast` or `plan-deep`

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
