### PR TITLE
SCM - view as list/tree actions are now hidden by default but can be manually restored

### DIFF
--- a/src/vs/workbench/contrib/scm/browser/scmViewPane.ts
+++ b/src/vs/workbench/contrib/scm/browser/scmViewPane.ts
@@ -20,7 +20,7 @@ import { IContextViewService, IContextMenuService, IOpenContextView } from '../.
 import { IContextKeyService, IContextKey, ContextKeyExpr, RawContextKey } from '../../../../platform/contextkey/common/contextkey.js';
 import { ICommandService } from '../../../../platform/commands/common/commands.js';
 import { IKeybindingService } from '../../../../platform/keybinding/common/keybinding.js';
-import { MenuItemAction, IMenuService, registerAction2, MenuId, MenuRegistry, Action2, IMenu } from '../../../../platform/actions/common/actions.js';
+import { MenuItemAction, IMenuService, registerAction2, MenuId, IAction2Options, MenuRegistry, Action2, IMenu } from '../../../../platform/actions/common/actions.js';
 import { IAction, ActionRunner, Action, Separator, IActionRunner, toAction } from '../../../../base/common/actions.js';
 import { ActionBar, IActionViewItemProvider } from '../../../../base/browser/ui/actionbar/actionbar.js';
 import { IThemeService, IFileIconTheme } from '../../../../platform/theme/common/themeService.js';
@@ -1108,15 +1108,17 @@ class RepositoryVisibilityActionController {
 }
 
 class SetListViewModeAction extends ViewAction<SCMViewPane> {
-	constructor() {
+	constructor(
+		id = 'workbench.scm.action.setListViewMode',
+		menu: Partial<IAction2Options['menu']> = {}) {
 		super({
-			id: 'workbench.scm.action.setListViewMode',
+			id,
 			title: localize('setListViewMode', "View as List"),
 			viewId: VIEW_PANE_ID,
 			f1: false,
 			icon: Codicon.listTree,
 			toggled: ContextKeys.SCMViewMode.isEqualTo(ViewMode.List),
-			menu: { id: Menus.ViewSort, group: '1_viewmode' }
+			menu: { id: Menus.ViewSort, group: '1_viewmode', ...menu }
 		});
 	}
 
@@ -1125,17 +1127,32 @@ class SetListViewModeAction extends ViewAction<SCMViewPane> {
 	}
 }
 
-class SetTreeViewModeAction extends ViewAction<SCMViewPane> {
+class SetListViewModeNavigationAction extends SetListViewModeAction {
 	constructor() {
 		super(
+			'workbench.scm.action.setListViewModeNavigation',
 			{
-				id: 'workbench.scm.action.setTreeViewMode',
+				id: MenuId.SCMTitle,
+				when: ContextKeyExpr.and(ContextKeyExpr.equals('view', VIEW_PANE_ID), ContextKeys.RepositoryCount.notEqualsTo(0), ContextKeys.SCMViewMode.isEqualTo(ViewMode.Tree)),
+				group: 'navigation',
+				order: -1000
+			});
+	}
+}
+
+class SetTreeViewModeAction extends ViewAction<SCMViewPane> {
+	constructor(
+		id = 'workbench.scm.action.setTreeViewMode',
+		menu: Partial<IAction2Options['menu']> = {}) {
+		super(
+			{
+				id,
 				title: localize('setTreeViewMode', "View as Tree"),
 				viewId: VIEW_PANE_ID,
 				f1: false,
 				icon: Codicon.listFlat,
 				toggled: ContextKeys.SCMViewMode.isEqualTo(ViewMode.Tree),
-				menu: { id: Menus.ViewSort, group: '1_viewmode' }
+				menu: { id: Menus.ViewSort, group: '1_viewmode', ...menu }
 			});
 	}
 
@@ -1144,8 +1161,23 @@ class SetTreeViewModeAction extends ViewAction<SCMViewPane> {
 	}
 }
 
+class SetTreeViewModeNavigationAction extends SetTreeViewModeAction {
+	constructor() {
+		super(
+			'workbench.scm.action.setTreeViewModeNavigation',
+			{
+				id: MenuId.SCMTitle,
+				when: ContextKeyExpr.and(ContextKeyExpr.equals('view', VIEW_PANE_ID), ContextKeys.RepositoryCount.notEqualsTo(0), ContextKeys.SCMViewMode.isEqualTo(ViewMode.List)),
+				group: 'navigation',
+				order: -1000
+			});
+	}
+}
+
 registerAction2(SetListViewModeAction);
 registerAction2(SetTreeViewModeAction);
+registerAction2(SetListViewModeNavigationAction);
+registerAction2(SetTreeViewModeNavigationAction);
 
 abstract class RepositorySortAction extends Action2 {
 	constructor(private sortKey: ISCMRepositorySortKey, title: string) {

--- a/src/vs/workbench/contrib/scm/browser/scmViewPane.ts
+++ b/src/vs/workbench/contrib/scm/browser/scmViewPane.ts
@@ -1135,6 +1135,7 @@ class SetListViewModeNavigationAction extends SetListViewModeAction {
 				id: MenuId.SCMTitle,
 				when: ContextKeyExpr.and(ContextKeyExpr.equals('view', VIEW_PANE_ID), ContextKeys.RepositoryCount.notEqualsTo(0), ContextKeys.SCMViewMode.isEqualTo(ViewMode.Tree)),
 				group: 'navigation',
+				isHiddenByDefault: true,
 				order: -1000
 			});
 	}
@@ -1169,6 +1170,7 @@ class SetTreeViewModeNavigationAction extends SetTreeViewModeAction {
 				id: MenuId.SCMTitle,
 				when: ContextKeyExpr.and(ContextKeyExpr.equals('view', VIEW_PANE_ID), ContextKeys.RepositoryCount.notEqualsTo(0), ContextKeys.SCMViewMode.isEqualTo(ViewMode.List)),
 				group: 'navigation',
+				isHiddenByDefault: true,
 				order: -1000
 			});
 	}


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/277832
Bring back the "View as Tree" and "View as List" actions in the Changes title view but hide them by default