### PR TITLE
Fix: Refresh occurrence highlighting after line deletion

### DIFF
--- a/src/vs/editor/contrib/wordHighlighter/browser/wordHighlighter.ts
+++ b/src/vs/editor/contrib/wordHighlighter/browser/wordHighlighter.ts
@@ -286,49 +286,28 @@ class WordHighlighter {
 		}));
 
 		this.toUnhook.add(editor.onDidChangeModelContent((e) => {
-    // detect delete operation (text removed)
-    const isDeleteOperation = e.changes.some(change =>
-        change.text === '' && change.rangeLength > 0
-    );
 
-    if (isDeleteOperation) {
-        // refresh highlights after deletion
-        this.runDelayer.cancel();
-        this._run();
-        return;
-    }
+			// detect delete operation (text removed)
+			const isDeleteOperation = e.changes.some(change =>
+				change.text === '' && change.rangeLength > 0
+			);
 
-    // fallback to original behavior
-    if (!matchesScheme(this.model.uri, 'output')) {
-        this._stopAll();
-    }
-}));
+			if (isDeleteOperation) {
+				// refresh highlights after deletion
+				this.runDelayer.cancel();
+				this._run();
+				return;
+			}
 
-this.toUnhook.add(editor.onDidChangeModelContent((e) => {
-    // detect delete operation (text removed)
-    const isDeleteOperation = e.changes.some(change =>
-        change.text === '' && change.rangeLength > 0
-    );
-
-    if (isDeleteOperation) {
-        // refresh highlights after deletion
-        this.runDelayer.cancel();
-        this._run();
-        return;
-    }
-
-    // fallback to original behavior
-    if (!matchesScheme(this.model.uri, 'output')) {
-        this._stopAll();
-    }
-}));
+			// fallback to original behavior
+			if (!matchesScheme(this.model.uri, 'output')) {
+				this._stopAll();
+			}
+		}));
 
 
-		//this.toUnhook.add(editor.onDidChangeModelContent((e) => {
-		//	if (!matchesScheme(this.model.uri, 'output')) {
-		//		this._stopAll();
-		//	}
-	//	}));
+
+
 		this.toUnhook.add(editor.onDidChangeModel((e) => {
 			if (!e.newModelUrl && e.oldModelUrl) {
 				this._stopSingular();

--- a/src/vs/editor/contrib/wordHighlighter/browser/wordHighlighter.ts
+++ b/src/vs/editor/contrib/wordHighlighter/browser/wordHighlighter.ts
@@ -284,11 +284,51 @@ class WordHighlighter {
 				this.runDelayer.trigger(() => { this._run(); });
 			}
 		}));
+
 		this.toUnhook.add(editor.onDidChangeModelContent((e) => {
-			if (!matchesScheme(this.model.uri, 'output')) {
-				this._stopAll();
-			}
-		}));
+    // detect delete operation (text removed)
+    const isDeleteOperation = e.changes.some(change =>
+        change.text === '' && change.rangeLength > 0
+    );
+
+    if (isDeleteOperation) {
+        // refresh highlights after deletion
+        this.runDelayer.cancel();
+        this._run();
+        return;
+    }
+
+    // fallback to original behavior
+    if (!matchesScheme(this.model.uri, 'output')) {
+        this._stopAll();
+    }
+}));
+
+this.toUnhook.add(editor.onDidChangeModelContent((e) => {
+    // detect delete operation (text removed)
+    const isDeleteOperation = e.changes.some(change =>
+        change.text === '' && change.rangeLength > 0
+    );
+
+    if (isDeleteOperation) {
+        // refresh highlights after deletion
+        this.runDelayer.cancel();
+        this._run();
+        return;
+    }
+
+    // fallback to original behavior
+    if (!matchesScheme(this.model.uri, 'output')) {
+        this._stopAll();
+    }
+}));
+
+
+		//this.toUnhook.add(editor.onDidChangeModelContent((e) => {
+		//	if (!matchesScheme(this.model.uri, 'output')) {
+		//		this._stopAll();
+		//	}
+	//	}));
 		this.toUnhook.add(editor.onDidChangeModel((e) => {
 			if (!e.newModelUrl && e.oldModelUrl) {
 				this._stopSingular();


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
This PR fixes issue #279528.

Problem:
When deleting a line containing the highlighted word, all symbol highlights disappear.
This happens because onDidChangeCursorPosition does not fire during line deletion,
so the highlighter never recomputes occurrences.

Fix:
Added logic in onDidChangeModelContent to detect deletion operations
(change.text === '' && change.rangeLength > 0), and trigger _run()
to refresh the occurrence highlighting.

This ensures that remaining occurrences stay highlighted even after one
occurrence is deleted, matching expected behavior.

