### PR TITLE
Fix terminal search overwriting clipboardFix terminal search overwriting clipboard

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/find/browser/terminalFindWidget.ts
+++ b/src/vs/workbench/contrib/terminalContrib/find/browser/terminalFindWidget.ts
@@ -115,6 +115,11 @@ export class TerminalFindWidget extends SimpleFindWidget {
 	}
 
 	override reveal(): void {
+		// Disable copy-on-selection for search-related selections to prevent overwriting clipboard
+		if (!this._overrideCopyOnSelectionDisposable && TerminalClipboardContribution.get(this._instance)?.overrideCopyOnSelection) {
+			this._overrideCopyOnSelectionDisposable = TerminalClipboardContribution.get(this._instance)?.overrideCopyOnSelection(false);
+		}
+
 		const initialInput = this._instance.hasSelection() && !this._instance.selection!.includes('\n') ? this._instance.selection : undefined;
 		const inputValue = initialInput ?? this.inputValue;
 		const xterm = this._instance.xterm;
@@ -132,6 +137,11 @@ export class TerminalFindWidget extends SimpleFindWidget {
 	}
 
 	override show() {
+		// Disable copy-on-selection for search-related selections to prevent overwriting clipboard
+		if (!this._overrideCopyOnSelectionDisposable && TerminalClipboardContribution.get(this._instance)?.overrideCopyOnSelection) {
+			this._overrideCopyOnSelectionDisposable = TerminalClipboardContribution.get(this._instance)?.overrideCopyOnSelection(false);
+		}
+
 		const initialInput = this._instance.hasSelection() && !this._instance.selection!.includes('\n') ? this._instance.selection : undefined;
 		super.show(initialInput);
 		this._findWidgetVisible.set(true);
@@ -140,6 +150,9 @@ export class TerminalFindWidget extends SimpleFindWidget {
 	override hide() {
 		super.hide();
 		this._findWidgetVisible.reset();
+		// Re-enable copy-on-selection when find widget is hidden
+		this._overrideCopyOnSelectionDisposable?.dispose();
+		this._overrideCopyOnSelectionDisposable = undefined;
 		this._instance.focus(true);
 		this._instance.xterm?.clearSearchDecorations();
 	}


### PR DESCRIPTION
Fixes #272894

## Summary
When searching in the terminal with 'copy on selection' enabled, the search term was being automatically copied to the clipboard, overwriting any previously copied content.

## Root Cause
The search creates a selection which triggers the `onSelectionChange` event handler in the clipboard contribution. This handler automatically copies the selection when the 'copy on selection' setting is enabled, without distinguishing between user-initiated and programmatic selections.

## Solution
Extended the existing copy-on-selection override mechanism to be active whenever the find widget is shown, not just when it has focus. The override is now:
- Set when `show()` or `reveal()` is called
- Cleared when `hide()` is called

This prevents search-related selections from triggering clipboard copies while preserving normal copy-on-selection behavior for user-initiated selections.

## Testing
Manually tested with the following scenarios:
1. Search in terminal with 'copy on selection' enabled
2. Copy other content to clipboard
3. Interact with terminal (paste, close find widget)
4. Verify clipboard contains the manually copied content, not the search termWhen searching in the terminal with 'copy on selection' enabled, the search term was being automatically copied to the clipboard, overwriting any previously copied content. This happened because the search creates a selection which triggers the onSelectionChange event handler.

This fix extends the existing copy-on-selection override mechanism to be active whenever the find widget is shown, not just when it has focus. The override is now set when show() or reveal() is called and cleared when hide() is called.

Fixes #272894

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
