### PR TITLE
fix: update mathInlineRegExp to correctly handle $(a+b)^2$

### DIFF
--- a/src/vs/workbench/contrib/markdown/common/markedKatexExtension.ts
+++ b/src/vs/workbench/contrib/markdown/common/markedKatexExtension.ts
@@ -5,7 +5,7 @@
 import type * as marked from '../../../../base/common/marked/marked.js';
 import { htmlAttributeEncodeValue } from '../../../../base/common/strings.js';
 
-export const mathInlineRegExp = /(?<![a-zA-Z0-9])(?<dollars>\${1,2})(?!\.)(?!\()(?!["'#])((?:\\.|[^\\\n])*?(?:\\.|[^\\\n\$]))\k<dollars>(?![a-zA-Z0-9])/; // Non-standard, but ensure opening $ is not preceded and closing $ is not followed by word/number characters, opening $ not followed by ., (, ", ', or #
+export const mathInlineRegExp = /(?<![a-zA-Z0-9])(?<dollars>\${1,2})(?!\.|\(["'])((?:\\.|[^\\\n])*?(?:\\.|[^\\\n\$]))\k<dollars>(?![a-zA-Z0-9])/; // Non-standard, but ensure opening $ is not preceded and closing $ is not followed by word/number characters, opening $ not followed by ., (", ('
 export const katexContainerClassName = 'vscode-katex-container';
 export const katexContainerLatexAttributeName = 'data-latex';
 


### PR DESCRIPTION
fix: update mathInlineRegExp to correctly handle `$(a+b)^2$`. Fix #279080

Allowing `$(` should be fine, since it’s very common in mathematical expressions. It should be enough to block only `$.`, `$("` and `$('`.

cc: @mjbvz 

related to #269635