### PR TITLE
fix bug where terminal profiles with `${workspaceFolder}` do not resolve in vscode remote workspaces

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/baseTerminalBackend.ts
+++ b/src/vs/workbench/contrib/terminal/browser/baseTerminalBackend.ts
@@ -5,7 +5,6 @@
 
 import { Emitter } from '../../../../base/common/event.js';
 import { Disposable } from '../../../../base/common/lifecycle.js';
-import { Schemas } from '../../../../base/common/network.js';
 import { isNumber, isObject } from '../../../../base/common/types.js';
 import { localize } from '../../../../nls.js';
 import { ICrossVersionSerializedTerminalState, IPtyHostController, ISerializedTerminalState, ITerminalLogService } from '../../../../platform/terminal/common/terminal.js';
@@ -88,7 +87,7 @@ export abstract class BaseTerminalBackend extends Disposable {
 			if (e.workspaceId !== this._workspaceContextService.getWorkspace().id) {
 				return;
 			}
-			const activeWorkspaceRootUri = historyService.getLastActiveWorkspaceRoot(Schemas.file);
+			const activeWorkspaceRootUri = historyService.getLastActiveWorkspaceRoot();
 			const lastActiveWorkspaceRoot = activeWorkspaceRootUri ? this._workspaceContextService.getWorkspaceFolder(activeWorkspaceRootUri) ?? undefined : undefined;
 			const resolveCalls: Promise<string>[] = e.originalText.map(t => {
 				return configurationResolverService.resolveAsync(lastActiveWorkspaceRoot, t);


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Fix bug where terminal profiles with `${workspaceFolder}` do not resolve in vscode remote workspaces.

Refer to #280104 for bug repro details.


- When discovering new profiles the `PtsHostService` asks the web view to resolve variables
https://github.com/microsoft/vscode/blob/c15e31ffcde9fc40449c00915d75be7415b6bab9/src/vs/platform/terminal/node/ptyHostService.ts#L420-L424

- Web view listener uses `Schemas.file` filter when resolving variables. This fails because in this case the workspace root is not a `file:` uri it is a `vscode-remote:` uri.
https://github.com/microsoft/vscode/blob/c15e31ffcde9fc40449c00915d75be7415b6bab9/src/vs/workbench/contrib/terminal/browser/baseTerminalBackend.ts#L86-L98

Fixes #280104