### PR TITLE
edits: interim nicer play with background sessions

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/actions/chatActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatActions.ts
@@ -374,7 +374,7 @@ abstract class OpenChatGlobalAction extends Action2 {
 
 		if (switchToMode) {
 			const model = chatWidget.viewModel?.model;
-			const chatModeCheck = model ? await instaService.invokeFunction(handleModeSwitch, currentMode, switchToMode.kind, model.getRequests().length ?? 0, model) : { needToClearSession: false };
+			const chatModeCheck = model ? await instaService.invokeFunction(handleModeSwitch, currentMode, switchToMode.kind, model.getRequests().length, model) : { needToClearSession: false };
 			if (!chatModeCheck) {
 				return;
 			}

--- a/src/vs/workbench/contrib/chat/browser/actions/chatActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatActions.ts
@@ -58,8 +58,8 @@ import { SCMHistoryItemChangeRangeContentProvider, ScmHistoryItemChangeRangeUriF
 import { ISCMService } from '../../../scm/common/scm.js';
 import { IChatAgentResult, IChatAgentService } from '../../common/chatAgents.js';
 import { ChatContextKeys } from '../../common/chatContextKeys.js';
-import { IChatEditingSession, ModifiedFileEntryState } from '../../common/chatEditingService.js';
-import { IChatResponseModel } from '../../common/chatModel.js';
+import { ModifiedFileEntryState } from '../../common/chatEditingService.js';
+import { IChatModel, IChatResponseModel } from '../../common/chatModel.js';
 import { ChatMode, IChatMode, IChatModeService } from '../../common/chatModes.js';
 import { IChatDetail, IChatService } from '../../common/chatService.js';
 import { IChatSessionItem, IChatSessionsService, localChatSessionType } from '../../common/chatSessionsService.js';
@@ -73,7 +73,7 @@ import { ILanguageModelToolsConfirmationService } from '../../common/languageMod
 import { ILanguageModelToolsService } from '../../common/languageModelToolsService.js';
 import { ChatViewId, ChatViewPaneTarget, IChatWidget, IChatWidgetService } from '../chat.js';
 import { IChatEditorOptions } from '../chatEditor.js';
-import { ChatEditorInput, shouldShowClearEditingSessionConfirmation, showClearEditingSessionConfirmation } from '../chatEditorInput.js';
+import { ChatEditorInput, showClearEditingSessionConfirmation } from '../chatEditorInput.js';
 import { ChatViewPane } from '../chatViewPane.js';
 import { convertBufferToScreenshotVariable } from '../contrib/screenshot.js';
 import { clearChatEditor } from './chatClear.js';
@@ -373,9 +373,8 @@ abstract class OpenChatGlobalAction extends Action2 {
 		const currentMode = chatWidget.input.currentModeKind;
 
 		if (switchToMode) {
-			const editingSession = chatWidget.viewModel?.model.editingSession;
-			const requestCount = chatWidget.viewModel?.model.getRequests().length ?? 0;
-			const chatModeCheck = await instaService.invokeFunction(handleModeSwitch, currentMode, switchToMode.kind, requestCount, editingSession);
+			const model = chatWidget.viewModel?.model;
+			const chatModeCheck = model ? await instaService.invokeFunction(handleModeSwitch, currentMode, switchToMode.kind, model.getRequests().length ?? 0, model) : { needToClearSession: false };
 			if (!chatModeCheck) {
 				return;
 			}
@@ -1002,12 +1001,9 @@ export function registerChatActions() {
 				return;
 			}
 
-			const editingSession = view.widget.viewModel.model.editingSession;
-			if (editingSession) {
-				const phrase = localize('switchChat.confirmPhrase', "Switching chats will end your current edit session.");
-				if (!await handleCurrentEditingSession(editingSession, phrase, dialogService)) {
-					return;
-				}
+			const phrase = localize('switchChat.confirmPhrase', "Switching chats will end your current edit session.");
+			if (!await handleCurrentEditingSession(view.widget.viewModel.model, phrase, dialogService)) {
+				return;
 			}
 
 			// Check if there are any non-local chat session item providers registered
@@ -1715,12 +1711,8 @@ export class CopilotTitleBarMenuRendering extends Disposable implements IWorkben
 /**
  * Returns whether we can continue clearing/switching chat sessions, false to cancel.
  */
-export async function handleCurrentEditingSession(currentEditingSession: IChatEditingSession, phrase: string | undefined, dialogService: IDialogService): Promise<boolean> {
-	if (shouldShowClearEditingSessionConfirmation(currentEditingSession)) {
-		return showClearEditingSessionConfirmation(currentEditingSession, dialogService, { messageOverride: phrase });
-	}
-
-	return true;
+export async function handleCurrentEditingSession(model: IChatModel, phrase: string | undefined, dialogService: IDialogService): Promise<boolean> {
+	return showClearEditingSessionConfirmation(model, dialogService, { messageOverride: phrase });
 }
 
 /**
@@ -1731,9 +1723,9 @@ export async function handleModeSwitch(
 	fromMode: ChatModeKind,
 	toMode: ChatModeKind,
 	requestCount: number,
-	editingSession: IChatEditingSession | undefined,
+	model: IChatModel | undefined,
 ): Promise<false | { needToClearSession: boolean }> {
-	if (!editingSession || fromMode === toMode) {
+	if (!model?.editingSession || fromMode === toMode) {
 		return { needToClearSession: false };
 	}
 
@@ -1744,10 +1736,10 @@ export async function handleModeSwitch(
 		// If not using edits2 and switching into or out of edit mode, ask to discard the session
 		const phrase = localize('switchMode.confirmPhrase', "Switching agents will end your current edit session.");
 
-		const currentEdits = editingSession.entries.get();
+		const currentEdits = model.editingSession.entries.get();
 		const undecidedEdits = currentEdits.filter((edit) => edit.state.get() === ModifiedFileEntryState.Modified);
 		if (undecidedEdits.length > 0) {
-			if (!await handleCurrentEditingSession(editingSession, phrase, dialogService)) {
+			if (!await handleCurrentEditingSession(model, phrase, dialogService)) {
 				return false;
 			}
 

--- a/src/vs/workbench/contrib/chat/browser/actions/chatExecuteActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatExecuteActions.ts
@@ -701,7 +701,7 @@ class SendToNewChatAction extends Action2 {
 		}
 
 		if (widget.viewModel?.model) {
-			if (!(await handleCurrentEditingSession(widget.viewModel?.model, undefined, dialogService))) {
+			if (!(await handleCurrentEditingSession(widget.viewModel.model, undefined, dialogService))) {
 				return;
 			}
 		}

--- a/src/vs/workbench/contrib/chat/browser/actions/chatExecuteActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatExecuteActions.ts
@@ -344,7 +344,7 @@ class ToggleChatModeAction extends Action2 {
 			return;
 		}
 
-		const chatModeCheck = await instaService.invokeFunction(handleModeSwitch, widget.input.currentModeKind, switchToMode.kind, requestCount, widget.viewModel?.model.editingSession);
+		const chatModeCheck = await instaService.invokeFunction(handleModeSwitch, widget.input.currentModeKind, switchToMode.kind, requestCount, widget.viewModel?.model);
 		if (!chatModeCheck) {
 			return;
 		}
@@ -700,9 +700,8 @@ class SendToNewChatAction extends Action2 {
 			chatService.cancelCurrentRequestForSession(widget.viewModel.sessionResource);
 		}
 
-		const editingSession = widget.viewModel?.model.editingSession;
-		if (editingSession) {
-			if (!(await handleCurrentEditingSession(editingSession, undefined, dialogService))) {
+		if (widget.viewModel?.model) {
+			if (!(await handleCurrentEditingSession(widget.viewModel?.model, undefined, dialogService))) {
 				return;
 			}
 		}

--- a/src/vs/workbench/contrib/chat/browser/actions/chatNewActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatNewActions.ts
@@ -128,7 +128,8 @@ export function registerNewChatActions() {
 			const accessibilitySignalService = accessor.get(IAccessibilitySignalService);
 			const dialogService = accessor.get(IDialogService);
 
-			if (editingSession && !(await handleCurrentEditingSession(editingSession, undefined, dialogService))) {
+			const model = widget.viewModel?.model;
+			if (model && !(await handleCurrentEditingSession(model, undefined, dialogService))) {
 				return;
 			}
 

--- a/src/vs/workbench/contrib/chat/browser/chatEditorInput.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditorInput.ts
@@ -146,7 +146,7 @@ export class ChatEditorInput extends EditorInput implements IEditorCloseHandler 
 
 		const titleOverride = nls.localize('chatEditorConfirmTitle', "Close Chat Editor");
 		const messageOverride = nls.localize('chat.startEditing.confirmation.pending.message.default', "Closing the chat editor will end your current edit session.");
-		const result = await showClearEditingSessionConfirmation(this.model.editingSession, this.dialogService, { titleOverride, messageOverride });
+		const result = await showClearEditingSessionConfirmation(this.model, this.dialogService, { titleOverride, messageOverride });
 		return result ? ConfirmResult.SAVE : ConfirmResult.CANCEL;
 	}
 
@@ -428,7 +428,12 @@ export class ChatEditorInputSerializer implements IEditorSerializer {
 	}
 }
 
-export async function showClearEditingSessionConfirmation(editingSession: IChatEditingSession, dialogService: IDialogService, options?: IClearEditingSessionConfirmationOptions): Promise<boolean> {
+export async function showClearEditingSessionConfirmation(model: IChatModel, dialogService: IDialogService, options?: IClearEditingSessionConfirmationOptions): Promise<boolean> {
+	if (!model.editingSession || model.willKeepAlive) {
+		return true; // save to dispose without confirmation
+	}
+
+	const editingSession = model.editingSession;
 	const defaultPhrase = nls.localize('chat.startEditing.confirmation.pending.message.default1', "Starting a new chat will end your current edit session.");
 	const defaultTitle = nls.localize('chat.startEditing.confirmation.title', "Start new chat?");
 	const phrase = options?.messageOverride ?? defaultPhrase;
@@ -436,6 +441,9 @@ export async function showClearEditingSessionConfirmation(editingSession: IChatE
 
 	const currentEdits = editingSession.entries.get();
 	const undecidedEdits = currentEdits.filter((edit) => edit.state.get() === ModifiedFileEntryState.Modified);
+	if (!undecidedEdits.length) {
+		return true; // No pending edits, can just continue
+	}
 
 	const { result } = await dialogService.prompt({
 		title,

--- a/src/vs/workbench/contrib/chat/browser/chatEditorInput.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditorInput.ts
@@ -430,7 +430,7 @@ export class ChatEditorInputSerializer implements IEditorSerializer {
 
 export async function showClearEditingSessionConfirmation(model: IChatModel, dialogService: IDialogService, options?: IClearEditingSessionConfirmationOptions): Promise<boolean> {
 	if (!model.editingSession || model.willKeepAlive) {
-		return true; // save to dispose without confirmation
+		return true; // safe to dispose without confirmation
 	}
 
 	const editingSession = model.editingSession;

--- a/src/vs/workbench/contrib/chat/browser/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatWidget.ts
@@ -2501,7 +2501,7 @@ export class ChatWidget extends Disposable implements IChatWidget {
 			const agent = this.chatModeService.findModeByName(agentName);
 			if (agent) {
 				if (currentAgent.kind !== agent.kind) {
-					const chatModeCheck = await this.instantiationService.invokeFunction(handleModeSwitch, currentAgent.kind, agent.kind, this.viewModel?.model.getRequests().length ?? 0, this.viewModel?.model.editingSession);
+					const chatModeCheck = await this.instantiationService.invokeFunction(handleModeSwitch, currentAgent.kind, agent.kind, this.viewModel?.model.getRequests().length ?? 0, this.viewModel?.model);
 					if (!chatModeCheck) {
 						return;
 					}

--- a/src/vs/workbench/contrib/chat/common/chatModel.ts
+++ b/src/vs/workbench/contrib/chat/common/chatModel.ts
@@ -29,7 +29,7 @@ import { ILogService } from '../../../../platform/log/common/log.js';
 import { CellUri, ICellEditOperation } from '../../notebook/common/notebookCommon.js';
 import { migrateLegacyTerminalToolSpecificData } from './chat.js';
 import { IChatAgentCommand, IChatAgentData, IChatAgentResult, IChatAgentService, UserSelectedTools, reviveSerializedAgent } from './chatAgents.js';
-import { IChatEditingService, IChatEditingSession } from './chatEditingService.js';
+import { IChatEditingService, IChatEditingSession, ModifiedFileEntryState } from './chatEditingService.js';
 import { ChatRequestTextPart, IParsedChatRequest, reviveParsedChatRequest } from './chatParserTypes.js';
 import { ChatAgentVoteDirection, ChatAgentVoteDownReason, ChatResponseClearToPreviousToolInvocationReason, ElicitationState, IChatAgentMarkdownContentWithVulnerability, IChatClearToPreviousToolInvocation, IChatCodeCitation, IChatCommandButton, IChatConfirmation, IChatContentInlineReference, IChatContentReference, IChatEditingSessionAction, IChatElicitationRequest, IChatElicitationRequestSerialized, IChatExtensionsContent, IChatFollowup, IChatLocationData, IChatMarkdownContent, IChatMcpServersStarting, IChatModelReference, IChatMultiDiffData, IChatNotebookEdit, IChatPrepareToolInvocationPart, IChatProgress, IChatProgressMessage, IChatPullRequestContent, IChatResponseCodeblockUriPart, IChatResponseProgressFileTreeData, IChatService, IChatSessionContext, IChatTask, IChatTaskSerialized, IChatTextEdit, IChatThinkingPart, IChatToolInvocation, IChatToolInvocationSerialized, IChatTreeData, IChatUndoStop, IChatUsedContext, IChatWarningMessage, isIUsedContext } from './chatService.js';
 import { LocalChatSessionUri } from './chatUri.js';
@@ -1168,6 +1168,8 @@ export interface IChatModel extends IDisposable {
 	readonly inputModel: IInputModel;
 	readonly hasRequests: boolean;
 	readonly lastRequest: IChatRequestModel | undefined;
+	/** Whether this model will be kept alive while it is running or has edits */
+	readonly willKeepAlive: boolean;
 	getRequests(): IChatRequestModel[];
 	setCheckpoint(requestId: string | undefined): void;
 
@@ -1252,6 +1254,11 @@ export interface ISerializableChatData2 extends ISerializableChatData1 {
 export interface ISerializableChatData3 extends Omit<ISerializableChatData2, 'version' | 'computedTitle'> {
 	version: 3;
 	customTitle: string | undefined;
+	/**
+	 * Whether the session had pending edits when it was stored.
+	 * todo@connor4312 This will be cleaned up with the globalization of edits.
+	 */
+	hasPendingEdits?: boolean;
 	/** Current draft input state (added later, fully backwards compatible) */
 	inputState?: ISerializableChatModelInputState;
 }
@@ -1644,13 +1651,18 @@ export class ChatModel extends Disposable implements IChatModel {
 		return this._canUseTools;
 	}
 
+	private _disableBackgroundKeepAlive: boolean;
+	get willKeepAlive(): boolean {
+		return !this._disableBackgroundKeepAlive;
+	}
+
 	constructor(
 		initialData: ISerializableChatData | IExportableChatData | undefined,
 		initialModelProps: { initialLocation: ChatAgentLocation; canUseTools: boolean; resource?: URI; sessionId?: string; disableBackgroundKeepAlive?: boolean },
 		@ILogService private readonly logService: ILogService,
 		@IChatAgentService private readonly chatAgentService: IChatAgentService,
 		@IChatEditingService private readonly chatEditingService: IChatEditingService,
-		@IChatService chatService: IChatService,
+		@IChatService private readonly chatService: IChatService,
 	) {
 		super();
 
@@ -1663,6 +1675,7 @@ export class ChatModel extends Disposable implements IChatModel {
 		this._isImported = !!initialData && isValidExportedData && !isValidFullData;
 		this._sessionId = (isValidFullData && initialData.sessionId) || initialModelProps.sessionId || generateUuid();
 		this._sessionResource = initialModelProps.resource ?? LocalChatSessionUri.forSession(this._sessionId);
+		this._disableBackgroundKeepAlive = initialModelProps.disableBackgroundKeepAlive ?? false;
 
 		this._requests = initialData ? this._deserialize(initialData) : [];
 		this._timestamp = (isValidFullData && initialData.creationDate) || Date.now();
@@ -1737,6 +1750,20 @@ export class ChatModel extends Disposable implements IChatModel {
 					? this.chatEditingService.startOrContinueGlobalEditingSession(this)
 					: this.chatEditingService.createEditingSession(this)
 		);
+
+		if (!this._disableBackgroundKeepAlive) {
+			// todo@connor4312: hold onto a reference so background sessions don't
+			// trigger early disposal. This will be cleaned up with the globalization of edits.
+			const selfRef = this._register(new MutableDisposable<IChatModelReference>());
+			this._register(autorun(r => {
+				const hasModified = session.entries.read(r).some(e => e.state.read(r) === ModifiedFileEntryState.Modified);
+				if (hasModified && !selfRef.value) {
+					selfRef.value = this.chatService.getActiveSessionReference(this._sessionResource);
+				} else if (!hasModified && selfRef.value) {
+					selfRef.clear();
+				}
+			}));
+		}
 
 		this._register(autorun(reader => {
 			this._setDisabledRequests(session.requestDisablement.read(reader));
@@ -2122,6 +2149,7 @@ export class ChatModel extends Disposable implements IChatModel {
 			creationDate: this._timestamp,
 			lastMessageDate: this._lastMessageDate,
 			customTitle: this._customTitle,
+			hasPendingEdits: !!(this._editingSession?.entries.get().some(e => e.state.get() === ModifiedFileEntryState.Modified)),
 			// Only include inputState if it has been set
 			...(inputState ? {
 				inputState: {

--- a/src/vs/workbench/contrib/chat/common/chatServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/chatServiceImpl.ts
@@ -30,6 +30,7 @@ import { IExtensionService } from '../../../services/extensions/common/extension
 import { InlineChatConfigKeys } from '../../inlineChat/common/inlineChat.js';
 import { IMcpService } from '../../mcp/common/mcpTypes.js';
 import { IChatAgentCommand, IChatAgentData, IChatAgentHistoryEntry, IChatAgentRequest, IChatAgentResult, IChatAgentService } from './chatAgents.js';
+import { chatEditingSessionIsReady } from './chatEditingService.js';
 import { ChatModel, ChatRequestModel, ChatRequestRemovalReason, IChatModel, IChatRequestModel, IChatRequestVariableData, IChatResponseModel, IExportableChatData, ISerializableChatData, ISerializableChatDataIn, ISerializableChatsData, normalizeSerializableChatData, toChatHistoryContent, updateRanges } from './chatModel.js';
 import { ChatModelStore, IStartSessionProps } from './chatModelStore.js';
 import { chatAgentLeader, ChatRequestAgentPart, ChatRequestAgentSubcommandPart, ChatRequestSlashCommandPart, ChatRequestTextPart, chatSubcommandLeader, getPromptText, IParsedChatRequest } from './chatParserTypes.js';
@@ -180,7 +181,9 @@ export class ChatService extends Disposable implements IChatService {
 
 		// When using file storage, populate _persistedSessions with session metadata from the index
 		// This ensures that getPersistedSessionTitle() can find titles for inactive sessions
-		this.initializePersistedSessionsFromFileStorage();
+		this.initializePersistedSessionsFromFileStorage().then(() => {
+			this.reviveSessionsWithEdits();
+		});
 
 		this._register(storageService.onWillSaveState(() => this.saveState()));
 
@@ -302,6 +305,25 @@ export class ChatService extends Disposable implements IChatService {
 		return transferred;
 	}
 
+	/**
+	 * todo@connor4312 This will be cleaned up with the globalization of edits.
+	 */
+	private async reviveSessionsWithEdits(): Promise<void> {
+		await Promise.all(Object.values(this._persistedSessions).map(async session => {
+			if (!session.hasPendingEdits) {
+				return;
+			}
+
+			const sessionResource = LocalChatSessionUri.forSession(session.sessionId);
+			const sessionRef = await this.getOrRestoreSession(sessionResource);
+			if (sessionRef?.object.editingSession) {
+				await chatEditingSessionIsReady(sessionRef.object.editingSession);
+				// the session will hold a self-reference as long as there are modified files
+				sessionRef.dispose();
+			}
+		}));
+	}
+
 	private async initializePersistedSessionsFromFileStorage(): Promise<void> {
 
 		const index = await this._chatSessionStore.getIndex();
@@ -322,6 +344,7 @@ export class ChatService extends Disposable implements IChatService {
 					requests: [], // Empty requests array - this is just for title lookup
 					responderUsername: '',
 					responderAvatarIconUri: undefined,
+					hasPendingEdits: metadata.hasPendingEdits,
 				};
 
 				this._persistedSessions[sessionId] = minimalSession;

--- a/src/vs/workbench/contrib/chat/common/chatSessionStore.ts
+++ b/src/vs/workbench/contrib/chat/common/chatSessionStore.ts
@@ -20,6 +20,7 @@ import { ITelemetryService } from '../../../../platform/telemetry/common/telemet
 import { IUserDataProfilesService } from '../../../../platform/userDataProfile/common/userDataProfile.js';
 import { IWorkspaceContextService } from '../../../../platform/workspace/common/workspace.js';
 import { ILifecycleService } from '../../../services/lifecycle/common/lifecycle.js';
+import { ModifiedFileEntryState } from './chatEditingService.js';
 import { ChatModel, IChatModelInputState, ISerializableChatData, ISerializableChatDataIn, ISerializableChatsData, normalizeSerializableChatData } from './chatModel.js';
 import { ChatAgentLocation } from './constants.js';
 
@@ -388,6 +389,7 @@ export interface IChatSessionEntryMetadata {
 	title: string;
 	lastMessageDate: number;
 	initialLocation?: ChatAgentLocation;
+	hasPendingEdits?: boolean;
 
 	/**
 	 * This only exists because the migrated data from the storage service had empty sessions persisted, and it's impossible to know which ones are
@@ -447,6 +449,7 @@ function getSessionMetadata(session: ChatModel | ISerializableChatData): IChatSe
 		title: title || localize('newChat', "New Chat"),
 		lastMessageDate: session.lastMessageDate,
 		initialLocation: session.initialLocation,
+		hasPendingEdits: session instanceof ChatModel ? (session.editingSession?.entries.get().some(e => e.state.get() === ModifiedFileEntryState.Modified)) : false,
 		isEmpty: session instanceof ChatModel ? session.getRequests().length === 0 : session.requests.length === 0
 	};
 }

--- a/src/vs/workbench/contrib/chat/test/common/chatService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/chatService.test.ts
@@ -7,7 +7,7 @@ import assert from 'assert';
 import { Event } from '../../../../../base/common/event.js';
 import { MarkdownString } from '../../../../../base/common/htmlContent.js';
 import { DisposableStore } from '../../../../../base/common/lifecycle.js';
-import { observableValue } from '../../../../../base/common/observable.js';
+import { constObservable, observableValue } from '../../../../../base/common/observable.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { assertSnapshot } from '../../../../../base/test/common/snapshot.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
@@ -172,6 +172,7 @@ suite('ChatService', () => {
 			override startOrContinueGlobalEditingSession(): IChatEditingSession {
 				return {
 					requestDisablement: observableValue('requestDisablement', []),
+					entries: constObservable([]),
 					dispose: () => { }
 				} as unknown as IChatEditingSession;
 			}

--- a/src/vs/workbench/contrib/chat/test/common/mockChatModel.ts
+++ b/src/vs/workbench/contrib/chat/test/common/mockChatModel.ts
@@ -24,6 +24,7 @@ export class MockChatModel extends Disposable implements IChatModel {
 	readonly inputPlaceholder = undefined;
 	readonly editingSession = undefined;
 	readonly checkpoint = undefined;
+	readonly willKeepAlive = true;
 	readonly inputModel: IInputModel = {
 		state: observableValue('inputModelState', undefined),
 		setState: () => { },


### PR DESCRIPTION
- Keep a chat model alive (when enabled) as long as edits are pending
- Eagerly revive chat sessions that have pending edits on boot
- Disable the "Keep/Undo" dialog when closing the editor if the session
  would be kept alive.

Ref #278654 / #277318

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
