### PR TITLE
Migrate AsyncIterableObject to AsyncIterableProducer

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/actions/codeBlockOperations.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/codeBlockOperations.ts
@@ -2,7 +2,7 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import { AsyncIterableObject } from '../../../../../base/common/async.js';
+import { AsyncIterableObject, AsyncIterableProducer } from '../../../../../base/common/async.js';
 import { VSBuffer } from '../../../../../base/common/buffer.js';
 import { CancellationToken, CancellationTokenSource } from '../../../../../base/common/cancellation.js';
 import { CharCode } from '../../../../../base/common/charCode.js';
@@ -338,7 +338,7 @@ export class ApplyCodeBlockOperation {
 	}
 
 	private getTextEdits(codeBlock: ICodeMapperCodeBlock, chatSessionResource: URI | undefined, token: CancellationToken): AsyncIterable<TextEdit[]> {
-		return new AsyncIterableObject<TextEdit[]>(async executor => {
+		return new AsyncIterableProducer<TextEdit[]>(async executor => {
 			const request: ICodeMapperRequest = {
 				codeBlocks: [codeBlock],
 				chatSessionResource,
@@ -359,7 +359,7 @@ export class ApplyCodeBlockOperation {
 	}
 
 	private getNotebookEdits(codeBlock: ICodeMapperCodeBlock, chatSessionResource: URI | undefined, token: CancellationToken): AsyncIterable<[URI, TextEdit[]] | ICellEditOperation[]> {
-		return new AsyncIterableObject<[URI, TextEdit[]] | ICellEditOperation[]>(async executor => {
+		return new AsyncIterableProducer<[URI, TextEdit[]] | ICellEditOperation[]>(async executor => {
 			const request: ICodeMapperRequest = {
 				codeBlocks: [codeBlock],
 				chatSessionResource,


### PR DESCRIPTION
Migrated usages of AsyncIterableObject to AsyncIterableProducer to prevent memory leaks in single-consumption scenarios.

- Updated [codeBlockOperations.ts](cci:7://file:///Users/rohitdahiya/vscode/vscode/src/vs/workbench/contrib/chat/browser/actions/codeBlockOperations.ts:0:0-0:0) to use [AsyncIterableProducer](cci:2://file:///Users/rohitdahiya/vscode/vscode/src/vs/base/common/async.ts:2368:0-2524:1) for text and notebook edits.
- Updated [extHostTerminalShellIntegration.ts](cci:7://file:///Users/rohitdahiya/vscode/vscode/src/vs/workbench/api/common/extHostTerminalShellIntegration.ts:0:0-0:0) to use `AsyncIterableProducer` for shell execution data streams, ensuring data is not buffered indefinitely.
