### PR TITLE
Fix breakpoint range calculation

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/breakpointsView.ts
+++ b/src/vs/workbench/contrib/debug/browser/breakpointsView.ts
@@ -1613,11 +1613,11 @@ abstract class MemoryBreakpointAction extends Action2 {
 
 		const start = BigInt(startStr);
 		const end = BigInt(endStr);
-		if (start > end) {
-			return { error: localize('dataBreakpointAddrOrder', 'End ({1}) should be greater than Start ({0})', startStr, endStr) };
-		}
 		const address = `0x${start.toString(16)}`;
 		if (sign === '-') {
+			if (start > end) {
+				return { error: localize('dataBreakpointAddrOrder', 'End ({1}) should be greater than Start ({0})', startStr, endStr) };
+			}
 			return { address, bytes: Number(end - start) };
 		}
 

--- a/src/vs/workbench/contrib/debug/browser/breakpointsView.ts
+++ b/src/vs/workbench/contrib/debug/browser/breakpointsView.ts
@@ -1613,9 +1613,12 @@ abstract class MemoryBreakpointAction extends Action2 {
 
 		const start = BigInt(startStr);
 		const end = BigInt(endStr);
+		if (start > end) {
+			return { error: localize('dataBreakpointAddrOrder', 'End ({1}) should be greater than Start ({0})', startStr, endStr) };
+		}
 		const address = `0x${start.toString(16)}`;
 		if (sign === '-') {
-			return { address, bytes: Number(start - end) };
+			return { address, bytes: Number(end - start) };
 		}
 
 		return { address, bytes: Number(end) };


### PR DESCRIPTION
This patch fixes wrong `bytes` calculation for `dataBreakpointInfo` request. Also, added a check that `end` address is greater than `start` address.