### PR TITLE
Fix: Parallelize extension querying and target local server for insta…

### DIFF
--- a/src/vs/workbench/contrib/extensions/browser/extensionsActions.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionsActions.ts
@@ -2960,6 +2960,7 @@ export abstract class AbstractInstallExtensionsInServerAction extends Action {
 
 	constructor(
 		id: string,
+		private readonly serverToQuery: IExtensionManagementServer | undefined,
 		@IExtensionsWorkbenchService protected readonly extensionsWorkbenchService: IExtensionsWorkbenchService,
 		@IQuickInputService private readonly quickInputService: IQuickInputService,
 		@INotificationService private readonly notificationService: INotificationService,
@@ -2967,7 +2968,7 @@ export abstract class AbstractInstallExtensionsInServerAction extends Action {
 	) {
 		super(id);
 		this.update();
-		this.extensionsWorkbenchService.queryLocal().then(() => this.updateExtensions());
+		this.extensionsWorkbenchService.queryLocal(this.serverToQuery).then(() => this.updateExtensions());
 		this._register(this.extensionsWorkbenchService.onChange(() => {
 			if (this.extensions) {
 				this.updateExtensions();
@@ -2990,7 +2991,7 @@ export abstract class AbstractInstallExtensionsInServerAction extends Action {
 	}
 
 	private async queryExtensionsToInstall(): Promise<IExtension[]> {
-		const local = await this.extensionsWorkbenchService.queryLocal();
+		const local = await this.extensionsWorkbenchService.queryLocal(this.serverToQuery);
 		return this.getExtensionsToInstall(local);
 	}
 
@@ -3055,7 +3056,7 @@ export class InstallLocalExtensionsInRemoteAction extends AbstractInstallExtensi
 		@IFileService private readonly fileService: IFileService,
 		@ILogService private readonly logService: ILogService,
 	) {
-		super('workbench.extensions.actions.installLocalExtensionsInRemote', extensionsWorkbenchService, quickInputService, notificationService, progressService);
+		super('workbench.extensions.actions.installLocalExtensionsInRemote', extensionManagementServerService.localExtensionManagementServer || undefined, extensionsWorkbenchService, quickInputService, notificationService, progressService);
 	}
 
 	override get label(): string {
@@ -3119,7 +3120,7 @@ export class InstallRemoteExtensionsInLocalAction extends AbstractInstallExtensi
 		@IFileService private readonly fileService: IFileService,
 		@ILogService private readonly logService: ILogService,
 	) {
-		super(id, extensionsWorkbenchService, quickInputService, notificationService, progressService);
+		super(id, undefined, extensionsWorkbenchService, quickInputService, notificationService, progressService);
 	}
 
 	override get label(): string {

--- a/src/vs/workbench/contrib/extensions/browser/extensionsWorkbenchService.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionsWorkbenchService.ts
@@ -1335,30 +1335,26 @@ export class ExtensionsWorkbenchService extends Disposable implements IExtension
 			}
 		}
 
+		const promises: Promise<IExtension[]>[] = [];
 		if (this.localExtensions) {
-			try {
-				await this.localExtensions.queryInstalled(this.getProductVersion());
-			}
-			catch (error) {
+			promises.push(this.localExtensions.queryInstalled(this.getProductVersion()).catch(error => {
 				this.logService.error(error);
-			}
+				return [];
+			}));
 		}
 		if (this.remoteExtensions) {
-			try {
-				await this.remoteExtensions.queryInstalled(this.getProductVersion());
-			}
-			catch (error) {
+			promises.push(this.remoteExtensions.queryInstalled(this.getProductVersion()).catch(error => {
 				this.logService.error(error);
-			}
+				return [];
+			}));
 		}
 		if (this.webExtensions) {
-			try {
-				await this.webExtensions.queryInstalled(this.getProductVersion());
-			}
-			catch (error) {
+			promises.push(this.webExtensions.queryInstalled(this.getProductVersion()).catch(error => {
 				this.logService.error(error);
-			}
+				return [];
+			}));
 		}
+		await Promise.all(promises);
 		return this.local;
 	}
 


### PR DESCRIPTION
…ll action (#280336)

**Title:** Fix: Parallelize extension querying and target local server for install action

Investigated the issue where installing extensions on WSL2 would just spin forever. Turns out `ExtensionsWorkbenchService.queryLocal` was awaiting extension servers sequentially. If the remote server (WSL) didn't respond fast enough, it blocked the whole chain.

I've updated [queryLocal](cci:1://file:///Users/himanshumishramac198072gmail.com/.gemini/antigravity/scratch/vscode_fix/src/vs/workbench/contrib/extensions/common/extensions.ts:137:1-137:71) to fire off the queries in parallel so one slow server doesn't hold up the rest.

Also, for the "Install Local Extensions in Remote" action specifically, it was querying *all* servers for some reason. I switched it to only query the local server since that's all it actually needs. This should stop it from hanging if the remote side is acting up.

Tested locally and verified the queries are happening concurrently now.