### PR TITLE
provide output even if `executedMarker` is in scrollback, truncate the end of the output, don't keep start

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/chatTerminalCommandMirror.ts
+++ b/src/vs/workbench/contrib/terminal/browser/chatTerminalCommandMirror.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Disposable } from '../../../../base/common/lifecycle.js';
+import type { IMarker as IXtermMarker } from '@xterm/xterm';
 import type { ITerminalCommand } from '../../../../platform/terminal/common/capabilities/capabilities.js';
 import { ITerminalService, type IDetachedTerminalInstance } from './terminal.js';
 import { DetachedProcessInfo } from './detachedTerminal.js';
@@ -58,6 +59,43 @@ export class DetachedTerminalCommandMirror extends Disposable implements IDetach
 	private async _getCommandOutputAsVT(): Promise<{ text: string; lineCount: number } | undefined> {
 		const executedMarker = this._command.executedMarker;
 		const endMarker = this._command.endMarker;
+		// If there's no executedMarker, but there's an endMarker, the command marker was disposed
+		// in scrollback. Still provide output in that case.
+
+		if (executedMarker?.isDisposed && endMarker && !endMarker.isDisposed) {
+			// Fall back to the earliest retained buffer line when the execution marker has been trimmed.
+			const raw = this._xtermTerminal.raw;
+			const buffer = raw.buffer.active;
+			const offsets = [
+				-(buffer.baseY + buffer.cursorY),
+				-buffer.baseY,
+				0
+			];
+			let startMarker: IXtermMarker | undefined;
+			for (const offset of offsets) {
+				startMarker = raw.registerMarker(offset);
+				if (startMarker) {
+					break;
+				}
+			}
+			if (!startMarker || startMarker.isDisposed) {
+				return { text: '', lineCount: 0 };
+			}
+			const startLine = startMarker.line;
+			let text: string | undefined;
+			try {
+				text = await this._xtermTerminal.getRangeAsVT(startMarker, endMarker, true);
+			} finally {
+				startMarker.dispose();
+			}
+			if (!text) {
+				return { text: '', lineCount: 0 };
+			}
+			const endLine = endMarker.line - 1;
+			const lineCount = Math.max(endLine - startLine + 1, 0);
+			return { text, lineCount };
+		}
+
 		if (!executedMarker || executedMarker.isDisposed || !endMarker || endMarker.isDisposed) {
 			return undefined;
 		}

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/outputHelpers.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/outputHelpers.ts
@@ -5,6 +5,9 @@
 
 import { ITerminalInstance } from '../../../terminal/browser/terminal.js';
 import type { IMarker as IXtermMarker } from '@xterm/xterm';
+import { truncateOutputKeepingTail } from './runInTerminalHelpers.js';
+
+const MAX_OUTPUT_LENGTH = 16000;
 
 export function getOutput(instance: ITerminalInstance, startMarker?: IXtermMarker): string {
 	if (!instance.xterm || !instance.xterm.raw) {
@@ -21,8 +24,8 @@ export function getOutput(instance: ITerminalInstance, startMarker?: IXtermMarke
 	}
 
 	let output = lines.join('\n');
-	if (output.length > 16000) {
-		output = output.slice(-16000);
+	if (output.length > MAX_OUTPUT_LENGTH) {
+		output = truncateOutputKeepingTail(output, MAX_OUTPUT_LENGTH);
 	}
 	return output;
 }

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/runInTerminalHelpers.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/runInTerminalHelpers.ts
@@ -41,7 +41,20 @@ export function isFish(envShell: string, os: OperatingSystem): boolean {
 
 // Maximum output length to prevent context overflow
 const MAX_OUTPUT_LENGTH = 60000; // ~60KB limit to keep context manageable
-const TRUNCATION_MESSAGE = '\n\n[... MIDDLE OF OUTPUT TRUNCATED ...]\n\n';
+export const TRUNCATION_MESSAGE = '\n\n[... PREVIOUS OUTPUT TRUNCATED ...]\n\n';
+
+export function truncateOutputKeepingTail(output: string, maxLength: number): string {
+	if (output.length <= maxLength) {
+		return output;
+	}
+	const truncationMessageLength = TRUNCATION_MESSAGE.length;
+	if (truncationMessageLength >= maxLength) {
+		return TRUNCATION_MESSAGE.slice(TRUNCATION_MESSAGE.length - maxLength);
+	}
+	const availableLength = maxLength - truncationMessageLength;
+	const endPortion = output.slice(-availableLength);
+	return TRUNCATION_MESSAGE + endPortion;
+}
 
 export function sanitizeTerminalOutput(output: string): string {
 	let sanitized = removeAnsiEscapeCodes(output)
@@ -50,15 +63,7 @@ export function sanitizeTerminalOutput(output: string): string {
 
 	// Truncate if output is too long to prevent context overflow
 	if (sanitized.length > MAX_OUTPUT_LENGTH) {
-		const truncationMessageLength = TRUNCATION_MESSAGE.length;
-		const availableLength = MAX_OUTPUT_LENGTH - truncationMessageLength;
-		const startLength = Math.floor(availableLength * 0.4); // Keep 40% from start
-		const endLength = availableLength - startLength; // Keep 60% from end
-
-		const startPortion = sanitized.substring(0, startLength);
-		const endPortion = sanitized.substring(sanitized.length - endLength);
-
-		sanitized = startPortion + TRUNCATION_MESSAGE + endPortion;
+		sanitized = truncateOutputKeepingTail(sanitized, MAX_OUTPUT_LENGTH);
 	}
 
 	return sanitized;


### PR DESCRIPTION
fixes #280366
fixes #279174

cc @tyriar

When terminal command output exceeds scrollback, no output is provided inline in chat. Happens because `executedMarker.isDisposed`. When this is the case, we will now fall back to the earliest retained buffer line.

Before:

<img width="354" height="263" alt="Image" src="https://github.com/user-attachments/assets/e114cc65-1b58-4ee0-b34f-70f58e0cfa5c" />

After:

<img width="430" height="339" alt="Image" src="https://github.com/user-attachments/assets/28eba3bb-bdf8-456c-9358-0013c1f3b6c7" />
