### PR TITLE
fix single tab `when` expression

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminalMenus.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalMenus.ts
@@ -410,7 +410,7 @@ export function setupTerminalMenus(): void {
 					group: 'navigation',
 					order: 0,
 					when: ContextKeyExpr.and(
-						ContextKeyExpr.equals('hasHiddenChatTerminals', false),
+						ContextKeyExpr.not('hasHiddenChatTerminals'),
 						ContextKeyExpr.equals('view', TERMINAL_VIEW_ID),
 						ContextKeyExpr.has(`config.${TerminalSettingId.TabsEnabled}`),
 						ContextKeyExpr.or(

--- a/src/vs/workbench/contrib/terminal/common/terminalContextKey.ts
+++ b/src/vs/workbench/contrib/terminal/common/terminalContextKey.ts
@@ -146,7 +146,7 @@ export namespace TerminalContextKeys {
 	export const shouldShowViewInlineActions = ContextKeyExpr.and(
 		ContextKeyExpr.equals('view', TERMINAL_VIEW_ID),
 		ContextKeyExpr.notEquals(`config.${TerminalSettingId.TabsHideCondition}`, 'never'),
-		ContextKeyExpr.equals('hasHiddenChatTerminals', false),
+		ContextKeyExpr.not('hasHiddenChatTerminals'),
 		ContextKeyExpr.or(
 			ContextKeyExpr.not(`config.${TerminalSettingId.TabsEnabled}`),
 			ContextKeyExpr.and(


### PR DESCRIPTION
fix #279202

Works before this context key gets set