### PR TITLE
get overflow right for chat entry

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/media/terminal.css
+++ b/src/vs/workbench/contrib/terminal/browser/media/terminal.css
@@ -352,6 +352,8 @@
 	width: 100%;
 	height: 100%;
 	padding: 0;
+	box-sizing: border-box;
+	overflow: hidden;
 }
 
 .monaco-workbench .pane-body.integrated-terminal .terminal-tabs-chat-entry .terminal-tabs-entry:hover {


### PR DESCRIPTION
fixes #280082

<img width="176" height="336" alt="Screenshot 2025-12-01 at 12 35 23 PM" src="https://github.com/user-attachments/assets/c5641ab1-5b0b-4ad0-a604-277e7703330c" />
