### PR TITLE
polish chat terminal title style when expanded

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/media/chatTerminalToolProgressPart.css
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/media/chatTerminalToolProgressPart.css
@@ -141,7 +141,7 @@
 	padding: 5px 0px;
 }
 
-.chat-terminal-content-title.expanded {
+.chat-terminal-content-part .chat-terminal-content-title.chat-terminal-content-title-no-bottom-radius {
 	border-bottom-left-radius: 0px;
 	border-bottom-right-radius: 0px;
 	border-bottom: 0;

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart.ts
@@ -191,6 +191,7 @@ export class ChatTerminalToolProgressPart extends BaseChatToolInvocationSubPart 
 
 	private readonly _actionBar: ActionBar;
 
+	private readonly _titleElement: HTMLElement;
 	private readonly _outputView: ChatTerminalToolOutputSection;
 	private readonly _terminalOutputContextKey: IContextKey<boolean>;
 	private _terminalSessionRegistration: IDisposable | undefined;
@@ -256,6 +257,7 @@ export class ChatTerminalToolProgressPart extends BaseChatToolInvocationSubPart 
 			]),
 			h('.chat-terminal-content-message@message')
 		]);
+		this._titleElement = elements.title;
 
 		const command = terminalData.commandLine.userEdited ?? terminalData.commandLine.toolEdited ?? terminalData.commandLine.original;
 		this._terminalOutputContextKey = ChatContextKeys.inChatTerminalToolOutput.bindTo(this._contextKeyService);
@@ -542,9 +544,11 @@ export class ChatTerminalToolProgressPart extends BaseChatToolInvocationSubPart 
 
 	private async _toggleOutput(expanded: boolean): Promise<boolean> {
 		const didChange = await this._outputView.toggle(expanded);
-		this._showOutputAction.value?.syncPresentation(this._outputView.isExpanded);
+		const isExpanded = this._outputView.isExpanded;
+		this._titleElement.classList.toggle('chat-terminal-content-title-no-bottom-radius', isExpanded);
+		this._showOutputAction.value?.syncPresentation(isExpanded);
 		if (didChange) {
-			expandedStateByInvocation.set(this.toolInvocation, this._outputView.isExpanded);
+			expandedStateByInvocation.set(this.toolInvocation, isExpanded);
 		}
 		return didChange;
 	}


### PR DESCRIPTION
fixes #280393

Lost this in some refactor cc @Tyriar 

Before:

<img width="260" height="216" alt="image" src="https://github.com/user-attachments/assets/567ebf63-e09f-4b83-9432-611c15225c4f" />

After:

<img width="695" height="210" alt="Screenshot 2025-12-01 at 12 53 43 PM" src="https://github.com/user-attachments/assets/a25d3202-1c3d-4251-832f-ea74bb88bb5a" />
