### PR TITLE
Make terminal chat output action appear consistently on reload

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart.ts
@@ -497,10 +497,14 @@ export class ChatTerminalToolProgressPart extends BaseChatToolInvocationSubPart 
 
 			commandDetectionListener.value = commandDetection.onCommandFinished(() => {
 				this._addActions(terminalInstance, this._terminalData.terminalToolSessionId);
-				commandDetectionListener.clear();
+				const resolvedCommand = this._getResolvedCommand(terminalInstance);
+				if (resolvedCommand?.endMarker) {
+					commandDetectionListener.clear();
+				}
 			});
 			const resolvedImmediately = await tryResolveCommand();
 			if (resolvedImmediately?.endMarker) {
+				commandDetectionListener.clear();
 				return;
 			}
 		};

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart.ts
@@ -468,14 +468,16 @@ export class ChatTerminalToolProgressPart extends BaseChatToolInvocationSubPart 
 		this._showOutputActionAdded = true;
 	}
 
-	private _clearCommandAssociation(): void {
+	private _clearCommandAssociation(options?: { clearPersistentData?: boolean }): void {
 		this._terminalCommandUri = undefined;
 		this._storedCommandId = undefined;
-		if (this._terminalData.terminalCommandUri) {
-			delete this._terminalData.terminalCommandUri;
-		}
-		if (this._terminalData.terminalToolSessionId) {
-			delete this._terminalData.terminalToolSessionId;
+		if (options?.clearPersistentData) {
+			if (this._terminalData.terminalCommandUri) {
+				delete this._terminalData.terminalCommandUri;
+			}
+			if (this._terminalData.terminalToolSessionId) {
+				delete this._terminalData.terminalToolSessionId;
+			}
 		}
 		this._decoration.update();
 	}
@@ -516,7 +518,7 @@ export class ChatTerminalToolProgressPart extends BaseChatToolInvocationSubPart 
 			if (this._terminalInstance === terminalInstance) {
 				this._terminalInstance = undefined;
 			}
-			this._clearCommandAssociation();
+			this._clearCommandAssociation({ clearPersistentData: true });
 			commandDetectionListener.clear();
 			if (!this._store.isDisposed) {
 				this._actionBar.clear();

--- a/src/vs/workbench/contrib/terminalContrib/chat/browser/terminalChatService.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chat/browser/terminalChatService.ts
@@ -270,8 +270,14 @@ export class TerminalChatService extends Disposable implements ITerminalChatServ
 		try {
 			const entries: [string, number][] = [];
 			for (const [toolSessionId, instance] of this._terminalInstancesByToolSessionId.entries()) {
-				if (isNumber(instance.persistentProcessId) && instance.shouldPersist) {
-					entries.push([toolSessionId, instance.persistentProcessId]);
+				// Use the live persistent process id when available, otherwise fall back to the id
+				// from the attached process so mappings survive early in the terminal lifecycle.
+				const persistentId = isNumber(instance.persistentProcessId)
+					? instance.persistentProcessId
+					: instance.shellLaunchConfig.attachPersistentProcess?.id;
+				const shouldPersist = instance.shouldPersist || instance.shellLaunchConfig.forcePersist;
+				if (isNumber(persistentId) && shouldPersist) {
+					entries.push([toolSessionId, persistentId]);
 				}
 			}
 			if (entries.length > 0) {


### PR DESCRIPTION
fixes #280409

Gets the terminal chat toggle output action to appear across many reloads.

The output action only appears once the command resolver knows where that command’s output lives. Before the change we stopped listening after the first `onCommandFinished event`, even if the command’s `endMarker` (the bit that anchors its output) wasn’t ready yet; so on reload the toggle wouldn’t show until something else caused the command to resolve. Now we keep the listener active until the resolved command actually has an endMarker. As soon as that’s true we run `_addActions`, the toggle shows up immediately, and then we dispose the listener.

Persisted tool-session mappings more robustly - we now stash whichever process identifier is available (live `persistentProcessId` or the `attachPersistentProcess.id`) and treat `forcePersist` as a valid persistence signal. This prevents the hidden Copilot terminal from being “forgotten” between reloads.

Refined command-association cleanup - plain calls just clear in-memory handles, while disposal events pass `clearPersistentData: true` so serialized metadata is only dropped once the terminal is really gone. This keeps the toggle/focus actions visible after successive reloads without leaving stale data.

cc @tyriar