### PR TITLE
ensure height of output is correct

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart.ts
@@ -857,7 +857,8 @@ class ChatTerminalToolOutputSection extends Disposable {
 
 	private _getOutputContentHeight(lineCount: number, rowHeight: number, padding: number): number {
 		const contentRows = Math.max(lineCount, MIN_OUTPUT_ROWS);
-		return (contentRows * rowHeight) + padding;
+		const adjustedRows = contentRows + (lineCount > MAX_OUTPUT_ROWS ? 1 : 0);
+		return (adjustedRows * rowHeight) + padding;
 	}
 
 	private _getOutputPadding(): number {


### PR DESCRIPTION
fixes #280425

when terminal rows > max_rows, we need to add a line of height so it's not cutoff

cc @Tyriar 

<img width="877" height="246" alt="Screenshot 2025-12-01 at 2 13 10 PM" src="https://github.com/user-attachments/assets/59202a74-b82f-4b83-8ad3-39deafcab668" />



