### PR TITLE
feat: surface additional error details for spdy session failures

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,6 +1,6 @@
 disturl="https://electronjs.org/headers"
 target="39.2.3"
-ms_build_id="12857560"
+ms_build_id="12869810"
 runtime="electron"
 build_from_source="true"
 legacy-peer-deps="true"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "code-oss-dev",
   "version": "1.107.0",
-  "distro": "4c2f5059e83090f81ce2d12de556a3a6790dc24c",
+  "distro": "55e124105c9ac2939053cdc9f50ff7d84fc86294",
   "author": {
     "name": "Microsoft Corporation"
   },


### PR DESCRIPTION
Before

```
Error: net::ERR_HTTP2_PROTOCOL_ERROR
    at SimpleURLLoaderWrapper.<anonymous> (node:electron/js2c/browser_init:2:124687)
    at SimpleURLLoaderWrapper.emit (node:events:519:28)
```

After

```
Error: net::ERR_HTTP2_PROTOCOL_ERROR
    at SimpleURLLoaderWrapper.<anonymous> (node:electron/js2c/browser_init:6647:25)
    at SimpleURLLoaderWrapper.emit (node:events:508:28) {
  [cause]: {
    chromiumDetails: {
      active_stream_details: [],
      active_streams: 0,
      availability_state: 'Available',
      created_streams: 0,
      error: 0,
      error_on_unavailable: 0,
      frames_received: 0,
      host_port_pair: '',
      last_good_stream_id: 0,
      max_concurrent_streams: 100,
      negotiated_protocol: 'h2',
      network_anonymization_key: 'null',
      pending_create_stream_request_count: 0,
      proxy: '',
      recv_window_size: 15728640,
      reused: false,
      rst_stream_description: 'RST_STREAM error: 1 (PROTOCOL_ERROR)',
      rst_stream_error: -337,
      send_window_size: 65535,
      source_id: 26,
      spdy_session_key: [Object],
      stream_hi_water_mark: 3,
      streams_abandoned_count: 0,
      streams_initiated_count: 1,
      support_websocket: false,
      unacked_recv_window_bytes: 0
    }
  }
}
```