### PR TITLE
Fix SCM commit box indentation issue

### DIFF
--- a/src/vs/workbench/contrib/scm/browser/media/scm.css
+++ b/src/vs/workbench/contrib/scm/browser/media/scm.css
@@ -685,6 +685,7 @@
 	padding-right: 2px;
 }
 
+.scm-view .monaco-list-row > .monaco-tl-row > .monaco-tl-twistie.force-no-twistie,
 .scm-history-view .monaco-list-row > .monaco-tl-row > .monaco-tl-twistie.force-no-twistie {
 	display: none !important;
 }


### PR DESCRIPTION
Fixes #280493

This PR fixes a layout issue where the SCM commit box had an unnecessary large left margin when a single repository was open.

Changes:

Updated 
scm.css
 to correctly scope the force-no-twistie class to .scm-view in addition to .scm-history-view.
This ensures the twistie element is properly hidden for the input box, correcting the indentation.
