### PR TITLE
Improve layout of model token limits container

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatManagement/media/chatModelsWidget.css
+++ b/src/vs/workbench/contrib/chat/browser/chatManagement/media/chatModelsWidget.css
@@ -153,6 +153,7 @@
 	display: flex;
 	align-items: center;
 	gap: 4px;
+	min-width: 48px;
 }
 
 .models-widget .models-table-container .monaco-table-td .model-token-limits .codicon {


### PR DESCRIPTION
Add a minimum width to the model token limits container to enhance the layout and ensure better visibility. Test the changes by checking the appearance of the model token limits in the UI.

<img width="875" height="817" alt="image" src="https://github.com/user-attachments/assets/56ff96e1-718b-4419-8e45-92c31169edf5" />

