### PR TITLE
Enhance keybinding key visibility on hover in quick input list

### DIFF
--- a/src/vs/platform/quickinput/browser/media/quickInput.css
+++ b/src/vs/platform/quickinput/browser/media/quickInput.css
@@ -346,7 +346,8 @@
 	color: inherit
 }
 
-.quick-input-list .monaco-list-row.focused .monaco-keybinding-key {
+.quick-input-list .monaco-list-row.focused .monaco-keybinding-key,
+.quick-input-list .monaco-list-row:hover .monaco-keybinding-key {
 	background: none;
 	border-color: var(--vscode-widget-shadow);
 }


### PR DESCRIPTION
Improve the visibility of keybinding keys in the quick input list by ensuring they are highlighted on hover, enhancing user experience. This aligns keybinding styling with the selected state.

<img width="608" height="113" alt="image" src="https://github.com/user-attachments/assets/4aec418c-3c0b-4ce2-8ffc-47414f10f014" />

Test by hovering over items in the quick input list to see the improved key visibility.

