### PR TITLE
Fix #280551: Add padding to recent sessions view actions

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/agentSessions/media/agentsessionsviewer.css
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/media/agentsessionsviewer.css
@@ -32,7 +32,7 @@
 	}
 
 	.monaco-list-row .agent-session-title-toolbar .monaco-toolbar .action-label {
-		padding: 0; /* limit padding top/bottom to preserve line-height per row */
+		padding: 0 2px; /* limit padding top/bottom to preserve line-height per row */
 	}
 
 	.agent-session-item {

--- a/src/vs/workbench/contrib/chat/browser/media/chatViewPane.css
+++ b/src/vs/workbench/contrib/chat/browser/media/chatViewPane.css
@@ -31,7 +31,8 @@
 				display: none;
 
 				.action-label {
-					padding: 0; /* limit padding top/bottom to preserve line-height per row */
+					padding: 0 2px;
+					/* limit padding top/bottom to preserve line-height per row */
 				}
 			}
 		}


### PR DESCRIPTION
Fix: Add padding to recent sessions view actions
Description
This PR addresses issue #280551 where actions in the recent sessions view (both the main title and individual session entries) appeared cramped due to a lack of padding.

Changes
Added padding: 0 2px to .action-label in 
agentsessionsviewer.css
 to improve spacing for individual session actions.
Added padding: 0 2px to .action-label in 
chatViewPane.css
 to improve spacing for the main "Recent Sessions" title actions.
Verification
Verified that the padding is applied correctly to the action labels.
Ensured that the vertical alignment is preserved by keeping top/bottom padding at 0.