### PR TITLE
feat: add setting to control throttling for chat sessions

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -330,6 +330,11 @@ configurationRegistry.registerConfiguration({
 				},
 			}
 		},
+		[ChatConfiguration.SuspendThrottling]: {
+			type: 'boolean',
+			description: nls.localize('chat.suspendThrottling', "Controls whether background throttling is suspended when a chat request is in progress, allowing the chat session to continue even when the window is not in focus."),
+			default: true,
+		},
 		'chat.sendElementsToChat.enabled': {
 			default: true,
 			description: nls.localize('chat.sendElementsToChat.enabled', "Controls whether elements can be sent to chat from the Simple Browser."),

--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -330,10 +330,11 @@ configurationRegistry.registerConfiguration({
 				},
 			}
 		},
-		[ChatConfiguration.SuspendThrottling]: {
+		[ChatConfiguration.SuspendThrottling]: { // TODO@deepak1556 remove this once https://github.com/microsoft/vscode/issues/263554 is resolved.
 			type: 'boolean',
 			description: nls.localize('chat.suspendThrottling', "Controls whether background throttling is suspended when a chat request is in progress, allowing the chat session to continue even when the window is not in focus."),
 			default: true,
+			tags: ['preview']
 		},
 		'chat.sendElementsToChat.enabled': {
 			default: true,

--- a/src/vs/workbench/contrib/chat/common/constants.ts
+++ b/src/vs/workbench/contrib/chat/common/constants.ts
@@ -28,6 +28,7 @@ export enum ChatConfiguration {
 	SubagentToolCustomAgents = 'chat.customAgentInSubagent.enabled',
 	ShowCodeBlockProgressAnimation = 'chat.agent.codeBlockProgress',
 	RestoreLastPanelSession = 'chat.restoreLastPanelSession',
+	SuspendThrottling = 'chat.suspendThrottling',
 }
 
 /**

--- a/src/vs/workbench/contrib/chat/electron-browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/electron-browser/chat.contribution.ts
@@ -12,6 +12,7 @@ import { ipcRenderer } from '../../../../base/parts/sandbox/electron-browser/glo
 import { localize } from '../../../../nls.js';
 import { registerAction2 } from '../../../../platform/actions/common/actions.js';
 import { ICommandService } from '../../../../platform/commands/common/commands.js';
+import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
 import { IDialogService } from '../../../../platform/dialogs/common/dialogs.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
@@ -27,9 +28,9 @@ import { ILifecycleService, ShutdownReason } from '../../../services/lifecycle/c
 import { ACTION_ID_NEW_CHAT, CHAT_OPEN_ACTION_ID, IChatViewOpenOptions } from '../browser/actions/chatActions.js';
 import { IChatWidgetService } from '../browser/chat.js';
 import { ChatContextKeys } from '../common/chatContextKeys.js';
+import { ChatConfiguration, ChatModeKind } from '../common/constants.js';
 import { IChatService } from '../common/chatService.js';
 import { ChatUrlFetchingConfirmationContribution } from '../common/chatUrlFetchingConfirmation.js';
-import { ChatModeKind } from '../common/constants.js';
 import { ILanguageModelToolsConfirmationService } from '../common/languageModelToolsConfirmationService.js';
 import { ILanguageModelToolsService } from '../common/languageModelToolsService.js';
 import { InternalFetchWebPageToolId } from '../common/tools/tools.js';
@@ -126,9 +127,14 @@ class ChatSuspendThrottlingHandler extends Disposable {
 
 	constructor(
 		@INativeHostService nativeHostService: INativeHostService,
-		@IChatService chatService: IChatService
+		@IChatService chatService: IChatService,
+		@IConfigurationService configurationService: IConfigurationService
 	) {
 		super();
+
+		if (!configurationService.getValue<boolean>(ChatConfiguration.SuspendThrottling)) {
+			return;
+		}
 
 		this._register(autorun(reader => {
 			const running = chatService.requestInProgressObs.read(reader);


### PR DESCRIPTION
For https://github.com/microsoft/vscode/issues/263554

Based on some trace logs from @chrmarti who is occasionally affected by this issue, we are changing the background throttling of the affected windows but I am not sure why that would break compositing even after we restored the original throttling state when the chat requests ended. I will use this setting as a first step to either confirm or eliminate the chat customization as a source of the issue and then proceed to get additional diagnostics from the runtime.