### PR TITLE
fix: snap crash on startup with wayland sessions

### DIFF
--- a/resources/linux/snap/snapcraft.yaml
+++ b/resources/linux/snap/snapcraft.yaml
@@ -78,8 +78,8 @@ parts:
 
 apps:
   @@NAME@@:
-    command: electron-launch $SNAP/usr/share/@@NAME@@/bin/@@NAME@@ --no-sandbox
+    command: electron-launch $SNAP/usr/share/@@NAME@@/bin/@@NAME@@ --no-sandbox --ozone-platform=x11
     common-id: @@NAME@@.desktop
 
   url-handler:
-    command: electron-launch $SNAP/usr/share/@@NAME@@/bin/@@NAME@@ --open-url --no-sandbox
+    command: electron-launch $SNAP/usr/share/@@NAME@@/bin/@@NAME@@ --open-url --no-sandbox --ozone-platform=x11


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/277836

With Electron 38 ozone platform will use native wayland if `XDG_SESSION_TYPE` matches. However, wayland backend support is not setup correctly in our snap packages, need https://github.com/microsoft/vscode/pull/199052/files. Restore current behavior with XWayland till then.