### PR TITLE
fix height and width of embedded terminal when it exceeds max height

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart.ts
@@ -945,7 +945,7 @@ class ChatTerminalToolOutputSection extends Disposable {
 		const measuredBodyHeight = Math.max(this._outputBody.clientHeight, minHeight);
 		const appliedHeight = Math.min(clampedHeight, measuredBodyHeight);
 		scrollableDomNode.style.maxHeight = `${maxHeight}px`;
-		scrollableDomNode.style.height = `${appliedHeight}px`;
+		scrollableDomNode.style.height = appliedHeight < maxHeight ? `${appliedHeight}px` : '';
 		this._scrollableContainer.scanDomNode();
 		if (this._renderedOutputHeight !== appliedHeight) {
 			this._renderedOutputHeight = appliedHeight;


### PR DESCRIPTION
fixes https://github.com/microsoft/vscode/issues/280425
fixes https://github.com/microsoft/vscode/issues/280453

Looks bad, need to fix ASAP

<img width="726" height="434" alt="image" src="https://github.com/user-attachments/assets/46044818-d353-47cf-8c40-680ddde30a7a" />

<img width="1174" height="428" alt="image" src="https://github.com/user-attachments/assets/f4b6e680-8c13-4b66-b125-b7c4b754f947" />
