### PR TITLE
prevent chat entry from overlapping with terminals

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/media/terminal.css
+++ b/src/vs/workbench/contrib/terminal/browser/media/terminal.css
@@ -304,6 +304,13 @@
 	height: 100%;
 	overflow: hidden;
 	position: relative;
+	display: flex;
+	flex-direction: column;
+}
+
+.monaco-workbench .pane-body.integrated-terminal .tabs-list-container > .tabs-list {
+	flex: 1;
+	min-height: 0;
 }
 
 .monaco-workbench .pane-body.integrated-terminal .tabs-container > .monaco-toolbar {
@@ -330,10 +337,7 @@
 }
 
 .monaco-workbench .pane-body.integrated-terminal .terminal-tabs-chat-entry {
-	position: absolute;
-	left: 0;
-	right: 0;
-	bottom: 0;
+	flex-shrink: 0;
 	height: 22px;
 	line-height: 22px;
 	display: flex;


### PR DESCRIPTION
fixes https://github.com/microsoft/vscode/issues/274319
fixes [#275271](https://github.com/microsoft/vscode/issues/275271)

<img width="213" height="357" alt="Screenshot 2025-12-02 at 12 45 57 PM" src="https://github.com/user-attachments/assets/7bf852ec-06b0-4481-b8fa-fe4551d40cdf" />
