### PR TITLE
Fix quota exceeded warning for Copilot Pro users

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatStatus/chatStatusEntry.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatStatus/chatStatusEntry.ts
@@ -114,6 +114,7 @@ export class ChatStatusBarEntry extends Disposable implements IWorkbenchContribu
 		} else {
 			const chatQuotaExceeded = this.chatEntitlementService.quotas.chat?.percentRemaining === 0;
 			const completionsQuotaExceeded = this.chatEntitlementService.quotas.completions?.percentRemaining === 0;
+			const premiumChatQuotaExceeded = this.chatEntitlementService.quotas.premiumChat?.percentRemaining === 0;
 			const chatSessionsInProgressCount = this.chatSessionsService.getInProgress().reduce((total, item) => total + item.count, 0);
 
 			// Disabled
@@ -141,13 +142,15 @@ export class ChatStatusBarEntry extends Disposable implements IWorkbenchContribu
 				kind = 'prominent';
 			}
 
-			// Free Quota Exceeded
-			else if (this.chatEntitlementService.entitlement === ChatEntitlement.Free && (chatQuotaExceeded || completionsQuotaExceeded)) {
+			// Quota Exceeded (Free, Pro, ProPlus, Business, Enterprise)
+			else if (chatQuotaExceeded || completionsQuotaExceeded || premiumChatQuotaExceeded) {
 				let quotaWarning: string;
-				if (chatQuotaExceeded && !completionsQuotaExceeded) {
+				if (chatQuotaExceeded && !completionsQuotaExceeded && !premiumChatQuotaExceeded) {
 					quotaWarning = localize('chatQuotaExceededStatus', "Chat quota reached");
-				} else if (completionsQuotaExceeded && !chatQuotaExceeded) {
+				} else if (completionsQuotaExceeded && !chatQuotaExceeded && !premiumChatQuotaExceeded) {
 					quotaWarning = localize('completionsQuotaExceededStatus', "Inline suggestions quota reached");
+				} else if (premiumChatQuotaExceeded && !chatQuotaExceeded && !completionsQuotaExceeded) {
+					quotaWarning = localize('premiumChatQuotaExceededStatus', "Premium chat quota reached");
 				} else {
 					quotaWarning = localize('chatAndCompletionsQuotaExceededStatus', "Quota reached");
 				}


### PR DESCRIPTION
## Description

Fixes #280694

This PR fixes an issue where Copilot Pro subscribers were incorrectly seeing "out of requests" messages or not seeing quota warnings when they should.

### Problem

The quota exceeded warning in the status bar was only being displayed for Free tier users (`ChatEntitlement.Free`), but Pro/ProPlus/Business/Enterprise users also have quotas:
- Pro users have 300 premium chat requests per month
- The quota data is properly fetched and stored in `chatEntitlementService.quotas`
- However, the status bar wasn't showing quota warnings for Pro users

### Root Cause

In `chatStatusEntry.ts`, the quota check had this condition:

```typescript
// Free Quota Exceeded
else if (this.chatEntitlementService.entitlement === ChatEntitlement.Free && (chatQuotaExceeded || completionsQuotaExceeded)) {
```

This meant Pro users would never see quota warnings in the status bar, even when they exceeded their premium chat quota.

### Solution

1. **Removed the Free-tier-only restriction** - The quota check now applies to all entitled users
2. **Added premium chat quota checking** - Pro users have a `premiumChat` quota that wasn't being checked
3. **Updated quota warning logic** - Now handles all three quota types: `chat`, `completions`, and `premiumChat`

### Changes

- Updated `src/vs/workbench/contrib/chat/browser/chatStatus/chatStatusEntry.ts`:
  - Added `premiumChatQuotaExceeded` variable to check premium chat quota
  - Changed condition from `ChatEntitlement.Free && (chatQuotaExceeded || completionsQuotaExceeded)` to `chatQuotaExceeded || completionsQuotaExceeded || premiumChatQuotaExceeded`
  - Added specific warning message for premium chat quota: "Premium chat quota reached"
  - Updated comment from "Free Quota Exceeded" to "Quota Exceeded (Free, Pro, ProPlus, Business, Enterprise)"

### Testing

This change affects the status bar display logic for quota warnings. All entitled users (Free, Pro, ProPlus, Business, Enterprise) will now see appropriate quota warnings when they exceed any of their quotas.

The existing entitlement service tests already verify quota calculation logic, so no new tests are needed for this UI display change.

### Impact

- **Pro/ProPlus/Business/Enterprise users** will now see quota warnings when they exceed their limits
- **Free users** will continue to see quota warnings as before
- No breaking changes to existing functionality