### PR TITLE
fix: ci for snap builds

### DIFF
--- a/resources/linux/snap/electron-launch
+++ b/resources/linux/snap/electron-launch
@@ -276,4 +276,4 @@ fi
 
 wait_for_async_execs
 
-exec "$@"
+exec "$@" --ozone-platform=x11

--- a/resources/linux/snap/snapcraft.yaml
+++ b/resources/linux/snap/snapcraft.yaml
@@ -78,8 +78,8 @@ parts:
 
 apps:
   @@NAME@@:
-    command: electron-launch $SNAP/usr/share/@@NAME@@/bin/@@NAME@@ --no-sandbox --ozone-platform=x11
+    command: electron-launch $SNAP/usr/share/@@NAME@@/bin/@@NAME@@ --no-sandbox
     common-id: @@NAME@@.desktop
 
   url-handler:
-    command: electron-launch $SNAP/usr/share/@@NAME@@/bin/@@NAME@@ --open-url --no-sandbox --ozone-platform=x11
+    command: electron-launch $SNAP/usr/share/@@NAME@@/bin/@@NAME@@ --open-url --no-sandbox


### PR DESCRIPTION
Follow-up to https://github.com/microsoft/vscode/pull/280656

Refs https://dev.azure.com/monacotools/Monaco/_build/results?buildId=381128&view=logs&j=dcea01d9-8513-5a47-c936-5baceabd8c97&t=3982c868-0546-50e3-76c7-f050ce5b17d2