### PR TITLE
Adjust padding and font size in chat view title container

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/media/chatViewTitleControl.css
+++ b/src/vs/workbench/contrib/chat/browser/media/chatViewTitleControl.css
@@ -7,13 +7,13 @@
 
 	.chat-view-title-container {
 		display: none;
-		padding: 8px 16px;
+		padding: 4px 8px 8px 16px;
 		border-bottom: 1px solid var(--vscode-sideBarSectionHeader-border);
 		align-items: center;
 
 		.chat-view-title-label {
 			text-transform: uppercase;
-			font-size: 12px;
+			font-size: 11px;
 			color: var(--vscode-descriptionForeground);
 			overflow: hidden;
 			white-space: nowrap;


### PR DESCRIPTION
Modify the chat view title container's padding and font size for improved visual consistency. Test by checking the chat view to ensure the title appears correctly with the new styles applied.

