### PR TITLE
revert chatSession registration tweaks from 280738

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatSessions.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSessions.contribution.ts
@@ -8,7 +8,7 @@ import { raceCancellationError } from '../../../../base/common/async.js';
 import { CancellationToken } from '../../../../base/common/cancellation.js';
 import { Codicon } from '../../../../base/common/codicons.js';
 import { Emitter, Event } from '../../../../base/common/event.js';
-import { MutableDisposable, combinedDisposable, Disposable, DisposableMap, DisposableStore, IDisposable } from '../../../../base/common/lifecycle.js';
+import { combinedDisposable, Disposable, DisposableMap, DisposableStore, IDisposable } from '../../../../base/common/lifecycle.js';
 import { ResourceMap } from '../../../../base/common/map.js';
 import { Schemas } from '../../../../base/common/network.js';
 import * as resources from '../../../../base/common/resources.js';
@@ -633,31 +633,8 @@ export class ChatSessionsService extends Disposable implements IChatSessionsServ
 		const disposableStore = new DisposableStore();
 		this._contributionDisposables.set(contribution.type, disposableStore);
 
-		const providerDependentDisposables = new MutableDisposable<IDisposable>();
-		disposableStore.add(providerDependentDisposables);
-
-		// NOTE: Only those extensions that register as 'content providers' should have agents and commands auto-registered
-		//       This relationship may change in the future as the API grows.
-		const reconcileProviderRegistrations = () => {
-			if (this._contentProviders.has(contribution.type)) {
-				if (!providerDependentDisposables.value) {
-					providerDependentDisposables.value = combinedDisposable(
-						this._registerAgent(contribution, ext),
-						this._registerCommands(contribution)
-					);
-				}
-			} else {
-				providerDependentDisposables.clear();
-			}
-		};
-
-		reconcileProviderRegistrations();
-		disposableStore.add(this.onDidChangeContentProviderSchemes(({ added, removed }) => {
-			if (added.includes(contribution.type) || removed.includes(contribution.type)) {
-				reconcileProviderRegistrations();
-			}
-		}));
-
+		disposableStore.add(this._registerAgent(contribution, ext));
+		disposableStore.add(this._registerCommands(contribution));
 		disposableStore.add(this._registerMenuItems(contribution, ext));
 	}
 


### PR DESCRIPTION
partial revert of https://github.com/microsoft/vscode/pull/280738

Note that this is still over-registering implementors of chatsessions, but will need to fix another way (flag on the contribution, probably).

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
