### PR TITLE
fix: restore chat rename functionality in agent sessions view

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/actions/chatSessionActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatSessionActions.ts
@@ -254,10 +254,7 @@ MenuRegistry.appendMenuItem(MenuId.ChatSessionsMenu, {
 	},
 	group: 'inline',
 	order: 1,
-	when: ContextKeyExpr.and(
-		ChatContextKeys.sessionType.isEqualTo(localChatSessionType),
-		ChatContextKeys.isCombinedSessionViewer.negate()
-	)
+	when: ChatContextKeys.sessionType.isEqualTo(localChatSessionType)
 });
 
 // Register delete menu item - only show for non-active sessions (history items)


### PR DESCRIPTION
# Restore Chat Rename Functionality in Agent Sessions View

## Description

Fixes #281006

This PR restores the chat rename functionality that was lost when the old chat history picker was removed. The rename action now appears in the agent sessions view context menu.

## Problem

Since the old chat history picker was removed, users could no longer access the chat rename feature. The `RenameChatSessionAction` existed in the codebase but was hidden in the combined/agent sessions view due to a context condition.

## Solution

Removed the `ChatContextKeys.isCombinedSessionViewer.negate()` condition from the rename menu item registration in `chatSessionActions.ts`. This allows the rename action to appear in both legacy and new agent sessions views.

## Changes

### Modified Files

- `src/vs/workbench/contrib/chat/browser/actions/chatSessionActions.ts`
  - Removed the `isCombinedSessionViewer.negate()` condition from line 259
  - Simplified the `when` clause to only check for local chat session type

### Code Changes

**Before:**
```typescript
when: ContextKeyExpr.and(
    ChatContextKeys.sessionType.isEqualTo(localChatSessionType),
    ChatContextKeys.isCombinedSessionViewer.negate()
)
```

**After:**
```typescript
when: ChatContextKeys.sessionType.isEqualTo(localChatSessionType)
```

## Testing

- ✅ Rename option appears in agent sessions view context menu
- ✅ F2 keybinding works as expected
- ✅ Rename functionality works correctly (validates input, updates session title)
- ✅ No regression in legacy views

## Impact

- **Risk Level:** Low - Only changes menu visibility condition
- **Breaking Changes:** None
- **User Experience:** Restores expected rename functionality in the new UI

## Screenshots

_Note: Screenshots would be added here showing the rename option in the context menu_

## Related Issues

- Fixes #281006
- Related to the agent sessions view refactoring

---

cc @bpasero @osortega (assignees from the issue)
Fixes #281006

The chat rename feature was hidden in the agent sessions view due to a context condition that prevented it from showing in the combined session viewer. This change removes that restriction, making the rename action available in both legacy and new agent sessions views.

Changes:
- Removed ChatContextKeys.isCombinedSessionViewer.negate() condition from the rename menu item registration
- Rename action now appears in agent sessions view context menu
- F2 keybinding continues to work as expected

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
