### PR TITLE
fix assumptions with chat.exitAfterDelegation and chats in the sidebar

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/actions/chatContinueInAction.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatContinueInAction.ts
@@ -284,7 +284,7 @@ class CreateRemoteAgentJobAction {
 			});
 
 			if (requestData) {
-				await widget.handleDelegationExitIfNeeded(requestData.agent);
+				await widget.handleDelegationExitIfNeeded(defaultAgent, requestData.agent);
 			}
 		} catch (e) {
 			console.error('Error creating remote coding agent job', e);

--- a/src/vs/workbench/contrib/chat/browser/chat.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.ts
@@ -262,7 +262,7 @@ export interface IChatWidget {
 	clear(): Promise<void>;
 	getViewState(): IChatModelInputState | undefined;
 	lockToCodingAgent(name: string, displayName: string, agentId?: string): void;
-	handleDelegationExitIfNeeded(agent: IChatAgentData | undefined): Promise<void>;
+	handleDelegationExitIfNeeded(sourceAgent: Pick<IChatAgentData, 'id' | 'name'> | undefined, targetAgent: IChatAgentData | undefined): Promise<void>;
 
 	delegateScrollFromMouseWheelEvent(event: IMouseWheelEvent): void;
 }

--- a/src/vs/workbench/contrib/chat/browser/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatWidget.ts
@@ -1337,9 +1337,7 @@ export class ChatWidget extends Disposable implements IChatWidget {
 			return false;
 		}
 
-		if (!targetAgent) {
-			return false;
-		}
+
 
 		if (!isIChatViewViewContext(this.viewContext)) {
 			return false;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Yesterday it was impossible for the sidebar to open a non-local chat. That is not the case anymore.  The `chat.exitAfterDelegation` assumed this was the case