### PR TITLE
if `_mostRecentProgressPart` has been cleared, calculate it

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/chat/browser/terminalChatService.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chat/browser/terminalChatService.ts
@@ -182,10 +182,7 @@ export class TerminalChatService extends Disposable implements ITerminalChatServ
 				this._focusedProgressPart = undefined;
 			}
 			if (this._mostRecentProgressPart === part) {
-				const fallback = this._getLastActiveProgressPart();
-				if (fallback) {
-					this._mostRecentProgressPart = fallback;
-				}
+				this._mostRecentProgressPart = this._getLastActiveProgressPart();
 			}
 		});
 	}

--- a/src/vs/workbench/contrib/terminalContrib/chat/browser/terminalChatService.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chat/browser/terminalChatService.ts
@@ -202,6 +202,9 @@ export class TerminalChatService extends Disposable implements ITerminalChatServ
 	}
 
 	getMostRecentProgressPart(): IChatTerminalToolProgressPart | undefined {
+		if (!this._mostRecentProgressPart || !this._activeProgressParts.has(this._mostRecentProgressPart)) {
+			this._mostRecentProgressPart = this._getLastActiveProgressPart();
+		}
 		return this._mostRecentProgressPart;
 	}
 


### PR DESCRIPTION
fixes #274411

only reproduces in insider's, so waiting to verify in dev build ✅ verified

- Insiders virtualizes chat rows frequently.
- When a row leaves the render tree its ChatTerminalToolProgressPart disposal runs, so registerProgressPart removes it from _activeProgressParts 
- Any command triggered while the row is recycled has no live progress part to target, and getMostRecentProgressPart() returns undefined 

The fix calculates the part that we want in this case.