### PR TITLE
Store chat session stats in metadata

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/agentSessions/localAgentSessionsProvider.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/localAgentSessionsProvider.ts
@@ -13,7 +13,6 @@ import { ResourceSet } from '../../../../../base/common/map.js';
 import { autorun } from '../../../../../base/common/observable.js';
 import { truncate } from '../../../../../base/common/strings.js';
 import { IWorkbenchContribution } from '../../../../common/contributions.js';
-import { ModifiedFileEntryState } from '../../common/chatEditingService.js';
 import { IChatModel } from '../../common/chatModel.js';
 import { IChatDetail, IChatService } from '../../common/chatService.js';
 import { ChatSessionStatus, IChatSessionItem, IChatSessionItemProvider, IChatSessionsService, localChatSessionType } from '../../common/chatSessionsService.js';
@@ -126,7 +125,7 @@ export class LocalAgentsSessionsProvider extends Disposable implements IChatSess
 		const sessions: ChatSessionItemWithProvider[] = [];
 		const sessionsByResource = new ResourceSet();
 
-		for (const sessionDetail of this.chatService.getLiveSessionItems()) {
+		for (const sessionDetail of await this.chatService.getLiveSessionItems()) {
 			const editorSession = this.toChatSessionItem(sessionDetail);
 			if (!editorSession) {
 				continue;
@@ -200,33 +199,11 @@ export class LocalAgentsSessionsProvider extends Disposable implements IChatSess
 				startTime,
 				endTime
 			},
-			statistics: model ? this.getSessionStatistics(model) : undefined
-		};
-	}
-
-	private getSessionStatistics(chatModel: IChatModel) {
-		let linesAdded = 0;
-		let linesRemoved = 0;
-		const files = new ResourceSet();
-
-		const currentEdits = chatModel.editingSession?.entries.get();
-		if (currentEdits) {
-			const uncommittedEdits = currentEdits.filter(edit => edit.state.get() === ModifiedFileEntryState.Modified);
-			for (const edit of uncommittedEdits) {
-				linesAdded += edit.linesAdded?.get() ?? 0;
-				linesRemoved += edit.linesRemoved?.get() ?? 0;
-				files.add(edit.modifiedURI);
-			}
-		}
-
-		if (files.size === 0) {
-			return undefined;
-		}
-
-		return {
-			files: files.size,
-			insertions: linesAdded,
-			deletions: linesRemoved,
+			statistics: chat.stats ? {
+				insertions: chat.stats.added,
+				deletions: chat.stats.removed,
+				files: chat.stats.fileCount
+			} : undefined
 		};
 	}
 }

--- a/src/vs/workbench/contrib/chat/common/chatEditingService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatEditingService.ts
@@ -282,7 +282,7 @@ export interface IEditSessionEntryDiff extends IEditSessionDiffStats {
 	isBusy: boolean;
 }
 
-export function busySessionEntryDiff(originalURI: URI, modifiedURI: URI): IEditSessionEntryDiff {
+export function emptySessionEntryDiff(originalURI: URI, modifiedURI: URI): IEditSessionEntryDiff {
 	return {
 		originalURI,
 		modifiedURI,
@@ -291,7 +291,7 @@ export function busySessionEntryDiff(originalURI: URI, modifiedURI: URI): IEditS
 		quitEarly: false,
 		identical: false,
 		isFinal: false,
-		isBusy: true,
+		isBusy: false,
 	};
 }
 

--- a/src/vs/workbench/contrib/chat/common/chatService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService.ts
@@ -909,11 +909,18 @@ export interface IChatCompleteResponse {
 	followups?: IChatFollowup[];
 }
 
+export interface IChatSessionStats {
+	fileCount: number;
+	added: number;
+	removed: number;
+}
+
 export interface IChatDetail {
 	sessionResource: URI;
 	title: string;
 	lastMessageDate: number;
 	isActive: boolean;
+	stats?: IChatSessionStats;
 }
 
 export interface IChatProviderInfo {
@@ -1044,7 +1051,7 @@ export interface IChatService {
 	removeHistoryEntry(sessionResource: URI): Promise<void>;
 	getChatStorageFolder(): URI;
 	logChatIndex(): void;
-	getLiveSessionItems(): IChatDetail[];
+	getLiveSessionItems(): Promise<IChatDetail[]>;
 	getHistorySessionItems(): Promise<IChatDetail[]>;
 
 	readonly onDidPerformUserAction: Event<IChatUserActionEvent>;

--- a/src/vs/workbench/contrib/chat/common/chatService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService.ts
@@ -1069,6 +1069,11 @@ export interface IChatService {
 	/**
 	 * For tests only!
 	 */
+	setSaveModelsEnabled(enabled: boolean): void;
+
+	/**
+	 * For tests only!
+	 */
 	waitForModelDisposals(): Promise<void>;
 }
 

--- a/src/vs/workbench/contrib/chat/test/browser/chatEditingService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/chatEditingService.test.ts
@@ -107,6 +107,7 @@ suite('ChatEditingService', function () {
 
 		store.add(insta.get(IChatSessionsService) as ChatSessionsService); // Needs to be disposed in between test runs to clear extensionPoint contribution
 		store.add(chatService as ChatService);
+		chatService.setSaveModelsEnabled(false);
 
 		const chatAgentService = insta.get(IChatAgentService);
 
@@ -131,7 +132,6 @@ suite('ChatEditingService', function () {
 
 	teardown(async () => {
 		store.clear();
-		await chatService.waitForModelDisposals();
 	});
 
 	ensureNoDisposablesAreLeakedInTestSuite();

--- a/src/vs/workbench/contrib/chat/test/browser/localAgentSessionsProvider.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/localAgentSessionsProvider.test.ts
@@ -514,7 +514,12 @@ suite('LocalAgentsSessionsProvider', () => {
 					sessionResource,
 					title: 'Stats Session',
 					lastMessageDate: Date.now(),
-					isActive: true
+					isActive: true,
+					stats: {
+						added: 30,
+						removed: 8,
+						fileCount: 2
+					}
 				}]);
 
 				const sessions = await provider.provideChatSessionItems(CancellationToken.None);

--- a/src/vs/workbench/contrib/chat/test/browser/localAgentSessionsProvider.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/localAgentSessionsProvider.test.ts
@@ -166,7 +166,7 @@ class MockChatService implements IChatService {
 		return undefined;
 	}
 
-	getLiveSessionItems(): IChatDetail[] {
+	async getLiveSessionItems(): Promise<IChatDetail[]> {
 		return this.liveSessionItems;
 	}
 

--- a/src/vs/workbench/contrib/chat/test/browser/localAgentSessionsProvider.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/localAgentSessionsProvider.test.ts
@@ -44,6 +44,10 @@ class MockChatService implements IChatService {
 		this._onDidDisposeSession.fire({ sessionResource, reason: 'cleared' });
 	}
 
+	setSaveModelsEnabled(enabled: boolean): void {
+
+	}
+
 	setLiveSessionItems(items: IChatDetail[]): void {
 		this.liveSessionItems = items;
 	}

--- a/src/vs/workbench/contrib/chat/test/common/mockChatService.ts
+++ b/src/vs/workbench/contrib/chat/test/common/mockChatService.ts
@@ -24,6 +24,9 @@ export class MockChatService implements IChatService {
 
 	private sessions = new ResourceMap<IChatModel>();
 
+	setSaveModelsEnabled(enabled: boolean): void {
+
+	}
 	isEnabled(location: ChatAgentLocation): boolean {
 		throw new Error('Method not implemented.');
 	}

--- a/src/vs/workbench/contrib/chat/test/common/mockChatService.ts
+++ b/src/vs/workbench/contrib/chat/test/common/mockChatService.ts
@@ -133,7 +133,7 @@ export class MockChatService implements IChatService {
 		throw new Error('Method not implemented.');
 	}
 
-	getLiveSessionItems(): IChatDetail[] {
+	async getLiveSessionItems(): Promise<IChatDetail[]> {
 		throw new Error('Method not implemented.');
 	}
 	getHistorySessionItems(): Promise<IChatDetail[]> {


### PR DESCRIPTION
So they can be shown without loading a ChatModel

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
