### PR TITLE
fix a11y issue on windows

### DIFF
--- a/src/vs/editor/browser/controller/editContext/textArea/textAreaEditContext.ts
+++ b/src/vs/editor/browser/controller/editContext/textArea/textAreaEditContext.ts
@@ -39,6 +39,7 @@ import { ICompositionData, IPasteData, ITextAreaInputHost, TextAreaInput, TextAr
 import { ariaLabelForScreenReaderContent, newlinecount, SimplePagedScreenReaderStrategy } from '../screenReaderUtils.js';
 import { _debugComposition, ITypeData, TextAreaState } from './textAreaEditContextState.js';
 import { getMapForWordSeparators, WordCharacterClass } from '../../../../common/core/wordCharacterClassifier.js';
+import { TextAreaEditContextRegistry } from './textAreaEditContextRegistry.js';
 
 export interface IVisibleRangeProvider {
 	visibleRangeForPosition(position: Position): HorizontalPosition | null;
@@ -144,6 +145,7 @@ export class TextAreaEditContext extends AbstractEditContext {
 	private readonly _textAreaInput: TextAreaInput;
 
 	constructor(
+		ownerID: string,
 		context: ViewContext,
 		overflowGuardContainer: FastDomNode<HTMLElement>,
 		viewController: ViewController,
@@ -440,6 +442,8 @@ export class TextAreaEditContext extends AbstractEditContext {
 		this._register(IME.onDidChange(() => {
 			this._ensureReadOnlyAttribute();
 		}));
+
+		this._register(TextAreaEditContextRegistry.register(ownerID, this));
 	}
 
 	public get domNode() {

--- a/src/vs/editor/browser/controller/editContext/textArea/textAreaEditContextRegistry.ts
+++ b/src/vs/editor/browser/controller/editContext/textArea/textAreaEditContextRegistry.ts
@@ -1,0 +1,27 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IDisposable } from '../../../../../base/common/lifecycle.js';
+import { TextAreaEditContext } from './textAreaEditContext.js';
+
+class TextAreaEditContextRegistryImpl {
+
+	private _textAreaEditContextMapping: Map<string, TextAreaEditContext> = new Map();
+
+	register(ownerID: string, textAreaEditContext: TextAreaEditContext): IDisposable {
+		this._textAreaEditContextMapping.set(ownerID, textAreaEditContext);
+		return {
+			dispose: () => {
+				this._textAreaEditContextMapping.delete(ownerID);
+			}
+		};
+	}
+
+	get(ownerID: string): TextAreaEditContext | undefined {
+		return this._textAreaEditContextMapping.get(ownerID);
+	}
+}
+
+export const TextAreaEditContextRegistry = new TextAreaEditContextRegistryImpl();

--- a/src/vs/editor/browser/view.ts
+++ b/src/vs/editor/browser/view.ts
@@ -293,7 +293,7 @@ export class View extends ViewEventHandler {
 		if (usingExperimentalEditContext) {
 			return this._instantiationService.createInstance(NativeEditContext, this._ownerID, this._context, this._overflowGuardContainer, this._viewController, this._createTextAreaHandlerHelper());
 		} else {
-			return this._instantiationService.createInstance(TextAreaEditContext, this._context, this._overflowGuardContainer, this._viewController, this._createTextAreaHandlerHelper());
+			return this._instantiationService.createInstance(TextAreaEditContext, this._ownerID, this._context, this._overflowGuardContainer, this._viewController, this._createTextAreaHandlerHelper());
 		}
 	}
 

--- a/src/vs/workbench/contrib/chat/browser/contrib/chatInputEditorContrib.ts
+++ b/src/vs/workbench/contrib/chat/browser/contrib/chatInputEditorContrib.ts
@@ -25,6 +25,7 @@ import { IChatWidget } from '../chat.js';
 import { ChatWidget } from '../chatWidget.js';
 import { dynamicVariableDecorationType } from './chatDynamicVariables.js';
 import { NativeEditContextRegistry } from '../../../../../editor/browser/controller/editContext/native/nativeEditContextRegistry.js';
+import { TextAreaEditContextRegistry } from '../../../../../editor/browser/controller/editContext/textArea/textAreaEditContextRegistry.js';
 import { CancellationToken } from '../../../../../base/common/cancellation.js';
 import { ThrottledDelayer } from '../../../../../base/common/async.js';
 
@@ -322,14 +323,23 @@ class InputEditorDecorations extends Disposable {
 
 	private updateAriaPlaceholder(value: string | undefined): void {
 		const nativeEditContext = NativeEditContextRegistry.get(this.widget.inputEditor.getId());
-		const domNode = nativeEditContext?.domNode.domNode;
-		if (!domNode) {
-			return;
-		}
-		if (value && value.trim().length) {
-			domNode.setAttribute('aria-placeholder', value);
+		if (nativeEditContext) {
+			const domNode = nativeEditContext.domNode.domNode;
+			if (value && value.trim().length) {
+				domNode.setAttribute('aria-placeholder', value);
+			} else {
+				domNode.removeAttribute('aria-placeholder');
+			}
 		} else {
-			domNode.removeAttribute('aria-placeholder');
+			const textAreaEditContext = TextAreaEditContextRegistry.get(this.widget.inputEditor.getId());
+			if (textAreaEditContext) {
+				const textArea = textAreaEditContext.textArea.domNode;
+				if (value && value.trim().length) {
+					textArea.setAttribute('aria-placeholder', value);
+				} else {
+					textArea.removeAttribute('aria-placeholder');
+				}
+			}
 		}
 	}
 }


### PR DESCRIPTION
fixes #269070

The fix addresses the issue where chat input placeholder text wasn't read by screen readers in certain browser configurations. The original PR only worked when the browser's native EditContext API was available (determined by checking if the global EditContext function exists), but failed when VS Code fell back to TextAreaEditContext on browsers without this API support. The solution creates a TextAreaEditContextRegistry similar to the existing NativeEditContextRegistry, registers TextAreaEditContext instances with their editor IDs, and updates the updateAriaPlaceholder method to check both registries - first attempting NativeEditContext, then falling back to TextAreaEditContext. This ensures aria-placeholder is set correctly regardless of which edit context implementation the browser uses, without relying on querySelector for DOM access.

I don't have access to windows, but had @amunger check and confirmed that on windows, the active element is:

<img width="1152" height="702" alt="image (45)" src="https://github.com/user-attachments/assets/7eec6ff0-c4df-482e-84f6-d7ce8fb3a9e3" />

@aiday-mar could you pls test on windows?

This `TextAreaEditContextRegistryImpl` is needed to avoid a call of `.querySelector`