### PR TITLE
Change tooltip text for prompt file copy button in quickpick

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/promptSyntax/pickers/promptFilePickers.ts
+++ b/src/vs/workbench/contrib/chat/browser/promptSyntax/pickers/promptFilePickers.ts
@@ -206,7 +206,7 @@ const RENAME_BUTTON: IQuickInputButton = {
  * Button that copies a prompt file.
  */
 const COPY_BUTTON: IQuickInputButton = {
-	tooltip: localize('copy', "Copy"),
+	tooltip: localize('makeACopy', "Make a Copy"),
 	iconClass: ThemeIcon.asClassName(Codicon.copy),
 };
 


### PR DESCRIPTION
Current text "Copy" makes it seem like it will copy to clipboard, or some other copy action that later requires a "paste" action