### PR TITLE
Update Fig spec for Azure Developer CLI (azd)

### DIFF
--- a/extensions/terminal-suggest/src/completions/azd.ts
+++ b/extensions/terminal-suggest/src/completions/azd.ts
@@ -192,6 +192,16 @@ const completionSpec: Fig.Spec = {
 			description: 'Add a component to your project.',
 		},
 		{
+			name: ['ai'],
+			description: 'Extension for the Foundry Agent Service. (Preview)',
+			subcommands: [
+				{
+					name: ['agent'],
+					description: 'Extension for the Foundry Agent Service. (Preview)',
+				},
+			],
+		},
+		{
 			name: ['auth'],
 			description: 'Authenticate with Azure.',
 			subcommands: [
@@ -275,6 +285,10 @@ const completionSpec: Fig.Spec = {
 			],
 		},
 		{
+			name: ['coding-agent'],
+			description: 'This extension configures GitHub Copilot Coding Agent access to Azure',
+		},
+		{
 			name: ['completion'],
 			description: 'Generate shell completion scripts.',
 			subcommands: [
@@ -352,6 +366,10 @@ const completionSpec: Fig.Spec = {
 			],
 		},
 		{
+			name: ['demo'],
+			description: 'This extension provides examples of the AZD extension framework.',
+		},
+		{
 			name: ['deploy'],
 			description: 'Deploy your project code to Azure.',
 			options: [
@@ -407,6 +425,10 @@ const completionSpec: Fig.Spec = {
 					isDangerous: true,
 				},
 			],
+			args: {
+				name: 'layer',
+				isOptional: true,
+			},
 		},
 		{
 			name: ['env'],
@@ -496,6 +518,15 @@ const completionSpec: Fig.Spec = {
 							args: [
 								{
 									name: 'hint',
+								},
+							],
+						},
+						{
+							name: ['--layer'],
+							description: 'Provisioning layer to refresh the environment from.',
+							args: [
+								{
+									name: 'layer',
 								},
 							],
 						},
@@ -647,7 +678,8 @@ const completionSpec: Fig.Spec = {
 						},
 					],
 					args: {
-						name: 'extension-name',
+						name: 'extension-id',
+						generators: azdGenerators.listExtensions,
 					},
 				},
 				{
@@ -1273,6 +1305,10 @@ const completionSpec: Fig.Spec = {
 					description: 'Preview changes to Azure resources.',
 				},
 			],
+			args: {
+				name: 'layer',
+				isOptional: true,
+			},
 		},
 		{
 			name: ['publish'],
@@ -1475,12 +1511,26 @@ const completionSpec: Fig.Spec = {
 			description: 'Print the version number of Azure Developer CLI.',
 		},
 		{
+			name: ['x'],
+			description: 'This extension provides a set of tools for AZD extension developers to test and debug their extensions.',
+		},
+		{
 			name: ['help'],
 			description: 'Help about any command',
 			subcommands: [
 				{
 					name: ['add'],
 					description: 'Add a component to your project.',
+				},
+				{
+					name: ['ai'],
+					description: 'Extension for the Foundry Agent Service. (Preview)',
+					subcommands: [
+						{
+							name: ['agent'],
+							description: 'Extension for the Foundry Agent Service. (Preview)',
+						},
+					],
 				},
 				{
 					name: ['auth'],
@@ -1495,6 +1545,10 @@ const completionSpec: Fig.Spec = {
 							description: 'Log out of Azure.',
 						},
 					],
+				},
+				{
+					name: ['coding-agent'],
+					description: 'This extension configures GitHub Copilot Coding Agent access to Azure',
 				},
 				{
 					name: ['completion'],
@@ -1551,6 +1605,10 @@ const completionSpec: Fig.Spec = {
 							description: 'Unsets a configuration.',
 						},
 					],
+				},
+				{
+					name: ['demo'],
+					description: 'This extension provides examples of the AZD extension framework.',
 				},
 				{
 					name: ['deploy'],
@@ -1767,6 +1825,10 @@ const completionSpec: Fig.Spec = {
 				{
 					name: ['version'],
 					description: 'Print the version number of Azure Developer CLI.',
+				},
+				{
+					name: ['x'],
+					description: 'This extension provides a set of tools for AZD extension developers to test and debug their extensions.',
 				},
 			],
 		},


### PR DESCRIPTION
Closes https://github.com/Azure/azure-dev/issues/6318

This PR updates the Fig autocomplete spec for Azure Developer CLI (azd) with the following changes:

- Include extension commands
    <img width="1232" height="320" alt="image" src="https://github.com/user-attachments/assets/356608a5-8405-4210-a6f1-1df5659993e6" />
- Add `layer` arg to supported commands
    <img width="1348" height="180" alt="image" src="https://github.com/user-attachments/assets/332da9a9-331b-496a-b844-9d5de05d44ea" />
- Use generator for `extension show`
    <img width="1346" height="518" alt="image" src="https://github.com/user-attachments/assets/ec78cb67-edea-4449-a546-23b0a165e3d2" />

cc @Tyriar, @meganrogge