### PR TITLE
Update input container width for better alignment

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/media/chat.css
@@ -755,7 +755,7 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	border-radius: 4px;
 	padding: 0 6px 6px 6px;
 	/* top padding is inside the editor widget */
-	max-width: 100%;
+	width: 100%;
 }
 
 .interactive-input-part:has(.chat-editing-session > .chat-editing-session-container) .chat-input-container,


### PR DESCRIPTION

The chat input container and its associated widgets (editing session, todo list) were misaligned by approximately 0.5-1px on the right edge. max-width: 100% uses constraint-based sizing where the browser calculates intrinsic content width first, then constrains it potentially introducing subpixel rounding differences between elements. Changed to width: 100% so that all elements use explicit percentage-based width calculation

Also see linked issue for screen shot of issue