### PR TITLE
match styles with thinking headers

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/media/chatConfirmationWidget.css
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/media/chatConfirmationWidget.css
@@ -16,7 +16,7 @@
 	padding: 0 12px;
 	min-height: 2em;
 	box-sizing: border-box;
-	font-size: var(--vscode-chat-font-size-body-s);
+	font-size: var(--vscode-chat-font-size-body-m);
 }
 
 .chat-confirmation-widget:not(:last-child) {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

all the dropdownable pieces have `medium` font size except the chat-confirmation titles for some reason
<img width="508" height="201" alt="Screenshot 2025-12-04 at 4 38 13 PM" src="https://github.com/user-attachments/assets/827a34b4-8e97-406a-9d8f-ccb5be5adf12" />
