### PR TITLE
Use correlationId when available

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadLanguageFeatures.ts
+++ b/src/vs/workbench/api/browser/mainThreadLanguageFeatures.ts
@@ -1434,7 +1434,7 @@ class ExtensionBackedInlineCompletionsProvider extends Disposable implements lan
 			selectedSuggestionInfo: lifetimeSummary.selectedSuggestionInfo,
 			extensionId: this.providerId.extensionId!,
 			extensionVersion: this.providerId.extensionVersion!,
-			groupId: this.groupId,
+			groupId: extractEngineFromCorrelationId(lifetimeSummary.correlationId) ?? this.groupId,
 			skuPlan: lifetimeSummary.skuPlan,
 			skuType: lifetimeSummary.skuType,
 			performanceMarkers: lifetimeSummary.performanceMarkers,
@@ -1476,5 +1476,17 @@ class ExtensionBackedInlineCompletionsProvider extends Disposable implements lan
 
 	override toString() {
 		return `InlineCompletionsProvider(${this.providerId.toString()})`;
+	}
+}
+
+function extractEngineFromCorrelationId(correlationId: string | undefined): string | undefined {
+	if (!correlationId) {
+		return undefined;
+	}
+	try {
+		const parsed = JSON.parse(correlationId);
+		return parsed.engine;
+	} catch {
+		return undefined;
 	}
 }

--- a/src/vs/workbench/api/browser/mainThreadLanguageFeatures.ts
+++ b/src/vs/workbench/api/browser/mainThreadLanguageFeatures.ts
@@ -1485,7 +1485,10 @@ function extractEngineFromCorrelationId(correlationId: string | undefined): stri
 	}
 	try {
 		const parsed = JSON.parse(correlationId);
-		return parsed.engine;
+		if (typeof parsed === 'object' && parsed !== null && typeof parsed.engine === 'string') {
+			return parsed.engine;
+		}
+		return undefined;
 	} catch {
 		return undefined;
 	}


### PR DESCRIPTION
```Copilot Generated Description:``` Implement logic to extract the engine from the correlationId when it is present, updating the groupId accordingly. A new function is added to parse the correlationId.

