### PR TITLE
Trigger NES when accepting rename suggestion

### DIFF
--- a/src/vs/editor/contrib/inlineCompletions/browser/model/inlineCompletionsModel.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/model/inlineCompletionsModel.ts
@@ -919,12 +919,14 @@ export class InlineCompletionsModel extends Disposable {
 		completion.addRef();
 
 		try {
+			let followUpTrigger = false;
 			editor.pushUndoStop();
 			if (isNextEditUri) {
 				// Do nothing
 			} else if (completion.action?.kind === 'edit') {
 				const action = completion.action;
-				if (action.alternativeAction && alternativeAction) {
+				if (alternativeAction && action.alternativeAction) {
+					followUpTrigger = true;
 					const altCommand = action.alternativeAction.command;
 					await this._commandService
 						.executeCommand(altCommand.id, ...(altCommand.arguments || []))
@@ -977,6 +979,11 @@ export class InlineCompletionsModel extends Disposable {
 				await this._commandService
 					.executeCommand(completion.command.id, ...(completion.command.arguments || []))
 					.then(undefined, onUnexpectedExternalError);
+			}
+
+			// TODO: how can we make alternative actions to retrigger?
+			if (followUpTrigger) {
+				this.trigger(undefined);
 			}
 
 			completion.reportEndOfLife({ kind: InlineCompletionEndOfLifeReasonKind.Accepted });


### PR DESCRIPTION
```Copilot Generated Description:``` Introduce a mechanism to trigger the next edit suggestion when an alternative action is accepted

