### PR TITLE
Rename suggestion tweaks

### DIFF
--- a/src/vs/editor/contrib/inlineCompletions/browser/model/InlineSuggestAlternativeAction.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/model/InlineSuggestAlternativeAction.ts
@@ -7,7 +7,7 @@ import { Command } from '../../../../common/languages.js';
 
 export type InlineSuggestAlternativeAction = {
 	label: string;
-	icon?: ThemeIcon;
+	icon: ThemeIcon;
 	command: Command;
 	count: Promise<number>;
 };

--- a/src/vs/editor/contrib/inlineCompletions/browser/model/renameSymbolProcessor.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/model/renameSymbolProcessor.ts
@@ -25,6 +25,7 @@ import { renameSymbolCommandId } from '../controller/commandIds.js';
 import { InlineSuggestionItem } from './inlineSuggestionItem.js';
 import { IInlineSuggestDataActionEdit } from './provideInlineCompletions.js';
 import { InlineSuggestAlternativeAction } from './InlineSuggestAlternativeAction.js';
+import { Codicon } from '../../../../../base/common/codicons.js';
 
 enum RenameKind {
 	no = 'no',
@@ -365,7 +366,7 @@ export class RenameSymbolProcessor extends Disposable {
 
 		// Check asynchronously if a rename is possible
 		let timedOut = false;
-		const check = await raceTimeout<RenameKind>(this.checkRenamePrecondition(suggestItem, textModel, position, oldName, newName), 1000, () => { timedOut = true; });
+		const check = await raceTimeout<RenameKind>(this.checkRenamePrecondition(suggestItem, textModel, position, oldName, newName), 100, () => { timedOut = true; });
 		const renamePossible = check === RenameKind.yes || check === RenameKind.maybe;
 
 		suggestItem.setRenameProcessingInfo({
@@ -404,7 +405,7 @@ export class RenameSymbolProcessor extends Disposable {
 		};
 		const alternativeAction: InlineSuggestAlternativeAction = {
 			label: localize('rename', "Rename"),
-			//icon: Codicon.replaceAll,
+			icon: Codicon.replaceAll,
 			command,
 			count: runnable.getCount(),
 		};

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/components/gutterIndicatorMenu.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/components/gutterIndicatorMenu.ts
@@ -26,7 +26,7 @@ import { defaultKeybindingLabelStyles } from '../../../../../../../platform/them
 import { asCssVariable, descriptionForeground, editorActionListForeground, editorHoverBorder } from '../../../../../../../platform/theme/common/colorRegistry.js';
 import { ObservableCodeEditor } from '../../../../../../browser/observableCodeEditor.js';
 import { EditorOption } from '../../../../../../common/config/editorOptions.js';
-import { hideInlineCompletionId, inlineSuggestCommitId, toggleShowCollapsedId } from '../../../controller/commandIds.js';
+import { hideInlineCompletionId, inlineSuggestCommitAlternativeActionId, inlineSuggestCommitId, toggleShowCollapsedId } from '../../../controller/commandIds.js';
 import { FirstFnArg, } from '../utils/utils.js';
 import { InlineSuggestionGutterMenuData } from './gutterIndicatorView.js';
 
@@ -80,6 +80,13 @@ export class GutterIndicatorMenuContent {
 			icon: Codicon.close,
 			commandId: hideInlineCompletionId
 		}));
+
+		const alternativeCommand = this._data.alternativeAction ? option(createOptionArgs({
+			id: 'alternativeCommand',
+			title: this._data.alternativeAction.command.title,
+			icon: this._data.alternativeAction.icon,
+			commandId: inlineSuggestCommitAlternativeActionId,
+		})) : undefined;
 
 		const extensionCommands = this._data.extensionCommands.map((c, idx) => option(createOptionArgs({
 			id: c.command.id + '_' + idx,
@@ -148,6 +155,7 @@ export class GutterIndicatorMenuContent {
 		return hoverContent([
 			title,
 			gotoAndAccept,
+			alternativeCommand,
 			reject,
 			toggleCollapsedMode,
 			modelOptions.length ? separator() : undefined,

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/components/gutterIndicatorView.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/components/gutterIndicatorView.ts
@@ -46,10 +46,12 @@ export class InlineEditsGutterIndicatorData {
 
 export class InlineSuggestionGutterMenuData {
 	public static fromInlineSuggestion(suggestion: InlineSuggestionItem): InlineSuggestionGutterMenuData {
+		const alternativeAction = suggestion.action?.kind === 'edit' ? suggestion.action.alternativeAction : undefined;
 		return new InlineSuggestionGutterMenuData(
 			suggestion.gutterMenuLinkAction,
 			suggestion.source.provider.displayName ?? localize('inlineSuggestion', "Inline Suggestion"),
 			suggestion.source.inlineSuggestions.commands ?? [],
+			alternativeAction,
 			suggestion.source.provider.modelInfo,
 			suggestion.source.provider.setModelId?.bind(suggestion.source.provider),
 		);
@@ -59,6 +61,7 @@ export class InlineSuggestionGutterMenuData {
 		readonly action: Command | undefined,
 		readonly displayName: string,
 		readonly extensionCommands: InlineCompletionCommand[],
+		readonly alternativeAction: InlineSuggestAlternativeAction | undefined,
 		readonly modelInfo: IInlineCompletionModelInfo | undefined,
 		readonly setModelId: ((modelId: string) => Promise<void>) | undefined,
 	) { }

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/inlineEditsWordReplacementView.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/inlineEditsWordReplacementView.ts
@@ -122,10 +122,15 @@ export class InlineEditsWordReplacementView extends Disposable implements IInlin
 				const label = this._viewData.alternativeAction.label;
 				const count = altCount.read(reader);
 				const active = altModifierActive.read(reader);
+				const occurrencesLabel = count !== undefined ? count === 1 ?
+					localize('labelOccurence', "{0} 1 occurrence", label) :
+					localize('labelOccurences', "{0} {1} occurrences", label, count)
+					: label;
+				const keybindingTooltip = localize('shiftToSeeOccurences', "{0} show occurrences", '[shift]');
 				alternativeAction = {
-					label: count !== undefined ? (active ? localize('labelOccurances', "{0} {1} occurrences", label, count) : label) : label,
-					tooltip: count !== undefined ? localize('labelOccurances', "{0} {1} occurrences", label, count) : label,
-					icon: this._viewData.alternativeAction.icon,
+					label: count !== undefined ? (active ? occurrencesLabel : label) : label,
+					tooltip: occurrencesLabel ? `${occurrencesLabel}\n${keybindingTooltip}` : undefined,
+					icon: undefined, //this._viewData.alternativeAction.icon, Do not render icon fo the moment
 					count,
 					keybinding: this._keybindingService.lookupKeybinding(inlineSuggestCommitAlternativeActionId),
 					active: altModifierActive,
@@ -290,7 +295,9 @@ export class InlineEditsWordReplacementView extends Disposable implements IInlin
 										this._secondaryElement.set(elem, undefined);
 									},
 									ref: (elem) => {
-										reader.store.add(this._hoverService.setupDelayedHoverAtMouse(elem, { content: altAction.tooltip, appearance: { compact: true } }));
+										if (altAction.tooltip) {
+											reader.store.add(this._hoverService.setupDelayedHoverAtMouse(elem, { content: altAction.tooltip, appearance: { compact: true } }));
+										}
 									}
 								}, [
 									keybinding,


### PR DESCRIPTION
```Copilot Generated Description:``` Adjust the handling of inline suggestion actions by refining the alternative action structure and updating related command identifiers. Modify the timeout duration for rename precondition checks and ensure proper rendering of alternative action details in the gutter menu.

fixes https://github.com/microsoft/vscode-copilot/issues/19166
fixes https://github.com/microsoft/vscode-copilot/issues/19164