### PR TITLE
Fix arrow background issue

### DIFF
--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/inlineEditsWordReplacementView.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/inlineEditsWordReplacementView.ts
@@ -195,7 +195,7 @@ export class InlineEditsWordReplacementView extends Disposable implements IInlin
 
 				const primaryActionStyles = derived(this, r => alternativeActionActive.read(r) ? primaryActiveStyles : primaryActiveStyles);
 				const secondaryActionStyles = derived(this, r => alternativeActionActive.read(r) ? secondaryActiveStyles : passiveStyles);
-
+				// TODO@benibenj clicking the arrow does not accept suggestion anymore
 				return [
 					n.div({
 						style: {
@@ -209,7 +209,6 @@ export class InlineEditsWordReplacementView extends Disposable implements IInlin
 							style: {
 								position: 'absolute',
 								...rectToProps(reader => layout.read(reader).lowerBackground.withMargin(BORDER_WIDTH, 2 * BORDER_WIDTH, BORDER_WIDTH, 0)),
-								width: undefined,
 								background: asCssVariable(editorBackground),
 							},
 							onmousedown: e => {


### PR DESCRIPTION
```Copilot Generated Description:``` Restore the background for the arrow in the inline edits word replacement view.

