### PR TITLE
Fix node-gyp configuration for macOS

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,7 +1,4 @@
 disturl="https://electronjs.org/headers"
 target="39.2.3"
-ms_build_id="12869810"
 runtime="electron"
-build_from_source="true"
 legacy-peer-deps="true"
-timeout=180000


### PR DESCRIPTION
Removes Windows-specific build settings from .npmrc that were causing Visual Studio detection errors on macOS. This allows npm install to complete successfully on macOS systems.