### PR TITLE
Ignore errors and UI interactions in fetch tool

### DIFF
--- a/src/vs/platform/webContentExtractor/test/electron-main/webPageLoader.test.ts
+++ b/src/vs/platform/webContentExtractor/test/electron-main/webPageLoader.test.ts
@@ -34,6 +34,14 @@ class MockWebContents {
 		return this;
 	}
 
+	on(event: string, listener: (...args: unknown[]) => void): this {
+		if (!this._listeners.has(event)) {
+			this._listeners.set(event, []);
+		}
+		this._listeners.get(event)!.push(listener);
+		return this;
+	}
+
 	emit(event: string, ...args: unknown[]): void {
 		const listeners = this._listeners.get(event) || [];
 		for (const listener of listeners) {


### PR DESCRIPTION
Fixes #280743

With this change we are able to load pages such as:
- xbox.com
- https://www.tagesanzeiger.ch/ukraine-news-us-gesandter-witkoff-bei-putin-in-moskau-939751065185
- others that result in ERR_ABORT in Electron

The change also disables some UI interaction events.
