### PR TITLE
Add DOM extraction fallback to fetch tool

### DIFF
--- a/src/vs/platform/webContentExtractor/electron-main/webPageLoader.ts
+++ b/src/vs/platform/webContentExtractor/electron-main/webPageLoader.ts
@@ -72,14 +72,8 @@ export class WebPageLoader extends Disposable {
 			.once('did-finish-load', this.onFinishLoad.bind(this))
 			.once('did-fail-load', this.onFailLoad.bind(this))
 			.once('will-navigate', this.onRedirect.bind(this))
-			.once('will-redirect', this.onRedirect.bind(this));
-
-		// Disable any UI interactions that could interfere with content loading.
-		this._window.webContents
-			.on('login', (event) => event.preventDefault())
-			.on('select-client-certificate', (event) => event.preventDefault())
-			.on('certificate-error', (event) => event.preventDefault());
-
+			.once('will-redirect', this.onRedirect.bind(this))
+			.on('select-client-certificate', (event) => event.preventDefault());
 	}
 
 	private trace(message: string) {


### PR DESCRIPTION
Fixes #280718

With this change fetch tool can load cnn.com and similar pages (where accessibility tree does not yield and results) by falling back to returning textContent of the main content node.

We will now return an error when no content can be extracted.
