### PR TITLE
Update request headers in fetch tool

### DIFF
--- a/src/vs/platform/webContentExtractor/electron-main/webPageLoader.ts
+++ b/src/vs/platform/webContentExtractor/electron-main/webPageLoader.ts
@@ -139,10 +139,6 @@ export class WebPageLoader extends Disposable {
 	 * Updates HTTP headers for each web request.
 	 */
 	private onBeforeSendHeaders(details: OnBeforeSendHeadersListenerDetails, callback: (beforeSendResponse: BeforeSendResponse) => void) {
-		if (this._store.isDisposed) {
-			return;
-		}
-
 		const headers = { ...details.requestHeaders };
 
 		// Request privacy for web-sites that respect these.

--- a/src/vs/platform/webContentExtractor/test/electron-main/webPageLoader.test.ts
+++ b/src/vs/platform/webContentExtractor/test/electron-main/webPageLoader.test.ts
@@ -22,6 +22,12 @@ class MockWebContents {
 	public loadURL = sinon.stub().resolves();
 	public getTitle = sinon.stub().returns('Test Page Title');
 
+	public session = {
+		webRequest: {
+			onBeforeSendHeaders: sinon.stub()
+		}
+	};
+
 	constructor() {
 		this.debugger = new MockDebugger();
 	}


### PR DESCRIPTION
With this change we are loading content from nytimes.com correctly.

This contributes towards fixing #280714.
The page will now load as this change prevents doubleclick.net redirect, but the rest of the redirect flow is changed.

Fixes #281140