### PR TITLE
InlineEditsView: remove redeclaration of textModel

### DIFF
--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsView.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsView.ts
@@ -348,15 +348,11 @@ export class InlineEditsView extends Disposable {
 			diff = lineRangeMappingFromRangeMappings(mappings, inlineEdit.originalText, newText);
 		}
 
-		const tm = this._editorObs.model.read(reader);
-		if (!tm) {
-			return undefined;
-		}
-		this._previewTextModel.setLanguage(tm.getLanguageId());
+		this._previewTextModel.setLanguage(textModel.getLanguageId());
 
 		const previousNewText = this._previewTextModel.getValue();
 		if (previousNewText !== newText.getValue()) {
-			this._previewTextModel.setEOL(tm.getEndOfLineSequence());
+			this._previewTextModel.setEOL(textModel.getEndOfLineSequence());
 			const updateOldValueEdit = StringEdit.replace(new OffsetRange(0, previousNewText.length), newText.getValue());
 			const updateOldValueEditSmall = updateOldValueEdit.removeCommonSuffixPrefix(previousNewText);
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
Seems that tm variable is redundant, because textModel is already read above. I don't see anything that can change it before it is reloaded, am I missing something?

If not, I think it worth it to remove redeclaration to simplify code.