### PR TITLE
Implement resetSession method in ChatListItemRenderer and invoke it in ChatWidget for session management.  Fix #277574

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatListRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatListRenderer.ts
@@ -291,6 +291,19 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 
 	}
 
+	resetSession(): void {
+		for (const templateData of this.templateDataByRequestId.values()) {
+			this.clearRenderedParts(templateData);
+			templateData.elementDisposables.clear();
+			templateData.currentElement = undefined;
+		}
+		this.templateDataByRequestId.clear();
+		this.codeBlocksByResponseId.clear();
+		this.codeBlocksByEditorUri.clear();
+		this.fileTreesByResponseId.clear();
+		this.focusedFileTreesByResponseId.clear();
+	}
+
 	getCodeBlockInfoForEditor(uri: URI): IChatCodeBlockInfo | undefined {
 		return this.codeBlocksByEditorUri.get(uri);
 	}

--- a/src/vs/workbench/contrib/chat/browser/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatWidget.ts
@@ -797,6 +797,7 @@ export class ChatWidget extends Disposable implements IChatWidget {
 		this.inputPart.clearTodoListWidget(this.viewModel?.sessionResource, true);
 		this.chatSuggestNextWidget.hide();
 		await this.viewOptions.clear?.();
+		this.renderer?.resetSession();
 	}
 
 	private onDidChangeItems(skipDynamicLayout?: boolean) {
@@ -1967,6 +1968,7 @@ export class ChatWidget extends Disposable implements IChatWidget {
 		}
 
 		if (!model) {
+			this.renderer?.resetSession();
 			this.viewModel = undefined;
 			this.onDidChangeItems();
 			return;
@@ -1975,6 +1977,8 @@ export class ChatWidget extends Disposable implements IChatWidget {
 		if (isEqual(model.sessionResource, this.viewModel?.sessionResource)) {
 			return;
 		}
+
+		this.renderer?.resetSession();
 		this.inputPart.clearTodoListWidget(model.sessionResource, false);
 		this.chatSuggestNextWidget.hide();
 


### PR DESCRIPTION
Implement resetSession method in ChatListItemRenderer and invoke it in ChatWidget for session management.  Fix #277574.

gpt-5.1-codex-mini and I found another fix for #277574. I confirmed it is fixed.

A message from gpt-5.1-codex-mini:

- **What caused it?** Chat templates and renderer caches were left intact when a saved chat session was reloaded, so `ChatListItemRenderer` reused stale DOM/events (focusing, progressive rendering, etc.) tied to the previous session because `templateDataByRequestId`, code block maps, hover artifacts, and in-progress rendered parts were never reset.
- **Why this fixes it?** Introducing `resetSession()` clears every `templateData` (rendered parts, disposables, current element) and wipes the cached maps before a new model is bound or the widget is cleared, ensuring ListView always renders against a clean slate instead of recycling the old nodes, which eliminates the leftover rendering glitches.


cc: @connor4312 