### PR TITLE
SingleUpdatedNextEdit: Correctly apply insertion changes

### DIFF
--- a/src/vs/editor/contrib/inlineCompletions/browser/model/inlineSuggestionItem.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/model/inlineSuggestionItem.ts
@@ -673,7 +673,7 @@ class SingleUpdatedNextEdit {
 			if (isInsertion && !shouldPreserveEditShape && change.replaceRange.start === editStart && editReplaceText.startsWith(change.newText)) {
 				editStart += change.newText.length;
 				editReplaceText = editReplaceText.substring(change.newText.length);
-				editEnd = Math.max(editStart, editEnd);
+				editEnd += change.newText.length;
 				editHasChanged = true;
 				continue;
 			}

--- a/src/vs/editor/contrib/inlineCompletions/test/browser/inlineEdits.test.ts
+++ b/src/vs/editor/contrib/inlineCompletions/test/browser/inlineEdits.test.ts
@@ -18,6 +18,10 @@ class Point {
 	getLength2D(): number {
 		return↓ Math.sqrt(this.x * this.x + this.y * this.y↓);
 	}
+
+	getJson(): string {
+		return ↓Ü;
+	}
 }
 `);
 
@@ -57,6 +61,10 @@ class Point {
 	getLength3D(): number {
 		return Math.sqrt(this.x * this.x + this.y * this.y + this.z * this.z);
 	}
+
+	getJson(): string {
+		return Ü;
+	}
 }
 `);
 		});
@@ -86,6 +94,24 @@ class Point {
 			editorViewModel.type('his.z * this.z');
 			assert.deepStrictEqual(view.getAndClearViewStates(), ([
 				'\n\tget❰Length2↦Length3❱D(): numbe...'
+			]));
+		});
+	});
+
+	test('Inline Edit Is Correctly Shifted When Typing', async function () {
+		await runTest(async ({ context, model, editor, editorViewModel }, provider, view) => {
+			provider.add(`Ü`, `{x: this.x, y: this.y}`);
+			await model.trigger();
+			await timeout(10000);
+			assert.deepStrictEqual(view.getAndClearViewStates(), ([
+				undefined,
+				"...\n\t\treturn ❰Ü↦{x: t...is.y}❱;\n"
+			]));
+			editor.setPosition(val.getMarkerPosition(2));
+			editorViewModel.type('{');
+
+			assert.deepStrictEqual(view.getAndClearViewStates(), ([
+				"...\t\treturn {❰Ü↦x: th...is.y}❱;\n"
 			]));
 		});
 	});

--- a/src/vs/editor/contrib/inlineCompletions/test/browser/inlineEdits.test.ts
+++ b/src/vs/editor/contrib/inlineCompletions/test/browser/inlineEdits.test.ts
@@ -100,18 +100,18 @@ class Point {
 
 	test('Inline Edit Is Correctly Shifted When Typing', async function () {
 		await runTest(async ({ context, model, editor, editorViewModel }, provider, view) => {
-			provider.add(`Ü`, `{x: this.x, y: this.y}`);
+			provider.add('Ü', '{x: this.x, y: this.y}');
 			await model.trigger();
 			await timeout(10000);
 			assert.deepStrictEqual(view.getAndClearViewStates(), ([
 				undefined,
-				"...\n\t\treturn ❰Ü↦{x: t...is.y}❱;\n"
+				'...\n\t\treturn ❰Ü↦{x: t...is.y}❱;\n'
 			]));
 			editor.setPosition(val.getMarkerPosition(2));
 			editorViewModel.type('{');
 
 			assert.deepStrictEqual(view.getAndClearViewStates(), ([
-				"...\t\treturn {❰Ü↦x: th...is.y}❱;\n"
+				'...\t\treturn {❰Ü↦x: th...is.y}❱;\n'
 			]));
 		});
 	});


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Currently when changes are applied to a `SingleUpdatedNextEdit` insertions are applied not entirely correctly.

In case if:
1. The change is insertion
2. The change starts exactly at cursor
3. Edit starts with inserted text

We do the following:
1. Reduce the length of the edit, removing first character, since they have been typed manually. 
2. Shift the left (start) border of the edit to the right
3. Leave the right (end) border as is, except the edge case when start becomes bigger then end, then move end to the new start.

What is the problem:
1. The user inserted chars, typing chars from our suggestion, so our suggested text becomes shorted - this is correct
2. The area we want to replace also becomes shorter since we only move the left edge - this is incorrect.

Why this is incorrect:
1. Our suggestion recommends to replace certain old text with a certain new text
2. If the user typed some of our new text we can assume that this typed part should not longer be inserted
3. But the old text we wanted to remove is still entirely there and we probably still want to replace it.

Here is an example:

```
const myVar = "hel"
                  ^---cursor here before "
suggestion to replace `"` with `lo world";`
(notice semicolon in the end)
```

If the user types `l`, the system goes to this state:
```
const myVar = "hell"
                   ^---cursor here before "
```
It is correct to assume that we only want to insert `o world";` now, but we still want to replace `"` char.

So we should move both start and end edge of replace range.

Fixes #281520