### PR TITLE
Fix not revealing edit in long distance hint

### DIFF
--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/longDistanceHint/longDistancePreviewEditor.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/longDistanceHint/longDistancePreviewEditor.ts
@@ -5,6 +5,7 @@
 
 import { n } from '../../../../../../../../base/browser/dom.js';
 import { Disposable } from '../../../../../../../../base/common/lifecycle.js';
+import { clamp } from '../../../../../../../../base/common/numbers.js';
 import { IObservable, derived, constObservable, IReader, autorun, observableValue } from '../../../../../../../../base/common/observable.js';
 import { IInstantiationService } from '../../../../../../../../platform/instantiation/common/instantiation.js';
 import { ICodeEditor } from '../../../../../../../browser/editorBrowser.js';
@@ -259,11 +260,13 @@ export class LongDistancePreviewEditor extends Disposable {
 			return undefined;
 		}
 
-
 		// find the horizontal range we want to show.
 		const preferredRange = growUntilVariableBoundaries(editor.getModel()!, firstCharacterChange, 5);
-		const left = this._previewEditorObs.getLeftOfPosition(preferredRange.getStartPosition(), reader);
-		const right = Math.min(left, trueContentWidth); //this._previewEditorObs.getLeftOfPosition(preferredRange.getEndPosition(), reader);
+		const leftOffset = this._previewEditorObs.getLeftOfPosition(preferredRange.getStartPosition(), reader);
+		const rightOffset = this._previewEditorObs.getLeftOfPosition(preferredRange.getEndPosition(), reader);
+
+		const left = clamp(leftOffset, 0, trueContentWidth);
+		const right = clamp(rightOffset, left, trueContentWidth);
 
 		const indentCol = editor.getModel()!.getLineFirstNonWhitespaceColumn(preferredRange.startLineNumber);
 		const indentationEnd = this._previewEditorObs.getLeftOfPosition(new Position(preferredRange.startLineNumber, indentCol), reader);


### PR DESCRIPTION
```Copilot Generated Description:``` Adjust the calculation of left and right offsets in the LongDistancePreviewEditor to ensure edits are properly revealed. Use the `clamp` function to constrain the offsets within valid bounds.

https://github.com/microsoft/vscode/issues/281473