### PR TITLE
fix: traffic light position on macOS 26

### DIFF
--- a/src/vs/platform/windows/electron-main/windowImpl.ts
+++ b/src/vs/platform/windows/electron-main/windowImpl.ts
@@ -420,12 +420,11 @@ export abstract class BaseWindow extends Disposable implements IBaseWindow {
 
 		// macOS: update window controls via setWindowButtonPosition()
 		else if (isMacintosh && options.height !== undefined) {
-			// The traffic lights have a height of 12px. There's an invisible margin
-			// of 2px at the top and bottom, and 1px on the left and right. Therefore,
-			// the height for centering is 12px + 2 * 2px = 16px. When the position
-			// is set, the horizontal margin is offset to ensure the distance between
-			// the traffic lights and the window frame is equal in both directions.
-			const offset = Math.floor((options.height - 16) / 2);
+			// When the position is set, the horizontal margin is offset to ensure
+			// the distance between the traffic lights and the window frame is equal
+			// in both directions.
+			const buttonHeight = isTahoeOrNewer(release()) ? 14 : 16;
+			const offset = Math.floor((options.height - buttonHeight) / 2);
 			if (!offset) {
 				win.setWindowButtonPosition(null);
 			} else {


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/279769

Couldn't find an official documentation on the change, calculated by checking the frame.height value for `NSButton` obtained via https://developer.apple.com/documentation/appkit/nswindow/standardwindowbutton(_:)?language=objc 