### PR TITLE
feat(scm): add setting to hide commit input box

### DIFF
--- a/src/vs/workbench/contrib/scm/browser/scm.contribution.ts
+++ b/src/vs/workbench/contrib/scm/browser/scm.contribution.ts
@@ -374,6 +374,11 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).regis
 			markdownDescription: localize('showInputActionButton', "Controls whether an action button can be shown in the Source Control input."),
 			default: true
 		},
+		'scm.showInputBox': {
+			type: 'boolean',
+			markdownDescription: localize('showInputBox', "Controls whether the commit input box is shown in the Source Control view."),
+			default: true
+		},
 		'scm.workingSets.enabled': {
 			type: 'boolean',
 			description: localize('scm.workingSets.enabled', "Controls whether to store editor working sets when switching between source control history item groups."),

--- a/src/vs/workbench/contrib/scm/browser/scmViewPane.ts
+++ b/src/vs/workbench/contrib/scm/browser/scmViewPane.ts
@@ -750,9 +750,15 @@ class SCMTreeCompressionDelegate implements ITreeCompressionDelegate<TreeElement
 
 class SCMTreeFilter implements ITreeFilter<TreeElement> {
 
+	constructor(
+		private readonly configurationService: IConfigurationService
+	) { }
+
 	filter(element: TreeElement): boolean {
 		if (isSCMResourceGroup(element)) {
 			return element.resources.length > 0 || !element.hideWhenEmpty;
+		} else if (isSCMInput(element)) {
+			return this.configurationService.getValue<boolean>('scm.showInputBox') !== false;
 		} else {
 			return true;
 		}
@@ -2345,7 +2351,8 @@ export class SCMViewPane extends ViewPane {
 						e =>
 							e.affectsConfiguration('scm.inputMinLineCount') ||
 							e.affectsConfiguration('scm.inputMaxLineCount') ||
-							e.affectsConfiguration('scm.showActionButton'),
+							e.affectsConfiguration('scm.showActionButton') ||
+							e.affectsConfiguration('scm.showInputBox'),
 						this.visibilityDisposables)
 						(() => this.updateChildren(), this, this.visibilityDisposables);
 
@@ -2421,7 +2428,7 @@ export class SCMViewPane extends ViewPane {
 				horizontalScrolling: false,
 				setRowLineHeight: false,
 				transformOptimization: false,
-				filter: new SCMTreeFilter(),
+				filter: new SCMTreeFilter(this.configurationService),
 				dnd: new SCMTreeDragAndDrop(this.instantiationService),
 				identityProvider: new SCMResourceIdentityProvider(),
 				sorter: new SCMTreeSorter(() => this.viewMode, () => this.viewSortKey),


### PR DESCRIPTION
## Summary

Add `scm.showInputBox` setting that allows users to hide the commit message input box in the Source Control view.

- Adds new boolean setting `scm.showInputBox` (default: `true`)
- Filters input box elements from the SCM tree when setting is `false`
- Refreshes the tree when setting changes

## Use Case

This is useful for users who:
- Prefer committing via terminal/CLI (e.g., using git CLI or other tools)
- Want a cleaner, more compact Source Control view
- Only use the panel to view changed files, not to commit

Fixes #281562