### PR TITLE
edits: fix files created from background agents showing 0/0 in diff

### DIFF
--- a/.github/workflows/monaco-editor.yml
+++ b/.github/workflows/monaco-editor.yml
@@ -9,6 +9,7 @@ on:
     branches:
       - main
       - release/*
+      - '1.107/sessions'
 permissions: {}
 
 jobs:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - 'release/*'
+      - '1.107/sessions'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingCheckpointTimelineImpl.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingCheckpointTimelineImpl.ts
@@ -326,7 +326,8 @@ export class ChatEditingCheckpointTimelineImpl implements IChatEditingCheckpoint
 
 	public hasFileBaseline(uri: URI, requestId: string): boolean {
 		const key = this._getBaselineKey(uri, requestId);
-		return this._fileBaselines.has(key);
+		return this._fileBaselines.has(key) || this._operations.get().some(op =>
+			op.type === FileOperationType.Create && op.requestId === requestId && isEqual(uri, op.uri));
 	}
 
 	public async getContentAtStop(requestId: string, contentURI: URI, stopId: string | undefined) {


### PR DESCRIPTION
Our baseline lookup logic was aware of 'create' operations to show them
at the right time, but if a created file was edited, we would
incorrectly add a baseline for it anyway which caused issues.

Closes https://github.com/microsoft/vscode/issues/281633

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
