### PR TITLE
Use ref counted IChatModelReference to fix agentSession.local.openChanges

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsActions.ts
@@ -18,7 +18,7 @@ import { ViewAction } from '../../../../browser/parts/views/viewPane.js';
 import { AGENT_SESSIONS_VIEW_ID, AgentSessionProviders, IAgentSessionsControl } from './agentSessions.js';
 import { AgentSessionsView } from './agentSessionsView.js';
 import { URI } from '../../../../../base/common/uri.js';
-import { IChatService } from '../../common/chatService.js';
+import { IChatModelReference, IChatService } from '../../common/chatService.js';
 import { ChatContextKeys } from '../../common/chatContextKeys.js';
 import { IMarshalledChatSessionContext } from '../actions/chatSessionActions.js';
 import { IChatEditorOptions } from '../chatEditor.js';
@@ -162,8 +162,8 @@ export class AgentSessionDiffActionViewItem extends ActionViewItem {
 CommandsRegistry.registerCommand(`agentSession.${AgentSessionProviders.Local}.openChanges`, async (accessor: ServicesAccessor, resource: URI) => {
 	const chatService = accessor.get(IChatService);
 
-	const session = chatService.getSession(resource);
-	session?.editingSession?.show();
+	const sessionRef = await chatService.getOrRestoreSession(resource);
+	sessionRef?.object.editingSession?.show();
 });
 
 //#endregion

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsActions.ts
@@ -162,8 +162,13 @@ export class AgentSessionDiffActionViewItem extends ActionViewItem {
 CommandsRegistry.registerCommand(`agentSession.${AgentSessionProviders.Local}.openChanges`, async (accessor: ServicesAccessor, resource: URI) => {
 	const chatService = accessor.get(IChatService);
 
-	const sessionRef = await chatService.getOrRestoreSession(resource);
-	sessionRef?.object.editingSession?.show();
+	let sessionRef: IChatModelReference | undefined;
+	try {
+		sessionRef = await chatService.getOrRestoreSession(resource);
+		await sessionRef?.object.editingSession?.show();
+	} finally {
+		sessionRef?.dispose();
+	}
 });
 
 //#endregion


### PR DESCRIPTION
Unless the chat was already open, clicking on the little file changes icon would not open the diff
<img width="344" height="93" alt="image" src="https://github.com/user-attachments/assets/397e1f21-1374-4be0-837e-b1f75ecb1320" />


<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
