### PR TITLE
fix: ensure finishedEditing is called in ChatWidget

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatWidget.ts
@@ -1967,6 +1967,9 @@ export class ChatWidget extends Disposable implements IChatWidget {
 		}
 
 		if (!model) {
+			if (this.viewModel?.editing) {
+				this.finishedEditing();
+			}
 			this.viewModel = undefined;
 			this.onDidChangeItems();
 			return;
@@ -1974,6 +1977,10 @@ export class ChatWidget extends Disposable implements IChatWidget {
 
 		if (isEqual(model.sessionResource, this.viewModel?.sessionResource)) {
 			return;
+		}
+
+		if (this.viewModel?.editing) {
+			this.finishedEditing();
 		}
 		this.inputPart.clearTodoListWidget(model.sessionResource, false);
 		this.chatSuggestNextWidget.hide();


### PR DESCRIPTION
fix: ensure finishedEditing is called in ChatWidget. Fix #281734 