### PR TITLE
editor: implement StandaloneProductService for Monaco Editor

### DIFF
--- a/src/vs/editor/contrib/clipboard/browser/clipboard.ts
+++ b/src/vs/editor/contrib/clipboard/browser/clipboard.ts
@@ -285,13 +285,7 @@ if (PasteAction) {
 		const codeEditorService = accessor.get(ICodeEditorService);
 		const clipboardService = accessor.get(IClipboardService);
 		const telemetryService = accessor.get(ITelemetryService);
-		let productService: IProductService | undefined;
-		try {
-			// In standalone builds the product service might not be registered.
-			productService = accessor.get(IProductService);
-		} catch {
-			productService = undefined;
-		}
+		const productService = accessor.get(IProductService);
 
 		// Only if editor text focus (i.e. not if editor has widget focus).
 		const focusedEditor = codeEditorService.getFocusedCodeEditor();
@@ -312,7 +306,7 @@ if (PasteAction) {
 				logService.trace('registerExecCommandImpl (triggerPaste defined)');
 				return triggerPaste.then(async () => {
 					logService.trace('registerExecCommandImpl (after triggerPaste)');
-					if (productService && productService.quality !== 'stable') {
+					if (productService.quality !== 'stable') {
 						const duration = sw.elapsed();
 						type EditorAsyncPasteClassification = {
 							duration: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The duration of the paste operation.' };

--- a/src/vs/editor/contrib/clipboard/browser/clipboard.ts
+++ b/src/vs/editor/contrib/clipboard/browser/clipboard.ts
@@ -285,7 +285,13 @@ if (PasteAction) {
 		const codeEditorService = accessor.get(ICodeEditorService);
 		const clipboardService = accessor.get(IClipboardService);
 		const telemetryService = accessor.get(ITelemetryService);
-		const productService = accessor.get(IProductService);
+		let productService: IProductService | undefined;
+		try {
+			// In standalone builds the product service might not be registered.
+			productService = accessor.get(IProductService);
+		} catch {
+			productService = undefined;
+		}
 
 		// Only if editor text focus (i.e. not if editor has widget focus).
 		const focusedEditor = codeEditorService.getFocusedCodeEditor();
@@ -306,7 +312,7 @@ if (PasteAction) {
 				logService.trace('registerExecCommandImpl (triggerPaste defined)');
 				return triggerPaste.then(async () => {
 					logService.trace('registerExecCommandImpl (after triggerPaste)');
-					if (productService.quality !== 'stable') {
+					if (productService && productService.quality !== 'stable') {
 						const duration = sw.elapsed();
 						type EditorAsyncPasteClassification = {
 							duration: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The duration of the paste operation.' };

--- a/src/vs/editor/standalone/browser/standaloneServices.ts
+++ b/src/vs/editor/standalone/browser/standaloneServices.ts
@@ -100,6 +100,7 @@ import { IWebWorkerService } from '../../../platform/webWorker/browser/webWorker
 import { StandaloneWebWorkerService } from './services/standaloneWebWorkerService.js';
 import { IDefaultAccountService } from '../../../platform/defaultAccount/common/defaultAccount.js';
 import { IDefaultAccount } from '../../../base/common/defaultAccount.js';
+import { IProductService } from '../../../platform/product/common/productService.js';
 
 class SimpleModel implements IResolvedTextEditorModel {
 
@@ -1123,6 +1124,55 @@ class StandaloneDefaultAccountService implements IDefaultAccountService {
 	}
 }
 
+class StandaloneProductService implements IProductService {
+	declare readonly _serviceBrand: undefined;
+
+	readonly version = '1.0.0';
+	readonly nameShort = 'Monaco Editor';
+	readonly nameLong = 'Monaco Editor';
+	readonly applicationName = 'monaco-editor';
+	readonly dataFolderName = '.monaco-editor';
+	readonly urlProtocol = 'monaco-editor';
+	readonly quality = 'stable';
+	readonly serverApplicationName = 'monaco-editor-server';
+	readonly extensionProperties = {};
+	readonly defaultChatAgent = {
+		extensionId: '',
+		chatExtensionId: '',
+		documentationUrl: '',
+		skusDocumentationUrl: '',
+		publicCodeMatchesUrl: '',
+		manageSettingsUrl: '',
+		managePlanUrl: '',
+		manageOverageUrl: '',
+		upgradePlanUrl: '',
+		signUpUrl: '',
+		termsStatementUrl: '',
+		privacyStatementUrl: '',
+		provider: {
+			default: { id: '', name: '' },
+			enterprise: { id: '', name: '' },
+			google: { id: '', name: '' },
+			apple: { id: '', name: '' },
+		},
+		providerUriSetting: '',
+		providerScopes: [],
+		entitlementUrl: '',
+		entitlementSignupLimitedUrl: '',
+		chatQuotaExceededContext: '',
+		completionsQuotaExceededContext: '',
+		walkthroughCommand: '',
+		completionsMenuCommand: '',
+		completionsRefreshTokenCommand: '',
+		chatRefreshTokenCommand: '',
+		generateCommitMessageCommand: '',
+		resolveMergeConflictsCommand: '',
+		completionsAdvancedSetting: '',
+		completionsEnablementSetting: '',
+		nextEditSuggestionsSetting: '',
+	};
+}
+
 export interface IEditorOverrideServices {
 	[index: string]: unknown;
 }
@@ -1166,6 +1216,7 @@ registerSingleton(ITreeSitterLibraryService, StandaloneTreeSitterLibraryService,
 registerSingleton(ILoggerService, NullLoggerService, InstantiationType.Eager);
 registerSingleton(IDataChannelService, NullDataChannelService, InstantiationType.Eager);
 registerSingleton(IDefaultAccountService, StandaloneDefaultAccountService, InstantiationType.Eager);
+registerSingleton(IProductService, StandaloneProductService, InstantiationType.Eager);
 
 /**
  * We don't want to eagerly instantiate services because embedders get a one time chance


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Related Issues: 

- #https://github.com/microsoft/monaco-editor/issues/5079

This PR fixes an issue where the `PasteAction` would crash in the standalone editor (Monaco Editor) because `IProductService` is not registered in that environment.

Bug Fix

- Wrapped the retrieval of `IProductService` in a `try-catch` block.
- Added a check for `productService` existence before accessing its properties.

Verification

1. Verified that PasteAction no longer throws an error when `IProductService` is missing.
2. Verified that telemetry logic relying on productService is skipped safely when the service is undefined.