### PR TITLE
Fix text wrapping for rename occurrences

### DIFF
--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/inlineEditsWordReplacementView.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/inlineEditsWordReplacementView.ts
@@ -287,6 +287,7 @@ export class InlineEditsWordReplacementView extends Disposable implements IInlin
 										background: secondaryActionStyles.map(s => s.backgroundColor),
 										pointerEvents: 'auto',
 										cursor: 'pointer',
+										textWrap: 'nowrap',
 									},
 									class: 'inline-edit-alternative-action-label',
 									onmouseup: (e) => this._onDidClick.fire(InlineEditClickEvent.create(e, true)),


### PR DESCRIPTION
```Copilot Generated Description:``` Implement text wrapping for the rename occurrences action to prevent overflow.

https://github.com/microsoft/vscode/issues/281586