### PR TITLE
Fix chat sessions overflow issue

### DIFF
--- a/src/vs/base/browser/ui/list/list.css
+++ b/src/vs/base/browser/ui/list/list.css
@@ -8,6 +8,7 @@
 	height: 100%;
 	width: 100%;
 	white-space: nowrap;
+	overflow: hidden;
 }
 
 .monaco-list.mouse-support {

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/media/agentsessionsviewer.css
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/media/agentsessionsviewer.css
@@ -8,7 +8,6 @@
 	flex: 1 1 auto;
 	height: 100%;
 	min-height: 0;
-	overflow: hidden;
 
 	.monaco-list-row .force-no-twistie {
 		display: none !important;


### PR DESCRIPTION
```Copilot Generated Description:``` Adjust the CSS for the chat sessions list to ensure proper overflow handling by setting `overflow: hidden` on the list element.

microsoft/vscode#281920