### PR TITLE
Exclude terminal editors from recently closed editors history

### DIFF
--- a/src/vs/workbench/common/editor/editorInput.ts
+++ b/src/vs/workbench/common/editor/editorInput.ts
@@ -358,6 +358,9 @@ export abstract class EditorInput extends AbstractEditorInput {
 		super.dispose();
 	}
 
+	/**
+	 * Returns whether this editor input can be reopened after being closed.
+	 */
 	canReopen(): boolean {
 		return true;
 	}

--- a/src/vs/workbench/common/editor/editorInput.ts
+++ b/src/vs/workbench/common/editor/editorInput.ts
@@ -357,4 +357,8 @@ export abstract class EditorInput extends AbstractEditorInput {
 
 		super.dispose();
 	}
+
+	canReopen(): boolean {
+		return true;
+	}
 }

--- a/src/vs/workbench/common/editor/editorInput.ts
+++ b/src/vs/workbench/common/editor/editorInput.ts
@@ -301,6 +301,16 @@ export abstract class EditorInput extends AbstractEditorInput {
 	}
 
 	/**
+	 * Indicates if this editor can be reopened after being closed. By default
+	 * editors can be reopened. Subclasses can override to prevent this.
+	 *
+	 * @returns `true` if the editor can be reopened after being closed.
+	 */
+	canReopen(): boolean {
+		return true;
+	}
+
+	/**
 	 * Returns if the other object matches this input.
 	 */
 	matches(otherInput: EditorInput | IUntypedEditorInput): boolean {
@@ -356,12 +366,5 @@ export abstract class EditorInput extends AbstractEditorInput {
 		}
 
 		super.dispose();
-	}
-
-	/**
-	 * Returns whether this editor input can be reopened after being closed.
-	 */
-	canReopen(): boolean {
-		return true;
 	}
 }

--- a/src/vs/workbench/contrib/terminal/browser/terminalEditorInput.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalEditorInput.ts
@@ -244,4 +244,8 @@ export class TerminalEditorInput extends EditorInput implements IEditorCloseHand
 			}
 		};
 	}
+
+	override canReopen(): boolean {
+		return false;
+	}
 }

--- a/src/vs/workbench/contrib/terminal/browser/terminalEditorInput.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalEditorInput.ts
@@ -245,7 +245,7 @@ export class TerminalEditorInput extends EditorInput implements IEditorCloseHand
 		};
 	}
 
-	override canReopen(): boolean {
+	public override canReopen(): boolean {
 		return false;
 	}
 }

--- a/src/vs/workbench/services/history/browser/historyService.ts
+++ b/src/vs/workbench/services/history/browser/historyService.ts
@@ -669,6 +669,10 @@ export class HistoryService extends Disposable implements IHistoryService {
 			return; // ignore if editor was replaced or moved
 		}
 
+		if (editor.editorId === 'terminalEditor') {
+			return;
+		}
+
 		const untypedEditor = editor.toUntyped();
 		if (!untypedEditor) {
 			return; // we need a untyped editor to restore from going forward

--- a/src/vs/workbench/services/history/browser/historyService.ts
+++ b/src/vs/workbench/services/history/browser/historyService.ts
@@ -669,8 +669,8 @@ export class HistoryService extends Disposable implements IHistoryService {
 			return; // ignore if editor was replaced or moved
 		}
 
-		if (editor.editorId === 'terminalEditor') {
-			return;
+		if (!editor.canReopen()) {
+			return; // only editors that can be reopened
 		}
 
 		const untypedEditor = editor.toUntyped();


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Fix #280043 

Now `historyService.recentlyClosedEditors` will not track terminal editors.
