### PR TITLE
File diff behavior changes for chat sessions

### DIFF
--- a/src/vs/workbench/contrib/chat/common/chat.ts
+++ b/src/vs/workbench/contrib/chat/common/chat.ts
@@ -3,7 +3,8 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { awaitCompleteChatEditingDiff } from './chatEditingService.js';
+import { ResourceSet } from '../../../../base/common/map.js';
+import { chatEditingSessionIsReady } from './chatEditingService.js';
 import { IChatModel } from './chatModel.js';
 import type { IChatSessionStats, IChatTerminalToolInvocationData, ILegacyChatTerminalToolInvocationData } from './chatService.js';
 import { ChatModeKind } from './constants.js';
@@ -42,11 +43,22 @@ export async function awaitStatsForSession(model: IChatModel): Promise<IChatSess
 		return undefined;
 	}
 
-	const diffs = await awaitCompleteChatEditingDiff(model.editingSession.getDiffsForFilesInSession());
-	return diffs.reduce((acc, diff) => {
-		acc.fileCount++;
-		acc.added += diff.added;
-		acc.removed += diff.removed;
+	await chatEditingSessionIsReady(model.editingSession);
+
+	const diffs = model.editingSession.entries.get();
+	const reduceResult = diffs.reduce((acc, diff) => {
+		acc.fileUris.add(diff.originalURI);
+		acc.added += diff.linesAdded?.get() ?? 0;
+		acc.removed += diff.linesRemoved?.get() ?? 0;
 		return acc;
-	}, { fileCount: 0, added: 0, removed: 0 } satisfies IChatSessionStats);
+	}, { fileUris: new ResourceSet(), added: 0, removed: 0 });
+
+	if (reduceResult.fileUris.size > 0 && (reduceResult.added > 0 || reduceResult.removed > 0)) {
+		return {
+			fileCount: reduceResult.fileUris.size,
+			added: reduceResult.added,
+			removed: reduceResult.removed
+		};
+	}
+	return undefined;
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

We have decided to change the behavior for local chats and workspace background chats so that we only show the file diff stats up until the user keeps/undos the changes.
So we only need the current editing session for now