### PR TITLE
File diff behavior changes for chat sessions

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingModifiedDocumentEntry.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingModifiedDocumentEntry.ts
@@ -11,6 +11,7 @@ import { URI } from '../../../../../base/common/uri.js';
 import { getCodeEditor } from '../../../../../editor/browser/editorBrowser.js';
 import { TextEdit as EditorTextEdit } from '../../../../../editor/common/core/edits/textEdit.js';
 import { StringText } from '../../../../../editor/common/core/text/abstractText.js';
+import { IDocumentDiff } from '../../../../../editor/common/diff/documentDiffProvider.js';
 import { Location, TextEdit } from '../../../../../editor/common/languages.js';
 import { ILanguageService } from '../../../../../editor/common/languages/language.js';
 import { ITextModel } from '../../../../../editor/common/model.js';
@@ -177,6 +178,10 @@ export class ChatEditingModifiedDocumentEntry extends AbstractChatEditingModifie
 				resourceFilter.clear();
 			}
 		}));
+	}
+
+	getDiffInfo(): Promise<IDocumentDiff> {
+		return this._textModelChangeService.getDiffInfo();
 	}
 
 	equalsSnapshot(snapshot: ISnapshotEntry | undefined): boolean {

--- a/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingTextModelChangeService.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingTextModelChangeService.ts
@@ -442,6 +442,15 @@ export class ChatEditingTextModelChangeService extends Disposable {
 		return true;
 	}
 
+	public async getDiffInfo() {
+		if (!this._diffOperation) {
+			this._updateDiffInfoSeq();
+		}
+
+		await this._diffOperation;
+		return this._diffInfo.get();
+	}
+
 
 	private async _updateDiffInfoSeq(notifyAction: 'accepted' | 'rejected' | undefined = undefined) {
 		const myDiffOperationId = ++this._diffOperationIds;

--- a/src/vs/workbench/contrib/chat/common/chat.ts
+++ b/src/vs/workbench/contrib/chat/common/chat.ts
@@ -44,6 +44,7 @@ export async function awaitStatsForSession(model: IChatModel): Promise<IChatSess
 	}
 
 	await chatEditingSessionIsReady(model.editingSession);
+	await Promise.all(model.editingSession.entries.get().map(entry => entry.getDiffInfo?.()));
 
 	const diffs = model.editingSession.entries.get();
 	const reduceResult = diffs.reduce((acc, diff) => {

--- a/src/vs/workbench/contrib/chat/common/chat.ts
+++ b/src/vs/workbench/contrib/chat/common/chat.ts
@@ -3,7 +3,8 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { awaitCompleteChatEditingDiff } from './chatEditingService.js';
+import { ResourceSet } from '../../../../base/common/map.js';
+import { chatEditingSessionIsReady } from './chatEditingService.js';
 import { IChatModel } from './chatModel.js';
 import type { IChatSessionStats, IChatTerminalToolInvocationData, ILegacyChatTerminalToolInvocationData } from './chatService.js';
 import { ChatModeKind } from './constants.js';
@@ -42,11 +43,22 @@ export async function awaitStatsForSession(model: IChatModel): Promise<IChatSess
 		return undefined;
 	}
 
-	const diffs = await awaitCompleteChatEditingDiff(model.editingSession.getDiffsForFilesInSession());
-	return diffs.reduce((acc, diff) => {
-		acc.fileCount++;
-		acc.added += diff.added;
-		acc.removed += diff.removed;
+	await chatEditingSessionIsReady(model.editingSession);
+
+	const diffs = model.editingSession.entries.get();
+	const reduceResult = diffs.reduce((acc, diff) => {
+		acc.fileUris.add(diff.originalURI);
+		acc.added += diff.linesAdded?.get() ?? 0;
+		acc.removed += diff.linesRemoved?.get() ?? 0;
 		return acc;
-	}, { fileCount: 0, added: 0, removed: 0 } satisfies IChatSessionStats);
+	}, { fileUris: new ResourceSet(), added: 0, removed: 0 });
+
+	if (reduceResult.fileUris.size > 0 && (reduceResult.added > 0 || reduceResult.removed > 0)) {
+		return {
+			fileCount: reduceResult.fileUris.size,
+			added: reduceResult.added,
+			removed: reduceResult.removed
+		};
+	}
+	return undefined;
 }

--- a/src/vs/workbench/contrib/chat/common/chatEditingService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatEditingService.ts
@@ -400,6 +400,10 @@ export interface IModifiedFileEntry {
 
 	getEditorIntegration(editor: IEditorPane): IModifiedFileEntryEditorIntegration;
 	hasModificationAt(location: Location): boolean;
+	/**
+	 * Gets the document diff info, waiting for any ongoing promises to flush.
+	 */
+	getDiffInfo?(): Promise<IDocumentDiff>;
 }
 
 export interface IChatEditingSessionStream {

--- a/src/vs/workbench/contrib/chat/test/common/chatService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/chatService.test.ts
@@ -171,6 +171,7 @@ suite('ChatService', () => {
 		instantiationService.stub(IChatEditingService, new class extends mock<IChatEditingService>() {
 			override startOrContinueGlobalEditingSession(): IChatEditingSession {
 				return {
+					state: constObservable('idle'),
 					requestDisablement: observableValue('requestDisablement', []),
 					entries: constObservable([]),
 					dispose: () => { }


### PR DESCRIPTION
We have decided to change the behavior for local chats and workspace background chats so that we only show the file diff stats up until the user keeps/undos the changes.
So we only need the current editing session for now