### PR TITLE
Simplify `TestInstantiationService#stub` overloads

### DIFF
--- a/src/vs/platform/instantiation/test/common/instantiationServiceMock.ts
+++ b/src/vs/platform/instantiation/test/common/instantiationServiceMock.ts
@@ -53,10 +53,8 @@ export class TestInstantiationService extends InstantiationService implements ID
 		return super.createInstance(ctorOrDescriptor, ...rest);
 	}
 
-	public stub<T>(service: ServiceIdentifier<T>, ctor: Function): T;
-	public stub<T>(service: ServiceIdentifier<T>, obj: Partial<T>): T;
-	public stub<T, V>(service: ServiceIdentifier<T>, ctor: Function, property: string, value: V): V extends Function ? sinon.SinonSpy : sinon.SinonStub;
-	public stub<T, V>(service: ServiceIdentifier<T>, obj: Partial<T>, property: string, value: V): V extends Function ? sinon.SinonSpy : sinon.SinonStub;
+	public stub<T>(service: ServiceIdentifier<T>, obj: Partial<NoInfer<T>> | Function): T;
+	public stub<T, V>(service: ServiceIdentifier<T>, obj: Partial<NoInfer<T>> | Function, property: string, value: V): V extends Function ? sinon.SinonSpy : sinon.SinonStub;
 	public stub<T, V>(service: ServiceIdentifier<T>, property: string, value: V): V extends Function ? sinon.SinonSpy : sinon.SinonStub;
 	public stub<T>(serviceIdentifier: ServiceIdentifier<T>, arg2: any, arg3?: string, arg4?: any): sinon.SinonStub | sinon.SinonSpy {
 		const service = typeof arg2 !== 'string' ? arg2 : undefined;


### PR DESCRIPTION
**Why**

Current types run into a problem with this proposed patch to TypeScript: https://github.com/microsoft/TypeScript/pull/62243#issuecomment-3629464729

The current types luck out on contextual typing for return expressions, a seamingly equivalent change from a method to an arrow function uncover this:

<img width="1177" height="508" alt="Screenshot 2025-12-09 at 15 27 19" src="https://github.com/user-attachments/assets/ed467183-3186-4c61-bc2e-8b852d5cbed4" />
