### PR TITLE
Update node-pty to 1.1.0-beta39

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
         "native-is-elevated": "0.8.0",
         "native-keymap": "^3.3.5",
         "native-watchdog": "^1.4.1",
-        "node-pty": "1.1.0-beta35",
+        "node-pty": "^1.1.0-beta39",
         "open": "^10.1.2",
         "tas-client": "0.3.1",
         "undici": "^7.9.0",
@@ -12809,9 +12809,9 @@
       }
     },
     "node_modules/node-pty": {
-      "version": "1.1.0-beta35",
-      "resolved": "https://registry.npmjs.org/node-pty/-/node-pty-1.1.0-beta35.tgz",
-      "integrity": "sha512-dGKw3PtLj/+uiFWUODNjr3QMyNjxRB2JY372AN4uzonfb6ri23d4PMr4s6UoibiqsXOQ3elXRCdq1qDLd86J8Q==",
+      "version": "1.1.0-beta39",
+      "resolved": "https://registry.npmjs.org/node-pty/-/node-pty-1.1.0-beta39.tgz",
+      "integrity": "sha512-1xnN2dbS0QngT4xenpS/6Q77QtaDQo5vE6f4slATgZsFIv3NP4ObE7vAjYnZtMFG5OEh3jyDRZc+hy1DjDF7dg==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "native-is-elevated": "0.8.0",
     "native-keymap": "^3.3.5",
     "native-watchdog": "^1.4.1",
-    "node-pty": "1.1.0-beta35",
+    "node-pty": "^1.1.0-beta39",
     "open": "^10.1.2",
     "tas-client": "0.3.1",
     "undici": "^7.9.0",

--- a/remote/package-lock.json
+++ b/remote/package-lock.json
@@ -38,7 +38,7 @@
         "kerberos": "2.1.1",
         "minimist": "^1.2.8",
         "native-watchdog": "^1.4.1",
-        "node-pty": "1.1.0-beta35",
+        "node-pty": "^1.1.0-beta39",
         "tas-client": "0.3.1",
         "vscode-oniguruma": "1.7.0",
         "vscode-regexpp": "^3.1.0",
@@ -848,9 +848,9 @@
       }
     },
     "node_modules/node-pty": {
-      "version": "1.1.0-beta35",
-      "resolved": "https://registry.npmjs.org/node-pty/-/node-pty-1.1.0-beta35.tgz",
-      "integrity": "sha512-dGKw3PtLj/+uiFWUODNjr3QMyNjxRB2JY372AN4uzonfb6ri23d4PMr4s6UoibiqsXOQ3elXRCdq1qDLd86J8Q==",
+      "version": "1.1.0-beta39",
+      "resolved": "https://registry.npmjs.org/node-pty/-/node-pty-1.1.0-beta39.tgz",
+      "integrity": "sha512-1xnN2dbS0QngT4xenpS/6Q77QtaDQo5vE6f4slATgZsFIv3NP4ObE7vAjYnZtMFG5OEh3jyDRZc+hy1DjDF7dg==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/remote/package.json
+++ b/remote/package.json
@@ -33,7 +33,7 @@
     "kerberos": "2.1.1",
     "minimist": "^1.2.8",
     "native-watchdog": "^1.4.1",
-    "node-pty": "1.1.0-beta35",
+    "node-pty": "^1.1.0-beta39",
     "tas-client": "0.3.1",
     "vscode-oniguruma": "1.7.0",
     "vscode-regexpp": "^3.1.0",

--- a/src/vs/workbench/contrib/terminal/common/terminalConfiguration.ts
+++ b/src/vs/workbench/contrib/terminal/common/terminalConfiguration.ts
@@ -470,7 +470,7 @@ const terminalConfiguration: IStringDictionary<IConfigurationPropertySchema> = {
 		default: true
 	},
 	[TerminalSettingId.WindowsUseConptyDll]: {
-		markdownDescription: localize('terminal.integrated.windowsUseConptyDll', "Whether to use the experimental conpty.dll (v1.22.250204002) shipped with VS Code, instead of the one bundled with Windows."),
+		markdownDescription: localize('terminal.integrated.windowsUseConptyDll', "Whether to use the experimental conpty.dll (v1.23.251008001) shipped with VS Code, instead of the one bundled with Windows."),
 		type: 'boolean',
 		tags: ['preview'],
 		default: false


### PR DESCRIPTION
Take2 on: https://github.com/microsoft/vscode/pull/274736 

- Updates conpty microsoft/node-pty#811
- Adds Buffer support to API microsoft/node-pty#812

Part of #269213

Maybe we hold off to this until issue grooming gets wrapped up