### PR TITLE
Agent sessions: finished status and duration ago not provided in chat sessions aria label (fix #281334)

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsViewer.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsViewer.ts
@@ -350,7 +350,19 @@ export class AgentSessionsAccessibilityProvider implements IListAccessibilityPro
 	}
 
 	getAriaLabel(element: IAgentSession): string | null {
-		return element.label;
+		let statusLabel: string;
+		switch (element.status) {
+			case ChatSessionStatus.InProgress:
+				statusLabel = localize('agentSessionInProgress', "in progress");
+				break;
+			case ChatSessionStatus.Failed:
+				statusLabel = localize('agentSessionFailed', "failed");
+				break;
+			default:
+				statusLabel = localize('agentSessionCompleted', "completed");
+		}
+
+		return localize('agentSessionItemAriaLabel', "Agent session {0} ({1}), created {2}", statusLabel, new Date(element.timing.startTime).toLocaleString());
 	}
 }
 

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsViewer.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsViewer.ts
@@ -362,7 +362,7 @@ export class AgentSessionsAccessibilityProvider implements IListAccessibilityPro
 				statusLabel = localize('agentSessionCompleted', "completed");
 		}
 
-		return localize('agentSessionItemAriaLabel', "Agent session {0} ({1}), created {2}", statusLabel, new Date(element.timing.startTime).toLocaleString());
+		return localize('agentSessionItemAriaLabel', "Agent session {0} ({1}), created {2}", element.label, statusLabel, new Date(element.timing.startTime).toLocaleString());
 	}
 }
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
