### PR TITLE
don't focus list item when suggest setting is `never`

### DIFF
--- a/src/vs/workbench/services/suggest/browser/simpleSuggestWidget.ts
+++ b/src/vs/workbench/services/suggest/browser/simpleSuggestWidget.ts
@@ -443,6 +443,9 @@ export class SimpleSuggestWidget<TModel extends SimpleCompletionModel<TItem>, TI
 
 		this._loadingTimeout?.dispose();
 
+		const selectionMode = this._options?.selectionModeSettingId ? this._configurationService.getValue<SuggestSelectionMode>(this._options.selectionModeSettingId) : undefined;
+		const noFocus = selectionMode === SuggestSelectionMode.Never;
+
 		// this._currentSuggestionDetails?.cancel();
 		// this._currentSuggestionDetails = undefined;
 
@@ -473,8 +476,6 @@ export class SimpleSuggestWidget<TModel extends SimpleCompletionModel<TItem>, TI
 			this._list.splice(0, this._list.length, this._completionModel?.items ?? []);
 			this._setState(isFrozen ? State.Frozen : State.Open);
 			this._list.reveal(selectionIndex, 0);
-			this._list.setFocus([selectionIndex]);
-			const noFocus = this._options?.selectionModeSettingId ? this._configurationService.getValue<SuggestSelectionMode>(this._options.selectionModeSettingId) === SuggestSelectionMode.Never : false;
 			this._list.setFocus(noFocus ? [] : [selectionIndex]);
 		} finally {
 			// this._onDidFocus.resume();


### PR DESCRIPTION
fixes #282461

Previously the code always focused `selectionIndex` once and only then cleared it for the never case, so the first item briefly became focused/selected. With the change, the list is populated without ever focusing an item when never is set, so nothing is preselected.


https://github.com/user-attachments/assets/4a3f6ddb-dc03-4d65-a430-9214c9465c28

