### PR TITLE
Markdown preview: filter hidden elements from scroll sync (fix #281247)

### DIFF
--- a/extensions/markdown-language-features/preview-src/scroll-sync.ts
+++ b/extensions/markdown-language-features/preview-src/scroll-sync.ts
@@ -20,7 +20,21 @@ export class CodeLineElement {
 	}
 
 	get isVisible(): boolean {
-		return !this._detailParentElements.some(x => !x.open);
+		if (this._detailParentElements.some(x => !x.open)) {
+			return false;
+		}
+
+		const style = window.getComputedStyle(this.element);
+		if (style.display === 'none' || style.visibility === 'hidden') {
+			return false;
+		}
+
+		const bounds = this.element.getBoundingClientRect();
+		if (bounds.height === 0 && bounds.width === 0) {
+			return false;
+		}
+
+		return true;
 	}
 }
 

--- a/extensions/markdown-language-features/preview-src/scroll-sync.ts
+++ b/extensions/markdown-language-features/preview-src/scroll-sync.ts
@@ -30,7 +30,7 @@ export class CodeLineElement {
 		}
 
 		const bounds = this.element.getBoundingClientRect();
-		if (bounds.height === 0 && bounds.width === 0) {
+		if (bounds.height === 0 || bounds.width === 0) {
 			return false;
 		}
 


### PR DESCRIPTION
filter hidden elements from scroll sync in Markdown preview by enhancing isVisible property (fix #281247)