### PR TITLE
Rank/orgs repo v3

### DIFF
--- a/extensions/git-base/src/api/git-base.d.ts
+++ b/extensions/git-base/src/api/git-base.d.ts
@@ -83,4 +83,5 @@ export interface RemoteSourceProvider {
 	getRemoteSourceActions?(url: string): ProviderResult<RemoteSourceAction[]>;
 	getRecentRemoteSources?(query?: string): ProviderResult<RecentRemoteSource[]>;
 	getRemoteSources(query?: string): ProviderResult<RemoteSource[]>;
+	setRepoFilter?(filter: 'user' | 'orgs' | 'all'): ProviderResult<void>;
 }

--- a/extensions/git-base/src/remoteSource.ts
+++ b/extensions/git-base/src/remoteSource.ts
@@ -127,6 +127,29 @@ export async function pickRemoteSource(model: Model, options: PickRemoteSourceOp
 export async function pickRemoteSource(model: Model, options: PickRemoteSourceOptions & { branch?: false | undefined }): Promise<string | undefined>;
 export async function pickRemoteSource(model: Model, options: PickRemoteSourceOptions & { branch: true }): Promise<PickRemoteSourceResult | undefined>;
 export async function pickRemoteSource(model: Model, options: PickRemoteSourceOptions = {}): Promise<string | PickRemoteSourceResult | undefined> {
+	// Show GitHub repository filter picker if GitHub provider is available
+	const githubProvider = model.getRemoteProviders().find(provider => provider.name === 'GitHub');
+	if (githubProvider && !options.providerName) {
+		const filterPick = await window.showQuickPick(
+			[
+				{ label: 'Show my repositories', value: 'user' },
+				{ label: 'Show organization repositories', value: 'orgs' },
+				{ label: 'Show all repositories', value: 'all' }
+			],
+			{
+				title: 'Select which GitHub repositories to display',
+				placeHolder: 'Choose a category'
+			}
+		);
+
+		if (!filterPick) {
+			return undefined;
+		}
+
+		// Set the filter for GitHub provider to use
+		await githubProvider.setRepoFilter?.(filterPick.value as 'user' | 'orgs' | 'all');
+	}
+
 	const quickpick = window.createQuickPick<(QuickPickItem & { provider?: RemoteSourceProvider; url?: string })>();
 	quickpick.title = options.title;
 

--- a/extensions/github/package.json
+++ b/extensions/github/package.json
@@ -39,10 +39,6 @@
   "contributes": {
     "commands": [
       {
-        "command": "github.cloneFilteredRepos",
-        "title": "GitHub: Clone (Filtered)"
-      },
-      {
         "command": "github.publish",
         "title": "%command.publish%"
       },

--- a/extensions/github/package.json
+++ b/extensions/github/package.json
@@ -39,6 +39,10 @@
   "contributes": {
     "commands": [
       {
+        "command": "github.cloneFilteredRepos",
+        "title": "GitHub: Clone (Filtered)"
+      },
+      {
         "command": "github.publish",
         "title": "%command.publish%"
       },

--- a/extensions/github/src/categoryState.ts
+++ b/extensions/github/src/categoryState.ts
@@ -1,0 +1,15 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+let selectedCategory: 'user' | 'orgs' | 'all' | undefined;
+
+export function getSelectedCategory(): 'user' | 'orgs' | 'all' | undefined {
+	return selectedCategory;
+}
+
+export function setSelectedCategory(category: 'user' | 'orgs' | 'all'): void {
+	selectedCategory = category;
+}
+

--- a/extensions/github/src/extension.ts
+++ b/extensions/github/src/extension.ts
@@ -18,10 +18,37 @@ import { GitHubCanonicalUriProvider } from './canonicalUriProvider.js';
 import { VscodeDevShareProvider } from './shareProviders.js';
 import { GitHubSourceControlHistoryItemDetailsProvider } from './historyItemDetailsProvider.js';
 import { OctokitService } from './auth.js';
+import { setSelectedCategory } from './categoryState.js';
+import * as vscode from 'vscode';
+
 
 export function activate(context: ExtensionContext): void {
 	const disposables: Disposable[] = [];
 	context.subscriptions.push(new Disposable(() => Disposable.from(...disposables).dispose()));
+
+	context.subscriptions.push(
+		vscode.commands.registerCommand('github.cloneFilteredRepos', async () => {
+			const pick = await vscode.window.showQuickPick(
+				[
+					{ label: 'Show my repositories', value: 'user' },
+					{ label: 'Show organization repositories', value: 'orgs' },
+					{ label: 'Show all repositories', value: 'all' }
+				],
+				{
+					title: 'Select which GitHub repositories to display',
+					placeHolder: 'Choose a category'
+				}
+			);
+
+			if (!pick) return;
+
+			// Save mode in memory (your existing mechanism)
+			setSelectedCategory(pick.value as any);
+
+			// Now trigger GitHub repo list
+			await vscode.commands.executeCommand('git.clone');
+		})
+	);
 
 	const logger = window.createOutputChannel('GitHub', { log: true });
 	disposables.push(logger);

--- a/extensions/github/src/extension.ts
+++ b/extensions/github/src/extension.ts
@@ -18,39 +18,11 @@ import { GitHubCanonicalUriProvider } from './canonicalUriProvider.js';
 import { VscodeDevShareProvider } from './shareProviders.js';
 import { GitHubSourceControlHistoryItemDetailsProvider } from './historyItemDetailsProvider.js';
 import { OctokitService } from './auth.js';
-import { setSelectedCategory } from './categoryState.js';
-import * as vscode from 'vscode';
 
 
 export function activate(context: ExtensionContext): void {
 	const disposables: Disposable[] = [];
 	context.subscriptions.push(new Disposable(() => Disposable.from(...disposables).dispose()));
-
-	context.subscriptions.push(
-		vscode.commands.registerCommand('github.cloneFilteredRepos', async () => {
-			const pick = await vscode.window.showQuickPick(
-				[
-					{ label: 'Show my repositories', value: 'user' },
-					{ label: 'Show organization repositories', value: 'orgs' },
-					{ label: 'Show all repositories', value: 'all' }
-				],
-				{
-					title: 'Select which GitHub repositories to display',
-					placeHolder: 'Choose a category'
-				}
-			);
-
-			if (!pick) {
-				return;
-			}
-
-			// Save mode in memory (your existing mechanism)
-			setSelectedCategory(pick.value as 'user' | 'orgs' | 'all');
-
-			// Now trigger GitHub repo list
-			await vscode.commands.executeCommand('git.clone');
-		})
-	);
 
 	const logger = window.createOutputChannel('GitHub', { log: true });
 	disposables.push(logger);

--- a/extensions/github/src/extension.ts
+++ b/extensions/github/src/extension.ts
@@ -18,37 +18,11 @@ import { GitHubCanonicalUriProvider } from './canonicalUriProvider.js';
 import { VscodeDevShareProvider } from './shareProviders.js';
 import { GitHubSourceControlHistoryItemDetailsProvider } from './historyItemDetailsProvider.js';
 import { OctokitService } from './auth.js';
-import { setSelectedCategory } from './categoryState.js';
-import * as vscode from 'vscode';
 
 
 export function activate(context: ExtensionContext): void {
 	const disposables: Disposable[] = [];
 	context.subscriptions.push(new Disposable(() => Disposable.from(...disposables).dispose()));
-
-	context.subscriptions.push(
-		vscode.commands.registerCommand('github.cloneFilteredRepos', async () => {
-			const pick = await vscode.window.showQuickPick(
-				[
-					{ label: 'Show my repositories', value: 'user' },
-					{ label: 'Show organization repositories', value: 'orgs' },
-					{ label: 'Show all repositories', value: 'all' }
-				],
-				{
-					title: 'Select which GitHub repositories to display',
-					placeHolder: 'Choose a category'
-				}
-			);
-
-			if (!pick) return;
-
-			// Save mode in memory (your existing mechanism)
-			setSelectedCategory(pick.value as any);
-
-			// Now trigger GitHub repo list
-			await vscode.commands.executeCommand('git.clone');
-		})
-	);
 
 	const logger = window.createOutputChannel('GitHub', { log: true });
 	disposables.push(logger);

--- a/extensions/github/src/extension.ts
+++ b/extensions/github/src/extension.ts
@@ -18,11 +18,39 @@ import { GitHubCanonicalUriProvider } from './canonicalUriProvider.js';
 import { VscodeDevShareProvider } from './shareProviders.js';
 import { GitHubSourceControlHistoryItemDetailsProvider } from './historyItemDetailsProvider.js';
 import { OctokitService } from './auth.js';
+import { setSelectedCategory } from './categoryState.js';
+import * as vscode from 'vscode';
 
 
 export function activate(context: ExtensionContext): void {
 	const disposables: Disposable[] = [];
 	context.subscriptions.push(new Disposable(() => Disposable.from(...disposables).dispose()));
+
+	context.subscriptions.push(
+		vscode.commands.registerCommand('github.cloneFilteredRepos', async () => {
+			const pick = await vscode.window.showQuickPick(
+				[
+					{ label: 'Show my repositories', value: 'user' },
+					{ label: 'Show organization repositories', value: 'orgs' },
+					{ label: 'Show all repositories', value: 'all' }
+				],
+				{
+					title: 'Select which GitHub repositories to display',
+					placeHolder: 'Choose a category'
+				}
+			);
+
+			if (!pick) {
+				return;
+			}
+
+			// Save mode in memory (your existing mechanism)
+			setSelectedCategory(pick.value as 'user' | 'orgs' | 'all');
+
+			// Now trigger GitHub repo list
+			await vscode.commands.executeCommand('git.clone');
+		})
+	);
 
 	const logger = window.createOutputChannel('GitHub', { log: true });
 	disposables.push(logger);

--- a/extensions/github/src/remoteSourceProvider.ts
+++ b/extensions/github/src/remoteSourceProvider.ts
@@ -9,7 +9,7 @@ import { getOctokit } from './auth.js';
 import { Octokit } from '@octokit/rest';
 import { getRepositoryFromQuery, getRepositoryFromUrl } from './util.js';
 import { getBranchLink, getVscodeDevHost } from './links.js';
-import { getSelectedCategory } from './categoryState.js';
+import { getSelectedCategory, setSelectedCategory } from './categoryState.js';
 
 
 type RemoteSourceResponse = {
@@ -38,6 +38,10 @@ export class GithubRemoteSourceProvider implements RemoteSourceProvider {
 	readonly supportsQuery = true;
 
 	private userReposCache: RemoteSource[] = [];
+
+	async setRepoFilter(filter: 'user' | 'orgs' | 'all'): Promise<void> {
+		setSelectedCategory(filter);
+	}
 
 	async getRemoteSources(query?: string): Promise<RemoteSource[]> {
 		const octokit = await getOctokit();

--- a/extensions/github/src/remoteSourceProvider.ts
+++ b/extensions/github/src/remoteSourceProvider.ts
@@ -3,13 +3,13 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Uri, env, l10n, workspace, window } from 'vscode';
+import { Uri, env, l10n, workspace } from 'vscode';
 import { RemoteSourceProvider, RemoteSource, RemoteSourceAction } from './typings/git-base.js';
 import { getOctokit } from './auth.js';
 import { Octokit } from '@octokit/rest';
 import { getRepositoryFromQuery, getRepositoryFromUrl } from './util.js';
 import { getBranchLink, getVscodeDevHost } from './links.js';
-import { getSelectedCategory, setSelectedCategory } from './categoryState.js';
+import { getSelectedCategory } from './categoryState.js';
 
 
 type RemoteSourceResponse = {
@@ -57,30 +57,7 @@ export class GithubRemoteSourceProvider implements RemoteSourceProvider {
 		}
 
 		// ---------------------------------------------------------------
-		// 2. No query → show filter picker if not already selected
-		// ---------------------------------------------------------------
-		if (!getSelectedCategory()) {
-			const pick = await window.showQuickPick(
-				[
-					{ label: 'Show my repositories', value: 'user' },
-					{ label: 'Show organization repositories', value: 'orgs' },
-					{ label: 'Show all repositories', value: 'all' }
-				],
-				{
-					title: 'Select which GitHub repositories to display',
-					placeHolder: 'Choose a category'
-				}
-			);
-
-			if (!pick) {
-				// User cancelled - return empty array
-				return [];
-			}
-
-			// Save the selected filter category
-			setSelectedCategory(pick.value as 'user' | 'orgs' | 'all');
-		}		// ---------------------------------------------------------------
-		// 3. Use filtered repositories (user/org/all)
+		// 2. No query → use filtered repositories (user/org/all)
 		// ---------------------------------------------------------------
 		return this.getUserRemoteSources(octokit);
 	}

--- a/extensions/github/src/remoteSourceProvider.ts
+++ b/extensions/github/src/remoteSourceProvider.ts
@@ -3,13 +3,13 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Uri, env, l10n, workspace } from 'vscode';
+import { Uri, env, l10n, workspace, window } from 'vscode';
 import { RemoteSourceProvider, RemoteSource, RemoteSourceAction } from './typings/git-base.js';
 import { getOctokit } from './auth.js';
 import { Octokit } from '@octokit/rest';
 import { getRepositoryFromQuery, getRepositoryFromUrl } from './util.js';
 import { getBranchLink, getVscodeDevHost } from './links.js';
-import { getSelectedCategory } from './categoryState.js';
+import { getSelectedCategory, setSelectedCategory } from './categoryState.js';
 
 
 type RemoteSourceResponse = {
@@ -57,7 +57,30 @@ export class GithubRemoteSourceProvider implements RemoteSourceProvider {
 		}
 
 		// ---------------------------------------------------------------
-		// 2. No query → use filtered repositories (user/org/all)
+		// 2. No query → show filter picker if not already selected
+		// ---------------------------------------------------------------
+		if (!getSelectedCategory()) {
+			const pick = await window.showQuickPick(
+				[
+					{ label: 'Show my repositories', value: 'user' },
+					{ label: 'Show organization repositories', value: 'orgs' },
+					{ label: 'Show all repositories', value: 'all' }
+				],
+				{
+					title: 'Select which GitHub repositories to display',
+					placeHolder: 'Choose a category'
+				}
+			);
+
+			if (!pick) {
+				// User cancelled - return empty array
+				return [];
+			}
+
+			// Save the selected filter category
+			setSelectedCategory(pick.value as 'user' | 'orgs' | 'all');
+		}		// ---------------------------------------------------------------
+		// 3. Use filtered repositories (user/org/all)
 		// ---------------------------------------------------------------
 		return this.getUserRemoteSources(octokit);
 	}
@@ -78,7 +101,7 @@ export class GithubRemoteSourceProvider implements RemoteSourceProvider {
 
 			this.userReposCache.push(
 				...res.data.map(r => ({
-					...asRemoteSource(r as any),
+					...asRemoteSource(r as RemoteSourceResponse),
 					name: `[User] ${r.full_name}`
 				}))
 			);
@@ -98,7 +121,7 @@ export class GithubRemoteSourceProvider implements RemoteSourceProvider {
 
 				this.userReposCache.push(
 					...repos.data.map(r => ({
-						...asRemoteSource(r as any),
+						...asRemoteSource(r as RemoteSourceResponse),
 						name: `[Org: ${org.login}] ${r.full_name}`
 					}))
 				);

--- a/extensions/github/src/test/categoryState.test.ts
+++ b/extensions/github/src/test/categoryState.test.ts
@@ -1,0 +1,45 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import 'mocha';
+import * as assert from 'assert';
+import { getSelectedCategory, setSelectedCategory } from '../categoryState.js';
+
+suite('Category State Tests', function () {
+
+	test('should return default category when not set', function () {
+		const category = getSelectedCategory();
+		assert.strictEqual(category, undefined);
+	});
+
+	test('should store and retrieve user category', function () {
+		setSelectedCategory('user');
+		const category = getSelectedCategory();
+		assert.strictEqual(category, 'user');
+	});
+
+	test('should store and retrieve orgs category', function () {
+		setSelectedCategory('orgs');
+		const category = getSelectedCategory();
+		assert.strictEqual(category, 'orgs');
+	});
+
+	test('should store and retrieve all category', function () {
+		setSelectedCategory('all');
+		const category = getSelectedCategory();
+		assert.strictEqual(category, 'all');
+	});
+
+	test('should update category when set multiple times', function () {
+		setSelectedCategory('user');
+		assert.strictEqual(getSelectedCategory(), 'user');
+
+		setSelectedCategory('orgs');
+		assert.strictEqual(getSelectedCategory(), 'orgs');
+
+		setSelectedCategory('all');
+		assert.strictEqual(getSelectedCategory(), 'all');
+	});
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1187,11 +1187,35 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@isaacs/balanced-match": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
+      "integrity": "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@isaacs/brace-expansion": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.0.tgz",
+      "integrity": "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@isaacs/balanced-match": "^4.0.1"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
       "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "string-width": "^5.1.2",
         "string-width-cjs": "npm:string-width@^4.2.0",
@@ -1205,10 +1229,11 @@
       }
     },
     "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
-      "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -1217,10 +1242,11 @@
       }
     },
     "node_modules/@isaacs/cliui/node_modules/ansi-styles": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
-      "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -1232,13 +1258,15 @@
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@isaacs/cliui/node_modules/string-width": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
       "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "eastasianwidth": "^0.2.0",
         "emoji-regex": "^9.2.2",
@@ -1252,10 +1280,11 @@
       }
     },
     "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
-      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-regex": "^6.0.1"
       },
@@ -1271,6 +1300,7 @@
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
       "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^6.1.0",
         "string-width": "^5.0.1",
@@ -1689,6 +1719,7 @@
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
       "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "engines": {
         "node": ">=14"
@@ -2962,32 +2993,32 @@
       }
     },
     "node_modules/@vscode/l10n-dev/node_modules/glob": {
-      "version": "10.3.10",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.10.tgz",
-      "integrity": "sha512-fa46+tv1Ak0UPK1TOy/pZrIybNNt4HCv7SDzwyfiOZkvZLEbjsZkJBPtDHVshZjbecAoAGSC20MjLDG/qr679g==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "foreground-child": "^3.1.0",
-        "jackspeak": "^2.3.5",
-        "minimatch": "^9.0.1",
-        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0",
-        "path-scurry": "^1.10.1"
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
       },
       "bin": {
         "glob": "dist/esm/bin.mjs"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@vscode/l10n-dev/node_modules/minimatch": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
-      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -2996,6 +3027,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@vscode/l10n-dev/node_modules/minipass": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/@vscode/policy-watcher": {
@@ -3142,32 +3183,32 @@
       }
     },
     "node_modules/@vscode/test-cli/node_modules/glob": {
-      "version": "10.3.10",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.10.tgz",
-      "integrity": "sha512-fa46+tv1Ak0UPK1TOy/pZrIybNNt4HCv7SDzwyfiOZkvZLEbjsZkJBPtDHVshZjbecAoAGSC20MjLDG/qr679g==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "foreground-child": "^3.1.0",
-        "jackspeak": "^2.3.5",
-        "minimatch": "^9.0.1",
-        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0",
-        "path-scurry": "^1.10.1"
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
       },
       "bin": {
         "glob": "dist/esm/bin.mjs"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@vscode/test-cli/node_modules/minimatch": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
-      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -3176,6 +3217,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@vscode/test-cli/node_modules/minipass": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/@vscode/test-electron": {
@@ -3224,25 +3275,16 @@
         "node": ">=16"
       }
     },
-    "node_modules/@vscode/test-web/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
     "node_modules/@vscode/test-web/node_modules/glob": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-11.0.0.tgz",
-      "integrity": "sha512-9UiX/Bl6J2yaBbxKoEBRm4Cipxgok8kQYcOPEhScPwebu2I0HoQOuYdIO6S3hLuWoZgpDpwQZMzTFxgpkyT76g==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-11.1.0.tgz",
+      "integrity": "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==",
       "dev": true,
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^4.0.1",
-        "minimatch": "^10.0.0",
+        "foreground-child": "^3.3.1",
+        "jackspeak": "^4.1.1",
+        "minimatch": "^10.1.1",
         "minipass": "^7.1.2",
         "package-json-from-dist": "^1.0.0",
         "path-scurry": "^2.0.0"
@@ -3258,10 +3300,11 @@
       }
     },
     "node_modules/@vscode/test-web/node_modules/jackspeak": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.0.1.tgz",
-      "integrity": "sha512-cub8rahkh0Q/bw1+GxP7aeSe29hHHn2V4m29nnDlvCdlgU+3UGxkZp7Z53jLUdpX3jdTO0nJZUDl3xvbWc2Xog==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.1.1.tgz",
+      "integrity": "sha512-zptv57P3GpL+O0I7VdMJNBZCu+BPHVQUk55Ft8/QCJjTVxrnJHuVuX/0Bl2A6/+2oyR/ZMEuFKwmzqqZ/U5nPQ==",
       "dev": true,
+      "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"
       },
@@ -3270,9 +3313,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      },
-      "optionalDependencies": {
-        "@pkgjs/parseargs": "^0.11.0"
       }
     },
     "node_modules/@vscode/test-web/node_modules/lru-cache": {
@@ -3285,12 +3325,13 @@
       }
     },
     "node_modules/@vscode/test-web/node_modules/minimatch": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.1.tgz",
-      "integrity": "sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ==",
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.1.1.tgz",
+      "integrity": "sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==",
       "dev": true,
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "@isaacs/brace-expansion": "^5.0.0"
       },
       "engines": {
         "node": "20 || >=22"
@@ -7722,12 +7763,13 @@
       }
     },
     "node_modules/foreground-child": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.1.1.tgz",
-      "integrity": "sha512-TMKDUnIte6bfb5nWv7V/caI169OHgvwjb7V4WkeUvbQQdjr5rWKqHFiKWb/fcOwB+CzBT+qbWjvj+DVwRskpIg==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
-        "cross-spawn": "^7.0.0",
+        "cross-spawn": "^7.0.6",
         "signal-exit": "^4.0.1"
       },
       "engines": {
@@ -11097,15 +11139,13 @@
       }
     },
     "node_modules/jackspeak": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-2.3.6.tgz",
-      "integrity": "sha512-N3yCS/NegsOBokc8GAdM8UcmfsKiSS8cipheD/nivzr700H+nsMOxJjQnvwOcRYVuFkdH0wGUvW2WbXGmrZGbQ==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
       "dev": true,
+      "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"
-      },
-      "engines": {
-        "node": ">=14"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -11219,10 +11259,11 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -16290,6 +16331,7 @@
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -16303,7 +16345,8 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string-width/node_modules/ansi-regex": {
       "version": "6.0.1",
@@ -16393,6 +16436,7 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -18253,6 +18297,7 @@
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -18269,13 +18314,15 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/wrap-ansi-cjs/node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -18493,9 +18540,9 @@
       }
     },
     "node_modules/zx": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/zx/-/zx-8.7.0.tgz",
-      "integrity": "sha512-pArftqj5JV/er8p+czFZwF+k6SbCldl7kcfCR+rIiDIh3gUsLB0F3Xh05diP8PzToZ39D/GWeFoVFimjHQkbAg==",
+      "version": "8.8.5",
+      "resolved": "https://registry.npmjs.org/zx/-/zx-8.8.5.tgz",
+      "integrity": "sha512-SNgDF5L0gfN7FwVOdEFguY3orU5AkfFZm9B5YSHog/UDHv+lvmd82ZAsOenOkQixigwH2+yyH198AwNdKhj+RA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {


### PR DESCRIPTION
## Summary

Adds repository filtering to `Git: Clone` command to help users find their personal repositories more easily when they have many organization repositories.

Fixes #141754

## Problem

Users with access to many organization repositories found their personal repositories ranked too low in the clone picker due to the star-based sorting algorithm.

## Solution

Added a filter picker before the repository list that lets users choose:
- **Show my repositories** - Only personal repos (labeled `[User]`)
- **Show organization repositories** - Only org repos (labeled `[Org: orgname]`)
- **Show all repositories** - Both types with appropriate labels

## Changes

- `extensions/git-base/src/remoteSource.ts` - Added filter picker to `pickRemoteSource()`
- `extensions/git-base/src/api/git-base.d.ts` - Added `setRepoFilter()` to provider interface
- `extensions/github/src/remoteSourceProvider.ts` - Implemented filtering logic
- `extensions/github/src/categoryState.ts` - State management for filter selection
- `extensions/github/src/test/categoryState.test.ts` - Unit tests

## Testing

**Manual Tests:**
1. Run `Git: Clone` → Verify filter picker appears
2. Select "Show my repositories" → Only personal repos with `[User]` prefix appear
3. Select "Show organization repositories" → Only org repos with `[Org: name]` prefix appear
4. Select "Show all repositories" → Both types appear with labels, with user repos ranked higher
5. Type direct URL → Still works as before

**Automated Tests:**
```bash
npm test -- --grep "Category State"