### PR TITLE
Fix NES gutter icon rendering in notebook cells

### DIFF
--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/components/gutterIndicatorView.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/components/gutterIndicatorView.ts
@@ -82,6 +82,9 @@ export class SimpleInlineSuggestModel {
 	) { }
 }
 
+const CODICON_SIZE_PX = 16;
+const CODICON_PADDING_PX = 2;
+
 export class InlineEditsGutterIndicator extends Disposable {
 	constructor(
 		private readonly _editorObs: ObservableCodeEditor,
@@ -350,11 +353,10 @@ export class InlineEditsGutterIndicator extends Disposable {
 			return cursorLineNumber <= editStartLineNumber ? Codicon.keyboardTabAbove : Codicon.keyboardTabBelow;
 		});
 
-		const idealIconWidth = 22;
-		const minimalIconWidth = 16; // codicon size
+		const idealIconAreaWidth = 22;
 		const iconWidth = (pillRect: Rect) => {
-			const availableWidth = this._availableWidthForIcon.read(undefined)(pillRect.bottom + this._editorObs.editor.getScrollTop()) - gutterViewPortPadding;
-			return Math.max(Math.min(availableWidth, idealIconWidth), minimalIconWidth);
+			const availableIconAreaWidth = this._availableWidthForIcon.read(undefined)(pillRect.bottom + this._editorObs.editor.getScrollTop()) - gutterViewPortPadding;
+			return Math.max(Math.min(availableIconAreaWidth, idealIconAreaWidth), CODICON_SIZE_PX);
 		};
 
 		if (pillIsFullyDocked) {
@@ -362,20 +364,23 @@ export class InlineEditsGutterIndicator extends Disposable {
 
 			let lineNumberWidth;
 			if (layout.lineNumbersWidth === 0) {
-				lineNumberWidth = Math.min(Math.max(layout.lineNumbersLeft - gutterViewPortWithStickyScroll.left, 0), pillRect.width - idealIconWidth);
+				lineNumberWidth = Math.min(Math.max(layout.lineNumbersLeft - gutterViewPortWithStickyScroll.left, 0), pillRect.width - idealIconAreaWidth);
 			} else {
 				lineNumberWidth = Math.max(layout.lineNumbersLeft + layout.lineNumbersWidth - gutterViewPortWithStickyScroll.left, 0);
 			}
 
 			const lineNumberRect = pillRect.withWidth(lineNumberWidth);
-			const iconWidth = Math.max(Math.min(layout.decorationsWidth, idealIconWidth), minimalIconWidth);
-			const iconRect = pillRect.withWidth(iconWidth).translateX(lineNumberWidth);
+			const minimalIconWidthWithPadding = CODICON_SIZE_PX + CODICON_PADDING_PX;
+			const iconWidth = Math.min(layout.decorationsWidth, idealIconAreaWidth);
+			const iconRect = pillRect.withWidth(Math.max(iconWidth, minimalIconWidthWithPadding)).translateX(lineNumberWidth);
+			const iconVisible = iconWidth >= minimalIconWidthWithPadding;
 
 			return {
 				gutterEditArea,
 				icon: iconDocked,
 				iconDirection: 'right' as const,
 				iconRect,
+				iconVisible,
 				pillRect,
 				lineNumberRect,
 			};
@@ -397,6 +402,7 @@ export class InlineEditsGutterIndicator extends Disposable {
 				iconDirection: 'right' as const,
 				iconRect,
 				pillRect,
+				iconVisible: true,
 			};
 		}
 
@@ -416,6 +422,7 @@ export class InlineEditsGutterIndicator extends Disposable {
 			iconDirection,
 			iconRect,
 			pillRect,
+			iconVisible: true,
 		};
 	});
 
@@ -542,17 +549,18 @@ export class InlineEditsGutterIndicator extends Disposable {
 			),
 			n.div({
 				style: {
-					rotate: layout.map(l => `${getRotationFromDirection(l.iconDirection)}deg`),
-					transition: 'rotate 0.2s ease-in-out',
+					transform: layout.map(l => `rotate(${getRotationFromDirection(l.iconDirection)}deg)`),
+					transition: 'rotate 0.2s ease-in-out, opacity 0.2s ease-in-out',
 					display: 'flex',
 					alignItems: 'center',
 					justifyContent: 'center',
 					height: '100%',
+					opacity: layout.map(l => l.iconVisible ? '1' : '0'),
 					marginRight: layout.map(l => l.pillRect.width - l.iconRect.width - (l.lineNumberRect?.width ?? 0)),
 					width: layout.map(l => l.iconRect.width),
 				}
 			}, [
-				layout.map((l, reader) => renderIcon(l.icon.read(reader))),
+				layout.map((l, reader) => withStyles(renderIcon(l.icon.read(reader)), { fontSize: toPx(Math.min(l.iconRect.width - CODICON_PADDING_PX, CODICON_SIZE_PX)) })),
 			])
 		]),
 	]));
@@ -564,4 +572,16 @@ function getRotationFromDirection(direction: 'top' | 'bottom' | 'right'): number
 		case 'bottom': return -90;
 		case 'right': return 0;
 	}
+}
+
+function withStyles<T extends HTMLElement>(element: T, styles: { [key: string]: string }): T {
+	for (const key in styles) {
+		// eslint-disable-next-line local/code-no-any-casts
+		element.style[key as any] = styles[key];
+	}
+	return element;
+}
+
+function toPx(n: number): string {
+	return `${n}px`;
 }


### PR DESCRIPTION
```Copilot Generated Description:``` Improve the rendering of the NES gutter icon in notebook cells with line numbers by adjusting icon dimensions and visibility properties.

Fixes microsoft/vscode-copilot#18122

