### PR TITLE
Enhance inline edits for high contrast mode

### DIFF
--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/inlineEditsWordReplacementView.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/inlineEditsWordReplacementView.ts
@@ -178,8 +178,11 @@ export class InlineEditsWordReplacementView extends Disposable implements IInlin
 				const alternativeAction = layout.map(l => l.alternativeAction);
 				const alternativeActionActive = derived(reader => (alternativeAction.read(reader)?.active.read(reader) ?? false) || secondaryElementHovered.read(reader));
 
-				const theme = this._themeService.getColorTheme();
-				const isHighContrast = theme.type === 'hcDark' || theme.type === 'hcLight';
+				// const theme = this._themeService.getColorTheme();
+				const isHighContrast = observableFromEvent(this._themeService.onDidColorThemeChange, () => {
+					const theme = this._themeService.getColorTheme();
+					return theme.type === 'hcDark' || theme.type === 'hcLight';
+				}).read(reader);
 				const hcBorderColor = isHighContrast ? observeColor(contrastBorder, this._themeService).read(reader) : null;
 
 				const primaryActiveStyles = {

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/inlineEditsWordReplacementView.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/inlineEditsWordReplacementView.ts
@@ -14,6 +14,7 @@ import { localize } from '../../../../../../../nls.js';
 import { IHoverService } from '../../../../../../../platform/hover/browser/hover.js';
 import { IKeybindingService } from '../../../../../../../platform/keybinding/common/keybinding.js';
 import { editorBackground, editorHoverForeground } from '../../../../../../../platform/theme/common/colorRegistry.js';
+import { contrastBorder } from '../../../../../../../platform/theme/common/colors/baseColors.js';
 import { asCssVariable } from '../../../../../../../platform/theme/common/colorUtils.js';
 import { IThemeService } from '../../../../../../../platform/theme/common/themeService.js';
 import { ObservableCodeEditor } from '../../../../../../browser/observableCodeEditor.js';
@@ -177,22 +178,26 @@ export class InlineEditsWordReplacementView extends Disposable implements IInlin
 				const alternativeAction = layout.map(l => l.alternativeAction);
 				const alternativeActionActive = derived(reader => (alternativeAction.read(reader)?.active.read(reader) ?? false) || secondaryElementHovered.read(reader));
 
+				const theme = this._themeService.getColorTheme();
+				const isHighContrast = theme.type === 'hcDark' || theme.type === 'hcLight';
+				const hcBorderColor = isHighContrast ? observeColor(contrastBorder, this._themeService).read(reader) : null;
+
 				const primaryActiveStyles = {
-					borderColor: modifiedBorderColor,
+					borderColor: hcBorderColor ? hcBorderColor.toString() : modifiedBorderColor,
 					backgroundColor: asCssVariable(modifiedChangedTextOverlayColor),
 					color: '',
 					opacity: '1',
 				};
 
 				const secondaryActiveStyles = {
-					borderColor: asCssVariable(inlineEditIndicatorPrimaryBorder),
+					borderColor: hcBorderColor ? hcBorderColor.toString() : asCssVariable(inlineEditIndicatorPrimaryBorder),
 					backgroundColor: asCssVariable(inlineEditIndicatorPrimaryBackground),
 					color: asCssVariable(inlineEditIndicatorPrimaryForeground),
 					opacity: '1',
 				};
 
 				const passiveStyles = {
-					borderColor: observeColor(editorHoverForeground, this._themeService).map(c => c.transparent(0.2).toString()).read(reader),
+					borderColor: hcBorderColor ? hcBorderColor.toString() : observeColor(editorHoverForeground, this._themeService).map(c => c.transparent(0.2).toString()).read(reader),
 					backgroundColor: asCssVariable(editorBackground),
 					color: '',
 					opacity: '0.7',

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/inlineEditsWordReplacementView.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/inlineEditsWordReplacementView.ts
@@ -178,7 +178,6 @@ export class InlineEditsWordReplacementView extends Disposable implements IInlin
 				const alternativeAction = layout.map(l => l.alternativeAction);
 				const alternativeActionActive = derived(reader => (alternativeAction.read(reader)?.active.read(reader) ?? false) || secondaryElementHovered.read(reader));
 
-				// const theme = this._themeService.getColorTheme();
 				const isHighContrast = observableFromEvent(this._themeService.onDidColorThemeChange, () => {
 					const theme = this._themeService.getColorTheme();
 					return theme.type === 'hcDark' || theme.type === 'hcLight';

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/longDistanceHint/inlineEditsLongDistanceHint.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/longDistanceHint/inlineEditsLongDistanceHint.ts
@@ -5,7 +5,7 @@
 import { ChildNode, n, ObserverNode, ObserverNodeWithElement } from '../../../../../../../../base/browser/dom.js';
 import { Event } from '../../../../../../../../base/common/event.js';
 import { Disposable } from '../../../../../../../../base/common/lifecycle.js';
-import { IObservable, IReader, autorun, constObservable, debouncedObservable2, derived, derivedDisposable } from '../../../../../../../../base/common/observable.js';
+import { IObservable, IReader, autorun, constObservable, debouncedObservable2, derived, derivedDisposable, observableFromEvent } from '../../../../../../../../base/common/observable.js';
 import { IInstantiationService } from '../../../../../../../../platform/instantiation/common/instantiation.js';
 import { ICodeEditor } from '../../../../../../../browser/editorBrowser.js';
 import { observableCodeEditor } from '../../../../../../../browser/observableCodeEditor.js';
@@ -64,8 +64,10 @@ export class InlineEditsLongDistanceHint extends Disposable implements IInlineEd
 
 			// Check theme type by observing a color - this ensures we react to theme changes
 			const widgetBorderColor = observeColor(editorWidgetBorder, this._themeService).read(reader);
-			const theme = this._themeService.getColorTheme();
-			const isHighContrast = theme.type === 'hcDark' || theme.type === 'hcLight';
+			const isHighContrast = observableFromEvent(this._themeService.onDidColorThemeChange, () => {
+				const theme = this._themeService.getColorTheme();
+				return theme.type === 'hcDark' || theme.type === 'hcLight';
+			}).read(reader);
 
 			let borderColor;
 			if (isHighContrast) {

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/view.css
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/view.css
@@ -239,6 +239,12 @@
 	background: linear-gradient(to left, var(--vscode-editorWidget-background) 0, transparent 12px);
 }
 
+.hc-black .inline-edits-long-distance-hint-widget .go-to-label::before,
+.hc-light .inline-edits-long-distance-hint-widget .go-to-label::before {
+	/* Remove gradient in high contrast mode for clearer separation */
+	background: var(--vscode-editorWidget-background);
+}
+
 .inline-edit-alternative-action-label .codicon {
 	font-size: 12px !important;
 	padding-right: 4px;


### PR DESCRIPTION
Improve visibility of inline edits in high contrast mode by adding support for high contrast borders for long distance hints and word replacements. Adjust styles to ensure better clarity and separation in high contrast themes.

<img width="447" height="108" alt="image" src="https://github.com/user-attachments/assets/c8c56c4f-3509-43e0-92cd-4476abb74157" />

<img width="400" height="135" alt="image" src="https://github.com/user-attachments/assets/2b2086fb-8a3c-410f-b5f0-b81366764fff" />


