### PR TITLE
Support to copy breadcrumb paths

### DIFF
--- a/src/vs/workbench/browser/parts/editor/breadcrumbs.ts
+++ b/src/vs/workbench/browser/parts/editor/breadcrumbs.ts
@@ -71,6 +71,7 @@ export abstract class BreadcrumbsConfig<T> {
 	static readonly FilePath = BreadcrumbsConfig._stub<'on' | 'off' | 'last'>('breadcrumbs.filePath');
 	static readonly SymbolPath = BreadcrumbsConfig._stub<'on' | 'off' | 'last'>('breadcrumbs.symbolPath');
 	static readonly SymbolSortOrder = BreadcrumbsConfig._stub<'position' | 'name' | 'type'>('breadcrumbs.symbolSortOrder');
+	static readonly SymbolPathSeparator = BreadcrumbsConfig._stub<string>('breadcrumbs.symbolPathSeparator');
 	static readonly Icons = BreadcrumbsConfig._stub<boolean>('breadcrumbs.icons');
 	static readonly TitleScrollbarSizing = BreadcrumbsConfig._stub<IEditorPartOptions['titleScrollbarSizing']>('workbench.editor.titleScrollbarSizing');
 	static readonly TitleScrollbarVisibility = BreadcrumbsConfig._stub<IEditorPartOptions['titleScrollbarVisibility']>('workbench.editor.titleScrollbarVisibility');
@@ -164,6 +165,12 @@ Registry.as<IConfigurationRegistry>(Extensions.Configuration).registerConfigurat
 			description: localize('icons', "Render breadcrumb items with icons."),
 			type: 'boolean',
 			default: true
+		},
+		'breadcrumbs.symbolPathSeparator': {
+			description: localize('symbolPathSeparator', "The separator used when copying the breadcrumb symbol path."),
+			type: 'string',
+			default: '.',
+			scope: ConfigurationScope.LANGUAGE_OVERRIDABLE
 		},
 		'breadcrumbs.showFiles': {
 			type: 'boolean',

--- a/src/vs/workbench/browser/parts/editor/breadcrumbsControl.ts
+++ b/src/vs/workbench/browser/parts/editor/breadcrumbsControl.ts
@@ -23,6 +23,7 @@ import { localize, localize2 } from '../../../../nls.js';
 import { Categories } from '../../../../platform/action/common/actionCommonCategories.js';
 import { Action2, MenuId, registerAction2 } from '../../../../platform/actions/common/actions.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
+import { IClipboardService } from '../../../../platform/clipboard/common/clipboardService.js';
 import { ContextKeyExpr, IContextKey, IContextKeyService, RawContextKey } from '../../../../platform/contextkey/common/contextkey.js';
 import { IContextViewService } from '../../../../platform/contextview/browser/contextView.js';
 import { fillInSymbolsDragData, LocalSelectionTransfer } from '../../../../platform/dnd/browser/dnd.js';
@@ -38,7 +39,7 @@ import { registerIcon } from '../../../../platform/theme/common/iconRegistry.js'
 import { EditorResourceAccessor, IEditorPartOptions, SideBySideEditor } from '../../../common/editor.js';
 import { IEditorGroupsService } from '../../../services/editor/common/editorGroupsService.js';
 import { ACTIVE_GROUP, ACTIVE_GROUP_TYPE, IEditorService, SIDE_GROUP, SIDE_GROUP_TYPE } from '../../../services/editor/common/editorService.js';
-import { IOutline } from '../../../services/outline/browser/outline.js';
+import { IOutline, IOutlineService, OutlineTarget } from '../../../services/outline/browser/outline.js';
 import { DraggedEditorIdentifier, fillEditorsDragData } from '../../dnd.js';
 import { DEFAULT_LABELS_CONTAINER, ResourceLabels } from '../../labels.js';
 import { BreadcrumbsConfig, IBreadcrumbsService } from './breadcrumbs.js';
@@ -47,6 +48,7 @@ import { BreadcrumbsFilePicker, BreadcrumbsOutlinePicker } from './breadcrumbsPi
 import { IEditorGroupView } from './editor.js';
 import './media/breadcrumbscontrol.css';
 import { ScrollbarVisibility } from '../../../../base/common/scrollable.js';
+import { CancellationToken } from '../../../../base/common/cancellation.js';
 
 class OutlineItem extends BreadcrumbsItem {
 
@@ -60,6 +62,8 @@ class OutlineItem extends BreadcrumbsItem {
 	) {
 		super();
 	}
+
+
 
 	dispose(): void {
 		this._disposables.dispose();
@@ -949,3 +953,54 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 	}
 });
 //#endregion
+
+registerAction2(class CopyBreadcrumbPath extends Action2 {
+	constructor() {
+		super({
+			id: 'breadcrumbs.copyPath',
+			title: localize2('cmd.copyPath', "Copy Breadcrumbs Path"),
+			category: Categories.View,
+			precondition: BreadcrumbsControl.CK_BreadcrumbsVisible,
+			f1: true,
+			menu: [{
+				id: MenuId.EditorTitleContext,
+				group: '1_cutcopypaste',
+				order: 100,
+				when: BreadcrumbsControl.CK_BreadcrumbsPossible
+			}]
+		});
+	}
+	async run(accessor: ServicesAccessor): Promise<void> {
+		const groups = accessor.get(IEditorGroupsService);
+		const clipboardService = accessor.get(IClipboardService);
+		const configurationService = accessor.get(IConfigurationService);
+		const outlineService = accessor.get(IOutlineService);
+
+		if (!groups.activeGroup.activeEditorPane) {
+			return;
+		}
+
+		const outline = await outlineService.createOutline(groups.activeGroup.activeEditorPane, OutlineTarget.Breadcrumbs, CancellationToken.None);
+		if (!outline) {
+			return;
+		}
+
+		const elements = outline.config.breadcrumbsDataSource.getBreadcrumbElements();
+		const labels = elements.map(item => item.label).filter(Boolean);
+
+		outline.dispose();
+
+		if (labels.length === 0) {
+			return;
+		}
+
+		// Get separator with language override support
+		const resource = groups.activeGroup.activeEditorPane.input.resource;
+		const config = BreadcrumbsConfig.SymbolPathSeparator.bindTo(configurationService);
+		const separator = config.getValue(resource && { resource }) ?? '.';
+		config.dispose();
+
+		const path = labels.join(separator);
+		await clipboardService.writeText(path);
+	}
+});

--- a/src/vs/workbench/browser/parts/editor/breadcrumbsModel.ts
+++ b/src/vs/workbench/browser/parts/editor/breadcrumbsModel.ts
@@ -103,7 +103,7 @@ export class BreadcrumbsModel {
 
 		const breadcrumbsElements = this._currentOutline.value.config.breadcrumbsDataSource.getBreadcrumbElements();
 		for (let i = this._cfgSymbolPath.getValue() === 'last' && breadcrumbsElements.length > 0 ? breadcrumbsElements.length - 1 : 0; i < breadcrumbsElements.length; i++) {
-			result.push(new OutlineElement2(breadcrumbsElements[i], this._currentOutline.value));
+			result.push(new OutlineElement2(breadcrumbsElements[i].element, this._currentOutline.value));
 		}
 
 		if (breadcrumbsElements.length === 0 && !this._currentOutline.value.isEmpty) {

--- a/src/vs/workbench/contrib/codeEditor/browser/outline/documentSymbolsOutline.ts
+++ b/src/vs/workbench/contrib/codeEditor/browser/outline/documentSymbolsOutline.ts
@@ -5,7 +5,7 @@
 
 import { Emitter, Event } from '../../../../../base/common/event.js';
 import { Disposable, DisposableStore, IDisposable, toDisposable } from '../../../../../base/common/lifecycle.js';
-import { OutlineConfigCollapseItemsValues, IBreadcrumbsDataSource, IOutline, IOutlineCreator, IOutlineListConfig, IOutlineService, OutlineChangeEvent, OutlineConfigKeys, OutlineTarget, } from '../../../../services/outline/browser/outline.js';
+import { OutlineConfigCollapseItemsValues, IBreadcrumbsDataSource, IBreadcrumbsOutlineElement, IOutline, IOutlineCreator, IOutlineListConfig, IOutlineService, OutlineChangeEvent, OutlineConfigKeys, OutlineTarget, } from '../../../../services/outline/browser/outline.js';
 import { IWorkbenchContributionsRegistry, Extensions as WorkbenchExtensions } from '../../../../common/contributions.js';
 import { Registry } from '../../../../../platform/registry/common/platform.js';
 import { LifecyclePhase } from '../../../../services/lifecycle/common/lifecycle.js';
@@ -38,14 +38,14 @@ type DocumentSymbolItem = OutlineGroup | OutlineElement;
 
 class DocumentSymbolBreadcrumbsSource implements IBreadcrumbsDataSource<DocumentSymbolItem> {
 
-	private _breadcrumbs: (OutlineGroup | OutlineElement)[] = [];
+	private _breadcrumbs: IBreadcrumbsOutlineElement<DocumentSymbolItem>[] = [];
 
 	constructor(
 		private readonly _editor: ICodeEditor,
 		@ITextResourceConfigurationService private readonly _textResourceConfigurationService: ITextResourceConfigurationService,
 	) { }
 
-	getBreadcrumbElements(): readonly DocumentSymbolItem[] {
+	getBreadcrumbElements(): readonly IBreadcrumbsOutlineElement<DocumentSymbolItem>[] {
 		return this._breadcrumbs;
 	}
 
@@ -55,7 +55,10 @@ class DocumentSymbolBreadcrumbsSource implements IBreadcrumbsDataSource<Document
 
 	update(model: OutlineModel, position: IPosition): void {
 		const newElements = this._computeBreadcrumbs(model, position);
-		this._breadcrumbs = newElements;
+		this._breadcrumbs = newElements.map(element => ({
+			element,
+			label: element instanceof OutlineElement ? element.symbol.name : ''
+		}));
 	}
 
 	private _computeBreadcrumbs(model: OutlineModel, position: IPosition): Array<OutlineGroup | OutlineElement> {
@@ -180,7 +183,7 @@ class DocumentSymbolsOutline implements IOutline<DocumentSymbolItem> {
 			treeDataSource,
 			comparator,
 			options,
-			quickPickDataSource: { getQuickPickElements: () => { throw new Error('not implemented'); } }
+			quickPickDataSource: { getQuickPickElements: () => { throw new Error('not implemented'); } },
 		};
 
 

--- a/src/vs/workbench/contrib/notebook/browser/contrib/outline/notebookOutline.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/outline/notebookOutline.ts
@@ -33,7 +33,7 @@ import { INotebookCellOutlineDataSource, NotebookCellOutlineDataSource } from '.
 import { CellKind, NotebookCellsChangeType, NotebookSetting } from '../../../common/notebookCommon.js';
 import { IEditorService, SIDE_GROUP } from '../../../../../services/editor/common/editorService.js';
 import { LifecyclePhase } from '../../../../../services/lifecycle/common/lifecycle.js';
-import { IBreadcrumbsDataSource, IOutline, IOutlineComparator, IOutlineCreator, IOutlineListConfig, IOutlineService, IQuickPickDataSource, IQuickPickOutlineElement, OutlineChangeEvent, OutlineConfigCollapseItemsValues, OutlineConfigKeys, OutlineTarget } from '../../../../../services/outline/browser/outline.js';
+import { IBreadcrumbsDataSource, IBreadcrumbsOutlineElement, IOutline, IOutlineComparator, IOutlineCreator, IOutlineListConfig, IOutlineService, IQuickPickDataSource, IQuickPickOutlineElement, OutlineChangeEvent, OutlineConfigCollapseItemsValues, OutlineConfigKeys, OutlineTarget } from '../../../../../services/outline/browser/outline.js';
 import { OutlineEntry } from '../../viewModel/OutlineEntry.js';
 import { CancellationToken } from '../../../../../../base/common/cancellation.js';
 import { IModelDeltaDecoration } from '../../../../../../editor/common/model.js';
@@ -466,12 +466,12 @@ export class NotebookBreadcrumbsProvider implements IBreadcrumbsDataSource<Outli
 		}));
 	}
 
-	getBreadcrumbElements(): readonly OutlineEntry[] {
-		const result: OutlineEntry[] = [];
+	getBreadcrumbElements(): readonly IBreadcrumbsOutlineElement<OutlineEntry>[] {
+		const result: IBreadcrumbsOutlineElement<OutlineEntry>[] = [];
 		let candidate = this.outlineDataSourceRef?.object?.activeElement;
 		while (candidate) {
 			if (this.showCodeCells || candidate.cell.cellKind !== CellKind.Code) {
-				result.unshift(candidate);
+				result.unshift({ element: candidate, label: candidate.label });
 			}
 			candidate = candidate.parent;
 		}
@@ -595,7 +595,7 @@ export class NotebookCellOutline implements IOutline<OutlineEntry> {
 			delegate,
 			renderers,
 			comparator,
-			options
+			options,
 		};
 	}
 

--- a/src/vs/workbench/contrib/notebook/test/browser/contrib/notebookOutlineViewProviders.test.ts
+++ b/src/vs/workbench/contrib/notebook/test/browser/contrib/notebookOutlineViewProviders.test.ts
@@ -644,14 +644,14 @@ suite('Notebook Outline View Providers', function () {
 		// Validate
 		assert.equal(results.length, 3);
 
-		assert.equal(results[0].label, 'fakeRoot');
-		assert.equal(results[0].level, -1);
+		assert.equal(results[0].element.label, 'fakeRoot');
+		assert.equal(results[0].element.level, -1);
 
-		assert.equal(results[1].label, 'h1');
-		assert.equal(results[1].level, 1);
+		assert.equal(results[1].element.label, 'h1');
+		assert.equal(results[1].element.level, 1);
 
-		assert.equal(results[2].label, '# code cell 2');
-		assert.equal(results[2].level, 7);
+		assert.equal(results[2].element.label, '# code cell 2');
+		assert.equal(results[2].element.level, 7);
 	});
 
 	test('Breadcrumbs 1: Code Cells Off ', async function () {
@@ -695,11 +695,11 @@ suite('Notebook Outline View Providers', function () {
 		// Validate
 		assert.equal(results.length, 2);
 
-		assert.equal(results[0].label, 'fakeRoot');
-		assert.equal(results[0].level, -1);
+		assert.equal(results[0].element.label, 'fakeRoot');
+		assert.equal(results[0].element.level, -1);
 
-		assert.equal(results[1].label, 'h1');
-		assert.equal(results[1].level, 1);
+		assert.equal(results[1].element.label, 'h1');
+		assert.equal(results[1].element.level, 1);
 	});
 
 	// #endregion

--- a/src/vs/workbench/services/outline/browser/outline.ts
+++ b/src/vs/workbench/services/outline/browser/outline.ts
@@ -36,8 +36,13 @@ export interface IOutlineCreator<P extends IEditorPane, E> {
 	createOutline(editor: P, target: OutlineTarget, token: CancellationToken): Promise<IOutline<E> | undefined>;
 }
 
+export interface IBreadcrumbsOutlineElement<E> {
+	readonly element: E;
+	readonly label: string;
+}
+
 export interface IBreadcrumbsDataSource<E> {
-	getBreadcrumbElements(): readonly E[];
+	getBreadcrumbElements(): readonly IBreadcrumbsOutlineElement<E>[];
 }
 
 export interface IOutlineComparator<E> {


### PR DESCRIPTION
This update introduces functionality to copy breadcrumb paths, allowing users to easily share exact paths within the codebase. The separator for the breadcrumb path can be configured per language. To test, use the command palette to execute "Copy Breadcrumbs Path" while breadcrumbs are visible in the editor.


Fixes microsoft/vscode#58678

