### PR TITLE
fix: ensure fallback to default system monospace font

### DIFF
--- a/src/vs/editor/common/config/fontInfo.ts
+++ b/src/vs/editor/common/config/fontInfo.ts
@@ -227,7 +227,7 @@ export const DEFAULT_MAC_FONT_FAMILY = 'Menlo, Monaco, \'Courier New\', monospac
 /**
  * @internal
  */
-export const DEFAULT_LINUX_FONT_FAMILY = '\'Droid Sans Mono\', \'monospace\', monospace';
+export const DEFAULT_LINUX_FONT_FAMILY = '\'Droid Sans Mono\', monospace';
 /**
  * @internal
  */


### PR DESCRIPTION
This PR actually fixes an issue experienced when monaco-editor (the npm package) is used in a website loaded using Firefox on Linux.

By using quotes, the `'monospace'` family causes Firefox to load "Noto Arabic" on my system. Should be noted I have a _clean_ Fedora 43 installation, with the default Gnome 49 installed fonts. `monospace` without the quotes resolves to "Noto Sans Mono", as expected.

I see absolutely no difference for default font rendering inside Chromium-based web views. Testing with monaco-editor in Google Chrome and VSCode inside Electron.

Most Gnome-based Linux distros moved away from the Droid font-family, and are currently using the Noto font-family, but I'll leave that up to you guys. `monospace` (without quotes) properly resolves to "Noto Sans Mono".

I've tracked where this `'monospace'` value came from, and it seems to have been added in https://github.com/microsoft/vscode/commit/b99f4148788ae790c6621ed62550e78be29408d7 as part of not using "Courier New" on Linux. Seems like an oversight.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
