### PR TITLE
Better rename accepted telemetry

### DIFF
--- a/src/vs/editor/common/languages.ts
+++ b/src/vs/editor/common/languages.ts
@@ -1033,6 +1033,7 @@ export enum InlineCompletionEndOfLifeReasonKind {
 
 export type InlineCompletionEndOfLifeReason<TInlineCompletion = InlineCompletion> = {
 	kind: InlineCompletionEndOfLifeReasonKind.Accepted; // User did an explicit action to accept
+	alternativeAction: boolean; // Whether the user performed an alternative action.
 } | {
 	kind: InlineCompletionEndOfLifeReasonKind.Rejected; // User did an explicit action to reject
 } | {

--- a/src/vs/editor/contrib/inlineCompletions/browser/model/inlineCompletionsModel.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/model/inlineCompletionsModel.ts
@@ -986,7 +986,7 @@ export class InlineCompletionsModel extends Disposable {
 				this.trigger(undefined);
 			}
 
-			completion.reportEndOfLife({ kind: InlineCompletionEndOfLifeReasonKind.Accepted });
+			completion.reportEndOfLife({ kind: InlineCompletionEndOfLifeReasonKind.Accepted, alternativeAction });
 		} finally {
 			completion.removeRef();
 			this._inAcceptFlow.set(true, undefined);
@@ -1140,7 +1140,7 @@ export class InlineCompletionsModel extends Disposable {
 			transaction(tx => {
 				if (suggestion.action?.kind === 'jumpTo') {
 					this.stop(undefined, tx);
-					suggestion.reportEndOfLife({ kind: InlineCompletionEndOfLifeReasonKind.Accepted });
+					suggestion.reportEndOfLife({ kind: InlineCompletionEndOfLifeReasonKind.Accepted, alternativeAction: false });
 				}
 
 				this._jumpedToId.set(s.inlineSuggestion.semanticId, tx);

--- a/src/vs/editor/contrib/inlineCompletions/browser/model/inlineCompletionsSource.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/model/inlineCompletionsSource.ts
@@ -476,6 +476,7 @@ export class InlineCompletionsSource extends Disposable {
 			preceeded: undefined,
 			superseded: undefined,
 			reason: undefined,
+			acceptedAlternativeAction: undefined,
 			correlationId: undefined,
 			shownDuration: undefined,
 			shownDurationUncollapsed: undefined,

--- a/src/vs/editor/contrib/inlineCompletions/browser/telemetry.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/telemetry.ts
@@ -34,6 +34,7 @@ export type InlineCompletionEndOfLifeEvent = {
 	timeUntilProviderRequest: number | undefined;
 	timeUntilProviderResponse: number | undefined;
 	reason: 'accepted' | 'rejected' | 'ignored' | undefined;
+	acceptedAlternativeAction: boolean | undefined;
 	partiallyAccepted: number | undefined;
 	partiallyAcceptedCountSinceOriginal: number | undefined;
 	partiallyAcceptedRatioSinceOriginal: number | undefined;
@@ -83,6 +84,7 @@ type InlineCompletionsEndOfLifeClassification = {
 	timeUntilProviderRequest: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The time it took for the inline completion to be requested from the provider' };
 	timeUntilProviderResponse: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The time it took for the inline completion to be shown after the request' };
 	reason: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The reason for the inline completion ending' };
+	acceptedAlternativeAction: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Whether the user performed an alternative action when accepting the inline completion' };
 	selectedSuggestionInfo: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Whether the inline completion was requested with a selected suggestion' };
 	partiallyAccepted: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'How often the inline completion was partially accepted by the user' };
 	partiallyAcceptedCountSinceOriginal: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'How often the inline completion was partially accepted since the original request' };

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -7677,6 +7677,7 @@ declare namespace monaco.languages {
 
 	export type InlineCompletionEndOfLifeReason<TInlineCompletion = InlineCompletion> = {
 		kind: InlineCompletionEndOfLifeReasonKind.Accepted;
+		alternativeAction: boolean;
 	} | {
 		kind: InlineCompletionEndOfLifeReasonKind.Rejected;
 	} | {

--- a/src/vs/workbench/api/browser/mainThreadLanguageFeatures.ts
+++ b/src/vs/workbench/api/browser/mainThreadLanguageFeatures.ts
@@ -1447,6 +1447,7 @@ class ExtensionBackedInlineCompletionsProvider extends Disposable implements lan
 			reason: reason.kind === InlineCompletionEndOfLifeReasonKind.Accepted ? 'accepted'
 				: reason.kind === InlineCompletionEndOfLifeReasonKind.Rejected ? 'rejected'
 					: reason.kind === InlineCompletionEndOfLifeReasonKind.Ignored ? 'ignored' : undefined,
+			acceptedAlternativeAction: reason.kind === InlineCompletionEndOfLifeReasonKind.Accepted && reason.alternativeAction,
 			noSuggestionReason: undefined,
 			notShownReason: lifetimeSummary.notShownReason,
 			renameCreated: lifetimeSummary.renameCreated,


### PR DESCRIPTION
```Copilot Generated Description:``` Introduce an alternative action flag for accepted inline completions and update related telemetry structures to include this new information.

