### PR TITLE
Fix icon for settings folder dropdown in JSON Settings editor

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/preferencesIcons.ts
+++ b/src/vs/workbench/contrib/preferences/browser/preferencesIcons.ts
@@ -7,7 +7,7 @@ import { Codicon } from '../../../../base/common/codicons.js';
 import { localize } from '../../../../nls.js';
 import { registerIcon } from '../../../../platform/theme/common/iconRegistry.js';
 
-export const settingsScopeDropDownIcon = registerIcon('settings-folder-dropdown', Codicon.triangleDown, localize('settingsScopeDropDownIcon', 'Icon for the folder dropdown button in the split JSON Settings editor.'));
+export const settingsScopeDropDownIcon = registerIcon('settings-folder-dropdown', Codicon.chevronDown, localize('settingsScopeDropDownIcon', 'Icon for the folder dropdown button in the split JSON Settings editor.'));
 export const settingsMoreActionIcon = registerIcon('settings-more-action', Codicon.gear, localize('settingsMoreActionIcon', 'Icon for the \'more actions\' action in the Settings UI.'));
 
 export const keybindingsRecordKeysIcon = registerIcon('keybindings-record-keys', Codicon.recordKeys, localize('keybindingsRecordKeysIcon', 'Icon for the \'record keys\' action in the keybinding UI.'));


### PR DESCRIPTION
Update the icon for the settings folder dropdown in the JSON Settings editor from a triangle to a chevron for improved visual consistency. Test by opening the JSON Settings editor and verifying the icon change.

Addresses: https://github.com/microsoft/vscode/issues/264354
