### PR TITLE
improve tooltip accuracy for terminal chat show/focus action

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart.ts
@@ -1227,7 +1227,7 @@ export class FocusChatInstanceAction extends Action implements IAction {
 	}
 
 	public override async run() {
-		this.label = localize('focusTerminal', 'Focus Terminal');
+		this.label = this._instance?.shellLaunchConfig.hideFromUser ? localize('showAndFocusTerminal', 'Show and Focus Terminal') : localize('focusTerminal', 'Focus Terminal');
 		this._updateTooltip();
 
 		let target: FocusChatInstanceTelemetryEvent['target'] = 'none';


### PR DESCRIPTION
fixes #274413

Says `focus` if the terminal is already revealed, `show and focus` if it's hidden

cc @tyriar