### PR TITLE
Support .code-workspace.local overrides

### DIFF
--- a/extensions/configuration-editing/package.json
+++ b/extensions/configuration-editing/package.json
@@ -41,6 +41,7 @@
         "id": "jsonc",
         "extensions": [
           ".code-workspace",
+          ".code-workspace.local",
           "language-configuration.json",
           "icon-theme.json",
           "color-theme.json"
@@ -100,6 +101,10 @@
       },
       {
         "fileMatch": "**/*.code-workspace",
+        "url": "vscode://schemas/workspaceConfig"
+      },
+      {
+        "fileMatch": "**/*.code-workspace.local",
         "url": "vscode://schemas/workspaceConfig"
       },
       {

--- a/extensions/configuration-editing/src/configurationEditingMain.ts
+++ b/extensions/configuration-editing/src/configurationEditingMain.ts
@@ -24,6 +24,7 @@ export function activate(context: vscode.ExtensionContext): void {
 
 	// Workspace file launch/tasks variable completions
 	context.subscriptions.push(registerVariableCompletions('**/*.code-workspace'));
+	context.subscriptions.push(registerVariableCompletions('**/*.code-workspace.local'));
 
 	// keybindings.json/package.json context key suggestions
 	context.subscriptions.push(registerContextKeyCompletions());
@@ -42,7 +43,7 @@ function registerVariableCompletions(pattern: string): vscode.Disposable {
 		provideCompletionItems(document, position, _token) {
 			const location = getLocation(document.getText(), document.offsetAt(position));
 			if (isCompletingInsidePropertyStringValue(document, location, position)) {
-				if (document.fileName.endsWith('.code-workspace') && !isLocationInsideTopLevelProperty(location, ['launch', 'tasks'])) {
+				if ((document.fileName.endsWith('.code-workspace') || document.fileName.endsWith('.code-workspace.local')) && !isLocationInsideTopLevelProperty(location, ['launch', 'tasks'])) {
 					return [];
 				}
 
@@ -103,7 +104,11 @@ interface IExtensionsContent {
 }
 
 function registerExtensionsCompletions(): vscode.Disposable[] {
-	return [registerExtensionsCompletionsInExtensionsDocument(), registerExtensionsCompletionsInWorkspaceConfigurationDocument()];
+	return [
+		registerExtensionsCompletionsInExtensionsDocument(),
+		registerExtensionsCompletionsInWorkspaceConfigurationDocument('**/*.code-workspace'),
+		registerExtensionsCompletionsInWorkspaceConfigurationDocument('**/*.code-workspace.local')
+	];
 }
 
 function registerExtensionsCompletionsInExtensionsDocument(): vscode.Disposable {
@@ -120,8 +125,8 @@ function registerExtensionsCompletionsInExtensionsDocument(): vscode.Disposable 
 	});
 }
 
-function registerExtensionsCompletionsInWorkspaceConfigurationDocument(): vscode.Disposable {
-	return vscode.languages.registerCompletionItemProvider({ pattern: '**/*.code-workspace' }, {
+function registerExtensionsCompletionsInWorkspaceConfigurationDocument(pattern: string): vscode.Disposable {
+	return vscode.languages.registerCompletionItemProvider({ pattern }, {
 		provideCompletionItems(document, position, _token) {
 			const location = getLocation(document.getText(), document.offsetAt(position));
 			if (location.path[0] === 'extensions' && location.path[1] === 'recommendations') {

--- a/src/vs/workbench/services/extensionRecommendations/test/common/workspaceExtensionsConfig.test.ts
+++ b/src/vs/workbench/services/extensionRecommendations/test/common/workspaceExtensionsConfig.test.ts
@@ -1,0 +1,72 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { FileService } from '../../../../../platform/files/common/fileService.js';
+import { InMemoryFileSystemProvider } from '../../../../../platform/files/common/inMemoryFilesystemProvider.js';
+import { IFileService } from '../../../../../platform/files/common/files.js';
+import { NullLogService } from '../../../../../platform/log/common/log.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { joinPath } from '../../../../../base/common/resources.js';
+import { VSBuffer } from '../../../../../base/common/buffer.js';
+import { WorkspaceExtensionsConfigService } from '../../common/workspaceExtensionsConfig.js';
+import { TestContextService } from '../../../../test/common/workbenchTestServices.js';
+import { IQuickInputService } from '../../../../../platform/quickinput/common/quickInput.js';
+import { IModelService } from '../../../../../editor/common/services/model.js';
+import { ILanguageService } from '../../../../../editor/common/languages/language.js';
+import { IJSONEditingService } from '../../../configuration/common/jsonEditing.js';
+import { Workspace } from '../../../../../platform/workspace/test/common/testWorkspace.js';
+import { toWorkspaceFolder } from '../../../../../platform/workspace/common/workspace.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+
+const ROOT = URI.file('tests').with({ scheme: 'vscode-tests' });
+
+suite('WorkspaceExtensionsConfigService - Local Overrides', () => {
+
+	let fileService: IFileService;
+	let folderA: URI;
+	let folderB: URI;
+	let workspaceConfig: URI;
+	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
+
+	setup(async () => {
+		const logService = new NullLogService();
+		fileService = disposables.add(new FileService(logService));
+		const fileSystemProvider = disposables.add(new InMemoryFileSystemProvider());
+		disposables.add(fileService.registerProvider(ROOT.scheme, fileSystemProvider));
+
+		folderA = joinPath(ROOT, 'a');
+		folderB = joinPath(ROOT, 'b');
+		workspaceConfig = joinPath(ROOT, 'test.code-workspace');
+		const localWorkspaceConfig = workspaceConfig.with({ path: `${workspaceConfig.path}.local` });
+
+		await fileService.createFolder(folderA);
+		await fileService.createFolder(folderB);
+
+		await fileService.writeFile(workspaceConfig, VSBuffer.fromString(JSON.stringify({
+			folders: [{ path: folderA.path }, { path: folderB.path }],
+			extensions: { recommendations: ['shared.extension'] }
+		}, null, '\t')));
+
+		await fileService.writeFile(localWorkspaceConfig, VSBuffer.fromString(JSON.stringify({
+			extensions: { recommendations: ['local.extension'] }
+		}, null, '\t')));
+	});
+
+	test('merges local workspace extension recommendations', async () => {
+		const service = disposables.add(new WorkspaceExtensionsConfigService(
+			new TestContextService(new Workspace('test', [toWorkspaceFolder(folderA), toWorkspaceFolder(folderB)], workspaceConfig)),
+			fileService,
+			{} as IQuickInputService,
+			{} as IModelService,
+			{} as ILanguageService,
+			{} as IJSONEditingService
+		));
+
+		const recommendations = await service.getRecommendations();
+		assert.deepStrictEqual(recommendations.sort(), ['local.extension', 'shared.extension'].sort());
+	});
+
+});


### PR DESCRIPTION
**Fixes/Refs:** Fixes #282806

**Summary**
Adds automatic support for sibling `*.code-workspace.local` files. When present, VS Code loads and merges the local file on
top of the tracked `*.code-workspace` file, enabling per‑checkout/personal overrides without committing changes to the shared
workspace.

**Behavior / Merge Rules**
- `settings`: deep merge, local values override shared values.
- `folders`: ignored from `.local` (workspace structure stays shared).
- `extensions.recommendations` / `extensions.unwantedRecommendations`: concatenate arrays (local additions only).
- `tasks` / `launch`: deep merge with array concatenation for additive local configs.
- If no `.local` file exists or it’s invalid, VS Code falls back to the main workspace file.

**Implementation Notes**
- Added local override discovery + merge helpers in `src/vs/platform/workspaces/common/workspaces.ts`.
- Workspace config loading now reads/merges `.local` and watches it for changes in `src/vs/workbench/services/configuration/
browser/configuration.ts`.
- Workspace extension recommendations read merged config and react to local file changes; toggle actions still edit only the
shared workspace file in `src/vs/workbench/services/extensionRecommendations/common/workspaceExtensionsConfig.ts`.
- `.code-workspace.local` is treated like a workspace JSONC file for schema validation and completions via `extensions/
configuration-editing`.

**Tests**
- `./scripts/test.sh --grep "workspace local overrides are merged"`
- `./scripts/test.sh --grep "WorkspaceExtensionsConfigService - Local Overrides"`

**Notes**
- Backward compatible and opt‑in: only active when a `.code-workspace.local` file exists.
- Applies to saved workspaces (`*.code-workspace`), not untitled workspaces.