### PR TITLE
improve terminal completions relative path resolution

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalCompletionService.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalCompletionService.ts
@@ -321,11 +321,15 @@ export class TerminalCompletionService extends Disposable implements ITerminalCo
 			const refersToCwd = lastWordFolderBasename.length > 0 && basename(cwd.path) === lastWordFolderBasename;
 			const folderToResolve = (useWindowsStylePath ? lastWordFolder.replaceAll('/', '\\') : lastWordFolder).replaceAll('\\ ', ' ');
 			try {
-				const resolved = refersToCwd ? cwd : URI.joinPath(cwd, folderToResolve);
+				const resolved = URI.joinPath(cwd, folderToResolve);
 				await this._fileService.stat(resolved);
 				lastWordFolderResource = resolved;
 			} catch {
-				return undefined;
+				if (refersToCwd) {
+					lastWordFolderResource = cwd;
+				} else {
+					return undefined;
+				}
 			}
 		}
 

--- a/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalCompletionService.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalCompletionService.ts
@@ -316,8 +316,41 @@ export class TerminalCompletionService extends Disposable implements ITerminalCo
 		const cwd = URI.revive(resourceOptions.cwd);
 		let lastWordFolderResource: URI | string | undefined;
 		if (type === 'relative' && lastWordFolder.length > 0) {
-			// The extension already resolved the typed path into cwd when possible. Just ensure
-			// cwd exists before using it for completions.
+			// If the typed folder matches the tail of cwd (common when the extension already
+			// resolved the path, such as `./src/vs/`), reuse cwd to avoid duplicating segments.
+			const normalizedFolder = (useWindowsStylePath ? lastWordFolder.replaceAll('\\', '/') : lastWordFolder).replaceAll('\\ ', ' ');
+			const hasDotPrefix = normalizedFolder.startsWith('./');
+			if (hasDotPrefix) {
+				const stripped = normalizedFolder.replace(/^\.\/+/, '').replace(/\/+$/, '');
+				if (stripped) {
+					const cwdParts = cwd.path.replace(/\/+$/, '').split('/');
+					const strippedParts = stripped.split('/');
+					const tailMatches = strippedParts.length <= cwdParts.length && strippedParts.every((part, idx) => cwdParts[cwdParts.length - strippedParts.length + idx] === part);
+					if (tailMatches) {
+						try {
+							await this._fileService.stat(cwd);
+							lastWordFolderResource = cwd;
+						} catch {
+							return undefined;
+						}
+					}
+				}
+			}
+
+			// Otherwise resolve the folder relative to cwd.
+			if (!lastWordFolderResource) {
+				const folderToResolve = URI.joinPath(cwd, normalizedFolder);
+				try {
+					await this._fileService.stat(folderToResolve);
+					lastWordFolderResource = folderToResolve;
+				} catch {
+					return undefined;
+				}
+			}
+		} else if (type === 'relative') {
+			lastWordFolderResource = cwd;
+		}
+		if (type === 'relative' && !lastWordFolderResource) {
 			try {
 				await this._fileService.stat(cwd);
 				lastWordFolderResource = cwd;

--- a/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalCompletionService.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalCompletionService.ts
@@ -316,20 +316,13 @@ export class TerminalCompletionService extends Disposable implements ITerminalCo
 		const cwd = URI.revive(resourceOptions.cwd);
 		let lastWordFolderResource: URI | string | undefined;
 		if (type === 'relative' && lastWordFolder.length > 0) {
-			const lastWordFolderNoPrefix = lastWordFolder.replace(/^[.][\\\/]/, '');
-			const lastWordFolderBasename = lastWordFolderNoPrefix.replace(/[\\\/]$/, '');
-			const refersToCwd = lastWordFolderBasename.length > 0 && basename(cwd.path) === lastWordFolderBasename;
-			const folderToResolve = (useWindowsStylePath ? lastWordFolder.replaceAll('/', '\\') : lastWordFolder).replaceAll('\\ ', ' ');
+			// The extension already resolved the typed path into cwd when possible. Just ensure
+			// cwd exists before using it for completions.
 			try {
-				const resolved = URI.joinPath(cwd, folderToResolve);
-				await this._fileService.stat(resolved);
-				lastWordFolderResource = resolved;
+				await this._fileService.stat(cwd);
+				lastWordFolderResource = cwd;
 			} catch {
-				if (refersToCwd) {
-					lastWordFolderResource = cwd;
-				} else {
-					return undefined;
-				}
+				return undefined;
 			}
 		}
 

--- a/src/vs/workbench/contrib/terminalContrib/suggest/test/browser/terminalCompletionService.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/test/browser/terminalCompletionService.test.ts
@@ -582,14 +582,14 @@ suite('TerminalCompletionService', () => {
 				{ resource: URI.parse('file:///test/folder1/'), isDirectory: true },
 				{ resource: URI.parse('file:///test/folder2/'), isDirectory: true }
 			];
-			const result = await terminalCompletionService.resolveResources(resourceOptions, 'test/', 5, provider, capabilities);
+			const result = await terminalCompletionService.resolveResources(resourceOptions, './test/', 7, provider, capabilities);
 
 			assertCompletions(result, [
 				{ label: './test/', detail: '/test/' },
 				{ label: './test/folder1/', detail: '/test/folder1/' },
 				{ label: './test/folder2/', detail: '/test/folder2/' },
 				{ label: './test/../', detail: '/' }
-			], { replacementRange: [0, 5] });
+			], { replacementRange: [0, 7] });
 		});
 	});
 

--- a/src/vs/workbench/contrib/terminalContrib/suggest/test/browser/terminalCompletionService.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/test/browser/terminalCompletionService.test.ts
@@ -545,6 +545,28 @@ suite('TerminalCompletionService', () => {
 				{ label: './../', detail: '/' }
 			], { replacementRange: [1, 10] });
 		});
+		test('should resolve nested folder when name matches cwd basename', async () => {
+			const resourceOptions: TerminalCompletionResourceOptions = {
+				cwd: URI.parse('file:///test'),
+				showDirectories: true,
+				pathSeparator
+			};
+			validResources = [
+				URI.parse('file:///test'),
+				URI.parse('file:///test/test'),
+			];
+			childResources = [
+				{ resource: URI.parse('file:///test/test/'), isDirectory: true },
+				{ resource: URI.parse('file:///test/test/inner/'), isDirectory: true }
+			];
+			const result = await terminalCompletionService.resolveResources(resourceOptions, 'test/', 5, provider, capabilities);
+
+			assertCompletions(result, [
+				{ label: './test/', detail: '/test/test/' },
+				{ label: './test/inner/', detail: '/test/test/inner/' },
+				{ label: './test/../', detail: '/' }
+			], { replacementRange: [0, 5] });
+		});
 		test('test/| should normalize current and parent folders', async () => {
 			const resourceOptions: TerminalCompletionResourceOptions = {
 				cwd: URI.parse('file:///test'),


### PR DESCRIPTION
fixes #282458
fixes #282491

- For relative paths with content (`./src/vs/`), we first normalize separators/escapes and check whether that trailing segment already matches the end of cwd. This catches cases where the extension already resolved the path so we avoid re-appending segments (prevents `./src/src/...` duplicates). We stat cwd to be sure it exists.
- If that reuse doesn’t apply, we resolve the normalized folder against cwd (`URI.joinPath`) and ensure it exists via stat; if not, we bail.
- If the relative path is empty (e.g. cursor at start), we just use cwd.
- This makes resource completions consistent whether the extension pre-resolved the path or not, and prevents showing phantom paths like duplicated `./s/` segments.

Also updated tests to align with the stricter resolution, including path normalization in the test stub and ensuring `CDPATH` roots are marked as existing.