### PR TITLE
Replace old-style TS modules with namespaces

### DIFF
--- a/src/vs/editor/standalone/browser/standaloneServices.ts
+++ b/src/vs/editor/standalone/browser/standaloneServices.ts
@@ -1171,7 +1171,7 @@ registerSingleton(IDefaultAccountService, StandaloneDefaultAccountService, Insta
  * We don't want to eagerly instantiate services because embedders get a one time chance
  * to override services when they create the first editor.
  */
-export module StandaloneServices {
+export namespace StandaloneServices {
 
 	const serviceCollection = new ServiceCollection();
 	for (const [id, descriptor] of getSingletonServiceDescriptors()) {

--- a/src/vs/platform/extensionManagement/node/extensionSignatureVerificationService.ts
+++ b/src/vs/platform/extensionManagement/node/extensionSignatureVerificationService.ts
@@ -34,7 +34,7 @@ export interface IExtensionSignatureVerificationService {
 	verify(extensionId: string, version: string, vsixFilePath: string, signatureArchiveFilePath: string, clientTargetPlatform?: TargetPlatform): Promise<IExtensionSignatureVerificationResult | undefined>;
 }
 
-declare module vsceSign {
+declare namespace vsceSign {
 	export function verify(vsixFilePath: string, signatureArchiveFilePath: string, verbose: boolean): Promise<ExtensionSignatureVerificationResult>;
 }
 

--- a/src/vs/platform/sign/browser/signService.ts
+++ b/src/vs/platform/sign/browser/signService.ts
@@ -11,7 +11,7 @@ import { IProductService } from '../../product/common/productService.js';
 import { AbstractSignService, IVsdaValidator } from '../common/abstractSignService.js';
 import { ISignService } from '../common/sign.js';
 
-declare module vsdaWeb {
+declare namespace vsdaWeb {
 	export function sign(salted_message: string): string;
 
 	// eslint-disable-next-line @typescript-eslint/naming-convention

--- a/src/vs/platform/sign/node/signService.ts
+++ b/src/vs/platform/sign/node/signService.ts
@@ -6,7 +6,7 @@
 import { AbstractSignService, IVsdaValidator } from '../common/abstractSignService.js';
 import { ISignService } from '../common/sign.js';
 
-declare module vsda {
+declare namespace vsda {
 	// the signer is a native module that for historical reasons uses a lower case class name
 	// eslint-disable-next-line @typescript-eslint/naming-convention
 	export class signer {

--- a/src/vs/server/node/remoteExtensionHostAgentServer.ts
+++ b/src/vs/server/node/remoteExtensionHostAgentServer.ts
@@ -43,7 +43,7 @@ const require = createRequire(import.meta.url);
 
 const SHUTDOWN_TIMEOUT = 5 * 60 * 1000;
 
-declare module vsda {
+declare namespace vsda {
 	// the signer is a native module that for historical reasons uses a lower case class name
 	// eslint-disable-next-line @typescript-eslint/naming-convention
 	export class signer {

--- a/src/vs/workbench/contrib/debug/common/debugProtocol.d.ts
+++ b/src/vs/workbench/contrib/debug/common/debugProtocol.d.ts
@@ -6,7 +6,7 @@
 /** Declaration module describing the VS Code debug protocol.
 	Auto-generated from json schema. Do not edit manually.
 */
-declare module DebugProtocol {
+declare namespace DebugProtocol {
 
 	/** Base class of requests, responses, and events. */
 	interface ProtocolMessage {

--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewPreloads.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewPreloads.ts
@@ -20,7 +20,7 @@ import type { NotebookCellOutputTransferData } from '../../../../../../platform/
 // function. Imports are not allowed. This is stringified and injected into
 // the webview.
 
-declare module globalThis {
+declare namespace globalThis {
 	const acquireVsCodeApi: () => ({
 		getState(): { [key: string]: unknown };
 		setState(data: { [key: string]: unknown }): void;

--- a/src/vs/workbench/contrib/tasks/common/problemMatcher.ts
+++ b/src/vs/workbench/contrib/tasks/common/problemMatcher.ts
@@ -33,7 +33,7 @@ export enum FileLocationKind {
 	Search
 }
 
-export module FileLocationKind {
+export namespace FileLocationKind {
 	export function fromString(value: string): FileLocationKind | undefined {
 		value = value.toLowerCase();
 		if (value === 'absolute') {
@@ -55,7 +55,7 @@ export enum ProblemLocationKind {
 	Location
 }
 
-export module ProblemLocationKind {
+export namespace ProblemLocationKind {
 	export function fromString(value: string): ProblemLocationKind | undefined {
 		value = value.toLowerCase();
 		if (value === 'file') {
@@ -117,7 +117,7 @@ export enum ApplyToKind {
 	closedDocuments
 }
 
-export module ApplyToKind {
+export namespace ApplyToKind {
 	export function fromString(value: string): ApplyToKind | undefined {
 		value = value.toLowerCase();
 		if (value === 'alldocuments') {


### PR DESCRIPTION
See https://github.com/microsoft/TypeScript/pull/62876

`module` has been frowned on for a very long time, was soft deprecated a few releases ago, hard errors in 6.0, and won't even parse in 7.0.