### PR TITLE
Fix PRM fetching strategy

### DIFF
--- a/src/vs/base/common/oauth.ts
+++ b/src/vs/base/common/oauth.ts
@@ -1105,14 +1105,14 @@ export interface IFetchResourceMetadataOptions {
  * @param targetResource The target resource URL to compare origins with (e.g., the MCP server URL)
  * @param resourceMetadataUrl Optional URL to fetch the resource metadata from. If not provided, will try well-known URIs.
  * @param options Configuration options for the fetch operation
- * @returns Promise that resolves to the validated resource metadata
- * @throws Error if the fetch fails, returns non-200 status, or the response is invalid
+ * @returns Promise that resolves to an object containing the validated resource metadata and any errors encountered during discovery
+ * @throws Error if the fetch fails, returns non-200 status, or the response is invalid on all attempted URLs
  */
 export async function fetchResourceMetadata(
 	targetResource: string,
 	resourceMetadataUrl: string | undefined,
 	options: IFetchResourceMetadataOptions = {}
-): Promise<IAuthorizationProtectedResourceMetadata> {
+): Promise<{ metadata: IAuthorizationProtectedResourceMetadata; errors: Error[] }> {
 	const {
 		sameOriginHeaders = {},
 		fetch: fetchImpl = fetch
@@ -1120,73 +1120,79 @@ export async function fetchResourceMetadata(
 
 	const targetResourceUrlObj = new URL(targetResource);
 
-	// If no resourceMetadataUrl is provided, try well-known URIs as per RFC 9728
-	let urlsToTry: string[];
-	if (!resourceMetadataUrl) {
-		// Try in order: 1) with path appended, 2) at root
-		const pathComponent = targetResourceUrlObj.pathname === '/' ? undefined : targetResourceUrlObj.pathname;
-		const rootUrl = `${targetResourceUrlObj.origin}${AUTH_PROTECTED_RESOURCE_METADATA_DISCOVERY_PATH}`;
-		if (pathComponent) {
-			// Only try both URLs if we have a path component
-			urlsToTry = [
-				`${rootUrl}${pathComponent}`,
-				rootUrl
-			];
-		} else {
-			// If target is already at root, only try the root URL once
-			urlsToTry = [rootUrl];
+	const fetchPrm = async (prmUrl: string, validateUrl: string) => {
+		// Determine if we should include same-origin headers
+		let headers: Record<string, string> = {
+			'Accept': 'application/json'
+		};
+
+		const resourceMetadataUrlObj = new URL(prmUrl);
+		if (resourceMetadataUrlObj.origin === targetResourceUrlObj.origin) {
+			headers = {
+				...headers,
+				...sameOriginHeaders
+			};
 		}
-	} else {
-		urlsToTry = [resourceMetadataUrl];
-	}
+
+		const response = await fetchImpl(prmUrl, { method: 'GET', headers });
+		if (response.status !== 200) {
+			let errorText: string;
+			try {
+				errorText = await response.text();
+			} catch {
+				errorText = response.statusText;
+			}
+			throw new Error(`Failed to fetch resource metadata from ${prmUrl}: ${response.status} ${errorText}`);
+		}
+
+		const body = await response.json();
+		if (isAuthorizationProtectedResourceMetadata(body)) {
+			// Validate that the resource matches the target resource
+			// Use URL constructor for normalization - it handles hostname case and trailing slashes
+			const prmValue = new URL(body.resource).toString();
+			const expectedResource = new URL(validateUrl).toString();
+			if (prmValue !== expectedResource) {
+				throw new Error(`Protected Resource Metadata 'resource' property value "${prmValue}" does not match expected value "${expectedResource}" for URL ${prmUrl}. Per RFC 9728, these MUST match. See https://datatracker.ietf.org/doc/html/rfc9728#PRConfigurationValidation`);
+			}
+			return body;
+		} else {
+			throw new Error(`Invalid resource metadata from ${prmUrl}. Expected to follow shape of https://datatracker.ietf.org/doc/html/rfc9728#name-protected-resource-metadata (Hints: is scopes_supported an array? Is resource a string?). Current payload: ${JSON.stringify(body)}`);
+		}
+	};
 
 	const errors: Error[] = [];
-	for (const urlToTry of urlsToTry) {
+	if (resourceMetadataUrl) {
 		try {
-			// Determine if we should include same-origin headers
-			let headers: Record<string, string> = {
-				'Accept': 'application/json'
-			};
-
-			const resourceMetadataUrlObj = new URL(urlToTry);
-			if (resourceMetadataUrlObj.origin === targetResourceUrlObj.origin) {
-				headers = {
-					...headers,
-					...sameOriginHeaders
-				};
-			}
-
-			const response = await fetchImpl(urlToTry, { method: 'GET', headers });
-			if (response.status !== 200) {
-				let errorText: string;
-				try {
-					errorText = await response.text();
-				} catch {
-					errorText = response.statusText;
-				}
-				errors.push(new Error(`Failed to fetch resource metadata from ${urlToTry}: ${response.status} ${errorText}`));
-				continue;
-			}
-
-			const body = await response.json();
-			if (isAuthorizationProtectedResourceMetadata(body)) {
-				// Use URL constructor for normalization - it handles hostname case and trailing slashes
-				const prmValue = new URL(body.resource).toString();
-				const targetValue = targetResourceUrlObj.toString();
-				if (prmValue !== targetValue) {
-					throw new Error(`Protected Resource Metadata resource property value "${prmValue}" (length: ${prmValue.length}) does not match target server url "${targetValue}" (length: ${targetValue.length}). These MUST match to follow OAuth spec https://datatracker.ietf.org/doc/html/rfc9728#PRConfigurationValidation`);
-				}
-				return body;
-			} else {
-				errors.push(new Error(`Invalid resource metadata from ${urlToTry}. Expected to follow shape of https://datatracker.ietf.org/doc/html/rfc9728#name-protected-resource-metadata (Hints: is scopes_supported an array? Is resource a string?). Current payload: ${JSON.stringify(body)}`));
-				continue;
-			}
+			const metadata = await fetchPrm(resourceMetadataUrl, targetResource);
+			return { metadata, errors };
 		} catch (e) {
 			errors.push(e instanceof Error ? e : new Error(String(e)));
-			continue;
 		}
 	}
-	// If we've tried all URLs and none worked, throw the error(s)
+
+	// Try well-known URIs starting with path-appended, then root
+	const hasPathComponent = targetResourceUrlObj.pathname !== '/';
+	const rootUrl = `${targetResourceUrlObj.origin}${AUTH_PROTECTED_RESOURCE_METADATA_DISCOVERY_PATH}`;
+
+	if (hasPathComponent) {
+		const pathAppendedUrl = `${rootUrl}${targetResourceUrlObj.pathname}`;
+		try {
+			const metadata = await fetchPrm(pathAppendedUrl, targetResource);
+			return { metadata, errors };
+		} catch (e) {
+			errors.push(e instanceof Error ? e : new Error(String(e)));
+		}
+	}
+
+	// Finally, try root discovery
+	try {
+		const metadata = await fetchPrm(rootUrl, targetResourceUrlObj.origin);
+		return { metadata, errors };
+	} catch (e) {
+		errors.push(e instanceof Error ? e : new Error(String(e)));
+	}
+
+	// If we've tried all methods and none worked, throw the error(s)
 	if (errors.length === 1) {
 		throw errors[0];
 	} else {


### PR DESCRIPTION
The biggest part of this fix is what we were doing wrong is when we fell back to the root url. We were validating that the resource was the full mcp url... but that's not what the spec says.

> The resource value returned MUST be identical to the protected resource's resource identifier value into which the well-known URI path suffix was inserted to create the URL used to retrieve the metadata. If these values are not identical, the data contained in the response MUST NOT be used.
>
> If the protected resource metadata was retrieved from a URL returned by the protected resource via the WWW-Authenticate resource_metadata parameter, then the resource value returned MUST be identical to the URL that the client used to make the request to the resource server. If these values are not identical, the data contained in the response MUST NOT be used.

Namely the first part. We should be validating based on the root url in that case.

So this makes that functional change, while cleaning up the code to allow for logging of errors along the way and just cleaner code based on the new requirements.

Fixes https://github.com/microsoft/vscode/issues/279955

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
