### PR TITLE
Update action widget styles for improved appearance and spacing

### DIFF
--- a/src/vs/platform/actionWidget/browser/actionWidget.css
+++ b/src/vs/platform/actionWidget/browser/actionWidget.css
@@ -11,11 +11,11 @@
 	z-index: 40;
 	display: block;
 	width: 100%;
-	border: 1px solid var(--vscode-menu-border) !important;
+	border: 1px solid var(--vscode-editorHoverWidget-border) !important;
 	border-radius: 5px;
 	background-color: var(--vscode-menu-background);
 	color: var(--vscode-menu-foreground);
-	padding: 4px;
+	padding: 4px 0;
 	box-shadow: 0 2px 8px var(--vscode-widget-shadow);
 }
 
@@ -57,10 +57,11 @@
 /** Styles for each row in the list element **/
 .action-widget .monaco-list .monaco-list-row {
 	padding: 0 4px 0 4px;
+	margin: 0 4px 0 4px;
 	white-space: nowrap;
 	cursor: pointer;
 	touch-action: none;
-	width: 100%;
+	width: calc(100% - 8px);
 	border-radius: 3px;
 }
 
@@ -85,9 +86,10 @@
 	border-top: 1px solid var(--vscode-editorHoverWidget-border);
 	color: var(--vscode-descriptionForeground);
 	font-size: 12px;
-	padding: 0;
-	margin: 4px 0 0 0;
+	margin: 4px 0px;
+	width: 100%;
 	cursor: default;
+	-webkit-user-select: none;
 	user-select: none;
 	border-radius: 0;
 }
@@ -155,8 +157,8 @@
 
 .action-widget .action-widget-action-bar {
 	background-color: var(--vscode-menu-background);
-	border-top: 1px solid var(--vscode-menu-border);
-	margin-top: 2px;
+	border-top: 1px solid var(--vscode-editorHoverWidget-border);
+	margin-top: 4px;
 }
 
 .action-widget .action-widget-action-bar::before {
@@ -166,7 +168,8 @@
 }
 
 .action-widget .action-widget-action-bar .actions-container {
-	padding: 4px 8px 2px 24px;
+	padding: 4px 8px 2px 28px;
+	width: auto;
 }
 
 .action-widget-action-bar .action-label {


### PR DESCRIPTION
Refine styles for the action widget to enhance visual appeal and spacing. 

Adjustments include making the separator full width & updating separator color to work in all themes. 

Testing can be done by reviewing the action widget in the application to observe the updated styles.

Addresses: #247713

Before:

<img width="264" height="319" alt="image" src="https://github.com/user-attachments/assets/025035f8-0ef9-43c6-8819-c9a5d213d267" />

After:

<img width="246" height="277" alt="image" src="https://github.com/user-attachments/assets/cc6dfc64-8467-491d-aa03-4e59d2135158" />
