### PR TITLE
Preserve search listeners after replace (fix #282773)

### DIFF
--- a/src/vs/workbench/contrib/search/browser/searchTreeModel/fileMatch.ts
+++ b/src/vs/workbench/contrib/search/browser/searchTreeModel/fileMatch.ts
@@ -142,6 +142,12 @@ export class FileMatchImpl extends Disposable implements ISearchTreeFileMatch {
 		this.updateHighlights();
 	}
 
+	forceUpdateMatches(): void {
+		// Cancel any pending scheduled update and run immediately
+		this._updateScheduler.cancel();
+		this.updateMatchesForModel();
+	}
+
 	private onModelWillDispose(): void {
 		// Update matches because model might have some dirty changes
 		this.updateMatchesForModel();

--- a/src/vs/workbench/contrib/search/browser/searchTreeModel/searchTreeCommon.ts
+++ b/src/vs/workbench/contrib/search/browser/searchTreeModel/searchTreeCommon.ts
@@ -244,6 +244,7 @@ export interface ISearchTreeFileMatch {
 	getSelectedMatch(): ISearchTreeMatch | null;
 	parent(): ISearchTreeFolderMatch;
 	bindModel(model: ITextModel): void;
+	forceUpdateMatches(): void;
 	hasReadonlyMatches(): boolean;
 	addContext(results: ITextSearchResult[] | undefined): void;
 	add(match: ISearchTreeMatch, trigger?: boolean): void;


### PR DESCRIPTION
Solution Summary for #282773

Problem: After Replace All, calling clear() disposed all file match objects and their model listeners, so when users undo, the changes weren't detected and the Replace All button stayed disabled.

Solution: Remove the clear() call and instead force immediate match updates via forceUpdateMatches(), which:
1. Preserves folder/file match structure and model listeners
2. Immediately re-searches all files (finding 0 matches after replacement)
3. Batches all change events to avoid UI storms
4. Allows undo operations to be detected since listeners remain active

Trade-off: Slightly slower with large result sets (requires re-searching files) compared to the instant clear(), but necessary to maintain the infrastructure for undo detection.