### PR TITLE
fix simple suggest details height

### DIFF
--- a/src/vs/workbench/services/suggest/browser/simpleSuggestWidgetDetails.ts
+++ b/src/vs/workbench/services/suggest/browser/simpleSuggestWidgetDetails.ts
@@ -213,7 +213,7 @@ export class SimpleSuggestDetailsWidget {
 
 		this._body.scrollTop = 0;
 
-		this.layout(this._size.width, this._docs.clientHeight);
+		this.layout(this._size.width, this._type.clientHeight + this._docs.clientHeight);
 		this._onDidChangeContents.fire(this);
 	}
 

--- a/src/vs/workbench/services/suggest/browser/simpleSuggestWidgetDetails.ts
+++ b/src/vs/workbench/services/suggest/browser/simpleSuggestWidgetDetails.ts
@@ -213,7 +213,7 @@ export class SimpleSuggestDetailsWidget {
 
 		this._body.scrollTop = 0;
 
-		this.layout(this._size.width, this._type.clientHeight + this._docs.clientHeight + this.getLayoutInfo().verticalPadding);
+		this.layout(this._size.width, this._docs.clientHeight);
 		this._onDidChangeContents.fire(this);
 	}
 

--- a/src/vs/workbench/services/suggest/browser/simpleSuggestWidgetDetails.ts
+++ b/src/vs/workbench/services/suggest/browser/simpleSuggestWidgetDetails.ts
@@ -154,7 +154,12 @@ export class SimpleSuggestDetailsWidget {
 			documentation = new MarkdownString().appendCodeblock('empty', md);
 		}
 
-		if (!explainMode && !canExpandCompletionItem(item)) {
+		const hasDetail = typeof detail === 'string' ? detail.trim().length > 0 : !!detail;
+		const hasDocs = typeof documentation === 'string'
+			? documentation.trim().length > 0
+			: !!(documentation && documentation.value?.trim().length > 0);
+
+		if (!explainMode && (!canExpandCompletionItem(item) || (!hasDetail && !hasDocs))) {
 			this.clearContents();
 			return;
 		}
@@ -163,7 +168,7 @@ export class SimpleSuggestDetailsWidget {
 
 		// --- details
 
-		if (detail) {
+		if (hasDetail && detail) {
 			const cappedDetail = detail.length > 100000 ? `${detail.substr(0, 100000)}…` : detail;
 			this._type.textContent = cappedDetail;
 			this._type.title = cappedDetail;
@@ -179,11 +184,11 @@ export class SimpleSuggestDetailsWidget {
 		// // --- documentation
 
 		dom.clearNode(this._docs);
-		if (typeof documentation === 'string') {
+		if (hasDocs && typeof documentation === 'string') {
 			this._docs.classList.remove('markdown-docs');
 			this._docs.textContent = documentation;
 
-		} else if (documentation) {
+		} else if (hasDocs && documentation && typeof documentation !== 'string') {
 			this._docs.classList.add('markdown-docs');
 			dom.clearNode(this._docs);
 			const renderedContents = this.markdownRendererService.render(documentation, {
@@ -194,9 +199,11 @@ export class SimpleSuggestDetailsWidget {
 			});
 			this._docs.appendChild(renderedContents.element);
 			this._renderDisposeable.add(renderedContents);
+		} else {
+			this._docs.classList.remove('markdown-docs');
 		}
 
-		this.domNode.classList.toggle('detail-and-doc', !!detail && !!documentation);
+		this.domNode.classList.toggle('detail-and-doc', hasDetail && hasDocs);
 
 		this.domNode.style.userSelect = 'text';
 		this.domNode.tabIndex = -1;

--- a/src/vs/workbench/services/suggest/browser/simpleSuggestWidgetDetails.ts
+++ b/src/vs/workbench/services/suggest/browser/simpleSuggestWidgetDetails.ts
@@ -159,6 +159,11 @@ export class SimpleSuggestDetailsWidget {
 			? documentation.trim().length > 0
 			: !!(documentation && documentation.value?.trim().length > 0);
 
+		const updateSize = () => {
+			this.layout(this._size.width, this._type.clientHeight + this._docs.clientHeight);
+			this._onDidChangeContents.fire(this);
+		};
+
 		if (!explainMode && (!canExpandCompletionItem(item) || (!hasDetail && !hasDocs))) {
 			this.clearContents();
 			return;
@@ -193,8 +198,7 @@ export class SimpleSuggestDetailsWidget {
 			dom.clearNode(this._docs);
 			const renderedContents = this.markdownRendererService.render(documentation, {
 				asyncRenderCallback: () => {
-					this.layout(this._size.width, this._type.clientHeight + this._docs.clientHeight);
-					this._onDidChangeContents.fire(this);
+					updateSize();
 				}
 			});
 			this._docs.appendChild(renderedContents.element);
@@ -220,8 +224,7 @@ export class SimpleSuggestDetailsWidget {
 
 		this._body.scrollTop = 0;
 
-		this.layout(this._size.width, this._type.clientHeight + this._docs.clientHeight);
-		this._onDidChangeContents.fire(this);
+		updateSize();
 	}
 
 	clearContents() {


### PR DESCRIPTION
fixes #280980

Two issues - including a value in height calculation we didn't need and sometimes rendering empty docs, which added space, but not content

<img width="825" height="232" alt="Screenshot 2025-12-12 at 2 09 57 PM" src="https://github.com/user-attachments/assets/7b10fa19-16fb-4066-95fe-c3afd6406e95" />
