### PR TITLE
debug: fix stoppedDetails mutability during invalidation

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/debugSession.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugSession.ts
@@ -1330,7 +1330,7 @@ export class DebugSession implements IDebugSession {
 				this.cancelAllRequests();
 				this.model.clearThreads(this.getId(), true);
 
-				const details = this.stoppedDetails;
+				const details = this.stoppedDetails.slice();
 				this.stoppedDetails.length = 0;
 				if (details.length) {
 					await Promise.all(details.map(d => this.handleStop(d)));


### PR DESCRIPTION
I think this was always broken, but invalidating threads when stopped doesn't happen much so no one noticed.

thanks to @cwalther