### PR TITLE
Terminal: allow PowerShell 7.4+ constrained language audit mode to work with shell integrations

### DIFF
--- a/src/vs/workbench/contrib/terminal/common/scripts/shellIntegration.ps1
+++ b/src/vs/workbench/contrib/terminal/common/scripts/shellIntegration.ps1
@@ -17,7 +17,7 @@ if ($ExecutionContext.SessionState.LanguageMode -ne "FullLanguage") {
 	try {
 		# Allow ConstrainedLanguage only when Windows lockdown policy is Audit (PS 7.4+).
 		$Lockdown = [System.Management.Automation.Security.SystemPolicy]::GetSystemLockdownPolicy()
-		if ($Lockdown -and $Lockdown -ne [System.Management.Automation.Security.SystemEnforcementMode]::Audit) {
+		if ($Lockdown -and $Lockdown -ne "Audit") {
 			return;
 		}
 	} catch {

--- a/src/vs/workbench/contrib/terminal/common/scripts/shellIntegration.ps1
+++ b/src/vs/workbench/contrib/terminal/common/scripts/shellIntegration.ps1
@@ -11,22 +11,13 @@ if ((Test-Path variable:global:__VSCodeState) -and $null -ne $Global:__VSCodeSta
 # Disable shell integration when the language mode is restricted
 if ($ExecutionContext.SessionState.LanguageMode -ne "FullLanguage") {
 	$LanguageMode = $ExecutionContext.SessionState.LanguageMode
-	if ($LanguageMode -ne "ConstrainedLanguage") {
+	if (-not $IsWindows -or $LanguageMode -ne "ConstrainedLanguage") {
 		return;
 	}
 	try {
-		# PowerShell 7.4+ supports audit-only constrained language mode, which is safe to run.
-		# Older PowerShell versions do not have SystemPolicy/GetSystemLockdownPolicy, so block.
-		$SystemPolicyType = [Type]::GetType("System.Management.Automation.Security.SystemPolicy, System.Management.Automation", $false)
-		if (-not $SystemPolicyType) {
-			return;
-		}
-		$SystemPolicyMethod = $SystemPolicyType.GetMethod("GetSystemLockdownPolicy")
-		if (-not $SystemPolicyMethod) {
-			return;
-		}
-		$Lockdown = $SystemPolicyMethod.Invoke($null, $null)
-		if ($Lockdown -and $Lockdown.ToString() -ne "Audit") {
+		# Allow ConstrainedLanguage only when Windows lockdown policy is Audit (PS 7.4+).
+		$Lockdown = [System.Management.Automation.Security.SystemPolicy]::GetSystemLockdownPolicy()
+		if ($Lockdown -and $Lockdown -ne [System.Management.Automation.Security.SystemEnforcementMode]::Audit) {
 			return;
 		}
 	} catch {


### PR DESCRIPTION
# Fixes https://github.com/microsoft/vscode/issues/283151

## Description
PowerShell 7.4 introduced **Constrained Language Audit Mode**, where `$ExecutionContext.SessionState.LanguageMode` reports `ConstrainedLanguage` but runtime behavior is equivalent to `FullLanguage` Mode. This is intended only for logging what _would_ be blocked were ConstrainedLanguage mode actually being enforced seriously.

The PowerShell VSCode shell integration guard currently aborts unless `LanguageMode == FullLanguage`. This logic predates the existence of audit-only constrained language mode and was correct for its time. Presently however, it falsely blocks the shell integration from working in audit scenarios, even though PowerShell execution is fully functional.

This change updates the guard to allow shell integration when:

- `LanguageMode == FullLanguage`, or
- `LanguageMode == ConstrainedLanguage` **and** system lockdown policy is `Audit`

Enforced constrained language mode continues to be blocked.

## Why this change is safe
- Audit CLM is explicitly non-restrictive by design
- Enforced CLM behavior remains unchanged
- Backward compatible with all older PowerShell versions
- No elevation or system configuration changes required
- Uses PowerShell’s official `SystemPolicy.GetSystemLockdownPolicy()` API

## How to test
**Audit CLM scenario**
1. On Windows 11, enable a WDAC / App Control **audit-only** policy
2. Install PowerShell 7.4+. If step 1 went correctly, pwsh should be in ConstrainedLanguage Audit Mode
3. Open VS Code
4. Open the integrated terminal using `pwsh`
5. Verify shell integration initializes correctly (prompt tracking, command boundaries)

**Enforced CLM scenario**
1. Enable an enforced WDAC / App Control policy
2. Open the integrated terminal using `pwsh`
3. Verify shell integration does **not** initialize

**Baseline**
- Windows PowerShell 5.1 (FullLanguage) continues to work unchanged because it is too old to understand Audit Mode.

## Notes
The original language mode guard was introduced in #158548 and was correct at the time. This change adapts that logic to newer PowerShell semantics introduced in 7.4 without weakening security guarantees.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
