### PR TITLE
chat: fix content getting cut off/scroll stopping

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/chatConfirmationWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/chatConfirmationWidget.ts
@@ -269,7 +269,7 @@ abstract class BaseSimpleChatConfirmationWidget<T> extends Disposable {
 				['chatConfirmationPartSource', options.toolbarData.partSource],
 			]);
 			const nestedInsta = this._register(instantiationService.createChild(new ServiceCollection([IContextKeyService, overlay])));
-			this._register(nestedInsta.createInstance(
+			const toolbar = this._register(nestedInsta.createInstance(
 				MenuWorkbenchToolBar,
 				elements.toolbar,
 				MenuId.ChatConfirmationMenu,
@@ -281,6 +281,8 @@ abstract class BaseSimpleChatConfirmationWidget<T> extends Disposable {
 					}
 				}
 			));
+
+			this._register(toolbar.onDidChangeMenuItems(() => this._onDidChangeHeight.fire()));
 		}
 	}
 

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatToolConfirmationSubPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatToolConfirmationSubPart.ts
@@ -313,7 +313,7 @@ export class ToolConfirmationSubPart extends AbstractToolConfirmationSubPart {
 		const part = this._register(this.instantiationService.createInstance(ChatMarkdownContentPart,
 			{
 				kind: 'markdownContent',
-				content: typeof message === 'string' ? new MarkdownString().appendMarkdown(message) : message
+				content: typeof message === 'string' ? new MarkdownString().appendMarkdown(message) : message,
 			},
 			this.context,
 			this.editorPool,

--- a/src/vs/workbench/contrib/chat/browser/codeBlockPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/codeBlockPart.ts
@@ -446,6 +446,8 @@ export class CodeBlockPart extends Disposable {
 		} else {
 			this.element.classList.add('no-vulns');
 		}
+
+		this._onDidChangeContentHeight.fire();
 	}
 
 	reset() {


### PR DESCRIPTION
We never (apparently) correctly fired a content height change after the model got attached to the code blocks. We did did this is the CodeCompareBlockPart, just not the standard code block.

Also add an event on 'toolbar.onDidChangeMenuItems' -- don't think this ever caused issues but saw that when investigating.

Closes #276807

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
