### PR TITLE
Clarify behaviour of http.proxySupport and http.useLocalProxyConfiguration settings

### DIFF
--- a/src/vs/platform/request/common/request.ts
+++ b/src/vs/platform/request/common/request.ts
@@ -186,7 +186,7 @@ function registerProxyConfigurations(useHostProxy = true, useHostProxyDefault = 
 				'http.useLocalProxyConfiguration': {
 					type: 'boolean',
 					default: useHostProxyDefault,
-					markdownDescription: localize('useLocalProxy', "Controls whether in the remote extension host the local proxy configuration should be used. This setting only applies as a remote setting during [remote development](https://aka.ms/vscode-remote)."),
+					markdownDescription: localize('useLocalProxy', "Controls whether the local proxy configuration (of the VS Code host) is used by the remote extension host. This setting only applies as a remote setting during [remote development](https://aka.ms/vscode-remote)."),
 					restricted: true
 				},
 			}
@@ -252,7 +252,7 @@ function registerProxyConfigurations(useHostProxy = true, useHostProxyDefault = 
 						localize('proxySupportOverride', "Enable proxy support for extensions, override request options."),
 					],
 					default: 'override',
-					markdownDescription: localize('proxySupport', "Use the proxy support for extensions. When during [remote development](https://aka.ms/vscode-remote) the {0} setting is disabled this setting can be configured in the local and the remote settings separately.", '`#http.useLocalProxyConfiguration#`'),
+					markdownDescription: localize('proxySupport', "Use the proxy configuration for extensions. When during [remote development](https://aka.ms/vscode-remote) and the {0} setting is disabled this setting can be configured in the local and the remote settings separately.", '`#http.useLocalProxyConfiguration#`'),
 					restricted: true
 				},
 				'http.systemCertificates': {

--- a/src/vs/platform/request/common/request.ts
+++ b/src/vs/platform/request/common/request.ts
@@ -216,30 +216,30 @@ function registerProxyConfigurations(useHostProxy = true, useHostProxyDefault = 
 				'http.proxy': {
 					type: 'string',
 					pattern: '^(https?|socks|socks4a?|socks5h?)://([^:]*(:[^@]*)?@)?([^:]+|\\[[:0-9a-fA-F]+\\])(:\\d+)?/?$|^$',
-					markdownDescription: localize('proxy', "The proxy setting to use. If not set, will be inherited from the `http_proxy` and `https_proxy` environment variables. When during [remote development](https://aka.ms/vscode-remote) the {0} setting is disabled this setting can be configured in the local and the remote settings separately.", '`#http.useLocalProxyConfiguration#`'),
+					markdownDescription: localize('proxy', "The proxy setting to use. If not set, will be inherited from the `http_proxy` and `https_proxy` environment variables. When during [remote development](https://aka.ms/vscode-remote) and the {0} setting is disabled this setting can be configured in the local and the remote settings separately.", '`#http.useLocalProxyConfiguration#`'),
 					restricted: true
 				},
 				'http.proxyStrictSSL': {
 					type: 'boolean',
 					default: true,
-					markdownDescription: localize('strictSSL', "Controls whether the proxy server certificate should be verified against the list of supplied CAs. When during [remote development](https://aka.ms/vscode-remote) the {0} setting is disabled this setting can be configured in the local and the remote settings separately.", '`#http.useLocalProxyConfiguration#`'),
+					markdownDescription: localize('strictSSL', "Controls whether the proxy server certificate should be verified against the list of supplied CAs. When during [remote development](https://aka.ms/vscode-remote) and the {0} setting is disabled this setting can be configured in the local and the remote settings separately.", '`#http.useLocalProxyConfiguration#`'),
 					restricted: true
 				},
 				'http.proxyKerberosServicePrincipal': {
 					type: 'string',
-					markdownDescription: localize('proxyKerberosServicePrincipal', "Overrides the principal service name for Kerberos authentication with the HTTP proxy. A default based on the proxy hostname is used when this is not set. When during [remote development](https://aka.ms/vscode-remote) the {0} setting is disabled this setting can be configured in the local and the remote settings separately.", '`#http.useLocalProxyConfiguration#`'),
+					markdownDescription: localize('proxyKerberosServicePrincipal', "Overrides the principal service name for Kerberos authentication with the HTTP proxy. A default based on the proxy hostname is used when this is not set. When during [remote development](https://aka.ms/vscode-remote) and the {0} setting is disabled this setting can be configured in the local and the remote settings separately.", '`#http.useLocalProxyConfiguration#`'),
 					restricted: true
 				},
 				'http.noProxy': {
 					type: 'array',
 					items: { type: 'string' },
-					markdownDescription: localize('noProxy', "Specifies domain names for which proxy settings should be ignored for HTTP/HTTPS requests. When during [remote development](https://aka.ms/vscode-remote) the {0} setting is disabled this setting can be configured in the local and the remote settings separately.", '`#http.useLocalProxyConfiguration#`'),
+					markdownDescription: localize('noProxy', "Specifies domain names for which proxy settings should be ignored for HTTP/HTTPS requests. When during [remote development](https://aka.ms/vscode-remote) and the {0} setting is disabled this setting can be configured in the local and the remote settings separately.", '`#http.useLocalProxyConfiguration#`'),
 					restricted: true
 				},
 				'http.proxyAuthorization': {
 					type: ['null', 'string'],
 					default: null,
-					markdownDescription: localize('proxyAuthorization', "The value to send as the `Proxy-Authorization` header for every network request. When during [remote development](https://aka.ms/vscode-remote) the {0} setting is disabled this setting can be configured in the local and the remote settings separately.", '`#http.useLocalProxyConfiguration#`'),
+					markdownDescription: localize('proxyAuthorization', "The value to send as the `Proxy-Authorization` header for every network request. When during [remote development](https://aka.ms/vscode-remote) and the {0} setting is disabled this setting can be configured in the local and the remote settings separately.", '`#http.useLocalProxyConfiguration#`'),
 					restricted: true
 				},
 				'http.proxySupport': {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

- Updates the description of the `http.proxySupport` and `http.useLocalProxyConfiguration` settings to clarify their behaviour. With the original wording I had understood it to mean that the remote host would use its local configuration when true.
- Adds missing "and" to the description of multiple proxy settings.