### PR TITLE
Use different color for voice recording icon/animation

### DIFF
--- a/src/vs/workbench/contrib/chat/electron-browser/actions/voiceChatActions.ts
+++ b/src/vs/workbench/contrib/chat/electron-browser/actions/voiceChatActions.ts
@@ -31,7 +31,7 @@ import { isHighContrast } from '../../../../../platform/theme/common/theme.js';
 import { registerThemingParticipant } from '../../../../../platform/theme/common/themeService.js';
 import { ActiveEditorContext } from '../../../../common/contextkeys.js';
 import { IWorkbenchContribution } from '../../../../common/contributions.js';
-import { ACTIVITY_BAR_BADGE_BACKGROUND } from '../../../../common/theme.js';
+import { ACTIVITY_BAR_FOREGROUND } from '../../../../common/theme.js';
 import { IEditorService } from '../../../../services/editor/common/editorService.js';
 import { IHostService } from '../../../../services/host/browser/host.js';
 import { IWorkbenchLayoutService, Parts } from '../../../../services/layout/browser/layoutService.js';
@@ -1253,7 +1253,7 @@ registerThemingParticipant((theme, collector) => {
 	let activeRecordingColor: Color | undefined;
 	let activeRecordingDimmedColor: Color | undefined;
 	if (!isHighContrast(theme.type)) {
-		activeRecordingColor = theme.getColor(ACTIVITY_BAR_BADGE_BACKGROUND) ?? theme.getColor(focusBorder);
+		activeRecordingColor = theme.getColor(ACTIVITY_BAR_FOREGROUND) ?? theme.getColor(focusBorder);
 		activeRecordingDimmedColor = activeRecordingColor?.transparent(0.38);
 	} else {
 		activeRecordingColor = theme.getColor(contrastBorder);


### PR DESCRIPTION
Fixes #265676

Tested with light, dark, and the theme from the bug - all look good.