### PR TITLE
Make parameter hints widget resizable

### DIFF
--- a/src/vs/editor/contrib/parameterHints/browser/parameterHintsWidget.ts
+++ b/src/vs/editor/contrib/parameterHints/browser/parameterHintsWidget.ts
@@ -63,7 +63,7 @@ export class ParameterHintsWidget extends ResizableContentWidget {
 		const minimumWidth = 200;
 		super(editor, new dom.Dimension(minimumWidth, minimumHeight));
 
-		this._resizableNode.domNode.style.zIndex = '50';
+		this._resizableNode.domNode.style.zIndex = '10';
 		this._resizableNode.enableSashes(false, true, false, false);
 
 		this.keyVisible = Context.Visible.bindTo(contextKeyService);


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
Fix #252848

To make it resizable I took inspiration from the implementation of `ContentHoverWidget`. 
Now the parameter hints widget can be resized horizontally, and its height adjusts based on the inner text layout.
