### PR TITLE
Ignore invalid files when looking for copilot-instructions.md

### DIFF
--- a/src/vs/workbench/contrib/chat/common/promptSyntax/utils/promptFilesLocator.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/utils/promptFilesLocator.ts
@@ -288,8 +288,13 @@ export class PromptFilesLocator {
 		const { folders } = this.workspaceService.getWorkspace();
 		for (const folder of folders) {
 			const file = joinPath(folder.uri, `.github/` + COPILOT_CUSTOM_INSTRUCTIONS_FILENAME);
-			if (await this.fileService.exists(file)) {
-				result.push(file);
+			try {
+				const stat = await this.fileService.stat(file);
+				if (stat.isFile) {
+					result.push(file);
+				}
+			} catch (error) {
+				this.logService.trace(`[PromptFilesLocator] Skipping copilot-instructions.md at ${file.toString()}: ${error}`);
 			}
 		}
 		return result;


### PR DESCRIPTION
Fixes #261610

Technically the bug is already fixed as I am unable to repro with symlinks (code reading from such files is already protected).

This PR fixes one place which does not have the protection, although it is defence in depth as well since it works without this change.
