### PR TITLE
Strip trailing \r from edit text if the range ends at the end of a line and the text buffer is CRLF

### DIFF
--- a/src/vs/editor/common/model/textModel.ts
+++ b/src/vs/editor/common/model/textModel.ts
@@ -5,6 +5,8 @@
 
 import { ArrayQueue, pushMany } from '../../../base/common/arrays.js';
 import { VSBuffer, VSBufferReadableStream } from '../../../base/common/buffer.js';
+import { CharCode } from '../../../base/common/charCode.js';
+import { SetWithKey } from '../../../base/common/collections.js';
 import { Color } from '../../../base/common/color.js';
 import { BugIndicatingError, illegalArgument, onUnexpectedError } from '../../../base/common/errors.js';
 import { Emitter, Event } from '../../../base/common/event.js';
@@ -15,19 +17,30 @@ import * as strings from '../../../base/common/strings.js';
 import { ThemeColor } from '../../../base/common/themables.js';
 import { Constants } from '../../../base/common/uint.js';
 import { URI } from '../../../base/common/uri.js';
+import { IInstantiationService } from '../../../platform/instantiation/common/instantiation.js';
+import { isDark } from '../../../platform/theme/common/theme.js';
+import { IColorTheme } from '../../../platform/theme/common/themeService.js';
+import { IUndoRedoService, ResourceEditStackSnapshot, UndoRedoGroup } from '../../../platform/undoRedo/common/undoRedo.js';
 import { ISingleEditOperation } from '../core/editOperation.js';
+import { TextEdit } from '../core/edits/textEdit.js';
 import { countEOL } from '../core/misc/eolCounter.js';
 import { normalizeIndentation } from '../core/misc/indentation.js';
+import { EDITOR_MODEL_DEFAULTS } from '../core/misc/textModelDefaults.js';
 import { IPosition, Position } from '../core/position.js';
 import { IRange, Range } from '../core/range.js';
 import { Selection } from '../core/selection.js';
 import { TextChange } from '../core/textChange.js';
-import { EDITOR_MODEL_DEFAULTS } from '../core/misc/textModelDefaults.js';
 import { IWordAtPosition } from '../core/wordHelper.js';
 import { FormattingOptions } from '../languages.js';
 import { ILanguageSelection, ILanguageService } from '../languages/language.js';
 import { ILanguageConfigurationService } from '../languages/languageConfigurationRegistry.js';
 import * as model from '../model.js';
+import { IBracketPairsTextModelPart } from '../textModelBracketPairs.js';
+import { EditSources, TextModelEditSource } from '../textModelEditSource.js';
+import { IModelContentChangedEvent, IModelDecorationsChangedEvent, IModelOptionsChangedEvent, InternalModelContentChangeEvent, LineInjectedText, ModelFontChanged, ModelFontChangedEvent, ModelInjectedTextChangedEvent, ModelLineHeightChanged, ModelLineHeightChangedEvent, ModelRawChange, ModelRawContentChangedEvent, ModelRawEOLChanged, ModelRawFlush, ModelRawLineChanged, ModelRawLinesDeleted, ModelRawLinesInserted } from '../textModelEvents.js';
+import { IGuidesTextModelPart } from '../textModelGuides.js';
+import { ITokenizationTextModelPart } from '../tokenizationTextModelPart.js';
+import { TokenArray } from '../tokens/lineTokens.js';
 import { BracketPairsTextModelPart } from './bracketPairsTextModelPart/bracketPairsImpl.js';
 import { ColorizedBracketPairsDecorationProvider } from './bracketPairsTextModelPart/colorizedBracketPairsDecorationProvider.js';
 import { EditStack } from './editStack.js';
@@ -37,20 +50,8 @@ import { IntervalNode, IntervalTree, recomputeMaxEnd } from './intervalTree.js';
 import { PieceTreeTextBuffer } from './pieceTreeTextBuffer/pieceTreeTextBuffer.js';
 import { PieceTreeTextBufferBuilder } from './pieceTreeTextBuffer/pieceTreeTextBufferBuilder.js';
 import { SearchParams, TextModelSearch } from './textModelSearch.js';
-import { TokenizationTextModelPart } from './tokens/tokenizationTextModelPart.js';
 import { AttachedViews } from './tokens/abstractSyntaxTokenBackend.js';
-import { IBracketPairsTextModelPart } from '../textModelBracketPairs.js';
-import { IModelContentChangedEvent, IModelDecorationsChangedEvent, IModelOptionsChangedEvent, InternalModelContentChangeEvent, ModelInjectedTextChangedEvent, ModelRawChange, ModelRawContentChangedEvent, ModelRawEOLChanged, ModelRawFlush, ModelRawLineChanged, ModelRawLinesDeleted, ModelRawLinesInserted, ModelLineHeightChangedEvent, ModelLineHeightChanged, ModelFontChangedEvent, ModelFontChanged, LineInjectedText } from '../textModelEvents.js';
-import { IGuidesTextModelPart } from '../textModelGuides.js';
-import { ITokenizationTextModelPart } from '../tokenizationTextModelPart.js';
-import { IInstantiationService } from '../../../platform/instantiation/common/instantiation.js';
-import { IColorTheme } from '../../../platform/theme/common/themeService.js';
-import { IUndoRedoService, ResourceEditStackSnapshot, UndoRedoGroup } from '../../../platform/undoRedo/common/undoRedo.js';
-import { TokenArray } from '../tokens/lineTokens.js';
-import { SetWithKey } from '../../../base/common/collections.js';
-import { EditSources, TextModelEditSource } from '../textModelEditSource.js';
-import { TextEdit } from '../core/edits/textEdit.js';
-import { isDark } from '../../../platform/theme/common/theme.js';
+import { TokenizationTextModelPart } from './tokens/tokenizationTextModelPart.js';
 
 export function createTextBufferFactory(text: string): model.ITextBufferFactory {
 	const builder = new PieceTreeTextBufferBuilder();
@@ -1271,10 +1272,29 @@ export class TextModel extends Disposable implements model.ITextModel, IDecorati
 		if (rawOperation instanceof model.ValidAnnotatedEditOperation) {
 			return rawOperation;
 		}
+
+		const validatedRange = this.validateRange(rawOperation.range);
+
+		// Normalize edit when replacement text ends with lone CR
+		// and the range ends right before a CRLF in the buffer.
+		// We strip the trailing CR from the replacement text.
+		let opText = rawOperation.text;
+		if (opText) {
+			const endsWithLoneCR = (
+				opText.length > 0 && opText.charCodeAt(opText.length - 1) === CharCode.CarriageReturn
+			);
+			const removeTrailingCR = (
+				this.getEOL() === '\r\n' && endsWithLoneCR && validatedRange.endColumn === this.getLineMaxColumn(validatedRange.endLineNumber)
+			);
+			if (removeTrailingCR) {
+				opText = opText.substring(0, opText.length - 1);
+			}
+		}
+
 		return new model.ValidAnnotatedEditOperation(
 			rawOperation.identifier || null,
-			this.validateRange(rawOperation.range),
-			rawOperation.text,
+			validatedRange,
+			opText,
 			rawOperation.forceMoveMarkers || false,
 			rawOperation.isAutoWhitespaceEdit || false,
 			rawOperation._isTracked || false

--- a/src/vs/editor/test/common/model/editableTextModel.test.ts
+++ b/src/vs/editor/test/common/model/editableTextModel.test.ts
@@ -1119,3 +1119,122 @@ suite('EditorModel - EditableTextModel.applyEdits', () => {
 		model.dispose();
 	});
 });
+
+suite('CRLF edit normalization', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('edit ending with \\r followed by \\n in buffer should strip trailing \\r', () => {
+		// Document: "abc\r\ndef\r\n"
+		// Edit: Replace range (1,1)-(1,4) "abc" with "xyz\r"
+		// The \r at end of replacement should be stripped since next char is \n
+		const model = createTextModel('abc\r\ndef\r\n');
+		model.setEOL(EndOfLineSequence.CRLF);
+
+		assert.strictEqual(model.getEOL(), '\r\n');
+		assert.strictEqual(model.getLineCount(), 3);
+		assert.strictEqual(model.getLineContent(1), 'abc');
+		assert.strictEqual(model.getLineContent(2), 'def');
+
+		model.applyEdits([
+			{ range: new Range(1, 1, 1, 4), text: 'xyz\r' }
+		]);
+
+		// The trailing \r should be stripped, so we get "xyz" not "xyz\r"
+		assert.strictEqual(model.getLineContent(1), 'xyz');
+		assert.strictEqual(model.getLineContent(2), 'def');
+		assert.strictEqual(model.getLineCount(), 3);
+
+		model.dispose();
+	});
+
+	test('edit ending with \\r\\n should NOT be modified', () => {
+		// Document: "abc\r\ndef\r\n"
+		// Edit: Replace range (1,1)-(1,4) "abc" with "xyz\r\n"
+		// This is a proper CRLF so should not be modified
+		const model = createTextModel('abc\r\ndef\r\n');
+		model.setEOL(EndOfLineSequence.CRLF);
+
+		model.applyEdits([
+			{ range: new Range(1, 1, 1, 4), text: 'xyz\r\n' }
+		]);
+
+		// Should add a new line
+		assert.strictEqual(model.getLineContent(1), 'xyz');
+		assert.strictEqual(model.getLineContent(2), '');
+		assert.strictEqual(model.getLineContent(3), 'def');
+		assert.strictEqual(model.getLineCount(), 4);
+
+		model.dispose();
+	});
+
+	test('edit ending with \\r NOT followed by \\n should NOT be modified', () => {
+		// Document: "abcdef" (no newline after)
+		// Edit: Replace range (1,1)-(1,4) "abc" with "xyz\r"
+		// Since there's no \n after the range, the \r should stay
+		const model = createTextModel('abcdef');
+		model.setEOL(EndOfLineSequence.CRLF);
+
+		model.applyEdits([
+			{ range: new Range(1, 1, 1, 4), text: 'xyz\r' }
+		]);
+
+		// The \r should cause a new line since buffer normalizes EOL
+		// Actually since buffer uses CRLF, the lone \r will be normalized to \r\n
+		assert.strictEqual(model.getLineCount(), 2);
+
+		model.dispose();
+	});
+
+	test('edit in LF buffer should NOT strip trailing \\r', () => {
+		// Document with LF: "abc\ndef\n"
+		// Edit: Replace range (1,1)-(1,4) "abc" with "xyz\r"
+		// Since buffer is LF, no special handling needed
+		const model = createTextModel('abc\ndef\n');
+		model.setEOL(EndOfLineSequence.LF);
+
+		assert.strictEqual(model.getEOL(), '\n');
+		assert.strictEqual(model.getLineCount(), 3);
+
+		model.applyEdits([
+			{ range: new Range(1, 1, 1, 4), text: 'xyz\r' }
+		]);
+
+		// The \r will be normalized to \n (buffer's EOL)
+		assert.strictEqual(model.getLineCount(), 4);
+
+		model.dispose();
+	});
+
+	test('LSP include sorting scenario - edit ending with \\r should be normalized', () => {
+		// This is the real-world scenario from the issue
+		// Document: "#include \"a.h\"\r\n#include \"c.h\"\r\n#include \"b.h\"\r\n"
+		// Edit: Replace lines 1-3 with reordered includes ending with \r
+		const model = createTextModel('#include "a.h"\r\n#include "c.h"\r\n#include "b.h"\r\n');
+		model.setEOL(EndOfLineSequence.CRLF);
+
+		assert.strictEqual(model.getEOL(), '\r\n');
+		assert.strictEqual(model.getLineCount(), 4);
+		assert.strictEqual(model.getLineContent(1), '#include "a.h"');
+		assert.strictEqual(model.getLineContent(2), '#include "c.h"');
+		assert.strictEqual(model.getLineContent(3), '#include "b.h"');
+
+		// Edit: replace range (1,1)-(3,16) with text ending in \r
+		// Range covers: #include "a.h"\r\n#include "c.h"\r\n#include "b.h"
+		// Note: line 3 col 16 is after the last char "h" but before the \r\n
+		model.applyEdits([
+			{
+				range: new Range(1, 1, 3, 16),
+				text: '#include "a.h"\r\n#include "b.h"\r\n#include "c.h"\r'
+			}
+		]);
+
+		// The trailing \r should be stripped because the next char after range is \n
+		assert.strictEqual(model.getLineCount(), 4);
+		assert.strictEqual(model.getLineContent(1), '#include "a.h"');
+		assert.strictEqual(model.getLineContent(2), '#include "b.h"');
+		assert.strictEqual(model.getLineContent(3), '#include "c.h"');
+		assert.strictEqual(model.getLineContent(4), '');
+
+		model.dispose();
+	});
+});


### PR DESCRIPTION
Fixes #236671