### PR TITLE
Enable npm scripts

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -2,6 +2,7 @@ disturl="https://electronjs.org/headers"
 target="39.3.0"
 ms_build_id="13168319"
 runtime="electron"
+ignore-scripts=false
 build_from_source="true"
 legacy-peer-deps="true"
 timeout=180000


### PR DESCRIPTION
Due to recent attacks on the JavaScript ecosystem I decided to add `ignore-scripts=true` to `~/.npmrc`. However, the VSCode repository depends on npm scripts for local development. To support this situation, I added `ignore-scripts=false` to `.npmrc` in the repo.