### PR TITLE
Fix Playground type errors

### DIFF
--- a/build/vite/tsconfig.json
+++ b/build/vite/tsconfig.json
@@ -1,10 +1,13 @@
 {
 	"compilerOptions": {
 		"allowImportingTsExtensions": true,
+		"checkJs": true,
+		"module": "preserve",
 		"noEmit": true,
 		"strict": true,
-		"forceConsistentCasingInFileNames": true,
 		"experimentalDecorators": true,
-	},
-	"include": ["**/*.ts"]
+		"types": [
+			"vite/client"
+		]
+	}
 }

--- a/build/vite/vite.config.ts
+++ b/build/vite/vite.config.ts
@@ -5,7 +5,6 @@
 
 import { createLogger, defineConfig, Plugin } from 'vite';
 import path, { join } from 'path';
-/// @ts-ignore
 import { urlToEsmPlugin } from './rollup-url-to-module-plugin/index.mjs';
 import { statSync } from 'fs';
 import { pathToFileURL } from 'url';
@@ -185,7 +184,6 @@ export default defineConfig({
 		fs: {
 			allow: [
 				// To allow loading from sources, not needed when loading monaco-editor from npm package
-				/// @ts-ignore
 				join(import.meta.dirname, '../../../')
 			]
 		}


### PR DESCRIPTION
- `checkJs` type checks JavaScript files and allows importing them.
- Modern `module` options alow us to use `import.meta`. The `preserve` value is correct for bundlers.
- `forceConsistentCasingInFileNames` is enabled by default, so it’s redundant.
- The `vite/client` types allow us to use Vite supported imports, such as CSS files.
- By removing `include`, we include everything supported. This includes the `.mjs` file.

cc @hediet 
