### PR TITLE
Add vite-plugin-devtools-json to Monaco playground

### DIFF
--- a/build/vite/package-lock.json
+++ b/build/vite/package-lock.json
@@ -8,7 +8,8 @@
       "name": "@vscode/sample-source",
       "version": "0.0.0",
       "devDependencies": {
-        "vite": "^7.1.11"
+        "vite": "^7.1.11",
+        "vite-plugin-devtools-json": "^1.0.0"
       }
     },
     "../lib": {
@@ -861,6 +862,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -964,12 +966,27 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
+    "node_modules/uuid": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
+    },
     "node_modules/vite": {
       "version": "7.1.11",
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.1.11.tgz",
       "integrity": "sha512-uzcxnSDVjAopEUjljkWh8EIrg6tlzrjFUfMcR1EVsRDGwf/ccef0qQPRyOrROwhrTDaApueq+ja+KLPlzR/zdg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -1037,6 +1054,19 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vite-plugin-devtools-json": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-devtools-json/-/vite-plugin-devtools-json-1.0.0.tgz",
+      "integrity": "sha512-MobvwqX76Vqt/O4AbnNMNWoXWGrKUqZbphCUle/J2KXH82yKQiunOeKnz/nqEPosPsoWWPP9FtNuPBSYpiiwkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "uuid": "^11.1.0"
+      },
+      "peerDependencies": {
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     }
   }

--- a/build/vite/package.json
+++ b/build/vite/package.json
@@ -9,6 +9,7 @@
     "preview": "vite preview"
   },
   "devDependencies": {
-    "vite": "^7.1.11"
+    "vite": "^7.1.11",
+    "vite-plugin-devtools-json": "^1.0.0"
   }
 }

--- a/build/vite/vite.config.ts
+++ b/build/vite/vite.config.ts
@@ -9,6 +9,7 @@ import path, { join } from 'path';
 import { urlToEsmPlugin } from './rollup-url-to-module-plugin/index.mjs';
 import { statSync } from 'fs';
 import { pathToFileURL } from 'url';
+import devtoolsJson from 'vite-plugin-devtools-json';
 
 function injectBuiltinExtensionsPlugin(): Plugin {
 	let builtinExtensionsCache: unknown[] | null = null;
@@ -165,6 +166,7 @@ logger.warn = (msg, options) => {
 
 export default defineConfig({
 	plugins: [
+		devtoolsJson(),
 		urlToEsmPlugin(),
 		injectBuiltinExtensionsPlugin(),
 		createHotClassSupport()


### PR DESCRIPTION
This plugin adds better Chrome DevTools support by generating `devtools.json` in development. It’s developed by the Chrome DevTools team. https://github.com/ChromeDevTools/vite-plugin-devtools-json

cc @hediet 