### PR TITLE
Add automatic dark mode to the Monaco playground

### DIFF
--- a/build/vite/index.html
+++ b/build/vite/index.html
@@ -1,6 +1,12 @@
 <!-- Copyright (C) Microsoft Corporation. All rights reserved. -->
 <!DOCTYPE html>
 <html>
+	<head>
+		<meta charset="utf-8">
+		<meta name="color-scheme" content="light dark">
+		<meta name="viewport" content="width=device-width, initial-scale=1.0">
+		<title>Monaco Playground</title>
+	</head>
 	<body>
 		<div id="sampleContent"></div>
 		<p>Use the Playground Launch Config for a better dev experience</p>

--- a/build/vite/index.ts
+++ b/build/vite/index.ts
@@ -11,6 +11,14 @@ import './style.css';
 import * as monaco from '../../src/vs/editor/editor.main';
 
 globalThis.monaco = monaco;
+
+// Enable automatic dark mode for accessibility.
+const dark = matchMedia('(prefers-color-scheme: dark)');
+monaco.editor.setTheme(dark.matches ? 'vs-dark' : 'vs-light');
+dark.addEventListener('change', () => {
+	monaco.editor.setTheme(dark.matches ? 'vs-dark' : 'vs-light');
+});
+
 const root = document.getElementById('sampleContent');
 if (root) {
 	const d = monaco.editor.createDiffEditor(root);


### PR DESCRIPTION
This makes the playground more accessible for me due to my eye condition.

This also adds some additional metadata in the page head.

cc @hediet 