### PR TITLE
fix: memory leak in terminal find widget

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/find/browser/terminalFindWidget.ts
+++ b/src/vs/workbench/contrib/terminalContrib/find/browser/terminalFindWidget.ts
@@ -15,7 +15,7 @@ import { IKeybindingService } from '../../../../../platform/keybinding/common/ke
 import { Event } from '../../../../../base/common/event.js';
 import type { ISearchOptions } from '@xterm/addon-search';
 import { IClipboardService } from '../../../../../platform/clipboard/common/clipboardService.js';
-import { IDisposable } from '../../../../../base/common/lifecycle.js';
+import { IDisposable, MutableDisposable } from '../../../../../base/common/lifecycle.js';
 import { IHoverService } from '../../../../../platform/hover/browser/hover.js';
 import { TerminalFindCommandId } from '../common/terminal.find.js';
 import { TerminalClipboardContribution } from '../../clipboard/browser/terminal.clipboard.contribution.js';
@@ -31,6 +31,7 @@ export class TerminalFindWidget extends SimpleFindWidget {
 	private _findWidgetVisible: IContextKey<boolean>;
 
 	private _overrideCopyOnSelectionDisposable: IDisposable | undefined;
+	private _selectionDisposable = this._register(new MutableDisposable());
 
 	constructor(
 		private _instance: ITerminalInstance | IDetachedTerminalInstance,
@@ -191,17 +192,19 @@ export class TerminalFindWidget extends SimpleFindWidget {
 		}
 	}
 
+	private _registerSelectionChangeListener(xterm: IXtermTerminal): void {
+		this._selectionDisposable.value = Event.once(xterm.onDidChangeSelection)(() => xterm.clearActiveSearchDecoration());
+	}
+
 	private async _findNextWithEvent(xterm: IXtermTerminal, term: string, options: ISearchOptions): Promise<boolean> {
-		return xterm.findNext(term, options).then(foundMatch => {
-			this._register(Event.once(xterm.onDidChangeSelection)(() => xterm.clearActiveSearchDecoration()));
-			return foundMatch;
-		});
+		const foundMatch = await xterm.findNext(term, options);
+		this._registerSelectionChangeListener(xterm);
+		return foundMatch;
 	}
 
 	private async _findPreviousWithEvent(xterm: IXtermTerminal, term: string, options: ISearchOptions): Promise<boolean> {
-		return xterm.findPrevious(term, options).then(foundMatch => {
-			this._register(Event.once(xterm.onDidChangeSelection)(() => xterm.clearActiveSearchDecoration()));
-			return foundMatch;
-		});
+		const foundMatch = await xterm.findPrevious(term, options);
+		this._registerSelectionChangeListener(xterm);
+		return foundMatch;
 	}
 }


### PR DESCRIPTION
Fixes a memory leak in terminal find widget. 

When calling find multiple times, it seems to register a selection change event listener each time:

```ts
this._register(Event.once(xterm.onDidChangeSelection)(() => xterm.clearActiveSearchDecoration()));
```

Using a `MutableDisposable` ensures there can be at most one selection change listener. 

---

Perhaps another solution might be to register the listener in the constructor once. Not entirely sure if that would be the same overall logic, but if possible it would be simpler since the `MutableDisposable` could be completly removed.


### Before

When searching something with terminal find 97 times, the number of functions in `TerminalFindWidget._focusPreviousWithEvent` seems to grow by 1 each time:

![terminal search](https://github.com/user-attachments/assets/e8b61e4c-4af9-4b5e-a41a-3f374722ef34)


### After

No more leaks are detected.