### PR TITLE
Chat: hide Apply in Editor from Command Palette

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/actions/chatCodeblockActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatCodeblockActions.ts
@@ -278,7 +278,7 @@ export function registerChatCodeBlockActions() {
 				id: APPLY_IN_EDITOR_ID,
 				title: localize2('interactive.applyInEditor.label', "Apply in Editor"),
 				precondition: ChatContextKeys.enabled,
-				f1: true,
+				f1: false,
 				category: CHAT_CATEGORY,
 				icon: Codicon.gitPullRequestGoToChanges,
 


### PR DESCRIPTION
Fixes #253310

### Summary
`Chat: Apply in Editor` currently appears in the Command Palette (F1) even when launching VS Code on an empty workspace with no Copilot setup. This PR hides the command from the Command Palette while keeping the action available from its intended chat/codeblock UI entry points.

### Change
- Set `f1: false` for the "Apply in Editor" chat codeblock action registration.

### Testing
- Launch VS Code on an empty workspace, with no Copilot setup
- Open Command Palette (F1)
- Search for "Chat: Apply in Editor"
- Confirm the command does not appear
