### PR TITLE
Enhance width adjustment for code block on content change

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/chatToolOutputContentSubPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/chatToolOutputContentSubPart.ts
@@ -157,7 +157,10 @@ export class ChatToolOutputContentSubPart extends Disposable {
 		};
 		const editorReference = this._register(this.context.editorPool.get());
 		editorReference.object.render(data, this._currentWidth || 300);
-		this._register(editorReference.object.onDidChangeContentHeight(() => this._onDidChangeHeight.fire()));
+		this._register(editorReference.object.onDidChangeContentHeight(() => {
+			editorReference.object.layout(this._currentWidth || 300);
+			this._onDidChangeHeight.fire();
+		}));
 		container.appendChild(editorReference.object.element);
 		this._editorReferences.push(editorReference);
 		this.codeblocks.push(part.codeBlockInfo);


### PR DESCRIPTION
Enhance width adjustment for code block on content change. Fix #283523.

We can find similar lines at:

https://github.com/microsoft/vscode/blob/fbdaf9fc8dbf4d4d216a03b81788830627a4861b/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatToolConfirmationSubPart.ts#L244-L247
