### PR TITLE
Remove border color assignment in Toggle component styles

### DIFF
--- a/src/vs/base/browser/ui/toggle/toggle.ts
+++ b/src/vs/base/browser/ui/toggle/toggle.ts
@@ -229,7 +229,6 @@ export class Toggle extends Widget {
 
 	protected applyStyles(): void {
 		if (this.domNode) {
-			this.domNode.style.borderColor = (this._checked && this._opts.inputActiveOptionBorder) || '';
 			this.domNode.style.color = (this._checked && this._opts.inputActiveOptionForeground) || 'inherit';
 			this.domNode.style.backgroundColor = (this._checked && this._opts.inputActiveOptionBackground) || '';
 		}


### PR DESCRIPTION
Eliminate the border color assignment in the Toggle component to streamline styling. Test the Toggle component to ensure it behaves as expected without the border color.

Addresses: #200810

Before:

<img width="462" height="62" alt="image" src="https://github.com/user-attachments/assets/37f7f8ff-b664-4b86-a271-418da23e4e3b" />

After:

<img width="357" height="47" alt="image" src="https://github.com/user-attachments/assets/94e92518-0574-4667-aa30-6fa644522d38" />


