### PR TITLE
fix: correct the separator for uvx packages #283572

### DIFF
--- a/src/vs/platform/mcp/common/mcpManagementService.ts
+++ b/src/vs/platform/mcp/common/mcpManagementService.ts
@@ -129,7 +129,7 @@ export abstract class AbstractCommonMcpManagementService extends Disposable impl
 				args.push(serverPackage.version ? `${serverPackage.identifier}@${serverPackage.version}` : serverPackage.identifier);
 				break;
 			case RegistryType.PYTHON:
-				args.push(serverPackage.version ? `${serverPackage.identifier}==${serverPackage.version}` : serverPackage.identifier);
+				args.push(serverPackage.version ? `${serverPackage.identifier}@${serverPackage.version}` : serverPackage.identifier);
 				break;
 			case RegistryType.DOCKER:
 				args.push(serverPackage.version ? `${serverPackage.identifier}:${serverPackage.version}` : serverPackage.identifier);


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
fixes #283572 

uvx uses an `@` for separating package and version.  This is different to pip which uses `==`
https://docs.astral.sh/uv/concepts/tools/#tool-versions

Currently the code that installs MCP servers into VSCode from a registry uses `==` as a separator which causes MCP servers to fail to start.

This PR updates that separator to the correct `@` as currently it looks like UVX is the only supported python runtime
https://github.com/microsoft/vscode/blob/main/src/vs/platform/mcp/common/mcpManagementService.ts#L171