### PR TITLE
Adds `main-*` to git.branchProtection to support worktree scenarios with multiple main branches

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -131,6 +131,7 @@
 	"git.ignoreLimitWarning": true,
 	"git.branchProtection": [
 		"main",
+		"main-*",
 		"distro",
 		"release/*"
 	],


### PR DESCRIPTION
(see https://github.com/microsoft/vscode/issues/283598)