### PR TITLE
Revert "Remove border color assignment in Toggle component styles"

### DIFF
--- a/src/vs/base/browser/ui/toggle/toggle.ts
+++ b/src/vs/base/browser/ui/toggle/toggle.ts
@@ -229,6 +229,7 @@ export class Toggle extends Widget {
 
 	protected applyStyles(): void {
 		if (this.domNode) {
+			this.domNode.style.borderColor = (this._checked && this._opts.inputActiveOptionBorder) || '';
 			this.domNode.style.color = (this._checked && this._opts.inputActiveOptionForeground) || 'inherit';
 			this.domNode.style.backgroundColor = (this._checked && this._opts.inputActiveOptionBackground) || '';
 		}


### PR DESCRIPTION
Reverts microsoft/vscode#283569

This affected high contrast borders - reverting until a better solution is found.