### PR TITLE
chat prompt file contributions: make name optional

### DIFF
--- a/src/vs/workbench/contrib/chat/common/promptSyntax/chatPromptFilesContribution.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/chatPromptFilesContribution.ts
@@ -13,9 +13,9 @@ import { PromptsType } from './promptTypes.js';
 import { DisposableMap } from '../../../../../base/common/lifecycle.js';
 
 interface IRawChatFileContribution {
-	readonly name: string;
 	readonly path: string;
-	readonly description?: string; // reserved for future use
+	readonly name?: string;
+	readonly description?: string;
 }
 
 type ChatContributionPoint = 'chatPromptFiles' | 'chatInstructions' | 'chatAgents';
@@ -31,24 +31,23 @@ function registerChatFilesExtensionPoint(point: ChatContributionPoint) {
 				type: 'object',
 				defaultSnippets: [{
 					body: {
-						name: 'exampleName',
 						path: './relative/path/to/file.md',
-						description: 'Optional description'
 					}
 				}],
-				required: ['name', 'path'],
+				required: ['path'],
 				properties: {
-					name: {
-						description: localize('chatContribution.property.name', 'Identifier for this file. Must be unique within this extension for this contribution point.'),
-						type: 'string',
-						pattern: '^[\\w.-]+$'
-					},
 					path: {
 						description: localize('chatContribution.property.path', 'Path to the file relative to the extension root.'),
 						type: 'string'
 					},
+					name: {
+						description: localize('chatContribution.property.name', '(Optional) Name for this entry.'),
+						deprecationMessage: localize('chatContribution.property.name.deprecated', 'Specify "name" in the prompt file itself instead.'),
+						type: 'string'
+					},
 					description: {
-						description: localize('chatContribution.property.description', '(Optional) Description of the file.'),
+						description: localize('chatContribution.property.description', '(Optional) Description of the entry.'),
+						deprecationMessage: localize('chatContribution.property.description.deprecated', 'Specify "description" in the prompt file itself instead.'),
 						type: 'string'
 					}
 				}
@@ -69,8 +68,8 @@ function pointToType(contributionPoint: ChatContributionPoint): PromptsType {
 	}
 }
 
-function key(extensionId: ExtensionIdentifier, type: PromptsType, name: string) {
-	return `${extensionId.value}/${type}/${name}`;
+function key(extensionId: ExtensionIdentifier, type: PromptsType, path: string) {
+	return `${extensionId.value}/${type}/${path}`;
 }
 
 export class ChatPromptFilesExtensionPointHandler implements IWorkbenchContribution {
@@ -91,16 +90,8 @@ export class ChatPromptFilesExtensionPointHandler implements IWorkbenchContribut
 			for (const ext of delta.added) {
 				const type = pointToType(contributionPoint);
 				for (const raw of ext.value) {
-					if (!raw.name || !raw.name.match(/^[\w.-]+$/)) {
-						ext.collector.error(localize('extension.invalid.name', "Extension '{0}' cannot register {1} entry with invalid name '{2}'.", ext.description.identifier.value, contributionPoint, raw.name));
-						continue;
-					}
 					if (!raw.path) {
 						ext.collector.error(localize('extension.missing.path', "Extension '{0}' cannot register {1} entry '{2}' without path.", ext.description.identifier.value, contributionPoint, raw.name));
-						continue;
-					}
-					if (!raw.description) {
-						ext.collector.error(localize('extension.missing.description', "Extension '{0}' cannot register {1} entry '{2}' without description.", ext.description.identifier.value, contributionPoint, raw.name));
 						continue;
 					}
 					const fileUri = joinPath(ext.description.extensionLocation, raw.path);
@@ -109,8 +100,8 @@ export class ChatPromptFilesExtensionPointHandler implements IWorkbenchContribut
 						continue;
 					}
 					try {
-						const d = this.promptsService.registerContributedFile(type, raw.name, raw.description, fileUri, ext.description);
-						this.registrations.set(key(ext.description.identifier, type, raw.name), d);
+						const d = this.promptsService.registerContributedFile(type, fileUri, ext.description, raw.name, raw.description);
+						this.registrations.set(key(ext.description.identifier, type, raw.path), d);
 					} catch (e) {
 						const msg = e instanceof Error ? e.message : String(e);
 						ext.collector.error(localize('extension.registration.failed', "Failed to register {0} entry '{1}': {2}", contributionPoint, raw.name, msg));
@@ -120,7 +111,7 @@ export class ChatPromptFilesExtensionPointHandler implements IWorkbenchContribut
 			for (const ext of delta.removed) {
 				const type = pointToType(contributionPoint);
 				for (const raw of ext.value) {
-					this.registrations.deleteAndDispose(key(ext.description.identifier, type, raw.name));
+					this.registrations.deleteAndDispose(key(ext.description.identifier, type, raw.path));
 				}
 			}
 		});

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsService.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsService.ts
@@ -108,9 +108,9 @@ export interface IPromptPathBase {
 export interface IExtensionPromptPath extends IPromptPathBase {
 	readonly storage: PromptsStorage.extension;
 	readonly extension: IExtensionDescription;
-	readonly name: string;
-	readonly description: string;
 	readonly source: ExtensionAgentSourceType;
+	readonly name?: string;
+	readonly description?: string;
 }
 export interface ILocalPromptPath extends IPromptPathBase {
 	readonly storage: PromptsStorage.local;
@@ -278,7 +278,7 @@ export interface IPromptsService extends IDisposable {
 	 * Internal: register a contributed file. Returns a disposable that removes the contribution.
 	 * Not intended for extension authors; used by contribution point handler.
 	 */
-	registerContributedFile(type: PromptsType, name: string, description: string, uri: URI, extension: IExtensionDescription): IDisposable;
+	registerContributedFile(type: PromptsType, uri: URI, extension: IExtensionDescription, name: string | undefined, description: string | undefined): IDisposable;
 
 
 	getPromptLocationLabel(promptPath: IPromptPath): string;

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsServiceImpl.ts
@@ -465,7 +465,7 @@ export class PromptsService extends Disposable implements IPromptsService {
 		return new PromptFileParser().parse(uri, fileContent.value.toString());
 	}
 
-	public registerContributedFile(type: PromptsType, name: string, description: string, uri: URI, extension: IExtensionDescription) {
+	public registerContributedFile(type: PromptsType, uri: URI, extension: IExtensionDescription, name?: string, description?: string) {
 		const bucket = this.contributedFiles[type];
 		if (bucket.has(uri)) {
 			// keep first registration per extension (handler filters duplicates per extension already)

--- a/src/vs/workbench/contrib/chat/test/common/mockPromptsService.ts
+++ b/src/vs/workbench/contrib/chat/test/common/mockPromptsService.ts
@@ -52,7 +52,7 @@ export class MockPromptsService implements IPromptsService {
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	parseNew(_uri: URI, _token: CancellationToken): Promise<any> { throw new Error('Not implemented'); }
 	getParsedPromptFile(textModel: ITextModel): ParsedPromptFile { throw new Error('Not implemented'); }
-	registerContributedFile(type: PromptsType, name: string, description: string, uri: URI, extension: IExtensionDescription): IDisposable { throw new Error('Not implemented'); }
+	registerContributedFile(type: PromptsType, uri: URI, extension: IExtensionDescription, name: string | undefined, description: string | undefined): IDisposable { throw new Error('Not implemented'); }
 	getPromptLocationLabel(promptPath: IPromptPath): string { throw new Error('Not implemented'); }
 	findAgentMDsInWorkspace(token: CancellationToken): Promise<URI[]> { throw new Error('Not implemented'); }
 	listAgentMDs(token: CancellationToken): Promise<URI[]> { throw new Error('Not implemented'); }

--- a/src/vs/workbench/contrib/chat/test/common/promptSyntax/service/promptsService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/promptSyntax/service/promptsService.test.ts
@@ -1060,10 +1060,10 @@ suite('PromptsService', () => {
 			const uri = URI.parse('file://extensions/my-extension/textMate.instructions.md');
 			const extension = {} as IExtensionDescription;
 			const registered = service.registerContributedFile(PromptsType.instructions,
+				uri,
+				extension,
 				'TextMate Instructions',
 				'Instructions to follow when authoring TextMate grammars',
-				uri,
-				extension
 			);
 
 			const actual = await service.listPromptFiles(PromptsType.instructions, CancellationToken.None);
@@ -1227,18 +1227,18 @@ suite('PromptsService', () => {
 			// Register both agents (one exists, one doesn't)
 			const registered1 = service.registerContributedFile(
 				PromptsType.agent,
+				nonExistentUri,
+				extension,
 				'NonExistent Agent',
 				'An agent that does not exist',
-				nonExistentUri,
-				extension
 			);
 
 			const registered2 = service.registerContributedFile(
 				PromptsType.agent,
+				existingUri,
+				extension,
 				'Existing Agent',
 				'An agent that exists',
-				existingUri,
-				extension
 			);
 
 			// Verify that getCustomAgents doesn't crash and returns only the valid agent


### PR DESCRIPTION
The name and description of the chat file contribution points were not used when the prompt files also defined a name and description.
This was confusing. The change deprecated the name and description of the chat file contribution points. Extension authors now only have to define a path.

FYI @digitarald 