### PR TITLE
debug: Fix UI freezing on "continue" with high number of threads

### DIFF
--- a/src/vs/workbench/contrib/debug/common/debugModel.ts
+++ b/src/vs/workbench/contrib/debug/common/debugModel.ts
@@ -1458,6 +1458,9 @@ export class DebugModel extends Disposable implements IDebugModel {
 	private breakpointsActivated = true;
 	private readonly _onDidChangeBreakpoints = this._register(new Emitter<IBreakpointsChangeEvent | undefined>());
 	private readonly _onDidChangeCallStack = this._register(new Emitter<void>());
+	private _onDidChangeCallStackFire = new RunOnceScheduler(() => {
+		this._onDidChangeCallStack.fire(undefined);
+	}, 100);
 	private readonly _onDidChangeWatchExpressions = this._register(new Emitter<IExpression | undefined>());
 	private readonly _onDidChangeWatchExpressionValue = this._register(new Emitter<IExpression | undefined>());
 	private readonly _breakpointModes = new Map<string, IBreakpointModeInternal>();
@@ -1583,7 +1586,7 @@ export class DebugModel extends Disposable implements IDebugModel {
 
 		if (session) {
 			session.clearThreads(removeThreads, reference);
-			this._onDidChangeCallStack.fire(undefined);
+			this._onDidChangeCallStackFire.schedule();
 		}
 	}
 

--- a/src/vs/workbench/contrib/debug/common/debugModel.ts
+++ b/src/vs/workbench/contrib/debug/common/debugModel.ts
@@ -1458,9 +1458,9 @@ export class DebugModel extends Disposable implements IDebugModel {
 	private breakpointsActivated = true;
 	private readonly _onDidChangeBreakpoints = this._register(new Emitter<IBreakpointsChangeEvent | undefined>());
 	private readonly _onDidChangeCallStack = this._register(new Emitter<void>());
-	private _onDidChangeCallStackFire = new RunOnceScheduler(() => {
+	private _onDidChangeCallStackFire = this._register(new RunOnceScheduler(() => {
 		this._onDidChangeCallStack.fire(undefined);
-	}, 100);
+	}, 100));
 	private readonly _onDidChangeWatchExpressions = this._register(new Emitter<IExpression | undefined>());
 	private readonly _onDidChangeWatchExpressionValue = this._register(new Emitter<IExpression | undefined>());
 	private readonly _breakpointModes = new Map<string, IBreakpointModeInternal>();
@@ -1597,7 +1597,9 @@ export class DebugModel extends Disposable implements IDebugModel {
 			}
 
 			session.clearThreads(removeThreads, reference);
-			this._onDidChangeCallStackFire.schedule();
+			if (!this._onDidChangeCallStackFire.isScheduled()) {
+				this._onDidChangeCallStackFire.schedule();
+			}
 		}
 	}
 


### PR DESCRIPTION
This fixes a performance regression accidentally introduced in #265755.

Before that change, if the `continued` event had `allThreadsContinued` set, then we'd call `this.model.clearThreads()` passing `undefined` as `threadId`, which would update all threads in one pass. After that change, a call to `this.model.clearThreads()` would be done for each thread.

Because each call to `this.model.clearThreads()` ends up calling `this._onDidChangeCallStack.fire()`, we end up with quadratic overhead as some of the handlers traverse all threads in the call-stack box. This would lead to minute long freezes when using the Erlang debugger, to debug a system with ~20K Erlang processes.

The solution is to go back to the previous implementation, where `clearThreads()` is ever called with one thread-id or with `undefined`, but first wait on `this.fetchThreads()` if needed

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
