### PR TITLE
Add 'Use Excludes and Ignore Files' toggle to quick access

### DIFF
--- a/src/vs/base/browser/ui/toggle/toggle.ts
+++ b/src/vs/base/browser/ui/toggle/toggle.ts
@@ -259,6 +259,9 @@ export class Toggle extends Widget {
 	}
 
 	toggle(): void {
+		if (!this.enabled) {
+			return;
+		}
 		this.checked = !this._checked;
 		this._onChange.fire(false);
 	}

--- a/src/vs/base/browser/ui/toggle/toggle.ts
+++ b/src/vs/base/browser/ui/toggle/toggle.ts
@@ -257,6 +257,11 @@ export class Toggle extends Widget {
 	get visible() {
 		return this.domNode.style.display !== 'none';
 	}
+
+	toggle(): void {
+		this.checked = !this._checked;
+		this._onChange.fire(false);
+	}
 }
 
 

--- a/src/vs/platform/quickinput/browser/quickInput.ts
+++ b/src/vs/platform/quickinput/browser/quickInput.ts
@@ -632,6 +632,8 @@ export class QuickPick<T extends IQuickPickItem, O extends { useSeparators: bool
 
 	filterValue = (value: string) => value;
 
+	reload = () => this.onDidChangeValueEmitter.fire(this._value);
+
 	set ariaLabel(ariaLabel: string | undefined) {
 		this._ariaLabel = ariaLabel;
 		this.update();

--- a/src/vs/platform/quickinput/browser/quickInput.ts
+++ b/src/vs/platform/quickinput/browser/quickInput.ts
@@ -632,7 +632,11 @@ export class QuickPick<T extends IQuickPickItem, O extends { useSeparators: bool
 
 	filterValue = (value: string) => value;
 
-	reload = () => this.onDidChangeValueEmitter.fire(this._value);
+	/**
+	 * Triggers the change event handler with the current value to force a refresh,
+	 * without changing the value.
+	 */
+	refreshItems = () => this.onDidChangeValueEmitter.fire(this._value);
 
 	set ariaLabel(ariaLabel: string | undefined) {
 		this._ariaLabel = ariaLabel;

--- a/src/vs/platform/quickinput/browser/quickInput.ts
+++ b/src/vs/platform/quickinput/browser/quickInput.ts
@@ -632,10 +632,6 @@ export class QuickPick<T extends IQuickPickItem, O extends { useSeparators: bool
 
 	filterValue = (value: string) => value;
 
-	/**
-	 * Triggers the change event handler with the current value to force a refresh,
-	 * without changing the value.
-	 */
 	refreshItems = () => this.onDidChangeValueEmitter.fire(this._value);
 
 	set ariaLabel(ariaLabel: string | undefined) {

--- a/src/vs/platform/quickinput/common/quickInput.ts
+++ b/src/vs/platform/quickinput/common/quickInput.ts
@@ -508,6 +508,11 @@ export interface IQuickPick<T extends IQuickPickItem, O extends { useSeparators:
 	filterValue: (value: string) => string;
 
 	/**
+	 * Programmatically reloads the items in the quick pick without changing the `value`.
+	 */
+	reload(): void;
+
+	/**
 	 * The ARIA label for the quick pick input.
 	 */
 	ariaLabel: string | undefined;

--- a/src/vs/platform/quickinput/common/quickInput.ts
+++ b/src/vs/platform/quickinput/common/quickInput.ts
@@ -508,9 +508,9 @@ export interface IQuickPick<T extends IQuickPickItem, O extends { useSeparators:
 	filterValue: (value: string) => string;
 
 	/**
-	 * Programmatically reloads the items in the quick pick without changing the `value`.
+	 * Triggers the change event handler with the current value to force a refresh, without changing the value.
 	 */
-	reload(): void;
+	refreshItems(): void;
 
 	/**
 	 * The ARIA label for the quick pick input.

--- a/src/vs/platform/quickinput/test/browser/quickinput.test.ts
+++ b/src/vs/platform/quickinput/test/browser/quickinput.test.ts
@@ -279,4 +279,42 @@ suite('QuickInput', () => { // https://github.com/microsoft/vscode/issues/147543
 		assert.strictEqual(activeItemsFromEvent.length, 0);
 		assert.strictEqual(quickpick.activeItems.length, 0);
 	});
+
+	test('reload - verify onDidChangeValue event is fired with current value', async () => {
+		const quickpick = store.add(controller.createQuickPick());
+		const testValue = 'test search query';
+		quickpick.value = testValue;
+		quickpick.show();
+
+		// Setup listener for verification
+		const valueChanges: string[] = [];
+		store.add(quickpick.onDidChangeValue(value => valueChanges.push(value)));
+
+		// Call reload multiple times
+		quickpick.reload();
+		quickpick.reload();
+		quickpick.reload();
+
+		assert.strictEqual(valueChanges.length, 3);
+		assert.strictEqual(valueChanges[0], testValue);
+		assert.strictEqual(valueChanges[1], testValue);
+		assert.strictEqual(valueChanges[2], testValue);
+	});
+
+	test('reload - verify it works with empty value', async () => {
+		const quickpick = store.add(controller.createQuickPick());
+		quickpick.value = '';
+		quickpick.show();
+
+		// Setup listener for verification
+		let eventValue = undefined;
+		store.add(quickpick.onDidChangeValue(value => {
+			eventValue = value;
+		}));
+
+		// Call reload with empty value
+		quickpick.reload();
+
+		assert.strictEqual(eventValue, '');
+	});
 });

--- a/src/vs/platform/quickinput/test/browser/quickinput.test.ts
+++ b/src/vs/platform/quickinput/test/browser/quickinput.test.ts
@@ -280,7 +280,7 @@ suite('QuickInput', () => { // https://github.com/microsoft/vscode/issues/147543
 		assert.strictEqual(quickpick.activeItems.length, 0);
 	});
 
-	test('reload - verify onDidChangeValue event is fired with current value', async () => {
+	test('refreshItems - verify onDidChangeValue event is fired with current value', async () => {
 		const quickpick = store.add(controller.createQuickPick());
 		const testValue = 'test search query';
 		quickpick.value = testValue;
@@ -291,9 +291,9 @@ suite('QuickInput', () => { // https://github.com/microsoft/vscode/issues/147543
 		store.add(quickpick.onDidChangeValue(value => valueChanges.push(value)));
 
 		// Call reload multiple times
-		quickpick.reload();
-		quickpick.reload();
-		quickpick.reload();
+		quickpick.refreshItems();
+		quickpick.refreshItems();
+		quickpick.refreshItems();
 
 		assert.strictEqual(valueChanges.length, 3);
 		assert.strictEqual(valueChanges[0], testValue);
@@ -301,7 +301,7 @@ suite('QuickInput', () => { // https://github.com/microsoft/vscode/issues/147543
 		assert.strictEqual(valueChanges[2], testValue);
 	});
 
-	test('reload - verify it works with empty value', async () => {
+	test('refreshItems - verify it works with empty value', async () => {
 		const quickpick = store.add(controller.createQuickPick());
 		quickpick.value = '';
 		quickpick.show();
@@ -313,7 +313,7 @@ suite('QuickInput', () => { // https://github.com/microsoft/vscode/issues/147543
 		}));
 
 		// Call reload with empty value
-		quickpick.reload();
+		quickpick.refreshItems();
 
 		assert.strictEqual(eventValue, '');
 	});

--- a/src/vs/workbench/contrib/search/browser/anythingQuickAccess.ts
+++ b/src/vs/workbench/contrib/search/browser/anythingQuickAccess.ts
@@ -228,7 +228,7 @@ export class AnythingQuickAccessProvider extends PickerQuickAccessProvider<IAnyt
 
 		this.excludesToggle = disposables.add(this.instantiationService.createInstance(UseExcludesToggle));
 		picker.toggles = [this.excludesToggle];
-		disposables.add(this.excludesToggle.onChange(() => picker.reload()));
+		disposables.add(this.excludesToggle.onChange(() => picker.refreshItems()));
 
 		// Add editor decorations for active editor symbol picks
 		const editorDecorationsDisposable = disposables.add(new MutableDisposable());

--- a/src/vs/workbench/contrib/search/browser/quickTextSearch/textSearchQuickAccess.ts
+++ b/src/vs/workbench/contrib/search/browser/quickTextSearch/textSearchQuickAccess.ts
@@ -112,7 +112,7 @@ export class TextSearchQuickAccess extends PickerQuickAccessProvider<ITextSearch
 
 		this.excludesToggle = disposables.add(this._instantiationService.createInstance(UseExcludesToggle));
 		picker.toggles = [this.excludesToggle];
-		disposables.add(this.excludesToggle.onChange(() => picker.reload()));
+		disposables.add(this.excludesToggle.onChange(() => picker.refreshItems()));
 
 		if (TEXT_SEARCH_QUICK_ACCESS_PREFIX.length < picker.value.length) {
 			picker.valueSelection = [TEXT_SEARCH_QUICK_ACCESS_PREFIX.length, picker.value.length];

--- a/src/vs/workbench/contrib/search/browser/search.contribution.ts
+++ b/src/vs/workbench/contrib/search/browser/search.contribution.ts
@@ -33,6 +33,7 @@ import { assertType } from '../../../../base/common/types.js';
 import { getWorkspaceSymbols, IWorkspaceSymbol } from '../common/search.js';
 import * as Constants from '../common/constants.js';
 import { SearchChatContextContribution } from './searchChatContext.js';
+import { useExcludesToggleContributions } from './useExcludesToggle.js';
 
 import './searchActionsCopy.js';
 import './searchActionsFind.js';
@@ -51,6 +52,7 @@ registerSingleton(ISearchHistoryService, SearchHistoryService, InstantiationType
 replaceContributions();
 notebookSearchContributions();
 searchWidgetContributions();
+useExcludesToggleContributions();
 
 registerWorkbenchContribution2(SearchChatContextContribution.ID, SearchChatContextContribution, WorkbenchPhase.AfterRestored);
 

--- a/src/vs/workbench/contrib/search/browser/useExcludesToggle.ts
+++ b/src/vs/workbench/contrib/search/browser/useExcludesToggle.ts
@@ -1,0 +1,61 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Action2, registerAction2 } from '../../../../platform/actions/common/actions.js';
+import { Toggle } from '../../../../base/browser/ui/toggle/toggle.js';
+import { Codicon } from '../../../../base/common/codicons.js';
+import { defaultToggleStyles } from '../../../../platform/theme/browser/defaultStyles.js';
+import { KeyCode, KeyMod } from '../../../../base/common/keyCodes.js';
+import { localize } from '../../../../nls.js';
+import { InQuickInputContextKey } from '../../../../platform/quickinput/browser/quickInput.js';
+import { IQuickInputService } from '../../../../platform/quickinput/common/quickInput.js';
+import { ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
+import { KeybindingWeight } from '../../../../platform/keybinding/common/keybindingsRegistry.js';
+import * as Constants from '../common/constants.js';
+import { IKeybindingService } from '../../../../platform/keybinding/common/keybinding.js';
+
+/**
+ * Toggle widget for controlling whether to disregard exclude settings and ignore files in quick access searches.
+ */
+export class UseExcludesToggle extends Toggle {
+	constructor(@IKeybindingService keybindingService?: IKeybindingService) {
+		const keyBinding = keybindingService?.lookupKeybinding(Constants.SearchCommandIds.ToggleQuickAccessExcludesAndIgnoreFiles)?.getLabel();
+		const localizedTitle = localize('useExcludesDescription', "Use Exclude Settings and Ignore Files");
+		const title = keyBinding ? `${localizedTitle} (${keyBinding})` : localizedTitle;
+
+		super({
+			icon: Codicon.exclude,
+			title,
+			isChecked: true,
+			...defaultToggleStyles
+		});
+	}
+}
+
+export function useExcludesToggleContributions(): void {
+	registerAction2(class QuickAccessToggleExcludesAction extends Action2 {
+		constructor() {
+			super({
+				id: Constants.SearchCommandIds.ToggleQuickAccessExcludesAndIgnoreFiles,
+				title: localize('toggleUseExcludesAndIgnoreFiles', "Toggle Use Exclude Settings and Ignore Files"),
+				keybinding: {
+					when: InQuickInputContextKey,
+					primary: KeyMod.CtrlCmd | KeyCode.Period,
+					weight: KeybindingWeight.WorkbenchContrib,
+				}
+			});
+		}
+
+		run(accessor: ServicesAccessor): void {
+			const quickInputService = accessor.get(IQuickInputService);
+			const currentQuickInput = quickInputService.currentQuickInput;
+
+			currentQuickInput
+				?.toggles
+				?.find(toggle => toggle instanceof UseExcludesToggle)
+				?.toggle();
+		}
+	});
+}

--- a/src/vs/workbench/contrib/search/browser/useExcludesToggle.ts
+++ b/src/vs/workbench/contrib/search/browser/useExcludesToggle.ts
@@ -17,7 +17,8 @@ import * as Constants from '../common/constants.js';
 import { IKeybindingService } from '../../../../platform/keybinding/common/keybinding.js';
 
 /**
- * Toggle widget for controlling whether to disregard exclude settings and ignore files in quick access searches.
+ * Toggle widget for controlling whether exclude settings and ignore files are used in quick access searches.
+ * When checked (default), exclude settings and ignore files are used. When unchecked, they are disregarded.
  */
 export class UseExcludesToggle extends Toggle {
 	constructor(@IKeybindingService keybindingService?: IKeybindingService) {

--- a/src/vs/workbench/contrib/search/common/constants.ts
+++ b/src/vs/workbench/contrib/search/common/constants.ts
@@ -55,6 +55,7 @@ export const enum SearchCommandIds {
 	RestrictSearchToFolderId = 'search.action.restrictSearchToFolder',
 	FindInFolderId = 'filesExplorer.findInFolder',
 	FindInWorkspaceId = 'filesExplorer.findInWorkspace',
+	ToggleQuickAccessExcludesAndIgnoreFiles = 'search.action.quickAccess.toggleExcludesAndIgnore',
 }
 
 export const SearchContext = {

--- a/src/vs/workbench/contrib/search/test/browser/useExcludesToggle.test.ts
+++ b/src/vs/workbench/contrib/search/test/browser/useExcludesToggle.test.ts
@@ -1,0 +1,66 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { UseExcludesToggle } from '../../browser/useExcludesToggle.js';
+
+suite('UseExcludesToggle', () => {
+
+	const store = ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('initial state - toggle is checked by default', () => {
+		const toggle = store.add(new UseExcludesToggle(undefined));
+
+		assert.strictEqual(toggle.checked, true, 'Toggle should be checked by default');
+	});
+
+	test('toggle() - flips checked state', () => {
+		const toggle = store.add(new UseExcludesToggle(undefined));
+		const initialState = toggle.checked;
+
+		// Toggle to unchecked
+		toggle.toggle();
+		assert.strictEqual(toggle.checked, !initialState, 'State should be toggled after first toggle');
+
+		// Toggle back to checked
+		toggle.toggle();
+		assert.strictEqual(toggle.checked, initialState, 'State should be toggled after second toggle');
+	});
+
+	test('toggle() - fires onChange event exactly once per call', () => {
+		const toggle = store.add(new UseExcludesToggle());
+		let changeEventCount = 0;
+
+		store.add(toggle.onChange(() => {
+			changeEventCount++;
+		}));
+
+		toggle.toggle();
+		assert.strictEqual(changeEventCount, 1, 'onChange should fire exactly once on toggle');
+
+		toggle.toggle();
+		assert.strictEqual(changeEventCount, 2, 'onChange should fire exactly once on toggle');
+	});
+
+	test('toggle() - state and event are in sync', () => {
+		const toggle = store.add(new UseExcludesToggle(undefined));
+		const stateChanges: boolean[] = [];
+		const initialState = toggle.checked;
+
+		store.add(toggle.onChange(() => {
+			// Record the state at the moment the event fires
+
+			stateChanges.push(toggle.checked);
+		}));
+
+		toggle.toggle();
+		toggle.toggle();
+		toggle.toggle();
+
+		// State should be changed before event fires
+		assert.deepStrictEqual(stateChanges, [!initialState, initialState, !initialState], 'State should be consistent with events');
+	});
+});


### PR DESCRIPTION
Fixes #15604

Added a toggle to file and text search quick access to disable exclusions/ignore files. The toggle uses same icon as in Search View and is bound to Ctrl+Dot shortcut.
