### PR TITLE
Deduping url patterns while showing up for confirmation

### DIFF
--- a/src/vs/workbench/contrib/chat/common/chatUrlFetchingConfirmation.ts
+++ b/src/vs/workbench/contrib/chat/common/chatUrlFetchingConfirmation.ts
@@ -153,9 +153,14 @@ export class ChatUrlFetchingConfirmationContribution implements ILanguageModelTo
 
 			const treeItems: IPatternTreeItem[] = [];
 			const approvedUrls = this._getApprovedUrls();
+			const dedupedPatterns = new Set<string>();
 
 			for (const { uri, patterns } of urls) {
 				for (const pattern of patterns.slice().sort((a, b) => b.length - a.length)) {
+					if (dedupedPatterns.has(pattern)) {
+						continue;
+					}
+					dedupedPatterns.add(pattern);
 					const settings = approvedUrls[pattern];
 					const requestChecked = typeof settings === 'boolean' ? settings : (settings?.approveRequest ?? false);
 					const responseChecked = typeof settings === 'boolean' ? settings : (settings?.approveResponse ?? false);


### PR DESCRIPTION
fixes #283381 

Before fix:

<img width="1155" height="412" alt="image" src="https://github.com/user-attachments/assets/67353af3-47b0-4d1f-a251-710b5f249c3f" />

After fix:

<img width="837" height="334" alt="image" src="https://github.com/user-attachments/assets/b3ff1e02-6fa3-417a-b1e9-884cfe0e12f1" />
