### PR TITLE
Fix FormatOnSave when `modificationsIfAvailable`

### DIFF
--- a/extensions/git/src/repository.ts
+++ b/extensions/git/src/repository.ts
@@ -1128,10 +1128,10 @@ export class Repository implements Disposable {
 			return undefined;
 		}
 
-		// Ignore path that is ignored
+		// Ignore path that is git ignored
 		const ignored = await this.checkIgnore([uri.fsPath]);
 		if (ignored.size > 0) {
-			this.logger.trace(`[Repository][provideOriginalResource] Resource is ignored: ${uri.toString()}`);
+			this.logger.trace(`[Repository][provideOriginalResource] Resource is git ignored: ${uri.toString()}`);
 			return undefined;
 		}
 

--- a/extensions/git/src/repository.ts
+++ b/extensions/git/src/repository.ts
@@ -1128,7 +1128,7 @@ export class Repository implements Disposable {
 			return undefined;
 		}
 
-		// Ignore path this is ignored
+		// Ignore path that is ignored
 		const ignored = await this.checkIgnore([uri.fsPath]);
 		if (ignored.size > 0) {
 			this.logger.trace(`[Repository][provideOriginalResource] Resource is ignored: ${uri.toString()}`);

--- a/extensions/git/src/repository.ts
+++ b/extensions/git/src/repository.ts
@@ -1128,6 +1128,13 @@ export class Repository implements Disposable {
 			return undefined;
 		}
 
+		// Ignore path this is ignored
+		const ignored = await this.checkIgnore([uri.fsPath]);
+		if (ignored.size > 0) {
+			this.logger.trace(`[Repository][provideOriginalResource] Resource is ignored: ${uri.toString()}`);
+			return undefined;
+		}
+
 		const originalResource = toGitUri(uri, '', { replaceFileExtension: true });
 		this.logger.trace(`[Repository][provideOriginalResource] Original resource: ${originalResource.toString()}`);
 


### PR DESCRIPTION
Fixes #241795 #253840
* #241795
* #253840

the Git extension was not ignoring ignored files when asked for original resource
causing diff to fail to open non-existence files

this allows FormatOnSave to work on ignored files when `"editor.formatOnSaveMode": "modificationsIfAvailable"` is set


path I followed:

https://github.com/microsoft/vscode/blob/a24e66c85715bb273b949405a5d44e8f88b9a5c6/src/vs/workbench/contrib/codeEditor/browser/saveParticipants.ts#L260

https://github.com/microsoft/vscode/blob/a24e66c85715bb273b949405a5d44e8f88b9a5c6/src/vs/workbench/contrib/format/browser/formatModified.ts#L56

https://github.com/microsoft/vscode/blob/a24e66c85715bb273b949405a5d44e8f88b9a5c6/src/vs/workbench/contrib/scm/common/quickDiffService.ts#L154

https://github.com/microsoft/vscode/blob/a24e66c85715bb273b949405a5d44e8f88b9a5c6/src/vs/workbench/contrib/scm/common/quickDiffService.ts#L94

https://github.com/microsoft/vscode/blob/a24e66c85715bb273b949405a5d44e8f88b9a5c6/src/vs/workbench/api/browser/mainThreadSCM.ts#L425

https://github.com/microsoft/vscode/blob/a24e66c85715bb273b949405a5d44e8f88b9a5c6/src/vs/workbench/api/common/extHostSCM.ts#L1049

https://github.com/microsoft/vscode/blob/a24e66c85715bb273b949405a5d44e8f88b9a5c6/extensions/git/src/repository.ts#L1097