### PR TITLE
fix(runSubagent): collect computed attachments

### DIFF
--- a/src/vs/workbench/contrib/chat/common/tools/runSubagentTool.ts
+++ b/src/vs/workbench/contrib/chat/common/tools/runSubagentTool.ts
@@ -266,7 +266,7 @@ export class RunSubagentTool extends Disposable implements IToolImpl {
 		};
 	}
 
-	private async collectVariables (modeTools: UserSelectedTools | undefined, token: CancellationToken): Promise<ChatRequestVariableSet> {
+	private async collectVariables(modeTools: UserSelectedTools | undefined, token: CancellationToken): Promise<ChatRequestVariableSet> {
 		let enabledTools: IToolAndToolSetEnablementMap | undefined;
 
 		if (modeTools) {
@@ -276,8 +276,7 @@ export class RunSubagentTool extends Disposable implements IToolImpl {
 			const tools = enabledToolIds.map(id => this.languageModelToolsService.getTool(id)).filter(tool => !!tool);
 
 			const fullReferenceNames = tools.map(tool => this.languageModelToolsService.getFullReferenceName(tool));
-			if (fullReferenceNames.length > 0)
-			{
+			if (fullReferenceNames.length > 0) {
 				enabledTools = this.languageModelToolsService.toToolAndToolSetEnablementMap(fullReferenceNames, undefined);
 			}
 		}

--- a/src/vs/workbench/contrib/chat/common/tools/runSubagentTool.ts
+++ b/src/vs/workbench/contrib/chat/common/tools/runSubagentTool.ts
@@ -12,11 +12,13 @@ import { Disposable } from '../../../../../base/common/lifecycle.js';
 import { ThemeIcon } from '../../../../../base/common/themables.js';
 import { localize } from '../../../../../nls.js';
 import { IConfigurationChangeEvent, IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
+import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
 import { ILogService } from '../../../../../platform/log/common/log.js';
-import { IChatAgentRequest, IChatAgentService } from '../chatAgents.js';
+import { IChatAgentRequest, IChatAgentService, UserSelectedTools } from '../chatAgents.js';
 import { ChatModel, IChatRequestModeInstructions } from '../chatModel.js';
 import { IChatModeService } from '../chatModes.js';
 import { IChatProgress, IChatService } from '../chatService.js';
+import { ChatRequestVariableSet } from '../chatVariableEntries.js';
 import { ChatAgentLocation, ChatConfiguration, ChatModeKind } from '../constants.js';
 import { ILanguageModelChatMetadata, ILanguageModelsService } from '../languageModels.js';
 import {
@@ -31,8 +33,10 @@ import {
 	ToolDataSource,
 	ToolProgress,
 	ToolSet,
-	VSCodeToolReference
+	VSCodeToolReference,
+	IToolAndToolSetEnablementMap
 } from '../languageModelToolsService.js';
+import { ComputeAutomaticInstructions } from '../promptSyntax/computeAutomaticInstructions.js';
 import { ManageTodoListToolToolId } from './manageTodoListTool.js';
 import { createToolSimpleTextResult } from './toolHelpers.js';
 
@@ -65,6 +69,7 @@ export class RunSubagentTool extends Disposable implements IToolImpl {
 		@ILogService private readonly logService: ILogService,
 		@ILanguageModelToolsService private readonly toolsService: ILanguageModelToolsService,
 		@IConfigurationService private readonly configurationService: IConfigurationService,
+		@IInstantiationService private readonly instantiationService: IInstantiationService,
 	) {
 		super();
 		this.onDidUpdateToolData = Event.filter(this.configurationService.onDidChangeConfiguration, e => e.affectsConfiguration(ChatConfiguration.SubagentToolCustomAgents));
@@ -214,13 +219,15 @@ export class RunSubagentTool extends Disposable implements IToolImpl {
 				modeTools[ManageTodoListToolToolId] = false;
 			}
 
+			const variableSet = await this.collectVariables(modeTools, token);
+
 			// Build the agent request
 			const agentRequest: IChatAgentRequest = {
 				sessionResource: invocation.context.sessionResource,
 				requestId: invocation.callId ?? `subagent-${Date.now()}`,
 				agentId: defaultAgent.id,
 				message: args.prompt,
-				variables: { variables: [] },
+				variables: { variables: variableSet.asArray() },
 				location: ChatAgentLocation.Chat,
 				isSubagent: true,
 				userSelectedModelId: modeModelId,
@@ -257,5 +264,28 @@ export class RunSubagentTool extends Disposable implements IToolImpl {
 		return {
 			invocationMessage: args.description,
 		};
+	}
+
+	private async collectVariables (modeTools: UserSelectedTools | undefined, token: CancellationToken): Promise<ChatRequestVariableSet> {
+		let enabledTools: IToolAndToolSetEnablementMap | undefined;
+
+		if (modeTools) {
+			// Convert tool IDs to full reference names
+
+			const enabledToolIds = Object.entries(modeTools).filter(([, enabled]) => enabled).map(([id]) => id);
+			const tools = enabledToolIds.map(id => this.languageModelToolsService.getTool(id)).filter(tool => !!tool);
+
+			const fullReferenceNames = tools.map(tool => this.languageModelToolsService.getFullReferenceName(tool));
+			if (fullReferenceNames.length > 0)
+			{
+				enabledTools = this.languageModelToolsService.toToolAndToolSetEnablementMap(fullReferenceNames, undefined);
+			}
+		}
+
+		const variableSet = new ChatRequestVariableSet();
+		const computer = this.instantiationService.createInstance(ComputeAutomaticInstructions, enabledTools);
+		await computer.collect(variableSet, token);
+
+		return variableSet;
 	}
 }


### PR DESCRIPTION
Fixes #282310

Example of a `[tool/runSubagent]` request with instructions attached to the system prompt:

<img width="753" height="929" alt="image" src="https://github.com/user-attachments/assets/532ffb77-12bc-4508-a7e0-bfd93e721916" />
