### PR TITLE
Fix z-index issues for long-distance NES

### DIFF
--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/longDistanceHint/inlineEditsLongDistanceHint.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/longDistanceHint/inlineEditsLongDistanceHint.ts
@@ -26,7 +26,6 @@ import { debugLogHorizontalOffsetRanges, debugLogRects, debugView } from '../deb
 import { distributeFlexBoxLayout } from '../../utils/flexBoxLayout.js';
 import { Point } from '../../../../../../../common/core/2d/point.js';
 import { Size2D } from '../../../../../../../common/core/2d/size.js';
-import { getMaxTowerHeightInAvailableArea } from '../../utils/towersLayout.js';
 import { IThemeService } from '../../../../../../../../platform/theme/common/themeService.js';
 import { IKeybindingService } from '../../../../../../../../platform/keybinding/common/keybinding.js';
 import { getEditorBlendedColor, inlineEditIndicatorPrimaryBackground, inlineEditIndicatorSecondaryBackground, inlineEditIndicatorSuccessfulBackground, observeColor } from '../../theme.js';
@@ -35,10 +34,19 @@ import { editorWidgetBorder } from '../../../../../../../../platform/theme/commo
 import { ILongDistancePreviewProps, LongDistancePreviewEditor } from './longDistancePreviewEditor.js';
 import { InlineSuggestionGutterMenuData, SimpleInlineSuggestModel } from '../../components/gutterIndicatorView.js';
 import { jumpToNextInlineEditId } from '../../../../controller/commandIds.js';
+import { splitIntoContinuousLineRanges, WidgetLayoutConstants, WidgetOutline, WidgetPlacementContext } from './longDistnaceWidgetPlacement.js';
 
 const BORDER_RADIUS = 6;
 const MAX_WIDGET_WIDTH = { EMPTY_SPACE: 425, OVERLAY: 375 };
 const MIN_WIDGET_WIDTH = 250;
+
+const DEFAULT_WIDGET_LAYOUT_CONSTANTS: WidgetLayoutConstants = {
+	previewEditorMargin: 2,
+	widgetPadding: 2,
+	widgetBorder: 1,
+	lowerBarHeight: 20,
+	minWidgetWidth: MIN_WIDGET_WIDTH,
+};
 
 export class InlineEditsLongDistanceHint extends Disposable implements IInlineEditsView {
 
@@ -146,27 +154,23 @@ export class InlineEditsLongDistanceHint extends Disposable implements IInlineEd
 		const viewState = this._viewState.read(reader);
 		const p = this._hintTextPosition.read(reader);
 		if (!viewState || !p) {
-			return undefined;
+			return [];
 		}
 
 		const model = this._editorObs.model.read(reader);
 		if (!model) {
-			return undefined;
+			return [];
 		}
 		const range = LineRange.ofLength(p.lineNumber, 1).addMargin(5, 5).intersect(LineRange.ofLength(1, model.getLineCount()));
 
 		if (!range) {
-			return undefined;
+			return [];
 		}
 
 		const sizes = getContentSizeOfLines(this._editorObs, range, reader);
 		const top = this._editorObs.observeTopForLineNumber(range.startLineNumber).read(reader);
 
-		return {
-			lineRange: range,
-			top: top,
-			sizes: sizes,
-		};
+		return splitIntoContinuousLineRanges(range, sizes, top, this._editorObs, reader);
 	});
 
 	private readonly _isVisibleDelayed = debouncedObservable2(
@@ -181,8 +185,8 @@ export class InlineEditsLongDistanceHint extends Disposable implements IInlineEd
 			return undefined;
 		}
 
-		const lineSizes = this._lineSizesAroundHintPosition.read(reader);
-		if (!lineSizes) {
+		const continousLineRanges = this._lineSizesAroundHintPosition.read(reader);
+		if (continousLineRanges.length === 0) {
 			return undefined;
 		}
 
@@ -209,57 +213,66 @@ export class InlineEditsLongDistanceHint extends Disposable implements IInlineEd
 			return undefined;
 		}
 
-		const availableSpaceSizes = lineSizes.sizes.map((s, idx) => {
-			const lineNumber = lineSizes.lineRange.startLineNumber + idx;
-			let linePaddingLeft = 20;
-			if (lineNumber === viewState.hint.lineNumber) {
-				linePaddingLeft = 40;
-			}
-			return new Size2D(Math.max(0, editorTrueContentWidth - s.width - linePaddingLeft), s.height);
-		});
-
-		const showRects = false;
-		if (showRects) {
-			const rects2 = stackSizesDown(new Point(editorTrueContentRight, lineSizes.top - editorScrollTop), availableSpaceSizes, 'right');
-			debugView(debugLogRects({ ...rects2 }, this._editor.getDomNode()!), reader);
-		}
-
-		const availableSpaceHeightPrefixSums = getSums(availableSpaceSizes, s => s.height);
-		const availableSpaceSizesTransposed = availableSpaceSizes.map(s => s.transpose());
-
-		const previewEditorMargin = 2;
-		const widgetPadding = 2;
-		const lowerBarHeight = 20;
-		const widgetBorder = 1;
-
+		const layoutConstants = DEFAULT_WIDGET_LAYOUT_CONSTANTS;
 		const extraGutterMarginToAvoidScrollBar = 2;
-		const previewEditorHeight = previewContentHeight! + extraGutterMarginToAvoidScrollBar;
+		const previewEditorHeight = previewContentHeight + extraGutterMarginToAvoidScrollBar;
 
-		function getWidgetVerticalOutline(lineNumber: number): OffsetRange {
-			const sizeIdx = lineNumber - lineSizes!.lineRange.startLineNumber;
-			const top = lineSizes!.top + availableSpaceHeightPrefixSums[sizeIdx];
-			const editorRange = OffsetRange.ofStartAndLength(top, previewEditorHeight);
-			const verticalWidgetRange = editorRange.withMargin(previewEditorMargin + widgetPadding + widgetBorder).withMargin(0, lowerBarHeight);
-			return verticalWidgetRange;
+		// Try to find widget placement in available empty space
+		let possibleWidgetOutline: WidgetOutline | undefined;
+		let lastPlacementContext: WidgetPlacementContext | undefined;
+
+		const endOfLinePadding = (lineNumber: number) => lineNumber === viewState.hint.lineNumber ? 40 : 20;
+
+		for (const continousLineRange of continousLineRanges) {
+			const placementContext = new WidgetPlacementContext(
+				continousLineRange,
+				editorTrueContentWidth,
+				endOfLinePadding
+			);
+			lastPlacementContext = placementContext;
+
+			const showRects = false;
+			if (showRects) {
+				const rects2 = stackSizesDown(
+					new Point(editorTrueContentRight, continousLineRange.top - editorScrollTop),
+					placementContext.availableSpaceSizes as Size2D[],
+					'right'
+				);
+				debugView(debugLogRects({ ...rects2 }, this._editor.getDomNode()!), reader);
+			}
+
+			possibleWidgetOutline = placementContext.tryFindWidgetOutline(
+				viewState.hint.lineNumber,
+				previewEditorHeight,
+				editorTrueContentRight,
+				layoutConstants
+			);
+
+			if (possibleWidgetOutline) {
+				break;
+			}
 		}
 
-		let possibleWidgetOutline = findFirstMinimzeDistance(lineSizes.lineRange.addMargin(-1, -1), viewState.hint.lineNumber, lineNumber => {
-			const verticalWidgetRange = getWidgetVerticalOutline(lineNumber);
-			const maxWidth = getMaxTowerHeightInAvailableArea(verticalWidgetRange.delta(-lineSizes.top), availableSpaceSizesTransposed);
-			if (maxWidth < MIN_WIDGET_WIDTH) {
-				return undefined;
-			}
-			const horizontalWidgetRange = OffsetRange.ofStartAndLength(editorTrueContentRight - maxWidth, maxWidth);
-			return { horizontalWidgetRange, verticalWidgetRange };
-		});
-
+		// Fallback to overlay position if no empty space was found
 		let position: 'overlay' | 'empty-space' = 'empty-space';
 		if (!possibleWidgetOutline) {
 			position = 'overlay';
 			const maxAvailableWidth = Math.min(editorLayout.width - editorLayout.contentLeft, MAX_WIDGET_WIDTH.OVERLAY);
+
+			// Create a fallback placement context for computing overlay vertical position
+			const fallbackPlacementContext = lastPlacementContext ?? new WidgetPlacementContext(
+				continousLineRanges[0],
+				editorTrueContentWidth,
+				endOfLinePadding,
+			);
+
 			possibleWidgetOutline = {
 				horizontalWidgetRange: OffsetRange.ofStartAndLength(editorTrueContentRight - maxAvailableWidth, maxAvailableWidth),
-				verticalWidgetRange: getWidgetVerticalOutline(viewState.hint.lineNumber + 2).delta(10),
+				verticalWidgetRange: fallbackPlacementContext.getWidgetVerticalOutline(
+					viewState.hint.lineNumber + 2,
+					previewEditorHeight,
+					layoutConstants
+				).delta(10),
 			};
 		}
 
@@ -277,6 +290,7 @@ export class InlineEditsLongDistanceHint extends Disposable implements IInlineEd
 			debugView(debugLogRects({ rectAvailableSpace }, this._editor.getDomNode()!), reader);
 		}
 
+		const { previewEditorMargin, widgetPadding, widgetBorder, lowerBarHeight } = layoutConstants;
 		const maxWidgetWidth = Math.min(position === 'overlay' ? MAX_WIDGET_WIDTH.OVERLAY : MAX_WIDGET_WIDTH.EMPTY_SPACE, previewEditorContentLayout.maxEditorWidth + previewEditorMargin + widgetPadding);
 
 		const layout = distributeFlexBoxLayout(rectAvailableSpace.width, {
@@ -499,37 +513,7 @@ function stackSizesDown(at: Point, sizes: Size2D[], alignment: 'left' | 'right' 
 	return rects;
 }
 
-function findFirstMinimzeDistance<T>(range: LineRange, targetLine: number, predicate: (lineNumber: number) => T | undefined): T | undefined {
-	for (let offset = 0; ; offset++) {
-		const down = targetLine + offset;
-		if (down <= range.endLineNumberExclusive) {
-			const result = predicate(down);
-			if (result !== undefined) {
-				return result;
-			}
-		}
-		const up = targetLine - offset;
-		if (up >= range.startLineNumber) {
-			const result = predicate(up);
-			if (result !== undefined) {
-				return result;
-			}
-		}
-		if (up < range.startLineNumber && down > range.endLineNumberExclusive) {
-			return undefined;
-		}
-	}
-}
 
-function getSums<T>(array: T[], fn: (item: T) => number): number[] {
-	const result: number[] = [0];
-	let sum = 0;
-	for (const item of array) {
-		sum += fn(item);
-		result.push(sum);
-	}
-	return result;
-}
 
 export function drawEditorWidths(e: ICodeEditor, reader: IReader) {
 	const layoutInfo = e.getLayoutInfo();

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/longDistanceHint/longDistnaceWidgetPlacement.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/longDistanceHint/longDistnaceWidgetPlacement.ts
@@ -1,0 +1,188 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { derived, IReader } from '../../../../../../../../base/common/observable.js';
+import { ObservableCodeEditor } from '../../../../../../../browser/observableCodeEditor.js';
+import { Size2D } from '../../../../../../../common/core/2d/size.js';
+import { LineRange } from '../../../../../../../common/core/ranges/lineRange.js';
+import { OffsetRange } from '../../../../../../../common/core/ranges/offsetRange.js';
+import { getMaxTowerHeightInAvailableArea } from '../../utils/towersLayout.js';
+
+/**
+ * Layout constants used for the long-distance hint widget.
+ */
+export interface WidgetLayoutConstants {
+	readonly previewEditorMargin: number;
+	readonly widgetPadding: number;
+	readonly widgetBorder: number;
+	readonly lowerBarHeight: number;
+	readonly minWidgetWidth: number;
+}
+/**
+ * Represents a widget placement outline with horizontal and vertical ranges.
+ */
+export interface WidgetOutline {
+	readonly horizontalWidgetRange: OffsetRange;
+	readonly verticalWidgetRange: OffsetRange;
+}
+/**
+ * Represents a continuous range of lines with their sizes and positioning.
+ * Used to compute available space for widget placement.
+ */
+export interface ContinuousLineSizes {
+	readonly lineRange: LineRange;
+	readonly top: number;
+	readonly sizes: Size2D[];
+}
+/**
+ * Context for computing widget placement within a continuous line range.
+ */
+export class WidgetPlacementContext {
+	public readonly availableSpaceSizes: Size2D[];
+	public readonly availableSpaceHeightPrefixSums: number[];
+	public readonly availableSpaceSizesTransposed: Size2D[];
+
+	constructor(
+		private readonly _lineRangeInfo: ContinuousLineSizes,
+		editorTrueContentWidth: number,
+		endOfLinePadding: (lineNumber: number) => number,
+	) {
+		this.availableSpaceSizes = _lineRangeInfo.sizes.map((s, idx) => {
+			const lineNumber = _lineRangeInfo.lineRange.startLineNumber + idx;
+			const linePaddingLeft = endOfLinePadding(lineNumber);
+			return new Size2D(Math.max(0, editorTrueContentWidth - s.width - linePaddingLeft), s.height);
+		});
+
+		this.availableSpaceHeightPrefixSums = getSums(this.availableSpaceSizes, s => s.height);
+		this.availableSpaceSizesTransposed = this.availableSpaceSizes.map(s => s.transpose());
+	}
+
+	/**
+	 * Computes the vertical outline for a widget placed at the given line number.
+	 */
+	public getWidgetVerticalOutline(
+		lineNumber: number,
+		previewEditorHeight: number,
+		layoutConstants: WidgetLayoutConstants
+	): OffsetRange {
+		const sizeIdx = lineNumber - this._lineRangeInfo.lineRange.startLineNumber;
+		const top = this._lineRangeInfo.top + this.availableSpaceHeightPrefixSums[sizeIdx];
+		const editorRange = OffsetRange.ofStartAndLength(top, previewEditorHeight);
+		const { previewEditorMargin, widgetPadding, widgetBorder, lowerBarHeight } = layoutConstants;
+		const verticalWidgetRange = editorRange.withMargin(previewEditorMargin + widgetPadding + widgetBorder).withMargin(0, lowerBarHeight);
+		return verticalWidgetRange;
+	}
+
+	/**
+	 * Tries to find a valid widget outline within this line range context.
+	 */
+	public tryFindWidgetOutline(
+		targetLineNumber: number,
+		previewEditorHeight: number,
+		editorTrueContentRight: number,
+		layoutConstants: WidgetLayoutConstants
+	): WidgetOutline | undefined {
+		if (this._lineRangeInfo.lineRange.length < 3) {
+			return undefined;
+		}
+		return findFirstMinimzeDistance(
+			this._lineRangeInfo.lineRange.addMargin(-1, -1),
+			targetLineNumber,
+			lineNumber => {
+				const verticalWidgetRange = this.getWidgetVerticalOutline(lineNumber, previewEditorHeight, layoutConstants);
+				const maxWidth = getMaxTowerHeightInAvailableArea(
+					verticalWidgetRange.delta(-this._lineRangeInfo.top),
+					this.availableSpaceSizesTransposed
+				);
+				if (maxWidth < layoutConstants.minWidgetWidth) {
+					return undefined;
+				}
+				const horizontalWidgetRange = OffsetRange.ofStartAndLength(editorTrueContentRight - maxWidth, maxWidth);
+				return { horizontalWidgetRange, verticalWidgetRange };
+			}
+		);
+	}
+}
+/**
+ * Splits line size information into continuous ranges, breaking at positions where
+ * the expected vertical position differs from the actual position (e.g., due to folded regions).
+ */
+export function splitIntoContinuousLineRanges(
+	lineRange: LineRange,
+	sizes: Size2D[],
+	top: number,
+	editorObs: ObservableCodeEditor,
+	reader: IReader,
+): ContinuousLineSizes[] {
+	const result: ContinuousLineSizes[] = [];
+	let currentRangeStart = lineRange.startLineNumber;
+	let currentRangeTop = top;
+	let currentSizes: Size2D[] = [];
+
+	for (let i = 0; i < sizes.length; i++) {
+		const lineNumber = lineRange.startLineNumber + i;
+		const expectedTop = currentRangeTop + currentSizes.reduce((p, c) => p + c.height, 0);
+		const actualTop = editorObs.editor.getTopForLineNumber(lineNumber);
+
+		if (i > 0 && actualTop !== expectedTop) {
+			// Discontinuity detected - push the current range and start a new one
+			result.push({
+				lineRange: LineRange.ofLength(currentRangeStart, lineNumber - currentRangeStart),
+				top: currentRangeTop,
+				sizes: currentSizes,
+			});
+			currentRangeStart = lineNumber;
+			currentRangeTop = actualTop;
+			currentSizes = [];
+		}
+		currentSizes.push(sizes[i]);
+	}
+
+	// Push the final range
+	result.push({
+		lineRange: LineRange.ofLength(currentRangeStart, lineRange.endLineNumberExclusive - currentRangeStart),
+		top: currentRangeTop,
+		sizes: currentSizes,
+	});
+
+	// Don't observe each line individually for performance reasons
+	derived({ owner: 'splitIntoContinuousLineRanges' }, r => {
+		return editorObs.observeTopForLineNumber(lineRange.endLineNumberExclusive - 1).read(r);
+	}).read(reader);
+
+	return result;
+}
+
+function findFirstMinimzeDistance<T>(range: LineRange, targetLine: number, predicate: (lineNumber: number) => T | undefined): T | undefined {
+	for (let offset = 0; ; offset++) {
+		const down = targetLine + offset;
+		if (down <= range.endLineNumberExclusive) {
+			const result = predicate(down);
+			if (result !== undefined) {
+				return result;
+			}
+		}
+		const up = targetLine - offset;
+		if (up >= range.startLineNumber) {
+			const result = predicate(up);
+			if (result !== undefined) {
+				return result;
+			}
+		}
+		if (up < range.startLineNumber && down > range.endLineNumberExclusive) {
+			return undefined;
+		}
+	}
+}
+
+function getSums<T>(array: T[], fn: (item: T) => number): number[] {
+	const result: number[] = [0];
+	let sum = 0;
+	for (const item of array) {
+		sum += fn(item);
+		result.push(sum);
+	}
+	return result;
+}

--- a/src/vs/editor/contrib/inlineCompletions/test/browser/longDistanceWidgetPlacement.test.ts
+++ b/src/vs/editor/contrib/inlineCompletions/test/browser/longDistanceWidgetPlacement.test.ts
@@ -1,0 +1,297 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { Size2D } from '../../../../common/core/2d/size.js';
+import { LineRange } from '../../../../common/core/ranges/lineRange.js';
+import { WidgetLayoutConstants, WidgetPlacementContext, ContinuousLineSizes } from '../../browser/view/inlineEdits/inlineEditsViews/longDistanceHint/longDistnaceWidgetPlacement.js';
+
+suite('WidgetPlacementContext', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	function createLineRangeInfo(startLine: number, sizes: Size2D[], top: number = 0): ContinuousLineSizes {
+		return {
+			lineRange: LineRange.ofLength(startLine, sizes.length),
+			top,
+			sizes,
+		};
+	}
+
+	const defaultLayoutConstants: WidgetLayoutConstants = {
+		previewEditorMargin: 5,
+		widgetPadding: 2,
+		widgetBorder: 1,
+		lowerBarHeight: 10,
+		minWidgetWidth: 50,
+	};
+
+	suite('constructor - availableSpaceSizes computation', () => {
+		test('computes available space sizes correctly with no padding', () => {
+			const sizes = [new Size2D(100, 20), new Size2D(150, 20), new Size2D(80, 20)];
+			const lineRangeInfo = createLineRangeInfo(1, sizes);
+			const editorTrueContentWidth = 500;
+			const endOfLinePadding = () => 0;
+
+			const context = new WidgetPlacementContext(lineRangeInfo, editorTrueContentWidth, endOfLinePadding);
+
+			assert.strictEqual(context.availableSpaceSizes.length, 3);
+			assert.strictEqual(context.availableSpaceSizes[0].width, 400); // 500 - 100
+			assert.strictEqual(context.availableSpaceSizes[1].width, 350); // 500 - 150
+			assert.strictEqual(context.availableSpaceSizes[2].width, 420); // 500 - 80
+		});
+
+		test('computes available space sizes with end of line padding', () => {
+			const sizes = [new Size2D(100, 20), new Size2D(150, 20)];
+			const lineRangeInfo = createLineRangeInfo(1, sizes);
+			const editorTrueContentWidth = 500;
+			const endOfLinePadding = (lineNumber: number) => lineNumber * 10;
+
+			const context = new WidgetPlacementContext(lineRangeInfo, editorTrueContentWidth, endOfLinePadding);
+
+			assert.strictEqual(context.availableSpaceSizes[0].width, 390); // 500 - 100 - 10
+			assert.strictEqual(context.availableSpaceSizes[1].width, 330); // 500 - 150 - 20
+		});
+
+		test('available space width is never negative', () => {
+			const sizes = [new Size2D(600, 20)];
+			const lineRangeInfo = createLineRangeInfo(1, sizes);
+			const editorTrueContentWidth = 500;
+			const endOfLinePadding = () => 0;
+
+			const context = new WidgetPlacementContext(lineRangeInfo, editorTrueContentWidth, endOfLinePadding);
+
+			assert.strictEqual(context.availableSpaceSizes[0].width, 0);
+		});
+
+		test('preserves heights in available space sizes', () => {
+			const sizes = [new Size2D(100, 25), new Size2D(100, 30), new Size2D(100, 20)];
+			const lineRangeInfo = createLineRangeInfo(1, sizes);
+			const editorTrueContentWidth = 500;
+			const endOfLinePadding = () => 0;
+
+			const context = new WidgetPlacementContext(lineRangeInfo, editorTrueContentWidth, endOfLinePadding);
+
+			assert.strictEqual(context.availableSpaceSizes[0].height, 25);
+			assert.strictEqual(context.availableSpaceSizes[1].height, 30);
+			assert.strictEqual(context.availableSpaceSizes[2].height, 20);
+		});
+	});
+
+	suite('constructor - prefix sums computation', () => {
+		test('computes height prefix sums correctly', () => {
+			const sizes = [new Size2D(100, 20), new Size2D(100, 30), new Size2D(100, 25)];
+			const lineRangeInfo = createLineRangeInfo(1, sizes);
+
+			const context = new WidgetPlacementContext(lineRangeInfo, 500, () => 0);
+
+			assert.deepStrictEqual(context.availableSpaceHeightPrefixSums, [0, 20, 50, 75]);
+		});
+
+		test('prefix sums start with 0 and have length = sizes.length + 1', () => {
+			const sizes = [new Size2D(100, 10), new Size2D(100, 20)];
+			const lineRangeInfo = createLineRangeInfo(1, sizes);
+
+			const context = new WidgetPlacementContext(lineRangeInfo, 500, () => 0);
+
+			assert.strictEqual(context.availableSpaceHeightPrefixSums[0], 0);
+			assert.strictEqual(context.availableSpaceHeightPrefixSums.length, 3);
+		});
+	});
+
+	suite('constructor - transposed sizes', () => {
+		test('transposes width and height correctly', () => {
+			const sizes = [new Size2D(100, 20), new Size2D(150, 30)];
+			const lineRangeInfo = createLineRangeInfo(1, sizes);
+
+			const context = new WidgetPlacementContext(lineRangeInfo, 500, () => 0);
+
+			// Transposed: width becomes height and vice versa
+			// Available widths are 400 and 350, heights are 20 and 30
+			assert.strictEqual(context.availableSpaceSizesTransposed[0].width, 20);
+			assert.strictEqual(context.availableSpaceSizesTransposed[0].height, 400);
+			assert.strictEqual(context.availableSpaceSizesTransposed[1].width, 30);
+			assert.strictEqual(context.availableSpaceSizesTransposed[1].height, 350);
+		});
+	});
+
+	suite('getWidgetVerticalOutline', () => {
+		test('computes vertical outline for first line', () => {
+			const sizes = [new Size2D(100, 20), new Size2D(100, 20)];
+			const lineRangeInfo = createLineRangeInfo(1, sizes, 100);
+
+			const context = new WidgetPlacementContext(lineRangeInfo, 500, () => 0);
+			const outline = context.getWidgetVerticalOutline(1, 50, defaultLayoutConstants);
+
+			// previewEditorMargin + widgetPadding + widgetBorder = 5 + 2 + 1 = 8
+			// editorRange = [100, 150)
+			// verticalWidgetRange = [100 - 8, 150 + 8 + 10) = [92, 168)
+			assert.strictEqual(outline.start, 92);
+			assert.strictEqual(outline.endExclusive, 168);
+		});
+
+		test('computes vertical outline for second line', () => {
+			const sizes = [new Size2D(100, 20), new Size2D(100, 25)];
+			const lineRangeInfo = createLineRangeInfo(1, sizes, 100);
+
+			const context = new WidgetPlacementContext(lineRangeInfo, 500, () => 0);
+			const outline = context.getWidgetVerticalOutline(2, 50, defaultLayoutConstants);
+
+			// Line 2 is at index 1, prefixSum[1] = 20
+			// top = 100 + 20 = 120
+			// editorRange = [120, 170)
+			// margin = 8, lowerBarHeight = 10
+			// verticalWidgetRange = [120 - 8, 170 + 8 + 10) = [112, 188)
+			assert.strictEqual(outline.start, 112);
+			assert.strictEqual(outline.endExclusive, 188);
+		});
+
+		test('works with zero margins', () => {
+			const sizes = [new Size2D(100, 20)];
+			const lineRangeInfo = createLineRangeInfo(1, sizes, 0);
+			const zeroConstants: WidgetLayoutConstants = {
+				previewEditorMargin: 0,
+				widgetPadding: 0,
+				widgetBorder: 0,
+				lowerBarHeight: 0,
+				minWidgetWidth: 50,
+			};
+
+			const context = new WidgetPlacementContext(lineRangeInfo, 500, () => 0);
+			const outline = context.getWidgetVerticalOutline(1, 50, zeroConstants);
+
+			assert.strictEqual(outline.start, 0);
+			assert.strictEqual(outline.endExclusive, 50);
+		});
+	});
+
+	suite('tryFindWidgetOutline', () => {
+		test('returns undefined when no line has enough width', () => {
+			// All lines have content that leaves less than minWidgetWidth
+			const sizes = [new Size2D(460, 20), new Size2D(470, 20), new Size2D(480, 20)];
+			const lineRangeInfo = createLineRangeInfo(1, sizes);
+
+			const context = new WidgetPlacementContext(lineRangeInfo, 500, () => 0);
+			const result = context.tryFindWidgetOutline(2, 15, 500, defaultLayoutConstants);
+
+			assert.strictEqual(result, undefined);
+		});
+
+		test('finds widget outline on target line when it has enough space', () => {
+			const sizes = [new Size2D(100, 20), new Size2D(100, 20), new Size2D(100, 20)];
+			const lineRangeInfo = createLineRangeInfo(1, sizes, 0);
+
+			const context = new WidgetPlacementContext(lineRangeInfo, 500, () => 0);
+			const result = context.tryFindWidgetOutline(2, 15, 500, defaultLayoutConstants);
+
+			assert.ok(result !== undefined);
+			assert.ok(result.horizontalWidgetRange.length >= defaultLayoutConstants.minWidgetWidth);
+		});
+
+		test('searches outward from target line', () => {
+			// First and last lines are excluded from placement
+			// Lines 2, 3 have no space, line 4 has space
+			const sizes = [
+				new Size2D(100, 20),  // line 1 - excluded (first)
+				new Size2D(460, 20),  // line 2 - no space
+				new Size2D(460, 20),  // line 3 - no space (target)
+				new Size2D(100, 20),  // line 4 - has space
+				new Size2D(100, 20),  // line 5 - has space
+				new Size2D(100, 20),  // line 6 - has space
+				new Size2D(100, 20),  // line 7 - excluded (last)
+			];
+			const lineRangeInfo = createLineRangeInfo(1, sizes, 0);
+
+			const context = new WidgetPlacementContext(lineRangeInfo, 500, () => 0);
+			// Target is line 3, but it should find line 4 (searching outward)
+			const result = context.tryFindWidgetOutline(3, 15, 500, defaultLayoutConstants);
+
+			assert.ok(result !== undefined);
+		});
+
+		test('prefers closer lines to target', () => {
+			const sizes = [
+				new Size2D(100, 20),  // line 0 - excluded (first)
+				new Size2D(100, 20),  // line 1 - has space
+				new Size2D(100, 20),  // line 2 - has space
+				new Size2D(100, 20),  // line 3 - has space
+				new Size2D(500, 9999),// line 4 - no space (target)
+				new Size2D(100, 20),  // line 5 - has space
+				new Size2D(100, 20),  // line 6 - has space
+				new Size2D(100, 20),  // line 7 - has space
+				new Size2D(100, 20),  // line 8 - excluded (last)
+			];
+			const lineRangeInfo = createLineRangeInfo(1, sizes, 0);
+
+			for (let targetLine = 0; targetLine <= 4; targetLine++) {
+				const context = new WidgetPlacementContext(lineRangeInfo, 500, () => 0);
+				const result = context.tryFindWidgetOutline(targetLine, 15, 500, defaultLayoutConstants);
+				assert.ok(result !== undefined);
+				assert.ok(result.verticalWidgetRange.endExclusive < 9999);
+			}
+
+			for (let targetLine = 5; targetLine <= 10 /* test outside line range */; targetLine++) {
+				const context = new WidgetPlacementContext(lineRangeInfo, 500, () => 0);
+				const result = context.tryFindWidgetOutline(targetLine, 15, 500, defaultLayoutConstants);
+				assert.ok(result !== undefined);
+				assert.ok(result.verticalWidgetRange.start > 9999);
+			}
+		});
+
+		test('horizontal widget range ends at editor content right', () => {
+			const sizes = [new Size2D(100, 20), new Size2D(100, 20), new Size2D(100, 20)];
+			const lineRangeInfo = createLineRangeInfo(1, sizes, 0);
+			const editorTrueContentRight = 500;
+
+			const context = new WidgetPlacementContext(lineRangeInfo, 500, () => 0);
+			const result = context.tryFindWidgetOutline(2, 15, editorTrueContentRight, defaultLayoutConstants);
+
+			assert.ok(result !== undefined);
+			assert.strictEqual(result.horizontalWidgetRange.endExclusive, editorTrueContentRight);
+		});
+	});
+
+	suite('edge cases', () => {
+		test('handles single line range', () => {
+			const sizes = [new Size2D(100, 20)];
+			const lineRangeInfo = createLineRangeInfo(5, sizes, 50);
+
+			const context = new WidgetPlacementContext(lineRangeInfo, 500, () => 0);
+
+			assert.strictEqual(context.availableSpaceSizes.length, 1);
+			assert.deepStrictEqual(context.availableSpaceHeightPrefixSums, [0, 20]);
+		});
+
+		test('handles empty content lines (width 0)', () => {
+			const sizes = [new Size2D(0, 20), new Size2D(0, 20)];
+			const lineRangeInfo = createLineRangeInfo(1, sizes);
+
+			const context = new WidgetPlacementContext(lineRangeInfo, 500, () => 0);
+
+			assert.strictEqual(context.availableSpaceSizes[0].width, 500);
+			assert.strictEqual(context.availableSpaceSizes[1].width, 500);
+		});
+
+		test('handles varying line heights', () => {
+			const sizes = [new Size2D(100, 10), new Size2D(100, 30), new Size2D(100, 20)];
+			const lineRangeInfo = createLineRangeInfo(1, sizes, 100);
+
+			const context = new WidgetPlacementContext(lineRangeInfo, 500, () => 0);
+
+			// Verify prefix sums account for varying heights
+			assert.deepStrictEqual(context.availableSpaceHeightPrefixSums, [0, 10, 40, 60]);
+		});
+
+		test('handles very large line numbers', () => {
+			const sizes = [new Size2D(100, 20)];
+			const lineRangeInfo = createLineRangeInfo(10000, sizes, 0);
+
+			const context = new WidgetPlacementContext(lineRangeInfo, 500, () => 0);
+
+			const outline = context.getWidgetVerticalOutline(10000, 50, defaultLayoutConstants);
+			assert.ok(outline !== undefined);
+		});
+	});
+});


### PR DESCRIPTION
```Copilot Generated Description:``` Adjust z-index values for the long-distance NES widget to ensure proper layering and visibility when unhandled exceptions occur.

Fixes microsoft/vscode#283613

