### PR TITLE
Add size tokens and registry implementation for theme customization

### DIFF
--- a/src/vs/platform/theme/common/sizeRegistry.ts
+++ b/src/vs/platform/theme/common/sizeRegistry.ts
@@ -1,0 +1,9 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+export * from './sizeUtils.js';
+
+// Make sure all size files are exported
+export * from './sizes/baseSizes.js';

--- a/src/vs/platform/theme/common/sizeUtils.ts
+++ b/src/vs/platform/theme/common/sizeUtils.ts
@@ -111,7 +111,7 @@ export interface ISizeRegistry {
 	registerSize(id: string, defaults: SizeDefaults | SizeValue | null, description: string): SizeIdentifier;
 
 	/**
-	 * Register a size to the registry.
+	 * Deregister a size from the registry.
 	 */
 	deregisterSize(id: string): void;
 

--- a/src/vs/platform/theme/common/sizeUtils.ts
+++ b/src/vs/platform/theme/common/sizeUtils.ts
@@ -1,0 +1,266 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Emitter, Event } from '../../../base/common/event.js';
+import { IJSONSchema } from '../../../base/common/jsonSchema.js';
+import { IJSONContributionRegistry, Extensions as JSONExtensions } from '../../jsonschemas/common/jsonContributionRegistry.js';
+import * as platform from '../../registry/common/platform.js';
+import { IColorTheme } from './themeService.js';
+import { Disposable } from '../../../base/common/lifecycle.js';
+import { RunOnceScheduler } from '../../../base/common/async.js';
+
+//  ------ API types
+
+export type SizeIdentifier = string;
+
+/**
+ * Size value unit types supported by the registry
+ */
+export type SizeUnit = 'px' | 'rem' | 'em' | '%';
+
+/**
+ * A size value with a numeric amount and unit
+ */
+export interface SizeValue {
+	readonly value: number;
+	readonly unit: SizeUnit;
+}
+
+export interface SizeContribution {
+	readonly id: SizeIdentifier;
+	readonly description: string;
+	readonly defaults: SizeDefaults | SizeValue | null;
+	readonly deprecationMessage: string | undefined;
+}
+
+/**
+ * Returns the css variable name for the given size identifier. Dots (`.`) are replaced with hyphens (`-`) and
+ * everything is prefixed with `--vscode-`.
+ *
+ * @sample `editor.fontSize` is `--vscode-editor-fontSize`.
+ */
+export function asCssVariableName(sizeIdent: SizeIdentifier): string {
+	return `--vscode-${sizeIdent.replace(/\./g, '-')}`;
+}
+
+export function asCssVariable(size: SizeIdentifier): string {
+	return `var(${asCssVariableName(size)})`;
+}
+
+export function asCssVariableWithDefault(size: SizeIdentifier, defaultCssValue: string): string {
+	return `var(${asCssVariableName(size)}, ${defaultCssValue})`;
+}
+
+export interface SizeDefaults {
+	light: SizeValue | null;
+	dark: SizeValue | null;
+	hcDark: SizeValue | null;
+	hcLight: SizeValue | null;
+}
+
+export function isSizeDefaults(value: unknown): value is SizeDefaults {
+	return value !== null && typeof value === 'object' && 'light' in value && 'dark' in value;
+}
+
+/**
+ * Helper function to create a size value
+ */
+export function size(value: number, unit: SizeUnit = 'px'): SizeValue {
+	return { value, unit };
+}
+
+/**
+ * Helper function to create size defaults that use the same value for all themes
+ */
+export function sizeForAllThemes(value: number, unit: SizeUnit = 'px'): SizeDefaults {
+	const sizeValue = size(value, unit);
+	return {
+		light: sizeValue,
+		dark: sizeValue,
+		hcDark: sizeValue,
+		hcLight: sizeValue
+	};
+}
+
+/**
+ * Convert a size value to a CSS string
+ */
+export function sizeValueToCss(sizeValue: SizeValue): string {
+	return `${sizeValue.value}${sizeValue.unit}`;
+}
+
+// size registry
+export const Extensions = {
+	SizeContribution: 'base.contributions.sizes'
+};
+
+export const DEFAULT_SIZE_CONFIG_VALUE = 'default';
+
+export interface ISizeRegistry {
+
+	readonly onDidChangeSchema: Event<void>;
+
+	/**
+	 * Register a size to the registry.
+	 * @param id The size id as used in theme description files
+	 * @param defaults The default values
+	 * @param description the description
+	 */
+	registerSize(id: string, defaults: SizeDefaults | SizeValue | null, description: string): SizeIdentifier;
+
+	/**
+	 * Register a size to the registry.
+	 */
+	deregisterSize(id: string): void;
+
+	/**
+	 * Get all size contributions
+	 */
+	getSizes(): SizeContribution[];
+
+	/**
+	 * Gets the default size of the given id
+	 */
+	resolveDefaultSize(id: SizeIdentifier, theme: IColorTheme): SizeValue | undefined;
+
+	/**
+	 * JSON schema for an object to assign size values to one of the size contributions.
+	 */
+	getSizeSchema(): IJSONSchema;
+
+	/**
+	 * JSON schema to for a reference to a size contribution.
+	 */
+	getSizeReferenceSchema(): IJSONSchema;
+
+	/**
+	 * Notify when the color theme or settings change.
+	 */
+	notifyThemeUpdate(theme: IColorTheme): void;
+
+}
+
+type IJSONSchemaForSizes = IJSONSchema & { properties: { [name: string]: IJSONSchema } };
+
+class SizeRegistry extends Disposable implements ISizeRegistry {
+
+	private readonly _onDidChangeSchema = this._register(new Emitter<void>());
+	readonly onDidChangeSchema: Event<void> = this._onDidChangeSchema.event;
+
+	private sizesById: { [key: string]: SizeContribution };
+	private sizeSchema: IJSONSchemaForSizes = { type: 'object', properties: {} };
+	private sizeReferenceSchema: IJSONSchema & { enum: string[]; enumDescriptions: string[] } = { type: 'string', enum: [], enumDescriptions: [] };
+
+	constructor() {
+		super();
+		this.sizesById = {};
+	}
+
+	public notifyThemeUpdate(theme: IColorTheme) {
+		for (const key of Object.keys(this.sizesById)) {
+			const sizeVal = this.resolveDefaultSize(key, theme);
+			if (sizeVal) {
+				this.sizeSchema.properties[key].default = sizeValueToCss(sizeVal);
+			}
+		}
+		this._onDidChangeSchema.fire();
+	}
+
+	public registerSize(id: string, defaults: SizeDefaults | SizeValue | null, description: string, deprecationMessage?: string): SizeIdentifier {
+		const sizeContribution: SizeContribution = { id, description, defaults, deprecationMessage };
+		this.sizesById[id] = sizeContribution;
+
+		const propertySchema: IJSONSchema = {
+			type: 'string',
+			pattern: '^(\\d+(\\.\\d+)?(px|rem|em|%))|default$',
+			patternErrorMessage: 'Size must be a number followed by px, rem, em, or % (e.g., "12px", "1.5rem") or "default"'
+		};
+
+		if (deprecationMessage) {
+			propertySchema.deprecationMessage = deprecationMessage;
+		}
+
+		this.sizeSchema.properties[id] = {
+			description,
+			...propertySchema
+		};
+
+		this.sizeReferenceSchema.enum.push(id);
+		this.sizeReferenceSchema.enumDescriptions.push(description);
+
+		this._onDidChangeSchema.fire();
+		return id;
+	}
+
+	public deregisterSize(id: string): void {
+		delete this.sizesById[id];
+		delete this.sizeSchema.properties[id];
+		const index = this.sizeReferenceSchema.enum.indexOf(id);
+		if (index !== -1) {
+			this.sizeReferenceSchema.enum.splice(index, 1);
+			this.sizeReferenceSchema.enumDescriptions.splice(index, 1);
+		}
+		this._onDidChangeSchema.fire();
+	}
+
+	public getSizes(): SizeContribution[] {
+		return Object.keys(this.sizesById).map(id => this.sizesById[id]);
+	}
+
+	public resolveDefaultSize(id: SizeIdentifier, theme: IColorTheme): SizeValue | undefined {
+		const sizeDesc = this.sizesById[id];
+		if (sizeDesc?.defaults) {
+			const sizeValue = isSizeDefaults(sizeDesc.defaults) ? sizeDesc.defaults[theme.type] : sizeDesc.defaults;
+			return sizeValue ?? undefined;
+		}
+		return undefined;
+	}
+
+	public getSizeSchema(): IJSONSchema {
+		return this.sizeSchema;
+	}
+
+	public getSizeReferenceSchema(): IJSONSchema {
+		return this.sizeReferenceSchema;
+	}
+
+	public override toString() {
+		const sorter = (a: string, b: string) => {
+			const cat1 = a.indexOf('.') === -1 ? 0 : 1;
+			const cat2 = b.indexOf('.') === -1 ? 0 : 1;
+			if (cat1 !== cat2) {
+				return cat1 - cat2;
+			}
+			return a.localeCompare(b);
+		};
+
+		return Object.keys(this.sizesById).sort(sorter).map(k => `- \`${k}\`: ${this.sizesById[k].description}`).join('\n');
+	}
+
+}
+
+const sizeRegistry = new SizeRegistry();
+platform.Registry.add(Extensions.SizeContribution, sizeRegistry);
+
+export function registerSize(id: string, defaults: SizeDefaults | SizeValue | null, description: string, deprecationMessage?: string): SizeIdentifier {
+	return sizeRegistry.registerSize(id, defaults, description, deprecationMessage);
+}
+
+export function getSizeRegistry(): ISizeRegistry {
+	return sizeRegistry;
+}
+
+export const workbenchSizesSchemaId = 'vscode://schemas/workbench-sizes';
+
+const schemaRegistry = platform.Registry.as<IJSONContributionRegistry>(JSONExtensions.JSONContribution);
+schemaRegistry.registerSchema(workbenchSizesSchemaId, sizeRegistry.getSizeSchema());
+
+const delayer = new RunOnceScheduler(() => schemaRegistry.notifySchemaChanged(workbenchSizesSchemaId), 200);
+
+sizeRegistry.onDidChangeSchema(() => {
+	if (!delayer.isScheduled()) {
+		delayer.schedule();
+	}
+});

--- a/src/vs/platform/theme/common/sizeUtils.ts
+++ b/src/vs/platform/theme/common/sizeUtils.ts
@@ -131,7 +131,7 @@ export interface ISizeRegistry {
 	getSizeSchema(): IJSONSchema;
 
 	/**
-	 * JSON schema to for a reference to a size contribution.
+	 * JSON schema for a reference to a size contribution.
 	 */
 	getSizeReferenceSchema(): IJSONSchema;
 

--- a/src/vs/platform/theme/common/sizes/baseSizes.ts
+++ b/src/vs/platform/theme/common/sizes/baseSizes.ts
@@ -4,70 +4,54 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as nls from '../../../../nls.js';
-import { registerSize, size, sizeForAllThemes } from '../sizeUtils.js';
+import { registerSize, sizeForAllThemes } from '../sizeUtils.js';
 
 // ------ Font Sizes
 
-export const fontSize = registerSize('fontSize',
+export const bodyFontSize = registerSize('bodyFontSize',
 	sizeForAllThemes(13, 'px'),
-	nls.localize('fontSize', "Base font size. This size is used if not overridden by a component."));
+	nls.localize('bodyFontSize', "Base font size. This size is used if not overridden by a component."));
 
-export const fontSizeSmall = registerSize('fontSize.small',
+export const bodyFontSizeSmall = registerSize('bodyFontSize.small',
+	sizeForAllThemes(12, 'px'),
+	nls.localize('bodyFontSizeSmall', "Small font size for secondary content."));
+
+export const bodyFontSizeXSmall = registerSize('bodyFontSize.xSmall',
 	sizeForAllThemes(11, 'px'),
-	nls.localize('fontSizeSmall', "Small font size for secondary content."));
+	nls.localize('bodyFontSizeXSmall', "Extra small font size for less prominent content."));
 
-export const fontSizeLarge = registerSize('fontSize.large',
+export const codiconFontSize = registerSize('codiconFontSize',
 	sizeForAllThemes(16, 'px'),
-	nls.localize('fontSizeLarge', "Large font size for headings and prominent content."));
-
-// ------ Line Heights
-
-export const lineHeight = registerSize('lineHeight',
-	sizeForAllThemes(1.5, 'em'),
-	nls.localize('lineHeight', "Base line height. This height is used if not overridden by a component."));
-
-export const lineHeightCompact = registerSize('lineHeight.compact',
-	sizeForAllThemes(1.3, 'em'),
-	nls.localize('lineHeightCompact', "Compact line height for dense content."));
-
-export const lineHeightRelaxed = registerSize('lineHeight.relaxed',
-	sizeForAllThemes(1.8, 'em'),
-	nls.localize('lineHeightRelaxed', "Relaxed line height for readable content."));
-
-// ------ Letter Spacing
-
-export const letterSpacing = registerSize('letterSpacing',
-	sizeForAllThemes(0, 'px'),
-	nls.localize('letterSpacing', "Base letter spacing. This spacing is used if not overridden by a component."));
-
-export const letterSpacingWide = registerSize('letterSpacing.wide',
-	sizeForAllThemes(0.5, 'px'),
-	nls.localize('letterSpacingWide', "Wide letter spacing for headings."));
+	nls.localize('codiconFontSize', "Base font size for codicons."));
 
 // ------ Corner Radii
 
-export const cornerRadius = registerSize('cornerRadius',
-	{ dark: size(3, 'px'), light: size(3, 'px'), hcDark: size(0, 'px'), hcLight: size(0, 'px') },
-	nls.localize('cornerRadius', "Base corner radius for UI elements."));
+export const cornerRadiusMedium = registerSize('cornerRadius.medium',
+	sizeForAllThemes(6, 'px'),
+	nls.localize('cornerRadiusMedium', "Base corner radius for UI elements."));
+
+export const cornerRadiusXSmall = registerSize('cornerRadius.xSmall',
+	sizeForAllThemes(2, 'px'),
+	nls.localize('cornerRadiusXSmall', "Extra small corner radius for very compact UI elements."));
 
 export const cornerRadiusSmall = registerSize('cornerRadius.small',
-	{ dark: size(2, 'px'), light: size(2, 'px'), hcDark: size(0, 'px'), hcLight: size(0, 'px') },
+	sizeForAllThemes(4, 'px'),
 	nls.localize('cornerRadiusSmall', "Small corner radius for compact UI elements."));
 
 export const cornerRadiusLarge = registerSize('cornerRadius.large',
-	{ dark: size(6, 'px'), light: size(6, 'px'), hcDark: size(0, 'px'), hcLight: size(0, 'px') },
+	sizeForAllThemes(8, 'px'),
 	nls.localize('cornerRadiusLarge', "Large corner radius for prominent UI elements."));
+
+export const cornerRadiusXLarge = registerSize('cornerRadius.xLarge',
+	sizeForAllThemes(12, 'px'),
+	nls.localize('cornerRadiusXLarge', "Extra large corner radius for very prominent UI elements."));
+
+export const cornerRadiusCircle = registerSize('cornerRadius.circle',
+	sizeForAllThemes(9999, 'px'),
+	nls.localize('cornerRadiusCircle', "Circular corner radius for fully rounded UI elements."));
 
 // ------ Stroke Thickness
 
 export const strokeThickness = registerSize('strokeThickness',
 	sizeForAllThemes(1, 'px'),
 	nls.localize('strokeThickness', "Base stroke thickness for borders and outlines."));
-
-export const strokeThicknessThick = registerSize('strokeThickness.thick',
-	sizeForAllThemes(2, 'px'),
-	nls.localize('strokeThicknessThick', "Thick stroke for emphasized borders."));
-
-export const strokeThicknessFocus = registerSize('strokeThickness.focus',
-	{ dark: size(1, 'px'), light: size(1, 'px'), hcDark: size(2, 'px'), hcLight: size(2, 'px') },
-	nls.localize('strokeThicknessFocus', "Stroke thickness for focus indicators."));

--- a/src/vs/platform/theme/common/sizes/baseSizes.ts
+++ b/src/vs/platform/theme/common/sizes/baseSizes.ts
@@ -1,0 +1,73 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as nls from '../../../../nls.js';
+import { registerSize, size, sizeForAllThemes } from '../sizeUtils.js';
+
+// ------ Font Sizes
+
+export const fontSize = registerSize('fontSize',
+	sizeForAllThemes(13, 'px'),
+	nls.localize('fontSize', "Base font size. This size is used if not overridden by a component."));
+
+export const fontSizeSmall = registerSize('fontSize.small',
+	sizeForAllThemes(11, 'px'),
+	nls.localize('fontSizeSmall', "Small font size for secondary content."));
+
+export const fontSizeLarge = registerSize('fontSize.large',
+	sizeForAllThemes(16, 'px'),
+	nls.localize('fontSizeLarge', "Large font size for headings and prominent content."));
+
+// ------ Line Heights
+
+export const lineHeight = registerSize('lineHeight',
+	sizeForAllThemes(1.5, 'em'),
+	nls.localize('lineHeight', "Base line height. This height is used if not overridden by a component."));
+
+export const lineHeightCompact = registerSize('lineHeight.compact',
+	sizeForAllThemes(1.3, 'em'),
+	nls.localize('lineHeightCompact', "Compact line height for dense content."));
+
+export const lineHeightRelaxed = registerSize('lineHeight.relaxed',
+	sizeForAllThemes(1.8, 'em'),
+	nls.localize('lineHeightRelaxed', "Relaxed line height for readable content."));
+
+// ------ Letter Spacing
+
+export const letterSpacing = registerSize('letterSpacing',
+	sizeForAllThemes(0, 'px'),
+	nls.localize('letterSpacing', "Base letter spacing. This spacing is used if not overridden by a component."));
+
+export const letterSpacingWide = registerSize('letterSpacing.wide',
+	sizeForAllThemes(0.5, 'px'),
+	nls.localize('letterSpacingWide', "Wide letter spacing for headings."));
+
+// ------ Corner Radii
+
+export const cornerRadius = registerSize('cornerRadius',
+	{ dark: size(3, 'px'), light: size(3, 'px'), hcDark: size(0, 'px'), hcLight: size(0, 'px') },
+	nls.localize('cornerRadius', "Base corner radius for UI elements."));
+
+export const cornerRadiusSmall = registerSize('cornerRadius.small',
+	{ dark: size(2, 'px'), light: size(2, 'px'), hcDark: size(0, 'px'), hcLight: size(0, 'px') },
+	nls.localize('cornerRadiusSmall', "Small corner radius for compact UI elements."));
+
+export const cornerRadiusLarge = registerSize('cornerRadius.large',
+	{ dark: size(6, 'px'), light: size(6, 'px'), hcDark: size(0, 'px'), hcLight: size(0, 'px') },
+	nls.localize('cornerRadiusLarge', "Large corner radius for prominent UI elements."));
+
+// ------ Stroke Thickness
+
+export const strokeThickness = registerSize('strokeThickness',
+	sizeForAllThemes(1, 'px'),
+	nls.localize('strokeThickness', "Base stroke thickness for borders and outlines."));
+
+export const strokeThicknessThick = registerSize('strokeThickness.thick',
+	sizeForAllThemes(2, 'px'),
+	nls.localize('strokeThicknessThick', "Thick stroke for emphasized borders."));
+
+export const strokeThicknessFocus = registerSize('strokeThickness.focus',
+	{ dark: size(1, 'px'), light: size(1, 'px'), hcDark: size(2, 'px'), hcLight: size(2, 'px') },
+	nls.localize('strokeThicknessFocus', "Stroke thickness for focus indicators."));

--- a/src/vs/platform/theme/test/common/sizeRegistry.test.ts
+++ b/src/vs/platform/theme/test/common/sizeRegistry.test.ts
@@ -6,6 +6,8 @@
 import assert from 'assert';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
 import { getSizeRegistry, registerSize, size, sizeForAllThemes, sizeValueToCss, asCssVariableName, asCssVariable } from '../../common/sizeRegistry.js';
+// Import baseSizes to ensure base size tokens are registered
+import * as baseSizes from '../../common/sizes/baseSizes.js';
 
 suite('Size Registry', () => {
 
@@ -56,11 +58,12 @@ suite('Size Registry', () => {
 	test('size tokens should be available', () => {
 		const sizes = getSizeRegistry().getSizes();
 
-		// Check that base sizes are registered
-		assert.ok(sizes.find(s => s.id === 'fontSize'));
-		assert.ok(sizes.find(s => s.id === 'lineHeight'));
-		assert.ok(sizes.find(s => s.id === 'cornerRadius'));
-		assert.ok(sizes.find(s => s.id === 'strokeThickness'));
+		// Check that base sizes are registered (baseSizes import ensures they're loaded)
+		assert.ok(baseSizes); // Reference to ensure import side effects execute
+		assert.ok(sizes.find(s => s.id === 'bodyFontSize'), 'bodyFontSize should be registered');
+		assert.ok(sizes.find(s => s.id === 'cornerRadius.medium'), 'cornerRadius.medium should be registered');
+		assert.ok(sizes.find(s => s.id === 'strokeThickness'), 'strokeThickness should be registered');
+		assert.ok(sizes.find(s => s.id === 'codiconFontSize'), 'codiconFontSize should be registered');
 	});
 
 	test('sizeForAllThemes should create same value for all themes', () => {

--- a/src/vs/platform/theme/test/common/sizeRegistry.test.ts
+++ b/src/vs/platform/theme/test/common/sizeRegistry.test.ts
@@ -7,7 +7,7 @@ import assert from 'assert';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
 import { getSizeRegistry, registerSize, size, sizeForAllThemes, sizeValueToCss, asCssVariableName, asCssVariable } from '../../common/sizeRegistry.js';
 // Import baseSizes to ensure base size tokens are registered
-import * as baseSizes from '../../common/sizes/baseSizes.js';
+import { bodyFontSize, bodyFontSizeSmall, codiconFontSize, cornerRadiusMedium, cornerRadiusSmall, cornerRadiusLarge, strokeThickness } from '../../common/sizes/baseSizes.js';
 
 suite('Size Registry', () => {
 
@@ -58,12 +58,14 @@ suite('Size Registry', () => {
 	test('size tokens should be available', () => {
 		const sizes = getSizeRegistry().getSizes();
 
-		// Check that base sizes are registered (baseSizes import ensures they're loaded)
-		assert.ok(baseSizes); // Reference to ensure import side effects execute
-		assert.ok(sizes.find(s => s.id === 'bodyFontSize'), 'bodyFontSize should be registered');
-		assert.ok(sizes.find(s => s.id === 'cornerRadius.medium'), 'cornerRadius.medium should be registered');
-		assert.ok(sizes.find(s => s.id === 'strokeThickness'), 'strokeThickness should be registered');
-		assert.ok(sizes.find(s => s.id === 'codiconFontSize'), 'codiconFontSize should be registered');
+		// Check that base sizes are registered
+		assert.ok(sizes.find(s => s.id === bodyFontSize), 'bodyFontSize should be registered');
+		assert.ok(sizes.find(s => s.id === bodyFontSizeSmall), 'bodyFontSizeSmall should be registered');
+		assert.ok(sizes.find(s => s.id === codiconFontSize), 'codiconFontSize should be registered');
+		assert.ok(sizes.find(s => s.id === cornerRadiusMedium), 'cornerRadius.medium should be registered');
+		assert.ok(sizes.find(s => s.id === cornerRadiusSmall), 'cornerRadius.small should be registered');
+		assert.ok(sizes.find(s => s.id === cornerRadiusLarge), 'cornerRadius.large should be registered');
+		assert.ok(sizes.find(s => s.id === strokeThickness), 'strokeThickness should be registered');
 	});
 
 	test('sizeForAllThemes should create same value for all themes', () => {

--- a/src/vs/platform/theme/test/common/sizeRegistry.test.ts
+++ b/src/vs/platform/theme/test/common/sizeRegistry.test.ts
@@ -1,0 +1,84 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+import { getSizeRegistry, registerSize, size, sizeForAllThemes, sizeValueToCss, asCssVariableName, asCssVariable } from '../../common/sizeRegistry.js';
+
+suite('Size Registry', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('registerSize should register a size token', () => {
+		const id = registerSize('test.size', { dark: size(10, 'px'), light: size(10, 'px'), hcDark: size(10, 'px'), hcLight: size(10, 'px') }, 'Test size');
+		assert.strictEqual(id, 'test.size');
+
+		const sizes = getSizeRegistry().getSizes();
+		const testSize = sizes.find(s => s.id === 'test.size');
+		assert.ok(testSize);
+		assert.strictEqual(testSize.description, 'Test size');
+
+		getSizeRegistry().deregisterSize('test.size');
+	});
+
+	test('sizeValueToCss should convert size value to CSS string', () => {
+		assert.strictEqual(sizeValueToCss(size(10, 'px')), '10px');
+		assert.strictEqual(sizeValueToCss(size(1.5, 'rem')), '1.5rem');
+		assert.strictEqual(sizeValueToCss(size(100, '%')), '100%');
+		assert.strictEqual(sizeValueToCss(size(1.2, 'em')), '1.2em');
+	});
+
+	test('asCssVariableName should convert identifier to CSS variable name', () => {
+		assert.strictEqual(asCssVariableName('fontSize'), '--vscode-fontSize');
+		assert.strictEqual(asCssVariableName('corner.radius'), '--vscode-corner-radius');
+		assert.strictEqual(asCssVariableName('font.size.large'), '--vscode-font-size-large');
+	});
+
+	test('asCssVariable should create CSS variable reference', () => {
+		assert.strictEqual(asCssVariable('fontSize'), 'var(--vscode-fontSize)');
+		assert.strictEqual(asCssVariable('cornerRadius'), 'var(--vscode-cornerRadius)');
+	});
+
+	test('deregisterSize should remove a size token', () => {
+		registerSize('test.remove', { dark: size(5, 'px'), light: size(5, 'px'), hcDark: size(5, 'px'), hcLight: size(5, 'px') }, 'Test remove');
+
+		let sizes = getSizeRegistry().getSizes();
+		assert.ok(sizes.find(s => s.id === 'test.remove'));
+
+		getSizeRegistry().deregisterSize('test.remove');
+
+		sizes = getSizeRegistry().getSizes();
+		assert.ok(!sizes.find(s => s.id === 'test.remove'));
+	});
+
+	test('size tokens should be available', () => {
+		const sizes = getSizeRegistry().getSizes();
+
+		// Check that base sizes are registered
+		assert.ok(sizes.find(s => s.id === 'fontSize'));
+		assert.ok(sizes.find(s => s.id === 'lineHeight'));
+		assert.ok(sizes.find(s => s.id === 'cornerRadius'));
+		assert.ok(sizes.find(s => s.id === 'strokeThickness'));
+	});
+
+	test('sizeForAllThemes should create same value for all themes', () => {
+		const sizeDefaults = sizeForAllThemes(10, 'px');
+		assert.deepStrictEqual(sizeDefaults.light, { value: 10, unit: 'px' });
+		assert.deepStrictEqual(sizeDefaults.dark, { value: 10, unit: 'px' });
+		assert.deepStrictEqual(sizeDefaults.hcDark, { value: 10, unit: 'px' });
+		assert.deepStrictEqual(sizeDefaults.hcLight, { value: 10, unit: 'px' });
+	});
+
+	test('registerSize should work with sizeForAllThemes', () => {
+		const id = registerSize('test.allThemes', sizeForAllThemes(5, 'rem'), 'Test all themes');
+		assert.strictEqual(id, 'test.allThemes');
+
+		const sizes = getSizeRegistry().getSizes();
+		const testSize = sizes.find(s => s.id === 'test.allThemes');
+		assert.ok(testSize);
+
+		getSizeRegistry().deregisterSize('test.allThemes');
+	});
+});

--- a/src/vs/workbench/services/themes/browser/workbenchThemeService.ts
+++ b/src/vs/workbench/services/themes/browser/workbenchThemeService.ts
@@ -40,6 +40,7 @@ import { RunOnceScheduler, Sequencer } from '../../../../base/common/async.js';
 import { IUserDataInitializationService } from '../../userData/browser/userDataInit.js';
 import { getIconsStyleSheet } from '../../../../platform/theme/browser/iconsStyleSheet.js';
 import { asCssVariableName, getColorRegistry } from '../../../../platform/theme/common/colorRegistry.js';
+import { asCssVariableName as asSizeCssVariableName, getSizeRegistry, sizeValueToCss } from '../../../../platform/theme/common/sizeRegistry.js';
 import { ILanguageService } from '../../../../editor/common/languages/language.js';
 import { mainWindow } from '../../../../base/browser/window.js';
 
@@ -477,7 +478,16 @@ export class WorkbenchThemeService extends Disposable implements IWorkbenchTheme
 				colorVariables.push(`${asCssVariableName(item.id)}: ${color.toString()};`);
 			}
 		}
-		ruleCollector.addRule(`.monaco-workbench { ${colorVariables.join('\n')} }`);
+
+		const sizeVariables: string[] = [];
+		for (const item of getSizeRegistry().getSizes()) {
+			const sizeValue = getSizeRegistry().resolveDefaultSize(item.id, themeData);
+			if (sizeValue) {
+				sizeVariables.push(`${asSizeCssVariableName(item.id)}: ${sizeValueToCss(sizeValue)};`);
+			}
+		}
+
+		ruleCollector.addRule(`.monaco-workbench { ${colorVariables.join('\n')} ${sizeVariables.join('\n')} }`);
 
 		_applyRules([...cssRules].join('\n'), colorThemeRulesClassName);
 	}

--- a/src/vs/workbench/services/themes/browser/workbenchThemeService.ts
+++ b/src/vs/workbench/services/themes/browser/workbenchThemeService.ts
@@ -487,7 +487,7 @@ export class WorkbenchThemeService extends Disposable implements IWorkbenchTheme
 			}
 		}
 
-		ruleCollector.addRule(`.monaco-workbench { ${colorVariables.join('\n')} ${sizeVariables.join('\n')} }`);
+		ruleCollector.addRule(`.monaco-workbench { ${(colorVariables.concat(sizeVariables)).join('\n')} }`);
 
 		_applyRules([...cssRules].join('\n'), colorThemeRulesClassName);
 	}


### PR DESCRIPTION
This implementation adds a size registry system to VS Code, similar to the existing color registry. The size registry allows centralized management of size tokens (font sizes, line heights, letter spacing, corner radii, stroke thickness) that are automatically converted to CSS custom properties.

## Files Created

### Core Implementation
1. **`src/vs/platform/theme/common/sizeUtils.ts`**
   - Core `SizeRegistry` class
   - Type definitions (`SizeIdentifier`, `SizeValue`, `SizeContribution`, etc.)
   - Helper functions (`size()`, `sizeValueToCss()`, `asCssVariable()`, `asCssVariableName()`)
   - JSON schema integration
   - Registry singleton and exports

2. **`src/vs/platform/theme/common/sizeRegistry.ts`**
   - Main export file (similar to `colorRegistry.ts`)
   - Re-exports from `sizeUtils.ts` and size token definitions

3. **`src/vs/platform/theme/common/sizes/baseSizes.ts`**
   - Base size token definitions
   - Font sizes: `fontSize`, `fontSize.small`, `fontSize.large`
   - Line heights: `lineHeight`, `lineHeight.compact`, `lineHeight.relaxed`
   - Letter spacing: `letterSpacing`, `letterSpacing.wide`
   - Corner radii: `cornerRadius`, `cornerRadius.small`, `cornerRadius.large`
   - Stroke thickness: `strokeThickness`, `strokeThickness.thick`, `strokeThickness.focus`

### Integration
4. **`src/vs/workbench/services/themes/browser/workbenchThemeService.ts`** (modified)
   - Imports size registry utilities
   - Generates CSS custom properties for size tokens (similar to color tokens)
   - Injects size CSS variables into `.monaco-workbench` alongside color variables

### Tests
5. **`src/vs/platform/theme/test/common/sizeRegistry.test.ts`**
   - Unit tests for size registry functionality
   - All tests passing ✅

## Features Implemented

✅ **Size Token Registration**
- Register size tokens with theme-specific values (light, dark, hcDark, hcLight)
- Support for multiple units (px, rem, em, %)
- Type-safe API with full TypeScript support

✅ **CSS Variable Generation**
- Automatic conversion to CSS custom properties with `--vscode-` prefix
- Example: `fontSize` → `--vscode-fontSize: 13px`
- Integration with existing theme service

✅ **Helper Functions**
- `size(value, unit)` - Create size values
- `sizeForAllThemes(value, unit)` - Create same size value for all themes
- `sizeValueToCss(sizeValue)` - Convert to CSS string
- `asCssVariable(identifier)` - Get CSS variable reference
- `asCssVariableName(identifier)` - Get CSS variable name

✅ **JSON Schema Integration**
- Automatic schema generation for size tokens
- Validation support for configuration files

✅ **Base Size Tokens**
- 11 base size tokens covering common UI sizing needs

## Usage

### In TypeScript/JavaScript:
```typescript
import { asCssVariable, fontSize, cornerRadiusMedium } from 'vs/platform/theme/common/sizeRegistry';

const styles = `
  .my-element {
    font-size: ${asCssVariable(fontSize)};
    border-radius: ${asCssVariable(cornerRadiusMedium)};
  }
`;
```

### In CSS:
```css
.my-element {
  font-size: var(--vscode-fontSize);
  border-radius: var(--vscode-cornerRadius-medium);
  line-height: var(--vscode-lineHeight);
}
```

## Not Implemented (Future Work)

❌ **User Overrides**
- User configuration of size tokens in settings
- Similar to color customization in `workbench.colorCustomizations`

❌ **Size Transformations**
- Transform functions like color registry has (darken, lighten, transparent, etc.)
- Could add: scale, multiply, add, clamp

❌ **Theme JSON Support**
- Theme-specific size overrides in theme JSON files
- Extension themes defining custom size tokens

## Architecture

The implementation follows the exact same pattern as the color registry:
```
sizeRegistry.ts (exports) → sizeUtils.ts (core) → sizes/*.ts (tokens)
                                                      ↓
                                          workbenchThemeService.ts
                                                      ↓
                                            CSS custom properties
```