### PR TITLE
Update msCompile matcher to handle more cases

### DIFF
--- a/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts
+++ b/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts
@@ -3015,7 +3015,12 @@ export abstract class AbstractTaskService extends Disposable implements ITaskSer
 		return entries;
 	}
 	private async _showTwoLevelQuickPick(placeHolder: string, defaultEntry?: ITaskQuickPickEntry, type?: string, name?: string) {
-		return this._instantiationService.createInstance(TaskQuickPick).show(placeHolder, defaultEntry, type, name);
+		const taskQuickPick = this._instantiationService.createInstance(TaskQuickPick);
+		try {
+			return await taskQuickPick.show(placeHolder, defaultEntry, type, name);
+		} finally {
+			taskQuickPick.dispose();
+		}
 	}
 
 	private async _showQuickPick(tasks: Promise<Task[]> | Task[], placeHolder: string, defaultEntry?: ITaskQuickPickEntry, group: boolean = false, sort: boolean = false, selectedEntry?: ITaskQuickPickEntry, additionalEntries?: ITaskQuickPickEntry[], name?: string): Promise<ITaskQuickPickEntry | undefined | null> {

--- a/src/vs/workbench/contrib/tasks/common/problemMatcher.ts
+++ b/src/vs/workbench/contrib/tasks/common/problemMatcher.ts
@@ -502,6 +502,9 @@ class SingleLineMatcher extends AbstractLineMatcher {
 		const matches = this.pattern.regexp.exec(lines[start]);
 		if (matches) {
 			this.fillProblemData(data, this.pattern, matches);
+			if (data.kind === ProblemLocationKind.Location && !data.location && !data.line && data.file) {
+				data.kind = ProblemLocationKind.File;
+			}
 			const match = this.getMarkerMatch(data);
 			if (match) {
 				return { match: match, continue: false };
@@ -1501,13 +1504,13 @@ class ProblemPatternRegistryImpl implements IProblemPatternRegistry {
 
 	private fillDefaults(): void {
 		this.add('msCompile', {
-			regexp: /^(?:\s*\d+>)?(\S.*)\((\d+|\d+,\d+|\d+,\d+,\d+,\d+)\)\s*:\s+((?:fatal +)?error|warning|info)\s+(\w+\d+)\s*:\s*(.*)$/,
+			regexp: /^\s*(?:\s*\d+>)?(\S.*?)(?:\((\d+|\d+,\d+|\d+,\d+,\d+,\d+)\))?\s*:\s+(?:(\S+)\s+)?((?:fatal +)?error|warning|info)\s+(\w+\d+)?\s*:\s*(.*)$/,
 			kind: ProblemLocationKind.Location,
 			file: 1,
 			location: 2,
-			severity: 3,
-			code: 4,
-			message: 5
+			severity: 4,
+			code: 5,
+			message: 6
 		});
 		this.add('gulp-tsc', {
 			regexp: /^([^\s].*)\((\d+|\d+,\d+|\d+,\d+,\d+,\d+)\):\s+(\d+)\s+(.*)$/,

--- a/src/vs/workbench/contrib/tasks/test/common/problemMatcher.test.ts
+++ b/src/vs/workbench/contrib/tasks/test/common/problemMatcher.test.ts
@@ -6,6 +6,7 @@ import * as matchers from '../../common/problemMatcher.js';
 
 import assert from 'assert';
 import { ValidationState, IProblemReporter, ValidationStatus } from '../../../../../base/common/parsers.js';
+import { MarkerSeverity } from '../../../../../platform/markers/common/markers.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 
 class ProblemReporter implements IProblemReporter {
@@ -264,5 +265,134 @@ suite('ProblemPatternParser', () => {
 			assert.strictEqual(ValidationState.Error, reporter.state);
 			assert(reporter.hasMessage('The problem pattern is invalid. It must contain at least one pattern.'));
 		});
+	});
+});
+
+suite('ProblemPatternRegistry - msCompile', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+	test('matches lines with leading whitespace', () => {
+		const matcher = matchers.createLineMatcher({
+			owner: 'msCompile',
+			applyTo: matchers.ApplyToKind.allDocuments,
+			fileLocation: matchers.FileLocationKind.Absolute,
+			pattern: matchers.ProblemPatternRegistry.get('msCompile')
+		});
+		const line = '    /workspace/app.cs(5,10): error CS1001: Sample message';
+		const result = matcher.handle([line]);
+		assert.ok(result.match);
+		const marker = result.match!.marker;
+		assert.strictEqual(marker.code, 'CS1001');
+		assert.strictEqual(marker.message, 'Sample message');
+	});
+
+	test('matches lines without diagnostic code', () => {
+		const matcher = matchers.createLineMatcher({
+			owner: 'msCompile',
+			applyTo: matchers.ApplyToKind.allDocuments,
+			fileLocation: matchers.FileLocationKind.Absolute,
+			pattern: matchers.ProblemPatternRegistry.get('msCompile')
+		});
+		const line = '/workspace/app.cs(3,7): warning : Message without code';
+		const result = matcher.handle([line]);
+		assert.ok(result.match);
+		const marker = result.match!.marker;
+		assert.strictEqual(marker.code, undefined);
+		assert.strictEqual(marker.message, 'Message without code');
+	});
+
+	test('matches lines without location information', () => {
+		const matcher = matchers.createLineMatcher({
+			owner: 'msCompile',
+			applyTo: matchers.ApplyToKind.allDocuments,
+			fileLocation: matchers.FileLocationKind.Absolute,
+			pattern: matchers.ProblemPatternRegistry.get('msCompile')
+		});
+		const line = 'Main.cs: warning CS0168: The variable \'x\' is declared but never used';
+		const result = matcher.handle([line]);
+		assert.ok(result.match);
+		const marker = result.match!.marker;
+		assert.strictEqual(marker.code, 'CS0168');
+		assert.strictEqual(marker.message, 'The variable \'x\' is declared but never used');
+		assert.strictEqual(marker.severity, MarkerSeverity.Warning);
+	});
+
+	test('matches lines with build prefixes and fatal errors', () => {
+		const matcher = matchers.createLineMatcher({
+			owner: 'msCompile',
+			applyTo: matchers.ApplyToKind.allDocuments,
+			fileLocation: matchers.FileLocationKind.Absolute,
+			pattern: matchers.ProblemPatternRegistry.get('msCompile')
+		});
+		const line = '  1>c:/workspace/app.cs(12): fatal error C1002: Fatal diagnostics';
+		const result = matcher.handle([line]);
+		assert.ok(result.match);
+		const marker = result.match!.marker;
+		assert.strictEqual(marker.code, 'C1002');
+		assert.strictEqual(marker.message, 'Fatal diagnostics');
+		assert.strictEqual(marker.severity, MarkerSeverity.Error);
+	});
+
+	test('matches info diagnostics with codes', () => {
+		const matcher = matchers.createLineMatcher({
+			owner: 'msCompile',
+			applyTo: matchers.ApplyToKind.allDocuments,
+			fileLocation: matchers.FileLocationKind.Absolute,
+			pattern: matchers.ProblemPatternRegistry.get('msCompile')
+		});
+		const line = '2>/workspace/app.cs(20,5): info INF1001: Informational diagnostics';
+		const result = matcher.handle([line]);
+		assert.ok(result.match);
+		const marker = result.match!.marker;
+		assert.strictEqual(marker.code, 'INF1001');
+		assert.strictEqual(marker.message, 'Informational diagnostics');
+		assert.strictEqual(marker.severity, MarkerSeverity.Info);
+	});
+
+	test('matches lines with subcategory prefixes', () => {
+		const matcher = matchers.createLineMatcher({
+			owner: 'msCompile',
+			applyTo: matchers.ApplyToKind.allDocuments,
+			fileLocation: matchers.FileLocationKind.Absolute,
+			pattern: matchers.ProblemPatternRegistry.get('msCompile')
+		});
+		const line = 'Main.cs(17,20): subcategory warning CS0168: The variable \'x\' is declared but never used';
+		const result = matcher.handle([line]);
+		assert.ok(result.match);
+		const marker = result.match!.marker;
+		assert.strictEqual(marker.code, 'CS0168');
+		assert.strictEqual(marker.message, 'The variable \'x\' is declared but never used');
+		assert.strictEqual(marker.severity, MarkerSeverity.Warning);
+	});
+
+	test('matches complex diagnostics with all qualifiers', () => {
+		const matcher = matchers.createLineMatcher({
+			owner: 'msCompile',
+			applyTo: matchers.ApplyToKind.allDocuments,
+			fileLocation: matchers.FileLocationKind.Absolute,
+			pattern: matchers.ProblemPatternRegistry.get('msCompile')
+		});
+		const line = '  12>c:/workspace/Main.cs(42,7,43,2): subcategory fatal error CS9999: Complex diagnostics';
+		const result = matcher.handle([line]);
+		assert.ok(result.match);
+		const marker = result.match!.marker;
+		assert.strictEqual(marker.code, 'CS9999');
+		assert.strictEqual(marker.message, 'Complex diagnostics');
+		assert.strictEqual(marker.severity, MarkerSeverity.Error);
+		assert.strictEqual(marker.startLineNumber, 42);
+		assert.strictEqual(marker.startColumn, 7);
+		assert.strictEqual(marker.endLineNumber, 43);
+		assert.strictEqual(marker.endColumn, 2);
+	});
+
+	test('ignores diagnostics without origin', () => {
+		const matcher = matchers.createLineMatcher({
+			owner: 'msCompile',
+			applyTo: matchers.ApplyToKind.allDocuments,
+			fileLocation: matchers.FileLocationKind.Absolute,
+			pattern: matchers.ProblemPatternRegistry.get('msCompile')
+		});
+		const line = 'warning: The variable \'x\' is declared but never used';
+		const result = matcher.handle([line]);
+		assert.strictEqual(result.match, null);
 	});
 });


### PR DESCRIPTION
fixes #264202
fixes https://github.com/microsoft/vscode/issues/167454

- Enhanced the msCompile regex pattern to handle optional components (location, code, subcategory)
- Added fallback logic to change problem location kind from Location to File when location info is absent
- Added comprehensive test coverage for the new regex capabilities
