### PR TITLE
check the end part of `legacyToolReferenceFullNames` when evaluating `EligibleForAutoApproval`

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/languageModelToolsService.ts
+++ b/src/vs/workbench/contrib/chat/browser/languageModelToolsService.ts
@@ -613,13 +613,16 @@ export class LanguageModelToolsService extends Disposable implements ILanguageMo
 			// Back compat with legacy names
 			if (toolData.legacyToolReferenceFullNames) {
 				for (const legacyName of toolData.legacyToolReferenceFullNames) {
-					if (Object.prototype.hasOwnProperty.call(eligibilityConfig, legacyName)) {
+					// Some tools may be both renamed and namespaced from a toolset, eg: xxx/yyy -> yyy
+					const trimmedLegacyName = legacyName.includes('/') && legacyName.split('/').pop();
+					if (
+						Object.prototype.hasOwnProperty.call(eligibilityConfig, legacyName)
+						|| (trimmedLegacyName && Object.prototype.hasOwnProperty.call(eligibilityConfig, trimmedLegacyName))) {
 						return eligibilityConfig[legacyName];
 					}
 				}
 			}
 		}
-		// Default true
 		return true;
 	}
 

--- a/src/vs/workbench/contrib/chat/browser/languageModelToolsService.ts
+++ b/src/vs/workbench/contrib/chat/browser/languageModelToolsService.ts
@@ -613,12 +613,16 @@ export class LanguageModelToolsService extends Disposable implements ILanguageMo
 			// Back compat with legacy names
 			if (toolData.legacyToolReferenceFullNames) {
 				for (const legacyName of toolData.legacyToolReferenceFullNames) {
-					// Some tools may be both renamed and namespaced from a toolset, eg: xxx/yyy -> yyy
-					const trimmedLegacyName = legacyName.includes('/') && legacyName.split('/').pop();
-					if (
-						Object.prototype.hasOwnProperty.call(eligibilityConfig, legacyName)
-						|| (trimmedLegacyName && Object.prototype.hasOwnProperty.call(eligibilityConfig, trimmedLegacyName))) {
+					// Check if the full legacy name is in the config
+					if (Object.prototype.hasOwnProperty.call(eligibilityConfig, legacyName)) {
 						return eligibilityConfig[legacyName];
+					}
+					// Some tools may be both renamed and namespaced from a toolset, eg: xxx/yyy -> yyy
+					if (legacyName.includes('/')) {
+						const trimmedLegacyName = legacyName.split('/').pop();
+						if (trimmedLegacyName && Object.prototype.hasOwnProperty.call(eligibilityConfig, trimmedLegacyName)) {
+							return eligibilityConfig[trimmedLegacyName];
+						}
 					}
 				}
 			}

--- a/src/vs/workbench/contrib/chat/test/browser/languageModelToolsService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/languageModelToolsService.test.ts
@@ -1388,7 +1388,7 @@ suite('LanguageModelToolsService', () => {
 	test('eligibleForAutoApproval setting controls tool eligibility', async () => {
 		// Test the new eligibleForAutoApproval setting
 		const testConfigService = new TestConfigurationService();
-		testConfigService.setUserConfiguration('chat.tools.eligibleForAutoApproval', {
+		testConfigService.setUserConfiguration(ChatConfiguration.EligibleForAutoApproval, {
 			'eligibleToolRef': true,
 			'ineligibleToolRef': false
 		});
@@ -2166,7 +2166,7 @@ suite('LanguageModelToolsService', () => {
 			'toolA': true,
 			'toolB': false
 		};
-		testConfigService.setUserConfiguration('chat.tools.eligibleForAutoApproval', policyValue);
+		testConfigService.setUserConfiguration(ChatConfiguration.EligibleForAutoApproval, policyValue);
 
 		const instaService = workbenchInstantiationService({
 			contextKeyService: () => store.add(new ContextKeyService(testConfigService)),
@@ -2223,7 +2223,7 @@ suite('LanguageModelToolsService', () => {
 	test('eligibleForAutoApproval with legacy tool reference names - eligible', async () => {
 		// Test backwards compatibility: configuring a legacy name as eligible should work
 		const testConfigService = new TestConfigurationService();
-		testConfigService.setUserConfiguration('chat.tools.eligibleForAutoApproval', {
+		testConfigService.setUserConfiguration(ChatConfiguration.EligibleForAutoApproval, {
 			'oldToolName': true  // Using legacy name
 		});
 
@@ -2259,7 +2259,7 @@ suite('LanguageModelToolsService', () => {
 	test('eligibleForAutoApproval with legacy tool reference names - ineligible', async () => {
 		// Test backwards compatibility: configuring a legacy name as ineligible should work
 		const testConfigService = new TestConfigurationService();
-		testConfigService.setUserConfiguration('chat.tools.eligibleForAutoApproval', {
+		testConfigService.setUserConfiguration(ChatConfiguration.EligibleForAutoApproval, {
 			'deprecatedToolName': false  // Using legacy name
 		});
 
@@ -2302,7 +2302,7 @@ suite('LanguageModelToolsService', () => {
 	test('eligibleForAutoApproval with multiple legacy names', async () => {
 		// Test that any of the legacy names can be used in the configuration
 		const testConfigService = new TestConfigurationService();
-		testConfigService.setUserConfiguration('chat.tools.eligibleForAutoApproval', {
+		testConfigService.setUserConfiguration(ChatConfiguration.EligibleForAutoApproval, {
 			'secondLegacyName': true  // Using the second legacy name
 		});
 
@@ -2338,7 +2338,7 @@ suite('LanguageModelToolsService', () => {
 	test('eligibleForAutoApproval current name takes precedence over legacy names', async () => {
 		// Test forward compatibility: current name in config should take precedence
 		const testConfigService = new TestConfigurationService();
-		testConfigService.setUserConfiguration('chat.tools.eligibleForAutoApproval', {
+		testConfigService.setUserConfiguration(ChatConfiguration.EligibleForAutoApproval, {
 			'currentName': false,      // Current name says ineligible
 			'oldName': true           // Legacy name says eligible
 		});
@@ -2381,7 +2381,7 @@ suite('LanguageModelToolsService', () => {
 	test('eligibleForAutoApproval with legacy full reference names from toolsets', async () => {
 		// Test legacy names that include toolset prefixes (e.g., 'oldToolSet/oldToolName')
 		const testConfigService = new TestConfigurationService();
-		testConfigService.setUserConfiguration('chat.tools.eligibleForAutoApproval', {
+		testConfigService.setUserConfiguration(ChatConfiguration.EligibleForAutoApproval, {
 			'oldToolSet/oldToolName': false  // Legacy full reference name from old toolset
 		});
 
@@ -2424,7 +2424,7 @@ suite('LanguageModelToolsService', () => {
 	test('eligibleForAutoApproval mixed current and legacy names', async () => {
 		// Test realistic migration scenario with mixed current and legacy names
 		const testConfigService = new TestConfigurationService();
-		testConfigService.setUserConfiguration('chat.tools.eligibleForAutoApproval', {
+		testConfigService.setUserConfiguration(ChatConfiguration.EligibleForAutoApproval, {
 			'modernTool': true,           // Current name
 			'legacyToolOld': false,      // Legacy name
 			'unchangedTool': true        // Tool that never changed
@@ -2496,6 +2496,199 @@ suite('LanguageModelToolsService', () => {
 			CancellationToken.None
 		);
 		assert.strictEqual(result3.content[0].value, 'unchanged executed');
+	});
+
+	test('eligibleForAutoApproval with namespaced legacy names - extension prefix', async () => {
+		// Test legacy names with extension ID prefix (e.g., 'my.extension/toolName')
+		const testConfigService = new TestConfigurationService();
+		testConfigService.setUserConfiguration(ChatConfiguration.EligibleForAutoApproval, {
+			'vscode.git/gitCommit': true  // Legacy name with extension prefix
+		});
+
+		const instaService = workbenchInstantiationService({
+			contextKeyService: () => store.add(new ContextKeyService(testConfigService)),
+			configurationService: () => testConfigService
+		}, store);
+		instaService.stub(IChatService, chatService);
+		instaService.stub(ILanguageModelToolsConfirmationService, new MockLanguageModelToolsConfirmationService());
+		const testService = store.add(instaService.createInstance(LanguageModelToolsService));
+
+		// Tool that was previously namespaced under extension but is now internal
+		const tool = registerToolForTest(testService, store, 'gitCommitTool', {
+			prepareToolInvocation: async () => ({}),
+			invoke: async () => ({ content: [{ kind: 'text', value: 'commit executed' }] })
+		}, {
+			toolReferenceName: 'commit',
+			legacyToolReferenceFullNames: ['vscode.git/gitCommit']
+		});
+
+		const sessionId = 'test-extension-prefix';
+		stubGetSession(chatService, sessionId, { requestId: 'req1' });
+
+		// Tool should be eligible via legacy extension-prefixed name
+		const result = await testService.invokeTool(
+			tool.makeDto({ test: 1 }, { sessionId }),
+			async () => 0,
+			CancellationToken.None
+		);
+		assert.strictEqual(result.content[0].value, 'commit executed');
+	});
+
+	test('eligibleForAutoApproval with namespaced legacy names - MCP server prefix', async () => {
+		const testConfigService = new TestConfigurationService();
+		testConfigService.setUserConfiguration(ChatConfiguration.EligibleForAutoApproval, {
+			'github-mcp/create_issue': false
+		});
+
+		const instaService = workbenchInstantiationService({
+			contextKeyService: () => store.add(new ContextKeyService(testConfigService)),
+			configurationService: () => testConfigService
+		}, store);
+		instaService.stub(IChatService, chatService);
+		instaService.stub(ILanguageModelToolsConfirmationService, new MockLanguageModelToolsConfirmationService());
+		const testService = store.add(instaService.createInstance(LanguageModelToolsService));
+
+		const tool = registerToolForTest(testService, store, 'createIssueTool', {
+			prepareToolInvocation: async () => ({}),
+			invoke: async () => ({ content: [{ kind: 'text', value: 'issue created' }] })
+		}, {
+			toolReferenceName: 'createIssue',
+			legacyToolReferenceFullNames: ['github-mcp/create_issue']
+		});
+
+		const sessionId = 'test-mcp-prefix';
+		const capture: { invocation?: any } = {};
+		stubGetSession(chatService, sessionId, { requestId: 'req1', capture });
+
+		const promise = testService.invokeTool(
+			tool.makeDto({ test: 1 }, { sessionId }),
+			async () => 0,
+			CancellationToken.None
+		);
+		const published = await waitForPublishedInvocation(capture);
+		assert.ok(published?.confirmationMessages, 'tool should be ineligible via legacy MCP prefix name');
+		assert.strictEqual(published?.confirmationMessages?.allowAutoConfirm, false, 'should not allow auto confirm');
+
+		IChatToolInvocation.confirmWith(published, { type: ToolConfirmKind.UserAction });
+		const result = await promise;
+		assert.strictEqual(result.content[0].value, 'issue created');
+	});
+
+	test('eligibleForAutoApproval with multiple namespaced legacy names', async () => {
+		const testConfigService = new TestConfigurationService();
+		testConfigService.setUserConfiguration(ChatConfiguration.EligibleForAutoApproval, {
+			'old-extension/oldName': true
+		});
+
+		const instaService = workbenchInstantiationService({
+			contextKeyService: () => store.add(new ContextKeyService(testConfigService)),
+			configurationService: () => testConfigService
+		}, store);
+		instaService.stub(IChatService, chatService);
+		instaService.stub(ILanguageModelToolsConfirmationService, new MockLanguageModelToolsConfirmationService());
+		const testService = store.add(instaService.createInstance(LanguageModelToolsService));
+
+		// Tool with multiple namespaced legacy names
+		const tool = registerToolForTest(testService, store, 'multiNamespacedTool', {
+			prepareToolInvocation: async () => ({}),
+			invoke: async () => ({ content: [{ kind: 'text', value: 'multi namespaced executed' }] })
+		}, {
+			toolReferenceName: 'currentToolName',
+			legacyToolReferenceFullNames: [
+				'old-extension/oldName',
+				'other-mcp/previousName',
+				'deprecated-toolset/ancientName'
+			]
+		});
+
+		const sessionId = 'test-multi-namespaced';
+		stubGetSession(chatService, sessionId, { requestId: 'req1' });
+
+		// Tool should be eligible via one of the namespaced legacy names
+		const result = await testService.invokeTool(
+			tool.makeDto({ test: 1 }, { sessionId }),
+			async () => 0,
+			CancellationToken.None
+		);
+		assert.strictEqual(result.content[0].value, 'multi namespaced executed');
+	});
+
+	test('eligibleForAutoApproval namespaced legacy name does not match partial prefix', async () => {
+		// Test that 'extension/tool' does not match 'extension' or 'tool' alone
+		const testConfigService = new TestConfigurationService();
+		testConfigService.setUserConfiguration(ChatConfiguration.EligibleForAutoApproval, {
+			'myTool': true,           // Should NOT match 'some.ext/myTool'
+			'some.ext': true          // Should NOT match 'some.ext/myTool'
+		});
+
+		const instaService = workbenchInstantiationService({
+			contextKeyService: () => store.add(new ContextKeyService(testConfigService)),
+			configurationService: () => testConfigService
+		}, store);
+		instaService.stub(IChatService, chatService);
+		instaService.stub(ILanguageModelToolsConfirmationService, new MockLanguageModelToolsConfirmationService());
+		const testService = store.add(instaService.createInstance(LanguageModelToolsService));
+
+		// Tool with namespaced legacy name
+		const tool = registerToolForTest(testService, store, 'partialMatchTool', {
+			prepareToolInvocation: async () => ({}),
+			invoke: async () => ({ content: [{ kind: 'text', value: 'partial match test' }] })
+		}, {
+			toolReferenceName: 'newToolName',
+			legacyToolReferenceFullNames: ['some.ext/myTool']
+		});
+
+		const sessionId = 'test-partial-match';
+		const capture: { invocation?: any } = {};
+		stubGetSession(chatService, sessionId, { requestId: 'req1', capture });
+
+		// Tool should NOT be eligible because neither 'myTool' nor 'some.ext' matches 'some.ext/myTool'
+		const promise = testService.invokeTool(
+			tool.makeDto({ test: 1 }, { sessionId }),
+			async () => 0,
+			CancellationToken.None
+		);
+		const published = await waitForPublishedInvocation(capture);
+		assert.ok(published?.confirmationMessages, 'partial prefix should not match namespaced legacy name');
+
+		IChatToolInvocation.confirmWith(published, { type: ToolConfirmKind.UserAction });
+		const result = await promise;
+		assert.strictEqual(result.content[0].value, 'partial match test');
+	});
+
+	test('eligibleForAutoApproval with deeply nested namespaced legacy names', async () => {
+		// Test legacy names with multiple levels of namespacing (e.g., 'org/toolset/tool')
+		const testConfigService = new TestConfigurationService();
+		testConfigService.setUserConfiguration(ChatConfiguration.EligibleForAutoApproval, {
+			'github.copilot/codeActions/extract_function': true
+		});
+
+		const instaService = workbenchInstantiationService({
+			contextKeyService: () => store.add(new ContextKeyService(testConfigService)),
+			configurationService: () => testConfigService
+		}, store);
+		instaService.stub(IChatService, chatService);
+		instaService.stub(ILanguageModelToolsConfirmationService, new MockLanguageModelToolsConfirmationService());
+		const testService = store.add(instaService.createInstance(LanguageModelToolsService));
+
+		const tool = registerToolForTest(testService, store, 'extractFunctionTool', {
+			prepareToolInvocation: async () => ({}),
+			invoke: async () => ({ content: [{ kind: 'text', value: 'extract function executed' }] })
+		}, {
+			toolReferenceName: 'extractFunction',
+			legacyToolReferenceFullNames: ['github.copilot/codeActions/extract_function']
+		});
+
+		const sessionId = 'test-deeply-nested';
+		stubGetSession(chatService, sessionId, { requestId: 'req1' });
+
+		// Tool should be eligible via deeply nested legacy name
+		const result = await testService.invokeTool(
+			tool.makeDto({ test: 1 }, { sessionId }),
+			async () => 0,
+			CancellationToken.None
+		);
+		assert.strictEqual(result.content[0].value, 'extract function executed');
 	});
 
 

--- a/src/vs/workbench/contrib/chat/test/browser/languageModelToolsService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/languageModelToolsService.test.ts
@@ -2521,6 +2521,7 @@ suite('LanguageModelToolsService', () => {
 		});
 
 		const sessionId = 'test-extension-prefix';
+		const capture: { invocation?: any } = {};
 		stubGetSession(chatService, sessionId, { requestId: 'req1' });
 
 		// Tool should be eligible via legacy extension-prefixed name
@@ -2529,6 +2530,9 @@ suite('LanguageModelToolsService', () => {
 			async () => 0,
 			CancellationToken.None
 		);
+
+		const published = await waitForPublishedInvocation(capture);
+		assert.strictEqual(published, undefined, 'tool should not require confirmation when legacy trimmed name is eligible');
 		assert.strictEqual(result.content[0].value, 'commit executed');
 	});
 
@@ -2556,6 +2560,7 @@ suite('LanguageModelToolsService', () => {
 		});
 
 		const sessionId = 'test-renamed-prefix';
+		const capture: { invocation?: any } = {};
 		stubGetSession(chatService, sessionId, { requestId: 'req1' });
 
 		// Tool should be eligible via legacy extension-prefixed name
@@ -2564,6 +2569,9 @@ suite('LanguageModelToolsService', () => {
 			async () => 0,
 			CancellationToken.None
 		);
+
+		const published = await waitForPublishedInvocation(capture);
+		assert.strictEqual(published, undefined, 'tool should not require confirmation when legacy trimmed name is eligible');
 		assert.strictEqual(result.content[0].value, 'commit executed');
 	});
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

ref https://github.com/microsoft/vscode-internalbacklog/issues/6465