### PR TITLE
For post confirm actions do not include url query strings.

### DIFF
--- a/src/vs/workbench/contrib/chat/common/chatUrlFetchingConfirmation.ts
+++ b/src/vs/workbench/contrib/chat/common/chatUrlFetchingConfirmation.ts
@@ -87,10 +87,13 @@ export class ChatUrlFetchingConfirmationContribution implements ILanguageModelTo
 			return [];
 		}
 
+		//remove query strings
+		const urlsWithoutQuery = urls.map(u => u.split('?')[0]);
+
 		const actions: ILanguageModelToolConfirmationActions[] = [];
 
 		// Get unique URLs (may have duplicates)
-		const uniqueUrls = Array.from(new Set(urls)).map(u => URI.parse(u));
+		const uniqueUrls = Array.from(new Set(urlsWithoutQuery)).map(u => URI.parse(u));
 
 		// For each URL, get its patterns
 		const urlPatterns = new ResourceMap<string[]>(uniqueUrls.map(u => [u, extractUrlPatterns(u)] as const));


### PR DESCRIPTION
fixes #280723
Before fix:
<img width="1055" height="434" alt="image" src="https://github.com/user-attachments/assets/0a13b24a-7311-4ae7-ad86-8898bc8a92cf" />


After fix:

<img width="531" height="499" alt="image" src="https://github.com/user-attachments/assets/e11badd3-b29e-457c-8f75-d60a74ca876e" />

<img width="838" height="201" alt="image" src="https://github.com/user-attachments/assets/c5182c77-5608-4e7e-9ca1-2a2d02f62d7c" />


