### PR TITLE
refactor, consolidate terminal command mirrors

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart.ts
@@ -19,7 +19,7 @@ import { BaseChatToolInvocationSubPart } from './chatToolInvocationSubPart.js';
 import '../media/chatTerminalToolProgressPart.css';
 import type { ICodeBlockRenderOptions } from '../../codeBlockPart.js';
 import { Action, IAction } from '../../../../../../base/common/actions.js';
-import { IChatTerminalToolProgressPart, ITerminalChatService, ITerminalConfigurationService, ITerminalEditorService, ITerminalGroupService, ITerminalInstance, ITerminalService, type IDetachedTerminalInstance } from '../../../../terminal/browser/terminal.js';
+import { IChatTerminalToolProgressPart, ITerminalChatService, ITerminalConfigurationService, ITerminalEditorService, ITerminalGroupService, ITerminalInstance, ITerminalService } from '../../../../terminal/browser/terminal.js';
 import { Disposable, MutableDisposable, toDisposable, type IDisposable } from '../../../../../../base/common/lifecycle.js';
 import { Emitter } from '../../../../../../base/common/event.js';
 import { ThemeIcon } from '../../../../../../base/common/themables.js';
@@ -39,16 +39,13 @@ import { AccessibilityVerbositySettingId } from '../../../../accessibility/brows
 import { ChatContextKeys } from '../../../common/chatContextKeys.js';
 import { EditorPool } from '../chatContentCodePools.js';
 import { IKeybindingService } from '../../../../../../platform/keybinding/common/keybinding.js';
-import { DetachedTerminalCommandMirror } from '../../../../terminal/browser/chatTerminalCommandMirror.js';
-import { DetachedProcessInfo } from '../../../../terminal/browser/detachedTerminal.js';
+import { DetachedTerminalCommandMirror, DetachedTerminalSnapshotMirror } from '../../../../terminal/browser/chatTerminalCommandMirror.js';
 import { TerminalLocation } from '../../../../../../platform/terminal/common/terminal.js';
 import { Codicon } from '../../../../../../base/common/codicons.js';
 import { TerminalContribCommandId } from '../../../../terminal/terminalContribExports.js';
 import { ITelemetryService } from '../../../../../../platform/telemetry/common/telemetry.js';
 import { isNumber } from '../../../../../../base/common/types.js';
 import { removeAnsiEscapeCodes } from '../../../../../../base/common/strings.js';
-import { Color } from '../../../../../../base/common/color.js';
-import { TERMINAL_BACKGROUND_COLOR } from '../../../../terminal/common/terminalColorRegistry.js';
 import { PANEL_BACKGROUND } from '../../../../../common/theme.js';
 import { editorBackground } from '../../../../../../platform/theme/common/colorRegistry.js';
 import { IThemeService } from '../../../../../../platform/theme/common/themeService.js';
@@ -1018,129 +1015,6 @@ class ChatTerminalToolOutputSection extends Disposable {
 		if (backgroundColor) {
 			this.domNode.style.backgroundColor = backgroundColor.toString();
 		}
-	}
-}
-
-class DetachedTerminalSnapshotMirror extends Disposable {
-	private _detachedTerminal: Promise<IDetachedTerminalInstance> | undefined;
-	private _output: IChatTerminalToolInvocationData['terminalCommandOutput'] | undefined;
-	private _attachedContainer: HTMLElement | undefined;
-	private _container: HTMLElement | undefined;
-	private _dirty = true;
-	private _lastRenderedLineCount: number | undefined;
-
-	constructor(
-		output: IChatTerminalToolInvocationData['terminalCommandOutput'] | undefined,
-		private readonly _getTheme: () => IChatTerminalToolInvocationData['terminalTheme'] | undefined,
-		@ITerminalService private readonly _terminalService: ITerminalService,
-		@IContextKeyService private readonly _contextKeyService: IContextKeyService,
-	) {
-		super();
-		this._output = output;
-	}
-
-	public setOutput(output: IChatTerminalToolInvocationData['terminalCommandOutput'] | undefined): void {
-		this._output = output;
-		this._dirty = true;
-	}
-
-	public async attach(container: HTMLElement): Promise<void> {
-		const terminal = await this._getTerminal();
-		container.classList.add('chat-terminal-output-terminal');
-		if (this._attachedContainer !== container || container.firstChild === null) {
-			terminal.attachToElement(container);
-			this._attachedContainer = container;
-		}
-		this._container = container;
-		this._applyTheme(container);
-	}
-
-	public async render(): Promise<{ lineCount?: number } | undefined> {
-		const output = this._output;
-		if (!output) {
-			return undefined;
-		}
-		if (!this._dirty) {
-			return { lineCount: this._lastRenderedLineCount ?? output.lineCount };
-		}
-		const terminal = await this._getTerminal();
-		terminal.xterm.clearBuffer();
-		terminal.xterm.clearSearchDecorations?.();
-		if (this._container) {
-			this._applyTheme(this._container);
-		}
-		const text = output.text ?? '';
-		const lineCount = output.lineCount ?? this._estimateLineCount(text);
-		if (!text) {
-			this._dirty = false;
-			this._lastRenderedLineCount = lineCount;
-			return { lineCount: 0 };
-		}
-		await new Promise<void>(resolve => terminal.xterm.write(text, resolve));
-		this._dirty = false;
-		this._lastRenderedLineCount = lineCount;
-		return { lineCount };
-	}
-
-	private _estimateLineCount(text: string): number {
-		if (!text) {
-			return 0;
-		}
-		const sanitized = text.replace(/\r/g, '');
-		const segments = sanitized.split('\n');
-		const count = sanitized.endsWith('\n') ? segments.length - 1 : segments.length;
-		return Math.max(count, 1);
-	}
-
-	private _applyTheme(container: HTMLElement): void {
-		const theme = this._getTheme();
-		if (!theme) {
-			container.style.removeProperty('background-color');
-			container.style.removeProperty('color');
-			return;
-		}
-		if (theme.background) {
-			container.style.backgroundColor = theme.background;
-		}
-		if (theme.foreground) {
-			container.style.color = theme.foreground;
-		}
-	}
-
-	private async _getTerminal(): Promise<IDetachedTerminalInstance> {
-		if (!this._detachedTerminal) {
-			this._detachedTerminal = this._createTerminal();
-		}
-		return this._detachedTerminal;
-	}
-
-	private async _createTerminal(): Promise<IDetachedTerminalInstance> {
-		const terminal = await this._terminalService.createDetachedTerminal({
-			cols: 80,
-			rows: 10,
-			readonly: true,
-			processInfo: new DetachedProcessInfo({ initialCwd: '' }),
-			disableOverviewRuler: true,
-			colorProvider: {
-				getBackgroundColor: theme => {
-					const storedBackground = this._getTheme()?.background;
-					if (storedBackground) {
-						const color = Color.fromHex(storedBackground);
-						if (color) {
-							return color;
-						}
-					}
-					const terminalBackground = theme.getColor(TERMINAL_BACKGROUND_COLOR);
-					if (terminalBackground) {
-						return terminalBackground;
-					}
-					// Use editor background when in chat editor, panel background otherwise
-					const isInEditor = ChatContextKeys.inChatEditor.getValue(this._contextKeyService);
-					return theme.getColor(isInEditor ? editorBackground : PANEL_BACKGROUND);
-				}
-			}
-		});
-		return this._register(terminal);
 	}
 }
 

--- a/src/vs/workbench/contrib/terminal/browser/chatTerminalCommandMirror.ts
+++ b/src/vs/workbench/contrib/terminal/browser/chatTerminalCommandMirror.ts
@@ -15,6 +15,57 @@ import { PANEL_BACKGROUND } from '../../../common/theme.js';
 import { IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
 import { ChatContextKeys } from '../../chat/common/chatContextKeys.js';
 import { editorBackground } from '../../../../platform/theme/common/colorRegistry.js';
+import { Color } from '../../../../base/common/color.js';
+import type { IChatTerminalToolInvocationData } from '../../chat/common/chatService.js';
+import type { IColorTheme } from '../../../../platform/theme/common/themeService.js';
+
+function getChatTerminalBackgroundColor(theme: IColorTheme, contextKeyService: IContextKeyService, storedBackground?: string): Color | undefined {
+	if (storedBackground) {
+		const color = Color.fromHex(storedBackground);
+		if (color) {
+			return color;
+		}
+	}
+
+	const terminalBackground = theme.getColor(TERMINAL_BACKGROUND_COLOR);
+	if (terminalBackground) {
+		return terminalBackground;
+	}
+
+	const isInEditor = ChatContextKeys.inChatEditor.getValue(contextKeyService);
+	return theme.getColor(isInEditor ? editorBackground : PANEL_BACKGROUND);
+}
+
+/**
+ * Base class for detached terminal mirrors.
+ * Handles attaching to containers and managing the detached terminal instance.
+ */
+abstract class DetachedTerminalMirror extends Disposable {
+	private _detachedTerminal: Promise<IDetachedTerminalInstance> | undefined;
+	private _attachedContainer: HTMLElement | undefined;
+
+	protected _setDetachedTerminal(detachedTerminal: Promise<IDetachedTerminalInstance>): void {
+		this._detachedTerminal = detachedTerminal.then(terminal => this._register(terminal));
+	}
+
+	protected async _getTerminal(): Promise<IDetachedTerminalInstance> {
+		if (!this._detachedTerminal) {
+			throw new Error('Detached terminal not initialized');
+		}
+		return this._detachedTerminal;
+	}
+
+	protected async _attachToContainer(container: HTMLElement): Promise<IDetachedTerminalInstance> {
+		const terminal = await this._getTerminal();
+		container.classList.add('chat-terminal-output-terminal');
+		const needsAttach = this._attachedContainer !== container || container.firstChild === null;
+		if (needsAttach) {
+			terminal.attachToElement(container);
+			this._attachedContainer = container;
+		}
+		return terminal;
+	}
+}
 
 export async function getCommandOutputSnapshot(
 	xtermTerminal: XtermTerminal,
@@ -91,10 +142,7 @@ interface IDetachedTerminalCommandMirror {
  * Mirrors a terminal command's output into a detached terminal instance.
  * Used in the chat terminal tool progress part to show command output for example.
  */
-export class DetachedTerminalCommandMirror extends Disposable implements IDetachedTerminalCommandMirror {
-	private _detachedTerminal: Promise<IDetachedTerminalInstance>;
-	private _attachedContainer?: HTMLElement;
-
+export class DetachedTerminalCommandMirror extends DetachedTerminalMirror implements IDetachedTerminalCommandMirror {
 	constructor(
 		private readonly _xtermTerminal: XtermTerminal,
 		private readonly _command: ITerminalCommand,
@@ -102,17 +150,23 @@ export class DetachedTerminalCommandMirror extends Disposable implements IDetach
 		@IContextKeyService private readonly _contextKeyService: IContextKeyService,
 	) {
 		super();
-		this._detachedTerminal = this._createTerminal();
+		const processInfo = this._register(new DetachedProcessInfo({ initialCwd: '' }));
+		const capabilities = this._register(new TerminalCapabilityStore());
+		this._setDetachedTerminal(this._terminalService.createDetachedTerminal({
+			cols: this._xtermTerminal.raw!.cols,
+			rows: 10,
+			readonly: true,
+			processInfo,
+			disableOverviewRuler: true,
+			capabilities,
+			colorProvider: {
+				getBackgroundColor: theme => getChatTerminalBackgroundColor(theme, this._contextKeyService),
+			},
+		}));
 	}
 
 	async attach(container: HTMLElement): Promise<void> {
-		const terminal = await this._detachedTerminal;
-		container.classList.add('chat-terminal-output-terminal');
-		const needsAttach = this._attachedContainer !== container || container.firstChild === null;
-		if (needsAttach) {
-			terminal.attachToElement(container);
-			this._attachedContainer = container;
-		}
+		await this._attachToContainer(container);
 	}
 
 	async renderCommand(): Promise<{ lineCount?: number } | undefined> {
@@ -123,7 +177,7 @@ export class DetachedTerminalCommandMirror extends Disposable implements IDetach
 		if (!vt.text) {
 			return { lineCount: 0 };
 		}
-		const detached = await this._detachedTerminal;
+		const detached = await this._getTerminal();
 		detached.xterm.clearBuffer();
 		detached.xterm.clearSearchDecorations?.();
 		await new Promise<void>(resolve => {
@@ -131,30 +185,102 @@ export class DetachedTerminalCommandMirror extends Disposable implements IDetach
 		});
 		return { lineCount: vt.lineCount };
 	}
+}
 
-	private async _createTerminal(): Promise<IDetachedTerminalInstance> {
+/**
+ * Mirrors a terminal output snapshot into a detached terminal instance.
+ * Used when the terminal has been disposed of but we still want to show the output.
+ */
+export class DetachedTerminalSnapshotMirror extends DetachedTerminalMirror {
+	private _output: IChatTerminalToolInvocationData['terminalCommandOutput'] | undefined;
+	private _container: HTMLElement | undefined;
+	private _dirty = true;
+	private _lastRenderedLineCount: number | undefined;
+
+	constructor(
+		output: IChatTerminalToolInvocationData['terminalCommandOutput'] | undefined,
+		private readonly _getTheme: () => IChatTerminalToolInvocationData['terminalTheme'] | undefined,
+		@ITerminalService private readonly _terminalService: ITerminalService,
+		@IContextKeyService private readonly _contextKeyService: IContextKeyService,
+	) {
+		super();
+		this._output = output;
 		const processInfo = this._register(new DetachedProcessInfo({ initialCwd: '' }));
-		const capabilities = this._register(new TerminalCapabilityStore());
-		const detached = await this._terminalService.createDetachedTerminal({
-			cols: this._xtermTerminal.raw!.cols,
+		this._setDetachedTerminal(this._terminalService.createDetachedTerminal({
+			cols: 80,
 			rows: 10,
 			readonly: true,
 			processInfo,
 			disableOverviewRuler: true,
-			capabilities,
 			colorProvider: {
 				getBackgroundColor: theme => {
-					const terminalBackground = theme.getColor(TERMINAL_BACKGROUND_COLOR);
-					if (terminalBackground) {
-						return terminalBackground;
-					}
-					// Use editor background when in chat editor, panel background otherwise
-					const isInEditor = ChatContextKeys.inChatEditor.getValue(this._contextKeyService);
-					return theme.getColor(isInEditor ? editorBackground : PANEL_BACKGROUND);
-				},
+					const storedBackground = this._getTheme()?.background;
+					return getChatTerminalBackgroundColor(theme, this._contextKeyService, storedBackground);
+				}
 			}
-		});
-		return this._register(detached);
+		}));
 	}
 
+	public setOutput(output: IChatTerminalToolInvocationData['terminalCommandOutput'] | undefined): void {
+		this._output = output;
+		this._dirty = true;
+	}
+
+	public async attach(container: HTMLElement): Promise<void> {
+		await this._attachToContainer(container);
+		this._container = container;
+		this._applyTheme(container);
+	}
+
+	public async render(): Promise<{ lineCount?: number } | undefined> {
+		const output = this._output;
+		if (!output) {
+			return undefined;
+		}
+		if (!this._dirty) {
+			return { lineCount: this._lastRenderedLineCount ?? output.lineCount };
+		}
+		const terminal = await this._getTerminal();
+		terminal.xterm.clearBuffer();
+		terminal.xterm.clearSearchDecorations?.();
+		if (this._container) {
+			this._applyTheme(this._container);
+		}
+		const text = output.text ?? '';
+		const lineCount = output.lineCount ?? this._estimateLineCount(text);
+		if (!text) {
+			this._dirty = false;
+			this._lastRenderedLineCount = lineCount;
+			return { lineCount: 0 };
+		}
+		await new Promise<void>(resolve => terminal.xterm.write(text, resolve));
+		this._dirty = false;
+		this._lastRenderedLineCount = lineCount;
+		return { lineCount };
+	}
+
+	private _estimateLineCount(text: string): number {
+		if (!text) {
+			return 0;
+		}
+		const sanitized = text.replace(/\r/g, '');
+		const segments = sanitized.split('\n');
+		const count = sanitized.endsWith('\n') ? segments.length - 1 : segments.length;
+		return Math.max(count, 1);
+	}
+
+	private _applyTheme(container: HTMLElement): void {
+		const theme = this._getTheme();
+		if (!theme) {
+			container.style.removeProperty('background-color');
+			container.style.removeProperty('color');
+			return;
+		}
+		if (theme.background) {
+			container.style.backgroundColor = theme.background;
+		}
+		if (theme.foreground) {
+			container.style.color = theme.foreground;
+		}
+	}
 }


### PR DESCRIPTION
fixes #281012

cc @tyriar

- Moves the `snapshotMirror` to the `mirror` file. 
- Extracts shared functions between `snapshotMirror` and `commandMirror` into an abstract class