### PR TITLE
check the end part of `legacyToolReferenceFullNames` when evaluating `EligibleForAutoApproval`

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/languageModelToolsService.ts
+++ b/src/vs/workbench/contrib/chat/browser/languageModelToolsService.ts
@@ -613,13 +613,20 @@ export class LanguageModelToolsService extends Disposable implements ILanguageMo
 			// Back compat with legacy names
 			if (toolData.legacyToolReferenceFullNames) {
 				for (const legacyName of toolData.legacyToolReferenceFullNames) {
+					// Check if the full legacy name is in the config
 					if (Object.prototype.hasOwnProperty.call(eligibilityConfig, legacyName)) {
 						return eligibilityConfig[legacyName];
+					}
+					// Some tools may be both renamed and namespaced from a toolset, eg: xxx/yyy -> yyy
+					if (legacyName.includes('/')) {
+						const trimmedLegacyName = legacyName.split('/').pop();
+						if (trimmedLegacyName && Object.prototype.hasOwnProperty.call(eligibilityConfig, trimmedLegacyName)) {
+							return eligibilityConfig[trimmedLegacyName];
+						}
 					}
 				}
 			}
 		}
-		// Default true
 		return true;
 	}
 


### PR DESCRIPTION
main pr #283887
ref https://github.com/microsoft/vscode-internalbacklog/issues/6465