### PR TITLE
Fix typos in comments and strings across workbench

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatAttachmentWidgets.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatAttachmentWidgets.ts
@@ -820,7 +820,7 @@ export class NotebookCellOutputChatAttachmentWidget extends AbstractChatAttachme
 	private renderImageOutput(resource: URI, attachment: INotebookOutputVariableEntry) {
 		let ariaLabel: string;
 		if (attachment.omittedState === OmittedState.Full) {
-			ariaLabel = localize('chat.omittedNotebookImageAttachment', "Omitted this Notebook ouput: {0}", attachment.name);
+			ariaLabel = localize('chat.omittedNotebookImageAttachment', "Omitted this Notebook output: {0}", attachment.name);
 		} else if (attachment.omittedState === OmittedState.Partial) {
 			ariaLabel = localize('chat.partiallyOmittedNotebookImageAttachment', "Partially omitted this Notebook output: {0}", attachment.name);
 		} else {

--- a/src/vs/workbench/contrib/debug/browser/debugService.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugService.ts
@@ -589,7 +589,7 @@ export class DebugService implements IDebugService {
 
 				const result = await this.doCreateSession(sessionId, launch?.workspace, { resolved: resolvedConfig, unresolved: unresolvedConfig }, options, userConfirmedConcurrentSession);
 				if (result && guess && activeEditor && activeEditor.resource) {
-					// Remeber user choice of environment per active editor to make starting debugging smoother #124770
+					// Remember user choice of environment per active editor to make starting debugging smoother #124770
 					this.chosenEnvironments[activeEditor.resource.toString()] = { type: guess.debugger.type, dynamicLabel: guess.withConfig?.label };
 					this.debugStorage.storeChosenEnvironments(this.chosenEnvironments);
 				}

--- a/src/vs/workbench/contrib/debug/browser/debugSession.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugSession.ts
@@ -1219,7 +1219,7 @@ export class DebugSession implements IDebugSession {
 					return;
 				}
 
-				// Make sure to append output in the correct order by properly waiting on preivous promises #33822
+				// Make sure to append output in the correct order by properly waiting on previous promises #33822
 				const source = event.body.source && event.body.line ? {
 					lineNumber: event.body.line,
 					column: event.body.column ? event.body.column : 1,
@@ -1490,7 +1490,7 @@ export class DebugSession implements IDebugSession {
 	private shutdown(): void {
 		this.rawListeners.clear();
 		if (this.raw) {
-			// Send out disconnect and immediatly dispose (do not wait for response) #127418
+			// Send out disconnect and immediately dispose (do not wait for response) #127418
 			this.raw.disconnect({});
 			this.raw.dispose();
 			this.raw = undefined;

--- a/src/vs/workbench/contrib/debug/common/debugModel.ts
+++ b/src/vs/workbench/contrib/debug/common/debugModel.ts
@@ -916,7 +916,7 @@ export abstract class BaseBreakpoint extends Enablement implements IBaseBreakpoi
 		const allData = Array.from(this.sessionData.values());
 		const verifiedData = distinct(allData.filter(d => d.verified), d => `${d.line}:${d.column}`);
 		if (verifiedData.length) {
-			// In case multiple session verified the breakpoint and they provide different data show the intial data that the user set (corner case)
+			// In case multiple session verified the breakpoint and they provide different data show the initial data that the user set (corner case)
 			this.data = verifiedData.length === 1 ? verifiedData[0] : undefined;
 		} else {
 			// No session verified the breakpoint

--- a/src/vs/workbench/contrib/files/browser/explorerViewlet.ts
+++ b/src/vs/workbench/contrib/files/browser/explorerViewlet.ts
@@ -198,7 +198,7 @@ export class ExplorerViewPaneContainer extends ViewPaneContainer {
 							const config = this.configurationService.getValue<IFilesConfiguration>();
 							if (config.workbench?.editor?.enablePreview) {
 								// delay open editors view when preview is enabled
-								// to accomodate for the user doing a double click
+								// to accommodate for the user doing a double click
 								// to pin the editor.
 								// without this delay a double click would be not
 								// possible because the next element would move

--- a/src/vs/workbench/contrib/notebook/browser/services/notebookServiceImpl.ts
+++ b/src/vs/workbench/contrib/notebook/browser/services/notebookServiceImpl.ts
@@ -836,7 +836,7 @@ export class NotebookService extends Disposable implements INotebookService {
 		}
 	}
 
-	// --- notebook documents: create, destory, retrieve, enumerate
+	// --- notebook documents: create, destroy, retrieve, enumerate
 
 	async createNotebookTextModel(viewType: string, uri: URI, stream?: VSBufferReadableStream): Promise<NotebookTextModel> {
 		if (this._models.has(uri)) {

--- a/src/vs/workbench/contrib/notebook/common/notebookEditorModelResolverServiceImpl.ts
+++ b/src/vs/workbench/contrib/notebook/common/notebookEditorModelResolverServiceImpl.ts
@@ -148,7 +148,7 @@ class NotebookModelReferenceCollection extends ReferenceCollection<Promise<IReso
 				this._modelListener.delete(model);
 				model.dispose();
 			} catch (err) {
-				this._notebookLoggingService.error('NotebookModelCollection', 'FAILED to destory notebook - ' + err);
+				this._notebookLoggingService.error('NotebookModelCollection', 'FAILED to destroy notebook - ' + err);
 			} finally {
 				this.modelsToDispose.delete(key); // Untrack as being disposed
 			}

--- a/src/vs/workbench/contrib/scm/browser/scmHistoryViewPane.ts
+++ b/src/vs/workbench/contrib/scm/browser/scmHistoryViewPane.ts
@@ -2111,7 +2111,7 @@ export class SCMHistoryViewPane extends ViewPane {
 
 			const historyItemRefMenuItems = MenuRegistry.getMenuItems(MenuId.SCMHistoryItemRefContext).filter(item => isIMenuItem(item));
 
-			// If there are any history item references we have to add a submenu item for each orignal action,
+			// If there are any history item references we have to add a submenu item for each original action,
 			// and a menu item for each history item ref that matches the `when` clause of the original action.
 			if (historyItemRefMenuItems.length > 0 && element.historyItemViewModel.historyItem.references?.length) {
 				const historyItemRefActions = new Map<string, ISCMHistoryItemRef[]>();

--- a/src/vs/workbench/contrib/terminalContrib/suggest/browser/lspTerminalModelContentProvider.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/browser/lspTerminalModelContentProvider.ts
@@ -52,7 +52,7 @@ export class LspTerminalModelContentProvider extends Disposable implements ILspT
 
 	/**
 	 * Sets or updates content for a terminal virtual document.
-	 * This is when user has executed succesful command in terminal.
+	 * This is when user has executed successful command in terminal.
 	 * Transfer the content to virtual document, and relocate delimiter to get terminal prompt ready for next prompt.
 	 */
 	setContent(content: string): void {


### PR DESCRIPTION
Fixed various typos in comments, log messages, and aria-labels found in `src/vs/workbench`.

Corrections include:
- `destory` -> `destroy`
- `immediatly` -> `immediately`
- `preivous` -> `previous`
- `Remeber` -> `Remember`
- `ouput` -> `output`
- `succesful` -> `successful`
- `accomodate` -> `accommodate`
- `orignal` -> `original`

No logic changes were made.