### PR TITLE
Add some padding to align checkboxes when tree items have no children

### DIFF
--- a/src/vs/platform/quickinput/browser/media/quickInput.css
+++ b/src/vs/platform/quickinput/browser/media/quickInput.css
@@ -395,6 +395,10 @@
 	display: none !important;
 }
 
+.quick-input-tree.quick-input-tree-flat .monaco-checkbox {
+	margin-left: 6px;
+}
+
 .quick-input-tree .quick-input-tree-entry {
 	box-sizing: border-box;
 	overflow: hidden;


### PR DESCRIPTION
Fixes #259879