### PR TITLE
remote: fix connection listener leak

### DIFF
--- a/src/vs/workbench/services/extensions/browser/extensionService.ts
+++ b/src/vs/workbench/services/extensions/browser/extensionService.ts
@@ -193,12 +193,12 @@ export class ExtensionService extends AbstractExtensionService implements IExten
 		// monitor for breakage
 		const connection = this._remoteAgentService.getConnection();
 		if (connection) {
-			connection.onDidStateChange(async (e) => {
+			this._register(connection.onDidStateChange(async (e) => {
 				if (e.type === PersistentConnectionEventType.ConnectionLost) {
 					this._remoteAuthorityResolverService._clearResolvedAuthority(remoteAuthority);
 				}
-			});
-			connection.onReconnecting(() => this._resolveAuthorityAgain());
+			}));
+			this._register(connection.onReconnecting(() => this._resolveAuthorityAgain()));
 		}
 
 		return this._resolveExtensionsDefault(emitter);


### PR DESCRIPTION
This function is only called though AbstractExtensionService._initialize once, so registering to the instance is fine.

Closes #247610

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
