### PR TITLE
debug: fix webview debugging breaking with >256KB messages

### DIFF
--- a/src/vs/platform/debug/electron-main/extensionHostDebugIpc.ts
+++ b/src/vs/platform/debug/electron-main/extensionHostDebugIpc.ts
@@ -84,6 +84,7 @@ export class ElectronExtensionHostDebugBroadcastChannel<TContext> extends Extens
 			}
 			const upgraded = upgradeToISocket(req, socket as Socket, {
 				debugLabel: 'extension-host-cdp-' + generateUuid(),
+				enableMessageSplitting: false,
 			});
 
 			if (upgraded) {


### PR DESCRIPTION
Closes #273661

The WebSocket implementation was splitting messages in 256KB chunks. This was fine for normal renderer<->server protocol which is streaming and naive to the websocket's message boundaries, but not to debugging.

btw @alexdima I think this method is not really ideal -- websockets support [fragmentation](https://datatracker.ietf.org/doc/html/rfc6455#section-5.4) which allow a large message to be made of multiple smaller parts without losing semantics.