### PR TITLE
Update agent session section label colors for focus and selection states

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/agentSessions/media/agentsessionsviewer.css
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/media/agentsessionsviewer.css
@@ -246,4 +246,13 @@
 			display: block;
 		}
 	}
+
+	.monaco-list:focus .monaco-list-row.focused.selected .agent-session-section-label,
+	.monaco-list:focus .monaco-list-row.selected .agent-session-section-label {
+		color: var(--vscode-list-activeSelectionForeground);
+	}
+
+	.monaco-list:not(:focus) .monaco-list-row.selected .agent-session-section-label {
+		color: var(--vscode-list-inactiveSelectionForeground);
+	}
 }


### PR DESCRIPTION
Enhance the visibility of agent session section labels by updating their colors for focus and selection states. This change improves user experience by providing clearer feedback on selected items. Test the changes by navigating to the agent session section and observing the label color changes during focus and selection.

