### PR TITLE
Add editorBracketMatch-foreground color setting

### DIFF
--- a/build/lib/stylelint/vscode-known-variables.json
+++ b/build/lib/stylelint/vscode-known-variables.json
@@ -203,6 +203,7 @@
 		"--vscode-editorBracketHighlight-unexpectedBracket-foreground",
 		"--vscode-editorBracketMatch-background",
 		"--vscode-editorBracketMatch-border",
+		"--vscode-editorBracketMatch-foreground",
 		"--vscode-editorBracketPairGuide-activeBackground1",
 		"--vscode-editorBracketPairGuide-activeBackground2",
 		"--vscode-editorBracketPairGuide-activeBackground3",

--- a/src/vs/editor/common/core/editorColorRegistry.ts
+++ b/src/vs/editor/common/core/editorColorRegistry.ts
@@ -55,6 +55,7 @@ export const editorCodeLensForeground = registerColor('editorCodeLens.foreground
 
 export const editorBracketMatchBackground = registerColor('editorBracketMatch.background', { dark: '#0064001a', light: '#0064001a', hcDark: '#0064001a', hcLight: '#0000' }, nls.localize('editorBracketMatchBackground', 'Background color behind matching brackets'));
 export const editorBracketMatchBorder = registerColor('editorBracketMatch.border', { dark: '#888', light: '#B9B9B9', hcDark: contrastBorder, hcLight: contrastBorder }, nls.localize('editorBracketMatchBorder', 'Color for matching brackets boxes'));
+export const editorBracketMatchForeground = registerColor('editorBracketMatch.foreground', null, nls.localize('editorBracketMatchForeground', 'Foreground color for matching brackets'));
 
 export const editorOverviewRulerBorder = registerColor('editorOverviewRuler.border', { dark: '#7f7f7f4d', light: '#7f7f7f4d', hcDark: '#7f7f7f4d', hcLight: '#666666' }, nls.localize('editorOverviewRulerBorder', 'Color of the overview ruler border.'));
 export const editorOverviewRulerBackground = registerColor('editorOverviewRuler.background', null, nls.localize('editorOverviewRulerBackground', 'Background color of the editor overview ruler.'));

--- a/src/vs/editor/contrib/bracketMatching/browser/bracketMatching.css
+++ b/src/vs/editor/contrib/bracketMatching/browser/bracketMatching.css
@@ -7,5 +7,4 @@
 	box-sizing: border-box;
 	background-color: var(--vscode-editorBracketMatch-background);
 	border: 1px solid var(--vscode-editorBracketMatch-border);
-	color: var(--vscode-editorBracketMatch-foreground);
 }

--- a/src/vs/editor/contrib/bracketMatching/browser/bracketMatching.css
+++ b/src/vs/editor/contrib/bracketMatching/browser/bracketMatching.css
@@ -7,4 +7,5 @@
 	box-sizing: border-box;
 	background-color: var(--vscode-editorBracketMatch-background);
 	border: 1px solid var(--vscode-editorBracketMatch-border);
+	color: var(--vscode-editorBracketMatch-foreground);
 }

--- a/src/vs/editor/contrib/bracketMatching/browser/bracketMatching.ts
+++ b/src/vs/editor/contrib/bracketMatching/browser/bracketMatching.ts
@@ -21,7 +21,8 @@ import * as nls from '../../../../nls.js';
 import { MenuId, MenuRegistry } from '../../../../platform/actions/common/actions.js';
 import { KeybindingWeight } from '../../../../platform/keybinding/common/keybindingsRegistry.js';
 import { registerColor } from '../../../../platform/theme/common/colorRegistry.js';
-import { themeColorFromId } from '../../../../platform/theme/common/themeService.js';
+import { registerThemingParticipant, themeColorFromId } from '../../../../platform/theme/common/themeService.js';
+import { editorBracketMatchForeground } from '../../../common/core/editorColorRegistry.js';
 
 const overviewRulerBracketMatchForeground = registerColor('editorOverviewRuler.bracketMatchForeground', '#A0A0A0', nls.localize('overviewRulerBracketMatchForeground', 'Overview ruler marker color for matching brackets.'));
 
@@ -299,7 +300,7 @@ export class BracketMatchingController extends Disposable implements IEditorCont
 	private static readonly _DECORATION_OPTIONS_WITH_OVERVIEW_RULER = ModelDecorationOptions.register({
 		description: 'bracket-match-overview',
 		stickiness: TrackedRangeStickiness.NeverGrowsWhenTypingAtEdges,
-		className: 'bracket-match',
+		inlineClassName: 'bracket-match',
 		overviewRuler: {
 			color: themeColorFromId(overviewRulerBracketMatchForeground),
 			position: OverviewRulerLane.Center
@@ -309,7 +310,7 @@ export class BracketMatchingController extends Disposable implements IEditorCont
 	private static readonly _DECORATION_OPTIONS_WITHOUT_OVERVIEW_RULER = ModelDecorationOptions.register({
 		description: 'bracket-match-no-overview',
 		stickiness: TrackedRangeStickiness.NeverGrowsWhenTypingAtEdges,
-		className: 'bracket-match'
+		inlineClassName: 'bracket-match'
 	});
 
 	private _updateBrackets(): void {
@@ -413,4 +414,13 @@ MenuRegistry.appendMenuItem(MenuId.MenubarGoMenu, {
 		title: nls.localize({ key: 'miGoToBracket', comment: ['&& denotes a mnemonic'] }, "Go to &&Bracket")
 	},
 	order: 2
+});
+
+// Theming participant to ensure bracket-match color overrides bracket pair colorization
+registerThemingParticipant((theme, collector) => {
+	const bracketMatchForeground = theme.getColor(editorBracketMatchForeground);
+	if (bracketMatchForeground) {
+		// Use higher specificity to override bracket pair colorization
+		collector.addRule(`.monaco-editor .bracket-match { color: ${bracketMatchForeground} !important; }`);
+	}
 });


### PR DESCRIPTION
Fixes #85775

Added new color `editorBracketMatch-foreground` (defaults to `null`) and use it for matching brackets foreground color.

It would be possible to avoid themeing participant when bracket pair colorization is off, but I think the scenario with that setting enabled and foreground color being set is a valid one, hence this approach.
