### PR TITLE
Add support for secondary custom buttons in QuickPick and SimpleFileDialog

### DIFF
--- a/src/vs/base/browser/ui/button/button.ts
+++ b/src/vs/base/browser/ui/button/button.ts
@@ -176,18 +176,18 @@ export class Button extends Disposable implements IButton {
 
 		this._register(addDisposableListener(this._element, EventType.MOUSE_OVER, e => {
 			if (!this._element.classList.contains('disabled')) {
-				this.updateBackground(true);
+				this.updateStyles(true);
 			}
 		}));
 
 		this._register(addDisposableListener(this._element, EventType.MOUSE_OUT, e => {
-			this.updateBackground(false); // restore standard styles
+			this.updateStyles(false); // restore standard styles
 		}));
 
 		// Also set hover background when button is focused for feedback
 		this.focusTracker = this._register(trackFocus(this._element));
-		this._register(this.focusTracker.onDidFocus(() => { if (this.enabled) { this.updateBackground(true); } }));
-		this._register(this.focusTracker.onDidBlur(() => { if (this.enabled) { this.updateBackground(false); } }));
+		this._register(this.focusTracker.onDidFocus(() => { if (this.enabled) { this.updateStyles(true); } }));
+		this._register(this.focusTracker.onDidBlur(() => { if (this.enabled) { this.updateStyles(false); } }));
 	}
 
 	public override dispose(): void {
@@ -218,16 +218,19 @@ export class Button extends Disposable implements IButton {
 		return elements;
 	}
 
-	private updateBackground(hover: boolean): void {
+	private updateStyles(hover: boolean): void {
 		let background;
+		let foreground;
 		if (this.options.secondary) {
 			background = hover ? this.options.buttonSecondaryHoverBackground : this.options.buttonSecondaryBackground;
+			foreground = this.options.buttonSecondaryForeground;
 		} else {
 			background = hover ? this.options.buttonHoverBackground : this.options.buttonBackground;
+			foreground = this.options.buttonForeground;
 		}
-		if (background) {
-			this._element.style.backgroundColor = background;
-		}
+
+		this._element.style.backgroundColor = background || '';
+		this._element.style.color = foreground || '';
 	}
 
 	get element(): HTMLElement {
@@ -325,6 +328,12 @@ export class Button extends Disposable implements IButton {
 
 	get enabled() {
 		return !this._element.classList.contains('disabled');
+	}
+
+	set secondary(value: boolean) {
+		this._element.classList.toggle('secondary', value);
+		(this.options as { secondary?: boolean }).secondary = value;
+		this.updateStyles(false);
 	}
 
 	set checked(value: boolean) {

--- a/src/vs/platform/quickinput/browser/quickInput.ts
+++ b/src/vs/platform/quickinput/browser/quickInput.ts
@@ -841,8 +841,8 @@ export class QuickPick<T extends IQuickPickItem, O extends { useSeparators: bool
 		return this._customButtonSecondary;
 	}
 
-	set customButtonSecondary(secondary: boolean) {
-		this._customButtonSecondary = secondary;
+	set customButtonSecondary(secondary: boolean | undefined) {
+		this._customButtonSecondary = secondary ?? false;
 		this.update();
 	}
 

--- a/src/vs/platform/quickinput/browser/quickInput.ts
+++ b/src/vs/platform/quickinput/browser/quickInput.ts
@@ -584,6 +584,7 @@ export class QuickPick<T extends IQuickPickItem, O extends { useSeparators: bool
 	private _customButton = false;
 	private _customButtonLabel: string | undefined;
 	private _customButtonHover: string | undefined;
+	private _customButtonSecondary = false;
 	private _quickNavigate: IQuickNavigateConfiguration | undefined;
 	private _hideInput: boolean | undefined;
 	private _hideCountBadge: boolean | undefined;
@@ -833,6 +834,15 @@ export class QuickPick<T extends IQuickPickItem, O extends { useSeparators: bool
 
 	set customHover(hover: string | undefined) {
 		this._customButtonHover = hover;
+		this.update();
+	}
+
+	get customButtonSecondary() {
+		return this._customButtonSecondary;
+	}
+
+	set customButtonSecondary(secondary: boolean) {
+		this._customButtonSecondary = secondary;
 		this.update();
 	}
 
@@ -1154,6 +1164,7 @@ export class QuickPick<T extends IQuickPickItem, O extends { useSeparators: bool
 		this.ui.ok.label = this.okLabel || '';
 		this.ui.customButton.label = this.customLabel || '';
 		this.ui.customButton.element.title = this.customHover || '';
+		this.ui.customButton.secondary = this.customButtonSecondary || false;
 		if (!visibilities.inputBox) {
 			// we need to move focus into the tree to detect keybindings
 			// properly when the input box is not visible (quick nav)

--- a/src/vs/platform/quickinput/common/quickInput.ts
+++ b/src/vs/platform/quickinput/common/quickInput.ts
@@ -573,6 +573,11 @@ export interface IQuickPick<T extends IQuickPickItem, O extends { useSeparators:
 	customHover: string | undefined;
 
 	/**
+	 * Whether the custom button should be rendered as a secondary button.
+	 */
+	customButtonSecondary?: boolean;
+
+	/**
 	 * An event that is fired when an item button is triggered.
 	 */
 	readonly onDidTriggerItemButton: Event<IQuickPickItemButtonEvent<T>>;

--- a/src/vs/workbench/contrib/authentication/browser/actions/manageTrustedExtensionsForAccountAction.ts
+++ b/src/vs/workbench/contrib/authentication/browser/actions/manageTrustedExtensionsForAccountAction.ts
@@ -189,6 +189,7 @@ class ManageTrustedExtensionsForAccountActionImpl {
 		quickPick.canSelectMany = true;
 		quickPick.customButton = true;
 		quickPick.customLabel = localize('manageTrustedExtensions.cancel', 'Cancel');
+		quickPick.customButtonSecondary = true;
 		quickPick.title = localize('manageTrustedExtensions', "Manage Trusted Extensions");
 		quickPick.placeholder = localize('manageExtensions', "Choose which extensions can access this account");
 

--- a/src/vs/workbench/contrib/authentication/browser/actions/manageTrustedMcpServersForAccountAction.ts
+++ b/src/vs/workbench/contrib/authentication/browser/actions/manageTrustedMcpServersForAccountAction.ts
@@ -173,6 +173,7 @@ class ManageTrustedMcpServersForAccountActionImpl {
 		quickPick.canSelectMany = true;
 		quickPick.customButton = true;
 		quickPick.customLabel = localize('manageTrustedMcpServers.cancel', 'Cancel');
+		quickPick.customButtonSecondary = true;
 		quickPick.title = localize('manageTrustedMcpServers', "Manage Trusted MCP Servers");
 		quickPick.placeholder = localize('manageMcpServers', "Choose which MCP servers can access this account");
 

--- a/src/vs/workbench/services/dialogs/browser/simpleFileDialog.ts
+++ b/src/vs/workbench/services/dialogs/browser/simpleFileDialog.ts
@@ -314,6 +314,7 @@ export class SimpleFileDialog extends Disposable implements ISimpleFileDialog {
 			if ((this.scheme !== Schemas.file) && this.options && this.options.availableFileSystems && (this.options.availableFileSystems.length > 1) && (this.options.availableFileSystems.indexOf(Schemas.file) > -1)) {
 				this.filePickBox.customButton = true;
 				this.filePickBox.customLabel = nls.localize('remoteFileDialog.local', 'Show Local');
+				this.filePickBox.customButtonSecondary = true;
 				let action;
 				if (isSave) {
 					action = SaveLocalFileCommand;
@@ -817,6 +818,7 @@ export class SimpleFileDialog extends Disposable implements ISimpleFileDialog {
 		prompt.ok = true;
 		prompt.customButton = true;
 		prompt.customLabel = nls.localize('remoteFileDialog.cancel', 'Cancel');
+		prompt.customButtonSecondary = true;
 		prompt.value = this.pathFromUri(uri);
 
 		let isResolving = false;


### PR DESCRIPTION
To improve visual hierarchy, this PR introduces the ability to render custom buttons as secondary options in both QuickPick and SimpleFileDialog components. This enhancement allows for improved UI flexibility and user experience. Update existing button handling to accommodate the new secondary button style.

Before:

<img width="621" height="237" alt="image" src="https://github.com/user-attachments/assets/f7d10fae-089d-44ca-8166-b35e6e674691" />

After:

<img width="620" height="167" alt="image" src="https://github.com/user-attachments/assets/26a00ebd-f889-447f-ac44-ca28f99c58af" />

