### PR TITLE
Add sizes to known variables and update color registry tests

### DIFF
--- a/build/lib/stylelint/validateVariableNames.ts
+++ b/build/lib/stylelint/validateVariableNames.ts
@@ -13,7 +13,7 @@ function getKnownVariableNames() {
 	if (!knownVariables) {
 		const knownVariablesFileContent = readFileSync(path.join(import.meta.dirname, './vscode-known-variables.json'), 'utf8').toString();
 		const knownVariablesInfo = JSON.parse(knownVariablesFileContent);
-		knownVariables = new Set([...knownVariablesInfo.colors, ...knownVariablesInfo.others] as string[]);
+		knownVariables = new Set([...knownVariablesInfo.colors, ...knownVariablesInfo.others, ...(knownVariablesInfo.sizes || [])] as string[]);
 	}
 	return knownVariables;
 }

--- a/build/lib/stylelint/vscode-known-variables.json
+++ b/build/lib/stylelint/vscode-known-variables.json
@@ -869,8 +869,8 @@
 		"--vscode-textLink-activeForeground",
 		"--vscode-textLink-foreground",
 		"--vscode-textPreformat-background",
-		"--vscode-textPreformat-foreground",
 		"--vscode-textPreformat-border",
+		"--vscode-textPreformat-foreground",
 		"--vscode-textSeparator-foreground",
 		"--vscode-titleBar-activeBackground",
 		"--vscode-titleBar-activeForeground",
@@ -996,5 +996,18 @@
 		"--comment-thread-state-color",
 		"--comment-thread-state-background-color",
 		"--inline-edit-border-radius"
+	],
+	"sizes": [
+		"--vscode-bodyFontSize",
+		"--vscode-bodyFontSize-small",
+		"--vscode-bodyFontSize-xSmall",
+		"--vscode-codiconFontSize",
+		"--vscode-cornerRadius-circle",
+		"--vscode-cornerRadius-large",
+		"--vscode-cornerRadius-medium",
+		"--vscode-cornerRadius-small",
+		"--vscode-cornerRadius-xLarge",
+		"--vscode-cornerRadius-xSmall",
+		"--vscode-strokeThickness"
 	]
 }

--- a/src/vs/workbench/contrib/themes/test/node/colorRegistry.releaseTest.ts
+++ b/src/vs/workbench/contrib/themes/test/node/colorRegistry.releaseTest.ts
@@ -6,6 +6,7 @@
 import * as fs from 'fs';
 import { Registry } from '../../../../../platform/registry/common/platform.js';
 import { IColorRegistry, Extensions, ColorContribution, asCssVariableName } from '../../../../../platform/theme/common/colorRegistry.js';
+import { ISizeRegistry, Extensions as SizeExtensions, asCssVariableName as asSizeCssVariableName } from '../../../../../platform/theme/common/sizeUtils.js';
 import { asTextOrError } from '../../../../../platform/request/common/request.js';
 import * as pfs from '../../../../../base/node/pfs.js';
 import * as path from '../../../../../base/common/path.js';
@@ -76,9 +77,38 @@ suite('Color Registry', function () {
 			errorText += `\n\Removing the following colors:\n\n${superfluousKeys.join('\n')}\n`;
 		}
 
+		const sizesArray = variablesInfo.sizes as string[] || [];
+		const sizes = new Set(sizesArray);
+		const updatedSizes = [];
+		const missingSizes = [];
+		const sizeRegistry = Registry.as<ISizeRegistry>(SizeExtensions.SizeContribution);
+		for (const size of sizeRegistry.getSizes()) {
+			const id = asSizeCssVariableName(size.id);
+
+			if (!sizes.has(id)) {
+				if (!size.deprecationMessage) {
+					missingSizes.push(id);
+				}
+			} else {
+				sizes.delete(id);
+			}
+			updatedSizes.push(id);
+		}
+
+		const superfluousSizes = [...sizes.keys()];
+
+		if (missingSizes.length > 0) {
+			errorText += `\n\Adding the following sizes:\n\n${JSON.stringify(missingSizes, undefined, '\t')}\n`;
+		}
+		if (superfluousSizes.length > 0) {
+			errorText += `\n\Removing the following sizes:\n\n${superfluousSizes.join('\n')}\n`;
+		}
+
 		if (errorText.length > 0) {
 			updatedColors.sort();
 			variablesInfo.colors = updatedColors;
+			updatedSizes.sort();
+			variablesInfo.sizes = updatedSizes;
 			await pfs.Promises.writeFile(varFilePath, JSON.stringify(variablesInfo, undefined, '\t'));
 
 			assert.fail(`\n\Updating ${path.normalize(varFilePath)}.\nPlease verify and commit.\n\n${errorText}\n`);


### PR DESCRIPTION
Introduce size variables to the known variables registry and update the color registry tests to reflect these changes. This enhances the flexibility of the theme customization by including size-related CSS variables.

