### PR TITLE
Don't show word based suggestions when completion provider available

### DIFF
--- a/src/vs/editor/browser/services/editorWorkerService.ts
+++ b/src/vs/editor/browser/services/editorWorkerService.ts
@@ -93,7 +93,7 @@ export class EditorWorkerService extends Disposable implements IEditorWorkerServ
 				return links && { links };
 			}
 		}));
-		this._register(languageFeaturesService.completionProvider.register('*', new WordBasedCompletionItemProvider(this._workerManager, configurationService, this._modelService, this._languageConfigurationService, this._logService)));
+		this._register(languageFeaturesService.completionProvider.register('*', new WordBasedCompletionItemProvider(this._workerManager, configurationService, this._modelService, this._languageConfigurationService, this._logService, languageFeaturesService)));
 	}
 
 	public override dispose(): void {
@@ -263,7 +263,8 @@ class WordBasedCompletionItemProvider implements languages.CompletionItemProvide
 		configurationService: ITextResourceConfigurationService,
 		modelService: IModelService,
 		private readonly languageConfigurationService: ILanguageConfigurationService,
-		private readonly logService: ILogService
+		private readonly logService: ILogService,
+		private readonly languageFeaturesService: ILanguageFeaturesService,
 	) {
 		this._workerManager = workerManager;
 		this._configurationService = configurationService;
@@ -272,10 +273,14 @@ class WordBasedCompletionItemProvider implements languages.CompletionItemProvide
 
 	async provideCompletionItems(model: ITextModel, position: Position): Promise<languages.CompletionList | undefined> {
 		type WordBasedSuggestionsConfig = {
-			wordBasedSuggestions?: 'off' | 'currentDocument' | 'matchingDocuments' | 'allDocuments';
+			wordBasedSuggestions?: 'off' | 'currentDocument' | 'matchingDocuments' | 'allDocuments' | 'offWithInlineSuggestions';
 		};
 		const config = this._configurationService.getValue<WordBasedSuggestionsConfig>(model.uri, position, 'editor');
 		if (config.wordBasedSuggestions === 'off') {
+			return undefined;
+		}
+
+		if (config.wordBasedSuggestions === 'offWithInlineSuggestions' && this.languageFeaturesService.inlineCompletionsProvider.has(model)) {
 			return undefined;
 		}
 

--- a/src/vs/editor/common/config/editorConfigurationSchema.ts
+++ b/src/vs/editor/common/config/editorConfigurationSchema.ts
@@ -64,15 +64,17 @@ const editorConfiguration: IConfigurationNode = {
 			description: nls.localize('largeFileOptimizations', "Special handling for large files to disable certain memory intensive features.")
 		},
 		'editor.wordBasedSuggestions': {
-			enum: ['off', 'currentDocument', 'matchingDocuments', 'allDocuments'],
+			enum: ['off', 'currentDocument', 'matchingDocuments', 'allDocuments', 'offWithInlineSuggestions'],
 			default: 'matchingDocuments',
 			enumDescriptions: [
 				nls.localize('wordBasedSuggestions.off', 'Turn off Word Based Suggestions.'),
+				nls.localize('wordBasedSuggestions.offWithInlineSuggestions', 'Turn off Word Based Suggestions when Inline Suggestions are present.'),
 				nls.localize('wordBasedSuggestions.currentDocument', 'Only suggest words from the active document.'),
 				nls.localize('wordBasedSuggestions.matchingDocuments', 'Suggest words from all open documents of the same language.'),
-				nls.localize('wordBasedSuggestions.allDocuments', 'Suggest words from all open documents.')
+				nls.localize('wordBasedSuggestions.allDocuments', 'Suggest words from all open documents.'),
 			],
-			description: nls.localize('wordBasedSuggestions', "Controls whether completions should be computed based on words in the document and from which documents they are computed.")
+			description: nls.localize('wordBasedSuggestions', "Controls whether completions should be computed based on words in the document and from which documents they are computed."),
+			experiment: { mode: 'auto' },
 		},
 		'editor.semanticHighlighting.enabled': {
 			enum: [true, false, 'configuredByTheme'],


### PR DESCRIPTION
```Copilot Generated Description:``` Update the word-based suggestions configuration to include an option that disables suggestions when inline completions are available. Adjust the completion provider registration to accommodate this new behavior.

closes https://github.com/microsoft/vscode/issues/284076