### PR TITLE
Update button style hierarchy in extensions views

### DIFF
--- a/src/vs/workbench/contrib/extensions/browser/extensionsActions.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionsActions.ts
@@ -29,7 +29,7 @@ import { CommandsRegistry, ICommandService } from '../../../../platform/commands
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { registerThemingParticipant, IColorTheme, ICssStyleCollector } from '../../../../platform/theme/common/themeService.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
-import { buttonBackground, buttonForeground, buttonHoverBackground, registerColor, editorWarningForeground, editorInfoForeground, editorErrorForeground, buttonSeparator } from '../../../../platform/theme/common/colorRegistry.js';
+import { buttonBackground, buttonForeground, buttonHoverBackground, buttonSecondaryBackground, buttonSecondaryForeground, buttonSecondaryHoverBackground, registerColor, editorWarningForeground, editorInfoForeground, editorErrorForeground, buttonSeparator } from '../../../../platform/theme/common/colorRegistry.js';
 import { IJSONEditingService } from '../../../services/configuration/common/jsonEditing.js';
 import { ITextEditorSelection } from '../../../../platform/editor/common/editor.js';
 import { ITextModelService } from '../../../../editor/common/services/resolverService.js';
@@ -951,7 +951,7 @@ export class UninstallAction extends ExtensionAction {
 
 export class UpdateAction extends ExtensionAction {
 
-	private static readonly EnabledClass = `${this.LABEL_ACTION_CLASS} prominent update`;
+	private static readonly EnabledClass = `${this.LABEL_ACTION_CLASS} update`;
 	private static readonly DisabledClass = `${this.EnabledClass} disabled`;
 
 	private readonly updateThrottler = new Throttler();
@@ -1494,7 +1494,7 @@ export class TogglePreReleaseExtensionAction extends ExtensionAction {
 	static readonly ID = 'workbench.extensions.action.togglePreRlease';
 	static readonly LABEL = localize('togglePreRleaseLabel', "Pre-Release");
 
-	private static readonly EnabledClass = `${ExtensionAction.LABEL_ACTION_CLASS} pre-release`;
+	private static readonly EnabledClass = `${ExtensionAction.LABEL_ACTION_CLASS} prominent pre-release`;
 	private static readonly DisabledClass = `${this.EnabledClass} hide`;
 
 	constructor(
@@ -3176,22 +3176,22 @@ CommandsRegistry.registerCommand(showExtensionsWithIdsCommandId, function (acces
 });
 
 registerColor('extensionButton.background', {
-	dark: buttonBackground,
-	light: buttonBackground,
+	dark: buttonSecondaryBackground,
+	light: buttonSecondaryBackground,
 	hcDark: null,
 	hcLight: null
 }, localize('extensionButtonBackground', "Button background color for extension actions."));
 
 registerColor('extensionButton.foreground', {
-	dark: buttonForeground,
-	light: buttonForeground,
+	dark: buttonSecondaryForeground,
+	light: buttonSecondaryForeground,
 	hcDark: null,
 	hcLight: null
 }, localize('extensionButtonForeground', "Button foreground color for extension actions."));
 
 registerColor('extensionButton.hoverBackground', {
-	dark: buttonHoverBackground,
-	light: buttonHoverBackground,
+	dark: buttonSecondaryHoverBackground,
+	light: buttonSecondaryHoverBackground,
 	hcDark: null,
 	hcLight: null
 }, localize('extensionButtonHoverBackground', "Button background hover color for extension actions."));

--- a/src/vs/workbench/contrib/extensions/browser/media/extensionActions.css
+++ b/src/vs/workbench/contrib/extensions/browser/media/extensionActions.css
@@ -38,6 +38,20 @@
 .monaco-action-bar .action-item .action-label.extension-action.label,
 .monaco-action-bar .action-item.action-dropdown-item > .action-dropdown-item-separator {
 	background-color: var(--vscode-extensionButton-background);
+	border: 1px solid var(--vscode-button-border, transparent);
+}
+
+.monaco-action-bar .action-item.action-dropdown-item > .action-label.extension-action.label {
+	border-right-width: 0;
+}
+
+.monaco-action-bar .action-item.action-dropdown-item > .monaco-dropdown .action-label.extension-action.label {
+	border-left-width: 0;
+}
+
+.monaco-action-bar .action-item.action-dropdown-item > .action-dropdown-item-separator {
+	border-left-width: 0;
+	border-right-width: 0;
 }
 
 .monaco-list-row.focused .extension-list-item .monaco-action-bar .action-item .action-label.extension-action.label,
@@ -65,15 +79,6 @@
 
 .monaco-action-bar .action-item.action-item:not(.disabled) .action-label.extension-action.label.prominent:hover {
 	background-color: var(--vscode-extensionButton-prominentHoverBackground);
-}
-
-.monaco-action-bar .action-item .action-label.extension-action:not(.disabled) {
-	border: 1px solid var(--vscode-contrastBorder);
-}
-
-.monaco-action-bar .action-item.action-dropdown-item > .action-dropdown-item-separator {
-	border-top: 1px solid var(--vscode-contrastBorder);
-	border-bottom: 1px solid var(--vscode-contrastBorder);
 }
 
 .monaco-action-bar .action-item .action-label.extension-action.extension-status-error::before {

--- a/src/vs/workbench/contrib/extensions/browser/media/extensionActions.css
+++ b/src/vs/workbench/contrib/extensions/browser/media/extensionActions.css
@@ -54,6 +54,14 @@
 	border-right-width: 0;
 }
 
+.monaco-action-bar .action-item.action-dropdown-item.empty > .action-label.extension-action.label {
+	border-right-width: 1px;
+}
+
+.monaco-action-bar .action-item.action-dropdown-item.empty > .action-dropdown-item-separator {
+	display: none;
+}
+
 .monaco-list-row.focused .extension-list-item .monaco-action-bar .action-item .action-label.extension-action.label,
 .monaco-list-row.selected .extension-list-item .monaco-action-bar .action-item .action-label.extension-action.label,
 .monaco-action-bar .action-item .action-label.extension-action.label {
@@ -66,6 +74,10 @@
 
 .monaco-action-bar .action-item.action-dropdown-item > .action-dropdown-item-separator > div {
 	background-color: var(--vscode-extensionButton-separator);
+}
+
+.vscode-high-contrast .monaco-action-bar .action-item.action-dropdown-item > .action-dropdown-item-separator > div {
+	background-color: var(--vscode-button-border);
 }
 
 .monaco-action-bar .action-item .action-label.extension-action.label.prominent,


### PR DESCRIPTION
Improve visual hierarchy by updating button styles for extension actions and enhance the visibility of empty dropdown items in the action bar. Adjustments improve the overall user interface and experience.

Before:

<img width="1196" height="684" alt="image" src="https://github.com/user-attachments/assets/79d8bb97-8f57-442e-b653-1be1ae8a79e6" />

After:

<img width="1289" height="625" alt="image" src="https://github.com/user-attachments/assets/5cf53afe-0f43-4ffd-8c25-5e17c16f468a" />

