### PR TITLE
make `focusTerminal` async for consistency

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/actions/chatCodeblockActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatCodeblockActions.ts
@@ -468,19 +468,20 @@ export function registerChatCodeBlockActions() {
 			const terminalEditorService = accessor.get(ITerminalEditorService);
 			const terminalGroupService = accessor.get(ITerminalGroupService);
 
-			let terminal = await terminalService.getActiveOrCreateInstance();
+			let terminal = await terminalService.getActiveOrCreateInstance({ acceptsInput: true });
 
 			// isFeatureTerminal = debug terminal or task terminal
-			const unusableTerminal = terminal.xterm?.isStdinDisabled || terminal.shellLaunchConfig.isFeatureTerminal;
-			terminal = unusableTerminal ? await terminalService.createTerminal() : terminal;
+			if (terminal.xterm?.isStdinDisabled || terminal.shellLaunchConfig.isFeatureTerminal) {
+				terminal = await terminalService.createAndFocusTerminal({ location: TerminalLocation.Panel });
+			} else {
+				await terminalService.focusInstance(terminal);
+			}
 
-			terminalService.setActiveInstance(terminal);
-			await terminal.focusWhenReady(true);
 			if (terminal.target === TerminalLocation.Editor) {
 				const existingEditors = editorService.findEditors(terminal.resource);
 				terminalEditorService.openEditor(terminal, { viewColumn: existingEditors?.[0].groupId });
 			} else {
-				terminalGroupService.showPanel(true);
+				await terminalGroupService.showPanel(true);
 			}
 
 			terminal.runCommand(context.code, false);

--- a/src/vs/workbench/contrib/tasks/browser/terminalTaskSystem.ts
+++ b/src/vs/workbench/contrib/tasks/browser/terminalTaskSystem.ts
@@ -1143,8 +1143,8 @@ export class TerminalTaskSystem extends Disposable implements ITaskSystem {
 		} else if (task.command.presentation && (task.command.presentation.focus || task.command.presentation.reveal === RevealKind.Always)) {
 			this._terminalService.setActiveInstance(terminal);
 			await this._terminalService.revealTerminal(terminal);
-			if (task.command.presentation.focus) {
-				this._terminalService.focusInstance(terminal);
+			if (task.command.presentation.focus && terminal) {
+				await this._terminalService.focusInstance(terminal);
 			}
 		}
 		if (this._activeTasks[task.getMapKey()]) {

--- a/src/vs/workbench/contrib/terminal/browser/terminal.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminal.ts
@@ -727,7 +727,7 @@ export interface ITerminalInstanceHost {
 	/**
 	 * Reveal and focus the instance, regardless of its location.
 	 */
-	focusInstance(instance: ITerminalInstance): void;
+	focusInstance(instance: ITerminalInstance): Promise<void>;
 	/**
 	 * Reveal and focus the active instance, regardless of its location.
 	 */

--- a/src/vs/workbench/contrib/terminal/browser/terminalActions.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalActions.ts
@@ -509,7 +509,7 @@ export function registerTerminalActions() {
 				return;
 			}
 			c.service.setActiveInstance(instance);
-			focusActiveTerminal(instance, c);
+			await focusActiveTerminal(instance, c);
 		}
 	});
 
@@ -1722,13 +1722,17 @@ export function shrinkWorkspaceFolderCwdPairs(pairs: WorkspaceFolderCwdPair[]): 
 }
 
 async function focusActiveTerminal(instance: ITerminalInstance | undefined, c: ITerminalServicesCollection): Promise<void> {
-	// TODO@meganrogge: Is this the right logic for when instance is undefined?
-	if (instance?.target === TerminalLocation.Editor) {
-		await c.editorService.revealActiveEditor();
-		await instance.focusWhenReady(true);
-	} else {
-		await c.groupService.showPanel(true);
+	const target = instance
+		?? c.service.activeInstance
+		?? c.editorService.activeInstance
+		?? c.groupService.activeInstance;
+	if (!target) {
+		if (c.groupService.instances.length > 0) {
+			await c.groupService.showPanel(true);
+		}
+		return;
 	}
+	await c.service.focusInstance(target);
 }
 
 async function renameWithQuickPick(c: ITerminalServicesCollection, accessor: ServicesAccessor, resource?: unknown) {

--- a/src/vs/workbench/contrib/terminal/browser/terminalGroupService.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalGroupService.ts
@@ -148,8 +148,11 @@ export class TerminalGroupService extends Disposable implements ITerminalGroupSe
 		pane?.terminalTabbedView?.focusHover();
 	}
 
-	async focusInstance(_: ITerminalInstance): Promise<void> {
-		return this.showPanel(true);
+	async focusInstance(instance: ITerminalInstance): Promise<void> {
+		if (this.instances.includes(instance)) {
+			this.setActiveInstance(instance);
+		}
+		await this.showPanel(true);
 	}
 
 	async focusActiveInstance(): Promise<void> {

--- a/src/vs/workbench/contrib/terminal/browser/terminalService.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalService.ts
@@ -396,10 +396,17 @@ export class TerminalService extends Disposable implements ITerminalService {
 	}
 
 	async focusInstance(instance: ITerminalInstance): Promise<void> {
-		if (instance.target === TerminalLocation.Editor) {
-			return this._terminalEditorService.focusInstance(instance);
+		if (!instance) {
+			return;
 		}
-		return this._terminalGroupService.focusInstance(instance);
+		if (this._activeInstance !== instance) {
+			this.setActiveInstance(instance);
+		}
+		if (instance.target === TerminalLocation.Editor) {
+			await this._terminalEditorService.focusInstance(instance);
+			return;
+		}
+		await this._terminalGroupService.focusInstance(instance);
 	}
 
 	async focusActiveInstance(): Promise<void> {

--- a/src/vs/workbench/contrib/terminalContrib/chat/browser/terminalChatActions.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chat/browser/terminalChatActions.ts
@@ -420,7 +420,7 @@ registerAction2(class ShowChatTerminalsAction extends Action2 {
 					terminalService.setActiveInstance(instance);
 					await terminalService.revealTerminal(instance);
 					qp.hide();
-					terminalService.focusInstance(instance);
+					await terminalService.focusInstance(instance);
 				} else {
 					qp.hide();
 				}

--- a/src/vs/workbench/test/browser/workbenchTestServices.ts
+++ b/src/vs/workbench/test/browser/workbenchTestServices.ts
@@ -1879,7 +1879,7 @@ export class TestTerminalEditorService implements ITerminalEditorService {
 	getInputFromResource(resource: URI): TerminalEditorInput { throw new Error('Method not implemented.'); }
 	setActiveInstance(instance: ITerminalInstance): void { throw new Error('Method not implemented.'); }
 	focusActiveInstance(): Promise<void> { throw new Error('Method not implemented.'); }
-	focusInstance(instance: ITerminalInstance): void { throw new Error('Method not implemented.'); }
+	async focusInstance(instance: ITerminalInstance): Promise<void> { throw new Error('Method not implemented.'); }
 	getInstanceFromResource(resource: URI | undefined): ITerminalInstance | undefined { throw new Error('Method not implemented.'); }
 	focusFindWidget(): void { throw new Error('Method not implemented.'); }
 	hideFindWidget(): void { throw new Error('Method not implemented.'); }
@@ -1925,7 +1925,7 @@ export class TestTerminalGroupService implements ITerminalGroupService {
 	focusHover(): void { throw new Error('Method not implemented.'); }
 	setActiveInstance(instance: ITerminalInstance): void { throw new Error('Method not implemented.'); }
 	focusActiveInstance(): Promise<void> { throw new Error('Method not implemented.'); }
-	focusInstance(instance: ITerminalInstance): void { throw new Error('Method not implemented.'); }
+	async focusInstance(instance: ITerminalInstance): Promise<void> { throw new Error('Method not implemented.'); }
 	getInstanceFromResource(resource: URI | undefined): ITerminalInstance | undefined { throw new Error('Method not implemented.'); }
 	focusFindWidget(): void { throw new Error('Method not implemented.'); }
 	hideFindWidget(): void { throw new Error('Method not implemented.'); }


### PR DESCRIPTION
fixes #275562

- Focus terminal is now async and sets the active instance before focusing
- Callers await focusing so reveal/focus completes before running follow-up work, preventing races where a task/chat action proceeds while the terminal isn’t actually focused or even available.
- Terminal editor/panel focus is more robust: editor focus now no-ops on unknown instances and waits for any in-flight openEditor before calling focusWhenReady, while group focus marks the instance active before showing the panel.
- `focusActiveTerminal` now falls back to any known active instance and relies on the service to focus the correct location, avoiding blank focus attempts when the provided instance is missing.
