### PR TITLE
[BUG FIX] Inconsistency in how Git Repositories were disposed when wo…

### DIFF
--- a/extensions/git/src/model.ts
+++ b/extensions/git/src/model.ts
@@ -468,15 +468,9 @@ export class Model implements IRepositoryResolver, IBranchProtectionProviderRegi
 			const possibleRepositoryFolders = added
 				.filter(folder => !this.getOpenRepository(folder.uri));
 
-			const activeRepositoriesList = window.visibleTextEditors
-				.map(editor => this.getRepository(editor.document.uri))
-				.filter(repository => !!repository) as Repository[];
-
-			const activeRepositories = new Set<Repository>(activeRepositoriesList);
 			const openRepositoriesToDispose = removed
 				.map(folder => this.getOpenRepository(folder.uri))
 				.filter(r => !!r)
-				.filter(r => !activeRepositories.has(r!.repository))
 				.filter(r => !(workspace.workspaceFolders || []).some(f => isDescendant(f.uri.fsPath, r!.repository.root))) as OpenRepository[];
 
 			openRepositoriesToDispose.forEach(r => r.dispose());


### PR DESCRIPTION
Closes #108757

### Problem Description

When working in a multi-root workspace containing multiple Git repositories, VS Code does not immediately update the Source Control (SCM) view after a workspace folder is removed if that repository has uncommitted changes.
Specifically, removing a folder from the workspace correctly updates the Explorer, but the corresponding Git repository remains visible in the SCM pane, including its uncommitted changes. The SCM view only reflects the correct state after the workspace is reopened.
This results in a temporary but confusing inconsistency between the Explorer and the Source Control view.

### Expected Behaviour
When a folder is removed from the workspace:
* The folder should disappear from the Explorer.
* The corresponding Git repository should be immediately removed from the SCM view, regardless of whether it has uncommitted changes.

### Actual Behaviour
* The folder is removed from the Explorer as expected.
* The Git repository remains visible in the SCM pane if it has uncommitted changes.
* The SCM view is corrected only after reopening the workspace.

### Steps to Reproduce
1. Create a new workspace.
2. Add two folders to the workspace, each containing a separate Git repository.
3. Open a file from each repository in the editor.
4. Modify both files so that each repository has uncommitted changes.
5. Verify that both repositories are visible in the Explorer and the SCM pane.
6. Remove one of the folders from the workspace using the Explorer.
7. Observe that:
    * The removed folder no longer appears in the Explorer.
    * The corresponding Git repository is still visible in the SCM pane.
8. Reopen the workspace and observe that the SCM view now reflects the correct state.

### Summary
In a multi-root workspace, the SCM view does not immediately synchronise with workspace folder removal when the removed repository contains uncommitted changes, leading to a transient but incorrect UI state.



### Change-log:

Corrected Inconsistency in how Git repositories were disposed when workspace folders were removed.
Specifically, repositories were being kept alive if a file from that repository was still open in an editor. This caused the Source Control view to continue showing repositories whose backing workspace folders had already been removed.
To address this, I:
1. Removed the activeRepositories guard that prevented disposal of repositories associated with removed workspace folders.
2. Ensured repository disposal is now driven purely by workspace folder membership, so the SCM view immediately reflects workspace changes.
This change fixes the issue where removed workspace folders left behind stale repositories in SCM.


“Do not keep repositories around simply because an editor is open on a file from that repository. If the workspace folder backing the repository is removed from the workspace, the repository should be disposed so the SCM view immediately reflects the workspace state.”

Changed `vscode/extensions/git/src/model.ts` -

FROM

```
const possibleRepositoryFolders = added
                .filter(folder => !this.getOpenRepository(folder.uri));

            const activeRepositoriesList = window.visibleTextEditors
                .map(editor => this.getRepository(editor.document.uri))
                .filter(repository => !!repository) as Repository[];

            const activeRepositories = new Set<Repository>(activeRepositoriesList);

            const openRepositoriesToDispose = removed
                .map(folder => this.getOpenRepository(folder.uri))
                .filter(r => !!r)
                .filter(r => !activeRepositories.has(r!.repository))
                .filter(r => !(workspace.workspaceFolders || []).some(f => isDescendant(f.uri.fsPath, r!.repository.root))) as OpenRepository[];
```

TO

```
    const possibleRepositoryFolders = added
                .filter(folder => !this.getOpenRepository(folder.uri));

            const openRepositoriesToDispose = removed
                .map(folder => this.getOpenRepository(folder.uri))
                .filter(r => !!r)
                .filter(r => !(workspace.workspaceFolders || []).some(f => isDescendant(f.uri.fsPath, r!.repository.root))) as OpenRepository[];
```
