### PR TITLE
do not create rename when suggest widget is visible

### DIFF
--- a/src/vs/editor/contrib/inlineCompletions/browser/model/inlineCompletionsSource.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/model/inlineCompletionsSource.ts
@@ -271,7 +271,7 @@ export class InlineCompletionsSource extends Disposable {
 				providerSuggestions.forEach(s => s.addPerformanceMarker('providersResolved'));
 
 				const suggestions: InlineSuggestionItem[] = await Promise.all(providerSuggestions.map(async s => {
-					return this._renameProcessor.proposeRenameRefactoring(this._textModel, s);
+					return this._renameProcessor.proposeRenameRefactoring(this._textModel, s, context);
 				}));
 
 				suggestions.forEach(s => s.addPerformanceMarker('renameProcessed'));

--- a/src/vs/editor/contrib/inlineCompletions/browser/model/renameSymbolProcessor.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/model/renameSymbolProcessor.ts
@@ -23,7 +23,7 @@ import { EditSources, TextModelEditSource } from '../../../../common/textModelEd
 import { hasProvider, rawRename } from '../../../rename/browser/rename.js';
 import { renameSymbolCommandId } from '../controller/commandIds.js';
 import { InlineSuggestionItem } from './inlineSuggestionItem.js';
-import { IInlineSuggestDataActionEdit } from './provideInlineCompletions.js';
+import { IInlineSuggestDataActionEdit, InlineCompletionContextWithoutUuid } from './provideInlineCompletions.js';
 import { InlineSuggestAlternativeAction } from './InlineSuggestAlternativeAction.js';
 import { Codicon } from '../../../../../base/common/codicons.js';
 
@@ -343,8 +343,8 @@ export class RenameSymbolProcessor extends Disposable {
 		}));
 	}
 
-	public async proposeRenameRefactoring(textModel: ITextModel, suggestItem: InlineSuggestionItem): Promise<InlineSuggestionItem> {
-		if (!suggestItem.supportsRename || suggestItem.action?.kind !== 'edit') {
+	public async proposeRenameRefactoring(textModel: ITextModel, suggestItem: InlineSuggestionItem, context: InlineCompletionContextWithoutUuid): Promise<InlineSuggestionItem> {
+		if (!suggestItem.supportsRename || suggestItem.action?.kind !== 'edit' || context.selectedSuggestionInfo) {
 			return suggestItem;
 		}
 


### PR DESCRIPTION
We can not render a rename suggestion when the suggest widget is visible so do not  process it
