### PR TITLE
Terminal: show dimensions overlay while resizing

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/media/terminal.css
+++ b/src/vs/workbench/contrib/terminal/browser/media/terminal.css
@@ -16,7 +16,7 @@
 	z-index: 0;
 }
 
-.monaco-workbench .pane-body.integrated-terminal .terminal-resize-overlay {
+.monaco-workbench .terminal-resize-overlay {
 	position: absolute;
 	left: 50%;
 	top: 50%;
@@ -31,17 +31,16 @@
 	opacity: 0;
 	transition: opacity 80ms ease-out;
 	z-index: 35;
-	font-family: var(--vscode-editor-font-family);
 	font-size: 11px;
 }
 
-.monaco-workbench.hc-black .pane-body.integrated-terminal .terminal-resize-overlay,
-.monaco-workbench.hc-light .pane-body.integrated-terminal .terminal-resize-overlay {
+.monaco-workbench.hc-black .terminal-resize-overlay,
+.monaco-workbench.hc-light .terminal-resize-overlay {
 	box-shadow: none;
 	border-color: var(--vscode-contrastBorder);
 }
 
-.monaco-workbench .pane-body.integrated-terminal .terminal-resize-overlay.visible {
+.monaco-workbench .terminal-resize-overlay.visible {
 	opacity: 1;
 }
 
@@ -173,8 +172,8 @@
 	position: relative;
 }
 
-.monaco-workbench .terminal-editor .terminal-wrapper > div,
-.monaco-workbench .pane-body.integrated-terminal .terminal-wrapper > div {
+.monaco-workbench .terminal-editor .terminal-wrapper > .terminal-xterm-host,
+.monaco-workbench .pane-body.integrated-terminal .terminal-wrapper > .terminal-xterm-host {
 	height: 100%;
 }
 

--- a/src/vs/workbench/contrib/terminal/browser/media/terminal.css
+++ b/src/vs/workbench/contrib/terminal/browser/media/terminal.css
@@ -16,6 +16,35 @@
 	z-index: 0;
 }
 
+.monaco-workbench .pane-body.integrated-terminal .terminal-resize-overlay {
+	position: absolute;
+	left: 50%;
+	top: 50%;
+	transform: translate(-50%, -50%);
+	padding: 4px 10px;
+	border-radius: 4px;
+	background-color: var(--vscode-editorWidget-background);
+	color: var(--vscode-editorWidget-foreground);
+	border: 1px solid var(--vscode-editorWidget-border);
+	box-shadow: 0 2px 8px rgba(0, 0, 0, 0.5);
+	pointer-events: none;
+	opacity: 0;
+	transition: opacity 80ms ease-out;
+	z-index: 35;
+	font-family: var(--vscode-editor-font-family);
+	font-size: 11px;
+}
+
+.monaco-workbench.hc-black .pane-body.integrated-terminal .terminal-resize-overlay,
+.monaco-workbench.hc-light .pane-body.integrated-terminal .terminal-resize-overlay {
+	box-shadow: none;
+	border-color: var(--vscode-contrastBorder);
+}
+
+.monaco-workbench .pane-body.integrated-terminal .terminal-resize-overlay.visible {
+	opacity: 1;
+}
+
 .terminal-command-decoration.hide {
 	visibility: hidden;
 }

--- a/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
@@ -94,6 +94,7 @@ import { refreshShellIntegrationInfoStatus } from './terminalTooltip.js';
 import { generateUuid } from '../../../../base/common/uuid.js';
 import { PromptInputState } from '../../../../platform/terminal/common/capabilities/commandDetection/promptInputModel.js';
 import { hasKey, isNumber, isString } from '../../../../base/common/types.js';
+import { TerminalResizeDimensionsOverlay } from './terminalResizeDimensionsOverlay.js';
 
 const enum Constants {
 	/**
@@ -106,10 +107,6 @@ const enum Constants {
 	DefaultCols = 80,
 	DefaultRows = 30,
 	MaxCanvasWidth = 4096
-}
-
-const enum OverlayConstants {
-	ResizeOverlayHideDelay = 500
 }
 
 let xtermConstructor: Promise<typeof XTermTerminal> | undefined;
@@ -206,9 +203,7 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 	private _lineDataEventAddon: LineDataEventAddon | undefined;
 	private readonly _scopedContextKeyService: IContextKeyService;
 	private _resizeDebouncer?: TerminalResizeDebouncer;
-	private _resizeOverlay: HTMLElement | undefined;
-	private _resizeOverlayHideTimeout: IDisposable | undefined;
-	private _preventResizeOverlay: boolean = true;
+	private readonly _terminalResizeDimensionsOverlay: MutableDisposable<IDisposable> = this._register(new MutableDisposable());
 
 	readonly capabilities = this._register(new TerminalCapabilityStoreMultiplexer());
 	readonly statusList: ITerminalStatusList;
@@ -613,16 +608,6 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 			}
 		}));
 		this._register(this._workspaceContextService.onDidChangeWorkspaceFolders(() => this._labelComputer?.refreshLabel(this)));
-
-		// Register dimension change handler for resize overlay
-		this._register(this.onDimensionsChanged(() => this._handleDimensionsChanged()));
-
-		this._preventResizeOverlay = true;
-		this.processReady.then(() => {
-			timeout(1000).then(() => {
-				this._preventResizeOverlay = false;
-			});
-		});
 
 		// Clear out initial data events after 10 seconds, hopefully extension hosts are up and
 		// running at that point.
@@ -1044,6 +1029,7 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 		this._container.appendChild(this._wrapperElement);
 
 		const xterm = this.xterm;
+		const container = this._container;
 
 		// Attach the xterm object to the DOM, exposing it to the smoke tests
 		this._wrapperElement.xterm = xterm.raw;
@@ -1202,6 +1188,15 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 		if (xterm.raw.options.disableStdin) {
 			this._attachPressAnyKeyToCloseListener(xterm.raw);
 		}
+
+		// Initialize resize dimensions overlay
+		this.processReady.then(() => {
+			timeout(1000).then(() => {
+				if (!this._store.isDisposed) {
+					this._terminalResizeDimensionsOverlay.value = new TerminalResizeDimensionsOverlay(container, xterm);
+				}
+			});
+		});
 	}
 
 	private _setFocus(focused?: boolean): void {
@@ -1994,46 +1989,6 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 
 		TerminalInstance._lastKnownGridDimensions = { cols, rows };
 		this._resizeDebouncer!.resize(cols, rows, immediate ?? false);
-	}
-
-	private _ensureResizeOverlay(): HTMLElement {
-		if (!this._resizeOverlay) {
-			this._resizeOverlay = dom.$('.terminal-resize-overlay');
-			this._resizeOverlay.setAttribute('role', 'status');
-			this._resizeOverlay.setAttribute('aria-live', 'polite');
-			if (this._container) {
-				this._container.appendChild(this._resizeOverlay);
-			}
-			this._register(toDisposable(() => {
-				this._resizeOverlay?.remove();
-				this._resizeOverlay = undefined;
-				this._resizeOverlayHideTimeout?.dispose();
-				this._resizeOverlayHideTimeout = undefined;
-			}));
-		} else if (this._container && !this._container.contains(this._resizeOverlay)) {
-			// If container changed, move overlay to new container
-			this._container.appendChild(this._resizeOverlay);
-		}
-		return this._resizeOverlay;
-	}
-
-	private _handleDimensionsChanged(): void {
-		if (!this._container || !this._container.isConnected) {
-			return;
-		}
-
-		if (this._preventResizeOverlay) {
-			return;
-		}
-
-		const overlay = this._ensureResizeOverlay();
-		overlay.textContent = `${this.cols} x ${this.rows}`;
-		overlay.classList.add('visible');
-
-		this._resizeOverlayHideTimeout?.dispose();
-		this._resizeOverlayHideTimeout = disposableTimeout(() => {
-			this._resizeOverlay?.classList.remove('visible');
-		}, OverlayConstants.ResizeOverlayHideDelay);
 	}
 
 	private async _updatePtyDimensions(rawXterm: XTermTerminal): Promise<void> {

--- a/src/vs/workbench/contrib/terminal/browser/terminalResizeDimensionsOverlay.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalResizeDimensionsOverlay.ts
@@ -31,30 +31,30 @@ export class TerminalResizeDimensionsOverlay extends Disposable {
 		}));
 	}
 
-	private _ensureResizeOverlay(): HTMLElement {
-		if (!this._resizeOverlay) {
-			this._resizeOverlay = $('.terminal-resize-overlay');
-			this._resizeOverlay.setAttribute('role', 'status');
-			this._resizeOverlay.setAttribute('aria-live', 'polite');
-			this._container.appendChild(this._resizeOverlay);
-		} else if (this._container && !this._container.contains(this._resizeOverlay)) {
-			// If container changed, move overlay to new container
-			this._container.appendChild(this._resizeOverlay);
-		}
-		return this._resizeOverlay;
-	}
-
 	private _handleDimensionsChanged(dims: { cols: number; rows: number }): void {
-		if (!this._container || !this._container.isConnected) {
+		const container = this._container;
+		if (!container || !container.isConnected) {
 			return;
 		}
 
-		const overlay = this._ensureResizeOverlay();
+		const overlay = this._ensureResizeOverlay(container);
 		overlay.textContent = `${dims.cols} x ${dims.rows}`;
 		overlay.classList.add(Constants.VisibleClass);
 
 		this._resizeOverlayHideTimeout.value = disposableTimeout(() => {
 			this._resizeOverlay?.classList.remove(Constants.VisibleClass);
 		}, Constants.ResizeOverlayHideDelay);
+	}
+
+	private _ensureResizeOverlay(container: HTMLElement): HTMLElement {
+		if (!this._resizeOverlay) {
+			this._resizeOverlay = $('.terminal-resize-overlay');
+			this._resizeOverlay.setAttribute('role', 'status');
+			this._resizeOverlay.setAttribute('aria-live', 'polite');
+			container.appendChild(this._resizeOverlay);
+		} else if (!container.contains(this._resizeOverlay)) {
+			container.appendChild(this._resizeOverlay);
+		}
+		return this._resizeOverlay;
 	}
 }

--- a/src/vs/workbench/contrib/terminal/browser/terminalResizeDimensionsOverlay.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalResizeDimensionsOverlay.ts
@@ -1,0 +1,60 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { $ } from '../../../../base/browser/dom.js';
+import { disposableTimeout } from '../../../../base/common/async.js';
+import { Disposable, MutableDisposable, toDisposable, type IDisposable } from '../../../../base/common/lifecycle.js';
+import type { XtermTerminal } from './xterm/xtermTerminal.js';
+
+const enum Constants {
+	ResizeOverlayHideDelay = 500,
+	VisibleClass = 'visible',
+}
+
+export class TerminalResizeDimensionsOverlay extends Disposable {
+
+	private _resizeOverlay: HTMLElement | undefined;
+	private readonly _resizeOverlayHideTimeout: MutableDisposable<IDisposable> = this._register(new MutableDisposable());
+
+	constructor(
+		private readonly _container: HTMLElement,
+		xterm: XtermTerminal,
+	) {
+		super();
+
+		this._register(xterm.raw.onResize(dims => this._handleDimensionsChanged(dims)));
+		this._register(toDisposable(() => {
+			this._resizeOverlay?.remove();
+			this._resizeOverlay = undefined;
+		}));
+	}
+
+	private _ensureResizeOverlay(): HTMLElement {
+		if (!this._resizeOverlay) {
+			this._resizeOverlay = $('.terminal-resize-overlay');
+			this._resizeOverlay.setAttribute('role', 'status');
+			this._resizeOverlay.setAttribute('aria-live', 'polite');
+			this._container.appendChild(this._resizeOverlay);
+		} else if (this._container && !this._container.contains(this._resizeOverlay)) {
+			// If container changed, move overlay to new container
+			this._container.appendChild(this._resizeOverlay);
+		}
+		return this._resizeOverlay;
+	}
+
+	private _handleDimensionsChanged(dims: { cols: number; rows: number }): void {
+		if (!this._container || !this._container.isConnected) {
+			return;
+		}
+
+		const overlay = this._ensureResizeOverlay();
+		overlay.textContent = `${dims.cols} x ${dims.rows}`;
+		overlay.classList.add(Constants.VisibleClass);
+
+		this._resizeOverlayHideTimeout.value = disposableTimeout(() => {
+			this._resizeOverlay?.classList.remove(Constants.VisibleClass);
+		}, Constants.ResizeOverlayHideDelay);
+	}
+}

--- a/src/vs/workbench/contrib/terminal/browser/terminalTabbedView.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalTabbedView.ts
@@ -40,10 +40,7 @@ const enum WidthConstants {
 	SplitAnnotation = 30
 }
 
-
 export class TerminalTabbedView extends Disposable {
-
-	private readonly _parentElement: HTMLElement;
 
 	private _splitView: SplitView;
 
@@ -92,8 +89,6 @@ export class TerminalTabbedView extends Disposable {
 		@IHoverService private readonly _hoverService: IHoverService,
 	) {
 		super();
-
-		this._parentElement = parentElement;
 
 		this._tabContainer = $('.tabs-container');
 		const tabListContainer = $('.tabs-list-container');
@@ -218,7 +213,6 @@ export class TerminalTabbedView extends Disposable {
 	private _updateChatTerminalsEntry(): void {
 		this._chatEntry?.update();
 	}
-
 
 	private _getLastListWidth(): number {
 		const widthKey = this._panelOrientation === Orientation.VERTICAL ? TerminalStorageKeys.TabsListWidthVertical : TerminalStorageKeys.TabsListWidthHorizontal;

--- a/src/vs/workbench/contrib/terminal/browser/terminalTabbedView.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalTabbedView.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { LayoutPriority, Orientation, Sizing, SplitView } from '../../../../base/browser/ui/splitview/splitview.js';
-import { Disposable, dispose, IDisposable, toDisposable } from '../../../../base/common/lifecycle.js';
+import { Disposable, dispose, IDisposable } from '../../../../base/common/lifecycle.js';
 import { Event } from '../../../../base/common/event.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
@@ -15,7 +15,7 @@ import { Action, IAction, Separator } from '../../../../base/common/actions.js';
 import { IMenu, IMenuService, MenuId } from '../../../../platform/actions/common/actions.js';
 import { IContextKey, IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
 import { IContextMenuService } from '../../../../platform/contextview/browser/contextView.js';
-import { TerminalSettingId, TerminalLocation } from '../../../../platform/terminal/common/terminal.js';
+import { TerminalSettingId } from '../../../../platform/terminal/common/terminal.js';
 import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
 import { localize } from '../../../../nls.js';
 import { openContextMenu } from './terminalContextMenu.js';
@@ -28,7 +28,6 @@ import { containsDragType } from '../../../../platform/dnd/browser/dnd.js';
 import { getTerminalResourcesFromDragEvent, parseTerminalUri } from './terminalUri.js';
 import type { IProcessDetails } from '../../../../platform/terminal/common/terminalProcess.js';
 import { TerminalContribContextKeyStrings } from '../terminalContribExports.js';
-import { disposableTimeout } from '../../../../base/common/async.js';
 
 const $ = dom.$;
 
@@ -41,9 +40,6 @@ const enum WidthConstants {
 	SplitAnnotation = 30
 }
 
-const enum OverlayConstants {
-	ResizeOverlayHideDelay = 500
-}
 
 export class TerminalTabbedView extends Disposable {
 
@@ -81,10 +77,6 @@ export class TerminalTabbedView extends Disposable {
 	private _panelOrientation: Orientation | undefined;
 	private _emptyAreaDropTargetCount = 0;
 
-	private _resizeOverlay: HTMLElement | undefined;
-	private _resizeOverlayHideTimeout: IDisposable | undefined;
-	private _isManuallyResizing: boolean = false;
-
 	constructor(
 		parentElement: HTMLElement,
 		@ITerminalService private readonly _terminalService: ITerminalService,
@@ -102,7 +94,6 @@ export class TerminalTabbedView extends Disposable {
 		super();
 
 		this._parentElement = parentElement;
-		this._register(toDisposable(() => this._resizeOverlayHideTimeout?.dispose()));
 
 		this._tabContainer = $('.tabs-container');
 		const tabListContainer = $('.tabs-list-container');
@@ -124,8 +115,6 @@ export class TerminalTabbedView extends Disposable {
 		terminalOuterContainer.appendChild(this._terminalContainer);
 
 		this._terminalService.setContainers(parentElement, this._terminalContainer);
-
-		this._register(this._terminalService.onDidChangeInstanceDimensions(instance => this._handleInstanceDimensionsChanged(instance)));
 
 		this._terminalIsTabsNarrowContextKey = TerminalContextKeys.tabsNarrow.bindTo(contextKeyService);
 		this._terminalTabsFocusContextKey = TerminalContextKeys.tabsFocus.bindTo(contextKeyService);
@@ -230,43 +219,6 @@ export class TerminalTabbedView extends Disposable {
 		this._chatEntry?.update();
 	}
 
-	private _ensureResizeOverlay(): HTMLElement {
-		if (!this._resizeOverlay) {
-			this._resizeOverlay = $('.terminal-resize-overlay');
-			this._resizeOverlay.setAttribute('role', 'status');
-			this._resizeOverlay.setAttribute('aria-live', 'polite');
-			this._parentElement.append(this._resizeOverlay);
-			this._register(toDisposable(() => this._resizeOverlay?.remove()));
-		}
-		return this._resizeOverlay;
-	}
-
-	private _handleInstanceDimensionsChanged(instance: ITerminalInstance): void {
-		if (!this._parentElement.isConnected) {
-			return;
-		}
-
-		if (!this._isManuallyResizing) {
-			return;
-		}
-
-		if (instance.target !== TerminalLocation.Panel) {
-			return;
-		}
-
-		if (instance !== this._terminalGroupService.activeInstance) {
-			return;
-		}
-
-		const overlay = this._ensureResizeOverlay();
-		overlay.textContent = `${instance.cols} x ${instance.rows}`;
-		overlay.classList.add('visible');
-
-		this._resizeOverlayHideTimeout?.dispose();
-		this._resizeOverlayHideTimeout = disposableTimeout(() => {
-			this._resizeOverlay?.classList.remove('visible');
-		}, OverlayConstants.ResizeOverlayHideDelay);
-	}
 
 	private _getLastListWidth(): number {
 		const widthKey = this._panelOrientation === Orientation.VERTICAL ? TerminalStorageKeys.TabsListWidthVertical : TerminalStorageKeys.TabsListWidthHorizontal;
@@ -375,13 +327,11 @@ export class TerminalTabbedView extends Disposable {
 		let interval: IDisposable;
 		this._sashDisposables = [
 			this._splitView.sashes[0].onDidStart(e => {
-				this._isManuallyResizing = true;
 				interval = dom.disposableWindowInterval(dom.getWindow(this._splitView.el), () => {
 					this.rerenderTabs();
 				}, 100);
 			}),
 			this._splitView.sashes[0].onDidEnd(e => {
-				this._isManuallyResizing = false;
 				interval.dispose();
 			})
 		];

--- a/src/vs/workbench/contrib/terminal/browser/terminalTabbedView.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalTabbedView.ts
@@ -83,6 +83,7 @@ export class TerminalTabbedView extends Disposable {
 
 	private _resizeOverlay: HTMLElement | undefined;
 	private _resizeOverlayHideTimeout: IDisposable | undefined;
+	private _isManuallyResizing: boolean = false;
 
 	constructor(
 		parentElement: HTMLElement,
@@ -245,6 +246,10 @@ export class TerminalTabbedView extends Disposable {
 			return;
 		}
 
+		if (!this._isManuallyResizing) {
+			return;
+		}
+
 		if (instance.target !== TerminalLocation.Panel) {
 			return;
 		}
@@ -254,7 +259,7 @@ export class TerminalTabbedView extends Disposable {
 		}
 
 		const overlay = this._ensureResizeOverlay();
-		overlay.textContent = `${instance.cols}c \u00D7 ${instance.rows}r`;
+		overlay.textContent = `${instance.cols} x ${instance.rows}`;
 		overlay.classList.add('visible');
 
 		this._resizeOverlayHideTimeout?.dispose();
@@ -370,11 +375,13 @@ export class TerminalTabbedView extends Disposable {
 		let interval: IDisposable;
 		this._sashDisposables = [
 			this._splitView.sashes[0].onDidStart(e => {
+				this._isManuallyResizing = true;
 				interval = dom.disposableWindowInterval(dom.getWindow(this._splitView.el), () => {
 					this.rerenderTabs();
 				}, 100);
 			}),
 			this._splitView.sashes[0].onDidEnd(e => {
+				this._isManuallyResizing = false;
 				interval.dispose();
 			})
 		];


### PR DESCRIPTION
Fixes #284046

Adds a temporary overlay to the integrated terminal that displays
the current terminal dimensions (columns × rows) while resizing.

- Appears only during active resize
- Updates live with terminal size
- Automatically hides after resizing stops
- Theme-aware and accessible
