### PR TITLE
fix: memory leak in chat widget

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatWidget.ts
@@ -227,6 +227,8 @@ export class ChatWidget extends Disposable implements IChatWidget {
 	private lastItem: ChatTreeItem | undefined;
 
 	private readonly visibilityTimeoutDisposable: MutableDisposable<IDisposable> = this._register(new MutableDisposable());
+	private readonly visibilityAnimationFrameDisposable: MutableDisposable<IDisposable> = this._register(new MutableDisposable());
+	private readonly scrollAnimationFrameDisposable: MutableDisposable<IDisposable> = this._register(new MutableDisposable());
 
 	private readonly inputPartDisposable: MutableDisposable<ChatInputPart> = this._register(new MutableDisposable());
 	private readonly inlineInputPartDisposable: MutableDisposable<ChatInputPart> = this._register(new MutableDisposable());
@@ -1438,9 +1440,9 @@ export class ChatWidget extends Disposable implements IChatWidget {
 					}
 				}, 0);
 
-				this._register(dom.scheduleAtNextAnimationFrame(dom.getWindow(this.listContainer), () => {
+				this.visibilityAnimationFrameDisposable.value = dom.scheduleAtNextAnimationFrame(dom.getWindow(this.listContainer), () => {
 					this._onDidShow.fire();
-				}));
+				});
 			}
 		} else if (wasVisible) {
 			this._onDidHide.fire();
@@ -1797,11 +1799,11 @@ export class ChatWidget extends Disposable implements IChatWidget {
 				// Consider the tree to be scrolled all the way down if it is within 2px of the bottom.
 				const lastElementWasVisible = this.tree.scrollTop + this.tree.renderHeight >= this.previousTreeScrollHeight - 2;
 				if (lastElementWasVisible) {
-					this._register(dom.scheduleAtNextAnimationFrame(dom.getWindow(this.listContainer), () => {
+					this.scrollAnimationFrameDisposable.value = dom.scheduleAtNextAnimationFrame(dom.getWindow(this.listContainer), () => {
 						// Can't set scrollTop during this event listener, the list might overwrite the change
 
 						this.scrollToEnd();
-					}, 0));
+					}, 0);
 				}
 			}
 		}


### PR DESCRIPTION
Fixes a two memory in chat widget related to registering animation frames. 

### Details

When `setVisible` is called, an animation Frame Disposable gets registered using  `this._register(dom.scheduleAtNextAnimationFrame))`, making the number of registered disposables grow over time


```ts
setVisible(visible: boolean): void {
  this._register(dom.scheduleAtNextAnimationFrame(dom.getWindow(this.listContainer), () => {
	  this._onDidShow.fire();
  }));
}
```
<br>

Similarly, for `onDidChangeTreeContentHeight`,  a disposable also gets registered each time:

```ts
private onDidChangeTreeContentHeight(): void {
  this._register(dom.scheduleAtNextAnimationFrame(dom.getWindow(this.listContainer), () => {
	// Can't set scrollTop during this event listener, the list might overwrite the change

	this.scrollToEnd();
  }, 0));
}
```


### Fix

The fix uses a `MutableDisposable` so that there can be at most one animation frame disposable registered.


### Before

When sending a chat message and clearing all chat messages 37 times, the number of functions in `ChatWidget.onDidChangeTreeContentHeight` and `AnimationFrameQueueItem` seems to grow by 1 each time.

![chat-editor-send-message-with-link-original](https://github.com/user-attachments/assets/8ad5fc47-5ce7-4784-91ee-05b8002dbc93)


### After 

When sending a chat message and clearing all chat messages 37 times, the number of functions in `ChatWidget.onDidChangeTreeContentHeight` and `AnimationFrameQueueItem` stays constant:

![chat-editor-send-message-with-link](https://github.com/user-attachments/assets/e50d4027-1feb-4a90-b1db-f665b8dcbbe5)
