### PR TITLE
fix: memory leak in terminal chat widget

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/chat/browser/terminalChatWidget.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chat/browser/terminalChatWidget.ts
@@ -8,7 +8,7 @@ import { Dimension, getActiveWindow, IFocusTracker, trackFocus } from '../../../
 import { CancelablePromise, createCancelablePromise, DeferredPromise } from '../../../../../base/common/async.js';
 import { CancellationTokenSource } from '../../../../../base/common/cancellation.js';
 import { Emitter, Event } from '../../../../../base/common/event.js';
-import { Disposable, DisposableStore, MutableDisposable, toDisposable } from '../../../../../base/common/lifecycle.js';
+import { Disposable, DisposableStore, IDisposable, MutableDisposable, toDisposable } from '../../../../../base/common/lifecycle.js';
 import { autorun, observableValue, type IObservable } from '../../../../../base/common/observable.js';
 import { MicrotaskDelay } from '../../../../../base/common/symbols.js';
 import { localize } from '../../../../../nls.js';
@@ -82,6 +82,7 @@ export class TerminalChatWidget extends Disposable {
 	private _terminalAgentName = 'terminal';
 
 	private readonly _model: MutableDisposable<IChatModelReference> = this._register(new MutableDisposable());
+	private readonly _sessionDisposables: MutableDisposable<IDisposable> = this._register(new MutableDisposable());
 
 	private _sessionCtor: CancelablePromise<void> | undefined;
 
@@ -334,7 +335,7 @@ export class TerminalChatWidget extends Disposable {
 				this._resetPlaceholder();
 			}
 		});
-		this._register(toDisposable(() => this._sessionCtor?.cancel()));
+		this._sessionDisposables.value = toDisposable(() => this._sessionCtor?.cancel());
 	}
 
 	private _saveViewState() {


### PR DESCRIPTION
Fixes a memory leak in terminal chat widget.


### Details

When toggling terminal inline chat, this disposable seems to be registered each time, making the number of registered disposables grow by 1 each time when opening the terminal inline chat

```ts
private async _createSession(): Promise<void> {
	this._register(toDisposable(() => this._sessionCtor?.cancel()));
}
```

### Fix

Changing the code to use a `MutableDisposable` ensures that at most one session disposable registered.

```ts
private async _createSession(): Promise<void> {
	this._sessionDisposables.value = toDisposable(() => this._sessionCtor?.cancel());
}
```

### Before

When opening and closing terminal inline 97 times, the number of functions in `TerminalChatWidget` seems to grow by 1 each time

![terminal inline-chat-toggle-original](https://github.com/user-attachments/assets/4c92ca34-5dad-4b73-bc27-98263db9b708)


### After

No more leak is detected.
